### PR TITLE
Kernel: Prevent kprintf to reach the assert in Console::the().

### DIFF
--- a/Kernel/Console.cpp
+++ b/Kernel/Console.cpp
@@ -13,6 +13,11 @@ Console& Console::the()
     return *s_the;
 }
 
+bool Console::is_initialized()
+{
+    return s_the != nullptr;
+}
+
 Console::Console()
     : CharacterDevice(5, 1)
 {

--- a/Kernel/Console.h
+++ b/Kernel/Console.h
@@ -14,6 +14,7 @@ class Console final : public CharacterDevice {
     AK_MAKE_ETERNAL
 public:
     static Console& the();
+    static bool is_initialized();
 
     Console();
     virtual ~Console() override;

--- a/Kernel/kprintf.cpp
+++ b/Kernel/kprintf.cpp
@@ -70,7 +70,14 @@ static void console_putch(char*&, char ch)
 {
     if (serial_debug)
         serial_putch(ch);
-    Console::the().put_char(ch);
+
+    // It would be bad to reach the assert in Console()::the() and do a stack overflow
+
+    if (Console::is_initialized()) {
+        Console::the().put_char(ch);
+    } else {
+        IO::out8(0xe9, ch);
+    }
 }
 
 int kprintf(const char* fmt, ...)


### PR DESCRIPTION
This triggered a stack overflow because ubsan can call kprintf at any time even before the console get initialized.