### PR TITLE
Shell: Added `pushd`, `popd` and `dirs` builtins

### DIFF
--- a/Shell/GlobalState.h
+++ b/Shell/GlobalState.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <AK/Vector.h>
 #include <termios.h>
 
 struct GlobalState {
@@ -15,6 +16,7 @@ struct GlobalState {
     bool was_interrupted { false };
     bool was_resized { false };
     int last_return_code { 0 };
+    Vector<String> directory_stack;
 };
 
 extern GlobalState g;


### PR DESCRIPTION
Added a few builtin functions to the shell to make navigating a bit
easier in the terminal.

`pushd` allows a user to "push" the current directory to the directory
stack, and then `cd` to the new directory.
`popd` allows the used to take the directory on the top of the stack
off before `cd`'ing to it.
`dirs` gives the state of the current directory stack.

This is only a partial implementation of the `bash` version
(gnu.org/software/bash/manual/html_node/Directory-Stack-Builtins.html)
, and doesn't include any of the +N or -N commands as of yet.