### PR TITLE
AK: Add AKString::split_limit to split strings with a limit

### DIFF
--- a/AK/AKString.h
+++ b/AK/AKString.h
@@ -109,6 +109,7 @@ public:
         return m_impl->to_uppercase();
     }
 
+    Vector<String> split_limit(char separator, int limit) const;
     Vector<String> split(char separator) const;
     String substring(int start, int length) const;
 

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -69,12 +69,17 @@ StringView String::substring_view(int start, int length) const
 
 Vector<String> String::split(const char separator) const
 {
+    return split_limit(separator, 0);
+}
+
+Vector<String> String::split_limit(const char separator, int limit) const
+{
     if (is_empty())
         return {};
 
     Vector<String> v;
     ssize_t substart = 0;
-    for (ssize_t i = 0; i < length(); ++i) {
+    for (ssize_t i = 0; i < length() && (v.size() + 1) != limit; ++i) {
         char ch = characters()[i];
         if (ch == separator) {
             ssize_t sublen = i - substart;


### PR DESCRIPTION
This is a small change to the existing split() functionality to support
the case of splitting a string and stopping at a certain number of
tokens. This is useful for parsing e.g. key/value pairs, where the value
may contain the delimiter you're splitting on.