### PR TITLE
Userland JS repl: add live syntax highlighting

### DIFF
--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -181,6 +181,8 @@ bool Lexer::is_block_comment_end() const
 void Lexer::syntax_error(const char* msg)
 {
     m_has_errors = true;
+    if (m_errors_allowed)
+        return; // do not spam stderr
     fprintf(stderr, "Syntax Error: %s\n", msg);
 }
 

--- a/Libraries/LibJS/Lexer.h
+++ b/Libraries/LibJS/Lexer.h
@@ -39,6 +39,7 @@ public:
     explicit Lexer(StringView source);
     Token next();
     bool has_errors() const { return m_has_errors; }
+    void allow_errors() { m_errors_allowed = true; }
 
 private:
     void consume();
@@ -56,6 +57,7 @@ private:
     Token m_current_token;
     int m_current_char;
     bool m_has_errors = false;
+    bool m_errors_allowed = false;
 
     static HashMap<String, TokenType> s_keywords;
     static HashMap<String, TokenType> s_three_char_tokens;

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -38,8 +38,26 @@
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/Value.h>
 #include <stdio.h>
+#include <termios.h>
+
+struct CodeState {
+    int open_curlies = 0;
+    int open_brackets = 0;
+    int open_parens = 0;
+
+    auto level() const
+    {
+        return open_parens + open_brackets + open_curlies;
+    }
+
+    struct termios old_termios;
+    struct termios m_termios;
+};
 
 bool dump_ast = false;
+
+static CodeState getcode_state {};
+ssize_t getcode(char** buffer, size_t* buffer_size, FILE* file, CodeState& state);
 
 String read_next_piece()
 {
@@ -47,14 +65,11 @@ String read_next_piece()
     int level = 0;
 
     do {
-        if (level == 0)
-            fprintf(stderr, "> ");
-        else
-            fprintf(stderr, ".%*c", 4 * level + 1, ' ');
+        fprintf(stderr, "> ");
 
         char* line = nullptr;
         size_t allocated_size = 0;
-        ssize_t nread = getline(&line, &allocated_size, stdin);
+        ssize_t nread = getcode(&line, &allocated_size, stdin, getcode_state);
         if (nread < 0) {
             if (errno == 0) {
                 // Explicit EOF; stop reading. Print a newline though, to make
@@ -69,24 +84,7 @@ String read_next_piece()
         }
 
         piece.append(line);
-        auto lexer = JS::Lexer(line);
-
-        for (JS::Token token = lexer.next(); token.type() != JS::TokenType::Eof; token = lexer.next()) {
-            switch (token.type()) {
-            case JS::TokenType::BracketOpen:
-            case JS::TokenType::CurlyOpen:
-            case JS::TokenType::ParenOpen:
-                level++;
-                break;
-            case JS::TokenType::BracketClose:
-            case JS::TokenType::CurlyClose:
-            case JS::TokenType::ParenClose:
-                level--;
-                break;
-            default:
-                break;
-            }
-        }
+        level = getcode_state.level();
 
         free(line);
     } while (level > 0);
@@ -186,6 +184,334 @@ void repl(JS::Interpreter& interpreter)
         auto result = interpreter.run(*program);
         print(result);
     }
+}
+
+ssize_t getcode(char** buffer, size_t* buffer_size, FILE* file, CodeState& state)
+{
+    char c;
+    size_t m_size = 0;
+    const int m_line_size = 256;
+    // FIXME: Read from file instead of defaulting to stdin
+    //        We might want to read from pipes afterall
+    (void)file;
+
+    tcgetattr(1, &state.old_termios);
+    state.m_termios = state.old_termios;
+    state.m_termios.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+    state.m_termios.c_oflag &= ~OPOST;
+    state.m_termios.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+    state.m_termios.c_cflag &= ~(CSIZE | PARENB);
+    state.m_termios.c_cflag |= CS8;
+    tcsetattr(1, TCSANOW, &state.m_termios);
+
+    if (!*buffer) {
+        // You dare lie to me?
+        ASSERT(*buffer_size == 0);
+
+        *buffer = static_cast<char*>(malloc(m_line_size));
+        *buffer_size = m_line_size;
+    }
+    auto m_buffer = *buffer;
+    int trailing_spaces = 0;
+
+    auto readch = [&] {
+        while ((c = fgetc(file)) == EOF) {
+        }
+        return true;
+    };
+
+    auto prev_level = state.level();
+
+    const StringView cRed = "\x1b[31m";
+    const StringView cYellow = "\x1b[33m";
+    const StringView cCyan = "\x1b[36m";
+    const StringView cGreen = "\x1b[32m";
+    //
+    const StringView cString = "\x1b[37m";
+    const StringView cNumber = "\x1b[35m";
+    const StringView cBool = "\x1b[32m";
+    const StringView cNull = "\x1b[33m";
+    const StringView cUndefined = "\x1b[34m";
+
+    const StringView cClear = "\x1b[0m";
+
+    bool escaped = false;
+
+    while (readch()) {
+        // TODO: we may want tab-completion?
+        switch (c) {
+        case ' ':
+            trailing_spaces++;
+            break;
+        case '\r':
+        case '\n':
+            // return
+            goto exit;
+        case 3: // C-c
+            m_size = 0;
+            escaped = true;
+            /* fallthrough */
+        case 4: // C-d - intentional EOF
+            goto exit;
+        case 8: // backspace
+            if (m_size > 1) {
+                m_size--;
+                c = m_buffer[--m_size];
+            } else {
+                m_size = 0;
+                c = 0;
+            }
+            if (trailing_spaces)
+                trailing_spaces--;
+            break;
+        default:
+            trailing_spaces = 0;
+            // FIXME: Other escapes are not handled
+            if (c < 15)
+                dbg() << "Likely unhandled escape code _" << (int)c << "_";
+            break;
+        }
+
+        if (c == 0)
+            goto write_line;
+
+        if (*buffer_size == m_size)
+            goto exit;
+
+        m_buffer[m_size++] = c;
+
+    write_line:;
+        m_buffer[m_size] = 0;
+        auto lexer = JS::Lexer(m_buffer);
+        lexer.allow_errors();
+
+        StringBuilder todisplay {};
+        int p_open_curlies = state.open_curlies;
+        int p_open_brackets = state.open_brackets;
+        int p_open_parens = state.open_parens;
+        bool started_with_closes = true;
+
+        for (JS::Token token = lexer.next(); token.type() != JS::TokenType::Eof; token = lexer.next()) {
+            switch (token.type()) {
+            case JS::TokenType::BracketOpen:
+                started_with_closes = false;
+                todisplay.append(cYellow);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                if (p_open_brackets)
+                    --p_open_brackets;
+                else
+                    state.open_brackets++;
+                break;
+            case JS::TokenType::CurlyOpen:
+                started_with_closes = false;
+                todisplay.append(cYellow);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                if (p_open_curlies)
+                    --p_open_curlies;
+                else
+                    state.open_curlies++;
+                break;
+            case JS::TokenType::ParenOpen:
+                started_with_closes = false;
+                todisplay.append(cYellow);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                if (p_open_parens)
+                    --p_open_parens;
+                else
+                    state.open_parens++;
+                break;
+            case JS::TokenType::BracketClose:
+                if (state.open_brackets > 0) {
+                    todisplay.append(cYellow);
+                    state.open_brackets--;
+                    if (started_with_closes)
+                        prev_level--;
+                } else {
+                    todisplay.append(cRed);
+                }
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                break;
+            case JS::TokenType::CurlyClose:
+                if (state.open_curlies > 0) {
+                    todisplay.append(cYellow);
+                    state.open_curlies--;
+                    if (started_with_closes)
+                        prev_level--;
+                } else {
+                    todisplay.append(cRed);
+                }
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                break;
+            case JS::TokenType::ParenClose:
+                if (state.open_parens > 0) {
+                    todisplay.append(cYellow);
+                    state.open_parens--;
+                    if (started_with_closes)
+                        prev_level--;
+                } else {
+                    todisplay.append(cRed);
+                }
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                break;
+            case JS::TokenType::Colon:
+                started_with_closes = false;
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                break;
+            case JS::TokenType::NumericLiteral:
+                started_with_closes = false;
+                todisplay.append(cNumber);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                break;
+            case JS::TokenType::NullLiteral:
+                started_with_closes = false;
+                todisplay.append(cNull);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                break;
+            case JS::TokenType::BoolLiteral:
+                started_with_closes = false;
+                todisplay.append(cBool);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                break;
+            case JS::TokenType::UndefinedLiteral:
+                started_with_closes = false;
+                todisplay.append(cUndefined);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                break;
+            case JS::TokenType::Semicolon:
+                started_with_closes = false;
+                todisplay.append(cYellow);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+            case JS::TokenType::Eof:
+                break;
+            case JS::TokenType::Identifier:
+                started_with_closes = false;
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                break;
+            case JS::TokenType::StringLiteral:
+                started_with_closes = false;
+                todisplay.append(cString);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                break;
+            case JS::TokenType::UnterminatedStringLiteral:
+                started_with_closes = false;
+                todisplay.append(cString);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cRed);
+                todisplay.append(token.value().substring_view(0, 1));
+                todisplay.append(cClear);
+                break;
+            case JS::TokenType::Ampersand:
+            case JS::TokenType::AmpersandEquals:
+            case JS::TokenType::Asterisk:
+            case JS::TokenType::AsteriskAsteriskEquals:
+            case JS::TokenType::AsteriskEquals:
+            case JS::TokenType::DoubleAmpersand:
+            case JS::TokenType::DoubleAsterisk:
+            case JS::TokenType::DoublePipe:
+            case JS::TokenType::DoubleQuestionMark:
+            case JS::TokenType::Equals:
+            case JS::TokenType::EqualsEquals:
+            case JS::TokenType::EqualsEqualsEquals:
+            case JS::TokenType::ExclamationMark:
+            case JS::TokenType::ExclamationMarkEquals:
+            case JS::TokenType::ExclamationMarkEqualsEquals:
+            case JS::TokenType::GreaterThan:
+            case JS::TokenType::GreaterThanEquals:
+            case JS::TokenType::LessThan:
+            case JS::TokenType::LessThanEquals:
+            case JS::TokenType::Minus:
+            case JS::TokenType::MinusEquals:
+            case JS::TokenType::MinusMinus:
+            case JS::TokenType::Percent:
+            case JS::TokenType::PercentEquals:
+            case JS::TokenType::Period:
+            case JS::TokenType::Pipe:
+            case JS::TokenType::PipeEquals:
+            case JS::TokenType::Plus:
+            case JS::TokenType::PlusEquals:
+            case JS::TokenType::PlusPlus:
+            case JS::TokenType::QuestionMark:
+            case JS::TokenType::QuestionMarkPeriod:
+            case JS::TokenType::ShiftLeft:
+            case JS::TokenType::ShiftLeftEquals:
+            case JS::TokenType::ShiftRight:
+            case JS::TokenType::ShiftRightEquals:
+            case JS::TokenType::Slash:
+            case JS::TokenType::SlashEquals:
+            case JS::TokenType::Tilde:
+            case JS::TokenType::UnsignedShiftRight:
+            case JS::TokenType::UnsignedShiftRightEquals:
+                started_with_closes = false;
+                todisplay.append(cYellow);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                break;
+            case JS::TokenType::Await:
+            case JS::TokenType::Catch:
+            case JS::TokenType::Do:
+            case JS::TokenType::Else:
+            case JS::TokenType::Finally:
+            case JS::TokenType::For:
+            case JS::TokenType::If:
+            case JS::TokenType::Return:
+            case JS::TokenType::Try:
+            case JS::TokenType::While:
+            case JS::TokenType::Yield:
+                started_with_closes = false;
+                todisplay.append(cGreen);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                break;
+            default:
+                started_with_closes = false;
+                todisplay.append(cCyan);
+                todisplay.append(token.trivia());
+                todisplay.append(token.value());
+                todisplay.append(cClear);
+                break;
+            }
+        }
+        fprintf(stderr,
+            "\x1b[999D\x1b[K>%*c%s%*c",
+            prev_level * 4 + 1,
+            ' ',
+            todisplay.to_string().characters(),
+            trailing_spaces,
+            ' ');
+    }
+exit:;
+    tcsetattr(1, TCSANOW, &state.old_termios);
+    printf("\n");
+    return escaped ? -1 : m_size;
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This PR adds live syntax highlighting to the js repl.
Some of the colours might be of questionable taste, however.