### PR TITLE
LibWeb: Fix step within reconstruct the active elements

### DIFF
--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -430,7 +430,7 @@ void HTMLDocumentParser::reconstruct_the_active_formatting_elements()
     RefPtr<Element> entry = m_list_of_active_formatting_elements.at(index);
 
 Rewind:
-    if (m_list_of_active_formatting_elements.size() == 1) {
+    if (index == 0) {
         goto Create;
     }
 


### PR DESCRIPTION
In step 4 of the "renstruct the active formatting elements" algorithm it
says:
  Rewind: If there are no entries before entry in the list of active
  formatting elements, then jump to the step labeled create.

Prior to this patch, the implementation accorded to the spec only for
the first loop iteration.

Disclaimer: Not tested yet in qemu, as I could not yet get the qemu booting the built image on macOS... 