### PR TITLE
Kernel: Support ICMP echo without SOCK_RAW

### DIFF
--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -69,6 +69,7 @@ OBJS = \
     Net/RTL8139NetworkAdapter.o \
     Net/Routing.o \
     Net/Socket.o \
+    Net/ICMPSocket.o \
     Net/TCPSocket.o \
     Net/UDPSocket.o \
     PCI.o \

--- a/Kernel/Net/ICMPSocket.cpp
+++ b/Kernel/Net/ICMPSocket.cpp
@@ -1,0 +1,73 @@
+#include <Kernel/Net/ICMPSocket.h>
+#include <Kernel/Net/Routing.h>
+
+ICMPSocket::ICMPSocket()
+    : IPv4Socket(SOCK_DGRAM, IPPROTO_ICMP)
+{
+}
+
+ICMPSocket::~ICMPSocket()
+{
+}
+
+NonnullRefPtr<ICMPSocket> ICMPSocket::create()
+{
+    return adopt(*new ICMPSocket());
+}
+
+int ICMPSocket::protocol_receive(const KBuffer& packet_buffer, void* buffer, size_t buffer_size, int flags)
+{
+    (void)flags;
+    auto& ipv4_packet = *(const IPv4Packet*)(packet_buffer.data());
+    auto v4 = ByteBuffer::wrap(ipv4_packet.payload(), ipv4_packet.payload_size());
+
+    size_t to_copy = min(buffer_size, (size_t)ipv4_packet.payload_size());
+    memcpy(buffer, ipv4_packet.payload(), to_copy);
+    return ipv4_packet.payload_size();
+}
+
+int ICMPSocket::protocol_send(const void* data, int data_length)
+{
+    if ((size_t)data_length < sizeof(ICMPHeader)) {
+        // We must have at least the header to consider this a valid send
+        return -EINVAL;
+    }
+
+    auto& header = *static_cast<const ICMPHeader*>(data);
+
+    if (header.type() != ICMPType::EchoRequest || header.code() != 0) {
+        return -EINVAL;
+    }
+
+    // We have to copy the request here because the data is const
+    ByteBuffer buffer = ByteBuffer::create_zeroed(data_length);
+    memcpy(buffer.data(), data, data_length);
+    auto& icmp_request = *(ICMPEchoPacket*)buffer.data();
+    // Clear out the checksum before we calculate it
+    icmp_request.header.set_checksum(0);
+    icmp_request.header.set_checksum(internet_checksum(buffer.data(), buffer.size()));
+
+    auto routing_decision = route_to(peer_address(), local_address());
+    if (routing_decision.is_zero())
+        return -EHOSTUNREACH;
+
+    routing_decision.adapter->send_ipv4(routing_decision.next_hop, peer_address(), IPv4Protocol::ICMP, (const u8*)buffer.data(), buffer.size(), ttl());
+    return data_length;
+}
+
+KResult ICMPSocket::protocol_connect(FileDescription&, ShouldBlock)
+{
+    // connect isn't supported for ICMP sockets
+    return KResult(-EINVAL);
+}
+
+int ICMPSocket::protocol_allocate_local_port()
+{
+    return 0;
+}
+
+KResult ICMPSocket::protocol_bind()
+{
+    // There aren't any ports here to worry about...
+    return KSuccess;
+}

--- a/Kernel/Net/ICMPSocket.h
+++ b/Kernel/Net/ICMPSocket.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Kernel/Net/IPv4Socket.h>
+
+class ICMPSocket final : public IPv4Socket {
+public:
+    static NonnullRefPtr<ICMPSocket> create();
+    virtual ~ICMPSocket() override;
+
+private:
+    explicit ICMPSocket();
+    virtual const char* class_name() const override { return "ICMPSocket"; }
+
+    virtual int protocol_receive(const KBuffer&, void* buffer, size_t buffer_size, int flags) override;
+    virtual int protocol_send(const void*, int) override;
+    virtual KResult protocol_connect(FileDescription&, ShouldBlock) override;
+    virtual int protocol_allocate_local_port() override;
+    virtual KResult protocol_bind() override;
+};

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -2,6 +2,7 @@
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/Net/ARP.h>
 #include <Kernel/Net/ICMP.h>
+#include <Kernel/Net/ICMPSocket.h>
 #include <Kernel/Net/IPv4.h>
 #include <Kernel/Net/IPv4Socket.h>
 #include <Kernel/Net/NetworkAdapter.h>
@@ -29,6 +30,8 @@ NonnullRefPtr<IPv4Socket> IPv4Socket::create(int type, int protocol)
 {
     if (type == SOCK_STREAM)
         return TCPSocket::create(protocol);
+    if (type == SOCK_DGRAM && protocol == IPPROTO_ICMP)
+        return ICMPSocket::create();
     if (type == SOCK_DGRAM)
         return UDPSocket::create(protocol);
     return adopt(*new IPv4Socket(type, protocol));

--- a/Kernel/build-root-filesystem.sh
+++ b/Kernel/build-root-filesystem.sh
@@ -82,7 +82,6 @@ else
 find ../Userland/ -type f -perm +111 -exec cp {} mnt/bin/ \;
 fi
 chmod 4755 mnt/bin/su
-chmod 4755 mnt/bin/ping
 echo "done"
 
 printf "installing applications... "


### PR DESCRIPTION
Recent hardening has forced `ping` to have the `setuid` bit set. Modern Linux kernels have a feature whereby non-supers can do ICMP echo requests through a `SOCK_DGRAM` socket of protocol `IPPROTO_ICMP`. This socket acts largely the same as a `SOCK_RAW`, but only permits sending ICMP echo requests. The only difference, and added benefit, is that clients don't have to implement the checksum themselves.

This PR adds support for such sockets through `ICMPSocket`, and updates `ping` to use them and not have the `setuid` bet set. Please accept my apologies in advance - my C++ and low level programming are both _very_ rusty.