### PR TITLE
Ports: Fix binutils runtime

### DIFF
--- a/Ports/binutils/package.sh
+++ b/Ports/binutils/package.sh
@@ -8,3 +8,4 @@ https://ftp.gnu.org/gnu/binutils/binutils-${version}.tar.xz.sig binutils-${versi
 https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg binutils-${version}.tar.xz.sig"
+export ac_cv_func_getrusage=no


### PR DESCRIPTION
Hello --

GNU binutils will look for getrusage() during configure time and use it if found.
Serenity has only a stub of getrusage() which immediately assertion errors.

We can simply tell configure we don't have getrusage() for now, which fixes the binutils runtime and lets us build things again on Serenity.