### PR TITLE
LibJS: Add strict mode

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -120,6 +120,9 @@ public:
     void add_variables(NonnullRefPtrVector<VariableDeclaration>);
     const NonnullRefPtrVector<VariableDeclaration>& variables() const { return m_variables; }
 
+    bool in_strict_mode() const { return m_strict_mode; }
+    void set_strict_mode() { m_strict_mode = true; }
+
 protected:
     ScopeNode() { }
 
@@ -127,6 +130,7 @@ private:
     virtual bool is_scope_node() const final { return true; }
     NonnullRefPtrVector<Statement> m_children;
     NonnullRefPtrVector<VariableDeclaration> m_variables;
+    bool m_strict_mode { false };
 };
 
 class Program : public ScopeNode {

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -31,6 +31,7 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <AK/Weakable.h>
+#include <LibJS/AST.h>
 #include <LibJS/Console.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Heap.h>
@@ -122,6 +123,8 @@ public:
 
     const LexicalEnvironment* current_environment() const { return m_call_stack.last().environment; }
     LexicalEnvironment* current_environment() { return m_call_stack.last().environment; }
+
+    bool in_strict_mode() const { return m_scope_stack.last().scope_node->in_strict_mode(); }
 
     size_t argument_count() const
     {

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -816,6 +816,16 @@ NonnullRefPtr<Expression> Parser::parse_secondary_expression(NonnullRefPtr<Expre
             syntax_error("Invalid left-hand side in assignment");
             return create_ast_node<ErrorExpression>();
         }
+        if (m_parser_state.m_strict_mode && lhs->is_identifier()) {
+            auto name = static_cast<const Identifier&>(*lhs).string();
+            if (name == "eval" || name == "arguments") {
+                syntax_error(
+                    String::format("'%s' cannot be assigned to in strict mode code", name.characters()),
+                    m_parser_state.m_current_token.line_number(),
+                    m_parser_state.m_current_token.line_column()
+                );
+            }
+        }
         return create_ast_node<AssignmentExpression>(AssignmentOp::Assignment, move(lhs), parse_expression(min_precedence, associativity));
     case TokenType::Period:
         consume();

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -26,10 +26,10 @@
 
 #pragma once
 
-#include "AST.h"
-#include "Lexer.h"
 #include <AK/NonnullRefPtr.h>
 #include <AK/StringBuilder.h>
+#include <LibJS/AST.h>
+#include <LibJS/Lexer.h>
 #include <stdio.h>
 
 namespace JS {
@@ -134,12 +134,20 @@ private:
     void save_state();
     void load_state();
 
+    enum class UseStrictDirectiveState {
+        None,
+        Looking,
+        Found,
+    };
+
     struct ParserState {
         Lexer m_lexer;
         Token m_current_token;
         Vector<Error> m_errors;
         Vector<NonnullRefPtrVector<VariableDeclaration>> m_var_scopes;
         Vector<NonnullRefPtrVector<VariableDeclaration>> m_let_scopes;
+        UseStrictDirectiveState m_use_strict_directive { UseStrictDirectiveState::None };
+        bool m_strict_mode { false };
 
         explicit ParserState(Lexer);
     };

--- a/Libraries/LibJS/Tests/arrow-functions.js
+++ b/Libraries/LibJS/Tests/arrow-functions.js
@@ -60,6 +60,31 @@ try {
     assert(foo === undefined);
     assert(bar === undefined);
 
+    (() => {
+        "use strict";
+        assert(isStrictMode());
+
+        (() => {
+            assert(isStrictMode());
+        })();
+    })();
+
+    (() => {
+        'use strict';
+        assert(isStrictMode());
+    })();
+
+    (() => {
+        assert(!isStrictMode());
+
+        (() => {
+            "use strict";
+            assert(isStrictMode());
+        })();
+
+        assert(!isStrictMode());
+    })();
+
     console.log("PASS");
 } catch {
     console.log("FAIL");

--- a/Libraries/LibJS/Tests/function-strict-mode.js
+++ b/Libraries/LibJS/Tests/function-strict-mode.js
@@ -1,0 +1,52 @@
+load("test-common.js");
+
+try {
+    (function() {
+        assert(!isStrictMode());
+    })();
+
+    (function() {
+        'use strict';
+        assert(isStrictMode());
+    })();
+
+    (function() {
+        "use strict";
+        assert(isStrictMode());
+    })();
+
+    (function() {
+        `use strict`;
+        assert(!isStrictMode());
+    })();
+
+    (function() {
+        ;'use strict';
+        assert(!isStrictMode());
+    })();
+
+    (function() {
+        ;"use strict";
+        assert(!isStrictMode());
+    })();
+
+    (function() {
+        "use strict";
+        (function() {
+            assert(isStrictMode());
+        })();
+    })();
+
+    (function() {
+        assert(!isStrictMode());
+        (function(){
+            "use strict";
+            assert(isStrictMode());
+        })();
+        assert(!isStrictMode());
+    })();
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/program-strict-mode.js
+++ b/Libraries/LibJS/Tests/program-strict-mode.js
@@ -1,0 +1,30 @@
+"use strict";
+
+load("test-common.js");
+
+try {
+    assert(isStrictMode());
+
+    (function() {
+       assert(isStrictMode());
+    })();
+
+    (function() {
+        "use strict";
+         assert(isStrictMode());
+    })();
+
+
+    (() => {
+        assert(isStrictMode());
+    })();
+
+    (() => {
+        "use strict";
+        assert(isStrictMode());
+    })();
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -55,6 +55,7 @@ public:
     virtual ~ReplObject() override;
 
     static JS::Value load_file(JS::Interpreter&);
+    static JS::Value is_strict_mode(JS::Interpreter&);
 
 private:
     virtual const char* class_name() const override { return "ReplObject"; }
@@ -378,6 +379,11 @@ JS::Value ReplObject::load_file(JS::Interpreter& interpreter)
     return JS::Value(true);
 }
 
+JS::Value ReplObject::is_strict_mode(JS::Interpreter& interpreter)
+{
+    return JS::Value(interpreter.in_strict_mode());
+}
+
 void repl(JS::Interpreter& interpreter)
 {
     while (!s_fail_repl) {
@@ -392,6 +398,7 @@ void repl(JS::Interpreter& interpreter)
 void enable_test_mode(JS::Interpreter& interpreter)
 {
     interpreter.global_object().define_native_function("load", ReplObject::load_file);
+    interpreter.global_object().define_native_function("isStrictMode", ReplObject::is_strict_mode);
 }
 
 static Function<void()> interrupt_interpreter;


### PR DESCRIPTION
Adds the ability for a scope (either a function or the entire program) to be in strict mode. Scopes default to non-strict mode.

There are two ways to determine the strictness of the JS engine:

1. In the parser, this can be accessed with the parser_state variable `m_is_strict_mode` boolean. If true, the Parser is currently parsing in strict mode. This is done so that the Parser can generate syntax errors at parse time, which is required in some cases. The lexer will also need this information to determine whether or not to tokenize octal escapes. 

2. With `Interpreter.is_strict_mode()`. This allows strict mode checking at runtime as opposed to compile time.

Additionally, in order to test this, a global `isStrictMode()` function has been added to the JS `ReplObject` under the test-mode flag.

This PR also includes a small strict-mode change, just to demonstrate the functionality: left-hand-side identifier references cannot be the string `eval` or `arguments` under strict mode.