### PR TITLE
Kernel: Fixing the search method of free userspace physical pages

### DIFF
--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -103,6 +103,7 @@ private:
 
     static Region* region_from_vaddr(VirtualAddress);
 
+    RefPtr<PhysicalPage> find_free_user_physical_page();
     u8* quickmap_page(PhysicalPage&);
     void unquickmap_page();
 


### PR DESCRIPTION
Fixing issue #617 - now userspace memory allocator will search through the physical regions,
and will stop the search as it finds an available page.
Also remvoing the "address of" sign since we don't need that when
counting size of physical regions