### PR TITLE
LibJS: Add missing load("test-common.js") to comments-basic.js

### DIFF
--- a/Libraries/LibJS/Tests/comments-basic.js
+++ b/Libraries/LibJS/Tests/comments-basic.js
@@ -1,3 +1,5 @@
+load("test-common.js")
+
 try {
     var i = 0;
 


### PR DESCRIPTION
This fixes the test which is currently failing with "ReferenceError: 'assert' not known".