### PR TITLE
LibPthread: implicitly call pthread_exit on return from start routine.

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -3754,7 +3754,7 @@ void Process::send_signal(u8 signal, Process* sender)
     thread->send_signal(signal, sender);
 }
 
-int Process::sys$create_thread(void* (*entry)(void*), void* argument, const Syscall::SC_create_thread_params* user_params)
+int Process::sys$create_thread(void* (*entry)(void*), const Syscall::SC_create_thread_params* user_params)
 {
     REQUIRE_PROMISE(thread);
     if (!validate_read((const void*)entry, sizeof(void*)))
@@ -3805,10 +3805,6 @@ int Process::sys$create_thread(void* (*entry)(void*), void* argument, const Sysc
     tss.eflags = 0x0202;
     tss.cr3 = page_directory().cr3();
     tss.esp = user_stack_address;
-
-    // NOTE: The stack needs to be 16-byte aligned.
-    thread->push_value_on_stack((FlatPtr)argument);
-    thread->push_value_on_stack(0);
 
     thread->make_thread_specific_region({});
     thread->set_state(Thread::State::Runnable);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -272,7 +272,7 @@ public:
     int sys$getpeername(const Syscall::SC_getpeername_params*);
     int sys$sched_setparam(pid_t pid, const struct sched_param* param);
     int sys$sched_getparam(pid_t pid, struct sched_param* param);
-    int sys$create_thread(void* (*)(void*), void* argument, const Syscall::SC_create_thread_params*);
+    int sys$create_thread(void* (*)(void*), const Syscall::SC_create_thread_params*);
     void sys$exit_thread(void*);
     int sys$join_thread(int tid, void** exit_value);
     int sys$detach_thread(int tid);


### PR DESCRIPTION
Previously, when returning from a pthread's start_routine, we would
segfault. Now we instead implicitly call pthread_exit as specified in
the standard.

pthread_create now creates a thread running the new
pthread_create_helper, which properly manages the calling and exiting
of the start_routine supplied to pthread_create. To accomplish this,
the thread's stack initialization has been moved out of
sys$create_thread and into the userspace function create_thread.