### PR TITLE
Kernel: Allow process with multiple threads to call exec and exit

### DIFF
--- a/Kernel/Lock.cpp
+++ b/Kernel/Lock.cpp
@@ -86,4 +86,10 @@ bool Lock::force_unlock_if_locked()
     return true;
 }
 
+void Lock::clear_waiters()
+{
+    InterruptDisabler disabler;
+    m_queue.clear();
+}
+
 }

--- a/Kernel/Lock.h
+++ b/Kernel/Lock.h
@@ -47,6 +47,7 @@ public:
     void unlock();
     bool force_unlock_if_locked();
     bool is_locked() const { return m_holder; }
+    void clear_waiters();
 
     const char* name() const { return m_name; }
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -141,6 +141,8 @@ public:
     gid_t egid() const { return m_egid; }
     pid_t ppid() const { return m_ppid; }
 
+    pid_t exec_tid() const { return m_exec_tid; }
+
     mode_t umask() const { return m_umask; }
 
     bool in_group(gid_t) const;
@@ -417,6 +419,9 @@ private:
 
     Region& add_region(NonnullOwnPtr<Region>);
 
+    void kill_threads_except_self();
+    void kill_all_threads();
+
     int do_exec(NonnullRefPtr<FileDescription> main_program_description, Vector<String> arguments, Vector<String> environment, RefPtr<FileDescription> interpreter_description);
     ssize_t do_write(FileDescription&, const u8*, int data_size);
 
@@ -447,6 +452,8 @@ private:
     gid_t m_egid { 0 };
     pid_t m_sid { 0 };
     pid_t m_pgid { 0 };
+
+    pid_t m_exec_tid { 0 };
 
     static const int m_max_open_file_descriptors { FD_SETSIZE };
 

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -409,6 +409,9 @@ bool Scheduler::pick_next()
         if (thread->process().is_being_inspected())
             continue;
 
+        if (thread->process().exec_tid() && thread->process().exec_tid() != thread->tid())
+            continue;
+
         ASSERT(thread->state() == Thread::Runnable || thread->state() == Thread::Running);
 
         if (!thread_to_schedule) {

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -162,11 +162,17 @@ Thread::~Thread()
 void Thread::unblock()
 {
     if (current == this) {
-        set_state(Thread::Running);
+        if (m_should_die)
+            set_state(Thread::Dying);
+        else
+            set_state(Thread::Running);
         return;
     }
     ASSERT(m_state != Thread::Runnable && m_state != Thread::Running);
-    set_state(Thread::Runnable);
+    if (m_should_die)
+        set_state(Thread::Dying);
+    else
+        set_state(Thread::Runnable);
 }
 
 void Thread::set_should_die()

--- a/Kernel/WaitQueue.cpp
+++ b/Kernel/WaitQueue.cpp
@@ -65,4 +65,10 @@ void WaitQueue::wake_all()
     Scheduler::stop_idling();
 }
 
+void WaitQueue::clear()
+{
+    InterruptDisabler disabler;
+    m_threads.clear();
+}
+
 }

--- a/Kernel/WaitQueue.h
+++ b/Kernel/WaitQueue.h
@@ -40,6 +40,7 @@ public:
     void enqueue(Thread&);
     void wake_one(Atomic<bool>* lock = nullptr);
     void wake_all();
+    void clear();
 
 private:
     typedef IntrusiveList<Thread, &Thread::m_wait_queue_node> ThreadList;


### PR DESCRIPTION
This allows a process wich has more than 1 thread to call exec, even
from a thread. This kills all the other threads, but it won't wait for
them to finish, just makes sure that they are not in a running/runable
state.

In the case where a thread does exec, the new program PID will be the
thread TID, to keep the PID == TID in the new process.

This introduces a new function inside the Process class,
kill_threads_except_self which is called on exit() too (exit with
multiple threads wasn't properly working either).

Inside the Lock class, there is the need for a new function,
clear_waiters, which removes all the waiters from the
Process::big_lock. This is needed since after a exit/exec, there should
be no other threads waiting for this lock, the threads should be simply
killed. Only queued threads should wait for this lock at this point,
since blocked threads are handled in set_should_die.

After the do_exec passes the `old_regions = move(m_regions)` part, it's not safe to have any other threads from that process running, they simply crash at any syscall since `MM.validate_user_stack` can't find a region. What I did was to add a new `m_exec_tid`/`exec_tid()` in the Process class, and if that is set, then `Scheduler::pick_next()` will schedule only that thread from the process to run: `if (thread->process().exec_tid() && thread->process().exec_tid() != thread->tid()) continue`