### PR TITLE
LibJS: Handle empty values in Value::to_string()

### DIFF
--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -161,6 +161,11 @@ static void print_error(const JS::Object& object, HashTable<JS::Object*>&)
 
 void print_value(JS::Value value, HashTable<JS::Object*>& seen_objects)
 {
+    if (value.is_empty()) {
+        printf("\033[34;1m<empty>\033[0m");
+        return;
+    }
+        
     if (value.is_object()) {
         if (seen_objects.contains(&value.as_object())) {
             // FIXME: Maybe we should only do this for circular references,


### PR DESCRIPTION
The REPL calls `Value::to_string()` on ~~everything that's~~ most things that are being `print()`ed, and that fails with `ASSERT_NOT_REACHED()` for anything that contains an empty value.

Before:

```
$ ./js
> a = Array(5)
js: serenity/Libraries/LibJS/Runtime/Value.cpp:78: AK::String JS::Value::to_string() const: Assertion `false' failed.
Aborted (core dumped)
$
```

After:

```
$ ./js
> new Array(5)
[ <empty>, <empty>, <empty>, <empty>, <empty> ]
> 
```

![image](https://user-images.githubusercontent.com/19366641/78810363-2c2c3d80-79c0-11ea-83e5-1fad8bdd29f0.png)

![image](https://user-images.githubusercontent.com/19366641/78810633-80372200-79c0-11ea-91aa-aeb4636b7ced.png)
