### PR TITLE
Magical symlinks

### DIFF
--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -61,6 +61,8 @@ public:
     bool bind_socket(LocalSocket&);
     bool unbind_socket();
 
+    virtual FileDescription* preopen_fd() { return nullptr; };
+
     bool is_metadata_dirty() const { return m_metadata_dirty; }
 
     virtual int set_atime(time_t);

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -15,6 +15,7 @@ class FileDescription;
 class InodeVMObject;
 class InodeWatcher;
 class LocalSocket;
+class Custody;
 
 class Inode : public RefCounted<Inode>
     , public Weakable<Inode>
@@ -53,6 +54,7 @@ public:
     virtual KResult chmod(mode_t) = 0;
     virtual KResult chown(uid_t, gid_t) = 0;
     virtual KResult truncate(off_t) { return KSuccess; }
+    virtual KResultOr<NonnullRefPtr<Custody>> resolve_as_link(Custody& base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0) const;
 
     LocalSocket* socket() { return m_socket.ptr(); }
     const LocalSocket* socket() const { return m_socket.ptr(); }

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -230,6 +230,9 @@ KResultOr<NonnullRefPtr<FileDescription>> VFS::open(StringView path, int options
             return KResult(-EACCES);
     }
 
+    if (auto preopen_fd = inode.preopen_fd())
+        return *preopen_fd;
+
     if (metadata.is_device()) {
         if (custody.mount_flags() & MS_NODEV)
             return KResult(-EACCES);

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -144,6 +144,7 @@ void VFS::traverse_directory_inode(Inode& dir_inode, Function<bool(const FS::Dir
         else
             resolved_inode = entry.inode;
 
+        // FIXME: This is now broken considering chroot and bind mounts.
         if (dir_inode.identifier().is_root_inode() && !is_vfs_root(dir_inode.identifier()) && !strcmp(entry.name, "..")) {
             auto mount = find_mount_for_guest(entry.inode);
             ASSERT(mount);

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -741,16 +741,7 @@ KResultOr<NonnullRefPtr<Custody>> VFS::resolve_path(StringView path, Custody& ba
                 if (options & O_NOFOLLOW_NOERROR)
                     break;
             }
-            auto symlink_contents = child_inode->read_entire();
-            if (!symlink_contents) {
-                if (out_parent)
-                    *out_parent = nullptr;
-                return KResult(-ENOENT);
-            }
-
-            auto symlink_path = StringView(symlink_contents.data(), symlink_contents.size());
-            auto symlink_target = resolve_path(symlink_path, parent, out_parent, options, symlink_recursion_level + 1);
-
+            auto symlink_target = child_inode->resolve_as_link(parent, out_parent, options, symlink_recursion_level + 1);
             if (symlink_target.is_error() || !have_more_parts)
                 return symlink_target;
 

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -103,7 +103,7 @@ public:
     void sync();
 
     Custody& root_custody();
-    KResultOr<NonnullRefPtr<Custody>> resolve_path(StringView path, Custody& base, RefPtr<Custody>* parent = nullptr, int options = 0, int symlink_recursion_level = 0);
+    KResultOr<NonnullRefPtr<Custody>> resolve_path(StringView path, Custody& base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
 
 private:
     friend class FileDescription;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -1908,8 +1908,14 @@ int Process::sys$open(const Syscall::SC_open_params* user_params)
     if (result.is_error())
         return result.error();
     auto description = result.value();
-    description->set_rw_mode(options);
-    description->set_file_flags(options);
+    if (description->file_flags()) {
+        // We already have file flags set on this description, so
+        // it must be a preopen description (probably, /proc/pid/fd).
+        // So don't reset its flags and r/w mode.
+    } else {
+        description->set_rw_mode(options);
+        description->set_file_flags(options);
+    }
     u32 fd_flags = (options & O_CLOEXEC) ? FD_CLOEXEC : 0;
     m_fds[fd].set(move(description), fd_flags);
     return fd;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -2578,18 +2578,12 @@ int Process::sys$realpath(const Syscall::SC_realpath_params* user_params)
     if (custody_or_error.is_error())
         return custody_or_error.error();
     auto& custody = custody_or_error.value();
+    auto absolute_path = custody->absolute_path();
 
-    // FIXME: Once resolve_path is fixed to deal with .. and . , remove the use of FileSystemPath::canonical_path.
-    FileSystemPath canonical_path(custody->absolute_path());
-    if (!canonical_path.is_valid()) {
-        dbg() << "FileSystemPath failed to canonicalize " << custody->absolute_path();
-        ASSERT_NOT_REACHED();
-    }
-
-    if (canonical_path.string().length() + 1 > params.buffer.size)
+    if (absolute_path.length() + 1 > params.buffer.size)
         return -ENAMETOOLONG;
 
-    copy_to_user(params.buffer.data, canonical_path.string().characters(), canonical_path.string().length() + 1);
+    copy_to_user(params.buffer.data, absolute_path.characters(), absolute_path.length() + 1);
     return 0;
 };
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -145,7 +145,6 @@ public:
     pid_t sys$getppid();
     mode_t sys$umask(mode_t);
     int sys$open(const Syscall::SC_open_params*);
-    int sys$openat(const Syscall::SC_openat_params*);
     int sys$close(int fd);
     ssize_t sys$read(int fd, u8*, ssize_t);
     ssize_t sys$write(int fd, const u8*, ssize_t);

--- a/Kernel/Syscall.h
+++ b/Kernel/Syscall.h
@@ -132,7 +132,6 @@ typedef u32 socklen_t;
     __ENUMERATE_SYSCALL(setkeymap)                  \
     __ENUMERATE_SYSCALL(clock_gettime)              \
     __ENUMERATE_SYSCALL(clock_nanosleep)            \
-    __ENUMERATE_SYSCALL(openat)                     \
     __ENUMERATE_SYSCALL(join_thread)                \
     __ENUMERATE_SYSCALL(module_load)                \
     __ENUMERATE_SYSCALL(module_unload)              \
@@ -218,12 +217,6 @@ struct SC_mmap_params {
 };
 
 struct SC_open_params {
-    StringArgument path;
-    int options;
-    u16 mode;
-};
-
-struct SC_openat_params {
     int dirfd;
     StringArgument path;
     int options;

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -29,10 +29,7 @@
 #include <Kernel/Devices/SB16.h>
 #include <Kernel/Devices/SerialDevice.h>
 #include <Kernel/Devices/ZeroDevice.h>
-#include <Kernel/FileSystem/DevPtsFS.h>
 #include <Kernel/FileSystem/Ext2FileSystem.h>
-#include <Kernel/FileSystem/ProcFS.h>
-#include <Kernel/FileSystem/TmpFS.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Heap/SlabAllocator.h>
 #include <Kernel/Heap/kmalloc.h>

--- a/Libraries/LibC/fcntl.cpp
+++ b/Libraries/LibC/fcntl.cpp
@@ -33,17 +33,7 @@ int creat_with_path_length(const char* path, size_t path_length, mode_t mode)
 
 int open_with_path_length(const char* path, size_t path_length, int options, mode_t mode)
 {
-    if (!path) {
-        errno = EFAULT;
-        return -1;
-    }
-    if (path_length > INT32_MAX) {
-        errno = EINVAL;
-        return -1;
-    }
-    Syscall::SC_open_params params { { path, path_length }, options, mode };
-    int rc = syscall(SC_open, &params);
-    __RETURN_WITH_ERRNO(rc, rc, -1);
+    return openat_with_path_length(AT_FDCWD, path, path_length, options, mode);
 }
 
 int openat_with_path_length(int dirfd, const char* path, size_t path_length, int options, mode_t mode)
@@ -56,8 +46,8 @@ int openat_with_path_length(int dirfd, const char* path, size_t path_length, int
         errno = EINVAL;
         return -1;
     }
-    Syscall::SC_openat_params params { dirfd, { path, path_length }, options, mode };
-    int rc = syscall(SC_openat, &params);
+    Syscall::SC_open_params params { dirfd, { path, path_length }, options, mode };
+    int rc = syscall(SC_open, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Libraries/LibCore/CIODevice.cpp
+++ b/Libraries/LibCore/CIODevice.cpp
@@ -124,7 +124,7 @@ ByteBuffer CIODevice::read_all()
         m_buffered_data.clear();
     }
 
-    while (can_read_from_fd()) {
+    while (true) {
         char read_buffer[4096];
         int nread = ::read(m_fd, read_buffer, sizeof(read_buffer));
         if (nread < 0) {

--- a/Userland/ls.cpp
+++ b/Userland/ls.cpp
@@ -295,7 +295,7 @@ int do_file_system_object_long(const char* path)
                 return 0;
             return 2;
         }
-        fprintf(stderr, "CDirIterator: %s\n", di.error_string());
+        fprintf(stderr, "%s: %s\n", path, di.error_string());
         return 1;
     }
 
@@ -370,7 +370,7 @@ int do_file_system_object_short(const char* path)
                 return 0;
             return 2;
         }
-        fprintf(stderr, "CDirIterator: %s\n", di.error_string());
+        fprintf(stderr, "%s: %s\n", path, di.error_string());
         return 1;
     }
 


### PR DESCRIPTION
```sh
$ mkdir /tmp/foo
$ cd /tmp/foo
$ mv /tmp/foo /tmp/bar
$ realpath /proc/self/cwd
/tmp/foo
$ ls /tmp/foo
/tmp/foo: No such file or directory
$ ls /proc/self/cwd
```

```sh
$ rpcdump PID | jp /dev/stdin
```
(should now work, but it doesn't seem to, because of ~other pipe bugs~ `rpcdump` outputting bogus data, oh well)

~Known bugs: `echo > /dev/stdout` causes the Shell to exit on `EBADF` when trying to read its stdin???~

You can open `/proc/pid/fd/fileno`, and you get back an fd referring to the very same file description in the kernel (they share offset, mode, flags and so on). It's as if you do a remote `dup()`.