### PR TITLE
Help: Clicking on link changes the treeview selection

### DIFF
--- a/Applications/Help/ManualModel.cpp
+++ b/Applications/Help/ManualModel.cpp
@@ -47,6 +47,24 @@ ManualModel::ManualModel()
     m_page_icon.set_bitmap_for_size(16, Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-unknown.png"));
 }
 
+Optional<GUI::ModelIndex> ManualModel::index_from_path(const StringView& path) const
+{
+    for (int section = 0; section < row_count(); ++section) {
+        auto parent_index = index(section, 0);
+        for (int row = 0; row < row_count(parent_index); ++row) {
+            auto child_index = index(row, 0, parent_index);
+            auto* node = static_cast<const ManualNode*>(child_index.internal_data());
+            if (!node->is_page())
+                continue;
+            auto* page = static_cast<const ManualPageNode*>(node);
+            if (page->path() != path)
+                continue;
+            return child_index;
+        }
+    }
+    return {};
+}
+
 String ManualModel::page_path(const GUI::ModelIndex& index) const
 {
     if (!index.is_valid())

--- a/Applications/Help/ManualModel.h
+++ b/Applications/Help/ManualModel.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
 #include <AK/String.h>
 #include <LibGUI/Model.h>
 
@@ -38,6 +39,8 @@ public:
     }
 
     virtual ~ManualModel() override {};
+
+    Optional<GUI::ModelIndex> index_from_path(const StringView&) const;
 
     String page_path(const GUI::ModelIndex&) const;
     String page_and_section(const GUI::ModelIndex&) const;

--- a/Applications/Help/main.cpp
+++ b/Applications/Help/main.cpp
@@ -156,6 +156,12 @@ int main(int argc, char* argv[])
         char* dir_path = dirname(current_path);
         char* path = realpath(String::format("%s/%s", dir_path, href.characters()).characters(), nullptr);
         free(current_path);
+        auto tree_view_index = model->index_from_path(path);
+        if (tree_view_index.has_value()) {
+            dbg() << "Found path _" << path << "_ in model at index " << tree_view_index.value();
+            tree_view.selection().set(tree_view_index.value());
+            return;
+        }
         history.push(path);
         update_actions();
         open_page(path);


### PR DESCRIPTION
When clicking a link in the help application, the treeview selection now changes to select the page on the left sidebar (when possible).

If the requested file isn't in the treeview, then the previous behaviour takes place (the page attempts to be loaded, but the treeview sidebar isn't updated).

This also solves issue #1259 since the page title is computed from the treeview selection.

## Limitation

When the target page's category is collapsed, it doesn't get auto-uncollapsed on selection and the selected item stays hidden.

There is a piece of code surrounded by `#if 0 (...) #endif` in TreeView.cpp l. 344-356 which enables the expected behaviour, but I assume it was disabled for a reason.