### PR TITLE
IRCClient: Add Channel application menu and LIST and KICK commands

### DIFF
--- a/Applications/IRCClient/IRCAppWindow.h
+++ b/Applications/IRCClient/IRCAppWindow.h
@@ -55,9 +55,12 @@ private:
     RefPtr<GUI::StackWidget> m_container;
     RefPtr<GUI::TableView> m_window_list;
     RefPtr<GUI::Action> m_join_action;
+    RefPtr<GUI::Action> m_list_channels_action;
     RefPtr<GUI::Action> m_part_action;
     RefPtr<GUI::Action> m_whois_action;
     RefPtr<GUI::Action> m_open_query_action;
     RefPtr<GUI::Action> m_close_query_action;
     RefPtr<GUI::Action> m_change_nick_action;
+    RefPtr<GUI::Action> m_change_topic_action;
+    RefPtr<GUI::Action> m_kick_user_action;
 };

--- a/Applications/IRCClient/IRCClient.h
+++ b/Applications/IRCClient/IRCClient.h
@@ -99,12 +99,15 @@ public:
     void handle_user_input_in_query(const String& query_name, const String&);
     void handle_user_input_in_server(const String&);
 
+    void handle_list_channels_action();
     void handle_whois_action(const String&);
     void handle_open_query_action(const String&);
     void handle_close_query_action(const String&);
     void handle_join_action(const String&);
     void handle_part_action(const String&);
     void handle_change_nick_action(const String&);
+    void handle_change_topic_action(const String& channel_name, const String&);
+    void handle_kick_user_action(const String& channel_name, const String& nick, const String&);
 
     IRCQuery* query_with_name(const String&);
     IRCQuery& ensure_query(const String& name);
@@ -134,6 +137,8 @@ private:
     void send_privmsg(const String& target, const String&);
     void send_notice(const String& target, const String&);
     void send_topic(const String& channel_name, const String&);
+    void send_kick(const String& channel_name, const String& nick, const String&);
+    void send_list();
     void send_whois(const String&);
     void process_line(ByteBuffer&&);
     void handle_join(const Message&);


### PR DESCRIPTION
The new Channel application menu allow offers various commands
related to the currently visible channel, including changing
the topic, kicking a user, and leaving the channel.

The implemented `/kick` command does not strictly follow [the specification](https://tools.ietf.org/html/rfc2812#section-3.2.8), and expects commands in the form of "/kick <#channel> <nick> [reason]".

The specification does not require a `reason`, and allows for specifying multiple channels and users, so long as the number of users and channels is equal.

Also, the `/kick` command, like other existing commands such as `/part`, does not take into account the currently selected channel. Ideally, issuing `/kick <user>` should also work when viewing a channel window. I'm leaving this for a separate PR.
