### PR TITLE
Kernel: Move fchdir to end of enumerate syscalls.

### DIFF
--- a/Kernel/Syscall.h
+++ b/Kernel/Syscall.h
@@ -32,7 +32,6 @@ struct timeval;
     __ENUMERATE_SYSCALL(gettimeofday)           \
     __ENUMERATE_SYSCALL(gethostname)            \
     __ENUMERATE_SYSCALL(chdir)                  \
-    __ENUMERATE_SYSCALL(fchdir)                 \
     __ENUMERATE_SYSCALL(uname)                  \
     __ENUMERATE_SYSCALL(set_mmap_name)          \
     __ENUMERATE_SYSCALL(readlink)               \
@@ -130,7 +129,8 @@ struct timeval;
     __ENUMERATE_SYSCALL(set_process_icon)       \
     __ENUMERATE_SYSCALL(mprotect)               \
     __ENUMERATE_SYSCALL(realpath)               \
-    __ENUMERATE_SYSCALL(get_process_name)
+    __ENUMERATE_SYSCALL(get_process_name)       \
+    __ENUMERATE_SYSCALL(fchdir)
 
 namespace Syscall {
 


### PR DESCRIPTION
The introduction fchdir in the middle of the ENUMERATE_SYSCALLS
expression changed other syscall numbers, which broke compatibility.
This commit fixes that by moving it to the end.

This fixes #555.