### PR TITLE
LibJS: Add Function() and Function.prototype

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -333,6 +333,8 @@ Value UnaryExpression::execute(Interpreter& interpreter) const
         case Value::Type::String:
             return js_string(interpreter, "string");
         case Value::Type::Object:
+            if (lhs_result.as_object().is_function())
+                return js_string(interpreter, "function");
             return js_string(interpreter, "object");
         case Value::Type::Boolean:
             return js_string(interpreter, "boolean");

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -31,6 +31,7 @@
 #include <LibJS/Runtime/DatePrototype.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/ErrorPrototype.h>
+#include <LibJS/Runtime/FunctionPrototype.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/Object.h>
@@ -47,6 +48,7 @@ Interpreter::Interpreter()
     m_empty_object_shape = heap().allocate<Shape>();
 
     m_object_prototype = heap().allocate<ObjectPrototype>();
+    m_function_prototype = heap().allocate<FunctionPrototype>();
     m_string_prototype = heap().allocate<StringPrototype>();
     m_array_prototype = heap().allocate<ArrayPrototype>();
     m_error_prototype = heap().allocate<ErrorPrototype>();
@@ -171,6 +173,7 @@ void Interpreter::gather_roots(Badge<Heap>, HashTable<Cell*>& roots)
     roots.set(m_array_prototype);
     roots.set(m_error_prototype);
     roots.set(m_date_prototype);
+    roots.set(m_function_prototype);
 
     roots.set(m_exception);
 

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -136,6 +136,7 @@ public:
     Object* array_prototype() { return m_array_prototype; }
     Object* error_prototype() { return m_error_prototype; }
     Object* date_prototype() { return m_date_prototype; }
+    Object* function_prototype() { return m_function_prototype; }
 
     Exception* exception() { return m_exception; }
     void clear_exception() { m_exception = nullptr; }
@@ -168,6 +169,7 @@ private:
     Object* m_array_prototype { nullptr };
     Object* m_error_prototype { nullptr };
     Object* m_date_prototype { nullptr };
+    Object* m_function_prototype { nullptr };
 
     Exception* m_exception { nullptr };
 

--- a/Libraries/LibJS/Makefile
+++ b/Libraries/LibJS/Makefile
@@ -18,6 +18,8 @@ OBJS = \
     Runtime/ErrorPrototype.o \
     Runtime/Exception.o \
     Runtime/Function.o \
+    Runtime/FunctionConstructor.o \
+    Runtime/FunctionPrototype.o \
     Runtime/GlobalObject.o \
     Runtime/MathObject.o \
     Runtime/NativeFunction.o \

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -37,7 +37,7 @@ ArrayPrototype::ArrayPrototype()
 {
     put_native_function("shift", shift);
     put_native_function("pop", pop);
-    put_native_function("push", push);
+    put_native_function("push", push, 1);
 }
 
 ArrayPrototype::~ArrayPrototype()

--- a/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/StringBuilder.h>
+#include <LibJS/AST.h>
+#include <LibJS/Interpreter.h>
+#include <LibJS/Parser.h>
+#include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/FunctionConstructor.h>
+#include <LibJS/Runtime/ScriptFunction.h>
+
+namespace JS {
+
+FunctionConstructor::FunctionConstructor()
+{
+    put("prototype", interpreter().function_prototype());
+    put("length", Value(1));
+}
+
+FunctionConstructor::~FunctionConstructor()
+{
+}
+
+Value FunctionConstructor::call(Interpreter& interpreter)
+{
+    return construct(interpreter);
+}
+
+Value FunctionConstructor::construct(Interpreter& interpreter)
+{
+    String parameters_source = "";
+    String body_source = "";
+    if (interpreter.argument_count() == 1)
+        body_source = interpreter.argument(0).to_string();
+    if (interpreter.argument_count() > 1) {
+        Vector<String> parameters;
+        for (size_t i = 0; i < interpreter.argument_count() - 1; ++i)
+            parameters.append(interpreter.argument(i).to_string());
+        StringBuilder parameters_builder;
+        parameters_builder.join(',', parameters);
+        parameters_source = parameters_builder.build();
+        body_source = interpreter.argument(interpreter.argument_count() - 1).to_string();
+    }
+    auto source = String::format("function (%s) { %s }", parameters_source.characters(), body_source.characters());
+    auto parser = Parser(Lexer(source));
+    auto function_expression = parser.parse_function_node<FunctionExpression>();
+    if (parser.has_errors()) {
+        // FIXME: The parser should expose parsing error strings rather than just fprintf()'ing them
+        return interpreter.heap().allocate<Error>("SyntaxError", "");
+    }
+    return function_expression->execute(interpreter);
+}
+
+}

--- a/Libraries/LibJS/Runtime/FunctionConstructor.h
+++ b/Libraries/LibJS/Runtime/FunctionConstructor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,18 +24,23 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibJS/Interpreter.h>
-#include <LibJS/Runtime/Function.h>
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
 
 namespace JS {
 
-Function::Function()
-{
-    set_prototype(interpreter().function_prototype());
-}
+class FunctionConstructor final : public NativeFunction {
+public:
+    FunctionConstructor();
+    virtual ~FunctionConstructor() override;
 
-Function::~Function()
-{
-}
+    virtual Value call(Interpreter&) override;
+    virtual Value construct(Interpreter&) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+    virtual const char* class_name() const override { return "FunctionConstructor"; }
+};
 
 }

--- a/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Function.h>
+#include <AK/StringBuilder.h>
+#include <LibJS/AST.h>
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/Function.h>
+#include <LibJS/Runtime/FunctionPrototype.h>
+#include <LibJS/Runtime/ScriptFunction.h>
+
+namespace JS {
+
+FunctionPrototype::FunctionPrototype()
+{
+    put_native_function("apply", apply, 2);
+    put_native_function("bind", bind, 1);
+    put_native_function("call", call, 1);
+    put_native_function("toString", to_string);
+    put("length", Value(0));
+}
+
+FunctionPrototype::~FunctionPrototype()
+{
+}
+
+Value FunctionPrototype::apply(Interpreter& interpreter)
+{
+    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    if (!this_object)
+        return {};
+    if (!this_object->is_function())
+        return interpreter.throw_exception<Error>("TypeError", "Not a Function object");
+    auto function = static_cast<Function*>(this_object);
+    auto this_arg = interpreter.argument(0);
+    auto arg_array = interpreter.argument(1);
+    if (arg_array.is_null() || arg_array.is_undefined())
+        return interpreter.call(function, this_arg);
+    if (!arg_array.is_object())
+        return interpreter.throw_exception<Error>("TypeError", "argument array must be an object");
+    size_t length = 0;
+    auto length_property = arg_array.as_object().get("length");
+    if (length_property.has_value())
+        length = length_property.value().to_number().to_i32();
+    Vector<Value> arguments;
+    for (size_t i = 0; i < length; ++i)
+        arguments.append(arg_array.as_object().get(String::number(i)).value_or(js_undefined()));
+    return interpreter.call(function, this_arg, arguments);
+}
+
+Value FunctionPrototype::bind(Interpreter& interpreter)
+{
+    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    if (!this_object)
+        return {};
+    // FIXME: Implement me :^)
+    ASSERT_NOT_REACHED();
+}
+
+Value FunctionPrototype::call(Interpreter& interpreter)
+{
+    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    if (!this_object)
+        return {};
+    if (!this_object->is_function())
+        return interpreter.throw_exception<Error>("TypeError", "Not a Function object");
+    auto function = static_cast<Function*>(this_object);
+    auto this_arg = interpreter.argument(0);
+    Vector<Value> arguments;
+    if (interpreter.argument_count() > 1) {
+        for (size_t i = 1; i < interpreter.argument_count(); ++i)
+            arguments.append(interpreter.argument(i));
+    }
+    return interpreter.call(function, this_arg, arguments);
+}
+
+Value FunctionPrototype::to_string(Interpreter& interpreter)
+{
+    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    if (!this_object)
+        return {};
+    if (!this_object->is_function())
+        return interpreter.throw_exception<Error>("TypeError", "Not a Function object");
+    // FIXME: Functions should be able to know their name, if any
+    if (this_object->is_native_function()) {
+        auto function_source = String::format("function () {\n  [%s]\n}", this_object->class_name());
+        return js_string(interpreter, function_source);
+    }
+    auto parameters = static_cast<ScriptFunction*>(this_object)->parameters();
+    StringBuilder parameters_builder;
+    parameters_builder.join(", ", parameters);
+    // FIXME: ASTNodes should be able to dump themselves to source strings - something like this:
+    // auto& body = static_cast<ScriptFunction*>(this_object)->body();
+    // auto body_source = body.to_source();
+    auto function_source = String::format("function (%s) {\n  %s\n}", parameters_builder.build().characters(), "???");
+    return js_string(interpreter, function_source);
+}
+
+}

--- a/Libraries/LibJS/Runtime/FunctionPrototype.h
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,18 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibJS/Interpreter.h>
-#include <LibJS/Runtime/Function.h>
+#pragma once
+
+#include <LibJS/Runtime/Object.h>
 
 namespace JS {
 
-Function::Function()
-{
-    set_prototype(interpreter().function_prototype());
-}
+class FunctionPrototype final : public Object {
+public:
+    FunctionPrototype();
+    virtual ~FunctionPrototype() override;
 
-Function::~Function()
-{
-}
+private:
+    virtual const char* class_name() const override { return "FunctionPrototype"; }
+
+    static Value apply(Interpreter&);
+    static Value bind(Interpreter&);
+    static Value call(Interpreter&);
+    static Value to_string(Interpreter&);
+};
 
 }

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -5,6 +5,7 @@
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibJS/Runtime/DateConstructor.h>
 #include <LibJS/Runtime/ErrorConstructor.h>
+#include <LibJS/Runtime/FunctionConstructor.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/MathObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
@@ -26,6 +27,7 @@ GlobalObject::GlobalObject()
     put("console", heap().allocate<ConsoleObject>());
     put("Date", heap().allocate<DateConstructor>());
     put("Error", heap().allocate<ErrorConstructor>());
+    put("Function", heap().allocate<FunctionConstructor>());
     put("Math", heap().allocate<MathObject>());
     put("Object", heap().allocate<ObjectConstructor>());
 }

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -16,7 +16,7 @@ namespace JS {
 GlobalObject::GlobalObject()
 {
     put_native_function("gc", gc);
-    put_native_function("isNaN", is_nan);
+    put_native_function("isNaN", is_nan, 1);
 
     // FIXME: These are read-only in ES5
     put("NaN", js_nan());

--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -34,7 +34,7 @@ namespace JS {
 
 MathObject::MathObject()
 {
-    put_native_function("abs", abs);
+    put_native_function("abs", abs, 1);
     put_native_function("random", random);
 
     put("E", Value(M_E));

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -155,9 +155,11 @@ void Object::put(const FlyString& property_name, Value value)
     put_own_property(*this, property_name, value);
 }
 
-void Object::put_native_function(const FlyString& property_name, AK::Function<Value(Interpreter&)> native_function)
+void Object::put_native_function(const FlyString& property_name, AK::Function<Value(Interpreter&)> native_function, i32 length)
 {
-    put(property_name, heap().allocate<NativeFunction>(move(native_function)));
+    auto* function = heap().allocate<NativeFunction>(move(native_function));
+    function->put("length", Value(length));
+    put(property_name, function);
 }
 
 void Object::put_native_property(const FlyString& property_name, AK::Function<Value(Interpreter&)> getter, AK::Function<void(Interpreter&, Value)> setter)

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -49,7 +49,7 @@ public:
     virtual Optional<Value> get_own_property(const Object& this_object, const FlyString& property_name) const;
     virtual bool put_own_property(Object& this_object, const FlyString& property_name, Value);
 
-    void put_native_function(const FlyString& property_name, AK::Function<Value(Interpreter&)>);
+    void put_native_function(const FlyString& property_name, AK::Function<Value(Interpreter&)>, i32 length = 0);
     void put_native_property(const FlyString& property_name, AK::Function<Value(Interpreter&)> getter, AK::Function<void(Interpreter&, Value)> setter);
 
     virtual bool is_array() const { return false; }

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -37,9 +37,9 @@ ObjectConstructor::ObjectConstructor()
 {
     put("prototype", interpreter().object_prototype());
 
-    put_native_function("getOwnPropertyNames", get_own_property_names);
-    put_native_function("getPrototypeOf", get_prototype_of);
-    put_native_function("setPrototypeOf", set_prototype_of);
+    put_native_function("getOwnPropertyNames", get_own_property_names, 1);
+    put_native_function("getPrototypeOf", get_prototype_of, 1);
+    put_native_function("setPrototypeOf", set_prototype_of, 2);
 }
 
 ObjectConstructor::~ObjectConstructor()

--- a/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -37,7 +37,7 @@ ObjectPrototype::ObjectPrototype()
 {
     set_prototype(nullptr);
 
-    put_native_function("hasOwnProperty", has_own_property);
+    put_native_function("hasOwnProperty", has_own_property, 1);
     put_native_function("toString", to_string);
     put_native_function("valueOf", value_of);
 }

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -37,6 +37,7 @@ ScriptFunction::ScriptFunction(const ScopeNode& body, Vector<FlyString> paramete
     : m_body(body)
     , m_parameters(move(parameters))
 {
+    put("prototype", heap().allocate<Object>());
     put_native_property("length", length_getter, length_setter);
 }
 

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -24,8 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Function.h>
 #include <LibJS/AST.h>
 #include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/ScriptFunction.h>
 #include <LibJS/Runtime/Value.h>
 
@@ -35,6 +37,7 @@ ScriptFunction::ScriptFunction(const ScopeNode& body, Vector<FlyString> paramete
     : m_body(body)
     , m_parameters(move(parameters))
 {
+    put_native_property("length", length_getter, length_setter);
 }
 
 ScriptFunction::~ScriptFunction()
@@ -58,6 +61,20 @@ Value ScriptFunction::call(Interpreter& interpreter)
 Value ScriptFunction::construct(Interpreter& interpreter)
 {
     return call(interpreter);
+}
+
+Value ScriptFunction::length_getter(Interpreter& interpreter)
+{
+    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    if (!this_object)
+        return {};
+    if (!this_object->is_function())
+        return interpreter.throw_exception<Error>("TypeError", "Not a function");
+    return Value(static_cast<i32>(static_cast<const ScriptFunction*>(this_object)->parameters().size()));
+}
+
+void ScriptFunction::length_setter(Interpreter&, Value)
+{
 }
 
 }

--- a/Libraries/LibJS/Runtime/ScriptFunction.h
+++ b/Libraries/LibJS/Runtime/ScriptFunction.h
@@ -45,6 +45,9 @@ private:
     virtual bool is_script_function() const final { return true; }
     virtual const char* class_name() const override { return "ScriptFunction"; }
 
+    static Value length_getter(Interpreter&);
+    static void length_setter(Interpreter&, Value);
+
     NonnullRefPtr<ScopeNode> m_body;
     const Vector<FlyString> m_parameters;
 };

--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -39,9 +39,9 @@ namespace JS {
 StringPrototype::StringPrototype()
 {
     put_native_property("length", length_getter, nullptr);
-    put_native_function("charAt", char_at);
-    put_native_function("repeat", repeat);
-    put_native_function("startsWith", starts_with);
+    put_native_function("charAt", char_at, 1);
+    put_native_function("repeat", repeat, 1);
+    put_native_function("startsWith", starts_with, 1);
 }
 
 StringPrototype::~StringPrototype()

--- a/Libraries/LibJS/Tests/Function.js
+++ b/Libraries/LibJS/Tests/Function.js
@@ -1,0 +1,29 @@
+function assert(x) { if (!x) throw 1; }
+
+try {
+    assert(Function.length === 1);
+    assert(Function.prototype.length === 0);
+    assert(typeof Function() === "function");
+    assert(typeof new Function() === "function");
+    assert(Function()() === undefined);
+    assert(new Function()() === undefined);
+    assert(Function("return 42")() === 42);
+    assert(new Function("return 42")() === 42);
+    assert(new Function("foo", "return foo")(42) === 42);
+    assert(new Function("foo,bar", "return foo + bar")(1, 2) === 3);
+    assert(new Function("foo", "bar", "return foo + bar")(1, 2) === 3);
+    assert(new Function("foo", "bar,baz", "return foo + bar + baz")(1, 2, 3) === 6);
+    assert(new Function("foo", "bar", "baz", "return foo + bar + baz")(1, 2, 3) === 6);
+    assert(new Function("foo", "if (foo) { return 42; } else { return 'bar'; }")(true) === 42);
+    assert(new Function("foo", "if (foo) { return 42; } else { return 'bar'; }")(false) === "bar");
+    assert(new Function("return typeof Function()")() === "function");
+    // FIXME: This is equivalent to
+    //   (function (x) { return function (y) { return x + y;} })(1)(2)
+    // and should totally work, but both currently fail with
+    //   Uncaught exception: [ReferenceError]: 'x' not known
+    // assert(new Function("x", "return function (y) { return x + y };")(1)(2) === 3);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e.message);
+}

--- a/Libraries/LibJS/Tests/Function.prototype.apply.js
+++ b/Libraries/LibJS/Tests/Function.prototype.apply.js
@@ -1,0 +1,53 @@
+function assert(x) { if (!x) throw 1; }
+
+try {
+    function Foo(arg) {
+        this.foo = arg;
+    }
+    function Bar(arg) {
+        this.bar = arg;
+    }
+    function FooBar(arg) {
+        Foo.apply(this, [arg]);
+        Bar.apply(this, [arg]);
+    }
+    function FooBarBaz(arg) {
+        Foo.apply(this, [arg]);
+        Bar.apply(this, [arg]);
+        this.baz = arg;
+    }
+
+    assert(Function.prototype.apply.length === 2);
+
+    var foo = new Foo("test");
+    assert(foo.foo === "test");
+    assert(foo.bar === undefined);
+    assert(foo.baz === undefined);
+
+    var bar = new Bar("test");
+    assert(bar.foo === undefined);
+    assert(bar.bar === "test");
+    assert(bar.baz === undefined);
+
+    var foobar = new FooBar("test");
+    assert(foobar.foo === "test");
+    assert(foobar.bar === "test");
+    assert(foobar.baz === undefined);
+
+    var foobarbaz = new FooBarBaz("test");
+    assert(foobarbaz.foo === "test");
+    assert(foobarbaz.bar === "test");
+    assert(foobarbaz.baz === "test");
+
+    assert(Math.abs.apply(null, [-1]) === 1);
+
+    var add = (x, y) => x + y;
+    assert(add.apply(null, [1, 2]) === 3);
+
+    var multiply = function (x, y) { return x * y; };
+    assert(multiply.apply(null, [3, 4]) === 12);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Function.prototype.call.js
+++ b/Libraries/LibJS/Tests/Function.prototype.call.js
@@ -1,0 +1,53 @@
+function assert(x) { if (!x) throw 1; }
+
+try {
+    function Foo(arg) {
+        this.foo = arg;
+    }
+    function Bar(arg) {
+        this.bar = arg;
+    }
+    function FooBar(arg) {
+        Foo.call(this, arg);
+        Bar.call(this, arg);
+    }
+    function FooBarBaz(arg) {
+        Foo.call(this, arg);
+        Bar.call(this, arg);
+        this.baz = arg;
+    }
+
+    assert(Function.prototype.call.length === 1);
+
+    var foo = new Foo("test");
+    assert(foo.foo === "test");
+    assert(foo.bar === undefined);
+    assert(foo.baz === undefined);
+
+    var bar = new Bar("test");
+    assert(bar.foo === undefined);
+    assert(bar.bar === "test");
+    assert(bar.baz === undefined);
+
+    var foobar = new FooBar("test");
+    assert(foobar.foo === "test");
+    assert(foobar.bar === "test");
+    assert(foobar.baz === undefined);
+
+    var foobarbaz = new FooBarBaz("test");
+    assert(foobarbaz.foo === "test");
+    assert(foobarbaz.bar === "test");
+    assert(foobarbaz.baz === "test");
+
+    assert(Math.abs.call(null, -1) === 1);
+
+    var add = (x, y) => x + y;
+    assert(add.call(null, 1, 2) === 3);
+
+    var multiply = function (x, y) { return x * y; };
+    assert(multiply.call(null, 3, 4) === 12);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Function.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Function.prototype.toString.js
@@ -1,0 +1,21 @@
+function assert(x) { if (!x) throw 1; }
+
+try {
+    assert((function() {}).toString() === "function () {\n  ???\n}");
+    assert((function(foo) {}).toString() === "function (foo) {\n  ???\n}");
+    assert((function(foo, bar, baz) {}).toString() === "function (foo, bar, baz) {\n  ???\n}");
+    assert((function(foo, bar, baz) {
+        if (foo) {
+            return baz;
+        } else if (bar) {
+            return foo;
+        }
+        return bar + 42;
+    }).toString() === "function (foo, bar, baz) {\n  ???\n}");
+    assert(console.log.toString() === "function () {\n  [NativeFunction]\n}");
+    assert(Function.toString() === "function () {\n  [FunctionConstructor]\n}");
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/function-length.js
+++ b/Libraries/LibJS/Tests/function-length.js
@@ -1,0 +1,17 @@
+function assert(x) { if (!x) throw 1; }
+
+try {
+    function foo() { }
+    assert(foo.length === 0);
+    assert((foo.length = 5) === 5);
+    assert(foo.length === 0);
+
+    function bar(a, b, c) {}
+    assert(bar.length === 3);
+    assert((bar.length = 5) === 5);
+    assert(bar.length === 3);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.cpp
@@ -44,7 +44,7 @@ CanvasRenderingContext2DWrapper::CanvasRenderingContext2DWrapper(CanvasRendering
     : m_impl(impl)
 {
     put_native_property("fillStyle", fill_style_getter, fill_style_setter);
-    put_native_function("fillRect", fill_rect);
+    put_native_function("fillRect", fill_rect, 4);
 }
 
 CanvasRenderingContext2DWrapper::~CanvasRenderingContext2DWrapper()

--- a/Libraries/LibWeb/Bindings/DocumentWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/DocumentWrapper.cpp
@@ -40,8 +40,8 @@ namespace Bindings {
 DocumentWrapper::DocumentWrapper(Document& document)
     : NodeWrapper(document)
 {
-    put_native_function("getElementById", get_element_by_id);
-    put_native_function("querySelectorAll", query_selector_all);
+    put_native_function("getElementById", get_element_by_id, 1);
+    put_native_function("querySelectorAll", query_selector_all, 1);
 }
 
 DocumentWrapper::~DocumentWrapper()

--- a/Libraries/LibWeb/Bindings/EventTargetWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/EventTargetWrapper.cpp
@@ -39,7 +39,7 @@ namespace Bindings {
 EventTargetWrapper::EventTargetWrapper(EventTarget& impl)
     : m_impl(impl)
 {
-    put_native_function("addEventListener", add_event_listener);
+    put_native_function("addEventListener", add_event_listener, 2);
 }
 
 EventTargetWrapper::~EventTargetWrapper()

--- a/Libraries/LibWeb/Bindings/HTMLCanvasElementWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/HTMLCanvasElementWrapper.cpp
@@ -40,7 +40,7 @@ namespace Bindings {
 HTMLCanvasElementWrapper::HTMLCanvasElementWrapper(HTMLCanvasElement& element)
     : ElementWrapper(element)
 {
-    put_native_function("getContext", get_context);
+    put_native_function("getContext", get_context, 1);
 
     put_native_property("width", width_getter, nullptr);
     put_native_property("height", height_getter, nullptr);

--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -43,9 +43,9 @@ WindowObject::WindowObject(Window& impl)
 {
     put_native_property("document", document_getter, document_setter);
     put_native_function("alert", alert);
-    put_native_function("setInterval", set_interval);
-    put_native_function("requestAnimationFrame", request_animation_frame);
-    put_native_function("cancelAnimationFrame", cancel_animation_frame);
+    put_native_function("setInterval", set_interval, 1);
+    put_native_function("requestAnimationFrame", request_animation_frame, 1);
+    put_native_function("cancelAnimationFrame", cancel_animation_frame, 1);
 
     put("navigator", heap().allocate<NavigatorObject>());
 }

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -243,8 +243,8 @@ ReplObject::ReplObject()
 {
     put_native_function("exit", exit_interpreter);
     put_native_function("help", repl_help);
-    put_native_function("load", load_file);
-    put_native_function("save", save_to_file);
+    put_native_function("load", load_file, 1);
+    put_native_function("save", save_to_file, 1);
 }
 
 ReplObject::~ReplObject()


### PR DESCRIPTION
This adds:

- `[new] Function()`
  - https://www.ecma-international.org/ecma-262/5.1/#sec-15.3.2.1
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/Function
- `Function.prototype.apply()`
  - https://www.ecma-international.org/ecma-262/5.1/#sec-15.3.4.3
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply
- `Function.prototype.call()`
  - https://www.ecma-international.org/ecma-262/5.1/#sec-15.3.4.4
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call
- `Function.prototype.toString()`
  - https://www.ecma-international.org/ecma-262/5.1/#sec-15.3.4.2
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString

I also added a dummy for `Function.prototype.bind()`, but implementing that will require some more work - probably either extending `ScriptFunction` or adding a separate class for bound functions (https://www.ecma-international.org/ecma-262/5.1/#sec-15.3.4.5).

I know that there are a few FIXMEs in this patch, but those seem out of scope for this PR :^)
(also I want to not make it any larger)