### PR TITLE
LibJS: Add indentation to sections in SwitchCase::dump()

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1384,21 +1384,17 @@ void SwitchStatement::dump(int indent) const
 void SwitchCase::dump(int indent) const
 {
     ASTNode::dump(indent);
-    print_indent(indent);
+    print_indent(indent + 1);
     if (m_test) {
         printf("(Test)\n");
-        m_test->dump(indent + 1);
+        m_test->dump(indent + 2);
     } else {
         printf("(Default)\n");
     }
-    print_indent(indent);
+    print_indent(indent + 1);
     printf("(Consequent)\n");
-    int i = 0;
-    for (auto& statement : m_consequent) {
-        print_indent(indent);
-        printf("[%d]\n", i++);
-        statement.dump(indent + 1);
-    }
+    for (auto& statement : m_consequent)
+        statement.dump(indent + 2);
 }
 
 Value ConditionalExpression::execute(Interpreter& interpreter) const


### PR DESCRIPTION
This now matches the output of

```
Program
  (Variables)
    ...
  (Children)
    ...
```

or

```
FunctionDeclaration 'foo'
  (Parameters)
    ...
  (Body)
    ...
```

etc.

Also don't print each consequent statement index, it doesn't add any value.

---

Before and after for `Libraries/LibJS/Tests/switch-basic.js`:

```
Program
  (Children)
    SwitchStatement
      BinaryExpression
        NumericLiteral 1
        +
        NumericLiteral 2
      SwitchCase
      (Test)
        NumericLiteral 3
      (Consequent)
      [0]
        ExpressionStatement
          CallExpression 
            MemberExpression (computed=false)
              Identifier "console"
              Identifier "log"
            StringLiteral "PASS"
      [1]
        BreakStatement
      SwitchCase
      (Test)
        NumericLiteral 5
      (Consequent)
      SwitchCase
      (Test)
        NumericLiteral 1
      (Consequent)
      [0]
        BreakStatement
      SwitchCase
      (Default)
      (Consequent)
      [0]
        BreakStatement
PASS
```

```
Program
  (Children)
    SwitchStatement
      BinaryExpression
        NumericLiteral 1
        +
        NumericLiteral 2
      SwitchCase
        (Test)
          NumericLiteral 3
        (Consequent)
          ExpressionStatement
            CallExpression 
              MemberExpression (computed=false)
                Identifier "console"
                Identifier "log"
              StringLiteral "PASS"
          BreakStatement
      SwitchCase
        (Test)
          NumericLiteral 5
        (Consequent)
      SwitchCase
        (Test)
          NumericLiteral 1
        (Consequent)
          BreakStatement
      SwitchCase
        (Default)
        (Consequent)
          BreakStatement
```