### PR TITLE
Add Browser to QuickLaunch

### DIFF
--- a/Base/home/anon/Taskbar.ini
+++ b/Base/home/anon/Taskbar.ini
@@ -1,4 +1,5 @@
 [QuickLaunch]
+Browser=Browser.af
 SystemMonitor=SystemMonitor.af
 Terminal=Terminal.af
 FileManager=FileManager.af


### PR DESCRIPTION
With the increased focus on development of LibJS and LibWeb, it seems reasonable to add the `Browser` to the `QuickLaunch` tray.

Edit: Granted, using the QuickLaunch is slower than ctrl+shift+n, "br", enter, but that leaves a useless terminal window. As a desktop OS, Serenity should include the `Browser` in the QuickLaunch, in line with most other desktop OS.
