### PR TITLE
LibJS: Make (most) String.prototype functions generic

### DIFF
--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -360,12 +360,12 @@ Value Object::to_string() const
         && to_string_property.as_object().is_function()) {
         auto& to_string_function = static_cast<Function&>(to_string_property.as_object());
         auto& interpreter = const_cast<Object*>(this)->interpreter();
-        auto string_value = interpreter.call(to_string_function, const_cast<Object*>(this));
-        if (!string_value.is_string())
+        auto to_string_result = interpreter.call(to_string_function, const_cast<Object*>(this));
+        if (to_string_result.is_object())
             interpreter.throw_exception<TypeError>("Cannot convert object to string");
         if (interpreter.exception())
             return {};
-        return string_value;
+        return js_string(heap(), to_string_result.to_string());
     }
     return js_string(heap(), String::format("[object %s]", class_name()));
 }

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -359,7 +359,13 @@ Value Object::to_string() const
         && to_string_property.is_object()
         && to_string_property.as_object().is_function()) {
         auto& to_string_function = static_cast<Function&>(to_string_property.as_object());
-        return const_cast<Object*>(this)->interpreter().call(to_string_function, const_cast<Object*>(this));
+        auto& interpreter = const_cast<Object*>(this)->interpreter();
+        auto string_value = interpreter.call(to_string_function, const_cast<Object*>(this));
+        if (!string_value.is_string())
+            interpreter.throw_exception<TypeError>("Cannot convert object to string");
+        if (interpreter.exception())
+            return {};
+        return string_value;
     }
     return js_string(heap(), String::format("[object %s]", class_name()));
 }

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -69,8 +69,13 @@ String Value::to_string() const
         return String::format("%.4f", as_double());
     }
 
-    if (is_object())
-        return as_object().to_primitive(Object::PreferredType::String).to_string();
+    if (is_object()) {
+        auto primitive_value = as_object().to_primitive(Object::PreferredType::String);
+        // FIXME: Maybe we should pass in the Interpreter& and call interpreter.exception() instead?
+        if (primitive_value.is_empty())
+            return {};
+        return primitive_value.to_string();
+    }
 
     if (is_string())
         return m_value.as_string->string();

--- a/Libraries/LibJS/Tests/String.prototype-generic-functions.js
+++ b/Libraries/LibJS/Tests/String.prototype-generic-functions.js
@@ -1,0 +1,51 @@
+load("test-common.js");
+
+try {
+    const genericStringPrototypeFunctions = [
+        "charAt",
+        "repeat",
+        "startsWith",
+        "indexOf",
+        "toLowerCase",
+        "toUpperCase",
+        "padStart",
+        "padEnd",
+        "trim",
+        "trimStart",
+        "trimEnd",
+        "concat",
+        "substring",
+        "includes",
+    ];
+
+    genericStringPrototypeFunctions.forEach(name => {
+        String.prototype[name].call({ toString: () => "hello friends" });
+        String.prototype[name].call({ toString: () => 123 });
+        String.prototype[name].call({ toString: () => undefined });
+
+        assertThrowsError(() => {
+            String.prototype[name].call({ toString: () => new String() });
+        }, {
+            error: TypeError,
+            message: "Cannot convert object to string"
+        });
+
+        assertThrowsError(() => {
+            String.prototype[name].call({ toString: () => [] });
+        }, {
+            error: TypeError,
+            message: "Cannot convert object to string"
+        });
+
+        assertThrowsError(() => {
+            String.prototype[name].call({ toString: () => ({}) });
+        }, {
+            error: TypeError,
+            message: "Cannot convert object to string"
+        });
+    });
+
+    console.log("PASS");
+} catch (err) {
+    console.log("FAIL: " + err);
+}


### PR DESCRIPTION
I.e. they don't require the |this| value to be a string object and "can be transferred to other kinds of objects for use as a method" as the spec describes it.