### PR TITLE
LibCore/LibGUI: More library namespacing / cleanups

### DIFF
--- a/Applications/FileManager/DirectoryView.cpp
+++ b/Applications/FileManager/DirectoryView.cpp
@@ -144,8 +144,8 @@ DirectoryView::DirectoryView()
     };
 
     //  NOTE: We're using the on_update hook on the GSortingProxyModel here instead of
-    //        the GFileSystemModel's hook. This is because GSortingProxyModel has already
-    //        installed an on_update hook on the GFileSystemModel internally.
+    //        the GUI::FileSystemModel's hook. This is because GSortingProxyModel has already
+    //        installed an on_update hook on the GUI::FileSystemModel internally.
     // FIXME: This is an unfortunate design. We should come up with something better.
     m_table_view->model()->on_update = [this] {
         for_each_view_implementation([](auto& view) {

--- a/Applications/FileManager/PropertiesDialog.cpp
+++ b/Applications/FileManager/PropertiesDialog.cpp
@@ -79,7 +79,7 @@ PropertiesDialog::PropertiesDialog(GUI::FileSystemModel& model, String path, boo
     m_name_box->set_text(m_name);
     m_name_box->on_change = [&, disable_rename]() {
         if (disable_rename) {
-            m_name_box->set_text(m_name); //FIXME: GTextBox does not support set_enabled yet...
+            m_name_box->set_text(m_name); //FIXME: GUI::TextBox does not support set_enabled yet...
         } else {
             m_name_dirty = m_name != m_name_box->text();
             m_apply_button->set_enabled(true);

--- a/Applications/Help/ManualModel.h
+++ b/Applications/Help/ManualModel.h
@@ -52,6 +52,6 @@ public:
 private:
     ManualModel();
 
-    GIcon m_section_icon;
-    GIcon m_page_icon;
+    GUI::Icon m_section_icon;
+    GUI::Icon m_page_icon;
 };

--- a/Applications/HexEditor/HexEditor.cpp
+++ b/Applications/HexEditor/HexEditor.cpp
@@ -44,7 +44,7 @@
 HexEditor::HexEditor()
 {
     set_scrollbars_enabled(true);
-    set_font(GFontDatabase::the().get_by_name("Csilla Thin"));
+    set_font(GUI::FontDatabase::the().get_by_name("Csilla Thin"));
     set_background_role(ColorRole::Base);
     set_foreground_role(ColorRole::BaseText);
     vertical_scrollbar().set_step(line_height());

--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -281,11 +281,11 @@ int main(int argc, char** argv)
     GUI::ActionGroup font_action_group;
     font_action_group.set_exclusive(true);
     auto font_menu = GUI::Menu::construct("Font");
-    GFontDatabase::the().for_each_fixed_width_font([&](const StringView& font_name) {
+    GUI::FontDatabase::the().for_each_fixed_width_font([&](const StringView& font_name) {
         auto action = GUI::Action::create(font_name, [&](GUI::Action& action) {
             action.set_checked(true);
-            terminal.set_font(GFontDatabase::the().get_by_name(action.text()));
-            auto metadata = GFontDatabase::the().get_metadata_by_name(action.text());
+            terminal.set_font(GUI::FontDatabase::the().get_by_name(action.text()));
+            auto metadata = GUI::FontDatabase::the().get_metadata_by_name(action.text());
             ASSERT(metadata.has_value());
             config->write_entry("Text", "Font", metadata.value().path);
             config->sync();

--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -370,9 +370,9 @@ TextEditorWidget::TextEditorWidget()
     menubar->add_menu(move(edit_menu));
 
     auto font_menu = GUI::Menu::construct("Font");
-    GFontDatabase::the().for_each_fixed_width_font([&](const StringView& font_name) {
+    GUI::FontDatabase::the().for_each_fixed_width_font([&](const StringView& font_name) {
         font_menu->add_action(GUI::Action::create(font_name, [this](const GUI::Action& action) {
-            m_editor->set_font(GFontDatabase::the().get_by_name(action.text()));
+            m_editor->set_font(GUI::FontDatabase::the().get_by_name(action.text()));
             m_editor->update();
         }));
     });

--- a/Base/usr/share/man/man7/SystemServer.md
+++ b/Base/usr/share/man/man7/SystemServer.md
@@ -31,7 +31,7 @@ The service is advised to set this flag using [`fcntl`(2)](../man2/fcntl.md) and
 unset `SOCKET_TAKEOVER` from the environment in order not to confuse its
 children.
 
-LibCore provides `CLocalServer::take_over_from_system_server()` method that
+LibCore provides `Core::LocalServer::take_over_from_system_server()` method that
 performs the service side of the socket takeover automatically.
 
 If a service is configured as *lazy*, SystemServer will actually listen on the

--- a/DevTools/HackStudio/Project.cpp
+++ b/DevTools/HackStudio/Project.cpp
@@ -169,11 +169,11 @@ Project::Project(const String& path, Vector<String>&& filenames)
 {
     m_name = FileSystemPath(m_path).basename();
 
-    m_file_icon = GIcon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-unknown.png"));
-    m_cplusplus_icon = GIcon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-cplusplus.png"));
-    m_header_icon = GIcon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-header.png"));
-    m_directory_icon = GIcon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-folder.png"));
-    m_project_icon = GIcon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-hack-studio.png"));
+    m_file_icon = GUI::Icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-unknown.png"));
+    m_cplusplus_icon = GUI::Icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-cplusplus.png"));
+    m_header_icon = GUI::Icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-header.png"));
+    m_directory_icon = GUI::Icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-folder.png"));
+    m_project_icon = GUI::Icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-hack-studio.png"));
 
     for (auto& filename : filenames) {
         m_files.append(ProjectFile::construct_with_name(filename));

--- a/DevTools/HackStudio/Project.h
+++ b/DevTools/HackStudio/Project.h
@@ -71,9 +71,9 @@ private:
     NonnullRefPtrVector<ProjectFile> m_files;
     RefPtr<ProjectTreeNode> m_root_node;
 
-    GIcon m_directory_icon;
-    GIcon m_file_icon;
-    GIcon m_cplusplus_icon;
-    GIcon m_header_icon;
-    GIcon m_project_icon;
+    GUI::Icon m_directory_icon;
+    GUI::Icon m_file_icon;
+    GUI::Icon m_cplusplus_icon;
+    GUI::Icon m_header_icon;
+    GUI::Icon m_project_icon;
 };

--- a/DevTools/HackStudio/WidgetTreeModel.h
+++ b/DevTools/HackStudio/WidgetTreeModel.h
@@ -47,5 +47,5 @@ private:
     explicit WidgetTreeModel(GUI::Widget&);
 
     NonnullRefPtr<GUI::Widget> m_root;
-    GIcon m_widget_icon;
+    GUI::Icon m_widget_icon;
 };

--- a/DevTools/Inspector/RemoteObjectGraphModel.h
+++ b/DevTools/Inspector/RemoteObjectGraphModel.h
@@ -55,8 +55,8 @@ private:
 
     RemoteProcess& m_process;
 
-    GIcon m_object_icon;
-    GIcon m_window_icon;
-    GIcon m_layout_icon;
-    GIcon m_timer_icon;
+    GUI::Icon m_object_icon;
+    GUI::Icon m_window_icon;
+    GUI::Icon m_layout_icon;
+    GUI::Icon m_timer_icon;
 };

--- a/DevTools/ProfileViewer/ProfileModel.h
+++ b/DevTools/ProfileViewer/ProfileModel.h
@@ -61,6 +61,6 @@ private:
 
     Profile& m_profile;
 
-    GIcon m_user_frame_icon;
-    GIcon m_kernel_frame_icon;
+    GUI::Icon m_user_frame_icon;
+    GUI::Icon m_kernel_frame_icon;
 };

--- a/Games/Snake/SnakeGame.cpp
+++ b/Games/Snake/SnakeGame.cpp
@@ -35,7 +35,7 @@
 
 SnakeGame::SnakeGame()
 {
-    set_font(GFontDatabase::the().get_by_name("Liza Regular"));
+    set_font(GUI::FontDatabase::the().get_by_name("Liza Regular"));
     m_fruit_bitmaps.append(*Gfx::Bitmap::load_from_file("/res/icons/snake/paprika.png"));
     m_fruit_bitmaps.append(*Gfx::Bitmap::load_from_file("/res/icons/snake/eggplant.png"));
     m_fruit_bitmaps.append(*Gfx::Bitmap::load_from_file("/res/icons/snake/cauliflower.png"));

--- a/Libraries/LibCore/Gzip.cpp
+++ b/Libraries/LibCore/Gzip.cpp
@@ -31,7 +31,9 @@
 #include <limits.h>
 #include <stddef.h>
 
-bool CGzip::is_compressed(const ByteBuffer& data)
+namespace Core {
+
+bool Gzip::is_compressed(const ByteBuffer& data)
 {
     return data.size() > 2 && data[0] == 0x1F && data[1] == 0x8b;
 }
@@ -102,7 +104,7 @@ static Optional<ByteBuffer> get_gzip_payload(const ByteBuffer& data)
     return data.slice(current, new_size);
 }
 
-Optional<ByteBuffer> CGzip::decompress(const ByteBuffer& data)
+Optional<ByteBuffer> Gzip::decompress(const ByteBuffer& data)
 {
     ASSERT(is_compressed(data));
 
@@ -144,4 +146,6 @@ Optional<ByteBuffer> CGzip::decompress(const ByteBuffer& data)
     }
 
     return destination;
+}
+
 }

--- a/Libraries/LibCore/Gzip.h
+++ b/Libraries/LibCore/Gzip.h
@@ -28,8 +28,12 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 
-class CGzip {
+namespace Core {
+
+class Gzip {
 public:
     static bool is_compressed(const ByteBuffer& data);
     static Optional<ByteBuffer> decompress(const ByteBuffer& data);
 };
+
+}

--- a/Libraries/LibCore/IODevice.cpp
+++ b/Libraries/LibCore/IODevice.cpp
@@ -104,7 +104,7 @@ ByteBuffer IODevice::read(size_t max_size)
 
 bool IODevice::can_read_from_fd() const
 {
-    // FIXME: Can we somehow remove this once CSocket is implemented using non-blocking sockets?
+    // FIXME: Can we somehow remove this once Core::Socket is implemented using non-blocking sockets?
     fd_set rfds;
     FD_ZERO(&rfds);
     FD_SET(m_fd, &rfds);

--- a/Libraries/LibCore/LocalSocket.cpp
+++ b/Libraries/LibCore/LocalSocket.cpp
@@ -37,7 +37,7 @@ namespace Core {
 LocalSocket::LocalSocket(int fd, Object* parent)
     : Socket(Socket::Type::Local, parent)
 {
-    // NOTE: This constructor is used by CLocalServer::accept(), so the socket is already connected.
+    // NOTE: This constructor is used by LocalServer::accept(), so the socket is already connected.
     m_connected = true;
     set_fd(fd);
     set_mode(IODevice::ReadWrite);

--- a/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -40,7 +40,7 @@ HashMap<pid_t, Core::ProcessStatistics> ProcessStatisticsReader::get_all()
 {
     auto file = Core::File::construct("/proc/all");
     if (!file->open(Core::IODevice::ReadOnly)) {
-        fprintf(stderr, "CProcessStatisticsReader: Failed to open /proc/all: %s\n", file->error_string());
+        fprintf(stderr, "ProcessStatisticsReader: Failed to open /proc/all: %s\n", file->error_string());
         return {};
     }
 

--- a/Libraries/LibCore/SocketAddress.h
+++ b/Libraries/LibCore/SocketAddress.h
@@ -77,7 +77,7 @@ public:
         case Type::Local:
             return m_local_address;
         default:
-            return "[CSocketAddress]";
+            return "[SocketAddress]";
         }
     }
 

--- a/Libraries/LibCore/TCPSocket.cpp
+++ b/Libraries/LibCore/TCPSocket.cpp
@@ -33,7 +33,7 @@ namespace Core {
 TCPSocket::TCPSocket(int fd, Object* parent)
     : Socket(Socket::Type::TCP, parent)
 {
-    // NOTE: This constructor is used by CTCPServer::accept(), so the socket is already connected.
+    // NOTE: This constructor is used by TCPServer::accept(), so the socket is already connected.
     m_connected = true;
     set_fd(fd);
     set_mode(IODevice::ReadWrite);

--- a/Libraries/LibCore/UdpSocket.cpp
+++ b/Libraries/LibCore/UdpSocket.cpp
@@ -33,7 +33,7 @@ namespace Core {
 UdpSocket::UdpSocket(int fd, Object* parent)
     : Socket(Socket::Type::UDP, parent)
 {
-    // NOTE: This constructor is used by CUdpServer::accept(), so the socket is already connected.
+    // NOTE: This constructor is used by UdpServer::accept(), so the socket is already connected.
     m_connected = true;
     set_fd(fd);
     set_mode(IODevice::ReadWrite);

--- a/Libraries/LibGUI/AbstractButton.h
+++ b/Libraries/LibGUI/AbstractButton.h
@@ -31,7 +31,7 @@
 namespace GUI {
 
 class AbstractButton : public Widget {
-    C_OBJECT_ABSTRACT(GAbstractButton)
+    C_OBJECT_ABSTRACT(AbstractButton)
 public:
     virtual ~AbstractButton() override;
 

--- a/Libraries/LibGUI/Application.cpp
+++ b/Libraries/LibGUI/Application.cpp
@@ -69,7 +69,7 @@ int Application::exec()
 {
     int exit_code = m_event_loop->exec();
     // NOTE: Maybe it would be cool to return instead of exit()?
-    //       This would require cleaning up all the CObjects on the heap.
+    //       This would require cleaning up all the Core::Objects on the heap.
     exit(exit_code);
     return exit_code;
 }

--- a/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Libraries/LibGUI/FileSystemModel.cpp
@@ -199,14 +199,14 @@ FileSystemModel::FileSystemModel(const StringView& root_path, Mode mode)
     : m_root_path(canonicalized_path(root_path))
     , m_mode(mode)
 {
-    m_directory_icon = GIcon::default_icon("filetype-folder");
-    m_file_icon = GIcon::default_icon("filetype-unknown");
-    m_symlink_icon = GIcon::default_icon("filetype-symlink");
-    m_socket_icon = GIcon::default_icon("filetype-socket");
-    m_executable_icon = GIcon::default_icon("filetype-executable");
-    m_filetype_image_icon = GIcon::default_icon("filetype-image");
-    m_filetype_sound_icon = GIcon::default_icon("filetype-sound");
-    m_filetype_html_icon = GIcon::default_icon("filetype-html");
+    m_directory_icon = Icon::default_icon("filetype-folder");
+    m_file_icon = Icon::default_icon("filetype-unknown");
+    m_symlink_icon = Icon::default_icon("filetype-symlink");
+    m_socket_icon = Icon::default_icon("filetype-socket");
+    m_executable_icon = Icon::default_icon("filetype-executable");
+    m_filetype_image_icon = Icon::default_icon("filetype-image");
+    m_filetype_sound_icon = Icon::default_icon("filetype-sound");
+    m_filetype_html_icon = Icon::default_icon("filetype-html");
 
     setpwent();
     while (auto* passwd = getpwent())
@@ -341,7 +341,7 @@ Variant FileSystemModel::data(const ModelIndex& index, Role role) const
     auto& node = this->node(index);
 
     if (role == Role::Custom) {
-        // For GFileSystemModel, custom role means the full path.
+        // For GUI::FileSystemModel, custom role means the full path.
         ASSERT(index.column() == Column::Name);
         return node.full_path(*this);
     }
@@ -409,7 +409,7 @@ Variant FileSystemModel::data(const ModelIndex& index, Role role) const
     return {};
 }
 
-GIcon FileSystemModel::icon_for_file(const mode_t mode, const String& name) const
+Icon FileSystemModel::icon_for_file(const mode_t mode, const String& name) const
 {
     if (S_ISDIR(mode))
         return m_directory_icon;
@@ -428,14 +428,14 @@ GIcon FileSystemModel::icon_for_file(const mode_t mode, const String& name) cons
     return m_file_icon;
 }
 
-GIcon FileSystemModel::icon_for(const Node& node) const
+Icon FileSystemModel::icon_for(const Node& node) const
 {
     if (node.name.to_lowercase().ends_with(".png")) {
         if (!node.thumbnail) {
             if (!const_cast<FileSystemModel*>(this)->fetch_thumbnail_for(node))
                 return m_filetype_image_icon;
         }
-        return GIcon(m_filetype_image_icon.bitmap_for_size(16), *node.thumbnail);
+        return GUI::Icon(m_filetype_image_icon.bitmap_for_size(16), *node.thumbnail);
     }
 
     return icon_for_file(node.mode, node.name);

--- a/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Libraries/LibGUI/FileSystemModel.cpp
@@ -95,7 +95,7 @@ void FileSystemModel::Node::traverse_if_needed(const FileSystemModel& model)
     auto full_path = this->full_path(model);
     Core::DirIterator di(full_path, Core::DirIterator::SkipDots);
     if (di.has_error()) {
-        fprintf(stderr, "CDirIterator: %s\n", di.error_string());
+        fprintf(stderr, "DirIterator: %s\n", di.error_string());
         return;
     }
 

--- a/Libraries/LibGUI/FileSystemModel.h
+++ b/Libraries/LibGUI/FileSystemModel.h
@@ -109,7 +109,7 @@ public:
     ModelIndex index(const StringView& path, int column) const;
 
     const Node& node(const ModelIndex& index) const;
-    GIcon icon_for_file(const mode_t mode, const String& name) const;
+    GUI::Icon icon_for_file(const mode_t mode, const String& name) const;
 
     Function<void(int done, int total)> on_thumbnail_progress;
     Function<void()> on_root_path_change;
@@ -141,20 +141,20 @@ private:
     HashMap<gid_t, String> m_group_names;
 
     bool fetch_thumbnail_for(const Node& node);
-    GIcon icon_for(const Node& node) const;
+    GUI::Icon icon_for(const Node& node) const;
 
     String m_root_path;
     Mode m_mode { Invalid };
     OwnPtr<Node> m_root { nullptr };
 
-    GIcon m_directory_icon;
-    GIcon m_file_icon;
-    GIcon m_symlink_icon;
-    GIcon m_socket_icon;
-    GIcon m_executable_icon;
-    GIcon m_filetype_image_icon;
-    GIcon m_filetype_sound_icon;
-    GIcon m_filetype_html_icon;
+    GUI::Icon m_directory_icon;
+    GUI::Icon m_file_icon;
+    GUI::Icon m_symlink_icon;
+    GUI::Icon m_socket_icon;
+    GUI::Icon m_executable_icon;
+    GUI::Icon m_filetype_image_icon;
+    GUI::Icon m_filetype_sound_icon;
+    GUI::Icon m_filetype_html_icon;
 
     unsigned m_thumbnail_progress { 0 };
     unsigned m_thumbnail_progress_total { 0 };

--- a/Libraries/LibGUI/FontDatabase.cpp
+++ b/Libraries/LibGUI/FontDatabase.cpp
@@ -32,16 +32,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static GFontDatabase* s_the;
+namespace GUI {
 
-GFontDatabase& GFontDatabase::the()
+static FontDatabase* s_the;
+
+FontDatabase& FontDatabase::the()
 {
     if (!s_the)
-        s_the = new GFontDatabase;
+        s_the = new FontDatabase;
     return *s_the;
 }
 
-GFontDatabase::GFontDatabase()
+FontDatabase::FontDatabase()
 {
     Core::DirIterator di("/res/fonts", Core::DirIterator::SkipDots);
     if (di.has_error()) {
@@ -61,11 +63,11 @@ GFontDatabase::GFontDatabase()
     }
 }
 
-GFontDatabase::~GFontDatabase()
+FontDatabase::~FontDatabase()
 {
 }
 
-void GFontDatabase::for_each_font(Function<void(const StringView&)> callback)
+void FontDatabase::for_each_font(Function<void(const StringView&)> callback)
 {
     Vector<String> names;
     names.ensure_capacity(m_name_to_metadata.size());
@@ -76,7 +78,7 @@ void GFontDatabase::for_each_font(Function<void(const StringView&)> callback)
         callback(name);
 }
 
-void GFontDatabase::for_each_fixed_width_font(Function<void(const StringView&)> callback)
+void FontDatabase::for_each_fixed_width_font(Function<void(const StringView&)> callback)
 {
     Vector<String> names;
     names.ensure_capacity(m_name_to_metadata.size());
@@ -89,10 +91,12 @@ void GFontDatabase::for_each_fixed_width_font(Function<void(const StringView&)> 
         callback(name);
 }
 
-RefPtr<Gfx::Font> GFontDatabase::get_by_name(const StringView& name)
+RefPtr<Gfx::Font> FontDatabase::get_by_name(const StringView& name)
 {
     auto it = m_name_to_metadata.find(name);
     if (it == m_name_to_metadata.end())
         return nullptr;
     return Gfx::Font::load_from_file((*it).value.path);
+}
+
 }

--- a/Libraries/LibGUI/FontDatabase.cpp
+++ b/Libraries/LibGUI/FontDatabase.cpp
@@ -45,7 +45,7 @@ GFontDatabase::GFontDatabase()
 {
     Core::DirIterator di("/res/fonts", Core::DirIterator::SkipDots);
     if (di.has_error()) {
-        fprintf(stderr, "CDirIterator: %s\n", di.error_string());
+        fprintf(stderr, "DirIterator: %s\n", di.error_string());
         exit(1);
     }
     while (di.has_next()) {

--- a/Libraries/LibGUI/FontDatabase.h
+++ b/Libraries/LibGUI/FontDatabase.h
@@ -31,15 +31,17 @@
 #include <AK/String.h>
 #include <LibGfx/Forward.h>
 
+namespace GUI {
+
 struct Metadata {
     String path;
     bool is_fixed_width;
     int glyph_height;
 };
 
-class GFontDatabase {
+class FontDatabase {
 public:
-    static GFontDatabase& the();
+    static FontDatabase& the();
 
     RefPtr<Gfx::Font> get_by_name(const StringView&);
     void for_each_font(Function<void(const StringView&)>);
@@ -51,8 +53,10 @@ public:
     }
 
 private:
-    GFontDatabase();
-    ~GFontDatabase();
+    FontDatabase();
+    ~FontDatabase();
 
     HashMap<String, Metadata> m_name_to_metadata;
 };
+
+}

--- a/Libraries/LibGUI/Icon.cpp
+++ b/Libraries/LibGUI/Icon.cpp
@@ -28,23 +28,25 @@
 #include <LibGUI/Icon.h>
 #include <LibGfx/Bitmap.h>
 
-GIcon::GIcon()
-    : m_impl(GIconImpl::create())
+namespace GUI {
+
+Icon::Icon()
+    : m_impl(IconImpl::create())
 {
 }
 
-GIcon::GIcon(const GIconImpl& impl)
-    : m_impl(const_cast<GIconImpl&>(impl))
+Icon::Icon(const IconImpl& impl)
+    : m_impl(const_cast<IconImpl&>(impl))
 {
 }
 
-GIcon::GIcon(const GIcon& other)
+Icon::Icon(const Icon& other)
     : m_impl(other.m_impl)
 {
 }
 
-GIcon::GIcon(RefPtr<Gfx::Bitmap>&& bitmap)
-    : GIcon()
+Icon::Icon(RefPtr<Gfx::Bitmap>&& bitmap)
+    : Icon()
 {
     if (bitmap) {
         ASSERT(bitmap->width() == bitmap->height());
@@ -53,8 +55,8 @@ GIcon::GIcon(RefPtr<Gfx::Bitmap>&& bitmap)
     }
 }
 
-GIcon::GIcon(RefPtr<Gfx::Bitmap>&& bitmap1, RefPtr<Gfx::Bitmap>&& bitmap2)
-    : GIcon(move(bitmap1))
+Icon::Icon(RefPtr<Gfx::Bitmap>&& bitmap1, RefPtr<Gfx::Bitmap>&& bitmap2)
+    : Icon(move(bitmap1))
 {
     if (bitmap2) {
         ASSERT(bitmap2->width() == bitmap2->height());
@@ -63,7 +65,7 @@ GIcon::GIcon(RefPtr<Gfx::Bitmap>&& bitmap1, RefPtr<Gfx::Bitmap>&& bitmap2)
     }
 }
 
-const Gfx::Bitmap* GIconImpl::bitmap_for_size(int size) const
+const Gfx::Bitmap* IconImpl::bitmap_for_size(int size) const
 {
     auto it = m_bitmaps.find(size);
     if (it != m_bitmaps.end())
@@ -81,7 +83,7 @@ const Gfx::Bitmap* GIconImpl::bitmap_for_size(int size) const
     return best_fit;
 }
 
-void GIconImpl::set_bitmap_for_size(int size, RefPtr<Gfx::Bitmap>&& bitmap)
+void IconImpl::set_bitmap_for_size(int size, RefPtr<Gfx::Bitmap>&& bitmap)
 {
     if (!bitmap) {
         m_bitmaps.remove(size);
@@ -90,9 +92,11 @@ void GIconImpl::set_bitmap_for_size(int size, RefPtr<Gfx::Bitmap>&& bitmap)
     m_bitmaps.set(size, move(bitmap));
 }
 
-GIcon GIcon::default_icon(const StringView& name)
+Icon Icon::default_icon(const StringView& name)
 {
     auto bitmap16 = Gfx::Bitmap::load_from_file(String::format("/res/icons/16x16/%s.png", String(name).characters()));
     auto bitmap32 = Gfx::Bitmap::load_from_file(String::format("/res/icons/32x32/%s.png", String(name).characters()));
-    return GIcon(move(bitmap16), move(bitmap32));
+    return Icon(move(bitmap16), move(bitmap32));
+}
+
 }

--- a/Libraries/LibGUI/Icon.h
+++ b/Libraries/LibGUI/Icon.h
@@ -31,31 +31,33 @@
 #include <AK/RefCounted.h>
 #include <LibGfx/Forward.h>
 
-class GIconImpl : public RefCounted<GIconImpl> {
+namespace GUI {
+
+class IconImpl : public RefCounted<IconImpl> {
 public:
-    static NonnullRefPtr<GIconImpl> create() { return adopt(*new GIconImpl); }
-    ~GIconImpl() {}
+    static NonnullRefPtr<IconImpl> create() { return adopt(*new IconImpl); }
+    ~IconImpl() {}
 
     const Gfx::Bitmap* bitmap_for_size(int) const;
     void set_bitmap_for_size(int, RefPtr<Gfx::Bitmap>&&);
 
 private:
-    GIconImpl() {}
+    IconImpl() {}
     HashMap<int, RefPtr<Gfx::Bitmap>> m_bitmaps;
 };
 
-class GIcon {
+class Icon {
 public:
-    GIcon();
-    explicit GIcon(RefPtr<Gfx::Bitmap>&&);
-    explicit GIcon(RefPtr<Gfx::Bitmap>&&, RefPtr<Gfx::Bitmap>&&);
-    explicit GIcon(const GIconImpl&);
-    GIcon(const GIcon&);
-    ~GIcon() {}
+    Icon();
+    explicit Icon(RefPtr<Gfx::Bitmap>&&);
+    explicit Icon(RefPtr<Gfx::Bitmap>&&, RefPtr<Gfx::Bitmap>&&);
+    explicit Icon(const IconImpl&);
+    Icon(const Icon&);
+    ~Icon() {}
 
-    static GIcon default_icon(const StringView&);
+    static Icon default_icon(const StringView&);
 
-    GIcon& operator=(const GIcon& other)
+    Icon& operator=(const Icon& other)
     {
         if (this != &other)
             m_impl = other.m_impl;
@@ -65,8 +67,10 @@ public:
     const Gfx::Bitmap* bitmap_for_size(int size) const { return m_impl->bitmap_for_size(size); }
     void set_bitmap_for_size(int size, RefPtr<Gfx::Bitmap>&& bitmap) { m_impl->set_bitmap_for_size(size, move(bitmap)); }
 
-    const GIconImpl& impl() const { return *m_impl; }
+    const IconImpl& impl() const { return *m_impl; }
 
 private:
-    NonnullRefPtr<GIconImpl> m_impl;
+    NonnullRefPtr<IconImpl> m_impl;
 };
+
+}

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -56,7 +56,7 @@ TextEditor::TextEditor(Type type)
     set_foreground_role(ColorRole::BaseText);
     set_document(TextDocument::create());
     set_scrollbars_enabled(is_multi_line());
-    set_font(GFontDatabase::the().get_by_name("Csilla Thin"));
+    set_font(FontDatabase::the().get_by_name("Csilla Thin"));
     // FIXME: Recompute vertical scrollbar step size on font change.
     vertical_scrollbar().set_step(line_height());
     m_cursor = { 0, 0 };

--- a/Libraries/LibGUI/Variant.cpp
+++ b/Libraries/LibGUI/Variant.cpp
@@ -190,10 +190,10 @@ Variant::Variant(const Gfx::Bitmap& value)
     AK::ref_if_not_null(m_value.as_bitmap);
 }
 
-Variant::Variant(const GIcon& value)
+Variant::Variant(const GUI::Icon& value)
     : m_type(Type::Icon)
 {
-    m_value.as_icon = &const_cast<GIconImpl&>(value.impl());
+    m_value.as_icon = &const_cast<GUI::IconImpl&>(value.impl());
     AK::ref_if_not_null(m_value.as_icon);
 }
 
@@ -398,7 +398,7 @@ String Variant::to_string() const
     case Type::Bitmap:
         return "[Gfx::Bitmap]";
     case Type::Icon:
-        return "[GIcon]";
+        return "[GUI::Icon]";
     case Type::Color:
         return as_color().to_string();
     case Type::Point:

--- a/Libraries/LibGUI/Variant.h
+++ b/Libraries/LibGUI/Variant.h
@@ -44,7 +44,7 @@ public:
     Variant(const char*);
     Variant(const String&);
     Variant(const Gfx::Bitmap&);
-    Variant(const GIcon&);
+    Variant(const GUI::Icon&);
     Variant(const Gfx::Point&);
     Variant(const Gfx::Size&);
     Variant(const Gfx::Rect&);
@@ -207,10 +207,10 @@ public:
         return *m_value.as_bitmap;
     }
 
-    GIcon as_icon() const
+    GUI::Icon as_icon() const
     {
         ASSERT(type() == Type::Icon);
-        return GIcon(*m_value.as_icon);
+        return GUI::Icon(*m_value.as_icon);
     }
 
     Color as_color() const
@@ -263,7 +263,7 @@ private:
     union {
         StringImpl* as_string;
         Gfx::Bitmap* as_bitmap;
-        GIconImpl* as_icon;
+        GUI::IconImpl* as_icon;
         Gfx::Font* as_font;
         bool as_bool;
         i32 as_i32;

--- a/Libraries/LibHTML/DOMTreeModel.h
+++ b/Libraries/LibHTML/DOMTreeModel.h
@@ -51,7 +51,7 @@ private:
 
     NonnullRefPtr<Document> m_document;
 
-    GIcon m_document_icon;
-    GIcon m_element_icon;
-    GIcon m_text_icon;
+    GUI::Icon m_document_icon;
+    GUI::Icon m_element_icon;
+    GUI::Icon m_text_icon;
 };

--- a/Servers/WindowServer/WindowType.h
+++ b/Servers/WindowServer/WindowType.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-// Keep this in sync with GWindowType.
+// Keep this in sync with GUI::WindowType.
 enum class WindowType {
     Invalid = 0,
     Normal,

--- a/Userland/cp.cpp
+++ b/Userland/cp.cpp
@@ -176,7 +176,7 @@ bool copy_directory(String src_path, String dst_path)
     }
     Core::DirIterator di(src_path, Core::DirIterator::SkipDots);
     if (di.has_error()) {
-        fprintf(stderr, "cp: CDirIterator: %s\n", di.error_string());
+        fprintf(stderr, "cp: DirIterator: %s\n", di.error_string());
         return false;
     }
     while (di.has_next()) {

--- a/Userland/pape.cpp
+++ b/Userland/pape.cpp
@@ -44,7 +44,7 @@ static int handle_show_all()
 {
     Core::DirIterator di("/res/wallpapers", Core::DirIterator::SkipDots);
     if (di.has_error()) {
-        fprintf(stderr, "CDirIterator: %s\n", di.error_string());
+        fprintf(stderr, "DirIterator: %s\n", di.error_string());
         return 1;
     }
 

--- a/Userland/sysctl.cpp
+++ b/Userland/sysctl.cpp
@@ -78,7 +78,7 @@ static int handle_show_all()
 {
     Core::DirIterator di("/proc/sys", Core::DirIterator::SkipDots);
     if (di.has_error()) {
-        fprintf(stderr, "CDirIterator: %s\n", di.error_string());
+        fprintf(stderr, "DirIterator: %s\n", di.error_string());
         return 1;
     }
 

--- a/Userland/tail.cpp
+++ b/Userland/tail.cpp
@@ -75,7 +75,7 @@ off_t find_seek_pos(Core::File& file, int wanted_lines)
     off_t end = pos;
     int lines = 0;
 
-    // FIXME: Reading char-by-char is only OK if CIODevice's read buffer
+    // FIXME: Reading char-by-char is only OK if IODevice's read buffer
     // is smart enough to not read char-by-char. Fix it there, or fix it here :)
     for (; pos >= 0; pos--) {
         file.seek(pos);


### PR DESCRIPTION
This also fixes a potential bug with using: C_OBJECT_ABSTRACT(GAbstractButton)
instead of C_OBJECT_ABSTRACT(AbstractButton)