### PR TITLE
LibGUI: Add ColorInput component and small fixes at DisplayProperties

### DIFF
--- a/Applications/DisplayProperties/DisplayProperties.h
+++ b/Applications/DisplayProperties/DisplayProperties.h
@@ -27,19 +27,13 @@
 #pragma once
 
 #include "MonitorWidget.h"
+#include <LibGUI/ColorInput.h>
 #include <LibGUI/ComboBox.h>
-#include <LibGUI/TextBox.h>
 
 class DisplayPropertiesWidget : public GUI::Widget {
     C_OBJECT(MonitorWidget);
 
 public:
-    enum class ButtonOperations {
-        Ok,
-        Apply,
-        Cancel,
-    };
-
     DisplayPropertiesWidget();
 
     GUI::Widget* root_widget() { return m_root_widget; }
@@ -60,5 +54,5 @@ private:
     RefPtr<GUI::ComboBox> m_wallpaper_combo;
     RefPtr<GUI::ComboBox> m_mode_combo;
     RefPtr<GUI::ComboBox> m_resolution_combo;
-    RefPtr<GUI::TextBox> m_color_textbox;
+    RefPtr<GUI::ColorInput> m_color_input;
 };

--- a/Libraries/LibGUI/ColorInput.cpp
+++ b/Libraries/LibGUI/ColorInput.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2020, Hüseyin Aslıtürk <asliturk@hotmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibCore/Timer.h>
+#include <LibGUI/ColorPicker.h>
+#include <LibGUI/Painter.h>
+#include <LibGUI/ColorInput.h>
+#include <LibGfx/Palette.h>
+
+namespace GUI {
+
+ColorInput::ColorInput()
+    : TextEditor(TextEditor::SingleLine)
+{
+    set_readonly(true);
+
+    m_auto_repeat_timer = add<Core::Timer>();
+    m_auto_repeat_timer->on_timeout = [this] {
+        click();
+    };
+}
+
+ColorInput::~ColorInput()
+{
+}
+
+void ColorInput::set_color(Color color)
+{
+    m_color = color;
+    set_text(color.to_string());
+
+    update();
+
+    if (on_change)
+        on_change();
+};
+
+void ColorInput::mousedown_event(MouseEvent& event)
+{
+    if (event.button() == MouseButton::Left) {
+        if (is_enabled()) {
+            m_being_pressed = true;
+            update();
+
+            if (m_auto_repeat_interval) {
+                click();
+                m_auto_repeat_timer->start(m_auto_repeat_interval);
+            }
+        }
+    }
+
+    Widget::mousedown_event(event);
+}
+
+void ColorInput::mouseup_event(MouseEvent& event)
+{
+    if (event.button() == MouseButton::Left) {
+        bool was_auto_repeating = m_auto_repeat_timer->is_active();
+        m_auto_repeat_timer->stop();
+        if (is_enabled()) {
+            bool was_being_pressed = m_being_pressed;
+            m_being_pressed = false;
+            update();
+            if (was_being_pressed && !was_auto_repeating)
+                click();
+        }
+    }
+    Widget::mouseup_event(event);
+}
+
+void ColorInput::enter_event(Core::Event&)
+{
+    ASSERT(window());
+    window()->set_override_cursor(StandardCursor::Arrow);
+}
+
+void ColorInput::paint_event(PaintEvent& event)
+{
+    // Set cursor color to base color and stop timer. FIXME: Find better way to hide cursor.
+    auto pal = palette();
+    pal.set_color(ColorRole::TextCursor, palette().base());
+    set_palette(pal);
+    stop_timer();
+
+    TextEditor::paint_event(event);
+
+    auto color_box_padding = 3;
+    auto color_box_size = event.rect().height() - color_box_padding - color_box_padding;
+
+    Painter painter(*this);
+    painter.fill_rect({ event.rect().width() - color_box_size - color_box_padding , color_box_padding, color_box_size, color_box_size}, m_color);
+}
+
+void ColorInput::click()
+{
+    if (!is_enabled())
+        return;
+
+    auto dialog = GUI::ColorPicker::construct(m_color, window(), m_color_picker_title);
+    if (dialog->exec() == GUI::Dialog::ExecOK) {
+        auto tmp = dialog->color();
+        set_color(tmp);
+    }
+}
+
+}

--- a/Libraries/LibGUI/ColorInput.h
+++ b/Libraries/LibGUI/ColorInput.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, Hüseyin Aslıtürk <asliturk@hotmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <LibGUI/TextEditor.h>
+
+namespace GUI {
+
+class ColorInput : public TextEditor {
+    C_OBJECT(ColorInput)
+
+public:
+    ColorInput();
+    virtual ~ColorInput() override;
+
+    void set_color(Color color);
+    Color color() { return m_color; }
+
+    void set_color_picker_title(String title) { m_color_picker_title = title; }
+    String color_picker_title() { return m_color_picker_title; }
+
+    Function<void()> on_change;
+
+protected:
+    virtual void mousedown_event(MouseEvent&) override;
+    virtual void mouseup_event(MouseEvent&) override;
+    virtual void enter_event(Core::Event&) override;
+    virtual void paint_event(PaintEvent&) override;
+
+private:
+    virtual void click();
+
+    Color m_color;
+    String m_color_picker_title { "Select Color" };
+
+    int m_auto_repeat_interval { 0 };
+    bool m_being_pressed { false };
+    RefPtr<Core::Timer> m_auto_repeat_timer;
+};
+
+}

--- a/Libraries/LibGUI/Makefile
+++ b/Libraries/LibGUI/Makefile
@@ -10,6 +10,7 @@ OBJS = \
     Button.o \
     CheckBox.o \
     Clipboard.o \
+    ColorInput.o \
     ColorPicker.o \
     ColumnsView.o \
     ComboBox.o \


### PR DESCRIPTION
`ColorInput` simplify usage of `ColorPicker` dialog and more elegant view of current selected color in input field.

![ColorInput](https://user-images.githubusercontent.com/2991895/78979998-a3c7ad00-7b25-11ea-8d83-acfd9effb8e2.png)
