### PR TITLE
Browser: Persistent bookmark removal.

### DIFF
--- a/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Applications/Browser/BookmarksBarWidget.cpp
@@ -184,7 +184,10 @@ bool BookmarksBarWidget::remove_bookmark(const String& url)
         auto item_url = model()->data(model()->index(item_index, 1)).to_string();
         if (item_url == url) {
             auto& json_model = *static_cast<GUI::JsonArrayModel*>(model());
-            json_model.remove(item_index);
+
+            if (json_model.remove(item_index))
+                json_model.store();
+
             return true;
         }
     }

--- a/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Applications/Browser/BookmarksBarWidget.cpp
@@ -185,10 +185,10 @@ bool BookmarksBarWidget::remove_bookmark(const String& url)
         if (item_url == url) {
             auto& json_model = *static_cast<GUI::JsonArrayModel*>(model());
 
-            if (json_model.remove(item_index))
+            if (json_model.remove(item_index)) {
                 json_model.store();
-
-            return true;
+                return true;
+            }
         }
     }
 

--- a/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Applications/Browser/BookmarksBarWidget.cpp
@@ -185,10 +185,11 @@ bool BookmarksBarWidget::remove_bookmark(const String& url)
         if (item_url == url) {
             auto& json_model = *static_cast<GUI::JsonArrayModel*>(model());
 
-            if (json_model.remove(item_index)) {
+            const auto item_removed = json_model.remove(item_index);
+            if (item_removed)
                 json_model.store();
-                return true;
-            }
+
+            return item_removed;
         }
     }
 


### PR DESCRIPTION
Store the JSON model after the bookmark is removed.
Removed bookmark wasn't removed from the JSON model, so that on the next browser start it would show up again.