### PR TITLE
LibJS: Set Array length attributes to "Configurable | Writable"

### DIFF
--- a/Libraries/LibJS/Runtime/Array.cpp
+++ b/Libraries/LibJS/Runtime/Array.cpp
@@ -42,7 +42,7 @@ Array* Array::create(GlobalObject& global_object)
 Array::Array(Object& prototype)
     : Object(&prototype)
 {
-    put_native_property("length", length_getter, length_setter);
+    put_native_property("length", length_getter, length_setter, Attribute::Configurable | Attribute::Writable);
 }
 
 Array::~Array()


### PR DESCRIPTION
Forgot this one in 23ec578a016d5d8b4e55553924d3d37d899854c8