### PR TITLE
Minesweeper: Perform sanity check on configuration

### DIFF
--- a/Games/Minesweeper/Field.cpp
+++ b/Games/Minesweeper/Field.cpp
@@ -156,7 +156,13 @@ Field::Field(GUI::Label& flag_label, GUI::Label& time_label, GUI::Button& face_b
         int mine_count = config->read_num_entry("Game", "MineCount", 10);
         int rows = config->read_num_entry("Game", "Rows", 9);
         int columns = config->read_num_entry("Game", "Columns", 9);
-        set_field_size(rows, columns, mine_count);
+
+        // Do a quick sanity check to make sure the user hasn't tried anything crazy
+        if (mine_count > rows * columns || rows <= 0 || columns <= 0 || mine_count <= 0)
+            set_field_size(9, 9, 10);
+        else
+            set_field_size(rows, columns, mine_count);
+
         set_single_chording(single_chording);
     }
 }


### PR DESCRIPTION
This addresses the issue found in #1261. Previously we weren't doing
any form of sanity checking on the values in the configuration file,
meaning that a user could input a ridiculous number of mines such that
the number of mines is larger than the number of squares on the field.

Going forward, it might be best to store some of this information in
some kind of `Difficulty` struct.