### PR TITLE
LibJS: Tiny fix to make it build on Clang 10

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -151,7 +151,7 @@ Value CallExpression::execute(Interpreter& interpreter) const
                 for (auto ch : static_cast<const StringObject&>(value.as_object()).primitive_string().string())
                     iterables.append(Value(js_string(interpreter, String::format("%c", ch))));
             } else {
-                interpreter.throw_exception<TypeError>(String::format("%s is not iterable", value.to_string()));
+                interpreter.throw_exception<TypeError>(String::format("%s is not iterable", value.to_string().characters()));
             }
             for (auto& value : iterables)
                 arguments.append(value);

--- a/Libraries/LibJS/Heap/Heap.cpp
+++ b/Libraries/LibJS/Heap/Heap.cpp
@@ -135,7 +135,7 @@ void Heap::gather_conservative_roots(HashTable<Cell*>& roots)
 
     const FlatPtr* raw_jmp_buf = reinterpret_cast<const FlatPtr*>(buf);
 
-    for (size_t i = 0; i < sizeof(buf) / sizeof(FlatPtr); i += sizeof(FlatPtr))
+    for (size_t i = 0; i < ((size_t)sizeof(buf)) / sizeof(FlatPtr); i += sizeof(FlatPtr))
         possible_pointers.set(raw_jmp_buf[i]);
 
     FlatPtr stack_base;


### PR DESCRIPTION
I _did_ mention this awhile back, that clang didn't like dividing `sizeof(jmp_buf)` with something other than `sizeof(jmp_buf[0])`; this fixes that with essentially a no-op cast.

Also fixes a little bug in LibJS/AST where someone was passing a String as a vararg to String::format
Not sure how GCC was fine with that at all.