### PR TITLE
LibJS: Add Array.prototype.reduce

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
+ * Copyright (c) 2020, Marcin Gasperowicz <xnooga@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -56,6 +57,7 @@ ArrayPrototype::ArrayPrototype()
     put_native_function("concat", concat, 1, attr);
     put_native_function("slice", slice, 2, attr);
     put_native_function("indexOf", index_of, 1, attr);
+    put_native_function("reduce", reduce, 1, attr);
     put_native_function("reverse", reverse, 0, attr);
     put_native_function("lastIndexOf", last_index_of, 1, attr);
     put_native_function("includes", includes, 1, attr);
@@ -345,6 +347,65 @@ Value ArrayPrototype::index_of(Interpreter& interpreter)
     }
 
     return Value(-1);
+}
+
+Value ArrayPrototype::reduce(Interpreter& interpreter)
+{
+    auto* this_object = interpreter.this_value().to_object(interpreter);
+    if (!this_object)
+        return {};
+
+    auto initial_length = get_length(interpreter, *this_object);
+    if (interpreter.exception())
+        return {};
+
+    size_t start = 0;
+
+    auto accumulator = js_undefined();
+    if (interpreter.argument_count() > 1) {
+        accumulator = interpreter.argument(1);
+    } else {
+        bool start_found = false;
+        while (!start_found && start < initial_length) {
+            auto value = this_object->get_by_index(start);
+            if (interpreter.exception())
+                return {};
+            start_found = !value.is_empty();
+            if (start_found)
+                accumulator = value;
+            start += 1;
+        }
+        if (!start_found) {
+            interpreter.throw_exception<TypeError>("Reduce of empty array with no initial value");
+            return {};
+        }
+    }
+
+    auto* callback_function = callback_from_args(interpreter, "reduce");
+    if (!callback_function)
+        return {};
+
+    auto this_value = js_undefined();
+
+    for (size_t i = start; i < initial_length; ++i) {
+        auto value = this_object->get_by_index(i);
+        if (interpreter.exception())
+            return {};
+        if (value.is_empty())
+            continue;
+
+        MarkedValueList arguments(interpreter.heap());
+        arguments.append(accumulator);
+        arguments.append(value);
+        arguments.append(Value((i32)i));
+        arguments.append(this_object);
+
+        accumulator = interpreter.call(*callback_function, this_value, move(arguments));
+        if (interpreter.exception())
+            return {};
+    }
+
+    return accumulator;
 }
 
 Value ArrayPrototype::reverse(Interpreter& interpreter)

--- a/Libraries/LibJS/Runtime/ArrayPrototype.h
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.h
@@ -51,6 +51,7 @@ private:
     static Value concat(Interpreter&);
     static Value slice(Interpreter&);
     static Value index_of(Interpreter&);
+    static Value reduce(Interpreter&);
     static Value reverse(Interpreter&);
     static Value last_index_of(Interpreter&);
     static Value includes(Interpreter&);

--- a/Libraries/LibJS/Tests/Array.prototype-generic-functions.js
+++ b/Libraries/LibJS/Tests/Array.prototype-generic-functions.js
@@ -41,6 +41,18 @@ try {
         assert(visited[2] === "baz");
     });
 
+    ["reduce"].forEach(name => {
+        const visited = [];
+        Array.prototype[name].call(o, function (_, value) {
+            visited.push(value);
+            return false;
+        }, "initial");
+        assert(visited.length === 3);
+        assert(visited[0] === "foo");
+        assert(visited[1] === "bar");
+        assert(visited[2] === "baz");
+    });
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);

--- a/Libraries/LibJS/Tests/Array.prototype.reduce.js
+++ b/Libraries/LibJS/Tests/Array.prototype.reduce.js
@@ -1,0 +1,105 @@
+load("test-common.js");
+
+try {
+    assert(Array.prototype.reduce.length === 1);
+
+    assertThrowsError(() => {
+        [1].reduce();
+    }, {
+        error: TypeError,
+        message: "Array.prototype.reduce() requires at least one argument"
+    });
+
+    assertThrowsError(() => {
+        [1].reduce(undefined);
+    }, {
+        error: TypeError,
+        message: "undefined is not a function"
+    });
+
+    assertThrowsError(() => {
+        [].reduce((a, x) => x);
+    }, {
+        error: TypeError,
+        message: "Reduce of empty array with no initial value"
+    });
+
+    assertThrowsError(() => {
+        [, ,].reduce((a, x) => x);
+    }, {
+        error: TypeError,
+        message: "Reduce of empty array with no initial value"
+    });
+
+    [1, 2].reduce(() => { assert(this === undefined) });
+
+    var callbackCalled = 0;
+    var callback = () => { callbackCalled++; return true };
+
+    assert([1].reduce(callback) === 1);
+    assert(callbackCalled === 0);
+
+    assert([, 1].reduce(callback) === 1);
+    assert(callbackCalled === 0);
+
+    callbackCalled = 0;
+    assert([1, 2, 3].reduce(callback) === true);
+    assert(callbackCalled === 2);
+
+    callbackCalled = 0;
+    assert([, , 1, 2, 3].reduce(callback) === true);
+    assert(callbackCalled === 2);
+
+    callbackCalled = 0;
+    assert([1, , , 10, , 100, , ,].reduce(callback) === true);
+    assert(callbackCalled === 2);
+
+    var constantlySad = () => ":^(";
+    var result = [].reduce(constantlySad, ":^)");
+    assert(result === ":^)");
+
+    result = [":^0"].reduce(constantlySad, ":^)");
+    assert(result === ":^(");
+
+    result = [":^0"].reduce(constantlySad);
+    assert(result === ":^0");
+
+    result = [5, 4, 3, 2, 1].reduce((accum, elem) => accum + elem);
+    assert(result === 15);
+
+    // likely parser bug: arrow func parser eats ", 100" as a part of the function, hence the parens  
+    result = [1, 2, 3, 4, 5, 6].reduce(((accum, elem) => accum + elem), 100);
+    assert(result === 121);
+
+    result = [6, 5, 4, 3, 2, 1].reduce((accum, elem) => { return accum + elem }, 100);
+    assert(result === 121);
+
+    var indexes = [];
+    result = ["foo", 1, true].reduce((a, v, i) => { indexes.push(i) });
+    assert(result === undefined);
+    assert(indexes.length === 2);
+    assert(indexes[0] === 1);
+    assert(indexes[1] === 2);
+
+    indexes = [];
+    result = ["foo", 1, true].reduce((a, v, i) => { indexes.push(i) }, "foo");
+    assert(result === undefined);
+    assert(indexes.length === 3);
+    assert(indexes[0] === 0);
+    assert(indexes[1] === 1);
+    assert(indexes[2] === 2);
+
+    var mutable = { prop: 0 };
+    result = ["foo", 1, true].reduce((a, v) => { a.prop = v; return a; }, mutable);
+    assert(result === mutable);
+    assert(result.prop === true);
+
+    var a1 = [1, 2];
+    var a2 = null;
+    a1.reduce((a, v, i, t) => { a2 = t });
+    assert(a1 === a2);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
Adds `Array.prototype.reduce` implementation based on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce.

I chose not to use `for_each_item` in `ArrayPrototype::reduce` because `reduce` usually does not iterate over each array item and expects a slightly different callback than `map`, `each` etc. 
