### PR TITLE
Kernel: Fixed fdc read/write problem

### DIFF
--- a/Kernel/Devices/FloppyDiskDevice.h
+++ b/Kernel/Devices/FloppyDiskDevice.h
@@ -101,7 +101,7 @@ class FloppyDiskDevice final : public IRQHandler
     AK_MAKE_ETERNAL
 
     static constexpr u8 SECTORS_PER_CYLINDER = 18;
-    static constexpr u8 CCYLINDERS_PER_HEAD = 80;
+    static constexpr u8 CYLINDERS_PER_HEAD = 80;
     static constexpr u16 BYTES_PER_SECTOR = 512;
 
 public:
@@ -158,9 +158,9 @@ private:
     virtual const char* class_name() const override;
 
     // Helper functions
-    inline u16 lba2cylinder(u16 lba) const { return lba / (2 * SECTORS_PER_CYLINDER); } // Convert an LBA into a cylinder value
-    inline u16 lba2head(u16 lba) const { return ((lba / SECTORS_PER_CYLINDER) % 2); }   // Convert an LBA into a head value
-    inline u16 lba2sector(u16 lba) const { return ((lba % SECTORS_PER_CYLINDER) + 1); } // Convert an LBA into a sector value
+    inline u16 lba2head(u16 lba) const { return (lba % (SECTORS_PER_CYLINDER * 2)) / SECTORS_PER_CYLINDER; } // Convert an LBA into a head value
+    inline u16 lba2cylinder(u16 lba) const { return lba / (2 * SECTORS_PER_CYLINDER); }                      // Convert an LBA into a cylinder value
+    inline u16 lba2sector(u16 lba) const { return ((lba % SECTORS_PER_CYLINDER) + 1); }                      // Convert an LBA into a sector value
 
     void initialize();
     bool read_sectors_with_dma(u16, u16, u8*);


### PR DESCRIPTION
It seems ~the compiler might have been doing something strange to
the calls to `send_byte()`~ that operator precedence eludes me. Whenever the value of `head` was 1,
`is_slave()` would also be 1 due to abuse of the ternary operator
This resulted in the controller failing the read/write.

I've also added a seek to the top of the read/write code, which seems
to have fixed an issue with Linux not detecting the disk images after
they have been unmounted from Serenity. This isn't specified in the
datasheet, but a few other drivers have it so we should too :^)