### PR TITLE
LibC: Add PRIXPTR definition to inttypes.h

### DIFF
--- a/Libraries/LibC/inttypes.h
+++ b/Libraries/LibC/inttypes.h
@@ -26,3 +26,4 @@
 
 #define PRIdPTR __PRIPTR_PREFIX "d"
 #define PRIiPTR __PRIPTR_PREFIX "i"
+#define PRIXPTR __PRIPTR_PREFIX "X"


### PR DESCRIPTION
This is needed to build mgba as per https://github.com/SerenityOS/serenity/issues/850