### PR TITLE
Build: Fix missing IPC dependency for LibHTML

### DIFF
--- a/Libraries/LibHTML/Makefile
+++ b/Libraries/LibHTML/Makefile
@@ -88,6 +88,10 @@ CSS/PropertyID.cpp: CSS/Properties.json $(GENERATE_CSS_PROPERTYID_CPP)
 	@echo "GENERATE $@"
 	$(QUIET) $(GENERATE_CSS_PROPERTYID_CPP) $< > $@
 
+ResourceLoader.cpp: ../../Servers/ProtocolServer/ProtocolClientEndpoint.h
+../../Servers/ProtocolServer/ProtocolClientEndpoint.h:
+	@$(MAKE) -C $(dir $(@))
+
 EXTRA_CLEAN = CSS/DefaultStyleSheetSource.cpp CSS/PropertyID.h CSS/PropertyID.cpp
 
 OBJS = $(EXTRA_OBJS) $(LIBHTML_OBJS)


### PR DESCRIPTION
As spotted on #927, `LibHTML` now depends on `ProtocolServer` IPC generated headers.
The build system however doesn't track this dependency, leading to a "clean" rebuild to probably fail. From my tests I think that this fix could make b1a8ca211f8c6fad9408e8b82bba52bbc93868ff not needed anymore.