### PR TITLE
Hex editor enhancements

### DIFF
--- a/Applications/HexEditor/HexEditor.cpp
+++ b/Applications/HexEditor/HexEditor.cpp
@@ -93,7 +93,7 @@ bool HexEditor::copy_selected_hex_to_clipboard()
         return false;
 
     StringBuilder output_string_builder;
-    for (int i = m_selection_start; i < m_selection_end; i++) {
+    for (int i = m_selection_start; i <= m_selection_end; i++) {
         output_string_builder.appendf("%02X ", m_buffer.data()[i]);
     }
 
@@ -107,7 +107,7 @@ bool HexEditor::copy_selected_text_to_clipboard()
         return false;
 
     StringBuilder output_string_builder;
-    for (int i = m_selection_start; i < m_selection_end; i++) {
+    for (int i = m_selection_start; i <= m_selection_end; i++) {
         output_string_builder.appendf("%c", isprint(m_buffer.data()[i]) ? m_buffer[i] : '.');
     }
 

--- a/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Applications/HexEditor/HexEditorWidget.cpp
@@ -102,7 +102,7 @@ HexEditorWidget::HexEditorWidget()
         }));
     }
 
-    m_goto_action = GAction::create("Go To...", GraphicsBitmap::load_from_file("/res/icons/16x16/go-forward.png"), [this](const GAction&) {
+    m_goto_decimal_offset_action = GAction::create("Go To Offset (Decimal)...", GraphicsBitmap::load_from_file("/res/icons/16x16/go-forward.png"), [this](const GAction&) {
         auto input_box = GInputBox::construct("Enter offset:", "Go To", this);
         if (input_box->exec() == GInputBox::ExecOK && !input_box->text_value().is_empty()) {
             auto valid = false;
@@ -113,8 +113,17 @@ HexEditorWidget::HexEditorWidget()
         }
     });
 
+    m_goto_hex_offset_action = GAction::create("Go To Offset (Hex)...", GraphicsBitmap::load_from_file("/res/icons/16x16/go-forward.png"), [this](const GAction&) {
+        auto input_box = GInputBox::construct("Enter offset:", "Go To", this);
+        if (input_box->exec() == GInputBox::ExecOK && !input_box->text_value().is_empty()) {
+            auto new_offset = strtol(input_box->text_value().characters(), nullptr, 16);
+            m_editor->set_position(new_offset);
+        }
+    });
+
     auto edit_menu = make<GMenu>("Edit");
-    edit_menu->add_action(*m_goto_action);
+    edit_menu->add_action(*m_goto_decimal_offset_action);
+    edit_menu->add_action(*m_goto_hex_offset_action);
     edit_menu->add_separator();
     edit_menu->add_action(GAction::create("Copy Hex", [&](const GAction&) {
         m_editor->copy_selected_hex_to_clipboard();

--- a/Applications/HexEditor/HexEditorWidget.h
+++ b/Applications/HexEditor/HexEditorWidget.h
@@ -31,7 +31,8 @@ private:
     RefPtr<GAction> m_open_action;
     RefPtr<GAction> m_save_action;
     RefPtr<GAction> m_save_as_action;
-    RefPtr<GAction> m_goto_action;
+    RefPtr<GAction> m_goto_decimal_offset_action;
+    RefPtr<GAction> m_goto_hex_offset_action;
 
     RefPtr<GStatusBar> m_statusbar;
 


### PR DESCRIPTION
A small assortment of upgrades and fixes to HexEditor.

- Added the ability to select text and hex in reverse.
- When copying as hex or text we missed the last byte.
- Added the ability to navigate to a specified hex offset.