### PR TITLE
LibC: Define SIZE_MAX

### DIFF
--- a/Libraries/LibC/stdint.h
+++ b/Libraries/LibC/stdint.h
@@ -104,4 +104,6 @@ typedef __INTMAX_TYPE__ intmax_t;
 #define INT64_C(x) x##LL
 #define UINT64_C(x) x##ULL
 
+#define SIZE_MAX ((size_t)-1)
+
 __END_DECLS


### PR DESCRIPTION
According to the internet, this is a safe way to define SIZE_MAX. There
may be a better way to do it, but this worked for me.