### PR TITLE
Kernel: $SERENITY_KERNEL_CUSTOM_{CXXFLAGS/LDFLAGS} for build customization.

### DIFF
--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -139,11 +139,11 @@ KERNEL = 1
 PROGRAM = kernel
 
 SUBPROJECT_CXXFLAGS += -pie -fPIE -ffreestanding -fbuiltin -mno-80387 -mno-mmx -mno-sse -mno-sse2 -fno-asynchronous-unwind-tables
-SUBPROJECT_CXXFLAGS += -nostdlib -nostdinc -nostdinc++
+SUBPROJECT_CXXFLAGS += -nostdlib -nostdinc -nostdinc++ $(SERENITY_KERNEL_CUSTOM_CXXFLAGS)
 SUBPROJECT_CXXFLAGS += -I../Toolchain/Local/i686-pc-serenity/include/c++/9.3.0/
 SUBPROJECT_CXXFLAGS += -I../Toolchain/Local/i686-pc-serenity/include/c++/9.3.0/i686-pc-serenity/
 
-LDFLAGS += -Wl,-T linker.ld -nostdlib -lgcc -lstdc++
+LDFLAGS += -Wl,-T linker.ld -nostdlib -lgcc -lstdc++ $(SERENITY_KERNEL_CUSTOM_LDFLAGS)
 
 all: $(PROGRAM) $(MODULE_OBJS) kernel.map
 


### PR DESCRIPTION
I normally want to build with debug symbols for the kernel so I can use
a debugger. Add a hook to allow me to do so, but to impact no-one else.