### PR TITLE
Build: Use c++ as default HOST_CXX

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -33,7 +33,7 @@ ifneq ($(USE_HOST_CXX),)
         CXX_WARNING_FLAGS += -Wno-unknown-warning-option
     endif
     ifeq ($(HOST_CXX),)
-        CXX = $(PRE_CXX) g++
+        CXX = $(PRE_CXX) c++
     else
         CXX = $(HOST_CXX)
     endif


### PR DESCRIPTION
Because not everyone is using GCC :^p