### PR TITLE
Mounts, part 4

### DIFF
--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -78,7 +78,7 @@ static NonnullRefPtr<GUI::Widget> build_graphs_tab();
 class UnavailableProcessWidget final : public GUI::Frame {
     C_OBJECT(UnavailableProcessWidget)
 public:
-    virtual ~UnavailableProcessWidget() override {}
+    virtual ~UnavailableProcessWidget() override { }
 
     const String& text() const { return m_text; }
     void set_text(String text) { m_text = move(text); }
@@ -285,7 +285,7 @@ int main(int argc, char** argv)
 
 class ProgressBarPaintingDelegate final : public GUI::TableCellPaintingDelegate {
 public:
-    virtual ~ProgressBarPaintingDelegate() override {}
+    virtual ~ProgressBarPaintingDelegate() override { }
 
     virtual void paint(GUI::Painter& painter, const Gfx::Rect& a_rect, const Palette& palette, const GUI::Model& model, const GUI::ModelIndex& index) override
     {
@@ -357,7 +357,9 @@ NonnullRefPtr<GUI::Widget> build_file_systems_tab()
                 return object.get("free_block_count").to_u32() * object.get("block_size").to_u32();
             });
         df_fields.empend("Access", Gfx::TextAlignment::CenterLeft, [](const JsonObject& object) {
-            return object.get("readonly").to_bool() ? "Read-only" : "Read/Write";
+            bool readonly = object.get("readonly").to_bool();
+            int mount_flags = object.get("mount_flags").to_int();
+            return readonly || (mount_flags & MS_RDONLY) ? "Read-only" : "Read/Write";
         });
         df_fields.empend("Mount flags", Gfx::TextAlignment::CenterLeft, [](const JsonObject& object) {
             int mount_flags = object.get("mount_flags").to_int();
@@ -375,6 +377,7 @@ NonnullRefPtr<GUI::Widget> build_file_systems_tab()
             check(MS_NOEXEC, "noexec");
             check(MS_NOSUID, "nosuid");
             check(MS_BIND, "bind");
+            check(MS_RDONLY, "ro");
             if (builder.string_view().is_empty())
                 return String("defaults");
             return builder.to_string();

--- a/Base/etc/fstab
+++ b/Base/etc/fstab
@@ -1,10 +1,12 @@
 # Root file system. This is a fake entry which gets ignored by `mount -a`;
 # the actual logic for mounting root is in the kernel.
-/dev/hda	/	ext2	nodev,nosuid
-# Remount /bin and /dev while adding the appropriate permissions.
-/dev	/dev	bind	bind,nosuid
-/bin	/bin	bind	bind,nodev
+/dev/hda	/	ext2	nodev,nosuid,ro
+# Remount /bin, /dev, /root, and /home while adding the appropriate permissions.
+/dev	/dev	bind	bind,nosuid,ro
+/bin	/bin	bind	bind,nodev,ro
+/home	/home	bind	bind,nodev,nosuid
+/root	/root	bind	bind,nodev,nosuid
 
 none	/proc	proc	nosuid
-none	/dev/pts	devpts	noexec,nosuid
+none	/dev/pts	devpts	noexec,nosuid,ro
 none	/tmp	tmp	nodev,nosuid

--- a/Base/usr/share/man/man2/mount.md
+++ b/Base/usr/share/man/man2/mount.md
@@ -24,7 +24,7 @@ over `target`.
 
 For Ext2FS, `source_fd` must refer to an open file descriptor to a file containing
 the filesystem image. This may be a device file or any other seekable file. All
-the other filesystems ignore the `source_fd` — you can even pass an invalid file
+the other filesystems ignore the `source_fd` - you can even pass an invalid file
 descriptor such as -1.
 
 The following `flags` are supported:
@@ -33,6 +33,7 @@ The following `flags` are supported:
 * `MS_NOEXEC`: Disallow executing any executables from this file system.
 * `MS_NOSUID`: Ignore set-user-id bits on executables from this file system.
 * `MS_BIND`: Perform a bind-mount (see below).
+* `MS_RDONLY`: Mount the filesystem read-only.
 
 These flags can be used as a security measure to limit the possible abuses of the newly
 mounted file system.

--- a/Base/usr/share/man/man8/mount.md
+++ b/Base/usr/share/man/man8/mount.md
@@ -20,7 +20,7 @@ If invoked as `mount -a`, `mount` mounts all the filesystems configured in
 [`SystemServer`(7)](../man7/SystemServer.md).
 
 Otherwise, `mount` performs a single filesystem mount. Source should be a path
-to a file containing the filesystem image. Target, and fstype have the same
+to a file containing the filesystem image. Target and fstype have the same
 meaning as in the [`mount`(2)](../man2/mount.md) syscall (if not specified,
 fstype defaults to `ext2`).
 

--- a/DevTools/Inspector/RemoteProcess.cpp
+++ b/DevTools/Inspector/RemoteProcess.cpp
@@ -188,7 +188,7 @@ void RemoteProcess::update()
         }
     };
 
-    auto success = m_socket->connect(Core::SocketAddress::local(String::format("/tmp/rpc.%d", m_pid)));
+    auto success = m_socket->connect(Core::SocketAddress::local(String::format("/tmp/rpc/%d", m_pid)));
     if (!success) {
         fprintf(stderr, "Couldn't connect to PID %d\n", m_pid);
         exit(1);

--- a/Kernel/FileSystem/Custody.cpp
+++ b/Kernel/FileSystem/Custody.cpp
@@ -59,4 +59,12 @@ String Custody::absolute_path() const
     return builder.to_string();
 }
 
+bool Custody::is_readonly() const
+{
+    if (m_mount_flags & MS_RDONLY)
+        return true;
+
+    return m_inode->fs().is_readonly();
+}
+
 }

--- a/Kernel/FileSystem/Custody.h
+++ b/Kernel/FileSystem/Custody.h
@@ -54,6 +54,7 @@ public:
     String absolute_path() const;
 
     int mount_flags() const { return m_mount_flags; }
+    bool is_readonly() const;
 
 private:
     Custody(Custody* parent, const StringView& name, Inode&, int mount_flags);

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -82,8 +82,8 @@ public:
     virtual String absolute_path(const FileDescription&) const = 0;
 
     virtual KResult truncate(u64) { return KResult(-EINVAL); }
-    virtual KResult chown(uid_t, gid_t) { return KResult(-EBADF); }
-    virtual KResult chmod(mode_t) { return KResult(-EBADF); }
+    virtual KResult chown(FileDescription&, uid_t, gid_t) { return KResult(-EBADF); }
+    virtual KResult chmod(FileDescription&, mode_t) { return KResult(-EBADF); }
 
     virtual const char* class_name() const = 0;
 

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -330,13 +330,13 @@ void FileDescription::set_file_flags(u32 flags)
 KResult FileDescription::chmod(mode_t mode)
 {
     LOCKER(m_lock);
-    return m_file->chmod(mode);
+    return m_file->chmod(*this, mode);
 }
 
 KResult FileDescription::chown(uid_t uid, gid_t gid)
 {
     LOCKER(m_lock);
-    return m_file->chown(uid, gid);
+    return m_file->chown(*this, uid, gid);
 }
 
 }

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -97,13 +97,15 @@ KResult InodeFile::truncate(u64 size)
     return KSuccess;
 }
 
-KResult InodeFile::chown(uid_t uid, gid_t gid)
+KResult InodeFile::chown(FileDescription& description, uid_t uid, gid_t gid)
 {
+    ASSERT(description.inode() == m_inode);
     return VFS::the().chown(*m_inode, uid, gid);
 }
 
-KResult InodeFile::chmod(mode_t mode)
+KResult InodeFile::chmod(FileDescription& description, mode_t mode)
 {
+    ASSERT(description.inode() == m_inode);
     return VFS::the().chmod(*m_inode, mode);
 }
 

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -100,13 +100,15 @@ KResult InodeFile::truncate(u64 size)
 KResult InodeFile::chown(FileDescription& description, uid_t uid, gid_t gid)
 {
     ASSERT(description.inode() == m_inode);
-    return VFS::the().chown(*m_inode, uid, gid);
+    ASSERT(description.custody());
+    return VFS::the().chown(*description.custody(), uid, gid);
 }
 
 KResult InodeFile::chmod(FileDescription& description, mode_t mode)
 {
     ASSERT(description.inode() == m_inode);
-    return VFS::the().chmod(*m_inode, mode);
+    ASSERT(description.custody());
+    return VFS::the().chmod(*description.custody(), mode);
 }
 
 }

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -54,8 +54,8 @@ public:
     virtual String absolute_path(const FileDescription&) const override;
 
     virtual KResult truncate(u64) override;
-    virtual KResult chown(uid_t, gid_t) override;
-    virtual KResult chmod(mode_t) override;
+    virtual KResult chown(FileDescription&, uid_t, gid_t) override;
+    virtual KResult chmod(FileDescription&, mode_t) override;
 
     virtual const char* class_name() const override { return "InodeFile"; }
 

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -749,7 +749,7 @@ Optional<KBuffer> procfs$df(InodeIdentifier)
         if (fs.is_file_backed())
             fs_object.add("source", static_cast<const FileBackedFS&>(fs).file_description().absolute_path());
         else
-            fs_object.add("source", fs.class_name());
+            fs_object.add("source", "none");
     });
     array.finish();
     return builder.build();

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -70,6 +70,8 @@ InodeIdentifier VFS::root_inode_id() const
 
 KResult VFS::mount(FS& file_system, Custody& mount_point, int flags)
 {
+    LOCKER(m_lock);
+
     auto& inode = mount_point.inode();
     dbg() << "VFS: Mounting " << file_system.class_name() << " at " << mount_point.absolute_path() << " (inode: " << inode.identifier() << ") with flags " << flags;
     // FIXME: check that this is not already a mount point
@@ -80,6 +82,8 @@ KResult VFS::mount(FS& file_system, Custody& mount_point, int flags)
 
 KResult VFS::bind_mount(Custody& source, Custody& mount_point, int flags)
 {
+    LOCKER(m_lock);
+
     dbg() << "VFS: Bind-mounting " << source.absolute_path() << " at " << mount_point.absolute_path();
     // FIXME: check that this is not already a mount point
     Mount mount { source.inode(), mount_point, flags };

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -393,8 +393,9 @@ KResultOr<NonnullRefPtr<Custody>> VFS::open_directory(StringView path, Custody& 
     return custody;
 }
 
-KResult VFS::chmod(Inode& inode, mode_t mode)
+KResult VFS::chmod(Custody& custody, mode_t mode)
 {
+    auto& inode = custody.inode();
     if (inode.fs().is_readonly())
         return KResult(-EROFS);
 
@@ -412,8 +413,7 @@ KResult VFS::chmod(StringView path, mode_t mode, Custody& base)
     if (custody_or_error.is_error())
         return custody_or_error.error();
     auto& custody = *custody_or_error.value();
-    auto& inode = custody.inode();
-    return chmod(inode, mode);
+    return chmod(custody, mode);
 }
 
 KResult VFS::rename(StringView old_path, StringView new_path, Custody& base)
@@ -479,8 +479,9 @@ KResult VFS::rename(StringView old_path, StringView new_path, Custody& base)
     return KSuccess;
 }
 
-KResult VFS::chown(Inode& inode, uid_t a_uid, gid_t a_gid)
+KResult VFS::chown(Custody& custody, uid_t a_uid, gid_t a_gid)
 {
+    auto& inode = custody.inode();
     if (inode.fs().is_readonly())
         return KResult(-EROFS);
 
@@ -521,8 +522,7 @@ KResult VFS::chown(StringView path, uid_t a_uid, gid_t a_gid, Custody& base)
     if (custody_or_error.is_error())
         return custody_or_error.error();
     auto& custody = *custody_or_error.value();
-    auto& inode = custody.inode();
-    return chown(inode, a_uid, a_gid);
+    return chown(custody, a_uid, a_gid);
 }
 
 KResult VFS::link(StringView old_path, StringView new_path, Custody& base)

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -177,14 +177,15 @@ void VFS::traverse_directory_inode(Inode& dir_inode, Function<bool(const FS::Dir
 
 KResult VFS::utime(StringView path, Custody& base, time_t atime, time_t mtime)
 {
-    auto descriptor_or_error = VFS::the().open(move(path), 0, 0, base);
-    if (descriptor_or_error.is_error())
-        return descriptor_or_error.error();
-    auto& inode = *descriptor_or_error.value()->inode();
-    if (inode.fs().is_readonly())
-        return KResult(-EROFS);
+    auto custody_or_error = VFS::the().resolve_path(move(path), base);
+    if (custody_or_error.is_error())
+        return custody_or_error.error();
+    auto& custody = *custody_or_error.value();
+    auto& inode = custody.inode();
     if (!Process::current->is_superuser() && inode.metadata().uid != Process::current->euid())
         return KResult(-EACCES);
+    if (custody.is_readonly())
+        return KResult(-EROFS);
 
     int error = inode.set_atime(atime);
     if (error)
@@ -264,6 +265,12 @@ KResultOr<NonnullRefPtr<FileDescription>> VFS::open(StringView path, int options
         descriptor_or_error.value()->set_original_inode({}, inode);
         return descriptor_or_error;
     }
+
+    // Check for read-only FS. Do this after handling preopen FD and devices,
+    // but before modifying the inode in any way.
+    if ((options & O_WRONLY) && custody.is_readonly())
+        return KResult(-EROFS);
+
     if (should_truncate_file) {
         inode.truncate(0);
         inode.set_mtime(kgettimeofday().tv_sec);
@@ -290,6 +297,8 @@ KResult VFS::mknod(StringView path, mode_t mode, dev_t dev, Custody& base)
     auto& parent_inode = parent_custody->inode();
     if (!parent_inode.metadata().may_write(*Process::current))
         return KResult(-EACCES);
+    if (parent_custody->is_readonly())
+        return KResult(-EROFS);
 
     LexicalPath p(path);
     dbg() << "VFS::mknod: '" << p.basename() << "' mode=" << mode << " dev=" << dev << " in " << parent_inode.identifier();
@@ -310,6 +319,9 @@ KResultOr<NonnullRefPtr<FileDescription>> VFS::create(StringView path, int optio
     auto& parent_inode = parent_custody.inode();
     if (!parent_inode.metadata().may_write(*Process::current))
         return KResult(-EACCES);
+    if (parent_custody.is_readonly())
+        return KResult(-EROFS);
+
     LexicalPath p(path);
 #ifdef VFS_DEBUG
     dbg() << "VFS::create: '" << p.basename() << "' in " << parent_inode.identifier();
@@ -348,6 +360,8 @@ KResult VFS::mkdir(StringView path, mode_t mode, Custody& base)
     auto& parent_inode = parent_custody->inode();
     if (!parent_inode.metadata().may_write(*Process::current))
         return KResult(-EACCES);
+    if (parent_custody->is_readonly())
+        return KResult(-EROFS);
 
     LexicalPath p(path);
 #ifdef VFS_DEBUG
@@ -371,6 +385,8 @@ KResult VFS::access(StringView path, int mode, Custody& base)
     if (mode & W_OK) {
         if (!metadata.may_write(*Process::current))
             return KResult(-EACCES);
+        if (custody.is_readonly())
+            return KResult(-EROFS);
     }
     if (mode & X_OK) {
         if (!metadata.may_execute(*Process::current))
@@ -396,11 +412,11 @@ KResultOr<NonnullRefPtr<Custody>> VFS::open_directory(StringView path, Custody& 
 KResult VFS::chmod(Custody& custody, mode_t mode)
 {
     auto& inode = custody.inode();
-    if (inode.fs().is_readonly())
-        return KResult(-EROFS);
 
     if (Process::current->euid() != inode.metadata().uid && !Process::current->is_superuser())
         return KResult(-EPERM);
+    if (custody.is_readonly())
+        return KResult(-EROFS);
 
     // Only change the permission bits.
     mode = (inode.mode() & ~04777u) | (mode & 04777u);
@@ -449,6 +465,9 @@ KResult VFS::rename(StringView old_path, StringView new_path, Custody& base)
             return KResult(-EACCES);
     }
 
+    if (old_parent_custody->is_readonly() || new_parent_custody->is_readonly())
+        return KResult(-EROFS);
+
     auto new_basename = LexicalPath(new_path).basename();
 
     if (!new_custody_or_error.is_error()) {
@@ -482,9 +501,6 @@ KResult VFS::rename(StringView old_path, StringView new_path, Custody& base)
 KResult VFS::chown(Custody& custody, uid_t a_uid, gid_t a_gid)
 {
     auto& inode = custody.inode();
-    if (inode.fs().is_readonly())
-        return KResult(-EROFS);
-
     auto metadata = inode.metadata();
 
     if (Process::current->euid() != metadata.uid && !Process::current->is_superuser())
@@ -503,6 +519,9 @@ KResult VFS::chown(Custody& custody, uid_t a_uid, gid_t a_gid)
             return KResult(-EPERM);
         new_gid = a_gid;
     }
+
+    if (custody.is_readonly())
+        return KResult(-EROFS);
 
     dbg() << "VFS::chown(): inode " << inode.identifier() << " <- uid:" << new_uid << " gid:" << new_gid;
 
@@ -546,14 +565,14 @@ KResult VFS::link(StringView old_path, StringView new_path, Custody& base)
     if (parent_inode.fsid() != old_inode.fsid())
         return KResult(-EXDEV);
 
-    if (parent_inode.fs().is_readonly())
-        return KResult(-EROFS);
-
     if (!parent_inode.metadata().may_write(*Process::current))
         return KResult(-EACCES);
 
     if (old_inode.is_directory())
         return KResult(-EPERM);
+
+    if (parent_custody->is_readonly())
+        return KResult(-EROFS);
 
     return parent_inode.add_child(old_inode.identifier(), LexicalPath(new_path).basename(), old_inode.mode());
 }
@@ -570,6 +589,11 @@ KResult VFS::unlink(StringView path, Custody& base)
     if (inode.is_directory())
         return KResult(-EISDIR);
 
+    // We have just checked that the inode is not a directory, and thus it's not
+    // the root. So it should have a parent. Note that this would be invalidated
+    // if we were to support bind-mounting regular files on top of the root.
+    ASSERT(parent_custody);
+
     auto& parent_inode = parent_custody->inode();
     if (!parent_inode.metadata().may_write(*Process::current))
         return KResult(-EACCES);
@@ -578,6 +602,9 @@ KResult VFS::unlink(StringView path, Custody& base)
         if (!Process::current->is_superuser() && inode.metadata().uid != Process::current->euid())
             return KResult(-EACCES);
     }
+
+    if (parent_custody->is_readonly())
+        return KResult(-EROFS);
 
     auto result = parent_inode.remove_child(LexicalPath(path).basename());
     if (result.is_error())
@@ -599,6 +626,8 @@ KResult VFS::symlink(StringView target, StringView linkpath, Custody& base)
     auto& parent_inode = parent_custody->inode();
     if (!parent_inode.metadata().may_write(*Process::current))
         return KResult(-EACCES);
+    if (parent_custody->is_readonly())
+        return KResult(-EROFS);
 
     LexicalPath p(linkpath);
     dbg() << "VFS::symlink: '" << p.basename() << "' (-> '" << target << "') in " << parent_inode.identifier();
@@ -621,8 +650,6 @@ KResult VFS::rmdir(StringView path, Custody& base)
 
     auto& custody = *custody_or_error.value();
     auto& inode = custody.inode();
-    if (inode.fs().is_readonly())
-        return KResult(-EROFS);
 
     // FIXME: We should return EINVAL if the last component of the path is "."
     // FIXME: We should return ENOTEMPTY if the last component of the path is ".."
@@ -640,6 +667,9 @@ KResult VFS::rmdir(StringView path, Custody& base)
 
     if (inode.directory_entry_count() != 2)
         return KResult(-ENOTEMPTY);
+
+    if (custody.is_readonly())
+        return KResult(-EROFS);
 
     auto result = inode.remove_child(".");
     if (result.is_error())

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -91,6 +91,20 @@ KResult VFS::bind_mount(Custody& source, Custody& mount_point, int flags)
     return KSuccess;
 }
 
+KResult VFS::remount(Custody& mount_point, int new_flags)
+{
+    LOCKER(m_lock);
+
+    dbg() << "VFS: Remounting " << mount_point.absolute_path();
+
+    Mount* mount = find_mount_for_guest(mount_point.inode().identifier());
+    if (!mount)
+        return KResult(-ENODEV);
+
+    mount->set_flags(new_flags);
+    return KSuccess;
+}
+
 KResult VFS::unmount(InodeIdentifier guest_inode_id)
 {
     LOCKER(m_lock);

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -42,6 +42,7 @@ namespace Kernel {
 
 static VFS* s_the;
 static constexpr int symlink_recursion_limit { 5 }; // FIXME: increase?
+static constexpr int root_mount_flags = MS_NODEV | MS_NOSUID | MS_RDONLY;
 
 VFS& VFS::the()
 {
@@ -116,7 +117,7 @@ bool VFS::mount_root(FS& file_system)
         return false;
     }
 
-    Mount mount { file_system, nullptr, MS_NODEV | MS_NOSUID };
+    Mount mount { file_system, nullptr, root_mount_flags };
 
     auto root_inode_id = mount.guest().fs()->root_inode();
     auto root_inode = mount.guest().fs()->get_inode(root_inode_id);
@@ -734,7 +735,7 @@ void VFS::sync()
 Custody& VFS::root_custody()
 {
     if (!m_root_custody)
-        m_root_custody = Custody::create(nullptr, "", *m_root_inode, MS_NODEV | MS_NOSUID);
+        m_root_custody = Custody::create(nullptr, "", *m_root_inode, root_mount_flags);
     return *m_root_custody;
 }
 

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -66,6 +66,7 @@ public:
         String absolute_path() const;
 
         int flags() const { return m_flags; }
+        void set_flags(int flags) { m_flags = flags; }
 
     private:
         InodeIdentifier m_host;
@@ -83,6 +84,7 @@ public:
     bool mount_root(FS&);
     KResult mount(FS&, Custody& mount_point, int flags);
     KResult bind_mount(Custody& source, Custody& mount_point, int flags);
+    KResult remount(Custody& mount_point, int new_flags);
     KResult unmount(InodeIdentifier guest_inode_id);
 
     KResultOr<NonnullRefPtr<FileDescription>> open(StringView path, int options, mode_t mode, Custody& base, Optional<UidAndGid> = {});

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -40,31 +40,6 @@
 
 namespace Kernel {
 
-#define O_RDONLY (1 << 0)
-#define O_WRONLY (1 << 1)
-#define O_RDWR (O_RDONLY | O_WRONLY)
-#define O_ACCMODE (O_RDONLY | O_WRONLY)
-#define O_EXEC (1 << 2)
-#define O_CREAT (1 << 3)
-#define O_EXCL (1 << 4)
-#define O_NOCTTY (1 << 5)
-#define O_TRUNC (1 << 6)
-#define O_APPEND (1 << 7)
-#define O_NONBLOCK (1 << 8)
-#define O_DIRECTORY (1 << 9)
-#define O_NOFOLLOW (1 << 10)
-#define O_CLOEXEC (1 << 11)
-#define O_DIRECT (1 << 12)
-
-// Kernel internal options
-#define O_NOFOLLOW_NOERROR (1 << 29)
-#define O_UNLINK_INTERNAL (1 << 30)
-
-#define MS_NODEV 1
-#define MS_NOEXEC 2
-#define MS_NOSUID 4
-#define MS_BIND 8
-
 class Custody;
 class Device;
 class FileDescription;

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -118,9 +118,9 @@ public:
     KResult symlink(StringView target, StringView linkpath, Custody& base);
     KResult rmdir(StringView path, Custody& base);
     KResult chmod(StringView path, mode_t, Custody& base);
-    KResult chmod(Inode&, mode_t);
+    KResult chmod(Custody&, mode_t);
     KResult chown(StringView path, uid_t, gid_t, Custody& base);
-    KResult chown(Inode&, uid_t, gid_t);
+    KResult chown(Custody&, uid_t, gid_t);
     KResult access(StringView path, int mode, Custody& base);
     KResultOr<InodeMetadata> lookup_metadata(StringView path, Custody& base, int options = 0);
     KResult utime(StringView path, Custody& base, time_t atime, time_t mtime);

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -132,8 +132,7 @@ private:
     Lock m_lock { "VFSLock" };
 
     RefPtr<Inode> m_root_inode;
-    Vector<Mount> m_mounts;
-
+    Vector<Mount, 16> m_mounts;
     RefPtr<Custody> m_root_custody;
 };
 

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -375,7 +375,7 @@ KResult LocalSocket::getsockopt(FileDescription& description, int level, int opt
     }
 }
 
-KResult LocalSocket::chmod(mode_t mode)
+KResult LocalSocket::chmod(FileDescription&, mode_t mode)
 {
     if (m_file)
         return m_file->chmod(mode);
@@ -384,7 +384,7 @@ KResult LocalSocket::chmod(mode_t mode)
     return KSuccess;
 }
 
-KResult LocalSocket::chown(uid_t uid, gid_t gid)
+KResult LocalSocket::chown(FileDescription&, uid_t uid, gid_t gid)
 {
     if (m_file)
         return m_file->chown(uid, gid);

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -60,8 +60,8 @@ public:
     virtual ssize_t sendto(FileDescription&, const void*, size_t, int, const sockaddr*, socklen_t) override;
     virtual ssize_t recvfrom(FileDescription&, void*, size_t, int flags, sockaddr*, socklen_t*) override;
     virtual KResult getsockopt(FileDescription&, int level, int option, void*, socklen_t*) override;
-    virtual KResult chown(uid_t, gid_t) override;
-    virtual KResult chmod(mode_t) override;
+    virtual KResult chown(FileDescription&, uid_t, gid_t) override;
+    virtual KResult chmod(FileDescription&, mode_t) override;
 
 private:
     explicit LocalSocket(int type);

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -4103,6 +4103,11 @@ int Process::sys$mount(const Syscall::SC_mount_params* user_params)
 
     auto& target_custody = custody_or_error.value();
 
+    if (params.flags & MS_REMOUNT) {
+        // We're not creating a new mount, we're updating an existing one!
+        return VFS::the().remount(target_custody, params.flags & ~MS_REMOUNT);
+    }
+
     if (params.flags & MS_BIND) {
         // We're doing a bind mount.
         if (description.is_null())

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -430,7 +430,8 @@ void* Process::sys$mmap(const Syscall::SC_mmap_params* user_params)
             return (void*)-EBADF;
         if (description->is_directory())
             return (void*)-ENODEV;
-        if ((prot & PROT_READ) && !description->is_readable())
+        // Require read access even when read protection is not requested.
+        if (!description->is_readable())
             return (void*)-EACCES;
         if (map_shared) {
             if ((prot & PROT_WRITE) && !description->is_writable())

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -4088,7 +4088,7 @@ int Process::sys$mount(const Syscall::SC_mount_params* user_params)
     auto target = validate_and_copy_string_from_user(params.target);
     auto fs_type = validate_and_copy_string_from_user(params.fs_type);
 
-    if (target.is_null() || fs_type.is_null())
+    if (target.is_null())
         return -EFAULT;
 
     auto description = file_description(source_fd);
@@ -4103,8 +4103,6 @@ int Process::sys$mount(const Syscall::SC_mount_params* user_params)
 
     auto& target_custody = custody_or_error.value();
 
-    RefPtr<FS> fs;
-
     if (params.flags & MS_BIND) {
         // We're doing a bind mount.
         if (description.is_null())
@@ -4115,6 +4113,8 @@ int Process::sys$mount(const Syscall::SC_mount_params* user_params)
         }
         return VFS::the().bind_mount(*description->custody(), target_custody, params.flags);
     }
+
+    RefPtr<FS> fs;
 
     if (fs_type == "ext2" || fs_type == "Ext2FS") {
         if (description.is_null())

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -1345,6 +1345,8 @@ Process* Process::create_user_process(Thread*& first_thread, const String& path,
 
     error = process->exec(path, move(arguments), move(environment));
     if (error != 0) {
+        dbg() << "Failed to exec " << path << ": " << error;
+        delete first_thread;
         delete process;
         return nullptr;
     }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -318,6 +318,9 @@ static bool validate_inode_mmap_prot(const Process& process, int prot, const Ino
         return false;
 
     if (map_shared) {
+        // FIXME: What about readonly filesystem mounts? We cannot make a
+        // decision here without knowing the mount flags, so we would need to
+        // keep a Custody or something from mmap time.
         if ((prot & PROT_WRITE) && !metadata.may_write(process))
             return false;
         InterruptDisabler disabler;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -4104,14 +4104,16 @@ int Process::sys$mount(const Syscall::SC_mount_params* user_params)
         // We're doing a bind mount.
         if (description.is_null())
             return -EBADF;
-        ASSERT(description->custody());
+        if (!description->custody()) {
+            // We only support bind-mounting inodes, not arbitrary files.
+            return -ENODEV;
+        }
         return VFS::the().bind_mount(*description->custody(), target_custody, params.flags);
     }
 
     if (fs_type == "ext2" || fs_type == "Ext2FS") {
         if (description.is_null())
             return -EBADF;
-        ASSERT(description->custody());
         if (!description->file().is_seekable()) {
             dbg() << "mount: this is not a seekable file";
             return -ENODEV;

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -52,6 +52,7 @@
 #define MS_NOEXEC (1 << 1)
 #define MS_NOSUID (1 << 2)
 #define MS_BIND (1 << 3)
+#define MS_RDONLY (1 << 4)
 
 #define PERF_EVENT_MALLOC 1
 #define PERF_EVENT_FREE 2

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -28,6 +28,31 @@
 
 #include <AK/Types.h>
 
+#define O_RDONLY (1 << 0)
+#define O_WRONLY (1 << 1)
+#define O_RDWR (O_RDONLY | O_WRONLY)
+#define O_ACCMODE (O_RDONLY | O_WRONLY)
+#define O_EXEC (1 << 2)
+#define O_CREAT (1 << 3)
+#define O_EXCL (1 << 4)
+#define O_NOCTTY (1 << 5)
+#define O_TRUNC (1 << 6)
+#define O_APPEND (1 << 7)
+#define O_NONBLOCK (1 << 8)
+#define O_DIRECTORY (1 << 9)
+#define O_NOFOLLOW (1 << 10)
+#define O_CLOEXEC (1 << 11)
+#define O_DIRECT (1 << 12)
+
+// Kernel internal options.
+#define O_NOFOLLOW_NOERROR (1 << 29)
+#define O_UNLINK_INTERNAL (1 << 30)
+
+#define MS_NODEV (1 << 0)
+#define MS_NOEXEC (1 << 1)
+#define MS_NOSUID (1 << 2)
+#define MS_BIND (1 << 3)
+
 #define PERF_EVENT_MALLOC 1
 #define PERF_EVENT_FREE 2
 

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -53,6 +53,7 @@
 #define MS_NOSUID (1 << 2)
 #define MS_BIND (1 << 3)
 #define MS_RDONLY (1 << 4)
+#define MS_REMOUNT (1 << 5)
 
 #define PERF_EVENT_MALLOC 1
 #define PERF_EVENT_FREE 2

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -154,6 +154,7 @@ enum {
 #define MS_NOSUID (1 << 2)
 #define MS_BIND (1 << 3)
 #define MS_RDONLY (1 << 4)
+#define MS_REMOUNT (1 << 5)
 
 /*
  * We aren't fully compliant (don't support policies, and don't have a wide

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -153,6 +153,7 @@ enum {
 #define MS_NOEXEC (1 << 1)
 #define MS_NOSUID (1 << 2)
 #define MS_BIND (1 << 3)
+#define MS_RDONLY (1 << 4)
 
 /*
  * We aren't fully compliant (don't support policies, and don't have a wide

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -149,10 +149,10 @@ enum {
 #define X_OK 1
 #define F_OK 0
 
-#define MS_NODEV 1
-#define MS_NOEXEC 2
-#define MS_NOSUID 4
-#define MS_BIND 8
+#define MS_NODEV (1 << 0)
+#define MS_NOEXEC (1 << 1)
+#define MS_NOSUID (1 << 2)
+#define MS_BIND (1 << 3)
 
 /*
  * We aren't fully compliant (don't support policies, and don't have a wide

--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -45,6 +45,7 @@
 #include <string.h>
 #include <sys/select.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
@@ -250,8 +251,22 @@ EventLoop::~EventLoop()
 
 bool EventLoop::start_rpc_server()
 {
-    auto rpc_path = String::format("/tmp/rpc.%d", getpid());
-    int rc = unlink(rpc_path.characters());
+    // Create /tmp/rpc if it doesn't exist.
+    int rc = mkdir("/tmp/rpc", 0777);
+    if (rc == 0) {
+        // Ensure it gets created as 0777 despite our umask.
+        rc = chmod("/tmp/rpc", 0777);
+        if (rc < 0) {
+            perror("chmod /tmp/rpc");
+            // Continue further.
+        }
+    } else if (errno != EEXIST) {
+        perror("mkdir /tmp/rpc");
+        return false;
+    }
+
+    auto rpc_path = String::format("/tmp/rpc/%d", getpid());
+    rc = unlink(rpc_path.characters());
     if (rc < 0 && errno != ENOENT) {
         perror("unlink");
         return false;

--- a/Libraries/LibCore/EventLoop.h
+++ b/Libraries/LibCore/EventLoop.h
@@ -76,6 +76,7 @@ public:
     static void wake();
 
 private:
+    bool start_rpc_server();
     void wait_for_event(WaitMode);
     Optional<struct timeval> get_next_timer_expiration();
 

--- a/Libraries/LibCore/LocalServer.cpp
+++ b/Libraries/LibCore/LocalServer.cpp
@@ -123,13 +123,13 @@ bool LocalServer::listen(const String& address)
     rc = ::bind(m_fd, (const sockaddr*)&un, sizeof(un));
     if (rc < 0) {
         perror("bind");
-        ASSERT_NOT_REACHED();
+        return false;
     }
 
     rc = ::listen(m_fd, 5);
     if (rc < 0) {
         perror("listen");
-        ASSERT_NOT_REACHED();
+        return false;
     }
 
     m_listening = true;

--- a/Userland/chroot.cpp
+++ b/Userland/chroot.cpp
@@ -59,6 +59,8 @@ int main(int argc, char** argv)
                     flags |= MS_NOSUID;
                 else if (part == "ro")
                     flags |= MS_RDONLY;
+                else if (part == "remount")
+                    flags |= MS_REMOUNT;
                 else if (part == "bind")
                     fprintf(stderr, "Ignoring -o bind, as it doesn't make sense for chroot\n");
                 else

--- a/Userland/chroot.cpp
+++ b/Userland/chroot.cpp
@@ -57,6 +57,8 @@ int main(int argc, char** argv)
                     flags |= MS_NOEXEC;
                 else if (part == "nosuid")
                     flags |= MS_NOSUID;
+                else if (part == "ro")
+                    flags |= MS_RDONLY;
                 else if (part == "bind")
                     fprintf(stderr, "Ignoring -o bind, as it doesn't make sense for chroot\n");
                 else

--- a/Userland/mount.cpp
+++ b/Userland/mount.cpp
@@ -50,6 +50,8 @@ int parse_options(const StringView& options)
             flags |= MS_NOSUID;
         else if (part == "bind")
             flags |= MS_BIND;
+        else if (part == "ro")
+            flags |= MS_RDONLY;
         else
             fprintf(stderr, "Ignoring invalid option: %s\n", part.to_string().characters());
     }
@@ -157,7 +159,7 @@ bool print_mounts()
 
         printf("%s on %s type %s (", source.characters(), mount_point.characters(), class_name.characters());
 
-        if (readonly)
+        if (readonly || mount_flags & MS_RDONLY)
             printf("ro");
         else
             printf("rw");

--- a/Userland/mount.cpp
+++ b/Userland/mount.cpp
@@ -151,11 +151,11 @@ bool print_mounts()
         auto fs_object = value.as_object();
         auto class_name = fs_object.get("class_name").to_string();
         auto mount_point = fs_object.get("mount_point").to_string();
-        auto device = fs_object.get("device").as_string_or(class_name);
+        auto source = fs_object.get("source").as_string_or("none");
         auto readonly = fs_object.get("readonly").to_bool();
         auto mount_flags = fs_object.get("mount_flags").to_int();
 
-        printf("%s on %s type %s (", device.characters(), mount_point.characters(), class_name.characters());
+        printf("%s on %s type %s (", source.characters(), mount_point.characters(), class_name.characters());
 
         if (readonly)
             printf("ro");

--- a/Userland/mount.cpp
+++ b/Userland/mount.cpp
@@ -52,6 +52,8 @@ int parse_options(const StringView& options)
             flags |= MS_BIND;
         else if (part == "ro")
             flags |= MS_RDONLY;
+        else if (part == "remount")
+            flags |= MS_REMOUNT;
         else
             fprintf(stderr, "Ignoring invalid option: %s\n", part.to_string().characters());
     }


### PR DESCRIPTION
* Read-only FS mounts
* Mount `/` read-only, bind-mount `/home` read-write
* Remounting
* Misc fixes

Caveats:
* It's currently possible to circumvent read-only mounts using `mprotect(PROT_WRITE)`, we have to think of a solution
* Remounting `/` as read-write doesn't do what you think it does

cc @alimpfard if you want some revenge for https://github.com/SerenityOS/serenity/pull/2416