### PR TITLE
LibGUI: Use word breaks to intelligently navigate a TextEditor

### DIFF
--- a/Libraries/LibGUI/TextDocument.h
+++ b/Libraries/LibGUI/TextDocument.h
@@ -120,6 +120,9 @@ public:
     Optional<TextDocumentSpan> first_non_skippable_span_before(const TextPosition&) const;
     Optional<TextDocumentSpan> first_non_skippable_span_after(const TextPosition&) const;
 
+    TextPosition first_word_break_before(const TextPosition&) const;
+    TextPosition first_word_break_after(const TextPosition&) const;
+
     void add_to_undo_stack(NonnullOwnPtr<TextDocumentUndoCommand>);
 
     bool can_undo() const { return m_undo_stack.can_undo(); }


### PR DESCRIPTION
More text editor improvements!

Previously, holding Control while using the left/right arrow keys
to navigate through a TextEditor would only be helpful if the document
had spans. Now, if there are no spans, it will navigate to the
next "word break", defined to be the threshold where text changes
from alphanumeric to non-alphanumeric, or vice versa.

This also refactors out the word break calculation from the TextEditor's selection code, and makes it usable everywhere else, so maybe we'll find more places it will be helpful!