### PR TITLE
Names and sockets

### DIFF
--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -22,17 +22,16 @@ NonnullRefPtr<FileDescription> FileDescription::create(Custody& custody)
     return description;
 }
 
-NonnullRefPtr<FileDescription> FileDescription::create(File& file, SocketRole role)
+NonnullRefPtr<FileDescription> FileDescription::create(File& file)
 {
-    return adopt(*new FileDescription(file, role));
+    return adopt(*new FileDescription(file));
 }
 
-FileDescription::FileDescription(File& file, SocketRole role)
+FileDescription::FileDescription(File& file)
     : m_file(file)
 {
     if (file.is_inode())
         m_inode = static_cast<InodeFile&>(file).inode();
-    set_socket_role(role);
     if (is_socket())
         socket()->attach(*this);
 }
@@ -45,15 +44,6 @@ FileDescription::~FileDescription()
         static_cast<FIFO*>(m_file.ptr())->detach(m_fifo_direction);
     m_file->close();
     m_inode = nullptr;
-}
-
-void FileDescription::set_socket_role(SocketRole role)
-{
-    if (role == m_socket_role)
-        return;
-
-    ASSERT(is_socket());
-    m_socket_role = role;
 }
 
 KResult FileDescription::fstat(stat& buffer)

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -57,24 +57,6 @@ void FileDescription::set_socket_role(SocketRole role)
     socket()->attach(*this);
 }
 
-NonnullRefPtr<FileDescription> FileDescription::clone()
-{
-    RefPtr<FileDescription> description;
-    if (is_fifo()) {
-        description = fifo()->open_direction(m_fifo_direction);
-    } else {
-        description = FileDescription::create(m_file, m_socket_role);
-        description->m_custody = m_custody;
-        description->m_inode = m_inode;
-    }
-    ASSERT(description);
-    description->m_current_offset = m_current_offset;
-    description->m_is_blocking = m_is_blocking;
-    description->m_should_append = m_should_append;
-    description->m_file_flags = m_file_flags;
-    return *description;
-}
-
 KResult FileDescription::fstat(stat& buffer)
 {
     ASSERT(!is_fifo());

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -33,6 +33,8 @@ FileDescription::FileDescription(File& file, SocketRole role)
     if (file.is_inode())
         m_inode = static_cast<InodeFile&>(file).inode();
     set_socket_role(role);
+    if (is_socket())
+        socket()->attach(*this);
 }
 
 FileDescription::~FileDescription()
@@ -51,10 +53,7 @@ void FileDescription::set_socket_role(SocketRole role)
         return;
 
     ASSERT(is_socket());
-    if (m_socket_role != SocketRole::None)
-        socket()->detach(*this);
     m_socket_role = role;
-    socket()->attach(*this);
 }
 
 KResult FileDescription::fstat(stat& buffer)

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -23,7 +23,7 @@ class SharedMemory;
 class FileDescription : public RefCounted<FileDescription> {
 public:
     static NonnullRefPtr<FileDescription> create(Custody&);
-    static NonnullRefPtr<FileDescription> create(File&, SocketRole = SocketRole::None);
+    static NonnullRefPtr<FileDescription> create(File&);
     ~FileDescription();
 
     int close();
@@ -93,9 +93,6 @@ public:
 
     void set_original_inode(Badge<VFS>, NonnullRefPtr<Inode>&& inode) { m_inode = move(inode); }
 
-    SocketRole socket_role() const { return m_socket_role; }
-    void set_socket_role(SocketRole);
-
     KResult truncate(off_t);
 
     off_t offset() const { return m_current_offset; }
@@ -104,7 +101,7 @@ public:
 
 private:
     friend class VFS;
-    FileDescription(File&, SocketRole = SocketRole::None);
+    explicit FileDescription(File&);
     FileDescription(FIFO&, FIFO::Direction);
 
     RefPtr<Custody> m_custody;
@@ -119,6 +116,5 @@ private:
 
     bool m_is_blocking { true };
     bool m_should_append { false };
-    SocketRole m_socket_role { SocketRole::None };
     FIFO::Direction m_fifo_direction { FIFO::Direction::Neither };
 };

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -26,8 +26,6 @@ public:
     static NonnullRefPtr<FileDescription> create(File&, SocketRole = SocketRole::None);
     ~FileDescription();
 
-    NonnullRefPtr<FileDescription> clone();
-
     int close();
 
     off_t seek(off_t, int whence);

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -1,3 +1,4 @@
+#include <AK/StringBuilder.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/Net/ARP.h>
 #include <Kernel/Net/ICMP.h>
@@ -267,4 +268,36 @@ void IPv4Socket::did_receive(const IPv4Address& source_address, u16 source_port,
 #ifdef IPV4_SOCKET_DEBUG
     kprintf("IPv4Socket(%p): did_receive %d bytes, total_received=%u, packets in queue: %d\n", this, packet_size, m_bytes_received, m_receive_queue.size_slow());
 #endif
+}
+
+String IPv4Socket::absolute_path(const FileDescription&) const
+{
+    if (m_role == Role::None)
+        return "socket";
+
+    StringBuilder builder;
+    builder.append("socket:");
+
+    builder.appendf("%s:%d", m_local_address.to_string().characters(), m_local_port);
+    if (m_role == Role::Accepted || m_role == Role::Connected)
+        builder.appendf(" / %s:%d", m_peer_address.to_string().characters(), m_peer_port);
+
+    switch (m_role) {
+    case Role::Listener:
+        builder.append(" (listening)");
+        break;
+    case Role::Accepted:
+        builder.append(" (accepted)");
+        break;
+    case Role::Connected:
+        builder.append(" (connected)");
+        break;
+    case Role::Connecting:
+        builder.append(" (connecting)");
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+
+    return builder.to_string();
 }

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -108,6 +108,8 @@ KResult IPv4Socket::connect(FileDescription& description, const sockaddr* addres
         return KResult(-EINVAL);
     if (address->sa_family != AF_INET)
         return KResult(-EINVAL);
+    if (m_role == Role::Connected)
+        return KResult(-EISCONN);
 
     auto& ia = *(const sockaddr_in*)address;
     m_peer_address = IPv4Address((const u8*)&ia.sin_addr.s_addr);
@@ -124,9 +126,9 @@ void IPv4Socket::detach(FileDescription&)
 {
 }
 
-bool IPv4Socket::can_read(FileDescription& description) const
+bool IPv4Socket::can_read(FileDescription&) const
 {
-    if (description.socket_role() == SocketRole::Listener)
+    if (m_role == Role::Listener)
         return can_accept();
     if (protocol_is_disconnected())
         return true;

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -45,6 +45,8 @@ public:
 
     IPv4SocketTuple tuple() const { return IPv4SocketTuple(m_local_address, m_local_port, m_peer_address, m_peer_port); }
 
+    String absolute_path(const FileDescription& description) const override;
+
 protected:
     IPv4Socket(int type, int protocol);
     virtual const char* class_name() const override { return "IPv4Socket"; }

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -48,7 +48,7 @@ KResult LocalSocket::bind(const sockaddr* address, socklen_t address_size)
         return KResult(-EINVAL);
 
     const sockaddr_un& local_address = *reinterpret_cast<const sockaddr_un*>(address);
-    char safe_address[sizeof(local_address.sun_path) + 1];
+    char safe_address[sizeof(local_address.sun_path) + 1] = { 0 };
     memcpy(safe_address, local_address.sun_path, sizeof(local_address.sun_path));
 
 #ifdef DEBUG_LOCAL_SOCKET
@@ -81,7 +81,7 @@ KResult LocalSocket::connect(FileDescription& description, const sockaddr* addre
         return KResult(-EINVAL);
 
     const sockaddr_un& local_address = *reinterpret_cast<const sockaddr_un*>(address);
-    char safe_address[sizeof(local_address.sun_path) + 1];
+    char safe_address[sizeof(local_address.sun_path) + 1] = { 0 };
     memcpy(safe_address, local_address.sun_path, sizeof(local_address.sun_path));
 
 #ifdef DEBUG_LOCAL_SOCKET

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -227,3 +227,9 @@ ssize_t LocalSocket::recvfrom(FileDescription& description, void* buffer, size_t
     }
     ASSERT_NOT_REACHED();
 }
+
+StringView LocalSocket::socket_path() const
+{
+    int len = strnlen(m_address.sun_path, sizeof(m_address.sun_path));
+    return { m_address.sun_path, len };
+}

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -254,3 +254,29 @@ StringView LocalSocket::socket_path() const
     int len = strnlen(m_address.sun_path, sizeof(m_address.sun_path));
     return { m_address.sun_path, len };
 }
+
+String LocalSocket::absolute_path(const FileDescription& description) const
+{
+    StringBuilder builder;
+    builder.append("socket:");
+    builder.append(socket_path());
+
+    switch (role(description)) {
+    case Role::Listener:
+        builder.append(" (listening)");
+        break;
+    case Role::Accepted:
+        builder.appendf(" (accepted from pid %d)", origin_pid());
+        break;
+    case Role::Connected:
+        builder.appendf(" (connected to pid %d)", acceptor_pid());
+        break;
+    case Role::Connecting:
+        builder.append(" (connecting)");
+        break;
+    default:
+        break;
+    }
+
+    return builder.to_string();
+}

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -31,9 +31,8 @@ private:
     RefPtr<FileDescription> m_file;
 
     bool m_bound { false };
-    int m_accepted_fds_open { 0 };
-    int m_connected_fds_open { 0 };
-    int m_connecting_fds_open { 0 };
+    bool m_accept_side_fd_open { false };
+    bool m_connect_side_fd_open { false };
     sockaddr_un m_address;
 
     DoubleBuffer m_for_client;

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -28,11 +28,25 @@ private:
     virtual bool is_local() const override { return true; }
     bool has_attached_peer(const FileDescription&) const;
 
+    // An open socket file on the filesystem.
     RefPtr<FileDescription> m_file;
+
+    // A single LocalSocket is shared between two file descriptions
+    // on the connect side and the accept side; so we need to store
+    // an additional role for the connect side and differentiate
+    // between them.
+    Role m_connect_side_role { Role::None };
+    FileDescription* m_connect_side_fd { nullptr };
+
+    virtual Role role(const FileDescription& description) const override
+    {
+        if (m_connect_side_fd == &description)
+            return m_connect_side_role;
+        return m_role;
+    }
 
     bool m_bound { false };
     bool m_accept_side_fd_open { false };
-    bool m_connect_side_fd_open { false };
     sockaddr_un m_address;
 
     DoubleBuffer m_for_client;

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -15,6 +15,8 @@ public:
     static void for_each(Function<void(LocalSocket&)>);
 
     StringView socket_path() const;
+    String absolute_path(const FileDescription& description) const override;
+
     // ^Socket
     virtual KResult bind(const sockaddr*, socklen_t) override;
     virtual KResult connect(FileDescription&, const sockaddr*, socklen_t, ShouldBlock = ShouldBlock::Yes) override;

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -10,6 +10,8 @@ public:
     static NonnullRefPtr<LocalSocket> create(int type);
     virtual ~LocalSocket() override;
 
+
+    StringView socket_path() const;
     // ^Socket
     virtual KResult bind(const sockaddr*, socklen_t) override;
     virtual KResult connect(FileDescription&, const sockaddr*, socklen_t, ShouldBlock = ShouldBlock::Yes) override;

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -25,6 +25,7 @@ public:
 
 private:
     explicit LocalSocket(int type);
+    virtual const char* class_name() const override { return "LocalSocket"; }
     virtual bool is_local() const override { return true; }
     bool has_attached_peer(const FileDescription&) const;
 

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -1,3 +1,4 @@
+#include <AK/StringBuilder.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/Net/IPv4Socket.h>
 #include <Kernel/Net/LocalSocket.h>
@@ -149,23 +150,28 @@ void Socket::load_send_deadline()
     m_send_deadline.tv_usec %= 1000000;
 }
 
-static const char* to_string(Socket::Role role)
-{
-    switch (role) {
-    case Socket::Role::Listener:
-        return "Listener";
-    case Socket::Role::Accepted:
-        return "Accepted";
-    case Socket::Role::Connected:
-        return "Connected";
-    default:
-        return "None";
-    }
-}
-
 String Socket::absolute_path(const FileDescription& description) const
 {
-    return String::format("socket:%x (role: %s)", this, ::to_string(role(description)));
+    StringBuilder builder;
+    builder.appendf("socket:%x", this);
+
+    switch (role(description)) {
+    case Role::None:
+        break;
+    case Role::Listener:
+        builder.append(" (listening)");
+        break;
+    case Role::Accepted:
+        builder.append(" (accepted)");
+        break;
+    case Role::Connected:
+        builder.append(" (connected)");
+        break;
+    case Role::Connecting:
+        builder.append(" (connecting)");
+        break;
+    }
+    return builder.to_string();
 }
 
 ssize_t Socket::read(FileDescription& description, u8* buffer, ssize_t size)

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -63,6 +63,7 @@ RefPtr<Socket> Socket::accept()
 #endif
     auto client = m_pending.take_first();
     ASSERT(!client->is_connected());
+    client->m_acceptor_pid = m_origin_pid;
     client->set_setup_state(SetupState::Completed);
     client->m_connected = true;
     client->m_role = Role::Accepted;

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -9,13 +9,6 @@
 #include <Kernel/Lock.h>
 #include <Kernel/UnixTypes.h>
 
-enum class SocketRole : u8 {
-    None,
-    Listener,
-    Accepted,
-    Connected,
-    Connecting
-};
 enum class ShouldBlock {
     No = 0,
     Yes = 1
@@ -38,6 +31,14 @@ public:
         Completed,  // the setup process is complete, but not necessarily successful
     };
 
+    enum class Role : u8 {
+        None,
+        Listener,
+        Accepted,
+        Connected,
+        Connecting
+    };
+
     static const char* to_string(SetupState setup_state)
     {
         switch (setup_state) {
@@ -54,6 +55,8 @@ public:
 
     SetupState setup_state() const { return m_setup_state; }
     void set_setup_state(SetupState setup_state);
+
+    virtual Role role(const FileDescription&) const { return m_role; }
 
     bool is_connected() const { return m_connected; }
     void set_connected(bool connected) { m_connected = connected; }
@@ -100,6 +103,8 @@ protected:
     void set_backlog(int backlog) { m_backlog = backlog; }
 
     virtual const char* class_name() const override { return "Socket"; }
+
+    Role m_role { Role::None };
 
 private:
     virtual bool is_socket() const final { return true; }

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -80,6 +80,7 @@ public:
     KResult getsockopt(int level, int option, void*, socklen_t*);
 
     pid_t origin_pid() const { return m_origin_pid; }
+    pid_t acceptor_pid() const { return m_acceptor_pid; }
 
     timeval receive_deadline() const { return m_receive_deadline; }
     timeval send_deadline() const { return m_send_deadline; }
@@ -111,6 +112,7 @@ private:
 
     Lock m_lock { "Socket" };
     pid_t m_origin_pid { 0 };
+    pid_t m_acceptor_pid { 0 };
     int m_domain { 0 };
     int m_type { 0 };
     int m_protocol { 0 };

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -81,6 +81,12 @@ int UDPSocket::protocol_send(const void* data, int data_length)
     return data_length;
 }
 
+KResult UDPSocket::protocol_connect(FileDescription&, ShouldBlock)
+{
+    m_role = Role::Connected;
+    return KSuccess;
+}
+
 int UDPSocket::protocol_allocate_local_port()
 {
     static const u16 first_ephemeral_port = 32768;

--- a/Kernel/Net/UDPSocket.h
+++ b/Kernel/Net/UDPSocket.h
@@ -17,7 +17,7 @@ private:
 
     virtual int protocol_receive(const KBuffer&, void* buffer, size_t buffer_size, int flags) override;
     virtual int protocol_send(const void*, int) override;
-    virtual KResult protocol_connect(FileDescription&, ShouldBlock) override { return KSuccess; }
+    virtual KResult protocol_connect(FileDescription&, ShouldBlock) override;
     virtual int protocol_allocate_local_port() override;
     virtual KResult protocol_bind() override;
 };

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -624,8 +624,7 @@ Process::Process(String&& name, uid_t uid, gid_t gid, pid_t ppid, RingLevel ring
 #ifdef FORK_DEBUG
             dbgprintf("fork: cloning fd %u... (%p) istty? %u\n", i, fork_parent->m_fds[i].description.ptr(), fork_parent->m_fds[i].description->is_tty());
 #endif
-            m_fds[i].description = fork_parent->m_fds[i].description->clone();
-            m_fds[i].flags = fork_parent->m_fds[i].flags;
+            m_fds[i] = fork_parent->m_fds[i];
         }
     } else {
         m_fds.resize(m_max_open_file_descriptors);

--- a/Kernel/StdLib.cpp
+++ b/Kernel/StdLib.cpp
@@ -102,6 +102,14 @@ size_t strlen(const char* str)
     return len;
 }
 
+size_t strnlen(const char* str, size_t maxlen)
+{
+    size_t len = 0;
+    for (; len < maxlen && *str; str++)
+        len++;
+    return len;
+}
+
 int strcmp(const char* s1, const char* s2)
 {
     for (; *s1 == *s2; ++s1, ++s2) {

--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -11,6 +11,7 @@ char* strcpy(char*, const char*);
 char* strncpy(char*, const char*, size_t);
 int strcmp(char const*, const char*);
 size_t strlen(const char*);
+size_t strnlen(const char*, size_t);
 void* memset(void*, int, size_t);
 char* strdup(const char*);
 int memcmp(const void*, const void*, size_t);

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -102,3 +102,8 @@ int MasterPTY::ioctl(FileDescription& description, unsigned request, unsigned ar
         return m_slave->ioctl(description, request, arg);
     return -EINVAL;
 }
+
+String MasterPTY::absolute_path(const FileDescription&) const
+{
+    return String::format("ptm:%s", m_pts_name.characters());
+}

--- a/Kernel/TTY/MasterPTY.h
+++ b/Kernel/TTY/MasterPTY.h
@@ -18,6 +18,8 @@ public:
     void notify_slave_closed(Badge<SlavePTY>);
     bool is_closed() const { return m_closed; }
 
+    virtual String absolute_path(const FileDescription&) const override;
+
 private:
     // ^CharacterDevice
     virtual ssize_t read(FileDescription&, u8*, ssize_t) override;


### PR DESCRIPTION
Some work on kernel, mostly around sockets.

Interesting stuff:
* Expose local (Unix) sockets in `/proc/net/local`.
* For sockets, track _acceptor PID_ alongside the existing _origin PID_.
* Customize `absolute_path()` for some more types, including sockets.

I haven't gotten around to displaying more socket types in the Network tab, but with these changes the Open Files panel shows some of the info:
![image](https://user-images.githubusercontent.com/10091584/62824281-359ca600-bba4-11e9-809e-880766b09730.png)

I'm not sure you'll actually approve of all these changes, so let me know if you dislike something.