### PR TITLE
LibJS: Object index properties have descriptors; Handle sparse indices

### DIFF
--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
     Runtime/Function.cpp
     Runtime/FunctionPrototype.cpp
     Runtime/GlobalObject.cpp
+    Runtime/IndexedProperties.cpp
     Runtime/LexicalEnvironment.cpp
     Runtime/MarkedValueList.cpp
     Runtime/MathObject.cpp

--- a/Libraries/LibJS/Runtime/Accessor.h
+++ b/Libraries/LibJS/Runtime/Accessor.h
@@ -27,7 +27,9 @@
 
 #pragma once
 
+#include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Function.h>
+#include <LibJS/Runtime/MarkedValueList.h>
 
 namespace JS {
 

--- a/Libraries/LibJS/Runtime/Array.cpp
+++ b/Libraries/LibJS/Runtime/Array.cpp
@@ -66,7 +66,7 @@ Value Array::length_getter(Interpreter& interpreter)
     auto* array = array_from(interpreter);
     if (!array)
         return {};
-    return Value(array->length());
+    return Value(static_cast<i32>(array->indexed_properties().array_like_size()));
 }
 
 void Array::length_setter(Interpreter& interpreter, Value value)
@@ -81,7 +81,7 @@ void Array::length_setter(Interpreter& interpreter, Value value)
         interpreter.throw_exception<RangeError>("Invalid array length");
         return;
     }
-    array->elements().resize(length.as_double());
+    array->indexed_properties().set_array_like_size(length.as_double());
 }
 
 }

--- a/Libraries/LibJS/Runtime/Array.h
+++ b/Libraries/LibJS/Runtime/Array.h
@@ -39,8 +39,6 @@ public:
     explicit Array(Object& prototype);
     virtual ~Array() override;
 
-    i32 length() const { return static_cast<i32>(elements().size()); }
-
 private:
     virtual const char* class_name() const override { return "Array"; }
     virtual bool is_array() const override { return true; }

--- a/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -63,13 +63,13 @@ Value ArrayConstructor::call(Interpreter& interpreter)
             return {};
         }
         auto* array = Array::create(interpreter.global_object());
-        array->elements().resize(array_length_value.as_i32());
+        array->indexed_properties().set_array_like_size(array_length_value.as_i32());
         return array;
     }
 
     auto* array = Array::create(interpreter.global_object());
     for (size_t i = 0; i < interpreter.argument_count(); ++i)
-        array->elements().append(interpreter.argument(i));
+        array->indexed_properties().append(interpreter.argument(i));
     return array;
 }
 
@@ -91,7 +91,7 @@ Value ArrayConstructor::of(Interpreter& interpreter)
 {
     auto* array = Array::create(interpreter.global_object());
     for (size_t i = 0; i < interpreter.argument_count(); ++i)
-        array->elements().append(interpreter.argument(i));
+        array->indexed_properties().append(interpreter.argument(i));
     return array;
 }
 

--- a/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibJS/Runtime/Accessor.h>
+#include <LibJS/Runtime/IndexedProperties.h>
+
+namespace JS {
+
+SimpleIndexedPropertyStorage::SimpleIndexedPropertyStorage(Vector<Value>&& initial_values)
+    : m_array_size(initial_values.size())
+    , m_packed_elements(move(initial_values))
+{
+}
+
+bool SimpleIndexedPropertyStorage::has_index(u32 index) const
+{
+    return index < m_array_size && !m_packed_elements[index].is_empty();
+}
+
+Optional<ValueAndAttributes> SimpleIndexedPropertyStorage::get(u32 index) const
+{
+    if (index >= m_array_size)
+        return {};
+    return ValueAndAttributes { m_packed_elements[index], default_attributes };
+}
+
+void SimpleIndexedPropertyStorage::put(u32 index, Value value, u8 attributes)
+{
+    ASSERT(attributes == default_attributes);
+    ASSERT(index < SPARSE_ARRAY_THRESHOLD);
+
+    if (index >= m_array_size) {
+        m_array_size = index + 1;
+        if (index >= m_packed_elements.size())
+            m_packed_elements.resize(index + MIN_PACKED_RESIZE_AMOUNT >= SPARSE_ARRAY_THRESHOLD ? SPARSE_ARRAY_THRESHOLD : index + MIN_PACKED_RESIZE_AMOUNT);
+    }
+    m_packed_elements[index] = value;
+}
+
+void SimpleIndexedPropertyStorage::remove(u32 index)
+{
+    if (index < m_array_size)
+        m_packed_elements[index] = {};
+}
+
+void SimpleIndexedPropertyStorage::insert(u32 index, Value value, u8 attributes)
+{
+    ASSERT(attributes == default_attributes);
+    ASSERT(index < SPARSE_ARRAY_THRESHOLD);
+    m_array_size++;
+    ASSERT(m_array_size <= SPARSE_ARRAY_THRESHOLD);
+    m_packed_elements.insert(index, value);
+}
+
+ValueAndAttributes SimpleIndexedPropertyStorage::take_first()
+{
+    m_array_size--;
+    return { m_packed_elements.take_first(), default_attributes };
+}
+
+ValueAndAttributes SimpleIndexedPropertyStorage::take_last()
+{
+    m_array_size--;
+    auto last_element = m_packed_elements[m_array_size];
+    m_packed_elements[m_array_size] = {};
+    return { last_element, default_attributes };
+}
+
+void SimpleIndexedPropertyStorage::set_array_like_size(size_t new_size)
+{
+    ASSERT(new_size <= SPARSE_ARRAY_THRESHOLD);
+    m_array_size = new_size;
+    m_packed_elements.resize(new_size);
+}
+
+GenericIndexedPropertyStorage::GenericIndexedPropertyStorage(SimpleIndexedPropertyStorage&& storage)
+{
+    m_array_size = storage.array_like_size();
+    for (auto& element : move(storage.m_packed_elements))
+        m_packed_elements.append({ element, default_attributes });
+}
+
+bool GenericIndexedPropertyStorage::has_index(u32 index) const
+{
+    if (index < SPARSE_ARRAY_THRESHOLD)
+        return index < m_packed_elements.size() && !m_packed_elements[index].value.is_empty();
+    return m_sparse_elements.contains(index);
+}
+
+Optional<ValueAndAttributes> GenericIndexedPropertyStorage::get(u32 index) const
+{
+    if (index >= m_array_size)
+        return {};
+    if (index < SPARSE_ARRAY_THRESHOLD) {
+        if (index >= m_packed_elements.size())
+            return {};
+        return m_packed_elements[index];
+    }
+    return m_sparse_elements.get(index);
+}
+
+void GenericIndexedPropertyStorage::put(u32 index, Value value, u8 attributes)
+{
+    if (index >= m_array_size)
+        m_array_size = index + 1;
+    if (index < SPARSE_ARRAY_THRESHOLD) {
+        if (index >= m_packed_elements.size())
+            m_packed_elements.resize(index + MIN_PACKED_RESIZE_AMOUNT >= SPARSE_ARRAY_THRESHOLD ? SPARSE_ARRAY_THRESHOLD : index + MIN_PACKED_RESIZE_AMOUNT);
+        m_packed_elements[index] = { value, attributes };
+    } else {
+        m_sparse_elements.set(index, { value, attributes });
+    }
+}
+
+void GenericIndexedPropertyStorage::remove(u32 index)
+{
+    if (index >= m_array_size)
+        return;
+    if (index + 1 == m_array_size) {
+        take_last();
+        return;
+    }
+    if (index < SPARSE_ARRAY_THRESHOLD) {
+        if (index < m_packed_elements.size())
+            m_packed_elements[index] = {};
+    } else {
+        m_sparse_elements.remove(index);
+    }
+}
+
+void GenericIndexedPropertyStorage::insert(u32 index, Value value, u8 attributes)
+{
+    if (index >= m_array_size) {
+        put(index, value, attributes);
+        return;
+    }
+
+    m_array_size++;
+
+    if (!m_sparse_elements.is_empty()) {
+        HashMap<u32, ValueAndAttributes> new_sparse_elements;
+        for (auto& entry : m_sparse_elements)
+            new_sparse_elements.set(entry.key >= index ? entry.key + 1 : entry.key, entry.value);
+        m_sparse_elements = move(new_sparse_elements);
+    }
+
+    if (index < SPARSE_ARRAY_THRESHOLD) {
+        m_packed_elements.insert(index, { value, attributes });
+    } else {
+        m_sparse_elements.set(index, { value, attributes });
+    }
+}
+
+ValueAndAttributes GenericIndexedPropertyStorage::take_first()
+{
+    ASSERT(m_array_size > 0);
+    m_array_size--;
+
+    if (!m_sparse_elements.is_empty()) {
+        HashMap<u32, ValueAndAttributes> new_sparse_elements;
+        for (auto& entry : m_sparse_elements)
+            new_sparse_elements.set(entry.key - 1, entry.value);
+        m_sparse_elements = move(new_sparse_elements);
+    }
+
+    return m_packed_elements.take_first();
+}
+
+ValueAndAttributes GenericIndexedPropertyStorage::take_last()
+{
+    ASSERT(m_array_size > 0);
+    m_array_size--;
+
+    if (m_array_size <= SPARSE_ARRAY_THRESHOLD) {
+        auto last_element = m_packed_elements[m_array_size];
+        m_packed_elements[m_array_size] = {};
+        return last_element;
+    } else {
+        auto result = m_sparse_elements.get(m_array_size);
+        m_sparse_elements.remove(m_array_size);
+        ASSERT(result.has_value());
+        return result.value();
+    }
+}
+
+void GenericIndexedPropertyStorage::set_array_like_size(size_t new_size)
+{
+    if (new_size < SPARSE_ARRAY_THRESHOLD) {
+        m_packed_elements.resize(new_size);
+        m_sparse_elements.clear();
+    } else {
+        m_packed_elements.resize(SPARSE_ARRAY_THRESHOLD);
+
+        HashMap<u32, ValueAndAttributes> new_sparse_elements;
+        for (auto& entry : m_sparse_elements) {
+            if (entry.key < new_size)
+                new_sparse_elements.set(entry.key, entry.value);
+        }
+        m_sparse_elements = move(new_sparse_elements);
+    }
+}
+
+IndexedPropertyIterator::IndexedPropertyIterator(const IndexedProperties& indexed_properties, u32 staring_index, bool skip_empty)
+    : m_indexed_properties(indexed_properties)
+    , m_index(staring_index)
+    , m_skip_empty(skip_empty)
+{
+    while (m_skip_empty && m_index < m_indexed_properties.array_like_size()) {
+        if (m_indexed_properties.has_index(m_index))
+            break;
+        m_index++;
+    }
+}
+
+IndexedPropertyIterator& IndexedPropertyIterator::operator++()
+{
+    m_index++;
+
+    while (m_skip_empty && m_index < m_indexed_properties.array_like_size()) {
+        if (m_indexed_properties.has_index(m_index))
+            break;
+        m_index++;
+    };
+
+    return *this;
+}
+
+IndexedPropertyIterator& IndexedPropertyIterator::operator*()
+{
+    return *this;
+}
+
+bool IndexedPropertyIterator::operator!=(const IndexedPropertyIterator& other) const
+{
+    return m_index != other.m_index;
+}
+
+ValueAndAttributes IndexedPropertyIterator::value_and_attributes(Object* this_object, bool evaluate_accessors)
+{
+    if (m_index < m_indexed_properties.array_like_size())
+        return m_indexed_properties.get(this_object, m_index, evaluate_accessors).value();
+    return {};
+}
+
+Optional<ValueAndAttributes> IndexedProperties::get(Object* this_object, u32 index, bool evaluate_accessors) const
+{
+    auto result = m_storage->get(index);
+    if (!evaluate_accessors)
+        return result;
+    if (!result.has_value())
+        return {};
+    auto value = result.value();
+    if (value.value.is_accessor()) {
+        ASSERT(this_object);
+        auto& accessor = value.value.as_accessor();
+        return ValueAndAttributes { accessor.call_getter(this_object), value.attributes };
+    }
+    return result;
+}
+
+void IndexedProperties::put(Object* this_object, u32 index, Value value, u8 attributes, bool evaluate_accessors)
+{
+    if (m_storage->is_simple_storage() && (index >= SPARSE_ARRAY_THRESHOLD || attributes != default_attributes))
+        switch_to_generic_storage();
+    if (m_storage->is_simple_storage() || !evaluate_accessors) {
+        m_storage->put(index, value, attributes);
+        return;
+    }
+
+    auto value_here = m_storage->get(index);
+    if (value_here.has_value() && value_here.value().value.is_accessor()) {
+        ASSERT(this_object);
+        value_here.value().value.as_accessor().call_setter(this_object, value);
+    } else {
+        m_storage->put(index, value, attributes);
+    }
+}
+
+bool IndexedProperties::remove(u32 index)
+{
+    auto result = m_storage->get(index);
+    if (!result.has_value())
+        return true;
+    if (!(result.value().attributes & Attribute::Configurable))
+        return false;
+    m_storage->remove(index);
+    return true;
+}
+
+void IndexedProperties::insert(u32 index, Value value, u8 attributes)
+{
+    if (m_storage->is_simple_storage() && (index >= SPARSE_ARRAY_THRESHOLD || attributes != default_attributes || array_like_size() == SPARSE_ARRAY_THRESHOLD))
+        switch_to_generic_storage();
+    m_storage->insert(index, value, attributes);
+}
+
+ValueAndAttributes IndexedProperties::take_first(Object *this_object)
+{
+    auto first = m_storage->take_first();
+    if (first.value.is_accessor())
+        return { first.value.as_accessor().call_getter(this_object), first.attributes };
+    return first;
+}
+
+ValueAndAttributes IndexedProperties::take_last(Object *this_object)
+{
+    auto last = m_storage->take_last();
+    if (last.value.is_accessor())
+        return { last.value.as_accessor().call_getter(this_object), last.attributes };
+    return last;
+}
+
+void IndexedProperties::append_all(Object* this_object, const IndexedProperties& properties, bool evaluate_accessors)
+{
+    if (m_storage->is_simple_storage() && !properties.m_storage->is_simple_storage())
+        switch_to_generic_storage();
+
+    for (auto it = properties.begin(false); it != properties.end(); ++it) {
+        auto element = it.value_and_attributes(this_object, evaluate_accessors);
+        if (this_object && this_object->interpreter().exception())
+            return;
+        m_storage->put(m_storage->array_like_size(), element.value, element.attributes);
+    }
+}
+
+Vector<ValueAndAttributes> IndexedProperties::values_unordered() const
+{
+    if (m_storage->is_simple_storage()) {
+        auto elements = static_cast<const SimpleIndexedPropertyStorage&>(*m_storage).elements();
+        Vector<ValueAndAttributes> with_attributes;
+        for (auto& value : elements)
+            with_attributes.append({ value, default_attributes });
+        return with_attributes;
+    }
+
+    auto storage = static_cast<const GenericIndexedPropertyStorage&>(*m_storage);
+    auto values = storage.packed_elements();
+    values.ensure_capacity(values.size() + storage.sparse_elements().size());
+    for (auto& entry : storage.sparse_elements())
+        values.unchecked_append(entry.value);
+    return values;
+}
+
+void IndexedProperties::switch_to_generic_storage()
+{
+    auto storage = static_cast<const SimpleIndexedPropertyStorage&>(*m_storage);
+    m_storage = make<GenericIndexedPropertyStorage>(move(storage));
+}
+
+}

--- a/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/NonnullOwnPtr.h>
+#include <LibJS/Runtime/Shape.h>
+#include <LibJS/Runtime/Value.h>
+
+namespace JS {
+
+const u32 SPARSE_ARRAY_THRESHOLD = 200;
+const u32 MIN_PACKED_RESIZE_AMOUNT = 20;
+
+struct ValueAndAttributes {
+    Value value;
+    u8 attributes { default_attributes };
+};
+
+class IndexedProperties;
+class IndexedPropertyIterator;
+class GenericIndexedPropertyStorage;
+
+class IndexedPropertyStorage {
+public:
+    virtual ~IndexedPropertyStorage() {};
+
+    virtual bool has_index(u32 index) const = 0;
+    virtual Optional<ValueAndAttributes> get(u32 index) const = 0;
+    virtual void put(u32 index, Value value, u8 attributes = default_attributes) = 0;
+    virtual void remove(u32 index) = 0;
+
+    virtual void insert(u32 index, Value value, u8 attributes = default_attributes) = 0;
+    virtual ValueAndAttributes take_first() = 0;
+    virtual ValueAndAttributes take_last() = 0;
+
+    virtual size_t size() const = 0;
+    virtual size_t array_like_size() const = 0;
+    virtual void set_array_like_size(size_t new_size) = 0;
+
+    virtual bool is_simple_storage() const { return false; }
+};
+
+class SimpleIndexedPropertyStorage final : public IndexedPropertyStorage {
+public:
+    SimpleIndexedPropertyStorage() = default;
+    explicit SimpleIndexedPropertyStorage(Vector<Value>&& initial_values);
+
+    virtual bool has_index(u32 index) const override;
+    virtual Optional<ValueAndAttributes> get(u32 index) const override;
+    virtual void put(u32 index, Value value, u8 attributes = default_attributes) override;
+    virtual void remove(u32 index) override;
+
+    virtual void insert(u32 index, Value value, u8 attributes = default_attributes) override;
+    virtual ValueAndAttributes take_first() override;
+    virtual ValueAndAttributes take_last() override;
+
+    virtual size_t size() const override { return m_packed_elements.size(); }
+    virtual size_t array_like_size() const override { return m_array_size; }
+    virtual void set_array_like_size(size_t new_size) override;
+
+    virtual bool is_simple_storage() const override { return true; }
+    Vector<Value> elements() const { return m_packed_elements; }
+
+private:
+    friend GenericIndexedPropertyStorage;
+
+    size_t m_array_size { 0 };
+    Vector<Value> m_packed_elements;
+};
+
+class GenericIndexedPropertyStorage final : public IndexedPropertyStorage {
+public:
+    explicit GenericIndexedPropertyStorage(SimpleIndexedPropertyStorage&&);
+
+    virtual bool has_index(u32 index) const override;
+    virtual Optional<ValueAndAttributes> get(u32 index) const override;
+    virtual void put(u32 index, Value value, u8 attributes = default_attributes) override;
+    virtual void remove(u32 index) override;
+
+    virtual void insert(u32 index, Value value, u8 attributes = default_attributes) override;
+    virtual ValueAndAttributes take_first() override;
+    virtual ValueAndAttributes take_last() override;
+
+    virtual size_t size() const override { return m_packed_elements.size() + m_sparse_elements.size(); }
+    virtual size_t array_like_size() const override { return m_array_size; }
+    virtual void set_array_like_size(size_t new_size) override;
+
+    Vector<ValueAndAttributes> packed_elements() const { return m_packed_elements; }
+    HashMap<u32, ValueAndAttributes> sparse_elements() const { return m_sparse_elements; }
+
+private:
+    size_t m_array_size { 0 };
+    Vector<ValueAndAttributes> m_packed_elements;
+    HashMap<u32, ValueAndAttributes> m_sparse_elements;
+};
+
+class IndexedPropertyIterator {
+public:
+    IndexedPropertyIterator(const IndexedProperties&, u32 starting_index, bool skip_empty);
+
+    IndexedPropertyIterator& operator++();
+    IndexedPropertyIterator& operator*();
+    bool operator!=(const IndexedPropertyIterator&) const;
+
+    u32 index() const { return m_index; };
+    ValueAndAttributes value_and_attributes(Object* this_object, bool evaluate_accessors = true);
+
+private:
+    const IndexedProperties& m_indexed_properties;
+    u32 m_index;
+    bool m_skip_empty;
+};
+
+class IndexedProperties {
+public:
+    IndexedProperties() = default;
+
+    IndexedProperties(Vector<Value>&& values)
+        : m_storage(make<SimpleIndexedPropertyStorage>(move(values)))
+    {
+    }
+
+    bool has_index(u32 index) const { return m_storage->has_index(index); }
+    Optional<ValueAndAttributes> get(Object* this_object, u32 index, bool evaluate_accessors = true) const;
+    void put(Object* this_object, u32 index, Value value, u8 attributes = default_attributes, bool evaluate_accessors = true);
+    bool remove(u32 index);
+
+    void insert(u32 index, Value value, u8 attributes = default_attributes);
+    ValueAndAttributes take_first(Object* this_object);
+    ValueAndAttributes take_last(Object* this_object);
+
+    void append(Value value, u8 attributes = default_attributes) { put(nullptr, array_like_size(), value, attributes, false); }
+    void append_all(Object* this_object, const IndexedProperties& properties, bool evaluate_accessors = true);
+
+    IndexedPropertyIterator begin(bool skip_empty = true) const { return IndexedPropertyIterator(*this, 0, skip_empty); };
+    IndexedPropertyIterator end() const { return IndexedPropertyIterator(*this, array_like_size(), false); };
+
+    size_t size() const { return m_storage->size(); }
+    bool is_empty() const { return size() == 0; }
+    size_t array_like_size() const { return m_storage->array_like_size(); }
+    void set_array_like_size(size_t new_size) { m_storage->set_array_like_size(new_size); };
+
+    Vector<ValueAndAttributes> values_unordered() const;
+
+private:
+    void switch_to_generic_storage();
+
+    NonnullOwnPtr<IndexedPropertyStorage> m_storage { make<SimpleIndexedPropertyStorage>() };
+};
+
+}

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -30,14 +30,13 @@
 #include <AK/String.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Cell.h>
+#include <LibJS/Runtime/IndexedProperties.h>
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/PropertyName.h>
 #include <LibJS/Runtime/Shape.h>
 #include <LibJS/Runtime/Value.h>
 
 namespace JS {
-
-const u8 default_attributes = Attribute::Configurable | Attribute::Writable | Attribute::Enumerable;
 
 class Object : public Cell {
 public:
@@ -110,8 +109,9 @@ public:
 
     Value get_direct(size_t index) const { return m_storage[index]; }
 
-    const Vector<Value>& elements() const { return m_elements; }
-    Vector<Value>& elements() { return m_elements; }
+    const IndexedProperties& indexed_properties() const { return m_indexed_properties; }
+    IndexedProperties& indexed_properties() { return m_indexed_properties; }
+    void set_indexed_property_elements(Vector<Value>&& values) { m_indexed_properties = IndexedProperties(move(values)); }
 
 private:
     virtual Value get_by_index(u32 property_index) const;
@@ -124,7 +124,7 @@ private:
 
     Shape* m_shape { nullptr };
     Vector<Value> m_storage;
-    Vector<Value> m_elements;
+    IndexedProperties m_indexed_properties;
 };
 
 }

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -75,14 +75,11 @@ Value ObjectConstructor::get_own_property_names(Interpreter& interpreter)
     if (interpreter.exception())
         return {};
     auto* result = Array::create(interpreter.global_object());
-    for (size_t i = 0; i < object->elements().size(); ++i) {
-        if (!object->elements()[i].is_empty())
-            result->elements().append(js_string(interpreter, String::number(i)));
-    }
+    for (auto& entry : object->indexed_properties())
+        result->indexed_properties().append(js_string(interpreter, String::number(entry.index())));
+    for (auto& it : object->shape().property_table_ordered())
+        result->indexed_properties().append(js_string(interpreter, it.key));
 
-    for (auto& it : object->shape().property_table_ordered()) {
-        result->elements().append(js_string(interpreter, it.key));
-    }
     return result;
 }
 

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -104,7 +104,7 @@ Value ScriptFunction::call(Interpreter& interpreter)
         if (parameter.is_rest) {
             auto* array = Array::create(interpreter.global_object());
             for (size_t rest_index = i; rest_index < argument_values.size(); ++rest_index)
-                array->elements().append(argument_values[rest_index]);
+                array->indexed_properties().append(argument_values[rest_index]);
             value = Value(array);
         } else {
             if (i < argument_values.size() && !argument_values[i].is_undefined()) {

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -45,6 +45,8 @@ struct Attribute {
     };
 };
 
+const u8 default_attributes = Attribute::Configurable | Attribute::Writable | Attribute::Enumerable;
+
 struct PropertyMetadata {
     size_t offset { 0 };
     u8 attributes { 0 };

--- a/Libraries/LibJS/Tests/Array.js
+++ b/Libraries/LibJS/Tests/Array.js
@@ -29,6 +29,10 @@ try {
     assert(a[0][1] === 2);
     assert(a[0][2] === 3);
 
+    a = new Array(1, 2, 3);
+    Object.defineProperty(a, 3, { get() { return 10; } });
+    assert(a.toString() === "1,2,3,10");
+
     [-1, -100, -0.1, 0.1, 1.23, Infinity, -Infinity, NaN].forEach(value => {
         assertThrowsError(() => {
             new Array(value);

--- a/Libraries/LibJS/Tests/Array.of.js
+++ b/Libraries/LibJS/Tests/Array.of.js
@@ -31,6 +31,15 @@ try {
     assert(a[0][1] === 2);
     assert(a[0][2] === 3);
 
+    let t = [1, 2, 3];
+    Object.defineProperty(t, 3, { get() { return 4; } });
+    a = Array.of(...t);
+    assert(a.length === 4);
+    assert(a[0] === 1);
+    assert(a[1] === 2);
+    assert(a[2] === 3);
+    assert(a[3] === 4);
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);

--- a/Libraries/LibJS/Tests/Object.defineProperty.js
+++ b/Libraries/LibJS/Tests/Object.defineProperty.js
@@ -7,6 +7,8 @@ try {
     assert(o.foo === 1);
     o.foo = 2;
     assert(o.foo === 1);
+    Object.defineProperty(o, 2, { get() { return 10; } });
+    assert(o[2] === 10);
 
     var d = Object.getOwnPropertyDescriptor(o, "foo");
     assert(d.configurable === false);

--- a/Libraries/LibJS/Tests/array-basic.js
+++ b/Libraries/LibJS/Tests/array-basic.js
@@ -40,6 +40,23 @@ try {
     assert(a[4] === undefined);
     assert(a[5] === 3);
 
+    a = [1,,2,,,3,];
+    Object.defineProperty(a, 1, {
+        get() {
+            return this.secret_prop;
+        },
+        set(value) {
+            this.secret_prop = value;
+        },
+    });
+    assert(a.length === 6);
+    assert(a.toString() === "1,,2,,,3");
+    assert(a.secret_prop === undefined);
+    a[1] = 20;
+    assert(a.length === 6);
+    assert(a.toString() === "1,20,2,,,3");
+    assert(a.secret_prop === 20);
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);

--- a/Libraries/LibWeb/Bindings/DocumentWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/DocumentWrapper.cpp
@@ -119,7 +119,7 @@ JS::Value DocumentWrapper::query_selector_all(JS::Interpreter& interpreter)
     // FIXME: This should be a static NodeList, not a plain JS::Array.
     auto* node_list = JS::Array::create(interpreter.global_object());
     for (auto& element : elements) {
-        node_list->elements().append(wrap(interpreter.heap(), element));
+        node_list->indexed_properties().append(wrap(interpreter.heap(), element));
     }
     return node_list;
 }

--- a/Libraries/LibWeb/Bindings/NavigatorObject.cpp
+++ b/Libraries/LibWeb/Bindings/NavigatorObject.cpp
@@ -38,12 +38,12 @@ NavigatorObject::NavigatorObject()
     : Object(interpreter().global_object().object_prototype())
 {
     auto* languages = JS::Array::create(interpreter().global_object());
-    languages->elements().append(js_string(heap(), "en-US"));
+    languages->indexed_properties().append(js_string(heap(), "en-US"));
 
     define_property("appCodeName", js_string(heap(), "Mozilla"));
     define_property("appName", js_string(heap(), "Netscape"));
     define_property("appVersion", js_string(heap(), "4.0"));
-    define_property("language", languages->elements().first());
+    define_property("language", languages->get(0));
     define_property("languages", languages);
     define_property("platform", js_string(heap(), "SerenityOS"));
     define_property("product", js_string(heap(), "Gecko"));


### PR DESCRIPTION
This patch adds an `IndexedProperties` object for storing indexed properties within an `Object`. This accomplishes two goals: indexed properties now have an associated descriptor, and objects now gracefully handle sparse properties.

The `IndexedProperties` class is a wrapper around two other classes, one for simple indexed properties storage, and one for general indexed property storage. Simple indexed property storage is the common-case, and is simply a vector of properties which all have attributes of `default_attributes` (writable, enumerable, and configurable).

General indexed property storage is for a collection of indexed properties where EITHER one or more properties have attributes other than `default_attributes` OR there is a property with a large index (in particular, large is `200` or higher).

Indexed properties are now treated relatively the same as storage within the various `Object` methods. Additionally, there is a custom iterator class for `IndexedProperties` which makes iteration easy. The iterator skips empty values by default, but can be configured otherwise. Likewise, it evaluates getters by default, but can be set not to.

Closes #2330.

Things that need to be done after this PR is merged:

- Comprehensive exception checking. With this PR, all get and put operations on an object have side effects, and thus can throw exceptions. Everywhere a get or put is called, an exception check must follow.
- A review of `const` types. All `get`-type methods right now are const, but because they can have side effects, they really shouldn't be `const`. This would get rid of a few `const_cast`s scattered around in `Object.cpp`.
- Respect the `enumerable` attribute where necessary. This is something I didn't really try to do in the PR, since it is a problem throughout LibJS. This should be handled in a separate PR. 