### PR TITLE
WindowServer: Don't ignore modal events when showing menus

### DIFF
--- a/Servers/WindowServer/MenuManager.cpp
+++ b/Servers/WindowServer/MenuManager.cpp
@@ -147,11 +147,12 @@ void MenuManager::event(Core::Event& event)
 
 void MenuManager::handle_mouse_event(MouseEvent& mouse_event)
 {
+    auto* active_window = WindowManager::the().active_window();
     bool handled_menubar_event = false;
     for_each_active_menubar_menu([&](Menu& menu) {
         if (menu.rect_in_menubar().contains(mouse_event.position())) {
             handle_menu_mouse_event(menu, mouse_event);
-            handled_menubar_event = true;
+            handled_menubar_event = !active_window || !active_window->is_modal();
             return IterationDecision::Break;
         }
         return IterationDecision::Continue;

--- a/Servers/WindowServer/MenuManager.cpp
+++ b/Servers/WindowServer/MenuManager.cpp
@@ -120,15 +120,6 @@ void MenuManager::refresh()
 
 void MenuManager::event(Core::Event& event)
 {
-    auto* active_window = WindowManager::the().active_window();
-    if (active_window && active_window->is_modal() && has_open_menu()) {
-        auto* topmost_menu = m_open_menu_stack.last().ptr();
-        ASSERT(topmost_menu);
-        // Always allow window menu interaction, even while a modal window is active.
-        if (!topmost_menu->window_menu_of())
-            return Core::Object::event(event);
-    }
-
     if (static_cast<Event&>(event).is_mouse_event()) {
         handle_mouse_event(static_cast<MouseEvent&>(event));
         return;


### PR DESCRIPTION
PR #1495 fixes #1464 but only accounts for window menus. In File
Manager, for example, attempting to pop up the context menu on the file
name text box of the properties modal window, will result in the same
behavior.

Removing the code altogether solves the problem, altough I'm
not sure if it could have any bad implications.

I was thinking it might allow interaction with a parent window menu if
it remains open just before the popup window is shown, but I have not
seen a way to replicate this behavior.

![image](https://user-images.githubusercontent.com/55109673/79863244-b10f5200-83d7-11ea-9b10-3ff708b3904d.png)
