### PR TITLE
Kernel: Implement on-demand physical page accounting

### DIFF
--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -387,8 +387,8 @@ ByteBuffer procfs$mm(InodeIdentifier)
             vmo->name().characters());
     }
     builder.appendf("VMO count: %u\n", MM.m_vmos.size());
-    builder.appendf("Free physical pages: %u\n", MM.m_free_physical_pages.size());
-    builder.appendf("Free supervisor physical pages: %u\n", MM.m_free_supervisor_physical_pages.size());
+    builder.appendf("Free physical pages: %u\n", MM.user_physical_pages() - MM.user_physical_pages_used());
+    builder.appendf("Free supervisor physical pages: %u\n", MM.super_physical_pages() - MM.super_physical_pages_used());
     return builder.to_byte_buffer();
 }
 
@@ -544,10 +544,10 @@ ByteBuffer procfs$memstat(InodeIdentifier)
         kmalloc_sum_eternal,
         sum_alloc,
         sum_free,
-        MM.user_physical_pages_in_existence() - MM.m_free_physical_pages.size(),
-        MM.user_physical_pages_not_yet_used() + MM.m_free_physical_pages.size(),
-        MM.super_physical_pages_in_existence() - MM.m_free_supervisor_physical_pages.size(),
-        MM.m_free_supervisor_physical_pages.size(),
+        MM.user_physical_pages_used(),
+        MM.user_physical_pages() - MM.user_physical_pages_used(),
+        MM.super_physical_pages_used(),
+        MM.super_physical_pages() - MM.super_physical_pages_used(),
         g_kmalloc_call_count,
         g_kfree_call_count);
     return builder.to_byte_buffer();

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -545,7 +545,7 @@ ByteBuffer procfs$memstat(InodeIdentifier)
         sum_alloc,
         sum_free,
         MM.user_physical_pages_in_existence() - MM.m_free_physical_pages.size(),
-        MM.m_free_physical_pages.size(),
+        MM.user_physical_pages_not_yet_used() + MM.m_free_physical_pages.size(),
         MM.super_physical_pages_in_existence() - MM.m_free_supervisor_physical_pages.size(),
         MM.m_free_supervisor_physical_pages.size(),
         g_kmalloc_call_count,

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -604,7 +604,7 @@ struct SysVariableData final : public ProcFSInodeCustomData {
         Boolean,
         String,
     };
-    Type type { Invalid };
+    Type type{ Invalid };
     Function<void()> notify_callback;
     void* address;
 };
@@ -842,7 +842,7 @@ ssize_t ProcFSInode::read_bytes(off_t offset, ssize_t count, byte* buffer, FileD
     auto* directory_entry = fs().get_directory_entry(identifier());
 
     Function<ByteBuffer(InodeIdentifier)> callback_tmp;
-    Function<ByteBuffer(InodeIdentifier)>* read_callback { nullptr };
+    Function<ByteBuffer(InodeIdentifier)>* read_callback{ nullptr };
     if (directory_entry) {
         read_callback = &directory_entry->read_callback;
     } else {

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -18,6 +18,7 @@ KERNEL_OBJS = \
        VM/VMObject.o \
        VM/PageDirectory.o \
        VM/PhysicalPage.o \
+       VM/PhysicalRegion.o \
        VM/RangeAllocator.o \
        Console.o \
        IRQHandler.o \

--- a/Kernel/PhysicalAddress.h
+++ b/Kernel/PhysicalAddress.h
@@ -21,7 +21,11 @@ public:
     dword page_base() const { return m_address & 0xfffff000; }
 
     bool operator==(const PhysicalAddress& other) const { return m_address == other.m_address; }
+    bool operator>(const PhysicalAddress& other) const { return m_address > other.m_address; }
+    bool operator>=(const PhysicalAddress& other) const { return m_address >= other.m_address; }
+    bool operator<(const PhysicalAddress& other) const { return m_address < other.m_address; }
+    bool operator<=(const PhysicalAddress& other) const { return m_address <= other.m_address; }
 
 private:
-    dword m_address { 0 };
+    dword m_address{ 0 };
 };

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -446,9 +446,9 @@ RetainPtr<PhysicalPage> MemoryManager::allocate_physical_page(ShouldZeroFill sho
     InterruptDisabler disabler;
 
     if (m_free_physical_pages.is_empty()) {
-        for (auto region : m_physical_regions) {
+        for (auto& region : m_physical_regions) {
             if (!region->is_empty()) {
-                m_free_physical_pages.append(PhysicalPage::create_eternal(region->next(), false));
+                m_free_physical_pages.append(PhysicalPage::create_eternal(region->take_next_page(), false));
             }
         }
     }

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -12,9 +12,6 @@
 //#define PAGE_FAULT_DEBUG
 
 static MemoryManager* s_the;
-unsigned MemoryManager::s_user_physical_pages_in_existence;
-unsigned MemoryManager::s_user_physical_pages_not_yet_used;
-unsigned MemoryManager::s_super_physical_pages_in_existence;
 
 MemoryManager& MM
 {
@@ -79,6 +76,11 @@ void MemoryManager::initialize_paging()
     // 5 MB   -> 0xc0000000     Userspace physical pages (available for allocation!)
     // 0xc0000000-0xffffffff    Kernel-only linear address space
 
+#ifdef MM_DEBUG
+    dbgprintf("MM: Quickmap will use %p\n", m_quickmap_addr.get());
+#endif
+    m_quickmap_addr = VirtualAddress((1 * MB) - PAGE_SIZE);
+
     for (auto* mmap = (multiboot_memory_map_t*)multiboot_info_ptr->mmap_addr; (unsigned long)mmap < multiboot_info_ptr->mmap_addr + multiboot_info_ptr->mmap_length; mmap = (multiboot_memory_map_t*)((unsigned long)mmap + mmap->size + sizeof(mmap->size))) {
         kprintf("MM: Multiboot mmap: base_addr = 0x%x%08x, length = 0x%x%08x, type = 0x%x\n",
             (dword)(mmap->addr >> 32),
@@ -89,21 +91,82 @@ void MemoryManager::initialize_paging()
 
         if (mmap->type != MULTIBOOT_MEMORY_AVAILABLE)
             continue;
+
         // FIXME: Maybe make use of stuff below the 1MB mark?
         if (mmap->addr < (1 * MB))
             continue;
 
+#ifdef MM_DEBUG
+        kprintf("MM: considering memory at %p - %p\n",
+            (dword)mmap->addr, (dword)(mmap->addr + mmap->len));
+#endif
+
+        int in_super = 0, in_user = 0;
         size_t region_lower = 0, region_upper = 0;
 
         for (size_t page_base = mmap->addr; page_base < (mmap->addr + mmap->len); page_base += PAGE_SIZE) {
-            if (page_base < (4 * MB)) {
-                // Skip over pages managed by kmalloc.
-                continue;
-            }
+            if (page_base < 4 * MB) {
+                // nothing
+            } else if (page_base >= 4 * MB && page_base < 5 * MB) {
+                if (in_user) {
+#ifdef MM_DEBUG
+                    kprintf("MM: using %p - %p (%u pages; %uKB) for user\n",
+                        region_lower, region_upper,
+                        (region_upper - region_lower) / PAGE_SIZE,
+                        (region_upper - region_lower) / 1024);
+#endif
 
-            if (page_base < (5 * MB)) {
-                m_free_supervisor_physical_pages.append(PhysicalPage::create_eternal(PhysicalAddress(page_base), true));
+                    auto region = PhysicalRegion::create(
+                        PhysicalAddress(region_lower),
+                        PhysicalAddress(region_upper));
+
+                    m_user_physical_pages += region->size();
+                    m_user_physical_regions.append(region);
+
+                    in_user = 0;
+
+                    region_lower = 0;
+                    region_upper = 0;
+                }
+
+                if (!in_super) {
+                    kprintf("MM: entered super region @ %p\n", page_base);
+                    in_super = 1;
+                    in_user = 0;
+                }
+
+                if (page_base < region_lower || region_lower == 0)
+                    region_lower = page_base;
+                if (page_base > region_upper)
+                    region_upper = page_base;
             } else {
+                if (in_super) {
+#ifdef MM_DEBUG
+                    kprintf("MM: using %p - %p (%u pages; %uKB) for supervisor\n",
+                        region_lower, region_upper,
+                        (region_upper - region_lower) / PAGE_SIZE,
+                        (region_upper - region_lower) / 1024);
+#endif
+
+                    auto region = PhysicalRegion::create(
+                        PhysicalAddress(region_lower),
+                        PhysicalAddress(region_upper));
+
+                    m_super_physical_pages += region->size();
+                    m_super_physical_regions.append(region);
+
+                    in_super = 1;
+
+                    region_lower = 0;
+                    region_upper = 0;
+                }
+
+                if (!in_user) {
+                    kprintf("MM: entered user region @ %p\n", page_base);
+                    in_user = 1;
+                    in_super = 0;
+                }
+
                 if (page_base < region_lower || region_lower == 0)
                     region_lower = page_base;
                 if (page_base > region_upper)
@@ -111,14 +174,50 @@ void MemoryManager::initialize_paging()
             }
         }
 
-        if (region_lower != 0 && region_upper != 0) {
-            m_physical_regions.append(PhysicalRegion::create(PhysicalAddress(region_lower), PhysicalAddress(region_upper)));
+        if (in_user && region_lower != region_upper) {
+#ifdef MM_DEBUG
+            kprintf("MM: using remaining %p - %p (%u pages; %uKB) for user\n",
+                region_lower, region_upper,
+                (region_upper - region_lower) / PAGE_SIZE,
+                (region_upper - region_lower) / 1024);
+#endif
+
+            auto region = PhysicalRegion::create(
+                PhysicalAddress(region_lower),
+                PhysicalAddress(region_upper));
+
+            m_user_physical_pages += region->size();
+            m_user_physical_regions.append(region);
+
+            in_user = 0;
+
+            region_lower = 0;
+            region_upper = 0;
+        }
+
+        if (in_super && region_lower != region_upper) {
+#ifdef MM_DEBUG
+            kprintf("MM: using remaining %p - %p (%u pages; %uKB) for supervisor\n",
+                region_lower, region_upper,
+                (region_upper - region_lower) / PAGE_SIZE,
+                (region_upper - region_lower) / 1024);
+#endif
+
+            auto region = PhysicalRegion::create(
+                PhysicalAddress(region_lower),
+                PhysicalAddress(region_upper));
+
+            m_super_physical_pages += region->size();
+            m_super_physical_regions.append(region);
+
+            in_super = 1;
+
+            region_lower = 0;
+            region_upper = 0;
         }
     }
 
-    m_quickmap_addr = VirtualAddress((1 * MB) - PAGE_SIZE);
 #ifdef MM_DEBUG
-    dbgprintf("MM: Quickmap will use P%x\n", m_quickmap_addr.get());
     dbgprintf("MM: Installing page directory\n");
 #endif
 
@@ -293,7 +392,7 @@ bool MemoryManager::zero_page(Region& region, unsigned page_index_in_region)
         remap_region_page(region, page_index_in_region, true);
         return true;
     }
-    auto physical_page = allocate_physical_page(ShouldZeroFill::Yes);
+    auto physical_page = allocate_user_physical_page(ShouldZeroFill::Yes);
 #ifdef PAGE_FAULT_DEBUG
     dbgprintf("      >> ZERO P%x\n", physical_page->paddr().get());
 #endif
@@ -320,7 +419,7 @@ bool MemoryManager::copy_on_write(Region& region, unsigned page_index_in_region)
     dbgprintf("    >> It's a COW page and it's time to COW!\n");
 #endif
     auto physical_page_to_copy = move(vmo.physical_pages()[page_index_in_region]);
-    auto physical_page = allocate_physical_page(ShouldZeroFill::No);
+    auto physical_page = allocate_user_physical_page(ShouldZeroFill::No);
     byte* dest_ptr = quickmap_page(*physical_page);
     const byte* src_ptr = region.vaddr().offset(page_index_in_region * PAGE_SIZE).as_ptr();
 #ifdef PAGE_FAULT_DEBUG
@@ -371,7 +470,7 @@ bool MemoryManager::page_in_from_inode(Region& region, unsigned page_index_in_re
         memset(page_buffer + nread, 0, PAGE_SIZE - nread);
     }
     cli();
-    vmo_page = allocate_physical_page(ShouldZeroFill::No);
+    vmo_page = allocate_user_physical_page(ShouldZeroFill::No);
     if (vmo_page.is_null()) {
         kprintf("MM: page_in_from_inode was unable to allocate a physical page\n");
         return false;
@@ -441,51 +540,118 @@ RetainPtr<Region> MemoryManager::allocate_kernel_region(size_t size, String&& na
     return region;
 }
 
-RetainPtr<PhysicalPage> MemoryManager::allocate_physical_page(ShouldZeroFill should_zero_fill)
+void MemoryManager::deallocate_user_physical_page(PhysicalPage& page)
+{
+    for (auto& region : m_user_physical_regions) {
+        if (!region->owns_page(page)) {
+            kprintf(
+                "MM: deallocate_user_physical_page: %p not in %p -> %p\n",
+                page.paddr(), region->lower().get(), region->upper().get());
+            continue;
+        }
+
+        region->return_page(page);
+        m_user_physical_pages_used--;
+
+        return;
+    }
+
+    kprintf("MM: deallocate_user_physical_page couldn't figure out region for user page @ %p\n", page.paddr());
+    ASSERT_NOT_REACHED();
+}
+
+RetainPtr<PhysicalPage> MemoryManager::allocate_user_physical_page(ShouldZeroFill should_zero_fill)
 {
     InterruptDisabler disabler;
 
-    if (m_free_physical_pages.is_empty()) {
-        for (auto& region : m_physical_regions) {
-            if (!region->is_empty()) {
-                m_free_physical_pages.append(PhysicalPage::create_eternal(region->take_next_page(), false));
-            }
-        }
+    RetainPtr<PhysicalPage> page = nullptr;
+
+    for (auto& region : m_user_physical_regions) {
+        auto addr = region->take_free_page();
+        if (addr.is_null())
+            continue;
+
+        page = PhysicalPage::create_eternal(addr, false);
     }
 
-    if (m_free_physical_pages.is_empty()) {
-        kprintf("MM: no physical pages available even after attempting to fetch a new one\n");
+    if (!page) {
+        if (m_user_physical_regions.is_empty()) {
+            kprintf("MM: no user physical regions available (?)\n");
+        }
+
+        kprintf("MM: no user physical pages available\n");
         ASSERT_NOT_REACHED();
         return {};
     }
 
 #ifdef MM_DEBUG
-    dbgprintf("MM: allocate_physical_page vending P%x (%u remaining)\n", m_free_physical_pages.last()->paddr().get(), m_free_physical_pages.size());
+    dbgprintf("MM: allocate_user_physical_page vending P%p\n", page->paddr().get());
 #endif
 
-    auto physical_page = m_free_physical_pages.take_last();
     if (should_zero_fill == ShouldZeroFill::Yes) {
-        auto* ptr = (dword*)quickmap_page(*physical_page);
+        auto* ptr = (dword*)quickmap_page(*page);
         fast_dword_fill(ptr, 0, PAGE_SIZE / sizeof(dword));
         unquickmap_page();
     }
-    return physical_page;
+
+    m_user_physical_pages_used++;
+
+    return page;
+}
+
+void MemoryManager::deallocate_supervisor_physical_page(PhysicalPage& page)
+{
+    for (auto& region : m_super_physical_regions) {
+        if (!region->owns_page(page)) {
+            kprintf(
+                "MM: deallocate_supervisor_physical_page: %p not in %p -> %p\n",
+                page.paddr(), region->lower().get(), region->upper().get());
+            continue;
+        }
+
+        region->return_page(page);
+        m_super_physical_pages_used--;
+
+        return;
+    }
+
+    kprintf("MM: deallocate_supervisor_physical_page couldn't figure out region for super page @ %p\n", page.paddr());
+    ASSERT_NOT_REACHED();
 }
 
 RetainPtr<PhysicalPage> MemoryManager::allocate_supervisor_physical_page()
 {
     InterruptDisabler disabler;
-    if (1 > m_free_supervisor_physical_pages.size()) {
-        kprintf("FUCK! No physical pages available.\n");
+
+    RetainPtr<PhysicalPage> page = nullptr;
+
+    for (auto& region : m_super_physical_regions) {
+        auto addr = region->take_free_page();
+        if (addr.is_null())
+            continue;
+
+        page = PhysicalPage::create_eternal(addr, true);
+    }
+
+    if (!page) {
+        if (m_super_physical_regions.is_empty()) {
+            kprintf("MM: no super physical regions available (?)\n");
+        }
+
+        kprintf("MM: no super physical pages available\n");
         ASSERT_NOT_REACHED();
         return {};
     }
+
 #ifdef MM_DEBUG
-    dbgprintf("MM: allocate_supervisor_physical_page vending P%x (%u remaining)\n", m_free_supervisor_physical_pages.last()->paddr().get(), m_free_supervisor_physical_pages.size());
+    dbgprintf("MM: allocate_supervisor_physical_page vending P%p\n", page->paddr().get());
 #endif
-    auto physical_page = m_free_supervisor_physical_pages.take_last();
-    fast_dword_fill((dword*)physical_page->paddr().as_ptr(), 0, PAGE_SIZE / sizeof(dword));
-    return physical_page;
+
+    fast_dword_fill((dword*)page->paddr().as_ptr(), 0, PAGE_SIZE / sizeof(dword));
+
+    m_super_physical_pages_used++;
+
+    return page;
 }
 
 void MemoryManager::enter_process_paging_scope(Process& process)

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -13,6 +13,7 @@
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/FileSystem/InodeIdentifier.h>
 #include <Kernel/VM/PhysicalPage.h>
+#include <Kernel/VM/PhysicalRegion.h>
 #include <Kernel/VM/Region.h>
 #include <Kernel/VM/VMObject.h>
 #include <Kernel/VirtualAddress.h>
@@ -32,6 +33,7 @@ class MemoryManager {
     AK_MAKE_ETERNAL
     friend class PageDirectory;
     friend class PhysicalPage;
+    friend class PhysicalRegion;
     friend class Region;
     friend class VMObject;
     friend ByteBuffer procfs$mm(InodeIdentifier);
@@ -65,6 +67,7 @@ public:
     void remap_region(PageDirectory&, Region&);
 
     int user_physical_pages_in_existence() const { return s_user_physical_pages_in_existence; }
+    int user_physical_pages_not_yet_used() const { return s_user_physical_pages_not_yet_used; }
     int super_physical_pages_in_existence() const { return s_super_physical_pages_in_existence; }
 
     void map_for_kernel(VirtualAddress, PhysicalAddress);
@@ -207,6 +210,7 @@ private:
     };
 
     static unsigned s_user_physical_pages_in_existence;
+    static unsigned s_user_physical_pages_not_yet_used;
     static unsigned s_super_physical_pages_in_existence;
 
     PageTableEntry ensure_pte(PageDirectory&, VirtualAddress);
@@ -217,6 +221,7 @@ private:
 
     VirtualAddress m_quickmap_addr;
 
+    Vector<Retained<PhysicalRegion>> m_physical_regions;
     Vector<Retained<PhysicalPage>> m_free_physical_pages;
     Vector<Retained<PhysicalPage>> m_free_supervisor_physical_pages;
 

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -61,19 +61,22 @@ public:
         Yes
     };
 
-    RetainPtr<PhysicalPage> allocate_physical_page(ShouldZeroFill);
+    RetainPtr<PhysicalPage> allocate_user_physical_page(ShouldZeroFill);
     RetainPtr<PhysicalPage> allocate_supervisor_physical_page();
+    void deallocate_user_physical_page(PhysicalPage&);
+    void deallocate_supervisor_physical_page(PhysicalPage&);
 
     void remap_region(PageDirectory&, Region&);
-
-    int user_physical_pages_in_existence() const { return s_user_physical_pages_in_existence; }
-    int user_physical_pages_not_yet_used() const { return s_user_physical_pages_not_yet_used; }
-    int super_physical_pages_in_existence() const { return s_super_physical_pages_in_existence; }
 
     void map_for_kernel(VirtualAddress, PhysicalAddress);
 
     RetainPtr<Region> allocate_kernel_region(size_t, String&& name);
     void map_region_at_address(PageDirectory&, Region&, VirtualAddress, bool user_accessible);
+
+    unsigned user_physical_pages() const { return m_user_physical_pages; }
+    unsigned user_physical_pages_used() const { return m_user_physical_pages_used; }
+    unsigned super_physical_pages() const { return m_super_physical_pages; }
+    unsigned super_physical_pages_used() const { return m_super_physical_pages_used; }
 
 private:
     MemoryManager();
@@ -209,10 +212,6 @@ private:
         dword* m_pte;
     };
 
-    static unsigned s_user_physical_pages_in_existence;
-    static unsigned s_user_physical_pages_not_yet_used;
-    static unsigned s_super_physical_pages_in_existence;
-
     PageTableEntry ensure_pte(PageDirectory&, VirtualAddress);
 
     RetainPtr<PageDirectory> m_kernel_page_directory;
@@ -221,9 +220,13 @@ private:
 
     VirtualAddress m_quickmap_addr;
 
-    Vector<Retained<PhysicalRegion>> m_physical_regions;
-    Vector<Retained<PhysicalPage>> m_free_physical_pages;
-    Vector<Retained<PhysicalPage>> m_free_supervisor_physical_pages;
+    unsigned m_user_physical_pages{ 0 };
+    unsigned m_user_physical_pages_used{ 0 };
+    unsigned m_super_physical_pages{ 0 };
+    unsigned m_super_physical_pages_used{ 0 };
+
+    Vector<Retained<PhysicalRegion>> m_user_physical_regions;
+    Vector<Retained<PhysicalRegion>> m_super_physical_regions;
 
     HashTable<VMObject*> m_vmos;
     HashTable<Region*> m_user_regions;

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -216,8 +216,8 @@ private:
     PageTableEntry ensure_pte(PageDirectory&, VirtualAddress);
 
     RetainPtr<PageDirectory> m_kernel_page_directory;
-    dword* m_page_table_zero { nullptr };
-    dword* m_page_table_one { nullptr };
+    dword* m_page_table_zero{ nullptr };
+    dword* m_page_table_one{ nullptr };
 
     VirtualAddress m_quickmap_addr;
 
@@ -229,7 +229,7 @@ private:
     HashTable<Region*> m_user_regions;
     HashTable<Region*> m_kernel_regions;
 
-    bool m_quickmap_in_use { false };
+    bool m_quickmap_in_use{ false };
 };
 
 struct ProcessPagingScope {

--- a/Kernel/VM/PhysicalPage.cpp
+++ b/Kernel/VM/PhysicalPage.cpp
@@ -21,21 +21,21 @@ PhysicalPage::PhysicalPage(PhysicalAddress paddr, bool supervisor, bool may_retu
     , m_supervisor(supervisor)
     , m_paddr(paddr)
 {
-    if (supervisor)
-        ++MemoryManager::s_super_physical_pages_in_existence;
-    else
-        ++MemoryManager::s_user_physical_pages_in_existence;
 }
 
 void PhysicalPage::return_to_freelist()
 {
     ASSERT((paddr().get() & ~PAGE_MASK) == 0);
+
     InterruptDisabler disabler;
+
     m_retain_count = 1;
+
     if (m_supervisor)
-        MM.m_free_supervisor_physical_pages.append(adopt(*this));
+        MM.deallocate_supervisor_physical_page(*this);
     else
-        MM.m_free_physical_pages.append(adopt(*this));
+        MM.deallocate_user_physical_page(*this);
+
 #ifdef MM_DEBUG
     dbgprintf("MM: P%x released to freelist\n", m_paddr.get());
 #endif

--- a/Kernel/VM/PhysicalPage.h
+++ b/Kernel/VM/PhysicalPage.h
@@ -40,8 +40,8 @@ private:
 
     void return_to_freelist();
 
-    word m_retain_count { 1 };
-    bool m_may_return_to_freelist { true };
-    bool m_supervisor { false };
+    word m_retain_count{ 1 };
+    bool m_may_return_to_freelist{ true };
+    bool m_supervisor{ false };
     PhysicalAddress m_paddr;
 };

--- a/Kernel/VM/PhysicalRegion.cpp
+++ b/Kernel/VM/PhysicalRegion.cpp
@@ -1,0 +1,26 @@
+#include <AK/Retained.h>
+#include <Kernel/Assertions.h>
+#include <Kernel/VM/MemoryManager.h>
+#include <Kernel/VM/PhysicalRegion.h>
+
+Retained<PhysicalRegion> PhysicalRegion::create(PhysicalAddress lower, PhysicalAddress upper)
+{
+    return adopt(*new PhysicalRegion(lower, upper));
+}
+
+PhysicalRegion::PhysicalRegion(PhysicalAddress lower, PhysicalAddress upper)
+    : m_lower(lower), m_upper(upper), m_next(lower)
+{
+    MemoryManager::s_user_physical_pages_not_yet_used += size();
+}
+
+PhysicalAddress PhysicalRegion::next()
+{
+    ASSERT(!(m_next == m_upper));
+
+    --MemoryManager::s_user_physical_pages_not_yet_used;
+
+    auto addr = m_next;
+    m_next.set(m_next.get() + PAGE_SIZE);
+    return addr;
+}

--- a/Kernel/VM/PhysicalRegion.cpp
+++ b/Kernel/VM/PhysicalRegion.cpp
@@ -9,7 +9,9 @@ Retained<PhysicalRegion> PhysicalRegion::create(PhysicalAddress lower, PhysicalA
 }
 
 PhysicalRegion::PhysicalRegion(PhysicalAddress lower, PhysicalAddress upper)
-    : m_lower(lower), m_upper(upper), m_next(lower)
+    : m_lower(lower)
+    , m_upper(upper)
+    , m_next(lower)
 {
     MemoryManager::s_user_physical_pages_not_yet_used += size();
 }

--- a/Kernel/VM/PhysicalRegion.cpp
+++ b/Kernel/VM/PhysicalRegion.cpp
@@ -14,7 +14,7 @@ PhysicalRegion::PhysicalRegion(PhysicalAddress lower, PhysicalAddress upper)
     MemoryManager::s_user_physical_pages_not_yet_used += size();
 }
 
-PhysicalAddress PhysicalRegion::next()
+PhysicalAddress PhysicalRegion::take_next_page()
 {
     ASSERT(!(m_next == m_upper));
 

--- a/Kernel/VM/PhysicalRegion.h
+++ b/Kernel/VM/PhysicalRegion.h
@@ -14,10 +14,10 @@ public:
     static Retained<PhysicalRegion> create(PhysicalAddress lower, PhysicalAddress upper);
     ~PhysicalRegion() {}
 
-    bool is_empty() { return m_next == m_upper; }
-    int size() { return (m_upper.get() - m_next.get()) / PAGE_SIZE; }
+    bool is_empty() const { return m_next == m_upper; }
+    int size() const { return (m_upper.get() - m_next.get()) / PAGE_SIZE; }
 
-    PhysicalAddress next();
+    PhysicalAddress take_next_page();
 
 private:
     PhysicalRegion(PhysicalAddress lower, PhysicalAddress upper);

--- a/Kernel/VM/PhysicalRegion.h
+++ b/Kernel/VM/PhysicalRegion.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <AK/Retained.h>
+#include <Kernel/Assertions.h>
+#include <Kernel/PhysicalAddress.h>
+#include <Kernel/VM/PhysicalPage.h>
+
+class PhysicalRegion : public Retainable<PhysicalRegion> {
+    AK_MAKE_ETERNAL
+
+    friend class MemoryManager;
+
+public:
+    static Retained<PhysicalRegion> create(PhysicalAddress lower, PhysicalAddress upper);
+    ~PhysicalRegion() {}
+
+    bool is_empty() { return m_next == m_upper; }
+    int size() { return (m_upper.get() - m_next.get()) / PAGE_SIZE; }
+
+    PhysicalAddress next();
+
+private:
+    PhysicalRegion(PhysicalAddress lower, PhysicalAddress upper);
+
+    PhysicalAddress m_lower;
+    PhysicalAddress m_upper;
+    PhysicalAddress m_next;
+};

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -103,7 +103,7 @@ int Region::commit()
     for (size_t i = first_page_index(); i <= last_page_index(); ++i) {
         if (!vmo().physical_pages()[i].is_null())
             continue;
-        auto physical_page = MM.allocate_physical_page(MemoryManager::ShouldZeroFill::Yes);
+        auto physical_page = MM.allocate_user_physical_page(MemoryManager::ShouldZeroFill::Yes);
         if (!physical_page) {
             kprintf("MM: commit was unable to allocate a physical page\n");
             return -ENOMEM;

--- a/Kernel/build-image-disk.sh
+++ b/Kernel/build-image-disk.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+die() {
+    echo "die: $@"
+    exit 1
+}
+
+if [ $(id -u) != 0 ]; then
+    die "this script needs to run as root"
+fi
+
+if [ -z $BOOT_DEVICE ]; then
+    die "must define BOOT_DEVICE"
+fi
+
+if [ -z $ROOT_DEVICE ]; then
+    die "must define ROOT_DEVICE"
+fi
+
+cleanup() {
+    if [ -d mnt ]; then
+        if [ -d mnt/boot ]; then
+            echo -n "unmounting boot filesystem... "
+            umount mnt/boot || ( sleep 1 && sync && umount mnt/boot ) || die "couldn't unmount boot filesystem"
+            echo "done"
+        fi
+
+        echo -n "unmounting root filesystem... "
+        umount mnt || ( sleep 1 && sync && umount mnt ) || die "couldn't unmount root filesystem"
+        rm -rf mnt
+        echo "done"
+    fi
+}
+trap cleanup EXIT
+
+echo -n "destroying old filesystem... "
+dd if=/dev/zero of=${ROOT_DEVICE} bs=1M count=1 status=none || die "couldn't destroy old filesystem"
+echo "done"
+
+echo -n "creating new filesystem... "
+mke2fs -q -I 128 ${ROOT_DEVICE} || die "couldn't create filesystem"
+echo "done"
+
+echo -n "mounting root filesystem... "
+mkdir -p mnt
+mount ${ROOT_DEVICE} mnt || die "couldn't mount root filesystem"
+echo "done"
+
+echo -n "mounting boot filesystem... "
+mkdir -p mnt/boot
+mount ${BOOT_DEVICE} mnt/boot || die "couldn't mount boot filesystem"
+echo "done"
+
+./build-root-filesystem.sh
+
+echo -n "installing kernel in /boot... "
+cp kernel mnt/boot/serenity
+echo "done"

--- a/Kernel/run
+++ b/Kernel/run
@@ -5,14 +5,13 @@
 SERENITY_KERNEL_CMDLINE="hello"
 
 export SDL_VIDEO_X11_DGAMOUSE=0
-ram_size=128
 
 if [ "$1" = "b" ]; then
     # ./run b: bochs
     bochs -q -f .bochsrc
 elif [ "$1" = "qn" ]; then
     # ./run qn: qemu without network
-    $SERENITY_QEMU_BIN -s -m $ram_size \
+    $SERENITY_QEMU_BIN -s -m ${SERENITY_RAM_SIZE:-128} \
         $SERENITY_EXTRA_QEMU_ARGS \
         -d cpu_reset,guest_errors \
         -device VGA,vgamem_mb=64 \
@@ -23,7 +22,7 @@ elif [ "$1" = "qn" ]; then
         -soundhw pcspk
 elif [ "$1" = "qtap" ]; then
     # ./run qtap: qemu with tap
-    sudo $SERENITY_QEMU_BIN -s -m $ram_size \
+    sudo $SERENITY_QEMU_BIN -s -m ${SERENITY_RAM_SIZE:-128} \
         $SERENITY_EXTRA_QEMU_ARGS \
         -d cpu_reset,guest_errors \
         -device VGA,vgamem_mb=64 \
@@ -36,7 +35,7 @@ elif [ "$1" = "qtap" ]; then
         -soundhw pcspk
 elif [ "$1" = "qgrub" ]; then
     # ./run qgrub: qemu with grub
-    $SERENITY_QEMU_BIN -s -m $ram_size \
+    $SERENITY_QEMU_BIN -s -m ${SERENITY_RAM_SIZE:-128} \
         $SERENITY_EXTRA_QEMU_ARGS \
         -d cpu_reset,guest_errors \
         -device VGA,vgamem_mb=64 \
@@ -48,7 +47,7 @@ elif [ "$1" = "qgrub" ]; then
         -soundhw pcspk
 else
     # ./run: qemu with user networking
-    $SERENITY_QEMU_BIN -s -m $ram_size \
+    $SERENITY_QEMU_BIN -s -m ${SERENITY_RAM_SIZE:-128} \
         $SERENITY_EXTRA_QEMU_ARGS \
         -d cpu_reset,guest_errors \
         -device VGA,vgamem_mb=64 \

--- a/Userland/allocate.cpp
+++ b/Userland/allocate.cpp
@@ -8,7 +8,9 @@ void usage(void)
     exit(1);
 }
 
-enum Unit { Bytes, KiloBytes, MegaBytes };
+enum Unit { Bytes,
+    KiloBytes,
+    MegaBytes };
 
 int main(int argc, char** argv)
 {
@@ -35,9 +37,14 @@ int main(int argc, char** argv)
     }
 
     switch (unit) {
-    case Bytes: break;
-    case KiloBytes: count *= 1024; break;
-    case MegaBytes: count *= 1024 * 1024; break;
+    case Bytes:
+        break;
+    case KiloBytes:
+        count *= 1024;
+        break;
+    case MegaBytes:
+        count *= 1024 * 1024;
+        break;
     }
 
     printf("allocating memory (%d bytes)...\n", count);

--- a/Userland/allocate.cpp
+++ b/Userland/allocate.cpp
@@ -1,0 +1,69 @@
+#include <AK/AKString.h>
+#include <stdio.h>
+#include <unistd.h>
+
+void usage(void)
+{
+    printf("usage: allocate [number [unit (B/KB/MB)]]\n");
+    exit(1);
+}
+
+enum Unit { Bytes, KiloBytes, MegaBytes };
+
+int main(int argc, char** argv)
+{
+    unsigned count = 50;
+    Unit unit = MegaBytes;
+
+    if (argc >= 2) {
+        bool ok;
+        count = String(argv[1]).to_uint(ok);
+        if (!ok) {
+            usage();
+        }
+    }
+
+    if (argc >= 3) {
+        if (strcmp(argv[2], "B") == 0)
+            unit = Bytes;
+        else if (strcmp(argv[2], "KB") == 0)
+            unit = KiloBytes;
+        else if (strcmp(argv[2], "MB") == 0)
+            unit = MegaBytes;
+        else
+            usage();
+    }
+
+    switch (unit) {
+    case Bytes: break;
+    case KiloBytes: count *= 1024; break;
+    case MegaBytes: count *= 1024 * 1024; break;
+    }
+
+    printf("allocating memory (%d bytes)...\n", count);
+    char* ptr = (char*)malloc(count);
+    if (!ptr) {
+        printf("failed.\n");
+        return 1;
+    }
+    printf("done.\n");
+
+    printf("writing to allocated memory...\n");
+    for (int i = 0; i < count; i++) {
+        ptr[i] = i % 255;
+    }
+    printf("done.\n");
+
+    printf("sleeping for ten seconds...");
+    for (int i = 0; i < 10; i++) {
+        printf("%d\n", i);
+        sleep(1);
+    }
+    printf("done.\n");
+
+    printf("freeing memory...\n");
+    free(ptr);
+    printf("done.\n");
+
+    return 0;
+}

--- a/Userland/allocate.cpp
+++ b/Userland/allocate.cpp
@@ -55,9 +55,9 @@ int main(int argc, char** argv)
     }
     printf("done.\n");
 
-    printf("writing to allocated memory...\n");
-    for (int i = 0; i < count; i++) {
-        ptr[i] = i % 255;
+    printf("writing one byte to each page of allocated memory...\n");
+    for (int i = 0; i < count; i += 4096) {
+        ptr[i] = 1;
     }
     printf("done.\n");
 


### PR DESCRIPTION
This avoids the need to fill the m_free_physical_pages vector in the
MemoryManager at startup, which allows us to boot with much more memory
available. Previously at above about 250MB, the free page list would
outgrow the kernel's heap. Now that doesn't happen quite so often. It can
still happen if you allocate a lot of memory, then free it - as that will
also fill the free page list up. There's a test program included,
creatively named "allocate," which you can use to test this condition.