### PR TITLE
LibGfx + LibWeb: Implement GIF animation

### DIFF
--- a/Libraries/LibGfx/GIFLoader.cpp
+++ b/Libraries/LibGfx/GIFLoader.cpp
@@ -528,4 +528,28 @@ bool GIFImageDecoderPlugin::sniff()
     BufferStream stream(buffer);
     return decode_gif_header(stream).has_value();
 }
+
+bool GIFImageDecoderPlugin::is_animated()
+{
+    return false;
+}
+
+size_t GIFImageDecoderPlugin::loop_count()
+{
+    return 0;
+}
+
+size_t GIFImageDecoderPlugin::frame_count()
+{
+    return 1;
+}
+
+ImageFrameDescriptor GIFImageDecoderPlugin::frame(size_t i)
+{
+    if (i > 0) {
+        return { bitmap(), 0 };
+    }
+    return {};
+}
+
 }

--- a/Libraries/LibGfx/GIFLoader.h
+++ b/Libraries/LibGfx/GIFLoader.h
@@ -46,6 +46,10 @@ public:
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile() override;
     virtual bool sniff() override;
+    virtual bool is_animated() override;
+    virtual size_t loop_count() override;
+    virtual size_t frame_count() override;
+    virtual ImageFrameDescriptor frame(size_t i) override;
 
 private:
     OwnPtr<GIFLoadingContext> m_context;

--- a/Libraries/LibGfx/ImageDecoder.h
+++ b/Libraries/LibGfx/ImageDecoder.h
@@ -26,14 +26,19 @@
 
 #pragma once
 
-#include <AK/NonnullRefPtr.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
 #include <LibGfx/Size.h>
 
 namespace Gfx {
 
 class Bitmap;
+
+struct ImageFrameDescriptor {
+    RefPtr<Bitmap> image;
+    int duration { 0 };
+};
 
 class ImageDecoderPlugin {
 public:
@@ -46,6 +51,11 @@ public:
     [[nodiscard]] virtual bool set_nonvolatile() = 0;
 
     virtual bool sniff() = 0;
+
+    virtual bool is_animated() = 0;
+    virtual size_t loop_count() = 0;
+    virtual size_t frame_count() = 0;
+    virtual ImageFrameDescriptor frame(size_t i) = 0;
 
 protected:
     ImageDecoderPlugin() {}
@@ -62,7 +72,11 @@ public:
     RefPtr<Gfx::Bitmap> bitmap() const;
     void set_volatile() { m_plugin->set_volatile(); }
     [[nodiscard]] bool set_nonvolatile() { return m_plugin->set_nonvolatile(); }
-    bool sniff() { return m_plugin->sniff(); };
+    bool sniff() const { return m_plugin->sniff(); }
+    bool is_animated() const { return m_plugin->is_animated(); }
+    size_t loop_count() const { return m_plugin->loop_count(); }
+    size_t frame_count() const { return m_plugin->frame_count(); }
+    ImageFrameDescriptor frame(size_t i) const { return m_plugin->frame(i); }
 
 private:
     ImageDecoder(const u8*, size_t);

--- a/Libraries/LibGfx/PNGLoader.cpp
+++ b/Libraries/LibGfx/PNGLoader.cpp
@@ -834,4 +834,27 @@ bool PNGImageDecoderPlugin::sniff()
     return decode_png_header(*m_context);
 }
 
+bool PNGImageDecoderPlugin::is_animated()
+{
+    return false;
+}
+
+size_t PNGImageDecoderPlugin::loop_count()
+{
+    return 0;
+}
+
+size_t PNGImageDecoderPlugin::frame_count()
+{
+    return 1;
+}
+
+ImageFrameDescriptor PNGImageDecoderPlugin::frame(size_t i)
+{
+    if (i > 0) {
+        return { bitmap(), 0 };
+    }
+    return {};
+}
+
 }

--- a/Libraries/LibGfx/PNGLoader.h
+++ b/Libraries/LibGfx/PNGLoader.h
@@ -46,6 +46,10 @@ public:
     virtual void set_volatile() override;
     [[nodiscard]] virtual bool set_nonvolatile() override;
     virtual bool sniff() override;
+    virtual bool is_animated() override;
+    virtual size_t loop_count() override;
+    virtual size_t frame_count() override;
+    virtual ImageFrameDescriptor frame(size_t i) override;
 
 private:
     OwnPtr<PNGLoadingContext> m_context;

--- a/Libraries/LibWeb/DOM/HTMLImageElement.h
+++ b/Libraries/LibWeb/DOM/HTMLImageElement.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <LibCore/Forward.h>
 #include <LibGfx/Forward.h>
 #include <LibWeb/DOM/HTMLElement.h>
 
@@ -56,10 +57,16 @@ public:
 private:
     void load_image(const String& src);
 
+    void animate();
+
     virtual RefPtr<LayoutNode> create_layout_node(const StyleProperties* parent_style) const override;
 
     RefPtr<Gfx::ImageDecoder> m_image_decoder;
     ByteBuffer m_encoded_data;
+
+    size_t m_current_frame_index { 0 };
+    size_t m_loops_completed { 0 };
+    NonnullRefPtr<Core::Timer> m_timer;
 };
 
 template<>


### PR DESCRIPTION
This PR:
- LibGfx: Add methods applicable to animated images to ImageDecoder and ImageDecoderPlugin interfaces.
- LibGfx: Implement animated image methods for GIFImageDecoderPlugin and optimise LZWDecoder a little.
- LibWeb: Add support for animated images to HTMLImageElement.

Upshot: animated GIFs are now displayed in the browser. Includes support for variable delays between frames, and single-loop GIFs.

![SerenityGIFs](https://user-images.githubusercontent.com/328124/81406334-45e0b200-9131-11ea-8af9-92ca6292f6c7.gif)

Things to pay particular attention to:
- Animation methods added to ImageDecoder{Plugin} interfaces: felt like the right place to put them but happy to consider alternative approaches.
- Decoding is done lazily but is quite slow and memory-intensive. I intend to optimise in a follow-up PR but can do it here if requested.