### PR TITLE
Terminal: Make the settings window unresizable

### DIFF
--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -131,6 +131,7 @@ RefPtr<GUI::Window> create_settings_window(TerminalWidget& terminal)
 {
     auto window = GUI::Window::construct();
     window->set_title("Terminal Settings");
+    window->set_resizable(false);
     window->set_rect(50, 50, 200, 140);
     window->set_modal(true);
 


### PR DESCRIPTION
This window looks a bit weird on larger sizes. I don't think there's a need to be able to resize this, so just make it unresizable.