### PR TITLE
WindowServer: Fix not all menus closing after system menu toggle

### DIFF
--- a/Servers/WindowServer/MenuManager.cpp
+++ b/Servers/WindowServer/MenuManager.cpp
@@ -178,6 +178,7 @@ void MenuManager::handle_mouse_event(MouseEvent& mouse_event)
         ASSERT(topmost_menu);
         auto* window = topmost_menu->menu_window();
         ASSERT(window);
+        ASSERT(window->is_visible());
 
         bool event_is_inside_current_menu = window->rect().contains(mouse_event.position());
         if (event_is_inside_current_menu) {
@@ -340,6 +341,9 @@ void MenuManager::open_menu(Menu& menu)
 
 void MenuManager::set_current_menu(Menu* menu, bool is_submenu)
 {
+    if (menu == m_current_menu)
+        return;
+
     if (!is_submenu) {
         if (menu)
             close_everyone_not_in_lineage(*menu);


### PR DESCRIPTION
We were failing to check if the current menu was being re-set as the
current menu. This could result in there being two occurrences of the
menu in the open menu stack.

When we close all menus descending from the system menu we only delete the
first occurrence of the menu from the menu stack (a fair assumption to make
as a menu should only be open once).

-- Therefore the menu would remain in the open menu stack and be treated as
if it were actually open, leading to goofy behaviour.

Fixes #1238