### PR TITLE
LibJS: Object expressions computed properties

### DIFF
--- a/Base/home/anon/js/object-expression.js
+++ b/Base/home/anon/js/object-expression.js
@@ -1,7 +1,10 @@
 const a = 1;
-const object = {a, b: 2};
+const computedKey = "d";
+const object = {a, b: 2, "c": 3, [computedKey]: 2 + 2};
 const emptyObject = {};
 
 console.log(object.a);
 console.log(object.b);
+console.log(object.c);
+console.log(object.d);
 console.log(emptyObject.foo);

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -670,9 +670,30 @@ private:
     NonnullRefPtrVector<VariableDeclarator> m_declarations;
 };
 
+class ObjectProperty final : public ASTNode {
+public:
+    ObjectProperty(NonnullRefPtr<Expression> key, NonnullRefPtr<Expression> value)
+        : m_key(move(key))
+        , m_value(move(value))
+    {
+    }
+
+    const Expression& key() const { return m_key; }
+    const Expression& value() const { return m_value; }
+
+    virtual void dump(int indent) const override;
+    virtual Value execute(Interpreter&) const override;
+
+private:
+    virtual const char* class_name() const override { return "ObjectProperty"; }
+
+    NonnullRefPtr<Expression> m_key;
+    NonnullRefPtr<Expression> m_value;
+};
+
 class ObjectExpression : public Expression {
 public:
-    ObjectExpression(HashMap<FlyString, NonnullRefPtr<Expression>> properties = {})
+    ObjectExpression(NonnullRefPtrVector<ObjectProperty> properties = {})
         : m_properties(move(properties))
     {
     }
@@ -683,7 +704,7 @@ public:
 private:
     virtual const char* class_name() const override { return "ObjectExpression"; }
 
-    HashMap<FlyString, NonnullRefPtr<Expression>> m_properties;
+    NonnullRefPtrVector<ObjectProperty> m_properties;
 };
 
 class ArrayExpression : public Expression {

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -440,8 +440,10 @@ NonnullRefPtr<ObjectExpression> Parser::parse_object_expression()
 
     while (!done() && !match(TokenType::CurlyClose)) {
         FlyString property_name;
+        auto need_colon = true;
         if (match_identifier_name()) {
             property_name = consume().value();
+            need_colon = false;
         } else if (match(TokenType::StringLiteral)) {
             property_name = consume(TokenType::StringLiteral).string_value();
         } else if (match(TokenType::NumericLiteral)) {
@@ -457,7 +459,7 @@ NonnullRefPtr<ObjectExpression> Parser::parse_object_expression()
             continue;
         }
 
-        if (match(TokenType::Colon)) {
+        if (need_colon || match(TokenType::Colon)) {
             consume(TokenType::Colon);
             properties.set(property_name, parse_expression(0));
         } else {

--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -1,13 +1,27 @@
 load("test-common.js");
 
 try {
-    var o = { 1: 23, foo: "bar", "hello": "friends" };
+    var foo = "bar";
+    var computed = "computed"
+    var o = {
+        1: 23,
+        foo,
+        bar: "baz",
+        "hello": "friends",
+        [1 + 2]: 42,
+        ["I am a " + computed + " key"]: foo,
+        duplicate: "hello",
+        duplicate: "world"
+    };
     assert(o[1] === 23);
     assert(o["1"] === 23);
     assert(o.foo === "bar");
     assert(o["foo"] === "bar");
     assert(o.hello === "friends");
     assert(o["hello"] === "friends");
+    assert(o[3] === 42);
+    assert(o["I am a computed key"] === "bar");
+    assert(o.duplicate === "world");
     o.baz = "test";
     assert(o.baz === "test");
     assert(o["baz"] === "test");
@@ -30,6 +44,25 @@ try {
     assert(o2.for === 1);
     assert(o2.catch === 1);
     assert(o2.break === 1);
+
+    var a;
+    var append = x => { a.push(x); };
+
+    a = [];
+    var o3 = {[append(1)]: 1, [append(2)]: 2, [append(3)]: 3}
+    assert(a.length === 3);
+    assert(a[0] === 1);
+    assert(a[1] === 2);
+    assert(a[2] === 3);
+    assert(o3.undefined === 3);
+
+    a = [];
+    var o4 = {"test": append(1), "test": append(2), "test": append(3)}
+    assert(a.length === 3);
+    assert(a[0] === 1);
+    assert(a[1] === 2);
+    assert(a[2] === 3);
+    assert(o4.test === undefined);
 
     console.log("PASS");
 } catch (e) {


### PR DESCRIPTION
Had to change the datastructure for `ObjectExpression`s from `HashMap` to `Vector` as we need to execute all keys and values, even for duplicates.

(see updated tests for examples)