### PR TITLE
FileManager: Update directories_model after retrieving the current path

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -138,8 +138,6 @@ int main(int argc, char** argv)
     };
 
     auto refresh_tree_view = [&] {
-        directories_model->update();
-
         auto current_path = directory_view.path();
 
         struct stat st;
@@ -151,6 +149,8 @@ int main(int argc, char** argv)
                 break;
             }
         }
+
+        directories_model->update();
 
         // Reselect the existing folder in the tree.
         auto new_index = directories_model->index(current_path, GUI::FileSystemModel::Column::Name);


### PR DESCRIPTION
This avoids the crash after every refresh_tree_view call (mkdir, paste,
delete folder). During the model update it clears selection, which
triggers an on_selection_change with "/", which causes the directory
view to open it. After that the directory view is used to determine
the current path, which is now incorrect, to reselect the current
folder in the tree view.

Fixes #1765