### PR TITLE
Kernel: Detect support for no-execute (NX) CPU features

### DIFF
--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -111,6 +111,8 @@ private:
 
     PageTableEntry& ensure_pte(PageDirectory&, VirtualAddress);
 
+    bool has_nx_support() const { return m_has_nx_support; }
+
     RefPtr<PageDirectory> m_kernel_page_directory;
     PageTableEntry* m_low_page_tables[4] { nullptr };
 
@@ -130,6 +132,7 @@ private:
     InlineLinkedList<VMObject> m_vmobjects;
 
     bool m_quickmap_in_use { false };
+    bool m_has_nx_support { false };
 };
 
 struct ProcessPagingScope {

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -216,7 +216,8 @@ void Region::remap_page(size_t index)
         pte.set_writable(false);
     else
         pte.set_writable(is_writable());
-    pte.set_execute_disabled(!is_executable());
+    if (MM.has_nx_support())
+        pte.set_execute_disabled(!is_executable());
     pte.set_user_allowed(is_user_accessible());
     m_page_directory->flush(page_vaddr);
 #ifdef MM_DEBUG
@@ -265,7 +266,8 @@ void Region::map(PageDirectory& page_directory)
                 pte.set_writable(false);
             else
                 pte.set_writable(is_writable());
-            pte.set_execute_disabled(!is_executable());
+            if (MM.has_nx_support())
+                pte.set_execute_disabled(!is_executable());
         } else {
             pte.set_physical_page_base(0);
             pte.set_present(false);


### PR DESCRIPTION
Previously we assumed all hosts would have support for IA32_EFER.NXE.
This is mostly true for newer hardware, but older hardware will crash
and burn if you try to use this feature.

Now we check for support via CPUID.80000001[20].