### PR TITLE
File manager interactions

### DIFF
--- a/Applications/FileManager/FileUtils.h
+++ b/Applications/FileManager/FileUtils.h
@@ -29,8 +29,9 @@
 #include <sys/stat.h>
 
 namespace FileUtils {
-
+int delete_file(String path);
 int delete_directory(String directory, String& file_that_caused_error);
+bool move_file_or_directory(const String& src_path, const String& dst_path);
 bool copy_file_or_directory(const String& src_path, const String& dst_path);
 String get_duplicate_name(const String& path, int duplicate_count);
 bool copy_file(const String& src_path, const String& dst_path, const struct stat& src_stat, int src_fd);

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -170,7 +170,6 @@ int main(int argc, char** argv)
     auto open_parent_directory_action = GUI::Action::create("Open parent directory", { Mod_Alt, Key_Up }, Gfx::Bitmap::load_from_file("/res/icons/16x16/open-parent-directory.png"), [&](const GUI::Action&) {
         directory_view.open_parent_directory();
     });
-
     auto mkdir_action = GUI::Action::create("New directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::load_from_file("/res/icons/16x16/mkdir.png"), [&](const GUI::Action&) {
         auto input_box = GUI::InputBox::construct("Enter name:", "New directory", window);
         if (input_box->exec() == GUI::InputBox::ExecOK && !input_box->text_value().is_empty()) {
@@ -398,7 +397,7 @@ int main(int argc, char** argv)
                 } else {
                     refresh_tree_view();
                 }
-            } else if (unlink(path.characters()) < 0) {
+            } else if (FileUtils::delete_file(path.characters()) < 0) {
                 int saved_errno = errno;
                 GUI::MessageBox::show(
                     String::format("unlink(%s) failed: %s", path.characters(), strerror(saved_errno)),
@@ -596,15 +595,14 @@ int main(int argc, char** argv)
             auto new_path = String::format("%s/%s",
                 target_node.full_path(directory_view.model()).characters(),
                 FileSystemPath(url_to_copy.path()).basename().characters());
-
-            if (!FileUtils::copy_file_or_directory(url_to_copy.path(), new_path)) {
-                auto error_message = String::format("Could not copy %s into %s.",
+            // FIXME: Add keyevent to check for modifier Ctrl key to toggle copy on move or move files
+            if (!FileUtils::move_file_or_directory(url_to_copy.path(), new_path)) {
+                auto error_message = String::format("Could not move %s into %s.",
                     url_to_copy.to_string().characters(),
                     new_path.characters());
                 GUI::MessageBox::show(error_message, "File Manager", GUI::MessageBox::Type::Error);
-            } else {
-                refresh_tree_view();
             }
+            refresh_tree_view();
         }
     };
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -55,11 +55,16 @@ I'm also on [Patreon](https://www.patreon.com/serenityos) and [GitHub Sponsors](
 * GUI toolkit (LibGUI)
 * Cross-process communication library (LibIPC)
 * HTML/CSS engine (LibWeb)
+* JavaScript engine (LibJS)
 * Markdown (LibMarkdown)
 * Audio (LibAudio)
 * PCI database (LibPCIDB)
 * Terminal emulation (LibVT)
 * Network protocols (HTTP) (LibProtocol)
+* Mathematical functions (LibM)
+* ELF file handing (LibELF)
+* POSIX threading (LibPthread)
+* Higher-level threading (LibThread)
 
 ## Userland features
 


### PR DESCRIPTION
Most file managers use a move by default on a file -> folder or folder -> folder drag and drop operation. Implemented a hacky move function in FileUtils to move files from one location to another via copy and delete (should be a better way to change the file path information via system instead, but this works for now). This should also lead the way for a cut keyboard shortcut instead of only copy, and brought some awareness to permissions issues when copying files.