### PR TITLE
MenuBar and AboutDialog additions to a few apps

### DIFF
--- a/Applications/Calculator/main.cpp
+++ b/Applications/Calculator/main.cpp
@@ -1,5 +1,9 @@
 #include "CalculatorWidget.h"
+#include <LibDraw/PNGLoader.h>
+#include <LibGUI/GAboutDialog.h>
+#include <LibGUI/GAction.h>
 #include <LibGUI/GApplication.h>
+#include <LibGUI/GMenuBar.h>
 #include <LibGUI/GWindow.h>
 
 int main(int argc, char** argv)
@@ -16,5 +20,23 @@ int main(int argc, char** argv)
 
     window->show();
     window->set_icon(GraphicsBitmap::load_from_file("/res/icons/16x16/app-calculator.png"));
+
+    auto menubar = make<GMenuBar>();
+
+    auto app_menu = GMenu::construct("Calculator");
+    app_menu->add_action(GCommonActions::make_quit_action([](auto&) {
+        GApplication::the().quit(0);
+        return;
+    }));
+    menubar->add_menu(move(app_menu));
+
+    auto help_menu = GMenu::construct("Help");
+    help_menu->add_action(GAction::create("About", [&](const GAction&) {
+        GAboutDialog::show("Calculator", load_png("/res/icons/16x16/app-calculator.png"), window);
+    }));
+    menubar->add_menu(move(help_menu));
+
+    app.set_menubar(move(menubar));
+
     return app.exec();
 }

--- a/Applications/ChanViewer/main.cpp
+++ b/Applications/ChanViewer/main.cpp
@@ -1,9 +1,12 @@
 #include "BoardListModel.h"
 #include "ThreadCatalogModel.h"
 #include <LibDraw/PNGLoader.h>
+#include <LibGUI/GAboutDialog.h>
+#include <LibGUI/GAction.h>
 #include <LibGUI/GApplication.h>
 #include <LibGUI/GBoxLayout.h>
 #include <LibGUI/GComboBox.h>
+#include <LibGUI/GMenuBar.h>
 #include <LibGUI/GStatusBar.h>
 #include <LibGUI/GTableView.h>
 #include <LibGUI/GWindow.h>
@@ -52,6 +55,23 @@ int main(int argc, char** argv)
     };
 
     window->show();
+
+    auto menubar = make<GMenuBar>();
+
+    auto app_menu = GMenu::construct("ChanViewer");
+    app_menu->add_action(GCommonActions::make_quit_action([](auto&) {
+        GApplication::the().quit(0);
+        return;
+    }));
+    menubar->add_menu(move(app_menu));
+
+    auto help_menu = GMenu::construct("Help");
+    help_menu->add_action(GAction::create("About", [&](const GAction&) {
+        GAboutDialog::show("ChanViewer", load_png("/res/icons/32x32/app-chanviewer.png"), window);
+    }));
+    menubar->add_menu(move(help_menu));
+
+    app.set_menubar(move(menubar));
 
     return app.exec();
 }

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -6,6 +6,7 @@
 #include <LibCore/CConfigFile.h>
 #include <LibCore/CUserInfo.h>
 #include <LibDraw/PNGLoader.h>
+#include <LibGUI/GAboutDialog.h>
 #include <LibGUI/GAction.h>
 #include <LibGUI/GActionGroup.h>
 #include <LibGUI/GApplication.h>
@@ -383,8 +384,8 @@ int main(int argc, char** argv)
     menubar->add_menu(move(go_menu));
 
     auto help_menu = GMenu::construct("Help");
-    help_menu->add_action(GAction::create("About", [](const GAction&) {
-        dbgprintf("FIXME: Implement Help/About\n");
+    help_menu->add_action(GAction::create("About", [&](const GAction&) {
+        GAboutDialog::show("File Manager", load_png("/res/icons/32x32/filetype-folder.png"), window);
     }));
     menubar->add_menu(move(help_menu));
 

--- a/Applications/FontEditor/main.cpp
+++ b/Applications/FontEditor/main.cpp
@@ -1,6 +1,9 @@
 #include "FontEditor.h"
 #include <LibDraw/PNGLoader.h>
+#include <LibGUI/GAboutDialog.h>
+#include <LibGUI/GAction.h>
 #include <LibGUI/GApplication.h>
+#include <LibGUI/GMenuBar.h>
 #include <LibGUI/GWindow.h>
 #include <stdio.h>
 
@@ -28,9 +31,28 @@ int main(int argc, char** argv)
     auto window = GWindow::construct();
     window->set_title("Font Editor");
     window->set_rect({ 50, 50, 390, 342 });
+
     auto font_editor = FontEditorWidget::construct(path, move(edited_font));
     window->set_main_widget(font_editor);
     window->show();
     window->set_icon(load_png("/res/icons/16x16/app-font-editor.png"));
+
+    auto menubar = make<GMenuBar>();
+
+    auto app_menu = GMenu::construct("Font Editor");
+    app_menu->add_action(GCommonActions::make_quit_action([](auto&) {
+        GApplication::the().quit(0);
+        return;
+    }));
+    menubar->add_menu(move(app_menu));
+
+    auto help_menu = GMenu::construct("Help");
+    help_menu->add_action(GAction::create("About", [&](const GAction&) {
+        GAboutDialog::show("Font Editor", load_png("/res/icons/FontEditor.png"), window);
+    }));
+    menubar->add_menu(move(help_menu));
+
+    app.set_menubar(move(menubar));
+
     return app.exec();
 }

--- a/Applications/Piano/main.cpp
+++ b/Applications/Piano/main.cpp
@@ -3,9 +3,9 @@
 #include <LibAudio/AClientConnection.h>
 #include <LibCore/CFile.h>
 #include <LibDraw/PNGLoader.h>
+#include <LibGUI/GAboutDialog.h>
 #include <LibGUI/GAction.h>
 #include <LibGUI/GApplication.h>
-#include <LibGUI/GMenu.h>
 #include <LibGUI/GMenuBar.h>
 #include <LibGUI/GWindow.h>
 #include <LibThread/Thread.h>
@@ -50,6 +50,12 @@ int main(int argc, char** argv)
         return;
     }));
     menubar->add_menu(move(app_menu));
+
+    auto help_menu = GMenu::construct("Help");
+    help_menu->add_action(GAction::create("About", [&](const GAction&) {
+        GAboutDialog::show("Piano", load_png("/res/icons/32x32/app-piano.png"), window);
+    }));
+    menubar->add_menu(move(help_menu));
 
     app.set_menubar(move(menubar));
 

--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -157,7 +157,7 @@ int main(int argc, char** argv)
 
     auto help_menu = GMenu::construct("Help");
     help_menu->add_action(GAction::create("About", [&](const GAction&) {
-        GAboutDialog::show("SystemMonitor", load_png("/res/icons/32x32/app-system-monitor.png"), window);
+        GAboutDialog::show("System Monitor", load_png("/res/icons/32x32/app-system-monitor.png"), window);
     }));
     menubar->add_menu(move(help_menu));
 

--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -244,7 +244,7 @@ TextEditorWidget::TextEditorWidget()
 
     auto help_menu = GMenu::construct("Help");
     help_menu->add_action(GAction::create("About", [&](const GAction&) {
-        GAboutDialog::show("TextEditor", load_png("/res/icons/32x32/app-texteditor.png"), window());
+        GAboutDialog::show("Text Editor", load_png("/res/icons/32x32/app-texteditor.png"), window());
     }));
     menubar->add_menu(move(help_menu));
 

--- a/Games/Minesweeper/main.cpp
+++ b/Games/Minesweeper/main.cpp
@@ -1,6 +1,7 @@
 #include "Field.h"
 #include <LibCore/CConfigFile.h>
 #include <LibDraw/PNGLoader.h>
+#include <LibGUI/GAboutDialog.h>
 #include <LibGUI/GAction.h>
 #include <LibGUI/GApplication.h>
 #include <LibGUI/GBoxLayout.h>
@@ -89,8 +90,8 @@ int main(int argc, char** argv)
     menubar->add_menu(move(difficulty_menu));
 
     auto help_menu = GMenu::construct("Help");
-    help_menu->add_action(GAction::create("About", [](const GAction&) {
-        dbgprintf("FIXME: Implement Help/About\n");
+    help_menu->add_action(GAction::create("About", [&](const GAction&) {
+        GAboutDialog::show("Minesweeper", load_png("/res/icons/32x32/app-minesweeper.png"), window);
     }));
     menubar->add_menu(move(help_menu));
 

--- a/Games/Snake/main.cpp
+++ b/Games/Snake/main.cpp
@@ -1,5 +1,6 @@
 #include "SnakeGame.h"
 #include <LibDraw/PNGLoader.h>
+#include <LibGUI/GAboutDialog.h>
 #include <LibGUI/GAction.h>
 #include <LibGUI/GApplication.h>
 #include <LibGUI/GBoxLayout.h>
@@ -35,8 +36,8 @@ int main(int argc, char** argv)
     menubar->add_menu(move(app_menu));
 
     auto help_menu = GMenu::construct("Help");
-    help_menu->add_action(GAction::create("About", [](const GAction&) {
-        dbgprintf("FIXME: Implement Help/About\n");
+    help_menu->add_action(GAction::create("About", [&](const GAction&) {
+        GAboutDialog::show("Snake", load_png("/res/icons/32x32/app-snake.png"), window);
     }));
     menubar->add_menu(move(help_menu));
 


### PR DESCRIPTION
82b7385 - Implements missing `GMenuBars` to some applications as well as adding `GAboutDialogs` to them. This also hooks up `FileManager`, `Minesweeper` & `Snake` with About dialogs that they've been missing for now ^^
9ece080 - Simply space out `System Monitor` and `Text Editor` in their respective About dialogs to match the already set window titles, app menu labels & other apps like `Visual Builder`, `Display Properties` etc

Feedback is welcome! :smiley: 