### PR TITLE
LibELF: Re-organize ELFDynamicObject::load and add PLT trampoline

### DIFF
--- a/Libraries/LibC/Makefile
+++ b/Libraries/LibC/Makefile
@@ -62,7 +62,11 @@ ELF_OBJS = \
 
 OBJS = $(AK_OBJS) $(LIBC_OBJS) $(ELF_OBJS)
 
-EXTRA_OBJS = setjmp.ao crti.ao crtn.ao
+EXTRA_OBJS = \
+        setjmp.ao \
+        crti.ao \
+        crtn.ao  \
+        ../LibELF/Arch/i386/plt_trampoline.ao
 
 crt0.o: crt0.cpp
 

--- a/Libraries/LibELF/Arch/i386/plt_trampoline.S
+++ b/Libraries/LibELF/Arch/i386/plt_trampoline.S
@@ -1,0 +1,58 @@
+/*-
+ * Copyright (c) 1998, 2002 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Christos Zoulas and by Charles M. Hannum.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This asm method is copied from NetBSD. We changed the internal method that
+ * gets called and the name, but it's still essentially the same as
+ * _rtld_bind_start from libexec/ld.elf_so/arch/i386/rtld_start.S
+ */
+
+.align	4
+	.globl	_plt_trampoline
+	.hidden	_plt_trampoline
+	.type	_plt_trampoline,@function
+_plt_trampoline:	# (obj, reloff)
+	pushf				# save registers
+	pushl	%eax
+	pushl	%ecx
+	pushl	%edx
+
+	pushl	20(%esp)		 # Copy of reloff
+	pushl	20(%esp)		 # Copy of obj
+	call	_fixup_plt_entry # Call the binder
+	addl	$8,%esp			 # pop binder args
+	movl	%eax,20(%esp)	 # Store function to be called in obj
+
+	popl	%edx
+	popl	%ecx
+	popl	%eax
+	popf
+
+	leal	4(%esp),%esp		# Discard reloff, do not change eflags
+	ret

--- a/Libraries/LibELF/ELFDynamicObject.h
+++ b/Libraries/LibELF/ELFDynamicObject.h
@@ -28,6 +28,9 @@ public:
 
     void dump();
 
+    // Will be called from _fixup_plt_entry, as part of the PLT trampoline
+    Elf32_Addr patch_plt_entry(u32 relocation_offset);
+
 private:
     class ProgramHeaderRegion {
     public:
@@ -68,6 +71,12 @@ private:
 
     explicit ELFDynamicObject(const char* filename, int fd, size_t file_size);
 
+    void parse_dynamic_section();
+    void load_program_headers();
+    void do_relocations();
+    void setup_plt_trampoline();
+    void call_object_init_functions();
+
     String m_filename;
     size_t m_file_size { 0 };
     int m_image_fd { -1 };
@@ -75,11 +84,6 @@ private:
     bool m_valid { false };
 
     OwnPtr<ELFImage> m_image;
-
-    void parse_dynamic_section();
-    void do_relocations();
-
-    static void patch_plt_entry(u32 got_offset, void* dso_got_tag);
 
     Vector<ProgramHeaderRegion> m_program_header_regions;
     ProgramHeaderRegion* m_text_region { nullptr };


### PR DESCRIPTION
ELFDynamicObject::load looks a lot better with all the steps
re-organized into helpers.

Splits out load_program_headers and call_object_init_functions into
their own helpers for better code organization.

Add plt_trampoline.S to handle PLT fixups for lazy loading.
Add the needed trampoline-trampolines in ELFDynamicObject to get to
the proper relocations and to return the symbol back to the assembly
method to call into from the PLT once we return back to user code.

Finally, the PLT code won't work unless we build/link it into LibC :)