### PR TITLE
AK: Add String::replace() functionality

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -320,6 +320,41 @@ bool String::equals_ignoring_case(const StringView& other) const
     return StringUtils::equals_ignoring_case(view(), other);
 }
 
+int String::replace(const String& needle, const String& replacement, bool all_occurences)
+{
+    if (is_empty())
+        return 0;
+
+    Vector<size_t> positions;
+    size_t start = 0, pos;
+    for (;;) {
+        const char* ptr = strstr(characters() + start, needle.characters());
+        if (!ptr)
+            break;
+
+        pos = ptr - characters();
+        positions.append(pos);
+        if (!all_occurences)
+            break;
+
+        start = pos + 1;
+    }
+
+    if (!positions.size())
+        return 0;
+
+    StringBuilder b;
+    size_t lastpos = 0;
+    for (auto& pos : positions) {
+        b.append(substring_view(lastpos, pos - lastpos));
+        b.append(replacement);
+        lastpos = pos + needle.length();
+    }
+    b.append(substring_view(lastpos, length() - lastpos));
+    m_impl = StringImpl::create(b.build().characters());
+    return positions.size();
+}
+
 String escape_html_entities(const StringView& html)
 {
     StringBuilder builder;

--- a/AK/String.h
+++ b/AK/String.h
@@ -214,6 +214,8 @@ public:
 
     StringView view() const;
 
+    int replace(const String& needle, const String& replacement, bool all_occurences = false);
+
 private:
     RefPtr<StringImpl> m_impl;
 };

--- a/AK/Tests/TestString.cpp
+++ b/AK/Tests/TestString.cpp
@@ -159,4 +159,29 @@ TEST_CASE(flystring)
     }
 }
 
+TEST_CASE(replace)
+{
+    String test_string = "Well, hello Friends!";
+    u32 replacements = test_string.replace("Friends", "Testers");
+    EXPECT(replacements == 1);
+    EXPECT(test_string == "Well, hello Testers!");
+
+    replacements = test_string.replace("ell", "e're", true);
+    EXPECT(replacements == 2);
+    EXPECT(test_string == "We're, he'reo Testers!");
+
+    replacements = test_string.replace("!", " :^)");
+    EXPECT(replacements == 1);
+    EXPECT(test_string == "We're, he'reo Testers :^)");
+
+    test_string = String("111._.111._.111");
+    replacements = test_string.replace("111", "|||", true);
+    EXPECT(replacements == 3);
+    EXPECT(test_string == "|||._.|||._.|||");
+
+    replacements = test_string.replace("|||", "111");
+    EXPECT(replacements == 1);
+    EXPECT(test_string == "111._.|||._.|||");
+}
+
 TEST_MAIN(String)


### PR DESCRIPTION
This adds a replace functionality that replaces a string that contains
occurences of a "needle" by a "replacement" value. With "all_occurences"
enabled, all occurences are being replaced, otherwise only the first
occurence is being replaced.