### PR TITLE
Kernel: Return error when attempting to read from a directory.

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -1128,6 +1128,8 @@ ssize_t Process::sys$read(int fd, u8* buffer, ssize_t size)
     auto* description = file_description(fd);
     if (!description)
         return -EBADF;
+    if (description->is_directory())
+        return -EISDIR;
     if (description->is_blocking()) {
         if (!description->can_read()) {
             if (current->block<Thread::ReadBlocker>(*description) == Thread::BlockResult::InterruptedBySignal)


### PR DESCRIPTION
We now return EISDIR whenever a program attempts to call sys$read
on a directory. Previously, attempting to read a directory could
either return junk data or, in the case of /proc/, cause a kernel
panic.