### PR TITLE
LibJS: Do not execute scripts with parse errors

### DIFF
--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -72,7 +72,7 @@ public:
     NonnullRefPtr<NewExpression> parse_new_expression();
     RefPtr<FunctionExpression> try_parse_arrow_function_expression(bool expect_parens);
 
-    bool has_errors() const { return m_parser_state.m_has_errors; }
+    bool has_errors() const { return m_parser_state.m_lexer.has_errors() || m_parser_state.m_has_errors; }
 
 private:
     int operator_precedence(TokenType) const;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -374,7 +374,11 @@ JS::Interpreter& Document::interpreter()
 
 JS::Value Document::run_javascript(const StringView& source)
 {
-    auto program = JS::Parser(JS::Lexer(source)).parse_program();
+    auto parser = JS::Parser(JS::Lexer(source));
+    auto program = parser.parse_program();
+    if (parser.has_errors()) {
+        return JS::js_undefined();
+    }
     dbg() << "Document::run_javascript('" << source << "') will run:";
     program->dump(0);
     return document().interpreter().run(*program);

--- a/Libraries/LibWeb/DOM/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/DOM/HTMLScriptElement.cpp
@@ -59,7 +59,11 @@ void HTMLScriptElement::children_changed()
     if (source.is_empty())
         return;
 
-    auto program = JS::Parser(JS::Lexer(source)).parse_program();
+    auto parser = JS::Parser(JS::Lexer(source));
+    auto program = parser.parse_program();
+    if (parser.has_errors())
+        return;
+
     document().interpreter().run(*program);
 }
 
@@ -90,7 +94,11 @@ void HTMLScriptElement::inserted_into(Node& new_parent)
         return;
     }
 
-    auto program = JS::Parser(JS::Lexer(source)).parse_program();
+    auto parser = JS::Parser(JS::Lexer(source));
+    auto program = parser.parse_program();
+    if (parser.has_errors())
+        return;
+
     document().interpreter().run(*program);
 }
 

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -326,9 +326,14 @@ JS::Value ReplObject::load_file(JS::Interpreter& interpreter)
         } else {
             source = file_contents;
         }
-        auto program = JS::Parser(JS::Lexer(source)).parse_program();
+        auto parser = JS::Parser(JS::Lexer(source));
+        auto program = parser.parse_program();
         if (dump_ast)
             program->dump(0);
+
+        if (parser.has_errors())
+            continue;
+
         interpreter.run(*program);
         print(interpreter.last_value());
     }
@@ -342,9 +347,15 @@ void repl(JS::Interpreter& interpreter)
         if (piece.is_empty())
             continue;
         repl_statements.append(piece);
-        auto program = JS::Parser(JS::Lexer(piece)).parse_program();
+        auto parser = JS::Parser(JS::Lexer(piece));
+        auto program = parser.parse_program();
         if (dump_ast)
             program->dump(0);
+
+        if (parser.has_errors()) {
+            printf("Parse error\n");
+            continue;
+        }
 
         interpreter.run(*program);
         if (interpreter.exception()) {
@@ -628,10 +639,16 @@ int main(int argc, char** argv)
         } else {
             source = file_contents;
         }
-        auto program = JS::Parser(JS::Lexer(source)).parse_program();
+        auto parser = JS::Parser(JS::Lexer(source));
+        auto program = parser.parse_program();
 
         if (dump_ast)
             program->dump(0);
+
+        if (parser.has_errors()) {
+            printf("Parse Error\n");
+            return 1;
+        }
 
         auto result = interpreter->run(*program);
 


### PR DESCRIPTION
This adds missing checks in several LibJS consumers.