### PR TITLE
LibWeb: Improve rendering of awesomekling.github.io :^)

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -369,6 +369,20 @@ int String::replace(const String& needle, const String& replacement, bool all_oc
     return positions.size();
 }
 
+String String::trim_spaces() const
+{
+    size_t start = 0;
+    size_t end = length();
+    while (characters()[start] == ' ')
+        ++start;
+    while (characters()[end] == ' ') {
+        if (end <= start)
+            return "";
+        --end;
+    }
+    return substring(start, end - start);
+}
+
 String escape_html_entities(const StringView& html)
 {
     StringBuilder builder;

--- a/AK/String.h
+++ b/AK/String.h
@@ -114,6 +114,8 @@ public:
     String to_lowercase() const;
     String to_uppercase() const;
 
+    String trim_spaces() const;
+
     bool equals_ignoring_case(const StringView&) const;
 
     bool contains(const String&) const;

--- a/Libraries/LibWeb/CSS/Default.css
+++ b/Libraries/LibWeb/CSS/Default.css
@@ -52,7 +52,8 @@ h1, h2, h3, h4,
 h5, h6, noframes,
 ol, p, ul, center,
 dir, hr, menu, pre,
-header, footer {
+header, footer, nav, main,
+article, aside, section {
     display: block;
 }
 

--- a/Libraries/LibWeb/Layout/LayoutBox.cpp
+++ b/Libraries/LibWeb/Layout/LayoutBox.cpp
@@ -44,6 +44,8 @@ void LayoutBox::paint_border(RenderingContext& context, Edge edge, const Gfx::Fl
 
     auto border_style = style().property(style_property_id);
     float width = border_width.value()->to_length().to_px();
+    if (width <= 0)
+        return;
 
     int int_width = max((int)width, 1);
 

--- a/Libraries/LibWeb/Layout/LayoutBox.cpp
+++ b/Libraries/LibWeb/Layout/LayoutBox.cpp
@@ -200,9 +200,6 @@ void LayoutBox::render(RenderingContext& context)
         context.painter().draw_rect(m_rect, Color::Red);
 #endif
 
-    if (node() && document().inspected_node() == node())
-        context.painter().draw_rect(enclosing_int_rect(m_rect), Color::Magenta);
-
     Gfx::FloatRect padded_rect;
     padded_rect.set_x(x() - box_model().padding().left.to_px());
     padded_rect.set_width(width() + box_model().padding().left.to_px() + box_model().padding().right.to_px());
@@ -236,6 +233,9 @@ void LayoutBox::render(RenderingContext& context)
     paint_border(context, Edge::Bottom, bordered_rect, CSS::PropertyID::BorderBottomStyle, CSS::PropertyID::BorderBottomColor, CSS::PropertyID::BorderBottomWidth);
 
     LayoutNodeWithStyleAndBoxModelMetrics::render(context);
+
+    if (node() && document().inspected_node() == node())
+        context.painter().draw_rect(enclosing_int_rect(m_rect), Color::Magenta);
 }
 
 HitTestResult LayoutBox::hit_test(const Gfx::Point& position) const

--- a/Libraries/LibWeb/Parser/CSSParser.cpp
+++ b/Libraries/LibWeb/Parser/CSSParser.cpp
@@ -383,6 +383,12 @@ public:
             auto pseudo_name = String::copy(buffer);
             buffer.clear();
 
+
+            // Ignore for now, otherwise we produce a "false positive" selector
+            // and apply styles to the element itself, not its pseudo element
+            if (is_pseudo_element)
+                return {};
+
             if (pseudo_name == "link")
                 simple_selector.pseudo_class = Selector::SimpleSelector::PseudoClass::Link;
             else if (pseudo_name == "hover")
@@ -441,6 +447,9 @@ public:
             // If this assert triggers, we're most likely up to no good.
             PARSE_ASSERT(simple_selectors.size() < 100);
         }
+
+        if (simple_selectors.is_empty())
+            return {};
 
         return Selector::ComplexSelector { relation, move(simple_selectors) };
     }


### PR DESCRIPTION
A bunch of small fixes specifically targeted at improving the rendering of https://awesomekling.github.io.

Even the code blocks and images show up - this is so cool :D

From this...

![image](https://user-images.githubusercontent.com/19366641/81515225-eb12aa80-932a-11ea-9299-24f1a8daf5bc.png)

...to this:

![image](https://user-images.githubusercontent.com/19366641/81514941-9b7faf00-9329-11ea-94c7-9b33544bbac4.png)

![image](https://user-images.githubusercontent.com/19366641/81514955-afc3ac00-9329-11ea-9861-62c0326e7a9f.png)
![image](https://user-images.githubusercontent.com/19366641/81515088-5019d080-932a-11ea-98c4-291dce74cd4b.png)
![image](https://user-images.githubusercontent.com/19366641/81514987-daae0000-9329-11ea-8108-00262955f9e9.png)
