### PR TITLE
LibC: Sync file position when dropping read ahead buffer

### DIFF
--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -96,7 +96,7 @@ off_t FileDescription::seek(off_t offset, int whence)
 {
     LOCKER(m_lock);
     if (!m_file->is_seekable())
-        return -EINVAL;
+        return -ESPIPE;
 
     off_t new_offset;
 


### PR DESCRIPTION
When we flush a `FILE`, we behave differently depending on whether we reading from the file or writing to it:

* If we're writing, we actually write out the buffered data.
* If we're reading, we just drop the buffered (read ahead) data.

After flushing, there should be no additional buffered state stdio keeps about a `FILE`, compared to what is true about the underlying file. This includes file position (offset). When flushing writes, this is taken care of automatically, but dropping the buffer is not enough to achieve that when reading. This commit fixes that by seeking back explicitly in that case.

One way the problem manifested itself was upon `fseek(SEEK_CUR)` calls, as the position of the underlying file was oftentimes different to the logical position of the `FILE`. Since `FILE::seek()` already calls `FILE::flush()` prior to actually modifying the position, fixing `FILE::flush()` to sync the positions is enough to fix that issue.