### PR TITLE
LibVT: enforce a minimum size of 1 column and 1 row

### DIFF
--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -867,6 +867,11 @@ void Terminal::unimplemented_xterm_escape()
 
 void Terminal::set_size(u16 columns, u16 rows)
 {
+    if (!columns)
+        columns = 1;
+    if (!rows)
+        rows = 1;
+
     if (columns == m_columns && rows == m_rows)
         return;
 

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -150,8 +150,8 @@ private:
     int m_scroll_region_top { 0 };
     int m_scroll_region_bottom { 0 };
 
-    u16 m_columns { 0 };
-    u16 m_rows { 0 };
+    u16 m_columns { 1 };
+    u16 m_rows { 1 };
 
     u16 m_cursor_row { 0 };
     u16 m_cursor_column { 0 };


### PR DESCRIPTION
`m_cursor_row` or `m_cursor_column` can otherwise get set to 65535 since this function later subtracts 1 from the `u16`  values passed in.

Fixes #829