### PR TITLE
LibC: Fix get{sock,peer}name to match their kernel-side prototypes

### DIFF
--- a/Libraries/LibC/sys/socket.cpp
+++ b/Libraries/LibC/sys/socket.cpp
@@ -108,13 +108,15 @@ int setsockopt(int sockfd, int level, int option, const void* value, socklen_t v
 
 int getsockname(int sockfd, struct sockaddr* addr, socklen_t* addrlen)
 {
-    int rc = syscall(SC_getsockname, sockfd, addr, addrlen);
+    Syscall::SC_getsockname_params params { sockfd, addr, addrlen };
+    int rc = syscall(SC_getsockname, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
 int getpeername(int sockfd, struct sockaddr* addr, socklen_t* addrlen)
 {
-    int rc = syscall(SC_getpeername, sockfd, addr, addrlen);
+    Syscall::SC_getpeername_params params { sockfd, addr, addrlen };
+    int rc = syscall(SC_getpeername, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 }


### PR DESCRIPTION
In f4302b58fb0, the kernel-side syscalls (e.g `Process::sys$getsockname`)
were updated to use SC_get{sock,peer}name_params, but the libc functions were not updated.

Found this while working on a dropbear port (which will be ready in following
days, hopefully): this call was failing with `EFAULT` (was trying to read `params` from the "address" encoded in `sockfd`. I guess the NULL page is not mapped in Serenity ^^. Or maybe it did read it and failed with `params->addr`).