### PR TITLE
LibWeb: Canvas things

### DIFF
--- a/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.cpp
@@ -35,6 +35,7 @@
 #include <LibWeb/Bindings/HTMLImageElementWrapper.h>
 #include <LibWeb/Bindings/ImageDataWrapper.h>
 #include <LibWeb/DOM/CanvasRenderingContext2D.h>
+#include <LibWeb/DOM/HTMLCanvasElement.h>
 #include <LibWeb/DOM/HTMLImageElement.h>
 #include <LibWeb/DOM/ImageData.h>
 
@@ -50,14 +51,11 @@ CanvasRenderingContext2DWrapper::CanvasRenderingContext2DWrapper(CanvasRendering
     : Wrapper(*interpreter().global_object().object_prototype())
     , m_impl(impl)
 {
-    put_native_property("fillStyle", fill_style_getter, fill_style_setter);
     put_native_function("fillRect", fill_rect, 4);
     put_native_function("scale", scale, 2);
     put_native_function("translate", translate, 2);
-    put_native_property("strokeStyle", stroke_style_getter, stroke_style_setter);
     put_native_function("strokeRect", stroke_rect, 4);
     put_native_function("drawImage", draw_image, 3);
-
     put_native_function("beginPath", begin_path, 0);
     put_native_function("closePath", close_path, 0);
     put_native_function("stroke", stroke, 0);
@@ -65,11 +63,13 @@ CanvasRenderingContext2DWrapper::CanvasRenderingContext2DWrapper(CanvasRendering
     put_native_function("moveTo", move_to, 2);
     put_native_function("lineTo", line_to, 2);
     put_native_function("quadraticCurveTo", quadratic_curve_to, 4);
-
     put_native_function("createImageData", create_image_data, 1);
     put_native_function("putImageData", put_image_data, 3);
 
+    put_native_property("fillStyle", fill_style_getter, fill_style_setter);
+    put_native_property("strokeStyle", stroke_style_getter, stroke_style_setter);
     put_native_property("lineWidth", line_width_getter, line_width_setter);
+    put_native_property("canvas", canvas_getter, nullptr);
 }
 
 CanvasRenderingContext2DWrapper::~CanvasRenderingContext2DWrapper()
@@ -395,6 +395,17 @@ JS::Value CanvasRenderingContext2DWrapper::put_image_data(JS::Interpreter& inter
         return {};
     impl->put_image_data(image_data, x, y);
     return JS::js_undefined();
+}
+
+JS::Value CanvasRenderingContext2DWrapper::canvas_getter(JS::Interpreter& interpreter)
+{
+    auto* impl = impl_from(interpreter);
+    if (!impl)
+        return {};
+    auto* element = impl->element();
+    if (!element)
+        return JS::js_null();
+    return wrap(interpreter.heap(), *element);
 }
 
 }

--- a/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.h
+++ b/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.h
@@ -47,12 +47,6 @@ private:
     static JS::Value draw_image(JS::Interpreter&);
     static JS::Value scale(JS::Interpreter&);
     static JS::Value translate(JS::Interpreter&);
-    static JS::Value fill_style_getter(JS::Interpreter&);
-    static void fill_style_setter(JS::Interpreter&, JS::Value);
-    static JS::Value stroke_style_getter(JS::Interpreter&);
-    static void stroke_style_setter(JS::Interpreter&, JS::Value);
-    static JS::Value line_width_getter(JS::Interpreter&);
-    static void line_width_setter(JS::Interpreter&, JS::Value);
     static JS::Value begin_path(JS::Interpreter&);
     static JS::Value close_path(JS::Interpreter&);
     static JS::Value stroke(JS::Interpreter&);
@@ -60,9 +54,19 @@ private:
     static JS::Value move_to(JS::Interpreter&);
     static JS::Value line_to(JS::Interpreter&);
     static JS::Value quadratic_curve_to(JS::Interpreter&);
-
     static JS::Value create_image_data(JS::Interpreter&);
     static JS::Value put_image_data(JS::Interpreter&);
+
+    static JS::Value fill_style_getter(JS::Interpreter&);
+    static void fill_style_setter(JS::Interpreter&, JS::Value);
+
+    static JS::Value stroke_style_getter(JS::Interpreter&);
+    static void stroke_style_setter(JS::Interpreter&, JS::Value);
+
+    static void line_width_setter(JS::Interpreter&, JS::Value);
+    static JS::Value line_width_getter(JS::Interpreter&);
+
+    static JS::Value canvas_getter(JS::Interpreter&);
 
     NonnullRefPtr<CanvasRenderingContext2D> m_impl;
 };

--- a/Libraries/LibWeb/Bindings/HTMLCanvasElementWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/HTMLCanvasElementWrapper.cpp
@@ -74,15 +74,13 @@ JS::Value HTMLCanvasElementWrapper::get_context(JS::Interpreter& interpreter)
     auto* impl = impl_from(interpreter);
     if (!impl)
         return {};
-    auto& arguments = interpreter.call_frame().arguments;
-    if (arguments.size() >= 1) {
-        auto string = arguments[0].to_string(interpreter);
-        if (interpreter.exception())
-            return {};
-        auto* context = impl->get_context(string);
-        return wrap(interpreter.heap(), *context);
-    }
-    return JS::js_undefined();
+    auto context_type = interpreter.call_frame().arguments[0].to_string(interpreter);
+    if (interpreter.exception())
+        return {};
+    if (context_type != "2d")
+        return JS::js_null();
+    auto* context = impl->get_context(context_type);
+    return wrap(interpreter.heap(), *context);
 }
 
 JS::Value HTMLCanvasElementWrapper::width_getter(JS::Interpreter& interpreter)

--- a/Libraries/LibWeb/DOM/CanvasRenderingContext2D.h
+++ b/Libraries/LibWeb/DOM/CanvasRenderingContext2D.h
@@ -77,6 +77,8 @@ public:
     RefPtr<ImageData> create_image_data(JS::GlobalObject&, int width, int height) const;
     void put_image_data(const ImageData&, float x, float y);
 
+    HTMLCanvasElement* element() { return m_element; }
+
 private:
     explicit CanvasRenderingContext2D(HTMLCanvasElement&);
 

--- a/Libraries/LibWeb/DOM/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/DOM/HTMLCanvasElement.cpp
@@ -76,7 +76,7 @@ RefPtr<LayoutNode> HTMLCanvasElement::create_layout_node(const StyleProperties* 
 
 CanvasRenderingContext2D* HTMLCanvasElement::get_context(String type)
 {
-    ASSERT(type.to_lowercase() == "2d");
+    ASSERT(type == "2d");
     if (!m_context)
         m_context = CanvasRenderingContext2D::create(*this);
     return m_context;


### PR DESCRIPTION
- LibWeb: Let `HTMLCanvasElement.getContext()` return null for unknown types

  > https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
  >
  > The `HTMLCanvasElement.getContext()` method returns a drawing context on the canvas, or null if the context identifier is not supported.

- LibWeb: Add `CanvasRenderingContext2D.canvas`