### PR TITLE
Documentation: Suggest installing gcc 9 on Ubuntu since PPA doesn't have 8 anymore

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -10,8 +10,8 @@ sudo apt install build-essential curl libmpfr-dev libmpc-dev libgmp-dev e2fsprog
 Ensure your gcc version is >= 8 with `gcc --version`. Otherwise, install it (on Ubuntu) with:
 ```bash
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-sudo apt-get install gcc-8 g++-8
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
+sudo apt-get install gcc-9 g++-9
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 ```
 
 ### macOS prerequisites


### PR DESCRIPTION
Hello!

I just managed to build & run Serenity OS from an Ubuntu 18.04 live USB key. Very cool!

It seems the build instructions need to be updated to suggest installing `gcc-9` rather than `gcc-8`, as the PPA doesn't have `gcc-8` (anymore?). I also changed the priority from `800` to `900`... it's more of a guess, I don't know if that's appropriate... but it didn't hurt!

Hope that's helpful. Keep up the cool work!