### PR TITLE
LibJS: Add assertThrowsError() test function

### DIFF
--- a/Libraries/LibJS/Tests/Array.prototype.filter.js
+++ b/Libraries/LibJS/Tests/Array.prototype.filter.js
@@ -3,21 +3,19 @@ load("test-common.js");
 try {
     assert(Array.prototype.filter.length === 1);
 
-    try {
+    assertThrowsError(() => {
         [].filter();
-        assertNotReached();
-    } catch (e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "Array.prototype.filter() requires at least one argument");
-    }
+    }, {
+        error: TypeError,
+        message: "Array.prototype.filter() requires at least one argument"
+    });
 
-    try {
+    assertThrowsError(() => {
         [].filter(undefined);
-        assertNotReached();
-    } catch (e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "undefined is not a function");
-    }
+    }, {
+        error: TypeError,
+        message: "undefined is not a function"
+    });
 
     var callbackCalled = 0;
     var callback = () => { callbackCalled++; };

--- a/Libraries/LibJS/Tests/Array.prototype.forEach.js
+++ b/Libraries/LibJS/Tests/Array.prototype.forEach.js
@@ -3,21 +3,19 @@ load("test-common.js");
 try {
     assert(Array.prototype.forEach.length === 1);
 
-    try {
+    assertThrowsError(() => {
         [].forEach();
-        assertNotReached();
-    } catch (e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "Array.prototype.forEach() requires at least one argument");
-    }
+    }, {
+        error: TypeError,
+        message: "Array.prototype.forEach() requires at least one argument"
+    });
 
-    try {
+    assertThrowsError(() => {
         [].forEach(undefined);
-        assertNotReached();
-    } catch (e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "undefined is not a function");
-    }
+    }, {
+        error: TypeError,
+        message: "undefined is not a function"
+    });
 
     var a = [1, 2, 3];
     var o = {};

--- a/Libraries/LibJS/Tests/Array.prototype.map.js
+++ b/Libraries/LibJS/Tests/Array.prototype.map.js
@@ -3,21 +3,19 @@ load("test-common.js");
 try {
     assert(Array.prototype.map.length === 1);
 
-    try {
+    assertThrowsError(() => {
         [].map();
-        assertNotReached();
-    } catch (e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "Array.prototype.map() requires at least one argument");
-    }
+    }, {
+        error: TypeError,
+        message: "Array.prototype.map() requires at least one argument"
+    });
 
-    try {
+    assertThrowsError(() => {
         [].map(undefined);
-        assertNotReached();
-    } catch (e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "undefined is not a function");
-    }
+    }, {
+        error: TypeError,
+        message: "undefined is not a function"
+    });
 
     var callbackCalled = 0;
     var callback = () => { callbackCalled++; };

--- a/Libraries/LibJS/Tests/Boolean.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.toString.js
@@ -8,14 +8,12 @@ try {
     assert(Boolean.prototype.toString.call(true) === "true");
     assert(Boolean.prototype.toString.call(false) === "false");
 
-    try {
+    assertThrowsError(() => {
         Boolean.prototype.toString.call("foo");
-        assertNotReached();
-    } catch (e) {
-        assert(e instanceof Error);
-        assert(e.name === "TypeError");
-        assert(e.message === "Not a Boolean");
-    }
+    }, {
+        error: TypeError,
+        message: "Not a Boolean"
+    });
 
     console.log("PASS");
 } catch (err) {

--- a/Libraries/LibJS/Tests/Boolean.prototype.valueOf.js
+++ b/Libraries/LibJS/Tests/Boolean.prototype.valueOf.js
@@ -8,14 +8,12 @@ try {
     assert(Boolean.prototype.valueOf.call(true) === true);
     assert(Boolean.prototype.valueOf.call(false) === false);
 
-    try {
+    assertThrowsError(() => {
         Boolean.prototype.valueOf.call("foo");
-        assertNotReached();
-    } catch (e) {
-        assert(e instanceof Error);
-        assert(e.name === "TypeError");
-        assert(e.message === "Not a Boolean");
-    }
+    }, {
+        error: TypeError,
+        message: "Not a Boolean"
+    });
 
     console.log("PASS");
 } catch (err) {

--- a/Libraries/LibJS/Tests/Object.defineProperty.js
+++ b/Libraries/LibJS/Tests/Object.defineProperty.js
@@ -26,12 +26,11 @@ try {
     assert(d.writable === true);
     assert(d.value === "ho");
 
-    try {
+    assertThrowsError(() => {
         Object.defineProperty(o, "bar", { value: "xx", enumerable: false });
-        assertNotReached();
-    } catch (e) {
-        assert(e.name === "TypeError");
-    }
+    }, {
+        error: TypeError
+    });
 
     Object.defineProperty(o, "baz", { value: 9, configurable: true, writable: false });
     Object.defineProperty(o, "baz", { configurable: true, writable: true });

--- a/Libraries/LibJS/Tests/function-TypeError.js
+++ b/Libraries/LibJS/Tests/function-TypeError.js
@@ -1,56 +1,50 @@
 load("test-common.js");
 
 try {
-    try {
+    assertThrowsError(() => {
         var b = true;
         b();
-        assertNotReached();
-    } catch(e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "true is not a function (evaluated from 'b')");
-    }
+    }, {
+        error: TypeError,
+        message: "true is not a function (evaluated from 'b')"
+    });
 
-    try {
+    assertThrowsError(() => {
         var n = 100 + 20 + 3;
         n();
-        assertNotReached();
-    } catch(e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "123 is not a function (evaluated from 'n')");
-    }
+    }, {
+        error: TypeError,
+        message: "123 is not a function (evaluated from 'n')"
+    });
 
-    try {
+    assertThrowsError(() => {
         var o = {};
         o.a();
-        assertNotReached();
-    } catch(e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "undefined is not a function (evaluated from 'o.a')");
-    }
+    }, {
+        error: TypeError,
+        message: "undefined is not a function (evaluated from 'o.a')"
+    });
 
-    try {
+    assertThrowsError(() => {
         Math();
-        assertNotReached();
-    } catch(e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "[object MathObject] is not a function (evaluated from 'Math')");
-    }
+    }, {
+        error: TypeError,
+        message: "[object MathObject] is not a function (evaluated from 'Math')"
+    });
 
-    try {
+    assertThrowsError(() => {
         new Math();
-        assertNotReached();
-    } catch(e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "[object MathObject] is not a constructor (evaluated from 'Math')");
-    }
+    }, {
+        error: TypeError,
+        message: "[object MathObject] is not a constructor (evaluated from 'Math')"
+    });
 
-    try {
+    assertThrowsError(() => {
         new isNaN();
-        assertNotReached();
-    } catch(e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "function isNaN() {\n  [NativeFunction]\n} is not a constructor (evaluated from 'isNaN')");
-    }
+    }, {
+        error: TypeError,
+        message: "function isNaN() {\n  [NativeFunction]\n} is not a constructor (evaluated from 'isNaN')"
+    });
 
     console.log("PASS");
 } catch(e) {

--- a/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
+++ b/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
@@ -1,29 +1,26 @@
 load("test-common.js");
 
 try {
-    try {
-        Math.abs(-20) = 40;
-        assertNotReached();
-    } catch (e) {
-        assert(e.name === "ReferenceError");
-        assert(e.message === "Invalid left-hand side in assignment");
-    }
-
-    try {
+    assertThrowsError(() => {
         512 = 256;
-        assertNotReached();
-    } catch (e) {
-        assert(e.name === "ReferenceError");
-        assert(e.message === "Invalid left-hand side in assignment");
-    }
+    }, {
+        error: ReferenceError,
+        message: "Invalid left-hand side in assignment"
+    });
 
-    try {
+    assertThrowsError(() => {
+        512 = 256;
+    }, {
+        error: ReferenceError,
+        message: "Invalid left-hand side in assignment"
+    });
+
+    assertThrowsError(() => {
         "hello world" = "another thing?";
-        assertNotReached();
-    } catch (e) {
-        assert(e.name === "ReferenceError");
-        assert(e.message === "Invalid left-hand side in assignment");
-    }
+    }, {
+        error: ReferenceError,
+        message: "Invalid left-hand side in assignment"
+    });
 
     console.log("PASS");
 } catch (e) {

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -14,3 +14,18 @@ function assert(value) {
 function assertNotReached() {
     throw new AssertionError("assertNotReached() was reached!");
 }
+
+function assertThrowsError(testFunction, options) {
+    try {
+        testFunction();
+        assertNotReached();
+    } catch (e) {
+        if (options.error !== undefined)
+            assert(e instanceof options.error);
+        if (options.name !== undefined)
+            assert(e.name === options.name);
+        if (options.message !== undefined)
+            assert(e.message === options.message);
+    }
+}
+

--- a/Libraries/LibJS/Tests/variable-declaration.js
+++ b/Libraries/LibJS/Tests/variable-declaration.js
@@ -3,14 +3,13 @@ load("test-common.js");
 try {
 
     const constantValue = 1;
-    try {
+    assertThrowsError(() => {
         constantValue = 2;
-        assertNotReached();
-    } catch (e) {
-        assert(e.name === "TypeError");
-        assert(e.message === "Assignment to constant variable");
-        assert(constantValue === 1);
-    }
+    }, {
+        error: TypeError,
+        message: "Assignment to constant variable"
+    });
+    assert(constantValue === 1);
 
     // Make sure we can define new constants in inner scopes.
     const constantValue2 = 1;


### PR DESCRIPTION
This adds a new function `assertThrowsError()` to `test-common.js` that takes a test function which is expected to throw an error and an object describing these expecations - `error`, which will be checked agains using `instanceof`, `name` and `message`. All optional.

So instead of this:

```js
try {
    someThingThatHopefullyFails
    assertNotReached();
} catch (e) {
    assert(e.name === "SomeError");
    assert(e.message === "Error message");
}
```

We now can do:

```js
assertThrowsError(() => {
    someThingThatHopefullyFails
}, {
    error: SomeError,
    message: "Error message"
});
```

I find this expresses what we actually want to do in a better way - "assert this throws an error".

In most cases this now checks the actual error object type instead of "just" the name.