### PR TITLE
Ext2FileSystem: set_metadata_dirty(true) during write_directory().

### DIFF
--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -896,6 +896,7 @@ bool Ext2FSInode::write_directory(const Vector<FS::DirectoryEntry>& entries)
     stream.fill_to_end(0);
 
     ssize_t nwritten = write_bytes(0, directory_data.size(), directory_data.data(), nullptr);
+    set_metadata_dirty(true);
     return nwritten == directory_data.size();
 }
 


### PR DESCRIPTION
This adds a call to set_metadata_dirty(true) to
Ext2FS::write_directory(). This fixes a bug wherein InodeWatchers
weren't alerted on directory updates.

This fixes #810, but also exposes more bugs in FileManager.