### PR TITLE
LibJS: Handle empty strings and arrays in Value::to_number()

### DIFF
--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -27,7 +27,6 @@
 #include <AK/FlyString.h>
 #include <AK/Function.h>
 #include <LibJS/Interpreter.h>
-#include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/MathObject.h>
 
 namespace JS {
@@ -47,18 +46,7 @@ Value MathObject::abs(Interpreter& interpreter)
     if (interpreter.call_frame().arguments.is_empty())
         return js_nan();
 
-    auto argument = interpreter.call_frame().arguments[0];
-
-    if (argument.is_array()) {
-        auto& array = *static_cast<const Array*>(argument.as_object());
-        if (array.length() == 0)
-            return Value(0);
-        if (array.length() > 1)
-            return js_nan();
-        argument = array.elements()[0];
-    }
-
-    auto number = argument.to_number();
+    auto number = interpreter.call_frame().arguments[0].to_number();
     if (number.is_nan())
         return js_nan();
     return Value(number.as_double() >= 0 ? number.as_double() : -number.as_double());

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -28,6 +28,7 @@
 #include <AK/String.h>
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/PrimitiveString.h>
@@ -128,7 +129,16 @@ Value Value::to_number() const
     case Type::Undefined:
         return js_nan();
     case Type::Object:
-        return m_value.as_object->to_primitive(Object::PreferredType::Number).to_number();
+        if (m_value.as_object->is_array()) {
+            auto& array = *static_cast<Array*>(m_value.as_object);
+            if (array.length() == 0)
+                return Value(0);
+            if (array.length() > 1)
+                return js_nan();
+            return array.elements()[0].to_number();
+        } else {
+            return m_value.as_object->to_primitive(Object::PreferredType::Number).to_number();
+        }
     }
 
     ASSERT_NOT_REACHED();

--- a/Libraries/LibJS/Tests/to-number-basic.js
+++ b/Libraries/LibJS/Tests/to-number-basic.js
@@ -1,0 +1,33 @@
+function assert(x) { if (!x) throw 1; }
+
+// FIXME: Just "+x" doesn't parse currently,
+// so we use "x - 0", which is effectively the same.
+// "0 + x" would _not_ work in all cases.
+function n(x) { return x - 0; }
+
+try {
+    assert(n(false) === 0);
+    assert(n(true) === 1);
+    assert(n(null) === 0);
+    assert(n([]) === 0);
+    assert(n([[[[[]]]]]) === 0);
+    assert(n([[[[[42]]]]]) === 42);
+    assert(n("") === 0);
+    assert(n("42") === 42);
+    assert(n(42) === 42);
+    // FIXME: returns NaN
+    // assert(n("1.23") === 1.23)
+    // FIXME: chokes on ASSERT
+    // assert(n(1.23) === 1.23);
+
+    assert(isNaN(n(undefined)));
+    assert(isNaN(n({})));
+    assert(isNaN(n({a: 1})));
+    assert(isNaN(n([1, 2, 3])));
+    assert(isNaN(n([[[["foo"]]]])));
+    assert(isNaN(n("foo")));
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
- An empty string is converted to 0
- An empty array is converted to 0
- An array with one item is converted to that item's numeric value
- An array with more than one item is converted to NaN

Examples:

```js
+"" === 0
+[] === 0
+[[[[]]]] === 0
+[1] === 1
+[[[["42"]]]] === 42
isNaN(+["foo"]) === true
isNaN(+[1, 2, 3]) === true
isNaN(+[[[[1, 2, 3]]]]) === true
```

I also added some tests.