### PR TITLE
LibJS: LibJS: Skip undefined and null in join_array_with_separator() / Don't handle arrays separately in Value::to_number()

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -226,8 +226,9 @@ static Value join_array_with_separator(Interpreter& interpreter, const Array& ar
     for (size_t i = 0; i < array.elements().size(); ++i) {
         if (i != 0)
             builder.append(separator);
-        if (!array.elements()[i].is_empty())
-            builder.append(array.elements()[i].to_string());
+        auto value = array.elements()[i];
+        if (!value.is_empty() && !value.is_undefined() && !value.is_null())
+            builder.append(value.to_string());
     }
     return js_string(interpreter, builder.to_string());
 }

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -162,16 +162,7 @@ Value Value::to_number() const
     case Type::Undefined:
         return js_nan();
     case Type::Object:
-        if (m_value.as_object->is_array()) {
-            auto& array = *static_cast<Array*>(m_value.as_object);
-            if (array.length() == 0)
-                return Value(0);
-            if (array.length() > 1)
-                return js_nan();
-            return array.elements()[0].to_number();
-        } else {
-            return m_value.as_object->to_primitive(Object::PreferredType::Number).to_number();
-        }
+        return m_value.as_object->to_primitive(Object::PreferredType::Number).to_number();
     }
 
     ASSERT_NOT_REACHED();

--- a/Libraries/LibJS/Tests/Array.prototype.join.js
+++ b/Libraries/LibJS/Tests/Array.prototype.join.js
@@ -5,6 +5,11 @@ try {
 
     assert(["hello", "friends"].join() === "hello,friends");
     assert(["hello", "friends"].join(" ") === "hello friends");
+    assert([].join() === "");
+    assert([null].join() === "");
+    assert([undefined].join() === "");
+    assert([undefined, null, ""].join() === ",,");
+    assert([1, null, 2, undefined, 3].join() === "1,,2,,3");
     assert(Array(3).join() === ",,");
 
     console.log("PASS");

--- a/Libraries/LibJS/Tests/Array.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Array.prototype.toString.js
@@ -8,6 +8,8 @@ try {
 
     assert("rgb(" + [10, 11, 12] + ")" === "rgb(10,11,12)");
 
+    assert([undefined, null].toString() === ",");
+
     a = new Array(5);
     assert(a.toString() === ",,,,");
     a[2] = "foo";

--- a/Libraries/LibJS/Tests/to-number-basic.js
+++ b/Libraries/LibJS/Tests/to-number-basic.js
@@ -9,6 +9,12 @@ try {
     assert(-null === 0);
     assert(+[] === 0);
     assert(-[] === 0);
+    assert(+[,] === 0);
+    assert(-[,] === 0);
+    assert(+[null] === 0);
+    assert(-[null] === 0);
+    assert(+[undefined] === 0);
+    assert(-[undefined] === 0);
     assert(+[[[[[]]]]] === 0);
     assert(-[[[[[]]]]] === 0);
     assert(+[[[[[42]]]]] === 42);
@@ -35,8 +41,12 @@ try {
     assert(isNaN(-undefined));
     assert(isNaN(+{}));
     assert(isNaN(-{}));
-    assert(isNaN(+{a: 1}));
-    assert(isNaN(-{a: 1}));
+    assert(isNaN(+{ a: 1 }));
+    assert(isNaN(-{ a: 1 }));
+    assert(isNaN(+[, , ,]));
+    assert(isNaN(-[, , ,]));
+    assert(isNaN(+[undefined, undefined]));
+    assert(isNaN(-[undefined, undefined]));
     assert(isNaN(+[1, 2, 3]));
     assert(isNaN(-[1, 2, 3]));
     assert(isNaN(+[[[["foo"]]]]));


### PR DESCRIPTION
Small fix for `Array.prototype.join()`/`Array.prototype.toString()`: https://www.ecma-international.org/ecma-262/5.1/#sec-15.4.4.5

Subsequently we can remove our custom array code path in `Value::to_number()` and just use `to_primitive` as the spec dictates it.

See the commit descriptions for details.

This fixes a crash when doing `+[,]` reported by @Mindavi in https://github.com/SerenityOS/serenity/issues/1910 - keep 'em coming! :smile: