### PR TITLE
LibWeb/LibHTTP: Form submission improvements for google.com

### DIFF
--- a/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Libraries/LibHTTP/HttpRequest.cpp
@@ -65,6 +65,10 @@ ByteBuffer HttpRequest::to_raw_request() const
     builder.append(method_name());
     builder.append(' ');
     builder.append(m_url.path());
+    if (!m_url.query().is_empty()) {
+        builder.append('?');
+        builder.append(m_url.query());
+    }
     builder.append(" HTTP/1.1\r\nHost: ");
     builder.append(m_url.host());
     builder.append("\r\nConnection: close\r\n\r\n");

--- a/Libraries/LibWeb/DOM/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/DOM/HTMLFormElement.cpp
@@ -41,7 +41,7 @@ HTMLFormElement::~HTMLFormElement()
 {
 }
 
-void HTMLFormElement::submit()
+void HTMLFormElement::submit(RefPtr<HTMLInputElement> submitter)
 {
     if (action().is_null()) {
         dbg() << "Unsupported form action ''";
@@ -68,7 +68,7 @@ void HTMLFormElement::submit()
 
     for_each_in_subtree_of_type<HTMLInputElement>([&](auto& node) {
         auto& input = to<HTMLInputElement>(node);
-        if (!input.name().is_null())
+        if (!input.name().is_null() && (input.type() != "submit" || &input == submitter))
             parameters.append({ input.name(), input.value() });
         return IterationDecision::Continue;
     });

--- a/Libraries/LibWeb/DOM/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/DOM/HTMLFormElement.cpp
@@ -48,9 +48,13 @@ void HTMLFormElement::submit()
         return;
     }
 
-    if (method().to_lowercase() != "get") {
-        dbg() << "Unsupported form method '" << method() << "'";
-        return;
+    auto effective_method = method().to_lowercase();
+    if (effective_method != "get") {
+        if (effective_method == "post" || effective_method == "dialog") {
+            dbg() << "Unsupported form method '" << method() << "'";
+            return;
+        }
+        effective_method = "get";
     }
 
     URL url(document().complete_url(action()));

--- a/Libraries/LibWeb/DOM/HTMLFormElement.h
+++ b/Libraries/LibWeb/DOM/HTMLFormElement.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <LibWeb/DOM/HTMLElement.h>
+#include <LibWeb/DOM/HTMLInputElement.h>
 
 namespace Web {
 
@@ -38,7 +39,7 @@ public:
     String action() const { return attribute("action"); }
     String method() const { return attribute("method"); }
 
-    void submit();
+    void submit(RefPtr<HTMLInputElement> submitter);
 };
 
 template<>

--- a/Libraries/LibWeb/DOM/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/DOM/HTMLInputElement.cpp
@@ -63,7 +63,7 @@ RefPtr<LayoutNode> HTMLInputElement::create_layout_node(const StyleProperties*) 
         button.on_click = [this] {
             if (auto* form = first_ancestor_of_type<HTMLFormElement>()) {
                 // FIXME: Remove this const_cast once we have a non-const first_ancestor_of_type.
-                const_cast<HTMLFormElement*>(form)->submit();
+                const_cast<HTMLFormElement*>(form)->submit(this);
             }
         };
         widget = button;

--- a/Libraries/LibWeb/Makefile
+++ b/Libraries/LibWeb/Makefile
@@ -89,7 +89,8 @@ LIBWEB_OBJS = \
     Layout/LineBoxFragment.o \
     Parser/CSSParser.o \
     Parser/HTMLParser.o \
-    ResourceLoader.o
+    ResourceLoader.o \
+    URLEncoder.o
 
 EXTRA_SOURCES = \
     CSS/DefaultStyleSheetSource.cpp \

--- a/Libraries/LibWeb/URLEncoder.h
+++ b/Libraries/LibWeb/URLEncoder.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/Vector.h>
+
+namespace Web {
+
+struct URLQueryParam {
+    String name;
+    String value;
+};
+
+String url_encode(StringView);
+String url_encode(Vector<URLQueryParam>);
+
+}
+


### PR DESCRIPTION
### Improve <form> submit method
Defaults to GET if a method isn't provided or an invalid one is provided.
See: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method

### Actually include query parameters when serializing raw request
What it says on the tin. This is why before visiting `https://www.google.com/search?q=serenityos` would just redirect back to the google homepage, @linusg.

### When creating form action URL, only include value for the submit that was used to submit the form
Per the spec: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-form-data-set, only the button that was used to submit the form has its value included.

### Add basic URL encoder for individual values and param lists
Otherwise clicking the google search button would produce a parameter "btnK=Google Search" containing a literal space which would result in a malformed raw HTTP request. This follows the spec: https://url.spec.whatwg.org/#urlencoded-serializing, but I'm sure there are more edge cases. Right now, it's in LibWeb since I'm not sure if it should be there or in AK.

With all of this, it's possible to submit a google search and receive results back, though Browser crashes when rendering them because the CSS is too complex.