### PR TITLE
LibVT: RGB; Shell: basic syntax highlighting and some improvements; LibLine: Expose actual_rendered_string_length

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -1031,6 +1031,11 @@ size_t Editor::actual_rendered_string_length(const StringView& string) const
                 state = Escape;
                 continue;
             }
+            if (c == '\r' || c == '\n') {
+                // reset length to 0, since we either overwrite, or are on a newline
+                length = 0;
+                continue;
+            }
             // FIXME: This will not support anything sophisticated
             ++length;
             break;

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -130,6 +130,7 @@ public:
     const Vector<String>& history() const { return m_history; }
 
     void register_character_input_callback(char ch, Function<bool(Editor&)> callback);
+    size_t actual_rendered_string_length(const StringView& string) const;
 
     Function<Vector<CompletionSuggestion>(const String&)> on_tab_complete_first_token;
     Function<Vector<CompletionSuggestion>(const String&)> on_tab_complete_other_token;
@@ -251,8 +252,6 @@ private:
     {
         return (m_drawn_cursor + current_prompt_length()) % m_num_columns;
     }
-
-    size_t actual_rendered_string_length(const StringView& string) const;
 
     void set_origin()
     {

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -31,12 +31,13 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibVT/Position.h>
+#include <LibVT/XtermColors.h>
 
 namespace VT {
 
 class TerminalClient {
 public:
-    virtual ~TerminalClient() {}
+    virtual ~TerminalClient() { }
 
     virtual void beep() = 0;
     virtual void set_window_title(const StringView&) = 0;
@@ -48,8 +49,8 @@ public:
 struct Attribute {
     Attribute() { reset(); }
 
-    static const u8 default_foreground_color = 7;
-    static const u8 default_background_color = 0;
+    static const u32 default_foreground_color = xterm_colors[7];
+    static const u32 default_background_color = xterm_colors[0];
 
     void reset()
     {
@@ -57,8 +58,8 @@ struct Attribute {
         background_color = default_background_color;
         flags = Flags::NoAttributes;
     }
-    u8 foreground_color;
-    u8 background_color;
+    u32 foreground_color;
+    u32 background_color;
 
     String href;
     String href_id;
@@ -110,6 +111,7 @@ public:
     struct Line {
         AK_MAKE_NONCOPYABLE(Line);
         AK_MAKE_NONMOVABLE(Line);
+
     public:
         explicit Line(u16 columns);
         ~Line();

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -146,9 +146,9 @@ TerminalWidget::~TerminalWidget()
 {
 }
 
-static inline Color lookup_color(unsigned color)
+static inline Color color_from_rgb(unsigned color)
 {
-    return Color::from_rgb(xterm_colors[color]);
+    return Color::from_rgb(color);
 }
 
 Gfx::Rect TerminalWidget::glyph_rect(u16 row, u16 column)
@@ -349,7 +349,7 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
         if (m_visual_beep_timer->is_active())
             painter.clear_rect(row_rect, Color::Red);
         else if (has_only_one_background_color)
-            painter.clear_rect(row_rect, lookup_color(line.attributes[0].background_color).with_alpha(m_opacity));
+            painter.clear_rect(row_rect, color_from_rgb(line.attributes[0].background_color).with_alpha(m_opacity));
 
         // The terminal insists on thinking characters and
         // bytes are the same thing. We want to still draw
@@ -385,14 +385,14 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
                 auto character_rect = glyph_rect(row, column);
                 auto cell_rect = character_rect.inflated(0, m_line_spacing);
                 if (!has_only_one_background_color || should_reverse_fill_for_cursor_or_selection) {
-                    painter.clear_rect(cell_rect, lookup_color(should_reverse_fill_for_cursor_or_selection ? attribute.foreground_color : attribute.background_color).with_alpha(m_opacity));
+                    painter.clear_rect(cell_rect, color_from_rgb(should_reverse_fill_for_cursor_or_selection ? attribute.foreground_color : attribute.background_color).with_alpha(m_opacity));
                 }
 
                 bool should_paint_underline = attribute.flags & VT::Attribute::Underline
                     || (!m_hovered_href.is_empty() && m_hovered_href_id == attribute.href_id);
 
                 if (should_paint_underline)
-                    painter.draw_line(cell_rect.bottom_left(), cell_rect.bottom_right(), lookup_color(should_reverse_fill_for_cursor_or_selection ? attribute.background_color : attribute.foreground_color));
+                    painter.draw_line(cell_rect.bottom_left(), cell_rect.bottom_right(), color_from_rgb(should_reverse_fill_for_cursor_or_selection ? attribute.background_color : attribute.foreground_color));
             }
 
             if (codepoint == ' ')
@@ -405,7 +405,7 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
                 character_rect.location(),
                 codepoint,
                 attribute.flags & VT::Attribute::Bold ? bold_font() : font(),
-                lookup_color(should_reverse_fill_for_cursor_or_selection ? attribute.background_color : attribute.foreground_color));
+                color_from_rgb(should_reverse_fill_for_cursor_or_selection ? attribute.background_color : attribute.foreground_color));
         }
     }
 
@@ -413,7 +413,7 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
         auto& cursor_line = line_for_visual_row(row_with_cursor);
         if (m_terminal.cursor_row() < (m_terminal.rows() - rows_from_history)) {
             auto cell_rect = glyph_rect(row_with_cursor, m_terminal.cursor_column()).inflated(0, m_line_spacing);
-            painter.draw_rect(cell_rect, lookup_color(cursor_line.attributes[m_terminal.cursor_column()].foreground_color));
+            painter.draw_rect(cell_rect, color_from_rgb(cursor_line.attributes[m_terminal.cursor_column()].foreground_color));
         }
     }
 }

--- a/Libraries/LibVT/XtermColors.h
+++ b/Libraries/LibVT/XtermColors.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-static const unsigned xterm_colors[256] = {
+static constexpr unsigned xterm_colors[256] = {
     0x000000,
     0xcc0000,
     0x3e9a06,

--- a/Shell/Parser.cpp
+++ b/Shell/Parser.cpp
@@ -86,6 +86,19 @@ Vector<Command> Parser::parse()
         char ch = m_input.characters()[i];
         switch (state()) {
         case State::Free:
+            if (ch == '#') {
+                commit_token(Token::Bare);
+
+                while (i < m_input.length()) {
+                    ch = m_input.characters()[++i];
+                    ++m_position;
+                    if (ch == '\n')
+                        break;
+                    m_token.append(ch);
+                }
+                commit_token(Token::Comment);
+                break;
+            }
             if (ch == ' ') {
                 commit_token(Token::Bare);
                 break;

--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -36,6 +36,7 @@ struct Token {
         DoubleQuoted,
         UnterminatedSingleQuoted,
         UnterminatedDoubleQuoted,
+        Comment,
         Special,
     };
     String text;

--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -29,6 +29,21 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 
+struct Token {
+    enum Type {
+        Bare,
+        SingleQuoted,
+        DoubleQuoted,
+        UnterminatedSingleQuoted,
+        UnterminatedDoubleQuoted,
+        Special,
+    };
+    String text;
+    size_t end;
+    size_t length;
+    Type type;
+};
+
 struct Redirection {
     enum Type {
         Pipe,
@@ -48,7 +63,7 @@ struct Rewiring {
 };
 
 struct Subcommand {
-    Vector<String> args;
+    Vector<Token> args;
     Vector<Redirection> redirections;
     Vector<Rewiring> rewirings;
 };
@@ -71,7 +86,7 @@ private:
         No,
         Yes,
     };
-    void commit_token(AllowEmptyToken = AllowEmptyToken::No);
+    void commit_token(Token::Type, AllowEmptyToken = AllowEmptyToken::No);
     void commit_subcommand();
     void commit_command();
     void do_pipe();
@@ -105,7 +120,8 @@ private:
 
     Vector<Command> m_commands;
     Vector<Subcommand> m_subcommands;
-    Vector<String> m_tokens;
+    Vector<Token> m_tokens;
     Vector<Redirection> m_redirections;
     Vector<char> m_token;
+    size_t m_position { 0 };
 };

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -782,6 +782,9 @@ static Vector<String> process_arguments(const Vector<Token>& args)
 {
     Vector<String> argv_string;
     for (auto& arg : args) {
+        if (arg.type == Token::Comment)
+            continue;
+
         // This will return the text passed in if it wasn't a variable
         // This lets us just loop over its values
         auto expanded_parameters = expand_parameters(arg.text);
@@ -861,6 +864,9 @@ static ExitCodeOrContinuationRequest run_command(const StringView& cmd)
                     dbgprintf("\"<%s> ", arg.text.characters());
                     break;
                 case Token::Special:
+                    dbgprintf("<%s> ", arg.text.characters());
+                    break;
+                case Token::Comment:
                     dbgprintf("<%s> ", arg.text.characters());
                     break;
                 }

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -541,10 +541,10 @@ int main(int argc, char** argv)
                 switch (token.type()) {
                 case JS::TokenType::Invalid:
                 case JS::TokenType::Eof:
-                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::Color::Red), Line::Style::Underline });
+                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::XtermColor::Red), Line::Style::Underline });
                     break;
                 case JS::TokenType::NumericLiteral:
-                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::Color::Magenta) });
+                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::XtermColor::Magenta) });
                     break;
                 case JS::TokenType::StringLiteral:
                 case JS::TokenType::TemplateLiteralStart:
@@ -552,7 +552,7 @@ int main(int argc, char** argv)
                 case JS::TokenType::TemplateLiteralString:
                 case JS::TokenType::RegexLiteral:
                 case JS::TokenType::UnterminatedStringLiteral:
-                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::Color::Green), Line::Style::Bold });
+                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::XtermColor::Green), Line::Style::Bold });
                     break;
                 case JS::TokenType::BracketClose:
                 case JS::TokenType::BracketOpen:
@@ -609,7 +609,7 @@ int main(int argc, char** argv)
                     break;
                 case JS::TokenType::BoolLiteral:
                 case JS::TokenType::NullLiteral:
-                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::Color::Yellow), Line::Style::Bold });
+                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::XtermColor::Yellow), Line::Style::Bold });
                     break;
                 case JS::TokenType::Class:
                 case JS::TokenType::Const:
@@ -627,7 +627,7 @@ int main(int argc, char** argv)
                 case JS::TokenType::Typeof:
                 case JS::TokenType::Var:
                 case JS::TokenType::Void:
-                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::Color::Blue), Line::Style::Bold });
+                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::XtermColor::Blue), Line::Style::Bold });
                     break;
                 case JS::TokenType::Await:
                 case JS::TokenType::Case:
@@ -642,10 +642,10 @@ int main(int argc, char** argv)
                 case JS::TokenType::Try:
                 case JS::TokenType::While:
                 case JS::TokenType::Yield:
-                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::Color::Cyan), Line::Style::Italic });
+                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::XtermColor::Cyan), Line::Style::Italic });
                     break;
                 case JS::TokenType::Identifier:
-                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::Color::White), Line::Style::Bold });
+                    stylize({ start, end }, { Line::Style::Foreground(Line::Style::XtermColor::White), Line::Style::Bold });
                 default:
                     break;
                 }


### PR DESCRIPTION
![shot-2020-05-10_12-39-23](https://user-images.githubusercontent.com/14001776/81494102-4d33c700-92bb-11ea-944d-511f0d696a4a.jpg)

The most catch-all of catch-all PRs.
If separate reviews are needed, I can split this up no problem :)

- LibVT: Support RGB
- LibLine: Support RGB
- Shell: parse comments too
- Shell: wait until there's a complete command before running it
- Shell: highlight stuff

c.c. @bugaevc 

I'm not so sure about the colours, suggestions are welcome.