### PR TITLE
AK: Bytebuffer overwrite

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -216,6 +216,13 @@ public:
         __builtin_memcpy(this->data() + old_size, data, data_size);
     }
 
+    void overwrite(size_t offset, const void* data, size_t data_size)
+    {
+        // make sure we're not told to write past the end
+        ASSERT(offset + data_size < size());
+        __builtin_memcpy(this->data() + offset, data, data_size);
+    }
+
 private:
     explicit ByteBuffer(RefPtr<ByteBufferImpl>&& impl)
         : m_impl(move(impl))


### PR DESCRIPTION
Since ByteBuffer is a Buffer, it should allow us to overwrite parts of it that we have allocated.
This comes in useful in handling unsequenced writes like handling fragmented ip packets :^)

