### PR TITLE
LibJS: Correctness fixes for Array.prototype.{map,find,findIndex}()

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -452,12 +452,12 @@ Value ArrayPrototype::find(Interpreter& interpreter)
     auto array_size = array->elements().size();
 
     for (size_t i = 0; i < array_size; ++i) {
-        if (i >= array->elements().size())
-            break;
-
-        auto value = array->elements().at(i);
-        if (value.is_empty())
-            continue;
+        auto value = js_undefined();
+        if (i < array->elements().size()) {
+            value = array->elements().at(i);
+            if (value.is_empty())
+                value = js_undefined();
+        }
 
         MarkedValueList arguments(interpreter.heap());
         arguments.append(value);

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -489,12 +489,12 @@ Value ArrayPrototype::find_index(Interpreter& interpreter)
     auto array_size = array->elements().size();
 
     for (size_t i = 0; i < array_size; ++i) {
-        if (i >= array->elements().size())
-            break;
-
-        auto value = array->elements().at(i);
-        if (value.is_empty())
-            continue;
+        auto value = js_undefined();
+        if (i < array->elements().size()) {
+            value = array->elements().at(i);
+            if (value.is_empty())
+                value = js_undefined();
+        }
 
         MarkedValueList arguments(interpreter.heap());
         arguments.append(value);

--- a/Libraries/LibJS/Tests/Array.prototype.find.js
+++ b/Libraries/LibJS/Tests/Array.prototype.find.js
@@ -23,6 +23,26 @@ try {
     assert(array.find(value => value > 100) === undefined);
     assert([].find(value => value === 1) === undefined);
 
+    var callbackCalled = 0;
+    var callback = () => { callbackCalled++; };
+
+    [].find(callback)
+    assert(callbackCalled === 0);
+
+    [1, 2, 3].find(callback);
+    assert(callbackCalled === 3);
+
+    callbackCalled = 0;
+    [1, , , "foo", , undefined, , ,].find(callback);
+    assert(callbackCalled === 8);
+
+    callbackCalled = 0;
+    [1, , , "foo", , undefined, , ,].find(value => {
+        callbackCalled++;
+        return value === undefined;
+    });
+    assert(callbackCalled === 2);
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);

--- a/Libraries/LibJS/Tests/Array.prototype.findIndex.js
+++ b/Libraries/LibJS/Tests/Array.prototype.findIndex.js
@@ -23,6 +23,26 @@ try {
     assert(array.findIndex(value => value > 100) === -1);
     assert([].findIndex(value => value === 1) === -1);
 
+    var callbackCalled = 0;
+    var callback = () => { callbackCalled++; };
+
+    [].findIndex(callback)
+    assert(callbackCalled === 0);
+
+    [1, 2, 3].findIndex(callback);
+    assert(callbackCalled === 3);
+
+    callbackCalled = 0;
+    [1, , , "foo", , undefined, , ,].findIndex(callback);
+    assert(callbackCalled === 8);
+
+    callbackCalled = 0;
+    [1, , , "foo", , undefined, , ,].findIndex(value => {
+        callbackCalled++;
+        return value === undefined;
+    });
+    assert(callbackCalled === 2);
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);

--- a/Libraries/LibJS/Tests/Array.prototype.map.js
+++ b/Libraries/LibJS/Tests/Array.prototype.map.js
@@ -26,6 +26,10 @@ try {
     assert([1, 2, 3].map(callback).length === 3);
     assert(callbackCalled === 3);
 
+    callbackCalled = 0;
+    assert([1, , , "foo", , undefined, , ,].map(callback).length === 8);
+    assert(callbackCalled === 3);
+
     var results = [undefined, null, true, "foo", 42, {}].map((value, index) => "" + index + " -> " + value);
     assert(results.length === 6);
     assert(results[0] === "0 -> undefined");

--- a/Libraries/LibJS/Tests/array-shrink-during-find-crash.js
+++ b/Libraries/LibJS/Tests/array-shrink-during-find-crash.js
@@ -9,7 +9,7 @@ try {
         callbackCalled++;
         a.pop();
     });
-    assert(callbackCalled === 3);
+    assert(callbackCalled === 5);
 
     callbackCalled = 0;
     a = [1, 2, 3, 4, 5];

--- a/Libraries/LibJS/Tests/array-shrink-during-find-crash.js
+++ b/Libraries/LibJS/Tests/array-shrink-during-find-crash.js
@@ -17,7 +17,7 @@ try {
         callbackCalled++;
         a.pop();
     });
-    assert(callbackCalled === 3);
+    assert(callbackCalled === 5);
 
     console.log("PASS");
 } catch (e) {


### PR DESCRIPTION
I'll just leave this warning from MDN here.

![image](https://user-images.githubusercontent.com/19366641/80517232-a8d98880-897c-11ea-9137-eb9de008e3f2.png)

This is peak JavaScript inconsistency. Don't make any assumptions, ever!