### PR TITLE
AK: Abort on unknown printf formatting characters

### DIFF
--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/Types.h>
 #include <stdarg.h>
 
@@ -348,6 +349,8 @@ template<typename PutChFunc>
             case 'p':
                 ret += print_hex(putch, bufptr, va_arg(ap, u32), *p == 'P', true, false, true, 8);
                 break;
+            default:
+                ASSERT_NOT_REACHED();
             }
         } else {
             putch(bufptr, *p);


### PR DESCRIPTION
Right now if we encounter an unknown character, printf (and its related
functions) fail in a really bad way, where they forget to pull things off
the stack. This usually leads to a crash somewhere else, which is hard to
debug.

This patch makes printf abort as soon as it encounters a formatting
character that it can't handle. This is not the optimal solution, but it
is an improvement for debugging.