### PR TITLE
Kernel: Extended IDE interface to allow slave device

### DIFF
--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -84,7 +84,7 @@ VFS* vfs;
         hang();
     }
 
-    auto dev_hd0 = IDEDiskDevice::create();
+    auto dev_hd0 = IDEDiskDevice::create(IDEDiskDevice::DriveType::MASTER);
 
     NonnullRefPtr<DiskDevice> root_dev = dev_hd0.copy_ref();
 


### PR DESCRIPTION
The IDE Disk Controller driver has been extended to allow the secondary device on the channel to be initialised and used. A test as to whether this is working (for anyone interested) is to modify `init.cpp:87` to `auto dev_hd0 = IDEDiskDevice::create(true);`. The kernel will fail to boot, as there is no disk attached to CHANNEL 1's slave. This was born out of the fact that my FAT Driver can't be tested as easily without creating a partition on hda, and ain't nobody got time for dat.

There's probably a better, less verbose way to perform this (without the OR'ing), but this seemed like the best route, especially because we actually store whether THIS device is the master or slave on the channel. Feel free to let me know if there's any way I can make this cleaner, if I can make this cleaner, or if I'm missing something that will allow the driver to fail. I'm pretty sure the existing code is already following the spec completely, it just needed the dynamic addition of bit 4 in the `Drive/Head register` to allow it to select the slave device.

Cheers,
Quaker