### PR TITLE
Fix leaking physical pages

### DIFF
--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -458,7 +458,7 @@ RetainPtr<Region> MemoryManager::allocate_kernel_region(size_t size, String&& na
     return region;
 }
 
-void MemoryManager::deallocate_user_physical_page(PhysicalPage& page)
+void MemoryManager::deallocate_user_physical_page(PhysicalPage&& page)
 {
     for (auto& region : m_user_physical_regions) {
         if (!region->contains(page)) {
@@ -468,7 +468,7 @@ void MemoryManager::deallocate_user_physical_page(PhysicalPage& page)
             continue;
         }
 
-        region->return_page(page);
+        region->return_page(move(page));
         m_user_physical_pages_used--;
 
         return;
@@ -515,7 +515,7 @@ RetainPtr<PhysicalPage> MemoryManager::allocate_user_physical_page(ShouldZeroFil
     return page;
 }
 
-void MemoryManager::deallocate_supervisor_physical_page(PhysicalPage& page)
+void MemoryManager::deallocate_supervisor_physical_page(PhysicalPage&& page)
 {
     for (auto& region : m_super_physical_regions) {
         if (!region->contains(page)) {
@@ -525,7 +525,7 @@ void MemoryManager::deallocate_supervisor_physical_page(PhysicalPage& page)
             continue;
         }
 
-        region->return_page(page);
+        region->return_page(move(page));
         m_super_physical_pages_used--;
 
         return;

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -63,8 +63,8 @@ public:
 
     RetainPtr<PhysicalPage> allocate_user_physical_page(ShouldZeroFill);
     RetainPtr<PhysicalPage> allocate_supervisor_physical_page();
-    void deallocate_user_physical_page(PhysicalPage&);
-    void deallocate_supervisor_physical_page(PhysicalPage&);
+    void deallocate_user_physical_page(PhysicalPage&&);
+    void deallocate_supervisor_physical_page(PhysicalPage&&);
 
     void remap_region(PageDirectory&, Region&);
 

--- a/Kernel/VM/PageDirectory.cpp
+++ b/Kernel/VM/PageDirectory.cpp
@@ -9,7 +9,7 @@ static const dword kernelspace_range_base = 0xc0000000;
 PageDirectory::PageDirectory(PhysicalAddress paddr)
     : m_range_allocator(VirtualAddress(0xc0000000), 0x3f000000)
 {
-    m_directory_page = PhysicalPage::create_eternal(paddr, true);
+    m_directory_page = PhysicalPage::create(paddr, true, false);
 }
 
 PageDirectory::PageDirectory(const RangeAllocator* parent_range_allocator)

--- a/Kernel/VM/PhysicalPage.cpp
+++ b/Kernel/VM/PhysicalPage.cpp
@@ -2,13 +2,6 @@
 #include <Kernel/VM/PhysicalPage.h>
 #include <Kernel/kmalloc.h>
 
-Retained<PhysicalPage> PhysicalPage::create_eternal(PhysicalAddress paddr, bool supervisor)
-{
-    void* slot = kmalloc_eternal(sizeof(PhysicalPage));
-    new (slot) PhysicalPage(paddr, supervisor, false);
-    return adopt(*(PhysicalPage*)slot);
-}
-
 Retained<PhysicalPage> PhysicalPage::create(PhysicalAddress paddr, bool supervisor, bool may_return_to_freelist)
 {
     void* slot = kmalloc(sizeof(PhysicalPage));

--- a/Kernel/VM/PhysicalPage.cpp
+++ b/Kernel/VM/PhysicalPage.cpp
@@ -23,7 +23,7 @@ PhysicalPage::PhysicalPage(PhysicalAddress paddr, bool supervisor, bool may_retu
 {
 }
 
-void PhysicalPage::return_to_freelist()
+void PhysicalPage::return_to_freelist() &&
 {
     ASSERT((paddr().get() & ~PAGE_MASK) == 0);
 
@@ -32,9 +32,9 @@ void PhysicalPage::return_to_freelist()
     m_retain_count = 1;
 
     if (m_supervisor)
-        MM.deallocate_supervisor_physical_page(*this);
+        MM.deallocate_supervisor_physical_page(move(*this));
     else
-        MM.deallocate_user_physical_page(*this);
+        MM.deallocate_user_physical_page(move(*this));
 
 #ifdef MM_DEBUG
     dbgprintf("MM: P%x released to freelist\n", m_paddr.get());

--- a/Kernel/VM/PhysicalPage.cpp
+++ b/Kernel/VM/PhysicalPage.cpp
@@ -9,10 +9,10 @@ Retained<PhysicalPage> PhysicalPage::create_eternal(PhysicalAddress paddr, bool 
     return adopt(*(PhysicalPage*)slot);
 }
 
-Retained<PhysicalPage> PhysicalPage::create(PhysicalAddress paddr, bool supervisor)
+Retained<PhysicalPage> PhysicalPage::create(PhysicalAddress paddr, bool supervisor, bool may_return_to_freelist)
 {
     void* slot = kmalloc(sizeof(PhysicalPage));
-    new (slot) PhysicalPage(paddr, supervisor);
+    new (slot) PhysicalPage(paddr, supervisor, may_return_to_freelist);
     return adopt(*(PhysicalPage*)slot);
 }
 

--- a/Kernel/VM/PhysicalPage.cpp
+++ b/Kernel/VM/PhysicalPage.cpp
@@ -5,14 +5,14 @@
 Retained<PhysicalPage> PhysicalPage::create_eternal(PhysicalAddress paddr, bool supervisor)
 {
     void* slot = kmalloc_eternal(sizeof(PhysicalPage));
-    new (slot) PhysicalPage(paddr, supervisor);
+    new (slot) PhysicalPage(paddr, supervisor, false);
     return adopt(*(PhysicalPage*)slot);
 }
 
 Retained<PhysicalPage> PhysicalPage::create(PhysicalAddress paddr, bool supervisor)
 {
     void* slot = kmalloc(sizeof(PhysicalPage));
-    new (slot) PhysicalPage(paddr, supervisor, false);
+    new (slot) PhysicalPage(paddr, supervisor);
     return adopt(*(PhysicalPage*)slot);
 }
 

--- a/Kernel/VM/PhysicalPage.h
+++ b/Kernel/VM/PhysicalPage.h
@@ -28,7 +28,6 @@ public:
         }
     }
 
-    static Retained<PhysicalPage> create_eternal(PhysicalAddress, bool supervisor);
     static Retained<PhysicalPage> create(PhysicalAddress, bool supervisor, bool may_return_to_freelist = true);
 
     word retain_count() const { return m_retain_count; }

--- a/Kernel/VM/PhysicalPage.h
+++ b/Kernel/VM/PhysicalPage.h
@@ -23,7 +23,7 @@ public:
         ASSERT(m_retain_count);
         if (!--m_retain_count) {
             if (m_may_return_to_freelist)
-                return_to_freelist();
+                move(*this).return_to_freelist();
             else
                 delete this;
         }
@@ -38,7 +38,7 @@ private:
     PhysicalPage(PhysicalAddress paddr, bool supervisor, bool may_return_to_freelist = true);
     ~PhysicalPage() {}
 
-    void return_to_freelist();
+    void return_to_freelist() &&;
 
     word m_retain_count { 1 };
     bool m_may_return_to_freelist { true };

--- a/Kernel/VM/PhysicalPage.h
+++ b/Kernel/VM/PhysicalPage.h
@@ -29,7 +29,7 @@ public:
     }
 
     static Retained<PhysicalPage> create_eternal(PhysicalAddress, bool supervisor);
-    static Retained<PhysicalPage> create(PhysicalAddress, bool supervisor);
+    static Retained<PhysicalPage> create(PhysicalAddress, bool supervisor, bool may_return_to_freelist = true);
 
     word retain_count() const { return m_retain_count; }
 

--- a/Kernel/VM/PhysicalPage.h
+++ b/Kernel/VM/PhysicalPage.h
@@ -24,8 +24,7 @@ public:
         if (!--m_retain_count) {
             if (m_may_return_to_freelist)
                 move(*this).return_to_freelist();
-            else
-                delete this;
+            delete this;
         }
     }
 

--- a/Kernel/VM/PhysicalRegion.h
+++ b/Kernel/VM/PhysicalRegion.h
@@ -25,7 +25,7 @@ public:
 
     RetainPtr<PhysicalPage> take_free_page(bool supervisor);
     void return_page_at(PhysicalAddress addr);
-    void return_page(PhysicalPage& page) { return_page_at(page.paddr()); }
+    void return_page(PhysicalPage&& page) { return_page_at(page.paddr()); }
 
 private:
     PhysicalRegion(PhysicalAddress lower, PhysicalAddress upper);

--- a/Kernel/VM/VMObject.cpp
+++ b/Kernel/VM/VMObject.cpp
@@ -54,7 +54,7 @@ VMObject::VMObject(PhysicalAddress paddr, size_t size)
 {
     MM.register_vmo(*this);
     for (size_t i = 0; i < size; i += PAGE_SIZE) {
-        m_physical_pages.append(PhysicalPage::create(paddr.offset(i), false));
+        m_physical_pages.append(PhysicalPage::create(paddr.offset(i), false, false));
     }
     ASSERT(m_physical_pages.size() == page_count());
 }


### PR DESCRIPTION
The existing code leaks both physical pages and `PhysicalPage` instances representing them (amusingly enough, for different reasons). This is easy to reproduce: run `allocate` and see the memory usage never drop:
![Serenity page leak](https://user-images.githubusercontent.com/10091584/59508774-b64a6900-8eb7-11e9-8159-5856579b93d3.png)
Another way to reproduce this is to try continuously resizing a window, since that involves creating and freeing many `SharedBuffer`s.

I'm not sure the fixes are 100% correct, so please check! The commit that introduces `create()` and `create_eternal()` is https://github.com/SerenityOS/serenity/commit/0730b3c15fdc537e365fde0c307bea3fb615a43e

Screenshot with the fixes:
![Serenity page leak fixed](https://user-images.githubusercontent.com/10091584/59508949-4e485280-8eb8-11e9-9e7f-b1a69649d3dc.png)

Oh, and I couldn't find any bug report about this, even though it looks like something fairly easy to spot, and something `allocate` was written specifically to test?

cc @deoxxa