### PR TITLE
Piano: Add piano roll

### DIFF
--- a/Applications/Piano/PianoWidget.cpp
+++ b/Applications/Piano/PianoWidget.cpp
@@ -78,10 +78,7 @@ void PianoWidget::fill_audio_buffer(uint8_t* stream, int len)
                 val = ((volume * m_power[n]) * w_triangle(n));
             else if (m_wave_type == WaveType::Noise)
                 val = ((volume * m_power[n]) * w_noise());
-            if (sst[i].left == 0)
-                sst[i].left = val;
-            else
-                sst[i].left += val;
+            sst[i].left += val;
         }
         sst[i].right = sst[i].left;
     }

--- a/Applications/Piano/PianoWidget.h
+++ b/Applications/Piano/PianoWidget.h
@@ -28,13 +28,24 @@ private:
     double w_triangle(size_t);
     double w_noise();
 
+    struct RollNote {
+        bool pressed;
+        bool playing;
+    };
+
     Rect define_piano_key_rect(int index, PianoKey) const;
     PianoKey find_key_for_relative_position(int x, int y) const;
+    Rect define_roll_note_rect(int column, int row) const;
+    RollNote* find_roll_note_for_relative_position(int x, int y);
 
     void render_piano_key(GPainter&, int index, PianoKey, const StringView&);
     void render_piano(GPainter&);
     void render_knobs(GPainter&);
     void render_knob(GPainter&, const Rect&, bool state, const StringView&);
+    void render_roll_note(GPainter&, int column, int row, PianoKey);
+    void render_roll(GPainter&);
+
+    void change_roll_column();
 
     enum SwitchNote {
         Off,
@@ -73,4 +84,9 @@ private:
 
     PianoKey m_piano_key_under_mouse { K_None };
     bool m_mouse_pressed { false };
+
+    RollNote m_roll_notes[20][32] { { false, false } };
+
+    int m_time { 0 };
+    int m_tick { 10 };
 };

--- a/Applications/Piano/PianoWidget.h
+++ b/Applications/Piano/PianoWidget.h
@@ -36,8 +36,13 @@ private:
     void render_knobs(GPainter&);
     void render_knob(GPainter&, const Rect&, bool state, const StringView&);
 
-    void note(Music::PianoKey offset_n, KeyCode key_code);
-    void update_keys();
+    enum SwitchNote {
+        Off,
+        On
+    };
+    void note(KeyCode, SwitchNote);
+    void note(PianoKey, SwitchNote);
+
     int octave_base() const;
 
     int m_sample_count { 0 };
@@ -46,7 +51,7 @@ private:
 
 #define note_count sizeof(note_frequency) / sizeof(double)
 
-    bool m_note_on[note_count];
+    u8 m_note_on[note_count];
     double m_power[note_count];
     double m_sin_pos[note_count];
     double m_square_pos[note_count];


### PR DESCRIPTION
This is a very basic piano roll that just lets you draw notes.
The previous code has been modified so that the piano roll and piano keys can be played at the same time without interrupting each other. Also, the piano roll and delay are locked to the same timing.