### PR TITLE
build-root-filesystem.sh: Set umask to 0022

### DIFF
--- a/Kernel/build-root-filesystem.sh
+++ b/Kernel/build-root-filesystem.sh
@@ -16,6 +16,8 @@ if [ "$(id -u)" != 0 ]; then
     die "this script needs to run as root"
 fi
 
+umask 0022
+
 printf "creating initial filesystem structure... "
 for dir in bin etc proc mnt tmp; do
     mkdir -p mnt/$dir


### PR DESCRIPTION
On my system (Void Linux) the root user has a default umask of 0077,
causing files and directories in the disk image to have zero group and
world permissions.