### PR TITLE
LibJS: Rewrite Parser.parse_object_expression()

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -793,7 +793,7 @@ public:
         Spread,
     };
 
-    ObjectProperty(NonnullRefPtr<Expression> key, NonnullRefPtr<Expression> value, Type property_type)
+    ObjectProperty(NonnullRefPtr<Expression> key, RefPtr<Expression> value, Type property_type)
         : m_key(move(key))
         , m_value(move(value))
         , m_property_type(property_type)
@@ -801,7 +801,11 @@ public:
     }
 
     const Expression& key() const { return m_key; }
-    const Expression& value() const { return m_value; }
+    const Expression& value() const
+    {
+        ASSERT(m_value);
+        return *m_value;
+    }
 
     Type type() const { return m_property_type; }
 
@@ -812,7 +816,7 @@ private:
     virtual const char* class_name() const override { return "ObjectProperty"; }
 
     NonnullRefPtr<Expression> m_key;
-    NonnullRefPtr<Expression> m_value;
+    RefPtr<Expression> m_value;
     Type m_property_type;
 };
 

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -46,7 +46,7 @@ public:
     NonnullRefPtr<Program> parse_program();
 
     template<typename FunctionNodeType>
-    NonnullRefPtr<FunctionNodeType> parse_function_node(bool need_function_keyword = true);
+    NonnullRefPtr<FunctionNodeType> parse_function_node(bool check_for_function_and_name = true);
 
     NonnullRefPtr<Statement> parse_statement();
     NonnullRefPtr<BlockStatement> parse_block_statement();

--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -66,6 +66,17 @@ try {
     assert(a[2] === 3);
     assert(o4.test === undefined);
 
+    assertIsSyntaxError("({ get ...foo })");
+    assertIsSyntaxError("({ get... foo })");
+    assertIsSyntaxError("({ get foo })");
+    assertIsSyntaxError("({ get foo: bar })");
+    assertIsSyntaxError("({ get [foo]: bar })");
+    assertIsSyntaxError("({ get ...[foo] })");
+    assertIsSyntaxError("({ get foo(bar) {} })");
+    assertIsSyntaxError("({ set foo() {} })");
+    assertIsSyntaxError("({ set foo(bar, baz) {} })");
+    assertIsSyntaxError("({ ...foo: bar })");
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -51,6 +51,18 @@ function assertThrowsError(testFunction, options) {
 }
 
 /**
+ * Ensures the provided JavaScript source code results in a SyntaxError
+ * @param {string} source The JavaScript source code to compile
+ */
+function assertIsSyntaxError(source) {
+    assertThrowsError(() => {
+        new Function(source)();
+    }, {
+        error: SyntaxError,
+    });
+}
+
+/**
  * Ensures the provided arrays contain exactly the same items.
  * @param {Array} a First array
  * @param {Array} b Second array


### PR DESCRIPTION
This rewrite drastically increases the accuracy of object literals. Additionally, an `assertIsSyntaxError` function has been added to `test-common.js` to assist in testing syntax errors.

Fixes #2359, and adds all of the cases presented in that issue as tests to make sure they result in syntax errors.