### PR TITLE
LibCore: Make IODevice::can_read_line() const

### DIFF
--- a/Libraries/LibCore/IODevice.cpp
+++ b/Libraries/LibCore/IODevice.cpp
@@ -121,7 +121,7 @@ bool IODevice::can_read_from_fd() const
     return FD_ISSET(m_fd, &rfds);
 }
 
-bool IODevice::can_read_line()
+bool IODevice::can_read_line() const
 {
     if (m_eof && !m_buffered_data.is_empty())
         return true;
@@ -206,7 +206,7 @@ ByteBuffer IODevice::read_line(size_t max_size)
     return {};
 }
 
-bool IODevice::populate_read_buffer()
+bool IODevice::populate_read_buffer() const
 {
     if (m_fd < 0)
         return false;

--- a/Libraries/LibCore/IODevice.h
+++ b/Libraries/LibCore/IODevice.h
@@ -65,8 +65,7 @@ public:
     bool write(const u8*, int size);
     bool write(const StringView&);
 
-    // FIXME: I would like this to be const but currently it needs to call populate_read_buffer().
-    bool can_read_line();
+    bool can_read_line() const;
 
     bool can_read() const;
 
@@ -88,20 +87,20 @@ protected:
 
     void set_fd(int);
     void set_mode(OpenMode mode) { m_mode = mode; }
-    void set_error(int error) { m_error = error; }
-    void set_eof(bool eof) { m_eof = eof; }
+    void set_error(int error) const { m_error = error; }
+    void set_eof(bool eof) const { m_eof = eof; }
 
-    virtual void did_update_fd(int) {}
+    virtual void did_update_fd(int) { }
 
 private:
-    bool populate_read_buffer();
+    bool populate_read_buffer() const;
     bool can_read_from_fd() const;
 
     int m_fd { -1 };
-    int m_error { 0 };
-    bool m_eof { false };
     OpenMode m_mode { NotOpen };
-    Vector<u8> m_buffered_data;
+    mutable int m_error { 0 };
+    mutable bool m_eof { false };
+    mutable Vector<u8> m_buffered_data;
 };
 
 }

--- a/Libraries/LibHTTP/HttpJob.cpp
+++ b/Libraries/LibHTTP/HttpJob.cpp
@@ -73,7 +73,7 @@ void HttpJob::register_on_ready_to_write(Function<void()> callback)
     callback();
 }
 
-bool HttpJob::can_read_line()
+bool HttpJob::can_read_line() const
 {
     return m_socket->can_read_line();
 }

--- a/Libraries/LibHTTP/HttpJob.h
+++ b/Libraries/LibHTTP/HttpJob.h
@@ -53,7 +53,7 @@ public:
 protected:
     virtual void register_on_ready_to_read(Function<void()>) override;
     virtual void register_on_ready_to_write(Function<void()>) override;
-    virtual bool can_read_line() override;
+    virtual bool can_read_line() const override;
     virtual ByteBuffer read_line(size_t) override;
     virtual bool can_read() const override;
     virtual ByteBuffer receive(size_t) override;

--- a/Libraries/LibHTTP/HttpsJob.cpp
+++ b/Libraries/LibHTTP/HttpsJob.cpp
@@ -104,7 +104,7 @@ void HttpsJob::register_on_ready_to_write(Function<void()> callback)
     };
 }
 
-bool HttpsJob::can_read_line()
+bool HttpsJob::can_read_line() const
 {
     return m_socket->can_read_line();
 }

--- a/Libraries/LibHTTP/HttpsJob.h
+++ b/Libraries/LibHTTP/HttpsJob.h
@@ -53,7 +53,7 @@ public:
 protected:
     virtual void register_on_ready_to_read(Function<void()>) override;
     virtual void register_on_ready_to_write(Function<void()>) override;
-    virtual bool can_read_line() override;
+    virtual bool can_read_line() const override;
     virtual ByteBuffer read_line(size_t) override;
     virtual bool can_read() const override;
     virtual ByteBuffer receive(size_t) override;

--- a/Libraries/LibHTTP/Job.h
+++ b/Libraries/LibHTTP/Job.h
@@ -51,8 +51,7 @@ protected:
     void on_socket_connected();
     virtual void register_on_ready_to_read(Function<void()>) = 0;
     virtual void register_on_ready_to_write(Function<void()>) = 0;
-    // FIXME: I want const but Core::IODevice::can_read_line populates a cache with this
-    virtual bool can_read_line() = 0;
+    virtual bool can_read_line() const = 0;
     virtual ByteBuffer read_line(size_t) = 0;
     virtual bool can_read() const = 0;
     virtual ByteBuffer receive(size_t) = 0;


### PR DESCRIPTION
such const-correctness, much wow

I'm going to leave the `{} -> { }` changes in (as per #2213), if we'd rather do that in a separate commit, I can drop those.

-> Fixes #2219