### PR TITLE
Shell: Implement a "cd history" (cdh) builtin

### DIFF
--- a/Shell/GlobalState.h
+++ b/Shell/GlobalState.h
@@ -28,6 +28,7 @@
 
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <AK/CircularQueue.h>
 #include <termios.h>
 
 struct GlobalState {
@@ -43,6 +44,7 @@ struct GlobalState {
     bool was_resized { false };
     int last_return_code { 0 };
     Vector<String> directory_stack;
+    CircularQueue<String, 8> cd_history; // FIXME: have a configurable cd history length
 };
 
 extern GlobalState g;

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -187,6 +187,11 @@ static String expand_tilde(const char* expression)
 
 static int sh_cd(int argc, const char** argv)
 {
+    if (argc > 2) {
+        fprintf(stderr, "cd: too many arguments\n");
+        return 1;
+    }
+
     String new_path;
 
     if (argc == 1) {


### PR DESCRIPTION
`cdh` with no arguments dumps the last 8 cd calls in history, and
`cdh [index]` can be used to cd to re-run a specific index from that
history. `cdh` itself it a thin wrapper of the `cd` builtin.

There's definitely some improvements that can be made for this command,
but this seems like a good starting point for getting a feel for it and
ideas for changing it in the future.

Closes #397