### PR TITLE
LibJS: Simplify and normalize publicly-exposed Object functions

### DIFF
--- a/Libraries/LibJS/Runtime/Array.cpp
+++ b/Libraries/LibJS/Runtime/Array.cpp
@@ -42,7 +42,7 @@ Array* Array::create(GlobalObject& global_object)
 Array::Array(Object& prototype)
     : Object(&prototype)
 {
-    put_native_property("length", length_getter, length_setter, Attribute::Writable);
+    define_native_property("length", length_getter, length_setter, Attribute::Writable);
 }
 
 Array::~Array()

--- a/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -39,12 +39,12 @@ namespace JS {
 ArrayConstructor::ArrayConstructor()
     : NativeFunction("Array", *interpreter().global_object().function_prototype())
 {
-    put("prototype", interpreter().global_object().array_prototype(), 0);
-    put("length", Value(1), Attribute::Configurable);
+    define_property("prototype", interpreter().global_object().array_prototype(), 0);
+    define_property("length", Value(1), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    put_native_function("isArray", is_array, 1, attr);
-    put_native_function("of", of, 0, attr);
+    define_native_function("isArray", is_array, 1, attr);
+    define_native_function("of", of, 0, attr);
 }
 
 ArrayConstructor::~ArrayConstructor()

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -46,30 +46,30 @@ ArrayPrototype::ArrayPrototype()
 {
     u8 attr = Attribute::Writable | Attribute::Configurable;
 
-    put_native_function("filter", filter, 1, attr);
-    put_native_function("forEach", for_each, 1, attr);
-    put_native_function("map", map, 1, attr);
-    put_native_function("pop", pop, 0, attr);
-    put_native_function("push", push, 1, attr);
-    put_native_function("shift", shift, 0, attr);
-    put_native_function("toString", to_string, 0, attr);
-    put_native_function("unshift", unshift, 1, attr);
-    put_native_function("join", join, 1, attr);
-    put_native_function("concat", concat, 1, attr);
-    put_native_function("slice", slice, 2, attr);
-    put_native_function("indexOf", index_of, 1, attr);
-    put_native_function("reduce", reduce, 1, attr);
-    put_native_function("reduceRight", reduce_right, 1, attr);
-    put_native_function("reverse", reverse, 0, attr);
-    put_native_function("lastIndexOf", last_index_of, 1, attr);
-    put_native_function("includes", includes, 1, attr);
-    put_native_function("find", find, 1, attr);
-    put_native_function("findIndex", find_index, 1, attr);
-    put_native_function("some", some, 1, attr);
-    put_native_function("every", every, 1, attr);
-    put_native_function("splice", splice, 2, attr);
-    put_native_function("fill", fill, 1, attr);
-    put("length", Value(0), Attribute::Configurable);
+    define_native_function("filter", filter, 1, attr);
+    define_native_function("forEach", for_each, 1, attr);
+    define_native_function("map", map, 1, attr);
+    define_native_function("pop", pop, 0, attr);
+    define_native_function("push", push, 1, attr);
+    define_native_function("shift", shift, 0, attr);
+    define_native_function("toString", to_string, 0, attr);
+    define_native_function("unshift", unshift, 1, attr);
+    define_native_function("join", join, 1, attr);
+    define_native_function("concat", concat, 1, attr);
+    define_native_function("slice", slice, 2, attr);
+    define_native_function("indexOf", index_of, 1, attr);
+    define_native_function("reduce", reduce, 1, attr);
+    define_native_function("reduceRight", reduce_right, 1, attr);
+    define_native_function("reverse", reverse, 0, attr);
+    define_native_function("lastIndexOf", last_index_of, 1, attr);
+    define_native_function("includes", includes, 1, attr);
+    define_native_function("find", find, 1, attr);
+    define_native_function("findIndex", find_index, 1, attr);
+    define_native_function("some", some, 1, attr);
+    define_native_function("every", every, 1, attr);
+    define_native_function("splice", splice, 2, attr);
+    define_native_function("fill", fill, 1, attr);
+    define_property("length", Value(0), Attribute::Configurable);
 }
 
 ArrayPrototype::~ArrayPrototype()
@@ -115,7 +115,7 @@ static void for_each_item(Interpreter& interpreter, const String& name, AK::Func
     auto this_value = interpreter.argument(1);
 
     for (size_t i = 0; i < initial_length; ++i) {
-        auto value = this_object->get_by_index(i);
+        auto value = this_object->get(i);
         if (interpreter.exception())
             return;
         if (value.is_empty()) {
@@ -193,7 +193,7 @@ Value ArrayPrototype::push(Interpreter& interpreter)
     if (new_length > MAX_ARRAY_LIKE_INDEX)
         return interpreter.throw_exception<TypeError>("Maximum array size exceeded");
     for (size_t i = 0; i < argument_count; ++i)
-        this_object->put_by_index(length + i, interpreter.argument(i));
+        this_object->put(length + i, interpreter.argument(i));
     auto new_length_value = Value((i32)new_length);
     this_object->put("length", new_length_value);
     if (interpreter.exception())
@@ -228,10 +228,10 @@ Value ArrayPrototype::pop(Interpreter& interpreter)
         return js_undefined();
     }
     auto index = length - 1;
-    auto element = this_object->get_by_index(index).value_or(js_undefined());
+    auto element = this_object->get(index).value_or(js_undefined());
     if (interpreter.exception())
         return {};
-    this_object->delete_property(PropertyName(index));
+    this_object->delete_property(index);
     this_object->put("length", Value((i32)index));
     if (interpreter.exception())
         return {};
@@ -279,7 +279,7 @@ Value ArrayPrototype::join(Interpreter& interpreter)
     for (size_t i = 0; i < length; ++i) {
         if (i > 0)
             builder.append(separator);
-        auto value = this_object->get_by_index(i).value_or(js_undefined());
+        auto value = this_object->get(i).value_or(js_undefined());
         if (interpreter.exception())
             return {};
         if (value.is_undefined() || value.is_null())
@@ -379,7 +379,7 @@ Value ArrayPrototype::index_of(Interpreter& interpreter)
     }
     auto search_element = interpreter.argument(0);
     for (i32 i = from_index; i < length; ++i) {
-        auto element = this_object->get_by_index(i);
+        auto element = this_object->get(i);
         if (interpreter.exception())
             return {};
         if (strict_eq(interpreter, element, search_element))
@@ -410,7 +410,7 @@ Value ArrayPrototype::reduce(Interpreter& interpreter)
     } else {
         bool start_found = false;
         while (!start_found && start < initial_length) {
-            auto value = this_object->get_by_index(start);
+            auto value = this_object->get(start);
             if (interpreter.exception())
                 return {};
             start_found = !value.is_empty();
@@ -427,7 +427,7 @@ Value ArrayPrototype::reduce(Interpreter& interpreter)
     auto this_value = js_undefined();
 
     for (size_t i = start; i < initial_length; ++i) {
-        auto value = this_object->get_by_index(i);
+        auto value = this_object->get(i);
         if (interpreter.exception())
             return {};
         if (value.is_empty())
@@ -469,7 +469,7 @@ Value ArrayPrototype::reduce_right(Interpreter& interpreter)
     } else {
         bool start_found = false;
         while (!start_found && start >= 0) {
-            auto value = this_object->get_by_index(start);
+            auto value = this_object->get(start);
             if (interpreter.exception())
                 return {};
             start_found = !value.is_empty();
@@ -486,7 +486,7 @@ Value ArrayPrototype::reduce_right(Interpreter& interpreter)
     auto this_value = js_undefined();
 
     for (int i = start; i >= 0; --i) {
-        auto value = this_object->get_by_index(i);
+        auto value = this_object->get(i);
         if (interpreter.exception())
             return {};
         if (value.is_empty())
@@ -548,7 +548,7 @@ Value ArrayPrototype::last_index_of(Interpreter& interpreter)
     }
     auto search_element = interpreter.argument(0);
     for (i32 i = from_index; i >= 0; --i) {
-        auto element = this_object->get_by_index(i);
+        auto element = this_object->get(i);
         if (interpreter.exception())
             return {};
         if (strict_eq(interpreter, element, search_element))
@@ -579,7 +579,7 @@ Value ArrayPrototype::includes(Interpreter& interpreter)
     }
     auto value_to_find = interpreter.argument(0);
     for (i32 i = from_index; i < length; ++i) {
-        auto element = this_object->get_by_index(i).value_or(js_undefined());
+        auto element = this_object->get(i).value_or(js_undefined());
         if (interpreter.exception())
             return {};
         if (same_value_zero(interpreter, element, value_to_find))
@@ -687,7 +687,7 @@ Value ArrayPrototype::splice(Interpreter& interpreter)
     auto removed_elements = Array::create(interpreter.global_object());
 
     for (size_t i = 0; i < actual_delete_count; ++i) {
-        auto value = this_object->get_by_index(actual_start + i);
+        auto value = this_object->get(actual_start + i);
         if (interpreter.exception())
             return {};
 
@@ -696,43 +696,43 @@ Value ArrayPrototype::splice(Interpreter& interpreter)
 
     if (insert_count < actual_delete_count) {
         for (size_t i = actual_start; i < initial_length - actual_delete_count; ++i) {
-            auto from = this_object->get_by_index(i + actual_delete_count);
+            auto from = this_object->get(i + actual_delete_count);
             if (interpreter.exception())
                 return {};
 
             auto to = i + insert_count;
 
             if (!from.is_empty()) {
-                this_object->put_by_index(to, from);
+                this_object->put(to, from);
                 if (interpreter.exception())
                     return {};
             }
             else
-                this_object->delete_property(PropertyName(to));
+                this_object->delete_property(to);
         }
 
         for (size_t i = initial_length; i > new_length; --i)
-            this_object->delete_property(PropertyName(i - 1));
+            this_object->delete_property(i - 1);
     } else if (insert_count > actual_delete_count) {
         for (size_t i = initial_length - actual_delete_count; i > actual_start; --i) {
-            auto from = this_object->get_by_index(i + actual_delete_count - 1);
+            auto from = this_object->get(i + actual_delete_count - 1);
             if (interpreter.exception())
                 return {};
 
             auto to = i + insert_count - 1;
 
             if (!from.is_empty()) {
-                this_object->put_by_index(to, from);
+                this_object->put(to, from);
                 if (interpreter.exception())
                     return {};
             }
             else
-                this_object->delete_property(PropertyName(to));
+                this_object->delete_property(to);
         }
     }
 
     for (size_t i = 0; i < insert_count; ++i) {
-        this_object->put_by_index(actual_start + i, interpreter.argument(i + 2));
+        this_object->put(actual_start + i, interpreter.argument(i + 2));
         if (interpreter.exception())
             return {};
     }
@@ -782,7 +782,7 @@ Value ArrayPrototype::fill(Interpreter& interpreter)
         to = min(relative_end, length);
 
     for (size_t i = from; i < to; i++) {
-        this_object->put_by_index(i, interpreter.argument(0));
+        this_object->put(i, interpreter.argument(0));
         if (interpreter.exception())
             return {};
     }

--- a/Libraries/LibJS/Runtime/BooleanConstructor.cpp
+++ b/Libraries/LibJS/Runtime/BooleanConstructor.cpp
@@ -36,8 +36,8 @@ namespace JS {
 BooleanConstructor::BooleanConstructor()
     : NativeFunction("Boolean", *interpreter().global_object().function_prototype())
 {
-    put("prototype", Value(interpreter().global_object().boolean_prototype()), 0);
-    put("length", Value(1), Attribute::Configurable);
+    define_property("prototype", Value(interpreter().global_object().boolean_prototype()), 0);
+    define_property("length", Value(1), Attribute::Configurable);
 }
 
 BooleanConstructor::~BooleanConstructor()

--- a/Libraries/LibJS/Runtime/BooleanPrototype.cpp
+++ b/Libraries/LibJS/Runtime/BooleanPrototype.cpp
@@ -35,8 +35,8 @@ namespace JS {
 BooleanPrototype::BooleanPrototype()
     : BooleanObject(false, *interpreter().global_object().object_prototype())
 {
-    put_native_function("toString", to_string, 0, Attribute::Writable | Attribute::Configurable);
-    put_native_function("valueOf", value_of, 0, Attribute::Writable | Attribute::Configurable);
+    define_native_function("toString", to_string, 0, Attribute::Writable | Attribute::Configurable);
+    define_native_function("valueOf", value_of, 0, Attribute::Writable | Attribute::Configurable);
 }
 
 BooleanPrototype::~BooleanPrototype() { }

--- a/Libraries/LibJS/Runtime/BoundFunction.cpp
+++ b/Libraries/LibJS/Runtime/BoundFunction.cpp
@@ -36,7 +36,7 @@ BoundFunction::BoundFunction(Function& target_function, Value bound_this, Vector
     , m_constructor_prototype(constructor_prototype)
     , m_name(String::format("bound %s", target_function.name().characters()))
 {
-    put("length", Value(length), Attribute::Configurable);
+    define_property("length", Value(length), Attribute::Configurable);
 }
 
 BoundFunction::~BoundFunction()

--- a/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -38,15 +38,15 @@ namespace JS {
 ConsoleObject::ConsoleObject()
     : Object(interpreter().global_object().object_prototype())
 {
-    put_native_function("log", log);
-    put_native_function("debug", debug);
-    put_native_function("info", info);
-    put_native_function("warn", warn);
-    put_native_function("error", error);
-    put_native_function("trace", trace);
-    put_native_function("count", count);
-    put_native_function("countReset", count_reset);
-    put_native_function("clear", clear);
+    define_native_function("log", log);
+    define_native_function("debug", debug);
+    define_native_function("info", info);
+    define_native_function("warn", warn);
+    define_native_function("error", error);
+    define_native_function("trace", trace);
+    define_native_function("count", count);
+    define_native_function("countReset", count_reset);
+    define_native_function("clear", clear);
 }
 
 ConsoleObject::~ConsoleObject()

--- a/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -37,10 +37,10 @@ namespace JS {
 DateConstructor::DateConstructor()
     : NativeFunction("Date", *interpreter().global_object().function_prototype())
 {
-    put("prototype", interpreter().global_object().date_prototype(), 0);
-    put("length", Value(7), Attribute::Configurable);
+    define_property("prototype", interpreter().global_object().date_prototype(), 0);
+    define_property("length", Value(7), Attribute::Configurable);
 
-    put_native_function("now", now, 0, Attribute::Writable | Attribute::Configurable);
+    define_native_function("now", now, 0, Attribute::Writable | Attribute::Configurable);
 }
 
 DateConstructor::~DateConstructor()

--- a/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -52,18 +52,18 @@ DatePrototype::DatePrototype()
     : Object(interpreter().global_object().object_prototype())
 {
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    put_native_function("getDate", get_date, 0, attr);
-    put_native_function("getDay", get_day, 0, attr);
-    put_native_function("getFullYear", get_full_year, 0, attr);
-    put_native_function("getHours", get_hours, 0, attr);
-    put_native_function("getMilliseconds", get_milliseconds, 0, attr);
-    put_native_function("getMinutes", get_minutes, 0, attr);
-    put_native_function("getMonth", get_month, 0, attr);
-    put_native_function("getSeconds", get_seconds, 0, attr);
-    put_native_function("getTime", get_time, 0, attr);
-    put_native_function("toDateString", to_date_string, 0, attr);
-    put_native_function("toTimeString", to_time_string, 0, attr);
-    put_native_function("toString", to_string, 0, attr);
+    define_native_function("getDate", get_date, 0, attr);
+    define_native_function("getDay", get_day, 0, attr);
+    define_native_function("getFullYear", get_full_year, 0, attr);
+    define_native_function("getHours", get_hours, 0, attr);
+    define_native_function("getMilliseconds", get_milliseconds, 0, attr);
+    define_native_function("getMinutes", get_minutes, 0, attr);
+    define_native_function("getMonth", get_month, 0, attr);
+    define_native_function("getSeconds", get_seconds, 0, attr);
+    define_native_function("getTime", get_time, 0, attr);
+    define_native_function("toDateString", to_date_string, 0, attr);
+    define_native_function("toTimeString", to_time_string, 0, attr);
+    define_native_function("toString", to_string, 0, attr);
 }
 
 DatePrototype::~DatePrototype()

--- a/Libraries/LibJS/Runtime/ErrorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ErrorConstructor.cpp
@@ -34,8 +34,8 @@ namespace JS {
 ErrorConstructor::ErrorConstructor()
     : NativeFunction("Error", *interpreter().global_object().function_prototype())
 {
-    put("prototype", interpreter().global_object().error_prototype(), 0);
-    put("length", Value(1), Attribute::Configurable);
+    define_property("prototype", interpreter().global_object().error_prototype(), 0);
+    define_property("length", Value(1), Attribute::Configurable);
 }
 
 ErrorConstructor::~ErrorConstructor()
@@ -62,8 +62,8 @@ Value ErrorConstructor::construct(Interpreter& interpreter)
     ConstructorName::ConstructorName()                                                                                 \
         : NativeFunction(*interpreter().global_object().function_prototype())                                          \
     {                                                                                                                  \
-        put("prototype", interpreter().global_object().snake_name##_prototype(), 0);                                   \
-        put("length", Value(1), Attribute::Configurable);                                                              \
+        define_property("prototype", interpreter().global_object().snake_name##_prototype(), 0);                                   \
+        define_property("length", Value(1), Attribute::Configurable);                                                              \
     }                                                                                                                  \
     ConstructorName::~ConstructorName() { }                                                                            \
     Value ConstructorName::call(Interpreter& interpreter)                                                              \

--- a/Libraries/LibJS/Runtime/ErrorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ErrorPrototype.cpp
@@ -39,9 +39,9 @@ ErrorPrototype::ErrorPrototype()
     : Object(interpreter().global_object().object_prototype())
 {
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    put_native_property("name", name_getter, name_setter, attr);
-    put_native_property("message", message_getter, nullptr, attr);
-    put_native_function("toString", to_string, 0, attr);
+    define_native_property("name", name_getter, name_setter, attr);
+    define_native_property("message", message_getter, nullptr, attr);
+    define_native_function("toString", to_string, 0, attr);
 }
 
 ErrorPrototype::~ErrorPrototype()

--- a/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -38,8 +38,8 @@ namespace JS {
 FunctionConstructor::FunctionConstructor()
     : NativeFunction("Function", *interpreter().global_object().function_prototype())
 {
-    put("prototype", interpreter().global_object().function_prototype(), 0);
-    put("length", Value(1), Attribute::Configurable);
+    define_property("prototype", interpreter().global_object().function_prototype(), 0);
+    define_property("length", Value(1), Attribute::Configurable);
 }
 
 FunctionConstructor::~FunctionConstructor()

--- a/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -46,12 +46,12 @@ FunctionPrototype::FunctionPrototype()
 void FunctionPrototype::initialize()
 {
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    put_native_function("apply", apply, 2, attr);
-    put_native_function("bind", bind, 1, attr);
-    put_native_function("call", call, 1, attr);
-    put_native_function("toString", to_string, 0, attr);
-    put("length", Value(0), Attribute::Configurable);
-    put("name", js_string(heap(), ""), Attribute::Configurable);
+    define_native_function("apply", apply, 2, attr);
+    define_native_function("bind", bind, 1, attr);
+    define_native_function("call", call, 1, attr);
+    define_native_function("toString", to_string, 0, attr);
+    define_property("length", Value(0), Attribute::Configurable);
+    define_property("name", js_string(heap(), ""), Attribute::Configurable);
 }
 
 FunctionPrototype::~FunctionPrototype()
@@ -80,7 +80,7 @@ Value FunctionPrototype::apply(Interpreter& interpreter)
         return {};
     MarkedValueList arguments(interpreter.heap());
     for (size_t i = 0; i < length; ++i) {
-        auto element = arg_array.as_object().get(String::number(i));
+        auto element = arg_array.as_object().get(i);
         if (interpreter.exception())
             return {};
         arguments.append(element.value_or(js_undefined()));

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -82,19 +82,19 @@ void GlobalObject::initialize()
 #undef __JS_ENUMERATE
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    put_native_function("gc", gc, 0, attr);
-    put_native_function("isNaN", is_nan, 1, attr);
-    put_native_function("isFinite", is_finite, 1, attr);
-    put_native_function("parseFloat", parse_float, 1, attr);
+    define_native_function("gc", gc, 0, attr);
+    define_native_function("isNaN", is_nan, 1, attr);
+    define_native_function("isFinite", is_finite, 1, attr);
+    define_native_function("parseFloat", parse_float, 1, attr);
 
-    put("NaN", js_nan(), 0);
-    put("Infinity", js_infinity(), 0);
-    put("undefined", js_undefined(), 0);
+    define_property("NaN", js_nan(), 0);
+    define_property("Infinity", js_infinity(), 0);
+    define_property("undefined", js_undefined(), 0);
 
-    put("globalThis", this, attr);
-    put("console", heap().allocate<ConsoleObject>(), attr);
-    put("Math", heap().allocate<MathObject>(), attr);
-    put("Reflect", heap().allocate<ReflectObject>(), attr);
+    define_property("globalThis", this, attr);
+    define_property("console", heap().allocate<ConsoleObject>(), attr);
+    define_property("Math", heap().allocate<MathObject>(), attr);
+    define_property("Reflect", heap().allocate<ReflectObject>(), attr);
 
     add_constructor("Array", m_array_constructor, *m_array_prototype);
     add_constructor("Boolean", m_boolean_constructor, *m_boolean_prototype);

--- a/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Libraries/LibJS/Runtime/GlobalObject.h
@@ -73,9 +73,9 @@ template<typename ConstructorType>
 inline void GlobalObject::add_constructor(const FlyString& property_name, ConstructorType*& constructor, Object& prototype)
 {
     constructor = heap().allocate<ConstructorType>();
-    constructor->put("name", js_string(heap(), property_name), Attribute::Configurable);
-    prototype.put("constructor", constructor, Attribute::Writable | Attribute::Configurable);
-    put(property_name, constructor, Attribute::Writable | Attribute::Configurable);
+    constructor->define_property("name", js_string(heap(), property_name), Attribute::Configurable);
+    prototype.define_property("constructor", constructor, Attribute::Writable | Attribute::Configurable);
+    define_property(property_name, constructor, Attribute::Writable | Attribute::Configurable);
 }
 
 }

--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -38,32 +38,32 @@ MathObject::MathObject()
     : Object(interpreter().global_object().object_prototype())
 {
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    put_native_function("abs", abs, 1, attr);
-    put_native_function("random", random, 0, attr);
-    put_native_function("sqrt", sqrt, 1, attr);
-    put_native_function("floor", floor, 1, attr);
-    put_native_function("ceil", ceil, 1, attr);
-    put_native_function("round", round, 1, attr);
-    put_native_function("max", max, 2, attr);
-    put_native_function("min", min, 2, attr);
-    put_native_function("trunc", trunc, 1, attr);
-    put_native_function("sin", sin, 1, attr);
-    put_native_function("cos", cos, 1, attr);
-    put_native_function("tan", tan, 1, attr);
-    put_native_function("pow", pow, 2, attr);
-    put_native_function("exp", exp, 1, attr);
-    put_native_function("expm1", expm1, 1, attr);
-    put_native_function("sign", sign, 1, attr);
-    put_native_function("clz32", clz32, 1, attr);
+    define_native_function("abs", abs, 1, attr);
+    define_native_function("random", random, 0, attr);
+    define_native_function("sqrt", sqrt, 1, attr);
+    define_native_function("floor", floor, 1, attr);
+    define_native_function("ceil", ceil, 1, attr);
+    define_native_function("round", round, 1, attr);
+    define_native_function("max", max, 2, attr);
+    define_native_function("min", min, 2, attr);
+    define_native_function("trunc", trunc, 1, attr);
+    define_native_function("sin", sin, 1, attr);
+    define_native_function("cos", cos, 1, attr);
+    define_native_function("tan", tan, 1, attr);
+    define_native_function("pow", pow, 2, attr);
+    define_native_function("exp", exp, 1, attr);
+    define_native_function("expm1", expm1, 1, attr);
+    define_native_function("sign", sign, 1, attr);
+    define_native_function("clz32", clz32, 1, attr);
 
-    put("E", Value(M_E), 0);
-    put("LN2", Value(M_LN2), 0);
-    put("LN10", Value(M_LN10), 0);
-    put("LOG2E", Value(log2(M_E)), 0);
-    put("LOG10E", Value(log10(M_E)), 0);
-    put("PI", Value(M_PI), 0);
-    put("SQRT1_2", Value(M_SQRT1_2), 0);
-    put("SQRT2", Value(M_SQRT2), 0);
+    define_property("E", Value(M_E), 0);
+    define_property("LN2", Value(M_LN2), 0);
+    define_property("LN10", Value(M_LN10), 0);
+    define_property("LOG2E", Value(log2(M_E)), 0);
+    define_property("LOG10E", Value(log10(M_E)), 0);
+    define_property("PI", Value(M_PI), 0);
+    define_property("SQRT1_2", Value(M_SQRT1_2), 0);
+    define_property("SQRT2", Value(M_SQRT2), 0);
 }
 
 MathObject::~MathObject()

--- a/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -41,19 +41,19 @@ NumberConstructor::NumberConstructor()
     : NativeFunction("Number", *interpreter().global_object().function_prototype())
 {
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    put_native_function("isFinite", is_finite, 1, attr);
-    put_native_function("isInteger", is_integer, 1, attr);
-    put_native_function("isNaN", is_nan, 1, attr);
-    put_native_function("isSafeInteger", is_safe_integer, 1, attr);
-    put("parseFloat", interpreter().global_object().get("parseFloat"));
-    put("prototype", interpreter().global_object().number_prototype(), 0);
-    put("length", Value(1), Attribute::Configurable);
-    put("EPSILON", Value(EPSILON), 0);
-    put("MAX_SAFE_INTEGER", Value(MAX_SAFE_INTEGER), 0);
-    put("MIN_SAFE_INTEGER", Value(MIN_SAFE_INTEGER), 0);
-    put("NEGATIVE_INFINITY", js_negative_infinity(), 0);
-    put("POSITIVE_INFINITY", js_infinity(), 0);
-    put("NaN", js_nan(), 0);
+    define_native_function("isFinite", is_finite, 1, attr);
+    define_native_function("isInteger", is_integer, 1, attr);
+    define_native_function("isNaN", is_nan, 1, attr);
+    define_native_function("isSafeInteger", is_safe_integer, 1, attr);
+    define_property("parseFloat", interpreter().global_object().get("parseFloat"));
+    define_property("prototype", interpreter().global_object().number_prototype(), 0);
+    define_property("length", Value(1), Attribute::Configurable);
+    define_property("EPSILON", Value(EPSILON), 0);
+    define_property("MAX_SAFE_INTEGER", Value(MAX_SAFE_INTEGER), 0);
+    define_property("MIN_SAFE_INTEGER", Value(MIN_SAFE_INTEGER), 0);
+    define_property("NEGATIVE_INFINITY", js_negative_infinity(), 0);
+    define_property("POSITIVE_INFINITY", js_infinity(), 0);
+    define_property("NaN", js_nan(), 0);
 }
 
 NumberConstructor::~NumberConstructor()

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -60,25 +60,24 @@ public:
     Shape& shape() { return *m_shape; }
     const Shape& shape() const { return *m_shape; }
 
-    Value delete_property(PropertyName);
-
-    virtual Value get_by_index(i32 property_index) const;
-    Value get(const FlyString& property_name) const;
     Value get(PropertyName) const;
 
-    virtual bool put_by_index(i32 property_index, Value, u8 attributes = default_attributes);
-    bool put(const FlyString& property_name, Value, u8 attributes = default_attributes);
-    bool put(PropertyName, Value, u8 attributes = default_attributes);
+    bool has_property(PropertyName) const;
+    bool has_own_property(PropertyName) const;
 
-    Value get_own_property(const Object& this_object, const FlyString& property_name) const;
-    Value get_own_properties(const Object& this_object, GetOwnPropertyMode, u8 attributes = Attribute::Configurable | Attribute::Enumerable | Attribute::Writable) const;
-    Value get_own_property_descriptor(const FlyString& property_name) const;
+    bool put(PropertyName, Value);
+
+    Value get_own_property(const Object& this_object, PropertyName) const;
+    Value get_own_properties(const Object& this_object, GetOwnPropertyMode, u8 attributes = default_attributes) const;
+    Value get_own_property_descriptor(PropertyName) const;
 
     bool define_property(const FlyString& property_name, const Object& descriptor, bool throw_exceptions = true);
-    bool put_own_property(Object& this_object, const FlyString& property_name, u8 attributes, Value, PutOwnPropertyMode, bool throw_exceptions = true);
+    bool define_property(PropertyName, Value value, u8 attributes = default_attributes, bool throw_exceptions = true);
 
-    bool put_native_function(const FlyString& property_name, AK::Function<Value(Interpreter&)>, i32 length = 0, u8 attribute = default_attributes);
-    bool put_native_property(const FlyString& property_name, AK::Function<Value(Interpreter&)> getter, AK::Function<void(Interpreter&, Value)> setter, u8 attribute = default_attributes);
+    bool define_native_function(const FlyString& property_name, AK::Function<Value(Interpreter&)>, i32 length = 0, u8 attribute = default_attributes);
+    bool define_native_property(const FlyString& property_name, AK::Function<Value(Interpreter&)> getter, AK::Function<void(Interpreter&, Value)> setter, u8 attribute = default_attributes);
+
+    Value delete_property(PropertyName);
 
     virtual bool is_array() const { return false; }
     virtual bool is_boolean() const { return false; }
@@ -99,9 +98,6 @@ public:
     void set_prototype(Object*);
     bool has_prototype(const Object* prototype) const;
 
-    bool has_property(const FlyString& property_name) const;
-    bool has_own_property(const FlyString& property_name) const;
-
     enum class PreferredType {
         Default,
         String,
@@ -118,6 +114,11 @@ public:
     Vector<Value>& elements() { return m_elements; }
 
 private:
+    virtual Value get_by_index(u32 property_index) const;
+    virtual bool put_by_index(u32 property_index, Value);
+    bool put_own_property(Object& this_object, const FlyString& property_name, Value, u8 attributes, PutOwnPropertyMode = PutOwnPropertyMode::Put, bool throw_exceptions = true);
+    bool put_own_property_by_index(Object& this_object, u32 property_index, Value, u8 attributes, PutOwnPropertyMode = PutOwnPropertyMode::Put, bool throw_exceptions = true);
+
     void set_shape(Shape&);
     void ensure_shape_is_unique();
 

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -38,19 +38,19 @@ namespace JS {
 ObjectConstructor::ObjectConstructor()
     : NativeFunction("Object", *interpreter().global_object().function_prototype())
 {
-    put("prototype", interpreter().global_object().object_prototype(), 0);
-    put("length", Value(1), Attribute::Configurable);
+    define_property("prototype", interpreter().global_object().object_prototype(), 0);
+    define_property("length", Value(1), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    put_native_function("defineProperty", define_property, 3, attr);
-    put_native_function("is", is, 2, attr);
-    put_native_function("getOwnPropertyDescriptor", get_own_property_descriptor, 2, attr);
-    put_native_function("getOwnPropertyNames", get_own_property_names, 1, attr);
-    put_native_function("getPrototypeOf", get_prototype_of, 1, attr);
-    put_native_function("setPrototypeOf", set_prototype_of, 2, attr);
-    put_native_function("keys", keys, 1, attr);
-    put_native_function("values", values, 1, attr);
-    put_native_function("entries", entries, 1, attr);
+    define_native_function("defineProperty", define_property_, 3, attr);
+    define_native_function("is", is, 2, attr);
+    define_native_function("getOwnPropertyDescriptor", get_own_property_descriptor, 2, attr);
+    define_native_function("getOwnPropertyNames", get_own_property_names, 1, attr);
+    define_native_function("getPrototypeOf", get_prototype_of, 1, attr);
+    define_native_function("setPrototypeOf", set_prototype_of, 2, attr);
+    define_native_function("keys", keys, 1, attr);
+    define_native_function("values", values, 1, attr);
+    define_native_function("entries", entries, 1, attr);
 }
 
 ObjectConstructor::~ObjectConstructor()
@@ -118,7 +118,7 @@ Value ObjectConstructor::get_own_property_descriptor(Interpreter& interpreter)
     return object->get_own_property_descriptor(property_key);
 }
 
-Value ObjectConstructor::define_property(Interpreter& interpreter)
+Value ObjectConstructor::define_property_(Interpreter& interpreter)
 {
     if (!interpreter.argument(0).is_object())
         return interpreter.throw_exception<TypeError>("Object argument is not an object");

--- a/Libraries/LibJS/Runtime/ObjectConstructor.h
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.h
@@ -42,7 +42,7 @@ private:
     virtual bool has_constructor() const override { return true; }
     virtual const char* class_name() const override { return "ObjectConstructor"; }
 
-    static Value define_property(Interpreter&);
+    static Value define_property_(Interpreter&);
     static Value is(Interpreter&);
     static Value get_own_property_descriptor(Interpreter&);
     static Value get_own_property_names(Interpreter&);

--- a/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -43,9 +43,9 @@ void ObjectPrototype::initialize()
     // This must be called after the constructor has returned, so that the below code
     // can find the ObjectPrototype through normal paths.
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    put_native_function("hasOwnProperty", has_own_property, 1, attr);
-    put_native_function("toString", to_string, 0, attr);
-    put_native_function("valueOf", value_of, 0, attr);
+    define_native_function("hasOwnProperty", has_own_property, 1, attr);
+    define_native_function("toString", to_string, 0, attr);
+    define_native_function("valueOf", value_of, 0, attr);
 }
 
 ObjectPrototype::~ObjectPrototype()

--- a/Libraries/LibJS/Runtime/PropertyName.h
+++ b/Libraries/LibJS/Runtime/PropertyName.h
@@ -40,14 +40,26 @@ public:
 
     PropertyName() {}
 
-    explicit PropertyName(i32 index)
+    PropertyName(i32 index)
         : m_type(Type::Number)
         , m_number(index)
     {
-        ASSERT(m_number >= 0);
+        ASSERT(index >= 0);
     }
 
-    explicit PropertyName(const FlyString& string)
+    PropertyName(const char* chars)
+        : m_type(Type::String)
+        , m_string(FlyString(chars))
+    {
+    }
+
+    PropertyName(const String& string)
+        : m_type(Type::String)
+        , m_string(FlyString(string))
+    {
+    }
+
+    PropertyName(const FlyString& string)
         : m_type(Type::String)
         , m_string(string)
     {
@@ -70,7 +82,7 @@ public:
 private:
     Type m_type { Type::Invalid };
     FlyString m_string;
-    i32 m_number { 0 };
+    u32 m_number { 0 };
 };
 
 }

--- a/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -79,19 +79,19 @@ ReflectObject::ReflectObject()
     : Object(interpreter().global_object().object_prototype())
 {
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    put_native_function("apply", apply, 3, attr);
-    put_native_function("construct", construct, 2, attr);
-    put_native_function("defineProperty", define_property, 3, attr);
-    put_native_function("deleteProperty", delete_property, 2, attr);
-    put_native_function("get", get, 2, attr);
-    put_native_function("getOwnPropertyDescriptor", get_own_property_descriptor, 2, attr);
-    put_native_function("getPrototypeOf", get_prototype_of, 1, attr);
-    put_native_function("has", has, 2, attr);
-    put_native_function("isExtensible", is_extensible, 1, attr);
-    put_native_function("ownKeys", own_keys, 1, attr);
-    put_native_function("preventExtensions", prevent_extensions, 1, attr);
-    put_native_function("set", set, 3, attr);
-    put_native_function("setPrototypeOf", set_prototype_of, 2, attr);
+    define_native_function("apply", apply, 3, attr);
+    define_native_function("construct", construct, 2, attr);
+    define_native_function("defineProperty", define_property, 3, attr);
+    define_native_function("deleteProperty", delete_property, 2, attr);
+    define_native_function("get", get, 2, attr);
+    define_native_function("getOwnPropertyDescriptor", get_own_property_descriptor, 2, attr);
+    define_native_function("getPrototypeOf", get_prototype_of, 1, attr);
+    define_native_function("has", has, 2, attr);
+    define_native_function("isExtensible", is_extensible, 1, attr);
+    define_native_function("ownKeys", own_keys, 1, attr);
+    define_native_function("preventExtensions", prevent_extensions, 1, attr);
+    define_native_function("set", set, 3, attr);
+    define_native_function("setPrototypeOf", set_prototype_of, 2, attr);
 }
 
 ReflectObject::~ReflectObject()

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -60,9 +60,9 @@ ScriptFunction::ScriptFunction(const FlyString& name, const Statement& body, Vec
     , m_parent_environment(parent_environment)
     , m_function_length(m_function_length)
 {
-    put("prototype", Object::create_empty(interpreter(), interpreter().global_object()), 0);
-    put_native_property("length", length_getter, nullptr, Attribute::Configurable);
-    put_native_property("name", name_getter, nullptr, Attribute::Configurable);
+    define_property("prototype", Object::create_empty(interpreter(), interpreter().global_object()), 0);
+    define_native_property("length", length_getter, nullptr, Attribute::Configurable);
+    define_native_property("name", name_getter, nullptr, Attribute::Configurable);
 }
 
 ScriptFunction::~ScriptFunction()

--- a/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -37,10 +37,10 @@ namespace JS {
 StringConstructor::StringConstructor()
     : NativeFunction("String", *interpreter().global_object().function_prototype())
 {
-    put("prototype", interpreter().global_object().string_prototype(), 0);
-    put("length", Value(1), Attribute::Configurable);
+    define_property("prototype", interpreter().global_object().string_prototype(), 0);
+    define_property("length", Value(1), Attribute::Configurable);
 
-    put_native_function("raw", raw, 0, Attribute::Writable | Attribute::Configurable);
+    define_native_function("raw", raw, 0, Attribute::Writable | Attribute::Configurable);
 }
 
 StringConstructor::~StringConstructor()

--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -64,24 +64,24 @@ StringPrototype::StringPrototype()
 {
     u8 attr = Attribute::Writable | Attribute::Configurable;
 
-    put_native_property("length", length_getter, nullptr, 0);
-    put_native_function("charAt", char_at, 1, attr);
-    put_native_function("repeat", repeat, 1, attr);
-    put_native_function("startsWith", starts_with, 1, attr);
-    put_native_function("indexOf", index_of, 1, attr);
-    put_native_function("toLowerCase", to_lowercase, 0, attr);
-    put_native_function("toUpperCase", to_uppercase, 0, attr);
-    put_native_function("toString", to_string, 0, attr);
-    put_native_function("padStart", pad_start, 1, attr);
-    put_native_function("padEnd", pad_end, 1, attr);
-    put_native_function("trim", trim, 0, attr);
-    put_native_function("trimStart", trim_start, 0, attr);
-    put_native_function("trimEnd", trim_end, 0, attr);
-    put_native_function("concat", concat, 1, attr);
-    put_native_function("substring", substring, 2, attr);
-    put_native_function("includes", includes, 1, attr);
-    put_native_function("slice", slice, 2, attr);
-    put_native_function("lastIndexOf", last_index_of, 1, attr);
+    define_native_property("length", length_getter, nullptr, 0);
+    define_native_function("charAt", char_at, 1, attr);
+    define_native_function("repeat", repeat, 1, attr);
+    define_native_function("startsWith", starts_with, 1, attr);
+    define_native_function("indexOf", index_of, 1, attr);
+    define_native_function("toLowerCase", to_lowercase, 0, attr);
+    define_native_function("toUpperCase", to_uppercase, 0, attr);
+    define_native_function("toString", to_string, 0, attr);
+    define_native_function("padStart", pad_start, 1, attr);
+    define_native_function("padEnd", pad_end, 1, attr);
+    define_native_function("trim", trim, 0, attr);
+    define_native_function("trimStart", trim_start, 0, attr);
+    define_native_function("trimEnd", trim_end, 0, attr);
+    define_native_function("concat", concat, 1, attr);
+    define_native_function("substring", substring, 2, attr);
+    define_native_function("includes", includes, 1, attr);
+    define_native_function("slice", slice, 2, attr);
+    define_native_function("lastIndexOf", last_index_of, 1, attr);
 }
 
 StringPrototype::~StringPrototype()

--- a/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -35,27 +35,27 @@ namespace JS {
 SymbolConstructor::SymbolConstructor()
     : NativeFunction("Symbol", *interpreter().global_object().function_prototype())
 {
-    put("prototype", interpreter().global_object().symbol_prototype(), 0);
-    put("length", Value(0), Attribute::Configurable);
+    define_property("prototype", interpreter().global_object().symbol_prototype(), 0);
+    define_property("length", Value(0), Attribute::Configurable);
 
-    put_native_function("for", for_, 1, Attribute::Writable | Attribute::Configurable);
-    put_native_function("keyFor", key_for, 1, Attribute::Writable | Attribute::Configurable);
+    define_native_function("for", for_, 1, Attribute::Writable | Attribute::Configurable);
+    define_native_function("keyFor", key_for, 1, Attribute::Writable | Attribute::Configurable);
 
     SymbolObject::initialize_well_known_symbols(interpreter());
 
-    put("iterator", SymbolObject::well_known_iterator(), 0);
-    put("asyncIterator", SymbolObject::well_known_async_terator(), 0);
-    put("match", SymbolObject::well_known_match(), 0);
-    put("matchAll", SymbolObject::well_known_match_all(), 0);
-    put("replace", SymbolObject::well_known_replace(), 0);
-    put("search", SymbolObject::well_known_search(), 0);
-    put("split", SymbolObject::well_known_split(), 0);
-    put("hasInstance", SymbolObject::well_known_has_instance(), 0);
-    put("isConcatSpreadable", SymbolObject::well_known_is_concat_spreadable(), 0);
-    put("unscopables", SymbolObject::well_known_unscopables(), 0);
-    put("species", SymbolObject::well_known_species(), 0);
-    put("toPrimitive", SymbolObject::well_known_to_primtive(), 0);
-    put("toStringTag", SymbolObject::well_known_to_string_tag(), 0);
+    define_property("iterator", SymbolObject::well_known_iterator(), 0);
+    define_property("asyncIterator", SymbolObject::well_known_async_terator(), 0);
+    define_property("match", SymbolObject::well_known_match(), 0);
+    define_property("matchAll", SymbolObject::well_known_match_all(), 0);
+    define_property("replace", SymbolObject::well_known_replace(), 0);
+    define_property("search", SymbolObject::well_known_search(), 0);
+    define_property("split", SymbolObject::well_known_split(), 0);
+    define_property("hasInstance", SymbolObject::well_known_has_instance(), 0);
+    define_property("isConcatSpreadable", SymbolObject::well_known_is_concat_spreadable(), 0);
+    define_property("unscopables", SymbolObject::well_known_unscopables(), 0);
+    define_property("species", SymbolObject::well_known_species(), 0);
+    define_property("toPrimitive", SymbolObject::well_known_to_primtive(), 0);
+    define_property("toStringTag", SymbolObject::well_known_to_string_tag(), 0);
 }
 
 SymbolConstructor::~SymbolConstructor()

--- a/Libraries/LibJS/Runtime/SymbolPrototype.cpp
+++ b/Libraries/LibJS/Runtime/SymbolPrototype.cpp
@@ -42,10 +42,10 @@ namespace JS {
 SymbolPrototype::SymbolPrototype()
     : Object(interpreter().global_object().object_prototype())
 {
-    put_native_property("description", description_getter, nullptr, Attribute::Configurable);
+    define_native_property("description", description_getter, nullptr, Attribute::Configurable);
 
-    put_native_function("toString", to_string, 0, Attribute::Writable | Attribute::Configurable);
-    put_native_function("valueOf", value_of, 0, Attribute::Writable | Attribute::Configurable);
+    define_native_function("toString", to_string, 0, Attribute::Writable | Attribute::Configurable);
+    define_native_function("valueOf", value_of, 0, Attribute::Writable | Attribute::Configurable);
 }
 
 SymbolPrototype::~SymbolPrototype()

--- a/Libraries/LibJS/Runtime/Uint8ClampedArray.cpp
+++ b/Libraries/LibJS/Runtime/Uint8ClampedArray.cpp
@@ -32,19 +32,17 @@
 
 namespace JS {
 
-Uint8ClampedArray* Uint8ClampedArray::create(GlobalObject& global_object, i32 length)
+Uint8ClampedArray* Uint8ClampedArray::create(GlobalObject& global_object, u32 length)
 {
-    ASSERT(length >= 0);
     auto& interpreter = global_object.interpreter();
     return interpreter.heap().allocate<Uint8ClampedArray>(length, *global_object.array_prototype());
 }
 
-Uint8ClampedArray::Uint8ClampedArray(i32 length, Object& prototype)
+Uint8ClampedArray::Uint8ClampedArray(u32 length, Object& prototype)
     : Object(&prototype)
     , m_length(length)
 {
-    ASSERT(m_length >= 0);
-    put_native_property("length", length_getter, nullptr);
+    define_native_property("length", length_getter, nullptr);
     m_data = new u8[m_length];
 }
 
@@ -65,10 +63,9 @@ Value Uint8ClampedArray::length_getter(Interpreter& interpreter)
     return Value(static_cast<const Uint8ClampedArray*>(this_object)->length());
 }
 
-bool Uint8ClampedArray::put_by_index(i32 property_index, Value value, u8)
+bool Uint8ClampedArray::put_by_index(u32 property_index, Value value)
 {
     // FIXME: Use attributes
-    ASSERT(property_index >= 0);
     ASSERT(property_index < m_length);
     auto number = value.to_i32(interpreter());
     if (interpreter().exception())
@@ -77,9 +74,8 @@ bool Uint8ClampedArray::put_by_index(i32 property_index, Value value, u8)
     return true;
 }
 
-Value Uint8ClampedArray::get_by_index(i32 property_index) const
+Value Uint8ClampedArray::get_by_index(u32 property_index) const
 {
-    ASSERT(property_index >= 0);
     ASSERT(property_index < m_length);
     return Value((i32)m_data[property_index]);
 }

--- a/Libraries/LibJS/Runtime/Uint8ClampedArray.h
+++ b/Libraries/LibJS/Runtime/Uint8ClampedArray.h
@@ -32,15 +32,15 @@ namespace JS {
 
 class Uint8ClampedArray final : public Object {
 public:
-    static Uint8ClampedArray* create(GlobalObject&, i32 length);
+    static Uint8ClampedArray* create(GlobalObject&, u32 length);
 
-    Uint8ClampedArray(i32 length, Object& prototype);
+    Uint8ClampedArray(u32 length, Object& prototype);
     virtual ~Uint8ClampedArray() override;
 
     i32 length() const { return m_length; }
 
-    virtual bool put_by_index(i32 property_index, Value value, u8 attribute = default_attributes) override;
-    virtual Value get_by_index(i32 property_index) const override;
+    virtual bool put_by_index(u32 property_index, Value value) override;
+    virtual Value get_by_index(u32 property_index) const override;
 
     u8* data() { return m_data; }
     const u8* data() const { return m_data; }
@@ -52,7 +52,7 @@ private:
     static Value length_getter(Interpreter&);
 
     u8* m_data { nullptr };
-    i32 m_length { 0 };
+    u32 m_length { 0 };
 };
 
 }

--- a/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/CanvasRenderingContext2DWrapper.cpp
@@ -51,25 +51,25 @@ CanvasRenderingContext2DWrapper::CanvasRenderingContext2DWrapper(CanvasRendering
     : Wrapper(*interpreter().global_object().object_prototype())
     , m_impl(impl)
 {
-    put_native_function("fillRect", fill_rect, 4);
-    put_native_function("scale", scale, 2);
-    put_native_function("translate", translate, 2);
-    put_native_function("strokeRect", stroke_rect, 4);
-    put_native_function("drawImage", draw_image, 3);
-    put_native_function("beginPath", begin_path, 0);
-    put_native_function("closePath", close_path, 0);
-    put_native_function("stroke", stroke, 0);
-    put_native_function("fill", fill, 0);
-    put_native_function("moveTo", move_to, 2);
-    put_native_function("lineTo", line_to, 2);
-    put_native_function("quadraticCurveTo", quadratic_curve_to, 4);
-    put_native_function("createImageData", create_image_data, 1);
-    put_native_function("putImageData", put_image_data, 3);
+    define_native_function("fillRect", fill_rect, 4);
+    define_native_function("scale", scale, 2);
+    define_native_function("translate", translate, 2);
+    define_native_function("strokeRect", stroke_rect, 4);
+    define_native_function("drawImage", draw_image, 3);
+    define_native_function("beginPath", begin_path, 0);
+    define_native_function("closePath", close_path, 0);
+    define_native_function("stroke", stroke, 0);
+    define_native_function("fill", fill, 0);
+    define_native_function("moveTo", move_to, 2);
+    define_native_function("lineTo", line_to, 2);
+    define_native_function("quadraticCurveTo", quadratic_curve_to, 4);
+    define_native_function("createImageData", create_image_data, 1);
+    define_native_function("putImageData", put_image_data, 3);
 
-    put_native_property("fillStyle", fill_style_getter, fill_style_setter);
-    put_native_property("strokeStyle", stroke_style_getter, stroke_style_setter);
-    put_native_property("lineWidth", line_width_getter, line_width_setter);
-    put_native_property("canvas", canvas_getter, nullptr);
+    define_native_property("fillStyle", fill_style_getter, fill_style_setter);
+    define_native_property("strokeStyle", stroke_style_getter, stroke_style_setter);
+    define_native_property("lineWidth", line_width_getter, line_width_setter);
+    define_native_property("canvas", canvas_getter, nullptr);
 }
 
 CanvasRenderingContext2DWrapper::~CanvasRenderingContext2DWrapper()

--- a/Libraries/LibWeb/Bindings/DocumentWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/DocumentWrapper.cpp
@@ -40,9 +40,9 @@ namespace Bindings {
 DocumentWrapper::DocumentWrapper(Document& document)
     : NodeWrapper(document)
 {
-    put_native_function("getElementById", get_element_by_id, 1);
-    put_native_function("querySelector", query_selector, 1);
-    put_native_function("querySelectorAll", query_selector_all, 1);
+    define_native_function("getElementById", get_element_by_id, 1);
+    define_native_function("querySelector", query_selector, 1);
+    define_native_function("querySelectorAll", query_selector_all, 1);
 }
 
 DocumentWrapper::~DocumentWrapper()

--- a/Libraries/LibWeb/Bindings/ElementWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/ElementWrapper.cpp
@@ -40,12 +40,12 @@ namespace Bindings {
 ElementWrapper::ElementWrapper(Element& element)
     : NodeWrapper(element)
 {
-    put_native_property("innerHTML", inner_html_getter, inner_html_setter);
-    put_native_property("id", id_getter, id_setter);
+    define_native_property("innerHTML", inner_html_getter, inner_html_setter);
+    define_native_property("id", id_getter, id_setter);
 
     u8 attributes = JS::Attribute::Configurable | JS::Attribute::Enumerable | JS::Attribute::Writable;
-    put_native_function("getAttribute", get_attribute, 1, attributes);
-    put_native_function("setAttribute", set_attribute, 2, attributes);
+    define_native_function("getAttribute", get_attribute, 1, attributes);
+    define_native_function("setAttribute", set_attribute, 2, attributes);
 }
 
 ElementWrapper::~ElementWrapper()

--- a/Libraries/LibWeb/Bindings/EventTargetWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/EventTargetWrapper.cpp
@@ -42,7 +42,7 @@ EventTargetWrapper::EventTargetWrapper(EventTarget& impl)
     : Wrapper(*interpreter().global_object().object_prototype())
     , m_impl(impl)
 {
-    put_native_function("addEventListener", add_event_listener, 2);
+    define_native_function("addEventListener", add_event_listener, 2);
 }
 
 EventTargetWrapper::~EventTargetWrapper()

--- a/Libraries/LibWeb/Bindings/HTMLCanvasElementWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/HTMLCanvasElementWrapper.cpp
@@ -40,10 +40,10 @@ namespace Bindings {
 HTMLCanvasElementWrapper::HTMLCanvasElementWrapper(HTMLCanvasElement& element)
     : ElementWrapper(element)
 {
-    put_native_function("getContext", get_context, 1);
+    define_native_function("getContext", get_context, 1);
 
-    put_native_property("width", width_getter, nullptr);
-    put_native_property("height", height_getter, nullptr);
+    define_native_property("width", width_getter, nullptr);
+    define_native_property("height", height_getter, nullptr);
 }
 
 HTMLCanvasElementWrapper::~HTMLCanvasElementWrapper()

--- a/Libraries/LibWeb/Bindings/ImageDataWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/ImageDataWrapper.cpp
@@ -44,9 +44,9 @@ ImageDataWrapper::ImageDataWrapper(ImageData& impl)
     : Wrapper(*interpreter().global_object().object_prototype())
     , m_impl(impl)
 {
-    put_native_property("width", width_getter, nullptr);
-    put_native_property("height", height_getter, nullptr);
-    put_native_property("data", data_getter, nullptr);
+    define_native_property("width", width_getter, nullptr);
+    define_native_property("height", height_getter, nullptr);
+    define_native_property("data", data_getter, nullptr);
 }
 
 ImageDataWrapper::~ImageDataWrapper()

--- a/Libraries/LibWeb/Bindings/LocationObject.cpp
+++ b/Libraries/LibWeb/Bindings/LocationObject.cpp
@@ -39,15 +39,15 @@ LocationObject::LocationObject()
     : Object(interpreter().global_object().object_prototype())
 {
     u8 attr = JS::Attribute::Writable | JS::Attribute::Enumerable;
-    put_native_property("href", href_getter, href_setter, attr);
-    put_native_property("host", host_getter, nullptr, attr);
-    put_native_property("hostname", hostname_getter, nullptr, attr);
-    put_native_property("pathname", pathname_getter, nullptr, attr);
-    put_native_property("hash", hash_getter, nullptr, attr);
-    put_native_property("search", search_getter, nullptr, attr);
-    put_native_property("protocol", protocol_getter, nullptr, attr);
+    define_native_property("href", href_getter, href_setter, attr);
+    define_native_property("host", host_getter, nullptr, attr);
+    define_native_property("hostname", hostname_getter, nullptr, attr);
+    define_native_property("pathname", pathname_getter, nullptr, attr);
+    define_native_property("hash", hash_getter, nullptr, attr);
+    define_native_property("search", search_getter, nullptr, attr);
+    define_native_property("protocol", protocol_getter, nullptr, attr);
 
-    put_native_function("reload", reload, JS::Attribute::Enumerable);
+    define_native_function("reload", reload, JS::Attribute::Enumerable);
 }
 
 LocationObject::~LocationObject()

--- a/Libraries/LibWeb/Bindings/MouseEventWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/MouseEventWrapper.cpp
@@ -37,8 +37,8 @@ namespace Bindings {
 MouseEventWrapper::MouseEventWrapper(MouseEvent& event)
     : EventWrapper(event)
 {
-    put_native_property("offsetX", offset_x_getter, nullptr);
-    put_native_property("offsetY", offset_y_getter, nullptr);
+    define_native_property("offsetX", offset_x_getter, nullptr);
+    define_native_property("offsetY", offset_y_getter, nullptr);
 }
 
 MouseEventWrapper::~MouseEventWrapper()

--- a/Libraries/LibWeb/Bindings/NavigatorObject.cpp
+++ b/Libraries/LibWeb/Bindings/NavigatorObject.cpp
@@ -40,15 +40,15 @@ NavigatorObject::NavigatorObject()
     auto* languages = JS::Array::create(interpreter().global_object());
     languages->elements().append(js_string(heap(), "en-US"));
 
-    put("appCodeName", js_string(heap(), "Mozilla"));
-    put("appName", js_string(heap(), "Netscape"));
-    put("appVersion", js_string(heap(), "4.0"));
-    put("language", languages->elements().first());
-    put("languages", languages);
-    put("platform", js_string(heap(), "SerenityOS"));
-    put("product", js_string(heap(), "Gecko"));
+    define_property("appCodeName", js_string(heap(), "Mozilla"));
+    define_property("appName", js_string(heap(), "Netscape"));
+    define_property("appVersion", js_string(heap(), "4.0"));
+    define_property("language", languages->elements().first());
+    define_property("languages", languages);
+    define_property("platform", js_string(heap(), "SerenityOS"));
+    define_property("product", js_string(heap(), "Gecko"));
 
-    put_native_property("userAgent", user_agent_getter, nullptr);
+    define_native_property("userAgent", user_agent_getter, nullptr);
 }
 
 NavigatorObject::~NavigatorObject()

--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -51,21 +51,21 @@ void WindowObject::initialize()
 {
     GlobalObject::initialize();
 
-    put("window", this, JS::Attribute::Enumerable);
-    put_native_property("document", document_getter, document_setter, JS::Attribute::Enumerable);
-    put_native_function("alert", alert);
-    put_native_function("confirm", confirm);
-    put_native_function("setInterval", set_interval, 1);
-    put_native_function("setTimeout", set_timeout, 1);
-    put_native_function("requestAnimationFrame", request_animation_frame, 1);
-    put_native_function("cancelAnimationFrame", cancel_animation_frame, 1);
+    define_property("window", this, JS::Attribute::Enumerable);
+    define_native_property("document", document_getter, document_setter, JS::Attribute::Enumerable);
+    define_native_function("alert", alert);
+    define_native_function("confirm", confirm);
+    define_native_function("setInterval", set_interval, 1);
+    define_native_function("setTimeout", set_timeout, 1);
+    define_native_function("requestAnimationFrame", request_animation_frame, 1);
+    define_native_function("cancelAnimationFrame", cancel_animation_frame, 1);
 
-    put("navigator", heap().allocate<NavigatorObject>(), JS::Attribute::Enumerable | JS::Attribute::Configurable);
-    put("location", heap().allocate<LocationObject>(), JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_property("navigator", heap().allocate<NavigatorObject>(), JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_property("location", heap().allocate<LocationObject>(), JS::Attribute::Enumerable | JS::Attribute::Configurable);
 
     m_xhr_prototype = heap().allocate<XMLHttpRequestPrototype>();
     m_xhr_constructor = heap().allocate<XMLHttpRequestConstructor>();
-    m_xhr_constructor->put("prototype", m_xhr_prototype, 0);
+    m_xhr_constructor->define_property("prototype", m_xhr_prototype, 0);
     add_constructor("XMLHttpRequest", m_xhr_constructor, *m_xhr_prototype);
 }
 

--- a/Libraries/LibWeb/Bindings/XMLHttpRequestConstructor.cpp
+++ b/Libraries/LibWeb/Bindings/XMLHttpRequestConstructor.cpp
@@ -39,13 +39,13 @@ namespace Bindings {
 XMLHttpRequestConstructor::XMLHttpRequestConstructor()
     : NativeFunction(*interpreter().global_object().function_prototype())
 {
-    put("length", JS::Value(1), JS::Attribute::Configurable);
+    define_property("length", JS::Value(1), JS::Attribute::Configurable);
 
-    put("UNSENT", JS::Value((i32)XMLHttpRequest::ReadyState::Unsent), JS::Attribute::Enumerable);
-    put("OPENED", JS::Value((i32)XMLHttpRequest::ReadyState::Opened), JS::Attribute::Enumerable);
-    put("HEADERS_RECEIVED", JS::Value((i32)XMLHttpRequest::ReadyState::HeadersReceived), JS::Attribute::Enumerable);
-    put("LOADING", JS::Value((i32)XMLHttpRequest::ReadyState::Loading), JS::Attribute::Enumerable);
-    put("DONE", JS::Value((i32)XMLHttpRequest::ReadyState::Done), JS::Attribute::Enumerable);
+    define_property("UNSENT", JS::Value((i32)XMLHttpRequest::ReadyState::Unsent), JS::Attribute::Enumerable);
+    define_property("OPENED", JS::Value((i32)XMLHttpRequest::ReadyState::Opened), JS::Attribute::Enumerable);
+    define_property("HEADERS_RECEIVED", JS::Value((i32)XMLHttpRequest::ReadyState::HeadersReceived), JS::Attribute::Enumerable);
+    define_property("LOADING", JS::Value((i32)XMLHttpRequest::ReadyState::Loading), JS::Attribute::Enumerable);
+    define_property("DONE", JS::Value((i32)XMLHttpRequest::ReadyState::Done), JS::Attribute::Enumerable);
 }
 
 XMLHttpRequestConstructor::~XMLHttpRequestConstructor()

--- a/Libraries/LibWeb/Bindings/XMLHttpRequestPrototype.cpp
+++ b/Libraries/LibWeb/Bindings/XMLHttpRequestPrototype.cpp
@@ -38,16 +38,16 @@ namespace Bindings {
 XMLHttpRequestPrototype::XMLHttpRequestPrototype()
     : Object(interpreter().global_object().object_prototype())
 {
-    put_native_function("open", open, 2);
-    put_native_function("send", send, 0);
-    put_native_property("readyState", ready_state_getter, nullptr, JS::Attribute::Enumerable | JS::Attribute::Configurable);
-    put_native_property("responseText", response_text_getter, nullptr, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_function("open", open, 2);
+    define_native_function("send", send, 0);
+    define_native_property("readyState", ready_state_getter, nullptr, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_property("responseText", response_text_getter, nullptr, JS::Attribute::Enumerable | JS::Attribute::Configurable);
 
-    put("UNSENT", JS::Value((i32)XMLHttpRequest::ReadyState::Unsent), JS::Attribute::Enumerable);
-    put("OPENED", JS::Value((i32)XMLHttpRequest::ReadyState::Opened), JS::Attribute::Enumerable);
-    put("HEADERS_RECEIVED", JS::Value((i32)XMLHttpRequest::ReadyState::HeadersReceived), JS::Attribute::Enumerable);
-    put("LOADING", JS::Value((i32)XMLHttpRequest::ReadyState::Loading), JS::Attribute::Enumerable);
-    put("DONE", JS::Value((i32)XMLHttpRequest::ReadyState::Done), JS::Attribute::Enumerable);
+    define_property("UNSENT", JS::Value((i32)XMLHttpRequest::ReadyState::Unsent), JS::Attribute::Enumerable);
+    define_property("OPENED", JS::Value((i32)XMLHttpRequest::ReadyState::Opened), JS::Attribute::Enumerable);
+    define_property("HEADERS_RECEIVED", JS::Value((i32)XMLHttpRequest::ReadyState::HeadersReceived), JS::Attribute::Enumerable);
+    define_property("LOADING", JS::Value((i32)XMLHttpRequest::ReadyState::Loading), JS::Attribute::Enumerable);
+    define_property("DONE", JS::Value((i32)XMLHttpRequest::ReadyState::Done), JS::Attribute::Enumerable);
 }
 
 XMLHttpRequestPrototype::~XMLHttpRequestPrototype()

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -313,10 +313,10 @@ ReplObject::ReplObject()
 void ReplObject::initialize()
 {
     GlobalObject::initialize();
-    put_native_function("exit", exit_interpreter);
-    put_native_function("help", repl_help);
-    put_native_function("load", load_file, 1);
-    put_native_function("save", save_to_file, 1);
+    define_native_function("exit", exit_interpreter);
+    define_native_function("help", repl_help);
+    define_native_function("load", load_file, 1);
+    define_native_function("save", save_to_file, 1);
 }
 
 ReplObject::~ReplObject()
@@ -391,7 +391,7 @@ void repl(JS::Interpreter& interpreter)
 
 void enable_test_mode(JS::Interpreter& interpreter)
 {
-    interpreter.global_object().put_native_function("load", ReplObject::load_file);
+    interpreter.global_object().define_native_function("load", ReplObject::load_file);
 }
 
 static Function<void()> interrupt_interpreter;
@@ -751,7 +751,7 @@ int main(int argc, char** argv)
             case CompleteProperty: {
                 auto maybe_variable = interpreter->get_variable(variable_name);
                 if (maybe_variable.is_empty()) {
-                    maybe_variable = interpreter->global_object().get(variable_name);
+                    maybe_variable = interpreter->global_object().get(FlyString(variable_name));
                     if (maybe_variable.is_empty())
                         break;
                 }


### PR DESCRIPTION
Previously, the `Object` class had many different types of functions for each action. For example: `get_by_index`, `get(PropertyName)`, and `get(FlyString)`. This is a bit verbose, so these methods have been shortened to simply use the `PropertyName` structure. The methods then internally call `_by_index` if necessary. Note that the `_by_index` methods have been made private to enforce this change.

Secondly, a clear distinction has been made between "putting" and "defining" an object property. "Putting" should mean modifying a (potentially) already existing property. This is akin to doing `a.b = 'foo'`.

This implies two things about put operations:

- They will search the prototype chain for setters and call them, if necessary.
- If no property exists with a particular key, the put operation should create a new property with the default attributes (configurable, writable, and enumerable).

In contrast, "defining" a property should completely overwrite any existing value without calling setters (if that property is configurable, of course).

Thus, all of the many JS objects have had any relevant `put` calls changed to `define_property` calls. Additionally, `put_native_function` and `put_native_property` have had their `put` replaced with `define`.

Finally, `put_own_property` has been made private, as all necessary functionality should be exposed with the `put` and `define_property` methods.

This is progress towards the implementation of #2330. Allowing all public methods to deal with `PropertyName` allows the easy integration of numeric properties in a future PR.