### PR TITLE
LibLine: Default to resolving Spans as byte offsets

### DIFF
--- a/Libraries/LibLine/Span.h
+++ b/Libraries/LibLine/Span.h
@@ -30,17 +30,25 @@
 namespace Line {
 class Span {
 public:
-    Span(size_t start, size_t end)
+    enum Mode {
+        ByteOriented,
+        CodepointOriented,
+    };
+
+    Span(size_t start, size_t end, Mode mode = ByteOriented)
         : m_beginning(start)
         , m_end(end)
+        , m_mode(mode)
     {
     }
 
     size_t beginning() const { return m_beginning; }
     size_t end() const { return m_end; }
+    Mode mode() const { return m_mode; }
 
 private:
     size_t m_beginning { 0 };
     size_t m_end { 0 };
+    Mode m_mode { CodepointOriented };
 };
 }


### PR DESCRIPTION
This allows all the unicode processing to be internal to the line editor.

Supersedes #2279, and obsoletes it.