### PR TITLE
LibC changes and useradd utility and documentation

### DIFF
--- a/Base/usr/share/man/man8/useradd.md
+++ b/Base/usr/share/man/man8/useradd.md
@@ -1,0 +1,50 @@
+## Name
+
+useradd - add a new user to the system password file
+
+## Synopsis
+
+```**sh
+# useradd [options] <login>
+```
+
+## Description
+
+This program uses adds a new user to the system.
+
+By default, the user will be added to the **users** group (which has a GID of 100).
+
+This program must be run as root.
+
+## Options
+
+* `-u`, `--uid` _uid_: The user identifier for the new user. If not specified, an unused UID above `1000` will be auto-generated.
+* `-g`, `--gid` _gid_: The group identifier for the new user. If not specified, it will default to 100 (the **users** group).
+* `-s`, `--shell` _path-to-shell_: The shell binary for this login. The default is `/bin/Shell`. 
+* `-m`, `--create-home`: Create the specified home directory for this new user.
+* `-d`, `--home-dir` _path_: Set the home directory for this user to path. By default, this is `/home/username`, where `username` is the value of login.
+* `-n`, `--gecos` _general-info_: GECOS information about this login. See [Wikipedia](https://en.wikipedia.org/wiki/Gecos_field) for more information.
+
+## Exit Values
+
+* 0 - Success
+* 1 - Couldn't update the password file
+* 3 - Invalid argument to option
+* 4 - UID already in use
+* 12 - Couldn't create home directory
+
+## Files
+
+* `/etc/passwd` - new user information (such as UID and GID) is appended to this file.
+* `/home/` - user home directroy is created here if the `-m` flag is specified.
+
+## Examples
+
+```sh
+# useradd -u 300 -m kling
+# useradd -m -u 400 --gid 200 --gecos "Sergey Bugaev" bugaevc
+# useradd quaker
+# useradd --gid 1000 -d /tmp/somedir -n "Dan MacDonald" danboid
+# useradd --create-home supercomputer7
+```
+

--- a/Libraries/LibC/bits/FILE.h
+++ b/Libraries/LibC/bits/FILE.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018-2020, Jesse Buhagiar <jooster669@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#pragma once
+
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+#define BUFSIZ 1024
+
+__BEGIN_DECLS
+
+struct __STDIO_FILE {
+    int fd;
+    int eof;
+    int error;
+    int mode;
+    pid_t popen_child;
+    char* buffer;
+    size_t buffer_size;
+    size_t buffer_index;
+    int have_ungotten;
+    char ungotten;
+    char default_buffer[BUFSIZ];
+};
+
+typedef struct __STDIO_FILE FILE;
+
+__END_DECLS

--- a/Libraries/LibC/pwd.h
+++ b/Libraries/LibC/pwd.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <bits/FILE.h>
 #include <sys/cdefs.h>
 #include <sys/types.h>
 
@@ -46,5 +47,6 @@ void setpwent();
 void endpwent();
 struct passwd* getpwnam(const char* name);
 struct passwd* getpwuid(uid_t);
+int putpwent(const struct passwd* p, FILE* stream);
 
 __END_DECLS

--- a/Libraries/LibC/stdio.cpp
+++ b/Libraries/LibC/stdio.cpp
@@ -498,6 +498,10 @@ FILE* fopen(const char* pathname, const char* mode)
         flags = O_WRONLY | O_CREAT | O_TRUNC;
     else if (!strcmp(mode, "w+") || !strcmp(mode, "wb+"))
         flags = O_RDWR | O_CREAT | O_TRUNC;
+    else if (!strcmp(mode, "a") || !strcmp(mode, "ab"))
+        flags = O_WRONLY | O_APPEND | O_CREAT;
+    else if (!strcmp(mode, "a+") || !strcmp(mode, "ab+"))
+        flags = O_RDWR | O_APPEND | O_CREAT;
     else {
         fprintf(stderr, "FIXME(LibC): fopen('%s', '%s')\n", pathname, mode);
         ASSERT_NOT_REACHED();

--- a/Libraries/LibC/stdio.h
+++ b/Libraries/LibC/stdio.h
@@ -30,11 +30,11 @@
 
 #include <limits.h>
 #include <stdarg.h>
+#include <bits/FILE.h>
 #include <sys/cdefs.h>
 #include <sys/types.h>
 
 #define FILENAME_MAX 1024
-#define BUFSIZ 1024
 
 __BEGIN_DECLS
 #ifndef EOF
@@ -50,22 +50,6 @@ __BEGIN_DECLS
 #define _IONBF 2
 
 #define L_tmpnam 256
-
-struct __STDIO_FILE {
-    int fd;
-    int eof;
-    int error;
-    int mode;
-    pid_t popen_child;
-    char* buffer;
-    size_t buffer_size;
-    size_t buffer_index;
-    int have_ungotten;
-    char ungotten;
-    char default_buffer[BUFSIZ];
-};
-
-typedef struct __STDIO_FILE FILE;
 
 extern FILE* stdin;
 extern FILE* stdout;

--- a/Userland/useradd.cpp
+++ b/Userland/useradd.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2019-2020, Jesse Buhagiar <jooster669@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <AK/String.h>
+#include <LibCore/CArgsParser.h>
+#include <ctype.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+constexpr uid_t BASE_UID = 1000;
+constexpr gid_t USERS_GID = 100;
+constexpr const char* DEFAULT_SHELL = "/bin/Shell";
+
+int main(int argc, char** argv)
+{
+    const char* home_path = nullptr;
+    int uid = 0;
+    int gid = USERS_GID;
+    bool create_home_dir = false;
+    const char* shell = DEFAULT_SHELL;
+    const char* gecos = "";
+    const char* username = nullptr;
+
+    CArgsParser args_parser;
+    args_parser.add_option(home_path, "Home directory for the new user", "home-dir", 'd', "path");
+    args_parser.add_option(uid, "User ID (uid) for the new user", "uid", 'u', "uid");
+    args_parser.add_option(gid, "Group ID (gid) for the new user", "gid", 'g', "gid");
+    args_parser.add_option(create_home_dir, "Create home directory if it does not exist", "create-home", 'm');
+    args_parser.add_option(shell, "Path to the default shell binary for the new user", "shell", 's', "path-to-shell");
+    args_parser.add_option(gecos, "GECOS name of the new user", "gecos", 'n', "general-info");
+    args_parser.add_positional_argument(username, "Login user identity (username)", "login");
+
+    args_parser.parse(argc, argv);
+
+    // Let's run a quick sanity check on username
+    if (strpbrk(username, "\\/!@#$%^&*()~+=`:\n")) {
+        fprintf(stderr, "invalid character in username, %s\n", username);
+        return 1;
+    }
+
+    // Disallow names starting with _ and -
+    if (username[0] == '_' || username[0] == '-' || !isalpha(username[0])) {
+        fprintf(stderr, "invalid username, %s\n", username);
+        return 1;
+    }
+
+    if (uid < 0) {
+        fprintf(stderr, "invalid uid %d!\n", uid);
+        return 3;
+    }
+
+    // First, let's sort out the uid for the user
+    if (uid > 0) {
+        if (getpwuid(static_cast<uid_t>(uid))) {
+            fprintf(stderr, "uid %u already exists!\n", uid);
+            return 4;
+        }
+
+    } else {
+        for (uid = BASE_UID; getpwuid(static_cast<uid_t>(uid)); uid++) {
+        }
+    }
+
+    if (gid < 0) {
+        fprintf(stderr, "invalid gid %d\n", gid);
+        return 3;
+    }
+
+    FILE* pwfile = fopen("/etc/passwd", "a");
+    if (!pwfile) {
+        perror("failed to open /etc/passwd");
+        return 1;
+    }
+
+    String home;
+    if (!home_path)
+        home = String::format("/home/%s", username);
+    else
+        home = home_path;
+
+    if (create_home_dir) {
+        if (mkdir(home.characters(), 0700) < 0) {
+            perror(String::format("failed to create directory %s", home.characters()).characters());
+            return 12;
+        }
+
+        if (chown(home.characters(), static_cast<uid_t>(uid), static_cast<gid_t>(gid)) < 0) {
+            perror(String::format("failed to chown %s to %u:%u", home.characters(), uid, gid).characters());
+
+            if (rmdir(home.characters()) < 0) {
+                perror(String::format("failed to rmdir %s", home.characters()).characters());
+                return 12;
+            }
+            return 12;
+        }
+    }
+
+    struct passwd p;
+    p.pw_name = const_cast<char*>(username);
+    p.pw_dir = const_cast<char*>(home.characters());
+    p.pw_uid = static_cast<uid_t>(uid);
+    p.pw_gid = static_cast<gid_t>(gid);
+    p.pw_shell = const_cast<char*>(shell);
+    p.pw_gecos = const_cast<char*>(gecos);
+
+    if (putpwent(&p, pwfile) < 0) {
+        perror("putpwent");
+        return 1;
+    }
+
+    fclose(pwfile);
+
+    return 0;
+}


### PR DESCRIPTION
A few changes to LibC that allows the `useradd` Userspace utility to run. This makes it a lot easier to append to `/etc/passwd` without manually editing it (as well as having to know the format for the entries)