### PR TITLE
LibC: implement fgetpos and fsetpos

### DIFF
--- a/Libraries/LibC/stdio.cpp
+++ b/Libraries/LibC/stdio.cpp
@@ -327,6 +327,26 @@ long ftell(FILE* stream)
     return lseek(stream->fd, 0, SEEK_CUR);
 }
 
+int fgetpos(FILE* stream, fpos_t* pos)
+{
+    assert(stream);
+    assert(pos);
+
+    long val = ftell(stream);
+    if (val == -1L)
+        return 1;
+
+    *pos = val;
+    return 0;
+}
+
+int fsetpos(FILE* stream, const fpos_t* pos)
+{
+    assert(stream);
+    assert(pos);
+    return fseek(stream, (long) *pos, SEEK_SET);
+}
+
 void rewind(FILE* stream)
 {
     ASSERT(stream);

--- a/Libraries/LibC/stdio.h
+++ b/Libraries/LibC/stdio.h
@@ -45,7 +45,7 @@ extern FILE* stdin;
 extern FILE* stdout;
 extern FILE* stderr;
 
-typedef size_t fpos_t;
+typedef long fpos_t;
 
 int fseek(FILE*, long offset, int whence);
 int fgetpos(FILE*, fpos_t*);


### PR DESCRIPTION
They're just "front ends" for ftell and fseek, but they do their job.

Fixes #913