### PR TITLE
Desktop: Context menu!

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -200,12 +200,18 @@ int run_in_desktop_mode(RefPtr<Core::ConfigFile> config, String initial_location
         }
     });
 
+    auto file_manager_action = GUI::Action::create("Show in FileManager...", {}, Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-folder.png"), [&](const GUI::Action&) {
+        Core::DesktopServices::open(URL::create_with_file_protocol(model->root_path()));
+    });
+
     auto display_properties_action = GUI::Action::create("Display properties...", {}, Gfx::Bitmap::load_from_file("/res/icons/16x16/app-display-properties.png"), [&](const GUI::Action&) {
         Core::DesktopServices::open(URL::create_with_file_protocol("/bin/DisplayProperties"));
     });
 
     desktop_view_context_menu->add_action(mkdir_action);
     desktop_view_context_menu->add_action(touch_action);
+    desktop_view_context_menu->add_separator();
+    desktop_view_context_menu->add_action(file_manager_action);
     desktop_view_context_menu->add_separator();
     desktop_view_context_menu->add_action(display_properties_action);
 

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -200,8 +200,14 @@ int run_in_desktop_mode(RefPtr<Core::ConfigFile> config, String initial_location
         }
     });
 
+    auto display_properties_action = GUI::Action::create("Display properties...", {}, Gfx::Bitmap::load_from_file("/res/icons/16x16/app-display-properties.png"), [&](const GUI::Action&) {
+        Core::DesktopServices::open(URL::create_with_file_protocol("/bin/DisplayProperties"));
+    });
+
     desktop_view_context_menu->add_action(mkdir_action);
     desktop_view_context_menu->add_action(touch_action);
+    desktop_view_context_menu->add_separator();
+    desktop_view_context_menu->add_action(display_properties_action);
 
     item_view.on_context_menu_request = [&](const GUI::ModelIndex& index, const GUI::ContextMenuEvent& event) {
         if (!index.is_valid())


### PR DESCRIPTION
Currently only adds a basic context menu for when you click the background. I'll maybe work on file and folder context menus when I figure out how to reduce code duplication.

<img width="1136" alt="Screen Shot 2020-04-22 at 2 07 51 PM" src="https://user-images.githubusercontent.com/47130239/80023136-b4234480-84a2-11ea-933a-a91a514f6ecf.png">
