### PR TITLE
Kernel: Detect outgoing TCP connection errors

### DIFF
--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -74,7 +74,7 @@ bool IPv4Socket::get_peer_address(sockaddr* address, socklen_t* address_size)
 
 KResult IPv4Socket::bind(const sockaddr* address, socklen_t address_size)
 {
-    ASSERT(!is_connected());
+    ASSERT(setup_state() == SetupState::Unstarted);
     if (address_size != sizeof(sockaddr_in))
         return KResult(-EINVAL);
     if (address->sa_family != AF_INET)

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -378,7 +378,6 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
         kprintf("handle_tcp: unexpected flags in TimeWait state\n");
         socket->send_tcp_packet(TCPFlags::RST);
         socket->set_state(TCPSocket::State::Closed);
-        kprintf("handle_tcp: TimeWait -> Closed\n");
         return;
     case TCPSocket::State::Listen:
         switch (tcp_packet.flags()) {
@@ -397,7 +396,6 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
             client->send_tcp_packet(TCPFlags::SYN | TCPFlags::ACK);
             client->set_sequence_number(1001);
             client->set_state(TCPSocket::State::SynReceived);
-            kprintf("handle_tcp: Closed -> SynReceived\n");
             return;
         }
         default:
@@ -411,20 +409,17 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             socket->send_tcp_packet(TCPFlags::ACK);
             socket->set_state(TCPSocket::State::SynReceived);
-            kprintf("handle_tcp: SynSent -> SynReceived\n");
             return;
         case TCPFlags::SYN | TCPFlags::ACK:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             socket->send_tcp_packet(TCPFlags::ACK);
             socket->set_state(TCPSocket::State::Established);
             socket->set_connected(true);
-            kprintf("handle_tcp: SynSent -> Established\n");
             return;
         default:
             kprintf("handle_tcp: unexpected flags in SynSent state\n");
             socket->send_tcp_packet(TCPFlags::RST);
             socket->set_state(TCPSocket::State::Closed);
-            kprintf("handle_tcp: SynSent -> Closed\n");
             return;
         }
     case TCPSocket::State::SynReceived:
@@ -434,13 +429,11 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
             socket->set_state(TCPSocket::State::Established);
             if (socket->direction() == TCPSocket::Direction::Outgoing)
                 socket->set_connected(true);
-            kprintf("handle_tcp: SynReceived -> Established\n");
             return;
         default:
             kprintf("handle_tcp: unexpected flags in SynReceived state\n");
             socket->send_tcp_packet(TCPFlags::RST);
             socket->set_state(TCPSocket::State::Closed);
-            kprintf("handle_tcp: SynReceived -> Closed\n");
             return;
         }
     case TCPSocket::State::CloseWait:
@@ -449,7 +442,6 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
             kprintf("handle_tcp: unexpected flags in CloseWait state\n");
             socket->send_tcp_packet(TCPFlags::RST);
             socket->set_state(TCPSocket::State::Closed);
-            kprintf("handle_tcp: CloseWait -> Closed\n");
             return;
         }
     case TCPSocket::State::LastAck:
@@ -457,13 +449,11 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
         case TCPFlags::ACK:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             socket->set_state(TCPSocket::State::Closed);
-            kprintf("handle_tcp: LastAck -> Closed\n");
             return;
         default:
             kprintf("handle_tcp: unexpected flags in LastAck state\n");
             socket->send_tcp_packet(TCPFlags::RST);
             socket->set_state(TCPSocket::State::Closed);
-            kprintf("handle_tcp: LastAck -> Closed\n");
             return;
         }
     case TCPSocket::State::FinWait1:
@@ -471,18 +461,15 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
         case TCPFlags::ACK:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             socket->set_state(TCPSocket::State::FinWait2);
-            kprintf("handle_tcp: FinWait1 -> FinWait2\n");
             return;
         case TCPFlags::FIN:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             socket->set_state(TCPSocket::State::Closing);
-            kprintf("handle_tcp: FinWait1 -> Closing\n");
             return;
         default:
             kprintf("handle_tcp: unexpected flags in FinWait1 state\n");
             socket->send_tcp_packet(TCPFlags::RST);
             socket->set_state(TCPSocket::State::Closed);
-            kprintf("handle_tcp: FinWait1 -> Closed\n");
             return;
         }
     case TCPSocket::State::FinWait2:
@@ -490,13 +477,11 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
         case TCPFlags::FIN:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             socket->set_state(TCPSocket::State::TimeWait);
-            kprintf("handle_tcp: FinWait2 -> TimeWait\n");
             return;
         default:
             kprintf("handle_tcp: unexpected flags in FinWait2 state\n");
             socket->send_tcp_packet(TCPFlags::RST);
             socket->set_state(TCPSocket::State::Closed);
-            kprintf("handle_tcp: FinWait2 -> Closed\n");
             return;
         }
     case TCPSocket::State::Closing:
@@ -504,13 +489,11 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
         case TCPFlags::ACK:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             socket->set_state(TCPSocket::State::TimeWait);
-            kprintf("handle_tcp: Closing -> TimeWait\n");
             return;
         default:
             kprintf("handle_tcp: unexpected flags in Closing state\n");
             socket->send_tcp_packet(TCPFlags::RST);
             socket->set_state(TCPSocket::State::Closed);
-            kprintf("handle_tcp: Closing -> Closed\n");
             return;
         }
     case TCPSocket::State::Established:
@@ -522,7 +505,6 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
             socket->send_tcp_packet(TCPFlags::ACK);
             socket->set_state(TCPSocket::State::CloseWait);
             socket->set_connected(false);
-            kprintf("handle_tcp: Established -> CloseWait\n");
             return;
         }
 

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -414,12 +414,14 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             socket->send_tcp_packet(TCPFlags::ACK);
             socket->set_state(TCPSocket::State::Established);
+            socket->set_setup_state(Socket::SetupState::Completed);
             socket->set_connected(true);
             return;
         default:
             kprintf("handle_tcp: unexpected flags in SynSent state\n");
             socket->send_tcp_packet(TCPFlags::RST);
             socket->set_state(TCPSocket::State::Closed);
+            socket->set_setup_state(Socket::SetupState::Completed);
             return;
         }
     case TCPSocket::State::SynReceived:
@@ -427,8 +429,10 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
         case TCPFlags::ACK:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             socket->set_state(TCPSocket::State::Established);
-            if (socket->direction() == TCPSocket::Direction::Outgoing)
+            if (socket->direction() == TCPSocket::Direction::Outgoing) {
+                socket->set_setup_state(Socket::SetupState::Completed);
                 socket->set_connected(true);
+            }
             return;
         default:
             kprintf("handle_tcp: unexpected flags in SynReceived state\n");

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -15,6 +15,17 @@ void TCPSocket::for_each(Function<void(TCPSocket&)> callback)
         callback(*it.value);
 }
 
+void TCPSocket::set_state(State new_state)
+{
+#ifdef TCP_SOCKET_DEBUG
+    kprintf("%s(%u) TCPSocket{%p} state moving from %s to %s\n",
+        current->process().name().characters(), current->pid(), this,
+        to_string(m_state), to_string(new_state));
+#endif
+
+    m_state = new_state;
+}
+
 Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>& TCPSocket::sockets_by_tuple()
 {
     static Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>* s_map;

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -274,6 +274,8 @@ KResult TCPSocket::protocol_connect(FileDescription& description, ShouldBlock sh
         if (current->block<Thread::ConnectBlocker>(description) == Thread::BlockResult::InterruptedBySignal)
             return KResult(-EINTR);
         ASSERT(setup_state() == SetupState::Completed);
+        if (has_error())
+            return KResult(-ECONNREFUSED);
         return KSuccess;
     }
 

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -78,7 +78,7 @@ public:
     }
 
     State state() const { return m_state; }
-    void set_state(State state) { m_state = state; }
+    void set_state(State state);
 
     Direction direction() const { return m_direction; }
 

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -77,10 +77,37 @@ public:
         }
     }
 
+    enum class Error {
+        None,
+        FINDuringConnect,
+        RSTDuringConnect,
+        UnexpectedFlagsDuringConnect,
+    };
+
+    static const char* to_string(Error error)
+    {
+        switch (error) {
+        case Error::None:
+            return "None";
+        case Error::FINDuringConnect:
+            return "FINDuringConnect";
+        case Error::RSTDuringConnect:
+            return "RSTDuringConnect";
+        case Error::UnexpectedFlagsDuringConnect:
+            return "UnexpectedFlagsDuringConnect";
+        default:
+            return "Invalid";
+        }
+    }
+
     State state() const { return m_state; }
     void set_state(State state);
 
     Direction direction() const { return m_direction; }
+
+    bool has_error() const { return m_error != Error::None; }
+    Error error() const { return m_error; }
+    void set_error(Error error) { m_error = error; }
 
     void set_ack_number(u32 n) { m_ack_number = n; }
     void set_sequence_number(u32 n) { m_sequence_number = n; }
@@ -118,6 +145,7 @@ private:
     virtual KResult protocol_listen() override;
 
     Direction m_direction { Direction::Unspecified };
+    Error m_error { Error::None };
     WeakPtr<NetworkAdapter> m_adapter;
     u32 m_sequence_number { 0 };
     u32 m_ack_number { 0 };

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -2313,7 +2313,7 @@ int Process::sys$getpeername(int sockfd, sockaddr* addr, socklen_t* addrlen)
 
     auto& socket = *description->socket();
 
-    if (!socket.is_connected())
+    if (socket.setup_state() != Socket::SetupState::Completed)
         return -ENOTCONN;
 
     if (!socket.get_peer_address(addr, addrlen))

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -111,7 +111,7 @@ Thread::ConnectBlocker::ConnectBlocker(const FileDescription& description)
 bool Thread::ConnectBlocker::should_unblock(Thread&, time_t, long)
 {
     auto& socket = *blocked_description().socket();
-    return socket.is_connected();
+    return socket.setup_state() == Socket::SetupState::Completed;
 }
 
 Thread::WriteBlocker::WriteBlocker(const FileDescription& description)


### PR DESCRIPTION
This is a collection of smaller changes, the most invasive being a change
to the socket setup process. Instead of only tracking connected and
disconnected, we now track the initialisation process too. Ultimately
this allows asynchronous errors from the TCP stack to bubble up to the
original `connect()` call.

Bonus feature: better logging of TCP state transitions.

Fixes #419