### PR TITLE
LibGUI: Add Javascript syntax highlighter

### DIFF
--- a/Applications/TextEditor/Makefile
+++ b/Applications/TextEditor/Makefile
@@ -4,6 +4,6 @@ OBJS = \
 
 PROGRAM = TextEditor
 
-LIB_DEPS = GUI Gfx VT IPC Thread Pthread Core
+LIB_DEPS = GUI Gfx VT IPC Thread Pthread Core JS
 
 include ../../Makefile.common

--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -38,6 +38,7 @@
 #include <LibGUI/CppSyntaxHighlighter.h>
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/FontDatabase.h>
+#include <LibGUI/JSSyntaxHighlighter.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/MenuBar.h>
 #include <LibGUI/MessageBox.h>
@@ -402,6 +403,15 @@ TextEditorWidget::TextEditorWidget()
     syntax_actions.add_action(*m_cpp_highlight);
     syntax_menu->add_action(*m_cpp_highlight);
 
+    m_js_highlight = GUI::Action::create("Javascript", [&](GUI::Action& action) {
+        action.set_checked(true);
+        m_editor->set_syntax_highlighter(make<GUI::JSSyntaxHighlighter>());
+        m_editor->update();
+    });
+    m_js_highlight->set_checkable(true);
+    syntax_actions.add_action(*m_js_highlight);
+    syntax_menu->add_action(*m_js_highlight);
+
     auto view_menu = GUI::Menu::construct("View");
     view_menu->add_action(*m_line_wrapping_setting_action);
     view_menu->add_separator();
@@ -446,6 +456,8 @@ void TextEditorWidget::set_path(const FileSystemPath& file)
 
     if (m_extension == "cpp" || m_extension == "h")
         m_cpp_highlight->activate();
+    else if (m_extension == "js")
+        m_js_highlight->activate();
     else
         m_plain_text_highlight->activate();
 

--- a/Applications/TextEditor/TextEditorWidget.h
+++ b/Applications/TextEditor/TextEditorWidget.h
@@ -82,6 +82,7 @@ private:
     GUI::ActionGroup syntax_actions;
     RefPtr<GUI::Action> m_plain_text_highlight;
     RefPtr<GUI::Action> m_cpp_highlight;
+    RefPtr<GUI::Action> m_js_highlight;
 
     bool m_document_dirty { false };
     bool m_document_opening { false };

--- a/DevTools/HackStudio/Makefile
+++ b/DevTools/HackStudio/Makefile
@@ -17,6 +17,6 @@ OBJS = \
 
 PROGRAM = HackStudio
 
-LIB_DEPS = GUI Web VT Protocol Markdown Gfx IPC Thread Pthread Core
+LIB_DEPS = GUI Web VT Protocol Markdown Gfx IPC Thread Pthread Core JS
 
 include ../../Makefile.common

--- a/DevTools/HackStudio/main.cpp
+++ b/DevTools/HackStudio/main.cpp
@@ -46,6 +46,7 @@
 #include <LibGUI/CppSyntaxHighlighter.h>
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/InputBox.h>
+#include <LibGUI/JSSyntaxHighlighter.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/MenuBar.h>
@@ -590,6 +591,10 @@ void open_file(const String& filename)
 
     if (filename.ends_with(".cpp") || filename.ends_with(".h"))
         current_editor().set_syntax_highlighter(make<GUI::CppSyntaxHighlighter>());
+    else if (filename.ends_with(".js"))
+        current_editor().set_syntax_highlighter(make<GUI::JSSyntaxHighlighter>());
+    else
+        current_editor().set_syntax_highlighter(nullptr);
 
     if (filename.ends_with(".frm")) {
         set_edit_mode(EditMode::Form);

--- a/Libraries/LibGUI/CppSyntaxHighlighter.h
+++ b/Libraries/LibGUI/CppSyntaxHighlighter.h
@@ -14,7 +14,10 @@ public:
 
     virtual SyntaxLanguage language() const override { return SyntaxLanguage::Cpp; }
     virtual void rehighlight() override;
-    virtual void highlight_matching_token_pair() override;
+
+protected:
+    virtual Vector<MatchingTokenPair> matching_token_pairs() const override;
+    virtual bool token_types_equal(void*, void*) const override;
 };
 
 }

--- a/Libraries/LibGUI/JSSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/JSSyntaxHighlighter.cpp
@@ -1,0 +1,157 @@
+#include <LibGUI/JSSyntaxHighlighter.h>
+#include <LibGUI/TextEditor.h>
+#include <LibGfx/Font.h>
+#include <LibJS/Lexer.h>
+#include <LibJS/Token.h>
+
+namespace GUI {
+
+static TextStyle style_for_token_type(JS::TokenType type)
+{
+    switch (type) {
+    case JS::TokenType::BoolLiteral:
+    case JS::TokenType::NullLiteral:
+        return { Color::Black, &Gfx::Font::default_bold_fixed_width_font() };
+    case JS::TokenType::Catch:
+    case JS::TokenType::Class:
+    case JS::TokenType::Const:
+    case JS::TokenType::Delete:
+    case JS::TokenType::Do:
+    case JS::TokenType::Else:
+    case JS::TokenType::Finally:
+    case JS::TokenType::For:
+    case JS::TokenType::Function:
+    case JS::TokenType::If:
+    case JS::TokenType::Interface:
+    case JS::TokenType::Let:
+    case JS::TokenType::New:
+    case JS::TokenType::QuestionMark:
+    case JS::TokenType::Return:
+    case JS::TokenType::Try:
+    case JS::TokenType::Var:
+    case JS::TokenType::While:
+        return { Color::Black, &Gfx::Font::default_bold_fixed_width_font() };
+    case JS::TokenType::Identifier:
+        return { Color::from_rgb(0x092e64) };
+    case JS::TokenType::NumericLiteral:
+    case JS::TokenType::StringLiteral:
+    case JS::TokenType::RegexLiteral:
+        return { Color::from_rgb(0x800000) };
+    case JS::TokenType::Invalid:
+    case JS::TokenType::Eof:
+        return { Color::from_rgb(0x008000) };
+    default:
+        return { Color::Black };
+    }
+}
+
+bool JSSyntaxHighlighter::is_identifier(void* token) const
+{
+    auto js_token = static_cast<JS::TokenType>(reinterpret_cast<size_t>(token));
+    return js_token == JS::TokenType::Identifier;
+}
+
+bool JSSyntaxHighlighter::is_navigatable(void* token) const
+{
+    (void)token;
+    return false;
+}
+
+void JSSyntaxHighlighter::rehighlight()
+{
+    ASSERT(m_editor);
+    auto text = m_editor->text();
+
+    JS::Lexer lexer(text);
+
+    Vector<GUI::TextDocumentSpan> spans;
+    GUI::TextPosition position { 0, 0 };
+    GUI::TextPosition start { 0, 0 };
+
+    auto advance_position = [&](char ch) {
+        if (ch == '\n') {
+            position.set_line(position.line() + 1);
+            position.set_column(0);
+        } else
+            position.set_column(position.column() + 1);
+    };
+
+    bool was_eof = false;
+    for (auto token = lexer.next(); !was_eof; token = lexer.next()) {
+        start = position;
+        if (!token.trivia().is_empty()) {
+            for (auto ch : token.trivia())
+                advance_position(ch);
+
+            GUI::TextDocumentSpan span;
+
+            span.range.set_start(start);
+            if (position.column() > 0)
+                span.range.set_end({ position.line(), position.column() - 1 });
+            else
+                span.range.set_end({ position.line() - 1, 0 });
+            auto style = style_for_token_type(JS::TokenType::Invalid);
+            span.color = style.color;
+            span.font = style.font;
+            span.is_skippable = true;
+            spans.append(span);
+#ifdef DEBUG_SYNTAX_HIGHLIGHTING
+            dbg() << token.name() << " \"" << token.trivia() << "\" (trivia) @ " << span.range.start().line() << ":" << span.range.start().column() << " - " << span.range.end().line() << ":" << span.range.end().column();
+#endif
+        }
+
+        start = position;
+        if (!token.value().is_empty()) {
+            for (auto ch : token.value())
+                advance_position(ch);
+
+            GUI::TextDocumentSpan span;
+            span.range.set_start(start);
+            if (position.column() > 0)
+                span.range.set_end({ position.line(), position.column() - 1 });
+            else
+                span.range.set_end({ position.line() - 1, 0 });
+            auto style = style_for_token_type(token.type());
+            span.color = style.color;
+            span.font = style.font;
+            span.is_skippable = false;
+            span.data = reinterpret_cast<void*>(token.type());
+            spans.append(span);
+#ifdef DEBUG_SYNTAX_HIGHLIGHTING
+            dbg() << token.name() << " @ \"" << token.value() << "\" " << span.range.start().line() << ":" << span.range.start().column() << " - " << span.range.end().line() << ":" << span.range.end().column();
+#endif
+        }
+
+        if (token.type() == JS::TokenType::Eof)
+            was_eof = true;
+    }
+
+    m_editor->document().set_spans(spans);
+
+    m_has_brace_buddies = false;
+    highlight_matching_token_pair();
+
+    m_editor->update();
+}
+
+Vector<SyntaxHighlighter::MatchingTokenPair> JSSyntaxHighlighter::matching_token_pairs() const
+{
+    static Vector<SyntaxHighlighter::MatchingTokenPair> pairs;
+    if (pairs.is_empty()) {
+        pairs.append({ reinterpret_cast<void*>(JS::TokenType::CurlyOpen), reinterpret_cast<void*>(JS::TokenType::CurlyClose) });
+        pairs.append({ reinterpret_cast<void*>(JS::TokenType::ParenOpen), reinterpret_cast<void*>(JS::TokenType::ParenClose) });
+        pairs.append({ reinterpret_cast<void*>(JS::TokenType::BracketOpen), reinterpret_cast<void*>(JS::TokenType::BracketClose) });
+    }
+    return pairs;
+}
+
+bool JSSyntaxHighlighter::token_types_equal(void* token1, void* token2) const
+{
+    return static_cast<JS::TokenType>(reinterpret_cast<size_t>(token1)) == static_cast<JS::TokenType>(reinterpret_cast<size_t>(token2));
+}
+
+JSSyntaxHighlighter::~JSSyntaxHighlighter()
+{
+}
+
+}

--- a/Libraries/LibGUI/JSSyntaxHighlighter.h
+++ b/Libraries/LibGUI/JSSyntaxHighlighter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <LibGUI/SyntaxHighlighter.h>
+
+namespace GUI {
+
+class JSSyntaxHighlighter final : public SyntaxHighlighter {
+public:
+    JSSyntaxHighlighter() {}
+    virtual ~JSSyntaxHighlighter() override;
+
+    virtual bool is_identifier(void*) const override;
+    virtual bool is_navigatable(void*) const override;
+
+    virtual SyntaxLanguage language() const override { return SyntaxLanguage::Javascript; }
+    virtual void rehighlight() override;
+
+protected:
+    virtual Vector<MatchingTokenPair> matching_token_pairs() const override;
+    virtual bool token_types_equal(void*, void*) const override;
+};
+
+}

--- a/Libraries/LibGUI/Makefile
+++ b/Libraries/LibGUI/Makefile
@@ -29,6 +29,7 @@ OBJS = \
     InputBox.o \
     ItemView.o \
     JsonArrayModel.o \
+    JSSyntaxHighlighter.o \
     Label.o \
     Layout.o \
     LazyWidget.o \

--- a/Libraries/LibGUI/SyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/SyntaxHighlighter.cpp
@@ -7,6 +7,98 @@ SyntaxHighlighter::~SyntaxHighlighter()
 {
 }
 
+void SyntaxHighlighter::highlight_matching_token_pair()
+{
+    ASSERT(m_editor);
+    auto& document = m_editor->document();
+
+    enum class Direction {
+        Forward,
+        Backward,
+    };
+
+    auto find_span_of_type = [&](auto i, void* type, void* not_type, Direction direction) -> Optional<size_t> {
+        size_t nesting_level = 0;
+        bool forward = direction == Direction::Forward;
+
+        if (forward) {
+            ++i;
+            if (i >= document.spans().size())
+                return {};
+        } else {
+            if (i == 0)
+                return {};
+            --i;
+        }
+
+        for (;;) {
+            auto& span = document.spans().at(i);
+            auto span_token_type = span.data;
+            if (token_types_equal(span_token_type, not_type)) {
+                ++nesting_level;
+            } else if (token_types_equal(span_token_type, type)) {
+                if (nesting_level-- <= 0)
+                    return i;
+            }
+
+            if (forward) {
+                ++i;
+                if (i >= document.spans().size())
+                    return {};
+            } else {
+                if (i == 0)
+                    return {};
+                --i;
+            }
+        }
+
+        return {};
+    };
+
+    auto make_buddies = [&](int index0, int index1) {
+        auto& buddy0 = document.spans()[index0];
+        auto& buddy1 = document.spans()[index1];
+        m_has_brace_buddies = true;
+        m_brace_buddies[0].index = index0;
+        m_brace_buddies[1].index = index1;
+        m_brace_buddies[0].span_backup = buddy0;
+        m_brace_buddies[1].span_backup = buddy1;
+        buddy0.background_color = Color::DarkCyan;
+        buddy1.background_color = Color::DarkCyan;
+        buddy0.color = Color::White;
+        buddy1.color = Color::White;
+        m_editor->update();
+    };
+
+    auto pairs = matching_token_pairs();
+
+    for (size_t i = 0; i < document.spans().size(); ++i) {
+        auto& span = const_cast<GUI::TextDocumentSpan&>(document.spans().at(i));
+        auto token_type = span.data;
+
+        for (auto& pair : pairs) {
+            if (token_types_equal(token_type, pair.open) && span.range.start() == m_editor->cursor()) {
+                auto buddy = find_span_of_type(i, pair.close, pair.open, Direction::Forward);
+                if (buddy.has_value())
+                    make_buddies(i, buddy.value());
+                return;
+            }
+        }
+
+        auto right_of_end = span.range.end();
+        right_of_end.set_column(right_of_end.column() + 1);
+
+        for (auto& pair : pairs) {
+            if (token_types_equal(token_type, pair.close) && right_of_end == m_editor->cursor()) {
+                auto buddy = find_span_of_type(i, pair.open, pair.close, Direction::Backward);
+                if (buddy.has_value())
+                    make_buddies(i, buddy.value());
+                return;
+            }
+        }
+    }
+}
+
 void SyntaxHighlighter::attach(TextEditor& editor)
 {
     ASSERT(!m_editor);

--- a/Libraries/LibGUI/SyntaxHighlighter.h
+++ b/Libraries/LibGUI/SyntaxHighlighter.h
@@ -8,7 +8,13 @@ namespace GUI {
 
 enum class SyntaxLanguage {
     PlainText,
-    Cpp
+    Cpp,
+    Javascript
+};
+
+struct TextStyle {
+    Color color;
+    const Gfx::Font* font { nullptr };
 };
 
 class SyntaxHighlighter {
@@ -20,7 +26,7 @@ public:
 
     virtual SyntaxLanguage language() const = 0;
     virtual void rehighlight() = 0;
-    virtual void highlight_matching_token_pair() = 0;
+    virtual void highlight_matching_token_pair();
 
     virtual bool is_identifier(void*) const { return false; };
     virtual bool is_navigatable(void*) const { return false; };
@@ -33,6 +39,14 @@ protected:
     SyntaxHighlighter() {}
 
     WeakPtr<TextEditor> m_editor;
+
+    struct MatchingTokenPair {
+        void* open;
+        void* close;
+    };
+
+    virtual Vector<MatchingTokenPair> matching_token_pairs() const = 0;
+    virtual bool token_types_equal(void*, void*) const = 0;
 
     struct BuddySpan {
         int index { -1 };

--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -205,7 +205,7 @@ Token Lexer::next()
         token_type = TokenType::NumericLiteral;
     } else if (m_current_char == '"') {
         consume();
-        while (m_current_char != '"') {
+        while (m_current_char != '"' && !is_eof()) {
             consume();
         }
         consume();


### PR DESCRIPTION
Added a Javascript syntax highlighter using the lexer from LibJS. Made use of in TextEditor and HackStudio.

![Highlight](https://user-images.githubusercontent.com/62019142/76574568-56740380-64c5-11ea-9bb3-e6358856e02f.png)

~~The highlighting is still a bit wonky until #1431 is fixed.~~