### PR TITLE
Replace superuser with Good Boy Points

### DIFF
--- a/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Applications/SystemMonitor/ProcessModel.cpp
@@ -75,6 +75,8 @@ String ProcessModel::column_name(int column) const
         return "PID";
     case Column::TID:
         return "TID";
+    case Column::GBPs:
+        return "GBPs";
     case Column::State:
         return "State";
     case Column::User:
@@ -136,6 +138,8 @@ GUI::Model::ColumnMetadata ProcessModel::column_metadata(int column) const
     case Column::PID:
         return { 32, Gfx::TextAlignment::CenterRight };
     case Column::TID:
+        return { 32, Gfx::TextAlignment::CenterRight };
+    case Column::GBPs:
         return { 32, Gfx::TextAlignment::CenterRight };
     case Column::State:
         return { 75, Gfx::TextAlignment::CenterLeft };
@@ -210,6 +214,8 @@ GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, Role role) const
             return thread.current_state.pid;
         case Column::TID:
             return thread.current_state.tid;
+        case Column::GBPs:
+            return thread.current_state.gbps;
         case Column::State:
             return thread.current_state.state;
         case Column::User:
@@ -279,6 +285,8 @@ GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, Role role) const
             return thread.current_state.pid;
         case Column::TID:
             return thread.current_state.tid;
+        case Column::GBPs:
+            return thread.current_state.gbps;
         case Column::State:
             return thread.current_state.state;
         case Column::User:
@@ -350,6 +358,7 @@ void ProcessModel::update()
             state.user = it.value.username;
             state.pledge = it.value.pledge;
             state.veil = it.value.veil;
+            state.gbps = it.value.gbps;
             state.syscall_count = thread.syscall_count;
             state.inode_faults = thread.inode_faults;
             state.zero_faults = thread.zero_faults;

--- a/Applications/SystemMonitor/ProcessModel.h
+++ b/Applications/SystemMonitor/ProcessModel.h
@@ -55,6 +55,7 @@ public:
         User,
         PID,
         TID,
+        GBPs,
         Virtual,
         Physical,
         DirtyPrivate,
@@ -96,6 +97,7 @@ private:
     struct ThreadState {
         int tid;
         pid_t pid;
+        gbps_t gbps;
         unsigned times_scheduled;
         String name;
         String state;

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -11,6 +11,7 @@ Lazy=1
 Priority=low
 KeepAlive=1
 User=protocol
+GoodBoyPoints=0
 
 [LookupServer]
 Socket=/tmp/portal/lookup
@@ -27,6 +28,7 @@ Lazy=1
 Priority=low
 KeepAlive=1
 User=notify
+GoodBoyPoints=0
 
 [WindowServer]
 Socket=/tmp/portal/window
@@ -42,19 +44,23 @@ User=anon
 [Clock.MenuApplet]
 KeepAlive=1
 User=anon
+GoodBoyPoints=0
 
 [CPUGraph.MenuApplet]
 KeepAlive=1
 User=anon
+GoodBoyPoints=0
 
 [Audio.MenuApplet]
 KeepAlive=1
 User=anon
+GoodBoyPoints=0
 
 [UserName.MenuApplet]
 Priority=low
 KeepAlive=1
 User=anon
+GoodBoyPoints=0
 
 [AudioServer]
 Socket=/tmp/portal/audio
@@ -71,3 +77,4 @@ User=anon
 [Terminal]
 User=anon
 WorkingDirectory=/home/anon
+GoodBoyPoints=30

--- a/Base/usr/share/man/man1/getgbps.md
+++ b/Base/usr/share/man/man1/getgbps.md
@@ -1,0 +1,24 @@
+## Name
+
+getgbps - get number of good boy points
+
+## Synopsis
+
+```**sh
+$ getgbps
+```
+
+## Description
+
+This program reports the number of good boy points it is given.
+
+## Examples
+
+```sh
+$ getgbps
+7
+```
+
+## See also
+
+* [`getgbps`(2)](../man2/getgbps.md)

--- a/Base/usr/share/man/man2/getgbps.md
+++ b/Base/usr/share/man/man2/getgbps.md
@@ -1,0 +1,19 @@
+## Name
+
+getgbps - get number of good boy points
+
+## Synopsis
+
+```**c++
+#include <unistd.h>
+
+gbps_t getgbps(void);
+```
+
+## Description
+
+`getgbps()` returns the number of good boy points the current process has.
+
+## See also
+
+* [`getgbps`(1)](../man1/getgbps.md)

--- a/Base/usr/share/man/man5/SystemServer.md
+++ b/Base/usr/share/man/man5/SystemServer.md
@@ -26,6 +26,7 @@ describing how to launch and manage this service.
 * `SocketPermissions` - (octal) file system permissions for the socket file. The default permissions are 0600.
 * `User` - a name of the user to run the service as. This impacts what UID, GID (and extra GIDs) the service processes have. By default, services are run as root.
 * `WorkingDirectory` - The working directory in which the service is spawned. By Default, services are spawned in the root (`"/"`) directory.
+* `GoodBoyPoints` - how many good boy points the service process should start with.
 
 ## Environment
 

--- a/Kernel/FileSystem/InodeMetadata.h
+++ b/Kernel/FileSystem/InodeMetadata.h
@@ -50,6 +50,7 @@ inline bool is_socket(mode_t mode) { return (mode & 0170000) == 0140000; }
 inline bool is_sticky(mode_t mode) { return mode & 01000; }
 inline bool is_setuid(mode_t mode) { return mode & 04000; }
 inline bool is_setgid(mode_t mode) { return mode & 02000; }
+inline bool is_setgbps(mode_t mode) { return mode & 010000; }
 
 struct InodeMetadata {
     bool is_valid() const { return inode.is_valid(); }
@@ -102,6 +103,7 @@ struct InodeMetadata {
     bool is_sticky() const { return Kernel::is_sticky(mode); }
     bool is_setuid() const { return Kernel::is_setuid(mode); }
     bool is_setgid() const { return Kernel::is_setgid(mode); }
+    bool is_setgbps() const { return Kernel::is_setgbps(mode); }
 
     KResult stat(stat& buffer) const
     {
@@ -128,6 +130,7 @@ struct InodeMetadata {
     mode_t mode { 0 };
     uid_t uid { 0 };
     gid_t gid { 0 };
+    gbps_t gbps { 0 };
     nlink_t link_count { 0 };
     time_t atime { 0 };
     time_t ctime { 0 };

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -295,7 +295,7 @@ Optional<KBuffer> procfs$pid_vm(InodeIdentifier identifier)
     KBufferBuilder builder;
     JsonArraySerializer array { builder };
     for (auto& region : process.regions()) {
-        if (!region.is_user_accessible() && !Process::current->is_superuser())
+        if (!region.is_user_accessible() && Process::current->gbps() < 20)
             continue;
         auto region_object = array.add_object();
         region_object.add("readable", region.is_readable());
@@ -438,7 +438,7 @@ Optional<KBuffer> procfs$profile(InodeIdentifier)
     object.add("executable", Profiling::executable_path());
 
     auto array = object.add_array("events");
-    bool mask_kernel_addresses = !Process::current->is_superuser();
+    bool mask_kernel_addresses = Process::current->gbps() < 20;
     Profiling::for_each_sample([&](auto& sample) {
         auto object = array.add_object();
         object.add("type", "sample");

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -881,6 +881,7 @@ Optional<KBuffer> procfs$all(InodeIdentifier)
         process_object.add("uid", process.uid());
         process_object.add("gid", process.gid());
         process_object.add("ppid", process.ppid());
+        process_object.add("gbps", process.gbps());
         process_object.add("nfds", process.number_of_open_file_descriptors());
         process_object.add("name", process.name());
         process_object.add("tty", process.tty() ? process.tty()->tty_name() : "notty");

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -389,8 +389,8 @@ KResult LocalSocket::chown(uid_t uid, gid_t gid)
     if (m_file)
         return m_file->chown(uid, gid);
 
-    if (!Process::current->is_superuser() && (Process::current->euid() != uid || !Process::current->in_group(gid)))
-        return KResult(-EPERM);
+    if (Process::current->gbps() < 20 && (Process::current->euid() != uid || !Process::current->in_group(gid)))
+        return KResult(-ENOGBPS);
 
     m_prebind_uid = uid;
     m_prebind_gid = gid;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -4961,3 +4961,8 @@ bool Process::has_tracee_thread(int tracer_pid) const
 }
 
 }
+
+gbps_t Process::sys$getgbps()
+{
+    return m_gbps;
+}

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -951,6 +951,10 @@ int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Ve
 
     auto main_program_metadata = main_program_description->metadata();
 
+    if (main_program_metadata.is_setgbps()) {
+        m_gbps = main_program_metadata.gbps;
+    }
+
     if (!(main_program_description->custody()->mount_flags() & MS_NOSUID)) {
         if (main_program_metadata.is_setuid())
             m_euid = main_program_metadata.uid;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -693,6 +693,7 @@ pid_t Process::sys$fork(RegisterState& regs)
     child->m_execpromises = m_execpromises;
     child->m_veil_state = m_veil_state;
     child->m_unveiled_paths = m_unveiled_paths;
+    child->m_gbps = m_gbps;
     child->m_fds = m_fds;
     child->m_sid = m_sid;
     child->m_pgid = m_pgid;
@@ -1305,6 +1306,9 @@ Process* Process::create_user_process(Thread*& first_thread, const String& path,
     process->m_fds[0].set(*description);
     process->m_fds[1].set(*description);
     process->m_fds[2].set(*description);
+
+    // Kernel-created processes start with 35 GBPs.
+    process->m_gbps = 35;
 
     error = process->exec(path, move(arguments), move(environment));
     if (error != 0) {

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -140,6 +140,7 @@ public:
     uid_t euid() const { return m_euid; }
     gid_t egid() const { return m_egid; }
     pid_t ppid() const { return m_ppid; }
+    gbps_t gbps() const { return m_gbps; }
 
     pid_t exec_tid() const { return m_exec_tid; }
 
@@ -300,6 +301,7 @@ public:
     int sys$perf_event(int type, FlatPtr arg1, FlatPtr arg2);
     int sys$get_stack_bounds(FlatPtr* stack_base, size_t* stack_size);
     int sys$ptrace(const Syscall::SC_ptrace_params*);
+    gbps_t sys$getgbps();
 
     template<bool sockname, typename Params>
     int get_sock_or_peer_name(const Params&);
@@ -457,6 +459,8 @@ private:
     pid_t m_pgid { 0 };
 
     pid_t m_exec_tid { 0 };
+
+    int m_gbps { 0 };
 
     static const int m_max_open_file_descriptors { FD_SETSIZE };
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -371,8 +371,6 @@ public:
 
     int exec(String path, Vector<String> arguments, Vector<String> environment, int recusion_depth = 0);
 
-    bool is_superuser() const { return m_euid == 0; }
-
     Region* allocate_region_with_vmobject(VirtualAddress, size_t, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, const String& name, int prot);
     Region* allocate_region(VirtualAddress, size_t, const String& name, int prot = PROT_READ | PROT_WRITE, bool commit = true);
     Region* allocate_region_with_vmobject(const Range&, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, const String& name, int prot);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -324,6 +324,12 @@ public:
     u32 m_ticks_in_user_for_dead_children { 0 };
     u32 m_ticks_in_kernel_for_dead_children { 0 };
 
+    void decrement_gbps()
+    {
+        if (m_gbps > 0)
+            m_gbps--;
+    }
+
     bool validate_read_from_kernel(VirtualAddress, size_t) const;
 
     bool validate_read(const void*, size_t) const;

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -115,7 +115,10 @@ int handle(RegisterState& regs, u32 function, u32 arg1, u32 arg2, u32 arg3)
         dbg() << process << ": Null syscall " << function << " requested: \"" << to_string((Function)function) << "\", you probably need to rebuild this program.";
         return -ENOSYS;
     }
-    return (process.*(s_syscall_table[function]))(arg1, arg2, arg3);
+    int rc = (process.*(s_syscall_table[function]))(arg1, arg2, arg3);
+    if (rc < 0)
+        process.decrement_gbps();
+    return rc;
 }
 
 }

--- a/Kernel/Syscall.h
+++ b/Kernel/Syscall.h
@@ -182,7 +182,8 @@ namespace Kernel {
     __ENUMERATE_SYSCALL(perf_event)           \
     __ENUMERATE_SYSCALL(shutdown)             \
     __ENUMERATE_SYSCALL(get_stack_bounds)     \
-    __ENUMERATE_SYSCALL(ptrace)
+    __ENUMERATE_SYSCALL(ptrace)               \
+    __ENUMERATE_SYSCALL(getgbps)
 
 namespace Syscall {
 

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -783,7 +783,7 @@ static bool symbolicate(const RecognizedSymbol& symbol, const Process& process, 
     if (!symbol.address)
         return false;
 
-    bool mask_kernel_addresses = !process.is_superuser();
+    bool mask_kernel_addresses = process.gbps() < 10;
     if (!symbol.ksym) {
         if (!is_user_address(VirtualAddress(symbol.address))) {
             builder.append("0xdeadc0de\n");

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -262,6 +262,7 @@ typedef u32 gid_t;
 typedef u32 clock_t;
 typedef u32 socklen_t;
 typedef int pid_t;
+typedef int gbps_t;
 
 struct tms {
     clock_t tms_utime;

--- a/Libraries/LibC/errno_numbers.h
+++ b/Libraries/LibC/errno_numbers.h
@@ -99,4 +99,5 @@
 #define ENOTHREAD 70
 #define EPROTO 71
 #define ENOTSUP 72
-#define EMAXERRNO 73
+#define ENOGBPS 73
+#define EMAXERRNO 74

--- a/Libraries/LibC/string.cpp
+++ b/Libraries/LibC/string.cpp
@@ -422,6 +422,7 @@ const char* const sys_errlist[] = {
     "No such thread",
     "Protocol error",
     "Not supported",
+    "No tendies for you",
     "The highest errno +1 :^)",
 };
 

--- a/Libraries/LibC/sys/types.h
+++ b/Libraries/LibC/sys/types.h
@@ -44,6 +44,7 @@ typedef int __pid_t;
 #define pid_t __pid_t
 
 typedef int id_t;
+typedef int gbps_t;
 
 typedef int __ssize_t;
 #define ssize_t __ssize_t

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -582,6 +582,12 @@ int reboot()
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+gbps_t getgbps()
+{
+    int rc = syscall(SC_getgbps);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
 int mount(const char* source, const char* target, const char* fs_type, int flags)
 {
     if (!source || !target || !fs_type) {

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -133,6 +133,7 @@ int mount(const char* source, const char* target, const char* fs_type, int flags
 int umount(const char* mountpoint);
 int pledge(const char* promises, const char* execpromises);
 int unveil(const char* path, const char* permissions);
+gbps_t getgbps(void);
 char* getpass(const char* prompt);
 
 enum {

--- a/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -60,6 +60,7 @@ HashMap<pid_t, Core::ProcessStatistics> ProcessStatisticsReader::get_all()
         process.uid = process_object.get("uid").to_u32();
         process.gid = process_object.get("gid").to_u32();
         process.ppid = process_object.get("ppid").to_u32();
+        process.gbps = process_object.get("gbps").to_u32();
         process.nfds = process_object.get("nfds").to_u32();
         process.name = process_object.get("name").to_string();
         process.tty = process_object.get("tty").to_string();

--- a/Libraries/LibCore/ProcessStatisticsReader.h
+++ b/Libraries/LibCore/ProcessStatisticsReader.h
@@ -62,6 +62,7 @@ struct ProcessStatistics {
     uid_t uid;
     gid_t gid;
     pid_t ppid;
+    gbps_t gbps;
     unsigned nfds;
     String name;
     String tty;

--- a/Servers/SystemServer/Service.cpp
+++ b/Servers/SystemServer/Service.cpp
@@ -246,6 +246,13 @@ void Service::spawn()
             }
         }
 
+        // Drop GBPs. We use an invalid syscall for this.
+        while (getgbps() > m_gbps) {
+            rc = read(0, nullptr, 1);
+            ASSERT(errno == EFAULT);
+            ASSERT(rc == -1);
+        }
+
         char* argv[m_extra_arguments.size() + 2];
         argv[0] = const_cast<char*>(m_executable_path.characters());
         for (size_t i = 0; i < m_extra_arguments.size(); i++)
@@ -329,6 +336,7 @@ Service::Service(const Core::ConfigFile& config, const StringView& name)
     }
 
     m_working_directory = config.read_entry(name, "WorkingDirectory");
+    m_gbps = config.read_num_entry(name, "GoodBoyPoints", 10);
 }
 
 void Service::save_to(JsonObject& json)
@@ -362,4 +370,5 @@ void Service::save_to(JsonObject& json)
 
     json.set("restart_attempts", m_restart_attempts);
     json.set("working_directory", m_working_directory);
+    json.set("gbps", m_gbps);
 }

--- a/Servers/SystemServer/Service.h
+++ b/Servers/SystemServer/Service.h
@@ -84,6 +84,9 @@ private:
     // The working directory in which to spawn the service
     String m_working_directory;
 
+    // How many GBPs the service should be started with.
+    gbps_t m_gbps;
+
     void resolve_user();
     void setup_socket();
     void setup_notifier();

--- a/Userland/getgbps.cpp
+++ b/Userland/getgbps.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020, Sergey Bugaev <bugaevc@serenityos.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+int main()
+{
+    gbps_t gbps = getgbps();
+    printf("%d\n", gbps);
+    return 0;
+}


### PR DESCRIPTION
GBPs are a much more flexible system for allowing and disallowing privileged features. Different privileged actions require different GBPs counts. For instance:
* `sys$purge()` only requires 10 GBPs, as it's relatively harmless
* privileged filesystem operations require 20 GBPs
* `sys$reboot()` requires 30 GBPs
* manipulating kernel modules requires 40 GBPs

When a process tries to execute a privileged action without having enough GBPs, it gets a `ENOGBPS` error ("No tendies for you").

With this, UID 0 no longer bears any special meaning.

GBPs are inherited across `sys$fork()` and `sys$exec()`. The first kernel-created process starts with 35 GBPs. GBPs are decremented for every erroneous syscall a process makes.

A process can *increase* its GBPs if it executes an executable that has a `setgbps` flag set. You can also get more GBPs by writing man pages and/or using `Core::ArgsParser`, but that is not implemented at the moment.

SystemServer gains a new setting, `GoodBoyPoints=`, for specifying the initial GBPs for a service. You cannot set this any higher than SystemServer's own initial GBPs; to drop GBPs, SystemServer intentionally makes invalid syscalls in the forked process — this way, we avoid the need for a separate `setgbps()` syscall.

Finally, there's now a `getgbps(1)` utility to view the current GBPs of the shell.

This all comes with man pages, and live GBPs for processes can be read from `/proc/all`, and SystemMonitor displays them:

![image](https://user-images.githubusercontent.com/10091584/78151149-ef50cb80-7440-11ea-98c8-664a1405c0dc.png)

:smile: