### PR TITLE
Shell: Add basic tilde expansion

### DIFF
--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -53,6 +53,7 @@ public:
     void clear();
 
     size_t length() const { return m_length; }
+    bool is_empty() const { return m_length == 0; }
     void trim(size_t count) { m_length -= count; }
 
 private:

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -105,6 +105,13 @@ Vector<StringView> StringView::lines(bool consider_cr) const
     return v;
 }
 
+bool StringView::starts_with(char ch) const
+{
+    if (is_empty())
+        return false;
+    return ch == characters_without_null_termination()[0];
+}
+
 bool StringView::starts_with(const StringView& str) const
 {
     if (str.is_empty())
@@ -116,6 +123,13 @@ bool StringView::starts_with(const StringView& str) const
     if (characters_without_null_termination() == str.characters_without_null_termination())
         return true;
     return !memcmp(characters_without_null_termination(), str.characters_without_null_termination(), str.length());
+}
+
+bool StringView::ends_with(char ch) const
+{
+    if (is_empty())
+        return false;
+    return ch == characters_without_null_termination()[length() - 1];
 }
 
 bool StringView::ends_with(const StringView& str) const

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -63,6 +63,8 @@ public:
 
     bool starts_with(const StringView&) const;
     bool ends_with(const StringView&) const;
+    bool starts_with(char) const;
+    bool ends_with(char) const;
 
     StringView substring_view(size_t start, size_t length) const;
     Vector<StringView> split_view(char, bool keep_empty = false) const;

--- a/AK/Tests/TestStringView.cpp
+++ b/AK/Tests/TestStringView.cpp
@@ -63,6 +63,8 @@ TEST_CASE(starts_with)
 {
     String test_string = "ABCDEF";
     StringView test_string_view = test_string.view();
+    EXPECT(test_string_view.starts_with('A'));
+    EXPECT(!test_string_view.starts_with('B'));
     EXPECT(test_string_view.starts_with("AB"));
     EXPECT(test_string_view.starts_with("ABCDEF"));
     EXPECT(!test_string_view.starts_with("DEF"));
@@ -73,6 +75,8 @@ TEST_CASE(ends_with)
     String test_string = "ABCDEF";
     StringView test_string_view = test_string.view();
     EXPECT(test_string_view.ends_with("DEF"));
+    EXPECT(test_string_view.ends_with('F'));
+    EXPECT(!test_string_view.ends_with('E'));
     EXPECT(test_string_view.ends_with("ABCDEF"));
     EXPECT(!test_string_view.ends_with("ABCDE"));
     EXPECT(!test_string_view.ends_with("ABCDEFG"));

--- a/Libraries/LibC/string.cpp
+++ b/Libraries/LibC/string.cpp
@@ -297,6 +297,15 @@ char* strchr(const char* str, int c)
     }
 }
 
+char* strchrnul(const char* str, int c)
+{
+    char ch = c;
+    for (;; ++str) {
+        if (*str == ch || !*str)
+            return const_cast<char*>(str);
+    }
+}
+
 void* memchr(const void* ptr, int c, size_t size)
 {
     char ch = c;

--- a/Libraries/LibC/string.h
+++ b/Libraries/LibC/string.h
@@ -49,6 +49,7 @@ char* strndup(const char*, size_t);
 char* strcpy(char* dest, const char* src);
 char* strncpy(char* dest, const char* src, size_t);
 char* strchr(const char*, int c);
+char* strchrnul(const char*, int c);
 char* strstr(const char* haystack, const char* needle);
 char* strrchr(const char*, int c);
 char* strcat(char* dest, const char* src);

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -102,20 +102,20 @@ static String prompt()
     return builder.to_string();
 }
 
-static int sh_pwd(int, char**)
+static int sh_pwd(int, const char**)
 {
     printf("%s\n", g.cwd.characters());
     return 0;
 }
 
-static int sh_exit(int, char**)
+static int sh_exit(int, const char**)
 {
     printf("Good-bye!\n");
     exit(0);
     return 0;
 }
 
-static int sh_export(int argc, char** argv)
+static int sh_export(int argc, const char** argv)
 {
     if (argc == 1) {
         for (int i = 0; environ[i]; ++i)
@@ -136,7 +136,7 @@ static int sh_export(int argc, char** argv)
     return setenv_return;
 }
 
-static int sh_unset(int argc, char** argv)
+static int sh_unset(int argc, const char** argv)
 {
     if (argc != 2) {
         fprintf(stderr, "usage: unset variable\n");
@@ -185,7 +185,7 @@ static String expand_tilde(const char* expression)
     return String::format("%s/%s", passwd->pw_dir, path.to_string().characters());
 }
 
-static int sh_cd(int argc, char** argv)
+static int sh_cd(int argc, const char** argv)
 {
     char pathbuf[PATH_MAX];
 
@@ -239,7 +239,7 @@ static int sh_cd(int argc, char** argv)
     return 0;
 }
 
-static int sh_history(int, char**)
+static int sh_history(int, const char**)
 {
     for (int i = 0; i < editor.history().size(); ++i) {
         printf("%6d  %s\n", i, editor.history()[i].characters());
@@ -247,7 +247,7 @@ static int sh_history(int, char**)
     return 0;
 }
 
-static int sh_time(int argc, char** argv)
+static int sh_time(int argc, const char** argv)
 {
     if (argc == 1) {
         printf("usage: time <command>\n");
@@ -266,7 +266,7 @@ static int sh_time(int argc, char** argv)
     return exit_code;
 }
 
-static int sh_umask(int argc, char** argv)
+static int sh_umask(int argc, const char** argv)
 {
     if (argc == 1) {
         mode_t old_mask = umask(0);
@@ -286,7 +286,7 @@ static int sh_umask(int argc, char** argv)
     return 0;
 }
 
-static int sh_popd(int argc, char** argv)
+static int sh_popd(int argc, const char** argv)
 {
     if (g.directory_stack.size() <= 1) {
         fprintf(stderr, "Shell: popd: directory stack empty\n");
@@ -348,7 +348,7 @@ static int sh_popd(int argc, char** argv)
     return 0;
 }
 
-static int sh_pushd(int argc, char** argv)
+static int sh_pushd(int argc, const char** argv)
 {
     StringBuilder path_builder;
     bool should_switch = true;
@@ -435,7 +435,7 @@ static int sh_pushd(int argc, char** argv)
     return 0;
 }
 
-static int sh_dirs(int argc, char** argv)
+static int sh_dirs(int argc, const char** argv)
 {
     // The first directory in the stack is ALWAYS the current directory
     g.directory_stack.at(0) = g.cwd.characters();
@@ -479,7 +479,7 @@ static int sh_dirs(int argc, char** argv)
     return 0;
 }
 
-static bool handle_builtin(int argc, char** argv, int& retval)
+static bool handle_builtin(int argc, const char** argv, int& retval)
 {
     if (argc == 0)
         return false;
@@ -832,7 +832,7 @@ static int run_command(const String& cmd)
 #endif
 
             int retval = 0;
-            if (handle_builtin(argv.size() - 1, const_cast<char**>(argv.data()), retval))
+            if (handle_builtin(argv.size() - 1, argv.data(), retval))
                 return retval;
 
             pid_t child = fork();


### PR DESCRIPTION
This does not work with shell completion yet, but the basics of being
able a cd being able to expand "~" to the current user's home directory,
and "~foo" to the home directory of user "foo" is added in this commit

Work towards: #115