### PR TITLE
Thread: Return a result from block() indicating why the block terminated

### DIFF
--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -139,7 +139,9 @@ void SB16::handle_irq()
 
 void SB16::wait_for_irq()
 {
-    current->block_until("Interrupting", [this] {
+    // Well, we have no way of knowing how much got written. So just hope all of
+    // it did, even if we're interrupted.
+    (void)current->block_until("Interrupting", [this] {
         return m_interrupted;
     });
 }

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -59,7 +59,7 @@ void NetworkTask_main()
     for (;;) {
         auto packet = dequeue_packet();
         if (packet.is_null()) {
-            current->block_until("Networking", [] {
+            (void)current->block_until("Networking", [] {
                 if (LoopbackAdapter::the().has_queued_packets())
                     return true;
                 if (auto* e1000 = E1000NetworkAdapter::the()) {

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -162,7 +162,8 @@ KResult TCPSocket::protocol_connect(FileDescription& description, ShouldBlock sh
     m_state = State::Connecting;
 
     if (should_block == ShouldBlock::Yes) {
-        current->block<Thread::ConnectBlocker>(description);
+        if (current->block<Thread::ConnectBlocker>(description) == Thread::BlockResult::InterruptedBySignal)
+            return KResult(-EINTR);
         ASSERT(is_connected());
         return KSuccess;
     }

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -309,7 +309,8 @@ bool Scheduler::pick_next()
             return IterationDecision::Continue;
         if (was_blocked) {
             dbgprintf("Unblock %s(%u) due to signal\n", thread.process().name().characters(), thread.pid());
-            thread.m_was_interrupted_while_blocked = true;
+            ASSERT(thread.m_blocker);
+            thread.m_blocker->set_interrupted_by_signal();
             thread.unblock();
         }
         return IterationDecision::Continue;

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -513,20 +513,6 @@ Thread* Thread::clone(Process& process)
     return clone;
 }
 
-KResult Thread::wait_for_connect(FileDescription& description)
-{
-    ASSERT(description.is_socket());
-    auto& socket = *description.socket();
-    if (socket.is_connected())
-        return KSuccess;
-    if (block<Thread::ConnectBlocker>(description) == Thread::BlockResult::InterruptedBySignal)
-        return KResult(-EINTR);
-    Scheduler::yield();
-    if (!socket.is_connected())
-        return KResult(-ECONNREFUSED);
-    return KSuccess;
-}
-
 void Thread::initialize()
 {
     g_runnable_threads = new SchedulerThreadList;

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -233,8 +233,6 @@ public:
 
     void unblock();
 
-    KResult wait_for_connect(FileDescription&);
-
     const FarPtr& far_ptr() const { return m_far_ptr; }
 
     bool tick();

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -243,7 +243,6 @@ extern "C" [[noreturn]] void init()
         for (;;) {
             Thread::finalize_dying_threads();
             (void)current->block<Thread::SemiPermanentBlocker>(Thread::SemiPermanentBlocker::Reason::Lurking);
-            Scheduler::yield();
         }
     });
     Process::create_kernel_process("NetworkTask", NetworkTask_main);

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -242,7 +242,7 @@ extern "C" [[noreturn]] void init()
         current->process().set_priority(Process::LowPriority);
         for (;;) {
             Thread::finalize_dying_threads();
-            current->block<Thread::SemiPermanentBlocker>(Thread::SemiPermanentBlocker::Reason::Lurking);
+            (void)current->block<Thread::SemiPermanentBlocker>(Thread::SemiPermanentBlocker::Reason::Lurking);
             Scheduler::yield();
         }
     });


### PR DESCRIPTION
    And use this to return EINTR in various places; some of which we were
    not handling properly before.
    
    This might expose a few bugs in userspace, but should be more compatible
    with other POSIX systems, and is certainly a little cleaner.

Also clean up a few unnecessary yield calls. No sense in yielding immediately after a block.