### PR TITLE
Kernel: Move Kernel mapping to 0xc0000000

### DIFF
--- a/Kernel/Arch/i386/Boot/boot.S
+++ b/Kernel/Arch/i386/Boot/boot.S
@@ -34,9 +34,9 @@ stack_top:
 .section .page_tables
 .align 4096
 page_tables_start:
-.skip 4096*3
+.skip 4096*5
 
-.section .text
+.section .text.boot
 
 .global start
 .type start, @function
@@ -51,13 +51,79 @@ start:
     cli
     cld
 
+    # We first save the multiboot_info_ptr so it doesn't get trampled
+    addl $0xc0000000, %ebx
+    movl %ebx, multiboot_info_ptr - 0xc0000000
+
+    # First, let's set up the first page table to map the the first 4MiB of memory. 
+    # This makes sure we don't crash after we set CR3 and enable paging
+    movl $0x200, %ecx
+    xor %ebx, %ebx
+    movl $((page_tables_start + (4096 * 1)) - 0xc0000000), %edx
+    call make_table
+
+    # Now we create the kernel mappings. The kernel maps 0MiB -> 8MiB into its address space at 
+    # v0xc0000000. 
+    movl $0x400, %ecx
+    movl $0x0, %ebx # ebx is the base pointer (kernel base is at physical address 0 in this case)
+    movl $((page_tables_start + (4096 * 2)) - 0xc0000000), %edx
+    call make_table
+
+    movl $0x400, %ecx
+    movl $0x400000, %ebx # ebx is the base pointer (kernel base is at physical address 0 in this case)
+    movl $((page_tables_start + (4096 * 3)) - 0xc0000000), %edx
+    call make_table
+        
+    
+    # Okay, so we have a page table that contains addresses of the first 4MiB of memory. Let's insert this into the 
+    # boot page directory. The index we need to insert it into is at vaddr >> 22, which is the page directory index.
+    # This reveals that we need to insert the page directory into 0xc0000000 >> 22 = 768
+    # An interesting quirk is that we must also identity map the first 4MiB too, as the next instruction after enabling
+    # paging is at a physical address, which cause a page fault. As we have no handler, this would cause a triple fault.
+    movl $((page_tables_start + (4096 * 1)) - 0xc0000000 + 0x003), page_tables_start - 0xc0000000 + 0
+    movl $((page_tables_start + (4096 * 2)) - 0xc0000000 + 0x003), page_tables_start - 0xc0000000 + 768 * 4
+    movl $((page_tables_start + (4096 * 3)) - 0xc0000000 + 0x003), page_tables_start - 0xc0000000 + 769 * 4
+
+    # Now let's load the CR3 register with our page directory
+    movl $(page_tables_start - 0xc0000000), %ecx
+    movl %ecx, %cr3
+
+    # Let's enable paging!
+    movl %cr0, %ecx
+    orl $0x80000001, %ecx
+    movl %ecx, %cr0 
+
+    lea high_address_space_start, %ecx
+    jmp *%ecx
+
+
+# Make a page table. This is called with the following arguments:
+# ebx = base pointer of mapping
+# edx = page table physical address
+# ecx = number of pages to map
+#
+# Registers used in function
+# eax = loop counter
+make_table:
+    xorl %eax, %eax
+    .loop:
+        pushl %ecx
+        movl %ebx, %ecx
+        orl $0x3, %ecx # addr | READ_WRITE | PAGE_PRESENT
+        movl %ecx, 0(%edx, %eax, 4)
+        addl $0x1000, %ebx
+        inc %eax
+        popl %ecx
+        loop .loop
+    ret
+
+# At this point, the CPU now starts reading instructions from (virtual) address 0xc00100000 
+high_address_space_start:
     mov $stack_top, %esp
 
     and $-16, %esp
 
-    mov %ebx, multiboot_info_ptr
-
-    pushl $page_tables_start
+    pushl $(page_tables_start - 0xc0000000)
     call init
     add $4, %esp
 

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -8,6 +8,8 @@
 #define PAGE_SIZE 4096
 #define PAGE_MASK 0xfffff000
 
+static const u32 kernel_virtual_base = 0xc0000000;
+
 class MemoryManager;
 class PageTableEntry;
 
@@ -89,6 +91,7 @@ class PageDirectoryEntry {
 
 public:
     PageTableEntry* page_table_base() { return reinterpret_cast<PageTableEntry*>(m_raw & 0xfffff000u); }
+    PageTableEntry* page_table_virtual_base() { return reinterpret_cast<PageTableEntry*>((m_raw + kernel_virtual_base) & 0xfffff000u); }
     void set_page_table_base(u32 value)
     {
         m_raw &= 0xfff;

--- a/Kernel/Devices/PATAChannel.h
+++ b/Kernel/Devices/PATAChannel.h
@@ -55,6 +55,8 @@ private:
     bool ata_read_sectors(u32, u16, u8*, bool);
     bool ata_write_sectors(u32, u16, const u8*, bool);
 
+    PhysicalRegionDescriptor& prdt() { return *reinterpret_cast<PhysicalRegionDescriptor*>(m_prdt_page->paddr().as_ptr()); }
+
     // Data members
     u8 m_channel_number { 0 }; // Channel number. 0 = master, 1 = slave
     u16 m_io_base { 0x1F0 };
@@ -63,7 +65,7 @@ private:
     volatile bool m_interrupted { false };
 
     PCI::Address m_pci_address;
-    PhysicalRegionDescriptor m_prdt;
+    RefPtr<PhysicalPage> m_prdt_page;
     RefPtr<PhysicalPage> m_dma_buffer_page;
     u16 m_bus_master_base { 0 };
     Lockable<bool> m_dma_enabled;

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -107,7 +107,7 @@ CXXFLAGS += -nostdlib -nostdinc -nostdinc++
 CXXFLAGS += -I../Toolchain/Local/i686-pc-serenity/include/c++/8.3.0/
 CXXFLAGS += -I../Toolchain/Local/i686-pc-serenity/include/c++/8.3.0/i686-pc-serenity/
 DEFINES += -DKERNEL
-LDFLAGS += -Ttext 0x100000 -Wl,-T linker.ld -nostdlib
+LDFLAGS += -Wl,-T linker.ld -nostdlib
 
 all: $(KERNEL) kernel.map
 

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -1,10 +1,10 @@
 #include "VirtualConsole.h"
 #include "IO.h"
 #include "StdLib.h"
-#include <Kernel/Heap/kmalloc.h>
 #include <AK/String.h>
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/Devices/KeyboardDevice.h>
+#include <Kernel/Heap/kmalloc.h>
 
 static u8* s_vga_buffer;
 static VirtualConsole* s_consoles[6];
@@ -32,7 +32,7 @@ void VirtualConsole::flush_vga_cursor()
 
 void VirtualConsole::initialize()
 {
-    s_vga_buffer = (u8*)0xb8000;
+    s_vga_buffer = (u8*)(kernel_virtual_base + 0xb8000);
     memset(s_consoles, 0, sizeof(s_consoles));
     s_active_console = -1;
 }

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <AK/String.h>
 #include <AK/Badge.h>
 #include <AK/Bitmap.h>
 #include <AK/ByteBuffer.h>
@@ -8,6 +7,7 @@
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <AK/Weakable.h>
@@ -114,7 +114,8 @@ private:
 
     RefPtr<PageDirectory> m_kernel_page_directory;
     PageTableEntry* m_page_table_zero { nullptr };
-    PageTableEntry* m_page_table_one { nullptr };
+    PageTableEntry* m_page_table_768 { nullptr };
+    PageTableEntry* m_page_table_769 { nullptr };
 
     VirtualAddress m_quickmap_addr;
 

--- a/Kernel/VM/PageDirectory.cpp
+++ b/Kernel/VM/PageDirectory.cpp
@@ -22,7 +22,7 @@ RefPtr<PageDirectory> PageDirectory::find_by_pdb(u32 pdb)
 }
 
 PageDirectory::PageDirectory(PhysicalAddress paddr)
-    : m_range_allocator(VirtualAddress(0xc0000000), 0x3f000000)
+    : m_range_allocator(VirtualAddress(kernelspace_range_base + 0x800000), 0x3f000000)
 {
     m_directory_page = PhysicalPage::create(paddr, true, false);
     InterruptDisabler disabler;

--- a/Kernel/VM/PageDirectory.h
+++ b/Kernel/VM/PageDirectory.h
@@ -22,7 +22,7 @@ public:
     ~PageDirectory();
 
     u32 cr3() const { return m_directory_page->paddr().get(); }
-    PageDirectoryEntry* entries() { return reinterpret_cast<PageDirectoryEntry*>(cr3()); }
+    PageDirectoryEntry* entries() { return reinterpret_cast<PageDirectoryEntry*>(cr3() + kernel_virtual_base); }
 
     void flush(VirtualAddress);
 

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -252,7 +252,7 @@ void Region::map(PageDirectory& page_directory)
         pte.set_user_allowed(is_user_accessible());
         page_directory.flush(page_vaddr);
 #ifdef MM_DEBUG
-        dbgprintf("MM: >> map_region_at_address (PD=%p) '%s' V%p => P%p (@%p)\n", &page_directory, name().characters(), page_vaddr.get(), physical_page ? physical_page->paddr().get() : 0, physical_page.ptr());
+        kprintf("MM: >> map_region_at_address (PD=%p) '%s' V%p => P%p (@%p)\n", &page_directory, name().characters(), page_vaddr.get(), physical_page ? physical_page->paddr().get() : 0, physical_page.ptr());
 #endif
     }
 }

--- a/Kernel/linker.ld
+++ b/Kernel/linker.ld
@@ -2,9 +2,9 @@ ENTRY(start)
 
 SECTIONS
 {
-	. = 0x100000;
+	. = 0xc0100000;
 
-	.text BLOCK(4K) : ALIGN(4K)
+	.text ALIGN(4K) : AT(ADDR(.text) - 0xc0000000)
 	{
         Arch/i386/Boot/boot.ao
 		*(.multiboot)
@@ -13,7 +13,7 @@ SECTIONS
 		*(.text.startup)
 	}
 
-	.rodata BLOCK(4K) : ALIGN(4K)
+	.rodata ALIGN(4K) : AT(ADDR(.rodata) - 0xc0000000)
 	{
 		start_ctors = .;
 		*(.ctors)
@@ -22,12 +22,12 @@ SECTIONS
 		*(.rodata)
 	}
 
-	.data BLOCK(4K) : ALIGN(4K)
+	.data ALIGN(4K) : AT(ADDR(.data) - 0xc0000000)
 	{
 		*(.data)
 	}
 
-	.bss BLOCK(4K) : ALIGN(4K)
+	.bss ALIGN(4K) : AT(ADDR(.bss) - 0xc0000000)
 	{
 		*(COMMON)
 		*(.bss)


### PR DESCRIPTION
The kernel is now no longer identity mapped to the bottom 8MiB of
memory, and is now mapped at the higher address of `0xc0000000`.

The lower ~1MiB of memory (from GRUB's mmap), however is still
identity mapped to provide an easy way for the kernel to get
physical pages for things such as DMA etc. These could later be
mapped to the higher address too, as I'm not too sure how to
go about doing this elegantly without a lot of address subtractions.