### PR TITLE
Ports: Add grep port

### DIFF
--- a/Ports/grep/package.sh
+++ b/Ports/grep/package.sh
@@ -1,0 +1,6 @@
+#!/bin/bash ../.port_include.sh
+port=grep
+version=2.5.4
+files="https://ftp.gnu.org/gnu/grep/grep-2.5.4.tar.gz grep-2.5.4.tar.gz"
+useconfigure=true
+configopts=--disable-perl-regexp

--- a/Ports/grep/patches/fix-autoconf.patch
+++ b/Ports/grep/patches/fix-autoconf.patch
@@ -1,0 +1,10 @@
+--- grep-2.5.4/config.sub.orig	Sat Jan 25 11:56:17 2020
++++ grep-2.5.4/config.sub	Sat Jan 25 11:56:28 2020
+@@ -1204,6 +1204,7 @@
+ 	# Each alternative MUST END IN A *, to match a version number.
+ 	# -sysv* is not here because it comes later, after sysvr4.
+ 	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
++	      | -serenity* \
+ 	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -sunos | -sunos[34]*\
+ 	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -solaris* | -sym* \
+ 	      | -amigaos* | -amigados* | -msdos* | -newsos* | -unicos* | -aof* \


### PR DESCRIPTION
A grep utility would be useful.
GNU grep 2.5.4 is the last version to not include gnulib.
This port installs a utility named fgrep, which may be hidden/hide the base system's fgrep.