### PR TITLE
LibCore: Add a way to mark a socket as blocking (or not)

### DIFF
--- a/Libraries/LibCore/CLocalSocket.cpp
+++ b/Libraries/LibCore/CLocalSocket.cpp
@@ -4,7 +4,7 @@
 CLocalSocket::CLocalSocket(CObject* parent)
     : CSocket(CSocket::Type::Local, parent)
 {
-    int fd = socket(AF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    int fd = socket(AF_LOCAL, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
     if (fd < 0) {
         set_error(fd);
     } else {

--- a/Libraries/LibCore/CSocket.cpp
+++ b/Libraries/LibCore/CSocket.cpp
@@ -6,6 +6,8 @@
 #include <netinet/in.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
 #include <sys/socket.h>
 
 CSocket::CSocket(Type type, CObject* parent)
@@ -29,6 +31,17 @@ bool CSocket::connect(const String& hostname, int port)
     IPv4Address host_address((const u8*)hostent->h_addr_list[0]);
     dbg() << "CSocket::connect: Resolved '" << hostname << "' to " << host_address;
     return connect(host_address, port);
+}
+
+void CSocket::set_blocking(bool blocking)
+{
+    int flags = fcntl(fd(), F_GETFL, 0);
+    ASSERT(flags >= 0);
+    if (blocking)
+        flags = fcntl(fd(), F_SETFL, flags | O_NONBLOCK);
+    else
+        flags = fcntl(fd(), F_SETFL, flags & O_NONBLOCK);
+    ASSERT(flags >= 0);
 }
 
 bool CSocket::connect(const CSocketAddress& address, int port)

--- a/Libraries/LibCore/CSocket.h
+++ b/Libraries/LibCore/CSocket.h
@@ -23,6 +23,7 @@ public:
     bool send(const ByteBuffer&);
 
     bool is_connected() const { return m_connected; }
+    void set_blocking(bool blocking);
 
     CSocketAddress source_address() const { return m_source_address; }
     int source_port() const { return m_source_port; }


### PR DESCRIPTION
If custom I/O is being done outside CIODevice, we need a way to force blocking sometimes.
This also fixes the default of CLocalSocket to be non-blocking, the same
as CTCPSocket.