### PR TITLE
LookupServer: Switch to a more privacy-respecting DNS provider

### DIFF
--- a/Base/etc/LookupServer.ini
+++ b/Base/etc/LookupServer.ini
@@ -1,2 +1,2 @@
 [DNS]
-IPAddress=8.8.8.8
+IPAddress=1.1.1.1


### PR DESCRIPTION
Faster as well in my testing, `6.992ms` average vs. `14.126ms` for Google.