### PR TITLE
Add Yes/No and Yes/No/Cancel MessageBoxes to LibGUI

### DIFF
--- a/Applications/SystemDialog/main.cpp
+++ b/Applications/SystemDialog/main.cpp
@@ -55,20 +55,17 @@ int run_shutdown_dialog(int argc, char** argv)
     GUI::Application app(argc, argv);
 
     {
-        auto result = GUI::MessageBox::show("Shut down Serenity?", "Confirm Shutdown", GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::OKCancel);
+        auto result = GUI::MessageBox::show("Shut down Serenity?", "Confirm Shutdown", GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::YesNo);
 
-        if (result == GUI::MessageBox::ExecOK) {
-            dbg() << "OK";
+        if (result == GUI::MessageBox::ExecYes) {
             int rc = execl("/bin/shutdown", "/bin/shutdown", "-n", nullptr);
             if (rc < 0) {
                 perror("execl");
                 return 1;
             }
-        } else {
-            dbg() << "Cancel";
-            return 0;
+            ASSERT_NOT_REACHED();
         }
-    }
 
-    return app.exec();
+        return 0;
+    }
 }

--- a/Libraries/LibGUI/Dialog.h
+++ b/Libraries/LibGUI/Dialog.h
@@ -36,7 +36,9 @@ public:
     enum ExecResult {
         ExecOK = 0,
         ExecCancel = 1,
-        ExecAborted = 2
+        ExecAborted = 2,
+        ExecYes = 3,
+        ExecNo = 4,
     };
 
     virtual ~Dialog() override;

--- a/Libraries/LibGUI/MessageBox.cpp
+++ b/Libraries/LibGUI/MessageBox.cpp
@@ -74,7 +74,17 @@ bool MessageBox::should_include_ok_button() const
 
 bool MessageBox::should_include_cancel_button() const
 {
-    return m_input_type == InputType::OKCancel;
+    return m_input_type == InputType::OKCancel || m_input_type == InputType::YesNoCancel;
+}
+
+bool MessageBox::should_include_yes_button() const
+{
+    return m_input_type == InputType::YesNo || m_input_type == InputType::YesNoCancel;
+}
+
+bool MessageBox::should_include_no_button() const
+{
+    return should_include_yes_button();
 }
 
 void MessageBox::build()
@@ -114,27 +124,25 @@ void MessageBox::build()
     button_container->layout()->set_spacing(5);
     button_container->layout()->set_margins({ 15, 0, 15, 0 });
 
-    if (should_include_ok_button()) {
-        auto ok_button = Button::construct(button_container);
-        ok_button->set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
-        ok_button->set_preferred_size(0, 20);
-        ok_button->set_text("OK");
-        ok_button->on_click = [this](auto&) {
-            dbgprintf("GMessageBox: OK button clicked\n");
-            done(Dialog::ExecOK);
+    auto add_button = [&](String label, Dialog::ExecResult result) {
+        auto button = Button::construct(button_container);
+        button->set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
+        button->set_preferred_size(0, 20);
+        button->set_text(label);
+        button->on_click = [=](auto&) {
+            dbg() << "GUI::MessageBox: '" << label << "' button clicked";
+            done(result);
         };
-    }
+    };
 
-    if (should_include_cancel_button()) {
-        auto cancel_button = Button::construct(button_container);
-        cancel_button->set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
-        cancel_button->set_preferred_size(0, 20);
-        cancel_button->set_text("Cancel");
-        cancel_button->on_click = [this](auto&) {
-            dbgprintf("GMessageBox: Cancel button clicked\n");
-            done(Dialog::ExecCancel);
-        };
-    }
+    if (should_include_ok_button())
+        add_button("OK", Dialog::ExecOK);
+    if (should_include_yes_button())
+        add_button("Yes", Dialog::ExecYes);
+    if (should_include_no_button())
+        add_button("No", Dialog::ExecNo);
+    if (should_include_cancel_button())
+        add_button("Cancel", Dialog::ExecCancel);
 
     set_rect(x(), y(), text_width + icon_width + 80, 100);
     set_resizable(false);

--- a/Libraries/LibGUI/MessageBox.h
+++ b/Libraries/LibGUI/MessageBox.h
@@ -43,6 +43,8 @@ public:
     enum class InputType {
         OK,
         OKCancel,
+        YesNo,
+        YesNoCancel,
     };
 
     virtual ~MessageBox() override;
@@ -54,6 +56,8 @@ private:
 
     bool should_include_ok_button() const;
     bool should_include_cancel_button() const;
+    bool should_include_yes_button() const;
+    bool should_include_no_button() const;
     void build();
     RefPtr<Gfx::Bitmap> icon() const;
 


### PR DESCRIPTION
I think that in some cases, Yes/No or Yes/No/Cancel is a much more natural answer than Ok/Cancel. It also gives a third choice: for example, if you have a dirty buffer in TextEditor and you try to close you can save, exit, or cancel the close altogether.

With the new dialog in TextEditor, I'd find it more natural if attempting to save on window close, etc. would only close the window if the user completes the save, and cancelling the save would mean the window would stay open. However, I'm not quite sure how to do that — GUI::Action::activate() is void — and it seems to mirror the functionality on my Linux system, so I don't think it's much of a problem.