### PR TITLE
Demos: Add Screensaver demo

### DIFF
--- a/Demos/Screensaver/Makefile
+++ b/Demos/Screensaver/Makefile
@@ -1,0 +1,8 @@
+OBJS = \
+    Screensaver.o
+
+PROGRAM = Screensaver
+
+LIB_DEPS = GUI IPC Gfx Core
+
+include ../../Makefile.common

--- a/Demos/Screensaver/Screensaver.cpp
+++ b/Demos/Screensaver/Screensaver.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibCore/ElapsedTimer.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGUI/Application.h>
+#include <LibGUI/Action.h>
+#include <LibGUI/Event.h>
+#include <LibGUI/Painter.h>
+#include <LibGUI/Widget.h>
+#include <LibGUI/Window.h>
+#include <math.h>
+#include <stdio.h>
+
+#define WIDTH 64
+#define HEIGHT 48
+#define INTERVAL 10000
+
+class Screensaver final : public GUI::Widget {
+    C_OBJECT(Screensaver)
+public:
+    virtual ~Screensaver() override;
+
+private:
+    Screensaver();
+    RefPtr<Gfx::Bitmap> m_bitmap;
+
+    virtual void paint_event(GUI::PaintEvent&) override;
+    virtual void timer_event(Core::TimerEvent&) override;
+    virtual void keydown_event(GUI::KeyEvent&) override;
+    virtual void mousedown_event(GUI::MouseEvent& event) override;
+    virtual void mousemove_event(GUI::MouseEvent& event) override;
+};
+
+Screensaver::Screensaver()
+{
+    m_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::RGB32, { WIDTH, HEIGHT });
+    stop_timer();
+    start_timer(INTERVAL);
+}
+
+Screensaver::~Screensaver()
+{
+}
+
+void Screensaver::mousemove_event(GUI::MouseEvent&)
+{
+    ::exit(0);
+}
+
+void Screensaver::mousedown_event(GUI::MouseEvent&)
+{
+    ::exit(0);
+}
+void Screensaver::keydown_event(GUI::KeyEvent&)
+{
+    ::exit(0);
+}
+
+void Screensaver::paint_event(GUI::PaintEvent& event)
+{
+    GUI::Painter painter(*this);
+    painter.draw_scaled_bitmap(event.rect(), *m_bitmap, m_bitmap->rect());
+}
+
+void Screensaver::timer_event(Core::TimerEvent&)
+{
+    Core::ElapsedTimer timer;
+    timer.start();
+
+    const Color colors[] {
+        Color::Blue,
+        Color::Cyan,
+        Color::Green,
+        Color::LightGray,
+        Color::Magenta,
+        Color::Red,
+        Color::Yellow,
+    };
+
+    const Orientation orientations[] {
+        Gfx::Orientation::Horizontal,
+        Gfx::Orientation::Vertical
+    };
+
+
+    int start_color_index = 0;
+    int end_color_index = 0;
+    while (start_color_index == end_color_index) {
+        start_color_index = rand() % (sizeof(colors) / sizeof(colors[0]));
+        end_color_index = rand() % (sizeof(colors) / sizeof(colors[0]));
+    }
+
+    GUI::Painter painter(*m_bitmap);
+    painter.fill_rect_with_gradient(
+        orientations[rand() % (sizeof(orientations) / sizeof(orientations[0]))],
+        m_bitmap->rect(),
+        colors[start_color_index],
+        colors[end_color_index]
+    );
+
+    update();
+}
+
+int main(int argc, char** argv)
+{
+    GUI::Application app(argc, argv);
+
+    auto window = GUI::Window::construct();
+    window->set_double_buffering_enabled(true);
+    window->set_title("Screensaver");
+    window->set_resizable(false);
+    window->set_fullscreen(true);
+
+    auto& screensaver_window = window->set_main_widget<Screensaver>();
+    screensaver_window.update();
+
+    window->show();
+    window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-demo.png"));
+
+    return app.exec();
+}

--- a/Kernel/build-root-filesystem.sh
+++ b/Kernel/build-root-filesystem.sh
@@ -149,6 +149,7 @@ cp ../Games/Solitaire/Solitaire mnt/bin/Solitaire
 cp ../Demos/HelloWorld/HelloWorld mnt/bin/HelloWorld
 cp ../Demos/WidgetGallery/WidgetGallery mnt/bin/WidgetGallery
 cp ../Demos/Cube/Cube mnt/bin/Cube
+cp ../Demos/Screensaver/Screensaver mnt/bin/Screensaver
 cp ../Demos/Fire/Fire mnt/bin/Fire
 cp ../Demos/DynamicLink/LinkDemo/LinkDemo mnt/bin/LinkDemo
 cp ../DevTools/HackStudio/HackStudio mnt/bin/HackStudio


### PR DESCRIPTION
Rudimentary screensaver using color gradients. Computationally inexpensive.

Room for improvement:

* Pretty blending / dissolving.
* Hide the mouse cursor.
* The bitmap for first iteration (of `INTERVAL` length) is black.
* The screen resolution aspect ration could be used, rather than forcing a 4:3 aspect ratio. Although this shouldn't make much difference given that it's scaled.

Code mostly stolen from other demos.

![Screensaver](https://user-images.githubusercontent.com/434827/79671342-f7fd1c00-820c-11ea-815b-961d272b7522.png)


