### PR TITLE
Debugging: Add kernel debugging support

### DIFF
--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -119,11 +119,11 @@ KERNEL = 1
 PROGRAM = kernel
 
 SUBPROJECT_CXXFLAGS += -pie -fPIE -ffreestanding -mno-80387 -mno-mmx -mno-sse -mno-sse2 -fno-asynchronous-unwind-tables
-SUBPROJECT_CXXFLAGS += -nostdlib -nostdinc -nostdinc++
+SUBPROJECT_CXXFLAGS += -nostdlib -nostdinc -nostdinc++ -g3
 SUBPROJECT_CXXFLAGS += -I../Toolchain/Local/i686-pc-serenity/include/c++/9.2.0/
 SUBPROJECT_CXXFLAGS += -I../Toolchain/Local/i686-pc-serenity/include/c++/9.2.0/i686-pc-serenity/
 
-LDFLAGS += -Ttext 0x100000 -Wl,-T linker.ld -nostdlib -lgcc -lstdc++
+LDFLAGS += -Ttext 0x100000 -Wl,-T linker.ld -nostdlib -lgcc -lstdc++ -g3
 
 all: $(PROGRAM) $(MODULE_OBJS) kernel.map
 

--- a/Kernel/debug-kernel
+++ b/Kernel/debug-kernel
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Set this environment variable to override the default debugger.
+#
+[ -z "$SERENITY_KERNEL_DEBUGGER" ] && SERENITY_KERNEL_DEBUGGER="gdb"
+
+# The QEMU -s option (enabled by default in ./run) sets up a debugger
+# remote on localhost:1234. So point our debugger there, and inform
+# the debugger which binary to load symbols, etc from.
+#
+$SERENITY_KERNEL_DEBUGGER \
+    -ex "file $(pwd)/kernel" \
+    -ex 'set arch i386:intel' \
+    -ex 'target remote localhost:1234'


### PR DESCRIPTION
Introduce the 'debug-kernel' script to allow developers to
quickly attach a debugger to the QEMU debug remote. The
setting (-s) is already enabled by ./run today when using
QEMU for virtualisation.

If the system is running under QEMU, the debugger
will break in when the script is run. If you add
the -S option to QEMU it will wait for the debugger
to connect before booting the kernel. This allows
you to debug the init/boot process.

Personally I use cgdb instead of gdb, so I opted
to make the debugger used by the script customizable
via an environment variable.

This change also adds -g3 to the kernel build so that
rich debug symbols are available in the kernel binary.