### PR TITLE
WIP: LibGUI: Implement shift-selection

### DIFF
--- a/Libraries/LibGUI/GAbstractColumnView.cpp
+++ b/Libraries/LibGUI/GAbstractColumnView.cpp
@@ -344,10 +344,16 @@ void GAbstractColumnView::mousedown_event(GMouseEvent& event)
         return;
     }
 
-    if (event.modifiers() & Mod_Ctrl)
+    if (event.modifiers() & Mod_Ctrl) {
         selection().toggle(index);
-    else
+    } else if (event.modifiers() & Mod_Shift) {
+        selection().add(index);
+        if (m_last_selected_index.is_valid())
+            add_to_selection_between(m_last_selected_index, index);
+    } else {
         selection().set(index);
+    }
+    m_last_selected_index = index;
 }
 
 GModelIndex GAbstractColumnView::index_at_event_position(const Point& position, bool& is_toggle) const

--- a/Libraries/LibGUI/GAbstractColumnView.h
+++ b/Libraries/LibGUI/GAbstractColumnView.h
@@ -97,4 +97,5 @@ private:
     int m_pressed_column_header_index { -1 };
     bool m_pressed_column_header_is_pressed { false };
     int m_hovered_column_header_index { -1 };
+    GModelIndex m_last_selected_index;
 };

--- a/Libraries/LibGUI/GAbstractView.cpp
+++ b/Libraries/LibGUI/GAbstractView.cpp
@@ -107,6 +107,21 @@ void GAbstractView::select_all()
     }
 }
 
+void GAbstractView::add_to_selection_between(const GModelIndex& index_a, const GModelIndex& index_b)
+{
+    ASSERT(model());
+
+    GModelIndex start_index = index_a;
+    GModelIndex end_index = index_b;
+    if (index_a > index_b)
+        swap(start_index, end_index);
+
+    for (int i = start_index.row(); i <= end_index.row(); ++i) {
+        for (int j = start_index.column(); j <= end_index.column(); ++j)
+            selection().add(model()->index(i, j));
+    }
+}
+
 void GAbstractView::activate(const GModelIndex& index)
 {
     if (on_activation)

--- a/Libraries/LibGUI/GAbstractView.h
+++ b/Libraries/LibGUI/GAbstractView.h
@@ -19,6 +19,7 @@ public:
     GModelSelection& selection() { return m_selection; }
     const GModelSelection& selection() const { return m_selection; }
     void select_all();
+    void add_to_selection_between(const GModelIndex&, const GModelIndex&);
 
     bool is_editable() const { return m_editable; }
     void set_editable(bool editable) { m_editable = editable; }

--- a/Libraries/LibGUI/GColumnsView.cpp
+++ b/Libraries/LibGUI/GColumnsView.cpp
@@ -199,16 +199,22 @@ void GColumnsView::mousedown_event(GMouseEvent& event)
     auto index = index_at_event_position(event.position());
     if (!index.is_valid()) {
         selection().clear();
+        m_last_selected_index = GModelIndex();
         return;
     }
 
     if (event.modifiers() & Mod_Ctrl) {
         selection().toggle(index);
+    } else if (event.modifiers() & Mod_Shift) {
+        selection().add(index);
+        if (m_last_selected_index.is_valid())
+            add_to_selection_between(m_last_selected_index, index);
     } else {
         selection().set(index);
         if (model()->row_count(index))
             push_column(index);
     }
+    m_last_selected_index = index;
 }
 
 void GColumnsView::did_update_model()

--- a/Libraries/LibGUI/GColumnsView.h
+++ b/Libraries/LibGUI/GColumnsView.h
@@ -37,4 +37,5 @@ private:
 
     Vector<Column> m_columns;
     int m_model_column;
+    GModelIndex m_last_selected_index;
 };

--- a/Libraries/LibGUI/GItemView.cpp
+++ b/Libraries/LibGUI/GItemView.cpp
@@ -126,14 +126,22 @@ void GItemView::mousedown_event(GMouseEvent& event)
             m_rubber_banding = true;
             m_rubber_band_origin = event.position();
             m_rubber_band_current = event.position();
+            m_last_selected_index = GModelIndex();
         } else {
             auto index = model()->index(item_index, m_model_column);
-            if (event.modifiers() & Mod_Ctrl)
+            if (event.modifiers() & Mod_Ctrl) {
                 selection().toggle(index);
-            else if (selection().size() > 1)
+            } else if (event.modifiers() & Mod_Shift) {
+                selection().add(index);
+                if (m_last_selected_index.is_valid())
+                    add_to_selection_between(m_last_selected_index, index);
+            } else if (selection().size() > 1) {
                 m_might_drag = true;
-            else
+            } else {
                 selection().set(index);
+            }
+
+            m_last_selected_index = index;
         }
     }
 

--- a/Libraries/LibGUI/GItemView.h
+++ b/Libraries/LibGUI/GItemView.h
@@ -58,4 +58,5 @@ private:
     Point m_rubber_band_origin;
     Point m_rubber_band_current;
     Vector<GModelIndex> m_rubber_band_remembered_selection;
+    GModelIndex m_last_selected_index;
 };

--- a/Libraries/LibGUI/GModelIndex.h
+++ b/Libraries/LibGUI/GModelIndex.h
@@ -29,6 +29,34 @@ public:
         return !(*this == other);
     }
 
+    bool operator>(const GModelIndex& other) const
+    {
+        if (m_row > other.m_row)
+            return true;
+        if (m_row < other.m_row)
+            return false;
+        return m_column > other.m_column;
+    }
+
+    bool operator>=(const GModelIndex& other) const
+    {
+        if (m_row > other.m_row)
+            return true;
+        if (m_row < other.m_row)
+            return false;
+        return m_column >= other.m_column;
+    }
+
+    bool operator<(const GModelIndex& other) const
+    {
+        return !(*this >= other);
+    }
+
+    bool operator<=(const GModelIndex& other) const
+    {
+        return !(*this > other);
+    }
+
 private:
     GModelIndex(const GModel& model, int row, int column, void* internal_data)
         : m_model(&model)


### PR DESCRIPTION
I'm not sure whether using regional operators in GModelIndex is a good thing. Should this row-major position logic be somewhere else?

Other than that the changes are relatively simple, and views can just make use of a new add_to_selection_between() function to implement shift selection.

Closes #269