### PR TITLE
LibCrypto: Correctly pad blocks with FinalBlockSize < size < BlockSize 

### DIFF
--- a/Libraries/LibCrypto/Hash/SHA1.cpp
+++ b/Libraries/LibCrypto/Hash/SHA1.cpp
@@ -115,17 +115,26 @@ SHA1::DigestType SHA1::peek()
     __builtin_memcpy(data, m_data_buffer, m_data_length);
     __builtin_memcpy(state, m_state, 20);
 
+    if (BlockSize == m_data_length) {
+        transform(m_data_buffer);
+        m_bit_length += BlockSize * 8;
+        m_data_length = 0;
+        i = 0;
+    }
+
     if (m_data_length < FinalBlockDataSize) {
         m_data_buffer[i++] = 0x80;
         while (i < FinalBlockDataSize)
             m_data_buffer[i++] = 0x00;
 
     } else {
+        // First, complete a block with some padding.
         m_data_buffer[i++] = 0x80;
         while (i < BlockSize)
             m_data_buffer[i++] = 0x00;
-
         transform(m_data_buffer);
+
+        // Then start another block with BlockSize - 8 bytes of zeros
         __builtin_memset(m_data_buffer, 0, FinalBlockDataSize);
     }
 

--- a/Libraries/LibCrypto/Hash/SHA2.cpp
+++ b/Libraries/LibCrypto/Hash/SHA2.cpp
@@ -110,17 +110,26 @@ SHA256::DigestType SHA256::peek()
     DigestType digest;
     size_t i = m_data_length;
 
+    if (BlockSize == m_data_length) {
+        transform(m_data_buffer);
+        m_bit_length += BlockSize * 8;
+        m_data_length = 0;
+        i = 0;
+    }
+
     if (m_data_length < FinalBlockDataSize) {
         m_data_buffer[i++] = 0x80;
         while (i < FinalBlockDataSize)
             m_data_buffer[i++] = 0x00;
 
     } else {
+        // First, complete a block with some padding.
         m_data_buffer[i++] = 0x80;
         while (i < BlockSize)
             m_data_buffer[i++] = 0x00;
-
         transform(m_data_buffer);
+
+        // Then start another block with BlockSize - 8 bytes of zeros
         __builtin_memset(m_data_buffer, 0, FinalBlockDataSize);
     }
 
@@ -218,17 +227,26 @@ SHA512::DigestType SHA512::peek()
     DigestType digest;
     size_t i = m_data_length;
 
+    if (BlockSize == m_data_length) {
+        transform(m_data_buffer);
+        m_bit_length += BlockSize * 8;
+        m_data_length = 0;
+        i = 0;
+    }
+
     if (m_data_length < FinalBlockDataSize) {
         m_data_buffer[i++] = 0x80;
         while (i < FinalBlockDataSize)
             m_data_buffer[i++] = 0x00;
 
     } else {
+        // First, complete a block with some padding.
         m_data_buffer[i++] = 0x80;
         while (i < BlockSize)
             m_data_buffer[i++] = 0x00;
-
         transform(m_data_buffer);
+
+        // Then start another block with BlockSize - 8 bytes of zeros
         __builtin_memset(m_data_buffer, 0, FinalBlockDataSize);
     }
 

--- a/Libraries/LibTLS/Record.cpp
+++ b/Libraries/LibTLS/Record.cpp
@@ -68,24 +68,21 @@ void TLSv12::update_packet(ByteBuffer& packet)
         if (m_context.cipher_spec_set && m_context.crypto.created) {
             size_t length = packet.size() - header_size + mac_length();
             auto block_size = m_aes_local->cipher().block_size();
-            // if length is a multiple of block size, pad it up again
-            // since it seems no one handles aligned unpadded blocks
-            size_t padding = 0;
-            if (length % block_size == 0) {
-                padding = block_size;
-                length += padding;
-            }
+            // If the length is already a multiple a block_size,
+            // an entire block of padding is added.
+            // In short, we _never_ have no padding.
+            size_t padding = block_size - length % block_size;
+            length += padding;
             size_t mac_size = mac_length();
 
             if (m_context.crypto.created == 1) {
                 // `buffer' will continue to be encrypted
                 auto buffer = ByteBuffer::create_zeroed(length);
                 size_t buffer_position = 0;
-                u16 aligned_length = length + block_size - length % block_size;
                 auto iv_size = iv_length();
 
-                // we need enough space for a header, iv_length bytes of IV and whatever the packet contains
-                auto ct = ByteBuffer::create_zeroed(aligned_length + header_size + iv_size);
+                // We need enough space for a header, iv_length bytes of IV and whatever the packet contains
+                auto ct = ByteBuffer::create_zeroed(length + header_size + iv_size);
 
                 // copy the header over
                 ct.overwrite(0, packet.data(), header_size - 2);
@@ -101,32 +98,30 @@ void TLSv12::update_packet(ByteBuffer& packet)
                 buffer.overwrite(buffer_position, mac.data(), mac.size());
                 buffer_position += mac.size();
 
-                // if there's some padding to be done (since a packet MUST always be padded)
-                // apply it manually
-                if (padding) {
-                    memset(buffer.offset_pointer(buffer_position), padding - 1, padding);
-                    buffer_position += padding;
-                }
+                // Apply the padding (a packet MUST always be padded)
+                memset(buffer.offset_pointer(buffer_position), padding - 1, padding);
+                buffer_position += padding;
 
-                // should be the same value, but the manual padding
-                // throws a wrench into our plans
-                buffer.trim(buffer_position);
+                ASSERT(buffer_position == buffer.size());
 
-                // FIXME: REALLY Should be filled with random bytes
-                auto iv = ByteBuffer::create_zeroed(iv_size);
+                auto iv = ByteBuffer::create_uninitialized(iv_size);
+                AK::fill_with_random(iv.data(), iv.size());
 
                 // write it into the ciphertext portion of the message
                 ct.overwrite(header_size, iv.data(), iv.size());
-                ct.trim(length + block_size - length % block_size + header_size + block_size - padding);
+
+                ASSERT(header_size + iv_size + length == ct.size());
+                ASSERT(length % block_size == 0);
 
                 // get a block to encrypt into
-                auto view = ct.slice_view(header_size + iv_size, length + block_size - length % block_size + block_size - padding - iv_size);
+                auto view = ct.slice_view(header_size + iv_size, length);
 
                 // encrypt the message
                 m_aes_local->encrypt(buffer, view, iv);
 
                 // store the correct ciphertext length into the packet
                 u16 ct_length = (u16)ct.size() - header_size;
+
                 *(u16*)ct.offset_pointer(header_size - 2) = convert_between_host_and_network(ct_length);
 
                 // replace the packet with the ciphertext

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -960,6 +960,32 @@ void hmac_sha256_test_process()
             PASS;
     }
     {
+        I_TEST((HMAC - SHA256 | DataSize > FinalBlockDataSize));
+        Crypto::Authentication::HMAC<Crypto::Hash::SHA256> hmac("Well Hello Friends");
+        u8 result[] = {
+            0x9b, 0xa3, 0x9e, 0xf3, 0xb4, 0x30, 0x5f, 0x6f, 0x67, 0xd0, 0xa8, 0xb0, 0xf0, 0xcb, 0x12, 0xf5, 0x85, 0xe2, 0x19, 0xba, 0x0c, 0x8b, 0xe5, 0x43, 0xf0, 0x93, 0x39, 0xa8, 0xa3, 0x07, 0xf1, 0x95
+        };
+        auto mac = hmac.process("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        if (memcmp(result, mac.data, hmac.digest_size()) != 0) {
+            FAIL(Invalid mac);
+            print_buffer(ByteBuffer::wrap(mac.data, hmac.digest_size()), -1);
+        } else
+            PASS;
+    }
+    {
+        I_TEST((HMAC - SHA256 | DataSize == BlockSize));
+        Crypto::Authentication::HMAC<Crypto::Hash::SHA256> hmac("Well Hello Friends");
+        u8 result[] = {
+            0x1d, 0x90, 0xce, 0x68, 0x45, 0x0b, 0xba, 0xd6, 0xbe, 0x1c, 0xb2, 0x3a, 0xea, 0x7f, 0xac, 0x4b, 0x68, 0x08, 0xa4, 0x77, 0x81, 0x2a, 0xad, 0x5d, 0x05, 0xe2, 0x15, 0xe8, 0xf4, 0xcb, 0x06, 0xaf
+        };
+        auto mac = hmac.process("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        if (memcmp(result, mac.data, hmac.digest_size()) != 0) {
+            FAIL(Invalid mac);
+            print_buffer(ByteBuffer::wrap(mac.data, hmac.digest_size()), -1);
+        } else
+            PASS;
+    }
+    {
         I_TEST((HMAC - SHA256 | Reuse));
         Crypto::Authentication::HMAC<Crypto::Hash::SHA256> hmac("Well Hello Friends");
 


### PR DESCRIPTION
This fixes #2488

I am not entirely sure if we can load twitter, but at least we don't crash while doing so.
One out of bounds write is also addressed now (we were writing out of bounds in the hash function when `FinalBlockSize < size < BlockSize`).

Oh, and MORE ASSERTIONS :tada: