### PR TITLE
Kernel: Removing hardcoded offsets from Memory Manager

### DIFF
--- a/Kernel/Arch/i386/Boot/boot.S
+++ b/Kernel/Arch/i386/Boot/boot.S
@@ -31,6 +31,11 @@ stack_bottom:
 .skip 32768
 stack_top:
 
+.section .page_tables
+.align 4096
+page_tables_start:
+.skip 4096*3
+
 .section .text
 
 .global start
@@ -52,7 +57,9 @@ start:
 
     mov %ebx, multiboot_info_ptr
 
+    pushl $page_tables_start
     call init
+    add $4, %esp
 
     pushl $exit_message
     call kprintf

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -20,13 +20,11 @@ MemoryManager& MM
     return *s_the;
 }
 
-MemoryManager::MemoryManager()
+MemoryManager::MemoryManager(u32 physical_address_for_kernel_page_tables)
 {
-    // FIXME: Hard-coding these is stupid. Find a better way.
-    m_kernel_page_directory = PageDirectory::create_at_fixed_address(PhysicalAddress(0x4000));
-    m_page_table_zero = (PageTableEntry*)0x6000;
-    m_page_table_one = (PageTableEntry*)0x7000;
-
+    m_kernel_page_directory = PageDirectory::create_at_fixed_address(PhysicalAddress(physical_address_for_kernel_page_tables));
+    m_page_table_zero = (PageTableEntry*)(physical_address_for_kernel_page_tables + PAGE_SIZE);
+    m_page_table_one = (PageTableEntry*)(physical_address_for_kernel_page_tables + PAGE_SIZE * 2);
     initialize_paging();
 
     kprintf("MM initialized.\n");
@@ -262,9 +260,9 @@ void MemoryManager::create_identity_mapping(PageDirectory& page_directory, Virtu
     }
 }
 
-void MemoryManager::initialize()
+void MemoryManager::initialize(u32 physical_address_for_kernel_page_tables)
 {
-    s_the = new MemoryManager;
+    s_the = new MemoryManager(physical_address_for_kernel_page_tables);
 }
 
 Region* MemoryManager::kernel_region_from_vaddr(VirtualAddress vaddr)

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -38,7 +38,7 @@ class MemoryManager {
 public:
     static MemoryManager& the();
 
-    static void initialize();
+    static void initialize(u32 physical_address_for_kernel_page_tables);
 
     PageFaultResponse handle_page_fault(const PageFault&);
 
@@ -79,7 +79,7 @@ public:
     }
 
 private:
-    MemoryManager();
+    MemoryManager(u32 physical_address_for_kernel_page_tables);
     ~MemoryManager();
 
     void register_vmo(VMObject&);

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -206,7 +206,7 @@ extern "C" int __cxa_atexit ( void (*)(void *), void *, void *)
     return 0;
 }
 
-extern "C" [[noreturn]] void init()
+extern "C" [[noreturn]] void init(u32 physical_address_for_kernel_page_tables)
 {
     // this is only used one time, directly below here. we can't use this part
     // of libc at this point in the boot process, or we'd just pull strstr in
@@ -268,7 +268,7 @@ extern "C" [[noreturn]] void init()
 
     kprintf("Starting Serenity Operating System...\n");
 
-    MemoryManager::initialize();
+    MemoryManager::initialize(physical_address_for_kernel_page_tables);
 
     if (APIC::init())
         APIC::enable(0);

--- a/Kernel/linker.ld
+++ b/Kernel/linker.ld
@@ -8,6 +8,7 @@ SECTIONS
 	{
         Arch/i386/Boot/boot.ao
 		*(.multiboot)
+		*(.page_tables)
 		*(.text)
 		*(.text.startup)
 	}


### PR DESCRIPTION
Discussed already with AK, after finding out that the memory manager uses hardcoded offsets (and therefore failed to boot with my bootloader), we need to change that.

So, now the kernel page directory and the page tables are located at a
safe address, to prevent from paging data colliding with some garbage.