### PR TITLE
LibWeb: Copy paste error in HTMLDockumentParser

### DIFF
--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -214,7 +214,7 @@ void HTMLDocumentParser::handle_after_head(HTMLToken& token)
 
     {
         Vector<String> names = { "base", "basefont", "bgsound", "link", "meta", "noframes", "script", "style", "template", "title" };
-        if (token.is_end_tag() && names.contains_slow(token.tag_name())) {
+        if (token.is_start_tag() && names.contains_slow(token.tag_name())) {
             ASSERT_NOT_REACHED();
         }
     }


### PR DESCRIPTION
When watching the video of the new html parser I noticed a small copy and paste error. In one of the cases in `handle_after_head` the code was checking for end tags when it should check for start tags.

I haven't tested this change just looking at the spec: https://html.spec.whatwg.org/multipage/parsing.html#the-after-head-insertion-mode