### PR TITLE
AK+LibCore: Add an IDAllocator and use to allocate timer ids

### DIFF
--- a/AK/HashFunctions.h
+++ b/AK/HashFunctions.h
@@ -17,3 +17,10 @@ inline unsigned pair_int_hash(u32 key1, u32 key2)
 {
     return int_hash((int_hash(key1) * 209) ^ (int_hash(key2 * 413)));
 }
+
+inline unsigned u64_hash(u64 key)
+{
+    u32 first = key & 0xFFFFFFFF;
+    u32 last = key >> 32;
+    return pair_int_hash(first, last);
+}

--- a/AK/IDAllocator.h
+++ b/AK/IDAllocator.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <stdlib.h>
+#include <AK/HashTable.h>
+
+namespace AK {
+
+class IDAllocator {
+
+public:
+    IDAllocator() {}
+    ~IDAllocator() {}
+
+    int allocate()
+    {
+        int r = rand();
+        for (int i = 0; i < 100000; ++i) {
+            int allocated_id = r + i;
+            if (!m_allocated_ids.contains(allocated_id)) {
+                m_allocated_ids.set(allocated_id);
+                return allocated_id;
+            }
+        }
+        ASSERT_NOT_REACHED();
+    }
+
+    void deallocate(int id)
+    {
+        m_allocated_ids.remove(id);
+    }
+
+private:
+    HashTable<int> m_allocated_ids;
+};
+}
+
+using AK::IDAllocator;

--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -38,6 +38,13 @@ struct Traits<u16> : public GenericTraits<u16> {
 };
 
 template<>
+struct Traits<u64> : public GenericTraits<u64> {
+    static constexpr bool is_trivial() { return true; }
+    static unsigned hash(u64 u) { return u64_hash(u); }
+    static void dump(u64 u) { kprintf("%u", (unsigned)u); } // FIXME: Implement unsigned long long printf specifier, instead of this sadness :(
+};
+
+template<>
 struct Traits<char> : public GenericTraits<char> {
     static constexpr bool is_trivial() { return true; }
     static unsigned hash(char c) { return int_hash(c); }

--- a/Libraries/LibCore/CEventLoop.h
+++ b/Libraries/LibCore/CEventLoop.h
@@ -85,7 +85,6 @@ private:
     };
 
     static HashMap<int, NonnullOwnPtr<EventLoopTimer>>* s_timers;
-    static int s_next_timer_id;
 
     static HashTable<CNotifier*>* s_notifiers;
 


### PR DESCRIPTION
This (effectively) eliminates the possibility of an integer overflow on a timer id.

Also add a u64 type trait and hash function so they can be used in HashMaps.