### PR TITLE
First implementation of kernel level timers

### DIFF
--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -134,27 +134,23 @@ public:
         auto* new_node = new Node(move(value));
         new_node->value = value;
 
-        if (!m_head) {
-            m_head = new_node;
-            m_tail = new_node;
+        if (!m_head || m_head->value > new_node->value) {
+            new_node->next = m_head;
+        if (!m_head)
+                m_tail = new_node;
+        m_head = new_node;
             return;
         }
 
-	if (!m_head->next && new_node->value < m_head->value) {
-           new_node->next = m_head;
-	   m_head = new_node;
-	   return;
-	}
-
         Node* curr = m_head;
-	while (curr->next && curr->next->value < new_node->value) 
-	{
-	    curr = curr->next;
+        while (curr->next && curr->next->value < new_node->value) 
+        {
+            curr = curr->next;
         }
 
         new_node->next = curr->next;
-	curr->next = new_node;
-	if(m_tail == curr)
+        curr->next = new_node;
+        if(m_tail == curr)
             m_tail = new_node;
 
     }   
@@ -164,23 +160,24 @@ public:
         auto* new_node = new Node(move(value));
         new_node->value = value;
 
-        if (!m_head) {
+        if (!m_head || m_head->value > new_node->value) {
+            new_node->next = m_head;
+            if (!m_head)
+                m_tail = new_node;
             m_head = new_node;
-            m_tail = new_node;
             return;
         }
-	
+
         Node* curr = m_head;
-	while (curr->next && curr->next->value < new_node->value)
+        while (curr->next && curr->next->value < new_node->value)
         {
-	    curr = curr->next;
+            curr = curr->next;
         }
 
         new_node->next = curr->next;
-	curr->next = new_node;
-	if(m_tail == curr)
+        curr->next = new_node;
+        if(m_tail == curr)
             m_tail = new_node;
-
     }
 
     bool contains_slow(const T& value) const

--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -128,6 +128,60 @@ public:
         m_tail->next = node;
         m_tail = node;
     }
+    
+    void sorted_insert_slow(const T& value)
+    {
+        auto* new_node = new Node(move(value));
+        new_node->value = value;
+
+        if (!m_head) {
+            m_head = new_node;
+            m_tail = new_node;
+            return;
+        }
+
+	if (!m_head->next && new_node->value < m_head->value) {
+           new_node->next = m_head;
+	   m_head = new_node;
+	   return;
+	}
+
+        Node* curr = m_head;
+	while (curr->next && curr->next->value < new_node->value) 
+	{
+	    curr = curr->next;
+        }
+
+        new_node->next = curr->next;
+	curr->next = new_node;
+	if(m_tail == curr)
+            m_tail = new_node;
+
+    }   
+    
+    void sorted_insert_slow(T&& value)
+    {
+        auto* new_node = new Node(move(value));
+        new_node->value = value;
+
+        if (!m_head) {
+            m_head = new_node;
+            m_tail = new_node;
+            return;
+        }
+	
+        Node* curr = m_head;
+	while (curr->next && curr->next->value < new_node->value)
+        {
+	    curr = curr->next;
+        }
+
+        new_node->next = curr->next;
+	curr->next = new_node;
+	if(m_tail == curr)
+            m_tail = new_node;
+
+    }
 
     bool contains_slow(const T& value) const
     {
@@ -137,6 +191,7 @@ public:
         }
         return false;
     }
+
 
     using Iterator = SinglyLinkedListIterator<SinglyLinkedList, T>;
     friend Iterator;

--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -129,57 +129,6 @@ public:
         m_tail = node;
     }
     
-    void sorted_insert_slow(const T& value)
-    {
-        auto* new_node = new Node(move(value));
-        new_node->value = value;
-
-        if (!m_head || m_head->value > new_node->value) {
-            new_node->next = m_head;
-        if (!m_head)
-                m_tail = new_node;
-        m_head = new_node;
-            return;
-        }
-
-        Node* curr = m_head;
-        while (curr->next && curr->next->value < new_node->value) 
-        {
-            curr = curr->next;
-        }
-
-        new_node->next = curr->next;
-        curr->next = new_node;
-        if(m_tail == curr)
-            m_tail = new_node;
-
-    }   
-    
-    void sorted_insert_slow(T&& value)
-    {
-        auto* new_node = new Node(move(value));
-        new_node->value = value;
-
-        if (!m_head || m_head->value > new_node->value) {
-            new_node->next = m_head;
-            if (!m_head)
-                m_tail = new_node;
-            m_head = new_node;
-            return;
-        }
-
-        Node* curr = m_head;
-        while (curr->next && curr->next->value < new_node->value)
-        {
-            curr = curr->next;
-        }
-
-        new_node->next = curr->next;
-        curr->next = new_node;
-        if(m_tail == curr)
-            m_tail = new_node;
-    }
-
     bool contains_slow(const T& value) const
     {
         for (auto* node = m_head; node; node = node->next) {

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -62,11 +62,11 @@ struct Timer {
     void (*callback)();
     inline bool operator<(const Timer& rhs)
     {
-    	return expires < rhs.expires;
+        return expires < rhs.expires;
     }
     inline bool operator>( const Timer& rhs)
     {
-    	return expires > rhs.expires;
+        return expires > rhs.expires;
     }
 };
 
@@ -86,7 +86,7 @@ void Scheduler::beep()
     timer.expires = g_uptime + 100;
     timer.callback = []() {
         PCSpeaker::tone_off();
-	dbgprintf("tone off");
+    dbgprintf("tone off");
     };
     add_timer(timer);
 }
@@ -548,36 +548,6 @@ void Scheduler::initialize()
     load_task_register(s_redirection.selector);
 
     g_timer_queue = new SinglyLinkedList<Timer>();
-
-    auto timer = Timer();
-    timer.expires = g_uptime + 10000;
-    timer.callback = []() {
-	dbgprintf("10 secs\n");
-    };
-    add_timer(timer);
-    
-    
-    timer = Timer();
-    timer.expires = g_uptime + 12000;
-    timer.callback = []() {
-	dbgprintf("12 secs\n");
-    };
-    add_timer(timer);
-
-    timer = Timer();
-    timer.expires = g_uptime + 11000;
-    timer.callback = []() {
-	dbgprintf("11 secs\n");
-    };
-    add_timer(timer);
-    
-    timer = Timer();
-    timer.expires = g_uptime + 5000;
-    timer.callback = []() {
-	dbgprintf("5 secs\n");
-    };
-    add_timer(timer);
-
 }
 
 void Scheduler::timer_tick(RegisterDump& regs)
@@ -586,23 +556,18 @@ void Scheduler::timer_tick(RegisterDump& regs)
         return;
 
     ++g_uptime;
-/*
-    if (s_beep_timeout && g_uptime > s_beep_timeout) {
-        PCSpeaker::tone_off();
-        s_beep_timeout = 0;
-    }
-*/    
+   
     if ( s_next_timer_due && g_uptime > s_next_timer_due) {
         
-	ASSERT(s_next_timer_due == g_timer_queue->first().expires);
-	while (! g_timer_queue->is_empty() && g_uptime > g_timer_queue->first().expires)
-	{
+        ASSERT(s_next_timer_due == g_timer_queue->first().expires);
+        while (! g_timer_queue->is_empty() && g_uptime > g_timer_queue->first().expires)
+        {
             auto timer = g_timer_queue->take_first();
             timer.callback();
-	}
-	if (! g_timer_queue->is_empty())
+        }
+        if (! g_timer_queue->is_empty())
             s_next_timer_due = g_timer_queue->first().expires;
-	else
+        else
             s_next_timer_due = 0;
     }
 

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -33,7 +33,6 @@ public:
     static void beep();
     static void idle_loop();
     static void stop_idling();
-    static void add_timer(Timer& timer);
 
     template<typename Callback>
     static inline IterationDecision for_each_runnable(Callback);

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -7,6 +7,7 @@
 
 class Process;
 class Thread;
+struct Timer;
 struct RegisterDump;
 struct SchedulerData;
 
@@ -32,6 +33,7 @@ public:
     static void beep();
     static void idle_loop();
     static void stop_idling();
+    static void add_timer(Timer& timer);
 
     template<typename Callback>
     static inline IterationDecision for_each_runnable(Callback);

--- a/Kernel/TimerQueue.cpp
+++ b/Kernel/TimerQueue.cpp
@@ -1,0 +1,71 @@
+#include <AK/SinglyLinkedList.h>
+#include <Kernel/Scheduler.h>
+#include <Kernel/TimerQueue.h>
+
+
+SinglyLinkedList<Timer>* g_timer_queue;
+
+static u64 s_next_timer_due;
+static u64 s_timer_id_count;
+void TimerQueue::initialize()
+{
+ 
+    g_timer_queue = new SinglyLinkedList<Timer>();
+}
+
+
+u64 TimerQueue::add_timer(Timer& timer)
+{
+    ASSERT(timer.expires > Scheduler::g_uptime);
+    timer.id = ++s_timer_id_count;
+    g_timer_queue->sorted_insert_slow(timer);
+    s_next_timer_due = g_timer_queue->first().expires;
+    return s_timer_id_count;
+}
+
+u64 add_timer(u64 duration, TimeUnit unit, void (callback)())
+{
+	atuo timer = Timer();
+    timer.expires = g_uptime + duration * unit;
+    timer.callback = callback;
+    return add_timer(timer);
+}
+
+void TimerQueue::sorted_insert_slow(T&& value)
+{
+	auto* new_node = new Node(move(value));
+	new_node->value = value;
+
+	if (!g_timer_queue->m_head || g_timer_queue->m_head->value > new_node->value) {
+	    new_node->next = g_timer_queue->m_head;
+	    if (!m_head)
+	        m_tail = new_node;
+	    m_head = new_node;
+	    return;
+	}
+
+	Node* curr = m_head;
+	while (curr->next && curr->next->value < new_node->value)
+	{
+	    curr = curr->next;
+	}
+
+	new_node->next = curr->next;
+	curr->next = new_node;
+	if(g_timer_queue->m_tail == curr)
+	    g_timer_queue->m_tail = new_node;
+}
+
+void TimerQueue::fire_timer()
+{
+	ASSERT(s_next_timer_due == g_timer_queue->first().expires);
+	while (! g_timer_queue->is_empty() && Scheduler::g_uptime > g_timer_queue->first().expires)
+	{
+	    auto timer = g_timer_queue->take_first();
+	    timer.callback();
+	}
+	if (! g_timer_queue->is_empty())
+	    s_next_timer_due = g_timer_queue->first().expires;
+	else
+	    s_next_timer_due = 0;
+}

--- a/Kernel/TimerQueue.h
+++ b/Kernel/TimerQueue.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <Kernel/Arch/i386/PIT.h>
+
+struct Timer {
+    u64 id;
+    u64 expires;
+    void (*callback)();
+    bool operator<(const Timer& rhs) const
+    {
+        return expires < rhs.expires;
+    }
+    bool operator>( const Timer& rhs) const
+    {
+        return expires > rhs.expires;
+    }
+
+    bool operator==( const X& rhs) const
+    {
+        return id == rhs.id;
+    }
+};
+
+enum TimeUnit {
+    MS = TICKS_PER_SECOND / 1000,
+    S = TICKS_PER_SECOND,
+    M = TICKS_PER_SECOND * 60
+};
+
+
+class TimerQueue {
+friend class SinglyLinkedList;
+public:
+    static void initialize();
+    static u64 add_timer(Timer&);
+    static u64 add_timer(u64 duration, TimeUnit, void (callback)());
+    static Timer& get_timer(u64 id);
+    static bool update_timer(Timer&)
+    static bool cancel_timer(u64 id);
+private:
+    static void fire_timer();
+    static void sorted_list_insert_slow()
+};


### PR DESCRIPTION
Hi,
as I said on IRC, I would like to start working on Serenity's networking Stack. For that, I need reliable timers for timeout and retransmission events. The current method of lazily comparing g_uptime with a calculated timestamp is insufficient. Thus, I cobbled together a first version of kernel level timers. Currently, it lacks support for removing or rescheduling timers, which I would add when this PR is approved. I just wanted to get some initial feedback.

Cheers. 