### PR TITLE
Where cxbyte attempts a comprehensive fix of LibLine, and sprinkles more Utf8Views in it...and ends up refactoring the shit out of it

### DIFF
--- a/Libraries/LibLine/CMakeLists.txt
+++ b/Libraries/LibLine/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(SOURCES
     Editor.cpp
+    SuggestionManager.cpp
+    XtermSuggestionDisplay.cpp
 )
 
 serenity_lib(LibLine line)

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -566,6 +566,7 @@ String Editor::get_line(const String& prompt)
                     suggest(0, 0, Span::CodepointOriented);
                     m_times_tab_pressed = 0;
                     m_suggestion_manager.reset();
+                    m_suggestion_display->finish();
                 }
                 continue;
             }
@@ -582,6 +583,7 @@ String Editor::get_line(const String& prompt)
                 }
                 m_suggestion_manager.reset();
                 suggest(0, 0, Span::CodepointOriented);
+                m_suggestion_display->finish();
             }
             m_times_tab_pressed = 0; // Safe to say if we get here, the user didn't press TAB
 

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -176,12 +176,8 @@ public:
     //       ^ ^
     //       +-|- static offset: the suggestions start here
     //         +- invariant offset: the suggestions do not change up to here
-    void suggest(size_t invariant_offset = 0, size_t static_offset = 0) const
-    {
-        m_next_suggestion_index = 0;
-        m_next_suggestion_static_offset = static_offset;
-        m_next_suggestion_invariant_offset = invariant_offset;
-    }
+    //
+    void suggest(size_t invariant_offset = 0, size_t static_offset = 0, Span::Mode offset_mode = Span::ByteOriented) const;
 
     const struct termios& termios() const { return m_termios; }
     const struct termios& default_termios() const { return m_default_termios; }
@@ -292,6 +288,12 @@ private:
 
     void recalculate_origin();
     void reposition_cursor();
+
+    struct CodepointRange {
+        size_t start { 0 };
+        size_t end { 0 };
+    };
+    CodepointRange byte_offset_range_to_codepoint_offset_range(size_t byte_start, size_t byte_end, size_t codepoint_scan_offset, bool reverse = false) const;
 
     bool m_finish { false };
 

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -109,8 +109,8 @@ public:
     Function<void()> on_interrupt_handled;
     Function<void(Editor&)> on_display_refresh;
 
-    // FIXME: we will have to kindly ask our instantiators to set our signal handlers
-    // since we can not do this cleanly ourselves (signal() limitation: cannot give member functions)
+    // FIXME: we will have to kindly ask our instantiators to set our signal handlers,
+    // since we can not do this cleanly ourselves. (signal() limitation: cannot give member functions)
     void interrupted()
     {
         if (m_is_editing)
@@ -124,7 +124,7 @@ public:
     String line() const { return line(m_buffer.size()); }
     String line(size_t up_to_index) const;
 
-    // only makes sense inside a char_input callback or on_* callback
+    // Only makes sense inside a character_input callback or on_* callback.
     void set_prompt(const String& prompt)
     {
         if (m_cached_prompt_valid)
@@ -291,7 +291,7 @@ private:
     size_t m_prompt_lines_at_suggestion_initiation { 0 };
     bool m_cached_prompt_valid { false };
 
-    // exact position before our prompt in the terminal
+    // Exact position before our prompt in the terminal.
     size_t m_origin_x { 0 };
     size_t m_origin_y { 0 };
 
@@ -311,7 +311,7 @@ private:
 
     HashMap<char, NonnullOwnPtr<KeyCallback>> m_key_callbacks;
 
-    // TODO: handle signals internally
+    // TODO: handle signals internally.
     struct termios m_termios, m_default_termios;
     bool m_was_interrupted { false };
     bool m_was_resized { false };

--- a/Libraries/LibLine/Style.h
+++ b/Libraries/LibLine/Style.h
@@ -124,7 +124,7 @@ public:
     static constexpr ItalicTag Italic {};
     static constexpr AnchoredTag Anchored {};
 
-    // prepare for the horror of templates
+    // Prepare for the horror of templates.
     template<typename T, typename... Rest>
     Style(const T& style_arg, Rest... rest)
         : Style(rest...)

--- a/Libraries/LibLine/SuggestionDisplay.h
+++ b/Libraries/LibLine/SuggestionDisplay.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include <AK/Forward.h>
+#include <AK/String.h>
+#include <LibLine/SuggestionManager.h>
+#include <stdlib.h>
+
+namespace Line {
+
+class Editor;
+
+class SuggestionDisplay {
+public:
+    virtual ~SuggestionDisplay() { }
+    virtual void display(const SuggestionManager&) = 0;
+    virtual bool cleanup() = 0;
+    virtual void set_initial_prompt_lines(size_t) = 0;
+
+    virtual void set_vt_size(size_t lines, size_t columns) = 0;
+
+    size_t origin_x() const { return m_origin_x; }
+    size_t origin_y() const { return m_origin_y; }
+
+    void set_origin(int x, int y, Badge<Editor>)
+    {
+        m_origin_x = x;
+        m_origin_y = y;
+    }
+
+protected:
+    int m_origin_x { 0 };
+    int m_origin_y { 0 };
+};
+
+class XtermSuggestionDisplay : public SuggestionDisplay {
+public:
+    XtermSuggestionDisplay(size_t lines, size_t columns)
+        : m_num_lines(lines)
+        , m_num_columns(columns)
+    {
+    }
+    virtual ~XtermSuggestionDisplay() override { }
+    virtual void display(const SuggestionManager&) override;
+    virtual bool cleanup() override;
+
+    virtual void set_initial_prompt_lines(size_t lines) override
+    {
+        m_prompt_lines_at_suggestion_initiation = lines;
+    }
+
+    virtual void set_vt_size(size_t lines, size_t columns) override
+    {
+        m_num_lines = lines;
+        m_num_columns = columns;
+    }
+
+private:
+    size_t m_lines_used_for_last_suggestions { 0 };
+    size_t m_num_lines { 0 };
+    size_t m_num_columns { 0 };
+    size_t m_prompt_lines_at_suggestion_initiation { 0 };
+    size_t m_prompt_length { 0 };
+};
+
+}

--- a/Libraries/LibLine/SuggestionDisplay.h
+++ b/Libraries/LibLine/SuggestionDisplay.h
@@ -39,6 +39,7 @@ public:
     virtual ~SuggestionDisplay() { }
     virtual void display(const SuggestionManager&) = 0;
     virtual bool cleanup() = 0;
+    virtual void finish() = 0;
     virtual void set_initial_prompt_lines(size_t) = 0;
 
     virtual void set_vt_size(size_t lines, size_t columns) = 0;
@@ -67,6 +68,10 @@ public:
     virtual ~XtermSuggestionDisplay() override { }
     virtual void display(const SuggestionManager&) override;
     virtual bool cleanup() override;
+    virtual void finish() override
+    {
+        m_pages.clear();
+    }
 
     virtual void set_initial_prompt_lines(size_t lines) override
     {
@@ -77,14 +82,22 @@ public:
     {
         m_num_lines = lines;
         m_num_columns = columns;
+        m_pages.clear();
     }
 
 private:
+    size_t fit_to_page_boundary(size_t selection_index);
     size_t m_lines_used_for_last_suggestions { 0 };
     size_t m_num_lines { 0 };
     size_t m_num_columns { 0 };
     size_t m_prompt_lines_at_suggestion_initiation { 0 };
     size_t m_prompt_length { 0 };
+
+    struct PageRange {
+        size_t start;
+        size_t end;
+    };
+    Vector<PageRange> m_pages;
 };
 
 }

--- a/Libraries/LibLine/SuggestionManager.cpp
+++ b/Libraries/LibLine/SuggestionManager.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Function.h>
+#include <LibLine/SuggestionManager.h>
+
+namespace Line {
+
+CompletionSuggestion::CompletionSuggestion(const StringView& completion, const StringView& trailing_trivia, Style style)
+    : style(style)
+    , text_string(completion)
+{
+    Utf8View text_u8 { completion };
+    Utf8View trivia_u8 { trailing_trivia };
+
+    for (auto cp : text_u8)
+        text.append(cp);
+
+    for (auto cp : trivia_u8)
+        this->trailing_trivia.append(cp);
+
+    text_view = Utf32View { text.data(), text.size() };
+    trivia_view = Utf32View { this->trailing_trivia.data(), this->trailing_trivia.size() };
+}
+
+void SuggestionManager::set_suggestions(Vector<CompletionSuggestion>&& suggestions)
+{
+    m_suggestions = move(suggestions);
+    size_t common_suggestion_prefix { 0 };
+    if (m_suggestions.size() == 1) {
+        m_largest_common_suggestion_prefix_length = m_suggestions[0].text_view.length();
+    } else if (m_suggestions.size()) {
+        u32 last_valid_suggestion_codepoint;
+
+        for (;; ++common_suggestion_prefix) {
+            if (m_suggestions[0].text_view.length() <= common_suggestion_prefix)
+                goto no_more_commons;
+
+            last_valid_suggestion_codepoint = m_suggestions[0].text_view.codepoints()[common_suggestion_prefix];
+
+            for (auto& suggestion : m_suggestions) {
+                if (suggestion.text_view.length() <= common_suggestion_prefix || suggestion.text_view.codepoints()[common_suggestion_prefix] != last_valid_suggestion_codepoint) {
+                    goto no_more_commons;
+                }
+            }
+        }
+    no_more_commons:;
+        m_largest_common_suggestion_prefix_length = common_suggestion_prefix;
+    } else {
+        m_largest_common_suggestion_prefix_length = 0;
+    }
+}
+
+void SuggestionManager::next()
+{
+    if (m_suggestions.size())
+        m_next_suggestion_index = (m_next_suggestion_index + 1) % m_suggestions.size();
+    else
+        m_next_suggestion_index = 0;
+}
+
+void SuggestionManager::previous()
+{
+    if (m_next_suggestion_index == 0)
+        m_next_suggestion_index = m_suggestions.size();
+    m_next_suggestion_index--;
+}
+
+const CompletionSuggestion& SuggestionManager::suggest()
+{
+    m_last_shown_suggestion = m_suggestions[m_next_suggestion_index];
+    m_selected_suggestion_index = m_next_suggestion_index;
+    return m_last_shown_suggestion;
+}
+
+void SuggestionManager::set_current_suggestion_initiation_index(size_t index)
+{
+
+    if (m_last_shown_suggestion_display_length)
+        m_last_shown_suggestion.start_index = index - m_next_suggestion_static_offset - m_last_shown_suggestion_display_length;
+    else
+        m_last_shown_suggestion.start_index = index - m_next_suggestion_static_offset - m_next_suggestion_invariant_offset;
+
+    m_last_shown_suggestion_display_length = m_last_shown_suggestion.text_view.length();
+    m_last_shown_suggestion_was_complete = true;
+}
+
+SuggestionManager::CompletionAttemptResult SuggestionManager::attempt_completion(CompletionMode mode, size_t initiation_start_index)
+{
+    CompletionAttemptResult result { mode };
+
+    if (m_next_suggestion_index < m_suggestions.size()) {
+        auto can_complete = m_next_suggestion_invariant_offset <= m_largest_common_suggestion_prefix_length;
+        if (!m_last_shown_suggestion.text.is_null()) {
+            ssize_t actual_offset;
+            size_t shown_length = m_last_shown_suggestion_display_length;
+            switch (mode) {
+            case CompletePrefix:
+                actual_offset = 0;
+                break;
+            case ShowSuggestions:
+                actual_offset = 0 - m_largest_common_suggestion_prefix_length + m_next_suggestion_invariant_offset;
+                if (can_complete)
+                    shown_length = m_largest_common_suggestion_prefix_length + m_last_shown_suggestion.trivia_view.length();
+                break;
+            default:
+                if (m_last_shown_suggestion_display_length == 0)
+                    actual_offset = 0;
+                else
+                    actual_offset = 0 - m_last_shown_suggestion_display_length + m_next_suggestion_invariant_offset;
+                break;
+            }
+
+            result.offset_region_to_remove = { m_next_suggestion_invariant_offset, shown_length };
+            result.new_cursor_offset = actual_offset;
+        }
+
+        auto& suggestion = suggest();
+        set_current_suggestion_initiation_index(initiation_start_index);
+
+        if (mode == CompletePrefix) {
+            // only auto-complete *if possible*
+            if (can_complete) {
+                result.insert.append(suggestion.text_view.substring_view(m_next_suggestion_invariant_offset, m_largest_common_suggestion_prefix_length - m_next_suggestion_invariant_offset));
+                m_last_shown_suggestion_display_length = m_largest_common_suggestion_prefix_length;
+                // do not increment the suggestion index, as the first tab should only be a *peek*
+                if (m_suggestions.size() == 1) {
+                    // if there's one suggestion, commit and forget
+                    result.new_completion_mode = DontComplete;
+                    // add in the trivia of the last selected suggestion
+                    result.insert.append(suggestion.trivia_view);
+                    m_last_shown_suggestion_display_length = 0;
+                    result.style_to_apply = suggestion.style;
+                    m_last_shown_suggestion_was_complete = true;
+                    return result;
+                }
+            } else {
+                m_last_shown_suggestion_display_length = 0;
+            }
+            result.new_completion_mode = CompletionMode::ShowSuggestions;
+            m_last_shown_suggestion_was_complete = false;
+            m_last_shown_suggestion = String::empty();
+        } else {
+            result.insert.append(suggestion.text_view.substring_view(m_next_suggestion_invariant_offset, suggestion.text_view.length() - m_next_suggestion_invariant_offset));
+            // add in the trivia of the last selected suggestion
+            result.insert.append(suggestion.trivia_view);
+            m_last_shown_suggestion_display_length += suggestion.trivia_view.length();
+        }
+    } else {
+        m_next_suggestion_index = 0;
+    }
+    return result;
+}
+
+size_t SuggestionManager::for_each_suggestion(Function<IterationDecision(const CompletionSuggestion&, size_t)> callback) const
+{
+    size_t start_index { 0 };
+    for (auto& suggestion : m_suggestions) {
+        if (start_index++ < m_last_displayed_suggestion_index)
+            continue;
+        if (callback(suggestion, start_index - 1) == IterationDecision::Break)
+            break;
+    }
+    return start_index;
+}
+
+}

--- a/Libraries/LibLine/SuggestionManager.cpp
+++ b/Libraries/LibLine/SuggestionManager.cpp
@@ -148,15 +148,15 @@ SuggestionManager::CompletionAttemptResult SuggestionManager::attempt_completion
         set_current_suggestion_initiation_index(initiation_start_index);
 
         if (mode == CompletePrefix) {
-            // only auto-complete *if possible*
+            // Only auto-complete *if possible*.
             if (can_complete) {
                 result.insert.append(suggestion.text_view.substring_view(m_next_suggestion_invariant_offset, m_largest_common_suggestion_prefix_length - m_next_suggestion_invariant_offset));
                 m_last_shown_suggestion_display_length = m_largest_common_suggestion_prefix_length;
-                // do not increment the suggestion index, as the first tab should only be a *peek*
+                // Do not increment the suggestion index, as the first tab should only be a *peek*.
                 if (m_suggestions.size() == 1) {
-                    // if there's one suggestion, commit and forget
+                    // If there's one suggestion, commit and forget.
                     result.new_completion_mode = DontComplete;
-                    // add in the trivia of the last selected suggestion
+                    // Add in the trivia of the last selected suggestion.
                     result.insert.append(suggestion.trivia_view);
                     m_last_shown_suggestion_display_length = 0;
                     result.style_to_apply = suggestion.style;
@@ -171,7 +171,7 @@ SuggestionManager::CompletionAttemptResult SuggestionManager::attempt_completion
             m_last_shown_suggestion = String::empty();
         } else {
             result.insert.append(suggestion.text_view.substring_view(m_next_suggestion_invariant_offset, suggestion.text_view.length() - m_next_suggestion_invariant_offset));
-            // add in the trivia of the last selected suggestion
+            // Add in the trivia of the last selected suggestion.
             result.insert.append(suggestion.trivia_view);
             m_last_shown_suggestion_display_length += suggestion.trivia_view.length();
         }

--- a/Libraries/LibLine/SuggestionManager.cpp
+++ b/Libraries/LibLine/SuggestionManager.cpp
@@ -32,6 +32,7 @@ namespace Line {
 CompletionSuggestion::CompletionSuggestion(const StringView& completion, const StringView& trailing_trivia, Style style)
     : style(style)
     , text_string(completion)
+    , is_valid(true)
 {
     Utf8View text_u8 { completion };
     Utf8View trivia_u8 { trailing_trivia };
@@ -49,6 +50,11 @@ CompletionSuggestion::CompletionSuggestion(const StringView& completion, const S
 void SuggestionManager::set_suggestions(Vector<CompletionSuggestion>&& suggestions)
 {
     m_suggestions = move(suggestions);
+
+    // make sure we were not given invalid suggestions
+    for (auto& suggestion : m_suggestions)
+        ASSERT(suggestion.is_valid);
+
     size_t common_suggestion_prefix { 0 };
     if (m_suggestions.size() == 1) {
         m_largest_common_suggestion_prefix_length = m_suggestions[0].text_view.length();

--- a/Libraries/LibLine/SuggestionManager.h
+++ b/Libraries/LibLine/SuggestionManager.h
@@ -35,7 +35,7 @@
 namespace Line {
 
 // FIXME: These objects are pretty heavy since they store two copies of text
-//        somehow get rid of one
+//        somehow get rid of one.
 struct CompletionSuggestion {
 private:
     struct ForSearchTag {
@@ -44,7 +44,7 @@ private:
 public:
     static constexpr ForSearchTag ForSearch {};
 
-    // intentionally not explicit (allows suggesting bare strings)
+    // Intentionally not explicit. (To allow suggesting bare strings)
     CompletionSuggestion(const String& completion)
         : CompletionSuggestion(completion, "", {})
     {

--- a/Libraries/LibLine/SuggestionManager.h
+++ b/Libraries/LibLine/SuggestionManager.h
@@ -37,9 +37,21 @@ namespace Line {
 // FIXME: These objects are pretty heavy since they store two copies of text
 //        somehow get rid of one
 struct CompletionSuggestion {
+private:
+    struct ForSearchTag {
+    };
+
+public:
+    static constexpr ForSearchTag ForSearch {};
+
     // intentionally not explicit (allows suggesting bare strings)
     CompletionSuggestion(const String& completion)
         : CompletionSuggestion(completion, "", {})
+    {
+    }
+
+    CompletionSuggestion(const String& completion, ForSearchTag)
+        : text_string(completion)
     {
     }
 
@@ -52,7 +64,7 @@ struct CompletionSuggestion {
 
     bool operator==(const CompletionSuggestion& suggestion) const
     {
-        return suggestion.text == text;
+        return suggestion.text_string == text_string;
     }
 
     Vector<u32> text;
@@ -63,6 +75,7 @@ struct CompletionSuggestion {
     Utf32View text_view;
     Utf32View trivia_view;
     String text_string;
+    bool is_valid { false };
 };
 
 class SuggestionManager {

--- a/Libraries/LibLine/SuggestionManager.h
+++ b/Libraries/LibLine/SuggestionManager.h
@@ -83,12 +83,13 @@ class SuggestionManager {
 
 public:
     void set_suggestions(Vector<CompletionSuggestion>&& suggestions);
-    void set_current_suggestion_initiation_index(size_t index);
+    void set_current_suggestion_initiation_index(size_t start_index);
 
     size_t count() const { return m_suggestions.size(); }
     size_t display_length() const { return m_last_shown_suggestion_display_length; }
-    size_t index() const { return m_last_displayed_suggestion_index; }
+    size_t start_index() const { return m_last_displayed_suggestion_index; }
     size_t next_index() const { return m_next_suggestion_index; }
+    void set_start_index(size_t index) const { m_last_displayed_suggestion_index = index; }
 
     size_t for_each_suggestion(Function<IterationDecision(const CompletionSuggestion&, size_t)>) const;
 
@@ -151,7 +152,7 @@ private:
     mutable size_t m_next_suggestion_invariant_offset { 0 };
     mutable size_t m_next_suggestion_static_offset { 0 };
     size_t m_largest_common_suggestion_prefix_length { 0 };
-    size_t m_last_displayed_suggestion_index { 0 };
+    mutable size_t m_last_displayed_suggestion_index { 0 };
     size_t m_selected_suggestion_index { 0 };
 };
 

--- a/Libraries/LibLine/SuggestionManager.h
+++ b/Libraries/LibLine/SuggestionManager.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include <AK/Forward.h>
+#include <AK/String.h>
+#include <AK/Utf32View.h>
+#include <AK/Utf8View.h>
+#include <LibLine/Style.h>
+#include <stdlib.h>
+
+namespace Line {
+
+// FIXME: These objects are pretty heavy since they store two copies of text
+//        somehow get rid of one
+struct CompletionSuggestion {
+    // intentionally not explicit (allows suggesting bare strings)
+    CompletionSuggestion(const String& completion)
+        : CompletionSuggestion(completion, "", {})
+    {
+    }
+
+    CompletionSuggestion(const StringView& completion, const StringView& trailing_trivia)
+        : CompletionSuggestion(completion, trailing_trivia, {})
+    {
+    }
+
+    CompletionSuggestion(const StringView& completion, const StringView& trailing_trivia, Style style);
+
+    bool operator==(const CompletionSuggestion& suggestion) const
+    {
+        return suggestion.text == text;
+    }
+
+    Vector<u32> text;
+    Vector<u32> trailing_trivia;
+    Style style;
+    size_t start_index { 0 };
+
+    Utf32View text_view;
+    Utf32View trivia_view;
+    String text_string;
+};
+
+class SuggestionManager {
+    friend class Editor;
+
+public:
+    void set_suggestions(Vector<CompletionSuggestion>&& suggestions);
+    void set_current_suggestion_initiation_index(size_t index);
+
+    size_t count() const { return m_suggestions.size(); }
+    size_t display_length() const { return m_last_shown_suggestion_display_length; }
+    size_t index() const { return m_last_displayed_suggestion_index; }
+    size_t next_index() const { return m_next_suggestion_index; }
+
+    size_t for_each_suggestion(Function<IterationDecision(const CompletionSuggestion&, size_t)>) const;
+
+    enum CompletionMode {
+        DontComplete,
+        CompletePrefix,
+        ShowSuggestions,
+        CycleSuggestions,
+    };
+
+    class CompletionAttemptResult {
+    public:
+        CompletionMode new_completion_mode;
+
+        ssize_t new_cursor_offset { 0 };
+
+        struct {
+            size_t start;
+            size_t end;
+        } offset_region_to_remove { 0, 0 }; // The region to remove as defined by [start, end) translated by (old_cursor + new_cursor_offset)
+
+        Vector<Utf32View> insert {};
+
+        Optional<Style> style_to_apply {};
+    };
+
+    CompletionAttemptResult attempt_completion(CompletionMode, size_t initiation_start_index);
+
+    void next();
+    void previous();
+    void set_suggestion_variants(size_t static_offset, size_t invariant_offset, size_t suggestion_index) const
+    {
+        m_next_suggestion_index = suggestion_index;
+        m_next_suggestion_static_offset = static_offset;
+        m_next_suggestion_invariant_offset = invariant_offset;
+    }
+
+    const CompletionSuggestion& suggest();
+    const CompletionSuggestion& current_suggestion() const { return m_last_shown_suggestion; }
+    bool is_current_suggestion_complete() const { return m_last_shown_suggestion_was_complete; }
+
+    void reset()
+    {
+        m_last_shown_suggestion = String::empty();
+        m_last_shown_suggestion_display_length = 0;
+        m_suggestions.clear();
+        m_last_displayed_suggestion_index = 0;
+    }
+
+private:
+    SuggestionManager()
+    {
+    }
+
+    Vector<CompletionSuggestion> m_suggestions;
+    CompletionSuggestion m_last_shown_suggestion { String::empty() };
+    size_t m_last_shown_suggestion_display_length { 0 };
+    bool m_last_shown_suggestion_was_complete { false };
+    mutable size_t m_next_suggestion_index { 0 };
+    mutable size_t m_next_suggestion_invariant_offset { 0 };
+    mutable size_t m_next_suggestion_static_offset { 0 };
+    size_t m_largest_common_suggestion_prefix_length { 0 };
+    size_t m_last_displayed_suggestion_index { 0 };
+    size_t m_selected_suggestion_index { 0 };
+};
+
+}

--- a/Libraries/LibLine/VT.h
+++ b/Libraries/LibLine/VT.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <LibLine/Style.h>
+
+namespace Line {
+namespace VT {
+
+void save_cursor();
+void restore_cursor();
+void clear_to_end_of_line();
+void clear_lines(size_t count_above, size_t count_below = 0);
+void move_relative(int x, int y);
+void move_absolute(u32 x, u32 y);
+void apply_style(const Style&, bool is_starting = true);
+
+}
+}

--- a/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -55,8 +55,8 @@ void XtermSuggestionDisplay::display(const SuggestionManager& manager)
     auto max_line_count = (m_prompt_length + longest_suggestion_length + m_num_columns - 1) / m_num_columns;
     if (longest_suggestion_length >= m_num_columns - 2) {
         spans_entire_line = true;
-        // we should make enough space for the biggest entry in
-        // the suggestion list to fit in the prompt line
+        // We should make enough space for the biggest entry in
+        // the suggestion list to fit in the prompt line.
         auto start = max_line_count - m_prompt_lines_at_suggestion_initiation;
         for (size_t i = start; i < max_line_count; ++i) {
             putchar('\n');
@@ -70,7 +70,7 @@ void XtermSuggestionDisplay::display(const SuggestionManager& manager)
     if (m_pages.is_empty()) {
         size_t num_printed = 0;
         size_t lines_used = 1;
-        // cache the pages
+        // Cache the pages.
         manager.set_start_index(0);
         size_t page_start = 0;
         manager.for_each_suggestion([&](auto& suggestion, auto index) {
@@ -95,7 +95,7 @@ void XtermSuggestionDisplay::display(const SuggestionManager& manager)
 
             return IterationDecision::Continue;
         });
-        // last page
+        // Append the last page.
         m_pages.append({ page_start, manager.count() });
     }
 
@@ -113,12 +113,12 @@ void XtermSuggestionDisplay::display(const SuggestionManager& manager)
             num_printed = 0;
         }
 
-        // show just enough suggestions to fill up the screen
-        // without moving the prompt out of view
+        // Show just enough suggestions to fill up the screen
+        // without moving the prompt out of view.
         if (lines_used + m_prompt_lines_at_suggestion_initiation >= m_num_lines)
             return IterationDecision::Break;
 
-        // only apply colour to the selection if something is *actually* added to the buffer
+        // Only apply colour to the selection if something is *actually* added to the buffer.
         if (manager.is_current_suggestion_complete() && index == manager.next_index()) {
             VT::apply_style({ Style::Foreground(Style::XtermColor::Blue) });
             fflush(stdout);
@@ -141,7 +141,7 @@ void XtermSuggestionDisplay::display(const SuggestionManager& manager)
 
     m_lines_used_for_last_suggestions = lines_used;
 
-    // if we filled the screen, move back the origin
+    // If we filled the screen, move back the origin.
     if (m_origin_x + lines_used >= m_num_lines) {
         m_origin_x = m_num_lines - lines_used;
     }
@@ -152,7 +152,7 @@ void XtermSuggestionDisplay::display(const SuggestionManager& manager)
         auto string = String::format("%c page %d of %d %c", left_arrow, page_index + 1, m_pages.size(), right_arrow);
 
         if (string.length() > m_num_columns - 1) {
-            // this would overflow into the next line, so just don't print an indicator
+            // This would overflow into the next line, so just don't print an indicator.
             return;
         }
 

--- a/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Function.h>
+#include <LibLine/SuggestionDisplay.h>
+#include <LibLine/VT.h>
+#include <stdio.h>
+
+namespace Line {
+
+void XtermSuggestionDisplay::display(const SuggestionManager& manager)
+{
+    size_t longest_suggestion_length = 0;
+    size_t longest_suggestion_byte_length = 0;
+
+    manager.for_each_suggestion([&](auto& suggestion, auto) {
+        longest_suggestion_length = max(longest_suggestion_length, suggestion.text_view.length());
+        longest_suggestion_byte_length = max(longest_suggestion_byte_length, suggestion.text_string.length());
+        return IterationDecision::Continue;
+    });
+
+    size_t num_printed = 0;
+    size_t lines_used { 1 };
+
+    VT::save_cursor();
+    VT::clear_lines(0, m_lines_used_for_last_suggestions);
+    VT::restore_cursor();
+
+    auto spans_entire_line { false };
+    auto max_line_count = (m_prompt_length + longest_suggestion_length + m_num_columns - 1) / m_num_columns;
+    if (longest_suggestion_length >= m_num_columns - 2) {
+        spans_entire_line = true;
+        // we should make enough space for the biggest entry in
+        // the suggestion list to fit in the prompt line
+        auto start = max_line_count - m_prompt_lines_at_suggestion_initiation;
+        for (size_t i = start; i < max_line_count; ++i) {
+            putchar('\n');
+        }
+        lines_used += max_line_count;
+        longest_suggestion_length = 0;
+    }
+    VT::move_absolute(max_line_count + m_origin_x, 1);
+
+    manager.for_each_suggestion([&](auto& suggestion, auto index) {
+        size_t next_column = num_printed + suggestion.text_view.length() + longest_suggestion_length + 2;
+
+        if (next_column > m_num_columns) {
+            auto lines = (suggestion.text_view.length() + m_num_columns - 1) / m_num_columns;
+            lines_used += lines;
+            putchar('\n');
+            num_printed = 0;
+        }
+
+        // show just enough suggestions to fill up the screen
+        // without moving the prompt out of view
+        if (lines_used + m_prompt_lines_at_suggestion_initiation >= m_num_lines)
+            return IterationDecision::Break;
+
+        // only apply colour to the selection if something is *actually* added to the buffer
+        if (manager.is_current_suggestion_complete() && index == manager.next_index()) {
+            VT::apply_style({ Style::Foreground(Style::XtermColor::Blue) });
+            fflush(stdout);
+        }
+
+        if (spans_entire_line) {
+            num_printed += m_num_columns;
+            fprintf(stderr, "%s", suggestion.text_string.characters());
+        } else {
+            fprintf(stderr, "%-*s", static_cast<int>(longest_suggestion_byte_length) + 2, suggestion.text_string.characters());
+            num_printed += longest_suggestion_length + 2;
+        }
+
+        if (manager.is_current_suggestion_complete() && index == manager.next_index()) {
+            VT::apply_style(Style::reset_style());
+            fflush(stdout);
+        }
+        return IterationDecision::Continue;
+    });
+
+    m_lines_used_for_last_suggestions = lines_used;
+
+    // if we filled the screen, move back the origin
+    if (m_origin_x + lines_used >= m_num_lines) {
+        m_origin_x = m_num_lines - lines_used;
+    }
+}
+
+bool XtermSuggestionDisplay::cleanup()
+{
+    if (m_lines_used_for_last_suggestions) {
+        VT::clear_lines(0, m_lines_used_for_last_suggestions);
+        m_lines_used_for_last_suggestions = 0;
+        return true;
+    }
+
+    return false;
+}
+
+}

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -1501,8 +1501,14 @@ Vector<Line::CompletionSuggestion> Shell::complete(const Line::Editor& editor)
             if (args.last().type == Token::Comment) // we cannot complete comments
                 return {};
 
-            is_first_in_subcommand = args.size() == 1;
-            token = last_command.args.last().text;
+            if (args.last().end != line.length()) {
+                // There was a token separator at the end
+                is_first_in_subcommand = false;
+                token = "";
+            } else {
+                is_first_in_subcommand = args.size() == 1;
+                token = last_command.args.last().text;
+            }
         }
     }
 

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -729,9 +729,9 @@ int main(int argc, char** argv)
             Function<void(const JS::Shape&, const StringView&)> list_all_properties = [&results, &list_all_properties](const JS::Shape& shape, auto& property_pattern) {
                 for (const auto& descriptor : shape.property_table()) {
                     if (descriptor.key.view().starts_with(property_pattern)) {
-                        Line::CompletionSuggestion completion { descriptor.key };
+                        Line::CompletionSuggestion completion { descriptor.key, Line::CompletionSuggestion::ForSearch };
                         if (!results.contains_slow(completion)) { // hide duplicates
-                            results.append(completion);
+                            results.append({ descriptor.key });
                         }
                     }
                 }


### PR DESCRIPTION
- [x] successive tabs after completion should not mess with the anchored styles
- [x] emojis inside suggestions should not mess with the anchored styles
- [x] cycling emoji suggestions should not mess with the anchored styles
- [x] suggestion previews should be spaced properly, even if they have emojis
- [x] anchored styles should not disappear after
    - [x] failed completion attempt
    - [x] successful completion attempt for an unrelated token
- [x] anchored styles should be correctly applied after cycling suggestion pages
- [x] paging should work
- [x] going back a page. (how = by precalculating page boundaries)
- [x] cute little next-page indicator
- [x] redrawing completion previews should not be so dang slow
- [x] Userland/js should not do weird things when suggesting stuff

Please tell me of any edge cases you might think of~

This PR (so far) unbreaks paging because refactoring made that easy.