### PR TITLE
LookupServer: Lock unveil() after initialization.

### DIFF
--- a/Servers/LookupServer/main.cpp
+++ b/Servers/LookupServer/main.cpp
@@ -46,5 +46,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
+    unveil(nullptr, nullptr);
+
     return event_loop.exec();
 }


### PR DESCRIPTION
Once LookupServer is initialized it should never need
access to any any paths for the lifetime of the process.

Lock the veil post initialization.