### PR TITLE
LibJS: Remove UndefinedLiteral, add undefined to global object

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -490,12 +490,6 @@ void BooleanLiteral::dump(int indent) const
     printf("BooleanLiteral %s\n", m_value ? "true" : "false");
 }
 
-void UndefinedLiteral::dump(int indent) const
-{
-    print_indent(indent);
-    printf("undefined\n");
-}
-
 void NullLiteral::dump(int indent) const
 {
     print_indent(indent);
@@ -810,11 +804,6 @@ Value NumericLiteral::execute(Interpreter&) const
 Value BooleanLiteral::execute(Interpreter&) const
 {
     return Value(m_value);
-}
-
-Value UndefinedLiteral::execute(Interpreter&) const
-{
-    return {};
 }
 
 Value NullLiteral::execute(Interpreter&) const

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -440,19 +440,6 @@ private:
     virtual const char* class_name() const override { return "NullLiteral"; }
 };
 
-class UndefinedLiteral final : public Literal {
-public:
-    explicit UndefinedLiteral()
-    {
-    }
-
-    virtual Value execute(Interpreter&) const override;
-    virtual void dump(int indent) const override;
-
-private:
-    virtual const char* class_name() const override { return "UndefinedLiteral"; }
-};
-
 class Identifier final : public Expression {
 public:
     explicit Identifier(const FlyString& string)

--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -69,7 +69,6 @@ Lexer::Lexer(StringView source)
         s_keywords.set("true", TokenType::BoolLiteral);
         s_keywords.set("try", TokenType::Try);
         s_keywords.set("typeof", TokenType::Typeof);
-        s_keywords.set("undefined", TokenType::UndefinedLiteral);
         s_keywords.set("var", TokenType::Var);
         s_keywords.set("void", TokenType::Void);
         s_keywords.set("while", TokenType::While);

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -329,9 +329,6 @@ NonnullRefPtr<Expression> Parser::parse_primary_expression()
     case TokenType::NullLiteral:
         consume();
         return create_ast_node<NullLiteral>();
-    case TokenType::UndefinedLiteral:
-        consume();
-        return create_ast_node<UndefinedLiteral>();
     case TokenType::CurlyOpen:
         return parse_object_expression();
     case TokenType::Function:
@@ -821,7 +818,6 @@ bool Parser::match_expression() const
     return type == TokenType::BoolLiteral
         || type == TokenType::NumericLiteral
         || type == TokenType::StringLiteral
-        || type == TokenType::UndefinedLiteral
         || type == TokenType::NullLiteral
         || type == TokenType::Identifier
         || type == TokenType::New

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -21,6 +21,7 @@ GlobalObject::GlobalObject()
     // FIXME: These are read-only in ES5
     put("NaN", js_nan());
     put("Infinity", js_infinity());
+    put("undefined", js_undefined());
 
     put("console", heap().allocate<ConsoleObject>());
     put("Date", heap().allocate<DateConstructor>());

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -114,7 +114,6 @@ namespace JS {
     __ENUMERATE_JS_TOKEN(Tilde)                       \
     __ENUMERATE_JS_TOKEN(Try)                         \
     __ENUMERATE_JS_TOKEN(Typeof)                      \
-    __ENUMERATE_JS_TOKEN(UndefinedLiteral)            \
     __ENUMERATE_JS_TOKEN(UnsignedShiftRight)          \
     __ENUMERATE_JS_TOKEN(UnsignedShiftRightEquals)    \
     __ENUMERATE_JS_TOKEN(UnterminatedStringLiteral)   \


### PR DESCRIPTION
There is no such thing as a "undefined literal" in JS - "undefined" is just a property on the global object with a value of `undefined`. This is pretty similar to `NaN`.

`var undefined = "foo";` is a perfectly fine `AssignmentExpression` :^)

ECMAScript 5.1 spec: https://www.ecma-international.org/ecma-262/5.1/#sec-15.1.1.3

> **Value Properties of the Global Object**
>
> The value of undefined is undefined (see 8.1). This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.


MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined

> `undefined` is a property of the global object. That is, it is a variable in global scope. The initial value of `undefined` is the primitive value `undefined`.
>
> In modern browsers (JavaScript 1.8.5 / Firefox 4+), undefined is a non-configurable, non-writable property, per the ECMAScript 5 specification. (Even when this is not the case, avoid overriding it.)

[Esprima](https://esprima.org/demo/parse.html) AST examples:

```
undefined
```

```
{
    "type": "Program",
    "body": [
        {
            "type": "ExpressionStatement",
            "expression": {
                "type": "Identifier",
                "name": "undefined"
            }
        }
    ],
    "sourceType": "script"
}
```

```
undefined = "foo";
```

```
{
    "type": "Program",
    "body": [
        {
            "type": "ExpressionStatement",
            "expression": {
                "type": "AssignmentExpression",
                "operator": "=",
                "left": {
                    "type": "Identifier",
                    "name": "undefined"
                },
                "right": {
                    "type": "Literal",
                    "value": "foo",
                    "raw": "\"foo\""
                }
            }
        }
    ],
    "sourceType": "script"
}
```

```
var undefined = "foo";
```

```
{
    "type": "Program",
    "body": [
        {
            "type": "VariableDeclaration",
            "declarations": [
                {
                    "type": "VariableDeclarator",
                    "id": {
                        "type": "Identifier",
                        "name": "undefined"
                    },
                    "init": {
                        "type": "Literal",
                        "value": "foo",
                        "raw": "\"foo\""
                    }
                }
            ],
            "kind": "var"
        }
    ],
    "sourceType": "script"
}
```