### PR TITLE
Small thread for_each cleanups

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -425,22 +425,12 @@ inline void Process::for_each_thread(Callback callback) const
 {
     InterruptDisabler disabler;
     pid_t my_pid = pid();
-    for (auto* thread = g_runnable_threads->head(); thread;) {
-        auto* next_thread = thread->next();
-        if (thread->pid() == my_pid) {
-            if (callback(*thread) == IterationDecision::Break)
-                break;
-        }
-        thread = next_thread;
-    }
-    for (auto* thread = g_nonrunnable_threads->head(); thread;) {
-        auto* next_thread = thread->next();
-        if (thread->pid() == my_pid) {
-            if (callback(*thread) == IterationDecision::Break)
-                break;
-        }
-        thread = next_thread;
-    }
+    Thread::for_each([callback, my_pid](Thread& thread) -> IterationDecision {
+        if (thread.pid() == my_pid)
+            return callback(thread);
+
+        return IterationDecision::Continue;
+    });
 }
 
 template<typename Callback>

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -321,16 +321,18 @@ bool Scheduler::pick_next()
 
 #ifdef SCHEDULER_RUNNABLE_DEBUG
     dbgprintf("Non-runnables:\n");
-    for (auto* thread = g_nonrunnable_threads->head(); thread; thread = thread->next()) {
-        auto* process = &thread->process();
-        dbgprintf("[K%x] %-12s %s(%u:%u) @ %w:%x\n", process, to_string(thread->state()), process->name().characters(), process->pid(), thread->tid(), thread->tss().cs, thread->tss().eip);
-    }
+    Thread::for_each_nonrunnable([](Thread& thread) -> IterationDecision {
+        auto& process = thread.process();
+        dbgprintf("[K%x] %-12s %s(%u:%u) @ %w:%x\n", &process, thread.state_string(), process.name().characters(), process.pid(), thread.tid(), thread.tss().cs, thread.tss().eip);
+        return IterationDecision::Continue;
+    });
 
     dbgprintf("Runnables:\n");
-    for (auto* thread = g_runnable_threads->head(); thread; thread = thread->next()) {
-        auto* process = &thread->process();
-        dbgprintf("[K%x] %-12s %s(%u:%u) @ %w:%x\n", process, to_string(thread->state()), process->name().characters(), process->pid(), thread->tid(), thread->tss().cs, thread->tss().eip);
-    }
+    Thread::for_each_runnable([](Thread& thread) -> IterationDecision {
+        auto& process = thread.process();
+        dbgprintf("[K%x] %-12s %s(%u:%u) @ %w:%x\n", &process, thread.state_string(), process.name().characters(), process.pid(), thread.tid(), thread.tss().cs, thread.tss().eip);
+        return IterationDecision::Continue;
+    });
 #endif
 
     if (g_runnable_threads->is_empty())

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -178,6 +178,7 @@ void Thread::finalize_dying_threads()
         InterruptDisabler disabler;
         for_each_in_state(Thread::State::Dying, [&](Thread& thread) {
             dying_threads.append(&thread);
+            return IterationDecision::Continue;
         });
     }
     for (auto* thread : dying_threads)


### PR DESCRIPTION
We have a bunch of for_each variants, and that's really cool. But we should be consistent about returning IterationDecision. Even if the few callers of it don't make use of it now, someone may want to sometime.

And by returning IterationDecision, we can also compose individual for_each_* into larger, more complicated ones as this patchset shows, which helps improve encapsulation (like Process and Scheduler not poking the runnable lists directly as much).

This will help in improving the scheduler smarts in the future. :)