### PR TITLE
mkdir: Use ArgParser, support creating multiple directories, add -p option to create parent directories

### DIFF
--- a/AK/FileSystemPath.cpp
+++ b/AK/FileSystemPath.cpp
@@ -45,10 +45,10 @@ void FileSystemPath::canonicalize()
         return;
     }
 
-    bool is_absolute_path = m_string[0] == '/';
+    m_is_absolute = m_string[0] == '/';
     auto parts = m_string.split_view('/');
 
-    if (!is_absolute_path)
+    if (!m_is_absolute)
         parts.prepend(".");
 
     size_t approximate_canonical_length = 0;
@@ -56,7 +56,7 @@ void FileSystemPath::canonicalize()
 
     for (size_t i = 0; i < parts.size(); ++i) {
         auto& part = parts[i];
-        if (is_absolute_path || i != 0) {
+        if (m_is_absolute || i != 0) {
             if (part == ".")
                 continue;
         }
@@ -78,7 +78,7 @@ void FileSystemPath::canonicalize()
     StringBuilder dirname_builder(approximate_canonical_length);
     for (size_t i = 0; i < canonical_parts.size() - 1; ++i) {
         auto& canonical_part = canonical_parts[i];
-        if (is_absolute_path || i != 0)
+        if (m_is_absolute || i != 0)
             dirname_builder.append('/');
         dirname_builder.append(canonical_part);
     }
@@ -93,7 +93,7 @@ void FileSystemPath::canonicalize()
     StringBuilder builder(approximate_canonical_length);
     for (size_t i = 0; i < canonical_parts.size(); ++i) {
         auto& canonical_part = canonical_parts[i];
-        if (is_absolute_path || i != 0)
+        if (m_is_absolute || i != 0)
             builder.append('/');
         builder.append(canonical_part);
     }

--- a/AK/FileSystemPath.h
+++ b/AK/FileSystemPath.h
@@ -37,6 +37,7 @@ public:
     explicit FileSystemPath(const StringView&);
 
     bool is_valid() const { return m_is_valid; }
+    bool is_absolute() const { return m_is_absolute; }
     const String& string() const { return m_string; }
 
     const String& dirname() const { return m_dirname; }
@@ -58,6 +59,7 @@ private:
     String m_title;
     String m_extension;
     bool m_is_valid { false };
+    bool m_is_absolute { false };
 };
 
 String canonicalized_path(const StringView&);

--- a/Base/usr/share/man/man1/mkdir.md
+++ b/Base/usr/share/man/man1/mkdir.md
@@ -5,17 +5,21 @@ mkdir - create directories
 ## Synopsis
 
 ```**sh
-$ mkdir directories...
+$ mkdir [ options...] directories...
 ```
 
 ## Description
 
 Create a new empty directory for each of the given *directories*.
 
+## Options
+
+* `-p`, `--parents`: Create parent directories if they don't exist
+
 ## Examples
 
 ```sh
-$ mkdir /tmp/foo
+$ mkdir -p /tmp/foo/bar
 ```
 
 ## See also

--- a/Base/usr/share/man/man1/mkdir.md
+++ b/Base/usr/share/man/man1/mkdir.md
@@ -1,16 +1,16 @@
 ## Name
 
-mkdir - create a directory
+mkdir - create directories
 
 ## Synopsis
 
 ```**sh
-$ mkdir path
+$ mkdir directories...
 ```
 
 ## Description
 
-Create a new empty directory at the given *path*.
+Create a new empty directory for each of the given *directories*.
 
 ## Examples
 

--- a/Userland/mkdir.cpp
+++ b/Userland/mkdir.cpp
@@ -25,28 +25,67 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/FileSystemPath.h>
+#include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio cpath", nullptr) < 0) {
+    if (pledge("stdio cpath rpath", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
 
+    bool create_parents = false;
     Vector<const char*> directories;
 
     Core::ArgsParser args_parser;
+    args_parser.add_option(create_parents, "Create parent directories if they don't exist", "parents", 'p');
     args_parser.add_positional_argument(directories, "Directories to create", "directories");
     args_parser.parse(argc, argv);
 
+    // FIXME: Support -m/--mode option
+    mode_t mode = 0755;
+
     bool has_errors = false;
+
     for (auto& directory : directories) {
-        if (mkdir(directory, 0755) < 0) {
-            perror("mkdir");
-            has_errors = true;
+        FileSystemPath canonical_path(directory);
+        if (!create_parents) {
+            if (mkdir(canonical_path.string().characters(), mode) < 0) {
+                perror("mkdir");
+                has_errors = true;
+            }
+            continue;
+        }
+        StringBuilder path_builder;
+        if (canonical_path.is_absolute())
+            path_builder.append("/");
+        for (auto& part : canonical_path.parts()) {
+            path_builder.append(part);
+            auto path = path_builder.build();
+            struct stat st;
+            if (stat(path.characters(), &st) < 0) {
+                if (errno != ENOENT) {
+                    perror("stat");
+                    has_errors = true;
+                    break;
+                }
+                if (mkdir(path.characters(), mode) < 0) {
+                    perror("mkdir");
+                    has_errors = true;
+                    break;
+                }
+            } else {
+                if (!S_ISDIR(st.st_mode)) {
+                    fprintf(stderr, "mkdir: cannot create directory '%s': not a directory\n", path.characters());
+                    has_errors = true;
+                    break;
+                }
+            }
+            path_builder.append("/");
         }
     }
     return has_errors ? 1 : 0;

--- a/Userland/mkdir.cpp
+++ b/Userland/mkdir.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,11 +25,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <assert.h>
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <LibCore/ArgsParser.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -39,14 +36,18 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (argc != 2) {
-        printf("usage: mkdir <path>\n");
-        return 1;
+    Vector<const char*> directories;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_positional_argument(directories, "Directories to create", "directories");
+    args_parser.parse(argc, argv);
+
+    bool has_errors = false;
+    for (auto& directory : directories) {
+        if (mkdir(directory, 0755) < 0) {
+            perror("mkdir");
+            has_errors = true;
+        }
     }
-    int rc = mkdir(argv[1], 0755);
-    if (rc < 0) {
-        perror("mkdir");
-        return 1;
-    }
-    return 0;
+    return has_errors ? 1 : 0;
 }


### PR DESCRIPTION
Many shell scripts make use of `-p` and/or pass multiple directories to it - `mkdir` is now much closer to what other platforms have.