### PR TITLE
Build: Improved speed of makeall.sh

### DIFF
--- a/Kernel/makeall.sh
+++ b/Kernel/makeall.sh
@@ -24,6 +24,10 @@ if [ "$(uname -s)" = "OpenBSD" ] || [ "$(uname -s)" = "FreeBSD" ]; then
 	MAKE="gmake"
 fi
 
+if [ "$fast_mode" = 1 ] || [ "$(nproc)" -gt 2 ]; then
+    MAKE="$MAKE -j$(nproc)"
+fi
+
 if [ "$fast_mode" = "1" ]; then
     $MAKE -C ../ && \
         $MAKE -C ../ install &&


### PR DESCRIPTION
`Kernel/makeall.sh -f` now uses the `-j` option on make with the number of processors from `nproc`.
Additionally, if `nproc` returns greater than two processors, the same `-j` option is used.