### PR TITLE
Kernel: Add serial_debug cmdline parameter

### DIFF
--- a/Kernel/grub.cfg
+++ b/Kernel/grub.cfg
@@ -1,6 +1,11 @@
-timeout=0
+timeout=1
 
-menuentry 'Serenity' {
+menuentry 'Serenity (normal)' {
   root=hd0,1
   multiboot /boot/kernel root=/dev/hda1
+}
+
+menuentry 'Serenity (with serial debug)' {
+	root=hd0,1
+  multiboot /boot/kernel serial_debug root=/dev/hda1
 }

--- a/Kernel/kstdio.h
+++ b/Kernel/kstdio.h
@@ -7,6 +7,8 @@ int dbgprintf(const char* fmt, ...);
 int dbgputstr(const char*, int);
 int kprintf(const char* fmt, ...);
 int ksprintf(char* buf, const char* fmt, ...);
+void set_serial_debug(bool on_or_off);
+int get_serial_debug();
 }
 
 #ifndef USERLAND


### PR DESCRIPTION
serial_debug will output all the kprintf and dbgprintf data to COM1 at
8-N-1 57600 baud. this is particularly useful for debugging the boot
process on live hardware.

Note: it must be the first parameter in the boot cmdline.