### PR TITLE
LibJS: Object.{keys,values,entries} & correct object property ordering

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1046,9 +1046,9 @@ Value ObjectExpression::execute(Interpreter& interpreter) const
             } else if (key_result.is_object()) {
                 auto& obj_to_spread = key_result.as_object();
 
-                for (auto& it : obj_to_spread.shape().property_table()) {
-                    if (obj_to_spread.has_own_property(it.key) && it.value.attributes & Attribute::Enumerable)
-                        object->put(it.key, obj_to_spread.get(it.key));
+                for (auto& it : obj_to_spread.shape().property_table_ordered()) {
+                    if (it.metadata.attributes & Attribute::Enumerable)
+                        object->put(it.name, obj_to_spread.get(it.name));
                 }
             } else if (key_result.is_string()) {
                 auto& str_to_spread = key_result.as_string()->string();

--- a/Libraries/LibJS/Runtime/Array.cpp
+++ b/Libraries/LibJS/Runtime/Array.cpp
@@ -42,7 +42,7 @@ Array* Array::create(GlobalObject& global_object)
 Array::Array(Object& prototype)
     : Object(&prototype)
 {
-    put_native_property("length", length_getter, length_setter);
+    put_native_property("length", length_getter, length_setter, Attribute::Configurable | Attribute::Writable);
 }
 
 Array::~Array()

--- a/Libraries/LibJS/Runtime/Cell.cpp
+++ b/Libraries/LibJS/Runtime/Cell.cpp
@@ -56,6 +56,11 @@ Interpreter& Cell::interpreter()
     return heap().interpreter();
 }
 
+Interpreter& Cell::interpreter() const
+{
+    return heap().interpreter();
+}
+
 const LogStream& operator<<(const LogStream& stream, const Cell* cell)
 {
     if (!cell)

--- a/Libraries/LibJS/Runtime/Cell.h
+++ b/Libraries/LibJS/Runtime/Cell.h
@@ -60,6 +60,7 @@ public:
 
     Heap& heap() const;
     Interpreter& interpreter();
+    Interpreter& interpreter() const;
 
 protected:
     Cell() {}

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -61,6 +61,13 @@ public:
 
     Value get_own_property(const Object& this_object, const FlyString& property_name) const;
 
+    enum class GetOwnPropertyMode {
+        Key,
+        Value,
+        KeyAndValue,
+    };
+    Value get_own_properties(const Object& this_object, GetOwnPropertyMode, bool enumerable_only = false) const;
+
     enum class PutOwnPropertyMode {
         Put,
         DefineProperty,

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -47,6 +47,9 @@ ObjectConstructor::ObjectConstructor()
     put_native_function("getOwnPropertyNames", get_own_property_names, 1, attr);
     put_native_function("getPrototypeOf", get_prototype_of, 1, attr);
     put_native_function("setPrototypeOf", set_prototype_of, 2, attr);
+    put_native_function("keys", keys, 1, attr);
+    put_native_function("values", values, 1, attr);
+    put_native_function("entries", entries, 1, attr);
 }
 
 ObjectConstructor::~ObjectConstructor()
@@ -76,8 +79,8 @@ Value ObjectConstructor::get_own_property_names(Interpreter& interpreter)
             result->elements().append(js_string(interpreter, String::number(i)));
     }
 
-    for (auto& it : object->shape().property_table()) {
-        result->elements().append(js_string(interpreter, it.key));
+    for (auto& it : object->shape().property_table_ordered()) {
+        result->elements().append(js_string(interpreter, it.name));
     }
     return result;
 }
@@ -163,6 +166,42 @@ Value ObjectConstructor::is(Interpreter& interpreter)
         return Value(false);
     }
     return typed_eq(interpreter, value1, value2);
+}
+
+Value ObjectConstructor::keys(Interpreter& interpreter)
+{
+    if (!interpreter.argument_count())
+        interpreter.throw_exception<TypeError>("can't convert undefined to object");
+
+    auto* obj_arg = interpreter.argument(0).to_object(interpreter.heap());
+    if (interpreter.exception())
+        return {};
+
+    return obj_arg->get_own_properties(*obj_arg, GetOwnPropertyMode::Key, true);
+}
+
+Value ObjectConstructor::values(Interpreter& interpreter)
+{
+    if (!interpreter.argument_count())
+        interpreter.throw_exception<TypeError>("can't convert undefined to object");
+
+    auto* obj_arg = interpreter.argument(0).to_object(interpreter.heap());
+    if (interpreter.exception())
+        return {};
+
+    return obj_arg->get_own_properties(*obj_arg, GetOwnPropertyMode::Value, true);
+}
+
+Value ObjectConstructor::entries(Interpreter& interpreter)
+{
+    if (!interpreter.argument_count())
+        interpreter.throw_exception<TypeError>("can't convert undefined to object");
+
+    auto* obj_arg = interpreter.argument(0).to_object(interpreter.heap());
+    if (interpreter.exception())
+        return {};
+
+    return obj_arg->get_own_properties(*obj_arg, GetOwnPropertyMode::KeyAndValue, true);
 }
 
 }

--- a/Libraries/LibJS/Runtime/ObjectConstructor.h
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.h
@@ -48,6 +48,9 @@ private:
     static Value get_own_property_names(Interpreter&);
     static Value get_prototype_of(Interpreter&);
     static Value set_prototype_of(Interpreter&);
+    static Value keys(Interpreter&);
+    static Value values(Interpreter&);
+    static Value entries(Interpreter&);
 };
 
 }

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -112,6 +112,18 @@ const HashMap<FlyString, PropertyMetadata>& Shape::property_table() const
     return *m_property_table;
 }
 
+Vector<Shape::Property> Shape::property_table_ordered() const
+{
+    auto vec = Vector<Shape::Property>();
+    vec.resize(property_table().size());
+
+    for (auto& it : property_table()) {
+        vec[it.value.offset] = { it.key, it.value };
+    }
+
+    return vec;
+}
+
 size_t Shape::property_count() const
 {
     return property_table().size();

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -88,6 +88,12 @@ public:
     const HashMap<FlyString, PropertyMetadata>& property_table() const;
     size_t property_count() const;
 
+    struct Property {
+        FlyString name;
+        PropertyMetadata metadata;
+    };
+    Vector<Property> property_table_ordered() const;
+
     void set_prototype_without_transition(Object* new_prototype) { m_prototype = new_prototype; }
 
     void remove_property_from_unique_shape(const FlyString&, size_t offset);

--- a/Libraries/LibJS/Tests/Object.entries.js
+++ b/Libraries/LibJS/Tests/Object.entries.js
@@ -1,0 +1,54 @@
+load("test-common.js");
+
+try {
+    assert(Object.entries.length === 1);
+    assert(Object.entries(true).length === 0);
+    assert(Object.entries(45).length === 0);
+    assert(Object.entries(-998).length === 0);
+    assert(Object.entries("abcd").length === 4);
+    assert(Object.entries([1, 2, 3]).length === 3);
+    assert(Object.entries({ a: 1, b: 2, c: 3 }).length === 3);
+    
+    assertThrowsError(() => {
+        Object.entries(null);
+    }, {
+        error: TypeError,
+        message: "ToObject on null or undefined.",
+    });
+
+    assertThrowsError(() => {
+        Object.entries(undefined);
+    }, {
+        error: TypeError,
+        message: "ToObject on null or undefined.",
+    });
+    
+    let entries = Object.entries({ foo: 1, bar: 2, baz: 3 });
+    assert(
+        entries.length === 3 && entries[0].length === 2 && 
+        entries[1].length === 2 && entries[2].length === 2 &&
+        entries[0][0] === "foo" && entries[0][1] === 1 &&
+        entries[1][0] === "bar" && entries[1][1] === 2 &&
+        entries[2][0] === "baz" && entries[2][1] === 3
+    );
+
+    entries = Object.entries(["a", "b", "c"]);
+    assert(
+        entries.length === 3 && entries[0].length === 2 && 
+        entries[1].length === 2 && entries[2].length === 2 &&
+        entries[0][0] === "0" && entries[0][1] === "a" &&
+        entries[1][0] === "1" && entries[1][1] === "b" &&
+        entries[2][0] === "2" && entries[2][1] === "c"
+    );
+
+    let obj = { foo: 1 };
+    Object.defineProperty(obj, "getFoo", {
+        value: function() { return this.foo; },
+    });
+    let entries = Object.entries(obj);
+    assert(entries.length === 1 && entries[0][0] === "foo" && entries[0][1] === 1);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Object.keys.js
+++ b/Libraries/LibJS/Tests/Object.keys.js
@@ -1,0 +1,42 @@
+load("test-common.js");
+
+try {
+    assert(Object.keys.length === 1);
+    assert(Object.keys(true).length === 0);
+    assert(Object.keys(45).length === 0);
+    assert(Object.keys(-998).length === 0);
+    assert(Object.keys("abcd").length === 4);
+    assert(Object.keys([1, 2, 3]).length === 3);
+    assert(Object.keys({ a: 1, b: 2, c: 3 }).length === 3);
+    
+    assertThrowsError(() => {
+        Object.keys(null);
+    }, {
+        error: TypeError,
+        message: "ToObject on null or undefined.",
+    });
+
+    assertThrowsError(() => {
+        Object.keys(undefined);
+    }, {
+        error: TypeError,
+        message: "ToObject on null or undefined.",
+    });
+    
+    let keys = Object.keys({ foo: 1, bar: 2, baz: 3 });
+    assert(keys[0] === "foo" && keys[1] === "bar" && keys[2] === "baz");
+
+    keys = Object.keys(["a", "b", "c"]);
+    assert(keys[0] === "0" && keys[1] === "1" && keys[2] === "2");
+
+    let obj = { foo: 1 };
+    Object.defineProperty(obj, 'getFoo', {
+        value: function() { return this.foo; },
+    });
+    keys = Object.keys(obj);
+    assert(keys.length === 1 && keys[0] === 'foo');
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Object.values.js
+++ b/Libraries/LibJS/Tests/Object.values.js
@@ -1,0 +1,42 @@
+load("test-common.js");
+
+try {
+    assert(Object.values.length === 1);
+    assert(Object.values(true).length === 0);
+    assert(Object.values(45).length === 0);
+    assert(Object.values(-998).length === 0);
+    assert(Object.values("abcd").length === 4);
+    assert(Object.values([1, 2, 3]).length === 3);
+    assert(Object.values({ a: 1, b: 2, c: 3 }).length === 3);
+    
+    assertThrowsError(() => {
+        Object.values(null);
+    }, {
+        error: TypeError,
+        message: "ToObject on null or undefined.",
+    });
+
+    assertThrowsError(() => {
+        Object.values(undefined);
+    }, {
+        error: TypeError,
+        message: "ToObject on null or undefined.",
+    });
+    
+    let values = Object.values({ foo: 1, bar: 2, baz: 3 });
+    assert(values[0] === 1 && values[1] === 2 && values[2] === 3);
+
+    values = Object.values(["a", "b", "c"]);
+    assert(values[0] === "a" && values[1] === "b" && values[2] === "c");
+
+    let obj = { foo: 1 };
+    Object.defineProperty(obj, 'getFoo', {
+        value: function() { return this.foo; },
+    });
+    let values = Object.values(obj);
+    assert(values.length === 1 && values[0] === 1);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/object-spread.js
+++ b/Libraries/LibJS/Tests/object-spread.js
@@ -21,6 +21,12 @@ try {
         qux: 3,
     };
     assert(testObjSpread(obj));
+    
+    // Test spread object ordering
+    let keys = Object.keys(obj);
+    assert(
+        keys[0] === 'foo' && keys[1] === 'bar' && keys[2] === 'baz' && keys[3] === 'qux'
+    );
 
     obj = { foo: 0, bar: 1, baz: 2 };
     obj.qux = 3;

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -142,9 +142,9 @@ static void print_object(const JS::Object& object, HashTable<JS::Object*>& seen_
         fputs(", ", stdout);
 
     size_t index = 0;
-    for (auto& it : object.shape().property_table()) {
-        printf("\"\033[33;1m%s\033[0m\": ", it.key.characters());
-        print_value(object.get_direct(it.value.offset), seen_objects);
+    for (auto& it : object.shape().property_table_ordered()) {
+        printf("\"\033[33;1m%s\033[0m\": ", it.name.characters());
+        print_value(object.get_direct(it.metadata.offset), seen_objects);
         if (index != object.shape().property_count() - 1)
             fputs(", ", stdout);
         ++index;


### PR DESCRIPTION
Adds `Object.{keys,values,entries}()` which can be applied to all types except null and undefined.

This commit also introduces a way to get an object's own properties in the correct order. In this context, the order is the standard JS object property ordering: first, all array index-like properties (number keys), followed by all string properties. Each of the previous two groups is ordered by time of insertion, with the earliest inserted item coming first.

Also fixed the attributes of `Array.prototype.length` in order to make one of the tests work.

The implementation of `property_table_ordered` is not optimal, as it creates a new `Vector` every call. I was thinking about just constructing a vector alongside `m_property_table` and updating that whenever `m_property_table` is updated.