### PR TITLE
LibJS: Raw strings + String.raw

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1347,6 +1347,16 @@ Value TaggedTemplateLiteral::execute(Interpreter& interpreter) const
         else
             arguments.append(value);
     }
+
+    auto* raw_strings = Array::create(interpreter.global_object());
+    for (auto& raw_string : m_template_literal->raw_strings()) {
+        auto value = raw_string.execute(interpreter);
+        if (interpreter.exception())
+            return {};
+        raw_strings->elements().append(value);
+    }
+    strings->put("raw", raw_strings, 0);
+
     return interpreter.call(tag_function, js_undefined(), move(arguments));
 }
 

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -779,7 +779,13 @@ private:
 class TemplateLiteral final : public Expression {
 public:
     TemplateLiteral(NonnullRefPtrVector<Expression> expressions)
-        : m_expressions(expressions)
+        : m_expressions(move(expressions))
+    {
+    }
+
+    TemplateLiteral(NonnullRefPtrVector<Expression> expressions, NonnullRefPtrVector<Expression> raw_strings)
+        : m_expressions(move(expressions))
+        , m_raw_strings(move(raw_strings))
     {
     }
 
@@ -787,11 +793,13 @@ public:
     virtual void dump(int indent) const override;
 
     const NonnullRefPtrVector<Expression>& expressions() const { return m_expressions; }
+    const NonnullRefPtrVector<Expression>& raw_strings() const { return m_raw_strings; }
 
 private:
     virtual const char* class_name() const override { return "TemplateLiteral"; }
 
     const NonnullRefPtrVector<Expression> m_expressions;
+    const NonnullRefPtrVector<Expression> m_raw_strings;
 };
 
 class TaggedTemplateLiteral final : public Expression {

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -69,7 +69,7 @@ public:
     NonnullRefPtr<Expression> parse_unary_prefixed_expression();
     NonnullRefPtr<ObjectExpression> parse_object_expression();
     NonnullRefPtr<ArrayExpression> parse_array_expression();
-    NonnullRefPtr<TemplateLiteral> parse_template_literal();
+    NonnullRefPtr<TemplateLiteral> parse_template_literal(bool is_tagged);
     NonnullRefPtr<Expression> parse_secondary_expression(NonnullRefPtr<Expression>, int min_precedence, Associativity associate = Associativity::Right);
     NonnullRefPtr<CallExpression> parse_call_expression(NonnullRefPtr<Expression>);
     NonnullRefPtr<NewExpression> parse_new_expression();

--- a/Libraries/LibJS/Runtime/StringConstructor.h
+++ b/Libraries/LibJS/Runtime/StringConstructor.h
@@ -41,6 +41,8 @@ public:
 private:
     virtual bool has_constructor() const override { return true; }
     virtual const char* class_name() const override { return "StringConstructor"; }
+
+    static Value raw(Interpreter&);
 };
 
 }

--- a/Libraries/LibJS/Tests/String.raw.js
+++ b/Libraries/LibJS/Tests/String.raw.js
@@ -1,0 +1,35 @@
+load("test-common.js")
+
+try {
+    let str = String.raw`foo\nbar`;
+    assert(str.length === 8 && str === "foo\\nbar");
+
+    str = String.raw`foo ${1 + 9}\nbar${"hf!"}`;
+    assert(str === "foo 10\\nbarhf!");
+
+    str = String.raw`${10}${20}${30}`;
+    assert(str === "102030");
+
+    str = String.raw({ raw: ["foo ", "\\nbar"] }, 10, "hf!");
+    assert(str === "foo 10\\nbar");
+
+    str = String.raw({ raw: ["foo ", "\\nbar"] });
+    assert(str === "foo \\nbar");
+
+    str = String.raw({ raw: [] }, 10, "hf!");
+    assert(str === "");
+
+    str = String.raw({ raw: 1 });
+    assert(str === "");
+
+    assertThrowsError(() => {
+        String.raw({});
+    }, {
+        error: TypeError,
+        message: "Cannot convert property 'raw' to object from undefined",
+    });
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/tagged-template-literals.js
+++ b/Libraries/LibJS/Tests/tagged-template-literals.js
@@ -82,6 +82,18 @@ try {
     var rating = "great";
     assert(review`${name} is a ${rating} project!` === "**SerenityOS** is a _great_ project!");
 
+    const getTemplateObject = (...rest) => rest;
+    const getRawTemplateStrings = arr => arr.raw;
+
+    let o = getTemplateObject`foo\nbar`;
+    assert(Object.getOwnPropertyNames(o[0]).includes('raw'));
+
+    let raw = getRawTemplateStrings`foo${1 + 3}\nbar`;
+    assert(!Object.getOwnPropertyNames(raw).includes('raw'));
+    assert(raw.length === 2);
+    assert(raw[0] === 'foo');
+    assert(raw[1].length === 5 && raw[1] === '\\nbar');
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);


### PR DESCRIPTION
This PR adds the `raw` property to the array passed into a function called with a tagged template literal. This allow the support of `String.raw`, which is also included. 