### PR TITLE
LibMarkdown: Change MD Document parse API to return a RefPtr

### DIFF
--- a/Applications/Help/main.cpp
+++ b/Applications/Help/main.cpp
@@ -128,11 +128,10 @@ int main(int argc, char* argv[])
         auto buffer = file->read_all();
         StringView source { (const char*)buffer.data(), buffer.size() };
 
-        Markdown::Document md_document;
-        bool success = md_document.parse(source);
-        ASSERT(success);
+        auto md_document = Markdown::Document::parse(source);
+        ASSERT(md_document);
 
-        String html = md_document.render_to_html();
+        String html = md_document->render_to_html();
         auto html_document = Web::parse_html_document(html);
         page_view.set_document(html_document);
 

--- a/Applications/Help/main.cpp
+++ b/Applications/Help/main.cpp
@@ -128,10 +128,13 @@ int main(int argc, char* argv[])
         auto buffer = file->read_all();
         StringView source { (const char*)buffer.data(), buffer.size() };
 
-        auto md_document = Markdown::Document::parse(source);
-        ASSERT(md_document);
+        String html;
+        {
+            auto md_document = Markdown::Document::parse(source);
+            ASSERT(md_document);
+            html = md_document->render_to_html();
+        }
 
-        String html = md_document->render_to_html();
         auto html_document = Web::parse_html_document(html);
         page_view.set_document(html_document);
 

--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -560,9 +560,9 @@ void TextEditorWidget::set_markdown_preview_enabled(bool enabled)
 
 void TextEditorWidget::update_markdown_preview()
 {
-    Markdown::Document document;
-    if (document.parse(m_editor->text())) {
-        auto html = document.render_to_html();
+    auto document = Markdown::Document::parse(m_editor->text());
+    if (document) {
+        auto html = document->render_to_html();
         auto html_document = Web::parse_html_document(html, URL::create_with_file_protocol(m_path));
         m_page_view->set_document(html_document);
     }

--- a/DevTools/HackStudio/Editor.cpp
+++ b/DevTools/HackStudio/Editor.cpp
@@ -169,15 +169,14 @@ void Editor::show_documentation_tooltip_if_available(const String& hovered_token
         return;
     }
 
-    Markdown::Document man_document;
-    bool success = man_document.parse(file->read_all());
+    auto man_document = Markdown::Document::parse(file->read_all());
 
-    if (!success) {
+    if (!man_document) {
         dbg() << "failed to parse markdown";
         return;
     }
 
-    auto html_text = man_document.render_to_html();
+    auto html_text = man_document->render_to_html();
 
     auto html_document = Web::parse_html_document(html_text);
     if (!html_document) {

--- a/Libraries/LibMarkdown/Block.h
+++ b/Libraries/LibMarkdown/Block.h
@@ -37,7 +37,6 @@ public:
 
     virtual String render_to_html() const = 0;
     virtual String render_for_terminal() const = 0;
-    virtual bool parse(Vector<StringView>::ConstIterator& lines) = 0;
 };
 
 }

--- a/Libraries/LibMarkdown/CodeBlock.h
+++ b/Libraries/LibMarkdown/CodeBlock.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/OwnPtr.h>
 #include <LibMarkdown/Block.h>
 #include <LibMarkdown/Text.h>
 
@@ -33,11 +34,16 @@ namespace Markdown {
 
 class CodeBlock final : public Block {
 public:
-    virtual ~CodeBlock() override {}
+    CodeBlock(Text&& style_spec, const String& code)
+        : m_code(move(code))
+        , m_style_spec(move(style_spec))
+    {
+    }
+    virtual ~CodeBlock() override { }
 
     virtual String render_to_html() const override;
     virtual String render_for_terminal() const override;
-    virtual bool parse(Vector<StringView>::ConstIterator& lines) override;
+    static OwnPtr<CodeBlock> parse(Vector<StringView>::ConstIterator& lines);
 
 private:
     String style_language() const;

--- a/Libraries/LibMarkdown/Document.cpp
+++ b/Libraries/LibMarkdown/Document.cpp
@@ -75,25 +75,29 @@ static bool helper(Vector<StringView>::ConstIterator& lines, NonnullOwnPtrVector
     return true;
 }
 
-bool Document::parse(const StringView& str)
+RefPtr<Document> Document::parse(const StringView& str)
 {
     const Vector<StringView> lines_vec = str.lines();
     auto lines = lines_vec.begin();
+    auto document = adopt(*new Document);
+    auto& blocks = document->m_blocks;
 
     while (true) {
         if (lines.is_end())
-            return true;
+            break;
 
         if ((*lines).is_empty()) {
             ++lines;
             continue;
         }
 
-        bool any = helper<List>(lines, m_blocks) || helper<Paragraph>(lines, m_blocks) || helper<CodeBlock>(lines, m_blocks) || helper<Heading>(lines, m_blocks);
+        bool any = helper<List>(lines, blocks) || helper<Paragraph>(lines, blocks) || helper<CodeBlock>(lines, blocks) || helper<Heading>(lines, blocks);
 
         if (!any)
-            return false;
+            return nullptr;
     }
+
+    return document;
 }
 
 }

--- a/Libraries/LibMarkdown/Document.cpp
+++ b/Libraries/LibMarkdown/Document.cpp
@@ -67,19 +67,18 @@ String Document::render_for_terminal() const
 template<typename BlockType>
 static bool helper(Vector<StringView>::ConstIterator& lines, NonnullOwnPtrVector<Block>& blocks)
 {
-    NonnullOwnPtr<BlockType> block = make<BlockType>();
-    bool success = block->parse(lines);
-    if (!success)
+    OwnPtr<BlockType> block = BlockType::parse(lines);
+    if (!block)
         return false;
-    blocks.append(move(block));
+    blocks.append(block.release_nonnull());
     return true;
 }
 
-RefPtr<Document> Document::parse(const StringView& str)
+OwnPtr<Document> Document::parse(const StringView& str)
 {
     const Vector<StringView> lines_vec = str.lines();
     auto lines = lines_vec.begin();
-    auto document = adopt(*new Document);
+    auto document = make<Document>();
     auto& blocks = document->m_blocks;
 
     while (true) {

--- a/Libraries/LibMarkdown/Document.h
+++ b/Libraries/LibMarkdown/Document.h
@@ -32,12 +32,12 @@
 
 namespace Markdown {
 
-class Document final {
+class Document final : public RefCounted<Document> {
 public:
     String render_to_html() const;
     String render_for_terminal() const;
 
-    bool parse(const StringView&);
+    static RefPtr<Document> parse(const StringView&);
 
 private:
     NonnullOwnPtrVector<Block> m_blocks;

--- a/Libraries/LibMarkdown/Document.h
+++ b/Libraries/LibMarkdown/Document.h
@@ -32,12 +32,12 @@
 
 namespace Markdown {
 
-class Document final : public RefCounted<Document> {
+class Document final {
 public:
     String render_to_html() const;
     String render_for_terminal() const;
 
-    static RefPtr<Document> parse(const StringView&);
+    static OwnPtr<Document> parse(const StringView&);
 
 private:
     NonnullOwnPtrVector<Block> m_blocks;

--- a/Libraries/LibMarkdown/Heading.cpp
+++ b/Libraries/LibMarkdown/Heading.cpp
@@ -59,26 +59,30 @@ String Heading::render_for_terminal() const
     return builder.build();
 }
 
-bool Heading::parse(Vector<StringView>::ConstIterator& lines)
+OwnPtr<Heading> Heading::parse(Vector<StringView>::ConstIterator& lines)
 {
     if (lines.is_end())
-        return false;
+        return nullptr;
 
     const StringView& line = *lines;
+    size_t level;
 
-    for (m_level = 0; m_level < (int)line.length(); m_level++)
-        if (line[(size_t)m_level] != '#')
+    for (level = 0; level < line.length(); level++)
+        if (line[level] != '#')
             break;
 
-    if (m_level >= (int)line.length() || line[(size_t)m_level] != ' ')
-        return false;
+    if (level >= line.length() || line[level] != ' ')
+        return nullptr;
 
-    StringView title_view = line.substring_view((size_t)m_level + 1, line.length() - (size_t)m_level - 1);
-    bool success = m_text.parse(title_view);
-    ASSERT(success);
+    StringView title_view = line.substring_view(level + 1, line.length() - level - 1);
+    auto text = Text::parse(title_view);
+    if (!text.has_value())
+        return nullptr;
+
+    auto heading = make<Heading>(move(text.value()), level);
 
     ++lines;
-    return true;
+    return heading;
 }
 
 }

--- a/Libraries/LibMarkdown/Heading.h
+++ b/Libraries/LibMarkdown/Heading.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/OwnPtr.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibMarkdown/Block.h>
@@ -35,15 +36,20 @@ namespace Markdown {
 
 class Heading final : public Block {
 public:
-    virtual ~Heading() override {}
+    Heading(Text&& text, size_t level)
+        : m_text(move(text))
+        , m_level(level)
+    {
+    }
+    virtual ~Heading() override { }
 
     virtual String render_to_html() const override;
     virtual String render_for_terminal() const override;
-    virtual bool parse(Vector<StringView>::ConstIterator& lines) override;
+    static OwnPtr<Heading> parse(Vector<StringView>::ConstIterator& lines);
 
 private:
     Text m_text;
-    int m_level { -1 };
+    size_t m_level { 0 };
 };
 
 }

--- a/Libraries/LibMarkdown/List.h
+++ b/Libraries/LibMarkdown/List.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/OwnPtr.h>
 #include <AK/Vector.h>
 #include <LibMarkdown/Block.h>
 #include <LibMarkdown/Text.h>
@@ -34,11 +35,17 @@ namespace Markdown {
 
 class List final : public Block {
 public:
+    List(Vector<Text>&& text, bool is_ordered)
+        : m_items(move(text))
+        , m_is_ordered(is_ordered)
+    {
+    }
     virtual ~List() override {}
 
     virtual String render_to_html() const override;
     virtual String render_for_terminal() const override;
-    virtual bool parse(Vector<StringView>::ConstIterator& lines) override;
+
+    static OwnPtr<List> parse(Vector<StringView>::ConstIterator& lines);
 
 private:
     // TODO: List items should be considered blocks of their own kind.

--- a/Libraries/LibMarkdown/Paragraph.cpp
+++ b/Libraries/LibMarkdown/Paragraph.cpp
@@ -46,10 +46,10 @@ String Paragraph::render_for_terminal() const
     return builder.build();
 }
 
-bool Paragraph::parse(Vector<StringView>::ConstIterator& lines)
+OwnPtr<Paragraph> Paragraph::parse(Vector<StringView>::ConstIterator& lines)
 {
     if (lines.is_end())
-        return false;
+        return nullptr;
 
     bool first = true;
     StringBuilder builder;
@@ -86,11 +86,13 @@ bool Paragraph::parse(Vector<StringView>::ConstIterator& lines)
     }
 
     if (first)
-        return false;
+        return nullptr;
 
-    bool success = m_text.parse(builder.build());
-    ASSERT(success);
-    return true;
+    auto text = Text::parse(builder.build());
+    if (!text.has_value())
+        return nullptr;
+
+    return make<Paragraph>(move(text.value()));
 }
 
 }

--- a/Libraries/LibMarkdown/Paragraph.h
+++ b/Libraries/LibMarkdown/Paragraph.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/OwnPtr.h>
 #include <LibMarkdown/Block.h>
 #include <LibMarkdown/Text.h>
 
@@ -33,11 +34,12 @@ namespace Markdown {
 
 class Paragraph final : public Block {
 public:
+    explicit Paragraph(Text&& text) : m_text(move(text)) {}
     virtual ~Paragraph() override {}
 
     virtual String render_to_html() const override;
     virtual String render_for_terminal() const override;
-    virtual bool parse(Vector<StringView>::ConstIterator& lines) override;
+    static OwnPtr<Paragraph> parse(Vector<StringView>::ConstIterator& lines);
 
 private:
     Text m_text;

--- a/Libraries/LibMarkdown/Text.h
+++ b/Libraries/LibMarkdown/Text.h
@@ -26,12 +26,14 @@
 
 #pragma once
 
+#include <AK/Noncopyable.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 
 namespace Markdown {
 
 class Text final {
+    AK_MAKE_NONCOPYABLE(Text);
 public:
     struct Style {
         bool emph { false };
@@ -46,14 +48,21 @@ public:
         Style style;
     };
 
+    Text(Text&& text) = default;
+
     const Vector<Span>& spans() const { return m_spans; }
 
     String render_to_html() const;
     String render_for_terminal() const;
 
-    bool parse(const StringView&);
+    static Optional<Text> parse(const StringView&);
 
 private:
+    Text(Vector<Span>&& spans)
+        : m_spans(move(spans))
+    {
+    }
+
     Vector<Span> m_spans;
 };
 

--- a/Libraries/LibWeb/PageView.cpp
+++ b/Libraries/LibWeb/PageView.cpp
@@ -332,11 +332,11 @@ void PageView::reload()
 
 static RefPtr<Document> create_markdown_document(const ByteBuffer& data, const URL& url)
 {
-    Markdown::Document markdown_document;
-    if (!markdown_document.parse(data))
+    auto markdown_document = Markdown::Document::parse(data);
+    if (!markdown_document)
         return nullptr;
 
-    return parse_html_document(markdown_document.render_to_html(), url);
+    return parse_html_document(markdown_document->render_to_html(), url);
 }
 
 static RefPtr<Document> create_text_document(const ByteBuffer& data, const URL& url)

--- a/Userland/man.cpp
+++ b/Userland/man.cpp
@@ -101,10 +101,9 @@ int main(int argc, char* argv[])
 
     printf("%s(%s)\t\tSerenityOS manual\n", name, section);
 
-    Markdown::Document document;
-    bool success = document.parse(source);
-    ASSERT(success);
+    auto document = Markdown::Document::parse(source);
+    ASSERT(document);
 
-    String rendered = document.render_for_terminal();
+    String rendered = document->render_for_terminal();
     printf("%s", rendered.characters());
 }

--- a/Userland/md.cpp
+++ b/Userland/md.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <LibCore/File.h>
 #include <LibMarkdown/Document.h>

--- a/Userland/md.cpp
+++ b/Userland/md.cpp
@@ -70,14 +70,13 @@ int main(int argc, char* argv[])
     dbg() << "Read size " << buffer.size();
 
     auto input = String::copy(buffer);
-    Markdown::Document document;
-    success = document.parse(input);
+    auto document = Markdown::Document::parse(input);
 
-    if (!success) {
+    if (!document) {
         fprintf(stderr, "Error parsing\n");
         return 1;
     }
 
-    String res = html ? document.render_to_html() : document.render_for_terminal();
+    String res = html ? document->render_to_html() : document->render_for_terminal();
     printf("%s", res.characters());
 }


### PR DESCRIPTION
Now, markdown documents are now obtained via the static Document::parse
method, which returns a RefPtr<Document>, or nullptr on failure. This was mentioned in IRC, and will bring the Markdown parse API more in line with the rest of the Serenity's parse APIs.