### PR TITLE
Browser: Add option in DownloadWidget to open download's in folder

### DIFF
--- a/Applications/Browser/CMakeLists.txt
+++ b/Applications/Browser/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
 )
 
 serenity_bin(Browser)
-target_link_libraries(Browser LibWeb LibProtocol LibGUI)
+target_link_libraries(Browser LibWeb LibProtocol LibGUI LibDesktop)

--- a/Applications/Browser/DownloadWidget.cpp
+++ b/Applications/Browser/DownloadWidget.cpp
@@ -30,6 +30,7 @@
 #include <AK/StringBuilder.h>
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Label.h>
@@ -162,8 +163,14 @@ void DownloadWidget::did_finish(bool success, const ByteBuffer& payload, RefPtr<
     (void)payload_storage;
     (void)response_headers;
     dbg() << "did_finish, success=" << success;
-    m_cancel_button->set_enabled(false);
+
     m_close_button->set_enabled(true);
+    m_cancel_button->set_text("Open in Folder");
+    m_cancel_button->on_click = [this](auto) {
+        Desktop::Launcher::open(URL::create_with_file_protocol(Core::StandardPaths::downloads_directory()));
+        window()->close();
+    };
+    m_cancel_button->update();
 
     if (!success) {
         GUI::MessageBox::show(String::format("Download failed for some reason"), "Download failed", GUI::MessageBox::Type::Error, GUI::MessageBox::InputType::OK, window());

--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -64,7 +64,8 @@ int main(int argc, char** argv)
     // Connect to the ProtocolServer immediately so we can drop the "unix" pledge.
     Web::ResourceLoader::the();
 
-    if (pledge("stdio shared_buffer accept cpath rpath wpath", nullptr) < 0) {
+    // FIXME: Once there is a standalone Download Manager, we can drop the "unix" pledge.
+    if (pledge("stdio shared_buffer accept unix cpath rpath wpath", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
@@ -80,6 +81,12 @@ int main(int argc, char** argv)
     }
 
     if (unveil("/etc/passwd", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    // FIXME: Once there is a standalone Download Manager, we don't need to unveil this
+    if (unveil("/tmp/portal/launch", "rw") < 0) {
         perror("unveil");
         return 1;
     }


### PR DESCRIPTION
When a download has completed, instead of graying out the cancel option, replace it with an option to open your download in the file manager. Nice and handy!