### PR TITLE
Piano: Implement sampler

### DIFF
--- a/Applications/Piano/AudioEngine.cpp
+++ b/Applications/Piano/AudioEngine.cpp
@@ -158,10 +158,10 @@ String AudioEngine::set_recorded_sample(const StringView& path)
         m_recorded_sample.clear();
     m_recorded_sample.resize(wav_buffer->sample_count());
 
-    float peak = 0;
+    double peak = 0;
     for (int i = 0; i < wav_buffer->sample_count(); ++i) {
-        float left_abs = fabs(wav_buffer->samples()[i].left);
-        float right_abs = fabs(wav_buffer->samples()[i].right);
+        double left_abs = fabs(wav_buffer->samples()[i].left);
+        double right_abs = fabs(wav_buffer->samples()[i].right);
         if (left_abs > peak)
             peak = left_abs;
         if (right_abs > peak)
@@ -228,8 +228,8 @@ Audio::Sample AudioEngine::recorded_sample(size_t note)
     int t = m_pos[note];
     if (t >= m_recorded_sample.size())
         return 0;
-    float w_left = m_recorded_sample[t].left;
-    float w_right = m_recorded_sample[t].right;
+    double w_left = m_recorded_sample[t].left;
+    double w_right = m_recorded_sample[t].right;
     if (t + 1 < m_recorded_sample.size()) {
         double t_fraction = m_pos[note] - t;
         w_left += (m_recorded_sample[t + 1].left - m_recorded_sample[t].left) * t_fraction;

--- a/Applications/Piano/AudioEngine.h
+++ b/Applications/Piano/AudioEngine.h
@@ -42,7 +42,6 @@ public:
 
     const FixedArray<Sample>& buffer() const { return *m_front_buffer_ptr; }
     const Vector<Audio::Sample>& recorded_sample() const { return m_recorded_sample; }
-    void reset();
     Switch roll_note(int y, int x) const { return m_roll_notes[y][x]; }
     int current_column() const { return m_current_column; }
     int octave() const { return m_octave; }
@@ -57,6 +56,7 @@ public:
     int tick() const { return m_tick; }
 
     void fill_buffer(FixedArray<Sample>& buffer);
+    void reset();
     String set_recorded_sample(const StringView& path);
     void set_note(int note, Switch);
     void set_note_current_octave(int note, Switch);

--- a/Applications/Piano/AudioEngine.h
+++ b/Applications/Piano/AudioEngine.h
@@ -71,12 +71,12 @@ public:
     void set_delay(int delay);
 
 private:
-    double sine(size_t note);
-    double saw(size_t note);
-    double square(size_t note);
-    double triangle(size_t note);
-    double noise() const;
-    double recorded_sample(size_t note);
+    Audio::Sample sine(size_t note);
+    Audio::Sample saw(size_t note);
+    Audio::Sample square(size_t note);
+    Audio::Sample triangle(size_t note);
+    Audio::Sample noise() const;
+    Audio::Sample recorded_sample(size_t note);
 
     void update_roll();
     void set_notes_from_roll();

--- a/Applications/Piano/AudioEngine.h
+++ b/Applications/Piano/AudioEngine.h
@@ -31,6 +31,7 @@
 #include <AK/FixedArray.h>
 #include <AK/Noncopyable.h>
 #include <AK/Queue.h>
+#include <LibAudio/Buffer.h>
 
 class AudioEngine {
     AK_MAKE_NONCOPYABLE(AudioEngine)
@@ -40,6 +41,7 @@ public:
     ~AudioEngine();
 
     const FixedArray<Sample>& buffer() const { return *m_front_buffer_ptr; }
+    const Vector<Audio::Sample>& recorded_sample() const { return m_recorded_sample; }
     void reset();
     Switch roll_note(int y, int x) const { return m_roll_notes[y][x]; }
     int current_column() const { return m_current_column; }
@@ -55,6 +57,7 @@ public:
     int tick() const { return m_tick; }
 
     void fill_buffer(FixedArray<Sample>& buffer);
+    String set_recorded_sample(const StringView& path);
     void set_note(int note, Switch);
     void set_note_current_octave(int note, Switch);
     void set_roll_note(int y, int x, Switch);
@@ -73,6 +76,7 @@ private:
     double square(size_t note);
     double triangle(size_t note);
     double noise() const;
+    double recorded_sample(size_t note);
 
     void update_roll();
     void set_notes_from_roll();
@@ -85,6 +89,8 @@ private:
     FixedArray<Sample>* m_back_buffer_ptr { &m_back_buffer };
 
     Queue<NonnullOwnPtr<FixedArray<Sample>>> m_delay_buffers;
+
+    Vector<Audio::Sample> m_recorded_sample;
 
     u8 m_note_on[note_count] { 0 };
     double m_power[note_count] { 0 };

--- a/Applications/Piano/MainWidget.cpp
+++ b/Applications/Piano/MainWidget.cpp
@@ -30,8 +30,10 @@
 #include "KeysWidget.h"
 #include "KnobsWidget.h"
 #include "RollWidget.h"
+#include "SamplerWidget.h"
 #include "WaveWidget.h"
 #include <LibGUI/BoxLayout.h>
+#include <LibGUI/TabWidget.h>
 
 MainWidget::MainWidget(AudioEngine& audio_engine)
     : m_audio_engine(audio_engine)
@@ -45,9 +47,15 @@ MainWidget::MainWidget(AudioEngine& audio_engine)
     m_wave_widget->set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
     m_wave_widget->set_preferred_size(0, 100);
 
-    m_roll_widget = RollWidget::construct(this, audio_engine);
+    m_roll_widget = RollWidget::construct(nullptr, audio_engine);
     m_roll_widget->set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fill);
     m_roll_widget->set_preferred_size(0, 300);
+
+    m_sampler_widget = SamplerWidget::construct(nullptr, audio_engine);
+
+    m_tab_widget = GUI::TabWidget::construct(this);
+    m_tab_widget->add_widget("Piano Roll", m_roll_widget);
+    m_tab_widget->add_widget("Sampler", m_sampler_widget);
 
     m_keys_and_knobs_container = GUI::Widget::construct(this);
     m_keys_and_knobs_container->set_layout(make<GUI::HorizontalBoxLayout>());

--- a/Applications/Piano/Makefile
+++ b/Applications/Piano/Makefile
@@ -3,6 +3,7 @@ OBJS = \
     MainWidget.o \
     WaveWidget.o \
     RollWidget.o \
+    SamplerWidget.o \
     KeysWidget.o \
     KnobsWidget.o \
     main.o

--- a/Applications/Piano/Music.h
+++ b/Applications/Piano/Music.h
@@ -112,7 +112,7 @@ constexpr KeyColor key_pattern[] = {
 const Color note_pressed_color(64, 64, 255);
 const Color column_playing_color(128, 128, 255);
 
-const Color wave_colors[] = {
+const Color left_wave_colors[] = {
     // Sine
     {
         255,
@@ -147,6 +147,45 @@ const Color wave_colors[] = {
     {
         227,
         39,
+        39,
+    },
+};
+
+const Color right_wave_colors[] = {
+    // Sine
+    {
+        255,
+        223,
+        0,
+    },
+    // Triangle
+    {
+        35,
+        171,
+        90,
+    },
+    // Square
+    {
+        139,
+        128,
+        255,
+    },
+    // Saw
+    {
+        240,
+        100,
+        220,
+    },
+    // Noise
+    {
+        197,
+        223,
+        225,
+    },
+    // RecordedSample
+    {
+        227,
+        105,
         39,
     },
 };

--- a/Applications/Piano/Music.h
+++ b/Applications/Piano/Music.h
@@ -67,6 +67,7 @@ enum Wave {
     Square,
     Saw,
     Noise,
+    RecordedSample,
 };
 
 constexpr const char* wave_strings[] = {
@@ -75,10 +76,11 @@ constexpr const char* wave_strings[] = {
     "Square",
     "Saw",
     "Noise",
+    "Sample",
 };
 
 constexpr int first_wave = Sine;
-constexpr int last_wave = Noise;
+constexpr int last_wave = RecordedSample;
 
 enum Envelope {
     Done,
@@ -109,6 +111,45 @@ constexpr KeyColor key_pattern[] = {
 
 const Color note_pressed_color(64, 64, 255);
 const Color column_playing_color(128, 128, 255);
+
+const Color wave_colors[] = {
+    // Sine
+    {
+        255,
+        192,
+        0,
+    },
+    // Triangle
+    {
+        35,
+        171,
+        35,
+    },
+    // Square
+    {
+        128,
+        160,
+        255,
+    },
+    // Saw
+    {
+        240,
+        100,
+        128,
+    },
+    // Noise
+    {
+        197,
+        214,
+        225,
+    },
+    // RecordedSample
+    {
+        227,
+        39,
+        39,
+    },
+};
 
 constexpr int notes_per_octave = 12;
 constexpr int white_keys_per_octave = 7;
@@ -216,6 +257,8 @@ constexpr double note_frequencies[] = {
     3951.0664100489994,
 };
 constexpr int note_count = sizeof(note_frequencies) / sizeof(double);
+
+constexpr double middle_c = note_frequencies[36];
 
 }
 

--- a/Applications/Piano/SamplerWidget.cpp
+++ b/Applications/Piano/SamplerWidget.cpp
@@ -69,18 +69,26 @@ void WaveEditor::paint_event(GUI::PaintEvent& event)
     painter.translate(frame_thickness(), frame_thickness());
 
     int prev_x = 0;
-    int prev_y = sample_to_y(recorded_sample[0].left);
-    painter.set_pixel({ prev_x, prev_y }, wave_colors[RecordedSample]);
+    int left_prev_y = sample_to_y(recorded_sample[0].left);
+    int right_prev_y = sample_to_y(recorded_sample[0].right);
+    painter.set_pixel({ prev_x, left_prev_y }, left_wave_colors[RecordedSample]);
+    painter.set_pixel({ prev_x, right_prev_y }, right_wave_colors[RecordedSample]);
 
     for (int x = 1; x < recorded_sample.size(); ++x) {
-        int y = sample_to_y(recorded_sample[x].left);
+        int left_y = sample_to_y(recorded_sample[x].left);
+        int right_y = sample_to_y(recorded_sample[x].right);
 
-        Gfx::Point point1(prev_x * width_scale, prev_y);
-        Gfx::Point point2(x * width_scale, y);
-        painter.draw_line(point1, point2, wave_colors[RecordedSample]);
+        Gfx::Point left_point1(prev_x * width_scale, left_prev_y);
+        Gfx::Point left_point2(x * width_scale, left_y);
+        painter.draw_line(left_point1, left_point2, left_wave_colors[RecordedSample]);
+
+        Gfx::Point right_point1(prev_x * width_scale, right_prev_y);
+        Gfx::Point right_point2(x * width_scale, right_y);
+        painter.draw_line(right_point1, right_point2, right_wave_colors[RecordedSample]);
 
         prev_x = x;
-        prev_y = y;
+        left_prev_y = left_y;
+        right_prev_y = right_y;
     }
 }
 

--- a/Applications/Piano/SamplerWidget.cpp
+++ b/Applications/Piano/SamplerWidget.cpp
@@ -46,7 +46,7 @@ WaveEditor::~WaveEditor()
 {
 }
 
-int WaveEditor::sample_to_y(float percentage) const
+int WaveEditor::sample_to_y(double percentage) const
 {
     double portion_of_half_height = percentage * ((frame_inner_rect().height() - 1) / 2.0);
     double y = (frame_inner_rect().height() / 2.0) + portion_of_half_height;

--- a/Applications/Piano/SamplerWidget.cpp
+++ b/Applications/Piano/SamplerWidget.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020-2020, William McPherson <willmcpherson2@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "SamplerWidget.h"
+#include "AudioEngine.h"
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/FilePicker.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/MessageBox.h>
+#include <LibGUI/Painter.h>
+
+WaveEditor::WaveEditor(GUI::Widget* parent, AudioEngine& audio_engine)
+    : GUI::Frame(parent)
+    , m_audio_engine(audio_engine)
+{
+    set_frame_thickness(2);
+    set_frame_shadow(Gfx::FrameShadow::Sunken);
+    set_frame_shape(Gfx::FrameShape::Container);
+}
+
+WaveEditor::~WaveEditor()
+{
+}
+
+int WaveEditor::sample_to_y(float percentage) const
+{
+    double portion_of_half_height = percentage * ((frame_inner_rect().height() - 1) / 2.0);
+    double y = (frame_inner_rect().height() / 2.0) + portion_of_half_height;
+    return y;
+}
+
+void WaveEditor::paint_event(GUI::PaintEvent& event)
+{
+    GUI::Frame::paint_event(event);
+
+    GUI::Painter painter(*this);
+    painter.fill_rect(frame_inner_rect(), Color::Black);
+
+    auto recorded_sample = m_audio_engine.recorded_sample();
+    if (recorded_sample.is_empty())
+        return;
+
+    double width_scale = static_cast<double>(frame_inner_rect().width()) / recorded_sample.size();
+
+    painter.translate(frame_thickness(), frame_thickness());
+
+    int prev_x = 0;
+    int prev_y = sample_to_y(recorded_sample[0].left);
+    painter.set_pixel({ prev_x, prev_y }, wave_colors[RecordedSample]);
+
+    for (int x = 1; x < recorded_sample.size(); ++x) {
+        int y = sample_to_y(recorded_sample[x].left);
+
+        Gfx::Point point1(prev_x * width_scale, prev_y);
+        Gfx::Point point2(x * width_scale, y);
+        painter.draw_line(point1, point2, wave_colors[RecordedSample]);
+
+        prev_x = x;
+        prev_y = y;
+    }
+}
+
+SamplerWidget::SamplerWidget(GUI::Widget* parent, AudioEngine& audio_engine)
+    : GUI::Frame(parent)
+    , m_audio_engine(audio_engine)
+{
+    set_frame_thickness(2);
+    set_frame_shadow(Gfx::FrameShadow::Sunken);
+    set_frame_shape(Gfx::FrameShape::Container);
+    set_layout(make<GUI::VerticalBoxLayout>());
+    layout()->set_margins({ 10, 10, 10, 10 });
+    layout()->set_spacing(10);
+    set_fill_with_background_color(true);
+
+    m_open_button_and_recorded_sample_name_container = GUI::Widget::construct(this);
+    m_open_button_and_recorded_sample_name_container->set_layout(make<GUI::HorizontalBoxLayout>());
+    m_open_button_and_recorded_sample_name_container->layout()->set_spacing(10);
+    m_open_button_and_recorded_sample_name_container->set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
+    m_open_button_and_recorded_sample_name_container->set_preferred_size(0, 24);
+
+    m_open_button = GUI::Button::construct(m_open_button_and_recorded_sample_name_container);
+    m_open_button->set_size_policy(GUI::SizePolicy::Fixed, GUI::SizePolicy::Fixed);
+    m_open_button->set_preferred_size(24, 24);
+    m_open_button->set_focusable(false);
+    m_open_button->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/open.png"));
+    m_open_button->on_click = [this](const auto&) {
+        Optional<String> open_path = GUI::FilePicker::get_open_filepath();
+        if (!open_path.has_value())
+            return;
+        String error_string = m_audio_engine.set_recorded_sample(open_path.value());
+        if (!error_string.is_empty()) {
+            GUI::MessageBox::show(String::format("Failed to load WAV file: %s", error_string.characters()), "Error", GUI::MessageBox::Type::Error);
+            return;
+        }
+        m_recorded_sample_name->set_text(open_path.value());
+        m_wave_editor->update();
+    };
+
+    m_recorded_sample_name = GUI::Label::construct("No sample loaded", m_open_button_and_recorded_sample_name_container);
+    m_recorded_sample_name->set_text_alignment(Gfx::TextAlignment::CenterLeft);
+
+    m_wave_editor = WaveEditor::construct(this, m_audio_engine);
+    m_wave_editor->set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
+    m_wave_editor->set_preferred_size(0, 100);
+}
+
+SamplerWidget::~SamplerWidget()
+{
+}

--- a/Applications/Piano/SamplerWidget.h
+++ b/Applications/Piano/SamplerWidget.h
@@ -45,7 +45,7 @@ private:
 
     virtual void paint_event(GUI::PaintEvent&) override;
 
-    int sample_to_y(float percentage) const;
+    int sample_to_y(double percentage) const;
 
     AudioEngine& m_audio_engine;
 };

--- a/Applications/Piano/SamplerWidget.h
+++ b/Applications/Piano/SamplerWidget.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2019-2020, William McPherson <willmcpherson2@gmail.com>
+ * Copyright (c) 2020-2020, William McPherson <willmcpherson2@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,46 +26,42 @@
 
 #pragma once
 
-#include "Music.h"
-#include <LibGUI/Widget.h>
-
-class AudioEngine;
-class WaveWidget;
-class RollWidget;
-class SamplerWidget;
-class KeysWidget;
-class KnobsWidget;
+#include <LibGUI/Frame.h>
 
 namespace GUI {
-class TabWidget;
+class Label;
+class Button;
 }
 
-class MainWidget final : public GUI::Widget {
-    C_OBJECT(MainWidget)
-public:
-    virtual ~MainWidget() override;
+class AudioEngine;
 
-    void set_octave_and_ensure_note_change(Direction);
+class WaveEditor final : public GUI::Frame {
+    C_OBJECT(WaveEditor)
+public:
+    virtual ~WaveEditor() override;
 
 private:
-    explicit MainWidget(AudioEngine&);
+    WaveEditor(GUI::Widget* parent, AudioEngine&);
 
-    virtual void keydown_event(GUI::KeyEvent&) override;
-    virtual void keyup_event(GUI::KeyEvent&) override;
-    virtual void custom_event(Core::CustomEvent&) override;
+    virtual void paint_event(GUI::PaintEvent&) override;
 
-    void note_key_action(int key_code, Switch);
-    void special_key_action(int key_code);
+    int sample_to_y(float percentage) const;
+
+    AudioEngine& m_audio_engine;
+};
+
+class SamplerWidget final : public GUI::Frame {
+    C_OBJECT(SamplerWidget)
+public:
+    virtual ~SamplerWidget() override;
+
+private:
+    SamplerWidget(GUI::Widget* parent, AudioEngine&);
 
     AudioEngine& m_audio_engine;
 
-    RefPtr<WaveWidget> m_wave_widget;
-    RefPtr<RollWidget> m_roll_widget;
-    RefPtr<SamplerWidget> m_sampler_widget;
-    RefPtr<GUI::TabWidget> m_tab_widget;
-    RefPtr<GUI::Widget> m_keys_and_knobs_container;
-    RefPtr<KeysWidget> m_keys_widget;
-    RefPtr<KnobsWidget> m_knobs_widget;
-
-    bool m_keys_pressed[key_code_count] { false };
+    RefPtr<GUI::Widget> m_open_button_and_recorded_sample_name_container;
+    RefPtr<GUI::Button> m_open_button;
+    RefPtr<GUI::Label> m_recorded_sample_name;
+    RefPtr<WaveEditor> m_wave_editor;
 };

--- a/Applications/Piano/WaveWidget.cpp
+++ b/Applications/Piano/WaveWidget.cpp
@@ -60,23 +60,32 @@ void WaveWidget::paint_event(GUI::PaintEvent& event)
     painter.fill_rect(frame_inner_rect(), Color::Black);
     painter.translate(frame_thickness(), frame_thickness());
 
-    Color wave_color = wave_colors[m_audio_engine.wave()];
+    Color left_wave_color = left_wave_colors[m_audio_engine.wave()];
+    Color right_wave_color = right_wave_colors[m_audio_engine.wave()];
     auto buffer = m_audio_engine.buffer();
     double width_scale = static_cast<double>(frame_inner_rect().width()) / buffer.size();
 
     int prev_x = 0;
-    int prev_y = sample_to_y(buffer[0].left);
-    painter.set_pixel({ prev_x, prev_y }, wave_color);
+    int prev_y_left = sample_to_y(buffer[0].left);
+    int prev_y_right = sample_to_y(buffer[0].right);
+    painter.set_pixel({ prev_x, prev_y_left }, left_wave_color);
+    painter.set_pixel({ prev_x, prev_y_right }, right_wave_color);
 
     for (size_t x = 1; x < buffer.size(); ++x) {
-        int y = sample_to_y(buffer[x].left);
+        int y_left = sample_to_y(buffer[x].left);
+        int y_right = sample_to_y(buffer[x].right);
 
-        Gfx::Point point1(prev_x * width_scale, prev_y);
-        Gfx::Point point2(x * width_scale, y);
-        painter.draw_line(point1, point2, wave_color);
+        Gfx::Point point1_left(prev_x * width_scale, prev_y_left);
+        Gfx::Point point2_left(x * width_scale, y_left);
+        painter.draw_line(point1_left, point2_left, left_wave_color);
+
+        Gfx::Point point1_right(prev_x * width_scale, prev_y_right);
+        Gfx::Point point2_right(x * width_scale, y_right);
+        painter.draw_line(point1_right, point2_right, right_wave_color);
 
         prev_x = x;
-        prev_y = y;
+        prev_y_left = y_left;
+        prev_y_right = y_right;
     }
 
     GUI::Frame::paint_event(event);

--- a/Applications/Piano/WaveWidget.cpp
+++ b/Applications/Piano/WaveWidget.cpp
@@ -45,6 +45,8 @@ WaveWidget::~WaveWidget()
 
 int WaveWidget::sample_to_y(int sample) const
 {
+    constexpr int nice_scale_factor = 4;
+    sample *= nice_scale_factor;
     constexpr double sample_max = std::numeric_limits<i16>::max();
     double percentage = sample / sample_max;
     double portion_of_half_height = percentage * ((frame_inner_rect().height() - 1) / 2.0);

--- a/Applications/Piano/WaveWidget.cpp
+++ b/Applications/Piano/WaveWidget.cpp
@@ -47,8 +47,8 @@ int WaveWidget::sample_to_y(int sample) const
 {
     constexpr double sample_max = std::numeric_limits<i16>::max();
     double percentage = sample / sample_max;
-    double portion_of_height = percentage * frame_inner_rect().height();
-    int y = (frame_inner_rect().height() / 2) + portion_of_height;
+    double portion_of_half_height = percentage * ((frame_inner_rect().height() - 1) / 2.0);
+    double y = (frame_inner_rect().height() / 2.0) + portion_of_half_height;
     return y;
 }
 

--- a/Applications/Piano/WaveWidget.cpp
+++ b/Applications/Piano/WaveWidget.cpp
@@ -43,39 +43,6 @@ WaveWidget::~WaveWidget()
 {
 }
 
-static const Color wave_colors[] = {
-    // Sine
-    {
-        255,
-        192,
-        0,
-    },
-    // Triangle
-    {
-        35,
-        171,
-        35,
-    },
-    // Square
-    {
-        128,
-        160,
-        255,
-    },
-    // Saw
-    {
-        240,
-        100,
-        128,
-    },
-    // Noise
-    {
-        197,
-        214,
-        225,
-    },
-};
-
 int WaveWidget::sample_to_y(int sample) const
 {
     constexpr double sample_max = std::numeric_limits<i16>::max();

--- a/Libraries/LibAudio/Buffer.h
+++ b/Libraries/LibAudio/Buffer.h
@@ -43,14 +43,14 @@ struct Sample {
     }
 
     // For mono
-    Sample(float left)
+    Sample(double left)
         : left(left)
         , right(left)
     {
     }
 
     // For stereo
-    Sample(float left, float right)
+    Sample(double left, double right)
         : left(left)
         , right(right)
     {
@@ -71,7 +71,7 @@ struct Sample {
 
     void scale(int percent)
     {
-        float pct = (float)percent / 100.0;
+        double pct = (double)percent / 100.0;
         left *= pct;
         right *= pct;
     }
@@ -83,8 +83,8 @@ struct Sample {
         return *this;
     }
 
-    float left;
-    float right;
+    double left;
+    double right;
 };
 
 // Small helper to resample from one playback rate to another
@@ -92,16 +92,16 @@ struct Sample {
 // Should do better...
 class ResampleHelper {
 public:
-    ResampleHelper(float source, float target);
+    ResampleHelper(double source, double target);
 
-    void process_sample(float sample_l, float sample_r);
-    bool read_sample(float& next_l, float& next_r);
+    void process_sample(double sample_l, double sample_r);
+    bool read_sample(double& next_l, double& next_r);
 
 private:
-    const float m_ratio;
-    float m_current_ratio { 0 };
-    float m_last_sample_l { 0 };
-    float m_last_sample_r { 0 };
+    const double m_ratio;
+    double m_current_ratio { 0 };
+    double m_last_sample_l { 0 };
+    double m_last_sample_r { 0 };
 };
 
 // A buffer of audio samples, normalized to 44100hz.

--- a/Libraries/LibAudio/WavLoader.cpp
+++ b/Libraries/LibAudio/WavLoader.cpp
@@ -40,7 +40,9 @@ WavLoader::WavLoader(const StringView& path)
         return;
     }
 
-    parse_header();
+    if (!parse_header())
+        return;
+
     m_resampler = make<ResampleHelper>(m_sample_rate, 44100);
 }
 
@@ -81,7 +83,6 @@ bool WavLoader::parse_header()
 
 #define CHECK_OK(msg)                                                           \
     do {                                                                        \
-        ASSERT(ok);                                                             \
         if (stream.handle_read_failure()) {                                     \
             m_error_string = String::format("Premature stream EOF at %s", msg); \
             return {};                                                          \

--- a/Libraries/LibAudio/WavLoader.cpp
+++ b/Libraries/LibAudio/WavLoader.cpp
@@ -182,19 +182,19 @@ bool WavLoader::parse_header()
     return true;
 }
 
-ResampleHelper::ResampleHelper(float source, float target)
+ResampleHelper::ResampleHelper(double source, double target)
     : m_ratio(source / target)
 {
 }
 
-void ResampleHelper::process_sample(float sample_l, float sample_r)
+void ResampleHelper::process_sample(double sample_l, double sample_r)
 {
     m_last_sample_l = sample_l;
     m_last_sample_r = sample_r;
     m_current_ratio += 1;
 }
 
-bool ResampleHelper::read_sample(float& next_l, float& next_r)
+bool ResampleHelper::read_sample(double& next_l, double& next_r)
 {
     if (m_current_ratio > 0) {
         m_current_ratio -= m_ratio;
@@ -209,8 +209,8 @@ bool ResampleHelper::read_sample(float& next_l, float& next_r)
 template<typename SampleReader>
 static void read_samples_from_stream(BufferStream& stream, SampleReader read_sample, Vector<Sample>& samples, ResampleHelper& resampler, int num_channels)
 {
-    float norm_l = 0;
-    float norm_r = 0;
+    double norm_l = 0;
+    double norm_r = 0;
 
     switch (num_channels) {
     case 1:
@@ -245,7 +245,7 @@ static void read_samples_from_stream(BufferStream& stream, SampleReader read_sam
     }
 }
 
-static float read_norm_sample_24(BufferStream& stream)
+static double read_norm_sample_24(BufferStream& stream)
 {
     u8 byte = 0;
     stream >> byte;
@@ -259,21 +259,21 @@ static float read_norm_sample_24(BufferStream& stream)
     value = sample1 << 8;
     value |= (sample2 << 16);
     value |= (sample3 << 24);
-    return float(value) / std::numeric_limits<i32>::max();
+    return double(value) / std::numeric_limits<i32>::max();
 }
 
-static float read_norm_sample_16(BufferStream& stream)
+static double read_norm_sample_16(BufferStream& stream)
 {
     i16 sample = 0;
     stream >> sample;
-    return float(sample) / std::numeric_limits<i16>::max();
+    return double(sample) / std::numeric_limits<i16>::max();
 }
 
-static float read_norm_sample_8(BufferStream& stream)
+static double read_norm_sample_8(BufferStream& stream)
 {
     u8 sample = 0;
     stream >> sample;
-    return float(sample) / std::numeric_limits<u8>::max();
+    return double(sample) / std::numeric_limits<u8>::max();
 }
 
 // ### can't const this because BufferStream is non-const

--- a/Userland/aplay.cpp
+++ b/Userland/aplay.cpp
@@ -41,6 +41,10 @@ int main(int argc, char** argv)
     auto audio_client = Audio::ClientConnection::construct();
     audio_client->handshake();
     Audio::WavLoader loader(argv[1]);
+    if (loader.has_error()) {
+        fprintf(stderr, "Failed to load WAV file: %s\n", loader.error_string());
+        return 1;
+    }
 
     printf("\033[34;1m Playing\033[0m: %s\n", argv[1]);
     printf("\033[34;1m  Format\033[0m: %u Hz, %u-bit, %s\n",


### PR DESCRIPTION
This PR adds a sampler to Piano which can be used to load, view and play WAV files at different pitches. It also improves stereo support - the sampler playback and wave visualisations are in stereo. An assertion has been removed in Audio::WavLoader and we are now handling the error properly.

An interesting thing to note is that there are some WAV files that Piano loads correctly but aplay and SoundPlayer do not. Here are two examples:
(Warning: glitched playback is LOUD)
https://sndup.net/2pkj
https://sndup.net/2xgf
This is probably due to the fact that Piano does some normalization to the audio data (see 
aadc8ee)
