### PR TITLE
LibLine: Reset inline_search_cursor along with cursor

### DIFF
--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -219,6 +219,7 @@ private:
         m_old_prompt_length = m_cached_prompt_length;
         m_refresh_needed = true;
         m_cursor = 0;
+        m_inline_search_cursor = 0;
     }
 
     void refresh_display();


### PR DESCRIPTION
This fixes the issue where the editor would only scroll up one command and then 'search' for it.

