### PR TITLE
GTreeView: prevent doubleclick with right mouse button

### DIFF
--- a/Libraries/LibGUI/GTreeView.cpp
+++ b/Libraries/LibGUI/GTreeView.cpp
@@ -94,11 +94,13 @@ void GTreeView::doubleclick_event(GMouseEvent& event)
     if (!index.is_valid())
         return;
 
-    if (selection().first() != index)
-        selection().set(index);
+    if (event.button() == GMouseButton::Left) {
+        if (selection().first() != index)
+            selection().set(index);
 
-    if (model.row_count(index))
-        toggle_index(index);
+        if (model.row_count(index))
+            toggle_index(index);
+    }
 }
 
 void GTreeView::toggle_index(const GModelIndex& index)


### PR DESCRIPTION
This follows user expectations and prevents interference with context menu
handling.