### PR TITLE
PaintBrush: Shift key constrains the line angle

### DIFF
--- a/Applications/PaintBrush/LineTool.cpp
+++ b/Applications/PaintBrush/LineTool.cpp
@@ -3,6 +3,20 @@
 #include <LibGUI/GAction.h>
 #include <LibGUI/GMenu.h>
 #include <LibGUI/GPainter.h>
+#include <LibM/math.h>
+
+Point constrain_line_angle(const Point& start_pos, const Point& end_pos, float angle_increment)
+{
+    float current_angle = atan2(end_pos.y() - start_pos.y(), end_pos.x() - start_pos.x()) + M_PI * 2.;
+
+    float constrained_angle = ((int)((current_angle + angle_increment / 2.) / angle_increment)) * angle_increment;
+
+    auto diff = end_pos - start_pos;
+    float line_length = sqrt(diff.x() * diff.x() + diff.y() * diff.y());
+
+    return { start_pos.x() + (int)(cos(constrained_angle) * line_length),
+        start_pos.y() + (int)(sin(constrained_angle) * line_length) };
+}
 
 LineTool::LineTool()
 {
@@ -44,7 +58,12 @@ void LineTool::on_mousemove(GMouseEvent& event)
     if (!m_widget->rect().contains(event.position()))
         return;
 
-    m_line_end_position = event.position();
+    if (!m_constrain_angle) {
+        m_line_end_position = event.position();
+    } else {
+        const float ANGLE_STEP = M_PI / 8.0f;
+        m_line_end_position = constrain_line_angle(m_line_start_position, event.position(), ANGLE_STEP);
+    }
     m_widget->update();
 }
 
@@ -62,6 +81,21 @@ void LineTool::on_keydown(GKeyEvent& event)
 {
     if (event.key() == Key_Escape && m_drawing_button != GMouseButton::None) {
         m_drawing_button = GMouseButton::None;
+        m_widget->update();
+        event.accept();
+    }
+
+    if (event.key() == Key_Shift) {
+        m_constrain_angle = true;
+        m_widget->update();
+        event.accept();
+    }
+}
+
+void LineTool::on_keyup(GKeyEvent& event)
+{
+    if (event.key() == Key_Shift) {
+        m_constrain_angle = false;
         m_widget->update();
         event.accept();
     }

--- a/Applications/PaintBrush/LineTool.h
+++ b/Applications/PaintBrush/LineTool.h
@@ -16,6 +16,7 @@ public:
     virtual void on_contextmenu(GContextMenuEvent&) override;
     virtual void on_second_paint(GPaintEvent&) override;
     virtual void on_keydown(GKeyEvent&) override;
+    virtual void on_keyup(GKeyEvent&) override;
 
 private:
     virtual const char* class_name() const override { return "LineTool"; }
@@ -25,4 +26,5 @@ private:
     Point m_line_end_position;
     RefPtr<GMenu> m_context_menu;
     int m_thickness { 1 };
+    bool m_constrain_angle { false };
 };

--- a/Applications/PaintBrush/PaintableWidget.cpp
+++ b/Applications/PaintBrush/PaintableWidget.cpp
@@ -103,6 +103,13 @@ void PaintableWidget::keydown_event(GKeyEvent& event)
     GWidget::keydown_event(event);
 }
 
+void PaintableWidget::keyup_event(GKeyEvent& event)
+{
+    if (m_tool)
+        m_tool->on_keyup(event);
+    GWidget::keyup_event(event);
+}
+
 void PaintableWidget::set_primary_color(Color color)
 {
     if (m_primary_color == color)

--- a/Applications/PaintBrush/PaintableWidget.h
+++ b/Applications/PaintBrush/PaintableWidget.h
@@ -39,6 +39,7 @@ private:
     virtual void mouseup_event(GMouseEvent&) override;
     virtual void mousemove_event(GMouseEvent&) override;
     virtual void keydown_event(GKeyEvent&) override;
+    virtual void keyup_event(GKeyEvent&) override;
 
     RefPtr<GraphicsBitmap> m_bitmap;
 

--- a/Applications/PaintBrush/Tool.h
+++ b/Applications/PaintBrush/Tool.h
@@ -14,6 +14,7 @@ public:
     virtual void on_contextmenu(GContextMenuEvent&) {}
     virtual void on_second_paint(GPaintEvent&) {}
     virtual void on_keydown(GKeyEvent&) {}
+    virtual void on_keyup(GKeyEvent&) {}
 
     void clear() { m_widget = nullptr; }
     void setup(PaintableWidget& widget) { m_widget = widget.make_weak_ptr(); }


### PR DESCRIPTION
Simple feature that many other graphics editors have (MSPaint, Gimp).
Holding Shift key will constrain the line angle to 15 degrees increments. 
This angle can be changed in code, but I think 15° is a good compromise between 5° being too small, and 45° being not precise enough.