### PR TITLE
LibJS: Allow the choice of a scope of declaration for a variable

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -56,7 +56,7 @@ Value CallExpression::execute(Interpreter& interpreter) const
     auto* callee_object = callee.as_object();
     ASSERT(callee_object->is_function());
     auto& function = static_cast<Function&>(*callee_object);
-    return interpreter.run(function.body());
+    return interpreter.run(function.body(), ScopeType::Function);
 }
 
 Value ReturnStatement::execute(Interpreter& interpreter) const
@@ -385,18 +385,30 @@ void AssignmentExpression::dump(int indent) const
 
 Value VariableDeclaration::execute(Interpreter& interpreter) const
 {
-    interpreter.declare_variable(name().string());
+    interpreter.declare_variable(name().string(), m_declaration_type);
     if (m_initializer) {
         auto initalizer_result = m_initializer->execute(interpreter);
         interpreter.set_variable(name().string(), initalizer_result);
     }
+
     return js_undefined();
 }
 
-
 void VariableDeclaration::dump(int indent) const
 {
+    const char* op_string = nullptr;
+    switch (m_declaration_type) {
+    case DeclarationType::Let:
+        op_string = "Let";
+        break;
+    case DeclarationType::Var:
+        op_string = "Var";
+        break;
+    }
+
     ASTNode::dump(indent);
+    print_indent(indent + 1);
+    printf("%s\n", op_string);
     m_name->dump(indent + 1);
     if (m_initializer)
         m_initializer->dump(indent + 1);

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -332,10 +332,16 @@ private:
     NonnullOwnPtr<Expression> m_rhs;
 };
 
+enum class DeclarationType {
+    Var,
+    Let,
+};
+
 class VariableDeclaration : public ASTNode {
 public:
-    VariableDeclaration(NonnullOwnPtr<Identifier> name, OwnPtr<Expression> initializer)
-        : m_name(move(name))
+    VariableDeclaration(NonnullOwnPtr<Identifier> name, OwnPtr<Expression> initializer, DeclarationType declaration_type)
+        : m_declaration_type(declaration_type)
+        , m_name(move(name))
         , m_initializer(move(initializer))
     {
     }
@@ -348,6 +354,7 @@ public:
 private:
     virtual const char* class_name() const override { return "VariableDeclaration"; }
 
+    DeclarationType m_declaration_type;
     NonnullOwnPtr<Identifier> m_name;
     OwnPtr<Expression> m_initializer;
 };

--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -36,5 +36,6 @@ class Interpreter;
 class Object;
 class ScopeNode;
 class Value;
+enum class DeclarationType;
 
 }

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -33,7 +33,13 @@
 
 namespace JS {
 
+enum class ScopeType {
+    Function,
+    Block,
+};
+
 struct ScopeFrame {
+    ScopeType type;
     const ScopeNode& scope_node;
     HashMap<String, Value> variables;
 };
@@ -43,7 +49,7 @@ public:
     Interpreter();
     ~Interpreter();
 
-    Value run(const ScopeNode&);
+    Value run(const ScopeNode&, ScopeType = ScopeType::Block);
 
     Object& global_object() { return *m_global_object; }
     const Object& global_object() const { return *m_global_object; }
@@ -54,12 +60,12 @@ public:
 
     Value get_variable(const String& name);
     void set_variable(String name, Value);
-    void declare_variable(String name);
+    void declare_variable(String name, DeclarationType);
 
     void collect_roots(Badge<Heap>, HashTable<Cell*>&);
 
 private:
-    void enter_scope(const ScopeNode&);
+    void enter_scope(const ScopeNode&, ScopeType);
     void exit_scope(const ScopeNode&);
 
     Heap m_heap;

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -31,7 +31,7 @@
 #include <LibJS/Value.h>
 #include <stdio.h>
 
-#define PROGRAM 2
+#define PROGRAM 4
 
 static void build_program(JS::Program&);
 
@@ -91,10 +91,12 @@ void build_program(JS::Program& program)
     auto block = make<JS::BlockStatement>();
     block->append<JS::VariableDeclaration>(
         make<JS::Identifier>("a"),
-        make<JS::Literal>(JS::Value(5)));
+        make<JS::Literal>(JS::Value(5)),
+        JS::DeclarationType::Var);
     block->append<JS::VariableDeclaration>(
         make<JS::Identifier>("b"),
-        make<JS::Literal>(JS::Value(7)));
+        make<JS::Literal>(JS::Value(7)),
+        JS::DeclarationType::Var);
 
     block->append<JS::ReturnStatement>(
         make<JS::BinaryExpression>(
@@ -119,10 +121,35 @@ void build_program(JS::Program& program)
     auto block = make<JS::BlockStatement>();
     block->append<JS::VariableDeclaration>(
         make<JS::Identifier>("x"),
-        make<JS::ObjectExpression>());
+        make<JS::ObjectExpression>(),
+        JS::DeclarationType::Var);
     block->append<JS::CallExpression>("$gc");
 
     program.append<JS::FunctionDeclaration>("foo", move(block));
+    program.append<JS::CallExpression>("foo");
+}
+#elif PROGRAM == 4
+void build_program(JS::Program& program)
+{
+    // function foo() {
+    //   function bar() {
+    //      var y = 6;
+    //   }
+    //
+    //   bar()
+    //   return y;
+    // }
+    // foo(); //I should return `undefined` because y is bound to the inner-most enclosing function, i.e the nested one (bar()), therefore, it's undefined in the scope of foo()
+
+    auto block_bar = make<JS::BlockStatement>();
+    block_bar->append<JS::VariableDeclaration>(make<JS::Identifier>("y"), make<JS::Literal>(JS::Value(6)), JS::DeclarationType::Var);
+
+    auto block_foo = make<JS::BlockStatement>();
+    block_foo->append<JS::FunctionDeclaration>("bar", move(block_bar));
+    block_foo->append<JS::CallExpression>("bar");
+    block_foo->append<JS::ReturnStatement>(make<JS::Identifier>("y"));
+
+    program.append<JS::FunctionDeclaration>("foo", move(block_foo));
     program.append<JS::CallExpression>("foo");
 }
 #endif


### PR DESCRIPTION
This patch implements `let` and `var`, and the block-scope and function scope respectively for both.

Here are some edge cases:

- If we cannot find an enclosing function for a `var` variable: we assign it to the global object.
- The binding of a  variable to the global object if it is set without being declared still works normally. 