### PR TITLE
Purge all the things!

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -368,12 +368,11 @@ int Process::sys$madvise(void* address, size_t size, int advice)
 
 int Process::sys$purge()
 {
-    NonnullRefPtrVector<PurgeableVMObject> vmobjects;
+    NonnullRefPtrVector<VMObject> vmobjects;
     {
         InterruptDisabler disabler;
         MM.for_each_vmobject([&](auto& vmobject) {
-            if (vmobject.is_purgeable())
-                vmobjects.append(static_cast<PurgeableVMObject&>(vmobject));
+            vmobjects.append(vmobject);
             return IterationDecision::Continue;
         });
     }

--- a/Kernel/VM/InodeVMObject.h
+++ b/Kernel/VM/InodeVMObject.h
@@ -16,6 +16,8 @@ public:
     void inode_contents_changed(Badge<Inode>, off_t, ssize_t, const u8*);
     void inode_size_changed(Badge<Inode>, size_t old_size, size_t new_size);
 
+    int purge() override;
+
 private:
     explicit InodeVMObject(Inode&);
     explicit InodeVMObject(const InodeVMObject&);

--- a/Kernel/VM/PurgeableVMObject.cpp
+++ b/Kernel/VM/PurgeableVMObject.cpp
@@ -29,19 +29,10 @@ NonnullRefPtr<VMObject> PurgeableVMObject::clone()
 int PurgeableVMObject::purge()
 {
     LOCKER(m_paging_lock);
+
     if (!m_volatile)
         return 0;
-    int purged_page_count = 0;
-    for (size_t i = 0; i < m_physical_pages.size(); ++i) {
-        if (m_physical_pages[i])
-            ++purged_page_count;
-        m_physical_pages[i] = nullptr;
-    }
     m_was_purged = true;
 
-    for_each_region([&](auto& region) {
-        region.remap();
-    });
-
-    return purged_page_count;
+    return do_purge();
 }

--- a/Kernel/VM/PurgeableVMObject.h
+++ b/Kernel/VM/PurgeableVMObject.h
@@ -9,7 +9,7 @@ public:
     static NonnullRefPtr<PurgeableVMObject> create_with_size(size_t);
     virtual NonnullRefPtr<VMObject> clone() override;
 
-    int purge();
+    int purge() override;
 
     bool was_purged() const { return m_was_purged; }
     void set_was_purged(bool b) { m_was_purged = b; }

--- a/Kernel/VM/VMObject.cpp
+++ b/Kernel/VM/VMObject.cpp
@@ -19,3 +19,21 @@ VMObject::~VMObject()
 {
     MM.unregister_vmo(*this);
 }
+
+int VMObject::do_purge()
+{
+    LOCKER(m_paging_lock);
+
+    int purged_page_count = 0;
+    for (size_t i = 0; i < m_physical_pages.size(); ++i) {
+        if (m_physical_pages[i])
+            ++purged_page_count;
+        m_physical_pages[i] = nullptr;
+    }
+
+    for_each_region([&](auto& region) {
+        region.remap();
+    });
+
+    return purged_page_count;
+}

--- a/Kernel/VM/VMObject.h
+++ b/Kernel/VM/VMObject.h
@@ -29,6 +29,8 @@ public:
     const FixedArray<RefPtr<PhysicalPage>>& physical_pages() const { return m_physical_pages; }
     FixedArray<RefPtr<PhysicalPage>>& physical_pages() { return m_physical_pages; }
 
+    virtual int purge() { return 0; }
+
     size_t size() const { return m_physical_pages.size() * PAGE_SIZE; }
 
     // For InlineLinkedListNode

--- a/Kernel/VM/VMObject.h
+++ b/Kernel/VM/VMObject.h
@@ -44,6 +44,8 @@ protected:
     template<typename Callback>
     void for_each_region(Callback);
 
+    int do_purge();
+
     FixedArray<RefPtr<PhysicalPage>> m_physical_pages;
     Lock m_paging_lock { "VMObject" };
 


### PR DESCRIPTION
* Make malloc pages purgeable and volatile when empty
* Make shared inode mappings (in particular, executables themselves) purgeable

On a freshly booted system, this increases the number of pages `purge` prints from 30 to 659 (so over 2.5 MB).