### PR TITLE
LibJS: Parse object expressions

### DIFF
--- a/Base/home/anon/js/object-expression.js
+++ b/Base/home/anon/js/object-expression.js
@@ -1,0 +1,7 @@
+const a = 1;
+const object = {a, b: 2};
+const emptyObject = {};
+
+console.log(object.a);
+console.log(object.b);
+console.log(emptyObject.foo);

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -623,6 +623,11 @@ void VariableDeclaration::dump(int indent) const
 void ObjectExpression::dump(int indent) const
 {
     ASTNode::dump(indent);
+    for (String property_key : m_properties.keys()) {
+        print_indent(indent + 1);
+        printf("%s: ", property_key.characters());
+        m_properties.get(property_key).value()->dump(0);
+    }
 }
 
 void ExpressionStatement::dump(int indent) const
@@ -633,7 +638,12 @@ void ExpressionStatement::dump(int indent) const
 
 Value ObjectExpression::execute(Interpreter& interpreter) const
 {
-    return interpreter.heap().allocate<Object>();
+    auto object = interpreter.heap().allocate<Object>();
+    for (String property_key : m_properties.keys()) {
+        object->put(property_key, m_properties.get(property_key).value()->execute(interpreter));
+    }
+
+    return object;
 }
 
 void MemberExpression::dump(int indent) const

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
@@ -572,13 +573,18 @@ private:
 
 class ObjectExpression : public Expression {
 public:
-    ObjectExpression() {}
+    ObjectExpression(HashMap<String, NonnullRefPtr<Expression>> properties = {})
+        : m_properties(properties)
+    {
+    }
 
     virtual Value execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
 
 private:
     virtual const char* class_name() const override { return "ObjectExpression"; }
+
+    HashMap<String, NonnullRefPtr<Expression>> m_properties;
 };
 
 class ArrayExpression : public Expression {

--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -107,6 +107,7 @@ Lexer::Lexer(StringView source)
         s_single_char_tokens.set('[', TokenType::BracketOpen);
         s_single_char_tokens.set(']', TokenType::BracketClose);
         s_single_char_tokens.set('^', TokenType::Caret);
+        s_single_char_tokens.set(':', TokenType::Colon);
         s_single_char_tokens.set(',', TokenType::Comma);
         s_single_char_tokens.set('{', TokenType::CurlyOpen);
         s_single_char_tokens.set('}', TokenType::CurlyClose);

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -269,10 +269,27 @@ NonnullRefPtr<Expression> Parser::parse_unary_prefixed_expression()
 
 NonnullRefPtr<ObjectExpression> Parser::parse_object_expression()
 {
-    // FIXME: Parse actual object expression
+    HashMap<String, NonnullRefPtr<Expression>> properties;
     consume(TokenType::CurlyOpen);
+
+    while (!match(TokenType::CurlyClose)) {
+        auto identifier = create_ast_node<Identifier>(consume(TokenType::Identifier).value());
+
+        if (match(TokenType::Colon)) {
+            consume(TokenType::Colon);
+            properties.set(identifier->string(), parse_expression(0));
+        } else {
+            properties.set(identifier->string(), identifier);
+        }
+
+        if (!match(TokenType::Comma))
+            break;
+
+        consume(TokenType::Comma);
+    }
+
     consume(TokenType::CurlyClose);
-    return create_ast_node<ObjectExpression>();
+    return create_ast_node<ObjectExpression>(properties);
 }
 
 NonnullRefPtr<ArrayExpression> Parser::parse_array_expression()

--- a/Libraries/LibJS/Token.cpp
+++ b/Libraries/LibJS/Token.cpp
@@ -57,6 +57,8 @@ const char* Token::name(TokenType type)
         return "Catch";
     case TokenType::Class:
         return "Class";
+    case TokenType::Colon:
+        return "Colon";
     case TokenType::Comma:
         return "Comma";
     case TokenType::Const:

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -44,6 +44,7 @@ enum class TokenType {
     Caret,
     Catch,
     Class,
+    Colon,
     Comma,
     Const,
     CurlyClose,


### PR DESCRIPTION
We can now parse object expressions, if a property is defined without being explicitly assigned, we assign its value to the result of a lookup of a variable with the same name as the property's.