### PR TITLE
LibJS: Handle empty values in operator<<()

### DIFF
--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -370,7 +370,7 @@ Value instance_of(Interpreter&, Value lhs, Value rhs)
 
 const LogStream& operator<<(const LogStream& stream, const Value& value)
 {
-    return stream << value.to_string();
+    return stream << (value.is_empty() ? "<empty>" : value.to_string());
 }
 
 bool same_value(Interpreter& interpreter, Value lhs, Value rhs)


### PR DESCRIPTION
Otherwise something like `dbg() << Value();` chokes on `ASSERT_NOT_REACHED()` in `Value::to_string()`.