### PR TITLE
 Kernel: Refactor MemoryManager to use a Bitmap rather than a Vector

### DIFF
--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -387,8 +387,8 @@ ByteBuffer procfs$mm(InodeIdentifier)
             vmo->name().characters());
     }
     builder.appendf("VMO count: %u\n", MM.m_vmos.size());
-    builder.appendf("Free physical pages: %u\n", MM.m_free_physical_pages.size());
-    builder.appendf("Free supervisor physical pages: %u\n", MM.m_free_supervisor_physical_pages.size());
+    builder.appendf("Free physical pages: %u\n", MM.user_physical_pages() - MM.user_physical_pages_used());
+    builder.appendf("Free supervisor physical pages: %u\n", MM.super_physical_pages() - MM.super_physical_pages_used());
     return builder.to_byte_buffer();
 }
 
@@ -544,10 +544,10 @@ ByteBuffer procfs$memstat(InodeIdentifier)
         kmalloc_sum_eternal,
         sum_alloc,
         sum_free,
-        MM.user_physical_pages_in_existence() - MM.m_free_physical_pages.size(),
-        MM.m_free_physical_pages.size(),
-        MM.super_physical_pages_in_existence() - MM.m_free_supervisor_physical_pages.size(),
-        MM.m_free_supervisor_physical_pages.size(),
+        MM.user_physical_pages_used(),
+        MM.user_physical_pages() - MM.user_physical_pages_used(),
+        MM.super_physical_pages_used(),
+        MM.super_physical_pages() - MM.super_physical_pages_used(),
         g_kmalloc_call_count,
         g_kfree_call_count);
     return builder.to_byte_buffer();

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -18,6 +18,7 @@ KERNEL_OBJS = \
        VM/VMObject.o \
        VM/PageDirectory.o \
        VM/PhysicalPage.o \
+       VM/PhysicalRegion.o \
        VM/RangeAllocator.o \
        Console.o \
        IRQHandler.o \

--- a/Kernel/PhysicalAddress.h
+++ b/Kernel/PhysicalAddress.h
@@ -21,6 +21,11 @@ public:
     dword page_base() const { return m_address & 0xfffff000; }
 
     bool operator==(const PhysicalAddress& other) const { return m_address == other.m_address; }
+    bool operator!=(const PhysicalAddress& other) const { return m_address != other.m_address; }
+    bool operator>(const PhysicalAddress& other) const { return m_address > other.m_address; }
+    bool operator>=(const PhysicalAddress& other) const { return m_address >= other.m_address; }
+    bool operator<(const PhysicalAddress& other) const { return m_address < other.m_address; }
+    bool operator<=(const PhysicalAddress& other) const { return m_address <= other.m_address; }
 
 private:
     dword m_address { 0 };

--- a/Kernel/VM/PhysicalPage.cpp
+++ b/Kernel/VM/PhysicalPage.cpp
@@ -21,21 +21,21 @@ PhysicalPage::PhysicalPage(PhysicalAddress paddr, bool supervisor, bool may_retu
     , m_supervisor(supervisor)
     , m_paddr(paddr)
 {
-    if (supervisor)
-        ++MemoryManager::s_super_physical_pages_in_existence;
-    else
-        ++MemoryManager::s_user_physical_pages_in_existence;
 }
 
 void PhysicalPage::return_to_freelist()
 {
     ASSERT((paddr().get() & ~PAGE_MASK) == 0);
+
     InterruptDisabler disabler;
+
     m_retain_count = 1;
+
     if (m_supervisor)
-        MM.m_free_supervisor_physical_pages.append(adopt(*this));
+        MM.deallocate_supervisor_physical_page(*this);
     else
-        MM.m_free_physical_pages.append(adopt(*this));
+        MM.deallocate_user_physical_page(*this);
+
 #ifdef MM_DEBUG
     dbgprintf("MM: P%x released to freelist\n", m_paddr.get());
 #endif

--- a/Kernel/VM/PhysicalRegion.cpp
+++ b/Kernel/VM/PhysicalRegion.cpp
@@ -1,0 +1,77 @@
+#include <AK/Bitmap.h>
+#include <AK/Retained.h>
+#include <AK/RetainPtr.h>
+#include <Kernel/Assertions.h>
+#include <Kernel/PhysicalAddress.h>
+#include <Kernel/VM/PhysicalPage.h>
+#include <Kernel/VM/PhysicalRegion.h>
+
+Retained<PhysicalRegion> PhysicalRegion::create(PhysicalAddress lower, PhysicalAddress upper)
+{
+    return adopt(*new PhysicalRegion(lower, upper));
+}
+
+PhysicalRegion::PhysicalRegion(PhysicalAddress lower, PhysicalAddress upper)
+    : m_lower(lower)
+    , m_upper(upper)
+    , m_bitmap(Bitmap::create())
+{
+}
+
+void PhysicalRegion::expand(PhysicalAddress lower, PhysicalAddress upper)
+{
+    ASSERT(!m_pages);
+
+    m_lower = lower;
+    m_upper = upper;
+}
+
+unsigned PhysicalRegion::finalize_capacity()
+{
+    ASSERT(!m_pages);
+
+    m_pages = (m_upper.get() - m_lower.get()) / PAGE_SIZE;
+    m_bitmap.grow(m_pages, false);
+
+    return size();
+}
+
+RetainPtr<PhysicalPage> PhysicalRegion::take_free_page(bool supervisor)
+{
+    ASSERT(m_pages);
+
+    if (m_used == m_pages)
+        return nullptr;
+
+    for (unsigned page = m_last; page < m_pages; page++) {
+        if (!m_bitmap.get(page)) {
+            m_bitmap.set(page, true);
+            m_used++;
+            m_last = page + 1;
+            return PhysicalPage::create(m_lower.offset(page * PAGE_SIZE), supervisor);
+        }
+    }
+
+    ASSERT_NOT_REACHED();
+
+    return nullptr;
+}
+
+void PhysicalRegion::return_page_at(PhysicalAddress addr)
+{
+    ASSERT(m_pages);
+
+    if (m_used == 0) {
+        ASSERT_NOT_REACHED();
+    }
+
+    int local_offset = addr.get() - m_lower.get();
+    ASSERT(local_offset >= 0);
+    ASSERT(local_offset < m_pages * PAGE_SIZE);
+
+    auto page = local_offset / PAGE_SIZE;
+    if (page < m_last) m_last = page;
+
+    m_bitmap.set(page, false);
+    m_used--;
+}

--- a/Kernel/VM/PhysicalRegion.h
+++ b/Kernel/VM/PhysicalRegion.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <AK/Bitmap.h>
+#include <AK/Retainable.h>
+#include <AK/Retained.h>
+#include <Kernel/PhysicalAddress.h>
+#include <Kernel/VM/PhysicalPage.h>
+
+class PhysicalRegion : public Retainable<PhysicalRegion> {
+    AK_MAKE_ETERNAL
+
+public:
+    static Retained<PhysicalRegion> create(PhysicalAddress lower, PhysicalAddress upper);
+    ~PhysicalRegion() {}
+
+    void expand(PhysicalAddress lower, PhysicalAddress upper);
+    unsigned finalize_capacity();
+
+    PhysicalAddress lower() const { return m_lower; }
+    PhysicalAddress upper() const { return m_upper; }
+    unsigned size() const { return m_pages; }
+    unsigned used() const { return m_used; }
+    unsigned free() const { return m_pages - m_used; }
+    bool contains(PhysicalPage& page) const { return page.paddr() >= m_lower && page.paddr() <= m_upper; }
+
+    RetainPtr<PhysicalPage> take_free_page(bool supervisor);
+    void return_page_at(PhysicalAddress addr);
+    void return_page(PhysicalPage& page) { return_page_at(page.paddr()); }
+
+private:
+    PhysicalRegion(PhysicalAddress lower, PhysicalAddress upper);
+
+    PhysicalAddress m_lower;
+    PhysicalAddress m_upper;
+    unsigned m_pages { 0 };
+    unsigned m_used { 0 };
+    unsigned m_last { 0 };
+    Bitmap m_bitmap;
+};

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -103,7 +103,7 @@ int Region::commit()
     for (size_t i = first_page_index(); i <= last_page_index(); ++i) {
         if (!vmo().physical_pages()[i].is_null())
             continue;
-        auto physical_page = MM.allocate_physical_page(MemoryManager::ShouldZeroFill::Yes);
+        auto physical_page = MM.allocate_user_physical_page(MemoryManager::ShouldZeroFill::Yes);
         if (!physical_page) {
             kprintf("MM: commit was unable to allocate a physical page\n");
             return -ENOMEM;

--- a/Kernel/run
+++ b/Kernel/run
@@ -5,14 +5,13 @@
 SERENITY_KERNEL_CMDLINE="hello"
 
 export SDL_VIDEO_X11_DGAMOUSE=0
-ram_size=128
 
 if [ "$1" = "b" ]; then
     # ./run b: bochs
     bochs -q -f .bochsrc
 elif [ "$1" = "qn" ]; then
     # ./run qn: qemu without network
-    $SERENITY_QEMU_BIN -s -m $ram_size \
+    $SERENITY_QEMU_BIN -s -m ${SERENITY_RAM_SIZE:-128} \
         $SERENITY_EXTRA_QEMU_ARGS \
         -d cpu_reset,guest_errors \
         -device VGA,vgamem_mb=64 \
@@ -23,7 +22,7 @@ elif [ "$1" = "qn" ]; then
         -soundhw pcspk
 elif [ "$1" = "qtap" ]; then
     # ./run qtap: qemu with tap
-    sudo $SERENITY_QEMU_BIN -s -m $ram_size \
+    sudo $SERENITY_QEMU_BIN -s -m ${SERENITY_RAM_SIZE:-128} \
         $SERENITY_EXTRA_QEMU_ARGS \
         -d cpu_reset,guest_errors \
         -device VGA,vgamem_mb=64 \
@@ -36,7 +35,7 @@ elif [ "$1" = "qtap" ]; then
         -soundhw pcspk
 elif [ "$1" = "qgrub" ]; then
     # ./run qgrub: qemu with grub
-    $SERENITY_QEMU_BIN -s -m $ram_size \
+    $SERENITY_QEMU_BIN -s -m ${SERENITY_RAM_SIZE:-128} \
         $SERENITY_EXTRA_QEMU_ARGS \
         -d cpu_reset,guest_errors \
         -device VGA,vgamem_mb=64 \
@@ -48,7 +47,7 @@ elif [ "$1" = "qgrub" ]; then
         -soundhw pcspk
 else
     # ./run: qemu with user networking
-    $SERENITY_QEMU_BIN -s -m $ram_size \
+    $SERENITY_QEMU_BIN -s -m ${SERENITY_RAM_SIZE:-128} \
         $SERENITY_EXTRA_QEMU_ARGS \
         -d cpu_reset,guest_errors \
         -device VGA,vgamem_mb=64 \

--- a/Userland/allocate.cpp
+++ b/Userland/allocate.cpp
@@ -1,0 +1,98 @@
+#include <AK/AKString.h>
+#include <LibCore/CElapsedTimer.h>
+#include <stdio.h>
+#include <unistd.h>
+
+void usage(void)
+{
+    printf("usage: allocate [number [unit (B/KB/MB)]]\n");
+    exit(1);
+}
+
+enum Unit { Bytes, KiloBytes, MegaBytes };
+
+int main(int argc, char** argv)
+{
+    unsigned count = 50;
+    Unit unit = MegaBytes;
+
+    if (argc >= 2) {
+        bool ok;
+        count = String(argv[1]).to_uint(ok);
+        if (!ok) {
+            usage();
+        }
+    }
+
+    if (argc >= 3) {
+        if (strcmp(argv[2], "B") == 0)
+            unit = Bytes;
+        else if (strcmp(argv[2], "KB") == 0)
+            unit = KiloBytes;
+        else if (strcmp(argv[2], "MB") == 0)
+            unit = MegaBytes;
+        else
+            usage();
+    }
+
+    switch (unit) {
+    case Bytes:
+        break;
+    case KiloBytes:
+        count *= 1024;
+        break;
+    case MegaBytes:
+        count *= 1024 * 1024;
+        break;
+    }
+
+    CElapsedTimer timer;
+
+    printf("allocating memory (%d bytes)...\n", count);
+    timer.start();
+    char* ptr = (char*)malloc(count);
+    if (!ptr) {
+        printf("failed.\n");
+        return 1;
+    }
+    printf("done in %dms\n", timer.elapsed());
+
+    auto pages = count / 4096;
+    auto step = pages / 10;
+
+    CElapsedTimer timer2;
+
+    printf("writing one byte to each page of allocated memory...\n");
+    timer.start();
+    timer2.start();
+    for (int i = 0; i < pages; ++i) {
+        ptr[i * 4096] = 1;
+
+        if (i != 0 && (i % step) == 0) {
+            auto ms = timer2.elapsed();
+            if (ms == 0)
+                ms = 1;
+
+            auto bps = double(step * 4096) / (double(ms) / 1000);
+
+            printf("step took %dms (%fMB/s)\n", ms, bps / 1024 / 1024);
+
+            timer2.start();
+        }
+    }
+    printf("done in %dms\n", timer.elapsed());
+
+    printf("sleeping for ten seconds...\n");
+    for (int i = 0; i < 10; i++) {
+        printf("%d\n", i);
+        sleep(1);
+    }
+    printf("done.\n");
+
+    printf("freeing memory...\n");
+    timer.start();
+    free(ptr);
+    printf("done in %dms\n", timer.elapsed());
+
+    return 0;
+}


### PR DESCRIPTION
This significantly reduces the pressure on the kernel heap when
allocating a lot of pages.

Previously at about 250MB allocated, the free page list would outgrow
the kernel's heap. Given that there is no longer a page list, this does
not happen.

The next barrier will be the kernel memory used by the page records for
in-use memory. This kicks in at about 1GB.

Along with this change are three supporting patches. One is a test program
for stressing the memory allocator, one is a small change to
`PhysicalAddress` to support some comparisons, and one is a change to the
`run` script to use an environment variable to control the memory size.