### PR TITLE
LibELF+LibC: Split ELFDynamicObject into a Loader + Object

### DIFF
--- a/Libraries/LibC/Makefile
+++ b/Libraries/LibC/Makefile
@@ -58,6 +58,7 @@ LIBC_OBJS = \
 
 ELF_OBJS = \
         ../LibELF/ELFDynamicObject.o \
+        ../LibELF/ELFDynamicLoader.o \
         ../LibELF/ELFImage.o
 
 OBJS = $(AK_OBJS) $(LIBC_OBJS) $(ELF_OBJS)

--- a/Libraries/LibELF/ELFDynamicLoader.cpp
+++ b/Libraries/LibELF/ELFDynamicLoader.cpp
@@ -1,0 +1,343 @@
+#include <AK/StringBuilder.h>
+#include <LibELF/ELFDynamicLoader.h>
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <mman.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DYNAMIC_LOAD_DEBUG
+//#define DYNAMIC_LOAD_VERBOSE
+
+#ifdef DYNAMIC_LOAD_VERBOSE
+#    define VERBOSE(fmt, ...) dbgprintf(fmt, ##__VA_ARGS__)
+#else
+#    define VERBOSE(fmt, ...) \
+        do {                  \
+        } while (0)
+#endif
+
+static bool s_always_bind_now = false;
+
+NonnullRefPtr<ELFDynamicLoader> ELFDynamicLoader::construct(const char* filename, int fd, size_t size)
+{
+    return adopt(*new ELFDynamicLoader(filename, fd, size));
+}
+
+ELFDynamicLoader::ELFDynamicLoader(const char* filename, int fd, size_t size)
+    : m_filename(filename)
+    , m_file_size(size)
+    , m_image_fd(fd)
+{
+    String file_mmap_name = String::format("ELF_DYN: %s", m_filename.characters());
+
+    m_file_mapping = mmap_with_name(nullptr, size, PROT_READ, MAP_PRIVATE, m_image_fd, 0, file_mmap_name.characters());
+    if (MAP_FAILED == m_file_mapping) {
+        m_valid = false;
+    }
+}
+
+ELFDynamicLoader::~ELFDynamicLoader()
+{
+    if (MAP_FAILED != m_file_mapping)
+        munmap(m_file_mapping, m_file_size);
+}
+
+void* ELFDynamicLoader::symbol_for_name(const char* name)
+{
+    auto symbol = m_dynamic_object->hash_section().lookup_symbol(name);
+
+    if (symbol.is_undefined())
+        return nullptr;
+
+    return m_dynamic_object->base_address().offset(symbol.value()).as_ptr();
+}
+
+bool ELFDynamicLoader::load_from_image(unsigned flags)
+{
+    ELFImage elf_image((u8*)m_file_mapping);
+
+    m_valid = elf_image.is_valid() && elf_image.is_dynamic();
+
+    if (!m_valid) {
+        return false;
+    }
+
+    const ELFImage::DynamicSection probably_dynamic_section = elf_image.dynamic_section();
+    if (StringView(".dynamic") != probably_dynamic_section.name() || probably_dynamic_section.type() != SHT_DYNAMIC) {
+        m_valid = false;
+        return false;
+    }
+
+#ifdef DYNAMIC_LOAD_VERBOSE
+    m_image->dump();
+#endif
+
+    load_program_headers(elf_image);
+
+    const ELFImage::DynamicSection image_dynamic_section = elf_image.dynamic_section();
+    m_dynamic_object = AK::make<ELFDynamicObject>(m_text_segment_load_address, image_dynamic_section.offset());
+
+    return load_stage_2(flags);
+}
+
+bool ELFDynamicLoader::load_stage_2(unsigned flags)
+{
+    ASSERT(flags & RTLD_GLOBAL);
+    ASSERT(flags & RTLD_LAZY);
+
+#ifdef DYNAMIC_LOAD_DEBUG
+    m_dynamic_object->dump();
+#endif
+
+    if (m_dynamic_object->has_text_relocations()) {
+        ASSERT(m_text_segment_load_address.get() != 0);
+        if (0 > mprotect(m_text_segment_load_address.as_ptr(), m_text_segment_size, PROT_READ | PROT_WRITE)) {
+            perror("mprotect"); // FIXME: dlerror?
+            return false;
+        }
+    }
+
+    do_relocations();
+    setup_plt_trampoline();
+
+    // Clean up our setting of .text to PROT_READ | PROT_WRITE
+    if (m_dynamic_object->has_text_relocations()) {
+        if (0 > mprotect(m_text_segment_load_address.as_ptr(), m_text_segment_size, PROT_READ | PROT_EXEC)) {
+            perror("mprotect"); // FIXME: dlerror?
+            return false;
+        }
+    }
+
+    call_object_init_functions();
+
+#ifdef DYNAMIC_LOAD_DEBUG
+    dbgprintf("Loaded %s\n", m_filename.characters());
+#endif
+    return true;
+}
+
+void ELFDynamicLoader::load_program_headers(const ELFImage& elf_image)
+{
+    size_t total_required_allocation_size = 0; // NOTE: If we don't have any TEXTREL, we can keep RO data RO, which would be nice
+
+    Vector<ProgramHeaderRegion> program_headers;
+
+    ProgramHeaderRegion* text_region_ptr = nullptr;
+    ProgramHeaderRegion* data_region_ptr = nullptr;
+    ProgramHeaderRegion* tls_region_ptr = nullptr;
+
+    elf_image.for_each_program_header([&](const ELFImage::ProgramHeader& program_header) {
+        ProgramHeaderRegion new_region;
+        new_region.set_program_header(program_header.raw_header());
+        if (new_region.is_load())
+            total_required_allocation_size += new_region.required_load_size();
+        program_headers.append(move(new_region));
+        auto& region = program_headers.last();
+        if (region.is_tls_template())
+            tls_region_ptr = &region;
+        else if (region.is_load()) {
+            if (region.is_executable())
+                text_region_ptr = &region;
+            else
+                data_region_ptr = &region;
+        }
+    });
+
+    ASSERT(text_region_ptr && data_region_ptr);
+
+    // Process regions in order: .text, .data, .tls
+    auto* region = text_region_ptr;
+    void* text_segment_begin = mmap_with_name(nullptr, region->required_load_size(), region->mmap_prot(), MAP_PRIVATE, m_image_fd, region->offset(), String::format(".text: %s", m_filename.characters()).characters());
+    if (MAP_FAILED == text_segment_begin) {
+        ASSERT_NOT_REACHED();
+    }
+    m_text_segment_size = region->required_load_size();
+    m_text_segment_load_address = VirtualAddress { (u32)text_segment_begin };
+
+    region = data_region_ptr;
+    void* data_segment_begin = mmap_with_name((u8*)text_segment_begin + m_text_segment_size, region->required_load_size(), region->mmap_prot(), MAP_ANONYMOUS | MAP_PRIVATE, 0, 0, String::format(".data: %s", m_filename.characters()).characters());
+    if (MAP_FAILED == data_segment_begin) {
+        ASSERT_NOT_REACHED();
+    }
+    VirtualAddress data_segment_actual_addr = region->desired_load_address().offset((u32)text_segment_begin);
+    memcpy(data_segment_actual_addr.as_ptr(), (u8*)m_file_mapping + region->offset(), region->size_in_image());
+
+    // FIXME: Do some kind of 'allocate TLS section' or some such from a per-application pool
+    if (tls_region_ptr) {
+        region = tls_region_ptr;
+        // FIXME: This can't be right either. TLS needs some real work i'd say :)
+        m_tls_segment_address = tls_region_ptr->desired_load_address();
+        VirtualAddress tls_segment_actual_addr = region->desired_load_address().offset((u32)text_segment_begin);
+        memcpy(tls_segment_actual_addr.as_ptr(), (u8*)m_file_mapping + region->offset(), region->size_in_image());
+    }
+}
+
+void ELFDynamicLoader::do_relocations()
+{
+    u32 load_base_address = m_dynamic_object->base_address().get();
+
+    // FIXME: We should really bail on undefined symbols here.
+
+    auto main_relocation_section = m_dynamic_object->relocation_section();
+
+    main_relocation_section.for_each_relocation([&](const ELFDynamicObject::Relocation& relocation) {
+        VERBOSE("====== RELOCATION %d: offset 0x%08X, type %d, symidx %08X\n", relocation.offset_in_section() / main_relocation_section.entry_size(), relocation.offset(), relocation.type(), relocation.symbol_index());
+        u32* patch_ptr = (u32*)(load_base_address + relocation.offset());
+        switch (relocation.type()) {
+        case R_386_NONE:
+            // Apparently most loaders will just skip these?
+            // Seems if the 'link editor' generates one something is funky with your code
+            VERBOSE("None relocation. No symbol, no nothin.\n");
+            break;
+        case R_386_32: {
+            auto symbol = relocation.symbol();
+            VERBOSE("Absolute relocation: name: '%s', value: %p\n", symbol.name(), symbol.value());
+            u32 symbol_address = symbol.value() + load_base_address;
+            *patch_ptr += symbol_address;
+            VERBOSE("   Symbol address: %p\n", *patch_ptr);
+            break;
+        }
+        case R_386_PC32: {
+            auto symbol = relocation.symbol();
+            VERBOSE("PC-relative relocation: '%s', value: %p\n", symbol.name(), symbol.value());
+            u32 relative_offset = (symbol.value() - relocation.offset());
+            *patch_ptr += relative_offset;
+            VERBOSE("   Symbol address: %p\n", *patch_ptr);
+            break;
+        }
+        case R_386_GLOB_DAT: {
+            auto symbol = relocation.symbol();
+            VERBOSE("Global data relocation: '%s', value: %p\n", symbol.name(), symbol.value());
+            u32 symbol_location = load_base_address + symbol.value();
+            *patch_ptr = symbol_location;
+            VERBOSE("   Symbol address: %p\n", *patch_ptr);
+            break;
+        }
+        case R_386_RELATIVE: {
+            // FIXME: According to the spec, R_386_relative ones must be done first.
+            //     We could explicitly do them first using m_number_of_relocatoins from DT_RELCOUNT
+            //     However, our compiler is nice enough to put them at the front of the relocations for us :)
+            VERBOSE("Load address relocation at offset %X\n", relocation.offset());
+            VERBOSE("    patch ptr == %p, adding load base address (%p) to it and storing %p\n", *patch_ptr, load_base_address, *patch_ptr + load_base_address);
+            *patch_ptr += load_base_address; // + addend for RelA (addend for Rel is stored at addr)
+            break;
+        }
+        case R_386_TLS_TPOFF: {
+            VERBOSE("Relocation type: R_386_TLS_TPOFF at offset %X\n", relocation.offset());
+            // FIXME: this can't be right? I have no idea what "negative offset into TLS storage" means...
+            // FIXME: Check m_has_static_tls and do something different for dynamic TLS
+            *patch_ptr = relocation.offset() - (u32)m_tls_segment_address.as_ptr() - *patch_ptr;
+            break;
+        }
+        default:
+            // Raise the alarm! Someone needs to implement this relocation type
+            dbgprintf("Found a new exciting relocation type %d\n", relocation.type());
+            printf("ELFDynamicLoader: Found unknown relocation type %d\n", relocation.type());
+            ASSERT_NOT_REACHED();
+            break;
+        }
+        return IterationDecision::Continue;
+    });
+
+    // Handle PLT Global offset table relocations.
+    m_dynamic_object->plt_relocation_section().for_each_relocation([&](const ELFDynamicObject::Relocation& relocation) {
+        // FIXME: Or BIND_NOW flag passed in?
+        if (m_dynamic_object->must_bind_now() || s_always_bind_now) {
+            // Eagerly BIND_NOW the PLT entries, doing all the symbol looking goodness
+            // The patch method returns the address for the LAZY fixup path, but we don't need it here
+            (void)patch_plt_entry(relocation.offset_in_section());
+        } else {
+            // LAZY-ily bind the PLT slots by just adding the base address to the offsets stored there
+            // This avoids doing symbol lookup, which might be expensive
+            ASSERT(relocation.type() == R_386_JMP_SLOT);
+
+            u8* relocation_address = relocation.address().as_ptr();
+
+            *(u32*)relocation_address += load_base_address;
+        }
+        return IterationDecision::Continue;
+    });
+
+#ifdef DYNAMIC_LOAD_DEBUG
+    dbgprintf("Done relocating!\n");
+#endif
+}
+
+// Defined in <arch>/plt_trampoline.S
+extern "C" void _plt_trampoline(void) __attribute__((visibility("hidden")));
+
+void ELFDynamicLoader::setup_plt_trampoline()
+{
+    VirtualAddress got_address = m_dynamic_object->plt_got_base_address();
+
+    u32* got_u32_ptr = (u32*)got_address.as_ptr();
+    got_u32_ptr[1] = (u32)this;
+    got_u32_ptr[2] = (u32)&_plt_trampoline;
+
+#ifdef DYNAMIC_LOAD_DEBUG
+    dbgprintf("Set GOT PLT entries at %p: [0] = %p [1] = %p, [2] = %p\n", got_u32_ptr, got_u32_ptr[0], got_u32_ptr[1], got_u32_ptr[2]);
+#endif
+}
+
+// Called from our ASM routine _plt_trampoline
+extern "C" Elf32_Addr _fixup_plt_entry(ELFDynamicLoader* object, u32 relocation_offset)
+{
+    return object->patch_plt_entry(relocation_offset);
+}
+
+// offset is in PLT relocation table
+Elf32_Addr ELFDynamicLoader::patch_plt_entry(u32 relocation_offset)
+{
+    auto relocation = m_dynamic_object->plt_relocation_section().relocation_at_offset(relocation_offset);
+
+    ASSERT(relocation.type() == R_386_JMP_SLOT);
+
+    auto sym = relocation.symbol();
+
+    u8* relocation_address = relocation.address().as_ptr();
+    u32 symbol_location = sym.address().get();
+
+    VERBOSE("ELFDynamicLoader: Jump slot relocation: putting %s (%p) into PLT at %p\n", sym.name(), symbol_location, relocation_address);
+
+    *(u32*)relocation_address = symbol_location;
+
+    return symbol_location;
+}
+
+void ELFDynamicLoader::call_object_init_functions()
+{
+    typedef void (*InitFunc)();
+    auto init_function = (InitFunc)(m_dynamic_object->init_section().address().as_ptr());
+
+#ifdef DYNAMIC_LOAD_DEBUG
+    dbgprintf("Calling DT_INIT at %p\n", init_function);
+#endif
+    (init_function)();
+
+    auto init_array_section = m_dynamic_object->init_array_section();
+
+    InitFunc* init_begin = (InitFunc*)(init_array_section.address().as_ptr());
+    InitFunc* init_end = init_begin + init_array_section.entry_count();
+    while (init_begin != init_end) {
+        // Android sources claim that these can be -1, to be ignored.
+        // 0 definitely shows up. Apparently 0/-1 are valid? Confusing.
+        if (!*init_begin || ((i32)*init_begin == -1))
+            continue;
+#ifdef DYNAMIC_LOAD_DEBUG
+        dbgprintf("Calling DT_INITARRAY entry at %p\n", *init_begin);
+#endif
+        (*init_begin)();
+        ++init_begin;
+    }
+}
+
+u32 ELFDynamicLoader::ProgramHeaderRegion::mmap_prot() const
+{
+    int prot = 0;
+    prot |= is_executable() ? PROT_EXEC : 0;
+    prot |= is_readable() ? PROT_READ : 0;
+    prot |= is_writable() ? PROT_WRITE : 0;
+    return prot;
+}

--- a/Libraries/LibELF/ELFDynamicLoader.h
+++ b/Libraries/LibELF/ELFDynamicLoader.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <LibELF/ELFDynamicObject.h>
+#include <LibELF/ELFImage.h>
+#include <LibELF/exec_elf.h>
+#include <mman.h>
+
+#include <AK/OwnPtr.h>
+#include <AK/RefCounted.h>
+#include <AK/String.h>
+
+#define ALIGN_ROUND_UP(x, align) ((((size_t)(x)) + align - 1) & (~(align - 1)))
+
+class ELFDynamicLoader : public RefCounted<ELFDynamicLoader> {
+public:
+    static NonnullRefPtr<ELFDynamicLoader> construct(const char* filename, int fd, size_t file_size);
+
+    ~ELFDynamicLoader();
+
+    bool is_valid() const { return m_valid; }
+
+    // Load a full ELF image from file into the current process and create an ELFDynamicObject
+    // from the SHT_DYNAMIC in the file.
+    bool load_from_image(unsigned flags);
+
+    // Stage 2 of loading: relocations and init functions
+    // Assumes that the program headers have been loaded and that m_dynamic_object is initialized
+    // Splitting loading like this allows us to use the same code to relocate a main executable as an elf binary
+    bool load_stage_2(unsigned flags);
+
+    // Intended for use by dlsym or other internal methods
+    void* symbol_for_name(const char*);
+
+    void dump();
+
+    // Will be called from _fixup_plt_entry, as part of the PLT trampoline
+    Elf32_Addr patch_plt_entry(u32 relocation_offset);
+
+private:
+    class ProgramHeaderRegion {
+    public:
+        void set_program_header(const Elf32_Phdr& header) { m_program_header = header; }
+
+        // Information from ELF Program header
+        u32 type() const { return m_program_header.p_type; }
+        u32 flags() const { return m_program_header.p_flags; }
+        u32 offset() const { return m_program_header.p_offset; }
+        VirtualAddress desired_load_address() const { return VirtualAddress(m_program_header.p_vaddr); }
+        u32 size_in_memory() const { return m_program_header.p_memsz; }
+        u32 size_in_image() const { return m_program_header.p_filesz; }
+        u32 alignment() const { return m_program_header.p_align; }
+        u32 mmap_prot() const;
+        bool is_readable() const { return flags() & PF_R; }
+        bool is_writable() const { return flags() & PF_W; }
+        bool is_executable() const { return flags() & PF_X; }
+        bool is_tls_template() const { return type() == PT_TLS; }
+        bool is_load() const { return type() == PT_LOAD; }
+        bool is_dynamic() const { return type() == PT_DYNAMIC; }
+
+        u32 required_load_size() { return ALIGN_ROUND_UP(m_program_header.p_memsz, m_program_header.p_align); }
+
+    private:
+        Elf32_Phdr m_program_header; // Explictly a copy of the PHDR in the image
+    };
+
+    explicit ELFDynamicLoader(const char* filename, int fd, size_t file_size);
+    explicit ELFDynamicLoader(Elf32_Dyn* dynamic_location, Elf32_Addr load_address);
+
+    // Stage 1
+    void load_program_headers(const ELFImage& elf_image);
+
+    // Stage 2
+    void do_relocations();
+    void setup_plt_trampoline();
+    void call_object_init_functions();
+
+    String m_filename;
+    size_t m_file_size { 0 };
+    int m_image_fd { -1 };
+    void* m_file_mapping { nullptr };
+    bool m_valid { true };
+
+    OwnPtr<ELFDynamicObject> m_dynamic_object;
+
+    VirtualAddress m_text_segment_load_address;
+    size_t m_text_segment_size;
+
+    VirtualAddress m_tls_segment_address;
+};

--- a/Libraries/LibELF/ELFImage.h
+++ b/Libraries/LibELF/ELFImage.h
@@ -16,13 +16,9 @@ public:
 
     class Section;
     class RelocationSection;
-    class DynamicRelocationSection;
     class Symbol;
-    class DynamicSymbol;
     class Relocation;
-    class DynamicRelocation;
     class DynamicSection;
-    class DynamicSectionEntry;
 
     class Symbol {
     public:
@@ -36,32 +32,6 @@ public:
         ~Symbol() {}
 
         const char* name() const { return m_image.table_string(m_sym.st_name); }
-        unsigned section_index() const { return m_sym.st_shndx; }
-        unsigned value() const { return m_sym.st_value; }
-        unsigned size() const { return m_sym.st_size; }
-        unsigned index() const { return m_index; }
-        unsigned type() const { return ELF32_ST_TYPE(m_sym.st_info); }
-        unsigned bind() const { return ELF32_ST_BIND(m_sym.st_info); }
-        const Section section() const { return m_image.section(section_index()); }
-
-    private:
-        const ELFImage& m_image;
-        const Elf32_Sym& m_sym;
-        const unsigned m_index;
-    };
-
-    class DynamicSymbol {
-    public:
-        DynamicSymbol(const ELFImage& image, unsigned index, const Elf32_Sym& sym)
-            : m_image(image)
-            , m_sym(sym)
-            , m_index(index)
-        {
-        }
-
-        ~DynamicSymbol() {}
-
-        const char* name() const { return m_image.dynamic_table_string(m_sym.st_name); }
         unsigned section_index() const { return m_sym.st_shndx; }
         unsigned value() const { return m_sym.st_value; }
         unsigned size() const { return m_sym.st_size; }
@@ -151,38 +121,6 @@ public:
         void for_each_relocation(F) const;
     };
 
-    class DynamicRelocationSection : public Section {
-    public:
-        DynamicRelocationSection(const Section& section)
-            : Section(section.m_image, section.m_section_index)
-        {
-        }
-        unsigned relocation_count() const { return entry_count(); }
-        const DynamicRelocation relocation(unsigned index) const;
-        template<typename F>
-        void for_each_relocation(F) const;
-    };
-
-    class DynamicRelocation {
-    public:
-        DynamicRelocation(const ELFImage& image, const Elf32_Rel& rel)
-            : m_image(image)
-            , m_rel(rel)
-        {
-        }
-
-        ~DynamicRelocation() {}
-
-        unsigned offset() const { return m_rel.r_offset; }
-        unsigned type() const { return ELF32_R_TYPE(m_rel.r_info); }
-        unsigned symbol_index() const { return ELF32_R_SYM(m_rel.r_info); }
-        const DynamicSymbol symbol() const { return m_image.dynamic_symbol(symbol_index()); }
-
-    private:
-        const ELFImage& m_image;
-        const Elf32_Rel& m_rel;
-    };
-
     class Relocation {
     public:
         Relocation(const ELFImage& image, const Elf32_Rel& rel)
@@ -210,28 +148,6 @@ public:
         {
             ASSERT(type() == SHT_DYNAMIC);
         }
-
-        template<typename F>
-        void for_each_dynamic_entry(F) const;
-    };
-
-    class DynamicSectionEntry {
-    public:
-        DynamicSectionEntry(const ELFImage& image, const Elf32_Dyn& dyn)
-            : m_image(image)
-            , m_dyn(dyn)
-        {
-        }
-
-        ~DynamicSectionEntry() {}
-
-        Elf32_Sword tag() const { return m_dyn.d_tag; }
-        Elf32_Addr ptr() const { return m_dyn.d_un.d_ptr; }
-        Elf32_Word val() const { return m_dyn.d_un.d_val; }
-
-    private:
-        const ELFImage& m_image;
-        const Elf32_Dyn& m_dyn;
     };
 
     unsigned symbol_count() const;
@@ -240,11 +156,9 @@ public:
     unsigned program_header_count() const;
 
     const Symbol symbol(unsigned) const;
-    const DynamicSymbol dynamic_symbol(unsigned) const;
     const Section section(unsigned) const;
     const ProgramHeader program_header(unsigned const) const;
     const DynamicSection dynamic_section() const;
-    const DynamicRelocationSection dynamic_relocation_section() const;
 
     template<typename F>
     void for_each_section(F) const;
@@ -252,8 +166,6 @@ public:
     void for_each_section_of_type(unsigned, F) const;
     template<typename F>
     void for_each_symbol(F) const;
-    template<typename F>
-    void for_each_dynamic_symbol(F) const;
     template<typename F>
     void for_each_program_header(F) const;
 
@@ -276,17 +188,13 @@ private:
     const char* table_string(unsigned offset) const;
     const char* section_header_table_string(unsigned offset) const;
     const char* section_index_to_string(unsigned index) const;
-    const char* dynamic_table_string(unsigned offset) const;
 
     const u8* m_buffer { nullptr };
     HashMap<String, unsigned> m_sections;
     bool m_valid { false };
     unsigned m_symbol_table_section_index { 0 };
     unsigned m_string_table_section_index { 0 };
-    unsigned m_dynamic_symbol_table_section_index { 0 }; // .dynsym
-    unsigned m_dynamic_string_table_section_index { 0 }; // .dynstr
-    unsigned m_dynamic_section_index { 0 };              // .dynamic
-    unsigned m_dynamic_relocation_section_index { 0 };   // .rel.dyn
+    unsigned m_dynamic_section_index { 0 };
 };
 
 template<typename F>
@@ -318,27 +226,9 @@ inline void ELFImage::RelocationSection::for_each_relocation(F func) const
 }
 
 template<typename F>
-inline void ELFImage::DynamicRelocationSection::for_each_relocation(F func) const
-{
-    for (unsigned i = 0; i < relocation_count(); ++i) {
-        if (func(relocation(i)) == IterationDecision::Break)
-            break;
-    }
-}
-
-template<typename F>
 inline void ELFImage::for_each_symbol(F func) const
 {
     for (unsigned i = 0; i < symbol_count(); ++i) {
-        if (func(symbol(i)) == IterationDecision::Break)
-            break;
-    }
-}
-
-template<typename F>
-inline void ELFImage::for_each_dynamic_symbol(F func) const
-{
-    for (unsigned i = 0; i < dynamic_symbol_count(); ++i) {
         if (func(symbol(i)) == IterationDecision::Break)
             break;
     }
@@ -349,17 +239,4 @@ inline void ELFImage::for_each_program_header(F func) const
 {
     for (unsigned i = 0; i < program_header_count(); ++i)
         func(program_header(i));
-}
-
-template<typename F>
-inline void ELFImage::DynamicSection::for_each_dynamic_entry(F func) const
-{
-    auto* dyns = reinterpret_cast<const Elf32_Dyn*>(m_image.raw_data(offset()));
-    for (unsigned i = 0;; ++i) {
-        auto&& dyn = DynamicSectionEntry(m_image, dyns[i]);
-        if (dyn.tag() == DT_NULL)
-            break;
-        if (func(dyn) == IterationDecision::Break)
-            break;
-    }
 }


### PR DESCRIPTION
Separate some responsibilities:

ELFDynamicLoader is responsible for loading elf binaries from disk and
performing relocations, calling init functions, and eventually calling
finalizer functions.

ELFDynamicObject is a helper class to parse the .dynamic section of an
elf binary, or the table of Elf32_Dyn entries at the _DYNAMIC symbol.
ELFDynamicObject now owns the helper classes for Relocations, Symbols,
Sections and the like that ELFDynamicLoader will use to perform
relocations and symbol lookup.

Because these new helpers are constructed from offsets into the .dynamic
section within the loaded .data section of the binary, we don't need the
ELFImage for nearly as much of the loading processes as we did before.
Therefore we can remove most of the extra DynamicXXX classes and just
keep the one that lets us find the location of _DYNAMIC in the new ELF.

And finally, since we changed the name of the class that dlopen/dlsym
care about, we need to compile/link and use the new ELFDynamicLoader
class in LibC.