### PR TITLE
Fix WSMenu not working due to a failing assertion

### DIFF
--- a/Servers/WindowServer/WSMenu.cpp
+++ b/Servers/WindowServer/WSMenu.cpp
@@ -157,8 +157,8 @@ void WSMenu::draw()
 
 void WSMenu::event(CEvent& event)
 {
-    ASSERT(menu_window());
     if (event.type() == WSEvent::MouseMove) {
+        ASSERT(menu_window());
         auto* item = item_at(static_cast<const WSMouseEvent&>(event).position());
         if (!item || m_hovered_item == item)
             return;
@@ -168,6 +168,7 @@ void WSMenu::event(CEvent& event)
     }
 
     if (event.type() == WSEvent::MouseUp) {
+        ASSERT(menu_window());
         if (!m_hovered_item)
             return;
         if (m_hovered_item->is_enabled())


### PR DESCRIPTION
Now that the window used by a `WSMenu` is its child `CObject`, the menu also receives `CChildEvent`'s about the window, including `CEvent::ChildAdded` when the window gets created. At this point, `menu_window()` still returns `nullptr`, so stop unconditionally assuming that it doesn't. We should not care whether or not we have a window for unrelated events anyway.