### PR TITLE
LibLine: Unify completion hooks and adapt its users

### DIFF
--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -112,8 +112,7 @@ public:
     static ContinuationRequest is_complete(const Vector<Command>&);
 
     void highlight(Line::Editor&) const;
-    Vector<Line::CompletionSuggestion> complete_first(const String&);
-    Vector<Line::CompletionSuggestion> complete_other(const String&);
+    Vector<Line::CompletionSuggestion> complete(const Line::Editor&);
 
     String get_history_path();
     void load_history();

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -75,11 +75,8 @@ int main(int argc, char** argv)
         editor.strip_styles();
         shell->highlight(editor);
     };
-    editor.on_tab_complete_first_token = [&](const String& token_to_complete) -> Vector<Line::CompletionSuggestion> {
-        return shell->complete_first(token_to_complete);
-    };
-    editor.on_tab_complete_other_token = [&](const String& token_to_complete) -> Vector<Line::CompletionSuggestion> {
-        return shell->complete_other(token_to_complete);
+    editor.on_tab_complete = [&](const Line::Editor& editor) {
+        return shell->complete(editor);
     };
 
     signal(SIGINT, [](int) {


### PR DESCRIPTION
LibLine should ultimately not care about what a "token" means in the
context of its user, so force the user to split the buffer itself.
This also allows the users to pick up contextual clues as well, since
they have to lex the line themselves.

This commit pacthes Shell and the JS repl to better handle completions,
so certain wrong behaviours are now corrected as well:
- JS repl can now complete "Object . getOw<tab>"
- Shell can now complete "echo | ca<tab>" and paths inside strings

@bugaevc, following our prior discussion, I realised how much I hated having two "on_complete" hooks, so here we are.

I am not sure if it is sensible to complete paths inside strings, ideas on that are welcome.