### PR TITLE
Debugger: Additional functionality

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -317,6 +317,18 @@ bool String::contains(const String& needle) const
     return strstr(characters(), needle.characters());
 }
 
+Optional<size_t> String::index_of(const String& needle) const
+{
+    if (is_null() || needle.is_null())
+        return {};
+
+    const char* self_characters = characters();
+    const char* result = strstr(self_characters, needle.characters());
+    if (!result)
+        return {};
+    return Optional<size_t> { result - self_characters };
+}
+
 bool String::equals_ignoring_case(const StringView& other) const
 {
     return StringUtils::equals_ignoring_case(view(), other);

--- a/AK/String.h
+++ b/AK/String.h
@@ -117,6 +117,7 @@ public:
     bool equals_ignoring_case(const StringView&) const;
 
     bool contains(const String&) const;
+    Optional<size_t> index_of(const String&) const;
 
     Vector<String> split_limit(char separator, size_t limit, bool keep_empty = false) const;
     Vector<String> split(char separator, bool keep_empty = false) const;

--- a/Applications/Debugger/DebugSession.cpp
+++ b/Applications/Debugger/DebugSession.cpp
@@ -30,8 +30,8 @@
 
 DebugSession::DebugSession(int pid)
     : m_debugee_pid(pid)
-    , m_executable(make<MappedFile>(String::format("/proc/%d/exe", pid)))
-    , m_elf_image(make<ELF::Image>(reinterpret_cast<u8*>(m_executable->data()), m_executable->size()))
+    , m_executable(String::format("/proc/%d/exe", pid))
+    , m_elf(reinterpret_cast<u8*>(m_executable.data()), m_executable.size())
 {
 }
 
@@ -175,9 +175,4 @@ void DebugSession::continue_debugee()
         perror("continue");
         ASSERT_NOT_REACHED();
     }
-}
-
-VirtualAddress DebugSession::get_entry_point() const
-{
-    return m_elf_image->entry();
 }

--- a/Applications/Debugger/DebugSession.h
+++ b/Applications/Debugger/DebugSession.h
@@ -26,13 +26,14 @@
 
 #pragma once
 
+#include <AK/Demangle.h>
 #include <AK/HashMap.h>
 #include <AK/MappedFile.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <LibC/sys/arch/i386/regs.h>
-#include <LibELF/Image.h>
+#include <LibELF/Loader.h>
 #include <signal.h>
 #include <stdio.h>
 #include <sys/ptrace.h>
@@ -69,7 +70,7 @@ public:
     template<typename Callback>
     void run(Callback callback);
 
-    VirtualAddress get_entry_point() const;
+    const ELF::Loader& elf() const { return m_elf; }
 
     enum DebugDecision {
         Continue,
@@ -90,8 +91,8 @@ private:
     int m_debugee_pid { -1 };
     bool m_is_debugee_dead { false };
 
-    NonnullOwnPtr<MappedFile> m_executable;
-    NonnullOwnPtr<ELF::Image> m_elf_image;
+    MappedFile m_executable;
+    ELF::Loader m_elf;
 
     HashMap<void*, BreakPoint> m_breakpoints;
 };

--- a/Applications/Debugger/main.cpp
+++ b/Applications/Debugger/main.cpp
@@ -168,6 +168,7 @@ void print_help()
 {
     printf("Options:\n"
            "cont - Continue execution\n"
+           "s - step over the current instruction\n"
            "regs - Print registers\n"
            "dis [number of instructions] - Print disassembly\n"
            "bp <address/symbol> - Insert a breakpoint\n");
@@ -221,6 +222,9 @@ int main(int argc, char** argv)
 
             if (command == "cont") {
                 return DebugSession::DebugDecision::Continue;
+            }
+            if (command == "s") {
+                return DebugSession::DebugDecision::SingleStep;
             }
 
             if (command == "regs") {

--- a/Applications/Debugger/main.cpp
+++ b/Applications/Debugger/main.cpp
@@ -95,6 +95,7 @@ void handle_print_registers(const PtraceRegisters& regs)
 
 bool handle_disassemble_command(const String& command, void* first_instruction)
 {
+    (void)demangle("foo");
     auto parts = command.split(' ');
     size_t number_of_instructions_to_disassemble = 5;
     if (parts.size() == 2) {
@@ -212,7 +213,8 @@ int main(int argc, char** argv)
         ASSERT(optional_regs.has_value());
         const PtraceRegisters& regs = optional_regs.value();
 
-        printf("Program is stopped at: 0x%x\n", regs.eip);
+        auto symbol_at_ip = g_debug_session->elf().symbolicate(regs.eip);
+        printf("Program is stopped at: 0x%x (%s)\n", regs.eip, symbol_at_ip.characters());
         for (;;) {
             auto command = get_command();
             bool success = false;

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -480,6 +480,8 @@ inline FlatPtr offset_in_page(const void* address)
 u32 read_cr3();
 void write_cr3(u32);
 
+u32 read_dr6();
+
 class CPUID {
 public:
     CPUID(u32 function) { asm volatile("cpuid"

--- a/Libraries/LibELF/Loader.h
+++ b/Libraries/LibELF/Loader.h
@@ -52,9 +52,13 @@ public:
     Function<void*(VirtualAddress, size_t, size_t, bool, bool, const String&)> alloc_section_hook;
     Function<void*(size_t, size_t)> tls_section_hook;
     Function<void*(VirtualAddress, size_t, size_t, size_t, bool r, bool w, bool x, const String&)> map_section_hook;
-    VirtualAddress entry() const { return m_image.entry(); }
 #endif
-    char* symbol_ptr(const char* name);
+    VirtualAddress entry() const
+    {
+        return m_image.entry();
+    }
+    char* symbol_ptr(const char* name) const;
+    Optional<Image::Symbol> find_demangled_function(const String& name) const;
 
     bool has_symbols() const { return m_symbol_count; }
 


### PR DESCRIPTION
I Added the following:
- Insert a breakpoint at a function name
- The debugger prints the address & function it is stopped at
- Breakpoints now persist after being tripped.
  So if you put a breakpoint in a loop / in a function that's called multiple times,
  you do not have to re-insert it after each time it's tripped
- Single-stepping command
- Repeat the previous command when an empty command is entered

A fun thing you can do now is do a 'single-step' once, and then hold enter and see the program go :smile: 