### PR TITLE
LibJS: Remove no-op SymbolPrototype::description_setter()

### DIFF
--- a/Libraries/LibJS/Runtime/SymbolPrototype.cpp
+++ b/Libraries/LibJS/Runtime/SymbolPrototype.cpp
@@ -42,8 +42,7 @@ namespace JS {
 SymbolPrototype::SymbolPrototype()
     : Object(interpreter().global_object().object_prototype())
 {
-    // FIXME: description has no setter, eventually remove
-    put_native_property("description", description_getter, description_setter, Attribute::Configurable);
+    put_native_property("description", description_getter, nullptr, Attribute::Configurable);
 
     put_native_function("toString", to_string, 0, Attribute::Writable | Attribute::Configurable);
     put_native_function("valueOf", value_of, 0, Attribute::Writable | Attribute::Configurable);
@@ -71,11 +70,6 @@ Value SymbolPrototype::description_getter(Interpreter& interpreter)
     if (!this_object)
         return {};
     return js_string(interpreter, this_object->description());
-}
-
-void SymbolPrototype::description_setter(Interpreter&, Value)
-{
-    // No-op, remove eventually
 }
 
 Value SymbolPrototype::to_string(Interpreter& interpreter)

--- a/Libraries/LibJS/Runtime/SymbolPrototype.h
+++ b/Libraries/LibJS/Runtime/SymbolPrototype.h
@@ -39,7 +39,6 @@ private:
     virtual const char* class_name() const override { return "SymbolPrototype"; }
 
     static Value description_getter(Interpreter&);
-    static void description_setter(Interpreter&, Value);
 
     static Value to_string(Interpreter&);
     static Value value_of(Interpreter&);


### PR DESCRIPTION
We can just give `put_native_property()` a `nullptr` for the setter.