### PR TITLE
WindowServer: Invalidate the cursor when setting an override cursor

### DIFF
--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -614,6 +614,7 @@ OwnPtr<Messages::WindowServer::SetWindowOverrideCursorResponse> ClientConnection
     }
     auto& window = *(*it).value;
     window.set_override_cursor(Cursor::create((StandardCursor)message.cursor_type()));
+    Compositor::the().invalidate_cursor();
     return make<Messages::WindowServer::SetWindowOverrideCursorResponse>();
 }
 


### PR DESCRIPTION
Fixes that one bug from the end of last video :^)