### PR TITLE
HackStudio: Add Javascript projects

### DIFF
--- a/Base/home/anon/js/javascript.files
+++ b/Base/home/anon/js/javascript.files
@@ -1,0 +1,2 @@
+javascript.files
+*.js

--- a/DevTools/HackStudio/Editor.cpp
+++ b/DevTools/HackStudio/Editor.cpp
@@ -93,9 +93,10 @@ void Editor::paint_event(GUI::PaintEvent& event)
         if (horizontal_scrollbar().is_visible())
             rect.set_height(rect.height() - horizontal_scrollbar().height());
         painter.draw_rect(rect, palette().selection());
-
-        window()->set_override_cursor(m_hovering_link && m_holding_ctrl ? GUI::StandardCursor::Hand : GUI::StandardCursor::IBeam);
     }
+
+    if (m_hovering_editor)
+        window()->set_override_cursor(m_hovering_link && m_holding_ctrl ? GUI::StandardCursor::Hand : GUI::StandardCursor::IBeam);
 }
 
 static HashMap<String, String>& man_paths()
@@ -281,6 +282,18 @@ void Editor::keyup_event(GUI::KeyEvent& event)
     if (event.key() == Key_Control)
         m_holding_ctrl = false;
     GUI::TextEditor::keyup_event(event);
+}
+
+void Editor::enter_event(Core::Event& event)
+{
+    m_hovering_editor = true;
+    GUI::TextEditor::enter_event(event);
+}
+
+void Editor::leave_event(Core::Event& event)
+{
+    m_hovering_editor = false;
+    GUI::TextEditor::leave_event(event);
 }
 
 static HashMap<String, String>& include_paths()

--- a/DevTools/HackStudio/Editor.h
+++ b/DevTools/HackStudio/Editor.h
@@ -50,6 +50,8 @@ private:
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void keyup_event(GUI::KeyEvent&) override;
+    virtual void enter_event(Core::Event&) override;
+    virtual void leave_event(Core::Event&) override;
 
     void show_documentation_tooltip_if_available(const String&, const Gfx::Point& screen_location);
     void navigate_to_include_if_available(String);
@@ -60,6 +62,7 @@ private:
     RefPtr<Web::HtmlView> m_documentation_html_view;
     String m_last_parsed_token;
     GUI::TextPosition m_previous_text_position { 0, 0 };
+    bool m_hovering_editor { false };
     bool m_hovering_link { false };
     bool m_holding_ctrl { false };
 };

--- a/DevTools/HackStudio/Project.h
+++ b/DevTools/HackStudio/Project.h
@@ -33,6 +33,12 @@
 #include <LibGUI/Icon.h>
 #include <LibGUI/Model.h>
 
+enum class ProjectType {
+    Unknown,
+    Cpp,
+    Javascript
+};
+
 class Project {
     AK_MAKE_NONCOPYABLE(Project)
     AK_MAKE_NONMOVABLE(Project)
@@ -47,7 +53,9 @@ public:
 
     ProjectFile* get_file(const String& filename);
 
+    ProjectType type() const { return m_type; }
     GUI::Model& model() { return *m_model; }
+    String default_file() const;
 
     template<typename Callback>
     void for_each_text_file(Callback callback) const
@@ -65,6 +73,7 @@ private:
     const ProjectTreeNode& root_node() const { return *m_root_node; }
     void rebuild_tree();
 
+    ProjectType m_type { ProjectType::Unknown };
     String m_name;
     String m_path;
     RefPtr<GUI::Model> m_model;


### PR DESCRIPTION
Support running Javascript projects from within HackStudio. "Build" runs `js -A` and "Run" runs plain `js` with the currently open file.
Also included is a simple glob matching for the project file.
This is entirely orthogonal to the syntax highlighter support (#1435) and can be merged without.

![Project](https://user-images.githubusercontent.com/62019142/76625881-d25f6180-6540-11ea-826e-36770b0c8479.gif)
