### PR TITLE
SharedBuffer: Fix a denial of service

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -2408,7 +2408,7 @@ int Process::sys$create_shared_buffer(int size, void** buffer)
     int shared_buffer_id = ++s_next_shared_buffer_id;
     auto shared_buffer = make<SharedBuffer>(shared_buffer_id, size);
     shared_buffer->share_with(m_pid);
-    *buffer = shared_buffer->get_address(*this);
+    *buffer = shared_buffer->ref_for_process_and_get_address(*this);
     ASSERT((int)shared_buffer->size() >= size);
 #ifdef SHARED_BUFFER_DEBUG
     kprintf("%s(%u): Created shared buffer %d @ %p (%u bytes, vmo is %u)\n", name().characters(), pid(), shared_buffer_id, *buffer, size, shared_buffer->size());
@@ -2447,7 +2447,7 @@ int Process::sys$release_shared_buffer(int shared_buffer_id)
 #ifdef SHARED_BUFFER_DEBUG
     kprintf("%s(%u): Releasing shared buffer %d, buffer count: %u\n", name().characters(), pid(), shared_buffer_id, shared_buffers().resource().size());
 #endif
-    shared_buffer.release(*this);
+    shared_buffer.deref_for_process(*this);
     return 0;
 }
 
@@ -2463,7 +2463,7 @@ void* Process::sys$get_shared_buffer(int shared_buffer_id)
 #ifdef SHARED_BUFFER_DEBUG
     kprintf("%s(%u): Retaining shared buffer %d, buffer count: %u\n", name().characters(), pid(), shared_buffer_id, shared_buffers().resource().size());
 #endif
-    return shared_buffer.get_address(*this);
+    return shared_buffer.ref_for_process_and_get_address(*this);
 }
 
 int Process::sys$seal_shared_buffer(int shared_buffer_id)

--- a/Kernel/SharedBuffer.h
+++ b/Kernel/SharedBuffer.h
@@ -12,7 +12,7 @@ private:
         }
 
         pid_t pid;
-        unsigned count { 1 };
+        unsigned count { 0 };
         Region* region { nullptr };
     };
 public:
@@ -33,9 +33,9 @@ public:
     }
 
     bool is_shared_with(pid_t peer_pid);
-    void* get_address(Process& process);
+    void* ref_for_process_and_get_address(Process& process);
     void share_with(pid_t peer_pid);
-    void release(Process& process);
+    void deref_for_process(Process& process);
     void disown(pid_t pid);
     size_t size() const { return m_vmo->size(); }
     void destroy_if_unused();
@@ -45,6 +45,7 @@ public:
     bool m_writable { true };
     NonnullRefPtr<VMObject> m_vmo;
     Vector<Reference, 2> m_refs;
+    unsigned m_total_refs { 0 };
 };
 
 Lockable<HashMap<int, OwnPtr<SharedBuffer>>>& shared_buffers();


### PR DESCRIPTION
It's a very bad idea to increment the refcount on behalf of another
process. That process may (for either benign or evil reasons) not
reference the SharedBuffer, and then we'll be stuck with loads of
SharedBuffers until we OOM.

Instead, increment the refcount when the buffer is mapped. That way, a
buffer is only kept if *someone* has explicitly requested it via
get_shared_buffer.

Fixes #341