### PR TITLE
Taskbar: Remove FIXME comment re: tooltip rendering since it's now working properly

### DIFF
--- a/Applications/Taskbar/TaskbarWindow.cpp
+++ b/Applications/Taskbar/TaskbarWindow.cpp
@@ -99,7 +99,6 @@ void TaskbarWindow::create_quick_launch_bar()
         button.set_button_style(Gfx::ButtonStyle::CoolBar);
 
         button.set_icon(Gfx::Bitmap::load_from_file(app_icon_path));
-        // FIXME: the tooltip ends up outside the screen rect.
         button.set_tooltip(name);
         button.on_click = [app_executable] {
             pid_t pid = fork();


### PR DESCRIPTION
The tooltips on the taskbar don't render partially offscreen anymore, so I figured we could remove this comment.