### PR TITLE
Kernel: sys$mprotect protects sub-regions as well as whole ones

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -292,6 +292,7 @@ public:
     bool deallocate_region(Region& region);
 
     Region& allocate_split_region(const Region& source_region, const Range&, size_t offset_in_vmobject);
+    Vector<Region*, 2> split_region_around_range(const Region& source_region, const Range&);
 
     void set_being_inspected(bool b) { m_being_inspected = b; }
     bool is_being_inspected() const { return m_being_inspected; }


### PR DESCRIPTION
Use the same method as in sys$munmap to split a region into two if the
desired mprotect range is a strict subset of an existing region, then
mprotect the region that is our desired range and add both the new
desired subregion and the leftovers back to our page tables.