### PR TITLE
Kernel: Refactor TCP/IP stack

### DIFF
--- a/AK/IPv4Address.h
+++ b/AK/IPv4Address.h
@@ -67,6 +67,7 @@ public:
     }
 
     in_addr_t to_in_addr_t() const { return m_data_as_u32; }
+    u32 to_u32() const { return m_data_as_u32; }
 
     bool operator==(const IPv4Address& other) const { return m_data_as_u32 == other.m_data_as_u32; }
     bool operator!=(const IPv4Address& other) const { return m_data_as_u32 != other.m_data_as_u32; }

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -2,10 +2,11 @@
 
 #include <AK/HashMap.h>
 #include <AK/SinglyLinkedList.h>
-#include <Kernel/KBuffer.h>
 #include <Kernel/DoubleBuffer.h>
+#include <Kernel/KBuffer.h>
 #include <Kernel/Lock.h>
 #include <Kernel/Net/IPv4.h>
+#include <Kernel/Net/IPv4SocketTuple.h>
 #include <Kernel/Net/Socket.h>
 
 class IPv4SocketHandle;
@@ -23,6 +24,7 @@ public:
 
     virtual KResult bind(const sockaddr*, socklen_t) override;
     virtual KResult connect(FileDescription&, const sockaddr*, socklen_t, ShouldBlock = ShouldBlock::Yes) override;
+    virtual KResult listen(int) override;
     virtual bool get_local_address(sockaddr*, socklen_t*) override;
     virtual bool get_peer_address(sockaddr*, socklen_t*) override;
     virtual void attach(FileDescription&) override;
@@ -34,13 +36,15 @@ public:
 
     void did_receive(const IPv4Address& peer_address, u16 peer_port, KBuffer&&);
 
-    const IPv4Address& local_address() const;
+    const IPv4Address& local_address() const { return m_local_address; }
     u16 local_port() const { return m_local_port; }
     void set_local_port(u16 port) { m_local_port = port; }
 
     const IPv4Address& peer_address() const { return m_peer_address; }
     u16 peer_port() const { return m_peer_port; }
     void set_peer_port(u16 port) { m_peer_port = port; }
+
+    IPv4SocketTuple tuple() const { return IPv4SocketTuple(m_local_address, m_local_port, m_peer_address, m_peer_port); }
 
 protected:
     IPv4Socket(int type, int protocol);
@@ -49,11 +53,15 @@ protected:
     int allocate_local_port_if_needed();
 
     virtual KResult protocol_bind() { return KSuccess; }
+    virtual KResult protocol_listen() { return KSuccess; }
     virtual int protocol_receive(const KBuffer&, void*, size_t, int) { return -ENOTIMPL; }
     virtual int protocol_send(const void*, int) { return -ENOTIMPL; }
     virtual KResult protocol_connect(FileDescription&, ShouldBlock) { return KSuccess; }
     virtual int protocol_allocate_local_port() { return 0; }
     virtual bool protocol_is_disconnected() const { return false; }
+
+    void set_local_address(IPv4Address address) { m_local_address = address; }
+    void set_peer_address(IPv4Address address) { m_peer_address = address; }
 
 private:
     virtual bool is_ipv4() const override { return true; }

--- a/Kernel/Net/IPv4SocketTuple.h
+++ b/Kernel/Net/IPv4SocketTuple.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/SinglyLinkedList.h>
+#include <Kernel/DoubleBuffer.h>
+#include <Kernel/KBuffer.h>
+#include <Kernel/Lock.h>
+#include <Kernel/Net/IPv4.h>
+#include <Kernel/Net/Socket.h>
+
+class IPv4SocketTuple {
+public:
+    IPv4SocketTuple(IPv4Address local_address, u16 local_port, IPv4Address peer_address, u16 peer_port)
+        : m_local_address(local_address)
+        , m_local_port(local_port)
+        , m_peer_address(peer_address)
+        , m_peer_port(peer_port) {};
+
+    IPv4Address local_address() const { return m_local_address; };
+    u16 local_port() const { return m_local_port; };
+    IPv4Address peer_address() const { return m_peer_address; };
+    u16 peer_port() const { return m_peer_port; };
+
+    bool operator==(const IPv4SocketTuple other) const
+    {
+        return other.local_address() == m_local_address && other.local_port() == m_local_port && other.peer_address() == m_peer_address && other.peer_port() == m_peer_port;
+    };
+
+    String to_string() const
+    {
+        return String::format(
+            "%s:%d -> %s:%d",
+            m_local_address.to_string().characters(),
+            m_local_port,
+            m_peer_address.to_string().characters(),
+            m_peer_port);
+    }
+
+private:
+    IPv4Address m_local_address;
+    u16 m_local_port { 0 };
+    IPv4Address m_peer_address;
+    u16 m_peer_port { 0 };
+};
+
+namespace AK {
+
+template<>
+struct Traits<IPv4SocketTuple> : public GenericTraits<IPv4SocketTuple> {
+    static unsigned hash(const IPv4SocketTuple& tuple)
+    {
+        auto h1 = pair_int_hash(tuple.local_address().to_u32(), tuple.local_port());
+        auto h2 = pair_int_hash(tuple.peer_address().to_u32(), tuple.peer_port());
+        return pair_int_hash(h1, h2);
+    }
+
+    static void dump(const IPv4SocketTuple& tuple)
+    {
+        kprintf("%s", tuple.to_string().characters());
+    }
+};
+
+}

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -114,6 +114,16 @@ KResult LocalSocket::connect(FileDescription& description, const sockaddr* addre
     return KSuccess;
 }
 
+KResult LocalSocket::listen(int backlog)
+{
+    LOCKER(lock());
+    if (type() != SOCK_STREAM)
+        return KResult(-EOPNOTSUPP);
+    set_backlog(backlog);
+    kprintf("LocalSocket{%p} listening with backlog=%d\n", this, backlog);
+    return KSuccess;
+}
+
 void LocalSocket::attach(FileDescription& description)
 {
     switch (description.socket_role()) {

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -13,6 +13,7 @@ public:
     // ^Socket
     virtual KResult bind(const sockaddr*, socklen_t) override;
     virtual KResult connect(FileDescription&, const sockaddr*, socklen_t, ShouldBlock = ShouldBlock::Yes) override;
+    virtual KResult listen(int) override;
     virtual bool get_local_address(sockaddr*, socklen_t*) override;
     virtual bool get_peer_address(sockaddr*, socklen_t*) override;
     virtual void attach(FileDescription&) override;

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <AK/HashTable.h>
-#include <AK/RefPtr.h>
 #include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
 #include <AK/Vector.h>
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/KResult.h>
@@ -35,10 +35,10 @@ public:
     bool can_accept() const { return !m_pending.is_empty(); }
     RefPtr<Socket> accept();
     bool is_connected() const { return m_connected; }
-    KResult listen(int backlog);
 
     virtual KResult bind(const sockaddr*, socklen_t) = 0;
     virtual KResult connect(FileDescription&, const sockaddr*, socklen_t, ShouldBlock) = 0;
+    virtual KResult listen(int) = 0;
     virtual bool get_local_address(sockaddr*, socklen_t*) = 0;
     virtual bool get_peer_address(sockaddr*, socklen_t*) = 0;
     virtual bool is_local() const { return false; }
@@ -72,6 +72,9 @@ protected:
 
     void load_receive_deadline();
     void load_send_deadline();
+
+    int backlog() const { return m_backlog; }
+    void set_backlog(int backlog) { m_backlog = backlog; }
 
     virtual const char* class_name() const override { return "Socket"; }
 

--- a/Kernel/Net/TCP.h
+++ b/Kernel/Net/TCP.h
@@ -39,6 +39,7 @@ public:
     bool has_syn() const { return flags() & TCPFlags::SYN; }
     bool has_ack() const { return flags() & TCPFlags::ACK; }
     bool has_fin() const { return flags() & TCPFlags::FIN; }
+    bool has_rst() const { return flags() & TCPFlags::RST; }
 
     u8 data_offset() const { return (m_flags_and_data_offset & 0xf000) >> 12; }
     void set_data_offset(u16 data_offset) { m_flags_and_data_offset = (m_flags_and_data_offset & ~0xf000) | data_offset << 12; }


### PR DESCRIPTION
This has several significant changes to the networking stack.

* Significant refactoring of the TCP state machine. Right now it's
  probably more fragile than it used to be, but handles quite a lot
  more of the handshake process.
* `TCPSocket` holds a `NetworkAdapter*`, assigned during `connect()` or
  `bind()`, whichever comes first.
* `listen()` is now virtual in `Socket` and intended to be implemented
  in its child classes.
* `listen()` no longer works without `bind()` - this is a bit of a
  regression, but listening sockets didn't work at all before, so it's
  not possible to observe the regression.
* A file is exposed at `/proc/net_tcp`, which is a JSON document listing
  the current TCP sockets with a bit of metadata.
* There's an `ETHERNET_VERY_DEBUG` flag for dumping packet's content out
  to `kprintf`. It is, indeed, _very debug_.