### PR TITLE
LibLine: Ctrl-left/right and tiny suggestion fix

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -416,7 +416,7 @@ String Editor::get_line(const String& prompt)
 
                 auto current_suggestion_index = m_next_suggestion_index;
                 if (m_next_suggestion_index < m_suggestions.size()) {
-                    auto can_complete = m_next_suggestion_invariant_offset < m_largest_common_suggestion_prefix_length;
+                    auto can_complete = m_next_suggestion_invariant_offset <= m_largest_common_suggestion_prefix_length;
                     if (!m_last_shown_suggestion.text.is_null()) {
                         size_t actual_offset;
                         size_t shown_length = m_last_shown_suggestion_display_length;

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -195,19 +195,20 @@ void TerminalWidget::keydown_event(GUI::KeyEvent& event)
     m_cursor_blink_timer->stop();
     m_cursor_blink_state = true;
     m_cursor_blink_timer->start();
+    auto ctrl_held = !!(event.modifiers() & Mod_Ctrl);
 
     switch (event.key()) {
     case KeyCode::Key_Up:
-        write(m_ptm_fd, "\033[A", 3);
+        write(m_ptm_fd, ctrl_held ? "\033[OA" : "\033[A", 3 + ctrl_held);
         return;
     case KeyCode::Key_Down:
-        write(m_ptm_fd, "\033[B", 3);
+        write(m_ptm_fd, ctrl_held ? "\033[OB" : "\033[B", 3 + ctrl_held);
         return;
     case KeyCode::Key_Right:
-        write(m_ptm_fd, "\033[C", 3);
+        write(m_ptm_fd, ctrl_held ? "\033[OC" : "\033[C", 3 + ctrl_held);
         return;
     case KeyCode::Key_Left:
-        write(m_ptm_fd, "\033[D", 3);
+        write(m_ptm_fd, ctrl_held ? "\033[OD" : "\033[D", 3 + ctrl_held);
         return;
     case KeyCode::Key_Insert:
         write(m_ptm_fd, "\033[2~", 4);


### PR DESCRIPTION
This PR makes handling ctrl-left and right arrow keys possible, and allows the user to jump between words.

Also fixes a little issue with the suggestions:
`/etc` is not completed to `/etc/` even though it's the only valid suggestion.