### PR TITLE
LibGUI/Browser: Right clicking a tab opens a context menu

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -310,6 +310,14 @@ Tab::Tab()
 
     auto& help_menu = m_menubar->add_menu("Help");
     help_menu.add_action(WindowActions::the().about_action());
+
+    m_tab_context_menu = GUI::Menu::construct();
+    m_tab_context_menu->add_action(GUI::Action::create("Reload Tab", [this](auto&) {
+        m_reload_action->activate();
+    }));
+    m_tab_context_menu->add_action(GUI::Action::create("Close Tab", [this](auto&) {
+        on_tab_close_request(*this);
+    }));
 }
 
 Tab::~Tab()
@@ -367,6 +375,11 @@ void Tab::did_become_active()
     m_statusbar->set_visible(!is_fullscreen);
 
     GUI::Application::the().set_menubar(m_menubar);
+}
+
+void Tab::context_menu_requested(const Gfx::Point& screen_position)
+{
+    m_tab_context_menu->popup(screen_position);
 }
 
 }

--- a/Applications/Browser/Tab.h
+++ b/Applications/Browser/Tab.h
@@ -43,6 +43,7 @@ public:
     void load(const URL&);
 
     void did_become_active();
+    void context_menu_requested(const Gfx::Point& screen_position);
 
     Function<void(String)> on_title_change;
     Function<void(const URL&)> on_tab_open_request;
@@ -72,6 +73,8 @@ private:
 
     RefPtr<GUI::Menu> m_link_context_menu;
     String m_link_context_menu_href;
+
+    RefPtr<GUI::Menu> m_tab_context_menu;
 
     String m_title;
     RefPtr<const Gfx::Bitmap> m_icon;

--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -121,6 +121,11 @@ int main(int argc, char** argv)
         tab.on_tab_close_request(tab);
     };
 
+    tab_widget.on_context_menu_request = [&](auto& clicked_widget, const GUI::ContextMenuEvent& context_menu_event) {
+        auto& tab = static_cast<Browser::Tab&>(clicked_widget);
+        tab.context_menu_requested(context_menu_event.screen_position());
+    };
+
     Browser::WindowActions window_actions(*window);
 
     Function<void(URL url, bool activate)> create_new_tab;

--- a/Libraries/LibGUI/TabWidget.cpp
+++ b/Libraries/LibGUI/TabWidget.cpp
@@ -370,4 +370,19 @@ void TabWidget::keydown_event(KeyEvent& event)
     Widget::keydown_event(event);
 }
 
+void TabWidget::context_menu_event(ContextMenuEvent& context_menu_event)
+{
+    for (size_t i = 0; i < m_tabs.size(); ++i) {
+        auto button_rect = this->button_rect(i);
+        if (!button_rect.contains(context_menu_event.position()))
+            continue;
+        auto* widget = m_tabs[i].widget;
+        deferred_invoke([this, widget, context_menu_event](auto&) {
+            if (on_context_menu_request && widget)
+                on_context_menu_request(*widget, context_menu_event);
+        });
+        return;
+    }
+}
+
 }

--- a/Libraries/LibGUI/TabWidget.h
+++ b/Libraries/LibGUI/TabWidget.h
@@ -84,6 +84,7 @@ public:
 
     Function<void(Widget&)> on_change;
     Function<void(Widget&)> on_middle_click;
+    Function<void(Widget&, const ContextMenuEvent&)> on_context_menu_request;
 
 protected:
     TabWidget();
@@ -95,6 +96,7 @@ protected:
     virtual void mousemove_event(MouseEvent&) override;
     virtual void leave_event(Core::Event&) override;
     virtual void keydown_event(KeyEvent&) override;
+    virtual void context_menu_event(ContextMenuEvent&) override;
 
 private:
     Gfx::Rect child_rect_for_size(const Gfx::Size&) const;


### PR DESCRIPTION
To continue making the Browser's tabs more interactive, this patch pops up a context menu when a tab is right clicked. Currently, the only options provided in this context menu are to reload and close the tab, but I'm sure more will come with time :)