### PR TITLE
Browser: Add error page

### DIFF
--- a/Base/res/html/error.html
+++ b/Base/res/html/error.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Error!</title>
+        <style>
+            h1 {
+                display: inline;
+            }
+            header {
+                margin-bottom: 10px;
+            }
+        </style>
+    </head>
+    <body>
+        <header>
+            <img src="file:///res/icons/32x32/msgbox-warning.png" alt="Warning" width="24" height="24">
+            <h1>Failed to load %s</h1>
+        </header>
+        <p>Error: %s</p>
+    </body>
+</html>

--- a/Libraries/LibWeb/HtmlView.h
+++ b/Libraries/LibWeb/HtmlView.h
@@ -50,6 +50,7 @@ public:
 
     void reload();
     void load(const URL&);
+    void load_error_page(const URL&, const String& error);
     void scroll_to_anchor(const StringView&);
 
     URL url() const;

--- a/Libraries/LibWeb/ResourceLoader.h
+++ b/Libraries/LibWeb/ResourceLoader.h
@@ -41,7 +41,7 @@ class ResourceLoader : public Core::Object {
 public:
     static ResourceLoader& the();
 
-    void load(const URL&, Function<void(const ByteBuffer&)>);
+    void load(const URL&, Function<void(const ByteBuffer&)> success_callback, Function<void(const String&)> error_callback = nullptr);
 
     Function<void()> on_load_counter_change;
 


### PR DESCRIPTION
Add a simple HTML error page, populated via string formatting, that gets loaded into the `HtmlView` when loading the page fails.

There's a lot of room for improvements - most importantly `Protocol::Client` should expose error messages. But at least the browser does crash less now :)

Closes #1210 and #1516.

![image](https://user-images.githubusercontent.com/19366641/78082987-3e98ec80-73ac-11ea-9908-766405679c1b.png)

![image](https://user-images.githubusercontent.com/19366641/78083054-638d5f80-73ac-11ea-9e54-d6c33bf32d0b.png)

![image](https://user-images.githubusercontent.com/19366641/78083135-8c155980-73ac-11ea-9137-86b8c6b3933b.png)

![image](https://user-images.githubusercontent.com/19366641/78083187-ae0edc00-73ac-11ea-8932-b28e09b5814c.png)

(I don't really understand the last one, does it try to read the directory?)

---

![image](https://user-images.githubusercontent.com/19366641/78083769-5c675100-73ae-11ea-8a2f-358b2e27367a.png)
