### PR TITLE
Replace <!DOCTYPE> with <!DOCTYPE html> in a few files

### DIFF
--- a/Base/home/anon/www/demo.html
+++ b/Base/home/anon/www/demo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
 <head>
     <title>Canvas, timer, random and event demo</title>

--- a/Base/home/anon/www/dom.html
+++ b/Base/home/anon/www/dom.html
@@ -1,4 +1,4 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
     <head></head>
     <body>

--- a/Base/home/anon/www/form.html
+++ b/Base/home/anon/www/form.html
@@ -1,4 +1,4 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
 <head><title>Form</title></head>
 <body>

--- a/Base/home/anon/www/innerHTML.html
+++ b/Base/home/anon/www/innerHTML.html
@@ -1,4 +1,4 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
 <head>
 </head>

--- a/Base/www/index.html
+++ b/Base/www/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
     <head><title>WebServer start page!</title></head>
     <body>

--- a/Base/www/other.html
+++ b/Base/www/other.html
@@ -1,4 +1,4 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
     <head><title>WebServer other page!</title></head>
     <body>

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -57,7 +57,7 @@ void dump_tree(const Node& node)
     } else if (is<Text>(node)) {
         dbgprintf("\"%s\"\n", static_cast<const Text&>(node).data().characters());
     } else if (is<DocumentType>(node)) {
-        dbgprintf("<!DOCTYPE>\n");
+        dbgprintf("<!DOCTYPE html>\n");
     } else if (is<Comment>(node)) {
         dbgprintf("<!--%s-->\n", to<Comment>(node).data().characters());
     } else if (is<DocumentFragment>(node)) {


### PR DESCRIPTION
Hello there!

I noticed there are a bunch of `<!DOCTYPE>` declarations which are lacking the `html` root element specifier. I believe that's invalid and might not trigger HTML5 mode in some browsers (leading to quirks mode?), so probably best to unify them to the proper `<!DOCTYPE html>` declaration.