### PR TITLE
LibJS: Fix Array.prototype.indexOf fromIndex negative

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -333,7 +333,7 @@ Value ArrayPrototype::index_of(Interpreter& interpreter)
         if (from_index < negative_min_index)
             from_index = 0;
         else if (from_index < 0)
-            from_index = (array_size - 1) + from_index;
+            from_index = array_size + from_index;
     }
 
     auto search_element = interpreter.argument(0);

--- a/Libraries/LibJS/Tests/Array.prototype.indexOf.js
+++ b/Libraries/LibJS/Tests/Array.prototype.indexOf.js
@@ -14,6 +14,9 @@ try {
     assert(array.indexOf(1, 1000) === -1);
     assert(array.indexOf(1, -1000) === 2);
     assert(array.indexOf('serenity') === -1);
+    assert(array.indexOf(false, -1) === 4);
+    assert(array.indexOf(2, -1) === -1);
+    assert(array.indexOf(2, -2) === 3);
     assert([].indexOf('serenity') === -1);
     assert([].indexOf('serenity', 10) === -1);
     assert([].indexOf('serenity', -10) === -1);


### PR DESCRIPTION
If negative fromIndex considers displacement from the end of the array
without decreasing 1 of de size.