### PR TITLE
js/LibJS: Move test assert functions to pure javascript

### DIFF
--- a/Libraries/LibJS/Tests/Array.js
+++ b/Libraries/LibJS/Tests/Array.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Array.length === 1);
     assert(Array.prototype.length === 0);

--- a/Libraries/LibJS/Tests/Array.prototype.pop.js
+++ b/Libraries/LibJS/Tests/Array.prototype.pop.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var a = [1, 2, 3];
     var value = a.pop();

--- a/Libraries/LibJS/Tests/Array.prototype.shift.js
+++ b/Libraries/LibJS/Tests/Array.prototype.shift.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var a = [1, 2, 3];
     var value = a.shift();

--- a/Libraries/LibJS/Tests/Array.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Array.prototype.toString.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var a = [1, 2, 3];
     assert(a.toString() === '1,2,3');

--- a/Libraries/LibJS/Tests/Boolean.js
+++ b/Libraries/LibJS/Tests/Boolean.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Boolean.length === 1);
     assert(typeof new Boolean() === "object");

--- a/Libraries/LibJS/Tests/Boolean.prototype.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(typeof Boolean.prototype === "object");
     assert(Boolean.prototype.valueOf() === false);

--- a/Libraries/LibJS/Tests/Boolean.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.toString.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var foo = true;
     assert(foo.toString() === "true");

--- a/Libraries/LibJS/Tests/Boolean.prototype.valueOf.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.valueOf.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var foo = true;
     assert(foo.valueOf() === true);

--- a/Libraries/LibJS/Tests/Date.now.js
+++ b/Libraries/LibJS/Tests/Date.now.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var last = 0;
     for (var i = 0; i < 100; ++i) {

--- a/Libraries/LibJS/Tests/Date.prototype.getDate.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getDate.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var d = new Date();
     assert(!isNaN(d.getDate()));

--- a/Libraries/LibJS/Tests/Date.prototype.getDay.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getDay.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var d = new Date();
     assert(!isNaN(d.getDay()));

--- a/Libraries/LibJS/Tests/Date.prototype.getFullYear.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getFullYear.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var d = new Date();
     assert(!isNaN(d.getFullYear()));

--- a/Libraries/LibJS/Tests/Date.prototype.getHours.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getHours.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var d = new Date();
     assert(!isNaN(d.getHours()));

--- a/Libraries/LibJS/Tests/Date.prototype.getMilliseconds.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getMilliseconds.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var d = new Date();
     assert(!isNaN(d.getMilliseconds()));

--- a/Libraries/LibJS/Tests/Date.prototype.getMinutes.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getMinutes.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var d = new Date();
     assert(!isNaN(d.getMinutes()));

--- a/Libraries/LibJS/Tests/Date.prototype.getMonth.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getMonth.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var d = new Date();
     assert(!isNaN(d.getMonth()));

--- a/Libraries/LibJS/Tests/Date.prototype.getSeconds.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getSeconds.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var d = new Date();
     assert(!isNaN(d.getSeconds()));

--- a/Libraries/LibJS/Tests/Date.prototype.getTime.js
+++ b/Libraries/LibJS/Tests/Date.prototype.getTime.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var d = new Date();
     assert(!isNaN(d.getTime()));

--- a/Libraries/LibJS/Tests/Error.js
+++ b/Libraries/LibJS/Tests/Error.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var e;
 

--- a/Libraries/LibJS/Tests/Error.prototype.name.js
+++ b/Libraries/LibJS/Tests/Error.prototype.name.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var changedInstance = new Error("");
     changedInstance.name = 'NewCustomError';

--- a/Libraries/LibJS/Tests/Error.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Error.prototype.toString.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Error().toString() === "Error");
     assert(Error(undefined).toString() === "Error");

--- a/Libraries/LibJS/Tests/Function.js
+++ b/Libraries/LibJS/Tests/Function.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Function.length === 1);
     assert(Function.prototype.length === 0);

--- a/Libraries/LibJS/Tests/Function.prototype.apply.js
+++ b/Libraries/LibJS/Tests/Function.prototype.apply.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     function Foo(arg) {
         this.foo = arg;

--- a/Libraries/LibJS/Tests/Function.prototype.call.js
+++ b/Libraries/LibJS/Tests/Function.prototype.call.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     function Foo(arg) {
         this.foo = arg;

--- a/Libraries/LibJS/Tests/Function.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Function.prototype.toString.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert((function() {}).toString() === "function () {\n  ???\n}");
     assert((function(foo) {}).toString() === "function (foo) {\n  ???\n}");

--- a/Libraries/LibJS/Tests/Infinity-basic.js
+++ b/Libraries/LibJS/Tests/Infinity-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Infinity + "" === "Infinity");
     assert(-Infinity + "" === "-Infinity");

--- a/Libraries/LibJS/Tests/Math-constants.js
+++ b/Libraries/LibJS/Tests/Math-constants.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 // Borrowed from LibM/TestMath.cpp :^)
 function expectClose(a, b) { assert(Math.abs(a - b) < 0.000001); }
 

--- a/Libraries/LibJS/Tests/Math.abs.js
+++ b/Libraries/LibJS/Tests/Math.abs.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Math.abs('-1') === 1);
     assert(Math.abs(-2) === 2);

--- a/Libraries/LibJS/Tests/Math.ceil.js
+++ b/Libraries/LibJS/Tests/Math.ceil.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Math.ceil(0.95) === 1);
     assert(Math.ceil(4) === 4);

--- a/Libraries/LibJS/Tests/Math.cos.js
+++ b/Libraries/LibJS/Tests/Math.cos.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Math.cos(0) === 1);
     assert(Math.cos(null) === 1);

--- a/Libraries/LibJS/Tests/Math.max.js
+++ b/Libraries/LibJS/Tests/Math.max.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Math.max.length === 2);
     assert(Math.max() === -Infinity);

--- a/Libraries/LibJS/Tests/Math.min.js
+++ b/Libraries/LibJS/Tests/Math.min.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Math.min.length === 2);
     assert(Math.min(1) === 1);

--- a/Libraries/LibJS/Tests/Math.sin.js
+++ b/Libraries/LibJS/Tests/Math.sin.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Math.sin(0) === 0);
     assert(Math.sin(null) === 0);

--- a/Libraries/LibJS/Tests/Math.sqrt.js
+++ b/Libraries/LibJS/Tests/Math.sqrt.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Math.sqrt(9) === 3);
     console.log("PASS");

--- a/Libraries/LibJS/Tests/Math.tan.js
+++ b/Libraries/LibJS/Tests/Math.tan.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Math.tan(0) === 0);
     assert(Math.tan(null) === 0);

--- a/Libraries/LibJS/Tests/Math.trunc.js
+++ b/Libraries/LibJS/Tests/Math.trunc.js
@@ -1,3 +1,5 @@
+load("test-common.js")
+
 try {
     assert(Math.trunc(13.37) === 13);
     assert(Math.trunc(42.84) === 42);

--- a/Libraries/LibJS/Tests/NaN-basic.js
+++ b/Libraries/LibJS/Tests/NaN-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var nan = undefined + 1;
     assert(nan + "" == "NaN");

--- a/Libraries/LibJS/Tests/Number-constants.js
+++ b/Libraries/LibJS/Tests/Number-constants.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Number.EPSILON === 2 ** -52);
     assert(Number.EPSILON > 0);

--- a/Libraries/LibJS/Tests/Number.isSafeInteger.js
+++ b/Libraries/LibJS/Tests/Number.isSafeInteger.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Number.isSafeInteger.length === 1);
     assert(Number.isSafeInteger(0) === true);

--- a/Libraries/LibJS/Tests/Number.js
+++ b/Libraries/LibJS/Tests/Number.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Number.length === 1);
     assert(typeof Number() === "number");

--- a/Libraries/LibJS/Tests/Number.prototype.js
+++ b/Libraries/LibJS/Tests/Number.prototype.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
   assert(typeof Number.prototype === "object");
   assert(Number.prototype.valueOf() === 0);

--- a/Libraries/LibJS/Tests/Object.defineProperty.js
+++ b/Libraries/LibJS/Tests/Object.defineProperty.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var o = {};
     Object.defineProperty(o, "foo", { value: 1, writable: false, enumerable: false });

--- a/Libraries/LibJS/Tests/Object.getOwnPropertyNames.js
+++ b/Libraries/LibJS/Tests/Object.getOwnPropertyNames.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var names = Object.getOwnPropertyNames([1, 2, 3]);
 

--- a/Libraries/LibJS/Tests/Object.getPrototypeOf.js
+++ b/Libraries/LibJS/Tests/Object.getPrototypeOf.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var o1 = new Object();
     var o2 = {};

--- a/Libraries/LibJS/Tests/Object.prototype.constructor.js
+++ b/Libraries/LibJS/Tests/Object.prototype.constructor.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(Array.prototype.constructor === Array)
     assert(Boolean.prototype.constructor === Boolean)

--- a/Libraries/LibJS/Tests/Object.prototype.hasOwnProperty.js
+++ b/Libraries/LibJS/Tests/Object.prototype.hasOwnProperty.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var o = {};
     o.foo = 1;

--- a/Libraries/LibJS/Tests/Object.prototype.js
+++ b/Libraries/LibJS/Tests/Object.prototype.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var o = new Object();
     Object.prototype.foo = 123;

--- a/Libraries/LibJS/Tests/Object.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Object.prototype.toString.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(typeof Object.prototype.toString() === "string");
     console.log("PASS");

--- a/Libraries/LibJS/Tests/String.prototype.charAt.js
+++ b/Libraries/LibJS/Tests/String.prototype.charAt.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var s = "foobar"
     assert(typeof s === "string");

--- a/Libraries/LibJS/Tests/String.prototype.indexOf.js
+++ b/Libraries/LibJS/Tests/String.prototype.indexOf.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var s = "hello friends"
 

--- a/Libraries/LibJS/Tests/String.prototype.js
+++ b/Libraries/LibJS/Tests/String.prototype.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(typeof Object.getPrototypeOf("") === "object");
     assert(Object.getPrototypeOf("").valueOf() === '');

--- a/Libraries/LibJS/Tests/String.prototype.padEnd.js
+++ b/Libraries/LibJS/Tests/String.prototype.padEnd.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(String.prototype.padEnd.length === 1);
 

--- a/Libraries/LibJS/Tests/String.prototype.padStart.js
+++ b/Libraries/LibJS/Tests/String.prototype.padStart.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(String.prototype.padStart.length === 1);
 

--- a/Libraries/LibJS/Tests/String.prototype.startsWith.js
+++ b/Libraries/LibJS/Tests/String.prototype.startsWith.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var s = "foobar";
     assert(s.startsWith("f") === true);

--- a/Libraries/LibJS/Tests/String.prototype.toLowerCase.js
+++ b/Libraries/LibJS/Tests/String.prototype.toLowerCase.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(String.prototype.toLowerCase.length === 0);
 

--- a/Libraries/LibJS/Tests/String.prototype.toString.js
+++ b/Libraries/LibJS/Tests/String.prototype.toString.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(String.prototype.toString.length === 0)
     assert("".toString() === "");

--- a/Libraries/LibJS/Tests/String.prototype.toUpperCase.js
+++ b/Libraries/LibJS/Tests/String.prototype.toUpperCase.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(String.prototype.toUpperCase.length === 0);
 

--- a/Libraries/LibJS/Tests/array-basic.js
+++ b/Libraries/LibJS/Tests/array-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var a = [1, 2, 3];
 

--- a/Libraries/LibJS/Tests/arrow-functions.js
+++ b/Libraries/LibJS/Tests/arrow-functions.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     let getNumber = () => 42;
     assert(getNumber() === 42);

--- a/Libraries/LibJS/Tests/binary-bitwise-operators-basic.js
+++ b/Libraries/LibJS/Tests/binary-bitwise-operators-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert((0 | 0) === 0);
     assert((0 | 1) === 1);

--- a/Libraries/LibJS/Tests/continue-basic.js
+++ b/Libraries/LibJS/Tests/continue-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var j = 0;
     for (var i = 0; i < 9; ++i) {

--- a/Libraries/LibJS/Tests/do-while-basic.js
+++ b/Libraries/LibJS/Tests/do-while-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var number = 0;
     do {

--- a/Libraries/LibJS/Tests/exception-ReferenceError.js
+++ b/Libraries/LibJS/Tests/exception-ReferenceError.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     i < 3;
 } catch (e) {

--- a/Libraries/LibJS/Tests/exponentiation-basic.js
+++ b/Libraries/LibJS/Tests/exponentiation-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(2 ** 0 === 1);
     assert(2 ** 1 === 2);

--- a/Libraries/LibJS/Tests/for-basic.js
+++ b/Libraries/LibJS/Tests/for-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var a = [];
     for (var i = 0; i < 3; ++i) {

--- a/Libraries/LibJS/Tests/for-no-curlies.js
+++ b/Libraries/LibJS/Tests/for-no-curlies.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var number = 0;
 

--- a/Libraries/LibJS/Tests/function-TypeError.js
+++ b/Libraries/LibJS/Tests/function-TypeError.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     try {
         var b = true;

--- a/Libraries/LibJS/Tests/function-length.js
+++ b/Libraries/LibJS/Tests/function-length.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     function foo() { }
     assert(foo.length === 0);

--- a/Libraries/LibJS/Tests/function-missing-arg.js
+++ b/Libraries/LibJS/Tests/function-missing-arg.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 function foo(a, b) { return a + b; }
 
 try {

--- a/Libraries/LibJS/Tests/function-this-in-arguments.js
+++ b/Libraries/LibJS/Tests/function-this-in-arguments.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
   assert(typeof this === "object");
   assert(this === globalThis);

--- a/Libraries/LibJS/Tests/instanceof-basic.js
+++ b/Libraries/LibJS/Tests/instanceof-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     function Foo() {
         this.x = 123;

--- a/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
+++ b/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     try {
         Math.abs(-20) = 40;

--- a/Libraries/LibJS/Tests/let-scoping.js
+++ b/Libraries/LibJS/Tests/let-scoping.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
 
     let i = 1;

--- a/Libraries/LibJS/Tests/logical-expressions-basic.js
+++ b/Libraries/LibJS/Tests/logical-expressions-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert((true && true) === true);
     assert((false && false) === false);

--- a/Libraries/LibJS/Tests/logical-expressions-short-circuit.js
+++ b/Libraries/LibJS/Tests/logical-expressions-short-circuit.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     let foo = 1;
     false && (foo = 2);

--- a/Libraries/LibJS/Tests/modulo-basic.js
+++ b/Libraries/LibJS/Tests/modulo-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(10 % 3 === 1);
     assert(10.5 % 2.5 === 0.5);

--- a/Libraries/LibJS/Tests/numeric-literals-basic.js
+++ b/Libraries/LibJS/Tests/numeric-literals-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(0xff === 255);
     assert(0XFF === 255);

--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var o = { 1: 23, foo: "bar", "hello": "friends" };
     assert(o[1] === 23);

--- a/Libraries/LibJS/Tests/parser-unary-associativity.js
+++ b/Libraries/LibJS/Tests/parser-unary-associativity.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var o = {};
     o.a = 1;

--- a/Libraries/LibJS/Tests/run-tests
+++ b/Libraries/LibJS/Tests/run-tests
@@ -13,6 +13,7 @@ pass_count=0
 fail_count=0
 count=0
 
+GLOBIGNORE=test-common.js
 for f in *.js; do
     result=`$js_program -t $f`
     if [ "$result" = "PASS" ]; then

--- a/Libraries/LibJS/Tests/switch-break.js
+++ b/Libraries/LibJS/Tests/switch-break.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var i = 0;
     var three;

--- a/Libraries/LibJS/Tests/ternary-basic.js
+++ b/Libraries/LibJS/Tests/ternary-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var x = 1;
 

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -1,0 +1,16 @@
+
+function AssertionError(message) {
+    var instance = new Error(message);
+    instance.name = 'AssertionError';
+    Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+    return instance;
+}
+
+function assert(value) {
+    if (!value)
+        throw new AssertionError("The assertion failed!");
+}
+
+function assertNotReached() {
+    throw new AssertionError("assertNotReached() was reached!");
+}

--- a/Libraries/LibJS/Tests/throw-basic.js
+++ b/Libraries/LibJS/Tests/throw-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     throw 1;
     assertNotReached();

--- a/Libraries/LibJS/Tests/to-number-basic.js
+++ b/Libraries/LibJS/Tests/to-number-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(+false === 0);
     assert(-false === 0);

--- a/Libraries/LibJS/Tests/typeof-basic.js
+++ b/Libraries/LibJS/Tests/typeof-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     assert(typeof "foo" === "string");
     assert(!(typeof "foo" !== "string"));

--- a/Libraries/LibJS/Tests/var-multiple-declarator.js
+++ b/Libraries/LibJS/Tests/var-multiple-declarator.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     var a = 1, b = 2, c = a + b;
     assert(a === 1);

--- a/Libraries/LibJS/Tests/var-scoping.js
+++ b/Libraries/LibJS/Tests/var-scoping.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
     function foo() {
         i = 3;

--- a/Libraries/LibJS/Tests/variable-declaration.js
+++ b/Libraries/LibJS/Tests/variable-declaration.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 try {
 
     const constantValue = 1;

--- a/Libraries/LibJS/Tests/variable-undefined.js
+++ b/Libraries/LibJS/Tests/variable-undefined.js
@@ -1,3 +1,5 @@
+load("test-common.js");
+
 function foo(a) {
     return a;
 }

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -374,28 +374,9 @@ void repl(JS::Interpreter& interpreter)
     }
 }
 
-JS::Value assert_impl(JS::Interpreter& interpreter)
-{
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<JS::TypeError>("No arguments specified");
-
-    auto assertion_value = interpreter.argument(0).to_boolean();
-    if (!assertion_value)
-        return interpreter.throw_exception<JS::Error>("AssertionError", "The assertion failed!");
-
-    return JS::Value(assertion_value);
-}
-
-JS::Value assert_not_reached(JS::Interpreter& interpreter)
-{
-    return interpreter.throw_exception<JS::Error>("AssertionError", "assertNotReached() was reached!");
-}
-
 void enable_test_mode(JS::Interpreter& interpreter)
 {
     interpreter.global_object().put_native_function("load", ReplObject::load_file);
-    interpreter.global_object().put_native_function("assert", assert_impl);
-    interpreter.global_object().put_native_function("assertNotReached", assert_not_reached);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
The addition of assert functions to Userland/js
was done before we had load(..) implemented. Now
that it exists, it seems like the right move the
test helper functions to pure javascript instead
of poluting js with random global functions.