### PR TITLE
FileManager+LibGUI: Fix crash when opening a folder, as well as when …

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -104,6 +104,20 @@ int main(int argc, char** argv)
             if (rc < 0) {
                 GMessageBox::show(String::format("mkdir(\"%s\") failed: %s", new_dir_path.characters(), strerror(errno)), "Error", GMessageBox::Type::Error, GMessageBox::InputType::OK, window);
             } else {
+                file_system_model->update();
+
+                auto current_path = directory_view->path();
+
+                // not exactly sure why i have to reselect the root node first, but the index() fails if I dont
+                auto root_index = file_system_model->index(file_system_model->root_path());
+                tree_view->selection().set(root_index);
+
+                // reselect the existing folder in the tree
+                auto new_index = file_system_model->index(current_path);
+                tree_view->selection().set(new_index);
+                tree_view->scroll_into_view(new_index, Orientation::Vertical);
+                tree_view->update();
+
                 directory_view->refresh();
             }
         }

--- a/Libraries/LibGUI/GFileSystemModel.cpp
+++ b/Libraries/LibGUI/GFileSystemModel.cpp
@@ -31,6 +31,15 @@ struct GFileSystemModel::Node {
         ASSERT_NOT_REACHED();
     }
 
+    void cleanup()
+    {
+        for (auto& child: children) {
+            child->cleanup();
+            delete child;
+        }
+        children.clear();
+    }
+
     void traverse_if_needed(const GFileSystemModel& model)
     {
         if (type != Node::Directory || has_traversed)
@@ -146,13 +155,20 @@ GFileSystemModel::~GFileSystemModel()
 
 void GFileSystemModel::update()
 {
-    // FIXME: Support refreshing the model!
-    if (m_root)
-        return;
+    cleanup();
 
     m_root = new Node;
     m_root->name = m_root_path;
     m_root->reify_if_needed(*this);
+}
+
+void GFileSystemModel::cleanup()
+{
+    if (m_root) {
+        m_root->cleanup();
+        delete m_root;
+        m_root = nullptr;
+    }
 }
 
 int GFileSystemModel::row_count(const GModelIndex& index) const

--- a/Libraries/LibGUI/GFileSystemModel.h
+++ b/Libraries/LibGUI/GFileSystemModel.h
@@ -37,6 +37,7 @@ private:
 
     struct Node;
     Node* m_root { nullptr };
+    void cleanup();
 
     GIcon m_open_folder_icon;
     GIcon m_closed_folder_icon;

--- a/Libraries/LibGUI/GModelSelection.h
+++ b/Libraries/LibGUI/GModelSelection.h
@@ -33,15 +33,25 @@ public:
     template<typename Callback>
     void for_each_index(Callback callback)
     {
-        for (auto& index : m_indexes)
+        for (auto& index : indexes())
             callback(index);
     }
 
     template<typename Callback>
     void for_each_index(Callback callback) const
     {
-        for (auto& index : m_indexes)
+        for (auto& index : indexes())
             callback(index);
+    }
+
+    Vector<GModelIndex> indexes() const
+    {
+        Vector<GModelIndex> selected_indexes;
+
+        for (auto& index : m_indexes)
+            selected_indexes.append(index);
+            
+        return selected_indexes;
     }
 
     // FIXME: This doesn't guarantee that what you get is the lowest or "first" index selected..


### PR DESCRIPTION
- Fixed a crash that occurs when trying to open a folder, or when trying to open a newly created folder.
- Treeview now refreshes after creating the new folder.

This fixes #536.
