### PR TITLE
LibGfx: Fix build with FILL_PATH_DEBUG enabled

### DIFF
--- a/Libraries/LibGfx/Painter.cpp
+++ b/Libraries/LibGfx/Painter.cpp
@@ -1298,7 +1298,7 @@ void Painter::fill_path(Path& path, Color color, WindingRule winding_rule)
 #ifdef FILL_PATH_DEBUG
     size_t i { 0 };
     for (auto& segment : segments)
-        draw_line(segment.from, segment.to, Color::from_hsv(++i / segments.size() * 255, 255, 255), 1);
+        draw_line(Point(segment.from.x(), segment.from.y()), Point(segment.to.x(), segment.to.y()), Color::from_hsv(++i / segments.size() * 255, 255, 255), 1);
 #endif
 }
 


### PR DESCRIPTION
```
Painter.cpp: In member function 'void Gfx::Painter::fill_path(Gfx::Path&, Gfx::Color, Gfx::Painter::WindingRule)':
Painter.cpp:1301:27: error: cannot convert 'const Gfx::FloatPoint' to 'const Gfx::Point&'
 1301 |         draw_line(segment.from, segment.to, Color::from_hsv(++i / segments.size() * 255, 255, 255), 1);
      |                   ~~~~~~~~^~~~
      |                           |
      |                           const Gfx::FloatPoint
Painter.cpp:949:38: note:   initializing argument 1 of 'void Gfx::Painter::draw_line(const Gfx::Point&, const Gfx::Point&, Gfx::Color, int, bool)'
  949 | void Painter::draw_line(const Point& p1, const Point& p2, Color color, int thickness, bool dotted)
      |                         ~~~~~~~~~~~~~^~
```