### PR TITLE
TTY: add canonical mode and echoing

### DIFF
--- a/AK/CircularDeque.h
+++ b/AK/CircularDeque.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/CircularQueue.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+template<typename T, int Capacity>
+class CircularDeque : public CircularQueue<T, Capacity> {
+
+public:
+    T dequeue_end()
+    {
+        ASSERT(!this->is_empty());
+        T value = this->m_elements[(this->m_head + this->m_size - 1) % Capacity];
+        this->m_size--;
+        return value;
+    }
+};
+
+}
+
+using AK::CircularDeque;

--- a/AK/CircularQueue.h
+++ b/AK/CircularQueue.h
@@ -77,7 +77,7 @@ public:
 
     int head_index() const { return m_head; }
 
-private:
+protected:
     friend class ConstIterator;
     T m_elements[Capacity];
     int m_size { 0 };

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -30,6 +30,13 @@ StringView SlavePTY::tty_name() const
     return m_tty_name;
 }
 
+void SlavePTY::echo(u8 ch)
+{
+    if (should_echo_input()) {
+        m_master->on_slave_write(&ch, 1);
+    }
+}
+
 void SlavePTY::on_master_write(const u8* buffer, ssize_t size)
 {
     for (ssize_t i = 0; i < size; ++i)

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -16,6 +16,7 @@ private:
     // ^TTY
     virtual StringView tty_name() const override;
     virtual ssize_t on_tty_write(const u8*, ssize_t) override;
+    virtual void echo(u8) override;
 
     // ^CharacterDevice
     virtual bool can_read(FileDescription&) const override;

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "DoubleBuffer.h"
-#include <AK/CircularQueue.h>
+#include <AK/CircularDeque.h>
 #include <Kernel/Devices/CharacterDevice.h>
 #include <Kernel/UnixTypes.h>
 
@@ -40,14 +40,28 @@ protected:
 
     TTY(unsigned major, unsigned minor);
     void emit(u8);
+    virtual void echo(u8) = 0;
+
+    bool can_do_backspace() const;
+    void do_backspace();
+    void erase_word();
+    void kill_line();
+
+    bool is_eol(u8) const;
+    bool is_eof(u8) const;
+    bool is_kill(u8) const;
+    bool is_erase(u8) const;
+    bool is_werase(u8) const;
 
     void generate_signal(int signal);
+
+    int m_available_lines { 0 };
 
 private:
     // ^CharacterDevice
     virtual bool is_tty() const final override { return true; }
 
-    CircularQueue<u8, 1024> m_input_buffer;
+    CircularDeque<u8, 1024> m_input_buffer;
     pid_t m_pgid { 0 };
     termios m_termios;
     unsigned short m_rows { 0 };

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -33,6 +33,7 @@ private:
     // ^TTY
     virtual ssize_t on_tty_write(const u8*, ssize_t) override;
     virtual StringView tty_name() const override;
+    virtual void echo(u8) override { return; }
 
     // ^CharacterDevice
     virtual const char* class_name() const override { return "VirtualConsole"; }

--- a/Shell/GlobalState.h
+++ b/Shell/GlobalState.h
@@ -13,6 +13,7 @@ struct GlobalState {
     pid_t sid;
     uid_t uid;
     struct termios termios;
+    struct termios default_termios;
     bool was_interrupted { false };
     bool was_resized { false };
     int last_return_code { 0 };


### PR DESCRIPTION
This implements canonical editing and basic echoing in the TTY driver.
This is helpful for programs like cat or lua, as it allows the user to view/edit their input.