### PR TITLE
Kernel: Use the templated copy_from_user where possible

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -217,7 +217,7 @@ int Process::sys$set_mmap_name(const Syscall::SC_set_mmap_name_params* user_para
         return -EFAULT;
 
     Syscall::SC_set_mmap_name_params params;
-    copy_from_user(&params, user_params, sizeof(params));
+    copy_from_user(&params, user_params);
 
     auto name = validate_and_copy_string_from_user(params.name);
     if (name.is_null())
@@ -288,7 +288,7 @@ void* Process::sys$mmap(const Syscall::SC_mmap_params* user_params)
         return (void*)-EFAULT;
 
     Syscall::SC_mmap_params params;
-    copy_from_user(&params, user_params, sizeof(params));
+    copy_from_user(&params, user_params);
 
     void* addr = (void*)params.addr;
     size_t size = params.size;
@@ -934,7 +934,7 @@ int Process::sys$execve(const Syscall::SC_execve_params* user_params)
     Syscall::SC_execve_params params;
     if (!validate_read_typed(user_params))
         return -EFAULT;
-    copy_from_user(&params, user_params, sizeof(params));
+    copy_from_user(&params, user_params);
 
     if (params.arguments.length > ARG_MAX || params.environment.length > ARG_MAX)
         return -E2BIG;
@@ -1493,7 +1493,7 @@ int Process::sys$utime(const char* user_path, size_t path_length, const utimbuf*
         return path.error();
     utimbuf buf;
     if (user_buf) {
-        copy_from_user(&buf, user_buf, sizeof(buf));
+        copy_from_user(&buf, user_buf);
     } else {
         auto now = kgettimeofday();
         buf = { now.tv_sec, now.tv_sec };
@@ -1631,7 +1631,7 @@ int Process::sys$readlink(const Syscall::SC_readlink_params* user_params)
     if (!validate_read_typed(user_params))
         return -EFAULT;
     Syscall::SC_readlink_params params;
-    copy_from_user(&params, user_params, sizeof(params));
+    copy_from_user(&params, user_params);
 
     if (!validate(params.buffer))
         return -EFAULT;
@@ -1719,7 +1719,7 @@ int Process::sys$open(const Syscall::SC_open_params* user_params)
         return -EFAULT;
 
     Syscall::SC_open_params params;
-    copy_from_user(&params, user_params, sizeof(params));
+    copy_from_user(&params, user_params);
     auto options = params.options;
     auto mode = params.mode;
 
@@ -1761,7 +1761,7 @@ int Process::sys$openat(const Syscall::SC_openat_params* user_params)
         return -EFAULT;
 
     Syscall::SC_openat_params params;
-    copy_from_user(&params, user_params, sizeof(params));
+    copy_from_user(&params, user_params);
     int dirfd = params.dirfd;
     int options = params.options;
     u16 mode = params.mode;
@@ -2357,7 +2357,7 @@ int Process::sys$sigprocmask(int how, const sigset_t* set, sigset_t* old_set)
         if (!validate_read_typed(set))
             return -EFAULT;
         sigset_t set_value;
-        copy_from_user(&set_value, set, sizeof(set_value));
+        copy_from_user(&set_value, set);
         switch (how) {
         case SIG_BLOCK:
             current->m_signal_mask &= ~set_value;
@@ -2399,7 +2399,7 @@ int Process::sys$sigaction(int signum, const sigaction* act, sigaction* old_act)
         copy_to_user(&old_act->sa_flags, &action.flags, sizeof(action.flags));
         copy_to_user(&old_act->sa_sigaction, &action.handler_or_sigaction, sizeof(action.handler_or_sigaction));
     }
-    copy_from_user(&action.flags, &act->sa_flags, sizeof(action.flags));
+    copy_from_user(&action.flags, &act->sa_flags);
     copy_from_user(&action.handler_or_sigaction, &act->sa_sigaction, sizeof(action.flags));
     return 0;
 }
@@ -2457,7 +2457,7 @@ int Process::sys$realpath(const Syscall::SC_realpath_params* user_params)
         return -EFAULT;
 
     Syscall::SC_realpath_params params;
-    copy_from_user(&params, user_params, sizeof(params));
+    copy_from_user(&params, user_params);
 
     if (!validate_write(params.buffer.data, params.buffer.size))
         return -EFAULT;
@@ -2660,7 +2660,7 @@ int Process::sys$link(const Syscall::SC_link_params* user_params)
     if (!validate_read_typed(user_params))
         return -EFAULT;
     Syscall::SC_link_params params;
-    copy_from_user(&params, user_params, sizeof(params));
+    copy_from_user(&params, user_params);
     auto old_path = validate_and_copy_string_from_user(params.old_path);
     auto new_path = validate_and_copy_string_from_user(params.new_path);
     if (old_path.is_null() || new_path.is_null())
@@ -2753,7 +2753,7 @@ int Process::sys$chown(const Syscall::SC_chown_params* user_params)
     if (!validate_read_typed(user_params))
         return -EFAULT;
     Syscall::SC_chown_params params;
-    copy_from_user(&params, user_params, sizeof(params));
+    copy_from_user(&params, user_params);
     auto path = get_syscall_path_argument(params.path);
     if (path.is_error())
         return path.error();
@@ -4253,7 +4253,7 @@ int Process::sys$futex(const Syscall::SC_futex_params* user_params)
         return -EFAULT;
 
     Syscall::SC_futex_params params;
-    copy_from_user(&params, user_params, sizeof(params));
+    copy_from_user(&params, user_params);
 
     i32* userspace_address = params.userspace_address;
     int futex_op = params.futex_op;
@@ -4268,13 +4268,13 @@ int Process::sys$futex(const Syscall::SC_futex_params* user_params)
 
     timespec timeout { 0, 0 };
     if (user_timeout)
-        copy_from_user(&timeout, user_timeout, sizeof(timeout));
+        copy_from_user(&timeout, user_timeout);
 
     i32 user_value;
 
     switch (futex_op) {
     case FUTEX_WAIT:
-        copy_from_user(&user_value, userspace_address, sizeof(user_value));
+        copy_from_user(&user_value, userspace_address);
         if (user_value != value)
             return -EAGAIN;
         // FIXME: This is supposed to be interruptible by a signal, but right now WaitQueue cannot be interrupted.


### PR DESCRIPTION
Now that the templated version of copy_from_user exists
their is normally no reason to use the version which
takes the number of bytes to copy. Move to the templated
version where possible.