### PR TITLE
AK: Allow %m.nf specifier for double/float in printf to set fraction witdh

### DIFF
--- a/Libraries/LibGUI/Variant.cpp
+++ b/Libraries/LibGUI/Variant.cpp
@@ -398,7 +398,7 @@ String Variant::to_string() const
     case Type::UnsignedInt:
         return String::number(as_uint());
     case Type::Float:
-        return String::format("%f", (double)as_float());
+        return String::format("%.2f", (double)as_float());
     case Type::String:
         return as_string();
     case Type::Bitmap:


### PR DESCRIPTION
This patch adds the missing part for the printf of double values to specify
the length of the fraction part. For GVariant, a default of %.2 is used.

Fixes #1674