### PR TITLE
Kernel: Fixed FDC motor_enable()

### DIFF
--- a/Kernel/Devices/FloppyDiskDevice.cpp
+++ b/Kernel/Devices/FloppyDiskDevice.cpp
@@ -370,7 +370,7 @@ u8 FloppyDiskDevice::read_msr() const
 
 void FloppyDiskDevice::motor_enable(bool slave) const
 {
-    u8 val = slave ? 0x1C : 0x2D;
+    u8 val = slave ? 0x2D : 0x1C;
     write_dor(val);
 }
 


### PR DESCRIPTION
Motor Enable now selects the correct drive. The ternary
operations were backwards. QEMU doesn't care (obviously) but
on a real PC, the drive doesn't actually ever get selected...

Note that this code doesn't actually work on real hw yet. It seems to lock up at "Recalibrate" waiting for an IRQ. This sits there and spikes CPU usage to 100%, with a big increase in fan speed (a big no no!). We'll definitely need to add some kind of timeout. I'm not sure whether it's timing that's causing the drive to hang, or whether I have things around the wrong way, but I'll definitely need to look at the spec again.