### PR TITLE
Misc: Replace "String(string_view)" with "string_view.to_string()"

### DIFF
--- a/AK/Demangle.h
+++ b/AK/Demangle.h
@@ -41,7 +41,7 @@ inline String demangle(const StringView& name)
     return name;
 #else
     int status = 0;
-    auto* demangled_name = abi::__cxa_demangle(String(name).characters(), nullptr, nullptr, &status);
+    auto* demangled_name = abi::__cxa_demangle(name.to_string().characters(), nullptr, nullptr, &status);
     auto string = String(status == 0 ? demangled_name : name);
     if (status == 0)
         kfree(demangled_name);

--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -870,7 +870,7 @@ void IRCClient::handle_user_command(const String& input)
             return;
         int command_length = command.length() + 1;
         StringView raw_message = input.view().substring_view(command_length, input.view().length() - command_length);
-        send(String::format("%s\r\n", String(raw_message).characters()));
+        send(String::format("%s\r\n", raw_message.to_string().characters()));
         return;
     }
     if (command == "/NICK") {

--- a/Applications/PaintBrush/ToolboxWidget.cpp
+++ b/Applications/PaintBrush/ToolboxWidget.cpp
@@ -80,7 +80,7 @@ ToolboxWidget::ToolboxWidget()
         button.set_checkable(true);
         button.set_exclusive(true);
 
-        button.set_icon(Gfx::Bitmap::load_from_file(String::format("/res/icons/paintbrush/%s.png", String(icon_name).characters())));
+        button.set_icon(Gfx::Bitmap::load_from_file(String::format("/res/icons/paintbrush/%s.png", icon_name.to_string().characters())));
 
         button.on_checked = [button = &button](auto checked) {
             if (checked)

--- a/DevTools/ProfileViewer/Profile.cpp
+++ b/DevTools/ProfileViewer/Profile.cpp
@@ -167,7 +167,7 @@ OwnPtr<Profile> Profile::load_from_perfcore_file(const StringView& path)
 {
     auto file = Core::File::construct(path);
     if (!file->open(Core::IODevice::ReadOnly)) {
-        fprintf(stderr, "Unable to open %s, error: %s\n", String(path).characters(), file->error_string());
+        fprintf(stderr, "Unable to open %s, error: %s\n", path.to_string().characters(), file->error_string());
         return nullptr;
     }
 

--- a/Libraries/LibCore/DirIterator.cpp
+++ b/Libraries/LibCore/DirIterator.cpp
@@ -33,7 +33,7 @@ DirIterator::DirIterator(const StringView& path, Flags flags)
     : m_path(path)
     , m_flags(flags)
 {
-    m_dir = opendir(String(path).characters());
+    m_dir = opendir(path.to_string().characters());
     if (!m_dir) {
         m_error = errno;
     }

--- a/Libraries/LibGUI/FilePicker.cpp
+++ b/Libraries/LibGUI/FilePicker.cpp
@@ -307,7 +307,7 @@ void FilePicker::on_file_return()
 bool FilePicker::file_exists(const StringView& path)
 {
     struct stat st;
-    int rc = stat(String(path).characters(), &st);
+    int rc = stat(path.to_string().characters(), &st);
     if (rc < 0) {
         if (errno == ENOENT)
             return false;

--- a/Libraries/LibGUI/Icon.cpp
+++ b/Libraries/LibGUI/Icon.cpp
@@ -94,8 +94,8 @@ void IconImpl::set_bitmap_for_size(int size, RefPtr<Gfx::Bitmap>&& bitmap)
 
 Icon Icon::default_icon(const StringView& name)
 {
-    auto bitmap16 = Gfx::Bitmap::load_from_file(String::format("/res/icons/16x16/%s.png", String(name).characters()));
-    auto bitmap32 = Gfx::Bitmap::load_from_file(String::format("/res/icons/32x32/%s.png", String(name).characters()));
+    auto bitmap16 = Gfx::Bitmap::load_from_file(String::format("/res/icons/16x16/%s.png", name.to_string().characters()));
+    auto bitmap32 = Gfx::Bitmap::load_from_file(String::format("/res/icons/32x32/%s.png", name.to_string().characters()));
     return Icon(move(bitmap16), move(bitmap32));
 }
 

--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -194,7 +194,7 @@ Bitmap::~Bitmap()
 void Bitmap::set_mmap_name(const StringView& name)
 {
     ASSERT(m_needs_munmap);
-    ::set_mmap_name(m_data, size_in_bytes(), String(name).characters());
+    ::set_mmap_name(m_data, size_in_bytes(), name.to_string().characters());
 }
 
 void Bitmap::fill(Color color)

--- a/Libraries/LibGfx/Color.cpp
+++ b/Libraries/LibGfx/Color.cpp
@@ -182,7 +182,7 @@ static Optional<Color> parse_rgba_color(const StringView& string)
     if (!ok)
         return {};
 
-    double alpha = strtod(String(parts[3]).characters(), nullptr);
+    double alpha = strtod(parts[3].to_string().characters(), nullptr);
     int a = alpha * 255;
 
     if (r < 0 || r > 255)

--- a/Userland/mount.cpp
+++ b/Userland/mount.cpp
@@ -51,7 +51,7 @@ int parse_options(const StringView& options)
         else if (part == "bind")
             flags |= MS_BIND;
         else
-            fprintf(stderr, "Ignoring invalid option: %s\n", String(part).characters());
+            fprintf(stderr, "Ignoring invalid option: %s\n", part.to_string().characters());
     }
     return flags;
 }


### PR DESCRIPTION
`StringView::to_string()` was added in 917ccb1 but not actually used anywhere yet.