### PR TITLE
Build: Use -Wno-expansion-to-defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,14 +96,10 @@ set(CMAKE_AR ${TOOLCHAIN_PREFIX}ar)
 
 #FIXME: -fstack-protector
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os -Wno-sized-deallocation -fno-sized-deallocation -fno-exceptions -fno-rtti -Wno-address-of-packed-member -Wundef -Wcast-qual -Wwrite-strings -Wimplicit-fallthrough -Wno-nonnull-compare -Wno-deprecated-copy")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os -Wno-sized-deallocation -fno-sized-deallocation -fno-exceptions -fno-rtti -Wno-address-of-packed-member -Wundef -Wcast-qual -Wwrite-strings -Wimplicit-fallthrough -Wno-nonnull-compare -Wno-deprecated-copy -Wno-expansion-to-defined")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG -DSANITIZE_PTRS")
 add_link_options(--sysroot ${CMAKE_BINARY_DIR}/Root)
-
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-expansion-to-defined")
-endif()
 
 include_directories(Libraries/LibC)
 include_directories(Services)


### PR DESCRIPTION
Originally, we would use `-Wno-expansion-to-defined` only when the host compiler is GCC, however that breaks the project compilation when the host compiler is Clang, since the flag is absent in such configuration, despite the fact it's actually required to be present for the cross compiler itself.