### PR TITLE
Emoji support

### DIFF
--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -2,6 +2,11 @@
 
 namespace AK {
 
+Utf8View::Utf8View(const String& string)
+    : m_string(string)
+{
+}
+
 Utf8View::Utf8View(const StringView& string)
     : m_string(string)
 {
@@ -14,7 +19,7 @@ const unsigned char* Utf8View::begin_ptr() const
 
 const unsigned char* Utf8View::end_ptr() const
 {
-    return (const unsigned char*)m_string.characters_without_null_termination() + m_string.length();
+    return begin_ptr() + m_string.length();
 }
 
 Utf8CodepointIterator Utf8View::begin() const
@@ -25,6 +30,20 @@ Utf8CodepointIterator Utf8View::begin() const
 Utf8CodepointIterator Utf8View::end() const
 {
     return { end_ptr(), 0 };
+}
+
+int Utf8View::byte_offset_of(const Utf8CodepointIterator& it) const
+{
+    ASSERT(it.m_ptr >= begin_ptr());
+    ASSERT(it.m_ptr <= end_ptr());
+
+    return it.m_ptr - begin_ptr();
+}
+
+Utf8View Utf8View::substring_view(int byte_offset, int byte_length) const
+{
+    StringView string = m_string.substring_view(byte_offset, byte_length);
+    return Utf8View { string };
 }
 
 static inline bool decode_first_byte(

--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -1,4 +1,5 @@
 #include <AK/Utf8View.h>
+#include <AK/LogStream.h>
 
 namespace AK {
 
@@ -134,7 +135,13 @@ u32 Utf8CodepointIterator::operator*() const
     int codepoint_length_in_bytes;
 
     bool first_byte_makes_sense = decode_first_byte(m_ptr[0], codepoint_length_in_bytes, codepoint_value_so_far);
+    if (!first_byte_makes_sense) {
+        dbg() << "First byte doesn't make sense, bytes = " << (const char*)m_ptr;
+    }
     ASSERT(first_byte_makes_sense);
+    if (codepoint_length_in_bytes > m_length) {
+        dbg() << "Not enough bytes (need " << codepoint_length_in_bytes << ", have " << m_length << "), first byte is: " << m_ptr[0] << " " << (const char*)m_ptr;
+    }
     ASSERT(codepoint_length_in_bytes <= m_length);
 
     for (int offset = 1; offset < codepoint_length_in_bytes; offset++) {

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -26,6 +26,7 @@ private:
 
 class Utf8View {
 public:
+    explicit Utf8View(const String&);
     explicit Utf8View(const StringView&);
     ~Utf8View() {}
 
@@ -33,6 +34,12 @@ public:
 
     Utf8CodepointIterator begin() const;
     Utf8CodepointIterator end() const;
+
+    const unsigned char* bytes() const { return begin_ptr(); }
+    int byte_length() const { return m_string.length(); }
+    int byte_offset_of(const Utf8CodepointIterator&) const;
+    Utf8View substring_view(int byte_offset, int byte_length) const;
+    bool is_empty() const { return m_string.is_empty(); }
 
     bool validate() const;
 

--- a/Applications/FontEditor/FontEditor.cpp
+++ b/Applications/FontEditor/FontEditor.cpp
@@ -2,6 +2,7 @@
 #include "GlyphEditorWidget.h"
 #include "GlyphMapWidget.h"
 #include "UI_FontEditorBottom.h"
+#include <AK/StringBuilder.h>
 #include <LibGUI/GButton.h>
 #include <LibGUI/GCheckBox.h>
 #include <LibGUI/GGroupBox.h>
@@ -77,7 +78,16 @@ FontEditorWidget::FontEditorWidget(const String& path, RefPtr<Font>&& edited_fon
     m_glyph_map_widget->on_glyph_selected = [this](u8 glyph) {
         m_glyph_editor_widget->set_glyph(glyph);
         m_ui->width_spinbox->set_value(m_edited_font->glyph_width(m_glyph_map_widget->selected_glyph()));
-        m_ui->info_label->set_text(String::format("0x%b (%c)", glyph, glyph));
+        StringBuilder builder;
+        builder.appendf("0x%b (", glyph);
+        if (glyph < 128) {
+            builder.append(glyph);
+        } else {
+            builder.append(128 | 64 | (glyph / 64));
+            builder.append(128 | (glyph % 64));
+        }
+        builder.append(')');
+        m_ui->info_label->set_text(builder.to_string());
     };
 
     m_ui->fixed_width_checkbox->on_checked = [this, update_demo](bool checked) {

--- a/Applications/Terminal/TerminalWidget.cpp
+++ b/Applications/Terminal/TerminalWidget.cpp
@@ -225,21 +225,57 @@ void TerminalWidget::paint_event(GPaintEvent& event)
             painter.fill_rect(row_rect, Color::Red);
         else if (has_only_one_background_color)
             painter.fill_rect(row_rect, lookup_color(line.attributes[0].background_color).with_alpha(m_opacity));
-        for (u16 column = 0; column < m_terminal.columns(); ++column) {
-            char ch = line.characters[column];
-            bool should_reverse_fill_for_cursor_or_selection = (m_cursor_blink_state && m_in_active_window && row == row_with_cursor && column == m_terminal.cursor_column())
-                || selection_contains({ row, column });
-            auto& attribute = line.attributes[column];
-            auto character_rect = glyph_rect(row, column);
-            if (!has_only_one_background_color || should_reverse_fill_for_cursor_or_selection) {
-                auto cell_rect = character_rect.inflated(0, m_line_spacing);
-                painter.fill_rect(cell_rect, lookup_color(should_reverse_fill_for_cursor_or_selection ? attribute.foreground_color : attribute.background_color).with_alpha(m_opacity));
+
+
+        // The terminal insists on thinking characters and
+        // bytes are the same thing. We want to still draw
+        // emojis in *some* way, but it won't be completely
+        // perfect. So what we do is we make multi-byte
+        // characters take up multiple columns, and render
+        // the character itself in the center of the columns
+        // its bytes take up as far as the terminal is concerned.
+
+        ASSERT(line.text().length() == m_terminal.columns());
+        Utf8View utf8_view { line.text() };
+
+        for (auto it = utf8_view.begin(); it != utf8_view.end(); ++it) {
+            u32 codepoint = *it;
+            int this_char_column = utf8_view.byte_offset_of(it);
+            AK::Utf8CodepointIterator it_copy = it;
+            int next_char_column = utf8_view.byte_offset_of(++it_copy);
+
+            // Columns from this_char_column up until next_char_column
+            // are logically taken up by this (possibly multi-byte)
+            // character. Iterate over these columns and draw background
+            // for each one of them separately.
+
+            bool should_reverse_fill_for_cursor_or_selection = false;
+            VT::Attribute attribute;
+
+            for (u16 column = this_char_column; column < next_char_column; ++column) {
+                should_reverse_fill_for_cursor_or_selection |=
+                    m_cursor_blink_state
+                    && m_in_active_window
+                    && row == row_with_cursor
+                    && column == m_terminal.cursor_column();
+                should_reverse_fill_for_cursor_or_selection |= selection_contains({ row, column });
+                attribute = line.attributes[column];
+                auto character_rect = glyph_rect(row, column);
+                if (!has_only_one_background_color || should_reverse_fill_for_cursor_or_selection) {
+                    auto cell_rect = character_rect.inflated(0, m_line_spacing);
+                    painter.fill_rect(cell_rect, lookup_color(should_reverse_fill_for_cursor_or_selection ? attribute.foreground_color : attribute.background_color).with_alpha(m_opacity));
+                }
             }
-            if (ch == ' ')
+
+            if (codepoint == ' ')
                 continue;
-            painter.draw_glyph(
+
+            auto character_rect = glyph_rect(row, this_char_column);
+            auto num_columns = next_char_column - this_char_column;
+            character_rect.move_by((num_columns - 1) * font().glyph_width('x') / 2, 0);
+            painter.draw_glyph_or_emoji(
                 character_rect.location(),
-                ch,
+                codepoint,
                 attribute.flags & VT::Attribute::Bold ? Font::default_bold_fixed_width_font() : font(),
                 lookup_color(should_reverse_fill_for_cursor_or_selection ? attribute.background_color : attribute.foreground_color));
         }

--- a/Libraries/LibC/Makefile
+++ b/Libraries/LibC/Makefile
@@ -12,7 +12,8 @@ AK_OBJS = \
     ../../AK/JsonObject.o \
     ../../AK/JsonParser.o \
     ../../AK/LogStream.o \
-    ../../AK/MappedFile.o
+    ../../AK/MappedFile.o \
+    ../../AK/Utf8View.o
 
 LIBC_OBJS = \
        SharedBuffer.o \

--- a/Libraries/LibDraw/Emoji.cpp
+++ b/Libraries/LibDraw/Emoji.cpp
@@ -1,0 +1,27 @@
+#include "Emoji.h"
+#include "GraphicsBitmap.h"
+#include <AK/AKString.h>
+#include <AK/HashMap.h>
+
+static HashMap<u32, Emoji> s_emojis;
+
+Emoji::Emoji(NonnullRefPtr<GraphicsBitmap> bitmap)
+    : m_bitmap(move(bitmap))
+{
+}
+
+const Emoji* Emoji::emoji_for_codepoint(u32 codepoint)
+{
+    auto it = s_emojis.find(codepoint);
+    if (it != s_emojis.end())
+        return &(*it).value;
+
+    String path = String::format("/res/emoji/U+%X.png", codepoint);
+
+    auto bitmap = GraphicsBitmap::load_from_file(path);
+    if (!bitmap)
+        return nullptr;
+
+    s_emojis.set(codepoint, Emoji { bitmap.release_nonnull() });
+    return &(*s_emojis.find(codepoint)).value;
+}

--- a/Libraries/LibDraw/Emoji.h
+++ b/Libraries/LibDraw/Emoji.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <AK/Types.h>
+#include <AK/NonnullRefPtr.h>
+
+class GraphicsBitmap;
+
+class Emoji {
+ public:
+    ~Emoji() {}
+
+    static const Emoji* emoji_for_codepoint(u32 codepoint);
+    const GraphicsBitmap& bitmap() const { return m_bitmap; }
+
+private:
+    explicit Emoji(NonnullRefPtr<GraphicsBitmap>);
+
+    NonnullRefPtr<GraphicsBitmap> m_bitmap;
+};

--- a/Libraries/LibDraw/Font.cpp
+++ b/Libraries/LibDraw/Font.cpp
@@ -8,6 +8,9 @@
 #include <LibC/mman.h>
 #include <LibC/stdio.h>
 #include <LibC/unistd.h>
+#include <AK/Utf8View.h>
+#include "Emoji.h"
+#include "GraphicsBitmap.h"
 
 struct [[gnu::packed]] FontFileHeader
 {
@@ -170,17 +173,37 @@ bool Font::write_to_file(const StringView& path)
     return true;
 }
 
-int Font::width(const StringView& string) const
+int Font::glyph_or_emoji_width(u32 codepoint) const
 {
-    if (!string.length())
-        return 0;
+    if (codepoint < 256)
+        return glyph_width((char)codepoint);
 
     if (m_fixed_width)
-        return string.length() * m_glyph_width;
+        return m_glyph_width;
 
+    auto emoji = Emoji::emoji_for_codepoint(codepoint);
+    if (emoji == nullptr)
+        return glyph_width('?');
+    return emoji->bitmap().size().width();
+}
+
+int Font::width(const StringView& string) const
+{
+    Utf8View utf8 { string };
+    return width(utf8);
+}
+
+int Font::width(const Utf8View& utf8) const
+{
+    bool first = true;
     int width = 0;
-    for (int i = 0; i < string.length(); ++i)
-        width += glyph_width(string.characters_without_null_termination()[i]) + 1;
 
-    return width - 1;
+    for (u32 codepoint : utf8) {
+        if (!first)
+            width += glyph_spacing();
+        first = false;
+        width += glyph_or_emoji_width(codepoint);
+    }
+
+    return width;
 }

--- a/Libraries/LibDraw/Font.h
+++ b/Libraries/LibDraw/Font.h
@@ -6,6 +6,7 @@
 #include <AK/RefCounted.h>
 #include <AK/Types.h>
 #include <LibDraw/Rect.h>
+#include <AK/Utf8View.h>
 
 // FIXME: Make a MutableGlyphBitmap buddy class for FontEditor instead?
 class GlyphBitmap {
@@ -58,11 +59,13 @@ public:
     GlyphBitmap glyph_bitmap(char ch) const { return GlyphBitmap(&m_rows[(u8)ch * m_glyph_height], { glyph_width(ch), m_glyph_height }); }
 
     u8 glyph_width(char ch) const { return m_fixed_width ? m_glyph_width : m_glyph_widths[(u8)ch]; }
+    int glyph_or_emoji_width(u32 codepoint) const;
     u8 glyph_height() const { return m_glyph_height; }
     u8 min_glyph_width() const { return m_min_glyph_width; }
     u8 max_glyph_width() const { return m_max_glyph_width; }
     u8 glyph_spacing() const { return m_fixed_width ? 0 : 1; }
-    int width(const StringView& string) const;
+    int width(const StringView&) const;
+    int width(const Utf8View&) const;
 
     String name() const { return m_name; }
     void set_name(const StringView& name) { m_name = name; }

--- a/Libraries/LibDraw/Makefile
+++ b/Libraries/LibDraw/Makefile
@@ -9,7 +9,8 @@ OBJS = \
     Painter.o \
     PNGLoader.o \
     Rect.o \
-    StylePainter.o
+    StylePainter.o \
+    Emoji.o
 
 LIBRARY = libdraw.a
 DEFINES += -DUSERLAND

--- a/Libraries/LibDraw/Painter.h
+++ b/Libraries/LibDraw/Painter.h
@@ -7,11 +7,13 @@
 #include <AK/AKString.h>
 #include <LibDraw/TextAlignment.h>
 #include <LibDraw/TextElision.h>
+#include <AK/Utf8View.h>
 
 class CharacterBitmap;
 class GlyphBitmap;
 class GraphicsBitmap;
 class Font;
+class Emoji;
 
 class Painter {
 public:
@@ -34,6 +36,8 @@ public:
     void draw_text(const Rect&, const StringView&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None);
     void draw_glyph(const Point&, char, Color);
     void draw_glyph(const Point&, char, const Font&, Color);
+    void draw_emoji(const Point&, const Emoji&, const Font&);
+    void draw_glyph_or_emoji(const Point&, u32 codepoint, const Font&, Color);
 
     const Font& font() const { return *state().font; }
     void set_font(const Font& font) { state().font = &font; }
@@ -70,7 +74,7 @@ protected:
     void blit_with_opacity(const Point&, const GraphicsBitmap&, const Rect& src_rect, float opacity);
     void draw_pixel(const Point&, Color, int thickness = 1);
 
-    void draw_text_line(const Rect&, const StringView&, const Font&, TextAlignment, Color, TextElision);
+    void draw_text_line(const Rect&, const Utf8View&, const Font&, TextAlignment, Color, TextElision);
 
     struct State {
         const Font* font;

--- a/Libraries/LibGUI/GComboBox.cpp
+++ b/Libraries/LibGUI/GComboBox.cpp
@@ -20,7 +20,7 @@ GComboBox::GComboBox(GWidget* parent)
     };
     m_open_button = new GButton(this);
     m_open_button->set_focusable(false);
-    m_open_button->set_text("\xf7");
+    m_open_button->set_text("\xc3\xb6");
     m_open_button->on_click = [this](auto&) {
         if (m_list_window->is_visible())
             close();

--- a/Libraries/LibGUI/GSpinBox.cpp
+++ b/Libraries/LibGUI/GSpinBox.cpp
@@ -17,12 +17,12 @@ GSpinBox::GSpinBox(GWidget* parent)
     };
     m_increment_button = new GButton(this);
     m_increment_button->set_focusable(false);
-    m_increment_button->set_text("\xf6");
+    m_increment_button->set_text("\xc3\xb6");
     m_increment_button->on_click = [this](GButton&) { set_value(m_value + 1); };
     m_increment_button->set_auto_repeat_interval(150);
     m_decrement_button = new GButton(this);
     m_decrement_button->set_focusable(false);
-    m_decrement_button->set_text("\xf7");
+    m_decrement_button->set_text("\xc3\xb7");
     m_decrement_button->on_click = [this](GButton&) { set_value(m_value - 1); };
     m_decrement_button->set_auto_repeat_interval(150);
 }

--- a/Libraries/LibGUI/GTableView.cpp
+++ b/Libraries/LibGUI/GTableView.cpp
@@ -341,9 +341,9 @@ void GTableView::paint_headers(Painter& painter)
             builder.append(model()->column_name(column_index));
             auto sort_order = model()->sort_order();
             if (sort_order == GSortOrder::Ascending)
-                builder.append(" \xf6");
+                builder.append(" \xc3\xb6");
             else if (sort_order == GSortOrder::Descending)
-                builder.append(" \xf7");
+                builder.append(" \xc3\xb7");
             text = builder.to_string();
         } else {
             text = model()->column_name(column_index);

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -82,6 +82,8 @@ public:
         void clear(Attribute);
         bool has_only_one_background_color() const;
         void set_length(u16);
+        StringView text() const { return { characters, m_length }; }
+
         u8* characters { nullptr };
         Attribute* attributes { nullptr };
         bool dirty { false };

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -56,7 +56,7 @@ WSWindowManager::WSWindowManager()
         { "/bin/SystemMonitor", "Open SystemMonitor...", "/res/icons/16x16/app-system-monitor.png" }
     };
 
-    u8 system_menu_name[] = { 0xf8, 0 };
+    u8 system_menu_name[] = { 0xc3, 0xb8, 0 };
     m_system_menu = make<WSMenu>(nullptr, -1, String((const char*)system_menu_name));
 
     int appIndex = 1;


### PR DESCRIPTION
This introduces the `Emoji` class in LibDraw for loading emoji from the filesystem, and integrates it with `Font` and `Painter`. Next, there are a few tweaks to bring most of the system into this new "everything is UTF-8" reality.

The one remaining unported piece is `GTextEditor`; we need to fix/rewrite it too, but we can do it later. It still works fine for ASCII strings and does not break *too badly* upon encountering emojis.

https://github.com/SerenityOS/serenity/issues/490