### PR TITLE
LibELF: Workaround lack of MAP_PRIVATE mmap by mapping .text MAP_SHARED

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -336,6 +336,9 @@ void* Process::sys$mmap(const Syscall::SC_mmap_params* user_params)
             return (void*)-EINVAL;
         if (static_cast<size_t>(offset) & ~PAGE_MASK)
             return (void*)-EINVAL;
+        // FIXME: Implement MAP_PRIVATE for FileDescription-backed mmap
+        if (map_private)
+            return (void*)-ENOTSUP;
         auto description = file_description(fd);
         if (!description)
             return (void*)-EBADF;

--- a/Libraries/LibELF/ELFDynamicLoader.h
+++ b/Libraries/LibELF/ELFDynamicLoader.h
@@ -86,4 +86,5 @@ private:
     size_t m_text_segment_size;
 
     VirtualAddress m_tls_segment_address;
+    VirtualAddress m_dynamic_section_address;
 };

--- a/Libraries/LibELF/ELFDynamicObject.cpp
+++ b/Libraries/LibELF/ELFDynamicObject.cpp
@@ -8,9 +8,9 @@
 
 static const char* name_for_dtag(Elf32_Sword d_tag);
 
-ELFDynamicObject::ELFDynamicObject(VirtualAddress base_address, u32 dynamic_offset)
+ELFDynamicObject::ELFDynamicObject(VirtualAddress base_address, VirtualAddress dynamic_section_addresss)
     : m_base_address(base_address)
-    , m_dynamic_offset(dynamic_offset)
+    , m_dynamic_address(dynamic_section_addresss)
 {
     parse();
 }
@@ -32,7 +32,7 @@ void ELFDynamicObject::dump() const
         return IterationDecision::Continue;
     });
 
-    dbgprintf("Dynamic section at offset 0x%x contains %zu entries:\n", m_dynamic_offset, num_dynamic_sections);
+    dbgprintf("Dynamic section at address 0x%x contains %zu entries:\n", m_dynamic_address.as_ptr(), num_dynamic_sections);
     dbgprintf(builder.to_string().characters());
 }
 

--- a/Libraries/LibELF/ELFDynamicObject.h
+++ b/Libraries/LibELF/ELFDynamicObject.h
@@ -6,7 +6,7 @@
 
 class ELFDynamicObject {
 public:
-    explicit ELFDynamicObject(VirtualAddress base_address, u32 dynamic_offset);
+    explicit ELFDynamicObject(VirtualAddress base_address, VirtualAddress dynamic_section_address);
     ~ELFDynamicObject();
     void dump() const;
 
@@ -196,7 +196,7 @@ private:
     void for_each_dynamic_entry(F) const;
 
     VirtualAddress m_base_address;
-    u32 m_dynamic_offset;
+    VirtualAddress m_dynamic_address;
     Symbol m_the_undefined_symbol { *this, 0, {} };
 
     unsigned m_symbol_count { 0 };
@@ -255,7 +255,7 @@ inline void ELFDynamicObject::for_each_symbol(F func) const
 template<typename F>
 inline void ELFDynamicObject::for_each_dynamic_entry(F func) const
 {
-    auto* dyns = reinterpret_cast<const Elf32_Dyn*>(m_base_address.offset(m_dynamic_offset).as_ptr());
+    auto* dyns = reinterpret_cast<const Elf32_Dyn*>(m_dynamic_address.as_ptr());
     for (unsigned i = 0;; ++i) {
         auto&& dyn = DynamicEntry(dyns[i]);
         if (dyn.tag() == DT_NULL)

--- a/Libraries/LibELF/ELFImage.cpp
+++ b/Libraries/LibELF/ELFImage.cpp
@@ -117,10 +117,6 @@ bool ELFImage::parse()
             if (StringView(".strtab") == section_header_table_string(sh.sh_name))
                 m_string_table_section_index = i;
         }
-        if (sh.sh_type == SHT_DYNAMIC) {
-            ASSERT(!m_dynamic_section_index || m_dynamic_section_index == i);
-            m_dynamic_section_index = i;
-        }
     }
 
     // Then create a name-to-index map.
@@ -217,10 +213,4 @@ const ELFImage::Section ELFImage::lookup_section(const String& name) const
     if (auto it = m_sections.find(name); it != m_sections.end())
         return section((*it).value);
     return section(0);
-}
-
-const ELFImage::DynamicSection ELFImage::dynamic_section() const
-{
-    ASSERT(is_dynamic());
-    return section(m_dynamic_section_index);
 }

--- a/Libraries/LibELF/ELFImage.h
+++ b/Libraries/LibELF/ELFImage.h
@@ -27,7 +27,6 @@ public:
     class RelocationSection;
     class Symbol;
     class Relocation;
-    class DynamicSection;
 
     class Symbol {
     public:
@@ -111,8 +110,6 @@ public:
 
     protected:
         friend class RelocationSection;
-        friend class DynamicSection;
-        friend class DynamicRelocationSection;
         const ELFImage& m_image;
         const Elf32_Shdr& m_section_header;
         unsigned m_section_index;
@@ -150,24 +147,13 @@ public:
         const Elf32_Rel& m_rel;
     };
 
-    class DynamicSection : public Section {
-    public:
-        DynamicSection(const Section& section)
-            : Section(section.m_image, section.m_section_index)
-        {
-            ASSERT(type() == SHT_DYNAMIC);
-        }
-    };
-
     unsigned symbol_count() const;
-    unsigned dynamic_symbol_count() const;
     unsigned section_count() const;
     unsigned program_header_count() const;
 
     const Symbol symbol(unsigned) const;
     const Section section(unsigned) const;
     const ProgramHeader program_header(unsigned const) const;
-    const DynamicSection dynamic_section() const;
 
     template<typename F>
     void for_each_section(F) const;
@@ -204,7 +190,6 @@ private:
     bool m_valid { false };
     unsigned m_symbol_table_section_index { 0 };
     unsigned m_string_table_section_index { 0 };
-    unsigned m_dynamic_section_index { 0 };
 };
 
 template<typename F>


### PR DESCRIPTION
https://github.com/SerenityOS/serenity/issues/1045

This doesn't fully resolve the issue, but it makes it so user's don't expect their private mapping to be truly private while it still relys on the underlying file handle
Someone still needs to implement MAP_PRIVATE for Inodes to fully close it.