### PR TITLE
Kernel: Move E2BIG calculation from Thread to Process

### DIFF
--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -40,9 +40,6 @@ HashTable<Thread*>& thread_table()
     return *table;
 }
 
-static const u32 default_kernel_stack_size = 65536;
-static const u32 default_userspace_stack_size = 65536;
-
 Thread::Thread(Process& process)
     : m_process(process)
     , m_tid(process.m_next_tid++)
@@ -514,17 +511,6 @@ void Thread::make_userspace_stack_for_main_thread(Vector<String> arguments, Vect
     char** argv = (char**)stack_base;
     char** env = argv + arguments.size() + 1;
     char* bufptr = stack_base + (sizeof(char*) * (arguments.size() + 1)) + (sizeof(char*) * (environment.size() + 1));
-
-    size_t total_blob_size = 0;
-    for (auto& a : arguments)
-        total_blob_size += a.length() + 1;
-    for (auto& e : environment)
-        total_blob_size += e.length() + 1;
-
-    size_t total_meta_size = sizeof(char*) * (arguments.size() + 1) + sizeof(char*) * (environment.size() + 1);
-
-    // FIXME: It would be better if this didn't make us panic.
-    ASSERT((total_blob_size + total_meta_size) < default_userspace_stack_size);
 
     for (int i = 0; i < arguments.size(); ++i) {
         argv[i] = bufptr;

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <AK/String.h>
 #include <AK/Function.h>
 #include <AK/IntrusiveList.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/KResult.h>
@@ -311,6 +311,9 @@ public:
     {
         return state == Thread::State::Running || state == Thread::State::Runnable;
     }
+
+    static constexpr u32 default_kernel_stack_size = 65536;
+    static constexpr u32 default_userspace_stack_size = 65536;
 
 private:
     IntrusiveListNode m_runnable_list_node;

--- a/Libraries/LibC/limits.h
+++ b/Libraries/LibC/limits.h
@@ -6,7 +6,7 @@
 
 #define PATH_MAX 4096
 #if !defined MAXPATHLEN && defined PATH_MAX
-# define MAXPATHLEN  PATH_MAX
+#    define MAXPATHLEN PATH_MAX
 #endif
 
 #define INT_MAX INT32_MAX
@@ -30,3 +30,5 @@
 #define CHAR_MAX SCHAR_MAX
 
 #define MB_LEN_MAX 16
+
+#define ARG_MAX 65536


### PR DESCRIPTION
Thread::make_userspace_stack_for_main_thread is only ever called from
Process::do_exec, after all the fun ELF loading and TSS setup has
occured.

The calculations in there that check if the combined argv + envp
size will exceed the default stack size are not used in the rest of
the stack setup. So, it should be safe to move this to the beginning
of do_exec and bail early with -E2BIG, just like the man pages say.

Additionally, advertise this limit in limits.h to be a good POSIX.1
citizen. :)