### PR TITLE
TTY: Flush input on signal character.

### DIFF
--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -109,6 +109,9 @@ bool TTY::is_werase(u8 ch) const
 void TTY::emit(u8 ch)
 {
     if (should_generate_signals()) {
+        if (should_flush_on_signal())
+            flush_input();
+
         if (ch == m_termios.c_cc[VINTR]) {
             dbg() << tty_name() << ": VINTR pressed!";
             generate_signal(SIGINT);
@@ -212,6 +215,12 @@ void TTY::generate_signal(int signal)
         process.send_signal(signal, nullptr);
         return IterationDecision::Continue;
     });
+}
+
+void TTY::flush_input()
+{
+    m_available_lines = 0;
+    m_input_buffer.clear();
 }
 
 void TTY::set_termios(const termios& t)

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -28,6 +28,7 @@ public:
 
     void set_termios(const termios&);
     bool should_generate_signals() const { return m_termios.c_lflag & ISIG; }
+    bool should_flush_on_signal() const { return !(m_termios.c_lflag & NOFLSH); }
     bool should_echo_input() const { return m_termios.c_lflag & ECHO; }
     bool in_canonical_mode() const { return m_termios.c_lflag & ICANON; }
 
@@ -46,6 +47,7 @@ protected:
     void do_backspace();
     void erase_word();
     void kill_line();
+    void flush_input();
 
     bool is_eol(u8) const;
     bool is_eof(u8) const;


### PR DESCRIPTION
We now flush the input when we recieve a signal character.
This can be disabled using the newly implemented NOFLSH
attribute.