### PR TITLE
Userland: Add the cal command

### DIFF
--- a/Userland/cal.cpp
+++ b/Userland/cal.cpp
@@ -1,21 +1,24 @@
 #include <stdio.h>
 #include <time.h>
 
-int dayOfWeek(int day, int month, int year)
+int day_of_week(int day, int month, int year)
 {
-    const int seekTable[] = { 0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4 };
+    static const int seek_table[] = { 0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4 };
     if (month < 3)
         --year;
 
-    return (year + year / 4 - year / 100 + year / 400 + seekTable[month - 1] + day) % 7;
+    return (year + year / 4 - year / 100 + year / 400 + seek_table[month - 1] + day) % 7;
 }
 
-int getNumberOfDays(int month, int year)
+int get_number_of_days(int month, int year)
 {
-    if (month == 2)
-        return ((year % 400 == 0) || (year % 4 == 0 && year % 100 != 0)) ? 29 : 30;
+    bool is_leap_year = ((year % 400 == 0) || (year % 4 == 0 && year % 100 != 0));
+    bool is_long_month = (month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12);
 
-    return (month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12) ? 31 : 30;
+    if (month == 2)
+        return is_leap_year ? 29 : 30;
+
+    return is_long_month ? 31 : 30;
 }
 
 int main(int argc, char** argv)
@@ -25,19 +28,19 @@ int main(int argc, char** argv)
 
     time_t now = time(nullptr);
     auto* tm = localtime(&now);
-    int targetDay = tm->tm_mday;
-    int targetMonth = tm->tm_mon + 1;
-    int targetYear = tm->tm_year + 1900;
-    int targetDayOfWeek = dayOfWeek(1, targetMonth, targetYear);
+    int target_day = tm->tm_mday;
+    int target_month = tm->tm_mon + 1;
+    int target_year = tm->tm_year + 1900;
+    int target_day_of_week = day_of_week(1, target_month, target_year);
 
-    printf("     %02u - %04u    \n", targetMonth, targetYear);
+    printf("     %02u - %04u    \n", target_month, target_year);
     printf("Su Mo Tu We Th Fr Sa\n");
 
-    for (int i = 1; i <= getNumberOfDays(targetMonth, targetYear); ++i) {
-        if (i < targetDayOfWeek) {
+    for (int i = 1; i <= get_number_of_days(target_month, target_year); ++i) {
+        if (i < target_day_of_week) {
             printf("  ");
         } else {
-            printf(i != targetDay ? "%2d" : "\x1b[30;47m%2d\x1b[0m", i);
+            printf(i != target_day ? "%2d" : "\x1b[30;47m%2d\x1b[0m", i);
         }
 
         printf(i % 7 == 0 ? "\n" : " ");

--- a/Userland/cal.cpp
+++ b/Userland/cal.cpp
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <time.h>
+
+int dayOfWeek(int day, int month, int year)
+{
+    const int seekTable[] = { 0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4 };
+    if (month < 3)
+        --year;
+
+    return (year + year / 4 - year / 100 + year / 400 + seekTable[month - 1] + day) % 7;
+}
+
+int getNumberOfDays(int month, int year)
+{
+    if (month == 2)
+        return ((year % 400 == 0) || (year % 4 == 0 && year % 100 != 0)) ? 29 : 30;
+
+    return (month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12) ? 31 : 30;
+}
+
+int main(int argc, char** argv)
+{
+    (void)argc;
+    (void)argv;
+
+    time_t now = time(nullptr);
+    auto* tm = localtime(&now);
+    int targetDay = tm->tm_mday;
+    int targetMonth = tm->tm_mon + 1;
+    int targetYear = tm->tm_year + 1900;
+    int targetDayOfWeek = dayOfWeek(1, targetMonth, targetYear);
+
+    printf("     %02u - %04u    \n", targetMonth, targetYear);
+    printf("Su Mo Tu We Th Fr Sa\n");
+
+    for (int i = 1; i <= getNumberOfDays(targetMonth, targetYear); ++i) {
+        if (i < targetDayOfWeek) {
+            printf("  ");
+        } else {
+            printf(i != targetDay ? "%2d" : "\x1b[30;47m%2d\x1b[0m", i);
+        }
+
+        printf(i % 7 == 0 ? "\n" : " ");
+    }
+    printf("\n\n");
+}

--- a/Userland/cal.cpp
+++ b/Userland/cal.cpp
@@ -16,7 +16,7 @@ int get_number_of_days(int month, int year)
     bool is_long_month = (month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12);
 
     if (month == 2)
-        return is_leap_year ? 29 : 30;
+        return is_leap_year ? 29 : 28;
 
     return is_long_month ? 31 : 30;
 }


### PR DESCRIPTION
This commit adds a simple `cal` command to the Userland. It is fairly basic but at least displays the current month and year as well as it highlights the current day. I've tried to clone the appearance of the GNU/Linux standard `cal` command.

I've probably messed up in a lot of ways as this is my very first contribution ever on a large, foreign project and I know nothing about C++.

Edit: I should say this was inspired by @danboid on #395 . However this obviously doesn't cover the issue. I'm starting slow and easy to see comments on this so I can start growing it and covering even the GUI part of the calendar like said in the issue :) 