### PR TITLE
LibJS: Fix some tests for Math.min()

### DIFF
--- a/Libraries/LibJS/Tests/Math.min.js
+++ b/Libraries/LibJS/Tests/Math.min.js
@@ -3,8 +3,8 @@ try {
     assert(Math.min(1) === 1);
     assert(Math.min(2, 1) === 1);
     assert(Math.min(1, 2, 3) === 1);
-    assert(isNaN(Math.max(NaN)));
-    assert(isNaN(Math.max("String", 1)));
+    assert(isNaN(Math.min(NaN)));
+    assert(isNaN(Math.min("String", 1)));
 
     console.log("PASS");
 } catch {


### PR DESCRIPTION
In some of the tests in Math.min.js, we were testing Math.max() instead
of Math.min()