### PR TITLE
[Taskbar] Don't let buttons overflow the taskbar

### DIFF
--- a/Services/Taskbar/TaskbarWindow.h
+++ b/Services/Taskbar/TaskbarWindow.h
@@ -39,9 +39,13 @@ public:
 private:
     void create_quick_launch_bar();
     void on_screen_rect_change(const Gfx::Rect&);
+    void update_buttons_size_policy();
     NonnullRefPtr<GUI::Button> create_button(const WindowIdentifier&);
 
     virtual void wm_event(GUI::WMEvent&) override;
 
+    GUI::SizePolicy m_size_policy;
+
     RefPtr<Gfx::Bitmap> m_default_icon;
+    RefPtr<GUI::Frame> m_quick_launch_bar;
 };


### PR DESCRIPTION
This little project has the aim of improving taskbar UX. Here's what we've got so far:

- [X] Shrink taskbar buttons when overflowing the available space.
- [X] Show tooltips for taskbar buttons so that the user can still see the window title when there are too many buttons on the taskbar.
- [ ] ~~Grouping buttons from the same application when overflowing so that we have extra room for more buttons.~~ This one is maybe too big for me right now
- [ ] ~~Taskbar rows?~~ Too cluttered
- [x] Allow applications to display progress on the taskbar buttons? (Implemented by Andreas)

![image](https://user-images.githubusercontent.com/55109673/83134664-f7498680-a0e4-11ea-9c19-4f5cb4123fa9.png)

So that's it. Just shrinking buttons is okay for now (admittedly, I don't have that much free time right now...)
