### PR TITLE
AK: Remove relative path in AK testsuite

### DIFF
--- a/AK/Tests/TestJSON.cpp
+++ b/AK/Tests/TestJSON.cpp
@@ -35,7 +35,7 @@
 
 TEST_CASE(load_form)
 {
-    FILE* fp = fopen("../../Base/home/anon/little/test.frm", "r");
+    FILE* fp = fopen("test.frm", "r");
     ASSERT(fp);
 
     StringBuilder builder;

--- a/AK/Tests/test.frm
+++ b/AK/Tests/test.frm
@@ -1,0 +1,1 @@
+../../Base/home/anon/little/test.frm


### PR DESCRIPTION
With relative filenames in the executable code, the executable is basically not
relocatable. This makes out-of-source builds unneccesery hard. This patchset moves
the relative link into the filesystem: that can be handled much easier :^)