### PR TITLE
js: Improve exception output for errors with empty message

### DIFF
--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -136,7 +136,9 @@ static void print_date(const JS::Object& date, HashTable<JS::Object*>&)
 static void print_error(const JS::Object& object, HashTable<JS::Object*>&)
 {
     auto& error = static_cast<const JS::Error&>(object);
-    printf("\033[34;1m[%s]\033[0m: %s", error.name().characters(), error.message().characters());
+    printf("\033[34;1m[%s]\033[0m", error.name().characters());
+    if (!error.message().is_empty())
+        printf(": %s", error.message().characters());
 }
 
 void print_value(JS::Value value, HashTable<JS::Object*>& seen_objects)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19366641/78253963-1c5ab800-74ed-11ea-9198-0ce31ef8aece.png)

(i.e. get rid of the trailing `: ` if the message is empty)