### PR TITLE
LibGUI: Implement keyboard and mouse wheel events for SpinBox

### DIFF
--- a/Libraries/LibGUI/ScrollableWidget.cpp
+++ b/Libraries/LibGUI/ScrollableWidget.cpp
@@ -56,6 +56,10 @@ ScrollableWidget::~ScrollableWidget()
 
 void ScrollableWidget::mousewheel_event(MouseEvent& event)
 {
+    if (!m_scrollbars_enabled) {
+        event.ignore();
+        return;
+    }
     // FIXME: The wheel delta multiplier should probably come from... somewhere?
     vertical_scrollbar().set_value(vertical_scrollbar().value() + event.wheel_delta() * 20);
 }

--- a/Libraries/LibGUI/SpinBox.cpp
+++ b/Libraries/LibGUI/SpinBox.cpp
@@ -87,6 +87,25 @@ void SpinBox::set_range(int min, int max)
     update();
 }
 
+void SpinBox::keydown_event(KeyEvent& event)
+{
+    if (event.key() == KeyCode::Key_Up) {
+        set_value(m_value + 1);
+        return;
+    }
+    if (event.key() == KeyCode::Key_Down) {
+        set_value(m_value - 1);
+        return;
+    }
+
+    event.ignore();
+}
+
+void SpinBox::mousewheel_event(MouseEvent& event)
+{
+    set_value(m_value - event.wheel_delta());
+}
+
 void SpinBox::resize_event(ResizeEvent& event)
 {
     int frame_thickness = m_editor->frame_thickness();

--- a/Libraries/LibGUI/SpinBox.h
+++ b/Libraries/LibGUI/SpinBox.h
@@ -49,6 +49,8 @@ public:
 protected:
     SpinBox();
 
+    virtual void keydown_event(KeyEvent&) override;
+    virtual void mousewheel_event(MouseEvent&) override;
     virtual void resize_event(ResizeEvent&) override;
 
 private:

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -615,7 +615,7 @@ void TextEditor::keydown_event(KeyEvent& event)
             on_escape_pressed();
         return;
     }
-    if (event.key() == KeyCode::Key_Up) {
+    if (is_multi_line() && event.key() == KeyCode::Key_Up) {
         if (m_cursor.line() > 0) {
             if (event.ctrl() && event.shift()) {
                 move_selected_lines_up();
@@ -632,7 +632,7 @@ void TextEditor::keydown_event(KeyEvent& event)
         }
         return;
     }
-    if (event.key() == KeyCode::Key_Down) {
+    if (is_multi_line() && event.key() == KeyCode::Key_Down) {
         if (m_cursor.line() < (line_count() - 1)) {
             if (event.ctrl() && event.shift()) {
                 move_selected_lines_down();
@@ -649,7 +649,7 @@ void TextEditor::keydown_event(KeyEvent& event)
         }
         return;
     }
-    if (event.key() == KeyCode::Key_PageUp) {
+    if (is_multi_line() && event.key() == KeyCode::Key_PageUp) {
         if (m_cursor.line() > 0) {
             size_t page_step = (size_t)visible_content_rect().height() / (size_t)line_height();
             size_t new_line = m_cursor.line() < page_step ? 0 : m_cursor.line() - page_step;
@@ -663,7 +663,7 @@ void TextEditor::keydown_event(KeyEvent& event)
         }
         return;
     }
-    if (event.key() == KeyCode::Key_PageDown) {
+    if (is_multi_line() && event.key() == KeyCode::Key_PageDown) {
         if (m_cursor.line() < (line_count() - 1)) {
             int new_line = min(line_count() - 1, m_cursor.line() + visible_content_rect().height() / line_height());
             int new_column = min(m_cursor.column(), lines()[new_line].length());
@@ -840,8 +840,12 @@ void TextEditor::keydown_event(KeyEvent& event)
         return;
     }
 
-    if (!is_readonly() && !event.ctrl() && !event.alt() && !event.text().is_empty())
+    if (!is_readonly() && !event.ctrl() && !event.alt() && !event.text().is_empty()) {
         insert_at_cursor_or_replace_selection(event.text());
+        return;
+    }
+
+    event.ignore();
 }
 
 void TextEditor::delete_current_line()


### PR DESCRIPTION
Based on how HackStudio's locator works. I didn't add those `on_up`/`on_down` events to the parent TextBox class because I wasn't sure if they are gonna be useful for other components and I didn't want to unnecessarily pollute the public interface of TextBox with them. That's why I introduced that custom TextBox widget.