### PR TITLE
NotificationServer: Update locations of notifications after closing one

### DIFF
--- a/Servers/NotificationServer/NotificationWindow.h
+++ b/Servers/NotificationServer/NotificationWindow.h
@@ -35,6 +35,7 @@ class NotificationWindow final : public GUI::Window {
 
 public:
     virtual ~NotificationWindow() override;
+    void set_original_rect(Gfx::Rect original_rect) { m_original_rect = original_rect; };
 
 private:
     NotificationWindow(const String& text, const String& title, const String& icon_path);


### PR DESCRIPTION
When multiple notifications are open and one notification in the
beginning or in the middle is closed the location of the remaining
notification windows are updated so that there is no gap between them.