### PR TITLE
LibLine (also Shell,js): Handle unicode

### DIFF
--- a/AK/Tests/TestUtf8.cpp
+++ b/AK/Tests/TestUtf8.cpp
@@ -48,7 +48,9 @@ TEST_CASE(decode_ascii)
 TEST_CASE(decode_utf8)
 {
     Utf8View utf8 { "Привет, мир! 😀 γειά σου κόσμος こんにちは世界" };
-    EXPECT(utf8.validate());
+    size_t valid_bytes;
+    EXPECT(utf8.validate(valid_bytes));
+    EXPECT(valid_bytes == (size_t)utf8.byte_length());
 
     u32 expected[] = { 1055, 1088, 1080, 1074, 1077, 1090, 44, 32, 1084, 1080, 1088, 33, 32, 128512, 32, 947, 949, 953, 940, 32, 963, 959, 965, 32, 954, 972, 963, 956, 959, 962, 32, 12371, 12435, 12395, 12385, 12399, 19990, 30028 };
     size_t expected_size = sizeof(expected) / sizeof(expected[0]);
@@ -64,21 +66,26 @@ TEST_CASE(decode_utf8)
 
 TEST_CASE(validate_invalid_ut8)
 {
+    size_t valid_bytes;
     char invalid_utf8_1[] = { 42, 35, (char)182, 9, 0 };
     Utf8View utf8_1 { invalid_utf8_1 };
-    EXPECT(!utf8_1.validate());
+    EXPECT(!utf8_1.validate(valid_bytes));
+    EXPECT(valid_bytes == 2);
 
     char invalid_utf8_2[] = { 42, 35, (char)208, (char)208, 0 };
     Utf8View utf8_2 { invalid_utf8_2 };
-    EXPECT(!utf8_2.validate());
+    EXPECT(!utf8_2.validate(valid_bytes));
+    EXPECT(valid_bytes == 2);
 
     char invalid_utf8_3[] = { (char)208, 0 };
     Utf8View utf8_3 { invalid_utf8_3 };
-    EXPECT(!utf8_3.validate());
+    EXPECT(!utf8_3.validate(valid_bytes));
+    EXPECT(valid_bytes == 0);
 
     char invalid_utf8_4[] = { (char)208, 35, 0 };
     Utf8View utf8_4 { invalid_utf8_4 };
-    EXPECT(!utf8_4.validate());
+    EXPECT(!utf8_4.validate(valid_bytes));
+    EXPECT(valid_bytes == 0);
 }
 
 TEST_MAIN(UTF8)

--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -111,8 +111,9 @@ static inline bool decode_first_byte(
     return false;
 }
 
-bool Utf8View::validate() const
+bool Utf8View::validate(size_t& valid_bytes) const
 {
+    valid_bytes = 0;
     for (auto ptr = begin_ptr(); ptr < end_ptr(); ptr++) {
         int codepoint_length_in_bytes;
         u32 value;
@@ -127,6 +128,8 @@ bool Utf8View::validate() const
             if (*ptr >> 6 != 2)
                 return false;
         }
+
+        valid_bytes += codepoint_length_in_bytes;
     }
 
     return true;

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -37,7 +37,7 @@ class Utf8CodepointIterator {
     friend class Utf8View;
 
 public:
-    ~Utf8CodepointIterator() {}
+    ~Utf8CodepointIterator() { }
 
     bool operator==(const Utf8CodepointIterator&) const;
     bool operator!=(const Utf8CodepointIterator&) const;
@@ -57,7 +57,7 @@ public:
     explicit Utf8View(const String&);
     explicit Utf8View(const StringView&);
     explicit Utf8View(const char*);
-    ~Utf8View() {}
+    ~Utf8View() { }
 
     const StringView& as_string() const { return m_string; }
 
@@ -70,7 +70,12 @@ public:
     Utf8View substring_view(int byte_offset, int byte_length) const;
     bool is_empty() const { return m_string.is_empty(); }
 
-    bool validate() const;
+    bool validate(size_t& valid_bytes) const;
+    bool validate() const
+    {
+        size_t valid_bytes;
+        return validate(valid_bytes);
+    }
 
     size_t length_in_codepoints() const;
 

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -147,8 +147,9 @@ public:
     void resized() { m_was_resized = true; }
 
     size_t cursor() const { return m_cursor; }
-    const Vector<char, 1024>& buffer() const { return m_buffer; }
-    char buffer_at(size_t pos) const { return m_buffer.at(pos); }
+    const Vector<u32, 1024>& buffer() const { return m_buffer; }
+    u32 buffer_at(size_t pos) const { return m_buffer.at(pos); }
+    String line() const;
 
     // only makes sense inside a char_input callback or on_* callback
     void set_prompt(const String& prompt)
@@ -162,7 +163,7 @@ public:
 
     void clear_line();
     void insert(const String&);
-    void insert(const char);
+    void insert(const u32);
     void stylize(const Span&, const Style&);
     void strip_styles()
     {
@@ -275,9 +276,10 @@ private:
     size_t m_search_offset { 0 };
     bool m_searching_backwards { true };
     size_t m_pre_search_cursor { 0 };
-    Vector<char, 1024> m_pre_search_buffer;
+    Vector<u32, 1024> m_pre_search_buffer;
 
-    Vector<char, 1024> m_buffer;
+    Vector<u32, 1024> m_buffer;
+    Vector<char, 512> m_incomplete_data;
     ByteBuffer m_pending_chars;
     size_t m_cursor { 0 };
     size_t m_drawn_cursor { 0 };

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -1389,7 +1389,7 @@ void Shell::highlight(Line::Editor&) const
     if (m_should_continue == ExitCodeOrContinuationRequest::SingleQuotedString) {
         builder.append('\'');
     }
-    builder.append(StringView { editor.buffer().data(), editor.buffer().size() });
+    builder.append(editor.line());
     auto commands = Parser { builder.string_view() }.parse();
     auto first_command { true };
     for (auto& command : commands) {

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -518,7 +518,7 @@ int main(int argc, char** argv)
             };
             editor.strip_styles();
             StringBuilder builder;
-            builder.append({ editor.buffer().data(), editor.buffer().size() });
+            builder.append(editor.line());
             // FIXME: The lexer returns weird position information without this
             builder.append(" ");
             String str = builder.build();
@@ -659,7 +659,7 @@ int main(int argc, char** argv)
             if (token.length() == 0)
                 return {}; // nyeh
 
-            StringView line { editor.buffer().data(), editor.cursor() };
+            auto line = editor.line();
             // we're only going to complete either
             //    - <N>
             //        where N is part of the name of a variable


### PR DESCRIPTION
This allows inputting arbitrary codepoints to LibLine, at the expense of sprinkling Utf{8,32}View everywhere in the editor.

Also finally does _something_ with the inputs that were discarded in `vt_dsr`

pls merge before #2269