### PR TITLE
LibWeb: Add HTML copyright escape

### DIFF
--- a/Libraries/LibWeb/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLParser.cpp
@@ -229,6 +229,7 @@ static bool parse_html_document(const StringView& html, Document& document, Pare
                     { "&quot;", "\"" },
                     { "&raquo;", ">>" },
                     { "&laquo;", "<<" },
+                    { "&copy;", "\xC2\xA9" },
                 };
                 auto rest_of_html = html.substring_view(i, html.length() - i);
                 bool found = false;


### PR DESCRIPTION
Implements support for the `&copy;` HTML escape.