### PR TITLE
Meta: Add configuration for setting up project in CLion

### DIFF
--- a/Documentation/CLionConfiguration.md
+++ b/Documentation/CLionConfiguration.md
@@ -1,0 +1,19 @@
+## CLion Project Configuration
+
+Configuring CLion for development requires a CMakeLists.txt file. The one provided in Meta/CLion packs the bare minimum configuration so that you can take advantage of code completion and basic error checking. This is not necessarily the best setup, there could be better ways to configure the IDE. Below instructions are intended for people not familiar with CMake, or who don't want to get bothered setting up the IDE first.
+
+It's assumed that a directory named `serenity` contains all your source files. If you cloned the repository directly from GitHub, this is the directory that git creates to copy sources.
+
+- Create the project directory and cd to it: `mkdir serenity-project && cd serenity-project`
+- Move `serenity` to the project directory: `mv <path/to/serenity> .`
+- Copy CMake file to project directory: `cp serenity/Meta/CLion/CMakeLists.txt .`
+- Create new CMake project in IDE: `File->New CMake Project from Sources`
+- In the file selection dialog, find and select `serenity-project`, then click OK.
+
+The project will start loading. Building the index for the first time takes a while. Let it finish the first scan. Once it's done, you can start hacking :)
+
+**Note:** Don't create a new git repo in `serenity-project`. The whole point of wrapping the sources to a new directory is to keep the project files created by CLion away from the main repository (the `.git` in `serenity`).  
+
+**Note:** If you don't want the workspace to list files ending with certain extensions, go to `File->Settings->Editor->File Types` and add entries in the `Ignore files and folders` field.
+
+**Note:** If you have created the project after building serenity, you may get link errors on `makeall.sh` after moving `serenity` to the project directory. If you move `serenity` out to its original location, the build will succeed. It is recommended that you create a simple script that merely moves `serenity` before attempting to rebuild and once the build finishes, moves `serenity` back to the project directory. It's inconvenient, but kind of necessary.

--- a/Meta/CLion/CMakeLists.txt
+++ b/Meta/CLion/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.0)
+project(serenity)
+set(CMAKE_CXX_STANDARD 17)
+
+file(GLOB_RECURSE AK_SOURCES "serenity/AK/*.cpp")
+file(GLOB_RECURSE APPLICATIONS_SOURCES "serenity/Applications/*.cpp")
+file(GLOB_RECURSE BASE_SOURCES "serenity/Base/*.cpp")
+file(GLOB_RECURSE DEMOS_SOURCES "serenity/Demos/*.cpp")
+file(GLOB_RECURSE DEVTOOLS_SOURCES "serenity/DevTools/*.cpp")
+file(GLOB_RECURSE GAMES_SOURCES "serenity/Games/*.cpp")
+file(GLOB_RECURSE KERNEL_SOURCES "serenity/Kernel/*.cpp")
+file(GLOB_RECURSE LIBRARIES_SOURCES "serenity/Libraries/*.cpp")
+file(GLOB_RECURSE MENU_APPLETS_SOURCES "serenity/MenuApplets/*.cpp")
+file(GLOB_RECURSE PORTS_SOURCES "serenity/Ports/*.cpp")
+file(GLOB_RECURSE SERVERS_SOURCES "serenity/Servers/*.cpp")
+file(GLOB_RECURSE SHELL_SOURCES "serenity/Shell/*.cpp")
+file(GLOB_RECURSE TESTS_SOURCES "serenity/Tests/*.cpp")
+file(GLOB_RECURSE TOOLCHAIN_SOURCES "serenity/Toolchain/*.cpp")
+file(GLOB_RECURSE USERLAND_SOURCES "serenity/Userland/*.cpp")
+
+set(INCLUDE_DIRS
+    "serenity"
+    "serenity/Kernel"
+    "serenity/Libraries"
+    "serenity/Libraries/LibC"
+    "serenity/Libraries/LibPthread"
+    "serenity/Servers"
+    "serenity/Toolchain/Local/i686-pc-serenity/include/c++/9.3.0")
+
+add_library(serenity
+    ${AK_SOURCES}
+    ${APPLICATIONS_SOURCES}
+    ${BASE_SOURCES}
+    ${DEMOS_SOURCES}
+    ${DEVTOOLS_SOURCES}
+    ${GAMES_SOURCES}
+    ${KERNEL_SOURCES}
+    ${LIBRARIES_SOURCES}
+    ${MENU_APPLETS_SOURCES}
+    ${PORTS_SOURCES}
+    ${SERVERS_SOURCES}
+    ${SHELL_SOURCES}
+    ${TESTS_SOURCES}
+    ${TOOLCHAIN_SOURCES}
+    ${USERLAND_SOURCES})
+
+target_compile_definitions(serenity PRIVATE __serenity__ USERLAND SANITIZE_PTRS DEBUG)
+target_include_directories(serenity PRIVATE ${INCLUDE_DIRS})


### PR DESCRIPTION
This commit adds a CMakeLists.txt file that will be used by CLion to
configure the project and documentation explaining the steps to follow.
Configuring CLion this way enables important features like code
completion and file search. The configuration isn't perfect. There are
source files for which CLion cannot pick up the headers and asks to
manually include them from certain directories. But for the most part,
it works all right.