### PR TITLE
FileManager: Clear metadata when updating filesystem model

### DIFF
--- a/Libraries/LibGUI/GFileSystemModel.cpp
+++ b/Libraries/LibGUI/GFileSystemModel.cpp
@@ -160,6 +160,8 @@ void GFileSystemModel::update()
     m_root = new Node;
     m_root->name = m_root_path;
     m_root->reify_if_needed(*this);
+
+    did_update();
 }
 
 void GFileSystemModel::cleanup()

--- a/Libraries/LibGUI/GTreeView.cpp
+++ b/Libraries/LibGUI/GTreeView.cpp
@@ -250,6 +250,7 @@ void GTreeView::scroll_into_view(const GModelIndex& a_index, Orientation orienta
 
 void GTreeView::did_update_model()
 {
+    m_view_metadata.clear();
     GAbstractView::did_update_model();
     update_content_size();
     update();


### PR DESCRIPTION
When the filesystem model is updated, it is rebuilt. This means dangling
indexes inside the TreeView metadata table will have old information and random
directories will toggle open.