### PR TITLE
LibJS: Break loop on EOF when parsing object expression

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -388,7 +388,7 @@ NonnullRefPtr<ObjectExpression> Parser::parse_object_expression()
     HashMap<FlyString, NonnullRefPtr<Expression>> properties;
     consume(TokenType::CurlyOpen);
 
-    while (!match(TokenType::CurlyClose)) {
+    while (!done() && !match(TokenType::CurlyClose)) {
         FlyString property_name;
         if (match(TokenType::Identifier)) {
             property_name = consume(TokenType::Identifier).value();


### PR DESCRIPTION
JS "code" to reproduce: `!{`

Found and reported by pmr on IRC.