### PR TITLE
PaintBrush: Select tool button on context menu event

### DIFF
--- a/Applications/PaintBrush/ToolboxWidget.cpp
+++ b/Applications/PaintBrush/ToolboxWidget.cpp
@@ -27,6 +27,7 @@ public:
 
     virtual void context_menu_event(GContextMenuEvent& event) override
     {
+        set_checked(true);
         m_tool->on_contextmenu(event);
     }
 


### PR DESCRIPTION
This means that (for example) if you change the line width of the line
tool, you now switch to the line tool, instead of sticking with the
currently "checked" tool.