### PR TITLE
WindowServer: Unset previously active input window when active window changes

### DIFF
--- a/Servers/WindowServer/WindowManager.cpp
+++ b/Servers/WindowServer/WindowManager.cpp
@@ -1086,6 +1086,7 @@ void WindowManager::set_active_window(Window* window)
         Core::EventLoop::current().post_event(*previously_active_window, make<Event>(Event::WindowDeactivated));
         invalidate(*previously_active_window);
         m_active_window = nullptr;
+        m_active_input_window = nullptr;
         tell_wm_listeners_window_state_changed(*previously_active_window);
     }
 


### PR DESCRIPTION
This was not done previously and resulted in modal windows not being
able to accept input unless they were clicked one time if their parent
windows were the active input window.

(e.g. Properties window on FileManager would not accept input unless first clicked)