### PR TITLE
LibJS: Object.setPrototypeOf() fixes & Reflect.{isExtensible,preventExtension}()

### DIFF
--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -69,15 +69,18 @@ const Object* Object::prototype() const
     return shape().prototype();
 }
 
-void Object::set_prototype(Object* new_prototype)
+bool Object::set_prototype(Object* new_prototype)
 {
     if (prototype() == new_prototype)
-        return;
+        return true;
+    if (!m_is_extensible)
+        return false;
     if (shape().is_unique()) {
         shape().set_prototype_without_transition(new_prototype);
-        return;
+        return true;
     }
     m_shape = m_shape->create_prototype_transition(new_prototype);
+    return true;
 }
 
 bool Object::has_prototype(const Object* prototype) const

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -95,7 +95,7 @@ public:
 
     Object* prototype();
     const Object* prototype() const;
-    void set_prototype(Object*);
+    bool set_prototype(Object* prototype);
     bool has_prototype(const Object* prototype) const;
 
     bool is_extensible() const { return m_is_extensible; }

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -103,7 +103,7 @@ Value ObjectConstructor::set_prototype_of(Interpreter& interpreter)
     if (interpreter.exception())
         return {};
     object->set_prototype(&const_cast<Object&>(interpreter.argument(1).as_object()));
-    return {};
+    return object;
 }
 
 Value ObjectConstructor::is_extensible(Interpreter& interpreter)

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -102,7 +102,17 @@ Value ObjectConstructor::set_prototype_of(Interpreter& interpreter)
     auto* object = interpreter.argument(0).to_object(interpreter);
     if (interpreter.exception())
         return {};
-    object->set_prototype(&const_cast<Object&>(interpreter.argument(1).as_object()));
+    auto prototype_value = interpreter.argument(1);
+    Object* prototype;
+    if (prototype_value.is_null()) {
+        prototype = nullptr;
+    } else if (prototype_value.is_object()) {
+        prototype = &prototype_value.as_object();
+    } else {
+        interpreter.throw_exception<TypeError>("Prototype must be null or object");
+        return {};
+    }
+    object->set_prototype(prototype);
     return object;
 }
 

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -112,7 +112,10 @@ Value ObjectConstructor::set_prototype_of(Interpreter& interpreter)
         interpreter.throw_exception<TypeError>("Prototype must be null or object");
         return {};
     }
-    object->set_prototype(prototype);
+    if (!object->set_prototype(prototype)) {
+        interpreter.throw_exception<TypeError>("Can't set prototype of non-extensible object");
+        return {};
+    }
     return object;
 }
 

--- a/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -211,12 +211,12 @@ Value ReflectObject::has(Interpreter& interpreter)
     return Value(target->has_property(property_key));
 }
 
-Value ReflectObject::is_extensible(Interpreter&)
+Value ReflectObject::is_extensible(Interpreter& interpreter)
 {
-    // FIXME: For this to be useful we need one of these:
-    // Object.seal(), Object.freeze(), Reflect.preventExtensions()
-    // For now we just return true, as that's always the case.
-    return Value(true);
+    auto* target = get_target_object_from(interpreter, "isExtensible");
+    if (!target)
+        return {};
+    return Value(target->is_extensible());
 }
 
 Value ReflectObject::own_keys(Interpreter& interpreter)
@@ -227,10 +227,12 @@ Value ReflectObject::own_keys(Interpreter& interpreter)
     return target->get_own_properties(*target, GetOwnPropertyMode::Key);
 }
 
-Value ReflectObject::prevent_extensions(Interpreter&)
+Value ReflectObject::prevent_extensions(Interpreter& interpreter)
 {
-    // FIXME: Implement me :^)
-    ASSERT_NOT_REACHED();
+    auto* target = get_target_object_from(interpreter, "preventExtensions");
+    if (!target)
+        return {};
+    return Value(target->prevent_extensions());
 }
 
 Value ReflectObject::set(Interpreter& interpreter)

--- a/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -261,9 +261,7 @@ Value ReflectObject::set_prototype_of(Interpreter& interpreter)
     Object* prototype = nullptr;
     if (!prototype_value.is_null())
         prototype = const_cast<Object*>(&prototype_value.as_object());
-    target->set_prototype(prototype);
-    // FIXME: Needs to return false for prototype chain cycles and non-extensible objects (don't have those yet).
-    return Value(true);
+    return Value(target->set_prototype(prototype));
 }
 
 }

--- a/Libraries/LibJS/Tests/Object.setPrototypeOf.js
+++ b/Libraries/LibJS/Tests/Object.setPrototypeOf.js
@@ -3,6 +3,13 @@ load("test-common.js");
 try {
     assert(Object.setPrototypeOf.length === 2);
 
+    assertThrowsError(() => {
+        Object.setPrototypeOf({}, "foo");
+    }, {
+        error: TypeError,
+        message: "Prototype must be null or object"
+    });
+
     o = {};
     assert(Object.setPrototypeOf(o, {}) === o);
 

--- a/Libraries/LibJS/Tests/Object.setPrototypeOf.js
+++ b/Libraries/LibJS/Tests/Object.setPrototypeOf.js
@@ -1,0 +1,12 @@
+load("test-common.js");
+
+try {
+    assert(Object.setPrototypeOf.length === 2);
+
+    o = {};
+    assert(Object.setPrototypeOf(o, {}) === o);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Object.setPrototypeOf.js
+++ b/Libraries/LibJS/Tests/Object.setPrototypeOf.js
@@ -11,7 +11,17 @@ try {
     });
 
     o = {};
-    assert(Object.setPrototypeOf(o, {}) === o);
+    p = {};
+    assert(Object.setPrototypeOf(o, p) === o);
+
+    Object.preventExtensions(o);
+    assertThrowsError(() => {
+        Object.setPrototypeOf(o, {});
+    }, {
+        error: TypeError,
+        message: "Can't set prototype of non-extensible object"
+    });
+    assert(Object.setPrototypeOf(o, p) === o);
 
     console.log("PASS");
 } catch (e) {

--- a/Libraries/LibJS/Tests/Reflect.isExtensible.js
+++ b/Libraries/LibJS/Tests/Reflect.isExtensible.js
@@ -1,0 +1,29 @@
+load("test-common.js");
+
+try {
+    assert(Reflect.isExtensible.length === 1);
+
+    [null, undefined, "foo", 123, NaN, Infinity].forEach(value => {
+        assertThrowsError(() => {
+            Reflect.isExtensible(value);
+        }, {
+            error: TypeError,
+            message: "First argument of Reflect.isExtensible() must be an object"
+        });
+    });
+
+    assert(Reflect.isExtensible({}) === true);
+
+    var o = {};
+    o.foo = "foo";
+    assert(o.foo === "foo");
+    assert(Reflect.isExtensible(o) === true);
+    Reflect.preventExtensions(o);
+    o.bar = "bar";
+    assert(o.bar === undefined);
+    assert(Reflect.isExtensible(o) === false);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Reflect.preventExtensions.js
+++ b/Libraries/LibJS/Tests/Reflect.preventExtensions.js
@@ -1,0 +1,23 @@
+load("test-common.js");
+
+try {
+    assert(Reflect.preventExtensions.length === 1);
+
+    [null, undefined, "foo", 123, NaN, Infinity].forEach(value => {
+        assertThrowsError(() => {
+            Reflect.preventExtensions(value);
+        }, {
+            error: TypeError,
+            message: "First argument of Reflect.preventExtensions() must be an object"
+        });
+    });
+
+    var o = {};
+    assert(Reflect.isExtensible(o) === true);
+    assert(Reflect.preventExtensions(o) === true);
+    assert(Reflect.isExtensible(o) === false);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Reflect.setPrototypeOf.js
+++ b/Libraries/LibJS/Tests/Reflect.setPrototypeOf.js
@@ -28,10 +28,14 @@ try {
     assert(Reflect.setPrototypeOf({}, Reflect.getPrototypeOf({})) === true);
 
     var o = {};
+    var p = { foo: "bar" };
     assert(o.foo === undefined);
-    assert(Reflect.setPrototypeOf(o, { foo: "bar" }) === true);
+    assert(Reflect.setPrototypeOf(o, p) === true);
     assert(o.foo === "bar");
 
+    Reflect.preventExtensions(o);
+    assert(Reflect.setPrototypeOf(o, {}) === false);
+    assert(Reflect.setPrototypeOf(o, p) === true);
 
     console.log("PASS");
 } catch (e) {


### PR DESCRIPTION
A few fixes for `Object.setPrototypeOf()` (has a test now) and proper implementations of  `Reflect.isExtensible()` and `Reflect.preventExtension()`.