### PR TITLE
LibWeb: Implicitly close all subpaths when trying to do canvas.fill

### DIFF
--- a/Libraries/LibGfx/Path.h
+++ b/Libraries/LibGfx/Path.h
@@ -69,6 +69,7 @@ public:
     }
 
     void close();
+    void close_all_subpaths();
 
     struct LineSegment {
         FloatPoint from, to;

--- a/Libraries/LibWeb/DOM/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/DOM/CanvasRenderingContext2D.cpp
@@ -185,7 +185,9 @@ void CanvasRenderingContext2D::fill(Gfx::Painter::WindingRule winding)
     if (!painter)
         return;
 
-    painter->fill_path(m_path, m_fill_style, winding);
+    auto path = m_path;
+    path.close_all_subpaths();
+    painter->fill_path(path, m_fill_style, winding);
 }
 
 RefPtr<ImageData> CanvasRenderingContext2D::create_image_data(JS::GlobalObject& global_object, int width, int height) const


### PR DESCRIPTION
Well...that was rather painless...

closes #2172

