### PR TITLE
Meta: Update C++ standard to C++20 in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Nobody is perfect, and sometimes we mess things up. That said, here are some goo
 
 **Do:**
 
-* Write in idiomatic Serenity C++17, using the `AK` containers in all code.
+* Write in idiomatic Serenity C++20, using the `AK` containers in all code.
 * Conform to the project coding style found in [CodingStyle.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Please use `clang-format` (version 10 or later) to automatically format C++ files.
 * Choose expressive variable, function and class names. Make it as obvious as possible what the code is doing.
 * Split your changes into separate, atomic commits.


### PR DESCRIPTION
We are compiling with `-std=c++2a` and we are using some C++20 features, e.g. in `Kernel/VM/Region.h`
```cpp
bool m_shared : 1 { false };
bool m_user_accessible : 1 { false };
bool m_cacheable : 1 { false };
bool m_stack : 1 { false };
bool m_mmap : 1 { false };
```