### PR TITLE
LibJS: Disallow multiple parameters in paren-less arrow function

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -287,7 +287,7 @@ RefPtr<FunctionExpression> Parser::try_parse_arrow_function_expression(bool expe
     i32 function_length = -1;
     while (true) {
         if (match(TokenType::Comma)) {
-            if (has_rest_parameter) {
+            if (has_rest_parameter || !expect_parens) {
                 parse_failed = true;
                 break;
             }

--- a/Libraries/LibJS/Tests/arrow-functions.js
+++ b/Libraries/LibJS/Tests/arrow-functions.js
@@ -55,6 +55,11 @@ try {
     })(10);
     assert(half === 5);
 
+    var foo, bar;
+    foo = bar, baz => {};
+    assert(foo === undefined);
+    assert(bar === undefined);
+
     console.log("PASS");
 } catch {
     console.log("FAIL");


### PR DESCRIPTION
Fixes #2323.