### PR TITLE
Browser: Show line numbers when viewing page source

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -238,6 +238,7 @@ Tab::Tab()
             auto& editor = window->set_main_widget<GUI::TextEditor>();
             editor.set_text(source);
             editor.set_readonly(true);
+            editor.set_ruler_visible(true);
             window->set_rect(150, 150, 640, 480);
             window->set_title(url);
             window->show();


### PR DESCRIPTION
When we view the source code of a web page, line numbers will now be shown in the text editor. Firefox and Chrome both do this, so I figured it might be nice if Browser did it too. 😄 