### PR TITLE
Kernel: Implement naiive TCP retransmission

### DIFF
--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -216,7 +216,7 @@ ssize_t IPv4Socket::recvfrom(FileDescription& description, void* buffer, size_t 
             packet = m_receive_queue.take_first();
             m_can_read = !m_receive_queue.is_empty();
 #ifdef IPV4_SOCKET_DEBUG
-            kprintf("IPv4Socket(%p): recvfrom without blocking %d bytes, packets in queue: %d\n", this, packet.data.size(), m_receive_queue.size_slow());
+            kprintf("IPv4Socket(%p): recvfrom without blocking %d bytes, packets in queue: %d\n", this, packet.data.value().size(), m_receive_queue.size_slow());
 #endif
         }
     }
@@ -242,7 +242,7 @@ ssize_t IPv4Socket::recvfrom(FileDescription& description, void* buffer, size_t 
         packet = m_receive_queue.take_first();
         m_can_read = !m_receive_queue.is_empty();
 #ifdef IPV4_SOCKET_DEBUG
-        kprintf("IPv4Socket(%p): recvfrom with blocking %d bytes, packets in queue: %d\n", this, packet.data.size(), m_receive_queue.size_slow());
+        kprintf("IPv4Socket(%p): recvfrom with blocking %d bytes, packets in queue: %d\n", this, packet.data.value().size(), m_receive_queue.size_slow());
 #endif
     }
     ASSERT(packet.data.has_value());

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -106,6 +106,7 @@ KResult IPv4Socket::listen(int backlog)
         return KResult(-EADDRINUSE);
 
     set_backlog(backlog);
+    m_role = Role::Listener;
 
     kprintf("IPv4Socket{%p} listening with backlog=%d\n", this, backlog);
 

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -190,7 +190,9 @@ ssize_t IPv4Socket::sendto(FileDescription&, const void* data, size_t data_lengt
     if (rc < 0)
         return rc;
 
+#ifdef IPV4_SOCKET_DEBUG
     kprintf("sendto: destination=%s:%u\n", m_peer_address.to_string().characters(), m_peer_port);
+#endif
 
     if (type() == SOCK_RAW) {
         routing_decision.adapter->send_ipv4(routing_decision.next_hop, m_peer_address, (IPv4Protocol)protocol(), (const u8*)data, data_length);

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -437,7 +437,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
             socket->set_setup_state(Socket::SetupState::Completed);
             return;
         case TCPFlags::ACK | TCPFlags::RST:
-            socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
+            socket->set_ack_number(tcp_packet.sequence_number() + payload_size);
             socket->send_tcp_packet(TCPFlags::ACK);
             socket->set_state(TCPSocket::State::Closed);
             socket->set_error(TCPSocket::Error::RSTDuringConnect);
@@ -454,7 +454,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
     case TCPSocket::State::SynReceived:
         switch (tcp_packet.flags()) {
         case TCPFlags::ACK:
-            socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
+            socket->set_ack_number(tcp_packet.sequence_number() + payload_size);
             socket->set_state(TCPSocket::State::Established);
             if (socket->direction() == TCPSocket::Direction::Outgoing) {
                 socket->set_setup_state(Socket::SetupState::Completed);
@@ -478,7 +478,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
     case TCPSocket::State::LastAck:
         switch (tcp_packet.flags()) {
         case TCPFlags::ACK:
-            socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
+            socket->set_ack_number(tcp_packet.sequence_number() + payload_size);
             socket->set_state(TCPSocket::State::Closed);
             return;
         default:
@@ -490,7 +490,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
     case TCPSocket::State::FinWait1:
         switch (tcp_packet.flags()) {
         case TCPFlags::ACK:
-            socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
+            socket->set_ack_number(tcp_packet.sequence_number() + payload_size);
             socket->set_state(TCPSocket::State::FinWait2);
             return;
         case TCPFlags::FIN:
@@ -518,7 +518,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
     case TCPSocket::State::Closing:
         switch (tcp_packet.flags()) {
         case TCPFlags::ACK:
-            socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
+            socket->set_ack_number(tcp_packet.sequence_number() + payload_size);
             socket->set_state(TCPSocket::State::TimeWait);
             return;
         default:

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -527,8 +527,12 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
                 socket->did_receive(ipv4_packet.source(), tcp_packet.source_port(), KBuffer::copy(&ipv4_packet, sizeof(IPv4Packet) + ipv4_packet.payload_size()));
 
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
-            socket->send_tcp_packet(TCPFlags::ACK);
-            socket->set_state(TCPSocket::State::CloseWait);
+            // TODO: We should only send a FIN packet out once we're shutting
+            // down our side of the socket, so we should change this back to
+            // just being an ACK and a transition to CloseWait once we have a
+            // shutdown() implementation.
+            socket->send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);
+            socket->set_state(TCPSocket::State::Closing);
             socket->set_connected(false);
             return;
         }

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -459,6 +459,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
                 socket->set_setup_state(Socket::SetupState::Completed);
                 socket->set_connected(true);
             }
+            socket->release_to_originator();
             return;
         default:
             kprintf("handle_tcp: unexpected flags in SynReceived state\n");

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -389,7 +389,9 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
     case TCPSocket::State::Listen:
         switch (tcp_packet.flags()) {
         case TCPFlags::SYN: {
+#ifdef TCP_DEBUG
             kprintf("handle_tcp: incoming connection\n");
+#endif
             auto& local_address = ipv4_packet.destination();
             auto& peer_address = ipv4_packet.source();
             auto client = socket->create_client(local_address, tcp_packet.destination_port(), peer_address, tcp_packet.source_port());
@@ -397,7 +399,9 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
                 kprintf("handle_tcp: couldn't create client socket\n");
                 return;
             }
+#ifdef TCP_DEBUG
             kprintf("handle_tcp: created new client socket with tuple %s\n", client->tuple().to_string().characters());
+#endif
             client->set_sequence_number(1000);
             client->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             client->send_tcp_packet(TCPFlags::SYN | TCPFlags::ACK);

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -374,12 +374,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
     kprintf("handle_tcp: got socket; state=%s\n", socket->tuple().to_string().characters(), TCPSocket::to_string(socket->state()));
 #endif
 
-    if (tcp_packet.ack_number() != socket->sequence_number()) {
-        kprintf("handle_tcp: ack/seq mismatch: got %u, wanted %u\n", tcp_packet.ack_number(), socket->sequence_number());
-        return;
-    }
-
-    socket->record_incoming_data(ipv4_packet.payload_size());
+    socket->receive_tcp_packet(tcp_packet, ipv4_packet.payload_size());
 
     switch (socket->state()) {
     case TCPSocket::State::Closed:

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -406,7 +406,6 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
             client->set_sequence_number(1000);
             client->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
             client->send_tcp_packet(TCPFlags::SYN | TCPFlags::ACK);
-            client->set_sequence_number(1001);
             client->set_state(TCPSocket::State::SynReceived);
             return;
         }

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -455,10 +455,9 @@ void handle_tcp(const IPv4Packet& ipv4_packet)
         case TCPFlags::ACK:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size);
             socket->set_state(TCPSocket::State::Established);
-            if (socket->direction() == TCPSocket::Direction::Outgoing) {
-                socket->set_setup_state(Socket::SetupState::Completed);
+            socket->set_setup_state(Socket::SetupState::Completed);
+            if (socket->direction() == TCPSocket::Direction::Outgoing)
                 socket->set_connected(true);
-            }
             socket->release_to_originator();
             return;
         default:

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -1,3 +1,4 @@
+#include <AK/Time.h>
 #include <Kernel/Devices/RandomDevice.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/Net/NetworkAdapter.h>
@@ -184,7 +185,9 @@ void TCPSocket::send_outgoing_packets()
     auto now = kgettimeofday();
 
     for (auto& packet : m_not_acked) {
-        if (now.tv_sec <= packet.tx_time.tv_sec)
+        timeval diff;
+        timeval_sub(packet.tx_time, now, diff);
+        if (diff.tv_sec < 1 && diff.tv_usec <= 500000)
             continue;
 
         packet.tx_time = now;

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -37,7 +37,7 @@ Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>& TCPSocket::sockets_by_tuple()
     return *s_map;
 }
 
-SocketHandle<TCPSocket> TCPSocket::from_tuple(const IPv4SocketTuple& tuple)
+RefPtr<TCPSocket> TCPSocket::from_tuple(const IPv4SocketTuple& tuple)
 {
     LOCKER(sockets_by_tuple().lock());
 
@@ -58,12 +58,12 @@ SocketHandle<TCPSocket> TCPSocket::from_tuple(const IPv4SocketTuple& tuple)
     return {};
 }
 
-SocketHandle<TCPSocket> TCPSocket::from_endpoints(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port)
+RefPtr<TCPSocket> TCPSocket::from_endpoints(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port)
 {
     return from_tuple(IPv4SocketTuple(local_address, local_port, peer_address, peer_port));
 }
 
-SocketHandle<TCPSocket> TCPSocket::create_client(const IPv4Address& new_local_address, u16 new_local_port, const IPv4Address& new_peer_address, u16 new_peer_port)
+RefPtr<TCPSocket> TCPSocket::create_client(const IPv4Address& new_local_address, u16 new_local_port, const IPv4Address& new_peer_address, u16 new_peer_port)
 {
     auto tuple = IPv4SocketTuple(new_local_address, new_local_port, new_peer_address, new_peer_port);
 

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -219,13 +219,17 @@ void TCPSocket::receive_tcp_packet(const TCPPacket& packet, u16 size)
     if (packet.has_ack()) {
         u32 ack_number = packet.ack_number();
 
+#ifdef TCP_SOCKET_DEBUG
         dbg() << "TCPSocket: receive_tcp_packet: " << ack_number;
+#endif
 
         int removed = 0;
         while (!m_not_acked.is_empty()) {
             auto& packet = m_not_acked.first();
 
+#ifdef TCP_SOCKET_DEBUG
             dbg() << "TCPSocket: iterate: " << packet.ack_number;
+#endif
 
             if (packet.ack_number <= ack_number) {
                 m_not_acked.take_first();
@@ -235,7 +239,9 @@ void TCPSocket::receive_tcp_packet(const TCPPacket& packet, u16 size)
             }
         }
 
+#ifdef TCP_SOCKET_DEBUG
         dbg() << "TCPSocket: receive_tcp_packet acknowledged " << removed << " packets";
+#endif
     }
 
     m_packets_in++;

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -6,7 +6,8 @@
 #include <AK/WeakPtr.h>
 #include <Kernel/Net/IPv4Socket.h>
 
-class TCPSocket final : public IPv4Socket {
+class TCPSocket final : public IPv4Socket
+    , public Weakable<TCPSocket> {
 public:
     static void for_each(Function<void(TCPSocket&)>);
     static NonnullRefPtr<TCPSocket> create(int protocol);
@@ -129,7 +130,8 @@ public:
     static RefPtr<TCPSocket> from_endpoints(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port);
 
     RefPtr<TCPSocket> create_client(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port);
-    void set_originator(RefPtr<TCPSocket> originator) { m_originator = originator; }
+    void set_originator(TCPSocket& originator) { m_originator = originator.make_weak_ptr(); }
+    bool has_originator() { return !!m_originator; }
     void release_to_originator();
     void release_for_accept(RefPtr<TCPSocket>);
 
@@ -150,7 +152,7 @@ private:
     virtual KResult protocol_bind() override;
     virtual KResult protocol_listen() override;
 
-    RefPtr<TCPSocket> m_originator;
+    WeakPtr<TCPSocket> m_originator;
     HashMap<IPv4SocketTuple, NonnullRefPtr<TCPSocket>> m_pending_release_for_accept;
     Direction m_direction { Direction::Unspecified };
     Error m_error { Error::None };

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/HashMap.h>
+#include <AK/SinglyLinkedList.h>
 #include <AK/WeakPtr.h>
 #include <Kernel/Net/IPv4Socket.h>
 
@@ -119,7 +121,8 @@ public:
     u32 bytes_out() const { return m_bytes_out; }
 
     void send_tcp_packet(u16 flags, const void* = nullptr, int = 0);
-    void record_incoming_data(int);
+    void send_outgoing_packets();
+    void receive_tcp_packet(const TCPPacket&, u16 size);
 
     static Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>& sockets_by_tuple();
     static RefPtr<TCPSocket> from_tuple(const IPv4SocketTuple& tuple);
@@ -159,4 +162,13 @@ private:
     u32 m_bytes_in { 0 };
     u32 m_packets_out { 0 };
     u32 m_bytes_out { 0 };
+
+    struct OutgoingPacket {
+        u32 ack_number;
+        ByteBuffer buffer;
+        int tx_counter { 0 };
+        timeval tx_time;
+    };
+
+    SinglyLinkedList<OutgoingPacket> m_not_acked;
 };

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -126,6 +126,9 @@ public:
     static RefPtr<TCPSocket> from_endpoints(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port);
 
     RefPtr<TCPSocket> create_client(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port);
+    void set_originator(RefPtr<TCPSocket> originator) { m_originator = originator; }
+    void release_to_originator();
+    void release_for_accept(RefPtr<TCPSocket>);
 
 protected:
     void set_direction(Direction direction) { m_direction = direction; }
@@ -144,6 +147,8 @@ private:
     virtual KResult protocol_bind() override;
     virtual KResult protocol_listen() override;
 
+    RefPtr<TCPSocket> m_originator;
+    HashMap<IPv4SocketTuple, NonnullRefPtr<TCPSocket>> m_pending_release_for_accept;
     Direction m_direction { Direction::Unspecified };
     Error m_error { Error::None };
     WeakPtr<NetworkAdapter> m_adapter;

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -122,10 +122,10 @@ public:
     void record_incoming_data(int);
 
     static Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>& sockets_by_tuple();
-    static SocketHandle<TCPSocket> from_tuple(const IPv4SocketTuple& tuple);
-    static SocketHandle<TCPSocket> from_endpoints(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port);
+    static RefPtr<TCPSocket> from_tuple(const IPv4SocketTuple& tuple);
+    static RefPtr<TCPSocket> from_endpoints(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port);
 
-    SocketHandle<TCPSocket> create_client(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port);
+    RefPtr<TCPSocket> create_client(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port);
 
 protected:
     void set_direction(Direction direction) { m_direction = direction; }


### PR DESCRIPTION
There are several changes in this patch, but the overall goal is to
improve the stability and functionality of listening sockets and
incoming connections in the TCP stack.