### PR TITLE
Kernel: Implement recursion limit on path resolution

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -88,7 +88,7 @@ public:
     void sync();
 
     Custody& root_custody();
-    KResultOr<NonnullRefPtr<Custody>> resolve_path(StringView path, Custody& base, RefPtr<Custody>* parent = nullptr, int options = 0);
+    KResultOr<NonnullRefPtr<Custody>> resolve_path(StringView path, Custody& base, RefPtr<Custody>* parent = nullptr, int options = 0, int symlink_recursion_level = 0);
 
 private:
     friend class FileDescription;


### PR DESCRIPTION
From the man pages:
> As currently implemented on Linux, the maximum number of symbolic
> links that will be followed while resolving a pathname is 40. In
> kernels before 2.6.18, the limit on the recursion depth was 5.
> Starting with Linux 2.6.18, this limit was raised to 8. In Linux
> 4.2, the kernel's pathname-resolution code was reworked to eliminate
> the use of recursion, so that the only limit that remains is the
> maximum of 40 resolutions for the entire pathname.

Cautiously use 5 as a limit for now.