### PR TITLE
Sleep: Allow fractional seconds, fix Kernel timing, fix overflow in Kernel

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -2436,7 +2436,7 @@ int Process::sys$usleep(useconds_t usec)
     REQUIRE_PROMISE(stdio);
     if (!usec)
         return 0;
-    u64 wakeup_time = Thread::current()->sleep(usec / 1000);
+    u64 wakeup_time = Thread::current()->sleep(usec * TimeManagement::the().ticks_per_second() / 1000000);
     if (wakeup_time > g_uptime)
         return -EINTR;
     return 0;

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -220,7 +220,7 @@ void Thread::relock_process(bool did_unlock)
         process().big_lock().lock();
 }
 
-u64 Thread::sleep(u32 ticks)
+u64 Thread::sleep(u64 ticks)
 {
     ASSERT(state() == Thread::Running);
     u64 wakeup_time = g_uptime + ticks;

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -297,7 +297,7 @@ public:
     VirtualAddress thread_specific_data() const { return m_thread_specific_data; }
     size_t thread_specific_region_size() const { return m_thread_specific_region_size; }
 
-    u64 sleep(u32 ticks);
+    u64 sleep(u64 ticks);
     u64 sleep_until(u64 wakeup_time);
 
     class BlockResult {


### PR DESCRIPTION
My masterplan behind strtod: Supporting fractional seconds in `sleep`! :^)

This changes three interrelated things:
- Kernel: No longer overflow on large sleeps, which used to cause hard-to-predict actual delays
- Kernel: Fix "ticks_per_seconds" handling, because some code used to assume that there are always exactly 1000 ticks in a second.
- `/bin/sleep`: Support fractional seconds (even `inf`!)

Here's what it looked like intermediately:

![Bildschirmfoto_2020-05-11_15-09-16](https://user-images.githubusercontent.com/2690845/81567651-e38be980-939c-11ea-88df-28204b0537e8.png)

(I removed the debug output before pushing.)