### PR TITLE
Fixes for /proc/self

### DIFF
--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -767,7 +767,7 @@ KResult Ext2FSInode::add_child(InodeIdentifier child_id, const StringView& name,
     Vector<FS::DirectoryEntry> entries;
     bool name_already_exists = false;
     traverse_as_directory([&](auto& entry) {
-        if (!strcmp(entry.name, name.characters())) {
+        if (name == entry.name) {
             name_already_exists = true;
             return false;
         }
@@ -812,7 +812,7 @@ KResult Ext2FSInode::remove_child(const StringView& name)
 
     Vector<FS::DirectoryEntry> entries;
     traverse_as_directory([&](auto& entry) {
-        if (strcmp(entry.name, name.characters()) != 0)
+        if (name != entry.name)
             entries.append(entry);
         return true;
     });

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -966,7 +966,7 @@ InodeIdentifier ProcFSInode::lookup(StringView name)
             if (entry.name == nullptr)
                 continue;
             if (entry.proc_file_type > __FI_Root_Start && entry.proc_file_type < __FI_Root_End) {
-                if (!strcmp(entry.name, name.characters())) {
+                if (name == entry.name) {
                     return to_identifier(fsid(), PDI_Root, 0, (ProcFileType)entry.proc_file_type);
                 }
             }
@@ -988,7 +988,7 @@ InodeIdentifier ProcFSInode::lookup(StringView name)
     if (proc_file_type == FI_Root_sys) {
         for (int i = 0; i < fs().m_sys_entries.size(); ++i) {
             auto& entry = fs().m_sys_entries[i];
-            if (!strcmp(entry.name, name.characters()))
+            if (name == entry.name)
                 return sys_var_to_identifier(fsid(), i);
         }
         return {};
@@ -1005,7 +1005,7 @@ InodeIdentifier ProcFSInode::lookup(StringView name)
                     continue;
                 if (entry.name == nullptr)
                     continue;
-                if (!strcmp(entry.name, name.characters())) {
+                if (name == entry.name) {
                     return to_identifier(fsid(), PDI_PID, to_pid(identifier()), (ProcFileType)entry.proc_file_type);
                 }
             }


### PR DESCRIPTION
A couple of fixes in the kernel for resolving `/proc/self` and related paths.

Without this PR:
```
anon@courage:/home/anon$> ls -l /proc/self/exe
opendir: No such file or directory
Shell: ls(12) exited with status 1
```

With the first fix:
```
anon@courage:/home/anon$> ls -l /proc/self/exe
drwxrwxrwx  anon users          0   1985-02-09 02:23:00 vm/
drwxrwxrwx  anon users          0   1985-02-09 02:23:00 vmo/
drwxrwxrwx  anon users          0   1985-02-09 02:23:00 stack/
drwxrwxrwx  anon users          0   1985-02-09 02:23:00 regs/
drwxrwxrwx  anon users          0   1985-02-09 02:23:00 fds/
drwxrwxrwx  anon users          0   1985-02-09 02:23:00 exe/
drwxrwxrwx  anon users          0   1985-02-09 02:23:00 cwd/
drwxrwxrwx  anon users          0   1985-02-09 02:23:00 fd/
```
With both fixes, it works as expected:
```
anon@courage:/home/anon$> ls -l /proc/self/exe
drwxrwxrwx  anon users          0   1985-02-09 02:23:00 /proc/self/exe -> /bin/ls
```

I've also tried to handle (& tested) various other corner cases such as `/proc/self/cwd/../../////tmp///`, and it all seems to work as expected.

I've used this to debug the kernel, not sure why debugging is disabled upstream:
```patch
diff --git a/Makefile.common b/Makefile.common
index 60911ec7..7e80ee09 100644
--- a/Makefile.common
+++ b/Makefile.common
@@ -2,7 +2,7 @@ ARCH_FLAGS =
 STANDARD_FLAGS = -std=c++17 -Wno-sized-deallocation -fno-sized-deallocation
 WARNING_FLAGS = -Wextra -Wall -Wundef -Wcast-qual -Wwrite-strings -Wimplicit-fallthrough
 FLAVOR_FLAGS = -fno-exceptions -fno-rtti
-OPTIMIZATION_FLAGS = -Os
+OPTIMIZATION_FLAGS = -Os -g
 
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 SERENITY_BASE_DIR := $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
```

P.S. Thank you for such a great OS, @awesomekling! I've been watching your videos & following Serenity development for a while now, and finally got around to contributing.