### PR TITLE
AK: JSON improvements: get_or() and parsing of double numbers

### DIFF
--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -72,6 +72,12 @@ public:
         return value ? *value : JsonValue(JsonValue::Type::Undefined);
     }
 
+    JsonValue get_or(const String& key, JsonValue alternative) const
+    {
+        auto* value = get_ptr(key);
+        return value ? *value : alternative;
+    }
+
     const JsonValue* get_ptr(const String& key) const
     {
         auto it = m_members.find(key);


### PR DESCRIPTION
AK: Add get_or() method to JsonObject
This allows to retrieve a default value for items thare are not
available in the json object.

AK: Add parsing of JSON double values
This patch adds the parsing of double values to the JSON parser.
There is another char buffer that get's filled when a "." is present
in the number parsing. When number finished, a divider is calculated
to transform the number behind the "." to the actual fraction value.