### PR TITLE
LibELF: Return false instead of assert on unrecognized program header

### DIFF
--- a/Libraries/LibELF/ELFImage.cpp
+++ b/Libraries/LibELF/ELFImage.cpp
@@ -407,9 +407,8 @@ bool ELFImage::validate_program_headers(const Elf32_Ehdr& elf_header, size_t fil
             break;
         default:
             // Not handling other program header types in other code so... let's not surprise them
-            dbgprintf("Found program header (%d) of unrecognized type %d!\n", header_index, program_header.p_type);
-            ASSERT_NOT_REACHED();
-            break;
+            dbgprintf("Found program header (%d) of unrecognized type %x!\n", header_index, program_header.p_type);
+            return false;
         }
     }
     return true;


### PR DESCRIPTION
No reason to assert here when the only callers (currently Process::find_elf_interpreter_for_executable) check the return value. Also, change the output to hex, since that will make it easier to google and figure out which program header the compiler generated that we don't know how to handle.

Fixes #1519