### PR TITLE
Build: Only look at SUBDIRS with Makefiles

### DIFF
--- a/Applications/Makefile
+++ b/Applications/Makefile
@@ -1,3 +1,3 @@
-SUBDIRS := $(wildcard */.)
+SUBDIRS := $(patsubst %/Makefile,%/,$(wildcard */Makefile))
 
 include ../Makefile.subdir

--- a/Demos/Makefile
+++ b/Demos/Makefile
@@ -1,3 +1,3 @@
-SUBDIRS := $(wildcard */.)
+SUBDIRS := $(patsubst %/Makefile,%/,$(wildcard */Makefile))
 
 include ../Makefile.subdir

--- a/DevTools/Makefile
+++ b/DevTools/Makefile
@@ -1,3 +1,3 @@
-SUBDIRS := $(wildcard */.)
+SUBDIRS := $(patsubst %/Makefile,%/,$(wildcard */Makefile))
 
 include ../Makefile.subdir

--- a/Games/Makefile
+++ b/Games/Makefile
@@ -1,3 +1,3 @@
-SUBDIRS := $(wildcard */.)
+SUBDIRS := $(patsubst %/Makefile,%/,$(wildcard */Makefile))
 
 include ../Makefile.subdir

--- a/Libraries/Makefile
+++ b/Libraries/Makefile
@@ -1,3 +1,3 @@
-SUBDIRS := $(wildcard */.)
+SUBDIRS := $(patsubst %/Makefile,%/,$(wildcard */Makefile))
 
 include ../Makefile.subdir

--- a/MenuApplets/Makefile
+++ b/MenuApplets/Makefile
@@ -1,3 +1,3 @@
-SUBDIRS := $(wildcard */.)
+SUBDIRS := $(patsubst %/Makefile,%/,$(wildcard */Makefile))
 
 include ../Makefile.subdir

--- a/Servers/Makefile
+++ b/Servers/Makefile
@@ -1,3 +1,3 @@
-SUBDIRS := $(wildcard */.)
+SUBDIRS := $(patsubst %/Makefile,%/,$(wildcard */Makefile))
 
 include ../Makefile.subdir


### PR DESCRIPTION
If a directory is renamed or deleted before 'make clean', git will
delete the Makefile but leave all of the object and dependency files
around.  When make would try to recurse into that directory from the
wildcard, it would error out since there is no Makefile.