### PR TITLE
Fast build mode in ./makeall.sh script

### DIFF
--- a/Kernel/makeall.sh
+++ b/Kernel/makeall.sh
@@ -10,6 +10,18 @@ build_group=$(id -g)
 export build_user
 export build_group
 
+fast_mode=
+while [ "$1" != "" ]; do
+    case $1 in
+        -f | --fast )           fast_mode=1
+                                ;;
+        -h | --help )           echo "-f or --fast: build fast without cleaning or running tests"
+                                exit 0
+                                ;;
+    esac
+    shift
+done
+
 sudo id
 
 MAKE=make
@@ -18,8 +30,14 @@ if [ "$(uname -s)" = "OpenBSD" ]; then
 	MAKE=gmake
 fi
 
-$MAKE -C ../ clean && \
+if [ $fast_mode = 1 ]; then
     $MAKE -C ../ && \
-    $MAKE -C ../ test && \
-    $MAKE -C ../ install &&
-    sudo -E PATH="$PATH" ./build-image-qemu.sh
+        $MAKE -C ../ install &&
+        sudo -E PATH="$PATH" ./build-image-qemu.sh
+else
+    $MAKE -C ../ clean && \
+        $MAKE -C ../ && \
+        $MAKE -C ../ test && \
+        $MAKE -C ../ install &&
+        sudo -E PATH="$PATH" ./build-image-qemu.sh
+fi


### PR DESCRIPTION
Passing the "-f" or "--fast" option to the ./makeall.sh script will build and install everything without cleaning first, and then will skip tests. This won't always work when make doesn't understand what depends on what but for some things (like editing a library and quickly rebuilding its dependent applications) its pretty nice. 