### PR TITLE
LibJS: fix style inconsistencies in AST.h

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -207,7 +207,8 @@ private:
     virtual const char* class_name() const override { return "FunctionDeclaration"; }
 };
 
-class FunctionExpression final : public Expression
+class FunctionExpression final
+    : public Expression
     , public FunctionNode {
 public:
     static bool must_have_name() { return false; }


### PR DESCRIPTION
Our current configuration clang-format allows both of these styles:
------------------
    class A : B
        , C {
-----------------
    class A
        : B
        , C {
------------------

I was not able to find a setting of clang-format to only allow the
latter style (or disallow the first style), but let's at least be
consistent with the style within a file.