### PR TITLE
Kernel: Move ring0 stacks out of kmalloc_eternal

### DIFF
--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -104,12 +104,12 @@ static void load_ksyms_from_data(const ByteBuffer& buffer)
     RecognizedSymbol recognized_symbols[max_recognized_symbol_count];
     int recognized_symbol_count = 0;
     if (use_ksyms) {
-        for (u32* stack_ptr = (u32*)ebp; current->process().validate_read_from_kernel(VirtualAddress((u32)stack_ptr)) && recognized_symbol_count < max_recognized_symbol_count; stack_ptr = (u32*)*stack_ptr) {
+        for (u32* stack_ptr = (u32*)ebp; current->process().validate_read_from_kernel(VirtualAddress((u32)stack_ptr), sizeof(void*) * 2) && recognized_symbol_count < max_recognized_symbol_count; stack_ptr = (u32*)*stack_ptr) {
             u32 retaddr = stack_ptr[1];
             recognized_symbols[recognized_symbol_count++] = { retaddr, ksymbolicate(retaddr) };
         }
     } else {
-        for (u32* stack_ptr = (u32*)ebp; current->process().validate_read_from_kernel(VirtualAddress((u32)stack_ptr)); stack_ptr = (u32*)*stack_ptr) {
+        for (u32* stack_ptr = (u32*)ebp; current->process().validate_read_from_kernel(VirtualAddress((u32)stack_ptr), sizeof(void*) * 2); stack_ptr = (u32*)*stack_ptr) {
             u32 retaddr = stack_ptr[1];
             dbgprintf("%x (next: %x)\n", retaddr, stack_ptr ? (u32*)*stack_ptr : 0);
         }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -1896,7 +1896,7 @@ static KernelMemoryCheckResult check_kernel_memory_access(VirtualAddress vaddr, 
     return KernelMemoryCheckResult::NotInsideKernelMemory;
 }
 
-bool Process::validate_read_from_kernel(VirtualAddress vaddr) const
+bool Process::validate_read_from_kernel(VirtualAddress vaddr, ssize_t size) const
 {
     if (vaddr.is_null())
         return false;
@@ -1909,7 +1909,7 @@ bool Process::validate_read_from_kernel(VirtualAddress vaddr) const
         return false;
     if (is_kmalloc_address(vaddr.as_ptr()))
         return true;
-    return validate_read(vaddr.as_ptr(), 1);
+    return validate_read(vaddr.as_ptr(), size);
 }
 
 bool Process::validate_read_str(const char* str)

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -255,7 +255,7 @@ public:
     u32 m_ticks_in_user_for_dead_children { 0 };
     u32 m_ticks_in_kernel_for_dead_children { 0 };
 
-    bool validate_read_from_kernel(VirtualAddress) const;
+    bool validate_read_from_kernel(VirtualAddress, ssize_t) const;
 
     bool validate_read(const void*, ssize_t) const;
     bool validate_write(void*, ssize_t) const;

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -85,6 +85,7 @@ Thread::Thread(Process& process)
 
     if (m_process.is_ring0()) {
         m_kernel_stack_region = MM.allocate_kernel_region(default_kernel_stack_size, String::format("Kernel Stack (Thread %d; Ring0)", m_tid), false, true);
+        m_kernel_stack_region->set_stack(true);
         m_kernel_stack_base = m_kernel_stack_region->vaddr().get();
         m_kernel_stack_top = m_kernel_stack_region->vaddr().offset(default_kernel_stack_size).get() & 0xfffffff8u;
         m_tss.esp = m_kernel_stack_top;
@@ -92,6 +93,7 @@ Thread::Thread(Process& process)
     } else {
         // Ring3 processes need a separate stack for Ring0.
         m_kernel_stack_region = MM.allocate_kernel_region(default_kernel_stack_size, String::format("Kernel Stack (Thread %d; Ring3)", m_tid), false, true);
+        m_kernel_stack_region->set_stack(true);
         m_kernel_stack_base = m_kernel_stack_region->vaddr().get();
         m_kernel_stack_top = m_kernel_stack_region->vaddr().offset(default_kernel_stack_size).get() & 0xfffffff8u;
         m_tss.ss0 = 0x10;

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -708,7 +708,7 @@ String Thread::backtrace_impl() const
     StringBuilder builder;
     Vector<RecognizedSymbol, 64> recognized_symbols;
     recognized_symbols.append({ tss().eip, ksymbolicate(tss().eip) });
-    for (u32* stack_ptr = (u32*)frame_ptr(); process.validate_read_from_kernel(VirtualAddress((u32)stack_ptr)); stack_ptr = (u32*)*stack_ptr) {
+    for (u32* stack_ptr = (u32*)frame_ptr(); process.validate_read_from_kernel(VirtualAddress((u32)stack_ptr), sizeof(void*) * 2); stack_ptr = (u32*)*stack_ptr) {
         u32 retaddr = stack_ptr[1];
         recognized_symbols.append({ retaddr, ksymbolicate(retaddr) });
     }
@@ -738,7 +738,7 @@ Vector<u32> Thread::raw_backtrace(u32 ebp) const
     ProcessPagingScope paging_scope(process);
     Vector<u32> backtrace;
     backtrace.append(ebp);
-    for (u32* stack_ptr = (u32*)ebp; process.validate_read_from_kernel(VirtualAddress((u32)stack_ptr)); stack_ptr = (u32*)*stack_ptr) {
+    for (u32* stack_ptr = (u32*)ebp; process.validate_read_from_kernel(VirtualAddress((u32)stack_ptr), sizeof(void*) * 2); stack_ptr = (u32*)*stack_ptr) {
         u32 retaddr = stack_ptr[1];
         backtrace.append(retaddr);
     }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -84,20 +84,21 @@ Thread::Thread(Process& process)
     m_tss.cr3 = m_process.page_directory().cr3();
 
     if (m_process.is_ring0()) {
-        // FIXME: This memory is leaked.
-        // But uh, there's also no kernel process termination, so I guess it's not technically leaked...
-        m_kernel_stack_base = (u32)kmalloc_eternal(default_kernel_stack_size);
-        m_kernel_stack_top = (m_kernel_stack_base + default_kernel_stack_size) & 0xfffffff8u;
+        m_kernel_stack_region = MM.allocate_kernel_region(default_kernel_stack_size, String::format("Kernel Stack (Thread %d; Ring0)", m_tid), false, true);
+        m_kernel_stack_base = m_kernel_stack_region->vaddr().get();
+        m_kernel_stack_top = m_kernel_stack_region->vaddr().offset(default_kernel_stack_size).get() & 0xfffffff8u;
         m_tss.esp = m_kernel_stack_top;
-
+        kprintf("Allocated ring0 stack @ %p - %p\n", m_kernel_stack_base, m_kernel_stack_top);
     } else {
         // Ring3 processes need a separate stack for Ring0.
-        m_kernel_stack_region = MM.allocate_kernel_region(default_kernel_stack_size, String::format("Kernel Stack (Thread %d)", m_tid));
+        m_kernel_stack_region = MM.allocate_kernel_region(default_kernel_stack_size, String::format("Kernel Stack (Thread %d; Ring3)", m_tid), false, true);
         m_kernel_stack_base = m_kernel_stack_region->vaddr().get();
         m_kernel_stack_top = m_kernel_stack_region->vaddr().offset(default_kernel_stack_size).get() & 0xfffffff8u;
         m_tss.ss0 = 0x10;
         m_tss.esp0 = m_kernel_stack_top;
+        kprintf("Allocated ring3 stack @ %p - %p\n", m_kernel_stack_base, m_kernel_stack_top);
     }
+    m_process.page_directory().update_kernel_mappings();
 
     // HACK: Ring2 SS in the TSS is the current PID.
     m_tss.ss2 = m_process.pid();

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -84,7 +84,7 @@ Thread::Thread(Process& process)
     m_tss.cr3 = m_process.page_directory().cr3();
 
     if (m_process.is_ring0()) {
-        m_kernel_stack_region = MM.allocate_kernel_region(default_kernel_stack_size, String::format("Kernel Stack (Thread %d; Ring0)", m_tid), false, true);
+        m_kernel_stack_region = MM.allocate_kernel_region(default_kernel_stack_size, String::format("Kernel Stack (Thread %d)", m_tid), false, true);
         m_kernel_stack_region->set_stack(true);
         m_kernel_stack_base = m_kernel_stack_region->vaddr().get();
         m_kernel_stack_top = m_kernel_stack_region->vaddr().offset(default_kernel_stack_size).get() & 0xfffffff8u;
@@ -92,13 +92,13 @@ Thread::Thread(Process& process)
         kprintf("Allocated ring0 stack @ %p - %p\n", m_kernel_stack_base, m_kernel_stack_top);
     } else {
         // Ring3 processes need a separate stack for Ring0.
-        m_kernel_stack_region = MM.allocate_kernel_region(default_kernel_stack_size, String::format("Kernel Stack (Thread %d; Ring3)", m_tid), false, true);
+        m_kernel_stack_region = MM.allocate_kernel_region(default_kernel_stack_size, String::format("Kernel Stack (Thread %d)", m_tid), false, true);
         m_kernel_stack_region->set_stack(true);
         m_kernel_stack_base = m_kernel_stack_region->vaddr().get();
         m_kernel_stack_top = m_kernel_stack_region->vaddr().offset(default_kernel_stack_size).get() & 0xfffffff8u;
         m_tss.ss0 = 0x10;
         m_tss.esp0 = m_kernel_stack_top;
-        kprintf("Allocated ring3 stack @ %p - %p\n", m_kernel_stack_base, m_kernel_stack_top);
+        kprintf("Allocated ring0 stack @ %p - %p\n", m_kernel_stack_base, m_kernel_stack_top);
     }
     m_process.page_directory().update_kernel_mappings();
 


### PR DESCRIPTION
This allows us to use all the same fun memory protection features as the
rest of the system for ring0 processes. Previously a ring0 process could
over- or underrun its stack and nobody cared, since kmalloc_eternal is the
wild west of memory.

There are two other small changes to memory-related functions as well.