### PR TITLE
Kernel: Add KParams class for accessing kernel cmdline parameters

### DIFF
--- a/Kernel/KParams.cpp
+++ b/Kernel/KParams.cpp
@@ -1,0 +1,38 @@
+#include <Kernel/KParams.h>
+
+static KParams* s_the;
+
+KParams& KParams::the()
+{
+    return *s_the;
+}
+
+KParams::KParams(const String cmdline) : m_cmdline(cmdline)
+{
+    s_the = this;
+
+    for (auto str : m_cmdline.split(' ')) {
+        auto pair = str.split_limit('=', 2);
+
+        if (pair.size() == 1) {
+            m_params.set(pair[0], "");
+        } else {
+            m_params.set(pair[0], pair[1]);
+        }
+    }
+}
+
+const String KParams::cmdline() const
+{
+    return m_cmdline;
+}
+
+const String KParams::get(const String& key) const
+{
+    return m_params.get(key);
+}
+
+bool KParams::has(const String& key) const
+{
+    return m_params.contains(key);
+}

--- a/Kernel/KParams.cpp
+++ b/Kernel/KParams.cpp
@@ -7,7 +7,8 @@ KParams& KParams::the()
     return *s_the;
 }
 
-KParams::KParams(const String cmdline) : m_cmdline(cmdline)
+KParams::KParams(const String& cmdline)
+    : m_cmdline(cmdline)
 {
     s_the = this;
 
@@ -22,12 +23,7 @@ KParams::KParams(const String cmdline) : m_cmdline(cmdline)
     }
 }
 
-const String KParams::cmdline() const
-{
-    return m_cmdline;
-}
-
-const String KParams::get(const String& key) const
+String KParams::get(const String& key) const
 {
     return m_params.get(key);
 }

--- a/Kernel/KParams.h
+++ b/Kernel/KParams.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <AK/AKString.h>
+#include <AK/HashMap.h>
+
+class KParams {
+    AK_MAKE_ETERNAL
+public:
+    static KParams& the();
+
+    KParams(const String cmdline);
+
+    const String cmdline() const;
+    const String get(const String& key) const;
+    bool has(const String& key) const;
+private:
+    String m_cmdline;
+    HashMap<String, String> m_params;
+};

--- a/Kernel/KParams.h
+++ b/Kernel/KParams.h
@@ -8,10 +8,10 @@ class KParams {
 public:
     static KParams& the();
 
-    KParams(const String cmdline);
+    KParams(const String& cmdline);
 
-    const String cmdline() const;
-    const String get(const String& key) const;
+    const String& cmdline() const { return m_cmdline; }
+    String get(const String& key) const;
     bool has(const String& key) const;
 private:
     String m_cmdline;

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -32,6 +32,7 @@ KERNEL_OBJS = \
        Scheduler.o \
        DoubleBuffer.o \
        KSyms.o \
+       KParams.o \
        SharedMemory.o \
        FileSystem/DevPtsFS.o \
        Devices/BXVGADevice.o \

--- a/Kernel/grub.cfg
+++ b/Kernel/grub.cfg
@@ -2,5 +2,5 @@ timeout=0
 
 menuentry 'Serenity' {
   root=hd0,1
-  multiboot /boot/kernel Hello from grub!
+  multiboot /boot/kernel root=hd0,1
 }

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -28,6 +28,7 @@
 #include <Kernel/Net/NetworkTask.h>
 #include <Kernel/Devices/DebugLogDevice.h>
 #include <Kernel/Multiboot.h>
+#include <Kernel/KParams.h>
 
 //#define STRESS_TEST_SPAWNING
 
@@ -123,12 +124,13 @@ multiboot_info_t* multiboot_info_ptr;
 
 extern "C" [[noreturn]] void init()
 {
-    kprintf("Kernel command line: '%s'\n", multiboot_info_ptr->cmdline);
-
     sse_init();
 
     kmalloc_init();
     init_ksyms();
+
+    // must come after kmalloc_init because we use AK_MAKE_ETERNAL in KParams
+    new KParams(String(reinterpret_cast<const char*>(multiboot_info_ptr->cmdline)));
 
     vfs = new VFS;
     dev_debuglog = new DebugLogDevice;


### PR DESCRIPTION
This allows us to use the kernel command line provided by the bootloader without parsing the entire string each time.

My theory is that we'll parse the command line at startup, then keep it around forever, but never modify it. I'm keeping the raw command line as a property on `KParams` so we can expose it via `/proc/cmdline` later on.

I think the API is sound, but I'd love to know if I'm using the appropriate memory allocation strategies - not to mention whether I've used `const` in the right (or wrong!) places.