### PR TITLE
Stop stdio string printing overrunning buffer with null termination

### DIFF
--- a/Libraries/LibC/stdio.cpp
+++ b/Libraries/LibC/stdio.cpp
@@ -395,7 +395,6 @@ int sprintf(char* buffer, const char* fmt, ...)
     va_list ap;
     va_start(ap, fmt);
     int ret = vsprintf(buffer, fmt, ap);
-    buffer[ret] = '\0';
     va_end(ap);
     return ret;
 }
@@ -413,7 +412,9 @@ int vsnprintf(char* buffer, size_t size, const char* fmt, va_list ap)
 {
     __vsnprintf_space_remaining = size;
     int ret = printf_internal(sized_buffer_putch, buffer, fmt, ap);
-    buffer[ret] = '\0';
+    if (__vsnprintf_space_remaining) {
+	    buffer[ret] = '\0';
+    }
     return ret;
 }
 
@@ -422,7 +423,6 @@ int snprintf(char* buffer, size_t size, const char* fmt, ...)
     va_list ap;
     va_start(ap, fmt);
     int ret = vsnprintf(buffer, size, fmt, ap);
-    buffer[ret] = '\0';
     va_end(ap);
     return ret;
 }


### PR DESCRIPTION
When using the bounded string operations (e.g. snprinf) the null
termination was always being written even if there was no space for
it (or indeed any valid buffer at all)

This overwriting caused segmentation faults and memory corruption

an example program that demonstrated the issue
```
#include <stdlib.h>
#include <stdio.h>

int main(int argc, char **argv)
{
	char *opbuf = NULL;
	int oplen = 0;
	const char *rstr = "Some random string";
	int num = 31415926;

	oplen = snprintf(opbuf, oplen, "%s %d %d %s", rstr, num, argc, argv[0]);

	oplen++;/* allow for null */
	opbuf = (char *)malloc(oplen);

	snprintf(opbuf, oplen, "%s %d %d %s", rstr, num, argc, argv[0]);

	printf("%d\n%s\n", oplen, opbuf);

	free(opbuf);
}
```