### PR TITLE
IRCClient: Autojoin channels after client registration

### DIFF
--- a/Applications/IRCClient/IRCClient.h
+++ b/Applications/IRCClient/IRCClient.h
@@ -169,6 +169,7 @@ private:
     void handle_quit(const Message&);
     void handle_ping(const Message&);
     void handle_topic(const Message&);
+    void handle_rpl_welcome(const Message&);
     void handle_rpl_topic(const Message&);
     void handle_rpl_whoisuser(const Message&);
     void handle_rpl_whoisserver(const Message&);


### PR DESCRIPTION
Wait for the server to advise negotiation was successful (RPL_WELCOME)
before autojoining channels.

Fixes #1713

![RPL_WELCOME](https://user-images.githubusercontent.com/434827/78916581-08a4e800-7ad1-11ea-9fa4-f5043c9fe7ae.png)
