### PR TITLE
LibJS: Fix Array.prototype.{indexOf,lastIndexOf}()

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -357,7 +357,7 @@ Value ArrayPrototype::index_of(Interpreter& interpreter)
         return {};
 
     i32 array_size = static_cast<i32>(array->elements().size());
-    if (interpreter.argument_count() == 0 || array_size == 0)
+    if (array_size == 0)
         return Value(-1);
 
     i32 from_index = 0;
@@ -411,7 +411,7 @@ Value ArrayPrototype::last_index_of(Interpreter& interpreter)
         return {};
 
     i32 array_size = static_cast<i32>(array->elements().size());
-    if (interpreter.argument_count() == 0 || array_size == 0)
+    if (array_size == 0)
         return Value(-1);
 
     i32 from_index = 0;

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -414,22 +414,19 @@ Value ArrayPrototype::last_index_of(Interpreter& interpreter)
     if (array_size == 0)
         return Value(-1);
 
-    i32 from_index = 0;
+    i32 from_index = array_size - 1;
     if (interpreter.argument_count() >= 2) {
         from_index = interpreter.argument(1).to_i32(interpreter);
         if (interpreter.exception())
             return {};
-        if (from_index >= array_size)
-            return Value(-1);
-        auto negative_min_index = ((array_size - 1) * -1);
-        if (from_index < negative_min_index)
-            from_index = 0;
-        else if (from_index < 0)
+        if (from_index >= 0)
+            from_index = min(from_index, array_size - 1);
+        else
             from_index = array_size + from_index;
     }
 
     auto search_element = interpreter.argument(0);
-    for (i32 i = array_size - 1; i >= from_index; --i) {
+    for (i32 i = from_index; i >= 0; --i) {
         auto& element = array->elements().at(i);
         if (strict_eq(interpreter, element, search_element))
             return Value(i);

--- a/Libraries/LibJS/Tests/Array.prototype.indexOf.js
+++ b/Libraries/LibJS/Tests/Array.prototype.indexOf.js
@@ -20,6 +20,8 @@ try {
     assert([].indexOf('serenity') === -1);
     assert([].indexOf('serenity', 10) === -1);
     assert([].indexOf('serenity', -10) === -1);
+    assert([].indexOf() === -1);
+    assert([undefined].indexOf() === 0);
 
     console.log("PASS");
 } catch (e) {

--- a/Libraries/LibJS/Tests/Array.prototype.lastIndexOf.js
+++ b/Libraries/LibJS/Tests/Array.prototype.lastIndexOf.js
@@ -15,6 +15,9 @@ try {
     assert([].lastIndexOf('hello') === -1);
     assert([].lastIndexOf('hello', 10) === -1);
     assert([].lastIndexOf('hello', -10) === -1);
+    assert([].lastIndexOf() === -1);
+    assert([undefined].lastIndexOf() === 0);
+    assert([undefined, undefined, undefined].lastIndexOf() === 2);
 
     console.log("PASS");
 } catch (e) {

--- a/Libraries/LibJS/Tests/Array.prototype.lastIndexOf.js
+++ b/Libraries/LibJS/Tests/Array.prototype.lastIndexOf.js
@@ -6,11 +6,12 @@ try {
     var array = [1, 2, 3, 1, "hello"];
 
     assert(array.lastIndexOf("hello") === 4);
+    assert(array.lastIndexOf("hello", 1000) === 4);
     assert(array.lastIndexOf(1) === 3);
-    assert(array.lastIndexOf(1, -1) === -1);
+    assert(array.lastIndexOf(1, -1) === 3);
     assert(array.lastIndexOf(1, -2) === 3);
     assert(array.lastIndexOf(2) === 1);
-    assert(array.lastIndexOf(2, -3) === -1);
+    assert(array.lastIndexOf(2, -3) === 1);
     assert(array.lastIndexOf(2, -4) === 1);
     assert([].lastIndexOf('hello') === -1);
     assert([].lastIndexOf('hello', 10) === -1);


### PR DESCRIPTION
Both were returning `-1` for `[undefined].indexOf()`, which is incorrect - also `lastIndexOf` was *really* not working according to the spec.

Since our tests passed nonetheless we should learn from that and occasionally run them against a mature engine - there's no real value in adding tests if they test an incorrect implementation :clown_face: