### PR TITLE
WindowServer: Fixed Menubar resize issue

### DIFF
--- a/Servers/WindowServer/WSMenuManager.cpp
+++ b/Servers/WindowServer/WSMenuManager.cpp
@@ -9,6 +9,7 @@
 WSMenuManager::WSMenuManager()
 {
     m_username = getlogin();
+    m_needs_window_resize = false;
 
     m_timer = CTimer::construct(300, [this] {
         static time_t last_update_time;
@@ -44,6 +45,11 @@ void WSMenuManager::draw()
 {
     auto& wm = WSWindowManager::the();
     auto menubar_rect = wm.menubar_rect();
+
+    if (m_needs_window_resize) {
+        m_window->set_rect(menubar_rect);
+        m_needs_window_resize = false;
+    }
 
     Painter painter(*window().backing_store());
 
@@ -134,8 +140,8 @@ void WSMenuManager::handle_menu_mouse_event(WSMenu& menu, const WSMouseEvent& ev
 {
     auto& wm = WSWindowManager::the();
     bool is_hover_with_any_menu_open = event.type() == WSMouseEvent::MouseMove
-                                       && !m_open_menu_stack.is_empty()
-                                       && (m_open_menu_stack.first()->menubar() || m_open_menu_stack.first() == wm.system_menu());
+        && !m_open_menu_stack.is_empty()
+        && (m_open_menu_stack.first()->menubar() || m_open_menu_stack.first() == wm.system_menu());
     bool is_mousedown_with_left_button = event.type() == WSMouseEvent::MouseDown && event.button() == MouseButton::Left;
     bool should_open_menu = &menu != wm.current_menu() && (is_hover_with_any_menu_open || is_mousedown_with_left_button);
 
@@ -156,4 +162,9 @@ void WSMenuManager::handle_menu_mouse_event(WSMenu& menu, const WSMouseEvent& ev
         wm.close_current_menu();
         return;
     }
+}
+
+void WSMenuManager::set_needs_window_resize()
+{
+    m_needs_window_resize = true;
 }

--- a/Servers/WindowServer/WSMenuManager.h
+++ b/Servers/WindowServer/WSMenuManager.h
@@ -21,6 +21,8 @@ public:
 
     Vector<WeakPtr<WSMenu>>& open_menu_stack() { return m_open_menu_stack; }
 
+    void set_needs_window_resize();
+
 private:
     WSWindow& window() { return *m_window; }
     const WSWindow& window() const { return *m_window; }
@@ -36,4 +38,6 @@ private:
     RefPtr<CTimer> m_timer;
 
     Vector<WeakPtr<WSMenu>> m_open_menu_stack;
+
+    bool m_needs_window_resize;
 };

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -196,6 +196,7 @@ const Font& WSWindowManager::app_menu_font() const
 void WSWindowManager::set_resolution(int width, int height)
 {
     WSCompositor::the().set_resolution(width, height);
+    m_menu_manager.set_needs_window_resize();
     WSClientConnection::for_each_client([&](WSClientConnection& client) {
         client.notify_about_new_screen_rect(WSScreen::the().rect());
     });
@@ -421,7 +422,7 @@ void WSWindowManager::start_window_drag(WSWindow& window, const WSMouseEvent& ev
     if (window.is_maximized()) {
         auto width_before_resize = window.width();
         window.set_maximized(false);
-        window.move_to(m_drag_origin.x() - (window.width() * ((float) m_drag_origin.x() / width_before_resize)), m_drag_origin.y());
+        window.move_to(m_drag_origin.x() - (window.width() * ((float)m_drag_origin.x() / width_before_resize)), m_drag_origin.y());
     }
     m_drag_window_origin = window.position();
     invalidate(window);


### PR DESCRIPTION
The menubar bar wasn't being resized correctly, as the underlying Window
was never being resized when `DisplayProperties` was chaning the
resolution while the system was running. `m_window` now gets the
correct window size when it's been updated, so a reboot isn't required.