### PR TITLE
Ports: Build ncurses --without-ada to avoid potential build failures.

### DIFF
--- a/Ports/ncurses/package.sh
+++ b/Ports/ncurses/package.sh
@@ -2,7 +2,7 @@
 port=ncurses
 version=6.1
 useconfigure=true
-configopts="--with-termlib --enable-pc-files --with-pkg-config=/usr/local/lib/pkgconfig --with-pkg-config-libdir=/usr/local/lib/pkgconfig"
+configopts="--with-termlib --enable-pc-files --with-pkg-config=/usr/local/lib/pkgconfig --with-pkg-config-libdir=/usr/local/lib/pkgconfig --without-ada"
 files="ftp://ftp.gnu.org/gnu/ncurses/ncurses-${version}.tar.gz ncurses-${version}.tar.gz
 http://ftp.gnu.org/gnu/ncurses/ncurses-${version}.tar.gz.sig ncurses-${version}.tar.gz.sig
 https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"


### PR DESCRIPTION
Hello --

ncurses will detect an Ada compiler on the system and attempt to use it even in a cross compile situation, which causes the build to fail. Adding --without-ada to the configure flags prevents the Ada code from being built.
