### PR TITLE
Ports: Update git to 2.26.0

### DIFF
--- a/Ports/git/package.sh
+++ b/Ports/git/package.sh
@@ -1,6 +1,6 @@
 #!/bin/bash ../.port_include.sh
 port=git
-version=2.25.1
+version=2.26.0
 useconfigure="true"
 files="https://mirrors.edge.kernel.org/pub/software/scm/git/git-${version}.tar.xz git-${version}.tar.xz"
 configopts="--target=i686-pc-serenity"


### PR DESCRIPTION
Needless to say, patches still apply cleanly and it builds :smile:

Release notes: https://github.com/git/git/blob/master/Documentation/RelNotes/2.26.0.txt