### PR TITLE
Make serenity boot even if the umask at git clone time was 027.

### DIFF
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -26,6 +26,10 @@ umask 0022
 printf "installing base system... "
 cp -R "$SERENITY_ROOT"/Base/* mnt/
 cp -R Root/* mnt/
+# If umask was 027 or similar when the repo was cloned,
+# file permissions in Base/ are too restrictive. Restore
+# the permissions needed in the image.
+chmod -R g+rX,o+rX "$SERENITY_ROOT"/Base/* mnt/
 chmod 400 mnt/res/kernel.map
 
 chmod 660 mnt/etc/WindowServer/WindowServer.ini

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -23,6 +23,29 @@ fi
 
 umask 0022
 
+printf "installing base system... "
+cp -R "$SERENITY_ROOT"/Base/* mnt/
+cp -R Root/* mnt/
+chmod 400 mnt/res/kernel.map
+
+chmod 660 mnt/etc/WindowServer/WindowServer.ini
+chown $window_uid:$window_gid mnt/etc/WindowServer/WindowServer.ini
+echo "/bin/sh" > mnt/etc/shells
+
+chown 0:$wheel_gid mnt/bin/su
+chown 0:$phys_gid mnt/bin/shutdown
+chown 0:$phys_gid mnt/bin/reboot
+chown 0:0 mnt/boot/Kernel
+chown 0:0 mnt/res/kernel.map
+chmod 0400 mnt/res/kernel.map
+chmod 0400 mnt/boot/Kernel
+chmod 4750 mnt/bin/su
+chmod 4755 mnt/bin/ping
+chmod 4750 mnt/bin/reboot
+chmod 4750 mnt/bin/shutdown
+
+echo "done"
+
 printf "creating initial filesystem structure... "
 for dir in bin etc proc mnt tmp boot mod; do
     mkdir -p mnt/$dir
@@ -81,29 +104,6 @@ done
 ln -s /proc/self/fd/0 mnt/dev/stdin
 ln -s /proc/self/fd/1 mnt/dev/stdout
 ln -s /proc/self/fd/2 mnt/dev/stderr
-echo "done"
-
-printf "installing base system... "
-cp -R "$SERENITY_ROOT"/Base/* mnt/
-cp -R Root/* mnt/
-chmod 400 mnt/res/kernel.map
-
-chmod 660 mnt/etc/WindowServer/WindowServer.ini
-chown $window_uid:$window_gid mnt/etc/WindowServer/WindowServer.ini
-echo "/bin/sh" > mnt/etc/shells
-
-chown 0:$wheel_gid mnt/bin/su
-chown 0:$phys_gid mnt/bin/shutdown
-chown 0:$phys_gid mnt/bin/reboot
-chown 0:0 mnt/boot/Kernel
-chown 0:0 mnt/res/kernel.map
-chmod 0400 mnt/res/kernel.map
-chmod 0400 mnt/boot/Kernel
-chmod 4750 mnt/bin/su
-chmod 4755 mnt/bin/ping
-chmod 4750 mnt/bin/reboot
-chmod 4750 mnt/bin/shutdown
-
 echo "done"
 
 printf "writing version file... "


### PR DESCRIPTION
My system has an umask of 027. This means that every file that's created gets the w bit erased for group members, and all of rwx erased for others. It's likely some security measure.

This has the effect that the files in Base/ don't have rx set for others, but those bits are needed when serenity runs so that e.g. the window user can read /etc/WindowServer/WindowServer.ini.
Instead of just copying the on-disk permissions into the image, explicitly set w for group and others,
and set x for group and others for files that are x for user (ie executables and directories -- that's
what X does).