### PR TITLE
Lagom: Add clang address/memory/undefined-behavior analyzer support

### DIFF
--- a/Libraries/LibJS/Tests/run-tests
+++ b/Libraries/LibJS/Tests/run-tests
@@ -4,6 +4,9 @@ if [ "`uname`" = "SerenityOS" ]; then
     js_program=/bin/js
 else
     [ -z "$js_program" ] && js_program="$SERENITY_ROOT/Meta/Lagom/build/js"
+
+    # Enable back traces if sanitizers are enabled
+    export UBSAN_OPTIONS=print_stacktrace=1
 fi
 
 pass_count=0

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -5,6 +5,29 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -Wall -Wextra -Werror -std=c++17 -fP
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wconsumed")
+
+    option(ENABLE_ADDRESS_SANITIZER "Enable address sanitizer testing in gcc/clang" FALSE)
+    if (ENABLE_ADDRESS_SANITIZER)
+        add_definitions(-fsanitize=address -fno-omit-frame-pointer)
+        set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=address")
+    endif()
+
+    option(ENABLE_MEMORY_SANITIZER "Enable memory sanitizer testing in gcc/clang" FALSE)
+    if (ENABLE_MEMORY_SANITIZER)
+        add_definitions(-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer)
+        set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=memory -fsanitize-memory-track-origins")
+    endif()
+
+    option(ENABLE_UNDEFINED_SANITIZER "Enable undefined behavior sanitizer testing in gcc/clang" FALSE)
+    if (ENABLE_UNDEFINED_SANITIZER)
+        add_definitions(-fsanitize=undefined -fno-omit-frame-pointer)
+        set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=undefined")
+    endif()
+
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINKER_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LINKER_FLAGS}")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${LINKER_FLAGS}")
+
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-expansion-to-defined")
 endif()


### PR DESCRIPTION
Adding the ability to turn on Clang analyzer support in the Lagom build.
Right now the following are working warning free on the LibJS test suite:

 -DENABLE_MEMORY_SANITIZER:BOOL=ON

 -DENABLE_ADDRESS_SANITIZER:BOOL=ON

The following analyzer produces errors when running the LibJS test suite:

 -DENABLE_UNDEFINED_SANITIZER:BOOL=ON