### PR TITLE
Don't alloc malloc allocators

### DIFF
--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -84,6 +84,11 @@ inline void* operator new(size_t, void* ptr)
 {
     return ptr;
 }
+
+inline void* operator new[](size_t, void* ptr)
+{
+    return ptr;
+}
 #    endif
 
 #endif


### PR DESCRIPTION
And a drive-by `operator` placement `new[]`, which turned out to be unnecessary for this, but still why not have it.

cc @ADKaster (https://github.com/SerenityOS/serenity/pull/894)