### PR TITLE
Shell: More general tilde expansion

### DIFF
--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -700,8 +700,7 @@ static Vector<String> expand_globs(const StringView& path, const StringView& bas
 
 static Vector<String> expand_parameters(const StringView& param)
 {
-    bool is_variable = param.length() > 1 && param[0] == '$';
-    if (!is_variable)
+    if (!param.starts_with('$'))
         return { param };
 
     String variable_name = String(param.substring_view(1, param.length() - 1));

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -755,15 +755,15 @@ static int run_command(const String& cmd)
 
 #ifdef SH_DEBUG
     for (auto& command : commands) {
-        for (int i = 0; i < command.subcommands.size(); ++i) {
-            for (int j = 0; j < i; ++j)
+        for (size_t i = 0; i < command.subcommands.size(); ++i) {
+            for (size_t j = 0; j < i; ++j)
                 dbgprintf("    ");
             for (auto& arg : command.subcommands[i].args) {
                 dbgprintf("<%s> ", arg.characters());
             }
             dbgprintf("\n");
             for (auto& redirecton : command.subcommands[i].redirections) {
-                for (int j = 0; j < i; ++j)
+                for (size_t j = 0; j < i; ++j)
                     dbgprintf("    ");
                 dbgprintf("  ");
                 switch (redirecton.type) {


### PR DESCRIPTION
Not sure if I am doing this in the right place, but hey, it's a start (I'm especially
lost at how to integrate into the LineEditor)

Now expanding a tilde isn't hardcoded to just work for `cd`. It is instead
expanded while processing shell arguments. Autocompletion still doesn't
work, but this is definitely an improvement over the last iteration.