### PR TITLE
WSCompositor: Allow a compose to bypass the timer when it first happens

### DIFF
--- a/Servers/WindowServer/WSCompositor.h
+++ b/Servers/WindowServer/WSCompositor.h
@@ -40,6 +40,7 @@ private:
     unsigned m_compose_count { 0 };
     unsigned m_flush_count { 0 };
     CTimer m_compose_timer;
+    CTimer m_immediate_compose_timer;
     bool m_flash_flush { false };
     bool m_buffers_are_flipped { false };
 

--- a/SharedGraphics/DisjointRectSet.h
+++ b/SharedGraphics/DisjointRectSet.h
@@ -12,6 +12,7 @@ public:
     void add(const Rect&);
 
     bool is_empty() const { return m_rects.is_empty(); }
+    int size() const { return m_rects.size(); }
 
     void clear() { m_rects.clear(); }
     void clear_with_capacity() { m_rects.clear_with_capacity(); }


### PR DESCRIPTION
d66fa60fcf23fa7217a065479af6b1f5a851a506 introduced the use of a timer
to coalesce screen updates. This is OK, but it does introduce update
latency.

To help mitigate the impact of this, we now have a second (immediate)
timer. When a compose pass is first triggered, the immediate timer will
allow the compose to happen on the next spin of the event loop (so, only
coalescing updates across a single event loop pass). Any updates that
trigger while the delayed timer is running, though, will be delayed to
that (~60fps) timer.