### PR TITLE
run.sh: Pass -drive instead of -hda to qemu.

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -22,7 +22,7 @@ $SERENITY_EXTRA_QEMU_ARGS
 -d cpu_reset,guest_errors
 -smp 2
 -device VGA,vgamem_mb=64
--hda _disk_image
+-drive file=_disk_image,format=raw,index=0,media=disk
 -device ich9-ahci
 -debugcon stdio
 -soundhw pcspk


### PR DESCRIPTION
run.sh currently makes qemu print this as the very first output:

WARNING: Image format was not specified for '_disk_image' and probing guessed raw.
         Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the restrictions.

This is scary for people who don't know that this is normal, and
write operations to block 0 being restricted could be confusing
for some operations happening from within serenity too at some point.

So specify the 'raw' format explicitly, like the warning suggests.
Requires using -drive instead of -hda.

From `man qemu-system`:

    Instead of -hda, -hdb, -hdc, -hdd, you can use:
        qemu-system-x86_64 -drive file=file,index=0,media=disk

So use that, and also pass format=raw.