### PR TITLE
LibJS: Improve CallExpression::execute()'s error messages

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -716,6 +716,8 @@ public:
 
     PropertyName computed_property_name(Interpreter&) const;
 
+    String to_string_approximation() const;
+
 private:
     virtual bool is_member_expression() const override { return true; }
     virtual const char* class_name() const override { return "MemberExpression"; }


### PR DESCRIPTION
I've heard @awesomekling complaining about how "undefined is not a function" is more or less useless - hopefully for the last time :smile:

Let's improve this message.

```
> foo = {}
{  }
> foo.bar()
Uncaught exception: [TypeError]: undefined is not a function (evaluated from 'foo.bar')
> 
> foo[1 + 2]()
Uncaught exception: [TypeError]: undefined is not a function (evaluated from 'foo[<computed>]')
> 
> ({}).foo()
Uncaught exception: [TypeError]: undefined is not a function (evaluated from '<object>.foo')
> 
> ({})[1 + 2]()
Uncaught exception: [TypeError]: undefined is not a function (evaluated from '<object>[<computed>]')
>
> (1)()
Uncaught exception: [TypeError]: 1 is not a function
>
> "foo"()
Uncaught exception: [TypeError]: foo is not a function

```

Works with values other than `undefined` as well, of course, but that's going to be the most common one. E.g. via `ctx.someFunctionWeDontHaveYet()`.

We can't just (re-)evaluate the computed expression as that could have side effects, but maybe we can work towards every AST node knowing its source string in the future...