### PR TITLE
Move runnable/non-runnable list control entirely over to Scheduler

### DIFF
--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -2,6 +2,8 @@
 
 #include <AK/Assertions.h>
 #include <AK/Types.h>
+#include <AK/Function.h>
+#include <AK/IntrusiveList.h>
 
 class Process;
 class Thread;
@@ -27,6 +29,29 @@ public:
     static bool is_active();
     static void beep();
 
+    template<typename Callback>
+    static inline IterationDecision for_each_runnable(Callback callback)
+    {
+        return for_each_runnable_func([callback](Thread& thread) {
+            return callback(thread);
+        });
+    }
+
+    template<typename Callback>
+    static inline IterationDecision for_each_nonrunnable(Callback callback)
+    {
+        return for_each_nonrunnable_func([callback](Thread& thread) {
+            return callback(thread);
+        });
+    }
+
+    static void init_thread(Thread& thread);
+    static void update_state_for_thread(Thread& thread);
+
 private:
     static void prepare_for_iret_to_new_process();
+    static IterationDecision for_each_runnable_func(Function<IterationDecision(Thread&)>&& callback);
+    static IterationDecision for_each_nonrunnable_func(Function<IterationDecision(Thread&)>&& callback);
+
 };
+


### PR DESCRIPTION
This way, we can change how the scheduler works without having to change Thread too.