### PR TITLE
Refresh OpenSSL port and make it build the command line utilities

### DIFF
--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -125,6 +125,9 @@ KResult Socket::setsockopt(int level, int option, const void* value, socklen_t v
         m_bound_interface = device;
         return KSuccess;
     }
+    case SO_KEEPALIVE:
+        // FIXME: Obviously, this is not a real keepalive.
+        return KSuccess;
     default:
         dbg() << "setsockopt(" << option << ") at SOL_SOCKET not implemented.";
         return KResult(-ENOPROTOOPT);

--- a/Libraries/LibC/ulimit.cpp
+++ b/Libraries/LibC/ulimit.cpp
@@ -26,6 +26,7 @@
 
 #include <assert.h>
 #include <ulimit.h>
+#include <sys/resource.h>
 
 extern "C" {
 
@@ -36,4 +37,13 @@ long ulimit(int cmd, long newlimit)
     ASSERT_NOT_REACHED();
     return -1;
 }
+
+int getrusage(int who, struct rusage *usage)
+{
+    (void)who;
+    (void)usage;
+    ASSERT_NOT_REACHED();
+    return -1;
+}
+
 }

--- a/Ports/openssl/package.sh
+++ b/Ports/openssl/package.sh
@@ -1,19 +1,20 @@
 #!/bin/bash ../.port_include.sh
 port=openssl
-version=1.0.2t
+branch='1.0.2'
+version="${branch}t"
 useconfigure=true
 configscript=Configure
-files="https://www.openssl.org/source/openssl-${version}.tar.gz openssl-${version}.tar.gz
-https://www.openssl.org/source/openssl-${version}.tar.gz.asc openssl-${version}.tar.gz.asc"
+files="https://ftp.openssl.org/source/old/${branch}/openssl-${version}.tar.gz openssl-${version}.tar.gz
+https://ftp.openssl.org/source/old/${branch}/openssl-${version}.tar.gz.asc openssl-${version}.tar.gz.asc"
 auth_type="sig"
 auth_import_key="8657ABB260F056B1E5190839D9C4D26D0E604491"
 auth_opts="openssl-${version}.tar.gz.asc openssl-${version}.tar.gz"
 
 depends="zlib"
 usr_local=$SERENITY_ROOT/Root/usr/local/
-configopts="--prefix=$usr_local --openssldir=$usr_local/ssl BSD-x86 zlib no-tests no-threads no-asm no-sock"
+configopts="--prefix=$usr_local -DOPENSSL_SYS_SERENITY=1 --openssldir=$usr_local/ssl BSD-x86 zlib no-tests no-threads no-asm"
 
 configure() {
-    run rm -rf ./test/ ./apps/
+    run rm -rf ./test/
     run ./"$configscript" $configopts
 }

--- a/Ports/openssl/patches/ocsp_fd_set.patch
+++ b/Ports/openssl/patches/ocsp_fd_set.patch
@@ -1,0 +1,13 @@
+--- a/apps/ocsp.c	2020-04-05 16:49:54.499380971 +0100
++++ b/apps/ocsp.c	2020-04-05 16:50:13.175380426 +0100
+@@ -94,6 +94,10 @@
+ #  endif
+ # endif
+ 
++# if defined(OPENSSL_SYS_SERENITY)
++#  include <sys/select.h>
++# endif
++
+ /* Maximum leeway in validity period: default 5 minutes */
+ # define MAX_VALIDITY_PERIOD     (5 * 60)
+ 

--- a/Ports/openssl/patches/s_apps.patch
+++ b/Ports/openssl/patches/s_apps.patch
@@ -1,0 +1,13 @@
+--- a/apps/s_apps.h	2020-04-05 13:52:44.967691150 +0100
++++ b/apps/s_apps.h	2020-04-05 13:52:50.147690999 +0100
+@@ -122,6 +122,10 @@
+ # define _kbhit kbhit
+ #endif
+ 
++#if defined(OPENSSL_SYS_SERENITY)
++# include <sys/select.h>
++#endif
++
+ #if defined(OPENSSL_SYS_VMS) && !defined(FD_SET)
+ /*
+  * VAX C does not defined fd_set and friends, but it's actually quite simple


### PR DESCRIPTION
This patch refreshes the openssl port and makes it build the utilities in `apps/`, e.g. the `openssl` utility.

Now you can do this from Serenity:

    $ openssl s_client -connect example.org:443
    ...
    GET / HTTP/1.1
    Host: example.org

    <HTTP response here>

The download URL was bit-rotten and needed a fix.