### PR TITLE
HackStudio: Underline header links

### DIFF
--- a/DevTools/HackStudio/Editor.h
+++ b/DevTools/HackStudio/Editor.h
@@ -48,6 +48,8 @@ private:
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
+    virtual void keydown_event(GUI::KeyEvent&) override;
+    virtual void keyup_event(GUI::KeyEvent&) override;
 
     void show_documentation_tooltip_if_available(const String&, const Gfx::Point& screen_location);
     void navigate_to_include_if_available(String);
@@ -57,4 +59,7 @@ private:
     RefPtr<GUI::Window> m_documentation_tooltip_window;
     RefPtr<Web::HtmlView> m_documentation_html_view;
     String m_last_parsed_token;
+    GUI::TextPosition m_previous_text_position { 0, 0 };
+    bool m_hovering_link { false };
+    bool m_holding_ctrl { false };
 };

--- a/Libraries/LibGUI/CppSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/CppSyntaxHighlighter.cpp
@@ -56,7 +56,7 @@ void CppSyntaxHighlighter::rehighlight()
         span.color = style.color;
         span.font = style.font;
         span.is_skippable = token.m_type == CppToken::Type::Whitespace;
-        span.data = (void*)token.m_type;
+        span.data = reinterpret_cast<void*>(token.m_type);
         spans.append(span);
     }
     m_editor->document().set_spans(spans);

--- a/Libraries/LibGUI/CppSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/CppSyntaxHighlighter.cpp
@@ -37,6 +37,18 @@ static TextStyle style_for_token_type(CppToken::Type type)
     }
 }
 
+bool CppSyntaxHighlighter::is_identifier(void* token) const
+{
+    auto cpp_token = static_cast<GUI::CppToken::Type>(reinterpret_cast<size_t>(token));
+    return cpp_token == GUI::CppToken::Type::Identifier;
+}
+
+bool CppSyntaxHighlighter::is_navigatable(void* token) const
+{
+    auto cpp_token = static_cast<GUI::CppToken::Type>(reinterpret_cast<size_t>(token));
+    return cpp_token == GUI::CppToken::Type::IncludePath;
+}
+
 void CppSyntaxHighlighter::rehighlight()
 {
     ASSERT(m_editor);

--- a/Libraries/LibGUI/CppSyntaxHighlighter.h
+++ b/Libraries/LibGUI/CppSyntaxHighlighter.h
@@ -7,8 +7,9 @@ namespace GUI {
 class CppSyntaxHighlighter final : public SyntaxHighlighter {
 public:
     CppSyntaxHighlighter() {}
-
     virtual ~CppSyntaxHighlighter() override;
+
+    virtual SyntaxLanguage language() const override { return SyntaxLanguage::Cpp; }
     virtual void rehighlight() override;
     virtual void highlight_matching_token_pair() override;
 };

--- a/Libraries/LibGUI/CppSyntaxHighlighter.h
+++ b/Libraries/LibGUI/CppSyntaxHighlighter.h
@@ -9,6 +9,9 @@ public:
     CppSyntaxHighlighter() {}
     virtual ~CppSyntaxHighlighter() override;
 
+    virtual bool is_identifier(void*) const override;
+    virtual bool is_navigatable(void*) const override;
+
     virtual SyntaxLanguage language() const override { return SyntaxLanguage::Cpp; }
     virtual void rehighlight() override;
     virtual void highlight_matching_token_pair() override;

--- a/Libraries/LibGUI/SyntaxHighlighter.h
+++ b/Libraries/LibGUI/SyntaxHighlighter.h
@@ -22,6 +22,9 @@ public:
     virtual void rehighlight() = 0;
     virtual void highlight_matching_token_pair() = 0;
 
+    virtual bool is_identifier(void*) const { return false; };
+    virtual bool is_navigatable(void*) const { return false; };
+
     void attach(TextEditor& editor);
     void detach();
     void cursor_did_change();

--- a/Libraries/LibGUI/SyntaxHighlighter.h
+++ b/Libraries/LibGUI/SyntaxHighlighter.h
@@ -6,6 +6,11 @@
 
 namespace GUI {
 
+enum class SyntaxLanguage {
+    PlainText,
+    Cpp
+};
+
 class SyntaxHighlighter {
     AK_MAKE_NONCOPYABLE(SyntaxHighlighter);
     AK_MAKE_NONMOVABLE(SyntaxHighlighter);
@@ -13,6 +18,7 @@ class SyntaxHighlighter {
 public:
     virtual ~SyntaxHighlighter();
 
+    virtual SyntaxLanguage language() const = 0;
     virtual void rehighlight() = 0;
     virtual void highlight_matching_token_pair() = 0;
 

--- a/Libraries/LibGUI/TextDocument.h
+++ b/Libraries/LibGUI/TextDocument.h
@@ -46,6 +46,7 @@ struct TextDocumentSpan {
     Color color;
     Optional<Color> background_color;
     bool is_skippable { false };
+    bool is_underlined { false };
     const Gfx::Font* font { nullptr };
     void* data { nullptr };
 };
@@ -87,6 +88,7 @@ public:
     NonnullOwnPtrVector<TextDocumentLine>& lines() { return m_lines; }
 
     bool has_spans() const { return !m_spans.is_empty(); }
+    Vector<TextDocumentSpan>& spans() { return m_spans; }
     const Vector<TextDocumentSpan>& spans() const { return m_spans; }
     void set_span_at_index(size_t index, TextDocumentSpan span) { m_spans[index] = move(span); }
 

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -1497,10 +1497,7 @@ void TextEditor::flush_pending_change_notification_if_needed()
 
 const SyntaxHighlighter* TextEditor::syntax_highlighter() const
 {
-    if (m_highlighter)
-        return m_highlighter.ptr();
-    else
-        return nullptr;
+    return m_highlighter.ptr();
 }
 
 void TextEditor::set_syntax_highlighter(OwnPtr<SyntaxHighlighter> highlighter)

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -425,6 +425,7 @@ void TextEditor::paint_event(PaintEvent& event)
                     const Gfx::Font* font = &this->font();
                     Color color;
                     Optional<Color> background_color;
+                    bool underline = false;
                     TextPosition physical_position(line_index, start_of_visual_line + i);
                     // FIXME: This is *horribly* inefficient.
                     for (auto& span : document().spans()) {
@@ -434,11 +435,15 @@ void TextEditor::paint_event(PaintEvent& event)
                         if (span.font)
                             font = span.font;
                         background_color = span.background_color;
+                        underline = span.is_underlined;
                         break;
                     }
                     if (background_color.has_value())
                         painter.fill_rect(character_rect, background_color.value());
                     painter.draw_text(character_rect, visual_line_text.substring_view(i, 1), *font, m_text_alignment, color);
+                    if (underline) {
+                        painter.draw_line(character_rect.bottom_left().translated(0, 1), character_rect.bottom_right().translated(0, 1), color);
+                    }
                     character_rect.move_by(advance, 0);
                 }
             }
@@ -1488,6 +1493,14 @@ void TextEditor::flush_pending_change_notification_if_needed()
     if (m_highlighter)
         m_highlighter->rehighlight();
     m_has_pending_change_notification = false;
+}
+
+const SyntaxHighlighter* TextEditor::syntax_highlighter() const
+{
+    if (m_highlighter)
+        return m_highlighter.ptr();
+    else
+        return nullptr;
 }
 
 void TextEditor::set_syntax_highlighter(OwnPtr<SyntaxHighlighter> highlighter)

--- a/Libraries/LibGUI/TextEditor.h
+++ b/Libraries/LibGUI/TextEditor.h
@@ -127,6 +127,7 @@ public:
     void set_cursor(size_t line, size_t column);
     void set_cursor(const TextPosition&);
 
+    const SyntaxHighlighter* syntax_highlighter() const;
     void set_syntax_highlighter(OwnPtr<SyntaxHighlighter>);
 
 protected:


### PR DESCRIPTION
Making things a bit more intuitive. Headers are now underlined when moused over and ctrl is held.

![Underline](https://user-images.githubusercontent.com/62019142/76532948-00c93800-6480-11ea-971e-a9d26e45150e.gif)