### PR TITLE
SystemMonitor: Add device column to filesystems tab

### DIFF
--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -219,6 +219,7 @@ RefPtr<GWidget> build_file_systems_tab()
         Vector<GJsonArrayModel::FieldSpec> df_fields;
         df_fields.empend("mount_point", "Mount point", TextAlignment::CenterLeft);
         df_fields.empend("class_name", "Class", TextAlignment::CenterLeft);
+        df_fields.empend("device", "Device", TextAlignment::CenterLeft);
         df_fields.empend(
             "Size", TextAlignment::CenterRight,
             [](const JsonObject& object) {

--- a/Kernel/sync.sh
+++ b/Kernel/sync.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./build-image-qemu.sh
+sudo -E ./build-image-qemu.sh


### PR DESCRIPTION
I'm sneaking in a change in sync.sh too. I can split it to a separate PR or skip it if you want.