### PR TITLE
Build: Fix missing ProtocolClient endpoint dependency for Browser

### DIFF
--- a/Applications/Browser/Makefile
+++ b/Applications/Browser/Makefile
@@ -9,4 +9,8 @@ main.cpp: ../../Libraries/LibHTML/CSS/PropertyID.h
 ../../Libraries/LibHTML/CSS/PropertyID.h:
 	@$(MAKE) -C ../../Libraries/LibHTML
 
+main.cpp: ../../Servers/ProtocolServer/ProtocolClientEndpoint.h
+../../Servers/ProtocolServer/ProtocolClientEndpoint.h:
+	@$(MAKE) -C $(dir $(@))
+
 include ../../Makefile.common


### PR DESCRIPTION
This patch was authored by @awesomekling 