### PR TITLE
WindowServer: make menus wrap vertically

### DIFF
--- a/Servers/WindowServer/WSMenu.cpp
+++ b/Servers/WindowServer/WSMenu.cpp
@@ -393,9 +393,12 @@ void WSMenu::event(CEvent& event)
                 return;
 
             do {
-                if (m_hovered_item_index <= 0)
+                if (m_hovered_item_index == 0)
+                    m_hovered_item_index = m_items.size() - 1;
+                else if (m_hovered_item_index < 0)
                     return;
-                --m_hovered_item_index;
+                else
+                    --m_hovered_item_index;
             } while (hovered_item()->type() == WSMenuItem::Separator);
 
             if (is_scrollable() && m_hovered_item_index < m_scroll_offset)
@@ -412,9 +415,12 @@ void WSMenu::event(CEvent& event)
                 return;
 
             do {
-                if (m_hovered_item_index >= m_items.size() - 1)
+                if (m_hovered_item_index == m_items.size() - 1)
+                    m_hovered_item_index = 0;
+                else if (m_hovered_item_index > m_items.size() - 1)
                     return;
-                ++m_hovered_item_index;
+                else
+                    ++m_hovered_item_index;
             } while (hovered_item()->type() == WSMenuItem::Separator);
 
             if (is_scrollable() && m_hovered_item_index >= (m_scroll_offset + visible_item_count()))


### PR DESCRIPTION
This commit adds vertical wrap to menus. The first item is focused if
Key_Down is pressed on the last item and the last item is focused if
Key_up is pressed on the first item.