### PR TITLE
Toolchain: Make BuildQemu.sh choose the correct ui library

### DIFF
--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -52,11 +52,20 @@ if [ -z "$MAKEJOBS" ]; then
     MAKEJOBS=$(nproc)
 fi
 
+if [[ $(uname) == "Darwin" ]]
+then
+    UI_LIB=cocoa
+else
+    UI_LIB=gtk
+fi
+
+echo Using $UI_LIB based UI
+
 pushd "$DIR/Build/"
     pushd qemu
         "$DIR"/Tarballs/$QEMU_VERSION/configure --prefix="$PREFIX" \
                                                 --target-list=i386-softmmu \
-                                                --enable-gtk || exit 1
+                                                --enable-$UI_LIB || exit 1
         make -j "$MAKEJOBS" || exit 1
         make install || exit 1
     popd


### PR DESCRIPTION
BuildQemu.sh fails on OS X as the Qemu configure script complains bitterly in this case, so we just make it explicitly opt into the cocoa ui when building on Darwin.