### PR TITLE
RFC: Compile-assisted error handling

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <AK/Platform.h>
+
+namespace AK {
+
+template <typename T, auto NoErrorValue>
+class CONSUMABLE(unknown) Error {
+public:
+    RETURN_TYPESTATE(unknown)
+    Error()
+        : t(NoErrorValue)
+    {}
+
+    RETURN_TYPESTATE(unknown)
+    Error(T t)
+        : t(t)
+    {}
+
+    RETURN_TYPESTATE(unknown)
+    Error(Error&& other)
+        : t(move(other.t))
+    {
+    }
+
+    RETURN_TYPESTATE(unknown)
+    Error(const Error& other)
+        : t(other.t)
+    {
+    }
+
+    CALLABLE_WHEN("unknown", "consumed")
+    ~Error() {}
+
+    SET_TYPESTATE(consumed)
+    bool failed() const {
+        return t != NoErrorValue;
+    }
+
+    [[deprecated]]
+    SET_TYPESTATE(consumed)
+    void ignore() {}
+
+    const T& value() const { return t; }
+
+    bool operator==(const Error& o) { return t == o.t; }
+    bool operator!=(const Error& o) { return t != o.t; }
+    T t;
+};
+
+}
+
+using AK::Error;

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -1,12 +1,15 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Platform.h>
 
 template<typename T>
-class alignas(T) Optional {
+class CONSUMABLE(unknown) alignas(T) Optional {
 public:
+    RETURN_TYPESTATE(unknown)
     Optional() {}
 
+    RETURN_TYPESTATE(unknown)
     Optional(T&& value)
         : m_has_value(true)
     {
@@ -14,29 +17,33 @@ public:
     }
 
     template<typename U>
+    RETURN_TYPESTATE(unknown)
     Optional(U&& value)
         : m_has_value(true)
     {
         new (&m_storage) T(move(value));
     }
 
+    RETURN_TYPESTATE(unknown)
     Optional(Optional&& other)
         : m_has_value(other.m_has_value)
     {
         if (m_has_value) {
-            new (&m_storage) T(move(other.value()));
+            new (&m_storage) T(move(other.value_without_consume_state()));
             other.m_has_value = false;
         }
     }
 
+    RETURN_TYPESTATE(unknown)
     Optional(const Optional& other)
         : m_has_value(other.m_has_value)
     {
         if (m_has_value) {
-            new (&m_storage) T(other.value());
+            new (&m_storage) T(other.value_without_consume_state());
         }
     }
 
+    RETURN_TYPESTATE(unknown)
     Optional& operator=(const Optional& other)
     {
         if (this != &other) {
@@ -49,6 +56,7 @@ public:
         return *this;
     }
 
+    RETURN_TYPESTATE(unknown)
     Optional& operator=(Optional&& other)
     {
         if (this != &other) {
@@ -74,20 +82,23 @@ public:
         }
     }
 
+    SET_TYPESTATE(consumed)
     bool has_value() const { return m_has_value; }
 
+    CALLABLE_WHEN(consumed)
     T& value()
     {
         ASSERT(m_has_value);
         return *reinterpret_cast<T*>(&m_storage);
     }
 
+    CALLABLE_WHEN(consumed)
     const T& value() const
     {
-        ASSERT(m_has_value);
-        return *reinterpret_cast<const T*>(&m_storage);
+        return value_without_consume_state();
     }
 
+    CALLABLE_WHEN(consumed)
     T release_value()
     {
         ASSERT(m_has_value);
@@ -98,14 +109,20 @@ public:
 
     T value_or(const T& fallback) const
     {
-        if (has_value())
+        if (m_has_value)
             return value();
         return fallback;
     }
 
-    operator bool() const { return has_value(); }
+    operator bool() const { return m_has_value; }
 
 private:
+    // Call when we don't want to alter the consume state
+    const T& value_without_consume_state() const
+    {
+        ASSERT(m_has_value);
+        return *reinterpret_cast<const T*>(&m_storage);
+    }
     char m_storage[sizeof(T)];
     bool m_has_value { false };
 };

--- a/AK/Result.h
+++ b/AK/Result.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/Platform.h>
+#include <AK/Optional.h>
+
+namespace AK {
+
+template<typename T, typename E>
+class CONSUMABLE(unknown) Result {
+public:
+    RETURN_TYPESTATE(unknown)
+    Result(const T& res)
+        : m_result(res)
+    {}
+
+    RETURN_TYPESTATE(unknown)
+    Result(const E& error)
+        : m_error(error)
+    {
+    }
+
+    RETURN_TYPESTATE(unknown)
+    Result(const T& res, const E& error)
+        : m_result(res)
+        , m_error(error)
+    {
+    }
+
+    RETURN_TYPESTATE(unknown)
+    Result(Result&& other)
+        : m_result(move(other.m_result))
+        , m_error(move(other.m_error))
+    {
+    }
+
+    RETURN_TYPESTATE(unknown)
+    Result(Result& other)
+        : m_result(other.m_result)
+        , m_error(other.m_error)
+    {
+    }
+
+    CALLABLE_WHEN("unknown", "consumed")
+    ~Result()
+    {}
+
+    CALLABLE_WHEN(consumed)
+    T& unwrap() {
+        return m_result.value();
+    }
+
+    CALLABLE_WHEN(consumed)
+    E& error() {
+        return m_error.value();
+    }
+
+    bool has_error() const {
+        return m_error.has_value();
+    }
+    bool has_value() const {
+        return m_result.has_value();
+    }
+
+    SET_TYPESTATE(consumed)
+    bool failed() const {
+        return m_error.value().failed();
+    }
+
+private:
+    Optional<T> m_result;
+    Optional<E> m_error;
+};
+
+}
+
+using AK::Result;
+


### PR DESCRIPTION
# Error\<T\>

Add an Error\<T, noerror\> template that can be used to communicate whether a call succeeded or failed, and port CIODevice::open() to it as a first test.

It's annotated with consumable attributes so that if you fail to check an error, you get a -Wconsumed warning under clang. For the simple case, this is similar to [[nodiscard]], but the added benefit is that you can also communicate _what_ the error was for handling more complex (non-boolean) cases too.

---

# Result\<T, E\>

Also add a Result template building on top of Error. The idea is that Result communicates both the _data_ of a function call, _or_ the error that occurred during that call. Similarly to Error, Result uses consumed attributes to enforce checking for errors rather than just blindly accessing the data.

In porting CIODevice::read to use this in just LibCore, I already found a number of places where errors have been silently ignored rather than propagated in the correct way. Take CIODevice::read(u8, int) -- it was reading a ByteBuffer, and copying the result into the u8 buffer, which meant that the caller had no way of knowing whether a 0-size return was EOF, or due to an error.

Now, we can pass that information upwards, and be ensured that it is being used properly.

---

TODO:

* clang-format
* fix the rest of serenity against LibCore
* sanity-check the implementation, I've been a bit distracted :)