### PR TITLE
LibJS: Make string to number coercion work for doubles & trim whitespace beforehand // AK: Replace String::trim_spaces() with String::trim_whitespace()

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -369,18 +369,42 @@ int String::replace(const String& needle, const String& replacement, bool all_oc
     return positions.size();
 }
 
-String String::trim_spaces() const
+String String::trim_whitespace(TrimMode mode) const
 {
-    size_t start = 0;
-    size_t end = length();
-    while (characters()[start] == ' ')
-        ++start;
-    while (characters()[end] == ' ') {
-        if (end <= start)
-            return "";
-        --end;
+    auto is_whitespace_character = [](char ch) -> bool {
+        return ch == '\t'
+            || ch == '\n'
+            || ch == '\v'
+            || ch == '\f'
+            || ch == '\r'
+            || ch == ' ';
+    };
+
+    size_t substring_start = 0;
+    size_t substring_length = length();
+
+    if (mode == TrimMode::Left || mode == TrimMode::Both) {
+        for (size_t i = 0; i < length(); ++i) {
+            if (substring_length == 0)
+                return "";
+            if (!is_whitespace_character(characters()[i]))
+                break;
+            ++substring_start;
+            --substring_length;
+        }
     }
-    return substring(start, end - start);
+
+    if (mode == TrimMode::Right || mode == TrimMode::Both) {
+        for (size_t i = length() - 1; i > 0; --i) {
+            if (substring_length == 0)
+                return "";
+            if (!is_whitespace_character(characters()[i]))
+                break;
+            --substring_length;
+        }
+    }
+
+    return substring(substring_start, substring_length);
 }
 
 String escape_html_entities(const StringView& html)

--- a/AK/String.h
+++ b/AK/String.h
@@ -114,7 +114,12 @@ public:
     String to_lowercase() const;
     String to_uppercase() const;
 
-    String trim_spaces() const;
+    enum class TrimMode {
+        Left,
+        Right,
+        Both
+    };
+    String trim_whitespace(TrimMode mode = TrimMode::Both) const;
 
     bool equals_ignoring_case(const StringView&) const;
 

--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -237,54 +237,12 @@ Value StringPrototype::pad_end(Interpreter& interpreter)
     return pad_string(interpreter, string, PadPlacement::End);
 }
 
-enum class TrimMode {
-    Left,
-    Right,
-    Both
-};
-
-static Value trim_string(Interpreter& interpreter, const String& string, TrimMode mode)
-{
-    size_t substring_start = 0;
-    size_t substring_length = string.length();
-
-    auto is_white_space_character = [](char character) -> bool {
-        return character == 0x9 || character == 0xa || character == 0xb || character == 0xc || character == 0xd || character == 0x20;
-    };
-
-    if (mode == TrimMode::Left || mode == TrimMode::Both) {
-        for (size_t i = 0; i < string.length(); ++i) {
-            if (!is_white_space_character(string[i])) {
-                substring_start = i;
-                substring_length -= substring_start;
-                break;
-            }
-        }
-    }
-
-    if (substring_length == 0)
-        return js_string(interpreter, "");
-
-    if (mode == TrimMode::Right || mode == TrimMode::Both) {
-        size_t count = 0;
-        for (size_t i = string.length() - 1; i > 0; --i) {
-            if (!is_white_space_character(string[i])) {
-                substring_length -= count;
-                break;
-            }
-            count++;
-        }
-    }
-
-    return js_string(interpreter, string.substring(substring_start, substring_length));
-}
-
 Value StringPrototype::trim(Interpreter& interpreter)
 {
     auto string = string_from(interpreter);
     if (string.is_null())
         return {};
-    return trim_string(interpreter, string, TrimMode::Both);
+    return js_string(interpreter, string.trim_whitespace(String::TrimMode::Both));
 }
 
 Value StringPrototype::trim_start(Interpreter& interpreter)
@@ -292,7 +250,7 @@ Value StringPrototype::trim_start(Interpreter& interpreter)
     auto string = string_from(interpreter);
     if (string.is_null())
         return {};
-    return trim_string(interpreter, string, TrimMode::Left);
+    return js_string(interpreter, string.trim_whitespace(String::TrimMode::Left));
 }
 
 Value StringPrototype::trim_end(Interpreter& interpreter)
@@ -300,7 +258,7 @@ Value StringPrototype::trim_end(Interpreter& interpreter)
     auto string = string_from(interpreter);
     if (string.is_null())
         return {};
-    return trim_string(interpreter, string, TrimMode::Right);
+    return js_string(interpreter, string.trim_whitespace(String::TrimMode::Right));
 }
 
 Value StringPrototype::concat(Interpreter& interpreter)

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -173,13 +173,11 @@ Value Value::to_number() const
             return js_infinity();
         if (string == "-Infinity")
             return js_negative_infinity();
-        bool ok;
-        //FIXME: Parse in a better way
-        auto parsed_int = string.to_int(ok);
-        if (ok)
-            return Value(parsed_int);
-
-        return js_nan();
+        char* endptr;
+        auto parsed_double = strtod(string.characters(), &endptr);
+        if (*endptr)
+            return js_nan();
+        return Value(parsed_double);
     }
     case Type::Object:
         return m_value.as_object->to_primitive(Object::PreferredType::Number).to_number();

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -165,8 +165,7 @@ Value Value::to_number() const
     case Type::Number:
         return Value(m_value.as_double);
     case Type::String: {
-        // FIXME: Trim whitespace beforehand
-        auto& string = as_string().string();
+        auto string = as_string().string().trim_whitespace();
         if (string.is_empty())
             return Value(0);
         if (string == "Infinity" || string == "+Infinity")

--- a/Libraries/LibJS/Tests/to-number-basic.js
+++ b/Libraries/LibJS/Tests/to-number-basic.js
@@ -27,9 +27,8 @@ try {
     assert(-42 === -42);
     assert(+1.23 === 1.23);
     assert(-1.23 === -1.23);
-    // FIXME: returns NaN
-    // assert(+"1.23" === 1.23)
-    // assert(-"1.23" === -1.23)
+    assert(+"1.23" === 1.23)
+    assert(-"1.23" === -1.23)
     assert(+"Infinity" === Infinity);
     assert(+"+Infinity" === Infinity);
     assert(+"-Infinity" === -Infinity);

--- a/Libraries/LibJS/Tests/to-number-basic.js
+++ b/Libraries/LibJS/Tests/to-number-basic.js
@@ -35,6 +35,9 @@ try {
     assert(-"Infinity" === -Infinity);
     assert(-"+Infinity" === -Infinity);
     assert(-"-Infinity" === Infinity);
+    assert(+"  \r  \t \n " === 0);
+    assert(+"  \n  \t    Infinity   \r   " === Infinity);
+    assert(+"\r     \n1.23   \t\t\t  \n" === 1.23);
 
     assert(isNaN(+undefined));
     assert(isNaN(-undefined));

--- a/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -144,7 +144,7 @@ void StyleProperties::load_font() const
 
     // FIXME: Do this properly, with quote handling etc.
     for (auto& font_name : font_family.split(',')) {
-        font_name = font_name.trim_spaces();
+        font_name = font_name.trim_whitespace();
         if (font_name == "monospace")
             font_name = "Csilla";
 


### PR DESCRIPTION
- LibJS: Make string to number coercion work for doubles

  Well... just that. `+"1.23"` works now.

- AK: Replace `String::trim_spaces()` with `String::trim_whitespace()`

  As suggested by @awesomekling in a code review and (initially) ignored by me :^)

  Implementation is roughly based on LibJS's `trim_string()`, but with a fix for trimming all-whitespace strings.

- LibJS: Use `String::trim_whitespace()` for `String.prototype.trim*()`

  No need to keep a second string trimming function with a bug around.

- LibJS: Trim whitespace from string before coercing to number

  That's how it's supposed to work. `+"<long string only whitespace>" === 0`.