### PR TITLE
TextEditor: Stopped disappearing text at end of document

### DIFF
--- a/Libraries/LibGUI/GTextEditor.cpp
+++ b/Libraries/LibGUI/GTextEditor.cpp
@@ -139,7 +139,8 @@ GTextPosition GTextEditor::text_position_at(const Point& a_position) const
             if (position.y() >= rect.top() && position.y() <= rect.bottom()) {
                 line_index = i;
                 break;
-            }
+            } else if (position.y() > rect.bottom())
+                line_index = m_lines.size() - 1;
         }
     } else {
         line_index = position.y() / line_height();


### PR DESCRIPTION
text_position_at() was returning -1 if the position wasn't in
the bounds of a visual line. Now if the position is past the last
line, we simimply return the last line index instead of -1.
Fixes #502