### PR TITLE
FileManager: Disable actions based on user permissions

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -460,10 +460,10 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
             }
         },
         window);
-    paste_action->set_enabled(GUI::Clipboard::the().type() == "file-list");
 
     GUI::Clipboard::the().on_content_change = [&](const String& data_type) {
-        paste_action->set_enabled(data_type == "file-list");
+        auto current_location = directory_view.path();
+        paste_action->set_enabled(data_type == "file-list" && access(current_location.characters(), W_OK) == 0);
     };
 
     auto properties_action
@@ -662,6 +662,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
 
         auto can_write_in_path = access(new_path.characters(), W_OK) == 0;
         mkdir_action->set_enabled(can_write_in_path);
+        paste_action->set_enabled(can_write_in_path && GUI::Clipboard::the().type() == "file-list");
         go_forward_action->set_enabled(directory_view.path_history_position() < directory_view.path_history_size() - 1);
         go_back_action->set_enabled(directory_view.path_history_position() > 0);
         open_parent_directory_action->set_enabled(new_path != "/");
@@ -800,6 +801,8 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
 
     directory_view.open(initial_location);
     directory_view.set_focus(true);
+
+    paste_action->set_enabled(GUI::Clipboard::the().type() == "file-list" && access(initial_location.characters(), W_OK) == 0);
 
     window->show();
 

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -702,8 +702,10 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
 
     directory_view.on_selection_change = [&](GUI::AbstractView& view) {
         // FIXME: Figure out how we can enable/disable the paste action, based on clipboard contents.
-        copy_action->set_enabled(!view.selection().is_empty());
-        delete_action->set_enabled(!view.selection().is_empty());
+        auto selection = view.selection();
+
+        delete_action->set_enabled(!selection.is_empty() && access(directory_view.path().characters(), W_OK) == 0);
+        copy_action->set_enabled(!selection.is_empty());
     };
 
     auto open_in_text_editor_action = GUI::Action::create("Open in TextEditor...", Gfx::Bitmap::load_from_file("/res/icons/TextEditor16.png"), [&](auto&) {

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -428,13 +428,16 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
         = GUI::Action::create(
             "Properties...", { Mod_Alt, Key_Return }, Gfx::Bitmap::load_from_file("/res/icons/16x16/properties.png"), [&](const GUI::Action& action) {
                 auto& model = directory_view.model();
+                String container_dir_path;
                 String path;
                 Vector<String> selected;
                 if (action.activator() == directory_context_menu || directory_view.active_widget()->is_focused()) {
                     path = directory_view.path();
+                    container_dir_path = path;
                     selected = selected_file_paths();
                 } else {
                     path = directories_model->full_path(tree_view.selection().first());
+                    container_dir_path = FileSystemPath(path).basename();
                     selected = tree_view_selected_file_paths();
                 }
 
@@ -442,7 +445,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
                 if (selected.is_empty()) {
                     properties = window->add<PropertiesDialog>(model, path, true);
                 } else {
-                    properties = window->add<PropertiesDialog>(model, selected.first(), false);
+                    properties = window->add<PropertiesDialog>(model, selected.first(), access(container_dir_path.characters(), W_OK) != 0);
                 }
 
                 properties->exec();

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -654,8 +654,15 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
             tree_view.update();
         }
 
-        go_forward_action->set_enabled(directory_view.path_history_position()
-            < directory_view.path_history_size() - 1);
+        struct stat st;
+        if (lstat(new_path.characters(), &st)) {
+            perror("stat");
+            return;
+        }
+
+        auto can_write_in_path = access(new_path.characters(), W_OK) == 0;
+        mkdir_action->set_enabled(can_write_in_path);
+        go_forward_action->set_enabled(directory_view.path_history_position() < directory_view.path_history_size() - 1);
         go_back_action->set_enabled(directory_view.path_history_position() > 0);
         open_parent_directory_action->set_enabled(new_path != "/");
     };


### PR DESCRIPTION
I changed the PR to a draft so I can add multiple changes related to this.

- [x] Change write permission logic to use access() syscall.
- [x] Disable Paste action if user doesn't have write permission.
- [x] Disable delete if user doesn't have write permissions in directory.
- [x] Disable name text box on PropertiesDialog if the user can't change the name.
- [x] Disable permission checkboxes on PropertiesDialog if the user can't change them.

**Edit:**
I'll ignore the delete action for now because of a bit of UI misleading behaviour. Some actions act not on the selected item but on the current folder and that probably needs fixup. So writing logic to disable/enable some items that are contextually wrong doesn't make a lot of sense. Also removed the checkbox from the list item, as it's not going to be changed and shows 2 of 3 constantly on the PR list :)

**Edit 2:**
Now that #1980 is merged I converted this to a draft again to keep adding polish/features to the actions on FileManager