### PR TITLE
 Kernel: Retry mmap if MAP_FIXED is not in flags and addr is not 0 

### DIFF
--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -56,10 +56,28 @@ public:
         m_is_error = other.m_is_error;
         if (m_is_error)
             m_error = other.m_error;
-        else
+        else {
             new (&m_storage) T(move(other.value()));
+            other.value().~T();
+        }
         other.m_is_error = true;
         other.m_error = KSuccess;
+    }
+
+    KResultOr& operator=(KResultOr&& other)
+    {
+        if (!m_is_error)
+           value().~T();
+        m_is_error = other.m_is_error;
+        if (m_is_error)
+            m_error = other.m_error;
+        else {
+            new (&m_storage) T(move(other.value()));
+            other.value().~T();
+        }
+        other.m_is_error = true;
+        other.m_error = KSuccess;
+        return *this;
     }
 
     ~KResultOr()


### PR DESCRIPTION
If an mmap fails to allocate a region, but the addr passed in was
non-zero, non-fixed mmaps should attempt to allocate at any available
virtual address.

Also includes adding a move-assign operator to KResultOr because you couldn't re-use the same "optional" before.

Closes #884 
