### PR TITLE
LibJS: Add Math constants

### DIFF
--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -28,6 +28,7 @@
 #include <AK/Function.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/MathObject.h>
+#include <LibM/math.h>
 
 namespace JS {
 
@@ -35,6 +36,15 @@ MathObject::MathObject()
 {
     put_native_function("abs", abs);
     put_native_function("random", random);
+
+    put("E", Value(M_E));
+    put("LN2", Value(M_LN2));
+    put("LN10", Value(M_LN10));
+    put("LOG2E", Value(log2(M_E)));
+    put("LOG10E", Value(log10(M_E)));
+    put("PI", Value(M_PI));
+    put("SQRT1_2", Value(sqrt(1 / 2)));
+    put("SQRT2", Value(sqrt(2)));
 }
 
 MathObject::~MathObject()

--- a/Libraries/LibJS/Tests/Math-constants.js
+++ b/Libraries/LibJS/Tests/Math-constants.js
@@ -1,0 +1,28 @@
+function assert(x) { if (!x) throw 1; }
+
+// FIXME: The parser seems to have issues with decimals,
+// so we multiply everything and compare with whole numbers.
+// I.e. 1233 < X * 1000 < 1235 instead of 1.233 < X < 1.235
+
+try {
+    // approx. 2.718
+    assert(2717 < Math.E * 1000 < 2719);
+    // approx. 0.693MATH
+    assert(692 < Math.LN2 * 1000 < 694);
+    // approx. 2.303
+    assert(2302 < Math.LN10 * 1000 < 2304);
+    // approx. 1.443
+    assert(1442 < Math.LOG2E * 1000 < 1444);
+    // approx. 0.434
+    assert(433 < Math.LOG10E * 1000 < 435);
+    // approx. 3.1415
+    assert(31414 < Math.PI * 10000 < 31416);
+    // approx. 0.707
+    assert(706 < Math.SQRT1_2 * 1000 < 708);
+    // approx. 1.414
+    assert(1413 < Math.SQRT2 * 1000 < 1415);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math#Properties

```js
Math.E
Math.LN2
Math.LN10
Math.LOG2E
Math.LOG10E
Math.PI
Math.SQRT1_2
Math.SQRT2
```