### PR TITLE
Ports: Add cpp-i386-kernel

### DIFF
--- a/Ports/cpp-i386-kernel/package.sh
+++ b/Ports/cpp-i386-kernel/package.sh
@@ -1,0 +1,22 @@
+#!/bin/bash ../.port_include.sh
+port=cpp-i386-kernel
+version=git
+workdir=cpp-i386-kernel-master
+useconfigure=true
+curlopts="-L"
+linker="$SERENITY_ROOT/Toolchain/Local/bin/i686-pc-serenity-g++"
+files="https://github.com/remyabel/cpp-i386-kernel/archive/master.tar.gz cpp-i386-kernel-git.tar.gz"
+configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMakeToolchain.txt -DCMAKE_LINKER=$linker -Bbuild-output"
+
+configure() {
+    run cmake $configopts
+}
+
+build() {
+    run cmake --build build-output
+}
+
+install() {
+	mkdir -p $SERENITY_ROOT/Root/home/anon/cpp-i386-kernel
+	cp -r cpp-i386-kernel-master/* $SERENITY_ROOT/Root/home/anon/cpp-i386-kernel
+}

--- a/Ports/cpp-i386-kernel/patches/add-dummy-configure.patch
+++ b/Ports/cpp-i386-kernel/patches/add-dummy-configure.patch
@@ -1,0 +1,3 @@
+diff --git a/configure b/configure
+new file mode 100644
+index 0000000..e69de29

--- a/Ports/cpp-i386-kernel/patches/remove-configure-flag.patch
+++ b/Ports/cpp-i386-kernel/patches/remove-configure-flag.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 510e1af..6464944 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -106,7 +106,7 @@ target_compile_options(tinyprintf PRIVATE "-ffreestanding" "-nostdlib")
+ # the flags at the beginning rather than the end.
+ set(
+   CMAKE_CXX_LINK_EXECUTABLE
+-  "<CMAKE_LINKER> -T ${CMAKE_SOURCE_DIR}/linker.ld --coverage -ffreestanding -nostdlib -fno-exceptions -fno-rtti <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>"
++  "<CMAKE_LINKER> -T ${CMAKE_SOURCE_DIR}/linker.ld -ffreestanding -nostdlib -fno-exceptions -fno-rtti <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>"
+   )
+ 
+ execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=crtbegin.o


### PR DESCRIPTION
This port adds my own project (https://github.com/remyabel/cpp-i386-kernel). I
will admit this port is pretty useless since you probably can't do anything
with the binary, however it demonstrates the Serenity toolchain can be used to
cross-compile other homebrew kernels.