### PR TITLE
LibWeb: support confirm() with no arguments

### DIFF
--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -108,10 +108,10 @@ JS::Value WindowObject::confirm(JS::Interpreter& interpreter)
     auto* impl = impl_from(interpreter);
     if (!impl)
         return {};
-    auto& arguments = interpreter.call_frame().arguments;
-    if (arguments.size() < 1)
-        return {};
-    return JS::Value(impl->confirm(arguments[0].to_string()));
+    String message = "";
+    if (interpreter.argument_count())
+        message = interpreter.argument(0).to_string();
+    return JS::Value(impl->confirm(message));
 }
 
 JS::Value WindowObject::set_interval(JS::Interpreter& interpreter)


### PR DESCRIPTION
Similar to #1816, support passing no arguments to `confirm()`, essentially acting the same as `confirm("")`, since Firefox, Chrome, etc. seem to support this behavior as well.