### PR TITLE
LibLine: More fixes

### DIFF
--- a/Applications/Debugger/main.cpp
+++ b/Applications/Debugger/main.cpp
@@ -186,8 +186,6 @@ int main(int argc, char** argv)
     if (argc == 1)
         return usage();
 
-    editor.initialize();
-
     StringBuilder command;
     command.append(argv[1]);
     for (int i = 2; i < argc; ++i) {

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -124,6 +124,8 @@ void Editor::stylize(const Span& span, const Style& style)
 
 String Editor::get_line(const String& prompt)
 {
+    m_is_editing = true;
+
     set_prompt(prompt);
     reset();
     set_origin();
@@ -139,6 +141,7 @@ String Editor::get_line(const String& prompt)
             fflush(stdout);
             auto string = String::copy(m_buffer);
             m_buffer.clear();
+            m_is_editing = false;
             return string;
         }
         char keybuf[16];

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -50,7 +50,7 @@ Editor::Editor(bool always_refresh)
 Editor::~Editor()
 {
     if (m_initialized)
-        tcsetattr(0, TCSANOW, &m_default_termios);
+        restore();
 }
 
 void Editor::add_to_history(const String& line)
@@ -124,6 +124,7 @@ void Editor::stylize(const Span& span, const Style& style)
 
 String Editor::get_line(const String& prompt)
 {
+    initialize();
     m_is_editing = true;
 
     set_prompt(prompt);
@@ -142,6 +143,7 @@ String Editor::get_line(const String& prompt)
             auto string = String::copy(m_buffer);
             m_buffer.clear();
             m_is_editing = false;
+            restore();
             return string;
         }
         char keybuf[16];
@@ -648,7 +650,6 @@ String Editor::get_line(const String& prompt)
                         m_pre_search_buffer.append(ch);
                     m_pre_search_cursor = m_cursor;
                     m_search_editor = make<Editor>(true); // Has anyone seen 'Inception'?
-                    m_search_editor->initialize();
                     m_search_editor->on_display_refresh = [this](Editor& search_editor) {
                         search(StringView { search_editor.buffer().data(), search_editor.buffer().size() });
                         refresh_display();

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -107,7 +107,11 @@ public:
 
     // FIXME: we will have to kindly ask our instantiators to set our signal handlers
     // since we can not do this cleanly ourselves (signal() limitation: cannot give member functions)
-    void interrupted() { m_was_interrupted = true; }
+    void interrupted()
+    {
+        if (m_is_editing)
+            m_was_interrupted = true;
+    }
     void resized() { m_was_resized = true; }
 
     size_t cursor() const { return m_cursor; }
@@ -147,6 +151,8 @@ public:
     {
         m_finish = true;
     }
+
+    bool is_editing() const { return m_is_editing; }
 
 private:
     void vt_save_cursor();
@@ -291,6 +297,8 @@ private:
 
     bool m_initialized { false };
     bool m_refresh_needed { false };
+
+    bool m_is_editing { false };
 };
 
 }

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -80,9 +80,13 @@ public:
     explicit Editor(bool always_refresh = false);
     ~Editor();
 
+    String get_line(const String& prompt);
+
     void initialize()
     {
-        ASSERT(!m_initialized);
+        if (m_initialized)
+            return;
+
         struct termios termios;
         tcgetattr(0, &termios);
         m_default_termios = termios; // grab a copy to restore
@@ -93,8 +97,6 @@ public:
         m_termios = termios;
         m_initialized = true;
     }
-
-    String get_line(const String& prompt);
 
     void add_to_history(const String&);
     const Vector<String>& history() const { return m_history; }
@@ -193,6 +195,13 @@ private:
 
     void refresh_display();
     void cleanup();
+
+    void restore()
+    {
+        ASSERT(m_initialized);
+        tcsetattr(0, TCSANOW, &m_default_termios);
+        m_initialized = false;
+    }
 
     size_t current_prompt_length() const
     {

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -421,7 +421,8 @@ int main(int argc, char** argv)
         s_editor = make<Line::Editor>();
 
         signal(SIGINT, [](int) {
-            sigint_handler();
+            if (!s_editor->is_editing())
+                sigint_handler();
             s_editor->interrupted();
         });
 

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -430,7 +430,6 @@ int main(int argc, char** argv)
             s_editor->resized();
         });
 
-        s_editor->initialize();
         s_editor->on_display_refresh = [syntax_highlight](Line::Editor& editor) {
             auto stylize = [&](Line::Span span, Line::Style styles) {
                 if (syntax_highlight)


### PR DESCRIPTION
- Fixes #2008.
- removes the need to call `editor.initialize()`
- restores the "default_termios" when editing finishes
- Ignores meaningless interrupts
