### PR TITLE
Kernel: Resurrect VGA text console

### DIFF
--- a/Kernel/Devices/KeyboardDevice.cpp
+++ b/Kernel/Devices/KeyboardDevice.cpp
@@ -289,10 +289,12 @@ void KeyboardDevice::handle_irq()
                     VirtualConsole::switch_to(map[ch] - '0' - 1);
                     break;
                 default:
+                    key_state_changed(ch, pressed);
                     break;
                 }
+            } else {
+                key_state_changed(ch, pressed);
             }
-            key_state_changed(ch, pressed);
         }
     }
 }

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -26,7 +26,13 @@ void TTY::set_default_termios()
 
 ssize_t TTY::read(FileDescription&, u8* buffer, ssize_t size)
 {
-    return m_buffer.read(buffer, size);
+    if (m_input_buffer.size() < size)
+        size = m_input_buffer.size();
+
+    for (int i = 0; i < size; i++)
+        buffer[i] = m_input_buffer.dequeue();
+
+    return size;
 }
 
 ssize_t TTY::write(FileDescription&, const u8* buffer, ssize_t size)
@@ -44,7 +50,7 @@ ssize_t TTY::write(FileDescription&, const u8* buffer, ssize_t size)
 
 bool TTY::can_read(FileDescription&) const
 {
-    return !m_buffer.is_empty();
+    return !m_input_buffer.is_empty();
 }
 
 bool TTY::can_write(FileDescription&) const
@@ -71,7 +77,7 @@ void TTY::emit(u8 ch)
             return;
         }
     }
-    m_buffer.write(&ch, 1);
+    m_input_buffer.enqueue(ch);
 }
 
 void TTY::generate_signal(int signal)

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "DoubleBuffer.h"
+#include <AK/CircularQueue.h>
 #include <Kernel/Devices/CharacterDevice.h>
 #include <Kernel/UnixTypes.h>
 
@@ -46,7 +47,7 @@ private:
     // ^CharacterDevice
     virtual bool is_tty() const final override { return true; }
 
-    DoubleBuffer m_buffer;
+    CircularQueue<u8, 16> m_input_buffer;
     pid_t m_pgid { 0 };
     termios m_termios;
     unsigned short m_rows { 0 };

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -494,6 +494,8 @@ void VirtualConsole::on_char(u8 ch)
 
 void VirtualConsole::on_key_pressed(KeyboardDevice::Event key)
 {
+    if (!key.is_press())
+        return;
     if (key.ctrl()) {
         if (key.character >= 'a' && key.character <= 'z') {
             emit(key.character - 'a' + 1);

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -4,6 +4,7 @@
 #include "kmalloc.h"
 #include <AK/AKString.h>
 #include <Kernel/Arch/i386/CPU.h>
+#include <Kernel/Devices/KeyboardDevice.h>
 
 static u8* s_vga_buffer;
 static VirtualConsole* s_consoles[6];
@@ -101,6 +102,7 @@ void VirtualConsole::set_active(bool b)
     m_active = b;
     if (!m_active) {
         memcpy(m_buffer, m_current_vga_window, rows() * columns() * 2);
+        KeyboardDevice::the().set_client(nullptr);
         return;
     }
 
@@ -108,9 +110,7 @@ void VirtualConsole::set_active(bool b)
     set_vga_start_row(0);
     flush_vga_cursor();
 
-#if 0
-    Keyboard::the().set_client(this);
-#endif
+    KeyboardDevice::the().set_client(this);
 }
 
 inline bool is_valid_parameter_character(u8 ch)


### PR DESCRIPTION
This brings back the non-graphical functionality of Serenity. This is
useful for booting on real hardware until we have some more advanced VGA
drivers.

There are two minor regressions:

1. We're using a 16-character circular buffer for input to the TTY
	 subsystem, which means if you type at the speed of light, or implement
	 an alternative input mechanism which types at the speed of light for
	 you, we might drop some inputs. Enlarging this buffer is the wrong way
	 to fix the issue - instead we should teach the TTY subsystem how to read
	 from the keyboard the same way WindowServer does.
2. Because the alt+n keystrokes are hijacked way down low in the kernel, it
	 is possible to, in graphical mode, select a secondary virtual console,
	 without it being obvious that you have. This means that all of your
	 keystrokes will be silently forwarded to a root terminal. So I guess,
	 like, don't hit alt+2 or whatever in graphical mode for the next week or
	 so.