### PR TITLE
Terminal: Remove working directory argument

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -189,8 +189,12 @@ int main(int argc, char** argv)
 
     auto open_terminal_action = GUI::Action::create("Open Terminal here...", Gfx::Bitmap::load_from_file("/res/icons/16x16/app-terminal.png"), [&](const GUI::Action&) {
         if (!fork()) {
-            int rc = execl("/bin/Terminal", "Terminal", "-d", directory_view.path().characters(), nullptr);
-            if (rc < 0)
+            if (chdir(directory_view.path().characters()) < 0) {
+                perror("chdir");
+                exit(1);
+            }
+
+            if (execl("/bin/Terminal", "Terminal", nullptr) < 0)
                 perror("execl");
             exit(1);
         }

--- a/Applications/Taskbar/TaskbarWindow.cpp
+++ b/Applications/Taskbar/TaskbarWindow.cpp
@@ -28,6 +28,7 @@
 #include "TaskbarButton.h"
 #include <AK/SharedBuffer.h>
 #include <LibCore/ConfigFile.h>
+#include <LibCore/UserInfo.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Desktop.h>
@@ -105,6 +106,10 @@ void TaskbarWindow::create_quick_launch_bar()
             if (pid < 0) {
                 perror("fork");
             } else if (pid == 0) {
+                if (chdir(get_current_user_home_path().characters()) < 0) {
+                    perror("chdir");
+                    exit(1);
+                }
                 execl(app_executable.characters(), app_executable.characters(), nullptr);
                 perror("execl");
                 ASSERT_NOT_REACHED();

--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -197,22 +197,11 @@ int main(int argc, char** argv)
     }
 
     const char* command_to_execute = nullptr;
-    const char* working_directory_chars = nullptr;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(command_to_execute, "Execute this command inside the terminal", nullptr, 'e', "command");
-    args_parser.add_option(working_directory_chars, "Set the working directory", nullptr, 'd', "directory");
 
     args_parser.parse(argc, argv);
-
-    String working_directory(working_directory_chars);
-
-    if (working_directory.is_empty()) {
-        working_directory = get_current_user_home_path();
-    }
-
-    if (chdir(working_directory.characters()) < 0)
-        perror("chdir");
 
     int ptm_fd = posix_openpt(O_RDWR | O_CLOEXEC);
     if (ptm_fd < 0) {

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -70,3 +70,4 @@ User=anon
 
 [Terminal]
 User=anon
+WorkingDirectory=/home/anon

--- a/Base/usr/share/man/man5/SystemServer.md
+++ b/Base/usr/share/man/man5/SystemServer.md
@@ -25,6 +25,7 @@ describing how to launch and manage this service.
 * `Socket` - a path to a socket to create on behalf of the service. For lazy services, SystemServer will actually watch the socket for new connection attempts. An open file descriptor to this socket will be passed as fd 3 to the service.
 * `SocketPermissions` - (octal) file system permissions for the socket file. The default permissions are 0600.
 * `User` - a name of the user to run the service as. This impacts what UID, GID (and extra GIDs) the service processes have. By default, services are run as root.
+* `WorkingDirectory` - The working directory in which the service is spawned. By Default, services are spawned in the root (`"/"`) directory.
 
 ## Environment
 

--- a/Servers/SystemServer/Service.cpp
+++ b/Servers/SystemServer/Service.cpp
@@ -188,6 +188,13 @@ void Service::spawn()
     } else if (m_pid == 0) {
         // We are the child.
 
+        if (!m_working_directory.is_null()) {
+            if (chdir(m_working_directory.characters()) < 0) {
+                perror("chdir");
+                ASSERT_NOT_REACHED();
+            }
+        }
+
         struct sched_param p;
         p.sched_priority = m_priority;
         int rc = sched_setparam(0, &p);
@@ -320,6 +327,8 @@ Service::Service(const Core::ConfigFile& config, const StringView& name)
         m_socket_permissions = strtol(socket_permissions_string.characters(), nullptr, 8) & 04777;
         setup_socket();
     }
+
+    m_working_directory = config.read_entry(name, "WorkingDirectory");
 }
 
 void Service::save_to(JsonObject& json)
@@ -352,4 +361,5 @@ void Service::save_to(JsonObject& json)
         json.set("pid", nullptr);
 
     json.set("restart_attempts", m_restart_attempts);
+    json.set("working_directory", m_working_directory);
 }

--- a/Servers/SystemServer/Service.h
+++ b/Servers/SystemServer/Service.h
@@ -81,6 +81,9 @@ private:
     // times where it has exited unsuccessfully and too quickly.
     int m_restart_attempts { 0 };
 
+    // The working directory in which to spawn the service
+    String m_working_directory;
+
     void resolve_user();
     void setup_socket();
     void setup_notifier();


### PR DESCRIPTION
Following #1467, @bugaevc suggested removing the working directory argument
from the `Terminal` app, and instead `chdir` there before `exec`ing Terminal.

This PR implements that change.

I also had to change `SystemMenu`, `Taskbar` and `SystemServer` because they
spawn the `Terminal` App, and so they now have to `chdir` before doing so.