### PR TITLE
LibJS: Fix Parser.parse_template_literal looping forever

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -719,7 +719,7 @@ NonnullRefPtr<TemplateLiteral> Parser::parse_template_literal(bool is_tagged)
     if (!match(TokenType::TemplateLiteralString))
         append_empty_string();
 
-    while (!match(TokenType::TemplateLiteralEnd) && !match(TokenType::UnterminatedTemplateLiteral)) {
+    while (!done() && !match(TokenType::TemplateLiteralEnd) && !match(TokenType::UnterminatedTemplateLiteral)) {
         if (match(TokenType::TemplateLiteralString)) {
             auto token = consume();
             expressions.append(parse_string_literal(token));
@@ -741,6 +741,9 @@ NonnullRefPtr<TemplateLiteral> Parser::parse_template_literal(bool is_tagged)
 
             if (!match(TokenType::TemplateLiteralString))
                 append_empty_string();
+        } else {
+            expected("Template literal string or expression");
+            break;
         }
     }
 


### PR DESCRIPTION
`parse_template_literal` now breaks out of the loop if it sees something it doesn't expect. Additionally, it now checks for EOFs.