### PR TITLE
Kernel: Fix KParams parsing with trailing space in kernel cmdline

### DIFF
--- a/Kernel/KParams.cpp
+++ b/Kernel/KParams.cpp
@@ -13,6 +13,10 @@ KParams::KParams(const String& cmdline)
     s_the = this;
 
     for (auto str : m_cmdline.split(' ')) {
+        if (str == "") {
+            continue;
+        }
+
         auto pair = str.split_limit('=', 2);
 
         if (pair.size() == 1) {


### PR DESCRIPTION
When there's a trailing space in the cmdline from the boot loader, this
results in an empty string being emitted from `String::split` after
splitting apart the argument list. This empty string resulted in a
zero-length Vector from the subsequent call to split the key=value pairs,
which was unexpected. This ultimately caused a crash when we tried to
access `[0]` of that zero-length vector.

We now detect and handle an empty string coming from `String::split`
correctly.