### PR TITLE
LibJS: Parse arrow function expression with correct precedence

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -370,7 +370,7 @@ RefPtr<FunctionExpression> Parser::try_parse_arrow_function_expression(bool expe
             // for arrow function bodies which are a single expression.
             // Esprima generates a single "ArrowFunctionExpression"
             // with a "body" property.
-            auto return_expression = parse_expression(0);
+            auto return_expression = parse_expression(2);
             auto return_block = create_ast_node<BlockStatement>();
             return_block->append<ReturnStatement>(move(return_expression));
             return return_block;
@@ -848,8 +848,7 @@ NonnullRefPtr<Expression> Parser::parse_secondary_expression(NonnullRefPtr<Expre
                 syntax_error(
                     String::format("'%s' cannot be assigned to in strict mode code", name.characters()),
                     m_parser_state.m_current_token.line_number(),
-                    m_parser_state.m_current_token.line_column()
-                );
+                    m_parser_state.m_current_token.line_column());
             }
         }
         return create_ast_node<AssignmentExpression>(AssignmentOp::Assignment, move(lhs), parse_expression(min_precedence, associativity));

--- a/Libraries/LibJS/Tests/Array.prototype.reduce.js
+++ b/Libraries/LibJS/Tests/Array.prototype.reduce.js
@@ -67,8 +67,7 @@ try {
     result = [5, 4, 3, 2, 1].reduce((accum, elem) => accum + elem);
     assert(result === 15);
 
-    // likely parser bug: arrow func parser eats ", 100" as a part of the function, hence the parens  
-    result = [1, 2, 3, 4, 5, 6].reduce(((accum, elem) => accum + elem), 100);
+    result = [1, 2, 3, 4, 5, 6].reduce((accum, elem) => accum + elem, 100);
     assert(result === 121);
 
     result = [6, 5, 4, 3, 2, 1].reduce((accum, elem) => { return accum + elem }, 100);

--- a/Libraries/LibJS/Tests/arrow-functions.js
+++ b/Libraries/LibJS/Tests/arrow-functions.js
@@ -16,6 +16,10 @@ try {
     };
     assert(addBlock(5, 4) === 9);
 
+    let chompy = [(x) => x, 2];
+    assert(chompy.length === 2);
+    assert(chompy[0](1) === 1); 
+
     const makeObject = (a, b) => ({ a, b });
     const obj = makeObject(33, 44);
     assert(typeof obj === "object");


### PR DESCRIPTION
The parser was chomping on commas present after the arrow function expression. eg. `[x=>x,2]` would parse as `[x=>(x,2)]` instead of `[(x=>x),2]`.

This is not the case anymore. I've added a small test to prove this.
