### PR TITLE
LibCrypto: Add a simple SignedBigInteger

### DIFF
--- a/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "SignedBigInteger.h"
+#include <AK/StringBuilder.h>
+
+namespace Crypto {
+
+SignedBigInteger SignedBigInteger::import_data(const u8* ptr, size_t length)
+{
+    bool sign = *ptr;
+    auto unsigned_data = UnsignedBigInteger::import_data(ptr + 1, length - 1);
+    return { move(unsigned_data), sign };
+}
+
+size_t SignedBigInteger::export_data(AK::ByteBuffer& data) const
+{
+    data[0] = m_sign;
+    auto bytes_view = data.slice_view(1, data.size() - 1);
+    return m_unsigned_data.export_data(bytes_view) + 1;
+}
+
+SignedBigInteger SignedBigInteger::from_base10(StringView str)
+{
+    bool sign = false;
+    if (str.length() > 1) {
+        auto maybe_sign = str[0];
+        if (maybe_sign == '-') {
+            str = str.substring_view(1, str.length() - 1);
+            sign = true;
+        }
+        if (maybe_sign == '+')
+            str = str.substring_view(1, str.length() - 1);
+    }
+    auto unsigned_data = UnsignedBigInteger::from_base10(str);
+    return { move(unsigned_data), sign };
+}
+
+String SignedBigInteger::to_base10() const
+{
+    StringBuilder builder;
+
+    if (m_sign)
+        builder.append('-');
+
+    builder.append(m_unsigned_data.to_base10());
+
+    return builder.to_string();
+}
+
+FLATTEN SignedBigInteger SignedBigInteger::plus(const SignedBigInteger& other) const
+{
+    // If both are of the same sign, just add the unsigned data and return.
+    if (m_sign == other.m_sign)
+        return { other.m_unsigned_data.plus(m_unsigned_data), m_sign };
+
+    // One value is signed while the other is not.
+    return m_sign ? other.minus(this->m_unsigned_data) : minus(other.m_unsigned_data);
+}
+
+FLATTEN SignedBigInteger SignedBigInteger::minus(const SignedBigInteger& other) const
+{
+    // If the signs are different, convert the op to an addition.
+    if (m_sign != other.m_sign) {
+        // -x - y = - (x + y)
+        // x - -y = (x + y)
+        SignedBigInteger result { other.m_unsigned_data.plus(this->m_unsigned_data) };
+        if (m_sign)
+            result.negate();
+        return result;
+    }
+
+    if (!m_sign) {
+        // Both operands are positive.
+        // x - y = - (y - x)
+        if (m_unsigned_data < other.m_unsigned_data) {
+            // The result will be negative.
+            return { other.m_unsigned_data.minus(m_unsigned_data), true };
+        }
+
+        // The result will be either zero, or positive.
+        return SignedBigInteger { m_unsigned_data.minus(other.m_unsigned_data) };
+    }
+
+    // Both operands are negative.
+    // -x - -y = y - x
+    if (m_unsigned_data < other.m_unsigned_data) {
+        // The result will be positive.
+        return SignedBigInteger { m_unsigned_data.minus(other.m_unsigned_data) };
+    }
+    // The result will be either zero, or negative.
+    // y - x = - (x - y)
+    return { other.m_unsigned_data.minus(m_unsigned_data), true };
+}
+
+FLATTEN SignedBigInteger SignedBigInteger::plus(const UnsignedBigInteger& other) const
+{
+    if (m_sign) {
+        if (other < m_unsigned_data)
+            return { m_unsigned_data.minus(other), true };
+
+        return { other.minus(m_unsigned_data), false };
+    }
+
+    return { m_unsigned_data.plus(other), false };
+}
+
+FLATTEN SignedBigInteger SignedBigInteger::minus(const UnsignedBigInteger& other) const
+{
+    if (m_sign)
+        return { m_unsigned_data.plus(m_unsigned_data), true };
+
+    if (other < m_unsigned_data)
+        return { m_unsigned_data.minus(other), false };
+
+    return { other.minus(m_unsigned_data), true };
+}
+
+bool SignedBigInteger::operator==(const UnsignedBigInteger& other) const
+{
+    if (m_sign)
+        return false;
+    return m_unsigned_data == other;
+}
+
+bool SignedBigInteger::operator!=(const UnsignedBigInteger& other) const
+{
+    if (m_sign)
+        return true;
+    return m_unsigned_data != other;
+}
+
+bool SignedBigInteger::operator<(const UnsignedBigInteger& other) const
+{
+    if (m_sign)
+        return true;
+    return m_unsigned_data < other;
+}
+
+FLATTEN SignedBigInteger SignedBigInteger::shift_left(size_t num_bits) const
+{
+    return SignedBigInteger { m_unsigned_data.shift_left(num_bits), m_sign };
+}
+
+FLATTEN SignedBigInteger SignedBigInteger::multiplied_by(const SignedBigInteger& other) const
+{
+    bool result_sign = m_sign ^ other.m_sign;
+    return { m_unsigned_data.multiplied_by(other.m_unsigned_data), result_sign };
+}
+
+FLATTEN SignedDivisionResult SignedBigInteger::divided_by(const SignedBigInteger& divisor) const
+{
+    // Aa / Bb -> (A^B)q, Ar
+    bool result_sign = m_sign ^ divisor.m_sign;
+    auto unsigned_division_result = m_unsigned_data.divided_by(divisor.m_unsigned_data);
+    return {
+        { move(unsigned_division_result.quotient), result_sign },
+        { move(unsigned_division_result.remainder), m_sign }
+    };
+}
+
+void SignedBigInteger::set_bit_inplace(size_t bit_index)
+{
+    m_unsigned_data.set_bit_inplace(bit_index);
+}
+
+bool SignedBigInteger::operator==(const SignedBigInteger& other) const
+{
+    if (is_invalid() != other.is_invalid())
+        return false;
+
+    if (m_unsigned_data == 0 && other.m_unsigned_data == 0)
+        return true;
+
+    return m_sign == other.m_sign && m_unsigned_data == other.m_unsigned_data;
+}
+
+bool SignedBigInteger::operator!=(const SignedBigInteger& other) const
+{
+    return !(*this == other);
+}
+
+bool SignedBigInteger::operator<(const SignedBigInteger& other) const
+{
+    if (m_sign ^ other.m_sign)
+        return m_sign;
+
+    if (m_sign)
+        return other.m_unsigned_data < m_unsigned_data;
+
+    return m_unsigned_data < other.m_unsigned_data;
+}
+
+}

--- a/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibCrypto/BigInt/UnsignedBigInteger.h>
+
+namespace Crypto {
+
+struct SignedDivisionResult;
+
+class SignedBigInteger {
+public:
+    SignedBigInteger(i32 x)
+        : m_sign(x < 0)
+        , m_unsigned_data(abs(x))
+    {
+    }
+
+    SignedBigInteger(UnsignedBigInteger&& unsigned_data, bool sign)
+        : m_sign(sign)
+        , m_unsigned_data(move(unsigned_data))
+    {
+    }
+
+    explicit SignedBigInteger(UnsignedBigInteger unsigned_data)
+        : m_sign(false)
+        , m_unsigned_data(move(unsigned_data))
+    {
+    }
+
+    SignedBigInteger()
+        : m_sign(false)
+        , m_unsigned_data()
+    {
+    }
+
+    static SignedBigInteger create_invalid()
+    {
+        return { UnsignedBigInteger::create_invalid(), false };
+    }
+
+    static SignedBigInteger import_data(const AK::StringView& data) { return import_data((const u8*)data.characters_without_null_termination(), data.length()); }
+    static SignedBigInteger import_data(const u8* ptr, size_t length);
+
+    size_t export_data(AK::ByteBuffer& data) const;
+    size_t export_data(const u8* ptr, size_t length) const
+    {
+        auto buffer = ByteBuffer::wrap(ptr, length);
+        return export_data(buffer);
+    }
+
+    static SignedBigInteger from_base10(StringView str);
+    String to_base10() const;
+
+    const UnsignedBigInteger& unsigned_value() const { return m_unsigned_data; }
+    const Vector<u32, STARTING_WORD_SIZE> words() const { return m_unsigned_data.words(); }
+    bool is_negative() const { return m_sign; }
+
+    void negate() { m_sign = !m_sign; }
+
+    void set_to_0() { m_unsigned_data.set_to_0(); }
+    void set_to(i32 other)
+    {
+        m_unsigned_data.set_to((u32)other);
+        m_sign = other < 0;
+    }
+    void set_to(const SignedBigInteger& other)
+    {
+        m_unsigned_data.set_to(other.m_unsigned_data);
+        m_sign = other.m_sign;
+    }
+
+    void invalidate()
+    {
+        m_unsigned_data.invalidate();
+    }
+
+    bool is_invalid() const { return m_unsigned_data.is_invalid(); }
+
+    // These get + 1 byte for the sign.
+    size_t length() const { return m_unsigned_data.length() + 1; }
+    size_t trimmed_length() const { return m_unsigned_data.trimmed_length() + 1; };
+
+    SignedBigInteger plus(const SignedBigInteger& other) const;
+    SignedBigInteger minus(const SignedBigInteger& other) const;
+    SignedBigInteger shift_left(size_t num_bits) const;
+    SignedBigInteger multiplied_by(const SignedBigInteger& other) const;
+    SignedDivisionResult divided_by(const SignedBigInteger& divisor) const;
+
+    SignedBigInteger plus(const UnsignedBigInteger& other) const;
+    SignedBigInteger minus(const UnsignedBigInteger& other) const;
+    SignedBigInteger multiplied_by(const UnsignedBigInteger& other) const;
+    SignedDivisionResult divided_by(const UnsignedBigInteger& divisor) const;
+
+    void set_bit_inplace(size_t bit_index);
+
+    bool operator==(const SignedBigInteger& other) const;
+    bool operator!=(const SignedBigInteger& other) const;
+    bool operator<(const SignedBigInteger& other) const;
+
+    bool operator==(const UnsignedBigInteger& other) const;
+    bool operator!=(const UnsignedBigInteger& other) const;
+    bool operator<(const UnsignedBigInteger& other) const;
+
+private:
+    bool m_sign { false };
+    UnsignedBigInteger m_unsigned_data;
+};
+
+struct SignedDivisionResult {
+    Crypto::SignedBigInteger quotient;
+    Crypto::SignedBigInteger remainder;
+};
+
+}
+
+inline const LogStream&
+operator<<(const LogStream& stream, const Crypto::SignedBigInteger value)
+{
+    if (value.is_invalid()) {
+        stream << "Invalid BigInt";
+        return stream;
+    }
+    if (value.is_negative())
+        stream << "-";
+
+    stream << value.unsigned_value();
+    return stream;
+}
+
+inline Crypto::SignedBigInteger
+operator""_sbigint(const char* string, size_t length)
+{
+    return Crypto::SignedBigInteger::from_base10({ string, length });
+}

--- a/Libraries/LibCrypto/CMakeLists.txt
+++ b/Libraries/LibCrypto/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     BigInt/UnsignedBigInteger.cpp
+    BigInt/SignedBigInteger.cpp
     Cipher/AES.cpp
     Hash/MD5.cpp
     Hash/SHA1.cpp

--- a/Libraries/LibCrypto/NumberTheory/ModularFunctions.h
+++ b/Libraries/LibCrypto/NumberTheory/ModularFunctions.h
@@ -161,6 +161,30 @@ static auto ModularPower(const UnsignedBigInteger& b, const UnsignedBigInteger& 
     return exp;
 }
 
+// Note: This function _will_ generate extremely huge numbers, and in doing so,
+//       it will allocate and free a lot of memory!
+//       Please use |ModularPower| if your use-case is modexp.
+template<typename IntegerType>
+static auto Power(const IntegerType& b, const IntegerType& e) -> IntegerType
+{
+    IntegerType ep { e };
+    IntegerType base { b };
+    IntegerType exp { 1 };
+
+    while (!(ep < 1)) {
+        if (ep.words()[0] % 2 == 1)
+            exp.set_to(exp.multiplied_by(base));
+
+        // ep = ep / 2;
+        ep.set_to(ep.divided_by(2).quotient);
+
+        // base = base * base
+        base.set_to(base.multiplied_by(base));
+    }
+
+    return exp;
+}
+
 static void GCD_without_allocation(
     const UnsignedBigInteger& a,
     const UnsignedBigInteger& b,


### PR DESCRIPTION
This patchset adds a simple SignedBigInteger that is entirely defined in terms of UnsignedBigInteger.

It also adds a NumberTheory::Power function, which is terribly
inefficient, but since the use of exponentiation is very much
discouraged for large inputs, no particular attempts were made
to make it more performant.

@linusg ^^