### PR TITLE
LibLine+Shell: Slash mess-up fix, hidden file completion

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -118,14 +118,6 @@ void Editor::stylize(const Span& span, const Style& style)
     m_spans_ending.set(span.end(), ending_map);
 }
 
-void Editor::cut_mismatching_chars(String& completion, const String& other, size_t start_compare)
-{
-    size_t i = start_compare;
-    while (i < completion.length() && i < other.length() && completion[i] == other[i])
-        ++i;
-    completion = completion.substring(0, i);
-}
-
 String Editor::get_line(const String& prompt)
 {
     set_prompt(prompt);

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -382,7 +382,15 @@ String Editor::get_line(const String& prompt)
                     }
                     reposition_cursor();
                 }
-
+                if (m_suggestions.size() < 2) {
+                    // we have none, or just one suggestion
+                    // we should just commit that and continue
+                    // after it, as if it were auto-completed
+                    suggest(0, 0);
+                    m_last_shown_suggestion = String::empty();
+                    m_suggestions.clear();
+                    m_times_tab_pressed = 0;
+                }
                 continue;
             }
 

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -105,7 +105,6 @@ public:
     void clear_line();
     void insert(const String&);
     void insert(const char);
-    void cut_mismatching_chars(String& completion, const String& other, size_t start_compare);
     void stylize(const Span&, const Style&);
     void strip_styles()
     {

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -1067,10 +1067,6 @@ int main(int argc, char** argv)
             suggestions[0] = String::format("%s ", suggestions[0].characters());
         }
 
-        dbg() << "found " << suggestions.size() << " elements";
-        for (auto& el : suggestions)
-            dbg() << ">>> '" << el << "'";
-
         editor.suggest(token.length(), 0);
 
         return suggestions;

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -1100,9 +1100,15 @@ int main(int argc, char** argv)
         //      `/foo/', but rather just `bar...'
         editor.suggest(token.length(), 0);
 
-        Core::DirIterator files(path, Core::DirIterator::SkipDots);
+        // only suggest dot-files if path starts with a dot
+        Core::DirIterator files(path,
+            token.starts_with('.') ? Core::DirIterator::NoFlags : Core::DirIterator::SkipDots);
+
         while (files.has_next()) {
             auto file = files.next_path();
+            // manually skip `.' and `..'
+            if (file == "." || file == "..")
+                continue;
             if (file.starts_with(token)) {
                 suggestions.append(file);
             }


### PR DESCRIPTION
fixes #1762.

Also de-soupifies the code soup @awesomekling had created in the path suggestions of Shell

Edit: also fixes #1535
```sh
touch .test
ls .<tab> #-> ls .test
```