### PR TITLE
DisplayProperties: Wallpaper tab now has preview

### DIFF
--- a/Applications/DisplayProperties/DisplayProperties.cpp
+++ b/Applications/DisplayProperties/DisplayProperties.cpp
@@ -1,5 +1,6 @@
 #include <AK/StringBuilder.h>
 #include <LibCore/CDirIterator.h>
+#include <LibDraw/PNGLoader.h>
 #include <LibGUI/GAction.h>
 #include <LibGUI/GApplication.h>
 #include <LibGUI/GBoxLayout.h>
@@ -8,6 +9,7 @@
 #include <LibGUI/GEventLoop.h>
 #include <LibGUI/GFileSystemModel.h>
 #include <LibGUI/GGroupBox.h>
+#include <LibGUI/GLabel.h>
 #include <LibGUI/GListView.h>
 #include <LibGUI/GScrollBar.h>
 #include <LibGUI/GSplitter.h>
@@ -72,15 +74,21 @@ void DisplayPropertiesWidget::create_frame()
 
     auto* background_content = new GWidget(background_splitter);
     background_content->set_layout(make<GBoxLayout>(Orientation::Vertical));
-    background_content->layout()->add_spacer();
     background_content->layout()->set_margins({ 4, 4, 4, 4 });
+
+    auto* wallpaper_preview = new GLabel(background_splitter);
 
     auto* wallpaper_list = new GListView(background_content);
     wallpaper_list->set_background_color(Color::White);
     wallpaper_list->set_model(*ItemListModel<AK::String>::create(m_wallpapers));
     wallpaper_list->horizontal_scrollbar().set_visible(false);
-    wallpaper_list->on_selection = [this](auto& index) {
+    wallpaper_list->on_selection = [this, wallpaper_preview](auto& index) {
+        StringBuilder builder;
         m_selected_wallpaper = m_wallpapers.at(index.row());
+        builder.append("/res/wallpapers/");
+        builder.append(m_selected_wallpaper);
+        wallpaper_preview->set_icon(load_png(builder.to_string()));
+        wallpaper_preview->set_should_stretch_icon(true);
     };
 
     // Let's add the settings tab


### PR DESCRIPTION
As was mentioned in #556, the `DisplayProperties` Wallpaper tab
contained a lot of "extra space", in which half the tab was taken up
by the list of wallpapers. The rest of that space is now reserved for
a wallpaper preview, so the user can see the selected image before
applying it.