### PR TITLE
LibGUI+FileManager: Improve painting and managing of disabled widgets: CheckBox & TextBox

### DIFF
--- a/Applications/FileManager/PropertiesDialog.cpp
+++ b/Applications/FileManager/PropertiesDialog.cpp
@@ -79,13 +79,10 @@ PropertiesDialog::PropertiesDialog(GUI::FileSystemModel& model, String path, boo
     m_name_box->set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
     m_name_box->set_preferred_size({ 0, 22 });
     m_name_box->set_text(m_name);
-    m_name_box->on_change = [&, disable_rename]() {
-        if (disable_rename) {
-            m_name_box->set_text(m_name); //FIXME: GUI::TextBox does not support set_enabled yet...
-        } else {
-            m_name_dirty = m_name != m_name_box->text();
-            m_apply_button->set_enabled(true);
-        }
+    m_name_box->set_enabled(!disable_rename);
+    m_name_box->on_change = [&]() {
+        m_name_dirty = m_name != m_name_box->text();
+        m_apply_button->set_enabled(true);
     };
 
     set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/properties.png"));

--- a/Libraries/LibGUI/CheckBox.cpp
+++ b/Libraries/LibGUI/CheckBox.cpp
@@ -79,7 +79,7 @@ void CheckBox::paint_event(PaintEvent& event)
         0, height() / 2 - s_box_height / 2 - 1,
         s_box_width, s_box_height
     };
-    painter.fill_rect(box_rect, palette().base());
+    painter.fill_rect(box_rect, is_enabled() ? palette().base() : palette().window());
     Gfx::StylePainter::paint_frame(painter, box_rect, palette(), Gfx::FrameShape::Container, Gfx::FrameShadow::Sunken, 2);
 
     if (is_being_pressed())

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -359,7 +359,7 @@ Gfx::Rect TextEditor::visible_text_rect_in_inner_coordinates() const
 
 void TextEditor::paint_event(PaintEvent& event)
 {
-    Color widget_background_color = palette().color(background_role());
+    Color widget_background_color = palette().color(is_enabled() ? background_role() : Gfx::ColorRole::Window);
     // NOTE: This ensures that spans are updated before we look at them.
     flush_pending_change_notification_if_needed();
 


### PR DESCRIPTION
Now it looks something like this:

![image](https://user-images.githubusercontent.com/6155245/80482766-1a054580-8955-11ea-911e-a13beb2de86c.png)

In Redmond 2000:
![image](https://user-images.githubusercontent.com/6155245/80482885-5042c500-8955-11ea-8e5d-af9d7fce6ad6.png)


I thin'k now it looks pretty neat :)

Closes #1987