### PR TITLE
js: Add a new --test-mode option, which exposes an assert() function, switch LibJS test cases to use it. 

### DIFF
--- a/Libraries/LibJS/Tests/Array.js
+++ b/Libraries/LibJS/Tests/Array.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(Array.length === 1);
     assert(Array.prototype.length === 0);

--- a/Libraries/LibJS/Tests/Array.prototype.pop.js
+++ b/Libraries/LibJS/Tests/Array.prototype.pop.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var a = [1, 2, 3];
     var value = a.pop();

--- a/Libraries/LibJS/Tests/Array.prototype.shift.js
+++ b/Libraries/LibJS/Tests/Array.prototype.shift.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var a = [1, 2, 3];
     var value = a.shift();

--- a/Libraries/LibJS/Tests/Date.now.js
+++ b/Libraries/LibJS/Tests/Date.now.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var last = 0;
     for (var i = 0; i < 100; ++i) {

--- a/Libraries/LibJS/Tests/Date.prototype.getDate.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getDate.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var d = new Date();
     assert(!isNaN(d.getDate()));

--- a/Libraries/LibJS/Tests/Date.prototype.getDay.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getDay.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var d = new Date();
     assert(!isNaN(d.getDay()));

--- a/Libraries/LibJS/Tests/Date.prototype.getFullYear.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getFullYear.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var d = new Date();
     assert(!isNaN(d.getFullYear()));

--- a/Libraries/LibJS/Tests/Date.prototype.getHours.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getHours.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var d = new Date();
     assert(!isNaN(d.getHours()));

--- a/Libraries/LibJS/Tests/Date.prototype.getMilliseconds.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getMilliseconds.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var d = new Date();
     assert(!isNaN(d.getMilliseconds()));

--- a/Libraries/LibJS/Tests/Date.prototype.getMinutes.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getMinutes.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var d = new Date();
     assert(!isNaN(d.getMinutes()));

--- a/Libraries/LibJS/Tests/Date.prototype.getMonth.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getMonth.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var d = new Date();
     assert(!isNaN(d.getMonth()));

--- a/Libraries/LibJS/Tests/Date.prototype.getSeconds.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getSeconds.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var d = new Date();
     assert(!isNaN(d.getSeconds()));

--- a/Libraries/LibJS/Tests/Date.prototype.getTime.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getTime.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var d = new Date();
     assert(!isNaN(d.getTime()));

--- a/Libraries/LibJS/Tests/Error.js
+++ b/Libraries/LibJS/Tests/Error.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var e;
 

--- a/Libraries/LibJS/Tests/Error.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Error.prototype.toString.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(Error().toString() === "Error");
     assert(Error(undefined).toString() === "Error");

--- a/Libraries/LibJS/Tests/Function.js
+++ b/Libraries/LibJS/Tests/Function.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(Function.length === 1);
     assert(Function.prototype.length === 0);

--- a/Libraries/LibJS/Tests/Function.prototype.apply.js
+++ b/Libraries/LibJS/Tests/Function.prototype.apply.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     function Foo(arg) {
         this.foo = arg;

--- a/Libraries/LibJS/Tests/Function.prototype.call.js
+++ b/Libraries/LibJS/Tests/Function.prototype.call.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     function Foo(arg) {
         this.foo = arg;

--- a/Libraries/LibJS/Tests/Function.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Function.prototype.toString.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert((function() {}).toString() === "function () {\n  ???\n}");
     assert((function(foo) {}).toString() === "function (foo) {\n  ???\n}");

--- a/Libraries/LibJS/Tests/Infinity-basic.js
+++ b/Libraries/LibJS/Tests/Infinity-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(Infinity + "" === "Infinity");
     assert(-Infinity + "" === "-Infinity");

--- a/Libraries/LibJS/Tests/Math-constants.js
+++ b/Libraries/LibJS/Tests/Math-constants.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 // FIXME: The parser seems to have issues with decimals,
 // so we multiply everything and compare with whole numbers.
 // I.e. 1233 < X * 1000 < 1235 instead of 1.233 < X < 1.235

--- a/Libraries/LibJS/Tests/Math.abs.js
+++ b/Libraries/LibJS/Tests/Math.abs.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(Math.abs('-1') === 1);
     assert(Math.abs(-2) === 2);

--- a/Libraries/LibJS/Tests/Math.ceil.js
+++ b/Libraries/LibJS/Tests/Math.ceil.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(Math.ceil(0.95) === 1);
     assert(Math.ceil(4) === 4);

--- a/Libraries/LibJS/Tests/Math.max.js
+++ b/Libraries/LibJS/Tests/Math.max.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(Math.max.length === 2);
     assert(Math.max(1) === 1);

--- a/Libraries/LibJS/Tests/Math.sqrt.js
+++ b/Libraries/LibJS/Tests/Math.sqrt.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(Math.sqrt(9) === 3);
     console.log("PASS");

--- a/Libraries/LibJS/Tests/Math.trunc.js
+++ b/Libraries/LibJS/Tests/Math.trunc.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(Math.trunc(13.37) === 13);
     assert(Math.trunc(42.84) === 42);

--- a/Libraries/LibJS/Tests/NaN-basic.js
+++ b/Libraries/LibJS/Tests/NaN-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var nan = undefined + 1;
     assert(nan + "" == "NaN");

--- a/Libraries/LibJS/Tests/Object.getOwnPropertyNames.js
+++ b/Libraries/LibJS/Tests/Object.getOwnPropertyNames.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var names = Object.getOwnPropertyNames([1, 2, 3]);
 

--- a/Libraries/LibJS/Tests/Object.getPrototypeOf.js
+++ b/Libraries/LibJS/Tests/Object.getPrototypeOf.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var o1 = new Object();
     var o2 = {};

--- a/Libraries/LibJS/Tests/Object.prototype.hasOwnProperty.js
+++ b/Libraries/LibJS/Tests/Object.prototype.hasOwnProperty.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var o = {};
     o.foo = 1;

--- a/Libraries/LibJS/Tests/Object.prototype.js
+++ b/Libraries/LibJS/Tests/Object.prototype.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var o = new Object();
     Object.prototype.foo = 123;

--- a/Libraries/LibJS/Tests/Object.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Object.prototype.toString.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(typeof Object.prototype.toString() === "string");
     console.log("PASS");

--- a/Libraries/LibJS/Tests/String.prototype.charAt.js
+++ b/Libraries/LibJS/Tests/String.prototype.charAt.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var s = "foobar"
     assert(typeof s === "string");

--- a/Libraries/LibJS/Tests/String.prototype.indexOf.js
+++ b/Libraries/LibJS/Tests/String.prototype.indexOf.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var s = "hello friends"
 

--- a/Libraries/LibJS/Tests/String.prototype.startsWith.js
+++ b/Libraries/LibJS/Tests/String.prototype.startsWith.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var s = "foobar";
     assert(s.startsWith("f") === true);

--- a/Libraries/LibJS/Tests/array-basic.js
+++ b/Libraries/LibJS/Tests/array-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var a = [1, 2, 3];
 

--- a/Libraries/LibJS/Tests/arrow-functions.js
+++ b/Libraries/LibJS/Tests/arrow-functions.js
@@ -1,4 +1,3 @@
-function assert(x) { if (!x) throw 1; }
 try {
   let getNumber = () => 42;
   assert(getNumber() === 42);

--- a/Libraries/LibJS/Tests/binary-bitwise-operators-basic.js
+++ b/Libraries/LibJS/Tests/binary-bitwise-operators-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert((0 | 0) === 0);
     assert((0 | 1) === 1);

--- a/Libraries/LibJS/Tests/continue-basic.js
+++ b/Libraries/LibJS/Tests/continue-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var j = 0;
     for (var i = 0; i < 9; ++i) {

--- a/Libraries/LibJS/Tests/do-while-basic.js
+++ b/Libraries/LibJS/Tests/do-while-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var number = 0;
     do {

--- a/Libraries/LibJS/Tests/exception-ReferenceError.js
+++ b/Libraries/LibJS/Tests/exception-ReferenceError.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) console.log("FAIL"); }
-
 try {
     i < 3;
 } catch (e) {

--- a/Libraries/LibJS/Tests/for-basic.js
+++ b/Libraries/LibJS/Tests/for-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var a = [];
     for (var i = 0; i < 3; ++i) {

--- a/Libraries/LibJS/Tests/for-no-curlies.js
+++ b/Libraries/LibJS/Tests/for-no-curlies.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var number = 0;
 

--- a/Libraries/LibJS/Tests/function-TypeError.js
+++ b/Libraries/LibJS/Tests/function-TypeError.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     try {
         var b = true;

--- a/Libraries/LibJS/Tests/function-length.js
+++ b/Libraries/LibJS/Tests/function-length.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     function foo() { }
     assert(foo.length === 0);

--- a/Libraries/LibJS/Tests/function-missing-arg.js
+++ b/Libraries/LibJS/Tests/function-missing-arg.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 function foo(a, b) { return a + b; }
 
 try {

--- a/Libraries/LibJS/Tests/function-this-in-arguments.js
+++ b/Libraries/LibJS/Tests/function-this-in-arguments.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
   assert(typeof this === "object");
   assert(this === global);

--- a/Libraries/LibJS/Tests/instanceof-basic.js
+++ b/Libraries/LibJS/Tests/instanceof-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     function Foo() {
         this.x = 123;

--- a/Libraries/LibJS/Tests/logical-expressions-basic.js
+++ b/Libraries/LibJS/Tests/logical-expressions-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert((true && true) === true);
     assert((false && false) === false);

--- a/Libraries/LibJS/Tests/logical-expressions-short-circuit.js
+++ b/Libraries/LibJS/Tests/logical-expressions-short-circuit.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     let foo = 1;
     false && (foo = 2);

--- a/Libraries/LibJS/Tests/modulo-basic.js
+++ b/Libraries/LibJS/Tests/modulo-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(10 % 3 === 1);
     assert(10.5 % 2.5 === 0.5);

--- a/Libraries/LibJS/Tests/parser-unary-associativity.js
+++ b/Libraries/LibJS/Tests/parser-unary-associativity.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var o = {};
     o.a = 1;

--- a/Libraries/LibJS/Tests/run-tests
+++ b/Libraries/LibJS/Tests/run-tests
@@ -14,7 +14,7 @@ fail_count=0
 count=0
 
 for f in *.js; do
-    result=`$js_program $f`
+    result=`$js_program -t $f`
     if [ "$result" = "PASS" ]; then
         let pass_count++
         echo -ne "( \033[32;1mPass\033[0m ) "

--- a/Libraries/LibJS/Tests/switch-break.js
+++ b/Libraries/LibJS/Tests/switch-break.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var i = 0;
     var three;

--- a/Libraries/LibJS/Tests/ternary-basic.js
+++ b/Libraries/LibJS/Tests/ternary-basic.js
@@ -1,10 +1,8 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var x = 1;
 
     assert(x === 1 ? true : false);
-    assert(x ? x : 0);
+    assert((x ? x : 0) === x);
     assert(1 < 2 ? (true) : (false));
 
     var o = {};

--- a/Libraries/LibJS/Tests/throw-basic.js
+++ b/Libraries/LibJS/Tests/throw-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) console.log("FAIL"); }
-
 try {
     throw 1;
 } catch (e) {

--- a/Libraries/LibJS/Tests/to-number-basic.js
+++ b/Libraries/LibJS/Tests/to-number-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(+false === 0);
     assert(-false === 0);

--- a/Libraries/LibJS/Tests/typeof-basic.js
+++ b/Libraries/LibJS/Tests/typeof-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(typeof "foo" === "string");
     assert(!(typeof "foo" !== "string"));

--- a/Libraries/LibJS/Tests/var-multiple-declarator.js
+++ b/Libraries/LibJS/Tests/var-multiple-declarator.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     var a = 1, b = 2, c = a + b;
     assert(a === 1);

--- a/Libraries/LibJS/Tests/variable-undefined.js
+++ b/Libraries/LibJS/Tests/variable-undefined.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 function foo(a) {
     return a;
 }


### PR DESCRIPTION
Currently ever test case in the LlibJS test suite has it's own implementation of function assert(x) { ... }.
As the collection of test cases starts to grow it seemed like it was time to start consolidating this type
of test only functionality in a common location. 

To solve this I've added a --test-mode option to the js repl, which LibJS/Tests/run-tests now passes
for all test cases. This flag exposes a new native implementation of the assert function that can be
shared across all tests. 