### PR TITLE
WSWindowManager: Ensure that we pick a single window to deliver a full stream of events to

### DIFF
--- a/Servers/WindowServer/WSWindowManager.h
+++ b/Servers/WindowServer/WSWindowManager.h
@@ -220,6 +220,7 @@ private:
     WeakPtr<WSWindow> m_active_window;
     WeakPtr<WSWindow> m_hovered_window;
     WeakPtr<WSWindow> m_highlight_window;
+    WeakPtr<WSWindow> m_active_input_window;
 
     WeakPtr<WSWindow> m_drag_window;
     Point m_drag_origin;


### PR DESCRIPTION
This is effectively a mouse grab except that we don't require any client
coordination to request it (which is probably OK, and certainly a lot
simpler to implement).

This prevents e.g. dragging the mouse cursor out of paint and over the
terminal from selecting text unexpectedly.