### PR TITLE
Toolchain: support building the toolchain with Ninja

### DIFF
--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -229,7 +229,7 @@ pushd "$DIR/Build/"
         mkdir -p "$BUILD"
         pushd "$BUILD"
             CXXFLAGS="-DBUILDING_SERENITY_TOOLCHAIN" cmake ..
-            "$MAKE" LibC
+            cmake --build . --target LibC
             install -D Libraries/LibC/libc.a Libraries/LibM/libm.a Root/usr/lib/
             SRC_ROOT=$(realpath "$DIR"/..)
             for header in "$SRC_ROOT"/Libraries/Lib{C,M}/**/*.h; do


### PR DESCRIPTION
This change allows users to use CMAKE_GENERATOR=Ninja ./BuildIt.sh

BuildIt.sh assumes the default cmake generator is Make. However,
the user may specify CMAKE_GENERATOR=Ninja, for example, to set the
default generator. Therefore, instead of calling make to build the
LibC target we should call cmake --build to use the correct generated
files.