### PR TITLE
LibJS: Rename to_{i32,size_t}() to as_{i32,size_t}() for clarity

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1189,8 +1189,8 @@ PropertyName MemberExpression::computed_property_name(Interpreter& interpreter) 
 
     ASSERT(!index.is_empty());
 
-    if (index.is_integer() && index.to_i32() >= 0)
-        return PropertyName(index.to_i32());
+    if (index.is_integer() && index.as_i32() >= 0)
+        return PropertyName(index.as_i32());
 
     auto index_string = index.to_string(interpreter);
     if (interpreter.exception())

--- a/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -58,12 +58,12 @@ Value ArrayConstructor::call(Interpreter& interpreter)
 
     if (interpreter.argument_count() == 1 && interpreter.argument(0).is_number()) {
         auto array_length_value = interpreter.argument(0);
-        if (!array_length_value.is_integer() || array_length_value.to_i32() < 0) {
+        if (!array_length_value.is_integer() || array_length_value.as_i32() < 0) {
             interpreter.throw_exception<TypeError>("Invalid array length");
             return {};
         }
         auto* array = Array::create(interpreter.global_object());
-        array->elements().resize(array_length_value.to_i32());
+        array->elements().resize(array_length_value.as_i32());
         return array;
     }
 

--- a/Libraries/LibJS/Runtime/Function.cpp
+++ b/Libraries/LibJS/Runtime/Function.cpp
@@ -69,7 +69,7 @@ BoundFunction* Function::bind(Value bound_this_value, Vector<Value> arguments)
     if (interpreter().exception())
         return nullptr;
     if (length_property.is_number())
-        computed_length = max(0, length_property.to_i32() - static_cast<i32>(arguments.size()));
+        computed_length = max(0, length_property.as_i32() - static_cast<i32>(arguments.size()));
 
     Object* constructor_prototype = nullptr;
     auto prototype_property = target_function.get("prototype");

--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -118,7 +118,7 @@ Value StringPrototype::repeat(Interpreter& interpreter)
         return interpreter.throw_exception<RangeError>("repeat count must be a positive number");
     if (count_value.is_infinity())
         return interpreter.throw_exception<RangeError>("repeat count must be a finite number");
-    auto count = count_value.to_size_t();
+    auto count = count_value.as_size_t();
     StringBuilder builder;
     for (size_t i = 0; i < count; ++i)
         builder.append(string);

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -184,15 +184,16 @@ public:
 
     Function& as_function();
 
+    i32 as_i32() const;
+    size_t as_size_t() const;
+
     String to_string(Interpreter&) const;
     PrimitiveString* to_primitive_string(Interpreter&);
     Value to_primitive(Interpreter&) const;
     Object* to_object(Interpreter&) const;
     Value to_number(Interpreter&) const;
     double to_double(Interpreter&) const;
-    i32 to_i32() const;
     i32 to_i32(Interpreter&) const;
-    size_t to_size_t() const;
     size_t to_size_t(Interpreter&) const;
     bool to_boolean() const;
 


### PR DESCRIPTION
As these parameter-less overloads don't change the value's type and just assume `Type::Number`, naming them `as_i32()` and `as_size_t()` is more appropriate.

---

Confirmed by @awesomekling in https://github.com/SerenityOS/serenity/pull/2270#issuecomment-630002105 and then he ninja-merged the PR before I could make amendments smh