### PR TITLE
Build: Make Lagom build under MacOS

### DIFF
--- a/Libraries/LibCore/TCPServer.cpp
+++ b/Libraries/LibCore/TCPServer.cpp
@@ -33,17 +33,21 @@
 #include <sys/socket.h>
 
 #ifndef SOCK_NONBLOCK
-#    include <fcntl.h>
-#    define SOCK_NONBLOCK O_NONBLOCK
-#    define SOCK_CLOEXEC O_CLOEXEC
+#    include <sys/ioctl.h>
 #endif
-
 namespace Core {
 
 TCPServer::TCPServer(Object* parent)
     : Object(parent)
 {
+#ifdef SOCK_NONBLOCK
     m_fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+#else
+    m_fd = socket(AF_INET, SOCK_STREAM, 0);
+    int option = 1;
+    ioctl(m_fd, FIONBIO, &option);
+    fcntl(m_fd, F_SETFD, FD_CLOEXEC);
+#endif
     ASSERT(m_fd >= 0);
 }
 

--- a/Libraries/LibCore/TCPServer.cpp
+++ b/Libraries/LibCore/TCPServer.cpp
@@ -32,6 +32,12 @@
 #include <stdio.h>
 #include <sys/socket.h>
 
+#ifndef SOCK_NONBLOCK
+#    include <fcntl.h>
+#    define SOCK_NONBLOCK O_NONBLOCK
+#    define SOCK_CLOEXEC O_CLOEXEC
+#endif
+
 namespace Core {
 
 TCPServer::TCPServer(Object* parent)

--- a/Libraries/LibCore/TCPSocket.cpp
+++ b/Libraries/LibCore/TCPSocket.cpp
@@ -29,8 +29,7 @@
 #include <sys/socket.h>
 
 #ifndef SOCK_NONBLOCK
-#    include <fcntl.h>
-#    define SOCK_NONBLOCK O_NONBLOCK
+#    include <sys/ioctl.h>
 #endif
 
 namespace Core {
@@ -48,7 +47,13 @@ TCPSocket::TCPSocket(int fd, Object* parent)
 TCPSocket::TCPSocket(Object* parent)
     : Socket(Socket::Type::TCP, parent)
 {
+#ifdef SOCK_NONBLOCK
     int fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+#else
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    int option = 1;
+    ioctl(fd, FIONBIO, &option);
+#endif
     if (fd < 0) {
         set_error(errno);
     } else {

--- a/Libraries/LibCore/TCPSocket.cpp
+++ b/Libraries/LibCore/TCPSocket.cpp
@@ -28,6 +28,11 @@
 #include <errno.h>
 #include <sys/socket.h>
 
+#ifndef SOCK_NONBLOCK
+#    include <fcntl.h>
+#    define SOCK_NONBLOCK O_NONBLOCK
+#endif
+
 namespace Core {
 
 TCPSocket::TCPSocket(int fd, Object* parent)

--- a/Libraries/LibCore/UDPServer.cpp
+++ b/Libraries/LibCore/UDPServer.cpp
@@ -31,6 +31,12 @@
 #include <LibCore/UDPSocket.h>
 #include <stdio.h>
 
+#ifndef SOCK_NONBLOCK
+#    include <fcntl.h>
+#    define SOCK_NONBLOCK O_NONBLOCK
+#    define SOCK_CLOEXEC O_CLOEXEC
+#endif
+
 namespace Core {
 
 UDPServer::UDPServer(Object* parent)

--- a/Libraries/LibCore/UDPServer.cpp
+++ b/Libraries/LibCore/UDPServer.cpp
@@ -32,9 +32,7 @@
 #include <stdio.h>
 
 #ifndef SOCK_NONBLOCK
-#    include <fcntl.h>
-#    define SOCK_NONBLOCK O_NONBLOCK
-#    define SOCK_CLOEXEC O_CLOEXEC
+#    include <sys/ioctl.h>
 #endif
 
 namespace Core {
@@ -42,7 +40,14 @@ namespace Core {
 UDPServer::UDPServer(Object* parent)
     : Object(parent)
 {
+#ifdef SOCK_NONBLOCK
     m_fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+#else
+    m_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    int option = 1;
+    ioctl(m_fd, FIONBIO, &option);
+    fcntl(m_fd, F_SETFD, FD_CLOEXEC);
+#endif
     ASSERT(m_fd >= 0);
 }
 

--- a/Libraries/LibCore/UDPSocket.cpp
+++ b/Libraries/LibCore/UDPSocket.cpp
@@ -28,6 +28,11 @@
 #include <errno.h>
 #include <sys/socket.h>
 
+#ifndef SOCK_NONBLOCK
+#    include <fcntl.h>
+#    define SOCK_NONBLOCK O_NONBLOCK
+#endif
+
 namespace Core {
 
 UDPSocket::UDPSocket(int fd, Object* parent)

--- a/Libraries/LibCore/UDPSocket.cpp
+++ b/Libraries/LibCore/UDPSocket.cpp
@@ -29,8 +29,7 @@
 #include <sys/socket.h>
 
 #ifndef SOCK_NONBLOCK
-#    include <fcntl.h>
-#    define SOCK_NONBLOCK O_NONBLOCK
+#    include <sys/ioctl.h>
 #endif
 
 namespace Core {
@@ -48,7 +47,14 @@ UDPSocket::UDPSocket(int fd, Object* parent)
 UDPSocket::UDPSocket(Object* parent)
     : Socket(Socket::Type::UDP, parent)
 {
+#ifdef SOCK_NONBLOCK
     int fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+#else
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    int option = 1;
+    ioctl(fd, FIONBIO, &option);
+#endif
+
     if (fd < 0) {
         set_error(errno);
     } else {

--- a/Libraries/LibJS/Heap/Heap.cpp
+++ b/Libraries/LibJS/Heap/Heap.cpp
@@ -37,7 +37,7 @@
 
 #ifdef __serenity__
 #    include <serenity.h>
-#elif __linux__
+#elif __linux__ or __MACH__
 #    include <pthread.h>
 #endif
 
@@ -154,6 +154,14 @@ void Heap::gather_conservative_roots(HashTable<Cell*>& roots)
     }
     if (int rc = pthread_attr_getstack(&attr, (void**)&stack_base, &stack_size) != 0) {
         fprintf(stderr, "pthread_attr_getstack: %s\n", strerror(-rc));
+        ASSERT_NOT_REACHED();
+    }
+    pthread_attr_destroy(&attr);
+#elif __MACH__
+    stack_base = (FlatPtr)pthread_get_stackaddr_np(pthread_self());
+    pthread_attr_t attr = {};
+    if (int rc = pthread_attr_getstacksize(&attr, &stack_size) != 0) {
+        fprintf(stderr, "pthread_attr_getstacksize: %s\n", strerror(-rc));
         ASSERT_NOT_REACHED();
     }
     pthread_attr_destroy(&attr);


### PR DESCRIPTION
Lagom now builds under MacOS. 

Only two minor adjustments were required:
* LibCore TCP/UDP code requires `SOCK_{NONBLOCK, CLOEXEC}` - ~defined them in terms of `O_{NONBLOCK, CLOEXEC}`  from `fcntl.h`~ set them using `ioctl(...FIONBIO...)` and `fnctl(...FD_CLOEXEC)`
* 
* LibJS `Heap` code pthread usage ported to MacOS

Antalet ändringar var Lagom :^)