### PR TITLE
Taskbar: Remove checkable property from taskbar buttons

### DIFF
--- a/Applications/Taskbar/TaskbarWindow.cpp
+++ b/Applications/Taskbar/TaskbarWindow.cpp
@@ -135,7 +135,6 @@ NonnullRefPtr<GUI::Button> TaskbarWindow::create_button(const WindowIdentifier& 
     auto& button = main_widget()->add<TaskbarButton>(identifier);
     button.set_size_policy(GUI::SizePolicy::Fixed, GUI::SizePolicy::Fixed);
     button.set_preferred_size(140, 22);
-    button.set_checkable(true);
     button.set_text_alignment(Gfx::TextAlignment::CenterLeft);
     button.set_icon(*m_default_icon);
     return button;


### PR DESCRIPTION
If a button is checkable, its "checked" state is inversed in
Button::click. It's not needed for taskbar buttons - their checked
state is updated in TaskbarWindow::wm_event, based on the
current state of their window.

Fixes: #1878.