### PR TITLE
LibTLS: Only try to flush data when needed

### DIFF
--- a/Libraries/LibTLS/Record.cpp
+++ b/Libraries/LibTLS/Record.cpp
@@ -34,6 +34,12 @@ namespace TLS {
 void TLSv12::write_packet(ByteBuffer& packet)
 {
     m_context.tls_buffer.append(packet.data(), packet.size());
+    if (!m_has_scheduled_write_flush && m_context.connection_status > ConnectionStatus::Disconnected) {
+#ifdef TLS_DEBUG
+        dbg() << "Scheduling write of " << m_context.tls_buffer.size();
+#endif
+        deferred_invoke([this](auto&) { write_into_socket(); });
+    }
 }
 
 void TLSv12::update_packet(ByteBuffer& packet)

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -375,6 +375,9 @@ private:
     void build_random(PacketBuilder&);
 
     bool flush();
+    void write_into_socket();
+
+    bool check_connection_state(bool read);
 
     ssize_t handle_hello(const ByteBuffer& buffer, WritePacketStage&);
     ssize_t handle_finished(const ByteBuffer& buffer, WritePacketStage&);
@@ -463,7 +466,7 @@ private:
     OwnPtr<Crypto::Cipher::AESCipher::CBCMode> m_aes_local;
     OwnPtr<Crypto::Cipher::AESCipher::CBCMode> m_aes_remote;
 
-    RefPtr<Core::Notifier> m_write_notifier;
+    bool m_has_scheduled_write_flush = false;
 };
 
 namespace Constants {


### PR DESCRIPTION
This patchset drops the write notifier, and schedules writes only when necessary.
As a result, the CPU utilisation no longer spikes to the skies :^)

Though empirical tests :tm: (aka trying to load google) have shown that the loading process becomes a bit slower as we defer writes now.