### PR TITLE
LibJS: Add function call spreading

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -567,7 +567,12 @@ private:
 
 class CallExpression : public Expression {
 public:
-    CallExpression(NonnullRefPtr<Expression> callee, NonnullRefPtrVector<Expression> arguments = {})
+    struct Argument {
+        NonnullRefPtr<Expression> value;
+        bool is_spread;
+    };
+
+    CallExpression(NonnullRefPtr<Expression> callee, Vector<Argument> arguments = {})
         : m_callee(move(callee))
         , m_arguments(move(arguments))
     {
@@ -586,12 +591,12 @@ private:
     ThisAndCallee compute_this_and_callee(Interpreter&) const;
 
     NonnullRefPtr<Expression> m_callee;
-    const NonnullRefPtrVector<Expression> m_arguments;
+    const Vector<Argument> m_arguments;
 };
 
 class NewExpression final : public CallExpression {
 public:
-    NewExpression(NonnullRefPtr<Expression> callee, NonnullRefPtrVector<Expression> arguments = {})
+    NewExpression(NonnullRefPtr<Expression> callee, Vector<Argument> arguments = {})
         : CallExpression(move(callee), move(arguments))
     {
     }

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -777,10 +777,15 @@ NonnullRefPtr<CallExpression> Parser::parse_call_expression(NonnullRefPtr<Expres
 {
     consume(TokenType::ParenOpen);
 
-    NonnullRefPtrVector<Expression> arguments;
+    Vector<CallExpression::Argument> arguments;
 
-    while (match_expression()) {
-        arguments.append(parse_expression(0));
+    while (match_expression() || match(TokenType::TripleDot)) {
+        if (match(TokenType::TripleDot)) {
+            consume();
+            arguments.append({ parse_expression(0), true });
+        } else {
+            arguments.append({ parse_expression(0), false });
+        }
         if (!match(TokenType::Comma))
             break;
         consume();
@@ -798,12 +803,17 @@ NonnullRefPtr<NewExpression> Parser::parse_new_expression()
     // FIXME: Support full expressions as the callee as well.
     auto callee = create_ast_node<Identifier>(consume(TokenType::Identifier).value());
 
-    NonnullRefPtrVector<Expression> arguments;
+    Vector<CallExpression::Argument> arguments;
 
     if (match(TokenType::ParenOpen)) {
         consume(TokenType::ParenOpen);
-        while (match_expression()) {
-            arguments.append(parse_expression(0));
+        while (match_expression() || match(TokenType::TripleDot)) {
+            if (match(TokenType::TripleDot)) {
+                consume();
+                arguments.append({ parse_expression(0), true });
+            } else {
+                arguments.append({ parse_expression(0), false });
+            }
             if (!match(TokenType::Comma))
                 break;
             consume();

--- a/Libraries/LibJS/Tests/function-spread.js
+++ b/Libraries/LibJS/Tests/function-spread.js
@@ -1,0 +1,27 @@
+load("test-common.js");
+
+try {
+    const sum = (a, b, c) => a + b + c;
+    const a = [1, 2, 3];
+
+    assert(sum(...a) === 6);
+    assert(sum(1, ...a) === 4);
+    assert(sum(...a, 10) === 6);
+
+    const foo = (a, b, c) => c;
+
+    const o = { bar: [1, 2, 3] };
+    assert(foo(...o.bar) === 3);
+    assert(foo(..."abc") === "c");
+
+    assertThrowsError(() => {
+        [...1];
+    }, {
+        error: TypeError,
+        message: "1 is not iterable",
+    });
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
Adds support for the following syntax:

```js
Math.max(...x, ...[1, 2, 3], ...o.foo, ...'abcd')
```