### PR TITLE
LibTLS: "Properly" handle the server dropping the connection

### DIFF
--- a/Libraries/LibHTTP/HttpsJob.h
+++ b/Libraries/LibHTTP/HttpsJob.h
@@ -50,6 +50,7 @@ private:
     RefPtr<TLS::TLSv12> construct_socket() { return TLS::TLSv12::construct(this); }
     void on_socket_connected();
     void finish_up();
+    void read_body(TLS::TLSv12&);
 
     enum class State {
         InStatus,
@@ -66,6 +67,7 @@ private:
     Vector<ByteBuffer> m_received_buffers;
     size_t m_received_size { 0 };
     bool m_sent_data { false };
+    bool m_queued_finish { false };
 };
 
 }

--- a/Libraries/LibTLS/Socket.cpp
+++ b/Libraries/LibTLS/Socket.cpp
@@ -113,7 +113,7 @@ bool TLSv12::common_connect(const struct sockaddr* saddr, socklen_t length)
 
     Core::Socket::on_connected = [this] {
         Core::Socket::on_ready_to_read = [this] {
-            if (!Core::Socket::is_open()) {
+            if (!Core::Socket::is_open() || !Core::Socket::is_connected() || Core::Socket::eof()) {
                 // an abrupt closure (the server is a jerk)
                 dbg() << "Socket not open, assuming abrupt closure";
                 m_context.connection_finished = true;
@@ -143,7 +143,7 @@ bool TLSv12::common_connect(const struct sockaddr* saddr, socklen_t length)
                     on_tls_ready_to_read(*this);
         };
         Core::Socket::on_ready_to_write = [this] {
-            if (!Core::Socket::is_open()) {
+            if (!Core::Socket::is_open() || !Core::Socket::is_connected() || Core::Socket::eof()) {
                 // an abrupt closure (the server is a jerk)
                 dbg() << "Socket not open, assuming abrupt closure";
                 m_context.connection_finished = true;


### PR DESCRIPTION
Contrary to popular belief, not every implementation of TLS follows the specs.
Some of them just drop the connection without sending a proper close_notify, and we should handle that gracefully.

\*glares at google.com\*
