### PR TITLE
LibC: open/openat: Make sure path is not a nullptr before dereferencing

### DIFF
--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -202,6 +202,10 @@ int openat_with_path_length(int dirfd, const char* path, size_t path_length, int
 
 int open(const char* path, int options, ...)
 {
+    if (!path) {
+        errno = EFAULT;
+        return -1;
+    }
     va_list ap;
     va_start(ap, options);
     auto mode = (mode_t)va_arg(ap, unsigned);
@@ -211,6 +215,10 @@ int open(const char* path, int options, ...)
 
 int openat(int dirfd, const char* path, int options, ...)
 {
+    if (!path) {
+        errno = EFAULT;
+        return -1;
+    }
     va_list ap;
     va_start(ap, options);
     auto mode = (mode_t)va_arg(ap, unsigned);
@@ -633,5 +641,4 @@ int get_process_name(char* buffer, int buffer_size)
     int rc = syscall(SC_get_process_name, buffer, buffer_size);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
-
 }


### PR DESCRIPTION
This caused the FileManager to crash when clicking between the plus sign and the folder icon in the tree view.