### PR TITLE
LibGUI: Fix GDirectoryModel lifetime bug.

### DIFF
--- a/Libraries/LibGUI/GDirectoryModel.h
+++ b/Libraries/LibGUI/GDirectoryModel.h
@@ -5,7 +5,8 @@
 #include <LibGUI/GModel.h>
 #include <sys/stat.h>
 
-class GDirectoryModel final : public GModel {
+class GDirectoryModel final : public GModel
+    , public Weakable<GDirectoryModel> {
 public:
     static NonnullRefPtr<GDirectoryModel> create() { return adopt(*new GDirectoryModel); }
     virtual ~GDirectoryModel() override;


### PR DESCRIPTION
Thumbnail generation callbacks were getting called after the class was already being disposed of causing a crash to occur.

Let me know if there's a more elegant way to solve this problem.

This should fix #619.