### PR TITLE
LIBGUI: Make descendants of GAbstractView define their own select_all()

### DIFF
--- a/Libraries/LibGUI/GAbstractTableView.cpp
+++ b/Libraries/LibGUI/GAbstractTableView.cpp
@@ -248,6 +248,15 @@ int GAbstractTableView::column_width(int column_index) const
     return column_data.width;
 }
 
+void GAbstractTableView::select_all()
+{
+    selection().clear();
+    for (int item_index = 0; item_index < item_count(); ++item_index) {
+        auto index = model()->index(item_index, item_index);
+        selection().add(index);
+    }
+}
+
 void GAbstractTableView::mousemove_event(GMouseEvent& event)
 {
     if (!model())

--- a/Libraries/LibGUI/GAbstractTableView.h
+++ b/Libraries/LibGUI/GAbstractTableView.h
@@ -71,6 +71,7 @@ public:
     virtual GModelIndex index_at_event_position(const Point&, bool& is_toggle) const;
     virtual GModelIndex index_at_event_position(const Point&) const override;
 
+    void select_all() override;
 protected:
     virtual ~GAbstractTableView() override;
     explicit GAbstractTableView(GWidget* parent);

--- a/Libraries/LibGUI/GAbstractView.cpp
+++ b/Libraries/LibGUI/GAbstractView.cpp
@@ -125,14 +125,7 @@ void GAbstractView::stop_editing()
 
 void GAbstractView::select_all()
 {
-    ASSERT(model());
-    int rows = model()->row_count();
-    int columns = model()->column_count();
 
-    for (int i = 0; i < rows; ++i) {
-        for (int j = 0; j < columns; ++j)
-            selection().add(model()->index(i, j));
-    }
 }
 
 void GAbstractView::activate(const GModelIndex& index)

--- a/Libraries/LibGUI/GAbstractView.h
+++ b/Libraries/LibGUI/GAbstractView.h
@@ -44,7 +44,7 @@ public:
 
     GModelSelection& selection() { return m_selection; }
     const GModelSelection& selection() const { return m_selection; }
-    void select_all();
+    virtual void select_all();
 
     bool is_editable() const { return m_editable; }
     void set_editable(bool editable) { m_editable = editable; }

--- a/Libraries/LibGUI/GColumnsView.cpp
+++ b/Libraries/LibGUI/GColumnsView.cpp
@@ -136,6 +136,19 @@ void GColumnsView::paint_event(GPaintEvent& event)
     }
 }
 
+void GColumnsView::select_all()
+{
+    selection().clear();
+    for (int column_index = 0; column_index < m_columns.size(); ++column_index) {
+        for (int item_index = 0; item_index < model()->row_count(m_columns[column_index].parent_index); item_index++) {
+            auto& column = m_columns[column_index];
+            auto index = model()->index(item_index, m_model_column, column.parent_index);
+            selection().add(index);
+        }
+        update();
+    }
+}
+
 void GColumnsView::push_column(GModelIndex& parent_index)
 {
     ASSERT(model());

--- a/Libraries/LibGUI/GColumnsView.h
+++ b/Libraries/LibGUI/GColumnsView.h
@@ -37,6 +37,7 @@ public:
 
     virtual GModelIndex index_at_event_position(const Point&) const override;
 
+    void select_all() override;
 private:
     GColumnsView(GWidget* parent = nullptr);
     virtual ~GColumnsView();

--- a/Libraries/LibGUI/GItemView.cpp
+++ b/Libraries/LibGUI/GItemView.cpp
@@ -136,6 +136,15 @@ GModelIndex GItemView::index_at_event_position(const Point& position) const
     return {};
 }
 
+void GItemView::select_all()
+{
+    selection().clear();
+    for (int item_index = 0; item_index < item_count(); ++item_index) {
+        auto index = model()->index(item_index, model_column());
+        selection().add(index);
+    }
+}
+
 void GItemView::mousedown_event(GMouseEvent& event)
 {
     if (!model())

--- a/Libraries/LibGUI/GItemView.h
+++ b/Libraries/LibGUI/GItemView.h
@@ -50,6 +50,7 @@ public:
 
     virtual GModelIndex index_at_event_position(const Point&) const override;
 
+    void select_all() override;
 private:
     explicit GItemView(GWidget* parent);
 


### PR DESCRIPTION
GAbstractView does not know which column it is displaying which makes it
impossible to implement the select_all functionality up there. Now
descendants override the select_all methods and impliment it themselfs.