### PR TITLE
LibCore: Allow ConfigFile::read_num_entry to handle negative numbers

### DIFF
--- a/Libraries/LibCore/ConfigFile.cpp
+++ b/Libraries/LibCore/ConfigFile.cpp
@@ -132,7 +132,7 @@ int ConfigFile::read_num_entry(const String& group, const String& key, int defau
     }
 
     bool ok;
-    int value = read_entry(group, key).to_uint(ok);
+    int value = read_entry(group, key).to_int(ok);
     if (!ok)
         return default_value;
     return value;


### PR DESCRIPTION
Previously, this function was using `AK::String::to_uint()`, which is
wrong considering the function returns type `int`. This also means that
configuration files would revert to the default value on negative
values.