### PR TITLE
Man links

### DIFF
--- a/Applications/Help/History.cpp
+++ b/Applications/Help/History.cpp
@@ -1,0 +1,33 @@
+#include "History.h"
+
+void History::push(const StringView& history_item)
+{
+    m_items.shrink(m_current_history_item + 1);
+    m_items.append(history_item);
+    m_current_history_item++;
+}
+
+String History::current()
+{
+    if (m_current_history_item == -1)
+        return {};
+    return m_items[m_current_history_item];
+}
+
+void History::go_back()
+{
+    ASSERT(can_go_back());
+    m_current_history_item--;
+}
+
+void History::go_forward()
+{
+    ASSERT(can_go_forward());
+    m_current_history_item++;
+}
+
+void History::clear()
+{
+    m_items = {};
+    m_current_history_item = -1;
+}

--- a/Applications/Help/History.h
+++ b/Applications/Help/History.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <AK/String.h>
+#include <AK/Vector.h>
+
+class History final {
+public:
+    void push(const StringView& history_item);
+    String current();
+
+    void go_back();
+    void go_forward();
+
+    bool can_go_back() { return m_current_history_item > 0; }
+    bool can_go_forward() { return m_current_history_item + 1 < m_items.size(); }
+
+    void clear();
+
+private:
+    Vector<String> m_items;
+    int m_current_history_item { -1 };
+};

--- a/Applications/Help/Makefile
+++ b/Applications/Help/Makefile
@@ -1,9 +1,10 @@
 include ../../Makefile.common
 
 OBJS = \
-		ManualModel.o \
-		ManualSectionNode.o \
-		ManualPageNode.o \
+    ManualModel.o \
+    ManualSectionNode.o \
+    ManualPageNode.o \
+    History.o \
     main.o
 
 APP = Help

--- a/Applications/Help/main.cpp
+++ b/Applications/Help/main.cpp
@@ -1,10 +1,17 @@
+#include "History.h"
 #include "ManualModel.h"
 #include <LibCore/CFile.h>
 #include <LibDraw/PNGLoader.h>
+#include <LibGUI/GAboutDialog.h>
+#include <LibGUI/GAction.h>
 #include <LibGUI/GApplication.h>
+#include <LibGUI/GBoxLayout.h>
+#include <LibGUI/GMenu.h>
+#include <LibGUI/GMenuBar.h>
 #include <LibGUI/GMessageBox.h>
 #include <LibGUI/GSplitter.h>
 #include <LibGUI/GTextEditor.h>
+#include <LibGUI/GToolBar.h>
 #include <LibGUI/GTreeView.h>
 #include <LibGUI/GWindow.h>
 #include <LibHTML/HtmlView.h>
@@ -12,6 +19,7 @@
 #include <LibHTML/Parser/CSSParser.h>
 #include <LibHTML/Parser/HTMLParser.h>
 #include <LibMarkdown/MDDocument.h>
+#include <libgen.h>
 
 int main(int argc, char* argv[])
 {
@@ -21,7 +29,13 @@ int main(int argc, char* argv[])
     window->set_title("Help");
     window->set_rect(300, 200, 570, 500);
 
-    auto splitter = GSplitter::construct(Orientation::Horizontal, nullptr);
+    auto widget = GWidget::construct();
+    widget->set_layout(make<GBoxLayout>(Orientation::Vertical));
+    widget->layout()->set_spacing(0);
+
+    auto toolbar = GToolBar::construct(widget);
+
+    auto splitter = GSplitter::construct(Orientation::Horizontal, widget);
 
     auto model = ManualModel::create();
 
@@ -36,8 +50,17 @@ int main(int argc, char* argv[])
     String css = default_stylesheet_source;
     auto sheet = parse_css(css);
 
-    tree_view->on_selection_change = [&] {
-        String path = model->page_path(tree_view->selection().first());
+    History history;
+
+    RefPtr<GAction> go_back_action;
+    RefPtr<GAction> go_forward_action;
+
+    auto update_actions = [&]() {
+        go_back_action->set_enabled(history.can_go_back());
+        go_forward_action->set_enabled(history.can_go_forward());
+    };
+
+    auto open_page = [&](String path) {
         if (path.is_null()) {
             html_view->set_document(nullptr);
             return;
@@ -70,7 +93,66 @@ int main(int argc, char* argv[])
         window->set_title(String::format("Help: %s", page_and_section.characters()));
     };
 
-    window->set_main_widget(splitter);
+    tree_view->on_selection_change = [&] {
+        String path = model->page_path(tree_view->selection().first());
+        if (path.is_null()) {
+            html_view->set_document(nullptr);
+            return;
+        }
+        history.push(path);
+        update_actions();
+        open_page(path);
+    };
+
+    html_view->on_link_click = [&](const String& href) {
+        char* current_path = strdup(history.current().characters());
+        char* dir_path = dirname(current_path);
+        char* path = realpath(String::format("%s/%s", dir_path, href.characters()).characters(), nullptr);
+        free(current_path);
+        history.push(path);
+        update_actions();
+        open_page(path);
+        free(path);
+    };
+
+    go_back_action = GAction::create("Go Back", { Mod_Alt, Key_Left }, GraphicsBitmap::load_from_file("/res/icons/16x16/go-back.png"), [&](const GAction&) {
+        history.go_back();
+        update_actions();
+        open_page(history.current());
+    });
+
+    go_forward_action = GAction::create("Go Forward", { Mod_Alt, Key_Right }, GraphicsBitmap::load_from_file("/res/icons/16x16/go-forward.png"), [&](const GAction&) {
+        history.go_forward();
+        update_actions();
+        open_page(history.current());
+    });
+
+    go_back_action->set_enabled(false);
+    go_forward_action->set_enabled(false);
+
+    toolbar->add_action(*go_back_action);
+    toolbar->add_action(*go_forward_action);
+
+    auto menubar = make<GMenuBar>();
+
+    auto app_menu = make<GMenu>("Help");
+    app_menu->add_action(GAction::create("About", [&](const GAction&) {
+        GAboutDialog::show("Help", load_png("/res/icons/16x16/book.png"), window);
+    }));
+    app_menu->add_separator();
+    app_menu->add_action(GCommonActions::make_quit_action([](auto&) {
+        GApplication::the().quit(0);
+    }));
+    menubar->add_menu(move(app_menu));
+
+    auto go_menu = make<GMenu>("Go");
+    go_menu->add_action(*go_back_action);
+    go_menu->add_action(*go_forward_action);
+    menubar->add_menu(move(go_menu));
+
+    app.set_menubar(move(menubar));
+
+    window->set_main_widget(widget);
     window->show();
 
     window->set_icon(load_png("/res/icons/16x16/book.png"));

--- a/Base/usr/share/man/man1/mkdir.md
+++ b/Base/usr/share/man/man1/mkdir.md
@@ -17,3 +17,7 @@ Create a new empty directory at the given *path*.
 ```sh
 $ mkdir /tmp/foo
 ```
+
+## See also
+
+* [`mkdir`(2)](../man2/mkdir.md)

--- a/Base/usr/share/man/man2/create_shared_buffer.md
+++ b/Base/usr/share/man/man2/create_shared_buffer.md
@@ -21,3 +21,7 @@ If a region is successfully created, `create_shared_buffer()` stores a pointer t
 
 * `EINVAL`: `size` is zero or negative.
 * `EFAULT`: `buffer` is not a valid address.
+
+## See also
+
+* [`share_buffer_with`(2)](share_buffer_with.md)

--- a/Base/usr/share/man/man2/mkdir.md
+++ b/Base/usr/share/man/man2/mkdir.md
@@ -18,3 +18,7 @@ Create a new empty directory at the given *path* using the given *mode*.
 
 If the directory was created successfully, `mkdir()` returns 0. Otherwise,
 it returns -1 and sets `errno` to describe the error.
+
+## See also
+
+* [`mkdir`(1)](../man1/mkdir.md)

--- a/Base/usr/share/man/man2/share_buffer_with.md
+++ b/Base/usr/share/man/man2/share_buffer_with.md
@@ -22,3 +22,7 @@ On success, returns 0. Otherwise, returns -1 and `errno` is set.
 * `EINVAL`: `peer_pid` is invalid, or `shared_buffer_id` is not a valid ID.
 * `EPERM`: The calling process does not have access to the buffer with `shared_buffer_id`.
 * `ESRCH`: No process with PID `peer_pid` is found.
+
+## See also
+
+* [`create_shared_buffer`(2)](create_shared_buffer.md)

--- a/Base/usr/share/man/man3/basename.md
+++ b/Base/usr/share/man/man3/basename.md
@@ -1,0 +1,53 @@
+## Name
+
+basename - extract file name from a path
+
+## Synopsis
+
+```**c++
+#include <libgen.h>
+
+char* basename(char* path);
+```
+
+## Description
+
+Given a file path, `basename()` returns that file's name. `basename()` works
+purely lexically, meaning it only manipulates the path as a string, and does
+not check if such a file actually exists.
+
+A call to `basename()` may reuse and modify the passed in `path` buffer. Do not
+expect it to have the same value after calling `basename()`.
+
+## Return value
+
+`basename()` returns the file name as a string. This string may be allocated
+in static memory, or it may point to some part of the original `path` buffer.
+Do not `free()` the returned string, and do not `free()` the original `path`
+buffer while using the returned string.
+
+## Examples
+
+```c++
+#include <AK/LogStream.h>
+#include <libgen.h>
+
+int main()
+{
+    char path1[] = "/home/anon/ReadMe.md";
+    dbg() << basename(path1); // should be "ReadMe.md"
+
+    char path2[] = "foo/bar/";
+    dbg() << basename(path2); // should be "bar"
+
+    char path3[] = "foo";
+    dbg() << basename(path3); // should be "foo"
+
+    char path4[] = "/";
+    dbg() << basename(path4); // should be "/"
+}
+```
+
+## See also
+
+* [`dirname`(3)](dirname.md)

--- a/Base/usr/share/man/man3/dirname.md
+++ b/Base/usr/share/man/man3/dirname.md
@@ -1,0 +1,54 @@
+## Name
+
+dirname - get a file's containing directory path
+
+## Synopsis
+
+```**c++
+#include <libgen.h>
+
+char* dirname(char* path);
+```
+
+## Description
+
+Given a file path, `dirname()` returns a path to the directory that contains the
+file. `dirname()` works purely lexically, meaning it only manipulates the path
+as a string, and does not check if such a file or its containing directory
+actually exist.
+
+A call to `dirname()` may reuse and modify the passed in `path` buffer. Do not
+expect it to have the same value after calling `dirname()`.
+
+## Return value
+
+`dirname()` returns the directory path as a string. This string may be allocated
+in static memory, or it may point to some part of the original `path` buffer.
+Do not `free()` the returned string, and do not `free()` the original `path`
+buffer while using the returned string.
+
+## Examples
+
+```c++
+#include <AK/LogStream.h>
+#include <libgen.h>
+
+int main()
+{
+    char path1[] = "/home/anon/ReadMe.md";
+    dbg() << dirname(path1); // should be "/home/anon"
+
+    char path2[] = "foo/bar/";
+    dbg() << dirname(path2); // should be "foo"
+
+    char path3[] = "foo";
+    dbg() << dirname(path3); // should be "."
+
+    char path4[] = "/";
+    dbg() << dirname(path4); // should be "/"
+}
+```
+
+## See also
+
+* [`basename`(3)](basename.md)

--- a/Libraries/LibC/Makefile
+++ b/Libraries/LibC/Makefile
@@ -51,7 +51,8 @@ LIBC_OBJS = \
        arpa/inet.o \
        netdb.o \
        sched.o \
-       dlfcn.o
+       dlfcn.o \
+       libgen.o
 
 ASM_OBJS = setjmp.ao crti.ao crtn.ao
 

--- a/Libraries/LibC/libgen.cpp
+++ b/Libraries/LibC/libgen.cpp
@@ -1,0 +1,58 @@
+#include <AK/Assertions.h>
+#include <libgen.h>
+#include <string.h>
+
+static char dot[] = ".";
+static char slash[] = "/";
+
+char* dirname(char* path)
+{
+    if (path == nullptr)
+        return dot;
+
+    int len = strlen(path);
+    if (len == 0)
+        return dot;
+
+    while (len > 1 && path[len - 1] == '/') {
+        path[len - 1] = 0;
+        len--;
+    }
+
+    char* last_slash = strrchr(path, '/');
+    if (last_slash == nullptr)
+        return dot;
+
+    if (last_slash == path)
+        return slash;
+
+    *last_slash = 0;
+    return path;
+}
+
+char* basename(char* path)
+{
+    if (path == nullptr)
+        return dot;
+
+    int len = strlen(path);
+    if (len == 0)
+        return dot;
+
+    while (len > 1 && path[len - 1] == '/') {
+        path[len - 1] = 0;
+        len--;
+    }
+
+    char* last_slash = strrchr(path, '/');
+    if (last_slash == nullptr)
+        return path;
+
+    if (len == 1) {
+        ASSERT(last_slash == path);
+        ASSERT(path[0] == '/');
+        return slash;
+    }
+
+    return last_slash + 1;
+}

--- a/Libraries/LibC/libgen.h
+++ b/Libraries/LibC/libgen.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
+char* dirname(char* path);
+char* basename(char* path);
+
+__END_DECLS

--- a/Libraries/LibGUI/GModel.h
+++ b/Libraries/LibGUI/GModel.h
@@ -65,7 +65,6 @@ public:
     void unregister_view(Badge<GAbstractView>, GAbstractView&);
 
     Function<void()> on_update;
-    Function<void(const GModelIndex&)> on_selection_changed;
 
 protected:
     GModel();

--- a/Libraries/LibMarkdown/MDText.h
+++ b/Libraries/LibMarkdown/MDText.h
@@ -9,6 +9,7 @@ public:
         bool emph { false };
         bool strong { false };
         bool code { false };
+        String href;
     };
 
     struct Span {

--- a/Makefile.common
+++ b/Makefile.common
@@ -23,6 +23,7 @@ LDFLAGS = \
     -L$(SERENITY_BASE_DIR)/Libraries/LibDraw \
     -L$(SERENITY_BASE_DIR)/Libraries/LibGUI \
     -L$(SERENITY_BASE_DIR)/Libraries/LibHTML \
+    -L$(SERENITY_BASE_DIR)/Libraries/LibMarkdown \
     -L$(SERENITY_BASE_DIR)/Libraries/LibThread \
     -L$(SERENITY_BASE_DIR)/Libraries/LibVT \
     -L$(SERENITY_BASE_DIR)/Libraries/LibAudio


### PR DESCRIPTION
LibMarkdown now supports `[links like this](...)`, and we use this for referencing other man pages, particularly in the "See also" sections. Here's the format:

```markdown
[`page`(section)](relative-path-to-the-page.md)
```

You can actually click these links with the mouse in the Help app,and it will resolve the path, using the new `dirname()` function, and take you there!

To top it off, there's history support, so you can go back and forth ^)

Issues:
* LibHTML doesn't detect clicks on the links on the two new `basename(3)` and `dirname(3)` pages for some reason; it works elsewhere
* Because of the infamous -11px layouting hack, the transition from monospace page name to non-monospace section number looks less than ideal
* Ideally the toolbar should be large, like in the Windows CHM viewer. I've implemented this, but it looks meh without large icons :smile:
* Instead of a separate Help menu and an app menu, the Help app has a single "Help" menu that's both an app menu and a Help menu for the app (containing the "About" action); it seems something in the stack doesn't like duplicated menu titles. On the other hand perhaps two Help menus would indeed be confusing.
* Also need a larger icon for the About dialog in the Help app :smile: