### PR TITLE
FileManager+LibWeb: Small access modifiers fixes

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -118,7 +118,6 @@ int main(int argc, char** argv)
 class DesktopWidget final : public GUI::Widget {
     C_OBJECT(DesktopWidget);
 
-public:
 private:
     virtual void paint_event(GUI::PaintEvent& event) override
     {

--- a/Libraries/LibWeb/CSS/StyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/StyleDeclaration.h
@@ -49,7 +49,7 @@ public:
 
     const Vector<StyleProperty>& properties() const { return m_properties; }
 
-public:
+private:
     explicit StyleDeclaration(Vector<StyleProperty>&&);
 
     Vector<StyleProperty> m_properties;


### PR DESCRIPTION
Remove empty `public` access modifier from `DesktopWidget` and change accidentally duplicated public access modifier in `StyleDeclaration` to `private`.

