### PR TITLE
LibVT: Rename escape functions

### DIFF
--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -330,8 +330,9 @@ void Terminal::CUD(const ParamVector& params)
     set_cursor(new_row, m_cursor_column);
 }
 
-void Terminal::escape$C(const ParamVector& params)
+void Terminal::CUF(const ParamVector& params)
 {
+    // CUF – Cursor Forward
     int num = 1;
     if (params.size() >= 1)
         num = params[0];
@@ -618,7 +619,7 @@ void Terminal::execute_escape_sequence(u8 final)
         CUD(params);
         break;
     case 'C':
-        escape$C(params);
+        CUF(params);
         break;
     case 'D':
         escape$D(params);

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -292,7 +292,7 @@ void Terminal::CUP(const ParamVector& params)
     set_cursor(row - 1, col - 1);
 }
 
-void Terminal::escape$f(const ParamVector& params)
+void Terminal::HVP(const ParamVector& params)
 {
     // HVP – Horizontal and Vertical Position
     unsigned row = 1;
@@ -688,7 +688,7 @@ void Terminal::execute_escape_sequence(u8 final)
         DA(params);
         break;
     case 'f':
-        escape$f(params);
+        HVP(params);
         break;
     default:
         dbgprintf("Terminal::execute_escape_sequence: Unhandled final '%c'\n", final);

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -279,8 +279,9 @@ void Terminal::escape$r(const ParamVector& params)
     set_cursor(0, 0);
 }
 
-void Terminal::escape$H(const ParamVector& params)
+void Terminal::CUP(const ParamVector& params)
 {
+    // CUP – Cursor Position
     unsigned row = 1;
     unsigned col = 1;
     if (params.size() >= 1)
@@ -626,7 +627,7 @@ void Terminal::execute_escape_sequence(u8 final)
         CUB(params);
         break;
     case 'H':
-        escape$H(params);
+        CUP(params);
         break;
     case 'J':
         ED(params);

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -316,8 +316,9 @@ void Terminal::CUU(const ParamVector& params)
     set_cursor(new_row, m_cursor_column);
 }
 
-void Terminal::escape$B(const ParamVector& params)
+void Terminal::CUD(const ParamVector& params)
 {
+    // CUD – Cursor Down
     int num = 1;
     if (params.size() >= 1)
         num = params[0];
@@ -614,7 +615,7 @@ void Terminal::execute_escape_sequence(u8 final)
         CUU(params);
         break;
     case 'B':
-        escape$B(params);
+        CUD(params);
         break;
     case 'C':
         escape$C(params);
@@ -778,7 +779,7 @@ void Terminal::NEL()
 void Terminal::IND()
 {
     // IND - Index (move down)
-    escape$B({});
+    CUD({});
 }
 
 void Terminal::RI()

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -153,8 +153,9 @@ void Terminal::escape$h_l(bool should_set, bool question_param, const ParamVecto
     }
 }
 
-void Terminal::escape$m(const ParamVector& params)
+void Terminal::SGR(const ParamVector& params)
 {
+    // SGR – Select Graphic Rendition
     if (params.is_empty()) {
         m_current_attribute.reset();
         return;
@@ -239,7 +240,7 @@ void Terminal::escape$m(const ParamVector& params)
             m_current_attribute.background_color = Attribute::default_background_color;
             break;
         default:
-            dbgprintf("FIXME: escape$m: p: %u\n", param);
+            dbgprintf("FIXME: SGR: p: %u\n", param);
         }
     }
 }
@@ -663,7 +664,7 @@ void Terminal::execute_escape_sequence(u8 final)
         escape$d(params);
         break;
     case 'm':
-        escape$m(params);
+        SGR(params);
         break;
     case 's':
         escape$s(params);

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -344,8 +344,9 @@ void Terminal::CUF(const ParamVector& params)
     set_cursor(m_cursor_row, new_column);
 }
 
-void Terminal::escape$D(const ParamVector& params)
+void Terminal::CUB(const ParamVector& params)
 {
+    // CUB – Cursor Backward
     int num = 1;
     if (params.size() >= 1)
         num = params[0];
@@ -622,7 +623,7 @@ void Terminal::execute_escape_sequence(u8 final)
         CUF(params);
         break;
     case 'D':
-        escape$D(params);
+        CUB(params);
         break;
     case 'H':
         escape$H(params);

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -275,8 +275,9 @@ void Terminal::escape$t(const ParamVector& params)
     dbgprintf("FIXME: escape$t: Ps: %u (param count: %d)\n", params[0], params.size());
 }
 
-void Terminal::escape$r(const ParamVector& params)
+void Terminal::DECSTBM(const ParamVector& params)
 {
+    // DECSTBM – Set Top and Bottom Margins ("Scrolling Region")
     unsigned top = 1;
     unsigned bottom = m_rows;
     if (params.size() >= 1)
@@ -284,7 +285,7 @@ void Terminal::escape$r(const ParamVector& params)
     if (params.size() >= 2)
         bottom = params[1];
     if ((bottom - top) < 2 || bottom > m_rows) {
-        dbgprintf("Error: escape$r: scrolling region invalid: %u-%u\n", top, bottom);
+        dbgprintf("Error: DECSTBM: scrolling region invalid: %u-%u\n", top, bottom);
         return;
     }
     m_scroll_region_top = top - 1;
@@ -688,7 +689,7 @@ void Terminal::execute_escape_sequence(u8 final)
         escape$t(params);
         break;
     case 'r':
-        escape$r(params);
+        DECSTBM(params);
         break;
     case 'l':
         RM(question_param, params);

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -510,7 +510,7 @@ void Terminal::escape$L(const ParamVector& params)
     m_need_full_flush = true;
 }
 
-void Terminal::escape$c(const ParamVector&)
+void Terminal::DA(const ParamVector&)
 {
     // DA - Device Attributes
     emit_string("\033[?1;0c");
@@ -685,7 +685,7 @@ void Terminal::execute_escape_sequence(u8 final)
         escape$h_l(false, question_param, params);
         break;
     case 'c':
-        escape$c(params);
+        DA(params);
         break;
     case 'f':
         escape$f(params);

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -302,8 +302,9 @@ void Terminal::escape$f(const ParamVector& params)
     set_cursor(row - 1, col - 1);
 }
 
-void Terminal::escape$A(const ParamVector& params)
+void Terminal::CUU(const ParamVector& params)
 {
+    // CUU – Cursor Up
     int num = 1;
     if (params.size() >= 1)
         num = params[0];
@@ -610,7 +611,7 @@ void Terminal::execute_escape_sequence(u8 final)
 
     switch (final) {
     case 'A':
-        escape$A(params);
+        CUU(params);
         break;
     case 'B':
         escape$B(params);
@@ -783,7 +784,7 @@ void Terminal::IND()
 void Terminal::RI()
 {
     // RI - Reverse Index (move up)
-    escape$A({});
+    CUU({});
 }
 
 void Terminal::on_char(u8 ch)

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -165,7 +165,6 @@ void Terminal::SM(bool question_param, const ParamVector& params)
     alter_mode(false, question_param, params);
 }
 
-
 void Terminal::SGR(const ParamVector& params)
 {
     // SGR – Select Graphic Rendition

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -124,7 +124,7 @@ inline bool is_valid_final_character(u8 ch)
     return ch >= 0x40 && ch <= 0x7e;
 }
 
-void Terminal::escape$h_l(bool should_set, bool question_param, const ParamVector& params)
+void Terminal::alter_mode(bool should_set, bool question_param, const ParamVector& params)
 {
     int mode = 2;
     if (params.size() > 0) {
@@ -152,6 +152,19 @@ void Terminal::escape$h_l(bool should_set, bool question_param, const ParamVecto
         }
     }
 }
+
+void Terminal::RM(bool question_param, const ParamVector& params)
+{
+    // RM – Reset Mode
+    alter_mode(true, question_param, params);
+}
+
+void Terminal::SM(bool question_param, const ParamVector& params)
+{
+    // SM – Set Mode
+    alter_mode(false, question_param, params);
+}
+
 
 void Terminal::SGR(const ParamVector& params)
 {
@@ -679,10 +692,10 @@ void Terminal::execute_escape_sequence(u8 final)
         escape$r(params);
         break;
     case 'l':
-        escape$h_l(true, question_param, params);
+        RM(question_param, params);
         break;
     case 'h':
-        escape$h_l(false, question_param, params);
+        SM(question_param, params);
         break;
     case 'c':
         DA(params);

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -148,7 +148,7 @@ private:
 
     void emit_string(const StringView&);
 
-    void alter_mode(bool, bool, const ParamVector&);
+    void alter_mode(bool should_set, bool question_param, const ParamVector&);
 
     void CUU(const ParamVector&);
     void CUD(const ParamVector&);
@@ -171,8 +171,8 @@ private:
     void escape$S(const ParamVector&);
     void escape$T(const ParamVector&);
     void escape$L(const ParamVector&);
-    void RM(bool, const ParamVector&);
-    void SM(bool, const ParamVector&);
+    void RM(bool question_param, const ParamVector&);
+    void SM(bool question_param, const ParamVector&);
     void DA(const ParamVector&);
     void HVP(const ParamVector&);
     void NEL();

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -148,6 +148,8 @@ private:
 
     void emit_string(const StringView&);
 
+    void alter_mode(bool, bool, const ParamVector&);
+
     void CUU(const ParamVector&);
     void CUD(const ParamVector&);
     void CUF(const ParamVector&);
@@ -169,7 +171,8 @@ private:
     void escape$S(const ParamVector&);
     void escape$T(const ParamVector&);
     void escape$L(const ParamVector&);
-    void escape$h_l(bool, bool, const ParamVector&);
+    void RM(bool, const ParamVector&);
+    void SM(bool, const ParamVector&);
     void DA(const ParamVector&);
     void HVP(const ParamVector&);
     void NEL();

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -170,7 +170,7 @@ private:
     void escape$T(const ParamVector&);
     void escape$L(const ParamVector&);
     void escape$h_l(bool, bool, const ParamVector&);
-    void escape$c(const ParamVector&);
+    void DA(const ParamVector&);
     void escape$f(const ParamVector&);
     void NEL();
     void IND();

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -149,7 +149,7 @@ private:
     void emit_string(const StringView&);
 
     void CUU(const ParamVector&);
-    void escape$B(const ParamVector&);
+    void CUD(const ParamVector&);
     void escape$C(const ParamVector&);
     void escape$D(const ParamVector&);
     void escape$H(const ParamVector&);

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -150,7 +150,7 @@ private:
 
     void CUU(const ParamVector&);
     void CUD(const ParamVector&);
-    void escape$C(const ParamVector&);
+    void CUF(const ParamVector&);
     void escape$D(const ParamVector&);
     void escape$H(const ParamVector&);
     void ED(const ParamVector&);

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -171,7 +171,7 @@ private:
     void escape$L(const ParamVector&);
     void escape$h_l(bool, bool, const ParamVector&);
     void DA(const ParamVector&);
-    void escape$f(const ParamVector&);
+    void HVP(const ParamVector&);
     void NEL();
     void IND();
     void RI();

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -148,7 +148,7 @@ private:
 
     void emit_string(const StringView&);
 
-    void escape$A(const ParamVector&);
+    void CUU(const ParamVector&);
     void escape$B(const ParamVector&);
     void escape$C(const ParamVector&);
     void escape$D(const ParamVector&);

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -161,7 +161,7 @@ private:
     void escape$X(const ParamVector&);
     void escape$b(const ParamVector&);
     void escape$d(const ParamVector&);
-    void escape$m(const ParamVector&);
+    void SGR(const ParamVector&);
     void escape$s(const ParamVector&);
     void escape$u(const ParamVector&);
     void escape$t(const ParamVector&);

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -152,7 +152,7 @@ private:
     void CUD(const ParamVector&);
     void CUF(const ParamVector&);
     void CUB(const ParamVector&);
-    void escape$H(const ParamVector&);
+    void CUP(const ParamVector&);
     void ED(const ParamVector&);
     void EL(const ParamVector&);
     void escape$M(const ParamVector&);

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -151,7 +151,7 @@ private:
     void CUU(const ParamVector&);
     void CUD(const ParamVector&);
     void CUF(const ParamVector&);
-    void escape$D(const ParamVector&);
+    void CUB(const ParamVector&);
     void escape$H(const ParamVector&);
     void ED(const ParamVector&);
     void EL(const ParamVector&);

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -167,7 +167,7 @@ private:
     void escape$s(const ParamVector&);
     void escape$u(const ParamVector&);
     void escape$t(const ParamVector&);
-    void escape$r(const ParamVector&);
+    void DECSTBM(const ParamVector&);
     void escape$S(const ParamVector&);
     void escape$T(const ParamVector&);
     void escape$L(const ParamVector&);


### PR DESCRIPTION
As suggested in https://github.com/SerenityOS/serenity/commit/8c1f2d713172bca788fec4e05cac5e25781a6481:

> We should rename all of these functions to match the real VT100 names.
> This will make it 100% easier to work on LibVT.
>
> For reference: vt100.net/docs/vt100-ug

(Also see https://www.youtube.com/watch?v=YHf6fCK9u4I)

Please note, right now there are still escape functions left to be renamed.

@awesomekling as you've mentioned in the video, not all sequences have an official abbreviation - for example **Scrolling Region** (`escape$r`).

> **Scrolling Region**
>
> `ESC [ Pt ; Pb r`
>
>Pt is the number of the top line of the scrolling region; Pb is the number of the bottom line of the scrolling region and must be greater than Pt.

What naming scheme should be used here? I know `ScrollingRegion` is not the one :smile:

Possible options (also mentioned in the video):

- `esc$scrolling_region`
- `seq$scrolling_region`
- Just `scrolling_region`