### PR TITLE
WindowServer: Small menu key improvements

### DIFF
--- a/Servers/WindowServer/WSMenuManager.cpp
+++ b/Servers/WindowServer/WSMenuManager.cpp
@@ -389,18 +389,16 @@ void WSMenuManager::open_menu(WSMenu& menu)
 
 void WSMenuManager::set_current_menu(WSMenu* menu, bool is_submenu)
 {
-    if (!is_submenu && m_current_menu)
-        m_current_menu->close();
-    if (menu)
-        m_current_menu = menu->make_weak_ptr();
-
-    if (!is_submenu) {
+    if (!is_submenu)
         close_everyone();
-        if (menu)
-            m_open_menu_stack.append(menu->make_weak_ptr());
-    } else {
-        m_open_menu_stack.append(menu->make_weak_ptr());
+
+    if (!menu) {
+        m_current_menu = nullptr;
+        return;
     }
+
+    m_open_menu_stack.append(menu->make_weak_ptr());
+    m_current_menu = menu->make_weak_ptr();
 }
 
 void WSMenuManager::close_bar()

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -940,6 +940,18 @@ void WSWindowManager::event(CEvent& event)
             return;
         }
 
+        if (key_event.type() == WSEvent::KeyUp && key_event.key() == Key_Logo && !m_switcher.is_visible()) {
+            WSMenuManager::the().open_menu(WSMenuManager::the().system_menu());
+            return;
+        }
+
+        if (key_event.type() == WSEvent::KeyUp && key_event.key() == Key_Escape) {
+            auto current_menu = WSMenuManager::the().current_menu();
+            if (current_menu)
+                WSMenuManager::the().close_everyone();
+            return;
+        }
+
         if (key_event.type() == WSEvent::KeyDown && ((key_event.modifiers() == Mod_Logo && key_event.key() == Key_Tab) || (key_event.modifiers() == (Mod_Logo | Mod_Shift) && key_event.key() == Key_Tab)))
             m_switcher.show();
         if (m_switcher.is_visible()) {
@@ -989,13 +1001,8 @@ void WSWindowManager::event(CEvent& event)
             return;
         }
 
-        // FIXME: I would prefer to be WSEvent::KeyUp, and be at the top of this function
-        // However, the modifier is Invalid of Mod_Logo for a keyup event. Move after a fix is made.
-        if (key_event.type() == WSEvent::KeyDown && key_event.modifiers() == Mod_Logo) {
-            WSMenuManager::the().open_menu(WSMenuManager::the().system_menu());
-            return;
-        }
-
+        // FIXME: We should send events to the MenuManager if a window is open
+        // This should take priority over sending to a window.
         WSMenuManager::the().dispatch_event(event);
     }
 


### PR DESCRIPTION
The system menu can now be opened by pressing the window key even while
in a focused window. The current menu can also now be closed by pressing
escape.

We still cannot navigate a menu using arrow keys while there is an
active window, but this is another small step towards that.

