### PR TITLE
LibCore: Always call on_connected whether the connection was synchronous or not

### DIFF
--- a/Libraries/LibCore/CSocket.cpp
+++ b/Libraries/LibCore/CSocket.cpp
@@ -92,6 +92,8 @@ bool CSocket::connect(const CSocketAddress& address)
     }
 
     m_connected = true;
+    if (on_connected)
+        on_connected();
     return true;
 }
 

--- a/Libraries/LibCore/CSocket.cpp
+++ b/Libraries/LibCore/CSocket.cpp
@@ -66,9 +66,12 @@ bool CSocket::connect(const CSocketAddress& address, int port)
         }
         perror("connect");
         exit(1);
+    } else {
+        dbg() << *this << " connected ok!";
+        m_connected = true;
+        if (on_connected)
+            on_connected();
     }
-    dbg() << *this << " connected ok!";
-    m_connected = true;
     return true;
 }
 


### PR DESCRIPTION
It's unreasonable to expect the client to have to call it themselves if
the connection was immediate (local).