### PR TITLE
WindowServer: Control menu title font from menubar as a property of a Menu

### DIFF
--- a/Servers/WindowServer/Menu.cpp
+++ b/Servers/WindowServer/Menu.cpp
@@ -56,6 +56,16 @@ Menu::~Menu()
 {
 }
 
+void Menu::set_title_font(const Gfx::Font& font)
+{
+    m_title_font = &font;
+}
+
+const Gfx::Font& Menu::title_font() const
+{
+    return *m_title_font;
+}
+
 const Gfx::Font& Menu::font() const
 {
     return Gfx::Font::default_font();

--- a/Servers/WindowServer/Menu.h
+++ b/Servers/WindowServer/Menu.h
@@ -30,6 +30,7 @@
 #include <AK/String.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/Object.h>
+#include <LibGfx/Font.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
 #include <WindowServer/Cursor.h>
@@ -96,6 +97,8 @@ public:
 
     void draw();
     const Gfx::Font& font() const;
+    const Gfx::Font& title_font() const;
+    void set_title_font(const Gfx::Font& font);
 
     MenuItem* item_with_identifier(unsigned);
     void redraw();
@@ -118,6 +121,8 @@ public:
 
 private:
     virtual void event(Core::Event&) override;
+
+    RefPtr<Gfx::Font> m_title_font { &Gfx::Font::default_font() };
 
     void handle_mouse_move_event(const MouseEvent&);
     int visible_item_count() const;

--- a/Servers/WindowServer/MenuBar.cpp
+++ b/Servers/WindowServer/MenuBar.cpp
@@ -41,4 +41,15 @@ MenuBar::~MenuBar()
 {
 }
 
+void MenuBar::add_menu(Menu& menu)
+{
+    menu.set_menubar(this);
+
+    // NOTE: We assume that the first menu is the App menu, which has a bold font.
+    if (m_menus.is_empty())
+        menu.set_title_font(Gfx::Font::default_bold_font());
+
+    m_menus.append(&menu);
+}
+
 }

--- a/Servers/WindowServer/MenuBar.h
+++ b/Servers/WindowServer/MenuBar.h
@@ -41,11 +41,7 @@ public:
     ClientConnection& client() { return m_client; }
     const ClientConnection& client() const { return m_client; }
     int menubar_id() const { return m_menubar_id; }
-    void add_menu(Menu& menu)
-    {
-        menu.set_menubar(this);
-        m_menus.append(&menu);
-    }
+    void add_menu(Menu&);
 
     template<typename Callback>
     void for_each_menu(Callback callback)

--- a/Servers/WindowServer/MenuManager.cpp
+++ b/Servers/WindowServer/MenuManager.cpp
@@ -74,16 +74,6 @@ bool MenuManager::is_open(const Menu& menu) const
     return false;
 }
 
-const Gfx::Font& MenuManager::menu_font() const
-{
-    return Gfx::Font::default_font();
-}
-
-const Gfx::Font& MenuManager::app_menu_font() const
-{
-    return Gfx::Font::default_bold_font();
-}
-
 void MenuManager::draw()
 {
     auto& wm = WindowManager::the();
@@ -100,7 +90,7 @@ void MenuManager::draw()
 
     painter.fill_rect(menubar_rect, palette.window());
     painter.draw_line({ 0, menubar_rect.bottom() }, { menubar_rect.right(), menubar_rect.bottom() }, palette.threed_shadow1());
-    int index = 0;
+
     for_each_active_menubar_menu([&](Menu& menu) {
         Color text_color = palette.window_text();
         if (is_open(menu)) {
@@ -111,10 +101,9 @@ void MenuManager::draw()
         painter.draw_text(
             menu.text_rect_in_menubar(),
             menu.name(),
-            index == 1 ? app_menu_font() : menu_font(),
+            menu.title_font(),
             Gfx::TextAlignment::CenterLeft,
             text_color);
-        ++index;
         return IterationDecision::Continue;
     });
 
@@ -382,13 +371,11 @@ void MenuManager::set_current_menubar(MenuBar* menubar)
     dbg() << "[WM] Current menubar is now " << menubar;
 #endif
     Gfx::Point next_menu_location { MenuManager::menubar_menu_margin() / 2, 0 };
-    int index = 0;
     for_each_active_menubar_menu([&](Menu& menu) {
-        int text_width = index == 1 ? Gfx::Font::default_bold_font().width(menu.name()) : Gfx::Font::default_font().width(menu.name());
+        int text_width = menu.title_font().width(menu.name());
         menu.set_rect_in_menubar({ next_menu_location.x() - MenuManager::menubar_menu_margin() / 2, 0, text_width + MenuManager::menubar_menu_margin(), menubar_rect().height() - 1 });
         menu.set_text_rect_in_menubar({ next_menu_location, { text_width, menubar_rect().height() } });
         next_menu_location.move_by(menu.rect_in_menubar().width(), 0);
-        ++index;
         return IterationDecision::Continue;
     });
     refresh();

--- a/Servers/WindowServer/MenuManager.h
+++ b/Servers/WindowServer/MenuManager.h
@@ -95,9 +95,6 @@ public:
     void did_change_theme();
 
 private:
-    const Gfx::Font& menu_font() const;
-    const Gfx::Font& app_menu_font() const;
-
     void close_menus(const Vector<Menu*>&);
 
     const Window& window() const { return *m_window; }


### PR DESCRIPTION
It makes a little more sense for the menubar to control what the font of
the menu title is, as opposed to the menu manager. Menumanager now
simply uses the font that the menu wants it to use.