### PR TITLE
Kernel: Allow rebooting via ACPI

### DIFF
--- a/Kernel/ACPI/ACPIDynamicParser.cpp
+++ b/Kernel/ACPI/ACPIDynamicParser.cpp
@@ -82,7 +82,7 @@ namespace ACPI {
         // FIXME: Implement AML Interpretation
         ASSERT_NOT_REACHED();
     }
-    void DynamicParser::do_acpi_shutdown()
+    void DynamicParser::try_acpi_shutdown()
     {
         // FIXME: Implement AML Interpretation to perform ACPI shutdown
         ASSERT_NOT_REACHED();

--- a/Kernel/ACPI/ACPIDynamicParser.h
+++ b/Kernel/ACPI/ACPIDynamicParser.h
@@ -44,8 +44,9 @@ public:
     virtual void enable_aml_interpretation() override;
     virtual void enable_aml_interpretation(File& dsdt_file) override;
     virtual void enable_aml_interpretation(u8* physical_dsdt, u32 dsdt_payload_legnth) override;
-    virtual void disable_aml_interpretation() override;
-    virtual void do_acpi_shutdown() override;
+    virtual void disable_aml_interpretation() override;    
+    virtual void try_acpi_shutdown() override;
+    virtual bool can_shutdown() override { return true; }
 
 protected:
     DynamicParser();

--- a/Kernel/ACPI/ACPIDynamicParser.h
+++ b/Kernel/ACPI/ACPIDynamicParser.h
@@ -35,30 +35,29 @@
 
 namespace Kernel {
 namespace ACPI {
-class DynamicParser final : public IRQHandler
-    , StaticParser {
-public:
-    static void initialize(PhysicalAddress rsdp);
-    static void initialize_without_rsdp();
+    class DynamicParser final : public IRQHandler
+        , StaticParser {
+    public:
+        static void initialize(PhysicalAddress rsdp);
+        static void initialize_without_rsdp();
 
-    virtual void enable_aml_interpretation() override;
-    virtual void enable_aml_interpretation(File& dsdt_file) override;
-    virtual void enable_aml_interpretation(u8* physical_dsdt, u32 dsdt_payload_legnth) override;
-    virtual void disable_aml_interpretation() override;    
-    virtual void try_acpi_shutdown() override;
-    virtual bool can_shutdown() override { return true; }
+        virtual void enable_aml_interpretation() override;
+        virtual void enable_aml_interpretation(File& dsdt_file) override;
+        virtual void enable_aml_interpretation(u8* physical_dsdt, u32 dsdt_payload_legnth) override;
+        virtual void disable_aml_interpretation() override;
+        virtual void try_acpi_shutdown() override;
+        virtual bool can_shutdown() override { return true; }
 
-protected:
-    DynamicParser();
-    explicit DynamicParser(PhysicalAddress);
+    protected:
+        DynamicParser();
+        explicit DynamicParser(PhysicalAddress);
 
-private:
-    void build_namespace();
-    // ^IRQHandler
-    virtual void handle_irq(RegisterState&) override;
+    private:
+        void build_namespace();
+        // ^IRQHandler
+        virtual void handle_irq(RegisterState&) override;
 
-    OwnPtr<Region> m_acpi_namespace;
-};
-
+        OwnPtr<Region> m_acpi_namespace;
+    };
 }
 }

--- a/Kernel/ACPI/ACPIParser.cpp
+++ b/Kernel/ACPI/ACPIParser.cpp
@@ -64,16 +64,14 @@ namespace ACPI {
         return {};
     }
 
-    void Parser::do_acpi_reboot()
+    void Parser::try_acpi_reboot()
     {
         klog() << "ACPI: Cannot invoke reboot!";
-        ASSERT_NOT_REACHED();
     }
 
-    void Parser::do_acpi_shutdown()
+    void Parser::try_acpi_shutdown()
     {
         klog() << "ACPI: Cannot invoke shutdown!";
-        ASSERT_NOT_REACHED();
     }
 
     void Parser::enable_aml_interpretation()

--- a/Kernel/ACPI/ACPIParser.h
+++ b/Kernel/ACPI/ACPIParser.h
@@ -43,8 +43,10 @@ public:
     static void initialize_limited();
     virtual PhysicalAddress find_table(const char* sig);
 
-    virtual void do_acpi_reboot();
-    virtual void do_acpi_shutdown();
+    virtual void try_acpi_reboot();
+    virtual bool can_reboot() { return false; }
+    virtual void try_acpi_shutdown();
+    virtual bool can_shutdown() { return false; }
 
     virtual void enable_aml_interpretation();
     virtual void enable_aml_interpretation(File&);

--- a/Kernel/ACPI/ACPIStaticParser.h
+++ b/Kernel/ACPI/ACPIStaticParser.h
@@ -39,8 +39,10 @@ namespace ACPI {
         static bool is_initialized();
 
         virtual PhysicalAddress find_table(const char* sig) override;
-        virtual void do_acpi_reboot() override;
-        virtual void do_acpi_shutdown() override;
+        virtual void try_acpi_reboot() override;
+        virtual bool can_reboot() override;
+        virtual bool can_shutdown() override { return false; }
+        virtual void try_acpi_shutdown() override;
         virtual bool is_operable() override { return m_operable; }
 
     protected:

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -31,6 +31,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/Time.h>
 #include <AK/Types.h>
+#include <Kernel/ACPI/ACPIParser.h>
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/Devices/BlockDevice.h>
 #include <Kernel/Devices/KeyboardDevice.h>
@@ -3990,6 +3991,10 @@ int Process::sys$reboot()
     FS::lock_all();
     dbg() << "syncing mounted filesystems...";
     FS::sync();
+    if (ACPI::Parser::the().can_reboot()) {
+        dbg() << "attempting reboot via ACPI";
+        ACPI::Parser::the().try_acpi_reboot();
+    }
     dbg() << "attempting reboot via KB Controller...";
     IO::out8(0x64, 0xFE);
 

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -829,7 +829,6 @@ int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Ve
     dbg() << "Process " << pid() << " exec: PD=" << m_page_directory.ptr() << " created";
 #endif
 
-
     InodeMetadata loader_metadata;
 
     // FIXME: Hoooo boy this is a hack if I ever saw one.


### PR DESCRIPTION
This patch adds a call to the ACPI parser to initiate a reboot. It will fail on PIIX4 (i440fx) machines, and therefore it will fallback automatically to rebooting via the keyboard controller. on Q35 machines, it will work and thus no need to use the keyboard controller to do a reboot.