### PR TITLE
Meta: Update CodingStyle.md and BuildInstructions.md

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -1,6 +1,8 @@
 ## SerenityOS build instructions
 
-### Linux prerequisites
+### Prerequisites
+
+#### Linux prerequisites
 Make sure you have all the dependencies installed:
 
 **Debian / Ubuntu**
@@ -30,7 +32,7 @@ sudo apt-get install gcc-9 g++-9
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 ```
 
-### macOS prerequisites
+#### macOS prerequisites
 Make sure you have all the dependencies installed:
 ```bash
 brew install coreutils
@@ -43,6 +45,7 @@ brew install m4
 brew install autoconf
 brew install libtool
 brew install automake
+brew install bash
 brew cask install osxfuse
 Toolchain/BuildFuseExt2.sh
 ```
@@ -54,9 +57,10 @@ Notes:
 - `flock` command can also be installed with `brew install util-linux` but in that case you will need to add it to `$PATH`
 - qemu is needed to run the compiled OS image. You can also build it using the `BuildQemu.sh` script
 - osxfuse, e2fsprogs, m4, autoconf, automake, libtool and `BuildFuseExt2.sh` are needed if you want to build the root filesystem disk image natively on macOS. This allows mounting an EXT2 fs and also installs commands like `mke2fs` that are not available on stock macOS. 
+- bash is needed because the default version installed on macOS doesn't support globstar
 - If you install some commercial EXT2 macOS fs handler instead of osxfuse and fuse-ext2, you will need to `brew install e2fsprogs` to obtain `mke2fs` anyway.
 
-### OpenBSD prerequisites
+#### OpenBSD prerequisites
 ```
 pkg_add bash gmp gcc git flock gmake sudo
 ```
@@ -64,19 +68,29 @@ pkg_add bash gmp gcc git flock gmake sudo
 ### Build
 > Before starting, make sure that you have configured your global identity for git, or the first script will fail after running for a bit.
 
-Go into the `Toolchain/` directory and run the **BuildIt.sh** script.
-
-Once you've built the toolchain, create a directory for the build to live in (for example, `Build/`), and run the CMake build:
+Go into the `Toolchain/` directory and run the **BuildIt.sh** script:
+```bash
+$ cd Toolchain
+$ ./BuildIt.sh
 ```
-$ mkdir Build && cd Build
-$ cmake ..
+
+Building the toolchain will also automatically create a `Build/` directory for the build to live in, and build cmake inside that directory.
+
+Once the toolchain and cmake have been built, go into the `Build/` directory and run the `make` and `make install` commands:
+```bash
+$ cd ..
+$ cd Build
 $ make
 $ make install
 ```
 
-This will compile all of SerenityOS and install the built files into `Root/` inside the build tree. `make install` actually pulls in the regular `make` (`make all`) automatically, so there isn't really a need to run it exlicitly. You may also want ask `make` to build things in parallel by using `-j`, optionally specifying the maximum number of jobs to run.
+This will compile all of SerenityOS and install the built files into `Root/` inside the build tree. `make install` actually pulls in the regular `make` (`make all`) automatically, so there isn't really a need to run it explicitly. You may also want ask `make` to build things in parallel by using `-j`, optionally specifying the maximum number of jobs to run.
 
 Now to build a disk image, run `make image`, and if nothing breaks too much, take it for a spin by using `make run`.
+```bash
+$ make image
+$ make run
+```
 
 Note that the `anon` user is able to become `root` without password by default, as a development convenience.
 To prevent this, remove `anon` from the `wheel` group and he will no longer be able to run `/bin/su`.
@@ -87,7 +101,7 @@ Bare curious users may even consider sourcing suitable hardware to [install Sere
 
 Later on, when you `git pull` to get the latest changes, there's no need to rebuild the toolchain. You can simply run `make install`, `make image`, `make run` again. CMake will only rebuild those parts that have been updated.
 
-You may also want to replace `make` with `ninja` in the above (use `cmake .. -G Ninja` when configuring the build) for some additional build speed benefits.
+You may also want to replace `make` with `ninja` in the above commands for some additional build speed benefits. To do this, go to an empty directory at the root and call `cmake .. -G Ninja` inside that directory. You might either create a new directory or reuse the existing `Build` directory after cleaning it.
 
 #### Ports
-To add a package from the ports collection to Serenity, for example curl, go into `Ports/curl/` and run **./package.sh**. The sourcecode for the package will be downloaded and the package will be built. After that, run **./sync.sh** from the `Kernel/` directory to update the disk image. The next time you start Serenity with **./run**, `curl` will be available.
+To add a package from the ports collection to Serenity, for example curl, go into `Ports/curl/` and run **./package.sh**. The sourcecode for the package will be downloaded and the package will be built. After that, run **make image** from the `Build/` directory to update the disk image. The next time you start Serenity with **make run**, `curl` will be available.

--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -2,7 +2,7 @@
 
 For low-level styling (spaces, parentheses, brace placement, etc), all code should follow the format specified in `.clang-format` in the project root.
 
-**Important: Make sure you use `clang-format` version 8 or later!**
+**Important: Make sure you use `clang-format` version 10 or later!**
 
 This document describes the coding style used for C++ code in the Serenity Operating System project. All new code should conform to this style.
 


### PR DESCRIPTION
List of changes:
- The required clang-format version has been updated to 10 as per #2213
- The cmake command has been moved away from the main build instructions since the BuildIt script executes it automatically
- The ninja install has been clarified to take the BuildIt script into account and explain that the folder needs to be cleaned before executing cmake
- `brew install bash` has been added to the macOS prerequisites (as per https://github.com/SerenityOS/serenity/pull/2132#issuecomment-628819467)
- The ports instructions have been updated to use the make commands
- The build instructions headers have been indented to group the prerequisites together
- The build instructions code snippets have been standardized into code blocks
- Fixed a typo

Closes #2213 