### PR TITLE
Kernel: Send Fragmented IPv4 packets if payload size > mtu

### DIFF
--- a/Kernel/Net/IPv4.h
+++ b/Kernel/Net/IPv4.h
@@ -40,6 +40,11 @@ enum class IPv4Protocol : u16 {
     UDP = 17,
 };
 
+enum class IPv4PacketFlags : u16 {
+    DontFragment = 0x4000,
+    MoreFragments = 0x2000,
+};
+
 NetworkOrdered<u16> internet_checksum(const void*, size_t);
 
 class [[gnu::packed]] IPv4Packet
@@ -75,6 +80,28 @@ public:
     void* payload() { return this + 1; }
     const void* payload() const { return this + 1; }
 
+    u16 flags_and_fragment() const { return m_flags_and_fragment; }
+    u16 fragment_offset() const { return ((u16)m_flags_and_fragment & 0x2fff); }
+    u16 flags() const { return (((u16)m_flags_and_fragment) & (((u16)IPv4PacketFlags::MoreFragments) | ((u16)IPv4PacketFlags::DontFragment))); }
+
+    void set_has_more_fragments(bool more_fragments)
+    {
+        if (more_fragments)
+            m_flags_and_fragment = (u16)m_flags_and_fragment | ((u16)IPv4PacketFlags::MoreFragments);
+        else
+            m_flags_and_fragment = (u16)m_flags_and_fragment & ((u16)IPv4PacketFlags::MoreFragments);
+    }
+    void set_fragment_offset(u16 offset)
+    {
+        m_flags_and_fragment = flags() | (offset & 0x2fff);
+    }
+
+    bool is_a_fragment() const
+    {
+        // either has More-Fragments set, or has a fragment offset
+        return (((u16)m_flags_and_fragment) & ((u16)IPv4PacketFlags::MoreFragments)) || ((u16)m_flags_and_fragment & 0x2fff);
+    }
+
     u16 payload_size() const { return m_length - sizeof(IPv4Packet); }
 
     NetworkOrdered<u16> compute_checksum() const
@@ -97,6 +124,7 @@ private:
 };
 
 static_assert(sizeof(IPv4Packet) == 20);
+const LogStream& operator<<(const LogStream& stream, const IPv4Packet& packet);
 
 inline NetworkOrdered<u16> internet_checksum(const void* ptr, size_t count)
 {

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -64,6 +64,7 @@ public:
 
     void send(const MACAddress&, const ARPPacket&);
     void send_ipv4(const MACAddress&, const IPv4Address&, IPv4Protocol, const u8* payload, size_t payload_size, u8 ttl);
+    void send_ipv4_fragmented(const MACAddress&, const IPv4Address&, IPv4Protocol, const u8* payload, size_t payload_size, u8 ttl);
 
     size_t dequeue_packet(u8* buffer, size_t buffer_size);
 


### PR DESCRIPTION
This adds IPv4 fragmentation, so now we can send huuuuuuge packets
properly.

Bit of a possible concern is that the ID of the packets is set to the
closest thing to a random number available: the number of bytes
transmitted :^)

c.f. #1134, #1530 and #1559 