### PR TITLE
AK: Add equals method to JsonValue to semantically compare two values.

### DIFF
--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -238,6 +238,8 @@ public:
         return default_value;
     }
 
+    bool equals(const JsonValue& other) const;
+
 private:
     void clear();
     void copy_from(const JsonValue&);


### PR DESCRIPTION
This patchsets adds the semantic check of two values. One first approach
was to compare the (generated) json strings of the two values. This works
out in the most cases, but not with numbers, where "1.0" and "1" in JSON
format are semantically the same. Therefore, this patch adds deep (recursive)
check of two JsonValues.