### PR TITLE
QuickShow: Hide toolbar container in fullscreen mode / on toggle toolbar action

### DIFF
--- a/Applications/QuickShow/main.cpp
+++ b/Applications/QuickShow/main.cpp
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
     auto full_sceen_action = GUI::CommonActions::make_fullscreen_action(
         [&](auto&) {
             window->set_fullscreen(!window->is_fullscreen());
-            main_toolbar.set_visible(!window->is_fullscreen());
+            toolbar_container.set_visible(!window->is_fullscreen());
         });
 
     auto zoom_in_action = GUI::Action::create("Zoom In", { Mod_None, Key_Plus }, Gfx::Bitmap::load_from_file("/res/icons/16x16/zoom-in.png"),

--- a/Applications/QuickShow/main.cpp
+++ b/Applications/QuickShow/main.cpp
@@ -213,13 +213,7 @@ int main(int argc, char** argv)
 
     auto hide_show_toolbar_action = GUI::Action::create("Hide/Show Toolbar", { Mod_Ctrl, Key_T },
         [&](auto&) {
-            main_toolbar.set_visible(!main_toolbar.is_visible());
-
-            if (main_toolbar.is_visible()) {
-                widget.set_toolbar_height(main_toolbar.height());
-            } else {
-                widget.set_toolbar_height(0);
-            }
+            toolbar_container.set_visible(!toolbar_container.is_visible());
         });
 
     auto about_action = GUI::Action::create("About",


### PR DESCRIPTION
If we just hide the toolbar itself, its container is still visible and taking up space at the top of the screen.

![image](https://user-images.githubusercontent.com/19366641/80223015-9c34f780-863f-11ea-98f1-958d3b39f8a2.png)

<div align="center">
:arrow_down:
</div>
<br>

![image](https://user-images.githubusercontent.com/19366641/80222937-7c9dcf00-863f-11ea-8547-b469bac452f2.png)
