### PR TITLE
WindowServer: Implement switching windows in reverse order

### DIFF
--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -1065,7 +1065,8 @@ void WSWindowManager::event(CEvent& event)
             return;
         }
 
-        if (key_event.type() == WSEvent::KeyDown && key_event.modifiers() == Mod_Logo && key_event.key() == Key_Tab)
+        if (key_event.type() == WSEvent::KeyDown && ((key_event.modifiers() == Mod_Logo && key_event.key() == Key_Tab) ||
+            (key_event.modifiers() == (Mod_Logo | Mod_Shift) && key_event.key() == Key_Tab)))
             m_switcher.show();
         if (m_switcher.is_visible()) {
             m_switcher.on_key_event(key_event);

--- a/Servers/WindowServer/WSWindowSwitcher.cpp
+++ b/Servers/WindowServer/WSWindowSwitcher.cpp
@@ -56,13 +56,23 @@ void WSWindowSwitcher::on_key_event(const WSKeyEvent& event)
         }
         return;
     }
+
+    if (event.key() == Key_LeftShift || event.key() == Key_RightShift)
+        return;
     if (event.key() != Key_Tab) {
         WSWindowManager::the().set_highlight_window(nullptr);
         hide();
         return;
     }
     ASSERT(!m_windows.is_empty());
-    m_selected_index = (m_selected_index + 1) % m_windows.size();
+
+    if (!event.shift()) {
+        m_selected_index = (m_selected_index + 1) % m_windows.size();
+    } else {
+        m_selected_index = (m_selected_index - 1) % m_windows.size();
+        if (m_selected_index < 0)
+            m_selected_index = m_windows.size() - 1;
+    }
     ASSERT(m_selected_index < m_windows.size());
     auto* highlight_window = m_windows.at(m_selected_index).ptr();
     ASSERT(highlight_window);


### PR DESCRIPTION
Does exactly as the title states; now you can also switch between running windows in reverse using `Logo` + `Shift` + `Tab` :)

Currently only one thing I didn't achieve: switching between the two most recently used windows (like in `Logo` + `Tab`) doesn't work when just pressing the keys over and over again continually while also letting the switcher close each time.

Feedback, as always, is much welcomed!