### PR TITLE
Kernel: Fix a bad printf, and stub out SO_ERROR a bit more fully

### DIFF
--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -97,8 +97,15 @@ KResult Socket::getsockopt(int level, int option, void* value, socklen_t* value_
         *(timeval*)value = m_receive_timeout;
         *value_size = sizeof(timeval);
         return KSuccess;
+    case SO_ERROR:
+        if (*value_size < sizeof(int))
+            return KResult(-EINVAL);
+        kprintf("%s(%u): getsockopt() SO_ERROR: WARNING! I have no idea what the real error is, so I'll just stick my fingers in my ears and pretend there is none! %d\n", current->process().name().characters(), option);
+        *(int*)value = 0;
+        *value_size = sizeof(int);
+        return KSuccess;
     default:
-        kprintf("%s(%u): getsockopt() at SOL_SOCKET with unimplemented option %d\n", option);
+        kprintf("%s(%u): getsockopt() at SOL_SOCKET with unimplemented option %d\n", current->process().name().characters(), option);
         return KResult(-ENOPROTOOPT);
     }
 }

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -335,6 +335,8 @@ struct pollfd {
 
 #define SO_RCVTIMEO 1
 #define SO_SNDTIMEO 2
+#define SO_KEEPALIVE 3
+#define SO_ERROR 4
 
 #define IPPROTO_ICMP 1
 #define IPPROTO_TCP 6


### PR DESCRIPTION
links requests SO_ERROR, so in not supporting it, things were unhappy.
Supporting this properly looks a little messy. I guess Socket will need
an m_error member it sets everywhere it returns an error. Or Syscall
could set it, perhaps, but I don't know if that's the right thing to
do, so let's just stub this for now and file a bug.