### PR TITLE
LibJS: Add numeric literal parsing for different bases and exponents

### DIFF
--- a/Libraries/LibJS/Lexer.h
+++ b/Libraries/LibJS/Lexer.h
@@ -42,12 +42,14 @@ public:
 
 private:
     void consume();
+    void consume_exponent();
     bool is_eof() const;
     bool is_identifier_start() const;
     bool is_identifier_middle() const;
     bool is_line_comment_start() const;
     bool is_block_comment_start() const;
     bool is_block_comment_end() const;
+    bool is_numeric_literal_start() const;
 
     void syntax_error(const char*);
 

--- a/Libraries/LibJS/Tests/numeric-literals-basic.js
+++ b/Libraries/LibJS/Tests/numeric-literals-basic.js
@@ -1,0 +1,20 @@
+try {
+    assert(0xff === 255);
+    assert(0XFF === 255);
+    assert(0o10 === 8);
+    assert(0O10 === 8);
+    assert(0b10 === 2);
+    assert(0B10 === 2);
+    assert(1e3 === 1000);
+    assert(1e+3 === 1000);
+    assert(1e-3 === 0.001);
+    assert(.1 === 0.1);
+    assert(.1e1 === 1);
+    assert(0.1e1 === 1);
+    assert(.1e+1 === 1);
+    assert(0.1e+1 === 1);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
WIP because I want to double check everything.
Also this depends on #1645 being merged