### PR TITLE
SystemMonitor+ProcFS: fix panic on clicking dead process

### DIFF
--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -997,10 +997,14 @@ ssize_t ProcFSInode::read_bytes(off_t offset, ssize_t count, u8* buffer, FileDes
     }
 
     auto& data = generated_data;
-    ssize_t nread = min(static_cast<off_t>(data.value().size() - offset), static_cast<off_t>(count));
-    memcpy(buffer, data.value().data() + offset, nread);
-    if (nread == 0 && description && description->generator_cache())
-        description->generator_cache().clear();
+    ssize_t nread = 0;
+    if (data.has_value()) {
+        nread = min(static_cast<off_t>(data.value().size() - offset), static_cast<off_t>(count));
+        memcpy(buffer, data.value().data() + offset, nread);
+        if (nread == 0 && description && description->generator_cache())
+            description->generator_cache().clear();
+    }
+
     return nread;
 }
 


### PR DESCRIPTION
This tidies up a few things in ProcFS which means that SystemMonitor no longer crashes
when inspecting a dead process.

This fixes #680 .