### PR TITLE
LibJS: Implement (no-op) debugger statement

### DIFF
--- a/Libraries/LibGUI/JSSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/JSSyntaxHighlighter.cpp
@@ -102,6 +102,7 @@ static TextStyle style_for_token_type(Gfx::Palette palette, JS::TokenType type)
     case JS::TokenType::Class:
     case JS::TokenType::Const:
     case JS::TokenType::Delete:
+    case JS::TokenType::Debugger:
     case JS::TokenType::Function:
     case JS::TokenType::In:
     case JS::TokenType::Instanceof:

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1390,6 +1390,12 @@ Value SequenceExpression::execute(Interpreter& interpreter) const
     return last_value;
 }
 
+Value DebuggerStatement::execute(Interpreter&) const
+{
+    dbg() << "Sorry, no JavaScript debugger available (yet)!";
+    return js_undefined();
+}
+
 void ScopeNode::add_variables(NonnullRefPtrVector<VariableDeclaration> variables)
 {
     m_variables.append(move(variables));

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -923,4 +923,14 @@ private:
     virtual const char* class_name() const override { return "ContinueStatement"; }
 };
 
+class DebuggerStatement final : public Statement {
+public:
+    DebuggerStatement() {}
+
+    virtual Value execute(Interpreter&) const override;
+
+private:
+    virtual const char* class_name() const override { return "DebuggerStatement"; }
+};
+
 }

--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -49,6 +49,7 @@ Lexer::Lexer(StringView source)
         s_keywords.set("class", TokenType::Class);
         s_keywords.set("const", TokenType::Const);
         s_keywords.set("continue", TokenType::Continue);
+        s_keywords.set("debugger", TokenType::Debugger);
         s_keywords.set("default", TokenType::Default);
         s_keywords.set("delete", TokenType::Delete);
         s_keywords.set("do", TokenType::Do);

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -253,6 +253,8 @@ NonnullRefPtr<Statement> Parser::parse_statement()
         return parse_do_while_statement();
     case TokenType::While:
         return parse_while_statement();
+    case TokenType::Debugger:
+         return parse_debugger_statement();
     default:
         if (match_expression()) {
             auto expr = parse_expression(0);
@@ -1040,6 +1042,13 @@ NonnullRefPtr<ForStatement> Parser::parse_for_statement()
     return create_ast_node<ForStatement>(move(init), move(test), move(update), move(body));
 }
 
+NonnullRefPtr<DebuggerStatement> Parser::parse_debugger_statement()
+{
+    consume(TokenType::Debugger);
+    consume_or_insert_semicolon();
+    return create_ast_node<DebuggerStatement>();
+}
+
 bool Parser::match(TokenType type) const
 {
     return m_parser_state.m_current_token.type() == type;
@@ -1152,7 +1161,8 @@ bool Parser::match_statement() const
         || type == TokenType::Switch
         || type == TokenType::Break
         || type == TokenType::Continue
-        || type == TokenType::Var;
+        || type == TokenType::Var
+        || type == TokenType::Debugger;
 }
 
 bool Parser::match_identifier_name() const

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -61,6 +61,7 @@ public:
     NonnullRefPtr<ContinueStatement> parse_continue_statement();
     NonnullRefPtr<DoWhileStatement> parse_do_while_statement();
     NonnullRefPtr<WhileStatement> parse_while_statement();
+    NonnullRefPtr<DebuggerStatement> parse_debugger_statement();
     NonnullRefPtr<ConditionalExpression> parse_conditional_expression(NonnullRefPtr<Expression> test);
 
     NonnullRefPtr<Expression> parse_expression(int min_precedence, Associativity associate = Associativity::Right);

--- a/Libraries/LibJS/Tests/debugger-statement.js
+++ b/Libraries/LibJS/Tests/debugger-statement.js
@@ -1,0 +1,9 @@
+load("test-common.js");
+
+try {
+    debugger;
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -53,6 +53,7 @@ namespace JS {
     __ENUMERATE_JS_TOKEN(Continue)                    \
     __ENUMERATE_JS_TOKEN(CurlyClose)                  \
     __ENUMERATE_JS_TOKEN(CurlyOpen)                   \
+    __ENUMERATE_JS_TOKEN(Debugger)                    \
     __ENUMERATE_JS_TOKEN(Default)                     \
     __ENUMERATE_JS_TOKEN(Delete)                      \
     __ENUMERATE_JS_TOKEN(Do)                          \

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -532,6 +532,7 @@ int main(int argc, char** argv)
                     break;
                 case JS::TokenType::Class:
                 case JS::TokenType::Const:
+                case JS::TokenType::Debugger:
                 case JS::TokenType::Delete:
                 case JS::TokenType::Function:
                 case JS::TokenType::In:


### PR DESCRIPTION
https://tc39.es/ecma262/#sec-debugger-statement

> Evaluating a DebuggerStatement may allow an implementation to cause a breakpoint when run under a debugger. If a debugger is not present or active this statement has no observable effect.

Anyone wanna add a JS debugger to HackStudio?