### PR TITLE
Kernel: Fix SMAP in setkeymap syscall

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -3955,6 +3955,7 @@ int Process::sys$setkeymap(const Syscall::SC_setkeymap_params* params)
     if (!validate_read(altgr_map, 0x80))
         return -EFAULT;
 
+    SmapDisabler disabler;
     KeyboardDevice::the().set_maps(map, shift_map, alt_map, altgr_map);
     return 0;
 }


### PR DESCRIPTION
It looks like setkeymap was missed when
the SMAP functionality was introduced.

Disable SMAP only in the scope where we
actually read the usermode addresses for
the keymap.