### PR TITLE
More dran'n'drop

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -131,12 +131,12 @@ StringView String::substring_view(size_t start, size_t length) const
     return { characters() + start, length };
 }
 
-Vector<String> String::split(const char separator) const
+Vector<String> String::split(char separator, bool keep_empty) const
 {
-    return split_limit(separator, 0);
+    return split_limit(separator, 0, keep_empty);
 }
 
-Vector<String> String::split_limit(const char separator, size_t limit) const
+Vector<String> String::split_limit(char separator, size_t limit, bool keep_empty) const
 {
     if (is_empty())
         return {};
@@ -147,16 +147,14 @@ Vector<String> String::split_limit(const char separator, size_t limit) const
         char ch = characters()[i];
         if (ch == separator) {
             size_t sublen = i - substart;
-            if (sublen != 0)
+            if (sublen != 0 || keep_empty)
                 v.append(substring(substart, sublen));
             substart = i + 1;
         }
     }
     size_t taillen = length() - substart;
-    if (taillen != 0)
+    if (taillen != 0 || keep_empty)
         v.append(substring(substart, taillen));
-    if (characters()[length() - 1] == separator)
-        v.append(empty());
     return v;
 }
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -140,8 +140,8 @@ public:
 
     bool contains(const String&) const;
 
-    Vector<String> split_limit(char separator, size_t limit) const;
-    Vector<String> split(char separator) const;
+    Vector<String> split_limit(char separator, size_t limit, bool keep_empty = false) const;
+    Vector<String> split(char separator, bool keep_empty = false) const;
     String substring(size_t start, size_t length) const;
 
     Vector<StringView> split_view(char separator, bool keep_empty = false) const;

--- a/Libraries/LibGUI/GAbstractColumnView.cpp
+++ b/Libraries/LibGUI/GAbstractColumnView.cpp
@@ -396,6 +396,13 @@ GModelIndex GAbstractColumnView::index_at_event_position(const Point& position, 
     return {};
 }
 
+GModelIndex GAbstractColumnView::index_at_event_position(const Point& position) const
+{
+    bool is_toggle;
+    auto index = index_at_event_position(position, is_toggle);
+    return is_toggle ? GModelIndex() : index;
+}
+
 int GAbstractColumnView::item_count() const
 {
     if (!model())

--- a/Libraries/LibGUI/GAbstractColumnView.cpp
+++ b/Libraries/LibGUI/GAbstractColumnView.cpp
@@ -251,7 +251,7 @@ int GAbstractColumnView::column_width(int column_index) const
 void GAbstractColumnView::mousemove_event(GMouseEvent& event)
 {
     if (!model())
-        return;
+        return GAbstractView::mousemove_event(event);
 
     if (m_in_column_resize) {
         auto delta = event.position() - m_column_resize_origin;
@@ -301,6 +301,8 @@ void GAbstractColumnView::mousemove_event(GMouseEvent& event)
             set_hovered_header_index(-1);
     }
     window()->set_override_cursor(GStandardCursor::None);
+
+    GAbstractView::mousemove_event(event);
 }
 
 void GAbstractColumnView::mouseup_event(GMouseEvent& event)
@@ -311,6 +313,7 @@ void GAbstractColumnView::mouseup_event(GMouseEvent& event)
             if (!column_resize_grabbable_rect(m_resizing_column).contains(adjusted_position))
                 window()->set_override_cursor(GStandardCursor::None);
             m_in_column_resize = false;
+            return;
         }
         if (m_pressed_column_header_index != -1) {
             auto header_rect = this->header_rect(m_pressed_column_header_index);
@@ -325,17 +328,20 @@ void GAbstractColumnView::mouseup_event(GMouseEvent& event)
             m_pressed_column_header_index = -1;
             m_pressed_column_header_is_pressed = false;
             update_headers();
+            return;
         }
     }
+
+    GAbstractView::mouseup_event(event);
 }
 
 void GAbstractColumnView::mousedown_event(GMouseEvent& event)
 {
     if (!model())
-        return;
+        return GAbstractView::mousedown_event(event);
 
     if (event.button() != GMouseButton::Left)
-        return;
+        return GAbstractView::mousedown_event(event);
 
     if (event.y() < header_height()) {
         int column_count = model()->column_count();
@@ -361,19 +367,13 @@ void GAbstractColumnView::mousedown_event(GMouseEvent& event)
 
     bool is_toggle;
     auto index = index_at_event_position(event.position(), is_toggle);
-    if (!index.is_valid()) {
-        selection().clear();
-        return;
-    }
-    if (is_toggle && model()->row_count(index)) {
+
+    if (index.is_valid() && is_toggle && model()->row_count(index)) {
         toggle_index(index);
         return;
     }
 
-    if (event.modifiers() & Mod_Ctrl)
-        selection().toggle(index);
-    else
-        selection().set(index);
+    GAbstractView::mousedown_event(event);
 }
 
 GModelIndex GAbstractColumnView::index_at_event_position(const Point& position, bool& is_toggle) const

--- a/Libraries/LibGUI/GAbstractColumnView.h
+++ b/Libraries/LibGUI/GAbstractColumnView.h
@@ -68,6 +68,9 @@ public:
 
     void scroll_into_view(const GModelIndex&, Orientation);
 
+    virtual GModelIndex index_at_event_position(const Point&, bool& is_toggle) const;
+    virtual GModelIndex index_at_event_position(const Point&) const override;
+
 protected:
     virtual ~GAbstractColumnView() override;
     explicit GAbstractColumnView(GWidget* parent);
@@ -81,7 +84,6 @@ protected:
     virtual void leave_event(CEvent&) override;
     virtual void context_menu_event(GContextMenuEvent&) override;
 
-    virtual GModelIndex index_at_event_position(const Point&, bool& is_toggle) const;
     virtual void toggle_index(const GModelIndex&) {}
 
     void paint_headers(GPainter&);

--- a/Libraries/LibGUI/GAbstractTableView.cpp
+++ b/Libraries/LibGUI/GAbstractTableView.cpp
@@ -26,7 +26,7 @@
 
 #include <AK/StringBuilder.h>
 #include <LibDraw/Palette.h>
-#include <LibGUI/GAbstractColumnView.h>
+#include <LibGUI/GAbstractTableView.h>
 #include <LibGUI/GAction.h>
 #include <LibGUI/GMenu.h>
 #include <LibGUI/GPainter.h>
@@ -34,7 +34,7 @@
 
 static const int minimum_column_width = 2;
 
-GAbstractColumnView::GAbstractColumnView(GWidget* parent)
+GAbstractTableView::GAbstractTableView(GWidget* parent)
     : GAbstractView(parent)
 {
     set_frame_shape(FrameShape::Container);
@@ -44,11 +44,11 @@ GAbstractColumnView::GAbstractColumnView(GWidget* parent)
     set_should_hide_unnecessary_scrollbars(true);
 }
 
-GAbstractColumnView::~GAbstractColumnView()
+GAbstractTableView::~GAbstractTableView()
 {
 }
 
-void GAbstractColumnView::update_column_sizes()
+void GAbstractTableView::update_column_sizes()
 {
     if (!m_size_columns_to_fit_content)
         return;
@@ -84,7 +84,7 @@ void GAbstractColumnView::update_column_sizes()
     }
 }
 
-void GAbstractColumnView::update_content_size()
+void GAbstractTableView::update_content_size()
 {
     if (!model())
         return set_content_size({});
@@ -101,7 +101,7 @@ void GAbstractColumnView::update_content_size()
     set_size_occupied_by_fixed_elements({ 0, header_height() });
 }
 
-Rect GAbstractColumnView::header_rect(int column_index) const
+Rect GAbstractTableView::header_rect(int column_index) const
 {
     if (!model())
         return {};
@@ -116,7 +116,7 @@ Rect GAbstractColumnView::header_rect(int column_index) const
     return { x_offset, 0, column_width(column_index) + horizontal_padding() * 2, header_height() };
 }
 
-void GAbstractColumnView::set_hovered_header_index(int index)
+void GAbstractTableView::set_hovered_header_index(int index)
 {
     if (m_hovered_column_header_index == index)
         return;
@@ -124,7 +124,7 @@ void GAbstractColumnView::set_hovered_header_index(int index)
     update_headers();
 }
 
-void GAbstractColumnView::paint_headers(GPainter& painter)
+void GAbstractTableView::paint_headers(GPainter& painter)
 {
     if (!headers_visible())
         return;
@@ -164,12 +164,12 @@ void GAbstractColumnView::paint_headers(GPainter& painter)
     }
 }
 
-bool GAbstractColumnView::is_column_hidden(int column) const
+bool GAbstractTableView::is_column_hidden(int column) const
 {
     return !column_data(column).visibility;
 }
 
-void GAbstractColumnView::set_column_hidden(int column, bool hidden)
+void GAbstractTableView::set_column_hidden(int column, bool hidden)
 {
     auto& column_data = this->column_data(column);
     if (column_data.visibility == !hidden)
@@ -179,7 +179,7 @@ void GAbstractColumnView::set_column_hidden(int column, bool hidden)
     update();
 }
 
-GMenu& GAbstractColumnView::ensure_header_context_menu()
+GMenu& GAbstractTableView::ensure_header_context_menu()
 {
     // FIXME: This menu needs to be rebuilt if the model is swapped out,
     //        or if the column count/names change.
@@ -203,31 +203,31 @@ GMenu& GAbstractColumnView::ensure_header_context_menu()
     return *m_header_context_menu;
 }
 
-const Font& GAbstractColumnView::header_font()
+const Font& GAbstractTableView::header_font()
 {
     return Font::default_bold_font();
 }
 
-void GAbstractColumnView::set_cell_painting_delegate(int column, OwnPtr<GTableCellPaintingDelegate>&& delegate)
+void GAbstractTableView::set_cell_painting_delegate(int column, OwnPtr<GTableCellPaintingDelegate>&& delegate)
 {
     column_data(column).cell_painting_delegate = move(delegate);
 }
 
-void GAbstractColumnView::update_headers()
+void GAbstractTableView::update_headers()
 {
     Rect rect { 0, 0, frame_inner_rect().width(), header_height() };
     rect.move_by(frame_thickness(), frame_thickness());
     update(rect);
 }
 
-GAbstractColumnView::ColumnData& GAbstractColumnView::column_data(int column) const
+GAbstractTableView::ColumnData& GAbstractTableView::column_data(int column) const
 {
     if (column >= m_column_data.size())
         m_column_data.resize(column + 1);
     return m_column_data.at(column);
 }
 
-Rect GAbstractColumnView::column_resize_grabbable_rect(int column) const
+Rect GAbstractTableView::column_resize_grabbable_rect(int column) const
 {
     if (!model())
         return {};
@@ -235,7 +235,7 @@ Rect GAbstractColumnView::column_resize_grabbable_rect(int column) const
     return { header_rect.right() - 1, header_rect.top(), 4, header_rect.height() };
 }
 
-int GAbstractColumnView::column_width(int column_index) const
+int GAbstractTableView::column_width(int column_index) const
 {
     if (!model())
         return 0;
@@ -248,7 +248,7 @@ int GAbstractColumnView::column_width(int column_index) const
     return column_data.width;
 }
 
-void GAbstractColumnView::mousemove_event(GMouseEvent& event)
+void GAbstractTableView::mousemove_event(GMouseEvent& event)
 {
     if (!model())
         return GAbstractView::mousemove_event(event);
@@ -305,7 +305,7 @@ void GAbstractColumnView::mousemove_event(GMouseEvent& event)
     GAbstractView::mousemove_event(event);
 }
 
-void GAbstractColumnView::mouseup_event(GMouseEvent& event)
+void GAbstractTableView::mouseup_event(GMouseEvent& event)
 {
     auto adjusted_position = this->adjusted_position(event.position());
     if (event.button() == GMouseButton::Left) {
@@ -335,7 +335,7 @@ void GAbstractColumnView::mouseup_event(GMouseEvent& event)
     GAbstractView::mouseup_event(event);
 }
 
-void GAbstractColumnView::mousedown_event(GMouseEvent& event)
+void GAbstractTableView::mousedown_event(GMouseEvent& event)
 {
     if (!model())
         return GAbstractView::mousedown_event(event);
@@ -376,7 +376,7 @@ void GAbstractColumnView::mousedown_event(GMouseEvent& event)
     GAbstractView::mousedown_event(event);
 }
 
-GModelIndex GAbstractColumnView::index_at_event_position(const Point& position, bool& is_toggle) const
+GModelIndex GAbstractTableView::index_at_event_position(const Point& position, bool& is_toggle) const
 {
     is_toggle = false;
     if (!model())
@@ -396,21 +396,21 @@ GModelIndex GAbstractColumnView::index_at_event_position(const Point& position, 
     return {};
 }
 
-GModelIndex GAbstractColumnView::index_at_event_position(const Point& position) const
+GModelIndex GAbstractTableView::index_at_event_position(const Point& position) const
 {
     bool is_toggle;
     auto index = index_at_event_position(position, is_toggle);
     return is_toggle ? GModelIndex() : index;
 }
 
-int GAbstractColumnView::item_count() const
+int GAbstractTableView::item_count() const
 {
     if (!model())
         return 0;
     return model()->row_count();
 }
 
-void GAbstractColumnView::keydown_event(GKeyEvent& event)
+void GAbstractTableView::keydown_event(GKeyEvent& event)
 {
     if (!model())
         return;
@@ -474,13 +474,13 @@ void GAbstractColumnView::keydown_event(GKeyEvent& event)
     return GWidget::keydown_event(event);
 }
 
-void GAbstractColumnView::scroll_into_view(const GModelIndex& index, Orientation orientation)
+void GAbstractTableView::scroll_into_view(const GModelIndex& index, Orientation orientation)
 {
     auto rect = row_rect(index.row()).translated(0, -header_height());
     GScrollableWidget::scroll_into_view(rect, orientation);
 }
 
-void GAbstractColumnView::doubleclick_event(GMouseEvent& event)
+void GAbstractTableView::doubleclick_event(GMouseEvent& event)
 {
     if (!model())
         return;
@@ -496,7 +496,7 @@ void GAbstractColumnView::doubleclick_event(GMouseEvent& event)
     }
 }
 
-void GAbstractColumnView::context_menu_event(GContextMenuEvent& event)
+void GAbstractTableView::context_menu_event(GContextMenuEvent& event)
 {
     if (!model())
         return;
@@ -517,13 +517,13 @@ void GAbstractColumnView::context_menu_event(GContextMenuEvent& event)
         on_context_menu_request(index, event);
 }
 
-void GAbstractColumnView::leave_event(CEvent&)
+void GAbstractTableView::leave_event(CEvent&)
 {
     window()->set_override_cursor(GStandardCursor::None);
     set_hovered_header_index(-1);
 }
 
-Rect GAbstractColumnView::content_rect(int row, int column) const
+Rect GAbstractTableView::content_rect(int row, int column) const
 {
     auto row_rect = this->row_rect(row);
     int x = 0;
@@ -533,22 +533,22 @@ Rect GAbstractColumnView::content_rect(int row, int column) const
     return { row_rect.x() + x, row_rect.y(), column_width(column) + horizontal_padding() * 2, item_height() };
 }
 
-Rect GAbstractColumnView::content_rect(const GModelIndex& index) const
+Rect GAbstractTableView::content_rect(const GModelIndex& index) const
 {
     return content_rect(index.row(), index.column());
 }
 
-Rect GAbstractColumnView::row_rect(int item_index) const
+Rect GAbstractTableView::row_rect(int item_index) const
 {
     return { 0, header_height() + (item_index * item_height()), max(content_size().width(), width()), item_height() };
 }
 
-Point GAbstractColumnView::adjusted_position(const Point& position) const
+Point GAbstractTableView::adjusted_position(const Point& position) const
 {
     return position.translated(horizontal_scrollbar().value() - frame_thickness(), vertical_scrollbar().value() - frame_thickness());
 }
 
-void GAbstractColumnView::did_update_model()
+void GAbstractTableView::did_update_model()
 {
     GAbstractView::did_update_model();
     update_column_sizes();

--- a/Libraries/LibGUI/GAbstractTableView.h
+++ b/Libraries/LibGUI/GAbstractTableView.h
@@ -38,7 +38,7 @@ public:
     virtual void paint(GPainter&, const Rect&, const Palette&, const GModel&, const GModelIndex&) = 0;
 };
 
-class GAbstractColumnView : public GAbstractView {
+class GAbstractTableView : public GAbstractView {
 public:
     int item_height() const { return 16; }
 
@@ -72,8 +72,8 @@ public:
     virtual GModelIndex index_at_event_position(const Point&) const override;
 
 protected:
-    virtual ~GAbstractColumnView() override;
-    explicit GAbstractColumnView(GWidget* parent);
+    virtual ~GAbstractTableView() override;
+    explicit GAbstractTableView(GWidget* parent);
 
     virtual void did_update_model() override;
     virtual void mouseup_event(GMouseEvent&) override;

--- a/Libraries/LibGUI/GAbstractView.cpp
+++ b/Libraries/LibGUI/GAbstractView.cpp
@@ -191,7 +191,7 @@ void GAbstractView::mousedown_event(GMouseEvent& event)
         m_selection.clear();
     } else if (event.modifiers() & Mod_Ctrl) {
         m_selection.toggle(index);
-    } else if (event.button() == GMouseButton::Left) {
+    } else if (event.button() == GMouseButton::Left && !m_model->drag_data_type().is_null()) {
         // We might be starting a drag, so don't throw away other selected items yet.
         m_might_drag = true;
         m_selection.add(index);
@@ -218,6 +218,9 @@ void GAbstractView::mousemove_event(GMouseEvent& event)
 
     if (distance_travelled_squared <= drag_distance_threshold)
         return GScrollableWidget::mousemove_event(event);
+
+    auto data_type = m_model->drag_data_type();
+    ASSERT(!data_type.is_null());
 
     dbg() << "Initiate drag!";
     auto drag_operation = GDragOperation::construct();
@@ -248,7 +251,7 @@ void GAbstractView::mousemove_event(GMouseEvent& event)
 
     drag_operation->set_text(text_builder.to_string());
     drag_operation->set_bitmap(bitmap);
-    drag_operation->set_data("url-list", data_builder.to_string());
+    drag_operation->set_data(data_type, data_builder.to_string());
 
     auto outcome = drag_operation->exec();
 

--- a/Libraries/LibGUI/GAbstractView.h
+++ b/Libraries/LibGUI/GAbstractView.h
@@ -76,6 +76,12 @@ protected:
     explicit GAbstractView(GWidget* parent);
     virtual ~GAbstractView() override;
 
+    virtual void mousedown_event(GMouseEvent&) override;
+    virtual void mousemove_event(GMouseEvent&) override;
+    virtual void mouseup_event(GMouseEvent&) override;
+    virtual void doubleclick_event(GMouseEvent&) override;
+    virtual void context_menu_event(GContextMenuEvent&) override;
+
     virtual void did_scroll() override;
     void activate(const GModelIndex&);
     void activate_selected();
@@ -85,6 +91,9 @@ protected:
     GModelIndex m_edit_index;
     RefPtr<GWidget> m_edit_widget;
     Rect m_edit_widget_content_rect;
+
+    Point m_left_mousedown_position;
+    bool m_might_drag { false };
 
 private:
     RefPtr<GModel> m_model;

--- a/Libraries/LibGUI/GAbstractView.h
+++ b/Libraries/LibGUI/GAbstractView.h
@@ -54,6 +54,7 @@ public:
     virtual void did_update_selection();
 
     virtual Rect content_rect(const GModelIndex&) const { return {}; }
+    virtual GModelIndex index_at_event_position(const Point&) const = 0;
     void begin_editing(const GModelIndex&);
     void stop_editing();
 

--- a/Libraries/LibGUI/GColumnsView.cpp
+++ b/Libraries/LibGUI/GColumnsView.cpp
@@ -216,6 +216,8 @@ GModelIndex GColumnsView::index_at_event_position(const Point& a_position) const
 
 void GColumnsView::mousedown_event(GMouseEvent& event)
 {
+    GAbstractView::mousedown_event(event);
+
     if (!model())
         return;
 
@@ -223,15 +225,7 @@ void GColumnsView::mousedown_event(GMouseEvent& event)
         return;
 
     auto index = index_at_event_position(event.position());
-    if (!index.is_valid()) {
-        selection().clear();
-        return;
-    }
-
-    if (event.modifiers() & Mod_Ctrl) {
-        selection().toggle(index);
-    } else {
-        selection().set(index);
+    if (index.is_valid() && !(event.modifiers() & Mod_Ctrl)) {
         if (model()->row_count(index))
             push_column(index);
     }
@@ -248,34 +242,6 @@ void GColumnsView::did_update_model()
 
     update_column_sizes();
     update();
-}
-
-void GColumnsView::doubleclick_event(GMouseEvent& event)
-{
-    if (!model())
-        return;
-
-    if (event.button() != GMouseButton::Left)
-        return;
-
-    mousedown_event(event);
-    activate_selected();
-}
-
-void GColumnsView::context_menu_event(GContextMenuEvent& event)
-{
-    if (!model())
-        return;
-
-    auto index = index_at_event_position(event.position());
-    if (index.is_valid()) {
-        if (!selection().contains(index))
-            selection().set(index);
-    } else {
-        selection().clear();
-    }
-    if (on_context_menu_request)
-        on_context_menu_request(index, event);
 }
 
 void GColumnsView::keydown_event(GKeyEvent& event)

--- a/Libraries/LibGUI/GColumnsView.h
+++ b/Libraries/LibGUI/GColumnsView.h
@@ -35,11 +35,11 @@ public:
     int model_column() const { return m_model_column; }
     void set_model_column(int column) { m_model_column = column; }
 
+    virtual GModelIndex index_at_event_position(const Point&) const override;
+
 private:
     GColumnsView(GWidget* parent = nullptr);
     virtual ~GColumnsView();
-
-    GModelIndex index_at_event_position(const Point&) const;
     void push_column(GModelIndex& parent_index);
     void update_column_sizes();
 

--- a/Libraries/LibGUI/GColumnsView.h
+++ b/Libraries/LibGUI/GColumnsView.h
@@ -51,8 +51,6 @@ private:
     virtual void did_update_model() override;
     virtual void paint_event(GPaintEvent&) override;
     virtual void mousedown_event(GMouseEvent& event) override;
-    virtual void doubleclick_event(GMouseEvent& event) override;
-    virtual void context_menu_event(GContextMenuEvent& event) override;
     virtual void keydown_event(GKeyEvent& event) override;
 
     struct Column {

--- a/Libraries/LibGUI/GFileSystemModel.h
+++ b/Libraries/LibGUI/GFileSystemModel.h
@@ -117,6 +117,7 @@ public:
     virtual void update() override;
     virtual GModelIndex parent_index(const GModelIndex&) const override;
     virtual GModelIndex index(int row, int column = 0, const GModelIndex& parent = GModelIndex()) const override;
+    virtual StringView drag_data_type() const override { return "url-list"; }
 
     static String timestamp_string(time_t timestamp)
     {

--- a/Libraries/LibGUI/GItemView.cpp
+++ b/Libraries/LibGUI/GItemView.cpp
@@ -198,8 +198,8 @@ void GItemView::mousemove_event(GMouseEvent& event)
                 selection().add(model()->index(item_index, model_column()));
             }
             if (event.modifiers() & Mod_Ctrl) {
-                for (auto storeditem : m_rubber_band_remembered_selection) {
-                    selection().add(storeditem);
+                for (auto stored_item : m_rubber_band_remembered_selection) {
+                    selection().add(stored_item);
                 }
             }
             update();

--- a/Libraries/LibGUI/GItemView.h
+++ b/Libraries/LibGUI/GItemView.h
@@ -61,8 +61,6 @@ private:
     virtual void mousemove_event(GMouseEvent&) override;
     virtual void mouseup_event(GMouseEvent&) override;
     virtual void keydown_event(GKeyEvent&) override;
-    virtual void doubleclick_event(GMouseEvent&) override;
-    virtual void context_menu_event(GContextMenuEvent&) override;
 
     int item_count() const;
     Rect item_rect(int item_index) const;
@@ -74,10 +72,6 @@ private:
     int m_model_column { 0 };
     int m_visual_column_count { 0 };
     int m_visual_row_count { 0 };
-
-    bool m_might_drag { false };
-
-    Point m_left_mousedown_position;
 
     Size m_effective_item_size { 80, 80 };
 

--- a/Libraries/LibGUI/GItemView.h
+++ b/Libraries/LibGUI/GItemView.h
@@ -64,7 +64,7 @@ private:
 
     int item_count() const;
     Rect item_rect(int item_index) const;
-    int item_at_event_position(const Point&) const;
+    GModelIndex index_at_event_position(const Point&) const;
     Vector<int> items_intersecting_rect(const Rect&) const;
     void update_content_size();
     void get_item_rects(int item_index, const Font&, const GVariant& item_text, Rect& item_rect, Rect& icon_rect, Rect& text_rect) const;

--- a/Libraries/LibGUI/GItemView.h
+++ b/Libraries/LibGUI/GItemView.h
@@ -48,6 +48,8 @@ public:
     int model_column() const { return m_model_column; }
     void set_model_column(int column) { m_model_column = column; }
 
+    virtual GModelIndex index_at_event_position(const Point&) const override;
+
 private:
     explicit GItemView(GWidget* parent);
 
@@ -64,7 +66,6 @@ private:
 
     int item_count() const;
     Rect item_rect(int item_index) const;
-    GModelIndex index_at_event_position(const Point&) const;
     Vector<int> items_intersecting_rect(const Rect&) const;
     void update_content_size();
     void get_item_rects(int item_index, const Font&, const GVariant& item_text, Rect& item_rect, Rect& icon_rect, Rect& text_rect) const;

--- a/Libraries/LibGUI/GListView.cpp
+++ b/Libraries/LibGUI/GListView.cpp
@@ -102,25 +102,6 @@ Point GListView::adjusted_position(const Point& position) const
     return position.translated(horizontal_scrollbar().value() - frame_thickness(), vertical_scrollbar().value() - frame_thickness());
 }
 
-void GListView::mousedown_event(GMouseEvent& event)
-{
-    if (!model())
-        return;
-
-    if (event.button() != GMouseButton::Left)
-        return;
-
-    auto index = index_at_event_position(event.position());
-    if (index.is_valid()) {
-        if (event.modifiers() & Mod_Ctrl)
-            selection().toggle(index);
-        else
-            selection().set(index);
-    } else {
-        selection().clear();
-    }
-}
-
 void GListView::paint_event(GPaintEvent& event)
 {
     GFrame::paint_event(event);

--- a/Libraries/LibGUI/GListView.h
+++ b/Libraries/LibGUI/GListView.h
@@ -49,8 +49,9 @@ public:
 
     void scroll_into_view(const GModelIndex&, Orientation);
 
-    Point adjusted_position(const Point&);
+    Point adjusted_position(const Point&) const;
 
+    GModelIndex index_at_event_position(const Point&) const;
     virtual Rect content_rect(const GModelIndex&) const override;
 
     int model_column() const { return m_model_column; }

--- a/Libraries/LibGUI/GListView.h
+++ b/Libraries/LibGUI/GListView.h
@@ -51,7 +51,7 @@ public:
 
     Point adjusted_position(const Point&) const;
 
-    GModelIndex index_at_event_position(const Point&) const;
+    virtual GModelIndex index_at_event_position(const Point&) const override;
     virtual Rect content_rect(const GModelIndex&) const override;
 
     int model_column() const { return m_model_column; }

--- a/Libraries/LibGUI/GListView.h
+++ b/Libraries/LibGUI/GListView.h
@@ -60,7 +60,6 @@ public:
 private:
     virtual void did_update_model() override;
     virtual void paint_event(GPaintEvent&) override;
-    virtual void mousedown_event(GMouseEvent&) override;
     virtual void doubleclick_event(GMouseEvent&) override;
     virtual void keydown_event(GKeyEvent&) override;
     virtual void resize_event(GResizeEvent&) override;

--- a/Libraries/LibGUI/GModel.h
+++ b/Libraries/LibGUI/GModel.h
@@ -94,6 +94,8 @@ public:
     virtual GSortOrder sort_order() const { return GSortOrder::None; }
     virtual void set_key_column_and_sort_order(int, GSortOrder) {}
 
+    virtual StringView drag_data_type() const { return {}; }
+
     void register_view(Badge<GAbstractView>, GAbstractView&);
     void unregister_view(Badge<GAbstractView>, GAbstractView&);
 

--- a/Libraries/LibGUI/GSortingProxyModel.cpp
+++ b/Libraries/LibGUI/GSortingProxyModel.cpp
@@ -87,6 +87,11 @@ void GSortingProxyModel::update()
     target().update();
 }
 
+StringView GSortingProxyModel::drag_data_type() const
+{
+    return target().drag_data_type();
+}
+
 void GSortingProxyModel::set_key_column_and_sort_order(int column, GSortOrder sort_order)
 {
     if (column == m_key_column && sort_order == m_sort_order)

--- a/Libraries/LibGUI/GSortingProxyModel.h
+++ b/Libraries/LibGUI/GSortingProxyModel.h
@@ -40,6 +40,7 @@ public:
     virtual ColumnMetadata column_metadata(int) const override;
     virtual GVariant data(const GModelIndex&, Role = Role::Display) const override;
     virtual void update() override;
+    virtual StringView drag_data_type() const override;
 
     virtual int key_column() const override { return m_key_column; }
     virtual GSortOrder sort_order() const override { return m_sort_order; }

--- a/Libraries/LibGUI/GTableView.cpp
+++ b/Libraries/LibGUI/GTableView.cpp
@@ -37,7 +37,7 @@
 #include <LibGUI/GWindow.h>
 
 GTableView::GTableView(GWidget* parent)
-    : GAbstractColumnView(parent)
+    : GAbstractTableView(parent)
 {
     set_background_role(ColorRole::Base);
     set_foreground_role(ColorRole::BaseText);

--- a/Libraries/LibGUI/GTableView.h
+++ b/Libraries/LibGUI/GTableView.h
@@ -28,10 +28,10 @@
 
 #include <AK/Function.h>
 #include <AK/HashMap.h>
-#include <LibGUI/GAbstractColumnView.h>
+#include <LibGUI/GAbstractTableView.h>
 #include <LibGUI/GModel.h>
 
-class GTableView : public GAbstractColumnView {
+class GTableView : public GAbstractTableView {
     C_OBJECT(GTableView)
 public:
     virtual ~GTableView() override;

--- a/Libraries/LibGUI/GTextEditor.h
+++ b/Libraries/LibGUI/GTextEditor.h
@@ -90,7 +90,6 @@ public:
     // FIXME: This should take glyph spacing into account, no?
     int glyph_width() const { return font().glyph_width('x'); }
 
-
     void insert_at_cursor_or_replace_selection(const StringView&);
     bool write_to_file(const StringView& path);
     bool has_selection() const { return m_selection.is_valid(); }

--- a/Libraries/LibGUI/GTreeView.cpp
+++ b/Libraries/LibGUI/GTreeView.cpp
@@ -435,7 +435,6 @@ void GTreeView::keydown_event(GKeyEvent& event)
             return;
         }
     }
-
 }
 
 int GTreeView::item_count() const

--- a/Libraries/LibGUI/GTreeView.cpp
+++ b/Libraries/LibGUI/GTreeView.cpp
@@ -48,7 +48,7 @@ GTreeView::MetadataForIndex& GTreeView::ensure_metadata_for_index(const GModelIn
 }
 
 GTreeView::GTreeView(GWidget* parent)
-    : GAbstractColumnView(parent)
+    : GAbstractTableView(parent)
 {
     set_background_role(ColorRole::Base);
     set_foreground_role(ColorRole::BaseText);
@@ -331,7 +331,7 @@ void GTreeView::scroll_into_view(const GModelIndex& a_index, Orientation orienta
 void GTreeView::did_update_model()
 {
     m_view_metadata.clear();
-    GAbstractColumnView::did_update_model();
+    GAbstractTableView::did_update_model();
 }
 
 void GTreeView::did_update_selection()

--- a/Libraries/LibGUI/GTreeView.h
+++ b/Libraries/LibGUI/GTreeView.h
@@ -26,9 +26,9 @@
 
 #pragma once
 
-#include <LibGUI/GAbstractColumnView.h>
+#include <LibGUI/GAbstractTableView.h>
 
-class GTreeView : public GAbstractColumnView {
+class GTreeView : public GAbstractTableView {
     C_OBJECT(GTreeView)
 public:
     virtual ~GTreeView() override;

--- a/Libraries/LibGUI/Makefile
+++ b/Libraries/LibGUI/Makefile
@@ -35,7 +35,7 @@ OBJS = \
     GDesktop.o \
     GProgressBar.o \
     GAbstractView.o \
-    GAbstractColumnView.o \
+    GAbstractTableView.o \
     GItemView.o \
     GIcon.o \
     GFrame.o \

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -689,6 +689,27 @@ void TerminalWidget::context_menu_event(GContextMenuEvent& event)
     m_context_menu->popup(event.screen_position());
 }
 
+void TerminalWidget::drop_event(GDropEvent& event)
+{
+    if (event.data_type() == "text") {
+        event.accept();
+        write(m_ptm_fd, event.data().characters(), event.data().length());
+    } else if (event.data_type() == "url-list") {
+        event.accept();
+        auto lines = event.data().split('\n');
+        bool first = true;
+        for (auto& line : lines) {
+            if (!first)
+                write(m_ptm_fd, " ", 1);
+            first = false;
+
+            if (line.starts_with("file://"))
+                line = line.substring(7, line.length() - 7);
+            write(m_ptm_fd, line.characters(), line.length());
+        }
+    }
+}
+
 void TerminalWidget::did_change_font()
 {
     GFrame::did_change_font();

--- a/Libraries/LibVT/TerminalWidget.h
+++ b/Libraries/LibVT/TerminalWidget.h
@@ -100,6 +100,7 @@ private:
     virtual void focusin_event(CEvent&) override;
     virtual void focusout_event(CEvent&) override;
     virtual void context_menu_event(GContextMenuEvent&) override;
+    virtual void drop_event(GDropEvent&) override;
     virtual void did_change_font() override;
 
     // ^TerminalClient


### PR DESCRIPTION
* Input dragged file path into the terminal on drop
* Move most of mouse event handling up to `GAbstractView`
    * This deduplicates existing code, and also gives all the model-backed widgets selection manipulation and drag support for free :smile:
* Rename `GAbstractColumnView` to `GAbstractTableView`
* Misc

cc @DAlperin