### PR TITLE
LibC: populate endian.h

### DIFF
--- a/Libraries/LibC/arpa/inet.h
+++ b/Libraries/LibC/arpa/inet.h
@@ -13,7 +13,7 @@ int inet_pton(int af, const char* src, void* dst);
 
 inline uint16_t htons(uint16_t value)
 {
-#if BYTE_ORDER == LITTLE_ENDIAN
+#if __BYTE_ORDER == __LITTLE_ENDIAN
     return __builtin_bswap16(value);
 #else
     return value;
@@ -27,7 +27,7 @@ inline uint16_t ntohs(uint16_t value)
 
 inline uint32_t htonl(uint32_t value)
 {
-#if BYTE_ORDER == LITTLE_ENDIAN
+#if __BYTE_ORDER == __LITTLE_ENDIAN
     return __builtin_bswap32(value);
 #else
     return value;

--- a/Libraries/LibC/endian.h
+++ b/Libraries/LibC/endian.h
@@ -4,8 +4,47 @@
 
 __BEGIN_DECLS
 
-#define LITTLE_ENDIAN 1234
-#define BIG_ENDIAN 4321
-#define BYTE_ORDER LITTLE_ENDIAN
+#define __LITTLE_ENDIAN	1234
+#define __BIG_ENDIAN	4321
+#define __PDP_ENDIAN	3412
+
+#if defined(__GNUC__) && defined(__BYTE_ORDER__)
+#define __BYTE_ORDER	__BYTE_ORDER__
+#else
+#include <bits/endian.h>
+#endif
+
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+
+#include <stdint.h>
+
+#define LITTLE_ENDIAN	__LITTLE_ENDIAN
+#define BIG_ENDIAN	__BIG_ENDIAN
+#define PDP_ENDIAN	__PDP_ENDIAN
+#define BYTE_ORDER	__BYTE_ORDER
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define htole16(x) (uint16_t)(x)
+#define le16toh(x) (uint16_t)(x)
+#define letoh16(x) (uint16_t)(x)
+#define htole32(x) (uint32_t)(x)
+#define le32toh(x) (uint32_t)(x)
+#define letoh32(x) (uint32_t)(x)
+#define htole64(x) (uint64_t)(x)
+#define le64toh(x) (uint64_t)(x)
+#define letoh64(x) (uint64_t)(x)
+#else
+#define htobe16(x) (uint16_t)(x)
+#define be16toh(x) (uint16_t)(x)
+#define betoh16(x) (uint16_t)(x)
+#define htobe32(x) (uint32_t)(x)
+#define be32toh(x) (uint32_t)(x)
+#define betoh32(x) (uint32_t)(x)
+#define htobe64(x) (uint64_t)(x)
+#define be64toh(x) (uint64_t)(x)
+#define betoh64(x) (uint64_t)(x)
+#endif
+
+#endif
 
 __END_DECLS


### PR DESCRIPTION
We're still missing byteswap functions, could use __built_in(s) from gcc.