### PR TITLE
SystemMonitor: Fix display of file system size column.

### DIFF
--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -294,7 +294,11 @@ RefPtr<GUI::Widget> build_file_systems_tab()
         df_fields.empend(
             "Size", Gfx::TextAlignment::CenterRight,
             [](const JsonObject& object) {
-                return human_readable_size(object.get("total_block_count").to_u32() * object.get("block_size").to_u32());
+                StringBuilder size_builder;
+                size_builder.append(" ");
+                size_builder.append(human_readable_size(object.get("total_block_count").to_u32() * object.get("block_size").to_u32()));
+                size_builder.append(" ");
+                return size_builder.to_string();
             },
             [](const JsonObject& object) {
                 return object.get("total_block_count").to_u32() * object.get("block_size").to_u32();


### PR DESCRIPTION
The Size column in the "File systems" tab of SystemMonitor
had a rendering artifact where the bounding box outline would
be drawn in the same location as the text. This makes the text
look strange and hard to read.

Pad the size with a signle space character on either side to
give the text a gap on each side.