### PR TITLE
Added VIM and ncurses ports

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -66,6 +66,12 @@ function run_make_install() {
     run_command make $INSTALLOPTS install "$@"
 }
 
+function run_send_to_file() {
+    echo "+ rewrite '$1'"
+	(cd "$PORT_DIR" && echo "$2" > "$1")
+    echo "+ FINISHED"
+}
+
 if [ -z "$1" ]; then
     echo "+ Fetching..."
     fetch

--- a/Ports/ncurses/allow-serenity-os-ncurses.patch
+++ b/Ports/ncurses/allow-serenity-os-ncurses.patch
@@ -1,0 +1,13 @@
+diff --git a/config.sub b/config.sub
+index a44fd8ae..eb9be19b 100755
+--- a/config.sub
++++ b/config.sub
+@@ -1367,7 +1367,7 @@ case $os in
+ 	     | powermax* | dnix* | nx6 | nx7 | sei* | dragonfly* \
+ 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
+ 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
+-	     | midnightbsd* | amdhsa* | unleashed* | emscripten*)
++	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | *serenity* )
+ 	# Remember, each alternative MUST END IN *, to match a version number.
+ 		;;
+ 	qnx*)

--- a/Ports/ncurses/ncurses.sh
+++ b/Ports/ncurses/ncurses.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+PORT_DIR=ncurses
+INSTALLOPTS="DESTDIR=$SERENITY_ROOT/Root/"
+
+function fetch() {
+    run_fetch_git "https://github.com/mirror/ncurses.git"
+    run_patch allow-serenity-os-ncurses.patch -p1
+}
+function configure() {
+    run_configure_autotools
+}
+function build() {
+    run_make
+}
+function install() {
+    run_make_install
+}
+source ../.port_include.sh

--- a/Ports/vim/vim.sh
+++ b/Ports/vim/vim.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+PORT_DIR=vim
+INSTALLOPTS="DESTDIR=$SERENITY_ROOT/Root/"
+
+function fetch() {
+    run_fetch_git "https://github.com/vim/vim.git"
+}
+
+function configure() {
+	run_send_to_file src/auto/config.cache "
+	vim_cv_getcwd_broken=no
+	vim_cv_memmove_handles_overlap=yes
+	vim_cv_stat_ignores_slash=yes
+	vim_cv_tgetent=zero
+	vim_cv_terminfo=yes
+	vim_cv_toupper_broken=no
+	vim_cv_tty_group=world
+	"
+	run_configure_autotools --with-tlib=ncurses --with-features=small
+}
+
+function build() {
+    run_make
+}
+
+function install() {
+    run_make_install
+}
+
+source ../.port_include.sh


### PR DESCRIPTION
Note that the shift key pastes this `~@` character into VIM, causing beeps & such. I suspect that this is due to a Serenity thing (probably terminal emulation), so the next PR will have a fix for that, as well as a way to set the Terminal's default shell.