### PR TITLE
LibJS: For loop scoping improvements

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -95,6 +95,13 @@ Value WhileStatement::execute(Interpreter& interpreter) const
 
 Value ForStatement::execute(Interpreter& interpreter) const
 {
+    OwnPtr<BlockStatement> wrapper;
+
+    if (m_init->is_variable_declaration() && static_cast<const VariableDeclaration*>(m_init.ptr())->declaration_type() != DeclarationType::Var) {
+        wrapper = make<BlockStatement>();
+        interpreter.enter_scope(*wrapper, {}, ScopeType::Block);
+    }
+
     Value last_value = js_undefined();
 
     if (m_init)
@@ -113,6 +120,9 @@ Value ForStatement::execute(Interpreter& interpreter) const
                 m_update->execute(interpreter);
         }
     }
+
+    if (wrapper)
+        interpreter.exit_scope(*wrapper);
 
     return last_value;
 }

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -50,6 +50,8 @@ private:
 };
 
 class Statement : public ASTNode {
+public:
+    virtual bool is_variable_declaration() const { return false; }
 };
 
 class ErrorStatement final : public Statement {
@@ -482,7 +484,9 @@ public:
     {
     }
 
+    virtual bool is_variable_declaration() const override { return true; }
     const Identifier& name() const { return *m_name; }
+    DeclarationType declaration_type() const { return m_declaration_type; }
 
     virtual Value execute(Interpreter&) const override;
     virtual void dump(int indent) const override;

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -68,8 +68,8 @@ void Interpreter::enter_scope(const ScopeNode& scope_node, Vector<Argument> argu
 
 void Interpreter::exit_scope(const ScopeNode& scope_node)
 {
-    ASSERT(&m_scope_stack.last().scope_node == &scope_node);
-    m_scope_stack.take_last();
+    while (&m_scope_stack.last().scope_node != &scope_node)
+        m_scope_stack.take_last();
 }
 
 void Interpreter::do_return()

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -76,10 +76,10 @@ public:
 
     void collect_roots(Badge<Heap>, HashTable<Cell*>&);
 
-private:
     void enter_scope(const ScopeNode&, Vector<Argument>, ScopeType);
     void exit_scope(const ScopeNode&);
 
+private:
     Heap m_heap;
 
     Vector<ScopeFrame> m_scope_stack;

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -296,9 +296,6 @@ NonnullOwnPtr<ForStatement> Parser::parse_for_statement()
 
     OwnPtr<Statement> init = nullptr;
     switch (m_current_token.type()) {
-    case TokenType::Var:
-        init = parse_variable_declaration();
-        break;
     case TokenType::Semicolon:
         break;
     default:


### PR DESCRIPTION
This patch allows us to use `let` and `const` variables in a proper manner in for loops.