### PR TITLE
LibJS: Fix do..while parsing by consuming parentheses explicitly

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -726,9 +726,16 @@ NonnullRefPtr<TryStatement> Parser::parse_try_statement()
 NonnullRefPtr<DoWhileStatement> Parser::parse_do_while_statement()
 {
     consume(TokenType::Do);
+
     auto body = parse_statement();
+
     consume(TokenType::While);
+    consume(TokenType::ParenOpen);
+
     auto test = parse_expression(0);
+
+    consume(TokenType::ParenClose);
+
     return create_ast_node<DoWhileStatement>(move(test), move(body));
 }
 


### PR DESCRIPTION
Hi,

this is my first commit and contribute in c++.
Hope it helps :)

kind regards,
Maxim