### PR TITLE
LibJS: Parse "this" as ThisExpression

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -662,6 +662,16 @@ void Identifier::dump(int indent) const
     printf("Identifier \"%s\"\n", m_string.characters());
 }
 
+Value ThisExpression::execute(Interpreter& interpreter) const
+{
+    return interpreter.this_value();
+}
+
+void ThisExpression::dump(int indent) const
+{
+    ASTNode::dump(indent);
+}
+
 Value AssignmentExpression::execute(Interpreter& interpreter) const
 {
     auto rhs_result = m_rhs->execute(interpreter);

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -502,6 +502,15 @@ private:
     FlyString m_string;
 };
 
+class ThisExpression final : public Expression {
+public:
+    virtual Value execute(Interpreter&) const override;
+    virtual void dump(int indent) const override;
+
+private:
+    virtual const char* class_name() const override { return "ThisExpression"; }
+};
+
 class CallExpression : public Expression {
 public:
     CallExpression(NonnullRefPtr<Expression> callee, NonnullRefPtrVector<Expression> arguments = {})

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -158,10 +158,6 @@ void Interpreter::set_variable(const FlyString& name, Value value, bool first_as
 
 Optional<Value> Interpreter::get_variable(const FlyString& name)
 {
-    static FlyString this_name = "this";
-    if (name == this_name)
-        return this_value();
-
     for (ssize_t i = m_scope_stack.size() - 1; i >= 0; --i) {
         auto& scope = m_scope_stack.at(i);
         auto value = scope.variables.get(name);

--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -66,6 +66,7 @@ Lexer::Lexer(StringView source)
         s_keywords.set("null", TokenType::NullLiteral);
         s_keywords.set("return", TokenType::Return);
         s_keywords.set("switch", TokenType::Switch);
+        s_keywords.set("this", TokenType::This);
         s_keywords.set("throw", TokenType::Throw);
         s_keywords.set("true", TokenType::BoolLiteral);
         s_keywords.set("try", TokenType::Try);

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -111,6 +111,7 @@ namespace JS {
     __ENUMERATE_JS_TOKEN(SlashEquals)                 \
     __ENUMERATE_JS_TOKEN(StringLiteral)               \
     __ENUMERATE_JS_TOKEN(Switch)                      \
+    __ENUMERATE_JS_TOKEN(This)                        \
     __ENUMERATE_JS_TOKEN(Throw)                       \
     __ENUMERATE_JS_TOKEN(Tilde)                       \
     __ENUMERATE_JS_TOKEN(Try)                         \


### PR DESCRIPTION
Saw in today's video that "this" was parsed as an identifier which Esprima doesn't seem to agree with.