### PR TITLE
WindowServer: Allow the system menu to be open when a modal is shown

### DIFF
--- a/Servers/WindowServer/MenuManager.cpp
+++ b/Servers/WindowServer/MenuManager.cpp
@@ -151,8 +151,9 @@ void MenuManager::handle_mouse_event(MouseEvent& mouse_event)
     bool handled_menubar_event = false;
     for_each_active_menubar_menu([&](Menu& menu) {
         if (menu.rect_in_menubar().contains(mouse_event.position())) {
-            handle_menu_mouse_event(menu, mouse_event);
-            handled_menubar_event = !active_window || !active_window->is_modal();
+            handled_menubar_event = &menu == m_system_menu || !active_window || !active_window->is_modal();
+            if (handled_menubar_event)
+                handle_menu_mouse_event(menu, mouse_event);
             return IterationDecision::Break;
         }
         return IterationDecision::Continue;


### PR DESCRIPTION
A little heads up from my previous PR. Events going towards system menu would not be processed!
This fixes it. Also, I guess I should test a bit before making too many pull requests :upside_down_face: 