### PR TITLE
LibCore: fix segfault in CArgsParser.

### DIFF
--- a/Libraries/LibCore/CArgsParser.cpp
+++ b/Libraries/LibCore/CArgsParser.cpp
@@ -59,6 +59,7 @@ CArgsParserResult CArgsParser::parse(int argc, char** argv)
 
 int CArgsParser::parse_next_param(int index, char** argv, const int params_left, CArgsParserResult& res)
 {
+    ASSERT(params_left >= 0);
     if (params_left == 0)
         return 0;
 
@@ -80,7 +81,7 @@ int CArgsParser::parse_next_param(int index, char** argv, const int params_left,
 
         // If this parameter must be followed by a value, we look for it
         if (!arg->value.value_name.is_null()) {
-            if (params_left < 1) {
+            if (params_left < 2) {
                 printf("Missing value for argument %s\n", arg->value.name.characters());
                 return -1;
             }


### PR DESCRIPTION
CArgsParser::parse_next_param did not properly ensure that, when
a param required a following argument, there were enough parameters left to
complete the parse. This meant that params_left could become negative,
avoiding parse_next_param's termination condition, and cause a segfault
when reading from argv with an out of bounds index.

This fixes the check to ensure that we do in fact have the right amount
of parameters and also adds an assertion to ensure that params_left does
not become negative.

This fixes: #1058 