### PR TITLE
Ports: Add tr utility

### DIFF
--- a/Ports/tr/package.sh
+++ b/Ports/tr/package.sh
@@ -1,0 +1,5 @@
+#!/bin/bash ../.port_include.sh
+port=tr
+version=6.7
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/tr-${version}.tar.gz tr-${version}.tar.gz"
+depends=libpuffy

--- a/Ports/tr/patches/fix-Makefile.patch
+++ b/Ports/tr/patches/fix-Makefile.patch
@@ -1,0 +1,12 @@
+--- tr-6.7/Makefile.orig	Sun May 10 10:31:10 2020
++++ tr-6.7/Makefile	Sun May 10 10:31:45 2020
+@@ -6,5 +6,9 @@
+ all: ${OBJS}
+ 	${CC} ${LDFLAGS} -o ${PROG} ${OBJS} -L/usr/local/lib -lpuffy
+ 
++install:
++	install -c -m 755 tr ${DESTDIR}/usr/local/bin
++	install -c -m 644 tr.1 ${DESTDIR}/usr/local/share/man/man1
++
+ clean:
+ 	rm -f ${PROG} ${OBJS}

--- a/Ports/tr/patches/fix-str.patch
+++ b/Ports/tr/patches/fix-str.patch
@@ -1,0 +1,93 @@
+--- tr-6.7/str.c.orig	Sun May 10 10:17:16 2020
++++ tr-6.7/str.c	Sun May 10 10:25:37 2020
+@@ -147,6 +147,90 @@
+ 	int *set;
+ } CLASS;
+ 
++#undef isalnum
++#undef isalpha
++#undef iscntrl
++#undef isdigit
++#undef isgraph
++#undef islower
++#undef isprint
++#undef ispunct
++#undef isspace
++#undef isupper
++#undef isxdigit
++
++int
++isalnum(int c)
++{
++	return (_ctype_[(int)(c)] & (_U | _L | _N));
++}
++
++int
++isalpha(int c)
++{
++	return (_ctype_[(int)(c)] & (_U | _L));
++}
++
++int
++isblank(int c)
++{
++	return (c == ' ' || c == '\t');
++}
++
++int
++iscntrl(int c)
++{
++	return (_ctype_[(int)(c)] & (_C));
++}
++
++int
++isdigit(int c)
++{
++	return (_ctype_[(int)(c)] & (_N));
++}
++
++int
++isgraph(int c)
++{
++	return (_ctype_[(int)(c)] & (_P | _U | _L | _N));
++}
++
++int
++islower(int c)
++{
++	return ((_ctype_[(int)(c)] & (_U | _L)) == _L);
++}
++
++int
++isprint(int c)
++{
++	return (_ctype_[(int)(c)] & (_P | _U | _L | _N | _B));
++}
++
++int
++ispunct(int c)
++{
++	return (_ctype_[(int)(c)] & (_P));
++}
++
++int
++isspace(int c)
++{
++	return (_ctype_[(int)(c)] & (_S));
++}
++
++int
++isupper(int c)
++{
++	return ((_ctype_[(int)(c)] & (_U | _L)) == _U);
++}
++
++int
++isxdigit(int c)
++{
++	return (_ctype_[(int)(c)] & (_N | _X));
++}
++
+ static CLASS classes[] = {
+ 	{ "alnum",  isalnum,  },
+ 	{ "alpha",  isalpha,  },

--- a/Ports/tr/patches/fix-tr.patch
+++ b/Ports/tr/patches/fix-tr.patch
@@ -1,0 +1,10 @@
+--- tr-6.7/tr.c.orig	Sun May 10 10:14:40 2020
++++ tr-6.7/tr.c	Sun May 10 10:14:53 2020
+@@ -32,6 +32,7 @@
+ 
+ #include <sys/types.h>
+ 
++#include <getopt.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>


### PR DESCRIPTION
Hello --

This PR adds the tr(1) utility from OpenBSD 6.7.
It is needed to build mksh.

The isctype macros lead to undefined reference errors, so they have been replaced with functions.