### PR TITLE
Kernel: Handle symlink path resolution when path ends with "/" 

### DIFF
--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -102,6 +102,7 @@ StringView StringView::substring_view(size_t start, size_t length) const
 
 StringView StringView::substring_view_starting_from_substring(const StringView& substring) const
 {
+    ASSERT(!substring.is_null());
     const char* remaining_characters = substring.characters_without_null_termination();
     ASSERT(remaining_characters >= m_characters);
     ASSERT(remaining_characters <= m_characters + m_length);
@@ -111,6 +112,7 @@ StringView StringView::substring_view_starting_from_substring(const StringView& 
 
 StringView StringView::substring_view_starting_after_substring(const StringView& substring) const
 {
+    ASSERT(!substring.is_null());
     const char* remaining_characters = substring.characters_without_null_termination() + substring.length();
     ASSERT(remaining_characters >= m_characters);
     ASSERT(remaining_characters <= m_characters + m_length);

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -720,11 +720,10 @@ KResultOr<NonnullRefPtr<Custody>> VFS::resolve_path(StringView path, Custody& ba
             if (symlink_target.is_error())
                 return symlink_target;
 
-            bool have_more_parts = i + 1 < parts.size();
-            if (i + 1 == parts.size() - 1 && parts[i + 1].is_empty())
-                have_more_parts = false;
+            if (i == parts.size() - 1)
+                return symlink_target;
 
-            if (!have_more_parts)
+            if (parts[i + 1].is_empty())
                 return symlink_target;
 
             StringView remaining_path = path.substring_view_starting_from_substring(parts[i + 1]);


### PR DESCRIPTION
Fixes an assert when `ls /proc/self/` is run.

A null StringView would be passed in as the substring to ascertain the remaining path to resolve.