### PR TITLE
APIC: Detect processors and boot them into protected mode

### DIFF
--- a/AK/Atomic.h
+++ b/AK/Atomic.h
@@ -39,6 +39,63 @@ enum MemoryOrder {
     memory_order_seq_cst = __ATOMIC_SEQ_CST
 };
 
+template <typename T>
+static inline T atomic_exchange(volatile T* var, T desired, MemoryOrder order = memory_order_seq_cst) noexcept
+{
+    return __atomic_exchange_n(var, desired, order);
+}
+
+template <typename T>
+static inline bool atomic_compare_exchange_strong(volatile T* var, T& expected, T desired, MemoryOrder order = memory_order_seq_cst) noexcept
+{
+    if (order == memory_order_acq_rel || order == memory_order_release)
+        return __atomic_compare_exchange_n(var, &expected, desired, false, memory_order_release, memory_order_acquire);
+    else
+        return __atomic_compare_exchange_n(var, &expected, desired, false, order, order);
+}
+
+template <typename T>
+static inline T atomic_fetch_add(volatile T* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
+{
+    return __atomic_fetch_add(var, val, order);
+}
+
+template <typename T>
+static inline T atomic_fetch_sub(volatile T* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
+{
+    return __atomic_fetch_sub(var, val, order);
+}
+
+template <typename T>
+static inline T atomic_fetch_and(volatile T* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
+{
+    return __atomic_fetch_and(var, val, order);
+}
+
+template <typename T>
+static inline T atomic_fetch_or(volatile T* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
+{
+    return __atomic_fetch_or(var, val, order);
+}
+
+template <typename T>
+static inline T atomic_fetch_xor(volatile T* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
+{
+    return __atomic_fetch_xor(var, val, order);
+}
+
+template <typename T>
+static inline T atomic_load(volatile T* var, MemoryOrder order = memory_order_seq_cst) noexcept
+{
+    return __atomic_load_n(var, order);
+}
+
+template <typename T>
+static inline void atomic_store(volatile T* var, T desired, MemoryOrder order = memory_order_seq_cst) noexcept
+{
+    __atomic_store_n(var, desired, order);
+}
+
 template<typename T>
 class Atomic {
     T m_value { 0 };
@@ -51,6 +108,11 @@ public:
     Atomic(T val) noexcept
         : m_value(val)
     {
+    }
+
+    volatile T* ptr()
+    {
+        return &m_value;
     }
 
     T exchange(T desired, MemoryOrder order = memory_order_seq_cst) volatile noexcept
@@ -175,6 +237,11 @@ public:
     Atomic(T* val) noexcept
         : m_value(val)
     {
+    }
+
+    volatile T** ptr()
+    {
+        return &m_value;
     }
 
     T* exchange(T* desired, MemoryOrder order = memory_order_seq_cst) volatile noexcept

--- a/Kernel/ACPI/Definitions.h
+++ b/Kernel/ACPI/Definitions.h
@@ -290,6 +290,14 @@ struct [[gnu::packed]] IOAPIC
     u32 gsi_base;
 };
 
+struct [[gnu::packed]] ProcessorLocalAPIC
+{
+    MADTEntryHeader h;
+    u8 acpi_processor_id;
+    u8 apic_id;
+    u32 flags;
+};
+
 struct [[gnu::packed]] InterruptSourceOverride
 {
     MADTEntryHeader h;

--- a/Kernel/Arch/i386/Boot/boot.S
+++ b/Kernel/Arch/i386/Boot/boot.S
@@ -218,7 +218,6 @@ start:
     pushl $exit_message
     call kprintf
     add $4, %esp
-
     cli
 
 loop:
@@ -227,3 +226,171 @@ loop:
 
 exit_message:
     .asciz "Kernel exited."
+
+.extern init_ap
+.type init_ap, @function
+
+/*
+  The apic_ap_start function will be loaded to P0x00008000 where the APIC
+  will boot the AP from in real mode. This code also contains space for
+  special variables that *must* remain here. When initializing the APIC,
+  the code here gets copied to P0x00008000, the variables in here get
+  populated and then the the boot of the APs will be triggered. Having
+  the variables here allows us to access them from real mode. Also, the
+  code here avoids the need for relocation entries.
+
+  Basically, the variables between apic_ap_start and end_apic_ap_start
+  *MUST* remain here and cannot be moved into a .bss or any other location.
+*/
+.global apic_ap_start
+.type apic_ap_start, @function
+apic_ap_start:
+.code16
+    cli
+    jmp $0x800, $(1f - apic_ap_start) /* avoid relocation entries */
+1:
+    mov %cs, %ax
+    mov %ax, %ds
+
+    /* Generate a new processor id. This is not the APIC id. We just
+       need a way to find ourselves a stack without stomping on other
+       APs that may be doing this concurrently. */
+    xor %ax, %ax
+    mov %ax, %bp
+    inc %ax
+    lock; xaddw %ax, %ds:(ap_cpu_id - apic_ap_start)(%bp) /* avoid relocation entries */
+    mov %ax, %bx
+
+    xor %ax, %ax
+    mov %ax, %sp
+
+    /* load the first temporary gdt */
+    lgdt (ap_cpu_gdtr_initial - apic_ap_start)
+
+    /* enable PM */
+    movl %cr0, %eax
+    orl $1, %eax
+    movl %eax, %cr0
+
+    ljmpl $8, $(apic_ap_start32 - apic_ap_start + 0x8000)
+apic_ap_start32:
+.code32
+    mov $0x10, %ax
+    mov %ax, %ss
+    mov %ax, %ds
+    mov %ax, %es
+    mov %ax, %fs
+    mov %ax, %gs
+    
+    movl $0x8000, %ebp
+    
+    /* find our allocated stack based on the generated id */
+    andl 0x0000FFFF, %ebx
+    movl %ebx, %esi
+    movl (ap_cpu_init_stacks - apic_ap_start)(%ebp, %ebx, 4), %esp
+    
+    /* check if we support NX and enable it if we do */
+    movl $0x80000001, %eax
+    cpuid
+    testl $0x100000, %edx
+    je (1f - apic_ap_start + 0x8000)
+    /* turn on IA32_EFER.NXE */
+    movl $0xc0000080, %ecx
+    rdmsr
+    orl $0x800, %eax
+    wrmsr
+1:
+    
+    /* load the bsp's cr3 value */
+    movl (ap_cpu_init_cr3 - apic_ap_start)(%ebp), %eax
+    movl %eax, %cr3
+    
+    /* enable PAE + PSE */
+    movl %cr4, %eax
+    orl $0x60, %eax
+    movl %eax, %cr4
+
+    /* enable PG */
+    movl %cr0, %eax
+    orl $0x80000000, %eax
+    movl %eax, %cr0
+
+    /* load a second temporary gdt that points above 3GB */
+    lgdt (ap_cpu_gdtr_initial2 - apic_ap_start + 0xc0008000)
+
+    /* jump above 3GB into our identity mapped area now */
+    ljmp $8, $(1f - apic_ap_start + 0xc0008000)
+1:
+    /* flush the TLB */
+    movl %cr3, %eax
+    movl %eax, %cr3
+    
+    movl $0xc0008000, %ebp
+    
+    /* now load the final gdt and idt from the identity mapped area */
+    movl (ap_cpu_gdtr - apic_ap_start)(%ebp), %eax
+    lgdt (%eax)
+    movl (ap_cpu_idtr - apic_ap_start)(%ebp), %eax
+    lidt (%eax)
+
+    /* set same cr0 and cr4 values as the BSP */
+    movl (ap_cpu_init_cr0 - apic_ap_start)(%ebp), %eax
+    movl %eax, %cr0
+    movl (ap_cpu_init_cr4 - apic_ap_start)(%ebp), %eax
+    movl %eax, %cr4
+
+    xor %ebp, %ebp
+    cld
+    
+    /* push the arbitrary cpu id, 0 representing the bsp and call into c++ */
+    inc %esi
+    push %esi
+    /* We are in identity mapped P0x8000 and the BSP will unload this code
+       once all APs are initialized, so call init_ap but return to our
+       infinite loop */
+    push $loop
+    ljmp $8, $init_ap
+
+.align 4
+.global apic_ap_start_size
+apic_ap_start_size:
+    .2byte end_apic_ap_start - apic_ap_start
+ap_cpu_id:
+    .2byte 0x0
+ap_cpu_gdt:
+    /* null */
+    .8byte 0x0
+    /* code */
+    .4byte 0x0000FFFF
+    .4byte 0x00cf9a00
+    /* data */
+    .4byte 0x0000FFFF
+    .4byte 0x00cf9200
+ap_cpu_gdt_end:
+ap_cpu_gdtr_initial:
+    .2byte ap_cpu_gdt_end - ap_cpu_gdt - 1
+    .4byte (ap_cpu_gdt - apic_ap_start) + 0x8000
+ap_cpu_gdtr_initial2:
+    .2byte ap_cpu_gdt_end - ap_cpu_gdt - 1
+    .4byte (ap_cpu_gdt - apic_ap_start) + 0xc0008000
+.global ap_cpu_gdtr
+ap_cpu_gdtr:
+    .4byte 0x0 /* will be set at runtime */
+.global ap_cpu_idtr
+ap_cpu_idtr:
+    .4byte 0x0 /* will be set at runtime */
+.global ap_cpu_init_cr0
+ap_cpu_init_cr0:
+    .4byte 0x0 /* will be set at runtime */
+.global ap_cpu_init_cr3
+ap_cpu_init_cr3:
+    .4byte 0x0 /* will be set at runtime */
+.global ap_cpu_init_cr4
+ap_cpu_init_cr4:
+    .4byte 0x0 /* will be set at runtime */
+.global ap_cpu_init_stacks
+ap_cpu_init_stacks:
+    /* array of allocated stack pointers */
+    /* NOTE: ap_cpu_init_stacks must be the last variable before
+             end_apic_ap_start! */
+.set end_apic_ap_start, .

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -46,12 +46,6 @@
 
 namespace Kernel {
 
-struct [[gnu::packed]] DescriptorTablePointer
-{
-    u16 limit;
-    void* address;
-};
-
 static DescriptorTablePointer s_idtr;
 static DescriptorTablePointer s_gdtr;
 static Descriptor s_idt[256];
@@ -389,6 +383,16 @@ void flush_gdt()
     s_gdtr.limit = (s_gdt_length * 8) - 1;
     asm("lgdt %0" ::"m"(s_gdtr)
         : "memory");
+}
+
+const DescriptorTablePointer& get_gdtr()
+{
+    return s_gdtr;
+}
+
+const DescriptorTablePointer& get_idtr()
+{
+    return s_idtr;
 }
 
 void gdt_init()
@@ -819,6 +823,14 @@ void cpu_setup()
     }
 }
 
+u32 read_cr0()
+{
+    u32 cr0;
+    asm("movl %%cr0, %%eax"
+        : "=a"(cr0));
+    return cr0;
+}
+
 u32 read_cr3()
 {
     u32 cr3;
@@ -831,6 +843,14 @@ void write_cr3(u32 cr3)
 {
     asm volatile("movl %%eax, %%cr3" ::"a"(cr3)
                  : "memory");
+}
+
+u32 read_cr4()
+{
+    u32 cr4;
+    asm("movl %%cr4, %%eax"
+        : "=a"(cr4));
+    return cr4;
 }
 
 u32 read_dr6()

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -41,6 +41,12 @@ class MemoryManager;
 class PageDirectory;
 class PageTableEntry;
 
+struct [[gnu::packed]] DescriptorTablePointer
+{
+    u16 limit;
+    void* address;
+};
+
 struct [[gnu::packed]] TSS32
 {
     u16 backlink, __blh;
@@ -248,6 +254,8 @@ public:
 class GenericInterruptHandler;
 struct RegisterState;
 
+const DescriptorTablePointer& get_gdtr();
+const DescriptorTablePointer& get_idtr();
 void gdt_init();
 void idt_init();
 void sse_init();
@@ -477,8 +485,10 @@ inline FlatPtr offset_in_page(const void* address)
     return offset_in_page((FlatPtr)address);
 }
 
+u32 read_cr0();
 u32 read_cr3();
 void write_cr3(u32);
+u32 read_cr4();
 
 u32 read_dr6();
 

--- a/Kernel/Interrupts/IOAPIC.cpp
+++ b/Kernel/Interrupts/IOAPIC.cpp
@@ -297,7 +297,7 @@ void IOAPIC::eoi(const GenericInterruptHandler& handler) const
     ASSERT(!is_hard_disabled());
     ASSERT(handler.interrupt_number() >= gsi_base() && handler.interrupt_number() < interrupt_vectors_count());
     ASSERT(handler.type() != HandlerType::SpuriousInterruptHandler);
-    APIC::eoi();
+    APIC::the().eoi();
 }
 
 u16 IOAPIC::get_isr() const

--- a/Kernel/Interrupts/InterruptManagement.cpp
+++ b/Kernel/Interrupts/InterruptManagement.cpp
@@ -188,8 +188,7 @@ void InterruptManagement::switch_to_ioapic_mode()
             dbg() << "Interrupts: Detected " << irq_controller->model();
         }
     }
-    APIC::init();
-    APIC::enable_bsp();
+    APIC::the().init_bsp();
 
     if (auto mp_parser = MultiProcessorParser::autodetect()) {
         m_pci_interrupt_overrides = mp_parser->get_pci_interrupt_redirections();

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -107,6 +107,7 @@ public:
     OwnPtr<Region> allocate_contiguous_kernel_region(size_t, const StringView& name, u8 access, bool user_accessible = false, bool cacheable = true);
     OwnPtr<Region> allocate_kernel_region(size_t, const StringView& name, u8 access, bool user_accessible = false, bool should_commit = true, bool cacheable = true);
     OwnPtr<Region> allocate_kernel_region(PhysicalAddress, size_t, const StringView& name, u8 access, bool user_accessible = false, bool cacheable = true);
+    OwnPtr<Region> allocate_kernel_region_identity(PhysicalAddress, size_t, const StringView& name, u8 access, bool user_accessible = false, bool cacheable = true);
     OwnPtr<Region> allocate_kernel_region_with_vmobject(VMObject&, size_t, const StringView& name, u8 access, bool user_accessible = false, bool cacheable = true);
     OwnPtr<Region> allocate_kernel_region_with_vmobject(const Range&, VMObject&, const StringView& name, u8 access, bool user_accessible = false, bool cacheable = true);
     OwnPtr<Region> allocate_user_accessible_kernel_region(size_t, const StringView& name, u8 access, bool cacheable = true);
@@ -143,6 +144,8 @@ public:
 
     PhysicalPage& shared_zero_page() { return *m_shared_zero_page; }
 
+    PageDirectory& kernel_page_directory() { return *m_kernel_page_directory; }
+
 private:
     MemoryManager();
     ~MemoryManager();
@@ -176,8 +179,6 @@ private:
 
     PageDirectoryEntry* quickmap_pd(PageDirectory&, size_t pdpt_index);
     PageTableEntry* quickmap_pt(PhysicalAddress);
-
-    PageDirectory& kernel_page_directory() { return *m_kernel_page_directory; }
 
     const PageTableEntry* pte(const PageDirectory&, VirtualAddress);
     PageTableEntry& ensure_pte(PageDirectory&, VirtualAddress);

--- a/Kernel/VM/PageDirectory.cpp
+++ b/Kernel/VM/PageDirectory.cpp
@@ -59,6 +59,7 @@ extern "C" PageDirectoryEntry boot_pd3[1024];
 PageDirectory::PageDirectory()
 {
     m_range_allocator.initialize_with_range(VirtualAddress(0xc0800000), 0x3f000000);
+    m_identity_range_allocator.initialize_with_range(VirtualAddress(FlatPtr(0x00000000)), 0x00200000);
 
     // Adopt the page tables already set up by boot.S
     PhysicalAddress boot_pdpt_paddr(virtual_to_low_physical((FlatPtr)boot_pdpt));

--- a/Kernel/VM/PageDirectory.h
+++ b/Kernel/VM/PageDirectory.h
@@ -52,6 +52,7 @@ public:
     u32 cr3() const { return m_directory_table->paddr().get(); }
 
     RangeAllocator& range_allocator() { return m_range_allocator; }
+    RangeAllocator& identity_range_allocator() { return m_identity_range_allocator; }
 
     Process* process() { return m_process; }
     const Process* process() const { return m_process; }
@@ -62,6 +63,7 @@ private:
 
     Process* m_process { nullptr };
     RangeAllocator m_range_allocator;
+    RangeAllocator m_identity_range_allocator;
     RefPtr<PhysicalPage> m_directory_table;
     RefPtr<PhysicalPage> m_directory_pages[4];
     HashMap<unsigned, RefPtr<PhysicalPage>> m_physical_pages;

--- a/Kernel/VM/RangeAllocator.h
+++ b/Kernel/VM/RangeAllocator.h
@@ -90,6 +90,11 @@ public:
 
     void dump() const;
 
+    bool contains(const Range& range) const
+    {
+        return m_total_range.contains(range);
+    }
+
 private:
     void carve_at_index(int, const Range&);
 

--- a/Kernel/VM/Region.h
+++ b/Kernel/VM/Region.h
@@ -95,6 +95,9 @@ public:
     bool is_user_accessible() const { return m_user_accessible; }
     void set_user_accessible(bool b) { m_user_accessible = b; }
 
+    bool is_kernel() const { return m_kernel || vaddr().get() >= 0xc0000000; }
+    void set_kernel(bool kernel) { m_kernel = kernel; }
+
     PageFaultResponse handle_fault(const PageFault&);
 
     NonnullOwnPtr<Region> clone();
@@ -178,7 +181,7 @@ public:
     Region* m_prev { nullptr };
 
     // NOTE: These are public so we can make<> them.
-    Region(const Range&, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, const String&, u8 access, bool cacheable);
+    Region(const Range&, NonnullRefPtr<VMObject>, size_t offset_in_vmobject, const String&, u8 access, bool cacheable, bool kernel);
 
     void set_inherit_mode(InheritMode inherit_mode) { m_inherit_mode = inherit_mode; }
 
@@ -211,6 +214,7 @@ private:
     bool m_cacheable : 1 { false };
     bool m_stack : 1 { false };
     bool m_mmap : 1 { false };
+    bool m_kernel : 1 { false };
     mutable OwnPtr<Bitmap> m_cow_map;
 };
 

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -121,6 +121,7 @@ extern "C" [[noreturn]] void init()
     for (ctor_func_t* ctor = &start_ctors; ctor < &end_ctors; ctor++)
         (*ctor)();
 
+    APIC::initialize();
     InterruptManagement::initialize();
     ACPI::initialize();
 
@@ -158,6 +159,26 @@ extern "C" [[noreturn]] void init()
     sti();
 
     Scheduler::idle_loop();
+    ASSERT_NOT_REACHED();
+}
+
+//
+// This is where C++ execution begins for APs, after boot.S transfers control here.
+//
+// The purpose of init_ap() is to initialize APs for multi-tasking.
+//
+extern "C" [[noreturn]] void init_ap(u32 cpu)
+{
+    APIC::the().enable(cpu);
+    
+#if 0
+    Scheduler::idle_loop();
+#else
+    // FIXME: remove once schedule can handle APs
+    cli();
+    for (;;)
+        asm volatile("hlt");
+#endif
     ASSERT_NOT_REACHED();
 }
 


### PR DESCRIPTION
This isn't fully working, though not stopping the OS from booting (the APs are in protected mode, but halted for now)

    For some reason we have what might be a paging issue. Accessing
    the stack or any memory after lgdt/lidt triggers a page fault, which
    it for some reason can't handle, so it ends up triple-faulting here.
    Interestingly, the CR2 register shows a fault address that is equal
    to &s_idt + 0x40, which happens to be IDT entry #8 (double fault):

    GDT=     c01c9240 000007ff
    IDT=     c01c9a40 000007ff
    CR0=e0000011 CR2=c01c9a80 CR3=00109000 CR4=00000060

    Same GDT/IDT and CR3 as the BSP. Also, both GDT and IDT look
    fine in both qemu and bochs debugger. qemu's `monitor info mem`
    also shows correct mappings (they also look fine in bochs):

    0000000000008000-0000000000009000 0000000000001000 -rw
    0000000000100000-0000000000200000 0000000000100000 -rw
    00000000c0000000-00000000c0118000 0000000000118000 -rw
    00000000c0118000-00000000c01c7000 00000000000af000 -r-
    00000000c01c7000-00000000c0800000 0000000000639000 -rw
    00000000c0801000-00000000c0802000 0000000000001000 -rw
    00000000c0803000-00000000c0804000 0000000000001000 -r-
    00000000c0805000-00000000c0815000 0000000000010000 -rw
    00000000ffe04000-00000000ffe05000 0000000000001000 -rw
    00000000ffe08000-00000000ffe09000 0000000000001000 -rw

    Qemu's `monitor info tlb` also has entries, but they look
    a little suspicious:

    00000000c07fe000: 00000000007fe000 --------W
    00000000c07ff000: 00000000007ff000 --------W
    00000000c0801000: 80000000fee00000 X--DA---W
    00000000c0803000: 800000000ffe1000 X---A----
    00000000c0805000: 8000000000802000 X-------W
    00000000c0806000: 8000000000803000 X-------W
    00000000c0807000: 8000000000804000 X-------W
    00000000c0808000: 8000000000805000 X-------W
    00000000c0809000: 8000000000806000 X-------W
    00000000c080a000: 8000000000807000 X-------W
    00000000c080b000: 8000000000808000 X-------W
    00000000c080c000: 8000000000809000 X-------W
    00000000c080d000: 800000000080a000 X-------W
    00000000c080e000: 800000000080b000 X-------W
    00000000c080f000: 800000000080c000 X-------W
    00000000c0810000: 800000000080d000 X-------W
    00000000c0811000: 800000000080e000 X-------W
    00000000c0812000: 800000000080f000 X-------W
    00000000c0813000: 8000000000810000 X-------W
    00000000c0814000: 8000000000811000 X-------W
    00000000ffe04000: 000000000010b000 ---DA---W
    00000000ffe08000: 0000000000801000 ---DA---W

    Notice the phyiscal address bit 63 being set. Bad tables?

https://github.com/SerenityOS/serenity/commit/9e5351ad3a410a55cb32ffb775911a01cb354fc2#diff-b10e477bf060d4b90924a2559b177384R320-R373