### PR TITLE
FileManager: Added support for deleting directories from the context menu

### DIFF
--- a/Applications/FileManager/FileUtils.h
+++ b/Applications/FileManager/FileUtils.h
@@ -2,9 +2,11 @@
 #include <AK/String.h>
 
 namespace FileUtils {
-bool copy_file_or_directory(const String& src_path, const String& dst_path);
 
+int delete_directory(String directory, String& file_that_caused_error);
+bool copy_file_or_directory(const String& src_path, const String& dst_path);
 String get_duplicate_name(const String& path, int duplicate_count);
 bool copy_file(const String& src_path, const String& dst_path, const struct stat& src_stat, int src_fd);
 bool copy_directory(const String& src_path, const String& dst_path);
+
 }


### PR DESCRIPTION
Directories can now be deleted using the "Delete..." action from the
context menu.
I hope you don't have an issue with me placing the function in the FileUtils class, I thought it will be useful for some other things in the future as well.