### PR TITLE
LibLine: Correctly track the completion start and end

### DIFF
--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -169,9 +169,17 @@ public:
     void stylize(const Span&, const Style&);
     void strip_styles(bool strip_anchored = false);
 
-    void suggest(size_t invariant_offset = 0, size_t index = 0) const
+    // Invariant Offset is an offset into the suggested data, hinting the editor what parts of the suggestion will not change
+    // Static Offset is an offset into the token, signifying where the suggestions start
+    // e.g.
+    //    foobar<suggestion initiated>, on_tab_complete returns "barx", "bary", "barz"
+    //       ^ ^
+    //       +-|- static offset: the suggestions start here
+    //         +- invariant offset: the suggestions do not change up to here
+    void suggest(size_t invariant_offset = 0, size_t static_offset = 0) const
     {
-        m_next_suggestion_index = index;
+        m_next_suggestion_index = 0;
+        m_next_suggestion_static_offset = static_offset;
         m_next_suggestion_invariant_offset = invariant_offset;
     }
 
@@ -207,6 +215,7 @@ private:
     enum class ModificationKind {
         Insertion,
         Removal,
+        ForcedOverlapRemoval,
     };
     void readjust_anchored_styles(size_t hint_index, ModificationKind);
 
@@ -322,6 +331,7 @@ private:
     bool m_last_shown_suggestion_was_complete { false };
     mutable size_t m_next_suggestion_index { 0 };
     mutable size_t m_next_suggestion_invariant_offset { 0 };
+    mutable size_t m_next_suggestion_static_offset { 0 };
     size_t m_largest_common_suggestion_prefix_length { 0 };
     size_t m_last_displayed_suggestion_index { 0 };
 

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -1540,6 +1540,7 @@ Vector<Line::CompletionSuggestion> Shell::complete(const Line::Editor& editor)
     }
 
     String path;
+    String original_token = token;
 
     ssize_t last_slash = token.length() - 1;
     while (last_slash >= 0 && token[last_slash] != '/')
@@ -1563,7 +1564,8 @@ Vector<Line::CompletionSuggestion> Shell::complete(const Line::Editor& editor)
     // e. in `cd /foo/bar', 'bar' is the invariant
     //      since we are not suggesting anything starting with
     //      `/foo/', but rather just `bar...'
-    editor.suggest(escape_token(token).length(), 0);
+    auto token_length = escape_token(token).length();
+    editor.suggest(token_length, original_token.length() - token_length);
 
     // only suggest dot-files if path starts with a dot
     Core::DirIterator files(path,


### PR DESCRIPTION
> This is a little glitchy;
> `ls m<tab>` causes the `s` in `ls` to become hyperlinked as well as the completed `myfile.txt` :]

We can't have that :^)