### PR TITLE
LibJS: Throw TypeError when calling non-function object

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -66,8 +66,9 @@ Value CallExpression::execute(Interpreter& interpreter) const
     if (interpreter.exception())
         return {};
 
-    ASSERT(callee.is_object());
-    ASSERT(callee.as_object()->is_function());
+    if (!callee.is_object() || !callee.as_object()->is_function())
+        return interpreter.throw_exception<Error>("TypeError", String::format("%s is not a function", callee.to_string().characters()));
+
     auto* function = static_cast<Function*>(callee.as_object());
 
     auto& call_frame = interpreter.push_call_frame();

--- a/Libraries/LibJS/Tests/function-TypeError.js
+++ b/Libraries/LibJS/Tests/function-TypeError.js
@@ -1,0 +1,31 @@
+function assert(x) { if (!x) throw 1; }
+
+try {
+    try {
+        var b = true;
+        b();
+    } catch(e) {
+        assert(e.name === "TypeError");
+        assert(e.message === "true is not a function");
+    }
+
+    try {
+        var n = 100 + 20 + 3;
+        n();
+    } catch(e) {
+        assert(e.name === "TypeError");
+        assert(e.message === "123 is not a function");
+    }
+
+    try {
+        var o = {};
+        o.a();
+    } catch(e) {
+        assert(e.name === "TypeError");
+        assert(e.message === "undefined is not a function");
+    }
+
+    console.log("PASS");
+} catch(e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
We now have "undefined is not a function" :^)