### PR TITLE
LibJS: Hoist function declarations

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -67,10 +67,8 @@ Value ScopeNode::execute(Interpreter& interpreter) const
     return interpreter.run(*this);
 }
 
-Value FunctionDeclaration::execute(Interpreter& interpreter) const
+Value FunctionDeclaration::execute(Interpreter&) const
 {
-    auto* function = ScriptFunction::create(interpreter.global_object(), name(), body(), parameters(), function_length(), interpreter.current_environment());
-    interpreter.set_variable(name(), function);
     return js_undefined();
 }
 
@@ -1763,6 +1761,11 @@ Value DebuggerStatement::execute(Interpreter&) const
 void ScopeNode::add_variables(NonnullRefPtrVector<VariableDeclaration> variables)
 {
     m_variables.append(move(variables));
+}
+
+void ScopeNode::add_functions(NonnullRefPtrVector<FunctionDeclaration> functions)
+{
+    m_functions.append(move(functions));
 }
 
 }

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -40,6 +40,7 @@
 namespace JS {
 
 class VariableDeclaration;
+class FunctionDeclaration;
 
 template<class T, class... Args>
 static inline NonnullRefPtr<T>
@@ -124,8 +125,9 @@ public:
     virtual void dump(int indent) const override;
 
     void add_variables(NonnullRefPtrVector<VariableDeclaration>);
+    void add_functions(NonnullRefPtrVector<FunctionDeclaration>);
     const NonnullRefPtrVector<VariableDeclaration>& variables() const { return m_variables; }
-
+    const NonnullRefPtrVector<FunctionDeclaration>& functions() const { return m_functions; }
     bool in_strict_mode() const { return m_strict_mode; }
     void set_strict_mode() { m_strict_mode = true; }
 
@@ -136,6 +138,7 @@ private:
     virtual bool is_scope_node() const final { return true; }
     NonnullRefPtrVector<Statement> m_children;
     NonnullRefPtrVector<VariableDeclaration> m_variables;
+    NonnullRefPtrVector<FunctionDeclaration> m_functions;
     bool m_strict_mode { false };
 };
 
@@ -175,6 +178,7 @@ public:
     const FlyString& name() const { return m_name; }
     const Statement& body() const { return *m_body; }
     const Vector<Parameter>& parameters() const { return m_parameters; };
+    i32 function_length() const { return m_function_length; }
 
 protected:
     FunctionNode(const FlyString& name, NonnullRefPtr<Statement> body, Vector<Parameter> parameters, i32 function_length, NonnullRefPtrVector<VariableDeclaration> variables)
@@ -189,7 +193,6 @@ protected:
     void dump(int indent, const char* class_name) const;
 
     const NonnullRefPtrVector<VariableDeclaration>& variables() const { return m_variables; }
-    i32 function_length() const { return m_function_length; }
 
 private:
     FlyString m_name;

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -35,6 +35,7 @@
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/Reference.h>
+#include <LibJS/Runtime/ScriptFunction.h>
 #include <LibJS/Runtime/Shape.h>
 #include <LibJS/Runtime/SymbolObject.h>
 #include <LibJS/Runtime/Value.h>
@@ -91,6 +92,11 @@ Value Interpreter::run(const Statement& statement, ArgumentVector arguments, Sco
 
 void Interpreter::enter_scope(const ScopeNode& scope_node, ArgumentVector arguments, ScopeType scope_type)
 {
+    for (auto& declaration : scope_node.functions()) {
+        auto* function = ScriptFunction::create(global_object(), declaration.name(), declaration.body(), declaration.parameters(), declaration.function_length(), current_environment());
+        set_variable(declaration.name(), function);
+    }
+
     if (scope_type == ScopeType::Function) {
         m_scope_stack.append({ scope_type, scope_node, false });
         return;

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -147,6 +147,7 @@ private:
         Vector<Error> m_errors;
         Vector<NonnullRefPtrVector<VariableDeclaration>> m_var_scopes;
         Vector<NonnullRefPtrVector<VariableDeclaration>> m_let_scopes;
+        Vector<NonnullRefPtrVector<FunctionDeclaration>> m_function_scopes;
         UseStrictDirectiveState m_use_strict_directive { UseStrictDirectiveState::None };
         bool m_strict_mode { false };
 

--- a/Libraries/LibJS/Tests/function-hoisting.js
+++ b/Libraries/LibJS/Tests/function-hoisting.js
@@ -1,0 +1,37 @@
+load("test-common.js");
+
+try {
+    var callHoisted = hoisted();
+    function hoisted() {
+        return true;
+    }
+    assert(hoisted() === true);
+    assert(callHoisted === true);
+
+    {
+        var callScopedHoisted = scopedHoisted();
+        function scopedHoisted() {
+            return "foo";
+        }
+        assert(scopedHoisted() === "foo");
+        assert(callScopedHoisted === "foo");
+    }
+    assert(scopedHoisted() === "foo");
+    assert(callScopedHoisted === "foo");
+
+    const test = () => {
+        var iife = (function () {
+            return declaredLater();
+        })();
+        function declaredLater() {
+            return "yay";
+        }
+        return iife;
+    };
+    assert(typeof declaredLater === "undefined");
+    assert(test() === "yay");
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/function-rest-params.js
+++ b/Libraries/LibJS/Tests/function-rest-params.js
@@ -7,7 +7,7 @@ try {
     }
     foo();
 
-    function foo(...a) {
+    function foo1(...a) {
         assert(a instanceof Array);
         assert(a.length === 4);
         assert(a[0] === "foo");
@@ -15,17 +15,17 @@ try {
         assert(a[2] === undefined);
         assert(a[3].foo === "bar");
     }
-    foo("foo", 123, undefined, { foo: "bar" });
+    foo1("foo", 123, undefined, { foo: "bar" });
 
-    function foo(a, b, ...c) {
+    function foo2(a, b, ...c) {
         assert(a === "foo");
         assert(b === 123);
         assert(c instanceof Array);
         assert(c.length === 0);
     }
-    foo("foo", 123);
+    foo2("foo", 123);
 
-    function foo(a, b, ...c) {
+    function foo3(a, b, ...c) {
         assert(a === "foo");
         assert(b === 123);
         assert(c instanceof Array);
@@ -33,7 +33,7 @@ try {
         assert(c[0] === undefined);
         assert(c[1].foo === "bar");
     }
-    foo("foo", 123, undefined, { foo: "bar" });
+    foo3("foo", 123, undefined, { foo: "bar" });
 
     var foo = (...a) => {
         assert(a instanceof Array);


### PR DESCRIPTION
This patch adds function declaration hoisting. The mechanism
is similar to var hoisting. Hoisted function declarations are to be put
before the hoisted var declarations, hence they have to be treated
separately.