### PR TITLE
Read-write lock, kind of

### DIFF
--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -168,7 +168,7 @@ ByteBuffer FileDescription::read_entire_file()
 
 ssize_t FileDescription::get_dir_entries(u8* buffer, ssize_t size)
 {
-    LOCKER(m_lock);
+    LOCKER(m_lock, Lock::Mode::Shared);
     if (!is_directory())
         return -ENOTDIR;
 

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -153,12 +153,12 @@ private:
 
     u32 m_file_flags { 0 };
 
-    bool m_readable { false };
-    bool m_writable { false };
-    bool m_is_blocking { true };
-    bool m_is_directory { false };
-    bool m_should_append { false };
-    bool m_direct { false };
+    bool m_readable : 1 { false };
+    bool m_writable : 1 { false };
+    bool m_is_blocking : 1 { true };
+    bool m_is_directory : 1 { false };
+    bool m_should_append : 1 { false };
+    bool m_direct : 1 { false };
     FIFO::Direction m_fifo_direction { FIFO::Direction::Neither };
 
     Lock m_lock { "FileDescription" };

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -491,7 +491,7 @@ Optional<KBuffer> procfs$net_arp(InodeIdentifier)
 {
     KBufferBuilder builder;
     JsonArraySerializer array { builder };
-    LOCKER(arp_table().lock());
+    LOCKER(arp_table().lock(), Lock::Mode::Shared);
     for (auto& it : arp_table().resource()) {
         auto obj = array.add_object();
         obj.add("mac_address", it.value.to_string());
@@ -983,7 +983,7 @@ static ByteBuffer read_sys_bool(InodeIdentifier inode_id)
     auto buffer = ByteBuffer::create_uninitialized(2);
     auto* lockable_bool = reinterpret_cast<Lockable<bool>*>(variable.address);
     {
-        LOCKER(lockable_bool->lock());
+        LOCKER(lockable_bool->lock(), Lock::Mode::Shared);
         buffer[0] = lockable_bool->resource() ? '1' : '0';
     }
     buffer[1] = '\n';
@@ -1013,7 +1013,7 @@ static ByteBuffer read_sys_string(InodeIdentifier inode_id)
     ASSERT(variable.type == SysVariable::Type::String);
 
     auto* lockable_string = reinterpret_cast<Lockable<String>*>(variable.address);
-    LOCKER(lockable_string->lock());
+    LOCKER(lockable_string->lock(), Lock::Mode::Shared);
     return lockable_string->resource().to_byte_buffer();
 }
 

--- a/Kernel/FileSystem/TmpFS.cpp
+++ b/Kernel/FileSystem/TmpFS.cpp
@@ -81,7 +81,7 @@ unsigned TmpFS::next_inode_index()
 
 RefPtr<Inode> TmpFS::get_inode(InodeIdentifier identifier) const
 {
-    LOCKER(m_lock);
+    LOCKER(m_lock, Lock::Mode::Shared);
     ASSERT(identifier.fsid() == fsid());
 
     auto it = m_inodes.find(identifier.index());
@@ -161,14 +161,14 @@ NonnullRefPtr<TmpFSInode> TmpFSInode::create_root(TmpFS& fs)
 
 InodeMetadata TmpFSInode::metadata() const
 {
-    LOCKER(m_lock);
+    LOCKER(m_lock, Lock::Mode::Shared);
 
     return m_metadata;
 }
 
 bool TmpFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntry&)> callback) const
 {
-    LOCKER(m_lock);
+    LOCKER(m_lock, Lock::Mode::Shared);
 
     if (!is_directory())
         return false;
@@ -183,7 +183,7 @@ bool TmpFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>
 
 ssize_t TmpFSInode::read_bytes(off_t offset, ssize_t size, u8* buffer, FileDescription*) const
 {
-    LOCKER(m_lock);
+    LOCKER(m_lock, Lock::Mode::Shared);
     ASSERT(!is_directory());
     ASSERT(size >= 0);
     ASSERT(offset >= 0);
@@ -247,7 +247,7 @@ ssize_t TmpFSInode::write_bytes(off_t offset, ssize_t size, const u8* buffer, Fi
 
 RefPtr<Inode> TmpFSInode::lookup(StringView name)
 {
-    LOCKER(m_lock);
+    LOCKER(m_lock, Lock::Mode::Shared);
     ASSERT(is_directory());
 
     if (name == ".")
@@ -263,7 +263,7 @@ RefPtr<Inode> TmpFSInode::lookup(StringView name)
 
 size_t TmpFSInode::directory_entry_count() const
 {
-    LOCKER(m_lock);
+    LOCKER(m_lock, Lock::Mode::Shared);
     ASSERT(is_directory());
     return 2 + m_children.size();
 }

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -45,9 +45,9 @@ Lockable<InlineLinkedList<LocalSocket>>& LocalSocket::all_sockets()
     return *s_list;
 }
 
-void LocalSocket::for_each(Function<void(LocalSocket&)> callback)
+void LocalSocket::for_each(Function<void(const LocalSocket&)> callback)
 {
-    LOCKER(all_sockets().lock());
+    LOCKER(all_sockets().lock(), Lock::Mode::Shared);
     for (auto& socket : all_sockets().resource())
         callback(socket);
 }

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -42,7 +42,7 @@ public:
     static KResultOr<NonnullRefPtr<Socket>> create(int type);
     virtual ~LocalSocket() override;
 
-    static void for_each(Function<void(LocalSocket&)>);
+    static void for_each(Function<void(const LocalSocket&)>);
 
     StringView socket_path() const;
     String absolute_path(const FileDescription& description) const override;

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -38,9 +38,9 @@
 
 namespace Kernel {
 
-void TCPSocket::for_each(Function<void(TCPSocket&)> callback)
+void TCPSocket::for_each(Function<void(const TCPSocket&)> callback)
 {
-    LOCKER(sockets_by_tuple().lock());
+    LOCKER(sockets_by_tuple().lock(), Lock::Mode::Shared);
     for (auto& it : sockets_by_tuple().resource())
         callback(*it.value);
 }
@@ -80,7 +80,7 @@ Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>& TCPSocket::sockets_by_tuple()
 
 RefPtr<TCPSocket> TCPSocket::from_tuple(const IPv4SocketTuple& tuple)
 {
-    LOCKER(sockets_by_tuple().lock());
+    LOCKER(sockets_by_tuple().lock(), Lock::Mode::Shared);
 
     auto exact_match = sockets_by_tuple().resource().get(tuple);
     if (exact_match.has_value())
@@ -230,7 +230,7 @@ void TCPSocket::send_outgoing_packets()
 
     auto now = kgettimeofday();
 
-    LOCKER(m_not_acked_lock);
+    LOCKER(m_not_acked_lock, Lock::Mode::Shared);
     for (auto& packet : m_not_acked) {
         timeval diff;
         timeval_sub(packet.tx_time, now, diff);

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -37,7 +37,7 @@ namespace Kernel {
 class TCPSocket final : public IPv4Socket
     , public Weakable<TCPSocket> {
 public:
-    static void for_each(Function<void(TCPSocket&)>);
+    static void for_each(Function<void(const TCPSocket&)>);
     static NonnullRefPtr<TCPSocket> create(int protocol);
     virtual ~TCPSocket() override;
 

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -34,9 +34,9 @@
 
 namespace Kernel {
 
-void UDPSocket::for_each(Function<void(UDPSocket&)> callback)
+void UDPSocket::for_each(Function<void(const UDPSocket&)> callback)
 {
-    LOCKER(sockets_by_port().lock());
+    LOCKER(sockets_by_port().lock(), Lock::Mode::Shared);
     for (auto it : sockets_by_port().resource())
         callback(*it.value);
 }
@@ -53,7 +53,7 @@ SocketHandle<UDPSocket> UDPSocket::from_port(u16 port)
 {
     RefPtr<UDPSocket> socket;
     {
-        LOCKER(sockets_by_port().lock());
+        LOCKER(sockets_by_port().lock(), Lock::Mode::Shared);
         auto it = sockets_by_port().resource().find(port);
         if (it == sockets_by_port().resource().end())
             return {};

--- a/Kernel/Net/UDPSocket.h
+++ b/Kernel/Net/UDPSocket.h
@@ -36,7 +36,7 @@ public:
     virtual ~UDPSocket() override;
 
     static SocketHandle<UDPSocket> from_port(u16);
-    static void for_each(Function<void(UDPSocket&)>);
+    static void for_each(Function<void(const UDPSocket&)>);
 
 private:
     explicit UDPSocket(int protocol);

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -704,7 +704,7 @@ int Process::sys$gethostname(char* buffer, ssize_t size)
         return -EINVAL;
     if (!validate_write(buffer, size))
         return -EFAULT;
-    LOCKER(*s_hostname_lock);
+    LOCKER(*s_hostname_lock, Lock::Mode::Shared);
     if ((size_t)size < (s_hostname->length() + 1))
         return -ENAMETOOLONG;
     copy_to_user(buffer, s_hostname->characters(), s_hostname->length() + 1);
@@ -2157,7 +2157,7 @@ int Process::sys$uname(utsname* buf)
     REQUIRE_PROMISE(stdio);
     if (!validate_write_typed(buf))
         return -EFAULT;
-    LOCKER(*s_hostname_lock);
+    LOCKER(*s_hostname_lock, Lock::Mode::Shared);
     if (s_hostname->length() + 1 > sizeof(utsname::nodename))
         return -ENAMETOOLONG;
     copy_to_user(buf->sysname, "SerenityOS", 11);

--- a/Kernel/SharedBuffer.cpp
+++ b/Kernel/SharedBuffer.cpp
@@ -39,7 +39,7 @@ Lockable<HashMap<int, NonnullOwnPtr<SharedBuffer>>>& shared_buffers()
 
 void SharedBuffer::sanity_check(const char* what)
 {
-    LOCKER(shared_buffers().lock());
+    LOCKER(shared_buffers().lock(), Lock::Mode::Shared);
 
     unsigned found_refs = 0;
     for (const auto& ref : m_refs)
@@ -56,7 +56,7 @@ void SharedBuffer::sanity_check(const char* what)
 
 bool SharedBuffer::is_shared_with(pid_t peer_pid)
 {
-    LOCKER(shared_buffers().lock());
+    LOCKER(shared_buffers().lock(), Lock::Mode::Shared);
     if (m_global)
         return true;
     for (auto& ref : m_refs) {


### PR DESCRIPTION
A `Kernel::Lock` can now be locked in either _exclusive_ (the default) or _shared_ mode. Multiple threads can hold the same lock in shared mode at one time, but if any thread holds the lock in exclusive mode, no other thread can hold it at the same time in either mode.

Typically, the shared mode is used when reading a lockable resource, and exclusive mode when modifying it. This way, multiple threads can read the same resource without blocking each other, but while still blocking those threads that want to modify it.

The `Lock` remains _reentrant_: if a thread already holds a lock, it can claim it again, and the second time will succeed immediately (without blocking further), except when trying to "upgrade" a shared lock to a unique lock (which is not supported and will deadlock). If you hold a lock in exclusive mode, you can claim it again in either mode (the mode makes no difference in this case, you get the lock back immediately either way).

Note that `m_times_locked` is used for both "the reentrancy level" and "readers count", because they're essentially the same thing: how many times the lock has been locked; when it's unlocked back this many times, it actually becomes unlocked.

Caveat: no fairness is guaranteed, which means constantly arriving readers can starve writers.

The primary motivation for read-write locks was to make it possible for multiple threads to resolve paths (exercising Ext2FS as it's used for the root file system mount) without them blocking each other. This PR only prepares infrastructure for that, but does _not_ convert Ext2FS to use shared locking where appropriate, because I'm afraid to break it.