### PR TITLE
LibVT: only use default bold font if it's the same size as our font

### DIFF
--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -340,7 +340,7 @@ void TerminalWidget::paint_event(GPaintEvent& event)
             painter.draw_glyph_or_emoji(
                 character_rect.location(),
                 codepoint,
-                attribute.flags & VT::Attribute::Bold ? Font::default_bold_fixed_width_font() : font(),
+                attribute.flags & VT::Attribute::Bold ? bold_font() : font(),
                 lookup_color(should_reverse_fill_for_cursor_or_selection ? attribute.background_color : attribute.foreground_color));
         }
     }
@@ -667,6 +667,15 @@ void TerminalWidget::did_change_font()
 {
     GFrame::did_change_font();
     m_line_height = font().glyph_height() + m_line_spacing;
+
+    // TODO: try to find a bold version of the new font (e.g. CsillaThin7x10 -> CsillaBold7x10)
+    const Font& bold_font = Font::default_bold_fixed_width_font();
+
+    if (bold_font.glyph_height() == font().glyph_height() && bold_font.glyph_width(' ') == font().glyph_width(' '))
+        m_bold_font = &bold_font;
+    else
+        m_bold_font = font();
+
     if (!size().is_empty())
         relayout(size());
 }

--- a/Libraries/LibVT/TerminalWidget.h
+++ b/Libraries/LibVT/TerminalWidget.h
@@ -32,6 +32,8 @@ public:
 
     void apply_size_increments_to_window(GWindow&);
 
+    const Font& bold_font() const { return *m_bold_font; }
+
     void set_opacity(u8);
     float opacity() { return m_opacity; };
     bool should_beep() { return m_should_beep; }
@@ -119,6 +121,8 @@ private:
     bool m_needs_background_fill { true };
     bool m_cursor_blink_state { true };
     bool m_automatic_size_policy { false };
+
+    RefPtr<Font> m_bold_font;
 
     int m_glyph_width { 0 };
 


### PR DESCRIPTION
When the new font is a different size, just use that font for bold glyphs as well.