### PR TITLE
LibWeb: HtmlTokenizer.cpp: fix ON_WHITESPACE macro

### DIFF
--- a/Libraries/LibWeb/Parser/HTMLTokenizer.cpp
+++ b/Libraries/LibWeb/Parser/HTMLTokenizer.cpp
@@ -69,7 +69,7 @@
     if (current_input_character.has_value() && current_input_character.value() >= 'A' && current_input_character.value() <= 'Z')
 
 #define ON_WHITESPACE \
-    if (current_input_character.has_value() && (current_input_character.value() == '\t' || current_input_character.value() == '\a' || current_input_character.value() == '\f' || current_input_character.value() == ' '))
+    if (current_input_character.has_value() && (current_input_character.value() == '\t' || current_input_character.value() == '\n' || current_input_character.value() == '\f' || current_input_character.value() == ' '))
 
 #define ANYTHING_ELSE if (1)
 


### PR DESCRIPTION
We were treating the "audible bell" character ('\a' U+0007) as whitespace instead of treating the "line feed" character ('\n' U+0000a) as whitespace.