### PR TITLE
Browser: assume http:// when no URL protocol is provided in the location bar

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -30,6 +30,7 @@
 #include "History.h"
 #include "InspectorWidget.h"
 #include "WindowActions.h"
+#include <AK/StringBuilder.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
@@ -98,7 +99,15 @@ Tab::Tab()
     m_location_box = toolbar.add<GUI::TextBox>();
 
     m_location_box->on_return_pressed = [this] {
-        m_html_widget->load(m_location_box->text());
+        String location = m_location_box->text();
+        if (!location.starts_with("file://") && !location.starts_with("http://") && !location.starts_with("https://")) {
+            StringBuilder builder;
+            builder.append("http://");
+            builder.append(location);
+            location = builder.build();
+        }
+
+        m_html_widget->load(location);
     };
 
     m_bookmark_button = toolbar.add<GUI::Button>();


### PR DESCRIPTION
Hello!

After over half a year of watching all of the videos and following the commits here (even though I have no idea about C++) the time had come for the first, humble pull request.

Honestly, I have no idea whether it's correct when it comes to our let's say _business needs_ or to the code. I figured out that it shouldn't break anything (correct me if I'm wrong).

I purposely didn't touch CLI invocation of `Browser` because then, if I'm not mistaken, we'd have to actually check whether a file exists to assume the protocol. And that would require a total `unveil` so...

Please feel free to point any issues in the approach or the idea itself! Thanks