### PR TITLE
LibJS: Fix ObjectExpression::execute()

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -967,11 +967,11 @@ Value ObjectExpression::execute(Interpreter& interpreter) const
 {
     auto* object = Object::create_empty(interpreter, interpreter.global_object());
     for (auto& property : m_properties) {
-        auto key_result = property.key()->execute(interpreter);
+        auto key_result = property.key().execute(interpreter);
         if (interpreter.exception())
             return {};
         auto key = key_result.to_string();
-        auto value = property.value()->execute(interpreter);
+        auto value = property.value().execute(interpreter);
         if (interpreter.exception())
             return {};
         object->put(key, value);


### PR DESCRIPTION
Change from code review changed key() and value() getters - forgot to
update this...