### PR TITLE
LibWeb: s_initialized should be static in the AttributeNames initialiser

### DIFF
--- a/Libraries/LibWeb/DOM/AttributeNames.cpp
+++ b/Libraries/LibWeb/DOM/AttributeNames.cpp
@@ -35,7 +35,7 @@ FlyString class_;
 
 void initialize()
 {
-    bool s_initialized = false;
+    static bool s_initialized = false;
     if (s_initialized)
         return;
     id = "id";


### PR DESCRIPTION
`s_initialized`(in `Web::HTML::AttributeNames::initialize()`) was not `static`.