### PR TITLE
LibJS+js+Browser: Show "source location hint" on syntax error

### DIFF
--- a/Applications/Browser/ConsoleWidget.cpp
+++ b/Applications/Browser/ConsoleWidget.cpp
@@ -79,15 +79,18 @@ ConsoleWidget::ConsoleWidget()
         auto parser = JS::Parser(JS::Lexer(js_source));
         auto program = parser.parse_program();
 
+        StringBuilder output_html;
         if (parser.has_errors()) {
             auto error = parser.errors()[0];
+            auto hint = error.source_location_hint(js_source);
+            if (!hint.is_empty())
+                output_html.append(String::format("<pre>%s</pre>", hint.characters()));
             m_interpreter->throw_exception<JS::SyntaxError>(error.to_string());
         } else {
             m_interpreter->run(*program);
         }
 
         if (m_interpreter->exception()) {
-            StringBuilder output_html;
             output_html.append("Uncaught exception: ");
             output_html.append(JS::MarkupGenerator::html_from_value(m_interpreter->exception()->value()));
             print_html(output_html.string_view());

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -239,6 +239,7 @@ Value Interpreter::construct(Function& function, Function& new_target, Optional<
 
 Value Interpreter::throw_exception(Exception* exception)
 {
+#ifdef __serenity__
     if (exception->value().is_object() && exception->value().as_object().is_error()) {
         auto& error = static_cast<Error&>(exception->value().as_object());
         dbg() << "Throwing JavaScript Error: " << error.name() << ", " << error.message();
@@ -250,6 +251,7 @@ Value Interpreter::throw_exception(Exception* exception)
             dbg() << "  " << function_name;
         }
     }
+#endif
     m_exception = exception;
     unwind(ScopeType::Try);
     return {};

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -29,6 +29,7 @@
 #include "AST.h"
 #include "Lexer.h"
 #include <AK/NonnullRefPtr.h>
+#include <AK/StringBuilder.h>
 #include <stdio.h>
 
 namespace JS {
@@ -88,6 +89,19 @@ public:
             if (line == 0 || column == 0)
                 return message;
             return String::format("%s (line: %zu, column: %zu)", message.characters(), line, column);
+        }
+
+        String source_location_hint(const StringView& source, const char spacer = ' ', const char indicator = '^') const
+        {
+            if (line == 0 || column == 0)
+                return {};
+            StringBuilder builder;
+            builder.append(source.split_view('\n')[line - 1]);
+            builder.append('\n');
+            for (size_t i = 0; i < column - 1; ++i)
+                builder.append(spacer);
+            builder.append(indicator);
+            return builder.build();
         }
     };
 

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -287,6 +287,9 @@ bool parse_and_run(JS::Interpreter& interpreter, const StringView& source)
 
     if (parser.has_errors()) {
         auto error = parser.errors()[0];
+        auto hint = error.source_location_hint(source);
+        if (!hint.is_empty())
+            printf("%s\n", hint.characters());
         interpreter.throw_exception<JS::SyntaxError>(error.to_string());
     } else {
         interpreter.run(*program);


### PR DESCRIPTION
Disclaimer: I totally made that name up, but I guess that what it is: a hint about the location of the syntax error in the source code :^)

![image](https://user-images.githubusercontent.com/19366641/82900727-dfdb9380-9f54-11ea-991d-56c84060441c.png)


Note: As long as https://github.com/SerenityOS/serenity/issues/2377 is unresolved this *might* of course yield some inaccurate results.