### PR TITLE
AK: appending 0 bytes to a ByteBuffer should be a no-op

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -211,6 +211,9 @@ public:
 
     void append(const void* data, size_t data_size)
     {
+        if (data_size == 0)
+            return;
+        ASSERT(data != nullptr);
         int old_size = size();
         grow(size() + data_size);
         __builtin_memcpy(this->data() + old_size, data, data_size);


### PR DESCRIPTION
- inserting an empty string into LibLine Editor triggered an assertion
  trying to grow a ByteBuffer by 0 bytes.