### PR TITLE
Ports: Add gnuplot port

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -144,6 +144,9 @@ func_defined patch_internal || patch_internal() {
         done
     fi
 }
+func_defined pre_configure || pre_configure() {
+    :
+}
 func_defined configure || configure() {
     run ./"$configscript" --host=i686-pc-serenity $configopts
 }
@@ -242,6 +245,7 @@ do_patch() {
 do_configure() {
     if [ "$useconfigure" = "true" ]; then
         echo "Configuring $port!"
+        pre_configure
         chmod +x "${workdir}"/"$configscript"
         configure
     else

--- a/Ports/gnuplot/package.sh
+++ b/Ports/gnuplot/package.sh
@@ -1,0 +1,15 @@
+#!/bin/bash ../.port_include.sh
+port=gnuplot
+version=5.2.8
+useconfigure=true
+# Note: gnuplot's source code is hosted on SourceForge, but using the GitHub mirror makes downloading a versioned .tar.gz easier.
+files="https://github.com/gnuplot/gnuplot/archive/${version}.tar.gz gnuplot-${version}.tar.gz"
+configopts="--prefix=$SERENITY_ROOT/Root/usr/local --with-readline=builtin"
+
+pre_configure() {
+    run ./prepare
+}
+
+install() {
+    run make install-strip
+}

--- a/Ports/gnuplot/patches/fix-makefile.patch
+++ b/Ports/gnuplot/patches/fix-makefile.patch
@@ -1,0 +1,14 @@
+--- gnuplot-5.2.8/Makefile.am.orig	2020-04-15 12:56:22.001000000 +0100
++++ gnuplot-5.2.8/Makefile.am	2020-04-15 12:58:18.603091197 +0100
+@@ -1,7 +1,10 @@
+ ## Process this file with automake to produce Makefile.in -*-Makefile-*-
+ AUTOMAKE_OPTIONS = foreign
+ 
+-SUBDIRS = config m4 term src docs man demo tutorial share
++# Note: For the SerenityOS port of gnuplot, the following have been removed:
++# docs - segfault during make :/
++# demo - i686-pc-serenity-gcc: error: unrecognized command line option '-rdynamic'
++SUBDIRS = config m4 term src man tutorial share
+ 
+ EXTRA_DIST = BUGS Copyright FAQ.pdf GNUmakefile INSTALL INSTALL.gnu \
+ Makefile.maint PATCHLEVEL PGPKEYS README RELEASE_NOTES \


### PR DESCRIPTION
Obviously we don't support many of the common terminals (i.e. "output targets", http://www.bersch.net/gnuplot-doc/complete-list-of-terminals.html) as we're missing X11, Qt, WxWidgets, Cairo etc. - but at least the "dumb" terminal (ASCII output) and "canvas" terminal (generates JS to plot on a HTML `<canvas>`) are confirmed to be working :^)

![image](https://user-images.githubusercontent.com/19366641/79342905-a19a8f80-7f25-11ea-97cb-1b4dc22138a4.png)
