### PR TITLE
Build: Fix incorrect user and group settings for disk image

### DIFF
--- a/Kernel/build-image-qemu.sh
+++ b/Kernel/build-image-qemu.sh
@@ -13,7 +13,7 @@ fi
 
 echo "setting up disk image..."
 qemu-img create _disk_image ${DISK_SIZE:-500}m || die "couldn't create disk image"
-chown 1000:1000 _disk_image || die "couldn't adjust permissions on disk image"
+chown $(<build_user):$(<build_group) _disk_image || die "couldn't adjust permissions on disk image"
 echo "done"
 
 echo -n "creating new filesystem... "

--- a/Kernel/build-image-qemu.sh
+++ b/Kernel/build-image-qemu.sh
@@ -13,7 +13,7 @@ fi
 
 echo "setting up disk image..."
 qemu-img create _disk_image ${DISK_SIZE:-500}m || die "couldn't create disk image"
-chown $(<build_user):$(<build_group) _disk_image || die "couldn't adjust permissions on disk image"
+chown $build_user:$build_group _disk_image || die "couldn't adjust permissions on disk image"
 echo "done"
 
 echo -n "creating new filesystem... "

--- a/Kernel/makeall.sh
+++ b/Kernel/makeall.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Get user and group details for setting qemu disk image ownership
+echo $USER > build_user
+echo $(id -g) > build_group
+
 sudo id
 
 if [ -z "$MAKEJOBS" ]; then
@@ -59,3 +63,4 @@ done
 
 sudo ./sync.sh
 
+rm build_user build_group

--- a/Kernel/makeall.sh
+++ b/Kernel/makeall.sh
@@ -2,8 +2,8 @@
 set -e
 
 # Get user and group details for setting qemu disk image ownership
-echo $USER > build_user
-echo $(id -g) > build_group
+export build_user=$(id -u)
+export build_group=$(id -g)
 
 sudo id
 
@@ -63,4 +63,3 @@ done
 
 sudo ./sync.sh
 
-rm build_user build_group


### PR DESCRIPTION
The current serenity makeall.sh build assumes the user is running Linux as the normal user / group. This means that if you are building on a machine authenticating to AD or LDAP or you are not the first user on your machine (UID/GID 1001) you either have to run the serenity run script as sudo/root or you manually fix the permissions of the disk image. This patch fixes that.