### PR TITLE
StringView: Add code for starts_with method

### DIFF
--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -40,6 +40,19 @@ Vector<StringView> StringView::split_view(const char separator) const
     return v;
 }
 
+bool StringView::starts_with(const StringView& str) const
+{
+    if (str.is_empty())
+        return true;
+    if (is_empty())
+        return false;
+    if (str.length() > length())
+        return false;
+    if (characters_without_null_termination() == str.characters_without_null_termination())
+        return true;
+    return !memcmp(characters_without_null_termination(), str.characters_without_null_termination(), str.length());
+}
+
 StringView StringView::substring_view(int start, int length) const
 {
     if (!length)

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -41,6 +41,8 @@ public:
 
     unsigned hash() const;
 
+    bool starts_with(const StringView&) const;
+
     StringView substring_view(int start, int length) const;
     Vector<StringView> split_view(char) const;
 

--- a/AK/Tests/TestStringView.cpp
+++ b/AK/Tests/TestStringView.cpp
@@ -33,4 +33,13 @@ TEST_CASE(compare_views)
     EXPECT_EQ(view1, "foo");
 }
 
+TEST_CASE(starts_with)
+{
+    String test_string = "ABCDEF";
+    StringView test_string_view = test_string.view();
+    EXPECT(test_string_view.starts_with("AB"));
+    EXPECT(test_string_view.starts_with("ABCDEF"));
+    EXPECT(!test_string_view.starts_with("DEF"));
+}
+
 TEST_MAIN(StringView)

--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -735,8 +735,7 @@ void IRCClient::handle_ctcp_request(const StringView& peer, const StringView& pa
         return;
     }
 
-    // FIXME: Add StringView::starts_with()
-    if (String(payload).starts_with("PING")) {
+    if (payload.starts_with("PING")) {
         send_ctcp_response(peer, payload);
         return;
     }


### PR DESCRIPTION
Adds the code for the `starts_with` method to `AK::StringView`. Fixes FIXME at https://github.com/SerenityOS/serenity/blob/bc23db2c71491f30fbfa221222bb26990ae4c98d/Applications/IRCClient/IRCClient.cpp#L738-L739 and makes that code use the new `starts_with` method.

The code is really similar, and makes me wonder if String should use StringView's `starts_with` method rather than duplicate the code. (String creates a StringView of itself, then calls `StringView::starts_with` on it?)