### PR TITLE
CircularQueue: increase performance of enqueue operation

### DIFF
--- a/AK/CircularQueue.h
+++ b/AK/CircularQueue.h
@@ -64,7 +64,7 @@ public:
         if (m_size == Capacity)
             slot.~T();
 
-        new (&slot) T(value);
+        new (&slot) T(move(value));
         if (m_size == Capacity)
             m_head = (m_head + 1) % Capacity;
         else


### PR DESCRIPTION
Change the two `enqueue` member functions to avoid unnecessary copy operation. 