### PR TITLE
Show repository information in 'About' application

### DIFF
--- a/Applications/About/main.cpp
+++ b/Applications/About/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
 
     auto window = GWindow::construct();
     window->set_title("About Serenity");
-    Rect window_rect { 0, 0, 240, 150 };
+    Rect window_rect { 0, 0, 240, 180 };
     window_rect.center_within(GDesktop::the().rect());
     window->set_resizable(false);
     window->set_rect(window_rect);
@@ -43,6 +43,16 @@ int main(int argc, char** argv)
     version_label->set_text(String::format("Version %s", uts.release));
     version_label->set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
     version_label->set_preferred_size(0, 11);
+
+    auto git_info_label = GLabel::construct(widget);
+    git_info_label->set_text(String::format("Built on %s@%s", GIT_BRANCH, GIT_COMMIT));
+    git_info_label->set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
+    git_info_label->set_preferred_size(0, 11);
+
+    auto git_changes_label = GLabel::construct(widget);
+    git_changes_label->set_text(String::format("Changes: %s", GIT_CHANGES));
+    git_changes_label->set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
+    git_changes_label->set_preferred_size(0, 11);
 
     auto quit_button = GButton::construct(widget);
     quit_button->set_text("Okay");

--- a/Makefile.common
+++ b/Makefile.common
@@ -40,6 +40,6 @@ LD = i686-pc-serenity-g++
 AS = i686-pc-serenity-as
 LINK = i686-pc-serenity-ld
 
-DEFINES = -DSANITIZE_PTRS -DDEBUG
+DEFINES = -DSANITIZE_PTRS -DDEBUG -DGIT_COMMIT=\"`git rev-parse --short HEAD`\" -DGIT_BRANCH=\"`git rev-parse --abbrev-ref HEAD`\" -DGIT_CHANGES=\"`git diff-index --quiet HEAD -- && echo "tracked"|| echo "untracked"`\"
 
 IPCCOMPILER = $(SERENITY_BASE_DIR)/DevTools/IPCCompiler/IPCCompiler


### PR DESCRIPTION
Fixes #832, but does not show repository name because it's not really something that git keeps track of, it's just the root source directory name. If this should be included, let me know. This allows the current diff status to be reported as well, i.e. if there are any uncommitted changes made to the source tree.

Also, if you wanted a different way for 'About' to get the repository info, let me know as well as this is really just a quick solution.

<img width="463" alt="Screen Shot 2019-12-01 at 6 13 34 PM" src="https://user-images.githubusercontent.com/47130239/69923119-dec71f00-1467-11ea-8dd3-06d9c30a681c.png">
