### PR TITLE
AK: Add case insensitive String::ends_with support

### DIFF
--- a/AK/FileSystemPath.cpp
+++ b/AK/FileSystemPath.cpp
@@ -105,11 +105,9 @@ void FileSystemPath::canonicalize()
     m_string = builder.to_string();
 }
 
-bool FileSystemPath::has_extension(StringView extension) const
+bool FileSystemPath::has_extension(const StringView& extension) const
 {
-    // FIXME: This is inefficient, expand StringView with enough functionality that we don't need to copy strings here.
-    String extension_string = extension;
-    return m_string.to_lowercase().ends_with(extension_string.to_lowercase());
+    return m_string.ends_with(extension, CaseSensitivity::CaseInsensitive);
 }
 
 String canonicalized_path(const StringView& path)

--- a/AK/FileSystemPath.h
+++ b/AK/FileSystemPath.h
@@ -47,7 +47,7 @@ public:
 
     const Vector<String>& parts() const { return m_parts; }
 
-    bool has_extension(StringView) const;
+    bool has_extension(const StringView&) const;
 
 private:
     void canonicalize();

--- a/AK/FlyString.cpp
+++ b/AK/FlyString.cpp
@@ -98,6 +98,11 @@ bool FlyString::equals_ignoring_case(const StringView& other) const
     return StringUtils::equals_ignoring_case(view(), other);
 }
 
+bool FlyString::ends_with(const StringView& str, CaseSensitivity case_sensitivity) const
+{
+    return StringUtils::ends_with(view(), str, case_sensitivity);
+}
+
 FlyString FlyString::to_lowercase() const
 {
     return String(*m_impl).to_lowercase();

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -85,6 +85,7 @@ public:
     int to_int(bool& ok) const;
 
     bool equals_ignoring_case(const StringView&) const;
+    bool ends_with(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
 
     static void did_destroy_impl(Badge<StringImpl>, StringImpl&);
 

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -280,13 +280,7 @@ bool String::starts_with(char ch) const
 
 bool String::ends_with(const StringView& str) const
 {
-    if (str.is_empty())
-        return true;
-    if (is_empty())
-        return false;
-    if (str.length() > length())
-        return false;
-    return !memcmp(characters() + (length() - str.length()), str.characters_without_null_termination(), str.length());
+    return StringUtils::ends_with(*this, str);
 }
 
 bool String::ends_with(char ch) const

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -278,9 +278,9 @@ bool String::starts_with(char ch) const
     return characters()[0] == ch;
 }
 
-bool String::ends_with(const StringView& str) const
+bool String::ends_with(const StringView& str, CaseSensitivity case_sensitivity) const
 {
-    return StringUtils::ends_with(*this, str);
+    return StringUtils::ends_with(*this, str, case_sensitivity);
 }
 
 bool String::ends_with(char ch) const

--- a/AK/String.h
+++ b/AK/String.h
@@ -146,7 +146,7 @@ public:
     ConstIterator end() const { return begin() + length(); }
 
     bool starts_with(const StringView&) const;
-    bool ends_with(const StringView&) const;
+    bool ends_with(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
     bool starts_with(char) const;
     bool ends_with(char) const;
 

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -25,6 +25,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Memory.h>
 #include <AK/String.h>
 #include <AK/StringUtils.h>
 #include <AK/StringView.h>
@@ -193,6 +194,17 @@ bool equals_ignoring_case(const StringView& a, const StringView& b)
             return false;
     }
     return true;
+}
+
+bool ends_with(const StringView& str, const StringView& end)
+{
+    if (end.is_empty())
+        return true;
+    if (str.is_empty())
+        return false;
+    if (end.length() > str.length())
+        return false;
+    return !memcmp(str.characters_without_null_termination() + (str.length() - end.length()), end.characters_without_null_termination(), end.length());
 }
 
 }

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -196,7 +196,7 @@ bool equals_ignoring_case(const StringView& a, const StringView& b)
     return true;
 }
 
-bool ends_with(const StringView& str, const StringView& end)
+bool ends_with(const StringView& str, const StringView& end, CaseSensitivity case_sensitivity)
 {
     if (end.is_empty())
         return true;
@@ -204,7 +204,19 @@ bool ends_with(const StringView& str, const StringView& end)
         return false;
     if (end.length() > str.length())
         return false;
-    return !memcmp(str.characters_without_null_termination() + (str.length() - end.length()), end.characters_without_null_termination(), end.length());
+
+    if (case_sensitivity == CaseSensitivity::CaseSensitive)
+        return !memcmp(str.characters_without_null_termination() + (str.length() - end.length()), end.characters_without_null_termination(), end.length());
+
+    auto str_chars = str.characters_without_null_termination();
+    auto end_chars = end.characters_without_null_termination();
+
+    size_t si = str.length() - end.length();
+    for (size_t ei = 0; ei < end.length(); ++si, ++ei) {
+        if (to_lowercase(str_chars[si]) != to_lowercase(end_chars[ei]))
+            return false;
+    }
+    return true;
 }
 
 }

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -43,8 +43,7 @@ int convert_to_int(const StringView&, bool& ok);
 unsigned convert_to_uint(const StringView&, bool& ok);
 unsigned convert_to_uint_from_hex(const StringView&, bool& ok);
 bool equals_ignoring_case(const StringView&, const StringView&);
-bool ends_with(const StringView& str, const StringView& end);
-
+bool ends_with(const StringView& a, const StringView& b, CaseSensitivity);
 }
 
 }

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -43,6 +43,8 @@ int convert_to_int(const StringView&, bool& ok);
 unsigned convert_to_uint(const StringView&, bool& ok);
 unsigned convert_to_uint_from_hex(const StringView&, bool& ok);
 bool equals_ignoring_case(const StringView&, const StringView&);
+bool ends_with(const StringView& str, const StringView& end);
+
 }
 
 }

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -141,15 +141,9 @@ bool StringView::ends_with(char ch) const
     return ch == characters_without_null_termination()[length() - 1];
 }
 
-bool StringView::ends_with(const StringView& str) const
+bool StringView::ends_with(const StringView& str, CaseSensitivity case_sensitivity) const
 {
-    if (str.is_empty())
-        return true;
-    if (is_empty())
-        return false;
-    if (str.length() > length())
-        return false;
-    return !memcmp(characters_without_null_termination() + length() - str.length(), str.characters_without_null_termination(), str.length());
+    return StringUtils::ends_with(*this, str, case_sensitivity);
 }
 
 bool StringView::matches(const StringView& mask, CaseSensitivity case_sensitivity) const

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -73,7 +73,7 @@ public:
     unsigned hash() const;
 
     bool starts_with(const StringView&) const;
-    bool ends_with(const StringView&) const;
+    bool ends_with(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
     bool starts_with(char) const;
     bool ends_with(char) const;
     bool matches(const StringView& mask, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;

--- a/AK/Tests/TestFileSystemPath.cpp
+++ b/AK/Tests/TestFileSystemPath.cpp
@@ -85,4 +85,36 @@ TEST_CASE(relative_paths)
     }
 }
 
+TEST_CASE(has_extension)
+{
+    {
+        FileSystemPath path("/tmp/simple.png");
+        EXPECT(path.has_extension(".png"));
+        EXPECT(path.has_extension(".pnG"));
+        EXPECT(path.has_extension(".PNG"));
+    }
+
+    {
+        FileSystemPath path("/TMP/SIMPLE.PNG");
+        EXPECT(path.has_extension(".png"));
+        EXPECT(path.has_extension(".pnG"));
+        EXPECT(path.has_extension(".PNG"));
+    }
+
+    {
+        FileSystemPath path(".png");
+        EXPECT(path.has_extension(".png"));
+    }
+
+    {
+        FileSystemPath path;
+        EXPECT_EQ(path.has_extension(".png"), false);
+    }
+
+    {
+        FileSystemPath path("png");
+        EXPECT_EQ(path.has_extension(".png"), false);
+    }
+}
+
 TEST_MAIN(FileSystemPath)

--- a/AK/Tests/TestString.cpp
+++ b/AK/Tests/TestString.cpp
@@ -97,6 +97,8 @@ TEST_CASE(ends_with)
     EXPECT(!test_string.ends_with('E'));
     EXPECT(test_string.ends_with("ABCDEF"));
     EXPECT(!test_string.ends_with("ABC"));
+    EXPECT(test_string.ends_with("def",  CaseSensitivity::CaseInsensitive));
+    EXPECT(!test_string.ends_with("def",  CaseSensitivity::CaseSensitive));
 }
 
 TEST_CASE(copy_string)

--- a/AK/Tests/TestStringUtils.cpp
+++ b/AK/Tests/TestStringUtils.cpp
@@ -144,4 +144,15 @@ TEST_CASE(convert_to_uint)
     EXPECT(ok && actual == 12345u);
 }
 
+TEST_CASE(ends_with)
+{
+    String test_string = "ABCDEF";
+    EXPECT(AK::StringUtils::ends_with(test_string, "DEF", CaseSensitivity::CaseSensitive));
+    EXPECT(AK::StringUtils::ends_with(test_string, "ABCDEF",  CaseSensitivity::CaseSensitive));
+    EXPECT(!AK::StringUtils::ends_with(test_string, "ABCDE", CaseSensitivity::CaseSensitive));
+    EXPECT(!AK::StringUtils::ends_with(test_string, "ABCDEFG", CaseSensitivity::CaseSensitive));
+    EXPECT(AK::StringUtils::ends_with(test_string, "def",  CaseSensitivity::CaseInsensitive));
+    EXPECT(!AK::StringUtils::ends_with(test_string, "def",  CaseSensitivity::CaseSensitive));
+}
+
 TEST_MAIN(StringUtils)

--- a/AK/Tests/TestStringView.cpp
+++ b/AK/Tests/TestStringView.cpp
@@ -80,6 +80,8 @@ TEST_CASE(ends_with)
     EXPECT(test_string_view.ends_with("ABCDEF"));
     EXPECT(!test_string_view.ends_with("ABCDE"));
     EXPECT(!test_string_view.ends_with("ABCDEFG"));
+    EXPECT(test_string_view.ends_with("def",  CaseSensitivity::CaseInsensitive));
+    EXPECT(!test_string_view.ends_with("def",  CaseSensitivity::CaseSensitive));
 }
 
 TEST_CASE(lines)


### PR DESCRIPTION
FileSystemPath::has_extension was jumping through hoops and allocating
memory to do a case insensitive comparison needlessly. Extend the
existing String::ends_with method to allow the caller to specify the
case sensitivity required.