### PR TITLE
AK: rename variables with camelCase names in PrintfImplementation.h

### DIFF
--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -42,7 +42,7 @@ extern "C" size_t strlen(const char*);
 #endif
 
 template<typename PutChFunc, typename T>
-ALWAYS_INLINE int print_hex(PutChFunc putch, char*& bufptr, T number, bool upper_case, bool alternate_form, bool left_pad, bool zeroPad, u8 width)
+ALWAYS_INLINE int print_hex(PutChFunc putch, char*& bufptr, T number, bool upper_case, bool alternate_form, bool left_pad, bool zero_pad, u8 field_width)
 {
     int ret = 0;
 
@@ -53,7 +53,7 @@ ALWAYS_INLINE int print_hex(PutChFunc putch, char*& bufptr, T number, bool upper
         digits = 1;
 
     if (left_pad) {
-        int stop_at = width - digits;
+        int stop_at = field_width - digits;
         if (alternate_form)
             stop_at -= 2;
 
@@ -67,11 +67,11 @@ ALWAYS_INLINE int print_hex(PutChFunc putch, char*& bufptr, T number, bool upper
         putch(bufptr, '0');
         putch(bufptr, 'x');
         ret += 2;
-        width += 2;
+        field_width += 2;
     }
 
-    if (zeroPad) {
-        while (ret < width - digits) {
+    if (zero_pad) {
+        while (ret < field_width - digits) {
             putch(bufptr, '0');
             ++ret;
         }
@@ -96,7 +96,7 @@ ALWAYS_INLINE int print_hex(PutChFunc putch, char*& bufptr, T number, bool upper
 }
 
 template<typename PutChFunc>
-ALWAYS_INLINE int print_number(PutChFunc putch, char*& bufptr, u32 number, bool leftPad, bool zeroPad, u32 fieldWidth)
+ALWAYS_INLINE int print_number(PutChFunc putch, char*& bufptr, u32 number, bool left_pad, bool zero_pad, u32 field_width)
 {
     u32 divisor = 1000000000;
     char ch;
@@ -117,27 +117,27 @@ ALWAYS_INLINE int print_number(PutChFunc putch, char*& bufptr, u32 number, bool 
     }
 
     size_t numlen = p - buf;
-    if (!fieldWidth || fieldWidth < numlen)
-        fieldWidth = numlen;
-    if (!leftPad) {
-        for (unsigned i = 0; i < fieldWidth - numlen; ++i) {
-            putch(bufptr, zeroPad ? '0' : ' ');
+    if (!field_width || field_width < numlen)
+        field_width = numlen;
+    if (!left_pad) {
+        for (unsigned i = 0; i < field_width - numlen; ++i) {
+            putch(bufptr, zero_pad ? '0' : ' ');
         }
     }
     for (unsigned i = 0; i < numlen; ++i) {
         putch(bufptr, buf[i]);
     }
-    if (leftPad) {
-        for (unsigned i = 0; i < fieldWidth - numlen; ++i) {
+    if (left_pad) {
+        for (unsigned i = 0; i < field_width - numlen; ++i) {
             putch(bufptr, ' ');
         }
     }
 
-    return fieldWidth;
+    return field_width;
 }
 
 template<typename PutChFunc>
-ALWAYS_INLINE int print_u64(PutChFunc putch, char*& bufptr, u64 number, bool leftPad, bool zeroPad, u32 fieldWidth)
+ALWAYS_INLINE int print_u64(PutChFunc putch, char*& bufptr, u64 number, bool left_pad, bool zero_pad, u32 field_width)
 {
     u64 divisor = 10000000000000000000LLU;
     char ch;
@@ -158,27 +158,27 @@ ALWAYS_INLINE int print_u64(PutChFunc putch, char*& bufptr, u64 number, bool lef
     }
 
     size_t numlen = p - buf;
-    if (!fieldWidth || fieldWidth < numlen)
-        fieldWidth = numlen;
-    if (!leftPad) {
-        for (unsigned i = 0; i < fieldWidth - numlen; ++i) {
-            putch(bufptr, zeroPad ? '0' : ' ');
+    if (!field_width || field_width < numlen)
+        field_width = numlen;
+    if (!left_pad) {
+        for (unsigned i = 0; i < field_width - numlen; ++i) {
+            putch(bufptr, zero_pad ? '0' : ' ');
         }
     }
     for (unsigned i = 0; i < numlen; ++i) {
         putch(bufptr, buf[i]);
     }
-    if (leftPad) {
-        for (unsigned i = 0; i < fieldWidth - numlen; ++i) {
+    if (left_pad) {
+        for (unsigned i = 0; i < field_width - numlen; ++i) {
             putch(bufptr, ' ');
         }
     }
 
-    return fieldWidth;
+    return field_width;
 }
 
 template<typename PutChFunc>
-ALWAYS_INLINE int print_double(PutChFunc putch, char*& bufptr, double number, bool leftPad, bool zeroPad, u32 fieldWidth, u32 fraction_length = 6)
+ALWAYS_INLINE int print_double(PutChFunc putch, char*& bufptr, double number, bool left_pad, bool zero_pad, u32 field_width, u32 fraction_length = 6)
 {
     int length = 0;
 
@@ -188,7 +188,7 @@ ALWAYS_INLINE int print_double(PutChFunc putch, char*& bufptr, double number, bo
         number = 0 - number;
     }
 
-    length = print_u64(putch, bufptr, (i64)number, leftPad, zeroPad, fieldWidth);
+    length = print_u64(putch, bufptr, (i64)number, left_pad, zero_pad, field_width);
     putch(bufptr, '.');
     length++;
     double fraction = number - (i64)number;
@@ -200,17 +200,17 @@ ALWAYS_INLINE int print_double(PutChFunc putch, char*& bufptr, double number, bo
 }
 
 template<typename PutChFunc>
-ALWAYS_INLINE int print_i64(PutChFunc putch, char*& bufptr, i64 number, bool leftPad, bool zeroPad, u32 fieldWidth)
+ALWAYS_INLINE int print_i64(PutChFunc putch, char*& bufptr, i64 number, bool left_pad, bool zero_pad, u32 field_width)
 {
     if (number < 0) {
         putch(bufptr, '-');
-        return print_u64(putch, bufptr, 0 - number, leftPad, zeroPad, fieldWidth) + 1;
+        return print_u64(putch, bufptr, 0 - number, left_pad, zero_pad, field_width) + 1;
     }
-    return print_u64(putch, bufptr, number, leftPad, zeroPad, fieldWidth);
+    return print_u64(putch, bufptr, number, left_pad, zero_pad, field_width);
 }
 
 template<typename PutChFunc>
-ALWAYS_INLINE int print_octal_number(PutChFunc putch, char*& bufptr, u32 number, bool leftPad, bool zeroPad, u32 fieldWidth)
+ALWAYS_INLINE int print_octal_number(PutChFunc putch, char*& bufptr, u32 number, bool left_pad, bool zero_pad, u32 field_width)
 {
     u32 divisor = 134217728;
     char ch;
@@ -231,23 +231,23 @@ ALWAYS_INLINE int print_octal_number(PutChFunc putch, char*& bufptr, u32 number,
     }
 
     size_t numlen = p - buf;
-    if (!fieldWidth || fieldWidth < numlen)
-        fieldWidth = numlen;
-    if (!leftPad) {
-        for (unsigned i = 0; i < fieldWidth - numlen; ++i) {
-            putch(bufptr, zeroPad ? '0' : ' ');
+    if (!field_width || field_width < numlen)
+        field_width = numlen;
+    if (!left_pad) {
+        for (unsigned i = 0; i < field_width - numlen; ++i) {
+            putch(bufptr, zero_pad ? '0' : ' ');
         }
     }
     for (unsigned i = 0; i < numlen; ++i) {
         putch(bufptr, buf[i]);
     }
-    if (leftPad) {
-        for (unsigned i = 0; i < fieldWidth - numlen; ++i) {
+    if (left_pad) {
+        for (unsigned i = 0; i < field_width - numlen; ++i) {
             putch(bufptr, ' ');
         }
     }
 
-    return fieldWidth;
+    return field_width;
 }
 
 template<typename PutChFunc>
@@ -273,15 +273,15 @@ ALWAYS_INLINE int print_string(PutChFunc putch, char*& bufptr, const char* str, 
 }
 
 template<typename PutChFunc>
-ALWAYS_INLINE int print_signed_number(PutChFunc putch, char*& bufptr, int number, bool leftPad, bool zeroPad, u32 fieldWidth, bool always_sign)
+ALWAYS_INLINE int print_signed_number(PutChFunc putch, char*& bufptr, int number, bool left_pad, bool zero_pad, u32 field_width, bool always_sign)
 {
     if (number < 0) {
         putch(bufptr, '-');
-        return print_number(putch, bufptr, 0 - number, leftPad, zeroPad, fieldWidth) + 1;
+        return print_number(putch, bufptr, 0 - number, left_pad, zero_pad, field_width) + 1;
     }
     if (always_sign)
         putch(bufptr, '+');
-    return print_number(putch, bufptr, number, leftPad, zeroPad, fieldWidth);
+    return print_number(putch, bufptr, number, left_pad, zero_pad, field_width);
 }
 
 template<typename PutChFunc>
@@ -294,9 +294,9 @@ ALWAYS_INLINE int printf_internal(PutChFunc putch, char* buffer, const char*& fm
 
     for (p = fmt; *p; ++p) {
         bool left_pad = false;
-        bool zeroPad = false;
+        bool zero_pad = false;
         bool dot = false;
-        unsigned fieldWidth = 0;
+        unsigned field_width = 0;
         unsigned fraction_length = 0;
         unsigned long_qualifiers = 0;
         bool size_qualifier = false;
@@ -321,15 +321,15 @@ ALWAYS_INLINE int printf_internal(PutChFunc putch, char* buffer, const char*& fm
                 if (*(p + 1))
                     goto one_more;
             }
-            if (!zeroPad && !fieldWidth && *p == '0') {
-                zeroPad = true;
+            if (! zero_pad && !field_width && *p == '0') {
+                zero_pad = true;
                 if (*(p + 1))
                     goto one_more;
             }
             if (*p >= '0' && *p <= '9') {
                 if (!dot) {
-                    fieldWidth *= 10;
-                    fieldWidth += *p - '0';
+                    field_width *= 10;
+                    field_width += *p - '0';
                     if (*(p + 1))
                         goto one_more;
                 } else {
@@ -340,7 +340,7 @@ ALWAYS_INLINE int printf_internal(PutChFunc putch, char* buffer, const char*& fm
                 }
             }
             if (*p == '*') {
-                fieldWidth = va_arg(ap, int);
+                field_width = va_arg(ap, int);
                 if (*(p + 1))
                     goto one_more;
             }
@@ -362,36 +362,36 @@ ALWAYS_INLINE int printf_internal(PutChFunc putch, char* buffer, const char*& fm
             switch (*p) {
             case 's': {
                 const char* sp = va_arg(ap, const char*);
-                ret += print_string(putch, bufptr, sp ? sp : "(null)", left_pad, fieldWidth, dot);
+                ret += print_string(putch, bufptr, sp ? sp : "(null)", left_pad, field_width, dot);
             } break;
 
             case 'd':
             case 'i':
                 if (long_qualifiers >= 2)
-                    ret += print_i64(putch, bufptr, va_arg(ap, i64), left_pad, zeroPad, fieldWidth);
+                    ret += print_i64(putch, bufptr, va_arg(ap, i64), left_pad, zero_pad, field_width);
                 else
-                    ret += print_signed_number(putch, bufptr, va_arg(ap, int), left_pad, zeroPad, fieldWidth, always_sign);
+                    ret += print_signed_number(putch, bufptr, va_arg(ap, int), left_pad, zero_pad, field_width, always_sign);
                 break;
 
             case 'u':
                 if (long_qualifiers >= 2)
-                    ret += print_u64(putch, bufptr, va_arg(ap, u64), left_pad, zeroPad, fieldWidth);
+                    ret += print_u64(putch, bufptr, va_arg(ap, u64), left_pad, zero_pad, field_width);
                 else
-                    ret += print_number(putch, bufptr, va_arg(ap, u32), left_pad, zeroPad, fieldWidth);
+                    ret += print_number(putch, bufptr, va_arg(ap, u32), left_pad, zero_pad, field_width);
                 break;
 
             case 'Q':
-                ret += print_u64(putch, bufptr, va_arg(ap, u64), left_pad, zeroPad, fieldWidth);
+                ret += print_u64(putch, bufptr, va_arg(ap, u64), left_pad, zero_pad, field_width);
                 break;
 
             case 'q':
-                ret += print_hex(putch, bufptr, va_arg(ap, u64), false, false, left_pad, zeroPad, 16);
+                ret += print_hex(putch, bufptr, va_arg(ap, u64), false, false, left_pad, zero_pad, 16);
                 break;
 
 #if !defined(BOOTSTRAPPER) && !defined(KERNEL)
             case 'g':
             case 'f':
-                ret += print_double(putch, bufptr, va_arg(ap, double), left_pad, zeroPad, fieldWidth, fraction_length);
+                ret += print_double(putch, bufptr, va_arg(ap, double), left_pad, zero_pad, field_width, fraction_length);
                 break;
 #endif
 
@@ -400,12 +400,12 @@ ALWAYS_INLINE int printf_internal(PutChFunc putch, char* buffer, const char*& fm
                     putch(bufptr, '0');
                     ++ret;
                 }
-                ret += print_octal_number(putch, bufptr, va_arg(ap, u32), left_pad, zeroPad, fieldWidth);
+                ret += print_octal_number(putch, bufptr, va_arg(ap, u32), left_pad, zero_pad, field_width);
                 break;
 
             case 'X':
             case 'x':
-                ret += print_hex(putch, bufptr, va_arg(ap, u32), *p == 'X', alternate_form, left_pad, zeroPad, fieldWidth);
+                ret += print_hex(putch, bufptr, va_arg(ap, u32), *p == 'X', alternate_form, left_pad, zero_pad, field_width);
                 break;
 
             case 'w':
@@ -418,7 +418,7 @@ ALWAYS_INLINE int printf_internal(PutChFunc putch, char* buffer, const char*& fm
 
             case 'c': {
                 char s[2] { (char)va_arg(ap, int), 0 };
-                ret += print_string(putch, bufptr, s, left_pad, fieldWidth, dot);
+                ret += print_string(putch, bufptr, s, left_pad, field_width, dot);
             } break;
 
             case '%':


### PR DESCRIPTION
zeroPad => zero_pad
leftPad => left_pad
fieldWidth => field_width

These were the only variables with names in camelCase.
We were not consistent with the naming of these variables: some times we
called them zeroPad, leftPad, fieldWidth; other times we called them
zero_pad, left_pad, field_width.

These inconsistencies made the code hard to read, so I changed their
names to snake_case.

Also rename width => field_width in AK::print_hex()