### PR TITLE
LibJS: Fix string roots not being collected

### DIFF
--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -122,8 +122,8 @@ void Interpreter::collect_roots(Badge<Heap>, HashTable<Cell*>& roots)
 
     for (auto& scope : m_scope_stack) {
         for (auto& it : scope.variables) {
-            if (it.value.is_object())
-                roots.set(it.value.as_object());
+            if (it.value.is_cell())
+                roots.set(it.value.as_cell());
         }
     }
 }


### PR DESCRIPTION
Previously objects were the only heap allocated value. Now there are also strings.

This replaces a usage of is_object with is_cell.
Without this change strings could be garbage collected while still being used in an active scope.

Reproduce with:
```cpp
void build_program(JS::Program& program, JS::Heap& heap)
{
    // function foo() {
    //   var s = "hello friends";
    //   $gc();
    //   s.length;
    // }
    // foo();

    auto block_foo = make<JS::BlockStatement>();
    block_foo->append<JS::VariableDeclaration>(
        make<JS::Identifier>("s"),
        make<JS::Literal>(JS::Value(js_string(heap, "hello friends"))),
        JS::DeclarationType::Var);

    block_foo->append<JS::CallExpression>("$gc");

    block_foo->append<JS::MemberExpression>(
        make<JS::Identifier>("s"),
        make<JS::Identifier>("length"));

    program.append<JS::FunctionDeclaration>("foo", move(block_foo));
    program.append<JS::CallExpression>("foo");
}
```

Before:
![image](https://user-images.githubusercontent.com/2600682/76477634-49dca600-6406-11ea-970e-e9ed037ef612.png)

After:
![image](https://user-images.githubusercontent.com/2600682/76477866-ee5ee800-6406-11ea-9072-863ce462d338.png)
