### PR TITLE
Kernel: Do not reject broadcast UDP packets right away

### DIFF
--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -288,7 +288,7 @@ void handle_udp(const IPv4Packet& ipv4_packet)
     }
 
     auto adapter = NetworkAdapter::from_ipv4_address(ipv4_packet.destination());
-    if (!adapter) {
+    if (!adapter && ipv4_packet.destination() != IPv4Address(255, 255, 255, 255)) {
         klog() << "handle_udp: this packet is not for me, it's for " << ipv4_packet.destination().to_string().characters();
         return;
     }


### PR DESCRIPTION
This patch relaxes how we think about UDP packets being "for us" a bit;
the proper way to handle this would be to also check if the matched
socket has SO_BROADCAST set, but we don't have that :)

This is part of the GimmeDHCPBecause10.0.2.15IsAnnoying series of patches :^)