### PR TITLE
ProcFS: Idenity virtual filesystems' device in df

### DIFF
--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -570,7 +570,7 @@ Optional<KBuffer> procfs$df(InodeIdentifier)
         if (fs.is_disk_backed())
             fs_object.add("device", static_cast<const DiskBackedFS&>(fs).device().absolute_path());
         else
-            fs_object.add("device", nullptr);
+            fs_object.add("device", fs.class_name());
     });
     array.finish();
     return builder.build();


### PR DESCRIPTION
I was looking to fix the output of mount - the virtual filesystems lines' look not-neat - but I felt changing mount.cpp was a bit short sighted.

Let me know what you think.