### PR TITLE
WindowServer: Menu::popup() should return when the menu is empty

### DIFF
--- a/Servers/WindowServer/Menu.cpp
+++ b/Servers/WindowServer/Menu.cpp
@@ -519,7 +519,10 @@ void Menu::redraw_if_theme_changed()
 
 void Menu::popup(const Gfx::Point& position, bool is_submenu)
 {
-    ASSERT(!is_empty());
+    if (is_empty()) {
+        dbg() << "Menu: Empty menu popup";
+        return;
+    }
 
     auto& window = ensure_menu_window();
     redraw_if_theme_changed();


### PR DESCRIPTION
Previously the WindowServer would assert `!is_empty()` and crash.

Fixes #1689