### PR TITLE
Ports: Add bc port

### DIFF
--- a/Ports/bc/package.sh
+++ b/Ports/bc/package.sh
@@ -1,0 +1,11 @@
+#!/bin/bash ../.port_include.sh
+port=bc
+version=2.5.1
+curlopts="-L"
+files="https://github.com/gavinhoward/bc/releases/download/2.5.1/bc-2.5.1.tar.xz bc-2.5.1.tar.xz"
+useconfigure=true
+configscript=configure.sh
+
+configure() {
+    run env HOSTCC=gcc ./"$configscript"
+}

--- a/Ports/bc/patches/fix-args.patch
+++ b/Ports/bc/patches/fix-args.patch
@@ -1,0 +1,11 @@
+--- bc-2.5.1/include/args.h.orig	Fri Jan 24 19:27:06 2020
++++ bc-2.5.1/include/args.h	Fri Jan 24 19:27:14 2020
+@@ -36,6 +36,8 @@
+ #ifndef BC_ARGS_H
+ #define BC_ARGS_H
+ 
++#include <getopt.h>
++
+ #include <status.h>
+ #include <vm.h>
+ 

--- a/Ports/bc/patches/fix-num.patch
+++ b/Ports/bc/patches/fix-num.patch
@@ -1,0 +1,13 @@
+--- bc-2.5.1/include/num.h.orig	Fri Jan 24 19:24:12 2020
++++ bc-2.5.1/include/num.h	Fri Jan 24 19:24:54 2020
+@@ -134,6 +134,10 @@
+ 
+ #define BC_NUM_KARATSUBA_ALLOCS (6)
+ 
++#ifndef SSIZE_MAX
++#define SSIZE_MAX LONG_MAX
++#endif
++
+ #define BC_NUM_CMP_SIGNAL_VAL (~((ssize_t) ((size_t) SSIZE_MAX)))
+ #define BC_NUM_CMP_SIGNAL(cmp) (cmp == BC_NUM_CMP_SIGNAL_VAL)
+ 


### PR DESCRIPTION
A bc (and dc) utility would be useful.
This implementation of bc is POSIX compliant and supports GNU and BSD extensions: https://github.com/gavinhoward/bc. It includes dc.