### PR TITLE
Almost reliable abort(), sigaction hardening, and LexicalPath

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -24,21 +24,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 
 namespace AK {
 
-FileSystemPath::FileSystemPath(const StringView& s)
+LexicalPath::LexicalPath(const StringView& s)
     : m_string(s)
 {
     canonicalize();
     m_is_valid = true;
 }
 
-void FileSystemPath::canonicalize()
+void LexicalPath::canonicalize()
 {
     if (m_string.is_empty()) {
         m_parts.clear();
@@ -105,14 +105,14 @@ void FileSystemPath::canonicalize()
     m_string = builder.to_string();
 }
 
-bool FileSystemPath::has_extension(const StringView& extension) const
+bool LexicalPath::has_extension(const StringView& extension) const
 {
     return m_string.ends_with(extension, CaseSensitivity::CaseInsensitive);
 }
 
-String canonicalized_path(const StringView& path)
+String LexicalPath::canonicalized_path(const StringView& path)
 {
-    return FileSystemPath(path).string();
+    return LexicalPath(path).string();
 }
 
 }

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -31,10 +31,10 @@
 
 namespace AK {
 
-class FileSystemPath {
+class LexicalPath {
 public:
-    FileSystemPath() {}
-    explicit FileSystemPath(const StringView&);
+    LexicalPath() { }
+    explicit LexicalPath(const StringView&);
 
     bool is_valid() const { return m_is_valid; }
     bool is_absolute() const { return m_is_absolute; }
@@ -49,6 +49,8 @@ public:
 
     bool has_extension(const StringView&) const;
 
+    static String canonicalized_path(const StringView&);
+
 private:
     void canonicalize();
 
@@ -62,9 +64,6 @@ private:
     bool m_is_absolute { false };
 };
 
-String canonicalized_path(const StringView&);
-
 };
 
-using AK::canonicalized_path;
-using AK::FileSystemPath;
+using AK::LexicalPath;

--- a/AK/Tests/TestLexicalPath.cpp
+++ b/AK/Tests/TestLexicalPath.cpp
@@ -26,17 +26,17 @@
 
 #include <AK/TestSuite.h>
 
+#include <AK/LexicalPath.h>
 #include <AK/String.h>
-#include <AK/FileSystemPath.h>
 
 TEST_CASE(construct)
 {
-    EXPECT_EQ(FileSystemPath().is_valid(), false);
+    EXPECT_EQ(LexicalPath().is_valid(), false);
 }
 
 TEST_CASE(basic)
 {
-    FileSystemPath path("/abc/def/ghi.txt");
+    LexicalPath path("/abc/def/ghi.txt");
     EXPECT_EQ(path.is_valid(), true);
     EXPECT_EQ(path.basename(), "ghi.txt");
     EXPECT_EQ(path.title(), "ghi");
@@ -48,8 +48,8 @@ TEST_CASE(basic)
 
 TEST_CASE(dotdot_coalescing)
 {
-    EXPECT_EQ(FileSystemPath("/home/user/../../not/home").string(), "/not/home");
-    EXPECT_EQ(FileSystemPath("/../../../../").string(), "/");
+    EXPECT_EQ(LexicalPath("/home/user/../../not/home").string(), "/not/home");
+    EXPECT_EQ(LexicalPath("/../../../../").string(), "/");
 }
 
 // Temporarily disabled, as they were broken by commit a3e4dfdf9859a9b955bf4728328f740a47de5851
@@ -59,21 +59,21 @@ TEST_CASE(dotdot_coalescing)
 TEST_CASE(relative_paths)
 {
     {
-        FileSystemPath path("simple");
+        LexicalPath path("simple");
         EXPECT_EQ(path.is_valid(), true);
         EXPECT_EQ(path.string(), "./simple");
         EXPECT_EQ(path.parts().size(), 2u);
         EXPECT_EQ(path.basename(), "simple");
     }
     {
-        FileSystemPath path("a/relative/path");
+        LexicalPath path("a/relative/path");
         EXPECT_EQ(path.is_valid(), true);
         EXPECT_EQ(path.string(), "./a/relative/path");
         EXPECT_EQ(path.parts().size(), 4u);
         EXPECT_EQ(path.basename(), "path");
     }
     {
-        FileSystemPath path("./././foo");
+        LexicalPath path("./././foo");
         EXPECT_EQ(path.is_valid(), true);
         EXPECT_EQ(path.string(), "./foo");
         EXPECT_EQ(path.parts().size(), 2u);
@@ -81,7 +81,7 @@ TEST_CASE(relative_paths)
     }
 
     {
-        FileSystemPath path(".");
+        LexicalPath path(".");
         EXPECT_EQ(path.is_valid(), true);
         EXPECT_EQ(path.string(), ".");
         EXPECT_EQ(path.parts().size(), 1u);
@@ -123,4 +123,4 @@ TEST_CASE(has_extension)
 
 #endif
 
-TEST_MAIN(FileSystemPath)
+TEST_MAIN(LexicalPath)

--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
 
@@ -314,22 +314,22 @@ URL URL::complete_url(const String& string) const
     }
 
     StringBuilder builder;
-    FileSystemPath fspath(path());
+    LexicalPath lexical_path(path());
     builder.append('/');
 
     bool document_url_ends_in_slash = path()[path().length() - 1] == '/';
 
-    for (size_t i = 0; i < fspath.parts().size(); ++i) {
-        if (i == fspath.parts().size() - 1 && !document_url_ends_in_slash)
+    for (size_t i = 0; i < lexical_path.parts().size(); ++i) {
+        if (i == lexical_path.parts().size() - 1 && !document_url_ends_in_slash)
             break;
-        builder.append(fspath.parts()[i]);
+        builder.append(lexical_path.parts()[i]);
         builder.append('/');
     }
     builder.append(string);
     auto built = builder.to_string();
-    fspath = FileSystemPath(built);
+    lexical_path = LexicalPath(built);
 
-    built = fspath.string();
+    built = lexical_path.string();
     if (string.ends_with('/') && !built.ends_with('/')) {
         builder.clear();
         builder.append(built);
@@ -399,7 +399,7 @@ URL URL::create_with_url_or_path(const String& url_or_path)
     if (url.is_valid())
         return url;
 
-    String path = canonicalized_path(url_or_path);
+    String path = LexicalPath::canonicalized_path(url_or_path);
     return URL::create_with_file_protocol(path);
 }
 
@@ -407,7 +407,7 @@ String URL::basename() const
 {
     if (!m_valid)
         return {};
-    return FileSystemPath(m_path).basename();
+    return LexicalPath(m_path).basename();
 }
 
 }

--- a/Applications/Debugger/main.cpp
+++ b/Applications/Debugger/main.cpp
@@ -173,7 +173,7 @@ void print_help()
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio proc exec rpath tty", nullptr) < 0) {
+    if (pledge("stdio proc exec rpath tty sigaction", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Applications/FileManager/DirectoryView.cpp
+++ b/Applications/FileManager/DirectoryView.cpp
@@ -25,7 +25,6 @@
  */
 
 #include "DirectoryView.h"
-#include <AK/FileSystemPath.h>
 #include <AK/NumberFormat.h>
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>

--- a/Applications/FileManager/FileUtils.cpp
+++ b/Applications/FileManager/FileUtils.cpp
@@ -25,7 +25,7 @@
  */
 
 #include "FileUtils.h"
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/DirIterator.h>
 #include <stdio.h>
@@ -134,7 +134,7 @@ bool copy_file(const String& src_path, const String& dst_path, const struct stat
         if (errno != EISDIR) {
             return false;
         }
-        auto dst_dir_path = String::format("%s/%s", dst_path.characters(), FileSystemPath(src_path).basename().characters());
+        auto dst_dir_path = String::format("%s/%s", dst_path.characters(), LexicalPath(src_path).basename().characters());
         dst_fd = creat(dst_dir_path.characters(), 0666);
         if (dst_fd < 0) {
             return false;
@@ -186,21 +186,21 @@ String get_duplicate_name(const String& path, int duplicate_count)
     if (duplicate_count == 0) {
         return path;
     }
-    FileSystemPath fsp(path);
+    LexicalPath lexical_path(path);
     StringBuilder duplicated_name;
     duplicated_name.append('/');
-    for (size_t i = 0; i < fsp.parts().size() - 1; ++i) {
-        duplicated_name.appendf("%s/", fsp.parts()[i].characters());
+    for (size_t i = 0; i < lexical_path.parts().size() - 1; ++i) {
+        duplicated_name.appendf("%s/", lexical_path.parts()[i].characters());
     }
     auto prev_duplicate_tag = String::format("(%d)", duplicate_count);
-    auto title = fsp.title();
+    auto title = lexical_path.title();
     if (title.ends_with(prev_duplicate_tag)) {
         // remove the previous duplicate tag "(n)" so we can add a new tag.
         title = title.substring(0, title.length() - prev_duplicate_tag.length());
     }
-    duplicated_name.appendf("%s (%d)", fsp.title().characters(), duplicate_count);
-    if (!fsp.extension().is_empty()) {
-        duplicated_name.appendf(".%s", fsp.extension().characters());
+    duplicated_name.appendf("%s (%d)", lexical_path.title().characters(), duplicate_count);
+    if (!lexical_path.extension().is_empty()) {
+        duplicated_name.appendf(".%s", lexical_path.extension().characters());
     }
     return duplicated_name.build();
 }

--- a/Applications/FileManager/PropertiesDialog.cpp
+++ b/Applications/FileManager/PropertiesDialog.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "PropertiesDialog.h"
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/CheckBox.h>
@@ -42,8 +43,8 @@ PropertiesDialog::PropertiesDialog(GUI::FileSystemModel& model, String path, boo
     : Dialog(parent_window)
     , m_model(model)
 {
-    auto file_path = FileSystemPath(path);
-    ASSERT(file_path.is_valid());
+    auto lexical_path = LexicalPath(path);
+    ASSERT(lexical_path.is_valid());
 
     auto& main_widget = set_main_widget<GUI::Widget>();
     main_widget.set_layout<GUI::VerticalBoxLayout>();
@@ -72,8 +73,8 @@ PropertiesDialog::PropertiesDialog(GUI::FileSystemModel& model, String path, boo
     m_icon->set_size_policy(GUI::SizePolicy::Fixed, GUI::SizePolicy::Fixed);
     m_icon->set_preferred_size(32, 32);
 
-    m_name = file_path.basename();
-    m_path = file_path.string();
+    m_name = lexical_path.basename();
+    m_path = lexical_path.string();
 
     m_name_box = file_container.add<GUI::TextBox>();
     m_name_box->set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);

--- a/Applications/FileManager/PropertiesDialog.h
+++ b/Applications/FileManager/PropertiesDialog.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <AK/FileSystemPath.h>
 #include <LibCore/File.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Dialog.h>

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -27,7 +27,7 @@
 #include "DirectoryView.h"
 #include "FileUtils.h"
 #include "PropertiesDialog.h"
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
 #include <LibCore/ConfigFile.h>
@@ -165,7 +165,7 @@ int run_in_desktop_mode(RefPtr<Core::ConfigFile> config, String initial_location
     auto mkdir_action = GUI::Action::create("New directory...", {}, Gfx::Bitmap::load_from_file("/res/icons/16x16/mkdir.png"), [&](const GUI::Action&) {
         auto input_box = GUI::InputBox::construct("Enter name:", "New directory", window);
         if (input_box->exec() == GUI::InputBox::ExecOK && !input_box->text_value().is_empty()) {
-            auto new_dir_path = canonicalized_path(
+            auto new_dir_path = LexicalPath::canonicalized_path(
                 String::format("%s/%s",
                     model->root_path().characters(),
                     input_box->text_value().characters()));
@@ -179,7 +179,7 @@ int run_in_desktop_mode(RefPtr<Core::ConfigFile> config, String initial_location
     auto touch_action = GUI::Action::create("New file...", {}, Gfx::Bitmap::load_from_file("/res/icons/16x16/new.png"), [&](const GUI::Action&) {
         auto input_box = GUI::InputBox::construct("Enter name:", "New file", window);
         if (input_box->exec() == GUI::InputBox::ExecOK && !input_box->text_value().is_empty()) {
-            auto new_file_path = canonicalized_path(
+            auto new_file_path = LexicalPath::canonicalized_path(
                 String::format("%s/%s",
                     model->root_path().characters(),
                     input_box->text_value().characters()));
@@ -323,7 +323,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     auto mkdir_action = GUI::Action::create("New directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::load_from_file("/res/icons/16x16/mkdir.png"), [&](const GUI::Action&) {
         auto input_box = GUI::InputBox::construct("Enter name:", "New directory", window);
         if (input_box->exec() == GUI::InputBox::ExecOK && !input_box->text_value().is_empty()) {
-            auto new_dir_path = canonicalized_path(
+            auto new_dir_path = LexicalPath::canonicalized_path(
                 String::format("%s/%s",
                     directory_view.path().characters(),
                     input_box->text_value().characters()));
@@ -442,7 +442,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
                     selected = selected_file_paths();
                 } else {
                     path = directories_model->full_path(tree_view.selection().first());
-                    container_dir_path = FileSystemPath(path).basename();
+                    container_dir_path = LexicalPath(path).basename();
                     selected = tree_view_selected_file_paths();
                 }
 
@@ -510,7 +510,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
 
         String message;
         if (paths.size() == 1) {
-            message = String::format("Really delete %s?", FileSystemPath(paths[0]).basename().characters());
+            message = String::format("Really delete %s?", LexicalPath(paths[0]).basename().characters());
         } else {
             message = String::format("Really delete %d files?", paths.size());
         }
@@ -791,7 +791,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
                 continue;
             auto new_path = String::format("%s/%s",
                 target_node.full_path(directory_view.model()).characters(),
-                FileSystemPath(url_to_copy.path()).basename().characters());
+                LexicalPath(url_to_copy.path()).basename().characters());
 
             if (url_to_copy.path() == new_path)
                 continue;

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -67,7 +67,7 @@ static int run_in_windowed_mode(RefPtr<Core::ConfigFile>, String initial_locatio
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio thread shared_buffer accept unix cpath rpath wpath fattr proc exec", nullptr) < 0) {
+    if (pledge("stdio thread shared_buffer accept unix cpath rpath wpath fattr proc exec sigaction", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Applications/Help/ManualSectionNode.cpp
+++ b/Applications/Help/ManualSectionNode.cpp
@@ -26,7 +26,7 @@
 
 #include "ManualSectionNode.h"
 #include "ManualPageNode.h"
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/QuickSort.h>
 #include <AK/String.h>
 #include <LibCore/DirIterator.h>
@@ -46,10 +46,10 @@ void ManualSectionNode::reify_if_needed() const
 
     Vector<String> page_names;
     while (dir_iter.has_next()) {
-        FileSystemPath file_path(dir_iter.next_path());
-        if (file_path.extension() != "md")
+        LexicalPath lexical_path(dir_iter.next_path());
+        if (lexical_path.extension() != "md")
             continue;
-        page_names.append(file_path.title());
+        page_names.append(lexical_path.title());
     }
 
     quick_sort(page_names);

--- a/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Applications/HexEditor/HexEditorWidget.cpp
@@ -87,7 +87,7 @@ HexEditorWidget::HexEditorWidget()
             if (valid && file_size > 0) {
                 m_document_dirty = false;
                 m_editor->set_buffer(ByteBuffer::create_zeroed(file_size));
-                set_path(FileSystemPath());
+                set_path(LexicalPath());
                 update_title();
             } else {
                 GUI::MessageBox::show("Invalid file size entered.", "Error", GUI::MessageBox::Type::Error, GUI::MessageBox::InputType::OK, window());
@@ -129,7 +129,7 @@ HexEditorWidget::HexEditorWidget()
         }
 
         m_document_dirty = false;
-        set_path(FileSystemPath(save_path.value()));
+        set_path(LexicalPath(save_path.value()));
         dbg() << "Wrote document to " << save_path.value();
     });
 
@@ -211,11 +211,11 @@ HexEditorWidget::~HexEditorWidget()
 {
 }
 
-void HexEditorWidget::set_path(const FileSystemPath& file)
+void HexEditorWidget::set_path(const LexicalPath& lexical_path)
 {
-    m_path = file.string();
-    m_name = file.title();
-    m_extension = file.extension();
+    m_path = lexical_path.string();
+    m_name = lexical_path.title();
+    m_extension = lexical_path.extension();
     update_title();
 }
 
@@ -239,7 +239,7 @@ void HexEditorWidget::open_file(const String& path)
 
     m_document_dirty = false;
     m_editor->set_buffer(file->read_all()); // FIXME: On really huge files, this is never going to work. Should really create a framework to fetch data from the file on-demand.
-    set_path(FileSystemPath(path));
+    set_path(LexicalPath(path));
 }
 
 bool HexEditorWidget::request_close()

--- a/Applications/HexEditor/HexEditorWidget.h
+++ b/Applications/HexEditor/HexEditorWidget.h
@@ -27,8 +27,8 @@
 #pragma once
 
 #include "HexEditor.h"
-#include <AK/FileSystemPath.h>
 #include <AK/Function.h>
+#include <AK/LexicalPath.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/Widget.h>
@@ -45,7 +45,7 @@ public:
 
 private:
     HexEditorWidget();
-    void set_path(const FileSystemPath& file);
+    void set_path(const LexicalPath& file);
     void update_title();
 
     RefPtr<HexEditor> m_editor;

--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -179,7 +179,7 @@ RefPtr<GUI::Window> create_settings_window(TerminalWidget& terminal)
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio tty rpath accept cpath wpath shared_buffer proc exec unix fattr", nullptr) < 0) {
+    if (pledge("stdio tty rpath accept cpath wpath shared_buffer proc exec unix fattr sigaction", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -301,7 +301,7 @@ TextEditorWidget::TextEditorWidget()
 
         m_document_dirty = false;
         m_editor->set_text(StringView());
-        set_path(FileSystemPath());
+        set_path(LexicalPath());
         update_title();
     });
 
@@ -333,7 +333,7 @@ TextEditorWidget::TextEditorWidget()
         }
 
         m_document_dirty = false;
-        set_path(FileSystemPath(save_path.value()));
+        set_path(LexicalPath(save_path.value()));
         dbg() << "Wrote document to " << save_path.value();
     });
 
@@ -465,11 +465,11 @@ TextEditorWidget::~TextEditorWidget()
 {
 }
 
-void TextEditorWidget::set_path(const FileSystemPath& file)
+void TextEditorWidget::set_path(const LexicalPath& lexical_path)
 {
-    m_path = file.string();
-    m_name = file.title();
-    m_extension = file.extension();
+    m_path = lexical_path.string();
+    m_name = lexical_path.title();
+    m_extension = lexical_path.extension();
 
     if (m_extension == "cpp" || m_extension == "h") {
         m_cpp_highlight->activate();
@@ -508,7 +508,7 @@ void TextEditorWidget::open_sesame(const String& path)
     m_document_dirty = false;
     m_document_opening = true;
 
-    set_path(FileSystemPath(path));
+    set_path(LexicalPath(path));
 
     m_editor->set_focus(true);
 }

--- a/Applications/TextEditor/TextEditorWidget.h
+++ b/Applications/TextEditor/TextEditorWidget.h
@@ -26,14 +26,15 @@
 
 #pragma once
 
-#include <AK/FileSystemPath.h>
 #include <AK/Function.h>
+#include <AK/LexicalPath.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibWeb/Forward.h>
+
 class TextEditorWidget final : public GUI::Widget {
     C_OBJECT(TextEditorWidget)
 public:
@@ -47,7 +48,7 @@ public:
 
 private:
     TextEditorWidget();
-    void set_path(const FileSystemPath& file);
+    void set_path(const LexicalPath& file);
     void update_title();
     void update_markdown_preview();
 

--- a/Base/usr/share/man/man2/pledge.md
+++ b/Base/usr/share/man/man2/pledge.md
@@ -24,6 +24,10 @@ Note that `pledge()` can be called repeatedly to remove previously-pledged promi
 
 If `promises` or `execpromises` is null, the corresponding value is unchanged.
 
+If the process later attempts to use any system functionality it has previously promised *not* to use, the process is instantly terminated. Note that a process that has not ever called `pledge()` is considered to not have made any promises, and is allowed use any system functionality (subject to regular permission checks).
+
+`pledge()` is intended to be used in programs that want to sandbox themselves, either to limit the impact of a possible vulnerability exploitation, or before intentionally executing untrusted code.
+
 ## Promises
 
 * `stdio`: Basic I/O, memory allocation, information about self, various non-destructive syscalls
@@ -45,6 +49,7 @@ If `promises` or `execpromises` is null, the corresponding value is unchanged.
 * `chroot`: The [`chroot(2)`](chroot.md) syscall (\*)
 * `video`: May use [`ioctl(2)`](ioctl.md) and [`mmap(2)`](mmap.md) on framebuffer video devices
 * `settime`: Changing the system time and date
+* `sigaction`: Change signal handlers and dispositions (\*)
 
 Promises marked with an asterisk (\*) are SerenityOS specific extensions not supported by the original OpenBSD `pledge()`.
 

--- a/DevTools/HackStudio/Editor.cpp
+++ b/DevTools/HackStudio/Editor.cpp
@@ -27,7 +27,7 @@
 #include "Editor.h"
 #include "EditorWrapper.h"
 #include <AK/ByteBuffer.h>
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
 #include <LibGUI/Application.h>
@@ -137,7 +137,7 @@ static HashMap<String, String>& man_paths()
         Core::DirIterator it("/usr/share/man/man2", Core::DirIterator::Flags::SkipDots);
         while (it.has_next()) {
             auto path = String::format("/usr/share/man/man2/%s", it.next_path().characters());
-            auto title = FileSystemPath(path).title();
+            auto title = LexicalPath(path).title();
             paths.set(title, path);
         }
     }

--- a/DevTools/HackStudio/Project.cpp
+++ b/DevTools/HackStudio/Project.cpp
@@ -25,7 +25,7 @@
  */
 
 #include "Project.h"
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/DirIterator.h>
@@ -169,7 +169,7 @@ private:
 Project::Project(const String& path, Vector<String>&& filenames)
     : m_path(path)
 {
-    m_name = FileSystemPath(m_path).basename();
+    m_name = LexicalPath(m_path).basename();
 
     m_file_icon = GUI::Icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-unknown.png"));
     m_cplusplus_icon = GUI::Icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-cplusplus.png"));
@@ -283,7 +283,7 @@ bool Project::save()
 ProjectFile* Project::get_file(const String& filename)
 {
     for (auto& file : m_files) {
-        if (FileSystemPath(file.name()).string() == FileSystemPath(filename).string())
+        if (LexicalPath(file.name()).string() == LexicalPath(filename).string())
             return &file;
     }
     return nullptr;
@@ -307,7 +307,7 @@ void Project::rebuild_tree()
     root->type = ProjectTreeNode::Type::Project;
 
     for (auto& file : m_files) {
-        FileSystemPath path(file.name());
+        LexicalPath path(file.name());
         ProjectTreeNode* current = root.ptr();
         StringBuilder partial_path;
 

--- a/DevTools/HackStudio/main.cpp
+++ b/DevTools/HackStudio/main.cpp
@@ -242,7 +242,7 @@ int main(int argc, char** argv)
 
         String message;
         if (files.size() == 1) {
-            message = String::format("Really remove %s from the project?", FileSystemPath(files[0]).basename().characters());
+            message = String::format("Really remove %s from the project?", LexicalPath(files[0]).basename().characters());
         } else {
             message = String::format("Really remove %d files from the project?", files.size());
         }
@@ -711,8 +711,8 @@ void run(TerminalWrapper& wrapper)
 
 void open_project(String filename)
 {
-    FileSystemPath path(filename);
-    if (chdir(path.dirname().characters()) < 0) {
+    LexicalPath lexical_path(filename);
+    if (chdir(lexical_path.dirname().characters()) < 0) {
         perror("chdir");
         exit(1);
     }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -121,10 +121,10 @@ set(KERNEL_SOURCES
 )
 
 set(AK_SOURCES
-    ../AK/FileSystemPath.cpp
     ../AK/FlyString.cpp
     ../AK/JsonParser.cpp
     ../AK/JsonValue.cpp
+    ../AK/LexicalPath.cpp
     ../AK/LogStream.cpp
     ../AK/String.cpp
     ../AK/StringBuilder.cpp

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <Kernel/Devices/BlockDevice.h>
 #include <Kernel/FileSystem/Custody.h>
@@ -291,7 +291,7 @@ KResult VFS::mknod(StringView path, mode_t mode, dev_t dev, Custody& base)
     if (!parent_inode.metadata().may_write(*Process::current))
         return KResult(-EACCES);
 
-    FileSystemPath p(path);
+    LexicalPath p(path);
     dbg() << "VFS::mknod: '" << p.basename() << "' mode=" << mode << " dev=" << dev << " in " << parent_inode.identifier();
     return parent_inode.fs().create_inode(parent_inode.identifier(), p.basename(), mode, 0, dev, Process::current->uid(), Process::current->gid()).result();
 }
@@ -310,7 +310,7 @@ KResultOr<NonnullRefPtr<FileDescription>> VFS::create(StringView path, int optio
     auto& parent_inode = parent_custody.inode();
     if (!parent_inode.metadata().may_write(*Process::current))
         return KResult(-EACCES);
-    FileSystemPath p(path);
+    LexicalPath p(path);
 #ifdef VFS_DEBUG
     dbg() << "VFS::create: '" << p.basename() << "' in " << parent_inode.identifier();
 #endif
@@ -349,7 +349,7 @@ KResult VFS::mkdir(StringView path, mode_t mode, Custody& base)
     if (!parent_inode.metadata().may_write(*Process::current))
         return KResult(-EACCES);
 
-    FileSystemPath p(path);
+    LexicalPath p(path);
 #ifdef VFS_DEBUG
     dbg() << "VFS::mkdir: '" << p.basename() << "' in " << parent_inode.identifier();
 #endif
@@ -449,7 +449,7 @@ KResult VFS::rename(StringView old_path, StringView new_path, Custody& base)
             return KResult(-EACCES);
     }
 
-    auto new_basename = FileSystemPath(new_path).basename();
+    auto new_basename = LexicalPath(new_path).basename();
 
     if (!new_custody_or_error.is_error()) {
         auto& new_custody = *new_custody_or_error.value();
@@ -472,7 +472,7 @@ KResult VFS::rename(StringView old_path, StringView new_path, Custody& base)
     if (result.is_error())
         return result;
 
-    result = old_parent_inode.remove_child(FileSystemPath(old_path).basename());
+    result = old_parent_inode.remove_child(LexicalPath(old_path).basename());
     if (result.is_error())
         return result;
 
@@ -555,7 +555,7 @@ KResult VFS::link(StringView old_path, StringView new_path, Custody& base)
     if (old_inode.is_directory())
         return KResult(-EPERM);
 
-    return parent_inode.add_child(old_inode.identifier(), FileSystemPath(new_path).basename(), old_inode.mode());
+    return parent_inode.add_child(old_inode.identifier(), LexicalPath(new_path).basename(), old_inode.mode());
 }
 
 KResult VFS::unlink(StringView path, Custody& base)
@@ -579,7 +579,7 @@ KResult VFS::unlink(StringView path, Custody& base)
             return KResult(-EACCES);
     }
 
-    auto result = parent_inode.remove_child(FileSystemPath(path).basename());
+    auto result = parent_inode.remove_child(LexicalPath(path).basename());
     if (result.is_error())
         return result;
 
@@ -600,7 +600,7 @@ KResult VFS::symlink(StringView target, StringView linkpath, Custody& base)
     if (!parent_inode.metadata().may_write(*Process::current))
         return KResult(-EACCES);
 
-    FileSystemPath p(linkpath);
+    LexicalPath p(linkpath);
     dbg() << "VFS::symlink: '" << p.basename() << "' (-> '" << target << "') in " << parent_inode.identifier();
     auto inode_or_error = parent_inode.fs().create_inode(parent_inode.identifier(), p.basename(), 0120644, 0, 0, Process::current->uid(), Process::current->gid());
     if (inode_or_error.is_error())
@@ -649,7 +649,7 @@ KResult VFS::rmdir(StringView path, Custody& base)
     if (result.is_error())
         return result;
 
-    return parent_inode.remove_child(FileSystemPath(path).basename());
+    return parent_inode.remove_child(LexicalPath(path).basename());
 }
 
 RefPtr<Inode> VFS::get_inode(InodeIdentifier inode_id)

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -2711,7 +2711,7 @@ int Process::sys$sigpending(sigset_t* set)
 
 int Process::sys$sigaction(int signum, const sigaction* act, sigaction* old_act)
 {
-    REQUIRE_PROMISE(stdio);
+    REQUIRE_PROMISE(sigaction);
     if (signum < 1 || signum >= 32 || signum == SIGKILL || signum == SIGSTOP)
         return -EINVAL;
     if (!validate_read_typed(act))

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -25,7 +25,6 @@
  */
 
 #include <AK/Demangle.h>
-#include <AK/FileSystemPath.h>
 #include <AK/RefPtr.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StdLibExtras.h>

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -72,6 +72,7 @@ extern VirtualAddress g_return_to_ring3_from_signal_trampoline;
     __ENUMERATE_PLEDGE_PROMISE(video)   \
     __ENUMERATE_PLEDGE_PROMISE(accept)  \
     __ENUMERATE_PLEDGE_PROMISE(settime) \
+    __ENUMERATE_PLEDGE_PROMISE(sigaction) \
     __ENUMERATE_PLEDGE_PROMISE(shared_buffer)
 
 enum class Pledge : u32 {

--- a/Libraries/LibC/assert.cpp
+++ b/Libraries/LibC/assert.cpp
@@ -37,8 +37,6 @@ void __assertion_failed(const char* msg)
     dbgprintf("USERSPACE(%d) ASSERTION FAILED: %s\n", getpid(), msg);
     fprintf(stderr, "ASSERTION FAILED: %s\n", msg);
     abort();
-    for (;;)
-        ;
 }
 #endif
 }

--- a/Libraries/LibC/dlfcn.cpp
+++ b/Libraries/LibC/dlfcn.cpp
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/HashMap.h>
 #include <AK/RefPtr.h>
 #include <AK/ScopeGuard.h>
@@ -70,9 +70,9 @@ void* dlopen(const char* filename, int flags)
         ASSERT_NOT_REACHED();
     }
 
-    FileSystemPath file_path(filename);
+    auto basename = LexicalPath(filename).basename();
 
-    auto existing_elf_object = g_elf_objects.get(file_path.basename());
+    auto existing_elf_object = g_elf_objects.get(basename);
     if (existing_elf_object.has_value()) {
         return const_cast<ELF::DynamicLoader*>(existing_elf_object.value());
     }
@@ -105,11 +105,11 @@ void* dlopen(const char* filename, int flags)
         return nullptr;
     }
 
-    g_elf_objects.set(file_path.basename(), move(loader));
+    g_elf_objects.set(basename, move(loader));
     g_dlerror_msg = "Successfully loaded ELF object.";
 
     // we have one refcount already
-    return const_cast<ELF::DynamicLoader*>(g_elf_objects.get(file_path.basename()).value());
+    return const_cast<ELF::DynamicLoader*>(g_elf_objects.get(basename).value());
 }
 
 void* dlsym(void* handle, const char* symbol_name)

--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -208,7 +208,6 @@ void exit(int status)
     fflush(stdout);
     fflush(stderr);
     _exit(status);
-    ASSERT_NOT_REACHED();
 }
 
 static void __atexit_to_cxa_atexit(void* handler)

--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -222,8 +222,11 @@ int atexit(void (*handler)())
 
 void abort()
 {
+    // For starters, send ourselves a SIGABRT.
     raise(SIGABRT);
-    ASSERT_NOT_REACHED();
+    // If that didn't kill us, try harder.
+    raise(SIGKILL);
+    _exit(127);
 }
 
 static HashTable<const char*> s_malloced_environment_variables;

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -72,7 +72,7 @@ int execlp(const char* filename, const char* arg, ...);
 int chroot(const char* path);
 int chroot_with_mount_flags(const char* path, int mount_flags);
 void sync();
-void _exit(int status);
+__attribute__((noreturn)) void _exit(int status);
 pid_t getsid(pid_t);
 pid_t setsid();
 int setpgid(pid_t pid, pid_t pgid);

--- a/Libraries/LibCore/StandardPaths.cpp
+++ b/Libraries/LibCore/StandardPaths.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/StandardPaths.h>
@@ -37,12 +37,12 @@ namespace Core {
 String StandardPaths::home_directory()
 {
     if (auto* home_env = getenv("HOME"))
-        return canonicalized_path(home_env);
+        return LexicalPath::canonicalized_path(home_env);
 
     auto* pwd = getpwuid(getuid());
     String path = pwd ? pwd->pw_dir : "/";
     endpwent();
-    return canonicalized_path(path);
+    return LexicalPath::canonicalized_path(path);
 }
 
 String StandardPaths::desktop_directory()
@@ -50,7 +50,7 @@ String StandardPaths::desktop_directory()
     StringBuilder builder;
     builder.append(home_directory());
     builder.append("/Desktop");
-    return canonicalized_path(builder.to_string());
+    return LexicalPath::canonicalized_path(builder.to_string());
 }
 
 String StandardPaths::downloads_directory()
@@ -58,7 +58,7 @@ String StandardPaths::downloads_directory()
     StringBuilder builder;
     builder.append(home_directory());
     builder.append("/Downloads");
-    return canonicalized_path(builder.to_string());
+    return LexicalPath::canonicalized_path(builder.to_string());
 }
 
 String StandardPaths::tempfile_directory()

--- a/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <AK/Utf32View.h>
 #include <LibCore/DirIterator.h>
@@ -43,10 +43,10 @@ static Vector<u32> supported_emoji_codepoints()
     Core::DirIterator dt("/res/emoji", Core::DirIterator::SkipDots);
     while (dt.has_next()) {
         auto filename = dt.next_path();
-        auto fspath = FileSystemPath(filename);
-        if (fspath.extension() != "png")
+        auto lexical_path = LexicalPath(filename);
+        if (lexical_path.extension() != "png")
             continue;
-        auto basename = fspath.basename();
+        auto basename = lexical_path.basename();
         if (!basename.starts_with("U+"))
             continue;
         u32 codepoint = strtoul(basename.characters() + 2, nullptr, 16);

--- a/Libraries/LibGUI/FilePicker.cpp
+++ b/Libraries/LibGUI/FilePicker.cpp
@@ -24,8 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
 #include <AK/Function.h>
+#include <AK/LexicalPath.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -142,9 +142,9 @@ FilePicker::FilePicker(Mode mode, const StringView& file_name, const StringView&
     auto mkdir_action = Action::create("New directory...", Gfx::Bitmap::load_from_file("/res/icons/16x16/mkdir.png"), [this](const Action&) {
         auto& input_box = add<InputBox>("Enter name:", "New directory");
         if (input_box.exec() == InputBox::ExecOK && !input_box.text_value().is_empty()) {
-            auto new_dir_path = FileSystemPath(String::format("%s/%s",
-                                                   m_model->root_path().characters(),
-                                                   input_box.text_value().characters()))
+            auto new_dir_path = LexicalPath(String::format("%s/%s",
+                                                m_model->root_path().characters(),
+                                                input_box.text_value().characters()))
                                     .string();
             int rc = mkdir(new_dir_path.characters(), 0777);
             if (rc < 0) {
@@ -196,7 +196,7 @@ FilePicker::FilePicker(Mode mode, const StringView& file_name, const StringView&
         auto& filter_model = (SortingProxyModel&)*m_view->model();
         auto local_index = filter_model.map_to_target(index);
         const FileSystemModel::Node& node = m_model->node(local_index);
-        FileSystemPath path { node.full_path(m_model) };
+        LexicalPath path { node.full_path(m_model) };
 
         clear_preview();
 
@@ -267,7 +267,7 @@ FilePicker::~FilePicker()
 {
 }
 
-void FilePicker::set_preview(const FileSystemPath& path)
+void FilePicker::set_preview(const LexicalPath& path)
 {
     if (path.has_extension(".png")) {
         auto bitmap = Gfx::Bitmap::load_from_file(path.string());
@@ -292,7 +292,7 @@ void FilePicker::clear_preview()
 
 void FilePicker::on_file_return()
 {
-    FileSystemPath path(String::format("%s/%s", m_model->root_path().characters(), m_filename_textbox->text().characters()));
+    LexicalPath path(String::format("%s/%s", m_model->root_path().characters(), m_filename_textbox->text().characters()));
 
     if (FilePicker::file_exists(path.string()) && m_mode == Mode::Save) {
         auto result = MessageBox::show("File already exists, overwrite?", "Existing File", MessageBox::Type::Warning, MessageBox::InputType::OKCancel);

--- a/Libraries/LibGUI/FilePicker.h
+++ b/Libraries/LibGUI/FilePicker.h
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/Optional.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/Dialog.h>
@@ -45,10 +45,10 @@ public:
 
     virtual ~FilePicker() override;
 
-    FileSystemPath selected_file() const { return m_selected_file; }
+    LexicalPath selected_file() const { return m_selected_file; }
 
 private:
-    void set_preview(const FileSystemPath&);
+    void set_preview(const LexicalPath&);
     void clear_preview();
     void on_file_return();
 
@@ -68,7 +68,7 @@ private:
 
     RefPtr<MultiView> m_view;
     NonnullRefPtr<FileSystemModel> m_model;
-    FileSystemPath m_selected_file;
+    LexicalPath m_selected_file;
 
     RefPtr<TextBox> m_filename_textbox;
     RefPtr<Label> m_preview_image_label;

--- a/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Libraries/LibGUI/FileSystemModel.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/DirIterator.h>
 #include <LibGUI/FileSystemModel.h>
@@ -162,24 +162,24 @@ String FileSystemModel::Node::full_path(const FileSystemModel& model) const
     }
     builder.append('/');
     builder.append(name);
-    return canonicalized_path(builder.to_string());
+    return LexicalPath::canonicalized_path(builder.to_string());
 }
 
 ModelIndex FileSystemModel::index(const StringView& path, int column) const
 {
-    FileSystemPath canonical_path(path);
+    LexicalPath lexical_path(path);
     const Node* node = m_root;
-    if (canonical_path.string() == "/")
+    if (lexical_path.string() == "/")
         return m_root->index(*this, column);
-    for (size_t i = 0; i < canonical_path.parts().size(); ++i) {
-        auto& part = canonical_path.parts()[i];
+    for (size_t i = 0; i < lexical_path.parts().size(); ++i) {
+        auto& part = lexical_path.parts()[i];
         bool found = false;
         for (auto& child : node->children) {
             if (child.name == part) {
                 const_cast<Node&>(child).reify_if_needed(*this);
                 node = &child;
                 found = true;
-                if (i == canonical_path.parts().size() - 1)
+                if (i == lexical_path.parts().size() - 1)
                     return child.index(*this, column);
                 break;
             }
@@ -198,7 +198,7 @@ String FileSystemModel::full_path(const ModelIndex& index) const
 }
 
 FileSystemModel::FileSystemModel(const StringView& root_path, Mode mode)
-    : m_root_path(canonicalized_path(root_path))
+    : m_root_path(LexicalPath::canonicalized_path(root_path))
     , m_mode(mode)
 {
     m_directory_icon = Icon::default_icon("filetype-folder");
@@ -284,7 +284,7 @@ static String permission_string(mode_t mode)
 
 void FileSystemModel::set_root_path(const StringView& root_path)
 {
-    m_root_path = canonicalized_path(root_path);
+    m_root_path = LexicalPath::canonicalized_path(root_path);
     update();
 
     if (m_root->has_error()) {

--- a/Libraries/LibGUI/MultiView.cpp
+++ b/Libraries/LibGUI/MultiView.cpp
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
 #include <AK/StringBuilder.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>

--- a/Libraries/LibGfx/GIFLoader.cpp
+++ b/Libraries/LibGfx/GIFLoader.cpp
@@ -26,7 +26,7 @@
 
 #include <AK/BufferStream.h>
 #include <AK/ByteBuffer.h>
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/MappedFile.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <LibGfx/GIFLoader.h>
@@ -99,7 +99,7 @@ RefPtr<Gfx::Bitmap> load_gif(const StringView& path)
     GIFImageDecoderPlugin gif_decoder((const u8*)mapped_file.data(), mapped_file.size());
     auto bitmap = gif_decoder.bitmap();
     if (bitmap)
-        bitmap->set_mmap_name(String::format("Gfx::Bitmap [%dx%d] - Decoded GIF: %s", bitmap->width(), bitmap->height(), canonicalized_path(path).characters()));
+        bitmap->set_mmap_name(String::format("Gfx::Bitmap [%dx%d] - Decoded GIF: %s", bitmap->width(), bitmap->height(), LexicalPath::canonicalized_path(path).characters()));
     return bitmap;
 }
 
@@ -536,7 +536,7 @@ GIFImageDecoderPlugin::GIFImageDecoderPlugin(const u8* data, size_t size)
     m_context->data_size = size;
 }
 
-GIFImageDecoderPlugin::~GIFImageDecoderPlugin() {}
+GIFImageDecoderPlugin::~GIFImageDecoderPlugin() { }
 
 Size GIFImageDecoderPlugin::size()
 {

--- a/Libraries/LibGfx/PNGLoader.cpp
+++ b/Libraries/LibGfx/PNGLoader.cpp
@@ -25,7 +25,7 @@
  */
 
 #include <AK/ByteBuffer.h>
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/MappedFile.h>
 #include <AK/NetworkOrdered.h>
 #include <LibCore/puff.h>
@@ -193,7 +193,7 @@ RefPtr<Gfx::Bitmap> load_png(const StringView& path)
         return nullptr;
     auto bitmap = load_png_impl((const u8*)mapped_file.data(), mapped_file.size());
     if (bitmap)
-        bitmap->set_mmap_name(String::format("Gfx::Bitmap [%dx%d] - Decoded PNG: %s", bitmap->width(), bitmap->height(), canonicalized_path(path).characters()));
+        bitmap->set_mmap_name(String::format("Gfx::Bitmap [%dx%d] - Decoded PNG: %s", bitmap->width(), bitmap->height(), LexicalPath::canonicalized_path(path).characters()));
     return bitmap;
 }
 

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -28,7 +28,6 @@
 
 #include <AK/BinarySearch.h>
 #include <AK/ByteBuffer.h>
-#include <AK/FileSystemPath.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -26,7 +26,7 @@
 
 #include "TerminalWidget.h"
 #include "XtermColors.h"
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
@@ -843,7 +843,7 @@ void TerminalWidget::context_menu_event(GUI::ContextMenuEvent& event)
         // Then add them to the context menu.
         // FIXME: Adapt this code when we actually support calling LaunchServer with a specific handler in mind.
         for (auto& handler : handlers) {
-            auto af_path = String::format("/res/apps/%s.af", FileSystemPath(handler).basename().characters());
+            auto af_path = String::format("/res/apps/%s.af", LexicalPath(handler).basename().characters());
             auto af = Core::ConfigFile::open(af_path);
             auto handler_name = af->read_entry("App", "Name", handler);
             auto handler_icon = af->read_entry("Icons", "16x16", {});

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/Application.h>

--- a/Libraries/LibWeb/HtmlView.cpp
+++ b/Libraries/LibWeb/HtmlView.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/URL.h>
 #include <LibCore/File.h>
 #include <LibCore/MimeData.h>
@@ -377,7 +377,7 @@ static RefPtr<Document> create_image_document(const ByteBuffer& data, const URL&
     auto title_element = create_element(document, "title");
     head_element->append_child(title_element);
 
-    auto basename = FileSystemPath(url.path()).basename();
+    auto basename = LexicalPath(url.path()).basename();
     auto title_text = adopt(*new Text(document, String::format("%s [%dx%d]", basename.characters(), bitmap->width(), bitmap->height())));
     title_element->append_child(title_text);
 

--- a/Services/LaunchServer/Launcher.cpp
+++ b/Services/LaunchServer/Launcher.cpp
@@ -25,8 +25,8 @@
  */
 
 #include "Launcher.h"
-#include <AK/FileSystemPath.h>
 #include <AK/Function.h>
+#include <AK/LexicalPath.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DirIterator.h>
 #include <stdio.h>
@@ -191,7 +191,7 @@ Vector<String> Launcher::handlers_for_path(const String& path)
     if (S_ISDIR(st.st_mode))
         return { "/bin/FileManager" };
 
-    auto extension = FileSystemPath(path).extension().to_lowercase();
+    auto extension = LexicalPath(path).extension().to_lowercase();
 
     return handlers_for(extension, m_file_handlers, [](auto& handler, auto& key) {
         return handler.file_types.contains(key);

--- a/Services/SystemMenu/main.cpp
+++ b/Services/SystemMenu/main.cpp
@@ -25,7 +25,7 @@
  */
 
 #include "ShutdownDialog.h"
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/QuickSort.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DirIterator.h>
@@ -171,7 +171,7 @@ NonnullRefPtr<GUI::Menu> build_system_menu()
         while (dt.has_next()) {
             auto theme_name = dt.next_path();
             auto theme_path = String::format("/res/themes/%s", theme_name.characters());
-            g_themes.append({ FileSystemPath(theme_name).title(), theme_path });
+            g_themes.append({ LexicalPath(theme_name).title(), theme_path });
         }
         quick_sort(g_themes, [](auto& a, auto& b) { return a.name < b.name; });
     }

--- a/Services/SystemServer/main.cpp
+++ b/Services/SystemServer/main.cpp
@@ -105,7 +105,7 @@ static void mount_all_filesystems()
 
 int main(int, char**)
 {
-    if (pledge("stdio proc exec tty accept unix rpath wpath cpath chown fattr id", nullptr) < 0) {
+    if (pledge("stdio proc exec tty accept unix rpath wpath cpath chown fattr id sigaction", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Services/Taskbar/main.cpp
+++ b/Services/Taskbar/main.cpp
@@ -32,12 +32,17 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio shared_buffer accept proc exec rpath unix cpath fattr", nullptr) < 0) {
+    if (pledge("stdio shared_buffer accept proc exec rpath unix cpath fattr sigaction", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
 
     GUI::Application app(argc, argv);
+
+    signal(SIGCHLD, [](int signo) {
+        (void)signo;
+        wait(nullptr);
+    });
 
     if (pledge("stdio shared_buffer accept proc exec rpath", nullptr) < 0) {
         perror("pledge");
@@ -46,11 +51,6 @@ int main(int argc, char** argv)
 
     TaskbarWindow window;
     window.show();
-
-    signal(SIGCHLD, [](int signo) {
-        (void)signo;
-        wait(nullptr);
-    });
 
     return app.exec();
 }

--- a/Services/WebServer/Client.cpp
+++ b/Services/WebServer/Client.cpp
@@ -25,7 +25,7 @@
  */
 
 #include "Client.h"
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/DirIterator.h>
@@ -82,7 +82,7 @@ void Client::handle_request(ByteBuffer raw_request)
         return;
     }
 
-    auto requested_path = canonicalized_path(request.resource());
+    auto requested_path = LexicalPath::canonicalized_path(request.resource());
     dbg() << "Canonical requested path: '" << requested_path << "'";
 
     StringBuilder path_builder;

--- a/Services/WindowServer/MenuManager.cpp
+++ b/Services/WindowServer/MenuManager.cpp
@@ -26,7 +26,6 @@
  */
 
 #include <AK/Badge.h>
-#include <AK/FileSystemPath.h>
 #include <AK/QuickSort.h>
 #include <LibCore/DirIterator.h>
 #include <LibGfx/Font.h>

--- a/Services/WindowServer/main.cpp
+++ b/Services/WindowServer/main.cpp
@@ -39,7 +39,7 @@
 
 int main(int, char**)
 {
-    if (pledge("stdio video thread shared_buffer accept rpath wpath cpath unix proc fattr", nullptr) < 0) {
+    if (pledge("stdio video thread shared_buffer accept rpath wpath cpath unix proc fattr sigaction", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/basename.cpp
+++ b/Userland/basename.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <stdio.h>
 
 int main(int argc, char** argv)
@@ -38,6 +38,6 @@ int main(int argc, char** argv)
         printf("usage: basename <path>\n");
         return 1;
     }
-    printf("%s\n", FileSystemPath(argv[1]).basename().characters());
+    printf("%s\n", LexicalPath(argv[1]).basename().characters());
     return 0;
 }

--- a/Userland/cp.cpp
+++ b/Userland/cp.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>
@@ -112,7 +112,7 @@ bool copy_file(String src_path, String dst_path, struct stat src_stat, int src_f
         StringBuilder builder;
         builder.append(dst_path);
         builder.append('/');
-        builder.append(FileSystemPath(src_path).basename());
+        builder.append(LexicalPath(src_path).basename());
         dst_path = builder.to_string();
         dst_fd = creat(dst_path.characters(), 0666);
         if (dst_fd < 0) {

--- a/Userland/du.cpp
+++ b/Userland/du.cpp
@@ -25,7 +25,7 @@
  */
 
 #include <AK/ByteBuffer.h>
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
@@ -164,7 +164,7 @@ int print_space_usage(const String& path, const DuOption& du_option, int max_dep
         }
     }
 
-    const auto basename = FileSystemPath(path).basename();
+    const auto basename = LexicalPath(path).basename();
     for (const auto& pattern : du_option.excluded_patterns) {
         if (basename.matches(pattern, CaseSensitivity::CaseSensitive))
             return 0;

--- a/Userland/functrace.cpp
+++ b/Userland/functrace.cpp
@@ -110,7 +110,7 @@ NonnullOwnPtr<HashMap<void*, X86::Instruction>> instrument_code()
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio proc exec rpath", nullptr) < 0) {
+    if (pledge("stdio proc exec rpath sigaction", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/mkdir.cpp
+++ b/Userland/mkdir.cpp
@@ -25,7 +25,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>
 #include <sys/stat.h>
@@ -52,18 +52,18 @@ int main(int argc, char** argv)
     bool has_errors = false;
 
     for (auto& directory : directories) {
-        FileSystemPath canonical_path(directory);
+        LexicalPath lexical_path(directory);
         if (!create_parents) {
-            if (mkdir(canonical_path.string().characters(), mode) < 0) {
+            if (mkdir(lexical_path.string().characters(), mode) < 0) {
                 perror("mkdir");
                 has_errors = true;
             }
             continue;
         }
         StringBuilder path_builder;
-        if (canonical_path.is_absolute())
+        if (lexical_path.is_absolute())
             path_builder.append("/");
-        for (auto& part : canonical_path.parts()) {
+        for (auto& part : lexical_path.parts()) {
             path_builder.append(part);
             auto path = path_builder.build();
             struct stat st;

--- a/Userland/mv.cpp
+++ b/Userland/mv.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
+#include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <LibCore/ArgsParser.h>
 #include <stdio.h>
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
 
     String combined_new_path;
     if (rc == 0 && S_ISDIR(st.st_mode)) {
-        auto old_basename = FileSystemPath(old_path).basename();
+        auto old_basename = LexicalPath(old_path).basename();
         combined_new_path = String::format("%s/%s", new_path, old_basename.characters());
         new_path = combined_new_path.characters();
     }

--- a/Userland/pape.cpp
+++ b/Userland/pape.cpp
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/FileSystemPath.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/Vector.h>

--- a/Userland/sleep.cpp
+++ b/Userland/sleep.cpp
@@ -36,11 +36,6 @@ void handle_sigint(int)
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
-
     int secs;
 
     Core::ArgsParser args_parser;
@@ -51,6 +46,12 @@ int main(int argc, char** argv)
     memset(&sa, 0, sizeof(struct sigaction));
     sa.sa_handler = handle_sigint;
     sigaction(SIGINT, &sa, nullptr);
+
+    if (pledge("stdio", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
     unsigned remaining = sleep(secs);
     if (remaining) {
         printf("Sleep interrupted with %u seconds remaining.\n", remaining);

--- a/Userland/sleep.cpp
+++ b/Userland/sleep.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/String.h>
+#include <LibCore/ArgsParser.h>
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
@@ -41,16 +41,12 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (argc != 2) {
-        printf("usage: sleep <seconds>\n");
-        return 1;
-    }
-    bool ok;
-    unsigned secs = String(argv[1]).to_uint(ok);
-    if (!ok) {
-        fprintf(stderr, "Not a valid number of seconds: \"%s\"\n", argv[1]);
-        return 1;
-    }
+    int secs;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_positional_argument(secs, "Number of seconds to sleep for", "num-seconds");
+    args_parser.parse(argc, argv);
+
     struct sigaction sa;
     memset(&sa, 0, sizeof(struct sigaction));
     sa.sa_handler = handle_sigint;


### PR DESCRIPTION
With this, using `LexicalPath` to canonicalize (local) paths is considered deprecated: please let the kernel deal with it, as it can handle things like symlinks (and other filesystem magic) properly. `LexicalPath` is still useful for things like getting an extension of a file.