### PR TITLE
FileManager: Do the right actions on the right directories

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -714,6 +714,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     file_context_menu->add_action(properties_action);
 
     directory_view_context_menu->add_action(mkdir_action);
+    directory_view_context_menu->add_action(paste_action);
     directory_view_context_menu->add_action(open_terminal_action);
     directory_view_context_menu->add_separator();
     directory_view_context_menu->add_action(properties_action);

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -425,7 +425,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     copy_action->set_enabled(false);
 
     auto paste_action = GUI::CommonActions::make_paste_action(
-        [&](const GUI::Action&) {
+        [&](const GUI::Action& action) {
             auto data_and_type = GUI::Clipboard::the().data_and_type();
             if (data_and_type.type != "file-list") {
                 dbg() << "Cannot paste clipboard type " << data_and_type.type;
@@ -436,12 +436,19 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
                 dbg() << "No files to paste";
                 return;
             }
+
+            AK::String target_directory;
+            if (action.activator() == directory_context_menu)
+                target_directory = selected_file_paths()[0];
+            else
+                target_directory = directory_view.path();
+
             for (auto& current_path : copied_lines) {
                 if (current_path.is_empty())
                     continue;
-                auto current_directory = directory_view.path();
+
                 auto new_path = String::format("%s/%s",
-                    current_directory.characters(),
+                    target_directory.characters(),
                     FileSystemPath(current_path).basename().characters());
                 if (!FileUtils::copy_file_or_directory(current_path, new_path)) {
                     auto error_message = String::format("Could not paste %s.",


### PR DESCRIPTION
FileManager had a really weird behaviour while choosing what to copy, where to paste, what to delete, etc.

It was mostly due Widget::is_focused() returning false while a file/directory was focused, and treating that as a condition to check if we would want to copy/delete/ those files.

With these patches we now check for selection contents and decide accordingly.

Also, if you right click + paste while selecting a directory, now we paste inside of it, like most of the file managers out there.