### PR TITLE
LibJS: Throw exception if LHS of assignment is of unexpected type

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -711,7 +711,7 @@ Value AssignmentExpression::execute(Interpreter& interpreter) const
             object->put(property_name, rhs_result);
         }
     } else {
-        ASSERT_NOT_REACHED();
+        return interpreter.throw_exception<Error>("ReferenceError", "Invalid left-hand side in assignment");
     }
 
     return rhs_result;

--- a/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
+++ b/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
@@ -1,0 +1,26 @@
+try {
+    try {
+        Math.abs(-20) = 40;
+    } catch (e) {
+        assert(e.name === "ReferenceError");
+        assert(e.message === "Invalid left-hand side in assignment");
+    }
+
+    try {
+        512 = 256;
+    } catch (e) {
+        assert(e.name === "ReferenceError");
+        assert(e.message === "Invalid left-hand side in assignment");
+    }
+
+    try {
+        "hello world" = "another thing?";
+    } catch (e) {
+        assert(e.name === "ReferenceError");
+        assert(e.message === "Invalid left-hand side in assignment");
+    }
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
If the left hand side of an assignment is not a valid type then throw an error instead of just crashing.
Throwing a ReferenceError is consistent with the behavior of other browsers (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_assignment_left-hand_side)