### PR TITLE
LibHTTP: Support Transfer-Encoding: chunked

### DIFF
--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -929,6 +929,9 @@ long long strtoll(const char* str, char** endptr, int base)
         return 0;
     }
 
+    if (endptr)
+        *endptr = parse_ptr;
+
     if (overflow) {
         errno = ERANGE;
         if (sign != Sign::Negative) {
@@ -1002,6 +1005,9 @@ unsigned long long strtoull(const char* str, char** endptr, int base)
             *endptr = const_cast<char*>(str);
         return 0;
     }
+
+    if (endptr)
+        *endptr = parse_ptr;
 
     if (overflow) {
         errno = ERANGE;

--- a/Libraries/LibHTTP/Job.h
+++ b/Libraries/LibHTTP/Job.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/Optional.h>
 #include <LibCore/NetworkJob.h>
 #include <LibCore/TCPSocket.h>
 #include <LibHTTP/HttpRequest.h>
@@ -66,6 +67,7 @@ protected:
         InHeaders,
         InBody,
         Finished,
+        AfterChunkedEncodingTrailer,
     };
 
     HttpRequest m_request;
@@ -75,6 +77,8 @@ protected:
     Vector<ByteBuffer> m_received_buffers;
     size_t m_received_size { 0 };
     bool m_sent_data { 0 };
+    Optional<ssize_t> m_current_chunk_remaining_size;
+    Optional<size_t> m_current_chunk_total_size;
 };
 
 }


### PR DESCRIPTION
We advertise ourselves to servers as supporting HTTP/1.1; we should put our money where our mouth is, and start supporting some of its features.

p.s. I tried to open nyaa.si/?q=foo
> muh anime torrents