### PR TITLE
LibC: Implement time formatting functions, partially support timezone

### DIFF
--- a/Libraries/LibC/time.h
+++ b/Libraries/LibC/time.h
@@ -43,7 +43,7 @@ struct tm {
     int tm_isdst; /* Daylight saving time */
 };
 
-extern long timezone;
+extern long timezone; /* The difference in seconds between UTC and local time */
 extern long altzone;
 extern char* tzname[2];
 extern int daylight;


### PR DESCRIPTION
Also fix a bug in mktime() caused by forgetting to check if the present year
is a leap year.