### PR TITLE
wc.cpp: Rewritten with added features

### DIFF
--- a/Userland/wc.cpp
+++ b/Userland/wc.cpp
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
     do {
         if (files.size() > 0 && (file_pointer = fopen(files[iteration].characters(), "r"))==NULL) {
             fprintf(stderr, "wc: unable to open %s\n", files[iteration].characters());
-	    file_count--;
+	    existing_file_count--;
             continue;
         }
         word_flags.line=true;


### PR DESCRIPTION
This time I think I got it right.
Now gets a true byte count by using the file size. This means that the byte count of stdin will be 0.
Lines are counted correctly. When giving a single lined string without a trailing newline, the line count should not go up (ex. printf "test" | wc -l should output 0)
Doesn't hang up when using two or more switch options in a row (it would hang if I did wc -lw test.frm). While mine works with multiple args like that, they don't switch anything, you have to do wc -l -w etc but I think that's because of CArgsParser.
It can now take standard input without needing a "-".
When encountering a file that doesn't exist, it doesn't halt the program. It prints the counts for each file that does, and prints an error message to stderr for each file that doesn't. 
Has slight buffering between counts to be closer to GNU and BSD wc's.