### PR TITLE
LibJS: Update tests

### DIFF
--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -49,7 +49,7 @@ MathObject::MathObject()
     put("LOG2E", Value(log2(M_E)));
     put("LOG10E", Value(log10(M_E)));
     put("PI", Value(M_PI));
-    put("SQRT1_2", Value(::sqrt(1 / 2)));
+    put("SQRT1_2", Value(::sqrt(1.0 / 2.0)));
     put("SQRT2", Value(::sqrt(2)));
 }
 

--- a/Libraries/LibJS/Tests/Math-constants.js
+++ b/Libraries/LibJS/Tests/Math-constants.js
@@ -1,24 +1,15 @@
-// FIXME: The parser seems to have issues with decimals,
-// so we multiply everything and compare with whole numbers.
-// I.e. 1233 < X * 1000 < 1235 instead of 1.233 < X < 1.235
+// Borrowed from LibM/TestMath.cpp :^)
+function expectClose(a, b) { assert(Math.abs(a - b) < 0.000001); }
 
 try {
-    // approx. 2.718
-    assert(2717 < Math.E * 1000 < 2719);
-    // approx. 0.693MATH
-    assert(692 < Math.LN2 * 1000 < 694);
-    // approx. 2.303
-    assert(2302 < Math.LN10 * 1000 < 2304);
-    // approx. 1.443
-    assert(1442 < Math.LOG2E * 1000 < 1444);
-    // approx. 0.434
-    assert(433 < Math.LOG10E * 1000 < 435);
-    // approx. 3.1415
-    assert(31414 < Math.PI * 10000 < 31416);
-    // approx. 0.707
-    assert(706 < Math.SQRT1_2 * 1000 < 708);
-    // approx. 1.414
-    assert(1413 < Math.SQRT2 * 1000 < 1415);
+    expectClose(Math.E, 2.718281);
+    expectClose(Math.LN2, 0.693147);
+    expectClose(Math.LN10, 2.302585);
+    expectClose(Math.LOG2E, 1.442695);
+    expectClose(Math.LOG10E, 0.434294);
+    expectClose(Math.PI, 3.1415926);
+    expectClose(Math.SQRT1_2, 0.707106);
+    expectClose(Math.SQRT2, 1.414213);
 
     console.log("PASS");
 } catch (e) {

--- a/Libraries/LibJS/Tests/exponentiation-basic.js
+++ b/Libraries/LibJS/Tests/exponentiation-basic.js
@@ -1,5 +1,3 @@
-function assert(x) { if (!x) throw 1; }
-
 try {
     assert(2 ** 0 === 1);
     assert(2 ** 1 === 2);

--- a/Libraries/LibJS/Tests/to-number-basic.js
+++ b/Libraries/LibJS/Tests/to-number-basic.js
@@ -17,12 +17,11 @@ try {
     assert(-"42" === -42);
     assert(+42 === 42);
     assert(-42 === -42);
+    assert(+1.23 === 1.23);
+    assert(-1.23 === -1.23);
     // FIXME: returns NaN
     // assert(+"1.23" === 1.23)
     // assert(-"1.23" === -1.23)
-    // FIXME: chokes on ASSERT
-    // assert(+1.23 === 1.23);
-    // assert(-1.23 === -1.23);
 
     assert(isNaN(+undefined));
     assert(isNaN(-undefined));


### PR DESCRIPTION
- The value of `Math.SQRT1_2` was zero as we were dividing two integers.
- Uncomment lines that are now parsing correctly :^)
- By borrowing an "expect close" function from `LibM/TestMath.cpp`, we can make this a lot simpler. Also the parser now understands decimals!