### PR TITLE
LibCore: read_bool_entry parse "true" / "false" strings in config files

### DIFF
--- a/Libraries/LibCore/ConfigFile.cpp
+++ b/Libraries/LibCore/ConfigFile.cpp
@@ -138,7 +138,10 @@ int ConfigFile::read_num_entry(const String& group, const String& key, int defau
 
 bool ConfigFile::read_bool_entry(const String& group, const String& key, bool default_value) const
 {
-    return read_entry(group, key, default_value ? "1" : "0") == "1";
+    auto value = read_entry(group, key, default_value ? "1" : "0");
+    if (value == "1" || value.to_lowercase() == "true")
+        return 1;
+    return 0;
 }
 
 void ConfigFile::write_entry(const String& group, const String& key, const String& value)


### PR DESCRIPTION
`read_bool_entry()` can now interpret both integers (1 or 0) and
Boolean strings ("true" or "false") in configuration files.

All values other than "1" or "true" are considered false.