### PR TITLE
HackStudio: Don't parse documentation if already parsed

### DIFF
--- a/DevTools/HackStudio/Editor.cpp
+++ b/DevTools/HackStudio/Editor.cpp
@@ -94,6 +94,10 @@ void Editor::show_documentation_tooltip_if_available(const String& hovered_token
         return;
     }
 
+    if (m_documentation_tooltip_window->is_visible() && hovered_token == m_last_parsed_token) {
+        return;
+    }
+
     dbg() << "opening " << it->value;
     auto file = CFile::construct(it->value);
     if (!file->open(CFile::ReadOnly)) {
@@ -129,6 +133,8 @@ void Editor::show_documentation_tooltip_if_available(const String& hovered_token
     m_documentation_html_view->set_document(html_document);
     m_documentation_tooltip_window->move_to(screen_location.translated(4, 4));
     m_documentation_tooltip_window->show();
+
+    m_last_parsed_token = hovered_token;
 }
 
 void Editor::mousemove_event(GMouseEvent& event)

--- a/DevTools/HackStudio/Editor.h
+++ b/DevTools/HackStudio/Editor.h
@@ -27,4 +27,5 @@ private:
 
     RefPtr<GWindow> m_documentation_tooltip_window;
     RefPtr<HtmlView> m_documentation_html_view;
+    String m_last_parsed_token;
 };


### PR DESCRIPTION
If the m_documentation_tooltip_window is visible, we already parsed the documentation for symbol under cursor.