### PR TITLE
SoundPlayer: small cosmetic changes

### DIFF
--- a/Applications/SoundPlayer/SoundPlayerWidget.cpp
+++ b/Applications/SoundPlayer/SoundPlayerWidget.cpp
@@ -5,9 +5,11 @@
 #include <LibGUI/GLabel.h>
 #include <LibM/math.h>
 
-SoundPlayerWidget::SoundPlayerWidget(NonnullRefPtr<AClientConnection> connection, AWavLoader& loader)
+SoundPlayerWidget::SoundPlayerWidget(GWindow& window, NonnullRefPtr<AClientConnection> connection, AWavLoader& loader)
     : m_manager(PlaybackManager(connection, loader))
 {
+    window.set_title(String::format("SoundPlayer - \"%s\"", loader.file()->filename().characters()));
+
     set_fill_with_background_color(true);
     set_layout(make<GBoxLayout>(Orientation::Vertical));
     layout()->set_margins({ 2, 2, 2, 2 });
@@ -66,9 +68,10 @@ SoundPlayerWidget::SoundPlayerWidget(NonnullRefPtr<AClientConnection> connection
     m_status->set_preferred_size(0, 18);
 
     m_status->set_text(String::format(
-        "Sample rate %uHz, %u channels, %u bits per sample",
+        "Sample rate %uHz, %u %s, %u bits per sample",
         loader.sample_rate(),
         loader.num_channels(),
+        (loader.num_channels() == 1) ? "channel" : "channels",
         loader.bits_per_sample()));
 
     update_position(0);
@@ -109,7 +112,7 @@ void SoundPlayerWidget::update_position(const int position)
     float remaining_seconds = m_manager.total_length() - seconds;
 
     m_elapsed->set_text(String::format(
-        "Position:\n%u:%02u.%02u",
+        "Elapsed:\n%u:%02u.%02u",
         static_cast<int>(seconds / 60),
         static_cast<int>(seconds) % 60,
         static_cast<int>(seconds * 100) % 100));

--- a/Applications/SoundPlayer/SoundPlayerWidget.h
+++ b/Applications/SoundPlayer/SoundPlayerWidget.h
@@ -6,6 +6,7 @@
 #include <LibGUI/GLabel.h>
 #include <LibGUI/GSlider.h>
 #include <LibGUI/GWidget.h>
+#include <LibGUI/GWindow.h>
 
 class SoundPlayerWidget final : public GWidget {
     C_OBJECT(SoundPlayerWidget)
@@ -13,7 +14,7 @@ public:
     virtual ~SoundPlayerWidget() override;
 
 private:
-    explicit SoundPlayerWidget(NonnullRefPtr<AClientConnection>, AWavLoader&);
+    explicit SoundPlayerWidget(GWindow&, NonnullRefPtr<AClientConnection>, AWavLoader&);
 
     void update_position(const int position);
     void update_ui();

--- a/Applications/SoundPlayer/main.cpp
+++ b/Applications/SoundPlayer/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
     window->set_rect(300, 300, 350, 140);
     window->set_icon(GraphicsBitmap::load_from_file("/res/icons/16x16/app-sound-player.png"));
 
-    auto player = SoundPlayerWidget::construct(audio_client, loader);
+    auto player = SoundPlayerWidget::construct(window, audio_client, loader);
     window->set_main_widget(player);
     window->show();
 

--- a/Libraries/LibAudio/AWavLoader.cpp
+++ b/Libraries/LibAudio/AWavLoader.cpp
@@ -27,7 +27,9 @@ RefPtr<ABuffer> AWavLoader::get_more_samples(size_t max_bytes_to_read_from_input
         return nullptr;
 
     auto buffer = ABuffer::from_pcm_data(raw_samples, *m_resampler, m_num_channels, m_bits_per_sample);
-    m_loaded_samples += buffer->sample_count();
+    //Buffer contains normalized samples, but m_loaded_samples should containt the ammount of actually loaded samples
+    m_loaded_samples += static_cast<int>(max_bytes_to_read_from_input) / (m_num_channels * (m_bits_per_sample / 8));
+    m_loaded_samples = min(m_total_samples, m_loaded_samples);
     return buffer;
 }
 

--- a/Libraries/LibAudio/AWavLoader.h
+++ b/Libraries/LibAudio/AWavLoader.h
@@ -30,6 +30,7 @@ public:
     u32 sample_rate() const { return m_sample_rate; }
     u16 num_channels() const { return m_num_channels; }
     u16 bits_per_sample() const { return m_bits_per_sample; }
+    RefPtr<CFile> file() const { return m_file; }
 
 private:
     bool parse_header();


### PR DESCRIPTION
In addition to the cosmetic changes, I noticed that m_loaded_samples was calculated incorrectly.
This caused SoundPlayer to stop to early when playing files with less than 44100Hz sample rate, because the PlaybackManager thought all the samples were already loaded.