### PR TITLE
LibJS: Allow null or undefined as a bound |this| value in strict mode

### DIFF
--- a/Libraries/LibJS/Runtime/Function.cpp
+++ b/Libraries/LibJS/Runtime/Function.cpp
@@ -57,7 +57,8 @@ BoundFunction* Function::bind(Value bound_this_value, Vector<Value> arguments)
         switch (bound_this_value.type()) {
         case Value::Type::Undefined:
         case Value::Type::Null:
-            // FIXME: Null or undefined should be passed through in strict mode.
+            if (interpreter().in_strict_mode())
+                return bound_this_value;
             return &interpreter().global_object();
         default:
             return bound_this_value.to_object(interpreter());

--- a/Libraries/LibJS/Tests/Function.prototype.bind.js
+++ b/Libraries/LibJS/Tests/Function.prototype.bind.js
@@ -103,15 +103,17 @@ try {
     assert(Make5() === 5);
     assert(new Make5().valueOf() === 5);
 
-    // FIXME: Uncomment me when strict mode is implemented
-    //     function strictIdentity() {
-    //         return this;
-    //     }
+    // Null or undefined should be passed through as a |this| value in strict mode.
+    (() => {
+      "use strict";
+      function strictIdentity() {
+        return this;
+      }
 
-    //     assert(strictIdentity.bind()() === undefined);
-    //     assert(strictIdentity.bind(null)() === null);
-    //     assert(strictIdentity.bind(undefined)() === undefined);
-    // })();
+      assert(strictIdentity.bind()() === undefined);
+      assert(strictIdentity.bind(null)() === null);
+      assert(strictIdentity.bind(undefined)() === undefined);
+    })();
 
     // Arrow functions can not have their |this| value set.
     assert((() => this).bind("foo")() === globalThis)


### PR DESCRIPTION
This PR allows `null` or `undefined` to be a bound `this` value in functions produced from `Function.prototype.bind` when in strict mode.