### PR TITLE
Kernel/LibPthread: Add names to threads.

### DIFF
--- a/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Applications/SystemMonitor/ProcessModel.cpp
@@ -295,10 +295,11 @@ void ProcessModel::update()
             state.ipv4_socket_write_bytes = thread.ipv4_socket_write_bytes;
             state.file_read_bytes = thread.file_read_bytes;
             state.file_write_bytes = thread.file_write_bytes;
-            state.name = it.value.name;
             state.amount_virtual = it.value.amount_virtual;
             state.amount_resident = it.value.amount_resident;
             state.icon_id = it.value.icon_id;
+
+            state.name = thread.name;
 
             state.tid = thread.tid;
             state.times_scheduled = thread.times_scheduled;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -721,6 +721,7 @@ Optional<KBuffer> procfs$all(InodeIdentifier)
         process.for_each_thread([&](const Thread& thread) {
             auto thread_object = thread_array.add_object();
             thread_object.add("tid", thread.tid());
+            thread_object.add("name", thread.name());
             thread_object.add("times_scheduled", thread.times_scheduled());
             thread_object.add("ticks", thread.ticks());
             thread_object.add("state", thread.state_string());

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -205,6 +205,8 @@ public:
     void sys$exit_thread(void*);
     int sys$join_thread(int tid, void** exit_value);
     int sys$detach_thread(int tid);
+    int sys$set_thread_name(int tid, const char* buffer, int buffer_size);
+    int sys$get_thread_name(int tid, char* buffer, int buffer_size);
     int sys$rename(const char* oldpath, const char* newpath);
     int sys$systrace(pid_t);
     int sys$mknod(const char* pathname, mode_t, dev_t);

--- a/Kernel/Syscall.h
+++ b/Kernel/Syscall.h
@@ -142,7 +142,9 @@ typedef u32 socklen_t;
     __ENUMERATE_SYSCALL(join_thread)            \
     __ENUMERATE_SYSCALL(module_load)            \
     __ENUMERATE_SYSCALL(module_unload)          \
-    __ENUMERATE_SYSCALL(detach_thread)
+    __ENUMERATE_SYSCALL(detach_thread)          \
+    __ENUMERATE_SYSCALL(set_thread_name)        \
+    __ENUMERATE_SYSCALL(get_thread_name)
 
 namespace Syscall {
 

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -44,6 +44,7 @@ HashTable<Thread*>& thread_table()
 Thread::Thread(Process& process)
     : m_process(process)
     , m_tid(process.m_next_tid++)
+    , m_name(process.name())
 {
     dbgprintf("Thread{%p}: New thread TID=%u in %s(%u)\n", this, m_tid, process.name().characters(), process.pid());
     set_default_signal_dispositions();

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -73,6 +73,9 @@ public:
 
     String backtrace(ProcessInspectionHandle&) const;
 
+    const String& name() const { return m_name; }
+    void set_name(StringView s) { m_name = s; }
+
     void finalize();
 
     enum State : u8 {
@@ -463,6 +466,7 @@ private:
 
     FPUState* m_fpu_state { nullptr };
     State m_state { Invalid };
+    String m_name;
     ThreadPriority m_priority { ThreadPriority::Normal };
     bool m_has_used_fpu { false };
     bool m_dump_backtrace_on_finalization { false };

--- a/Libraries/LibCore/CProcessStatisticsReader.cpp
+++ b/Libraries/LibCore/CProcessStatisticsReader.cpp
@@ -46,6 +46,7 @@ HashMap<pid_t, CProcessStatistics> CProcessStatisticsReader::get_all()
             CThreadStatistics thread;
             thread.tid = thread_object.get("tid").to_u32();
             thread.times_scheduled = thread_object.get("times_scheduled").to_u32();
+            thread.name = thread_object.get("name").to_string();
             thread.state = thread_object.get("state").to_string();
             thread.ticks = thread_object.get("ticks").to_u32();
             thread.priority = thread_object.get("priority").to_string();

--- a/Libraries/LibCore/CProcessStatisticsReader.h
+++ b/Libraries/LibCore/CProcessStatisticsReader.h
@@ -20,6 +20,7 @@ struct CThreadStatistics {
     unsigned file_write_bytes;
     String state;
     String priority;
+    String name;
 };
 
 struct CProcessStatistics {

--- a/Libraries/LibPthread/pthread.cpp
+++ b/Libraries/LibPthread/pthread.cpp
@@ -23,9 +23,9 @@ constexpr size_t highest_reasonable_stack_size = 8 * MB; // That's the default i
 
 extern "C" {
 
-static int create_thread(void* (*entry)(void*), void* argument, void* stack)
+static int create_thread(void* (*entry)(void*), void* argument, void* thread_params)
 {
-    return syscall(SC_create_thread, entry, argument, stack);
+    return syscall(SC_create_thread, entry, argument, thread_params);
 }
 
 static void exit_thread(void* code)
@@ -537,4 +537,14 @@ int pthread_setspecific(pthread_key_t key, const void* value)
     t_specifics.values[key] = const_cast<void*>(value);
     return 0;
 }
+int pthread_setname_np(pthread_t thread, const char* buffer, int buffer_size)
+{
+    return syscall(SC_set_thread_name, thread, buffer, buffer_size);
 }
+
+int pthread_getname_np(pthread_t thread, char* buffer, int buffer_size)
+{
+    return syscall(SC_get_thread_name, thread, buffer, buffer_size);
+}
+
+} // extern "C"

--- a/Libraries/LibPthread/pthread.h
+++ b/Libraries/LibPthread/pthread.h
@@ -81,4 +81,7 @@ int pthread_mutexattr_init(pthread_mutexattr_t*);
 int pthread_mutexattr_settype(pthread_mutexattr_t*, int);
 int pthread_mutexattr_destroy(pthread_mutexattr_t*);
 
+int pthread_setname_np(pthread_t, const char*, int);
+int pthread_getname_np(pthread_t, char*, int);
+
 __END_DECLS

--- a/Libraries/LibThread/Thread.cpp
+++ b/Libraries/LibThread/Thread.cpp
@@ -2,9 +2,10 @@
 #include <pthread.h>
 #include <unistd.h>
 
-LibThread::Thread::Thread(Function<int()> action)
+LibThread::Thread::Thread(Function<int()> action, StringView thread_name)
     : CObject(nullptr)
     , m_action(move(action))
+    , m_thread_name(thread_name.is_null() ? "" : thread_name)
 {
 }
 
@@ -31,6 +32,10 @@ void LibThread::Thread::start()
         static_cast<void*>(this));
 
     ASSERT(rc == 0);
+    if (!m_thread_name.is_empty()) {
+        rc = pthread_setname_np(m_tid, m_thread_name.characters(), m_thread_name.length());
+        ASSERT(rc == 0);
+    }
     dbg() << "Started a thread, tid = " << m_tid;
 }
 

--- a/Libraries/LibThread/Thread.h
+++ b/Libraries/LibThread/Thread.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/String.h>
 #include <LibCore/CObject.h>
 
 namespace LibThread {
@@ -9,7 +10,7 @@ class Thread final : public CObject {
     C_OBJECT(Thread);
 
 public:
-    explicit Thread(Function<int()> action);
+    explicit Thread(Function<int()> action, StringView thread_name = nullptr);
     virtual ~Thread();
 
     void start();
@@ -18,6 +19,7 @@ public:
 private:
     Function<int()> m_action;
     int m_tid { -1 };
+    String m_thread_name;
 };
 
 }

--- a/Servers/AudioServer/ASMixer.cpp
+++ b/Servers/AudioServer/ASMixer.cpp
@@ -8,7 +8,7 @@ ASMixer::ASMixer()
     , m_sound_thread([this] {
         mix();
         return 0;
-    })
+    }, "AudioServer[mixer]")
 {
     if (!m_device->open(CIODevice::WriteOnly)) {
         dbgprintf("Can't open audio device: %s\n", m_device->error_string());


### PR DESCRIPTION
Kernel: Add thread name to Thread. The main thread of each kernel/user
process will take the name of the process. Extra threads will get a
fancy new name "ProcessName[\<tid\>]". Add the thread name to /proc/all
(should it get its own proc file?). Add two new syscalls,
set_thread_name and get_thread_name.

SystemMonitor/CProcessStatisicsReader: Incorporate the new thread names,
with system moniotor using thread name instead of duplicating process
name. Stacks also show the thread names in addtion to the tid.

LibPthread: Add wrappers for set/get_thread_name.

LibThread: Add optional thread name setting to constructor/start().

AudioServer: Name the mixer thread "AudioServer[mixer]"