### PR TITLE
WebServer: Add the requested path so far to the directory listing links

### DIFF
--- a/Servers/WebServer/Client.h
+++ b/Servers/WebServer/Client.h
@@ -45,6 +45,7 @@ private:
 
     void handle_request(ByteBuffer);
     void send_response(StringView, const Core::HttpRequest&);
+    void send_redirect(StringView redirect, const Core::HttpRequest& request);
     void send_error_response(unsigned code, const StringView& message, const Core::HttpRequest&);
     void die();
     void log_response(unsigned code, const Core::HttpRequest&);


### PR DESCRIPTION
Without the requested path added, every link will point to the root directory

eg:
```
mkdir /www/dir1
mkdir /www/dir1/dir2
touch /www/dir1/x.html
touch /www/dir1/dir2/y.html
```

In browser go to [localhost:8000/dir1](http://localhost:8000/dir1) and x.html will point to  http://localhost:8000/x.html