### PR TITLE
Ports: Added quake package

### DIFF
--- a/Ports/quake/package.sh
+++ b/Ports/quake/package.sh
@@ -1,0 +1,9 @@
+#!/bin/bash ../.port_include.sh
+port=quake
+version=0.65
+workdir=SerenityQuake-master
+useconfigure=false
+curlopts="-L"
+files="https://github.com/SerenityOS/SerenityQuake/archive/master.tar.gz quake.tar.gz"
+makeopts="V=1 SYMBOLS_ON=Y"
+depends=SDL2


### PR DESCRIPTION
Quake now will build and run on Serenity. There are a few issues,
that'll stop you from playing currently, however, such as SDL
not having any keyboard input, as well as `printf_internal` throwing
an assertion over the `.` format specifier. However, the game launches
perfectly.