### PR TITLE
AK: Make printf %x actually work properly

### DIFF
--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -18,7 +18,7 @@ template<typename PutChFunc, typename T>
     int ret = 0;
 
     int digits = 0;
-    for (T n = number; n > 0; n /= 0x0f)
+    for (T n = number; n > 0; n >>= 4)
         ++digits;
     if (digits == 0)
         digits = 1;


### PR DESCRIPTION
When printing hex numbers, we were printing the wrong thing sometimes. This
was because we were dividing the digit to print by 15 instead of 16. Also,
dividing by 16 is the same as shifting four bits to the right, which is a
bit closer to our actual intention in this case, so let's use a shift
instead.