### PR TITLE
Use ccache if available

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -54,8 +54,6 @@ Once you've built the toolchain, go into the `Kernel/` directory, then run
 **./makeall.sh**, and if nothing breaks too much, take it for a spin by using
 **./run**.
 
-You can vastly reduce the build time of successive rebuilds of Serenity by installing `ccache` and `export`ing ```PRE_CXX=ccache```
-
 Bare curious users may even consider sourcing suitable hardware to [install Serenity on a physical PC.](https://github.com/SerenityOS/serenity/blob/master/INSTALL.md)
 
 Later on, when you `git pull` to get the latest changes, there's no need to rebuild the toolchain. You can simply rerun **./makeall.sh** in the `Kernel/` directory and you'll be good to **./run** again.

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ SUBDIRS += \
 	Games \
 	Demos
 
+ifneq (, $(shell which ccache))
+  export PRE_CXX=ccache
+endif
+
 include Makefile.subdir
 
 all: subdirs


### PR DESCRIPTION
Hi,

Based on experience from my current workspace, there is seldom a reason to **not** use `ccache`, if it's installed.

This pull request uses `ccache` by default in the Makefile, if it's discovered by `which`.

If you consider this too bold of a move, that's understandable, but I'll give it a shot. :slightly_smiling_face:

Cheers!