### PR TITLE
LibGUI: Track window visibility with a separate flag.

### DIFF
--- a/Libraries/LibGUI/Window.h
+++ b/Libraries/LibGUI/Window.h
@@ -221,6 +221,7 @@ private:
     bool m_show_titlebar { true };
     bool m_layout_pending { false };
     bool m_visible_for_timer_purposes { true };
+    bool m_visible { false };
 };
 
 }


### PR DESCRIPTION
LibGUI: Track client window visibility with separate flag.

This decouples window IDs and window visibility.