### PR TITLE
AK: Add a BinarySearch template implementation

### DIFF
--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -1,0 +1,32 @@
+#pragma once
+
+namespace AK {
+
+template<typename T>
+int integral_compare(const T& a, const T& b)
+{
+    return a - b;
+}
+
+template<typename T, typename Compare>
+T* binary_search(T* haystack, size_t haystack_size, const T& needle, Compare compare = integral_compare)
+{
+    int low = 0;
+    int high = haystack_size - 1;
+    while (low <= high) {
+        int middle = (low + high) / 2;
+        int comparison = compare(needle, haystack[middle]);
+        if (comparison < 0)
+            high = middle - 1;
+        else if (comparison > 0)
+            low = middle + 1;
+        else
+            return &haystack[middle];
+    }
+
+    return nullptr;
+}
+
+}
+
+using AK::binary_search;

--- a/AK/Tests/Makefile
+++ b/AK/Tests/Makefile
@@ -1,4 +1,4 @@
-PROGRAMS = TestAtomic TestString TestQueue TestVector TestHashMap TestJSON TestWeakPtr TestNonnullRefPtr TestRefPtr TestFixedArray TestFileSystemPath TestURL TestStringView TestUtf8 TestCircularQueue
+PROGRAMS = TestBinarySearch TestAtomic TestString TestQueue TestVector TestHashMap TestJSON TestWeakPtr TestNonnullRefPtr TestRefPtr TestFixedArray TestFileSystemPath TestURL TestStringView TestUtf8 TestCircularQueue
 
 CXXFLAGS = -std=c++17 -Wall -Wextra -ggdb3 -O2 -I../ -I../../
 
@@ -24,6 +24,9 @@ endef
 
 all: $(PROGRAMS)
 	$(foreach x,$(PROGRAMS),$(call execute-command,./$(x)))
+
+TestBinarySearch: TestBinarySearch.o $(SHARED_TEST_OBJS)
+	$(PRE_CXX) $(CXX) $(CXXFLAGS) -o $@ TestBinarySearch.o $(SHARED_TEST_OBJS)
 
 TestAtomic: TestAtomic.o $(SHARED_TEST_OBJS)
 	$(PRE_CXX) $(CXX) $(CXXFLAGS) -o $@ TestAtomic.o $(SHARED_TEST_OBJS)

--- a/AK/Tests/TestBinarySearch.cpp
+++ b/AK/Tests/TestBinarySearch.cpp
@@ -1,0 +1,82 @@
+#include <AK/TestSuite.h>
+
+#include <AK/BinarySearch.h>
+
+TEST_CASE(vector_ints)
+{
+    Vector<int> ints;
+    ints.append(1);
+    ints.append(2);
+    ints.append(3);
+
+    auto test1 = *binary_search(ints.data(), ints.size(), 1, AK::integral_compare<int>);
+    auto test2 = *binary_search(ints.data(), ints.size(), 2, AK::integral_compare<int>);
+    auto test3 = *binary_search(ints.data(), ints.size(), 3, AK::integral_compare<int>);
+    EXPECT_EQ(test1, 1);
+    EXPECT_EQ(test2, 2);
+    EXPECT_EQ(test3, 3);
+}
+
+TEST_CASE(array_doubles)
+{
+    double doubles[] = { 1.1, 9.9, 33.33 };
+
+    auto test1 = *binary_search(doubles, 3, 1.1, AK::integral_compare<double>);
+    auto test2 = *binary_search(doubles, 3, 9.9, AK::integral_compare<double>);
+    auto test3 = *binary_search(doubles, 3, 33.33, AK::integral_compare<double>);
+    EXPECT_EQ(test1, 1.1);
+    EXPECT_EQ(test2, 9.9);
+    EXPECT_EQ(test3, 33.33);
+}
+
+TEST_CASE(vector_strings)
+{
+    Vector<String> strings;
+    strings.append("bat");
+    strings.append("cat");
+    strings.append("dog");
+
+    auto string_compare = [](const String& a, const String& b) -> int {
+        return strcmp(a.characters(), b.characters());
+    };
+    auto test1 = *binary_search(strings.data(), strings.size(), String("bat"), string_compare);
+    auto test2 = *binary_search(strings.data(), strings.size(), String("cat"), string_compare);
+    auto test3 = *binary_search(strings.data(), strings.size(), String("dog"), string_compare);
+    EXPECT_EQ(test1, String("bat"));
+    EXPECT_EQ(test2, String("cat"));
+    EXPECT_EQ(test3, String("dog"));
+}
+
+TEST_CASE(single_element)
+{
+    Vector<int> ints;
+    ints.append(1);
+
+    auto test1 = *binary_search(ints.data(), ints.size(), 1, AK::integral_compare<int>);
+    EXPECT_EQ(test1, 1);
+}
+
+TEST_CASE(not_found)
+{
+    Vector<int> ints;
+    ints.append(1);
+    ints.append(2);
+    ints.append(3);
+
+    auto test1 = binary_search(ints.data(), ints.size(), -1, AK::integral_compare<int>);
+    auto test2 = binary_search(ints.data(), ints.size(), 0, AK::integral_compare<int>);
+    auto test3 = binary_search(ints.data(), ints.size(), 4, AK::integral_compare<int>);
+    EXPECT_EQ(test1, nullptr);
+    EXPECT_EQ(test2, nullptr);
+    EXPECT_EQ(test3, nullptr);
+}
+
+TEST_CASE(no_elements)
+{
+    Vector<int> ints;
+
+    auto test1 = binary_search(ints.data(), ints.size(), 1, AK::integral_compare<int>);
+    EXPECT_EQ(test1, nullptr);
+}
+
+TEST_MAIN(BinarySearch)


### PR DESCRIPTION
binary_search takes an Iterator begin and end, a key to look for and a
compare function. The compare function should return negative if a < b,
positive if a > b or 0 if a == b. The "sane default" integral_compare
implements this with subtraction a - b.
binary_search returns an Optional<Iterator> because it may not find the
key. The Iterator will be positioned at a matching element, but NOT
necessarily the FIRST matching element.

Added the following operators to Vector:
bool operator<=(const VectorIterator& other) const
VectorIterator operator+(const VectorIterator& other)
VectorIterator operator/(int value)
These are implemented in the exact same way as other methods in Vector.