### PR TITLE
Kernel: fix assertion on readlink() syscall

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -1944,7 +1944,7 @@ int Process::sys$readlink(const Syscall::SC_readlink_params* user_params)
         return -EINVAL;
 
     auto contents = description->read_entire_file();
-    if (!contents.is_error())
+    if (contents.is_error())
         return contents.error();
 
     auto link_target = String::copy(contents.value());


### PR DESCRIPTION
The is_error() check on the KResultOr returned when reading the link
target had a stray ! operator which causes link resolution to crash the
kernel with an assertion error.