### PR TITLE
LibJS: Implement Error.prototype.toString()

### DIFF
--- a/Libraries/LibJS/Runtime/ErrorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ErrorPrototype.cpp
@@ -38,6 +38,7 @@ ErrorPrototype::ErrorPrototype()
 {
     put_native_property("name", name_getter, nullptr);
     put_native_property("message", message_getter, nullptr);
+    put_native_function("toString", to_string);
 }
 
 ErrorPrototype::~ErrorPrototype()
@@ -62,6 +63,29 @@ Value ErrorPrototype::message_getter(Interpreter& interpreter)
     if (!this_object->is_error())
         return interpreter.throw_exception<Error>("TypeError", "Not an Error object");
     return js_string(interpreter.heap(), static_cast<const Error*>(this_object)->message());
+}
+
+Value ErrorPrototype::to_string(Interpreter& interpreter)
+{
+    if (!interpreter.this_value().is_object())
+        return interpreter.throw_exception<Error>("TypeError", "Not an object");
+    auto& this_object = interpreter.this_value().as_object();
+
+    String name = "Error";
+    auto object_name_property = this_object.get("name");
+    if (object_name_property.has_value() && !object_name_property.value().is_undefined())
+        name = object_name_property.value().to_string();
+
+    String message = "";
+    auto object_message_property = this_object.get("message");
+    if (object_message_property.has_value() && !object_message_property.value().is_undefined())
+        message = object_message_property.value().to_string();
+    
+    if (name.length() == 0)
+        return js_string(interpreter.heap(), message);
+    if (message.length() == 0)
+        return js_string(interpreter.heap(), name);
+    return js_string(interpreter.heap(), String::format("%s: %s", name.characters(), message.characters()));
 }
 
 }

--- a/Libraries/LibJS/Runtime/ErrorPrototype.h
+++ b/Libraries/LibJS/Runtime/ErrorPrototype.h
@@ -38,6 +38,8 @@ public:
 private:
     virtual const char* class_name() const override { return "ErrorPrototype"; }
 
+    static Value to_string(Interpreter&);
+
     static Value name_getter(Interpreter&);
     static Value message_getter(Interpreter&);
 };

--- a/Libraries/LibJS/Tests/Error.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Error.prototype.toString.js
@@ -1,0 +1,13 @@
+function assert(x) { if (!x) throw 1; }
+
+try {
+    assert(Error().toString() === "Error");
+    assert(Error(undefined).toString() === "Error");
+    assert(Error(null).toString() === "Error: null");
+    assert(Error("test").toString() === "Error: test");
+    assert(Error(42).toString() === "Error: 42");
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
The spec has a [fantastic description](https://www.ecma-international.org/ecma-262/5.1/#sec-15.11.4.4):

```
The following steps are taken:

    Let O be the this value.
    If Type(O) is not Object, throw a TypeError exception.
    Let name be the result of calling the [[Get]] internal method of O with argument "name".
    If name is undefined, then let name be "Error"; else let name be ToString(name).
    Let msg be the result of calling the [[Get]] internal method of O with argument "message".
    If msg is undefined, then let msg be the empty String; else let msg be ToString(msg).
    If msg is undefined, then let msg be the empty String; else let msg be ToString(msg).
    If name is the empty String, return msg.
    If msg is the empty String, return name.
    Return the result of concatenating name, ":", a single space character, and msg.
```

I believe in the future `Error.prototype.name` and `Error.prototype.message` should be both writable and be able to hold any value, not just a string - this implementation already takes that into account.