### PR TITLE
WindowManager+DisplayProperties: Allow us to roll back to a colour background from a bitmap one

### DIFF
--- a/Applications/DisplayProperties/DisplayProperties.cpp
+++ b/Applications/DisplayProperties/DisplayProperties.cpp
@@ -72,6 +72,8 @@ void DisplayPropertiesWidget::create_wallpaper_list()
 {
     Core::DirIterator iterator("/res/wallpapers/", Core::DirIterator::Flags::SkipDots);
 
+    m_wallpapers.append("Use background color");
+
     while (iterator.has_next()) {
         m_wallpapers.append(iterator.next_path());
     }
@@ -123,11 +125,15 @@ void DisplayPropertiesWidget::create_frame()
     m_wallpaper_combo->set_model(*ItemListModel<AK::String>::create(m_wallpapers));
     m_wallpaper_combo->on_change = [this](auto& text, const GUI::ModelIndex& index) {
         String path = text;
-        if (index.is_valid()) {
-            StringBuilder builder;
-            builder.append("/res/wallpapers/");
-            builder.append(path);
-            path = builder.to_string();
+        if (index.row() == 0) {
+            path = "";
+        } else {
+            if (index.is_valid()) {
+                StringBuilder builder;
+                builder.append("/res/wallpapers/");
+                builder.append(path);
+                path = builder.to_string();
+            }
         }
 
         this->m_monitor_widget->set_wallpaper(path);
@@ -281,6 +287,8 @@ void DisplayPropertiesWidget::load_current_settings()
             m_wallpaper_combo->set_text(selected_wallpaper);
             m_wallpaper_combo->set_only_allow_values_from_model(true);
         }
+    } else {
+        m_wallpaper_combo->set_selected_index(0);
     }
 
     /// Mode //////////////////////////////////////////////////////////////////////////////////////
@@ -340,11 +348,11 @@ void DisplayPropertiesWidget::send_settings_to_window_server()
 
     if (!m_monitor_widget->wallpaper().is_empty()) {
         GUI::Desktop::the().set_wallpaper(m_monitor_widget->wallpaper());
+    } else {
+        dbg() << "Setting color input: __" << m_color_input->text() << "__";
+        GUI::Desktop::the().set_wallpaper("");
+        GUI::Desktop::the().set_background_color(m_color_input->text());
     }
 
     GUI::Desktop::the().set_wallpaper_mode(m_monitor_widget->wallpaper_mode());
-
-    if (m_color_input->color() != this->palette().desktop_background()) {
-        GUI::Desktop::the().set_background_color(m_color_input->text());
-    }
 }

--- a/Servers/WindowServer/Compositor.cpp
+++ b/Servers/WindowServer/Compositor.cpp
@@ -351,10 +351,6 @@ bool Compositor::set_wallpaper(const String& path, Function<void(bool)>&& callba
         },
 
         [this, path, callback = move(callback)](RefPtr<Gfx::Bitmap> bitmap) {
-            if (!bitmap) {
-                callback(false);
-                return;
-            }
             m_wallpaper_path = path;
             m_wallpaper = move(bitmap);
             invalidate();


### PR DESCRIPTION
This PR improves a bit how `DisplayProperties` work (and removes the empty item on the `ComboBox` for something more insightful) and allows us to go from a set bitmap to a background colour again.