### PR TITLE
Kernel: Implement MBR partition loader

### DIFF
--- a/Kernel/Devices/MBRPartitionTable.cpp
+++ b/Kernel/Devices/MBRPartitionTable.cpp
@@ -1,0 +1,74 @@
+#include <AK/ByteBuffer.h>
+#include <Kernel/Devices/MBRPartitionTable.h>
+
+#define MBR_DEBUG
+
+Retained<MBRPartitionTable> MBRPartitionTable::create(Retained<DiskDevice>&& device)
+{
+    return adopt(*new MBRPartitionTable(move(device)));
+}
+
+MBRPartitionTable::MBRPartitionTable(Retained<DiskDevice>&& device)
+    : m_device(move(device))
+{
+}
+
+MBRPartitionTable::~MBRPartitionTable()
+{
+}
+
+ByteBuffer MBRPartitionTable::read_header() const
+{
+    auto buffer = ByteBuffer::create_uninitialized(512);
+    bool success = m_device->read_block(0, buffer.pointer());
+    ASSERT(success);
+    return buffer;
+}
+
+const MBRPartitionHeader& MBRPartitionTable::header() const
+{
+    if (!m_cached_header) {
+        m_cached_header = read_header();
+    }
+
+    return *reinterpret_cast<MBRPartitionHeader*>(m_cached_header.pointer());
+}
+
+bool MBRPartitionTable::initialize()
+{
+    auto& header = this->header();
+
+#ifdef MBR_DEBUG
+    kprintf("MBRPartitionTable::initialize: mbr_signature=%#x\n", header.mbr_signature);
+#endif
+
+    if (header.mbr_signature != MBR_SIGNATURE) {
+        kprintf("MBRPartitionTable::initialize: bad mbr signature %#x\n", header.mbr_signature);
+        return false;
+    }
+
+    return true;
+}
+
+RetainPtr<DiskPartition> MBRPartitionTable::partition(unsigned index)
+{
+    ASSERT(index >= 1 && index <= 4);
+
+    auto& header = this->header();
+    auto& entry = header.entry[index - 1];
+
+#ifdef MBR_DEBUG
+    kprintf("MBRPartitionTable::partition: status=%#x offset=%#x\n", entry.status, entry.offset);
+#endif
+
+    if (entry.status == 0x00) {
+        return nullptr;
+    }
+
+    return DiskPartition::create(m_device.copy_ref(), entry.offset);
+}
+
+const char* MBRPartitionTable::class_name() const
+{
+    return "MBRPartitionTable";
+}

--- a/Kernel/Devices/MBRPartitionTable.h
+++ b/Kernel/Devices/MBRPartitionTable.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <AK/RetainPtr.h>
+#include <AK/Vector.h>
+#include <Kernel/Devices/DiskDevice.h>
+#include <Kernel/Devices/DiskPartition.h>
+
+#define MBR_SIGNATURE 0xaa55
+
+struct MBRPartitionEntry {
+    byte status;
+    byte chs1[3];
+    byte type;
+    byte chs2[3];
+    dword offset;
+    dword length;
+} __attribute__((packed));
+
+struct MBRPartitionHeader {
+    byte code1[218];
+    word ts_zero;
+    byte ts_drive, ts_seconds, ts_minutes, ts_hours;
+    byte code2[216];
+    dword disk_signature;
+    word disk_signature_zero;
+    MBRPartitionEntry entry[4];
+    word mbr_signature;
+} __attribute__((packed));
+
+class MBRPartitionTable : public Retainable<MBRPartitionTable> {
+public:
+    static Retained<MBRPartitionTable> create(Retained<DiskDevice>&& device);
+    virtual ~MBRPartitionTable();
+
+    bool initialize();
+    RetainPtr<DiskPartition> partition(unsigned index);
+
+private:
+    virtual const char* class_name() const;
+
+    MBRPartitionTable(Retained<DiskDevice>&&);
+
+    Retained<DiskDevice> m_device;
+
+    ByteBuffer read_header() const;
+    const MBRPartitionHeader& header() const;
+
+    mutable ByteBuffer m_cached_header;
+};

--- a/Kernel/Devices/MBRPartitionTable.h
+++ b/Kernel/Devices/MBRPartitionTable.h
@@ -27,23 +27,21 @@ struct MBRPartitionHeader {
     word mbr_signature;
 } __attribute__((packed));
 
-class MBRPartitionTable : public Retainable<MBRPartitionTable> {
+class MBRPartitionTable {
+    AK_MAKE_ETERNAL
+
 public:
-    static Retained<MBRPartitionTable> create(Retained<DiskDevice>&& device);
-    virtual ~MBRPartitionTable();
+    MBRPartitionTable(Retained<DiskDevice>&& device);
+    ~MBRPartitionTable();
 
     bool initialize();
     RetainPtr<DiskPartition> partition(unsigned index);
 
 private:
-    virtual const char* class_name() const;
-
-    MBRPartitionTable(Retained<DiskDevice>&&);
-
     Retained<DiskDevice> m_device;
 
     ByteBuffer read_header() const;
     const MBRPartitionHeader& header() const;
 
-    mutable ByteBuffer m_cached_header;
+    byte m_cached_header[512];
 };

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -66,6 +66,7 @@ VFS_OBJS = \
     Devices/RandomDevice.o \
     Devices/DebugLogDevice.o \
     Devices/DiskPartition.o \
+    Devices/MBRPartitionTable.o \
     FileSystem/FileSystem.o \
     FileSystem/DiskBackedFileSystem.o \
     FileSystem/Ext2FileSystem.o \

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -73,13 +73,13 @@ VFS* vfs;
 
     auto dev_hd0 = IDEDiskDevice::create();
 
-    auto dev_hd0pt = MBRPartitionTable::create(dev_hd0.copy_ref());
-    if (!dev_hd0pt->initialize()) {
+    MBRPartitionTable dev_hd0pt(dev_hd0.copy_ref());
+    if (!dev_hd0pt.initialize()) {
         kprintf("init_stage2: couldn't read MBR from disk");
         hang();
     }
 
-    auto dev_hd0p1 = dev_hd0pt->partition(1);
+    auto dev_hd0p1 = dev_hd0pt.partition(1);
     if (!dev_hd0p1) {
         kprintf("init_stage2: couldn't get first partition");
         hang();

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -6,6 +6,7 @@
 #include "Process.h"
 #include "PIC.h"
 #include <Kernel/Devices/IDEDiskDevice.h>
+#include <Kernel/Devices/MBRPartitionTable.h>
 #include <Kernel/Devices/DiskPartition.h>
 #include "KSyms.h"
 #include <Kernel/Devices/NullDevice.h>
@@ -58,11 +59,6 @@ VFS* vfs;
 }
 #endif
 
-// TODO: delete this magic number. this block offset corresponds to a
-// partition that starts at 32k into an MBR disk. this value is also specified
-// in sync.sh, but should ideally be read from the MBR header at startup.
-#define PARTITION_OFFSET 62
-
 [[noreturn]] static void init_stage2()
 {
     Syscall::initialize();
@@ -71,10 +67,29 @@ VFS* vfs;
     auto dev_full = make<FullDevice>();
     auto dev_random = make<RandomDevice>();
     auto dev_ptmx = make<PTYMultiplexer>();
+
+    // TODO: decide what drive/partition to use based on cmdline from
+    // bootloader. currently hardcoded to the equivalent of hd0,1.
+
     auto dev_hd0 = IDEDiskDevice::create();
-    auto dev_hd0p1 = DiskPartition::create(dev_hd0.copy_ref(), PARTITION_OFFSET);
-    auto e2fs = Ext2FS::create(dev_hd0p1.copy_ref());
-    e2fs->initialize();
+
+    auto dev_hd0pt = MBRPartitionTable::create(dev_hd0.copy_ref());
+    if (!dev_hd0pt->initialize()) {
+        kprintf("init_stage2: couldn't read MBR from disk");
+        hang();
+    }
+
+    auto dev_hd0p1 = dev_hd0pt->partition(1);
+    if (!dev_hd0p1) {
+        kprintf("init_stage2: couldn't get first partition");
+        hang();
+    }
+
+    auto e2fs = Ext2FS::create(*dev_hd0p1.copy_ref());
+    if (!e2fs->initialize()) {
+        kprintf("init_stage2: couldn't open root filesystem");
+        hang();
+    }
 
     vfs->mount_root(e2fs.copy_ref());
 
@@ -89,7 +104,7 @@ VFS* vfs;
 
     auto* system_server_process = Process::create_user_process("/bin/SystemServer", (uid_t)100, (gid_t)100, (pid_t)0, error, { }, { }, tty0);
     if (error != 0) {
-        dbgprintf("error spawning SystemServer: %d\n", error);
+        dbgprintf("init_stage2: error spawning SystemServer: %d\n", error);
         hang();
     }
     system_server_process->set_priority(Process::HighPriority);


### PR DESCRIPTION
This implements a basic MBR partition loader, which removes the reliance
on a hard-coded filesystem offset in the stage2 init.