### PR TITLE
LibHTTP: Trim received data to Content-Length

### DIFF
--- a/Libraries/LibHTTP/HttpJob.cpp
+++ b/Libraries/LibHTTP/HttpJob.cpp
@@ -158,8 +158,11 @@ void HttpJob::on_socket_connected()
         auto content_length_header = m_headers.get("Content-Length");
         if (content_length_header.has_value()) {
             bool ok;
-            if (m_received_size >= content_length_header.value().to_uint(ok) && ok)
-                return finish_up();
+            auto content_length = content_length_header.value().to_uint(ok);
+            if (ok && m_received_size >= content_length) {
+                m_received_size = content_length;
+                finish_up();
+            }
         }
     };
 }

--- a/Libraries/LibHTTP/HttpsJob.cpp
+++ b/Libraries/LibHTTP/HttpsJob.cpp
@@ -168,8 +168,11 @@ void HttpsJob::on_socket_connected()
         auto content_length_header = m_headers.get("Content-Length");
         if (content_length_header.has_value()) {
             bool ok;
-            if (m_received_size >= content_length_header.value().to_uint(ok) && ok)
+            auto content_length = content_length_header.value().to_uint(ok);
+            if (ok && m_received_size >= content_length) {
+                m_received_size = content_length;
                 finish_up();
+            }
         } else {
             // no content-length, assume closed connection
             finish_up();


### PR DESCRIPTION
Apparently servers will feel free to pad their response if they send one that contains a content-length field.
We should not assume that the entirety of the response is valid data.

(test case: load https://templeos.org; thanks @supercomputer7)