### PR TITLE
 LibWeb: Use specific error classes when throwing exceptions

### DIFF
--- a/Libraries/LibWeb/Bindings/DocumentWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/DocumentWrapper.cpp
@@ -64,7 +64,7 @@ static Document* document_from(JS::Interpreter& interpreter)
     if (!this_object)
         return {};
     if (StringView("DocumentWrapper") != this_object->class_name()) {
-        interpreter.throw_exception<JS::Error>("TypeError", "That's not a DocumentWrapper, bro.");
+        interpreter.throw_exception<JS::TypeError>("That's not a DocumentWrapper, bro.");
         return {};
     }
     return &static_cast<DocumentWrapper*>(this_object)->node();

--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -78,7 +78,7 @@ static Window* impl_from(JS::Interpreter& interpreter)
         return nullptr;
     }
     if (StringView("WindowObject") != this_object->class_name()) {
-        interpreter.throw_exception<JS::Error>("TypeError", "That's not a WindowObject, bro.");
+        interpreter.throw_exception<JS::TypeError>("That's not a WindowObject, bro.");
         return nullptr;
     }
     return &static_cast<WindowObject*>(this_object)->impl();
@@ -108,7 +108,7 @@ JS::Value WindowObject::set_interval(JS::Interpreter& interpreter)
     if (!callback_object)
         return {};
     if (!callback_object->is_function())
-        return interpreter.throw_exception<JS::Error>("TypeError", "Not a function");
+        return interpreter.throw_exception<JS::TypeError>("Not a function");
     impl->set_interval(*static_cast<JS::Function*>(callback_object), arguments[1].to_i32());
     return JS::js_undefined();
 }
@@ -125,7 +125,7 @@ JS::Value WindowObject::set_timeout(JS::Interpreter& interpreter)
     if (!callback_object)
         return {};
     if (!callback_object->is_function())
-        return interpreter.throw_exception<JS::Error>("TypeError", "Not a function");
+        return interpreter.throw_exception<JS::TypeError>("Not a function");
 
     i32 interval = 0;
     if (interpreter.argument_count() >= 2)
@@ -147,7 +147,7 @@ JS::Value WindowObject::request_animation_frame(JS::Interpreter& interpreter)
     if (!callback_object)
         return {};
     if (!callback_object->is_function())
-        return interpreter.throw_exception<JS::Error>("TypeError", "Not a function");
+        return interpreter.throw_exception<JS::TypeError>("Not a function");
     return JS::Value(impl->request_animation_frame(*static_cast<JS::Function*>(callback_object)));
 }
 

--- a/Libraries/LibWeb/Bindings/XMLHttpRequestPrototype.cpp
+++ b/Libraries/LibWeb/Bindings/XMLHttpRequestPrototype.cpp
@@ -51,7 +51,7 @@ static XMLHttpRequest* impl_from(JS::Interpreter& interpreter)
     if (!this_object)
         return nullptr;
     if (StringView("XMLHttpRequestWrapper") != this_object->class_name()) {
-        interpreter.throw_exception<JS::Error>("TypeError", "This is not an XMLHttpRequest object");
+        interpreter.throw_exception<JS::TypeError>("This is not an XMLHttpRequest object");
         return nullptr;
     }
     return &static_cast<XMLHttpRequestWrapper*>(this_object)->impl();

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -360,16 +360,13 @@ void repl(JS::Interpreter& interpreter)
 JS::Value assert_impl(JS::Interpreter& interpreter)
 {
     if (!interpreter.argument_count())
-        return interpreter.throw_exception<JS::Error>("TypeError", "No arguments specified");
+        return interpreter.throw_exception<JS::TypeError>("No arguments specified");
 
-    auto assertion_value = interpreter.argument(0);
-    if (!assertion_value.is_boolean())
-        return interpreter.throw_exception<JS::Error>("TypeError", "The first argument is not a boolean");
-
-    if (!assertion_value.to_boolean())
+    auto assertion_value = interpreter.argument(0).to_boolean();
+    if (!assertion_value)
         return interpreter.throw_exception<JS::Error>("AssertionError", "The assertion failed!");
 
-    return assertion_value;
+    return JS::Value(assertion_value);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
I.e.

```
interpreter.throw_exception<JS::TypeError>("Message");
```

instead of

```
interpreter.throw_exception<JS::Error>("TypeError", "Message");
```

Some were missed in e5da1cc5660f6a284b9b21c7bcb1a547fac1cabe - probably as there's a `JS` namespace prefix :^)

Also sneaked in a small change to `js`'s `assert()` function where I changed the error classes as well. I don't see why we should be enforcing a boolean argument.
