### PR TITLE
Meta: Integrate shellcheck into Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ notifications:
 before_install:
 - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 - sudo apt-get update -qq
-- sudo apt-get install g++-8 libstdc++-8-dev
+- sudo apt-get install g++-8 libstdc++-8-dev shellcheck
 - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 90
 - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 90
 - sudo apt-get install -y libmpfr-dev libmpc-dev libgmp-dev
@@ -33,3 +33,4 @@ script:
 - ./BuildIt.sh
 - cd ../Kernel
 - ./makeall.sh
+- ../Meta/lint-shell-scripts.sh

--- a/Kernel/build-image-qemu.sh
+++ b/Kernel/build-image-qemu.sh
@@ -15,20 +15,20 @@ if [ "$(uname -s)" = "Darwin" ]; then
     export PATH="/usr/local/opt/e2fsprogs/sbin:$PATH"
 fi
 echo "setting up disk image..."
-qemu-img create _disk_image "${DISK_SIZE:-600}"m || die "couldn't create disk image"
-chown "$SUDO_UID":"$SUDO_GID" _disk_image || die "couldn't adjust permissions on disk image"
+qemu-img create _disk_image "${DISK_SIZE:-600}"m || die "could not create disk image"
+chown "$SUDO_UID":"$SUDO_GID" _disk_image || die "could not adjust permissions on disk image"
 echo "done"
 
 printf "creating new filesystem... "
 if [ "$(uname -s)" = "OpenBSD" ]; then
-    VND=`vnconfig _disk_image`
-    (echo "e 0"; echo 83; echo n; echo 0; echo "*"; echo "quit") | fdisk -e $VND
-    mkfs.ext2 -I 128 -F /dev/${VND}i || die "couldn't create filesystem"
+    VND=$(vnconfig _disk_image)
+    (echo "e 0"; echo 83; echo n; echo 0; echo "*"; echo "quit") | fdisk -e "$VND"
+    mkfs.ext2 -I 128 -F "/dev/${VND}i" || die "could not create filesystem"
 else
     if [ -x /sbin/mke2fs ]; then
-        /sbin/mke2fs -q -I 128 _disk_image || die "couldn't create filesystem"
+        /sbin/mke2fs -q -I 128 _disk_image || die "could not create filesystem"
     else
-        mke2fs -q -I 128 _disk_image || die "couldn't create filesystem"
+        mke2fs -q -I 128 _disk_image || die "could not create filesystem"
     fi
 fi
 echo "done"
@@ -36,11 +36,11 @@ echo "done"
 printf "mounting filesystem... "
 mkdir -p mnt
 if [ "$(uname -s)" = "Darwin" ]; then
-    fuse-ext2 _disk_image mnt -o rw+,allow_other,uid=501,gid=20 || die "couldn't mount filesystem"
+    fuse-ext2 _disk_image mnt -o rw+,allow_other,uid=501,gid=20 || die "could not mount filesystem"
 elif [ "$(uname -s)" = "OpenBSD" ]; then
-    mount -t ext2fs /dev/${VND}i mnt/ || die "couldn't mount filesystem"
+    mount -t ext2fs "/dev/${VND}i" mnt/ || die "could not mount filesystem"
 else
-    mount _disk_image mnt/ || die "couldn't mount filesystem"
+    mount _disk_image mnt/ || die "could not mount filesystem"
 fi
 echo "done"
 
@@ -50,7 +50,7 @@ cleanup() {
         umount mnt || ( sleep 1 && sync && umount mnt )
         rm -rf mnt
         if [ "$(uname -s)" = "OpenBSD" ]; then
-           vnconfig -u $VND
+           vnconfig -u "$VND"
         fi
         echo "done"
     fi

--- a/Kernel/makeall.sh
+++ b/Kernel/makeall.sh
@@ -9,7 +9,7 @@ while [ "$1" != "" ]; do
     case $1 in
         -f | --fast )           fast_mode=1
                                 ;;
-        -h | --help )           echo "-f or --fast: build fast without cleaning or running tests"
+        -h | --help )           printf -- "-f or --fast: build fast without cleaning or running tests\n"
                                 exit 0
                                 ;;
     esac
@@ -18,10 +18,10 @@ done
 
 sudo id
 
-MAKE=make
+MAKE="make"
 
 if [ "$(uname -s)" = "OpenBSD" ]; then
-	MAKE=gmake
+	MAKE="gmake"
 fi
 
 if [ "$fast_mode" = "1" ]; then

--- a/Kernel/mkmap.sh
+++ b/Kernel/mkmap.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 tmp=$(mktemp)
-nm -n kernel | awk '{ if ($2 != "a") print; }' | uniq > $tmp
-printf "%08x\n" $(wc -l $tmp | cut -f1 -d' ') > kernel.map
-cat $tmp >> kernel.map
-rm -f $tmp
+nm -n kernel | awk '{ if ($2 != "a") print; }' | uniq > "$tmp"
+printf "%08x\n" "$(wc -l "$tmp" | cut -f1 -d' ')" > kernel.map
+cat "$tmp" >> kernel.map
+rm -f "$tmp"

--- a/Kernel/run
+++ b/Kernel/run
@@ -1,11 +1,14 @@
 #!/bin/sh
+# shellcheck disable=SC2086 # FIXME: fix these globing warnings
+
+set -e
 
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path"
 
 #SERENITY_PACKET_LOGGING_ARG="-object filter-dump,id=hue,netdev=breh,file=e1000.pcap"
 
-[ -e /dev/kvm -a -r /dev/kvm -a -w /dev/kvm ] && SERENITY_KVM_ARG="-enable-kvm"
+[ -e /dev/kvm ] && [ -r /dev/kvm ] && [ -w /dev/kvm ] && SERENITY_KVM_ARG="-enable-kvm"
 
 [ -z "$SERENITY_BOCHS_BIN" ] && SERENITY_BOCHS_BIN="bochs"
 
@@ -33,7 +36,7 @@ $SERENITY_EXTRA_QEMU_ARGS
 -s -m $SERENITY_RAM_SIZE
 -cpu max
 -machine q35
--d cpu_reset,guest_errors 
+-d cpu_reset,guest_errors
 -device VGA,vgamem_mb=64
 -device piix3-ide
 -drive file=_disk_image,id=disk,if=none
@@ -76,7 +79,7 @@ elif [ "$1" = "qgrub" ]; then
 elif [ "$1" = "q35_cmd" ]; then
     SERENITY_KERNEL_CMDLINE=""
     # FIXME: Someone who knows sh syntax better, please help:
-    for i in `seq 2 $#`; do
+    for _ in $(seq 2 $#); do
         shift
         SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE $1"
     done
@@ -92,7 +95,7 @@ elif [ "$1" = "q35_cmd" ]; then
 elif [ "$1" = "qcmd" ]; then
     SERENITY_KERNEL_CMDLINE=""
     # FIXME: Someone who knows sh syntax better, please help:
-    for i in `seq 2 $#`; do
+    for _ in $(seq 2 $#); do
         shift
         SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE $1"
     done

--- a/Kernel/sync.sh
+++ b/Kernel/sync.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path"
 

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e pipefail
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+cd "$script_path/.."
+
+ERRORS=()
+
+for f in $(find . -path ./Root -prune -o \
+    -path ./Ports -prune -o \
+    -path ./.git -prune -o \
+    -path ./Toolchain -prune -o \
+    -type f | sort -u); do
+    if file "$f" | grep --quiet shell; then
+        {
+            shellcheck "$f" && echo -e "[\033[0;32mOK\033[0m]: sucessfully linted $f"
+        } || {
+            ERRORS+=("$f")
+        }
+fi
+done
+
+if (( ${#ERRORS[@]} )); then
+    echo "Files failing shellcheck: ${ERRORS[*]}"
+    exit 1
+fi

--- a/Meta/refresh-serenity-qtcreator.sh
+++ b/Meta/refresh-serenity-qtcreator.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ ! -n "$SERENITY_ROOT" ]
+if [ -z "$SERENITY_ROOT" ]
 then echo "Serenity root not set. Please set environment variable first. E.g. export SERENITY_ROOT=$(git rev-parse --show-toplevel)"
 fi
 


### PR DESCRIPTION
Hopefully I'm going to start being less busy again, and can start contributing
some small things again :^) Hopefully I didn't break anything when I fixed some
of the warnings!

Add a script that traverses the repository for shell scripts, and runs
shellcheck on those files. Add the script as part of Travis.

Warning SC2086 has been ignored in Kernel/run for now, but should be
fixed in the future.

(Also, I've never used Travis before, but I assume that's how you integrate it into the CI?)

Closes #201