### PR TITLE
Ports: update make to 4.2.1, disable Guile

### DIFF
--- a/Ports/make/package.sh
+++ b/Ports/make/package.sh
@@ -1,6 +1,6 @@
 #!/bin/bash ../.port_include.sh
 port=make
-version=4.2
+version=4.2.1
 useconfigure=true
-files="https://ftp.gnu.org/gnu/make/make-4.2.tar.bz2 make-4.2.tar.bz2"
-configopts="--target=i686-pc-serenity --with-sysroot=/"
+files="https://ftp.gnu.org/gnu/make/make-4.2.1.tar.bz2 make-4.2.1.tar.bz2"
+configopts="--target=i686-pc-serenity --with-sysroot=/ --without-guile"


### PR DESCRIPTION
Some systems (e.g. Arch Linux) build their gmake with Guile support and
thus have it installed. This patch disables Guile autodetection in the
configure script. It also updates the version of gmake to 4.2.1.

Fixes #645.