### PR TITLE
LibJS: Fix impossible member access for negative integers

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -893,7 +893,7 @@ PropertyName MemberExpression::computed_property_name(Interpreter& interpreter) 
         return {};
     ASSERT(!index.is_empty());
     // FIXME: What about non-integer numbers tho.
-    if (index.is_number())
+    if (index.is_number() && index.to_i32() >= 0)
         return PropertyName(index.to_i32());
     return PropertyName(index.to_string());
 }

--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -1,0 +1,17 @@
+try {
+    var o = { foo: "bar" };
+    assert(o.foo === "bar");
+    assert(o["foo"] === "bar");
+    o.baz = "test";
+    assert(o.baz === "test");
+    assert(o["baz"] === "test");
+    o[10] = "123";
+    assert(o[10] === "123");
+    assert(o["10"] === "123");
+    o[-1] = "hello friends";
+    assert(o[-1] === "hello friends");
+    assert(o["-1"] === "hello friends");
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
I saw that in the last video, and thought that it would make a good first contribution :^)

The PropertyName class able to match a number or an array can only accept positive numerical values. However, the computed_property_name method sometimes returned negative values.

This commit also adds a basic object access test case for this and other standard access.