### PR TITLE
LibLine: Change get_line to return a Result<String, Error>

### DIFF
--- a/Applications/Debugger/main.cpp
+++ b/Applications/Debugger/main.cpp
@@ -236,7 +236,13 @@ int main(int argc, char** argv)
         }
 
         for (;;) {
-            auto command = editor.get_line("(sdb) ");
+            auto command_result = editor.get_line("(sdb) ");
+
+            if (command_result.is_error())
+                return DebugSession::DebugDecision::Detach;
+
+            auto& command = command_result.value();
+
             bool success = false;
             Optional<DebugSession::DebugDecision> decision;
 

--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -57,6 +57,12 @@
 static void run_command(int ptm_fd, String command)
 {
     pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        dbg() << "run_command: could not fork to run '" << command << "'";
+        return;
+    }
+
     if (pid == 0) {
         const char* tty_name = ptsname(ptm_fd);
         if (!tty_name) {

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -33,6 +33,7 @@
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/QuickSort.h>
+#include <AK/Result.h>
 #include <AK/String.h>
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
@@ -78,10 +79,16 @@ struct Configuration {
 
 class Editor {
 public:
+    enum class Error {
+        ReadFailure,
+        Empty,
+        Eof,
+    };
+
     explicit Editor(Configuration configuration = {});
     ~Editor();
 
-    String get_line(const String& prompt);
+    Result<String, Error> get_line(const String& prompt);
 
     void initialize()
     {
@@ -209,6 +216,7 @@ private:
         set_origin(0, 0);
         m_prompt_lines_at_suggestion_initiation = 0;
         m_refresh_needed = true;
+        m_input_error.clear();
     }
 
     void refresh_display();
@@ -276,8 +284,10 @@ private:
     Vector<u32, 1024> m_pre_search_buffer;
 
     Vector<u32, 1024> m_buffer;
-    Vector<char, 512> m_incomplete_data;
     ByteBuffer m_pending_chars;
+    Vector<char, 512> m_incomplete_data;
+    Optional<Error> m_input_error;
+
     size_t m_cursor { 0 };
     size_t m_drawn_cursor { 0 };
     size_t m_inline_search_cursor { 0 };

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -123,7 +123,7 @@ public:
     bool should_read_more() const { return m_should_continue != ContinuationRequest::Nothing; }
     void finish_command() { m_should_break_current_command = true; }
 
-    void read_single_line();
+    bool read_single_line();
 
     struct termios termios;
     struct termios default_termios;

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -104,6 +104,9 @@ int main(int argc, char** argv)
         }
     });
 
+    // Ignore SIGTSTP as the shell should not be suspended with ^Z.
+    signal(SIGTSTP, [](auto) {});
+
     if (argc > 2 && !strcmp(argv[1], "-c")) {
         dbgprintf("sh -c '%s'\n", argv[2]);
         shell->run_command(argv[2]);

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -113,7 +113,12 @@ int run(Function<void(const char*, size_t)> fn)
         Line::Editor editor;
         editor.initialize();
         for (;;) {
-            auto line = editor.get_line("> ");
+            auto line_result = editor.get_line("> ");
+
+            if (line_result.is_error())
+                break;
+            auto& line = line_result.value();
+
             if (line == ".wait") {
                 loop.exec();
             } else {


### PR DESCRIPTION
This fixes a bunch of FIXME's in LibLine.
Also handles the case where read() would read zero bytes in vt_dsr() and effectively block forever by erroring out.

Also disallows `^Z` in shell, because that was annoying.

Fixes #2370

Morale of this story: I do not Unix enough.