### PR TITLE
ProtocolServer: did_finish_download: Do not create 0 byte shared buffer

### DIFF
--- a/Servers/ProtocolServer/PSClientConnection.cpp
+++ b/Servers/ProtocolServer/PSClientConnection.cpp
@@ -79,7 +79,7 @@ OwnPtr<Messages::ProtocolServer::StopDownloadResponse> PSClientConnection::handl
 void PSClientConnection::did_finish_download(Badge<Download>, Download& download, bool success)
 {
     RefPtr<SharedBuffer> buffer;
-    if (success && !download.payload().is_null()) {
+    if (success && download.payload().size() > 0 && !download.payload().is_null()) {
         buffer = SharedBuffer::create_with_size(download.payload().size());
         memcpy(buffer->data(), download.payload().data(), download.payload().size());
         buffer->seal();


### PR DESCRIPTION
`PSClientConnection::did_finish_download()` no longer tries to create
a zero byte shared buffer when `download.payload().data()` is zero
bytes in length.

Fixes #1821