### PR TITLE
Taskbar: Add a quick launch bar

### DIFF
--- a/Applications/Taskbar/TaskbarWindow.h
+++ b/Applications/Taskbar/TaskbarWindow.h
@@ -11,6 +11,7 @@ public:
     int taskbar_height() const { return 28; }
 
 private:
+    void create_quick_launch_bar();
     void on_screen_rect_change(const Rect&);
     NonnullRefPtr<GButton> create_button(const WindowIdentifier&);
 

--- a/Applications/Taskbar/main.cpp
+++ b/Applications/Taskbar/main.cpp
@@ -1,10 +1,17 @@
 #include "TaskbarWindow.h"
 #include <LibGUI/GApplication.h>
+#include <signal.h>
 
 int main(int argc, char** argv)
 {
     GApplication app(argc, argv);
     TaskbarWindow window;
     window.show();
+
+    signal(SIGCHLD, [](int signo) {
+        (void)signo;
+        wait(nullptr);
+    });
+
     return app.exec();
 }

--- a/Base/home/anon/Taskbar.ini
+++ b/Base/home/anon/Taskbar.ini
@@ -1,0 +1,4 @@
+[QuickLaunch]
+SystemMonitor=SystemMonitor.af
+Terminal=Terminal.af
+FileManager=FileManager.af


### PR DESCRIPTION
This is a tiny bar at the left of the taskbar where you can put your most used apps to launch them with a single click. In a way, it's another replacement for the Launcher, in addition to the app menu. Unlike the launcher and the menu, it's not meant to be the primary way to launch apps; it's only a faster way to launch a few most often used utilities.

![image](https://user-images.githubusercontent.com/10091584/70145835-fb569780-16b1-11ea-8558-94502ca61f26.png)
