### PR TITLE
Work-in-progress: AHCI Support (Booting on Q35 machine), New Disk Subsystem

### DIFF
--- a/Kernel/SeekQueue.cpp
+++ b/Kernel/SeekQueue.cpp
@@ -1,0 +1,81 @@
+#include <Kernel/SeekQueue.h>
+#include <Kernel/Thread.h>
+
+void SeekQueue::insert_request(Thread& thread, u32 namespace_id, u16 priority, u32 lbal, u32 lbah, u32 block_count, u16 flags, u8* buf)
+{
+    m_seek_requests.append(new SeekQueueEntry(entry_counter, namespace_id, priority, lbal, lbah, block_count, flags, buf, thread));
+    entry_counter++;
+}
+void SeekQueue::process_request()
+{
+}
+void SeekQueue::wake_one()
+{
+    m_seek_requests.take_first()->get_thread().unblock();
+}
+void SeekQueue::clear_all()
+{
+    wake_all();
+    m_seek_requests.clear();
+}
+void SeekQueue::wake_all()
+{
+    AK::SinglyLinkedList<SeekQueueEntry*>::Iterator iterator = m_seek_requests.begin();
+    while (!iterator.is_end) {
+        SeekQueueEntry* entry = *iterator;
+        if (entry != nullptr) {
+            entry->get_thread().unblock();
+        }
+        ++iterator;
+    }
+}
+
+SeekQueueEntry::SeekQueueEntry(u32 entry_id, u32 namespace_id, u16 priority, u32 lbal, u32 lbah, u32 block_count, u16 flags, u8* buf, Thread& thread)
+    : m_blocked_thread(thread)
+    , m_entry_id(entry_id)
+    , m_namespace_id(namespace_id)
+    , m_priority(priority)
+    , m_lbal(lbal)
+    , m_lbah(lbah)
+    , m_block_count(block_count)
+    , m_flags(flags)
+    , m_buf(buf)
+{
+}
+
+u32 SeekQueueEntry::get_entry_id()
+{
+    return m_entry_id;
+}
+u32 SeekQueueEntry::get_namespace_id()
+{
+    return m_namespace_id;
+}
+u32 SeekQueueEntry::get_priority()
+{
+    return m_priority;
+}
+u32 SeekQueueEntry::get_lba_low()
+{
+    return m_lbal;
+}
+u32 SeekQueueEntry::get_lba_high()
+{
+    return m_lbah;
+}
+u32 SeekQueueEntry::get_block_count()
+{
+    return m_block_count;
+}
+u16 SeekQueueEntry::get_flags()
+{
+    return m_flags;
+}
+u8* SeekQueueEntry::get_io_buffer()
+{
+    return m_buf;
+}
+Thread& SeekQueueEntry::get_thread()
+{
+    return m_blocked_thread;
+}

--- a/Kernel/SeekQueue.h
+++ b/Kernel/SeekQueue.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <AK/SinglyLinkedList.h>
+
+class Thread;
+
+class SeekQueueEntry {
+
+public:
+    SeekQueueEntry(u32, u32, u16, u32, u32, u32, u16, u8*, Thread&);
+    ~SeekQueueEntry();
+
+    u32 get_entry_id();
+    u32 get_namespace_id();
+    u32 get_priority();
+    u32 get_lba_low();
+    u32 get_lba_high();
+    u32 get_block_count();
+    u16 get_flags();
+    u8* get_io_buffer();
+    Thread& get_thread();
+
+private:
+    u32 m_entry_id;
+    u32 m_namespace_id;
+    u16 m_priority;
+    u32 m_lbal;
+    u32 m_lbah;
+    u32 m_block_count;
+    u16 m_flags;
+    u8* m_buf;
+    Thread& m_blocked_thread;
+};
+
+class SeekQueue {
+public:
+    SeekQueue();
+    ~SeekQueue();
+
+    void insert_request(Thread&, u32 namespace_id, u16 priority, u32 lbal, u32 lbah, u32 block_count, u16 flags, u8* buf);
+    void process_request();
+    void wake_one();
+    void wake_all();
+    void clear_all();
+
+private:
+    u32 entry_counter;
+    SinglyLinkedList<SeekQueueEntry*> m_seek_requests;
+};


### PR DESCRIPTION
Now that I have more time on hand, I'm trying to build an AHCI support.
The initial design was to use Channels and Devices. Based on some experience I decided to change the pattern - Storage Controllers & Devices.
Together with that, I'm planning to build disk detection namespace. Therefore, the disk subsystem will be a whole new subsystem.
To sum up the goals (so I won't forget):

1. Detecting Disk Controllers, enumerating them and create corresponding DiskDevice(s).
2. AHCI Support so we can boot on Q35 machine and AHCI enabled chipsets.
3. Abstracting Sector size, so each controller doesn't check what is the sector size. Each DiskDevice holds a class member with the sector size. That will enable us to use ATAPI devices (optical discs devices) in the future, or [Advanced Format drives](https://wiki.archlinux.org/index.php/Advanced_Format). 
4. Expanding LBA addressing to 48 bit, So we can use large disks (>2TB with 512 byte sectors).
5. Support parallelism in reading and writing to and from disk devices, with region locking system to prevent access to the same region from multiple threads. This includes an implementation of what Sergey tried to build at #803 together with the mindset of "what to do if there is a need for a timeout or what happens if some operation fails abruptly".
6. Some sort of initial support in ATAPI devices. Many of us still have DVD reader in their PCs, so supporting such hardware is probably a good idea.
7. Support IRQ sharing. Since we intend to support multiple controllers, this is mandatory for functioning OS using the PIC (or the I/O APIC later).

So... This PR isn't ready ofc to be merged for now.