### PR TITLE
LibCore: Fix UDPServer up to properly receive data

### DIFF
--- a/Libraries/LibCore/UDPServer.h
+++ b/Libraries/LibCore/UDPServer.h
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/Forward.h>
 #include <AK/Function.h>
 #include <LibCore/Forward.h>
 #include <LibCore/Object.h>
+#include <LibCore/SocketAddress.h>
 
 namespace Core {
 
@@ -38,21 +40,26 @@ class UDPServer : public Object {
 public:
     virtual ~UDPServer() override;
 
-    bool is_listening() const { return m_listening; }
-    bool listen(const IPv4Address& address, u16 port);
+    bool is_bound() const { return m_bound; }
 
-    RefPtr<UDPSocket> accept();
+    bool bind(const IPv4Address& address, u16 port);
+    ByteBuffer receive(size_t size, sockaddr_in& from);
+    ByteBuffer receive(size_t size)
+    {
+        struct sockaddr_in saddr;
+        return receive(size, saddr);
+    };
 
     Optional<IPv4Address> local_address() const;
     Optional<u16> local_port() const;
 
-    Function<void()> on_ready_to_accept;
+    Function<void()> on_ready_to_receive;
 
 private:
     explicit UDPServer(Object* parent = nullptr);
 
     int m_fd { -1 };
-    bool m_listening { false };
+    bool m_bound { false };
     RefPtr<Notifier> m_notifier;
 };
 


### PR DESCRIPTION
This patchset fixes Core::UDPServer to handle a proper udp session.
Prior to this, it used listen() and accept(), which is mostly nonsensical for udp.