### PR TITLE
Core: Notifier::Exceptional; Shell: more completion stuff

### DIFF
--- a/Libraries/LibCore/Event.h
+++ b/Libraries/LibCore/Event.h
@@ -42,18 +42,19 @@ public:
         Timer,
         NotifierRead,
         NotifierWrite,
+        NotifierExceptional,
         DeferredInvoke,
         ChildAdded,
         ChildRemoved,
         Custom,
     };
 
-    Event() {}
+    Event() { }
     explicit Event(unsigned type)
         : m_type(type)
     {
     }
-    virtual ~Event() {}
+    virtual ~Event() { }
 
     unsigned type() const { return m_type; }
 
@@ -87,7 +88,7 @@ public:
         , m_timer_id(timer_id)
     {
     }
-    ~TimerEvent() {}
+    ~TimerEvent() { }
 
     int timer_id() const { return m_timer_id; }
 
@@ -102,7 +103,7 @@ public:
         , m_fd(fd)
     {
     }
-    ~NotifierReadEvent() {}
+    ~NotifierReadEvent() { }
 
     int fd() const { return m_fd; }
 
@@ -117,7 +118,22 @@ public:
         , m_fd(fd)
     {
     }
-    ~NotifierWriteEvent() {}
+    ~NotifierWriteEvent() { }
+
+    int fd() const { return m_fd; }
+
+private:
+    int m_fd;
+};
+
+class NotifierExceptionalEvent final : public Event {
+public:
+    explicit NotifierExceptionalEvent(int fd)
+        : Event(Event::NotifierExceptional)
+        , m_fd(fd)
+    {
+    }
+    ~NotifierExceptionalEvent() { }
 
     int fd() const { return m_fd; }
 
@@ -149,7 +165,7 @@ public:
         , m_data(data)
     {
     }
-    ~CustomEvent() {}
+    ~CustomEvent() { }
 
     int custom_type() const { return m_custom_type; }
     void* data() { return m_data; }

--- a/Libraries/LibCore/Notifier.cpp
+++ b/Libraries/LibCore/Notifier.cpp
@@ -58,6 +58,8 @@ void Notifier::event(Core::Event& event)
         on_ready_to_read();
     } else if (event.type() == Core::Event::NotifierWrite && on_ready_to_write) {
         on_ready_to_write();
+    } else if (event.type() == Core::Event::NotifierExceptional && on_exceptional_event) {
+        on_exceptional_event();
     } else {
         Object::event(event);
     }

--- a/Libraries/LibCore/Notifier.h
+++ b/Libraries/LibCore/Notifier.h
@@ -47,6 +47,7 @@ public:
 
     Function<void()> on_ready_to_read;
     Function<void()> on_ready_to_write;
+    Function<void()> on_exceptional_event;
 
     int fd() const { return m_fd; }
     unsigned event_mask() const { return m_event_mask; }

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -110,20 +110,22 @@ public:
     Function<void()> on_interrupt_handled;
     Function<void(Editor&)> on_display_refresh;
 
-    // FIXME: we will have to kindly ask our instantiators to set our signal handlers,
-    // since we can not do this cleanly ourselves. (signal() limitation: cannot give member functions)
+    // FIXME: We cannot safely detect a specific signal, so we will have to rely on
+    //        our users to tell us if the signal was indeed a WINCH.
+    void resized() { m_was_resized = true; }
+
     void interrupted()
     {
         if (m_is_editing)
             m_was_interrupted = true;
     }
-    void resized() { m_was_resized = true; }
 
     size_t cursor() const { return m_cursor; }
     const Vector<u32, 1024>& buffer() const { return m_buffer; }
     u32 buffer_at(size_t pos) const { return m_buffer.at(pos); }
     String line() const { return line(m_buffer.size()); }
     String line(size_t up_to_index) const;
+    void reposition_origin();
 
     // Only makes sense inside a character_input callback or on_* callback.
     void set_prompt(const String& prompt)
@@ -223,6 +225,7 @@ private:
 
     void refresh_display();
     void cleanup();
+    void handle_interrupt();
 
     void restore()
     {
@@ -324,7 +327,6 @@ private:
 
     HashMap<char, NonnullOwnPtr<KeyCallback>> m_key_callbacks;
 
-    // TODO: handle signals internally.
     struct termios m_termios, m_default_termios;
     bool m_was_interrupted { false };
     bool m_was_resized { false };

--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -61,7 +61,7 @@ struct Redirection {
     Type type;
     int fd { -1 };
     int rewire_fd { -1 };
-    String path {};
+    Token path {};
 };
 
 struct Rewiring {

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -1749,8 +1749,12 @@ void Shell::custom_event(Core::CustomEvent& event)
         auto* job_ptr = event.data();
         if (job_ptr) {
             auto& job = *(Job*)job_ptr;
-            if (job.is_running_in_background())
-                fprintf(stderr, "Shell: Job %d(%s) exited\n", job.pid(), job.cmd().characters());
+            if (job.is_running_in_background()) {
+                fprintf(stderr, "\nShell: Job %d(%s) exited\n", job.pid(), job.cmd().characters());
+                fflush(stderr);
+                if (editor)
+                    editor->reposition_origin();
+            }
             jobs.remove(job.pid());
         }
         return;

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -133,7 +133,7 @@ int main(int argc, char** argv)
     }
 
     editor->on_interrupt_handled = [&] {
-        if (!shell->should_read_more()) {
+        if (shell->should_read_more()) {
             shell->finish_command();
             editor->finish();
         }


### PR DESCRIPTION
- `EINTR` treated as "exceptional event" for Notifiers, callback added
- LibLine: ^C works again
- Shell: redirection path completion
```
$ ls foob*
foobar
$ foo > "foob<tab>
$ foo > "foobar"
```

update: @bugaevc pls