### PR TITLE
aplay: Fixed incomplete playback of files

### DIFF
--- a/Libraries/LibAudio/AClientConnection.cpp
+++ b/Libraries/LibAudio/AClientConnection.cpp
@@ -41,3 +41,8 @@ void AClientConnection::set_main_mix_volume(int volume)
 {
     send_sync<AudioServer::SetMainMixVolume>(volume);
 }
+
+int AClientConnection::get_remaining_samples()
+{
+    return send_sync<AudioServer::GetRemainingSamples>()->remaining_samples();
+}

--- a/Libraries/LibAudio/AClientConnection.h
+++ b/Libraries/LibAudio/AClientConnection.h
@@ -16,4 +16,6 @@ public:
 
     int get_main_mix_volume();
     void set_main_mix_volume(int);
+
+    int get_remaining_samples();
 };

--- a/Servers/AudioServer/ASClientConnection.cpp
+++ b/Servers/AudioServer/ASClientConnection.cpp
@@ -71,3 +71,12 @@ OwnPtr<AudioServer::EnqueueBufferResponse> ASClientConnection::handle(const Audi
     m_queue->enqueue(ABuffer::create_with_shared_buffer(*shared_buffer, message.sample_count()));
     return make<AudioServer::EnqueueBufferResponse>(true);
 }
+
+OwnPtr<AudioServer::GetRemainingSamplesResponse> ASClientConnection::handle(const AudioServer::GetRemainingSamples&)
+{
+    int remaining = 0;
+    if(m_queue)
+        remaining = m_queue->get_remaining_samples();
+
+    return make<AudioServer::GetRemainingSamplesResponse>(remaining);
+}

--- a/Servers/AudioServer/ASClientConnection.h
+++ b/Servers/AudioServer/ASClientConnection.h
@@ -22,6 +22,7 @@ private:
     virtual OwnPtr<AudioServer::GetMainMixVolumeResponse> handle(const AudioServer::GetMainMixVolume&) override;
     virtual OwnPtr<AudioServer::SetMainMixVolumeResponse> handle(const AudioServer::SetMainMixVolume&) override;
     virtual OwnPtr<AudioServer::EnqueueBufferResponse> handle(const AudioServer::EnqueueBuffer&) override;
+    virtual OwnPtr<AudioServer::GetRemainingSamplesResponse> handle(const AudioServer::GetRemainingSamples&) override;
 
     ASMixer& m_mixer;
     RefPtr<ASBufferQueue> m_queue;

--- a/Servers/AudioServer/ASMixer.cpp
+++ b/Servers/AudioServer/ASMixer.cpp
@@ -100,5 +100,6 @@ ASBufferQueue::ASBufferQueue(ASClientConnection& client)
 
 void ASBufferQueue::enqueue(NonnullRefPtr<ABuffer>&& buffer)
 {
+    m_remaining_samples += buffer->sample_count();
     m_queue.enqueue(move(buffer));
 }

--- a/Servers/AudioServer/ASMixer.h
+++ b/Servers/AudioServer/ASMixer.h
@@ -24,9 +24,13 @@ public:
     {
         while (!m_current && !m_queue.is_empty())
             m_current = m_queue.dequeue();
+
         if (!m_current)
             return false;
+
         sample = m_current->samples()[m_position++];
+        m_remaining_samples--;
+
         if (m_position >= m_current->sample_count()) {
             m_current = nullptr;
             m_position = 0;
@@ -35,16 +39,20 @@ public:
     }
 
     ASClientConnection* client() { return m_client.ptr(); }
+
     void clear()
     {
         m_queue.clear();
         m_position = 0;
     }
 
+    int get_remaining_samples() const { return m_remaining_samples; }
+
 private:
     RefPtr<ABuffer> m_current;
     Queue<NonnullRefPtr<ABuffer>> m_queue;
     int m_position { 0 };
+    int m_remaining_samples { 0 };
     WeakPtr<ASClientConnection> m_client;
 };
 

--- a/Servers/AudioServer/ASMixer.h
+++ b/Servers/AudioServer/ASMixer.h
@@ -45,7 +45,6 @@ private:
     RefPtr<ABuffer> m_current;
     Queue<NonnullRefPtr<ABuffer>> m_queue;
     int m_position { 0 };
-    int m_playing_queued_buffer_id { -1 };
     WeakPtr<ASClientConnection> m_client;
 };
 

--- a/Servers/AudioServer/AudioServer.ipc
+++ b/Servers/AudioServer/AudioServer.ipc
@@ -9,4 +9,6 @@ endpoint AudioServer
 
     // Buffer playback
     EnqueueBuffer(i32 buffer_id, int sample_count) => (bool success)
+
+    GetRemainingSamples() => (int remaining_samples)
 }

--- a/Userland/aplay.cpp
+++ b/Userland/aplay.cpp
@@ -24,12 +24,16 @@ int main(int argc, char** argv)
     printf("\033[34;1mProgress\033[0m: \033[s");
     for (;;) {
         auto samples = loader.get_more_samples();
-        if (!samples)
+        if (samples) {
+            printf("\033[u");
+            printf("%d/%d", loader.loaded_samples(), loader.total_samples());
+            fflush(stdout);
+            audio_client->enqueue(*samples);
+        } else if (audio_client->get_remaining_samples()) {
+            sleep(1);
+        } else {
             break;
-        printf("\033[u");
-        printf("%d/%d", loader.loaded_samples(), loader.total_samples());
-        fflush(stdout);
-        audio_client->enqueue(*samples);
+        }
     }
     printf("\n");
     return 0;


### PR DESCRIPTION
When playing files using aplay, the playback was stopped to soon.
This was because there was no way of checking if the ASBufferQueue was still full or not, and we simply quit out of the program as soon as we successfully enqueued the last buffer.
