### PR TITLE
Toolchain: Improve building toolchain on Darwin (macOS)

### DIFF
--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -30,6 +30,9 @@ elif [ "$(uname -s)" = "FreeBSD" ]; then
     MAKE=gmake
     MD5SUM="md5 -q"
     NPROC="sysctl -n hw.ncpu"
+elif [ "$(uname -s)" = "Darwin" ]; then
+    MD5SUM="md5 -q"
+    NPROC="sysctl -n hw.ncpu"
 fi
 
 echo PREFIX is "$PREFIX"


### PR DESCRIPTION
At least on my system, `md5sum` exits with some kind of linking error
but `md5 -q` works, as on other BSD-based OSes. Likewise, `nproc` does
not exist but `sysctl -n hw.ncpu` works.

This commit uses those tools on Darwin (macOS) systems.

This change is unfortunately motivated solely by "it works on my machine." Before these changes, `BuildIt.sh` would stop at line 153 because `nproc` didn't exist. In addition, it would redownload tarballs over and over again because it couldn't successfully hash them. With these changes, `BuildIt.sh` runs successfully (exits with `0`), and doesn't redownload tarballs every run. I am then able to build and run SerenityOS.

Changes are inspired by #1002. However, in that PR, two people confirm that they can build on macOS at that point in time. This might indicate a configuration error on my end, which would make this PR unnecessary or ill-advised. I'm tagging @Pagghiu, author of #841, which initially added support for building on macOS, in hopes that he might have thoughts on this.

I'm on macOS 10.15.3 (19D76).