### PR TITLE
Ext2FS: Fix indirect-blocks iteration

### DIFF
--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -450,7 +450,7 @@ Vector<Ext2FS::BlockIndex> Ext2FS::block_list_for_inode_impl(const ext2_inode& e
 
     auto process_block_array = [&](unsigned array_block_index, auto&& callback) {
         if (include_block_list_blocks)
-            callback(array_block_index);
+            add_block(array_block_index);
         unsigned count = min(blocks_remaining, entries_per_block);
         size_t read_size = count * sizeof(__u32);
         auto array_block = ByteBuffer::create_uninitialized(read_size);


### PR DESCRIPTION
For singly-indirect blocks, "callback" is just "add_block".
For doubly-indirect blocks, "callback" is the lambda function
iterating on singly-indirect blocks: so instead of adding itself to the
list, the doubly-indirect block will add all its childs, but they add
themselves again when they run the callback of singly-indirect blocks.
And nothing adds the doubly-indirect block itself :(

This leads to a double free of all child blocks of the doubly-indirect
block, which is the failed assert described in #1549.

Closes: #1549.