### PR TITLE
[Multiple] Add the posibility to copy/paste bitmaps to/from the Clipboard

### DIFF
--- a/Applications/PaintBrush/main.cpp
+++ b/Applications/PaintBrush/main.cpp
@@ -31,6 +31,7 @@
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
+#include <LibGUI/Clipboard.h>
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/MenuBar.h>
@@ -96,7 +97,26 @@ int main(int argc, char** argv)
         return;
     }));
 
-    menubar->add_menu("Edit");
+    auto& edit_menu = menubar->add_menu("Edit");
+
+    auto paste_action = GUI::CommonActions::make_paste_action(
+        [&](const GUI::Action&) {
+            auto old_bitmap = RefPtr<Gfx::Bitmap>(paintable_widget.bitmap());
+            auto clipboard_bitmap = GUI::Clipboard::the().get_bitmap();
+            if (!clipboard_bitmap)
+                return;
+            paintable_widget.set_bitmap(*clipboard_bitmap->cloned());
+        },
+        window);
+
+    auto copy_action = GUI::CommonActions::make_copy_action(
+        [&](const GUI::Action&) {
+            GUI::Clipboard::the().set_data(paintable_widget.bitmap());
+        },
+        window);
+
+    edit_menu.add_action(copy_action);
+    edit_menu.add_action(paste_action);
 
     auto& help_menu = menubar->add_menu("Help");
     help_menu.add_action(GUI::Action::create("About", [&](auto&) {

--- a/Libraries/LibGUI/Clipboard.h
+++ b/Libraries/LibGUI/Clipboard.h
@@ -27,8 +27,10 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/SharedBuffer.h>
 #include <AK/String.h>
 #include <LibGUI/Forward.h>
+#include <LibGfx/Bitmap.h>
 
 namespace GUI {
 
@@ -39,13 +41,14 @@ public:
     String data() const { return data_and_type().data; }
     String type() const { return data_and_type().type; }
     void set_data(const StringView&, const String& data_type = "text");
-
+    void set_data(const Gfx::Bitmap&);
     struct DataAndType {
         String data;
         String type;
     };
 
     DataAndType data_and_type() const;
+    RefPtr<Gfx::Bitmap> get_bitmap();
 
     void did_receive_clipboard_contents_changed(Badge<WindowServerConnection>, const String& data_type);
 

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -1198,11 +1198,13 @@ void TextEditor::paste()
 {
     if (is_readonly())
         return;
-    auto paste_text = Clipboard::the().data();
-    printf("Paste: \"%s\"\n", paste_text.characters());
+    auto [data, type] = Clipboard::the().data_and_type();
+    if (type != "text")
+        return;
+    printf("Paste: \"%s\"\n", data.characters());
 
     TemporaryChange change(m_automatic_indentation_enabled, false);
-    insert_at_cursor_or_replace_selection(paste_text);
+    insert_at_cursor_or_replace_selection(data);
 }
 
 void TextEditor::enter_event(Core::Event&)

--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -29,8 +29,8 @@
 #include <AK/SharedBuffer.h>
 #include <AK/String.h>
 #include <LibGfx/Bitmap.h>
-#include <LibGfx/PNGLoader.h>
 #include <LibGfx/GIFLoader.h>
+#include <LibGfx/PNGLoader.h>
 #include <LibGfx/ShareableBitmap.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -61,6 +61,16 @@ RefPtr<Bitmap> Bitmap::create_purgeable(BitmapFormat format, const Size& size)
     return adopt(*new Bitmap(format, size, Purgeable::Yes));
 }
 
+RefPtr<Bitmap> Bitmap::cloned()
+{
+    auto cloned_bitmap = Bitmap::create(format(), size());
+    if (!cloned_bitmap) {
+        return nullptr;
+    }
+    memcpy(cloned_bitmap->scanline(0), scanline(0), size_in_bytes());
+    return cloned_bitmap;
+}
+
 Bitmap::Bitmap(BitmapFormat format, const Size& size, Purgeable purgeable)
     : m_size(size)
     , m_pitch(round_up_to_power_of_two(size.width() * sizeof(RGBA32), 16))
@@ -86,9 +96,9 @@ RefPtr<Bitmap> Bitmap::create_wrapper(BitmapFormat format, const Size& size, siz
 
 RefPtr<Bitmap> Bitmap::load_from_file(const StringView& path)
 {
-    if(path.ends_with(".png"))
+    if (path.ends_with(".png"))
         return load_png(path);
-    if(path.ends_with(".gif"))
+    if (path.ends_with(".gif"))
         return load_gif(path);
 
     return nullptr;

--- a/Libraries/LibGfx/Bitmap.h
+++ b/Libraries/LibGfx/Bitmap.h
@@ -59,6 +59,7 @@ public:
     RefPtr<Gfx::Bitmap> flipped(Gfx::Orientation) const;
     RefPtr<Bitmap> to_bitmap_backed_by_shared_buffer() const;
 
+    RefPtr<Bitmap> cloned();
     ShareableBitmap to_shareable_bitmap(pid_t peer_pid = -1) const;
 
     ~Bitmap();

--- a/Libraries/LibIPC/Decoder.cpp
+++ b/Libraries/LibIPC/Decoder.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/BufferStream.h>
+#include <LibGfx/Bitmap.h>
 #include <LibIPC/Decoder.h>
 
 namespace IPC {
@@ -110,6 +111,51 @@ bool Decoder::decode(String& value)
     }
     value = *text_impl;
     return !m_stream.handle_read_failure();
+}
+
+bool Decoder::decode(Gfx::BitmapFormat& format)
+{
+    i32 index;
+    m_stream >> index;
+
+    if (index == -1)
+        return false;
+
+    if (index == 0) {
+        format = Gfx::BitmapFormat::RGB32;
+    } else if (index == 1) {
+        format = Gfx::BitmapFormat::RGBA32;
+    } else if (index == 2) {
+        format = Gfx::BitmapFormat::Indexed8;
+    } else {
+        format = Gfx::BitmapFormat::Invalid;
+    }
+    return true;
+}
+
+bool Decoder::decode(Gfx::Size& size)
+{
+    i32 height;
+    m_stream >> height;
+    if (m_stream.handle_read_failure())
+        return false;
+    if (height < 0) {
+        size = {};
+        return true;
+    }
+    size.set_height(height);
+
+    i32 width;
+    m_stream >> width;
+    if (m_stream.handle_read_failure())
+        return false;
+    if (width < 0) {
+        size = {};
+        return true;
+    }
+    size.set_width(width);
+
+    return true;
 }
 
 }

--- a/Libraries/LibIPC/Decoder.h
+++ b/Libraries/LibIPC/Decoder.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <LibGfx/Bitmap.h>
 #include <LibIPC/Message.h>
 
 namespace IPC {
@@ -55,6 +56,8 @@ public:
     bool decode(i64&);
     bool decode(float&);
     bool decode(String&);
+    bool decode(Gfx::BitmapFormat&);
+    bool decode(Gfx::Size&);
 
     template<typename T>
     bool decode(T& value)

--- a/Libraries/LibIPC/Encoder.cpp
+++ b/Libraries/LibIPC/Encoder.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/String.h>
+#include <LibGfx/Bitmap.h>
 #include <LibIPC/Encoder.h>
 
 namespace IPC {
@@ -139,4 +140,31 @@ Encoder& Encoder::operator<<(const String& value)
     return *this << value.view();
 }
 
+Encoder& Encoder::operator<<(Gfx::BitmapFormat format)
+{
+    i32 index;
+    switch (format) {
+    case Gfx::BitmapFormat::RGB32:
+        index = 0;
+        break;
+    case Gfx::BitmapFormat::RGBA32:
+        index = 1;
+        break;
+    case Gfx::BitmapFormat::Indexed8:
+        index = 2;
+        break;
+    case Gfx::BitmapFormat::Invalid:
+        index = 3;
+        break;
+    default:
+        index = -1;
+    }
+
+    return *this << index;
+}
+
+Encoder& Encoder::operator<<(Gfx::Size size)
+{
+    return *this << static_cast<i32>(size.width()) << static_cast<i32>(size.height());
+}
 }

--- a/Libraries/LibIPC/Encoder.h
+++ b/Libraries/LibIPC/Encoder.h
@@ -50,6 +50,8 @@ public:
     Encoder& operator<<(const char*);
     Encoder& operator<<(const StringView&);
     Encoder& operator<<(const String&);
+    Encoder& operator<<(Gfx::BitmapFormat);
+    Encoder& operator<<(Gfx::Size);
 
 private:
     MessageBuffer& m_buffer;

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -568,10 +568,12 @@ void TerminalWidget::paste()
 {
     if (m_ptm_fd == -1)
         return;
-    auto text = GUI::Clipboard::the().data();
-    if (text.is_empty())
+    auto [data, type] = GUI::Clipboard::the().data_and_type();
+    if (type != "text")
         return;
-    int nwritten = write(m_ptm_fd, text.characters(), text.length());
+    if (data.is_empty())
+        return;
+    int nwritten = write(m_ptm_fd, data.characters(), data.length());
     if (nwritten < 0) {
         perror("write");
         ASSERT_NOT_REACHED();

--- a/Servers/WindowServer/ClientConnection.h
+++ b/Servers/WindowServer/ClientConnection.h
@@ -104,6 +104,8 @@ private:
     virtual OwnPtr<Messages::WindowServer::SetWindowBackingStoreResponse> handle(const Messages::WindowServer::SetWindowBackingStore&) override;
     virtual OwnPtr<Messages::WindowServer::GetClipboardContentsResponse> handle(const Messages::WindowServer::GetClipboardContents&) override;
     virtual OwnPtr<Messages::WindowServer::SetClipboardContentsResponse> handle(const Messages::WindowServer::SetClipboardContents&) override;
+    virtual OwnPtr<Messages::WindowServer::GetClipboardBitmapResponse> handle(const Messages::WindowServer::GetClipboardBitmap&) override;
+    virtual OwnPtr<Messages::WindowServer::SetClipboardBitmapResponse> handle(const Messages::WindowServer::SetClipboardBitmap&) override;
     virtual void handle(const Messages::WindowServer::WM_SetActiveWindow&) override;
     virtual void handle(const Messages::WindowServer::WM_SetWindowMinimized&) override;
     virtual void handle(const Messages::WindowServer::WM_StartWindowResize&) override;

--- a/Servers/WindowServer/Clipboard.cpp
+++ b/Servers/WindowServer/Clipboard.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <LibGfx/Bitmap.h>
 #include <WindowServer/Clipboard.h>
 
 namespace WindowServer {
@@ -70,6 +71,17 @@ void Clipboard::set_data(NonnullRefPtr<SharedBuffer>&& data, int contents_size, 
     m_shared_buffer = move(data);
     m_contents_size = contents_size;
     m_data_type = data_type;
+
+    if (on_content_change)
+        on_content_change();
+}
+
+void Clipboard::set_data(NonnullRefPtr<SharedBuffer>&& data, int contents_size, Gfx::Size bitmap_size, Gfx::BitmapFormat bitmap_format)
+{
+    m_shared_buffer = move(data);
+    m_contents_size = contents_size;
+    m_bitmap_format = bitmap_format;
+    m_bitmap_size = bitmap_size;
 
     if (on_content_change)
         on_content_change();

--- a/Servers/WindowServer/Clipboard.h
+++ b/Servers/WindowServer/Clipboard.h
@@ -29,6 +29,7 @@
 #include <AK/Function.h>
 #include <AK/SharedBuffer.h>
 #include <AK/String.h>
+#include <LibGfx/Bitmap.h>
 
 namespace WindowServer {
 
@@ -46,8 +47,12 @@ public:
     const u8* data() const;
     int size() const;
 
+    Gfx::BitmapFormat bitmap_format() const { return m_bitmap_format; }
+    Gfx::Size bitmap_size() const { return m_bitmap_size; }
+
     void clear();
     void set_data(NonnullRefPtr<SharedBuffer>&&, int contents_size, const String& data_type);
+    void set_data(NonnullRefPtr<SharedBuffer>&&, int contents_size, const Gfx::Size bitmap_size, const Gfx::BitmapFormat bitmap_format);
 
     Function<void()> on_content_change;
 
@@ -57,6 +62,9 @@ private:
     String m_data_type;
     RefPtr<SharedBuffer> m_shared_buffer;
     int m_contents_size { 0 };
+
+    Gfx::BitmapFormat m_bitmap_format;
+    Gfx::Size m_bitmap_size;
 };
 
 }

--- a/Servers/WindowServer/WindowServer.ipc
+++ b/Servers/WindowServer/WindowServer.ipc
@@ -62,6 +62,9 @@ endpoint WindowServer = 2
     GetClipboardContents() => (i32 shbuf_id, i32 content_size, String content_type)
     SetClipboardContents(i32 shbuf_id, i32 content_size, String content_type) => ()
 
+    GetClipboardBitmap() => (i32 shbuf_id, i32 content_size, Gfx::BitmapFormat bitmap_format, Gfx::Size bitmap_size)
+    SetClipboardBitmap(i32 shbuf_id, i32 content_size, Gfx::BitmapFormat bitmap_format, Gfx::Size bitmap_size) => ()
+
     WM_SetActiveWindow(i32 client_id, i32 window_id) =|
     WM_SetWindowMinimized(i32 client_id, i32 window_id, bool minimized) =|
     WM_StartWindowResize(i32 client_id, i32 window_id) =|


### PR DESCRIPTION
This also adds the appropriate actions to PaintBrush and fixes the actions on TerminalWidget + TextEditor so they check that whatever they're trying to paste is indeed text.

It is a pretty barebones implementation but just enough to get started.


Kind of matches #2001 btw. Maybe once this is in the tree we could create a menu item that said "New from clipboard" and just create a new bitmap and paste.

EDIT: Title s/contents/bitmaps/