### PR TITLE
TextEditorWidget: Fix nullptr refrence to save action & m_path

### DIFF
--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -29,20 +29,20 @@ TextEditorWidget::TextEditorWidget()
         statusbar->set_text(builder.to_string());
     };
 
-    auto new_action = GAction::create("New", { Mod_Ctrl, Key_N }, GraphicsBitmap::load_from_file("/res/icons/16x16/new.png"), [](const GAction&) {
+    m_new_action = GAction::create("New", { Mod_Ctrl, Key_N }, GraphicsBitmap::load_from_file("/res/icons/16x16/new.png"), [](const GAction&) {
         dbgprintf("FIXME: Implement File/New\n");
     });
 
-    auto open_action = GAction::create("Open...", { Mod_Ctrl, Key_O }, GraphicsBitmap::load_from_file("/res/icons/16x16/open.png"), [this](const GAction&) {
+    m_open_action = GAction::create("Open...", { Mod_Ctrl, Key_O }, GraphicsBitmap::load_from_file("/res/icons/16x16/open.png"), [this](const GAction&) {
         Optional<String> open_name = GFilePicker::get_open_filepath();
 
         if (!open_name.has_value())
             return;
 
-        open_sesame(m_path);
+        open_sesame(open_name.value());
     });
 
-    auto save_as_action = GAction::create("Save as...", { Mod_None, Key_F12 }, GraphicsBitmap::load_from_file("/res/icons/16x16/save.png"), [this](const GAction&) {
+    m_save_as_action = GAction::create("Save as...", { Mod_None, Key_F12 }, GraphicsBitmap::load_from_file("/res/icons/16x16/save.png"), [this](const GAction&) {
         Optional<String> save_name = GFilePicker::get_save_filepath();
         if (!save_name.has_value())
             return;
@@ -56,14 +56,14 @@ TextEditorWidget::TextEditorWidget()
         dbg() << "Wrote document to " << save_name.value();
     });
 
-    auto save_action = GAction::create("Save", { Mod_Ctrl, Key_S }, GraphicsBitmap::load_from_file("/res/icons/16x16/save.png"), [&](const GAction&) {
+    m_save_action = GAction::create("Save", { Mod_Ctrl, Key_S }, GraphicsBitmap::load_from_file("/res/icons/16x16/save.png"), [&](const GAction&) {
         if (!m_path.is_empty()) {
             if (!m_editor->write_to_file(m_path))
                 GMessageBox::show("Unable to save file.\n", "Error", GMessageBox::Type::Error, GMessageBox::InputType::OK, window());
             return;
         }
 
-        save_as_action->activate();
+        m_save_as_action->activate();
     });
 
     auto menubar = make<GMenuBar>();
@@ -75,10 +75,9 @@ TextEditorWidget::TextEditorWidget()
     menubar->add_menu(move(app_menu));
 
     auto file_menu = make<GMenu>("File");
-    file_menu->add_action(new_action);
-    file_menu->add_action(open_action);
-    file_menu->add_action(save_action);
-    file_menu->add_action(save_as_action);
+    file_menu->add_action(*m_new_action);
+    file_menu->add_action(*m_open_action);
+    file_menu->add_action(*m_save_action);
     menubar->add_menu(move(file_menu));
 
     auto edit_menu = make<GMenu>("Edit");
@@ -108,9 +107,9 @@ TextEditorWidget::TextEditorWidget()
 
     GApplication::the().set_menubar(move(menubar));
 
-    toolbar->add_action(move(new_action));
-    toolbar->add_action(move(open_action));
-    toolbar->add_action(move(save_action));
+    toolbar->add_action(*m_new_action);
+    toolbar->add_action(*m_open_action);
+    toolbar->add_action(*m_save_action);
 
     toolbar->add_separator();
 

--- a/Applications/TextEditor/TextEditorWidget.h
+++ b/Applications/TextEditor/TextEditorWidget.h
@@ -19,4 +19,8 @@ private:
 
     GTextEditor* m_editor { nullptr };
     String m_path;
+    RefPtr<GAction> m_new_action;
+    RefPtr<GAction> m_open_action;
+    RefPtr<GAction> m_save_action;
+    RefPtr<GAction> m_save_as_action;
 };


### PR DESCRIPTION
We forgot to include our action in the constructor to reference later, whoops.
Hope this is acceptable, saw the same thing being done in the irc client so fingers crossed.