### PR TITLE
LibLine: Restore previous state only if initialized

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -44,7 +44,8 @@ Editor::Editor()
 
 Editor::~Editor()
 {
-    tcsetattr(0, TCSANOW, &m_default_termios);
+    if (m_initialized)
+        tcsetattr(0, TCSANOW, &m_default_termios);
 }
 
 void Editor::add_to_history(const String& line)


### PR DESCRIPTION
Just a tiny patch, since I realised that the library was assuming it would always be initialized.

It seems @awesomekling went around this, but I'm gonna go ahead and assume we want the library to behave correctly nonetheless.