### PR TITLE
Kernel: Expose timers via a TimerId type

### DIFF
--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -893,7 +893,7 @@ Thread::BlockResult Thread::wait_on(WaitQueue& queue, timeval* timeout, Atomic<b
     set_state(State::Queued);
     queue.enqueue(*current);
 
-    u64 timer_id = 0;
+    TimerId timer_id {};
     if (timeout) {
         timer_id = TimerQueue::the().add_timer(*timeout, [&]() {
             wake_from_queue();

--- a/Kernel/TimerQueue.cpp
+++ b/Kernel/TimerQueue.cpp
@@ -47,7 +47,7 @@ TimerQueue::TimerQueue()
     m_ticks_per_second = TimeManagement::the().ticks_per_second();
 }
 
-u64 TimerQueue::add_timer(NonnullOwnPtr<Timer>&& timer)
+TimerId TimerQueue::add_timer(NonnullOwnPtr<Timer>&& timer)
 {
     ASSERT(timer->expires >= g_uptime);
 
@@ -64,7 +64,7 @@ u64 TimerQueue::add_timer(NonnullOwnPtr<Timer>&& timer)
     return m_timer_id_count;
 }
 
-u64 TimerQueue::add_timer(timeval& deadline, Function<void()>&& callback)
+TimerId TimerQueue::add_timer(timeval& deadline, Function<void()>&& callback)
 {
     NonnullOwnPtr timer = make<Timer>();
     timer->expires = g_uptime + seconds_to_ticks(deadline.tv_sec) + microseconds_to_ticks(deadline.tv_usec);
@@ -72,7 +72,7 @@ u64 TimerQueue::add_timer(timeval& deadline, Function<void()>&& callback)
     return add_timer(move(timer));
 }
 
-bool TimerQueue::cancel_timer(u64 id)
+bool TimerQueue::cancel_timer(TimerId id)
 {
     auto it = m_timer_queue.find([id](auto& timer) { return timer->id == id; });
     if (it.is_end())

--- a/Kernel/TimerQueue.h
+++ b/Kernel/TimerQueue.h
@@ -34,8 +34,10 @@
 
 namespace Kernel {
 
+typedef u64 TimerId;
+
 struct Timer {
-    u64 id;
+    TimerId id;
     u64 expires;
     Function<void()> callback;
     bool operator<(const Timer& rhs) const
@@ -56,9 +58,9 @@ class TimerQueue {
 public:
     static TimerQueue& the();
 
-    u64 add_timer(NonnullOwnPtr<Timer>&&);
-    u64 add_timer(timeval& timeout, Function<void()>&& callback);
-    bool cancel_timer(u64 id);
+    TimerId add_timer(NonnullOwnPtr<Timer>&&);
+    TimerId add_timer(timeval& timeout, Function<void()>&& callback);
+    bool cancel_timer(TimerId id);
     void fire();
 
 private:


### PR DESCRIPTION
The public consumers of the timer API shouldn't need to know
the how timer id's are tracked internally. Expose a typedef
instead to allow the internal implementation to be protected
from potential churn in the future.

It's also just good API design.