### PR TITLE
LibGUI+WindowServer: Various tweaks & QoL improvements

### DIFF
--- a/Libraries/LibGUI/GWindow.cpp
+++ b/Libraries/LibGUI/GWindow.cpp
@@ -61,6 +61,7 @@ void GWindow::show()
         m_rect_when_windowless,
         m_has_alpha_channel,
         m_modal,
+        m_minimizable,
         m_resizable,
         m_fullscreen,
         m_show_titlebar,
@@ -549,6 +550,7 @@ void GWindow::save_to(AK::JsonObject& json)
     json.set("title", title());
     json.set("visible", is_visible());
     json.set("active", is_active());
+    json.set("minimizable", is_minimizable());
     json.set("resizable", is_resizable());
     json.set("fullscreen", is_fullscreen());
     json.set("rect", rect().to_string());

--- a/Libraries/LibGUI/GWindow.h
+++ b/Libraries/LibGUI/GWindow.h
@@ -40,6 +40,9 @@ public:
     bool is_resizable() const { return m_resizable; }
     void set_resizable(bool resizable) { m_resizable = resizable; }
 
+    bool is_minimizable() const { return m_minimizable; }
+    void set_minimizable(bool minimizable) { m_minimizable = minimizable; }
+
     void set_double_buffering_enabled(bool);
     void set_has_alpha_channel(bool);
     void set_opacity(float);
@@ -175,6 +178,7 @@ private:
     bool m_double_buffering_enabled { true };
     bool m_modal { false };
     bool m_resizable { true };
+    bool m_minimizable { true };
     bool m_fullscreen { false };
     bool m_show_titlebar { true };
     bool m_layout_pending { false };

--- a/Servers/WindowServer/WSClientConnection.cpp
+++ b/Servers/WindowServer/WSClientConnection.cpp
@@ -394,7 +394,7 @@ OwnPtr<WindowServer::GetClipboardContentsResponse> WSClientConnection::handle(co
 OwnPtr<WindowServer::CreateWindowResponse> WSClientConnection::handle(const WindowServer::CreateWindow& message)
 {
     int window_id = m_next_window_id++;
-    auto window = WSWindow::construct(*this, (WSWindowType)message.type(), window_id, message.modal(), message.resizable(), message.fullscreen());
+    auto window = WSWindow::construct(*this, (WSWindowType)message.type(), window_id, message.modal(), message.minimizable(), message.resizable(), message.fullscreen());
     window->set_has_alpha_channel(message.has_alpha_channel());
     window->set_title(message.title());
     if (!message.fullscreen())

--- a/Servers/WindowServer/WSMenu.h
+++ b/Servers/WindowServer/WSMenu.h
@@ -5,12 +5,13 @@
 #include <AK/WeakPtr.h>
 #include <LibCore/CObject.h>
 #include <LibDraw/Rect.h>
+#include <WindowServer/WSCursor.h>
 #include <WindowServer/WSMenuItem.h>
+#include <WindowServer/WSWindow.h>
 
 class WSClientConnection;
 class WSMenuBar;
 class WSEvent;
-class WSWindow;
 class Font;
 
 class WSMenu final : public CObject {
@@ -30,6 +31,7 @@ public:
     bool is_empty() const { return m_items.is_empty(); }
     int item_count() const { return m_items.size(); }
     const WSMenuItem& item(int index) const { return m_items.at(index); }
+    WSMenuItem& item(int index) { return m_items.at(index); }
 
     void add_item(NonnullOwnPtr<WSMenuItem>&& item) { m_items.append(move(item)); }
 
@@ -50,6 +52,11 @@ public:
 
     WSWindow* menu_window() { return m_menu_window.ptr(); }
     WSWindow& ensure_menu_window();
+
+    WSWindow* window_menu_of() { return m_window_menu_of; }
+    void set_window_menu_of(WSWindow& window) { m_window_menu_of = window.make_weak_ptr(); }
+    bool is_window_menu_open() { return m_is_window_menu_open; }
+    void set_window_menu_open(bool is_open) { m_is_window_menu_open = is_open; }
 
     int width() const;
     int height() const;
@@ -94,5 +101,7 @@ private:
     WSMenuItem* m_hovered_item { nullptr };
     NonnullOwnPtrVector<WSMenuItem> m_items;
     RefPtr<WSWindow> m_menu_window;
+    WeakPtr<WSWindow> m_window_menu_of;
+    bool m_is_window_menu_open = { false };
     int m_theme_index_at_last_paint { -1 };
 };

--- a/Servers/WindowServer/WSWindow.cpp
+++ b/Servers/WindowServer/WSWindow.cpp
@@ -162,6 +162,7 @@ void WSWindow::set_maximized(bool maximized)
         return;
     if (maximized && !is_resizable())
         return;
+    set_tiled(WindowTileType::None);
     m_maximized = maximized;
     update_menu_item_text(PopupMenuItem::Maximize);
     auto old_rect = m_rect;
@@ -355,7 +356,7 @@ void WSWindow::set_tiled(WindowTileType tiled)
 
     int frame_width = (m_frame.rect().width() - m_rect.width()) / 2;
     switch (tiled) {
-        case WindowTileType::None :
+    case WindowTileType::None :
         set_rect(m_untiled_rect);
         break;
     case WindowTileType::Left :
@@ -369,7 +370,7 @@ void WSWindow::set_tiled(WindowTileType tiled)
         m_untiled_rect = m_rect;
         set_rect(WSScreen::the().width() / 2 + frame_width,
                 WSWindowManager::the().maximized_window_rect(*this).y(),
-                (WSScreen::the().width() / 2) - frame_width,
+                WSScreen::the().width() / 2 - frame_width,
                 WSWindowManager::the().maximized_window_rect(*this).height());
         break;
     }

--- a/Servers/WindowServer/WSWindow.h
+++ b/Servers/WindowServer/WSWindow.h
@@ -31,7 +31,7 @@ class WSWindow final : public CObject
     , public InlineLinkedListNode<WSWindow> {
     C_OBJECT(WSWindow)
 public:
-    WSWindow(WSClientConnection&, WSWindowType, int window_id, bool modal, bool resizable, bool fullscreen);
+    WSWindow(WSClientConnection&, WSWindowType, int window_id, bool modal, bool minimizable, bool resizable, bool fullscreen);
     WSWindow(CObject&, WSWindowType);
     virtual ~WSWindow() override;
 
@@ -43,6 +43,12 @@ public:
 
     bool is_minimized() const { return m_minimized; }
     void set_minimized(bool);
+
+    bool is_minimizable() const { return m_minimizable; }
+    void set_minimizable(bool);
+
+    bool is_resizable() const { return m_resizable && !m_fullscreen; }
+    void set_resizable(bool);
 
     bool is_maximized() const { return m_maximized; }
     void set_maximized(bool);
@@ -94,8 +100,6 @@ public:
     void set_visible(bool);
 
     bool is_modal() const { return m_modal; }
-
-    bool is_resizable() const { return m_resizable && !m_fullscreen; }
 
     Rect rect() const { return m_rect; }
     void set_rect(const Rect&);
@@ -198,6 +202,7 @@ private:
     bool m_visible { true };
     bool m_has_alpha_channel { false };
     bool m_modal { false };
+    bool m_minimizable { false };
     bool m_resizable { false };
     bool m_listens_to_wm_events { false };
     bool m_minimized { false };

--- a/Servers/WindowServer/WSWindow.h
+++ b/Servers/WindowServer/WSWindow.h
@@ -27,6 +27,11 @@ enum class WindowTileType {
     Right,
 };
 
+enum class PopupMenuItem {
+    Minimize = 0,
+    Maximize,
+};
+
 class WSWindow final : public CObject
     , public InlineLinkedListNode<WSWindow> {
     C_OBJECT(WSWindow)
@@ -190,6 +195,8 @@ public:
 
 private:
     void handle_mouse_event(const WSMouseEvent&);
+    void update_menu_item_text(PopupMenuItem item);
+    void update_menu_item_enabled(PopupMenuItem item);
 
     WSClientConnection* m_client { nullptr };
     String m_title;

--- a/Servers/WindowServer/WSWindowFrame.cpp
+++ b/Servers/WindowServer/WSWindowFrame.cpp
@@ -284,7 +284,9 @@ void WSWindowFrame::on_mouse_event(const WSMouseEvent& event)
     if (m_window.type() != WSWindowType::Normal)
         return;
 
-    if (event.type() == WSEvent::MouseDown && event.button() == MouseButton::Left && title_bar_icon_rect().contains(event.position())) {
+    if (event.type() == WSEvent::MouseDown && (event.button() == MouseButton::Left || event.button() == MouseButton::Right) &&
+        title_bar_icon_rect().contains(event.position())) {
+        wm.move_to_front_and_make_active(m_window);
         m_window.popup_window_menu(event.position().translated(rect().location()));
         return;
     }
@@ -305,8 +307,14 @@ void WSWindowFrame::on_mouse_event(const WSMouseEvent& event)
             if (button.relative_rect().contains(event.position()))
                 return button.on_mouse_event(event.translated(-button.relative_rect().location()));
         }
-        if (event.type() == WSEvent::MouseDown && event.button() == MouseButton::Left)
-            wm.start_window_move(m_window, event.translated(rect().location()));
+        if (event.type() == WSEvent::MouseDown) {
+            if (event.button() == MouseButton::Right) {
+                m_window.popup_window_menu(event.position().translated(rect().location()));
+                return;
+            }
+            if (event.button() == MouseButton::Left)
+                wm.start_window_move(m_window, event.translated(rect().location()));
+        }
         return;
     }
 

--- a/Servers/WindowServer/WSWindowFrame.cpp
+++ b/Servers/WindowServer/WSWindowFrame.cpp
@@ -102,9 +102,13 @@ WSWindowFrame::WSWindowFrame(WSWindow& window)
         m_buttons.append(move(button));
     }
 
-    m_buttons.append(make<WSButton>(*this, *s_minimize_button_bitmap, [this](auto&) {
-        m_window.set_minimized(true);
-    }));
+    if (window.is_minimizable()) {
+        auto button = make<WSButton>(*this, *s_minimize_button_bitmap, [this](auto&) {
+            m_window.set_minimized(true);
+        });
+        m_minimize_button = button.ptr();
+        m_buttons.append(move(button));
+    }
 }
 
 WSWindowFrame::~WSWindowFrame()

--- a/Servers/WindowServer/WSWindowFrame.h
+++ b/Servers/WindowServer/WSWindowFrame.h
@@ -30,4 +30,5 @@ private:
     WSWindow& m_window;
     NonnullOwnPtrVector<WSButton> m_buttons;
     WSButton* m_maximize_button { nullptr };
+    WSButton* m_minimize_button { nullptr };
 };

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -348,8 +348,6 @@ void WSWindowManager::remove_window(WSWindow& window)
     m_windows_in_order.remove(&window);
     if (window.is_active())
         pick_new_active_window();
-    if (m_active_window.ptr() == &window)
-        set_active_window(nullptr);
     if (m_switcher.is_visible() && window.type() != WSWindowType::WindowSwitcher)
         m_switcher.refresh();
 
@@ -489,10 +487,14 @@ void WSWindowManager::notify_occlusion_state_changed(WSWindow& window)
 
 void WSWindowManager::pick_new_active_window()
 {
+    bool new_window_picked = false;
     for_each_visible_window_of_type_from_front_to_back(WSWindowType::Normal, [&](WSWindow& candidate) {
         set_active_window(&candidate);
+        new_window_picked = true;
         return IterationDecision::Break;
     });
+    if (!new_window_picked)
+        set_active_window(nullptr);
 }
 
 void WSWindowManager::start_window_move(WSWindow& window, const WSMouseEvent& event)

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -1114,8 +1114,48 @@ void WSWindowManager::event(CEvent& event)
             m_switcher.on_key_event(key_event);
             return;
         }
-        if (m_active_window)
+
+        if (m_active_window) {
+            if (key_event.type() == WSEvent::KeyDown && key_event.modifiers() == Mod_Logo) {
+                if (key_event.key() == Key_Down) {
+                    if (m_active_window->is_resizable() && m_active_window->is_maximized()) {
+                        m_active_window->set_maximized(false);
+                        return;
+                    }
+                    if (m_active_window->is_minimizable())
+                        m_active_window->set_minimized(true);
+                    return;
+                }
+                if (m_active_window->is_resizable()) {
+                    if (key_event.key() == Key_Up) {
+                        m_active_window->set_maximized(!m_active_window->is_maximized());
+                        return;
+                    }
+                    if (key_event.key() == Key_Left) {
+                        if (m_active_window->tiled() != WindowTileType::None) {
+                            m_active_window->set_tiled(WindowTileType::None);
+                            return;
+                        }
+                        if (m_active_window->is_maximized())
+                            m_active_window->set_maximized(false);
+                        m_active_window->set_tiled(WindowTileType::Left);
+                        return;
+                    }
+                    if (key_event.key() == Key_Right) {
+                        if (m_active_window->tiled() != WindowTileType::None) {
+                            m_active_window->set_tiled(WindowTileType::None);
+                            return;
+                        }
+                        if (m_active_window->is_maximized())
+                            m_active_window->set_maximized(false);
+                        m_active_window->set_tiled(WindowTileType::Right);
+                        return;
+                    }
+                }
+            }
+
             return m_active_window->dispatch_event(event);
+        }
         return;
     }
 

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -883,8 +883,18 @@ void WSWindowManager::process_mouse_event(WSMouseEvent& event, WSWindow*& hovere
         if (!event_is_inside_current_menu) {
             if (topmost_menu->hovered_item())
                 topmost_menu->clear_hovered_item();
-            if (event.type() == WSEvent::MouseDown || event.type() == WSEvent::MouseUp)
+            if (event.type() == WSEvent::MouseDown || event.type() == WSEvent::MouseUp) {
+                auto* window_menu_of = topmost_menu->window_menu_of();
+                if (window_menu_of) {
+                    bool event_is_inside_taskbar_button = window_menu_of->taskbar_rect().contains(event.position());
+                    if (event_is_inside_taskbar_button && !topmost_menu->is_window_menu_open()) {
+                        topmost_menu->set_window_menu_open(true);
+                        return;
+                    }
+                }
                 m_menu_manager.close_bar();
+                topmost_menu->set_window_menu_open(false);
+            }
             if (event.type() == WSEvent::MouseMove) {
                 for (auto& menu : m_menu_manager.open_menu_stack()) {
                     if (!menu)

--- a/Servers/WindowServer/WindowServer.ipc
+++ b/Servers/WindowServer/WindowServer.ipc
@@ -20,6 +20,7 @@ endpoint WindowServer = 2
         Rect rect,
         bool has_alpha_channel,
         bool modal,
+        bool minimizable,
         bool resizable,
         bool fullscreen,
         bool show_titlebar,


### PR DESCRIPTION
I guess you could call this a "mini overhaul" :stuck_out_tongue_closed_eyes: here's roughly everything new:
* There are now **window management shortcuts** and they are configured as follows (97c6904):
Tile left -  `Logo` + `Left` (press again to untile, or maximize with `Logo` + `Up`)
Tile right -  `Logo` + `Right` (press again to untile, or maximize with `Logo` + `Up`)
Maximize -  `Logo` + `Up` (press again to unmaximize/restore, or tile to a side with above shortcuts)
Minimize -  `Logo` + `Down` (if maximized this will unmaximize/restore first; press again to minimize)
* Windows now maximize when they're dragged to the very top of the screen (3244d50)
* The window pop-up menu has been completely reworked (3727eba):
  1. Simply right-clicking the window taskbar button once opens the menu properly now (bugfix)
  2. A maximization/restore option has been added
  3. Menu button text/enabled states are updated dynamically
  4. The menu can be invoked from any point in window titlebar using right-click
* When all running windows were minimized, the menubar used to stay visible for the last window you minimized as well as the taskbar button was shown as active. This is now fixed with 65fc878 :)
* Windows now have a "minimizable" property which can be set e.g. on [About windows to hide the minimize button](https://i.imgur.com/K7wClNQ.png) (0fecaf1 no apps modified on this PR, it's just used in some of the code; some- thing should also be done later about taskbar button when a window is set as non-minimizable)

And as always, feedback is highly welcome!