### PR TITLE
Userland: add arp utility

### DIFF
--- a/Userland/arp.cpp
+++ b/Userland/arp.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/JsonObject.h>
+#include <AK/String.h>
+#include <LibCore/File.h>
+#include <stdio.h>
+
+int main()
+{
+    auto file = Core::File::construct("/proc/net/arp");
+    if (!file->open(Core::IODevice::ReadOnly)) {
+        fprintf(stderr, "Error: %s\n", file->error_string());
+        return 1;
+    }
+
+    printf("Address          HWaddress\n");
+    auto file_contents = file->read_all();
+    auto json = JsonValue::from_string(file_contents).as_array();
+    json.for_each([](auto& value) {
+        auto if_object = value.as_object();
+
+        auto ip_address = if_object.get("ip_address").to_string();
+        auto mac_address = if_object.get("mac_address").to_string();
+
+        printf("%-15s  ", ip_address.characters());
+        printf("%-17s  ", mac_address.characters());
+        printf("\n");
+    });
+
+    return 0;
+}


### PR DESCRIPTION
Add a simple userland `arp` utility to print a formatted ARP table.

![arp](https://user-images.githubusercontent.com/434827/80295909-328d2880-87ba-11ea-8a59-64243089f176.png)

Various useful entries such as the interface name and hardware type aren't included, as these are missing from `Kernel::arp_table()` and the associated ProcFS `net/arp` entry.

`root` privileges are required, as `/proc/net/arp` is not exposed with world readable permissions. This seems like an oversight.

