### PR TITLE
Base: Space out some names in app files

### DIFF
--- a/Base/res/apps/DisplayProperties.af
+++ b/Base/res/apps/DisplayProperties.af
@@ -1,5 +1,5 @@
 [App]
-Name=DisplayProperties
+Name=Display Properties
 Executable=/bin/DisplayProperties
 Category=Graphics
 

--- a/Base/res/apps/FileManager.af
+++ b/Base/res/apps/FileManager.af
@@ -1,5 +1,5 @@
 [App]
-Name=FileManager
+Name=File Manager
 Executable=/bin/FileManager
 Category=Utilities
 

--- a/Base/res/apps/FontEditor.af
+++ b/Base/res/apps/FontEditor.af
@@ -1,5 +1,5 @@
 [App]
-Name=FontEditor
+Name=Font Editor
 Executable=/bin/FontEditor
 Category=Development
 

--- a/Base/res/apps/HexEditor.af
+++ b/Base/res/apps/HexEditor.af
@@ -1,5 +1,5 @@
 [App]
-Name=HexEditor
+Name=Hex Editor
 Executable=/bin/HexEditor
 Category=Development
 

--- a/Base/res/apps/IRCClient.af
+++ b/Base/res/apps/IRCClient.af
@@ -1,5 +1,5 @@
 [App]
-Name=IRCClient
+Name=IRC Client
 Executable=/bin/IRCClient
 Category=Internet
 

--- a/Base/res/apps/SystemMonitor.af
+++ b/Base/res/apps/SystemMonitor.af
@@ -1,5 +1,5 @@
 [App]
-Name=SystemMonitor
+Name=System Monitor
 Executable=/bin/SystemMonitor
 Category=Utilities
 

--- a/Base/res/apps/TextEditor.af
+++ b/Base/res/apps/TextEditor.af
@@ -1,5 +1,5 @@
 [App]
-Name=TextEditor
+Name=Text Editor
 Executable=/bin/TextEditor
 Category=Utilities
 

--- a/Base/res/apps/VisualBuilder.af
+++ b/Base/res/apps/VisualBuilder.af
@@ -1,5 +1,5 @@
 [App]
-Name=VisualBuilder
+Name=Visual Builder
 Executable=/bin/VisualBuilder
 Category=Development
 


### PR DESCRIPTION
It's a simple change which makes the menus a bit nicer to look at when applications with spaced out names in MenuBar / AboutDialogs also match in the main menu :p
### Preview
![Spaced out app names preview](https://i.imgur.com/30MJKh5.png)