### PR TITLE
Add ptrace syscall & update strace

### DIFF
--- a/AK/Types.h
+++ b/AK/Types.h
@@ -70,6 +70,8 @@ typedef i16 int16_t;
 typedef i32 int32_t;
 typedef i64 int64_t;
 
+typedef int pid_t;
+
 #else
 #    include <stdint.h>
 #    include <sys/types.h>
@@ -84,9 +86,9 @@ typedef int16_t i16;
 typedef int32_t i32;
 typedef int64_t i64;
 
-#ifdef __ptrdiff_t
+#    ifdef __ptrdiff_t
 typedef __PTRDIFF_TYPE__ __ptrdiff_t;
-#endif
+#    endif
 
 #endif
 
@@ -115,4 +117,6 @@ inline constexpr size_t align_up_to(const size_t value, const size_t alignment)
     return (value + (alignment - 1)) & ~(alignment - 1);
 }
 
-enum class TriState : u8 { False, True, Unknown };
+enum class TriState : u8 { False,
+    True,
+    Unknown };

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -50,7 +50,7 @@ class PhysicalPage;
 class PhysicalRegion;
 class Process;
 class ProcessInspectionHandle;
-class ProcessTracer;
+class ThreadTracer;
 class Range;
 class RangeAllocator;
 class Region;

--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -92,7 +92,7 @@ OBJS = \
     PCI/Device.o \
     PerformanceEventBuffer.o \
     Process.o \
-    ProcessTracer.o \
+    ThreadTracer.o \
     Profiling.o \
     RTC.o \
     Random.o \

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -261,7 +261,12 @@ bool Thread::WaitBlocker::should_unblock(Thread& thread, time_t, long)
             return IterationDecision::Continue;
 
         bool child_exited = child.is_dead();
-        bool child_stopped = child.thread_count() && child.any_thread().state() == Thread::State::Stopped;
+        bool child_stopped = false;
+        if (child.thread_count()) {
+            auto& child_thread = child.any_thread();
+            if (child_thread.state() == Thread::State::Stopped && !child_thread.has_pending_signal(SIGCONT))
+                child_stopped = true;
+        }
 
         bool wait_finished = ((m_wait_options & WEXITED) && child_exited)
             || ((m_wait_options & WSTOPPED) && child_stopped);

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -26,9 +26,9 @@
 
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/Process.h>
-#include <Kernel/ProcessTracer.h>
 #include <Kernel/Random.h>
 #include <Kernel/Syscall.h>
+#include <Kernel/ThreadTracer.h>
 #include <Kernel/VM/MemoryManager.h>
 
 namespace Kernel {
@@ -92,8 +92,6 @@ int handle(RegisterState& regs, u32 function, u32 arg1, u32 arg2, u32 arg3)
     if (function == SC_exit || function == SC_exit_thread) {
         // These syscalls need special handling since they never return to the caller.
         cli();
-        if (auto* tracer = process.tracer())
-            tracer->did_syscall(function, arg1, arg2, arg3, 0);
         if (function == SC_exit)
             process.sys$exit((int)arg1);
         else
@@ -132,6 +130,11 @@ void syscall_handler(RegisterState& regs)
         return;
     }
 
+    if (Thread::current->tracer() && Thread::current->tracer()->is_tracing_syscalls()) {
+        Thread::current->tracer()->set_trace_syscalls(false);
+        Thread::current->tracer_trap(regs);
+    }
+
     // Make sure SMAP protection is enabled on syscall entry.
     clac();
 
@@ -168,8 +171,12 @@ void syscall_handler(RegisterState& regs)
     u32 arg2 = regs.ecx;
     u32 arg3 = regs.ebx;
     regs.eax = (u32)Syscall::handle(regs, function, arg1, arg2, arg3);
-    if (auto* tracer = process.tracer())
-        tracer->did_syscall(function, arg1, arg2, arg3, regs.eax);
+
+    if (Thread::current->tracer() && Thread::current->tracer()->is_tracing_syscalls()) {
+        Thread::current->tracer()->set_trace_syscalls(false);
+        Thread::current->tracer_trap(regs);
+    }
+
     process.big_lock().unlock();
 
     // Check if we're supposed to return to userspace or just die.

--- a/Kernel/Syscall.h
+++ b/Kernel/Syscall.h
@@ -133,7 +133,6 @@ namespace Kernel {
     __ENUMERATE_SYSCALL(donate)               \
     __ENUMERATE_SYSCALL(rename)               \
     __ENUMERATE_SYSCALL(ftruncate)            \
-    __ENUMERATE_SYSCALL(systrace)             \
     __ENUMERATE_SYSCALL(exit_thread)          \
     __ENUMERATE_SYSCALL(mknod)                \
     __ENUMERATE_SYSCALL(writev)               \
@@ -182,7 +181,8 @@ namespace Kernel {
     __ENUMERATE_SYSCALL(unveil)               \
     __ENUMERATE_SYSCALL(perf_event)           \
     __ENUMERATE_SYSCALL(shutdown)             \
-    __ENUMERATE_SYSCALL(get_stack_bounds)
+    __ENUMERATE_SYSCALL(get_stack_bounds)     \
+    __ENUMERATE_SYSCALL(ptrace)
 
 namespace Syscall {
 
@@ -422,6 +422,13 @@ struct SC_stat_params {
     StringArgument path;
     struct stat* statbuf;
     bool follow_symlinks;
+};
+
+struct SC_ptrace_params {
+    int request;
+    pid_t pid;
+    u8* addr;
+    int data;
 };
 
 void initialize();

--- a/Kernel/ThreadTracer.h
+++ b/Kernel/ThreadTracer.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/CircularDeque.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/Optional.h>
+#include <AK/RefCounted.h>
+#include <Kernel/Arch/i386/CPU.h>
+#include <Kernel/UnixTypes.h>
+#include <LibC/sys/arch/i386/regs.h>
+
+namespace Kernel {
+
+class ThreadTracer {
+public:
+    static NonnullOwnPtr<ThreadTracer> create(pid_t tracer) { return make<ThreadTracer>(tracer); }
+
+    pid_t tracer_pid() const { return m_tracer_pid; }
+    bool has_pending_signal(u32 signal) const { return m_pending_signals & (1 << (signal - 1)); }
+    void set_signal(u32 signal) { m_pending_signals |= (1 << (signal - 1)); }
+    void unset_signal(u32 signal) { m_pending_signals &= ~(1 << (signal - 1)); }
+
+    bool is_tracing_syscalls() const { return m_trace_syscalls; }
+    void set_trace_syscalls(bool val) { m_trace_syscalls = val; }
+
+    void set_regs(const RegisterState& regs);
+    bool has_regs() const { return m_regs.has_value(); }
+    const PtraceRegisters& regs() const
+    {
+        ASSERT(m_regs.has_value());
+        return m_regs.value();
+    }
+
+    explicit ThreadTracer(pid_t);
+
+private:
+    pid_t m_tracer_pid { -1 };
+
+    // This is a bitmap for signals that are sent from the tracer to the tracee
+    // TODO: Since we do not currently support sending signals
+    //       to the tracee via PT_CONTINUE, this bitmap is always zeroed
+    u32 m_pending_signals { 0 };
+
+    bool m_trace_syscalls { false };
+    Optional<PtraceRegisters> m_regs;
+};
+
+}

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -544,3 +544,10 @@ struct rtentry {
 
 #define PURGE_ALL_VOLATILE 0x1
 #define PURGE_ALL_CLEAN_INODE 0x2
+
+#define PT_TRACE_ME 1
+#define PT_ATTACH 2
+#define PT_CONTINUE 3
+#define PT_SYSCALL 4
+#define PT_GETREGS 5
+#define PT_DETACH 6

--- a/Libraries/LibC/Makefile
+++ b/Libraries/LibC/Makefile
@@ -46,6 +46,7 @@ LIBC_OBJS = \
        sys/socket.o \
        sys/wait.o \
        sys/uio.o \
+       sys/ptrace.o \
        poll.o \
        locale.o \
        arpa/inet.o \

--- a/Libraries/LibC/sys/arch/i386/regs.h
+++ b/Libraries/LibC/sys/arch/i386/regs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,47 +25,25 @@
  */
 
 #pragma once
+#include <AK/kmalloc.h>
+#include <bits/stdint.h>
 
-#include <AK/CircularQueue.h>
-#include <Kernel/FileSystem/File.h>
-#include <Kernel/UnixTypes.h>
-
-namespace Kernel {
-
-class ProcessTracer : public File {
-public:
-    static NonnullRefPtr<ProcessTracer> create(pid_t pid) { return adopt(*new ProcessTracer(pid)); }
-    virtual ~ProcessTracer() override;
-
-    bool is_dead() const { return m_dead; }
-    void set_dead() { m_dead = true; }
-
-    virtual bool can_read(const FileDescription&) const override { return !m_calls.is_empty() || m_dead; }
-    virtual int read(FileDescription&, u8*, int) override;
-
-    virtual bool can_write(const FileDescription&) const override { return true; }
-    virtual int write(FileDescription&, const u8*, int) override { return -EIO; }
-
-    virtual String absolute_path(const FileDescription&) const override;
-
-    void did_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3, u32 result);
-    pid_t pid() const { return m_pid; }
-
-private:
-    virtual const char* class_name() const override { return "ProcessTracer"; }
-    explicit ProcessTracer(pid_t);
-
-    struct CallData {
-        u32 function;
-        u32 arg1;
-        u32 arg2;
-        u32 arg3;
-        u32 result;
-    };
-
-    pid_t m_pid;
-    bool m_dead { false };
-    CircularQueue<CallData, 200> m_calls;
+struct [[gnu::packed]] PtraceRegisters
+{
+    uint32_t eax;
+    uint32_t ecx;
+    uint32_t edx;
+    uint32_t ebx;
+    uint32_t esp;
+    uint32_t ebp;
+    uint32_t esi;
+    uint32_t edi;
+    uint32_t eip;
+    uint32_t eflags;
+    uint32_t cs;
+    uint32_t ss;
+    uint32_t ds;
+    uint32_t es;
+    uint32_t fs;
+    uint32_t gs;
 };
-
-}

--- a/Libraries/LibC/sys/ptrace.cpp
+++ b/Libraries/LibC/sys/ptrace.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Kernel/Syscall.h>
+#include <errno.h>
+#include <sys/ptrace.h>
+
+extern "C" {
+
+int ptrace(int request, pid_t pid, void* addr, int data)
+{
+    Syscall::SC_ptrace_params params {
+        request,
+        pid,
+        reinterpret_cast<u8*>(addr),
+        data
+    };
+    int rc = syscall(SC_ptrace, &params);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+}

--- a/Libraries/LibC/sys/ptrace.h
+++ b/Libraries/LibC/sys/ptrace.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <sys/types.h>
+
+__BEGIN_DECLS
+
+#define PT_TRACE_ME 1
+#define PT_ATTACH 2
+#define PT_CONTINUE 3
+#define PT_SYSCALL 4
+#define PT_GETREGS 5
+#define PT_DETACH 6
+
+int ptrace(int request, pid_t pid, void* addr, int data);
+
+__END_DECLS

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -45,12 +45,6 @@
 
 extern "C" {
 
-int systrace(pid_t pid)
-{
-    int rc = syscall(SC_systrace, pid);
-    __RETURN_WITH_ERRNO(rc, rc, -1);
-}
-
 int chown(const char* pathname, uid_t uid, gid_t gid)
 {
     if (!pathname) {

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -58,7 +58,6 @@ int get_process_name(char* buffer, int buffer_size);
 void dump_backtrace();
 int fsync(int fd);
 void sysbeep();
-int systrace(pid_t);
 int gettid();
 int donate(int tid);
 int set_process_icon(int icon_id);


### PR DESCRIPTION
This upgrades our tracing mechanism from `systrace` to `ptrace`.
The interface of `ptrace()` is based on [openbsd's](https://man.openbsd.org/ptrace.2) implementation.

In the future we could use `ptrace` for a debugger,
but right now it's only used by `strace`.