### PR TITLE
LibGUI: Highlight various number literals

### DIFF
--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -48,7 +48,8 @@ namespace GUI {
     __TOKEN(SingleQuotedString)    \
     __TOKEN(EscapeSequence)        \
     __TOKEN(Comment)               \
-    __TOKEN(Number)                \
+    __TOKEN(Integer)               \
+    __TOKEN(Float)                 \
     __TOKEN(Keyword)               \
     __TOKEN(KnownType)             \
     __TOKEN(Identifier)

--- a/Libraries/LibGUI/CppSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/CppSyntaxHighlighter.cpp
@@ -21,7 +21,8 @@ static TextStyle style_for_token_type(CppToken::Type type)
         return { Color::from_rgb(0x092e64) };
     case CppToken::Type::DoubleQuotedString:
     case CppToken::Type::SingleQuotedString:
-    case CppToken::Type::Number:
+    case CppToken::Type::Integer:
+    case CppToken::Type::Float:
         return { Color::from_rgb(0x800000) };
     case CppToken::Type::EscapeSequence:
         return { Color::from_rgb(0x800080), &Gfx::Font::default_bold_fixed_width_font() };


### PR DESCRIPTION
Now highlights all kinds of various number literals as a single token, including: binary and hex numbers, digit separators, float exponents and type specifiers.

![Literals](https://user-images.githubusercontent.com/62019142/76451137-a379ac00-63d7-11ea-9222-6e5991d49756.png)
