### PR TITLE
LibJS: Add hex and unicode escape sequences

### DIFF
--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -70,6 +70,7 @@ public:
     NonnullRefPtr<Expression> parse_unary_prefixed_expression();
     NonnullRefPtr<ObjectExpression> parse_object_expression();
     NonnullRefPtr<ArrayExpression> parse_array_expression();
+    NonnullRefPtr<StringLiteral> parse_string_literal(Token token);
     NonnullRefPtr<TemplateLiteral> parse_template_literal(bool is_tagged);
     NonnullRefPtr<Expression> parse_secondary_expression(NonnullRefPtr<Expression>, int min_precedence, Associativity associate = Associativity::Right);
     NonnullRefPtr<CallExpression> parse_call_expression(NonnullRefPtr<Expression>);

--- a/Libraries/LibJS/Tests/string-escapes.js
+++ b/Libraries/LibJS/Tests/string-escapes.js
@@ -1,0 +1,17 @@
+load("test-common.js")
+
+try {
+    assert("\x55" === "U");
+    assert("\X55" === "X55");
+    assert(`\x55` === "U");
+    assert(`\X55` === "X55");
+
+    assert("\u26a0" === "⚠");
+    assert(`\u26a0` === "⚠");
+    assert("\u{1f41e}" === "🐞");
+    assert(`\u{1f41e}` === "🐞");
+    
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -172,8 +172,15 @@ public:
     size_t line_number() const { return m_line_number; }
     size_t line_column() const { return m_line_column; }
     double double_value() const;
-    String string_value() const;
     bool bool_value() const;
+
+    enum class StringValueStatus {
+        Ok,
+        MalformedHexEscape,
+        MalformedUnicodeEscape,
+        UnicodeEscapeOverflow,
+    };
+    String string_value(StringValueStatus& status) const;
 
     bool is_identifier_name() const;
 


### PR DESCRIPTION
Inspired by the recent terminal UTF-8 support, this PR adds support for the following:

```js
'\x55'      // => 'U'
'\u26a0'    // => '⚠'
'\u{1f41e}' // => '🐞'
```

All of the above also work within template literals. I was planning on also adding octal escape sequences, but it seems like they're deprecated in ES6 -- using them in strict mode generates a syntax error. Knowing that, I didn't think it was super important to add them in this PR (or, really at all). 