### PR TITLE
LibC: Add some wchar functions

### DIFF
--- a/Libraries/LibC/Makefile
+++ b/Libraries/LibC/Makefile
@@ -52,7 +52,8 @@ LIBC_OBJS = \
        netdb.o \
        sched.o \
        dlfcn.o \
-       libgen.o
+       libgen.o \
+       wchar.o
 
 ASM_OBJS = setjmp.ao crti.ao crtn.ao
 

--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -385,6 +385,16 @@ size_t mbstowcs(wchar_t*, const char*, size_t)
     ASSERT_NOT_REACHED();
 }
 
+size_t mbtowc(wchar_t*, const char*, size_t)
+{
+    ASSERT_NOT_REACHED();
+}
+
+int wctomb(char*, wchar_t)
+{
+    ASSERT_NOT_REACHED();
+}
+
 template<typename T, T min_value, T max_value>
 static T strtol_impl(const char* nptr, char** endptr, int base)
 {

--- a/Libraries/LibC/stdlib.h
+++ b/Libraries/LibC/stdlib.h
@@ -44,6 +44,8 @@ char* mktemp(char*);
 char* mkdtemp(char*);
 void* bsearch(const void* key, const void* base, size_t nmemb, size_t size, int (*compar)(const void*, const void*));
 size_t mbstowcs(wchar_t*, const char*, size_t);
+size_t mbtowc(wchar_t*, const char*, size_t);
+int wctomb(char*, wchar_t);
 
 #define RAND_MAX 32767
 int rand();

--- a/Libraries/LibC/wchar.cpp
+++ b/Libraries/LibC/wchar.cpp
@@ -1,0 +1,40 @@
+#include <wchar.h>
+
+extern "C" {
+
+size_t wcslen(const wchar_t* str)
+{
+    size_t len = 0;
+    while (*(str++))
+        ++len;
+    return len;
+}
+
+wchar_t* wcscpy(wchar_t* dest, const wchar_t* src)
+{
+    wchar_t* originalDest = dest;
+    while ((*dest++ = *src++) != '\0')
+        ;
+    return originalDest;
+}
+
+int wcscmp(const wchar_t* s1, const wchar_t* s2)
+{
+    while (*s1 == *s2++)
+        if (*s1++ == 0)
+            return 0;
+    return *(const wchar_t*)s1 - *(const wchar_t*)--s2;
+}
+
+wchar_t* wcschr(const wchar_t* str, int c)
+{
+    wchar_t ch = c;
+    for (;; ++str) {
+        if (*str == ch)
+            return const_cast<wchar_t*>(str);
+        if (!*str)
+            return nullptr;
+    }
+}
+
+}

--- a/Libraries/LibC/wchar.h
+++ b/Libraries/LibC/wchar.h
@@ -9,4 +9,9 @@ __BEGIN_DECLS
 #    define WEOF (0xffffffffu)
 #endif
 
+size_t wcslen(const wchar_t*);
+wchar_t* wcscpy(wchar_t*, const wchar_t*);
+int wcscmp(const wchar_t*, const wchar_t*);
+wchar_t* wcschr(const wchar_t*, int);
+
 __END_DECLS


### PR DESCRIPTION
These are basically copy and pasted from the regular string version.
Also add some more multi-byte/wide conversion stub.

libarchive wanted these. There's a lot more, but we can add them
one at a time.