### PR TITLE
Browser: Default page title to URL if no title is provided

### DIFF
--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -197,8 +197,13 @@ int main(int argc, char** argv)
     };
 
     html_widget.on_title_change = [&](auto& title) {
-        s_title = title;
-        window->set_title(String::format("%s - Browser", title.characters()));
+        if (title.is_null()) {
+            s_title = html_widget.main_frame().document()->url().to_string();
+        }
+        else {
+            s_title = title;
+        }
+        window->set_title(String::format("%s - Browser", s_title.characters()));
     };
 
     auto focus_location_box_action = GUI::Action::create("Focus location box", { Mod_Ctrl, Key_L }, [&](auto&) {


### PR DESCRIPTION
If a `<title>` tag is not provided on a web page, the browser will use the URL of the page as the default window title. This prevents **(null)** from appearing in the browser title bar for pages that don't have an explicit title set.