### PR TITLE
HackStudio: Fixes CppLexer crashing on a comment block that does

### DIFF
--- a/DevTools/HackStudio/CppLexer.cpp
+++ b/DevTools/HackStudio/CppLexer.cpp
@@ -278,13 +278,21 @@ Vector<CppToken> CppLexer::lex()
             begin_token();
             consume();
             consume();
+            bool comment_block_ends = false;
             while (peek()) {
-                if (peek() == '*' && peek(1) == '/')
+                if (peek() == '*' && peek(1) == '/') {
+                    comment_block_ends = true;
                     break;
+                }
+
                 consume();
             }
-            consume();
-            consume();
+
+            if (comment_block_ends) {
+                consume();
+                consume();
+            }
+
             commit_token(CppToken::Type::Comment);
             continue;
         }


### PR DESCRIPTION
CppLexer expected that `/*` always has `*/` at the end. This PR
fixes the issue and assumes the rest of file is a comment.