### PR TITLE
gcc port: add missing ' after timestamp

### DIFF
--- a/Ports/gcc/patches/gcc.patch
+++ b/Ports/gcc/patches/gcc.patch
@@ -7,7 +7,7 @@ index 75bb6a313..da281fb48 100755
  #   Copyright 1992-2019 Free Software Foundation, Inc.
  
 -timestamp='2019-01-01'
-+timestamp='2020-01-01
++timestamp='2020-01-02'
  
  # This file is free software; you can redistribute it and/or modify it
  # under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Looks like this got missed, maybe a messy `git add --patch` job? It
caused packaging of the gcc port to fail.