### PR TITLE
Display more fd flags

### DIFF
--- a/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
+++ b/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
@@ -19,6 +19,12 @@ ProcessFileDescriptorMapWidget::ProcessFileDescriptorMapWidget(GWidget* parent)
     pid_fds_fields.empend("Access", TextAlignment::CenterLeft, [](auto& object) {
         return object.get("seekable").to_bool() ? "Seekable" : "Sequential";
     });
+    pid_fds_fields.empend("Blocking", TextAlignment::CenterLeft, [](auto& object) {
+        return object.get("blocking").to_bool() ? "Blocking" : "Nonblocking";
+    });
+    pid_fds_fields.empend("On exec", TextAlignment::CenterLeft, [](auto& object) {
+        return object.get("cloexec").to_bool() ? "Close" : "Keep";
+    });
 
     m_table_view->set_model(GJsonArrayModel::create({}, move(pid_fds_fields)));
 }

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -211,12 +211,16 @@ Optional<KBuffer> procfs$pid_fds(InodeIdentifier identifier)
         auto* description = process.file_description(i);
         if (!description)
             continue;
+        bool cloexec = process.fd_flags(i) & FD_CLOEXEC;
+
         JsonObjectSerializer description_object = array.add_object();
         description_object.add("fd", i);
         description_object.add("absolute_path", description->absolute_path());
         description_object.add("seekable", description->file().is_seekable());
         description_object.add("class", description->file().class_name());
         description_object.add("offset", description->offset());
+        description_object.add("cloexec", cloexec);
+        description_object.add("blocking", description->is_blocking());
     }
     array.finish();
     return builder.build();

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -917,6 +917,15 @@ const FileDescription* Process::file_description(int fd) const
     return nullptr;
 }
 
+int Process::fd_flags(int fd) const
+{
+    if (fd < 0)
+        return -1;
+    if (fd < m_fds.size())
+        return m_fds[fd].flags;
+    return -1;
+}
+
 ssize_t Process::sys$get_dir_entries(int fd, void* buffer, ssize_t size)
 {
     if (size < 0)

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -95,6 +95,7 @@ public:
 
     FileDescription* file_description(int fd);
     const FileDescription* file_description(int fd) const;
+    int fd_flags(int fd) const;
 
     template<typename Callback>
     static void for_each(Callback);


### PR DESCRIPTION
Not quite sure about naming in the UI, but it's very helpful to be able to see what's `CLOEXEC` and what's not.

![image](https://user-images.githubusercontent.com/10091584/65821898-89427c00-e244-11e9-9a4c-8473061e4f1f.png)
