### PR TITLE
AK: Fix URL's operator<<() and use it / Handle "protocol relative URLs" in URL::complete_url()

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -293,6 +293,12 @@ URL URL::complete_url(const String& string) const
     if (url.is_valid())
         return url;
 
+    if (string.starts_with("//")) {
+        URL url(String::format("%s:%s", m_protocol.characters(), string.characters()));
+        if (url.is_valid())
+            return url;
+    }
+
     if (string.starts_with("/")) {
         url = *this;
         url.set_path(string);

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -89,11 +89,9 @@ private:
     String m_data_payload;
 };
 
-}
-
-using AK::URL;
-
 inline const LogStream& operator<<(const LogStream& stream, const URL& value)
 {
     return stream << value.to_string();
+}
+
 }

--- a/Libraries/LibWeb/DOM/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/DOM/HTMLScriptElement.cpp
@@ -95,6 +95,7 @@ void HTMLScriptElement::inserted_into(Node& new_parent)
         return;
     }
 
+    dbg() << "Parsing and running script from " << src_url;
     auto parser = JS::Parser(JS::Lexer(source));
     auto program = parser.parse_program();
     if (parser.has_errors()) {

--- a/Libraries/LibWeb/DOM/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/DOM/HTMLScriptElement.cpp
@@ -78,7 +78,7 @@ void HTMLScriptElement::inserted_into(Node& new_parent)
 
     URL src_url = document().complete_url(src);
     if (src_url.protocol() == "file" && document().url().protocol() != src_url.protocol()) {
-        dbg() << "HTMLScriptElement: Forbidden to load " << src_url.to_string() << " from " << document().url().to_string();
+        dbg() << "HTMLScriptElement: Forbidden to load " << src_url << " from " << document().url();
         return;
     }
 

--- a/Libraries/LibWeb/HtmlView.cpp
+++ b/Libraries/LibWeb/HtmlView.cpp
@@ -433,7 +433,7 @@ static RefPtr<Document> create_document_from_mime_type(const ByteBuffer& data, c
 
 void HtmlView::load(const URL& url)
 {
-    dbg() << "HtmlView::load: " << url.to_string();
+    dbg() << "HtmlView::load: " << url;
 
     if (!url.is_valid()) {
         load_error_page(url, "Invalid URL");
@@ -495,11 +495,11 @@ void HtmlView::load(const URL& url)
         ResourceLoader::the().load(
             favicon_url,
             [this, favicon_url](auto data, auto&) {
-                dbg() << "Favicon downloaded, " << data.size() << " bytes from " << favicon_url.to_string();
+                dbg() << "Favicon downloaded, " << data.size() << " bytes from " << favicon_url;
                 auto decoder = Gfx::ImageDecoder::create(data.data(), data.size());
                 auto bitmap = decoder->bitmap();
                 if (!bitmap) {
-                    dbg() << "Could not decode favicon " << favicon_url.to_string();
+                    dbg() << "Could not decode favicon " << favicon_url;
                     return;
                 }
                 dbg() << "Decoded favicon, " << bitmap->size();


### PR DESCRIPTION
The existing `operator<<()` for `AK::URL` wouldn't compile when using it - no idea why but moving it inside the namespace fixed it.

Also handle URLs starting with `//` properly, i.e. prepend the document URL's protocol.

Closes https://github.com/SerenityOS/serenity/issues/2250, where `//some.host/some/script.js` would be completed as `https://www.minecraft.net//some.host/some/script.js` and the resulting 404 HTML page fed to the parser making it blow up.

(now it chokes on the CSS parser but that's another story)