### PR TITLE
LibJS: Add object literal getter/setter shorthand

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -31,6 +31,7 @@
 #include <AK/StringBuilder.h>
 #include <LibJS/AST.h>
 #include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/Accessor.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -1129,7 +1130,7 @@ Value ObjectExpression::execute(Interpreter& interpreter) const
         if (interpreter.exception())
             return {};
 
-        if (property.is_spread()) {
+        if (property.type() == ObjectProperty::Type::Spread) {
             if (key_result.is_array()) {
                 auto& array_to_spread = static_cast<Array&>(key_result.as_object());
                 auto& elements = array_to_spread.elements();
@@ -1163,8 +1164,34 @@ Value ObjectExpression::execute(Interpreter& interpreter) const
         auto value = property.value().execute(interpreter);
         if (interpreter.exception())
             return {};
-        update_function_name(value, key);
-        object->put(key, value);
+
+        String name = key;
+        if (property.type() == ObjectProperty::Type::Getter) {
+            name = String::format("get %s", key.characters());
+        } else if (property.type() == ObjectProperty::Type::Setter) {
+            name = String::format("set %s", key.characters());
+        }
+
+        update_function_name(value, name);
+
+        if (property.type() == ObjectProperty::Type::Getter || property.type() == ObjectProperty::Type::Setter) {
+            Value getter;
+            Value setter;
+            auto existing_property_metadata = object->shape().lookup(key);
+            Value existing_property;
+            if (existing_property_metadata.has_value())
+                existing_property = object->get_direct(existing_property_metadata.value().offset);
+            if (property.type() == ObjectProperty::Type::Getter) {
+                getter = value;
+                setter = existing_property.is_accessor() ? existing_property.as_accessor().setter() : Value();
+            } else {
+                getter = existing_property.is_accessor() ? existing_property.as_accessor().getter() : Value();
+                setter = value;
+            }
+            object->put_own_property(*object, key, Attribute::Configurable | Attribute::Enumerable, Accessor::create(interpreter, getter, setter), Object::PutOwnPropertyMode::DefineProperty);
+        } else {
+            object->put(key, value);
+        }
     }
     return object;
 }

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -722,17 +722,24 @@ private:
 
 class ObjectProperty final : public ASTNode {
 public:
-    ObjectProperty(NonnullRefPtr<Expression> key, NonnullRefPtr<Expression> value)
+    enum class Type {
+        KeyValue,
+        Getter,
+        Setter,
+        Spread,
+    };
+
+    ObjectProperty(NonnullRefPtr<Expression> key, NonnullRefPtr<Expression> value, Type property_type)
         : m_key(move(key))
         , m_value(move(value))
+        , m_property_type(property_type)
     {
     }
 
     const Expression& key() const { return m_key; }
     const Expression& value() const { return m_value; }
 
-    bool is_spread() const { return m_is_spread; }
-    void set_is_spread() { m_is_spread = true; }
+    Type type() const { return m_property_type; }
 
     virtual void dump(int indent) const override;
     virtual Value execute(Interpreter&) const override;
@@ -742,7 +749,7 @@ private:
 
     NonnullRefPtr<Expression> m_key;
     NonnullRefPtr<Expression> m_value;
-    bool m_is_spread { false };
+    Type m_property_type;
 };
 
 class ObjectExpression : public Expression {

--- a/Libraries/LibJS/Tests/object-getter-setter-shorthand.js
+++ b/Libraries/LibJS/Tests/object-getter-setter-shorthand.js
@@ -1,0 +1,50 @@
+load("test-common.js")
+
+try {
+    let o = {
+        get() { return 5; },
+        set() { return 10; },
+    };
+    assert(o.get() === 5);
+    assert(o.set() === 10);
+
+    o = {
+        get x() { return 5; },
+        set x(_) { },
+    };
+    assert(o.x === 5);
+    o.x = 10;
+    assert(o.x === 5);
+
+    o = {
+        get x() {
+            return this._x + 1;
+        },
+        set x(value) {
+            this._x = value + 1;
+        },
+    };
+
+    assert(isNaN(o.x));
+    o.x = 10;
+    assert(o.x === 12);
+    o.x = 20;
+    assert(o.x === 22);
+
+    o = {
+        get x() { return 5; },
+        get x() { return 10; },
+    };
+
+    assert(o.x === 10);
+
+    o = {
+        set x(value) { return 10; },
+    };
+
+    assert((o.x = 20) === 20);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
Adds support for the following syntax:

```js
let foo = {
    get x() {
        // ...
    },
    set x(value) {
        // ...
    }
}
```

The tests file is a bit shorter than I'd like it to be, but that's due to some inconsistencies with getters and setters that aren't related to this PR. I intend to fix up the edge cases and add more tests in a different PR, which will include more tests for these shorthand properties.