### PR TITLE
LibJS: Add object literal method shorthand

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -482,7 +482,9 @@ NonnullRefPtr<ObjectExpression> Parser::parse_object_expression()
             continue;
         }
 
-        if (need_colon || match(TokenType::Colon)) {
+        if (!is_spread && match(TokenType::ParenOpen)) {
+            property_value = parse_function_node<FunctionExpression>(false);
+        } else if (need_colon || match(TokenType::Colon)) {
             consume(TokenType::Colon);
             property_value = parse_expression(0);
         }
@@ -756,11 +758,13 @@ NonnullRefPtr<BlockStatement> Parser::parse_block_statement()
 }
 
 template<typename FunctionNodeType>
-NonnullRefPtr<FunctionNodeType> Parser::parse_function_node()
+NonnullRefPtr<FunctionNodeType> Parser::parse_function_node(bool needs_function_keyword)
 {
     ScopePusher scope(*this, ScopePusher::Var);
 
-    consume(TokenType::Function);
+    if (needs_function_keyword)
+        consume(TokenType::Function);
+
     String name;
     if (FunctionNodeType::must_have_name()) {
         name = consume(TokenType::Identifier).value();

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -44,7 +44,7 @@ public:
     NonnullRefPtr<Program> parse_program();
 
     template<typename FunctionNodeType>
-    NonnullRefPtr<FunctionNodeType> parse_function_node();
+    NonnullRefPtr<FunctionNodeType> parse_function_node(bool need_function_keyword = true);
 
     NonnullRefPtr<Statement> parse_statement();
     NonnullRefPtr<BlockStatement> parse_block_statement();

--- a/Libraries/LibJS/Tests/object-method-shorthand.js
+++ b/Libraries/LibJS/Tests/object-method-shorthand.js
@@ -1,0 +1,29 @@
+load("test-common.js");
+
+try {
+    const o = {
+        foo: "bar",
+        getFoo() {
+            return this.foo;
+        },
+        12() {
+            return this.getFoo();
+        },
+        "hello friends"() {
+            return this.getFoo();
+        },
+        [4 + 10]() {
+            return this.getFoo();
+        },
+    };
+
+    assert(o.foo === "bar");
+    assert(o.getFoo() === "bar");
+    assert(o[12]() === "bar");
+    assert(o["hello friends"]() === "bar");
+    assert(o[14]() === "bar");
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
Adds support for syntax such as:

```js
const o = {
    foo: 'bar',
    getFoo() { return this.foo; },
};
```