### PR TITLE
Kernel: Add a kernel boot parameter to force PIO mode

### DIFF
--- a/Kernel/Devices/PATAChannel.h
+++ b/Kernel/Devices/PATAChannel.h
@@ -35,8 +35,8 @@ public:
     };
 
 public:
-    static OwnPtr<PATAChannel> create(ChannelType type);
-    explicit PATAChannel(ChannelType);
+    static OwnPtr<PATAChannel> create(ChannelType type, bool force_pio);
+    PATAChannel(ChannelType type, bool force_pio);
     virtual ~PATAChannel() override;
 
     RefPtr<PATADiskDevice> master_device() { return m_master; };
@@ -46,7 +46,7 @@ private:
     //^ IRQHandler
     virtual void handle_irq() override;
 
-    void initialize();
+    void initialize(bool force_pio);
     void detect_disks();
 
     bool wait_for_irq();
@@ -67,6 +67,7 @@ private:
     RefPtr<PhysicalPage> m_dma_buffer_page;
     u16 m_bus_master_base { 0 };
     Lockable<bool> m_dma_enabled;
+    Lockable<bool> m_force_pio;
 
     RefPtr<PATADiskDevice> m_master;
     RefPtr<PATADiskDevice> m_slave;

--- a/Kernel/Devices/PATADiskDevice.cpp
+++ b/Kernel/Devices/PATADiskDevice.cpp
@@ -24,7 +24,7 @@ const char* PATADiskDevice::class_name() const
 
 bool PATADiskDevice::read_blocks(unsigned index, u16 count, u8* out)
 {
-    if (m_channel.m_bus_master_base && m_channel.m_dma_enabled.resource())
+    if (m_channel.m_bus_master_base && m_channel.m_dma_enabled.resource() && !m_channel.m_force_pio.resource())
         return read_sectors_with_dma(index, count, out);
     return read_sectors(index, count, out);
 }

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -67,6 +67,7 @@ VFS* vfs;
     auto dev_ptmx = make<PTYMultiplexer>();
 
     bool text_debug = KParams::the().has("text_debug");
+    bool force_pio = KParams::the().has("force_pio");
 
     auto root = KParams::the().get("root");
     if (root.is_empty()) {
@@ -78,7 +79,7 @@ VFS* vfs;
         hang();
     }
 
-    auto pata0 = PATAChannel::create(PATAChannel::ChannelType::Primary);
+    auto pata0 = PATAChannel::create(PATAChannel::ChannelType::Primary, force_pio);
     NonnullRefPtr<DiskDevice> root_dev = *pata0->master_device();
 
     root = root.substring(strlen("/dev/hda"), root.length() - strlen("/dev/hda"));

--- a/Kernel/run
+++ b/Kernel/run
@@ -51,13 +51,18 @@ elif [ "$1" = "qgrub" ]; then
         $SERENITY_PACKET_LOGGING_ARG \
         -netdev user,id=breh,hostfwd=tcp:127.0.0.1:8888-10.0.2.15:8888,hostfwd=tcp:127.0.0.1:8823-10.0.2.15:23 \
         -device e1000,netdev=breh
-elif [ "$1" = "qtext" ]; then
-    # ./run: qemu with serenity in text mode
+elif [ "$1" = "qcmd" ]; then
+    SERENITY_KERNEL_CMDLINE=""
+    for (( i=2; i<=$#; i++)); do
+        SERENITY_KERNEL_CMDLINE+="${!i} "
+    done
+    echo "Starting SerenityOS, Commandline: ${SERENITY_KERNEL_CMDLINE}"
+    # ./run: qemu with serenity with custom commandline
     $SERENITY_QEMU_BIN \
         $SERENITY_COMMON_QEMU_ARGS \
         -device e1000 \
         -kernel kernel \
-        -append "${SERENITY_KERNEL_CMDLINE} text_debug"
+        -append "${SERENITY_KERNEL_CMDLINE}"
 else
     # ./run: qemu with user networking
     $SERENITY_QEMU_BIN \


### PR DESCRIPTION
Also added an option in the run script to force PIO operation mode with
the IDE controller.

I think white-listing is not a good approach to handle hardware (unless needed). Presumably most IDE controllers are designed to be compatible with the ATA command set, therefore I see no good reason to disable by default the DMA operation mode. If there is a need to troubleshoot a suspected faulty IDE controller (which doesn't conform to the ATA spec), then, a user can add the boot parameter "force_pio" to make sure that no read/write operations will use DMA.