### PR TITLE
LibJS: Add GeneratorFunction

### DIFF
--- a/Libraries/LibJS/Makefile
+++ b/Libraries/LibJS/Makefile
@@ -26,6 +26,8 @@ OBJS = \
     Runtime/FunctionConstructor.o \
     Runtime/FunctionPrototype.o \
     Runtime/GlobalObject.o \
+    Runtime/GeneratorFunction.o \
+    Runtime/Iterator.o \
     Runtime/LexicalEnvironment.o \
     Runtime/MathObject.o \
     Runtime/MarkedValueList.o \

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -72,6 +72,7 @@ public:
     NonnullRefPtr<CallExpression> parse_call_expression(NonnullRefPtr<Expression>);
     NonnullRefPtr<NewExpression> parse_new_expression();
     RefPtr<FunctionExpression> try_parse_arrow_function_expression(bool expect_parens);
+    NonnullRefPtr<YieldExpression> parse_yield_expression();
 
     bool has_errors() const { return m_parser_state.m_lexer.has_errors() || m_parser_state.m_has_errors; }
 

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -112,8 +112,7 @@ Value ArrayPrototype::filter(Interpreter& interpreter)
         arguments.append(Value((i32)i));
         arguments.append(array);
         auto result = interpreter.call(callback, this_value, move(arguments));
-        if (interpreter.exception())
-            return {};
+        STOP_EXECUTION_IF_NEEDED(interpreter, result);
         if (result.to_boolean())
             new_array->elements().append(value);
     }
@@ -140,9 +139,8 @@ Value ArrayPrototype::for_each(Interpreter& interpreter)
         arguments.append(value);
         arguments.append(Value((i32)i));
         arguments.append(array);
-        interpreter.call(callback, this_value, move(arguments));
-        if (interpreter.exception())
-            return {};
+        auto result = interpreter.call(callback, this_value, move(arguments));
+        STOP_EXECUTION_IF_NEEDED(interpreter, result);
     }
     return js_undefined();
 }
@@ -169,8 +167,7 @@ Value ArrayPrototype::map(Interpreter& interpreter)
         arguments.append(Value((i32)i));
         arguments.append(array);
         auto result = interpreter.call(callback, this_value, move(arguments));
-        if (interpreter.exception())
-            return {};
+        STOP_EXECUTION_IF_NEEDED(interpreter, result);
         new_array->elements().append(result);
     }
     return Value(new_array);

--- a/Libraries/LibJS/Runtime/GeneratorFunction.cpp
+++ b/Libraries/LibJS/Runtime/GeneratorFunction.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Function.h>
+#include <LibJS/AST.h>
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/GeneratorFunction.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Iterator.h>
+#include <LibJS/Runtime/Value.h>
+
+namespace JS {
+
+GeneratorFunction* GeneratorFunction::create(GlobalObject& global_object, const FlyString& name, const Statement& body, Vector<FlyString> parameters, LexicalEnvironment* parent_environment, LexicalEnvironment* own_environment)
+{
+    return global_object.heap().allocate<GeneratorFunction>(name, body, move(parameters), parent_environment, *global_object.function_prototype(), own_environment);
+}
+
+GeneratorFunction::GeneratorFunction(const FlyString& name, const Statement& body, Vector<FlyString> parameters, LexicalEnvironment* parent_environment, Object& prototype, LexicalEnvironment* own_environment)
+    : ScriptFunction(name, move(body), move(parameters), parent_environment, prototype)
+    , m_own_environment(own_environment)
+{
+}
+
+GeneratorFunction::~GeneratorFunction()
+{
+}
+
+void GeneratorFunction::visit_children(Visitor& visitor)
+{
+    ScriptFunction::visit_children(visitor);
+    visitor.visit(m_own_environment);
+}
+
+LexicalEnvironment* GeneratorFunction::create_environment()
+{
+    if (m_own_environment)
+        return m_own_environment;
+
+    return m_own_environment = ScriptFunction::create_environment();
+}
+
+Value GeneratorFunction::call(Interpreter& interpreter)
+{
+    auto& argument_values = interpreter.call_frame().arguments;
+    ArgumentVector arguments;
+    for (size_t i = 0; i < m_parameters.size(); ++i) {
+        auto name = parameters()[i];
+        auto value = js_undefined();
+        if (i < argument_values.size())
+            value = argument_values[i];
+        arguments.append({ name, value });
+        interpreter.current_environment()->set(name, { value, DeclarationKind::Var });
+    }
+
+    auto new_body = adopt(*new BlockStatement);
+    auto* block = static_cast<ScopeNode*>(new_body);
+
+    auto& my_block = static_cast<const ScopeNode&>(body());
+
+    for (auto& node : my_block.children()) {
+        block->append(node);
+    }
+    HashMap<FlyString, Variable> values;
+    auto new_lexical_environment = interpreter.heap().allocate<LexicalEnvironment>(move(values), create_environment());
+    auto iterator = heap().allocate<Iterator>(
+        *heap().allocate<GeneratorFunction>(name(), *new_body, parameters(), m_parent_environment, *prototype(), new_lexical_environment),
+        [&interpreter, argument_values, arguments](Object& generator_object, const Vector<Value>& next_arguments) -> Iterator::IteratorResult {
+            auto& generator = static_cast<GeneratorFunction&>(generator_object);
+            if (generator.m_done)
+                return { true, js_undefined() };
+
+            auto& call_frame = interpreter.push_call_frame();
+            call_frame.environment = generator.create_environment();
+            call_frame.arguments = next_arguments;
+            call_frame.function_name = generator.name();
+
+            auto result = interpreter.destructive_run(generator.m_body, arguments, ScopeType::Function);
+
+            interpreter.pop_call_frame();
+
+            if (interpreter.has_returned() || static_cast<ScopeNode&>(*generator.m_body).children().size() == 0)
+                generator.m_done = true;
+            return { generator.m_done, result };
+        });
+
+    return Value(iterator);
+}
+
+Value GeneratorFunction::construct(Interpreter& interpreter)
+{
+    return interpreter.throw_exception<TypeError>("Not a constructor");
+}
+
+}

--- a/Libraries/LibJS/Runtime/GeneratorFunction.h
+++ b/Libraries/LibJS/Runtime/GeneratorFunction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, The SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,38 +26,31 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Function.h>
+#include <LibJS/Runtime/ScriptFunction.h>
 
 namespace JS {
 
-class ScriptFunction : public Function {
+class GeneratorFunction final : public ScriptFunction {
 public:
-    static ScriptFunction* create(GlobalObject&, const FlyString& name, const Statement& body, Vector<FlyString> parameters, LexicalEnvironment* parent_environment);
+    static GeneratorFunction* create(GlobalObject&, const FlyString& name, const Statement& body, Vector<FlyString> parameters, LexicalEnvironment* parent_environment, LexicalEnvironment* own_environment = nullptr);
 
-    ScriptFunction(const FlyString& name, const Statement& body, Vector<FlyString> parameters, LexicalEnvironment* parent_environment, Object& prototype);
-    virtual ~ScriptFunction();
-
-    const Statement& body() const { return m_body; }
-    const Vector<FlyString>& parameters() const { return m_parameters; };
+    GeneratorFunction(const FlyString& name, const Statement& body, Vector<FlyString> parameters, LexicalEnvironment* parent_environment, Object& prototype, LexicalEnvironment* own_environment);
+    virtual ~GeneratorFunction();
 
     virtual Value call(Interpreter&) override;
     virtual Value construct(Interpreter&) override;
 
-    virtual const FlyString& name() const override { return m_name; };
-
-protected:
-    virtual bool is_script_function() const final { return true; }
-    virtual const char* class_name() const override { return "ScriptFunction"; }
+private:
+    virtual bool is_generator_function() const final { return true; }
+    virtual const char* class_name() const override { return "GeneratorFunction"; }
     virtual LexicalEnvironment* create_environment() override;
     virtual void visit_children(Visitor&) override;
 
-    static Value length_getter(Interpreter&);
-    static void length_setter(Interpreter&, Value);
+    static Value iterator_method(Interpreter&);
+    static Value next(Interpreter&);
 
-    FlyString m_name;
-    NonnullRefPtr<Statement> m_body;
-    const Vector<FlyString> m_parameters;
-    LexicalEnvironment* m_parent_environment { nullptr };
+    bool m_done { false };
+    LexicalEnvironment* m_own_environment { nullptr };
 };
 
 }

--- a/Libraries/LibJS/Runtime/Iterator.h
+++ b/Libraries/LibJS/Runtime/Iterator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, The SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,38 +26,37 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Function.h>
+#include <AK/Function.h>
+#include <LibJS/Runtime/Object.h>
 
 namespace JS {
 
-class ScriptFunction : public Function {
+class Iterator final : public Object {
 public:
-    static ScriptFunction* create(GlobalObject&, const FlyString& name, const Statement& body, Vector<FlyString> parameters, LexicalEnvironment* parent_environment);
+    struct IteratorResult {
+        bool finished { false };
+        Value value;
+    };
 
-    ScriptFunction(const FlyString& name, const Statement& body, Vector<FlyString> parameters, LexicalEnvironment* parent_environment, Object& prototype);
-    virtual ~ScriptFunction();
+    Iterator(Object& iterable, AK::Function<IteratorResult(Object&, const Vector<Value>&)>&& next_function);
 
-    const Statement& body() const { return m_body; }
-    const Vector<FlyString>& parameters() const { return m_parameters; };
+    virtual ~Iterator() override;
 
-    virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    Object& iterable() { return m_iterable; }
+    AK::Function<IteratorResult(Object&, const Vector<Value>&)>& next_function() { return m_next_function; }
+    bool done() const { return m_done; }
 
-    virtual const FlyString& name() const override { return m_name; };
+    virtual bool is_iterator() const override { return true; }
 
-protected:
-    virtual bool is_script_function() const final { return true; }
-    virtual const char* class_name() const override { return "ScriptFunction"; }
-    virtual LexicalEnvironment* create_environment() override;
+private:
     virtual void visit_children(Visitor&) override;
+    virtual const char* class_name() const override { return "Iterator"; }
 
-    static Value length_getter(Interpreter&);
-    static void length_setter(Interpreter&, Value);
+    static Value next(Interpreter&);
 
-    FlyString m_name;
-    NonnullRefPtr<Statement> m_body;
-    const Vector<FlyString> m_parameters;
-    LexicalEnvironment* m_parent_environment { nullptr };
+    Object& m_iterable;
+    bool m_done { false };
+    AK::Function<IteratorResult(Object&, const Vector<Value>&)> m_next_function;
 };
 
 }

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -71,10 +71,12 @@ public:
     virtual bool is_date() const { return false; }
     virtual bool is_error() const { return false; }
     virtual bool is_function() const { return false; }
+    virtual bool is_generator_function() const { return false; }
     virtual bool is_native_function() const { return false; }
     virtual bool is_bound_function() const { return false; }
     virtual bool is_native_property() const { return false; }
     virtual bool is_string_object() const { return false; }
+    virtual bool is_iterator() const { return false; }
 
     virtual const char* class_name() const override { return "Object"; }
     virtual void visit_children(Cell::Visitor&) override;

--- a/Libraries/LibJS/Tests/generator-basic.js
+++ b/Libraries/LibJS/Tests/generator-basic.js
@@ -1,0 +1,59 @@
+load("test-common.js")
+
+function* generator0(i) {
+    yield i;
+    yield i + 10;
+}
+
+function* idMaker(index) {
+    for(;;)
+        yield index++;
+}
+
+function* logGenerator() {
+    var a = [];
+    a.push(yield a);
+    a.push(yield a);
+    a.push(yield a);
+    a.push(yield a);
+    a.push(yield a);
+    return a;
+}
+
+function* yieldAndReturn() {
+  yield "Y";
+  return "R";
+  yield "unreachable";
+}
+
+try {
+    let gen = generator0(10)
+    assert(gen.next().value == 10)
+    assert(gen.next().value == 20)
+    assert(gen.next().done == true)
+
+    gen = idMaker(0);
+    assert(gen.next().value == 0)
+    assert(gen.next().value == 1)
+    assert(gen.next().value == 2)
+    assert(gen.next().value == 3)
+
+    gen = logGenerator();
+    assert(gen.next('you shall not see me').value.length == 0);
+    assert(gen.next('foo').value.length == 1);
+    assert(gen.next('bar').value.length == 2);
+    assert(gen.next('baz').value.length == 3);
+    assert(gen.next('fub').value.length == 4);
+    let log = gen.next().value;
+    assert(log[0] != 'you shall not see me');
+    assert(log[3] == 'fub');
+
+    gen = yieldAndReturn()
+    assert(gen.next().value == 'Y');
+    assert(gen.next().value == 'R');
+    assert(gen.next().value == undefined);
+
+    console.log("PASS")
+} catch(e) {
+    console.log("FAIL: " + e)
+}


### PR DESCRIPTION
Note that this version of Generators cannot correctly evaluate `yield (yield)`, because our evaluation is granular only at the statement level.
We also do not (yet) support delegate yields (`yield* ...`)