### PR TITLE
Window icon related changes

### DIFF
--- a/Applications/SoundPlayer/main.cpp
+++ b/Applications/SoundPlayer/main.cpp
@@ -93,8 +93,8 @@ int main(int argc, char** argv)
     }));
 
     auto help_menu = GUI::Menu::construct("Help");
-    help_menu->add_action(GUI::Action::create("About", [](auto&) {
-        GUI::AboutDialog::show("SoundPlayer", Gfx::Bitmap::load_from_file("/res/icons/32x32/app-sound-player.png"));
+    help_menu->add_action(GUI::Action::create("About", [&](auto&) {
+        GUI::AboutDialog::show("SoundPlayer", Gfx::Bitmap::load_from_file("/res/icons/32x32/app-sound-player.png"), window);
     }));
 
     menubar->add_menu(move(app_menu));

--- a/Applications/Taskbar/TaskbarWindow.cpp
+++ b/Applications/Taskbar/TaskbarWindow.cpp
@@ -56,6 +56,8 @@ TaskbarWindow::TaskbarWindow()
     widget.set_frame_shape(Gfx::FrameShape::Panel);
     widget.set_frame_shadow(Gfx::FrameShadow::Raised);
 
+    m_default_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/window.png");
+
     WindowList::the().aid_create_button = [this](auto& identifier) {
         return create_button(identifier);
     };
@@ -137,6 +139,7 @@ NonnullRefPtr<GUI::Button> TaskbarWindow::create_button(const WindowIdentifier& 
     button.set_preferred_size(140, 22);
     button.set_checkable(true);
     button.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    button.set_icon(*m_default_icon);
     return button;
 }
 

--- a/Applications/Taskbar/TaskbarWindow.h
+++ b/Applications/Taskbar/TaskbarWindow.h
@@ -42,4 +42,6 @@ private:
     NonnullRefPtr<GUI::Button> create_button(const WindowIdentifier&);
 
     virtual void wm_event(GUI::WMEvent&) override;
+
+    RefPtr<Gfx::Bitmap> m_default_icon;
 };

--- a/Games/Solitaire/main.cpp
+++ b/Games/Solitaire/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv)
     app_menu->add_action(GUI::CommonActions::make_quit_action([&](auto&) { app.quit(); }));
 
     help_menu->add_action(GUI::Action::create("About", [&](auto&) {
-        GUI::AboutDialog::show("Solitaire", Gfx::Bitmap::load_from_file("/res/icons/32x32/app-solitaire.png"));
+        GUI::AboutDialog::show("Solitaire", Gfx::Bitmap::load_from_file("/res/icons/32x32/app-solitaire.png"), window);
     }));
 
     menu_bar->add_menu(move(app_menu));

--- a/Libraries/LibGUI/AboutDialog.cpp
+++ b/Libraries/LibGUI/AboutDialog.cpp
@@ -42,6 +42,9 @@ AboutDialog::AboutDialog(const StringView& name, const Gfx::Bitmap* icon, Window
     set_title(String::format("About %s", m_name.characters()));
     set_resizable(false);
 
+    if (parent_window)
+        set_icon(parent_window->icon());
+
     auto& widget = set_main_widget<Widget>();
     widget.set_fill_with_background_color(true);
     widget.set_layout<HorizontalBoxLayout>();


### PR DESCRIPTION
There are two user facing changes in this pull request:

1. About dialogs now inherit the icons of their parent windows:

![Screenshot_20200330_084228](https://user-images.githubusercontent.com/1627292/77884749-f8397580-7265-11ea-82cc-43bdcfcf4ce2.png)

2. The taskbar is now consistent with WindowServer how it displays windows without icons:

![Screenshot_20200330_084318](https://user-images.githubusercontent.com/1627292/77884757-fc659300-7265-11ea-8a7c-2b4eb6b5316c.png)
