### PR TITLE
AK: Made Strings reversible

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -110,6 +110,13 @@ public:
         return m_impl->to_uppercase();
     }
 
+    String reversed() const
+    {
+        if (!m_impl)
+            return String();
+        return m_impl->reversed();
+    }
+
     Vector<String> split_limit(char separator, int limit) const;
     Vector<String> split(char separator) const;
     String substring(int start, int length) const;
@@ -226,7 +233,6 @@ struct Traits<String> : public GenericTraits<String> {
 struct CaseInsensitiveStringTraits : public AK::Traits<String> {
     static unsigned hash(const String& s) { return s.impl() ? s.to_lowercase().impl()->hash() : 0; }
     static bool equals(const String& a, const String& b) { return a.to_lowercase() == b.to_lowercase(); }
-
 };
 
 inline bool operator<(const char* characters, const String& string)
@@ -263,5 +269,5 @@ inline bool operator<=(const char* characters, const String& string)
 
 }
 
-using AK::String;
 using AK::CaseInsensitiveStringTraits;
+using AK::String;

--- a/AK/StringImpl.cpp
+++ b/AK/StringImpl.cpp
@@ -4,7 +4,7 @@
 #include "kmalloc.h"
 
 #ifndef __serenity__
-#include <new>
+#    include <new>
 #endif
 
 //#define DEBUG_STRINGIMPL
@@ -170,6 +170,21 @@ void StringImpl::compute_hash() const
     else
         m_hash = string_hash(characters(), m_length);
     m_has_hash = true;
+}
+
+NonnullRefPtr<StringImpl> StringImpl::reversed() const
+{
+    if (m_length == 0)
+        return the_empty_stringimpl();
+
+    char* buffer;
+    const char* pos = &m_inline_buffer[m_length - 1];
+    auto new_impl = create_uninitialized(m_length, buffer);
+
+    for (int i = 0; i < m_length; i++)
+        buffer[i] = *pos--;
+
+    return new_impl;
 }
 
 }

--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <AK/RefPtr.h>
 #include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
 #include <AK/Types.h>
 #include <AK/kmalloc.h>
 
@@ -43,6 +43,8 @@ public:
             compute_hash();
         return m_hash;
     }
+
+    NonnullRefPtr<StringImpl> reversed() const;
 
 private:
     enum ConstructTheEmptyStringImplTag {

--- a/AK/Tests/TestString.cpp
+++ b/AK/Tests/TestString.cpp
@@ -41,6 +41,7 @@ TEST_CASE(compare)
     EXPECT(!("a" >= String("b")));
     EXPECT("a" <= String("a"));
     EXPECT(!("b" <= String("a")));
+    EXPECT(!strcmp(test_string.reversed().characters(), "FEDCBA"));
 }
 
 TEST_CASE(index_access)


### PR DESCRIPTION
`AK::String` can now be reversed via AK::String::reverse(). This makes
life a lot easier for functions like `itoa()`, where the output
ends up being backwards. Very much not like the normal STL
(which requires an `std::reverse` object) way of doing things.