### PR TITLE
js: Implement print function for Date objects

### DIFF
--- a/Libraries/LibJS/Runtime/Date.h
+++ b/Libraries/LibJS/Runtime/Date.h
@@ -35,11 +35,16 @@ public:
     virtual ~Date() override;
 
     Core::DateTime& datetime() { return m_datetime; }
+    const Core::DateTime& datetime() const { return m_datetime; }
     u16 milliseconds() { return m_milliseconds; }
 
-    String date_string() { return m_datetime.to_string("%a %b %d %Y"); }
+    String date_string() const { return m_datetime.to_string("%a %b %d %Y"); }
     // FIXME: Deal with timezones once SerenityOS has a working tzset(3)
-    String time_string() { return m_datetime.to_string("%T GMT+0000 (UTC)"); }
+    String time_string() const { return m_datetime.to_string("%T GMT+0000 (UTC)"); }
+    String string() const
+    {
+        return String::format("%s %s", date_string().characters(), time_string().characters());
+    }
 
     virtual Value value_of() const override
     {

--- a/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -172,10 +172,7 @@ Value DatePrototype::to_string(Interpreter& interpreter)
     auto* this_object = this_date_from_interpreter(interpreter);
     if (!this_object)
         return {};
-    auto string = String::format(
-        "%s %s",
-        this_object->date_string().characters(),
-        this_object->time_string().characters());
+    auto string = this_object->string();
     return js_string(interpreter.heap(), move(string));
 }
 

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -33,6 +33,7 @@
 #include <LibJS/Interpreter.h>
 #include <LibJS/Parser.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/Function.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/PrimitiveString.h>
@@ -113,6 +114,11 @@ static void print_function(const JS::Object* function, HashTable<JS::Object*>&)
     printf("\033[34;1m[%s]\033[0m", function->class_name());
 }
 
+static void print_date(const JS::Object* date, HashTable<JS::Object*>&)
+{
+    printf("\033[34;1mDate %s\033[0m", static_cast<const JS::Date*>(date)->string().characters());
+}
+
 void print_value(JS::Value value, HashTable<JS::Object*>& seen_objects)
 {
     if (value.is_object()) {
@@ -127,12 +133,15 @@ void print_value(JS::Value value, HashTable<JS::Object*>& seen_objects)
 
     if (value.is_array())
         return print_array(static_cast<const JS::Array*>(value.as_object()), seen_objects);
-
-    if (value.is_object() && value.as_object()->is_function())
-        return print_function(value.as_object(), seen_objects);
-
-    if (value.is_object())
-        return print_object(value.as_object(), seen_objects);
+    
+    if (value.is_object()) {
+        auto* object = value.as_object();
+        if (object->is_function())
+            return print_function(object, seen_objects);
+        if (object->is_date())
+            return print_date(object, seen_objects);
+        return print_object(object, seen_objects);
+    }
 
     if (value.is_string())
         printf("\033[31;1m");


### PR DESCRIPTION
Currently, `js` prints out `Date` objects with the default object print function in the interactive mode:

```
$ js
> new Date()
{  }
>
```

This is not very useful. This patch adds a custom print function for `Date` Objects:

![image](https://user-images.githubusercontent.com/19366641/77946832-e0d8a780-72ba-11ea-954d-c838951d2b1f.png)

This is already more useful. I'm happy to implement a different format though.