### PR TITLE
LibJS: Add missing arrow function behavior & use bound this/arguments in Interpreter::call()

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -76,7 +76,7 @@ Value FunctionDeclaration::execute(Interpreter& interpreter) const
 
 Value FunctionExpression::execute(Interpreter& interpreter) const
 {
-    return ScriptFunction::create(interpreter.global_object(), name(), body(), parameters(), function_length(), interpreter.current_environment());
+    return ScriptFunction::create(interpreter.global_object(), name(), body(), parameters(), function_length(), interpreter.current_environment(), m_is_arrow_function);
 }
 
 Value ExpressionStatement::execute(Interpreter& interpreter) const

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -223,8 +223,9 @@ class FunctionExpression final
 public:
     static bool must_have_name() { return false; }
 
-    FunctionExpression(const FlyString& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables)
+    FunctionExpression(const FlyString& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables, bool is_arrow_function = false)
         : FunctionNode(name, move(body), move(parameters), function_length, move(variables))
+        , m_is_arrow_function(is_arrow_function)
     {
     }
 
@@ -233,6 +234,8 @@ public:
 
 private:
     virtual const char* class_name() const override { return "FunctionExpression"; }
+
+    bool m_is_arrow_function;
 };
 
 class ErrorExpression final : public Expression {

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -207,9 +207,10 @@ Value Interpreter::call(Function& function, Value this_value, Optional<MarkedVal
 {
     auto& call_frame = push_call_frame();
     call_frame.function_name = function.name();
-    call_frame.this_value = this_value;
+    call_frame.this_value = function.bound_this().value_or(this_value);
+    call_frame.arguments = function.bound_arguments();
     if (arguments.has_value())
-        call_frame.arguments = arguments.value().values();
+        call_frame.arguments.append(arguments.value().values());
     call_frame.environment = function.create_environment();
     auto result = function.call(*this);
     pop_call_frame();

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -382,7 +382,7 @@ RefPtr<FunctionExpression> Parser::try_parse_arrow_function_expression(bool expe
     if (!function_body_result.is_null()) {
         state_rollback_guard.disarm();
         auto body = function_body_result.release_nonnull();
-        return create_ast_node<FunctionExpression>("", move(body), move(parameters), function_length, m_parser_state.m_var_scopes.take_last());
+        return create_ast_node<FunctionExpression>("", move(body), move(parameters), function_length, m_parser_state.m_var_scopes.take_last(), true);
     }
 
     return nullptr;

--- a/Libraries/LibJS/Runtime/Function.h
+++ b/Libraries/LibJS/Runtime/Function.h
@@ -56,7 +56,7 @@ public:
 
 protected:
     explicit Function(Object& prototype);
-    explicit Function(Object& prototype, Value bound_this, Vector<Value> bound_arguments);
+    Function(Object& prototype, Value bound_this, Vector<Value> bound_arguments);
     virtual const char* class_name() const override { return "Function"; }
 
 private:

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -53,7 +53,7 @@ ScriptFunction* ScriptFunction::create(GlobalObject& global_object, const FlyStr
 }
 
 ScriptFunction::ScriptFunction(const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, LexicalEnvironment* parent_environment, Object& prototype, bool is_arrow_function)
-    : Function(prototype)
+    : Function(prototype, is_arrow_function ? interpreter().this_value() : Value(), {})
     , m_name(name)
     , m_body(body)
     , m_parameters(move(parameters))

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -125,6 +125,8 @@ Value ScriptFunction::call(Interpreter& interpreter)
 
 Value ScriptFunction::construct(Interpreter& interpreter)
 {
+    if (m_is_arrow_function)
+        return interpreter.throw_exception<TypeError>(String::format("%s is not a constructor", m_name.characters()));
     return call(interpreter);
 }
 

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -61,7 +61,8 @@ ScriptFunction::ScriptFunction(const FlyString& name, const Statement& body, Vec
     , m_function_length(m_function_length)
     , m_is_arrow_function(is_arrow_function)
 {
-    define_property("prototype", Object::create_empty(interpreter(), interpreter().global_object()), 0);
+    if (!is_arrow_function)
+        define_property("prototype", Object::create_empty(interpreter(), interpreter().global_object()), 0);
     define_native_property("length", length_getter, nullptr, Attribute::Configurable);
     define_native_property("name", name_getter, nullptr, Attribute::Configurable);
 }

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -47,18 +47,19 @@ static ScriptFunction* script_function_from(Interpreter& interpreter)
     return static_cast<ScriptFunction*>(this_object);
 }
 
-ScriptFunction* ScriptFunction::create(GlobalObject& global_object, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, LexicalEnvironment* parent_environment)
+ScriptFunction* ScriptFunction::create(GlobalObject& global_object, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, LexicalEnvironment* parent_environment, bool is_arrow_function)
 {
-    return global_object.heap().allocate<ScriptFunction>(name, body, move(parameters), m_function_length, parent_environment, *global_object.function_prototype());
+    return global_object.heap().allocate<ScriptFunction>(name, body, move(parameters), m_function_length, parent_environment, *global_object.function_prototype(), is_arrow_function);
 }
 
-ScriptFunction::ScriptFunction(const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, LexicalEnvironment* parent_environment, Object& prototype)
+ScriptFunction::ScriptFunction(const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, LexicalEnvironment* parent_environment, Object& prototype, bool is_arrow_function)
     : Function(prototype)
     , m_name(name)
     , m_body(body)
     , m_parameters(move(parameters))
     , m_parent_environment(parent_environment)
     , m_function_length(m_function_length)
+    , m_is_arrow_function(is_arrow_function)
 {
     define_property("prototype", Object::create_empty(interpreter(), interpreter().global_object()), 0);
     define_native_property("length", length_getter, nullptr, Attribute::Configurable);

--- a/Libraries/LibJS/Runtime/ScriptFunction.h
+++ b/Libraries/LibJS/Runtime/ScriptFunction.h
@@ -33,9 +33,9 @@ namespace JS {
 
 class ScriptFunction final : public Function {
 public:
-    static ScriptFunction* create(GlobalObject&, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, LexicalEnvironment* parent_environment);
+    static ScriptFunction* create(GlobalObject&, const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, LexicalEnvironment* parent_environment, bool is_arrow_function = false);
 
-    ScriptFunction(const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, LexicalEnvironment* parent_environment, Object& prototype);
+    ScriptFunction(const FlyString& name, const Statement& body, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, LexicalEnvironment* parent_environment, Object& prototype, bool is_arrow_function = false);
     virtual ~ScriptFunction();
 
     const Statement& body() const { return m_body; }
@@ -61,6 +61,7 @@ private:
     const Vector<FunctionNode::Parameter> m_parameters;
     LexicalEnvironment* m_parent_environment { nullptr };
     i32 m_function_length;
+    bool m_is_arrow_function;
 };
 
 }

--- a/Libraries/LibJS/Tests/Array.prototype.reduce.js
+++ b/Libraries/LibJS/Tests/Array.prototype.reduce.js
@@ -31,7 +31,7 @@ try {
         message: "Reduce of empty array with no initial value"
     });
 
-    [1, 2].reduce(() => { assert(this === undefined) });
+    [1, 2].reduce(function () { assert(this === undefined) });
 
     var callbackCalled = 0;
     var callback = () => { callbackCalled++; return true };

--- a/Libraries/LibJS/Tests/Array.prototype.reduceRight.js
+++ b/Libraries/LibJS/Tests/Array.prototype.reduceRight.js
@@ -43,7 +43,7 @@ try {
     }
   );
 
-  [1, 2].reduceRight(() => {
+  [1, 2].reduceRight(function () {
     assert(this === undefined);
   });
 

--- a/Libraries/LibJS/Tests/Function.prototype.apply.js
+++ b/Libraries/LibJS/Tests/Function.prototype.apply.js
@@ -47,6 +47,8 @@ try {
     var multiply = function (x, y) { return x * y; };
     assert(multiply.apply(null, [3, 4]) === 12);
 
+    assert((() => this).apply("foo") === globalThis);
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);

--- a/Libraries/LibJS/Tests/Function.prototype.bind.js
+++ b/Libraries/LibJS/Tests/Function.prototype.bind.js
@@ -11,6 +11,17 @@ try {
     }
     assert(getB.bind("bar")() === "B");
 
+    // Bound functions should work with array functions
+    var Make3 = Number.bind(null, 3);
+    assert([55].map(Make3)[0] === 3);
+
+    var MakeTrue = Boolean.bind(null, true);
+    assert([1, 2, 3].filter(MakeTrue).length === 3);
+
+    assert([1, 2, 3].reduce((function (acc, x) { return acc + x }).bind(null, 4, 5)) === 9);
+
+    assert([1, 2, 3].reduce((function (acc, x) { return acc + x + this; }).bind(3)) === 12);
+
     function sum(a, b, c) {
         return a + b + c;
     }

--- a/Libraries/LibJS/Tests/Function.prototype.bind.js
+++ b/Libraries/LibJS/Tests/Function.prototype.bind.js
@@ -102,9 +102,8 @@ try {
     //     assert(strictIdentity.bind(undefined)() === undefined);
     // })();
 
-    // FIXME: Uncomment me when arrow functions have the correct |this| value.
-    // // Arrow functions can not have their |this| value set.
-    // assert((() => this).bind("foo")() === globalThis)
+    // Arrow functions can not have their |this| value set.
+    assert((() => this).bind("foo")() === globalThis)
 
     console.log("PASS");
 } catch (e) {

--- a/Libraries/LibJS/Tests/Function.prototype.call.js
+++ b/Libraries/LibJS/Tests/Function.prototype.call.js
@@ -47,6 +47,8 @@ try {
     var multiply = function (x, y) { return x * y; };
     assert(multiply.call(null, 3, 4) === 12);
 
+    assert((() => this).call("foo") === globalThis);
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);

--- a/Libraries/LibJS/Tests/arrow-functions.js
+++ b/Libraries/LibJS/Tests/arrow-functions.js
@@ -81,6 +81,13 @@ try {
 
     assert(Baz.prototype === undefined);
 
+    assertThrowsError(() => {
+        new Baz();
+    }, {
+        error: TypeError,
+        message: "Baz is not a constructor"
+    });
+
     (() => {
         "use strict";
         assert(isStrictMode());

--- a/Libraries/LibJS/Tests/arrow-functions.js
+++ b/Libraries/LibJS/Tests/arrow-functions.js
@@ -64,6 +64,19 @@ try {
     assert(foo === undefined);
     assert(bar === undefined);
 
+    function FooBar() {
+      this.x = {
+        y: () => this,
+        z: function () {
+          return (() => this)();
+        }
+      };
+    }
+
+    var foobar = new FooBar();
+    assert(foobar.x.y() === foobar);
+    assert(foobar.x.z() === foobar.x);
+
     (() => {
         "use strict";
         assert(isStrictMode());

--- a/Libraries/LibJS/Tests/arrow-functions.js
+++ b/Libraries/LibJS/Tests/arrow-functions.js
@@ -77,6 +77,10 @@ try {
     assert(foobar.x.y() === foobar);
     assert(foobar.x.z() === foobar.x);
 
+    var Baz = () => {};
+
+    assert(Baz.prototype === undefined);
+
     (() => {
         "use strict";
         assert(isStrictMode());


### PR DESCRIPTION
This PR fills in some of the missing behavior for arrow functions:
- The `this` value in an arrow function should be bound to that of the scope where it is defined
- Arrow functions should not have a `prototype` property
- Arrow functions should throw a `TypeError` when used as a constructor

While working on this I found that a Function's bound arguments and `this` value are not used in `Interpreter::call()`, which is also fixed here. This allows bound functions (and arrow functions) to use the correct `this` value and arguments in functions such as `Array.prototype.{map,reduce,filter}`.

This caused a couple of tests for `Array.prototype.reduce` and `reduceRight` to fail, which were asserting `this === undefined` in the callback. These were changed to use a non-arrow function.
@linusg I saw there was some discussion about this when it was implemented. I've observed the following results using V8 with arrow/non-arrow functions with this test:
```
> [1, 2].reduce(() => { "use strict"; console.log(this === undefined) })
false

> [1, 2].reduce(function () { "use strict"; console.log(this === undefined) })
true
```