### PR TITLE
Make sure PATH is passed properly

### DIFF
--- a/Kernel/makeall.sh
+++ b/Kernel/makeall.sh
@@ -105,4 +105,4 @@ for targ in $build_targets; do
     fi
 done
 
-sudo -E PATH=$PATH ./build-image-qemu.sh
+sudo -E PATH="$PATH" ./build-image-qemu.sh

--- a/Kernel/sync.sh
+++ b/Kernel/sync.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-sudo -E PATH=$PATH ./build-image-qemu.sh
+sudo -E PATH="$PATH" ./build-image-qemu.sh


### PR DESCRIPTION
Newest changes to the `makeall.sh` and `sync.sh` script broke the workflow under the WSL 2 environment, due to PATH containing locations with unescaped spaces (such as "Program Files").

This commit hopefully addresses that issue.