### PR TITLE
LibJS: Add template literals

### DIFF
--- a/Libraries/LibGUI/JSSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/JSSyntaxHighlighter.cpp
@@ -42,7 +42,9 @@ static TextStyle style_for_token_type(Gfx::Palette palette, JS::TokenType type)
     case JS::TokenType::NumericLiteral:
         return { palette.syntax_number() };
     case JS::TokenType::StringLiteral:
-    case JS::TokenType::TemplateLiteral:
+    case JS::TokenType::TemplateLiteralStart:
+    case JS::TokenType::TemplateLiteralEnd:
+    case JS::TokenType::TemplateLiteralString:
     case JS::TokenType::RegexLiteral:
     case JS::TokenType::UnterminatedStringLiteral:
         return { palette.syntax_string() };
@@ -55,6 +57,8 @@ static TextStyle style_for_token_type(Gfx::Palette palette, JS::TokenType type)
     case JS::TokenType::ParenClose:
     case JS::TokenType::ParenOpen:
     case JS::TokenType::Semicolon:
+    case JS::TokenType::TemplateLiteralExprStart:
+    case JS::TokenType::TemplateLiteralExprEnd:
         return { palette.syntax_punctuation() };
     case JS::TokenType::Ampersand:
     case JS::TokenType::AmpersandEquals:

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1229,6 +1229,28 @@ Value ArrayExpression::execute(Interpreter& interpreter) const
     return array;
 }
 
+void TemplateLiteral::dump(int indent) const
+{
+    ASTNode::dump(indent);
+
+    for (auto& expression : expressions())
+        expression.dump(indent + 1);
+}
+
+Value TemplateLiteral::execute(Interpreter& interpreter) const
+{
+    StringBuilder string_builder;
+
+    for (auto& expression : expressions()) {
+        auto expr = expression.execute(interpreter);
+        if (interpreter.exception())
+            return {};
+        string_builder.append(expr.to_string());
+    }
+
+    return js_string(interpreter, string_builder.build());
+}
+
 void TryStatement::dump(int indent) const
 {
     ASTNode::dump(indent);
@@ -1398,15 +1420,15 @@ Value ConditionalExpression::execute(Interpreter& interpreter) const
 void ConditionalExpression::dump(int indent) const
 {
     ASTNode::dump(indent);
-    print_indent(indent);
+    print_indent(indent + 1);
     printf("(Test)\n");
-    m_test->dump(indent + 1);
-    print_indent(indent);
+    m_test->dump(indent + 2);
+    print_indent(indent + 1);
     printf("(Consequent)\n");
-    m_consequent->dump(indent + 1);
-    print_indent(indent);
+    m_consequent->dump(indent + 2);
+    print_indent(indent + 1);
     printf("(Alternate)\n");
-    m_alternate->dump(indent + 1);
+    m_alternate->dump(indent + 2);
 }
 
 void SequenceExpression::dump(int indent) const

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -762,6 +762,24 @@ private:
     Vector<RefPtr<Expression>> m_elements;
 };
 
+class TemplateLiteral final : public Expression {
+public:
+    TemplateLiteral(NonnullRefPtrVector<Expression> expressions)
+        : m_expressions(expressions)
+    {
+    }
+
+    virtual Value execute(Interpreter&) const override;
+    virtual void dump(int indent) const override;
+
+    const NonnullRefPtrVector<Expression>& expressions() const { return m_expressions; }
+
+private:
+    virtual const char* class_name() const override { return "TemplateLiteral"; }
+
+    const NonnullRefPtrVector<Expression> m_expressions;
+};
+
 class MemberExpression final : public Expression {
 public:
     MemberExpression(NonnullRefPtr<Expression> object, NonnullRefPtr<Expression> property, bool computed = false)

--- a/Libraries/LibJS/Lexer.h
+++ b/Libraries/LibJS/Lexer.h
@@ -71,6 +71,12 @@ private:
     size_t m_line_column = 1;
     bool m_log_errors = true;
 
+    struct TemplateState {
+        bool in_expr;
+        u8 open_bracket_count;
+    };
+    Vector<TemplateState> m_template_states;
+
     static HashMap<String, TokenType> s_keywords;
     static HashMap<String, TokenType> s_three_char_tokens;
     static HashMap<String, TokenType> s_two_char_tokens;

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -69,6 +69,7 @@ public:
     NonnullRefPtr<Expression> parse_unary_prefixed_expression();
     NonnullRefPtr<ObjectExpression> parse_object_expression();
     NonnullRefPtr<ArrayExpression> parse_array_expression();
+    NonnullRefPtr<TemplateLiteral> parse_template_literal();
     NonnullRefPtr<Expression> parse_secondary_expression(NonnullRefPtr<Expression>, int min_precedence, Associativity associate = Associativity::Right);
     NonnullRefPtr<CallExpression> parse_call_expression(NonnullRefPtr<Expression>);
     NonnullRefPtr<NewExpression> parse_new_expression();

--- a/Libraries/LibJS/Tests/template-literals.js
+++ b/Libraries/LibJS/Tests/template-literals.js
@@ -1,0 +1,45 @@
+load("test-common.js");
+
+try {
+    assert(`foo` === "foo");
+    assert(`foo{` === "foo{");
+    assert(`foo}` === "foo}");
+    assert(`foo$` === "foo$");
+    assert(`foo\`` === "foo`")
+    assert(`foo\$` === "foo$");
+    
+    assert(`foo ${undefined}` === "foo undefined");
+    assert(`foo ${null}` === "foo null");
+    assert(`foo ${5}` === "foo 5");
+    assert(`foo ${true}` === "foo true");
+    assert(`foo ${"bar"}` === "foo bar");
+    assert(`foo \${"bar"}` === 'foo ${"bar"}');
+
+    assert(`foo ${{}}` === "foo [object Object]");
+    assert(`foo ${{ bar: { baz: "qux" }}}` === "foo [object Object]");
+    assert(`foo ${"bar"} ${"baz"}` === "foo bar baz");
+    assert(`${"foo"} bar baz` === "foo bar baz");
+    assert(`${"foo bar baz"}` === "foo bar baz");
+
+    let a = 27;
+    assert(`${a}` === "27");
+    assert(`foo ${a}` === "foo 27");
+    assert(`foo ${a ? "bar" : "baz"}` === "foo bar");
+    assert(`foo ${(() => a)()}` === "foo 27");
+
+    assert(`foo ${`bar`}` === "foo bar");
+    assert(`${`${`${`${"foo"}`} bar`}`}` === "foo bar");
+    assert(`foo
+    bar` === "foo\n    bar");
+    
+    assertThrowsError(() => {
+        `${b}`;
+    }, {
+        error: ReferenceError,
+        message: "'b' not known"
+    })
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -112,7 +112,11 @@ namespace JS {
     __ENUMERATE_JS_TOKEN(SlashEquals)                 \
     __ENUMERATE_JS_TOKEN(StringLiteral)               \
     __ENUMERATE_JS_TOKEN(Switch)                      \
-    __ENUMERATE_JS_TOKEN(TemplateLiteral)             \
+    __ENUMERATE_JS_TOKEN(TemplateLiteralEnd)          \
+    __ENUMERATE_JS_TOKEN(TemplateLiteralExprEnd)      \
+    __ENUMERATE_JS_TOKEN(TemplateLiteralExprStart)    \
+    __ENUMERATE_JS_TOKEN(TemplateLiteralStart)        \
+    __ENUMERATE_JS_TOKEN(TemplateLiteralString)       \
     __ENUMERATE_JS_TOKEN(This)                        \
     __ENUMERATE_JS_TOKEN(Throw)                       \
     __ENUMERATE_JS_TOKEN(Tilde)                       \
@@ -122,6 +126,7 @@ namespace JS {
     __ENUMERATE_JS_TOKEN(UnsignedShiftRight)          \
     __ENUMERATE_JS_TOKEN(UnsignedShiftRightEquals)    \
     __ENUMERATE_JS_TOKEN(UnterminatedStringLiteral)   \
+    __ENUMERATE_JS_TOKEN(UnterminatedTemplateLiteral) \
     __ENUMERATE_JS_TOKEN(Var)                         \
     __ENUMERATE_JS_TOKEN(Void)                        \
     __ENUMERATE_JS_TOKEN(While)                       \

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -500,7 +500,9 @@ int main(int argc, char** argv)
                     stylize({ start, end }, { Line::Style::Foreground(Line::Style::Color::Magenta) });
                     break;
                 case JS::TokenType::StringLiteral:
-                case JS::TokenType::TemplateLiteral:
+                case JS::TokenType::TemplateLiteralStart:
+                case JS::TokenType::TemplateLiteralEnd:
+                case JS::TokenType::TemplateLiteralString:
                 case JS::TokenType::RegexLiteral:
                 case JS::TokenType::UnterminatedStringLiteral:
                     stylize({ start, end }, { Line::Style::Foreground(Line::Style::Color::Green), Line::Style::Bold });
@@ -571,6 +573,8 @@ int main(int argc, char** argv)
                 case JS::TokenType::Interface:
                 case JS::TokenType::Let:
                 case JS::TokenType::New:
+                case JS::TokenType::TemplateLiteralExprStart:
+                case JS::TokenType::TemplateLiteralExprEnd:
                 case JS::TokenType::Throw:
                 case JS::TokenType::Typeof:
                 case JS::TokenType::Var:


### PR DESCRIPTION
Adds fully functioning template literals. Because template literals contain expressions, most of the work has to be done in the Lexer rather than the Parser. And because of the complexity of template literals (expressions, nesting, escapes, etc), the Lexer needs to have some template-related state.

When entering a new template literal, a `TemplateLiteralStart` token is emitted. When inside a literal, all text will be parsed up until a `${` or `` ` `` (or `EOF`, but that's a syntax error) is seen, and then a `TemplateLiteralExprStart` token is emitted. At this point, the Lexer proceeds as normal, however it keeps track of the number of opening and closing curly braces it has seen in order to determine the close of the expression. Once it finds a matching curly brace for the `${`, a `TemplateLiteralExprEnd` token is emitted and the state is updated accordingly.

When the Lexer is inside of a template literal, but not an expression, and sees a `` ` ``, this must be the closing grave: a `TemplateLiteralEnd` token is emitted.

The state required to correctly parse template strings consists of a vector (for nesting) of two pieces of information: whether or not we are in a template expression (as opposed to a template string); and the count of the number of unmatched open curly braces we have seen (only applicable if the Lexer is currently in a template expression).

TODO: Add support for template literal newlines in the JS REPL (this will cause a syntax error currently):

```
> `foo
> bar`
'foo
bar'
```