### PR TITLE
LibGUI/Browser: Browser location box improvements

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -113,7 +113,13 @@ Tab::Tab()
         }
 
         m_html_widget->load(location);
+        m_location_box->set_focus(false);
     };
+
+    m_location_box->add_custom_context_menu_action(GUI::Action::create("Paste & Go", [this](auto&) {
+        m_location_box->set_text(GUI::Clipboard::the().data());
+        m_location_box->on_return_pressed();
+    }));
 
     m_bookmark_button = toolbar.add<GUI::Button>();
     m_bookmark_button->set_button_style(Gfx::ButtonStyle::CoolBar);

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -210,16 +210,19 @@ void TextEditor::doubleclick_event(MouseEvent& event)
     auto start = text_position_at(event.position());
     auto end = start;
     auto& line = this->line(start.line());
+    auto clicked_on_alphanumeric = isalnum(line.codepoints()[start.column()]);
 
     if (!document().has_spans()) {
         while (start.column() > 0) {
-            if (isspace(line.codepoints()[start.column() - 1]))
+            auto next_codepoint = line.codepoints()[start.column() - 1];
+            if ((clicked_on_alphanumeric && !isalnum(next_codepoint)) || (!clicked_on_alphanumeric && isalnum(next_codepoint)))
                 break;
             start.set_column(start.column() - 1);
         }
 
         while (end.column() < line.length()) {
-            if (isspace(line.codepoints()[end.column()]))
+            auto next_codepoint = line.codepoints()[end.column()];
+            if ((clicked_on_alphanumeric && !isalnum(next_codepoint)) || (!clicked_on_alphanumeric && isalnum(next_codepoint)))
                 break;
             end.set_column(end.column() + 1);
         }


### PR DESCRIPTION
This patch works on improving the functionality and feel of the Browser's location box.

Firstly, this patch adds a "Paste & Go" action to the location box's context menu, which will take the clipboard data, put it into the location box, and navigate to that page. Note: the clipboard's text overwrites the location box, which seems curious, but that is how Firefox works, and actually seems convenient.

Secondly, this patch makes the location bar lose focus after being activated. It felt odd that the location bar was still taking keyboard input after activating it, so this just makes it feel more natural.

Last but not least, this patch improves the double-click selection on the location box (and `TextEditor`s in general). Previously, double clicking would select the range around your click up until it found a space, and in the browser's location bar this behaviour didn't suffice. Now, it will select the range around your click until there is a "word break". A word break is considered to be when your selection changes from being alphanumeric to being non alphanumeric, or vice versa.