### PR TITLE
LibCore: Rename Udp classes to UDP

### DIFF
--- a/Libraries/LibCore/Forward.h
+++ b/Libraries/LibCore/Forward.h
@@ -54,8 +54,8 @@ class TCPServer;
 class TCPSocket;
 class Timer;
 class TimerEvent;
-class UdpServer;
-class UdpSocket;
+class UDPServer;
+class UDPSocket;
 
 enum class TimerShouldFireWhenNotVisible;
 

--- a/Libraries/LibCore/Makefile
+++ b/Libraries/LibCore/Makefile
@@ -1,33 +1,33 @@
 OBJS = \
     ArgsParser.o \
+    ConfigFile.o \
     DateTime.o \
-    IODevice.o \
-    File.o \
-    SocketAddress.o \
-    Socket.o \
-    LocalSocket.o \
-    LocalServer.o \
-    TCPSocket.o \
-    TCPServer.o \
-    UdpSocket.o \
-    UdpServer.o \
+    DirIterator.o \
     ElapsedTimer.o \
-    MimeData.o \
-    Notifier.o \
+    Event.o \
+    EventLoop.o \
+    File.o \
+    Gzip.o \
+    HttpJob.o \
     HttpRequest.o \
     HttpResponse.o \
-    HttpJob.o \
+    IODevice.o \
+    LocalServer.o \
+    LocalSocket.o \
+    MimeData.o \
     NetworkJob.o \
     NetworkResponse.o \
+    Notifier.o \
     Object.o \
-    Timer.o \
-    EventLoop.o \
-    ConfigFile.o \
-    Event.o \
     ProcessStatisticsReader.o \
-    DirIterator.o \
+    Socket.o \
+    SocketAddress.o \
+    TCPServer.o \
+    TCPSocket.o \
+    Timer.o \
+    UDPServer.o \
+    UDPSocket.o \
     UserInfo.o \
-    Gzip.o \
     puff.o
 
 LIBRARY = libcore.a

--- a/Libraries/LibCore/UDPServer.cpp
+++ b/Libraries/LibCore/UDPServer.cpp
@@ -27,25 +27,25 @@
 #include <AK/IPv4Address.h>
 #include <AK/Types.h>
 #include <LibCore/Notifier.h>
-#include <LibCore/UdpServer.h>
-#include <LibCore/UdpSocket.h>
+#include <LibCore/UDPServer.h>
+#include <LibCore/UDPSocket.h>
 #include <stdio.h>
 #include <sys/socket.h>
 
 namespace Core {
 
-UdpServer::UdpServer(Object* parent)
+UDPServer::UDPServer(Object* parent)
     : Object(parent)
 {
     m_fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
     ASSERT(m_fd >= 0);
 }
 
-UdpServer::~UdpServer()
+UDPServer::~UDPServer()
 {
 }
 
-bool UdpServer::listen(const IPv4Address& address, u16 port)
+bool UDPServer::listen(const IPv4Address& address, u16 port)
 {
     if (m_listening)
         return false;
@@ -68,7 +68,7 @@ bool UdpServer::listen(const IPv4Address& address, u16 port)
     return true;
 }
 
-RefPtr<UdpSocket> UdpServer::accept()
+RefPtr<UDPSocket> UDPServer::accept()
 {
     ASSERT(m_listening);
     sockaddr_in in;
@@ -79,10 +79,10 @@ RefPtr<UdpSocket> UdpServer::accept()
         return nullptr;
     }
 
-    return UdpSocket::construct(accepted_fd);
+    return UDPSocket::construct(accepted_fd);
 }
 
-Optional<IPv4Address> UdpServer::local_address() const
+Optional<IPv4Address> UDPServer::local_address() const
 {
     if (m_fd == -1)
         return {};
@@ -95,7 +95,7 @@ Optional<IPv4Address> UdpServer::local_address() const
     return IPv4Address(address.sin_addr.s_addr);
 }
 
-Optional<u16> UdpServer::local_port() const
+Optional<u16> UDPServer::local_port() const
 {
     if (m_fd == -1)
         return {};

--- a/Libraries/LibCore/UDPServer.h
+++ b/Libraries/LibCore/UDPServer.h
@@ -33,15 +33,15 @@
 
 namespace Core {
 
-class UdpServer : public Object {
-    C_OBJECT(UdpServer)
+class UDPServer : public Object {
+    C_OBJECT(UDPServer)
 public:
-    virtual ~UdpServer() override;
+    virtual ~UDPServer() override;
 
     bool is_listening() const { return m_listening; }
     bool listen(const IPv4Address& address, u16 port);
 
-    RefPtr<UdpSocket> accept();
+    RefPtr<UDPSocket> accept();
 
     Optional<IPv4Address> local_address() const;
     Optional<u16> local_port() const;
@@ -49,7 +49,7 @@ public:
     Function<void()> on_ready_to_accept;
 
 private:
-    explicit UdpServer(Object* parent = nullptr);
+    explicit UDPServer(Object* parent = nullptr);
 
     int m_fd { -1 };
     bool m_listening { false };

--- a/Libraries/LibCore/UDPSocket.cpp
+++ b/Libraries/LibCore/UDPSocket.cpp
@@ -24,20 +24,37 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <LibCore/Socket.h>
+#include <LibCore/UDPSocket.h>
+#include <errno.h>
+#include <sys/socket.h>
 
 namespace Core {
 
-class UdpSocket final : public Socket {
-    C_OBJECT(UdpSocket)
-public:
-    virtual ~UdpSocket() override;
+UDPSocket::UDPSocket(int fd, Object* parent)
+    : Socket(Socket::Type::UDP, parent)
+{
+    // NOTE: This constructor is used by UDPServer::accept(), so the socket is already connected.
+    m_connected = true;
+    set_fd(fd);
+    set_mode(IODevice::ReadWrite);
+    set_error(0);
+}
 
-private:
-    UdpSocket(int fd, Object* parent = nullptr);
-    explicit UdpSocket(Object* parent = nullptr);
-};
+UDPSocket::UDPSocket(Object* parent)
+    : Socket(Socket::Type::UDP, parent)
+{
+    int fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+    if (fd < 0) {
+        set_error(errno);
+    } else {
+        set_fd(fd);
+        set_mode(IODevice::ReadWrite);
+        set_error(0);
+    }
+}
+
+UDPSocket::~UDPSocket()
+{
+}
 
 }

--- a/Libraries/LibCore/UDPSocket.h
+++ b/Libraries/LibCore/UDPSocket.h
@@ -24,37 +24,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibCore/UdpSocket.h>
-#include <errno.h>
-#include <sys/socket.h>
+#pragma once
+
+#include <LibCore/Socket.h>
 
 namespace Core {
 
-UdpSocket::UdpSocket(int fd, Object* parent)
-    : Socket(Socket::Type::UDP, parent)
-{
-    // NOTE: This constructor is used by UdpServer::accept(), so the socket is already connected.
-    m_connected = true;
-    set_fd(fd);
-    set_mode(IODevice::ReadWrite);
-    set_error(0);
-}
+class UDPSocket final : public Socket {
+    C_OBJECT(UDPSocket)
+public:
+    virtual ~UDPSocket() override;
 
-UdpSocket::UdpSocket(Object* parent)
-    : Socket(Socket::Type::UDP, parent)
-{
-    int fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
-    if (fd < 0) {
-        set_error(errno);
-    } else {
-        set_fd(fd);
-        set_mode(IODevice::ReadWrite);
-        set_error(0);
-    }
-}
-
-UdpSocket::~UdpSocket()
-{
-}
+private:
+    UDPSocket(int fd, Object* parent = nullptr);
+    explicit UDPSocket(Object* parent = nullptr);
+};
 
 }

--- a/Servers/LookupServer/LookupServer.cpp
+++ b/Servers/LookupServer/LookupServer.cpp
@@ -35,7 +35,7 @@
 #include <LibCore/File.h>
 #include <LibCore/LocalServer.h>
 #include <LibCore/LocalSocket.h>
-#include <LibCore/UdpSocket.h>
+#include <LibCore/UDPSocket.h>
 #include <stdio.h>
 #include <unistd.h>
 
@@ -176,7 +176,7 @@ Vector<String> LookupServer::lookup(const String& hostname, bool& did_timeout, u
 
     auto buffer = request.to_byte_buffer();
 
-    auto udp_socket = Core::UdpSocket::construct();
+    auto udp_socket = Core::UDPSocket::construct();
     udp_socket->set_blocking(true);
 
     struct timeval timeout {


### PR DESCRIPTION
The kernel was already using the UDP prefix, and the TCP LibCore classes
are also uppercased. Let's rename for consistency.

Also order the LibCore Makefile alphabetically, because everywhere else
seems to be doing that :)