### PR TITLE
Markdown images & don't assert on broken link markup

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -234,13 +234,16 @@ public:
         return *this;
     }
 
+    template<typename U, typename V>
+    static bool addition_would_overflow(U u, V v)
+    {
+        return __builtin_add_overflow_p(u, v, (T)0);
+    }
+
     template<typename U, typename V, typename X>
     static bool multiplication_would_overflow(U u, V v)
     {
-        Checked checked;
-        checked = u;
-        checked *= v;
-        return checked.has_overflow();
+        return __builtin_mul_overflow_p(u, v, (T)0);
     }
 
     template<typename U, typename V, typename X>

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -38,14 +38,14 @@ class StringView {
 public:
     using ConstIterator = const char*;
 
-    StringView() { }
-    StringView(const char* characters, size_t length)
+    [[gnu::always_inline]] inline StringView() { }
+    [[gnu::always_inline]] inline StringView(const char* characters, size_t length)
         : m_characters(characters)
         , m_length(length)
     {
         ASSERT(!Checked<uintptr_t>::addition_would_overflow((uintptr_t)characters, length));
     }
-    StringView(const unsigned char* characters, size_t length)
+    [[gnu::always_inline]] inline StringView(const unsigned char* characters, size_t length)
         : m_characters((const char*)characters)
         , m_length(length)
     {

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
+#include <AK/Checked.h>
 #include <AK/Forward.h>
 #include <AK/StdLibExtras.h>
 #include <AK/StringUtils.h>
@@ -36,16 +38,18 @@ class StringView {
 public:
     using ConstIterator = const char*;
 
-    StringView() {}
+    StringView() { }
     StringView(const char* characters, size_t length)
         : m_characters(characters)
         , m_length(length)
     {
+        ASSERT(!Checked<uintptr_t>::addition_would_overflow((uintptr_t)characters, length));
     }
     StringView(const unsigned char* characters, size_t length)
         : m_characters((const char*)characters)
         , m_length(length)
     {
+        ASSERT(!Checked<uintptr_t>::addition_would_overflow((uintptr_t)characters, length));
     }
     [[gnu::always_inline]] inline StringView(const char* cstring)
         : m_characters(cstring)

--- a/Libraries/LibC/assert.h
+++ b/Libraries/LibC/assert.h
@@ -34,7 +34,11 @@ __BEGIN_DECLS
 __attribute__((noreturn)) void __assertion_failed(const char* msg);
 #    define __stringify_helper(x) #    x
 #    define __stringify(x) __stringify_helper(x)
-#    define assert(expr) ((expr) ? (void)0 : __assertion_failed(#    expr "\n" __FILE__ ":" __stringify(__LINE__)));
+#    define assert(expr)                                                           \
+        do {                                                                       \
+            if (__builtin_expect(!(expr), 0))                                      \
+                __assertion_failed(#expr "\n" __FILE__ ":" __stringify(__LINE__)); \
+        } while (0)
 #    define ASSERT_NOT_REACHED() assert(false)
 #else
 #    define assert(expr)

--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -331,9 +331,6 @@ void EventLoop::pump(WaitMode mode)
 
     for (size_t i = 0; i < events.size(); ++i) {
         auto& queued_event = events.at(i);
-#ifndef __clang__
-        ASSERT(queued_event.event);
-#endif
         auto* receiver = queued_event.receiver.ptr();
         auto& event = *queued_event.event;
 #ifdef CEVENTLOOP_DEBUG

--- a/Libraries/LibMarkdown/Text.h
+++ b/Libraries/LibMarkdown/Text.h
@@ -38,6 +38,7 @@ public:
         bool strong { false };
         bool code { false };
         String href;
+        String img;
     };
 
     struct Span {


### PR DESCRIPTION
Please check that the new assertion in `StringView` doesn't regress performance on all those benchmarks (JS, ProfileVIewer...). If it does, the first commit can be dropped.

We can now parse those images in ReadMe.md, but not display them because they're HTTPS. Sad face.