### PR TITLE
JS REPL

### DIFF
--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -387,10 +387,10 @@ template<typename PutChFunc>
                 ret += print_hex(putch, bufptr, va_arg(ap, int), false, alternate_form, false, true, 2);
                 break;
 
-            case 'c':
-                putch(bufptr, (char)va_arg(ap, int));
-                ++ret;
-                break;
+            case 'c': {
+                char s[2] { (char)va_arg(ap, int), 0 };
+                ret += print_string(putch, bufptr, s, left_pad, fieldWidth, dot);
+            } break;
 
             case '%':
                 putch(bufptr, '%');


### PR DESCRIPTION
If you invoke `js` without a script path, it will now enter REPL mode, where you input commands one by one and immediately get each one interpreted in one shared interpreter. We support multi-line commands in case we detect you have unclosed braces or parens or brackets.

Known issues: automatic indentation doesn't look right on the line where you close the brace. E.g. if you type
```
> if (condition) {
.     foo();
.     bar();
.     }
```
the closing brace stays indented. Not sure what could be done about this, other than escape sequences magic to go back and rewrite the previous line.