### PR TITLE
Userland: Set the mask of a network adapter with ifconfig.

### DIFF
--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -485,6 +485,14 @@ int IPv4Socket::ioctl(FileDescription&, unsigned request, unsigned arg)
         adapter->set_ipv4_address(IPv4Address(((sockaddr_in&)ifr->ifr_addr).sin_addr.s_addr));
         return 0;
 
+    case SIOCSIFNETMASK:
+        if (!Process::current->is_superuser())
+            return -EPERM;
+        if (ifr->ifr_addr.sa_family != AF_INET)
+            return -EAFNOSUPPORT;
+        adapter->set_ipv4_netmask(IPv4Address(((sockaddr_in&)ifr->ifr_netmask).sin_addr.s_addr));
+        return 0;
+
     case SIOCGIFADDR:
         if (!Process::current->validate_write_typed(ifr))
             return -EFAULT;

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -501,6 +501,7 @@ struct ifreq {
         struct sockaddr ifru_addr;
         struct sockaddr ifru_dstaddr;
         struct sockaddr ifru_broadaddr;
+        struct sockaddr ifru_netmask;
         struct sockaddr ifru_hwaddr;
         short ifru_flags;
         int ifru_metric;
@@ -512,6 +513,7 @@ struct ifreq {
 #define ifr_addr ifr_ifru.ifru_addr           // address
 #define ifr_dstaddr ifr_ifru.ifru_dstaddr     // other end of p-to-p link
 #define ifr_broadaddr ifr_ifru.ifru_broadaddr // broadcast address
+#define ifr_netmask ifr_ifru.ifru_netmask     // network mask
 #define ifr_flags ifr_ifru.ifru_flags         // flags
 #define ifr_metric ifr_ifru.ifru_metric       // metric
 #define ifr_mtu ifr_ifru.ifru_metric          // mtu (overload)

--- a/Libraries/LibC/net/if.h
+++ b/Libraries/LibC/net/if.h
@@ -38,6 +38,7 @@ struct ifreq {
         struct sockaddr ifru_addr;
         struct sockaddr ifru_dstaddr;
         struct sockaddr ifru_broadaddr;
+        struct sockaddr ifru_netmask;
         struct sockaddr ifru_hwaddr;
         short ifru_flags;
         int ifru_metric;
@@ -49,6 +50,7 @@ struct ifreq {
 #define ifr_addr ifr_ifru.ifru_addr           // address
 #define ifr_dstaddr ifr_ifru.ifru_dstaddr     // other end of p-to-p link
 #define ifr_broadaddr ifr_ifru.ifru_broadaddr // broadcast address
+#define ifr_netmask ifr_ifru.ifru_netmask     // network mask
 #define ifr_flags ifr_ifru.ifru_flags         // flags
 #define ifr_metric ifr_ifru.ifru_metric       // metric
 #define ifr_mtu ifr_ifru.ifru_metric          // mtu (overload)

--- a/Libraries/LibC/net/route.h
+++ b/Libraries/LibC/net/route.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Marios Prokopakis <mariosprokopakis@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,43 +25,9 @@
  */
 
 #pragma once
+#include <sys/socket.h>
 
-#include <sys/cdefs.h>
-
-__BEGIN_DECLS
-
-struct winsize {
-    unsigned short ws_row;
-    unsigned short ws_col;
-};
-
-struct FBResolution {
-    int pitch;
-    int width;
-    int height;
-};
-
-__END_DECLS
-
-enum IOCtlNumber {
-    TIOCGPGRP,
-    TIOCSPGRP,
-    TCGETS,
-    TCSETS,
-    TCSETSW,
-    TCSETSF,
-    TIOCGWINSZ,
-    TIOCSCTTY,
-    TIOCNOTTY,
-    TIOCSWINSZ,
-    FB_IOCTL_GET_SIZE_IN_BYTES,
-    FB_IOCTL_GET_RESOLUTION,
-    FB_IOCTL_SET_RESOLUTION,
-    FB_IOCTL_GET_BUFFER,
-    FB_IOCTL_SET_BUFFER,
-    SIOCSIFADDR,
-    SIOCGIFADDR,
-    SIOCGIFHWADDR,
-    SIOCADDRT,
-    SIOCSIFNETMASK
+struct rtentry {
+    struct sockaddr* rt_gateway;
+    /* FIXME: complete the struct */
 };

--- a/Userland/ifconfig.cpp
+++ b/Userland/ifconfig.cpp
@@ -28,6 +28,7 @@
 #include <AK/JsonObject.h>
 #include <AK/String.h>
 #include <AK/Types.h>
+#include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <net/if.h>
 #include <netinet/in.h>
@@ -48,66 +49,124 @@ String si_bytes(unsigned bytes)
 
 int main(int argc, char** argv)
 {
-    if (argc == 3) {
-        String ifname = argv[1];
-        auto address = IPv4Address::from_string(argv[2]);
+    const char* value_ipv4 = nullptr;
+    const char* value_adapter = nullptr;
+    const char* value_gateway = nullptr;
+    const char* value_mask = nullptr;
 
-        if (!address.has_value()) {
-            fprintf(stderr, "Invalid IPv4 address: '%s'\n", argv[2]);
+    Core::ArgsParser args_parser;
+    args_parser.add_option(value_ipv4, "Set the IP address of the selected network", "ipv4", 'i', "The new IP of the network");
+    args_parser.add_option(value_adapter, "Select a specific network adapter to configure", "adapter", 'a', "The name of a network adapter");
+    args_parser.add_option(value_gateway, "Set the default gateway of the selected network", "gateway", 'g', "The new IP of the gateway");
+    args_parser.add_option(value_mask, "Set the network mask of the selected network", "mask", 'm', "The new network mask");
+    args_parser.parse(argc, argv);
+
+    if (!value_ipv4 && !value_adapter && !value_gateway && !value_mask) {
+
+        auto file = Core::File::construct("/proc/net/adapters");
+        if (!file->open(Core::IODevice::ReadOnly)) {
+            fprintf(stderr, "Error: %s\n", file->error_string());
             return 1;
         }
 
-        int fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
-        if (fd < 0) {
-            perror("socket");
+        auto file_contents = file->read_all();
+        auto json = JsonValue::from_string(file_contents).as_array();
+        json.for_each([](auto& value) {
+            auto if_object = value.as_object();
+
+            auto name = if_object.get("name").to_string();
+            auto class_name = if_object.get("class_name").to_string();
+            auto mac_address = if_object.get("mac_address").to_string();
+            auto ipv4_address = if_object.get("ipv4_address").to_string();
+            auto gateway = if_object.get("ipv4_gateway").to_string();
+            auto netmask = if_object.get("ipv4_netmask").to_string();
+            auto packets_in = if_object.get("packets_in").to_u32();
+            auto bytes_in = if_object.get("bytes_in").to_u32();
+            auto packets_out = if_object.get("packets_out").to_u32();
+            auto bytes_out = if_object.get("bytes_out").to_u32();
+            auto mtu = if_object.get("mtu").to_u32();
+
+            printf("%s:\n", name.characters());
+            printf("\tmac: %s\n", mac_address.characters());
+            printf("\tipv4: %s\n", ipv4_address.characters());
+            printf("\tnetmask: %s\n", netmask.characters());
+            printf("\tgateway: %s\n", gateway.characters());
+            printf("\tclass: %s\n", class_name.characters());
+            printf("\tRX: %u packets %u bytes (%s)\n", packets_in, bytes_in, si_bytes(bytes_in).characters());
+            printf("\tTX: %u packets %u bytes (%s)\n", packets_out, bytes_out, si_bytes(bytes_out).characters());
+            printf("\tMTU: %u\n", mtu);
+            printf("\n");
+        });
+    } else {
+
+        if (!value_adapter) {
+            fprintf(stderr, "No network adapter was specified.\n");
             return 1;
         }
 
-        struct ifreq ifr;
-        memset(&ifr, 0, sizeof(ifr));
+        String ifname = value_adapter;
 
-        strncpy(ifr.ifr_name, ifname.characters(), IFNAMSIZ);
-        ifr.ifr_addr.sa_family = AF_INET;
-        ((sockaddr_in&)ifr.ifr_addr).sin_addr.s_addr = address.value().to_in_addr_t();
+        if (value_ipv4) {
+            auto address = IPv4Address::from_string(value_ipv4);
 
-        int rc = ioctl(fd, SIOCSIFADDR, &ifr);
-        if (rc < 0) {
-            perror("ioctl(SIOCSIFADDR)");
+            if (!address.has_value()) {
+                fprintf(stderr, "Invalid IPv4 address: '%s'\n", value_ipv4);
+                return 1;
+            }
+
+            int fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+            if (fd < 0) {
+                perror("socket");
+                return 1;
+            }
+
+            struct ifreq ifr;
+            memset(&ifr, 0, sizeof(ifr));
+
+            strncpy(ifr.ifr_name, ifname.characters(), IFNAMSIZ);
+            ifr.ifr_addr.sa_family = AF_INET;
+            ((sockaddr_in&)ifr.ifr_addr).sin_addr.s_addr = address.value().to_in_addr_t();
+
+            int rc = ioctl(fd, SIOCSIFADDR, &ifr);
+            if (rc < 0) {
+                perror("ioctl(SIOCSIFADDR)");
+                return 1;
+            }
+        }
+
+        if (value_mask) {
+            auto address = IPv4Address::from_string(value_mask);
+
+            if (!address.has_value()) {
+                fprintf(stderr, "Invalid IPv4 mask: '%s'\n", value_mask);
+                return 1;
+            }
+
+            int fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+            if (fd < 0) {
+                perror("socket");
+                return 1;
+            }
+
+            struct ifreq ifr;
+            memset(&ifr, 0, sizeof(ifr));
+
+            strncpy(ifr.ifr_name, ifname.characters(), IFNAMSIZ);
+            ifr.ifr_netmask.sa_family = AF_INET;
+            ((sockaddr_in&)ifr.ifr_netmask).sin_addr.s_addr = address.value().to_in_addr_t();
+
+            int rc = ioctl(fd, SIOCSIFNETMASK, &ifr);
+            if (rc < 0) {
+                perror("ioctl(SIOCSIFNETMASK)");
+                return 1;
+            }
+        }
+
+        if (value_gateway) {
+            // ioctl does not support rtentry yet
+            fprintf(stderr, "Changing the gateway is not supported yet\n");
             return 1;
         }
-        return 0;
     }
-
-    auto file = Core::File::construct("/proc/net/adapters");
-    if (!file->open(Core::IODevice::ReadOnly)) {
-        fprintf(stderr, "Error: %s\n", file->error_string());
-        return 1;
-    }
-
-    auto file_contents = file->read_all();
-    auto json = JsonValue::from_string(file_contents).as_array();
-    json.for_each([](auto& value) {
-        auto if_object = value.as_object();
-
-        auto name = if_object.get("name").to_string();
-        auto class_name = if_object.get("class_name").to_string();
-        auto mac_address = if_object.get("mac_address").to_string();
-        auto ipv4_address = if_object.get("ipv4_address").to_string();
-        auto packets_in = if_object.get("packets_in").to_u32();
-        auto bytes_in = if_object.get("bytes_in").to_u32();
-        auto packets_out = if_object.get("packets_out").to_u32();
-        auto bytes_out = if_object.get("bytes_out").to_u32();
-        auto mtu = if_object.get("mtu").to_u32();
-
-        printf("%s:\n", name.characters());
-        printf("     mac: %s\n", mac_address.characters());
-        printf("    ipv4: %s\n", ipv4_address.characters());
-        printf("   class: %s\n", class_name.characters());
-        printf("      RX: %u packets %u bytes (%s)\n", packets_in, bytes_in, si_bytes(bytes_in).characters());
-        printf("      TX: %u packets %u bytes (%s)\n", packets_out, bytes_out, si_bytes(bytes_out).characters());
-        printf("     MTU: %u\n", mtu);
-        printf("\n");
-    });
-
     return 0;
 }


### PR DESCRIPTION
A partial fix to #702 since the changes are not retained after a reboot. Changing the gateway is not supported yet. I have added the `net/route.h` file to the LibC headers but it is not completed. The `ioctl` method of the `IPv4Socket` casts the `arg` to a `(ifreq*)` but to change the IP of the default gateway, a `rtentry*` must be used. Maybe this must be an issue of it's own?