### PR TITLE
LibGUI: Fix TextEditor crashing when selecting a blank line

### DIFF
--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -498,12 +498,14 @@ void TextEditor::paint_event(PaintEvent& event)
 
                     painter.fill_rect(selection_rect, background_color);
 
-                    Utf32View visual_selected_text {
-                        visual_line_text.codepoints() + start_of_selection_within_visual_line,
-                        end_of_selection_within_visual_line - start_of_selection_within_visual_line
-                    };
+                    if (visual_line_text.codepoints()) {
+                        Utf32View visual_selected_text {
+                            visual_line_text.codepoints() + start_of_selection_within_visual_line,
+                            end_of_selection_within_visual_line - start_of_selection_within_visual_line
+                        };
 
-                    painter.draw_text(selection_rect, visual_selected_text, Gfx::TextAlignment::CenterLeft, text_color);
+                        painter.draw_text(selection_rect, visual_selected_text, Gfx::TextAlignment::CenterLeft, text_color);
+                    }
                 }
             }
             ++visual_line_index;


### PR DESCRIPTION
Previously, the TextEditor would crash when selecting a line with no codepoints due to a null dereference, so this patch makes sure there is actually any text to render before giving it to the painter.