### PR TITLE
Kernel: Basic core dump memory files

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -312,6 +312,7 @@ public:
 
     [[noreturn]] void crash(int signal, u32 eip);
     [[nodiscard]] static siginfo_t reap(Process&);
+    void create_core_dump();
 
     const TTY* tty() const { return m_tty; }
     void set_tty(TTY*);
@@ -382,6 +383,7 @@ public:
 
     void terminate_due_to_signal(u8 signal);
     void send_signal(u8, Process* sender);
+    void set_dump_core(bool enable) { m_should_dump_core = enable; }
 
     u16 thread_count() const { return m_thread_count; }
 
@@ -482,6 +484,7 @@ private:
     u8 m_termination_status { 0 };
     u8 m_termination_signal { 0 };
     u16 m_thread_count { 0 };
+    bool m_should_dump_core { false };
 
     bool m_dead { false };
     bool m_profiling { false };

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -541,6 +541,8 @@ ShouldUnblockThread Thread::dispatch_signal(u8 signal)
             set_state(Stopped);
             return ShouldUnblockThread::No;
         case DefaultSignalAction::DumpCore:
+            m_process.set_dump_core(true);
+            dbg() << "Yikes!";
             process().for_each_thread([](auto& thread) {
                 thread.set_dump_backtrace_on_finalization();
                 return IterationDecision::Continue;
@@ -575,8 +577,7 @@ ShouldUnblockThread Thread::dispatch_signal(u8 signal)
 
     m_signal_mask |= new_signal_mask;
 
-    auto setup_stack = [&]<typename ThreadState>(ThreadState state, u32 * stack)
-    {
+    auto setup_stack = [&]<typename ThreadState>(ThreadState state, u32* stack) {
         u32 old_esp = *stack;
         u32 ret_eip = state.eip;
         u32 ret_eflags = state.eflags;


### PR DESCRIPTION
The Kernel now has a way to generate core dump files when a process
terminates abnormally or outright crashes. It can currently dump
all virtual regions to a file, which can then be opened in GDB to
inspect what the procecss did before it crashed. Note that this
currently doesn't contain code to generate `PT_NOTE` headers,
so GDB functionality doesn't work (though memory regions can be
viewed for at least _some_ debugging functionality)

Here's an image of a generated file from `crash`

![Image](https://i.imgur.com/TJcvLa1.png)

This is going to be part of a bigger system that gives a popup window (similar to Ubuntu) for when a program crashes, so the user is actually informed that the program has terminated abnormally, similar to `Apport` or `Dr. Konqi`