### PR TITLE
Toolchain: Use crtbeginS and crtendS for shared objects

### DIFF
--- a/Demos/DynamicLink/LinkLib/DynamicLib.cpp
+++ b/Demos/DynamicLink/LinkLib/DynamicLib.cpp
@@ -3,14 +3,10 @@
 #include <assert.h>
 #include <stdio.h>
 
-// FIXME: See Makefile. We need -ffreestanding and -nostartfiles to
-//     Get GCC to stop linking crt0.o w/our .so.
-//     So, we need __dso_handle. ... Yikes
-extern void* __dso_handle __attribute__((__section__(".sdata")));
-extern void* __dso_handle __attribute__((__visibility__("hidden")));
-void* __dso_handle = (void*)1234; // FIXME: Is the dynamic linker supposed to set this value?
 
 // FIXME: Things defined in crt0 >:(
+//     We need to figure out a better way to get these symbols defined and available
+//     Even if we're linking a shared object.
 __thread int errno;
 char* __static_environ[] = { nullptr }; // We don't get the environment without some libc workarounds..
 char** environ = __static_environ;

--- a/Demos/DynamicLink/LinkLib/Makefile
+++ b/Demos/DynamicLink/LinkLib/Makefile
@@ -11,8 +11,5 @@ all: $(DYNLIBRARY)
 DynamicLib.o: DynamicLib.cpp
 	$(CXX) -DDEBUG -fPIC -isystem../../../ -o $@ -c $<
 
-# FIXME: Why do I need -nostartfiles and -nofreestanding?
-#     GCC isn't smart enough to not link crt0 against this dynamic lib
-#     which is clearly wrong. Isn't it? We don't want _start...
 $(DYNLIBRARY): DynamicLib.o
-	$(CXX) -shared -nostartfiles -ffreestanding -o $(DYNLIBRARY) $<
+	$(CXX) -shared -o $(DYNLIBRARY) $<

--- a/Libraries/LibELF/ELFDynamicObject.cpp
+++ b/Libraries/LibELF/ELFDynamicObject.cpp
@@ -290,14 +290,8 @@ bool ELFDynamicObject::load(unsigned flags)
 #ifdef DYNAMIC_LOAD_DEBUG
     dbgprintf("Calling DT_INIT at %p\n", init_function);
 #endif
-    // FIXME:
-    // Disassembly of section .init:
-    //
-    //  00007e98 <_init>:
-    //        7e98:       55                      push   ebp
-    //
-    // Where da ret at? related to -nostartfiles for sure...
-    //(init_function)();
+
+    (init_function)();
 
     InitFunc* init_begin = (InitFunc*)(load_addr + m_init_array_offset);
     u32 init_end = (u32)((u8*)init_begin + m_init_array_size);

--- a/Ports/gcc/patches/gcc.patch
+++ b/Ports/gcc/patches/gcc.patch
@@ -7,7 +7,7 @@ index 75bb6a313..da281fb48 100755
  #   Copyright 1992-2019 Free Software Foundation, Inc.
  
 -timestamp='2019-01-01'
-+timestamp='2019-12-17'
++timestamp='2020-01-01
  
  # This file is free software; you can redistribute it and/or modify it
  # under the terms of the GNU General Public License as published by
@@ -153,11 +153,11 @@ index 000000000..925c88dd6
 +/* Files that are linked before user code.
 +   The %s tells GCC to look for these files in the library directory. */
 +#undef STARTFILE_SPEC
-+#define STARTFILE_SPEC "crt0.o%s crti.o%s crtbegin.o%s"
++#define STARTFILE_SPEC "%{!shared:crt0.o%s} crti.o%s %{shared:crtbeginS.o%s; :crtbegin.o%s}"
 + 
 +/* Files that are linked after user code. */
 +#undef ENDFILE_SPEC
-+#define ENDFILE_SPEC "crtend.o%s crtn.o%s"
++#define ENDFILE_SPEC "%{shared:crtendS.o%s; :crtend.o%s} crtn.o%s"
 +
 +#undef LINK_SPEC
 +#define LINK_SPEC "%{shared:-shared} %{static:-static} %{!shared: %{!static: %{rdynamic:-export-dynamic}}}"
@@ -181,11 +181,11 @@ index 91abc84da..659376d14 100644
  	extra_parts="crt0.o"
  	;;
 +i[34567]86-*-serenity*)
-+	extra_parts="$extra_parts crti.o crtbegin.o crtend.o crtn.o"
++	extra_parts="$extra_parts crti.o crtbegin.o crtbeginS.o crtend.o crtendS.o crtn.o"
 +	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
 +	;;
 +x86_64-*-serenity*)
-+	extra_parts="$extra_parts crti.o crtbegin.o crtend.o crtn.o"
++	extra_parts="$extra_parts crti.o crtbegin.o crtbeginS.o crtend.o crtendS.o crtn.o"
 +	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
 +	;;
 +arm-*-serenity*)

--- a/Toolchain/Patches/gcc.patch
+++ b/Toolchain/Patches/gcc.patch
@@ -7,7 +7,7 @@ index 75bb6a313..da281fb48 100755
  #   Copyright 1992-2019 Free Software Foundation, Inc.
  
 -timestamp='2019-01-01'
-+timestamp='2019-12-17'
++timestamp='2020-01-01'
  
  # This file is free software; you can redistribute it and/or modify it
  # under the terms of the GNU General Public License as published by
@@ -153,11 +153,11 @@ index 000000000..925c88dd6
 +/* Files that are linked before user code.
 +   The %s tells GCC to look for these files in the library directory. */
 +#undef STARTFILE_SPEC
-+#define STARTFILE_SPEC "crt0.o%s crti.o%s crtbegin.o%s"
++#define STARTFILE_SPEC "%{!shared:crt0.o%s} crti.o%s %{shared:crtbeginS.o%s; :crtbegin.o%s}"
 + 
 +/* Files that are linked after user code. */
 +#undef ENDFILE_SPEC
-+#define ENDFILE_SPEC "crtend.o%s crtn.o%s"
++#define ENDFILE_SPEC "%{shared:crtendS.o%s; :crtend.o%s} crtn.o%s"
 +
 +#undef LINK_SPEC
 +#define LINK_SPEC "%{shared:-shared} %{static:-static} %{!shared: %{!static: %{rdynamic:-export-dynamic}}}"
@@ -181,11 +181,11 @@ index 91abc84da..659376d14 100644
  	extra_parts="crt0.o"
  	;;
 +i[34567]86-*-serenity*)
-+	extra_parts="$extra_parts crti.o crtbegin.o crtend.o crtn.o"
++	extra_parts="$extra_parts crti.o crtbegin.o crtbeginS.o crtend.o crtendS.o crtn.o"
 +	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
 +	;;
 +x86_64-*-serenity*)
-+	extra_parts="$extra_parts crti.o crtbegin.o crtend.o crtn.o"
++	extra_parts="$extra_parts crti.o crtbegin.o crtbeginS.o crtend.o crtendS.o crtn.o"
 +	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
 +	;;
 +arm-*-serenity*)


### PR DESCRIPTION
Turns out the reason GCC wasn't as smart about startup code for
shared objects as we hoped is because nobody told it to be :D

Change the STARTFILE_SPEC and ENDFILE_SPEC in gcc/config/serenity.h to
skip crt0.o and to link the S variants of crtbegin
and crtend for shared objects.

Because we're using the crtbegin and crtend from libgcc, also tell
libgcc in libgcc/config.host to compile crtbeginS and crtendS from
crtstuff.c.

This patch also includes fixes to Demos/LinkLib and LibELF/ELFDynamicObject
to take advantage of the proper shared object start files. crt0.o is still not linked to
shared objects though, so we still need to move some of the definitions that aren't directly related to CRT startup out of there (looking at you, errno :) ) 