### PR TITLE
LibHTTP+LibTLS: Handle silly chunked-encoding chunk sizes

### DIFF
--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -376,6 +376,7 @@ private:
 
     bool flush();
     void write_into_socket();
+    void read_from_socket();
 
     bool check_connection_state(bool read);
 


### PR DESCRIPTION
Apparently that's allowed and the RFC is just unclear about it.
Some servers seem to zero-pad the chunk size for whatever reason, and previously, we interpreted that as the last chunk.

This still does not fix loading github, as the CSS parser chokes on one of the stylesheets.
This sort of infinite loop seems to stem from us handing it something that has invalid data in it, so I am still quite suspicious of Transfer-Encoding's.