### PR TITLE
Ports: Add flex and pcre2 ports

### DIFF
--- a/Ports/flex/package.sh
+++ b/Ports/flex/package.sh
@@ -1,0 +1,8 @@
+#!/bin/bash ../.port_include.sh
+port=flex
+version=2.6.4
+curlopts="-L"
+files="https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz flex-2.6.4.tar.gz"
+useconfigure=true
+configopts=--disable-bootstrap
+depends="m4 pcre2"

--- a/Ports/flex/patches/fix-Makefile-in.patch
+++ b/Ports/flex/patches/fix-Makefile-in.patch
@@ -1,0 +1,11 @@
+--- flex-2.6.4/src/Makefile.in.orig	Thu Jan 23 22:45:32 2020
++++ flex-2.6.4/src/Makefile.in	Thu Jan 23 22:46:15 2020
+@@ -342,7 +342,7 @@
+ LIBINTL = @LIBINTL@
+ LIBOBJS = @LIBOBJS@
+ LIBPTHREAD = @LIBPTHREAD@
+-LIBS = @LIBS@
++LIBS = @LIBS@ -lpcre2-posix -lpcre2-8
+ LIBTOOL = @LIBTOOL@
+ LIPO = @LIPO@
+ LN_S = @LN_S@

--- a/Ports/flex/patches/fix-autoconf.patch
+++ b/Ports/flex/patches/fix-autoconf.patch
@@ -1,0 +1,10 @@
+--- flex-2.6.4/build-aux/config.sub.orig	Thu Jan 23 22:05:46 2020
++++ flex-2.6.4/build-aux/config.sub	Thu Jan 23 22:05:59 2020
+@@ -1375,6 +1375,7 @@
+ 	# Each alternative MUST END IN A *, to match a version number.
+ 	# -sysv* is not here because it comes later, after sysvr4.
+ 	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
++	      | -serenity* \
+ 	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -cnk* | -sunos | -sunos[34]*\
+ 	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -auroraux* | -solaris* \
+ 	      | -sym* | -kopensolaris* | -plan9* \

--- a/Ports/flex/patches/fix-config-h-in.patch
+++ b/Ports/flex/patches/fix-config-h-in.patch
@@ -1,0 +1,17 @@
+--- flex-2.6.4/src/config.h.in.orig	Thu Jan 23 22:25:56 2020
++++ flex-2.6.4/src/config.h.in	Thu Jan 23 22:26:30 2020
+@@ -249,14 +249,8 @@
+ /* Define to empty if `const' does not conform to ANSI C. */
+ #undef const
+ 
+-/* Define to rpl_malloc if the replacement function should be used. */
+-#undef malloc
+-
+ /* Define to `int' if <sys/types.h> does not define. */
+ #undef pid_t
+-
+-/* Define to rpl_realloc if the replacement function should be used. */
+-#undef realloc
+ 
+ /* Define to `unsigned int' if <sys/types.h> does not define. */
+ #undef size_t

--- a/Ports/flex/patches/fix-configure.patch
+++ b/Ports/flex/patches/fix-configure.patch
@@ -1,0 +1,20 @@
+--- flex-2.6.4/configure.orig	Thu Jan 23 22:41:22 2020
++++ flex-2.6.4/configure	Thu Jan 23 22:44:41 2020
+@@ -19854,7 +19854,7 @@
+ 
+ # checks for headers
+ 
+-for ac_header in regex.h strings.h sys/stat.h sys/wait.h unistd.h
++for ac_header in pcre2posix.h strings.h sys/stat.h sys/wait.h unistd.h
+ do :
+   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+@@ -20739,7 +20739,7 @@
+ $as_echo "$as_me: WARNING: result $ac_cv_func_realloc_0_nonnull guessed because of cross compilation" >&2;}
+ fi
+ 
+-for ac_func in dup2 memset regcomp strcasecmp strchr strdup strtol
++for ac_func in dup2 memset strcasecmp strchr strdup strtol
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/Ports/flex/patches/fix-flexdef.patch
+++ b/Ports/flex/patches/fix-flexdef.patch
@@ -1,0 +1,11 @@
+--- flex-2.6.4/src/flexdef.h.orig	Thu Jan 23 22:38:30 2020
++++ flex-2.6.4/src/flexdef.h	Thu Jan 23 22:38:45 2020
+@@ -72,7 +72,7 @@
+ #include <stdbool.h>
+ #include <stdarg.h>
+ /* Required: regcomp(), regexec() and regerror() in <regex.h> */
+-#include <regex.h>
++#include <pcre2posix.h>
+ /* Required: strcasecmp() in <strings.h> */
+ #include <strings.h>
+ #include "flexint.h"

--- a/Ports/flex/patches/fix-src-Makefile-in.patch
+++ b/Ports/flex/patches/fix-src-Makefile-in.patch
@@ -1,0 +1,20 @@
+--- flex-2.6.4/src/Makefile.in.orig	Thu Jan 23 23:27:22 2020
++++ flex-2.6.4/src/Makefile.in	Thu Jan 23 23:27:51 2020
+@@ -350,7 +350,7 @@
+ LTLIBINTL = @LTLIBINTL@
+ LTLIBOBJS = @LTLIBOBJS@
+ LT_SYS_LIBRARY_PATH = @LT_SYS_LIBRARY_PATH@
+-M4 = @M4@
++M4 = /usr/local/bin/m4
+ MAKEINFO = @MAKEINFO@
+ MANIFEST_TOOL = @MANIFEST_TOOL@
+ MKDIR_P = @MKDIR_P@
+@@ -444,7 +444,7 @@
+ top_srcdir = @top_srcdir@
+ AM_YFLAGS = -d
+ AM_CPPFLAGS = -DLOCALEDIR=\"$(localedir)\"
+-m4 = @M4@
++m4 = /usr/local/bin/m4
+ @ENABLE_LIBFL_TRUE@lib_LTLIBRARIES = libfl.la
+ libfl_la_SOURCES = \
+ 	libmain.c \

--- a/Ports/flex/patches/fix-tables.patch
+++ b/Ports/flex/patches/fix-tables.patch
@@ -1,0 +1,11 @@
+--- flex-2.6.4/src/tables.c.orig	Thu Jan 23 22:22:14 2020
++++ flex-2.6.4/src/tables.c	Thu Jan 23 22:22:27 2020
+@@ -33,6 +33,8 @@
+  */
+ 
+ 
++#include <arpa/inet.h>
++
+ #include "flexdef.h"
+ #include "tables.h"
+ 

--- a/Ports/pcre2/package.sh
+++ b/Ports/pcre2/package.sh
@@ -1,0 +1,5 @@
+#!/bin/bash ../.port_include.sh
+port=pcre2
+version=10.34
+useconfigure=true
+files="https://ftp.pcre.org/pub/pcre/pcre2-10.34.tar.gz pcre2-10.34.tar.gz"

--- a/Ports/pcre2/patches/fix-autoconf.patch
+++ b/Ports/pcre2/patches/fix-autoconf.patch
@@ -1,0 +1,10 @@
+--- pcre2-10.34/config.sub.orig	Sun Jan 19 18:21:01 2020
++++ pcre2-10.34/config.sub	Sun Jan 19 18:21:19 2020
+@@ -1364,6 +1364,7 @@
+ 	# Each alternative MUST end in a * to match a version number.
+ 	# -sysv* is not here because it comes later, after sysvr4.
+ 	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
++	      | -serenity* \
+ 	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -cnk* | -sunos | -sunos[34]*\
+ 	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -auroraux* | -solaris* \
+ 	      | -sym* | -kopensolaris* | -plan9* \

--- a/Ports/pcre2/patches/fix-pcre2test.patch
+++ b/Ports/pcre2/patches/fix-pcre2test.patch
@@ -1,0 +1,11 @@
+--- pcre2-10.34/src/pcre2test.c.orig	Sun Jan 19 18:24:43 2020
++++ pcre2-10.34/src/pcre2test.c	Sun Jan 19 18:24:59 2020
+@@ -8604,7 +8604,7 @@
+   else if (strcmp(arg, "-S") == 0 && argc > 2 &&
+       ((uli = strtoul(argv[op+1], &endptr, 10)), *endptr == 0))
+     {
+-#if defined(_WIN32) || defined(WIN32) || defined(__minix) || defined(NATIVE_ZOS) || defined(__VMS)
++#if defined(_WIN32) || defined(WIN32) || defined(__minix) || defined(NATIVE_ZOS) || defined(__VMS) || defined(__serenity__)
+     fprintf(stderr, "pcre2test: -S is not supported on this OS\n");
+     exit(1);
+ #else


### PR DESCRIPTION
A lex program would be useful.
Flex is a POSIX-compliant lex.

Usually, flex requires the regex functions normally found in libc. These functions are not yet provided in Serenity. However, the pcre2 library includes such functions, and as such a pcre2 port is also provided in this pull request, which flex then uses.

When flex attempts to write to a file (the default codepath), the lexer fails because freopen is not yet implemented. However, with the `-t` option (write scanner to stdout), the scanner is in fact written out, and so flex is in fact useful as long as one remembers to add the `-t` flag for now.