### PR TITLE
Toolchain: Fix building binutils on macOS with --enable-shared

### DIFF
--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -102,6 +102,15 @@ pushd "$DIR/Build/"
                                                 --with-sysroot="$SYSROOT" \
                                                 --enable-shared \
                                                 --disable-nls || exit 1
+        if [ "$(uname)" = "Darwin" ]; then
+            # under macOS generated makefiles are not resolving the "intl"
+            # dependency properly to allow linking its own copy of
+            # libintl when building with --enable-shared.
+            make -j "$MAKEJOBS" || true
+            pushd intl
+            make all-yes
+            popd
+        fi
         make -j "$MAKEJOBS" || exit 1
         make install || exit 1
     popd


### PR DESCRIPTION
Commit 4a0fb34eb833a586fd8dde93dbbe844a544ef251 has been breaking building binutils on macOS with  error message similar to the following.

> ld: library not found for -lintl
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[4]: *** [libbfd.la] Error 1
make[3]: *** [all-recursive] Error 1
make[2]: *** [all] Error 2
make[1]: *** [all-bfd] Error 2
make: *** [all] Error 2

If you're not getting this error it means that you have `libintl` installed through `gettext` on your system (probably with `brew link gettext` or something similar).
In the spirit of getting the Toolchain as much as possible self containted as possible, and also in the spirit of correctness, as binutils probably wants to link its own built-in version of libintl, I am sending this pull request.

I am not an autotools expert but it looks like the `bfd` library it's specifying something to be done differently on macOS inside `configure.ac`

>   Use built-in libintl on macOS, since it is not provided by libc.
  *-*-darwin*)
    SHARED_LIBADD="-L`pwd`/../libiberty/pic -L`pwd`/../intl -liberty -lintl"

Probably here we should file a bug report inside the binutils project, but for now this is a small hack to get `libintl` to be built before `libbfd`.

I am open for suggestions from anyone that knows a better way of fixing it 😃 
