### PR TITLE
Terminal: Write an empty string instead of (null) on Command key

### DIFF
--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -221,7 +221,7 @@ int main(int argc, char** argv)
     if (command_to_execute)
         run_command(ptm_fd, command_to_execute);
     else
-        run_command(ptm_fd, config->read_entry("Startup", "Command"));
+        run_command(ptm_fd, config->read_entry("Startup", "Command", ""));
 
     auto window = GUI::Window::construct();
     window->set_title("Terminal");


### PR DESCRIPTION
This prevents a Terminal to create a configuration file with
     Command=(null)
    
That would make it try to execute the command "(null)" on the next run.