### PR TITLE
Build: Use sudo -E to preserve EVs when calling build-image-qemu.sh from makeall.sh

### DIFF
--- a/Kernel/makeall.sh
+++ b/Kernel/makeall.sh
@@ -61,5 +61,5 @@ done
 (cd ../SharedGraphics && ./install.sh)
 (cd ../AK && ./install.sh)
 
-sudo ./sync.sh
+sudo -E ./build-image-qemu.sh
 


### PR DESCRIPTION
This change is required as the build user and group EVs weren't being inherited when it was sync.sh being called by makeall.sh, but the only thing that sync does is run build-image-qemu.sh anyway.