### PR TITLE
GItemView improvements

### DIFF
--- a/Libraries/LibGUI/GItemView.cpp
+++ b/Libraries/LibGUI/GItemView.cpp
@@ -124,6 +124,8 @@ void GItemView::mousedown_event(GMouseEvent& event)
             auto index = model()->index(item_index, m_model_column);
             if (event.modifiers() & Mod_Ctrl)
                 selection().toggle(index);
+            else if (selection().size() > 1)
+                m_might_drag = true;
             else
                 selection().set(index);
         }
@@ -138,6 +140,12 @@ void GItemView::mouseup_event(GMouseEvent& event)
         m_rubber_banding = false;
         update();
         return;
+    }
+    int item_index = item_at_event_position(event.position());
+    auto index = model()->index(item_index, m_model_column);
+    if((selection().size() > 1) & m_might_drag) {
+        selection().set(index);
+        m_might_drag = false;
     }
     GAbstractView::mouseup_event(event);
 }

--- a/Libraries/LibGUI/GItemView.cpp
+++ b/Libraries/LibGUI/GItemView.cpp
@@ -172,10 +172,15 @@ void GItemView::mousemove_event(GMouseEvent& event)
 
             StringBuilder text_builder;
             StringBuilder data_builder;
+            int index_iterations = 0;
             selection().for_each_index([&](auto& index) {
+                index_iterations++;
                 auto text_data = model()->data(index);
+                if (index_iterations == 0)
+                    text_builder.append(" ");
                 text_builder.append(text_data.to_string());
-                text_builder.append(" ");
+                if (!(index_iterations == selection().size()))
+                    text_builder.append(", ");
 
                 auto drag_data = model()->data(index, GModel::Role::DragData);
                 data_builder.append(drag_data.to_string());

--- a/Libraries/LibGUI/GItemView.h
+++ b/Libraries/LibGUI/GItemView.h
@@ -48,6 +48,8 @@ private:
     int m_visual_column_count { 0 };
     int m_visual_row_count { 0 };
 
+    bool m_might_drag { false };
+
     Point m_left_mousedown_position;
 
     Size m_effective_item_size { 80, 80 };


### PR DESCRIPTION
This PR has two parts

1. Allow dragging multiple items when multiple are selected. Previously even if multiple files where selected clicking on one and dragging would deselect the others instead of dragging all of them. This should **close: #1028** 
2. Some formatting changes in the file list that is shown when you drag multiple items. What previously looked like this: `little www FileManager.ini ` now looks like: ` little, www, FileManager.ini`. The key differences are space at the beginning separating the list from the icon, commas between items, no trailing space.