### PR TITLE
TTY: fix virtual console echoing

### DIFF
--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -545,6 +545,13 @@ StringView VirtualConsole::tty_name() const
     return m_tty_name;
 }
 
+void VirtualConsole::echo(u8 ch)
+{
+    if (should_echo_input()) {
+        on_tty_write(&ch, 1);
+    }
+}
+
 void VirtualConsole::set_vga_start_row(u16 row)
 {
     m_vga_start_row = row;

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -33,7 +33,7 @@ private:
     // ^TTY
     virtual ssize_t on_tty_write(const u8*, ssize_t) override;
     virtual StringView tty_name() const override;
-    virtual void echo(u8) override { return; }
+    virtual void echo(u8) override;
 
     // ^CharacterDevice
     virtual const char* class_name() const override { return "VirtualConsole"; }

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -634,7 +634,6 @@ static int run_command(const String& cmd)
 
     struct termios trm;
     tcgetattr(0, &trm);
-    tcsetattr(0, TCSANOW, &g.default_termios);
 
     struct SpawnedProcess {
         String name;
@@ -730,6 +729,7 @@ static int run_command(const String& cmd)
             if (!child) {
                 setpgid(0, 0);
                 tcsetpgrp(0, getpid());
+                tcsetattr(0, TCSANOW, &g.default_termios);
                 for (auto& rewiring : subcommand.rewirings) {
 #ifdef SH_DEBUG
                     dbgprintf("in %s<%d>, dup2(%d, %d)\n", argv[0], getpid(), rewiring.rewire_fd, rewiring.fd);


### PR DESCRIPTION
This fixes the the echoing and termios setting issues mentioned in #697. Note however, that I wasn't able to properly work out how to properly use LibVT, so the line editing can still be quite janky and I wouldn't consider the issue fully resolved.