### PR TITLE
LibJS: rename JS::DeclarationType => JS::DeclarationKind

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -202,7 +202,7 @@ Value ForStatement::execute(Interpreter& interpreter) const
 {
     RefPtr<BlockStatement> wrapper;
 
-    if (m_init && m_init->is_variable_declaration() && static_cast<const VariableDeclaration*>(m_init.ptr())->declaration_type() != DeclarationType::Var) {
+    if (m_init && m_init->is_variable_declaration() && static_cast<const VariableDeclaration*>(m_init.ptr())->declaration_kind() != DeclarationKind::Var) {
         wrapper = create_ast_node<BlockStatement>();
         interpreter.enter_scope(*wrapper, {}, ScopeType::Block);
     }
@@ -799,7 +799,7 @@ void UpdateExpression::dump(int indent) const
 Value VariableDeclaration::execute(Interpreter& interpreter) const
 {
     for (auto& declarator : m_declarations) {
-        interpreter.declare_variable(declarator.id().string(), m_declaration_type);
+        interpreter.declare_variable(declarator.id().string(), m_declaration_kind);
         if (auto* init = declarator.init()) {
             auto initalizer_result = init->execute(interpreter);
             if (interpreter.exception())
@@ -818,22 +818,22 @@ Value VariableDeclarator::execute(Interpreter&) const
 
 void VariableDeclaration::dump(int indent) const
 {
-    const char* declaration_type_string = nullptr;
-    switch (m_declaration_type) {
-    case DeclarationType::Let:
-        declaration_type_string = "Let";
+    const char* declaration_kind_string = nullptr;
+    switch (m_declaration_kind) {
+    case DeclarationKind::Let:
+        declaration_kind_string = "Let";
         break;
-    case DeclarationType::Var:
-        declaration_type_string = "Var";
+    case DeclarationKind::Var:
+        declaration_kind_string = "Var";
         break;
-    case DeclarationType::Const:
-        declaration_type_string = "Const";
+    case DeclarationKind::Const:
+        declaration_kind_string = "Const";
         break;
     }
 
     ASTNode::dump(indent);
     print_indent(indent + 1);
-    printf("%s\n", declaration_type_string);
+    printf("%s\n", declaration_kind_string);
 
     for (auto& declarator : m_declarations)
         declarator.dump(indent + 1);

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -591,7 +591,7 @@ private:
     bool m_prefixed;
 };
 
-enum class DeclarationType {
+enum class DeclarationKind {
     Var,
     Let,
     Const,
@@ -620,14 +620,14 @@ private:
 
 class VariableDeclaration : public Declaration {
 public:
-    VariableDeclaration(DeclarationType declaration_type, NonnullRefPtrVector<VariableDeclarator> declarations)
-        : m_declaration_type(declaration_type)
+    VariableDeclaration(DeclarationKind declaration_kind, NonnullRefPtrVector<VariableDeclarator> declarations)
+        : m_declaration_kind(declaration_kind)
         , m_declarations(move(declarations))
     {
     }
 
     virtual bool is_variable_declaration() const override { return true; }
-    DeclarationType declaration_type() const { return m_declaration_type; }
+    DeclarationKind declaration_kind() const { return m_declaration_kind; }
 
     virtual Value execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
@@ -635,7 +635,7 @@ public:
 private:
     virtual const char* class_name() const override { return "VariableDeclaration"; }
 
-    DeclarationType m_declaration_type;
+    DeclarationKind m_declaration_kind;
     NonnullRefPtrVector<VariableDeclarator> m_declarations;
 };
 

--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -52,7 +52,7 @@ class ScopeNode;
 class Shape;
 class Statement;
 class Value;
-enum class DeclarationType;
+enum class DeclarationKind;
 
 struct Argument;
 

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -48,7 +48,7 @@ enum class ScopeType {
 
 struct Variable {
     Value value;
-    DeclarationType declaration_type;
+    DeclarationKind declaration_kind;
 };
 
 struct ScopeFrame {
@@ -95,7 +95,7 @@ public:
 
     Optional<Value> get_variable(const FlyString& name);
     void set_variable(const FlyString& name, Value, bool first_assignment = false);
-    void declare_variable(const FlyString& name, DeclarationType);
+    void declare_variable(const FlyString& name, DeclarationKind);
 
     void gather_roots(Badge<Heap>, HashTable<Cell*>&);
 

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -658,19 +658,19 @@ NonnullRefPtr<FunctionNodeType> Parser::parse_function_node()
 
 NonnullRefPtr<VariableDeclaration> Parser::parse_variable_declaration()
 {
-    DeclarationType declaration_type;
+    DeclarationKind declaration_kind;
 
     switch (m_parser_state.m_current_token.type()) {
     case TokenType::Var:
-        declaration_type = DeclarationType::Var;
+        declaration_kind = DeclarationKind::Var;
         consume(TokenType::Var);
         break;
     case TokenType::Let:
-        declaration_type = DeclarationType::Let;
+        declaration_kind = DeclarationKind::Let;
         consume(TokenType::Let);
         break;
     case TokenType::Const:
-        declaration_type = DeclarationType::Const;
+        declaration_kind = DeclarationKind::Const;
         consume(TokenType::Const);
         break;
     default:
@@ -692,7 +692,7 @@ NonnullRefPtr<VariableDeclaration> Parser::parse_variable_declaration()
         }
         break;
     }
-    return create_ast_node<VariableDeclaration>(declaration_type, move(declarations));
+    return create_ast_node<VariableDeclaration>(declaration_kind, move(declarations));
 }
 
 NonnullRefPtr<ThrowStatement> Parser::parse_throw_statement()


### PR DESCRIPTION
Many other parsers call it with this name.

Also Type can be confusing in this context since the DeclarationType is
not the type (number, string, etc.) of the variables that are being
declared by the VariableDeclaration.