### PR TITLE
FileManager: Ignore empty selections on tree view

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -702,6 +702,8 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     };
 
     tree_view.on_selection_change = [&] {
+        if (tree_view.selection().is_empty())
+            return;
         auto path = directories_model->full_path(tree_view.selection().first());
         if (directory_view.path() == path)
             return;


### PR DESCRIPTION
If the selection is empty, the model index will be invalid and the file
system model will return the root directory path by default. This causes
the file manager to jump to the root directory when the currently
selected item on the tree view is deselected.