### PR TITLE
LibC: Add byteswap.h, forwarding bswap_N to GCC builtins

### DIFF
--- a/Libraries/LibC/byteswap.h
+++ b/Libraries/LibC/byteswap.h
@@ -1,0 +1,11 @@
+#include <sys/cdefs.h>
+
+#pragma once
+
+__BEGIN_DECLS
+
+#define bswap_16(x) (__builtin_bswap16(x))
+#define bswap_32(x) (__builtin_bswap32(x))
+#define bswap_64(x) (__builtin_bswap64(x))
+
+__END_DECLS


### PR DESCRIPTION
Provide `bswap_N` variants in LibC for usage by userspace applications that expect them.