### PR TITLE
KeyboardDevice: Implement Caps Lock key handling.

### DIFF
--- a/Kernel/Devices/KeyboardDevice.cpp
+++ b/Kernel/Devices/KeyboardDevice.cpp
@@ -104,7 +104,7 @@ static KeyCode unshifted_key_map[0x80] = {
     Key_Invalid,
     Key_Alt,     // 56
     Key_Space,   // 57
-    Key_Invalid, // 58
+    Key_CapsLock, // 58
     Key_F1,
     Key_F2,
     Key_F3,
@@ -199,7 +199,7 @@ static KeyCode shifted_key_map[0x100] = {
     Key_Invalid,
     Key_Alt,
     Key_Space,   // 57
-    Key_Invalid, // 58
+    Key_CapsLock, // 58
     Key_F1,
     Key_F2,
     Key_F3,
@@ -248,6 +248,17 @@ void KeyboardDevice::key_state_changed(u8 raw, bool pressed)
         else
             // FIXME: Very unreliable because release IRQ sometimes gets lost somewhere.
             just_released = true;
+    }
+
+    if (key == Key_CapsLock && just_pressed)
+        m_caps_lock_on = !m_caps_lock_on;
+
+    if (m_caps_lock_on && (m_modifiers == 0 || m_modifiers == Mod_Shift))
+    {
+        if (character >= 'a' && character <= 'z')
+            character &= ~0x20;
+        else if (character >= 'A' && character <= 'Z')
+            character |= 0x20;
     }
 
     Event event;

--- a/Kernel/Devices/KeyboardDevice.h
+++ b/Kernel/Devices/KeyboardDevice.h
@@ -47,6 +47,7 @@ private:
     KeyboardClient* m_client { nullptr };
     CircularQueue<Event, 16> m_queue;
     u8 m_modifiers { 0 };
+    bool m_last_state[0x100] { 0 };
 };
 
 class KeyboardClient {

--- a/Kernel/Devices/KeyboardDevice.h
+++ b/Kernel/Devices/KeyboardDevice.h
@@ -48,6 +48,7 @@ private:
     CircularQueue<Event, 16> m_queue;
     u8 m_modifiers { 0 };
     bool m_last_state[0x100] { 0 };
+    bool m_caps_lock_on { false };
 };
 
 class KeyboardClient {

--- a/Kernel/KeyCode.h
+++ b/Kernel/KeyCode.h
@@ -128,6 +128,8 @@ struct KeyEvent {
     KeyCode key { Key_Invalid };
     u8 character { 0 };
     u8 flags { 0 };
+    bool just_pressed;
+    bool just_released;
     bool alt() const { return flags & Mod_Alt; }
     bool ctrl() const { return flags & Mod_Ctrl; }
     bool shift() const { return flags & Mod_Shift; }

--- a/Kernel/KeyCode.h
+++ b/Kernel/KeyCode.h
@@ -119,7 +119,8 @@ enum KeyModifier {
     Mod_Ctrl = 0x02,
     Mod_Shift = 0x04,
     Mod_Logo = 0x08,
-    Mod_Mask = 0x0f,
+    Mod_CapsLock = 0x10,
+    Mod_Mask = 0x1f,
 
     Is_Press = 0x80,
 };

--- a/Libraries/LibGUI/GEvent.h
+++ b/Libraries/LibGUI/GEvent.h
@@ -229,9 +229,11 @@ enum GMouseButton : u8 {
 
 class GKeyEvent final : public GEvent {
 public:
-    GKeyEvent(Type type, int key, u8 modifiers)
+    GKeyEvent(Type type, int key, bool just_pressed, bool just_released, u8 modifiers)
         : GEvent(type)
         , m_key(key)
+        , m_just_pressed(just_pressed)
+        , m_just_released(just_released)
         , m_modifiers(modifiers)
     {
     }
@@ -241,12 +243,16 @@ public:
     bool alt() const { return m_modifiers & Mod_Alt; }
     bool shift() const { return m_modifiers & Mod_Shift; }
     bool logo() const { return m_modifiers & Mod_Logo; }
+    bool just_pressed() const { return m_just_pressed; }
+    bool just_released() const { return m_just_released; }
     u8 modifiers() const { return m_modifiers; }
     String text() const { return m_text; }
 
 private:
     friend class GWindowServerConnection;
     int m_key { 0 };
+    bool m_just_pressed { false };
+    bool m_just_released { false };
     u8 m_modifiers { 0 };
     String m_text;
 };

--- a/Libraries/LibGUI/GEventLoop.cpp
+++ b/Libraries/LibGUI/GEventLoop.cpp
@@ -87,7 +87,7 @@ void GWindowServerConnection::handle_key_event(const WSAPI_ServerMessage& event,
 #ifdef GEVENTLOOP_DEBUG
     dbgprintf("WID=%x KeyEvent character=0x%b\n", event.window_id, event.key.character);
 #endif
-    auto key_event = make<GKeyEvent>(event.type == WSAPI_ServerMessage::Type::KeyDown ? GEvent::KeyDown : GEvent::KeyUp, event.key.key, event.key.modifiers);
+    auto key_event = make<GKeyEvent>(event.type == WSAPI_ServerMessage::Type::KeyDown ? GEvent::KeyDown : GEvent::KeyUp, event.key.key, event.key.just_pressed, event.key.just_released, event.key.modifiers);
     if (event.key.character != '\0')
         key_event->m_text = String(&event.key.character, 1);
 

--- a/Servers/WindowServer/WSAPITypes.h
+++ b/Servers/WindowServer/WSAPITypes.h
@@ -175,6 +175,8 @@ struct WSAPI_ServerMessage {
             char character;
             u8 key;
             u8 modifiers;
+            bool just_pressed;
+            bool just_released;
             bool ctrl : 1;
             bool alt : 1;
             bool shift : 1;

--- a/Servers/WindowServer/WSEvent.h
+++ b/Servers/WindowServer/WSEvent.h
@@ -766,9 +766,11 @@ enum class MouseButton : u8 {
 
 class WSKeyEvent final : public WSEvent {
 public:
-    WSKeyEvent(Type type, int key, char character, u8 modifiers)
+    WSKeyEvent(Type type, int key, char character, bool just_pressed, bool just_released, u8 modifiers)
         : WSEvent(type)
         , m_key(key)
+        , m_just_pressed(just_pressed)
+        , m_just_released(just_released)
         , m_character(character)
         , m_modifiers(modifiers)
     {
@@ -781,11 +783,15 @@ public:
     bool logo() const { return m_modifiers & Mod_Logo; }
     u8 modifiers() const { return m_modifiers; }
     char character() const { return m_character; }
+    bool just_pressed() const { return m_just_pressed; }
+    bool just_released() const { return m_just_released; }
 
 private:
     friend class WSEventLoop;
     friend class WSScreen;
     int m_key { 0 };
+    bool m_just_pressed { false };
+    bool m_just_released { false };
     char m_character { 0 };
     u8 m_modifiers { 0 };
 };

--- a/Servers/WindowServer/WSScreen.cpp
+++ b/Servers/WindowServer/WSScreen.cpp
@@ -105,6 +105,6 @@ void WSScreen::on_receive_mouse_data(int dx, int dy, int dz, unsigned buttons)
 void WSScreen::on_receive_keyboard_data(KeyEvent kernel_event)
 {
     m_modifiers = kernel_event.modifiers();
-    auto message = make<WSKeyEvent>(kernel_event.is_press() ? WSEvent::KeyDown : WSEvent::KeyUp, kernel_event.key, kernel_event.character, kernel_event.modifiers());
+    auto message = make<WSKeyEvent>(kernel_event.is_press() ? WSEvent::KeyDown : WSEvent::KeyUp, kernel_event.key, kernel_event.character, kernel_event.just_pressed, kernel_event.just_released, kernel_event.modifiers());
     CEventLoop::current().post_event(WSWindowManager::the(), move(message));
 }

--- a/Servers/WindowServer/WSWindow.cpp
+++ b/Servers/WindowServer/WSWindow.cpp
@@ -203,6 +203,8 @@ void WSWindow::event(CEvent& event)
         server_message.key.character = static_cast<const WSKeyEvent&>(event).character();
         server_message.key.key = static_cast<const WSKeyEvent&>(event).key();
         server_message.key.modifiers = static_cast<const WSKeyEvent&>(event).modifiers();
+        server_message.key.just_pressed = static_cast<const WSKeyEvent&>(event).just_pressed();
+        server_message.key.just_released = static_cast<const WSKeyEvent&>(event).just_released();
         break;
     case WSEvent::KeyUp:
         server_message.type = WSAPI_ServerMessage::Type::KeyUp;


### PR DESCRIPTION
This PR implements Caps Lock key handling. 
To do that I had to know when exactly a key is pressed, not just whether it's pressed at this moment or not, to be able to properly toggle the Caps Lock flag. The `just_pressed` and `just_released` kernel flags are also passed all the way up to `GKeyEvent` so they can be used by userland apps as I reckon they may be useful.
Although, there's an issue with this. The key release IRQ doesn't always go through for some reason so `just_released` flag is not reliable. I'm not sure how to go about fixing this so I'm leaving it for someone else with more experience with this stuff but the Caps Lock feature works just fine.

I will also try to implement Num Lock the same way.  