### PR TITLE
LibWeb: Scroll back to the top when a new page is loaded

### DIFF
--- a/Libraries/LibWeb/HtmlView.cpp
+++ b/Libraries/LibWeb/HtmlView.cpp
@@ -379,6 +379,7 @@ void HtmlView::load(const URL& url)
         [this, url](auto error) {
             load_error_page(url, error);
         });
+    this->scroll_to_top();
 }
 
 void HtmlView::load_error_page(const URL& failed_url, const String& error)


### PR DESCRIPTION
Noticed while playing with the browser that this behaviour that I expected was missing and couldn't think of any reason why it shouldn't be implemented.