### PR TITLE
WindowServer: Scaled backgrounds now supported

### DIFF
--- a/Base/home/anon/WindowManager.ini
+++ b/Base/home/anon/WindowManager.ini
@@ -1,5 +1,5 @@
 [Screen]
-Width=1080
+Width=1024
 Height=768
 
 [Cursor]
@@ -36,4 +36,4 @@ MenuSelectionColor=132,53,26
 DoubleClickSpeed=250
 
 [Background]
-Mode=center
+Mode=scaled

--- a/Servers/WindowServer/WSCompositor.cpp
+++ b/Servers/WindowServer/WSCompositor.cpp
@@ -104,10 +104,10 @@ void WSCompositor::compose()
             } else if (m_wallpaper_mode == WallpaperMode::Tile) {
                 m_back_painter->blit_tiled(dirty_rect.location(), *m_wallpaper, dirty_rect);
             } else {
-                // FIXME: Does not work: offset rect creates trails.
-                m_back_painter->draw_scaled_bitmap(dirty_rect, *m_wallpaper,
-                    { dirty_rect.location(),
-                        m_wallpaper->size() });
+                float hscale = (float)m_wallpaper->size().width() / (float)ws.size().width();
+                float vscale = (float)m_wallpaper->size().height() / (float)ws.size().height();
+
+                m_back_painter->blit_scaled(dirty_rect.location(), *m_wallpaper, dirty_rect, hscale, vscale);
             }
         }
     }

--- a/Servers/WindowServer/WSCompositor.cpp
+++ b/Servers/WindowServer/WSCompositor.cpp
@@ -80,7 +80,7 @@ void WSCompositor::compose()
     dbgprintf("[WM] compose #%u (%u rects)\n", ++m_compose_count, dirty_rects.rects().size());
 #endif
 
-    auto any_dirty_rect_intersects_window = [&dirty_rects] (const WSWindow& window) {
+    auto any_dirty_rect_intersects_window = [&dirty_rects](const WSWindow& window) {
         auto window_frame_rect = window.frame().rect();
         for (auto& dirty_rect : dirty_rects.rects()) {
             if (dirty_rect.intersects(window_frame_rect))
@@ -97,22 +97,22 @@ void WSCompositor::compose()
             if (m_wallpaper_mode == WallpaperMode::Simple) {
                 m_back_painter->blit(dirty_rect.location(), *m_wallpaper, dirty_rect);
             } else if (m_wallpaper_mode == WallpaperMode::Center) {
-                Point offset{ ws.size().width() / 2 - m_wallpaper->size().width() / 2,
-                              ws.size().height() / 2 - m_wallpaper->size().height() / 2 };
+                Point offset { ws.size().width() / 2 - m_wallpaper->size().width() / 2,
+                    ws.size().height() / 2 - m_wallpaper->size().height() / 2 };
                 m_back_painter->blit_offset(dirty_rect.location(), *m_wallpaper,
-                                            dirty_rect, offset);
+                    dirty_rect, offset);
             } else if (m_wallpaper_mode == WallpaperMode::Tile) {
                 m_back_painter->blit_tiled(dirty_rect.location(), *m_wallpaper, dirty_rect);
             } else {
                 // FIXME: Does not work: offset rect creates trails.
                 m_back_painter->draw_scaled_bitmap(dirty_rect, *m_wallpaper,
-                                                   { dirty_rect.location(),
-                                                     m_wallpaper->size() });
+                    { dirty_rect.location(),
+                        m_wallpaper->size() });
             }
         }
     }
 
-    auto compose_window = [&] (WSWindow& window) -> IterationDecision {
+    auto compose_window = [&](WSWindow& window) -> IterationDecision {
         if (!any_dirty_rect_intersects_window(window))
             return IterationDecision::Continue;
         PainterStateSaver saver(*m_back_painter);
@@ -154,7 +154,7 @@ void WSCompositor::compose()
     if (auto* fullscreen_window = wm.active_fullscreen_window()) {
         compose_window(*fullscreen_window);
     } else {
-        wm.for_each_visible_window_from_back_to_front([&] (WSWindow& window) {
+        wm.for_each_visible_window_from_back_to_front([&](WSWindow& window) {
             return compose_window(window);
         });
 
@@ -234,7 +234,7 @@ bool WSCompositor::set_wallpaper(const String& path, Function<void(bool)>&& call
     context->path = path;
     context->callback = move(callback);
 
-    int rc = create_thread([] (void* ctx) -> int {
+    int rc = create_thread([](void* ctx) -> int {
         OwnPtr<Context> context((Context*)ctx);
         context->bitmap = load_png(context->path);
         if (!context->bitmap) {
@@ -242,13 +242,14 @@ bool WSCompositor::set_wallpaper(const String& path, Function<void(bool)>&& call
             exit_thread(0);
             return 0;
         }
-        the().deferred_invoke([context = move(context)] (auto&) {
+        the().deferred_invoke([context = move(context)](auto&) {
             the().finish_setting_wallpaper(context->path, *context->bitmap);
             context->callback(true);
         });
         exit_thread(0);
         return 0;
-    }, context.leak_ptr());
+    },
+        context.leak_ptr());
     ASSERT(rc == 0);
 
     return true;
@@ -275,7 +276,7 @@ void WSCompositor::set_resolution(int width, int height)
     auto screen_rect = WSScreen::the().rect();
     if (screen_rect.width() == width && screen_rect.height() == height)
         return;
-    m_wallpaper_path = { };
+    m_wallpaper_path = {};
     m_wallpaper = nullptr;
     WSScreen::the().set_resolution(width, height);
     m_front_bitmap = GraphicsBitmap::create_wrapper(GraphicsBitmap::Format::RGB32, { width, height }, WSScreen::the().scanline(0));
@@ -303,7 +304,7 @@ void WSCompositor::draw_geometry_label()
     auto& wm = WSWindowManager::the();
     auto* window_being_moved_or_resized = wm.m_drag_window ? wm.m_drag_window.ptr() : (wm.m_resize_window ? wm.m_resize_window.ptr() : nullptr);
     if (!window_being_moved_or_resized) {
-        m_last_geometry_label_rect = { };
+        m_last_geometry_label_rect = {};
         return;
     }
     auto geometry_string = window_being_moved_or_resized->rect().to_string();
@@ -340,7 +341,7 @@ void WSCompositor::draw_menubar()
     m_back_painter->fill_rect(menubar_rect, Color::LightGray);
     m_back_painter->draw_line({ 0, menubar_rect.bottom() }, { menubar_rect.right(), menubar_rect.bottom() }, Color::MidGray);
     int index = 0;
-    wm.for_each_active_menubar_menu([&] (WSMenu& menu) {
+    wm.for_each_active_menubar_menu([&](WSMenu& menu) {
         Color text_color = Color::Black;
         if (&menu == wm.current_menu()) {
             m_back_painter->fill_rect(menu.rect_in_menubar(), wm.menu_selection_color());
@@ -351,8 +352,7 @@ void WSCompositor::draw_menubar()
             menu.name(),
             index == 1 ? wm.app_menu_font() : wm.menu_font(),
             TextAlignment::CenterLeft,
-            text_color
-        );
+            text_color);
         ++index;
         return true;
     });

--- a/Servers/WindowServer/WSCompositor.cpp
+++ b/Servers/WindowServer/WSCompositor.cpp
@@ -107,7 +107,7 @@ void WSCompositor::compose()
                 float hscale = (float)m_wallpaper->size().width() / (float)ws.size().width();
                 float vscale = (float)m_wallpaper->size().height() / (float)ws.size().height();
 
-                m_back_painter->blit_scaled(dirty_rect.location(), *m_wallpaper, dirty_rect, hscale, vscale);
+                m_back_painter->blit_scaled(dirty_rect, *m_wallpaper, dirty_rect, hscale, vscale);
             }
         }
     }

--- a/SharedGraphics/Painter.cpp
+++ b/SharedGraphics/Painter.cpp
@@ -204,6 +204,36 @@ void Painter::draw_bitmap(const Point& p, const GlyphBitmap& bitmap, Color color
     }
 }
 
+void Painter::blit_scaled(const Point& position, const GraphicsBitmap& source, const Rect& src_rect, float hscale, float vscale)
+{
+    auto dst_rect = Rect(position, src_rect.size()).translated(translation());
+    auto clipped_rect = dst_rect.intersected(clip_rect());
+    if (clipped_rect.is_empty())
+        return;
+    const int first_row = (clipped_rect.top() - dst_rect.top());
+    const int last_row = (clipped_rect.bottom() - dst_rect.top());
+    const int first_column = (clipped_rect.left() - dst_rect.left());
+    RGBA32* dst = m_target->scanline(clipped_rect.y()) + clipped_rect.x();
+    const size_t dst_skip = m_target->pitch() / sizeof(RGBA32);
+
+    int x_start = first_column + src_rect.left();
+    for (int row = first_row; row <= last_row; ++row) {
+        int sr = (row + src_rect.top()) * vscale;
+        if (sr >= source.size().height() || sr < 0) {
+            dst += dst_skip;
+            continue;
+        }
+        const RGBA32* sl = source.scanline(sr);
+        for (int x = x_start; x < clipped_rect.width() + x_start; ++x) {
+            int sx = x * hscale;
+            if (sx < source.size().width() && sx >= 0)
+                dst[x - x_start] = sl[sx];
+        }
+        dst += dst_skip;
+    }
+    return;
+}
+
 void Painter::blit_with_opacity(const Point& position, const GraphicsBitmap& source, const Rect& src_rect, float opacity)
 {
     ASSERT(!m_target->has_alpha_channel());

--- a/SharedGraphics/Painter.cpp
+++ b/SharedGraphics/Painter.cpp
@@ -204,9 +204,9 @@ void Painter::draw_bitmap(const Point& p, const GlyphBitmap& bitmap, Color color
     }
 }
 
-void Painter::blit_scaled(const Point& position, const GraphicsBitmap& source, const Rect& src_rect, float hscale, float vscale)
+void Painter::blit_scaled(const Rect& dst_rect_raw, const GraphicsBitmap& source, const Rect& src_rect, float hscale, float vscale)
 {
-    auto dst_rect = Rect(position, src_rect.size()).translated(translation());
+    auto dst_rect = Rect(dst_rect_raw.location(), dst_rect_raw.size()).translated(translation());
     auto clipped_rect = dst_rect.intersected(clip_rect());
     if (clipped_rect.is_empty())
         return;

--- a/SharedGraphics/Painter.cpp
+++ b/SharedGraphics/Painter.cpp
@@ -1,13 +1,13 @@
 #include "Painter.h"
 #include "Font.h"
 #include "GraphicsBitmap.h"
-#include <SharedGraphics/CharacterBitmap.h>
 #include <AK/Assertions.h>
 #include <AK/StdLibExtras.h>
 #include <AK/StringBuilder.h>
-#include <unistd.h>
-#include <stdio.h>
+#include <SharedGraphics/CharacterBitmap.h>
 #include <math.h>
+#include <stdio.h>
+#include <unistd.h>
 
 #pragma GCC optimize("O3")
 
@@ -89,7 +89,7 @@ void Painter::fill_rect_with_gradient(const Rect& a_rect, Color gradient_start, 
     RGBA32* dst = m_target->scanline(clipped_rect.top()) + clipped_rect.left();
     const size_t dst_skip = m_target->pitch() / sizeof(RGBA32);
 
-    float increment = (1.0/((rect.width())/255.0));
+    float increment = (1.0 / ((rect.width()) / 255.0));
 
     int r2 = gradient_start.red();
     int g2 = gradient_start.green();
@@ -104,8 +104,8 @@ void Painter::fill_rect_with_gradient(const Rect& a_rect, Color gradient_start, 
             dst[j] = Color(
                 r1 / 255.0 * c + r2 / 255.0 * (255 - c),
                 g1 / 255.0 * c + g2 / 255.0 * (255 - c),
-                b1 / 255.0 * c + b2 / 255.0 * (255 - c)
-            ).value();
+                b1 / 255.0 * c + b2 / 255.0 * (255 - c))
+                         .value();
             c += increment;
         }
         dst += dst_skip;
@@ -289,7 +289,7 @@ void Painter::blit_tiled(const Point& position, const GraphicsBitmap& source, co
         int x_start = first_column + src_rect.left();
         for (int row = first_row; row <= last_row; ++row) {
             const RGBA32* sl = source.scanline((row + src_rect.top())
-                                               % source.size().height());
+                % source.size().height());
             for (int x = x_start; x < clipped_rect.width() + x_start; ++x) {
                 dst[x - x_start] = sl[x % source.size().width()];
             }
@@ -302,9 +302,9 @@ void Painter::blit_tiled(const Point& position, const GraphicsBitmap& source, co
 }
 
 void Painter::blit_offset(const Point& position,
-                          const GraphicsBitmap& source,
-                          const Rect& src_rect,
-                          const Point& offset)
+    const GraphicsBitmap& source,
+    const Rect& src_rect,
+    const Point& offset)
 {
     auto dst_rect = Rect(position, src_rect.size()).translated(translation());
     auto clipped_rect = dst_rect.intersected(clip_rect());
@@ -483,17 +483,33 @@ void Painter::draw_scaled_bitmap(const Rect& a_dst_rect, const GraphicsBitmap& s
 
     if (source.has_alpha_channel()) {
         switch (source.format()) {
-        case GraphicsBitmap::Format::RGB32: do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::RGB32>); break;
-        case GraphicsBitmap::Format::RGBA32: do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::RGB32>); break;
-        case GraphicsBitmap::Format::Indexed8: do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::Indexed8>); break;
-        default: do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::Invalid>); break;
+        case GraphicsBitmap::Format::RGB32:
+            do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::RGB32>);
+            break;
+        case GraphicsBitmap::Format::RGBA32:
+            do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::RGB32>);
+            break;
+        case GraphicsBitmap::Format::Indexed8:
+            do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::Indexed8>);
+            break;
+        default:
+            do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::Invalid>);
+            break;
         }
     } else {
         switch (source.format()) {
-        case GraphicsBitmap::Format::RGB32: do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::RGB32>); break;
-        case GraphicsBitmap::Format::RGBA32: do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::RGB32>); break;
-        case GraphicsBitmap::Format::Indexed8: do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::Indexed8>); break;
-        default: do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::Invalid>); break;
+        case GraphicsBitmap::Format::RGB32:
+            do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::RGB32>);
+            break;
+        case GraphicsBitmap::Format::RGBA32:
+            do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::RGB32>);
+            break;
+        case GraphicsBitmap::Format::Indexed8:
+            do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::Indexed8>);
+            break;
+        default:
+            do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, hscale, vscale, get_pixel<GraphicsBitmap::Format::Invalid>);
+            break;
         }
     }
 }

--- a/SharedGraphics/Painter.h
+++ b/SharedGraphics/Painter.h
@@ -4,9 +4,9 @@
 #include "Point.h"
 #include "Rect.h"
 #include "Size.h"
+#include <AK/AKString.h>
 #include <SharedGraphics/TextAlignment.h>
 #include <SharedGraphics/TextElision.h>
-#include <AK/AKString.h>
 
 class CharacterBitmap;
 class GlyphBitmap;
@@ -38,7 +38,11 @@ public:
     const Font& font() const { return *state().font; }
     void set_font(const Font& font) { state().font = &font; }
 
-    enum class DrawOp { Copy, Xor };
+    enum class DrawOp
+    {
+        Copy,
+        Xor
+    };
     void set_draw_op(DrawOp op) { state().draw_op = op; }
     DrawOp draw_op() const { return state().draw_op; }
 
@@ -54,7 +58,11 @@ public:
     GraphicsBitmap* target() { return m_target.ptr(); }
 
     void save() { m_state_stack.append(m_state_stack.last()); }
-    void restore() { ASSERT(m_state_stack.size() > 1); m_state_stack.take_last(); }
+    void restore()
+    {
+        ASSERT(m_state_stack.size() > 1);
+        m_state_stack.take_last();
+    }
 
 protected:
     void set_pixel_with_draw_op(dword& pixel, const Color&);

--- a/SharedGraphics/Painter.h
+++ b/SharedGraphics/Painter.h
@@ -29,7 +29,7 @@ public:
     void blit_dimmed(const Point&, const GraphicsBitmap&, const Rect& src_rect);
     void blit_tiled(const Point&, const GraphicsBitmap&, const Rect& src_rect);
     void blit_offset(const Point&, const GraphicsBitmap&, const Rect& src_rect, const Point&);
-    void blit_scaled(const Point&, const GraphicsBitmap&, const Rect& src_rect, const Size&);
+    void blit_scaled(const Point&, const GraphicsBitmap&, const Rect&, float, float);
     void draw_text(const Rect&, const StringView&, const Font&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None);
     void draw_text(const Rect&, const StringView&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None);
     void draw_glyph(const Point&, char, Color);

--- a/SharedGraphics/Painter.h
+++ b/SharedGraphics/Painter.h
@@ -29,7 +29,7 @@ public:
     void blit_dimmed(const Point&, const GraphicsBitmap&, const Rect& src_rect);
     void blit_tiled(const Point&, const GraphicsBitmap&, const Rect& src_rect);
     void blit_offset(const Point&, const GraphicsBitmap&, const Rect& src_rect, const Point&);
-    void blit_scaled(const Point&, const GraphicsBitmap&, const Rect&, float, float);
+    void blit_scaled(const Rect&, const GraphicsBitmap&, const Rect&, float, float);
     void draw_text(const Rect&, const StringView&, const Font&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None);
     void draw_text(const Rect&, const StringView&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None);
     void draw_glyph(const Point&, char, Color);


### PR DESCRIPTION
Completing the code from my earlier configuration PR, I finished getting scaled backgrounds to work properly. As it turns out, `draw_scaled_bitmap` does not work properly for doing dirty_rect backgrounds because it doesn't do clipping, and seems to ignore doing positioning like `blit` operations do, so I implemented a proper `blit_scaled` function. In a subsequent PR I will unify all the blit functions into one, and have them take a `enum` mode.

![2019-06-04-173039_1084x1083_scrot](https://user-images.githubusercontent.com/1920151/58922127-80a2c480-86ee-11e9-9f94-be130065bac2.png)
