### PR TITLE
LibHTML: Skip over non-ascii characters

### DIFF
--- a/Libraries/LibHTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibHTML/Parser/HTMLParser.cpp
@@ -128,6 +128,11 @@ static bool parse_html_document(const StringView& html, Document& document, Pare
             return html[i + offset];
         };
         char ch = html[i];
+
+        //Skip non-ascii characters
+        if (!isascii(ch))
+            continue;
+
         switch (state) {
         case State::Free:
             if (ch == '<') {


### PR DESCRIPTION
Fixes #757