### PR TITLE
Kernel: Log Stream via klog()

### DIFF
--- a/AK/LogStream.cpp
+++ b/AK/LogStream.cpp
@@ -126,6 +126,31 @@ DebugLogStream dbg()
     return stream;
 }
 
+#if defined(KERNEL)
+KernelLogStream klog()
+{
+    KernelLogStream stream;
+    if (Kernel::Thread::current)
+        stream << "\033[34;1m[" << *Kernel::Thread::current << "]\033[0m: ";
+    else
+        stream << "\033[36;1m[Kernel]\033[0m: ";
+    return stream;
+}
+#elif !defined(BOOTSTRAPPER)
+DebugLogStream klog()
+{
+    return dbg();
+}
+#endif
+
+#if defined(KERNEL)
+KernelLogStream::~KernelLogStream()
+{
+    char newline = '\n';
+    write(&newline, 1);
+}
+#endif
+
 DebugLogStream::~DebugLogStream()
 {
     char newline = '\n';

--- a/AK/LogStream.h
+++ b/AK/LogStream.h
@@ -70,6 +70,19 @@ public:
     }
 };
 
+#if !defined(BOOTSTRAPPER) && defined(KERNEL)
+class KernelLogStream final : public LogStream {
+public:
+    KernelLogStream() {}
+    virtual ~KernelLogStream() override;
+
+    virtual void write(const char* characters, int length) const override
+    {
+        kernelputstr(characters, length);
+    }
+};
+#endif
+
 inline const LogStream& operator<<(const LogStream& stream, const char* value)
 {
     int length = 0;
@@ -103,7 +116,14 @@ inline const LogStream& operator<<(const LogStream& stream, bool value)
 
 DebugLogStream dbg();
 
+#if defined(KERNEL)
+KernelLogStream klog();
+#elif !defined(BOOTSTRAPPER)
+DebugLogStream klog();
+#endif
+
 }
 
 using AK::dbg;
+using AK::klog;
 using AK::LogStream;

--- a/Kernel/ACPI/ACPIDynamicParser.cpp
+++ b/Kernel/ACPI/ACPIDynamicParser.cpp
@@ -47,13 +47,13 @@ namespace ACPI {
         , StaticParser()
 
     {
-        kprintf("ACPI: Dynamic Parsing Enabled, Can parse AML\n");
+        klog() << "ACPI: Dynamic Parsing Enabled, Can parse AML";
     }
     DynamicParser::DynamicParser(PhysicalAddress rsdp)
         : IRQHandler(9)
         , StaticParser(rsdp)
     {
-        kprintf("ACPI: Dynamic Parsing Enabled, Can parse AML\n");
+        klog() << "ACPI: Dynamic Parsing Enabled, Can parse AML";
     }
 
     void DynamicParser::handle_irq(RegisterState&)

--- a/Kernel/ACPI/ACPIParser.cpp
+++ b/Kernel/ACPI/ACPIParser.cpp
@@ -51,49 +51,49 @@ namespace ACPI {
     Parser::Parser(bool usable)
     {
         if (usable) {
-            kprintf("ACPI: Setting up a functional parser\n");
+            klog() << "ACPI: Setting up a functional parser";
         } else {
-            kprintf("ACPI: Limited Initialization. Vital functions are disabled by a request\n");
+            klog() << "ACPI: Limited Initialization. Vital functions are disabled by a request";
         }
         s_acpi_parser = this;
     }
 
     PhysicalAddress Parser::find_table(const char*)
     {
-        kprintf("ACPI: Requested to search for a table, Abort!\n");
+        klog() << "ACPI: Requested to search for a table, Abort!";
         return {};
     }
 
     void Parser::do_acpi_reboot()
     {
-        kprintf("ACPI: Cannot invoke reboot!\n");
+        klog() << "ACPI: Cannot invoke reboot!";
         ASSERT_NOT_REACHED();
     }
 
     void Parser::do_acpi_shutdown()
     {
-        kprintf("ACPI: Cannot invoke shutdown!\n");
+        klog() << "ACPI: Cannot invoke shutdown!";
         ASSERT_NOT_REACHED();
     }
 
     void Parser::enable_aml_interpretation()
     {
-        kprintf("ACPI: No AML Interpretation Allowed\n");
+        klog() << "ACPI: No AML Interpretation Allowed";
         ASSERT_NOT_REACHED();
     }
     void Parser::enable_aml_interpretation(File&)
     {
-        kprintf("ACPI: No AML Interpretation Allowed\n");
+        klog() << "ACPI: No AML Interpretation Allowed";
         ASSERT_NOT_REACHED();
     }
     void Parser::enable_aml_interpretation(u8*, u32)
     {
-        kprintf("ACPI: No AML Interpretation Allowed\n");
+        klog() << "ACPI: No AML Interpretation Allowed";
         ASSERT_NOT_REACHED();
     }
     void Parser::disable_aml_interpretation()
     {
-        kprintf("ACPI Limited: No AML Interpretation Allowed\n");
+        klog() << "ACPI Limited: No AML Interpretation Allowed";
         ASSERT_NOT_REACHED();
     }
     bool Parser::is_operable()

--- a/Kernel/ACPI/DMIDecoder.cpp
+++ b/Kernel/ACPI/DMIDecoder.cpp
@@ -62,7 +62,7 @@ void DMIDecoder::initialize_untrusted()
 
 void DMIDecoder::set_64_bit_entry_initialization_values(PhysicalAddress entry)
 {
-    kprintf("DMIDecoder: SMBIOS 64bit Entry point @ P 0x%x\n", m_entry64bit_point.get());
+    klog() << "DMIDecoder: SMBIOS 64bit Entry point @ P " << String::format("%p", m_entry64bit_point.get());
     m_use_64bit_entry = true;
 
     auto region = MM.allocate_kernel_region(entry.page_base(), PAGE_ROUND_UP(SMBIOS_SEARCH_AREA_SIZE), "DMI Decoder 64 bit Initialization", Region::Access::Read, false, false);
@@ -74,7 +74,7 @@ void DMIDecoder::set_64_bit_entry_initialization_values(PhysicalAddress entry)
 
 void DMIDecoder::set_32_bit_entry_initialization_values(PhysicalAddress entry)
 {
-    kprintf("DMIDecoder: SMBIOS 32bit Entry point @ P 0x%x\n", m_entry32bit_point.get());
+    klog() << "DMIDecoder: SMBIOS 32bit Entry point @ P " << String::format("%p", m_entry32bit_point.get());
     m_use_64bit_entry = false;
 
     auto region = MM.allocate_kernel_region(entry.page_base(), PAGE_ROUND_UP(SMBIOS_SEARCH_AREA_SIZE), "DMI Decoder 32 bit Initialization", Region::Access::Read, false, false);
@@ -90,18 +90,18 @@ void DMIDecoder::initialize_parser()
 
     if (m_entry32bit_point.is_null() && m_entry64bit_point.is_null()) {
         m_operable = false;
-        kprintf("DMI Decoder is disabled. Cannot find SMBIOS tables.\n");
+        klog() << "DMI Decoder is disabled. Cannot find SMBIOS tables.";
         return;
     }
 
     m_operable = true;
-    kprintf("DMI Decoder is enabled\n");
+    klog() << "DMI Decoder is enabled";
     if (!m_entry64bit_point.is_null()) {
         set_64_bit_entry_initialization_values(m_entry64bit_point);
     } else if (!m_entry32bit_point.is_null()) {
         set_32_bit_entry_initialization_values(m_entry32bit_point);
     }
-    kprintf("DMIDecoder: Data table @ P 0x%x\n", m_structure_table.get());
+    klog() << "DMIDecoder: Data table @ P " << String::format("%p", m_structure_table.get());
     enumerate_smbios_tables();
 }
 
@@ -125,10 +125,10 @@ void DMIDecoder::enumerate_smbios_tables()
 #endif
         structures_count++;
         if (v_table_ptr->type == (u8)SMBIOS::TableType::EndOfTable) {
-            kprintf("DMIDecoder: Detected table with type 127, End of SMBIOS data.\n");
+            klog() << "DMIDecoder: Detected table with type 127, End of SMBIOS data.";
             break;
         }
-        kprintf("DMIDecoder: Detected table with type %d\n", v_table_ptr->type);
+        klog() << "DMIDecoder: Detected table with type " << v_table_ptr->type;
         m_smbios_tables.append(p_table);
         table_length -= v_table_ptr->length;
 
@@ -205,7 +205,7 @@ DMIDecoder::DMIDecoder(bool trusted)
     , m_untrusted(!trusted)
 {
     if (!trusted) {
-        kprintf("DMI Decoder initialized as untrusted due to user request.\n");
+        klog() << "DMI Decoder initialized as untrusted due to user request.";
     }
     initialize_parser();
 }
@@ -249,7 +249,7 @@ PhysicalAddress DMIDecoder::find_entry32bit_point()
 Vector<SMBIOS::PhysicalMemoryArray*>& DMIDecoder::get_physical_memory_areas()
 {
     // FIXME: Implement it...
-    kprintf("DMIDecoder::get_physical_memory_areas() is not implemented.\n");
+    klog() << "DMIDecoder::get_physical_memory_areas() is not implemented.";
     ASSERT_NOT_REACHED();
 }
 bool DMIDecoder::is_reliable()
@@ -264,7 +264,7 @@ u64 DMIDecoder::get_bios_characteristics()
     auto* bios_info = (SMBIOS::BIOSInfo*)get_smbios_physical_table_by_type(0).as_ptr();
     ASSERT(bios_info != nullptr);
 
-    kprintf("DMIDecoder: BIOS info @ P 0x%x\n", bios_info);
+    klog() << "DMIDecoder: BIOS info @ P " << String::format("%p", bios_info);
     return bios_info->bios_characteristics;
 }
 
@@ -272,7 +272,7 @@ char* DMIDecoder::get_smbios_string(PhysicalAddress, u8)
 {
     // FIXME: Implement it...
     // FIXME: Make sure we have some mapping here so we don't rely on existing identity mapping...
-    kprintf("DMIDecoder::get_smbios_string() is not implemented.\n");
+    klog() << "DMIDecoder::get_smbios_string() is not implemented.";
     ASSERT_NOT_REACHED();
     return nullptr;
 }

--- a/Kernel/ACPI/MultiProcessorParser.cpp
+++ b/Kernel/ACPI/MultiProcessorParser.cpp
@@ -48,11 +48,11 @@ MultiProcessorParser::MultiProcessorParser()
     , m_operable((m_floating_pointer != (uintptr_t) nullptr))
 {
     if (m_floating_pointer != (uintptr_t) nullptr) {
-        kprintf("MultiProcessor: Floating Pointer Structure @ P 0x%x\n", m_floating_pointer);
+        klog() << "MultiProcessor: Floating Pointer Structure @ P " << String::format("%p", m_floating_pointer);
         parse_floating_pointer_data();
         parse_configuration_table();
     } else {
-        kprintf("MultiProcessor: Can't Locate Floating Pointer Structure, disabled.\n");
+        klog() << "MultiProcessor: Can't Locate Floating Pointer Structure, disabled.";
     }
 }
 
@@ -128,7 +128,7 @@ uintptr_t MultiProcessorParser::search_floating_pointer()
     uintptr_t mp_floating_pointer = (uintptr_t) nullptr;
     auto region = MM.allocate_kernel_region(PhysicalAddress(0), PAGE_SIZE, "MultiProcessor Parser Floating Pointer Structure Finding", Region::Access::Read);
     u16 ebda_seg = (u16) * ((uint16_t*)((region->vaddr().get() & PAGE_MASK) + 0x40e));
-    kprintf("MultiProcessor: Probing EBDA, Segment 0x%x\n", ebda_seg);
+    klog() << "MultiProcessor: Probing EBDA, Segment 0x" << String::format("%x", ebda_seg);
 
     mp_floating_pointer = search_floating_pointer_in_ebda(ebda_seg);
     if (mp_floating_pointer != (uintptr_t) nullptr)
@@ -195,12 +195,7 @@ Vector<RefPtr<PCIInterruptOverrideMetadata>> MultiProcessorParser::get_pci_inter
         for (auto id : pci_bus_ids) {
             if (id == v_entry_ptr->source_bus_id) {
 
-                kprintf("Interrupts: Bus %d, Polarity 0x%x, Trigger Mode 0x%x, INT %x, IOAPIC %d, IOAPIC INTIN %d\n", v_entry_ptr->source_bus_id,
-                    v_entry_ptr->polarity,
-                    v_entry_ptr->trigger_mode,
-                    v_entry_ptr->source_bus_irq,
-                    v_entry_ptr->destination_ioapic_id,
-                    v_entry_ptr->destination_ioapic_intin_pin);
+                klog() << "Interrupts: Bus " << v_entry_ptr->source_bus_id << ", Polarity " << v_entry_ptr->polarity << ", Trigger Mode " << v_entry_ptr->trigger_mode << ", INT " << v_entry_ptr->source_bus_irq << ", IOAPIC " << v_entry_ptr->destination_ioapic_id << ", IOAPIC INTIN " << v_entry_ptr->destination_ioapic_intin_pin;
                 overrides.append(adopt(*new PCIInterruptOverrideMetadata(
                     v_entry_ptr->source_bus_id,
                     v_entry_ptr->polarity,
@@ -213,14 +208,7 @@ Vector<RefPtr<PCIInterruptOverrideMetadata>> MultiProcessorParser::get_pci_inter
     }
 
     for (auto override_metadata : overrides) {
-        kprintf("Interrupts: Bus %d, Polarity 0x%x, PCI Device %d, Trigger Mode 0x%x, INT %x, IOAPIC %d, IOAPIC INTIN %d\n",
-            override_metadata->bus(),
-            override_metadata->polarity(),
-            override_metadata->pci_device_number(),
-            override_metadata->trigger_mode(),
-            override_metadata->pci_interrupt_pin(),
-            override_metadata->ioapic_id(),
-            override_metadata->ioapic_interrupt_pin());
+        klog() << "Interrupts: Bus " << override_metadata->bus() << ", Polarity " << override_metadata->polarity() << ", PCI Device " << override_metadata->pci_device_number() << ", Trigger Mode " << override_metadata->trigger_mode() << ", INT " << override_metadata->pci_interrupt_pin() << ", IOAPIC " << override_metadata->ioapic_id() << ", IOAPIC INTIN " << override_metadata->ioapic_interrupt_pin();
     }
     return overrides;
 }

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -177,7 +177,7 @@ void handle_crash(RegisterState& regs, const char* description, int signal)
     // make sure we switch back to the right page tables.
     MM.enter_process_paging_scope(*Process::current);
 
-    klog() << "CRASH: " << description << ". " << (Process::current->is_ring0() ? "Kernel" : "Process") << ": " << Process::current->name().characters() << "(" << Process::current->pid() << ")";
+    klog() << "CRASH: " << description << ". Ring " << (Process::current->is_ring0() ? 0 : 3) << ".";
     dump(regs);
 
     if (Process::current->is_ring0()) {

--- a/Kernel/Devices/BXVGADevice.cpp
+++ b/Kernel/Devices/BXVGADevice.cpp
@@ -160,7 +160,7 @@ u32 BXVGADevice::find_framebuffer_address()
     PCI::enumerate_all([&framebuffer_address](const PCI::Address& address, PCI::ID id) {
         if (id == bochs_vga_id || id == virtualbox_vga_id) {
             framebuffer_address = PCI::get_BAR0(address) & 0xfffffff0;
-            kprintf("BXVGA: framebuffer @ P%x\n", framebuffer_address);
+            klog() << "BXVGA: framebuffer @ P " << String::format("%p", framebuffer_address);
         }
     });
     return framebuffer_address;

--- a/Kernel/Devices/DiskPartition.cpp
+++ b/Kernel/Devices/DiskPartition.cpp
@@ -50,7 +50,7 @@ DiskPartition::~DiskPartition()
 bool DiskPartition::read_blocks(unsigned index, u16 count, u8* out)
 {
 #ifdef OFFD_DEBUG
-    kprintf("DiskPartition::read_blocks %u (really: %u) count=%u\n", index, m_block_offset + index, count);
+    klog() << "DiskPartition::read_blocks " << index << " (really: " << (m_block_offset + index) << ") count=" << count;
 #endif
 
     return m_device->read_blocks(m_block_offset + index, count, out);
@@ -59,7 +59,7 @@ bool DiskPartition::read_blocks(unsigned index, u16 count, u8* out)
 bool DiskPartition::write_blocks(unsigned index, u16 count, const u8* data)
 {
 #ifdef OFFD_DEBUG
-    kprintf("DiskPartition::write_blocks %u (really: %u) count=%u\n", index, m_block_offset + index, count);
+    klog() << "DiskPartition::write_blocks " << index << " (really: " << (m_block_offset + index) << ") count=" << count;
 #endif
 
     return m_device->write_blocks(m_block_offset + index, count, data);

--- a/Kernel/Devices/FloppyDiskDevice.cpp
+++ b/Kernel/Devices/FloppyDiskDevice.cpp
@@ -134,7 +134,7 @@ bool FloppyDiskDevice::read_sectors_with_dma(u16 lba, u16 count, u8* outbuf)
 {
     LOCKER(m_lock); // Acquire lock
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: read_sectors_with_dma lba = %d count = %d\n", lba, count);
+    klog() << "fdc: read_sectors_with_dma lba = " << lba << " count = " << count;
 #endif
 
     motor_enable(is_slave()); // Should I bother casting this?!
@@ -142,7 +142,7 @@ bool FloppyDiskDevice::read_sectors_with_dma(u16 lba, u16 count, u8* outbuf)
     recalibrate();
 
     if (!seek(lba)) {
-        kprintf("fdc: failed to seek to lba = %d!\n", lba);
+        klog() << "fdc: failed to seek to lba = " << lba << "!";
         return false;
     }
 
@@ -168,7 +168,7 @@ bool FloppyDiskDevice::read_sectors_with_dma(u16 lba, u16 count, u8* outbuf)
     u16 sector = lba2sector(lba);
 
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: addr = 0x%x c = %d h = %d s = %d\n", lba * BYTES_PER_SECTOR, cylinder, head, sector);
+    klog() << "fdc: addr = 0x" << String::format("%x", lba * BYTES_PER_SECTOR) << " c = " << cylinder << " h = " << head << " s = " << sector;
 #endif
 
     // Intel recommends 3 attempts for a read/write
@@ -194,13 +194,13 @@ bool FloppyDiskDevice::read_sectors_with_dma(u16 lba, u16 count, u8* outbuf)
         // the command executed correctly
         u8 cmd_st0 = read_byte();
         if ((cmd_st0 & 0xc0) != 0) {
-            kprintf("fdc: read failed with error code (st0) 0x%x\n", cmd_st0 >> 6);
+            klog() << "fdc: read failed with error code (st0) 0x" << String::format("%x", cmd_st0 >> 6);
             return false;
         }
 
         u8 cmd_st1 = read_byte();
         if (cmd_st1 != 0) {
-            kprintf("fdc: read failed with error code (st1) 0x%x\n", cmd_st1);
+            klog() << "fdc: read failed with error code (st1) 0x" << String::format("%x", cmd_st1);
             return false;
         }
 
@@ -212,7 +212,7 @@ bool FloppyDiskDevice::read_sectors_with_dma(u16 lba, u16 count, u8* outbuf)
 
         if (cyl != cylinder) {
 #ifdef FLOPPY_DEBUG
-            kprintf("fdc: cyl != cylinder (cyl = %d cylinder = %d)! Retrying...\n", cyl, cylinder);
+            klog() << "fdc: cyl != cylinder (cyl = " << cyl << " cylinder = " << cylinder << ")! Retrying...";
 #endif
             continue;
         }
@@ -230,7 +230,7 @@ bool FloppyDiskDevice::read_sectors_with_dma(u16 lba, u16 count, u8* outbuf)
     }
 
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: out of read attempts (check your hardware maybe!?)\n");
+    klog() << "fdc: out of read attempts (check your hardware maybe!?)";
 #endif
     return false;
 }
@@ -239,7 +239,7 @@ bool FloppyDiskDevice::write_sectors_with_dma(u16 lba, u16 count, const u8* inbu
 {
     LOCKER(m_lock); // Acquire lock
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: write_sectors_with_dma lba = %d count = %d\n", lba, count);
+    klog() << "fdc: write_sectors_with_dma lba = " << lba << " count = " << count;
 #endif
 
     motor_enable(is_slave() ? 1 : 0); // Should I bother casting this?!
@@ -247,7 +247,7 @@ bool FloppyDiskDevice::write_sectors_with_dma(u16 lba, u16 count, const u8* inbu
     recalibrate(); // Recalibrate the drive
 
     if (!seek(lba)) {
-        kprintf("fdc: failed to seek to lba = %d!\n", lba);
+        klog() << "fdc: failed to seek to lba = " << lba << "!";
         return false;
     }
 
@@ -269,7 +269,7 @@ bool FloppyDiskDevice::write_sectors_with_dma(u16 lba, u16 count, const u8* inbu
     u16 sector = lba2sector(lba);
 
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: addr = 0x%x c = %d h = %d s = %d\n", lba * BYTES_PER_SECTOR, cylinder, head, sector);
+    klog() << "fdc: addr = 0x" << String::format("%x", lba * BYTES_PER_SECTOR) << " c = " << cylinder << " h = " << head << " s = " << sector;
 #endif
 
     for (int i = 0; i < 3; i++) {
@@ -292,13 +292,13 @@ bool FloppyDiskDevice::write_sectors_with_dma(u16 lba, u16 count, const u8* inbu
         // Flush FIFO
         u8 cmd_st0 = read_byte();
         if ((cmd_st0 & 0xc0) != 0) {
-            kprintf("fdc: write failed! Error code 0x%x\n", cmd_st0 >> 6);
+            klog() << "fdc: write failed! Error code 0x" << String::format("%x", cmd_st0 >> 6);
             return false;
         }
 
         u8 cmd_st1 = read_byte();
         if (cmd_st1 != 0) {
-            kprintf("fdc: write failed with error code (st1) 0x%x\n", cmd_st1);
+            klog() << "fdc: write failed with error code (st1) 0x" << String::format("%x", cmd_st1);
             return false;
         }
 
@@ -310,7 +310,7 @@ bool FloppyDiskDevice::write_sectors_with_dma(u16 lba, u16 count, const u8* inbu
 
         if (cyl != cylinder) {
 #ifdef FLOPPY_DEBUG
-            kprintf("fdc: cyl != cylinder (cyl = %d cylinder = %d)! Retrying...\n", cyl, cylinder);
+            klog() << "fdc: cyl != cylinder (cyl = " << cyl << " cylinder = " << cylinder << ")! Retrying...";
 #endif
             continue;
         }
@@ -328,7 +328,7 @@ bool FloppyDiskDevice::write_sectors_with_dma(u16 lba, u16 count, const u8* inbu
     }
 
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: out of read attempts (check your hardware maybe!?)\n");
+    klog() << "fdc: out of read attempts (check your hardware maybe!?)";
 #endif
     return false;
 }
@@ -336,7 +336,7 @@ bool FloppyDiskDevice::write_sectors_with_dma(u16 lba, u16 count, const u8* inbu
 bool FloppyDiskDevice::wait_for_irq()
 {
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: Waiting for interrupt...\n");
+    klog() << "fdc: Waiting for interrupt...";
 #endif
 
     while (!m_interrupted) {
@@ -353,7 +353,7 @@ void FloppyDiskDevice::handle_irq(RegisterState&)
     m_interrupted = true;
 
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: Received IRQ!\n");
+    klog() << "fdc: Received IRQ!";
 #endif
 }
 
@@ -367,7 +367,7 @@ void FloppyDiskDevice::send_byte(u8 value) const
     }
 
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: FIFO write timed out!\n");
+    klog() << "fdc: FIFO write timed out!";
 #endif
 }
 
@@ -381,7 +381,7 @@ void FloppyDiskDevice::send_byte(FloppyCommand value) const
     }
 
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: FIFO write timed out!\n");
+    klog() << "fdc: FIFO write timed out!";
 #endif
 }
 
@@ -394,7 +394,7 @@ u8 FloppyDiskDevice::read_byte() const
     }
 
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: FIFO read timed out!\n");
+    klog() << "fdc: FIFO read timed out!";
 #endif
 
     return 0xff;
@@ -429,7 +429,7 @@ bool FloppyDiskDevice::is_busy() const
 bool FloppyDiskDevice::recalibrate()
 {
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: recalibrating drive...\n");
+    klog() << "fdc: recalibrating drive...";
 #endif
 
     u8 slave = is_slave();
@@ -451,7 +451,7 @@ bool FloppyDiskDevice::recalibrate()
     }
 
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: failed to calibrate drive (check your hardware!)\n");
+    klog() << "fdc: failed to calibrate drive (check your hardware!)";
 #endif
     return false;
 }
@@ -465,7 +465,7 @@ bool FloppyDiskDevice::seek(u16 lba)
     // First, we need to enable the correct drive motor
     motor_enable(slave);
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: seeking to cylinder %d on side %d on drive %d\n", cylinder, head, slave);
+    klog() << "fdc: seeking to cylinder " << cylinder << " on side " << head << " on drive " << slave;
 #endif
 
     // Try at most 5 times to seek to the desired cylinder
@@ -482,7 +482,7 @@ bool FloppyDiskDevice::seek(u16 lba)
 
         if ((st0 >> 5) != 1 || pcn != cylinder || (st0 & 0x01)) {
 #ifdef FLOPPY_DEBUG
-            kprintf("fdc: failed to seek to cylinder %d on attempt %d!\n", cylinder, attempt);
+            klog() << "fdc: failed to seek to cylinder " << cylinder << " on attempt " << attempt << "!";
 #endif
             continue;
         }
@@ -490,7 +490,7 @@ bool FloppyDiskDevice::seek(u16 lba)
         return true;
     }
 
-    kprintf("fdc: failed to seek after 3 attempts! Aborting...\n");
+    klog() << "fdc: failed to seek after 3 attempts! Aborting...";
     return false;
 }
 
@@ -498,7 +498,7 @@ bool FloppyDiskDevice::seek(u16 lba)
 void FloppyDiskDevice::initialize()
 {
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: m_io_base = 0x%x IRQn = %d\n", m_io_base_addr, IRQ_FLOPPY_DRIVE);
+    klog() << "fdc: m_io_base = 0x" << String::format("%x", m_io_base_addr) << " IRQn = " << IRQ_FLOPPY_DRIVE;
 #endif
 
     enable_irq();
@@ -506,7 +506,7 @@ void FloppyDiskDevice::initialize()
     // Get the version of the Floppy Disk Controller
     send_byte(FloppyCommand::Version);
     m_controller_version = read_byte();
-    kprintf("fdc: Version = 0x%x\n", m_controller_version);
+    klog() << "fdc: Version = 0x" << String::format("%x", m_controller_version);
 
     // Reset
     write_dor(0);
@@ -523,7 +523,7 @@ void FloppyDiskDevice::initialize()
         u8 sr0 = read_byte();
         u8 trk = read_byte();
 
-        kprintf("sr0 = 0x%x, cyl = 0x%x\n", sr0, trk);
+        klog() << "sr0 = 0x" << String::format("%x", sr0) << ", cyl = 0x" << String::format("%x", trk);
     }
 
     // This is hardcoded for a 3.5" floppy disk drive
@@ -534,7 +534,7 @@ void FloppyDiskDevice::initialize()
     // Allocate a buffer page for us to read into. This only needs to be one sector in size.
     m_dma_buffer_page = MM.allocate_supervisor_physical_page();
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: allocated supervisor page at paddr 0x%x\n", m_dma_buffer_page->paddr());
+    klog() << "fdc: allocated supervisor page at paddr 0x", String::format("%x", m_dma_buffer_page->paddr());
 #endif
 
     // Now, let's initialise channel 2 of the DMA controller!
@@ -557,7 +557,7 @@ void FloppyDiskDevice::initialize()
     IO::out8(0xA, 0x2); // Unmask Channel 2
 
 #ifdef FLOPPY_DEBUG
-    kprintf("fdc: fd%d initialised succesfully!\n", is_slave() ? 1 : 0);
+    klog() << "fdc: fd" << (is_slave() ? 1 : 0) << " initialised succesfully!";
 #endif
 }
 

--- a/Kernel/Devices/GPTPartitionTable.cpp
+++ b/Kernel/Devices/GPTPartitionTable.cpp
@@ -54,11 +54,11 @@ bool GPTPartitionTable::initialize()
     auto& header = this->header();
 
 #ifdef GPT_DEBUG
-    kprintf("GPTPartitionTable::initialize: gpt_signature=%#x%x\n", header.sig[1], header.sig[0]);
+    klog() << "GPTPartitionTable::initialize: gpt_signature=0x" << String::format("%x", header.sig[1]) << String::format("%x", header.sig[0]);
 #endif
 
     if (header.sig[0] != GPT_SIGNATURE && header.sig[1] != GPT_SIGNATURE2) {
-        kprintf("GPTPartitionTable::initialize: bad GPT signature %#x%x\n", header.sig[1], header.sig[0]);
+        klog() << "GPTPartitionTable::initialize: bad GPT signature 0x" << String::format("%x", header.sig[1]) << String::format("%x", header.sig[0]);
         return false;
     }
 
@@ -73,7 +73,7 @@ RefPtr<DiskPartition> GPTPartitionTable::partition(unsigned index)
     unsigned lba = header.partition_array_start_lba + (((index - 1) * header.partition_entry_size) / BytesPerSector);
 
     if (header.sig[0] != GPT_SIGNATURE) {
-        kprintf("GPTPartitionTable::initialize: bad gpt signature - not initalized? %#x\n", header.sig);
+        klog() << "GPTPartitionTable::initialize: bad gpt signature - not initalized? 0x" << String::format("%x", header.sig);
         return nullptr;
     }
 
@@ -84,20 +84,20 @@ RefPtr<DiskPartition> GPTPartitionTable::partition(unsigned index)
     GPTPartitionEntry& entry = entries[((index - 1) % entries_per_sector)];
 
 #ifdef GPT_DEBUG
-    kprintf("GPTPartitionTable::partition %d\n", index);
-    kprintf("GPTPartitionTable - offset = %d%d\n", entry.first_lba[1], entry.first_lba[0]);
+    klog() << "GPTPartitionTable::partition " << index;
+    klog() << "GPTPartitionTable - offset = " << entry.first_lba[1] << entry.first_lba[0];
 #endif
 
     if (entry.first_lba[0] == 0x00) {
 #ifdef GPT_DEBUG
-        kprintf("GPTPartitionTable::partition: missing partition requested index=%d\n", index);
+        klog() << "GPTPartitionTable::partition: missing partition requested index=" << index;
 #endif
 
         return nullptr;
     }
 
 #ifdef GPT_DEBUG
-    kprintf("GPTPartitionTable::partition: found partition index=%d type=%x-%x-%x-%x\n", index, entry.partition_guid[3], entry.partition_guid[2], entry.partition_guid[1], entry.partition_guid[0]);
+    klog() << "GPTPartitionTable::partition: found partition index=" << index << " type=" << String::format("%x", entry.partition_guid[3]) << "-" << String::format("%x", entry.partition_guid[2]) << "-" << String::format("%x", entry.partition_guid[1]) << "-" << String::format("%x", entry.partition_guid[0]);
 #endif
     return DiskPartition::create(m_device, entry.first_lba[0], entry.last_lba[0]);
 }

--- a/Kernel/Devices/MBRPartitionTable.cpp
+++ b/Kernel/Devices/MBRPartitionTable.cpp
@@ -54,11 +54,11 @@ bool MBRPartitionTable::initialize()
     auto& header = this->header();
 
 #ifdef MBR_DEBUG
-    kprintf("MBRPartitionTable::initialize: mbr_signature=%#x\n", header.mbr_signature);
+    klog() << "MBRPartitionTable::initialize: mbr_signature=0x" << String::format("%x", header.mbr_signature);
 #endif
 
     if (header.mbr_signature != MBR_SIGNATURE) {
-        kprintf("MBRPartitionTable::initialize: bad mbr signature %#x\n", header.mbr_signature);
+        klog() << "MBRPartitionTable::initialize: bad mbr signature 0x" << String::format("%x", header.mbr_signature);
         return false;
     }
 
@@ -87,24 +87,24 @@ RefPtr<DiskPartition> MBRPartitionTable::partition(unsigned index)
     auto& entry = header.entry[index - 1];
 
     if (header.mbr_signature != MBR_SIGNATURE) {
-        kprintf("MBRPartitionTable::initialize: bad mbr signature - not initalized? %#x\n", header.mbr_signature);
+        klog() << "MBRPartitionTable::initialize: bad mbr signature - not initalized? 0x" << String::format("%x", header.mbr_signature);
         return nullptr;
     }
 
 #ifdef MBR_DEBUG
-    kprintf("MBRPartitionTable::partition: status=%#x offset=%#x\n", entry.status, entry.offset);
+    klog() << "MBRPartitionTable::partition: status=0x" << String::format("%x", entry.status) << " offset=0x" << String::format("%x", entry.offset);
 #endif
 
     if (entry.offset == 0x00) {
 #ifdef MBR_DEBUG
-        kprintf("MBRPartitionTable::partition: missing partition requested index=%d\n", index);
+        klog() << "MBRPartitionTable::partition: missing partition requested index=" << index;
 #endif
 
         return nullptr;
     }
 
 #ifdef MBR_DEBUG
-    kprintf("MBRPartitionTable::partition: found partition index=%d type=%x\n", index, entry.type);
+    klog() << "MBRPartitionTable::partition: found partition index=" << index << " type=" << String::format("%x", entry.type);
 #endif
 
     return DiskPartition::create(m_device, entry.offset, (entry.offset + entry.length));

--- a/Kernel/Devices/PATAChannel.cpp
+++ b/Kernel/Devices/PATAChannel.cpp
@@ -261,7 +261,7 @@ bool PATAChannel::ata_read_sectors_with_dma(u32 lba, u16 count, u8* outbuf, bool
 {
     LOCKER(s_lock());
 #ifdef PATA_DEBUG
-    dbg() << Process::current->name().characters() << "(" << Process::current->pid() << "): PATAChannel::ata_read_sectors_with_dma (" << lba << " x" << count << ") -> " << outbuf;
+    dbg() << "PATAChannel::ata_read_sectors_with_dma (" << lba << " x" << count << ") -> " << outbuf;
 #endif
 
     prdt().offset = m_dma_buffer_page->paddr();
@@ -332,7 +332,7 @@ bool PATAChannel::ata_write_sectors_with_dma(u32 lba, u16 count, const u8* inbuf
 {
     LOCKER(s_lock());
 #ifdef PATA_DEBUG
-    dbg() << Process::current->name().characters() << "(" << Process::current->pid() << "): PATAChannel::ata_write_sectors_with_dma (" << lba << " x" << count << ") <- " << inbuf;
+    dbg() << "PATAChannel::ata_write_sectors_with_dma (" << lba << " x" << count << ") <- " << inbuf;
 #endif
 
     prdt().offset = m_dma_buffer_page->paddr();
@@ -401,7 +401,7 @@ bool PATAChannel::ata_read_sectors(u32 start_sector, u16 count, u8* outbuf, bool
     ASSERT(count <= 256);
     LOCKER(s_lock());
 #ifdef PATA_DEBUG
-    dbg() << Process::current->name().characters() << "(" << Process::current->pid() << "): PATAChannel::ata_read_sectors request (" << count << " sector(s) @ " << start_sector << " into " << outbuf << ")";
+    dbg() << "PATAChannel::ata_read_sectors request (" << count << " sector(s) @ " << start_sector << " into " << outbuf << ")";
 #endif
 
     while (m_io_base.offset(ATA_REG_STATUS).in<u8>() & ATA_SR_BSY)

--- a/Kernel/Devices/PATAChannel.h
+++ b/Kernel/Devices/PATAChannel.h
@@ -43,6 +43,7 @@
 #include <Kernel/PCI/Device.h>
 #include <Kernel/VM/PhysicalPage.h>
 #include <Kernel/WaitQueue.h>
+#include <LibBareMetal/IO.h>
 #include <LibBareMetal/Memory/PhysicalAddress.h>
 
 namespace Kernel {
@@ -86,8 +87,8 @@ private:
 
     // Data members
     u8 m_channel_number { 0 }; // Channel number. 0 = master, 1 = slave
-    u16 m_io_base { 0x1F0 };
-    u16 m_control_base { 0 };
+    IOAddress m_io_base;
+    IOAddress m_control_base;
     volatile u8 m_device_error { 0 };
 
     WaitQueue m_irq_queue;
@@ -95,7 +96,7 @@ private:
     PhysicalRegionDescriptor& prdt() { return *reinterpret_cast<PhysicalRegionDescriptor*>(m_prdt_page->paddr().offset(0xc0000000).as_ptr()); }
     RefPtr<PhysicalPage> m_prdt_page;
     RefPtr<PhysicalPage> m_dma_buffer_page;
-    u16 m_bus_master_base { 0 };
+    IOAddress m_bus_master_base;
     Lockable<bool> m_dma_enabled;
 
     RefPtr<PATADiskDevice> m_master;

--- a/Kernel/Devices/PATADiskDevice.cpp
+++ b/Kernel/Devices/PATADiskDevice.cpp
@@ -55,14 +55,14 @@ const char* PATADiskDevice::class_name() const
 
 bool PATADiskDevice::read_blocks(unsigned index, u16 count, u8* out)
 {
-    if (m_channel.m_bus_master_base && m_channel.m_dma_enabled.resource())
+    if (!m_channel.m_bus_master_base.is_null() && m_channel.m_dma_enabled.resource())
         return read_sectors_with_dma(index, count, out);
     return read_sectors(index, count, out);
 }
 
 bool PATADiskDevice::write_blocks(unsigned index, u16 count, const u8* data)
 {
-    if (m_channel.m_bus_master_base && m_channel.m_dma_enabled.resource())
+    if (!m_channel.m_bus_master_base.is_null() && m_channel.m_dma_enabled.resource())
         return write_sectors_with_dma(index, count, data);
     for (unsigned i = 0; i < count; ++i) {
         if (!write_sectors(index + i, 1, data + i * 512))
@@ -94,7 +94,7 @@ ssize_t PATADiskDevice::read(FileDescription& fd, u8* outbuf, ssize_t len)
     }
 
 #ifdef PATA_DEVICE_DEBUG
-    kprintf("PATADiskDevice::read() index=%d whole_blocks=%d remaining=%d\n", index, whole_blocks, remaining);
+    klog() << "PATADiskDevice::read() index=" << index << " whole_blocks=" << whole_blocks << " remaining=" << remaining;
 #endif
 
     if (whole_blocks > 0) {
@@ -135,7 +135,7 @@ ssize_t PATADiskDevice::write(FileDescription& fd, const u8* inbuf, ssize_t len)
     }
 
 #ifdef PATA_DEVICE_DEBUG
-    kprintf("PATADiskDevice::write() index=%d whole_blocks=%d remaining=%d\n", index, whole_blocks, remaining);
+    klog() << "PATADiskDevice::write() index=" << index << " whole_blocks=" << whole_blocks << " remaining=" << remaining;
 #endif
 
     if (whole_blocks > 0) {

--- a/Kernel/Devices/PIT.cpp
+++ b/Kernel/Devices/PIT.cpp
@@ -84,7 +84,7 @@ PIT::PIT()
 
     IO::out8(PIT_CTL, TIMER0_SELECT | WRITE_WORD | MODE_SQUARE_WAVE);
 
-    kprintf("PIT: %u Hz, square wave (%x)\n", TICKS_PER_SECOND, m_default_timer_reload);
+    klog() << "PIT: " << TICKS_PER_SECOND << " Hz, square wave (" << String::format("%x", m_default_timer_reload) << ")";
 
     IO::out8(TIMER0_CTL, LSB(m_default_timer_reload));
     IO::out8(TIMER0_CTL, MSB(m_default_timer_reload));

--- a/Kernel/Devices/PS2MouseDevice.cpp
+++ b/Kernel/Devices/PS2MouseDevice.cpp
@@ -246,7 +246,7 @@ void PS2MouseDevice::check_device_presence()
     u8 maybe_ack = mouse_read();
     if (maybe_ack == I8042_ACK) {
         m_device_present = true;
-        kprintf("PS2MouseDevice: Device detected\n");
+        klog() << "PS2MouseDevice: Device detected";
 
         // the mouse will send a packet of data, since that's what we asked
         // for. we don't care about the content.
@@ -255,7 +255,7 @@ void PS2MouseDevice::check_device_presence()
         mouse_read();
     } else {
         m_device_present = false;
-        kprintf("PS2MouseDevice: Device not detected\n");
+        klog() << "PS2MouseDevice: Device not detected";
     }
 }
 
@@ -307,9 +307,9 @@ void PS2MouseDevice::initialize_device()
 
     if (device_id == PS2MOUSE_INTELLIMOUSE_ID) {
         m_has_wheel = true;
-        kprintf("PS2MouseDevice: Mouse wheel enabled!\n");
+        klog() << "PS2MouseDevice: Mouse wheel enabled!";
     } else {
-        kprintf("PS2MouseDevice: No mouse wheel detected!\n");
+        klog() << "PS2MouseDevice: No mouse wheel detected!";
     }
 
     enable_irq();

--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -103,7 +103,7 @@ void SB16::initialize()
 
     auto data = dsp_read();
     if (data != 0xaa) {
-        kprintf("SB16: sb not ready");
+        klog() << "SB16: sb not ready";
         return;
     }
 
@@ -112,9 +112,9 @@ void SB16::initialize()
     m_major_version = dsp_read();
     auto vmin = dsp_read();
 
-    kprintf("SB16: found version %d.%d\n", m_major_version, vmin);
+    klog() << "SB16: found version " << m_major_version << "." << vmin;
     set_irq_register(SB16_DEFAULT_IRQ);
-    kprintf("SB16: IRQ %d\n", get_irq_line());
+    klog() << "SB16: IRQ " << get_irq_line();
 }
 
 void SB16::set_irq_register(u8 irq_number)
@@ -235,7 +235,7 @@ ssize_t SB16::write(FileDescription&, const u8* data, ssize_t length)
     }
 
 #ifdef SB16_DEBUG
-    kprintf("SB16: Writing buffer of %d bytes\n", length);
+    klog() << "SB16: Writing buffer of " << length << " bytes";
 #endif
     ASSERT(length <= PAGE_SIZE);
     const int BLOCK_SIZE = 32 * 1024;

--- a/Kernel/Devices/VMWareBackdoor.cpp
+++ b/Kernel/Devices/VMWareBackdoor.cpp
@@ -97,11 +97,11 @@ VMWareBackdoor& VMWareBackdoor::the()
 VMWareBackdoor::VMWareBackdoor()
 {
     if (!detect_presence()) {
-        kprintf("VMWare Backdoor: Not supported!\n");
+        klog() << "VMWare Backdoor: Not supported!";
         m_supported = false;
         return;
     }
-    kprintf("VMWare Backdoor: Supported.\n");
+    klog() << "VMWare Backdoor: Supported.";
     m_supported = true;
 }
 bool VMWareBackdoor::detect_presence()
@@ -153,7 +153,7 @@ void VMWareBackdoor::enable_absolute_vmmouse()
     command.command = VMMOUSE_STATUS;
     send(command);
     if (command.ax == 0xFFFF0000) {
-        kprintf("VMMouse retuned bad status.\n");
+        klog() << "VMMouse retuned bad status.";
         return;
     }
 

--- a/Kernel/FileSystem/DiskBackedFileSystem.cpp
+++ b/Kernel/FileSystem/DiskBackedFileSystem.cpp
@@ -125,7 +125,7 @@ DiskBackedFS::~DiskBackedFS()
 bool DiskBackedFS::write_block(unsigned index, const u8* data, FileDescription* description)
 {
 #ifdef DBFS_DEBUG
-    kprintf("DiskBackedFileSystem::write_block %u, size=%u\n", index, data.size());
+    klog() << "DiskBackedFileSystem::write_block " << index << ", size=" << data.size();
 #endif
 
     bool allow_cache = !description || !description->is_direct();
@@ -149,7 +149,7 @@ bool DiskBackedFS::write_block(unsigned index, const u8* data, FileDescription* 
 bool DiskBackedFS::write_blocks(unsigned index, unsigned count, const u8* data, FileDescription* description)
 {
 #ifdef DBFS_DEBUG
-    kprintf("DiskBackedFileSystem::write_blocks %u x%u\n", index, count);
+    klog() << "DiskBackedFileSystem::write_blocks " << index << " x%u" << count;
 #endif
     for (unsigned i = 0; i < count; ++i)
         write_block(index + i, data + i * block_size(), description);
@@ -159,7 +159,7 @@ bool DiskBackedFS::write_blocks(unsigned index, unsigned count, const u8* data, 
 bool DiskBackedFS::read_block(unsigned index, u8* buffer, FileDescription* description) const
 {
 #ifdef DBFS_DEBUG
-    kprintf("DiskBackedFileSystem::read_block %u\n", index);
+    klog() << "DiskBackedFileSystem::read_block " << index;
 #endif
 
     bool allow_cache = !description || !description->is_direct();

--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -78,12 +78,12 @@ void FIFO::attach(Direction direction)
     if (direction == Direction::Reader) {
         ++m_readers;
 #ifdef FIFO_DEBUG
-        kprintf("open reader (%u)\n", m_readers);
+        klog() << "open reader (" << m_readers << ")";
 #endif
     } else if (direction == Direction::Writer) {
         ++m_writers;
 #ifdef FIFO_DEBUG
-        kprintf("open writer (%u)\n", m_writers);
+        klog() << "open writer (" << m_writers << ")";
 #endif
     }
 }
@@ -92,13 +92,13 @@ void FIFO::detach(Direction direction)
 {
     if (direction == Direction::Reader) {
 #ifdef FIFO_DEBUG
-        kprintf("close reader (%u - 1)\n", m_readers);
+        klog() << "close reader (" << m_readers << " - 1)";
 #endif
         ASSERT(m_readers);
         --m_readers;
     } else if (direction == Direction::Writer) {
 #ifdef FIFO_DEBUG
-        kprintf("close writer (%u - 1)\n", m_writers);
+        klog() << "close writer (" << m_writers << " - 1)";
 #endif
         ASSERT(m_writers);
         --m_writers;

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -26,12 +26,12 @@
 
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/StringBuilder.h>
+#include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/Inode.h>
 #include <Kernel/FileSystem/InodeWatcher.h>
+#include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Net/LocalSocket.h>
 #include <Kernel/VM/SharedInodeVMObject.h>
-#include <Kernel/FileSystem/VirtualFileSystem.h>
-#include <Kernel/FileSystem/Custody.h>
 
 namespace Kernel {
 

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -79,7 +79,7 @@ ByteBuffer Inode::read_entire(FileDescription* descriptor) const
             break;
     }
     if (nread < 0) {
-        kprintf("Inode::read_entire: ERROR: %d\n", nread);
+        klog() << "Inode::read_entire: ERROR: " << nread;
         return nullptr;
     }
 

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -52,7 +52,7 @@ VFS& VFS::the()
 VFS::VFS()
 {
 #ifdef VFS_DEBUG
-    kprintf("VFS: Constructing VFS\n");
+    klog() << "VFS: Constructing VFS";
 #endif
     s_the = this;
 }
@@ -112,7 +112,7 @@ KResult VFS::unmount(InodeIdentifier guest_inode_id)
 bool VFS::mount_root(FS& file_system)
 {
     if (m_root_inode) {
-        kprintf("VFS: mount_root can't mount another root\n");
+        klog() << "VFS: mount_root can't mount another root";
         return false;
     }
 
@@ -121,7 +121,7 @@ bool VFS::mount_root(FS& file_system)
     auto root_inode_id = mount.guest().fs()->root_inode();
     auto root_inode = mount.guest().fs()->get_inode(root_inode_id);
     if (!root_inode->is_directory()) {
-        kprintf("VFS: root inode (%02u:%08u) for / is not a directory :(\n", root_inode_id.fsid(), root_inode_id.index());
+        klog() << "VFS: root inode (" << String::format("%02u", root_inode_id.fsid()) << ":" << String::format("%08u", root_inode_id.index()) << ") for / is not a directory :(";
         return false;
     }
 
@@ -133,7 +133,7 @@ bool VFS::mount_root(FS& file_system)
     } else {
         sprintf(device_name, "not-a-disk");
     }
-    kprintf("VFS: mounted root on %s (%s)\n", m_root_inode->fs().class_name(), device_name);
+    klog() << "VFS: mounted root on " << m_root_inode->fs().class_name() << " (" << device_name << ")";
 
     m_mounts.append(move(mount));
     return true;

--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -124,7 +124,7 @@ void* kmalloc_impl(size_t size)
 
     if (sum_free < real_size) {
         Kernel::dump_backtrace();
-        kprintf("%s(%u) kmalloc(): PANIC! Out of memory (sucks, dude)\nsum_free=%u, real_size=%u\n", Kernel::Process::current->name().characters(), Kernel::Process::current->pid(), sum_free, real_size);
+        klog() << "kmalloc(): PANIC! Out of memory (sucks, dude)\nsum_free=" << sum_free << ", real_size=" << real_size;
         Kernel::hang();
     }
 
@@ -174,7 +174,7 @@ void* kmalloc_impl(size_t size)
         }
     }
 
-    kprintf("%s(%u) kmalloc(): PANIC! Out of memory (no suitable block for size %u)\n", Kernel::Process::current->name().characters(), Kernel::Process::current->pid(), size);
+    klog() << "kmalloc(): PANIC! Out of memory (no suitable block for size " << size << ")";
     Kernel::dump_backtrace();
     Kernel::hang();
 }

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -172,7 +172,7 @@ namespace APIC {
             return false;
 
         PhysicalAddress apic_base = get_base();
-        kprintf("Initializing APIC, base: P%x\n", apic_base);
+        klog() << "Initializing APIC, base: P " << String::format("%p", apic_base);
         set_base(apic_base);
 
         g_apic_base = apic_base.as_ptr();
@@ -188,7 +188,7 @@ namespace APIC {
 
     void enable(u32 cpu)
     {
-        kprintf("Enabling local APIC for cpu #%u\n", cpu);
+        klog() << "Enabling local APIC for cpu #" << cpu;
 
         // set spurious interrupt vector
         write_register(APIC_REG_SIV, read_register(APIC_REG_SIV) | 0x100);

--- a/Kernel/Interrupts/IOAPIC.cpp
+++ b/Kernel/Interrupts/IOAPIC.cpp
@@ -51,9 +51,9 @@ IOAPIC::IOAPIC(ioapic_mmio_regs& regs, u32 gsi_base, Vector<RefPtr<ISAInterruptO
     , m_isa_interrupt_overrides(isa_overrides)
     , m_pci_interrupt_overrides(pci_overrides)
 {
-    kprintf("IOAPIC ID: 0x%x\n", m_id);
-    kprintf("IOAPIC Version: 0x%x, Redirection Entries count - %u\n", m_version, m_redirection_entries);
-    kprintf("IOAPIC Arbitration ID 0x%x\n", read_register(0x2));
+    klog() << "IOAPIC ID: 0x" << String::format("%x", m_id);
+    klog() << "IOAPIC Version: 0x" << String::format("%x", m_version) << ", Redirection Entries count - " << m_redirection_entries;
+    klog() << "IOAPIC Arbitration ID 0x" << String::format("%x", read_register(0x2));
     mask_all_redirection_entries();
 }
 

--- a/Kernel/Interrupts/IOAPIC.cpp
+++ b/Kernel/Interrupts/IOAPIC.cpp
@@ -113,7 +113,6 @@ void IOAPIC::isa_identity_map(int index)
     configure_redirection_entry(index, index + IRQ_VECTOR_BASE, DeliveryMode::Normal, true, false, false, true, 1);
 }
 
-
 void IOAPIC::map_pci_interrupts()
 {
     configure_redirection_entry(11, 11 + IRQ_VECTOR_BASE, DeliveryMode::Normal, false, false, true, true, 0);

--- a/Kernel/Interrupts/InterruptManagement.cpp
+++ b/Kernel/Interrupts/InterruptManagement.cpp
@@ -109,7 +109,7 @@ InterruptManagement::InterruptManagement()
 
 void InterruptManagement::switch_to_pic_mode()
 {
-    kprintf("Interrupts: Switch to Legacy PIC mode\n");
+    klog() << "Interrupts: Switch to Legacy PIC mode";
     SpuriousInterruptHandler::initialize(7);
     SpuriousInterruptHandler::initialize(15);
     for (auto& irq_controller : m_interrupt_controllers) {
@@ -125,10 +125,10 @@ void InterruptManagement::switch_to_pic_mode()
 
 void InterruptManagement::switch_to_ioapic_mode()
 {
-    kprintf("Interrupts: Switch to IOAPIC mode\n");
+    klog() << "Interrupts: Switch to IOAPIC mode";
     if (m_interrupt_controllers.size() == 1) {
         if (get_interrupt_controller(0).type() == IRQControllerType::i8259) {
-            kprintf("Interrupts: NO IOAPIC detected, Reverting to PIC mode.\n");
+            klog() << "Interrupts: NO IOAPIC detected, Reverting to PIC mode.";
             return;
         }
     }

--- a/Kernel/Interrupts/PIC.cpp
+++ b/Kernel/Interrupts/PIC.cpp
@@ -190,7 +190,7 @@ void PIC::initialize()
     // ...except IRQ2, since that's needed for the master to let through slave interrupts.
     enable(2);
 
-    kprintf("PIC(i8259): cascading mode, vectors 0x%b-0x%b\n", IRQ_VECTOR_BASE, IRQ_VECTOR_BASE + 0xf);
+    klog() << "PIC(i8259): cascading mode, vectors 0x" << String::format("%x", IRQ_VECTOR_BASE) << "-0x" << String::format("%x", IRQ_VECTOR_BASE + 0xf);
 }
 
 u16 PIC::get_isr() const

--- a/Kernel/Interrupts/SharedIRQHandler.cpp
+++ b/Kernel/Interrupts/SharedIRQHandler.cpp
@@ -42,7 +42,7 @@ void SharedIRQHandler::initialize(u8 interrupt_number)
 void SharedIRQHandler::register_handler(GenericInterruptHandler& handler)
 {
 #ifdef INTERRUPT_DEBUG
-    kprintf("Interrupt Handler registered @ Shared Interrupt Handler %d\n", m_interrupt_number);
+    klog() << "Interrupt Handler registered @ Shared Interrupt Handler " << m_interrupt_number;
 #endif
     m_handlers.set(&handler);
     enable_interrupt_vector();
@@ -50,7 +50,7 @@ void SharedIRQHandler::register_handler(GenericInterruptHandler& handler)
 void SharedIRQHandler::unregister_handler(GenericInterruptHandler& handler)
 {
 #ifdef INTERRUPT_DEBUG
-    kprintf("Interrupt Handler unregistered @ Shared Interrupt Handler %d\n", m_interrupt_number);
+    klog() << "Interrupt Handler unregistered @ Shared Interrupt Handler " << m_interrupt_number;
 #endif
     m_handlers.remove(&handler);
     if (m_handlers.is_empty())
@@ -71,7 +71,7 @@ SharedIRQHandler::SharedIRQHandler(u8 irq)
     , m_responsible_irq_controller(InterruptManagement::the().get_responsible_irq_controller(irq))
 {
 #ifdef INTERRUPT_DEBUG
-    kprintf("Shared Interrupt Handler registered @ %d\n", m_interrupt_number);
+    klog() << "Shared Interrupt Handler registered @ " << m_interrupt_number;
 #endif
     disable_interrupt_vector();
 }
@@ -79,7 +79,7 @@ SharedIRQHandler::SharedIRQHandler(u8 irq)
 SharedIRQHandler::~SharedIRQHandler()
 {
 #ifdef INTERRUPT_DEBUG
-    kprintf("Shared Interrupt Handler unregistered @ %d\n", interrupt_number());
+    klog() << "Shared Interrupt Handler unregistered @ " << interrupt_number();
 #endif
     disable_interrupt_vector();
 }

--- a/Kernel/Interrupts/SpuriousInterruptHandler.cpp
+++ b/Kernel/Interrupts/SpuriousInterruptHandler.cpp
@@ -62,7 +62,7 @@ SpuriousInterruptHandler::~SpuriousInterruptHandler()
 void SpuriousInterruptHandler::handle_interrupt(RegisterState&)
 {
     // FIXME: Actually check if IRQ7 or IRQ15 are spurious, and if not, call the real handler to handle the IRQ.
-    kprintf("Spurious Interrupt, vector %d\n", interrupt_number());
+    klog() << "Spurious Interrupt, vector " << interrupt_number();
 }
 
 void SpuriousInterruptHandler::enable_interrupt_vector()

--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -81,7 +81,7 @@ static void load_ksyms_from_data(const ByteBuffer& buffer)
     s_ksyms = static_cast<KSym*>(kmalloc_eternal(sizeof(KSym) * ksym_count));
     ++bufptr; // skip newline
 
-    kprintf("Loading ksyms...");
+    klog() << "Loading ksyms...";
 
     unsigned current_ksym_index = 0;
 
@@ -110,7 +110,7 @@ static void load_ksyms_from_data(const ByteBuffer& buffer)
         ++bufptr;
         ++current_ksym_index;
     }
-    kprintf("ok\n");
+    klog() << "ok";
     ksyms_ready = true;
 }
 

--- a/Kernel/Lock.cpp
+++ b/Kernel/Lock.cpp
@@ -34,7 +34,7 @@ void Lock::lock()
 {
     ASSERT(!Scheduler::is_active());
     if (!are_interrupts_enabled()) {
-        kprintf("Interrupts disabled when trying to take Lock{%s}\n", m_name);
+        klog() << "Interrupts disabled when trying to take Lock{" << m_name << "}";
         dump_backtrace();
         hang();
     }

--- a/Kernel/Net/E1000NetworkAdapter.h
+++ b/Kernel/Net/E1000NetworkAdapter.h
@@ -29,6 +29,7 @@
 #include <AK/OwnPtr.h>
 #include <Kernel/Interrupts/IRQHandler.h>
 #include <Kernel/Net/NetworkAdapter.h>
+#include <LibBareMetal/IO.h>
 #include <Kernel/PCI/Access.h>
 #include <Kernel/PCI/Device.h>
 
@@ -89,7 +90,7 @@ private:
 
     void receive();
 
-    u16 m_io_base { 0 };
+    IOAddress m_io_base;
     VirtualAddress m_mmio_base;
     OwnPtr<Region> m_mmio_region;
     u8 m_interrupt_line { 0 };

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -68,7 +68,7 @@ LocalSocket::LocalSocket(int type)
     m_prebind_mode = 0666;
 
 #ifdef DEBUG_LOCAL_SOCKET
-    kprintf("%s(%u) LocalSocket{%p} created with type=%u\n", Process::current->name().characters(), Process::current->pid(), this, type);
+    dbg() << "LocalSocket{" << this << "} created with type=" << type;
 #endif
 }
 
@@ -105,7 +105,7 @@ KResult LocalSocket::bind(const sockaddr* user_address, socklen_t address_size)
     auto path = String(address.sun_path, strnlen(address.sun_path, sizeof(address.sun_path)));
 
 #ifdef DEBUG_LOCAL_SOCKET
-    kprintf("%s(%u) LocalSocket{%p} bind(%s)\n", Process::current->name().characters(), Process::current->pid(), this, safe_address);
+    dbg() << "LocalSocket{" << this << "} bind(" << safe_address << ")";
 #endif
 
     mode_t mode = S_IFSOCK | (m_prebind_mode & 04777);
@@ -145,7 +145,7 @@ KResult LocalSocket::connect(FileDescription& description, const sockaddr* addre
     memcpy(safe_address, local_address.sun_path, sizeof(local_address.sun_path));
 
 #ifdef DEBUG_LOCAL_SOCKET
-    kprintf("%s(%u) LocalSocket{%p} connect(%s)\n", Process::current->name().characters(), Process::current->pid(), this, safe_address);
+    dbg() << "LocalSocket{" << this << "} connect(" << safe_address << ")";
 #endif
 
     auto description_or_error = VFS::the().open(safe_address, O_RDWR, 0, Process::current->current_directory());
@@ -181,7 +181,7 @@ KResult LocalSocket::connect(FileDescription& description, const sockaddr* addre
     }
 
 #ifdef DEBUG_LOCAL_SOCKET
-    kprintf("%s(%u) LocalSocket{%p} connect(%s) status is %s\n", Process::current->name().characters(), Process::current->pid(), this, safe_address, to_string(setup_state()));
+    dbg() << "LocalSocket{" << this << "} connect(" << safe_address << ") status is " << to_string(setup_state());
 #endif
 
     if (!is_connected()) {
@@ -200,7 +200,7 @@ KResult LocalSocket::listen(size_t backlog)
     set_backlog(backlog);
     m_connect_side_role = m_role = Role::Listener;
 #ifdef DEBUG_LOCAL_SOCKET
-    kprintf("LocalSocket{%p} listening with backlog=%zu\n", this, backlog);
+    dbg() << "LocalSocket{" << this << "} listening with backlog=" << backlog;
 #endif
     return KSuccess;
 }

--- a/Kernel/Net/RTL8139NetworkAdapter.h
+++ b/Kernel/Net/RTL8139NetworkAdapter.h
@@ -30,6 +30,7 @@
 #include <Kernel/Net/NetworkAdapter.h>
 #include <Kernel/PCI/Access.h>
 #include <Kernel/PCI/Device.h>
+#include <LibBareMetal/IO.h>
 
 namespace Kernel {
 
@@ -62,7 +63,7 @@ private:
     u16 in16(u16 address);
     u32 in32(u16 address);
 
-    u16 m_io_base { 0 };
+    IOAddress m_io_base;
     u8 m_interrupt_line { 0 };
     u32 m_rx_buffer_addr { 0 };
     u16 m_rx_buffer_offset { 0 };

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -76,8 +76,7 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source)
 
     if (!local_adapter && !gateway_adapter) {
 #ifdef ROUTING_DEBUG
-        kprintf("Routing: Couldn't find a suitable adapter for route to %s\n",
-            target.to_string().characters());
+        klog() << "Routing: Couldn't find a suitable adapter for route to " << target.to_string().characters();
 #endif
         return { nullptr, {} };
     }
@@ -87,22 +86,13 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source)
 
     if (local_adapter) {
 #ifdef ROUTING_DEBUG
-        kprintf("Routing: Got adapter for route (direct): %s (%s/%s) for %s\n",
-            local_adapter->name().characters(),
-            local_adapter->ipv4_address().to_string().characters(),
-            local_adapter->ipv4_netmask().to_string().characters(),
-            target.to_string().characters());
+        klog() << "Routing: Got adapter for route (direct): " << local_adapter->name().characters() << " (" << local_adapter->ipv4_address().to_string().characters() << "/" << local_adapter->ipv4_netmask().to_string().characters() << ") for " << target.to_string().characters();
 #endif
         adapter = local_adapter;
         next_hop_ip = target;
     } else if (gateway_adapter) {
 #ifdef ROUTING_DEBUG
-        kprintf("Routing: Got adapter for route (using gateway %s): %s (%s/%s) for %s\n",
-            gateway_adapter->ipv4_gateway().to_string().characters(),
-            gateway_adapter->name().characters(),
-            gateway_adapter->ipv4_address().to_string().characters(),
-            gateway_adapter->ipv4_netmask().to_string().characters(),
-            target.to_string().characters());
+        klog() << "Routing: Got adapter for route (using gateway " << gateway_adapter->ipv4_gateway().to_string().characters() << "): " << gateway_adapter->name().characters() << " (" << gateway_adapter->ipv4_address().to_string().characters() << "/" << gateway_adapter->ipv4_netmask().to_string().characters() << ") for " << target.to_string().characters();
 #endif
         adapter = gateway_adapter;
         next_hop_ip = gateway_adapter->ipv4_gateway();
@@ -115,18 +105,14 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source)
         auto addr = arp_table().resource().get(next_hop_ip);
         if (addr.has_value()) {
 #ifdef ROUTING_DEBUG
-            kprintf("Routing: Using cached ARP entry for %s (%s)\n",
-                next_hop_ip.to_string().characters(),
-                addr.value().to_string().characters());
+            klog() << "Routing: Using cached ARP entry for " << next_hop_ip.to_string().characters() << " (" << addr.value().to_string().characters() << ")";
 #endif
             return { adapter, addr.value() };
         }
     }
 
 #ifdef ROUTING_DEBUG
-    kprintf("Routing: Sending ARP request via adapter %s for IPv4 address %s\n",
-        adapter->name().characters(),
-        next_hop_ip.to_string().characters());
+    klog() << "Routing: Sending ARP request via adapter " << adapter->name().characters() << " for IPv4 address " << next_hop_ip.to_string().characters();
 #endif
 
     ARPPacket request;
@@ -146,19 +132,14 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source)
         auto addr = arp_table().resource().get(next_hop_ip);
         if (addr.has_value()) {
 #ifdef ROUTING_DEBUG
-            kprintf("Routing: Got ARP response using adapter %s for %s (%s)\n",
-                adapter->name().characters(),
-                next_hop_ip.to_string().characters(),
-                addr.value().to_string().characters());
+            klog() << "Routing: Got ARP response using adapter " << adapter->name().characters() << " for " << next_hop_ip.to_string().characters() << " (" << addr.value().to_string().characters() << ")";
 #endif
             return { adapter, addr.value() };
         }
     }
 
 #ifdef ROUTING_DEBUG
-    kprintf("Routing: Couldn't find route using adapter %s for %s\n",
-        adapter->name().characters(),
-        target.to_string().characters());
+    klog() << "Routing: Couldn't find route using adapter " << adapter->name().characters() << " for " << target.to_string().characters();
 #endif
 
     return { nullptr, {} };

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -65,7 +65,7 @@ Socket::~Socket()
 void Socket::set_setup_state(SetupState new_setup_state)
 {
 #ifdef SOCKET_DEBUG
-    kprintf("%s(%u) Socket{%p} setup state moving from %s to %s\n", Process::current->name().characters(), Process::current->pid(), this, to_string(m_setup_state), to_string(new_setup_state));
+    dbg() << "Socket{" << this << "} setup state moving from " << to_string(m_setup_state) << " to " << to_string(new_setup_state);
 #endif
 
     m_setup_state = new_setup_state;
@@ -77,7 +77,7 @@ RefPtr<Socket> Socket::accept()
     if (m_pending.is_empty())
         return nullptr;
 #ifdef SOCKET_DEBUG
-    kprintf("%s(%u) Socket{%p} de-queueing connection\n", Process::current->name().characters(), Process::current->pid(), this);
+    dbg() << "Socket{" << this << "} de-queueing connection";
 #endif
     auto client = m_pending.take_first();
     ASSERT(!client->is_connected());
@@ -91,7 +91,7 @@ RefPtr<Socket> Socket::accept()
 KResult Socket::queue_connection_from(NonnullRefPtr<Socket> peer)
 {
 #ifdef SOCKET_DEBUG
-    kprintf("%s(%u) Socket{%p} queueing connection\n", Process::current->name().characters(), Process::current->pid(), this);
+    dbg() << "Socket{" << this << "} queueing connection";
 #endif
     LOCKER(m_lock);
     if (m_pending.size() >= m_backlog)

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -48,9 +48,7 @@ void TCPSocket::for_each(Function<void(TCPSocket&)> callback)
 void TCPSocket::set_state(State new_state)
 {
 #ifdef TCP_SOCKET_DEBUG
-    kprintf("%s(%u) TCPSocket{%p} state moving from %s to %s\n",
-        Process::current->name().characters(), Process::current->pid(), this,
-        to_string(m_state), to_string(new_state));
+    dbg() << "TCPSocket{" << this << "} state moving from " << to_string(m_state) << " to " << to_string(new_state);
 #endif
 
     m_state = new_state;
@@ -170,7 +168,7 @@ int TCPSocket::protocol_receive(const KBuffer& packet_buffer, void* buffer, size
     auto& tcp_packet = *static_cast<const TCPPacket*>(ipv4_packet.payload());
     size_t payload_size = packet_buffer.size() - sizeof(IPv4Packet) - tcp_packet.header_size();
 #ifdef TCP_SOCKET_DEBUG
-    kprintf("payload_size %u, will it fit in %u?\n", payload_size, buffer_size);
+    klog() << "payload_size " << payload_size << ", will it fit in " << buffer_size << "?";
 #endif
     ASSERT(buffer_size >= payload_size);
     memcpy(buffer, tcp_packet.payload(), payload_size);
@@ -243,18 +241,7 @@ void TCPSocket::send_outgoing_packets()
 
 #ifdef TCP_SOCKET_DEBUG
         auto& tcp_packet = *(TCPPacket*)(packet.buffer.data());
-        kprintf("sending tcp packet from %s:%u to %s:%u with (%s%s%s%s) seq_no=%u, ack_no=%u, tx_counter=%u\n",
-            local_address().to_string().characters(),
-            local_port(),
-            peer_address().to_string().characters(),
-            peer_port(),
-            tcp_packet.has_syn() ? "SYN " : "",
-            tcp_packet.has_ack() ? "ACK " : "",
-            tcp_packet.has_fin() ? "FIN " : "",
-            tcp_packet.has_rst() ? "RST " : "",
-            tcp_packet.sequence_number(),
-            tcp_packet.ack_number(),
-            packet.tx_counter);
+        klog() << "sending tcp packet from " << local_address().to_string().characters() << ":" << local_port() << " to " << peer_address().to_string().characters() << ":" << peer_port() << " with (" << (tcp_packet.has_syn() ? "SYN " : "") << (tcp_packet.has_ack() ? "ACK " : "") << (tcp_packet.has_fin() ? "FIN " : "") << (tcp_packet.has_rst() ? "RST " : "") << ") seq_no=" << tcp_packet.sequence_number() << ", ack_no=" << tcp_packet.ack_number() << ", tx_counter=" << packet.tx_counter;
 #endif
         routing_decision.adapter->send_ipv4(
             routing_decision.next_hop, peer_address(), IPv4Protocol::TCP,

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -101,11 +101,7 @@ int UDPSocket::protocol_send(const void* data, size_t data_length)
     udp_packet.set_destination_port(peer_port());
     udp_packet.set_length(sizeof(UDPPacket) + data_length);
     memcpy(udp_packet.payload(), data, data_length);
-    kprintf("sending as udp packet from %s:%u to %s:%u!\n",
-        routing_decision.adapter->ipv4_address().to_string().characters(),
-        local_port(),
-        peer_address().to_string().characters(),
-        peer_port());
+    klog() << "sending as udp packet from " << routing_decision.adapter->ipv4_address().to_string().characters() << ":" << local_port() << " to " << peer_address().to_string().characters() << ":" << peer_port() << "!";
     routing_decision.adapter->send_ipv4(routing_decision.next_hop, peer_address(), IPv4Protocol::UDP, buffer.data(), buffer.size(), ttl());
     return data_length;
 }

--- a/Kernel/PCI/Access.cpp
+++ b/Kernel/PCI/Access.cpp
@@ -57,7 +57,7 @@ void PCI::Access::enumerate_functions(int type, u8 bus, u8 slot, u8 function, Fu
     if (read_type(address) == PCI_TYPE_BRIDGE) {
         u8 secondary_bus = read8_field(address, PCI_SECONDARY_BUS);
 #ifdef PCI_DEBUG
-        kprintf("PCI: Found secondary bus: %u\n", secondary_bus);
+        klog() << "PCI: Found secondary bus: " << secondary_bus;
 #endif
         ASSERT(secondary_bus != bus);
         enumerate_bus(type, secondary_bus, callback);

--- a/Kernel/PCI/IOAccess.cpp
+++ b/Kernel/PCI/IOAccess.cpp
@@ -37,7 +37,7 @@ void PCI::IOAccess::initialize()
 
 PCI::IOAccess::IOAccess()
 {
-    kprintf("PCI: Using IO Mechanism for PCI Configuartion Space Access\n");
+    klog() << "PCI: Using IO Mechanism for PCI Configuartion Space Access";
 }
 
 u8 PCI::IOAccess::read8_field(Address address, u32 field)

--- a/Kernel/PCI/Initializer.cpp
+++ b/Kernel/PCI/Initializer.cpp
@@ -58,13 +58,7 @@ void PCI::Initializer::initialize_pci_io_access()
 void PCI::Initializer::detect_devices()
 {
     PCI::enumerate_all([&](const PCI::Address& address, PCI::ID id) {
-        kprintf("PCI: device @ %w:%b:%b.%d [%w:%w]\n",
-            address.seg(),
-            address.bus(),
-            address.slot(),
-            address.function(),
-            id.vendor_id,
-            id.device_id);
+        klog() << "PCI: device @ " << String::format("%w", address.seg()) << ":" << String::format("%b", address.bus()) << ":" << String::format("%b", address.slot()) << "." << String::format("%d", address.function()) << " [" << String::format("%w", id.vendor_id) << ":" << String::format("%w", id.device_id) << "]";
         E1000NetworkAdapter::detect(address);
         RTL8139NetworkAdapter::detect(address);
     });
@@ -76,7 +70,7 @@ void PCI::Initializer::test_and_initialize(bool disable_pci_mmio)
         if (test_pci_io()) {
             initialize_pci_io_access();
         } else {
-            kprintf("No PCI Bus Access Method Detected, Halt!\n");
+            klog() << "No PCI Bus Access Method Detected, Halt!";
             ASSERT_NOT_REACHED(); // NO PCI Access ?!
         }
         return;
@@ -88,7 +82,7 @@ void PCI::Initializer::test_and_initialize(bool disable_pci_mmio)
             if (test_pci_io()) {
                 initialize_pci_io_access();
             } else {
-                kprintf("No PCI Bus Access Method Detected, Halt!\n");
+                klog() << "No PCI Bus Access Method Detected, Halt!";
                 ASSERT_NOT_REACHED(); // NO PCI Access ?!
             }
         }
@@ -96,7 +90,7 @@ void PCI::Initializer::test_and_initialize(bool disable_pci_mmio)
         if (test_pci_io()) {
             initialize_pci_io_access();
         } else {
-            kprintf("No PCI Bus Access Method Detected, Halt!\n");
+            klog() << "No PCI Bus Access Method Detected, Halt!";
             ASSERT_NOT_REACHED(); // NO PCI Access ?!
         }
     }
@@ -114,16 +108,16 @@ bool PCI::Initializer::test_acpi()
 
 bool PCI::Initializer::test_pci_io()
 {
-    kprintf("Testing PCI via manual probing... ");
+    klog() << "Testing PCI via manual probing... ";
     u32 tmp = 0x80000000;
     IO::out32(PCI_ADDRESS_PORT, tmp);
     tmp = IO::in32(PCI_ADDRESS_PORT);
     if (tmp == 0x80000000) {
-        kprintf("PCI IO Supported!\n");
+        klog() << "PCI IO Supported!";
         return true;
     }
 
-    kprintf("PCI IO Not Supported!\n");
+    klog() << "PCI IO Not Supported!";
     return false;
 }
 
@@ -141,7 +135,7 @@ void PCI::Initializer::dismiss()
 {
     if (s_pci_initializer == nullptr)
         return;
-    kprintf("PCI Subsystem Initializer dismissed.\n");
+    klog() << "PCI Subsystem Initializer dismissed.";
     delete s_pci_initializer;
     s_pci_initializer = nullptr;
 }

--- a/Kernel/PCI/MMIOAccess.cpp
+++ b/Kernel/PCI/MMIOAccess.cpp
@@ -58,7 +58,7 @@ PCI::MMIOAccess::MMIOAccess(PhysicalAddress p_mcfg)
     , m_segments(*new HashMap<u16, MMIOSegment*>())
     , m_mapped_address(ChangeableAddress(0xFFFF, 0xFF, 0xFF, 0xFF))
 {
-    kprintf("PCI: Using MMIO Mechanism for PCI Configuartion Space Access\n");
+    klog() << "PCI: Using MMIO Mechanism for PCI Configuartion Space Access";
     m_mmio_window_region = MM.allocate_kernel_region(PAGE_ROUND_UP(PCI_MMIO_CONFIG_SPACE_SIZE), "PCI MMIO", Region::Access::Read | Region::Access::Write);
 
     auto checkup_region = MM.allocate_kernel_region(p_mcfg.page_base(), (PAGE_SIZE * 2), "PCI MCFG Checkup", Region::Access::Read | Region::Access::Write);
@@ -70,7 +70,7 @@ PCI::MMIOAccess::MMIOAccess(PhysicalAddress p_mcfg)
     u32 length = sdt->length;
     u8 revision = sdt->revision;
 
-    kprintf("PCI: MCFG, length - %u, revision %d\n", length, revision);
+    klog() << "PCI: MCFG, length - " << length << ", revision " << revision;
     checkup_region->unmap();
 
     auto mcfg_region = MM.allocate_kernel_region(p_mcfg.page_base(), PAGE_ROUND_UP(length) + PAGE_SIZE, "PCI Parsing MCFG", Region::Access::Read | Region::Access::Write);
@@ -86,10 +86,10 @@ PCI::MMIOAccess::MMIOAccess(PhysicalAddress p_mcfg)
         u32 lower_addr = mcfg.descriptors[index].base_addr;
 
         m_segments.set(index, new PCI::MMIOSegment(PhysicalAddress(lower_addr), start_bus, end_bus));
-        kprintf("PCI: New PCI segment @ P 0x%x, PCI buses (%d-%d)\n", lower_addr, start_bus, end_bus);
+        klog() << "PCI: New PCI segment @ P " << String::format("%p", lower_addr) << ", PCI buses (" << start_bus << "-" << end_bus << ")";
     }
     mcfg_region->unmap();
-    kprintf("PCI: MMIO segments - %d\n", m_segments.size());
+    klog() << "PCI: MMIO segments - " << m_segments.size();
     InterruptDisabler disabler;
 #ifdef PCI_DEBUG
     dbg() << "PCI: mapped address (" << String::format("%w", m_mapped_address.seg()) << ":" << String::format("%b", m_mapped_address.bus()) << ":" << String::format("%b", m_mapped_address.slot()) << "." << String::format("%b", m_mapped_address.function()) << ")";

--- a/Kernel/RTC.cpp
+++ b/Kernel/RTC.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/LogStream.h>
 #include <Kernel/CMOS.h>
 #include <Kernel/RTC.h>
 
@@ -154,7 +155,7 @@ time_t now()
     unsigned year, month, day, hour, minute, second;
     read_registers(year, month, day, hour, minute, second);
 
-    kprintf("year: %d, month: %d, day: %d\n", year, month, day);
+    klog() << "year: " << year << ", month: " << month << ", day: " << day;
 
     ASSERT(year >= 2018);
 

--- a/Kernel/SharedBuffer.cpp
+++ b/Kernel/SharedBuffer.cpp
@@ -173,7 +173,7 @@ void SharedBuffer::destroy_if_unused()
     sanity_check("destroy_if_unused");
     if (m_total_refs == 0) {
 #ifdef SHARED_BUFFER_DEBUG
-        kprintf("Destroying unused SharedBuffer{%p} id: %d\n", this, m_shbuf_id);
+        dbg() << "Destroying unused SharedBuffer{" << this << "} id: " << m_shbuf_id;
 #endif
         auto count_before = shared_buffers().resource().size();
         shared_buffers().resource().remove(m_shbuf_id);

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -70,7 +70,7 @@ static int handle(RegisterState&, u32 function, u32 arg1, u32 arg2, u32 arg3);
 void initialize()
 {
     register_user_callable_interrupt_handler(0x82, syscall_asm_entry);
-    kprintf("Syscall: int 0x82 handler installed\n");
+    klog() << "Syscall: int 0x82 handler installed";
 }
 
 #pragma GCC diagnostic ignored "-Wcast-function-type"

--- a/Kernel/TestModule.cpp
+++ b/Kernel/TestModule.cpp
@@ -30,17 +30,14 @@ extern "C" const char module_name[] = "TestModule";
 
 extern "C" void module_init()
 {
-    kprintf("TestModule has booted!\n");
+    klog() << "TestModule has booted!";
 
     for (int i = 0; i < 3; ++i) {
-        kprintf("i is now %d\n", i);
+        klog() << "i is now " << i;
     }
-
-    kprintf("current pid: %d\n", Process::current->sys$getpid());
-    kprintf("current process name: %s\n", Process::current->name().characters());
 }
 
 extern "C" void module_fini()
 {
-    kprintf("TestModule is being removed!\n");
+    klog() << "TestModule is being removed!";
 }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -284,7 +284,7 @@ const char* Thread::state_string() const
         ASSERT(m_blocker != nullptr);
         return m_blocker->state_string();
     }
-    kprintf("Thread::state_string(): Invalid state: %u\n", state());
+    klog() << "Thread::state_string(): Invalid state: " << state();
     ASSERT_NOT_REACHED();
     return nullptr;
 }
@@ -485,7 +485,7 @@ ShouldUnblockThread Thread::dispatch_signal(u8 signal)
     ASSERT(!process().is_ring0());
 
 #ifdef SIGNAL_DEBUG
-    kprintf("dispatch_signal %s(%u) <- %u\n", process().name().characters(), pid(), signal);
+    klog() << "dispatch_signal <- " << signal;
 #endif
 
     auto& action = m_signal_action_data[signal];
@@ -536,7 +536,7 @@ ShouldUnblockThread Thread::dispatch_signal(u8 signal)
 
     if (handler_vaddr.as_ptr() == SIG_IGN) {
 #ifdef SIGNAL_DEBUG
-        kprintf("%s(%u) ignored signal %u\n", process().name().characters(), pid(), signal);
+        klog() << "ignored signal " << signal;
 #endif
         return ShouldUnblockThread::Yes;
     }
@@ -612,7 +612,7 @@ ShouldUnblockThread Thread::dispatch_signal(u8 signal)
     }
 
 #ifdef SIGNAL_DEBUG
-    kprintf("signal: Okay, %s(%u) {%s} has been primed with signal handler %w:%x\n", process().name().characters(), pid(), state_string(), m_tss.cs, m_tss.eip);
+    klog() << "signal: Okay, {" << state_string() << "} has been primed with signal handler " << String::format("%w", m_tss.cs) << ":" << String::format("%x", m_tss.eip);
 #endif
     return ShouldUnblockThread::Yes;
 }

--- a/Kernel/VM/PageDirectory.cpp
+++ b/Kernel/VM/PageDirectory.cpp
@@ -63,9 +63,9 @@ PageDirectory::PageDirectory()
     PhysicalAddress boot_pdpt_paddr(virtual_to_low_physical((uintptr_t)boot_pdpt));
     PhysicalAddress boot_pd0_paddr(virtual_to_low_physical((uintptr_t)boot_pd0));
     PhysicalAddress boot_pd3_paddr(virtual_to_low_physical((uintptr_t)boot_pd3));
-    kprintf("MM: boot_pdpt @ P%p\n", boot_pdpt_paddr.get());
-    kprintf("MM: boot_pd0 @ P%p\n", boot_pd0_paddr.get());
-    kprintf("MM: boot_pd3 @ P%p\n", boot_pd3_paddr.get());
+    klog() << "MM: boot_pdpt @ " << boot_pdpt_paddr;
+    klog() << "MM: boot_pd0 @ " << boot_pd0_paddr;
+    klog() << "MM: boot_pd3 @ " << boot_pd3_paddr;
     m_directory_table = PhysicalPage::create(boot_pdpt_paddr, true, false);
     m_directory_pages[0] = PhysicalPage::create(boot_pd0_paddr, true, false);
     m_directory_pages[3] = PhysicalPage::create(boot_pd3_paddr, true, false);

--- a/Kernel/VM/RangeAllocator.cpp
+++ b/Kernel/VM/RangeAllocator.cpp
@@ -130,7 +130,7 @@ Range RangeAllocator::allocate_anywhere(size_t size, size_t alignment)
 #endif
         return allocated_range;
     }
-    kprintf("VRA: Failed to allocate anywhere: %zu, %zu\n", size, alignment);
+    klog() << "VRA: Failed to allocate anywhere: " << size << ", " << alignment;
     return {};
 }
 
@@ -155,7 +155,7 @@ Range RangeAllocator::allocate_specific(VirtualAddress base, size_t size)
 #endif
         return allocated_range;
     }
-    kprintf("VRA: Failed to allocate specific range: %x(%u)\n", base.get(), size);
+    dbg() << "VRA: Failed to allocate specific range: " << base << "(" << size << ")";
     return {};
 }
 

--- a/Libraries/LibBareMetal/Output/kprintf.cpp
+++ b/Libraries/LibBareMetal/Output/kprintf.cpp
@@ -96,7 +96,7 @@ static void serial_putch(char ch)
         was_cr = false;
 }
 
-static void console_putch(char*&, char ch)
+static void console_out(char ch)
 {
     if (serial_debug)
         serial_putch(ch);
@@ -108,6 +108,11 @@ static void console_putch(char*&, char ch)
     } else {
         IO::out8(0xe9, ch);
     }
+}
+
+static void console_putch(char*&, char ch)
+{
+    console_out(ch);
 }
 
 int kprintf(const char* fmt, ...)
@@ -152,6 +157,13 @@ extern "C" int dbgputstr(const char* characters, int length)
 {
     for (int i = 0; i < length; ++i)
         debugger_out(characters[i]);
+    return 0;
+}
+
+extern "C" int kernelputstr(const char* characters, int length)
+{
+    for (int i = 0; i < length; ++i)
+        console_out(characters[i]);
     return 0;
 }
 

--- a/Libraries/LibBareMetal/Output/kstdio.h
+++ b/Libraries/LibBareMetal/Output/kstdio.h
@@ -31,6 +31,7 @@
 extern "C" {
 int dbgprintf(const char* fmt, ...);
 int dbgputstr(const char*, int);
+int kernelputstr(const char*, int);
 int kprintf(const char* fmt, ...);
 int sprintf(char* buf, const char* fmt, ...);
 void set_serial_debug(bool on_or_off);


### PR DESCRIPTION
Looking at #979, I thought it might be nice to have a similar mechanism to `dbg()` but that is capable of printing debug messages into `/proc/dmesg` also.
If the idea is acceptable, we can replace all `kprintf()` calls in the kernel with `kdbg()` instead.