### PR TITLE
LibJS: New expressions look for expressions with correct precedence

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -893,8 +893,7 @@ NonnullRefPtr<NewExpression> Parser::parse_new_expression()
 {
     consume(TokenType::New);
 
-    // FIXME: Support full expressions as the callee as well.
-    auto callee = create_ast_node<Identifier>(consume(TokenType::Identifier).value());
+    auto callee = parse_expression(g_operator_precedence.get(TokenType::New).value(), Associativity::Right, { TokenType::ParenOpen });
 
     Vector<CallExpression::Argument> arguments;
 

--- a/Libraries/LibJS/Tests/new-expression.js
+++ b/Libraries/LibJS/Tests/new-expression.js
@@ -1,0 +1,51 @@
+load("test-common.js");
+
+try {
+    function Foo() { this.x = 1; }
+
+    let foo = new Foo();
+    assert(foo.x === 1);
+
+    foo = new Foo
+    assert(foo.x === 1);
+
+    foo = new
+    Foo
+    ()
+    assert(foo.x === 1);
+
+    foo = new Foo + 2
+    assert(foo === "[object Object]2");
+
+    let a = {
+        b: function() {
+            this.x = 2;
+        },
+    };
+
+    foo = new a.b();
+    assert(foo.x === 2);
+
+    foo = new a.b;
+    assert(foo.x === 2);
+
+    foo = new
+    a.b();
+    assert(foo.x === 2);
+
+    function funcGetter() {
+        return function(a, b) {
+            this.x = a + b;
+        };
+    };
+
+    foo = new funcGetter()(1, 5);
+    assert(foo === undefined);
+
+    foo = new (funcGetter())(1, 5);
+    assert(foo.x === 6);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
This seems too easy, but from all my testing it seems to work correctly with precedence. The reason there aren't any tests with this PR is because I can't really test it without either 1) being able to test files for syntax errors or 2) new expressions actually working with proper `this` values. So until one of those things happens, this will be test-less.

Also, shout-out to google for easy bug hunting :)