### PR TITLE
QuickShow+LibGfx: Operator overload changes

### DIFF
--- a/Applications/QuickShow/QSWidget.cpp
+++ b/Applications/QuickShow/QSWidget.cpp
@@ -47,14 +47,10 @@ void QSWidget::relayout()
 
     float scale_factor = (float)m_scale / 100.0f;
 
-    Gfx::Size new_size;
-    new_size.set_width(m_bitmap->width() * scale_factor);
-    new_size.set_height(m_bitmap->height() * scale_factor);
+    auto new_size = (Gfx::Size)((Gfx::FloatPoint)m_bitmap->size() * scale_factor);
     m_bitmap_rect.set_size(new_size);
 
-    Gfx::Point new_location;
-    new_location.set_x((width() / 2) - (new_size.width() / 2) - (m_pan_origin.x() * scale_factor));
-    new_location.set_y((height() / 2) - (new_size.height() / 2) - (m_pan_origin.y() * scale_factor));
+    auto new_location = (Gfx::Point)(size() / 2) - (Gfx::Point)(new_size / 2) - (Gfx::Point)(m_pan_origin * scale_factor);
     m_bitmap_rect.set_location(new_location);
 
     update();
@@ -95,11 +91,9 @@ void QSWidget::mousemove_event(GUI::MouseEvent& event)
     if (!(event.buttons() & GUI::MouseButton::Left))
         return;
 
-    auto delta = event.position() - m_click_position;
+    auto delta = (Gfx::FloatPoint)(event.position() - m_click_position);
     float scale_factor = (float)m_scale / 100.0f;
-    m_pan_origin = m_saved_pan_origin.translated(
-        -delta.x() / scale_factor,
-        -delta.y() / scale_factor);
+    m_pan_origin = m_saved_pan_origin.translated(-delta / scale_factor);
 
     relayout();
 }
@@ -117,13 +111,8 @@ void QSWidget::mousewheel_event(GUI::MouseEvent& event)
 
     auto new_scale_factor = (float)m_scale / 100.0f;
 
-    auto focus_point = Gfx::FloatPoint(
-        m_pan_origin.x() - ((float)event.x() - (float)width() / 2.0) / old_scale_factor,
-        m_pan_origin.y() - ((float)event.y() - (float)height() / 2.0) / old_scale_factor);
-
-    m_pan_origin = Gfx::FloatPoint(
-        focus_point.x() - new_scale_factor / old_scale_factor * (focus_point.x() - m_pan_origin.x()),
-        focus_point.y() - new_scale_factor / old_scale_factor * (focus_point.y() - m_pan_origin.y()));
+    auto focus_point = m_pan_origin - (Gfx::FloatPoint)(event.position() - (Gfx::Point)(size() / 2)) / old_scale_factor;
+    m_pan_origin = focus_point - (focus_point - m_pan_origin) * (new_scale_factor / old_scale_factor);
 
     relayout();
 

--- a/Libraries/LibGfx/FloatPoint.cpp
+++ b/Libraries/LibGfx/FloatPoint.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, Nagy Tibor <xnagytibor@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibGfx/FloatPoint.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Size.h>
+
+namespace Gfx {
+
+FloatPoint::operator Point() const {
+    return Point(x(), y());
+}
+
+FloatPoint::operator Size() const {
+    return Size(x(), y());
+}
+
+}

--- a/Libraries/LibGfx/FloatPoint.h
+++ b/Libraries/LibGfx/FloatPoint.h
@@ -33,6 +33,8 @@
 namespace Gfx {
 
 class FloatRect;
+class Point;
+class Size;
 
 class FloatPoint {
 public:
@@ -96,13 +98,32 @@ public:
         return *this;
     }
 
+    FloatPoint operator+(const FloatPoint& other) const { return { m_x + other.m_x, m_y + other.m_y }; }
     FloatPoint& operator+=(const FloatPoint& other)
     {
         m_x += other.m_x;
         m_y += other.m_y;
         return *this;
     }
-    FloatPoint operator+(const FloatPoint& other) const { return { m_x + other.m_x, m_y + other.m_y }; }
+
+    FloatPoint operator*(float other) const { return { m_x * other, m_y * other }; }
+    FloatPoint& operator*=(float other)
+    {
+        m_x *= other;
+        m_y *= other;
+        return *this;
+    }
+
+    FloatPoint operator/(float other) const { return { m_x / other, m_y / other }; }
+    FloatPoint& operator/=(float other)
+    {
+        m_x /= other;
+        m_y /= other;
+        return *this;
+    }
+
+    explicit operator Point() const;
+    explicit operator Size() const;
 
     String to_string() const { return String::format("[%g,%g]", x(), y()); }
 

--- a/Libraries/LibGfx/Makefile
+++ b/Libraries/LibGfx/Makefile
@@ -4,6 +4,7 @@ OBJS = \
     Color.o \
     DisjointRectSet.o \
     Emoji.o \
+    FloatPoint.o \
     Font.o \
     GIFLoader.o \
     ImageDecoder.o \

--- a/Libraries/LibGfx/Point.cpp
+++ b/Libraries/LibGfx/Point.cpp
@@ -26,10 +26,20 @@
 
 #include <AK/BufferStream.h>
 #include <AK/String.h>
+#include <LibGfx/FloatPoint.h>
 #include <LibGfx/Point.h>
+#include <LibGfx/Size.h>
 #include <LibIPC/Decoder.h>
 
 namespace Gfx {
+
+Point::operator FloatPoint() const {
+    return FloatPoint(x(), y());
+}
+
+Point::operator Size() const {
+    return Size(x(), y());
+}
 
 String Point::to_string() const
 {

--- a/Libraries/LibGfx/Point.h
+++ b/Libraries/LibGfx/Point.h
@@ -34,7 +34,9 @@
 
 namespace Gfx {
 
+class FloatPoint;
 class Rect;
+class Size;
 
 class Point {
 public:
@@ -99,13 +101,32 @@ public:
         return *this;
     }
 
+    Point operator+(const Point& other) const { return { m_x + other.m_x, m_y + other.m_y }; }
     Point& operator+=(const Point& other)
     {
         m_x += other.m_x;
         m_y += other.m_y;
         return *this;
     }
-    Point operator+(const Point& other) const { return { m_x + other.m_x, m_y + other.m_y }; }
+
+    Point operator*(int other) const { return { m_x * other, m_y * other }; }
+    Point& operator*=(int other)
+    {
+        m_x *= other;
+        m_y *= other;
+        return *this;
+    }
+
+    Point operator/(int other) const { return { m_x / other, m_y / other }; }
+    Point& operator/=(int other)
+    {
+        m_x /= other;
+        m_y /= other;
+        return *this;
+    }
+
+    explicit operator Size() const;
+    explicit operator FloatPoint() const;
 
     String to_string() const;
 

--- a/Libraries/LibGfx/Size.cpp
+++ b/Libraries/LibGfx/Size.cpp
@@ -26,10 +26,20 @@
 
 #include <AK/BufferStream.h>
 #include <AK/String.h>
+#include <LibGfx/FloatPoint.h>
+#include <LibGfx/Point.h>
 #include <LibGfx/Size.h>
 #include <LibIPC/Decoder.h>
 
 namespace Gfx {
+
+Size::operator FloatPoint() const {
+    return FloatPoint(width(), height());
+}
+
+Size::operator Point() const {
+    return Point(width(), height());
+}
 
 String Size::to_string() const
 {

--- a/Libraries/LibGfx/Size.h
+++ b/Libraries/LibGfx/Size.h
@@ -32,6 +32,9 @@
 
 namespace Gfx {
 
+class FloatPoint;
+class Point;
+
 class Size {
 public:
     Size() {}
@@ -75,6 +78,25 @@ public:
         m_height += other.m_height;
         return *this;
     }
+
+    Size operator*(int other) const { return { m_width * other, m_height * other }; }
+    Size& operator*=(int other)
+    {
+        m_width *= other;
+        m_height *= other;
+        return *this;
+    }
+
+    Size operator/(int other) const { return { m_width / other, m_height / other }; }
+    Size& operator/=(int other)
+    {
+        m_width /= other;
+        m_height /= other;
+        return *this;
+    }
+
+    explicit operator Point() const;
+    explicit operator FloatPoint() const;
 
     int primary_size_for_orientation(Orientation orientation) const
     {


### PR DESCRIPTION
These `Size`/`Point`/`FloatPoint` operator additions in LibGfx enables for example going from this:

```cpp
m_pan_origin = Gfx::FloatPoint(
    focus_point.x() - new_scale_factor / old_scale_factor * (focus_point.x() - m_pan_origin.x()),
    focus_point.y() - new_scale_factor / old_scale_factor * (focus_point.y() - m_pan_origin.y()));
```

...to this in QuickShow:

```cpp
m_pan_origin = focus_point - (focus_point - m_pan_origin) * (new_scale_factor / old_scale_factor);
```