### PR TITLE
PATAChannel: Alert User when no PCI device is found

### DIFF
--- a/Kernel/Devices/PATAChannel.cpp
+++ b/Kernel/Devices/PATAChannel.cpp
@@ -124,6 +124,8 @@ void PATAChannel::initialize()
         m_bus_master_base = PCI::get_BAR4(m_pci_address) & 0xfffc;
         m_dma_buffer_page = MM.allocate_supervisor_physical_page();
         kprintf("PATAChannel: PIIX Bus master IDE: I/O @ %x\n", m_bus_master_base);
+    } else {
+        kprintf("PATAChannel: Unable to find valid PATAChannel controller! Falling back to PIO mode!\n");
     }
 }
 


### PR DESCRIPTION
This helps aid debugging of issues such as #695, where the bridge chip
that controls IDE is NOT a PIIX3/4 compatible controller. Instead of
just hanging when the DMA registers can't be accessed, the system will
inform the user that no valid IDE controller has been found. In this
case, the system will not attempt to initialise the DMA registers and
instead use PIO mode.

@awesomekling I was weighing up whether or not to do this as an assertion, but considering they're disabled when not in a debug build, I felt it was more appropriate to just halt like this in general (considering the system won't be able to boot anyway)