### PR TITLE
CNotifier: Turn into a CObject and Use the event queue to deliver events

### DIFF
--- a/Applications/Piano/main.cpp
+++ b/Applications/Piano/main.cpp
@@ -9,8 +9,8 @@
 
 int main(int argc, char** argv)
 {
-    AClientConnection audio_connection;
     GApplication app(argc, argv);
+    AClientConnection audio_connection;
 
     auto* window = new GWindow;
     window->set_title("Piano");

--- a/Libraries/LibCore/CEvent.h
+++ b/Libraries/LibCore/CEvent.h
@@ -13,6 +13,8 @@ public:
         Invalid = 0,
         Quit,
         Timer,
+        NotifierRead,
+        NotifierWrite,
         DeferredDestroy,
         DeferredInvoke,
         ChildAdded,
@@ -60,6 +62,36 @@ public:
 
 private:
     int m_timer_id;
+};
+
+class CNotifierReadEvent final : public CEvent {
+public:
+    explicit CNotifierReadEvent(int fd)
+        : CEvent(CEvent::NotifierRead)
+        , m_fd(fd)
+    {
+    }
+    ~CNotifierReadEvent() {}
+
+    int fd() const { return m_fd; }
+
+private:
+    int m_fd;
+};
+
+class CNotifierWriteEvent final : public CEvent {
+public:
+    explicit CNotifierWriteEvent(int fd)
+        : CEvent(CEvent::NotifierWrite)
+        , m_fd(fd)
+    {
+    }
+    ~CNotifierWriteEvent() {}
+
+    int fd() const { return m_fd; }
+
+private:
+    int m_fd;
 };
 
 class CChildEvent final : public CEvent {

--- a/Libraries/LibCore/CEventLoop.cpp
+++ b/Libraries/LibCore/CEventLoop.cpp
@@ -245,11 +245,11 @@ void CEventLoop::wait_for_event(WaitMode mode)
     for (auto& notifier : *s_notifiers) {
         if (FD_ISSET(notifier->fd(), &rfds)) {
             if (notifier->on_ready_to_read)
-                notifier->on_ready_to_read();
+                post_event(*notifier, make<CNotifierReadEvent>(notifier->fd()));
         }
         if (FD_ISSET(notifier->fd(), &wfds)) {
             if (notifier->on_ready_to_write)
-                notifier->on_ready_to_write();
+                post_event(*notifier, make<CNotifierWriteEvent>(notifier->fd()));
         }
     }
 

--- a/Libraries/LibCore/CNotifier.cpp
+++ b/Libraries/LibCore/CNotifier.cpp
@@ -21,3 +21,14 @@ void CNotifier::set_enabled(bool enabled)
     else
         CEventLoop::unregister_notifier({}, *this);
 }
+
+void CNotifier::event(CEvent& event)
+{
+    if (event.type() == CEvent::NotifierRead && on_ready_to_read) {
+        on_ready_to_read();
+    } else if (event.type() == CEvent::NotifierWrite && on_ready_to_write) {
+        on_ready_to_write();
+    } else {
+        CObject::event(event);
+    }
+}

--- a/Libraries/LibCore/CNotifier.h
+++ b/Libraries/LibCore/CNotifier.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <AK/Function.h>
+#include "CObject.h"
 
-class CNotifier {
+class CNotifier : public CObject {
 public:
     enum Event {
         None = 0,
@@ -21,6 +22,9 @@ public:
     int fd() const { return m_fd; }
     unsigned event_mask() const { return m_event_mask; }
     void set_event_mask(unsigned event_mask) { m_event_mask = event_mask; }
+
+    const char* class_name() const override { return "CNotifier"; }
+    void event(CEvent& event) override;
 
 private:
     int m_fd { -1 };


### PR DESCRIPTION
This way, CNotifier can mutate state to its little heart's content
without destroying the world when the global CNotifier hash changes
during delivery.