### PR TITLE
IRCClient: Add support for raw protocol commands with /RAW

### DIFF
--- a/Applications/IRCClient/IRCClient.h
+++ b/Applications/IRCClient/IRCClient.h
@@ -168,6 +168,7 @@ private:
     void handle_rpl_topicwhotime(const Message&);
     void handle_rpl_endofnames(const Message&);
     void handle_rpl_namreply(const Message&);
+    void handle_rpl_unknowncommand(const Message&);
     void handle_privmsg_or_notice(const Message&, PrivmsgOrNotice);
     void handle_nick(const Message&);
     void handle(const Message&);


### PR DESCRIPTION
This eases debugging and testing and acts as a stop-gap for commands which are yet to be implemented.

The `String` parsing should probably be abstracted away into a separate function, as it needs to be implemented for handling other /commands. Submitting for review here first before making other changes.