### PR TITLE
Kernel: Implement a DHCPv4 client

### DIFF
--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -74,6 +74,8 @@ OBJS = \
     KParams.o \
     KSyms.o \
     Lock.o \
+	Net/DHCPv4.o \
+	Net/DHCPv4Client.o \
     Net/E1000NetworkAdapter.o \
     Net/IPv4Socket.o \
     Net/LocalSocket.o \

--- a/Kernel/Net/DHCPv4.cpp
+++ b/Kernel/Net/DHCPv4.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Kernel/Net/DHCPv4.h>
+
+//#define DHCPV4_DEBUG
+
+namespace Kernel {
+ParsedDHCPv4Options DHCPv4Packet::parse_options() const
+{
+    ParsedDHCPv4Options options;
+    for (auto idx = 4; idx < 312; ++idx) {
+        auto opt_name = *(const DHCPOptions*)&m_options[idx];
+        switch (opt_name) {
+        case DHCPOptions::Pad:
+            continue;
+        case DHCPOptions::End:
+            goto escape;
+        default:
+            ++idx;
+            auto len = m_options[idx];
+#ifdef DHCPV4_DEBUG
+            dbg() << "DHCP Option " << (u8)opt_name << " with length " << len;
+#endif
+            ++idx;
+            options.options.set(opt_name, { len, &m_options[idx] });
+            idx += len - 1;
+            break;
+        }
+    }
+escape:;
+    return options;
+}
+}

--- a/Kernel/Net/DHCPv4.h
+++ b/Kernel/Net/DHCPv4.h
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/ByteBuffer.h>
+#include <AK/HashMap.h>
+#include <AK/IPv4Address.h>
+#include <AK/NetworkOrdered.h>
+#include <AK/StringBuilder.h>
+#include <AK/StringView.h>
+#include <AK/Traits.h>
+#include <AK/Types.h>
+#include <Kernel/Net/MACAddress.h>
+#include <Kernel/Random.h>
+
+enum class DHCPv4Flags : u16 {
+    Broadcast = 1,
+    /* everything else is reserved and must be zero */
+};
+
+enum class DHCPv4Ops : u8 {
+    BootRequest = 1,
+    BootReply = 2
+};
+
+enum class DHCPOptions : u8 {
+    // BOOTP
+    Pad = 0,
+    SubnetMask,
+    TimeOffset,
+    Router,
+    TimeServer,
+    NameServer,
+    DomainNameServer,
+    LogServer,
+    CookieServer,
+    LPRServer,
+    ImpressServer,
+    ResourceLocationServer,
+    HostName,
+    BootFileSize,
+    MeritDumpFile,
+    DomainName,
+    SwapServer,
+    RootPath,
+    ExtensionsPath,
+    IPForwardingEnableDisable,
+    NonLocalSourceRoutingEnableDisable,
+    PolicyFilter,
+    MaximumDatagramReassemblySize,
+    DefaultIPTTL,
+    PathMTUAgingTimeout,
+    PathMTUPlateauTable,
+    InterfaceMTU,
+    AllSubnetsAreLocal,
+    BroadcastAddress,
+    PerformMaskDiscovery,
+    MaskSupplier,
+    PerformRouterDiscovery,
+    RouterSolicitationAddress,
+    StaticRoute,
+    TrailerEncapsulation,
+    ARPCacheTimeout,
+    EthernetEncapsulation,
+    TCPDefaultTTL,
+    TCPKeepaliveInterval,
+    TCPKeepaliveGarbage,
+    NetworkInformationServiceDomain,
+    NetworkInformationServers,
+    NetworkTimeProtocolServers,
+    VendorSpecificInformation,
+    NetBIOSOverTCPIPNameServer,
+    NetBIOSOverTCPIPDatagramDistributionServer,
+    NetBIOSOverTCPIPNodeType,
+    NetBIOSOverTCPIPScope,
+    XWindowSystemFontServer, // wow
+    XWindowSystemDisplayManager,
+    // DHCP
+    RequestedIPAddress = 50,
+    IPAddressLeaseTime,
+    OptionOverload,
+    DHCPMessageType,
+    ServerIdentifier,
+    ParameterRequestList,
+    Message,
+    MaximumDHCPMessageSize,
+    RenewalT1Time,
+    RenewalT2Time,
+    ClassIdentifier,
+    ClientIdentifier,
+    End = 255
+};
+
+enum class DHCPMessageType : u8 {
+    DHCPDiscover = 1,
+    DHCPOffer,
+    DHCPRequest,
+    DHCPDecline,
+    DHCPAck,
+    DHCPNak,
+    DHCPRelease,
+};
+
+template <>
+struct AK::Traits<DHCPOptions> : public AK::GenericTraits<DHCPOptions> {
+    static constexpr bool is_trivial() { return true; }
+    static unsigned hash(DHCPOptions u) { return int_hash((u8)u); }
+};
+
+namespace Kernel {
+
+struct ParsedDHCPv4Options {
+    template <typename T>
+    Optional<const T> get(DHCPOptions option_name) const
+    {
+        auto opt = options.get(option_name);
+        if (!opt.has_value()) {
+            return {};
+        }
+        auto& val = opt.value();
+        if (val.length != sizeof(T))
+            return {};
+        return *(const T*)val.value;
+    }
+
+    template <typename T>
+    Vector<T> get_many(DHCPOptions option_name, size_t max_number) const
+    {
+        Vector<T> values;
+
+        auto opt = options.get(option_name);
+        if (!opt.has_value()) {
+            return {};
+        }
+        auto& val = opt.value();
+        if (val.length < sizeof(T))
+            return {};
+
+        for (size_t i = 0; i < max_number; ++i) {
+            auto offset = i * sizeof(T);
+            if (offset >= val.length)
+                break;
+            values.append(*(T*)((u8*)const_cast<void*>(val.value) + offset));
+        }
+
+        return values;
+    }
+
+    String to_string() const
+    {
+        StringBuilder builder;
+        builder.append("DHCP Options (");
+        builder.appendf("%d", options.size());
+        builder.append(" entries)\n");
+        for (auto& opt : options) {
+            builder.appendf("\toption %d (%d bytes):", (u8)opt.key, (u8)opt.value.length);
+            for (auto i = 0; i < opt.value.length; ++i)
+                builder.appendf(" %u ", ((const u8*)opt.value.value)[i]);
+            builder.append('\n');
+        }
+        return builder.build();
+    }
+
+    struct DHCPOptionValue {
+        u8 length;
+        const void* value;
+    };
+
+    HashMap<DHCPOptions, DHCPOptionValue> options;
+};
+
+class [[gnu::packed]] DHCPv4Packet
+{
+public:
+    u8 op() const { return m_op; }
+    void set_op(DHCPv4Ops op) { m_op = (u8)op; }
+
+    u8 htype() const { return m_htype; }
+    void set_htype(u8 htype) { m_htype = htype; }
+
+    u8 hlen() const { return m_hlen; }
+    void set_hlen(u8 hlen) { m_hlen = hlen; }
+
+    u8 hops() const { return m_hops; }
+    void set_hops(u8 hops) { m_hops = hops; }
+
+    u32 xid() const { return m_xid; }
+    void set_xid(u32 xid) { m_xid = xid; }
+
+    u16 secs() const { return m_secs; }
+    void set_secs(u16 secs) { m_secs = secs; }
+
+    u16 flags() const { return m_flags; }
+    void set_flags(DHCPv4Flags flags) { m_flags = (u16)flags; }
+
+    const IPv4Address& ciaddr() const { return m_ciaddr; }
+    const IPv4Address& yiaddr() const { return m_yiaddr; }
+    const IPv4Address& siaddr() const { return m_siaddr; }
+    const IPv4Address& giaddr() const { return m_giaddr; }
+
+    IPv4Address& ciaddr() { return m_ciaddr; }
+    IPv4Address& yiaddr() { return m_yiaddr; }
+    IPv4Address& siaddr() { return m_siaddr; }
+    IPv4Address& giaddr() { return m_giaddr; }
+
+    u8* options() { return m_options; }
+    ParsedDHCPv4Options parse_options() const;
+
+    const MACAddress& chaddr() const { return *(const MACAddress*)&m_chaddr[0]; }
+    void set_chaddr(const MACAddress& mac) { *(MACAddress*)&m_chaddr[0] = mac; }
+
+    StringView sname() const { return { (const char*)&m_sname[0] }; }
+    StringView file() const { return { (const char*)&m_file[0] }; }
+
+private:
+    NetworkOrdered<u8> m_op;
+    NetworkOrdered<u8> m_htype;
+    NetworkOrdered<u8> m_hlen;
+    NetworkOrdered<u8> m_hops;
+    NetworkOrdered<u32> m_xid;
+    NetworkOrdered<u16> m_secs;
+    NetworkOrdered<u16> m_flags;
+    IPv4Address m_ciaddr;
+    IPv4Address m_yiaddr;
+    IPv4Address m_siaddr;
+    IPv4Address m_giaddr;
+    u8 m_chaddr[16]; // 10 bytes of padding at the end
+    u8 m_sname[64] { 0 };
+    u8 m_file[128] { 0 };
+    u8 m_options[312] { 0 }; // variable, less than 312 bytes
+};
+
+class DHCPv4PacketBuilder {
+public:
+    DHCPv4PacketBuilder()
+        : m_buffer(ByteBuffer::create_zeroed(sizeof(DHCPv4Packet)))
+    {
+        auto* options = peek().options();
+        options[0] = 99;
+        options[1] = 130;
+        options[2] = 83;
+        options[3] = 99;
+    }
+
+    void add_option(DHCPOptions option, u8 length, const void* data)
+    {
+        ASSERT(m_can_add);
+        auto* options = peek().options();
+        options[next_option_offset++] = (u8)option;
+        __builtin_memcpy(options + next_option_offset, &length, 1);
+        next_option_offset++;
+        __builtin_memcpy(options + next_option_offset, data, length);
+        next_option_offset += length;
+    }
+
+    void set_message_type(DHCPMessageType type) { add_option(DHCPOptions::DHCPMessageType, 1, &type); }
+
+    DHCPv4Packet& peek() { return *(DHCPv4Packet*)m_buffer.data(); }
+    DHCPv4Packet& build()
+    {
+        add_option(DHCPOptions::End, 0, nullptr);
+        m_can_add = false;
+        return *(DHCPv4Packet*)m_buffer.data();
+    }
+    size_t size() const { return m_buffer.size(); }
+
+private:
+    ByteBuffer m_buffer;
+    size_t next_option_offset { 4 };
+    bool m_can_add { true };
+};
+
+}

--- a/Kernel/Net/DHCPv4Client.cpp
+++ b/Kernel/Net/DHCPv4Client.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Function.h>
+#include <Kernel/Net/DHCPv4Client.h>
+#include <Kernel/Net/UDP.h>
+#include <Kernel/TimerQueue.h>
+
+//#define DHCPV4CLIENT_DEBUG
+
+namespace Kernel {
+
+static DHCPv4Client* s_client;
+DHCPv4Client& DHCPv4Client::the()
+{
+    if (s_client)
+        return *s_client;
+    return *(s_client = new DHCPv4Client);
+}
+
+DHCPv4Client::DHCPv4Client()
+{
+}
+
+DHCPv4Client::~DHCPv4Client()
+{
+}
+
+void DHCPv4Client::handle_offer(const DHCPv4Packet& packet, const ParsedDHCPv4Options& options)
+{
+    dbg() << "We were offered " << packet.yiaddr().to_string() << " for " << options.get<u32>(DHCPOptions::IPAddressLeaseTime).value_or(0);
+    auto* transaction = const_cast<DHCPv4Transaction*>(m_ongoing_transactions.get(packet.xid()).value());
+    if (transaction->has_ip)
+        return;
+    if (transaction->accepted_offer) {
+        // we've accepted someone's offer, but they haven't given us an ack
+        // TODO: maybe record this offer?
+        return;
+    }
+    // TAKE IT...
+    transaction->offered_lease_time = options.get<u32>(DHCPOptions::IPAddressLeaseTime).value();
+    dhcp_request(*transaction, packet);
+}
+
+void DHCPv4Client::handle_ack(const DHCPv4Packet& packet, const ParsedDHCPv4Options& options)
+{
+#ifdef DHCPV4CLIENT_DEBUG
+    dbg() << "The DHCP server handed us " << packet.yiaddr().to_string();
+    dbg() << "Here are the options: " << options.to_string();
+#endif
+    auto* transaction = const_cast<DHCPv4Transaction*>(m_ongoing_transactions.get(packet.xid()).value());
+    transaction->has_ip = true;
+    auto& adapter = transaction->adapter;
+    auto new_ip = packet.yiaddr();
+    auto lease_time = convert_between_host_and_network(options.get<u32>(DHCPOptions::IPAddressLeaseTime).value_or(transaction->offered_lease_time));
+    // set a timer for the duration of the lease, we shall renew if needed
+    TimerQueue::the().add_timer(lease_time, TimeUnit::S, [&] {
+        transaction->accepted_offer = false;
+        transaction->has_ip = false;
+        dhcp_discover(adapter, new_ip);
+    });
+    adapter.set_ipv4_address(new_ip);
+    adapter.set_ipv4_gateway(options.get_many<IPv4Address>(DHCPOptions::Router, 1).first());
+    adapter.set_ipv4_netmask(options.get<IPv4Address>(DHCPOptions::SubnetMask).value());
+    dbg() << "DHCPv4Client: Leased for hw=" << adapter.mac_address().to_string() << " address=" << adapter.ipv4_address().to_string() << " netmask=" << adapter.ipv4_netmask().to_string() << " gateway=" << adapter.ipv4_gateway().to_string();
+}
+
+void DHCPv4Client::handle_nak(const DHCPv4Packet& packet, const ParsedDHCPv4Options& options)
+{
+    dbg() << "The DHCP server told us to go chase our own tail about " << packet.yiaddr().to_string();
+    dbg() << "Here are the options: " << options.to_string();
+    // make another request a bit later :shrug:
+    auto* transaction = const_cast<DHCPv4Transaction*>(m_ongoing_transactions.get(packet.xid()).value());
+    transaction->accepted_offer = false;
+    transaction->has_ip = false;
+    auto& adapter = transaction->adapter;
+    TimerQueue::the().add_timer(10, TimeUnit::S, [&] {
+        dhcp_discover(adapter);
+    });
+}
+
+void DHCPv4Client::process_incoming(const DHCPv4Packet& packet)
+{
+    auto options = packet.parse_options();
+#ifdef DHCPV4CLIENT_DEBUG
+    dbg() << "Here are the options: " << options.to_string();
+#endif
+    auto value = options.get<DHCPMessageType>(DHCPOptions::DHCPMessageType).value();
+    switch (value) {
+    case DHCPMessageType::DHCPOffer:
+        handle_offer(packet, options);
+        break;
+    case DHCPMessageType::DHCPAck:
+        handle_ack(packet, options);
+        break;
+    case DHCPMessageType::DHCPNak:
+        handle_nak(packet, options);
+        break;
+    default:
+        dbg() << "I dunno what to do with this " << (u8)value;
+        ASSERT_NOT_REACHED();
+        break;
+    }
+}
+
+void DHCPv4Client::dhcp_discover(NetworkAdapter& adapter, IPv4Address previous)
+{
+    auto transaction_id = get_fast_random<u32>();
+#ifdef DHCPV4CLIENT_DEBUG
+    dbg() << "Trying to lease an IP for " << adapter.class_name() << " with ID " << transaction_id;
+    if (!previous.is_zero())
+        dbg() << "going to request the server to hand us " << previous.to_string();
+#endif
+    DHCPv4PacketBuilder builder;
+
+    DHCPv4Packet& packet = builder.peek();
+    packet.set_op(DHCPv4Ops::BootRequest);
+    packet.set_htype(1); // 10mb ethernet
+    packet.set_hlen(sizeof(MACAddress));
+    packet.set_xid(transaction_id);
+    packet.set_flags(DHCPv4Flags::Broadcast);
+    packet.ciaddr() = previous;
+    packet.set_chaddr(adapter.mac_address());
+    packet.set_secs(65535); // we lie
+
+    // set packet options
+    builder.set_message_type(DHCPMessageType::DHCPDiscover);
+    auto& dhcp_packet = builder.build();
+
+    // broadcast the discover request
+    adapter.send({ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }, dhcp_packet);
+    m_ongoing_transactions.set(transaction_id, make<DHCPv4Transaction>(adapter));
+}
+
+void DHCPv4Client::dhcp_request(DHCPv4Transaction& transaction, const DHCPv4Packet& offer)
+{
+    auto& adapter = transaction.adapter;
+    dbg() << "Leasing the IP " << offer.yiaddr().to_string() << " for adapter " << adapter.class_name();
+    DHCPv4PacketBuilder builder;
+
+    DHCPv4Packet& packet = builder.peek();
+    packet.set_op(DHCPv4Ops::BootRequest);
+    packet.set_htype(1); // 10mb ethernet
+    packet.set_hlen(sizeof(MACAddress));
+    packet.set_xid(offer.xid());
+    packet.set_flags(DHCPv4Flags::Broadcast);
+    packet.set_chaddr(adapter.mac_address());
+    packet.set_secs(65535); // we lie
+
+    // set packet options
+    builder.set_message_type(DHCPMessageType::DHCPRequest);
+    auto& dhcp_packet = builder.build();
+
+    // broadcast the discover request
+    adapter.send({ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }, dhcp_packet);
+    transaction.accepted_offer = true;
+}
+}

--- a/Kernel/Net/DHCPv4Client.h
+++ b/Kernel/Net/DHCPv4Client.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/OwnPtr.h>
+#include <AK/Vector.h>
+#include <Kernel/Net/DHCPv4.h>
+#include <Kernel/Net/NetworkAdapter.h>
+
+namespace Kernel {
+
+struct DHCPv4Transaction {
+    DHCPv4Transaction(NetworkAdapter& adapter)
+        : adapter(adapter)
+    {
+    }
+
+    NetworkAdapter& adapter;
+    bool accepted_offer { false };
+    bool has_ip { false };
+    u32 offered_lease_time { 0 };
+};
+
+struct DHCPv4Client {
+    DHCPv4Client();
+    ~DHCPv4Client();
+    void dhcp_discover(NetworkAdapter& adapter, IPv4Address previous = IPv4Address { 0, 0, 0, 0 });
+    void dhcp_request(DHCPv4Transaction& transaction, const DHCPv4Packet& packet);
+
+    void process_incoming(const DHCPv4Packet& packet);
+
+    bool id_is_registered(u32 id) { return m_ongoing_transactions.contains(id); }
+
+    static DHCPv4Client& the();
+
+private:
+    HashMap<u32, OwnPtr<DHCPv4Transaction>> m_ongoing_transactions;
+    void handle_offer(const DHCPv4Packet&, const ParsedDHCPv4Options&);
+    void handle_ack(const DHCPv4Packet&, const ParsedDHCPv4Options&);
+    void handle_nak(const DHCPv4Packet&, const ParsedDHCPv4Options&);
+};
+}

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -34,6 +34,7 @@
 #include <AK/Weakable.h>
 #include <Kernel/KBuffer.h>
 #include <Kernel/Net/ARP.h>
+#include <Kernel/Net/DHCPv4.h>
 #include <Kernel/Net/ICMP.h>
 #include <Kernel/Net/IPv4.h>
 #include <Kernel/Net/MACAddress.h>
@@ -63,6 +64,7 @@ public:
     void set_ipv4_gateway(const IPv4Address&);
 
     void send(const MACAddress&, const ARPPacket&);
+    void send(const MACAddress&, const DHCPv4Packet&);
     void send_ipv4(const MACAddress&, const IPv4Address&, IPv4Protocol, const u8* payload, size_t payload_size, u8 ttl);
     void send_ipv4_fragmented(const MACAddress&, const IPv4Address&, IPv4Protocol, const u8* payload, size_t payload_size, u8 ttl);
 


### PR DESCRIPTION
This patch adds a DHCPv4 client, a minor caveat is that it will not take
into consideration any other offer once it has accepted an offer.
These could be reserved to be faster about requests next time

Also of note is that we simply start spamming discovers if we get a NAK;
I am very hazy on what should happen here, and the RFC was, as always,
not helpful.

p.s. we're not handling all that relaying nonsense (yet)