### PR TITLE
js: Return 1 after exception in non-REPL mode

### DIFF
--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -340,9 +340,10 @@ int main(int argc, char** argv)
             printf("Uncaught exception: ");
             print(interpreter->exception()->value());
             interpreter->clear_exception();
-        } else if (print_last_result) {
-            printf("%s\n", result.to_string().characters());
+            return 1;
         }
+        if (print_last_result)
+            print(result);
     }
 
     return 0;


### PR DESCRIPTION
Also print the last result with our custom `print` function, which produces nicer output :^)