### PR TITLE
Build: better dependency tracking

### DIFF
--- a/Applications/About/Makefile
+++ b/Applications/About/Makefile
@@ -3,7 +3,7 @@ OBJS = \
 
 PROGRAM = About
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI Draw IPC Core
 
 DEFINES += -DGIT_COMMIT=\"`git rev-parse --short HEAD`\" -DGIT_BRANCH=\"`git rev-parse --abbrev-ref HEAD`\" -DGIT_CHANGES=\"`git diff-index --quiet HEAD -- && echo "tracked"|| echo "untracked"`\"
 

--- a/Applications/Browser/Makefile
+++ b/Applications/Browser/Makefile
@@ -3,6 +3,10 @@ OBJS = \
 
 PROGRAM = Browser
 
-LDFLAGS = -lgui -lhtml -ldraw -lprotocol -lipc -lcore -lc
+LIB_DEPS = GUI HTML Draw IPC Protocol Core
+
+main.cpp: ../../Libraries/LibHTML/CSS/PropertyID.h
+../../Libraries/LibHTML/CSS/PropertyID.h:
+	@$(MAKE) -C ../../Libraries/LibHTML
 
 include ../../Makefile.common

--- a/Applications/Calculator/Makefile
+++ b/Applications/Calculator/Makefile
@@ -6,6 +6,6 @@ OBJS = \
 
 PROGRAM = Calculator
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI Draw IPC Core
 
 include ../../Makefile.common

--- a/Applications/ChanViewer/Makefile
+++ b/Applications/ChanViewer/Makefile
@@ -5,6 +5,6 @@ OBJS = \
 
 PROGRAM = ChanViewer
 
-LDFLAGS = -lgui -ldraw -lipc -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI Draw IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/DisplayProperties/Makefile
+++ b/Applications/DisplayProperties/Makefile
@@ -4,6 +4,6 @@ OBJS = \
 
 PROGRAM = DisplayProperties
 
-LDFLAGS = -lgui -ldraw -lipc -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI Draw IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/FileManager/Makefile
+++ b/Applications/FileManager/Makefile
@@ -6,6 +6,6 @@ OBJS = \
 
 PROGRAM = FileManager
 
-LDFLAGS = -lgui -ldraw -lipc -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI Draw IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/FontEditor/Makefile
+++ b/Applications/FontEditor/Makefile
@@ -6,12 +6,12 @@ OBJS = \
 
 PROGRAM = FontEditor
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI Draw Core IPC
 
 FontEditor.cpp: UI_FontEditorBottom.h
 
-UI_FontEditorBottom.h: FontEditorBottom.frm
-	../../DevTools/FormCompiler/FormCompiler $< > $@
+UI_FontEditorBottom.h: FontEditorBottom.frm FORMCOMPILER
+	$(QUIET) $(FORMCOMPILER) $< > $@
 
 EXTRA_CLEAN = UI_FontEditorBottom.h
 

--- a/Applications/Help/Makefile
+++ b/Applications/Help/Makefile
@@ -7,6 +7,6 @@ OBJS = \
 
 PROGRAM = Help
 
-LDFLAGS = -lgui -lhtml -lmarkdown -ldraw -lipc -lprotocol -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI HTML Draw Markdown IPC Protocol Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/HexEditor/Makefile
+++ b/Applications/HexEditor/Makefile
@@ -5,6 +5,6 @@ OBJS = \
 
 PROGRAM = HexEditor
 
-LDFLAGS = -lgui -ldraw -lipc -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI Draw IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/IRCClient/Makefile
+++ b/Applications/IRCClient/Makefile
@@ -11,6 +11,6 @@ OBJS = \
 
 PROGRAM = IRCClient
 
-LDFLAGS = -lgui -lhtml -ldraw -lprotocol -lipc -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI HTML Draw Protocol IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/PaintBrush/Makefile
+++ b/Applications/PaintBrush/Makefile
@@ -14,6 +14,6 @@ OBJS = \
 
 PROGRAM = PaintBrush
 
-LDFLAGS = -lgui -ldraw -lipc -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI Draw IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/Piano/Makefile
+++ b/Applications/Piano/Makefile
@@ -4,6 +4,6 @@ OBJS = \
 
 PROGRAM = Piano
 
-LDFLAGS = -lgui -ldraw -laudio -lipc -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI Draw Audio IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/QuickShow/Makefile
+++ b/Applications/QuickShow/Makefile
@@ -4,6 +4,6 @@ OBJS = \
 
 PROGRAM = QuickShow
 
-LDFLAGS = -lgui -ldraw -lprotocol -lipc -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI Draw Protocol IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/SoundPlayer/Makefile
+++ b/Applications/SoundPlayer/Makefile
@@ -6,6 +6,6 @@ OBJS = \
 
 PROGRAM = SoundPlayer
 
-LDFLAGS = -lgui -ldraw -laudio -lipc -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI Draw Audio IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/SystemDialog/Makefile
+++ b/Applications/SystemDialog/Makefile
@@ -3,6 +3,6 @@ OBJS = \
 
 PROGRAM = SystemDialog
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI Draw IPC Core
 
 include ../../Makefile.common

--- a/Applications/SystemMonitor/Makefile
+++ b/Applications/SystemMonitor/Makefile
@@ -12,6 +12,6 @@ OBJS = \
 
 PROGRAM = SystemMonitor
 
-LDFLAGS = -lgui -ldraw -lprotocol -lpcidb -lipc -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI Draw Protocol PCIDB IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/Taskbar/Makefile
+++ b/Applications/Taskbar/Makefile
@@ -6,6 +6,6 @@ OBJS = \
 
 PROGRAM = Taskbar
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI Draw IPC Core
 
 include ../../Makefile.common

--- a/Applications/Terminal/Makefile
+++ b/Applications/Terminal/Makefile
@@ -3,6 +3,6 @@ OBJS = \
 
 PROGRAM = Terminal
 
-LDFLAGS = -lgui -ldraw -lvt -lprotocol -lipc -lcore -lc
+LIB_DEPS = GUI Draw VT IPC Protocol Core
 
 include ../../Makefile.common

--- a/Applications/TextEditor/Makefile
+++ b/Applications/TextEditor/Makefile
@@ -4,6 +4,6 @@ OBJS = \
 
 PROGRAM = TextEditor
 
-LDFLAGS = -lgui -ldraw -lvt -lipc -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI Draw VT IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/Applications/Welcome/Makefile
+++ b/Applications/Welcome/Makefile
@@ -5,7 +5,7 @@ OBJS = \
 
 PROGRAM = Welcome
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI Draw IPC Core
 
 .SUFFIXES: .png
 %.png.o: %.png

--- a/Demos/Fire/Makefile
+++ b/Demos/Fire/Makefile
@@ -3,6 +3,6 @@ OBJS = \
 
 PROGRAM = Fire
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI IPC Draw Core
 
 include ../../Makefile.common

--- a/Demos/HelloWorld/Makefile
+++ b/Demos/HelloWorld/Makefile
@@ -3,6 +3,6 @@ OBJS = \
 
 PROGRAM = HelloWorld
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI IPC Draw Core
 
 include ../../Makefile.common

--- a/Demos/HelloWorld2/Makefile
+++ b/Demos/HelloWorld2/Makefile
@@ -3,7 +3,7 @@ OBJS = \
 
 PROGRAM = HelloWorld2
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI IPC Draw Core
 
 main.cpp: UI_HelloWorld2.h
 

--- a/Demos/WidgetGallery/Makefile
+++ b/Demos/WidgetGallery/Makefile
@@ -3,6 +3,6 @@ OBJS = \
 
 PROGRAM = WidgetGallery
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI IPC Draw Core
 
 include ../../Makefile.common

--- a/DevTools/HackStudio/Makefile
+++ b/DevTools/HackStudio/Makefile
@@ -18,6 +18,6 @@ OBJS = \
 
 PROGRAM = HackStudio
 
-LDFLAGS = -lvt -lhtml -lprotocol -lipc -lmarkdown -lgui -ldraw -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI HTML VT Protocol Markdown Draw IPC Thread Pthread Core
 
 include ../../Makefile.common

--- a/DevTools/Inspector/Makefile
+++ b/DevTools/Inspector/Makefile
@@ -7,6 +7,6 @@ OBJS = \
 
 PROGRAM = Inspector
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI Draw IPC Core
 
 include ../../Makefile.common

--- a/DevTools/ProfileViewer/Makefile
+++ b/DevTools/ProfileViewer/Makefile
@@ -6,6 +6,6 @@ OBJS = \
 
 PROGRAM = ProfileViewer
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI Draw IPC Core
 
 include ../../Makefile.common

--- a/DevTools/VisualBuilder/Makefile
+++ b/DevTools/VisualBuilder/Makefile
@@ -9,6 +9,6 @@ OBJS = \
 
 PROGRAM = VisualBuilder
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI Draw IPC Core
 
 include ../../Makefile.common

--- a/Games/Minesweeper/Makefile
+++ b/Games/Minesweeper/Makefile
@@ -4,6 +4,6 @@ OBJS = \
 
 PROGRAM = Minesweeper
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI IPC Draw Core
 
 include ../../Makefile.common

--- a/Games/Snake/Makefile
+++ b/Games/Snake/Makefile
@@ -4,6 +4,6 @@ OBJS = \
 
 PROGRAM = Snake
 
-LDFLAGS = -lgui -ldraw -lipc -lcore -lc
+LIB_DEPS = GUI IPC Draw Core
 
 include ../../Makefile.common

--- a/Libraries/LibAudio/Makefile
+++ b/Libraries/LibAudio/Makefile
@@ -4,6 +4,10 @@ OBJS = \
 
 LIBRARY = libaudio.a
 
+AClientConnection.cpp: ../../Servers/AudioServer/AudioClientEndpoint.h
+../../Servers/AudioServer/AudioClientEndpoint.h:
+	@$(MAKE) -C $(dir $(@))
+
 install:
 	mkdir -p $(SERENITY_BASE_DIR)/Root/usr/include/LibAudio/
 	cp *.h $(SERENITY_BASE_DIR)/Root/usr/include/LibAudio/

--- a/Libraries/LibC/Makefile
+++ b/Libraries/LibC/Makefile
@@ -1,3 +1,5 @@
+.NOTPARALLEL:
+
 AK_OBJS = \
     ../../AK/StringImpl.o \
     ../../AK/String.o \
@@ -59,19 +61,22 @@ OBJS = $(AK_OBJS) $(LIBC_OBJS)
 
 EXTRA_OBJS = setjmp.ao crti.ao crtn.ao
 
-.PHONY: startfiles
-startfiles: $(EXTRA_OBJS)
-	$(CXX) $(CXXFLAGS) -o crt0.o -c crt0.cpp
+crt0.o: crt0.cpp
+	$(QUIET) $(CXX) $(CXXFLAGS) -o crt0.o -c crt0.cpp
+
+crtio.o: crti.ao
 	$(QUIET) cp crti.ao crti.o
+
+crtn.o: crtin.ao
 	$(QUIET) cp crtn.ao crtn.o
 
-EXTRA_CLEAN = crt0.d
+EXTRA_CLEAN = crt0.d crt0.o
 
 DEFINES = -DSERENITY_LIBC_BUILD
 
 LIBRARY = libc.a
 
-all: $(LIBRARY) startfiles install
+all: crt0.o $(EXTRA_OBJS) $(LIBRARY) install
 
 install:
 	mkdir -p $(SERENITY_BASE_DIR)/Root/usr/include/sys/

--- a/Libraries/LibCore/CGzip.cpp
+++ b/Libraries/LibCore/CGzip.cpp
@@ -2,7 +2,6 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Optional.h>
 #include <LibCore/puff.h>
-#include <LibCore/puff.c>
 #include <limits.h>
 #include <stddef.h>
 

--- a/Libraries/LibCore/Makefile
+++ b/Libraries/LibCore/Makefile
@@ -22,7 +22,8 @@ OBJS = \
     CProcessStatisticsReader.o \
     CDirIterator.o \
     CUserInfo.o \
-    CGzip.o
+    CGzip.o \
+    puff.o
 
 LIBRARY = libcore.a
 

--- a/Libraries/LibCore/puff.h
+++ b/Libraries/LibCore/puff.h
@@ -21,6 +21,10 @@
   Mark Adler    madler@alumni.caltech.edu
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * See puff.c for purpose and usage.
  */
@@ -32,3 +36,7 @@ int puff(unsigned char* dest,    /* pointer to destination pointer */
     unsigned long* destlen,      /* amount of output space */
     const unsigned char* source, /* pointer to source data pointer */
     unsigned long* sourcelen);   /* amount of input available */
+
+#ifdef __cplusplus
+}
+#endif

--- a/Libraries/LibGUI/Makefile
+++ b/Libraries/LibGUI/Makefile
@@ -63,6 +63,11 @@ OBJS = \
 
 LIBRARY = libgui.a
 
+GWindowServerConnection.cpp: ../../Servers/WindowServer/WindowServerEndpoint.h
+
+../../Servers/WindowServer/WindowServerEndpoint.h:
+	@$(MAKE) -C $(dir $(@))
+
 install:
 	mkdir -p $(SERENITY_BASE_DIR)/Root/usr/include/LibGUI/
 	cp ./*.h $(SERENITY_BASE_DIR)/Root/usr/include/LibGUI/

--- a/Libraries/LibHTML/CodeGenerators/Makefile
+++ b/Libraries/LibHTML/CodeGenerators/Makefile
@@ -1,0 +1,3 @@
+SUBDIRS := $(wildcard */.)
+
+include ../../../Makefile.subdir

--- a/Libraries/LibHTML/Makefile
+++ b/Libraries/LibHTML/Makefile
@@ -67,17 +67,28 @@ EXTRA_SOURCES = \
     CSS/PropertyID.h \
     CSS/PropertyID.cpp
 
+GENERATE_CSS_PROPERTYID_CPP = CodeGenerators/Generate_CSS_PropertyID_cpp/Generate_CSS_PropertyID_cpp
+GENERATE_CSS_PROPERTYID_H = CodeGenerators/Generate_CSS_PropertyID_h/Generate_CSS_PropertyID_h
+
+$(GENERATE_CSS_PROPERTYID_H):
+	@$(MAKE) -C $(dir $(GENERATE_CSS_PROPERTYID_H))
+
+$(GENERATE_CSS_PROPERTYID_CPP):
+	@$(MAKE) -C $(dir $(GENERATE_CSS_PROPERTYID_CPP))
+
 CSS/DefaultStyleSheetSource.cpp: CSS/Default.css Scripts/GenerateStyleSheetSource.sh
 	@echo "GENERATE $@"
 	$(QUIET) Scripts/GenerateStyleSheetSource.sh default_stylesheet_source $< > $@
 
-CSS/PropertyID.h: CSS/Properties.json CodeGenerators/Generate_CSS_PropertyID_h/Generate_CSS_PropertyID_h.cpp
+CSS/PropertyID.h: CSS/Properties.json $(GENERATE_CSS_PROPERTYID_H)
 	@echo "GENERATE $@"
-	$(QUIET) CodeGenerators/Generate_CSS_PropertyID_h/Generate_CSS_PropertyID_h $< > $@
+	$(QUIET) $(GENERATE_CSS_PROPERTYID_H) $< > $@
 
-CSS/PropertyID.cpp: CSS/Properties.json CodeGenerators/Generate_CSS_PropertyID_cpp/Generate_CSS_PropertyID_cpp.cpp
+CSS/PropertyID.cpp: CSS/Properties.json $(GENERATE_CSS_PROPERTYID_CPP)
 	@echo "GENERATE $@"
-	$(QUIET) CodeGenerators/Generate_CSS_PropertyID_cpp/Generate_CSS_PropertyID_cpp $< > $@
+	$(QUIET) $(GENERATE_CSS_PROPERTYID_CPP) $< > $@
+
+EXTRA_CLEAN = CSS/DefaultStyleSheetSource.cpp CSS/PropertyID.h CSS/PropertyID.cpp
 
 OBJS = $(EXTRA_OBJS) $(LIBHTML_OBJS)
 
@@ -91,3 +102,7 @@ install:
 	cp $(LIBRARY) $(SERENITY_BASE_DIR)/Root/usr/lib/
 
 include ../../Makefile.common
+
+SUBDIRS = CodeGenerators
+
+include ../../Makefile.subdir

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ SUBDIRS += \
 
 include Makefile.subdir
 
+all: subdirs
+
 .PHONY: test
 test:
 	$(QUIET) $(MAKE) -C AK/Tests clean all clean

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,17 @@
-# Build the host-side tools first, since they are needed to build some programs.
-SUBDIRS = \
-	DevTools/IPCCompiler \
-	DevTools/FormCompiler \
-	Libraries/LibHTML/CodeGenerators/Generate_CSS_PropertyID_cpp \
-	Libraries/LibHTML/CodeGenerators/Generate_CSS_PropertyID_h
-
-# Build some libraries before IPC servers, since they depend on them.
 SUBDIRS += \
-	Libraries/LibC \
-	Libraries/LibM \
-	Libraries/LibCore \
-	Libraries/LibDraw \
-	Libraries/LibIPC \
-	Libraries/LibThread \
-	Libraries/LibPthread
-
-# Build IPC servers before their client code to ensure the IPC definitions are available.
-SUBDIRS += \
-	Servers/AudioServer \
-	Servers/LookupServer \
-	Servers/ProtocolServer \
-	Libraries/LibAudio \
-	Servers/WindowServer
-
-SUBDIRS += \
-	AK
-
-SUBDIRS += \
-	Libraries \
+	AK \
 	Applications \
 	DevTools \
+	Kernel \
+	Libraries \
+	MenuApplets \
 	Servers \
 	Shell \
-	Userland \
-	MenuApplets \
-	Demos \
+	Userland
+
+SUBDIRS += \
 	Games \
-	Kernel
+	Demos
 
 include Makefile.subdir
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,11 +1,17 @@
-ARCH_FLAGS =
-STANDARD_FLAGS = -std=c++17 -Wno-sized-deallocation -fno-sized-deallocation
-WARNING_FLAGS = -Werror -Wextra -Wall -Wno-nonnull-compare -Wno-deprecated-copy -Wno-address-of-packed-member -Wundef -Wcast-qual -Wwrite-strings -Wimplicit-fallthrough -Wno-expansion-to-defined
-FLAVOR_FLAGS = -fno-exceptions -fno-rtti -fstack-protector
-OPTIMIZATION_FLAGS = -Os
-
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 SERENITY_BASE_DIR := $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
+
+CXX_STANDARD_FLAGS = -std=c++17 -Wno-sized-deallocation -fno-sized-deallocation
+CXX_WARNING_FLAGS = -Werror -Wextra -Wall -Wno-nonnull-compare -Wno-deprecated-copy -Wno-address-of-packed-member -Wundef -Wcast-qual -Wwrite-strings -Wimplicit-fallthrough -Wno-expansion-to-defined
+CXX_FLAVOR_FLAGS = -fno-exceptions -fno-rtti -fstack-protector
+#CXX_SUGGEST_FLAGS = -Wsuggest-final-types -Wsuggest-final-methods -Wsuggest-override #-Wsuggest-attribute=noreturn 
+
+C_STANDARD_FLAGS =
+C_WARNING_FLAGS = -Werror -Wextra -Wall -Wno-nonnull-compare -Wno-address-of-packed-member -Wundef -Wcast-qual -Wwrite-strings -Wimplicit-fallthrough -Wno-expansion-to-defined
+C_FLAVOR_FLAGS = -fstack-protector
+
+ARCH_FLAGS =
+OPTIMIZATION_FLAGS = -Os
 
 INCLUDE_FLAGS += \
     -I. \
@@ -40,6 +46,7 @@ ifneq ($(HOST_CXX),)
 else
     TOOLCHAIN_PATH = $(SERENITY_BASE_DIR)/Toolchain/Local/bin
     CXX = $(PRE_CXX) $(TOOLCHAIN_PATH)/i686-pc-serenity-g++
+    CC = $(PRE_CC) $(TOOLCHAIN_PATH)/i686-pc-serenity-gcc
     AS = $(TOOLCHAIN_PATH)/i686-pc-serenity-as
     LINK = $(TOOLCHAIN_PATH)/i686-pc-serenity-ld
     DEFINES += -DDEBUG
@@ -62,8 +69,8 @@ endif
 #CXX = clang $(CLANG_FLAGS)
 #CLANG_FLAGS = -Wconsumed -m32 -ffreestanding -march=i686
 
-#SUGGEST_FLAGS = -Wsuggest-final-types -Wsuggest-final-methods -Wsuggest-override #-Wsuggest-attribute=noreturn 
-CXXFLAGS = -MMD -MP $(WARNING_FLAGS) $(OPTIMIZATION_FLAGS) $(FLAVOR_FLAGS) $(ARCH_FLAGS) $(STANDARD_FLAGS) $(SUGGEST_FLAGS) $(INCLUDE_FLAGS) $(DEFINES) $(SUBPROJECT_CXXFLAGS)
+CXXFLAGS = -MMD -MP $(CXX_WARNING_FLAGS) $(CXX_OPTIMIZATION_FLAGS) $(CXX_FLAVOR_FLAGS) $(ARCH_FLAGS) $(CXX_STANDARD_FLAGS) $(CXX_SUGGEST_FLAGS) $(INCLUDE_FLAGS) $(DEFINES) $(SUBPROJECT_CXXFLAGS)
+CFLAGS = -MMD -MP $(C_FLAVOR_FLAGS) $(ARCH_FLAGS) $(C_STANDARD_FLAGS) $(C_SUGGEST_FLAGS) $(INCLUDE_FLAGS) $(DEFINES) $(SUBPROJECT_CXXFLAGS)
 
 DEFINES += -DSANITIZE_PTRS
 
@@ -82,6 +89,10 @@ endif
 %$(OBJ_SUFFIX).o: %.cpp $(EXTRA_SOURCES)
 	@echo "C++ $@"
 	$(QUIET) $(CXX) $(CXXFLAGS) -o $@ -c $<
+
+%$(OBJ_SUFFIX).o: %.c
+	@echo "C $@"
+	$(QUIET) $(CC) $(CFLAGS) -o $@ -c $<
 
 %.ao: %.S
 	@echo "AS $@"

--- a/Makefile.common
+++ b/Makefile.common
@@ -20,22 +20,6 @@ INCLUDE_FLAGS += \
     -I$(SERENITY_BASE_DIR)/Libraries \
     -I$(SERENITY_BASE_DIR)/Servers
 
-LDFLAGS += \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibC \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibPthread \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibCore \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibIPC \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibM \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibDraw \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibGUI \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibHTML \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibMarkdown \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibThread \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibVT \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibPCIDB \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibProtocol \
-    -L$(SERENITY_BASE_DIR)/Libraries/LibAudio
-
 VERBOSE = 0
 
 ifneq ($(HOST_CXX),)
@@ -56,12 +40,21 @@ else
     	-I$(SERENITY_BASE_DIR)/Libraries/LibM \
     	-I$(SERENITY_BASE_DIR)/Libraries/LibPthread
 
-    LDFLAGS += \
-        -L$(SERENITY_BASE_DIR)/Libraries/LibC
-
     ifdef KERNEL
         DEFINES += -DKERNEL
+    else
+        # everything else gets -lc -lm
+        LIB_DEPS += C M
     endif
+
+    # turn "LIB_DEPS=C Core Thread" into "-lc -lcore -lthread -L.../LibC ..."
+    LDFLAGS += $(foreach lib,$(LIB_DEPS),\
+        -l$(shell echo $(lib) | tr A-Z a-z))
+    LDFLAGS += $(foreach lib,$(LIB_DEPS),\
+        -L$(SERENITY_BASE_DIR)/Libraries/Lib$(lib))
+
+    STATIC_LIB_DEPS = $(foreach lib,$(LIB_DEPS),\
+        $(SERENITY_BASE_DIR)/Libraries/Lib$(lib)/lib$(shell echo $(lib) | tr A-Z a-z).a)
 
     OBJ_SUFFIX ?=
 endif
@@ -69,12 +62,10 @@ endif
 #CXX = clang $(CLANG_FLAGS)
 #CLANG_FLAGS = -Wconsumed -m32 -ffreestanding -march=i686
 
-CXXFLAGS = -MMD -MP $(CXX_WARNING_FLAGS) $(CXX_OPTIMIZATION_FLAGS) $(CXX_FLAVOR_FLAGS) $(ARCH_FLAGS) $(CXX_STANDARD_FLAGS) $(CXX_SUGGEST_FLAGS) $(INCLUDE_FLAGS) $(DEFINES) $(SUBPROJECT_CXXFLAGS)
+CXXFLAGS = -MMD -MP $(CXX_WARNING_FLAGS) $(OPTIMIZATION_FLAGS) $(CXX_FLAVOR_FLAGS) $(ARCH_FLAGS) $(CXX_STANDARD_FLAGS) $(CXX_SUGGEST_FLAGS) $(INCLUDE_FLAGS) $(DEFINES) $(SUBPROJECT_CXXFLAGS)
 CFLAGS = -MMD -MP $(C_FLAVOR_FLAGS) $(ARCH_FLAGS) $(C_STANDARD_FLAGS) $(C_SUGGEST_FLAGS) $(INCLUDE_FLAGS) $(DEFINES) $(SUBPROJECT_CXXFLAGS)
 
 DEFINES += -DSANITIZE_PTRS
-
-IPCCOMPILER = $(SERENITY_BASE_DIR)/DevTools/IPCCompiler/IPCCompiler
 
 SUFFIXED_OBJS = $(patsubst %.o,%$(OBJ_SUFFIX).o,$(OBJS))
 
@@ -98,13 +89,26 @@ endif
 	@echo "AS $@"
 	$(QUIET) $(AS) -o $@ $<
 
-$(PROGRAM): $(SUFFIXED_OBJS) $(EXTRA_OBJS)
+$(PROGRAM): $(SUFFIXED_OBJS) $(EXTRA_OBJS) $(STATIC_LIB_DEPS)
 	@echo "LINK $(PROGRAM)"
 	$(QUIET) $(CXX) -o $(PROGRAM) $(EXTRA_OBJS) $(SUFFIXED_OBJS) $(LDFLAGS)
 
 $(LIBRARY): $(SUFFIXED_OBJS) $(EXTRA_OBJS)
 	@echo "LIB $@"
 	$(QUIET) $(AR) rcs $@ $(OBJS) $(EXTRA_OBJS) $(LIBS)
+
+$(STATIC_LIB_DEPS):
+	@$(MAKE) -C $(dir $(@))
+
+IPCCOMPILER = $(SERENITY_BASE_DIR)/DevTools/IPCCompiler/IPCCompiler
+IPCCOMPILER: $(IPCCOMPILER)
+$(IPCCOMPILER):
+	@$(MAKE) -C $(dir $(@))
+
+FORMCOMPILER = $(SERENITY_BASE_DIR)/DevTools/FormCompiler/FormCompiler
+FORMCOMPILER: $(FORMCOMPILER)
+$(FORMCOMPILER):
+	@$(MAKE) -C $(dir $(@))
 
 .DEFAULT_GOAL := all
 
@@ -117,5 +121,7 @@ clean:
 	$(QUIET) rm -f $(PROGRAM) $(LIBRARY) $(SUFFIXED_OBJS) $(EXTRA_OBJS) *.d $(EXTRA_CLEAN)
 
 install:
+
+.DELETE_ON_ERROR:
 
 .PHONY: all clean install

--- a/MenuApplets/Audio/Makefile
+++ b/MenuApplets/Audio/Makefile
@@ -2,6 +2,6 @@ OBJS = main.o
 
 PROGRAM = Audio.MenuApplet
 
-LDFLAGS = -laudio -lgui -lipc -ldraw -lthread -lpthread -lcore -lc
+LIB_DEPS = Audio GUI IPC Draw Thread Pthread Core
 
 include ../../Makefile.common

--- a/MenuApplets/CPUGraph/Makefile
+++ b/MenuApplets/CPUGraph/Makefile
@@ -2,6 +2,6 @@ OBJS = main.o
 
 PROGRAM = CPUGraph.MenuApplet
 
-LDFLAGS = -laudio -lgui -lipc -ldraw -lthread -lpthread -lcore -lc
+LIB_DEPS = GUI IPC Draw Thread Pthread Core
 
 include ../../Makefile.common

--- a/Servers/AudioServer/Makefile
+++ b/Servers/AudioServer/Makefile
@@ -6,16 +6,16 @@ OBJS = \
 
 PROGRAM = AudioServer
 
-LDFLAGS = -lc -lcore -lipc -lthread -lpthread
+LIB_DEPS = Core IPC Thread Pthread
 
 EXTRA_CLEAN = AudioServerEndpoint.h AudioClientEndpoint.h
 
 *.cpp: AudioServerEndpoint.h AudioClientEndpoint.h
 
-AudioServerEndpoint.h: AudioServer.ipc
+AudioServerEndpoint.h: AudioServer.ipc IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
-AudioClientEndpoint.h: AudioClient.ipc
+AudioClientEndpoint.h: AudioClient.ipc IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
 install:

--- a/Servers/LookupServer/Makefile
+++ b/Servers/LookupServer/Makefile
@@ -4,6 +4,6 @@ OBJS = \
 
 PROGRAM = LookupServer
 
-LDFLAGS = -lc -lcore
+LIB_DEPS = Core
 
 include ../../Makefile.common

--- a/Servers/ProtocolServer/Makefile
+++ b/Servers/ProtocolServer/Makefile
@@ -8,14 +8,14 @@ OBJS = \
 
 PROGRAM = ProtocolServer
 
-LDFLAGS = -lc -lcore -lipc
+LIB_DEPS = Core IPC
 
 *.cpp: ProtocolServerEndpoint.h ProtocolClientEndpoint.h
 
-ProtocolServerEndpoint.h: ProtocolServer.ipc
+ProtocolServerEndpoint.h: ProtocolServer.ipc IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
-ProtocolClientEndpoint.h: ProtocolClient.ipc
+ProtocolClientEndpoint.h: ProtocolClient.ipc IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
 include ../../Makefile.common

--- a/Servers/SystemServer/Makefile
+++ b/Servers/SystemServer/Makefile
@@ -4,7 +4,7 @@ OBJS = \
 
 PROGRAM = SystemServer
 
-LDFLAGS = -lcore -lc
+LIB_DEPS = Core
 
 install:
 	mkdir -p ../../Root/usr/include/SystemServer/

--- a/Servers/TelnetServer/Makefile
+++ b/Servers/TelnetServer/Makefile
@@ -5,6 +5,6 @@ OBJS = \
 
 PROGRAM = TelnetServer
 
-LDFLAGS = -lcore -lc
+LIB_DEPS = Core
 
 include ../../Makefile.common

--- a/Servers/WindowServer/Makefile
+++ b/Servers/WindowServer/Makefile
@@ -18,14 +18,14 @@ OBJS = \
 
 PROGRAM = WindowServer
 
-LDFLAGS = -lc -ldraw -lcore -lthread -lpthread -lipc
+LIB_DEPS = Draw Core Thread Pthread IPC
 
 *.cpp: WindowServerEndpoint.h WindowClientEndpoint.h
 
-WindowServerEndpoint.h: WindowServer.ipc
+WindowServerEndpoint.h: WindowServer.ipc IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
-WindowClientEndpoint.h: WindowClient.ipc
+WindowClientEndpoint.h: WindowClient.ipc IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
 EXTRA_CLEAN = WindowServerEndpoint.h WindowClientEndpoint.h

--- a/Shell/Makefile
+++ b/Shell/Makefile
@@ -5,6 +5,6 @@ OBJS = \
 
 PROGRAM = Shell
 
-LDFLAGS = -lcore -lc
+LIB_DEPS = Core
 
 include ../Makefile.common

--- a/Userland/Makefile
+++ b/Userland/Makefile
@@ -4,7 +4,7 @@ APPS = ${SRCS:.cpp=}
 
 EXTRA_CLEAN = $(APPS)
 
-LDFLAGS = -lc -lhtml -lgui -ldraw -laudio -lipc -lthread -lcore -lpcidb -lmarkdown -lpthread -lprotocol -lipc
+LIB_DEPS = HTML GUI Draw Audio Protocol IPC Thread Pthread Core PCIDB Markdown
 
 all: $(OBJS) $(APPS)
 


### PR DESCRIPTION
I say better but not perfect.  If you build the tree and then `git pull`, then `make` again, and it tries recompiling an application that uses newly added functionality in a library, it won't know the library needs to be rebuilt and will fail.  This is because the Makefiles aren't shared, so `make` is just looking to see that the library's `.a` file is there.  To actually know whether the library is up to date, the dependency would have to include a `make -C ...` for every library dependency which is very slow.  (You can test this by adding `.PHONY: $(STATIC_LIB_DEPS)` to `Makefile.common`, and see how many times it has to check LibC and friends.)

So after updating the source tree, I think it's best to just do a `make clean all` from the root directory each time.  OpenBSD's build system explicitly `clean`s first when doing a `make build`.

Anyway, this does improve things by not requiring a specific build order.  For example, `make clean`, clear out `Root`, then enter `Games/Minesweeper` and `make`. It will build LibGUI, WindowServer, IPCCompiler, LibDraw, LibCore, LibThread, LibPthread, LibIPC, LibC, and LibM automatically first, before returning to link Minesweeper.