### PR TITLE
IRCClient: Rename /hop command to /cycle

### DIFF
--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -850,7 +850,7 @@ void IRCClient::handle_user_command(const String& input)
         }
         return;
     }
-    if (command == "/HOP") {
+    if (command == "/CYCLE") {
         if (parts.size() >= 2) {
             auto channel = parts[1];
             part_channel(channel);


### PR DESCRIPTION
Some IRC clients use /hop to part and re-join a channel; however this
can be confused with granting half-op (+h) channel privileges to a user.

The general convention used by other IRC clients is /cycle.