### PR TITLE
LibWeb: Fix set{Interval,Timout}() callback this value

### DIFF
--- a/Base/home/anon/www/set-interval.html
+++ b/Base/home/anon/www/set-interval.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>setInterval() test</title>
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            var output = document.getElementById("output");
+            var counter = 0;
+            function updateOutput () {
+                output.innerHTML = `setInterval() was called ${counter} times!`;
+            }
+            updateOutput();
+            setInterval(function () {
+                counter++;
+                updateOutput();
+            }, 1000);
+        });
+    </script>
+</head>
+<body>
+    <div id="output"></div>
+</body>
+</html>

--- a/Base/home/anon/www/welcome.html
+++ b/Base/home/anon/www/welcome.html
@@ -28,6 +28,7 @@ span#ua {
     <p>Your user agent is: <b><span id="ua"></span></b></p>
     <p>Some small test pages:</p>
     <ul>
+        <li><a href="set-interval.html">setInterval() test</a></li>
         <li><a href="html-escape-test.html">html character escape test</a></li>
         <li><a href="location.html">window.location property</a></li>
         <li><a href="percent-css.html">CSS percentage values</a></li>

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -104,7 +104,7 @@ public:
     void enter_scope(const ScopeNode&, ArgumentVector, ScopeType);
     void exit_scope(const ScopeNode&);
 
-    Value call(Function&, Value this_value = {}, Optional<MarkedValueList> arguments = {});
+    Value call(Function&, Value this_value, Optional<MarkedValueList> arguments = {});
     Value construct(Function&, Function& new_target, Optional<MarkedValueList> arguments = {});
 
     CallFrame& push_call_frame()

--- a/Libraries/LibWeb/DOM/Window.cpp
+++ b/Libraries/LibWeb/DOM/Window.cpp
@@ -68,7 +68,8 @@ void Window::set_interval(JS::Function& callback, i32 interval)
     (void)Core::Timer::construct(interval, [handle = make_handle(&callback)] {
         auto& function = const_cast<JS::Function&>(static_cast<const JS::Function&>(*handle.cell()));
         auto& interpreter = function.interpreter();
-        interpreter.call(function);
+        auto& window = static_cast<Bindings::WindowObject&>(interpreter.global_object());
+        interpreter.call(function, &window);
     }).leak_ref();
 }
 
@@ -78,7 +79,8 @@ void Window::set_timeout(JS::Function& callback, i32 interval)
     auto& timer = Core::Timer::construct(interval, [handle = make_handle(&callback)] {
         auto& function = const_cast<JS::Function&>(static_cast<const JS::Function&>(*handle.cell()));
         auto& interpreter = function.interpreter();
-        interpreter.call(function);
+        auto& window = static_cast<Bindings::WindowObject&>(interpreter.global_object());
+        interpreter.call(function, &window);
     }).leak_ref();
     timer.set_single_shot(true);
 }


### PR DESCRIPTION
We were giving it an empty value, which shouldn't happen, ever - so now we

1. set the window object as this value and
2. enforce explicitly setting a this value when calling `Interpreter::call()` by making `this_value` a required argument.

Also add a simple demo for `setInterval()` as we had nothing to showcase it :^)