### PR TITLE
Remove remaining G prefixes

### DIFF
--- a/Applications/FileManager/DirectoryView.cpp
+++ b/Applications/FileManager/DirectoryView.cpp
@@ -143,8 +143,8 @@ DirectoryView::DirectoryView()
             on_path_change(model().root_path());
     };
 
-    //  NOTE: We're using the on_update hook on the GSortingProxyModel here instead of
-    //        the GUI::FileSystemModel's hook. This is because GSortingProxyModel has already
+    //  NOTE: We're using the on_update hook on the GUI::SortingProxyModel here instead of
+    //        the GUI::FileSystemModel's hook. This is because GUI::SortingProxyModel has already
     //        installed an on_update hook on the GUI::FileSystemModel internally.
     // FIXME: This is an unfortunate design. We should come up with something better.
     m_table_view->model()->on_update = [this] {
@@ -321,7 +321,7 @@ void DirectoryView::update_statusbar()
     if (selected_item_count == 1) {
         auto index = current_view().selection().first();
 
-        // FIXME: This is disgusting. This code should not even be aware that there is a GSortingProxyModel in the table view.
+        // FIXME: This is disgusting. This code should not even be aware that there is a GUI::SortingProxyModel in the table view.
         if (m_view_mode == ViewMode::List) {
             auto& filter_model = (GUI::SortingProxyModel&)*m_table_view->model();
             index = filter_model.map_to_target(index);

--- a/Applications/Piano/KnobsWidget.cpp
+++ b/Applications/Piano/KnobsWidget.cpp
@@ -68,7 +68,7 @@ KnobsWidget::KnobsWidget(AudioEngine& audio_engine, MainWidget& main_widget)
     m_knobs_container = add<GUI::Widget>();
     m_knobs_container->set_layout<GUI::HorizontalBoxLayout>();
 
-    // FIXME: Implement vertical flipping in GSlider, not here.
+    // FIXME: Implement vertical flipping in GUI::Slider, not here.
 
     m_octave_knob = m_knobs_container->add<GUI::VerticalSlider>();
     m_octave_knob->set_tooltip("Z: octave down, X: octave up");

--- a/Demos/WidgetGallery/main.cpp
+++ b/Demos/WidgetGallery/main.cpp
@@ -53,19 +53,19 @@ int main(int argc, char** argv)
     main_widget.set_layout<GUI::VerticalBoxLayout>();
     main_widget.layout()->set_margins({ 4, 4, 4, 4 });
 
-    auto& checkbox1 = main_widget.add<GUI::CheckBox>("GCheckBox 1");
+    auto& checkbox1 = main_widget.add<GUI::CheckBox>("CheckBox 1");
     (void)checkbox1;
-    auto& checkbox2 = main_widget.add<GUI::CheckBox>("GCheckBox 2");
+    auto& checkbox2 = main_widget.add<GUI::CheckBox>("CheckBox 2");
     checkbox2.set_enabled(false);
 
-    auto& radio1 = main_widget.add<GUI::RadioButton>("GRadioButton 1");
+    auto& radio1 = main_widget.add<GUI::RadioButton>("RadioButton 1");
     (void)radio1;
-    auto& radio2 = main_widget.add<GUI::RadioButton>("GRadioButton 2");
+    auto& radio2 = main_widget.add<GUI::RadioButton>("RadioButton 2");
     radio2.set_enabled(false);
 
-    auto& button1 = main_widget.add<GUI::Button>("GButton 1");
+    auto& button1 = main_widget.add<GUI::Button>("Button 1");
     (void)button1;
-    auto& button2 = main_widget.add<GUI::Button>("GButton 2");
+    auto& button2 = main_widget.add<GUI::Button>("Button 2");
     button2.set_enabled(false);
 
     auto& progress1 = main_widget.add<GUI::ProgressBar>();
@@ -75,15 +75,15 @@ int main(int argc, char** argv)
             progress1.set_value(progress1.min());
     });
 
-    auto& label1 = main_widget.add<GUI::Label>("GLabel 1");
+    auto& label1 = main_widget.add<GUI::Label>("Label 1");
     (void)label1;
-    auto& label2 = main_widget.add<GUI::Label>("GLabel 2");
+    auto& label2 = main_widget.add<GUI::Label>("Label 2");
     label2.set_enabled(false);
 
     auto& textbox1 = main_widget.add<GUI::TextBox>();
-    textbox1.set_text("GTextBox 1");
+    textbox1.set_text("TextBox 1");
     auto& textbox2 = main_widget.add<GUI::TextBox>();
-    textbox2.set_text("GTextBox 2");
+    textbox2.set_text("TextBox 2");
     textbox2.set_enabled(false);
 
     auto& spinbox1 = main_widget.add<GUI::SpinBox>();

--- a/Libraries/LibGUI/Application.cpp
+++ b/Libraries/LibGUI/Application.cpp
@@ -112,7 +112,7 @@ class Application::TooltipWindow final : public Window {
 public:
     void set_tooltip(const StringView& tooltip)
     {
-        // FIXME: Add some kind of GLabel auto-sizing feature.
+        // FIXME: Add some kind of GUI::Label auto-sizing feature.
         int text_width = m_label->font().width(tooltip);
         set_rect(100, 100, text_width + 10, m_label->font().glyph_height() + 8);
         m_label->set_text(tooltip);

--- a/Libraries/LibGUI/InputBox.cpp
+++ b/Libraries/LibGUI/InputBox.cpp
@@ -84,7 +84,7 @@ void InputBox::build()
     m_cancel_button->set_preferred_size(0, 20);
     m_cancel_button->set_text("Cancel");
     m_cancel_button->on_click = [this] {
-        dbgprintf("GInputBox: Cancel button clicked\n");
+        dbgprintf("GUI::InputBox: Cancel button clicked\n");
         done(ExecCancel);
     };
 
@@ -93,7 +93,7 @@ void InputBox::build()
     m_ok_button->set_preferred_size(0, 20);
     m_ok_button->set_text("OK");
     m_ok_button->on_click = [this] {
-        dbgprintf("GInputBox: OK button clicked\n");
+        dbgprintf("GUI::InputBox: OK button clicked\n");
         m_text_value = m_text_editor->text();
         done(ExecOK);
     };

--- a/Libraries/LibGUI/TextDocument.h
+++ b/Libraries/LibGUI/TextDocument.h
@@ -149,9 +149,6 @@ private:
 };
 
 class TextDocumentLine {
-    friend class GTextEditor;
-    friend class TextDocument;
-
 public:
     explicit TextDocumentLine(TextDocument&);
     explicit TextDocumentLine(TextDocument&, const StringView&);

--- a/Libraries/LibGUI/TextPosition.h
+++ b/Libraries/LibGUI/TextPosition.h
@@ -60,7 +60,7 @@ private:
 inline const LogStream& operator<<(const LogStream& stream, const TextPosition& value)
 {
     if (!value.is_valid())
-        return stream << "GTextPosition(Invalid)";
+        return stream << "GUI::TextPosition(Invalid)";
     return stream << String::format("(%zu,%zu)", value.line(), value.column());
 }
 

--- a/Libraries/LibGUI/TextRange.h
+++ b/Libraries/LibGUI/TextRange.h
@@ -88,7 +88,7 @@ private:
 inline const LogStream& operator<<(const LogStream& stream, const TextRange& value)
 {
     if (!value.is_valid())
-        return stream << "GTextRange(Invalid)";
+        return stream << "GUI::TextRange(Invalid)";
     return stream << value.start() << '-' << value.end();
 }
 


### PR DESCRIPTION
VisualBuilder still has G prefixes but as far as I know it's being deprecated in favour of HackStudio, so I left it alone.