### PR TITLE
LibJS: Check length property of Array.prototype.join in its test

### DIFF
--- a/Libraries/LibJS/Tests/Array.prototype.join.js
+++ b/Libraries/LibJS/Tests/Array.prototype.join.js
@@ -1,7 +1,7 @@
 load("test-common.js");
 
 try {
-    assert(Array.prototype.push.length === 1);
+    assert(Array.prototype.join.length === 1);
 
     assert(["hello", "friends"].join() === "hello,friends");
     assert(["hello", "friends"].join(" ") === "hello friends");


### PR DESCRIPTION
I assume this was copied from the `Array.prototype.push()` test :^)