### PR TITLE
Add support for getting environment variables in Shell

### DIFF
--- a/Shell/GlobalState.h
+++ b/Shell/GlobalState.h
@@ -14,6 +14,7 @@ struct GlobalState {
     struct termios termios;
     bool was_interrupted { false };
     bool was_resized { false };
+    int last_return_code { 0 };
 };
 
 extern GlobalState g;

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -309,6 +309,8 @@ static Vector<String> expand_parameters(const StringView& param)
     String variable_name = String(param.substring_view(1, param.length() - 1));
     if (variable_name == "?")
         return { String::number(g.last_return_code) };
+    else if (variable_name == "$")
+        return { String::number(getpid()) };
 
     char* env_value = getenv(variable_name.characters());
     if (env_value == nullptr)

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -307,6 +307,8 @@ static Vector<String> expand_parameters(const StringView& param)
         return { param };
 
     String variable_name = String(param.substring_view(1, param.length() - 1));
+    if (variable_name == "?")
+        return { String::number(g.last_return_code) };
 
     char* env_value = getenv(variable_name.characters());
     if (env_value == nullptr)
@@ -545,6 +547,8 @@ static int run_command(const String& cmd)
             } while (errno == EINTR);
         }
     }
+
+    g.last_return_code = return_value;
 
     // FIXME: Should I really have to tcsetpgrp() after my child has exited?
     //        Is the terminal controlling pgrp really still the PGID of the dead process?


### PR DESCRIPTION
This adds support for using environment variables in terminal commands, and one special 'variable' (`$?`) which expands to the return code of the last executed program.  
This doesn't support setting environment variables in the shell, though that is something that would be nice to have in the future.
![2019-09-08-200340_945x347_scrot](https://user-images.githubusercontent.com/13157904/64555217-78b47b00-d302-11e9-996b-7731ac641f16.png)
