### PR TITLE
/proc/net

### DIFF
--- a/Applications/ProcessManager/NetworkAdapterModel.cpp
+++ b/Applications/ProcessManager/NetworkAdapterModel.cpp
@@ -5,7 +5,7 @@
 
 void NetworkAdapterModel::update()
 {
-    CFile file("/proc/netadapters");
+    CFile file("/proc/net/adapters");
     if (!file.open(CIODevice::ReadOnly)) {
         dbg() << "Unable to open " << file.filename();
         return;

--- a/Applications/ProcessManager/SocketModel.cpp
+++ b/Applications/ProcessManager/SocketModel.cpp
@@ -5,7 +5,7 @@
 
 void SocketModel::update()
 {
-    CFile file("/proc/net_tcp");
+    CFile file("/proc/net/tcp");
     if (!file.open(CIODevice::ReadOnly)) {
         dbg() << "Unable to open " << file.filename();
         return;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -295,17 +295,17 @@ Optional<KBuffer> procfs$net_tcp(InodeIdentifier)
     JsonArray json;
     TCPSocket::for_each([&json](auto& socket) {
         JsonObject obj;
-        obj.set("local_address", socket->local_address().to_string());
-        obj.set("local_port", socket->local_port());
-        obj.set("peer_address", socket->peer_address().to_string());
-        obj.set("peer_port", socket->peer_port());
-        obj.set("state", TCPSocket::to_string(socket->state()));
-        obj.set("ack_number", socket->ack_number());
-        obj.set("sequence_number", socket->sequence_number());
-        obj.set("packets_in", socket->packets_in());
-        obj.set("bytes_in", socket->bytes_in());
-        obj.set("packets_out", socket->packets_out());
-        obj.set("bytes_out", socket->bytes_out());
+        obj.set("local_address", socket.local_address().to_string());
+        obj.set("local_port", socket.local_port());
+        obj.set("peer_address", socket.peer_address().to_string());
+        obj.set("peer_port", socket.peer_port());
+        obj.set("state", TCPSocket::to_string(socket.state()));
+        obj.set("ack_number", socket.ack_number());
+        obj.set("sequence_number", socket.sequence_number());
+        obj.set("packets_in", socket.packets_in());
+        obj.set("bytes_in", socket.bytes_in());
+        obj.set("packets_out", socket.packets_out());
+        obj.set("bytes_out", socket.bytes_out());
         json.append(obj);
     });
     return json.serialized<KBufferBuilder>();

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -8,11 +8,11 @@
 
 //#define TCP_SOCKET_DEBUG
 
-void TCPSocket::for_each(Function<void(TCPSocket*&)> callback)
+void TCPSocket::for_each(Function<void(TCPSocket&)> callback)
 {
     LOCKER(sockets_by_tuple().lock());
     for (auto& it : sockets_by_tuple().resource())
-        callback(it.value);
+        callback(*it.value);
 }
 
 Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>& TCPSocket::sockets_by_tuple()

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -6,7 +6,7 @@
 
 class TCPSocket final : public IPv4Socket {
 public:
-    static void for_each(Function<void(TCPSocket*&)>);
+    static void for_each(Function<void(TCPSocket&)>);
     static NonnullRefPtr<TCPSocket> create(int protocol);
     virtual ~TCPSocket() override;
 

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -5,6 +5,13 @@
 #include <Kernel/Net/UDPSocket.h>
 #include <Kernel/Process.h>
 
+void UDPSocket::for_each(Function<void(UDPSocket&)> callback)
+{
+    LOCKER(sockets_by_port().lock());
+    for (auto it : sockets_by_port().resource())
+        callback(*it.value);
+}
+
 Lockable<HashMap<u16, UDPSocket*>>& UDPSocket::sockets_by_port()
 {
     static Lockable<HashMap<u16, UDPSocket*>>* s_map;

--- a/Kernel/Net/UDPSocket.h
+++ b/Kernel/Net/UDPSocket.h
@@ -8,6 +8,7 @@ public:
     virtual ~UDPSocket() override;
 
     static SocketHandle<UDPSocket> from_port(u16);
+    static void for_each(Function<void(UDPSocket&)>);
 
 private:
     explicit UDPSocket(int protocol);


### PR DESCRIPTION
* Move `/proc/netadapters` and `/proc/net_tcp` to a new `/proc/net` directory, as `/proc/net/adapters` and `/proc/net/tcp`
* Expose UDP socket info as `/proc/net/udp`

Would make sense to do next:
* Expose local sockets info as `/proc/net/local` (or `unix`); it'd be great to expose interesting info like peer PID(s), but currently `LocalSocket` doesn't have enough functionality for this.
* Display this all in ProcessManager — but how? UDP sockets have a strict subset of what TCP sockets have, so we could just combine both sources in one model and leave some fields empty. But local sockets have lots of additional fields, and adding more columns to the table is not an option since the existing ones don't fit in the default window size already. As a separate table, perhaps?