### PR TITLE
Shell: Attach links to completed paths 

### DIFF
--- a/Libraries/LibLine/Style.h
+++ b/Libraries/LibLine/Style.h
@@ -25,6 +25,7 @@
  */
 
 #pragma once
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <stdlib.h>
@@ -43,8 +44,11 @@ public:
         Magenta,
         Cyan,
         White,
+        Unchanged,
     };
 
+    struct AnchoredTag {
+    };
     struct UnderlineTag {
     };
     struct BoldTag {
@@ -63,8 +67,13 @@ public:
         {
         }
 
-        XtermColor m_xterm_color { XtermColor::Default };
-        Vector<u8, 3> m_rgb_color;
+        bool is_default() const
+        {
+            return !m_is_rgb && m_xterm_color == XtermColor::Unchanged;
+        }
+
+        XtermColor m_xterm_color { XtermColor::Unchanged };
+        Vector<int, 3> m_rgb_color;
         bool m_is_rgb { false };
     };
 
@@ -93,9 +102,27 @@ public:
         String to_vt_escape() const;
     };
 
+    struct Hyperlink {
+        explicit Hyperlink(const StringView& link)
+            : m_link(link)
+        {
+            m_has_link = true;
+        }
+
+        Hyperlink() { }
+
+        String to_vt_escape(bool starting) const;
+
+        bool is_empty() const { return !m_has_link; }
+
+        String m_link;
+        bool m_has_link { false };
+    };
+
     static constexpr UnderlineTag Underline {};
     static constexpr BoldTag Bold {};
     static constexpr ItalicTag Italic {};
+    static constexpr AnchoredTag Anchored {};
 
     // prepare for the horror of templates
     template<typename T, typename... Rest>
@@ -103,26 +130,54 @@ public:
         : Style(rest...)
     {
         set(style_arg);
+        m_is_empty = false;
     }
     Style() { }
+
+    static Style reset_style()
+    {
+        return { Foreground(XtermColor::Default), Background(XtermColor::Default), Hyperlink("") };
+    }
+
+    Style unified_with(const Style& other, bool prefer_other = true) const
+    {
+        Style style = *this;
+        style.unify_with(other, prefer_other);
+        return style;
+    }
+
+    void unify_with(const Style&, bool prefer_other = false);
 
     bool underline() const { return m_underline; }
     bool bold() const { return m_bold; }
     bool italic() const { return m_italic; }
     Background background() const { return m_background; }
     Foreground foreground() const { return m_foreground; }
+    Hyperlink hyperlink() const { return m_hyperlink; }
 
     void set(const ItalicTag&) { m_italic = true; }
     void set(const BoldTag&) { m_bold = true; }
     void set(const UnderlineTag&) { m_underline = true; }
     void set(const Background& bg) { m_background = bg; }
     void set(const Foreground& fg) { m_foreground = fg; }
+    void set(const Hyperlink& link) { m_hyperlink = link; }
+    void set(const AnchoredTag&) { m_is_anchored = true; }
+
+    bool is_anchored() const { return m_is_anchored; }
+    bool is_empty() const { return m_is_empty; }
+
+    String to_string() const;
 
 private:
     bool m_underline { false };
     bool m_bold { false };
     bool m_italic { false };
-    Background m_background { XtermColor::Default };
-    Foreground m_foreground { XtermColor::Default };
+    Background m_background { XtermColor::Unchanged };
+    Foreground m_foreground { XtermColor::Unchanged };
+    Hyperlink m_hyperlink;
+
+    bool m_is_anchored { false };
+
+    bool m_is_empty { true };
 };
 }

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -1578,9 +1578,9 @@ Vector<Line::CompletionSuggestion> Shell::complete(const Line::Editor& editor)
             if (!stat_error) {
                 if (S_ISDIR(program_status.st_mode)) {
                     if (!should_suggest_only_executables)
-                        suggestions.append({ escape_token(file), "/" });
+                        suggestions.append({ escape_token(file), "/", { Line::Style::Hyperlink(String::format("file://%s", file_path.characters())), Line::Style::Anchored } });
                 } else {
-                    suggestions.append({ escape_token(file), " " });
+                    suggestions.append({ escape_token(file), " ", { Line::Style::Hyperlink(String::format("file://%s", file_path.characters())), Line::Style::Anchored } });
                 }
             }
         }


### PR DESCRIPTION
This patch adds the concept of "anchored" styles, which are applied to a specific part of the line, and are tracked to always stay applied to that specific part.

Further, the main goal of the PR is to attach links to completed paths:
```
ls ./Ter<tab>
```
gets you a link to ./Terminal.ini, which you may edit without the link disappearing or changing.

As with all lunches, nothing is ever free, we lost some performance for relocating anchored styles, but we only pay for them when we use them :tm: