### PR TITLE
PATA Driver supports multiple drives

### DIFF
--- a/Kernel/Devices/PATAChannel.h
+++ b/Kernel/Devices/PATAChannel.h
@@ -1,0 +1,72 @@
+//
+// Parallel ATA (PATA) controller driver
+//
+// This driver describes a logical PATA Channel. Each channel can connect up to 2
+// IDE Hard Disk Drives. The drives themselves can be either the master drive (hd0)
+// or the slave drive (hd1).
+//
+// More information about the ATA spec for PATA can be found here:
+//      ftp://ftp.seagate.com/acrobat/reference/111-1c.pdf
+//
+#pragma once
+
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <Kernel/IRQHandler.h>
+#include <Kernel/Lock.h>
+#include <Kernel/PCI.h>
+#include <Kernel/VM/PhysicalAddress.h>
+#include <Kernel/VM/PhysicalPage.h>
+
+struct PhysicalRegionDescriptor {
+    PhysicalAddress offset;
+    u16 size { 0 };
+    u16 end_of_table { 0 };
+};
+
+class PATADiskDevice;
+class PATAChannel final : public IRQHandler {
+    friend class PATADiskDevice;
+    AK_MAKE_ETERNAL
+public:
+    enum class ChannelType : u8 {
+        Primary,
+        Secondary
+    };
+
+public:
+    static OwnPtr<PATAChannel> create(ChannelType type);
+    explicit PATAChannel(ChannelType);
+    virtual ~PATAChannel() override;
+
+    RefPtr<PATADiskDevice> master_device() { return m_master; };
+    RefPtr<PATADiskDevice> slave_device() { return m_slave; };
+
+private:
+    //^ IRQHandler
+    virtual void handle_irq() override;
+
+    void initialize();
+    void detect_disks();
+
+    bool wait_for_irq();
+    bool ata_read_sectors_with_dma(u32, u16, u8*, bool);
+    bool ata_write_sectors_with_dma(u32, u16, const u8*, bool);
+    bool ata_read_sectors(u32, u16, u8*, bool);
+    bool ata_write_sectors(u32, u16, const u8*, bool);
+
+    // Data members
+    u8 m_channel_number { 0 }; // Channel number. 0 = master, 1 = slave
+    u16 m_io_base { 0x1F0 };
+    volatile u8 m_device_error { 0 };
+    volatile bool m_interrupted { false };
+
+    PCI::Address m_pci_address;
+    PhysicalRegionDescriptor m_prdt;
+    RefPtr<PhysicalPage> m_dma_buffer_page;
+    u16 m_bus_master_base { 0 };
+    Lockable<bool> m_dma_enabled;
+
+    RefPtr<PATADiskDevice> m_master;
+    RefPtr<PATADiskDevice> m_slave;
+};

--- a/Kernel/Devices/PATADiskDevice.cpp
+++ b/Kernel/Devices/PATADiskDevice.cpp
@@ -1,0 +1,164 @@
+#include "PATADiskDevice.h"
+#include <Kernel/Arch/i386/PIC.h>
+#include <Kernel/FileSystem/ProcFS.h>
+#include <Kernel/IO.h>
+#include <Kernel/Process.h>
+#include <Kernel/StdLib.h>
+#include <Kernel/VM/MemoryManager.h>
+
+//#define DISK_DEBUG
+
+#define IRQ_FIXED_DISK 14
+
+#define ATA_SR_BSY 0x80
+#define ATA_SR_DRDY 0x40
+#define ATA_SR_DF 0x20
+#define ATA_SR_DSC 0x10
+#define ATA_SR_DRQ 0x08
+#define ATA_SR_CORR 0x04
+#define ATA_SR_IDX 0x02
+#define ATA_SR_ERR 0x01
+
+#define ATA_ER_BBK 0x80
+#define ATA_ER_UNC 0x40
+#define ATA_ER_MC 0x20
+#define ATA_ER_IDNF 0x10
+#define ATA_ER_MCR 0x08
+#define ATA_ER_ABRT 0x04
+#define ATA_ER_TK0NF 0x02
+#define ATA_ER_AMNF 0x01
+
+#define ATA_CMD_READ_PIO 0x20
+#define ATA_CMD_READ_PIO_EXT 0x24
+#define ATA_CMD_READ_DMA 0xC8
+#define ATA_CMD_READ_DMA_EXT 0x25
+#define ATA_CMD_WRITE_PIO 0x30
+#define ATA_CMD_WRITE_PIO_EXT 0x34
+#define ATA_CMD_WRITE_DMA 0xCA
+#define ATA_CMD_WRITE_DMA_EXT 0x35
+#define ATA_CMD_CACHE_FLUSH 0xE7
+#define ATA_CMD_CACHE_FLUSH_EXT 0xEA
+#define ATA_CMD_PACKET 0xA0
+#define ATA_CMD_IDENTIFY_PACKET 0xA1
+#define ATA_CMD_IDENTIFY 0xEC
+
+#define ATAPI_CMD_READ 0xA8
+#define ATAPI_CMD_EJECT 0x1B
+
+#define ATA_IDENT_DEVICETYPE 0
+#define ATA_IDENT_CYLINDERS 2
+#define ATA_IDENT_HEADS 6
+#define ATA_IDENT_SECTORS 12
+#define ATA_IDENT_SERIAL 20
+#define ATA_IDENT_MODEL 54
+#define ATA_IDENT_CAPABILITIES 98
+#define ATA_IDENT_FIELDVALID 106
+#define ATA_IDENT_MAX_LBA 120
+#define ATA_IDENT_COMMANDSETS 164
+#define ATA_IDENT_MAX_LBA_EXT 200
+
+#define IDE_ATA 0x00
+#define IDE_ATAPI 0x01
+
+#define ATA_REG_DATA 0x00
+#define ATA_REG_ERROR 0x01
+#define ATA_REG_FEATURES 0x01
+#define ATA_REG_SECCOUNT0 0x02
+#define ATA_REG_LBA0 0x03
+#define ATA_REG_LBA1 0x04
+#define ATA_REG_LBA2 0x05
+#define ATA_REG_HDDEVSEL 0x06
+#define ATA_REG_COMMAND 0x07
+#define ATA_REG_STATUS 0x07
+#define ATA_REG_SECCOUNT1 0x08
+#define ATA_REG_LBA3 0x09
+#define ATA_REG_LBA4 0x0A
+#define ATA_REG_LBA5 0x0B
+#define ATA_REG_CONTROL 0x0C
+#define ATA_REG_ALTSTATUS 0x0C
+#define ATA_REG_DEVADDRESS 0x0D
+
+NonnullRefPtr<PATADiskDevice> PATADiskDevice::create(PATAChannel& channel, DriveType type)
+{
+    return adopt(*new PATADiskDevice(channel, type));
+}
+
+PATADiskDevice::PATADiskDevice(PATAChannel& channel, DriveType type)
+    : m_drive_type(type)
+    , m_channel(channel)
+{
+}
+
+PATADiskDevice::~PATADiskDevice()
+{
+}
+
+const char* PATADiskDevice::class_name() const
+{
+    return "PATADiskDevice";
+}
+
+unsigned PATADiskDevice::block_size() const
+{
+    return 512;
+}
+
+bool PATADiskDevice::read_blocks(unsigned index, u16 count, u8* out)
+{
+    if (m_channel.m_bus_master_base && m_channel.m_dma_enabled.resource())
+        return read_sectors_with_dma(index, count, out);
+    return read_sectors(index, count, out);
+}
+
+bool PATADiskDevice::read_block(unsigned index, u8* out) const
+{
+    return const_cast<PATADiskDevice*>(this)->read_blocks(index, 1, out);
+}
+
+bool PATADiskDevice::write_blocks(unsigned index, u16 count, const u8* data)
+{
+    if (m_channel.m_bus_master_base && m_channel.m_dma_enabled.resource())
+        return write_sectors_with_dma(index, count, data);
+    for (unsigned i = 0; i < count; ++i) {
+        if (!write_sectors(index + i, 1, data + i * 512))
+            return false;
+    }
+    return true;
+}
+
+bool PATADiskDevice::write_block(unsigned index, const u8* data)
+{
+    return write_blocks(index, 1, data);
+}
+
+void PATADiskDevice::set_drive_geometry(u16 cyls, u16 heads, u16 spt)
+{
+    m_cylinders = cyls;
+    m_heads = heads;
+    m_sectors_per_track = spt;
+}
+
+bool PATADiskDevice::read_sectors_with_dma(u32 lba, u16 count, u8* outbuf)
+{
+    return m_channel.ata_read_sectors_with_dma(lba, count, outbuf, is_slave());
+}
+
+bool PATADiskDevice::read_sectors(u32 start_sector, u16 count, u8* outbuf)
+{
+    return m_channel.ata_read_sectors(start_sector, count, outbuf, is_slave());
+}
+
+bool PATADiskDevice::write_sectors_with_dma(u32 lba, u16 count, const u8* inbuf)
+{
+    return m_channel.ata_write_sectors_with_dma(lba, count, inbuf, is_slave());
+}
+
+bool PATADiskDevice::write_sectors(u32 start_sector, u16 count, const u8* inbuf)
+{
+    return m_channel.ata_write_sectors(start_sector, count, inbuf, is_slave());
+}
+
+bool PATADiskDevice::is_slave() const
+{
+    return m_drive_type == DriveType::Slave;
+}

--- a/Kernel/Devices/PATADiskDevice.h
+++ b/Kernel/Devices/PATADiskDevice.h
@@ -1,36 +1,33 @@
+//
+// A Disk Device Connected to a PATA Channel
+//
+//
 #pragma once
 
 #include <AK/RefPtr.h>
 #include <Kernel/Devices/DiskDevice.h>
+#include <Kernel/Devices/PATAChannel.h>
 #include <Kernel/IRQHandler.h>
 #include <Kernel/Lock.h>
 #include <Kernel/PCI.h>
 #include <Kernel/VM/PhysicalAddress.h>
 #include <Kernel/VM/PhysicalPage.h>
 
-struct PhysicalRegionDescriptor {
-    PhysicalAddress offset;
-    u16 size { 0 };
-    u16 end_of_table { 0 };
-};
-
-class IDEDiskDevice final : public IRQHandler
-    , public DiskDevice {
+class PATADiskDevice final : public DiskDevice {
     AK_MAKE_ETERNAL
 public:
-
     // Type of drive this IDEDiskDevice is on the ATA channel.
     //
     // Each PATA channel can contain only two devices, which (I think) are
     // jumper selectable on the drive itself by shorting two pins.
     enum class DriveType : u8 {
-        MASTER,
-        SLAVE
+        Master,
+        Slave
     };
 
 public:
-    static NonnullRefPtr<IDEDiskDevice> create(DriveType type);
-    virtual ~IDEDiskDevice() override;
+    static NonnullRefPtr<PATADiskDevice> create(PATAChannel&, DriveType);
+    virtual ~PATADiskDevice() override;
 
     // ^DiskDevice
     virtual unsigned block_size() const override;
@@ -39,37 +36,27 @@ public:
     virtual bool read_blocks(unsigned index, u16 count, u8*) override;
     virtual bool write_blocks(unsigned index, u16 count, const u8*) override;
 
+    void set_drive_geometry(u16, u16, u16);
+
 protected:
-    explicit IDEDiskDevice(DriveType);
+    explicit PATADiskDevice(PATAChannel&, DriveType);
 
 private:
-    // ^IRQHandler
-    virtual void handle_irq() override;
-
     // ^DiskDevice
     virtual const char* class_name() const override;
 
-    void initialize();
     bool wait_for_irq();
     bool read_sectors_with_dma(u32 lba, u16 count, u8*);
     bool write_sectors_with_dma(u32 lba, u16 count, const u8*);
     bool read_sectors(u32 lba, u16 count, u8* buffer);
     bool write_sectors(u32 lba, u16 count, const u8* data);
-
     bool is_slave() const;
 
     Lock m_lock { "IDEDiskDevice" };
     u16 m_cylinders { 0 };
     u16 m_heads { 0 };
     u16 m_sectors_per_track { 0 };
-    u16 m_io_base { 0 };
-    volatile bool m_interrupted { false };
-    volatile u8 m_device_error { 0 };
+    DriveType m_drive_type { DriveType::Master };
 
-    DriveType m_drive_type { DriveType::MASTER };
-    PCI::Address m_pci_address;
-    PhysicalRegionDescriptor m_prdt;
-    RefPtr<PhysicalPage> m_dma_buffer_page;
-    u16 m_bus_master_base { 0 };
-    Lockable<bool> m_dma_enabled;
+    PATAChannel& m_channel;
 };

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -13,7 +13,8 @@ KERNEL_OBJS = \
        CMOS.o \
        Arch/i386/PIC.o \
        Syscall.o \
-       Devices/IDEDiskDevice.o \
+       Devices/PATAChannel.o \
+       Devices/PATADiskDevice.o \
        Devices/FloppyDiskDevice.o \
        VM/MemoryManager.o \
        VM/Region.o \

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -1,3 +1,4 @@
+#include "Devices/PATADiskDevice.h"
 #include "KSyms.h"
 #include "Process.h"
 #include "RTC.h"
@@ -13,13 +14,13 @@
 #include <Kernel/Devices/DiskPartition.h>
 #include <Kernel/Devices/FloppyDiskDevice.h>
 #include <Kernel/Devices/FullDevice.h>
-#include <Kernel/Devices/IDEDiskDevice.h>
 #include <Kernel/Devices/KeyboardDevice.h>
 #include <Kernel/Devices/MBRPartitionTable.h>
 #include <Kernel/Devices/NullDevice.h>
+#include <Kernel/Devices/PATAChannel.h>
 #include <Kernel/Devices/PS2MouseDevice.h>
-#include <Kernel/Devices/SB16.h>
 #include <Kernel/Devices/RandomDevice.h>
+#include <Kernel/Devices/SB16.h>
 #include <Kernel/Devices/SerialDevice.h>
 #include <Kernel/Devices/ZeroDevice.h>
 #include <Kernel/FileSystem/DevPtsFS.h>
@@ -68,9 +69,8 @@ VFS* vfs;
         hang();
     }
 
-    auto dev_hd0 = IDEDiskDevice::create(IDEDiskDevice::DriveType::MASTER);
-
-    NonnullRefPtr<DiskDevice> root_dev = dev_hd0;
+    auto pata0 = PATAChannel::create(PATAChannel::ChannelType::Primary);
+    NonnullRefPtr<DiskDevice> root_dev = *pata0->master_device();
 
     root = root.substring(strlen("/dev/hda"), root.length() - strlen("/dev/hda"));
 


### PR DESCRIPTION
The previous implementation of the PIIX3/4 PATA/IDE channel driver
only supported a single drive, as the object model was wrong (the channel
inherits the IRQ, not the disk drive itself). This fixes
it by 'attaching' two `PATADiskDevices` to a `PATAChannel`, which
makes more sense.

The reading/writing code is presented as is, which (somewhat) violates the
spec outlined by Seagate in the linked datasheet. That spec
is rather old, so it might not be 100% up to date, though may cause
issues on real hardware, so until we can actually test it, this will
suffice.