### PR TITLE
LibLine: Complete only common prefixes, and tweak suggestion interface

### DIFF
--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -53,6 +53,28 @@ struct KeyCallback {
     Function<bool(Editor&)> callback;
 };
 
+struct CompletionSuggestion {
+    // intentionally not explicit (allows suggesting bare strings)
+    CompletionSuggestion(const String& completion)
+        : text(completion)
+        , trailing_trivia("")
+    {
+    }
+    CompletionSuggestion(const StringView& completion, const StringView& trailing_trivia)
+        : text(completion)
+        , trailing_trivia(trailing_trivia)
+    {
+    }
+
+    bool operator==(const CompletionSuggestion& suggestion) const
+    {
+        return suggestion.text == text;
+    }
+
+    String text;
+    String trailing_trivia;
+};
+
 class Editor {
 public:
     Editor();
@@ -79,8 +101,8 @@ public:
 
     void register_character_input_callback(char ch, Function<bool(Editor&)> callback);
 
-    Function<Vector<String>(const String&)> on_tab_complete_first_token;
-    Function<Vector<String>(const String&)> on_tab_complete_other_token;
+    Function<Vector<CompletionSuggestion>(const String&)> on_tab_complete_first_token;
+    Function<Vector<CompletionSuggestion>(const String&)> on_tab_complete_other_token;
     Function<void(Editor&)> on_display_refresh;
 
     // FIXME: we will have to kindly ask our instantiators to set our signal handlers
@@ -195,8 +217,8 @@ private:
     size_t m_origin_y { 0 };
 
     String m_new_prompt;
-    Vector<String> m_suggestions;
-    String m_last_shown_suggestion { String::empty() };
+    Vector<CompletionSuggestion> m_suggestions;
+    CompletionSuggestion m_last_shown_suggestion { String::empty() };
     size_t m_last_shown_suggestion_display_length { 0 };
     bool m_last_shown_suggestion_was_complete { false };
     size_t m_next_suggestion_index { 0 };

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -196,9 +196,12 @@ private:
 
     String m_new_prompt;
     Vector<String> m_suggestions;
-    String m_last_shown_suggestion;
+    String m_last_shown_suggestion { String::empty() };
+    size_t m_last_shown_suggestion_display_length { 0 };
+    bool m_last_shown_suggestion_was_complete { false };
     size_t m_next_suggestion_index { 0 };
     size_t m_next_suggestion_invariant_offset { 0 };
+    size_t m_largest_common_suggestion_prefix_length { 0 };
 
     enum class TabDirection {
         Forward,

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -553,7 +553,7 @@ int main(int argc, char** argv)
             editor.set_prompt(prompt_for_level(open_indents));
         };
 
-        auto complete = [&interpreter, &editor = *editor](const String& token) -> Vector<String> {
+        auto complete = [&interpreter, &editor = *editor](const String& token) -> Vector<Line::CompletionSuggestion> {
             if (token.length() == 0)
                 return {}; // nyeh
 
@@ -564,13 +564,13 @@ int main(int argc, char** argv)
             //    - <N>.<P>
             //        where N is the complete name of a variable and
             //        P is part of the name of one of its properties
-            Vector<String> results;
+            Vector<Line::CompletionSuggestion> results;
 
             Function<void(const JS::Shape&, const StringView&)> list_all_properties = [&results, &list_all_properties](const JS::Shape& shape, auto& property_pattern) {
                 for (const auto& descriptor : shape.property_table()) {
                     if (descriptor.value.attributes & JS::Attribute::Enumerable) {
                         if (descriptor.key.view().starts_with(property_pattern)) {
-                            auto completion = descriptor.key;
+                            Line::CompletionSuggestion completion { descriptor.key };
                             if (!results.contains_slow(completion)) { // hide duplicates
                                 results.append(completion);
                             }


### PR DESCRIPTION
cc @bugaevc 

`/re<tab>` -> `/res/`
`/r<tab>` -> `/r` showing suggestions, without having anything selected
`ls www/ac<tab>` -> `ls www/acid`, and shows suggestions.
`<tab>` -> immediately show suggestions (nothing selected)

Changes the suggestion callbacks to return a `Vector<Line::CompletionSuggestion>`, which contains a `text` field, and a `trivia` field.
The `trivia` string is only appended when the suggestion is selected.