### PR TITLE
LibJS: Limit scope of 'for' loop variables

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -236,6 +236,9 @@ Value ForStatement::execute(Interpreter& interpreter) const
 
     if (m_init && m_init->is_variable_declaration() && static_cast<const VariableDeclaration*>(m_init.ptr())->declaration_kind() != DeclarationKind::Var) {
         wrapper = create_ast_node<BlockStatement>();
+        NonnullRefPtrVector<VariableDeclaration> decls;
+        decls.append(*static_cast<const VariableDeclaration*>(m_init.ptr()));
+        wrapper->add_variables(decls);
         interpreter.enter_scope(*wrapper, {}, ScopeType::Block);
     }
 

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -1066,6 +1066,7 @@ NonnullRefPtr<ForStatement> Parser::parse_for_statement()
     consume(TokenType::ParenOpen);
 
     bool first_semicolon_consumed = false;
+    bool in_scope = false;
     RefPtr<ASTNode> init;
     switch (m_parser_state.m_current_token.type()) {
     case TokenType::Semicolon:
@@ -1074,6 +1075,11 @@ NonnullRefPtr<ForStatement> Parser::parse_for_statement()
         if (match_expression()) {
             init = parse_expression(0);
         } else if (match_variable_declaration()) {
+            if (m_parser_state.m_current_token.type() != TokenType::Var) {
+                m_parser_state.m_let_scopes.append(NonnullRefPtrVector<VariableDeclaration>());
+                in_scope = true;
+            }
+
             init = parse_variable_declaration();
             first_semicolon_consumed = true;
         } else {
@@ -1108,6 +1114,10 @@ NonnullRefPtr<ForStatement> Parser::parse_for_statement()
     consume(TokenType::ParenClose);
 
     auto body = parse_statement();
+
+    if (in_scope) {
+        m_parser_state.m_let_scopes.take_last();
+    }
 
     return create_ast_node<ForStatement>(move(init), move(test), move(update), move(body));
 }

--- a/Libraries/LibJS/Tests/for-scopes.js
+++ b/Libraries/LibJS/Tests/for-scopes.js
@@ -1,0 +1,22 @@
+load("test-common.js");
+
+try {
+    for (var v = 5; false; );
+    assert(v == 5);
+
+    const options = {error: ReferenceError};
+
+    assertThrowsError(() => {
+        for (let l = 5; false; );
+        l;
+    }, options);
+
+    assertThrowsError(() => {
+        for (const c = 5; false; );
+        c;
+    }, options)
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
This required 2 changes:
1. In the parser, create a new variable scope, so the variable is declared in it
   instead of the scope in which the 'for' is found.
2. On execute, push the variable into the newly created block. Existing
   code created an empty block (no variables, no arguments) which allows
   `Interpreter::enter_scope()` to skip the creation of a new environment,
   therefore when the variable initializer is executed, it sets the variable
   to the outer scope. By attaching the variable to the new block, it receives
   a new environment.

This is only needed for 'let' / 'const' declarations, since 'var'
declarations are expected to leak.

I'm also a C guy so I'm fairly new to C++. Perhaps that `static_cast` trick is not legit, I'm not sure.

Also I'm not sure it's the right way to solve it: perhaps it's better to have the variable declared in the same scope, and make sure to delete it afterwards? I went with current solution because `ForStatement::execute` already had this logic of creating a new block for `let`/ `const`.

Fixes #2103 if we merge it :)

~~P.S `js-tests/run-tests` is broken when running on Serenity, so I didn't run them all. My test works. Tomorrow I'll try running all others, to make sure I didn't break anything.~~
~~I also hadn't run `clang-format` on it yet.~~
All tests (168 + 1 new) JS tests pass. Also ran `clang-format`.