### PR TITLE
LibWeb: Recognise :focus pseudo-class

### DIFF
--- a/Libraries/LibWeb/CSS/Selector.h
+++ b/Libraries/LibWeb/CSS/Selector.h
@@ -48,6 +48,7 @@ public:
             None,
             Link,
             Hover,
+            Focus,
             FirstChild,
             LastChild,
             OnlyChild,

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -56,6 +56,9 @@ bool matches(const Selector::SimpleSelector& component, const Element& element)
         if (!matches_hover_pseudo_class(element))
             return false;
         break;
+    case Selector::SimpleSelector::PseudoClass::Focus:
+        // FIXME: Implement matches_focus_pseudo_class(element)
+        return false;
     case Selector::SimpleSelector::PseudoClass::FirstChild:
         if (element.previous_element_sibling())
             return false;

--- a/Libraries/LibWeb/Parser/CSSParser.cpp
+++ b/Libraries/LibWeb/Parser/CSSParser.cpp
@@ -385,6 +385,8 @@ public:
                 simple_selector.pseudo_class = Selector::SimpleSelector::PseudoClass::Link;
             else if (pseudo_name == "hover")
                 simple_selector.pseudo_class = Selector::SimpleSelector::PseudoClass::Hover;
+            else if (pseudo_name == "focus")
+                simple_selector.pseudo_class = Selector::SimpleSelector::PseudoClass::Focus;
             else if (pseudo_name == "first-child")
                 simple_selector.pseudo_class = Selector::SimpleSelector::PseudoClass::FirstChild;
             else if (pseudo_name == "last-child")


### PR DESCRIPTION
It's still only a dummy as LibWeb doesn't have focused elements yet, but at least now we don't treat "selector:focus" as just "selector".

This fixes an issue on google.com which was mostly grey - coming from some menu item focus styles :^)

```css
.gbzt:hover,
.gbzt:focus,
.gbgt-hvr,
.gbgt:focus {
    background-color:#4c4c4c; /* <-- */
    background-image:none;
    _background-image:none;
    background-position:0 -102px;
    background-repeat:repeat-x;
    outline:none;
    text-decoration:none !important
}
```

(yes, the menu items are still all over the place)

![image](https://user-images.githubusercontent.com/19366641/81058533-88528680-8ec6-11ea-8578-8bebec773f29.png)
