### PR TITLE
LibGUI: Fix display issue when selecting multi-lines in TextEditor

### DIFF
--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -99,7 +99,7 @@ void TextEditor::create_actions()
             this);
     }
     m_select_all_action = Action::create(
-        "Select all", { Mod_Ctrl, Key_A },Gfx::Bitmap::load_from_file("/res/icons/16x16/select-all.png"), [this](auto&) { select_all(); }, this);
+        "Select all", { Mod_Ctrl, Key_A }, Gfx::Bitmap::load_from_file("/res/icons/16x16/select-all.png"), [this](auto&) { select_all(); }, this);
 }
 
 void TextEditor::set_text(const StringView& text)
@@ -473,9 +473,12 @@ void TextEditor::paint_event(PaintEvent& event)
             }
             bool physical_line_has_selection = has_selection && line_index >= selection.start().line() && line_index <= selection.end().line();
             if (physical_line_has_selection) {
+                size_t start_of_selection_within_visual_line = (size_t)max(0, (int)selection_start_column_within_line - (int)start_of_visual_line);
+                size_t end_of_selection_within_visual_line = selection_end_column_within_line - start_of_visual_line;
 
-                bool current_visual_line_has_selection = (line_index != selection.start().line() && line_index != selection.end().line())
-                    || (visual_line_index >= first_visual_line_with_selection && visual_line_index <= last_visual_line_with_selection);
+                bool current_visual_line_has_selection = start_of_selection_within_visual_line != end_of_selection_within_visual_line
+                    && ((line_index != selection.start().line() && line_index != selection.end().line())
+                        || (visual_line_index >= first_visual_line_with_selection && visual_line_index <= last_visual_line_with_selection));
                 if (current_visual_line_has_selection) {
                     bool selection_begins_on_current_visual_line = visual_line_index == first_visual_line_with_selection;
                     bool selection_ends_on_current_visual_line = visual_line_index == last_visual_line_with_selection;
@@ -499,9 +502,6 @@ void TextEditor::paint_event(PaintEvent& event)
                     Color text_color = is_focused() ? palette().selection_text() : palette().inactive_selection_text();
 
                     painter.fill_rect(selection_rect, background_color);
-
-                    size_t start_of_selection_within_visual_line = (size_t)max(0, (int)selection_start_column_within_line - (int)start_of_visual_line);
-                    size_t end_of_selection_within_visual_line = selection_end_column_within_line - start_of_visual_line;
 
                     StringView visual_selected_text {
                         visual_line_text.characters_without_null_termination() + start_of_selection_within_visual_line,


### PR DESCRIPTION
When selecting the start of a multi-line line, a selection rect was displayed for the whole line but the text wasn't rendered properly, as shown below :
![BugBeforeFix](https://user-images.githubusercontent.com/5400651/80244217-df579080-8668-11ea-84ee-92d16088cc75.png)

This change prevents the selection rect from being drawn in virtual lines with no selected characters :
![BugAfterFix](https://user-images.githubusercontent.com/5400651/80244228-e1b9ea80-8668-11ea-90fc-1e22168690e7.png)

There is still some things going on with the cursor position being at the end of the line, but this would require a way bigger rework to handle equivalent cursor positions in multi-line mode.