### PR TITLE
LibGui: Stop sending text selection updates on mousemove_event during automatic scrolling.

### DIFF
--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -301,7 +301,7 @@ void TextEditor::mouseup_event(MouseEvent& event)
 void TextEditor::mousemove_event(MouseEvent& event)
 {
     m_last_mousemove_position = event.position();
-    if (m_in_drag_select) {
+    if (m_in_drag_select && !m_automatic_selection_scroll_timer->is_active()) {
         set_cursor(text_position_at(event.position()));
         m_selection.set_end(m_cursor);
         did_update_selection();


### PR DESCRIPTION
This little tweak fixes the issue where the scrolling speeds up
significantly if the user wiggles their cursor. Just something obvious I
spotted while watching the video :^)