### PR TITLE
LibC: unistd.h should provide SEEK_SET etc. if stdio.h is not included

### DIFF
--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -1,3 +1,10 @@
+/* standard symbolic constants and types
+ *
+ * values from POSIX standard unix specification
+ *
+ * https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html
+ */
+
 #pragma once
 
 #include <errno.h>
@@ -11,6 +18,14 @@ __BEGIN_DECLS
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
+
+/* lseek whence values */
+#ifndef _STDIO_H /* also defined in stdio.h */
+#define SEEK_SET 0 /* from beginning of file.  */
+#define SEEK_CUR 1 /* from current position in file.  */
+#define SEEK_END 2 /* from the end of the file.  */
+#endif
+
 
 extern char** environ;
 


### PR DESCRIPTION
seems POSIX is odd and unistd also defines SEEK_SET if stdio.h this
 simply follows the pattern several other c libraries take of setting
 these macros to the same values in stdio if that header is not included.
