### PR TITLE
LibGUI/Browser: Middle clicking a tab closes it

### DIFF
--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -111,6 +111,11 @@ int main(int argc, char** argv)
         tab.did_become_active();
     };
 
+    tab_widget.on_middle_click = [&](auto& clicked_widget) {
+        auto& tab = static_cast<Browser::Tab&>(clicked_widget);
+        tab.on_tab_close_request(tab);
+    };
+
     Browser::WindowActions window_actions(*window);
 
     Function<void(URL url, bool activate)> create_new_tab;

--- a/Libraries/LibGUI/TabWidget.cpp
+++ b/Libraries/LibGUI/TabWidget.cpp
@@ -236,7 +236,15 @@ void TabWidget::mousedown_event(MouseEvent& event)
         auto button_rect = this->button_rect(i);
         if (!button_rect.contains(event.position()))
             continue;
-        set_active_widget(m_tabs[i].widget);
+        if (event.button() == MouseButton::Left) {
+            set_active_widget(m_tabs[i].widget);
+        } else if (event.button() == MouseButton::Middle) {
+            auto* widget = m_tabs[i].widget;
+            deferred_invoke([this, widget](auto&) {
+                if (on_middle_click && widget)
+                    on_middle_click(*widget);
+            });
+        }
         return;
     }
 }

--- a/Libraries/LibGUI/TabWidget.h
+++ b/Libraries/LibGUI/TabWidget.h
@@ -80,6 +80,7 @@ public:
     int uniform_tab_width() const;
 
     Function<void(Widget&)> on_change;
+    Function<void(Widget&)> on_middle_click;
 
 protected:
     TabWidget();


### PR DESCRIPTION
In continuing with small quality of life changes in the browser, this patch makes it so that middle clicking a tab fires a hook on the `TabWidget`. In the Browser this is used to close the clicked tab.