### PR TITLE
Ports: Add dash shell

### DIFF
--- a/Ports/dash/package.sh
+++ b/Ports/dash/package.sh
@@ -1,0 +1,8 @@
+#!/bin/bash ../.port_include.sh
+port=dash
+version=0.5.10.2
+useconfigure=true
+configopts="--enable-static"
+files="http://gondor.apana.org.au/~herbert/dash/files/dash-${version}.tar.gz dash-${version}.tar.gz
+http://gondor.apana.org.au/~herbert/dash/files/dash-${version}.tar.gz.sha256sum dash-${version}.tar.gz.sha256sum"
+auth_type="sha256"

--- a/Ports/dash/patches/fix-jobs.patch
+++ b/Ports/dash/patches/fix-jobs.patch
@@ -1,0 +1,11 @@
+--- dash-0.5.10.2/src/jobs.c.orig	Sun May 10 01:20:24 2020
++++ dash-0.5.10.2/src/jobs.c	Sun May 10 01:20:58 2020
+@@ -1147,7 +1147,7 @@
+ 
+ 	do {
+ 		gotsigchld = 0;
+-		err = wait3(status, flags, NULL);
++		err = waitpid(-1, status, flags);
+ 		if (err || !block)
+ 			break;
+ 

--- a/Ports/dash/patches/fix-shell.patch
+++ b/Ports/dash/patches/fix-shell.patch
@@ -1,0 +1,17 @@
+--- dash-0.5.10.2/src/shell.h.orig	Sun Sep 28 04:19:32 2014
++++ dash-0.5.10.2/src/shell.h	Fri Apr 24 18:25:38 2020
+@@ -51,6 +51,14 @@
+ 
+ #include <sys/param.h>
+ 
++#ifndef PATH_MAX
++#define PATH_MAX 4096
++#endif
++
++#ifndef NAME_MAX
++#define NAME_MAX 1024
++#endif
++
+ #ifndef JOBS
+ #define JOBS 1
+ #endif

--- a/Ports/dash/patches/fix-system.patch
+++ b/Ports/dash/patches/fix-system.patch
@@ -1,0 +1,79 @@
+--- dash-0.5.10.2/src/system.c.orig	Sun May 10 01:45:02 2020
++++ dash-0.5.10.2/src/system.c	Sun May 10 01:50:52 2020
+@@ -131,64 +131,64 @@
+ 
+ #ifndef HAVE_ISALPHA
+ int isalnum(int c) {
+-	return _isalnum(c);
++	return (_ctype_[(int)(c)] & (_U | _L | _N));
+ }
+ 
+ 
+ int iscntrl(int c) {
+-	return _iscntrl(c);
++	return (_ctype_[(int)(c)] & (_C));
+ }
+ 
+ 
+ int islower(int c) {
+-	return _islower(c);
++	return ((_ctype_[(int)(c)] & (_U | _L)) == _L);
+ }
+ 
+ 
+ int isspace(int c) {
+-	return _isspace(c);
++	return (_ctype_[(int)(c)] & (_S));
+ }
+ 
+ 
+ int isalpha(int c) {
+-	return _isalpha(c);
++	return (_ctype_[(int)(c)] & (_U | _L));
+ }
+ 
+ 
+ int isdigit(int c) {
+-	return _isdigit(c);
++	return (_ctype_[(int)(c)] & (_N));
+ }
+ 
+ 
+ int isprint(int c) {
+-	return _isprint(c);
++	return (_ctype_[(int)(c)] & (_P | _U | _L | _N | _B));
+ }
+ 
+ 
+ int isupper(int c) {
+-	return _isupper(c);
++	return ((_ctype_[(int)(c)] & (_U | _L)) == _U);
+ }
+ 
+ 
+ #if HAVE_DECL_ISBLANK
+ int isblank(int c) {
+-	return _isblank(c);
++	return (c == ' ' || c == '\t');
+ }
+ #endif
+ 
+ 
+ int isgraph(int c) {
+-	return _isgraph(c);
++	return (_ctype_[(int)(c)] & (_P | _U | _L | _N));
+ }
+ 
+ 
+ int ispunct(int c) {
+-	return _ispunct(c);
++	return (_ctype_[(int)(c)] & (_P));
+ }
+ 
+ 
+ int isxdigit(int c) {
+-	return _isxdigit(c);
++	return (_ctype_[(int)(c)] & (_N | _X));
+ }
+ #endif
+ 


### PR DESCRIPTION
Hello --

Here is a port of the Debian Almquist shell. I have found it to be more stable than bash on Serenity (though without many of the bells and whistles). It is good to have dash anyway so that pure POSIX shell scripting can be easily tested on Serenity.

Some notes:
* Serenity doesn't implement wait3 (it is non-POSIX) but there is an easy conversion from wait3 to waitpid.
* I cannot for whatever reason get ports to notice the defines for PATH_MAX et al. Maybe it is some weirdness building ports on OpenBSD.
* The isctype macros do not get picked up by the configure script so some hackiness is needed. dash is not the only place I have noticed this. isblank() isn't implemented in Serenity.