### PR TITLE
LibCore+LibGUI: Premature quit bug fix

### DIFF
--- a/Libraries/LibCore/CEventLoop.cpp
+++ b/Libraries/LibCore/CEventLoop.cpp
@@ -186,6 +186,13 @@ void CEventLoop::quit(int code)
     m_exit_code = code;
 }
 
+void CEventLoop::unquit()
+{
+    dbg() << "CEventLoop::unquit()";
+    m_exit_requested = false;
+    m_exit_code = 0;
+}
+
 struct CEventLoopPusher {
 public:
     CEventLoopPusher(CEventLoop& event_loop)

--- a/Libraries/LibCore/CEventLoop.h
+++ b/Libraries/LibCore/CEventLoop.h
@@ -45,6 +45,7 @@ public:
     static void unregister_notifier(Badge<CNotifier>, CNotifier&);
 
     void quit(int);
+    void unquit();
 
     void take_pending_events_from(CEventLoop& other)
     {

--- a/Libraries/LibGUI/GApplication.cpp
+++ b/Libraries/LibGUI/GApplication.cpp
@@ -119,6 +119,12 @@ void GApplication::hide_tooltip()
     }
 }
 
+void GApplication::did_create_window(Badge<GWindow>)
+{
+    if (m_event_loop->was_exit_requested())
+        m_event_loop->unquit();
+}
+
 void GApplication::did_delete_last_window(Badge<GWindow>)
 {
     if (m_quit_when_last_window_deleted)

--- a/Libraries/LibGUI/GApplication.h
+++ b/Libraries/LibGUI/GApplication.h
@@ -33,6 +33,7 @@ public:
     bool quit_when_last_window_deleted() const { return m_quit_when_last_window_deleted; }
     void set_quit_when_last_window_deleted(bool b) { m_quit_when_last_window_deleted = b; }
 
+    void did_create_window(Badge<GWindow>);
     void did_delete_last_window(Badge<GWindow>);
 
     const String& invoked_as() const { return m_invoked_as; }

--- a/Libraries/LibGUI/GWindow.cpp
+++ b/Libraries/LibGUI/GWindow.cpp
@@ -84,6 +84,7 @@ void GWindow::show()
     apply_icon();
 
     reified_windows.set(m_window_id, this);
+    GApplication::the().did_create_window({});
     update();
 }
 


### PR DESCRIPTION
-  LibCore: Added unquit() method to CEventLoop. 
-  LibGUI: Added window creation callback to GApplication/GWindow 