### PR TITLE
js: Fix "error: ‘%s’ directive argument is null" (Lagom build)

### DIFF
--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -439,8 +439,9 @@ public:
         auto trace = interpreter().get_trace();
         for (auto function_name : trace) {
             if (String(function_name).is_empty())
-                function_name = "<anonymous>";
-            printf(" -> %s\n", function_name.characters());
+                printf(" -> <anonymous>\n");
+            else
+                printf(" -> %s\n", function_name.characters());
         }
         return JS::js_undefined();
     }


### PR DESCRIPTION
Lagom build of js was broken for me after https://github.com/SerenityOS/serenity/pull/2098 was merged. Seems to be fine for other people's host compilers (source: @awesomekling on IRC)

```
serenity/Userland/js.cpp: In member function ‘virtual JS::Value ReplConsoleClient::trace()’:
serenity/Userland/js.cpp:443:19: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  443 |             printf(" -> %s\n", function_name.characters());
      |             ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[3]: *** [CMakeFiles/js.dir/build.make:83: CMakeFiles/js.dir/serenity/Userland/js.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:131: CMakeFiles/js.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:138: CMakeFiles/js.dir/rule] Error 2
make: *** [Makefile:151: js] Error 2
```

Now works on my machine (:tm:) again (Fedora 32, `gcc` 10.0.1)