### PR TITLE
GTextEditor: Fixed bug in find_prev

### DIFF
--- a/Libraries/LibGUI/GTextEditor.cpp
+++ b/Libraries/LibGUI/GTextEditor.cpp
@@ -1295,6 +1295,7 @@ GTextRange GTextEditor::find_prev(const StringView& needle, const GTextPosition&
         return {};
 
     GTextPosition position = start.is_valid() ? start : GTextPosition(0, 0);
+    position = prev_position_before(position);
     GTextPosition original_position = position;
 
     GTextPosition end_of_potential_match;


### PR DESCRIPTION
find_prev returned invalid when the contents of the buffer were equal to the contents of the search box. This is due to the checker walking on an empty character at the end of a line.