### PR TITLE
LibJS: Add arrow functions

### DIFF
--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -86,6 +86,7 @@ Lexer::Lexer(StringView source)
     }
 
     if (s_two_char_tokens.is_empty()) {
+        s_two_char_tokens.set("=>", TokenType::Arrow);
         s_two_char_tokens.set("+=", TokenType::PlusEquals);
         s_two_char_tokens.set("-=", TokenType::MinusEquals);
         s_two_char_tokens.set("*=", TokenType::AsteriskEquals);

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -67,6 +67,7 @@ public:
     NonnullRefPtr<Expression> parse_secondary_expression(NonnullRefPtr<Expression>, int min_precedence, Associativity associate = Associativity::Right);
     NonnullRefPtr<CallExpression> parse_call_expression(NonnullRefPtr<Expression>);
     NonnullRefPtr<NewExpression> parse_new_expression();
+    RefPtr<FunctionExpression> try_parse_arrow_function_expression(bool expect_parens);
 
     bool has_errors() const { return m_parser_state.m_has_errors; }
 

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -68,7 +68,7 @@ public:
     NonnullRefPtr<CallExpression> parse_call_expression(NonnullRefPtr<Expression>);
     NonnullRefPtr<NewExpression> parse_new_expression();
 
-    bool has_errors() const { return m_has_errors; }
+    bool has_errors() const { return m_parser_state.m_has_errors; }
 
 private:
     int operator_precedence(TokenType) const;
@@ -83,9 +83,18 @@ private:
     void expected(const char* what);
     Token consume();
     Token consume(TokenType type);
+    void save_state();
+    void load_state();
 
-    Lexer m_lexer;
-    Token m_current_token;
-    bool m_has_errors = false;
+    struct ParserState {
+        Lexer m_lexer;
+        Token m_current_token;
+        bool m_has_errors = false;
+
+        explicit ParserState(Lexer);
+    };
+
+    ParserState m_parser_state;
+    Optional<ParserState> m_saved_state;
 };
 }

--- a/Libraries/LibJS/Tests/arrow-functions.js
+++ b/Libraries/LibJS/Tests/arrow-functions.js
@@ -1,0 +1,57 @@
+function assert(x) { if (!x) throw 1; }
+try {
+  let getNumber = () => 42;
+  assert(getNumber() === 42);
+
+  let add = (a, b) => a + b;
+  assert(add(2, 3) === 5);
+
+  const addBlock = (a, b) => {
+    let res = a + b;
+    return res;
+  };
+  assert(addBlock(5, 4) === 9);
+
+  const makeObject = (a, b) => ({ a, b });
+  const obj = makeObject(33, 44);
+  assert(typeof obj === "object");
+  assert(obj.a === 33);
+  assert(obj.b === 44);
+
+  let returnUndefined = () => {};
+  assert(typeof returnUndefined() === "undefined");
+
+  const makeArray = (a, b) => [a, b];
+  const array = makeArray("3", { foo: 4 });
+  assert(array[0] === "3");
+  assert(array[1].foo === 4);
+
+  let square = x => x * x;
+  assert(square(3) === 9);
+
+  let squareBlock = x => {
+    return x * x;
+  };
+  assert(squareBlock(4) === 16);
+
+  const message = (who => "Hello " + who)("friends!");
+  assert(message === "Hello friends!");
+
+  const sum = ((x, y, z) => x + y + z)(1, 2, 3);
+  assert(sum === 6);
+
+  const product = ((x, y, z) => {
+    let res = x * y * z;
+    return res;
+  })(5, 4, 2);
+  assert(product === 40);
+
+  const half = (x => {
+    return x / 2;
+  })(10);
+  assert(half === 5);
+
+  console.log("PASS");
+} catch {
+  console.log("FAIL");
+}

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -34,6 +34,7 @@ namespace JS {
 #define ENUMERATE_JS_TOKENS                           \
     __ENUMERATE_JS_TOKEN(Ampersand)                   \
     __ENUMERATE_JS_TOKEN(AmpersandEquals)             \
+    __ENUMERATE_JS_TOKEN(Arrow)                       \
     __ENUMERATE_JS_TOKEN(Asterisk)                    \
     __ENUMERATE_JS_TOKEN(AsteriskAsteriskEquals)      \
     __ENUMERATE_JS_TOKEN(AsteriskEquals)              \


### PR DESCRIPTION
This PR add initial syntax support for arrow functions (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions). 
Notably missing is the correct binding of the `this` value in an arrow function (it should be the `this` in the function's containing scope). Also, arrow function should not be able to be used as constructors in `new` expressions. I think the correct `this` binding would work better with an implementation of [`Function.prototype.bind`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind), so that Function objects track their bound `this` value. I wanted to get things started with an initial syntax implementation.