### PR TITLE
IRCClient: Set nick and userinfo to OS username when not set in config

### DIFF
--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -39,6 +39,7 @@
 #include <netinet/in.h>
 #include <stdio.h>
 #include <sys/socket.h>
+#include <pwd.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -71,13 +72,14 @@ IRCClient::IRCClient()
     , m_log(IRCLogBuffer::create())
     , m_config(Core::ConfigFile::get_for_app("IRCClient"))
 {
+    struct passwd* user_pw = getpwuid(getuid());
     m_socket = Core::TCPSocket::construct(this);
-    m_nickname = m_config->read_entry("User", "Nickname", "seren1ty");
+    m_nickname = m_config->read_entry("User", "Nickname", String::format("%s_seren1ty", user_pw->pw_name));
     m_hostname = m_config->read_entry("Connection", "Server", "");
     m_port = m_config->read_num_entry("Connection", "Port", 6667);
     m_ctcp_version_reply = m_config->read_entry("CTCP", "VersionReply", "IRC Client [x86] / Serenity OS");
-    m_ctcp_userinfo_reply = m_config->read_entry("CTCP", "UserInfoReply", "anon");
-    m_ctcp_finger_reply = m_config->read_entry("CTCP", "FingerReply", "anon");
+    m_ctcp_userinfo_reply = m_config->read_entry("CTCP", "UserInfoReply", user_pw->pw_name);
+    m_ctcp_finger_reply = m_config->read_entry("CTCP", "FingerReply", user_pw->pw_name);
 }
 
 IRCClient::~IRCClient()


### PR DESCRIPTION
As a multi-user OS, it makes sense to use the OS username for default configuration options when there's no existing configuration file (or the configuration file is incomplete).

This also allows for auto-populating a new config file with reasonable default values when a new user runs the IRCClient for the first time and does not have an existing config file.

Serenity currently builds with a `IRCClient.ini` configuration file for the `anon` user which contains default options.

An alternative approach may be to set the `nick` to the OS username, then let the other fields such as `userinfo` and `finger` CTCP replies, default to whatever is set as the `nick`.
