### PR TITLE
HackStudio: Clear selection on file open

### DIFF
--- a/Libraries/LibGUI/GTextEditor.cpp
+++ b/Libraries/LibGUI/GTextEditor.cpp
@@ -1409,6 +1409,8 @@ void GTextEditor::set_document(GTextDocument& document)
         m_line_visual_data.append(make<LineVisualData>());
     }
     m_cursor = { 0, 0 };
+    if (has_selection())
+        m_selection.clear();
     recompute_all_visual_lines();
     update();
     m_document->register_client(*this);

--- a/Libraries/LibGUI/GTextEditor.cpp
+++ b/Libraries/LibGUI/GTextEditor.cpp
@@ -1223,6 +1223,14 @@ void GTextEditor::set_selection(const GTextRange& selection)
     update();
 }
 
+void GTextEditor::clear_selection()
+{
+    if (!has_selection())
+        return;
+    m_selection.clear();
+    update();
+}
+
 void GTextEditor::recompute_all_visual_lines()
 {
     int y_offset = 0;

--- a/Libraries/LibGUI/GTextEditor.h
+++ b/Libraries/LibGUI/GTextEditor.h
@@ -69,6 +69,7 @@ public:
     bool has_selection() const { return m_selection.is_valid(); }
     String selected_text() const;
     void set_selection(const GTextRange&);
+    void clear_selection();
     bool can_undo() const { return document().can_undo(); }
     bool can_redo() const { return document().can_redo(); }
 


### PR DESCRIPTION
Currently, if you open a file in HS editor and there is some selection it will stay and you will have selection in the new opened file. This PR fixes it.