### PR TITLE
LibCore: Trim decompressed Gzip output to size

### DIFF
--- a/Libraries/LibCore/Gzip.cpp
+++ b/Libraries/LibCore/Gzip.cpp
@@ -136,6 +136,7 @@ Optional<ByteBuffer> Gzip::decompress(const ByteBuffer& data)
 
         if (puff_ret == 0) {
             dbg() << "Gzip::decompress: Decompression success.";
+            destination.trim(destination_len);
             break;
         }
 


### PR DESCRIPTION
Prior to this commit, we would (re-)allocate the output buffer aligned to 1024 bytes, but never trim it down to size, which caused Gzip::decompress to return uninitialised data.

smh, @awesomekling 