### PR TITLE
LibM: Fix ceil() and ceilf() for negative numbers

### DIFF
--- a/Libraries/LibM/math.cpp
+++ b/Libraries/LibM/math.cpp
@@ -384,8 +384,12 @@ float ceilf(float value)
 {
     // FIXME: Please fix me. I am naive.
     int as_int = (int)value;
-    if (value == (float)as_int) {
-        return (float)as_int;
+    if (value == (float)as_int)
+        return as_int;
+    if (value < 0) {
+        if (as_int == 0)
+            return -0;
+        return as_int;
     }
     return as_int + 1;
 }
@@ -394,8 +398,12 @@ double ceil(double value)
 {
     // FIXME: Please fix me. I am naive.
     int as_int = (int)value;
-    if (value == (double)as_int) {
-        return (double)as_int;
+    if (value == (double)as_int)
+        return as_int;
+    if (value < 0) {
+        if (as_int == 0)
+            return -0;
+        return as_int;
     }
     return as_int + 1;
 }


### PR DESCRIPTION
These functions are using a naive approach: casting `double`/`float` to `int` and returning the result + 1. That increment by one must only happen for positive input values though.

This also fixes `Math.trunc()` and `Math.ceil()` in JS; their tests now fully pass.

Example demonstrating the issue:

```c
#include <stdio.h>

int main()
{
    double x;
    
    x = 1.123;
    printf("%d\n", (int)x);
    x = 0.123;
    printf("%d\n", (int)x);
    x = -0.123;
    printf("%d\n", (int)x);
    x = -1.123;
    printf("%d\n", (int)x);

    return 0;
}
```

```
 1.234 ->  1 + 1 = 2 [correct]
 0.123 ->  0 + 1 = 1 [correct]
-0.123 ->  0 + 1 = 1 [wrong; expected -0]
-1.123 -> -1 + 1 = 0 [wrong; expected -1]
```