### PR TITLE
LibC: Add MAXPATHLEN to limits.h

### DIFF
--- a/Libraries/LibC/limits.h
+++ b/Libraries/LibC/limits.h
@@ -5,6 +5,9 @@
 #define PAGE_SIZE 4096
 
 #define PATH_MAX 4096
+#if !defined MAXPATHLEN && defined PATH_MAX
+# define MAXPATHLEN  PATH_MAX
+#endif
 
 #define INT_MAX INT32_MAX
 #define INT_MIN INT32_MIN


### PR DESCRIPTION
MAXPATHLEN defines the longest permissable path length after expanding
symbolic links. It is used to allocate a temporary buffer from the buffer
pool in which to do the name expansion, hence should be a power of two.

On UNIX MAXPATHLEN has the same size as PATH_MAX.

---

Came across this issue when trying to port go 1.4.3 to serenity.
