### PR TITLE
CI: Updated .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: require
+os: linux
 dist: xenial
 
 language: cpp


### PR DESCRIPTION
According to https://travis-ci.com/SerenityOS/serenity/jobs/292769770/config the `sudo` key does nothing and `os` should be specified.