### PR TITLE
Ports: Add zstd port

### DIFF
--- a/Ports/zstd/package.sh
+++ b/Ports/zstd/package.sh
@@ -1,0 +1,6 @@
+#!/bin/bash ../.port_include.sh
+port=zstd
+version=1.4.4
+files="https://github.com/facebook/zstd/releases/download/v${version}/zstd-${version}.tar.gz zstd-${version}.tar.gz
+https://github.com/facebook/zstd/releases/download/v${version}/zstd-${version}.tar.gz.sha256 zstd-${version}.tar.gz.sha256"
+auth_type=sha256

--- a/Ports/zstd/patches/make-4.3.patch
+++ b/Ports/zstd/patches/make-4.3.patch
@@ -1,0 +1,43 @@
+--- zstd-1.4.4/programs/Makefile.orig	Sat Mar 14 15:12:59 2020
++++ zstd-1.4.4/programs/Makefile	Sat Mar 14 15:14:43 2020
+@@ -94,9 +94,12 @@
+ 
+ VOID = /dev/null
+ 
++# Make 4.3 doesn't support '\#' anymore (https://lwn.net/Articles/810071/)
++NUM_SYMBOL := \#
++
+ # thread detection
+ NO_THREAD_MSG := ==> no threads, building without multithreading support
+-HAVE_PTHREAD := $(shell printf '\#include <pthread.h>\nint main(void) { return 0; }' > have_pthread.c && $(CC) $(FLAGS) -o have_pthread$(EXT) have_pthread.c -pthread 2> $(VOID) && rm have_pthread$(EXT) && echo 1 || echo 0; rm have_pthread.c)
++HAVE_PTHREAD := $(shell printf '$(NUM_SYMBOL)include <pthread.h>\nint main(void) { return 0; }' > have_pthread.c && $(CC) $(FLAGS) -o have_pthread$(EXT) have_pthread.c -pthread 2> $(VOID) && rm have_pthread$(EXT) && echo 1 || echo 0; rm have_pthread.c)
+ HAVE_THREAD := $(shell [ "$(HAVE_PTHREAD)" -eq "1" -o -n "$(filter Windows%,$(OS))" ] && echo 1 || echo 0)
+ ifeq ($(HAVE_THREAD), 1)
+ THREAD_MSG := ==> building with threading support
+@@ -108,7 +111,7 @@
+ 
+ # zlib detection
+ NO_ZLIB_MSG := ==> no zlib, building zstd without .gz support
+-HAVE_ZLIB := $(shell printf '\#include <zlib.h>\nint main(void) { return 0; }' > have_zlib.c && $(CC) $(FLAGS) -o have_zlib$(EXT) have_zlib.c -lz 2> $(VOID) && rm have_zlib$(EXT) && echo 1 || echo 0; rm have_zlib.c)
++HAVE_ZLIB := $(shell printf '$(NUM_SYMBOL)include <zlib.h>\nint main(void) { return 0; }' > have_zlib.c && $(CC) $(FLAGS) -o have_zlib$(EXT) have_zlib.c -lz 2> $(VOID) && rm have_zlib$(EXT) && echo 1 || echo 0; rm have_zlib.c)
+ ifeq ($(HAVE_ZLIB), 1)
+ ZLIB_MSG := ==> building zstd with .gz compression support
+ ZLIBCPP = -DZSTD_GZCOMPRESS -DZSTD_GZDECOMPRESS
+@@ -119,7 +122,7 @@
+ 
+ # lzma detection
+ NO_LZMA_MSG := ==> no liblzma, building zstd without .xz/.lzma support
+-HAVE_LZMA := $(shell printf '\#include <lzma.h>\nint main(void) { return 0; }' > have_lzma.c && $(CC) $(FLAGS) -o have_lzma$(EXT) have_lzma.c -llzma 2> $(VOID) && rm have_lzma$(EXT) && echo 1 || echo 0; rm have_lzma.c)
++HAVE_LZMA := $(shell printf '$(NUM_SYMBOL)include <lzma.h>\nint main(void) { return 0; }' > have_lzma.c && $(CC) $(FLAGS) -o have_lzma$(EXT) have_lzma.c -llzma 2> $(VOID) && rm have_lzma$(EXT) && echo 1 || echo 0; rm have_lzma.c)
+ ifeq ($(HAVE_LZMA), 1)
+ LZMA_MSG := ==> building zstd with .xz/.lzma compression support
+ LZMACPP = -DZSTD_LZMACOMPRESS -DZSTD_LZMADECOMPRESS
+@@ -130,7 +133,7 @@
+ 
+ # lz4 detection
+ NO_LZ4_MSG := ==> no liblz4, building zstd without .lz4 support
+-HAVE_LZ4 := $(shell printf '\#include <lz4frame.h>\n\#include <lz4.h>\nint main(void) { return 0; }' > have_lz4.c && $(CC) $(FLAGS) -o have_lz4$(EXT) have_lz4.c -llz4 2> $(VOID) && rm have_lz4$(EXT) && echo 1 || echo 0; rm have_lz4.c)
++HAVE_LZ4 := $(shell printf '$(NUM_SYMBOL)include <lz4frame.h>\n\#include <lz4.h>\nint main(void) { return 0; }' > have_lz4.c && $(CC) $(FLAGS) -o have_lz4$(EXT) have_lz4.c -llz4 2> $(VOID) && rm have_lz4$(EXT) && echo 1 || echo 0; rm have_lz4.c)
+ ifeq ($(HAVE_LZ4), 1)
+ LZ4_MSG := ==> building zstd with .lz4 compression support
+ LZ4CPP = -DZSTD_LZ4COMPRESS -DZSTD_LZ4DECOMPRESS

--- a/Ports/zstd/patches/posix-compliance.patch
+++ b/Ports/zstd/patches/posix-compliance.patch
@@ -1,0 +1,15 @@
+--- zstd-1.4.4/programs/platform.h.orig	Sat Mar 14 15:22:06 2020
++++ zstd-1.4.4/programs/platform.h	Sat Mar 14 15:22:41 2020
+@@ -97,7 +97,11 @@
+ #    endif
+ #    include <unistd.h>  /* declares _POSIX_VERSION */
+ #    if defined(_POSIX_VERSION)  /* POSIX compliant */
+-#      define PLATFORM_POSIX_VERSION _POSIX_VERSION
++#      if defined(__serenity__)
++#        define PLATFORM_POSIX_VERSION 1
++#      else
++#        define PLATFORM_POSIX_VERSION _POSIX_VERSION
++#      endif
+ #    else
+ #      define PLATFORM_POSIX_VERSION 1
+ #    endif


### PR DESCRIPTION
zstd is an improved compression library from Facebook.
gcc will begin using zstd for LTO beginning with gcc-10, so this allows us to be ready for that if we would like the gcc port to support it.