### PR TITLE
PaintBrush: Move layers up and down or delete them

### DIFF
--- a/Applications/PaintBrush/Image.cpp
+++ b/Applications/PaintBrush/Image.cpp
@@ -104,6 +104,26 @@ void Image::move_layer_to_front(Layer& layer)
     m_layers.append(layer);
 }
 
+void Image::move_layer_down(Layer& layer)
+{
+    NonnullRefPtr<Layer> protector(layer);
+    auto index = index_of(layer);
+    if (!index)
+        return;
+    m_layers.remove(index);
+    m_layers.insert(index - 1, layer);
+}
+
+void Image::move_layer_up(Layer& layer)
+{
+    NonnullRefPtr<Layer> protector(layer);
+    auto index = index_of(layer);
+    if (index == m_layers.size() - 1)
+        return;
+    m_layers.remove(index);
+    m_layers.insert(index + 1, layer);
+}
+
 void Image::remove_layer(Layer& layer)
 {
     NonnullRefPtr<Layer> protector(layer);

--- a/Applications/PaintBrush/Image.h
+++ b/Applications/PaintBrush/Image.h
@@ -57,6 +57,8 @@ public:
 
     void move_layer_to_front(Layer&);
     void move_layer_to_back(Layer&);
+    void move_layer_up(Layer&);
+    void move_layer_down(Layer&);
     void remove_layer(Layer&);
 
 private:

--- a/Applications/PaintBrush/main.cpp
+++ b/Applications/PaintBrush/main.cpp
@@ -151,6 +151,23 @@ int main(int argc, char** argv)
         layer_table_view.selection().set(layer_table_view.model()->index(0));
     }, window));
     layer_menu.add_separator();
+    layer_menu.add_action(GUI::Action::create("Move active layer up", { Mod_Ctrl, Key_PageUp }, [&](auto&) {
+        auto active_layer = image_editor.active_layer();
+        if(!active_layer)
+            return;
+        image_editor.image()->move_layer_up(*active_layer);
+        layer_table_view.move_selection(1);
+        image_editor.layers_did_change();
+    }, window));
+    layer_menu.add_action(GUI::Action::create("Move active layer down", { Mod_Ctrl, Key_PageDown }, [&](auto&) {
+        auto active_layer = image_editor.active_layer();
+        if(!active_layer)
+            return;
+        image_editor.image()->move_layer_down(*active_layer);
+        layer_table_view.move_selection(-1);
+        image_editor.layers_did_change();
+    }, window));
+    layer_menu.add_separator();
     layer_menu.add_action(GUI::Action::create("Remove active layer", { Mod_Ctrl , Key_D }, [&](auto&) {
         auto active_layer = image_editor.active_layer();
         if(!active_layer)

--- a/Applications/PaintBrush/main.cpp
+++ b/Applications/PaintBrush/main.cpp
@@ -150,6 +150,15 @@ int main(int argc, char** argv)
     layer_menu.add_action(GUI::Action::create("Select bottom layer", { 0, Key_End }, [&](auto&) {
         layer_table_view.selection().set(layer_table_view.model()->index(0));
     }, window));
+    layer_menu.add_separator();
+    layer_menu.add_action(GUI::Action::create("Remove active layer", { Mod_Ctrl , Key_D }, [&](auto&) {
+        auto active_layer = image_editor.active_layer();
+        if(!active_layer)
+            return;
+        image_editor.image()->remove_layer(*active_layer);
+        image_editor.set_active_layer(nullptr);
+        image_editor.layers_did_change();
+    }, window));
 
     auto& help_menu = menubar->add_menu("Help");
     help_menu.add_action(GUI::Action::create("About", [&](auto&) {


### PR DESCRIPTION
I thought it might be useful to be able move layers up and down by a single step instead of front and back. The shortcuts go along with the select layer actions.