### PR TITLE
LibGUI: Properly draw the background of the selected TreeView line

### DIFF
--- a/Libraries/LibGUI/TreeView.cpp
+++ b/Libraries/LibGUI/TreeView.cpp
@@ -224,7 +224,17 @@ void TreeView::paint_event(PaintEvent& event)
             }
         }
 
-        Gfx::Rect row_rect { 0, rect.y(), frame_inner_rect().width(), rect.height() };
+        int row_width = 0;
+        for (int column_index = 0; column_index < model.column_count(); ++column_index) {
+            if (is_column_hidden(column_index))
+                continue;
+            row_width += this->column_width(column_index) + horizontal_padding() * 2;
+        }
+        if (frame_inner_rect().width() > row_width) {
+            row_width = frame_inner_rect().width();
+        }
+
+        Gfx::Rect row_rect { 0, rect.y(), row_width, rect.height() };
         painter.fill_rect(row_rect, background_color);
 
         int x_offset = 0;


### PR DESCRIPTION
In the TreeView, the background of the selected line (or any background, really) was only drawn until the frame's width. When the text was larger than the frame's width, this caused the end of the text to be displayed without background, making it unreadable if it was white (which is the default text color for selected lines). This issue is described in #2134

To compute the background width, we have a choice between :
- The inner frame width (the current behaviour which causes the issue)
- The total width of all columns (which causes the background to end
  early if the columns don't cover the full width)

The new algorithm uses the biggest of the above values, which gives us exactly what we want in all cases :^)

Fixes #2134