### PR TITLE
3D Cube demo

### DIFF
--- a/Demos/Cube/Cube.cpp
+++ b/Demos/Cube/Cube.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibCore/ElapsedTimer.h>
+#include <LibGUI/Application.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/Painter.h>
+#include <LibGUI/Widget.h>
+#include <LibGUI/Window.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Matrix4x4.h>
+#include <LibGfx/Vector3.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+const int WIDTH = 200;
+const int HEIGHT = 200;
+
+class Cube final : public GUI::Widget {
+    C_OBJECT(Cube)
+public:
+    virtual ~Cube() override;
+    void set_stat_label(RefPtr<GUI::Label> l) { m_stats = l; };
+
+private:
+    Cube();
+    RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<GUI::Label> m_stats;
+
+    virtual void paint_event(GUI::PaintEvent&) override;
+    virtual void timer_event(Core::TimerEvent&) override;
+
+    int m_accumulated_time;
+    int m_cycles;
+    int m_phase;
+};
+
+Cube::Cube()
+{
+    m_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::RGBA32, { WIDTH, HEIGHT });
+
+    m_accumulated_time = 0;
+    m_cycles = 0;
+    m_phase = 0;
+
+    stop_timer();
+    start_timer(20);
+}
+
+Cube::~Cube()
+{
+}
+
+void Cube::paint_event(GUI::PaintEvent& event)
+{
+    GUI::Painter painter(*this);
+    painter.add_clip_rect(event.rect());
+
+    /* Blit it! */
+    painter.draw_scaled_bitmap(event.rect(), *m_bitmap, m_bitmap->rect());
+}
+
+void Cube::timer_event(Core::TimerEvent&)
+{
+    Core::ElapsedTimer timer;
+    timer.start();
+
+    const FloatVector3 vertices[8] {
+        { -1, -1, -1 },
+        { -1, 1, -1 },
+        { 1, 1, -1 },
+        { 1, -1, -1 },
+        { -1, -1, 1 },
+        { -1, 1, 1 },
+        { 1, 1, 1 },
+        { 1, -1, 1 },
+    };
+
+#define QUAD(a, b, c, d) a, b, c, c, d, a
+
+    const int indices[] {
+        QUAD(0, 1, 2, 3),
+        QUAD(7, 6, 5, 4),
+        QUAD(4, 5, 1, 0),
+        QUAD(3, 2, 6, 7),
+        QUAD(1, 5, 6, 2),
+        QUAD(0, 3, 7, 4),
+    };
+
+    const Color colors[] {
+        Color::Red,
+        Color::Red,
+        Color::Green,
+        Color::Green,
+        Color::Blue,
+        Color::Blue,
+        Color::Magenta,
+        Color::Magenta,
+        Color::White,
+        Color::White,
+        Color::Yellow,
+        Color::Yellow,
+    };
+
+    FloatVector3 transformed_vertices[8];
+
+    static float angle = 0;
+    angle += 0.02f;
+
+    auto matrix = FloatMatrix4x4::translate(FloatVector3(0, 0, 1.5f))
+        * FloatMatrix4x4::rotate(FloatVector3(1, 0, 0), angle * 1.17356641f)
+        * FloatMatrix4x4::rotate(FloatVector3(0, 1, 0), angle * 0.90533273f)
+        * FloatMatrix4x4::rotate(FloatVector3(0, 0, 1), angle);
+
+    for (int i = 0; i < 8; i++) {
+        transformed_vertices[i] = matrix.transform_point(vertices[i]);
+    }
+
+    GUI::Painter painter(*m_bitmap);
+    painter.fill_rect_with_gradient(Gfx::Orientation::Vertical, painter.clip_rect(), Gfx::Color::White, Gfx::Color::Blue);
+
+    auto to_point = [](const FloatVector3& v) {
+        return Gfx::Point(v.x(), v.y());
+    };
+
+    for (size_t i = 0; i < sizeof(indices) / sizeof(indices[0]) / 3; i++) {
+        auto a = transformed_vertices[indices[i * 3]];
+        auto b = transformed_vertices[indices[i * 3 + 1]];
+        auto c = transformed_vertices[indices[i * 3 + 2]];
+        auto normal = (b - a).cross(c - a);
+        normal.normalize();
+
+        // Perspective projection
+        a.set_x(WIDTH / 2 + a.x() / (1 + a.z() * 0.35) * WIDTH / 3);
+        a.set_y(HEIGHT / 2 - a.y() / (1 + a.z() * 0.35) * WIDTH / 3);
+        b.set_x(WIDTH / 2 + b.x() / (1 + b.z() * 0.35) * WIDTH / 3);
+        b.set_y(HEIGHT / 2 - b.y() / (1 + b.z() * 0.35) * WIDTH / 3);
+        c.set_x(WIDTH / 2 + c.x() / (1 + c.z() * 0.35) * WIDTH / 3);
+        c.set_y(HEIGHT / 2 - c.y() / (1 + c.z() * 0.35) * WIDTH / 3);
+
+        float winding = (b.x() - a.x()) * (c.y() - a.y()) - (b.y() - a.y()) * (c.x() - a.x());
+        if (winding < 0)
+            continue;
+
+        float shade = 0.5f + normal.y() * 0.5f;
+        auto color = colors[i];
+        color.set_red(color.red() * shade);
+        color.set_green(color.green() * shade);
+        color.set_blue(color.blue() * shade);
+
+        painter.draw_triangle(to_point(a), to_point(b), to_point(c), color);
+    }
+
+    if ((m_cycles % 50) == 0) {
+        dbgprintf("%d total cycles. finished 50 in %d ms, avg %d ms\n", m_cycles, m_accumulated_time, m_accumulated_time / 50);
+        m_stats->set_text(String::format("%d ms", m_accumulated_time / 50));
+        m_accumulated_time = 0;
+    }
+
+    update();
+
+    m_accumulated_time += timer.elapsed();
+    m_cycles++;
+}
+
+int main(int argc, char** argv)
+{
+    GUI::Application app(argc, argv);
+
+    auto window = GUI::Window::construct();
+    window->set_double_buffering_enabled(true);
+    window->set_title("Cube");
+    window->set_resizable(false);
+    window->set_rect(100, 100, WIDTH, HEIGHT);
+
+    auto& cube = window->set_main_widget<Cube>();
+
+    auto& time = cube.add<GUI::Label>();
+    time.set_relative_rect({ 0, 4, 40, 10 });
+    time.move_by({ window->width() - time.width(), 0 });
+    time.set_foreground_color(Color::from_rgb(0x222222));
+    cube.set_stat_label(time);
+
+    window->show();
+    window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-demo.png"));
+
+    return app.exec();
+}

--- a/Demos/Cube/Makefile
+++ b/Demos/Cube/Makefile
@@ -1,0 +1,8 @@
+OBJS = \
+    Cube.o
+
+PROGRAM = Cube
+
+LIB_DEPS = GUI IPC Gfx Core
+
+include ../../Makefile.common

--- a/Kernel/build-root-filesystem.sh
+++ b/Kernel/build-root-filesystem.sh
@@ -147,6 +147,7 @@ cp ../Applications/Debugger/Debugger mnt/bin/sdb
 cp ../Games/Solitaire/Solitaire mnt/bin/Solitaire
 cp ../Demos/HelloWorld/HelloWorld mnt/bin/HelloWorld
 cp ../Demos/WidgetGallery/WidgetGallery mnt/bin/WidgetGallery
+cp ../Demos/Cube/Cube mnt/bin/Cube
 cp ../Demos/Fire/Fire mnt/bin/Fire
 cp ../Demos/DynamicLink/LinkDemo/LinkDemo mnt/bin/LinkDemo
 cp ../DevTools/HackStudio/HackStudio mnt/bin/HackStudio

--- a/Libraries/LibGfx/Matrix4x4.h
+++ b/Libraries/LibGfx/Matrix4x4.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibGfx/Vector3.h>
+#include <math.h>
+
+namespace Gfx {
+
+template<typename T>
+class Matrix4x4 final {
+public:
+    Matrix4x4() = default;
+    Matrix4x4(T _11, T _12, T _13, T _14,
+        T _21, T _22, T _23, T _24,
+        T _31, T _32, T _33, T _34,
+        T _41, T _42, T _43, T _44)
+        : m_elements {
+            _11, _12, _13, _14,
+            _21, _22, _23, _24,
+            _31, _32, _33, _34,
+            _41, _42, _43, _44
+        }
+    {
+    }
+
+    Matrix4x4 operator*(const Matrix4x4& other) const
+    {
+        Matrix4x4 product;
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                product.m_elements[i][j] = m_elements[0][j] * other.m_elements[i][0]
+                    + m_elements[1][j] * other.m_elements[i][1]
+                    + m_elements[2][j] * other.m_elements[i][2]
+                    + m_elements[3][j] * other.m_elements[i][3];
+            }
+        }
+        return product;
+    }
+
+    Vector3<T> transform_point(const Vector3<T>& p) const
+    {
+        return Vector3<T>(
+            p.x() * m_elements[0][0] + p.y() * m_elements[1][0] + p.z() * m_elements[2][0] + m_elements[3][0],
+            p.x() * m_elements[0][1] + p.y() * m_elements[1][1] + p.z() * m_elements[2][1] + m_elements[3][1],
+            p.x() * m_elements[0][2] + p.y() * m_elements[1][2] + p.z() * m_elements[2][2] + m_elements[3][2]);
+    }
+
+    static Matrix4x4 translate(const Vector3<T>& p)
+    {
+        return Matrix4x4(
+            1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            p.x(), p.y(), p.z(), 1);
+    }
+
+    static Matrix4x4 scale(const Vector3<T>& s)
+    {
+        return Matrix4x4(
+            s.x(), 0, 0, 0,
+            0, s.y(), 0, 0,
+            0, 0, s.z(), 0,
+            0, 0, 0, 1);
+    }
+
+    static Matrix4x4 rotate(const Vector3<T>& axis, T angle)
+    {
+        T c = cos(angle);
+        T s = sin(angle);
+        T t = 1 - c;
+        T x = axis.x();
+        T y = axis.y();
+        T z = axis.z();
+
+        return Matrix4x4(
+            t * x * x + c, t * x * y - z * s, t * x * z + y * s, 0,
+            t * x * y + z * s, t * y * y + c, t * y * z - x * s, 0,
+            t * x * z - y * s, t * y * z + x * s, t * z * z + c, 0,
+            0, 0, 0, 1);
+    }
+
+private:
+    T m_elements[4][4];
+};
+
+typedef Matrix4x4<float> FloatMatrix4x4;
+typedef Matrix4x4<double> DoubleMatrix4x4;
+
+}
+
+using Gfx::DoubleMatrix4x4;
+using Gfx::FloatMatrix4x4;
+using Gfx::Matrix4x4;

--- a/Libraries/LibGfx/Painter.h
+++ b/Libraries/LibGfx/Painter.h
@@ -51,6 +51,7 @@ public:
     void draw_rect(const Rect&, Color, bool rough = false);
     void draw_bitmap(const Point&, const CharacterBitmap&, Color = Color());
     void draw_bitmap(const Point&, const GlyphBitmap&, Color = Color());
+    void draw_triangle(const Point&, const Point&, const Point&, Color);
     void draw_ellipse_intersecting(const Rect&, Color, int thickness = 1);
     void set_pixel(const Point&, Color);
     void draw_line(const Point&, const Point&, Color, int thickness = 1, bool dotted = false);

--- a/Libraries/LibGfx/Vector3.h
+++ b/Libraries/LibGfx/Vector3.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <math.h>
+
+namespace Gfx {
+template<typename T>
+class Vector3 {
+public:
+    Vector3() = default;
+    Vector3(T x, T y, T z)
+        : m_x(x)
+        , m_y(y)
+        , m_z(z)
+    {
+    }
+
+    T x() const { return m_x; }
+    T y() const { return m_y; }
+    T z() const { return m_z; }
+
+    void set_x(T value) { m_x = value; }
+    void set_y(T value) { m_y = value; }
+    void set_z(T value) { m_z = value; }
+
+    Vector3 operator+(const Vector3& other) const
+    {
+        return Vector3(m_x + other.m_x, m_y + other.m_y, m_z + other.m_z);
+    }
+
+    Vector3 operator-(const Vector3& other) const
+    {
+        return Vector3(m_x - other.m_x, m_y - other.m_y, m_z - other.m_z);
+    }
+
+    Vector3 operator*(T f) const
+    {
+        return Vector3(m_x * f, m_y * f, m_z * f);
+    }
+
+    Vector3 operator/(T f) const
+    {
+        return Vector3(m_x / f, m_y / f, m_z / f);
+    }
+
+    T dot(const Vector3& other) const
+    {
+        return m_x * other.m_x + m_y * other.m_y + m_z * other.m_z;
+    }
+
+    Vector3 cross(const Vector3& other) const
+    {
+        return Vector3(
+            m_y * other.m_z - m_z * other.m_y,
+            m_z * other.m_x - m_x * other.m_z,
+            m_x * other.m_y - m_y * other.m_x);
+    }
+
+    Vector3 normalized() const
+    {
+        T inv_length = 1 / length();
+        return *this * inv_length;
+    }
+
+    void normalize()
+    {
+        T inv_length = 1 / length();
+        m_x *= inv_length;
+        m_y *= inv_length;
+        m_z *= inv_length;
+    }
+
+    T length() const
+    {
+        return sqrt(m_x * m_x + m_y * m_y + m_z * m_z);
+    }
+
+private:
+    T m_x;
+    T m_y;
+    T m_z;
+};
+
+typedef Vector3<float> FloatVector3;
+typedef Vector3<double> DoubleVector3;
+
+}
+
+using Gfx::DoubleVector3;
+using Gfx::FloatVector3;
+using Gfx::Vector3;


### PR DESCRIPTION
Renders a spinning 3D cube. Demonstrates the Gfx::Painter::draw_triangle() method that is also included in this PR.

![cube](https://user-images.githubusercontent.com/2094371/79618730-2e527280-810b-11ea-8863-5c50f8549df9.gif)

The vector/matrix headers could be extracted in the future and shared with other parts of Serenity.
