### PR TITLE
Terminal: Open settings as a modal window

### DIFF
--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -132,6 +132,7 @@ RefPtr<GUI::Window> create_settings_window(TerminalWidget& terminal)
     auto window = GUI::Window::construct();
     window->set_title("Terminal Settings");
     window->set_rect(50, 50, 200, 140);
+    window->set_modal(true);
 
     auto settings = GUI::Widget::construct();
     window->set_main_widget(settings);


### PR DESCRIPTION
To prevent the settings window from getting orphaned when someone closes the main window behind it.