### PR TITLE
Shell: Cache PATH for faster tab completion

### DIFF
--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <AK/Types.h>
+
 namespace AK {
 
 template<typename T>

--- a/Shell/LineEditor.h
+++ b/Shell/LineEditor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <AK/BinarySearch.h>
+#include <AK/QuickSort.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/Vector.h>
@@ -16,9 +18,12 @@ public:
     void add_to_history(const String&);
     const Vector<String>& history() const { return m_history; }
 
+    void cache_path();
+
 private:
     void clear_line();
     void append(const String&);
+    void cut_mismatching_chars(String& completion, const String& program, int token_length);
     void tab_complete_first_token();
     void vt_save_cursor();
     void vt_restore_cursor();
@@ -31,6 +36,8 @@ private:
     Vector<String> m_history;
     int m_history_cursor { 0 };
     int m_history_capacity { 100 };
+
+    Vector<String, 256> m_path;
 
     enum class InputState {
         Free,

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -64,7 +64,12 @@ static int sh_export(int argc, char** argv)
         return 1;
     }
 
-    return setenv(parts[0].characters(), parts[1].characters(), 1);
+    int setenv_return = setenv(parts[0].characters(), parts[1].characters(), 1);
+
+    if (setenv_return == 0 && parts[0] == "PATH")
+        editor.cache_path();
+
+    return setenv_return;
 }
 
 static int sh_unset(int argc, char** argv)
@@ -909,6 +914,8 @@ int main(int argc, char** argv)
 
     load_history();
     atexit(save_history);
+
+    editor.cache_path();
 
     for (;;) {
         auto line = editor.get_line(prompt());


### PR DESCRIPTION
This patch reduces the O(n) tab completion to something like O(log(n)).
The cache is just a sorted vector of strings and we binary search it to
get a string matching our input, and then check the surrounding strings
to see if we need to remove any characters. Also we no longer stat each
file every time.

Also added an #include in BinarySearch since it was using size_t. Oops.

But what if PATH changes? It's quite easy to just check PATH and recache
if it has changed. But what if you add a file to a directory in PATH...?