### PR TITLE
LibJS: Add console.{debug,info,warn,error}()

### DIFF
--- a/Base/home/anon/js/console.js
+++ b/Base/home/anon/js/console.js
@@ -1,0 +1,5 @@
+console.log("I am a generic log message");
+console.debug("I am a debug log message");
+console.info("I am an info log message");
+console.warn("I am a warning log message");
+console.error("I am an error log message");

--- a/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,9 +33,23 @@
 
 namespace JS {
 
+static void print_args(Interpreter& interpreter)
+{
+    for (size_t i = 0; i < interpreter.argument_count(); ++i) {
+        printf("%s", interpreter.argument(i).to_string().characters());
+        if (i != interpreter.argument_count() - 1)
+            putchar(' ');
+    }
+    putchar('\n');
+}
+
 ConsoleObject::ConsoleObject()
 {
     put_native_function("log", log);
+    put_native_function("debug", debug);
+    put_native_function("info", info);
+    put_native_function("warn", warn);
+    put_native_function("error", error);
     put_native_function("trace", trace);
 }
 
@@ -44,18 +59,43 @@ ConsoleObject::~ConsoleObject()
 
 Value ConsoleObject::log(Interpreter& interpreter)
 {
-    for (size_t i = 0; i < interpreter.argument_count(); ++i) {
-        printf("%s", interpreter.argument(i).to_string().characters());
-        if (i != interpreter.argument_count() - 1)
-            putchar(' ');
-    }
-    putchar('\n');
+    print_args(interpreter);
+    return js_undefined();
+}
+
+Value ConsoleObject::debug(Interpreter& interpreter)
+{
+    printf("\033[36;1m");
+    print_args(interpreter);
+    printf("\033[0m");
+    return js_undefined();
+}
+
+Value ConsoleObject::info(Interpreter& interpreter)
+{
+    print_args(interpreter);
+    return js_undefined();
+}
+
+Value ConsoleObject::warn(Interpreter& interpreter)
+{
+    printf("\033[33;1m");
+    print_args(interpreter);
+    printf("\033[0m");
+    return js_undefined();
+}
+
+Value ConsoleObject::error(Interpreter& interpreter)
+{
+    printf("\033[31;1m");
+    print_args(interpreter);
+    printf("\033[0m");
     return js_undefined();
 }
 
 Value ConsoleObject::trace(Interpreter& interpreter)
 {
-    log(interpreter);
+    print_args(interpreter);
     auto call_stack = interpreter.call_stack();
     // -2 to skip the console.trace() call frame
     for (ssize_t i = call_stack.size() - 2; i >= 0; --i) {

--- a/Libraries/LibJS/Runtime/ConsoleObject.h
+++ b/Libraries/LibJS/Runtime/ConsoleObject.h
@@ -39,6 +39,10 @@ private:
     virtual const char* class_name() const override { return "ConsoleObject"; }
 
     static Value log(Interpreter&);
+    static Value debug(Interpreter&);
+    static Value info(Interpreter&);
+    static Value warn(Interpreter&);
+    static Value error(Interpreter&);
     static Value trace(Interpreter&);
 };
 


### PR DESCRIPTION
Moved argument stringification & printing logic into a separate function. `info`'s functionality is equal to `log` for now, but I added a bit of color to `debug`, `warn` & `error` :^)

![image](https://user-images.githubusercontent.com/19366641/79073876-de297980-7ce0-11ea-9bb7-a9d6b92c3a1e.png)
