### PR TITLE
Remove magic numbers and replace with defined macros

### DIFF
--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -180,7 +180,7 @@ void init_stage2()
         if (bxvga_found) {
             new BXVGADevice;
         } else {
-            if (multiboot_info_ptr->framebuffer_type == 1 || multiboot_info_ptr->framebuffer_type == 2) {
+            if (multiboot_info_ptr->framebuffer_type == MULTIBOOT_FRAMEBUFFER_TYPE_RGB || multiboot_info_ptr->framebuffer_type == MULTIBOOT_FRAMEBUFFER_TYPE_EGA_TEXT) {
                 new MBVGADevice(
                     PhysicalAddress((u32)(multiboot_info_ptr->framebuffer_addr)),
                     multiboot_info_ptr->framebuffer_pitch,


### PR DESCRIPTION
MUTLIBOOT_FRAMEBUFFER_TYPE_{RGB,EGA_TEXT} are defined in the Mutliboot.h
header. Use those definitions instead of hardcoding 1 and 2 here.