### PR TITLE
sysctl: Slightly more user-friendly behavior

### DIFF
--- a/Userland/sysctl.cpp
+++ b/Userland/sysctl.cpp
@@ -114,10 +114,16 @@ int main(int argc, char** argv)
 
     Core::ArgsParser args_parser;
     args_parser.add_option(show_all, "Show all variables", nullptr, 'a');
-    args_parser.add_positional_argument(var, "Command (var[=value])", "command");
+    args_parser.add_positional_argument(var, "Command (var[=value])", "command", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
 
+    if (var == nullptr) {
+        // Not supplied; assume `-a`.
+        show_all = true;
+    }
+
     if (show_all) {
+        // Ignore `var`, even if it was supplied. Just like the real procps does.
         return handle_show_all();
     }
 

--- a/Userland/sysctl.cpp
+++ b/Userland/sysctl.cpp
@@ -45,12 +45,12 @@ static String read_var(const String& name)
     auto path = builder.to_string();
     auto f = Core::File::construct(path);
     if (!f->open(Core::IODevice::ReadOnly)) {
-        fprintf(stderr, "open: %s", f->error_string());
+        fprintf(stderr, "open: %s\n", f->error_string());
         exit(1);
     }
     const auto& b = f->read_all();
     if (f->error() < 0) {
-        fprintf(stderr, "read: %s", f->error_string());
+        fprintf(stderr, "read: %s\n", f->error_string());
         exit(1);
     }
     return String((const char*)b.data(), b.size(), Chomp);
@@ -64,12 +64,12 @@ static void write_var(const String& name, const String& value)
     auto path = builder.to_string();
     auto f = Core::File::construct(path);
     if (!f->open(Core::IODevice::WriteOnly)) {
-        fprintf(stderr, "open: %s", f->error_string());
+        fprintf(stderr, "open: %s\n", f->error_string());
         exit(1);
     }
     f->write(value);
     if (f->error() < 0) {
-        fprintf(stderr, "write: %s", f->error_string());
+        fprintf(stderr, "write: %s\n", f->error_string());
         exit(1);
     }
 }


### PR DESCRIPTION
Previously, `sysctl -a` absolutely required an argument which it would then ignore, and the error messages had missing newlines.

No other program in `Userland/` has missing newlines, at least I have this impression after a cursory `grep -Pn 'printf(.(?!\\n))+$' *.cpp`.