### PR TITLE
Shell: Add the `disown' shell builtin; Parse and correctly execute "command &" and "command &&" 

### DIFF
--- a/Shell/Job.h
+++ b/Shell/Job.h
@@ -42,8 +42,10 @@ public:
 
     ~Job()
     {
-        auto elapsed = m_command_timer.elapsed();
-        dbg() << "Command \"" << m_cmd << "\" finished in " << elapsed << " ms";
+        if (m_active) {
+            auto elapsed = m_command_timer.elapsed();
+            dbg() << "Command \"" << m_cmd << "\" finished in " << elapsed << " ms";
+        }
     }
 
     Job(pid_t pid, unsigned pgid, String cmd, u64 job_id)
@@ -79,6 +81,8 @@ public:
         m_running_in_background = running_in_background;
     }
 
+    void deactivate() const { m_active = false; }
+
 private:
     unsigned m_pgid { 0 };
     pid_t m_pid { 0 };
@@ -88,4 +92,5 @@ private:
     bool m_running_in_background { false };
     int m_exit_code { -1 };
     Core::ElapsedTimer m_command_timer;
+    mutable bool m_active { true };
 };

--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -45,6 +45,12 @@ struct Token {
     Type type;
 };
 
+enum Attributes {
+    None = 0x0,
+    ShortCircuitOnFailure = 0x1,
+    InBackground = 0x2,
+};
+
 struct Redirection {
     enum Type {
         Pipe,
@@ -71,6 +77,7 @@ struct Subcommand {
 
 struct Command {
     Vector<Subcommand> subcommands;
+    Attributes attributes;
 };
 
 class Parser {
@@ -89,7 +96,7 @@ private:
     };
     void commit_token(Token::Type, AllowEmptyToken = AllowEmptyToken::No);
     void commit_subcommand();
-    void commit_command();
+    void commit_command(Attributes = None);
     void do_pipe();
     void begin_redirect_read(int fd);
     void begin_redirect_write(int fd);

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -337,6 +337,13 @@ int Shell::builtin_dirs(int argc, const char** argv)
 
 int Shell::builtin_exit(int, const char**)
 {
+    if (!jobs.is_empty()) {
+        if (!m_should_ignore_jobs_on_next_exit) {
+            printf("Shell: Hey dude, you have %zu active job%s, run 'exit' again to really exit.\n", jobs.size(), jobs.size() > 1 ? "s" : "");
+            m_should_ignore_jobs_on_next_exit = true;
+            return 1;
+        }
+    }
     stop_all_jobs();
     printf("Good-bye!\n");
     exit(0);
@@ -1355,6 +1362,10 @@ ExitCodeOrContinuationRequest Shell::run_command(const StringView& cmd)
     //        Is the terminal controlling pgrp really still the PGID of the dead process?
     tcsetpgrp(0, getpid());
     tcsetattr(0, TCSANOW, &trm);
+
+    // Clear the exit flag after any non-exit command has been executed.
+    m_should_ignore_jobs_on_next_exit = false;
+
     return return_value;
 }
 

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -186,6 +186,7 @@ private:
     ExitCodeOrContinuationRequest::ContinuationRequest m_should_continue { ExitCodeOrContinuationRequest::Nothing };
     StringBuilder m_complete_line_builder;
     bool m_should_break_current_command { false };
+    bool m_should_ignore_jobs_on_next_exit { false };
 };
 
 static constexpr bool is_word_character(char c)

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -84,6 +84,7 @@ using ContinuationRequest = ExitCodeOrContinuationRequest::ContinuationRequest;
     __ENUMERATE_SHELL_BUILTIN(popd)    \
     __ENUMERATE_SHELL_BUILTIN(time)    \
     __ENUMERATE_SHELL_BUILTIN(jobs)    \
+    __ENUMERATE_SHELL_BUILTIN(disown)  \
     __ENUMERATE_SHELL_BUILTIN(fg)      \
     __ENUMERATE_SHELL_BUILTIN(bg)
 

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -162,6 +162,7 @@ private:
     };
 
     void cache_path();
+    void stop_all_jobs();
 
     IterationDecision wait_for_pid(const SpawnedProcess&, bool is_first_command_in_chain, int& return_value);
 


### PR DESCRIPTION
Adding one more job control primitive to the mix, and fixing a little oversight in the shell.
Also adds some nice `&` and `&&` handling; `te& disown` ftw!