### PR TITLE
LibJS: Make Value::to_number() failproof

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -941,11 +941,12 @@ Value UpdateExpression::execute(Interpreter& interpreter) const
     auto reference = m_argument->to_reference(interpreter);
     if (interpreter.exception())
         return {};
-
     auto old_value = reference.get(interpreter);
     if (interpreter.exception())
         return {};
-    old_value = old_value.to_number();
+    old_value = old_value.to_number(interpreter);
+    if (interpreter.exception())
+        return {};
 
     int op_result = 0;
     switch (m_op) {

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -96,7 +96,7 @@ CallExpression::ThisAndCallee CallExpression::compute_this_and_callee(Interprete
         auto object_value = member_expression.object().execute(interpreter);
         if (interpreter.exception())
             return {};
-        auto* this_value = object_value.to_object(interpreter.heap());
+        auto* this_value = object_value.to_object(interpreter);
         if (interpreter.exception())
             return {};
         auto callee = this_value->get(member_expression.computed_property_name(interpreter)).value_or(js_undefined());
@@ -431,7 +431,7 @@ Reference MemberExpression::to_reference(Interpreter& interpreter) const
     auto object_value = m_object->execute(interpreter);
     if (object_value.is_empty())
         return {};
-    auto* object = object_value.to_object(interpreter.heap());
+    auto* object = object_value.to_object(interpreter);
     if (!object)
         return {};
     auto property_name = computed_property_name(interpreter);
@@ -452,7 +452,7 @@ Value UnaryExpression::execute(Interpreter& interpreter) const
         ASSERT(!reference.is_local_variable());
         if (reference.is_global_variable())
             return interpreter.global_object().delete_property(reference.name());
-        auto* base_object = reference.base().to_object(interpreter.heap());
+        auto* base_object = reference.base().to_object(interpreter);
         if (!base_object)
             return {};
         return base_object->delete_property(reference.name());
@@ -1213,7 +1213,7 @@ Value MemberExpression::execute(Interpreter& interpreter) const
     auto object_value = m_object->execute(interpreter);
     if (interpreter.exception())
         return {};
-    auto* object_result = object_value.to_object(interpreter.heap());
+    auto* object_result = object_value.to_object(interpreter);
     if (interpreter.exception())
         return {};
     return object_result->get(computed_property_name(interpreter)).value_or(js_undefined());

--- a/Libraries/LibJS/Runtime/Array.cpp
+++ b/Libraries/LibJS/Runtime/Array.cpp
@@ -74,7 +74,9 @@ void Array::length_setter(Interpreter& interpreter, Value value)
     auto* array = array_from(interpreter);
     if (!array)
         return;
-    auto length = value.to_number();
+    auto length = value.to_number(interpreter);
+    if (interpreter.exception())
+        return;
     if (length.is_nan() || length.is_infinity() || length.as_double() < 0) {
         interpreter.throw_exception<RangeError>("Invalid array length");
         return;

--- a/Libraries/LibJS/Runtime/Array.cpp
+++ b/Libraries/LibJS/Runtime/Array.cpp
@@ -51,7 +51,7 @@ Array::~Array()
 
 Array* array_from(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     if (!this_object->is_array()) {

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -297,7 +297,9 @@ Value ArrayPrototype::slice(Interpreter& interpreter)
     }
 
     ssize_t array_size = static_cast<ssize_t>(array->elements().size());
-    auto start_slice = interpreter.argument(0).to_i32();
+    auto start_slice = interpreter.argument(0).to_i32(interpreter);
+    if (interpreter.exception())
+        return {};
     auto end_slice = array_size;
 
     if (start_slice > array_size)
@@ -307,8 +309,9 @@ Value ArrayPrototype::slice(Interpreter& interpreter)
         start_slice = end_slice + start_slice;
 
     if (interpreter.argument_count() >= 2) {
-        end_slice = interpreter.argument(1).to_i32();
-
+        end_slice = interpreter.argument(1).to_i32(interpreter);
+        if (interpreter.exception())
+            return {};
         if (end_slice < 0)
             end_slice = array_size + end_slice;
         else if (end_slice > array_size)
@@ -336,11 +339,11 @@ Value ArrayPrototype::index_of(Interpreter& interpreter)
 
     i32 from_index = 0;
     if (interpreter.argument_count() >= 2) {
-        from_index = interpreter.argument(1).to_number().to_i32();
-
+        from_index = interpreter.argument(1).to_i32(interpreter);
+        if (interpreter.exception())
+            return {};
         if (from_index >= array_size)
             return Value(-1);
-
         auto negative_min_index = ((array_size - 1) * -1);
         if (from_index < negative_min_index)
             from_index = 0;
@@ -390,11 +393,11 @@ Value ArrayPrototype::last_index_of(Interpreter& interpreter)
 
     i32 from_index = 0;
     if (interpreter.argument_count() >= 2) {
-        from_index = interpreter.argument(1).to_number().to_i32();
-
+        from_index = interpreter.argument(1).to_i32(interpreter);
+        if (interpreter.exception())
+            return {};
         if (from_index >= array_size)
             return Value(-1);
-
         auto negative_min_index = ((array_size - 1) * -1);
         if (from_index < negative_min_index)
             from_index = 0;
@@ -424,11 +427,11 @@ Value ArrayPrototype::includes(Interpreter& interpreter)
 
     i32 from_index = 0;
     if (interpreter.argument_count() >= 2) {
-        from_index = interpreter.argument(1).to_i32();
-
+        from_index = interpreter.argument(1).to_i32(interpreter);
+        if (interpreter.exception())
+            return {};
         if (from_index >= array_size)
             return Value(false);
-
         auto negative_min_index = ((array_size - 1) * -1);
         if (from_index < negative_min_index)
             from_index = 0;

--- a/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -38,7 +38,7 @@ namespace JS {
 
 static Date* this_date_from_interpreter(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return nullptr;
     if (!this_object->is_date()) {

--- a/Libraries/LibJS/Runtime/ErrorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ErrorPrototype.cpp
@@ -50,7 +50,7 @@ ErrorPrototype::~ErrorPrototype()
 
 Value ErrorPrototype::name_getter(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     if (!this_object->is_error())
@@ -60,7 +60,7 @@ Value ErrorPrototype::name_getter(Interpreter& interpreter)
 
 void ErrorPrototype::name_setter(Interpreter& interpreter, Value value)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return;
     if (!this_object->is_error()) {
@@ -75,7 +75,7 @@ void ErrorPrototype::name_setter(Interpreter& interpreter, Value value)
 
 Value ErrorPrototype::message_getter(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     if (!this_object->is_error())

--- a/Libraries/LibJS/Runtime/ErrorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ErrorPrototype.cpp
@@ -90,17 +90,17 @@ Value ErrorPrototype::to_string(Interpreter& interpreter)
     auto& this_object = interpreter.this_value().as_object();
 
     String name = "Error";
-    auto object_name_property = this_object.get("name");
-    if (!object_name_property.is_empty() && !object_name_property.is_undefined()) {
-        name = object_name_property.to_string(interpreter);
+    auto name_property = this_object.get("name");
+    if (!name_property.is_empty() && !name_property.is_undefined()) {
+        name = name_property.to_string(interpreter);
         if (interpreter.exception())
             return {};
     }
 
     String message = "";
-    auto object_message_property = this_object.get("message");
-    if (!object_message_property.is_empty() && !object_message_property.is_undefined()) {
-        message = object_message_property.to_string(interpreter);
+    auto message_property = this_object.get("message");
+    if (!message_property.is_empty() && !message_property.is_undefined()) {
+        message = message_property.to_string(interpreter);
         if (interpreter.exception())
             return {};
     }

--- a/Libraries/LibJS/Runtime/Function.cpp
+++ b/Libraries/LibJS/Runtime/Function.cpp
@@ -60,7 +60,7 @@ BoundFunction* Function::bind(Value bound_this_value, Vector<Value> arguments)
             // FIXME: Null or undefined should be passed through in strict mode.
             return &interpreter().global_object();
         default:
-            return bound_this_value.to_object(interpreter().heap());
+            return bound_this_value.to_object(interpreter());
         }
     }();
 

--- a/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -60,7 +60,7 @@ FunctionPrototype::~FunctionPrototype()
 
 Value FunctionPrototype::apply(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     if (!this_object->is_function())
@@ -86,7 +86,7 @@ Value FunctionPrototype::apply(Interpreter& interpreter)
 
 Value FunctionPrototype::bind(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     if (!this_object->is_function())
@@ -106,7 +106,7 @@ Value FunctionPrototype::bind(Interpreter& interpreter)
 
 Value FunctionPrototype::call(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     if (!this_object->is_function())
@@ -123,7 +123,7 @@ Value FunctionPrototype::call(Interpreter& interpreter)
 
 Value FunctionPrototype::to_string(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     if (!this_object->is_function())

--- a/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -73,7 +73,11 @@ Value FunctionPrototype::apply(Interpreter& interpreter)
     if (!arg_array.is_object())
         return interpreter.throw_exception<TypeError>("argument array must be an object");
     auto length_property = arg_array.as_object().get("length");
-    auto length = length_property.to_size_t();
+    if (interpreter.exception())
+        return {};
+    auto length = length_property.to_size_t(interpreter);
+    if (interpreter.exception())
+        return {};
     MarkedValueList arguments(interpreter.heap());
     for (size_t i = 0; i < length; ++i) {
         auto element = arg_array.as_object().get(String::number(i));

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -137,12 +137,18 @@ Value GlobalObject::gc(Interpreter& interpreter)
 
 Value GlobalObject::is_nan(Interpreter& interpreter)
 {
-    return Value(interpreter.argument(0).to_number().is_nan());
+    auto number = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
+    return Value(number.is_nan());
 }
 
 Value GlobalObject::is_finite(Interpreter& interpreter)
 {
-    return Value(interpreter.argument(0).to_number().is_finite_number());
+    auto number = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
+    return Value(number.is_finite_number());
 }
 
 Value GlobalObject::parse_float(Interpreter& interpreter)
@@ -151,7 +157,8 @@ Value GlobalObject::parse_float(Interpreter& interpreter)
     if (interpreter.exception())
         return {};
     for (size_t length = string.length(); length > 0; --length) {
-        auto number = Value(js_string(interpreter, string.substring(0, length))).to_number();
+        // This can't throw, so no exception check is fine.
+        auto number = Value(js_string(interpreter, string.substring(0, length))).to_number(interpreter);
         if (!number.is_nan())
             return number;
     }

--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -67,7 +67,9 @@ MathObject::~MathObject()
 
 Value MathObject::abs(Interpreter& interpreter)
 {
-    auto number = interpreter.argument(0).to_number();
+    auto number = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
     if (number.is_nan())
         return js_nan();
     return Value(number.as_double() >= 0 ? number.as_double() : -number.as_double());
@@ -85,7 +87,9 @@ Value MathObject::random(Interpreter&)
 
 Value MathObject::sqrt(Interpreter& interpreter)
 {
-    auto number = interpreter.argument(0).to_number();
+    auto number = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
     if (number.is_nan())
         return js_nan();
     return Value(::sqrt(number.as_double()));
@@ -93,7 +97,9 @@ Value MathObject::sqrt(Interpreter& interpreter)
 
 Value MathObject::floor(Interpreter& interpreter)
 {
-    auto number = interpreter.argument(0).to_number();
+    auto number = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
     if (number.is_nan())
         return js_nan();
     return Value(::floor(number.as_double()));
@@ -101,7 +107,9 @@ Value MathObject::floor(Interpreter& interpreter)
 
 Value MathObject::ceil(Interpreter& interpreter)
 {
-    auto number = interpreter.argument(0).to_number();
+    auto number = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
     if (number.is_nan())
         return js_nan();
     return Value(::ceil(number.as_double()));
@@ -109,7 +117,9 @@ Value MathObject::ceil(Interpreter& interpreter)
 
 Value MathObject::round(Interpreter& interpreter)
 {
-    auto number = interpreter.argument(0).to_number();
+    auto number = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
     if (number.is_nan())
         return js_nan();
     return Value(::round(number.as_double()));
@@ -120,12 +130,13 @@ Value MathObject::max(Interpreter& interpreter)
     if (!interpreter.argument_count())
         return js_negative_infinity();
 
-    if (interpreter.argument_count() == 1)
-        return interpreter.argument(0).to_number();
-
-    Value max = interpreter.argument(0).to_number();
+    auto max = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
     for (size_t i = 1; i < interpreter.argument_count(); ++i) {
-        Value cur = interpreter.argument(i).to_number();
+        auto cur = interpreter.argument(i).to_number(interpreter);
+        if (interpreter.exception())
+            return {};
         max = Value(cur.as_double() > max.as_double() ? cur : max);
     }
     return max;
@@ -136,12 +147,13 @@ Value MathObject::min(Interpreter& interpreter)
     if (!interpreter.argument_count())
         return js_infinity();
 
-    if (interpreter.argument_count() == 1)
-        return interpreter.argument(0).to_number();
-
-    Value min = interpreter.argument(0).to_number();
+    auto min = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
     for (size_t i = 1; i < interpreter.argument_count(); ++i) {
-        Value cur = interpreter.argument(i).to_number();
+        auto cur = interpreter.argument(i).to_number(interpreter);
+        if (interpreter.exception())
+            return {};
         min = Value(cur.as_double() < min.as_double() ? cur : min);
     }
     return min;
@@ -149,10 +161,11 @@ Value MathObject::min(Interpreter& interpreter)
 
 Value MathObject::trunc(Interpreter& interpreter)
 {
-    auto number = interpreter.argument(0).to_number();
+    auto number = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
     if (number.is_nan())
         return js_nan();
-
     if (number.as_double() < 0)
         return MathObject::ceil(interpreter);
     return MathObject::floor(interpreter);
@@ -160,7 +173,9 @@ Value MathObject::trunc(Interpreter& interpreter)
 
 Value MathObject::sin(Interpreter& interpreter)
 {
-    auto number = interpreter.argument(0).to_number();
+    auto number = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
     if (number.is_nan())
         return js_nan();
     return Value(::sin(number.as_double()));
@@ -168,7 +183,9 @@ Value MathObject::sin(Interpreter& interpreter)
 
 Value MathObject::cos(Interpreter& interpreter)
 {
-    auto number = interpreter.argument(0).to_number();
+    auto number = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
     if (number.is_nan())
         return js_nan();
     return Value(::cos(number.as_double()));
@@ -176,7 +193,9 @@ Value MathObject::cos(Interpreter& interpreter)
 
 Value MathObject::tan(Interpreter& interpreter)
 {
-    auto number = interpreter.argument(0).to_number();
+    auto number = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
     if (number.is_nan())
         return js_nan();
     return Value(::tan(number.as_double()));

--- a/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -64,16 +64,17 @@ Value NumberConstructor::call(Interpreter& interpreter)
 {
     if (!interpreter.argument_count())
         return Value(0);
-    return interpreter.argument(0).to_number();
+    return interpreter.argument(0).to_number(interpreter);
 }
 
 Value NumberConstructor::construct(Interpreter& interpreter)
 {
-    double number;
-    if (!interpreter.argument_count())
-        number = 0;
-    else
-        number = interpreter.argument(0).to_number().as_double();
+    double number = 0;
+    if (interpreter.argument_count()) {
+        number = interpreter.argument(0).to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+    }
     return NumberObject::create(interpreter.global_object(), number);
 }
 
@@ -96,7 +97,7 @@ Value NumberConstructor::is_safe_integer(Interpreter& interpreter)
 {
     if (!interpreter.argument(0).is_number())
         return Value(false);
-    auto value = interpreter.argument(0).to_number().as_double();
+    auto value = interpreter.argument(0).as_double();
     return Value((int64_t)value == value && value >= MIN_SAFE_INTEGER && value <= MAX_SAFE_INTEGER);
 }
 

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -71,7 +71,7 @@ Value ObjectConstructor::get_own_property_names(Interpreter& interpreter)
 {
     if (!interpreter.argument_count())
         return {};
-    auto* object = interpreter.argument(0).to_object(interpreter.heap());
+    auto* object = interpreter.argument(0).to_object(interpreter);
     if (interpreter.exception())
         return {};
     auto* result = Array::create(interpreter.global_object());
@@ -90,7 +90,7 @@ Value ObjectConstructor::get_prototype_of(Interpreter& interpreter)
 {
     if (!interpreter.argument_count())
         return {};
-    auto* object = interpreter.argument(0).to_object(interpreter.heap());
+    auto* object = interpreter.argument(0).to_object(interpreter);
     if (interpreter.exception())
         return {};
     return object->prototype();
@@ -100,7 +100,7 @@ Value ObjectConstructor::set_prototype_of(Interpreter& interpreter)
 {
     if (interpreter.argument_count() < 2)
         return {};
-    auto* object = interpreter.argument(0).to_object(interpreter.heap());
+    auto* object = interpreter.argument(0).to_object(interpreter);
     if (interpreter.exception())
         return {};
     object->set_prototype(&const_cast<Object&>(interpreter.argument(1).as_object()));
@@ -109,7 +109,7 @@ Value ObjectConstructor::set_prototype_of(Interpreter& interpreter)
 
 Value ObjectConstructor::get_own_property_descriptor(Interpreter& interpreter)
 {
-    auto* object = interpreter.argument(0).to_object(interpreter.heap());
+    auto* object = interpreter.argument(0).to_object(interpreter);
     if (interpreter.exception())
         return {};
     auto property_key = interpreter.argument(1).to_string(interpreter);
@@ -143,7 +143,7 @@ Value ObjectConstructor::keys(Interpreter& interpreter)
     if (!interpreter.argument_count())
         return interpreter.throw_exception<TypeError>("Can't convert undefined to object");
 
-    auto* obj_arg = interpreter.argument(0).to_object(interpreter.heap());
+    auto* obj_arg = interpreter.argument(0).to_object(interpreter);
     if (interpreter.exception())
         return {};
 
@@ -155,7 +155,7 @@ Value ObjectConstructor::values(Interpreter& interpreter)
     if (!interpreter.argument_count())
         return interpreter.throw_exception<TypeError>("Can't convert undefined to object");
 
-    auto* obj_arg = interpreter.argument(0).to_object(interpreter.heap());
+    auto* obj_arg = interpreter.argument(0).to_object(interpreter);
     if (interpreter.exception())
         return {};
 
@@ -167,7 +167,7 @@ Value ObjectConstructor::entries(Interpreter& interpreter)
     if (!interpreter.argument_count())
         return interpreter.throw_exception<TypeError>("Can't convert undefined to object");
 
-    auto* obj_arg = interpreter.argument(0).to_object(interpreter.heap());
+    auto* obj_arg = interpreter.argument(0).to_object(interpreter);
     if (interpreter.exception())
         return {};
 

--- a/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -54,7 +54,7 @@ ObjectPrototype::~ObjectPrototype()
 
 Value ObjectPrototype::has_own_property(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     auto name = interpreter.argument(0).to_string(interpreter);
@@ -65,7 +65,7 @@ Value ObjectPrototype::has_own_property(Interpreter& interpreter)
 
 Value ObjectPrototype::to_string(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     return js_string(interpreter, String::format("[object %s]", this_object->class_name()));
@@ -73,7 +73,7 @@ Value ObjectPrototype::to_string(Interpreter& interpreter)
 
 Value ObjectPrototype::value_of(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     return this_object->value_of();

--- a/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Libraries/LibJS/Runtime/Reference.cpp
@@ -50,7 +50,7 @@ void Reference::put(Interpreter& interpreter, Value value)
         return;
     }
 
-    auto* object = base().to_object(interpreter.heap());
+    auto* object = base().to_object(interpreter);
     if (!object)
         return;
 
@@ -92,7 +92,7 @@ Value Reference::get(Interpreter& interpreter)
         return value;
     }
 
-    auto* object = base().to_object(interpreter.heap());
+    auto* object = base().to_object(interpreter);
     if (!object)
         return {};
 

--- a/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -64,7 +64,9 @@ static void prepare_arguments_list(Interpreter& interpreter, Value value, Marked
     auto length_property = arguments_list.get("length");
     if (interpreter.exception())
         return;
-    auto length = length_property.to_size_t();
+    auto length = length_property.to_size_t(interpreter);
+    if (interpreter.exception())
+        return;
     for (size_t i = 0; i < length; ++i) {
         auto element = arguments_list.get(String::number(i));
         if (interpreter.exception())
@@ -156,8 +158,11 @@ Value ReflectObject::delete_property(Interpreter& interpreter)
     auto property_name = PropertyName(property_key.to_string(interpreter));
     if (interpreter.exception())
         return {};
-    if (property_key.to_number().is_finite_number()) {
-        auto property_key_as_double = property_key.to_double();
+    auto property_key_number = property_key.to_number(interpreter);
+    if (interpreter.exception())
+        return {};
+    if (property_key_number.is_finite_number()) {
+        auto property_key_as_double = property_key_number.as_double();
         if (property_key_as_double >= 0 && (i32)property_key_as_double == property_key_as_double)
             property_name = PropertyName(property_key_as_double);
     }

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -37,7 +37,7 @@ namespace JS {
 
 static ScriptFunction* script_function_from(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return nullptr;
     if (!this_object->is_function()) {

--- a/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -71,7 +71,7 @@ Value StringConstructor::construct(Interpreter& interpreter)
 
 Value StringConstructor::raw(Interpreter& interpreter)
 {
-    auto* template_object = interpreter.argument(0).to_object(interpreter.heap());
+    auto* template_object = interpreter.argument(0).to_object(interpreter);
     if (interpreter.exception())
         return {};
 
@@ -83,7 +83,7 @@ Value StringConstructor::raw(Interpreter& interpreter)
     if (!raw.is_array())
         return js_string(interpreter, "");
 
-    auto& raw_array_elements = static_cast<Array*>(raw.to_object(interpreter.heap()))->elements();
+    auto& raw_array_elements = static_cast<Array*>(raw.to_object(interpreter))->elements();
     StringBuilder builder;
 
     for (size_t i = 0; i < raw_array_elements.size(); ++i) {

--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -41,7 +41,7 @@ namespace JS {
 
 static StringObject* string_object_from(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return nullptr;
     if (!this_object->is_string_object()) {
@@ -53,7 +53,7 @@ static StringObject* string_object_from(Interpreter& interpreter)
 
 static String string_from(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     return Value(this_object).to_string(interpreter);

--- a/Libraries/LibJS/Runtime/SymbolPrototype.cpp
+++ b/Libraries/LibJS/Runtime/SymbolPrototype.cpp
@@ -55,7 +55,7 @@ SymbolPrototype::~SymbolPrototype()
 
 static SymbolObject* this_symbol_from_interpreter(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return nullptr;
     if (!this_object->is_symbol_object()) {

--- a/Libraries/LibJS/Runtime/Uint8ClampedArray.cpp
+++ b/Libraries/LibJS/Runtime/Uint8ClampedArray.cpp
@@ -57,7 +57,7 @@ Uint8ClampedArray::~Uint8ClampedArray()
 
 Value Uint8ClampedArray::length_getter(Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     if (StringView(this_object->class_name()) != "Uint8ClampedArray")

--- a/Libraries/LibJS/Runtime/Uint8ClampedArray.cpp
+++ b/Libraries/LibJS/Runtime/Uint8ClampedArray.cpp
@@ -70,7 +70,10 @@ bool Uint8ClampedArray::put_by_index(i32 property_index, Value value, u8)
     // FIXME: Use attributes
     ASSERT(property_index >= 0);
     ASSERT(property_index < m_length);
-    m_data[property_index] = clamp(value.to_i32(), 0, 255);
+    auto number = value.to_i32(interpreter());
+    if (interpreter().exception())
+        return {};
+    m_data[property_index] = clamp(number, 0, 255);
     return true;
 }
 

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -231,8 +231,8 @@ Value Value::to_number(Interpreter& interpreter) const
         return Value(parsed_double);
     }
     case Type::Symbol:
-        // FIXME: Get access to the interpreter and throw a TypeError
-        ASSERT_NOT_REACHED();
+        interpreter.throw_exception<TypeError>("Can't convert symbol to number");
+        return {};
     case Type::Object:
         auto primitive = m_value.as_object->to_primitive(Object::PreferredType::Number);
         if (interpreter.exception())

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -176,25 +176,25 @@ Value Value::to_primitive(Interpreter&) const
     return *this;
 }
 
-Object* Value::to_object(Heap& heap) const
+Object* Value::to_object(Interpreter& interpreter) const
 {
     if (is_object())
         return &const_cast<Object&>(as_object());
 
     if (is_string())
-        return StringObject::create(heap.interpreter().global_object(), *m_value.as_string);
+        return StringObject::create(interpreter.global_object(), *m_value.as_string);
 
     if (is_symbol())
-        return SymbolObject::create(heap.interpreter().global_object(), *m_value.as_symbol);
+        return SymbolObject::create(interpreter.global_object(), *m_value.as_symbol);
 
     if (is_number())
-        return NumberObject::create(heap.interpreter().global_object(), m_value.as_double);
+        return NumberObject::create(interpreter.global_object(), m_value.as_double);
 
     if (is_boolean())
-        return BooleanObject::create(heap.interpreter().global_object(), m_value.as_bool);
+        return BooleanObject::create(interpreter.global_object(), m_value.as_bool);
 
     if (is_null() || is_undefined()) {
-        heap.interpreter().throw_exception<TypeError>("ToObject on null or undefined.");
+        interpreter.throw_exception<TypeError>("ToObject on null or undefined.");
         return nullptr;
     }
 

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -136,8 +136,7 @@ String Value::to_string(Interpreter& interpreter) const
 
     if (is_object()) {
         auto primitive_value = as_object().to_primitive(Object::PreferredType::String);
-        // FIXME: Maybe we should pass in the Interpreter& and call interpreter.exception() instead?
-        if (primitive_value.is_empty())
+        if (interpreter.exception())
             return {};
         return primitive_value.to_string(interpreter);
     }

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -186,14 +186,13 @@ public:
 
     String to_string(Interpreter&) const;
     PrimitiveString* to_primitive_string(Interpreter&);
+    Value to_primitive(Interpreter&) const;
+    Object* to_object(Interpreter&) const;
     bool to_boolean() const;
     Value to_number() const;
     i32 to_i32() const;
     double to_double() const;
     size_t to_size_t() const;
-    Value to_primitive(Interpreter&) const;
-
-    Object* to_object(Heap&) const;
 
     Value value_or(Value fallback) const
     {

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -188,11 +188,13 @@ public:
     PrimitiveString* to_primitive_string(Interpreter&);
     Value to_primitive(Interpreter&) const;
     Object* to_object(Interpreter&) const;
-    bool to_boolean() const;
-    Value to_number() const;
+    Value to_number(Interpreter&) const;
+    double to_double(Interpreter&) const;
     i32 to_i32() const;
-    double to_double() const;
+    i32 to_i32(Interpreter&) const;
     size_t to_size_t() const;
+    size_t to_size_t(Interpreter&) const;
+    bool to_boolean() const;
 
     Value value_or(Value fallback) const
     {

--- a/Libraries/LibJS/Tests/Symbol.prototype.toString.js
+++ b/Libraries/LibJS/Tests/Symbol.prototype.toString.js
@@ -14,13 +14,12 @@ try {
         message: "Can't convert symbol to string",
     });
     
-    // FIXME: Uncomment when this doesn't assert
-    // assertThrowsError(() => {
-    //     s1 + 1;
-    // }, {
-    //     error: TypeError,
-    //     message: "Can't convert symbol to number",
-    // });
+    assertThrowsError(() => {
+        s1 + 1;
+    }, {
+        error: TypeError,
+        message: "Can't convert symbol to number",
+    });
     
     console.log("PASS");
 } catch (e) {

--- a/Libraries/LibJS/Tests/to-number-exception.js
+++ b/Libraries/LibJS/Tests/to-number-exception.js
@@ -1,0 +1,38 @@
+load("test-common.js");
+
+try {
+    const message = "oops, Value::to_number() failed";
+    const o = { toString() { throw new Error(message); } };
+
+    assertThrowsError(() => {
+        +o;
+    }, {
+        error: Error,
+        message
+    });
+
+    assertThrowsError(() => {
+        o - 1;
+    }, {
+        error: Error,
+        message
+    });
+
+    assertThrowsError(() => {
+        "foo".charAt(o);
+    }, {
+        error: Error,
+        message
+    });
+
+    assertThrowsError(() => {
+        "bar".repeat(o);
+    }, {
+        error: Error,
+        message
+    });
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.cpp
@@ -78,7 +78,7 @@ CanvasRenderingContext2DWrapper::~CanvasRenderingContext2DWrapper()
 
 static CanvasRenderingContext2D* impl_from(JS::Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return nullptr;
     // FIXME: Verify that it's a CanvasRenderingContext2DWrapper somehow!
@@ -116,7 +116,7 @@ JS::Value CanvasRenderingContext2DWrapper::draw_image(JS::Interpreter& interpret
     if (arguments.size() < 3)
         return interpreter.throw_exception<JS::TypeError>("drawImage() needs more arguments");
 
-    auto* image_argument = arguments[0].to_object(interpreter.heap());
+    auto* image_argument = arguments[0].to_object(interpreter);
     if (!image_argument)
         return {};
     if (StringView(image_argument->class_name()) != "HTMLImageElementWrapper")
@@ -307,7 +307,7 @@ JS::Value CanvasRenderingContext2DWrapper::put_image_data(JS::Interpreter& inter
     if (!impl)
         return {};
 
-    auto* image_data_object = interpreter.argument(0).to_object(interpreter.heap());
+    auto* image_data_object = interpreter.argument(0).to_object(interpreter);
     if (!image_data_object)
         return {};
 

--- a/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.cpp
@@ -91,8 +91,21 @@ JS::Value CanvasRenderingContext2DWrapper::fill_rect(JS::Interpreter& interprete
     if (!impl)
         return {};
     auto& arguments = interpreter.call_frame().arguments;
-    if (arguments.size() >= 4)
-        impl->fill_rect(arguments[0].to_double(), arguments[1].to_double(), arguments[2].to_double(), arguments[3].to_double());
+    if (arguments.size() >= 4) {
+        auto x = arguments[0].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        auto y = arguments[1].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        auto width = arguments[2].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        auto height = arguments[3].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        impl->fill_rect(x, y, width, height);
+    }
     return JS::js_undefined();
 }
 
@@ -102,8 +115,22 @@ JS::Value CanvasRenderingContext2DWrapper::stroke_rect(JS::Interpreter& interpre
     if (!impl)
         return {};
     auto& arguments = interpreter.call_frame().arguments;
-    if (arguments.size() >= 4)
-        impl->stroke_rect(arguments[0].to_double(), arguments[1].to_double(), arguments[2].to_double(), arguments[3].to_double());
+    if (arguments.size() >= 4) {
+
+        auto x = arguments[0].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        auto y = arguments[1].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        auto width = arguments[2].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        auto height = arguments[3].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        impl->stroke_rect(x, y, width, height);
+    }
     return JS::js_undefined();
 }
 
@@ -122,9 +149,12 @@ JS::Value CanvasRenderingContext2DWrapper::draw_image(JS::Interpreter& interpret
     if (StringView(image_argument->class_name()) != "HTMLImageElementWrapper")
         return interpreter.throw_exception<JS::TypeError>(String::format("Image is not an HTMLImageElement, it's an %s", image_argument->class_name()));
 
-    auto x = arguments[1].to_double();
-    auto y = arguments[2].to_double();
-
+    auto x = arguments[1].to_double(interpreter);
+    if (interpreter.exception())
+        return {};
+    auto y = arguments[2].to_double(interpreter);
+    if (interpreter.exception())
+        return {};
     impl->draw_image(static_cast<const HTMLImageElementWrapper&>(*image_argument).node(), x, y);
     return JS::js_undefined();
 }
@@ -135,8 +165,15 @@ JS::Value CanvasRenderingContext2DWrapper::scale(JS::Interpreter& interpreter)
     if (!impl)
         return {};
     auto& arguments = interpreter.call_frame().arguments;
-    if (arguments.size() >= 2)
-        impl->scale(arguments[0].to_double(), arguments[1].to_double());
+    if (arguments.size() >= 2) {
+        auto sx = arguments[0].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        auto sy = arguments[1].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        impl->scale(sx, sy);
+    }
     return JS::js_undefined();
 }
 
@@ -146,8 +183,15 @@ JS::Value CanvasRenderingContext2DWrapper::translate(JS::Interpreter& interprete
     if (!impl)
         return {};
     auto& arguments = interpreter.call_frame().arguments;
-    if (arguments.size() >= 2)
-        impl->translate(arguments[0].to_double(), arguments[1].to_double());
+    if (arguments.size() >= 2) {
+        auto tx = arguments[0].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        auto ty = arguments[1].to_double(interpreter);
+        if (interpreter.exception())
+            return {};
+        impl->translate(tx, ty);
+    }
     return JS::js_undefined();
 }
 
@@ -161,12 +205,13 @@ JS::Value CanvasRenderingContext2DWrapper::fill_style_getter(JS::Interpreter& in
 
 void CanvasRenderingContext2DWrapper::fill_style_setter(JS::Interpreter& interpreter, JS::Value value)
 {
-    if (auto* impl = impl_from(interpreter)) {
-        auto string = value.to_string(interpreter);
-        if (interpreter.exception())
-            return;
-        impl->set_fill_style(string);
-    }
+    auto* impl = impl_from(interpreter);
+    if (!impl)
+        return;
+    auto string = value.to_string(interpreter);
+    if (interpreter.exception())
+        return;
+    impl->set_fill_style(string);
 }
 
 JS::Value CanvasRenderingContext2DWrapper::stroke_style_getter(JS::Interpreter& interpreter)
@@ -179,12 +224,13 @@ JS::Value CanvasRenderingContext2DWrapper::stroke_style_getter(JS::Interpreter& 
 
 void CanvasRenderingContext2DWrapper::stroke_style_setter(JS::Interpreter& interpreter, JS::Value value)
 {
-    if (auto* impl = impl_from(interpreter)){
-        auto string = value.to_string(interpreter);
-        if (interpreter.exception())
-            return;
-        impl->set_stroke_style(string);
-    }
+    auto* impl = impl_from(interpreter);
+    if (!impl)
+        return;
+    auto string = value.to_string(interpreter);
+    if (interpreter.exception())
+        return;
+    impl->set_stroke_style(string);
 }
 
 JS::Value CanvasRenderingContext2DWrapper::line_width_getter(JS::Interpreter& interpreter)
@@ -197,8 +243,13 @@ JS::Value CanvasRenderingContext2DWrapper::line_width_getter(JS::Interpreter& in
 
 void CanvasRenderingContext2DWrapper::line_width_setter(JS::Interpreter& interpreter, JS::Value value)
 {
-    if (auto* impl = impl_from(interpreter))
-        impl->set_line_width(value.to_double());
+    auto* impl = impl_from(interpreter);
+    if (!impl)
+        return;
+    auto line_width = value.to_double(interpreter);
+    if (interpreter.exception())
+        return;
+    impl->set_line_width(line_width);
 }
 
 JS::Value CanvasRenderingContext2DWrapper::begin_path(JS::Interpreter& interpreter)
@@ -260,8 +311,12 @@ JS::Value CanvasRenderingContext2DWrapper::move_to(JS::Interpreter& interpreter)
     auto* impl = impl_from(interpreter);
     if (!impl)
         return {};
-    double x = interpreter.argument(0).to_double();
-    double y = interpreter.argument(1).to_double();
+    auto x = interpreter.argument(0).to_double(interpreter);
+    if (interpreter.exception())
+        return {};
+    auto y = interpreter.argument(1).to_double(interpreter);
+    if (interpreter.exception())
+        return {};
     impl->move_to(x, y);
     return JS::js_undefined();
 }
@@ -271,8 +326,12 @@ JS::Value CanvasRenderingContext2DWrapper::line_to(JS::Interpreter& interpreter)
     auto* impl = impl_from(interpreter);
     if (!impl)
         return {};
-    double x = interpreter.argument(0).to_double();
-    double y = interpreter.argument(1).to_double();
+    auto x = interpreter.argument(0).to_double(interpreter);
+    if (interpreter.exception())
+        return {};
+    auto y = interpreter.argument(1).to_double(interpreter);
+    if (interpreter.exception())
+        return {};
     impl->line_to(x, y);
     return JS::js_undefined();
 }
@@ -282,10 +341,18 @@ JS::Value CanvasRenderingContext2DWrapper::quadratic_curve_to(JS::Interpreter& i
     auto* impl = impl_from(interpreter);
     if (!impl)
         return {};
-    double cx = interpreter.argument(0).to_double();
-    double cy = interpreter.argument(1).to_double();
-    double x = interpreter.argument(2).to_double();
-    double y = interpreter.argument(3).to_double();
+    auto cx = interpreter.argument(0).to_double(interpreter);
+    if (interpreter.exception())
+        return {};
+    auto cy = interpreter.argument(1).to_double(interpreter);
+    if (interpreter.exception())
+        return {};
+    auto x = interpreter.argument(2).to_double(interpreter);
+    if (interpreter.exception())
+        return {};
+    auto y = interpreter.argument(3).to_double(interpreter);
+    if (interpreter.exception())
+        return {};
     impl->quadratic_curve_to(cx, cy, x, y);
     return JS::js_undefined();
 }
@@ -295,8 +362,12 @@ JS::Value CanvasRenderingContext2DWrapper::create_image_data(JS::Interpreter& in
     auto* impl = impl_from(interpreter);
     if (!impl)
         return {};
-    i32 width = interpreter.argument(0).to_i32();
-    i32 height = interpreter.argument(1).to_i32();
+    auto width = interpreter.argument(0).to_i32(interpreter);
+    if (interpreter.exception())
+        return {};
+    auto height = interpreter.argument(1).to_i32(interpreter);
+    if (interpreter.exception())
+        return {};
     auto image_data = impl->create_image_data(interpreter.global_object(), width, height);
     return wrap(interpreter.heap(), *image_data);
 }
@@ -316,8 +387,12 @@ JS::Value CanvasRenderingContext2DWrapper::put_image_data(JS::Interpreter& inter
     }
 
     auto& image_data = static_cast<ImageDataWrapper*>(image_data_object)->impl();
-    auto x = interpreter.argument(1).to_double();
-    auto y = interpreter.argument(2).to_double();
+    auto x = interpreter.argument(1).to_double(interpreter);
+    if (interpreter.exception())
+        return {};
+    auto y = interpreter.argument(2).to_double(interpreter);
+    if (interpreter.exception())
+        return {};
     impl->put_image_data(image_data, x, y);
     return JS::js_undefined();
 }

--- a/Libraries/LibWeb/Bindings/DocumentWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/DocumentWrapper.cpp
@@ -60,7 +60,7 @@ const Document& DocumentWrapper::node() const
 
 static Document* document_from(JS::Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     if (StringView("DocumentWrapper") != this_object->class_name()) {

--- a/Libraries/LibWeb/Bindings/ElementWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/ElementWrapper.cpp
@@ -58,7 +58,7 @@ const Element& ElementWrapper::node() const
 
 static Element* impl_from(JS::Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return nullptr;
     // FIXME: Verify that it's an ElementWrapper somehow!

--- a/Libraries/LibWeb/Bindings/EventTargetWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/EventTargetWrapper.cpp
@@ -50,7 +50,7 @@ EventTargetWrapper::~EventTargetWrapper()
 
 JS::Value EventTargetWrapper::add_event_listener(JS::Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return {};
     auto& arguments = interpreter.call_frame().arguments;

--- a/Libraries/LibWeb/Bindings/HTMLCanvasElementWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/HTMLCanvasElementWrapper.cpp
@@ -62,7 +62,7 @@ const HTMLCanvasElement& HTMLCanvasElementWrapper::node() const
 
 static HTMLCanvasElement* impl_from(JS::Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return nullptr;
     // FIXME: Verify that it's a HTMLCanvasElementWrapper somehow!

--- a/Libraries/LibWeb/Bindings/ImageDataWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/ImageDataWrapper.cpp
@@ -55,7 +55,7 @@ ImageDataWrapper::~ImageDataWrapper()
 
 static ImageData* impl_from(JS::Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object) {
         ASSERT_NOT_REACHED();
         return nullptr;

--- a/Libraries/LibWeb/Bindings/MouseEventWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/MouseEventWrapper.cpp
@@ -57,7 +57,7 @@ MouseEvent& MouseEventWrapper::event()
 
 static MouseEvent* impl_from(JS::Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return nullptr;
     // FIXME: Verify that it's a CanvasRenderingContext2DWrapper somehow!

--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -134,7 +134,10 @@ JS::Value WindowObject::set_interval(JS::Interpreter& interpreter)
         return {};
     if (!callback_object->is_function())
         return interpreter.throw_exception<JS::TypeError>("Not a function");
-    impl->set_interval(*static_cast<JS::Function*>(callback_object), arguments[1].to_i32());
+    auto interval = arguments[1].to_i32(interpreter);
+    if (interpreter.exception())
+        return {};
+    impl->set_interval(*static_cast<JS::Function*>(callback_object), interval);
     return JS::js_undefined();
 }
 
@@ -153,8 +156,11 @@ JS::Value WindowObject::set_timeout(JS::Interpreter& interpreter)
         return interpreter.throw_exception<JS::TypeError>("Not a function");
 
     i32 interval = 0;
-    if (interpreter.argument_count() >= 2)
-        interval = arguments[1].to_i32();
+    if (interpreter.argument_count() >= 2) {
+        interval = arguments[1].to_i32(interpreter);
+        if (interpreter.exception())
+            return {};
+    }
 
     impl->set_timeout(*static_cast<JS::Function*>(callback_object), interval);
     return JS::js_undefined();
@@ -184,7 +190,10 @@ JS::Value WindowObject::cancel_animation_frame(JS::Interpreter& interpreter)
     auto& arguments = interpreter.call_frame().arguments;
     if (arguments.size() < 1)
         return {};
-    impl->cancel_animation_frame(arguments[0].to_i32());
+    auto id = arguments[0].to_i32(interpreter);
+    if (interpreter.exception())
+        return {};
+    impl->cancel_animation_frame(id);
     return JS::js_undefined();
 }
 

--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -80,7 +80,7 @@ void WindowObject::visit_children(Visitor& visitor)
 
 static Window* impl_from(JS::Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object) {
         ASSERT_NOT_REACHED();
         return nullptr;
@@ -129,7 +129,7 @@ JS::Value WindowObject::set_interval(JS::Interpreter& interpreter)
     auto& arguments = interpreter.call_frame().arguments;
     if (arguments.size() < 2)
         return {};
-    auto* callback_object = arguments[0].to_object(interpreter.heap());
+    auto* callback_object = arguments[0].to_object(interpreter);
     if (!callback_object)
         return {};
     if (!callback_object->is_function())
@@ -146,7 +146,7 @@ JS::Value WindowObject::set_timeout(JS::Interpreter& interpreter)
     auto& arguments = interpreter.call_frame().arguments;
     if (arguments.size() < 1)
         return {};
-    auto* callback_object = arguments[0].to_object(interpreter.heap());
+    auto* callback_object = arguments[0].to_object(interpreter);
     if (!callback_object)
         return {};
     if (!callback_object->is_function())
@@ -168,7 +168,7 @@ JS::Value WindowObject::request_animation_frame(JS::Interpreter& interpreter)
     auto& arguments = interpreter.call_frame().arguments;
     if (arguments.size() < 1)
         return {};
-    auto* callback_object = arguments[0].to_object(interpreter.heap());
+    auto* callback_object = arguments[0].to_object(interpreter);
     if (!callback_object)
         return {};
     if (!callback_object->is_function())

--- a/Libraries/LibWeb/Bindings/XMLHttpRequestPrototype.cpp
+++ b/Libraries/LibWeb/Bindings/XMLHttpRequestPrototype.cpp
@@ -56,7 +56,7 @@ XMLHttpRequestPrototype::~XMLHttpRequestPrototype()
 
 static XMLHttpRequest* impl_from(JS::Interpreter& interpreter)
 {
-    auto* this_object = interpreter.this_value().to_object(interpreter.heap());
+    auto* this_object = interpreter.this_value().to_object(interpreter);
     if (!this_object)
         return nullptr;
     if (StringView("XMLHttpRequestWrapper") != this_object->class_name()) {

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -701,7 +701,7 @@ int main(int argc, char** argv)
                 if (!variable.is_object())
                     return {};
 
-                const auto* object = variable.to_object(interpreter->heap());
+                const auto* object = variable.to_object(*interpreter);
                 const auto& shape = object->shape();
                 list_all_properties(shape, property_pattern);
                 if (results.size())

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -328,9 +328,10 @@ JS::Value ReplObject::exit_interpreter(JS::Interpreter& interpreter)
 {
     if (!interpreter.argument_count())
         exit(0);
-    int exit_code = interpreter.argument(0).to_number().as_double();
-    exit(exit_code);
-    return JS::js_undefined();
+    auto exit_code = interpreter.argument(0).to_number(interpreter);
+    if (interpreter.exception())
+        return {};
+    exit(exit_code.as_double());
 }
 
 JS::Value ReplObject::repl_help(JS::Interpreter&)


### PR DESCRIPTION
This patch is unfortunately rather large and might make some things feel bloated, but it is necessary to fix a few flaws in LibJS, primarily blindly coercing values to numbers without exception checks - i.e.

```cpp
interpreter.argument(0).to_i32();  // can fail!!!
```

Some examples where the interpreter would actually crash:

```js
var o = { toString: () => { throw Error() } };
+o;
o - 1;
"foo".charAt(o);
"bar".repeat(o);
```

To fix this, we now have the following...

```cpp
to_double(Interpreter&)
to_i32()
to_i32(Interpreter&)
to_size_t()
to_size_t(Interpreter&)
```

...and a whole lot of exception checking.

There's intentionally no `to_double()`, use `as_double()` directly instead.

This way we still can use these convenient utility functions but don't need to check for exceptions if we are sure the value already is a number.

Fixes #2267.

---

**Should we maybe also rename the ones that aren't being passed the `Interpreter&` to `as_i32()` / `as_size_t()`?**