### PR TITLE
LibGUI/Browser: Right clicking a bookmark opens a context menu

### DIFF
--- a/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Applications/Browser/BookmarksBarWidget.cpp
@@ -70,6 +70,15 @@ BookmarksBarWidget::BookmarksBarWidget(const String& bookmarks_file, bool enable
 
     m_separator = GUI::Widget::construct();
 
+    m_context_menu = GUI::Menu::construct();
+    m_context_menu->add_action(GUI::Action::create("Delete", [this](auto&) {
+        remove_bookmark(m_context_menu_url);
+    }));
+    m_context_menu->add_action(GUI::Action::create("Open in new tab", [this](auto&) {
+        if (on_bookmark_click)
+            on_bookmark_click(m_context_menu_url, Mod_Ctrl);
+    }));
+
     Vector<GUI::JsonArrayModel::FieldSpec> fields;
     fields.empend("title", "Title", Gfx::TextAlignment::CenterLeft);
     fields.empend("url", "Url", Gfx::TextAlignment::CenterRight);
@@ -125,7 +134,12 @@ void BookmarksBarWidget::did_update_model()
 
         button.on_click = [title, url, this](auto modifiers) {
             if (on_bookmark_click)
-                on_bookmark_click(title, url, modifiers);
+                on_bookmark_click(url, modifiers);
+        };
+
+        button.on_context_menu_request = [this, url](auto& context_menu_event) {
+            m_context_menu_url = url;
+            m_context_menu->popup(context_menu_event.screen_position());
         };
 
         width += rect.width();

--- a/Applications/Browser/BookmarksBarWidget.h
+++ b/Applications/Browser/BookmarksBarWidget.h
@@ -42,7 +42,7 @@ public:
     GUI::Model* model() { return m_model.ptr(); }
     const GUI::Model* model() const { return m_model.ptr(); }
 
-    Function<void(const String&, const String&, unsigned modifiers)> on_bookmark_click;
+    Function<void(const String& url, unsigned modifiers)> on_bookmark_click;
     Function<void(const String&, const String&)> on_bookmark_hover;
 
     bool contains_bookmark(const String& url);
@@ -61,6 +61,9 @@ private:
     RefPtr<GUI::Button> m_additional;
     RefPtr<GUI::Widget> m_separator;
     RefPtr<GUI::Menu> m_additional_menu;
+
+    RefPtr<GUI::Menu> m_context_menu;
+    String m_context_menu_url;
 
     NonnullRefPtrVector<GUI::Button> m_bookmarks;
 

--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -356,7 +356,7 @@ void Tab::did_become_active()
         m_statusbar->set_text(String::format("Loading (%d pending resources...)", Web::ResourceLoader::the().pending_loads()));
     };
 
-    BookmarksBarWidget::the().on_bookmark_click = [this](auto&, auto& url, unsigned modifiers) {
+    BookmarksBarWidget::the().on_bookmark_click = [this](auto& url, unsigned modifiers) {
         if (modifiers & Mod_Ctrl)
             on_tab_open_request(url);
         else

--- a/Libraries/LibGUI/Button.cpp
+++ b/Libraries/LibGUI/Button.cpp
@@ -101,6 +101,14 @@ void Button::click(unsigned modifiers)
         m_action->activate(this);
 }
 
+void Button::context_menu_event(ContextMenuEvent& context_menu_event)
+{
+    if (!is_enabled())
+        return;
+    if (on_context_menu_request)
+        on_context_menu_request(context_menu_event);
+}
+
 void Button::set_action(Action& action)
 {
     m_action = action.make_weak_ptr();

--- a/Libraries/LibGUI/Button.h
+++ b/Libraries/LibGUI/Button.h
@@ -48,11 +48,13 @@ public:
     Gfx::TextAlignment text_alignment() const { return m_text_alignment; }
 
     Function<void(unsigned modifiers)> on_click;
+    Function<void(const ContextMenuEvent&)> on_context_menu_request;
 
     void set_button_style(Gfx::ButtonStyle style) { m_button_style = style; }
     Gfx::ButtonStyle button_style() const { return m_button_style; }
 
     virtual void click(unsigned modifiers = 0) override;
+    virtual void context_menu_event(ContextMenuEvent&) override;
 
     void set_action(Action&);
 


### PR DESCRIPTION
Another PR adding more interactivity to the browser, this time by giving the bookmark buttons a context menu that (currently) allows for opening in a new tab, and removing.

For future reference, should I have included this in #2291? They feel distinct enough to be separate, but I also do not wish to open an excessive amount of PRs. Thanks!