### PR TITLE
LibJS: Prefixed update expressions and unary expression parsing

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -450,14 +450,20 @@ Value UpdateExpression::execute(Interpreter& interpreter) const
     auto previous_value = interpreter.get_variable(name);
     ASSERT(previous_value.is_number());
 
+    int op_result = 0;
     switch (m_op) {
     case UpdateOp::Increment:
-        interpreter.set_variable(name, Value(previous_value.as_double() + 1));
+        op_result = 1;
         break;
     case UpdateOp::Decrement:
-        interpreter.set_variable(name, Value(previous_value.as_double() - 1));
+        op_result = -1;
         break;
     }
+
+    interpreter.set_variable(name, Value(previous_value.as_double() + op_result));
+
+    if (m_prefixed)
+        return JS::Value(previous_value.as_double() + op_result);
 
     return previous_value;
 }
@@ -504,8 +510,13 @@ void UpdateExpression::dump(int indent) const
 
     ASTNode::dump(indent);
     print_indent(indent + 1);
-    printf("%s\n", op_string);
+    if (m_prefixed)
+        printf("%s\n", op_string);
     m_argument->dump(indent + 1);
+    if (!m_prefixed) {
+        print_indent(indent + 1);
+        printf("%s\n", op_string);
+    }
 }
 
 Value VariableDeclaration::execute(Interpreter& interpreter) const

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -186,7 +186,7 @@ Value UnaryExpression::execute(Interpreter& interpreter) const
 {
     auto lhs_result = m_lhs->execute(interpreter);
     switch (m_op) {
-    case UnaryOp::BitNot:
+    case UnaryOp::BitwiseNot:
         return bitwise_not(lhs_result);
     case UnaryOp::Not:
         return Value(!lhs_result.to_boolean());
@@ -297,7 +297,7 @@ void UnaryExpression::dump(int indent) const
 {
     const char* op_string = nullptr;
     switch (m_op) {
-    case UnaryOp::BitNot:
+    case UnaryOp::BitwiseNot:
         op_string = "~";
         break;
     case UnaryOp::Not:

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -451,9 +451,10 @@ enum class UpdateOp {
 
 class UpdateExpression : public Expression {
 public:
-    UpdateExpression(UpdateOp op, NonnullOwnPtr<Expression> argument)
+    UpdateExpression(UpdateOp op, NonnullOwnPtr<Expression> argument, bool prefixed = false)
         : m_op(op)
         , m_argument(move(argument))
+        , m_prefixed(prefixed)
     {
     }
 
@@ -465,6 +466,7 @@ private:
 
     UpdateOp m_op;
     NonnullOwnPtr<Identifier> m_argument;
+    bool m_prefixed;
 };
 
 enum class DeclarationType {

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -304,7 +304,7 @@ private:
 };
 
 enum class UnaryOp {
-    BitNot,
+    BitwiseNot,
     Not,
 };
 

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -52,6 +52,7 @@ public:
 
     NonnullOwnPtr<Expression> parse_expression(int min_precedence, Associativity associate = Associativity::Right);
     NonnullOwnPtr<Expression> parse_primary_expression();
+    NonnullOwnPtr<Expression> parse_unary_prefixed_expression();
     NonnullOwnPtr<ObjectExpression> parse_object_expression();
     NonnullOwnPtr<Expression> parse_secondary_expression(NonnullOwnPtr<Expression>, int min_precedence, Associativity associate = Associativity::Right);
     NonnullOwnPtr<CallExpression> parse_call_expression(NonnullOwnPtr<Expression>);
@@ -62,6 +63,7 @@ private:
     int operator_precedence(TokenType) const;
     Associativity operator_associativity(TokenType) const;
     bool match_expression() const;
+    bool match_unary_prefixed_expression() const;
     bool match_secondary_expression() const;
     bool match_statement() const;
     bool match(TokenType type) const;


### PR DESCRIPTION
This patch enables the parsing of unary and prefixed update expressions, it also provides the ability to have prefixed update expressions, the only difference between them and ones where the operator comes after is the fact that the latter return the value before the update while as the former returns the value after it.