### PR TITLE
Meta: Add Lagom CMake dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.cflags
 *.cxxflags
 *.autosave
+Meta/Lagom/build
 Root
 Toolchain/Tarballs
 Toolchain/Build


### PR DESCRIPTION
Meta/Lagom/build seems to be the expected cmake output directory.
(It's hardcoded in Libraries/LibJS/Tests/run-tests.)

Add it to the project .gitignore