### PR TITLE
Kernel: Check if the Region's VMObject is a Shared Inode

### DIFF
--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -66,7 +66,7 @@ NonnullOwnPtr<Region> Region::clone()
 {
     ASSERT(Process::current);
 
-    if (m_shared) {
+    if (m_shared || vmobject().is_shared_inode()) {
         ASSERT(!m_stack);
 #ifdef MM_DEBUG
         dbg() << "Region::clone(): Sharing " << name() << " (" << vaddr() << ")";


### PR DESCRIPTION
This patch allows to boot Serenity correctly, it basically fixes this commit - https://github.com/SerenityOS/serenity/commit/fddc3c957b2302c9e166c709dedcde09945318e3

We need to check if the VMObject is a Shared Inode, otherwise when trying to clone the `Region` with a `SharedInodeVMObject`, it will assert on `ASSERT(vmobject().is_private_inode())`.