### PR TITLE
[WIP]  LibC: Use a reentrant lock in all stdio FILE

### DIFF
--- a/Libraries/LibC/bits/FILE.h
+++ b/Libraries/LibC/bits/FILE.h
@@ -44,6 +44,8 @@ struct __STDIO_FILE {
     size_t buffer_size;
     size_t buffer_index;
     int have_ungotten;
+    int lock_owner;
+    bool lock;
     char ungotten;
     char default_buffer[BUFSIZ];
 };

--- a/Libraries/LibC/stdio.h
+++ b/Libraries/LibC/stdio.h
@@ -114,5 +114,8 @@ FILE* tmpfile();
 char* tmpnam(char*);
 FILE* popen(const char* command, const char* type);
 int pclose(FILE*);
+void flockfile(FILE*);
+int ftrylockfile(FILE*);
+void funlockfile(FILE*);
 
 __END_DECLS


### PR DESCRIPTION
Multiple threads writing to the same FILE would hit the assert where the
buffer index was bigger than size. This just uses a very basic lock
(stolen from pthread_mutex functions).