### PR TITLE
Streaming JSON serializers

### DIFF
--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <AK/JsonArraySerializer.h>
 #include <AK/JsonValue.h>
 #include <AK/Vector.h>
 
@@ -68,13 +69,8 @@ private:
 template<typename Builder>
 inline void JsonArray::serialize(Builder& builder) const
 {
-    builder.append('[');
-    for (int i = 0; i < m_values.size(); ++i) {
-        m_values[i].serialize(builder);
-        if (i != size() - 1)
-            builder.append(',');
-    }
-    builder.append(']');
+    JsonArraySerializer serializer { builder };
+    for_each([&](auto& value) { serializer.add(value); });
 }
 
 template<typename Builder>

--- a/AK/JsonArraySerializer.h
+++ b/AK/JsonArraySerializer.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <AK/JsonValue.h>
+
+namespace AK {
+
+template<typename Builder>
+class JsonObjectSerializer;
+
+template<typename Builder>
+class JsonArraySerializer {
+public:
+    explicit JsonArraySerializer(Builder& builder)
+        : m_builder(builder)
+    {
+        m_builder.append('[');
+    }
+
+    JsonArraySerializer(const JsonArraySerializer&) = delete;
+    JsonArraySerializer(JsonArraySerializer&&) = delete;
+
+    ~JsonArraySerializer()
+    {
+        if (!m_finished)
+            finish();
+    }
+
+    void add(const JsonValue& value)
+    {
+        begin_item();
+        value.serialize(m_builder);
+    }
+
+    JsonArraySerializer<Builder> add_array()
+    {
+        begin_item();
+        return JsonArraySerializer(m_builder);
+    }
+
+    // Implemented in JsonObjectSerializer.h
+    JsonObjectSerializer<Builder> add_object();
+
+    void finish()
+    {
+        ASSERT(!m_finished);
+        m_finished = true;
+        m_builder.append(']');
+    }
+
+private:
+    void begin_item()
+    {
+        if (!m_empty)
+            m_builder.append(',');
+        m_empty = false;
+    }
+
+    Builder& m_builder;
+    bool m_empty { true };
+    bool m_finished { false };
+};
+
+}
+
+using AK::JsonArraySerializer;

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -3,6 +3,7 @@
 #include <AK/AKString.h>
 #include <AK/HashMap.h>
 #include <AK/JsonArray.h>
+#include <AK/JsonObjectSerializer.h>
 #include <AK/JsonValue.h>
 
 namespace AK {
@@ -79,19 +80,10 @@ private:
 template<typename Builder>
 inline void JsonObject::serialize(Builder& builder) const
 {
-    int index = 0;
-    builder.append('{');
+    JsonObjectSerializer serializer { builder };
     for_each_member([&](auto& key, auto& value) {
-        builder.append('"');
-        builder.append(key);
-        builder.append('"');
-        builder.append(':');
-        value.serialize(builder);
-        if (index != size() - 1)
-            builder.append(',');
-        ++index;
+            serializer.add(key, value);
     });
-    builder.append('}');
 }
 
 template<typename Builder>

--- a/AK/JsonObjectSerializer.h
+++ b/AK/JsonObjectSerializer.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <AK/JsonArraySerializer.h>
+#include <AK/JsonValue.h>
+
+namespace AK {
+
+template<typename Builder>
+class JsonObjectSerializer {
+public:
+    explicit JsonObjectSerializer(Builder& builder)
+        : m_builder(builder)
+    {
+        m_builder.append('{');
+    }
+
+    JsonObjectSerializer(const JsonObjectSerializer&) = delete;
+    JsonObjectSerializer(JsonObjectSerializer&&) = delete;
+
+    ~JsonObjectSerializer()
+    {
+        if (!m_finished)
+            finish();
+    }
+
+    void add(const StringView& key, const JsonValue& value)
+    {
+        begin_item(key);
+        value.serialize(m_builder);
+    }
+
+    JsonArraySerializer<Builder> add_array(const StringView& key)
+    {
+        begin_item(key);
+        return JsonArraySerializer(m_builder);
+    }
+
+    JsonObjectSerializer<Builder> add_object(const StringView& key)
+    {
+        begin_item(key);
+        return JsonObjectSerializer(m_builder);
+    }
+
+    void finish()
+    {
+        ASSERT(!m_finished);
+        m_finished = true;
+        m_builder.append('}');
+    }
+
+private:
+    void begin_item(const StringView& key)
+    {
+        if (!m_empty)
+            m_builder.append(',');
+        m_empty = false;
+
+        m_builder.append('"');
+        m_builder.append(key);
+        m_builder.append("\":");
+    }
+
+    Builder& m_builder;
+    bool m_empty { true };
+    bool m_finished { false };
+};
+
+template<typename Builder>
+JsonObjectSerializer<Builder> JsonArraySerializer<Builder>::add_object()
+{
+    begin_item();
+    return JsonObjectSerializer(m_builder);
+}
+
+}
+
+using AK::JsonObjectSerializer;


### PR DESCRIPTION
Two new classes, `JsonArraySerializer` and `JsonObjectSerializer`, that can be used to serialize JSON to a builder without generating the whole structure in memory in advance. You can use them like this:

```c++
SomeBuilder builder;
JsonArraySerializer array { builder };
array.add(35);
array.add("awesome");

// A nested array.
{
    JsonArraySerializer nested_array = array.add_array();
    nested_array.add(42);
}

// A nested object.
{
    JsonObjectSerializer nested_object = array.add_object();
    nested_object.add("foo", "bar");
}
```

Note how instead of first creating the nested array/object (all in memory!) and then doing `array.add(move(nested))` we get the nested object from the parent. Both serializer classes are just a few bytes in size, so doing this is really cheap, and `add()` writes content directly to the builder.

This should help with https://github.com/SerenityOS/serenity/issues/484

`JsonObject::serialize()` and `JsonArray::serialize()` themselves now wrap these serializer classes. It's not more (or less) efficient to do this if you already have the array/object in memory, but this way we avoid duplicating the logic.