### PR TITLE
TextEditor: Replaced 'Find' button with 'Prev' and 'Next' buttons.

### DIFF
--- a/Applications/TextEditor/TextEditorWidget.h
+++ b/Applications/TextEditor/TextEditorWidget.h
@@ -31,6 +31,7 @@ private:
     RefPtr<GAction> m_find_action;
 
     GTextBox* m_find_textbox { nullptr };
-    GButton* m_find_button { nullptr };
+    GButton* m_find_prev_button { nullptr };
+    GButton* m_find_next_button { nullptr };
     GWidget* m_find_widget { nullptr };
 };

--- a/Libraries/LibGUI/GTextEditor.h
+++ b/Libraries/LibGUI/GTextEditor.h
@@ -12,6 +12,7 @@ class GScrollBar;
 class Painter;
 
 enum class ShouldWrapAtEndOfDocument { No = 0, Yes };
+enum class ShouldWrapAtStartOfDocument { No = 0, Yes };
 
 class GTextPosition {
 public:
@@ -126,9 +127,12 @@ public:
 
     bool write_to_file(const StringView& path);
 
-    GTextRange find(const StringView&, const GTextPosition& start = {});
-    GTextPosition next_position_after(const GTextPosition&, ShouldWrapAtEndOfDocument = ShouldWrapAtEndOfDocument::Yes);
+    GTextRange find_next(const StringView&, const GTextPosition& start = {});
+    GTextRange find_prev(const StringView&, const GTextPosition& start = {});
 
+    GTextPosition next_position_after(const GTextPosition&, ShouldWrapAtEndOfDocument = ShouldWrapAtEndOfDocument::Yes);
+    GTextPosition prev_position_before(const GTextPosition&, ShouldWrapAtStartOfDocument = ShouldWrapAtStartOfDocument::Yes);
+    
     bool has_selection() const { return m_selection.is_valid(); }
     String selected_text() const;
     void set_selection(const GTextRange&);


### PR DESCRIPTION
This is my first PR, so Hello!

I did this because I saw  [issue #478](https://github.com/SerenityOS/serenity/issues/478) and thought it would be fun.

There is some duplicated code in the TextEditorWidget.cpp constructor because the prev and next buttons have some shared functionality. 

I was thinking about consolidating it into one method but I wasn't sure if that was too much stuff to do in one commit.

I tried my best to follow all guidlines. Feedback is appreciated!

Here's a 30 second youtube video showing the functionality.
https://youtu.be/Webnl071VSA