### PR TITLE
LibJS: Implement basic for..in and for..of loops

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -341,6 +341,54 @@ private:
     NonnullRefPtr<Statement> m_body;
 };
 
+class ForInStatement : public Statement {
+public:
+    ForInStatement(NonnullRefPtr<ASTNode> lhs, NonnullRefPtr<Expression> rhs, NonnullRefPtr<Statement> body)
+        : m_lhs(move(lhs))
+        , m_rhs(move(rhs))
+        , m_body(move(body))
+    {
+    }
+
+    const ASTNode& lhs() const { return *m_lhs; }
+    const Expression& rhs() const { return *m_rhs; }
+    const Statement& body() const { return *m_body; }
+
+    virtual Value execute(Interpreter&) const override;
+    virtual void dump(int indent) const override;
+
+private:
+    virtual const char* class_name() const override { return "ForInStatement"; }
+
+    NonnullRefPtr<ASTNode> m_lhs;
+    NonnullRefPtr<Expression> m_rhs;
+    NonnullRefPtr<Statement> m_body;
+};
+
+class ForOfStatement : public Statement {
+public:
+    ForOfStatement(NonnullRefPtr<ASTNode> lhs, NonnullRefPtr<Expression> rhs, NonnullRefPtr<Statement> body)
+        : m_lhs(move(lhs))
+        , m_rhs(move(rhs))
+        , m_body(move(body))
+    {
+    }
+
+    const ASTNode& lhs() const { return *m_lhs; }
+    const Expression& rhs() const { return *m_rhs; }
+    const Statement& body() const { return *m_body; }
+
+    virtual Value execute(Interpreter&) const override;
+    virtual void dump(int indent) const override;
+
+private:
+    virtual const char* class_name() const override { return "ForOfStatement"; }
+
+    NonnullRefPtr<ASTNode> m_lhs;
+    NonnullRefPtr<Expression> m_rhs;
+    NonnullRefPtr<Statement> m_body;
+};
+
 enum class BinaryOp {
     Addition,
     Subtraction,
@@ -678,6 +726,11 @@ enum class DeclarationKind {
 
 class VariableDeclarator final : public ASTNode {
 public:
+    VariableDeclarator(NonnullRefPtr<Identifier> id)
+        : m_id(move(id))
+    {
+    }
+
     VariableDeclarator(NonnullRefPtr<Identifier> id, RefPtr<Expression> init)
         : m_id(move(id))
         , m_init(move(init))

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -50,8 +50,9 @@ public:
     NonnullRefPtr<Statement> parse_statement();
     NonnullRefPtr<BlockStatement> parse_block_statement();
     NonnullRefPtr<ReturnStatement> parse_return_statement();
-    NonnullRefPtr<VariableDeclaration> parse_variable_declaration();
-    NonnullRefPtr<ForStatement> parse_for_statement();
+    NonnullRefPtr<VariableDeclaration> parse_variable_declaration(bool with_semicolon = true);
+    NonnullRefPtr<Statement> parse_for_statement();
+    NonnullRefPtr<Statement> parse_for_in_of_statement(NonnullRefPtr<ASTNode> lhs);
     NonnullRefPtr<IfStatement> parse_if_statement();
     NonnullRefPtr<ThrowStatement> parse_throw_statement();
     NonnullRefPtr<TryStatement> parse_try_statement();
@@ -65,7 +66,7 @@ public:
     NonnullRefPtr<DebuggerStatement> parse_debugger_statement();
     NonnullRefPtr<ConditionalExpression> parse_conditional_expression(NonnullRefPtr<Expression> test);
 
-    NonnullRefPtr<Expression> parse_expression(int min_precedence, Associativity associate = Associativity::Right);
+    NonnullRefPtr<Expression> parse_expression(int min_precedence, Associativity associate = Associativity::Right, Vector<TokenType> forbidden = {});
     NonnullRefPtr<Expression> parse_primary_expression();
     NonnullRefPtr<Expression> parse_unary_prefixed_expression();
     NonnullRefPtr<ObjectExpression> parse_object_expression();
@@ -105,7 +106,7 @@ private:
     Associativity operator_associativity(TokenType) const;
     bool match_expression() const;
     bool match_unary_prefixed_expression() const;
-    bool match_secondary_expression() const;
+    bool match_secondary_expression(Vector<TokenType> forbidden = {}) const;
     bool match_statement() const;
     bool match_variable_declaration() const;
     bool match_identifier_name() const;

--- a/Libraries/LibJS/Tests/Array.prototype-generic-functions.js
+++ b/Libraries/LibJS/Tests/Array.prototype-generic-functions.js
@@ -73,67 +73,47 @@ try {
     const o = { length: 5, 0: "foo", 1: "bar", 3: "baz" };
 
     {
-        const visited = [];
-        Array.prototype.every.call(o, function (value) {
-            visited.push(value);
-            return true;
-        });
-        assert(visited.length === 3);
-        assert(visited[0] === "foo");
-        assert(visited[1] === "bar");
-        assert(visited[2] === "baz");
+        assertVisitsAll(visit => {
+            Array.prototype.every.call(o, function (value) {
+                visit(value);
+                return true;
+            });
+        }, ["foo", "bar", "baz"]);
     }
 
     ["find", "findIndex"].forEach(name => {
-        const visited = [];
-        Array.prototype[name].call(o, function (value) {
-            visited.push(value);
-            return false;
-        });
-        assert(visited.length === 5);
-        assert(visited[0] === "foo");
-        assert(visited[1] === "bar");
-        assert(visited[2] === undefined);
-        assert(visited[3] === "baz");
-        assert(visited[4] === undefined);
+        assertVisitsAll(visit => {
+            Array.prototype[name].call(o, function (value) {
+                visit(value);
+                return false;
+            });
+        }, ["foo", "bar", undefined, "baz", undefined]);
     });
 
     ["filter", "forEach", "map", "some"].forEach(name => {
-        const visited = [];
-        Array.prototype[name].call(o, function (value) {
-            visited.push(value);
-            return false;
-        });
-        assert(visited.length === 3);
-        assert(visited[0] === "foo");
-        assert(visited[1] === "bar");
-        assert(visited[2] === "baz");
+        assertVisitsAll(visit => {
+            Array.prototype[name].call(o, function (value) {
+                visit(value);
+                return false;
+            });
+        }, ["foo", "bar", "baz"]);
     });
-
     {
-        const visited = [];
-        Array.prototype.reduce.call(o, function (_, value) {
-            visited.push(value);
-            return false;
-        }, "initial");
-
-        assert(visited.length === 3);
-        assert(visited[0] === "foo");
-        assert(visited[1] === "bar");
-        assert(visited[2] === "baz");
+        assertVisitsAll(visit => {
+            Array.prototype.reduce.call(o, function (_, value) {
+                visit(value);
+                return false;
+            }, "initial");
+        }, ["foo", "bar", "baz"]);
     }
 
     {
-        const visited = [];
-        Array.prototype.reduceRight.call(o, function (_, value) {
-            visited.push(value);
-            return false;
-        }, "initial");
-
-        assert(visited.length === 3);
-        assert(visited[2] === "foo");
-        assert(visited[1] === "bar");
-        assert(visited[0] === "baz");
+        assertVisitsAll(visit => {
+            Array.prototype.reduceRight.call(o, function (_, value) {
+                visit(value);
+                return false;
+            }, "initial");
+        }, ["baz", "bar", "foo"]);
     }
 
     console.log("PASS");

--- a/Libraries/LibJS/Tests/for-in-basic.js
+++ b/Libraries/LibJS/Tests/for-in-basic.js
@@ -1,0 +1,41 @@
+load("test-common.js");
+
+try {
+    assertVisitsAll(visit => {
+        for (const property in "") {
+            visit(property);
+        }
+    }, []);
+
+    assertVisitsAll(visit => {
+        for (const property in 123) {
+            visit(property);
+        }
+    }, []);
+
+    assertVisitsAll(visit => {
+        for (const property in {}) {
+            visit(property);
+        }
+    }, []);
+
+    assertVisitsAll(visit => {
+        for (const property in "hello") {
+            visit(property);
+        }
+    }, ["0", "1", "2", "3", "4"]);
+
+    assertVisitsAll(visit => {
+        for (const property in {a: 1, b: 2, c: 2}) {
+            visit(property);
+        }
+    }, ["a", "b", "c"]);
+
+    var property;
+    for (property in "abc");
+    assert(property === "2");
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/for-of-basic.js
+++ b/Libraries/LibJS/Tests/for-of-basic.js
@@ -1,0 +1,43 @@
+load("test-common.js");
+
+try {
+    assertThrowsError(() => {
+        for (const _ of 123) {}
+    }, {
+        error: TypeError,
+        message: "for..of right-hand side must be iterable"
+    });
+
+    assertThrowsError(() => {
+        for (const _ of {foo: 1, bar: 2}) {}
+    }, {
+        error: TypeError,
+        message: "for..of right-hand side must be iterable"
+    });
+
+    assertVisitsAll(visit => {
+        for (const num of [1, 2, 3]) {
+            visit(num);
+        }
+    }, [1, 2, 3]);
+
+    assertVisitsAll(visit => {
+        for (const char of "hello") {
+            visit(char);
+        }
+    }, ["h", "e", "l", "l", "o"]);
+
+    assertVisitsAll(visit => {
+        for (const char of new String("hello")) {
+            visit(char);
+        }
+    }, ["h", "e", "l", "l", "o"]);
+
+    var char;
+    for (char of "abc");
+    assert(char === "c");
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -50,6 +50,13 @@ function assertThrowsError(testFunction, options) {
     }
 }
 
+const assertVisitsAll = (testFunction, expectedOutput) => {
+    const visited = [];
+    testFunction(value => visited.push(value));
+    assert(visited.length === expectedOutput.length);
+    expectedOutput.forEach((value, i) => assert(visited[i] === value));
+};
+
 /**
  * Check whether the difference between two numbers is less than 0.000001.
  * @param {Number} a First number


### PR DESCRIPTION
Draft for now, still needs a bit of work.

TODO:

- [x] Make object properties non-{writable,enumerable,configurable} unless specified otherwise (https://tc39.es/ecma262/#table-default-attribute-values)
- [x] Implement array-like indexing of strings - i.e. "foo" has the properties "0", "1" and "2"
- [x] go through the code with a fresh mind and clean that mess up (well, some of it at least)

I'd prefer to _not_ implement the iterable & iterator protocol in this PR and wing it instead, for now.