### PR TITLE
LibJS: Return early from parseFloat() if argument is a number

### DIFF
--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -153,6 +153,8 @@ Value GlobalObject::is_finite(Interpreter& interpreter)
 
 Value GlobalObject::parse_float(Interpreter& interpreter)
 {
+    if (interpreter.argument(0).is_number())
+        return interpreter.argument(0);
     auto string = interpreter.argument(0).to_string(interpreter);
     if (interpreter.exception())
         return {};


### PR DESCRIPTION
This saves us both a bit of time and accuracy, as Serenity's `strtod()` still is a little bit off sometimes - and stringifying the result and parsing it again just increases that offset.