### PR TITLE
LibELF: Use MAP_PRIVATE for file-backed mmaps in ELFDynamicLoader

### DIFF
--- a/Demos/DynamicLink/LinkDemo/Makefile
+++ b/Demos/DynamicLink/LinkDemo/Makefile
@@ -4,6 +4,5 @@ OBJS = \
 PROGRAM = LinkDemo
 
 SUBPROJECT_CXXFLAGS = -fPIC
-LDFLAGS = -pie -Wl,--dynamic-linker=/lib/ld-elf.so
 
 include ../../../Makefile.common


### PR DESCRIPTION
Clean up some unused code, clean up FIXMEs, and remove premature
--dynamic-loader/-pie from LinkDemo (so it runs again on master)