### PR TITLE
LibJS: Spec-compliant equality comparisons

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -41,7 +41,6 @@
 #include <LibJS/Runtime/ScriptFunction.h>
 #include <LibJS/Runtime/Shape.h>
 #include <LibJS/Runtime/StringObject.h>
-#include <LibJS/Runtime/Value.h>
 #include <stdio.h>
 
 namespace JS {
@@ -345,13 +344,13 @@ Value BinaryExpression::execute(Interpreter& interpreter) const
     case BinaryOp::Exponentiation:
         return exp(interpreter, lhs_result, rhs_result);
     case BinaryOp::TypedEquals:
-        return typed_eq(interpreter, lhs_result, rhs_result);
+        return Value(strict_eq(interpreter, lhs_result, rhs_result));
     case BinaryOp::TypedInequals:
-        return Value(!typed_eq(interpreter, lhs_result, rhs_result).as_bool());
+        return Value(!strict_eq(interpreter, lhs_result, rhs_result));
     case BinaryOp::AbstractEquals:
-        return eq(interpreter, lhs_result, rhs_result);
+        return Value(abstract_eq(interpreter, lhs_result, rhs_result));
     case BinaryOp::AbstractInequals:
-        return Value(!eq(interpreter, lhs_result, rhs_result).as_bool());
+        return Value(!abstract_eq(interpreter, lhs_result, rhs_result));
     case BinaryOp::GreaterThan:
         return greater_than(interpreter, lhs_result, rhs_result);
     case BinaryOp::GreaterThanEquals:
@@ -1444,7 +1443,7 @@ Value SwitchStatement::execute(Interpreter& interpreter) const
             auto test_result = switch_case.test()->execute(interpreter);
             if (interpreter.exception())
                 return {};
-            if (!eq(interpreter, discriminant_result, test_result).to_boolean())
+            if (!strict_eq(interpreter, discriminant_result, test_result))
                 continue;
         }
         falling_through = true;

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -344,7 +344,7 @@ Value ArrayPrototype::index_of(Interpreter& interpreter)
     auto search_element = interpreter.argument(0);
     for (i32 i = from_index; i < array_size; ++i) {
         auto& element = array->elements().at(i);
-        if (typed_eq(interpreter, element, search_element).as_bool())
+        if (strict_eq(interpreter, element, search_element))
             return Value(i);
     }
 
@@ -398,7 +398,7 @@ Value ArrayPrototype::last_index_of(Interpreter& interpreter)
     auto search_element = interpreter.argument(0);
     for (i32 i = array_size - 1; i >= from_index; --i) {
         auto& element = array->elements().at(i);
-        if (typed_eq(interpreter, element, search_element).as_bool())
+        if (strict_eq(interpreter, element, search_element))
             return Value(i);
     }
 
@@ -432,7 +432,7 @@ Value ArrayPrototype::includes(Interpreter& interpreter)
     auto value_to_find = interpreter.argument(0);
     for (i32 i = from_index; i < array_size; ++i) {
         auto& element = array->elements().at(i);
-        if (typed_eq(interpreter, element, value_to_find).as_bool())
+        if (same_value_zero(interpreter, element, value_to_find))
             return Value(true);
     }
 

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -131,18 +131,7 @@ Value ObjectConstructor::define_property(Interpreter& interpreter)
 
 Value ObjectConstructor::is(Interpreter& interpreter)
 {
-    auto value1 = interpreter.argument(0);
-    auto value2 = interpreter.argument(1);
-    if (value1.is_nan() && value2.is_nan())
-        return Value(true);
-    if (value1.is_number() && value1.as_double() == 0 && value2.is_number() && value2.as_double() == 0) {
-        if (value1.is_positive_zero() && value2.is_positive_zero())
-            return Value(true);
-        if (value1.is_negative_zero() && value2.is_negative_zero())
-            return Value(true);
-        return Value(false);
-    }
-    return typed_eq(interpreter, value1, value2);
+    return Value(same_value(interpreter, interpreter.argument(0), interpreter.argument(1)));
 }
 
 Value ObjectConstructor::keys(Interpreter& interpreter)

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -233,10 +233,14 @@ Value mul(Interpreter&, Value lhs, Value rhs);
 Value div(Interpreter&, Value lhs, Value rhs);
 Value mod(Interpreter&, Value lhs, Value rhs);
 Value exp(Interpreter&, Value lhs, Value rhs);
-Value eq(Interpreter&, Value lhs, Value rhs);
-Value typed_eq(Interpreter&, Value lhs, Value rhs);
 Value in(Interpreter&, Value lhs, Value rhs);
 Value instance_of(Interpreter&, Value lhs, Value rhs);
+
+bool abstract_eq(Interpreter&, Value lhs, Value rhs);
+bool strict_eq(Interpreter&, Value lhs, Value rhs);
+bool same_value(Interpreter&, Value lhs, Value rhs);
+bool same_value_zero(Interpreter&, Value lhs, Value rhs);
+bool same_value_non_numeric(Interpreter&, Value lhs, Value rhs);
 
 const LogStream& operator<<(const LogStream&, const Value&);
 

--- a/Libraries/LibJS/Tests/switch-basic.js
+++ b/Libraries/LibJS/Tests/switch-basic.js
@@ -1,4 +1,8 @@
+load("test-common.js");
+
 switch (1 + 2) {
+case '3':
+    assertNotReached();
 case 3:
     console.log("PASS");
     break;


### PR DESCRIPTION
The ECMAScript spec defines multiple equality operations which are used all over the spec; this patch introduces them. Of course, the two primary equality operations are `AbtractEquals` (`==`) and `StrictEquals` (`===`), which have been renamed to `abstract_eq` and `strict_eq` in this patch to improve clarity.

In support of the two operations mentioned above, the following have also been added: `SameValue`, `SameValueZero`, and `SameValueNonNumeric`. These are important to have, because they are used elsewhere in the spec aside from the two primary equality comparisons.