### PR TITLE
LibGfx: Decode paletted and grayscale images with 1/2/4 bit depth

### DIFF
--- a/Base/home/anon/www/pngsuite_siz_png.html
+++ b/Base/home/anon/www/pngsuite_siz_png.html
@@ -1,0 +1,30 @@
+<HTML>
+<HEAD>
+<TITLE>PngSuite - Odd sizes / PNG-files</TITLE>
+</HEAD>
+<BODY BGCOLOR="#ede">
+
+<!-- Modified version of http://schaik.com/pngsuite/pngsuite_siz_png.html -->
+
+<BR><IMG SRC="http://schaik.com/pngsuite/s01n3p01.png" WIDTH="1" HEIGHT="1"> --- s01n3p01 - 1x1 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s02n3p01.png" WIDTH="2" HEIGHT="2"> --- s02n3p01 - 2x2 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s03n3p01.png" WIDTH="3" HEIGHT="3"> --- s03n3p01 - 3x3 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s04n3p01.png" WIDTH="4" HEIGHT="4"> --- s04n3p01 - 4x4 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s05n3p02.png" WIDTH="5" HEIGHT="5"> --- s05n3p02 - 5x5 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s06n3p02.png" WIDTH="6" HEIGHT="6"> --- s06n3p02 - 6x6 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s07n3p02.png" WIDTH="7" HEIGHT="7"> --- s07n3p02 - 7x7 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s08n3p02.png" WIDTH="8" HEIGHT="8"> --- s08n3p02 - 8x8 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s09n3p02.png" WIDTH="9" HEIGHT="9"> --- s09n3p02 - 9x9 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s32n3p04.png" WIDTH="32" HEIGHT="32"> --- s32n3p04 - 32x32 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s33n3p04.png" WIDTH="33" HEIGHT="33"> --- s33n3p04 - 33x33 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s34n3p04.png" WIDTH="34" HEIGHT="34"> --- s34n3p04 - 34x34 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s35n3p04.png" WIDTH="35" HEIGHT="35"> --- s35n3p04 - 35x35 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s36n3p04.png" WIDTH="36" HEIGHT="36"> --- s36n3p04 - 36x36 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s37n3p04.png" WIDTH="37" HEIGHT="37"> --- s37n3p04 - 37x37 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s38n3p04.png" WIDTH="38" HEIGHT="38"> --- s38n3p04 - 38x38 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s39n3p04.png" WIDTH="39" HEIGHT="39"> --- s39n3p04 - 39x39 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s40n3p04.png" WIDTH="40" HEIGHT="40"> --- s40n3p04 - 40x40 paletted file, no interlacing
+
+</BODY>
+</HTML>
+

--- a/Base/home/anon/www/welcome.html
+++ b/Base/home/anon/www/welcome.html
@@ -28,6 +28,7 @@ span#ua {
     <p>Your user agent is: <b><span id="ua"></span></b></p>
     <p>Some small test pages:</p>
     <ul>
+        <li><a href="pngsuite_siz_png.html">pngsuite odd sizes test</a></li>
         <li><a href="pngsuite_bas_png.html">pngsuite basic formats test</a></li>
         <li><a href="canvas-path.html">canvas path house!</a></li>
         <li><a href="img-canvas.html">canvas drawImage() test</a></li>


### PR DESCRIPTION
When dealing with png data that has less than 8 bits per pixel, round
up to the next byte when allocating per row buffers and streamers. This
fixes decoding odd sized PNGs with less than 8 bits per pixel.

Also added a test page with some odd sized palleted PNGs.