### PR TITLE
LibJS: Add bounds check to Array.prototype.{find,findIndex}

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -439,6 +439,9 @@ Value ArrayPrototype::find(Interpreter& interpreter)
     auto array_size = array->elements().size();
 
     for (size_t i = 0; i < array_size; ++i) {
+        if (i >= array->elements().size())
+            break;
+
         auto value = array->elements().at(i);
         if (value.is_empty())
             continue;
@@ -473,6 +476,9 @@ Value ArrayPrototype::find_index(Interpreter& interpreter)
     auto array_size = array->elements().size();
 
     for (size_t i = 0; i < array_size; ++i) {
+        if (i >= array->elements().size())
+            break;
+
         auto value = array->elements().at(i);
         if (value.is_empty())
             continue;

--- a/Libraries/LibJS/Tests/array-shrink-during-find-crash.js
+++ b/Libraries/LibJS/Tests/array-shrink-during-find-crash.js
@@ -1,0 +1,25 @@
+load("test-common.js");
+
+try {
+    var a, callbackCalled;
+
+    callbackCalled = 0;
+    a = [1, 2, 3, 4, 5];
+    a.find(() => {
+        callbackCalled++;
+        a.pop();
+    });
+    assert(callbackCalled === 3);
+
+    callbackCalled = 0;
+    a = [1, 2, 3, 4, 5];
+    a.findIndex(() => {
+        callbackCalled++;
+        a.pop();
+    });
+    assert(callbackCalled === 3);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
The number of iterations is limited to the initial array size, but we still need to check if the array did shrink since then before accessing each element.

The other "loop & callback" functions already do this.

Fixes #1992.