### PR TITLE
Paritition Table: Allow to boot with partition number higher than 4

### DIFF
--- a/Kernel/Devices/GPTPartitionTable.h
+++ b/Kernel/Devices/GPTPartitionTable.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/RefPtr.h>
+#include <AK/Types.h>
 #include <AK/Vector.h>
 #include <Kernel/Devices/DiskDevice.h>
 #include <Kernel/Devices/DiskPartition.h>
@@ -35,7 +36,8 @@
 #define GPT_SIGNATURE 0x20494645
 #define BytesPerSector 512
 
-struct GPTPartitionEntry {
+struct [[gnu::packed]] GPTPartitionEntry
+{
     u32 partition_guid[4];
     u32 unique_guid[4];
 
@@ -44,9 +46,10 @@ struct GPTPartitionEntry {
 
     u64 attributes;
     u8 partition_name[72];
-} __attribute__((packed));
+};
 
-struct GPTPartitionHeader {
+struct [[gnu::packed]] GPTPartitionHeader
+{
     u32 sig[2];
     u32 revision;
     u32 header_size;
@@ -65,7 +68,7 @@ struct GPTPartitionHeader {
     u32 entries_count;
     u32 partition_entry_size;
     u32 crc32_entries_array;
-} __attribute__((packed));
+};
 
 class GPTPartitionTable {
 

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -251,11 +251,6 @@ void init_stage2()
             hang();
         }
 
-        if (partition_number < 1 || partition_number > 4) {
-            kprintf("init_stage2: invalid partition number %d; expected 1 to 4\n", partition_number);
-            hang();
-        }
-
         MBRPartitionTable mbr(root_dev);
 
         if (!mbr.initialize()) {
@@ -278,6 +273,10 @@ void init_stage2()
             root_dev = *partition;
         } else {
             dbgprintf("MBR Partitioned Storage Detected!\n");
+            if (partition_number < 1 || partition_number > 4) {
+                kprintf("init_stage2: invalid partition number %d; expected 1 to 4\n", partition_number);
+                hang();
+            }
             auto partition = mbr.partition(partition_number);
             if (!partition) {
                 kprintf("init_stage2: couldn't get partition %d\n", partition_number);


### PR DESCRIPTION
Partially fixes #1052 
We still need to support [EBR partition scheme](https://en.wikipedia.org/wiki/Extended_boot_record) to achieve full support in booting partitions with number higher than 4.