### PR TITLE
Documentation: Add build dependencies for Fedora

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -3,8 +3,14 @@
 ### Linux prerequisites
 Make sure you have all the dependencies installed:
 
+**Debian / Ubuntu**
 ```bash
 sudo apt install build-essential curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs qemu-system-i386 qemu-utils
+```
+
+**Fedora**
+```bash
+sudo dnf install curl mpfr-devel libmpc-devel gmp-devel e2fsprogs @"C Development Tools and Libraries" @Virtualization
 ```
 
 Ensure your gcc version is >= 8 with `gcc --version`. Otherwise, install it (on Ubuntu) with:


### PR DESCRIPTION
I successfully built and ran SerenityOS (in QEMU, of course) on Fedora 31 today and thought I'd add the dependencies I had to install to the docs.

The `C Development Tools and Libraries` group is similar to `build-essential`, the `Virtualization` group [installs QEMU](https://www.qemu.org/download/).

Don't ask me why `mpc` has a `lib` prefix and `mpfr`/`gmp` don't.