### PR TITLE
Add .gitignore for Ports

### DIFF
--- a/Ports/.gitignore
+++ b/Ports/.gitignore
@@ -1,0 +1,3 @@
+*/*
+!*/package.sh
+!*/patches/*


### PR DESCRIPTION
Ports folder gets easily polluted in Git, so I've added a simple .gitignore that ignores anything inside of directories except `package.sh` and `ports` dir.