### PR TITLE
AK: StringView uses WeakPtr instead of raw pointer to StringImpl

### DIFF
--- a/AK/LogStream.h
+++ b/AK/LogStream.h
@@ -32,7 +32,6 @@
 
 #if !defined(KERNEL) && !defined(BOOTSTRAPPER)
 #    include <AK/ScopedValueRollback.h>
-#    include <AK/StringView.h>
 #    include <errno.h>
 #    include <unistd.h>
 #endif

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -137,7 +137,7 @@ StringView String::substring_view(size_t start, size_t length) const
     ASSERT(m_impl);
     ASSERT(start + length <= m_impl->length());
     // FIXME: This needs some input bounds checking.
-    return { characters() + start, length };
+    return { characters() + start, length, m_impl };
 }
 
 Vector<String> String::split(char separator, bool keep_empty) const

--- a/AK/String.h
+++ b/AK/String.h
@@ -30,6 +30,7 @@
 #include <AK/RefPtr.h>
 #include <AK/StringImpl.h>
 #include <AK/StringUtils.h>
+#include <AK/StringView.h>
 #include <AK/Traits.h>
 
 namespace AK {

--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -30,6 +30,7 @@
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Types.h>
+#include <AK/Weakable.h>
 #include <AK/kmalloc.h>
 
 namespace AK {
@@ -39,7 +40,8 @@ enum ShouldChomp {
     Chomp
 };
 
-class StringImpl : public RefCounted<StringImpl> {
+class StringImpl : public RefCounted<StringImpl>
+    , public Weakable<StringImpl> {
 public:
     static NonnullRefPtr<StringImpl> create_uninitialized(size_t length, char*& buffer);
     static RefPtr<StringImpl> create(const char* cstring, ShouldChomp = NoChomp);

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -28,7 +28,9 @@
 
 #include <AK/Forward.h>
 #include <AK/StdLibExtras.h>
+#include <AK/StringImpl.h>
 #include <AK/StringUtils.h>
+#include <AK/WeakPtr.h>
 
 namespace AK {
 
@@ -42,8 +44,22 @@ public:
         , m_length(length)
     {
     }
+    StringView(const char* characters, size_t length, const StringImpl* impl)
+        : m_impl(!impl ? nullptr : const_cast<StringImpl*>(impl)->make_weak_ptr())
+        , m_has_impl(impl ? true : false)
+        , m_characters((const char*)characters)
+        , m_length(length)
+    {
+    }
     StringView(const unsigned char* characters, size_t length)
         : m_characters((const char*)characters)
+        , m_length(length)
+    {
+    }
+    StringView(const unsigned char* characters, size_t length, const StringImpl* impl)
+        : m_impl(!impl ? nullptr : const_cast<StringImpl*>(impl)->make_weak_ptr())
+        , m_has_impl(impl ? true : false)
+        , m_characters((const char*)characters)
         , m_length(length)
     {
     }
@@ -52,12 +68,18 @@ public:
         , m_length(cstring ? __builtin_strlen(cstring) : 0)
     {
     }
-
+    [[gnu::always_inline]] inline StringView(const char* cstring, const StringImpl* impl)
+        : m_impl(!impl ? nullptr : const_cast<StringImpl*>(impl)->make_weak_ptr())
+        , m_has_impl(impl ? true : false)
+        , m_characters(cstring)
+        , m_length(cstring ? __builtin_strlen(cstring) : 0)
+    {
+    }
     StringView(const ByteBuffer&);
     StringView(const String&);
     StringView(const FlyString&);
 
-    bool is_null() const { return !m_characters; }
+    bool is_null() const { return !m_characters || (m_has_impl && !m_impl.ptr()); }
     bool is_empty() const { return m_length == 0; }
     const char* characters_without_null_termination() const { return m_characters; }
     size_t length() const { return m_length; }
@@ -140,11 +162,12 @@ public:
         return !(*this == other);
     }
 
-    const StringImpl* impl() const { return m_impl; }
+    const StringImpl* impl() const { return m_impl.ptr(); }
 
 private:
     friend class String;
-    const StringImpl* m_impl { nullptr };
+    WeakPtr<const StringImpl> m_impl { nullptr };
+    bool m_has_impl { false };
     const char* m_characters { nullptr };
     size_t m_length { 0 };
 };

--- a/AK/Tests/TestStringView.cpp
+++ b/AK/Tests/TestStringView.cpp
@@ -111,4 +111,21 @@ TEST_CASE(lines)
     EXPECT_EQ(test_string_vector.at(2).is_empty(), true);
 }
 
+TEST_CASE(impl_scope_unref)
+{
+    StringView test_string_view;
+    {
+        String test_string = "ABCDEF";
+        test_string_view = test_string.substring_view(0, test_string.length());
+
+        EXPECT(test_string.impl() != nullptr);
+        EXPECT(test_string_view.impl() != nullptr);
+    }
+
+    EXPECT(test_string_view.impl() == nullptr);
+
+    EXPECT_EQ(test_string_view.starts_with('A'), false);
+    EXPECT_EQ(test_string_view.is_null(), true);
+}
+
 TEST_MAIN(StringView)

--- a/Libraries/LibGfx/StylePainter.cpp
+++ b/Libraries/LibGfx/StylePainter.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/StringView.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/Palette.h>

--- a/Libraries/LibMarkdown/MDBlock.h
+++ b/Libraries/LibMarkdown/MDBlock.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <AK/Vector.h>
 
 class MDBlock {


### PR DESCRIPTION
This allows more safety in terms of accessing string view characters
when the memory already freed. When using a WeakPtr to the StringImpl,
we can check if the impl already has gone and assure freed memory is
not being accessed anymore.
New constructors for the StringView allow to hand over the impl, and
Strings substring_view method and StringViews own substring_view*
methods hand over the impl to the StringView constructors.
StringViews created from plain C character are not affected.

Needed some const_casts to allow the creation of the WeakPtr and
we don't wont to loose the constness of the String or FlyString
handed over in the constructor.