### PR TITLE
[WIP, RFC] unify all of our extensions to the escape sequences into one, structured sequence

### DIFF
--- a/Libraries/LibJS/Tests/run-tests.sh
+++ b/Libraries/LibJS/Tests/run-tests.sh
@@ -29,12 +29,12 @@ for f in *.js; do
         echo -ne "( \033[31;1mFail\033[0m ) "
         (( ++fail_count ))
     fi
-    echo -ne "\033]9;${count};${test_count}\033\\"
+    echo -ne "\033{S{\"SetProgress\":{\"value\":${count},\"maximum\":${test_count}}}\033"
     echo "$f"
     (( ++count ))
 done
 
-echo -e "\033]9;-1\033\\"
+echo -e "\033{S{\"SetProgress\":{}}\033"
 
 pass_color=""
 fail_color=""

--- a/Libraries/LibVT/Escape.h
+++ b/Libraries/LibVT/Escape.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/JsonObject.h>
+#include <AK/String.h>
+
+namespace VT {
+
+enum Property {
+    Progress,
+    Hyperlink,
+    Title,
+};
+
+struct EscapeSequenceBase {
+    operator String() const
+    {
+        ASSERT(!cached.is_empty());
+        return cached;
+    }
+
+    const char* characters() const
+    {
+        return cached.characters();
+    }
+
+    constexpr static const char OSC = '\033';
+
+protected:
+    template<typename KeyT, typename ValueT, typename... Rest>
+    static void add_to_json(JsonObject& object, KeyT key, ValueT value, Rest... rest)
+    {
+        object.set(key, JsonValue(value));
+        add_to_json(object, rest...);
+    }
+
+    static void add_to_json(JsonObject&)
+    {
+    }
+
+    template<typename... Args>
+    String encode(const StringView& name, Args... args) const
+    {
+        JsonObject object, containing_object;
+        add_to_json(object, args...);
+        containing_object.set(name, move(object));
+
+        return String::format("%c{S%s%c", OSC, containing_object.to_string().characters(), OSC);
+    }
+
+    EscapeSequenceBase(String data)
+        : cached(data)
+    {
+    }
+
+    String cached;
+};
+
+template<int PropertyName>
+struct EscapeSequenceFor : public EscapeSequenceBase {
+};
+
+enum UnsetTag {
+    Unset
+};
+
+template<>
+struct EscapeSequenceFor<Progress> : public EscapeSequenceBase {
+    explicit EscapeSequenceFor(int value, int max = 100)
+        : EscapeSequenceBase(encode("SetProgress", "value", value, "maximum", max))
+    {
+    }
+
+    explicit EscapeSequenceFor(const UnsetTag&)
+        : EscapeSequenceFor(-1, 1)
+    {
+    }
+
+private:
+    mutable String cached;
+};
+
+template<>
+struct EscapeSequenceFor<Hyperlink> : public EscapeSequenceBase {
+    explicit EscapeSequenceFor(const StringView& link, StringView id = "")
+        : EscapeSequenceBase(
+            String::format("%c]8;%.*s;%.*s%c\\",
+                OSC,
+                id.length(), id.characters_without_null_termination(),
+                link.length(), link.characters_without_null_termination(),
+                OSC))
+    {
+    }
+
+    explicit EscapeSequenceFor(const UnsetTag&)
+        : EscapeSequenceFor("", "")
+    {
+    }
+};
+
+template<>
+struct EscapeSequenceFor<Title> : public EscapeSequenceBase {
+    explicit EscapeSequenceFor(const StringView& title)
+        : EscapeSequenceBase(String::format("%c]0;%s%c\\", OSC, title.length(), title.characters_without_null_termination(), OSC))
+    {
+    }
+};
+
+}

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -174,6 +174,7 @@ private:
 
     void execute_escape_sequence(u8 final);
     void execute_xterm_command();
+    void execute_terminal_json_command();
     void execute_hashtag(u8);
 
     enum ParserState {
@@ -184,6 +185,8 @@ private:
         ExpectFinal,
         ExpectHashtagDigit,
         ExpectXtermParameter,
+        ExpectSerenityTerminalEscapedJson,
+        ExpectSerenityTerminalJson,
         ExpectStringTerminator,
         UTF8Needs3Bytes,
         UTF8Needs2Bytes,
@@ -195,6 +198,7 @@ private:
     Vector<u8> m_parameters;
     Vector<u8> m_intermediates;
     Vector<u8> m_xterm_parameters;
+    Vector<u8> m_json_data;
     Vector<bool> m_horizontal_tabs;
     u8 m_final { 0 };
     u32 m_last_codepoint { 0 };

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -37,6 +37,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibLine/Editor.h>
+#include <LibVT/Escape.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <pwd.h>
@@ -65,7 +66,9 @@ void Shell::print_path(const String& path)
         printf("%s", path.characters());
         return;
     }
-    printf("\033]8;;file://%s%s\033\\%s\033]8;;\033\\", hostname, path.characters(), path.characters());
+    printf("%s", VT::EscapeSequenceFor<VT::Hyperlink>(String::format("file://%s%s", hostname, path.characters())).characters());
+    printf("%s", path.characters());
+    printf("%s", VT::EscapeSequenceFor<VT::Hyperlink>(VT::Unset).characters());
 }
 
 String Shell::prompt() const
@@ -77,7 +80,7 @@ String Shell::prompt() const
                 return "# ";
 
             StringBuilder builder;
-            builder.appendf("\033]0;%s@%s:%s\007", username.characters(), hostname, cwd.characters());
+            builder.appendf("%s", VT::EscapeSequenceFor<VT::Title>(String::format("%s@%s:%s", username.characters(), hostname, cwd.characters())).characters());
             builder.appendf("\033[31;1m%s\033[0m@\033[37;1m%s\033[0m:\033[32;1m%s\033[0m$> ", username.characters(), hostname, cwd.characters());
             return builder.to_string();
         }

--- a/Userland/ls.cpp
+++ b/Userland/ls.cpp
@@ -33,6 +33,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/DirIterator.h>
+#include <LibVT/Escape.h>
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
@@ -170,7 +171,7 @@ size_t print_name(const struct stat& st, const String& name, const char* path_fo
 {
     if (!flag_disable_hyperlinks) {
         if (auto* full_path = realpath(path_for_hyperlink, nullptr)) {
-            printf("\033]8;;file://%s%s\033\\", hostname().characters(), full_path);
+            printf("%s", VT::EscapeSequenceFor<VT::Hyperlink>(String::format("file://%s%s", hostname().characters(), full_path)).characters());
             free(full_path);
         }
     }
@@ -221,7 +222,7 @@ size_t print_name(const struct stat& st, const String& name, const char* path_fo
     }
 
     if (!flag_disable_hyperlinks) {
-        printf("\033]8;;\033\\");
+        printf("%s", VT::EscapeSequenceFor<VT::Hyperlink>(VT::Unset).characters());
     }
 
     return nprinted;

--- a/Userland/pro.cpp
+++ b/Userland/pro.cpp
@@ -30,6 +30,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibProtocol/Client.h>
 #include <LibProtocol/Download.h>
+#include <LibVT/Escape.h>
 #include <stdio.h>
 
 int main(int argc, char** argv)
@@ -61,7 +62,7 @@ int main(int argc, char** argv)
     download->on_progress = [&](Optional<u32> maybe_total_size, u32 downloaded_size) {
         fprintf(stderr, "\r\033[2K");
         if (maybe_total_size.has_value()) {
-            fprintf(stderr, "\033]9;%d;%d;\033\\", downloaded_size, maybe_total_size.value());
+            fprintf(stderr, "%s", VT::EscapeSequenceFor<VT::Progress>(downloaded_size, maybe_total_size.value()).characters());
             fprintf(stderr, "Download progress: %s / %s", human_readable_size(downloaded_size).characters(), human_readable_size(maybe_total_size.value()).characters());
         } else {
             fprintf(stderr, "Download progress: %s / ???", human_readable_size(downloaded_size).characters());
@@ -79,7 +80,7 @@ int main(int argc, char** argv)
         prev_time = current_time;
     };
     download->on_finish = [&](bool success, auto& payload, auto, auto&) {
-        fprintf(stderr, "\033]9;-1;\033\\");
+        fprintf(stderr, "%s", VT::EscapeSequenceFor<VT::Progress>(VT::Unset).characters());
         fprintf(stderr, "\n");
         if (success)
             write(STDOUT_FILENO, payload.data(), payload.size());


### PR DESCRIPTION
This commit also adds helper functions for constructing some terminal escape sequences, and replaces all previous instances of \x1b]9;value;max\x1b\\ with the new escape system.

@awesomekling, @bugaevc pls throw ideas at me, or tell me if this idea is completely insane.

The escape sequence is such: 
`OSC { S JSON-object OSC`

where the json object encodes commands as `command:{...parameters}`.
This is of course, a very rough draft, and any perf loss from this should be addressed if we decide to go with it.

as an aside, I also want some feedback on the helpers, if they look OK, I'll yank them out of this PR and finish their implementation.