### PR TITLE
LibLine: Add styling; LibJS/JS repl: add syntax highlighting

### DIFF
--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -327,7 +327,7 @@ Token Lexer::next()
         m_source.substring_view(trivia_start - 1, value_start - trivia_start),
         m_source.substring_view(value_start - 1, m_position - value_start),
         m_line_number,
-        m_line_column);
+        m_line_column - m_position + value_start);
 
     return m_current_token;
 }

--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -189,7 +189,8 @@ bool Lexer::is_block_comment_end() const
 void Lexer::syntax_error(const char* msg)
 {
     m_has_errors = true;
-    fprintf(stderr, "Syntax Error: %s (line: %zu, column: %zu)\n", msg, m_line_number, m_line_column);
+    if (m_log_errors)
+        fprintf(stderr, "Syntax Error: %s (line: %zu, column: %zu)\n", msg, m_line_number, m_line_column);
 }
 
 Token Lexer::next()

--- a/Libraries/LibJS/Lexer.h
+++ b/Libraries/LibJS/Lexer.h
@@ -37,6 +37,12 @@ namespace JS {
 class Lexer {
 public:
     explicit Lexer(StringView source);
+    Lexer(StringView source, bool log_errors)
+        : Lexer(source)
+    {
+        m_log_errors = log_errors;
+    }
+
     Token next();
     bool has_errors() const { return m_has_errors; }
 
@@ -58,6 +64,7 @@ private:
     bool m_has_errors = false;
     size_t m_line_number = 1;
     size_t m_line_column = 1;
+    bool m_log_errors = true;
 
     static HashMap<String, TokenType> s_keywords;
     static HashMap<String, TokenType> s_three_char_tokens;

--- a/Libraries/LibLine/Span.h
+++ b/Libraries/LibLine/Span.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include <stdlib.h>
+
+namespace Line {
+class Span {
+public:
+    Span(size_t start, size_t end)
+        : m_beginning(start)
+        , m_end(end)
+    {
+    }
+
+    size_t beginning() const { return m_beginning; }
+    size_t end() const { return m_end; }
+
+private:
+    size_t m_beginning { 0 };
+    size_t m_end { 0 };
+};
+}

--- a/Libraries/LibLine/Style.h
+++ b/Libraries/LibLine/Style.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include <stdlib.h>
+
+namespace Line {
+
+class Style {
+public:
+    enum class Color : int {
+        Default = 9,
+        Black = 0,
+        Red,
+        Green,
+        Yellow,
+        Blue,
+        Magenta,
+        Cyan,
+        White,
+        // TODO: it appears that we do not support these SGR options
+        BrightBlack = 60,
+        BrightRed,
+        BrightGreen,
+        BrightYellow,
+        BrightBlue,
+        BrightMagenta,
+        BrightCyan,
+        BrightWhite,
+    };
+
+    struct UnderlineTag {
+    };
+    struct BoldTag {
+    };
+    struct ItalicTag {
+    };
+    struct Background {
+        explicit Background(Color color)
+            : m_color(color)
+        {
+        }
+        Color m_color;
+    };
+    struct Foreground {
+        explicit Foreground(Color color)
+            : m_color(color)
+        {
+        }
+        Color m_color;
+    };
+
+    static constexpr UnderlineTag Underline {};
+    static constexpr BoldTag Bold {};
+    static constexpr ItalicTag Italic {};
+
+    // prepare for the horror of templates
+    template <typename T, typename... Rest>
+    Style(const T& style_arg, Rest... rest)
+        : Style(rest...)
+    {
+        set(style_arg);
+    }
+    Style() {}
+
+    bool underline() const { return m_underline; }
+    bool bold() const { return m_bold; }
+    bool italic() const { return m_italic; }
+    Color background() const { return m_background; }
+    Color foreground() const { return m_foreground; }
+
+    void set(const ItalicTag&) { m_italic = true; }
+    void set(const BoldTag&) { m_bold = true; }
+    void set(const UnderlineTag&) { m_underline = true; }
+    void set(const Background& bg) { m_background = bg.m_color; }
+    void set(const Foreground& fg) { m_foreground = fg.m_color; }
+
+private:
+    bool m_underline { false };
+    bool m_bold { false };
+    bool m_italic { false };
+    Color m_background { Color::Default };
+    Color m_foreground { Color::Default };
+};
+}


### PR DESCRIPTION
Perhaps best served as separate PRs, but they were on the same branch...

These patches mainly add live styling to LibLine, and are my second take on the syntax-highlighted js repl.
If this goes well, we might even be able to provide optional highlighting for the shell itself~