### PR TITLE
FileManager: Fix asserts on checking properties of symlinks

### DIFF
--- a/Applications/FileManager/PropertiesDialog.cpp
+++ b/Applications/FileManager/PropertiesDialog.cpp
@@ -107,12 +107,11 @@ PropertiesDialog::PropertiesDialog(GUI::FileSystemModel& model, String path, boo
 
     if (S_ISLNK(m_mode)) {
         char link_destination[PATH_MAX];
-        if (readlink(path.characters(), link_destination, sizeof(link_destination))) {
+        if (readlink(path.characters(), link_destination, sizeof(link_destination)) < 0) {
             perror("readlink");
-            return;
+        } else {
+            properties.append({ "Link target:", link_destination });
         }
-
-        properties.append({ "Link target:", link_destination });
     }
 
     properties.append({ "Size:", String::format("%zu bytes", st.st_size) });


### PR DESCRIPTION
There were two issues with this code:
- The result of the readlink() call was checked incorrectly for errors.
- This code shouldn't return because otherwise it leaves the GUI buttons uninitialized below, causing RefPtr asserts to trigger when the dialog tries to access the buttons later on.