### PR TITLE
LibGfx: Handle filling complex shapes better

### DIFF
--- a/Libraries/LibGfx/Painter.cpp
+++ b/Libraries/LibGfx/Painter.cpp
@@ -1154,7 +1154,7 @@ void Painter::stroke_path(const Path& path, Color color, int thickness)
 
 void Painter::fill_path(Path& path, Color color, WindingRule winding_rule)
 {
-    const auto& segments = path.split_lines();
+    const auto& segments = path.split_lines(Path::Simple);
 
     if (segments.size() == 0)
         return;

--- a/Libraries/LibGfx/Path.h
+++ b/Libraries/LibGfx/Path.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
+#include <AK/Optional.h>
 #include <AK/Vector.h>
 #include <LibGfx/FloatPoint.h>
 #include <LibGfx/Forward.h>
@@ -68,7 +70,22 @@ public:
 
     void close();
 
+    struct LineSegment {
+        Point from, to;
+        float inverse_slope;
+        float x_of_minimum_y;
+        float maximum_y;
+        float minimum_y;
+        float x;
+    };
+
+    enum ShapeKind {
+        Simple,
+        Complex,
+    };
+
     const Vector<Segment>& segments() const { return m_segments; }
+    Vector<LineSegment> split_lines(ShapeKind);
     const auto& split_lines()
     {
         if (m_split_lines.has_value())
@@ -80,22 +97,34 @@ public:
 
     String to_string() const;
 
-    struct LineSegment {
-        Point from, to;
-        float inverse_slope;
-        float x_of_minimum_y;
-        float maximum_y;
-        float minimum_y;
-        float x;
-    };
-
 private:
-    void invalidate_split_lines() { m_split_lines.clear(); }
+    void invalidate_split_lines()
+    {
+        m_split_lines.clear();
+        m_graph_node_map.clear();
+    }
     void segmentize_path();
+    void generate_path_graph();
+    bool is_part_of_closed_polygon(const Point& p0, const Point& p1);
+    static unsigned hash_line(const Point& from, const Point& to);
 
     Vector<Segment> m_segments;
 
     Optional<Vector<LineSegment>> m_split_lines {};
+
+    struct PathGraphNode {
+        PathGraphNode(u32 hash, const LineSegment& line)
+            : hash(hash)
+            , line(line)
+        {
+        }
+
+        Vector<const PathGraphNode*> children;
+        u32 hash;
+        LineSegment line;
+    };
+
+    Optional<HashMap<u32, OwnPtr<PathGraphNode>>> m_graph_node_map;
 };
 
 inline const LogStream& operator<<(const LogStream& stream, const Path& path)


### PR DESCRIPTION
This allows the painter to render filled complex shapes better, by constructing a path graph for (interesting) intersecting lines and omitting lines from the containing segments if they are detected
to take no part in defining the edges of a shape.

This approach would still fail if there are multiple logical shapes that are confined to the collection of lines.
For instance, two polygons intersecting each other in a way that one vertex of polygon A ends up inside polygon B.
we would detect that polygon A's edges are part of the shape (technically correct) even though they are not a part of polygon B at all.

If there _is_ a better way to handle filling complex shapes, I'm interested in knowing about it.
Google yielded nothing of interest, and I found no academic resources on the matter (not locked behind a paywall) that presented a solution.
