### PR TITLE
LibJS: Allow parsing numeric and string literals in object expressions

### DIFF
--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -1,7 +1,11 @@
 try {
-    var o = { foo: "bar" };
+    var o = { 1: 23, foo: "bar", "hello": "friends" };
+    assert(o[1] === 23);
+    assert(o["1"] === 23);
     assert(o.foo === "bar");
     assert(o["foo"] === "bar");
+    assert(o.hello === "friends");
+    assert(o["hello"] === "friends");
     o.baz = "test";
     assert(o.baz === "test");
     assert(o["baz"] === "test");
@@ -11,6 +15,12 @@ try {
     o[-1] = "hello friends";
     assert(o[-1] === "hello friends");
     assert(o["-1"] === "hello friends");
+
+    var math = { 3.14: "pi" };
+    assert(math["3.14"] === "pi");
+    // Note : this test doesn't pass yet due to floating-point literals being coerced to i32 on access
+    // assert(math[3.14] === "pi");
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);


### PR DESCRIPTION
This adds parsing for objects matching the patterns :
`o = { 1: "test", 3.14: "pi", "foo": "bar" }`

Also updated the object-basic.js test to include this change !