### PR TITLE
WindowServer: A bit less surprising

### DIFF
--- a/Servers/WindowServer/Button.cpp
+++ b/Servers/WindowServer/Button.cpp
@@ -78,8 +78,14 @@ void Button::on_mouse_event(const MouseEvent& event)
             if (on_click)
                 on_click(*this);
         }
-        if (old_pressed != m_pressed)
+        if (old_pressed != m_pressed) {
+            // Would like to compute:
+            // m_hovered = rect_after_action().contains(event.position());
+            // However, we don't know that rect yet. We can make an educated
+            // guess which also looks okay even when wrong:
+            m_hovered = false;
             wm.invalidate(screen_rect());
+        }
         return;
     }
 

--- a/Servers/WindowServer/Window.cpp
+++ b/Servers/WindowServer/Window.cpp
@@ -362,7 +362,14 @@ bool Window::is_active() const
 
 bool Window::is_blocked_by_modal_window() const
 {
-    return !is_modal() && client() && client()->is_showing_modal_window();
+    bool is_any_modal = false;
+    const Window* next = this;
+    while (!is_any_modal && next) {
+        is_any_modal = next->is_modal();
+        next = next->parent_window();
+    }
+
+    return !is_any_modal && client() && client()->is_showing_modal_window();
 }
 
 void Window::set_default_icon()


### PR DESCRIPTION
ComboBoxes in Dialogs (and probably other WindowTypes) were broken, because the dropdown part was treated like a regular (= less privileged) window.

The "maximize" button used to be permanently lit under certain semi-regular conditions. Note that this patch introduces a different bug, but at least the bug happens under much rarer conditions (the maximize button must end up in basically the same spot), and the buggy behavior is less visible (the button fails to light up until the mouse is moved).