### PR TITLE
Scheduler: Allow reentry into block()

### DIFF
--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -221,8 +221,8 @@ void Thread::consider_unblock(time_t now_sec, long now_usec)
         /* don't know, don't care */
         return;
     case Thread::Blocked:
-        ASSERT(m_blocker);
-        if (m_blocker->should_unblock(*this, now_sec, now_usec))
+        ASSERT(!m_blockers.is_empty());
+        if (m_blockers.first()->should_unblock(*this, now_sec, now_usec))
             unblock();
         return;
     case Thread::Skip1SchedulerPass:
@@ -307,8 +307,8 @@ bool Scheduler::pick_next()
             return IterationDecision::Continue;
         if (was_blocked) {
             dbgprintf("Unblock %s(%u) due to signal\n", thread.process().name().characters(), thread.pid());
-            ASSERT(thread.m_blocker);
-            thread.m_blocker->set_interrupted_by_signal();
+            ASSERT(!thread.m_blockers.is_empty());
+            thread.m_blockers.first()->set_interrupted_by_signal();
             thread.unblock();
         }
         return IterationDecision::Continue;

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -148,8 +148,8 @@ const char* Thread::state_string() const
     case Thread::Skip0SchedulerPasses:
         return "Skip0";
     case Thread::Blocked:
-        ASSERT(m_blocker);
-        return m_blocker->state_string();
+        ASSERT(!m_blockers.is_empty());
+        return m_blockers.first()->state_string();
     }
     kprintf("to_string(Thread::State): Invalid state: %u\n", state());
     ASSERT_NOT_REACHED();
@@ -539,8 +539,8 @@ void Thread::set_state(State new_state)
 {
     InterruptDisabler disabler;
     if (new_state == Blocked) {
-        // we should always have an m_blocker while blocked
-        ASSERT(m_blocker != nullptr);
+        // we should always have a Blocker while blocked
+        ASSERT(!m_blockers.is_empty());
     }
 
     m_state = new_state;


### PR DESCRIPTION
With the presence of signal handlers, it is possible that a thread might
be blocked multiple times. Picture for instance a signal handler using
read(), or wait() while the thread is already blocked elsewhere before
the handler is invoked.

To fix this, we turn m_blocker into a chain of handlers. Each block()
call now prepends to the list, and unblocking will only consider the
most recent (first) blocker in the chain.

Fixes #309