### PR TITLE
LibJS: Make Function and CallFrame aware of their function name / Add console.trace()

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -48,14 +48,14 @@ Value ScopeNode::execute(Interpreter& interpreter) const
 
 Value FunctionDeclaration::execute(Interpreter& interpreter) const
 {
-    auto* function = interpreter.heap().allocate<ScriptFunction>(body(), parameters());
+    auto* function = interpreter.heap().allocate<ScriptFunction>(name(), body(), parameters());
     interpreter.set_variable(name(), function);
     return js_undefined();
 }
 
 Value FunctionExpression::execute(Interpreter& interpreter) const
 {
-    return interpreter.heap().allocate<ScriptFunction>(body(), parameters());
+    return interpreter.heap().allocate<ScriptFunction>(name(), body(), parameters());
 }
 
 Value ExpressionStatement::execute(Interpreter& interpreter) const
@@ -117,6 +117,7 @@ Value CallExpression::execute(Interpreter& interpreter) const
     }
 
     auto& call_frame = interpreter.push_call_frame();
+    call_frame.function_name = function.name();
     call_frame.arguments = move(arguments);
 
     Object* new_object = nullptr;

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -163,8 +163,8 @@ class FunctionDeclaration final
 public:
     static bool must_have_name() { return true; }
 
-    FunctionDeclaration(String name, NonnullRefPtr<Statement> body, Vector<FlyString> parameters = {})
-        : FunctionNode(move(name), move(body), move(parameters))
+    FunctionDeclaration(const FlyString& name, NonnullRefPtr<Statement> body, Vector<FlyString> parameters = {})
+        : FunctionNode(name, move(body), move(parameters))
     {
     }
 

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -205,6 +205,7 @@ void Interpreter::gather_roots(Badge<Heap>, HashTable<Cell*>& roots)
 Value Interpreter::call(Function* function, Value this_value, const Vector<Value>& arguments)
 {
     auto& call_frame = push_call_frame();
+    call_frame.function_name = function->name();
     call_frame.this_value = this_value;
     call_frame.arguments = arguments;
     auto result = function->call(*this);

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -112,6 +112,7 @@ public:
     }
     void pop_call_frame() { m_call_stack.take_last(); }
     const CallFrame& call_frame() { return m_call_stack.last(); }
+    const Vector<CallFrame> call_stack() { return m_call_stack; }
 
     size_t argument_count() const
     {

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -58,6 +58,7 @@ struct ScopeFrame {
 };
 
 struct CallFrame {
+    FlyString function_name;
     Value this_value;
     Vector<Value> arguments;
 };
@@ -106,7 +107,7 @@ public:
 
     CallFrame& push_call_frame()
     {
-        m_call_stack.append({ js_undefined(), {} });
+        m_call_stack.append({ {}, js_undefined(), {} });
         return m_call_stack.last();
     }
     void pop_call_frame() { m_call_stack.take_last(); }

--- a/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -35,6 +35,7 @@ namespace JS {
 ConsoleObject::ConsoleObject()
 {
     put_native_function("log", log);
+    put_native_function("trace", trace);
 }
 
 ConsoleObject::~ConsoleObject()
@@ -49,6 +50,20 @@ Value ConsoleObject::log(Interpreter& interpreter)
             putchar(' ');
     }
     putchar('\n');
+    return js_undefined();
+}
+
+Value ConsoleObject::trace(Interpreter& interpreter)
+{
+    log(interpreter);
+    auto call_stack = interpreter.call_stack();
+    // -2 to skip the console.trace() call frame
+    for (ssize_t i = call_stack.size() - 2; i >= 0; --i) {
+        auto function_name = call_stack[i].function_name;
+        if (String(function_name).is_empty())
+            function_name = "<anonymous>";
+        printf("%s\n", function_name.characters());
+    }
     return js_undefined();
 }
 

--- a/Libraries/LibJS/Runtime/ConsoleObject.h
+++ b/Libraries/LibJS/Runtime/ConsoleObject.h
@@ -39,6 +39,7 @@ private:
     virtual const char* class_name() const override { return "ConsoleObject"; }
 
     static Value log(Interpreter&);
+    static Value trace(Interpreter&);
 };
 
 }

--- a/Libraries/LibJS/Runtime/Function.h
+++ b/Libraries/LibJS/Runtime/Function.h
@@ -37,6 +37,7 @@ public:
 
     virtual Value call(Interpreter&) = 0;
     virtual Value construct(Interpreter&) = 0;
+    virtual const FlyString& name() const = 0;
 
 protected:
     Function();

--- a/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -105,18 +105,24 @@ Value FunctionPrototype::to_string(Interpreter& interpreter)
         return {};
     if (!this_object->is_function())
         return interpreter.throw_exception<TypeError>("Not a Function object");
-    // FIXME: Functions should be able to know their name, if any
+
+    String function_name = static_cast<Function*>(this_object)->name();
+    String function_parameters = "";
+    String function_body;
+
     if (this_object->is_native_function()) {
-        auto function_source = String::format("function () {\n  [%s]\n}", this_object->class_name());
-        return js_string(interpreter, function_source);
+        function_body = String::format("  [%s]", this_object->class_name());
+    } else {
+        auto& parameters = static_cast<ScriptFunction*>(this_object)->parameters();
+        StringBuilder parameters_builder;
+        parameters_builder.join(", ", parameters);
+        function_parameters = parameters_builder.build();
+        // FIXME: ASTNodes should be able to dump themselves to source strings - something like this:
+        // auto& body = static_cast<ScriptFunction*>(this_object)->body();
+        // function_body = body.to_source();
+        function_body = "  ???";
     }
-    auto parameters = static_cast<ScriptFunction*>(this_object)->parameters();
-    StringBuilder parameters_builder;
-    parameters_builder.join(", ", parameters);
-    // FIXME: ASTNodes should be able to dump themselves to source strings - something like this:
-    // auto& body = static_cast<ScriptFunction*>(this_object)->body();
-    // auto body_source = body.to_source();
-    auto function_source = String::format("function (%s) {\n  %s\n}", parameters_builder.build().characters(), "???");
+    auto function_source = String::format("function %s(%s) {\n%s\n}", function_name.characters(), function_parameters.characters(), function_body.characters());
     return js_string(interpreter, function_source);
 }
 

--- a/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -30,8 +30,9 @@
 
 namespace JS {
 
-NativeFunction::NativeFunction(AK::Function<Value(Interpreter&)> native_function)
-    : m_native_function(move(native_function))
+NativeFunction::NativeFunction(const FlyString& name, AK::Function<Value(Interpreter&)> native_function)
+    : m_name(name)
+    , m_native_function(move(native_function))
 {
 }
 

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -33,12 +33,13 @@ namespace JS {
 
 class NativeFunction : public Function {
 public:
-    explicit NativeFunction(AK::Function<Value(Interpreter&)>);
+    explicit NativeFunction(const FlyString& name, AK::Function<Value(Interpreter&)>);
     virtual ~NativeFunction() override;
 
     virtual Value call(Interpreter&) override;
     virtual Value construct(Interpreter&) override;
 
+    virtual const FlyString& name() const override { return m_name; };
     virtual bool has_constructor() const { return false; }
 
 protected:
@@ -48,6 +49,7 @@ private:
     virtual bool is_native_function() const override { return true; }
     virtual const char* class_name() const override { return "NativeFunction"; }
 
+    FlyString m_name;
     AK::Function<Value(Interpreter&)> m_native_function;
 };
 

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -235,7 +235,7 @@ void Object::put(PropertyName property_name, Value value)
 
 void Object::put_native_function(const FlyString& property_name, AK::Function<Value(Interpreter&)> native_function, i32 length)
 {
-    auto* function = heap().allocate<NativeFunction>(move(native_function));
+    auto* function = heap().allocate<NativeFunction>(property_name, move(native_function));
     function->put("length", Value(length));
     put(property_name, function);
 }

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -33,8 +33,9 @@
 
 namespace JS {
 
-ScriptFunction::ScriptFunction(const Statement& body, Vector<FlyString> parameters)
-    : m_body(body)
+ScriptFunction::ScriptFunction(const FlyString& name, const Statement& body, Vector<FlyString> parameters)
+    : m_name(name)
+    , m_body(body)
     , m_parameters(move(parameters))
 {
     put("prototype", heap().allocate<Object>());

--- a/Libraries/LibJS/Runtime/ScriptFunction.h
+++ b/Libraries/LibJS/Runtime/ScriptFunction.h
@@ -32,7 +32,7 @@ namespace JS {
 
 class ScriptFunction final : public Function {
 public:
-    ScriptFunction(const Statement& body, Vector<FlyString> parameters = {});
+    ScriptFunction(const FlyString& name, const Statement& body, Vector<FlyString> parameters = {});
     virtual ~ScriptFunction();
 
     const Statement& body() const { return m_body; }
@@ -41,6 +41,8 @@ public:
     virtual Value call(Interpreter&) override;
     virtual Value construct(Interpreter&) override;
 
+    virtual const FlyString& name() const override { return m_name; };
+
 private:
     virtual bool is_script_function() const final { return true; }
     virtual const char* class_name() const override { return "ScriptFunction"; }
@@ -48,6 +50,7 @@ private:
     static Value length_getter(Interpreter&);
     static void length_setter(Interpreter&, Value);
 
+    FlyString m_name;
     NonnullRefPtr<Statement> m_body;
     const Vector<FlyString> m_parameters;
 };


### PR DESCRIPTION
The first commit prepares `Function` (and thus `ScriptFunction` and `NativeFunction`), as well as `CallFrame` to store their own name / name of the currently executed function.

This also improves `Function.prototype.toString()` which now includes the function name for both `ScriptFunction`s and `NativeFunction`s:

![image](https://user-images.githubusercontent.com/19366641/79043076-c674c700-7bf4-11ea-9a2c-8fdce2a04ef1.png)

The second commit adds `console.trace()` (https://developer.mozilla.org/en-US/docs/Web/API/Console/trace):

![image](https://user-images.githubusercontent.com/19366641/79043154-6fbbbd00-7bf5-11ea-9b9e-33af7326c6f1.png)
