### PR TITLE
Make back and forward buttons work in FileManager

### DIFF
--- a/Applications/FileManager/DirectoryView.cpp
+++ b/Applications/FileManager/DirectoryView.cpp
@@ -108,8 +108,18 @@ void DirectoryView::set_view_mode(ViewMode mode)
     ASSERT_NOT_REACHED();
 }
 
+void DirectoryView::add_path_to_history(const String& path)
+{
+    if (m_path_history_position < m_path_history.size())
+        m_path_history.resize(m_path_history_position + 1);
+
+    m_path_history.append(path);
+    m_path_history_position = m_path_history.size() - 1;
+}
+
 void DirectoryView::open(const String& path)
 {
+    add_path_to_history(path);
     model().open(path);
 }
 
@@ -121,10 +131,27 @@ void DirectoryView::set_status_message(const String& message)
 
 void DirectoryView::open_parent_directory()
 {
-    model().open(String::format("%s/..", model().path().characters()));
+    auto path = String::format("%s/..", model().path().characters());
+    add_path_to_history(path);
+    model().open(path);
 }
 
 void DirectoryView::refresh()
 {
     model().update();
+}
+
+void DirectoryView::open_previous_directory()
+{
+    if (m_path_history_position > 0) {
+        m_path_history_position--;
+        model().open(m_path_history[m_path_history_position]);
+    }
+}
+void DirectoryView::open_next_directory()
+{
+    if (m_path_history_position < m_path_history.size() - 1) {
+        m_path_history_position++;
+        model().open(m_path_history[m_path_history_position]);
+    }
 }

--- a/Applications/FileManager/DirectoryView.h
+++ b/Applications/FileManager/DirectoryView.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <AK/Vector.h>
 #include <LibGUI/GTableView.h>
 #include <LibGUI/GItemView.h>
 #include <LibGUI/GStackWidget.h>
@@ -14,6 +15,10 @@ public:
     void open(const String& path);
     String path() const { return model().path(); }
     void open_parent_directory();
+    void open_previous_directory();
+    void open_next_directory();
+    int path_history_size() const { return m_path_history.size(); }
+    int path_history_position() const { return m_path_history_position; }
 
     void refresh();
 
@@ -36,6 +41,9 @@ private:
     ViewMode m_view_mode { Invalid };
 
     Retained<GDirectoryModel> m_model;
+    int m_path_history_position{ 0 };
+    Vector<String> m_path_history;
+    void add_path_to_history(const String& path);
 
     GTableView* m_table_view { nullptr };
     GItemView* m_item_view { nullptr };


### PR DESCRIPTION
Also fixed it so that directories don't get double-opened (first when they are opened, and second when the selection changes to match in the file tree view). Fixes: #36.