### PR TITLE
LibJS: Return undefined in Array.prototype.{pop,shift} for empty values

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -207,7 +207,7 @@ Value ArrayPrototype::pop(Interpreter& interpreter)
         return {};
     if (array->elements().is_empty())
         return js_undefined();
-    return array->elements().take_last();
+    return array->elements().take_last().value_or(js_undefined());
 }
 
 Value ArrayPrototype::shift(Interpreter& interpreter)
@@ -217,7 +217,7 @@ Value ArrayPrototype::shift(Interpreter& interpreter)
         return {};
     if (array->elements().is_empty())
         return js_undefined();
-    return array->elements().take_first();
+    return array->elements().take_first().value_or(js_undefined());
 }
 
 static Value join_array_with_separator(Interpreter& interpreter, const Array& array, StringView separator)

--- a/Libraries/LibJS/Tests/Array.prototype.pop.js
+++ b/Libraries/LibJS/Tests/Array.prototype.pop.js
@@ -13,6 +13,8 @@ try {
     assert(value === undefined);
     assert(a.length === 0);
 
+    assert([,].pop() === undefined);
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);

--- a/Libraries/LibJS/Tests/Array.prototype.shift.js
+++ b/Libraries/LibJS/Tests/Array.prototype.shift.js
@@ -13,6 +13,8 @@ try {
     assert(value === undefined);
     assert(a.length === 0);
 
+    assert([,].shift() === undefined);
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);


### PR DESCRIPTION
This fixes a crash when doing `var foo = [,].shift()` - we shouldn't be handing out empty values, and the assignment expression asserts to enforce this. (reported by @Mindavi in #1910)