### PR TITLE
Applications: Terminal support for ctr-e and ctr-a.

### DIFF
--- a/Applications/Terminal/TerminalWidget.cpp
+++ b/Applications/Terminal/TerminalWidget.cpp
@@ -161,6 +161,13 @@ void TerminalWidget::keydown_event(GKeyEvent& event)
     char ch = !event.text().is_empty() ? event.text()[0] : 0;
     if (ch) {
         if (event.ctrl()) {
+            if (ch == 'e') {
+                write(m_ptm_fd, "\033[F", 3);
+                return;
+            } else if (ch == 'a') {
+                write(m_ptm_fd, "\033[H", 3);
+                return;
+            }
             if (ch >= 'a' && ch <= 'z') {
                 ch = ch - 'a' + 1;
             } else if (ch == '\\') {


### PR DESCRIPTION
By pressing ctr-e/a the cursor goes to the end/beginning of the line. I think it is a helpful feature to have when the command is too big. HOME and END buttons are too slow for me  :stuck_out_tongue: