### PR TITLE
LibJS: Tweak FunctionPrototype::to_string and constructors

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -34,6 +34,7 @@
 namespace JS {
 
 ArrayConstructor::ArrayConstructor()
+    : NativeFunction("Array")
 {
     put("prototype", interpreter().array_prototype());
     put("length", Value(1));

--- a/Libraries/LibJS/Runtime/BooleanConstructor.cpp
+++ b/Libraries/LibJS/Runtime/BooleanConstructor.cpp
@@ -33,6 +33,7 @@
 namespace JS {
 
 BooleanConstructor::BooleanConstructor()
+    : NativeFunction("Boolean")
 {
     put("prototype", Value(interpreter().boolean_prototype()));
     put("length", Value(1));

--- a/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -34,6 +34,7 @@
 namespace JS {
 
 DateConstructor::DateConstructor()
+    : NativeFunction("Date")
 {
     put("prototype", interpreter().date_prototype());
     put("length", Value(7));

--- a/Libraries/LibJS/Runtime/ErrorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ErrorConstructor.cpp
@@ -31,6 +31,7 @@
 namespace JS {
 
 ErrorConstructor::ErrorConstructor()
+    : NativeFunction("Error")
 {
     put("prototype", interpreter().error_prototype());
     put("length", Value(1));

--- a/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -35,6 +35,7 @@
 namespace JS {
 
 FunctionConstructor::FunctionConstructor()
+    : NativeFunction("Function")
 {
     put("prototype", interpreter().function_prototype());
     put("length", Value(1));

--- a/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -122,7 +122,11 @@ Value FunctionPrototype::to_string(Interpreter& interpreter)
         // function_body = body.to_source();
         function_body = "  ???";
     }
-    auto function_source = String::format("function %s(%s) {\n%s\n}", function_name.characters(), function_parameters.characters(), function_body.characters());
+
+    auto function_source = String::format("function %s(%s) {\n%s\n}",
+        function_name.is_null() ? "" : function_name.characters(),
+        function_parameters.characters(),
+        function_body.characters());
     return js_string(interpreter, function_source);
 }
 

--- a/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -36,6 +36,11 @@ NativeFunction::NativeFunction(const FlyString& name, AK::Function<Value(Interpr
 {
 }
 
+NativeFunction::NativeFunction(const FlyString& name)
+    : m_name(name)
+{
+}
+
 NativeFunction::~NativeFunction()
 {
 }

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -43,6 +43,7 @@ public:
     virtual bool has_constructor() const { return false; }
 
 protected:
+    NativeFunction(const FlyString& name);
     NativeFunction() {}
 
 private:

--- a/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -37,6 +37,7 @@
 namespace JS {
 
 NumberConstructor::NumberConstructor()
+    : NativeFunction("Number")
 {
     put_native_function("isSafeInteger", is_safe_integer, 1);
 

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -35,6 +35,7 @@
 namespace JS {
 
 ObjectConstructor::ObjectConstructor()
+    : NativeFunction("Object")
 {
     put("prototype", interpreter().object_prototype());
 

--- a/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -33,6 +33,7 @@
 namespace JS {
 
 StringConstructor::StringConstructor()
+    : NativeFunction("String")
 {
     put("prototype", interpreter().string_prototype());
     put("length", Value(1));

--- a/Libraries/LibJS/Tests/Function.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Function.prototype.toString.js
@@ -10,8 +10,8 @@ try {
         }
         return bar + 42;
     }).toString() === "function (foo, bar, baz) {\n  ???\n}");
-    assert(console.log.toString() === "function () {\n  [NativeFunction]\n}");
-    assert(Function.toString() === "function () {\n  [FunctionConstructor]\n}");
+    assert(console.log.toString() === "function log() {\n  [NativeFunction]\n}");
+    assert(Function.toString() === "function Function() {\n  [FunctionConstructor]\n}");
 
     console.log("PASS");
 } catch (e) {

--- a/Libraries/LibJS/Tests/function-TypeError.js
+++ b/Libraries/LibJS/Tests/function-TypeError.js
@@ -41,7 +41,7 @@ try {
         new isNaN();
     } catch(e) {
         assert(e.name === "TypeError");
-        assert(e.message === "function () {\n  [NativeFunction]\n} is not a constructor");
+        assert(e.message === "function isNaN() {\n  [NativeFunction]\n} is not a constructor");
     }
 
     console.log("PASS");


### PR DESCRIPTION
This fixes the libjs tests.

The output of FunctionPrototype::to_string is now more in line
with the output in Firefox. The builtin constructors have been
extended to include their function name in the output.