### PR TITLE
LibTLS: Timeout after 10 seconds while waiting for handshake completion

### DIFF
--- a/Libraries/LibTLS/ClientHandshake.cpp
+++ b/Libraries/LibTLS/ClientHandshake.cpp
@@ -238,6 +238,16 @@ ssize_t TLSv12::handle_finished(const ByteBuffer& buffer, WritePacketStage& writ
 #endif
     m_context.connection_status = ConnectionStatus::Established;
 
+    if (m_handshake_timeout_timer) {
+        // Disable the handshake timeout timer as handshake has been established.
+        m_handshake_timeout_timer->stop();
+        m_handshake_timeout_timer->remove_from_parent();
+        m_handshake_timeout_timer = nullptr;
+    }
+
+    if (on_tls_ready_to_write)
+        on_tls_ready_to_write(*this);
+
     return handle_message(buffer);
 }
 

--- a/Libraries/LibTLS/Handshake.cpp
+++ b/Libraries/LibTLS/Handshake.cpp
@@ -167,4 +167,11 @@ ByteBuffer TLSv12::build_finished()
     return packet;
 }
 
+void TLSv12::alert(AlertLevel level, AlertDescription code)
+{
+    auto the_alert = build_alert(level == AlertLevel::Critical, (u8)code);
+    write_packet(the_alert);
+    flush();
+}
+
 }

--- a/Libraries/LibTLS/Record.cpp
+++ b/Libraries/LibTLS/Record.cpp
@@ -311,9 +311,7 @@ ssize_t TLSv12::handle_message(const ByteBuffer& buffer)
             if (code == 0) {
                 // close notify
                 res += 2;
-                auto closure_alert = build_alert(true, (u8)AlertDescription::CloseNotify);
-                write_packet(closure_alert);
-                flush();
+                alert(AlertLevel::Critical, AlertDescription::CloseNotify);
                 m_context.connection_finished = true;
             }
             m_context.error_code = (Error)code;


### PR DESCRIPTION
We have to busy-wait for ServerHello after the server accepts our connection; this causes us to wait forever if the server decides to ignore our handshake request.
Timeout after 10 seconds to avoid too much CPU usage.

This is related to #2449, while it does not close that issue, this mitigation is needed regardless, as we do not want a handshake to continue forever.