### PR TITLE
LibJS: Rename BinaryOp::{Plus,Minus,Asterisk,Slash}

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -273,13 +273,13 @@ Value BinaryExpression::execute(Interpreter& interpreter) const
         return {};
 
     switch (m_op) {
-    case BinaryOp::Plus:
+    case BinaryOp::Addition:
         return add(lhs_result, rhs_result);
-    case BinaryOp::Minus:
+    case BinaryOp::Subtraction:
         return sub(lhs_result, rhs_result);
-    case BinaryOp::Asterisk:
+    case BinaryOp::Multiplication:
         return mul(lhs_result, rhs_result);
-    case BinaryOp::Slash:
+    case BinaryOp::Division:
         return div(lhs_result, rhs_result);
     case BinaryOp::Modulo:
         return mod(lhs_result, rhs_result);
@@ -406,16 +406,16 @@ void BinaryExpression::dump(int indent) const
 {
     const char* op_string = nullptr;
     switch (m_op) {
-    case BinaryOp::Plus:
+    case BinaryOp::Addition:
         op_string = "+";
         break;
-    case BinaryOp::Minus:
+    case BinaryOp::Subtraction:
         op_string = "-";
         break;
-    case BinaryOp::Asterisk:
+    case BinaryOp::Multiplication:
         op_string = "*";
         break;
-    case BinaryOp::Slash:
+    case BinaryOp::Division:
         op_string = "/";
         break;
     case BinaryOp::Modulo:

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -309,10 +309,10 @@ private:
 };
 
 enum class BinaryOp {
-    Plus,
-    Minus,
-    Asterisk,
-    Slash,
+    Addition,
+    Subtraction,
+    Multiplication,
+    Division,
     Modulo,
     TypedEquals,
     TypedInequals,

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -445,25 +445,25 @@ NonnullRefPtr<Expression> Parser::parse_secondary_expression(NonnullRefPtr<Expre
     switch (m_parser_state.m_current_token.type()) {
     case TokenType::Plus:
         consume();
-        return create_ast_node<BinaryExpression>(BinaryOp::Plus, move(lhs), parse_expression(min_precedence, associativity));
+        return create_ast_node<BinaryExpression>(BinaryOp::Addition, move(lhs), parse_expression(min_precedence, associativity));
     case TokenType::PlusEquals:
         consume();
         return create_ast_node<AssignmentExpression>(AssignmentOp::AdditionAssignment, move(lhs), parse_expression(min_precedence, associativity));
     case TokenType::Minus:
         consume();
-        return create_ast_node<BinaryExpression>(BinaryOp::Minus, move(lhs), parse_expression(min_precedence, associativity));
+        return create_ast_node<BinaryExpression>(BinaryOp::Subtraction, move(lhs), parse_expression(min_precedence, associativity));
     case TokenType::MinusEquals:
         consume();
         return create_ast_node<AssignmentExpression>(AssignmentOp::SubtractionAssignment, move(lhs), parse_expression(min_precedence, associativity));
     case TokenType::Asterisk:
         consume();
-        return create_ast_node<BinaryExpression>(BinaryOp::Asterisk, move(lhs), parse_expression(min_precedence, associativity));
+        return create_ast_node<BinaryExpression>(BinaryOp::Multiplication, move(lhs), parse_expression(min_precedence, associativity));
     case TokenType::AsteriskEquals:
         consume();
         return create_ast_node<AssignmentExpression>(AssignmentOp::MultiplicationAssignment, move(lhs), parse_expression(min_precedence, associativity));
     case TokenType::Slash:
         consume();
-        return create_ast_node<BinaryExpression>(BinaryOp::Slash, move(lhs), parse_expression(min_precedence, associativity));
+        return create_ast_node<BinaryExpression>(BinaryOp::Division, move(lhs), parse_expression(min_precedence, associativity));
     case TokenType::SlashEquals:
         consume();
         return create_ast_node<AssignmentExpression>(AssignmentOp::DivisionAssignment, move(lhs), parse_expression(min_precedence, associativity));


### PR DESCRIPTION
This is not a functional change, just renaming these four `BinaryOp` members:

- `Plus` -> `Addition`
- `Minus` -> `Subtraction`
- `Asterisk` -> `Multiplication`
- `Slash` -> `Division`

This is closer to their actual meaning, similar to how `TokenType::Caret` maps to `BinaryOp::BitwiseXor` (not "`BinaryOp::Caret`")