### PR TITLE
LibELF: Simplify R_386_32 relocations to ignore symbol bind value 

### DIFF
--- a/Demos/DynamicLink/LinkLib/Makefile
+++ b/Demos/DynamicLink/LinkLib/Makefile
@@ -4,12 +4,12 @@ DYNLIBRARY = libDynamicLib.so
 
 EXTRA_CLEAN = *.o *.so
 
-.PHONY: clean all
-
 all: $(DYNLIBRARY)
 
 DynamicLib.o: DynamicLib.cpp
-	$(CXX) -DDEBUG -fPIC -isystem../../../ -o $@ -c $<
+	@echo "$(notdir $(CURDIR)): C++ $@"
+	$(QUIET) $(CXX) -DDEBUG -fPIC -isystem../../../ -o $@ -c $<
 
 $(DYNLIBRARY): DynamicLib.o
-	$(CXX) -shared -o $(DYNLIBRARY) $<
+	@echo "$(notdir $(CURDIR)): DYLIB $@"
+	$(QUIET) $(CXX) -shared -o $(DYNLIBRARY) $<


### PR DESCRIPTION
For dynamic loading, the symbol bind of a symbol actually doesn't
matter. We could do what old glibc did and try to find a strong
symbol for any weak definitions, but the ELF spec doesn't require
it and they changed that a few years ago anyway. So, moot point. :)

Also clean up the LinkLib Makefile a bit more so that it stands out less when building.
At a later date we'll probably want a template for SHLIB_OBJS and
SHLIB or some such in Makefile.common, but for now at least the library demo isn't
printing compile commands all over the user's terminal.