### PR TITLE
LibJS: Refactor Array.prototype callback functions and make them generic

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -422,8 +422,8 @@ Value ArrayPrototype::includes(Interpreter& interpreter)
     if (!array)
         return {};
 
-    i32 array_size = static_cast<i32>(array->elements().size());
-    if (interpreter.argument_count() == 0 || array_size == 0)
+    i32 array_size = array->elements().size();
+    if (array_size == 0)
         return Value(false);
 
     i32 from_index = 0;

--- a/Libraries/LibJS/Tests/Array.prototype-generic-functions.js
+++ b/Libraries/LibJS/Tests/Array.prototype-generic-functions.js
@@ -1,0 +1,47 @@
+load("test-common.js");
+
+try {
+    const o = { length: 5, 0: "foo", 1: "bar", 3: "baz" };
+
+    ["every"].forEach(name => {
+        const visited = [];
+        Array.prototype[name].call(o, function (value) {
+            visited.push(value);
+            return true;
+        });
+        assert(visited.length === 3);
+        assert(visited[0] === "foo");
+        assert(visited[1] === "bar");
+        assert(visited[2] === "baz");
+    });
+
+    ["find", "findIndex"].forEach(name => {
+        const visited = [];
+        Array.prototype[name].call(o, function (value) {
+            visited.push(value);
+            return false;
+        });
+        assert(visited.length === 5);
+        assert(visited[0] === "foo");
+        assert(visited[1] === "bar");
+        assert(visited[2] === undefined);
+        assert(visited[3] === "baz");
+        assert(visited[4] === undefined);
+    });
+
+    ["filter", "forEach", "map", "some"].forEach(name => {
+        const visited = [];
+        Array.prototype[name].call(o, function (value) {
+            visited.push(value);
+            return false;
+        });
+        assert(visited.length === 3);
+        assert(visited[0] === "foo");
+        assert(visited[1] === "bar");
+        assert(visited[2] === "baz");
+    });
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Array.prototype.includes.js
+++ b/Libraries/LibJS/Tests/Array.prototype.includes.js
@@ -5,6 +5,8 @@ try {
 
     var array = ['hello', 'friends', 1, 2, false];
 
+    assert([].includes() === false);
+    assert([undefined].includes() === true);
     assert(array.includes('hello') === true);
     assert(array.includes(1) === true);
     assert(array.includes(1, -3) === true);

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -35,6 +35,8 @@
 #include <sys/time.h>
 #include <unistd.h>
 
+// #define SUGGESTIONS_DEBUG
+
 namespace Line {
 
 Editor::Editor(Configuration configuration)
@@ -524,7 +526,9 @@ String Editor::get_line(const String& prompt)
                     }
                     m_last_shown_suggestion = m_suggestions[m_next_suggestion_index];
                     m_last_shown_suggestion.token_start_index = token_start - m_next_suggestion_invariant_offset - m_next_suggestion_static_offset;
+#ifdef SUGGESTIONS_DEBUG
                     dbg() << "Last shown suggestion token start index: " << m_last_shown_suggestion.token_start_index << " Token Start " << token_start << " invariant offset " << m_next_suggestion_invariant_offset;
+#endif
                     m_last_shown_suggestion_display_length = m_last_shown_suggestion.text.length();
                     m_last_shown_suggestion_was_complete = true;
                     if (m_times_tab_pressed == 1) {
@@ -661,7 +665,9 @@ String Editor::get_line(const String& prompt)
 
             if (m_times_tab_pressed) {
                 // Apply the style of the last suggestion
+#ifdef SUGGESTIONS_DEBUG
                 dbg() << "Last shown suggestion token start index: " << m_last_shown_suggestion.token_start_index << " invariant offset " << m_next_suggestion_invariant_offset << " static offset " << m_next_suggestion_static_offset;
+#endif
                 readjust_anchored_styles(m_last_shown_suggestion.token_start_index, ModificationKind::ForcedOverlapRemoval);
                 stylize({ m_last_shown_suggestion.token_start_index, m_cursor, Span::Mode::CodepointOriented }, m_last_shown_suggestion.style);
                 // we probably have some suggestions drawn


### PR DESCRIPTION
There are more to be made generic, but doing the ones taking a callback and optional this value was most straightforward as they have more or less the same logic every time.