### PR TITLE
Kernel: Update TimerQueue next due timer only when necessary

### DIFF
--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -46,6 +46,7 @@ public:
     ElementType& operator*() { return m_node->value; }
     ElementType* operator->() { return &m_node->value; }
     bool is_end() const { return !m_node; }
+    bool is_begin() const { return !m_prev; }
 
 private:
     friend ListType;


### PR DESCRIPTION
Previously we blindly just called update_next_timer_due() when
 ever we modified the timer list. Since we know the list is sorted
 this is a bit wasteful, and we can do better.
    
 This change refactors the code so we only update the next due time
 when necessary. In places where it was possible the code was modified
 to directly modify the next due time, instead of having to go to the
 front of the list to fetch it.

This pr also includes a change to SingularlyLinkedListIterator to add a
is_begin() method, so we can tell if we are inserting at the front of the
timer queue or not.
