### PR TITLE
WindowServer: Make perror() strings slightly more detailed.

### DIFF
--- a/Services/WindowServer/main.cpp
+++ b/Services/WindowServer/main.cpp
@@ -45,22 +45,22 @@ int main(int, char**)
     }
 
     if (unveil("/res", "r") < 0) {
-        perror("unveil");
+        perror("unveil /res");
         return 1;
     }
 
     if (unveil("/tmp", "cw") < 0) {
-        perror("unveil");
+        perror("unveil /tmp cw");
         return 1;
     }
 
     if (unveil("/etc/WindowServer/WindowServer.ini", "rwc") < 0) {
-        perror("unveil");
+        perror("unveil /etc/WindowServer/WindowServer.ini");
         return 1;
     }
 
     if (unveil("/dev", "rw") < 0) {
-        perror("unveil");
+        perror("unveil /dev rw");
         return 1;
     }
 
@@ -97,12 +97,12 @@ int main(int, char**)
     auto mm = WindowServer::MenuManager::construct();
 
     if (unveil("/tmp", "") < 0) {
-        perror("unveil");
+        perror("unveil /tmp");
         return 1;
     }
 
     if (unveil("/dev", "") < 0) {
-        perror("unveil");
+        perror("unveil /dev");
         return 1;
     }
 


### PR DESCRIPTION
My system has an umask of 027. This means that every file that's created gets the w bit erased for group members, and all of rwx erased for others. It's likely some security measure.

This has the effect that the files in Base/ don't have rx set for others, but those bits are needed when serenity runs so that e.g. the window user can read /etc/WindowServer/WindowServer.ini.
Instead of just copying the on-disk permissions into the image, explicitly set w for group and others,
and set x for group and others for files that are x for user (ie executables and directories -- that's
what X does).

(I added this locally why debugging my umask issue and it seems like it's maybe generally
useful.)