### PR TITLE
More build fixes

### DIFF
--- a/AK/Tests/Makefile
+++ b/AK/Tests/Makefile
@@ -35,7 +35,6 @@ SHARED_TEST_OBJS = \
 
 define execute-command
 $(1)
-
 endef
 
 all: $(PROGRAMS)

--- a/Applications/Browser/Makefile
+++ b/Applications/Browser/Makefile
@@ -7,10 +7,10 @@ LIB_DEPS = GUI HTML Draw IPC Protocol Core
 
 main.cpp: ../../Libraries/LibHTML/CSS/PropertyID.h
 ../../Libraries/LibHTML/CSS/PropertyID.h:
-	@$(MAKE) -C ../../Libraries/LibHTML
+	@flock ../../Libraries/LibHTML $(MAKE) -C ../../Libraries/LibHTML
 
 main.cpp: ../../Servers/ProtocolServer/ProtocolClientEndpoint.h
 ../../Servers/ProtocolServer/ProtocolClientEndpoint.h:
-	@$(MAKE) -C $(dir $(@))
+	@flock ../../Servers/ProtocolServer $(MAKE) -C $(dir $(@))
 
 include ../../Makefile.common

--- a/Applications/FontEditor/Makefile
+++ b/Applications/FontEditor/Makefile
@@ -10,7 +10,7 @@ LIB_DEPS = GUI Draw Core IPC
 
 FontEditor.cpp: UI_FontEditorBottom.h
 
-UI_FontEditorBottom.h: FontEditorBottom.frm FORMCOMPILER
+UI_FontEditorBottom.h: FontEditorBottom.frm | FORMCOMPILER
 	$(QUIET) $(FORMCOMPILER) $< > $@
 
 EXTRA_CLEAN = UI_FontEditorBottom.h

--- a/Libraries/LibAudio/Makefile
+++ b/Libraries/LibAudio/Makefile
@@ -6,7 +6,7 @@ LIBRARY = libaudio.a
 
 AClientConnection.cpp: ../../Servers/AudioServer/AudioClientEndpoint.h
 ../../Servers/AudioServer/AudioClientEndpoint.h:
-	@$(MAKE) -C $(dir $(@))
+	@flock $(dir $(@)) $(MAKE) -C $(dir $(@))
 
 install:
 	mkdir -p $(SERENITY_BASE_DIR)/Root/usr/include/LibAudio/

--- a/Libraries/LibC/Makefile
+++ b/Libraries/LibC/Makefile
@@ -1,5 +1,3 @@
-.NOTPARALLEL:
-
 AK_OBJS = \
     ../../AK/StringImpl.o \
     ../../AK/String.o \
@@ -62,7 +60,6 @@ OBJS = $(AK_OBJS) $(LIBC_OBJS)
 EXTRA_OBJS = setjmp.ao crti.ao crtn.ao
 
 crt0.o: crt0.cpp
-	$(QUIET) $(CXX) $(CXXFLAGS) -o crt0.o -c crt0.cpp
 
 crtio.o: crti.ao
 	$(QUIET) cp crti.ao crti.o
@@ -76,7 +73,9 @@ DEFINES = -DSERENITY_LIBC_BUILD
 
 LIBRARY = libc.a
 
-all: crt0.o $(EXTRA_OBJS) $(LIBRARY) install
+POST_LIBRARY_BUILD = $(QUIET) $(MAKE) install
+
+all: crt0.o $(EXTRA_OBJS) $(LIBRARY)
 
 install:
 	mkdir -p $(SERENITY_BASE_DIR)/Root/usr/include/sys/

--- a/Libraries/LibGUI/Makefile
+++ b/Libraries/LibGUI/Makefile
@@ -66,7 +66,7 @@ LIBRARY = libgui.a
 GWindowServerConnection.cpp: ../../Servers/WindowServer/WindowServerEndpoint.h
 
 ../../Servers/WindowServer/WindowServerEndpoint.h:
-	@$(MAKE) -C $(dir $(@))
+	@flock $(dir $(@)) $(MAKE) -C $(dir $(@))
 
 install:
 	mkdir -p $(SERENITY_BASE_DIR)/Root/usr/include/LibGUI/

--- a/Libraries/LibHTML/Makefile
+++ b/Libraries/LibHTML/Makefile
@@ -71,10 +71,10 @@ GENERATE_CSS_PROPERTYID_CPP = CodeGenerators/Generate_CSS_PropertyID_cpp/Generat
 GENERATE_CSS_PROPERTYID_H = CodeGenerators/Generate_CSS_PropertyID_h/Generate_CSS_PropertyID_h
 
 $(GENERATE_CSS_PROPERTYID_H):
-	@$(MAKE) -C $(dir $(GENERATE_CSS_PROPERTYID_H))
+	@flock $(dir $(GENERATE_CSS_PROPERTYID_H)) $(MAKE) -C $(dir $(GENERATE_CSS_PROPERTYID_H))
 
 $(GENERATE_CSS_PROPERTYID_CPP):
-	@$(MAKE) -C $(dir $(GENERATE_CSS_PROPERTYID_CPP))
+	@flock $(dir $(GENERATE_CSS_PROPERTYID_CPP)) $(MAKE) -C $(dir $(GENERATE_CSS_PROPERTYID_CPP))
 
 CSS/DefaultStyleSheetSource.cpp: CSS/Default.css Scripts/GenerateStyleSheetSource.sh
 	@echo "GENERATE $@"
@@ -82,11 +82,11 @@ CSS/DefaultStyleSheetSource.cpp: CSS/Default.css Scripts/GenerateStyleSheetSourc
 
 CSS/PropertyID.h: CSS/Properties.json $(GENERATE_CSS_PROPERTYID_H)
 	@echo "GENERATE $@"
-	$(QUIET) $(GENERATE_CSS_PROPERTYID_H) $< > $@
+	$(QUIET) flock CSS $(GENERATE_CSS_PROPERTYID_H) $< > $@
 
 CSS/PropertyID.cpp: CSS/Properties.json $(GENERATE_CSS_PROPERTYID_CPP)
 	@echo "GENERATE $@"
-	$(QUIET) $(GENERATE_CSS_PROPERTYID_CPP) $< > $@
+	$(QUIET) flock CSS $(GENERATE_CSS_PROPERTYID_CPP) $< > $@
 
 EXTRA_CLEAN = CSS/DefaultStyleSheetSource.cpp CSS/PropertyID.h CSS/PropertyID.cpp
 

--- a/Libraries/LibProtocol/Makefile
+++ b/Libraries/LibProtocol/Makefile
@@ -6,6 +6,6 @@ LIBRARY = libprotocol.a
 
 Download.cpp: ../../Servers/ProtocolServer/ProtocolClientEndpoint.h
 ../../Servers/ProtocolServer/ProtocolClientEndpoint.h:
-	@$(MAKE) -C $(dir $(@))
+	@flock $(dir $(@)) $(MAKE) -C $(dir $(@))
 
 include ../../Makefile.common

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,6 @@ ifeq ($(UNAME_S),Darwin)
 test: 
 else
 test:
-	$(QUIET) $(MAKE) -C AK/Tests clean all clean
+	$(QUIET) flock AK/Tests $(MAKE) -C AK/Tests clean all clean
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 SUBDIRS += \
 	AK \
-	Applications \
 	DevTools \
-	Kernel \
 	Libraries \
+	Servers
+
+SUBDIRS += \
+	Applications \
+	Kernel \
 	MenuApplets \
-	Servers \
 	Shell \
 	Userland
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -103,19 +103,21 @@ $(PROGRAM): $(STATIC_LIB_DEPS) $(SUFFIXED_OBJS) $(EXTRA_OBJS)
 $(LIBRARY): $(SUFFIXED_OBJS) $(EXTRA_OBJS)
 	@echo "LIB $@"
 	$(QUIET) $(AR) rcs $@ $(OBJS) $(EXTRA_OBJS) $(LIBS)
+	$(POST_LIBRARY_BUILD)
 
+#.PHONY: $(STATIC_LIB_DEPS)
 $(STATIC_LIB_DEPS):
-	@$(MAKE) -C $(dir $(@))
+	@flock $(dir $(@)) $(MAKE) -C $(dir $(@))
 
 IPCCOMPILER = $(SERENITY_BASE_DIR)/DevTools/IPCCompiler/IPCCompiler
 IPCCOMPILER: $(IPCCOMPILER)
 $(IPCCOMPILER):
-	@$(MAKE) -C $(dir $(@))
+	@flock $(dir $(@)) $(MAKE) -C $(dir $(@))
 
 FORMCOMPILER = $(SERENITY_BASE_DIR)/DevTools/FormCompiler/FormCompiler
 FORMCOMPILER: $(FORMCOMPILER)
 $(FORMCOMPILER):
-	@$(MAKE) -C $(dir $(@))
+	@flock $(dir $(@)) $(MAKE) -C $(dir $(@))
 
 .DEFAULT_GOAL := all
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -39,7 +39,7 @@ else
     LINK = $(TOOLCHAIN_PATH)/i686-pc-serenity-ld
     RANLIB = $(TOOLCHAIN_PATH)/i686-pc-serenity-ranlib
     AR = $(TOOLCHAIN_PATH)/i686-pc-serenity-ar
-    
+
     DEFINES += -DDEBUG
 
     INCLUDE_FLAGS += \
@@ -51,7 +51,7 @@ else
         DEFINES += -DKERNEL
     else
         # everything else gets -lc -lm
-        LIB_DEPS += C M
+        LIB_DEPS := C M $(LIB_DEPS)
     endif
 
     # turn "LIB_DEPS=C Core Thread" into "-lc -lcore -lthread -L.../LibC ..."

--- a/Makefile.subdir
+++ b/Makefile.subdir
@@ -1,17 +1,17 @@
 subdirs: $(SUBDIRS)
 $(SUBDIRS):
-	@$(MAKE) -C $@
+	@flock $@ $(MAKE) -C $@
 
 all: $(subdirs)
 
 SUBDIRS_CLEAN = $(addsuffix .clean,$(SUBDIRS))
 clean: $(SUBDIRS_CLEAN)
 $(SUBDIRS_CLEAN): %.clean:
-	@$(MAKE) -C $* clean
+	@flock $* $(MAKE) -C $* clean
 
 SUBDIRS_INSTALL = $(addsuffix .install,$(SUBDIRS))
 install: $(SUBDIRS_INSTALL)
 $(SUBDIRS_INSTALL): %.install:
-	@$(MAKE) -C $* install
+	@flock $* $(MAKE) -C $* install
 
 .PHONY: all clean install $(SUBDIRS)

--- a/Servers/AudioServer/Makefile
+++ b/Servers/AudioServer/Makefile
@@ -12,10 +12,10 @@ EXTRA_CLEAN = AudioServerEndpoint.h AudioClientEndpoint.h
 
 *.cpp: AudioServerEndpoint.h AudioClientEndpoint.h
 
-AudioServerEndpoint.h: AudioServer.ipc IPCCOMPILER
+AudioServerEndpoint.h: AudioServer.ipc | IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
-AudioClientEndpoint.h: AudioClient.ipc IPCCOMPILER
+AudioClientEndpoint.h: AudioClient.ipc | IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
 install:

--- a/Servers/ProtocolServer/Makefile
+++ b/Servers/ProtocolServer/Makefile
@@ -12,10 +12,10 @@ LIB_DEPS = Core IPC
 
 *.cpp: ProtocolServerEndpoint.h ProtocolClientEndpoint.h
 
-ProtocolServerEndpoint.h: ProtocolServer.ipc IPCCOMPILER
+ProtocolServerEndpoint.h: ProtocolServer.ipc | IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
-ProtocolClientEndpoint.h: ProtocolClient.ipc IPCCOMPILER
+ProtocolClientEndpoint.h: ProtocolClient.ipc | IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
 include ../../Makefile.common

--- a/Servers/WindowServer/Makefile
+++ b/Servers/WindowServer/Makefile
@@ -22,10 +22,10 @@ LIB_DEPS = Draw Core Thread Pthread IPC
 
 *.cpp: WindowServerEndpoint.h WindowClientEndpoint.h
 
-WindowServerEndpoint.h: WindowServer.ipc IPCCOMPILER
+WindowServerEndpoint.h: WindowServer.ipc | IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
-WindowClientEndpoint.h: WindowClient.ipc IPCCOMPILER
+WindowClientEndpoint.h: WindowClient.ipc | IPCCOMPILER
 	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
 EXTRA_CLEAN = WindowServerEndpoint.h WindowClientEndpoint.h

--- a/Userland/Makefile
+++ b/Userland/Makefile
@@ -6,13 +6,17 @@ EXTRA_CLEAN = $(APPS)
 
 LIB_DEPS = HTML GUI Draw Audio Protocol IPC Thread Pthread Core PCIDB Markdown
 
-all: $(OBJS) $(APPS)
+include ../Makefile.common
+
+all: $(APPS)
 
 list:
 	@echo $(APPS)
 
-$(APPS): %: %.o $(OBJS)
+%.o: %.cpp
+	@echo "C++ $@"
+	$(QUIET) $(CXX) $(CXXFLAGS) -o $@ -c $<
+
+$(APPS): %: %.o $(STATIC_LIB_DEPS)
 	@echo "LINK $@"
 	$(QUIET) $(CXX) -o $@ $< $(LDFLAGS)
-
-include ../Makefile.common


### PR DESCRIPTION
This adds locking to get building with `-j` and not trip over itself, though it still won't be able to build everything with all those child processes because some will sit idle waiting to acquire a lock file while the dependency library is being built by another child.  So if you do `make -j4` and two `make` processes sit idle waiting for `flock` to exit, `make` will only execute 2 `g++` processes in the directories where they have locks.

It should also fix an issue where something like LibGUI would build, then an application using it would build, then later in the build a few files in LibGUI would need recompiling without being modified.  This was because of the IPC-generated header files being re-generated when they shouldn't have, making the `.cpp` file's `.o` out-of-date.

And it should also fix building in `Userland` where only one file is modified and it was relinking all of the binaries.