### PR TITLE
Shell: Break out of continuation when ^C is pressed

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -171,6 +171,10 @@ String Editor::get_line(const String& prompt)
 
                 m_buffer.clear();
                 m_cursor = 0;
+
+                if (on_interrupt_handled)
+                    on_interrupt_handled();
+
                 m_refresh_needed = true;
                 continue;
             }

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -134,6 +134,7 @@ public:
 
     Function<Vector<CompletionSuggestion>(const String&)> on_tab_complete_first_token;
     Function<Vector<CompletionSuggestion>(const String&)> on_tab_complete_other_token;
+    Function<void()> on_interrupt_handled;
     Function<void(Editor&)> on_display_refresh;
 
     // FIXME: we will have to kindly ask our instantiators to set our signal handlers

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -1540,8 +1540,25 @@ int main(int argc, char** argv)
 
     StringBuilder complete_line_builder;
 
+    bool should_break_current_command { false };
+
+    editor.on_interrupt_handled = [&] {
+        if (s_should_continue != ExitCodeOrContinuationRequest::ContinuationRequest::Nothing) {
+            should_break_current_command = true;
+            editor.finish();
+        }
+    };
+
     for (;;) {
         auto line = editor.get_line(prompt());
+
+        if (should_break_current_command) {
+            complete_line_builder.clear();
+            s_should_continue = ExitCodeOrContinuationRequest::ContinuationRequest::Nothing;
+            should_break_current_command = false;
+            continue;
+        }
+
         if (line.is_empty())
             continue;
 


### PR DESCRIPTION
This fixes the little issue with Shell not allowing cancellation of commands once they were in continuation mode

```sh
$ ls '
$ # No matter what we do here, we cannot escape 'ls'
```