### PR TITLE
LibJS: Update expressions and scoping improvements

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -367,6 +367,25 @@ Value AssignmentExpression::execute(Interpreter& interpreter) const
     return rhs_result;
 }
 
+Value UpdateExpression::execute(Interpreter& interpreter) const
+{
+    ASSERT(m_argument->is_identifier());
+    auto name = static_cast<const Identifier&>(*m_argument).string();
+
+    auto previous_value = interpreter.get_variable(name);
+    ASSERT(previous_value.is_number());
+
+    switch (m_op) {
+    case UpdateOp::Increment:
+        interpreter.set_variable(name, Value(previous_value.as_double() + 1));
+        break;
+    case UpdateOp::Decrement:
+        interpreter.set_variable(name, Value(previous_value.as_double() - 1));
+    }
+
+    return previous_value;
+}
+
 void AssignmentExpression::dump(int indent) const
 {
     const char* op_string = nullptr;
@@ -381,6 +400,24 @@ void AssignmentExpression::dump(int indent) const
     printf("%s\n", op_string);
     m_lhs->dump(indent + 1);
     m_rhs->dump(indent + 1);
+}
+
+void UpdateExpression::dump(int indent) const
+{
+    const char* op_string = nullptr;
+    switch (m_op) {
+    case UpdateOp::Increment:
+        op_string = "++";
+        break;
+    case UpdateOp::Decrement:
+        op_string = "--";
+        break;
+    }
+
+    ASTNode::dump(indent);
+    print_indent(indent + 1);
+    printf("%s\n", op_string);
+    m_argument->dump(indent + 1);
 }
 
 Value VariableDeclaration::execute(Interpreter& interpreter) const

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -381,6 +381,7 @@ Value UpdateExpression::execute(Interpreter& interpreter) const
         break;
     case UpdateOp::Decrement:
         interpreter.set_variable(name, Value(previous_value.as_double() - 1));
+        break;
     }
 
     return previous_value;
@@ -433,19 +434,22 @@ Value VariableDeclaration::execute(Interpreter& interpreter) const
 
 void VariableDeclaration::dump(int indent) const
 {
-    const char* op_string = nullptr;
+    const char* declaration_type_string = nullptr;
     switch (m_declaration_type) {
     case DeclarationType::Let:
-        op_string = "Let";
+        declaration_type_string = "Let";
         break;
     case DeclarationType::Var:
-        op_string = "Var";
+        declaration_type_string = "Var";
+        break;
+    case DeclarationType::Const:
+        declaration_type_string = "Const";
         break;
     }
 
     ASTNode::dump(indent);
     print_indent(indent + 1);
-    printf("%s\n", op_string);
+    printf("%s\n", declaration_type_string);
     m_name->dump(indent + 1);
     if (m_initializer)
         m_initializer->dump(indent + 1);

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -435,6 +435,7 @@ private:
 enum class DeclarationType {
     Var,
     Let,
+    Const,
 };
 
 class VariableDeclaration : public Statement {

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -409,6 +409,29 @@ private:
     NonnullOwnPtr<Expression> m_rhs;
 };
 
+enum class UpdateOp {
+    Increment,
+    Decrement,
+};
+
+class UpdateExpression : public Expression {
+public:
+    UpdateExpression(UpdateOp op, NonnullOwnPtr<Expression> argument)
+        : m_op(op)
+        , m_argument(move(argument))
+    {
+    }
+
+    virtual Value execute(Interpreter&) const override;
+    virtual void dump(int indent) const override;
+
+private:
+    virtual const char* class_name() const override { return "UpdateExpression"; }
+
+    UpdateOp m_op;
+    NonnullOwnPtr<Identifier> m_argument;
+};
+
 enum class DeclarationType {
     Var,
     Let,

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -30,6 +30,7 @@
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap.h>
+#include <LibJS/Value.h>
 
 namespace JS {
 
@@ -38,10 +39,15 @@ enum class ScopeType {
     Block,
 };
 
+struct Variable {
+    Value value;
+    DeclarationType declaration_type;
+};
+
 struct ScopeFrame {
     ScopeType type;
     const ScopeNode& scope_node;
-    HashMap<String, Value> variables;
+    HashMap<String, Variable> variables;
 };
 
 class Interpreter {

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -136,6 +136,12 @@ NonnullOwnPtr<Expression> Parser::parse_secondary_expression(NonnullOwnPtr<Expre
     case TokenType::Period:
         consume();
         return make<MemberExpression>(move(lhs), parse_expression());
+    case TokenType::PlusPlus:
+        consume();
+        return make<UpdateExpression>(UpdateOp::Increment, move(lhs));
+    case TokenType::MinusMinus:
+        consume();
+        return make<UpdateExpression>(UpdateOp::Decrement, move(lhs));
     default:
         m_has_errors = true;
         expected("secondary expression (missing switch case)");
@@ -257,7 +263,9 @@ bool Parser::match_secondary_expression() const
         || type == TokenType::Slash
         || type == TokenType::Equals
         || type == TokenType::ParenOpen
-        || type == TokenType::Period;
+        || type == TokenType::Period
+        || type == TokenType::PlusPlus
+        || type == TokenType::MinusMinus;
 }
 
 bool Parser::match_statement() const

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -66,6 +66,7 @@ NonnullOwnPtr<Statement> Parser::parse_statement()
         return parse_return_statement();
     case TokenType::Var:
     case TokenType::Let:
+    case TokenType::Const:
         return parse_variable_declaration();
     default:
         m_has_errors = true;
@@ -222,6 +223,10 @@ NonnullOwnPtr<VariableDeclaration> Parser::parse_variable_declaration()
     case TokenType::Let:
         declaration_type = DeclarationType::Let;
         consume(TokenType::Let);
+        break;
+    case TokenType::Const:
+        declaration_type = DeclarationType::Const;
+        consume(TokenType::Const);
         break;
     default:
         ASSERT_NOT_REACHED();

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -65,6 +65,7 @@ NonnullOwnPtr<Statement> Parser::parse_statement()
     case TokenType::Return:
         return parse_return_statement();
     case TokenType::Var:
+    case TokenType::Let:
         return parse_variable_declaration();
     default:
         m_has_errors = true;
@@ -205,14 +206,27 @@ NonnullOwnPtr<FunctionDeclaration> Parser::parse_function_declaration()
 
 NonnullOwnPtr<VariableDeclaration> Parser::parse_variable_declaration()
 {
-    consume(TokenType::Var);
+    DeclarationType declaration_type;
+
+    switch (m_current_token.type()) {
+    case TokenType::Var:
+        declaration_type = DeclarationType::Var;
+        consume(TokenType::Var);
+        break;
+    case TokenType::Let:
+        declaration_type = DeclarationType::Let;
+        consume(TokenType::Let);
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+    }
     auto name = consume(TokenType::Identifier).value();
     OwnPtr<Expression> initializer;
     if (match(TokenType::Equals)) {
         consume();
         initializer = parse_expression();
     }
-    return make<VariableDeclaration>(make<Identifier>(name), move(initializer), DeclarationType::Var);
+    return make<VariableDeclaration>(make<Identifier>(name), move(initializer), declaration_type);
 }
 
 bool Parser::match(TokenType type) const


### PR DESCRIPTION
This patch introduces:

- `Let` variable parsing
- `Const` variables
- Update expressions (i.e increment and decrement)