### PR TITLE
About: Add changelogs, and display the most recent

### DIFF
--- a/Applications/About/Makefile
+++ b/Applications/About/Makefile
@@ -3,7 +3,7 @@ OBJS = \
 
 PROGRAM = About
 
-LIB_DEPS = GUI Draw IPC Core
+LIB_DEPS = GUI HTML Draw Markdown IPC Protocol Core
 
 DEFINES += -DGIT_COMMIT=\"`git rev-parse --short HEAD`\" -DGIT_BRANCH=\"`git rev-parse --abbrev-ref HEAD`\" -DGIT_CHANGES=\"`git diff-index --quiet HEAD -- && echo "tracked"|| echo "untracked"`\"
 

--- a/Applications/About/main.cpp
+++ b/Applications/About/main.cpp
@@ -1,9 +1,18 @@
+#include <AK/FileSystemPath.h>
+#include <LibCore/CDirIterator.h>
+#include <LibCore/CFile.h>
+#include <LibCore/CIODevice.h>
 #include <LibGUI/GApplication.h>
 #include <LibGUI/GBoxLayout.h>
 #include <LibGUI/GButton.h>
 #include <LibGUI/GDesktop.h>
 #include <LibGUI/GLabel.h>
+#include <LibGUI/GMessageBox.h>
+#include <LibGUI/GSplitter.h>
 #include <LibGUI/GWindow.h>
+#include <LibHTML/HtmlView.h>
+#include <LibHTML/Parser/HTMLParser.h>
+#include <LibMarkdown/MDDocument.h>
 #include <sys/utsname.h>
 
 int main(int argc, char** argv)
@@ -12,17 +21,19 @@ int main(int argc, char** argv)
 
     auto window = GWindow::construct();
     window->set_title("About SerenityOS");
-    Rect window_rect { 0, 0, 240, 180 };
+    Rect window_rect { 0, 0, 570, 500 };
     window_rect.center_within(GDesktop::the().rect());
-    window->set_resizable(false);
     window->set_rect(window_rect);
 
     auto widget = GWidget::construct();
-    window->set_main_widget(widget);
     widget->set_fill_with_background_color(true);
     widget->set_layout(make<GBoxLayout>(Orientation::Vertical));
     widget->layout()->set_margins({ 0, 8, 0, 8 });
     widget->layout()->set_spacing(8);
+
+    auto splitter = GSplitter::construct(Orientation::Horizontal, widget);
+    auto html_view = HtmlView::construct(splitter);
+    html_view->set_scrollbars_enabled(true);
 
     auto icon_label = GLabel::construct(widget);
     icon_label->set_icon(GraphicsBitmap::load_from_file("/res/icons/serenity.png"));
@@ -62,6 +73,50 @@ int main(int argc, char** argv)
         GApplication::the().quit(0);
     };
 
+    auto open_changelog = [&](const String& path) {
+        if (path.is_null()) {
+            html_view->set_document(nullptr);
+            return;
+        }
+
+        dbg() << "Opening changelog at " << path;
+        auto file = CFile::construct();
+        file->set_filename(path);
+
+        if (!file->open(CIODevice::OpenMode::ReadOnly)) {
+            int saved_errno = errno;
+            GMessageBox::show(strerror(saved_errno), "Failed to open changelog", GMessageBox::Type::Error, GMessageBox::InputType::OK, window);
+            return;
+        }
+        auto buffer = file->read_all();
+        StringView source { (const char*)buffer.data(), (size_t)buffer.size() };
+
+        MDDocument md_document;
+        bool success = md_document.parse(source);
+        ASSERT(success);
+
+        String html = md_document.render_to_html();
+        auto html_document = parse_html_document(html);
+        html_view->set_document(html_document);
+    };
+
+    auto it = CDirIterator("/res/changelogs/", CDirIterator::Flags::SkipDots);
+    if (it.has_error())
+        ASSERT_NOT_REACHED();
+
+    bool found = false;
+    while (it.has_next()) {
+        auto filename = it.next_path();
+        if (filename.ends_with("current.md")) {
+            auto path = String::format("%s/%s", "/res/changelogs", filename.characters());
+            found = true;
+            open_changelog(path);
+            break;
+        }
+    }
+    ASSERT(found);
+
+    window->set_main_widget(widget);
     window->show();
     return app.exec();
 }

--- a/Base/res/changelogs/01-01-2019_current.md
+++ b/Base/res/changelogs/01-01-2019_current.md
@@ -1,0 +1,20 @@
+# Changelog | 01/01/2019 - current
+
+### Kernel
+* Introduce the ACPI subsystem
+* Add support for PCI ECAM
+* Kernel adress validation
+* Enable x86 UMIP if supported
+* Random offset
+
+### Applications
+* Add this changelog to the about section!
+
+### Base
+* Hungarian and Finnish keymap support
+
+### WindowServer
+* Window tiling
+
+### LibGUI
+* Close and cancel GDialog on `escape` keypress


### PR DESCRIPTION
Add markdown changelog files that lists a number of features and
bugfixes that have been made over a certain time period. The filename
format of a changelog is of the form:

`start-date_end-date.md`

Where each date being: `dd-mm-yyyy`

However, the end-date is labelled `current` in the case that the
changelog is the most recent.

This might not have the structure of a changelog that we would want,
but at least it is a start. The idea is that changelogs can be used
in the monthly Serenity update videos :^)

About by default will start up with the `current` changelog displayed.
In the future support, can be added for displaying changelogs from
previous months.