### PR TITLE
Userland: Fixed a division by zero error in the ls command.

### DIFF
--- a/Userland/ls.cpp
+++ b/Userland/ls.cpp
@@ -272,7 +272,9 @@ int do_file_system_object_short(const char* path)
 
         if (!print_filesystem_object_short(pathbuf, name.characters(), &nprinted))
             return 2;
-        int offset = columns % longest_name / (columns / longest_name);
+        int offset = 0;
+        if (columns > longest_name)
+            offset = columns % longest_name / (columns / longest_name);
         /* The offset must be at least 2 because:
 	 * - With each file an aditional char is printed e.g. '@','*'.
 	 * - Each filename must be separated by a space.


### PR DESCRIPTION
When the Terminal app window became small enough so that the columns were smaller than the longest filename, the calculation of the offset resulted in a division by zero.