### PR TITLE
LibJS: Implement variable declaration hoisting

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -632,6 +632,8 @@ public:
     virtual Value execute(Interpreter&) const override;
     virtual void dump(int indent) const override;
 
+    const NonnullRefPtrVector<VariableDeclarator>& declarations() const { return m_declarations; }
+
 private:
     virtual const char* class_name() const override { return "VariableDeclaration"; }
 

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -94,6 +94,20 @@ void Interpreter::enter_scope(const ScopeNode& scope_node, ArgumentVector argume
     for (auto& argument : arguments) {
         scope_variables_with_declaration_kind.set(argument.name, { argument.value, DeclarationKind::Var });
     }
+    auto children = scope_node.children();
+    for (auto& child : children) {
+        if (child.is_variable_declaration()) {
+            auto& vd = static_cast<const VariableDeclaration&>(child);
+            if (vd.declaration_kind() == DeclarationKind::Var) {
+                auto decls = vd.declarations();
+                for (auto& decl : decls) {
+                    scope_variables_with_declaration_kind.set(decl.id().string(),
+                        { js_undefined(), DeclarationKind::Var });
+                }
+            }
+        }
+    }
+
     m_scope_stack.append({ scope_type, scope_node, move(scope_variables_with_declaration_kind) });
 }
 


### PR DESCRIPTION
A naive attempt at implementing var declaration hoisting.
Iterates over the children of `ScopeNode`s when entered to look
for var declarations and declares them in the same manner as args.