### PR TITLE
LibJS: Make Number.isInteger() test pass on Serenity

### DIFF
--- a/Libraries/LibJS/Tests/Number.isInteger.js
+++ b/Libraries/LibJS/Tests/Number.isInteger.js
@@ -8,13 +8,13 @@ try {
     assert(Number.isInteger(-10000) === true);
     assert(Number.isInteger(5) === true);
     assert(Number.isInteger(5.0) === true);
-    assert(Number.isInteger(5.0000000000000001) === true);
+    assert(Number.isInteger(5 + 1/10000000000000000) === true);
     // FIXME: values outside of i32's range should still return true
     // assert(Number.isInteger(+2147483647 + 1) === true);
     // assert(Number.isInteger(-2147483648 - 1) === true);
     // assert(Number.isInteger(99999999999999999999999999999999999) === true);
 
-    assert(Number.isInteger(5.000000000000001) === false);
+    assert(Number.isInteger(5 + 1/1000000000000000) === false);
     assert(Number.isInteger(1.23) === false);
     assert(Number.isInteger("") === false);
     assert(Number.isInteger("0") === false);


### PR DESCRIPTION
The parser doesn't like may decimals, an issue with our strtod() implementation. Let's use division instead - all tests green again :^)