### PR TITLE
Unveil: Accept relative paths

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -137,6 +137,7 @@ public:
 
     Custody& root_custody();
     KResultOr<NonnullRefPtr<Custody>> resolve_path(StringView path, Custody& base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
+    KResultOr<NonnullRefPtr<Custody>> resolve_path_without_veil(StringView path, Custody& base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
 
 private:
     friend class FileDescription;


### PR DESCRIPTION
This splits `VFS::resolve_path()` into a helper (`resolve_path_without_unveil()`) which does the actual lookup _without_ checking the unveiled paths, and a wrapper `resolve_path()` that calls the helper, and then checks the unveiled paths.

(Addresses https://github.com/SerenityOS/serenity/issues/1260)