### PR TITLE
LibJS: Implement Number.is{Finite,NaN,Integer}()

### DIFF
--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -144,8 +144,7 @@ Value GlobalObject::is_nan(Interpreter& interpreter)
 
 Value GlobalObject::is_finite(Interpreter& interpreter)
 {
-    auto value = interpreter.argument(0).to_number();
-    return Value(!value.is_infinity() && !value.is_nan());
+    return Value(interpreter.argument(0).to_number().is_finite_number());
 }
 
 }

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -138,8 +138,7 @@ Value GlobalObject::gc(Interpreter& interpreter)
 
 Value GlobalObject::is_nan(Interpreter& interpreter)
 {
-    auto value = interpreter.argument(0).to_number();
-    return Value(value.is_nan());
+    return Value(interpreter.argument(0).to_number().is_nan());
 }
 
 Value GlobalObject::is_finite(Interpreter& interpreter)

--- a/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -41,6 +41,7 @@ NumberConstructor::NumberConstructor()
     : NativeFunction("Number", *interpreter().global_object().function_prototype())
 {
     put_native_function("isFinite", is_finite, 1);
+    put_native_function("isInteger", is_integer, 1);
     put_native_function("isNaN", is_nan, 1);
     put_native_function("isSafeInteger", is_safe_integer, 1);
 
@@ -78,6 +79,12 @@ Value NumberConstructor::construct(Interpreter& interpreter)
 Value NumberConstructor::is_finite(Interpreter& interpreter)
 {
     return Value(interpreter.argument(0).is_finite_number());
+}
+
+Value NumberConstructor::is_integer(Interpreter& interpreter)
+{
+    auto value = interpreter.argument(0);
+    return Value(value.is_number() && (i32)value.as_double() == value.as_double());
 }
 
 Value NumberConstructor::is_nan(Interpreter& interpreter)

--- a/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -40,6 +40,7 @@ namespace JS {
 NumberConstructor::NumberConstructor()
     : NativeFunction("Number", *interpreter().global_object().function_prototype())
 {
+    put_native_function("isFinite", is_finite, 1);
     put_native_function("isSafeInteger", is_safe_integer, 1);
 
     put("prototype", interpreter().global_object().number_prototype());
@@ -71,6 +72,11 @@ Value NumberConstructor::construct(Interpreter& interpreter)
     else
         number = interpreter.argument(0).to_number().as_double();
     return NumberObject::create(interpreter.global_object(), number);
+}
+
+Value NumberConstructor::is_finite(Interpreter& interpreter)
+{
+    return Value(interpreter.argument(0).is_finite_number());
 }
 
 Value NumberConstructor::is_safe_integer(Interpreter& interpreter)

--- a/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -41,6 +41,7 @@ NumberConstructor::NumberConstructor()
     : NativeFunction("Number", *interpreter().global_object().function_prototype())
 {
     put_native_function("isFinite", is_finite, 1);
+    put_native_function("isNaN", is_nan, 1);
     put_native_function("isSafeInteger", is_safe_integer, 1);
 
     put("prototype", interpreter().global_object().number_prototype());
@@ -77,6 +78,11 @@ Value NumberConstructor::construct(Interpreter& interpreter)
 Value NumberConstructor::is_finite(Interpreter& interpreter)
 {
     return Value(interpreter.argument(0).is_finite_number());
+}
+
+Value NumberConstructor::is_nan(Interpreter& interpreter)
+{
+    return Value(interpreter.argument(0).is_nan());
 }
 
 Value NumberConstructor::is_safe_integer(Interpreter& interpreter)

--- a/Libraries/LibJS/Runtime/NumberConstructor.h
+++ b/Libraries/LibJS/Runtime/NumberConstructor.h
@@ -43,6 +43,7 @@ private:
     virtual const char* class_name() const override { return "NumberConstructor"; }
 
     static Value is_finite(Interpreter&);
+    static Value is_nan(Interpreter&);
     static Value is_safe_integer(Interpreter&);
 };
 

--- a/Libraries/LibJS/Runtime/NumberConstructor.h
+++ b/Libraries/LibJS/Runtime/NumberConstructor.h
@@ -42,6 +42,7 @@ private:
     virtual bool has_constructor() const override { return true; }
     virtual const char* class_name() const override { return "NumberConstructor"; }
 
+    static Value is_finite(Interpreter&);
     static Value is_safe_integer(Interpreter&);
 };
 

--- a/Libraries/LibJS/Runtime/NumberConstructor.h
+++ b/Libraries/LibJS/Runtime/NumberConstructor.h
@@ -43,6 +43,7 @@ private:
     virtual const char* class_name() const override { return "NumberConstructor"; }
 
     static Value is_finite(Interpreter&);
+    static Value is_integer(Interpreter&);
     static Value is_nan(Interpreter&);
     static Value is_safe_integer(Interpreter&);
 };

--- a/Libraries/LibJS/Tests/Number.isFinite.js
+++ b/Libraries/LibJS/Tests/Number.isFinite.js
@@ -1,0 +1,29 @@
+load("test-common.js");
+
+try {
+    assert(Number.isFinite.length === 1);
+
+    assert(Number.isFinite(0) === true);
+    assert(Number.isFinite(1.23) === true);
+    assert(Number.isFinite(42) === true);
+
+    assert(Number.isFinite("") === false);
+    assert(Number.isFinite("0") === false);
+    assert(Number.isFinite("42") === false);
+    assert(Number.isFinite(true) === false);
+    assert(Number.isFinite(false) === false);
+    assert(Number.isFinite(null) === false);
+    assert(Number.isFinite([]) === false);
+    assert(Number.isFinite() === false);
+    assert(Number.isFinite(NaN) === false);
+    assert(Number.isFinite(undefined) === false);
+    assert(Number.isFinite(Infinity) === false);
+    assert(Number.isFinite(-Infinity) === false);
+    assert(Number.isFinite("foo") === false);
+    assert(Number.isFinite({}) === false);
+    assert(Number.isFinite([1, 2, 3]) === false);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e.message);
+}

--- a/Libraries/LibJS/Tests/Number.isInteger.js
+++ b/Libraries/LibJS/Tests/Number.isInteger.js
@@ -1,0 +1,38 @@
+load("test-common.js");
+
+try {
+    assert(Number.isInteger.length === 1);
+
+    assert(Number.isInteger(0) === true);
+    assert(Number.isInteger(42) === true);
+    assert(Number.isInteger(-10000) === true);
+    assert(Number.isInteger(5) === true);
+    assert(Number.isInteger(5.0) === true);
+    assert(Number.isInteger(5.0000000000000001) === true);
+    // FIXME: values outside of i32's range should still return true
+    // assert(Number.isInteger(+2147483647 + 1) === true);
+    // assert(Number.isInteger(-2147483648 - 1) === true);
+    // assert(Number.isInteger(99999999999999999999999999999999999) === true);
+
+    assert(Number.isInteger(5.000000000000001) === false);
+    assert(Number.isInteger(1.23) === false);
+    assert(Number.isInteger("") === false);
+    assert(Number.isInteger("0") === false);
+    assert(Number.isInteger("42") === false);
+    assert(Number.isInteger(true) === false);
+    assert(Number.isInteger(false) === false);
+    assert(Number.isInteger(null) === false);
+    assert(Number.isInteger([]) === false);
+    assert(Number.isInteger(Infinity) === false);
+    assert(Number.isInteger(-Infinity) === false);
+    assert(Number.isInteger(NaN) === false);
+    assert(Number.isInteger() === false);
+    assert(Number.isInteger(undefined) === false);
+    assert(Number.isInteger("foo") === false);
+    assert(Number.isInteger({}) === false);
+    assert(Number.isInteger([1, 2, 3]) === false);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e.message);
+}

--- a/Libraries/LibJS/Tests/Number.isNaN.js
+++ b/Libraries/LibJS/Tests/Number.isNaN.js
@@ -1,0 +1,30 @@
+load("test-common.js");
+
+try {
+    assert(Number.isNaN.length === 1);
+
+    assert(Number.isNaN(0) === false);
+    assert(Number.isNaN(42) === false);
+    assert(Number.isNaN("") === false);
+    assert(Number.isNaN("0") === false);
+    assert(Number.isNaN("42") === false);
+    assert(Number.isNaN(true) === false);
+    assert(Number.isNaN(false) === false);
+    assert(Number.isNaN(null) === false);
+    assert(Number.isNaN([]) === false);
+    assert(Number.isNaN(Infinity) === false);
+    assert(Number.isNaN(-Infinity) === false);
+    assert(Number.isNaN() === false);
+    assert(Number.isNaN(undefined) === false);
+    assert(Number.isNaN("foo") === false);
+    assert(Number.isNaN({}) === false);
+    assert(Number.isNaN([1, 2, 3]) === false);
+
+    assert(Number.isNaN(NaN) === true);
+    assert(Number.isNaN(Number.NaN) === true);
+    assert(Number.isNaN(0 / 0) === true);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e.message);
+}

--- a/Libraries/LibJS/Tests/Number.isSafeInteger.js
+++ b/Libraries/LibJS/Tests/Number.isSafeInteger.js
@@ -2,12 +2,14 @@ load("test-common.js");
 
 try {
     assert(Number.isSafeInteger.length === 1);
+
     assert(Number.isSafeInteger(0) === true);
     assert(Number.isSafeInteger(1) === true);
     assert(Number.isSafeInteger(2.0) === true);
     assert(Number.isSafeInteger(42) === true);
     assert(Number.isSafeInteger(Number.MAX_SAFE_INTEGER) === true);
     assert(Number.isSafeInteger(Number.MIN_SAFE_INTEGER) === true);
+
     assert(Number.isSafeInteger() === false);
     assert(Number.isSafeInteger("1") === false);
     assert(Number.isSafeInteger(2.1) === false);

--- a/Libraries/LibJS/Tests/isFinite.js
+++ b/Libraries/LibJS/Tests/isFinite.js
@@ -4,6 +4,7 @@ try {
     assert(isFinite.length === 1);
 
     assert(isFinite(0) === true);
+    assert(isFinite(1.23) === true);
     assert(isFinite(42) === true);
     assert(isFinite("") === true);
     assert(isFinite("0") === true);


### PR DESCRIPTION
Like the global `isFinite()` and `isNaN()` without the number coercion.