### PR TITLE
Kernel: Avoid panics in kmalloc()

### DIFF
--- a/Kernel/kmalloc.cpp
+++ b/Kernel/kmalloc.cpp
@@ -116,7 +116,7 @@ void* kmalloc_impl(size_t size)
         }
         kprintf("Crashing active process %s(%u).\n", current->process().name().characters(), current->pid());
         current->process().crash();
-        return {};
+        ASSERT_NOT_REACHED();
     }
 
     size_t chunks_needed = real_size / CHUNK_SIZE;
@@ -175,7 +175,7 @@ void* kmalloc_impl(size_t size)
     }
     kprintf("Crashing active process %s(%u).\n", current->process().name().characters(), current->pid());
     current->process().crash();
-    return {};
+    ASSERT_NOT_REACHED();
 }
 
 void kfree(void* ptr)


### PR DESCRIPTION
Previously, whenever the system ran out of memory and a process attempted to allocate some, the kernel would simply panic.

Now the kernel simply crashes the process trying to allocate memory, unless the process is ring 0.

To test this, use the `allocate` program and try to allocate more memory than available. Before, the system would kp.

Let me know if I need to change anything! :)