### PR TITLE
LibJS: Handle Object.prototype.hasOwnProperty() with no arg correctly

### DIFF
--- a/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -57,8 +57,6 @@ Value ObjectPrototype::has_own_property(Interpreter& interpreter)
     auto* this_object = interpreter.this_value().to_object(interpreter.heap());
     if (!this_object)
         return {};
-    if (!interpreter.argument_count())
-        return {};
     return Value(this_object->has_own_property(interpreter.argument(0).to_string()));
 }
 

--- a/Libraries/LibJS/Tests/Object.prototype.hasOwnProperty.js
+++ b/Libraries/LibJS/Tests/Object.prototype.hasOwnProperty.js
@@ -5,6 +5,12 @@ try {
     o.foo = 1;
     assert(o.hasOwnProperty("foo") === true);
     assert(o.hasOwnProperty("bar") === false);
+    assert(o.hasOwnProperty() === false);
+    assert(o.hasOwnProperty(undefined) === false);
+    o.undefined = 2;
+    assert(o.hasOwnProperty() === true);
+    assert(o.hasOwnProperty(undefined) === true);
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);


### PR DESCRIPTION
I.e. the same as `hasOwnProperty(undefined)` or `hasOwnProperty("undefined")` :^)

cc @Mindavi - this solves one of the crashes mentioned in https://github.com/SerenityOS/serenity/issues/1910 as we would return an empty `JS::Value` (which should never be exposed) and fails to stringify when `console.log()`ing.