### PR TITLE
Browser: Add network history window

### DIFF
--- a/Applications/Browser/CMakeLists.txt
+++ b/Applications/Browser/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     DownloadWidget.cpp
     InspectorWidget.cpp
     main.cpp
+    NetworkHistoryWidget.cpp
     Tab.cpp
     WindowActions.cpp
 )

--- a/Applications/Browser/NetworkHistoryWidget.cpp
+++ b/Applications/Browser/NetworkHistoryWidget.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2020, Luke Wilde <luke.wilde@live.co.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "NetworkHistoryWidget.h"
+#include <LibGUI/Action.h>
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/CheckBox.h>
+#include <LibGUI/Menu.h>
+#include <LibGUI/Splitter.h>
+#include <LibGUI/TableView.h>
+#include <LibGUI/ToolBar.h>
+#include <LibGUI/ToolBarContainer.h>
+#include <LibWeb/Loader/ResourceLoader.h>
+
+namespace Browser {
+
+NetworkHistoryWidget::NetworkHistoryWidget()
+{
+    set_fill_with_background_color(true);
+
+    set_layout<GUI::VerticalBoxLayout>();
+    layout()->set_margins({ 4, 4, 4, 4 });
+    layout()->set_spacing(4);
+
+    auto& toolbar_container = add<GUI::ToolBarContainer>();
+    auto& toolbar = toolbar_container.add<GUI::ToolBar>();
+
+    auto& paused = toolbar.add<GUI::CheckBox>("Paused");
+    paused.on_checked = [this](bool checked) { m_paused = checked; };
+    paused.set_checked(m_paused);
+    paused.set_size_policy(GUI::SizePolicy::Fixed, GUI::SizePolicy::Fixed);
+    paused.set_preferred_size(61, 26);
+
+    auto& clear_on_navigation = toolbar.add<GUI::CheckBox>("Clear on navigation");
+    clear_on_navigation.on_checked = [this](bool checked) { m_clear_on_navigation = checked; };
+    clear_on_navigation.set_checked(m_clear_on_navigation);
+    clear_on_navigation.set_size_policy(GUI::SizePolicy::Fixed, GUI::SizePolicy::Fixed);
+    clear_on_navigation.set_preferred_size(131, 26);
+
+    auto& disable_cache = toolbar.add<GUI::CheckBox>("Disable cache (while open)");
+    disable_cache.on_checked = [this](bool checked) { m_cache_disabled = checked; };
+    disable_cache.set_checked(m_cache_disabled);
+    disable_cache.set_size_policy(GUI::SizePolicy::Fixed, GUI::SizePolicy::Fixed);
+    disable_cache.set_preferred_size(166, 26);
+
+    auto& splitter = add<GUI::VerticalSplitter>();
+
+    m_history_view = splitter.add<GUI::TableView>();
+    m_history_view->set_model(Web::NetworkHistoryModel::create(m_network_history));
+
+    // Path can be very long, so it's hidden by default.
+    m_history_view->set_column_hidden(Web::NetworkHistoryModel::Column::Path, true);
+
+    m_context_menu = GUI::Menu::construct();
+
+    m_context_menu->add_action(GUI::Action::create("Open in new tab", [this](auto&) {
+        if (on_tab_open_request)
+            on_tab_open_request(m_context_menu_url);
+    }));
+
+    m_history_view->on_context_menu_request = [this](const auto& index, const auto& event) {
+        if (!index.is_valid())
+            return;
+
+        m_context_menu_url = m_history_view->model()->data(index, GUI::Model::Role::Custom).to_string();
+        m_context_menu->popup(event.screen_position());
+    };
+}
+
+NetworkHistoryWidget::~NetworkHistoryWidget()
+{
+    unregister_callbacks();
+}
+
+void NetworkHistoryWidget::update_view()
+{
+    m_history_view->model()->update();
+}
+
+void NetworkHistoryWidget::register_callbacks()
+{
+    // FIXME: Resource loader can't tell which tab the load came from,
+    //        so all tabs will report to the most recently opened window.
+    Web::ResourceLoader::the().on_load = [this](auto load_id, auto& url) {
+        if (m_paused)
+            return;
+
+        Web::NetworkHistoryModel::Entry new_entry;
+        new_entry.url = url;
+        new_entry.load_timer.start();
+
+        m_network_history.set(load_id, new_entry);
+
+        // This will add some microseconds to the load timer, which isn't that big of a deal.
+        update_view();
+    };
+
+    Web::ResourceLoader::the().on_load_finish = [this](auto load_id, bool success, bool cached) {
+        auto& entry = m_network_history.get(load_id).value();
+
+        entry.time = entry.load_timer.elapsed();
+        entry.complete = true;
+        entry.success = success;
+        entry.cached = cached;
+
+        m_network_history.set(load_id, entry);
+
+        update_view();
+    };
+
+    Web::ResourceLoader::the().cache_disabled_check = [this] { return m_cache_disabled; };
+}
+
+void NetworkHistoryWidget::unregister_callbacks()
+{
+    // FIXME: If you open two or more windows and close one, the rest will stop working.
+    Web::ResourceLoader::the().on_load = nullptr;
+    Web::ResourceLoader::the().on_load_finish = nullptr;
+    Web::ResourceLoader::the().cache_disabled_check = nullptr;
+}
+
+void NetworkHistoryWidget::on_page_navigation()
+{
+    if (!m_clear_on_navigation)
+        return;
+
+    m_network_history.clear();
+    update_view();
+}
+
+}

--- a/Applications/Browser/NetworkHistoryWidget.h
+++ b/Applications/Browser/NetworkHistoryWidget.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Luke Wilde <luke.wilde@live.co.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,62 +26,41 @@
 
 #pragma once
 
-#include "History.h"
 #include <AK/URL.h>
+#include <AK/HashMap.h>
+#include <LibCore/ElapsedTimer.h>
+#include <LibGUI/Forward.h>
 #include <LibGUI/Widget.h>
-#include <LibHTTP/HttpJob.h>
-#include <LibWeb/Forward.h>
+#include <LibWeb/NetworkHistoryModel.h>
 
 namespace Browser {
 
-class Tab final : public GUI::Widget {
-    C_OBJECT(Tab);
-
+class NetworkHistoryWidget final : public GUI::Widget {
+    C_OBJECT(NetworkHistoryWidget)
 public:
-    virtual ~Tab() override;
+    virtual ~NetworkHistoryWidget();
 
-    void load(const URL&);
+    void register_callbacks();
+    void unregister_callbacks();
 
-    void did_become_active();
-    void context_menu_requested(const Gfx::Point& screen_position);
+    void on_page_navigation();
 
-    Function<void(String)> on_title_change;
     Function<void(const URL&)> on_tab_open_request;
-    Function<void(Tab&)> on_tab_close_request;
-    Function<void(const Gfx::Bitmap&)> on_favicon_change;
-
-    const String& title() const { return m_title; }
-    const Gfx::Bitmap* icon() const { return m_icon; }
 
 private:
-    Tab();
+    NetworkHistoryWidget();
 
-    void update_actions();
-    void update_bookmark_button(const String& url);
+    void update_view();
 
-    History<URL> m_history;
-    RefPtr<Web::PageView> m_page_view;
-    RefPtr<GUI::Action> m_go_back_action;
-    RefPtr<GUI::Action> m_go_forward_action;
-    RefPtr<GUI::Action> m_reload_action;
-    RefPtr<GUI::TextBox> m_location_box;
-    RefPtr<GUI::Button> m_bookmark_button;
-    RefPtr<GUI::Window> m_dom_inspector_window;
-    RefPtr<GUI::Window> m_console_window;
-    RefPtr<GUI::Window> m_network_history_window;
-    RefPtr<GUI::StatusBar> m_statusbar;
-    RefPtr<GUI::MenuBar> m_menubar;
-    RefPtr<GUI::ToolBarContainer> m_toolbar_container;
+    bool m_clear_on_navigation { true };
+    bool m_paused { false };
+    bool m_cache_disabled { false };
 
-    RefPtr<GUI::Menu> m_link_context_menu;
-    String m_link_context_menu_href;
+    HashMap<u32, Web::NetworkHistoryModel::Entry> m_network_history;
 
-    RefPtr<GUI::Menu> m_tab_context_menu;
-
-    String m_title;
-    RefPtr<const Gfx::Bitmap> m_icon;
-
-    bool m_should_push_loads_to_history { true };
+    RefPtr<GUI::TableView> m_history_view;
+    RefPtr<GUI::Menu> m_context_menu;
+    URL m_context_menu_url;
 };
 
 }

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -86,6 +86,7 @@ set(SOURCES
     Loader/ImageResource.cpp
     Loader/Resource.cpp
     Loader/ResourceLoader.cpp
+    NetworkHistoryModel.cpp
     PageView.cpp
     Parser/CSSParser.cpp
     Parser/Entities.cpp

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -201,9 +201,8 @@ void ResourceLoader::load(const URL& url, Function<void(const ByteBuffer&, const
                 on_load_counter_change();
             on_load_end(new_load_id, success);
             if (!success) {
-                if (error_callback) {
+                if (error_callback)
                     error_callback("HTTP load failed");
-                }
                 return;
             }
             success_callback(ByteBuffer::copy(payload.data(), payload.size()), response_headers);

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -48,6 +48,9 @@ public:
     void load_sync(const URL&, Function<void(const ByteBuffer&, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers)> success_callback, Function<void(const String&)> error_callback = nullptr);
 
     Function<void()> on_load_counter_change;
+    Function<void(u32, const URL&)> on_load;
+    Function<void(u32, bool, bool)> on_load_finish;
+    Function<bool()> cache_disabled_check;
 
     int pending_loads() const { return m_pending_loads; }
 
@@ -59,9 +62,13 @@ private:
     ResourceLoader();
     static bool is_port_blocked(int port);
 
+    u32 on_load_begin(const URL&);
+    void on_load_end(u32, bool, bool cached = false);
+
     virtual void save_to(JsonObject&) override;
 
     int m_pending_loads { 0 };
+    u32 m_load_id { 0 };
 
     RefPtr<Protocol::Client> m_protocol_client;
     String m_user_agent;

--- a/Libraries/LibWeb/NetworkHistoryModel.cpp
+++ b/Libraries/LibWeb/NetworkHistoryModel.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2020, Luke Wilde <luke.wilde@live.co.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "NetworkHistoryModel.h"
+#include <AK/StringBuilder.h>
+#include <AK/QuickSort.h>
+
+namespace Web {
+
+NetworkHistoryModel::NetworkHistoryModel(const HashMap<u32, Entry>& history)
+{
+    // HACK: Hash map does not preserve insertion order,
+    //       so I'm sorting the load ids and then copying entries to a vector.
+    auto load_ids = history.keys();
+
+    quick_sort(load_ids, [](const auto id0, const auto id1) {
+        return id0 < id1;
+    });
+
+    m_entries.ensure_capacity(history.size());
+
+    for (auto load_id : load_ids) {
+        auto opt_entry = history.get(load_id);
+        m_entries.append(opt_entry.value());
+    }
+}
+
+NetworkHistoryModel::~NetworkHistoryModel()
+{
+}
+
+int NetworkHistoryModel::row_count(const GUI::ModelIndex &) const
+{
+    return m_entries.size();
+}
+
+String NetworkHistoryModel::column_name(int column_index) const
+{
+    switch (column_index) {
+    case Column::Name:
+        return "Name";
+    case Column::Path:
+        return "Path";
+    case Column::Host:
+        return "Host";
+    case Column::Protocol:
+        return "Protocol";
+    case Column::Time:
+        return "Time";
+    default:
+        ASSERT_NOT_REACHED();
+    }
+}
+
+GUI::Variant NetworkHistoryModel::data(const GUI::ModelIndex& index, Role role) const
+{
+    auto& entry = m_entries.at(index.row());
+
+    if (role == Role::Display) {
+        if (index.column() == Column::Name) {
+            if (entry.url.protocol() == "data")
+                return "[data]";
+
+            return entry.url.basename();
+        }
+
+        if (index.column() == Column::Path) {
+            if (entry.url.protocol() == "data")
+                return "N/A";
+
+            return entry.url.path();
+        }
+
+        if (index.column() == Column::Host) {
+            if (entry.url.protocol() == "data" || entry.url.protocol() == "file")
+                return "N/A";
+
+            return entry.url.host();
+        }
+
+        if (index.column() == Column::Protocol)
+            return entry.url.protocol();
+
+        if (index.column() == Column::Time) {
+            if (!entry.complete)
+                return "Pending";
+
+            StringBuilder builder;
+            builder.appendf("%d ms", entry.time);
+
+            if (entry.cached)
+                builder.append(" (cached)");
+
+            return builder.to_string();
+        }
+    }
+
+    if (role == Role::ForegroundColor) {
+        if (entry.complete && !entry.success)
+            return Color(Color::Red);
+    }
+
+    if (role == Role::Custom) {
+        return entry.url.to_string();
+    }
+
+    return {};
+}
+
+void NetworkHistoryModel::update()
+{
+    did_update();
+}
+
+}

--- a/Libraries/LibWeb/NetworkHistoryModel.h
+++ b/Libraries/LibWeb/NetworkHistoryModel.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, Luke Wilde <luke.wilde@live.co.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/URL.h>
+#include <LibGUI/Model.h>
+
+namespace Web {
+
+class NetworkHistoryModel final : public GUI::Model {
+public:
+    struct Entry {
+        bool complete { false };
+        bool success { false };
+        bool cached { false };
+        URL url;
+        int time { 0 };
+    };
+
+    enum Column {
+        Name = 0,
+        Path,
+        Host,
+        Protocol,
+        Time,
+        __Count
+    };
+
+    static NonnullRefPtr<NetworkHistoryModel> create(const HashMap<u32, Entry>& history)
+    {
+        return adopt(*new NetworkHistoryModel(history));
+    }
+
+    virtual ~NetworkHistoryModel() override;
+
+    virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
+
+    String column_name(int i) const override;
+
+    virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
+    virtual GUI::Variant data(const GUI::ModelIndex&, Role = Role::Display) const override;
+    virtual void update() override;
+
+private:
+    explicit NetworkHistoryModel(const HashMap<u32, Entry>& history);
+
+    Vector<Entry> m_entries;
+};
+
+}

--- a/Libraries/LibWeb/NetworkHistoryModel.h
+++ b/Libraries/LibWeb/NetworkHistoryModel.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/URL.h>
+#include <LibCore/ElapsedTimer.h>
 #include <LibGUI/Model.h>
 
 namespace Web {
@@ -39,6 +40,7 @@ public:
         bool cached { false };
         URL url;
         int time { 0 };
+        Core::ElapsedTimer load_timer;
     };
 
     enum Column {
@@ -68,6 +70,9 @@ public:
 private:
     explicit NetworkHistoryModel(const HashMap<u32, Entry>& history);
 
+    void update_entries();
+
+    const HashMap<u32, Entry>& m_history;
     Vector<Entry> m_entries;
 };
 


### PR DESCRIPTION
This tool provides a table of network requests and a few extra tools.
It can be opened via the inspect menu or Ctrl+E.

The information it shows is the base name, path, host and protocol
from the URL. It also shows how long each request took in ms.

There are currently three extra tools provided:
- History across multiple pages or a single page
- Cache bypass (while the window is open)
- Open requested resource in a new tab (in context menu)

Demo: 
![History Demo](https://user-images.githubusercontent.com/25595356/83566184-7ee52a00-a517-11ea-8e08-0ae169d83f79.gif)

Note: Path can be very long, so it's hidden by default.

The main issue I had with this is passing data to the model. It can surely be cleaned up :^)