### PR TITLE
LibJS+Meta: fix warnings for run-tests and stop ignoring it in lint-shell-scripts.sh

### DIFF
--- a/Libraries/LibJS/Tests/run-tests
+++ b/Libraries/LibJS/Tests/run-tests
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "`uname`" = "SerenityOS" ]; then
+if [ "$(uname)" = "SerenityOS" ]; then
     js_program=/bin/js
 else
     [ -z "$js_program" ] && js_program="$SERENITY_ROOT/Meta/Lagom/build/js"
@@ -9,24 +9,22 @@ else
     export UBSAN_OPTIONS=print_stacktrace=1
 fi
 
-extra_args="$*"
-
 pass_count=0
 fail_count=0
 count=0
 
 GLOBIGNORE=test-common.js
 for f in *.js; do
-    result=`$js_program $extra_args -t $f 2>/dev/null`
+    result="$("$js_program" "$@" -t "$f" 2>/dev/null)"
     if [ "$result" = "PASS" ]; then
-        let pass_count++
+        (( ++pass_count ))
         echo -ne "( \033[32;1mPass\033[0m ) "
     else
         echo -ne "( \033[31;1mFail\033[0m ) "
-        let fail_count++
+        (( ++fail_count ))
     fi
-    echo $f
-    let count++
+    echo "$f"
+    (( ++count ))
 done
 
 pass_color=""
@@ -35,11 +33,11 @@ color_off="\033[0m"
 
 exit_code=0
 
-if [ $pass_count -gt 0 ]; then
+if (( pass_count > 0 )); then
     pass_color="\033[32;1m"
 fi
 
-if [ $fail_count -gt 0 ]; then
+if (( fail_count > 0 )); then
     fail_color="\033[31;1m"
     exit_code=1
 fi

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -10,7 +10,6 @@ for f in $(find . -path ./Root -prune -o \
     -path ./Ports -prune -o \
     -path ./.git -prune -o \
     -path ./Toolchain -prune -o \
-    -path ./Libraries/LibJS/Tests -prune -o \
     -type f | sort -u); do
     if file "$f" | grep --quiet shell; then
         {


### PR DESCRIPTION
We can just fix the warnings: the script will still work fine in Serenity.