### PR TITLE
Add ColorInput, TabWidget and MessageBox demos in WidgetGallery

### DIFF
--- a/Demos/WidgetGallery/main.cpp
+++ b/Demos/WidgetGallery/main.cpp
@@ -29,13 +29,16 @@
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/CheckBox.h>
+#include <LibGUI/ColorInput.h>
 #include <LibGUI/GroupBox.h>
 #include <LibGUI/Label.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/ProgressBar.h>
 #include <LibGUI/RadioButton.h>
 #include <LibGUI/ScrollBar.h>
 #include <LibGUI/Slider.h>
 #include <LibGUI/SpinBox.h>
+#include <LibGUI/TabWidget.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
@@ -45,53 +48,77 @@ int main(int argc, char** argv)
     GUI::Application app(argc, argv);
 
     auto window = GUI::Window::construct();
-    window->set_rect(100, 100, 320, 620);
+    window->set_rect(100, 100, 400, 487);
     window->set_title("Widget Gallery");
 
-    auto& main_widget = window->set_main_widget<GUI::Widget>();
-    main_widget.set_fill_with_background_color(true);
-    main_widget.set_layout<GUI::VerticalBoxLayout>();
-    main_widget.layout()->set_margins({ 4, 4, 4, 4 });
+    auto& root_widget = window->set_main_widget<GUI::Widget>();
+    root_widget.set_fill_with_background_color(true);
+    root_widget.set_layout<GUI::VerticalBoxLayout>();
+    root_widget.layout()->set_margins({ 4, 4, 4, 4 });
 
-    auto& checkbox1 = main_widget.add<GUI::CheckBox>("CheckBox 1");
+    auto& tab_widget = root_widget.add<GUI::TabWidget>();
+
+    auto& tab_basic = tab_widget.add_tab<GUI::Widget>("Basic");
+    tab_basic.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fill);
+    tab_basic.set_layout<GUI::VerticalBoxLayout>();
+    tab_basic.layout()->set_margins({ 4, 4, 4, 4 });
+    tab_basic.layout()->set_spacing(4);
+
+    auto& checkbox1 = tab_basic.add<GUI::CheckBox>("CheckBox 1");
     (void)checkbox1;
-    auto& checkbox2 = main_widget.add<GUI::CheckBox>("CheckBox 2");
+    auto& checkbox2 = tab_basic.add<GUI::CheckBox>("CheckBox 2");
     checkbox2.set_enabled(false);
 
-    auto& radio1 = main_widget.add<GUI::RadioButton>("RadioButton 1");
+    auto& radio1 = tab_basic.add<GUI::RadioButton>("RadioButton 1");
     (void)radio1;
-    auto& radio2 = main_widget.add<GUI::RadioButton>("RadioButton 2");
+    auto& radio2 = tab_basic.add<GUI::RadioButton>("RadioButton 2");
     radio2.set_enabled(false);
 
-    auto& button1 = main_widget.add<GUI::Button>("Button 1");
+    auto& button1 = tab_basic.add<GUI::Button>("Button 1");
     (void)button1;
-    auto& button2 = main_widget.add<GUI::Button>("Button 2");
+    auto& button2 = tab_basic.add<GUI::Button>("Button 2");
     button2.set_enabled(false);
 
-    auto& progress1 = main_widget.add<GUI::ProgressBar>();
+    auto& progress1 = tab_basic.add<GUI::ProgressBar>();
     progress1.add<Core::Timer>(100, [&] {
         progress1.set_value(progress1.value() + 1);
         if (progress1.value() == progress1.max())
             progress1.set_value(progress1.min());
     });
 
-    auto& label1 = main_widget.add<GUI::Label>("Label 1");
+    auto& label1 = tab_basic.add<GUI::Label>("Label 1");
     (void)label1;
-    auto& label2 = main_widget.add<GUI::Label>("Label 2");
+    auto& label2 = tab_basic.add<GUI::Label>("Label 2");
     label2.set_enabled(false);
 
-    auto& textbox1 = main_widget.add<GUI::TextBox>();
+    auto& textbox1 = tab_basic.add<GUI::TextBox>();
     textbox1.set_text("TextBox 1");
-    auto& textbox2 = main_widget.add<GUI::TextBox>();
+    auto& textbox2 = tab_basic.add<GUI::TextBox>();
     textbox2.set_text("TextBox 2");
     textbox2.set_enabled(false);
 
-    auto& spinbox1 = main_widget.add<GUI::SpinBox>();
+    auto& spinbox1 = tab_basic.add<GUI::SpinBox>();
     (void)spinbox1;
-    auto& spinbox2 = main_widget.add<GUI::SpinBox>();
+    auto& spinbox2 = tab_basic.add<GUI::SpinBox>();
     spinbox2.set_enabled(false);
 
-    auto& vertical_slider_container = main_widget.add<GUI::Widget>();
+    auto& color_input_enabled = tab_basic.add<GUI::ColorInput>();
+    color_input_enabled.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fill);
+    color_input_enabled.set_color(Color::from_string("#573666ff").value());
+    color_input_enabled.set_color_picker_title("Select color for desktop");
+
+    auto& color_input_disabled = tab_basic.add<GUI::ColorInput>();
+    color_input_disabled.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fill);
+    color_input_disabled.set_color(Color::from_string("#573666ff").value());
+    color_input_disabled.set_enabled(false);
+
+    auto& tab_others = tab_widget.add_tab<GUI::Widget>("Sliders");
+    tab_others.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fill);
+    tab_others.set_layout<GUI::VerticalBoxLayout>();
+    tab_others.layout()->set_margins({ 4, 4, 4, 4 });
+    tab_others.layout()->set_spacing(4);
+
+    auto& vertical_slider_container = tab_others.add<GUI::Widget>();
     vertical_slider_container.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
     vertical_slider_container.set_preferred_size(0, 100);
     vertical_slider_container.set_layout<GUI::HorizontalBoxLayout>();
@@ -103,24 +130,101 @@ int main(int argc, char** argv)
     vslider3.set_max(5);
     vslider3.set_knob_size_mode(GUI::Slider::KnobSizeMode::Proportional);
 
-    auto& slider1 = main_widget.add<GUI::HorizontalSlider>();
+    auto& slider1 = tab_others.add<GUI::HorizontalSlider>();
     (void)slider1;
-    auto& slider2 = main_widget.add<GUI::HorizontalSlider>();
+    auto& slider2 = tab_others.add<GUI::HorizontalSlider>();
     slider2.set_enabled(false);
-    auto& slider3 = main_widget.add<GUI::HorizontalSlider>();
+    auto& slider3 = tab_others.add<GUI::HorizontalSlider>();
     slider3.set_max(5);
     slider3.set_knob_size_mode(GUI::Slider::KnobSizeMode::Proportional);
 
-    auto& scrollbar1 = main_widget.add<GUI::ScrollBar>(Orientation::Horizontal);
+    auto& scrollbar1 = tab_others.add<GUI::ScrollBar>(Orientation::Horizontal);
     scrollbar1.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
     scrollbar1.set_preferred_size(0, 16);
     scrollbar1.set_min(0);
     scrollbar1.set_max(100);
     scrollbar1.set_value(50);
-    auto& scrollbar2 = main_widget.add<GUI::ScrollBar>(Orientation::Horizontal);
+    auto& scrollbar2 = tab_others.add<GUI::ScrollBar>(Orientation::Horizontal);
     scrollbar2.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
     scrollbar2.set_preferred_size(0, 16);
     scrollbar2.set_enabled(false);
+
+    auto& tab_msgbox = tab_widget.add_tab<GUI::Widget>("Message Box");
+    tab_msgbox.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fill);
+    tab_msgbox.set_layout<GUI::VerticalBoxLayout>();
+    tab_msgbox.layout()->set_margins({ 4, 4, 4, 4 });
+    tab_msgbox.layout()->set_spacing(4);
+
+    GUI::MessageBox::Type msg_box_type = GUI::MessageBox::Type::Error;
+
+    auto& icon_group_box = tab_msgbox.add<GUI::GroupBox>("Icon");
+    icon_group_box.set_layout<GUI::VerticalBoxLayout>();
+    icon_group_box.layout()->set_margins({ 5, 15, 5, 5 });
+    icon_group_box.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
+    icon_group_box.set_preferred_size(0, 120);
+
+    auto& radio_none = icon_group_box.add<GUI::RadioButton>("None");
+    radio_none.on_checked = [&](bool) {
+        msg_box_type = GUI::MessageBox::Type::None;
+    };
+    auto& radio_information = icon_group_box.add<GUI::RadioButton>("Information");
+    radio_information.on_checked = [&](bool) {
+        msg_box_type = GUI::MessageBox::Type::Information;
+    };
+    auto& radio_warning = icon_group_box.add<GUI::RadioButton>("Warning");
+    radio_warning.on_checked = [&](bool) {
+        msg_box_type = GUI::MessageBox::Type::Warning;
+    };
+    auto& radio_error = icon_group_box.add<GUI::RadioButton>("Error");
+    radio_error.set_checked(true);
+    radio_error.on_checked = [&](bool) {
+        msg_box_type = GUI::MessageBox::Type::Error;
+    };
+
+    auto& button_group_box = tab_msgbox.add<GUI::GroupBox>("Buttons");
+    button_group_box.set_layout<GUI::VerticalBoxLayout>();
+    button_group_box.layout()->set_margins({ 5, 10, 5, 5 });
+    button_group_box.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
+    button_group_box.set_preferred_size(0, 120);
+
+    GUI::MessageBox::InputType msg_box_input_type = GUI::MessageBox::InputType::OKCancel;
+
+    auto& radio_ok = button_group_box.add<GUI::RadioButton>("OK");
+    radio_ok.on_checked = [&](bool) {
+        msg_box_input_type = GUI::MessageBox::InputType::OK;
+    };
+    auto& radio_ok_cancel = button_group_box.add<GUI::RadioButton>("OK & Cancel");
+    radio_ok_cancel.set_checked(true);
+    radio_ok_cancel.on_checked = [&](bool) {
+        msg_box_input_type = GUI::MessageBox::InputType::OKCancel;
+    };
+    auto& radio_yes_no = button_group_box.add<GUI::RadioButton>("Yes & No");
+    radio_yes_no.on_checked = [&](bool) {
+        msg_box_input_type = GUI::MessageBox::InputType::YesNo;
+    };
+    auto& radio_yes_no_cancel = button_group_box.add<GUI::RadioButton>("Yes & No & Cancel");
+    radio_yes_no_cancel.on_checked = [&](bool) {
+        msg_box_input_type = GUI::MessageBox::InputType::YesNoCancel;
+    };
+
+    auto& title_textbox = tab_msgbox.add<GUI::TextBox>();
+    title_textbox.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
+    title_textbox.set_preferred_size(0, 20);
+    title_textbox.set_text("Demo Title");
+
+    auto& content_textbox = tab_msgbox.add<GUI::TextBox>();
+    content_textbox.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
+    content_textbox.set_preferred_size(0, 20);
+    content_textbox.set_text("Demo text for message box.");
+
+    auto& show_buton = tab_msgbox.add<GUI::Button>("Show");
+    show_buton.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
+    show_buton.set_preferred_size(0, 20);
+    show_buton.on_click = [&]() {
+        GUI::MessageBox::show(content_textbox.text(), title_textbox.text(), msg_box_type, msg_box_input_type, window);
+    };
+
+    tab_msgbox.layout()->add_spacer();
 
     window->show();
 

--- a/Libraries/LibGUI/MessageBox.cpp
+++ b/Libraries/LibGUI/MessageBox.cpp
@@ -101,43 +101,45 @@ void MessageBox::build()
     widget.set_layout<VerticalBoxLayout>();
     widget.set_fill_with_background_color(true);
 
-    widget.layout()->set_margins({ 0, 15, 0, 15 });
-    widget.layout()->set_spacing(15);
+    widget.layout()->set_margins({ 8, 8, 8, 8 });
+    widget.layout()->set_spacing(8);
 
-    RefPtr<Widget> message_container = widget;
+    auto& message_container = widget.add<Widget>();
+    message_container.set_layout<HorizontalBoxLayout>();
+    message_container.layout()->set_margins({ 8, 0, 0, 0 });
+    message_container.layout()->set_spacing(8);
+
     if (m_type != Type::None) {
-        message_container = widget.add<Widget>();
-        message_container->set_layout<HorizontalBoxLayout>();
-        message_container->layout()->set_margins({ 8, 0, 8, 0 });
-        message_container->layout()->set_spacing(8);
-
-        auto& icon_label = message_container->add<Label>();
+        auto& icon_label = message_container.add<Label>();
         icon_label.set_size_policy(SizePolicy::Fixed, SizePolicy::Fixed);
         icon_label.set_preferred_size(32, 32);
         icon_label.set_icon(icon());
         icon_width = icon_label.icon()->width();
     }
 
-    auto& label = message_container->add<Label>(m_text);
+    auto& label = message_container.add<Label>(m_text);
     label.set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
     label.set_preferred_size(text_width, 16);
+    if (m_type != Type::None)
+        label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
     auto& button_container = widget.add<Widget>();
     button_container.set_layout<HorizontalBoxLayout>();
-    button_container.layout()->set_spacing(5);
-    button_container.layout()->set_margins({ 15, 0, 15, 0 });
+    button_container.set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
+    button_container.set_preferred_size(0, 24);
+    button_container.layout()->set_spacing(8);
 
     auto add_button = [&](String label, Dialog::ExecResult result) {
         auto& button = button_container.add<Button>();
-        button.set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
-        button.set_preferred_size(0, 20);
+        button.set_size_policy(SizePolicy::Fixed, SizePolicy::Fill);
+        button.set_preferred_size(96, 0);
         button.set_text(label);
         button.on_click = [this, label, result] {
-            dbg() << "GUI::MessageBox: '" << label << "' button clicked";
             done(result);
         };
     };
 
+    button_container.layout()->add_spacer();
     if (should_include_ok_button())
         add_button("OK", Dialog::ExecOK);
     if (should_include_yes_button())
@@ -146,8 +148,13 @@ void MessageBox::build()
         add_button("No", Dialog::ExecNo);
     if (should_include_cancel_button())
         add_button("Cancel", Dialog::ExecCancel);
+    button_container.layout()->add_spacer();
 
-    set_rect(x(), y(), text_width + icon_width + 80, 115);
+    int width = button_container.child_widgets().size() * 96 + 32;
+    if (width < text_width + icon_width + 56)
+        width = text_width + icon_width + 56;
+
+    set_rect(x(), y(), width, 96);
     set_resizable(false);
 }
 


### PR DESCRIPTION
If message is too short calculate dialog width via buttons count. And icon is present lets align text to left.

![Untitled](https://user-images.githubusercontent.com/2991895/80083808-afbc6180-855e-11ea-824a-6868a1c4136f.png)
