### PR TITLE
Docs: Update FreeBSD instructions

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -63,7 +63,6 @@ pkg_add bash gmp gcc git flock gmake sudo
 #### FreeBSD prerequisites
 ```
 $ pkg add coreutils gmake bash sudo git
-$ ln -s /usr/local/bin/ginstall /usr/local/bin/install
 ```
 
 ### Build


### PR DESCRIPTION
ginstall should not be symlinked to install globally. The actual issue of having GNU coreutils prefixed with `g` and not being picked up by CMake can be fixed on CMake level as noted here: https://github.com/SerenityOS/serenity/issues/2234#issuecomment-629754194