### PR TITLE
LibC: Implement getprotoent() family of functions

### DIFF
--- a/Base/etc/protocols
+++ b/Base/etc/protocols
@@ -1,0 +1,64 @@
+# Internet (IP) protocols
+#
+# Updated from http://www.iana.org/assignments/protocol-numbers and other
+# sources.
+# New protocols will be added on request if they have been officially
+# assigned by IANA and are not historical.
+# If you need a huge list of used numbers please install the nmap package.
+
+ip	0	IP		# internet protocol, pseudo protocol number
+hopopt	0	HOPOPT		# IPv6 Hop-by-Hop Option [RFC1883]
+icmp	1	ICMP		# internet control message protocol
+igmp	2	IGMP		# Internet Group Management
+ggp	3	GGP		# gateway-gateway protocol
+ipencap	4	IP-ENCAP	# IP encapsulated in IP (officially ``IP'')
+st	5	ST		# ST datagram mode
+tcp	6	TCP		# transmission control protocol
+egp	8	EGP		# exterior gateway protocol
+igp	9	IGP		# any private interior gateway (Cisco)
+pup	12	PUP		# PARC universal packet protocol
+udp	17	UDP		# user datagram protocol
+hmp	20	HMP		# host monitoring protocol
+xns-idp	22	XNS-IDP		# Xerox NS IDP
+rdp	27	RDP		# "reliable datagram" protocol
+iso-tp4	29	ISO-TP4		# ISO Transport Protocol class 4 [RFC905]
+dccp	33	DCCP		# Datagram Congestion Control Prot. [RFC4340]
+xtp	36	XTP		# Xpress Transfer Protocol
+ddp	37	DDP		# Datagram Delivery Protocol
+idpr-cmtp 38	IDPR-CMTP	# IDPR Control Message Transport
+ipv6	41	IPv6		# Internet Protocol, version 6
+ipv6-route 43	IPv6-Route	# Routing Header for IPv6
+ipv6-frag 44	IPv6-Frag	# Fragment Header for IPv6
+idrp	45	IDRP		# Inter-Domain Routing Protocol
+rsvp	46	RSVP		# Reservation Protocol
+gre	47	GRE		# General Routing Encapsulation
+esp	50	IPSEC-ESP	# Encap Security Payload [RFC2406]
+ah	51	IPSEC-AH	# Authentication Header [RFC2402]
+skip	57	SKIP		# SKIP
+ipv6-icmp 58	IPv6-ICMP	# ICMP for IPv6
+ipv6-nonxt 59	IPv6-NoNxt	# No Next Header for IPv6
+ipv6-opts 60	IPv6-Opts	# Destination Options for IPv6
+rspf	73	RSPF CPHB	# Radio Shortest Path First (officially CPHB)
+vmtp	81	VMTP		# Versatile Message Transport
+eigrp	88	EIGRP		# Enhanced Interior Routing Protocol (Cisco)
+ospf	89	OSPFIGP		# Open Shortest Path First IGP
+ax.25	93	AX.25		# AX.25 frames
+ipip	94	IPIP		# IP-within-IP Encapsulation Protocol
+etherip	97	ETHERIP		# Ethernet-within-IP Encapsulation [RFC3378]
+encap	98	ENCAP		# Yet Another IP encapsulation [RFC1241]
+#	99			# any private encryption scheme
+pim	103	PIM		# Protocol Independent Multicast
+ipcomp	108	IPCOMP		# IP Payload Compression Protocol
+vrrp	112	VRRP		# Virtual Router Redundancy Protocol [RFC5798]
+l2tp	115	L2TP		# Layer Two Tunneling Protocol [RFC2661]
+isis	124	ISIS		# IS-IS over IPv4
+sctp	132	SCTP		# Stream Control Transmission Protocol
+fc	133	FC		# Fibre Channel
+mobility-header 135 Mobility-Header # Mobility Support for IPv6 [RFC3775]
+udplite	136	UDPLite		# UDP-Lite [RFC3828]
+mpls-in-ip 137	MPLS-in-IP	# MPLS-in-IP [RFC4023]
+manet	138			# MANET Protocols [RFC5498]
+hip	139	HIP		# Host Identity Protocol
+shim6	140	Shim6		# Shim6 Protocol [RFC5533]
+wesp	141	WESP		# Wrapped Encapsulating Security Payload
+rohc	142	ROHC		# Robust Header Compression

--- a/Libraries/LibC/netdb.h
+++ b/Libraries/LibC/netdb.h
@@ -55,6 +55,19 @@ struct servent* getservbyname(const char* name, const char* protocol);
 struct servent* getservbyport(int port, const char* protocol);
 void setservent(int stay_open);
 void endservent();
+
+struct protoent {
+    char* p_name;
+    char** p_aliases;
+    int p_proto;
+};
+
+void endprotoent();
+struct protoent* getprotobyname(const char* name);
+struct protoent* getprotobynumber(int proto);
+struct protoent* getprotoent();
+void setprotoent(int stay_open);
+
 extern int h_errno;
 
 #define HOST_NOT_FOUND 101


### PR DESCRIPTION
This pull request implements the protocol entry family of functions as defined by the [manual](http://man7.org/linux/man-pages/man3/getprotoent.3.html) and also fixes a bug in the way in which aliases were being read in the services entry family of functions. The aliases were not null terminated in their ByteBuffer representation, so this was remedied by appending the null terminating character before inserting the aliases into their list. 

Test program in Userland to test both service and protocol entry retrieval:

```

#include <netdb.h>
#include <AK/LogStream.h>
int main() 
{
    struct servent* test_s;
    test_s = getservent();
    
    test_s = getservbyname("zserv", "udp");
    dbg() <<  test_s->s_name << " " << test_s->s_port << " " << test_s->s_proto << "\n";
    
    //should be fatserv 347/tcp
    test_s = getservent();
    dbg() <<  test_s->s_name << " " << test_s->s_port << " " << test_s->s_proto << "\n";

    //doing getservbyport, earlier than 347 to test_s reset, should also have aliases
    test_s = getservbyport(88, "tcp");
    dbg() <<  test_s->s_name << " " << test_s->s_port << " " << test_s->s_proto << " "
    << test_s->s_aliases[0] << " " << test_s->s_aliases[1] << " " << test_s->s_aliases[2] << "\n";

    //test_sing that sctp is found:
    test_s = getservbyname("amqp", "sctp");
    dbg() <<  test_s->s_name << " " << test_s->s_port << " " << test_s->s_proto << "\n";

    //test_sing that weird spaced services are found ok
    test_s = getservbyname("afs3-fileserver", "udp");
    dbg() <<  test_s->s_name << " " << test_s->s_port << " " << test_s->s_proto << " " << test_s->s_aliases[0] << "\n";
    //test_sing if no entry found:
    test_s = getservbyname("fake", "fake");
    dbg() << "test_s is null: " << (test_s == nullptr);

    struct protoent* test_p;

    test_p = getprotobyname("rdp");
    dbg() <<  test_p->p_name << " " << test_p->p_proto << " " << test_p->p_aliases[0] << "\n";
    
    //should be iso-tp4 29 ISO-TP4
    test_p = getprotoent();
    dbg() <<  test_p->p_name << " " << test_p->p_proto << " " << test_p->p_aliases[0] << "\n";

    //doing getprotobynumber, earlier than 29 to test_p reset
    test_p = getprotobynumber(88);
    dbg() <<  test_p->p_name << " " << test_p->p_proto << " " << test_p->p_aliases[0] << "\n";
    
    //test_ping weirdly spaced protocols
    test_p = getprotobyname("mobility-header");
    dbg() <<  test_p->p_name << " " << test_p->p_proto << " " << test_p->p_aliases[0] << "\n";

    //test_ping if no entry found:
    test_p = getprotobyname("fake");
    dbg() << "test_p is null: " << (test_p == nullptr);

    test_p = getprotobynumber(5000);
    dbg() << "test_p is null: " << (test_p == nullptr);
}

```

[related issue](https://github.com/SerenityOS/serenity/issues/191)