### PR TITLE
WindowServer: Windows tile when moved onto the edge of the screen

### DIFF
--- a/Servers/WindowServer/WSWindow.cpp
+++ b/Servers/WindowServer/WSWindow.cpp
@@ -340,3 +340,33 @@ void WSWindow::set_fullscreen(bool fullscreen)
     CEventLoop::current().post_event(*this, make<WSResizeEvent>(m_rect, new_window_rect));
     set_rect(new_window_rect);
 }
+
+void WSWindow::set_tiled(WindowTileType tiled)
+{
+    if (m_tiled == tiled)
+        return;
+    m_tiled = tiled;
+    auto old_rect = m_rect;
+
+    auto frame_width = m_frame.rect().width() - m_rect.width();
+    switch (tiled) {
+        case WindowTileType::None :
+        set_rect(m_untiled_rect);
+        break;
+    case WindowTileType::Left :
+        m_untiled_rect = m_rect;
+        set_rect(0,
+                WSWindowManager::the().maximized_window_rect(*this).y(),
+                WSScreen::the().width() / 2,
+                WSWindowManager::the().maximized_window_rect(*this).height());
+        break;
+    case WindowTileType::Right :
+        m_untiled_rect = m_rect;
+        set_rect(WSScreen::the().width() / 2 + frame_width,
+                WSWindowManager::the().maximized_window_rect(*this).y(),
+                (WSScreen::the().width() / 2),
+                WSWindowManager::the().maximized_window_rect(*this).height());
+        break;
+    }
+    CEventLoop::current().post_event(*this, make<WSResizeEvent>(old_rect, m_rect));
+}

--- a/Servers/WindowServer/WSWindow.h
+++ b/Servers/WindowServer/WSWindow.h
@@ -21,6 +21,12 @@ enum WSWMEventMask {
     WindowRemovals = 1 << 3,
 };
 
+enum class WindowTileType {
+    None = 0,
+    Left,
+    Right,
+};
+
 class WSWindow final : public CObject
     , public InlineLinkedListNode<WSWindow> {
     C_OBJECT(WSWindow)
@@ -43,6 +49,9 @@ public:
 
     bool is_fullscreen() const { return m_fullscreen; }
     void set_fullscreen(bool);
+
+    WindowTileType tiled() const { return m_tiled; }
+    void set_tiled(WindowTileType);
 
     bool is_occluded() const { return m_occluded; }
     void set_occluded(bool);
@@ -194,6 +203,8 @@ private:
     bool m_minimized { false };
     bool m_maximized { false };
     bool m_fullscreen { false };
+    WindowTileType m_tiled { WindowTileType::None };
+    Rect m_untiled_rect;
     bool m_occluded { false };
     bool m_show_titlebar { true };
     RefPtr<GraphicsBitmap> m_backing_store;


### PR DESCRIPTION
Drag a window onto the left or right edge and it'll fill up that half of the screen, drag it back and it'll return to its original size. I like having windows side by side like this when I'm working on something, so i thought I'd implement it in serenity.

![image](https://user-images.githubusercontent.com/52710130/71644264-7749fc80-2cbd-11ea-9bf2-a3df30d7aa82.png)
