### PR TITLE
LibJS: Add missing exception check to ArrayPrototype's for_each_item()

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -111,6 +111,8 @@ static void for_each_item(Interpreter& interpreter, const String& name, AK::Func
 
     for (size_t i = 0; i < initial_length; ++i) {
         auto value = this_object->get_by_index(i);
+        if (interpreter.exception())
+            return;
         if (value.is_empty()) {
             if (skip_empty)
                 continue;


### PR DESCRIPTION
`Object::get_by_index()` cannot throw for positive indices *right now*, but once we implement descriptors for array index properties, it can.