### PR TITLE
Ports: mbedtls

### DIFF
--- a/Ports/mbedtls/add-missing-includes.patch
+++ b/Ports/mbedtls/add-missing-includes.patch
@@ -1,0 +1,22 @@
+diff -u -r mbedtls/library/ssl_tls.c mbedtls-patched/library/ssl_tls.c
+--- mbedtls/library/ssl_tls.c	2019-06-18 23:23:28.000000000 +1000
++++ mbedtls-patched/library/ssl_tls.c	2019-08-05 00:36:37.049255960 +1000
+@@ -49,6 +49,7 @@
+ #include "mbedtls/platform_util.h"
+ 
+ #include <string.h>
++#include <stdint.h>
+ 
+ #if defined(MBEDTLS_X509_CRT_PARSE_C)
+ #include "mbedtls/oid.h"
+diff -u -r mbedtls/library/x509_crt.c mbedtls-patched/library/x509_crt.c
+--- mbedtls/library/x509_crt.c	2019-06-18 23:23:28.000000000 +1000
++++ mbedtls-patched/library/x509_crt.c	2019-08-05 00:24:22.606023827 +1000
+@@ -75,6 +75,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <dirent.h>
++#include <unistd.h>
+ #endif /* !_WIN32 || EFIX64 || EFI32 */
+ #endif
+ 

--- a/Ports/mbedtls/mbedtls.sh
+++ b/Ports/mbedtls/mbedtls.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+PORT_DIR=mbedtls
+
+fetch() {
+    run_fetch_web "https://tls.mbed.org/download/mbedtls-2.16.2-apache.tgz"
+    run_patch remove-net-from-config.patch -p1
+    run_patch add-missing-includes.patch -p1
+}
+
+configure() {
+    echo "move along, nothing to see here"
+}
+
+build() {
+    run_export_env CC i686-pc-serenity-gcc
+    run_make clean
+    run_make CFLAGS=-DPLATFORM_UTIL_USE_GMTIME
+}
+
+install() {
+    run_make_install DESTDIR="$SERENITY_ROOT"/Root
+}
+
+. ../.port_include.sh

--- a/Ports/mbedtls/remove-net-from-config.patch
+++ b/Ports/mbedtls/remove-net-from-config.patch
@@ -1,0 +1,12 @@
+diff -u -r mbedtls/include/mbedtls/config.h mbedtls-patched/include/mbedtls/config.h
+--- mbedtls/include/mbedtls/config.h	2019-06-18 23:23:28.000000000 +1000
++++ mbedtls-patched/include/mbedtls/config.h	2019-08-05 00:27:17.322830039 +1000
+@@ -2460,7 +2460,7 @@
+  *
+  * This module provides networking routines.
+  */
+-#define MBEDTLS_NET_C
++//#define MBEDTLS_NET_C
+ 
+ /**
+  * \def MBEDTLS_OID_C


### PR DESCRIPTION
This is a very basic mbedtls port. I've disabled the networking bits,
since they want some macros that we don't have defined. We might not even
want the networking functions anyway, since they wouldn't play very nice
with CEventLoop and friends.