### PR TITLE
POSIX compliance: (most) shell scripts converted to generic shell

### DIFF
--- a/Kernel/build-gpt-image-grub.sh
+++ b/Kernel/build-gpt-image-grub.sh
@@ -1,19 +1,19 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
 die() {
-    echo "die: $@"
+    echo "die: $*"
     exit 1
 }
 
-if [ $(id -u) != 0 ]; then
+if [ "$(id -u)" != 0 ]; then
     die "this script needs to run as root"
 fi
 
-grub=$(which grub-install 2>/dev/null) || true
-if [[ -z "$grub" ]]; then
-    grub=$(which grub2-install 2>/dev/null) || true
+grub=$(command -v grub-install 2>/dev/null) || true
+if [ -z "$grub" ]; then
+    grub=$(command -v grub2-install 2>/dev/null) || true
 fi
 if [ -z "$grub" ]; then
     echo "can't find a grub-install or grub2-install binary, oh no"
@@ -22,58 +22,58 @@ fi
 echo "using grub-install at ${grub}"
 
 echo "setting up disk image..."
-dd if=/dev/zero of=_disk_image bs=1M count=${DISK_SIZE:-701} status=none || die "couldn't create disk image"
+dd if=/dev/zero of=_disk_image bs=1M count="${DISK_SIZE:-701}" status=none || die "couldn't create disk image"
 chown 1000:1000 _disk_image || die "couldn't adjust permissions on disk image"
 echo "done"
 
-echo -n "creating loopback device... "
+printf "creating loopback device... "
 dev=$(losetup --find --partscan --show _disk_image)
-if [ -z $dev ]; then
+if [ -z "$dev" ]; then
     die "couldn't mount loopback device"
 fi
 echo "loopback device is at ${dev}"
 
 cleanup() {
     if [ -d mnt ]; then
-        echo -n "unmounting filesystem... "
+        printf "unmounting filesystem... "
         umount mnt || ( sleep 1 && sync && umount mnt )
         rm -rf mnt
         echo "done"
     fi
 
-    if [ -e ${dev} ]; then
-        echo -n "cleaning up loopback device... "
-        losetup -d ${dev}
+    if [ -e "${dev}" ]; then
+        printf "cleaning up loopback device... "
+        losetup -d "${dev}"
         echo "done"
     fi
 }
 trap cleanup EXIT
 
-echo -n "creating partition table... "
-parted -s ${dev} mklabel gpt mkpart BIOSBOOT ext3 1MiB 8MiB mkpart OS ext2 8MiB 700MiB set 1 bios_grub || die "couldn't partition disk"
+printf "creating partition table... "
+parted -s "${dev}" mklabel gpt mkpart BIOSBOOT ext3 1MiB 8MiB mkpart OS ext2 8MiB 700MiB set 1 bios_grub || die "couldn't partition disk"
 echo "done"
 
-echo -n "destroying old filesystem... "
-dd if=/dev/zero of=${dev}p2 bs=1M count=1 status=none || die "couldn't destroy old filesystem"
+printf "destroying old filesystem... "
+dd if=/dev/zero of="${dev}"p2 bs=1M count=1 status=none || die "couldn't destroy old filesystem"
 echo "done"
 
-echo -n "creating new filesystem... "
-mke2fs -q ${dev}p2 || die "couldn't create filesystem"
+printf "creating new filesystem... "
+mke2fs -q "${dev}"p2 || die "couldn't create filesystem"
 echo "done"
 
-echo -n "mounting filesystem... "
+printf "mounting filesystem... "
 mkdir -p mnt
-mount ${dev}p2 mnt/ || die "couldn't mount filesystem"
+mount "${dev}"p2 mnt/ || die "couldn't mount filesystem"
 echo "done"
 
 ./build-root-filesystem.sh
 
-echo -n "creating /boot... "
+printf "creating /boot... "
 mkdir -p mnt/boot
 echo "done"
 
 echo "installing grub using $grub..."
-$grub --boot-directory=mnt/boot --target=i386-pc --modules="ext2 part_msdos part_gpt" ${dev}
+$grub --boot-directory=mnt/boot --target=i386-pc --modules="ext2 part_msdos part_gpt ${dev}" 
 
 if [ -d mnt/boot/grub2 ]; then
     cp grub_gpt.cfg mnt/boot/grub2/grub.cfg
@@ -82,6 +82,6 @@ else
 fi
 echo "done"
 
-echo -n "installing kernel in /boot... "
+printf "installing kernel in /boot... "
 cp kernel mnt/boot
 echo "done"

--- a/Kernel/build-image-grub.sh
+++ b/Kernel/build-image-grub.sh
@@ -1,19 +1,19 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
 die() {
-    echo "die: $@"
+    echo "die: $*"
     exit 1
 }
 
-if [ $(id -u) != 0 ]; then
+if [ "$(id -u)" != 0 ]; then
     die "this script needs to run as root"
 fi
 
-grub=$(which grub-install 2>/dev/null) || true
-if [[ -z "$grub" ]]; then
-    grub=$(which grub2-install 2>/dev/null) || true
+grub=$(command -v grub-install 2>/dev/null) || true
+if [ -z "$grub" ]; then
+    grub=$(command -v grub2-install 2>/dev/null) || true
 fi
 if [ -z "$grub" ]; then
     echo "can't find a grub-install or grub2-install binary, oh no"
@@ -22,58 +22,58 @@ fi
 echo "using grub-install at ${grub}"
 
 echo "setting up disk image..."
-dd if=/dev/zero of=_disk_image bs=1M count=${DISK_SIZE:-500} status=none || die "couldn't create disk image"
+dd if=/dev/zero of=_disk_image bs=1M count="${DISK_SIZE:-500}" status=none || die "couldn't create disk image"
 chown 1000:1000 _disk_image || die "couldn't adjust permissions on disk image"
 echo "done"
 
-echo -n "creating loopback device... "
+printf "creating loopback device... "
 dev=$(losetup --find --partscan --show _disk_image)
-if [ -z $dev ]; then
+if [ -z "$dev" ]; then
     die "couldn't mount loopback device"
 fi
 echo "loopback device is at ${dev}"
 
 cleanup() {
     if [ -d mnt ]; then
-        echo -n "unmounting filesystem... "
+        printf "unmounting filesystem... "
         umount mnt || ( sleep 1 && sync && umount mnt )
         rm -rf mnt
         echo "done"
     fi
 
-    if [ -e ${dev} ]; then
-        echo -n "cleaning up loopback device... "
-        losetup -d ${dev}
+    if [ -e "${dev}" ]; then
+        printf "cleaning up loopback device... "
+        losetup -d "${dev}"
         echo "done"
     fi
 }
 trap cleanup EXIT
 
-echo -n "creating partition table... "
-parted -s ${dev} mklabel msdos mkpart primary ext2 32k 100% -a minimal set 1 boot on || die "couldn't partition disk"
+printf "creating partition table... "
+parted -s "${dev}" mklabel msdos mkpart primary ext2 32k 100% -a minimal set 1 boot on || die "couldn't partition disk"
 echo "done"
 
-echo -n "destroying old filesystem... "
-dd if=/dev/zero of=${dev}p1 bs=1M count=1 status=none || die "couldn't destroy old filesystem"
+printf "destroying old filesystem... "
+dd if=/dev/zero of="${dev}"p1 bs=1M count=1 status=none || die "couldn't destroy old filesystem"
 echo "done"
 
-echo -n "creating new filesystem... "
-mke2fs -q -I 128 ${dev}p1 || die "couldn't create filesystem"
+printf "creating new filesystem... "
+mke2fs -q -I 128 "${dev}"p1 || die "couldn't create filesystem"
 echo "done"
 
-echo -n "mounting filesystem... "
+printf "mounting filesystem... "
 mkdir -p mnt
-mount ${dev}p1 mnt/ || die "couldn't mount filesystem"
+mount "${dev}"p1 mnt/ || die "couldn't mount filesystem"
 echo "done"
 
 ./build-root-filesystem.sh
 
-echo -n "creating /boot... "
+printf "creating /boot... "
 mkdir -p mnt/boot
 echo "done"
 
 echo "installing grub using $grub..."
-$grub --boot-directory=mnt/boot --target=i386-pc --modules="ext2 part_msdos" ${dev}
+$grub --boot-directory=mnt/boot --target=i386-pc --modules="ext2 part_msdos ${dev}"
 
 if [ -d mnt/boot/grub2 ]; then
     cp grub.cfg mnt/boot/grub2/grub.cfg
@@ -82,6 +82,6 @@ else
 fi
 echo "done"
 
-echo -n "installing kernel in /boot... "
+printf "installing kernel in /boot... "
 cp kernel mnt/boot
 echo "done"

--- a/Kernel/build-image-qemu.sh
+++ b/Kernel/build-image-qemu.sh
@@ -1,33 +1,33 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
 die() {
-    echo "die: $@"
+    echo "die: $*"
     exit 1
 }
 
-if [ $(id -u) != 0 ]; then
+if [ "$(id -u)" != 0 ]; then
     die "this script needs to run as root"
 fi
 
 echo "setting up disk image..."
-qemu-img create _disk_image ${DISK_SIZE:-500}m || die "couldn't create disk image"
-chown $build_user:$build_group _disk_image || die "couldn't adjust permissions on disk image"
+qemu-img create _disk_image "${DISK_SIZE:-500}"m || die "couldn't create disk image"
+chown "$build_user":"$build_group" _disk_image || die "couldn't adjust permissions on disk image"
 echo "done"
 
-echo -n "creating new filesystem... "
+printf "creating new filesystem... "
 mke2fs -q -I 128 _disk_image || die "couldn't create filesystem"
 echo "done"
 
-echo -n "mounting filesystem... "
+printf "mounting filesystem... "
 mkdir -p mnt
 mount _disk_image mnt/ || die "couldn't mount filesystem"
 echo "done"
 
 cleanup() {
     if [ -d mnt ]; then
-        echo -n "unmounting filesystem... "
+        printf "unmounting filesystem... "
         umount mnt || ( sleep 1 && sync && umount mnt )
         rm -rf mnt
         echo "done"

--- a/Kernel/build-root-filesystem.sh
+++ b/Kernel/build-root-filesystem.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -6,20 +6,22 @@ set -e
 rm -f ../Userland/qs
 
 die() {
-    echo "die: $@"
+    echo "die: $*"
     exit 1
 }
 
-if [ $(id -u) != 0 ]; then
+if [ "$(id -u)" != 0 ]; then
     die "this script needs to run as root"
 fi
 
-echo -n "creating initial filesystem structure... "
-mkdir -p mnt/{bin,etc,proc,mnt,tmp}
+printf "creating initial filesystem structure... "
+for dir in bin etc proc mnt tmp; do
+    mkdir -p mnt/$dir
+done
 chmod 1777 mnt/tmp
 echo "done"
 
-echo -n "setting up device nodes... "
+printf "setting up device nodes... "
 mkdir -p mnt/dev
 mkdir -p mnt/dev/pts
 mknod -m 666 mnt/dev/fb0 b 29 0
@@ -49,13 +51,13 @@ ln -s /proc/self/fd/1 mnt/dev/stdout
 ln -s /proc/self/fd/2 mnt/dev/stderr
 echo "done"
 
-echo -n "installing base system... "
+printf "installing base system... "
 cp -R ../Base/* mnt/
 cp -R ../Root/* mnt/
 cp kernel.map mnt/
 echo "done"
 
-echo -n "installing users... "
+printf "installing users... "
 mkdir -p mnt/home/anon
 mkdir -p mnt/home/nona
 cp ../ReadMe.md mnt/home/anon/
@@ -63,12 +65,12 @@ chown -R 100:100 mnt/home/anon
 chown -R 200:200 mnt/home/nona
 echo "done"
 
-echo -n "installing userland... "
+printf "installing userland... "
 find ../Userland/ -type f -executable -exec cp {} mnt/bin/ \;
 chmod 4755 mnt/bin/su
 echo "done"
 
-echo -n "installing applications... "
+printf "installing applications... "
 cp ../Applications/About/About mnt/bin/About
 cp ../Applications/Downloader/Downloader mnt/bin/Downloader
 cp ../Applications/FileManager/FileManager mnt/bin/FileManager
@@ -110,7 +112,7 @@ cp ../Servers/TelnetServer/TelnetServer mnt/bin/TelnetServer
 cp ../Shell/Shell mnt/bin/Shell
 echo "done"
 
-echo -n "installing shortcuts... "
+printf "installing shortcuts... "
 ln -s Downloader mnt/bin/dl
 ln -s FileManager mnt/bin/fm
 ln -s HelloWorld mnt/bin/hw

--- a/Kernel/install.sh
+++ b/Kernel/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 mkdir -p ../Root/usr/include/Kernel/
-cp *.h ../Root/usr/include/Kernel/
+cp ./*.h ../Root/usr/include/Kernel/

--- a/Kernel/makeall.sh
+++ b/Kernel/makeall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # Get user and group details for setting qemu disk image ownership

--- a/Kernel/sync.sh
+++ b/Kernel/sync.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 ./build-image-qemu.sh

--- a/Libraries/LibC/install.sh
+++ b/Libraries/LibC/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 SERENITY_ROOT=../../
@@ -8,7 +8,7 @@ mkdir -p $SERENITY_ROOT/Root/usr/include/bits/
 mkdir -p $SERENITY_ROOT/Root/usr/include/netinet/
 mkdir -p $SERENITY_ROOT/Root/usr/include/arpa/
 mkdir -p $SERENITY_ROOT/Root/usr/lib/
-cp *.h $SERENITY_ROOT/Root/usr/include/
+cp ./*.h $SERENITY_ROOT/Root/usr/include/
 cp sys/*.h $SERENITY_ROOT/Root/usr/include/sys/
 cp bits/*.h $SERENITY_ROOT/Root/usr/include/bits/
 cp arpa/*.h $SERENITY_ROOT/Root/usr/include/arpa/

--- a/Libraries/LibCore/install.sh
+++ b/Libraries/LibCore/install.sh
@@ -4,5 +4,5 @@ set -e
 SERENITY_ROOT=../../
 
 mkdir -p $SERENITY_ROOT/Root/usr/include/LibCore/
-cp *.h $SERENITY_ROOT/Root/usr/include/LibCore/
+cp ./*.h $SERENITY_ROOT/Root/usr/include/LibCore/
 cp libcore.a $SERENITY_ROOT/Root/usr/lib/

--- a/Libraries/LibDraw/install.sh
+++ b/Libraries/LibDraw/install.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 SERENITY_ROOT=../../
 
 mkdir -p $SERENITY_ROOT/Root/usr/include/LibDraw/
-cp *.h $SERENITY_ROOT/Root/usr/include/LibDraw/
+cp ./*.h $SERENITY_ROOT/Root/usr/include/LibDraw/
 cp libdraw.a $SERENITY_ROOT/Root/usr/lib/

--- a/Libraries/LibGUI/install.sh
+++ b/Libraries/LibGUI/install.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 SERENITY_ROOT=../../
 
 mkdir -p $SERENITY_ROOT/Root/usr/include/LibGUI/
-cp *.h $SERENITY_ROOT/Root/usr/include/LibGUI/
+cp ./*.h $SERENITY_ROOT/Root/usr/include/LibGUI/
 cp libgui.a $SERENITY_ROOT/Root/usr/lib/

--- a/Libraries/LibHTML/Scripts/GenerateStyleSheetSource.sh
+++ b/Libraries/LibHTML/Scripts/GenerateStyleSheetSource.sh
@@ -1,10 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "extern const char $1[];"
 echo "const char $1[] = \"\\"
-IFS=$'\n'
-for line in $(cat $2); do
-    echo $line"\\"
+grep -v '^ *#' < "$2" | while IFS= read -r line; do
+  echo "$line""\\"
 done
 echo "\";"
-

--- a/Libraries/LibIPC/install.sh
+++ b/Libraries/LibIPC/install.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 SERENITY_ROOT=../../
 
 mkdir -p $SERENITY_ROOT/Root/usr/include/LibIPC/
-cp *.h $SERENITY_ROOT/Root/usr/include/LibIPC/
+cp ./*.h $SERENITY_ROOT/Root/usr/include/LibIPC/

--- a/Libraries/LibM/install.sh
+++ b/Libraries/LibM/install.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 SERENITY_ROOT=../../
 
 mkdir -p $SERENITY_ROOT/Root/usr/include/sys/
 mkdir -p $SERENITY_ROOT/Root/usr/lib/
-cp *.h $SERENITY_ROOT/Root/usr/include/
+cp ./*.h $SERENITY_ROOT/Root/usr/include/
 cp libm.a $SERENITY_ROOT/Root/usr/lib/

--- a/Libraries/LibPCIDB/install.sh
+++ b/Libraries/LibPCIDB/install.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 SERENITY_ROOT=../../
 
 mkdir -p $SERENITY_ROOT/Root/usr/include/LibPCIDB/
-cp *.h $SERENITY_ROOT/Root/usr/include/LibPCIDB/
+cp ./*.h $SERENITY_ROOT/Root/usr/include/LibPCIDB/
 cp libpcidb.a $SERENITY_ROOT/Root/usr/lib/

--- a/Libraries/LibThread/install.sh
+++ b/Libraries/LibThread/install.sh
@@ -4,5 +4,5 @@ set -e
 SERENITY_ROOT=../../
 
 mkdir -p $SERENITY_ROOT/Root/usr/include/LibThread/
-cp *.h $SERENITY_ROOT/Root/usr/include/LibThread/
+cp ./*.h $SERENITY_ROOT/Root/usr/include/LibThread/
 cp libthread.a $SERENITY_ROOT/Root/usr/lib/

--- a/Meta/refresh-serenity-qtcreator.sh
+++ b/Meta/refresh-serenity-qtcreator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
-cd $SERENITY_ROOT
+cd "$SERENITY_ROOT" || exit 1
 find . -name '*.ipc' -or -name '*.cpp' -or -name '*.h' -or -name '*.S' -or -name '*.css' | grep -Fv Patches/ | grep -Fv Root/ | grep -Fv Ports/ | grep -Fv Toolchain/ | grep -Fv Base/ > serenity.files

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# This file will need to be run in bash, for now.
+
 if [ -z "$SERENITY_ROOT" ]; then
     echo "You must source UseIt.sh to build ports."
     exit 1
@@ -30,19 +33,19 @@ run() {
     (cd "$workdir" && "$@")
 }
 run_replace_in_file(){
-    run perl -p -i -e "$1" $2
+    run perl -p -i -e "$1" "$2"
 }
 # Checks if a function is defined. In this case, if the function is not defined in the port's script, then we will use our defaults. This way, ports don't need to include these functions every time, but they can override our defaults if needed.
 func_defined() {
-    PATH= command -V "$1"  > /dev/null 2>&1
+    PATH=$(command -V "$1"  > /dev/null 2>&1)
 }
 func_defined fetch || fetch() {
     OLDIFS=$IFS
     IFS=$'\n'
     for f in $files; do
         IFS=$OLDIFS
-        read url filename <<< $(echo "$f")
-        run_nocd curl ${curlopts:-} "$url" -o "$filename"
+        read url filename <<< "$(echo $f)"
+        run_nocd curl "${curlopts:-}" "$url" -o "$filename"
         case "$filename" in
             *.tar*|.tbz*|*.txz|*.tgz)
                 run_nocd tar xf "$filename"
@@ -65,13 +68,13 @@ func_defined configure || configure() {
     run ./"$configscript" --host=i686-pc-serenity $configopts
 }
 func_defined build || build() {
-    run make $makeopts
+    run make "$makeopts"
 }
 func_defined install || install() {
     run make DESTDIR="$SERENITY_ROOT"/Root $installopts install
 }
 func_defined clean || clean() {
-    rm -rf "$workdir" *.out
+    rm -rf "$workdir" -- *.out
 }
 func_defined clean_dist || clean_dist() {
     OLDIFS=$IFS
@@ -83,7 +86,7 @@ func_defined clean_dist || clean_dist() {
     done
 }
 func_defined clean_all || clean_all() {
-    rm -rf "$workdir" *.out
+    rm -rf "$workdir" -- *.out
     OLDIFS=$IFS
     IFS=$'\n'
     for f in $files; do
@@ -103,7 +106,7 @@ addtodb() {
             echo "auto $port $version" >> "$prefix"/packages.db
         else
             echo "manual $port $version" >> "$prefix"/packages.db
-            if [ ! -z "${dependlist:-}" ]; then
+            if [ -n "${dependlist:-}" ]; then
                 echo "dependency $port$dependlist" >> "$prefix/packages.db"
             fi
         fi
@@ -194,10 +197,10 @@ if [ -z "${1:-}" ]; then
 else
     case "$1" in
         fetch|configure|build|install|clean|clean_dist|clean_all|uninstall)
-            do_$1
+            do_"$1"
             ;;
         --auto)
-            do_all $1
+            do_all "$1"
             ;;
         *)
             >&2 echo "I don't understand $1! Supported arguments: fetch, configure, build, install, clean, clean_dist, clean_all, uninstall."

--- a/Ports/SDL2/package.sh
+++ b/Ports/SDL2/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=SDL2
 version=serenity-git
 workdir=SDL-master-serenity
@@ -8,5 +8,5 @@ files="https://github.com/SerenityOS/SDL/archive/master-serenity.tar.gz SDL2-git
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMakeToolchain.txt -DPULSEAUDIO=OFF"
 
 configure() {
-    run cmake $configopts
+    run cmake "$configopts"
 }

--- a/Ports/bash/package.sh
+++ b/Ports/bash/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=bash
 version=5.0
 useconfigure=true
@@ -8,5 +8,5 @@ files="https://ftp.gnu.org/gnu/bash/bash-5.0.tar.gz bash-5.0.tar.gz"
 build() {
     run_replace_in_file "s/define GETCWD_BROKEN 1/undef GETCWD_BROKEN/" config.h
     run_replace_in_file "s/define CAN_REDEFINE_GETENV 1/undef CAN_REDEFINE_GETENV/" config.h
-    run make $makeopts
+    run make "$makeopts"
 }

--- a/Ports/binutils/package.sh
+++ b/Ports/binutils/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=binutils
 version=2.32
 useconfigure=true

--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=curl
 version=7.65.3
 useconfigure=true

--- a/Ports/doom/package.sh
+++ b/Ports/doom/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=doom
 workdir=SerenityDOOM-master
 version=serenity-git

--- a/Ports/figlet/package.sh
+++ b/Ports/figlet/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=figlet
 version=2.2.5
 files="http://ftp.figlet.org/pub/figlet/program/unix/figlet-2.2.5.tar.gz figlet-2.2.5.tar.gz"

--- a/Ports/gcc/package.sh
+++ b/Ports/gcc/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=gcc
 version=8.3.0
 useconfigure=true
@@ -18,10 +18,10 @@ fetch() {
     done
 }
 build() {
-    run make $makeopts
+    run make "$makeopts"
     run find ./host-i686-pc-serenity/gcc/ -maxdepth 1 -type f -executable -exec strip --strip-debug {} \; || echo
 }
 
 install() {
-    run make $installopts
+    run make "$installopts"
 }

--- a/Ports/less/package.sh
+++ b/Ports/less/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=less
 version=530
 useconfigure="true"

--- a/Ports/libarchive/package.sh
+++ b/Ports/libarchive/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=libarchive
 version=3.4.0
 useconfigure=true

--- a/Ports/libexpat/package.sh
+++ b/Ports/libexpat/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=libexpat
 version=2.2.9
 useconfigure=true

--- a/Ports/libiconv/package.sh
+++ b/Ports/libiconv/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=libiconv
 version=1.16
 useconfigure=true

--- a/Ports/links/package.sh
+++ b/Ports/links/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=links
 version=2.19
 useconfigure=true

--- a/Ports/lua/package.sh
+++ b/Ports/lua/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=lua
 version=5.3.5
 files="http://www.lua.org/ftp/lua-5.3.5.tar.gz lua-5.3.5.tar.gz"

--- a/Ports/make/package.sh
+++ b/Ports/make/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=make
 version=4.2
 useconfigure=true

--- a/Ports/mbedtls/package.sh
+++ b/Ports/mbedtls/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=mbedtls
 version=2.16.2
 files="https://tls.mbed.org/download/mbedtls-2.16.2-apache.tgz mbedtls-2.16.2-apache.tgz"

--- a/Ports/ncurses/package.sh
+++ b/Ports/ncurses/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=ncurses
 version=git
 workdir=ncurses-master

--- a/Ports/nyancat/package.sh
+++ b/Ports/nyancat/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=nyancat
 version=git
 workdir=nyancat-master

--- a/Ports/quake/package.sh
+++ b/Ports/quake/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=quake
 version=0.65
 workdir=SerenityQuake-master

--- a/Ports/tinycc/package.sh
+++ b/Ports/tinycc/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=tinycc
 workdir=tinycc-dev
 version=dev

--- a/Ports/vim/package.sh
+++ b/Ports/vim/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=vim
 version=git
 workdir=vim-master

--- a/Ports/zlib/package.sh
+++ b/Ports/zlib/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/bin/sh ../.port_include.sh
 port=zlib
 version=1.2.11
 useconfigure=true

--- a/Servers/SystemServer/install.sh
+++ b/Servers/SystemServer/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #mkdir -p ../../Root/usr/include/SystemServer/
 #cp *.h ../../Root/usr/include/SystemServer/

--- a/Servers/WindowServer/install.sh
+++ b/Servers/WindowServer/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 mkdir -p ../../Root/usr/include/WindowServer/
-cp *.h ../../Root/usr/include/WindowServer/
+cp ./*.h ../../Root/usr/include/WindowServer/

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 set -e
 
+# This file will need to be run in bash, for now.
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-echo $DIR
+echo "$DIR"
 
 TARGET=i686-pc-serenity
 PREFIX="$DIR/Local"
 SYSROOT="$DIR/../Root"
 
-echo PREFIX is $PREFIX
-echo SYSROOT is $SYSROOT
+echo PREFIX is "$PREFIX"
+echo SYSROOT is "$SYSROOT"
 
 mkdir -p "$DIR/Tarballs"
 
@@ -40,7 +42,7 @@ pushd "$DIR/Tarballs"
         tar -xf "binutils-2.32.tar.gz"
 
         pushd "binutils-2.32"
-            patch -p1 < $DIR/Patches/binutils.patch > /dev/null
+            patch -p1 < "$DIR"/Patches/binutils.patch > /dev/null
         popd
     else
         echo "Skipped extracting binutils"
@@ -51,14 +53,14 @@ pushd "$DIR/Tarballs"
         tar -xf "gcc-8.3.0.tar.gz"
 
         pushd "gcc-8.3.0"
-            patch -p1 < $DIR/Patches/gcc.patch > /dev/null
+            patch -p1 < "$DIR"/Patches/gcc.patch > /dev/null
         popd
     else
         echo "Skipped extracting gcc"
     fi
 popd
 
-mkdir -p $PREFIX
+mkdir -p "$PREFIX"
 
 mkdir -p "$DIR/Build/binutils"
 mkdir -p "$DIR/Build/gcc"
@@ -71,24 +73,24 @@ pushd "$DIR/Build/"
     unset PKG_CONFIG_LIBDIR # Just in case
 
     pushd binutils
-        $DIR/Tarballs/binutils-2.32/configure --prefix=$PREFIX \
-                                              --target=$TARGET \
-                                              --with-sysroot=$SYSROOT \
+        "$DIR"/Tarballs/binutils-2.32/configure --prefix="$PREFIX" \
+                                              --target="$TARGET" \
+                                              --with-sysroot="$SYSROOT" \
                                               --disable-nls || exit 1
-        make -j $MAKEJOBS || exit 1
+        make -j "$MAKEJOBS" || exit 1
         make install || exit 1
     popd
 
     pushd gcc
-        $DIR/Tarballs/gcc-8.3.0/configure --prefix=$PREFIX \
-                                          --target=$TARGET \
-                                          --with-sysroot=$SYSROOT \
+        "$DIR"/Tarballs/gcc-8.3.0/configure --prefix="$PREFIX" \
+                                          --target="$TARGET" \
+                                          --with-sysroot="$SYSROOT" \
                                           --disable-nls \
                                           --with-newlib \
                                           --enable-languages=c,c++ || exit 1
 
         echo "XXX build gcc and libgcc"
-        make -j $MAKEJOBS all-gcc all-target-libgcc || exit 1
+        make -j "$MAKEJOBS" all-gcc all-target-libgcc || exit 1
         echo "XXX install gcc and libgcc"
         make install-gcc install-target-libgcc || exit 1
 

--- a/Toolchain/UseIt.sh
+++ b/Toolchain/UseIt.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# This file will need to be run in bash, for now.
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export PATH="$DIR/Local/bin:$PATH"
 export TOOLCHAIN="$DIR"


### PR DESCRIPTION
Ports/.port_include.sh, Toolchain/BuildIt.sh, Toolchain/UseIt.sh have been left largely untouched due to use of Bash-exclusive functions and variables such as $BASH_SOURCE, pushd and popd.

shellcheck was used as the linting tool. If you'd like me to explain any of the changes I've made, feel free to ask.