### PR TITLE
Uninterruptible, killable WaitForIRQBlocker

### DIFF
--- a/Kernel/Devices/FloppyDiskDevice.h
+++ b/Kernel/Devices/FloppyDiskDevice.h
@@ -151,9 +151,6 @@ protected:
     explicit FloppyDiskDevice(DriveType);
 
 private:
-    // ^IRQHandler
-    void handle_irq();
-
     // ^DiskDevice
     virtual const char* class_name() const override;
 
@@ -165,7 +162,6 @@ private:
     void initialize();
     bool read_sectors_with_dma(u16, u16, u8*);
     bool write_sectors_with_dma(u16, u16, const u8*);
-    bool wait_for_irq();
 
     bool is_busy() const;
     bool seek(u16);
@@ -186,7 +182,6 @@ private:
 
     Lock m_lock { "FloppyDiskDevice" };
     u16 m_io_base_addr { 0 };
-    volatile bool m_interrupted { false };
 
     DriveType m_drive_type { DriveType::Master };
     RefPtr<PhysicalPage> m_dma_buffer_page;

--- a/Kernel/Devices/PATAChannel.h
+++ b/Kernel/Devices/PATAChannel.h
@@ -49,7 +49,6 @@ private:
     void initialize(bool force_pio);
     void detect_disks();
 
-    bool wait_for_irq();
     bool ata_read_sectors_with_dma(u32, u16, u8*, bool);
     bool ata_write_sectors_with_dma(u32, u16, const u8*, bool);
     bool ata_read_sectors(u32, u16, u8*, bool);
@@ -60,7 +59,6 @@ private:
     u16 m_io_base { 0x1F0 };
     u16 m_control_base { 0 };
     volatile u8 m_device_error { 0 };
-    volatile bool m_interrupted { false };
 
     PCI::Address m_pci_address;
     PhysicalRegionDescriptor m_prdt;

--- a/Kernel/Devices/SB16.h
+++ b/Kernel/Devices/SB16.h
@@ -30,13 +30,11 @@ private:
     virtual const char* class_name() const override { return "SB16"; }
 
     void initialize();
-    void wait_for_irq();
     void dma_start(uint32_t length);
     void set_sample_rate(uint16_t hz);
     void dsp_write(u8 value);
     u8 dsp_read();
 
     RefPtr<PhysicalPage> m_dma_buffer_page;
-    bool m_interrupted { false };
     int m_major_version { 0 };
 };

--- a/Kernel/IRQHandler.cpp
+++ b/Kernel/IRQHandler.cpp
@@ -1,6 +1,7 @@
 #include "IRQHandler.h"
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/Arch/i386/PIC.h>
+#include "Thread.h"
 
 IRQHandler::IRQHandler(u8 irq)
     : m_irq_number(irq)
@@ -21,4 +22,18 @@ void IRQHandler::enable_irq()
 void IRQHandler::disable_irq()
 {
     PIC::disable(m_irq_number);
+}
+
+bool IRQHandler::wait_for_irq()
+{
+    // Wait for IRQ, uninterruptibly. That means that even if we do
+    // get unterrupted, we continue waiting instead of returning to
+    // the caller. However, we still want to be "killable" when we
+    // actually get killed, not just sent a harmless signal.
+    while (!m_interrupted) {
+        auto block_result = current->block<Thread::WaitForIRQBlocker>(*this);
+        if (block_result == Thread::BlockResult::Interrupted && current->should_die())
+            return false;
+    }
+    return true;
 }

--- a/Kernel/IRQHandler.h
+++ b/Kernel/IRQHandler.h
@@ -5,16 +5,22 @@
 class IRQHandler {
 public:
     virtual ~IRQHandler();
-    virtual void handle_irq() = 0;
+    virtual void handle_irq() { m_interrupted = true; }
 
     u8 irq_number() const { return m_irq_number; }
 
     void enable_irq();
     void disable_irq();
 
+    bool wait_for_irq();
+
+    bool was_interrupted() const { return m_interrupted; }
+
 protected:
     explicit IRQHandler(u8 irq);
+    void set_interrupted(bool interrupted) { m_interrupted = interrupted; }
 
 private:
     u8 m_irq_number { 0 };
+    volatile bool m_interrupted { false };
 };

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -250,7 +250,7 @@ ssize_t IPv4Socket::recvfrom(FileDescription& description, void* buffer, size_t 
 
         LOCKER(lock());
         if (!m_can_read) {
-            if (res == Thread::BlockResult::InterruptedBySignal)
+            if (res == Thread::BlockResult::Interrupted)
                 return -EINTR;
 
             // Unblocked due to timeout.

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -134,7 +134,7 @@ KResult LocalSocket::connect(FileDescription& description, const sockaddr* addre
         return KSuccess;
     }
 
-    if (current->block<Thread::ConnectBlocker>(description) == Thread::BlockResult::InterruptedBySignal) {
+    if (current->block<Thread::ConnectBlocker>(description) == Thread::BlockResult::Interrupted) {
         m_connect_side_role = Role::None;
         return KResult(-EINTR);
     }
@@ -251,7 +251,7 @@ ssize_t LocalSocket::recvfrom(FileDescription& description, void* buffer, size_t
         }
     } else if (!can_read(description)) {
         auto result = current->block<Thread::ReceiveBlocker>(description);
-        if (result == Thread::BlockResult::InterruptedBySignal)
+        if (result == Thread::BlockResult::Interrupted)
             return -EINTR;
     }
     if (!has_attached_peer(description) && buffer_for_me.is_empty())

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -337,7 +337,7 @@ KResult TCPSocket::protocol_connect(FileDescription& description, ShouldBlock sh
     m_direction = Direction::Outgoing;
 
     if (should_block == ShouldBlock::Yes) {
-        if (current->block<Thread::ConnectBlocker>(description) == Thread::BlockResult::InterruptedBySignal)
+        if (current->block<Thread::ConnectBlocker>(description) == Thread::BlockResult::Interrupted)
             return KResult(-EINTR);
         ASSERT(setup_state() == SetupState::Completed);
         if (has_error()) {

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -1098,7 +1098,7 @@ ssize_t Process::do_write(FileDescription& description, const u8* data, int data
 #ifdef IO_DEBUG
             dbgprintf("block write on %d\n", fd);
 #endif
-            if (current->block<Thread::WriteBlocker>(description) == Thread::BlockResult::InterruptedBySignal) {
+            if (current->block<Thread::WriteBlocker>(description) == Thread::BlockResult::Interrupted) {
                 if (nwritten == 0)
                     return -EINTR;
             }
@@ -1155,7 +1155,7 @@ ssize_t Process::sys$read(int fd, u8* buffer, ssize_t size)
         return -EISDIR;
     if (description->is_blocking()) {
         if (!description->can_read()) {
-            if (current->block<Thread::ReadBlocker>(*description) == Thread::BlockResult::InterruptedBySignal)
+            if (current->block<Thread::ReadBlocker>(*description) == Thread::BlockResult::Interrupted)
                 return -EINTR;
         }
     }
@@ -1727,7 +1727,7 @@ pid_t Process::sys$waitpid(pid_t waitee, int* wstatus, int options)
     }
 
     pid_t waitee_pid = waitee;
-    if (current->block<Thread::WaitBlocker>(options, waitee_pid) == Thread::BlockResult::InterruptedBySignal)
+    if (current->block<Thread::WaitBlocker>(options, waitee_pid) == Thread::BlockResult::Interrupted)
         return -EINTR;
 
     InterruptDisabler disabler;
@@ -2146,7 +2146,7 @@ int Process::sys$select(const Syscall::SC_select_params* params)
 #endif
 
     if (!timeout || select_has_timeout) {
-        if (current->block<Thread::SelectBlocker>(computed_timeout, select_has_timeout, rfds, wfds, efds) == Thread::BlockResult::InterruptedBySignal)
+        if (current->block<Thread::SelectBlocker>(computed_timeout, select_has_timeout, rfds, wfds, efds) == Thread::BlockResult::Interrupted)
             return -EINTR;
     }
 
@@ -2204,7 +2204,7 @@ int Process::sys$poll(pollfd* fds, int nfds, int timeout)
 #endif
 
     if (has_timeout || timeout < 0) {
-        if (current->block<Thread::SelectBlocker>(actual_timeout, has_timeout, rfds, wfds, Thread::SelectBlocker::FDVector()) == Thread::BlockResult::InterruptedBySignal)
+        if (current->block<Thread::SelectBlocker>(actual_timeout, has_timeout, rfds, wfds, Thread::SelectBlocker::FDVector()) == Thread::BlockResult::Interrupted)
             return -EINTR;
     }
 
@@ -2448,7 +2448,7 @@ int Process::sys$accept(int accepting_socket_fd, sockaddr* address, socklen_t* a
     auto& socket = *accepting_socket_description->socket();
     if (!socket.can_accept()) {
         if (accepting_socket_description->is_blocking()) {
-            if (current->block<Thread::AcceptBlocker>(*accepting_socket_description) == Thread::BlockResult::InterruptedBySignal)
+            if (current->block<Thread::AcceptBlocker>(*accepting_socket_description) == Thread::BlockResult::Interrupted)
                 return -EINTR;
         } else {
             return -EAGAIN;

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -5,6 +5,7 @@
 #include <Kernel/Process.h>
 #include <Kernel/RTC.h>
 #include <Kernel/Scheduler.h>
+#include <Kernel/IRQHandler.h>
 
 SchedulerData* g_scheduler_data;
 
@@ -232,6 +233,15 @@ bool Thread::WaitBlocker::should_unblock(Thread& thread, time_t, long)
         return IterationDecision::Break;
     });
     return should_unblock;
+}
+
+Thread::WaitForIRQBlocker::WaitForIRQBlocker(IRQHandler& handler)
+    : m_irq_handler(handler)
+{}
+
+bool Thread::WaitForIRQBlocker::should_unblock(Thread&, time_t, long)
+{
+    return m_irq_handler.was_interrupted();
 }
 
 Thread::SemiPermanentBlocker::SemiPermanentBlocker(Reason reason)

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -344,7 +344,7 @@ bool Scheduler::pick_next()
         if (was_blocked) {
             dbgprintf("Unblock %s(%u) due to signal\n", thread.process().name().characters(), thread.pid());
             ASSERT(thread.m_blocker != nullptr);
-            thread.m_blocker->set_interrupted_by_signal();
+            thread.m_blocker->set_interrupted();
             thread.unblock();
         }
         return IterationDecision::Continue;

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -203,6 +203,16 @@ public:
         pid_t& m_waitee_pid;
     };
 
+    class WaitForIRQBlocker final : public Blocker {
+    public:
+        explicit WaitForIRQBlocker(IRQHandler& handler);
+        virtual bool should_unblock(Thread&, time_t, long) override;
+        virtual const char* state_string() const override { return "Waiting for IRQ"; }
+
+    private:
+        IRQHandler& m_irq_handler;
+    };
+
     class SemiPermanentBlocker final : public Blocker {
     public:
         enum class Reason {
@@ -294,6 +304,7 @@ public:
     // Tell this thread to unblock if needed,
     // gracefully unwind the stack and die.
     void set_should_die();
+    bool should_die() { return m_should_die; }
     void die_if_needed();
 
     const FarPtr& far_ptr() const { return m_far_ptr; }

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -90,8 +90,8 @@ public:
         virtual ~Blocker() {}
         virtual bool should_unblock(Thread&, time_t now_s, long us) = 0;
         virtual const char* state_string() const = 0;
-        void set_interrupted_by_signal() { m_was_interrupted_while_blocked = true; }
-        bool was_interrupted_by_signal() const { return m_was_interrupted_while_blocked; }
+        void set_interrupted() { m_was_interrupted_while_blocked = true; }
+        bool was_interrupted() const { return m_was_interrupted_while_blocked; }
 
     private:
         bool m_was_interrupted_while_blocked { false };
@@ -253,7 +253,7 @@ public:
 
     enum class BlockResult {
         WokeNormally,
-        InterruptedBySignal,
+        Interrupted,
     };
 
     template<typename T, class... Args>
@@ -278,8 +278,8 @@ public:
         // Remove ourselves...
         m_blocker = nullptr;
 
-        if (t.was_interrupted_by_signal())
-            return BlockResult::InterruptedBySignal;
+        if (t.was_interrupted())
+            return BlockResult::Interrupted;
 
         return BlockResult::WokeNormally;
     };


### PR DESCRIPTION
I'm once again not quite sure what I'm doing, and could have broken stuff, but it seems to work so far.

The idea is to not have "completely uninterruptible" state _ever_, even when we cannot return `-EINTR` to userspace, and instead do something like `TASK_KILLABLE` in Linux — unblock, but only once we know the thread is going to die before we reach userspace.

Tell me if this is a bad idea.

cc @Quaker762 & @deoxxa