### PR TITLE
LibThread: Fix destroying background actions

### DIFF
--- a/Libraries/LibThread/BackgroundAction.h
+++ b/Libraries/LibThread/BackgroundAction.h
@@ -75,17 +75,17 @@ private:
     {
         LOCKER(all_actions().lock());
 
-        this->ref();
         all_actions().resource().enqueue([this] {
             m_result = m_action();
             if (m_on_complete) {
                 Core::EventLoop::current().post_event(*this, make<Core::DeferredInvocationEvent>([this](auto&) {
                     m_on_complete(m_result.release_value());
-                    this->unref();
+                    this->remove_from_parent();
                 }));
                 Core::EventLoop::wake();
-            } else
-                this->unref();
+            } else {
+                this->remove_from_parent();
+            }
         });
     }
 


### PR DESCRIPTION
In the old model, before bc319d9e8873734bb8e8cea3d762d7fab2ded887, the parent (the background thread) would delete us when it exits (i.e. never), so we had to keep track of our own refcount in order to destroy ourselves when we're done.

With bc319d9e8873734bb8e8cea3d762d7fab2ded887, the parent keeps additional reference to us, so:
* There should be no need to explicitly `ref()` ourselves
* The `unref()` would not get rid of the last reference to us anymore

The latter is why all the `BackgroundAction`s were getting leaked. Fix this by simply unparenting ourselves from the background thread when we're done.