### PR TITLE
AK: Implement %n printf specifier

### DIFF
--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -358,6 +358,11 @@ template<typename PutChFunc>
             case 'p':
                 ret += print_hex(putch, bufptr, va_arg(ap, u32), *p == 'P', true, false, true, 8);
                 break;
+
+            case 'n':
+                *va_arg(ap, int*) = ret;
+                break;
+
             default:
                 dbg() << "printf_internal: Unimplemented format specifier " << *p << " (fmt: " << fmt << ")";
             }


### PR DESCRIPTION
This is a special specifier that does not output anything to the stream, but saves the number of already output chars to the provided pointer.

This is apparently used by GNU Nano.

cc @xeons