### PR TITLE
WindowServer: Move some menu related code into MenuManager

### DIFF
--- a/Servers/WindowServer/MenuManager.h
+++ b/Servers/WindowServer/MenuManager.h
@@ -44,8 +44,6 @@ public:
 
     void refresh();
 
-    virtual void event(Core::Event&) override;
-
     bool is_open(const Menu&) const;
 
     Vector<WeakPtr<Menu>>& open_menu_stack() { return m_open_menu_stack; }
@@ -95,6 +93,8 @@ private:
 
     const Window& window() const { return *m_window; }
 
+    virtual void event(Core::Event&) override;
+    void handle_mouse_event(MouseEvent&);
     void handle_menu_mouse_event(Menu&, const MouseEvent&);
 
     void draw();

--- a/Servers/WindowServer/WindowManager.h
+++ b/Servers/WindowServer/WindowManager.h
@@ -168,18 +168,19 @@ public:
 
     void update_theme(String theme_path, String theme_name);
 
+    void set_hovered_window(Window*);
+    void deliver_mouse_event(Window& window, MouseEvent& event);
+
 private:
     NonnullRefPtr<Cursor> get_cursor(const String& name);
     NonnullRefPtr<Cursor> get_cursor(const String& name, const Gfx::Point& hotspot);
 
     void process_mouse_event(MouseEvent&, Window*& hovered_window);
     void process_event_for_doubleclick(Window& window, MouseEvent& event);
-    void deliver_mouse_event(Window& window, MouseEvent& event);
     bool process_ongoing_window_resize(const MouseEvent&, Window*& hovered_window);
     bool process_ongoing_window_move(MouseEvent&, Window*& hovered_window);
     bool process_ongoing_drag(MouseEvent&, Window*& hovered_window);
     void start_window_move(Window&, const MouseEvent&);
-    void set_hovered_window(Window*);
     template<typename Callback>
     IterationDecision for_each_visible_window_of_type_from_back_to_front(WindowType, Callback, bool ignore_highlight = false);
     template<typename Callback>


### PR DESCRIPTION
Shuffle around some menu related code from window manager into menu
manager. This still is not perfect, and results in a little more of the
window manager to be publically exposed - but this is another step
towards better seperation of concerns between menu and window manager.

We also move the mouse_event handling into a new function in menu manager
as event handling was beginning to become a bit chunky.