### PR TITLE
LibGUI: Don't update windows that aren't visible.

### DIFF
--- a/Libraries/LibGUI/Window.cpp
+++ b/Libraries/LibGUI/Window.cpp
@@ -348,6 +348,8 @@ void Window::update()
 
 void Window::force_update()
 {
+    if (!this->is_visible())
+        return;
     auto rect = this->rect();
     WindowServerConnection::the().post_message(Messages::WindowServer::InvalidateRect(m_window_id, { { 0, 0, rect.width(), rect.height() } }, true));
 }
@@ -633,8 +635,8 @@ void Window::schedule_relayout()
 
 void Window::update_all_windows(Badge<WindowServerConnection>)
 {
-    for (auto* window : *all_windows) {
-        window->force_update();
+    for (auto& e : *reified_windows) {
+        e.value->force_update();
     }
 }
 


### PR DESCRIPTION
Because the ID of a hidden window is 0, the window server will fail to update them when the system theme is changed. When an application has multiple windows, some of which are hidden, and the system theme is changed (see
https://github.com/SerenityOS/serenity/issues/1378).

This PR changes the window code to ignore update messages if the window has the ID 0--is hidden.

Ideally the window ID would not change, and visibility would be managed separately.