### PR TITLE
LibWeb: Implement more of the "in body" insertion mode in the parser

### DIFF
--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -1195,10 +1195,12 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
     }
 
     if (token.is_end_tag() && token.tag_name() == "br") {
-        TODO();
+        token.drop_attributes();
+        goto BRStartTag;
     }
 
     if (token.is_start_tag() && token.tag_name().is_one_of("area", "br", "embed", "img", "keygen", "wbr")) {
+    BRStartTag:
         reconstruct_the_active_formatting_elements();
         insert_html_element(token);
         m_stack_of_open_elements.pop();

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -1169,7 +1169,18 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
     }
 
     if (token.is_end_tag() && token.tag_name().is_one_of("applet", "marquee", "object")) {
-        TODO();
+        if (!m_stack_of_open_elements.has_in_scope(token.tag_name())) {
+            PARSE_ERROR();
+            return;
+        }
+
+        generate_implied_end_tags();
+        if (current_node().tag_name() != token.tag_name()) {
+            PARSE_ERROR();
+        }
+        m_stack_of_open_elements.pop_until_an_element_with_tag_name_has_been_popped(token.tag_name());
+        m_list_of_active_formatting_elements.clear_up_to_the_last_marker();
+        return;
     }
 
     if (token.is_start_tag() && token.tag_name() == "table") {

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -1161,7 +1161,15 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == "nobr") {
-        TODO();
+        reconstruct_the_active_formatting_elements();
+        if (m_stack_of_open_elements.has_in_scope("nobr")) {
+            PARSE_ERROR();
+            run_the_adoption_agency_algorithm(token);
+            reconstruct_the_active_formatting_elements();
+        }
+        auto element = insert_html_element(token);
+        m_list_of_active_formatting_elements.add(*element);
+        return;
     }
 
     if (token.is_end_tag() && token.tag_name().is_one_of("a", "b", "big", "code", "em", "font", "i", "nobr", "s", "small", "strike", "strong", "tt", "u")) {

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -1284,7 +1284,13 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == "xmp") {
-        TODO();
+        if (m_stack_of_open_elements.has_in_button_scope("p")) {
+            close_a_p_element();
+        }
+        reconstruct_the_active_formatting_elements();
+        m_frameset_ok = false;
+        parse_generic_raw_text_element(token);
+        return;
     }
 
     if (token.is_start_tag() && token.tag_name() == "iframe") {

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -889,15 +889,16 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
 
     if (token.is_end_tag() && token.tag_name() == "body") {
         if (!m_stack_of_open_elements.has_in_scope("body")) {
-            TODO();
+            PARSE_ERROR();
+            return;
         }
 
-        // FIXME: Otherwise, if there is a node in the stack of open elements that is
-        // not either a dd element, a dt element, an li element, an optgroup element,
-        // an option element, a p element, an rb element, an rp element, an rt element,
-        // an rtc element, a tbody element, a td element, a tfoot element, a th element,
-        // a thead element, a tr element, the body element, or the html element,
-        // then this is a parse error.
+        for (auto& node : m_stack_of_open_elements.elements()) {
+            if (!node.tag_name().is_one_of("dd", "dt", "li", "optgroup", "option", "p", "rb", "rp", "rt", "rtc", "tbody", "td", "tfoot", "th", "thead", "tr", "body", "html")) {
+                PARSE_ERROR();
+                break;
+            }
+        }
 
         m_insertion_mode = InsertionMode::AfterBody;
         return;

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -1061,7 +1061,15 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
             }
             m_stack_of_open_elements.elements().remove_first_matching([&](auto& entry) { return entry.ptr() == node.ptr(); });
         } else {
-            TODO();
+            if (!m_stack_of_open_elements.has_in_scope("form")) {
+                PARSE_ERROR();
+                return;
+            }
+            generate_implied_end_tags();
+            if (current_node().tag_name() != "form") {
+                PARSE_ERROR();
+            }
+            m_stack_of_open_elements.pop_until_an_element_with_tag_name_has_been_popped("form");
         }
         return;
     }

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -809,7 +809,8 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
 {
     if (token.is_character()) {
         if (token.codepoint() == 0) {
-            TODO();
+            PARSE_ERROR();
+            return;
         }
         if (token.is_parser_whitespace()) {
             reconstruct_the_active_formatting_elements();

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -905,6 +905,24 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
         return;
     }
 
+    if (token.is_end_tag() && token.tag_name() == "html") {
+        if (!m_stack_of_open_elements.has_in_scope("body")) {
+            PARSE_ERROR();
+            return;
+        }
+
+        for (auto& node : m_stack_of_open_elements.elements()) {
+            if (!node.tag_name().is_one_of("dd", "dt", "li", "optgroup", "option", "p", "rb", "rp", "rt", "rtc", "tbody", "td", "tfoot", "th", "thead", "tr", "body", "html")) {
+                PARSE_ERROR();
+                break;
+            }
+        }
+
+        m_insertion_mode = InsertionMode::AfterBody;
+        process_using_the_rules_for(m_insertion_mode, token);
+        return;
+    }
+
     if (token.is_start_tag() && token.tag_name().is_one_of("address", "article", "aside", "blockquote", "center", "details", "dialog", "dir", "div", "dl", "fieldset", "figcaption", "figure", "footer", "header", "hgroup", "main", "menu", "nav", "ol", "p", "section", "summary", "ul")) {
         if (m_stack_of_open_elements.has_in_button_scope("p"))
             close_a_p_element();

--- a/Libraries/LibWeb/Parser/HTMLToken.h
+++ b/Libraries/LibWeb/Parser/HTMLToken.h
@@ -123,6 +123,12 @@ public:
         return {};
     }
 
+    void drop_attributes()
+    {
+        ASSERT(is_start_tag() || is_end_tag());
+        m_tag.attributes.clear();
+    }
+
     Type type() const { return m_type; }
 
     String to_string() const;


### PR DESCRIPTION
I implemented some of the `TODO()`s that were in `HTMLDocumentParser::handle_in_body`.

We can now parse `</marquee>` without crashing, which I imagine at some point will prove to be incredibly helpful.