### PR TITLE
Ports: libpuffy helper library (and some OpenBSD utilities)

### DIFF
--- a/Ports/jot/package.sh
+++ b/Ports/jot/package.sh
@@ -1,0 +1,5 @@
+#!/bin/bash ../.port_include.sh
+port=jot
+version=6.6
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/jot-${version}.tar.gz jot-${version}.tar.gz"
+depends=libpuffy

--- a/Ports/libpuffy/package.sh
+++ b/Ports/libpuffy/package.sh
@@ -1,0 +1,4 @@
+#!/bin/bash ../.port_include.sh
+port=libpuffy
+version=1.0
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-${version}/libpuffy-${version}.tar.gz libpuffy-${version}.tar.gz"

--- a/Ports/patch/package.sh
+++ b/Ports/patch/package.sh
@@ -1,0 +1,5 @@
+#!/bin/bash ../.port_include.sh
+port=patch
+version=6.6
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/patch-${version}.tar.gz patch-${version}.tar.gz"
+depends=libpuffy

--- a/Ports/printf/package.sh
+++ b/Ports/printf/package.sh
@@ -1,0 +1,5 @@
+#!/bin/bash ../.port_include.sh
+port=printf
+version=6.6
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/printf-${version}.tar.gz printf-${version}.tar.gz"
+depends=libpuffy


### PR DESCRIPTION
Hello.
This PR adds a libpuffy library. This library provides a number of functions from OpenBSD libc and libm that make porting OpenBSD (and POSIX) utilities much easier.
Also includes the jot(1), patch(1), and printf(1) utilities from OpenBSD, all of which use libpuffy, as a demonstration of usefulness.