### PR TITLE
LibGUI/HackStudio: Fix cursor appearance and crash while debugging

### DIFF
--- a/DevTools/HackStudio/Editor.h
+++ b/DevTools/HackStudio/Editor.h
@@ -77,7 +77,6 @@ private:
     bool m_hovering_editor { false };
     bool m_hovering_link { false };
     bool m_holding_ctrl { false };
-    bool m_hovering_lines_ruler { false };
 
     Vector<size_t> m_breakpoint_lines;
     Optional<size_t> m_execution_position;

--- a/Libraries/LibGUI/TextEditor.h
+++ b/Libraries/LibGUI/TextEditor.h
@@ -129,6 +129,8 @@ public:
     const SyntaxHighlighter* syntax_highlighter() const;
     void set_syntax_highlighter(OwnPtr<SyntaxHighlighter>);
 
+    bool is_in_drag_select() const { return m_in_drag_select; }
+
 protected:
     explicit TextEditor(Type = Type::MultiLine);
 

--- a/Libraries/LibGUI/TreeView.cpp
+++ b/Libraries/LibGUI/TreeView.cpp
@@ -377,7 +377,8 @@ void TreeView::did_update_model(unsigned flags)
 void TreeView::did_update_selection()
 {
     AbstractView::did_update_selection();
-    ASSERT(model());
+    if (!model())
+        return;
     auto index = selection().first();
     if (!index.is_valid())
         return;


### PR DESCRIPTION
HackStudio uses a TreeView to display the list of current variables while debugging, and when the program completes, it sets that view's model to a null model. This would trip an assertion if the TreeView had something selected at the time, so this patch lessens the assertion into a simple null check.

Additionally, the cursor would look laggy when moving about the editor because the code was waiting for a window repaint to update the cursor's look when it makes more sense to update the cursor when it actually moves. This change also requires the base GUI::TextEditor to expose a getter to tell if its currently in a drag selection.

Finally, requesting a context menu in the line ruler on the side of the editor would also place/remove breakpoints, which was counter intuitive, so this requires a left click to modify breakpoint placement.