### PR TITLE
LibC: Add O_ACCMODE to fcntl.h

### DIFF
--- a/Libraries/LibC/fcntl.h
+++ b/Libraries/LibC/fcntl.h
@@ -16,6 +16,7 @@ __BEGIN_DECLS
 #define O_RDONLY 0
 #define O_WRONLY 1
 #define O_RDWR 2
+#define O_ACCMODE 3
 #define O_CREAT 0100
 #define O_EXCL 0200
 #define O_NOCTTY 0400


### PR DESCRIPTION
I needed to add O_ACCMODE to get mksh (MirBSD Korn shell) to compile.