### PR TITLE
Quick fix for binutils

### DIFF
--- a/Libraries/LibC/stdlib.h
+++ b/Libraries/LibC/stdlib.h
@@ -43,6 +43,7 @@ int system(const char* command);
 char* mktemp(char*);
 char* mkdtemp(char*);
 void* bsearch(const void* key, const void* base, size_t nmemb, size_t size, int (*compar)(const void*, const void*));
+size_t mbstowcs(wchar_t*, const char*, size_t);
 
 #define RAND_MAX 32767
 int rand();


### PR DESCRIPTION
This became broken after https://github.com/SerenityOS/serenity/commit/89bf38864a300dacc73e516fe359bd7a94a2ab98 shuffled some things in `stdlib.cpp` out of the `extern "C"` block. Ideally, everything that needs C linkage has to be declared in a header inside an `extern "C"` block, then it doesn't matter where we put it in the cpp file. So do that for `mbstowcs()`.