### PR TITLE
Fix group names in FileManager and FileSystemModel

### DIFF
--- a/Applications/FileManager/PropertiesDialog.cpp
+++ b/Applications/FileManager/PropertiesDialog.cpp
@@ -31,6 +31,7 @@
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/TabWidget.h>
+#include <grp.h>
 #include <limits.h>
 #include <pwd.h>
 #include <stdio.h>
@@ -95,8 +96,8 @@ PropertiesDialog::PropertiesDialog(GUI::FileSystemModel& model, String path, boo
     }
 
     struct passwd* user_pw = getpwuid(st.st_uid);
-    struct passwd* group_pw = getpwuid(st.st_gid);
-    ASSERT(user_pw && group_pw);
+    struct group* group_gr = getgrgid(st.st_gid);
+    ASSERT(user_pw && group_gr);
 
     m_mode = st.st_mode;
 
@@ -116,7 +117,7 @@ PropertiesDialog::PropertiesDialog(GUI::FileSystemModel& model, String path, boo
 
     properties.append({ "Size:", String::format("%zu bytes", st.st_size) });
     properties.append({ "Owner:", String::format("%s (%lu)", user_pw->pw_name, static_cast<u32>(user_pw->pw_uid)) });
-    properties.append({ "Group:", String::format("%s (%lu)", group_pw->pw_name, static_cast<u32>(group_pw->pw_uid)) });
+    properties.append({ "Group:", String::format("%s (%lu)", group_gr->gr_name, static_cast<u32>(group_gr->gr_gid)) });
     properties.append({ "Created at:", GUI::FileSystemModel::timestamp_string(st.st_ctime) });
     properties.append({ "Last modified:", GUI::FileSystemModel::timestamp_string(st.st_mtime) });
 

--- a/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Libraries/LibGUI/FileSystemModel.cpp
@@ -233,10 +233,10 @@ String FileSystemModel::name_for_uid(uid_t uid) const
     return (*it).value;
 }
 
-String FileSystemModel::name_for_gid(uid_t gid) const
+String FileSystemModel::name_for_gid(gid_t gid) const
 {
-    auto it = m_user_names.find(gid);
-    if (it == m_user_names.end())
+    auto it = m_group_names.find(gid);
+    if (it == m_group_names.end())
         return String::number(gid);
     return (*it).value;
 }


### PR DESCRIPTION
I have a feeling a somewhat competent static analyzer could have caught these `uid`/`gid` mixups. Might worth scanning the repo with one on them looking for similar bugs some day.