### PR TITLE
LibJS: Fix syntax error for arrow function non-decl variable assignment

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -295,7 +295,7 @@ RefPtr<FunctionExpression> Parser::try_parse_arrow_function_expression(bool expe
         } else if (match(TokenType::Identifier)) {
             auto parameter_name = consume(TokenType::Identifier).value();
             RefPtr<Expression> default_value;
-            if (match(TokenType::Equals)) {
+            if (expect_parens && match(TokenType::Equals)) {
                 consume(TokenType::Equals);
                 default_value = parse_expression(0);
             }

--- a/Libraries/LibJS/Tests/arrow-functions.js
+++ b/Libraries/LibJS/Tests/arrow-functions.js
@@ -4,6 +4,9 @@ try {
     let getNumber = () => 42;
     assert(getNumber() === 42);
 
+    getNumber = () => 99;
+    assert(getNumber() === 99);
+
     let add = (a, b) => a + b;
     assert(add(2, 3) === 5);
 


### PR DESCRIPTION
A regression was introduced in dc9b4da where the parser would incorrectly parse the assignment of arrow functions to (non-declaration) variables. For example, consider:

```js
a = () => {}
```

Because the parser was aware of default parameters, in `try_parse_arrow_function`, the equals sign would be interpreted as a default argument, leading to incorrect parsing of the overall expression. Also resulted in some funny behavior (`a = () => {} => {}` worked just fine!).

The simple fix is to only look for default parameters if the arrow function is required to have parenthesis.

EDIT: Fixes #2124