### PR TITLE
Ports: Remove bashisms and switch all scripts to /bin/sh.

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -19,19 +19,19 @@ if [ -z "$PORT_DIR" ]; then
     exit 1
 fi
 
-function run_command() {
+run_command() {
     echo "+ $@"
     (cd "$PORT_DIR" && "$@")
     echo "+ FINISHED: $@"
 }
 
-function run_command_nocd() {
+run_command_nocd() {
     echo "+ $@ (nocd)"
     ("$@")
     echo "+ FINISHED (nocd): $@"
 }
 
-function run_fetch_git() {
+run_fetch_git() {
     if [ -d "$PORT_DIR/.git" ]; then
         run_command git fetch
         run_command git reset --hard FETCH_HEAD
@@ -41,7 +41,7 @@ function run_fetch_git() {
     fi
 }
 
-function run_fetch_web() {
+run_fetch_web() {
     if [ -d "$PORT_DIR" ]; then
         run_command_nocd rm -rf "$PORT_DIR"
     fi
@@ -54,36 +54,36 @@ function run_fetch_web() {
     run_command_nocd tar xavf "$file" -C "$PORT_DIR" --strip-components=1
 }
 
-function run_export_env() {
+run_export_env() {
     export $1="$2"
 }
 
-function run_replace_in_file() {
+run_replace_in_file() {
     run_command perl -p -i -e "$1" $2
 }
 
-function run_patch() {
+run_patch() {
     echo "+ Applying patch $1"
     run_command patch "$2" < "$1"
 }
 
-function run_configure_cmake() {
+run_configure_cmake() {
     run_command cmake -DCMAKE_TOOLCHAIN_FILE="$SERENITY_ROOT/Toolchain/CMakeToolchain.txt" .
 }
 
-function run_configure_autotools() {
+run_configure_autotools() {
     run_command ./configure --host=i686-pc-serenity "$@"
 }
 
-function run_make() {
+run_make() {
     run_command make $MAKEOPTS "$@"
 }
 
-function run_make_install() {
+run_make_install() {
     run_command make $INSTALLOPTS install "$@"
 }
 
-function run_send_to_file() {
+run_send_to_file() {
     echo "+ rewrite '$1'"
 	(cd "$PORT_DIR" && echo "$2" > "$1")
     echo "+ FINISHED"
@@ -101,16 +101,16 @@ if [ -z "$1" ]; then
     exit 0
 fi
 
-if [ "$1" == "fetch" ]; then
+if [ "$1" = "fetch" ]; then
     echo "+ Fetching..."
     fetch
-elif [ "$1" == "configure" ]; then
+elif [ "$1" = "configure" ]; then
     echo "+ Configuring..."
     configure
-elif [ "$1" == "build" ]; then
+elif [ "$1" = "build" ]; then
     echo "+ Building..."
     build
-elif [ "$1" == "install" ]; then
+elif [ "$1" = "install" ]; then
     echo "+ Installing..."
     install
 else

--- a/Ports/SDL2/SDL2.sh
+++ b/Ports/SDL2/SDL2.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 PORT_DIR=SDL
-function fetch() {
+fetch() {
     run_fetch_git "https://github.com/SerenityOS/SDL"
 }
-function configure() {
+configure() {
     run_configure_cmake
 }
-function build() {
+build() {
     run_make
 }
-function install() {
+install() {
     run_make_install
 }
-source ../.port_include.sh
+. ../.port_include.sh

--- a/Ports/bash/bash.sh
+++ b/Ports/bash/bash.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 PORT_DIR=bash
-function fetch() {
+fetch() {
     run_fetch_git "https://git.savannah.gnu.org/git/bash.git"
 
     # Add serenity as a system for configure
@@ -13,16 +13,16 @@ function fetch() {
     # Locale calls crash right now. LibC bug, probably.
     run_patch disable-locale.patch -p1
 }
-function configure() {
+configure() {
     run_configure_autotools --disable-nls --without-bash-malloc
 }
-function build() {
+build() {
     # Avoid some broken cross compile tests...
     run_replace_in_file "s/define GETCWD_BROKEN 1/undef GETCWD_BROKEN/" config.h
     run_replace_in_file "s/define CAN_REDEFINE_GETENV 1/undef CAN_REDEFINE_GETENV/" config.h
     run_make
 }
-function install() {
+install() {
     run_make_install DESTDIR="$SERENITY_ROOT"/Root
 }
-source ../.port_include.sh
+. ../.port_include.sh

--- a/Ports/binutils/binutils.sh
+++ b/Ports/binutils/binutils.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 PORT_DIR=binutils
-function fetch() {
+fetch() {
     run_fetch_web "https://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.xz"
 
     # Add the big binutils patch (same one used by toolchain.)
     run_patch $SERENITY_ROOT/Toolchain/Patches/binutils.patch -p1
 }
-function configure() {
+configure() {
     run_configure_autotools \
         --target=i686-pc-serenity \
         --with-sysroot=/ \
@@ -15,10 +15,10 @@ function configure() {
         --disable-gdb \
         --disable-nls
 }
-function build() {
+build() {
     run_make
 }
-function install() {
+install() {
     run_make_install DESTDIR="$SERENITY_ROOT"/Root
 }
-source ../.port_include.sh
+. ../.port_include.sh

--- a/Ports/gcc/gcc.sh
+++ b/Ports/gcc/gcc.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 PORT_DIR=gcc
-function fetch() {
+fetch() {
     run_fetch_web "https://ftp.gnu.org/gnu/gcc/gcc-8.3.0/gcc-8.3.0.tar.xz"
 
     # Add the big GCC patch (same one used by toolchain.)
@@ -12,7 +12,7 @@ function fetch() {
     # Patch mpfr, mpc and isl to teach them about "serenity" targets.
     run_patch dependencies-config.patch -p1
 }
-function configure() {
+configure() {
     run_configure_autotools \
         --target=i686-pc-serenity \
         --with-sysroot=/ \
@@ -22,12 +22,12 @@ function configure() {
         --disable-lto \
         --disable-nls
 }
-function build() {
+build() {
     MAKEOPTS=""
     run_make all-gcc all-target-libgcc all-target-libstdc++-v3
     run_command find ./host-i686-pc-serenity/gcc/ -maxdepth 1 -type f -executable -exec strip --strip-debug {} \; || echo
 }
-function install() {
+install() {
     run_make $INSTALLOPTS DESTDIR="$SERENITY_ROOT"/Root install-gcc install-target-libgcc install-target-libstdc++-v3
 }
-source ../.port_include.sh
+. ../.port_include.sh

--- a/Ports/less/less.sh
+++ b/Ports/less/less.sh
@@ -2,16 +2,16 @@
 PORT_DIR=less
 INSTALLOPTS="DESTDIR=$SERENITY_ROOT/Root/"
 
-function fetch() {
+fetch() {
     run_fetch_web "http://ftp.gnu.org/gnu/less/less-530.tar.gz"
 }
-function configure() {
+configure() {
     run_configure_autotools
 }
-function build() {
+build() {
     run_make
 }
-function install() {
+install() {
     run_make_install
 }
-source ../.port_include.sh
+. ../.port_include.sh

--- a/Ports/links/links.sh
+++ b/Ports/links/links.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 PORT_DIR=links
-function fetch() {
+fetch() {
     run_fetch_web "http://links.twibright.com/download/links-2.19.tar.bz2"
 }
-function configure() {
+configure() {
     run_export_env CC i686-pc-serenity-gcc
     run_configure_autotools
 }
-function build() {
+build() {
     run_make
 }
-function install() {
+install() {
     run_make_install DESTDIR="$SERENITY_ROOT"/Root
 }
-source ../.port_include.sh
+. ../.port_include.sh

--- a/Ports/lua/lua.sh
+++ b/Ports/lua/lua.sh
@@ -4,21 +4,21 @@ MAKEOPTS='generic'
 
 INSTALLOPTS="INSTALL_TOP=$SERENITY_ROOT/Root/"
 
-function fetch() {
+fetch() {
     run_fetch_web "http://www.lua.org/ftp/lua-5.3.5.tar.gz"
     run_patch lua.patch -p1
 }
-function configure() {
+configure() {
     run_export_env CC i686-pc-serenity-gcc
 }
-function run_make() {
+run_make() {
     run_command make $MAKEOPTS "$@"
 }
 
-function build() {
+build() {
     run_make
 }
-function install() {
+install() {
     run_make_install DESTDIR="$SERENITY_ROOT"/Root
 }
-source ../.port_include.sh
+. ../.port_include.sh

--- a/Ports/ncurses/ncurses.sh
+++ b/Ports/ncurses/ncurses.sh
@@ -2,17 +2,17 @@
 PORT_DIR=ncurses
 INSTALLOPTS="DESTDIR=$SERENITY_ROOT/Root/"
 
-function fetch() {
+fetch() {
     run_fetch_git "https://github.com/mirror/ncurses.git"
     run_patch allow-serenity-os-ncurses.patch -p1
 }
-function configure() {
+configure() {
     run_configure_autotools
 }
-function build() {
+build() {
     run_make
 }
-function install() {
+install() {
     run_make_install
 }
-source ../.port_include.sh
+. ../.port_include.sh

--- a/Ports/vim/vim.sh
+++ b/Ports/vim/vim.sh
@@ -2,11 +2,11 @@
 PORT_DIR=vim
 INSTALLOPTS="DESTDIR=$SERENITY_ROOT/Root/"
 
-function fetch() {
+fetch() {
     run_fetch_git "https://github.com/vim/vim.git"
 }
 
-function configure() {
+configure() {
 	run_send_to_file src/auto/config.cache "
 	vim_cv_getcwd_broken=no
 	vim_cv_memmove_handles_overlap=yes
@@ -19,12 +19,12 @@ function configure() {
 	run_configure_autotools --with-tlib=ncurses --with-features=small
 }
 
-function build() {
+build() {
     run_make
 }
 
-function install() {
+install() {
     run_make_install
 }
 
-source ../.port_include.sh
+. ../.port_include.sh


### PR DESCRIPTION
Many of the port scripts were shebanged as /bin/sh even though they contained bashisms (e.g. using `function` even though that's not POSIX). This leads to problems on systems that use a more strictly POSIX compliant shell as /bin/sh, such as dash. 

I've gone ahead and removed all of the bashisms and switched all of the shebangs to /bin/sh. An (in my opinion, lesser) alternative is just shebanging all of the scripts as /bin/bash.