### PR TITLE
LibJS: Fix left shift operator

### DIFF
--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -259,7 +259,7 @@ Value left_shift(Interpreter&, Value lhs, Value rhs)
     auto rhs_number = rhs.to_number();
     if (!rhs_number.is_finite_number())
         return lhs_number;
-    return Value((i32)lhs_number.as_double() << (i32)lhs_number.as_double());
+    return Value((i32)lhs_number.as_double() << (i32)rhs_number.as_double());
 }
 
 Value right_shift(Interpreter&, Value lhs, Value rhs)


### PR DESCRIPTION
Typo causing it to compute lhs << lhs, not lhs << rhs as expected.