### PR TITLE
LibJS: Redirect stderr to /dev/null when running js in run-tests

### DIFF
--- a/Libraries/LibJS/Tests/run-tests
+++ b/Libraries/LibJS/Tests/run-tests
@@ -15,7 +15,7 @@ count=0
 
 GLOBIGNORE=test-common.js
 for f in *.js; do
-    result=`$js_program -t $f`
+    result=`$js_program -t $f 2>/dev/null`
     if [ "$result" = "PASS" ]; then
         let pass_count++
         echo -ne "( \033[32;1mPass\033[0m ) "


### PR DESCRIPTION
This "mutes" output from `dbg()` calls - which is not an issue inside serenity itself but if the script is run on the host machine and stdout and stderr are displayed in the same terminal window.

E.g. this is what the output looks like on a Linux system right now:

```
( Pass ) array-basic.js
( Pass ) Array.js
Throwing JavaScript Error: TypeError, Array.prototype.filter() requires at least one argument
Throwing JavaScript Error: TypeError, undefined is not a function
( Pass ) Array.prototype.filter.js
Throwing JavaScript Error: TypeError, Array.prototype.forEach() requires at least one argument
Throwing JavaScript Error: TypeError, undefined is not a function
( Pass ) Array.prototype.forEach.js
Throwing JavaScript Error: TypeError, Array.prototype.map() requires at least one argument
Throwing JavaScript Error: TypeError, undefined is not a function
( Pass ) Array.prototype.map.js
( Pass ) Array.prototype.pop.js
( Pass ) Array.prototype.push.js
( Pass ) Array.prototype.shift.js
( Pass ) Array.prototype.toString.js
( Pass ) Array.prototype.unshift.js
( Pass ) arrow-functions.js
( Pass ) binary-bitwise-operators-basic.js
( Pass ) Boolean.js
( Pass ) Boolean.prototype.js
Throwing JavaScript Error: TypeError, Not a Boolean
( Pass ) Boolean.prototype.toString.js
Throwing JavaScript Error: TypeError, Not a Boolean
( Pass ) Boolean.prototype.valueOf.js
( Pass ) comments-basic.js
( Pass ) constructor-basic.js
( Pass ) continue-basic.js
( Pass ) Date.now.js
( Pass ) Date.prototype.getDate.js
( Pass ) Date.prototype.getDay.js
( Pass ) Date.prototype.getFullYear.js
( Pass ) Date.prototype.getHours.js
( Pass ) Date.prototype.getMilliseconds.js
( Pass ) Date.prototype.getMinutes.js
( Pass ) Date.prototype.getMonth.js
( Pass ) Date.prototype.getSeconds.js
( Pass ) Date.prototype.getTime.js
( Pass ) do-while-basic.js
( Pass ) Error.js
( Pass ) Error.prototype.name.js
( Pass ) Error.prototype.toString.js
Throwing JavaScript Error: ReferenceError, 'i' not known
( Pass ) exception-ReferenceError.js
( Pass ) exponentiation-basic.js
( Pass ) for-basic.js
( Pass ) for-no-curlies.js
( Pass ) Function.js
( Pass ) function-length.js
( Pass ) function-missing-arg.js
( Pass ) Function.prototype.apply.js
( Pass ) Function.prototype.call.js
( Pass ) Function.prototype.toString.js
( Pass ) function-this-in-arguments.js
Throwing JavaScript Error: TypeError, true is not a function
Throwing JavaScript Error: TypeError, 123 is not a function
Throwing JavaScript Error: TypeError, undefined is not a function
Throwing JavaScript Error: TypeError, [object MathObject] is not a function
Throwing JavaScript Error: TypeError, [object MathObject] is not a constructor
Throwing JavaScript Error: TypeError, function isNaN() {
  [NativeFunction]
} is not a constructor
( Pass ) function-TypeError.js
( Pass ) Infinity-basic.js
( Pass ) instanceof-basic.js
Throwing JavaScript Error: ReferenceError, Invalid left-hand side in assignment
Throwing JavaScript Error: ReferenceError, Invalid left-hand side in assignment
Throwing JavaScript Error: ReferenceError, Invalid left-hand side in assignment
( Pass ) invalid-lhs-in-assignment.js
( Pass ) let-scoping.js
( Pass ) logical-expressions-basic.js
( Pass ) logical-expressions-short-circuit.js
( Pass ) Math.abs.js
( Pass ) Math.ceil.js
( Pass ) Math-constants.js
( Pass ) Math.cos.js
( Pass ) Math.max.js
( Pass ) Math.min.js
( Pass ) Math.sin.js
( Pass ) Math.sqrt.js
( Pass ) Math.tan.js
( Pass ) Math.trunc.js
( Pass ) modulo-basic.js
( Pass ) NaN-basic.js
( Pass ) Number-constants.js
( Pass ) Number.isSafeInteger.js
( Pass ) Number.js
( Pass ) Number.prototype.js
( Pass ) numeric-literals-basic.js
( Pass ) object-basic.js
Defining new property foo with descriptor { 0, 0, 0, attributes=0 }
Disallow write to non-writable property
Defining new property bar with descriptor { 0, 2, 4, attributes=6 }
Defining new property bar with descriptor { 0, 0, 0, attributes=0 }
Disallow reconfig of non-configurable property
Throwing JavaScript Error: TypeError, Cannot redefine property 'bar'
Defining new property baz with descriptor { 1, 0, 0, attributes=1 }
Defining new property baz with descriptor { 1, 0, 4, attributes=5 }
Reconfigured property baz, new shape says offset is 2 and my storage capacity is 3
( Pass ) Object.defineProperty.js
( Pass ) Object.getOwnPropertyNames.js
( Pass ) Object.getPrototypeOf.js
( Pass ) Object.prototype.constructor.js
( Pass ) Object.prototype.hasOwnProperty.js
( Pass ) Object.prototype.js
( Pass ) Object.prototype.toString.js
( Pass ) parser-unary-associativity.js
( Pass ) String.prototype.charAt.js
( Pass ) String.prototype.indexOf.js
( Pass ) String.prototype.js
( Pass ) String.prototype.padEnd.js
( Pass ) String.prototype.padStart.js
( Pass ) String.prototype.startsWith.js
( Pass ) String.prototype.toLowerCase.js
( Pass ) String.prototype.toString.js
( Pass ) String.prototype.toUpperCase.js
( Pass ) switch-basic-2.js
( Pass ) switch-basic-3.js
( Pass ) switch-basic.js
( Pass ) switch-break.js
( Pass ) ternary-basic.js
( Pass ) throw-basic.js
( Pass ) to-number-basic.js
( Pass ) typeof-basic.js
Throwing JavaScript Error: TypeError, Assignment to constant variable
( Pass ) variable-declaration.js
( Pass ) variable-undefined.js
( Pass ) var-multiple-declarator.js
Throwing JavaScript Error: ReferenceError, 'i' not known
( Pass ) var-scoping.js

Ran 98 tests. Passed: 98, Failed: 0
```

This PR gets rid of all the debug spam between the `( PASS )` lines.