### PR TITLE
LibELF: Handle DT_SONAME dynamic entries

### DIFF
--- a/Libraries/LibELF/DynamicObject.cpp
+++ b/Libraries/LibELF/DynamicObject.cpp
@@ -59,6 +59,9 @@ void DynamicObject::dump() const
         return IterationDecision::Continue;
     });
 
+    if (m_has_soname)
+        builder.appendf("DT_SONAME: %s\n", soname()); // FIXME: Valdidate that this string is null terminated?
+
     dbgprintf("Dynamic section at address 0x%x contains %zu entries:\n", m_dynamic_address.as_ptr(), num_dynamic_sections);
     dbgprintf(builder.to_string().characters());
 }
@@ -134,6 +137,10 @@ void DynamicObject::parse()
             break;
         case DT_TEXTREL:
             m_dt_flags |= DF_TEXTREL; // This tag seems to exist for legacy reasons only?
+            break;
+        case DT_SONAME:
+            m_soname_index = entry.val();
+            m_has_soname = true;
             break;
         default:
             dbgprintf("DynamicObject: DYNAMIC tag handling not implemented for DT_%s\n", name_for_dtag(entry.tag()));

--- a/Libraries/LibELF/DynamicObject.h
+++ b/Libraries/LibELF/DynamicObject.h
@@ -213,6 +213,8 @@ public:
     VirtualAddress plt_got_base_address() const { return m_base_address.offset(m_procedure_linkage_table_offset); }
     VirtualAddress base_address() const { return m_base_address; }
 
+    const char* soname() const { return m_has_soname ? symbol_string_table_string(m_soname_index) : nullptr; }
+
 private:
     const char* symbol_string_table_string(Elf32_Word) const;
     void parse();
@@ -259,6 +261,9 @@ private:
 
     // DT_FLAGS
     Elf32_Word m_dt_flags { 0 };
+
+    bool m_has_soname { false };
+    Elf32_Word m_soname_index { 0 }; // Index into dynstr table for SONAME
     // End Section information from DT_* entries
 };
 


### PR DESCRIPTION
Store the offset in the string table for the DT_SONAME entry. Now that
the build uses cmake, cmake is helpfully passing --Wl,-soname to the
linker for shared objects. This makes the LinkDemo run again.