### PR TITLE
LibJS: Add getter/setter support

### DIFF
--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -59,6 +59,7 @@ class DeferGC;
 class Error;
 class Exception;
 class Expression;
+class Accessor;
 class GlobalObject;
 class HandleImpl;
 class Heap;

--- a/Libraries/LibJS/Runtime/Accessor.h
+++ b/Libraries/LibJS/Runtime/Accessor.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Cell.h>
+#include <LibJS/Runtime/Value.h>
+
+namespace JS {
+
+class Accessor final : public Cell {
+public:
+    static Accessor* create(Interpreter& interpreter, Value getter, Value setter)
+    {
+        return interpreter.heap().allocate<Accessor>(getter, setter);
+    }
+
+    Accessor(Value getter, Value setter)
+        : m_getter(getter)
+        , m_setter(setter)
+    {
+    }
+
+    Value getter() { return m_getter; }
+    Value setter() { return m_setter; }
+
+    Value call_getter(Value this_object)
+    {
+        if (!getter().is_function())
+            return js_undefined();
+        return interpreter().call(getter().as_function(), this_object);
+    }
+
+    void call_setter(Value this_object, Value setter_value)
+    {
+        if (!setter().is_function())
+            return;
+        MarkedValueList arguments(interpreter().heap());
+        arguments.values().append(setter_value);
+        interpreter().call(setter().as_function(), this_object, move(arguments));
+    }
+
+    void visit_children(Cell::Visitor& visitor) override
+    {
+        visitor.visit(m_getter);
+        visitor.visit(m_setter);
+    }
+
+private:
+    const char* class_name() const override { return "Accessor"; };
+
+    Value m_getter;
+    Value m_setter;
+};
+
+}

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -40,6 +40,8 @@ struct Attribute {
         Configurable = 1 << 0,
         Enumerable = 1 << 1,
         Writable = 1 << 2,
+        HasGet = 1 << 3,
+        HasSet = 1 << 4,
     };
 };
 

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -29,6 +29,7 @@
 #include <AK/StringBuilder.h>
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/Accessor.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/BooleanObject.h>
 #include <LibJS/Runtime/Error.h>
@@ -63,6 +64,12 @@ Function& Value::as_function()
     return static_cast<Function&>(as_object());
 }
 
+Accessor& Value::as_accessor()
+{
+    ASSERT(is_accessor());
+    return static_cast<Accessor&>(*m_value.as_accessor);
+}
+
 String Value::to_string_without_side_effects() const
 {
     if (is_boolean())
@@ -91,6 +98,9 @@ String Value::to_string_without_side_effects() const
 
     if (is_symbol())
         return as_symbol().to_string();
+
+    if (is_accessor())
+        return "<accessor>";
 
     ASSERT(is_object());
     return String::format("[object %s]", as_object().class_name());
@@ -205,6 +215,7 @@ Value Value::to_number(Interpreter& interpreter) const
 {
     switch (m_type) {
     case Type::Empty:
+    case Type::Accessor:
         ASSERT_NOT_REACHED();
         return {};
     case Type::Undefined:

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -45,6 +45,7 @@ public:
         Object,
         Boolean,
         Symbol,
+        Accessor,
     };
 
     bool is_empty() const { return m_type == Type::Empty; }
@@ -55,7 +56,8 @@ public:
     bool is_object() const { return m_type == Type::Object; }
     bool is_boolean() const { return m_type == Type::Boolean; }
     bool is_symbol() const { return m_type == Type::Symbol; }
-    bool is_cell() const { return is_string() || is_object(); }
+    bool is_accessor() const { return m_type == Type::Accessor; };
+    bool is_cell() const { return is_string() || is_accessor() || is_object(); }
     bool is_array() const;
     bool is_function() const;
 
@@ -117,6 +119,12 @@ public:
         : m_type(Type::Symbol)
     {
         m_value.as_symbol = symbol;
+    }
+
+    Value(Accessor* accessor)
+        : m_type(Type::Accessor)
+    {
+        m_value.as_accessor = accessor;
     }
 
     explicit Value(Type type)
@@ -183,6 +191,7 @@ public:
     String to_string_without_side_effects() const;
 
     Function& as_function();
+    Accessor& as_accessor();
 
     i32 as_i32() const;
     size_t as_size_t() const;
@@ -214,6 +223,7 @@ private:
         Symbol* as_symbol;
         Object* as_object;
         Cell* as_cell;
+        Accessor* as_accessor;
     } m_value;
 };
 

--- a/Libraries/LibJS/Tests/Object.defineProperty.js
+++ b/Libraries/LibJS/Tests/Object.defineProperty.js
@@ -40,6 +40,81 @@ try {
     assert(d.writable === true);
     assert(d.value === 9);
 
+    Object.defineProperty(o, "qux", {
+        configurable: true,
+        get() {
+            return o.secret_qux + 1;
+        },
+        set(value) {
+            this.secret_qux = value + 1;
+        },
+    });
+
+    o.qux = 10;
+    assert(o.qux === 12);
+    o.qux = 20;
+    assert(o.qux = 22);
+
+    Object.defineProperty(o, "qux", { configurable: true, value: 4 });
+
+    assert(o.qux === 4);
+    o.qux = 5;
+    assert(o.qux = 4);
+
+    Object.defineProperty(o, "qux", {
+        configurable: false,
+        get() {
+            return this.secret_qux + 2;
+        },
+        set(value) {
+            o.secret_qux = value + 2;
+        },
+    });
+
+    o.qux = 10;
+    assert(o.qux === 14);
+    o.qux = 20;
+    assert(o.qux = 24);
+
+    assertThrowsError(() => {
+        Object.defineProperty(o, "qux", {
+            configurable: false,
+            get() {
+                return this.secret_qux + 2;
+            },
+        });
+    }, {
+        error: TypeError,
+        message: "Cannot change attributes of non-configurable property 'qux'",
+    });
+
+    assertThrowsError(() => {
+        Object.defineProperty(o, "qux", { value: 2 });
+    }, {
+        error: TypeError,
+        message: "Cannot change attributes of non-configurable property 'qux'",
+    });
+
+    assertThrowsError(() => {
+        Object.defineProperty(o, "a", {
+            get() {},
+            value: 9,
+        });
+    }, {
+        error: TypeError,
+        message: "Accessor property descriptors cannot specify a value or writable key",
+    });
+
+    assertThrowsError(() => {
+        Object.defineProperty(o, "a", {
+            set() {},
+            writable: true,
+        });
+    }, {
+        error: TypeError,
+        message: "Accessor property descriptors cannot specify a value or writable key",
+    });
+
     console.log("PASS");
 } catch (e) {
     console.log(e)


### PR DESCRIPTION
This patch adds a `GetterSetterPair` object. Values can now store pointers to objects of this type. These objects are created when using `Object.defineProperty` and providing an accessor descriptor.

This allows for property getter and setter support. For example:

```js
Object.defineProperty(o, 'foo', { get() { return 5; } });
console.log(o.foo);
```
Object getter and setter shorthand will be coming in a future PR :)