### PR TITLE
Calculator: accept more keyboard input

### DIFF
--- a/Applications/Calculator/CalculatorWidget.cpp
+++ b/Applications/Calculator/CalculatorWidget.cpp
@@ -236,6 +236,16 @@ void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
     } else if (event.key() >= KeyCode::Key_0 && event.key() <= KeyCode::Key_9) {
         m_keypad.type_digit(atoi(event.text().characters()));
 
+    } else if (event.key() == KeyCode::Key_Period) {
+	m_keypad.type_decimal_point();
+
+    } else if (event.key() == KeyCode::Key_Escape) {
+	m_keypad.set_value(0.0);
+        m_calculator.clear_operation();
+
+    } else if (event.key() == KeyCode::Key_Backspace) {
+	m_keypad.type_backspace();
+
     } else {
         Calculator::Operation operation;
 

--- a/Applications/Calculator/CalculatorWidget.cpp
+++ b/Applications/Calculator/CalculatorWidget.cpp
@@ -240,7 +240,7 @@ void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
 	m_keypad.type_decimal_point();
 
     } else if (event.key() == KeyCode::Key_Escape) {
-	m_keypad.set_value(0.0);
+        m_keypad.set_value(0.0);
         m_calculator.clear_operation();
 
     } else if (event.key() == KeyCode::Key_Backspace) {

--- a/Applications/Calculator/CalculatorWidget.cpp
+++ b/Applications/Calculator/CalculatorWidget.cpp
@@ -237,14 +237,14 @@ void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
         m_keypad.type_digit(atoi(event.text().characters()));
 
     } else if (event.key() == KeyCode::Key_Period) {
-	m_keypad.type_decimal_point();
+        m_keypad.type_decimal_point();
 
     } else if (event.key() == KeyCode::Key_Escape) {
         m_keypad.set_value(0.0);
         m_calculator.clear_operation();
 
     } else if (event.key() == KeyCode::Key_Backspace) {
-	m_keypad.type_backspace();
+        m_keypad.type_backspace();
 
     } else {
         Calculator::Operation operation;


### PR DESCRIPTION
Allow user to clear/remove last numeral from input (Esc/Backspace
respectively) and type the decimal point.