### PR TITLE
LibAudio: Fixed stuttery playback of audio

### DIFF
--- a/Libraries/LibAudio/ABuffer.h
+++ b/Libraries/LibAudio/ABuffer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <AK/RefCounted.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
@@ -12,19 +11,22 @@ struct ASample {
     ASample()
         : left(0)
         , right(0)
-    {}
+    {
+    }
 
     // For mono
     ASample(float left)
         : left(left)
         , right(left)
-    {}
+    {
+    }
 
     // For stereo
     ASample(float left, float right)
         : left(left)
         , right(right)
-    {}
+    {
+    }
 
     void clip()
     {
@@ -57,38 +59,57 @@ struct ASample {
     float right;
 };
 
+// Small helper to resample from one playback rate to another
+// This isn't really "smart", in that we just insert (or drop) samples.
+// Should do better...
+class AResampleHelper {
+public:
+    AResampleHelper(float source, float target);
+
+    void process_sample(float sample_l, float sample_r);
+    bool read_sample(float& next_l, float& next_r);
+
+private:
+    const float m_ratio;
+    float m_current_ratio { 0 };
+    float m_last_sample_l { 0 };
+    float m_last_sample_r { 0 };
+};
+
 // A buffer of audio samples, normalized to 44100hz.
 class ABuffer : public RefCounted<ABuffer> {
 public:
-    static RefPtr<ABuffer> from_pcm_data(ByteBuffer& data, int num_channels, int bits_per_sample, int source_rate);
+    static RefPtr<ABuffer> from_pcm_data(ByteBuffer& data, AResampleHelper& resampler, int num_channels, int bits_per_sample);
     static NonnullRefPtr<ABuffer> create_with_samples(Vector<ASample>&& samples)
     {
         return adopt(*new ABuffer(move(samples)));
     }
-    static NonnullRefPtr<ABuffer> create_with_shared_buffer(NonnullRefPtr<SharedBuffer>&& buffer)
+    static NonnullRefPtr<ABuffer> create_with_shared_buffer(NonnullRefPtr<SharedBuffer>&& buffer, int sample_count)
     {
-        return adopt(*new ABuffer(move(buffer)));
+        return adopt(*new ABuffer(move(buffer), sample_count));
     }
 
     const ASample* samples() const { return (const ASample*)data(); }
-    int sample_count() const { return m_buffer->size() / (int)sizeof(ASample); }
+    int sample_count() const { return m_sample_count; }
     const void* data() const { return m_buffer->data(); }
-    int size_in_bytes() const { return m_buffer->size(); }
+    int size_in_bytes() const { return m_sample_count * (int)sizeof(ASample); }
     int shared_buffer_id() const { return m_buffer->shared_buffer_id(); }
     SharedBuffer& shared_buffer() { return *m_buffer; }
 
 private:
     explicit ABuffer(Vector<ASample>&& samples)
-        : m_buffer(*SharedBuffer::create_with_size(samples.size() * sizeof(ASample)))
+        : m_buffer(*SharedBuffer::create_with_size(samples.size() * sizeof(ASample))),
+        m_sample_count(samples.size())
     {
         memcpy(m_buffer->data(), samples.data(), samples.size() * sizeof(ASample));
     }
 
-    explicit ABuffer(NonnullRefPtr<SharedBuffer>&& buffer)
-        : m_buffer(move(buffer))
+    explicit ABuffer(NonnullRefPtr<SharedBuffer>&& buffer, int sample_count)
+        : m_buffer(move(buffer)),
+        m_sample_count(sample_count)
     {
     }
 
     NonnullRefPtr<SharedBuffer> m_buffer;
-    int m_sample_count { 0 };
+    const int m_sample_count;
 };

--- a/Libraries/LibAudio/AClientConnection.cpp
+++ b/Libraries/LibAudio/AClientConnection.cpp
@@ -18,7 +18,7 @@ void AClientConnection::enqueue(const ABuffer& buffer)
 {
     for (;;) {
         const_cast<ABuffer&>(buffer).shared_buffer().share_with(server_pid());
-        auto response = send_sync<AudioServer::EnqueueBuffer>(buffer.shared_buffer_id());
+        auto response = send_sync<AudioServer::EnqueueBuffer>(buffer.shared_buffer_id(), buffer.sample_count());
         if (response->success())
             break;
         sleep(1);
@@ -28,7 +28,7 @@ void AClientConnection::enqueue(const ABuffer& buffer)
 bool AClientConnection::try_enqueue(const ABuffer& buffer)
 {
     const_cast<ABuffer&>(buffer).shared_buffer().share_with(server_pid());
-    auto response = send_sync<AudioServer::EnqueueBuffer>(buffer.shared_buffer_id());
+    auto response = send_sync<AudioServer::EnqueueBuffer>(buffer.shared_buffer_id(), buffer.sample_count());
     return response->success();
 }
 

--- a/Libraries/LibAudio/AWavLoader.h
+++ b/Libraries/LibAudio/AWavLoader.h
@@ -4,6 +4,7 @@
 #include <AK/RefPtr.h>
 #include <AK/StringView.h>
 #include <LibCore/CFile.h>
+#include <LibAudio/ABuffer.h>
 
 class ABuffer;
 
@@ -31,6 +32,7 @@ private:
     bool parse_header();
     RefPtr<CFile> m_file;
     String m_error_string;
+    OwnPtr<AResampleHelper> m_resampler;
 
     u32 m_sample_rate { 0 };
     u16 m_num_channels { 0 };

--- a/Servers/AudioServer/ASClientConnection.cpp
+++ b/Servers/AudioServer/ASClientConnection.cpp
@@ -68,6 +68,6 @@ OwnPtr<AudioServer::EnqueueBufferResponse> ASClientConnection::handle(const Audi
     if (m_queue->is_full())
         return make<AudioServer::EnqueueBufferResponse>(false);
 
-    m_queue->enqueue(ABuffer::create_with_shared_buffer(*shared_buffer));
+    m_queue->enqueue(ABuffer::create_with_shared_buffer(*shared_buffer, message.sample_count()));
     return make<AudioServer::EnqueueBufferResponse>(true);
 }

--- a/Servers/AudioServer/AudioServer.ipc
+++ b/Servers/AudioServer/AudioServer.ipc
@@ -8,5 +8,5 @@ endpoint AudioServer
     SetMainMixVolume(i32 volume) => ()
 
     // Buffer playback
-    EnqueueBuffer(i32 buffer_id) => (bool success)
+    EnqueueBuffer(i32 buffer_id, int sample_count) => (bool success)
 }


### PR DESCRIPTION
The commit message pretty much says it all. Playing audio sounds better now, especially when upsampling/downsampling to 44100 Hz. Regarding the changes to the resample helper, you _technically_ do not need to reuse the same helper for each chunk of data(you really can't spot the difference when playing music), but when playing a pure sine there is a noticeable change to hear, and i thought it would be nicer to just change it.