### PR TITLE
FileManager: Show home directory by default, or command line argument

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -222,7 +222,23 @@ int main(int argc, char** argv)
         progressbar->set_visible(true);
     };
 
-    directory_view->open("/");
+    // our initial location is defined as, in order of precedence:
+    // 1. the first command-line argument (e.g. FileManager /bin)
+    // 2. the user's home directory
+    // 3. the root directory
+
+    String initial_location;
+
+    if (argc >= 2)
+        initial_location = argv[1];
+
+    if (initial_location.is_empty())
+        initial_location = get_current_user_home_path();
+
+    if (initial_location.is_empty())
+        initial_location = "/";
+
+    directory_view->open(initial_location);
     directory_view->set_focus(true);
 
     window->set_main_widget(widget);

--- a/Libraries/LibGUI/GFileSystemModel.cpp
+++ b/Libraries/LibGUI/GFileSystemModel.cpp
@@ -107,6 +107,7 @@ GModelIndex GFileSystemModel::index(const StringView& path) const
         bool found = false;
         for (auto& child : node->children) {
             if (child->name == part) {
+                child->reify_if_needed(*this);
                 node = child;
                 found = true;
                 if (i == canonical_path.parts().size() - 1)


### PR DESCRIPTION
FileManager used to open up with the root directory loaded by default.
Now it will try to load either 1) the first argument specified on the
command line, 2) the user's home directory, or 3) the root directory.

To support this feature, a small change was introduced to
GFileSystemModel, allowing it to resolve deeply-nested paths.

Fixes #389