### PR TITLE
AK: Fix gcc 10.1 compiler warnings in Vector.h

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -268,12 +268,12 @@ public:
 
     ALWAYS_INLINE const T& at(size_t i) const
     {
-        ASSERT(i >= 0 && i < m_size);
+        ASSERT(i < m_size);
         return data()[i];
     }
     ALWAYS_INLINE T& at(size_t i)
     {
-        ASSERT(i >= 0 && i < m_size);
+        ASSERT(i < m_size);
         return data()[i];
     }
 


### PR DESCRIPTION
It's complaining about "size_t >= 0" checks.

Fixes #2196.