### PR TITLE
LibC: Implement Itanium DSO Object Destruction API

### DIFF
--- a/Libraries/LibC/crt0.cpp
+++ b/Libraries/LibC/crt0.cpp
@@ -3,6 +3,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+//#define GLOBAL_DTORS_DEBUG
+
 extern "C" {
 
 int main(int, char**, char**);
@@ -83,11 +85,18 @@ void __cxa_finalize(void* dso_handle)
 
     int entry_index = __exit_entry_count;
 
+#ifdef GLOBAL_DTORS_DEBUG
+    dbgprintf("__cxa_finalize: %d entries in the finalizer list\n", entry_index);
+#endif
+
     while (--entry_index >= 0)
     {
         auto& exit_entry = __exit_entries[entry_index];
         bool needs_calling = !exit_entry.has_been_called && (!dso_handle || dso_handle == exit_entry.dso_handle);
         if (needs_calling) {
+#ifdef GLOBAL_DTORS_DEBUG
+            dbgprintf("__cxa_finalize: calling entry[%d] %p(%p) dso: %p\n", entry_index, exit_entry.method, exit_entry.parameter, exit_entry.dso_handle);
+#endif
             exit_entry.method(exit_entry.parameter);
             exit_entry.has_been_called = true;
         }

--- a/Libraries/LibC/crt0.cpp
+++ b/Libraries/LibC/crt0.cpp
@@ -49,8 +49,49 @@ int _start(int argc, char** argv, char** env)
     ASSERT_NOT_REACHED();
 }
 
-void __cxa_atexit()
+typedef void (*AtExitFunction)(void *);
+
+struct __exit_entry
 {
+    AtExitFunction method;
+    void* parameter;
+    void* dso_handle;
+    bool has_been_called;
+};
+
+static __exit_entry __exit_entries[1024]{};
+static int __exit_entry_count = 0;
+
+int __cxa_atexit(AtExitFunction exit_function, void *parameter, void *dso_handle)
+{
+    if (__exit_entry_count >= 1024)
+        return -1;
+
+    __exit_entries[__exit_entry_count++] = { exit_function, parameter, dso_handle, false};
+
+    return 0;
+}
+
+void __cxa_finalize(void* dso_handle)
+{
+    // From the itanium abi, https://itanium-cxx-abi.github.io/cxx-abi/abi.html#dso-dtor-runtime-api
+    //
+    // When __cxa_finalize(d) is called, it should walk the termination function list, calling each in turn
+    // if d matches __dso_handle for the termination function entry. If d == NULL, it should call all of them.
+    // Multiple calls to __cxa_finalize shall not result in calling termination function entries multiple times;
+    // the implementation may either remove entries or mark them finished.
+
+    int entry_index = __exit_entry_count;
+
+    while (--entry_index >= 0)
+    {
+        auto& exit_entry = __exit_entries[entry_index];
+        bool needs_calling = !exit_entry.has_been_called && (!dso_handle || dso_handle == exit_entry.dso_handle);
+        if (needs_calling) {
+            exit_entry.method(exit_entry.parameter);
+            exit_entry.has_been_called = true;
+        }
+    }
 }
 
 extern u32 __stack_chk_guard;

--- a/Libraries/LibGUI/GWidget.cpp
+++ b/Libraries/LibGUI/GWidget.cpp
@@ -50,7 +50,6 @@ GWidgetClassRegistration::GWidgetClassRegistration(const String& class_name, Fun
 
 GWidgetClassRegistration::~GWidgetClassRegistration()
 {
-    ASSERT_NOT_REACHED();
 }
 
 void GWidgetClassRegistration::for_each(Function<void(const GWidgetClassRegistration&)> callback)


### PR DESCRIPTION
Implement __cxa_atexit and __cxa_finalize per the Itanium ABI spec. This allows serenity C++ programs to have globals with non-trivial destructors, and also lays some groundwork for dynamic linking in Userspace.

https://itanium-cxx-abi.github.io/cxx-abi/abi.html#dso-dtor

Also, get rid of the exit time destructor in LibGUI that causes every GUI app to ASSERT on exit :)

Unfortunately, the file static Allocators that the malloc implementation uses are not trivially destructible, so we have to guard against things trying to be free'd/allocated after they are destroyed. Now each Allocator has a "destroyed" flag that needs checked before interacting with it in malloc/free. If the chosen allocator has been destroyed in malloc, we panic, but in free, since the process is being destroyed anyway it's ok to not do as much bookkeeping as we might like.

