### PR TITLE
Meta: Rearrange makeall.sh for more consistent builds

### DIFF
--- a/Kernel/makeall.sh
+++ b/Kernel/makeall.sh
@@ -14,56 +14,74 @@ fi
 make_cmd="make -j $MAKEJOBS"
 
 build_targets=""
-build_targets="$build_targets ../DevTools/FormCompiler"
-build_targets="$build_targets ../DevTools/IPCCompiler"
-build_targets="$build_targets ../Libraries/LibC"
-build_targets="$build_targets ../Libraries/LibM"
-build_targets="$build_targets ../Libraries/LibCore"
-build_targets="$build_targets ../Libraries/LibIPC"
-build_targets="$build_targets ../Libraries/LibDraw"
-build_targets="$build_targets ../Libraries/LibPCIDB"
-build_targets="$build_targets ../Servers/SystemServer"
-build_targets="$build_targets ../Servers/LookupServer"
-build_targets="$build_targets ../Servers/WindowServer"
-build_targets="$build_targets ../Servers/AudioServer"
-build_targets="$build_targets ../Servers/TTYServer"
+
+build_targets="$build_targets ../AK"
+
 build_targets="$build_targets ../Libraries/LibAudio"
+build_targets="$build_targets ../Libraries/LibC"
+build_targets="$build_targets ../Libraries/LibCore"
+build_targets="$build_targets ../Libraries/LibDraw"
 build_targets="$build_targets ../Libraries/LibGUI"
-build_targets="$build_targets ../Libraries/LibVT"
 build_targets="$build_targets ../Libraries/LibHTML"
-build_targets="$build_targets ../Userland"
-build_targets="$build_targets ../Applications/Terminal"
-build_targets="$build_targets ../Applications/FontEditor"
-build_targets="$build_targets ../Applications/Launcher"
-build_targets="$build_targets ../Applications/FileManager"
-build_targets="$build_targets ../Applications/SystemMonitor"
-build_targets="$build_targets ../Applications/TextEditor"
+build_targets="$build_targets ../Libraries/LibIPC"
+build_targets="$build_targets ../Libraries/LibM"
+build_targets="$build_targets ../Libraries/LibPCIDB"
+build_targets="$build_targets ../Libraries/LibVT"
+
 build_targets="$build_targets ../Applications/About"
-build_targets="$build_targets ../Applications/IRCClient"
-build_targets="$build_targets ../Applications/Taskbar"
-build_targets="$build_targets ../Applications/Downloader"
-build_targets="$build_targets ../Applications/PaintBrush"
-build_targets="$build_targets ../Applications/QuickShow"
-build_targets="$build_targets ../Applications/Piano"
-build_targets="$build_targets ../Applications/SystemDialog"
-build_targets="$build_targets ../Applications/ChanViewer"
 build_targets="$build_targets ../Applications/Calculator"
-build_targets="$build_targets ../DevTools/VisualBuilder"
-build_targets="$build_targets ../Games/Minesweeper"
-build_targets="$build_targets ../Games/Snake"
-build_targets="$build_targets ../Shell"
+build_targets="$build_targets ../Applications/ChanViewer"
+build_targets="$build_targets ../Applications/Downloader"
+build_targets="$build_targets ../Applications/FileManager"
+build_targets="$build_targets ../Applications/FontEditor"
+build_targets="$build_targets ../Applications/IRCClient"
+build_targets="$build_targets ../Applications/Launcher"
+build_targets="$build_targets ../Applications/PaintBrush"
+build_targets="$build_targets ../Applications/Piano"
+build_targets="$build_targets ../Applications/QuickShow"
+build_targets="$build_targets ../Applications/SystemDialog"
+build_targets="$build_targets ../Applications/SystemMonitor"
+build_targets="$build_targets ../Applications/Taskbar"
+build_targets="$build_targets ../Applications/Terminal"
+build_targets="$build_targets ../Applications/TextEditor"
+
+build_targets="$build_targets ../Demos/Fire"
 build_targets="$build_targets ../Demos/HelloWorld"
 build_targets="$build_targets ../Demos/HelloWorld2"
 build_targets="$build_targets ../Demos/RetroFetch"
 build_targets="$build_targets ../Demos/WidgetGallery"
-build_targets="$build_targets ../Demos/Fire"
+
+build_targets="$build_targets ../DevTools/FormCompiler"
+build_targets="$build_targets ../DevTools/IPCCompiler"
+build_targets="$build_targets ../DevTools/VisualBuilder"
+
+build_targets="$build_targets ../Games/Minesweeper"
+build_targets="$build_targets ../Games/Snake"
+
+build_targets="$build_targets ../Servers/AudioServer"
+build_targets="$build_targets ../Servers/LookupServer"
+build_targets="$build_targets ../Servers/SystemServer"
+build_targets="$build_targets ../Servers/TTYServer"
+build_targets="$build_targets ../Servers/WindowServer"
+
+build_targets="$build_targets ../Shell"
+
+build_targets="$build_targets ../Userland"
+
 build_targets="$build_targets ." # the kernel
 
+(cd ../AK/Tests && $make_cmd clean)
+(cd ../AK/Tests && $make_cmd clean && $make_cmd)
+(cd ../AK/Tests && $make_cmd clean)
+
 for targ in $build_targets; do
-    echo "Building $targ"
     #(cd "$targ" && find . -name "*.c" -o -name "*.cpp" -o -name "*.h" -exec clang-format -i {} \;)
-    $make_cmd -C "$targ" clean
-    $make_cmd -C "$targ"
+
+    if [ -f "$targ/Makefile" ]; then
+        echo "Building $targ"
+        $make_cmd -C "$targ" clean
+        $make_cmd -C "$targ"
+    fi
 
     if [ -f "$targ/install.sh" ]; then
         echo "Installing $targ"
@@ -71,10 +89,4 @@ for targ in $build_targets; do
     fi
 done
 
-# has no need to build separately, but install headers.
-(cd ../AK && ./install.sh)
-(cd ../AK/Tests && $make_cmd clean)
-(cd ../AK/Tests && $make_cmd)
-
 sudo -E ./build-image-qemu.sh
-


### PR DESCRIPTION
makeall.sh used to build the AK tests and leave some binary objects laying
around that would get in the way of further incremental builds. There also
wasn't a lot of structure to the order things were built in. This patch
improves both of those things.