### PR TITLE
LibGUI: Close and cancel GDialog on escape

### DIFF
--- a/Libraries/LibGUI/GDialog.cpp
+++ b/Libraries/LibGUI/GDialog.cpp
@@ -1,5 +1,6 @@
 #include <LibGUI/GDesktop.h>
 #include <LibGUI/GDialog.h>
+#include <LibGUI/GEvent.h>
 
 GDialog::GDialog(CObject* parent)
     : GWindow(parent)
@@ -38,6 +39,19 @@ void GDialog::done(int result)
     m_result = result;
     dbgprintf("%s: quit event loop with result %d\n", class_name(), result);
     m_event_loop->quit(result);
+}
+
+void GDialog::event(CEvent& event)
+{
+    if (event.type() == GEvent::KeyUp) {
+        auto& key_event = static_cast<GKeyEvent&>(event);
+        if (key_event.key() == KeyCode::Key_Escape) {
+            done(ExecCancel);
+            return;
+        }
+    }
+
+    GWindow::event(event);
 }
 
 void GDialog::close()

--- a/Libraries/LibGUI/GDialog.h
+++ b/Libraries/LibGUI/GDialog.h
@@ -19,6 +19,8 @@ public:
     int result() const { return m_result; }
     void done(int result);
 
+    virtual void event(CEvent&) override;
+
     virtual void close() override;
 
 protected:


### PR DESCRIPTION
This is a small usability enhancement. If a GMessageBox has a cancel
button, and if that box is focused, it will now finish with
GDialog::ExecCancel.