### PR TITLE
CMake: fix cmake toolchain and missing header

### DIFF
--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -1,0 +1,1 @@
+serenity_lib_headers(AK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ include_directories(Services)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/Services)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/Libraries)
 
+add_subdirectory(AK)
 add_subdirectory(Kernel)
 add_subdirectory(Libraries)
 add_subdirectory(Services)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -181,4 +181,6 @@ add_custom_command(
 )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/kernel.map DESTINATION res)
 
+serenity_lib_headers(Kernel)
+
 add_subdirectory(Modules)

--- a/Toolchain/CMakeToolchain.txt
+++ b/Toolchain/CMakeToolchain.txt
@@ -7,10 +7,10 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
 
 # where to read from/write to
-set(CMAKE_SYSROOT $ENV{SERENITY_ROOT}/Root)
-set(CMAKE_STAGING_PREFIX $ENV{SERENITY_ROOT}/Root/usr)
-set(CMAKE_INSTALL_PREFIX $ENV{SERENITY_ROOT}/Root/usr)
-set(CMAKE_INSTALL_DATAROOTDIR $ENV{SERENITY_ROOT}/Root/usr/share)
+set(CMAKE_SYSROOT $ENV{SERENITY_ROOT}/Build/Root)
+set(CMAKE_STAGING_PREFIX $ENV{SERENITY_ROOT}/Build/Root/usr)
+set(CMAKE_INSTALL_PREFIX $ENV{SERENITY_ROOT}/Build/Root/usr)
+set(CMAKE_INSTALL_DATAROOTDIR $ENV{SERENITY_ROOT}/Build/Root/usr/share)
 
 set(CMAKE_C_COMPILER i686-pc-serenity-gcc)
 set(CMAKE_CXX_COMPILER i686-pc-serenity-g++)


### PR DESCRIPTION
- AK and Kernel headers should be installed Root/usr/include
- Toolchain/CMakeToolchain.txt should point to Root/ in the Build/
  directory