### PR TITLE
IRCClient: Add application and context menu items to hop/dehop users

### DIFF
--- a/Applications/IRCClient/IRCAppWindow.cpp
+++ b/Applications/IRCClient/IRCAppWindow.cpp
@@ -196,6 +196,26 @@ void IRCAppWindow::setup_actions()
             m_client->handle_devoice_user_action(window->channel().name(), input_box->text_value());
     });
 
+    m_hop_user_action = GUI::Action::create("Hop user", [this](auto&) {
+        auto* window = m_client->current_window();
+        if (!window || window->type() != IRCWindow::Type::Channel) {
+            return;
+        }
+        auto input_box = GUI::InputBox::construct("Enter nick:", "Hop user", this);
+        if (input_box->exec() == GUI::InputBox::ExecOK && !input_box->text_value().is_empty())
+            m_client->handle_hop_user_action(window->channel().name(), input_box->text_value());
+    });
+
+    m_dehop_user_action = GUI::Action::create("DeHop user", [this](auto&) {
+        auto* window = m_client->current_window();
+        if (!window || window->type() != IRCWindow::Type::Channel) {
+            return;
+        }
+        auto input_box = GUI::InputBox::construct("Enter nick:", "DeHop user", this);
+        if (input_box->exec() == GUI::InputBox::ExecOK && !input_box->text_value().is_empty())
+            m_client->handle_dehop_user_action(window->channel().name(), input_box->text_value());
+    });
+
     m_op_user_action = GUI::Action::create("Op user", [this](auto&) {
         auto* window = m_client->current_window();
         if (!window || window->type() != IRCWindow::Type::Channel) {
@@ -264,6 +284,8 @@ void IRCAppWindow::setup_menus()
     channel_menu.add_separator();
     channel_menu.add_action(*m_voice_user_action);
     channel_menu.add_action(*m_devoice_user_action);
+    channel_menu.add_action(*m_hop_user_action);
+    channel_menu.add_action(*m_dehop_user_action);
     channel_menu.add_action(*m_op_user_action);
     channel_menu.add_action(*m_deop_user_action);
     channel_menu.add_separator();
@@ -341,6 +363,8 @@ void IRCAppWindow::update_gui_actions()
     m_banlist_action->set_enabled(is_open_channel);
     m_voice_user_action->set_enabled(is_open_channel);
     m_devoice_user_action->set_enabled(is_open_channel);
+    m_hop_user_action->set_enabled(is_open_channel);
+    m_dehop_user_action->set_enabled(is_open_channel);
     m_op_user_action->set_enabled(is_open_channel);
     m_deop_user_action->set_enabled(is_open_channel);
     m_kick_user_action->set_enabled(is_open_channel);

--- a/Applications/IRCClient/IRCAppWindow.h
+++ b/Applications/IRCClient/IRCAppWindow.h
@@ -67,6 +67,8 @@ private:
     RefPtr<GUI::Action> m_banlist_action;
     RefPtr<GUI::Action> m_voice_user_action;
     RefPtr<GUI::Action> m_devoice_user_action;
+    RefPtr<GUI::Action> m_hop_user_action;
+    RefPtr<GUI::Action> m_dehop_user_action;
     RefPtr<GUI::Action> m_op_user_action;
     RefPtr<GUI::Action> m_deop_user_action;
     RefPtr<GUI::Action> m_kick_user_action;

--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -367,6 +367,16 @@ void IRCClient::send_devoice_user(const String& channel_name, const String& nick
     send(String::format("MODE %s -v %s\r\n", channel_name.characters(), nick.characters()));
 }
 
+void IRCClient::send_hop_user(const String& channel_name, const String& nick)
+{
+    send(String::format("MODE %s +h %s\r\n", channel_name.characters(), nick.characters()));
+}
+
+void IRCClient::send_dehop_user(const String& channel_name, const String& nick)
+{
+    send(String::format("MODE %s -h %s\r\n", channel_name.characters(), nick.characters()));
+}
+
 void IRCClient::send_op_user(const String& channel_name, const String& nick)
 {
     send(String::format("MODE %s +o %s\r\n", channel_name.characters(), nick.characters()));
@@ -850,7 +860,7 @@ void IRCClient::handle_user_command(const String& input)
         }
         return;
     }
-    if (command == "/HOP") {
+    if (command == "/CYCLE") {
         if (parts.size() >= 2) {
             auto channel = parts[1];
             part_channel(channel);
@@ -999,6 +1009,16 @@ void IRCClient::handle_voice_user_action(const String& channel, const String& ni
 void IRCClient::handle_devoice_user_action(const String& channel, const String& nick)
 {
     send_devoice_user(channel, nick);
+}
+
+void IRCClient::handle_hop_user_action(const String& channel, const String& nick)
+{
+    send_hop_user(channel, nick);
+}
+
+void IRCClient::handle_dehop_user_action(const String& channel, const String& nick)
+{
+    send_dehop_user(channel, nick);
 }
 
 void IRCClient::handle_op_user_action(const String& channel, const String& nick)

--- a/Applications/IRCClient/IRCClient.h
+++ b/Applications/IRCClient/IRCClient.h
@@ -117,6 +117,8 @@ public:
     void handle_banlist_action(const String& channel_name);
     void handle_voice_user_action(const String& channel_name, const String& nick);
     void handle_devoice_user_action(const String& channel_name, const String& nick);
+    void handle_hop_user_action(const String& channel_name, const String& nick);
+    void handle_dehop_user_action(const String& channel_name, const String& nick);
     void handle_op_user_action(const String& channel_name, const String& nick);
     void handle_deop_user_action(const String& channel_name, const String& nick);
     void handle_kick_user_action(const String& channel_name, const String& nick, const String&);
@@ -153,6 +155,8 @@ private:
     void send_banlist(const String& channel_name);
     void send_voice_user(const String& channel_name, const String& nick);
     void send_devoice_user(const String& channel_name, const String& nick);
+    void send_hop_user(const String& channel_name, const String& nick);
+    void send_dehop_user(const String& channel_name, const String& nick);
     void send_op_user(const String& channel_name, const String& nick);
     void send_deop_user(const String& channel_name, const String& nick);
     void send_kick(const String& channel_name, const String& nick, const String&);

--- a/Applications/IRCClient/IRCWindow.cpp
+++ b/Applications/IRCClient/IRCWindow.cpp
@@ -111,6 +111,26 @@ IRCWindow::IRCWindow(IRCClient& client, void* owner, Type type, const String& na
                 m_client.handle_devoice_user_action(m_name.characters(), nick.characters());
             }));
 
+            m_context_menu->add_action(GUI::Action::create("Hop", [&](const GUI::Action&) {
+                GUI::ModelIndex new_index = member_view.selection().first();
+                auto nick = member_view.model()->data(new_index, IRCChannelMemberListModel::Role::Display).to_string();
+                if (nick.is_empty())
+                    return;
+                if (IRCClient::is_nick_prefix(nick[0]))
+                    nick = nick.substring(1, nick.length() - 1);
+                m_client.handle_hop_user_action(m_name.characters(), nick.characters());
+            }));
+
+            m_context_menu->add_action(GUI::Action::create("DeHop", [&](const GUI::Action&) {
+                GUI::ModelIndex new_index = member_view.selection().first();
+                auto nick = member_view.model()->data(new_index, IRCChannelMemberListModel::Role::Display).to_string();
+                if (nick.is_empty())
+                    return;
+                if (IRCClient::is_nick_prefix(nick[0]))
+                    nick = nick.substring(1, nick.length() - 1);
+                m_client.handle_dehop_user_action(m_name.characters(), nick.characters());
+            }));
+
             m_context_menu->add_action(GUI::Action::create("Op", [&](const GUI::Action&) {
                 GUI::ModelIndex new_index = member_view.selection().first();
                 auto nick = member_view.model()->data(new_index, IRCChannelMemberListModel::Role::Display).to_string();


### PR DESCRIPTION
Add application and context menu items to hop (+h) / dehop (-h) users.

Also renames `/HOP` command to `/CYCLE`. While some clients use HOP to join/part a channel, this is kind of confusing, and the general convention is to use `CYCLE`.
