### PR TITLE
New args parser

### DIFF
--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -193,11 +193,11 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    CArgsParser args_parser("Terminal");
+    const char* command_to_execute = "/bin/Shell";
 
-    args_parser.add_arg("e", "execute", "Execute this command inside the terminal.");
-
-    CArgsParserResult args = args_parser.parse(argc, argv);
+    CArgsParser args_parser;
+    args_parser.add_option(command_to_execute, "Execute this command inside the terminal", nullptr, 'e', "command");
+    args_parser.parse(argc, argv);
 
     if (chdir(get_current_user_home_path().characters()) < 0)
         perror("chdir");
@@ -208,7 +208,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    run_command(ptm_fd, args.get("e"));
+    run_command(ptm_fd, command_to_execute);
 
     auto window = GWindow::construct();
     window->set_title("Terminal");
@@ -268,7 +268,6 @@ int main(int argc, char** argv)
     edit_menu->add_action(terminal->copy_action());
     edit_menu->add_action(terminal->paste_action());
     menubar->add_menu(move(edit_menu));
-
 
     GActionGroup font_action_group;
     font_action_group.set_exclusive(true);

--- a/Userland/chroot.cpp
+++ b/Userland/chroot.cpp
@@ -24,82 +24,51 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/String.h>
 #include <AK/StringView.h>
+#include <LibCore/CArgsParser.h>
 #include <stdio.h>
 #include <unistd.h>
 
-struct Options {
-    const char* path;
-    const char* program { "/bin/Shell" };
-    int flags { -1 };
-};
-
-void print_usage(const char* argv0)
-{
-    fprintf(
-        stderr,
-        "Usage:\n"
-        "\t%s <path> [program] [-o options]\n",
-        argv0
-    );
-}
-
-Options parse_options(int argc, char** argv)
-{
-    Options options;
-
-    if (argc < 2) {
-        print_usage(argv[0]);
-        exit(1);
-    }
-
-    options.path = argv[1];
-    int i = 2;
-    if (i < argc && argv[i][0] != '-')
-        options.program = argv[i++];
-
-    if (i >= argc)
-        return options;
-
-    if (strcmp(argv[i], "-o") != 0) {
-        print_usage(argv[0]);
-        exit(1);
-    }
-    i++;
-    if (i >= argc) {
-        print_usage(argv[0]);
-        exit(1);
-    }
-
-    options.flags = 0;
-
-    StringView arg = argv[i];
-    Vector<StringView> parts = arg.split_view(',');
-    for (auto& part : parts) {
-        if (part == "defaults")
-            continue;
-        else if (part == "nodev")
-            options.flags |= MS_NODEV;
-        else if (part == "noexec")
-            options.flags |= MS_NOEXEC;
-        else if (part == "nosuid")
-            options.flags |= MS_NOSUID;
-        else if (part == "bind")
-            fprintf(stderr, "Ignoring -o bind, as it doesn't make sense for chroot");
-        else
-            fprintf(stderr, "Ignoring invalid option: %s\n", String(part).characters());
-    }
-
-    return options;
-}
-
 int main(int argc, char** argv)
 {
+    const char* path = nullptr;
+    const char* program = "/bin/Shell";
+    int flags = -1;
 
-    Options options = parse_options(argc, argv);
+    CArgsParser args_parser;
+    args_parser.add_positional_argument(path, "New root directory", "path");
+    args_parser.add_positional_argument(program, "Program to run", "program", CArgsParser::Required::No);
 
-    if (chroot_with_mount_flags(options.path, options.flags) < 0) {
+    CArgsParser::Option option {
+        true,
+        "Mount options",
+        "options",
+        'o',
+        "options",
+        [&flags](const char* s) {
+            flags = 0;
+            Vector<StringView> parts = StringView(s).split_view(',');
+            for (auto& part : parts) {
+                if (part == "defaults")
+                    continue;
+                else if (part == "nodev")
+                    flags |= MS_NODEV;
+                else if (part == "noexec")
+                    flags |= MS_NOEXEC;
+                else if (part == "nosuid")
+                    flags |= MS_NOSUID;
+                else if (part == "bind")
+                    fprintf(stderr, "Ignoring -o bind, as it doesn't make sense for chroot\n");
+                else
+                    return false;
+            }
+            return true;
+        }
+    };
+    args_parser.add_option(move(option));
+    args_parser.parse(argc, argv);
+
+    if (chroot_with_mount_flags(path, flags) < 0) {
         perror("chroot");
         return 1;
     }
@@ -109,7 +78,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    execl(options.program, options.program, nullptr);
+    execl(program, program, nullptr);
     perror("execl");
     return 1;
 }

--- a/Userland/copy.cpp
+++ b/Userland/copy.cpp
@@ -27,74 +27,32 @@
 #include <AK/ByteBuffer.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
+#include <LibCore/CArgsParser.h>
 #include <LibCore/CFile.h>
 #include <LibGUI/GApplication.h>
 #include <LibGUI/GClipboard.h>
-#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 struct Options {
     String data;
-    String type { "text" };
+    StringView type { "text" };
 };
-
-void print_usage(FILE* stream, const char* argv0)
-{
-    fprintf(
-        stream,
-        "Usage:\n"
-        "\t%s [--type type] text\n"
-        "\t%s [--type type] < file\n"
-        "\n"
-        "\t-t type, --type type\tPick a type.\n"
-        "\t-h, --help\t\tPrint this help message.\n",
-        argv0,
-        argv0);
-}
 
 Options parse_options(int argc, char* argv[])
 {
+    const char* type = nullptr;
+    Vector<const char*> text;
+
+    CArgsParser args_parser;
+    args_parser.add_option(type, "Pick a type", "type", 't', "type");
+    args_parser.add_positional_argument(text, "Text to copy", "text", CArgsParser::Required::No);
+    args_parser.parse(argc, argv);
+
     Options options;
+    options.type = type;
 
-    static struct option long_options[] = {
-        { "type", required_argument, 0, 't' },
-        { "help", no_argument, 0, 'h' },
-        { 0, 0, 0, 0 }
-    };
-    while (true) {
-        int option_index;
-        int c = getopt_long(argc, argv, "t:h", long_options, &option_index);
-        if (c == -1)
-            break;
-        if (c == 0)
-            c = long_options[option_index].val;
-
-        switch (c) {
-        case 't':
-            options.type = optarg;
-            break;
-        case 'h':
-            print_usage(stdout, argv[0]);
-            exit(0);
-        default:
-            print_usage(stderr, argv[0]);
-            exit(1);
-        }
-    }
-
-    if (optind < argc) {
-        // Copy the rest of our command-line args.
-        StringBuilder builder;
-        bool first = true;
-        for (int i = optind; i < argc; i++) {
-            if (!first)
-                builder.append(' ');
-            first = false;
-            builder.append(argv[i]);
-        }
-        options.data = builder.to_string();
-    } else {
+    if (text.is_empty()) {
         // Copy our stdin.
         auto c_stdin = CFile::construct();
         bool success = c_stdin->open(
@@ -105,6 +63,17 @@ Options parse_options(int argc, char* argv[])
         auto buffer = c_stdin->read_all();
         dbg() << "Read size " << buffer.size();
         options.data = String((char*)buffer.data(), buffer.size());
+    } else {
+        // Copy the rest of our command-line args.
+        StringBuilder builder;
+        bool first = true;
+        for (auto& word : text) {
+            if (!first)
+                builder.append(' ');
+            first = false;
+            builder.append(word);
+        }
+        options.data = builder.to_string();
     }
 
     return options;

--- a/Userland/head.cpp
+++ b/Userland/head.cpp
@@ -35,56 +35,29 @@ int head(const String& filename, bool print_filename, int line_count, int char_c
 
 int main(int argc, char** argv)
 {
-    CArgsParser args_parser("head");
-
-    args_parser.add_arg("n", "lines", "Number of lines to print (default 10)");
-    args_parser.add_arg("c", "characters", "Number of characters to print");
-    args_parser.add_arg("q", "Never print filenames");
-    args_parser.add_arg("v", "Always print filenames");
-
-    CArgsParserResult args = args_parser.parse(argc, argv);
-
     int line_count = 0;
-    if (args.is_present("n")) {
-        line_count = strtol(args.get("n").characters(), NULL, 10);
-        if (errno) {
-            args_parser.print_usage();
-            return -1;
-        }
-
-        if (!line_count) {
-            args_parser.print_usage();
-            return -1;
-        }
-    }
-
     int char_count = 0;
-    if (args.is_present("c")) {
-        char_count = strtol(args.get("c").characters(), NULL, 10);
-        if (errno) {
-            args_parser.print_usage();
-            return -1;
-        }
+    bool never_print_filenames = false;
+    bool always_print_filenames = false;
+    Vector<const char*> files;
 
-        if (!char_count) {
-            args_parser.print_usage();
-            return -1;
-        }
-    }
+    CArgsParser args_parser;
+    args_parser.add_option(line_count, "Number of lines to print (default 10)", "lines", 'n', "number");
+    args_parser.add_option(char_count, "Number of characters to print", "characters", 'c', "number");
+    args_parser.add_option(never_print_filenames, "Never print file names", "quiet", 'q');
+    args_parser.add_option(always_print_filenames, "Always print file names", "verbose", 'v');
+    args_parser.add_positional_argument(files, "File to process", "file", CArgsParser::Required::No);
+    args_parser.parse(argc, argv);
 
     if (line_count == 0 && char_count == 0) {
         line_count = 10;
     }
 
-    Vector<String> files = args.get_single_values();
-
     bool print_filenames = files.size() > 1;
-
-    if (args.is_present("v")) {
+    if (always_print_filenames)
         print_filenames = true;
-    } else if (args.is_present("q")) {
+    else if (never_print_filenames)
         print_filenames = false;
-    }
 
     if (files.is_empty()) {
         return head("", print_filenames, line_count, char_count);

--- a/Userland/id.cpp
+++ b/Userland/id.cpp
@@ -24,8 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <LibCore/CArgsParser.h>
 #include <alloca.h>
-#include <getopt.h>
 #include <grp.h>
 #include <pwd.h>
 #include <stdio.h>
@@ -59,28 +59,13 @@ int main(int argc, char** argv)
         perror("pledge");
         return 1;
     }
-    static const char* valid_option_characters = "ugGn";
-    int opt;
-    while ((opt = getopt(argc, argv, valid_option_characters)) != -1) {
-        switch (opt) {
-        case 'u':
-            flag_print_uid = true;
-            break;
-        case 'g':
-            flag_print_gid = true;
-            break;
-        case 'G':
-            flag_print_gid_all = true;
-            break;
-        case 'n':
-            flag_print_name = true;
-            break;
 
-        default:
-            fprintf(stderr, "usage: id [-%s]\n", valid_option_characters);
-            return 1;
-        }
-    }
+    CArgsParser args_parser;
+    args_parser.add_option(flag_print_uid, "Print UID", nullptr, 'u');
+    args_parser.add_option(flag_print_gid, "Print GID", nullptr, 'g');
+    args_parser.add_option(flag_print_gid_all, "Print all GIDs", nullptr, 'G');
+    args_parser.add_option(flag_print_name, "Print name", nullptr, 'n');
+    args_parser.parse(argc, argv);
 
     if (flag_print_name && !(flag_print_uid || flag_print_gid || flag_print_gid_all)) {
         fprintf(stderr, "cannot print only names or real IDs in default format\n");

--- a/Userland/ln.cpp
+++ b/Userland/ln.cpp
@@ -32,21 +32,18 @@
 
 int main(int argc, char** argv)
 {
-    CArgsParser args_parser("ln");
+    bool symbolic = false;
+    const char* target = nullptr;
+    const char* path = nullptr;
 
-    args_parser.add_arg("s", "create a symlink");
-    args_parser.add_required_single_value("target");
-    args_parser.add_required_single_value("link-path");
+    CArgsParser args_parser;
+    args_parser.add_option(symbolic, "Create a symlink", "symbolic", 's');
+    args_parser.add_positional_argument(target, "Link target", "target");
+    args_parser.add_positional_argument(path, "Link path", "path");
+    args_parser.parse(argc, argv);
 
-    CArgsParserResult args = args_parser.parse(argc, argv);
-    Vector<String> values = args.get_single_values();
-    if (values.size() == 0) {
-        args_parser.print_usage();
-        return 0;
-    }
-
-    if (args.is_present("s")) {
-        int rc = symlink(values[0].characters(), values[1].characters());
+    if (symbolic) {
+        int rc = symlink(target, path);
         if (rc < 0) {
             perror("symlink");
             return 1;
@@ -54,7 +51,7 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    int rc = link(values[0].characters(), values[1].characters());
+    int rc = link(target, path);
     if (rc < 0) {
         perror("link");
         return 1;

--- a/Userland/pape.cpp
+++ b/Userland/pape.cpp
@@ -24,8 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/String.h>
 #include <AK/FileSystemPath.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/Vector.h>
 #include <LibCore/CArgsParser.h>
@@ -76,26 +76,22 @@ static int handle_set_pape(const String& name)
 
 int main(int argc, char** argv)
 {
+    bool show_all = false;
+    bool show_current = false;
+    const char* name = nullptr;
+
+    CArgsParser args_parser;
+    args_parser.add_option(show_all, "Show all wallpapers", "show-all", 'a');
+    args_parser.add_option(show_current, "Show current wallpaper", "show-current", 'c');
+    args_parser.add_positional_argument(name, "Wallpaper to set", "name", CArgsParser::Required::No);
+    args_parser.parse(argc, argv);
+
     GApplication app(argc, argv);
 
-    CArgsParser args_parser("pape");
-
-    args_parser.add_arg("a", "show all wallpapers");
-    args_parser.add_arg("c", "show current wallpaper");
-    args_parser.add_single_value("name");
-
-    CArgsParserResult args = args_parser.parse(argc, argv);
-
-    if (args.is_present("a"))
+    if (show_all)
         return handle_show_all();
-    else if (args.is_present("c"))
+    else if (show_current)
         return handle_show_current();
 
-    Vector<String> values = args.get_single_values();
-    if (values.size() != 1) {
-        args_parser.print_usage();
-        return 0;
-    }
-
-    return handle_set_pape(values[0]);
+    return handle_set_pape(name);
 }

--- a/Userland/paste.cpp
+++ b/Userland/paste.cpp
@@ -25,81 +25,32 @@
  */
 
 #include <AK/String.h>
+#include <LibCore/CArgsParser.h>
 #include <LibGUI/GApplication.h>
 #include <LibGUI/GClipboard.h>
-#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-struct Options {
-    bool print_type { false };
-    bool no_newline { false };
-};
-
-void print_usage(FILE* stream, const char* argv0)
-{
-    fprintf(
-        stream,
-        "Usage:\n"
-        "\t%s [--print-type] [--no-newline]\n"
-        "\n"
-        "\t--print-type\t\tDisplay the copied type.\n"
-        "\t-n, --no-newline\tDo not append a newline.\n"
-        "\t-h, --help\t\tPrint this help message.\n",
-        argv0);
-}
-
-Options parse_options(int argc, char* argv[])
-{
-    Options options;
-
-    static struct option long_options[] = {
-        { "print-type", no_argument, 0, 'p' },
-        { "no-newline", no_argument, 0, 'n' },
-        { "help", no_argument, 0, 'h' },
-        { 0, 0, 0, 0 }
-    };
-    while (true) {
-        int option_index;
-        int c = getopt_long(argc, argv, "hn", long_options, &option_index);
-        if (c == -1)
-            break;
-        if (c == 0)
-            c = long_options[option_index].val;
-
-        switch (c) {
-        case 'p':
-            options.print_type = true;
-            break;
-        case 'n':
-            options.no_newline = true;
-            break;
-        case 'h':
-            print_usage(stdout, argv[0]);
-            exit(0);
-        default:
-            print_usage(stderr, argv[0]);
-            exit(1);
-        }
-    }
-
-    return options;
-}
-
 int main(int argc, char* argv[])
 {
-    GApplication app(argc, argv);
+    bool print_type = false;
+    bool no_newline = false;
 
-    Options options = parse_options(argc, argv);
+    CArgsParser args_parser;
+    args_parser.add_option(print_type, "Display the copied type", "print-type", 0);
+    args_parser.add_option(no_newline, "Do not append a newline", "no-newline", 'n');
+    args_parser.parse(argc, argv);
+
+    GApplication app(argc, argv);
 
     GClipboard& clipboard = GClipboard::the();
     auto data_and_type = clipboard.data_and_type();
 
-    if (!options.print_type) {
+    if (!print_type) {
         printf("%s", data_and_type.data.characters());
         // Append a newline to text contents, but
         // only if we're not asked not to do this.
-        if (data_and_type.type == "text" && !options.no_newline)
+        if (data_and_type.type == "text" && !no_newline)
             putchar('\n');
     } else {
         printf("%s\n", data_and_type.type.characters());

--- a/Userland/shutdown.cpp
+++ b/Userland/shutdown.cpp
@@ -30,17 +30,19 @@
 
 int main(int argc, char** argv)
 {
-    CArgsParser args_parser("shutdown");
-    args_parser.add_arg("n", "shut down now");
-    CArgsParserResult args = args_parser.parse(argc, argv);
+    bool now = false;
 
-    if (args.is_present("n")) {
+    CArgsParser args_parser;
+    args_parser.add_option(now, "Shut down now", "now", 'n');
+    args_parser.parse(argc, argv);
+
+    if (now) {
         if (halt() < 0) {
             perror("shutdown");
             return 1;
         }
     } else {
-        args_parser.print_usage();
-        return 0;
+        args_parser.print_usage(stderr, argv[0]);
+        return 1;
     }
 }

--- a/Userland/sysctl.cpp
+++ b/Userland/sysctl.cpp
@@ -109,20 +109,17 @@ static int handle_var(const String& var)
 
 int main(int argc, char** argv)
 {
-    CArgsParser args_parser("sysctl");
+    bool show_all = false;
+    const char* var = nullptr;
 
-    args_parser.add_arg("a", "show all variables");
-    args_parser.add_single_value("variable=[value]");
+    CArgsParser args_parser;
+    args_parser.add_option(show_all, "Show all variables", nullptr, 'a');
+    args_parser.add_positional_argument(var, "Command (var[=value])", "command");
+    args_parser.parse(argc, argv);
 
-    CArgsParserResult args = args_parser.parse(argc, argv);
-
-    if (args.is_present("a")) {
+    if (show_all) {
         return handle_show_all();
-    } else if (args.get_single_values().size() != 1) {
-        args_parser.print_usage();
-        return 0;
     }
 
-    Vector<String> values = args.get_single_values();
-    return handle_var(values[0]);
+    return handle_var(var);
 }

--- a/Userland/umount.cpp
+++ b/Userland/umount.cpp
@@ -30,19 +30,15 @@
 
 int main(int argc, char** argv)
 {
-    CArgsParser args_parser("umount");
-    args_parser.add_arg("mountpoint", "mount point");
-    CArgsParserResult args = args_parser.parse(argc, argv);
+    const char* mount_point = nullptr;
 
-    if (argc == 2) {
-        if (umount(argv[1]) < 0) {
-            perror("umount");
-            return 1;
-        }
-    } else {
-        args_parser.print_usage();
-        return 0;
+    CArgsParser args_parser;
+    args_parser.add_positional_argument(mount_point, "Mount point", "mountpoint");
+    args_parser.parse(argc, argv);
+
+    if (umount(mount_point) < 0) {
+        perror("umount");
+        return 1;
     }
-
     return 0;
 }

--- a/Userland/wc.cpp
+++ b/Userland/wc.cpp
@@ -110,7 +110,7 @@ Count get_count(const String& file_name)
 
 Count get_total_count(Vector<Count>& counts)
 {
-    Count total_count{ "total" };
+    Count total_count { "total" };
     for (auto& count : counts) {
         total_count.lines += count.lines;
         total_count.words += count.words;
@@ -122,47 +122,30 @@ Count get_total_count(Vector<Count>& counts)
 
 int main(int argc, char** argv)
 {
-    CArgsParser args_parser("wc");
-    args_parser.add_arg("l", "Output line count");
-    args_parser.add_arg("c", "Output byte count");
-    args_parser.add_arg("m", "Output character count");
-    args_parser.add_arg("w", "Output word count");
-    args_parser.add_arg("h", "Print help message");
-    CArgsParserResult args = args_parser.parse(argc, argv);
-    if (args.is_present("h")) {
-        args_parser.print_usage();
-        return 1;
-    }
-    if (args.is_present("l")) {
-        output_line = true;
-    }
-    if (args.is_present("w")) {
-        output_word = true;
-    }
-    if (args.is_present("m")) {
-        output_character = true;
-    }
-    if (args.is_present("c")) {
-        if (!output_word && !output_line && !output_character)
-            output_word = output_line = true;
-        output_byte = true;
-    }
-    if (!output_line && !output_character && !output_word && !output_byte)
-        output_line = output_character = output_word = true;
+    Vector<const char*> files;
 
-    Vector<String> file_names = args.get_single_values();
+    CArgsParser args_parser;
+    args_parser.add_option(output_line, "Output line count", "lines", 'l');
+    args_parser.add_option(output_byte, "Output byte count", "bytes", 'c');
+    args_parser.add_option(output_word, "Output word count", "words", 'w');
+    args_parser.add_positional_argument(files, "File to process", "file", CArgsParser::Required::No);
+    args_parser.parse(argc, argv);
+
+    if (!output_line && !output_byte && !output_word)
+        output_line = output_byte = output_word = true;
+
     Vector<Count> counts;
-    for (auto& file_name : file_names) {
-        Count count = get_count(file_name);
+    for (auto& file : files) {
+        Count count = get_count(file);
         counts.append(count);
     }
 
-    if (file_names.size() > 1) {
+    if (files.size() > 1) {
         Count total_count = get_total_count(counts);
         counts.append(total_count);
     }
 
-    if (file_names.is_empty()) {
+    if (files.is_empty()) {
         Count count = get_count("-");
         counts.append(count);
     }


### PR DESCRIPTION
Here's the new, completely rewritten `CArgsParser`. Hope you like it!

It properly supports and distinguishes between:
* Positional arguments (required or not)
* Options

Options can be short and/or long.

The API allows you to add custom option and argument types (see `nl` for an example). A few types are pre-implemented for convenience:
* Boolean options (take no value)
* String and integer options (take a required value)
* String and integer arguments
* Vector-of-string arguments

The general pattern of using the new API is:

```cpp
bool some_option = false;
const char* some_stirng = "default";

CArgsParser args_parser;
args_parser.add_option(some_option, "Do some useful stuff", "do-stuff", 's');
args_parser.add_positional_argument(some_string, "A very important string", "some-string");
args_parser.parse(argc, argv);

// Use some_option and some_string here.
```

I ported all the old `CArgsParser` users, and some manual `getopt()` users (namely, `copy` and `paste`). I could have broken things while porting them, so cc @zlotny @rburchell @balatt @Quaker762

Some more stuff that either uses `getopt()` or parses args manually remains to be ported at some other time, because I gotta run home :smile: