### PR TITLE
HackStudio: Add header navigation

### DIFF
--- a/DevTools/HackStudio/Editor.h
+++ b/DevTools/HackStudio/Editor.h
@@ -37,6 +37,7 @@ public:
     virtual ~Editor() override;
 
     Function<void()> on_focus;
+    Function<void(String)> on_open;
 
     EditorWrapper& wrapper();
     const EditorWrapper& wrapper() const;
@@ -46,8 +47,10 @@ private:
     virtual void focusout_event(Core::Event&) override;
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;
+    virtual void mousedown_event(GUI::MouseEvent&) override;
 
     void show_documentation_tooltip_if_available(const String&, const Gfx::Point& screen_location);
+    void navigate_to_include_if_available(String);
 
     explicit Editor();
 

--- a/DevTools/HackStudio/EditorWrapper.cpp
+++ b/DevTools/HackStudio/EditorWrapper.cpp
@@ -33,6 +33,7 @@
 #include <LibGfx/Font.h>
 
 extern RefPtr<EditorWrapper> g_current_editor_wrapper;
+extern Function<void(String)> g_open_file;
 
 EditorWrapper::EditorWrapper()
 {
@@ -66,6 +67,10 @@ EditorWrapper::EditorWrapper()
 
     m_editor->on_focus = [this] {
         g_current_editor_wrapper = this;
+    };
+
+    m_editor->on_open = [this](String path) {
+        g_open_file(path);
     };
 }
 

--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -35,6 +35,8 @@ namespace GUI {
     __TOKEN(Unknown)               \
     __TOKEN(Whitespace)            \
     __TOKEN(PreprocessorStatement) \
+    __TOKEN(IncludeStatement)      \
+    __TOKEN(IncludePath)           \
     __TOKEN(LeftParen)             \
     __TOKEN(RightParen)            \
     __TOKEN(LeftCurly)             \

--- a/Libraries/LibGUI/CppSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/CppSyntaxHighlighter.cpp
@@ -23,10 +23,12 @@ static TextStyle style_for_token_type(CppToken::Type type)
     case CppToken::Type::SingleQuotedString:
     case CppToken::Type::Integer:
     case CppToken::Type::Float:
+    case CppToken::Type::IncludePath:
         return { Color::from_rgb(0x800000) };
     case CppToken::Type::EscapeSequence:
         return { Color::from_rgb(0x800080), &Gfx::Font::default_bold_fixed_width_font() };
     case CppToken::Type::PreprocessorStatement:
+    case CppToken::Type::IncludeStatement:
         return { Color::from_rgb(0x008080) };
     case CppToken::Type::Comment:
         return { Color::from_rgb(0x008000) };


### PR DESCRIPTION
Ctrl+clicking an include statement in C++ code now opens the header file. If the header is not part of the project, the document is readonly.

![Navigate](https://user-images.githubusercontent.com/62019142/76469552-29591f80-63f7-11ea-9d74-4754e38c0ac2.gif)
