### PR TITLE
WindowServer: More menu-key navigation fixes

### DIFF
--- a/Servers/WindowServer/WSMenu.cpp
+++ b/Servers/WindowServer/WSMenu.cpp
@@ -207,7 +207,7 @@ void WSMenu::draw()
     }
 }
 
-void WSMenu::redraw_for_new_hovered_item()
+void WSMenu::update_for_new_hovered_item()
 {
     if (m_hovered_item && m_hovered_item->is_submenu()) {
         ASSERT(m_hovered_item == &m_items.at(m_current_index));
@@ -215,6 +215,8 @@ void WSMenu::redraw_for_new_hovered_item()
         m_hovered_item->submenu()->popup(m_hovered_item->rect().top_right().translated(menu_window()->rect().location()), true);
     } else {
         WSMenuManager::the().close_everyone_not_in_lineage(*this);
+        WSMenuManager::the().set_current_menu(this);
+        menu_window()->set_visible(true);
     }
     redraw();
 }
@@ -239,7 +241,7 @@ void WSMenu::decend_into_submenu_at_hovered_item()
     ASSERT(submenu->m_current_index == 0);
     submenu->m_hovered_item = &submenu->m_items.at(0);
     ASSERT(submenu->m_hovered_item->type() != WSMenuItem::Separator);
-    submenu->redraw_for_new_hovered_item();
+    submenu->update_for_new_hovered_item();
     m_in_submenu = true;
 }
 
@@ -259,7 +261,7 @@ void WSMenu::event(CEvent& event)
         }
 
         m_in_submenu = false;
-        redraw_for_new_hovered_item();
+        update_for_new_hovered_item();
         return;
     }
 
@@ -280,7 +282,7 @@ void WSMenu::event(CEvent& event)
         // Default to the first item on key press if one has not been selected yet
         if (!m_hovered_item) {
             m_hovered_item = &m_items.at(0);
-            redraw_for_new_hovered_item();
+            update_for_new_hovered_item();
             return;
         }
 
@@ -309,7 +311,7 @@ void WSMenu::event(CEvent& event)
                 m_hovered_item = &m_items.at(m_current_index);
             } while (m_hovered_item->type() == WSMenuItem::Separator);
 
-            redraw_for_new_hovered_item();
+            update_for_new_hovered_item();
             return;
         }
 
@@ -323,7 +325,7 @@ void WSMenu::event(CEvent& event)
                 m_hovered_item = &m_items.at(m_current_index);
             } while (m_hovered_item->type() == WSMenuItem::Separator);
 
-            redraw_for_new_hovered_item();
+            update_for_new_hovered_item();
             return;
         }
 

--- a/Servers/WindowServer/WSMenu.h
+++ b/Servers/WindowServer/WSMenu.h
@@ -93,7 +93,7 @@ private:
     int padding_between_text_and_shortcut() const { return 50; }
     void did_activate(WSMenuItem&);
     void open_hovered_item();
-    void redraw_for_new_hovered_item();
+    void update_for_new_hovered_item();
     void decend_into_submenu_at_hovered_item();
 
     WSClientConnection* m_client { nullptr };

--- a/Servers/WindowServer/WSMenuManager.cpp
+++ b/Servers/WindowServer/WSMenuManager.cpp
@@ -389,8 +389,12 @@ void WSMenuManager::open_menu(WSMenu& menu)
 
 void WSMenuManager::set_current_menu(WSMenu* menu, bool is_submenu)
 {
-    if (!is_submenu)
-        close_everyone();
+    if (!is_submenu) {
+        if (menu)
+            close_everyone_not_in_lineage(*menu);
+        else
+            close_everyone();
+    }
 
     if (!menu) {
         m_current_menu = nullptr;

--- a/Servers/WindowServer/WSMenuManager.cpp
+++ b/Servers/WindowServer/WSMenuManager.cpp
@@ -270,12 +270,21 @@ void WSMenuManager::event(CEvent& event)
         }
     }
 
-    if (event.type() == WSEvent::KeyDown) {
-        for_each_active_menubar_menu([&](WSMenu& menu) {
-            if (is_open(menu))
-                menu.dispatch_event(event);
-            return IterationDecision::Continue;
-        });
+    if (static_cast<WSEvent&>(event).is_key_event()) {
+        auto& key_event = static_cast<const WSKeyEvent&>(event);
+
+        if (key_event.type() == WSEvent::KeyUp && key_event.key() == Key_Escape) {
+            close_everyone();
+            return;
+        }
+
+        if (event.type() == WSEvent::KeyDown) {
+            for_each_active_menubar_menu([&](WSMenu& menu) {
+                if (is_open(menu))
+                    menu.dispatch_event(event);
+                return IterationDecision::Continue;
+            });
+        }
     }
 
     return CObject::event(event);

--- a/Servers/WindowServer/WSWindowManager.cpp
+++ b/Servers/WindowServer/WSWindowManager.cpp
@@ -949,10 +949,8 @@ void WSWindowManager::event(CEvent& event)
             return;
         }
 
-        if (key_event.type() == WSEvent::KeyUp && key_event.key() == Key_Escape) {
-            auto current_menu = WSMenuManager::the().current_menu();
-            if (current_menu)
-                WSMenuManager::the().close_everyone();
+        if (WSMenuManager::the().current_menu()) {
+            WSMenuManager::the().dispatch_event(event);
             return;
         }
 
@@ -1004,10 +1002,6 @@ void WSWindowManager::event(CEvent& event)
             m_active_window->dispatch_event(event);
             return;
         }
-
-        // FIXME: We should send events to the MenuManager if a window is open
-        // This should take priority over sending to a window.
-        WSMenuManager::the().dispatch_event(event);
     }
 
     CObject::event(event);


### PR DESCRIPTION
Menu key navigation should now be a lot more pleasant to use! Key events are now redirected to the menu manager if there is a current menu. A few minor fixes in WSMenuManager and WSMenu in order to support this change :^)