### PR TITLE
Ports: Disable JACK for SDL2 in `configopts`

### DIFF
--- a/Ports/SDL2/package.sh
+++ b/Ports/SDL2/package.sh
@@ -4,7 +4,7 @@ version=serenity-git
 workdir=SDL-master-serenity
 useconfigure=true
 files="https://github.com/SerenityOS/SDL/archive/master-serenity.tar.gz SDL2-git.tar.gz"
-configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMakeToolchain.txt -DPULSEAUDIO=OFF"
+configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMakeToolchain.txt -DPULSEAUDIO=OFF -DJACK=OFF"
 
 configure() {
     run cmake $configopts


### PR DESCRIPTION
This is causing build errors for myself and a few other people.
This config option disables the SDL2 port from trying to compile
with the JACK audio server (which we don't need).