### PR TITLE
Mount system call

### DIFF
--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -25,6 +25,7 @@ public:
     uid_t gid() const { return m_gid; }
 
     virtual bool is_device() const override { return true; }
+    virtual bool is_disk_device() const { return false; }
 
 protected:
     Device(unsigned major, unsigned minor);

--- a/Kernel/Devices/DiskDevice.cpp
+++ b/Kernel/Devices/DiskDevice.cpp
@@ -1,6 +1,7 @@
 #include <Kernel/Devices/DiskDevice.h>
 
-DiskDevice::DiskDevice()
+DiskDevice::DiskDevice(int major, int minor)
+    : BlockDevice(major, minor)
 {
 }
 

--- a/Kernel/Devices/DiskDevice.h
+++ b/Kernel/Devices/DiskDevice.h
@@ -2,11 +2,12 @@
 
 #include <AK/RefCounted.h>
 #include <AK/Types.h>
+#include <Kernel/Devices/BlockDevice.h>
 
 // FIXME: Support 64-bit DiskOffset
 typedef u32 DiskOffset;
 
-class DiskDevice : public RefCounted<DiskDevice> {
+class DiskDevice : public BlockDevice {
 public:
     virtual ~DiskDevice();
 
@@ -20,6 +21,8 @@ public:
     virtual bool read_blocks(unsigned index, u16 count, u8*) = 0;
     virtual bool write_blocks(unsigned index, u16 count, const u8*) = 0;
 
+    virtual bool is_disk_device() const override { return true; };
+
 protected:
-    DiskDevice();
+    DiskDevice(int major, int minor);
 };

--- a/Kernel/Devices/DiskPartition.cpp
+++ b/Kernel/Devices/DiskPartition.cpp
@@ -8,7 +8,8 @@ NonnullRefPtr<DiskPartition> DiskPartition::create(NonnullRefPtr<DiskDevice> dev
 }
 
 DiskPartition::DiskPartition(NonnullRefPtr<DiskDevice> device, unsigned block_offset)
-    : m_device(move(device))
+    : DiskDevice(100, 0)
+    , m_device(move(device))
     , m_block_offset(block_offset)
 {
 }

--- a/Kernel/Devices/DiskPartition.h
+++ b/Kernel/Devices/DiskPartition.h
@@ -14,6 +14,12 @@ public:
     virtual bool read_blocks(unsigned index, u16 count, u8*) override;
     virtual bool write_blocks(unsigned index, u16 count, const u8*) override;
 
+    // ^BlockDevice
+    virtual ssize_t read(FileDescription&, u8*, ssize_t) override { return 0; }
+    virtual bool can_read(FileDescription&) const override { return true; }
+    virtual ssize_t write(FileDescription&, const u8*, ssize_t) override { return 0; }
+    virtual bool can_write(FileDescription&) const override { return true; }
+
 private:
     virtual const char* class_name() const override;
 

--- a/Kernel/Devices/FloppyDiskDevice.cpp
+++ b/Kernel/Devices/FloppyDiskDevice.cpp
@@ -84,6 +84,7 @@ const char* FloppyDiskDevice::class_name() const
 
 FloppyDiskDevice::FloppyDiskDevice(FloppyDiskDevice::DriveType type)
     : IRQHandler(IRQ_FLOPPY_DRIVE)
+    , DiskDevice(89, (type == FloppyDiskDevice::DriveType::Master) ? 0 : 1)
     , m_io_base_addr((type == FloppyDiskDevice::DriveType::Master) ? 0x3F0 : 0x370)
 {
     initialize();

--- a/Kernel/Devices/FloppyDiskDevice.h
+++ b/Kernel/Devices/FloppyDiskDevice.h
@@ -132,7 +132,7 @@ private:
     };
 
 public:
-    static NonnullRefPtr<FloppyDiskDevice> create(DriveType type);
+    static NonnullRefPtr<FloppyDiskDevice> create(DriveType);
     virtual ~FloppyDiskDevice() override;
 
     // ^DiskDevice
@@ -141,6 +141,12 @@ public:
     virtual bool write_block(unsigned index, const u8*) override;
     virtual bool read_blocks(unsigned index, u16 count, u8*) override;
     virtual bool write_blocks(unsigned index, u16 count, const u8*) override;
+
+    // ^BlockDevice
+    virtual ssize_t read(FileDescription&, u8*, ssize_t) override { return 0; }
+    virtual bool can_read(FileDescription&) const override { return true; }
+    virtual ssize_t write(FileDescription&, const u8*, ssize_t) override { return 0; }
+    virtual bool can_write(FileDescription&) const override { return true; }
 
 protected:
     explicit FloppyDiskDevice(DriveType);

--- a/Kernel/Devices/PATAChannel.cpp
+++ b/Kernel/Devices/PATAChannel.cpp
@@ -236,11 +236,12 @@ void PATAChannel::detect_disks()
             heads,
             spt);
 
+        int major = (m_channel_number == 0) ? 3 : 4;
         if (i == 0) {
-            m_master = PATADiskDevice::create(*this, PATADiskDevice::DriveType::Master);
+            m_master = PATADiskDevice::create(*this, PATADiskDevice::DriveType::Master, major, 0);
             m_master->set_drive_geometry(cyls, heads, spt);
         } else {
-            m_slave = PATADiskDevice::create(*this, PATADiskDevice::DriveType::Slave);
+            m_slave = PATADiskDevice::create(*this, PATADiskDevice::DriveType::Slave, major, 1);
             m_slave->set_drive_geometry(cyls, heads, spt);
         }
     }

--- a/Kernel/Devices/PATADiskDevice.cpp
+++ b/Kernel/Devices/PATADiskDevice.cpp
@@ -78,13 +78,14 @@
 #define ATA_REG_ALTSTATUS 0x0C
 #define ATA_REG_DEVADDRESS 0x0D
 
-NonnullRefPtr<PATADiskDevice> PATADiskDevice::create(PATAChannel& channel, DriveType type)
+NonnullRefPtr<PATADiskDevice> PATADiskDevice::create(PATAChannel& channel, DriveType type, int major, int minor)
 {
-    return adopt(*new PATADiskDevice(channel, type));
+    return adopt(*new PATADiskDevice(channel, type, major, minor));
 }
 
-PATADiskDevice::PATADiskDevice(PATAChannel& channel, DriveType type)
-    : m_drive_type(type)
+PATADiskDevice::PATADiskDevice(PATAChannel& channel, DriveType type, int major, int minor)
+    : DiskDevice(major, minor)
+    , m_drive_type(type)
     , m_channel(channel)
 {
 }

--- a/Kernel/Devices/PATADiskDevice.h
+++ b/Kernel/Devices/PATADiskDevice.h
@@ -26,7 +26,7 @@ public:
     };
 
 public:
-    static NonnullRefPtr<PATADiskDevice> create(PATAChannel&, DriveType);
+    static NonnullRefPtr<PATADiskDevice> create(PATAChannel&, DriveType, int major, int minor);
     virtual ~PATADiskDevice() override;
 
     // ^DiskDevice
@@ -38,8 +38,14 @@ public:
 
     void set_drive_geometry(u16, u16, u16);
 
+    // ^BlockDevice
+    virtual ssize_t read(FileDescription&, u8*, ssize_t) override { return 0; }
+    virtual bool can_read(FileDescription&) const override { return true; }
+    virtual ssize_t write(FileDescription&, const u8*, ssize_t) override { return 0; }
+    virtual bool can_write(FileDescription&) const override { return true; }
+
 protected:
-    explicit PATADiskDevice(PATAChannel&, DriveType);
+    explicit PATADiskDevice(PATAChannel&, DriveType, int, int);
 
 private:
     // ^DiskDevice

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -183,6 +183,7 @@ public:
     int sys$unlink(const char* pathname);
     int sys$symlink(const char* target, const char* linkpath);
     int sys$rmdir(const char* pathname);
+    int sys$mount(const char* device, const char* mountpoint);
     int sys$read_tsc(u32* lsw, u32* msw);
     int sys$chmod(const char* pathname, mode_t);
     int sys$fchmod(int fd, mode_t);

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -292,6 +292,8 @@ static u32 handle(RegisterDump& regs, u32 function, u32 arg1, u32 arg2, u32 arg3
         return current->process().sys$halt();
         break;
     }
+    case Syscall::SC_mount:
+        return current->process().sys$mount((const char*)arg1, (const char*)arg2);
     case Syscall::SC_reboot: {
         return current->process().sys$reboot();
     }

--- a/Kernel/Syscall.h
+++ b/Kernel/Syscall.h
@@ -116,6 +116,7 @@ struct timeval;
     __ENUMERATE_SYSCALL(fchown)                 \
     __ENUMERATE_SYSCALL(halt)                   \
     __ENUMERATE_SYSCALL(reboot)                 \
+    __ENUMERATE_SYSCALL(mount)                  \
     __ENUMERATE_SYSCALL(dump_backtrace)         \
     __ENUMERATE_SYSCALL(dbgputch)               \
     __ENUMERATE_SYSCALL(dbgputstr)              \

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -546,6 +546,12 @@ int reboot()
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+int mount(const char* device, const char* mountpoint)
+{
+    int rc = syscall(SC_mount, device, mountpoint);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
 void dump_backtrace()
 {
     syscall(SC_dump_backtrace);

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -98,6 +98,7 @@ int fchown(int fd, uid_t, gid_t);
 int ftruncate(int fd, off_t length);
 int halt();
 int reboot();
+int mount(const char* device, const char* mountpoint);
 
 enum {
     _PC_NAME_MAX,

--- a/Userland/mount.cpp
+++ b/Userland/mount.cpp
@@ -1,0 +1,29 @@
+#include <LibCore/CArgsParser.h>
+#include <stdio.h>
+#include <unistd.h>
+
+// This version of 'mount' must have the following arguments
+// 'mount <device_path> <mount_point>
+// It can currently only mount _physical_ devices found in /dev
+//
+// Currently, it is only possible to mount ext2 devices. Sorry! :^)
+int main(int argc, char** argv)
+{
+    CArgsParser args_parser("mount");
+    args_parser.add_arg("devname", "device path");
+    args_parser.add_arg("mountpoint", "mount point");
+    CArgsParserResult args = args_parser.parse(argc, argv);
+
+    if (argc == 3) {
+        // Let's use lstat so we can convert devname into a major/minor device pair!
+        if (mount(argv[1], argv[2]) < 0) {
+            perror("mount");
+            return 1;
+        }
+    } else {
+        args_parser.print_usage();
+        return 0;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
It is now possible to mount ext2 `DiskDevice` devices under serenity to any
folder on the root filesystem. Currently any user can do this with any
permissions. There's a fair amount of assumptions made here too, that might
not be too good, but can be worked on in the future. This is a good start
to allow more dynamic operation under the OS itself.

It is also currently impossible to unmount and such, and devices will
fail to mount in Linux as the FS 'needs to be cleaned'. I'll work
on getting `umount` done ASAP to rectify this (as well as working
on less assumption making in the mount syscall. We don't want to
just be able to mount DiskDevices!). This could probably be fixed
with some `-t` flag or something similar.