### PR TITLE
Build: Support building in Docker

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -8,6 +8,11 @@ Make sure you have all the dependencies installed:
 sudo apt install build-essential curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs qemu-system-i386 qemu-utils
 ```
 
+On Docker, install these as well:
+```bash
+sudo apt install wget genext2fs
+```
+
 **Fedora**
 ```bash
 sudo dnf install curl mpfr-devel libmpc-devel gmp-devel e2fsprogs @"C Development Tools and Libraries" @Virtualization

--- a/Kernel/build-image-qemu.sh
+++ b/Kernel/build-image-qemu.sh
@@ -38,6 +38,7 @@ echo "done"
 
 printf "mounting filesystem... "
 mkdir -p mnt
+use_genext2fs=0
 if [ "$(uname -s)" = "Darwin" ]; then
     fuse-ext2 _disk_image mnt -o rw+,allow_other,uid=501,gid=20 || die "could not mount filesystem"
 elif [ "$(uname -s)" = "OpenBSD" ]; then
@@ -45,14 +46,23 @@ elif [ "$(uname -s)" = "OpenBSD" ]; then
 elif [ "$(uname -s)" = "FreeBSD" ]; then
     fuse-ext2 -o rw+ "/dev/${MD}" mnt/ || die "could not mount filesystem"
 else
-    mount _disk_image mnt/ || die "could not mount filesystem"
+    if ! mount _disk_image mnt/ ; then
+        if command -v genext2fs 1>/dev/null ; then
+            echo "mount failed but genext2fs exists, use it instead"
+            use_genext2fs=1
+        else
+            die "could not mount filesystem and genext2fs is missing"
+        fi
+    fi
 fi
 echo "done"
 
 cleanup() {
     if [ -d mnt ]; then
-        printf "unmounting filesystem... "
-        umount mnt || ( sleep 1 && sync && umount mnt )
+        if [ $use_genext2fs = 0 ] ; then
+            printf "unmounting filesystem... "
+            umount mnt || ( sleep 1 && sync && umount mnt )
+        fi
         rm -rf mnt
         if [ "$(uname -s)" = "OpenBSD" ]; then
             vnconfig -u "$VND"
@@ -65,3 +75,13 @@ cleanup() {
 trap cleanup EXIT
 
 ./build-root-filesystem.sh
+
+if [ $use_genext2fs = 1 ]; then
+    # regenerate new image, since genext2fs is unable to reuse the previously written image.
+    # genext2fs is very slow in generating big images, so I use a smaller image here. size can be updated
+    # if it's not enough.
+    # not using "-i 128" since it hangs. Serenity handles whatever default this uses instead.
+    genext2fs -b 250000 -d mnt _disk_image || die "try increasing image size (genext2fs -b)"
+    # if using docker with shared mount, file is created as root, so make it writable for users
+    chmod 0666 _disk_image
+fi


### PR DESCRIPTION
Add missing installations to instructions, and use genext2fs instead of mounting.

On this branch I'm able to run `makeall.sh -f` fully dockerized and use the result image with `Kernel/run` outside of the docker.
The resulting image is somewhat different (`genext2fs` writes images using different properties comparing to modern Linux kernels) but Serenity handles it as well :)

Partially solves https://github.com/SerenityOS/serenity/issues/1791 - no need to `mount` anymore, but `mknod`s are still there. `genext2fs` can be leveraged forward to remove `mknod`s and other `chown`s as well.