### PR TITLE
Kernel: Send SIGSEGV to threads on segfault.

### DIFF
--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -262,6 +262,11 @@ void exception_14_handler(RegisterDump& regs)
     auto response = MM.handle_page_fault(PageFault(regs.exception_code, VirtualAddress(fault_address)));
 
     if (response == PageFaultResponse::ShouldCrash) {
+	    if(current->has_signal_handler(SIGSEGV)){
+	        current->send_urgent_signal_to_self(SIGSEGV);
+	       	return;
+	    }
+
         kprintf("\033[31;1m%s(%u:%u) Unrecoverable page fault, %s address %p\033[0m\n",
             current->process().name().characters(),
             current->pid(),

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -347,29 +347,6 @@ struct [[gnu::packed]] RegisterDump
     u32 edx;
     u32 ecx;
     u32 eax;
-    u32 eip;
-    u16 cs;
-    u16 __csPadding;
-    u32 eflags;
-    u32 esp_if_crossRing;
-    u16 ss_if_crossRing;
-};
-
-struct [[gnu::packed]] RegisterDumpWithExceptionCode
-{
-    u16 ss;
-    u16 gs;
-    u16 fs;
-    u16 es;
-    u16 ds;
-    u32 edi;
-    u32 esi;
-    u32 ebp;
-    u32 esp;
-    u32 ebx;
-    u32 edx;
-    u32 ecx;
-    u32 eax;
     u16 exception_code;
     u16 __exception_code_padding;
     u32 eip;
@@ -379,6 +356,7 @@ struct [[gnu::packed]] RegisterDumpWithExceptionCode
     u32 esp_if_crossRing;
     u16 ss_if_crossRing;
 };
+
 
 struct [[gnu::aligned(16)]] FPUState
 {

--- a/Kernel/Arch/i386/PIT.cpp
+++ b/Kernel/Arch/i386/PIT.cpp
@@ -12,6 +12,7 @@ extern "C" void timer_interrupt_handler(RegisterDump&);
 asm(
     ".globl timer_interrupt_entry \n"
     "timer_interrupt_entry: \n"
+    "    pushl $0x0\n"
     "    pusha\n"
     "    pushw %ds\n"
     "    pushw %es\n"
@@ -34,6 +35,7 @@ asm(
     "    popw %es\n"
     "    popw %ds\n"
     "    popa\n"
+    "    add $0x4, %esp\n"
     "    iret\n");
 
 static u32 s_ticks_this_second;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -864,9 +864,12 @@ int Process::sys$sigreturn(RegisterDump& registers)
     current->m_signal_mask = *stack_ptr;
     stack_ptr++;
 
-    //pop edi, esi, ebp, esp, ebx, edx, ecx, eax and eip
-    memcpy(&registers.edi, stack_ptr, 9 * sizeof(u32));
-    stack_ptr += 9;
+    //pop edi, esi, ebp, esp, ebx, edx, ecx and eax
+    memcpy(&registers.edi, stack_ptr, 8 * sizeof(u32));
+    stack_ptr += 8;
+
+    registers.eip = *stack_ptr;
+    stack_ptr++;
 
     registers.eflags = *stack_ptr;
     stack_ptr++;

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -561,8 +561,8 @@ void Scheduler::timer_tick(RegisterDump& regs)
     outgoing_tss.eflags = regs.eflags;
 
     // Compute process stack pointer.
-    // Add 12 for CS, EIP, EFLAGS (interrupt mechanic)
-    outgoing_tss.esp = regs.esp + 12;
+    // Add 16 for CS, EIP, EFLAGS, exception code (interrupt mechanic)
+    outgoing_tss.esp = regs.esp + 16;
     outgoing_tss.ss = regs.ss;
 
     if ((outgoing_tss.cs & 3) != 0) {

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -13,6 +13,7 @@ extern volatile RegisterDump* syscallRegDump;
 asm(
     ".globl syscall_trap_handler \n"
     "syscall_trap_handler:\n"
+    "    pushl $0x0\n"
     "    pusha\n"
     "    pushw %ds\n"
     "    pushw %es\n"
@@ -35,6 +36,7 @@ asm(
     "    popw %es\n"
     "    popw %ds\n"
     "    popa\n"
+    "    add $0x4, %esp\n"
     "    iret\n");
 
 namespace Syscall {

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -273,6 +273,7 @@ public:
     void set_selector(u16 s) { m_far_ptr.selector = s; }
     void set_state(State);
 
+    void send_urgent_signal_to_self(u8 signal);
     void send_signal(u8 signal, Process* sender);
     void consider_unblock(time_t now_sec, long now_usec);
 
@@ -283,6 +284,7 @@ public:
     bool has_unmasked_pending_signals() const;
     void terminate_due_to_signal(u8 signal);
     bool should_ignore_signal(u8 signal) const;
+    bool has_signal_handler(u8 signal) const;
 
     FPUState& fpu_state() { return *m_fpu_state; }
     bool has_used_fpu() const { return m_has_used_fpu; }


### PR DESCRIPTION
This allows the kernel to send the SIGSEGV signal to segfaulting threads, fixing #598.