### PR TITLE
AK, LibGfx, LibGUI: Initialize various variables to zero.

### DIFF
--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -152,7 +152,7 @@ Utf8CodepointIterator& Utf8CodepointIterator::operator++()
 {
     ASSERT(m_length > 0);
 
-    int codepoint_length_in_bytes;
+    int codepoint_length_in_bytes = 0;
     u32 value;
     bool first_byte_makes_sense = decode_first_byte(*m_ptr, codepoint_length_in_bytes, value);
 
@@ -169,7 +169,7 @@ Utf8CodepointIterator& Utf8CodepointIterator::operator++()
 int Utf8CodepointIterator::codepoint_length_in_bytes() const
 {
     ASSERT(m_length > 0);
-    int codepoint_length_in_bytes;
+    int codepoint_length_in_bytes = 0;
     u32 value;
     bool first_byte_makes_sense = decode_first_byte(*m_ptr, codepoint_length_in_bytes, value);
     ASSERT(first_byte_makes_sense);
@@ -180,8 +180,8 @@ u32 Utf8CodepointIterator::operator*() const
 {
     ASSERT(m_length > 0);
 
-    u32 codepoint_value_so_far;
-    int codepoint_length_in_bytes;
+    u32 codepoint_value_so_far = 0;
+    int codepoint_length_in_bytes = 0;
 
     bool first_byte_makes_sense = decode_first_byte(m_ptr[0], codepoint_length_in_bytes, codepoint_value_so_far);
     if (!first_byte_makes_sense) {

--- a/Libraries/LibGfx/Color.cpp
+++ b/Libraries/LibGfx/Color.cpp
@@ -352,7 +352,7 @@ const LogStream& operator<<(const LogStream& stream, Color value)
 
 bool IPC::decode(BufferStream& stream, Color& color)
 {
-    u32 rgba;
+    u32 rgba = 0;
     stream >> rgba;
     if (stream.handle_read_failure())
         return false;

--- a/Libraries/LibGfx/GIFLoader.cpp
+++ b/Libraries/LibGfx/GIFLoader.cpp
@@ -200,7 +200,7 @@ RefPtr<Gfx::Bitmap> load_gif_impl(const u8* data, size_t data_size)
         if (sentinel == 0x2c) {
             images.append(make<ImageDescriptor>());
             auto& image = images.last();
-            u8 packed_fields;
+            u8 packed_fields { 0 };
             stream >> image.x;
             stream >> image.y;
             stream >> image.width;

--- a/Libraries/LibGfx/Point.cpp
+++ b/Libraries/LibGfx/Point.cpp
@@ -46,8 +46,8 @@ namespace IPC {
 
 bool decode(BufferStream& stream, Gfx::Point& point)
 {
-    int x;
-    int y;
+    int x = 0;
+    int y = 0;
     stream >> x;
     stream >> y;
     if (stream.handle_read_failure())

--- a/Libraries/LibGfx/Size.cpp
+++ b/Libraries/LibGfx/Size.cpp
@@ -46,8 +46,8 @@ namespace IPC {
 
 bool decode(BufferStream& stream, Gfx::Size& size)
 {
-    int width;
-    int height;
+    int width = 0;
+    int height = 0;
     stream >> width;
     stream >> height;
     if (stream.handle_read_failure())


### PR DESCRIPTION
The not initialized variables can lead to compiler warnings that become errors with the -Werror flag.