### PR TITLE
Add getrandom syscall and arc4random libc functions

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -225,6 +225,7 @@ public:
     int sys$reboot();
     int sys$set_process_icon(int icon_id);
     int sys$realpath(const char* pathname, char*, size_t);
+    ssize_t sys$getrandom(void*, size_t, unsigned int);
 
     static void initialize();
 

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -313,6 +313,8 @@ static u32 handle(RegisterDump& regs, u32 function, u32 arg1, u32 arg2, u32 arg3
         return current->process().sys$get_process_name((char*)arg1, (int)arg2);
     case Syscall::SC_realpath:
         return current->process().sys$realpath((const char*)arg1, (char*)arg2, (size_t)arg3);
+    case Syscall::SC_getrandom:
+        return current->process().sys$getrandom((void*)arg1, (size_t)arg2, (unsigned int)arg3);
     default:
         kprintf("<%u> int0x82: Unknown function %u requested {%x, %x, %x}\n", current->process().pid(), function, arg1, arg2, arg3);
         return -ENOSYS;

--- a/Kernel/Syscall.h
+++ b/Kernel/Syscall.h
@@ -130,7 +130,8 @@ struct timeval;
     __ENUMERATE_SYSCALL(mprotect)               \
     __ENUMERATE_SYSCALL(realpath)               \
     __ENUMERATE_SYSCALL(get_process_name)       \
-    __ENUMERATE_SYSCALL(fchdir)
+    __ENUMERATE_SYSCALL(fchdir)                 \
+    __ENUMERATE_SYSCALL(getrandom)
 
 namespace Syscall {
 

--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -511,9 +511,6 @@ unsigned long long strtoull(const char* str, char** endptr, int base)
 uint32_t arc4random(void)
 {
     char buf[4];
-    // XXX: RandomDevice does return a uint32_t but the syscall works with
-    // a byte at a time. It could be better optimzied for this use case
-    // while remaining generic.
     syscall(SC_getrandom, buf, 4, 0);
     return *(uint32_t*)buf;
 }

--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -505,3 +505,29 @@ unsigned long long strtoull(const char* str, char** endptr, int base)
     return value;
 }
 
+// Serenity's PRNG is not cryptographically secure. Do not rely on this for
+// any real crypto! These functions (for now) are for compatibility.
+// TODO: In the future, rand can be made determinstic and this not.
+uint32_t arc4random(void)
+{
+    char buf[4];
+    // XXX: RandomDevice does return a uint32_t but the syscall works with
+    // a byte at a time. It could be better optimzied for this use case
+    // while remaining generic.
+    syscall(SC_getrandom, buf, 4, 0);
+    return *(uint32_t*)buf;
+}
+
+void arc4random_buf(void* buffer, size_t buffer_size)
+{
+    // arc4random_buf should never fail, but user supplied buffers could fail.
+    // However, if the user passes a garbage buffer, that's on them.
+    syscall(SC_getrandom, buffer, buffer_size, 0);
+}
+
+uint32_t arc4random_uniform(uint32_t max_bounds)
+{
+    // XXX: Should actually apply special rules for uniformity; avoid what is
+    // called "modulo bias".
+    return arc4random() % max_bounds;
+}

--- a/Libraries/LibC/stdlib.h
+++ b/Libraries/LibC/stdlib.h
@@ -54,6 +54,10 @@ void srand(unsigned seed);
 long int random();
 void srandom(unsigned seed);
 
+uint32_t arc4random(void);
+void arc4random_buf(void*, size_t);
+uint32_t arc4random_uniform(uint32_t);
+
 typedef struct {
     int quot;
     int rem;


### PR DESCRIPTION
These are for compat right now due to the vile-for-production-use (but totally fine for just its current state) PRNG, but could be used for getting good-quality random numbers once Serenity has a nicer PRNG.

The big annoyance to me in the getrandom syscall. Right now, because the buffer can be non-word-sized, it works by treating it as a character array, but it would be nicer if we could just return whole uint32s like what arc4random wants.

I also left a flags argument (so like getrandom in Linux, not like getentropy in OpenBSD) in case we want to extend the interface. We should learn from Linux's mistakes here though.