### PR TITLE
LibGUI: Add flag to TextDocument's word break locator methods

### DIFF
--- a/Libraries/LibGUI/TextDocument.cpp
+++ b/Libraries/LibGUI/TextDocument.cpp
@@ -427,7 +427,7 @@ Optional<TextDocumentSpan> TextDocument::first_non_skippable_span_after(const Te
     return {};
 }
 
-TextPosition TextDocument::first_word_break_before(const TextPosition& position) const
+TextPosition TextDocument::first_word_break_before(const TextPosition& position, bool start_at_column_before) const
 {
     if (position.column() == 0) {
         if (position.line() == 0) {
@@ -439,7 +439,7 @@ TextPosition TextDocument::first_word_break_before(const TextPosition& position)
 
     auto target = position;
     auto line = this->line(target.line());
-    auto is_start_alphanumeric = isalnum(line.codepoints()[target.column() - 1]);
+    auto is_start_alphanumeric = isalnum(line.codepoints()[target.column() - (start_at_column_before ? 1 : 0)]);
 
     while (target.column() > 0) {
         auto next_codepoint = line.codepoints()[target.column() - 1];

--- a/Libraries/LibGUI/TextDocument.h
+++ b/Libraries/LibGUI/TextDocument.h
@@ -120,7 +120,7 @@ public:
     Optional<TextDocumentSpan> first_non_skippable_span_before(const TextPosition&) const;
     Optional<TextDocumentSpan> first_non_skippable_span_after(const TextPosition&) const;
 
-    TextPosition first_word_break_before(const TextPosition&) const;
+    TextPosition first_word_break_before(const TextPosition&, bool start_at_column_before) const;
     TextPosition first_word_break_after(const TextPosition&) const;
 
     void add_to_undo_stack(NonnullOwnPtr<TextDocumentUndoCommand>);

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -211,7 +211,7 @@ void TextEditor::doubleclick_event(MouseEvent& event)
     auto end = start;
 
     if (!document().has_spans()) {
-        start = document().first_word_break_before(start);
+        start = document().first_word_break_before(start, false);
         end = document().first_word_break_after(end);
     } else {
         for (auto& span : document().spans()) {
@@ -720,10 +720,10 @@ void TextEditor::keydown_event(KeyEvent& event)
                     new_cursor = span.value().range.start();
                 } else {
                     // No remaining spans, just use word break calculation
-                    new_cursor = document().first_word_break_before(m_cursor);
+                    new_cursor = document().first_word_break_before(m_cursor, true);
                 }
             } else {
-                new_cursor = document().first_word_break_before(m_cursor);
+                new_cursor = document().first_word_break_before(m_cursor, true);
             }
             toggle_selection_if_needed_for_event(event);
             set_cursor(new_cursor);


### PR DESCRIPTION
This is a small patch to improve on the work of #2354.

TextDocument::first_word_break_before turns out to need slightly different behaviour depending on where its called, so it now has a start_at_column_before flag to decide which letter it "thinks" was clicked.