### PR TITLE
Browser: Add proc pledge

### DIFF
--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -30,7 +30,7 @@ static const char* home_url = "file:///home/anon/www/welcome.html";
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio shared_buffer accept unix cpath rpath fattr", nullptr) < 0) {
+    if (pledge("stdio shared_buffer proc accept unix cpath rpath fattr", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
     // Connect to the ProtocolServer immediately so we can drop the "unix" pledge.
     ResourceLoader::the();
 
-    if (pledge("stdio shared_buffer accept rpath", nullptr) < 0) {
+    if (pledge("stdio shared_buffer proc accept rpath", nullptr) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
proc seems to be required for resource loading in some cases. This fixes
bettermotherfuckingwebsite.com not being able to load (and crashing the
browser). The browser will definitely be using different processes in the
future, adding the pledge now does not seem like a big deal.