### PR TITLE
LibGUI: Syntax highlight string escape sequences

### DIFF
--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -46,6 +46,7 @@ namespace GUI {
     __TOKEN(Semicolon)             \
     __TOKEN(DoubleQuotedString)    \
     __TOKEN(SingleQuotedString)    \
+    __TOKEN(EscapeSequence)        \
     __TOKEN(Comment)               \
     __TOKEN(Number)                \
     __TOKEN(Keyword)               \

--- a/Libraries/LibGUI/CppSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/CppSyntaxHighlighter.cpp
@@ -23,6 +23,8 @@ static TextStyle style_for_token_type(CppToken::Type type)
     case CppToken::Type::SingleQuotedString:
     case CppToken::Type::Number:
         return { Color::from_rgb(0x800000) };
+    case CppToken::Type::EscapeSequence:
+        return { Color::from_rgb(0x800080), &Gfx::Font::default_bold_fixed_width_font() };
     case CppToken::Type::PreprocessorStatement:
         return { Color::from_rgb(0x008080) };
     case CppToken::Type::Comment:


### PR DESCRIPTION
Added syntax highlighting for escape sequences in single and double quoted strings:

![Highlight](https://user-images.githubusercontent.com/62019142/76356338-73220700-631e-11ea-8c33-30ad02134c07.png)

Not sure if there's any implementation specific ones in Serenity that I missed.