### PR TITLE
LibWeb: Add port blacklist for ResourceLoader::load

### DIFF
--- a/Libraries/LibWeb/ResourceLoader.cpp
+++ b/Libraries/LibWeb/ResourceLoader.cpp
@@ -67,6 +67,11 @@ void ResourceLoader::load_sync(const URL& url, Function<void(const ByteBuffer&)>
 
 void ResourceLoader::load(const URL& url, Function<void(const ByteBuffer&)> success_callback, Function<void(const String&)> error_callback)
 {
+    if (is_port_blocked(url.port())) {
+	dbg() << "ResourceLoader::load: Error: blocked port " << url.port() << " for URL: " << url;
+	return;
+    }
+
     if (url.protocol() == "file") {
         auto f = Core::File::construct();
         f->set_filename(url.path());
@@ -110,6 +115,18 @@ void ResourceLoader::load(const URL& url, Function<void(const ByteBuffer&)> succ
 
     if (error_callback)
         error_callback(String::format("Protocol not implemented: %s", url.protocol().characters()));
+}
+
+bool ResourceLoader::is_port_blocked(int port) {
+    int ports[] { 1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42,
+        43, 53, 77, 79, 87, 95, 101, 102, 103, 104, 109, 110, 111, 113,
+        115, 117, 119, 123, 135, 139, 143, 179, 389, 465, 512, 513, 514,
+        515, 526, 530, 531, 532, 540, 556, 563, 587, 601, 636, 993, 995,
+        2049, 3659, 4045, 6000, 6379, 6665, 6666, 6667, 6668, 6669, 9000 };
+    for (auto blocked_port : ports)
+        if (port == blocked_port)
+            return true;
+    return false;
 }
 
 }

--- a/Libraries/LibWeb/ResourceLoader.h
+++ b/Libraries/LibWeb/ResourceLoader.h
@@ -55,6 +55,7 @@ private:
 
     Protocol::Client& protocol_client() { return *m_protocol_client; }
     RefPtr<Protocol::Client> m_protocol_client;
+    bool is_port_blocked(int port);
 };
 
 }


### PR DESCRIPTION
`ResourceLoader::load` now rejects URLs which specify a `port`
associated with network services known to be vulnerable to
inter-protocol exploitation.

Fixes #1735

```
Browser(21): HtmlView::load: http://172.16.191.165/root.html
ProtocolServer(22): TCPSocket{0x00ed0406} connection appears to have closed in receive().
Browser(21): ResourceLoader::load: Error: blocked port 23 for URL: http://127.0.0.1:23/;paddingAA;/bin/rm -r /home/anon/; echo
```

Note that this won't prevent inter-protocol exploitation against services which are not running on their default assigned port.

This PR does not address the secondary issue related to URL encoding. URL paths and query strings should be automatically URL encoded before loading. This is a separate bug, which potentially affects all resource loading, and is outside the scope of this PR. 
