### PR TITLE
LibJS: Clean up how parser errors work

### DIFF
--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -240,13 +240,6 @@ bool Lexer::is_numeric_literal_start() const
     return isdigit(m_current_char) || (m_current_char == '.' && m_position < m_source.length() && isdigit(m_source[m_position]));
 }
 
-void Lexer::syntax_error(const char* msg)
-{
-    m_has_errors = true;
-    if (m_log_errors)
-        fprintf(stderr, "Syntax Error: %s (line: %zu, column: %zu)\n", msg, m_line_number, m_line_column);
-}
-
 Token Lexer::next()
 {
     size_t trivia_start = m_position;
@@ -395,7 +388,6 @@ Token Lexer::next()
             consume();
         }
         if (m_current_char != stop_char) {
-            syntax_error("unterminated string literal");
             token_type = TokenType::UnterminatedStringLiteral;
         } else {
             consume();

--- a/Libraries/LibJS/Lexer.h
+++ b/Libraries/LibJS/Lexer.h
@@ -37,14 +37,8 @@ namespace JS {
 class Lexer {
 public:
     explicit Lexer(StringView source);
-    Lexer(StringView source, bool log_errors)
-        : Lexer(source)
-    {
-        m_log_errors = log_errors;
-    }
 
     Token next();
-    bool has_errors() const { return m_has_errors; }
 
 private:
     void consume();
@@ -60,16 +54,12 @@ private:
     bool match(char, char, char) const;
     bool match(char, char, char, char) const;
 
-    void syntax_error(const char*);
-
     StringView m_source;
     size_t m_position = 0;
     Token m_current_token;
     int m_current_char = 0;
-    bool m_has_errors = false;
     size_t m_line_number = 1;
     size_t m_line_column = 1;
-    bool m_log_errors = true;
 
     struct TemplateState {
         bool in_expr;

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -29,7 +29,6 @@
 #include <AK/HashMap.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StdLibExtras.h>
-#include <stdio.h>
 
 namespace JS {
 
@@ -1385,12 +1384,11 @@ void Parser::expected(const char* what)
 
 void Parser::syntax_error(const String& message, size_t line, size_t column)
 {
-    m_parser_state.m_has_errors = true;
     if (line == 0 || column == 0) {
         line = m_parser_state.m_current_token.line_number();
         column = m_parser_state.m_current_token.line_column();
     }
-    fprintf(stderr, "Syntax Error: %s (line: %zu, column: %zu)\n", message.characters(), line, column);
+    m_parser_state.m_errors.append({ message, line, column });
 }
 
 void Parser::save_state()

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -75,7 +75,7 @@ public:
     NonnullRefPtr<NewExpression> parse_new_expression();
     RefPtr<FunctionExpression> try_parse_arrow_function_expression(bool expect_parens);
 
-    bool has_errors() const { return m_parser_state.m_lexer.has_errors() || m_parser_state.m_has_errors; }
+    bool has_errors() const { m_parser_state.m_has_errors; }
 
 private:
     friend class ScopePusher;

--- a/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -70,8 +70,8 @@ Value FunctionConstructor::construct(Interpreter& interpreter)
     auto parser = Parser(Lexer(source));
     auto function_expression = parser.parse_function_node<FunctionExpression>();
     if (parser.has_errors()) {
-        // FIXME: The parser should expose parsing error strings rather than just fprintf()'ing them
-        interpreter.throw_exception<SyntaxError>("");
+        auto error = parser.errors()[0];
+        interpreter.throw_exception<SyntaxError>(error.to_string());
         return {};
     }
     return function_expression->execute(interpreter);

--- a/Libraries/LibJS/Tests/Function.js
+++ b/Libraries/LibJS/Tests/Function.js
@@ -29,7 +29,11 @@ try {
     assertThrowsError(() => {
         new Function("[");
     }, {
-        error: SyntaxError
+        error: SyntaxError,
+        // This might be confusing at first but keep in mind it's actually parsing
+        // function anonymous() { [ }
+        // This is in line with what other engines are reporting.
+        message: "Unexpected token CurlyClose. Expected BracketClose (line: 1, column: 26)"
     });
 
     console.log("PASS");

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -378,6 +378,7 @@ JS::Value Document::run_javascript(const StringView& source)
     auto parser = JS::Parser(JS::Lexer(source));
     auto program = parser.parse_program();
     if (parser.has_errors()) {
+        parser.print_errors();
         return JS::js_undefined();
     }
     dbg() << "Document::run_javascript('" << source << "') will run:";

--- a/Libraries/LibWeb/DOM/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/DOM/HTMLScriptElement.cpp
@@ -61,9 +61,10 @@ void HTMLScriptElement::children_changed()
 
     auto parser = JS::Parser(JS::Lexer(source));
     auto program = parser.parse_program();
-    if (parser.has_errors())
+    if (parser.has_errors()) {
+        parser.print_errors();
         return;
-
+    }
     document().interpreter().run(*program);
 }
 
@@ -96,9 +97,10 @@ void HTMLScriptElement::inserted_into(Node& new_parent)
 
     auto parser = JS::Parser(JS::Lexer(source));
     auto program = parser.parse_program();
-    if (parser.has_errors())
+    if (parser.has_errors()) {
+        parser.print_errors();
         return;
-
+    }
     document().interpreter().run(*program);
 }
 

--- a/Meta/Lagom/Fuzzers/FuzzJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzJs.cpp
@@ -36,5 +36,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     auto lexer = JS::Lexer(js);
     auto parser = JS::Parser(lexer);
     parser.parse_program();
+    if (parser.has_errors())
+        parser.print_errors();
     return 0;
 }

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -524,7 +524,7 @@ int main(int argc, char** argv)
 
             size_t open_indents = s_repl_line_level;
 
-            JS::Lexer lexer(str, false);
+            JS::Lexer lexer(str);
             bool indenters_starting_line = true;
             for (JS::Token token = lexer.next(); token.type() != JS::TokenType::Eof; token = lexer.next()) {
                 auto length = token.value().length();


### PR DESCRIPTION
Addresses https://github.com/SerenityOS/serenity/issues/2207, I guess.

- LibJS: Remove syntax errors from lexer 

  Giving the lexer the ability to generate errors adds unnecessary complexity - also it only calls its `syntax_error()` function in one place anyway ("unterminated string literal"). But since the lexer *also* emits tokens like `Eof` or `UnterminatedStringLiteral`, it should be up to the consumer of these tokens to decide what to do.

  Also remove the option to not print errors to stderr as that's not relevant anymore.

- LibJS: Let parser keep track of errors

  Rather than printing them to stderr directly the parser now keeps a `Vector<Error>`, which allows the "owner" of the parser to consume them individually after parsing.

  The `Error` struct has a message, line number, column number and a `to_string()` helper function to format this information into a meaningful error message.

  The `Function()` constructor will now include an error message when throwing a `SyntaxError`.

- js: Throw a regular SyntaxError for errors from the parser

  ```
  > foo]bar)baz
  Uncaught exception: [SyntaxError]: Unexpected token BracketClose. Expected Semicolon (line: 1, column: 5)
  >
  ``` 