### PR TITLE
LibJS: Handle exception in for loop test execution

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -236,9 +236,12 @@ Value ForStatement::execute(Interpreter& interpreter) const
     }
 
     if (m_test) {
-        while (m_test->execute(interpreter).to_boolean()) {
+        while (true) {
+            auto test_result = m_test->execute(interpreter);
             if (interpreter.exception())
                 return {};
+            if (!test_result.to_boolean())
+                break;
             last_value = interpreter.run(*m_body);
             if (interpreter.exception())
                 return {};

--- a/Libraries/LibJS/Tests/for-head-errors.js
+++ b/Libraries/LibJS/Tests/for-head-errors.js
@@ -1,0 +1,36 @@
+load("test-common.js");
+
+try {
+    assertThrowsError(() => {
+        for (var i = foo; i < 100; ++i) {
+            assertNotReached();
+        }
+    }, {
+        error: ReferenceError,
+        message: "'foo' not known"
+    });
+
+    assertThrowsError(() => {
+        for (var i = 0; i < foo; ++i) {
+            assertNotReached();
+        }
+    }, {
+        error: ReferenceError,
+        message: "'foo' not known"
+    });
+
+    var loopCount = 0;
+    assertThrowsError(() => {
+        for (var i = 0; i < 100; ++foo) {
+            loopCount++;
+        }
+    }, {
+        error: ReferenceError,
+        message: "'foo' not known"
+    });
+    assert(loopCount === 1);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
We have to check if `m_test->execute(interpreter)` did succeed before calling `on_boolean()` on the result.

cc @Mindavi again :smile:
Thanks for opening and updating https://github.com/SerenityOS/serenity/issues/1910, that's super helpful!