### PR TITLE
LibCore: Add local_{address,port} functions to CTCPServer

### DIFF
--- a/Libraries/LibCore/CTCPServer.cpp
+++ b/Libraries/LibCore/CTCPServer.cpp
@@ -53,3 +53,29 @@ RefPtr<CTCPSocket> CTCPServer::accept()
 
     return CTCPSocket::construct(accepted_fd);
 }
+
+IPv4Address CTCPServer::local_address()
+{
+    if (m_fd == -1)
+        return {};
+
+    sockaddr_in address;
+    socklen_t len = sizeof(address);
+    if (getsockname(m_fd, (sockaddr*)&address, &len) != 0)
+        return 0;
+
+    return IPv4Address(address.sin_addr.s_addr);
+}
+
+u16 CTCPServer::local_port()
+{
+    if (m_fd == -1)
+        return 0;
+
+    sockaddr_in address;
+    socklen_t len = sizeof(address);
+    if (getsockname(m_fd, (sockaddr*)&address, &len) != 0)
+        return 0;
+
+    return ntohs(address.sin_port);
+}

--- a/Libraries/LibCore/CTCPServer.h
+++ b/Libraries/LibCore/CTCPServer.h
@@ -16,6 +16,9 @@ public:
 
     RefPtr<CTCPSocket> accept();
 
+    IPv4Address local_address();
+    u16 local_port();
+
     Function<void()> on_ready_to_accept;
 
 private:


### PR DESCRIPTION
This is useful if you want to know what address or port a server is
listening on. Especially in the case of port numbers, you might not
actually specify one, letting the kernel pick one for you instead, and
this lets you find out what port was chosen.