### PR TITLE
PartitionTable: Removing unnecessary declarations from GPT & MBR classes

### DIFF
--- a/Kernel/Devices/GPTPartitionTable.h
+++ b/Kernel/Devices/GPTPartitionTable.h
@@ -53,7 +53,6 @@ public:
 private:
     NonnullRefPtr<DiskDevice> m_device;
 
-    ByteBuffer read_header() const;
     const GPTPartitionHeader& header() const;
 
     u8 m_cached_header[512];

--- a/Kernel/Devices/MBRPartitionTable.h
+++ b/Kernel/Devices/MBRPartitionTable.h
@@ -42,7 +42,6 @@ public:
 private:
     NonnullRefPtr<DiskDevice> m_device;
 
-    ByteBuffer read_header() const;
     const MBRPartitionHeader& header() const;
 
     u8 m_cached_header[512];


### PR DESCRIPTION
Talked with AK in the IRC about that, we figured out that those declarations can be deleted.