### PR TITLE
Keyboard shortcuts for more applications!

### DIFF
--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -156,7 +156,7 @@ int main(int argc, char** argv)
             ASSERT_NOT_REACHED();
         }
     }));
-    inspect_menu->add_action(GAction::create("Inspect DOM tree", [&](auto&) {
+    inspect_menu->add_action(GAction::create("Inspect DOM tree", { Mod_None, Key_F12 }, [&](auto&) {
         if (!dom_inspector_window) {
             dom_inspector_window = GWindow::construct();
             dom_inspector_window->set_rect(100, 100, 300, 500);

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -128,7 +128,7 @@ int main(int argc, char** argv)
         directory_view->open_parent_directory();
     });
 
-    auto mkdir_action = GAction::create("New directory...", GraphicsBitmap::load_from_file("/res/icons/16x16/mkdir.png"), [&](const GAction&) {
+    auto mkdir_action = GAction::create("New directory...", { Mod_Ctrl | Mod_Shift, Key_N }, GraphicsBitmap::load_from_file("/res/icons/16x16/mkdir.png"), [&](const GAction&) {
         auto input_box = GInputBox::construct("Enter name:", "New directory", window);
         if (input_box->exec() == GInputBox::ExecOK && !input_box->text_value().is_empty()) {
             auto new_dir_path = canonicalized_path(

--- a/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Applications/HexEditor/HexEditorWidget.cpp
@@ -128,7 +128,7 @@ HexEditorWidget::HexEditorWidget()
     }
 
     m_goto_decimal_offset_action = GAction::create("Go To Offset (Decimal)...", GraphicsBitmap::load_from_file("/res/icons/16x16/go-forward.png"), [this](const GAction&) {
-        auto input_box = GInputBox::construct("Enter offset:", "Go To", this);
+        auto input_box = GInputBox::construct("Enter Decimal offset:", "Go To", this);
         if (input_box->exec() == GInputBox::ExecOK && !input_box->text_value().is_empty()) {
             auto valid = false;
             auto new_offset = input_box->text_value().to_int(valid);
@@ -139,7 +139,7 @@ HexEditorWidget::HexEditorWidget()
     });
 
     m_goto_hex_offset_action = GAction::create("Go To Offset (Hex)...", GraphicsBitmap::load_from_file("/res/icons/16x16/go-forward.png"), [this](const GAction&) {
-        auto input_box = GInputBox::construct("Enter offset:", "Go To", this);
+        auto input_box = GInputBox::construct("Enter Hex offset:", "Go To", this);
         if (input_box->exec() == GInputBox::ExecOK && !input_box->text_value().is_empty()) {
             auto new_offset = strtol(input_box->text_value().characters(), nullptr, 16);
             m_editor->set_position(new_offset);

--- a/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Applications/HexEditor/HexEditorWidget.cpp
@@ -90,7 +90,7 @@ HexEditorWidget::HexEditorWidget()
         m_save_as_action->activate();
     });
 
-    m_save_as_action = GAction::create("Save as...", { Mod_None, Key_F12 }, GraphicsBitmap::load_from_file("/res/icons/16x16/save.png"), [this](const GAction&) {
+    m_save_as_action = GAction::create("Save as...", { Mod_Ctrl | Mod_Shift, Key_S }, GraphicsBitmap::load_from_file("/res/icons/16x16/save.png"), [this](const GAction&) {
         Optional<String> save_path = GFilePicker::get_save_filepath(m_name.is_null() ? "Untitled" : m_name, m_extension.is_null() ? "bin" : m_extension);
         if (!save_path.has_value())
             return;
@@ -127,7 +127,7 @@ HexEditorWidget::HexEditorWidget()
         }));
     }
 
-    m_goto_decimal_offset_action = GAction::create("Go To Offset (Decimal)...", GraphicsBitmap::load_from_file("/res/icons/16x16/go-forward.png"), [this](const GAction&) {
+    m_goto_decimal_offset_action = GAction::create("Go To Offset (Decimal)...", { Mod_Ctrl | Mod_Shift, Key_G }, GraphicsBitmap::load_from_file("/res/icons/16x16/go-forward.png"), [this](const GAction&) {
         auto input_box = GInputBox::construct("Enter Decimal offset:", "Go To", this);
         if (input_box->exec() == GInputBox::ExecOK && !input_box->text_value().is_empty()) {
             auto valid = false;
@@ -138,7 +138,7 @@ HexEditorWidget::HexEditorWidget()
         }
     });
 
-    m_goto_hex_offset_action = GAction::create("Go To Offset (Hex)...", GraphicsBitmap::load_from_file("/res/icons/16x16/go-forward.png"), [this](const GAction&) {
+    m_goto_hex_offset_action = GAction::create("Go To Offset (Hex)...", { Mod_Ctrl, Key_G }, GraphicsBitmap::load_from_file("/res/icons/16x16/go-forward.png"), [this](const GAction&) {
         auto input_box = GInputBox::construct("Enter Hex offset:", "Go To", this);
         if (input_box->exec() == GInputBox::ExecOK && !input_box->text_value().is_empty()) {
             auto new_offset = strtol(input_box->text_value().characters(), nullptr, 16);
@@ -147,7 +147,7 @@ HexEditorWidget::HexEditorWidget()
     });
 
     auto edit_menu = GMenu::construct("Edit");
-    edit_menu->add_action(GAction::create("Fill selection...", [&](const GAction&) {
+    edit_menu->add_action(GAction::create("Fill selection...", { Mod_Ctrl, Key_B }, [&](const GAction&) {
         auto input_box = GInputBox::construct("Fill byte (hex):", "Fill Selection", this);
         if (input_box->exec() == GInputBox::ExecOK && !input_box->text_value().is_empty()) {
             auto fill_byte = strtol(input_box->text_value().characters(), nullptr, 16);
@@ -158,14 +158,14 @@ HexEditorWidget::HexEditorWidget()
     edit_menu->add_action(*m_goto_decimal_offset_action);
     edit_menu->add_action(*m_goto_hex_offset_action);
     edit_menu->add_separator();
-    edit_menu->add_action(GAction::create("Copy Hex", [&](const GAction&) {
+    edit_menu->add_action(GAction::create("Copy Hex", { Mod_Ctrl, Key_C }, [&](const GAction&) {
         m_editor->copy_selected_hex_to_clipboard();
     }));
-    edit_menu->add_action(GAction::create("Copy Text", [&](const GAction&) {
+    edit_menu->add_action(GAction::create("Copy Text", { Mod_Ctrl | Mod_Shift, Key_C }, [&](const GAction&) {
         m_editor->copy_selected_text_to_clipboard();
     }));
     edit_menu->add_separator();
-    edit_menu->add_action(GAction::create("Copy As C Code", [&](const GAction&) {
+    edit_menu->add_action(GAction::create("Copy As C Code", { Mod_Alt | Mod_Shift, Key_C }, [&](const GAction&) {
         m_editor->copy_selected_hex_to_clipboard_as_c_code();
     }));
     menubar->add_menu(move(edit_menu));

--- a/Applications/IRCClient/IRCAppWindow.cpp
+++ b/Applications/IRCClient/IRCAppWindow.cpp
@@ -82,13 +82,13 @@ void IRCAppWindow::setup_client()
 
 void IRCAppWindow::setup_actions()
 {
-    m_join_action = GAction::create("Join channel", GraphicsBitmap::load_from_file("/res/icons/16x16/irc-join.png"), [&](auto&) {
+    m_join_action = GAction::create("Join channel", { Mod_Ctrl, Key_J }, GraphicsBitmap::load_from_file("/res/icons/16x16/irc-join.png"), [&](auto&) {
         auto input_box = GInputBox::construct("Enter channel name:", "Join channel", this);
         if (input_box->exec() == GInputBox::ExecOK && !input_box->text_value().is_empty())
             m_client.handle_join_action(input_box->text_value());
     });
 
-    m_part_action = GAction::create("Part from channel", GraphicsBitmap::load_from_file("/res/icons/16x16/irc-part.png"), [this](auto&) {
+    m_part_action = GAction::create("Part from channel", { Mod_Ctrl, Key_P }, GraphicsBitmap::load_from_file("/res/icons/16x16/irc-part.png"), [this](auto&) {
         auto* window = m_client.current_window();
         if (!window || window->type() != IRCWindow::Type::Channel) {
             // FIXME: Perhaps this action should have been disabled instead of allowing us to activate it.
@@ -103,13 +103,13 @@ void IRCAppWindow::setup_actions()
             m_client.handle_whois_action(input_box->text_value());
     });
 
-    m_open_query_action = GAction::create("Open query", GraphicsBitmap::load_from_file("/res/icons/16x16/irc-open-query.png"), [&](auto&) {
+    m_open_query_action = GAction::create("Open query", { Mod_Ctrl, Key_O }, GraphicsBitmap::load_from_file("/res/icons/16x16/irc-open-query.png"), [&](auto&) {
         auto input_box = GInputBox::construct("Enter nickname:", "Open IRC query with...", this);
         if (input_box->exec() == GInputBox::ExecOK && !input_box->text_value().is_empty())
             m_client.handle_open_query_action(input_box->text_value());
     });
 
-    m_close_query_action = GAction::create("Close query", GraphicsBitmap::load_from_file("/res/icons/16x16/irc-close-query.png"), [](auto&) {
+    m_close_query_action = GAction::create("Close query", { Mod_Ctrl, Key_D }, GraphicsBitmap::load_from_file("/res/icons/16x16/irc-close-query.png"), [](auto&) {
         printf("FIXME: Implement close-query action\n");
     });
 

--- a/Applications/SoundPlayer/main.cpp
+++ b/Applications/SoundPlayer/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char** argv)
         player->manager().play();
     }
 
-    auto hide_scope = GAction::create("Hide scope", [&](GAction& action) {
+    auto hide_scope = GAction::create("Hide scope", { Mod_Ctrl, Key_H }, [&](GAction& action) {
         action.set_checked(!action.is_checked());
         player->hide_scope(action.is_checked());
     });

--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -87,19 +87,19 @@ int main(int argc, char** argv)
             memory_stats_widget->refresh();
     });
 
-    auto kill_action = GAction::create("Kill process", GraphicsBitmap::load_from_file("/res/icons/kill16.png"), [process_table_view](const GAction&) {
+    auto kill_action = GAction::create("Kill process", { Mod_Ctrl, Key_K }, GraphicsBitmap::load_from_file("/res/icons/kill16.png"), [process_table_view](const GAction&) {
         pid_t pid = process_table_view->selected_pid();
         if (pid != -1)
             kill(pid, SIGKILL);
     });
 
-    auto stop_action = GAction::create("Stop process", GraphicsBitmap::load_from_file("/res/icons/stop16.png"), [process_table_view](const GAction&) {
+    auto stop_action = GAction::create("Stop process", { Mod_Ctrl, Key_S }, GraphicsBitmap::load_from_file("/res/icons/stop16.png"), [process_table_view](const GAction&) {
         pid_t pid = process_table_view->selected_pid();
         if (pid != -1)
             kill(pid, SIGSTOP);
     });
 
-    auto continue_action = GAction::create("Continue process", GraphicsBitmap::load_from_file("/res/icons/continue16.png"), [process_table_view](const GAction&) {
+    auto continue_action = GAction::create("Continue process", { Mod_Ctrl, Key_C }, GraphicsBitmap::load_from_file("/res/icons/continue16.png"), [process_table_view](const GAction&) {
         pid_t pid = process_table_view->selected_pid();
         if (pid != -1)
             kill(pid, SIGCONT);

--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -164,7 +164,7 @@ TextEditorWidget::TextEditorWidget()
         open_sesame(open_path.value());
     });
 
-    m_save_as_action = GAction::create("Save as...", { Mod_None, Key_F12 }, GraphicsBitmap::load_from_file("/res/icons/16x16/save.png"), [this](const GAction&) {
+    m_save_as_action = GAction::create("Save as...", { Mod_Ctrl | Mod_Shift, Key_S }, GraphicsBitmap::load_from_file("/res/icons/16x16/save.png"), [this](const GAction&) {
         Optional<String> save_path = GFilePicker::get_save_filepath(m_name.is_null() ? "Untitled" : m_name, m_extension.is_null() ? "txt" : m_extension);
         if (!save_path.has_value())
             return;


### PR DESCRIPTION
a89b735 - Added this so it's 100% clear which offset you're Going To as both InputBoxes just used to say "Enter offset:" without any context :p
34c004d - Keyboard shortcuts for applications have been altered as specified below:

Changed
-------
**HexEditor**
Save as... - `F12` => `Ctrl` + `Shift` + `S`

**TextEditor**
Save as... - `F12` => `Ctrl` + `Shift` + `S`

Added
-----
**Browser**
~~Reload - `F5`~~ (dropped for now; should be implemented globally in [GAction's make_reload_action()](https://github.com/SerenityOS/serenity/blob/571c4d3fb81a64199f94412c078f7dbe6c992236/Libraries/LibGUI/GAction.cpp#L79) down the road!)
Inspect DOM tree - `F12`

**FileManager**
New directory... - `Ctrl` + `Shift` + `N` (reserving `Ctrl` + `N` for New window later on)

**HexEditor**
Fill selection... - `Ctrl` + `B` (reserving `Ctrl` + `F` for Find shortcuts later on)
Go To Offset (Decimal)... - `Ctrl` + `Shift` + `G`
Go To Offset (Hex)... - `Ctrl` + `G`
Copy Hex - `Ctrl` + `C`
Copy Text - `Ctrl` + `Shift` + `C`
Copy As C Code - `Alt` + `Shift` + `C`

**IRCClient**
Join channel - `Ctrl` + `J`
Part from channel - `Ctrl` + `P`
Open query - `Ctrl` + `O`
Close query - `Ctrl` + `D`  (usable when the logic is implemented :p)

**SoundPlayer**
Hide scope - `Ctrl` + `H` (toggle)

**SystemMonitor**
Kill process - `Ctrl` + `K`
Stop process - `Ctrl` + `S`
Continue process - `Ctrl` + `C`

And as always, feedback is very much welcome :)