### PR TITLE
Kernel: Use established device name and number for framebuffer

### DIFF
--- a/Kernel/Devices/BXVGADevice.cpp
+++ b/Kernel/Devices/BXVGADevice.cpp
@@ -38,7 +38,7 @@ BXVGADevice& BXVGADevice::the()
 }
 
 BXVGADevice::BXVGADevice()
-    : BlockDevice(82, 413)
+    : BlockDevice(29, 0)
 {
     s_the = this;
     m_framebuffer_address = PhysicalAddress(find_framebuffer_address());

--- a/Kernel/build-root-filesystem.sh
+++ b/Kernel/build-root-filesystem.sh
@@ -22,7 +22,7 @@ echo "done"
 echo -n "setting up device nodes... "
 mkdir -p mnt/dev
 mkdir -p mnt/dev/pts
-mknod -m 666 mnt/dev/bxvga b 82 413
+mknod -m 666 mnt/dev/fb0 b 29 0
 mknod mnt/dev/tty0 c 4 0
 mknod mnt/dev/tty1 c 4 1
 mknod mnt/dev/tty2 c 4 2

--- a/Servers/WindowServer/WSScreen.cpp
+++ b/Servers/WindowServer/WSScreen.cpp
@@ -23,7 +23,7 @@ WSScreen::WSScreen(unsigned width, unsigned height)
     ASSERT(!s_the);
     s_the = this;
     m_cursor_location = rect().center();
-    m_framebuffer_fd = open("/dev/bxvga", O_RDWR);
+    m_framebuffer_fd = open("/dev/fb0", O_RDWR);
     ASSERT(m_framebuffer_fd >= 0);
 
     set_resolution(width, height);


### PR DESCRIPTION
This is to prepare for other framebuffer implementations, for which it
would be inappropriate to use the /dev/bxvga device name.