### PR TITLE
FileManager: Don't fail silently when attempting to open an inaccessible directory

### DIFF
--- a/Applications/FileManager/DirectoryView.h
+++ b/Applications/FileManager/DirectoryView.h
@@ -55,6 +55,7 @@ public:
     Function<void(const GUI::AbstractView&, const GUI::ModelIndex&, const GUI::DropEvent&)> on_drop;
     Function<void(const StringView&)> on_status_message;
     Function<void(int done, int total)> on_thumbnail_progress;
+    Function<void(int error, const char* error_string, bool quit)> on_error;
 
     enum ViewMode {
         Invalid,

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -588,6 +588,14 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
         go_back_action->set_enabled(directory_view.path_history_position() > 0);
     };
 
+    directory_view.on_error = [&](int, const char* error_string, bool quit) {
+        auto error_message = String::format("Could not read directory: %s", error_string);
+        GUI::MessageBox::show(error_message, "File Manager", GUI::MessageBox::Type::Error);
+
+        if (quit)
+            exit(1);
+    };
+
     directory_view.on_status_message = [&](const StringView& message) {
         statusbar.set_text(message);
     };

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -593,7 +593,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
         GUI::MessageBox::show(error_message, "File Manager", GUI::MessageBox::Type::Error);
 
         if (quit)
-            exit(1);
+            app.quit(1);
     };
 
     directory_view.on_status_message = [&](const StringView& message) {

--- a/Libraries/LibGUI/FileSystemModel.h
+++ b/Libraries/LibGUI/FileSystemModel.h
@@ -31,6 +31,7 @@
 #include <LibCore/DateTime.h>
 #include <LibCore/Notifier.h>
 #include <LibGUI/Model.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <time.h>
 
@@ -79,6 +80,10 @@ public:
         bool is_directory() const { return S_ISDIR(mode); }
         bool is_executable() const { return mode & (S_IXUSR | S_IXGRP | S_IXOTH); }
 
+        bool has_error() const { return m_error != 0; }
+        int error() const { return m_error; }
+        const char* error_string() const { return strerror(m_error); }
+
         String full_path(const FileSystemModel&) const;
 
     private:
@@ -90,6 +95,8 @@ public:
 
         int m_watch_fd { -1 };
         RefPtr<Core::Notifier> m_notifier;
+
+        int m_error { 0 };
 
         ModelIndex index(const FileSystemModel&, int column) const;
         void traverse_if_needed(const FileSystemModel&);
@@ -112,7 +119,8 @@ public:
     GUI::Icon icon_for_file(const mode_t mode, const String& name) const;
 
     Function<void(int done, int total)> on_thumbnail_progress;
-    Function<void()> on_root_path_change;
+    Function<void()> on_complete;
+    Function<void(int error, const char* error_string)> on_error;
 
     virtual int tree_column() const override { return Column::Name; }
     virtual int row_count(const ModelIndex& = ModelIndex()) const override;


### PR DESCRIPTION
This PR fixes #1890. I implemented `on_error` events on FileSystemModel and DirectoryView and replaced `on_path_change` with `on_complete`, which is only triggered if we could change the path successfully.

It would also make sense to trigger an `on_error` on DirectoryView when the currently open directory ceases to be accessible, but I could not yet figure a way to use the `watch_file` syscall to this end...

![image](https://user-images.githubusercontent.com/55109673/79907506-f94f6400-8419-11ea-8545-4f6d46dbd4a2.png)
![image](https://user-images.githubusercontent.com/55109673/79907543-05d3bc80-841a-11ea-91a9-1773f5035bb2.png)

