### PR TITLE
LibWeb/Browser: Middle-clicking a link opens it in a new tab

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -165,6 +165,10 @@ Tab::Tab()
         m_link_context_menu->popup(screen_position);
     };
 
+    m_html_widget->on_link_middle_click = [this](auto& href) {
+        m_html_widget->on_link_click(href, "_blank", 0);
+    };
+
     m_html_widget->on_title_change = [this](auto& title) {
         if (title.is_null()) {
             m_title = m_html_widget->main_frame().document()->url().to_string();

--- a/Libraries/LibWeb/HtmlView.cpp
+++ b/Libraries/LibWeb/HtmlView.cpp
@@ -244,6 +244,9 @@ void HtmlView::mousedown_event(GUI::MouseEvent& event)
                 } else if (event.button() == GUI::MouseButton::Right) {
                     if (on_link_context_menu_request)
                         on_link_context_menu_request(link->href(), event.position().translated(screen_relative_rect().location()));
+                } else if (event.button() == GUI::MouseButton::Middle) {
+                    if (on_link_middle_click)
+                        on_link_middle_click(link->href());
                 }
             } else {
                 if (event.button() == GUI::MouseButton::Left) {

--- a/Libraries/LibWeb/HtmlView.h
+++ b/Libraries/LibWeb/HtmlView.h
@@ -59,6 +59,7 @@ public:
 
     Function<void(const String& href, const String& target, unsigned modifiers)> on_link_click;
     Function<void(const String& href, const Gfx::Point& screen_position)> on_link_context_menu_request;
+    Function<void(const String& href)> on_link_middle_click;
     Function<void(const String&)> on_link_hover;
     Function<void(const String&)> on_title_change;
     Function<void(const URL&)> on_load_start;


### PR DESCRIPTION
This is my first contribution, so I hope I've done everything correctly!

This patch allows links to be opened in a new tab when middle-clicked, which is a small, but handy quality of life feature from most browsers.