### PR TITLE
MenuManager event handling & menu 'search'

### DIFF
--- a/Applications/Calculator/CalculatorWidget.cpp
+++ b/Applications/Calculator/CalculatorWidget.cpp
@@ -232,8 +232,8 @@ void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
     if (event.key() == KeyCode::Key_Return) {
         m_keypad.set_value(m_calculator.finish_operation(m_keypad.value()));
 
-    } else if (event.key() >= KeyCode::Key_0 && event.key() <= KeyCode::Key_9) {
-        m_keypad.type_digit(atoi(event.text().characters()));
+    } else if (event.is_numeric()) {
+        m_keypad.type_digit(event.to_number());
 
     } else if (event.key() == KeyCode::Key_Period) {
         m_keypad.type_decimal_point();

--- a/Libraries/LibGUI/Event.h
+++ b/Libraries/LibGUI/Event.h
@@ -278,6 +278,22 @@ public:
     u8 modifiers() const { return m_modifiers; }
     String text() const { return m_text; }
 
+    bool is_alpha() const { return m_key >= Key_A && m_key <= Key_Z; }
+    bool is_numeric() const { return m_key >= Key_0 && m_key <= Key_9; }
+    bool is_alphanumeric() const { return is_alpha() || is_numeric(); }
+    bool is_hex() const { return is_numeric() || (m_key >= KeyCode::Key_A && m_key <= KeyCode::Key_F); }
+
+    int to_number() const
+    {
+        ASSERT(is_numeric());
+        return m_key - Key_0;
+    }
+    int to_hex() const
+    {
+        ASSERT(is_hex());
+        return is_numeric() ? to_number() : m_key - KeyCode::Key_A + 0xA;
+    }
+
 private:
     friend class WindowServerConnection;
     int m_key { 0 };

--- a/Services/WindowServer/Event.h
+++ b/Services/WindowServer/Event.h
@@ -92,6 +92,10 @@ public:
     u8 modifiers() const { return m_modifiers; }
     char character() const { return m_character; }
 
+    bool is_alpha() const { return m_key >= Key_A && m_key <= Key_Z; }
+    bool is_numeric() const { return m_key >= Key_0 && m_key <= Key_9; }
+    bool is_alphanumeric() const { return is_alpha() || is_numeric(); }
+
 private:
     friend class EventLoop;
     friend class Screen;

--- a/Services/WindowServer/Menu.h
+++ b/Services/WindowServer/Menu.h
@@ -104,13 +104,20 @@ public:
     void redraw();
 
     MenuItem* hovered_item() const;
+
+    void set_hovered_item(int index)
+    {
+        m_hovered_item_index = index;
+        update_for_new_hovered_item();
+    }
+
     void clear_hovered_item();
 
     Function<void(MenuItem&)> on_item_activation;
 
     void close();
 
-    void popup(const Gfx::Point&, bool is_submenu = false);
+    void popup(const Gfx::Point&);
 
     bool is_menu_ancestor_of(const Menu&) const;
 
@@ -118,6 +125,9 @@ public:
 
     bool is_scrollable() const { return m_scrollable; }
     int scroll_offset() const { return m_scroll_offset; }
+
+    void descend_into_submenu_at_hovered_item();
+    void open_hovered_item();
 
 private:
     virtual void event(Core::Event&) override;
@@ -130,9 +140,7 @@ private:
     int item_index_at(const Gfx::Point&);
     int padding_between_text_and_shortcut() const { return 50; }
     void did_activate(MenuItem&);
-    void open_hovered_item();
     void update_for_new_hovered_item();
-    void descend_into_submenu_at_hovered_item();
 
     ClientConnection* m_client { nullptr };
     int m_menu_id { 0 };
@@ -148,7 +156,6 @@ private:
     Gfx::Point m_last_position_in_hover;
     int m_theme_index_at_last_paint { -1 };
     int m_hovered_item_index { -1 };
-    bool m_in_submenu { false };
 
     bool m_scrollable { false };
     int m_scroll_offset { 0 };

--- a/Services/WindowServer/MenuManager.cpp
+++ b/Services/WindowServer/MenuManager.cpp
@@ -42,6 +42,7 @@
 namespace WindowServer {
 
 static MenuManager* s_the;
+static constexpr int s_search_timeout = 3000;
 
 MenuManager& MenuManager::the()
 {
@@ -59,6 +60,10 @@ MenuManager::MenuManager()
 
     m_window = Window::construct(*this, WindowType::Menubar);
     m_window->set_rect(menubar_rect());
+
+    m_search_timer = Core::Timer::create_single_shot(0, [this] {
+        m_current_search.clear();
+    });
 }
 
 MenuManager::~MenuManager()
@@ -130,6 +135,26 @@ void MenuManager::event(Core::Event& event)
 
         if (key_event.type() == Event::KeyUp && key_event.key() == Key_Escape) {
             close_everyone();
+            return;
+        }
+
+        if (key_event.key() == Key_Backspace) {
+            if (m_current_menu)
+                m_current_menu->clear_hovered_item();
+            m_current_search.clear();
+            return;
+        }
+
+        if (m_current_menu && key_event.is_alphanumeric() && event.type() == Event::KeyDown) {
+            m_current_search.append(key_event.character());
+            m_search_timer->restart(s_search_timeout);
+            for (int i = 0; i < m_current_menu->item_count(); ++i) {
+                auto text = m_current_menu->item(i).text();
+                if (text.to_lowercase().starts_with(m_current_search.to_string().to_lowercase())) {
+                    m_current_menu->set_hovered_item(i);
+                    return;
+                }
+            }
             return;
         }
 
@@ -284,6 +309,7 @@ void MenuManager::close_everyone()
         menu->clear_hovered_item();
     }
     m_open_menu_stack.clear();
+    m_current_search.clear();
     m_current_menu = nullptr;
     refresh();
 }
@@ -381,6 +407,7 @@ void MenuManager::set_current_menu(Menu* menu)
         return;
     }
 
+    m_current_search.clear();
     m_current_menu = menu->make_weak_ptr();
 }
 

--- a/Services/WindowServer/MenuManager.h
+++ b/Services/WindowServer/MenuManager.h
@@ -30,7 +30,9 @@
 #include "MenuBar.h"
 #include "Window.h"
 #include <AK/HashMap.h>
+#include <AK/StringBuilder.h>
 #include <LibCore/Object.h>
+#include <LibCore/Timer.h>
 
 namespace WindowServer {
 
@@ -110,6 +112,8 @@ private:
     WeakPtr<Menu> m_current_menu;
     Vector<WeakPtr<Menu>> m_open_menu_stack;
 
+    RefPtr<Core::Timer> m_search_timer;
+    StringBuilder m_current_search;
     WeakPtr<Menu> m_system_menu;
 
     bool m_needs_window_resize { false };

--- a/Services/WindowServer/MenuManager.h
+++ b/Services/WindowServer/MenuManager.h
@@ -53,8 +53,8 @@ public:
     void set_needs_window_resize();
 
     Menu* current_menu() { return m_current_menu.ptr(); }
-    void set_current_menu(Menu*, bool is_submenu = false);
-    void open_menu(Menu&);
+    void set_current_menu(Menu*);
+    void open_menu(Menu&, bool as_current_menu = true);
     void toggle_menu(Menu&);
 
     MenuBar* current_menubar() { return m_current_menubar.ptr(); }

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -423,7 +423,6 @@ void WindowManager::start_window_resize(Window& window, const Gfx::Point& positi
 #endif
     m_resizing_mouse_button = button;
     m_resize_window = window.make_weak_ptr();
-    ;
     m_resize_origin = position;
     m_resize_window_original_rect = window.rect();
 


### PR DESCRIPTION
Clean up some of the spaghetti I had written in menu manager event handling which I wasn't very happy with that also fixes some inconsistencies.

Add basic menu search where you can type in the menu item name and jump to that item in the menu.

I figured I would also add in some helpers for KeyEvents as well instead of having that scattered around in Application logic.