### PR TITLE
Shell: Explicitly check if command is a directory

### DIFF
--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -885,6 +885,12 @@ static int run_command(const String& cmd)
             if (handle_builtin(argv.size() - 1, argv.data(), retval))
                 return retval;
 
+            struct stat st;
+            if (stat(argv[0], &st) == 0 && S_ISDIR(st.st_mode)) {
+                fprintf(stderr, "Shell: %s: Is a directory\n", argv[0]);
+                return 126;
+            }
+
             pid_t child = fork();
             if (!child) {
                 setpgid(0, 0);


### PR DESCRIPTION
This is a bit nicer than getting "Exec format error" after trying to `execvp()` a directory.

[Return code in that case is 126.](https://pubs.opengroup.org/onlinepubs/9699919799//utilities/V3_chap02.html#tag_18_08_02)