### PR TITLE
Kernel: Parse cmdline for root filesystem e.g. root=/dev/hda1

### DIFF
--- a/Kernel/grub.cfg
+++ b/Kernel/grub.cfg
@@ -2,5 +2,5 @@ timeout=0
 
 menuentry 'Serenity' {
   root=hd0,1
-  multiboot /boot/kernel root=hd0,1
+  multiboot /boot/kernel root=/dev/hda1
 }


### PR DESCRIPTION
This introduces very basic handling of the kernel command line to choose
the root filesystem at startup. Given that we currently only support a
single IDE hard drive, it's hard-coded to look for `/dev/hda` at the start
of the argument.

If there is nothing following this, or if the parameter is empty,
init_stage2 will try to load the ext2 filesystem from the start of the
device. This is intended to be the default behaviour when running
development builds, as it is faster to set up and doesn't require a
working grub installation.

If `/dev/hda` is followed by a number, init_stage2 will try to read an MBR
partition header from the drive, then load the requested partition. It
will reject non-numeric trailing data, and anything outside of partitions
one through four.