### PR TITLE
LibWeb: Prevent http:// URLs loading scripts sourced from file:// URLs

### DIFF
--- a/Libraries/LibWeb/DOM/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/DOM/HTMLScriptElement.cpp
@@ -71,8 +71,13 @@ void HTMLScriptElement::inserted_into(Node& new_parent)
     if (src.is_null())
         return;
 
-    String source;
     URL src_url = document().complete_url(src);
+    if (src_url.protocol() == "file" && document().url().protocol() != src_url.protocol()) {
+        dbg() << "HTMLScriptElement: Forbidden to load " << src_url.to_string() << " from " << document().url().to_string();
+        return;
+    }
+
+    String source;
     ResourceLoader::the().load_sync(src_url, [&](auto& data) {
         if (data.is_null()) {
             dbg() << "HTMLScriptElement: Failed to load " << src;


### PR DESCRIPTION
Prevent `<script>` element access to `file://` URLs from anywhere except other `file://` URLs.

Fixes #1616 

It is worth noting that a secondary risk exists for `file://` URLs which is *not addressed in this PR.*

In the event that a user downloads and opens a `.html` file in their browser, script content within the file will have to access any other `file://` URL, effectively allowing theft of arbitrary files from the file system by exfiltrating file contents to a remote server.

```
Browser(21): HtmlView::load: http://172.16.191.165/script.html
ProtocolServer(22): TCPSocket{0x028d020e} connection appears to have closed in receive().
Browser(21): HTMLScriptElement: Forbidden to load file:///home/anon/.history from http://172.16.191.165/script.html
Browser(21): Undo stack increased to 2
```
