### PR TITLE
js: Ignore property attributes for completion

### DIFF
--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -617,12 +617,10 @@ int main(int argc, char** argv)
 
             Function<void(const JS::Shape&, const StringView&)> list_all_properties = [&results, &list_all_properties](const JS::Shape& shape, auto& property_pattern) {
                 for (const auto& descriptor : shape.property_table()) {
-                    if (descriptor.value.attributes & JS::Attribute::Enumerable) {
-                        if (descriptor.key.view().starts_with(property_pattern)) {
-                            Line::CompletionSuggestion completion { descriptor.key };
-                            if (!results.contains_slow(completion)) { // hide duplicates
-                                results.append(completion);
-                            }
+                    if (descriptor.key.view().starts_with(property_pattern)) {
+                        Line::CompletionSuggestion completion { descriptor.key };
+                        if (!results.contains_slow(completion)) { // hide duplicates
+                            results.append(completion);
                         }
                     }
                 }


### PR DESCRIPTION
Only being able to complete enumerable properties is annoying, especially since we updated everything to use the correct attributes.

Most standard built-in objects are *not* enumerable.

- `A<tab>` - expecting `Array`, nothing happens.
- `B<tab>` - expecting `Boolean`, nothing happens.
- `c<tab>` - expecting `console`, nothing happens.
- ...
- `O<tab>` - expecting `Object`, nothing happens.