### PR TITLE
LibGfx: Add support for grayscale PNGs

### DIFF
--- a/Base/home/anon/www/pngsuite_bas_png.html
+++ b/Base/home/anon/www/pngsuite_bas_png.html
@@ -1,0 +1,26 @@
+<HTML>
+<HEAD>
+<TITLE>PngSuite - Basic formats / PNG-files</TITLE>
+</HEAD>
+<BODY BGCOLOR="#ede">
+
+<!-- Modified version of http://schaik.com/pngsuite/pngsuite_bas_png.html -->
+
+<BR><IMG SRC="http://schaik.com/pngsuite/basn0g01.png" WIDTH="32" HEIGHT="32"> --- basn0g01 - black & white
+<BR><IMG SRC="http://schaik.com/pngsuite/basn0g02.png" WIDTH="32" HEIGHT="32"> --- basn0g02 - 2 bit (4 level) grayscale
+<BR><IMG SRC="http://schaik.com/pngsuite/basn0g04.png" WIDTH="32" HEIGHT="32"> --- basn0g04 - 4 bit (16 level) grayscale
+<BR><IMG SRC="http://schaik.com/pngsuite/basn0g08.png" WIDTH="32" HEIGHT="32"> --- basn0g08 - 8 bit (256 level) grayscale
+<BR><IMG SRC="http://schaik.com/pngsuite/basn0g16.png" WIDTH="32" HEIGHT="32"> --- basn0g16 - 16 bit (64k level) grayscale
+<BR><IMG SRC="http://schaik.com/pngsuite/basn2c08.png" WIDTH="32" HEIGHT="32"> --- basn2c08 - 3x8 bits rgb color
+<BR><IMG SRC="http://schaik.com/pngsuite/basn2c16.png" WIDTH="32" HEIGHT="32"> --- basn2c16 - 3x16 bits rgb color
+<BR><IMG SRC="http://schaik.com/pngsuite/basn3p01.png" WIDTH="32" HEIGHT="32"> --- basn3p01 - 1 bit (2 color) paletted
+<BR><IMG SRC="http://schaik.com/pngsuite/basn3p02.png" WIDTH="32" HEIGHT="32"> --- basn3p02 - 2 bit (4 color) paletted
+<BR><IMG SRC="http://schaik.com/pngsuite/basn3p04.png" WIDTH="32" HEIGHT="32"> --- basn3p04 - 4 bit (16 color) paletted
+<BR><IMG SRC="http://schaik.com/pngsuite/basn3p08.png" WIDTH="32" HEIGHT="32"> --- basn3p08 - 8 bit (256 color) paletted
+<BR><IMG SRC="http://schaik.com/pngsuite/basn4a08.png" WIDTH="32" HEIGHT="32"> --- basn4a08 - 8 bit grayscale + 8 bit alpha-channel
+<BR><IMG SRC="http://schaik.com/pngsuite/basn4a16.png" WIDTH="32" HEIGHT="32"> --- basn4a16 - 16 bit grayscale + 16 bit alpha-channel
+<BR><IMG SRC="http://schaik.com/pngsuite/basn6a08.png" WIDTH="32" HEIGHT="32"> --- basn6a08 - 3x8 bits rgb color + 8 bit alpha-channel
+<BR><IMG SRC="http://schaik.com/pngsuite/basn6a16.png" WIDTH="32" HEIGHT="32"> --- basn6a16 - 3x16 bits rgb color + 16 bit alpha-channel
+
+</BODY>
+</HTML>

--- a/Base/home/anon/www/welcome.html
+++ b/Base/home/anon/www/welcome.html
@@ -28,6 +28,7 @@ span#ua {
     <p>Your user agent is: <b><span id="ua"></span></b></p>
     <p>Some small test pages:</p>
     <ul>
+        <li><a href="pngsuite_bas_png.html">pngsuite basic formats test</a></li>
         <li><a href="canvas-path.html">canvas path house!</a></li>
         <li><a href="img-canvas.html">canvas drawImage() test</a></li>
         <li><a href="trigonometry.html">canvas + trigonometry functions</a></li>


### PR DESCRIPTION
I also added a modified local copy of a test page that loads all basic PNG formats (http://schaik.com/pngsuite/pngsuite_bas_png.html) since the serenity html parser doesn't parse the malformed table present on that page.