### PR TITLE
LibJS: Minor operator improvements

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -200,17 +200,12 @@ Value LogicalExpression::execute(Interpreter& interpreter) const
 {
     auto lhs_result = m_lhs->execute(interpreter).as_bool();
 
-    if (m_op == LogicalOp::Not)
-        return Value(!lhs_result);
-
     auto rhs_result = m_rhs->execute(interpreter).as_bool();
     switch (m_op) {
     case LogicalOp::And:
         return Value(lhs_result && rhs_result);
     case LogicalOp::Or:
         return Value(lhs_result || rhs_result);
-    case LogicalOp::Not:
-        ASSERT_NOT_REACHED();
     }
 
     ASSERT_NOT_REACHED();
@@ -222,6 +217,8 @@ Value UnaryExpression::execute(Interpreter& interpreter) const
     switch (m_op) {
     case UnaryOp::BitNot:
         return bit_not(lhs_result);
+    case UnaryOp::Not:
+        return Value(!lhs_result.as_bool());
     }
 
     ASSERT_NOT_REACHED();
@@ -303,14 +300,6 @@ void LogicalExpression::dump(int indent) const
     case LogicalOp::Or:
         op_string = "||";
         break;
-    case LogicalOp::Not:
-        op_string = "!";
-        print_indent(indent);
-        printf("%s\n", class_name());
-        print_indent(indent + 1);
-        printf("%s\n", op_string);
-        m_lhs->dump(indent + 1);
-        return;
     }
 
     print_indent(indent);
@@ -327,6 +316,9 @@ void UnaryExpression::dump(int indent) const
     switch (m_op) {
     case UnaryOp::BitNot:
         op_string = "~";
+        break;
+    case UnaryOp::Not:
+        op_string = "!";
         break;
     }
 

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -108,6 +108,61 @@ const Value typed_eq(const Value lhs, const Value rhs)
     ASSERT_NOT_REACHED();
 }
 
+Value greater(Value lhs, Value rhs)
+{
+    ASSERT(lhs.is_number());
+    ASSERT(rhs.is_number());
+    return Value(lhs.as_double() > rhs.as_double());
+}
+
+Value smaller(Value lhs, Value rhs)
+{
+    ASSERT(lhs.is_number());
+    ASSERT(rhs.is_number());
+    return Value(lhs.as_double() < rhs.as_double());
+}
+
+Value bit_and(Value lhs, Value rhs)
+{
+    ASSERT(lhs.is_number());
+    ASSERT(rhs.is_number());
+    return Value((i32)lhs.as_double() & (i32)rhs.as_double());
+}
+
+Value bit_or(Value lhs, Value rhs)
+{
+    ASSERT(lhs.is_number());
+    ASSERT(rhs.is_number());
+    return Value((i32)lhs.as_double() | (i32)rhs.as_double());
+}
+
+Value bit_xor(Value lhs, Value rhs)
+{
+    ASSERT(lhs.is_number());
+    ASSERT(rhs.is_number());
+    return Value((i32)lhs.as_double() ^ (i32)rhs.as_double());
+}
+
+Value bit_not(Value lhs)
+{
+    ASSERT(lhs.is_number());
+    return Value(~(i32)lhs.as_double());
+}
+
+Value bit_left(Value lhs, Value rhs)
+{
+    ASSERT(lhs.is_number());
+    ASSERT(rhs.is_number());
+    return Value((i32)lhs.as_double() << (i32)rhs.as_double());
+}
+
+Value bit_right(Value lhs, Value rhs)
+{
+    ASSERT(lhs.is_number());
+    ASSERT(rhs.is_number());
+    return Value((i32)lhs.as_double() >> (i32)rhs.as_double());
+}
+
 Value BinaryExpression::execute(Interpreter& interpreter) const
 {
     auto lhs_result = m_lhs->execute(interpreter);
@@ -120,6 +175,22 @@ Value BinaryExpression::execute(Interpreter& interpreter) const
         return sub(lhs_result, rhs_result);
     case BinaryOp::TypedEquals:
         return typed_eq(lhs_result, rhs_result);
+    case BinaryOp::TypedInequals:
+        return Value(!typed_eq(lhs_result, rhs_result).as_bool());
+    case BinaryOp::Greater:
+        return greater(lhs_result, rhs_result);
+    case BinaryOp::Smaller:
+        return smaller(lhs_result, rhs_result);
+    case BinaryOp::BitAnd:
+        return bit_and(lhs_result, rhs_result);
+    case BinaryOp::BitOr:
+        return bit_or(lhs_result, rhs_result);
+    case BinaryOp::BitXor:
+        return bit_xor(lhs_result, rhs_result);
+    case BinaryOp::BitLeftShift:
+        return bit_left(lhs_result, rhs_result);
+    case BinaryOp::BitRightShift:
+        return bit_right(lhs_result, rhs_result);
     }
 
     ASSERT_NOT_REACHED();
@@ -140,6 +211,17 @@ Value LogicalExpression::execute(Interpreter& interpreter) const
         return Value(lhs_result || rhs_result);
     case LogicalOp::Not:
         ASSERT_NOT_REACHED();
+    }
+
+    ASSERT_NOT_REACHED();
+}
+
+Value UnaryExpression::execute(Interpreter& interpreter) const
+{
+    auto lhs_result = m_lhs->execute(interpreter);
+    switch (m_op) {
+    case UnaryOp::BitNot:
+        return bit_not(lhs_result);
     }
 
     ASSERT_NOT_REACHED();
@@ -177,6 +259,30 @@ void BinaryExpression::dump(int indent) const
     case BinaryOp::TypedEquals:
         op_string = "===";
         break;
+    case BinaryOp::TypedInequals:
+        op_string = "!==";
+        break;
+    case BinaryOp::Greater:
+        op_string = ">";
+        break;
+    case BinaryOp::Smaller:
+        op_string = "<";
+        break;
+    case BinaryOp::BitAnd:
+        op_string = "&";
+        break;
+    case BinaryOp::BitOr:
+        op_string = "|";
+        break;
+    case BinaryOp::BitXor:
+        op_string = "^";
+        break;
+    case BinaryOp::BitLeftShift:
+        op_string = "<<";
+        break;
+    case BinaryOp::BitRightShift:
+        op_string = ">>";
+        break;
     }
 
     print_indent(indent);
@@ -213,6 +319,22 @@ void LogicalExpression::dump(int indent) const
     print_indent(indent + 1);
     printf("%s\n", op_string);
     m_rhs->dump(indent + 1);
+}
+
+void UnaryExpression::dump(int indent) const
+{
+    const char* op_string = nullptr;
+    switch (m_op) {
+    case UnaryOp::BitNot:
+        op_string = "~";
+        break;
+    }
+
+    print_indent(indent);
+    printf("%s\n", class_name());
+    print_indent(indent + 1);
+    printf("%s\n", op_string);
+    m_lhs->dump(indent + 1);
 }
 
 void CallExpression::dump(int indent) const

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -188,7 +188,6 @@ private:
 enum class LogicalOp {
     And,
     Or,
-    Not
 };
 
 class LogicalExpression : public Expression {
@@ -200,13 +199,6 @@ public:
     {
     }
 
-    LogicalExpression(LogicalOp op, NonnullOwnPtr<Expression> lhs)
-        : m_op(op)
-        , m_lhs(move(lhs))
-    {
-        ASSERT(op == LogicalOp::Not);
-    }
-
     virtual Value execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
 
@@ -215,11 +207,12 @@ private:
 
     LogicalOp m_op;
     NonnullOwnPtr<Expression> m_lhs;
-    OwnPtr<Expression> m_rhs;
+    NonnullOwnPtr<Expression> m_rhs;
 };
 
 enum class UnaryOp {
     BitNot,
+    Not,
 };
 
 class UnaryExpression : public Expression {

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -155,6 +155,14 @@ enum class BinaryOp {
     Plus,
     Minus,
     TypedEquals,
+    TypedInequals,
+    Greater,
+    Smaller,
+    BitAnd,
+    BitOr,
+    BitXor,
+    BitLeftShift,
+    BitRightShift,
 };
 
 class BinaryExpression : public Expression {
@@ -208,6 +216,28 @@ private:
     LogicalOp m_op;
     NonnullOwnPtr<Expression> m_lhs;
     OwnPtr<Expression> m_rhs;
+};
+
+enum class UnaryOp {
+    BitNot,
+};
+
+class UnaryExpression : public Expression {
+public:
+    UnaryExpression(UnaryOp op, NonnullOwnPtr<Expression> lhs)
+        : m_op(op)
+        , m_lhs(move(lhs))
+    {
+    }
+
+    virtual Value execute(Interpreter&) const override;
+    virtual void dump(int indent) const override;
+
+private:
+    virtual const char* class_name() const override { return "UnaryExpression"; }
+
+    UnaryOp m_op;
+    NonnullOwnPtr<Expression> m_lhs;
 };
 
 class Literal : public Expression {


### PR DESCRIPTION
Just a small and simple patch that adds a few operators and moves the logical `not` operator to a new `UnaryExpression` class.