### PR TITLE
QuickShow: Miscellaneous improvements

### DIFF
--- a/Applications/QuickShow/QSWidget.h
+++ b/Applications/QuickShow/QSWidget.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <LibGUI/Frame.h>
+#include <LibGfx/FloatPoint.h>
 
 class QSLabel;
 
@@ -35,13 +36,13 @@ class QSWidget final : public GUI::Frame {
 public:
     virtual ~QSWidget() override;
 
-    void set_bitmap(NonnullRefPtr<Gfx::Bitmap>);
     const Gfx::Bitmap* bitmap() const { return m_bitmap.ptr(); }
-
-    void set_path(const String&);
     const String& path() const { return m_path; }
 
+    void load_from_file(const String&);
+
     Function<void(int)> on_scale_change;
+    Function<void(const GUI::DropEvent&)> on_drop;
 
 private:
     QSWidget();
@@ -55,10 +56,13 @@ private:
 
     void relayout();
 
+    String m_path;
     RefPtr<Gfx::Bitmap> m_bitmap;
+
     Gfx::Rect m_bitmap_rect;
     int m_scale { 100 };
-    Gfx::Point m_pan_origin;
-    Gfx::Point m_pan_bitmap_origin;
-    String m_path;
+    Gfx::FloatPoint m_pan_origin;
+
+    Gfx::Point m_click_position;
+    Gfx::FloatPoint m_saved_pan_origin;
 };


### PR DESCRIPTION
Major changes are:

* The layout and mouse handling has been rewritten to always center images in the window.
* QuickShow now accepts multiple images on drag and drop. The first image gets opened in the current window, further images are opened in new processes.
* QSWidget now loads images on its own with QSWidget::load_from_file().
* An on_drop callback has been introduced for QSWidget.
* Added an open menu.
* Added an about box and placeholder icons to the application.
* QuickShow now starts without loading the sunset-retro wallpaper.