### PR TITLE
Scheduler: Move thread unblocking out of a lambda to help make things more readable

### DIFF
--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -120,6 +120,7 @@ public:
     void set_state(State);
 
     void send_signal(u8 signal, Process* sender);
+    void consider_unblock(time_t now_sec, long now_usec);
 
     ShouldUnblockThread dispatch_one_pending_signal();
     ShouldUnblockThread dispatch_signal(u8 signal);


### PR DESCRIPTION
We also use a switch to explicitly make sure we handle all cases properly.