### PR TITLE
Kernel: Fix ASSERTION failed in join_thread syscall

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -3841,10 +3841,14 @@ int Process::sys$join_thread(int tid, void** exit_value)
         if (result == Thread::BlockResult::InterruptedByDeath) {
             // NOTE: This cleans things up so that Thread::finalize() won't
             //       get confused about a missing joiner when finalizing the joinee.
-            InterruptDisabler disabler;
-            Thread::current->m_joinee->m_joiner = nullptr;
-            Thread::current->m_joinee = nullptr;
-            return 0;
+            InterruptDisabler disabler_t;
+
+            if (Thread::current->m_joinee) {
+                Thread::current->m_joinee->m_joiner = nullptr;
+                Thread::current->m_joinee = nullptr;
+            }
+
+            break;
         }
     }
 

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -300,6 +300,7 @@ void Thread::finalize()
     if (m_joiner) {
         ASSERT(m_joiner->m_joinee == this);
         static_cast<JoinBlocker*>(m_joiner->m_blocker)->set_joinee_exit_value(m_exit_value);
+        static_cast<JoinBlocker*>(m_joiner->m_blocker)->set_interrupted_by_death();
         m_joiner->m_joinee = nullptr;
         // NOTE: We clear the joiner pointer here as well, to be tidy.
         m_joiner = nullptr;


### PR DESCRIPTION
set_interrupted_by_death was never called whenever a thread that had
a joiner died, so the joiner remained with the joinee pointer there,
resulting in an assertion fail in JoinBlocker: m_joinee pointed to
a freed task, filled with garbage.

Thread::current->m_joinee may not be valid after the unblock

Properly return the joinee exit value to the joiner thread.

This is more like 3 fixes, but found them one right after another, and they are dependent of each other. To test the modifications, the running `Userland/tt` is enough (without these fixes it will hit the ASSERTION in JoinBlocker constructor).