### PR TITLE
GTextEditor: Sort Selected Lines

### DIFF
--- a/Libraries/LibGUI/GTextEditor.cpp
+++ b/Libraries/LibGUI/GTextEditor.cpp
@@ -1,3 +1,4 @@
+#include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
 #include <Kernel/KeyCode.h>
 #include <LibGUI/GAction.h>
@@ -573,6 +574,31 @@ void GTextEditor::move_selected_lines_down()
     update();
 }
 
+void GTextEditor::sort_selected_lines()
+{
+    if (is_readonly())
+        return;
+
+    if (!has_selection())
+        return;
+        
+    int first_line;
+    int last_line;
+    get_selection_line_boundaries(first_line, last_line);
+
+    auto& lines = document().lines();
+
+    auto start = lines.begin() + first_line;
+    auto end = lines.begin() + last_line + 1;
+
+    quick_sort(start, end, [](auto& a, auto& b) {
+        return strcmp(a.characters(), b.characters()) < 0;
+    });
+
+    did_change();
+    update();
+}
+
 void GTextEditor::keydown_event(GKeyEvent& event)
 {
     if (is_single_line() && event.key() == KeyCode::Key_Tab)
@@ -732,7 +758,10 @@ void GTextEditor::keydown_event(GKeyEvent& event)
         select_all();
         return;
     }
-
+    if (event.alt() && event.shift() && event.key() == KeyCode::Key_S) {
+        sort_selected_lines();
+        return;
+    }
     if (event.key() == KeyCode::Key_Backspace) {
         if (is_readonly())
             return;

--- a/Libraries/LibGUI/GTextEditor.h
+++ b/Libraries/LibGUI/GTextEditor.h
@@ -167,6 +167,7 @@ private:
     void get_selection_line_boundaries(int& first_line, int& last_line);
     void move_selected_lines_up();
     void move_selected_lines_down();
+    void sort_selected_lines();
 
     class UndoCommand {
 


### PR DESCRIPTION
Hi all! This is my first pull request to any repository ever!

I'm not too familiar with the library and the way I reconstructed the lines_to_sort Vector from the lines Vector, only to put them back into lines seemed a little odd. I was hoping I could iterate over some (i, j) in the lines Vector, but there didn't seem a straightforward approach to doing this.

Addresses issue: #770