### PR TITLE
WindowServer: Support menu navigation through key presses

### DIFF
--- a/Servers/WindowServer/WSMenu.h
+++ b/Servers/WindowServer/WSMenu.h
@@ -92,6 +92,10 @@ private:
 
     int padding_between_text_and_shortcut() const { return 50; }
     void did_activate(WSMenuItem&);
+    void open_hovered_item();
+    void redraw_for_new_hovered_item();
+    void decend_into_submenu_at_hovered_item();
+
     WSClientConnection* m_client { nullptr };
     int m_menu_id { 0 };
     String m_name;
@@ -101,7 +105,11 @@ private:
     WSMenuItem* m_hovered_item { nullptr };
     NonnullOwnPtrVector<WSMenuItem> m_items;
     RefPtr<WSWindow> m_menu_window;
+
     WeakPtr<WSWindow> m_window_menu_of;
     bool m_is_window_menu_open = { false };
+
     int m_theme_index_at_last_paint { -1 };
+    int m_current_index { 0 };
+    bool m_in_submenu { false };
 };

--- a/Servers/WindowServer/WSMenuManager.cpp
+++ b/Servers/WindowServer/WSMenuManager.cpp
@@ -315,6 +315,7 @@ void WSMenuManager::close_everyone()
     for (auto& menu : m_open_menu_stack) {
         if (menu && menu->menu_window())
             menu->menu_window()->set_visible(false);
+        menu->clear_hovered_item();
     }
     m_open_menu_stack.clear();
     m_current_menu = nullptr;
@@ -341,6 +342,7 @@ void WSMenuManager::close_menus(const Vector<WSMenu*>& menus)
             m_current_menu = nullptr;
         if (menu->menu_window())
             menu->menu_window()->set_visible(false);
+        menu->clear_hovered_item();
         m_open_menu_stack.remove_first_matching([&](auto& entry) {
             return entry == menu;
         });

--- a/Servers/WindowServer/WSMenuManager.h
+++ b/Servers/WindowServer/WSMenuManager.h
@@ -30,6 +30,7 @@ public:
 
     WSMenu* current_menu() { return m_current_menu.ptr(); }
     void set_current_menu(WSMenu*, bool is_submenu = false);
+    void open_menu(WSMenu&);
 
     WSMenuBar* current_menubar() { return m_current_menubar.ptr(); }
     void set_current_menubar(WSMenuBar*);
@@ -47,14 +48,14 @@ public:
     void invalidate_applet(const WSWindow&, const Rect&);
 
     Color menu_selection_color() const { return m_menu_selection_color; }
-    WSMenu* system_menu() { return m_system_menu; }
+    WSMenu& system_menu() { return *m_system_menu; }
     WSMenu* find_internal_menu_by_id(int);
     int theme_index() const { return m_theme_index; }
 
     template<typename Callback>
     void for_each_active_menubar_menu(Callback callback)
     {
-        if (callback(*system_menu()) == IterationDecision::Break)
+        if (callback(system_menu()) == IterationDecision::Break)
             return;
         if (m_current_menubar)
             m_current_menubar->for_each_menu(callback);

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -713,38 +713,41 @@ void WSWindowManager::process_mouse_event(WSMouseEvent& event, WSWindow*& hovere
         ASSERT(topmost_menu);
         auto* window = topmost_menu->menu_window();
         ASSERT(window);
+
         bool event_is_inside_current_menu = window->rect().contains(event.position());
-        if (!event_is_inside_current_menu) {
-            if (topmost_menu->hovered_item())
-                topmost_menu->clear_hovered_item();
-            if (event.type() == WSEvent::MouseDown || event.type() == WSEvent::MouseUp) {
-                auto* window_menu_of = topmost_menu->window_menu_of();
-                if (window_menu_of) {
-                    bool event_is_inside_taskbar_button = window_menu_of->taskbar_rect().contains(event.position());
-                    if (event_is_inside_taskbar_button && !topmost_menu->is_window_menu_open()) {
-                        topmost_menu->set_window_menu_open(true);
-                        return;
-                    }
-                }
-                m_menu_manager.close_bar();
-                topmost_menu->set_window_menu_open(false);
-            }
-            if (event.type() == WSEvent::MouseMove) {
-                for (auto& menu : m_menu_manager.open_menu_stack()) {
-                    if (!menu)
-                        continue;
-                    if (!menu->menu_window()->rect().contains(event.position()))
-                        continue;
-                    hovered_window = menu->menu_window();
-                    auto translated_event = event.translated(-menu->menu_window()->position());
-                    deliver_mouse_event(*menu->menu_window(), translated_event);
-                    break;
-                }
-            }
-        } else {
+        if (event_is_inside_current_menu) {
             hovered_window = window;
             auto translated_event = event.translated(-window->position());
             deliver_mouse_event(*window, translated_event);
+            return;
+        }
+
+        if (topmost_menu->hovered_item())
+            topmost_menu->clear_hovered_item();
+        if (event.type() == WSEvent::MouseDown || event.type() == WSEvent::MouseUp) {
+            auto* window_menu_of = topmost_menu->window_menu_of();
+            if (window_menu_of) {
+                bool event_is_inside_taskbar_button = window_menu_of->taskbar_rect().contains(event.position());
+                if (event_is_inside_taskbar_button && !topmost_menu->is_window_menu_open()) {
+                    topmost_menu->set_window_menu_open(true);
+                    return;
+                }
+            }
+            m_menu_manager.close_bar();
+            topmost_menu->set_window_menu_open(false);
+        }
+
+        if (event.type() == WSEvent::MouseMove) {
+            for (auto& menu : m_menu_manager.open_menu_stack()) {
+                if (!menu)
+                    continue;
+                if (!menu->menu_window()->rect().contains(event.position()))
+                    continue;
+                hovered_window = menu->menu_window();
+                auto translated_event = event.translated(-menu->menu_window()->position());
+                deliver_mouse_event(*menu->menu_window(), translated_event);
+                break;
+            }
         }
         return;
     }

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -733,8 +733,11 @@ void WSWindowManager::process_mouse_event(WSMouseEvent& event, WSWindow*& hovere
                     return;
                 }
             }
-            m_menu_manager.close_bar();
-            topmost_menu->set_window_menu_open(false);
+
+            if (event.type() == WSEvent::MouseDown) {
+                m_menu_manager.close_bar();
+                topmost_menu->set_window_menu_open(false);
+            }
         }
 
         if (event.type() == WSEvent::MouseMove) {

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -975,10 +975,18 @@ void WSWindowManager::event(CEvent& event)
                     }
                 }
             }
-
-            return m_active_window->dispatch_event(event);
+            m_active_window->dispatch_event(event);
+            return;
         }
-        return;
+
+        // FIXME: I would prefer to be WSEvent::KeyUp, and be at the top of this function
+        // However, the modifier is Invalid of Mod_Logo for a keyup event. Move after a fix is made.
+        if (key_event.type() == WSEvent::KeyDown && key_event.modifiers() == Mod_Logo) {
+            m_menu_manager.open_menu(m_menu_manager.system_menu());
+            return;
+        }
+
+        m_menu_manager.dispatch_event(event);
     }
 
     CObject::event(event);

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -708,12 +708,6 @@ void WSWindowManager::process_mouse_event(WSMouseEvent& event, WSWindow*& hovere
         deliver_mouse_event(*window, translated_event);
     }
 
-    // FIXME: Now that the menubar has a dedicated window, is this special-casing really necessary?
-    if (!active_window_is_modal() && menubar_rect().contains(event.position())) {
-        m_menu_manager.dispatch_event(event);
-        return;
-    }
-
     if (!menu_manager().open_menu_stack().is_empty()) {
         auto* topmost_menu = menu_manager().open_menu_stack().last().ptr();
         ASSERT(topmost_menu);

--- a/Servers/WindowServer/WSWindowManager.h
+++ b/Servers/WindowServer/WSWindowManager.h
@@ -258,7 +258,6 @@ private:
 
     u8 m_keyboard_modifiers { 0 };
 
-
     WSWindowSwitcher m_switcher;
     WSMenuManager m_menu_manager;
 


### PR DESCRIPTION
I have currently got menu traversal working in WSMenu so far, besides from the small issue mentioned in the commit message.

I also can't figure out how to get `m_items.find_first_index(*m_hovered_item)` to work because of type conversion from `WSMenuItem*` to `NonnullOwnPtr<WSMenuItem>` (there's probably something simple I am missing)

Once I figure out how to get key press events to WSMenu properly, I think I am mostly done (I have only managed to get this working with System Menu so far). But I thought I would make this PR just to see if I could get any feedback on this, or even it it was good idea.

Also I was wondering whether there were any ideas for a fix for the issue mentioned in the commit message - my current thoughts being something like a WSMenu knowing who its parent is, and telling the parent menu if that submenu is being hovered.