### PR TITLE
LibJS: Add String.prototype.toString()

### DIFF
--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -48,6 +48,7 @@ StringPrototype::StringPrototype()
     put_native_function("indexOf", index_of, 1);
     put_native_function("toLowerCase", to_lowercase, 0);
     put_native_function("toUpperCase", to_uppercase, 0);
+    put_native_function("toString", to_string, 0);
 }
 
 StringPrototype::~StringPrototype()
@@ -167,12 +168,18 @@ Value StringPrototype::to_uppercase(Interpreter& interpreter)
 
 Value StringPrototype::length_getter(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
-    if (!this_object)
+    auto* string_object = string_object_from(interpreter);
+    if (!string_object)
         return {};
-    if (!this_object->is_string_object())
-        return interpreter.throw_exception<TypeError>("Not a String object");
-    return Value((i32) static_cast<const StringObject*>(this_object)->primitive_string()->string().length());
+    return Value((i32) string_object->primitive_string()->string().length());
+}
+
+Value StringPrototype::to_string(Interpreter& interpreter)
+{
+    auto* string_object = string_object_from(interpreter);
+    if (!string_object)
+        return {};
+    return js_string(interpreter, string_object->primitive_string()->string());
 }
 
 }

--- a/Libraries/LibJS/Runtime/StringPrototype.h
+++ b/Libraries/LibJS/Runtime/StringPrototype.h
@@ -44,6 +44,7 @@ private:
     static Value index_of(Interpreter&);
     static Value to_lowercase(Interpreter&);
     static Value to_uppercase(Interpreter&);
+    static Value to_string(Interpreter&);
 
     static Value length_getter(Interpreter&);
 };

--- a/Libraries/LibJS/Tests/String.prototype.toString.js
+++ b/Libraries/LibJS/Tests/String.prototype.toString.js
@@ -1,0 +1,9 @@
+try {
+    assert(String.prototype.toString.length === 0)
+    assert("".toString() === "");
+    assert("hello friends".toString() === "hello friends");
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
🤨 Current behaviour:

```js
> "Hello friends!".toString()
"[object StringObject]"
```

😃 New behaviour:

```js
> "Hello friends!".toString()
"Hello friends!"
```

---

https://www.ecma-international.org/ecma-262/5.1/#sec-15.5.4.2