### PR TITLE
LibJS: Add globalThis

### DIFF
--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -61,6 +61,7 @@ GlobalObject::GlobalObject()
     put("Infinity", js_infinity());
     put("undefined", js_undefined());
 
+    put("globalThis", this);
     put("console", heap().allocate<ConsoleObject>());
     put("Math", heap().allocate<MathObject>());
 

--- a/Libraries/LibJS/Tests/function-this-in-arguments.js
+++ b/Libraries/LibJS/Tests/function-this-in-arguments.js
@@ -1,6 +1,6 @@
 try {
   assert(typeof this === "object");
-  assert(this === global);
+  assert(this === globalThis);
 
   function Foo() {
     this.x = 5;

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -384,7 +384,6 @@ int main(int argc, char** argv)
     if (script_path == nullptr) {
         auto interpreter = JS::Interpreter::create<ReplObject>();
         interpreter->heap().set_should_collect_on_every_allocation(gc_on_every_allocation);
-        interpreter->global_object().put("global", &interpreter->global_object());
         if (test_mode) {
             interpreter->global_object().put_native_function("assert", assert_impl);
         }
@@ -515,7 +514,6 @@ int main(int argc, char** argv)
     } else {
         auto interpreter = JS::Interpreter::create<JS::GlobalObject>();
         interpreter->heap().set_should_collect_on_every_allocation(gc_on_every_allocation);
-        interpreter->global_object().put("global", &interpreter->global_object());
         if (test_mode) {
             interpreter->global_object().put_native_function("assert", assert_impl);
         }


### PR DESCRIPTION
We already have "`global`" as a (non-standard) way to access the global object in `js(1)` (both REPL and script mode). This replaces it with "`globalThis`", which is available in all environments, not just `js`.

`globalThis` is relatively new, but supported by all modern browsers/engines.

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
- https://tc39.es/ecma262/#sec-globalthis