### PR TITLE
LibLine: Fix suggestion spacing regression

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -506,7 +506,7 @@ String Editor::get_line(const String& prompt)
                     size_t start_index = 0;
 
                     for (auto& suggestion : m_suggestions) {
-                        if (start_index++ <= m_last_displayed_suggestion_index)
+                        if (start_index++ < m_last_displayed_suggestion_index)
                             continue;
                         longest_suggestion_length = max(longest_suggestion_length, suggestion.text.length());
                     }


### PR DESCRIPTION
This patch fixes an issue where the line editor would put no spacing between suggestions (only when there are two suggestions).

To reproduce, try on a build with no ports (starting with `pro`):
```
> pro<tab>
profilepro
```