### PR TITLE
PixelPaint: Set active layer to nullptr after its removal

### DIFF
--- a/Applications/PixelPaint/main.cpp
+++ b/Applications/PixelPaint/main.cpp
@@ -184,6 +184,7 @@ int main(int argc, char** argv)
             if (!active_layer)
                 return;
             image_editor.image()->remove_layer(*active_layer);
+            image_editor.set_active_layer(nullptr);
         },
         window));
 


### PR DESCRIPTION
PixelPaint would crash if "Remove Active Layer" would be used twice, without selecting a new layer in the meanwhile.