### PR TITLE
WindowServer: Detect framebuffer capabilities and settings

### DIFF
--- a/Kernel/Devices/BXVGADevice.h
+++ b/Kernel/Devices/BXVGADevice.h
@@ -12,16 +12,8 @@ public:
 
     BXVGADevice();
 
-    PhysicalAddress framebuffer_address() const { return m_framebuffer_address; }
-    void set_resolution(int width, int height);
-    void set_y_offset(int);
-
     virtual int ioctl(FileDescription&, unsigned request, unsigned arg) override;
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, VirtualAddress preferred_vaddr, size_t offset, size_t, int prot) override;
-
-    size_t framebuffer_size_in_bytes() const { return m_framebuffer_width * m_framebuffer_height * sizeof(u32) * 2; }
-    int framebuffer_width() const { return m_framebuffer_width; }
-    int framebuffer_height() const { return m_framebuffer_height; }
 
 private:
     virtual const char* class_name() const override { return "BXVGA"; }
@@ -32,8 +24,13 @@ private:
 
     void set_register(u16 index, u16 value);
     u32 find_framebuffer_address();
+    size_t framebuffer_size_in_bytes() const { return m_framebuffer_pitch * m_framebuffer_height * 2; }
+    void set_resolution(int width, int height);
+    void set_y_offset(int);
 
     PhysicalAddress m_framebuffer_address;
+    int m_framebuffer_pitch { 0 };
     int m_framebuffer_width { 0 };
     int m_framebuffer_height { 0 };
+    int m_y_offset { 0 };
 };

--- a/Kernel/FB.h
+++ b/Kernel/FB.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <sys/cdefs.h>
+#include <sys/ioctl.h>
+
+__BEGIN_DECLS
+
+int fb_get_size_in_bytes(int fd, size_t* out)
+{
+    return ioctl(fd, FB_IOCTL_GET_SIZE_IN_BYTES, out);
+}
+
+int fb_get_resolution(int fd, FBResolution* info)
+{
+    return ioctl(fd, FB_IOCTL_GET_RESOLUTION, info);
+}
+
+int fb_set_resolution(int fd, FBResolution* info)
+{
+    return ioctl(fd, FB_IOCTL_SET_RESOLUTION, info);
+}
+
+int fb_get_buffer(int fd, int* index)
+{
+    return ioctl(fd, FB_IOCTL_GET_BUFFER, index);
+}
+
+int fb_set_buffer(int fd, int index)
+{
+    return ioctl(fd, FB_IOCTL_SET_BUFFER, index);
+}
+
+__END_DECLS

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -215,11 +215,6 @@
 #define TCSADRAIN 1
 #define TCSAFLUSH 2
 
-struct winsize {
-    unsigned short ws_row;
-    unsigned short ws_col;
-};
-
 typedef u32 dev_t;
 typedef u32 ino_t;
 typedef u16 mode_t;

--- a/Libraries/LibC/sys/ioctl.h
+++ b/Libraries/LibC/sys/ioctl.h
@@ -5,11 +5,6 @@
 
 __BEGIN_DECLS
 
-struct winsize {
-    unsigned short ws_row;
-    unsigned short ws_col;
-};
-
 int ioctl(int fd, unsigned request, ...);
 
 __END_DECLS

--- a/Libraries/LibC/sys/ioctl_numbers.h
+++ b/Libraries/LibC/sys/ioctl_numbers.h
@@ -1,5 +1,16 @@
 #pragma once
 
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
+struct winsize {
+    unsigned short ws_row;
+    unsigned short ws_col;
+};
+
+__END_DECLS
+
 enum IOCtlNumber {
     TIOCGPGRP,
     TIOCSPGRP,

--- a/Libraries/LibC/sys/ioctl_numbers.h
+++ b/Libraries/LibC/sys/ioctl_numbers.h
@@ -9,6 +9,12 @@ struct winsize {
     unsigned short ws_col;
 };
 
+struct FBResolution {
+    int pitch;
+    int width;
+    int height;
+};
+
 __END_DECLS
 
 enum IOCtlNumber {
@@ -22,4 +28,9 @@ enum IOCtlNumber {
     TIOCSCTTY,
     TIOCNOTTY,
     TIOCSWINSZ,
+    FB_IOCTL_GET_SIZE_IN_BYTES,
+    FB_IOCTL_GET_RESOLUTION,
+    FB_IOCTL_SET_RESOLUTION,
+    FB_IOCTL_GET_BUFFER,
+    FB_IOCTL_SET_BUFFER,
 };

--- a/Servers/WindowServer/WSCompositor.h
+++ b/Servers/WindowServer/WSCompositor.h
@@ -27,7 +27,7 @@ public:
     void invalidate();
     void invalidate(const Rect&);
 
-    void set_resolution(int width, int height);
+    void set_resolution(int desired_width, int desired_height);
 
     bool set_wallpaper(const String& path, Function<void(bool)>&& callback);
     String wallpaper_path() const { return m_wallpaper_path; }
@@ -35,10 +35,9 @@ public:
     void invalidate_cursor();
     Rect current_cursor_rect() const;
 
-    bool can_flip_buffers() const { return false; }
-
 private:
     WSCompositor();
+    void init_bitmaps();
     void flip_buffers();
     void flush(const Rect&);
     void draw_cursor();
@@ -52,6 +51,7 @@ private:
     CTimer m_immediate_compose_timer;
     bool m_flash_flush { false };
     bool m_buffers_are_flipped { false };
+    bool m_screen_can_set_buffer { false };
 
     RefPtr<GraphicsBitmap> m_front_bitmap;
     RefPtr<GraphicsBitmap> m_back_bitmap;

--- a/Servers/WindowServer/WSScreen.h
+++ b/Servers/WindowServer/WSScreen.h
@@ -11,6 +11,8 @@ public:
     ~WSScreen();
 
     void set_resolution(int width, int height);
+    bool can_set_buffer() { return m_can_set_buffer; }
+    void set_buffer(int index);
 
     int width() const { return m_width; }
     int height() const { return m_height; }
@@ -21,8 +23,6 @@ public:
     Size size() const { return { width(), height() }; }
     Rect rect() const { return { 0, 0, width(), height() }; }
 
-    void set_y_offset(int);
-
     Point cursor_location() const { return m_cursor_location; }
     unsigned mouse_button_state() const { return m_mouse_button_state; }
 
@@ -30,8 +30,14 @@ public:
     void on_receive_keyboard_data(KeyEvent);
 
 private:
-    RGBA32* m_framebuffer { nullptr };
+    void on_change_resolution(int pitch, int width, int height);
 
+    size_t m_size_in_bytes;
+
+    RGBA32* m_framebuffer { nullptr };
+    bool m_can_set_buffer { false };
+
+    int m_pitch { 0 };
     int m_width { 0 };
     int m_height { 0 };
     int m_framebuffer_fd { -1 };
@@ -43,6 +49,5 @@ private:
 
 inline RGBA32* WSScreen::scanline(int y)
 {
-    size_t pitch = sizeof(RGBA32) * width();
-    return reinterpret_cast<RGBA32*>(((u8*)m_framebuffer) + (y * pitch));
+    return reinterpret_cast<RGBA32*>(((u8*)m_framebuffer) + (y * m_pitch));
 }


### PR DESCRIPTION
The main changes are twofold:

* Buffer flipping is now controlled by the m_screen_can_set_buffer flag
in WSCompositor. This flag, in turn, is impacted by m_can_set_buffer
flag, in WSScreen. m_can_set_buffer is set in the WSScreen constructor
by checking the return value of fb_set_buffer. If the framebuffer
supports this operation, it will succeed, and we record this fact. This
information is then used by WSCompositor to set its own
m_screen_can_set_buffer flag.

* WSScreen now only requests a resolution change of the framebuffer. The
driver itself is ultimately responsible for what resolution or mode is
actually set, so WSScreen has to read the response from that request,
and has no choice but to accept the answer. This allows the driver to
choose a "close enough" value to what was requested, or simply ignore
it.

The result of this is that there is no special configuration necessary for
WindowServer to work with reduced-capability framebuffer devices.

There are also some supporting changes introducing some generic
framebuffer ioctls that enable this functionality.