### PR TITLE
Smooth window resizing

### DIFF
--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -1108,6 +1108,13 @@ void WSWindowManager::set_resize_candidate(WSWindow& window, ResizeDirection dir
     m_resize_direction = direction;
 }
 
+ResizeDirection WSWindowManager::resize_direction_of_window(const WSWindow& window)
+{
+    if (&window != m_resize_window)
+        return ResizeDirection::None;
+    return m_resize_direction;
+}
+
 Rect WSWindowManager::maximized_window_rect(const WSWindow& window) const
 {
     Rect rect = WSScreen::the().rect();

--- a/Servers/WindowServer/WSWindowManager.h
+++ b/Servers/WindowServer/WSWindowManager.h
@@ -123,6 +123,7 @@ public:
 
     void set_resize_candidate(WSWindow&, ResizeDirection);
     void clear_resize_candidate();
+    ResizeDirection resize_direction_of_window(const WSWindow&);
 
     bool any_opaque_window_contains_rect(const Rect&);
     bool any_opaque_window_above_this_one_contains_rect(const WSWindow&, const Rect&);


### PR DESCRIPTION
These two changes makes window resizing much more smooth.

In particular we now pass [Raph's smooth resize test](https://raphlinus.github.io/rust/gui/2019/06/21/smooth-resize-test.html)!

It's still not as completely smooth as resizing on Wayland is; achieving that would require adding a lot more asynchrony, such as only resizing/moving a window once the client provides a new buffer of the right size.

https://github.com/SerenityOS/serenity/issues/52