### PR TITLE
LibC: Add fnmatch.h and glob.h

### DIFF
--- a/Libraries/LibC/fnmatch.h
+++ b/Libraries/LibC/fnmatch.h
@@ -1,0 +1,61 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 1992, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ *	@(#)fnmatch.h	8.1 (Berkeley) 6/2/93
+ */
+
+#ifndef	_FNMATCH_H_
+#define	_FNMATCH_H_
+
+#include <sys/cdefs.h>
+
+#define	FNM_NOMATCH	1	/* Match failed. */
+
+#define	FNM_NOESCAPE	0x01	/* Disable backslash escaping. */
+#define	FNM_PATHNAME	0x02	/* Slash must be matched by slash. */
+#define	FNM_PERIOD	0x04	/* Period must be matched by period. */
+
+#if __XSI_VISIBLE
+#define	FNM_NOSYS	(-1)	/* Reserved. */
+#endif
+
+#if __BSD_VISIBLE
+#define	FNM_LEADING_DIR	0x08	/* Ignore /<tail> after Imatch. */
+#define	FNM_CASEFOLD	0x10	/* Case insensitive search. */
+#define	FNM_IGNORECASE	FNM_CASEFOLD
+#define	FNM_FILE_NAME	FNM_PATHNAME
+#endif
+
+__BEGIN_DECLS
+int	 fnmatch(const char *, const char *, int);
+__END_DECLS
+
+#endif /* !_FNMATCH_H_ */

--- a/Libraries/LibC/glob.h
+++ b/Libraries/LibC/glob.h
@@ -68,7 +68,7 @@ typedef struct {
 	int (*gl_stat)(const char *, struct stat *);
 } glob_t;
 
-#if __POSIX_VISIBLE >= 199209
+//#if __POSIX_VISIBLE >= 199209
 /* Believed to have been introduced in 1003.2-1992 */
 #define	GLOB_APPEND	0x0001	/* Append to output from previous call. */
 #define	GLOB_DOOFFS	0x0002	/* Use gl_offs. */
@@ -105,4 +105,4 @@ int	glob(const char * __restrict, int,
 void	globfree(glob_t *);
 __END_DECLS
 
-#endif /* !_GLOB_H_ */
+//#endif /* !_GLOB_H_ */

--- a/Libraries/LibC/glob.h
+++ b/Libraries/LibC/glob.h
@@ -1,0 +1,108 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Guido van Rossum.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)glob.h	8.1 (Berkeley) 6/2/93
+ * $FreeBSD$
+ */
+
+#ifndef _GLOB_H_
+#define	_GLOB_H_
+
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+#ifndef	_SIZE_T_DECLARED
+typedef	__size_t	size_t;
+#define	_SIZE_T_DECLARED
+#endif
+
+struct stat;
+typedef struct {
+	size_t gl_pathc;	/* Count of total paths so far. */
+	size_t gl_matchc;	/* Count of paths matching pattern. */
+	size_t gl_offs;		/* Reserved at beginning of gl_pathv. */
+	int gl_flags;		/* Copy of flags parameter to glob. */
+	char **gl_pathv;	/* List of paths matching pattern. */
+				/* Copy of errfunc parameter to glob. */
+	int (*gl_errfunc)(const char *, int);
+
+	/*
+	 * Alternate filesystem access methods for glob; replacement
+	 * versions of closedir(3), readdir(3), opendir(3), stat(2)
+	 * and lstat(2).
+	 */
+	void (*gl_closedir)(void *);
+	struct dirent *(*gl_readdir)(void *);
+	void *(*gl_opendir)(const char *);
+	int (*gl_lstat)(const char *, struct stat *);
+	int (*gl_stat)(const char *, struct stat *);
+} glob_t;
+
+#if __POSIX_VISIBLE >= 199209
+/* Believed to have been introduced in 1003.2-1992 */
+#define	GLOB_APPEND	0x0001	/* Append to output from previous call. */
+#define	GLOB_DOOFFS	0x0002	/* Use gl_offs. */
+#define	GLOB_ERR	0x0004	/* Return on error. */
+#define	GLOB_MARK	0x0008	/* Append / to matching directories. */
+#define	GLOB_NOCHECK	0x0010	/* Return pattern itself if nothing matches. */
+#define	GLOB_NOSORT	0x0020	/* Don't sort. */
+#define	GLOB_NOESCAPE	0x2000	/* Disable backslash escaping. */
+
+/* Error values returned by glob(3) */
+#define	GLOB_NOSPACE	(-1)	/* Malloc call failed. */
+#define	GLOB_ABORTED	(-2)	/* Unignored error. */
+#define	GLOB_NOMATCH	(-3)	/* No match and GLOB_NOCHECK was not set. */
+#define	GLOB_NOSYS	(-4)	/* Obsolete: source comptability only. */
+#endif /* __POSIX_VISIBLE >= 199209 */
+
+#if __BSD_VISIBLE
+#define	GLOB_ALTDIRFUNC	0x0040	/* Use alternately specified directory funcs. */
+#define	GLOB_BRACE	0x0080	/* Expand braces ala csh. */
+#define	GLOB_MAGCHAR	0x0100	/* Pattern had globbing characters. */
+#define	GLOB_NOMAGIC	0x0200	/* GLOB_NOCHECK without magic chars (csh). */
+#define	GLOB_QUOTE	0x0400	/* Quote special chars with \. */
+#define	GLOB_TILDE	0x0800	/* Expand tilde names from the passwd file. */
+#define	GLOB_LIMIT	0x1000	/* limit number of returned paths */
+
+/* source compatibility, these are the old names */
+#define GLOB_MAXPATH	GLOB_LIMIT
+#define	GLOB_ABEND	GLOB_ABORTED
+#endif /* __BSD_VISIBLE */
+
+__BEGIN_DECLS
+int	glob(const char * __restrict, int,
+	int (*)(const char *, int), glob_t * __restrict);
+void	globfree(glob_t *);
+__END_DECLS
+
+#endif /* !_GLOB_H_ */


### PR DESCRIPTION
I'm still trying to get another shell (other than bash) ported to serenity. The latest attempt is wanting these two headers that we are missing. Are we safe to borrow them as-is from FreeBSD? Maybe some (or all) of those hex values may need adjusting? 

The only things I've changed are the filename of  sys/_types.h to sys/types.h and I've removed a check for a POSIX version definition in glob.h, which skipped most of its defines otherwise.