### PR TITLE
LibJS: Add Boolean constructor & fix conversion of NaN to bool

### DIFF
--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -28,6 +28,7 @@
 #include <LibJS/AST.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/ArrayPrototype.h>
+#include <LibJS/Runtime/BooleanPrototype.h>
 #include <LibJS/Runtime/DatePrototype.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/ErrorPrototype.h>
@@ -55,6 +56,7 @@ Interpreter::Interpreter()
     m_error_prototype = heap().allocate<ErrorPrototype>();
     m_date_prototype = heap().allocate<DatePrototype>();
     m_number_prototype = heap().allocate<NumberPrototype>();
+    m_boolean_prototype = heap().allocate<BooleanPrototype>();
 }
 
 Interpreter::~Interpreter()
@@ -180,6 +182,7 @@ void Interpreter::gather_roots(Badge<Heap>, HashTable<Cell*>& roots)
     roots.set(m_date_prototype);
     roots.set(m_function_prototype);
     roots.set(m_number_prototype);
+    roots.set(m_boolean_prototype);
 
     roots.set(m_exception);
 

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -143,6 +143,7 @@ public:
     Object* date_prototype() { return m_date_prototype; }
     Object* function_prototype() { return m_function_prototype; }
     Object* number_prototype() { return m_number_prototype; }
+    Object* boolean_prototype() { return m_boolean_prototype; }
 
     Exception* exception() { return m_exception; }
     void clear_exception() { m_exception = nullptr; }
@@ -181,6 +182,7 @@ private:
     Object* m_date_prototype { nullptr };
     Object* m_function_prototype { nullptr };
     Object* m_number_prototype { nullptr };
+    Object* m_boolean_prototype { nullptr };
 
     Exception* m_exception { nullptr };
 

--- a/Libraries/LibJS/Makefile
+++ b/Libraries/LibJS/Makefile
@@ -9,6 +9,9 @@ OBJS = \
     Runtime/Array.o \
     Runtime/ArrayConstructor.o \
     Runtime/ArrayPrototype.o \
+    Runtime/BooleanConstructor.o \
+    Runtime/BooleanObject.o \
+    Runtime/BooleanPrototype.o \
     Runtime/Cell.o \
     Runtime/ConsoleObject.o \
     Runtime/Date.o \

--- a/Libraries/LibJS/Runtime/BooleanConstructor.cpp
+++ b/Libraries/LibJS/Runtime/BooleanConstructor.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, Jack Karamanian <karamanian.jack@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibJS/Heap/Heap.h>
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/BooleanConstructor.h>
+#include <LibJS/Runtime/BooleanObject.h>
+#include <LibJS/Runtime/BooleanPrototype.h>
+
+namespace JS {
+BooleanConstructor::BooleanConstructor()
+{
+    put("prototype", Value(interpreter().boolean_prototype()));
+    put("length", Value(1));
+}
+
+BooleanConstructor::~BooleanConstructor() {}
+
+Value BooleanConstructor::call(Interpreter& interpreter)
+{
+    return Value(interpreter.argument(0).to_boolean());
+}
+
+Value BooleanConstructor::construct(Interpreter& interpreter)
+{
+    auto bool_object = interpreter.heap().allocate<BooleanObject>(interpreter.argument(0).to_boolean());
+    return Value(bool_object);
+}
+}

--- a/Libraries/LibJS/Runtime/BooleanConstructor.h
+++ b/Libraries/LibJS/Runtime/BooleanConstructor.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Jack Karamanian <karamanian.jack@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace JS {
+class BooleanConstructor final : public NativeFunction {
+public:
+    BooleanConstructor();
+    virtual ~BooleanConstructor() override;
+
+    virtual Value call(Interpreter&) override;
+    virtual Value construct(Interpreter&) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+    virtual const char* class_name() const override { return "BooleanConstructor"; }
+};
+}

--- a/Libraries/LibJS/Runtime/BooleanObject.cpp
+++ b/Libraries/LibJS/Runtime/BooleanObject.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, Jack Karamanian <karamanian.jack@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/BooleanObject.h>
+
+namespace JS {
+BooleanObject::BooleanObject(bool value)
+    : m_value(value)
+{
+    set_prototype(interpreter().boolean_prototype());
+}
+
+BooleanObject::~BooleanObject()
+{
+}
+}

--- a/Libraries/LibJS/Runtime/BooleanObject.h
+++ b/Libraries/LibJS/Runtime/BooleanObject.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, Jack Karamanian <karamanian.jack@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Object.h>
+
+namespace JS {
+class BooleanObject : public Object {
+public:
+    explicit BooleanObject(bool);
+    virtual ~BooleanObject() override;
+
+    virtual Value value_of() const override
+    {
+        return Value(m_value);
+    }
+
+private:
+    virtual const char* class_name() const override { return "BooleanObject"; }
+    virtual bool is_boolean() const override { return true; }
+    bool m_value { false };
+};
+}

--- a/Libraries/LibJS/Runtime/BooleanPrototype.cpp
+++ b/Libraries/LibJS/Runtime/BooleanPrototype.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, Jack Karamanian <karamanian.jack@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Function.h>
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/BooleanPrototype.h>
+#include <LibJS/Runtime/Error.h>
+
+namespace JS {
+BooleanPrototype::BooleanPrototype()
+    : BooleanObject(false)
+{
+    put_native_function("toString", to_string);
+    put_native_function("valueOf", value_of);
+}
+
+BooleanPrototype::~BooleanPrototype() {}
+
+Value BooleanPrototype::to_string(Interpreter& interpreter)
+{
+    auto this_object = interpreter.this_value();
+    if (this_object.is_boolean()) {
+        return js_string(interpreter.heap(), this_object.as_bool() ? "true" : "false");
+    }
+    if (!this_object.is_object() || !this_object.as_object().is_boolean()) {
+        interpreter.throw_exception<Error>("TypeError", "Not a Boolean");
+        return {};
+    }
+
+    bool bool_value = static_cast<BooleanObject&>(this_object.as_object()).value_of().as_bool();
+    return js_string(interpreter.heap(), bool_value ? "true" : "false");
+}
+
+Value BooleanPrototype::value_of(Interpreter& interpreter)
+{
+    auto this_object = interpreter.this_value();
+    if (this_object.is_boolean()) {
+        return this_object;
+    }
+    if (!this_object.is_object() || !this_object.as_object().is_boolean()) {
+        interpreter.throw_exception<Error>("TypeError", "Not a Boolean");
+        return {};
+    }
+
+    return static_cast<BooleanObject&>(this_object.as_object()).value_of();
+}
+}

--- a/Libraries/LibJS/Runtime/BooleanPrototype.h
+++ b/Libraries/LibJS/Runtime/BooleanPrototype.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Jack Karamanian <karamanian.jack@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/BooleanObject.h>
+
+namespace JS {
+class BooleanPrototype final : public BooleanObject {
+public:
+    BooleanPrototype();
+    virtual ~BooleanPrototype() override;
+
+private:
+    virtual const char* class_name() const override { return "BooleanPrototype"; }
+
+    static Value to_string(Interpreter&);
+    static Value value_of(Interpreter&);
+};
+}

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -29,6 +29,7 @@
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/ArrayConstructor.h>
+#include <LibJS/Runtime/BooleanConstructor.h>
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibJS/Runtime/DateConstructor.h>
 #include <LibJS/Runtime/ErrorConstructor.h>
@@ -58,6 +59,7 @@ GlobalObject::GlobalObject()
     put("Math", heap().allocate<MathObject>());
     put("Object", heap().allocate<ObjectConstructor>());
     put("Array", heap().allocate<ArrayConstructor>());
+    put("Boolean", heap().allocate<BooleanConstructor>());
 }
 
 GlobalObject::~GlobalObject()

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -59,6 +59,7 @@ public:
     void put_native_property(const FlyString& property_name, AK::Function<Value(Interpreter&)> getter, AK::Function<void(Interpreter&, Value)> setter);
 
     virtual bool is_array() const { return false; }
+    virtual bool is_boolean() const { return false; }
     virtual bool is_date() const { return false; }
     virtual bool is_error() const { return false; }
     virtual bool is_function() const { return false; }

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -83,6 +83,9 @@ bool Value::to_boolean() const
     case Type::Boolean:
         return m_value.as_bool;
     case Type::Number:
+        if (is_nan()) {
+            return false;
+        }
         return !(m_value.as_double == 0 || m_value.as_double == -0);
     case Type::Null:
     case Type::Undefined:

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -29,6 +29,7 @@
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/BooleanObject.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/NumberObject.h>
 #include <LibJS/Runtime/Object.h>
@@ -109,6 +110,9 @@ Object* Value::to_object(Heap& heap) const
 
     if (is_number())
         return heap.allocate<NumberObject>(m_value.as_double);
+
+    if (is_boolean())
+        return heap.allocate<BooleanObject>(m_value.as_bool);
 
     if (is_null() || is_undefined()) {
         heap.interpreter().throw_exception<Error>("TypeError", "ToObject on null or undefined.");

--- a/Libraries/LibJS/Tests/Boolean.js
+++ b/Libraries/LibJS/Tests/Boolean.js
@@ -1,0 +1,35 @@
+try {
+  assert(Boolean.length === 1);
+  assert(typeof new Boolean() === "object");
+  assert(new Boolean().valueOf() === false);
+
+  var foo = new Boolean(true);
+  var bar = new Boolean(true);
+
+  assert(foo !== bar);
+  assert(foo.valueOf() === bar.valueOf());
+
+  assert(new Boolean(true).toString() === "true");
+  assert(new Boolean(false).toString() === "false");
+
+  assert(typeof Boolean() === "boolean");
+  assert(typeof Boolean(true) === "boolean");
+
+  assert(Boolean() === false);
+  assert(Boolean(false) === false);
+  assert(Boolean(null) === false);
+  assert(Boolean(undefined) === false);
+  assert(Boolean(NaN) === false);
+  assert(Boolean("") === false);
+  assert(Boolean(0.0) === false);
+  assert(Boolean(-0.0) === false);
+  assert(Boolean(true) === true);
+  assert(Boolean("0") === true);
+  assert(Boolean({}) === true);
+  assert(Boolean([]) === true);
+  assert(Boolean(1)) === true;
+
+  console.log("PASS");
+} catch (err) {
+  console.log("FAIL: " + err);
+}

--- a/Libraries/LibJS/Tests/Boolean.prototype.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.js
@@ -1,0 +1,8 @@
+try {
+  assert(typeof Boolean.prototype === "object");
+  assert(Boolean.prototype.valueOf() === false);
+
+  console.log("PASS");
+} catch (err) {
+  console.log("FAIL: " + err);
+}

--- a/Libraries/LibJS/Tests/Boolean.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.toString.js
@@ -1,0 +1,23 @@
+try {
+  var foo = true;
+  assert(foo.toString() === "true");
+  assert(true.toString() === "true");
+
+  assert(Boolean.prototype.toString.call(true) === "true");
+  assert(Boolean.prototype.toString.call(false) === "false");
+
+  let error = null;
+  try {
+    Boolean.prototype.toString.call("foo");
+  } catch (err) {
+    error = err;
+  }
+
+  assert(error instanceof Error);
+  assert(error.name === "TypeError");
+  assert(error.message === "Not a Boolean");
+
+  console.log("PASS");
+} catch (err) {
+  console.log("FAIL: " + err);
+}

--- a/Libraries/LibJS/Tests/Boolean.prototype.valueOf.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.valueOf.js
@@ -1,0 +1,23 @@
+try {
+  var foo = true;
+  assert(foo.valueOf() === true);
+  assert(true.valueOf() === true);
+
+  assert(Boolean.prototype.valueOf.call(true) === true);
+  assert(Boolean.prototype.valueOf.call(false) === false);
+
+  let error = null;
+  try {
+    Boolean.prototype.valueOf.call("foo");
+  } catch (err) {
+    error = err;
+  }
+
+  assert(error instanceof Error);
+  assert(error.name === "TypeError");
+  assert(error.message === "Not a Boolean");
+
+  console.log("PASS");
+} catch (err) {
+  console.log("FAIL: " + err);
+}

--- a/Libraries/LibJS/Tests/NaN-basic.js
+++ b/Libraries/LibJS/Tests/NaN-basic.js
@@ -10,6 +10,9 @@ try {
     assert(isNaN(undefined) === true);
     assert(isNaN(null) === false);
     assert(isNaN(Infinity) === false);
+    assert(!!NaN === false);
+    assert(!!nan === false);
+  
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);


### PR DESCRIPTION
This PR:
- Adds the [`Boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) constructor
- Fixes the conversion of NaN to bool (should be false)