### PR TITLE
WindowServer: Make tiled windows actually centered.

### DIFF
--- a/Servers/WindowServer/WSWindow.cpp
+++ b/Servers/WindowServer/WSWindow.cpp
@@ -301,7 +301,7 @@ void WSWindow::set_tiled(WindowTileType tiled)
     m_tiled = tiled;
     auto old_rect = m_rect;
 
-    auto frame_width = m_frame.rect().width() - m_rect.width();
+    int frame_width = (m_frame.rect().width() - m_rect.width()) / 2;
     switch (tiled) {
         case WindowTileType::None :
         set_rect(m_untiled_rect);
@@ -310,14 +310,14 @@ void WSWindow::set_tiled(WindowTileType tiled)
         m_untiled_rect = m_rect;
         set_rect(0,
                 WSWindowManager::the().maximized_window_rect(*this).y(),
-                WSScreen::the().width() / 2,
+                WSScreen::the().width() / 2 - frame_width,
                 WSWindowManager::the().maximized_window_rect(*this).height());
         break;
     case WindowTileType::Right :
         m_untiled_rect = m_rect;
         set_rect(WSScreen::the().width() / 2 + frame_width,
                 WSWindowManager::the().maximized_window_rect(*this).y(),
-                (WSScreen::the().width() / 2),
+                (WSScreen::the().width() / 2) - frame_width,
                 WSWindowManager::the().maximized_window_rect(*this).height());
         break;
     }


### PR DESCRIPTION
The right window had a few pixels on the right cut off, i don't know how
i didn't notice this earlier.