### PR TITLE
FD shaving

### DIFF
--- a/AK/MappedFile.cpp
+++ b/AK/MappedFile.cpp
@@ -13,21 +13,26 @@ namespace AK {
 MappedFile::MappedFile(const StringView& file_name)
 {
     m_size = PAGE_SIZE;
-    m_fd = open_with_path_length(file_name.characters_without_null_termination(), file_name.length(), O_RDONLY | O_CLOEXEC, 0);
+    int fd = open_with_path_length(file_name.characters_without_null_termination(), file_name.length(), O_RDONLY | O_CLOEXEC, 0);
 
-    if (m_fd != -1) {
-        struct stat st;
-        fstat(m_fd, &st);
-        m_size = st.st_size;
-        m_map = mmap(nullptr, m_size, PROT_READ, MAP_SHARED, m_fd, 0);
-
-        if (m_map == MAP_FAILED)
-            perror("");
+    if (fd == -1) {
+        perror("open");
+        return;
     }
 
+    struct stat st;
+    fstat(fd, &st);
+    m_size = st.st_size;
+    m_map = mmap(nullptr, m_size, PROT_READ, MAP_SHARED, fd, 0);
+
+    if (m_map == MAP_FAILED)
+        perror("mmap");
+
 #ifdef DEBUG_MAPPED_FILE
-    dbgprintf("MappedFile{%s} := { m_fd=%d, m_size=%u, m_map=%p }\n", file_name.characters(), m_fd, m_size, m_map);
+    dbgprintf("MappedFile{%s} := { fd=%d, m_size=%u, m_map=%p }\n", file_name.characters(), fd, m_size, m_map);
 #endif
+
+    close(fd);
 }
 
 MappedFile::~MappedFile()
@@ -39,23 +44,17 @@ void MappedFile::unmap()
 {
     if (!is_valid())
         return;
-    ASSERT(m_fd != -1);
     int rc = munmap(m_map, m_size);
     ASSERT(rc == 0);
-    rc = close(m_fd);
-    ASSERT(rc == 0);
     m_size = 0;
-    m_fd = -1;
     m_map = (void*)-1;
 }
 
 MappedFile::MappedFile(MappedFile&& other)
     : m_size(other.m_size)
-    , m_fd(other.m_fd)
     , m_map(other.m_map)
 {
     other.m_size = 0;
-    other.m_fd = -1;
     other.m_map = (void*)-1;
 }
 
@@ -65,7 +64,6 @@ MappedFile& MappedFile::operator=(MappedFile&& other)
         return *this;
     unmap();
     swap(m_size, other.m_size);
-    swap(m_fd, other.m_fd);
     swap(m_map, other.m_map);
     return *this;
 }

--- a/AK/MappedFile.h
+++ b/AK/MappedFile.h
@@ -24,7 +24,6 @@ public:
 
 private:
     size_t m_size { 0 };
-    int m_fd { -1 };
     void* m_map { (void*)-1 };
 };
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -168,7 +168,7 @@ public:
     int sys$sigpending(sigset_t*);
     int sys$getgroups(ssize_t, gid_t*);
     int sys$setgroups(ssize_t, const gid_t*);
-    int sys$pipe(int* pipefd);
+    int sys$pipe(int pipefd[2], int flags);
     int sys$killpg(int pgrp, int sig);
     int sys$setgid(gid_t);
     int sys$setuid(uid_t);

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -189,7 +189,7 @@ static u32 handle(RegisterDump& regs, u32 function, u32 arg1, u32 arg2, u32 arg3
     case Syscall::SC_sigprocmask:
         return current->process().sys$sigprocmask((int)arg1, (const sigset_t*)arg2, (sigset_t*)arg3);
     case Syscall::SC_pipe:
-        return current->process().sys$pipe((int*)arg1);
+        return current->process().sys$pipe((int*)arg1, (int) arg2);
     case Syscall::SC_killpg:
         return current->process().sys$killpg((int)arg1, (int)arg2);
     case Syscall::SC_setuid:

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -366,7 +366,12 @@ int getgroups(int size, gid_t list[])
 
 int pipe(int pipefd[2])
 {
-    int rc = syscall(SC_pipe, pipefd);
+    return pipe2(pipefd, 0);
+}
+
+int pipe2(int pipefd[2], int flags)
+{
+    int rc = syscall(SC_pipe, pipefd, flags);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -86,6 +86,7 @@ int getdtablesize();
 int dup(int old_fd);
 int dup2(int old_fd, int new_fd);
 int pipe(int pipefd[2]);
+int pipe2(int pipefd[2], int flags);
 unsigned int alarm(unsigned int seconds);
 int access(const char* pathname, int mode);
 int isatty(int fd);

--- a/Libraries/LibCore/CEventLoop.cpp
+++ b/Libraries/LibCore/CEventLoop.cpp
@@ -36,7 +36,7 @@ CEventLoop::CEventLoop()
 
     if (!s_main_event_loop) {
         s_main_event_loop = this;
-        int rc = pipe(s_wake_pipe_fds);
+        int rc = pipe2(s_wake_pipe_fds, O_CLOEXEC);
         ASSERT(rc == 0);
         s_event_loop_stack->append(this);
     }


### PR DESCRIPTION
Thanks to the new open files view in ProcessManager, I've noticed some processes having open files I wouldn't expect them to have. This branch fixes two cases:

* Mmaped font files keeping their fds open because of how `MmapedFile` needlessly kept its fd open,
* `CEventLoop` leaking its wake pipe fds into child processes; to fix this I had to introduce the `pipe2()` syscall (which actually is the `sys$pipe` syscall itself, old `pipe()` being a userspace wrapper over it, just like `open`/`open_with_path_length`).