### PR TITLE
LibC: fix definition of wint_t

### DIFF
--- a/Libraries/LibC/sys/types.h
+++ b/Libraries/LibC/sys/types.h
@@ -20,7 +20,7 @@ typedef int __pid_t;
 typedef int __ssize_t;
 #define ssize_t __ssize_t
 
-typedef __WINT_TYPE__ wint_t;
+typedef uint32_t wint_t;
 
 typedef uint32_t ino_t;
 typedef int32_t off_t;


### PR DESCRIPTION
__WINT_TYPE__ is not defined, change wint_t to be an unsigned int, related to #856 