### PR TITLE
TextEditor: Fix bug when document is marked dirty on open.

### DIFF
--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -28,6 +28,12 @@ TextEditorWidget::TextEditorWidget()
     m_editor->set_line_wrapping_enabled(true);
 
     m_editor->on_change = [this] {
+        // Do not mark as diry on the first change (When document is first opened.)
+        if (m_document_opening) {
+            m_document_opening = false;
+            return;
+        }
+
         bool was_dirty = m_document_dirty;
         m_document_dirty = true;
         if (!was_dirty)
@@ -282,8 +288,10 @@ void TextEditorWidget::open_sesame(const String& path)
         return;
     }
 
-    m_document_dirty = false;
     m_editor->set_text(file->read_all());
+    m_document_dirty = false;
+    m_document_opening = true;
+
     set_path(FileSystemPath(path));
 }
 

--- a/Applications/TextEditor/TextEditorWidget.h
+++ b/Applications/TextEditor/TextEditorWidget.h
@@ -47,4 +47,5 @@ private:
     RefPtr<GWidget> m_find_widget;
 
     bool m_document_dirty { false };
+    bool m_document_opening { false };
 };


### PR DESCRIPTION
Currently, when `set_text()` is called on GTextDocument a change is
triggered and all clients registered get a document_did_set_text
call. This in turn causes the TextEditorWidget to mark the document
as dirty even on the first open, which makes for a weird experience.