### PR TITLE
LibWeb: Add NavigatorObject to Makefile

### DIFF
--- a/Libraries/LibWeb/Makefile
+++ b/Libraries/LibWeb/Makefile
@@ -7,6 +7,7 @@ LIBWEB_OBJS = \
     Bindings/EventTargetWrapper.o \
     Bindings/HTMLCanvasElementWrapper.o \
     Bindings/MouseEventWrapper.o \
+    Bindings/NavigatorObject.o \
     Bindings/NodeWrapper.o \
     Bindings/WindowObject.o \
     Bindings/Wrappable.o \


### PR DESCRIPTION
This was missing in https://github.com/SerenityOS/serenity/commit/a2b0cc8f08f5f082bbbf3f2c73cf8b2d2115ede9 and broke the build.