### PR TITLE
LibLine: Core::EventLoop-ification; a few custom property additions to RPC inspections

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -324,6 +324,24 @@ auto Editor::get_line(const String& prompt) -> Result<String, Editor::Error>
     return m_input_error.has_value() ? Result<String, Editor::Error> { m_input_error.value() } : Result<String, Editor::Error> { m_returned_line };
 }
 
+void Editor::save_to(JsonObject& object)
+{
+    Core::Object::save_to(object);
+    object.set("is_searching", m_is_searching);
+    object.set("is_editing", m_is_editing);
+    object.set("cursor_offset", m_cursor);
+    object.set("needs_refresh", m_refresh_needed);
+    object.set("unprocessed_characters", m_incomplete_data.size());
+    object.set("history_size", m_history.size());
+    object.set("current_prompt", m_new_prompt);
+    object.set("was_interrupted", m_was_interrupted);
+    JsonObject display_area;
+    display_area.set("top_left_x", m_origin_x);
+    display_area.set("top_left_y", m_origin_y);
+    display_area.set("line_count", num_lines());
+    object.set("used_display_area", move(display_area));
+}
+
 void Editor::handle_read_event()
 {
     char keybuf[16];

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -165,6 +165,9 @@ public:
 private:
     explicit Editor(Configuration configuration = {});
 
+    // ^Core::Object
+    virtual void save_to(JsonObject&) override;
+
     struct KeyCallback {
         KeyCallback(Function<bool(Editor&)> cb)
             : callback(move(cb))

--- a/Libraries/LibWeb/ResourceLoader.cpp
+++ b/Libraries/LibWeb/ResourceLoader.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/Base64.h>
+#include <AK/JsonObject.h>
 #include <AK/SharedBuffer.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
@@ -155,6 +156,13 @@ bool ResourceLoader::is_port_blocked(int port)
         if (port == blocked_port)
             return true;
     return false;
+}
+
+void ResourceLoader::save_to(JsonObject& object)
+{
+    Object::save_to(object);
+    object.set("pending_loads", m_pending_loads);
+    object.set("user_agent", m_user_agent);
 }
 
 }

--- a/Libraries/LibWeb/ResourceLoader.h
+++ b/Libraries/LibWeb/ResourceLoader.h
@@ -56,6 +56,8 @@ private:
     ResourceLoader();
     static bool is_port_blocked(int port);
 
+    virtual void save_to(JsonObject&) override;
+
     int m_pending_loads { 0 };
 
     RefPtr<Protocol::Client> m_protocol_client;

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -1835,3 +1835,27 @@ void Shell::stop_all_jobs()
         }
     }
 }
+
+void Shell::save_to(JsonObject& object)
+{
+    Core::Object::save_to(object);
+    object.set("working_directory", cwd);
+    object.set("username", username);
+    object.set("user_home_path", home);
+    object.set("user_id", uid);
+    object.set("directory_stack_size", directory_stack.size());
+    object.set("cd_history_size", cd_history.size());
+
+    // Jobs.
+    JsonArray job_objects;
+    for (auto& job_entry : jobs) {
+        JsonObject job_object;
+        job_object.set("pid", job_entry.value->pid());
+        job_object.set("pgid", job_entry.value->pgid());
+        job_object.set("running_time", job_entry.value->timer().elapsed());
+        job_object.set("command", job_entry.value->cmd());
+        job_object.set("is_running_in_background", job_entry.value->is_running_in_background());
+        job_objects.append(move(job_object));
+    }
+    object.set("jobs", move(job_objects));
+}

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -345,6 +345,7 @@ int Shell::builtin_exit(int, const char**)
         }
     }
     stop_all_jobs();
+    save_history();
     printf("Good-bye!\n");
     exit(0);
     return 0;

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -117,6 +117,8 @@ public:
 
     bool is_waiting_for(pid_t pid) const { return m_waiting_for_pid == pid; }
 
+    u64 find_last_job_id() const;
+
     String get_history_path();
     void load_history();
     void save_history();

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -158,6 +158,9 @@ private:
     Shell();
     virtual ~Shell() override;
 
+    // ^Core::Object
+    virtual void save_to(JsonObject&) override;
+
     struct SpawnedProcess {
         String name;
         pid_t pid;

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -115,6 +115,8 @@ public:
     void highlight(Line::Editor&) const;
     Vector<Line::CompletionSuggestion> complete(const Line::Editor&);
 
+    bool is_waiting_for(pid_t pid) const { return m_waiting_for_pid == pid; }
+
     String get_history_path();
     void load_history();
     void save_history();
@@ -187,6 +189,7 @@ private:
     StringBuilder m_complete_line_builder;
     bool m_should_break_current_command { false };
     bool m_should_ignore_jobs_on_next_exit { false };
+    pid_t m_waiting_for_pid { -1 };
 };
 
 static constexpr bool is_word_character(char c)

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -58,7 +58,7 @@ void FileDescriptionCollector::add(int fd)
 int main(int argc, char** argv)
 {
     Core::EventLoop loop;
-    
+
     signal(SIGINT, [](int) {
         editor->interrupted();
     });
@@ -74,6 +74,8 @@ int main(int argc, char** argv)
     signal(SIGCHLD, [](int) {
         auto& jobs = s_shell->jobs;
         for (auto& job : jobs) {
+            if (s_shell->is_waiting_for(job.value->pid()))
+                continue;
             int wstatus = 0;
             auto child_pid = waitpid(job.value->pid(), &wstatus, WNOHANG);
             if (child_pid == job.value->pid()) {

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -65,7 +65,7 @@ private:
 
 static bool s_dump_ast = false;
 static bool s_print_last_result = false;
-static OwnPtr<Line::Editor> s_editor;
+static RefPtr<Line::Editor> s_editor;
 static int s_repl_line_level = 0;
 static bool s_fail_repl = false;
 
@@ -510,7 +510,7 @@ int main(int argc, char** argv)
         if (test_mode)
             enable_test_mode(*interpreter);
 
-        s_editor = make<Line::Editor>();
+        s_editor = Line::Editor::construct();
 
         signal(SIGINT, [](int) {
             if (!s_editor->is_editing())

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -110,10 +110,9 @@ Core::EventLoop loop;
 int run(Function<void(const char*, size_t)> fn)
 {
     if (interactive) {
-        Line::Editor editor;
-        editor.initialize();
+        auto editor = Line::Editor::construct();
         for (;;) {
-            auto line_result = editor.get_line("> ");
+            auto line_result = editor->get_line("> ");
 
             if (line_result.is_error())
                 break;


### PR DESCRIPTION
This PR switches LibLine to a Core::Object and its looping to Core::EventLoop.
Individual characters will still block, but that's much better than blocking for an entire line.

Also adds some inspection properties to LibLine, Shell, and ResourceLoader.

I tried making the Property display widget of Inspector a treeview, but due to the lack of a GUI _thing_ processor in my brain, I couldn't do so (In particular, I found `parent_index` annoying to implement, as we don't have a "JsonPath" or anything similar)