### PR TITLE
Mounts & fstab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 !*/
 !Makefile
 !LICENSE
-!Base/*
+!Base/**
 
 *.o
 *.ao

--- a/Base/etc/fstab
+++ b/Base/etc/fstab
@@ -1,0 +1,4 @@
+/dev/hda	/	ext2
+proc	/proc	proc
+devpts	/dev/pts	devpts
+tmp	/tmp	tmp

--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -14,7 +14,12 @@ Device::~Device()
     VFS::the().unregister_device({}, *this);
 }
 
-String Device::absolute_path(const FileDescription&) const
+String Device::absolute_path() const
 {
     return String::format("device:%u,%u (%s)", m_major, m_minor, class_name());
+}
+
+String Device::absolute_path(const FileDescription&) const
+{
+    return absolute_path();
 }

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -20,6 +20,7 @@ public:
     unsigned minor() const { return m_minor; }
 
     virtual String absolute_path(const FileDescription&) const override;
+    virtual String absolute_path() const;
 
     uid_t uid() const { return m_uid; }
     uid_t gid() const { return m_gid; }

--- a/Kernel/Devices/PATAChannel.cpp
+++ b/Kernel/Devices/PATAChannel.cpp
@@ -99,7 +99,7 @@ PATAChannel::PATAChannel(ChannelType type)
     , m_io_base((type == ChannelType::Primary ? 0x1F0 : 0x170))
 {
     m_dma_enabled.resource() = true;
-    ProcFS::the().add_sys_bool("ide_dma", m_dma_enabled);
+    ProcFS::add_sys_bool("ide_dma", m_dma_enabled);
 
     initialize();
     detect_disks();

--- a/Kernel/FileSystem/DevPtsFS.cpp
+++ b/Kernel/FileSystem/DevPtsFS.cpp
@@ -3,14 +3,6 @@
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/TTY/SlavePTY.h>
 
-static DevPtsFS* s_the;
-
-DevPtsFS& DevPtsFS::the()
-{
-    ASSERT(s_the);
-    return *s_the;
-}
-
 NonnullRefPtr<DevPtsFS> DevPtsFS::create()
 {
     return adopt(*new DevPtsFS);
@@ -18,49 +10,175 @@ NonnullRefPtr<DevPtsFS> DevPtsFS::create()
 
 DevPtsFS::DevPtsFS()
 {
-    s_the = this;
 }
 
 DevPtsFS::~DevPtsFS()
 {
 }
 
+static HashTable<unsigned>* ptys;
+
 bool DevPtsFS::initialize()
 {
-    SynthFS::initialize();
+    if (ptys == nullptr) {
+        ptys = new HashTable<unsigned>();
+    }
+
+    m_root_inode = adopt(*new DevPtsFSInode(*this, 1));
+    m_root_inode->m_metadata.inode = { fsid(), 1 };
+    m_root_inode->m_metadata.mode = 0040555;
+    m_root_inode->m_metadata.uid = 0;
+    m_root_inode->m_metadata.gid = 0;
+    m_root_inode->m_metadata.size = 0;
+    m_root_inode->m_metadata.mtime = mepoch;
+
     return true;
 }
 
-const char* DevPtsFS::class_name() const
+static unsigned inode_index_to_pty_index(unsigned inode_index)
 {
-    return "DevPtsFS";
+    ASSERT(inode_index > 1);
+    return inode_index - 2;
 }
 
-NonnullRefPtr<SynthFSInode> DevPtsFS::create_slave_pty_device_file(unsigned index)
+static unsigned pty_index_to_inode_index(unsigned pty_index)
 {
-    auto file = adopt(*new SynthFSInode(*this, generate_inode_index()));
-    file->m_name = String::number(index);
+    return pty_index + 2;
+}
 
-    auto* device = VFS::the().get_device(11, index);
+InodeIdentifier DevPtsFS::root_inode() const
+{
+    return { fsid(), 1 };
+}
+
+RefPtr<Inode> DevPtsFS::create_inode(InodeIdentifier, const String&, mode_t, off_t, dev_t, int& error)
+{
+    error = -EROFS;
+    return nullptr;
+}
+
+RefPtr<Inode> DevPtsFS::create_directory(InodeIdentifier, const String&, mode_t, int& error)
+{
+    error = -EROFS;
+    return nullptr;
+}
+
+RefPtr<Inode> DevPtsFS::get_inode(InodeIdentifier inode_id) const
+{
+    if (inode_id.index() == 1)
+        return m_root_inode;
+
+    unsigned pty_index = inode_index_to_pty_index(inode_id.index());
+    auto* device = VFS::the().get_device(11, pty_index);
     ASSERT(device);
 
-    file->m_metadata.size = 0;
-    file->m_metadata.uid = device->uid();
-    file->m_metadata.gid = device->gid();
-    file->m_metadata.mode = 0020644;
-    file->m_metadata.major_device = device->major();
-    file->m_metadata.minor_device = device->minor();
-    file->m_metadata.mtime = mepoch;
-    return file;
+    auto inode = adopt(*new DevPtsFSInode(const_cast<DevPtsFS&>(*this), inode_id.index()));
+    inode->m_metadata.inode = inode_id;
+    inode->m_metadata.size = 0;
+    inode->m_metadata.uid = device->uid();
+    inode->m_metadata.gid = device->gid();
+    inode->m_metadata.mode = 0020644;
+    inode->m_metadata.major_device = device->major();
+    inode->m_metadata.minor_device = device->minor();
+    inode->m_metadata.mtime = mepoch;
+
+    return inode;
 }
 
 void DevPtsFS::register_slave_pty(SlavePTY& slave_pty)
 {
-    auto inode_id = add_file(create_slave_pty_device_file(slave_pty.index()));
-    slave_pty.set_devpts_inode_id(inode_id);
+    ptys->set(slave_pty.index());
 }
 
 void DevPtsFS::unregister_slave_pty(SlavePTY& slave_pty)
 {
-    remove_file(slave_pty.devpts_inode_id().index());
+    ptys->remove(slave_pty.index());
+}
+
+DevPtsFSInode::DevPtsFSInode(DevPtsFS& fs, unsigned index)
+    : Inode(fs, index)
+{
+}
+
+DevPtsFSInode::~DevPtsFSInode()
+{
+}
+
+ssize_t DevPtsFSInode::read_bytes(off_t, ssize_t, u8*, FileDescription*) const
+{
+    ASSERT_NOT_REACHED();
+}
+
+ssize_t DevPtsFSInode::write_bytes(off_t, ssize_t, const u8*, FileDescription*)
+{
+    ASSERT_NOT_REACHED();
+}
+
+InodeMetadata DevPtsFSInode::metadata() const
+{
+    return m_metadata;
+}
+
+bool DevPtsFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntry&)> callback) const
+{
+    if (identifier().index() > 1)
+        return false;
+
+    callback({ ".", 1, identifier(), 0 });
+    callback({ "..", 2, identifier(), 0 });
+
+    for (unsigned pty_index : *ptys) {
+        String name = String::number(pty_index);
+        InodeIdentifier identifier = { fsid(), pty_index_to_inode_index(pty_index) };
+        callback({ name.characters(), name.length(), identifier, 0 });
+    }
+
+    return true;
+}
+
+size_t DevPtsFSInode::directory_entry_count() const
+{
+    ASSERT(identifier().index() == 1);
+
+    return 2 + ptys->size();
+}
+
+InodeIdentifier DevPtsFSInode::lookup(StringView name)
+{
+    ASSERT(identifier().index() == 1);
+
+    if (name == "." || name == "..")
+        return identifier();
+
+    bool ok;
+    unsigned pty_index = name.to_uint(ok);
+    if (ok && ptys->contains(pty_index)) {
+        return { fsid(), pty_index_to_inode_index(pty_index) };
+    }
+
+    return {};
+}
+
+void DevPtsFSInode::flush_metadata()
+{
+}
+
+KResult DevPtsFSInode::add_child(InodeIdentifier, const StringView&, mode_t)
+{
+    return KResult(-EROFS);
+}
+
+KResult DevPtsFSInode::remove_child(const StringView&)
+{
+    return KResult(-EROFS);
+}
+
+KResult DevPtsFSInode::chmod(mode_t)
+{
+    return KResult(-EPERM);
+}
+
+KResult DevPtsFSInode::chown(uid_t, gid_t)
+{
+    return KResult(-EPERM);
 }

--- a/Kernel/FileSystem/DevPtsFS.h
+++ b/Kernel/FileSystem/DevPtsFS.h
@@ -1,28 +1,54 @@
 #pragma once
 
 #include <AK/Types.h>
-#include <Kernel/FileSystem/SyntheticFileSystem.h>
+#include <Kernel/FileSystem/FileSystem.h>
+#include <Kernel/FileSystem/Inode.h>
 
-class Process;
 class SlavePTY;
+class DevPtsFSInode;
 
-class DevPtsFS final : public SynthFS {
+class DevPtsFS final : public FS {
 public:
-    static DevPtsFS& the();
-
     virtual ~DevPtsFS() override;
     static NonnullRefPtr<DevPtsFS> create();
 
     virtual bool initialize() override;
-    virtual const char* class_name() const override;
+    virtual const char* class_name() const override { return "DevPtsFS"; }
 
-    void register_slave_pty(SlavePTY&);
-    void unregister_slave_pty(SlavePTY&);
+    virtual InodeIdentifier root_inode() const override;
+    virtual RefPtr<Inode> create_inode(InodeIdentifier parentInode, const String& name, mode_t, off_t size, dev_t, int& error) override;
+    virtual RefPtr<Inode> create_directory(InodeIdentifier parentInode, const String& name, mode_t, int& error) override;
+    virtual RefPtr<Inode> get_inode(InodeIdentifier) const override;
+
+    static void register_slave_pty(SlavePTY&);
+    static void unregister_slave_pty(SlavePTY&);
 
 private:
     DevPtsFS();
 
-    NonnullRefPtr<SynthFSInode> create_slave_pty_device_file(unsigned index);
+    RefPtr<DevPtsFSInode> m_root_inode;
+};
 
-    HashTable<SlavePTY*> m_slave_ptys;
+class DevPtsFSInode final : public Inode {
+    friend class DevPtsFS;
+public:
+    virtual ~DevPtsFSInode() override;
+
+private:
+    DevPtsFSInode(DevPtsFS&, unsigned index);
+
+    // ^Inode
+    virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const override;
+    virtual InodeMetadata metadata() const override;
+    virtual bool traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const override;
+    virtual InodeIdentifier lookup(StringView name) override;
+    virtual void flush_metadata() override;
+    virtual ssize_t write_bytes(off_t, ssize_t, const u8* buffer, FileDescription*) override;
+    virtual KResult add_child(InodeIdentifier child_id, const StringView& name, mode_t) override;
+    virtual KResult remove_child(const StringView& name) override;
+    virtual size_t directory_entry_count() const override;
+    virtual KResult chmod(mode_t) override;
+    virtual KResult chown(uid_t, gid_t) override;
+
+    InodeMetadata m_metadata;
 };

--- a/Kernel/FileSystem/DiskBackedFileSystem.h
+++ b/Kernel/FileSystem/DiskBackedFileSystem.h
@@ -7,6 +7,8 @@ class DiskBackedFS : public FS {
 public:
     virtual ~DiskBackedFS() override;
 
+    virtual bool is_disk_backed() const override { return true; }
+
     DiskDevice& device() { return *m_device; }
     const DiskDevice& device() const { return *m_device; }
 

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -65,6 +65,8 @@ public:
 
     int block_size() const { return m_block_size; }
 
+    virtual bool is_disk_backed() const { return false; }
+
 protected:
     FS();
 

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -9,6 +9,7 @@
 #include <AK/JsonValue.h>
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/FileSystem/Custody.h>
+#include <Kernel/FileSystem/DiskBackedFileSystem.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/KBufferBuilder.h>
@@ -502,7 +503,13 @@ Optional<KBuffer> procfs$df(InodeIdentifier)
         fs_object.set("mount_point", mount.absolute_path());
         fs_object.set("block_size", fs.block_size());
         fs_object.set("readonly", fs.is_readonly());
-        json.append(fs_object);
+
+        if (fs.is_disk_backed())
+            fs_object.set("device", static_cast<const DiskBackedFS&>(fs).device().absolute_path());
+        else
+            fs_object.set("device", nullptr);
+
+        json.append(move(fs_object));
     });
     return json.serialized<KBufferBuilder>();
 }

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -186,7 +186,7 @@ public:
     int sys$unlink(const char* pathname);
     int sys$symlink(const char* target, const char* linkpath);
     int sys$rmdir(const char* pathname);
-    int sys$mount(const char* device, const char* mountpoint);
+    int sys$mount(const char* device, const char* mountpoint, const char* fstype);
     int sys$umount(const char* mountpoint);
     int sys$read_tsc(u32* lsw, u32* msw);
     int sys$chmod(const char* pathname, mode_t);

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -293,7 +293,7 @@ static u32 handle(RegisterDump& regs, u32 function, u32 arg1, u32 arg2, u32 arg3
         break;
     }
     case Syscall::SC_mount:
-        return current->process().sys$mount((const char*)arg1, (const char*)arg2);
+        return current->process().sys$mount((const char*)arg1, (const char*)arg2, (const char*)arg3);
     case Syscall::SC_reboot: {
         return current->process().sys$reboot();
     }

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -13,7 +13,7 @@ SlavePTY::SlavePTY(MasterPTY& master, unsigned index)
     m_tty_name = String::format("/dev/pts/%u", m_index);
     set_uid(current->process().uid());
     set_gid(current->process().gid());
-    DevPtsFS::the().register_slave_pty(*this);
+    DevPtsFS::register_slave_pty(*this);
     set_size(80, 25);
 }
 
@@ -22,7 +22,7 @@ SlavePTY::~SlavePTY()
 #ifdef SLAVEPTY_DEBUG
     dbgprintf("~SlavePTY(%u)\n", m_index);
 #endif
-    DevPtsFS::the().unregister_slave_pty(*this);
+    DevPtsFS::unregister_slave_pty(*this);
 }
 
 String SlavePTY::tty_name() const

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -12,9 +12,6 @@ public:
     void on_master_write(const u8*, ssize_t);
     unsigned index() const { return m_index; }
 
-    InodeIdentifier devpts_inode_id() const { return m_devpts_inode_id; }
-    void set_devpts_inode_id(InodeIdentifier inode_id) { m_devpts_inode_id = inode_id; }
-
 private:
     // ^TTY
     virtual String tty_name() const override;
@@ -32,6 +29,5 @@ private:
 
     RefPtr<MasterPTY> m_master;
     unsigned m_index;
-    InodeIdentifier m_devpts_inode_id;
     String m_tty_name;
 };

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -122,7 +122,10 @@ VFS* vfs;
     auto procfs = ProcFS::create();
     procfs->initialize();
     vfs->mount(procfs, "/proc");
-    vfs->mount(DevPtsFS::the(), "/dev/pts");
+
+    auto devptsfs = DevPtsFS::create();
+    devptsfs->initialize();
+    vfs->mount(devptsfs, "/dev/pts");
 
     auto tmpfs = TmpFS::create();
     if (!tmpfs->initialize())

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -119,7 +119,9 @@ VFS* vfs;
     dbgprintf("Loaded ksyms\n");
 
     // TODO: we should mount these from SystemServer
-    vfs->mount(ProcFS::the(), "/proc");
+    auto procfs = ProcFS::create();
+    procfs->initialize();
+    vfs->mount(procfs, "/proc");
     vfs->mount(DevPtsFS::the(), "/dev/pts");
 
     auto tmpfs = TmpFS::create();

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -551,9 +551,9 @@ int reboot()
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-int mount(const char* device, const char* mountpoint)
+int mount(const char* device, const char* mountpoint, const char* fstype)
 {
-    int rc = syscall(SC_mount, device, mountpoint);
+    int rc = syscall(SC_mount, device, mountpoint, fstype);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -236,6 +236,11 @@ pid_t waitpid(pid_t waitee, int* wstatus, int options)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+pid_t wait(int* wstatus)
+{
+    return waitpid(-1, wstatus, 0);
+}
+
 int lstat(const char* path, struct stat* statbuf)
 {
     int rc = syscall(SC_lstat, path, statbuf);

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -100,7 +100,7 @@ int fchown(int fd, uid_t, gid_t);
 int ftruncate(int fd, off_t length);
 int halt();
 int reboot();
-int mount(const char* device, const char* mountpoint);
+int mount(const char* device, const char* mountpoint, const char* fstype);
 int umount(const char* mountpoint);
 
 enum {

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -66,6 +66,7 @@ ssize_t read(int fd, void* buf, size_t count);
 ssize_t write(int fd, const void* buf, size_t count);
 int close(int fd);
 pid_t waitpid(pid_t, int* wstatus, int options);
+pid_t wait(int* wstatus);
 int chdir(const char* path);
 char* getcwd(char* buffer, size_t size);
 char* getwd(char* buffer);

--- a/Libraries/LibCore/CArgsParser.cpp
+++ b/Libraries/LibCore/CArgsParser.cpp
@@ -108,7 +108,8 @@ int CArgsParser::parse_next_param(int index, char** argv, const int params_left,
 
 bool CArgsParser::is_param_valid(const String& param_name)
 {
-    return param_name.substring(0, m_prefix.length()) == m_prefix;
+    return param_name.length() >= m_prefix.length() &&
+        param_name.substring(0, m_prefix.length()) == m_prefix;
 }
 
 bool CArgsParser::check_required_args(const CArgsParserResult& res)

--- a/Userland/mount.cpp
+++ b/Userland/mount.cpp
@@ -1,28 +1,114 @@
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <AK/JsonValue.h>
 #include <LibCore/CArgsParser.h>
+#include <LibCore/CFile.h>
 #include <stdio.h>
 #include <unistd.h>
+
+bool mount_all()
+{
+    // Mount all filesystems listed in /etc/fstab.
+    dbg() << "Mounting all filesystems...";
+
+    CFile fstab { "/etc/fstab" };
+    if (!fstab.open(CIODevice::OpenMode::ReadOnly)) {
+        fprintf(stderr, "Failed to open /etc/fstab: %s\n", fstab.error_string());
+        return false;
+    }
+
+    bool all_ok = true;
+    while (fstab.can_read_line()) {
+        ByteBuffer buffer = fstab.read_line(1024);
+        StringView line_view = (const char*)buffer.data();
+
+        // Trim the trailing newline, if any.
+        if (line_view.length() > 0 && line_view[line_view.length() - 1] == '\n')
+            line_view = line_view.substring_view(0, line_view.length() - 1);
+        String line = line_view;
+
+        Vector<String> parts = line.split('\t');
+        if (parts.size() < 3) {
+            fprintf(stderr, "Invalid fstab entry: %s\n", line.characters());
+            all_ok = false;
+            continue;
+        }
+
+        const char* devname = parts[0].characters();
+        const char* mountpoint = parts[1].characters();
+        const char* fstype = parts[2].characters();
+
+        if (strcmp(mountpoint, "/") == 0) {
+            dbg() << "Skipping mounting root";
+            continue;
+        }
+
+        dbg() << "Mounting " << devname << "(" << fstype << ")"
+              << " on " << mountpoint;
+        int rc = mount(devname, mountpoint, fstype);
+        if (rc != 0) {
+            fprintf(stderr, "Failed to mount %s (%s) on %s: %s\n", devname, fstype, mountpoint, strerror(errno));
+            all_ok = false;
+            continue;
+        }
+    }
+
+    return all_ok;
+}
+
+bool print_mounts()
+{
+    // Output info about currently mounted filesystems.
+    CFile df("/proc/df");
+    if (!df.open(CIODevice::ReadOnly)) {
+        fprintf(stderr, "Failed to open /proc/df: %s\n", df.error_string());
+        return false;
+    }
+
+    auto content = df.read_all();
+    auto json = JsonValue::from_string(content).as_array();
+
+    json.for_each([](auto& value) {
+        auto fs_object = value.as_object();
+        auto class_name = fs_object.get("class_name").to_string();
+        auto mount_point = fs_object.get("mount_point").to_string();
+        auto device = fs_object.get("device").as_string_or(class_name);
+
+        printf("%s on %s type %s\n", device.characters(), mount_point.characters(), class_name.characters());
+    });
+
+    return true;
+}
 
 int main(int argc, char** argv)
 {
     CArgsParser args_parser("mount");
     args_parser.add_arg("devname", "device path");
     args_parser.add_arg("mountpoint", "mount point");
-    args_parser.add_arg("fstype", "file system type");
+    args_parser.add_arg("t", "fstype", "file system type");
+    args_parser.add_arg("a", "mount all systems listed in /etc/fstab");
     CArgsParserResult args = args_parser.parse(argc, argv);
 
-    if (argc < 3 || argc > 4) {
-        args_parser.print_usage();
+    if (args.is_present("a")) {
+        return mount_all() ? 0 : 1;
+    }
+
+    switch (args.get_single_values().size()) {
+    case 0:
+        return print_mounts() ? 0 : 1;
+    case 2: {
+        String devname = args.get_single_values()[0];
+        String mountpoint = args.get_single_values()[1];
+        String fstype = args.is_present("t") ? args.get("t") : "ext2";
+
+        if (mount(devname.characters(), mountpoint.characters(), fstype.characters()) < 0) {
+            perror("mount");
+            return 1;
+        }
         return 0;
     }
-
-    const char* devname = argv[1];
-    const char* mountpoint = argv[2];
-    const char* fstype = argc == 4 ? argv[3] : "ext2";
-
-    if (mount(devname, mountpoint, fstype) < 0) {
-        perror("mount");
+    default:
+        args_parser.print_usage();
         return 1;
     }
-
-    return 0;
 }

--- a/Userland/mount.cpp
+++ b/Userland/mount.cpp
@@ -2,27 +2,26 @@
 #include <stdio.h>
 #include <unistd.h>
 
-// This version of 'mount' must have the following arguments
-// 'mount <device_path> <mount_point>
-// It can currently only mount _physical_ devices found in /dev
-//
-// Currently, it is only possible to mount ext2 devices. Sorry! :^)
 int main(int argc, char** argv)
 {
     CArgsParser args_parser("mount");
     args_parser.add_arg("devname", "device path");
     args_parser.add_arg("mountpoint", "mount point");
+    args_parser.add_arg("fstype", "file system type");
     CArgsParserResult args = args_parser.parse(argc, argv);
 
-    if (argc == 3) {
-        // Let's use lstat so we can convert devname into a major/minor device pair!
-        if (mount(argv[1], argv[2]) < 0) {
-            perror("mount");
-            return 1;
-        }
-    } else {
+    if (argc < 3 || argc > 4) {
         args_parser.print_usage();
         return 0;
+    }
+
+    const char* devname = argv[1];
+    const char* mountpoint = argv[2];
+    const char* fstype = argc == 4 ? argv[3] : "ext2";
+
+    if (mount(devname, mountpoint, fstype) < 0) {
+        perror("mount");
+        return 1;
     }
 
     return 0;


### PR DESCRIPTION
The overall idea here is to move mounting filesystems and spawning `TTYServer`s to userspace (namely, `SystemServer`), see the last commit.

For this to work, we need to allow mounting non-ext2 filesystems from userspace.

For _that_ to work, `ProcFS` and `DevPtsFS` need to stop assuming there is exactly one of each mounted (`::the()`). Now, there can be none (and indeed that's how it is until `SystemServer` runs `mount -a` to mount them) or many (pretty useless unless we want to introduce containers, but it's fun — try `mkdir /tmp/foo && mount bar /tmp/foo -t proc`, for example).

Supporting _that_ meant refactoring "state" (sys variables for `ProcFS`, valid ptys for `DevPtsFS`) to be stored globally independent of any actual `FS` instance. That actually resulted in a cleanup of how sys variables work; but in case of `DevPtsFS` that meant it can no longer be based on `SynthFS`, so I had to reimplement it more or less completely.