### PR TITLE
LibWeb: Fix HTMLCanvasElement::preferred_height() default value

### DIFF
--- a/Libraries/LibWeb/DOM/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/DOM/HTMLCanvasElement.cpp
@@ -59,7 +59,7 @@ int HTMLCanvasElement::preferred_height() const
     if (ok)
         return height;
 
-    return 300;
+    return 150;
 }
 
 RefPtr<LayoutNode> HTMLCanvasElement::create_layout_node(const StyleProperties* parent_style) const


### PR DESCRIPTION
Hi there!

As per the spec https://html.spec.whatwg.org/multipage/canvas.html, the default width is indeed 300px but the default height is 150px.