### PR TITLE
Kernel: Support signalling all processes with pid == -1

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -445,6 +445,8 @@ private:
 
     KResult do_kill(Process&, int signal);
     KResult do_killpg(pid_t pgrp, int signal);
+    KResult do_killall(int signal);
+    KResult do_killself(int signal);
 
     KResultOr<siginfo_t> do_waitid(idtype_t idtype, int id, int options);
 

--- a/Userland/kill.cpp
+++ b/Userland/kill.cpp
@@ -58,13 +58,13 @@ int main(int argc, char** argv)
             return 2;
         }
     }
-    unsigned pid = String(argv[pid_argi]).to_uint(ok);
+    pid_t pid = String(argv[pid_argi]).to_int(ok);
     if (!ok) {
         printf("'%s' is not a valid PID\n", argv[pid_argi]);
         return 3;
     }
 
-    int rc = kill((pid_t)pid, signum);
+    int rc = kill(pid, signum);
     if (rc < 0)
         perror("kill");
     return 0;


### PR DESCRIPTION
This is a special case that was previously not implemented.
The idea is that you can dispatch a signal to all other processes
the calling process has access to.
    
There was some minor refactoring to make the self signal logic
into a function so it could easily be easily re-used from do_killall.

This PR also includes a change to Userland/kill.cpp to allow it
to actually parse negative pids, as that we previously broken.
There's no easy way to test this otherwise. 