### PR TITLE
TTY: Reset VGA start row when setting graphical TTY

### DIFF
--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -65,6 +65,14 @@ void VirtualConsole::initialize()
     s_active_console = -1;
 }
 
+void VirtualConsole::set_graphical(bool graphical)
+{
+    if (graphical)
+        set_vga_start_row(0);
+
+    m_graphical = graphical;
+}
+
 VirtualConsole::VirtualConsole(unsigned index, InitialContents initial_contents)
     : TTY(4, index)
     , m_index(index)

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -49,7 +49,7 @@ public:
     static void initialize();
 
     bool is_graphical() { return m_graphical; }
-    void set_graphical(bool graphical) { m_graphical = graphical; }
+    void set_graphical(bool graphical);
 
 private:
     // ^KeyboardClient


### PR DESCRIPTION
This was causing the screen (on a real machine) to be split in half.