### PR TITLE
Kernel/LibPthread: Plumb futex wait timeout support throughout.

### DIFF
--- a/AK/Time.h
+++ b/AK/Time.h
@@ -50,7 +50,23 @@ inline void timeval_add(const TimevalType& a, const TimevalType& b, TimevalType&
     }
 }
 
+template<typename TimevalType, typename TimespecType>
+inline void timeval_to_timespec(const TimevalType& tv, TimespecType& ts)
+{
+   ts.tv_sec = tv.tv_sec;
+   ts.tv_nsec = tv.tv_usec * 1000;
+}
+
+template<typename TimespecType, typename TimevalType>
+inline void timespec_to_timeval(const TimespecType& ts, TimevalType& tv)
+{
+    tv.tv_sec = ts.tv_sec;
+    tv.tv_usec = ts.tv_nsec / 1000;
+}
+
 }
 
 using AK::timeval_add;
 using AK::timeval_sub;
+using AK::timeval_to_timespec;
+using AK::timespec_to_timeval;

--- a/Kernel/Lock.cpp
+++ b/Kernel/Lock.cpp
@@ -65,7 +65,8 @@ void Lock::lock(Mode mode)
                 m_lock.store(false, AK::memory_order_release);
                 return;
             }
-            Thread::current->wait_on(m_queue, &m_lock, m_holder, m_name);
+            timeval* timeout = nullptr;
+            Thread::current->wait_on(m_queue, timeout, &m_lock, m_holder, m_name);
         }
     }
 }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -2282,6 +2282,19 @@ timeval kgettimeofday()
     return const_cast<const timeval&>(((KernelInfoPage*)s_info_page_address_for_kernel.as_ptr())->now);
 }
 
+void compute_relative_timeout_from_absolute(const timeval& absolute_time, timeval& relative_time)
+{
+    // Convert absolute time to relative time of day.
+    timeval_sub(absolute_time, kgettimeofday(), relative_time);
+}
+
+void compute_relative_timeout_from_absolute(const timespec& absolute_time, timeval& relative_time)
+{
+    timeval tv_absolute_time;
+    timespec_to_timeval(absolute_time, tv_absolute_time);
+    compute_relative_timeout_from_absolute(tv_absolute_time, relative_time);
+}
+
 void kgettimeofday(timeval& tv)
 {
     tv = kgettimeofday();
@@ -4615,21 +4628,33 @@ int Process::sys$futex(const Syscall::SC_futex_params* user_params)
     if (user_timeout && !validate_read_typed(user_timeout))
         return -EFAULT;
 
-    timespec timeout { 0, 0 };
-    if (user_timeout)
-        copy_from_user(&timeout, user_timeout);
-
-    i32 user_value;
-
     switch (futex_op) {
-    case FUTEX_WAIT:
+    case FUTEX_WAIT: {
+        i32 user_value;
         copy_from_user(&user_value, userspace_address);
         if (user_value != value)
             return -EAGAIN;
+
+        timespec ts_abstimeout { 0, 0 };
+        if (user_timeout && !validate_read_and_copy_typed(&ts_abstimeout, user_timeout))
+            return -EFAULT;
+
+        WaitQueue& wait_queue = futex_queue(userspace_address);
+        timeval* optional_timeout = nullptr;
+        timeval relative_timeout { 0, 0 };
+        if (user_timeout) {
+            compute_relative_timeout_from_absolute(ts_abstimeout, relative_timeout);
+            optional_timeout = &relative_timeout;
+        }
+
         // FIXME: This is supposed to be interruptible by a signal, but right now WaitQueue cannot be interrupted.
-        // FIXME: Support timeout!
-        Thread::current->wait_on(futex_queue(userspace_address));
+        Thread::BlockResult result = Thread::current->wait_on(wait_queue, optional_timeout);
+        if (result == Thread::BlockResult::InterruptedByTimeout) {
+            return -ETIMEDOUT;
+        }
+
         break;
+    }
     case FUTEX_WAKE:
         if (value == 0)
             return 0;

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -295,6 +295,7 @@ public:
         WokeNormally,
         InterruptedBySignal,
         InterruptedByDeath,
+        InterruptedByTimeout,
     };
 
     template<typename T, class... Args>
@@ -331,7 +332,7 @@ public:
         return block<ConditionBlocker>(state_string, move(condition));
     }
 
-    void wait_on(WaitQueue& queue, Atomic<bool>* lock = nullptr, Thread* beneficiary = nullptr, const char* reason = nullptr);
+    BlockResult wait_on(WaitQueue& queue, timeval* timeout = nullptr, Atomic<bool>* lock = nullptr, Thread* beneficiary = nullptr, const char* reason = nullptr);
     void wake_from_queue();
 
     void unblock();

--- a/Kernel/TimerQueue.h
+++ b/Kernel/TimerQueue.h
@@ -52,26 +52,26 @@ struct Timer {
     }
 };
 
-enum TimeUnit {
-    MS = OPTIMAL_TICKS_PER_SECOND_RATE / 1000,
-    S = OPTIMAL_TICKS_PER_SECOND_RATE,
-    M = OPTIMAL_TICKS_PER_SECOND_RATE * 60
-};
-
 class TimerQueue {
 public:
     static TimerQueue& the();
 
     u64 add_timer(NonnullOwnPtr<Timer>&&);
-    u64 add_timer(u64 duration, TimeUnit, Function<void()>&& callback);
+    u64 add_timer(timeval& timeout, Function<void()>&& callback);
     bool cancel_timer(u64 id);
     void fire();
 
 private:
+    TimerQueue();
+
     void update_next_timer_due();
+
+    u64 microseconds_to_ticks(u64 micro_seconds) { return micro_seconds * (m_ticks_per_second / 1'000'000); }
+    u64 seconds_to_ticks(u64 seconds) { return seconds * m_ticks_per_second; }
 
     u64 m_next_timer_due { 0 };
     u64 m_timer_id_count { 0 };
+    u64 m_ticks_per_second { 0 };
     SinglyLinkedList<NonnullOwnPtr<Timer>> m_timer_queue;
 };
 

--- a/Tests/Kernel/pthread-cond-timedwait-example.cpp
+++ b/Tests/Kernel/pthread-cond-timedwait-example.cpp
@@ -1,0 +1,71 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <errno.h>
+#include <unistd.h>
+#include <ctime>
+#include <cstring>
+#include <cassert>
+
+struct worker_t
+{
+    const char*     name;
+    int             count;
+    pthread_t       thread;
+    pthread_mutex_t lock;
+    pthread_cond_t  cond;
+    long int        wait_time;
+};
+
+void* run_worker(void* args)
+{
+    struct timespec time_to_wait = {0, 0};
+    worker_t* worker = (worker_t*)args;
+    worker->count = 0;
+
+    while (worker->count < 25) {
+        time_to_wait.tv_sec = time(nullptr) + worker->wait_time;
+        pthread_mutex_lock(&worker->lock);
+        int rc = pthread_cond_timedwait(&worker->cond, &worker->lock, &time_to_wait);
+
+        // Validate return code is always timed out.
+        assert(rc == -1);
+        assert(errno == ETIMEDOUT);
+
+        worker->count++;
+        printf("Increase worker[%s] count to [%d]\n", worker->name, worker->count);
+        pthread_mutex_unlock(&worker->lock);
+    }
+
+    return nullptr;
+}
+
+void init_worker(worker_t* worker, const char* name, long int wait_time)
+{
+    worker->name = name;
+    worker->wait_time = wait_time;
+
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+
+    pthread_mutex_init(&worker->lock, nullptr);
+    pthread_cond_init(&worker->cond, nullptr);
+    pthread_create(&worker->thread, &attr, &run_worker, (void*) worker);
+
+    pthread_attr_destroy(&attr);
+}
+
+int main()
+{
+    worker_t worker_a;
+    init_worker(&worker_a, "A", 2L);
+
+    worker_t worker_b;
+    init_worker(&worker_b, "B", 4L);
+
+    pthread_join(worker_a.thread, nullptr);
+    pthread_join(worker_b.thread, nullptr);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This change brings basic support for timeouts to the futex system call when invoked with the FUTEX_WAIT option. It's currently implemented by taking advantage of the timer queue to wake
the thread on timeout.

With that implemented LibPthread needed to be fixed to actually pass the option through.
A test case was added to very the feature works. 