### PR TITLE
PCI, ACPI & Friends

### DIFF
--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -290,10 +290,11 @@ RefPtr<GWidget> build_pci_devices_tab()
         pci_fields.empend(
             "Address", TextAlignment::CenterLeft,
             [](const JsonObject& object) {
+                auto seg = object.get("seg").to_u32();
                 auto bus = object.get("bus").to_u32();
                 auto slot = object.get("slot").to_u32();
                 auto function = object.get("function").to_u32();
-                return String::format("%02x:%02x.%d", bus, slot, function);
+                return String::format("%04x:%02x:%02x.%d", seg, bus, slot, function);
             });
         pci_fields.empend(
             "Class", TextAlignment::CenterLeft,

--- a/Kernel/ACPI/ACPIDynamicParser.cpp
+++ b/Kernel/ACPI/ACPIDynamicParser.cpp
@@ -1,0 +1,67 @@
+#include <Kernel/ACPI/ACPIDynamicParser.h>
+#include <Kernel/ACPI/ACPIParser.h>
+
+void ACPIDynamicParser::initialize(ACPI_RAW::RSDPDescriptor20& rsdp)
+{
+    if (!ACPIStaticParser::is_initialized()) {
+        new ACPIDynamicParser(rsdp);
+    }
+}
+void ACPIDynamicParser::initialize_without_rsdp()
+{
+    if (!ACPIStaticParser::is_initialized()) {
+        new ACPIDynamicParser();
+    }
+}
+
+ACPIDynamicParser::ACPIDynamicParser()
+    : IRQHandler(9)
+    , ACPIStaticParser()
+
+{
+    kprintf("ACPI: Dynamic Parsing Enabled, Can parse AML\n");
+}
+ACPIDynamicParser::ACPIDynamicParser(ACPI_RAW::RSDPDescriptor20& rsdp)
+    : IRQHandler(9)
+    , ACPIStaticParser(rsdp)
+{
+    kprintf("ACPI: Dynamic Parsing Enabled, Can parse AML\n");
+}
+
+void ACPIDynamicParser::handle_irq()
+{
+    // FIXME: Implement IRQ handling of ACPI signals!
+    ASSERT_NOT_REACHED();
+}
+
+void ACPIDynamicParser::enable_aml_interpretation()
+{
+    // FIXME: Implement AML Interpretation
+    ASSERT_NOT_REACHED();
+}
+void ACPIDynamicParser::enable_aml_interpretation(File&)
+{
+    // FIXME: Implement AML Interpretation
+    ASSERT_NOT_REACHED();
+}
+void ACPIDynamicParser::enable_aml_interpretation(u8*, u32)
+{
+    // FIXME: Implement AML Interpretation
+    ASSERT_NOT_REACHED();
+}
+void ACPIDynamicParser::disable_aml_interpretation()
+{
+    // FIXME: Implement AML Interpretation
+    ASSERT_NOT_REACHED();
+}
+void ACPIDynamicParser::do_acpi_shutdown()
+{
+    // FIXME: Implement AML Interpretation to perform ACPI shutdown
+    ASSERT_NOT_REACHED();
+}
+
+void ACPIDynamicParser::build_namespace()
+{
+    // FIXME: Implement AML Interpretation to build the ACPI namespace
+    ASSERT_NOT_REACHED();
+}

--- a/Kernel/ACPI/ACPIDynamicParser.h
+++ b/Kernel/ACPI/ACPIDynamicParser.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <AK/RefPtr.h>
+#include <Kernel/ACPI/ACPIStaticParser.h>
+#include <Kernel/Devices/DiskDevice.h>
+#include <Kernel/IRQHandler.h>
+#include <Kernel/Lock.h>
+#include <Kernel/VM/PhysicalAddress.h>
+#include <Kernel/VM/PhysicalPage.h>
+
+class ACPIDynamicParser final : public IRQHandler
+    , ACPIStaticParser {
+public:
+    static void initialize(ACPI_RAW::RSDPDescriptor20& rsdp);
+    static void initialize_without_rsdp();
+
+    virtual void enable_aml_interpretation() override;
+    virtual void enable_aml_interpretation(File& dsdt_file) override;
+    virtual void enable_aml_interpretation(u8* physical_dsdt, u32 dsdt_payload_legnth) override;
+    virtual void disable_aml_interpretation() override;
+    virtual void do_acpi_shutdown() override;
+
+protected:
+    ACPIDynamicParser();
+    explicit ACPIDynamicParser(ACPI_RAW::RSDPDescriptor20&);
+
+private:
+    void build_namespace();
+    // ^IRQHandler
+    virtual void handle_irq() override;
+
+    OwnPtr<Region> m_acpi_namespace;
+};

--- a/Kernel/ACPI/ACPIParser.cpp
+++ b/Kernel/ACPI/ACPIParser.cpp
@@ -1,0 +1,84 @@
+#include <Kernel/ACPI/ACPIParser.h>
+
+static ACPIParser* s_acpi_parser;
+
+ACPIParser& ACPIParser::the()
+{
+    ASSERT(s_acpi_parser != nullptr);
+    return *s_acpi_parser;
+}
+
+void ACPIParser::initialize_limited()
+{
+    if (!ACPIParser::is_initialized()) {
+        s_acpi_parser = new ACPIParser(false);
+    }
+}
+
+bool ACPIParser::is_initialized()
+{
+    return (s_acpi_parser != nullptr);
+}
+
+ACPIParser::ACPIParser(bool usable)
+{
+    if (usable) {
+        kprintf("ACPI: Setting up a functional parser\n");
+    } else {
+        kprintf("ACPI: Limited Initialization. Vital functions are disabled by a request\n");
+    }
+    s_acpi_parser = this;
+}
+
+ACPI_RAW::SDTHeader* ACPIParser::find_table(const char*)
+{
+    kprintf("ACPI: Requested to search for a table, Abort!\n");
+    return nullptr;
+}
+
+void ACPIParser::mmap(VirtualAddress, PhysicalAddress, u32)
+{
+    ASSERT_NOT_REACHED();
+}
+
+void ACPIParser::mmap_region(Region&, PhysicalAddress)
+{
+    ASSERT_NOT_REACHED();
+}
+
+void ACPIParser::do_acpi_reboot()
+{
+    kprintf("ACPI: Cannot invoke reboot!\n");
+    ASSERT_NOT_REACHED();
+}
+
+void ACPIParser::do_acpi_shutdown()
+{
+    kprintf("ACPI: Cannot invoke shutdown!\n");
+    ASSERT_NOT_REACHED();
+}
+
+void ACPIParser::enable_aml_interpretation()
+{
+    kprintf("ACPI: No AML Interpretation Allowed\n");
+    ASSERT_NOT_REACHED();
+}
+void ACPIParser::enable_aml_interpretation(File&)
+{
+    kprintf("ACPI: No AML Interpretation Allowed\n");
+    ASSERT_NOT_REACHED();
+}
+void ACPIParser::enable_aml_interpretation(u8*, u32)
+{
+    kprintf("ACPI: No AML Interpretation Allowed\n");
+    ASSERT_NOT_REACHED();
+}
+void ACPIParser::disable_aml_interpretation()
+{
+    kprintf("ACPI Limited: No AML Interpretation Allowed\n");
+    ASSERT_NOT_REACHED();
+}
+bool ACPIParser::is_operable()
+{
+    return false;
+}

--- a/Kernel/ACPI/ACPIParser.h
+++ b/Kernel/ACPI/ACPIParser.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/ACPI/Definitions.h>
+#include <Kernel/FileSystem/File.h>
+#include <Kernel/VM/PhysicalAddress.h>
+#include <Kernel/VM/Region.h>
+#include <Kernel/VM/VirtualAddress.h>
+
+class ACPIParser {
+public:
+    static ACPIParser& the();
+
+    static bool is_initialized();
+    static void initialize_limited();
+    virtual ACPI_RAW::SDTHeader* find_table(const char* sig);
+
+    virtual void do_acpi_reboot();
+    virtual void do_acpi_shutdown();
+
+    virtual void enable_aml_interpretation();
+    virtual void enable_aml_interpretation(File&);
+    virtual void enable_aml_interpretation(u8*, u32);
+    virtual void disable_aml_interpretation();
+    virtual bool is_operable();
+
+protected:
+    explicit ACPIParser(bool usable);
+    bool m_operable;
+
+    virtual void mmap(VirtualAddress, PhysicalAddress, u32);
+    virtual void mmap_region(Region&, PhysicalAddress);
+};

--- a/Kernel/ACPI/ACPIStaticParser.cpp
+++ b/Kernel/ACPI/ACPIStaticParser.cpp
@@ -1,0 +1,372 @@
+#include <Kernel/ACPI/ACPIStaticParser.h>
+#include <Kernel/IO.h>
+#include <Kernel/StdLib.h>
+#include <Kernel/VM/MemoryManager.h>
+
+void ACPIStaticParser::initialize(ACPI_RAW::RSDPDescriptor20& rsdp)
+{
+    if (!ACPIParser::is_initialized()) {
+        new ACPIStaticParser(rsdp);
+    }
+}
+void ACPIStaticParser::initialize_without_rsdp()
+{
+    if (!ACPIParser::is_initialized()) {
+        new ACPIStaticParser();
+    }
+}
+
+bool ACPIStaticParser::is_initialized()
+{
+    return ACPIParser::is_initialized();
+}
+
+void ACPIStaticParser::locate_static_data()
+{
+    locate_main_system_description_table();
+    initialize_main_system_description_table();
+    init_fadt();
+    locate_all_aml_tables();
+}
+
+ACPI_RAW::SDTHeader* ACPIStaticParser::find_table(const char* sig)
+{
+#ifdef ACPI_DEBUG
+    dbgprintf("ACPI: Calling Find Table method!\n");
+#endif
+    for (auto* physical_sdt_ptr : m_main_sdt->get_sdt_pointers()) {
+        auto region = MM.allocate_kernel_region((PAGE_SIZE * 2), "ACPI Static Parser Tables Finding", Region::Access::Read);
+        mmap_region(*region, PhysicalAddress((u32)physical_sdt_ptr));
+        ACPI_RAW::SDTHeader* sdt = (ACPI_RAW::SDTHeader*)(region->vaddr().get() + ((u32)physical_sdt_ptr & (~PAGE_MASK)));
+#ifdef ACPI_DEBUG
+        dbgprintf("ACPI: Examining Table @ P 0x%x\n", physical_sdt_ptr);
+#endif
+        if (!strncmp(sdt->sig, sig, 4)) {
+#ifdef ACPI_DEBUG
+            dbgprintf("ACPI: Found Table @ P 0x%x\n", physical_sdt_ptr);
+#endif
+            return physical_sdt_ptr;
+        }
+    }
+    return nullptr;
+}
+
+ACPI_RAW::SDTHeader& ACPIStaticParser::find_fadt()
+{
+    kprintf("ACPI: Searching for the Fixed ACPI Data Table\n");
+    for (auto* physical_sdt_ptr : m_main_sdt->get_sdt_pointers()) {
+        auto region = MM.allocate_kernel_region((PAGE_SIZE * 2), "ACPI Static Parser AML Tables Finding", Region::Access::Read);
+        mmap_region(*region, PhysicalAddress((u32)physical_sdt_ptr & PAGE_MASK));
+        ACPI_RAW::SDTHeader* sdt = (ACPI_RAW::SDTHeader*)(region->vaddr().get() + ((u32)physical_sdt_ptr & (~PAGE_MASK)));
+#ifdef ACPI_DEBUG
+        dbgprintf("ACPI: Examining Table @ P 0x%x\n", physical_sdt_ptr);
+#endif
+        if (!strncmp(sdt->sig, "FACP", 4)) {
+            kprintf("ACPI: Found FADT Table @ P 0x%x, registering\n", physical_sdt_ptr);
+            return *physical_sdt_ptr;
+        }
+    }
+    ASSERT_NOT_REACHED(); // If we reached this point, there's something very incorrect with the system!
+}
+
+void ACPIStaticParser::init_fadt()
+{
+    kprintf("ACPI: Initializing Fixed ACPI data\n");
+    ACPI_RAW::SDTHeader& physical_fadt = find_fadt();
+
+    auto checkup_region = MM.allocate_kernel_region((PAGE_SIZE * 2), "ACPI Static Parser", Region::Access::Read);
+#ifdef ACPI_DEBUG
+    dbgprintf("ACPI: Checking FADT Length to choose the correct mapping size\n");
+#endif
+    mmap_region(*checkup_region, PhysicalAddress((u32)(&physical_fadt) & PAGE_MASK));
+
+    ACPI_RAW::SDTHeader* sdt = (ACPI_RAW::SDTHeader*)(checkup_region->vaddr().get() + ((u32)(&physical_fadt) & (~PAGE_MASK)));
+#ifdef ACPI_DEBUG
+    dbgprintf("ACPI: FADT @ V 0x%x, P 0x%x\n", sdt, &physical_fadt);
+#endif
+    u32 length = sdt->length;
+    kprintf("ACPI: Fixed ACPI data, Revision %u\n", sdt->revision);
+
+    auto fadt_region = MM.allocate_kernel_region(PAGE_ROUND_UP(length) + PAGE_SIZE, "ACPI Static Parser", Region::Access::Read);
+    mmap_region(*fadt_region, PhysicalAddress((u32)(&physical_fadt) & PAGE_MASK));
+    m_fadt = OwnPtr<ACPI::FixedACPIData>(new ACPI::FixedACPIData(*((ACPI_RAW::FADT*)(fadt_region->vaddr().get() + ((u32)(&physical_fadt) & (~PAGE_MASK))))));
+#ifdef ACPI_DEBUG
+    dbgprintf("ACPI: Finished to initialize Fixed ACPI data\n");
+#endif
+}
+
+void ACPIStaticParser::do_acpi_reboot()
+{
+    // FIXME: Determine if we need to do MMIO/PCI/IO access to reboot, according to ACPI spec 6.2, Section 4.8.3.6
+#ifdef ACPI_DEBUG
+    dbgprintf("ACPI: Rebooting, Probing FADT (P @ 0x%x)\n", m_fadt.ptr());
+#endif
+    if (m_fadt->m_revision >= 2) {
+        kprintf("ACPI: Reboot, Sending value 0%x to Port 0x%x\n", m_fadt->m_reset_value, m_fadt->m_reset_reg.address);
+        IO::out8(m_fadt->m_reset_reg.address, m_fadt->m_reset_value);
+    } else {
+        kprintf("ACPI: Reboot, Not supported!\n");
+    }
+
+    ASSERT_NOT_REACHED(); /// If rebooting didn't work, halt.
+}
+
+void ACPIStaticParser::do_acpi_shutdown()
+{
+    kprintf("ACPI: Shutdown is not supported with the current configuration, Abort!\n");
+    ASSERT_NOT_REACHED();
+}
+
+void ACPIStaticParser::initialize_main_system_description_table()
+{
+    auto checkup_region = MM.allocate_kernel_region((PAGE_SIZE * 2), "ACPI Static Parser Copying Method", Region::Access::Read);
+#ifdef ACPI_DEBUG
+    dbgprintf("ACPI: Checking Main SDT Length to choose the correct mapping size");
+#endif
+    mmap_region(*checkup_region, PhysicalAddress((u32)m_main_system_description_table & PAGE_MASK));
+
+    auto* sdt = (ACPI_RAW::SDTHeader*)(checkup_region->vaddr().get() + ((u32)m_main_system_description_table & (~PAGE_MASK)));
+    u32 length = sdt->length;
+    u8 revision = sdt->revision;
+
+    auto main_sdt_region = MM.allocate_kernel_region(PAGE_ROUND_UP(length) + PAGE_SIZE, "ACPI Static Parser Copying Method", Region::Access::Read);
+    mmap_region(*main_sdt_region, PhysicalAddress((u32)m_main_system_description_table & PAGE_MASK));
+
+    Vector<ACPI_RAW::SDTHeader*> sdt_pointers;
+    if (m_xsdt_supported) {
+        ACPI_RAW::XSDT* xsdt = (ACPI_RAW::XSDT*)(main_sdt_region->vaddr().get() + ((u32)m_main_system_description_table & (~PAGE_MASK)));
+        kprintf("ACPI: Using XSDT, Enumerating tables @ P 0x%x\n", m_main_system_description_table);
+        kprintf("ACPI: XSDT Revision %d, Total length - %u\n", revision, length);
+        for (u32 i = 0; i < ((xsdt->h.length - sizeof(ACPI_RAW::SDTHeader)) / sizeof(u64)); i++) {
+#ifdef ACPI_DEBUG
+            dbgprintf("ACPI: Found new table, @ P 0x%x\n", xsdt->table_ptrs[i]);
+#endif
+            sdt_pointers.append((ACPI_RAW::SDTHeader*)xsdt->table_ptrs[i]);
+        }
+    } else {
+        ACPI_RAW::RSDT* rsdt = (ACPI_RAW::RSDT*)(main_sdt_region->vaddr().get() + ((u32)m_main_system_description_table & (~PAGE_MASK)));
+        kprintf("ACPI: Using RSDT, Enumerating tables @ P 0x%x\n", m_main_system_description_table);
+        kprintf("ACPI: RSDT Revision %d, Total length - %u\n", revision, length);
+        for (u32 i = 0; i < ((rsdt->h.length - sizeof(ACPI_RAW::SDTHeader)) / sizeof(u32)); i++) {
+#ifdef ACPI_DEBUG
+            dbgprintf("ACPI: Found new table, @ P 0x%x\n", rsdt->table_ptrs[i]);
+#endif
+            sdt_pointers.append((ACPI_RAW::SDTHeader*)rsdt->table_ptrs[i]);
+        }
+    }
+    m_main_sdt = OwnPtr<ACPI::MainSystemDescriptionTable>(new ACPI::MainSystemDescriptionTable(move(sdt_pointers)));
+}
+
+void ACPIStaticParser::locate_main_system_description_table()
+{
+    if (m_rsdp->base.revision == 0) {
+        m_xsdt_supported = false;
+    } else if (m_rsdp->base.revision >= 2) {
+        if (m_rsdp->xsdt_ptr != (u64) nullptr) {
+            m_xsdt_supported = true;
+        } else {
+            m_xsdt_supported = false;
+        }
+    }
+    if (!m_xsdt_supported) {
+        m_main_system_description_table = (ACPI_RAW::SDTHeader*)m_rsdp->base.rsdt_ptr;
+    } else {
+        m_main_system_description_table = (ACPI_RAW::SDTHeader*)m_rsdp->xsdt_ptr;
+    }
+}
+
+void ACPIStaticParser::locate_all_aml_tables()
+{
+    // Note: According to the ACPI spec, DSDT pointer may be found in the FADT table.
+    // All other continuation of the DSDT can be found as pointers in the RSDT/XSDT.
+
+    kprintf("ACPI: Searching for AML Tables\n");
+    m_aml_tables_ptrs.append(m_fadt->get_dsdt());
+    for (auto* sdt_ptr : m_main_sdt->get_sdt_pointers()) {
+        auto region = MM.allocate_kernel_region((PAGE_SIZE * 2), "ACPI Static Parser AML Tables Finding", Region::Access::Read);
+        mmap_region(*region, PhysicalAddress((u32)sdt_ptr));
+        auto* sdt = (ACPI_RAW::SDTHeader*)(region->vaddr().get() + ((u32)sdt_ptr & (~PAGE_MASK)));
+#ifdef ACPI_DEBUG
+        dbgprintf("ACPI: Examining Table @ P 0x%x\n", sdt_ptr);
+#endif
+        if (!strncmp(sdt->sig, "SSDT", 4)) {
+            kprintf("ACPI: Found AML Table @ P 0x%x, registering\n", sdt_ptr);
+            m_aml_tables_ptrs.append(sdt);
+        }
+    }
+}
+
+ACPIStaticParser::ACPIStaticParser()
+    : ACPIParser(true)
+    , m_rsdp(nullptr)
+    , m_main_sdt(nullptr)
+    , m_fadt(nullptr)
+{
+    m_rsdp = search_rsdp();
+    if (m_rsdp != nullptr) {
+        kprintf("ACPI: Using RSDP @ P 0x%x\n", m_rsdp);
+        m_operable = true;
+        locate_static_data();
+    } else {
+        m_operable = false;
+        kprintf("ACPI: Disabled, due to RSDP being absent\n");
+    }
+}
+
+ACPI_RAW::RSDPDescriptor20* ACPIStaticParser::search_rsdp()
+{
+    auto region = MM.allocate_kernel_region(PAGE_SIZE, "ACPI Static Parser RSDP Finding", Region::Access::Read);
+    mmap_region(*region, PhysicalAddress(0));
+    u16 ebda_seg = (u16) * ((uint16_t*)((region->vaddr().get() & PAGE_MASK) + 0x40e));
+    kprintf("ACPI: Probing EBDA, Segment 0x%x\n", ebda_seg);
+
+    // FIXME: Ensure that we always have identity mapping (identity paging) here! Don't rely on existing mapping...
+    for (char* rsdp_str = (char*)(PhysicalAddress(ebda_seg << 4).as_ptr()); rsdp_str < (char*)((ebda_seg << 4) + 1024); rsdp_str += 16) {
+#ifdef ACPI_DEBUG
+        dbgprintf("ACPI: Looking for RSDP in EBDA @ Px%x\n", rsdp_str);
+#endif
+        if (!strncmp("RSD PTR ", rsdp_str, strlen("RSD PTR ")))
+            return (ACPI_RAW::RSDPDescriptor20*)rsdp_str;
+    }
+
+    // FIXME: Ensure that we always have identity mapping (identity paging) here! Don't rely on existing mapping...
+    for (char* rsdp_str = (char*)(PhysicalAddress(0xE0000).as_ptr()); rsdp_str < (char*)0xFFFFF; rsdp_str += 16) {
+#ifdef ACPI_DEBUG
+        dbgprintf("ACPI: Looking for RSDP in EBDA @ Px%x\n", rsdp_str);
+#endif
+        if (!strncmp("RSD PTR ", rsdp_str, strlen("RSD PTR ")))
+            return (ACPI_RAW::RSDPDescriptor20*)rsdp_str;
+    }
+    return nullptr;
+}
+
+void ACPIStaticParser::mmap(VirtualAddress vaddr, PhysicalAddress paddr, u32 length)
+{
+    unsigned i = 0;
+    while (length >= PAGE_SIZE) {
+        MM.map_for_kernel(VirtualAddress(vaddr.offset(i * PAGE_SIZE).get()), PhysicalAddress(paddr.offset(i * PAGE_SIZE).get()));
+#ifdef ACPI_DEBUG
+        dbgprintf("ACPI: map - V 0x%x -> P 0x%x\n", vaddr.offset(i * PAGE_SIZE).get(), paddr.offset(i * PAGE_SIZE).get());
+#endif
+        length -= PAGE_SIZE;
+        i++;
+    }
+    if (length > 0) {
+        MM.map_for_kernel(vaddr.offset(i * PAGE_SIZE), paddr.offset(i * PAGE_SIZE), true);
+    }
+#ifdef ACPI_DEBUG
+    dbgprintf("ACPI: Finished mapping\n");
+#endif
+}
+
+void ACPIStaticParser::mmap_region(Region& region, PhysicalAddress paddr)
+{
+#ifdef ACPI_DEBUG
+    dbgprintf("ACPI: Mapping region, size - %u\n", region.size());
+#endif
+    mmap(region.vaddr(), paddr, region.size());
+}
+
+ACPIStaticParser::ACPIStaticParser(ACPI_RAW::RSDPDescriptor20& rsdp)
+    : ACPIParser(true)
+    , m_rsdp(&rsdp)
+    , m_main_sdt(nullptr)
+    , m_fadt(nullptr)
+{
+    kprintf("ACPI: Using RSDP @ Px%x\n", &rsdp);
+    m_operable = true;
+    locate_static_data();
+}
+
+ACPI::MainSystemDescriptionTable::MainSystemDescriptionTable(Vector<ACPI_RAW::SDTHeader*>&& sdt_pointers)
+{
+    for (auto* sdt_ptr : sdt_pointers) {
+#ifdef ACPI_DEBUG
+        dbgprintf("ACPI: Register new table in Main SDT, @ P 0x%x\n", sdt_ptr);
+#endif
+        m_sdt_pointers.append(sdt_ptr);
+    }
+}
+Vector<ACPI_RAW::SDTHeader*>& ACPI::MainSystemDescriptionTable::get_sdt_pointers()
+{
+    return m_sdt_pointers;
+}
+
+ACPI::FixedACPIData::FixedACPIData(ACPI_RAW::FADT& fadt)
+{
+    m_dsdt_ptr = fadt.dsdt_ptr;
+#ifdef ACPI_DEBUG
+    dbgprintf("ACPI: DSDT pointer @ P 0x%x\n", m_dsdt_ptr);
+#endif
+    m_revision = fadt.h.revision;
+    m_x_dsdt_ptr = fadt.x_dsdt;
+    m_preferred_pm_profile = fadt.preferred_pm_profile;
+    m_sci_int = fadt.sci_int;
+    m_smi_cmd = fadt.smi_cmd;
+    m_acpi_enable_value = fadt.acpi_enable_value;
+    m_acpi_disable_value = fadt.acpi_disable_value;
+    m_s4bios_req = fadt.s4bios_req;
+    m_pstate_cnt = fadt.pstate_cnt;
+
+    m_PM1a_EVT_BLK = fadt.PM1a_EVT_BLK;
+    m_PM1b_EVT_BLK = fadt.PM1b_EVT_BLK;
+    m_PM1a_CNT_BLK = fadt.PM1a_CNT_BLK;
+    m_PM1b_CNT_BLK = fadt.PM1b_CNT_BLK;
+    m_PM2_CNT_BLK = fadt.PM2_CNT_BLK;
+    m_PM_TMR_BLK = fadt.PM_TMR_BLK;
+    m_GPE0_BLK = fadt.GPE0_BLK;
+    m_GPE1_BLK = fadt.GPE1_BLK;
+    m_PM1_EVT_LEN = fadt.PM1_EVT_LEN;
+    m_PM1_CNT_LEN = fadt.PM1_CNT_LEN;
+    m_PM2_CNT_LEN = fadt.PM2_CNT_LEN;
+    m_PM_TMR_LEN = fadt.PM_TMR_LEN;
+    m_GPE0_BLK_LEN = fadt.GPE0_BLK_LEN;
+    m_GPE1_BLK_LEN = fadt.GPE1_BLK_LEN;
+    m_GPE1_BASE = fadt.GPE1_BASE;
+    m_cst_cnt = fadt.cst_cnt;
+    m_P_LVL2_LAT = fadt.P_LVL2_LAT;
+    m_P_LVL3_LAT = fadt.P_LVL3_LAT;
+    m_flush_size = fadt.flush_size;
+
+    m_flush_stride = fadt.flush_stride;
+    m_duty_offset = fadt.duty_offset;
+    m_duty_width = fadt.duty_width;
+    m_day_alrm = fadt.day_alrm;
+    m_mon_alrm = fadt.mon_alrm;
+    m_century = fadt.century;
+
+    m_ia_pc_boot_arch_flags = fadt.ia_pc_boot_arch_flags;
+    m_flags = fadt.flags;
+
+    m_reset_reg = fadt.reset_reg;
+#ifdef ACPI_DEBUG
+    dbgprintf("ACPI: Reset Register @ IO 0x%x\n", m_reset_reg.address);
+    dbgprintf("ACPI: Reset Register Address space %x\n", fadt.reset_reg.address_space);
+#endif
+    m_reset_value = fadt.reset_value;
+#ifdef ACPI_DEBUG
+    dbgprintf("ACPI: Reset Register value @ P 0x%x\n", m_reset_value);
+#endif
+    m_x_pm1a_evt_blk = fadt.x_pm1a_evt_blk;
+    m_x_pm1b_evt_blk = fadt.x_pm1b_evt_blk;
+    m_x_pm1a_cnt_blk = fadt.x_pm1a_cnt_blk;
+    m_x_pm1b_cnt_blk = fadt.x_pm1b_cnt_blk;
+    m_x_pm2_cnt_blk = fadt.x_pm2_cnt_blk;
+    m_x_pm_tmr_blk = fadt.x_pm_tmr_blk;
+    m_x_gpe0_blk = fadt.x_gpe0_blk;
+    m_x_gpe1_blk = fadt.x_gpe1_blk;
+    m_sleep_control = fadt.sleep_control;
+    m_sleep_status = fadt.sleep_status;
+
+    m_hypervisor_vendor_identity = fadt.hypervisor_vendor_identity;
+}
+
+ACPI_RAW::SDTHeader* ACPI::FixedACPIData::get_dsdt()
+{
+    if (m_x_dsdt_ptr != (u32) nullptr)
+        return (ACPI_RAW::SDTHeader*)m_x_dsdt_ptr;
+    else {
+        ASSERT((ACPI_RAW::SDTHeader*)m_dsdt_ptr != nullptr);
+        return (ACPI_RAW::SDTHeader*)m_dsdt_ptr;
+    }
+}

--- a/Kernel/ACPI/ACPIStaticParser.h
+++ b/Kernel/ACPI/ACPIStaticParser.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <ACPI/ACPIParser.h>
+#include <AK/OwnPtr.h>
+
+class ACPIStaticParser : ACPIParser {
+public:
+    static void initialize(ACPI_RAW::RSDPDescriptor20& rsdp);
+    static void initialize_without_rsdp();
+    static bool is_initialized();
+
+    virtual ACPI_RAW::SDTHeader* find_table(const char* sig) override;
+    virtual void do_acpi_reboot() override;
+    virtual void do_acpi_shutdown() override;
+    virtual bool is_operable() override { return m_operable; }
+
+protected:
+    ACPIStaticParser();
+    explicit ACPIStaticParser(ACPI_RAW::RSDPDescriptor20&);
+
+    virtual void mmap(VirtualAddress preferred_vaddr, PhysicalAddress paddr, u32) override;
+    virtual void mmap_region(Region& region, PhysicalAddress paddr) override;
+
+private:
+    void locate_static_data();
+    void locate_all_aml_tables();
+    void locate_main_system_description_table();
+    void initialize_main_system_description_table();
+    ACPI_RAW::SDTHeader& find_fadt();
+    void init_fadt();
+    ACPI_RAW::RSDPDescriptor20* search_rsdp();
+
+    // Early pointers that are needed really for initializtion only...
+    ACPI_RAW::RSDPDescriptor20* m_rsdp;
+    ACPI_RAW::SDTHeader* m_main_system_description_table;
+
+    OwnPtr<ACPI::MainSystemDescriptionTable> m_main_sdt;
+    OwnPtr<ACPI::FixedACPIData> m_fadt;
+
+    Vector<ACPI_RAW::SDTHeader*> m_aml_tables_ptrs;
+    bool m_xsdt_supported;
+};

--- a/Kernel/ACPI/DMIDecoder.cpp
+++ b/Kernel/ACPI/DMIDecoder.cpp
@@ -1,0 +1,260 @@
+#include <Kernel/ACPI/DMIDecoder.h>
+#include <Kernel/StdLib.h>
+#include <Kernel/VM/MemoryManager.h>
+
+static DMIDecoder* s_dmi_decoder;
+
+//#define SMBIOS_DEBUG
+
+#define SMBIOS_BASE_SEARCH_ADDR 0xf0000
+#define SMBIOS_END_SEARCH_ADDR 0xfffff
+#define SMBIOS_SEARCH_AREA_SIZE (SMBIOS_END_SEARCH_ADDR - SMBIOS_BASE_SEARCH_ADDR)
+
+DMIDecoder& DMIDecoder::the()
+{
+    if (s_dmi_decoder == nullptr) {
+        s_dmi_decoder = new DMIDecoder(true);
+    }
+    return *s_dmi_decoder;
+}
+
+void DMIDecoder::initialize()
+{
+    if (s_dmi_decoder == nullptr) {
+        s_dmi_decoder = new DMIDecoder(true);
+    }
+}
+
+void DMIDecoder::initialize_untrusted()
+{
+    if (s_dmi_decoder == nullptr) {
+        s_dmi_decoder = new DMIDecoder(false);
+    }
+}
+
+void DMIDecoder::initialize_parser()
+{
+    if (m_entry32bit_point != nullptr || m_entry64bit_point != nullptr) {
+        m_operable = true;
+        kprintf("DMI Decoder is enabled\n");
+        if (m_entry64bit_point != nullptr) {
+            kprintf("DMIDecoder: SMBIOS 64bit Entry point @ P 0x%x\n", m_entry64bit_point);
+            m_use_64bit_entry = true;
+            m_structure_table = (SMBIOS::TableHeader*)m_entry64bit_point->table_ptr;
+            m_structures_count = m_entry64bit_point->table_maximum_size;
+            m_table_length = m_entry64bit_point->table_maximum_size;
+        } else if (m_entry32bit_point != nullptr) {
+            kprintf("DMIDecoder: SMBIOS 32bit Entry point @ P 0x%x\n", m_entry32bit_point);
+            m_use_64bit_entry = false;
+            m_structure_table = (SMBIOS::TableHeader*)m_entry32bit_point->legacy_structure.smbios_table_ptr;
+            m_structures_count = m_entry32bit_point->legacy_structure.smbios_tables_count;
+            m_table_length = m_entry32bit_point->legacy_structure.smboios_table_length;
+        }
+        kprintf("DMIDecoder: Data table @ P 0x%x\n", m_structure_table);
+        enumerate_smbios_tables();
+    } else {
+        m_operable = false;
+        kprintf("DMI Decoder is disabled. Cannot find SMBIOS tables.\n");
+    }
+}
+
+void DMIDecoder::enumerate_smbios_tables()
+{
+    u32 table_length = m_table_length;
+    SMBIOS::TableHeader* physical_table = m_structure_table;
+
+    auto region = MM.allocate_kernel_region(PAGE_ROUND_UP(table_length), "DMI Decoder Entry Point Finding", Region::Access::Read);
+    PhysicalAddress paddr = PhysicalAddress((u32)physical_table & PAGE_MASK);
+    mmap_region(*region, paddr);
+
+    auto* v_smbios_table = (SMBIOS::TableHeader*)(region->vaddr().get() + ((u32)physical_table & (~PAGE_MASK)));
+
+    u32 structures_count = 0;
+    while (table_length > 0) {
+#ifdef SMBIOS_DEBUG
+        dbgprintf("DMIDecoder: Examining table @ P 0x%x\n", physical_table);
+#endif
+        structures_count++;
+        if (v_smbios_table->type == (u32)SMBIOS::TableType::EndOfTable) {
+            kprintf("DMIDecoder: Detected table with type 127, End of SMBIOS data.\n");
+            break;
+        }
+        m_smbios_tables.append(physical_table);
+        table_length -= v_smbios_table->length;
+        kprintf("DMIDecoder: Detected table with type %u\n", v_smbios_table->type);
+        SMBIOS::TableHeader* physical_next_table = get_next_physical_table(*physical_table);
+#ifdef SMBIOS_DEBUG
+        dbgprintf("DMIDecoder: Next table @ P 0x%x\n", physical_next_table);
+#endif
+        if (physical_next_table == nullptr)
+            break;
+
+        v_smbios_table = (SMBIOS::TableHeader*)(region->vaddr().get() + (u32)physical_next_table - paddr.get());
+        physical_table = physical_next_table;
+    }
+    m_structures_count = structures_count;
+}
+
+size_t DMIDecoder::get_table_size(SMBIOS::TableHeader& table)
+{
+    // FIXME: Make sure we have some mapping here so we don't rely on existing identity mapping...
+#ifdef SMBIOS_DEBUG
+    dbgprintf("DMIDecoder: table legnth - 0x%x\n", table.length);
+#endif
+    const char* strtab = (char*)&table + table.length;
+    size_t index = 1;
+    while (strtab[index - 1] != '\0' || strtab[index] != '\0') {
+        if (index > m_table_length) {
+            ASSERT_NOT_REACHED(); // FIXME: Instead of halting, find a better solution (Hint: use m_operable to disallow further use of DMIDecoder)
+        }
+        index++;
+    }
+#ifdef SMBIOS_DEBUG
+    dbgprintf("DMIDecoder: table size - 0x%x\n", table.length + i + 1);
+#endif
+    return table.length + index + 1;
+}
+
+SMBIOS::TableHeader* DMIDecoder::get_next_physical_table(SMBIOS::TableHeader& p_table)
+{
+    return (SMBIOS::TableHeader*)((u32)&p_table + get_table_size(p_table));
+}
+
+SMBIOS::TableHeader* DMIDecoder::get_smbios_physical_table_by_handle(u16 handle)
+{
+    auto region = MM.allocate_kernel_region(PAGE_ROUND_UP(PAGE_SIZE * 2), "DMI Decoder Finding Table", Region::Access::Read);
+
+    for (auto* table : m_smbios_tables) {
+        if (!table)
+            continue;
+        PhysicalAddress paddr = PhysicalAddress((u32)table & PAGE_MASK);
+        mmap_region(*region, paddr);
+        SMBIOS::TableHeader* table_v_ptr = (SMBIOS::TableHeader*)(region->vaddr().get() + ((u32)table & (~PAGE_MASK)));
+        if (table_v_ptr->handle == handle) {
+            return table;
+        }
+    }
+    return nullptr;
+}
+SMBIOS::TableHeader* DMIDecoder::get_smbios_physical_table_by_type(u8 table_type)
+{
+    auto region = MM.allocate_kernel_region(PAGE_ROUND_UP(PAGE_SIZE * 2), "DMI Decoder Finding Table", Region::Access::Read);
+
+    for (auto* table : m_smbios_tables) {
+        if (!table)
+            continue;
+        PhysicalAddress paddr = PhysicalAddress((u32)table & PAGE_MASK);
+        mmap_region(*region, paddr);
+        SMBIOS::TableHeader* table_v_ptr = (SMBIOS::TableHeader*)(region->vaddr().get() + ((u32)table & (~PAGE_MASK)));
+        if (table_v_ptr->type == table_type) {
+            return table;
+        }
+    }
+    return nullptr;
+}
+
+DMIDecoder::DMIDecoder(bool trusted)
+    : m_entry32bit_point(find_entry32bit_point())
+    , m_entry64bit_point(find_entry64bit_point())
+    , m_structure_table(nullptr)
+    , m_untrusted(!trusted)
+{
+    if (!trusted) {
+        kprintf("DMI Decoder initialized as untrusted due to user request.\n");
+    }
+    initialize_parser();
+}
+
+SMBIOS::EntryPoint64bit* DMIDecoder::find_entry64bit_point()
+{
+    auto region = MM.allocate_kernel_region(PAGE_ROUND_UP(SMBIOS_SEARCH_AREA_SIZE), "DMI Decoder Entry Point Finding", Region::Access::Read);
+    PhysicalAddress paddr = PhysicalAddress(SMBIOS_BASE_SEARCH_ADDR);
+    mmap_region(*region, paddr);
+
+    char* tested_physical_ptr = (char*)paddr.get();
+    for (char* entry_str = (char*)(region->vaddr().get()); entry_str < (char*)(region->vaddr().get() + (SMBIOS_SEARCH_AREA_SIZE)); entry_str += 16) {
+#ifdef SMBIOS_DEBUG
+        dbgprintf("DMI Decoder: Looking for 64 bit Entry point @ P 0x%x\n", entry_str, tested_physical_ptr);
+#endif
+        if (!strncmp("_SM3_", entry_str, strlen("_SM3_")))
+            return (SMBIOS::EntryPoint64bit*)tested_physical_ptr;
+
+        tested_physical_ptr += 16;
+    }
+    return nullptr;
+}
+
+SMBIOS::EntryPoint32bit* DMIDecoder::find_entry32bit_point()
+{
+    auto region = MM.allocate_kernel_region(PAGE_ROUND_UP(SMBIOS_SEARCH_AREA_SIZE), "DMI Decoder Entry Point Finding", Region::Access::Read);
+    PhysicalAddress paddr = PhysicalAddress(SMBIOS_BASE_SEARCH_ADDR);
+    mmap_region(*region, paddr);
+
+    char* tested_physical_ptr = (char*)paddr.get();
+    for (char* entry_str = (char*)(region->vaddr().get()); entry_str < (char*)(region->vaddr().get() + (SMBIOS_SEARCH_AREA_SIZE)); entry_str += 16) {
+#ifdef SMBIOS_DEBUG
+        dbgprintf("DMI Decoder: Looking for 32 bit Entry point @ P 0x%x\n", tested_physical_ptr);
+#endif
+        if (!strncmp("_SM_", entry_str, strlen("_SM_")))
+            return (SMBIOS::EntryPoint32bit*)tested_physical_ptr;
+
+        tested_physical_ptr += 16;
+    }
+    return nullptr;
+}
+
+void DMIDecoder::mmap(VirtualAddress vaddr, PhysicalAddress paddr, u32 length)
+{
+    unsigned i = 0;
+    while (length >= PAGE_SIZE) {
+        MM.map_for_kernel(VirtualAddress(vaddr.offset(i * PAGE_SIZE).get()), PhysicalAddress(paddr.offset(i * PAGE_SIZE).get()));
+#ifdef SMBIOS_DEBUG
+        dbgprintf("DMI Decoder: map - V 0x%x -> P 0x%x\n", vaddr.offset(i * PAGE_SIZE).get(), paddr.offset(i * PAGE_SIZE).get());
+#endif
+        length -= PAGE_SIZE;
+        i++;
+    }
+    if (length > 0) {
+        MM.map_for_kernel(vaddr.offset(i * PAGE_SIZE), paddr.offset(i * PAGE_SIZE), true);
+    }
+#ifdef SMBIOS_DEBUG
+    dbgprintf("DMI Decoder: Finished mapping\n");
+#endif
+}
+
+void DMIDecoder::mmap_region(Region& region, PhysicalAddress paddr)
+{
+#ifdef SMBIOS_DEBUG
+    dbgprintf("DMI Decoder: Mapping region, size - %u\n", region.size());
+#endif
+    mmap(region.vaddr(), paddr, region.size());
+}
+
+Vector<SMBIOS::PhysicalMemoryArray*>& DMIDecoder::get_physical_memory_areas()
+{
+    // FIXME: Implement it...
+    kprintf("DMIDecoder::get_physical_memory_areas() is not implemented.\n");
+    ASSERT_NOT_REACHED();
+}
+bool DMIDecoder::is_reliable()
+{
+    return !m_untrusted;
+}
+u64 DMIDecoder::get_bios_characteristics()
+{
+    // FIXME: Make sure we have some mapping here so we don't rely on existing identity mapping...
+    ASSERT(m_operable == true);
+    SMBIOS::BIOSInfo* bios_info = (SMBIOS::BIOSInfo*)get_smbios_physical_table_by_type(0);
+    ASSERT(bios_info != nullptr);
+    kprintf("DMIDecoder: BIOS info @ P 0x%x\n", bios_info);
+    return bios_info->bios_characteristics;
+}
+
+char* DMIDecoder::get_smbios_string(SMBIOS::TableHeader&, u8)
+{
+    // FIXME: Implement it...
+    // FIXME: Make sure we have some mapping here so we don't rely on existing identity mapping...
+    kprintf("DMIDecoder::get_smbios_string() is not implemented.\n");
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}

--- a/Kernel/ACPI/DMIDecoder.h
+++ b/Kernel/ACPI/DMIDecoder.h
@@ -1,0 +1,1341 @@
+#pragma once
+
+#include <AK/Types.h>
+#include <AK/Vector.h>
+#include <Kernel/VM/PhysicalAddress.h>
+#include <Kernel/VM/Region.h>
+#include <Kernel/VM/VirtualAddress.h>
+
+namespace SMBIOS {
+struct LegacyEntryPoint32bit {
+    char legacy_sig[5];
+    u8 checksum2;
+    u16 smboios_table_length;
+    u32 smbios_table_ptr;
+    u16 smbios_tables_count;
+    u8 smbios_bcd_revision;
+} __attribute__((packed));
+
+struct EntryPoint32bit {
+    char sig[4];
+    u8 checksum;
+    u8 length;
+    u8 major_version;
+    u8 minor_version;
+    u16 maximum_structure_size;
+    u8 implementation_revision;
+    char formatted_area[5];
+    LegacyEntryPoint32bit legacy_structure;
+} __attribute__((packed));
+
+struct EntryPoint64bit {
+    char sig[5];
+    u8 checksum;
+    u8 length;
+    u8 major_version;
+    u8 minor_version;
+    u8 document_revision;
+    u8 revision;
+    u8 reserved;
+    u32 table_maximum_size;
+    u64 table_ptr;
+} __attribute__((packed));
+
+struct TableHeader {
+    u8 type;
+    u8 length;
+    u16 handle;
+} __attribute__((packed));
+
+enum class TableType {
+    BIOSInfo = 0,
+    SysInfo = 1,
+    ModuleInfo = 2,
+    SysEnclosure = 3,
+    ProcessorInfo = 4,
+    CacheInfo = 7,
+    PortConnectorInfo = 8,
+    SystemSlots = 9,
+    OEMStrings = 11,
+    SysConfigOptions = 12,
+    BIOSLanguageInfo = 13,
+    GroupAssociations = 14,
+    SysEventLog = 15,
+    PhysicalMemoryArray = 16,
+    MemoryDevice = 17,
+    MemoryErrorInfo32Bit = 18,
+    MemoryArrayMappedAddress = 19,
+    MemoryDeviceMappedAddress = 20,
+    BuiltinPointingDevice = 21,
+    PortableBattery = 22,
+    SysReset = 23,
+    HardwareSecurity = 24,
+    SysPowerControls = 25,
+    VoltageProbe = 26,
+    CoolingDevice = 27,
+    TemperatureProbe = 28,
+    ElectricalCurrentProbe = 29,
+    OutOfBandRemoteAccess = 30,
+    SystemBootInfo = 32,
+    MemoryErrorInfo64Bit = 33,
+    ManagementDevice = 34,
+    ManagementDeviceComponent = 35,
+    ManagementDeviceThresholdData = 36,
+    MemoryChannel = 37,
+    IPMIDeviceInfo = 38,
+    SysPowerSupply = 39,
+    AdditionalInfo = 40,
+    OnboardDevicesExtendedInfo = 41,
+    ManagementControllerHostInterface = 42,
+    TPMDevice = 43,
+    ProcessorAdditionalInfo = 44,
+    Inactive = 126,
+    EndOfTable = 127
+};
+
+struct BIOSInfo { // Type 0
+    TableHeader h;
+    u8 bios_vendor_str_number;
+    u8 bios_version_str_number;
+    u16 bios_segment;
+    u8 bios_release_date_str_number;
+    u8 bios_rom_size;
+    u64 bios_characteristics;
+    u8 ext_bios_characteristics[];
+} __attribute__((packed));
+
+enum class BIOSCharacteristics {
+    Unknown = (1 << 2),
+    NotSupported = (1 << 3),
+    ISA_support = (1 << 4),
+    MCA_support = (1 << 5),
+    EISA_support = (1 << 6),
+    PCI_support = (1 << 7),
+    PCMCIA_support = (1 << 8),
+    PnP_support = (1 << 9),
+    APM_support = (1 << 10),
+    UpgradeableBIOS = (1 << 11),
+    Shadowing_BIOS = (1 << 12),
+    VL_VESA_support = (1 << 13),
+    ESCD_support = (1 << 14),
+    CD_boot_support = (1 << 15),
+    select_boot_support = (1 << 16),
+    BIOS_ROM_socketed = (1 << 17),
+    PCMCIA_boot_support = (1 << 18),
+    EDD_spec_support = (1 << 19),
+    floppy_nec98_1200k_support = (1 << 20),
+    floppy_toshiba_1200k_support = (1 << 21),
+    floppy_360k_support = (1 << 22),
+    floppy_1200k_services_support = (1 << 23),
+    floppy_720k_services_support = (1 << 24),
+    floppy_2880k_services_support = (1 << 25),
+    int5_print_screen_support = (1 << 26),
+    int9_8042_keyboard_support = (1 << 27),
+    int14_serial_support = (1 << 28),
+    int17_printer_support = (1 << 29),
+    int10_video_support = (1 << 30),
+    nec_pc98 = (1 << 31)
+};
+
+struct ExtBIOSInfo {
+    u8 bios_major_release;
+    u8 bios_minor_release;
+    u8 embedded_controller_firmware_major_release;
+    u8 embedded_controller_firmware_minor_release;
+    u16 ext_bios_rom_size;
+} __attribute__((packed));
+
+struct SysInfo { // Type 1
+    TableHeader h;
+    u8 manufacturer_str_number;
+    u8 product_name_str_number;
+    u8 version_str_number;
+    u8 serial_number_str_number;
+    u64 uuid[2];
+    u8 wake_up_type;
+    u8 sku_str_number;
+    u8 family_str_number;
+
+} __attribute__((packed));
+
+enum class WakeUpType {
+    Reserved = 0,
+    Other = 1,
+    Unknown = 2,
+    APM_TIMER = 3,
+    MODEM_RING = 4,
+    LAN_REMOTE = 5,
+    POWER_SWTCH = 6,
+    PCI_PME = 7,
+    AC_RESTORE = 8,
+};
+
+struct ModuleInfo { // Type 2
+    TableHeader h;
+    u8 manufacturer_str_number;
+    u8 product_name_str_number;
+    u8 version_str_number;
+    u8 serial_number_str_number;
+    u8 asset_tag_str_number;
+    u8 feature_flags;
+    u8 chassis_location;
+    u16 chassis_handle;
+    u8 board_type;
+    u8 contained_object_handles_count;
+    u16 contained_object_handles[];
+} __attribute__((packed));
+
+enum class BoardType {
+    Unkown = 0x1,
+    Other = 0x2,
+    Server_Blade = 0x3,
+    Connectivity_Switch = 0x4,
+    System_Management_Module = 0x5,
+    Processor_Module = 0x6,
+    IO_Module = 0x7,
+    Memory_Module = 0x8,
+    Daughter_Board = 0x9,
+    Motherboard = 0xA,
+    Processor_Memory_Module = 0xB,
+    Processor_IO_Module = 0xC,
+    Interconnect_Board = 0xD,
+};
+
+struct SysEnclosure { // Type 3
+    TableHeader h;
+    u8 manufacturer_str_number;
+    u8 type;
+    u8 version_str_number;
+    u8 serial_number_str_number;
+    u8 asset_tag_str_number;
+    u8 boot_up_state;
+    u8 power_supply_state;
+    u8 thermal_state;
+    u8 security_status;
+    u32 vendor_specific_info;
+    u8 height;
+    u8 power_cords_number;
+    u8 contained_element_count;
+    u8 contained_element_record_length;
+} __attribute__((packed));
+
+struct ExtSysEnclosure {
+    u8 sku_str_number;
+} __attribute__((packed));
+
+enum class SysEnclosureType {
+    Other = 0x1,
+    Unknown = 0x2,
+    Desktop = 0x3,
+    Low_Profile_Desktop = 0x4,
+    Pizza_Box = 0x5,
+    Mini_Tower = 0x6,
+    Tower = 0x7,
+    Portable = 0x8,
+    Laptop = 0x9,
+    Notebook = 0xA,
+    Hand_Held = 0xB,
+    Docking_Station = 0xC,
+    AIO = 0xD,
+    Sub_Notebook = 0xE,
+    Space_Saving = 0xF,
+    Lunch_Box = 0x10,
+    Main_Server_Chassis = 0x11,
+    Expansion_Chassis = 0x12,
+    Sub_Chassis = 0x13,
+    Bus_Expansion_Chassis = 0x14,
+    Peripheral_Chassis = 0x15,
+    RAID_Chassis = 0x16,
+    Rack_MOunt_Chassis = 0x17,
+    Sealed_case_PC = 0x18,
+    Multi_System_Chasis = 0x19,
+    Compact_PCI = 0x1A,
+    Advanced_TCA = 0x1B,
+    Blade = 0x1C,
+    Blade_Enclosure = 0x1D,
+    Tablet = 0x1E,
+    Convertible = 0x1F,
+    Detachable = 0x20,
+    IoT_Gateway = 0x21,
+    Embedded_PC = 0x22,
+    Mini_PC = 0x23,
+    Stick_PC = 0x24,
+};
+
+enum class SysEnclosureState {
+    Other = 0x1,
+    Unknown = 0x2,
+    Safe = 0x3,
+    Warning = 0x4,
+    Critical = 0x5,
+    Non_Recoverable = 0x6,
+};
+
+enum class SysEnclosureSecurityStatus {
+    Other = 0x1,
+    Unknown = 0x2,
+    None = 0x3,
+    External_Interface_Locked_Out = 0x4,
+    External_Interface_Enabled = 0x5,
+};
+
+struct SysEnclosureContainedElement {
+    u8 type;
+    u8 min_contained_element_count;
+    u8 max_contained_element_count;
+} __attribute__((packed));
+
+struct ProcessorInfo { // Type 4
+    TableHeader h;
+    u8 socket_designation_str_number;
+    u8 processor_type;
+    u8 processor_family;
+    u8 processor_manufacturer_str_number;
+    u64 processor_id;
+    u8 processor_version_str_number;
+    u8 voltage;
+    u16 external_clock;
+    u16 max_speed;
+    u16 current_speed;
+    u8 status;
+    u8 processor_upgrade;
+    u16 l1_cache_handle;
+    u16 l2_cache_handle;
+    u16 l3_cache_handle;
+    u8 serial_number_str_number;
+    u8 asset_tag_str_number;
+    u8 part_number_str_number;
+    u8 core_count;
+    u8 core_enabled;
+    u8 thread_count;
+    u16 processor_characteristics;
+    u16 processor_family2;
+    u16 core_count2;
+    u16 core_enabled2;
+    u16 thread_count2;
+} __attribute__((packed));
+
+enum class ProcessorType {
+    Other = 0x1,
+    Unknown = 0x2,
+    Central_Processor = 0x3,
+    Math_Processor = 0x4,
+    DSP_Processor = 0x5,
+    Video_Processor = 0x6,
+};
+
+enum class ProcessorUpgrade {
+    Other = 0x1,
+    Unknown = 0x2,
+    Daughter_Board = 0x3,
+    ZIF_Socket = 0x4,
+    Replaceable_Piggy_Back = 0x5,
+    None = 0x6,
+    LIF_Sokcet = 0x7,
+    Slot_1 = 0x8,
+    Slot_2 = 0x9,
+    Socket_370_pin = 0xA,
+    Slot_A = 0xB,
+    Slot_M = 0xC,
+    Socket_423 = 0xD,
+    Socket_A_462 = 0xE,
+    Socket_478 = 0xF,
+    Socket_754 = 0x10,
+    Socket_940 = 0x11,
+    Socket_939 = 0x12,
+    Socket_mPGA604 = 0x13,
+    Socket_LGA771 = 0x14,
+    Socket_LGA775 = 0x15,
+    Socket_S1 = 0x16,
+    Socket_AM2 = 0x17,
+    Socket_F_1207 = 0x18,
+    Socket_LGA1366 = 0x19,
+    Socket_G34 = 0x1A,
+    Socket_AM3 = 0x1B,
+    Socket_C32 = 0x1C,
+    Socket_LGA1156 = 0x1D,
+    Socket_LGA1567 = 0x1E,
+    Socket_PGA988A = 0x1F,
+    Socket_BGA1288 = 0x20,
+    Socket_rPGA988B = 0x21,
+    Socket_BGA1023 = 0x22,
+    Socket_BGA1224 = 0x23,
+    Socket_LGA1155 = 0x24,
+    Socket_LGA1356 = 0x25,
+    Socket_LGA2011 = 0x26,
+    Socket_FS1 = 0x27,
+    Socket_FS2 = 0x28,
+    Socket_FM1 = 0x29,
+    Socket_FM2 = 0x2A,
+    Socket_LGA2011_3 = 0x2B,
+    Socket_LGA1356_3 = 0x2C,
+    Socket_LGA1150 = 0x2D,
+    Socket_BGA1168 = 0x2E,
+    Socket_BGA1234 = 0x2F,
+    Socket_BGA1364 = 0x30,
+    Socket_AM4 = 0x31,
+    Socket_LGA1151 = 0x32,
+    Socket_BGA1356 = 0x33,
+    Socket_BGA1440 = 0x34,
+    Socket_BGA1515 = 0x35,
+    Socket_LGA3647_1 = 0x36,
+    Socket_SP3 = 0x37,
+    Socket_SP3r2 = 0x38,
+    Socket_LGA2066 = 0x39,
+    Socket_BGA1392 = 0x3A,
+    Socket_BGA1510 = 0x3B,
+    Socket_BGA1528 = 0x3C
+};
+
+struct CacheInfo { // Type 7
+    TableHeader h;
+    u8 socket_designation_str_number;
+    u16 cache_config;
+    u16 max_cache_size;
+    u16 installed_size;
+    u16 supported_sram_type;
+    u16 current_sram_type;
+    u8 cache_speed;
+    u8 error_correction_type;
+    u8 system_cache_type;
+    u8 associativity;
+    u32 max_cache_size2;
+    u32 installed_size2;
+} __attribute__((packed));
+
+struct PortConnectorInfo { // Type 8
+    TableHeader h;
+    u8 internal_reference_designator_str_number;
+    u8 internal_connector_type;
+    u8 external_reference_designator_str_number;
+    u8 external_connector_type;
+    u8 port_type;
+} __attribute__((packed));
+
+enum class ConnectorType {
+    None = 0x0,
+    Centronics = 0x1,
+    Mini_Centronics = 0x2,
+    Proprietary = 0x3,
+    DB_25_pin_male = 0x4,
+    DB_25_pin_female = 0x5,
+    DB_15_pin_male = 0x6,
+    DB_15_pin_female = 0x7,
+    DB_9_pin_male = 0x8,
+    DB_9_pin_female = 0x9,
+    RJ_11 = 0xA,
+    RJ_45 = 0xB,
+    MiniSCSI_50_pin = 0xC,
+    MiniDIN = 0xD,
+    MicroDIN = 0xE,
+    PS2 = 0xF,
+    Infrared = 0x10,
+    HP_HIL = 0x11,
+    AccessBus_USB = 0x12,
+    SSA_SCSI = 0x13,
+    Circular_DIN8_male = 0x14,
+    Circular_DIN8_female = 0x15,
+    OnBoard_IDE = 0x16,
+    OnBoard_Floppy = 0x17,
+    Dual_Inline_9pin = 0x18,
+    Dual_Inline_25pin = 0x19,
+    Dual_Inline_50pin = 0x1A,
+    Dual_Inline_68pin = 0x1B,
+    OnBoard_SoundInput_CDROM = 0x1C,
+    Mini_Centronics_Type14 = 0x1D,
+    Mini_Centronics_Type26 = 0x1E,
+    Mini_Jack_Headphones = 0x1F,
+    BNC = 0x20,
+    Connector_1394 = 0x21,
+    SAS_SATA_Plug_Receptacle = 0x22,
+    USB_TypeC_Receptacle = 0x23,
+    PC98 = 0xA0,
+    PC98_Hireso = 0xA1,
+    PC_H98 = 0xA2,
+    PC98_Note = 0xA3,
+    PC98_Full = 0xA4,
+    Other = 0xFF
+};
+
+enum class PortType {
+    None = 0x0,
+    Parallel_Port_XT_AT_Compatible = 0x1,
+    Parallel_Port_PS2 = 0x2,
+    Parallel_Port_ECP = 0x3,
+    Parallel_Port_EPP = 0x4,
+    Parallel_Port_ECP_EPP = 0x5,
+    Serial_Port_XT_AT_Compatible = 0x6,
+    Serial_Port_16450_Compatible = 0x7,
+    Serial_Port_16550_Compatible = 0x8,
+    Serial_Port_16550A_Compatible = 0x9,
+    SCSI_Port = 0xA,
+    MIDI_Port = 0xB,
+    Joy_Stick_Port = 0xC,
+    Keyboard_Port = 0xD,
+    Mouse_Port = 0xE,
+    SSA_SCSI = 0xF,
+    USB = 0x10,
+    FireWire = 0x11,
+    PCMCIA_Type1 = 0x12,
+    PCMCIA_Type2 = 0x13,
+    PCMCIA_Type3 = 0x14,
+    Cardbus = 0x15,
+    AccessBus_Port = 0x16,
+    SCSI_2 = 0x17,
+    SCSI_Wide = 0x18,
+    PC98 = 0x19,
+    PC98_Hireso = 0x1A,
+    PC_H98 = 0x1B,
+    Video_Port = 0x1C,
+    Audio_Port = 0x1D,
+    Modem_Port = 0x1E,
+    Network_Port = 0x1F,
+    SATA = 0x20,
+    SAS = 0x21,
+    MFDP = 0x22,
+    Thunderbolt = 0x23,
+    Intel_8251_Compatible = 0xA0,
+    Intel_8251_FIFO_Compatible = 0xA1,
+    Other = 0xFF
+};
+
+struct SystemSlotPeerGroup {
+    u16 segment_group_number;
+    u8 bus_number;
+    u8 device_function_number;
+    u8 data_bus_width;
+} __attribute__((packed));
+
+struct SystemSlots { // Type 9
+    TableHeader h;
+    u8 slot_designation_str_number;
+    u8 slot_type;
+    u8 slot_data_bus_width;
+    u8 current_stage;
+    u8 slot_length;
+    u16 slot_id;
+    u8 slot_characteristics_1;
+    u8 slot_characteristics_2;
+    u16 segment_group_number;
+    u8 bus_number;
+    u8 device_function_number;
+    u8 data_bus_width;
+    u8 peer_grouping_count;
+    SystemSlotPeerGroup peer_groups[];
+} __attribute__((packed));
+
+enum class SlotType {
+    Other = 0x1,
+    Unknown = 0x2,
+    ISA = 0x3,
+    MCA = 0x4,
+    EISA = 0x5,
+    PCI = 0x6,
+    PCMCIA = 0x7,
+    VL_VESA = 0x8,
+    Proprietary = 0x9,
+    Processor_Card_Slot = 0xA,
+    Proprietary_Memory_Card_Slot = 0xB,
+    IO_Riser_Card_Slot = 0xC,
+    NuBus = 0xD,
+    PCI_66MHZ_Capable = 0xE,
+    AGP = 0xF,
+    AGP_2X = 0x10,
+    AGP_4X = 0x11,
+    PCI_X = 0x12,
+    AGP_8X = 0x13,
+    M_Dot_2_Socket_1_DP = 0x14,
+    M_Dot_2_Socket_1_SD = 0x15,
+    M_Dot_2_Socket_2 = 0x16,
+    M_Dot_2_Socket_3 = 0x17,
+    MXM_Type1 = 0x18,
+    MXM_Type2 = 0x19,
+    MXM_Type3_Standard = 0x1A,
+    MXM_Type3_HE = 0x1B,
+    MXM_Type4 = 0x1C,
+    MXM_3_Type_A = 0x1D,
+    MXM_3_Type_B = 0x1E,
+    PCI_Express_Gen2 = 0x1F,
+    PCI_Express_Gen3 = 0x20,
+    PCI_Express_Mini_52pin_Type1 = 0x21,
+    PCI_Express_Mini_52pin_Type2 = 0x22,
+    PCI_Express_Mini_76pin = 0x23,
+    CXL_Flexbus_1_0 = 0x30,
+    PC98_C20 = 0xA0,
+    PC98_C24 = 0xA1,
+    PC98_E = 0xA2,
+    PC98_Local_Bus = 0xA3,
+    PC98_Card = 0xA4,
+    PCI_Express = 0xA5,
+    PCI_Express_x1 = 0xA6,
+    PCI_Express_x2 = 0xA7,
+    PCI_Express_x4 = 0xA8,
+    PCI_Express_x8 = 0xA9,
+    PCI_Express_x16 = 0xAA,
+    PCI_Express_Gen_2 = 0xAB,
+    PCI_Express_Gen_2_x1 = 0xAC,
+    PCI_Express_Gen_2_x2 = 0xAD,
+    PCI_Express_Gen_2_x4 = 0xAE,
+    PCI_Express_Gen_2_x8 = 0xAF,
+    PCI_Express_Gen_2_x16 = 0xB0,
+    PCI_Express_Gen_3 = 0xB1,
+    PCI_Express_Gen_3_x1 = 0xB2,
+    PCI_Express_Gen_3_x2 = 0xB3,
+    PCI_Express_Gen_3_x4 = 0xB4,
+    PCI_Express_Gen_3_x8 = 0xB5,
+    PCI_Express_Gen_3_x16 = 0xB6,
+    PCI_Express_Gen_4 = 0xB8,
+    PCI_Express_Gen_4_x1 = 0xB9,
+    PCI_Express_Gen_4_x2 = 0xBA,
+    PCI_Express_Gen_4_x4 = 0xBB,
+    PCI_Express_Gen_4_x8 = 0xBC,
+    PCI_Express_Gen_4_x16 = 0xBD
+};
+
+enum class SlotDataBusWidth {
+    Other = 0x1,
+    Unknown = 0x2,
+    _8_bit = 0x3,
+    _16_bit = 0x4,
+    _32_bit = 0x5,
+    _64_bit = 0x6,
+    _128_bit = 0x7,
+    _1x_x1 = 0x8,
+    _2x_x2 = 0x9,
+    _4x_x4 = 0xA,
+    _8x_x8 = 0xB,
+    _12x_x12 = 0xC,
+    _16x_x16 = 0xD,
+    _32x_x32 = 0xE
+};
+
+enum class SlotCurrentUsage {
+    Other = 0x1,
+    Unknown = 0x2,
+    Available = 0x3,
+    In_Use = 0x4,
+    Unavailable = 0x5
+};
+
+enum class SlotLength {
+    Other = 0x1,
+    Unknown = 0x2,
+    Short_Length = 0x3,
+    Long_Length = 0x4,
+    _2_5_Drive_Form_Factor = 0x5,
+    _3_5_Drive_Form_Factor = 0x6
+};
+
+enum class SlotCharacteristics1 {
+    Unknown = (1 << 0),
+    Provides_5volt = (1 << 1),
+    Provides_3_3volt = (1 << 2),
+    Shared_Slot = (1 << 3),
+    Support_PC_Card_16 = (1 << 4),
+    Support_CardBus = (1 << 5),
+    Support_Zoom_Video = (1 << 6),
+    Support_Modem_Ring_Resume = (1 << 7)
+};
+
+enum class SlotCharacteristics2 {
+    Support_PCI_PME = (1 << 0),
+    Support_Hot_Plug = (1 << 1),
+    Support_SMBus = (1 << 2),
+    Support_Bifurcation = (1 << 3),
+};
+
+struct OEMStrings { // Type 11
+    TableHeader h;
+    u8 strings_count;
+} __attribute__((packed));
+
+struct SysConfigOptions { // Type 12
+    TableHeader h;
+    u8 strings_count;
+} __attribute__((packed));
+
+struct BIOSLanguageInfo { // Type 13
+    TableHeader h;
+    u8 installable_langs_counts;
+    u8 flags;
+    u8 reserved[15];
+    u8 current_lang_str_number; // String number (one-based) of the currently installed language
+} __attribute__((packed));
+
+struct GroupAssociations { // Type 14
+    TableHeader h;
+    u8 group_name_str_number;
+    u8 item_type;
+    u16 item_handle;
+} __attribute__((packed));
+
+struct SysEventLog { // Type 15
+    TableHeader h;
+    u16 log_area_length;
+    u16 log_header_start_offset;
+    u16 log_data_start_offset;
+    u8 access_method;
+    u8 log_status;
+    u32 log_change_token;
+    u32 access_method_address;
+    u8 log_header_format;
+    u8 supported_log_type_descriptors_count;
+    u8 log_type_descriptor_length;
+    u8 supported_event_log_type_descriptor_list[];
+} __attribute__((packed));
+
+struct PhysicalMemoryArray { // Type 16
+    TableHeader h;
+    u8 location;
+    u8 use;
+    u8 memory_error_correction;
+    u32 max_capacity;
+    u16 memory_error_info_handle;
+    u16 memory_devices_count;
+    u64 ext_max_capacity;
+} __attribute__((packed));
+
+enum class MemoryArrayLocation {
+    Other = 0x1,
+    Unknown = 0x2,
+    Motherboard = 0x3,
+    ISA_addon_card = 0x4,
+    EISA_addon_card = 0x5,
+    PCI_addon_card = 0x6,
+    MCA_addon_card = 0x7,
+    PCMCIA_addon_card = 0x8,
+    Proprietary_addon_card = 0x9,
+    NuBus = 0xA,
+    PC98_C20_addon_card = 0xA0,
+    PC98_C24_addon_card = 0xA1,
+    PC98_E_addon_card = 0xA2,
+    PC98_Local_Bus_addon_card = 0xA3,
+    CXL_Flexbus_1_0_addon_card = 0xA4
+};
+
+enum class MemoryArrayUse {
+    Other = 0x1,
+    Unknown = 0x2,
+    System_Memory = 0x3,
+    Video_Memory = 0x4,
+    Flash_Memory = 0x5,
+    Non_Volatile_RAM = 0x6,
+    Cache_Memory = 0x7
+};
+
+enum class MemoryArrayErrorCorrectionType {
+    Other = 0x1,
+    Unknown = 0x2,
+    None = 0x3,
+    Parity = 0x4,
+    SingleBit_ECC = 0x5,
+    MultiBit_ECC = 0x6,
+    CRC = 0x7
+};
+
+struct MemoryDevice { // Type 17
+    TableHeader h;
+    u16 physical_memory_array_handle;
+    u16 memory_error_info_handle;
+    u16 total_width;
+    u16 data_width;
+    u16 size;
+    u8 form_factor;
+    u8 device_set;
+    u8 device_locator_str_number;
+    u8 bank_locator_str_number;
+    u8 memory_type;
+    u16 type_detail;
+    u16 speed;
+    u8 manufacturer_str_number;
+    u8 serial_number_str_number;
+    u8 asset_tag_str_number;
+    u8 part_number_str_number;
+    u8 attributes;
+    u32 ext_size;
+    u16 configured_memory_speed;
+    u16 min_voltage;
+    u16 max_voltage;
+    u16 configured_voltage;
+    u8 memory_technology;
+    u16 memory_operating_mode_capability;
+    u8 firmware_version_str_number;
+    u16 module_manufacturer_id;
+    u16 module_product_id;
+    u16 memory_subsystem_controller_manufacturer_id;
+    u16 memory_subsystem_controller_product_id;
+    u64 non_volatile_size;
+    u64 volatile_size;
+    u64 cache_size;
+    u64 logical_size;
+    u32 ext_speed;
+    u32 ext_configured_memory_speed;
+} __attribute__((packed));
+
+enum class MemoryDeviceFormFactor {
+    Other = 0x1,
+    Unknown = 0x2,
+    SIMM = 0x3,
+    SIP = 0x4,
+    Chip = 0x5,
+    DIP = 0x6,
+    ZIP = 0x7,
+    ProprietaryCard = 0x8,
+    DIMM = 0x9,
+    TSOP = 0xA,
+    Chips_Row = 0xB,
+    RIMM = 0xC,
+    SODIMM = 0xD,
+    SRIMM = 0xE,
+    FB_DIMM = 0xF,
+    Die = 0x10
+};
+
+enum class MemoryDeviceType {
+    Other = 0x1,
+    Unknown = 0x2,
+    DRAM = 0x3,
+    EDRAM = 0x4,
+    VRAM = 0x5,
+    SRAM = 0x6,
+    RAM = 0x7,
+    ROM = 0x8,
+    FLASH = 0x9,
+    EEPROM = 0xA,
+    FEPROM = 0xB,
+    EPROM = 0xC,
+    CDRAM = 0xD,
+    _3DRAM = 0xE,
+    SDRAM = 0xF,
+    SGRAM = 0x10,
+    RDRAM = 0x11,
+    DDR = 0x12,
+    DDR2 = 0x13,
+    DDR2_FB_DIMM = 0x14,
+    DDR3 = 0x18,
+    FBD2 = 0x19,
+    DDR4 = 0x1A,
+    LPDDR = 0x1B,
+    LPDDR2 = 0x1C,
+    LPDDR3 = 0x1D,
+    LPDDR4 = 0x1E,
+    Logical_Non_Volatile_Device = 0x1F,
+    HBM = 0x20,  // (High Bandwidth Memory)
+    HBM2 = 0x21, // (High Bandwidth Memory Generation 2)
+};
+
+enum class MemoryDeviceTypeDetail {
+    Other = (1 << 1),
+    Unknown = (1 << 2),
+    Fast_paged = (1 << 3),
+    Static_Column = (1 << 4),
+    Pseudo_Static = (1 << 5),
+    RAMBUS = (1 << 6),
+    Synchronous = (1 << 7),
+    CMOS = (1 << 8),
+    EDO = (1 << 9),
+    Window_DRAM = (1 << 10),
+    Cache_DRAM = (1 << 11),
+    Non_volatile = (1 << 12),
+    Registered_Buffered = (1 << 13),
+    Unbuffered_Unregistered = (1 << 14),
+    LRDIMM = (1 << 15)
+};
+
+enum class MemoryDeviceTechnology {
+    Other = 0x1,
+    Unknown = 0x2,
+    DRAM = 0x3,
+    NVDIMM_N = 0x4,
+    NVDIMM_F = 0x5,
+    NVDIMM_P = 0x6,
+    Intel_Optane_DC_Persistent_Memory = 0x7
+};
+
+enum class MemoryDeviceOperatingModeCapability {
+    Other = (1 << 1),
+    Unknown = (1 << 2),
+    Volatile_Memory = (1 << 3),
+    Byte_accessible_persistent_memory = (1 << 4),
+    Block_accessible_persistent_memory = (1 << 5),
+};
+
+struct MemoryErrorInfo32Bit { // Type 18
+    TableHeader h;
+    u8 error_type;
+    u8 error_granularity;
+    u8 error_operation;
+    u32 vendor_syndrome;
+    u32 memory_array_error_address;
+    u32 device_error_address;
+    u32 error_resolution;
+} __attribute__((packed));
+
+enum class MemoryErrorType {
+    Other = 0x1,
+    Unknown = 0x2,
+    OK = 0x3,
+    Bad_read = 0x4,
+    Parity_error = 0x5,
+    SingleBit_error = 0x6,
+    DoubleBit_error = 0x7,
+    MultiBit_error = 0x8,
+    Nibble_error = 0x9,
+    Checksum_error = 0xA,
+    CRC_error = 0xB,
+    Corrected_SingleBit_error = 0xC,
+    Corrected_error = 0xD,
+    Uncorrectable_error = 0xE
+};
+
+enum class MemoryErrorGranularity {
+    Other = 0x1,
+    Unknown = 0x2,
+    Device_level = 0x3,
+    Memory_partition_level = 0x4
+};
+
+enum class MemoryErrorOperation {
+    Other = 0x1,
+    Unknown = 0x2,
+    Read = 0x3,
+    Write = 0x4,
+    Partial_Write = 0x5
+};
+
+struct MemoryArrayMappedAddress { // Type 19
+    TableHeader h;
+    u32 starting_address;
+    u32 ending_address;
+    u16 memory_array_handle;
+    u8 partition_width;
+    u64 ext_starting_address;
+    u64 ext_ending_address;
+} __attribute__((packed));
+
+struct MemoryDeviceMappedAddress { // Type 20
+    TableHeader h;
+    u32 starting_address;
+    u32 ending_address;
+    u16 memory_device_handle;
+    u16 memory_array_mapped_handle;
+    u8 partition_row_position;
+    u8 interleave_position;
+    u8 interleaved_data_depth;
+    u64 ext_starting_address;
+    u64 ext_ending_address;
+
+} __attribute__((packed));
+
+struct BuiltinPointingDevice { // Type 21
+    TableHeader h;
+    u8 type;
+    u8 interface;
+    u8 buttons_count;
+} __attribute__((packed));
+
+enum class PointingDeviceType {
+    Other = 0x1,
+    Unknown = 0x2,
+    Mouse = 0x3,
+    Track_Ball = 0x4,
+    Track_Point = 0x5,
+    Glide_Point = 0x6,
+    Touch_Pad = 0x7,
+    Touch_Screen = 0x8,
+    Optical_Sensor = 0x9
+};
+
+enum class PointingDeviceInterface {
+    Other = 0x1,
+    Unknown = 0x2,
+    Serial = 0x3,
+    PS2 = 0x4,
+    Infrared = 0x5,
+    HP_HIL = 0x6,
+    Bus_mouse = 0x7,
+    AppleDesktopBus = 0x8,
+    Bus_mouse_DB9 = 0xA0,
+    Bus_mouse_microDIN = 0xA1,
+    USB = 0xA2
+};
+
+struct PortableBattery { // Type 22
+    TableHeader h;
+    u8 location_str_number;
+    u8 manufacturer_str_number;
+    u8 manufacture_date_str_number;
+    u8 serial_number_str_number;
+    u8 device_name_str_number;
+    u8 device_chemistry;
+    u16 design_capacity;
+    u16 design_voltage;
+    u8 sbds_version_number;
+    u8 max_error_battery_data;
+    u16 sbds_serial_number;
+    u16 sbds_manufacture_date;
+    u8 sbds_device_chemistry_str_number;
+    u8 design_capacity_multiplier;
+    u32 oem_specific;
+} __attribute__((packed));
+
+enum class PortableBatteryChemistry {
+    Other = 0x1,
+    Unknown = 0x2,
+    Lead_Acid = 0x3,
+    Nickel_Cadmium = 0x4,
+    Nickel_metal_hydride = 0x5,
+    Lithium_ion = 0x6,
+    Zinc_air = 0x7,
+    Lithium_polymer = 0x8
+};
+
+struct SysReset { // Type 23
+    TableHeader h;
+    u8 capabilities;
+    u16 reset_count;
+    u16 reset_limit;
+    u16 timer_interval;
+    u16 timeout;
+} __attribute__((packed));
+
+struct HardwareSecurity { // Type 24
+    TableHeader h;
+    u8 hardware_security_settings;
+} __attribute__((packed));
+
+struct SysPowerControls { // Type 25
+    TableHeader h;
+    u8 next_scheduled_power_on_month;
+    u8 next_scheduled_power_on_day_of_month;
+    u8 next_scheduled_power_on_hour;
+    u8 next_scheduled_power_on_minute;
+    u8 next_scheduled_power_on_second;
+} __attribute__((packed));
+
+struct VoltageProbe { // Type 26
+    TableHeader h;
+    u8 description_str_number;
+    u8 location_and_status;
+    u16 max_value;
+    u16 min_value;
+    u16 resolution;
+    u16 tolerance;
+    u16 accuracy;
+    u32 oem_defined;
+    u16 nominal_value;
+} __attribute__((packed));
+
+struct CoolingDevice { // Type 27
+    TableHeader h;
+    u16 temperature_probe_handle;
+    u8 device_type_and_status;
+    u8 cooling_unit_group;
+    u32 oem_defined;
+    u16 nominal_speed;
+    u8 description_str_number;
+} __attribute__((packed));
+
+struct TemperatureProbe { // Type 28
+    TableHeader h;
+    u8 description_str_number;
+    u8 location_and_status;
+    u16 max_value;
+    u16 min_value;
+    u16 resolution;
+    u16 tolerance;
+    u16 accuracy;
+    u32 oem_defined;
+    u16 nominal_value;
+} __attribute__((packed));
+
+struct ElectricalCurrentProbe { // Type 29
+    TableHeader h;
+    u8 description_str_number;
+    u8 location_and_status;
+    u16 max_value;
+    u16 min_value;
+    u16 resolution;
+    u16 tolerance;
+    u16 accuracy;
+    u32 oem_defined;
+    u16 nominal_value;
+} __attribute__((packed));
+
+struct OutOfBandRemoteAccess { // Type 30
+    TableHeader h;
+    u8 manufacturer_name_str_number;
+    u8 connections;
+} __attribute__((packed));
+
+struct SystemBootInfo { // Type 32
+    TableHeader h;
+    u8 reserved[6];
+    u8 boot_status[10];
+} __attribute__((packed));
+
+struct MemoryErrorInfo64Bit { // Type 33
+    TableHeader h;
+    u8 error_type;
+    u8 error_granularity;
+    u8 error_operation;
+    u32 vendor_syndrome;
+    u64 memory_array_error_address;
+    u64 device_error_address;
+    u32 error_resolution;
+} __attribute__((packed));
+
+struct ManagementDevice { // Type 34
+    TableHeader h;
+    u8 description_str_number;
+    u8 type;
+    u32 address;
+    u8 address_type;
+} __attribute__((packed));
+
+enum class ManagementDeviceType {
+    Other = 0x1,
+    Unknown = 0x2,
+    LM75 = 0x3,
+    LM78 = 0x4,
+    LM79 = 0x5,
+    LM80 = 0x6,
+    LM81 = 0x7,
+    ADM9240 = 0x8,
+    DS1780 = 0x9,
+    Maxim_1617 = 0xA,
+    GL518SM = 0xB, // Genesys GL518SM
+    W83781D = 0xC, // Winbond W83781D
+    HT82H791 = 0xD // Holtek HT82H791
+};
+
+enum class ManagementDeviceAddressType {
+    Other = 0x1,
+    Unknown = 0x2,
+    IO_Port = 0x3,
+    Memory = 0x4,
+    SMBus = 0x5
+};
+
+struct ManagementDeviceComponent { // Type 35
+    TableHeader h;
+    u8 description_str_number;
+    u16 management_device_handle;
+    u16 component_handle;
+    u16 threshold_handle;
+} __attribute__((packed));
+
+struct ManagementDeviceThresholdData { // Type 36
+    TableHeader h;
+    u16 lower_threshold_non_critical;
+    u16 upper_threshold_non_critical;
+    u16 lower_threshold_critical;
+    u16 upper_threshold_critical;
+    u16 lower_threshold_non_recoverable;
+    u16 upper_threshold_non_recoverable;
+} __attribute__((packed));
+
+struct MemoryDeviceDescriptor {
+    u8 device_load;
+    u16 device_handle;
+} __attribute__((packed));
+
+struct MemoryChannel { // Type 37
+    TableHeader h;
+    u8 channel_type;
+    u8 memory_device_count;
+    MemoryDeviceDescriptor memory_devices_descriptors[];
+} __attribute__((packed));
+
+enum class MemroryChannelType {
+    Other = 0x1,
+    Unknown = 0x2,
+    RamBus = 0x3,
+    SyncLink = 0x4
+};
+
+struct IPMIDeviceInfo { // Type 38
+    TableHeader h;
+    u8 interface_type;
+    u8 ipmi_spec_revision;
+    u8 i2c_slave_address;
+    u8 nv_storage_device_address;
+    u64 base_address;
+    u8 base_address_modifier;
+    u8 interrupt_number;
+} __attribute__((packed));
+
+enum class IPMIDeviceInfoBMCInterfaceType {
+    Unknown = 0x1,
+    KCS = 0x2,  // KCS: Keyboard Controller Style
+    SMIC = 0x3, // SMIC: Server Management Interface Chip
+    BT = 0x4,   // BT: Block Transfer
+    SSIF = 0x5  // SSIF: SMBus System Interface
+};
+
+struct SysPowerSupply { // Type 39
+    TableHeader h;
+    u8 power_unit_group;
+    u8 location_str_number;
+    u8 device_name_str_number;
+    u8 manufacturer_str_number;
+    u8 serial_number_str_number;
+    u8 asset_tag_number_str_number;
+    u8 model_part_number_str_number;
+    u8 revision_level_str_number;
+    u16 max_power_capacity;
+    u16 power_supply_characteristics;
+    u16 input_voltage_probe_handle;
+    u16 cooling_device_handle;
+    u16 input_current_probe_handle;
+} __attribute__((packed));
+
+struct AdditionalInfoEntry {
+    u8 entry_length;
+    u16 referenced_handle;
+    u8 referenced_offset;
+    u8 string_number;
+    u8 value[];
+} __attribute__((packed));
+
+struct AdditionalInfo { // Type 40
+    TableHeader h;
+    u8 additional_info_entries_count;
+    AdditionalInfoEntry entries[];
+} __attribute__((packed));
+
+struct OnboardDevicesExtendedInfo { // Type 41
+    TableHeader h;
+    u8 reference_designation_str_number;
+    u8 device_type;
+    u8 device_type_instance;
+    u16 segment_group_number;
+    u8 bus_number;
+    u8 device_function_number;
+} __attribute__((packed));
+
+enum class OnboardDeviceType {
+    Other = 0x1,
+    Unknown = 0x2,
+    Video = 0x3,
+    SCSI_Controller = 0x4,
+    Ethernet = 0x5,
+    Token_Ring = 0x6,
+    Sound = 0x7,
+    PATA_Controller = 0x8,
+    SATA_Controller = 0x9,
+    SAS_Controller = 0xA
+};
+
+struct ManagementControllerHostInterface { // Type 42
+    TableHeader h;
+    u8 interface_type;
+    u8 interface_type_specific_data_length;
+    u8 interface_type_specific_data[];
+} __attribute__((packed));
+
+struct ProtocolRecordData {
+    u8 protocol_type;
+    u8 protocol_type_specific_data_length;
+    u8 protocol_type_specific_data[];
+} __attribute__((packed));
+
+struct ExtManagementControllerHostInterface { // Type 42 Ext
+    u8 protocol_records_count;
+    ProtocolRecordData protocol_records[];
+} __attribute__((packed));
+
+enum class ManagementControllerHostInterfaceProtocolType {
+    IPMI = 0x2,
+    MCTP = 0x3,
+    RedfishOverIP = 0x4
+};
+
+struct TPMDevice { // Type 43
+    TableHeader h;
+    char vendor_id[4];
+    u8 major_spec_version;
+    u8 minor_spec_version;
+    u32 firmware_version_1;
+    u32 firmware_version_2;
+    u8 description_str_number;
+    u64 characteristics;
+    u32 oem_defined;
+} __attribute__((packed));
+
+enum class TPMDeviceCharacteristics {
+    Characteristics_not_supported = (1 << 2),
+    Family_Configurable_1 = (1 << 3), // Family configurable via firmware update; for example, switching between TPM 1.2 and TPM 2.0.
+    Family_Configurable_2 = (1 << 4), // Family configurable via platform software support, such as BIOS Setup; for example, switching between TPM 1.2 and TPM 2.0.
+    Family_Configurable_3 = (1 << 5), // Family configurable via OEM proprietary mechanism; for example, switching between TPM 1.2 and TPM 2.0.
+};
+
+struct ProcessorSpecificBlock {
+    u8 block_length;
+    u8 processor_type;
+    u8 processor_specific_data[];
+} __attribute__((packed));
+
+struct ProcessorAdditionalInfo { // Type 44
+    TableHeader h;
+    u16 referenced_handle;
+    ProcessorSpecificBlock blocks[];
+} __attribute__((packed));
+
+enum class ProcessorArchitectureType {
+    IA32 = 0x1,
+    x86_64 = 0x2,
+    Itanium = 0x3,
+    ARM32bit = 0x4,
+    ARM64bit = 0x5,
+    RISC_V_32bit = 0x6,
+    RISC_V_64bit = 0x7,
+    RISC_V_128bit = 0x8
+};
+
+struct Inactive { // Type 126
+    TableHeader h;
+} __attribute__((packed));
+
+struct EndOfTable { // Type 127
+    TableHeader h;
+} __attribute__((packed));
+}
+
+class DMIDecoder {
+public:
+    static DMIDecoder& the();
+    static void initialize();
+    static void initialize_untrusted();
+    Vector<SMBIOS::PhysicalMemoryArray*>& get_physical_memory_areas();
+    bool is_reliable();
+    u64 get_bios_characteristics();
+
+private:
+    void enumerate_smbios_tables();
+    SMBIOS::TableHeader* get_next_physical_table(SMBIOS::TableHeader& p_table);
+    SMBIOS::TableHeader* get_smbios_physical_table_by_handle(u16 handle);
+    SMBIOS::TableHeader* get_smbios_physical_table_by_type(u8 table_type);
+    char* get_smbios_string(SMBIOS::TableHeader& p_table, u8 string_number);
+    size_t get_table_size(SMBIOS::TableHeader& table);
+
+    explicit DMIDecoder(bool trusted);
+    void initialize_parser();
+
+    SMBIOS::EntryPoint32bit* find_entry32bit_point();
+    SMBIOS::EntryPoint64bit* find_entry64bit_point();
+
+    void mmap(VirtualAddress vaddr, PhysicalAddress paddr, u32 length);
+    void mmap_region(Region& region, PhysicalAddress paddr);
+
+    SMBIOS::EntryPoint32bit* m_entry32bit_point;
+    SMBIOS::EntryPoint64bit* m_entry64bit_point;
+    SMBIOS::TableHeader* m_structure_table;
+    u32 m_structures_count;
+    u32 m_table_length;
+    bool m_use_64bit_entry;
+    bool m_operable;
+    bool m_untrusted;
+
+    SinglyLinkedList<SMBIOS::TableHeader*> m_smbios_tables;
+};

--- a/Kernel/ACPI/Definitions.h
+++ b/Kernel/ACPI/Definitions.h
@@ -1,0 +1,262 @@
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+
+namespace ACPI_RAW {
+
+struct RSDPDescriptor {
+    char sig[8];
+    u8 checksum;
+    char oem_id[6];
+    u8 revision;
+    u32 rsdt_ptr;
+} __attribute__((__packed__));
+
+struct RSDPDescriptor20 {
+    RSDPDescriptor base;
+    u32 length;
+    u64 xsdt_ptr;
+    u8 ext_checksum;
+    u8 reserved[3];
+} __attribute__((__packed__));
+
+struct SDTHeader {
+    char sig[4];
+    u32 length;
+    u8 revision;
+    u8 checksum;
+    char oem_id[6];
+    char oem_table_id[8];
+    u32 oem_revision;
+    u32 creator_id;
+    u32 creator_revision;
+} __attribute__((__packed__));
+
+struct RSDT {
+    SDTHeader h;
+    u32 table_ptrs[1];
+} __attribute__((__packed__));
+
+struct XSDT {
+    SDTHeader h;
+    u64 table_ptrs[1];
+} __attribute__((__packed__));
+
+struct GenericAddressStructure {
+    u8 address_space;
+    u8 bit_width;
+    u8 bit_offset;
+    u8 access_size;
+    u64 address;
+} __attribute__((__packed__));
+
+struct FADT {
+    SDTHeader h;
+    u32 firmware_ctrl;
+    u32 dsdt_ptr;
+    u8 reserved;
+    u8 preferred_pm_profile;
+    u16 sci_int;
+    u32 smi_cmd;
+    u8 acpi_enable_value;
+    u8 acpi_disable_value;
+    u8 s4bios_req;
+    u8 pstate_cnt;
+    u32 PM1a_EVT_BLK;
+    u32 PM1b_EVT_BLK;
+    u32 PM1a_CNT_BLK;
+    u32 PM1b_CNT_BLK;
+    u32 PM2_CNT_BLK;
+    u32 PM_TMR_BLK;
+    u32 GPE0_BLK;
+    u32 GPE1_BLK;
+    u8 PM1_EVT_LEN;
+    u8 PM1_CNT_LEN;
+    u8 PM2_CNT_LEN;
+    u8 PM_TMR_LEN;
+    u8 GPE0_BLK_LEN;
+    u8 GPE1_BLK_LEN;
+    u8 GPE1_BASE;
+    u8 cst_cnt;
+    u16 P_LVL2_LAT;
+    u16 P_LVL3_LAT;
+    u16 flush_size;
+    u16 flush_stride;
+    u8 duty_offset;
+    u8 duty_width;
+    u8 day_alrm;
+    u8 mon_alrm;
+    u8 century;
+    u16 ia_pc_boot_arch_flags;
+    u8 reserved2;
+    u32 flags;
+    GenericAddressStructure reset_reg;
+    u8 reset_value;
+    u16 arm_boot_arch;
+    u8 fadt_minor_version;
+    u64 x_firmware_ctrl;
+    u64 x_dsdt;
+    GenericAddressStructure x_pm1a_evt_blk;
+    GenericAddressStructure x_pm1b_evt_blk;
+    GenericAddressStructure x_pm1a_cnt_blk;
+    GenericAddressStructure x_pm1b_cnt_blk;
+    GenericAddressStructure x_pm2_cnt_blk;
+    GenericAddressStructure x_pm_tmr_blk;
+    GenericAddressStructure x_gpe0_blk;
+    GenericAddressStructure x_gpe1_blk;
+    GenericAddressStructure sleep_control;
+    GenericAddressStructure sleep_status;
+    u64 hypervisor_vendor_identity;
+
+} __attribute__((__packed__));
+
+struct MADT : public SDTHeader {
+};
+
+struct DSDT : public SDTHeader {
+};
+
+struct PCI_MMIO_Descriptor {
+    u64 base_addr;
+    u16 seg_group_number;
+    u8 start_pci_bus;
+    u8 end_pci_bus;
+    u32 reserved;
+} __attribute__((__packed__));
+
+struct MCFG {
+    SDTHeader header;
+    u64 reserved;
+    PCI_MMIO_Descriptor descriptors[];
+} __attribute__((__packed__));
+}
+
+class ACPIStaticParser;
+
+namespace ACPI {
+
+class SDT : public RefCounted<SDT> {
+};
+
+struct GenericAddressStructure {
+    u8 address_space;
+    u8 bit_width;
+    u8 bit_offset;
+    u8 access_size;
+    u64 address;
+    GenericAddressStructure& operator=(const GenericAddressStructure& other)
+    {
+        this->address_space = other.address_space;
+        this->bit_width = other.bit_width;
+        this->bit_offset = other.bit_offset;
+        this->access_size = other.access_size;
+        this->address = (u32)other.address;
+        return *this;
+    }
+    GenericAddressStructure& operator=(const ACPI_RAW::GenericAddressStructure& other)
+    {
+        this->address_space = other.address_space;
+        this->bit_width = other.bit_width;
+        this->bit_offset = other.bit_offset;
+        this->access_size = other.access_size;
+        this->address = (u32)other.address;
+        return *this;
+    }
+};
+
+class FixedACPIData;
+}
+
+class ACPI::FixedACPIData : public ACPI::SDT {
+    friend ACPIStaticParser;
+
+public:
+    explicit FixedACPIData(ACPI_RAW::FADT&);
+    ACPI_RAW::SDTHeader* get_dsdt();
+
+private:
+    u8 m_revision;
+    u32 m_dsdt_ptr;
+    u64 m_x_dsdt_ptr;
+    u8 m_preferred_pm_profile;
+    u16 m_sci_int;
+    u32 m_smi_cmd;
+    u8 m_acpi_enable_value;
+    u8 m_acpi_disable_value;
+    u8 m_s4bios_req;
+    u8 m_pstate_cnt;
+    u32 m_PM1a_EVT_BLK;
+    u32 m_PM1b_EVT_BLK;
+    u32 m_PM1a_CNT_BLK;
+    u32 m_PM1b_CNT_BLK;
+    u32 m_PM2_CNT_BLK;
+    u32 m_PM_TMR_BLK;
+    u32 m_GPE0_BLK;
+    u32 m_GPE1_BLK;
+    u8 m_PM1_EVT_LEN;
+    u8 m_PM1_CNT_LEN;
+    u8 m_PM2_CNT_LEN;
+    u8 m_PM_TMR_LEN;
+    u8 m_GPE0_BLK_LEN;
+    u8 m_GPE1_BLK_LEN;
+    u8 m_GPE1_BASE;
+    u8 m_cst_cnt;
+    u16 m_P_LVL2_LAT;
+    u16 m_P_LVL3_LAT;
+    u16 m_flush_size;
+    u16 m_flush_stride;
+    u8 m_duty_offset;
+    u8 m_duty_width;
+    u8 m_day_alrm;
+    u8 m_mon_alrm;
+    u8 m_century;
+    u16 m_ia_pc_boot_arch_flags;
+    u32 m_flags;
+    ACPI::GenericAddressStructure m_reset_reg;
+    u8 m_reset_value;
+    ACPI::GenericAddressStructure m_x_pm1a_evt_blk;
+    ACPI::GenericAddressStructure m_x_pm1b_evt_blk;
+    ACPI::GenericAddressStructure m_x_pm1a_cnt_blk;
+    ACPI::GenericAddressStructure m_x_pm1b_cnt_blk;
+    ACPI::GenericAddressStructure m_x_pm2_cnt_blk;
+    ACPI::GenericAddressStructure m_x_pm_tmr_blk;
+    ACPI::GenericAddressStructure m_x_gpe0_blk;
+    ACPI::GenericAddressStructure m_x_gpe1_blk;
+    ACPI::GenericAddressStructure m_sleep_control;
+    ACPI::GenericAddressStructure m_sleep_status;
+    u64 m_hypervisor_vendor_identity;
+};
+
+namespace ACPI {
+
+class MainSystemDescriptionTable : public SDT {
+public:
+    explicit MainSystemDescriptionTable(Vector<ACPI_RAW::SDTHeader*>&& sdt_pointers);
+    Vector<ACPI_RAW::SDTHeader*>& get_sdt_pointers();
+
+private:
+    Vector<ACPI_RAW::SDTHeader*> m_sdt_pointers;
+};
+
+class MCFG : public SDT {
+public:
+    MCFG(ACPI_RAW::MCFG&);
+};
+
+class FACS : public SDT {
+
+public:
+private:
+    u32 hardware_sig;
+    u32 waking_vector;
+    u32 global_lock;
+    u32 flags;
+    u64 x_waking_vector;
+    u32 ospm_flags;
+};
+
+class MADT : public SDT {
+};
+}

--- a/Kernel/Devices/BXVGADevice.cpp
+++ b/Kernel/Devices/BXVGADevice.cpp
@@ -1,6 +1,6 @@
 #include <Kernel/Devices/BXVGADevice.h>
 #include <Kernel/IO.h>
-#include <Kernel/PCI.h>
+#include <Kernel/PCI/Access.h>
 #include <Kernel/Process.h>
 #include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/MemoryManager.h>

--- a/Kernel/Devices/PATAChannel.h
+++ b/Kernel/Devices/PATAChannel.h
@@ -14,7 +14,7 @@
 #include <AK/RefPtr.h>
 #include <Kernel/IRQHandler.h>
 #include <Kernel/Lock.h>
-#include <Kernel/PCI.h>
+#include <Kernel/PCI/Access.h>
 #include <Kernel/VM/PhysicalAddress.h>
 #include <Kernel/VM/PhysicalPage.h>
 #include <Kernel/WaitQueue.h>

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -22,7 +22,7 @@
 #include <Kernel/Net/Routing.h>
 #include <Kernel/Net/TCPSocket.h>
 #include <Kernel/Net/UDPSocket.h>
-#include <Kernel/PCI.h>
+#include <Kernel/PCI/Access.h>
 #include <Kernel/Profiling.h>
 #include <Kernel/VM/MemoryManager.h>
 #include <Kernel/VM/PurgeableVMObject.h>
@@ -289,6 +289,7 @@ Optional<KBuffer> procfs$pci(InodeIdentifier)
     JsonArraySerializer array { builder };
     PCI::enumerate_all([&array](PCI::Address address, PCI::ID id) {
         auto obj = array.add_object();
+        obj.add("seg", address.seg());
         obj.add("bus", address.bus());
         obj.add("slot", address.slot());
         obj.add("function", address.function());

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -71,7 +71,10 @@ OBJS = \
     Net/Socket.o \
     Net/TCPSocket.o \
     Net/UDPSocket.o \
-    PCI.o \
+    PCI/Access.o \
+    PCI/IOAccess.o \
+    PCI/MMIOAccess.o \
+    PCI/Initializer.o \
     Process.o \
     ProcessTracer.o \
     Profiling.o \
@@ -97,6 +100,10 @@ OBJS = \
     VM/RangeAllocator.o \
     VM/Region.o \
     VM/VMObject.o \
+    ACPI/ACPIParser.o \
+    ACPI/ACPIStaticParser.o \
+    ACPI/ACPIDynamicParser.o \
+    ACPI/DMIDecoder.o \
     WaitQueue.o \
     init.o \
     kprintf.o

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -1,6 +1,5 @@
 #include <Kernel/IO.h>
 #include <Kernel/Net/E1000NetworkAdapter.h>
-#include <Kernel/PCI.h>
 #include <Kernel/Thread.h>
 
 #define REG_CTRL 0x0000
@@ -119,6 +118,7 @@ E1000NetworkAdapter::E1000NetworkAdapter(PCI::Address pci_address, u8 irq)
     enable_bus_mastering(m_pci_address);
 
     m_mmio_base = PhysicalAddress(PCI::get_BAR0(m_pci_address));
+    u32 mmio_base_size = PCI::get_BAR_Space_Size(pci_address, 0);
     MM.map_for_kernel(VirtualAddress(m_mmio_base.get()), m_mmio_base);
     MM.map_for_kernel(VirtualAddress(m_mmio_base.offset(4096).get()), m_mmio_base.offset(4096));
     MM.map_for_kernel(VirtualAddress(m_mmio_base.offset(8192).get()), m_mmio_base.offset(8192));
@@ -129,6 +129,7 @@ E1000NetworkAdapter::E1000NetworkAdapter(PCI::Address pci_address, u8 irq)
     m_interrupt_line = PCI::get_interrupt_line(m_pci_address);
     kprintf("E1000: IO port base: %w\n", m_io_base);
     kprintf("E1000: MMIO base: P%x\n", m_mmio_base);
+    kprintf("E1000: MMIO base size: %u bytes\n", mmio_base_size);
     kprintf("E1000: Interrupt line: %u\n", m_interrupt_line);
     detect_eeprom();
     kprintf("E1000: Has EEPROM? %u\n", m_has_eeprom);

--- a/Kernel/Net/E1000NetworkAdapter.h
+++ b/Kernel/Net/E1000NetworkAdapter.h
@@ -3,7 +3,7 @@
 #include <AK/OwnPtr.h>
 #include <Kernel/IRQHandler.h>
 #include <Kernel/Net/NetworkAdapter.h>
-#include <Kernel/PCI.h>
+#include <Kernel/PCI/Access.h>
 
 class E1000NetworkAdapter final : public NetworkAdapter
     , public IRQHandler {

--- a/Kernel/Net/RTL8139NetworkAdapter.cpp
+++ b/Kernel/Net/RTL8139NetworkAdapter.cpp
@@ -1,6 +1,5 @@
 #include <Kernel/IO.h>
 #include <Kernel/Net/RTL8139NetworkAdapter.h>
-#include <Kernel/PCI.h>
 
 //#define RTL8139_DEBUG
 

--- a/Kernel/Net/RTL8139NetworkAdapter.h
+++ b/Kernel/Net/RTL8139NetworkAdapter.h
@@ -3,7 +3,7 @@
 #include <AK/OwnPtr.h>
 #include <Kernel/IRQHandler.h>
 #include <Kernel/Net/NetworkAdapter.h>
-#include <Kernel/PCI.h>
+#include <Kernel/PCI/Access.h>
 
 #define RTL8139_TX_BUFFER_COUNT 4
 

--- a/Kernel/PCI/Access.cpp
+++ b/Kernel/PCI/Access.cpp
@@ -1,0 +1,142 @@
+#include <Kernel/PCI/Access.h>
+#include <Kernel/PCI/IOAccess.h>
+
+static PCI::Access* s_access;
+
+PCI::Access& PCI::Access::the()
+{
+    if (s_access == nullptr) {
+        ASSERT_NOT_REACHED(); // We failed to initialize the PCI subsystem, so stop here!
+    }
+    return *s_access;
+}
+
+bool PCI::Access::is_initialized()
+{
+    return (s_access != nullptr);
+}
+
+PCI::Access::Access()
+{
+    s_access = this;
+}
+
+void PCI::Access::enumerate_functions(int type, u8 bus, u8 slot, u8 function, Function<void(Address, ID)>& callback)
+{
+    Address address(0, bus, slot, function);
+    if (type == -1 || type == read_type(address))
+        callback(address, { read16_field(address, PCI_VENDOR_ID), read16_field(address, PCI_DEVICE_ID) });
+    if (read_type(address) == PCI_TYPE_BRIDGE) {
+        u8 secondary_bus = read8_field(address, PCI_SECONDARY_BUS);
+#ifdef PCI_DEBUG
+        kprintf("PCI: Found secondary bus: %u\n", secondary_bus);
+#endif
+        ASSERT(secondary_bus != bus);
+        enumerate_bus(type, secondary_bus, callback);
+    }
+}
+
+void PCI::Access::enumerate_slot(int type, u8 bus, u8 slot, Function<void(Address, ID)>& callback)
+{
+    Address address(0, bus, slot, 0);
+    if (read16_field(address, PCI_VENDOR_ID) == PCI_NONE)
+        return;
+    enumerate_functions(type, bus, slot, 0, callback);
+    if (!(read8_field(address, PCI_HEADER_TYPE) & 0x80))
+        return;
+    for (u8 function = 1; function < 8; ++function) {
+        Address address(0, bus, slot, function);
+        if (read16_field(address, PCI_VENDOR_ID) != PCI_NONE)
+            enumerate_functions(type, bus, slot, function, callback);
+    }
+}
+
+void PCI::Access::enumerate_bus(int type, u8 bus, Function<void(Address, ID)>& callback)
+{
+    for (u8 slot = 0; slot < 32; ++slot)
+        enumerate_slot(type, bus, slot, callback);
+}
+
+void PCI::Access::enable_bus_mastering(Address address)
+{
+    auto value = read16_field(address, PCI_COMMAND);
+    value |= (1 << 2);
+    value |= (1 << 0);
+    write16_field(address, PCI_COMMAND, value);
+}
+
+void PCI::Access::disable_bus_mastering(Address address)
+{
+    auto value = read16_field(address, PCI_COMMAND);
+    value &= ~(1 << 2);
+    value |= (1 << 0);
+    write16_field(address, PCI_COMMAND, value);
+}
+
+namespace PCI {
+void enumerate_all(Function<void(Address, ID)> callback)
+{
+    PCI::Access::the().enumerate_all(callback);
+}
+
+u8 get_interrupt_line(Address address)
+{
+    return PCI::Access::the().get_interrupt_line(address);
+}
+u32 get_BAR0(Address address)
+{
+    return PCI::Access::the().get_BAR0(address);
+}
+u32 get_BAR1(Address address)
+{
+    return PCI::Access::the().get_BAR1(address);
+}
+u32 get_BAR2(Address address)
+{
+    return PCI::Access::the().get_BAR2(address);
+}
+u32 get_BAR3(Address address)
+{
+    return PCI::Access::the().get_BAR3(address);
+}
+u32 get_BAR4(Address address)
+{
+    return PCI::Access::the().get_BAR4(address);
+}
+u32 get_BAR5(Address address)
+{
+    return PCI::Access::the().get_BAR5(address);
+}
+u8 get_revision_id(Address address)
+{
+    return PCI::Access::the().get_revision_id(address);
+}
+u8 get_subclass(Address address)
+{
+    return PCI::Access::the().get_subclass(address);
+}
+u8 get_class(Address address)
+{
+    return PCI::Access::the().get_class(address);
+}
+u16 get_subsystem_id(Address address)
+{
+    return PCI::Access::the().get_subsystem_id(address);
+}
+u16 get_subsystem_vendor_id(Address address)
+{
+    return PCI::Access::the().get_subsystem_vendor_id(address);
+}
+void enable_bus_mastering(Address address)
+{
+    PCI::Access::the().enable_bus_mastering(address);
+}
+void disable_bus_mastering(Address address)
+{
+    PCI::Access::the().disable_bus_mastering(address);
+}
+u32 get_BAR_Space_Size(Address address, u8 bar_number)
+{
+    return PCI::Access::the().get_BAR_Space_Size(address, bar_number);
+}
+}

--- a/Kernel/PCI/Access.h
+++ b/Kernel/PCI/Access.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <AK/String.h>
+#include <Kernel/PCI/Definitions.h>
+
+class PCI::Access {
+public:
+    virtual void enumerate_all(Function<void(Address, ID)>&) = 0;
+    virtual u8 get_interrupt_line(Address address) { return read8_field(address, PCI_INTERRUPT_LINE); }
+    virtual u32 get_BAR0(Address address) { return read32_field(address, PCI_BAR0); }
+    virtual u32 get_BAR1(Address address) { return read32_field(address, PCI_BAR1); }
+    virtual u32 get_BAR2(Address address) { return read32_field(address, PCI_BAR2); }
+    virtual u32 get_BAR3(Address address) { return read32_field(address, PCI_BAR3); }
+    virtual u32 get_BAR4(Address address) { return read32_field(address, PCI_BAR4); }
+    virtual u32 get_BAR5(Address address) { return read32_field(address, PCI_BAR5); }
+
+    virtual u32 get_BAR_Space_Size(Address address, u8 bar_number)
+    {
+        // See PCI Spec 2.3, Page 222
+        ASSERT(bar_number < 6);
+        u8 field = (PCI_BAR0 + (bar_number << 2));
+        u32 bar_reserved = read32_field(address, field);
+        write32_field(address, field, 0xFFFFFFFF);
+        u32 space_size = read32_field(address, field);
+        write32_field(address, field, bar_reserved);
+        space_size &= 0xfffffff0;
+        space_size = (~space_size) + 1;
+        return space_size;
+    }
+
+    virtual u8 get_revision_id(Address address) { return read8_field(address, PCI_REVISION_ID); }
+    virtual u8 get_subclass(Address address) { return read8_field(address, PCI_SUBCLASS); }
+    virtual u8 get_class(Address address) { return read8_field(address, PCI_CLASS); }
+    virtual u16 get_subsystem_id(Address address) { return read16_field(address, PCI_SUBSYSTEM_ID); }
+    virtual u16 get_subsystem_vendor_id(Address address) { return read16_field(address, PCI_SUBSYSTEM_VENDOR_ID); }
+    virtual u16 read_type(Address address) { return (read8_field(address, PCI_CLASS) << 8u) | read8_field(address, PCI_SUBCLASS); }
+
+    virtual void enable_bus_mastering(Address) final;
+    virtual void disable_bus_mastering(Address) final;
+
+    virtual void enumerate_bus(int type, u8 bus, Function<void(Address, ID)>&) final;
+    virtual void enumerate_functions(int type, u8 bus, u8 slot, u8 function, Function<void(Address, ID)>& callback) final;
+    virtual void enumerate_slot(int type, u8 bus, u8 slot, Function<void(Address, ID)>& callback) final;
+
+    static Access& the();
+    static bool is_initialized();
+    virtual uint32_t get_segments_count() = 0;
+    virtual uint8_t get_segment_start_bus(u32 segment) = 0;
+    virtual uint8_t get_segment_end_bus(u32 segment) = 0;
+    virtual String get_access_type() = 0;
+
+protected:
+    Access();
+
+    virtual u8 read8_field(Address address, u32 field) = 0;
+    virtual u16 read16_field(Address address, u32 field) = 0;
+    virtual u32 read32_field(Address address, u32 field) = 0;
+
+    virtual void write8_field(Address address, u32 field, u8 value) = 0;
+    virtual void write16_field(Address address, u32 field, u16 value) = 0;
+    virtual void write32_field(Address address, u32 field, u32 value) = 0;
+};

--- a/Kernel/PCI/Definitions.h
+++ b/Kernel/PCI/Definitions.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/Types.h>
+
+#define PCI_VENDOR_ID 0x00           // word
+#define PCI_DEVICE_ID 0x02           // word
+#define PCI_COMMAND 0x04             // word
+#define PCI_STATUS 0x06              // word
+#define PCI_REVISION_ID 0x08         // byte
+#define PCI_PROG_IF 0x09             // byte
+#define PCI_SUBCLASS 0x0a            // byte
+#define PCI_CLASS 0x0b               // byte
+#define PCI_CACHE_LINE_SIZE 0x0c     // byte
+#define PCI_LATENCY_TIMER 0x0d       // byte
+#define PCI_HEADER_TYPE 0x0e         // byte
+#define PCI_BIST 0x0f                // byte
+#define PCI_BAR0 0x10                // u32
+#define PCI_BAR1 0x14                // u32
+#define PCI_BAR2 0x18                // u32
+#define PCI_BAR3 0x1C                // u32
+#define PCI_BAR4 0x20                // u32
+#define PCI_BAR5 0x24                // u32
+#define PCI_SUBSYSTEM_ID 0x2C        // u16
+#define PCI_SUBSYSTEM_VENDOR_ID 0x2E // u16
+#define PCI_INTERRUPT_LINE 0x3C      // byte
+#define PCI_SECONDARY_BUS 0x19       // byte
+#define PCI_HEADER_TYPE_DEVICE 0
+#define PCI_HEADER_TYPE_BRIDGE 1
+#define PCI_TYPE_BRIDGE 0x0604
+#define PCI_ADDRESS_PORT 0xCF8
+#define PCI_VALUE_PORT 0xCFC
+#define PCI_NONE 0xFFFF
+#define PCI_MAX_DEVICES_PER_BUS 32
+#define PCI_MAX_BUSES 256
+#define PCI_MAX_FUNCTIONS_PER_DEVICE 8
+
+//#define PCI_DEBUG 1
+
+namespace PCI {
+struct ID {
+    u16 vendor_id { 0 };
+    u16 device_id { 0 };
+
+    bool is_null() const { return !vendor_id && !device_id; }
+
+    bool operator==(const ID& other) const
+    {
+        return vendor_id == other.vendor_id && device_id == other.device_id;
+    }
+};
+
+struct Address {
+    Address() {}
+    Address(u16 seg)
+        : m_seg(seg)
+        , m_bus(0)
+        , m_slot(0)
+        , m_function(0)
+    {
+    }
+    Address(u16 seg, u8 bus, u8 slot, u8 function)
+        : m_seg(seg)
+        , m_bus(bus)
+        , m_slot(slot)
+        , m_function(function)
+    {
+    }
+
+    bool is_null() const { return !m_bus && !m_slot && !m_function; }
+    operator bool() const { return !is_null(); }
+
+    u16 seg() const { return m_seg; }
+    u8 bus() const { return m_bus; }
+    u8 slot() const { return m_slot; }
+    u8 function() const { return m_function; }
+
+    u32 io_address_for_field(u8 field) const
+    {
+        return 0x80000000u | (m_bus << 16u) | (m_slot << 11u) | (m_function << 8u) | (field & 0xfc);
+    }
+
+private:
+    u32 m_seg { 0 };
+    u8 m_bus { 0 };
+    u8 m_slot { 0 };
+    u8 m_function { 0 };
+};
+
+void enumerate_all(Function<void(Address, ID)> callback);
+u8 get_interrupt_line(Address);
+u32 get_BAR0(Address);
+u32 get_BAR1(Address);
+u32 get_BAR2(Address);
+u32 get_BAR3(Address);
+u32 get_BAR4(Address);
+u32 get_BAR5(Address);
+u8 get_revision_id(Address);
+u8 get_subclass(Address);
+u8 get_class(Address);
+u16 get_subsystem_id(Address);
+u16 get_subsystem_vendor_id(Address);
+u32 get_BAR_Space_Size(Address, u8);
+void enable_bus_mastering(Address);
+void disable_bus_mastering(Address);
+
+class Initializer;
+class Access;
+class MMIOAccess;
+class IOAccess;
+class MMIOSegment;
+
+}

--- a/Kernel/PCI/IOAccess.cpp
+++ b/Kernel/PCI/IOAccess.cpp
@@ -1,0 +1,63 @@
+#include <Kernel/IO.h>
+#include <Kernel/PCI/IOAccess.h>
+
+void PCI::IOAccess::initialize()
+{
+    if (!PCI::Access::is_initialized())
+        new PCI::IOAccess();
+}
+
+PCI::IOAccess::IOAccess()
+{
+    kprintf("PCI: Using IO Mechanism for PCI Configuartion Space Access\n");
+}
+
+u8 PCI::IOAccess::read8_field(Address address, u32 field)
+{
+    IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
+    return IO::in8(PCI_VALUE_PORT + (field & 3));
+}
+
+u16 PCI::IOAccess::read16_field(Address address, u32 field)
+{
+    IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
+    return IO::in16(PCI_VALUE_PORT + (field & 2));
+}
+
+u32 PCI::IOAccess::read32_field(Address address, u32 field)
+{
+    IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
+    return IO::in32(PCI_VALUE_PORT);
+}
+
+void PCI::IOAccess::write8_field(Address address, u32 field, u8 value)
+{
+    IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
+    IO::out8(PCI_VALUE_PORT + (field & 3), value);
+}
+void PCI::IOAccess::write16_field(Address address, u32 field, u16 value)
+{
+    IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
+    IO::out16(PCI_VALUE_PORT + (field & 2), value);
+}
+void PCI::IOAccess::write32_field(Address address, u32 field, u32 value)
+{
+    IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
+    IO::out32(PCI_VALUE_PORT, value);
+}
+
+void PCI::IOAccess::enumerate_all(Function<void(Address, ID)>& callback)
+{
+    // Single PCI host controller.
+    if ((read8_field(Address(), PCI_HEADER_TYPE) & 0x80) == 0) {
+        enumerate_bus(-1, 0, callback);
+        return;
+    }
+
+    // Multiple PCI host controllers.
+    for (u8 function = 0; function < 8; ++function) {
+        if (read16_field(Address(0, 0, 0, function), PCI_VENDOR_ID) == PCI_NONE)
+            break;
+        enumerate_bus(-1, function, callback);
+    }
+}

--- a/Kernel/PCI/IOAccess.h
+++ b/Kernel/PCI/IOAccess.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <Kernel/PCI/Access.h>
+
+class PCI::IOAccess final : public PCI::Access {
+public:
+    static void initialize();
+    virtual void enumerate_all(Function<void(Address, ID)>&) override final;
+
+    virtual String get_access_type() override final { return "IO-Access"; };
+
+protected:
+    IOAccess();
+
+private:
+    virtual u8 read8_field(Address address, u32) override final;
+    virtual u16 read16_field(Address address, u32) override final;
+    virtual u32 read32_field(Address address, u32) override final;
+    virtual void write8_field(Address address, u32, u8) override final;
+    virtual void write16_field(Address address, u32, u16) override final;
+    virtual void write32_field(Address address, u32, u32) override final;
+
+    virtual uint32_t get_segments_count() { return 1; };
+    virtual uint8_t get_segment_start_bus(u32) { return 0x0; };
+    virtual uint8_t get_segment_end_bus(u32) { return 0xFF; };
+};

--- a/Kernel/PCI/Initializer.cpp
+++ b/Kernel/PCI/Initializer.cpp
@@ -1,0 +1,126 @@
+#include <Kernel/ACPI/ACPIParser.h>
+#include <Kernel/ACPI/DMIDecoder.h>
+#include <Kernel/IO.h>
+#include <Kernel/KParams.h>
+#include <Kernel/PCI/IOAccess.h>
+#include <Kernel/PCI/Initializer.h>
+#include <Kernel/PCI/MMIOAccess.h>
+
+static PCI::Initializer* s_pci_initializer;
+
+PCI::Initializer& PCI::Initializer::the()
+{
+    if (s_pci_initializer == nullptr) {
+        s_pci_initializer = new PCI::Initializer();
+    }
+    return *s_pci_initializer;
+}
+void PCI::Initializer::initialize_pci_mmio_access(ACPI_RAW::MCFG& mcfg)
+{
+    PCI::MMIOAccess::initialize(mcfg);
+}
+void PCI::Initializer::initialize_pci_io_access()
+{
+    PCI::IOAccess::initialize();
+}
+void PCI::Initializer::test_and_initialize(bool disable_pci_mmio, bool pci_force_probing)
+{
+    if (disable_pci_mmio) {
+        if (test_pci_io(pci_force_probing)) {
+            initialize_pci_io_access();
+        } else {
+            kprintf("No PCI Bus Access Method Detected, Halt!\n");
+            ASSERT_NOT_REACHED(); // NO PCI Access ?!
+        }
+        return;
+    }
+    if (test_acpi()) {
+        if (test_pci_mmio()) {
+            initialize_pci_mmio_access_after_test();
+        } else {
+            if (test_pci_io(pci_force_probing)) {
+                initialize_pci_io_access();
+            } else {
+                kprintf("No PCI Bus Access Method Detected, Halt!\n");
+                ASSERT_NOT_REACHED(); // NO PCI Access ?!
+            }
+        }
+    } else {
+        if (test_pci_io(pci_force_probing)) {
+            initialize_pci_io_access();
+        } else {
+            kprintf("No PCI Bus Access Method Detected, Halt!\n");
+            ASSERT_NOT_REACHED(); // NO PCI Access ?!
+        }
+    }
+}
+PCI::Initializer::Initializer()
+{
+}
+bool PCI::Initializer::test_acpi()
+{
+    if ((KParams::the().has("noacpi")) || !ACPIParser::the().is_operable())
+        return false;
+    else
+        return true;
+}
+
+bool PCI::Initializer::test_pci_io(bool pci_force_probing)
+{
+    kprintf("Testing PCI via SMBIOS...\n");
+
+    if (!pci_force_probing) {
+        if (DMIDecoder::the().is_reliable()) {
+            if ((DMIDecoder::the().get_bios_characteristics() & (1 << 3)) != 0) {
+                kprintf("DMIDecoder: Warning, BIOS characteristics are not supported, skipping\n");
+            } else if ((DMIDecoder::the().get_bios_characteristics() & (u32)SMBIOS::BIOSCharacteristics::PCI_support) != 0) {
+                kprintf("PCI *should* be supported according to SMBIOS...\n");
+                return true;
+            } else {
+                kprintf("SMBIOS does not list PCI as supported, Falling back to manual probing!\n");
+            }
+        } else {
+            kprintf("DMI is classified as unreliable, ignore it!\n");
+        }
+    } else {
+        kprintf("Requested to force PCI probing...\n");
+    }
+
+    kprintf("Testing PCI via manual probing... ");
+
+    u32 tmp = 0x80000000;
+    IO::out32(PCI_ADDRESS_PORT, tmp);
+    tmp = IO::in32(PCI_ADDRESS_PORT);
+    if (tmp == 0x80000000) {
+        kprintf("PCI IO Supported!\n");
+        return true;
+    }
+
+    kprintf("PCI IO Not Supported!\n");
+    return false;
+}
+
+bool PCI::Initializer::test_pci_mmio()
+{
+    if (ACPIParser::the().find_table("MCFG") != nullptr)
+        return true;
+    else
+        return false;
+}
+
+void PCI::Initializer::initialize_pci_mmio_access_after_test()
+{
+    initialize_pci_mmio_access(*(ACPI_RAW::MCFG*)(ACPIParser::the().find_table("MCFG")));
+}
+
+void PCI::Initializer::dismiss()
+{
+    if (s_pci_initializer == nullptr)
+        return;
+    kprintf("PCI Subsystem Initializer dismissed.\n");
+    s_pci_initializer->~Initializer();
+}
+
+PCI::Initializer::~Initializer()
+{
+}

--- a/Kernel/PCI/Initializer.h
+++ b/Kernel/PCI/Initializer.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/ACPI/Definitions.h>
+#include <Kernel/PCI/Definitions.h>
+
+class PCI::Initializer {
+public:
+    static PCI::Initializer& the();
+    void initialize_pci_mmio_access(ACPI_RAW::MCFG& mcfg);
+    void initialize_pci_io_access();
+    void test_and_initialize(bool disable_pci_mmio, bool pci_force_probing);
+    static void dismiss();
+
+private:
+    ~Initializer();
+    Initializer();
+    bool test_acpi();
+    bool test_pci_io(bool pci_force_probing);
+    bool test_pci_mmio();
+    void initialize_pci_mmio_access_after_test();
+};

--- a/Kernel/PCI/MMIOAccess.cpp
+++ b/Kernel/PCI/MMIOAccess.cpp
@@ -1,0 +1,215 @@
+#include <AK/Optional.h>
+#include <Kernel/IO.h>
+#include <Kernel/PCI/MMIOAccess.h>
+#include <Kernel/VM/MemoryManager.h>
+
+#define PCI_MMIO_CONFIG_SPACE_SIZE 4096
+
+uint32_t PCI::MMIOAccess::get_segments_count()
+{
+    return m_segments.size();
+}
+uint8_t PCI::MMIOAccess::get_segment_start_bus(u32 seg)
+{
+    ASSERT(m_segments.contains(seg));
+    return m_segments.get(seg).value()->get_start_bus();
+}
+uint8_t PCI::MMIOAccess::get_segment_end_bus(u32 seg)
+{
+    ASSERT(m_segments.contains(seg));
+    return m_segments.get(seg).value()->get_end_bus();
+}
+
+void PCI::MMIOAccess::initialize(ACPI_RAW::MCFG& mcfg)
+{
+    if (!PCI::Access::is_initialized())
+        new PCI::MMIOAccess(mcfg);
+}
+
+PCI::MMIOAccess::MMIOAccess(ACPI_RAW::MCFG& raw_mcfg)
+    : m_mcfg(raw_mcfg)
+    , m_segments(*new HashMap<u16, MMIOSegment*>())
+{
+    kprintf("PCI: Using MMIO Mechanism for PCI Configuartion Space Access\n");
+    m_mmio_segment = MM.allocate_kernel_region(PAGE_ROUND_UP(PCI_MMIO_CONFIG_SPACE_SIZE), "PCI MMIO", Region::Access::Read | Region::Access::Write);
+
+    OwnPtr<Region> checkup_region = MM.allocate_kernel_region((PAGE_SIZE * 2), "PCI MCFG Checkup", Region::Access::Read | Region::Access::Write);
+#ifdef PCI_DEBUG
+    dbgprintf("PCI: Checking MCFG Table length to choose the correct mapping size\n");
+#endif
+    mmap_region(*checkup_region, PhysicalAddress((u32)&raw_mcfg & 0xfffff000));
+    ACPI_RAW::SDTHeader* sdt = (ACPI_RAW::SDTHeader*)(checkup_region->vaddr().get() + ((u32)&raw_mcfg & 0xfff));
+    u32 length = sdt->length;
+    u8 revision = sdt->revision;
+
+    kprintf("PCI: MCFG, length - %u, revision %d\n", length, revision);
+    checkup_region->unmap();
+
+    auto mcfg_region = MM.allocate_kernel_region(PAGE_ROUND_UP(length) + PAGE_SIZE, "PCI Parsing MCFG", Region::Access::Read | Region::Access::Write);
+    mmap_region(*mcfg_region, PhysicalAddress((u32)&raw_mcfg & 0xfffff000));
+
+    ACPI_RAW::MCFG& mcfg = *((ACPI_RAW::MCFG*)(mcfg_region->vaddr().get() + ((u32)&raw_mcfg & 0xfff)));
+#ifdef PCI_DEBUG
+    dbgprintf("PCI: Checking MCFG @ V 0x%x, P 0x%x\n", &mcfg, &raw_mcfg);
+#endif
+
+    for (u32 index = 0; index < ((mcfg.header.length - sizeof(ACPI_RAW::MCFG)) / sizeof(ACPI_RAW::PCI_MMIO_Descriptor)); index++) {
+        u8 start_bus = mcfg.descriptors[index].start_pci_bus;
+        u8 end_bus = mcfg.descriptors[index].end_pci_bus;
+        u32 lower_addr = mcfg.descriptors[index].base_addr;
+
+        m_segments.set(index, new PCI::MMIOSegment(PhysicalAddress(lower_addr), start_bus, end_bus));
+        kprintf("PCI: New PCI segment @ P 0x%x, PCI buses (%d-%d)\n", lower_addr, start_bus, end_bus);
+    }
+    mcfg_region->unmap();
+    kprintf("PCI: MMIO segments - %d\n", m_segments.size());
+    map_device(Address(0, 0, 0, 0));
+}
+
+void PCI::MMIOAccess::map_device(Address address)
+{
+    // FIXME: Map and put some lock!
+#ifdef PCI_DEBUG
+    dbgprintf("PCI: Mapping Device @ pci (%d:%d:%d:%d)\n", address.seg(), address.bus(), address.slot(), address.function());
+#endif
+    ASSERT(m_segments.contains(address.seg()));
+    auto segment = m_segments.get(address.seg());
+    PhysicalAddress segment_lower_addr = segment.value()->get_paddr();
+    PhysicalAddress device_physical_mmio_space = segment_lower_addr.offset(
+        PCI_MMIO_CONFIG_SPACE_SIZE * address.function() + (PCI_MMIO_CONFIG_SPACE_SIZE * PCI_MAX_FUNCTIONS_PER_DEVICE) * address.slot() + (PCI_MMIO_CONFIG_SPACE_SIZE * PCI_MAX_FUNCTIONS_PER_DEVICE * PCI_MAX_DEVICES_PER_BUS) * (address.bus() - segment.value()->get_start_bus()));
+#ifdef PCI_DEBUG
+    dbgprintf("PCI: Mapping (%d:%d:%d:%d), V 0x%x, P 0x%x\n", address.seg(), address.bus(), address.slot(), address.function(), m_mmio_segment->vaddr().get(), device_physical_mmio_space.get());
+#endif
+    MM.map_for_kernel(m_mmio_segment->vaddr(), device_physical_mmio_space, false);
+}
+
+u8 PCI::MMIOAccess::read8_field(Address address, u32 field)
+{
+    ASSERT(field <= 0xfff);
+#ifdef PCI_DEBUG
+    dbgprintf("PCI: Reading field %u, Address(%u:%u:%u:%u)\n", field, address.seg(), address.bus(), address.slot(), address.function());
+#endif
+    map_device(address);
+    return *((u8*)(m_mmio_segment->vaddr().get() + (field & 0xfff)));
+}
+
+u16 PCI::MMIOAccess::read16_field(Address address, u32 field)
+{
+    ASSERT(field < 0xfff);
+#ifdef PCI_DEBUG
+    dbgprintf("PCI: Reading field %u, Address(%u:%u:%u:%u)\n", field, address.seg(), address.bus(), address.slot(), address.function());
+#endif
+    map_device(address);
+    return *((u16*)(m_mmio_segment->vaddr().get() + (field & 0xfff)));
+}
+
+u32 PCI::MMIOAccess::read32_field(Address address, u32 field)
+{
+    ASSERT(field <= 0xffc);
+#ifdef PCI_DEBUG
+    dbgprintf("PCI: Reading field %u, Address(%u:%u:%u:%u)\n", field, address.seg(), address.bus(), address.slot(), address.function());
+#endif
+    map_device(address);
+    return *((u32*)(m_mmio_segment->vaddr().get() + (field & 0xfff)));
+}
+
+void PCI::MMIOAccess::write8_field(Address address, u32 field, u8 value)
+{
+    ASSERT(field <= 0xfff);
+#ifdef PCI_DEBUG
+    dbgprintf("PCI: Write to field %u, Address(%u:%u:%u:%u), value 0x%x\n", field, address.seg(), address.bus(), address.slot(), address.function(), value);
+#endif
+    map_device(address);
+    *((u8*)(m_mmio_segment->vaddr().get() + (field & 0xfff))) = value;
+}
+void PCI::MMIOAccess::write16_field(Address address, u32 field, u16 value)
+{
+    ASSERT(field < 0xfff);
+#ifdef PCI_DEBUG
+    dbgprintf("PCI: Write to field %u, Address(%u:%u:%u:%u), value 0x%x\n", field, address.seg(), address.bus(), address.slot(), address.function(), value);
+#endif
+    map_device(address);
+    *((u16*)(m_mmio_segment->vaddr().get() + (field & 0xfff))) = value;
+}
+void PCI::MMIOAccess::write32_field(Address address, u32 field, u32 value)
+{
+    ASSERT(field <= 0xffc);
+#ifdef PCI_DEBUG
+    dbgprintf("PCI: Write to field %u, Address(%u:%u:%u:%u), value 0x%x\n", field, address.seg(), address.bus(), address.slot(), address.function(), value);
+#endif
+    map_device(address);
+    *((u32*)(m_mmio_segment->vaddr().get() + (field & 0xfff))) = value;
+}
+
+void PCI::MMIOAccess::enumerate_all(Function<void(Address, ID)>& callback)
+{
+    for (u16 seg = 0; seg < m_segments.size(); seg++) {
+#ifdef PCI_DEBUG
+        dbgprintf("PCI: Enumerating Memory mapped IO segment %u\n", seg);
+#endif
+        // Single PCI host controller.
+        if ((read8_field(Address(seg), PCI_HEADER_TYPE) & 0x80) == 0) {
+            enumerate_bus(-1, 0, callback);
+            return;
+        }
+
+        // Multiple PCI host controllers.
+        for (u8 function = 0; function < 8; ++function) {
+            if (read16_field(Address(seg, 0, 0, function), PCI_VENDOR_ID) == PCI_NONE)
+                break;
+            enumerate_bus(-1, function, callback);
+        }
+    }
+}
+
+void PCI::MMIOAccess::mmap(VirtualAddress vaddr, PhysicalAddress paddr, u32 length)
+{
+    unsigned i = 0;
+    while (length >= PAGE_SIZE) {
+        MM.map_for_kernel(VirtualAddress(vaddr.offset(i * PAGE_SIZE).get()), PhysicalAddress(paddr.offset(i * PAGE_SIZE).get()));
+#ifdef ACPI_DEBUG
+        dbgprintf("PCI: map - V 0x%x -> P 0x%x\n", vaddr.offset(i * PAGE_SIZE).get(), paddr.offset(i * PAGE_SIZE).get());
+#endif
+        length -= PAGE_SIZE;
+        i++;
+    }
+    if (length > 0) {
+        MM.map_for_kernel(vaddr.offset(i * PAGE_SIZE), paddr.offset(i * PAGE_SIZE), true);
+    }
+#ifdef ACPI_DEBUG
+    dbgprintf("PCI: Finished mapping\n");
+#endif
+}
+
+void PCI::MMIOAccess::mmap_region(Region& region, PhysicalAddress paddr)
+{
+#ifdef PCI_DEBUG
+    dbgprintf("PCI: Mapping region, size - %u\n", region.size());
+#endif
+    mmap(region.vaddr(), paddr, region.size());
+}
+
+PCI::MMIOSegment::MMIOSegment(PhysicalAddress segment_base_addr, u8 start_bus, u8 end_bus)
+    : m_base_addr(segment_base_addr)
+    , m_start_bus(start_bus)
+    , m_end_bus(end_bus)
+{
+}
+u8 PCI::MMIOSegment::get_start_bus()
+{
+    return m_start_bus;
+}
+u8 PCI::MMIOSegment::get_end_bus()
+{
+    return m_end_bus;
+}
+
+size_t PCI::MMIOSegment::get_size()
+{
+    return (PCI_MMIO_CONFIG_SPACE_SIZE * PCI_MAX_FUNCTIONS_PER_DEVICE * PCI_MAX_DEVICES_PER_BUS * (get_end_bus() - get_start_bus()));
+}
+
+PhysicalAddress PCI::MMIOSegment::get_paddr()
+{
+    return m_base_addr;
+}

--- a/Kernel/PCI/MMIOAccess.h
+++ b/Kernel/PCI/MMIOAccess.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <AK/HashMap.h>
+#include <AK/OwnPtr.h>
+#include <AK/Types.h>
+#include <Kernel/ACPI/Definitions.h>
+#include <Kernel/PCI/Access.h>
+#include <Kernel/VM/PhysicalRegion.h>
+#include <Kernel/VM/Region.h>
+
+class PCI::MMIOAccess final : public PCI::Access {
+public:
+    static void initialize(ACPI_RAW::MCFG&);
+    virtual void enumerate_all(Function<void(Address, ID)>&) override final;
+
+    virtual String get_access_type() override final { return "MMIO-Access"; };
+
+protected:
+    MMIOAccess(ACPI_RAW::MCFG&);
+
+private:
+    virtual u8 read8_field(Address address, u32) override final;
+    virtual u16 read16_field(Address address, u32) override final;
+    virtual u32 read32_field(Address address, u32) override final;
+    virtual void write8_field(Address address, u32, u8) override final;
+    virtual void write16_field(Address address, u32, u16) override final;
+    virtual void write32_field(Address address, u32, u32) override final;
+
+    void map_device(Address address);
+    void mmap(VirtualAddress preferred_vaddr, PhysicalAddress paddr, u32);
+    void mmap_region(Region& region, PhysicalAddress paddr);
+
+    virtual u32 get_segments_count();
+    virtual u8 get_segment_start_bus(u32);
+    virtual u8 get_segment_end_bus(u32);
+
+    ACPI_RAW::MCFG& m_mcfg;
+    HashMap<u16, MMIOSegment*>& m_segments;
+    OwnPtr<Region> m_mmio_segment;
+};
+
+class PCI::MMIOSegment {
+public:
+    MMIOSegment(PhysicalAddress, u8, u8);
+    u8 get_start_bus();
+    u8 get_end_bus();
+    size_t get_size();
+    PhysicalAddress get_paddr();
+
+private:
+    PhysicalAddress m_base_addr;
+    u8 m_start_bus;
+    u8 m_end_bus;
+};

--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -9,6 +9,7 @@ static_assert(sizeof(size_t) == 4);
 void* memcpy(void*, const void*, size_t);
 char* strcpy(char*, const char*);
 char* strncpy(char*, const char*, size_t);
+int strncmp(const char* s1, const char* s2, size_t n);
 int strcmp(char const*, const char*);
 size_t strlen(const char*);
 size_t strnlen(const char*, size_t);

--- a/Userland/lspci.cpp
+++ b/Userland/lspci.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv)
     auto json = JsonValue::from_string(file_contents).as_array();
     json.for_each([db](auto& value) {
         auto dev = value.as_object();
-
+        auto seg = dev.get("seg").to_u32();
         auto bus = dev.get("bus").to_u32();
         auto slot = dev.get("slot").to_u32();
         auto function = dev.get("function").to_u32();
@@ -48,8 +48,8 @@ int main(int argc, char** argv)
         if (class_ptr != "")
             class_name = class_ptr;
 
-        printf("%02x:%02x.%d %s: %s %s (rev %02x)\n",
-            bus, slot, function,
+        printf("%04x:%02x:%02x.%d %s: %s %s (rev %02x)\n",
+            seg, bus, slot, function,
             class_name.characters(), vendor_name.characters(),
             device_name.characters(), revision_id);
     });


### PR DESCRIPTION
This PR intends to add a functionality of PCI Enhanced Configuration Access (required to be supported by PCIe specification), some other useful features to the PCI subsystem (for example, we can determine the size of the MMIO/IO space needed by a device).
The ACPI support is pretty basic - decoding information from static tables. I wrote a basic class for the dynamic interpretation (called `ACPIDynamicParser`), that will be implemented in the future.
In addition, a `DMIDecoder` is being used to determine if PCI is supported (because if BIOS supports it, sure we can too), thus making it slightly faster to determine if the machine supports PCI at all. If that doesn't work, we fallback to probing via IO ports.

Of course, any review is appreciated :)