### PR TITLE
MenuApplets: Rename CPUGraph to ResourceGraph and support multiple instances

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -48,7 +48,15 @@ User=anon
 KeepAlive=1
 User=anon
 
-[ResourceGraph.MenuApplet]
+[CPUGraph.MenuApplet]
+Executable=/bin/ResourceGraph.MenuApplet
+Arguments=--cpu --name=CPUGraph --color=limegreen
+KeepAlive=1
+User=anon
+
+[MemoryGraph.MenuApplet]
+Executable=/bin/ResourceGraph.MenuApplet
+Arguments=--memory --name=MemoryGraph --color=cyan
 KeepAlive=1
 User=anon
 

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -48,7 +48,7 @@ User=anon
 KeepAlive=1
 User=anon
 
-[CPUGraph.MenuApplet]
+[ResourceGraph.MenuApplet]
 KeepAlive=1
 User=anon
 

--- a/Base/etc/WindowServer/WindowServer.ini
+++ b/Base/etc/WindowServer/WindowServer.ini
@@ -24,4 +24,4 @@ DoubleClickSpeed=250
 Mode=scaled
 
 [Applet]
-Order=Clock,Audio,ResourceGraph,UserName
+Order=Clock,Audio,CPUGraph,MemoryGraph,UserName

--- a/Base/etc/WindowServer/WindowServer.ini
+++ b/Base/etc/WindowServer/WindowServer.ini
@@ -24,4 +24,4 @@ DoubleClickSpeed=250
 Mode=scaled
 
 [Applet]
-Order=Clock,Audio,CPUGraph,UserName
+Order=Clock,Audio,ResourceGraph,UserName

--- a/Kernel/build-root-filesystem.sh
+++ b/Kernel/build-root-filesystem.sh
@@ -166,7 +166,7 @@ cp ../Servers/NotificationServer/NotificationServer mnt/bin/NotificationServer
 cp ../Servers/WebServer/WebServer mnt/bin/WebServer
 cp ../Shell/Shell mnt/bin/Shell
 cp ../MenuApplets/Audio/Audio.MenuApplet mnt/bin/
-cp ../MenuApplets/CPUGraph/CPUGraph.MenuApplet mnt/bin/
+cp ../MenuApplets/ResourceGraph/ResourceGraph.MenuApplet mnt/bin/
 cp ../MenuApplets/Clock/Clock.MenuApplet mnt/bin/
 cp ../MenuApplets/UserName/UserName.MenuApplet mnt/bin
 echo "done"

--- a/MenuApplets/CPUGraph/.gitignore
+++ b/MenuApplets/CPUGraph/.gitignore
@@ -1,1 +1,0 @@
-CPUGraph.MenuApplet

--- a/MenuApplets/ResourceGraph/.gitignore
+++ b/MenuApplets/ResourceGraph/.gitignore
@@ -1,0 +1,1 @@
+ResourceGraph.MenuApplet

--- a/MenuApplets/ResourceGraph/Makefile
+++ b/MenuApplets/ResourceGraph/Makefile
@@ -1,6 +1,6 @@
 OBJS = main.o
 
-PROGRAM = CPUGraph.MenuApplet
+PROGRAM = ResourceGraph.MenuApplet
 
 LIB_DEPS = GUI IPC Gfx Thread Pthread Core
 

--- a/MenuApplets/ResourceGraph/main.cpp
+++ b/MenuApplets/ResourceGraph/main.cpp
@@ -124,7 +124,7 @@ int main(int argc, char** argv)
     }
 
     auto window = GUI::Window::construct();
-    window->set_title("CPUGraph");
+    window->set_title("ResourceGraph");
     window->set_window_type(GUI::WindowType::MenuApplet);
     window->resize(30, 16);
 


### PR DESCRIPTION
First, a screenshot:

![Screenshot from 2020-04-10 23-50-01](https://user-images.githubusercontent.com/19366641/79028528-39942400-7b88-11ea-9343-154b10fe186c.png)

TL;DR: CPUGraph is now ResourceGraph and supports multiple instances, a memory graph and custom colors. The next useful addition would probably be a network traffic graph, but something like one graph per CPU core is also a possibility.

I'm lazy so I'll just dump my commit messages here:

---

The plan is to extend what currently is known as "CPUGraph" and let the SystemServer spawn multiple instances of it - which then can show memory or network usages as well :^)

Simply renaming the applet is the first step.

---

The ResourceGraph menu applet now supports a few command line options:

- `--cpu` / `-C` to display a CPU usage graph
- `--memory` / `-M` to display a memory usage graph
- `--name` / `-n` to set a name which is used to order applets
- `--color` / `-c` to set the graph color (supports anything `Gfx::Color::from_string()` understands)

The `SystemServer.ini` and `WindowServer.ini` config files have been updated to spawn and show two ResourceGraph menu applets, one for CPU usage (green) and one for memory usage (cyan) - this matches the colors in the SystemMonitor graphs.
