### PR TITLE
IRCClient: Connect to IRC server URL specified in command line argument

### DIFF
--- a/Applications/IRCClient/IRCAppWindow.cpp
+++ b/Applications/IRCClient/IRCAppWindow.cpp
@@ -49,8 +49,8 @@ IRCAppWindow& IRCAppWindow::the()
     return *s_the;
 }
 
-IRCAppWindow::IRCAppWindow()
-    : m_client(IRCClient::construct())
+IRCAppWindow::IRCAppWindow(String server, int port)
+    : m_client(IRCClient::construct(server, port))
 {
     ASSERT(!s_the);
     s_the = this;

--- a/Applications/IRCClient/IRCAppWindow.h
+++ b/Applications/IRCClient/IRCAppWindow.h
@@ -41,7 +41,7 @@ public:
     void set_active_window(IRCWindow&);
 
 private:
-    IRCAppWindow();
+    IRCAppWindow(String server, int port);
 
     void setup_client();
     void setup_actions();

--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -67,7 +67,7 @@ enum IRCNumeric {
     ERR_NICKNAMEINUSE = 433,
 };
 
-IRCClient::IRCClient()
+IRCClient::IRCClient(String server, int port)
     : m_nickname("seren1ty")
     , m_client_window_list_model(IRCWindowListModel::create(*this))
     , m_log(IRCLogBuffer::create())
@@ -76,8 +76,14 @@ IRCClient::IRCClient()
     struct passwd* user_pw = getpwuid(getuid());
     m_socket = Core::TCPSocket::construct(this);
     m_nickname = m_config->read_entry("User", "Nickname", String::format("%s_seren1ty", user_pw->pw_name));
-    m_hostname = m_config->read_entry("Connection", "Server", "");
-    m_port = m_config->read_num_entry("Connection", "Port", 6667);
+
+    if (server.is_empty()) {
+        m_hostname = m_config->read_entry("Connection", "Server", "");
+        m_port = m_config->read_num_entry("Connection", "Port", 6667);
+    } else {
+        m_hostname = server;
+        m_port = port ? port : 6667;
+    }
 
     m_show_join_part_messages = m_config->read_bool_entry("Messaging", "ShowJoinPartMessages", 1);
     m_show_nick_change_messages = m_config->read_bool_entry("Messaging", "ShowNickChangeMessages", 1);

--- a/Applications/IRCClient/IRCClient.h
+++ b/Applications/IRCClient/IRCClient.h
@@ -138,7 +138,7 @@ public:
     void add_server_message(const String&, Color = Color::Black);
 
 private:
-    IRCClient();
+    IRCClient(String server, int port);
 
     struct Message {
         String prefix;

--- a/Libraries/LibCore/DesktopServices.cpp
+++ b/Libraries/LibCore/DesktopServices.cpp
@@ -39,6 +39,9 @@ bool DesktopServices::open(const URL& url)
     if (url.protocol() == "file")
         return open_file_url(url);
 
+    if (url.protocol() == "irc")
+        return spawn("/bin/IRCClient", url.to_string());
+
     return spawn("/bin/Browser", url.to_string());
 }
 


### PR DESCRIPTION
The IRCClient application can now connect to a specified IRC server using
a URL with `irc://` protocol as a command line argument.

If the URL is invalid, the application will report a relevant error message to `stderr` and exit.

If a URL is not supplied, the application will fall back to the server connection details specified in the user's `IRCClient.ini` configuration file. If the configuration file does not contain connection details, the user is prompted to enter a server address. (This is the current behavior, unchanged by this PR.)

![IRCClient](https://user-images.githubusercontent.com/434827/80037183-7839bf00-8536-11ea-86c6-a6376029fc3d.png)

Using a URL as a command line argument is inline with the current development direction, such as support for `file://` (`FileManager`, `SoundPlayer`, `QuickShow`) and `http://` (`Browser`) URLs elsewhere.

In my opinion, use of URI handlers fits with existing operating system design, and fits with "the essence of Serenity": putting a modern spin on a classic Unix thing.

As for "how is it better", I offer the following exaggeration for comparisson:

```
IRCClient ircs://irc.local.tld:6697
# versus
IRCClient --connect-to-this-server irc.local.tld --on-this-port 6697 --and-also-use-ssl
```

Note: Secure IRC `ircs` is not yet supported due to lack of SSL/TLS libraries.

Eventually this can be reworked to also allow `/#channel-name` in the URL path.

I toyed with handling the `server` and `port` in the `IRCAppWindow`, rather than `IRCClient`, however the latter makes mores sense. In the future, we may wish to support instantiating multiple `IRCClient` objects to support connecting to multiple servers, or handling changing connections from one server to another within one `IRCAppWindow`.

This is also a step towards decoupling the hard-coded connection settings in the configuration file, allowing for cleaner instantiation of new `IRCClient` objects.
