### PR TITLE
WindowServer: Change the desktop background colour on theme change

### DIFF
--- a/Servers/WindowServer/WindowManager.cpp
+++ b/Servers/WindowServer/WindowManager.cpp
@@ -1284,6 +1284,7 @@ bool WindowManager::update_theme(String theme_path, String theme_name)
     ASSERT(new_theme);
     Gfx::set_system_theme(*new_theme);
     m_palette = Gfx::PaletteImpl::create_with_shared_buffer(*new_theme);
+    Compositor::the().set_backgound_color(palette().desktop_background().to_string());
     HashTable<ClientConnection*> notified_clients;
     for_each_window([&](Window& window) {
         if (window.client()) {


### PR DESCRIPTION
Due to #1998 the desktop background wouldn't change if a colour was already set because the theme change never forced that. 

Now even if you have a wallpaper set up (a bitmap one, I mean), changing the theme will force the colour change as well so if you decide to remove the bitmap it will be there.

Just a bit of nitpicking, really, but I feel this is right.