### PR TITLE
IRCClient: Add ShowNickChangeMessages/ShowJoinPartMessages conf options

### DIFF
--- a/Applications/IRCClient/IRCChannel.cpp
+++ b/Applications/IRCClient/IRCChannel.cpp
@@ -100,7 +100,8 @@ void IRCChannel::handle_join(const String& nick, const String& hostmask)
     }
     add_member(nick, (char)0);
     m_member_model->update();
-    add_message(String::format("*** %s [%s] has joined %s", nick.characters(), hostmask.characters(), m_name.characters()), Color::MidGreen);
+    if (m_client.show_join_part_messages())
+        add_message(String::format("*** %s [%s] has joined %s", nick.characters(), hostmask.characters(), m_name.characters()), Color::MidGreen);
 }
 
 void IRCChannel::handle_part(const String& nick, const String& hostmask)
@@ -113,7 +114,8 @@ void IRCChannel::handle_part(const String& nick, const String& hostmask)
         remove_member(nick);
     }
     m_member_model->update();
-    add_message(String::format("*** %s [%s] has parted from %s", nick.characters(), hostmask.characters(), m_name.characters()), Color::MidGreen);
+    if (m_client.show_join_part_messages())
+        add_message(String::format("*** %s [%s] has parted from %s", nick.characters(), hostmask.characters(), m_name.characters()), Color::MidGreen);
 }
 
 void IRCChannel::handle_quit(const String& nick, const String& hostmask, const String& message)
@@ -142,8 +144,9 @@ void IRCChannel::notify_nick_changed(const String& old_nick, const String& new_n
     for (auto& member : m_members) {
         if (member.name == old_nick) {
             member.name = new_nick;
-            add_message(String::format("~ %s changed nickname to %s", old_nick.characters(), new_nick.characters()), Color::MidMagenta);
             m_member_model->update();
+            if (m_client.show_nick_change_messages())
+                add_message(String::format("~ %s changed nickname to %s", old_nick.characters(), new_nick.characters()), Color::MidMagenta);
             return;
         }
     }

--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -78,6 +78,10 @@ IRCClient::IRCClient()
     m_nickname = m_config->read_entry("User", "Nickname", String::format("%s_seren1ty", user_pw->pw_name));
     m_hostname = m_config->read_entry("Connection", "Server", "");
     m_port = m_config->read_num_entry("Connection", "Port", 6667);
+
+    m_show_join_part_messages = m_config->read_bool_entry("Messaging", "ShowJoinPartMessages", 1);
+    m_show_nick_change_messages = m_config->read_bool_entry("Messaging", "ShowNickChangeMessages", 1);
+
     m_ctcp_version_reply = m_config->read_entry("CTCP", "VersionReply", "IRC Client [x86] / Serenity OS");
     m_ctcp_userinfo_reply = m_config->read_entry("CTCP", "UserInfoReply", user_pw->pw_name);
     m_ctcp_finger_reply = m_config->read_entry("CTCP", "FingerReply", user_pw->pw_name);
@@ -620,7 +624,8 @@ void IRCClient::handle_nick(const Message& msg)
     auto& new_nick = msg.arguments[0];
     if (old_nick == m_nickname)
         m_nickname = new_nick;
-    add_server_message(String::format("~ %s changed nickname to %s", old_nick.characters(), new_nick.characters()));
+    if (m_show_nick_change_messages)
+        add_server_message(String::format("~ %s changed nickname to %s", old_nick.characters(), new_nick.characters()));
     if (on_nickname_changed)
         on_nickname_changed(new_nick);
     for (auto& it : m_channels) {

--- a/Applications/IRCClient/IRCClient.h
+++ b/Applications/IRCClient/IRCClient.h
@@ -60,6 +60,9 @@ public:
     String ctcp_userinfo_reply() const { return m_ctcp_userinfo_reply; }
     String ctcp_finger_reply() const { return m_ctcp_finger_reply; }
 
+    bool show_join_part_messages() const { return m_show_join_part_messages; }
+    bool show_nick_change_messages() const { return m_show_nick_change_messages; }
+
     void join_channel(const String&);
     void part_channel(const String&);
     void change_nick(const String&);
@@ -207,6 +210,9 @@ private:
     RefPtr<Core::Notifier> m_notifier;
     HashMap<String, RefPtr<IRCChannel>, CaseInsensitiveStringTraits> m_channels;
     HashMap<String, RefPtr<IRCQuery>, CaseInsensitiveStringTraits> m_queries;
+
+    bool m_show_join_part_messages { 1 };
+    bool m_show_nick_change_messages { 1 };
 
     String m_ctcp_version_reply;
     String m_ctcp_userinfo_reply;

--- a/Base/home/anon/IRCClient.ini
+++ b/Base/home/anon/IRCClient.ini
@@ -10,3 +10,7 @@ AutoJoinChannels=#serenityos
 VersionReply=IRC Client [x86] / Serenity OS
 UserInfoReply=anon
 FingerReply=anon
+
+[Messaging]
+ShowJoinPartMessages=1
+ShowNickChangeMessages=1


### PR DESCRIPTION
Allow IRCClient to hide nick change spam and join/part spam.

`ConfigFile::read_bool_entry` uses `0` and `1` for Boolean values.

```cpp
bool ConfigFile::read_bool_entry(const String& group, const String& key, bool default_value) const
{
    return read_entry(group, key, default_value ? "1" : "0") == "1";
}
```

As such, the `IRCClient.ini` configuration file also uses `0` and `1`.