### PR TITLE
Base: Change root user home directory from `/` to `/root`

### DIFF
--- a/Base/etc/passwd
+++ b/Base/etc/passwd
@@ -1,4 +1,4 @@
-root:x:0:0:root:/:/bin/sh
+root:x:0:0:root:/root:/bin/sh
 lookup:x:10:10:LookupServer,,,:/:/bin/false
 protocol:x:11:11:ProtocolServer,,,:/:/bin/false
 notify:x:12:12:NotificationServer,,,:/:/bin/false

--- a/Kernel/build-root-filesystem.sh
+++ b/Kernel/build-root-filesystem.sh
@@ -92,12 +92,15 @@ chown $window_uid:$window_gid mnt/etc/WindowServer/WindowServer.ini
 echo "done"
 
 printf "installing users... "
+mkdir -p mnt/root
 mkdir -p mnt/home/anon
 mkdir -p mnt/home/nona
 cp ../ReadMe.md mnt/home/anon/
 cp -r ../Libraries/LibJS/Tests mnt/home/anon/js-tests
+chmod 700 mnt/root
 chmod 700 mnt/home/anon
 chmod 700 mnt/home/nona
+chown -R 0:0 mnt/root
 chown -R 100:100 mnt/home/anon
 chown -R 200:200 mnt/home/nona
 echo "done"


### PR DESCRIPTION
Change root user home directory from `/` to `/root`.

This is much safer from a security and privacy perspective, as configuration files are no longer stored and loaded from `/`.

This also prevents loading and storing application configuration files from the `/tmp/` directory when running as root, as the [ConfigFile::get_for_app](https://github.com/SerenityOS/serenity/blob/master/Libraries/LibCore/ConfigFile.cpp) function contains a hard-coded check for a home directory `get_current_user_home_path()` of `/` and falls back to `/tmp` which is unsafe.

```cpp
NonnullRefPtr<ConfigFile> ConfigFile::get_for_app(const String& app_name)
{
    String home_path = get_current_user_home_path();
    if (home_path == "/")
        home_path = String::format("/tmp");
    auto path = String::format("%s/%s.ini", home_path.characters(), app_name.characters());
    return adopt(*new ConfigFile(path));
}
```

This function should also be reviewed.