### PR TITLE
Terminal: Scrollbar 'snaps' to current line

### DIFF
--- a/Applications/Terminal/TerminalWidget.cpp
+++ b/Applications/Terminal/TerminalWidget.cpp
@@ -184,6 +184,8 @@ void TerminalWidget::keydown_event(GKeyEvent& event)
 
         write(m_ptm_fd, &ch, 1);
     }
+
+    m_scrollbar->set_value(m_scrollbar->max());
 }
 
 void TerminalWidget::paint_event(GPaintEvent& event)


### PR DESCRIPTION
One feature that was missing from the terminal was 'scrollbar' snapping
That is, when the user has scrolled up and begins typing, the scrollbar
will automatically return them to the current cursor position so
that they can see what they're typing.