### PR TITLE
WindowServer: Resize maximised/tiled windows after resolution change

### DIFF
--- a/Servers/WindowServer/Window.h
+++ b/Servers/WindowServer/Window.h
@@ -218,6 +218,9 @@ public:
     void start_minimize_animation() { m_minimize_animation_step = 0; }
     void end_minimize_animation() { m_minimize_animation_step = -1; }
 
+    Gfx::Rect tiled_rect(WindowTileType) const;
+    void recalculate_rect();
+
     // For InlineLinkedList.
     // FIXME: Maybe make a ListHashSet and then WindowManager can just use that.
     Window* m_next { nullptr };

--- a/Servers/WindowServer/WindowManager.cpp
+++ b/Servers/WindowServer/WindowManager.cpp
@@ -140,6 +140,12 @@ bool WindowManager::set_resolution(int width, int height)
     ClientConnection::for_each_client([&](ClientConnection& client) {
         client.notify_about_new_screen_rect(Screen::the().rect());
     });
+    if (success) {
+        for_each_window([](Window& window) {
+            window.recalculate_rect();
+            return IterationDecision::Continue;
+        });
+    }
     if (m_wm_config) {
         if (success) {
             dbg() << "Saving resolution: " << Gfx::Size(width, height) << " to config file at " << m_wm_config->file_name();


### PR DESCRIPTION
Previously windows would either extend past the screen or stay at their
previous smaller size in the corner, now they are resized to fit the new
resolution.

Fixes #1371