### PR TITLE
LibJS: Evaluate CallExpression arguments before pushing a CallFrame

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -101,15 +101,19 @@ Value CallExpression::execute(Interpreter& interpreter) const
 
     auto& function = static_cast<Function&>(callee.as_object());
 
-    auto& call_frame = interpreter.push_call_frame();
+    Vector<Value> arguments;
+    arguments.ensure_capacity(m_arguments.size());
     for (size_t i = 0; i < m_arguments.size(); ++i) {
         auto value = m_arguments[i].execute(interpreter);
         if (interpreter.exception())
             return {};
-        call_frame.arguments.append(value);
+        arguments.append(value);
         if (interpreter.exception())
             return {};
     }
+
+    auto& call_frame = interpreter.push_call_frame();
+    call_frame.arguments = move(arguments);
 
     Object* new_object = nullptr;
     Value result;

--- a/Libraries/LibJS/Tests/function-this-in-arguments.js
+++ b/Libraries/LibJS/Tests/function-this-in-arguments.js
@@ -1,0 +1,17 @@
+function assert(x) { if (!x) throw 1; }
+
+try {
+  assert(typeof this === "object");
+  assert(this === global);
+
+  function Foo() {
+    this.x = 5;
+    assert(typeof this === "object");
+    assert(this.x === 5);
+  }
+
+  new Foo();
+  console.log("PASS");
+} catch (err) {
+  console.log("FAIL: " + err);
+}


### PR DESCRIPTION
This PR uses the outer `CallFrame` of a function call to evaluate arguments, instead of creating a new `CallFrame` first.
Currently, when `this` is used anywhere in an argument to a function call, it is always `undefined`. This is because a new `CallFrame` has been pushed before the arguments have been evaluated, which has a `this` value of `undefined`. The test included fails with the current LibJS.
A quick example:
![image](https://user-images.githubusercontent.com/792121/78209739-7caa1500-746d-11ea-97b4-c9640d31d7f3.png)
