### PR TITLE
FileManager: Add a context menu to the TreeView

### DIFF
--- a/Libraries/LibGUI/GTreeView.cpp
+++ b/Libraries/LibGUI/GTreeView.cpp
@@ -334,3 +334,17 @@ void GTreeView::keydown_event(GKeyEvent& event)
         return;
     }
 }
+
+void GTreeView::context_menu_event(GContextMenuEvent& event)
+{
+    if (!model())
+        return;
+    auto adjusted_position = event.position().translated(horizontal_scrollbar().value() - frame_thickness(), vertical_scrollbar().value() - frame_thickness());
+    bool is_toggle;
+    auto index = index_at_content_position(adjusted_position, is_toggle);
+    if (index.is_valid()) {
+        if (on_context_menu_request)
+            on_context_menu_request(index, event);
+    }
+    GAbstractView::context_menu_event(event);
+}

--- a/Libraries/LibGUI/GTreeView.h
+++ b/Libraries/LibGUI/GTreeView.h
@@ -18,6 +18,7 @@ protected:
     virtual void keydown_event(GKeyEvent&) override;
     virtual void did_update_selection() override;
     virtual void did_update_model() override;
+    virtual void context_menu_event(GContextMenuEvent&) override;
 
 private:
     GModelIndex index_at_content_position(const Point&, bool& is_toggle) const;


### PR DESCRIPTION
Ref: #826

This adds a context menu to the TreeView with the ability to copy/paste, create
new directories, etc. This does not address the issue mentioned above where
using the global application shortcut does not apply to whatever view has
focus.