### PR TITLE
IRCClient: Remove FIXME for RPL_TOPICWHOTIME

### DIFF
--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -632,7 +632,6 @@ void IRCClient::handle_rpl_topic(const Message& msg)
     auto& channel_name = msg.arguments[1];
     auto& topic = msg.arguments[2];
     ensure_channel(channel_name).handle_topic({}, topic);
-    // FIXME: Handle RPL_TOPICWHOTIME so we can know who set it and when.
 }
 
 void IRCClient::handle_rpl_namreply(const Message& msg)


### PR DESCRIPTION
`RPL_TOPICWHOTIME` is handled by `handle_rpl_topicwhotime`.

![RPL_TOPICWHOTIME](https://user-images.githubusercontent.com/434827/78782108-d1590d00-79e4-11ea-8a9c-4344a389cbcd.png)

