### PR TITLE
Kernel: Add kernel-level timer queue (heavily based on @juliusf's work)

### DIFF
--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -107,14 +107,7 @@ public:
 
     void append(const T& value)
     {
-        auto* node = new Node(value);
-        if (!m_head) {
-            m_head = node;
-            m_tail = node;
-            return;
-        }
-        m_tail->next = node;
-        m_tail = node;
+        append(T(value));
     }
 
     void append(T&& value)
@@ -196,12 +189,7 @@ public:
 
     void insert_before(Iterator iterator, const T& value)
     {
-        auto* node = new Node(value);
-        node->next = iterator.m_node;
-        if (m_head == iterator.m_node)
-            m_head = node;
-        if (iterator.m_prev)
-            iterator.m_prev->next = node;
+        insert_before(T(value));
     }
 
     void insert_before(Iterator iterator, T&& value)
@@ -216,18 +204,7 @@ public:
 
     void insert_after(Iterator iterator, const T& value)
     {
-        if (iterator.is_end()) {
-            append(value);
-            return;
-        }
-
-        auto* node = new Node(value);
-        node->next = iterator.m_node->next;
-
-        iterator.m_node->next = node;
-
-        if (m_tail == iterator.m_node)
-            m_tail = node;
+        insert_after(T(value));
     }
 
     void insert_after(Iterator iterator, T&& value)

--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -194,6 +194,58 @@ public:
         delete iterator.m_node;
     }
 
+    void insert_before(Iterator iterator, const T& value)
+    {
+        auto* node = new Node(value);
+        node->next = iterator.m_node;
+        if (m_head == iterator.m_node)
+            m_head = node;
+        if (iterator.m_prev)
+            iterator.m_prev->next = node;
+    }
+
+    void insert_before(Iterator iterator, T&& value)
+    {
+        auto* node = new Node(move(value));
+        node->next = iterator.m_node;
+        if (m_head == iterator.m_node)
+            m_head = node;
+        if (iterator.m_prev)
+            iterator.m_prev->next = node;
+    }
+
+    void insert_after(Iterator iterator, const T& value)
+    {
+        if (iterator.is_end()) {
+            append(value);
+            return;
+        }
+
+        auto* node = new Node(value);
+        node->next = iterator.m_node->next;
+
+        iterator.m_node->next = node;
+
+        if (m_tail == iterator.m_node)
+            m_tail = node;
+    }
+
+    void insert_after(Iterator iterator, T&& value)
+    {
+        if (iterator.is_end()) {
+            append(value);
+            return;
+        }
+
+        auto* node = new Node(move(value));
+        node->next = iterator.m_node->next;
+
+        iterator.m_node->next = node;
+
+        if (m_tail == iterator.m_node)
+            m_tail = node;
+    }
+
 private:
     Node* head() { return m_head; }
     const Node* head() const { return m_head; }

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -80,6 +80,7 @@ OBJS = \
     SharedBuffer.o \
     StdLib.o \
     Syscall.o \
+    TimerQueue.o \
     TTY/MasterPTY.o \
     TTY/PTYMultiplexer.o \
     TTY/SlavePTY.o \

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -5,6 +5,7 @@
 #include <Kernel/Profiling.h>
 #include <Kernel/RTC.h>
 #include <Kernel/Scheduler.h>
+#include <Kernel/TimerQueue.h>
 
 //#define LOG_EVERY_CONTEXT_SWITCH
 //#define SCHEDULER_DEBUG
@@ -578,6 +579,8 @@ void Scheduler::timer_tick(RegisterDump& regs)
             sample.frames[i] = backtrace[i];
         }
     }
+
+    TimerQueue::the().fire();
 
     if (current->tick())
         return;

--- a/Kernel/TimerQueue.cpp
+++ b/Kernel/TimerQueue.cpp
@@ -1,0 +1,72 @@
+#include <AK/Function.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
+#include <Kernel/Scheduler.h>
+#include <Kernel/TimerQueue.h>
+
+static TimerQueue* s_the;
+
+TimerQueue& TimerQueue::the()
+{
+    if (!s_the)
+        s_the = new TimerQueue;
+    return *s_the;
+}
+
+u64 TimerQueue::add_timer(NonnullOwnPtr<Timer>&& timer)
+{
+    ASSERT(timer->expires > g_uptime);
+
+    timer->id = ++m_timer_id_count;
+
+    auto following_timer = m_timer_queue.find([&timer](auto& other) { return other->expires > timer->expires; });
+    if (following_timer.is_end())
+        m_timer_queue.append(move(timer));
+    else
+        m_timer_queue.insert_before(following_timer, move(timer));
+
+    update_next_timer_due();
+
+    return m_timer_id_count;
+}
+
+u64 TimerQueue::add_timer(u64 duration, TimeUnit unit, Function<void()>&& callback)
+{
+    NonnullOwnPtr timer = make<Timer>();
+    timer->expires = g_uptime + duration * unit;
+    timer->callback = move(callback);
+    return add_timer(move(timer));
+}
+
+bool TimerQueue::cancel_timer(u64 id)
+{
+    auto it = m_timer_queue.find([id](auto& timer) { return timer->id == id; });
+    if (it.is_end())
+        return false;
+    m_timer_queue.remove(it);
+    update_next_timer_due();
+    return true;
+}
+
+void TimerQueue::fire()
+{
+    if (m_timer_queue.is_empty())
+        return;
+
+    ASSERT(m_next_timer_due == m_timer_queue.first()->expires);
+
+    while (!m_timer_queue.is_empty() && g_uptime > m_timer_queue.first()->expires) {
+        auto timer = m_timer_queue.take_first();
+        timer->callback();
+    }
+
+    update_next_timer_due();
+}
+
+void TimerQueue::update_next_timer_due()
+{
+    if (m_timer_queue.is_empty())
+        m_next_timer_due = 0;
+    else
+        m_next_timer_due = m_timer_queue.first()->expires;
+}

--- a/Kernel/TimerQueue.h
+++ b/Kernel/TimerQueue.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
+#include <AK/SinglyLinkedList.h>
+#include <Kernel/Arch/i386/PIT.h>
+
+struct Timer {
+    u64 id;
+    u64 expires;
+    Function<void()> callback;
+    bool operator<(const Timer& rhs) const
+    {
+        return expires < rhs.expires;
+    }
+    bool operator>(const Timer& rhs) const
+    {
+        return expires > rhs.expires;
+    }
+    bool operator==(const Timer& rhs) const
+    {
+        return id == rhs.id;
+    }
+};
+
+enum TimeUnit {
+    MS = TICKS_PER_SECOND / 1000,
+    S = TICKS_PER_SECOND,
+    M = TICKS_PER_SECOND * 60
+};
+
+class TimerQueue {
+public:
+    static TimerQueue& the();
+
+    u64 add_timer(NonnullOwnPtr<Timer>&&);
+    u64 add_timer(u64 duration, TimeUnit, Function<void()>&& callback);
+    bool cancel_timer(u64 id);
+    void fire();
+
+private:
+    void update_next_timer_due();
+
+    u64 m_next_timer_due { 0 };
+    u64 m_timer_id_count { 0 };
+    SinglyLinkedList<NonnullOwnPtr<Timer>> m_timer_queue;
+};


### PR DESCRIPTION
PR #591 defines the rationale for kernel-level timers. They're most
immediately useful for TCP retransmission, but will most likely see use in
many other areas as well.

It looks like @juliusf might have gotten a bit busy, but I figured it'd be
a shame to leave his code in limbo, so I rebased it and cleaned it up a bit
following the suggestions @awesomekling left in #591.