### PR TITLE
ProfileViewer: Make initial invert checkbox match initial tree view

### DIFF
--- a/DevTools/ProfileViewer/main.cpp
+++ b/DevTools/ProfileViewer/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
         profile->set_inverted(action.is_checked());
     });
     invert_action->set_checkable(true);
-    invert_action->set_checked(true);
+    invert_action->set_checked(false);
     view_menu->add_action(invert_action);
 
     menubar->add_menu(move(view_menu));


### PR DESCRIPTION
The "Invert tree" checkbox was accidentally defaulted to display true when the actual tree wasn't being inverted, causing the checkbox to say the opposite of the tree state initially. This change just brings the visual indicator in line with what the code is actually doing :^)

(Or I'm just being stupid and confusing which direction is the "inverted" one, who knows?)