### PR TITLE
Shell: Properly handle parser syntax errors

### DIFF
--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -857,6 +857,9 @@ static ExitCodeOrContinuationRequest run_command(const StringView& cmd)
 
     auto commands = Parser(cmd).parse();
 
+    if (!commands.size())
+        return 1;
+
     auto needs_more = is_complete(commands);
     if (needs_more != ExitCodeOrContinuationRequest::Nothing)
         return needs_more;


### PR DESCRIPTION
In the case of a syntax error the shell parser prints an error message to stderr and returns an empty `Vector<Command>` - in that case we shouldn't try to determine whether or not we can continue parsing but abort immediately - `is_complete()` expects that *something* was parsed successfully.

Fixes #2251.