### PR TITLE
Don't crash the kernel on invalid fcntl

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -1865,7 +1865,7 @@ int Process::sys$fcntl(int fd, int cmd, u32 arg)
         description->set_file_flags(arg);
         break;
     default:
-        ASSERT_NOT_REACHED();
+        return -EINVAL;
     }
     return 0;
 }

--- a/Tests/Kernel/crash-fcntl-invalid-cmd.cpp
+++ b/Tests/Kernel/crash-fcntl-invalid-cmd.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int, char**)
+{
+    int rc = fcntl(0, -42);
+    if (rc != -1) {
+        printf("FAIL: rc was %d, instead of -1\n", rc);
+        return 1;
+    } else if (errno != EINVAL) {
+        printf("FAIL: errno was %d, instead of EINVAL=%d\n", errno, EINVAL);
+        return 1;
+    } else {
+        printf("PASS\n");
+    }
+    return 0;
+}


### PR DESCRIPTION
I ran into this when running an outdated build of nyancat that apparently sent an invalid `cmd` to `fcntl`. Hanging the kernel was certainly not what I expected! :D