### PR TITLE
AK: Print double numbers with printf & A few JSON improvements

### DIFF
--- a/AK/JsonObjectSerializer.h
+++ b/AK/JsonObjectSerializer.h
@@ -109,6 +109,12 @@ public:
         m_builder.appendf("%llu", value);
     }
 
+    void add(const StringView& key, double value)
+    {
+        begin_item(key);
+        m_builder.appendf("%f", value);
+    }
+
     JsonArraySerializer<Builder> add_array(const StringView& key)
     {
         begin_item(key);

--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -100,8 +100,10 @@ String JsonParser::consume_quoted_string()
         char escaped_ch = consume();
         switch (escaped_ch) {
         case 'n':
-        case 'r':
             buffer.append('\n');
+            break;
+        case 'r':
+            buffer.append('\r');
             break;
         case 't':
             buffer.append('\t');
@@ -225,6 +227,7 @@ JsonValue JsonParser::parse_number()
         ASSERT(ok);
 
         int fraction = fraction_string.to_uint(ok);
+        fraction *= (whole < 0) ? -1 : 1;
         ASSERT(ok);
 
         auto divider = 1;

--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -178,6 +178,26 @@ template<typename PutChFunc>
 }
 
 template<typename PutChFunc>
+[[gnu::always_inline]] inline int print_double(PutChFunc putch, char*& bufptr, double number, bool leftPad, bool zeroPad, u32 fieldWidth)
+{
+    int length = 0;
+
+    if (number < 0) {
+        putch(bufptr, '-');
+        length++;
+        number = 0 - number;
+    }
+
+    length = print_u64(putch, bufptr, (i64)number, leftPad, zeroPad, fieldWidth);
+    putch(bufptr, '.');
+    length++;
+    double fraction = number - (i64)number;
+    // FIXME: Allow other fractions
+    fraction = fraction * 1000000;
+    return length + print_u64(putch, bufptr, (i64)fraction, leftPad, true, 6);
+}
+
+template<typename PutChFunc>
 [[gnu::always_inline]] inline int print_i64(PutChFunc putch, char*& bufptr, i64 number, bool leftPad, bool zeroPad, u32 fieldWidth)
 {
     if (number < 0) {
@@ -361,8 +381,7 @@ template<typename PutChFunc>
 #if !defined(BOOTSTRAPPER) && !defined(KERNEL)
             case 'g':
             case 'f':
-                // FIXME: Print as float!
-                ret += print_i64(putch, bufptr, (u64)va_arg(ap, double), left_pad, zeroPad, fieldWidth);
+                ret += print_double(putch, bufptr, va_arg(ap, double), left_pad, zeroPad, fieldWidth);
                 break;
 #endif
 


### PR DESCRIPTION
Hi Andreas,

here a few small improvements I found during implementing the JSON schema validator. I know the double printing could be improved a lot with the "%x.yf" notion, but today I have only a limited version that has %.6f implemented ;-)
