### PR TITLE
AK/LibWeb/Browser: Fix fragment/anchor handling

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -307,6 +307,12 @@ URL URL::complete_url(const String& string) const
         return url;
     }
 
+    if (string.starts_with("#")) {
+        url = *this;
+        url.set_fragment(string.substring(1, string.length() - 1));
+        return url;
+    }
+
     StringBuilder builder;
     FileSystemPath fspath(path());
     builder.append('/');

--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -146,15 +146,17 @@ Tab::Tab()
     };
 
     m_html_widget->on_link_click = [this](auto& href, auto& target, unsigned modifiers) {
-        if (href.starts_with("#")) {
-            auto anchor = href.substring_view(1, href.length() - 1);
-            m_html_widget->scroll_to_anchor(anchor);
-        } else {
+        if (target == "_blank" || modifiers == Mod_Ctrl) {
             auto url = m_html_widget->document()->complete_url(href);
-            if (target == "_blank" || modifiers == Mod_Ctrl)
-                on_tab_open_request(url);
-            else
+            on_tab_open_request(url);
+        } else {
+            if (href.starts_with("#")) {
+                auto anchor = href.substring_view(1, href.length() - 1);
+                m_html_widget->scroll_to_anchor(anchor);
+            } else {
+                auto url = m_html_widget->document()->complete_url(href);
                 m_html_widget->load(url);
+            }
         }
     };
 

--- a/Libraries/LibWeb/HtmlView.cpp
+++ b/Libraries/LibWeb/HtmlView.cpp
@@ -488,6 +488,10 @@ void HtmlView::load(const URL& url)
             auto document = create_document_from_mime_type(data, url, mime_type, encoding);
             ASSERT(document);
             set_document(document);
+
+            if (!url.fragment().is_empty())
+                scroll_to_anchor(url.fragment());
+
             if (on_title_change)
                 on_title_change(document->title());
         },


### PR DESCRIPTION
This patch focuses on the handling of fragment links in the system.

For starters, it fixes URL completion of fragment strings. Previously, passing a fragment string (`#section3`) to the URL::complete_url method would result in a URL that looked like `file:///home/anon/www/#section3` which was obviously incorrect. Now the result looks like `file:///home/anon/www/afrag.html#section3`.

Next, it fixes HtmlView not automatically scrolling to an anchor when a URL with a fragment is loaded.

Finally, it fixes the handling of fragment links not opening in a new tab. Previously, clicking on an anchor link (`href="#section1"`) would always scroll to it on the current page, even if control was held or the target="_blank" attribute was set. This fixes that behaviour, and the link will instead open in a new tab if required.