### PR TITLE
Kernel: fix pledge syscall applying new pledges when it fails

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -4826,23 +4826,25 @@ int Process::sys$pledge(const Syscall::SC_pledge_params* user_params)
         return true;
     };
 
+    u32 new_promises = m_promises;
+    u32 new_execpromises = m_execpromises;
+
     if (!promises.is_null()) {
-        u32 new_promises = 0;
         if (!parse_pledge(promises, new_promises))
             return -EINVAL;
         if (m_promises && (!new_promises || new_promises & ~m_promises))
             return -EPERM;
-        m_promises = new_promises;
     }
 
     if (!execpromises.is_null()) {
-        u32 new_execpromises = 0;
         if (!parse_pledge(execpromises, new_execpromises))
             return -EINVAL;
         if (m_execpromises && (!new_execpromises || new_execpromises & ~m_execpromises))
             return -EPERM;
-        m_execpromises = new_execpromises;
     }
+
+    m_promises = new_promises;
+    m_execpromises = new_execpromises;
 
     return 0;
 }

--- a/Tests/Kernel/pledge-test-failures.cpp
+++ b/Tests/Kernel/pledge-test-failures.cpp
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <unistd.h>
+
+int main(int argc, char** argv)
+{
+    int res = pledge("stdio unix rpath", "stdio");
+    if (res < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    res = pledge("stdio unix", "stdio unix");
+    if (res >= 0) {
+        fprintf(stderr, "second pledge should have failed\n");
+        return 1;
+    }
+
+    res = pledge("stdio rpath", "stdio");
+    if (res < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
If the exec promises fail to apply, then the normal promises should
not apply either. Add a test for this fixed functionality.