### PR TITLE
WindowServer: Move menu related code from WindowManager to MenuManager

### DIFF
--- a/MenuApplets/Clock/main.cpp
+++ b/MenuApplets/Clock/main.cpp
@@ -46,7 +46,7 @@ private:
             tm->tm_hour,
             tm->tm_min,
             tm->tm_sec);
-     
+
         GPainter painter(*this);
         painter.fill_rect(event.rect(), palette().window());
         painter.draw_text(event.rect(), time_text, Font::default_font(), TextAlignment::Center, palette().window_text());
@@ -69,7 +69,7 @@ int main(int argc, char** argv)
     window->set_window_type(GWindowType::MenuApplet);
 
     auto widget = ClockWidget::construct();
-    
+
     window->resize(widget->get_width(), 16);
     window->set_main_widget(widget);
     window->show();

--- a/Servers/WindowServer/WSClientConnection.cpp
+++ b/Servers/WindowServer/WSClientConnection.cpp
@@ -85,7 +85,7 @@ OwnPtr<WindowServer::DestroyMenubarResponse> WSClientConnection::handle(const Wi
         return nullptr;
     }
     auto& menubar = *(*it).value;
-    WSWindowManager::the().close_menubar(menubar);
+    WSWindowManager::the().menu_manager().close_menubar(menubar);
     m_menubars.remove(it);
     return make<WindowServer::DestroyMenubarResponse>();
 }

--- a/Servers/WindowServer/WSMenu.cpp
+++ b/Servers/WindowServer/WSMenu.cpp
@@ -127,7 +127,7 @@ WSWindow& WSMenu::ensure_menu_window()
 void WSMenu::draw()
 {
     auto palette = WSWindowManager::the().palette();
-    m_theme_index_at_last_paint = WSWindowManager::the().theme_index();
+    m_theme_index_at_last_paint = WSWindowManager::the().menu_manager().theme_index();
 
     ASSERT(menu_window());
     ASSERT(menu_window()->backing_store());
@@ -279,7 +279,7 @@ void WSMenu::close()
 
 void WSMenu::redraw_if_theme_changed()
 {
-    if (m_theme_index_at_last_paint != WSWindowManager::the().theme_index())
+    if (m_theme_index_at_last_paint != WSWindowManager::the().menu_manager().theme_index())
         redraw();
 }
 

--- a/Servers/WindowServer/WSMenuItem.cpp
+++ b/Servers/WindowServer/WSMenuItem.cpp
@@ -48,5 +48,5 @@ WSMenu* WSMenuItem::submenu()
     ASSERT(is_submenu());
     if (m_menu.client())
         return m_menu.client()->find_menu_by_id(m_submenu_id);
-    return WSWindowManager::the().find_internal_menu_by_id(m_submenu_id);
+    return WSWindowManager::the().menu_manager().find_internal_menu_by_id(m_submenu_id);
 }

--- a/Servers/WindowServer/WSWindowManager.h
+++ b/Servers/WindowServer/WSWindowManager.h
@@ -20,7 +20,6 @@
 #include <WindowServer/WSWindowType.h>
 
 class WSScreen;
-class WSMenuBar;
 class WSMouseEvent;
 class WSClientWantsToPaintMessage;
 class WSWindow;
@@ -99,9 +98,6 @@ public:
     const WSMenuManager& menu_manager() const { return m_menu_manager; }
 
     Rect menubar_rect() const;
-    WSMenuBar* current_menubar() { return m_current_menubar.ptr(); }
-    void set_current_menubar(WSMenuBar*);
-    WSMenu* system_menu() { return m_system_menu.ptr(); }
 
     const WSCursor& active_cursor() const;
     const WSCursor& arrow_cursor() const { return *m_arrow_cursor; }
@@ -126,9 +122,6 @@ public:
     const Font& menu_font() const;
     const Font& app_menu_font() const;
 
-    void close_menu(WSMenu&);
-    void close_menubar(WSMenuBar&);
-    Color menu_selection_color() const { return m_menu_selection_color; }
     int menubar_menu_margin() const;
 
     void set_resolution(int width, int height);
@@ -156,18 +149,7 @@ public:
     const WSWindow* active_fullscreen_window() const { return (m_active_window && m_active_window->is_fullscreen()) ? m_active_window : nullptr; }
     WSWindow* active_fullscreen_window() { return (m_active_window && m_active_window->is_fullscreen()) ? m_active_window : nullptr; }
 
-    template<typename Callback>
-    void for_each_active_menubar_menu(Callback callback)
-    {
-        if (callback(*m_system_menu) == IterationDecision::Break)
-            return;
-        if (m_current_menubar)
-            m_current_menubar->for_each_menu(callback);
-    }
-
-    WSMenu* find_internal_menu_by_id(int);
-
-    int theme_index() const { return m_theme_index; }
+    void update_theme(String theme_path, String theme_name);
 
 private:
     NonnullRefPtr<WSCursor> get_cursor(const String& name);
@@ -276,11 +258,6 @@ private:
 
     u8 m_keyboard_modifiers { 0 };
 
-    RefPtr<WSMenu> m_system_menu;
-    Color m_menu_selection_color;
-    WeakPtr<WSMenuBar> m_current_menubar;
-
-    int m_theme_index { 0 };
 
     WSWindowSwitcher m_switcher;
     WSMenuManager m_menu_manager;
@@ -291,22 +268,6 @@ private:
     NonnullRefPtr<PaletteImpl> m_palette;
 
     RefPtr<CConfigFile> m_wm_config;
-
-    struct AppMetadata {
-        String executable;
-        String name;
-        String icon_path;
-        String category;
-    };
-    Vector<AppMetadata> m_apps;
-    HashMap<String, NonnullRefPtr<WSMenu>> m_app_category_menus;
-
-    struct ThemeMetadata {
-        String name;
-        String path;
-    };
-    Vector<ThemeMetadata> m_themes;
-    RefPtr<WSMenu> m_themes_menu;
 
     WeakPtr<WSClientConnection> m_dnd_client;
     String m_dnd_text;


### PR DESCRIPTION
Working on this in relation to #1005, but making a separate PR to lower the diff on that. These changes are effectively just copy pasting some menu related code from the WindowManager to the MenuManager. No actual functionality should have been changed.

Menus should now only be exposed in the menu manager. It's not perfect, but hopefully a little nicer to work with. 