### PR TITLE
LibLine: Implement some history searching stuff

### DIFF
--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -160,6 +160,7 @@ private:
 
     Style find_applicable_style(size_t offset) const;
 
+    bool search(const StringView&, bool allow_empty = false, bool from_beginning = false);
     inline void end_search()
     {
         m_is_searching = false;
@@ -222,6 +223,7 @@ private:
     bool m_is_searching { false };
     bool m_reset_buffer_on_search_end { true };
     size_t m_search_offset { 0 };
+    bool m_searching_backwards { true };
     size_t m_pre_search_cursor { 0 };
     Vector<char, 1024> m_pre_search_buffer;
 
@@ -229,6 +231,7 @@ private:
     ByteBuffer m_pending_chars;
     size_t m_cursor { 0 };
     size_t m_drawn_cursor { 0 };
+    size_t m_inline_search_cursor { 0 };
     size_t m_chars_inserted_in_the_middle { 0 };
     size_t m_times_tab_pressed { 0 };
     size_t m_num_columns { 0 };

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -167,10 +167,12 @@ private:
         m_refresh_needed = true;
         m_search_offset = 0;
         if (m_reset_buffer_on_search_end) {
-            m_buffer = m_pre_search_buffer;
+            m_buffer.clear();
+            for (auto ch : m_pre_search_buffer)
+                m_buffer.append(ch);
             m_cursor = m_pre_search_cursor;
         }
-        m_reset_buffer_on_search_end = false;
+        m_reset_buffer_on_search_end = true;
         m_search_editor = nullptr;
     }
 


### PR DESCRIPTION
This commit adds searching in the editor history with ^R.
It does so by instantiating...another Line::Editor inside the current
Line::Editor :^)

and yes, @linusg, this works just fine with js's syntax highlighting :^)

- pressing Enter while the search is up will execute the selected history element
- pressing Tab will quit search, but keep the buffer and continue the prompt (better key for this?)
- ^R and backspace will cycle backwards and forwards, respectively.