### PR TITLE
Build: Make parallel builds possible again

### DIFF
--- a/AK/Tests/Makefile
+++ b/AK/Tests/Makefile
@@ -25,11 +25,11 @@ CXXFLAGS = -std=c++17 -Wall -Wextra -ggdb3 -O2 -I../ -I../../
 
 APPS_RUN = $(addsuffix .run,$(APPS))
 test: $(APPS) $(APPS_RUN)
-$(APPS_RUN): %.run:
+$(APPS_RUN): %.run: $(APPS)
 	./$*
 
 $(APPS): %: %$(OBJ_SUFFIX).o $(SHARED_TEST_OBJS)
 	@echo "LINK $@"
 	$(QUIET) $(CXX) -o $@ $< $(SHARED_TEST_OBJS) $(LDFLAGS)
 
-all: | $(APPS) $(APPS_RUN)
+all: | $(APPS_RUN)

--- a/Applications/Browser/Makefile
+++ b/Applications/Browser/Makefile
@@ -11,7 +11,8 @@ main.cpp: ../../Libraries/LibHTML/CSS/PropertyID.h
 	@flock ../../Libraries/LibHTML $(MAKE) -C ../../Libraries/LibHTML
 
 main.cpp: ../../Servers/ProtocolServer/ProtocolClientEndpoint.h
-../../Servers/ProtocolServer/ProtocolClientEndpoint.h:
-	@flock ../../Servers/ProtocolServer $(MAKE) -C $(dir $(@))
+
+../../Servers/ProtocolServer/ProtocolClientEndpoint.h: ../../Servers/ProtocolServer/ProtocolClient.ipc | IPCCOMPILER
+	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
 include ../../Makefile.common

--- a/DevTools/Makefile
+++ b/DevTools/Makefile
@@ -1,3 +1,7 @@
-SUBDIRS := $(wildcard */.)
+SUBDIRS := HackStudio \
+    Inspector \
+	ProfileViewer \
+	VisualBuilder \
+	FormCompiler
 
 include ../Makefile.subdir

--- a/Kernel/makeall.sh
+++ b/Kernel/makeall.sh
@@ -31,13 +31,13 @@ if [ "$(uname -s)" = "OpenBSD" ]; then
 fi
 
 if [ $fast_mode = 1 ]; then
-    $MAKE -C ../ && \
-        $MAKE -C ../ install &&
+    $MAKE -C .. && \
+        $MAKE -C .. install &&
         sudo -E PATH="$PATH" ./build-image-qemu.sh
 else
-    $MAKE -C ../ clean && \
-        $MAKE -C ../ && \
-        $MAKE -C ../ test && \
-        $MAKE -C ../ install &&
+    $MAKE -C .. clean && \
+        $MAKE -C .. && \
+        $MAKE -C .. test && \
+        $MAKE -C .. install &&
         sudo -E PATH="$PATH" ./build-image-qemu.sh
 fi

--- a/Libraries/LibAudio/Makefile
+++ b/Libraries/LibAudio/Makefile
@@ -5,8 +5,9 @@ OBJS = \
 LIBRARY = libaudio.a
 
 AClientConnection.cpp: ../../Servers/AudioServer/AudioClientEndpoint.h
-../../Servers/AudioServer/AudioClientEndpoint.h:
-	@flock $(dir $(@)) $(MAKE) -C $(dir $(@))
+
+../../Servers/AudioServer/AudioClientEndpoint.h: ../../Servers/AudioServer/AudioClient.ipc | IPCCOMPILER
+	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
 install:
 	mkdir -p $(SERENITY_BASE_DIR)/Root/usr/include/LibAudio/

--- a/Libraries/LibGUI/Makefile
+++ b/Libraries/LibGUI/Makefile
@@ -65,8 +65,8 @@ LIBRARY = libgui.a
 
 GWindowServerConnection.cpp: ../../Servers/WindowServer/WindowServerEndpoint.h
 
-../../Servers/WindowServer/WindowServerEndpoint.h:
-	@flock $(dir $(@)) $(MAKE) -C $(dir $(@))
+../../Servers/WindowServer/WindowServerEndpoint.h: ../../Servers/WindowServer/WindowServer.ipc | IPCCOMPILER
+	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
 install:
 	mkdir -p $(SERENITY_BASE_DIR)/Root/usr/include/LibGUI/

--- a/Libraries/LibHTML/Makefile
+++ b/Libraries/LibHTML/Makefile
@@ -89,9 +89,13 @@ CSS/PropertyID.cpp: CSS/Properties.json $(GENERATE_CSS_PROPERTYID_CPP)
 	@echo "GENERATE $@"
 	$(QUIET) flock CSS $(GENERATE_CSS_PROPERTYID_CPP) $< > $@
 
-ResourceLoader.cpp: ../../Servers/ProtocolServer/ProtocolClientEndpoint.h
-../../Servers/ProtocolServer/ProtocolClientEndpoint.h:
-	@flock ../../Servers/ProtocolServer $(MAKE) -C $(dir $(@))
+ResourceLoader.cpp: ../../Servers/ProtocolServer/ProtocolClientEndpoint.h ../../Servers/ProtocolServer/ProtocolServerEndpoint.h
+
+../../Servers/ProtocolServer/ProtocolClientEndpoint.h: ../../Servers/ProtocolServer/ProtocolClient.ipc | IPCCOMPILER
+	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
+
+../../Servers/ProtocolServer/ProtocolServerEndpoint.h: ../../Servers/ProtocolServer/ProtocolServer.ipc | IPCCOMPILER
+	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
 
 EXTRA_CLEAN = CSS/DefaultStyleSheetSource.cpp CSS/PropertyID.h CSS/PropertyID.cpp
 

--- a/Libraries/LibProtocol/Makefile
+++ b/Libraries/LibProtocol/Makefile
@@ -4,8 +4,14 @@ OBJS = \
 
 LIBRARY = libprotocol.a
 
-Download.cpp: ../../Servers/ProtocolServer/ProtocolClientEndpoint.h
-../../Servers/ProtocolServer/ProtocolClientEndpoint.h:
-	@flock $(dir $(@)) $(MAKE) -C $(dir $(@))
+
+Download.cpp: ../../Servers/ProtocolServer/ProtocolClientEndpoint.h ../../Servers/ProtocolServer/ProtocolServerEndpoint.h
+
+../../Servers/ProtocolServer/ProtocolClientEndpoint.h: ../../Servers/ProtocolServer/ProtocolClient.ipc | IPCCOMPILER
+	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
+
+../../Servers/ProtocolServer/ProtocolServerEndpoint.h: ../../Servers/ProtocolServer/ProtocolServer.ipc | IPCCOMPILER
+	@echo "IPC $<"; $(IPCCOMPILER) $< > $@
+
 
 include ../../Makefile.common

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,19 @@ SUBDIRS += \
 	Games \
 	Demos
 
-include Makefile.subdir
 
+MAKE_PID := $(shell echo $$PPID)
+JOBS := $(shell ps T | sed -n 's/.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs\) *\([0-9][0-9]*\).*/\2/p')
+
+ifeq (,$(JOBS))
+	NPROC := $(shell nproc)
+	PARALLEL_BUILD := -j $(NPROC)
+else
+	PARALLEL_BUILD := -j $(JOBS)
+endif
+MAKEFLAGS := $(MAKEFLAGS) $(PARALLEL_BUILD)
+
+include Makefile.subdir
 all: subdirs
 
 .PHONY: test
@@ -25,6 +36,6 @@ ifeq ($(UNAME_S),Darwin)
 test: 
 else
 test:
-	$(QUIET) flock AK/Tests -c "$(MAKE) -C AK/Tests clean all && $(MAKE) -C AK/Tests clean"
+	$(QUIET) flock AK/Tests -c "$(MAKE) $(PARALLEL_BUILD) -C AK/Tests clean all && $(MAKE) $(PARALLEL_BUILD) -C AK/Tests clean"
 endif
 

--- a/Makefile.subdir
+++ b/Makefile.subdir
@@ -1,17 +1,17 @@
 subdirs: $(SUBDIRS)
 $(SUBDIRS):
-	@flock $@ $(MAKE) -C $@
+	@flock $@ $(MAKE) $(PARALLEL_BUILD) -C $@
 
 all: $(subdirs)
 
 SUBDIRS_CLEAN = $(addsuffix .clean,$(SUBDIRS))
 clean: $(SUBDIRS_CLEAN)
 $(SUBDIRS_CLEAN): %.clean:
-	@flock $* $(MAKE) -C $* clean
+	@flock $* $(MAKE) $(PARALLEL_BUILD) -C $* clean
 
 SUBDIRS_INSTALL = $(addsuffix .install,$(SUBDIRS))
 install: $(SUBDIRS_INSTALL)
 $(SUBDIRS_INSTALL): %.install:
-	@flock $* $(MAKE) -C $* install
+	@flock $* $(MAKE) $(PARALLEL_BUILD) -C $* install
 
 .PHONY: all clean install $(SUBDIRS)


### PR DESCRIPTION
This change introduces the possibility to build Serenity OS parallel again.
It can be done by invoking one of the following commands:

  serenity/$ make

This will use the number of jobs according to the processors cores (identified by nproc).

  serenity/$ make -j [jobs]

This will use the number of jobs specified or the maximum available jobs (according to man make).

  serenity/Kernel/$ ./makeall.sh

This will use the first command from above within the script that uses all the CPU cores available.

For this to work, IPC compiler has to be called every time a generated IPC header file is needed.
This duplicates the IPC compiler calls for now, but from the runtime it's a good trade off so far.
In the future this might be replaced by a better solution to handle the code generation and
dependencies.

There were also some IPC header dependency missing for Download.cpp and ResourceLoader.cpp that
have been fixed.