### PR TITLE
Browser: Add missing tooltip to bookmark button

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -271,8 +271,10 @@ void Tab::update_bookmark_button(const String& url)
 {
     if (BookmarksBarWidget::the().contains_bookmark(url)) {
         m_bookmark_button->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/star-yellow.png"));
+        m_bookmark_button->set_tooltip("Remove Bookmark");
     } else {
         m_bookmark_button->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/star-contour.png"));
+        m_bookmark_button->set_tooltip("Add Bookmark");
     }
 }
 


### PR DESCRIPTION
The "bookmarks" button in the browser was missing a tool tip. Because what the button does is contextual to whether the current site is already a bookmark, I set it at the same location that the icon is set.