### PR TITLE
LibGUI: Auto focus MessageBox button

### DIFF
--- a/Libraries/LibGUI/MessageBox.cpp
+++ b/Libraries/LibGUI/MessageBox.cpp
@@ -130,6 +130,7 @@ void MessageBox::build()
         button.set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
         button.set_preferred_size(0, 20);
         button.set_text(label);
+        button.set_focus(true);
         button.on_click = [this, label, result] {
             dbg() << "GUI::MessageBox: '" << label << "' button clicked";
             done(result);


### PR DESCRIPTION
A simple quality of life patch, allowing easy dismissal of MessageBox dialogs by pressing Enter.

Focus is applied to the last created button, which may not always be a sane user experience.

Buttons are created in this order: OK, Yes, No, Cancel

Thus, the auto focus priority is: Cancel, No, Yes, OK (depending on which buttons are present).