### PR TITLE
Shell: Improve tab completion, add path completion

### DIFF
--- a/Shell/LineEditor.cpp
+++ b/Shell/LineEditor.cpp
@@ -51,17 +51,11 @@ void LineEditor::cache_path()
         CDirIterator programs(directory.characters(), CDirIterator::SkipDots);
         while (programs.has_next()) {
             auto program = programs.next_path();
-
-            StringBuilder program_path;
-            program_path.append(directory.characters());
-            program_path.append('/');
-            program_path.append(program.characters());
+            String program_path = String::format("%s/%s", directory.characters(), program.characters());
             struct stat program_status;
-            int stat_error = stat(program_path.to_string().characters(), &program_status);
-            if (stat_error || !(program_status.st_mode & S_IXUSR))
-                continue;
-
-            m_path.append(program.characters());
+            int stat_error = stat(program_path.characters(), &program_status);
+            if (!stat_error && (program_status.st_mode & S_IXUSR))
+                m_path.append(program.characters());
         }
     }
 

--- a/Shell/LineEditor.h
+++ b/Shell/LineEditor.h
@@ -21,7 +21,8 @@ public:
 
 private:
     void clear_line();
-    void append(const String&);
+    void insert(const String&);
+    void insert(const char);
     void cut_mismatching_chars(String& completion, const String& program, size_t token_length);
     void tab_complete_first_token();
     void vt_save_cursor();

--- a/Shell/LineEditor.h
+++ b/Shell/LineEditor.h
@@ -3,7 +3,6 @@
 #include <AK/BinarySearch.h>
 #include <AK/QuickSort.h>
 #include <AK/String.h>
-#include <AK/StringBuilder.h>
 #include <AK/Vector.h>
 #include <LibCore/CDirIterator.h>
 #include <sys/stat.h>

--- a/Shell/LineEditor.h
+++ b/Shell/LineEditor.h
@@ -24,7 +24,7 @@ private:
     void insert(const String&);
     void insert(const char);
     void cut_mismatching_chars(String& completion, const String& program, size_t token_length);
-    void tab_complete_first_token();
+    void tab_complete_first_token(const String&);
     void vt_save_cursor();
     void vt_restore_cursor();
     void vt_clear_to_end_of_line();

--- a/Shell/LineEditor.h
+++ b/Shell/LineEditor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AK/BinarySearch.h>
+#include <AK/FileSystemPath.h>
 #include <AK/QuickSort.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
@@ -23,8 +24,9 @@ private:
     void clear_line();
     void insert(const String&);
     void insert(const char);
-    void cut_mismatching_chars(String& completion, const String& program, size_t token_length);
+    void cut_mismatching_chars(String& completion, const String& other, size_t start_compare);
     void tab_complete_first_token(const String&);
+    void tab_complete_other_token(String&);
     void vt_save_cursor();
     void vt_restore_cursor();
     void vt_clear_to_end_of_line();


### PR DESCRIPTION
The 1st commit (fb05c75) is a minor refactor of the cache_path()
function.

The 2nd commit (dafb5f4) factors out the insert/append procedure into an
overloaded function that can take a string or char. The improved tab
completion behaviour requires inserting strings at the cursor, so this
makes things much easier.

The 3rd commit (c505738) improves tab completion for programs in PATH:
- Completion can be done at the start of the line
- Completion can be done on a space
- Completion is performed relative to the cursor
- A space is added if we see no other programs (only one match)

The 4th commit (16def24) adds tab completion for paths (non-first
tokens). It behaves like this:
- If the token has a slash, everything before the slash is the directory
  to search and everything after the slash is the token to complete. If
  there is no slash, the current directory is searched and the entire
  token is completed.
- If there was only one match and it was a directory, a slash is added.
  If it's a normal file a space is added.

The full behaviour of tab completion in Bash is pretty complicated! This
is closer to it. The thing is, Bash has some quirks that I can't be
bothered with, so we might diverge.

The next step is completion for paths as the first token. We obviously
want to be able to complete this:
`./script.sh`
