### PR TITLE
Build: FreeBSD support

### DIFF
--- a/AK/Tests/TestRefPtr.cpp
+++ b/AK/Tests/TestRefPtr.cpp
@@ -79,7 +79,16 @@ TEST_CASE(assign_copy_self)
 {
     RefPtr<Object> object = adopt(*new Object);
     EXPECT_EQ(object->ref_count(), 1);
-    object = object;
+
+    #ifdef __clang__
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wself-assign-overloaded"
+    #endif
+        object = object;
+    #ifdef __clang__
+    #pragma clang diagnostic pop
+    #endif
+
     EXPECT_EQ(object->ref_count(), 1);
 }
 

--- a/AK/Tests/TestWeakPtr.cpp
+++ b/AK/Tests/TestWeakPtr.cpp
@@ -29,6 +29,11 @@
 #include <AK/Weakable.h>
 #include <AK/WeakPtr.h>
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
+#endif
+
 class SimpleWeakable : public Weakable<SimpleWeakable> {
 public:
     SimpleWeakable() {}
@@ -36,6 +41,10 @@ public:
 private:
     int m_member { 123 };
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 TEST_CASE(basic_weak)
 {

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -65,6 +65,12 @@ Notes:
 pkg_add bash gmp gcc git flock gmake sudo
 ```
 
+#### FreeBSD prerequisites
+```
+$ pkg add coreutils gmake bash sudo git
+$ ln -s /usr/local/bin/ginstall /usr/local/bin/install
+```
+
 ### Build
 > Before starting, make sure that you have configured your global identity for git, or the first script will fail after running for a bit.
 


### PR DESCRIPTION
This commit fixes **FreeBSD** support on the new CMake build system.

It changes the following:
* `CMakeLists.txt` was updated to take the GNU GCC branch so it can
  define `-Wno-expansion-to-defined` flag. It would originally
  take the **Clang** branch, which was incorrect.
* Updated tests to fix warnings: `-Wunused-private-field` and `-Wself-assign-overload` respectively.

Reason why build fails on FreeBSD is that when we generate Makefiles, CMake picks up our system's default compiler (clang) and applies rules designed for Clang. However, once we compile using our cross-compiler, these (clang) flags are then put in effect and break the build.

As a side note, I recommend installing `sysutils/coreutils` port as well as `bash` and `gmake` as these are required to build the project successfully.

You should also link `/usr/local/bin/ginstall` to `install` so that cmake can leverage this command properly.