### PR TITLE
LibIPC: Fix server crashes on client disconnects

### DIFF
--- a/Libraries/LibIPC/ClientConnection.h
+++ b/Libraries/LibIPC/ClientConnection.h
@@ -121,7 +121,8 @@ public:
                 return;
             default:
                 perror("Connection::post_message write");
-                ASSERT_NOT_REACHED();
+                shutdown();
+                return;
             }
         }
 
@@ -130,6 +131,9 @@ public:
 
     void drain_messages_from_client()
     {
+        if (!m_socket->is_open())
+            return;
+
         Vector<u8> bytes;
         for (;;) {
             u8 buffer[4096];
@@ -143,7 +147,8 @@ public:
             }
             if (nread < 0) {
                 perror("recv");
-                ASSERT_NOT_REACHED();
+                shutdown();
+                return;
             }
             bytes.append(buffer, nread);
         }


### PR DESCRIPTION
Observed some WindowServer crashes when the Browser crashes because of switching pages (yay C++, and yay running JavaScript in-process); here's a fix.

On the positive side, the whole system comes right back up, it's almost as if it was only the Browser that crashed if it wasn't for some screen flashing and lost of backtraces in the QEMU log.