### PR TITLE
js/LibJS: Add & use assertNotReached() in tests

### DIFF
--- a/Libraries/LibJS/Tests/Boolean.js
+++ b/Libraries/LibJS/Tests/Boolean.js
@@ -1,35 +1,35 @@
 try {
-  assert(Boolean.length === 1);
-  assert(typeof new Boolean() === "object");
-  assert(new Boolean().valueOf() === false);
+    assert(Boolean.length === 1);
+    assert(typeof new Boolean() === "object");
+    assert(new Boolean().valueOf() === false);
 
-  var foo = new Boolean(true);
-  var bar = new Boolean(true);
+    var foo = new Boolean(true);
+    var bar = new Boolean(true);
 
-  assert(foo !== bar);
-  assert(foo.valueOf() === bar.valueOf());
+    assert(foo !== bar);
+    assert(foo.valueOf() === bar.valueOf());
 
-  assert(new Boolean(true).toString() === "true");
-  assert(new Boolean(false).toString() === "false");
+    assert(new Boolean(true).toString() === "true");
+    assert(new Boolean(false).toString() === "false");
 
-  assert(typeof Boolean() === "boolean");
-  assert(typeof Boolean(true) === "boolean");
+    assert(typeof Boolean() === "boolean");
+    assert(typeof Boolean(true) === "boolean");
 
-  assert(Boolean() === false);
-  assert(Boolean(false) === false);
-  assert(Boolean(null) === false);
-  assert(Boolean(undefined) === false);
-  assert(Boolean(NaN) === false);
-  assert(Boolean("") === false);
-  assert(Boolean(0.0) === false);
-  assert(Boolean(-0.0) === false);
-  assert(Boolean(true) === true);
-  assert(Boolean("0") === true);
-  assert(Boolean({}) === true);
-  assert(Boolean([]) === true);
-  assert(Boolean(1)) === true;
+    assert(Boolean() === false);
+    assert(Boolean(false) === false);
+    assert(Boolean(null) === false);
+    assert(Boolean(undefined) === false);
+    assert(Boolean(NaN) === false);
+    assert(Boolean("") === false);
+    assert(Boolean(0.0) === false);
+    assert(Boolean(-0.0) === false);
+    assert(Boolean(true) === true);
+    assert(Boolean("0") === true);
+    assert(Boolean({}) === true);
+    assert(Boolean([]) === true);
+    assert(Boolean(1)) === true;
 
-  console.log("PASS");
+    console.log("PASS");
 } catch (err) {
-  console.log("FAIL: " + err);
+    console.log("FAIL: " + err);
 }

--- a/Libraries/LibJS/Tests/Boolean.prototype.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.js
@@ -1,8 +1,8 @@
 try {
-  assert(typeof Boolean.prototype === "object");
-  assert(Boolean.prototype.valueOf() === false);
+    assert(typeof Boolean.prototype === "object");
+    assert(Boolean.prototype.valueOf() === false);
 
-  console.log("PASS");
+    console.log("PASS");
 } catch (err) {
-  console.log("FAIL: " + err);
+    console.log("FAIL: " + err);
 }

--- a/Libraries/LibJS/Tests/Boolean.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.toString.js
@@ -1,23 +1,23 @@
 try {
-  var foo = true;
-  assert(foo.toString() === "true");
-  assert(true.toString() === "true");
+    var foo = true;
+    assert(foo.toString() === "true");
+    assert(true.toString() === "true");
 
-  assert(Boolean.prototype.toString.call(true) === "true");
-  assert(Boolean.prototype.toString.call(false) === "false");
+    assert(Boolean.prototype.toString.call(true) === "true");
+    assert(Boolean.prototype.toString.call(false) === "false");
 
-  let error = null;
-  try {
-    Boolean.prototype.toString.call("foo");
-  } catch (err) {
-    error = err;
-  }
+    let error = null;
+    try {
+        Boolean.prototype.toString.call("foo");
+    } catch (err) {
+        error = err;
+    }
 
-  assert(error instanceof Error);
-  assert(error.name === "TypeError");
-  assert(error.message === "Not a Boolean");
+    assert(error instanceof Error);
+    assert(error.name === "TypeError");
+    assert(error.message === "Not a Boolean");
 
-  console.log("PASS");
+    console.log("PASS");
 } catch (err) {
-  console.log("FAIL: " + err);
+    console.log("FAIL: " + err);
 }

--- a/Libraries/LibJS/Tests/Boolean.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.toString.js
@@ -6,16 +6,14 @@ try {
     assert(Boolean.prototype.toString.call(true) === "true");
     assert(Boolean.prototype.toString.call(false) === "false");
 
-    let error = null;
     try {
         Boolean.prototype.toString.call("foo");
-    } catch (err) {
-        error = err;
+        assertNotReached();
+    } catch (e) {
+        assert(e instanceof Error);
+        assert(e.name === "TypeError");
+        assert(e.message === "Not a Boolean");
     }
-
-    assert(error instanceof Error);
-    assert(error.name === "TypeError");
-    assert(error.message === "Not a Boolean");
 
     console.log("PASS");
 } catch (err) {

--- a/Libraries/LibJS/Tests/Boolean.prototype.valueOf.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.valueOf.js
@@ -1,23 +1,23 @@
 try {
-  var foo = true;
-  assert(foo.valueOf() === true);
-  assert(true.valueOf() === true);
+    var foo = true;
+    assert(foo.valueOf() === true);
+    assert(true.valueOf() === true);
 
-  assert(Boolean.prototype.valueOf.call(true) === true);
-  assert(Boolean.prototype.valueOf.call(false) === false);
+    assert(Boolean.prototype.valueOf.call(true) === true);
+    assert(Boolean.prototype.valueOf.call(false) === false);
 
-  let error = null;
-  try {
-    Boolean.prototype.valueOf.call("foo");
-  } catch (err) {
-    error = err;
-  }
+    let error = null;
+    try {
+        Boolean.prototype.valueOf.call("foo");
+    } catch (err) {
+        error = err;
+    }
 
-  assert(error instanceof Error);
-  assert(error.name === "TypeError");
-  assert(error.message === "Not a Boolean");
+    assert(error instanceof Error);
+    assert(error.name === "TypeError");
+    assert(error.message === "Not a Boolean");
 
-  console.log("PASS");
+    console.log("PASS");
 } catch (err) {
-  console.log("FAIL: " + err);
+    console.log("FAIL: " + err);
 }

--- a/Libraries/LibJS/Tests/Boolean.prototype.valueOf.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.valueOf.js
@@ -6,16 +6,14 @@ try {
     assert(Boolean.prototype.valueOf.call(true) === true);
     assert(Boolean.prototype.valueOf.call(false) === false);
 
-    let error = null;
     try {
         Boolean.prototype.valueOf.call("foo");
-    } catch (err) {
-        error = err;
+        assertNotReached();
+    } catch (e) {
+        assert(e instanceof Error);
+        assert(e.name === "TypeError");
+        assert(e.message === "Not a Boolean");
     }
-
-    assert(error instanceof Error);
-    assert(error.name === "TypeError");
-    assert(error.message === "Not a Boolean");
 
     console.log("PASS");
 } catch (err) {

--- a/Libraries/LibJS/Tests/Object.defineProperty.js
+++ b/Libraries/LibJS/Tests/Object.defineProperty.js
@@ -26,7 +26,7 @@ try {
 
     try {
         Object.defineProperty(o, "bar", { value: "xx", enumerable: false });
-        assert(false);
+        assertNotReached();
     } catch (e) {
         assert(e.name === "TypeError");
     }

--- a/Libraries/LibJS/Tests/arrow-functions.js
+++ b/Libraries/LibJS/Tests/arrow-functions.js
@@ -1,56 +1,56 @@
 try {
-  let getNumber = () => 42;
-  assert(getNumber() === 42);
+    let getNumber = () => 42;
+    assert(getNumber() === 42);
 
-  let add = (a, b) => a + b;
-  assert(add(2, 3) === 5);
+    let add = (a, b) => a + b;
+    assert(add(2, 3) === 5);
 
-  const addBlock = (a, b) => {
-    let res = a + b;
-    return res;
-  };
-  assert(addBlock(5, 4) === 9);
+    const addBlock = (a, b) => {
+        let res = a + b;
+        return res;
+    };
+    assert(addBlock(5, 4) === 9);
 
-  const makeObject = (a, b) => ({ a, b });
-  const obj = makeObject(33, 44);
-  assert(typeof obj === "object");
-  assert(obj.a === 33);
-  assert(obj.b === 44);
+    const makeObject = (a, b) => ({ a, b });
+    const obj = makeObject(33, 44);
+    assert(typeof obj === "object");
+    assert(obj.a === 33);
+    assert(obj.b === 44);
 
-  let returnUndefined = () => {};
-  assert(typeof returnUndefined() === "undefined");
+    let returnUndefined = () => { };
+    assert(typeof returnUndefined() === "undefined");
 
-  const makeArray = (a, b) => [a, b];
-  const array = makeArray("3", { foo: 4 });
-  assert(array[0] === "3");
-  assert(array[1].foo === 4);
+    const makeArray = (a, b) => [a, b];
+    const array = makeArray("3", { foo: 4 });
+    assert(array[0] === "3");
+    assert(array[1].foo === 4);
 
-  let square = x => x * x;
-  assert(square(3) === 9);
+    let square = x => x * x;
+    assert(square(3) === 9);
 
-  let squareBlock = x => {
-    return x * x;
-  };
-  assert(squareBlock(4) === 16);
+    let squareBlock = x => {
+        return x * x;
+    };
+    assert(squareBlock(4) === 16);
 
-  const message = (who => "Hello " + who)("friends!");
-  assert(message === "Hello friends!");
+    const message = (who => "Hello " + who)("friends!");
+    assert(message === "Hello friends!");
 
-  const sum = ((x, y, z) => x + y + z)(1, 2, 3);
-  assert(sum === 6);
+    const sum = ((x, y, z) => x + y + z)(1, 2, 3);
+    assert(sum === 6);
 
-  const product = ((x, y, z) => {
-    let res = x * y * z;
-    return res;
-  })(5, 4, 2);
-  assert(product === 40);
+    const product = ((x, y, z) => {
+        let res = x * y * z;
+        return res;
+    })(5, 4, 2);
+    assert(product === 40);
 
-  const half = (x => {
-    return x / 2;
-  })(10);
-  assert(half === 5);
+    const half = (x => {
+        return x / 2;
+    })(10);
+    assert(half === 5);
 
-  console.log("PASS");
+    console.log("PASS");
 } catch {
-  console.log("FAIL");
+    console.log("FAIL");
 }

--- a/Libraries/LibJS/Tests/function-TypeError.js
+++ b/Libraries/LibJS/Tests/function-TypeError.js
@@ -2,6 +2,7 @@ try {
     try {
         var b = true;
         b();
+        assertNotReached();
     } catch(e) {
         assert(e.name === "TypeError");
         assert(e.message === "true is not a function");
@@ -10,6 +11,7 @@ try {
     try {
         var n = 100 + 20 + 3;
         n();
+        assertNotReached();
     } catch(e) {
         assert(e.name === "TypeError");
         assert(e.message === "123 is not a function");
@@ -18,6 +20,7 @@ try {
     try {
         var o = {};
         o.a();
+        assertNotReached();
     } catch(e) {
         assert(e.name === "TypeError");
         assert(e.message === "undefined is not a function");
@@ -25,6 +28,7 @@ try {
 
     try {
         Math();
+        assertNotReached();
     } catch(e) {
         assert(e.name === "TypeError");
         assert(e.message === "[object MathObject] is not a function");
@@ -32,6 +36,7 @@ try {
 
     try {
         new Math();
+        assertNotReached();
     } catch(e) {
         assert(e.name === "TypeError");
         assert(e.message === "[object MathObject] is not a constructor");
@@ -39,6 +44,7 @@ try {
 
     try {
         new isNaN();
+        assertNotReached();
     } catch(e) {
         assert(e.name === "TypeError");
         assert(e.message === "function isNaN() {\n  [NativeFunction]\n} is not a constructor");

--- a/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
+++ b/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
@@ -1,6 +1,7 @@
 try {
     try {
         Math.abs(-20) = 40;
+        assertNotReached();
     } catch (e) {
         assert(e.name === "ReferenceError");
         assert(e.message === "Invalid left-hand side in assignment");
@@ -8,6 +9,7 @@ try {
 
     try {
         512 = 256;
+        assertNotReached();
     } catch (e) {
         assert(e.name === "ReferenceError");
         assert(e.message === "Invalid left-hand side in assignment");
@@ -15,6 +17,7 @@ try {
 
     try {
         "hello world" = "another thing?";
+        assertNotReached();
     } catch (e) {
         assert(e.name === "ReferenceError");
         assert(e.message === "Invalid left-hand side in assignment");

--- a/Libraries/LibJS/Tests/switch-basic-2.js
+++ b/Libraries/LibJS/Tests/switch-basic-2.js
@@ -2,6 +2,7 @@ var a = "foo";
 
 switch (a + "bar") {
 case 1:
+    assertNotReached();
     break;
 case "foobar":
 case 2:

--- a/Libraries/LibJS/Tests/switch-basic-2.js
+++ b/Libraries/LibJS/Tests/switch-basic-2.js
@@ -2,9 +2,9 @@ var a = "foo";
 
 switch (a + "bar") {
 case 1:
-	break;
+    break;
 case "foobar":
 case 2:
-        console.log("PASS");
-	break;
+    console.log("PASS");
+    break;
 }

--- a/Libraries/LibJS/Tests/switch-basic-3.js
+++ b/Libraries/LibJS/Tests/switch-basic-3.js
@@ -2,5 +2,5 @@ var a = "foo";
 
 switch (100) {
 default:
-        console.log("PASS");
+    console.log("PASS");
 }

--- a/Libraries/LibJS/Tests/switch-basic.js
+++ b/Libraries/LibJS/Tests/switch-basic.js
@@ -1,10 +1,10 @@
 switch (1 + 2) {
 case 3:
-	console.log("PASS");
-	break;
+    console.log("PASS");
+    break;
 case 5:
 case 1:
-	break;
+    break;
 default:
-	break;
+    break;
 }

--- a/Libraries/LibJS/Tests/throw-basic.js
+++ b/Libraries/LibJS/Tests/throw-basic.js
@@ -1,11 +1,13 @@
 try {
     throw 1;
+    assertNotReached();
 } catch (e) {
     assert(e === 1);
 }
 
 try {
     throw [99];
+    assertNotReached();
 } catch (e) {
     assert(typeof e === "object");
     assert(e.length === 1);
@@ -13,10 +15,12 @@ try {
 
 function foo() {
     throw "hello";
+    assertNotReached();
 }
 
 try {
     foo();
+    assertNotReached();
 } catch (e) {
     assert(e === "hello");
 }

--- a/Libraries/LibJS/Tests/variable-declaration.js
+++ b/Libraries/LibJS/Tests/variable-declaration.js
@@ -1,23 +1,22 @@
 try {
 
-    const ConstantValue = 1;
+    const constantValue = 1;
     try {
-        ConstantValue = 2;
-    } catch (e) { 
+        constantValue = 2;
+        assertNotReached();
+    } catch (e) {
         assert(e.name === "TypeError");
         assert(e.message === "Assignment to constant variable");
-        assert(ConstantValue === 1);
+        assert(constantValue === 1);
     }
 
     // Make sure we can define new constants in inner scopes.
-    //
-    const ConstantValue2 = 1;
-
-    do 
-    {
-        const ConstantValue2 = 2;
-    }
-    while (false)
+    const constantValue2 = 1;
+    do {
+        const constantValue2 = 2;
+        assert(constantValue2 === 2);
+    } while (false);
+    assert(constantValue2 === 1);
 
     console.log("PASS");
 } catch (e) {

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -279,6 +279,7 @@ ReplObject::ReplObject()
 ReplObject::~ReplObject()
 {
 }
+
 JS::Value ReplObject::save_to_file(JS::Interpreter& interpreter)
 {
     if (!interpreter.argument_count())
@@ -290,6 +291,7 @@ JS::Value ReplObject::save_to_file(JS::Interpreter& interpreter)
     }
     return JS::Value(false);
 }
+
 JS::Value ReplObject::exit_interpreter(JS::Interpreter& interpreter)
 {
     if (!interpreter.argument_count())
@@ -298,6 +300,7 @@ JS::Value ReplObject::exit_interpreter(JS::Interpreter& interpreter)
     exit(exit_code);
     return JS::js_undefined();
 }
+
 JS::Value ReplObject::repl_help(JS::Interpreter& interpreter)
 {
     StringBuilder help_text;
@@ -383,10 +386,16 @@ JS::Value assert_impl(JS::Interpreter& interpreter)
     return JS::Value(assertion_value);
 }
 
+JS::Value assert_not_reached(JS::Interpreter& interpreter)
+{
+    return interpreter.throw_exception<JS::Error>("AssertionError", "assertNotReached() was reached!");
+}
+
 void enable_test_mode(JS::Interpreter& interpreter)
 {
     interpreter.global_object().put_native_function("load", ReplObject::load_file);
     interpreter.global_object().put_native_function("assert", assert_impl);
+    interpreter.global_object().put_native_function("assertNotReached", assert_not_reached);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Three commits:

- Add `assertNotReached()` function in test mode
- Fix test files indentation (4 spaces)
- Use `assertNotReached()` in tests

[1] should be self-explanatory, [2] because it was a bit of a mess, sometimes 2 spaces, mostly 4 spaces, sometimes 8 spaces and sometimes tabs and spaces mixed :scream:
[3] to ensure the tests actually fail when we test some code that's expected to fail but only assert that in the `catch` block - what if the interpreter (wrongly) never throws an exception?!