### PR TITLE
SystemServer: Allow more arguments for startup processes

### DIFF
--- a/Servers/SystemServer/main.cpp
+++ b/Servers/SystemServer/main.cpp
@@ -13,21 +13,21 @@ void start_process(const String& program, const Vector<String>& arguments, int p
     pid_t pid = 0;
 
     while (true) {
-        dbgprintf("Forking for %s...\n", program.characters());
+        dbg() << "Forking for " << program << "...";
         int pid = fork();
         if (pid < 0) {
-            dbgprintf("Fork %s failed! %s\n", program.characters(), strerror(errno));
+            dbg() << "Fork " << program << " failed! " << strerror(errno);
             continue;
         } else if (pid > 0) {
             // parent...
-            dbgprintf("Process %s hopefully started with priority %d...\n", program.characters(), prio);
+            dbg() << "Process " << program << " hopefully started with priority " << prio << "...";
             return;
         }
         break;
     }
 
     while (true) {
-        dbgprintf("Executing for %s... at prio %d\n", program.characters(), prio);
+        dbg() << "Executing for " << program << "... at prio " << prio;
         struct sched_param p;
         p.sched_priority = prio;
         int ret = sched_setparam(pid, &p);
@@ -47,7 +47,7 @@ void start_process(const String& program, const Vector<String>& arguments, int p
         progv[arguments.size() + 1] = nullptr;
         ret = execv(progv[0], progv);
         if (ret < 0) {
-            dbgprintf("Exec %s failed! %s", progv[0], strerror(errno));
+            dbg() << "Exec " << progv[0] << " failed! " << strerror(errno);
             continue;
         }
         break;
@@ -58,23 +58,23 @@ static void check_for_test_mode()
 {
     CFile f("/proc/cmdline");
     if (!f.open(CIODevice::ReadOnly)) {
-        dbgprintf("Failed to read command line: %s\n", f.error_string());
+        dbg() << "Failed to read command line: " << f.error_string();
         ASSERT(false);
     }
     const String cmd = String::copy(f.read_all());
-    dbgprintf("Read command line: %s\n", cmd.characters());
+    dbg() << "Read command line: " << cmd;
     if (cmd.matches("*testmode=1*")) {
         // Eventually, we should run a test binary and wait for it to finish
         // before shutting down. But this is good enough for now.
-        dbgprintf("Waiting for testmode shutdown...\n");
+        dbg() << "Waiting for testmode shutdown...";
         sleep(5);
-        dbgprintf("Shutting down due to testmode...\n");
+        dbg() << "Shutting down due to testmode...";
         if (fork() == 0) {
             execl("/bin/shutdown", "/bin/shutdown", "-n", nullptr);
             ASSERT_NOT_REACHED();
         }
     } else {
-        dbgprintf("Continuing normally\n");
+        dbg() << "Continuing normally";
     }
 }
 

--- a/Servers/SystemServer/main.cpp
+++ b/Servers/SystemServer/main.cpp
@@ -8,26 +8,26 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-void start_process(const char* prog, const char* arg, int prio, const char* tty = nullptr)
+void start_process(const String& program, const Vector<String>& arguments, int prio, const char* tty = nullptr)
 {
     pid_t pid = 0;
 
     while (true) {
-        dbgprintf("Forking for %s...\n", prog);
+        dbgprintf("Forking for %s...\n", program.characters());
         int pid = fork();
         if (pid < 0) {
-            dbgprintf("Fork %s failed! %s\n", prog, strerror(errno));
+            dbgprintf("Fork %s failed! %s\n", program.characters(), strerror(errno));
             continue;
         } else if (pid > 0) {
             // parent...
-            dbgprintf("Process %s hopefully started with priority %d...\n", prog, prio);
+            dbgprintf("Process %s hopefully started with priority %d...\n", program.characters(), prio);
             return;
         }
         break;
     }
 
     while (true) {
-        dbgprintf("Executing for %s... at prio %d\n", prog, prio);
+        dbgprintf("Executing for %s... at prio %d\n", program.characters(), prio);
         struct sched_param p;
         p.sched_priority = prio;
         int ret = sched_setparam(pid, &p);
@@ -41,12 +41,13 @@ void start_process(const char* prog, const char* arg, int prio, const char* tty 
         }
 
         char* progv[256];
-        progv[0] = const_cast<char*>(prog);
-        progv[1] = const_cast<char*>(arg);
-        progv[2] = nullptr;
-        ret = execv(prog, progv);
+        progv[0] = const_cast<char*>(program.characters());
+        for (int i = 0; i < arguments.size() && i < 254; i++)
+            progv[i+1] = const_cast<char*>(arguments[i].characters());
+        progv[arguments.size() + 1] = nullptr;
+        ret = execv(progv[0], progv);
         if (ret < 0) {
-            dbgprintf("Exec %s failed! %s", prog, strerror(errno));
+            dbgprintf("Exec %s failed! %s", progv[0], strerror(errno));
             continue;
         }
         break;
@@ -83,24 +84,24 @@ int main(int, char**)
     int highest_prio = sched_get_priority_max(SCHED_OTHER);
 
     // Mount the filesystems.
-    start_process("/bin/mount", "-a", highest_prio);
+    start_process("/bin/mount", { "-a" }, highest_prio);
     wait(nullptr);
 
     // NOTE: We don't start anything on tty0 since that's the "active" TTY while WindowServer is up.
-    start_process("/bin/TTYServer", "tty1", highest_prio, "/dev/tty1");
-    start_process("/bin/TTYServer", "tty2", highest_prio, "/dev/tty2");
-    start_process("/bin/TTYServer", "tty3", highest_prio, "/dev/tty3");
+    start_process("/bin/TTYServer", { "tty1" }, highest_prio, "/dev/tty1");
+    start_process("/bin/TTYServer", { "tty2" }, highest_prio, "/dev/tty2");
+    start_process("/bin/TTYServer", { "tty3" }, highest_prio, "/dev/tty3");
 
     // Drop privileges.
     setuid(100);
     setgid(100);
 
-    start_process("/bin/LookupServer", nullptr, lowest_prio);
-    start_process("/bin/WindowServer", nullptr, highest_prio);
-    start_process("/bin/AudioServer", nullptr, highest_prio);
-    start_process("/bin/Taskbar", nullptr, highest_prio);
-    start_process("/bin/Terminal", nullptr, highest_prio - 1);
-    start_process("/bin/Launcher", nullptr, highest_prio);
+    start_process("/bin/LookupServer", {}, lowest_prio);
+    start_process("/bin/WindowServer", {}, highest_prio);
+    start_process("/bin/AudioServer", {}, highest_prio);
+    start_process("/bin/Taskbar", {}, highest_prio);
+    start_process("/bin/Terminal", {}, highest_prio - 1);
+    start_process("/bin/Launcher", {}, highest_prio);
 
     // This won't return if we're in test mode.
     check_for_test_mode();


### PR DESCRIPTION
This is useful for starting more complicated programs at boot. I've used
it to start things like "ping 192.168.1.1" or "nc 192.168.1.1 22" to test
repetitive things with a bit less typing.