### PR TITLE
Kernel: Fixing PCI MMIO access mechanism

### DIFF
--- a/Kernel/PCI/Definitions.h
+++ b/Kernel/PCI/Definitions.h
@@ -51,6 +51,7 @@ struct ID {
 };
 
 struct Address {
+public:
     Address() {}
     Address(u16 seg)
         : m_seg(seg)
@@ -80,11 +81,45 @@ struct Address {
         return 0x80000000u | (m_bus << 16u) | (m_slot << 11u) | (m_function << 8u) | (field & 0xfc);
     }
 
-private:
+protected:
     u32 m_seg { 0 };
     u8 m_bus { 0 };
     u8 m_slot { 0 };
     u8 m_function { 0 };
+};
+
+struct ChangeableAddress : public Address {
+    ChangeableAddress()
+        : Address(0)
+    {
+    }
+    explicit ChangeableAddress(u16 seg)
+        : Address(seg)
+    {
+    }
+    ChangeableAddress(u16 seg, u8 bus, u8 slot, u8 function)
+        : Address(seg, bus, slot, function)
+    {
+    }
+    void set_seg(u16 seg) { m_seg = seg; }
+    void set_bus(u8 bus) { m_bus = bus; }
+    void set_slot(u8 slot) { m_slot = slot; }
+    void set_function(u8 function) { m_function = function; }
+    bool operator==(const Address& address)
+    {
+        if (m_seg == address.seg() && m_bus == address.bus() && m_slot == address.slot() && m_function == address.function())
+            return true;
+        else
+            return false;
+    }
+    const ChangeableAddress& operator=(const Address& address)
+    {
+        set_seg(address.seg());
+        set_bus(address.bus());
+        set_slot(address.slot());
+        set_function(address.function());
+        return *this;
+    }
 };
 
 void enumerate_all(Function<void(Address, ID)> callback);

--- a/Kernel/PCI/MMIOAccess.h
+++ b/Kernel/PCI/MMIOAccess.h
@@ -4,8 +4,10 @@
 #include <AK/Types.h>
 #include <Kernel/ACPI/Definitions.h>
 #include <Kernel/PCI/Access.h>
+#include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/PhysicalRegion.h>
 #include <Kernel/VM/Region.h>
+#include <Kernel/VM/VMObject.h>
 
 class PCI::MMIOAccess final : public PCI::Access {
 public:
@@ -15,7 +17,7 @@ public:
     virtual String get_access_type() override final { return "MMIO-Access"; };
 
 protected:
-    MMIOAccess(ACPI_RAW::MCFG&);
+    explicit MMIOAccess(ACPI_RAW::MCFG&);
 
 private:
     virtual u8 read8_field(Address address, u32) override final;
@@ -35,7 +37,9 @@ private:
 
     ACPI_RAW::MCFG& m_mcfg;
     HashMap<u16, MMIOSegment*>& m_segments;
-    OwnPtr<Region> m_mmio_segment;
+    RefPtr<VMObject> m_mmio_window;
+    OwnPtr<Region> m_mmio_window_region;
+    PCI::ChangeableAddress m_mapped_address;
 };
 
 class PCI::MMIOSegment {

--- a/Kernel/run
+++ b/Kernel/run
@@ -22,6 +22,22 @@ $SERENITY_EXTRA_QEMU_ARGS
 -d cpu_reset,guest_errors 
 -device VGA,vgamem_mb=64
 -hda _disk_image
+-device ich9-ahci
+-debugcon stdio
+-soundhw pcspk
+-soundhw sb16
+"
+
+[ -z "$SERENITY_COMMON_QEMU_Q35_ARGS" ] && SERENITY_COMMON_QEMU_Q35_ARGS="
+$SERENITY_EXTRA_QEMU_ARGS
+-s -m $SERENITY_RAM_SIZE
+-cpu max
+-machine q35
+-d cpu_reset,guest_errors 
+-device VGA,vgamem_mb=64
+-device piix3-ide
+-drive file=_disk_image,id=disk,if=none
+-device ide-hd,bus=ide.6,drive=disk,unit=0
 -debugcon stdio
 -soundhw pcspk
 -soundhw sb16
@@ -57,6 +73,20 @@ elif [ "$1" = "qgrub" ]; then
         $SERENITY_PACKET_LOGGING_ARG \
         -netdev user,id=breh,hostfwd=tcp:127.0.0.1:8888-10.0.2.15:8888,hostfwd=tcp:127.0.0.1:8823-10.0.2.15:23 \
         -device e1000,netdev=breh
+elif [ "$1" = "q35_cmd" ]; then
+    SERENITY_KERNEL_CMDLINE=""
+    # FIXME: Someone who knows sh syntax better, please help:
+    for i in `seq 2 $#`; do
+        shift
+        SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE $1"
+    done
+    echo "Starting SerenityOS, Commandline: ${SERENITY_KERNEL_CMDLINE}"
+    # ./run: qemu with SerenityOS with custom commandline
+    $SERENITY_QEMU_BIN \
+        $SERENITY_COMMON_QEMU_Q35_ARGS \
+        -device e1000 \
+        -kernel kernel \
+        -append "${SERENITY_KERNEL_CMDLINE}"
 elif [ "$1" = "qcmd" ]; then
     SERENITY_KERNEL_CMDLINE=""
     # FIXME: Someone who knows sh syntax better, please help:


### PR DESCRIPTION
Things that I changed in this PR:

- On every access to the PCI MMIO region, we allocate a temporary
region dynamically. Interrupts are disabled during read/write operations.

- We can boot a Q35 machine, to aid testing more modern machines.

- I fixed the preprocessor `ifdef` statements twice as you can see. That's due to my mistake in #971.