### PR TITLE
copy && paste

### DIFF
--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -48,7 +48,12 @@ FileDescription::~FileDescription()
 
 KResult FileDescription::fstat(stat& buffer)
 {
-    ASSERT(!is_fifo());
+    if (is_fifo()) {
+        memset(&buffer, 0, sizeof(buffer));
+        buffer.st_mode = 001000;
+        return KSuccess;
+    }
+
     if (!m_inode)
         return KResult(-EBADF);
     return metadata().stat(buffer);

--- a/Libraries/LibC/getopt.cpp
+++ b/Libraries/LibC/getopt.cpp
@@ -113,16 +113,16 @@ static int nonopt_start = -1; /* first non option argument (for permute) */
 static int nonopt_end = -1;   /* first option after non options (for permute) */
 
 /* Error messages */
-static const char recargchar[] = "option requires an argument -- %c";
-static const char illoptchar[] = "illegal option -- %c"; /* From P1003.2 */
+static const char recargchar[] = "option requires an argument -- %c\n";
+static const char illoptchar[] = "illegal option -- %c\n"; /* From P1003.2 */
 
 static int dash_prefix = NO_PREFIX;
-static const char gnuoptchar[] = "invalid option -- %c";
+static const char gnuoptchar[] = "invalid option -- %c\n";
 
-static const char recargstring[] = "option `%s%s' requires an argument";
-static const char ambig[] = "option `%s%.*s' is ambiguous";
-static const char noarg[] = "option `%s%.*s' doesn't allow an argument";
-static const char illoptstring[] = "unrecognized option `%s%s'";
+static const char recargstring[] = "option `%s%s' requires an argument\n";
+static const char ambig[] = "option `%s%.*s' is ambiguous\n";
+static const char noarg[] = "option `%s%.*s' doesn't allow an argument\n";
+static const char illoptstring[] = "unrecognized option `%s%s'\n";
 
 /*
  * Compute the greatest common divisor of a and b.

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -799,7 +799,7 @@ void Terminal::on_char(u8 ch)
         m_client.beep();
         return;
     case '\t': {
-        for (unsigned i = m_cursor_column; i < columns(); ++i) {
+        for (unsigned i = m_cursor_column + 1; i < columns(); ++i) {
             if (m_horizontal_tabs[i]) {
                 set_cursor(m_cursor_row, i);
                 return;

--- a/Userland/copy.cpp
+++ b/Userland/copy.cpp
@@ -1,0 +1,93 @@
+#include <AK/ByteBuffer.h>
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
+#include <LibCore/CFile.h>
+#include <LibGUI/GClipboard.h>
+#include <LibGUI/GEventLoop.h>
+#include <getopt.h>
+
+struct Options {
+    String data;
+    String type { "text" };
+};
+
+void print_usage(FILE* stream, const char* argv0)
+{
+    fprintf(
+        stream,
+        "Usage:\n"
+        "\t%s [--type type] text\n"
+        "\t%s [--type type] < file\n"
+        "\n"
+        "\t-t type, --type type\tPick a type.\n"
+        "\t-h, --help\t\tPrint this help message.\n",
+        argv0,
+        argv0);
+}
+
+Options parse_options(int argc, char* argv[])
+{
+    Options options;
+
+    static struct option long_options[] = {
+        { "type", required_argument, 0, 't' },
+        { "help", no_argument, 0, 'h' },
+        { 0, 0, 0, 0 }
+    };
+    while (true) {
+        int option_index;
+        int c = getopt_long(argc, argv, "t:h", long_options, &option_index);
+        if (c == -1)
+            break;
+        if (c == 0)
+            c = long_options[option_index].val;
+
+        switch (c) {
+        case 't':
+            options.type = optarg;
+            break;
+        case 'h':
+            print_usage(stdout, argv[0]);
+            exit(0);
+        default:
+            print_usage(stderr, argv[0]);
+            exit(1);
+        }
+    }
+
+    if (optind < argc) {
+        // Copy the rest of our command-line args.
+        StringBuilder builder;
+        bool first = true;
+        for (int i = optind; i < argc; i++) {
+            if (!first)
+                builder.append(' ');
+            first = false;
+            builder.append(argv[i]);
+        }
+        options.data = builder.to_string();
+    } else {
+        // Copy our stdin.
+        CFile c_stdin;
+        bool success = c_stdin.open(
+            STDIN_FILENO,
+            CIODevice::OpenMode::ReadOnly,
+            CFile::ShouldCloseFileDescription::No);
+        ASSERT(success);
+        auto buffer = c_stdin.read_all();
+        dbg() << "Read size " << buffer.size();
+        options.data = String((char*)buffer.data(), buffer.size());
+    }
+
+    return options;
+}
+
+int main(int argc, char* argv[])
+{
+    Options options = parse_options(argc, argv);
+
+    new GEventLoop;
+
+    GClipboard& clipboard = GClipboard::the();
+    clipboard.set_data(options.data, options.type);
+}

--- a/Userland/paste.cpp
+++ b/Userland/paste.cpp
@@ -1,0 +1,79 @@
+#include <AK/String.h>
+#include <LibGUI/GClipboard.h>
+#include <LibGUI/GEventLoop.h>
+#include <getopt.h>
+
+struct Options {
+    bool print_type { false };
+    bool no_newline { false };
+};
+
+void print_usage(FILE* stream, const char* argv0)
+{
+    fprintf(
+        stream,
+        "Usage:\n"
+        "\t%s [--print-type] [--no-newline]\n"
+        "\n"
+        "\t--print-type\t\tDisplay the copied type.\n"
+        "\t-n, --no-newline\tDo not append a newline.\n"
+        "\t-h, --help\t\tPrint this help message.\n",
+        argv0);
+}
+
+Options parse_options(int argc, char* argv[])
+{
+    Options options;
+
+    static struct option long_options[] = {
+        { "print-type", no_argument, 0, 'p' },
+        { "no-newline", no_argument, 0, 'n' },
+        { "help", no_argument, 0, 'h' },
+        { 0, 0, 0, 0 }
+    };
+    while (true) {
+        int option_index;
+        int c = getopt_long(argc, argv, "hn", long_options, &option_index);
+        if (c == -1)
+            break;
+        if (c == 0)
+            c = long_options[option_index].val;
+
+        switch (c) {
+        case 'p':
+            options.print_type = true;
+            break;
+        case 'n':
+            options.no_newline = true;
+            break;
+        case 'h':
+            print_usage(stdout, argv[0]);
+            exit(0);
+        default:
+            print_usage(stderr, argv[0]);
+            exit(1);
+        }
+    }
+
+    return options;
+}
+
+int main(int argc, char* argv[])
+{
+    Options options = parse_options(argc, argv);
+
+    new GEventLoop;
+
+    GClipboard& clipboard = GClipboard::the();
+    auto data_and_type = clipboard.data_and_type();
+
+    if (!options.print_type) {
+        printf("%s", data_and_type.data.characters());
+        // Append a newline to text contents, but
+        // only if we're not asked not to do this.
+        if (data_and_type.type == "text" && !options.no_newline)
+            putchar('\n');
+    } else {
+        printf("%s\n", data_and_type.type.characters());
+    }
+}


### PR DESCRIPTION
Two new commands, `copy` and `paste`, to copy and paste from the shell :smile:

This is basically the Serenity equivalent of xclip, wl-clipboard and `pbcopy`/`pbpaste`. The CLI looks a lot like wl-clipboard (but way simpler), because that's what I _happen_ to like most :wink:

You can now copy into the system clipboard like this:
```
$ copy hello friends
```

or like this:
```
$ copy < ReadMe.md
```

or like this:
```
 $ copy --type png < /res/wallpapers/sunset-retro.png
```

And paste with just
```
$ paste
```
or to view the copied type:
```
 $ paste --print-type
```

You can actually even fake a FileManager file copy by using `--type file-list` ^)