### PR TITLE
Ports: Add diffutils port

### DIFF
--- a/Ports/diffutils/package.sh
+++ b/Ports/diffutils/package.sh
@@ -1,0 +1,5 @@
+#!/bin/bash ../.port_include.sh
+port=diffutils
+version=3.5
+files="https://ftp.gnu.org/gnu/diffutils/diffutils-3.5.tar.xz diffutils-3.5.tar.xz"
+useconfigure=true

--- a/Ports/diffutils/patches/fix-autoconf.patch
+++ b/Ports/diffutils/patches/fix-autoconf.patch
@@ -1,0 +1,10 @@
+--- diffutils-3.5/build-aux/config.sub.orig	Sat Jan 25 19:30:30 2020
++++ diffutils-3.5/build-aux/config.sub	Sat Jan 25 19:30:39 2020
+@@ -1382,6 +1382,7 @@
+ 	# Each alternative MUST END IN A *, to match a version number.
+ 	# -sysv* is not here because it comes later, after sysvr4.
+ 	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
++	      | -serenity* \
+ 	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -cnk* | -sunos | -sunos[34]*\
+ 	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -auroraux* | -solaris* \
+ 	      | -sym* | -kopensolaris* | -plan9* \

--- a/Ports/diffutils/patches/fix-intprops.patch
+++ b/Ports/diffutils/patches/fix-intprops.patch
@@ -1,0 +1,17 @@
+--- diffutils-3.5/lib/intprops.h.orig	Sat Jan 25 19:35:59 2020
++++ diffutils-3.5/lib/intprops.h	Sat Jan 25 19:36:23 2020
+@@ -230,11 +230,11 @@
+    (e.g., A and B) have the same type as MIN and MAX.  Instead, they assume
+    that the result (e.g., A + B) has that type.  */
+ #if _GL_HAS_BUILTIN_OVERFLOW_WITH_NULL
+-# define _GL_ADD_OVERFLOW(a, b, min, max)
++# define _GL_ADD_OVERFLOW(a, b, min, max)		\
+    __builtin_add_overflow (a, b, (__typeof__ ((a) + (b)) *) 0)
+-# define _GL_SUBTRACT_OVERFLOW(a, b, min, max)
++# define _GL_SUBTRACT_OVERFLOW(a, b, min, max)		\
+    __builtin_sub_overflow (a, b, (__typeof__ ((a) - (b)) *) 0)
+-# define _GL_MULTIPLY_OVERFLOW(a, b, min, max)
++# define _GL_MULTIPLY_OVERFLOW(a, b, min, max)		\
+    __builtin_mul_overflow (a, b, (__typeof__ ((a) * (b)) *) 0)
+ #else
+ # define _GL_ADD_OVERFLOW(a, b, min, max)                                \


### PR DESCRIPTION
A suite of diff utilities would be nice to have.
GNU diffutils 3.5 is the latest that can be built on Serenity.
This port provides cmp, diff, and diff3.