### PR TITLE
IRCClient: Update channel user list when a user joins or quits

### DIFF
--- a/Applications/IRCClient/IRCChannel.cpp
+++ b/Applications/IRCClient/IRCChannel.cpp
@@ -94,8 +94,12 @@ void IRCChannel::say(const String& text)
 
 void IRCChannel::handle_join(const String& nick, const String& hostmask)
 {
-    if (nick == m_client.nickname())
+    if (nick == m_client.nickname()) {
         m_open = true;
+        return;
+    }
+    add_member(nick, (char)0);
+    m_member_model->update();
     add_message(String::format("*** %s [%s] has joined %s", nick.characters(), hostmask.characters(), m_name.characters()), Color::MidGreen);
 }
 
@@ -110,6 +114,19 @@ void IRCChannel::handle_part(const String& nick, const String& hostmask)
     }
     m_member_model->update();
     add_message(String::format("*** %s [%s] has parted from %s", nick.characters(), hostmask.characters(), m_name.characters()), Color::MidGreen);
+}
+
+void IRCChannel::handle_quit(const String& nick, const String& hostmask, const String& message)
+{
+    if (nick == m_client.nickname()) {
+        m_open = false;
+        m_members.clear();
+        m_client.did_part_from_channel({}, *this);
+    } else {
+        remove_member(nick);
+    }
+    m_member_model->update();
+    add_message(String::format("*** %s [%s] has quit (%s)", nick.characters(), hostmask.characters(), message.characters()), Color::MidGreen);
 }
 
 void IRCChannel::handle_topic(const String& nick, const String& topic)

--- a/Applications/IRCClient/IRCChannel.h
+++ b/Applications/IRCClient/IRCChannel.h
@@ -68,6 +68,7 @@ public:
 
     void handle_join(const String& nick, const String& hostmask);
     void handle_part(const String& nick, const String& hostmask);
+    void handle_quit(const String& nick, const String& hostmask, const String& message);
     void handle_topic(const String& nick, const String& topic);
 
     IRCWindow& window() { return *m_window; }

--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -290,6 +290,9 @@ void IRCClient::handle(const Message& msg)
     if (msg.command == "PART")
         return handle_part(msg);
 
+    if (msg.command == "QUIT")
+        return handle_quit(msg);
+
     if (msg.command == "TOPIC")
         return handle_topic(msg);
 
@@ -543,6 +546,20 @@ void IRCClient::handle_part(const Message& msg)
     auto nick = prefix_parts[0];
     auto& channel_name = msg.arguments[0];
     ensure_channel(channel_name).handle_part(nick, msg.prefix);
+}
+
+void IRCClient::handle_quit(const Message& msg)
+{
+    if (msg.arguments.size() < 1)
+        return;
+    auto prefix_parts = msg.prefix.split('!');
+    if (prefix_parts.size() < 1)
+        return;
+    auto nick = prefix_parts[0];
+    auto& message = msg.arguments[0];
+    for (auto& it : m_channels) {
+        it.value->handle_quit(nick, msg.prefix, message);
+    }
 }
 
 void IRCClient::handle_nick(const Message& msg)

--- a/Applications/IRCClient/IRCClient.h
+++ b/Applications/IRCClient/IRCClient.h
@@ -155,6 +155,7 @@ private:
     void process_line(ByteBuffer&&);
     void handle_join(const Message&);
     void handle_part(const Message&);
+    void handle_quit(const Message&);
     void handle_ping(const Message&);
     void handle_topic(const Message&);
     void handle_rpl_topic(const Message&);


### PR DESCRIPTION
Fixes #1565

The user list is still not updated upon other events, such as change of user modes (ie, nick prefixes), but I don't want to deal with that right now.
