### PR TITLE
Kernel: Plumb KResult through FileDescription::read_entire_file() implementation

### DIFF
--- a/Kernel/FileSystem/DevPtsFS.cpp
+++ b/Kernel/FileSystem/DevPtsFS.cpp
@@ -146,10 +146,10 @@ InodeMetadata DevPtsFSInode::metadata() const
     return m_metadata;
 }
 
-bool DevPtsFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntry&)> callback) const
+KResult DevPtsFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntry&)> callback) const
 {
     if (identifier().index() > 1)
-        return false;
+        return KResult(-ENOTDIR);
 
     callback({ ".", 1, identifier(), 0 });
     callback({ "..", 2, identifier(), 0 });
@@ -160,7 +160,7 @@ bool DevPtsFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntry
         callback({ name.characters(), name.length(), identifier, 0 });
     }
 
-    return true;
+    return KSuccess;
 }
 
 size_t DevPtsFSInode::directory_entry_count() const

--- a/Kernel/FileSystem/DevPtsFS.h
+++ b/Kernel/FileSystem/DevPtsFS.h
@@ -69,7 +69,7 @@ private:
     // ^Inode
     virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
-    virtual bool traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const override;
+    virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
     virtual ssize_t write_bytes(off_t, ssize_t, const u8* buffer, FileDescription*) override;

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -59,7 +59,7 @@ private:
     // ^Inode
     virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
-    virtual bool traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const override;
+    virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
     virtual ssize_t write_bytes(off_t, ssize_t, const u8* data, FileDescription*) override;

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -158,7 +158,7 @@ bool FileDescription::can_read() const
     return m_file->can_read(*this, offset());
 }
 
-ByteBuffer FileDescription::read_entire_file()
+KResultOr<ByteBuffer> FileDescription::read_entire_file()
 {
     // HACK ALERT: (This entire function)
     ASSERT(m_file->is_inode());

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -79,7 +79,7 @@ public:
 
     ssize_t get_dir_entries(u8* buffer, ssize_t);
 
-    ByteBuffer read_entire_file();
+    KResultOr<ByteBuffer> read_entire_file();
 
     String absolute_path() const;
 

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -83,7 +83,7 @@ public:
 
     virtual RefPtr<Inode> get_inode(InodeIdentifier) const = 0;
 
-    virtual void flush_writes() {}
+    virtual void flush_writes() { }
 
     size_t block_size() const { return m_block_size; }
 

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -61,7 +61,7 @@ void Inode::sync()
     }
 }
 
-ByteBuffer Inode::read_entire(FileDescription* descriptor) const
+KResultOr<ByteBuffer> Inode::read_entire(FileDescription* descriptor) const
 {
     size_t initial_size = metadata().size ? metadata().size : 4096;
     StringBuilder builder(initial_size);
@@ -92,8 +92,11 @@ KResultOr<NonnullRefPtr<Custody>> Inode::resolve_as_link(Custody& base, RefPtr<C
     // The default implementation simply treats the stored
     // contents as a path and resolves that. That is, it
     // behaves exactly how you would expect a symlink to work.
-    auto contents = read_entire();
+    auto contents_or = read_entire();
+    if (contents_or.is_error())
+        return contents_or.error();
 
+    auto& contents = contents_or.value();
     if (!contents) {
         if (out_parent)
             *out_parent = nullptr;

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -50,7 +50,7 @@ class Inode : public RefCounted<Inode>
 public:
     virtual ~Inode();
 
-    virtual void one_ref_left() {}
+    virtual void one_ref_left() { }
 
     FS& fs() { return m_fs; }
     const FS& fs() const { return m_fs; }

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -66,10 +66,10 @@ public:
     InodeIdentifier identifier() const { return { fsid(), index() }; }
     virtual InodeMetadata metadata() const = 0;
 
-    ByteBuffer read_entire(FileDescription* = nullptr) const;
+    KResultOr<ByteBuffer> read_entire(FileDescription* = nullptr) const;
 
     virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const = 0;
-    virtual bool traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const = 0;
+    virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const = 0;
     virtual RefPtr<Inode> lookup(StringView name) = 0;
     virtual ssize_t write_bytes(off_t, ssize_t, const u8* data, FileDescription*) = 0;
     virtual KResult add_child(InodeIdentifier child_id, const StringView& name, mode_t) = 0;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -30,6 +30,7 @@
 #include <AK/JsonValue.h>
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/CommandLine.h>
+#include <Kernel/Console.h>
 #include <Kernel/Devices/BlockDevice.h>
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/FileBackedFileSystem.h>
@@ -51,11 +52,10 @@
 #include <Kernel/Process.h>
 #include <Kernel/Profiling.h>
 #include <Kernel/Scheduler.h>
+#include <Kernel/StdLib.h>
 #include <Kernel/TTY/TTY.h>
 #include <Kernel/VM/MemoryManager.h>
 #include <Kernel/VM/PurgeableVMObject.h>
-#include <Kernel/Console.h>
-#include <Kernel/StdLib.h>
 #include <LibC/errno_numbers.h>
 
 namespace Kernel {

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -101,7 +101,7 @@ private:
     // ^Inode
     virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
-    virtual bool traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const override;
+    virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
     virtual ssize_t write_bytes(off_t, ssize_t, const u8* buffer, FileDescription*) override;
@@ -127,7 +127,7 @@ private:
     // ^Inode
     virtual ssize_t read_bytes(off_t, ssize_t, u8*, FileDescription*) const override { ASSERT_NOT_REACHED(); }
     virtual InodeMetadata metadata() const override;
-    virtual bool traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const override { ASSERT_NOT_REACHED(); }
+    virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const override { ASSERT_NOT_REACHED(); }
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override {};
     virtual ssize_t write_bytes(off_t, ssize_t, const u8*, FileDescription*) override { ASSERT_NOT_REACHED(); }

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -62,7 +62,7 @@ private:
     ProcFS();
 
     struct ProcFSDirectoryEntry {
-        ProcFSDirectoryEntry() {}
+        ProcFSDirectoryEntry() { }
         ProcFSDirectoryEntry(const char* a_name, unsigned a_proc_file_type, bool a_supervisor_only, Function<Optional<KBuffer>(InodeIdentifier)>&& a_read_callback = nullptr, Function<ssize_t(InodeIdentifier, const ByteBuffer&)>&& a_write_callback = nullptr, RefPtr<ProcFSInode>&& a_inode = nullptr)
             : name(a_name)
             , proc_file_type(a_proc_file_type)

--- a/Kernel/FileSystem/TmpFS.cpp
+++ b/Kernel/FileSystem/TmpFS.cpp
@@ -166,19 +166,19 @@ InodeMetadata TmpFSInode::metadata() const
     return m_metadata;
 }
 
-bool TmpFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntry&)> callback) const
+KResult TmpFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntry&)> callback) const
 {
     LOCKER(m_lock, Lock::Mode::Shared);
 
     if (!is_directory())
-        return false;
+        return KResult(-ENOTDIR);
 
     callback({ ".", identifier(), 0 });
     callback({ "..", m_parent, 0 });
 
     for (auto& it : m_children)
         callback(it.value.entry);
-    return true;
+    return KSuccess;
 }
 
 ssize_t TmpFSInode::read_bytes(off_t offset, ssize_t size, u8* buffer, FileDescription*) const

--- a/Kernel/FileSystem/TmpFS.h
+++ b/Kernel/FileSystem/TmpFS.h
@@ -79,7 +79,7 @@ public:
     // ^Inode
     virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
-    virtual bool traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const override;
+    virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
     virtual ssize_t write_bytes(off_t, ssize_t, const u8* buffer, FileDescription*) override;

--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -194,8 +194,8 @@ void load_kernel_symbol_table()
     ASSERT(!result.is_error());
     auto description = result.value();
     auto buffer = description->read_entire_file();
-    ASSERT(buffer);
-    load_kernel_sybols_from_data(buffer);
+    ASSERT(!buffer.is_error());
+    load_kernel_sybols_from_data(buffer.value());
 }
 
 }


### PR DESCRIPTION
Allow file system implementation to return meaningful error codes to
callers of the FileDescription::read_entire_file(). This allows both
Process::sys$readlink() and Process::sys$module_load() to return more
detailed errors to the user.