### PR TITLE
LibJS: Parse and handle labelled statements

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -282,9 +282,9 @@ Value ForStatement::execute(Interpreter& interpreter) const
             if (interpreter.exception())
                 return {};
             if (interpreter.should_unwind()) {
-                if (interpreter.should_unwind_until(ScopeType::Continuable)) {
+                if (interpreter.should_unwind_until(ScopeType::Continuable, m_label)) {
                     interpreter.stop_unwind();
-                } else if (interpreter.should_unwind_until(ScopeType::Breakable)) {
+                } else if (interpreter.should_unwind_until(ScopeType::Breakable, m_label)) {
                     interpreter.stop_unwind();
                     break;
                 } else {
@@ -303,9 +303,9 @@ Value ForStatement::execute(Interpreter& interpreter) const
             if (interpreter.exception())
                 return {};
             if (interpreter.should_unwind()) {
-                if (interpreter.should_unwind_until(ScopeType::Continuable)) {
+                if (interpreter.should_unwind_until(ScopeType::Continuable, m_label)) {
                     interpreter.stop_unwind();
-                } else if (interpreter.should_unwind_until(ScopeType::Breakable)) {
+                } else if (interpreter.should_unwind_until(ScopeType::Breakable, m_label)) {
                     interpreter.stop_unwind();
                     break;
                 } else {
@@ -370,9 +370,9 @@ Value ForInStatement::execute(Interpreter& interpreter) const
             if (interpreter.exception())
                 return {};
             if (interpreter.should_unwind()) {
-                if (interpreter.should_unwind_until(ScopeType::Continuable)) {
+                if (interpreter.should_unwind_until(ScopeType::Continuable, m_label)) {
                     interpreter.stop_unwind();
-                } else if (interpreter.should_unwind_until(ScopeType::Breakable)) {
+                } else if (interpreter.should_unwind_until(ScopeType::Breakable, m_label)) {
                     interpreter.stop_unwind();
                     break;
                 } else {
@@ -437,9 +437,9 @@ Value ForOfStatement::execute(Interpreter& interpreter) const
         if (interpreter.exception())
             return {};
         if (interpreter.should_unwind()) {
-            if (interpreter.should_unwind_until(ScopeType::Continuable)) {
+            if (interpreter.should_unwind_until(ScopeType::Continuable, m_label)) {
                 interpreter.stop_unwind();
-            } else if (interpreter.should_unwind_until(ScopeType::Breakable)) {
+            } else if (interpreter.should_unwind_until(ScopeType::Breakable, m_label)) {
                 interpreter.stop_unwind();
                 break;
             } else {
@@ -1635,7 +1635,7 @@ Value SwitchStatement::execute(Interpreter& interpreter) const
             if (interpreter.exception())
                 return {};
             if (interpreter.should_unwind()) {
-                if (interpreter.should_unwind_until(ScopeType::Breakable)) {
+                if (interpreter.should_unwind_until(ScopeType::Breakable, m_label)) {
                     interpreter.stop_unwind();
                     return {};
                 }
@@ -1655,13 +1655,13 @@ Value SwitchCase::execute(Interpreter& interpreter) const
 
 Value BreakStatement::execute(Interpreter& interpreter) const
 {
-    interpreter.unwind(ScopeType::Breakable);
+    interpreter.unwind(ScopeType::Breakable, m_target_label);
     return js_undefined();
 }
 
 Value ContinueStatement::execute(Interpreter& interpreter) const
 {
-    interpreter.unwind(ScopeType::Continuable);
+    interpreter.unwind(ScopeType::Continuable, m_target_label);
     return js_undefined();
 }
 

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -70,6 +70,12 @@ private:
 };
 
 class Statement : public ASTNode {
+public:
+    const FlyString& label() const { return m_label; }
+    void set_label(FlyString string) { m_label = string; }
+
+protected:
+    FlyString m_label;
 };
 
 class EmptyStatement final : public Statement {

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -1048,22 +1048,36 @@ private:
 
 class BreakStatement final : public Statement {
 public:
-    BreakStatement() { }
+    BreakStatement(FlyString target_label)
+        : m_target_label(target_label)
+    {
+    }
 
     virtual Value execute(Interpreter&) const override;
 
+    const FlyString& target_label() const { return m_target_label; }
+
 private:
     virtual const char* class_name() const override { return "BreakStatement"; }
+
+    FlyString m_target_label;
 };
 
 class ContinueStatement final : public Statement {
 public:
-    ContinueStatement() { }
+    ContinueStatement(FlyString target_label)
+        : m_target_label(target_label)
+    {
+    }
 
     virtual Value execute(Interpreter&) const override;
 
+    const FlyString& target_label() const { return m_target_label; }
+
 private:
     virtual const char* class_name() const override { return "ContinueStatement"; }
+
+    FlyString m_target_label;
 };
 
 class DebuggerStatement final : public Statement {

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -72,8 +72,11 @@ Value Interpreter::run(const Statement& statement, ArgumentVector arguments, Sco
     m_last_value = js_undefined();
     for (auto& node : block.children()) {
         m_last_value = node.execute(*this);
-        if (m_unwind_until != ScopeType::None)
+        if (should_unwind()) {
+            if (should_unwind_until(ScopeType::Breakable, block.label()))
+                stop_unwind();
             break;
+        }
     }
 
     bool did_return = m_unwind_until == ScopeType::Function;

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -91,9 +91,18 @@ public:
 
     Heap& heap() { return m_heap; }
 
-    void unwind(ScopeType type) { m_unwind_until = type; }
+    void unwind(ScopeType type, FlyString label = {})
+    {
+        m_unwind_until = type;
+        m_unwind_until_label = label;
+    }
     void stop_unwind() { m_unwind_until = ScopeType::None; }
-    bool should_unwind_until(ScopeType type) const { return m_unwind_until == type; }
+    bool should_unwind_until(ScopeType type, FlyString label) const
+    {
+        if (m_unwind_until_label.is_null())
+            return m_unwind_until == type;
+        return m_unwind_until == type && m_unwind_until_label == label;
+    }
     bool should_unwind() const { return m_unwind_until != ScopeType::None; }
 
     Value get_variable(const FlyString& name);
@@ -189,6 +198,7 @@ private:
     Exception* m_exception { nullptr };
 
     ScopeType m_unwind_until { ScopeType::None };
+    FlyString m_unwind_until_label;
 
     Console m_console;
 };

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -1113,17 +1113,29 @@ NonnullRefPtr<ThrowStatement> Parser::parse_throw_statement()
 NonnullRefPtr<BreakStatement> Parser::parse_break_statement()
 {
     consume(TokenType::Break);
+    FlyString target_label;
+    if (match(TokenType::Semicolon)) {
+        consume();
+        return create_ast_node<BreakStatement>(target_label);
+    }
+    if (match_identifier_name() && !m_parser_state.m_current_token.trivia().contains('\n'))
+        target_label = consume().value();
     consume_or_insert_semicolon();
-    // FIXME: Handle labels. When fixing this, take care to correctly implement semicolon insertion
-    return create_ast_node<BreakStatement>();
+    return create_ast_node<BreakStatement>(target_label);
 }
 
 NonnullRefPtr<ContinueStatement> Parser::parse_continue_statement()
 {
     consume(TokenType::Continue);
+    FlyString target_label;
+    if (match(TokenType::Semicolon)) {
+        consume();
+        return create_ast_node<ContinueStatement>(target_label);
+    }
+    if (match_identifier_name() && !m_parser_state.m_current_token.trivia().contains('\n'))
+        target_label = consume().value();
     consume_or_insert_semicolon();
-    // FIXME: Handle labels. When fixing this, take care to correctly implement semicolon insertion
-    return create_ast_node<ContinueStatement>();
+    return create_ast_node<ContinueStatement>(target_label);
 }
 
 NonnullRefPtr<ConditionalExpression> Parser::parse_conditional_expression(NonnullRefPtr<Expression> test)

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -269,9 +269,11 @@ NonnullRefPtr<Statement> Parser::parse_statement()
         consume();
         return create_ast_node<EmptyStatement>();
     default:
-        auto result = try_parse_labelled_statement();
-        if (!result.is_null())
-            return result.release_nonnull();
+        if (match(TokenType::Identifier)) {
+            auto result = try_parse_labelled_statement();
+            if (!result.is_null())
+                return result.release_nonnull();
+        }
         if (match_expression()) {
             auto expr = parse_expression(0);
             consume_or_insert_semicolon();
@@ -1118,7 +1120,7 @@ NonnullRefPtr<BreakStatement> Parser::parse_break_statement()
         consume();
         return create_ast_node<BreakStatement>(target_label);
     }
-    if (match_identifier_name() && !m_parser_state.m_current_token.trivia().contains('\n'))
+    if (match(TokenType::Identifier) && !m_parser_state.m_current_token.trivia().contains('\n'))
         target_label = consume().value();
     consume_or_insert_semicolon();
     return create_ast_node<BreakStatement>(target_label);
@@ -1132,7 +1134,7 @@ NonnullRefPtr<ContinueStatement> Parser::parse_continue_statement()
         consume();
         return create_ast_node<ContinueStatement>(target_label);
     }
-    if (match_identifier_name() && !m_parser_state.m_current_token.trivia().contains('\n'))
+    if (match(TokenType::Identifier) && !m_parser_state.m_current_token.trivia().contains('\n'))
         target_label = consume().value();
     consume_or_insert_semicolon();
     return create_ast_node<ContinueStatement>(target_label);

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -78,6 +78,7 @@ public:
     NonnullRefPtr<CallExpression> parse_call_expression(NonnullRefPtr<Expression>);
     NonnullRefPtr<NewExpression> parse_new_expression();
     RefPtr<FunctionExpression> try_parse_arrow_function_expression(bool expect_parens);
+    RefPtr<Statement> try_parse_labelled_statement();
 
     struct Error {
         String message;

--- a/Libraries/LibJS/Tests/automatic-semicolon-insertion.js
+++ b/Libraries/LibJS/Tests/automatic-semicolon-insertion.js
@@ -25,9 +25,13 @@ function bar() {
 }
 
 function foo() {
+    label:
     for (var i = 0; i < 4; i++) {
         break // semicolon inserted here
         continue // semicolon inserted here
+
+        break label // semicolon inserted here
+        continue label // semicolon inserted here
     }
 
     var j // semicolon inserted here
@@ -39,8 +43,25 @@ function foo() {
     1;
 var curly/* semicolon inserted here */}
 
+function baz() {
+    let counter = 0;
+    let outer;
+
+    outer:
+    for (let i = 0; i < 5; ++i) {
+        for (let j = 0; j < 5; ++j) {
+            continue // semicolon inserted here
+            outer // semicolon inserted here
+        }
+        counter++;
+    }
+
+    return counter;
+}
+
 try {
     assert(foo() === undefined);
+    assert(baz() === 5);
 
     console.log("PASS");
 } catch (e) {

--- a/Libraries/LibJS/Tests/labels.js
+++ b/Libraries/LibJS/Tests/labels.js
@@ -1,11 +1,41 @@
 load("test-common.js");
 
 try {
-    test:
-    {
+    test: {
         let o = 1;
         assert(o === 1);
+        break test;
+        assertNotReached();
     }
+
+    outer: {
+        {
+            break outer;
+        }
+        assertNotReached();
+    }
+
+    let counter = 0;
+    outer:
+    for (a of [1, 2, 3]) {
+        for (b of [4, 5, 6]) {
+            if (a === 2 && b === 5)
+                break outer;
+            counter++;
+        }
+    }
+    assert(counter === 4);
+
+    let counter = 0;
+    outer:
+    for (a of [1, 2, 3]) {
+        for (b of [4, 5, 6]) {
+            if (b === 6)
+                continue outer;
+            counter++;
+        }
+    }
+    assert(counter === 6);
 
     console.log("PASS");
 } catch (e) {

--- a/Libraries/LibJS/Tests/labels.js
+++ b/Libraries/LibJS/Tests/labels.js
@@ -1,0 +1,13 @@
+load("test-common.js");
+
+try {
+    test:
+    {
+        let o = 1;
+        assert(o === 1);
+    }
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
This patch introduces labels to the JS engine. All statements can be labelled, and most statements (not functions) can be broken out of. 

Known label issues:

1. Attempting to type something like the following in the REPL does not compile on line 1 (I'm not sure how to fix this; I'll open an issue if this PR gets merged):

```js
label: 
{
}
```

2. Function labels should not be allowed in strict mode. To do this, I'm thinking of introducing a way to test syntax errors. My thought is that we can have a `LibJS/Tests/SyntaxErrors` folder, where every file has to produce a syntax error to pass.

I'm sure there are more, but this is just the initial feature introduction. Other issues can be fixed as they get discovered. 