### PR TITLE
Kernel+LibELF: Enable loading ELF binaries with ELF interpreter sections.

### DIFF
--- a/AK/ScopeGuard.h
+++ b/AK/ScopeGuard.h
@@ -21,6 +21,28 @@ private:
     Callback m_callback;
 };
 
+template<typename Callback>
+class ArmedScopeGuard {
+public:
+    ArmedScopeGuard(Callback callback)
+        : m_callback(move(callback))
+    {
+    }
+
+    ~ArmedScopeGuard()
+    {
+        if (m_armed)
+            m_callback();
+    }
+
+    void disarm() { m_armed = false; }
+
+private:
+    Callback m_callback;
+    bool m_armed { true };
+};
+
 }
 
 using AK::ScopeGuard;
+using AK::ArmedScopeGuard;

--- a/Demos/DynamicLink/LinkDemo/Makefile
+++ b/Demos/DynamicLink/LinkDemo/Makefile
@@ -3,4 +3,7 @@ OBJS = \
 
 PROGRAM = LinkDemo
 
+SUBPROJECT_CXXFLAGS = -fPIC
+LDFLAGS = -pie -Wl,--dynamic-linker=/lib/ld-elf.so
+
 include ../../../Makefile.common

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -1,4 +1,5 @@
 #include <AK/FileSystemPath.h>
+#include <AK/ScopeGuard.h>
 #include <AK/StdLibExtras.h>
 #include <AK/StringBuilder.h>
 #include <AK/Time.h>
@@ -633,9 +634,10 @@ pid_t Process::sys$fork(RegisterDump& regs)
     return child->pid();
 }
 
-int Process::do_exec(String path, Vector<String> arguments, Vector<String> environment)
+int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Vector<String> arguments, Vector<String> environment, RefPtr<FileDescription> interpreter_description)
 {
     ASSERT(is_ring3());
+    auto path = main_program_description->absolute_path();
 
     dbgprintf("%s(%d) do_exec(%s): thread_count() = %d\n", m_name.characters(), m_pid, path.characters(), thread_count());
     // FIXME(Thread): Kill any threads the moment we commit to the exec().
@@ -665,15 +667,6 @@ int Process::do_exec(String path, Vector<String> arguments, Vector<String> envir
     if (parts.is_empty())
         return -ENOENT;
 
-    auto result = VFS::the().open(path, O_EXEC, 0, current_directory());
-    if (result.is_error())
-        return result.error();
-    auto description = result.value();
-    auto metadata = description->metadata();
-
-    if (!metadata.size)
-        return -ENOTIMPL;
-
     u32 entry_eip = 0;
     // FIXME: Is there a race here?
     auto old_page_directory = move(m_page_directory);
@@ -683,9 +676,37 @@ int Process::do_exec(String path, Vector<String> arguments, Vector<String> envir
 #endif
     ProcessPagingScope paging_scope(*this);
 
-    ASSERT(description->inode());
-    auto vmobject = InodeVMObject::create_with_inode(*description->inode());
-    auto* region = allocate_region_with_vmobject(VirtualAddress(), metadata.size, vmobject, 0, description->absolute_path(), PROT_READ, false);
+    struct VMObjectAndRegion {
+        NonnullRefPtr<VMObject> vmobject;
+        Region* region;
+    };
+
+    InodeMetadata loader_metadata;
+
+    // FIXME: Hoooo boy this is a hack if I ever saw one.
+    //      This is the 'random' offset we're giving to our ET_DYN exectuables to start as.
+    //      It also happens to be the static Virtual Addresss offset every static exectuable gets :)
+    //      Without this, some assumptions by the ELF loading hooks below are severely broken.
+    //      0x08000000 is a verified random number chosen by random dice roll https://xkcd.com/221/
+    u32 totally_random_offset = interpreter_description ? 0x08000000 : 0;
+
+    auto [vmobject, region] = [&]() {
+        // FIXME: We should be able to load both the PT_INTERP interpreter and the main program... once the RTLD is smart enough
+        if (interpreter_description) {
+            loader_metadata = interpreter_description->metadata();
+            auto vmobject = InodeVMObject::create_with_inode(*interpreter_description->inode());
+            auto region = allocate_region_with_vmobject(VirtualAddress(), loader_metadata.size, vmobject, 0, interpreter_description->absolute_path(), PROT_READ, false);
+            // we don't need the interpreter file desciption after we've loaded (or not) it into memory
+            interpreter_description = nullptr;
+            return VMObjectAndRegion { move(vmobject), region };
+        }
+
+        loader_metadata = main_program_description->metadata();
+        auto vmobject = InodeVMObject::create_with_inode(*main_program_description->inode());
+        auto region = allocate_region_with_vmobject(VirtualAddress(), loader_metadata.size, vmobject, 0, main_program_description->absolute_path(), PROT_READ, false);
+        return VMObjectAndRegion { move(vmobject), region };
+    }();
+
     ASSERT(region);
 
     // NOTE: We yank this out of 'm_regions' since we're about to manipulate the vector
@@ -701,7 +722,22 @@ int Process::do_exec(String path, Vector<String> arguments, Vector<String> envir
         // Okay, here comes the sleight of hand, pay close attention..
         auto old_regions = move(m_regions);
         m_regions.append(move(executable_region));
-        loader = make<ELFLoader>(region->vaddr().as_ptr(), metadata.size);
+
+        ArmedScopeGuard rollback_regions_guard([&]() {
+            m_page_directory = move(old_page_directory);
+            ASSERT(&current->process() == this);
+            MM.enter_process_paging_scope(*this);
+            executable_region = m_regions.take_first();
+            m_regions = move(old_regions);
+        });
+
+        loader = make<ELFLoader>(region->vaddr().as_ptr(), loader_metadata.size);
+
+        // Load the correct executable -- either interp or main program.
+        // FIXME: Once we actually load both interp and main, we'll need to be more clever about this.
+        //     In that case, both will be ET_DYN objects, so they'll both be completely relocatable.
+        //     That means, we can put them literally anywhere in User VM space (ASLR anyone?).
+        // ALSO FIXME: Reminder to really really fix that 'totally random offset' business.
         loader->map_section_hook = [&](VirtualAddress vaddr, size_t size, size_t alignment, size_t offset_in_image, bool is_readable, bool is_writable, bool is_executable, const String& name) -> u8* {
             ASSERT(size);
             ASSERT(alignment == PAGE_SIZE);
@@ -712,9 +748,9 @@ int Process::do_exec(String path, Vector<String> arguments, Vector<String> envir
                 prot |= PROT_WRITE;
             if (is_executable)
                 prot |= PROT_EXEC;
-            if (!allocate_region_with_vmobject(vaddr, size, vmobject, offset_in_image, String(name), prot))
-                return nullptr;
-            return vaddr.as_ptr();
+            if (auto* region = allocate_region_with_vmobject(vaddr.offset(totally_random_offset), size, vmobject, offset_in_image, String(name), prot))
+                return region->vaddr().as_ptr();
+            return nullptr;
         };
         loader->alloc_section_hook = [&](VirtualAddress vaddr, size_t size, size_t alignment, bool is_readable, bool is_writable, const String& name) -> u8* {
             ASSERT(size);
@@ -724,10 +760,17 @@ int Process::do_exec(String path, Vector<String> arguments, Vector<String> envir
                 prot |= PROT_READ;
             if (is_writable)
                 prot |= PROT_WRITE;
-            if (!allocate_region(vaddr, size, String(name), prot))
-                return nullptr;
-            return vaddr.as_ptr();
+            if (auto* region = allocate_region(vaddr.offset(totally_random_offset), size, String(name), prot)) 
+                return region->vaddr().as_ptr();
+            return nullptr;
         };
+
+        // FIXME: Move TLS region allocation to userspace: LibC and the dynamic loader.
+        //     LibC if we end up with a statically linked executable, and the
+        //     dynamic loader so that it can create new TLS blocks for each shared libarary
+        //     that gets loaded as part of DT_NEEDED processing, and via dlopen()
+        //     If that doesn't happen quickly, at least pass the location of the TLS region
+        //     some ELF Auxilliary Vector so the loader can use it/create new ones as necessary.
         loader->tls_section_hook = [&](size_t size, size_t alignment) {
             ASSERT(size);
             master_tls_region = allocate_region({}, size, String(), PROT_READ | PROT_WRITE);
@@ -736,19 +779,22 @@ int Process::do_exec(String path, Vector<String> arguments, Vector<String> envir
             return master_tls_region->vaddr().as_ptr();
         };
         bool success = loader->load();
-        if (!success || !loader->entry().get()) {
-            m_page_directory = move(old_page_directory);
-            // FIXME: RAII this somehow instead.
-            ASSERT(&current->process() == this);
-            MM.enter_process_paging_scope(*this);
-            executable_region = m_regions.take_first();
-            m_regions = move(old_regions);
+        if (!success) {
             kprintf("do_exec: Failure loading %s\n", path.characters());
             return -ENOEXEC;
         }
+        // FIXME: Validate that this virtual address is within executable region,
+        //     instead of just non-null. You could totally have a DSO with entry point of
+        //     the beginning of the text segement.
+        if (!loader->entry().offset(totally_random_offset).get()) {
+            kprintf("do_exec: Failure loading %s, entry pointer is invalid! (%p)",  path.characters(), loader->entry().offset(totally_random_offset).get());
+            return -ENOEXEC;
+        }
+
+        rollback_regions_guard.disarm();
 
         // NOTE: At this point, we've committed to the new executable.
-        entry_eip = loader->entry().get();
+        entry_eip = loader->entry().offset(totally_random_offset).get();
 
 #ifdef EXEC_DEBUG
         kprintf("Memory layout after ELF load:");
@@ -757,18 +803,20 @@ int Process::do_exec(String path, Vector<String> arguments, Vector<String> envir
     }
 
     m_elf_loader = move(loader);
-    m_executable = description->custody();
+    m_executable = main_program_description->custody();
 
     m_promises = m_execpromises;
 
     // Copy of the master TLS region that we will clone for new threads
     m_master_tls_region = master_tls_region;
 
-    if (!(description->custody()->mount_flags() & MS_NOSUID)) {
-        if (metadata.is_setuid())
-            m_euid = metadata.uid;
-        if (metadata.is_setgid())
-            m_egid = metadata.gid;
+    auto main_program_metadata = main_program_description->metadata();
+
+    if (!(main_program_description->custody()->mount_flags() & MS_NOSUID)) {
+        if (main_program_metadata.is_setuid())
+            m_euid = main_program_metadata.uid;
+        if (main_program_metadata.is_setgid())
+            m_egid = main_program_metadata.gid;
     }
 
     current->set_default_signal_dispositions();
@@ -847,25 +895,8 @@ int Process::do_exec(String path, Vector<String> arguments, Vector<String> envir
     return 0;
 }
 
-KResultOr<Vector<String>> Process::find_shebang_interpreter_for_executable(const String& executable_path)
+static KResultOr<Vector<String>> find_shebang_interpreter_for_executable(const char first_page[], int nread)
 {
-    // FIXME: It's a bit sad that we'll open the executable twice (in case there's no shebang)
-    //        Maybe we can find a way to plumb this opened FileDescription to the rest of the
-    //        exec implementation..
-    auto result = VFS::the().open(executable_path, 0, 0, current_directory());
-    if (result.is_error())
-        return result.error();
-    auto description = result.value();
-    auto metadata = description->metadata();
-
-    if (!metadata.may_execute(*this))
-        return KResult(-EACCES);
-
-    if (metadata.size < 3)
-        return KResult(-ENOEXEC);
-
-    char first_page[PAGE_SIZE];
-    int nread = description->read((u8*)&first_page, sizeof(first_page));
     int word_start = 2;
     int word_length = 0;
     if (nread > 2 && first_page[0] == '#' && first_page[1] == '!') {
@@ -899,23 +930,138 @@ KResultOr<Vector<String>> Process::find_shebang_interpreter_for_executable(const
     return KResult(-ENOEXEC);
 }
 
-int Process::exec(String path, Vector<String> arguments, Vector<String> environment)
+KResultOr<NonnullRefPtr<FileDescription>> Process::find_elf_interpreter_for_executable(const String& path, char (&first_page)[PAGE_SIZE], int nread, size_t file_size)
 {
-    auto result = find_shebang_interpreter_for_executable(path);
-    if (!result.is_error()) {
-        Vector<String> new_arguments(result.value());
+    if (nread < (int)sizeof(Elf32_Ehdr))
+        return KResult(-ENOEXEC);
+
+    auto elf_header = (Elf32_Ehdr*)first_page;
+    if (!ELFImage::validate_elf_header(*elf_header, file_size)) {
+        dbgprintf("%s(%d) exec(%s): File has invalid ELF header\n", m_name.characters(), m_pid, path.characters());
+        return KResult(-ENOEXEC);
+    }
+
+    // Not using KResultOr here because we'll want to do the same thing in userspace in the RTLD
+    String interpreter_path;
+    if (!ELFImage::validate_program_headers(*elf_header, file_size, (u8*)first_page, nread, interpreter_path)) {
+        dbgprintf("%s(%d) exec(%s): File has invalid ELF Program headers\n", m_name.characters(), m_pid, path.characters());
+        return KResult(-ENOEXEC);
+    }
+
+    if (!interpreter_path.is_empty()) {
+        // Programs with an interpreter better be relocatable executables or we don't know what to do...
+        if (elf_header->e_type != ET_DYN)
+            return KResult(-ENOEXEC);
+
+        dbgprintf("%s(%d) exec(%s): Using program interpreter %s\n", m_name.characters(), m_pid, path.characters(), interpreter_path.characters());
+        auto interp_result = VFS::the().open(interpreter_path, O_EXEC, 0, current_directory());
+        if (interp_result.is_error()) {
+            dbgprintf("%s(%d) exec(%s): Unable to open program interpreter %s\n", m_name.characters(), m_pid, path.characters(), interpreter_path.characters());
+            return interp_result.error();
+        }
+        auto interpreter_description = interp_result.value();
+        auto interp_metadata = interpreter_description->metadata();
+
+        ASSERT(interpreter_description->inode());
+
+        // Validate the program interpreter as a valid elf binary.
+        // If your program interpreter is a #! file or something, it's time to stop playing games :)
+        if (interp_metadata.size < (int)sizeof(Elf32_Ehdr))
+            return KResult(-ENOEXEC);
+
+        memset(first_page, 0, sizeof(first_page));
+        nread = interpreter_description->read((u8*)&first_page, sizeof(first_page));
+
+        if (nread < (int)sizeof(Elf32_Ehdr))
+            return KResult(-ENOEXEC);
+
+        elf_header = (Elf32_Ehdr*)first_page;
+        if (!ELFImage::validate_elf_header(*elf_header, interp_metadata.size)) {
+            dbgprintf("%s(%d) exec(%s): Interpreter (%s) has invalid ELF header\n", m_name.characters(), m_pid, path.characters(), interpreter_description->absolute_path().characters());
+            return KResult(-ENOEXEC);
+        }
+
+        // Not using KResultOr here because we'll want to do the same thing in userspace in the RTLD
+        String interpreter_interpreter_path;
+        if (!ELFImage::validate_program_headers(*elf_header, interp_metadata.size, (u8*)first_page, nread, interpreter_interpreter_path)) {
+            dbgprintf("%s(%d) exec(%s): Interpreter (%s) has invalid ELF Program headers\n", m_name.characters(), m_pid, path.characters(), interpreter_description->absolute_path().characters());
+            return KResult(-ENOEXEC);
+        }
+
+        if (!interpreter_interpreter_path.is_empty()) {
+            dbgprintf("%s(%d) exec(%s): Interpreter (%s) has its own interpreter (%s)! No thank you!\n",
+                m_name.characters(), m_pid, path.characters(), interpreter_description->absolute_path().characters(), interpreter_interpreter_path.characters());
+            return KResult(-ELOOP);
+        }
+
+        return interpreter_description;
+    }
+
+    if (elf_header->e_type != ET_EXEC) {
+        // We can't exec an ET_REL, that's just an object file from the compiler
+        // If it's ET_DYN with no PT_INTERP, then we can't load it properly either
+        return KResult(-ENOEXEC);
+    }
+
+    // No interpreter, but, path refers to a valid elf image
+    return KResult(KSuccess);
+}
+
+int Process::exec(String path, Vector<String> arguments, Vector<String> environment, int recursion_depth)
+{
+    if (recursion_depth > 2) {
+        dbgprintf("%s(%d) exec(%s): SHENANIGANS! recursed too far trying to find #! interpreter\n", m_name.characters(), m_pid, path.characters());
+        return -ELOOP;
+    }
+
+    // Open the file to check what kind of binary format it is
+    // Currently supported formats:
+    //    - #! interpreted file
+    //    - ELF32
+    //        * ET_EXEC binary that just gets loaded
+    //        * ET_DYN binary that requires a program interpreter
+    //
+    auto result = VFS::the().open(path, O_EXEC, 0, current_directory());
+    if (result.is_error())
+        return result.error();
+    auto description = result.value();
+    auto metadata = description->metadata();
+
+    // Always gonna need at least 3 bytes. these are for #!X
+    if (metadata.size < 3)
+        return -ENOEXEC;
+
+    ASSERT(description->inode());
+
+    // Read the first page of the program into memory so we can validate the binfmt of it
+    char first_page[PAGE_SIZE];
+    int nread = description->read((u8*)&first_page, sizeof(first_page));
+
+    // 1) #! interpreted file
+    auto shebang_result = find_shebang_interpreter_for_executable(first_page, nread);
+    if (!shebang_result.is_error()) {
+        Vector<String> new_arguments(shebang_result.value());
 
         new_arguments.append(path);
 
         arguments.remove(0);
         new_arguments.append(move(arguments));
 
-        return exec(result.value().first(), move(new_arguments), move(environment));
+        return exec(shebang_result.value().first(), move(new_arguments), move(environment), ++recursion_depth);
     }
+
+    // #2) ELF32 for i386
+    auto elf_result = find_elf_interpreter_for_executable(path, first_page, nread, metadata.size);
+    RefPtr<FileDescription> interpreter_description;
+    // We're getting either an interpreter, an error, or KSuccess (i.e. no interpreter but file checks out)
+    if (!elf_result.is_error())
+        interpreter_description = elf_result.value();
+    else if (elf_result.error().is_error())
+        return elf_result.error();
 
     // The bulk of exec() is done by do_exec(), which ensures that all locals
     // are cleaned up by the time we yield-teleport below.
-    int rc = do_exec(move(path), move(arguments), move(environment));
+    int rc = do_exec(move(description), move(arguments), move(environment), move(interpreter_description));
     if (rc < 0)
         return rc;
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -308,7 +308,7 @@ public:
     size_t amount_purgeable_volatile() const;
     size_t amount_purgeable_nonvolatile() const;
 
-    int exec(String path, Vector<String> arguments, Vector<String> environment);
+    int exec(String path, Vector<String> arguments, Vector<String> environment, int recusion_depth = 0);
 
     bool is_superuser() const { return m_euid == 0; }
 
@@ -355,13 +355,13 @@ private:
 
     Range allocate_range(VirtualAddress, size_t);
 
-    int do_exec(String path, Vector<String> arguments, Vector<String> environment);
+    int do_exec(NonnullRefPtr<FileDescription> main_program_description, Vector<String> arguments, Vector<String> environment, RefPtr<FileDescription> interpreter_description);
     ssize_t do_write(FileDescription&, const u8*, int data_size);
+
+    KResultOr<NonnullRefPtr<FileDescription>> find_elf_interpreter_for_executable(const String& path, char (&first_page)[PAGE_SIZE], int nread, size_t file_size);
 
     int alloc_fd(int first_candidate_fd = 0);
     void disown_all_shared_buffers();
-
-    KResultOr<Vector<String>> find_shebang_interpreter_for_executable(const String& executable_path);
 
     KResult do_kill(Process&, int signal);
     KResult do_killpg(pid_t pgrp, int signal);

--- a/Kernel/kstdio.h
+++ b/Kernel/kstdio.h
@@ -18,3 +18,13 @@ int get_serial_debug();
 #ifndef __serenity__
 #define dbgprintf printf
 #endif
+
+#ifdef __cplusplus
+
+template <size_t N>
+inline int dbgputstr(const char (&array)[N])
+{
+    return ::dbgputstr(array, N);
+}
+
+#endif

--- a/Libraries/LibC/Makefile
+++ b/Libraries/LibC/Makefile
@@ -54,7 +54,8 @@ LIBC_OBJS = \
        wchar.o \
        serenity.o \
        syslog.o \
-       cxxabi.o
+       cxxabi.o \
+       libcinit.o
 
 ELF_OBJS = \
         ../LibELF/ELFDynamicObject.o \

--- a/Libraries/LibC/crt0.cpp
+++ b/Libraries/LibC/crt0.cpp
@@ -7,18 +7,10 @@ extern "C" {
 
 int main(int, char**, char**);
 
-__thread int errno;
-char** environ;
-bool __environ_is_malloced;
-
-void __libc_init()
-{
-    void __malloc_init();
-    __malloc_init();
-
-    void __stdio_init();
-    __stdio_init();
-}
+extern void __libc_init();
+extern void _init();
+extern char** environ;
+extern bool __environ_is_malloced;
 
 int _start(int argc, char** argv, char** env)
 {
@@ -27,7 +19,6 @@ int _start(int argc, char** argv, char** env)
 
     __libc_init();
 
-    extern void _init();
     _init();
 
     extern void (*__init_array_start[])(int, char**, char**) __attribute__((visibility("hidden")));
@@ -42,18 +33,5 @@ int _start(int argc, char** argv, char** env)
     exit(status);
 
     return 20150614;
-}
-
-[[noreturn]] void __cxa_pure_virtual()
-{
-    ASSERT_NOT_REACHED();
-}
-
-extern u32 __stack_chk_guard;
-u32 __stack_chk_guard = (u32)0xc0000c13;
-
-[[noreturn]] void __stack_chk_fail()
-{
-    ASSERT_NOT_REACHED();
 }
 }

--- a/Libraries/LibC/libcinit.cpp
+++ b/Libraries/LibC/libcinit.cpp
@@ -1,0 +1,34 @@
+#include <AK/Types.h>
+#include <assert.h>
+
+extern "C" {
+
+__thread int errno;
+char** environ;
+bool __environ_is_malloced;
+
+void __libc_init()
+{
+    void __malloc_init();
+    __malloc_init();
+
+    void __stdio_init();
+    __stdio_init();
+}
+
+[[noreturn]] void __cxa_pure_virtual() __attribute__((weak));
+
+[[noreturn]] void __cxa_pure_virtual()
+{
+    ASSERT_NOT_REACHED();
+}
+
+extern u32 __stack_chk_guard;
+u32 __stack_chk_guard = (u32)0xc0000c13;
+
+[[noreturn]] void __stack_chk_fail()
+{
+    ASSERT_NOT_REACHED();
+}
+
+}

--- a/Libraries/LibELF/ELFImage.cpp
+++ b/Libraries/LibELF/ELFImage.cpp
@@ -64,6 +64,15 @@ void ELFImage::dump() const
     dbgprintf("    phnum:   %u\n", header().e_phnum);
     dbgprintf(" shstrndx:   %u\n", header().e_shstrndx);
 
+    for_each_program_header([&](const ProgramHeader& program_header) {
+        dbgprintf("    Program Header %d: {\n", program_header.index());
+        dbgprintf("        type: %x\n", program_header.type());
+        dbgprintf("      offset: %x\n", program_header.offset());
+        dbgprintf("       flags: %x\n", program_header.flags());
+        dbgprintf("        \n");
+        dbgprintf("    }\n");
+    });
+
     for (unsigned i = 0; i < header().e_shnum; ++i) {
         auto& section = this->section(i);
         dbgprintf("    Section %u: {\n", i);
@@ -100,9 +109,8 @@ unsigned ELFImage::program_header_count() const
 
 bool ELFImage::parse()
 {
-    // We only support i386.
-    if (header().e_machine != 3) {
-        dbgprintf("ELFImage::parse(): e_machine=%u not supported!\n", header().e_machine);
+    if (!validate_elf_header(header(), m_size)) {
+        dbgputstr("ELFImage::parse(): ELF Header not valid\n");
         return false;
     }
 
@@ -213,4 +221,160 @@ const ELFImage::Section ELFImage::lookup_section(const String& name) const
     if (auto it = m_sections.find(name); it != m_sections.end())
         return section((*it).value);
     return section(0);
+}
+
+bool ELFImage::validate_elf_header(const Elf32_Ehdr& elf_header, size_t file_size)
+{
+    if (!IS_ELF(elf_header)) {
+        dbgputstr("File is not an ELF file.\n");
+        return false;
+    }
+
+    if (ELFCLASS32 != elf_header.e_ident[EI_CLASS]) {
+        dbgputstr("File is not a 32 bit ELF file.\n");
+        return false;
+    }
+
+    if (ELFDATA2LSB != elf_header.e_ident[EI_DATA]) {
+        dbgputstr("File is not a little endian ELF file.\n");
+        return false;
+    }
+
+    if (EV_CURRENT != elf_header.e_ident[EI_VERSION]) {
+        dbgprintf("File has unrecognized ELF version (%d), expected (%d)!\n", elf_header.e_ident[EI_VERSION], EV_CURRENT);
+        return false;
+    }
+
+    if (ELFOSABI_SYSV != elf_header.e_ident[EI_OSABI]) {
+        dbgprintf("File has unknown OS ABI (%d), expected SYSV(0)!\n", elf_header.e_ident[EI_OSABI]);
+        return false;
+    }
+
+    if (0 != elf_header.e_ident[EI_ABIVERSION]) {
+        dbgprintf("File has unknown SYSV ABI version (%d)!\n", elf_header.e_ident[EI_ABIVERSION]);
+        return false;
+    }
+
+    if (EM_386 != elf_header.e_machine) {
+        dbgprintf("File has unknown machine (%d), expected i386 (3)!\n", elf_header.e_machine);
+        return false;
+    }
+
+    if (ET_EXEC != elf_header.e_type && ET_DYN != elf_header.e_type && ET_REL != elf_header.e_type) {
+        dbgprintf("File has unloadable ELF type (%d), expected REL (1), EXEC (2) or DYN (3)!\n", elf_header.e_type);
+        return false;
+    }
+
+    if (EV_CURRENT != elf_header.e_version) {
+        dbgprintf("File has unrecognized ELF version (%d), expected (%d)!\n", elf_header.e_version, EV_CURRENT);
+        return false;
+    }
+
+    if (sizeof(Elf32_Ehdr) != elf_header.e_ehsize) {
+        dbgprintf("File has incorrect ELF header size..? (%d), expected (%d)!\n", elf_header.e_ehsize, sizeof(Elf32_Ehdr));
+        return false;
+    }
+
+    if (elf_header.e_phoff > file_size || elf_header.e_shoff > file_size) {
+        dbgprintf("SHENANIGANS! program header offset (%d) or section header offset (%d) are past the end of the file!\n",
+            elf_header.e_phoff, elf_header.e_shoff);
+        return false;
+    }
+
+    if (elf_header.e_phnum != 0 && elf_header.e_phoff != elf_header.e_ehsize) {
+        dbgprintf("File does not have program headers directly after the ELF header? program header offset (%d), expected (%d).\n",
+            elf_header.e_phoff, elf_header.e_ehsize);
+        return false;
+    }
+
+    if (0 != elf_header.e_flags) {
+        dbgprintf("File has incorrect ELF header flags...? (%d), expected (%d).\n", elf_header.e_flags, 0);
+        return false;
+    }
+
+    if (0 != elf_header.e_phnum && sizeof(Elf32_Phdr) != elf_header.e_phentsize) {
+        dbgprintf("File has incorrect program header size..? (%d), expected (%d).\n", elf_header.e_phentsize, sizeof(Elf32_Phdr));
+        return false;
+    }
+
+    if (sizeof(Elf32_Shdr) != elf_header.e_shentsize) {
+        dbgprintf("File has incorrect section header size..? (%d), expected (%d).\n", elf_header.e_shentsize, sizeof(Elf32_Shdr));
+        return false;
+    }
+
+    size_t end_of_last_program_header = elf_header.e_phoff + (elf_header.e_phnum * elf_header.e_phentsize);
+    if (end_of_last_program_header > file_size) {
+        dbgprintf("SHENANIGANS! End of last program header (%d) is past the end of the file!\n", end_of_last_program_header);
+        return false;
+    }
+
+    size_t end_of_last_section_header = elf_header.e_shoff + (elf_header.e_shnum * elf_header.e_shentsize);
+    if (end_of_last_section_header > file_size) {
+        dbgprintf("SHENANIGANS! End of last section header (%d) is past the end of the file!\n", end_of_last_section_header);
+        return false;
+    }
+
+    if (elf_header.e_shstrndx >= elf_header.e_shnum) {
+        dbgprintf("SHENANIGANS! Section header string table index (%d) is not a valid index given we have %d section headers!\n", elf_header.e_shstrndx, elf_header.e_shnum);
+        return false;
+    }
+
+    return true;
+}
+
+bool ELFImage::validate_program_headers(const Elf32_Ehdr& elf_header, size_t file_size, u8* buffer, size_t buffer_size, String& interpreter_path)
+{
+    // Can we actually parse all the program headers in the given buffer?
+    size_t end_of_last_program_header = elf_header.e_phoff + (elf_header.e_phnum * elf_header.e_phentsize);
+    if (end_of_last_program_header > buffer_size) {
+        dbgprintf("Unable to parse program headers from buffer, buffer too small! Buffer size: %zu, End of program headers %zu\n",
+            buffer_size, end_of_last_program_header);
+        return false;
+    }
+
+    if (file_size < buffer_size) {
+        dbgputstr("We somehow read more from a file than was in the file in the first place!\n");
+        ASSERT_NOT_REACHED();
+    }
+
+    size_t num_program_headers = elf_header.e_phnum;
+    auto program_header_begin = (const Elf32_Phdr*)&(buffer[elf_header.e_phoff]);
+
+    for (size_t header_index = 0; header_index < num_program_headers; ++header_index) {
+        auto& program_header = program_header_begin[header_index];
+        switch (program_header.p_type) {
+        case PT_INTERP:
+            if (ET_DYN != elf_header.e_type) {
+                dbgprintf("Found PT_INTERP header (%d) in non-DYN ELF object! What? We can't handle this!\n", header_index);
+                return false;
+            }
+            // We checked above that file_size was >= buffer size. We only care about buffer size anyway, we're trying to read this!
+            if (program_header.p_offset + program_header.p_filesz > buffer_size) {
+                dbgprintf("Found PT_INTERP header (%d), but the .interp section was not within our buffer :( Your program will not be loaded today.\n", header_index);
+                return false;
+            }
+            interpreter_path = String((const char*)&buffer[program_header.p_offset], program_header.p_filesz - 1);
+            break;
+        case PT_LOAD:
+        case PT_DYNAMIC:
+        case PT_NOTE:
+        case PT_PHDR:
+        case PT_TLS:
+            if (program_header.p_offset + program_header.p_filesz > file_size) {
+                dbgprintf("SHENANIGANS! Program header %d segment leaks beyond end of file!\n", header_index);
+                return false;
+            }
+            if ((program_header.p_flags & PF_X) && (program_header.p_flags & PF_W)) {
+                dbgprintf("SHENANIGANS! Program header %d segment is marked write and execute\n", header_index);
+                return false;
+            }
+            break;
+        default:
+            // Not handling other program header types in other code so... let's not surprise them
+            dbgprintf("Found program header (%d) of unrecognized type %d!\n", header_index, program_header.p_type);
+            ASSERT_NOT_REACHED();
+            break;
+        }
+    }
+    return true;
 }

--- a/Libraries/LibELF/ELFImage.h
+++ b/Libraries/LibELF/ELFImage.h
@@ -14,7 +14,7 @@ public:
     bool is_valid() const { return m_valid; }
     bool parse();
 
-    bool is_within_image(const void* address, size_t size)
+    bool is_within_image(const void* address, size_t size) const
     {
         if (address < m_buffer)
             return false;
@@ -173,6 +173,9 @@ public:
     bool is_dynamic() const { return header().e_type == ET_DYN; }
 
     VirtualAddress entry() const { return VirtualAddress(header().e_entry); }
+
+    static bool validate_elf_header(const Elf32_Ehdr& elf_header, size_t file_size);
+    static bool validate_program_headers(const Elf32_Ehdr& elf_header, size_t file_size, u8* buffer, size_t buffer_size, String& interpreter_path);
 
 private:
     bool parse_header();


### PR DESCRIPTION
* [x] Check for PT_INTERP header when exec-ing a program in the Kernel, and load that program instead
* [x] Compile and link dynamic linking main executable as a position independent exectuable, using the -Wl,--dynamic-linker=XXX flag
* [x] Add more robust ELF checking to the kernel
* [x] Enable the kernel to load userspace programs at 'arbitrary' addresses. This will help with future ASLR and KASLR work. Right now the 'arbitrary' address will always be 0x08000000 but hey, it's a start.
* [x] Fix recursion issue with #! interpreter finding, and return -ELOOP if there's too many #! interpreters found in a row.

Future:
* Create ld-elf.so to be the entry point for a dynamic loader. Assume that the main program image has no actually been loaded yet, and load it from argv[0]
    * Relocate self and load the main program image
    * Exec the main() of the main program image
    * Do the things that _start does in crt0: setup environ, ... mostly just that.
* Load the program interpreter into memory at the same time as the executable from the kernel, and have the dynamic loader relocate itself, and then will into existence an ELFDynamicObject for the main program image.
* Make it possible to search for symbols in other DSO's, at symbol resolution time.
* Make methods in dlfcn.cpp more wrappers for an already existing/loaded dynamic loader object that handles shared object searching for symbols
* Make LibC and LibM built optionally as dynamic libraries
* Change GCC/libgcc config again to correctly handle pie's and use the dynamic linker by default