### PR TITLE
LibJS: Implement different constructor/non-constructor behaviour for functions

### DIFF
--- a/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -47,6 +47,14 @@ DateConstructor::~DateConstructor()
 
 Value DateConstructor::call(Interpreter& interpreter)
 {
+    auto* date = static_cast<Date*>(construct(interpreter).as_object());
+    if (!date)
+        return {};
+    return js_string(interpreter.heap(), date->string());
+}
+
+Value DateConstructor::construct(Interpreter& interpreter)
+{
     // TODO: Support args
     struct timeval tv;
     gettimeofday(&tv, nullptr);

--- a/Libraries/LibJS/Runtime/DateConstructor.h
+++ b/Libraries/LibJS/Runtime/DateConstructor.h
@@ -36,8 +36,10 @@ public:
     virtual ~DateConstructor() override;
 
     virtual Value call(Interpreter&) override;
+    virtual Value construct(Interpreter&) override;
 
 private:
+    virtual bool has_constructor() const override { return true; }
     virtual const char* class_name() const override { return "DateConstructor"; }
 
     static Value now(Interpreter&);

--- a/Libraries/LibJS/Runtime/Function.h
+++ b/Libraries/LibJS/Runtime/Function.h
@@ -36,6 +36,7 @@ public:
     virtual ~Function();
 
     virtual Value call(Interpreter&) = 0;
+    virtual Value construct(Interpreter&) = 0;
 
 protected:
     Function();

--- a/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -44,4 +44,9 @@ Value NativeFunction::call(Interpreter& interpreter)
     return m_native_function(interpreter);
 }
 
+Value NativeFunction::construct(Interpreter&)
+{
+    return {};
+}
+
 }

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -37,6 +37,9 @@ public:
     virtual ~NativeFunction() override;
 
     virtual Value call(Interpreter&) override;
+    virtual Value construct(Interpreter&) override;
+
+    virtual bool has_constructor() const { return false; }
 
 protected:
     NativeFunction() {}

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -50,6 +50,11 @@ Value ObjectConstructor::call(Interpreter& interpreter)
     return interpreter.heap().allocate<Object>();
 }
 
+Value ObjectConstructor::construct(Interpreter& interpreter)
+{
+    return call(interpreter);
+}
+
 Value ObjectConstructor::get_own_property_names(Interpreter& interpreter)
 {
     if (interpreter.call_frame().arguments.size() < 1)

--- a/Libraries/LibJS/Runtime/ObjectConstructor.h
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.h
@@ -36,8 +36,10 @@ public:
     virtual ~ObjectConstructor() override;
 
     virtual Value call(Interpreter&) override;
+    virtual Value construct(Interpreter&) override;
 
 private:
+    virtual bool has_constructor() const override { return true; }
     virtual const char* class_name() const override { return "ObjectConstructor"; }
 
     static Value get_own_property_names(Interpreter&);

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -55,4 +55,9 @@ Value ScriptFunction::call(Interpreter& interpreter)
     return interpreter.run(m_body, arguments, ScopeType::Function);
 }
 
+Value ScriptFunction::construct(Interpreter& interpreter)
+{
+    return call(interpreter);
+}
+
 }

--- a/Libraries/LibJS/Runtime/ScriptFunction.h
+++ b/Libraries/LibJS/Runtime/ScriptFunction.h
@@ -39,6 +39,7 @@ public:
     const Vector<FlyString>& parameters() const { return m_parameters; };
 
     virtual Value call(Interpreter&) override;
+    virtual Value construct(Interpreter&) override;
 
 private:
     virtual bool is_script_function() const final { return true; }

--- a/Libraries/LibJS/Tests/function-TypeError.js
+++ b/Libraries/LibJS/Tests/function-TypeError.js
@@ -25,6 +25,27 @@ try {
         assert(e.message === "undefined is not a function");
     }
 
+    try {
+        Math();
+    } catch(e) {
+        assert(e.name === "TypeError");
+        assert(e.message === "[object MathObject] is not a function");
+    }
+
+    try {
+        new Math();
+    } catch(e) {
+        assert(e.name === "TypeError");
+        assert(e.message === "[object MathObject] is not a constructor");
+    }
+
+    try {
+        new isNaN();
+    } catch(e) {
+        assert(e.name === "TypeError");
+        assert(e.message === "[object NativeFunction] is not a constructor");
+    }
+
     console.log("PASS");
 } catch(e) {
     console.log("FAIL: " + e);


### PR DESCRIPTION
This adds `Function::construct()` for constructor function calls via `new` keyword. `NativeFunction` doesn't have constructor behaviour by default, `ScriptFunction` simply calls `call()` in `construct()`.

This functionality is required for `Boolean`, `Date`, `Number`, `String`, etc.:

```js
typeof Boolean() === "boolean"
typeof new Boolean() === "object"

typeof Date() === "string"
typeof new Date() === "object"

typeof Number() === "number"
typeof new Number() === "object"

typeof String() === "string"
typeof new String() === "object"
```

I already implemented this for `Date` - quoting MDN:

> **Note:** The only correct way to instantiate a new `Date` object is by using the `new` operator. If you simply call the `Date` object directly, such as `now = Date()`, the returned value is a string rather than a `Date` object.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date

![image](https://user-images.githubusercontent.com/19366641/78071108-cd9a0a80-7394-11ea-96e4-254fb7e363a4.png)
