### PR TITLE
More Build cleanup

### DIFF
--- a/Applications/About/Makefile
+++ b/Applications/About/Makefile
@@ -5,4 +5,6 @@ PROGRAM = About
 
 LDFLAGS = -lgui -ldraw -lipc -lcore -lc
 
+DEFINES += -DGIT_COMMIT=\"`git rev-parse --short HEAD`\" -DGIT_BRANCH=\"`git rev-parse --abbrev-ref HEAD`\" -DGIT_CHANGES=\"`git diff-index --quiet HEAD -- && echo "tracked"|| echo "untracked"`\"
+
 include ../../Makefile.common

--- a/Kernel/makeall.sh
+++ b/Kernel/makeall.sh
@@ -1,9 +1,4 @@
 #!/bin/sh
-if [ -z "$SERENITY_ROOT" ]; then
-    echo "You must source Toolchain/UseIt.sh to build Serenity."
-    exit 1
-fi
-
 set -e
 
 # Get user and group details for setting qemu disk image ownership

--- a/Makefile.common
+++ b/Makefile.common
@@ -65,7 +65,7 @@ endif
 #SUGGEST_FLAGS = -Wsuggest-final-types -Wsuggest-final-methods -Wsuggest-override #-Wsuggest-attribute=noreturn 
 CXXFLAGS = -MMD -MP $(WARNING_FLAGS) $(OPTIMIZATION_FLAGS) $(FLAVOR_FLAGS) $(ARCH_FLAGS) $(STANDARD_FLAGS) $(SUGGEST_FLAGS) $(INCLUDE_FLAGS) $(DEFINES) $(SUBPROJECT_CXXFLAGS)
 
-DEFINES += -DSANITIZE_PTRS -DGIT_COMMIT=\"`git rev-parse --short HEAD`\" -DGIT_BRANCH=\"`git rev-parse --abbrev-ref HEAD`\" -DGIT_CHANGES=\"`git diff-index --quiet HEAD -- && echo "tracked"|| echo "untracked"`\"
+DEFINES += -DSANITIZE_PTRS
 
 IPCCOMPILER = $(SERENITY_BASE_DIR)/DevTools/IPCCompiler/IPCCompiler
 

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-if [ -z "$SERENITY_ROOT" ]; then
-    echo "You must source UseIt.sh to build ports."
-    exit 1
-fi
 set -eu
-prefix=$(pwd)/..
+
+SCRIPT=`dirname $0`
+export SERENITY_ROOT=`realpath $SCRIPT/../`
+prefix=$SERENITY_ROOT/Ports
 
 export CC=i686-pc-serenity-gcc
 export CXX=i686-pc-serenity-g++
+export PATH=$SERENITY_ROOT/Toolchain/Local/bin:$PATH
 
 . "$@"
 shift

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -77,9 +77,9 @@ sudo apt-get install gcc-8 g++-8
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 ```
 
-Go into the `Toolchain/` directory and run the **BuildIt.sh** script. Then ***source*** the **UseIt.sh** script to put the `i686-pc-serenity` toolchain in your `$PATH`.
+Go into the `Toolchain/` directory and run the **BuildIt.sh** script.
 
-Once you've done both of those, go into the `Kernel/` directory, then run
+Once you've built the toolchain, go into the `Kernel/` directory, then run
 **./makeall.sh**, and if nothing breaks too much, take it for a spin by using
 **./run**.
 

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -16,7 +16,6 @@ echo PREFIX is "$PREFIX"
 echo SYSROOT is "$SYSROOT"
 
 mkdir -p "$DIR/Tarballs"
-source "$DIR/UseIt.sh"
 
 BINUTILS_VERSION="2.33.1"
 BINUTILS_MD5SUM="1a6b16bcc926e312633fcc3fae14ba0a"

--- a/Toolchain/UseIt.sh
+++ b/Toolchain/UseIt.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# This file will need to be run in bash, for now.
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-export PATH="$DIR/Local/bin:$PATH"
-export TOOLCHAIN="$DIR"
-export SERENITY_ROOT="$DIR/.."
-echo "$PATH"


### PR DESCRIPTION
Tested with clean `Toolchain/Build` and `Root` directories.

I left the `ReadMe` mentioning `makeall.sh` instead of `make install`, but I think moving the remaining tasks in `makeall.sh` to root-level `make` targets in the future would be much cleaner.  If nothing else, building and running Qemu stuff from `Kernel` is weird :)