### PR TITLE
Browser: Support fullscreen view

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -39,6 +39,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/MenuBar.h>
 #include <LibGUI/StatusBar.h>
+#include <LibGUI/TabWidget.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/ToolBar.h>
 #include <LibGUI/ToolBarContainer.h>
@@ -231,6 +232,19 @@ Tab::Tab()
         GUI::Application::the().quit();
     }));
 
+    auto& view_menu = m_menubar->add_menu("View");
+    view_menu.add_action(GUI::CommonActions::make_fullscreen_action(
+        [this](auto&) {
+            window()->set_fullscreen(!window()->is_fullscreen());
+
+            auto is_fullscreen = window()->is_fullscreen();
+            auto* tab_widget = static_cast<GUI::TabWidget*>(parent_widget());
+            tab_widget->set_bar_visible(!is_fullscreen);
+            m_toolbar_container->set_visible(!is_fullscreen);
+            m_statusbar->set_visible(!is_fullscreen);
+        },
+        this));
+
     auto& inspect_menu = m_menubar->add_menu("Inspect");
     inspect_menu.add_action(GUI::Action::create(
         "View source", { Mod_Ctrl, Key_U }, [this](auto&) {
@@ -347,6 +361,10 @@ void Tab::did_become_active()
 
     BookmarksBarWidget::the().remove_from_parent();
     m_toolbar_container->add_child(BookmarksBarWidget::the());
+
+    auto is_fullscreen = window()->is_fullscreen();
+    m_toolbar_container->set_visible(!is_fullscreen);
+    m_statusbar->set_visible(!is_fullscreen);
 
     GUI::Application::the().set_menubar(m_menubar);
 }

--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -239,7 +239,7 @@ Tab::Tab()
 
             auto is_fullscreen = window()->is_fullscreen();
             auto* tab_widget = static_cast<GUI::TabWidget*>(parent_widget());
-            tab_widget->set_bar_visible(!is_fullscreen);
+            tab_widget->set_bar_visible(!is_fullscreen && tab_widget->children().size() > 1);
             m_toolbar_container->set_visible(!is_fullscreen);
             m_statusbar->set_visible(!is_fullscreen);
         },

--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -127,6 +127,7 @@ int main(int argc, char** argv)
     create_new_tab = [&](auto url, auto activate) {
         auto& new_tab = tab_widget.add_tab<Browser::Tab>("New tab");
 
+        tab_widget.set_bar_visible(!window->is_fullscreen() && tab_widget.children().size() > 1);
         tab_widget.set_tab_icon(new_tab, default_favicon);
 
         new_tab.on_title_change = [&](auto title) {
@@ -146,6 +147,7 @@ int main(int argc, char** argv)
         new_tab.on_tab_close_request = [&](auto& tab) {
             tab_widget.deferred_invoke([&](auto&) {
                 tab_widget.remove_tab(tab);
+                tab_widget.set_bar_visible(!window->is_fullscreen() && tab_widget.children().size() > 1);
                 if (tab_widget.children().is_empty())
                     app.quit();
             });

--- a/Libraries/LibGUI/TabWidget.cpp
+++ b/Libraries/LibGUI/TabWidget.cpp
@@ -147,6 +147,9 @@ Gfx::Rect TabWidget::container_rect() const
 
 void TabWidget::paint_event(PaintEvent& event)
 {
+    if (!m_bar_visible)
+        return;
+
     Painter painter(*this);
     painter.add_clip_rect(event.rect());
 
@@ -204,6 +207,14 @@ int TabWidget::uniform_tab_width() const
     if (total_tab_width > width())
         tab_width = width() / m_tabs.size();
     return max(tab_width, minimum_tab_width);
+}
+
+void TabWidget::set_bar_visible(bool bar_visible)
+{
+    m_bar_visible = bar_visible;
+    if (m_active_widget)
+        m_active_widget->set_relative_rect(child_rect_for_size(size()));
+    update_bar();
 }
 
 Gfx::Rect TabWidget::button_rect(int index) const
@@ -346,7 +357,7 @@ void TabWidget::activate_previous_tab()
     set_active_widget(m_tabs.at(index).widget);
 }
 
-void TabWidget::keydown_event(KeyEvent & event)
+void TabWidget::keydown_event(KeyEvent& event)
 {
     if (event.ctrl() && event.key() == Key_Tab) {
         if (event.shift())

--- a/Libraries/LibGUI/TabWidget.h
+++ b/Libraries/LibGUI/TabWidget.h
@@ -49,7 +49,7 @@ public:
     const Widget* active_widget() const { return m_active_widget.ptr(); }
     void set_active_widget(Widget*);
 
-    int bar_height() const { return 21; }
+    int bar_height() const { return m_bar_visible ? 21 : 0; }
 
     int container_padding() const { return m_container_padding; }
     void set_container_padding(int padding) { m_container_padding = padding; }
@@ -78,6 +78,9 @@ public:
 
     void set_uniform_tabs(bool uniform_tabs) { m_uniform_tabs = uniform_tabs; }
     int uniform_tab_width() const;
+
+    void set_bar_visible(bool bar_visible);
+    bool is_bar_visible() const { return m_bar_visible; };
 
     Function<void(Widget&)> on_change;
     Function<void(Widget&)> on_middle_click;
@@ -114,6 +117,7 @@ private:
     int m_container_padding { 2 };
     Gfx::TextAlignment m_text_alignment { Gfx::TextAlignment::Center };
     bool m_uniform_tabs { false };
+    bool m_bar_visible { true };
 };
 
 }


### PR DESCRIPTION
Fullscreen mode hides all widgets except the tab widget (but hides its tab bar), so effectively only the HTML view is shown. Switching/closing the active tab of course also works in fullscreen mode.

To make this possible, `set_bar_visible()`/`is_bar_visible()` was added to `GUI::TabWidget`, and it was pretty straightforward as all the event handling & rect calculation code already uses `bar_height()` - so we can just adjust that accordingly (as well as skipping painting the tab bar).

![image](https://user-images.githubusercontent.com/19366641/82344594-2593db80-99ec-11ea-98e2-816da1754bc3.png)
