### PR TITLE
LibJS: Add Math.{sin,cos,tan}() / Base: Add trigonometry demo webpage

### DIFF
--- a/Base/home/anon/www/trigonometry.html
+++ b/Base/home/anon/www/trigonometry.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Trigonometry</title>
+        <style type="text/css">
+            canvas {
+                border-width: 1px;
+                border-style: solid;
+                border-color: #000;
+            }
+        </style>
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+                var functions = ["sin", "cos", "tan"];
+                for (var i = 0; i < functions.length; ++i) {
+                    var func = functions[i];
+                    var canvas = document.getElementById(func);
+                    var ctx = canvas.getContext("2d");
+                    for (var x = 0; x < canvas.width; ++x) {
+                        var y = -Math[func](x / 20) * canvas.height / 4 + canvas.height / 2;
+                        ctx.fillStyle = "red";
+                        ctx.fillRect(x-1, y-1, 2, 2);
+                        ctx.fillStyle = "black";
+                        ctx.fillRect(x, canvas.height / 2, 1, 1);
+                    }
+                }
+            });
+        </script>
+    </head>
+    <body>
+        <h1>Sine</h1>
+        <canvas id="sin" width="300" height="100"></canvas>
+        <h1>Cosine</h1>
+        <canvas id="cos" width="300" height="100"></canvas>
+        <h1>Tangent</h1>
+        <canvas id="tan" width="300" height="100"></canvas>
+    </body>
+</html>

--- a/Base/home/anon/www/welcome.html
+++ b/Base/home/anon/www/welcome.html
@@ -28,6 +28,7 @@ span#ua {
     <p>Your user agent is: <b><span id="ua"></span></b></p>
     <p>Some small test pages:</p>
     <ul>
+        <li><a href="trigonometry.html">canvas + trigonometry functions</a></li>
         <li><a href="qsa.html">querySelectorAll test</a></li>
         <li><a href="innerHTML.html">innerHTML property test</a></li>
         <li><a href="position-absolute-top-left.html">position: absolute; for top and left</a></li>

--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -42,6 +42,9 @@ MathObject::MathObject()
     put_native_function("round", round, 1);
     put_native_function("max", max, 2);
     put_native_function("trunc", trunc, 1);
+    put_native_function("sin", sin, 1);
+    put_native_function("cos", cos, 1);
+    put_native_function("tan", tan, 1);
 
     put("E", Value(M_E));
     put("LN2", Value(M_LN2));
@@ -133,6 +136,30 @@ Value MathObject::trunc(Interpreter& interpreter)
     if (number.as_double() < 0)
         return MathObject::ceil(interpreter);
     return MathObject::floor(interpreter);
+}
+
+Value MathObject::sin(Interpreter& interpreter)
+{
+    auto number = interpreter.argument(0).to_number();
+    if (number.is_nan())
+        return js_nan();
+    return Value(::sin(number.as_double()));
+}
+
+Value MathObject::cos(Interpreter& interpreter)
+{
+    auto number = interpreter.argument(0).to_number();
+    if (number.is_nan())
+        return js_nan();
+    return Value(::cos(number.as_double()));
+}
+
+Value MathObject::tan(Interpreter& interpreter)
+{
+    auto number = interpreter.argument(0).to_number();
+    if (number.is_nan())
+        return js_nan();
+    return Value(::tan(number.as_double()));
 }
 
 }

--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -59,9 +59,6 @@ MathObject::~MathObject()
 
 Value MathObject::abs(Interpreter& interpreter)
 {
-    if (!interpreter.argument_count())
-        return js_nan();
-
     auto number = interpreter.argument(0).to_number();
     if (number.is_nan())
         return js_nan();
@@ -80,9 +77,6 @@ Value MathObject::random(Interpreter&)
 
 Value MathObject::sqrt(Interpreter& interpreter)
 {
-    if (!interpreter.argument_count())
-        return js_nan();
-
     auto number = interpreter.argument(0).to_number();
     if (number.is_nan())
         return js_nan();
@@ -91,9 +85,6 @@ Value MathObject::sqrt(Interpreter& interpreter)
 
 Value MathObject::floor(Interpreter& interpreter)
 {
-    if (!interpreter.argument_count())
-        return js_nan();
-
     auto number = interpreter.argument(0).to_number();
     if (number.is_nan())
         return js_nan();
@@ -102,9 +93,6 @@ Value MathObject::floor(Interpreter& interpreter)
 
 Value MathObject::ceil(Interpreter& interpreter)
 {
-    if (!interpreter.argument_count())
-        return js_nan();
-
     auto number = interpreter.argument(0).to_number();
     if (number.is_nan())
         return js_nan();
@@ -113,9 +101,6 @@ Value MathObject::ceil(Interpreter& interpreter)
 
 Value MathObject::round(Interpreter& interpreter)
 {
-    if (!interpreter.argument_count())
-        return js_nan();
-
     auto number = interpreter.argument(0).to_number();
     if (number.is_nan())
         return js_nan();
@@ -141,9 +126,6 @@ Value MathObject::max(Interpreter& interpreter)
 
 Value MathObject::trunc(Interpreter& interpreter)
 {
-    if (!interpreter.argument_count())
-        return js_nan();
-
     auto number = interpreter.argument(0).to_number();
     if (number.is_nan())
         return js_nan();

--- a/Libraries/LibJS/Runtime/MathObject.h
+++ b/Libraries/LibJS/Runtime/MathObject.h
@@ -46,6 +46,9 @@ private:
     static Value round(Interpreter&);
     static Value max(Interpreter&);
     static Value trunc(Interpreter&);
+    static Value sin(Interpreter&);
+    static Value cos(Interpreter&);
+    static Value tan(Interpreter&);
 };
 
 }

--- a/Libraries/LibJS/Tests/Math.cos.js
+++ b/Libraries/LibJS/Tests/Math.cos.js
@@ -1,0 +1,16 @@
+try {
+    assert(Math.cos(0) === 1);
+    assert(Math.cos(null) === 1);
+    assert(Math.cos('') === 1);
+    assert(Math.cos([]) === 1);
+    assert(Math.cos(Math.PI) === -1);
+    assert(isNaN(Math.cos()));
+    assert(isNaN(Math.cos(undefined)));
+    assert(isNaN(Math.cos([1, 2, 3])));
+    assert(isNaN(Math.cos({})));
+    assert(isNaN(Math.cos("foo")));
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Math.sin.js
+++ b/Libraries/LibJS/Tests/Math.sin.js
@@ -1,0 +1,17 @@
+try {
+    assert(Math.sin(0) === 0);
+    assert(Math.sin(null) === 0);
+    assert(Math.sin('') === 0);
+    assert(Math.sin([]) === 0);
+    assert(Math.sin(Math.PI * 3 / 2) === -1);
+    assert(Math.sin(Math.PI / 2) === 1);
+    assert(isNaN(Math.sin()));
+    assert(isNaN(Math.sin(undefined)));
+    assert(isNaN(Math.sin([1, 2, 3])));
+    assert(isNaN(Math.sin({})));
+    assert(isNaN(Math.sin("foo")));
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Math.tan.js
+++ b/Libraries/LibJS/Tests/Math.tan.js
@@ -1,0 +1,16 @@
+try {
+    assert(Math.tan(0) === 0);
+    assert(Math.tan(null) === 0);
+    assert(Math.tan('') === 0);
+    assert(Math.tan([]) === 0);
+    assert(Math.ceil(Math.tan(Math.PI / 4)) === 1);
+    assert(isNaN(Math.tan()));
+    assert(isNaN(Math.tan(undefined)));
+    assert(isNaN(Math.tan([1, 2, 3])));
+    assert(isNaN(Math.tan({})));
+    assert(isNaN(Math.tan("foo")));
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
- Simplify functions in `MathObject` - we don't need the argument length check as `interpreter.argument(0).to_number()` will return nan if the argument is missing - and `if (number.is_nan()) return js_nan()` then takes care of that. Less verbose now.
- Add `Math.sin()`, `Math.cos()` and `Math.tan()`
- Add a small demo page plotting these functions on a canvas :^)

  ![image](https://user-images.githubusercontent.com/19366641/78510419-e50a3680-778c-11ea-954b-70b393fdec60.png)
