### PR TITLE
AdLib Sound Card Device Driver

### DIFF
--- a/Kernel/Devices/AdLib.cpp
+++ b/Kernel/Devices/AdLib.cpp
@@ -1,0 +1,135 @@
+#include <Kernel/Devices/AdLib.h>
+#include <Kernel/IO.h>
+
+#define ADLIB_DEBUG
+
+#define ADLIB_STATUS_PORT 0x388 // r/w
+#define ADLIB_DATA_PORT 0x389   // w/o
+
+// Register addresses
+#define ADLIB_TEST_LSI 0x01
+#define ADLIB_ENABLE_WAVEFORM_CTRL 0x01
+#define ADLIB_TIMER1_DATA 0x02
+#define ADLIB_TIMER2_DATA 0x03
+#define ADLIB_TIMER_CTRL 0x04
+#define ADLIB_SPEECH_SYNTH_MODE 0x08
+#define ADLIB_KEYBOARD_SPLIT_NOTE 0x08
+
+#define ADLIB_TIMER2_EXPIRE_MASK 0x20  // Set if TIMER2 has expired
+#define ADLIB_TIMER1_EXPIRE_MASK 0x40  // Set if TIMER1 has expired
+#define ADLIB_TIMER12_EXPIRE_MASK 0x80 // Set if either TIMER1 or TIMER2 has expired
+
+static AdLib* s_the;
+
+AdLib& AdLib::the()
+{
+    return *s_the;
+}
+
+AdLib::AdLib()
+    : CharacterDevice(43, 42)
+{
+    detected = detect();
+    s_the = this;
+}
+
+AdLib::~AdLib()
+{
+}
+
+ssize_t AdLib::read(FileDescription&, u8* buffer, ssize_t)
+{
+    *buffer = read_status();
+    return 1;
+}
+
+bool AdLib::can_read(FileDescription&) const
+{
+    return detected;
+}
+
+ssize_t AdLib::write(FileDescription&, const u8* buffer, ssize_t size)
+{
+    if (!size || size != 2 || !detected)
+        return 0;
+
+    write_register(buffer[0], buffer[1]);
+    return size;
+}
+
+bool AdLib::can_write(FileDescription&) const
+{
+    return detected;
+}
+
+void AdLib::write_status(u8 val)
+{
+    IO::out16(ADLIB_STATUS_PORT, val);
+}
+
+void AdLib::write_data(u8 val)
+{
+    IO::out16(ADLIB_DATA_PORT, val);
+}
+
+u8 AdLib::read_status()
+{
+    return IO::in16(ADLIB_STATUS_PORT);
+}
+
+void AdLib::write_register(u8 reg, u8 data)
+{
+    // After writing to the register port, you must wait twelve cycles before sending the data;
+    // after writing the data, eighty-four cycles must elapse before any other sound card
+    // operation may be performed.
+
+    // The AdLib manual gives the wait times in microseconds: three point three (3.3)
+    // microseconds for the address, and twenty-three (23) microseconds for the data.
+
+    // Apparently this must be a minimum of 12 cycles (or 3.3us in the AdLib manual)
+    write_status(reg);
+    for (int i = 0; i < 5; i++)
+        IO::delay();
+
+    // Apparently this must be a minimum of 84 cycles (or 23us in the AdLib manual)
+    write_data(data);
+    for (int i = 0; i < 36; i++)
+        IO::delay();
+}
+
+bool AdLib::detect()
+{
+    write_register(ADLIB_TIMER_CTRL, 0x60);
+    write_register(ADLIB_TIMER_CTRL, 0x80);
+    u8 status1 = read_status();
+    write_register(ADLIB_TIMER1_DATA, 0xFF);
+    write_register(ADLIB_TIMER_CTRL, 0x21);
+
+    // This is approximately 96us
+    for (auto i = 0; i < 64; i++)
+        IO::delay();
+
+    u8 status2 = read_status();
+    write_register(ADLIB_TIMER_CTRL, 0x60);
+    write_register(ADLIB_TIMER_CTRL, 0x80);
+
+    status1 &= 0xE0;
+    status2 &= 0xE0;
+
+    if (status1 == 0x00 && status2 == 0xC0) {
+        kprintf("AdLib: Found an AdLib card!\n");
+
+        // At this point we know that an AdLib card is installed
+        // in the user's PC. Let's reset it completely.
+        for (auto i = 1; i <= 0xF5; i++) {
+            write_register(i, 0x00);
+        }
+
+        // Set BIT5 of register1 (WSEnable) so we can use waves other than a sine wave
+        write_register(ADLIB_ENABLE_WAVEFORM_CTRL, 0x20);
+        return true;
+    }
+
+    kprintf("AdLib: No AdLib card detected!\n");
+    return false;
+}

--- a/Kernel/Devices/AdLib.h
+++ b/Kernel/Devices/AdLib.h
@@ -1,0 +1,46 @@
+//
+// AdLib Sound Card Driver
+// Author: Jesse Buhagiar [quaker762]
+// Datasheet:   http://bochs.sourceforge.net/techspec/adlib_sb.txt (RIP no real documentation)
+//              http://www.shipbrook.net/jeff/sb.html
+//              http://www.vgmpf.com/Wiki/images/4/48/AdLib_-_Programming_Guide.pdf
+//
+// Email me at jooster669@gmail.com if you have any questions/suggestions :)
+//
+// Note: This card is NOT attached to any IRQ!
+//
+//
+#pragma once
+
+#include <Kernel/Devices/CharacterDevice.h>
+#include <Kernel/IRQHandler.h>
+
+class AdLib final : public CharacterDevice {
+    AK_MAKE_ETERNAL;
+
+public:
+    explicit AdLib();
+    virtual ~AdLib() override;
+
+    static AdLib& the();
+
+    // ^CharacterDevice
+    virtual ssize_t read(FileDescription&, u8*, ssize_t) override;
+    virtual bool can_read(FileDescription&) const override;
+    virtual ssize_t write(FileDescription&, const u8*, ssize_t) override;
+    virtual bool can_write(FileDescription&) const override;
+
+private:
+    // ^CharacterDevice
+    virtual const char* class_name() const override { return "AdLib"; }
+
+    void write_status(u8);
+    void write_data(u8);
+    void write_register(u8, u8);
+
+    u8 read_status();
+
+    bool detect();
+
+    bool detected = false;
+};

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -78,7 +78,8 @@ VFS_OBJS = \
     FileSystem/VirtualFileSystem.o \
     FileSystem/FileDescription.o \
     FileSystem/SyntheticFileSystem.o \
-    Devices/SB16.o
+    Devices/SB16.o \
+    Devices/AdLib.o
 
 AK_OBJS = \
     ../AK/String.o \

--- a/Kernel/build-root-filesystem.sh
+++ b/Kernel/build-root-filesystem.sh
@@ -39,6 +39,7 @@ mknod -m 666 mnt/dev/debuglog c 1 18
 mknod mnt/dev/keyboard c 85 1
 mknod mnt/dev/psaux c 10 1
 mknod -m 666 mnt/dev/audio c 42 42
+mknod -m 666 mnt/dev/adlib c 43 42
 mknod -m 666 mnt/dev/ptmx c 5 2
 ln -s /proc/self/fd/0 mnt/dev/stdin
 ln -s /proc/self/fd/1 mnt/dev/stdout

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -8,6 +8,7 @@
 #include <Kernel/Arch/i386/PIC.h>
 #include <Kernel/Arch/i386/PIT.h>
 #include <Kernel/CMOS.h>
+#include <Kernel/Devices/AdLib.h>
 #include <Kernel/Devices/BXVGADevice.h>
 #include <Kernel/Devices/DebugLogDevice.h>
 #include <Kernel/Devices/DiskPartition.h>
@@ -18,8 +19,8 @@
 #include <Kernel/Devices/MBRPartitionTable.h>
 #include <Kernel/Devices/NullDevice.h>
 #include <Kernel/Devices/PS2MouseDevice.h>
-#include <Kernel/Devices/SB16.h>
 #include <Kernel/Devices/RandomDevice.h>
+#include <Kernel/Devices/SB16.h>
 #include <Kernel/Devices/SerialDevice.h>
 #include <Kernel/Devices/ZeroDevice.h>
 #include <Kernel/FileSystem/DevPtsFS.h>
@@ -43,6 +44,7 @@ VirtualConsole* tty3;
 KeyboardDevice* keyboard;
 PS2MouseDevice* ps2mouse;
 SB16* sb16;
+AdLib* adlib;
 DebugLogDevice* dev_debuglog;
 NullDevice* dev_null;
 SerialDevice* ttyS0;
@@ -200,6 +202,7 @@ extern "C" [[noreturn]] void init()
     keyboard = new KeyboardDevice;
     ps2mouse = new PS2MouseDevice;
     sb16 = new SB16;
+    adlib = new AdLib;
     dev_null = new NullDevice;
     ttyS0 = new SerialDevice(SERIAL_COM1_ADDR, 64);
     ttyS1 = new SerialDevice(SERIAL_COM2_ADDR, 65);

--- a/Kernel/run
+++ b/Kernel/run
@@ -21,7 +21,8 @@ elif [ "$1" = "qn" ]; then
         -append "${SERENITY_KERNEL_CMDLINE}" \
         -hda _disk_image \
         -soundhw pcspk \
-        -soundhw sb16
+        -soundhw sb16 \
+        -soundhw adlib
 elif [ "$1" = "qtap" ]; then
     # ./run qtap: qemu with tap
     sudo $SERENITY_QEMU_BIN -s -m ${SERENITY_RAM_SIZE:-128} \
@@ -36,7 +37,8 @@ elif [ "$1" = "qtap" ]; then
         -append "${SERENITY_KERNEL_CMDLINE}" \
         -hda _disk_image \
         -soundhw pcspk \
-        -soundhw sb16
+        -soundhw sb16 \
+        -soundhw adlib
 elif [ "$1" = "qgrub" ]; then
     # ./run qgrub: qemu with grub
     $SERENITY_QEMU_BIN -s -m ${SERENITY_RAM_SIZE:-128} \
@@ -63,6 +65,7 @@ else
         -append "${SERENITY_KERNEL_CMDLINE}" \
         -hda _disk_image \
         -soundhw pcspk \
-        -soundhw sb16
+        -soundhw sb16 \
+        -soundhw adlib
 fi
 


### PR DESCRIPTION
A small and simple driver for a simple sound card.

I've created another device in `/dev/` for the AdLib, as it is
apparently a classic combination to have the SoundBlaster for
audio effects and the AdLib for music. There's no DMA on the
card (or an interrupt mind you....) so it's currently not
compatible with the `Piano` Application/SoundServer

Note that playing sounds is currently _VERY_ application dependent. From what
I can see, most games for the PC in the 80s/90s would write the
driver to play audio themselves. I'm not too comfortable with
playing around with the `AudioServer` code but I'm sure someone will
probably be able to get it to work :^)