### PR TITLE
LibJS: Plumb line and column information through Lexer / Parser

### DIFF
--- a/Libraries/LibJS/Lexer.h
+++ b/Libraries/LibJS/Lexer.h
@@ -54,8 +54,10 @@ private:
     StringView m_source;
     size_t m_position = 0;
     Token m_current_token;
-    int m_current_char;
+    int m_current_char = 0;
     bool m_has_errors = false;
+    size_t m_line_number = 1;
+    size_t m_line_column = 1;
 
     static HashMap<String, TokenType> s_keywords;
     static HashMap<String, TokenType> s_three_char_tokens;

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -967,7 +967,12 @@ Token Parser::consume(TokenType type)
 {
     if (m_parser_state.m_current_token.type() != type) {
         m_parser_state.m_has_errors = true;
-        fprintf(stderr, "Error: Unexpected token %s. Expected %s\n", m_parser_state.m_current_token.name(), Token::name(type));
+        auto& current_token = m_parser_state.m_current_token;
+        fprintf(stderr, "Error: Unexpected token %s. Expected %s (line: %zu, column: %zu))\n",
+                current_token.name(),
+                Token::name(type),
+                current_token.line_number(),
+                current_token.line_column());
     }
     return consume();
 }
@@ -975,7 +980,12 @@ Token Parser::consume(TokenType type)
 void Parser::expected(const char* what)
 {
     m_parser_state.m_has_errors = true;
-    fprintf(stderr, "Error: Unexpected token %s. Expected %s\n", m_parser_state.m_current_token.name(), what);
+    auto& current_token = m_parser_state.m_current_token;
+    fprintf(stderr, "Error: Unexpected token %s. Expected %s (line: %zu, column: %zu)\n",
+            current_token.name(),
+            what,
+            current_token.line_number(),
+            current_token.line_column());
 }
 
 void Parser::save_state()

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -131,10 +131,12 @@ enum class TokenType {
 
 class Token {
 public:
-    Token(TokenType type, StringView trivia, StringView value)
+    Token(TokenType type, StringView trivia, StringView value, size_t line_number, size_t line_column)
         : m_type(type)
         , m_trivia(trivia)
         , m_value(value)
+        , m_line_number(line_number)
+        , m_line_column(line_column)
     {
     }
 
@@ -144,6 +146,8 @@ public:
 
     const StringView& trivia() const { return m_trivia; }
     const StringView& value() const { return m_value; }
+    size_t line_number() const { return m_line_number; }
+    size_t line_column() const { return m_line_column; }
     double double_value() const;
     String string_value() const;
     bool bool_value() const;
@@ -152,6 +156,8 @@ private:
     TokenType m_type;
     StringView m_trivia;
     StringView m_value;
+    size_t m_line_number;
+    size_t m_line_column;
 };
 
 }


### PR DESCRIPTION
While debugging LibJS test failures, it's pretty frustrating having to 
resort to printf debugging to figure out what test is failing right now.
While watching your JS Raytracer video it seemed like it was hindering
your progress and causing some frustration as well.

I wanted to start working on improving the diagnostics here.
A good first step seemed to be to start surfacing the information
in the obvious places first like the Lexer / Parser error messages.

In the future I hope we can eventually plumb the info down to the
JS Error classes so any thrown exceptions will contain enough
metadata to know where they came from.