### PR TITLE
Ports: libarchive

### DIFF
--- a/Ports/libarchive/package.sh
+++ b/Ports/libarchive/package.sh
@@ -1,0 +1,10 @@
+#!/bin/bash ../.port_include.sh
+port=libarchive
+version=3.4.0
+useconfigure=true
+files="https://libarchive.org/downloads/libarchive-3.4.0.tar.gz libarchive-3.4.0.tar.gz"
+patchlevel=1
+
+configure() {
+    run ./"$configscript" --host=i686-pc-serenity $configopts
+}

--- a/Ports/libarchive/patches/fix-autoconf.patch
+++ b/Ports/libarchive/patches/fix-autoconf.patch
@@ -1,0 +1,19 @@
+--- libarchive-3.4.0/build/autoconf/config.sub.orig	2019-10-03 23:14:02.281000072 +0100
++++ libarchive-3.4.0/build/autoconf/config.sub	2019-10-03 23:14:36.896816822 +0100
+@@ -2,7 +2,7 @@
+ # Configuration validation subroutine script.
+ #   Copyright 1992-2019 Free Software Foundation, Inc.
+ 
+-timestamp='2019-05-23'
++timestamp='2019-10-12'
+ 
+ # This file is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by
+@@ -1342,6 +1342,7 @@
+ 	# Each alternative MUST end in a * to match a version number.
+ 	# sysv* is not here because it comes later, after sysvr4.
+ 	gnu* | bsd* | mach* | minix* | genix* | ultrix* | irix* \
++	     | serenity* \
+ 	     | *vms* | esix* | aix* | cnk* | sunos | sunos[34]*\
+ 	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* 
+ 	     | sym* | kopensolaris* | plan9* \

--- a/Ports/libarchive/patches/path-max-workaround.patch
+++ b/Ports/libarchive/patches/path-max-workaround.patch
@@ -1,0 +1,11 @@
+--- libarchive-3.4.0/libarchive/archive_read_disk_posix.c	2019-06-12 18:05:16.000000000 -0300
++++ libarchive-3.4.0-new/libarchive/archive_read_disk_posix.c	2019-10-12 22:30:12.774683968 -0300
+@@ -1984,7 +1984,7 @@
+ #  else
+ 		/* No way to get a trusted value of maximum filename
+ 		 * length. */
+-		t->current_filesystem->name_max = PATH_MAX;
++		t->current_filesystem->name_max = 4096; /* Toolchain workaround */
+ #  endif /* NAME_MAX */
+ #  if defined(_PC_NAME_MAX)
+ 	else


### PR DESCRIPTION
Provides a cpio and tar implementation. Unfortunately doesn't work
yet; requires a working mbtowc implementation.