### PR TITLE
LibJS: Object.getOwnPropertyDescriptor works properly with accessors

### DIFF
--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -116,6 +116,9 @@ private:
     bool put_own_property(Object& this_object, const FlyString& property_name, Value, u8 attributes, PutOwnPropertyMode = PutOwnPropertyMode::Put, bool throw_exceptions = true);
     bool put_own_property_by_index(Object& this_object, u32 property_index, Value, u8 attributes, PutOwnPropertyMode = PutOwnPropertyMode::Put, bool throw_exceptions = true);
 
+    Value call_native_property_getter(Object* this_object, Value property) const;
+    void call_native_property_setter(Object* this_object, Value property, Value) const;
+
     void set_shape(Shape&);
     void ensure_shape_is_unique();
 

--- a/Libraries/LibJS/Tests/Object.getOwnPropertyDescriptor.js
+++ b/Libraries/LibJS/Tests/Object.getOwnPropertyDescriptor.js
@@ -1,0 +1,51 @@
+load("test-common.js");
+
+try {
+    let o = {
+        foo: "bar",
+        get x() { },
+        set ["hi" + 1](_) { },
+    };
+
+    Object.defineProperty(o, "baz", {
+        enumerable: false,
+        writable: true,
+        value: 10,
+    });
+
+    let d = Object.getOwnPropertyDescriptor(o, "foo");
+    assert(d.enumerable === true);
+    assert(d.configurable === true);
+    assert(d.writable === true);
+    assert(d.value === "bar");
+    assert(d.get === undefined);
+    assert(d.set === undefined);
+
+    let d = Object.getOwnPropertyDescriptor(o, "x");
+    assert(d.enumerable === true);
+    assert(d.configurable === true);
+    assert(d.writable === undefined);
+    assert(d.value === undefined);
+    assert(typeof d.get === "function");
+    assert(d.set === undefined);
+
+    let d = Object.getOwnPropertyDescriptor(o, "hi1");
+    assert(d.enumerable === true);
+    assert(d.configurable === true);
+    assert(d.writable === undefined);
+    assert(d.value === undefined);
+    assert(d.get === undefined);
+    assert(typeof d.set === "function");
+
+    let d = Object.getOwnPropertyDescriptor(o, "baz");
+    assert(d.enumerable === false);
+    assert(d.configurable === false);
+    assert(d.writable === true);
+    assert(d.value === 10);
+    assert(d.get === undefined);
+    assert(d.set === undefined);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}


### PR DESCRIPTION
Also added some methods to shorten the boilerplate for calling native properties.