### PR TITLE
TextEditor: removed copy_ref()

### DIFF
--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -55,9 +55,9 @@ TextEditorWidget::TextEditorWidget()
     menubar->add_menu(move(app_menu));
 
     auto file_menu = make<GMenu>("File");
-    file_menu->add_action(new_action.copy_ref());
-    file_menu->add_action(open_action.copy_ref());
-    file_menu->add_action(save_action.copy_ref());
+    file_menu->add_action(new_action);
+    file_menu->add_action(open_action);
+    file_menu->add_action(save_action);
     menubar->add_menu(move(file_menu));
 
     auto edit_menu = make<GMenu>("Edit");


### PR DESCRIPTION
Didn't see that the function got removed. oops.