### PR TITLE
FileManager: Replicate permissions on directory copy (#1437)

### DIFF
--- a/Applications/FileManager/FileUtils.cpp
+++ b/Applications/FileManager/FileUtils.cpp
@@ -93,12 +93,12 @@ bool copy_file_or_directory(const String& src_path, const String& dst_path)
     }
 
     if (S_ISDIR(src_stat.st_mode)) {
-        return copy_directory(src_path, dst_path);
+        return copy_directory(src_path, dst_path, src_stat);
     }
     return copy_file(src_path, dst_path, src_stat, src_fd);
 }
 
-bool copy_directory(const String& src_path, const String& dst_path)
+bool copy_directory(const String& src_path, const String& dst_path, const struct stat& src_stat)
 {
     int rc = mkdir(dst_path.characters(), 0755);
     if (rc < 0) {
@@ -116,6 +116,13 @@ bool copy_directory(const String& src_path, const String& dst_path)
         if (!is_copied) {
             return false;
         }
+    }
+
+    auto my_umask = umask(0);
+    umask(my_umask);
+    rc = chmod(dst_path.characters(), src_stat.st_mode & ~my_umask);
+    if (rc < 0) {
+        return false;
     }
     return true;
 }

--- a/Applications/FileManager/FileUtils.h
+++ b/Applications/FileManager/FileUtils.h
@@ -34,6 +34,6 @@ int delete_directory(String directory, String& file_that_caused_error);
 bool copy_file_or_directory(const String& src_path, const String& dst_path);
 String get_duplicate_name(const String& path, int duplicate_count);
 bool copy_file(const String& src_path, const String& dst_path, const struct stat& src_stat, int src_fd);
-bool copy_directory(const String& src_path, const String& dst_path);
+bool copy_directory(const String& src_path, const String& dst_path, const struct stat& src_stat);
 
 }


### PR DESCRIPTION
When copying files, the original file permissions are applied to the
copy. However, this was not done with directories. This should do it.