### PR TITLE
Shell: Correctly complete paths in redirections

### DIFF
--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -61,7 +61,7 @@ struct Redirection {
     Type type;
     int fd { -1 };
     int rewire_fd { -1 };
-    String path {};
+    Token path {};
 };
 
 struct Rewiring {


### PR DESCRIPTION
This commit allows the Shell to complete paths in redirections.
A closing quote is added if the path is an unclosed quote.
```
$ foo > "foob<tab>
$ foo > "foobar"
```