### PR TITLE
WindowServer: Don't de-maximize windows immediatly on mousedown. Fix #751.

### DIFF
--- a/Libraries/LibDraw/Point.h
+++ b/Libraries/LibDraw/Point.h
@@ -110,6 +110,16 @@ public:
             set_y(value);
     }
 
+    // Returns pixels moved from other in either direction
+    int pixels_moved(const Point &other) const
+    {
+        auto pixels_moved = max(
+            abs(other.x() - x()),
+            abs(other.y() - y())
+        );
+        return pixels_moved;
+    }
+
 private:
     int m_x { 0 };
     int m_y { 0 };


### PR DESCRIPTION
At least 5 pixels of dragging in some direction needed until a window
gets de-maximized.