### PR TITLE
Kernel: SMP: Initial changes to make kernel more processor-aware

### DIFF
--- a/AK/LogStream.cpp
+++ b/AK/LogStream.cpp
@@ -125,8 +125,8 @@ DebugLogStream dbg()
         stream << "\033[33;1m" << process_name_buffer << '(' << getpid() << ")\033[0m: ";
 #endif
 #if defined(__serenity__) && defined(KERNEL)
-    if (Kernel::Thread::current)
-        stream << "\033[34;1m[" << *Kernel::Thread::current << "]\033[0m: ";
+    if (Kernel::Processor::is_initialized() && Kernel::Thread::current())
+        stream << "\033[34;1m[" << *Kernel::Thread::current() << "]\033[0m: ";
     else
         stream << "\033[36;1m[Kernel]\033[0m: ";
 #endif
@@ -137,8 +137,8 @@ DebugLogStream dbg()
 KernelLogStream klog()
 {
     KernelLogStream stream;
-    if (Kernel::Thread::current)
-        stream << "\033[34;1m[" << *Kernel::Thread::current << "]\033[0m: ";
+    if (Kernel::Processor::is_initialized() && Kernel::Thread::current())
+        stream << "\033[34;1m[" << *Kernel::Thread::current() << "]\033[0m: ";
     else
         stream << "\033[36;1m[Kernel]\033[0m: ";
     return stream;

--- a/Applications/SystemMonitor/ProcessModel.h
+++ b/Applications/SystemMonitor/ProcessModel.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/NonnullOwnPtrVector.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibGUI/Model.h>
@@ -49,6 +50,7 @@ public:
         Icon = 0,
         Name,
         CPU,
+        Processor,
         State,
         Priority,
         EffectivePriority,
@@ -87,7 +89,21 @@ public:
     virtual GUI::Variant data(const GUI::ModelIndex&, Role = Role::Display) const override;
     virtual void update() override;
 
-    Function<void(float)> on_new_cpu_data_point;
+    struct CpuInfo
+    {
+        u32 id;
+        float total_cpu_percent{0.0};
+        HashMap<String, String> values;
+        
+        CpuInfo(u32 id):
+            id(id)
+        {
+        }
+    };
+
+    Function<void(const NonnullOwnPtrVector<CpuInfo>&)> on_cpu_info_change;
+
+    const NonnullOwnPtrVector<CpuInfo>& cpus() const { return m_cpus; }
 
 private:
     ProcessModel();
@@ -101,6 +117,7 @@ private:
         String user;
         String pledge;
         String veil;
+        u32 cpu;
         u32 priority;
         u32 effective_priority;
         size_t amount_virtual;
@@ -130,6 +147,7 @@ private:
 
     HashMap<uid_t, String> m_usernames;
     HashMap<PidAndTid, NonnullOwnPtr<Thread>> m_threads;
+    NonnullOwnPtrVector<CpuInfo> m_cpus;
     Vector<PidAndTid> m_pids;
     RefPtr<Gfx::Bitmap> m_generic_process_icon;
     RefPtr<Gfx::Bitmap> m_high_priority_icon;

--- a/Kernel/Arch/i386/Boot/boot.S
+++ b/Kernel/Arch/i386/Boot/boot.S
@@ -252,15 +252,6 @@ apic_ap_start:
     mov %cs, %ax
     mov %ax, %ds
 
-    /* Generate a new processor id. This is not the APIC id. We just
-       need a way to find ourselves a stack without stomping on other
-       APs that may be doing this concurrently. */
-    xor %ax, %ax
-    mov %ax, %bp
-    inc %ax
-    lock; xaddw %ax, %ds:(ap_cpu_id - apic_ap_start)(%bp) /* avoid relocation entries */
-    mov %ax, %bx
-
     xor %ax, %ax
     mov %ax, %sp
 
@@ -281,14 +272,18 @@ apic_ap_start32:
     mov %ax, %es
     mov %ax, %fs
     mov %ax, %gs
-    
+
     movl $0x8000, %ebp
-    
+
+    /* generate a unique ap cpu id (0 means 1st ap, not bsp!) */
+    xorl %eax, %eax
+    incl %eax
+    lock; xaddl %eax, (ap_cpu_id - apic_ap_start)(%ebp) /* avoid relocation entries */
+    movl %eax, %esi
+
     /* find our allocated stack based on the generated id */
-    andl 0x0000FFFF, %ebx
-    movl %ebx, %esi
-    movl (ap_cpu_init_stacks - apic_ap_start)(%ebp, %ebx, 4), %esp
-    
+    movl (ap_cpu_init_stacks - apic_ap_start)(%ebp, %eax, 4), %esp
+
     /* check if we support NX and enable it if we do */
     movl $0x80000001, %eax
     cpuid
@@ -319,8 +314,8 @@ apic_ap_start32:
     lgdt (ap_cpu_gdtr_initial2 - apic_ap_start + 0xc0008000)
 
     /* jump above 3GB into our identity mapped area now */
-    ljmp $8, $(1f - apic_ap_start + 0xc0008000)
-1:
+    ljmp $8, $(apic_ap_start32_2 - apic_ap_start + 0xc0008000)
+apic_ap_start32_2:
     /* flush the TLB */
     movl %cr3, %eax
     movl %eax, %cr3
@@ -338,13 +333,20 @@ apic_ap_start32:
     movl %eax, %cr0
     movl (ap_cpu_init_cr4 - apic_ap_start)(%ebp), %eax
     movl %eax, %cr4
-
+    
+    /* push the Processor pointer this CPU is going to use */
+    movl (ap_cpu_init_processor_info_array - apic_ap_start)(%ebp), %eax
+    addl $0xc0000000, %eax
+    movl 0(%eax, %esi, 4), %eax
+    push %eax
+    
+    /* push the cpu id, 0 representing the bsp and call into c++ */
+    incl %esi
+    push %esi
+    
     xor %ebp, %ebp
     cld
     
-    /* push the arbitrary cpu id, 0 representing the bsp and call into c++ */
-    inc %esi
-    push %esi
     /* We are in identity mapped P0x8000 and the BSP will unload this code
        once all APs are initialized, so call init_ap but return to our
        infinite loop */
@@ -356,7 +358,7 @@ apic_ap_start32:
 apic_ap_start_size:
     .2byte end_apic_ap_start - apic_ap_start
 ap_cpu_id:
-    .2byte 0x0
+    .4byte 0x0
 ap_cpu_gdt:
     /* null */
     .8byte 0x0
@@ -387,6 +389,9 @@ ap_cpu_init_cr3:
     .4byte 0x0 /* will be set at runtime */
 .global ap_cpu_init_cr4
 ap_cpu_init_cr4:
+    .4byte 0x0 /* will be set at runtime */
+.global ap_cpu_init_processor_info_array
+ap_cpu_init_processor_info_array:
     .4byte 0x0 /* will be set at runtime */
 .global ap_cpu_init_stacks
 ap_cpu_init_stacks:

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -215,7 +215,7 @@ void page_fault_handler(TrapFrame* trap)
 
 #ifdef PAGE_FAULT_DEBUG
     u32 fault_page_directory = read_cr3();
-    dbg() << "Ring " << (regs.cs & 3)
+    dbg() << "CPU #" << (Processor::is_initialized() ? Processor::current().id() : 0) << " ring " << (regs.cs & 3)
           << " " << (regs.exception_code & 1 ? "PV" : "NP")
           << " page fault in PD=" << String::format("%x", fault_page_directory) << ", "
           << (regs.exception_code & 8 ? "reserved-bit " : "")
@@ -831,6 +831,7 @@ void Processor::initialize(u32 cpu)
 
     m_idle_thread = nullptr;
     m_current_thread = nullptr;
+    m_mm_data = nullptr;
 
     gdt_init();
     if (cpu == 0)
@@ -859,7 +860,7 @@ void Processor::initialize(u32 cpu)
         (*s_processors)[cpu] = this;
     }
 
-    klog() << "CPU #" << cpu << " using Processor at " << VirtualAddress(FlatPtr(this));
+    klog() << "CPU[" << cpu << "]: initialized Processor at " << VirtualAddress(FlatPtr(this));
 }
 
 void Processor::write_raw_gdt_entry(u16 selector, u32 low, u32 high)

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -904,12 +904,15 @@ extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
     set_fs(to_tss.fs);
     set_gs(to_tss.gs);
 
-    auto& tls_descriptor = Processor::current().get_gdt_entry(GDT_SELECTOR_TLS);
+    auto& processor = Processor::current();
+    auto& tls_descriptor = processor.get_gdt_entry(GDT_SELECTOR_TLS);
     tls_descriptor.set_base(to_thread->thread_specific_data().as_ptr());
     tls_descriptor.set_limit(to_thread->thread_specific_region_size());
 
     if (from_tss.cr3 != to_tss.cr3)
         write_cr3(to_tss.cr3);
+
+    to_thread->set_cpu(processor.id());
 
     asm volatile("fxrstor %0"
         ::"m"(to_thread->fpu_state()));

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -38,42 +38,28 @@
 #include <Kernel/Interrupts/UnhandledInterruptHandler.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Process.h>
+#include <Kernel/SpinLock.h>
+#include <Kernel/Thread.h>
 #include <Kernel/VM/MemoryManager.h>
+#include <Kernel/VM/PageDirectory.h>
 #include <Kernel/IO.h>
 #include <LibC/mallocdefs.h>
 
 //#define PAGE_FAULT_DEBUG
+//#define CONTEXT_SWITCH_DEBUG
 
 namespace Kernel {
 
 static DescriptorTablePointer s_idtr;
-static DescriptorTablePointer s_gdtr;
 static Descriptor s_idt[256];
-static Descriptor s_gdt[256];
 
 static GenericInterruptHandler* s_interrupt_handler[GENERIC_INTERRUPT_HANDLERS_COUNT];
 
-static Vector<u16>* s_gdt_freelist;
-
-static u16 s_gdt_length;
-
-u16 gdt_alloc_entry()
-{
-    ASSERT(s_gdt_freelist);
-    ASSERT(!s_gdt_freelist->is_empty());
-    return s_gdt_freelist->take_last();
-}
-
-void gdt_free_entry(u16 entry)
-{
-    s_gdt_freelist->append(entry);
-}
-
-extern "C" void handle_interrupt(RegisterState);
+extern "C" void handle_interrupt(TrapFrame*);
 
 #define EH_ENTRY(ec, title)                         \
     extern "C" void title##_asm_entry();            \
-    extern "C" void title##_handler(RegisterState); \
+    extern "C" void title##_handler(TrapFrame*); \
     asm(                                            \
         ".globl " #title "_asm_entry\n"             \
         "" #title "_asm_entry: \n"                  \
@@ -83,22 +69,21 @@ extern "C" void handle_interrupt(RegisterState);
         "    pushl %fs\n"                           \
         "    pushl %gs\n"                           \
         "    pushl %ss\n"                           \
-        "    mov $0x10, %ax\n"                      \
+        "    mov $" __STRINGIFY(GDT_SELECTOR_DATA0) ", %ax\n" \
         "    mov %ax, %ds\n"                        \
         "    mov %ax, %es\n"                        \
+        "    mov $" __STRINGIFY(GDT_SELECTOR_PROC) ", %ax\n" \
+        "    mov %ax, %fs\n"                        \
+        "    pushl %esp \n" /* set TrapFrame::regs */ \
+        "    subl $" __STRINGIFY(TRAP_FRAME_SIZE - 4) ", %esp \n" \
+        "    pushl %esp \n"                         \
         "    cld\n"                                 \
+        "    call enter_trap_no_irq \n"             \
         "    call " #title "_handler\n"             \
-        "    add $0x4, %esp \n"                     \
-        "    popl %gs\n"                            \
-        "    popl %fs\n"                            \
-        "    popl %es\n"                            \
-        "    popl %ds\n"                            \
-        "    popa\n"                                \
-        "    add $0x4, %esp\n"                      \
-        "    iret\n");
+        "    jmp common_trap_exit \n");
 
 #define EH_ENTRY_NO_CODE(ec, title)                 \
-    extern "C" void title##_handler(RegisterState); \
+    extern "C" void title##_handler(TrapFrame*); \
     extern "C" void title##_asm_entry();            \
     asm(                                            \
         ".globl " #title "_asm_entry\n"             \
@@ -110,19 +95,18 @@ extern "C" void handle_interrupt(RegisterState);
         "    pushl %fs\n"                           \
         "    pushl %gs\n"                           \
         "    pushl %ss\n"                           \
-        "    mov $0x10, %ax\n"                      \
+        "    mov $" __STRINGIFY(GDT_SELECTOR_DATA0) ", %ax\n" \
         "    mov %ax, %ds\n"                        \
         "    mov %ax, %es\n"                        \
+        "    mov $" __STRINGIFY(GDT_SELECTOR_PROC) ", %ax\n" \
+        "    mov %ax, %fs\n"                        \
+        "    pushl %esp \n" /* set TrapFrame::regs */ \
+        "    subl $" __STRINGIFY(TRAP_FRAME_SIZE - 4) ", %esp \n" \
+        "    pushl %esp \n"                         \
         "    cld\n"                                 \
+        "    call enter_trap_no_irq \n"             \
         "    call " #title "_handler\n"             \
-        "    add $0x4, %esp\n"                      \
-        "    popl %gs\n"                            \
-        "    popl %fs\n"                            \
-        "    popl %es\n"                            \
-        "    popl %ds\n"                            \
-        "    popa\n"                                \
-        "    add $0x4, %esp\n"                      \
-        "    iret\n");
+        "    jmp common_trap_exit \n");
 
 static void dump(const RegisterState& regs)
 {
@@ -172,7 +156,7 @@ void handle_crash(RegisterState& regs, const char* description, int signal, bool
     // make sure we switch back to the right page tables.
     MM.enter_process_paging_scope(*Process::current);
 
-    klog() << "CRASH: " << description << ". Ring " << (Process::current->is_ring0() ? 0 : 3) << ".";
+    klog() << "CRASH: CPU #" << Processor::current().id() << " " << description << ". Ring " << (Process::current->is_ring0() ? 0 : 3) << ".";
     dump(regs);
 
     if (Process::current->is_ring0()) {
@@ -186,29 +170,29 @@ void handle_crash(RegisterState& regs, const char* description, int signal, bool
 }
 
 EH_ENTRY_NO_CODE(6, illegal_instruction);
-void illegal_instruction_handler(RegisterState regs)
+void illegal_instruction_handler(TrapFrame* trap)
 {
     clac();
-    handle_crash(regs, "Illegal instruction", SIGILL);
+    handle_crash(*trap->regs, "Illegal instruction", SIGILL);
 }
 
 EH_ENTRY_NO_CODE(0, divide_error);
-void divide_error_handler(RegisterState regs)
+void divide_error_handler(TrapFrame* trap)
 {
     clac();
-    handle_crash(regs, "Divide error", SIGFPE);
+    handle_crash(*trap->regs, "Divide error", SIGFPE);
 }
 
 EH_ENTRY(13, general_protection_fault);
-void general_protection_fault_handler(RegisterState regs)
+void general_protection_fault_handler(TrapFrame* trap)
 {
     clac();
-    handle_crash(regs, "General protection fault", SIGSEGV);
+    handle_crash(*trap->regs, "General protection fault", SIGSEGV);
 }
 
 // 7: FPU not available exception
 EH_ENTRY_NO_CODE(7, fpu_exception);
-void fpu_exception_handler(RegisterState)
+void fpu_exception_handler(TrapFrame*)
 {
     // Just clear the TS flag. We've already restored the FPU state eagerly.
     // FIXME: It would be nice if we didn't have to do this at all.
@@ -217,10 +201,11 @@ void fpu_exception_handler(RegisterState)
 
 // 14: Page Fault
 EH_ENTRY(14, page_fault);
-void page_fault_handler(RegisterState regs)
+void page_fault_handler(TrapFrame* trap)
 {
     clac();
 
+    auto& regs = *trap->regs;
     u32 fault_address;
     asm("movl %%cr2, %%eax"
         : "=a"(fault_address));
@@ -294,9 +279,10 @@ void page_fault_handler(RegisterState regs)
 }
 
 EH_ENTRY_NO_CODE(1, debug);
-void debug_handler(RegisterState regs)
+void debug_handler(TrapFrame* trap)
 {
     clac();
+    auto& regs = *trap->regs;
     if (!Process::current || (regs.cs & 3) == 0) {
         klog() << "Debug Exception in Ring0";
         hang();
@@ -314,9 +300,10 @@ void debug_handler(RegisterState regs)
 }
 
 EH_ENTRY_NO_CODE(3, breakpoint);
-void breakpoint_handler(RegisterState regs)
+void breakpoint_handler(TrapFrame* trap)
 {
     clac();
+    auto& regs = *trap->regs;
     if (!Process::current || (regs.cs & 3) == 0) {
         klog() << "Breakpoint Trap in Ring0";
         hang();
@@ -356,78 +343,9 @@ EH(12, "Stack exception")
 EH(15, "Unknown error")
 EH(16, "Coprocessor error")
 
-static void write_raw_gdt_entry(u16 selector, u32 low, u32 high)
-{
-    u16 i = (selector & 0xfffc) >> 3;
-    s_gdt[i].low = low;
-    s_gdt[i].high = high;
-
-    if (i > s_gdt_length)
-        s_gdtr.limit = (s_gdt_length + 1) * 8 - 1;
-}
-
-void write_gdt_entry(u16 selector, Descriptor& descriptor)
-{
-    write_raw_gdt_entry(selector, descriptor.low, descriptor.high);
-}
-
-Descriptor& get_gdt_entry(u16 selector)
-{
-    u16 i = (selector & 0xfffc) >> 3;
-    return *(Descriptor*)(&s_gdt[i]);
-}
-
-void flush_gdt()
-{
-    s_gdtr.address = s_gdt;
-    s_gdtr.limit = (s_gdt_length * 8) - 1;
-    asm("lgdt %0" ::"m"(s_gdtr)
-        : "memory");
-}
-
-const DescriptorTablePointer& get_gdtr()
-{
-    return s_gdtr;
-}
-
 const DescriptorTablePointer& get_idtr()
 {
     return s_idtr;
-}
-
-void gdt_init()
-{
-    s_gdt_length = 5;
-
-    s_gdt_freelist = new Vector<u16>();
-    s_gdt_freelist->ensure_capacity(256);
-    for (size_t i = s_gdt_length; i < 256; ++i)
-        s_gdt_freelist->append(i * 8);
-
-    s_gdt_length = 256;
-    s_gdtr.address = s_gdt;
-    s_gdtr.limit = (s_gdt_length * 8) - 1;
-
-    write_raw_gdt_entry(0x0000, 0x00000000, 0x00000000);
-    write_raw_gdt_entry(0x0008, 0x0000ffff, 0x00cf9a00);
-    write_raw_gdt_entry(0x0010, 0x0000ffff, 0x00cf9200);
-    write_raw_gdt_entry(0x0018, 0x0000ffff, 0x00cffa00);
-    write_raw_gdt_entry(0x0020, 0x0000ffff, 0x00cff200);
-
-    flush_gdt();
-
-    asm volatile(
-        "mov %%ax, %%ds\n"
-        "mov %%ax, %%es\n"
-        "mov %%ax, %%fs\n"
-        "mov %%ax, %%gs\n"
-        "mov %%ax, %%ss\n" ::"a"(0x10)
-        : "memory");
-
-    // Make sure CS points to the kernel code descriptor.
-    asm volatile(
-        "ljmpl $0x8, $sanity\n"
-        "sanity:\n");
 }
 
 static void unimp_trap()
@@ -514,7 +432,7 @@ void flush_idt()
     asm("lidt %0" ::"m"(s_idtr));
 }
 
-void idt_init()
+static void idt_init()
 {
     s_idtr.address = s_idt;
     s_idtr.limit = 0x100 * 8 - 1;
@@ -683,19 +601,30 @@ void load_task_register(u16 selector)
     asm("ltr %0" ::"r"(selector));
 }
 
-u32 g_in_irq;
-
-void handle_interrupt(RegisterState regs)
+void handle_interrupt(TrapFrame* trap)
 {
     clac();
-    ++g_in_irq;
+    auto& regs = *trap->regs;
     ASSERT(regs.isr_number >= IRQ_VECTOR_BASE && regs.isr_number <= (IRQ_VECTOR_BASE + GENERIC_INTERRUPT_HANDLERS_COUNT));
     u8 irq = (u8)(regs.isr_number - 0x50);
     ASSERT(s_interrupt_handler[irq]);
     s_interrupt_handler[irq]->handle_interrupt(regs);
-    s_interrupt_handler[irq]->increment_invoking_counter();
-    --g_in_irq;
     s_interrupt_handler[irq]->eoi();
+}
+
+void enter_trap_no_irq(TrapFrame* trap)
+{
+    Processor::current().enter_trap(*trap, false);
+}
+
+void enter_trap(TrapFrame* trap)
+{
+    Processor::current().enter_trap(*trap, true);
+}
+
+void exit_trap(TrapFrame* trap)
+{
+    return Processor::current().exit_trap(*trap);
 }
 
 void sse_init()
@@ -740,9 +669,10 @@ void cpu_detect()
     g_cpu_supports_rdseed = (extended_features.ebx() & (1 << 18));
 }
 
-void cpu_setup()
+void cpu_setup(u32 cpu)
 {
-    cpu_detect();
+    if (cpu == 0)
+        cpu_detect();
 
     if (g_cpu_supports_sse) {
         sse_init();
@@ -861,6 +791,424 @@ u32 read_dr6()
     asm("movl %%dr6, %%eax"
         : "=a"(dr6));
     return dr6;
+}
+
+FPUState Processor::s_clean_fpu_state;
+
+void Processor::initialize(u32 cpu)
+{
+    m_self = this;
+
+    m_cpu = cpu;
+    m_in_irq = 0;
+
+    gdt_init();
+    if (cpu == 0)
+        idt_init();
+    else
+        flush_idt();
+
+    ASSERT(&current() == this); // sanity check
+
+    if (cpu == 0) {
+        ASSERT((FlatPtr(&s_clean_fpu_state) & 0xF) == 0);
+        asm volatile("fninit");
+        asm volatile("fxsave %0"
+            : "=m"(s_clean_fpu_state));
+    }
+
+    klog() << "CPU #" << cpu << " using Processor at " << VirtualAddress(FlatPtr(this));
+}
+
+void Processor::write_raw_gdt_entry(u16 selector, u32 low, u32 high)
+{
+    u16 i = (selector & 0xfffc) >> 3;
+    u32 prev_gdt_length = m_gdt_length;
+    
+    if (i > m_gdt_length) {
+        m_gdt_length = i + 1;
+        ASSERT(m_gdt_length <= sizeof(m_gdt) / sizeof(m_gdt[0]));
+        m_gdtr.limit = (m_gdt_length + 1) * 8 - 1;
+    }
+    m_gdt[i].low = low;
+    m_gdt[i].high = high;
+
+    // clear selectors we may have skipped
+    while (i < prev_gdt_length) {
+        m_gdt[i].low = 0;
+        m_gdt[i].high = 0;
+        i++;
+    }
+}
+
+void Processor::write_gdt_entry(u16 selector, Descriptor& descriptor)
+{
+    write_raw_gdt_entry(selector, descriptor.low, descriptor.high);
+}
+
+Descriptor& Processor::get_gdt_entry(u16 selector)
+{
+    u16 i = (selector & 0xfffc) >> 3;
+    return *(Descriptor*)(&m_gdt[i]);
+}
+
+void Processor::flush_gdt()
+{
+    m_gdtr.address = m_gdt;
+    m_gdtr.limit = (m_gdt_length * 8) - 1;
+    asm volatile("lgdt %0" ::"m"(m_gdtr)
+        : "memory");
+}
+
+const DescriptorTablePointer& Processor::get_gdtr()
+{
+    return m_gdtr;
+}
+
+extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
+{
+    ASSERT(from_thread == to_thread || from_thread->state() != Thread::Running);
+    ASSERT(to_thread->state() == Thread::Running);
+    auto& from_tss = from_thread->tss();
+    auto& to_tss = to_thread->tss();
+    asm volatile("fxsave %0"
+        : "=m"(from_thread->fpu_state()));
+
+    from_tss.fs = get_fs();
+    from_tss.gs = get_gs();
+    set_fs(to_tss.fs);
+    set_gs(to_tss.gs);
+
+    auto& tls_descriptor = Processor::current().get_gdt_entry(GDT_SELECTOR_TLS);
+    tls_descriptor.set_base(to_thread->thread_specific_data().as_ptr());
+    tls_descriptor.set_limit(to_thread->thread_specific_region_size());
+
+    if (from_tss.cr3 != to_tss.cr3)
+        write_cr3(to_tss.cr3);
+
+    asm volatile("fxrstor %0"
+        ::"m"(to_thread->fpu_state()));
+
+    // TODO: debug registers
+    // TODO: ioperm?
+}
+
+#define ENTER_THREAD_CONTEXT_ARGS_SIZE (2 * 4) //  to_thread, from_thread
+
+void Processor::switch_context(Thread* from_thread, Thread* to_thread)
+{
+    ASSERT(!in_irq());
+    ASSERT(is_kernel_mode());
+#ifdef CONTEXT_SWITCH_DEBUG
+    dbg() << "switch_context --> switching out of: " << *from_thread;
+#endif
+
+    // Switch to new thread context, passing from_thread and to_thread
+    // through to the new context using registers edx and eax
+    asm volatile(
+        // NOTE: changing how much we push to the stack affects
+        //       SWITCH_CONTEXT_TO_STACK_SIZE and thread_context_first_enter()!
+        "pushfl \n"
+        "pushl %%ebx \n"
+        "pushl %%esi \n"
+        "pushl %%edi \n"
+        "pushl %%ebp \n"
+        "movl %%esp, %[from_esp] \n"
+        "movl $1f, %[from_eip] \n"
+        "movl %[to_esp0], %%ebx \n"
+        "movl %%ebx, %[tss_esp0] \n"
+        "movl %[to_esp], %%esp \n"
+        "pushl %[to_thread] \n"
+        "pushl %[from_thread] \n"
+        "pushl %[to_eip] \n"
+        "cld \n"
+        "jmp enter_thread_context \n"
+        "1: \n"
+        "popl %%edx \n"
+        "popl %%eax \n"
+        "popl %%ebp \n"
+        "popl %%edi \n"
+        "popl %%esi \n"
+        "popl %%ebx \n"
+        "popfl \n"
+        : [from_esp] "=m" (from_thread->tss().esp),
+          [from_eip] "=m" (from_thread->tss().eip),
+          [tss_esp0] "=m" (m_tss.esp0),
+          "=d" (from_thread), // needed so that from_thread retains the correct value
+          "=a" (to_thread) // needed so that to_thread retains the correct value
+        : [to_esp] "g" (to_thread->tss().esp),
+          [to_esp0] "g" (to_thread->tss().esp0),
+          [to_eip] "c" (to_thread->tss().eip),
+          [from_thread] "d" (from_thread),
+          [to_thread] "a" (to_thread)
+    );
+#ifdef CONTEXT_SWITCH_DEBUG
+    dbg() << "switch_context <-- from " << *from_thread << " to " << *to_thread;
+#endif
+}
+
+extern "C" void context_first_init(Thread* from_thread, Thread* to_thread, TrapFrame* trap)
+{
+    ASSERT(!are_interrupts_enabled());
+    ASSERT(is_kernel_mode());
+    (void)from_thread;
+    (void)to_thread;
+    (void)trap;
+#ifdef CONTEXT_SWITCH_DEBUG
+    dbg() << "switch_context <-- from " << *from_thread << " to " << *to_thread << " (context_first_init)";
+#endif
+}
+
+extern "C" void thread_context_first_enter(void);
+asm(
+// enter_thread_context returns to here first time a thread is executing
+".globl thread_context_first_enter \n"
+"thread_context_first_enter: \n"
+// switch_context will have pushed from_thread and to_thread to our new
+// stack prior to thread_context_first_enter() being called, and the
+// pointer to TrapFrame was the top of the stack before that
+"    movl 8(%esp), %ebx \n" // save pointer to TrapFrame
+"    cld \n"
+"    call context_first_init \n"
+"    addl $" __STRINGIFY(ENTER_THREAD_CONTEXT_ARGS_SIZE) ", %esp \n"
+"    movl %ebx, 0(%esp) \n" // push pointer to TrapFrame
+"    jmp common_trap_exit \n"
+);
+
+u32 Processor::init_context(Thread& thread)
+{
+    ASSERT(is_kernel_mode());
+    const u32 kernel_stack_top = thread.kernel_stack_top();
+    u32 stack_top = kernel_stack_top;
+
+    // TODO: handle NT?
+    ASSERT((cpu_flags() & 0x24000) == 0); // Assume !(NT | VM)
+
+    auto& tss = thread.tss();
+    bool return_to_user = (tss.cs & 3) != 0;
+    
+    // make room for an interrupt frame
+    if (!return_to_user) {
+        // userspace_esp and userspace_ss are not popped off by iret
+        // unless we're switching back to user mode
+        stack_top -= sizeof(RegisterState) - 2 * sizeof(u32);
+    } else {
+        stack_top -= sizeof(RegisterState);
+    }
+
+    // we want to end up 16-byte aligned, %esp + 4 should be aligned
+    stack_top -= sizeof(u32);
+    *reinterpret_cast<u32*>(kernel_stack_top - 4) = 0;
+
+    // set up the stack so that after returning from thread_context_first_enter()
+    // we will end up either in kernel mode or user mode, depending on how the thread is set up
+    // However, the first step is to always start in kernel mode with thread_context_first_enter
+    RegisterState& iretframe = *reinterpret_cast<RegisterState*>(stack_top);
+    iretframe.ss = tss.ss;
+    iretframe.gs = tss.gs;
+    iretframe.fs = tss.fs;
+    iretframe.es = tss.es;
+    iretframe.ds = tss.ds;
+    iretframe.edi = tss.edi;
+    iretframe.esi = tss.esi;
+    iretframe.ebp = tss.ebp;
+    iretframe.esp = 0;
+    iretframe.ebx = tss.ebx;
+    iretframe.edx = tss.edx;
+    iretframe.ecx = tss.ecx;
+    iretframe.eax = tss.eax;
+    iretframe.eflags = tss.eflags;
+    iretframe.eip = tss.eip;
+    iretframe.cs = tss.cs;
+    if (return_to_user) {
+        iretframe.userspace_esp = tss.esp;
+        iretframe.userspace_ss = tss.ss;
+    }
+
+    // make space for a trap frame
+    stack_top -= sizeof(TrapFrame);
+    TrapFrame& trap = *reinterpret_cast<TrapFrame*>(stack_top);
+    trap.regs = &iretframe;
+    trap.prev_irq_level = 0;
+
+    stack_top -= sizeof(u32); // pointer to TrapFrame
+    *reinterpret_cast<u32*>(stack_top) = stack_top + 4;
+
+#ifdef CONTEXT_SWITCH_DEBUG
+    dbg() << "init_context " << thread << " set up to execute at eip: " << VirtualAddress(tss.eip) << " esp: " << VirtualAddress(tss.esp) << " stack top: " << VirtualAddress(stack_top);
+#endif
+
+    // make switch_context() always first return to thread_context_first_enter()
+    // in kernel mode, so set up these values so that we end up popping iretframe
+    // off the stack right after the context switch completed, at which point
+    // control is transferred to what iretframe is pointing to.
+    tss.eip = FlatPtr(&thread_context_first_enter);
+    tss.esp0 = kernel_stack_top;
+    tss.esp = stack_top;
+    tss.cs = GDT_SELECTOR_CODE0;
+    tss.ds = GDT_SELECTOR_DATA0;
+    tss.es = GDT_SELECTOR_DATA0;
+    tss.gs = GDT_SELECTOR_DATA0;
+    tss.ss = GDT_SELECTOR_DATA0;
+    tss.fs = GDT_SELECTOR_PROC;
+    return stack_top;
+}
+
+
+extern "C" u32 do_init_context(Thread* thread)
+{
+    return Processor::init_context(*thread);
+}
+
+extern "C" void do_assume_context(Thread* thread);
+
+asm(
+".global do_assume_context \n"
+"do_assume_context: \n"
+"    movl 4(%esp), %ebx \n"
+// We're going to call Processor::init_context, so just make sure
+// we have enough stack space so we don't stomp over it
+"    subl $(" __STRINGIFY(4 + REGISTER_STATE_SIZE + TRAP_FRAME_SIZE + 4) "), %esp \n"
+"    pushl %ebx \n"
+"    cld \n"
+"    call do_init_context \n"
+"    addl $4, %esp \n"
+"    movl %eax, %esp \n" // move stack pointer to what Processor::init_context set up for us
+"    pushl %ebx \n" // push to_thread
+"    pushl %ebx \n" // push from_thread
+"    pushl $thread_context_first_enter \n" // should be same as tss.eip
+"    jmp enter_thread_context \n"
+);
+
+void Processor::assume_context(Thread& thread)
+{
+    do_assume_context(&thread);
+    ASSERT_NOT_REACHED();
+}
+
+void Processor::initialize_context_switching(Thread& initial_thread)
+{
+    ASSERT(initial_thread.process().is_ring0());
+    
+    auto& tss = initial_thread.tss();
+    m_tss = tss;
+    m_tss.esp0 = tss.esp0;
+    m_tss.ss0 = GDT_SELECTOR_DATA0;
+    // user mode needs to be able to switch to kernel mode:
+    m_tss.cs = m_tss.ds = m_tss.es = m_tss.gs = m_tss.ss = GDT_SELECTOR_CODE0 | 3;
+    m_tss.fs = GDT_SELECTOR_PROC | 3;
+    
+    
+    asm volatile(
+        "movl %[new_esp], %%esp \n" // swich to new stack
+        "pushl %[from_to_thread] \n" // to_thread
+        "pushl %[from_to_thread] \n" // from_thread
+        "pushl $" __STRINGIFY(GDT_SELECTOR_CODE0) " \n"
+        "pushl %[new_eip] \n" // save the entry eip to the stack
+        "movl %%esp, %%ebx \n"
+        "addl $20, %%ebx \n" // calculate pointer to TrapFrame
+        "pushl %%ebx \n"
+        "cld \n"
+        "call enter_trap_no_irq \n"
+        "addl $4, %%esp \n"
+        "lret \n"
+        :: [new_esp] "g" (tss.esp),
+           [new_eip] "a" (tss.eip),
+           [from_to_thread] "b" (&initial_thread)
+    );
+    
+    ASSERT_NOT_REACHED();
+}
+
+void Processor::enter_trap(TrapFrame& trap, bool raise_irq)
+{
+    InterruptDisabler disabler;
+    trap.prev_irq_level = m_in_irq;
+    if (raise_irq)
+        m_in_irq++;
+}
+
+void Processor::exit_trap(TrapFrame& trap)
+{
+    InterruptDisabler disabler;
+    ASSERT(m_in_irq >= trap.prev_irq_level);
+    m_in_irq = trap.prev_irq_level;
+    
+    if (m_invoke_scheduler_async && !m_in_irq) {
+        m_invoke_scheduler_async = false;
+        Scheduler::invoke_async();
+    }
+}
+
+void Processor::gdt_init()
+{
+    m_gdt_length = 0;
+    m_gdtr.address = nullptr;
+    m_gdtr.limit = 0;
+
+    write_raw_gdt_entry(0x0000, 0x00000000, 0x00000000);
+    write_raw_gdt_entry(GDT_SELECTOR_CODE0, 0x0000ffff, 0x00cf9a00); // code0
+    write_raw_gdt_entry(GDT_SELECTOR_DATA0, 0x0000ffff, 0x00cf9200); // data0
+    write_raw_gdt_entry(GDT_SELECTOR_CODE3, 0x0000ffff, 0x00cffa00); // code3
+    write_raw_gdt_entry(GDT_SELECTOR_DATA3, 0x0000ffff, 0x00cff200); // data3
+
+    Descriptor tls_descriptor;
+    tls_descriptor.low = tls_descriptor.high = 0;
+    tls_descriptor.dpl = 3;
+    tls_descriptor.segment_present = 1;
+    tls_descriptor.granularity = 0;
+    tls_descriptor.zero = 0;
+    tls_descriptor.operation_size = 1;
+    tls_descriptor.descriptor_type = 1;
+    tls_descriptor.type = 2;
+    write_gdt_entry(GDT_SELECTOR_TLS, tls_descriptor); // tls3
+
+    Descriptor fs_descriptor;
+    fs_descriptor.set_base(this);
+    fs_descriptor.set_limit(sizeof(Processor));
+    fs_descriptor.dpl = 0;
+    fs_descriptor.segment_present = 1;
+    fs_descriptor.granularity = 0;
+    fs_descriptor.zero = 0;
+    fs_descriptor.operation_size = 1;
+    fs_descriptor.descriptor_type = 1;
+    fs_descriptor.type = 2;
+    write_gdt_entry(GDT_SELECTOR_PROC, fs_descriptor); // fs0
+
+    Descriptor tss_descriptor;
+    tss_descriptor.set_base(&m_tss);
+    tss_descriptor.set_limit(sizeof(TSS32));
+    tss_descriptor.dpl = 0;
+    tss_descriptor.segment_present = 1;
+    tss_descriptor.granularity = 0;
+    tss_descriptor.zero = 0;
+    tss_descriptor.operation_size = 1;
+    tss_descriptor.descriptor_type = 0;
+    tss_descriptor.type = 9;
+    write_gdt_entry(GDT_SELECTOR_TSS, tss_descriptor); // tss
+
+    flush_gdt();
+    load_task_register(GDT_SELECTOR_TSS);
+
+    asm volatile(
+        "mov %%ax, %%ds\n"
+        "mov %%ax, %%es\n"
+        "mov %%ax, %%gs\n"
+        "mov %%ax, %%ss\n" ::"a"(GDT_SELECTOR_DATA0)
+        : "memory");
+    set_fs(GDT_SELECTOR_PROC);
+
+    // Make sure CS points to the kernel code descriptor.
+    asm volatile(
+        "ljmpl $" __STRINGIFY(GDT_SELECTOR_CODE0) ", $sanity\n"
+        "sanity:\n");
+}
+
+void Processor::set_thread_specific(u8* data, size_t len)
+{
+    auto& descriptor = get_gdt_entry(GDT_SELECTOR_TLS);
+    descriptor.set_base(data);
+    descriptor.set_limit(len);
 }
 
 }

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -611,6 +611,7 @@ struct TrapFrame;
 #define GDT_SELECTOR_TSS 0x38
 
 class ProcessorInfo;
+struct MemoryManagerData;
 
 class Processor {
     Processor* m_self; // must be first field (%fs offset 0x0)
@@ -626,6 +627,7 @@ class Processor {
     static FPUState s_clean_fpu_state;
 
     ProcessorInfo* m_info;
+    MemoryManagerData* m_mm_data;
     Thread* m_current_thread;
     Thread* m_idle_thread;
 
@@ -666,6 +668,16 @@ public:
     ALWAYS_INLINE static bool is_initialized()
     {
         return get_fs() == GDT_SELECTOR_PROC && read_fs_u32(0) != 0;
+    }
+
+    ALWAYS_INLINE void set_mm_data(MemoryManagerData& mm_data)
+    {
+        m_mm_data = &mm_data;
+    }
+
+    ALWAYS_INLINE MemoryManagerData& get_mm_data() const
+    {
+        return *m_mm_data;
     }
 
     ALWAYS_INLINE Thread* idle_thread() const

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -626,6 +626,8 @@ class Processor {
     static FPUState s_clean_fpu_state;
 
     ProcessorInfo* m_info;
+    Thread* m_current_thread;
+    Thread* m_idle_thread;
 
     bool m_invoke_scheduler_async;
 
@@ -659,6 +661,33 @@ public:
     ALWAYS_INLINE static Processor& current()
     {
         return *(Processor*)read_fs_u32(0);
+    }
+
+    ALWAYS_INLINE static bool is_initialized()
+    {
+        return get_fs() == GDT_SELECTOR_PROC && read_fs_u32(0) != 0;
+    }
+
+    ALWAYS_INLINE Thread* idle_thread() const
+    {
+        return m_idle_thread;
+    }
+
+    ALWAYS_INLINE void set_idle_thread(Thread& idle_thread)
+    {
+        m_idle_thread = &idle_thread;
+    }
+
+    ALWAYS_INLINE Thread* current_thread() const
+    {
+        // NOTE: NOT safe to call from another processor!
+        ASSERT(&Processor::current() == this);
+        return m_current_thread;
+    }
+
+    ALWAYS_INLINE void set_current_thread(Thread& current_thread)
+    {
+        m_current_thread = &current_thread;
     }
 
     ALWAYS_INLINE u32 id()

--- a/Kernel/Arch/i386/Interrupts.h
+++ b/Kernel/Arch/i386/Interrupts.h
@@ -27,6 +27,8 @@
 #pragma once
 
 #include <AK/Types.h>
+#include <AK/Assertions.h>
+#include <Kernel/Arch/i386/CPU.h>
 
 extern "C" void interrupt_common_asm_entry();
 
@@ -47,16 +49,35 @@ asm(
     "    pushl %fs\n"
     "    pushl %gs\n"
     "    pushl %ss\n"
-    "    mov $0x10, %ax\n"
+    "    mov $" __STRINGIFY(GDT_SELECTOR_DATA0) ", %ax\n"
     "    mov %ax, %ds\n"
     "    mov %ax, %es\n"
+    "    mov $" __STRINGIFY(GDT_SELECTOR_PROC) ", %ax\n"
+    "    mov %ax, %fs\n"
+    "    pushl %esp \n" // set TrapFrame::regs
+    "    subl $" __STRINGIFY(TRAP_FRAME_SIZE - 4) ", %esp \n"
+    "    movl %esp, %ebx \n" // save pointer to TrapFrame
+    "    pushl %ebx \n"
     "    cld\n"
+    "    call enter_trap \n"
+    "    movl %ebx, 0(%esp) \n" // push pointer to TrapFrame
     "    call handle_interrupt\n"
-    "    add $0x4, %esp\n" // "popl %ss"
+    "    movl %ebx, 0(%esp) \n" // push pointer to TrapFrame
+    ".globl common_trap_exit \n"
+    "common_trap_exit: \n"
+         // another thread may have handled this trap at this point, so don't
+         // make assumptions about the stack other than there's a TrapFrame
+         // and a pointer to it.
+    "    call exit_trap \n"
+    "    addl $" __STRINGIFY(TRAP_FRAME_SIZE + 4) ", %esp\n" // pop TrapFrame and pointer to it
+    ".globl interrupt_common_asm_exit \n"
+    "interrupt_common_asm_exit: \n"
+    "    addl $4, %esp\n" // pop %ss
     "    popl %gs\n"
     "    popl %fs\n"
     "    popl %es\n"
     "    popl %ds\n"
     "    popa\n"
-    "    add $0x4, %esp\n"
-    "    iret\n");
+    "    addl $0x4, %esp\n" // skip exception_code, isr_number
+    "    iret\n"
+);

--- a/Kernel/Arch/i386/ProcessorInfo.cpp
+++ b/Kernel/Arch/i386/ProcessorInfo.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Assertions.h>
+#include <AK/HashMap.h>
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
+#include <AK/Types.h>
+#include <Kernel/Arch/i386/CPU.h>
+#include <Kernel/Arch/i386/ProcessorInfo.h>
+
+namespace Kernel {
+
+ProcessorInfo::ProcessorInfo(Processor& processor):
+    m_processor(processor)
+{
+    {
+        CPUID cpuid(0);
+        StringBuilder builder;
+        auto emit_u32 = [&](u32 value) {
+            builder.appendf("%c%c%c%c",
+                value & 0xff,
+                (value >> 8) & 0xff,
+                (value >> 16) & 0xff,
+                (value >> 24) & 0xff);
+        };
+        emit_u32(cpuid.ebx());
+        emit_u32(cpuid.edx());
+        emit_u32(cpuid.ecx());
+        m_cpuid = builder.build();
+    }
+    {
+        CPUID cpuid(1);
+        m_stepping = cpuid.eax() & 0xf;
+        u32 model = (cpuid.eax() >> 4) & 0xf;
+        u32 family = (cpuid.eax() >> 8) & 0xf;
+        m_type = (cpuid.eax() >> 12) & 0x3;
+        u32 extended_model = (cpuid.eax() >> 16) & 0xf;
+        u32 extended_family = (cpuid.eax() >> 20) & 0xff;
+        if (family == 15) {
+            m_display_family = family + extended_family;
+            m_display_model = model + (extended_model << 4);
+        } else if (family == 6) {
+            m_display_family = family;
+            m_display_model = model + (extended_model << 4);
+        } else {
+            m_display_family = family;
+            m_display_model = model;
+        }
+    }
+    {
+        // FIXME: Check first that this is supported by calling CPUID with eax=0x80000000
+        //        and verifying that the returned eax>=0x80000004.
+        alignas(u32) char buffer[48];
+        u32* bufptr = reinterpret_cast<u32*>(buffer);
+        auto copy_brand_string_part_to_buffer = [&](u32 i) {
+            CPUID cpuid(0x80000002 + i);
+            *bufptr++ = cpuid.eax();
+            *bufptr++ = cpuid.ebx();
+            *bufptr++ = cpuid.ecx();
+            *bufptr++ = cpuid.edx();
+        };
+        copy_brand_string_part_to_buffer(0);
+        copy_brand_string_part_to_buffer(1);
+        copy_brand_string_part_to_buffer(2);
+        m_brandstr = buffer;
+    }
+}
+
+}
+
+#include <AK/String.h>

--- a/Kernel/Arch/i386/ProcessorInfo.h
+++ b/Kernel/Arch/i386/ProcessorInfo.h
@@ -26,55 +26,31 @@
 
 #pragma once
 
-#include <AK/NonnullRefPtr.h>
-#include <Kernel/Arch/i386/CPU.h>
-#include <Kernel/Assertions.h>
-#include <Kernel/Heap/SlabAllocator.h>
-#include <Kernel/PhysicalAddress.h>
+#include <AK/String.h>
 
 namespace Kernel {
 
-class PhysicalPage {
-    friend class MemoryManager;
-    friend class PageDirectory;
-    friend class VMObject;
+class Processor;
 
-    MAKE_SLAB_ALLOCATED(PhysicalPage)
+class ProcessorInfo
+{
+    Processor& m_processor;
+    String m_cpuid;
+    String m_brandstr;
+    u32 m_display_model;
+    u32 m_display_family;
+    u32 m_stepping;
+    u32 m_type;
+
 public:
-    PhysicalAddress paddr() const { return m_paddr; }
-
-    void ref()
-    {
-        ASSERT(m_ref_count);
-        ++m_ref_count;
-    }
-
-    void unref()
-    {
-        ASSERT(m_ref_count);
-        if (!--m_ref_count) {
-            if (m_may_return_to_freelist)
-                move(*this).return_to_freelist();
-            delete this;
-        }
-    }
-
-    static NonnullRefPtr<PhysicalPage> create(PhysicalAddress, bool supervisor, bool may_return_to_freelist = true);
-
-    u32 ref_count() const { return m_ref_count; }
-
-    bool is_shared_zero_page() const;
-
-private:
-    PhysicalPage(PhysicalAddress paddr, bool supervisor, bool may_return_to_freelist = true);
-    ~PhysicalPage() {}
-
-    void return_to_freelist() &&;
-
-    u32 m_ref_count { 1 };
-    bool m_may_return_to_freelist { true };
-    bool m_supervisor { false };
-    PhysicalAddress m_paddr;
+    ProcessorInfo(Processor& processor);
+    
+    const String& cpuid() const { return m_cpuid; }
+    const String& brandstr() const { return m_brandstr; }
+    u32 display_model() const { return m_display_model; }
+    u32 display_family() const { return m_display_family; }
+    u32 stepping() const { return m_stepping; }
+    u32 type() const { return m_type; }
 };
 
 }

--- a/Kernel/Assertions.h
+++ b/Kernel/Assertions.h
@@ -28,6 +28,9 @@
 
 #include <Kernel/Arch/i386/CPU.h>
 
+#define __STRINGIFY_HELPER(x) #x
+#define __STRINGIFY(x) __STRINGIFY_HELPER(x)
+
 #ifdef DEBUG
 [[noreturn]] void __assertion_failed(const char* msg, const char* file, unsigned line, const char* func);
 #    define ASSERT(expr) (static_cast<bool>(expr) ? (void)0 : __assertion_failed(#    expr, __FILE__, __LINE__, __PRETTY_FUNCTION__))

--- a/Kernel/Assertions.h
+++ b/Kernel/Assertions.h
@@ -26,8 +26,6 @@
 
 #pragma once
 
-#include <Kernel/Arch/i386/CPU.h>
-
 #define __STRINGIFY_HELPER(x) #x
 #define __STRINGIFY(x) __STRINGIFY_HELPER(x)
 
@@ -48,6 +46,7 @@
         if (!(x))         \
             CRASH();      \
     } while (0)
+
 #define ASSERT_INTERRUPTS_DISABLED() ASSERT(!(cpu_flags() & 0x200))
 #define ASSERT_INTERRUPTS_ENABLED() ASSERT(cpu_flags() & 0x200)
 #define TODO ASSERT_NOT_REACHED

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -4,6 +4,7 @@ set(KERNEL_SOURCES
     ACPI/MultiProcessorParser.cpp
     ACPI/Parser.cpp
     Arch/i386/CPU.cpp
+    Arch/i386/ProcessorInfo.cpp
     Arch/PC/BIOS.cpp
     CMOS.cpp
     CommandLine.cpp

--- a/Kernel/Console.cpp
+++ b/Kernel/Console.cpp
@@ -27,11 +27,13 @@
 #include <Kernel/Console.h>
 #include <Kernel/IO.h>
 #include <Kernel/kstdio.h>
+#include <Kernel/SpinLock.h>
 
 // Bytes output to 0xE9 end up on the Bochs console. It's very handy.
 #define CONSOLE_OUT_TO_E9
 
 static Console* s_the;
+static Kernel::SpinLock g_console_lock;
 
 Console& Console::the()
 {
@@ -77,6 +79,7 @@ ssize_t Console::write(Kernel::FileDescription&, size_t, const u8* data, ssize_t
 
 void Console::put_char(char ch)
 {
+    Kernel::ScopedSpinLock lock(g_console_lock);
 #ifdef CONSOLE_OUT_TO_E9
     //if (ch != 27)
     IO::out8(0xe9, ch);

--- a/Kernel/Devices/BXVGADevice.cpp
+++ b/Kernel/Devices/BXVGADevice.cpp
@@ -198,14 +198,14 @@ int BXVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
     switch (request) {
     case FB_IOCTL_GET_SIZE_IN_BYTES: {
         auto* out = (size_t*)arg;
-        if (!Process::current->validate_write_typed(out))
+        if (!Process::current()->validate_write_typed(out))
             return -EFAULT;
         *out = framebuffer_size_in_bytes();
         return 0;
     }
     case FB_IOCTL_GET_BUFFER: {
         auto* index = (int*)arg;
-        if (!Process::current->validate_write_typed(index))
+        if (!Process::current()->validate_write_typed(index))
             return -EFAULT;
         *index = m_y_offset == 0 ? 0 : 1;
         return 0;
@@ -218,7 +218,7 @@ int BXVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
     }
     case FB_IOCTL_GET_RESOLUTION: {
         auto* resolution = (FBResolution*)arg;
-        if (!Process::current->validate_write_typed(resolution))
+        if (!Process::current()->validate_write_typed(resolution))
             return -EFAULT;
         resolution->pitch = m_framebuffer_pitch;
         resolution->width = m_framebuffer_width;
@@ -227,7 +227,7 @@ int BXVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
     }
     case FB_IOCTL_SET_RESOLUTION: {
         auto* resolution = (FBResolution*)arg;
-        if (!Process::current->validate_read_typed(resolution) || !Process::current->validate_write_typed(resolution))
+        if (!Process::current()->validate_read_typed(resolution) || !Process::current()->validate_write_typed(resolution))
             return -EFAULT;
         if (resolution->width > MAX_RESOLUTION_WIDTH || resolution->height > MAX_RESOLUTION_HEIGHT)
             return -EINVAL;

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -36,6 +36,7 @@
 //   - CharacterDevice (sequential)
 #include <AK/Function.h>
 #include <AK/HashMap.h>
+#include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/UnixTypes.h>
 

--- a/Kernel/Devices/FullDevice.cpp
+++ b/Kernel/Devices/FullDevice.cpp
@@ -27,6 +27,7 @@
 #include "FullDevice.h"
 #include <AK/Memory.h>
 #include <AK/StdLibExtras.h>
+#include <Kernel/Arch/i386/CPU.h>
 #include <LibC/errno_numbers.h>
 
 namespace Kernel {

--- a/Kernel/Devices/MBVGADevice.cpp
+++ b/Kernel/Devices/MBVGADevice.cpp
@@ -79,21 +79,21 @@ int MBVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
     switch (request) {
     case FB_IOCTL_GET_SIZE_IN_BYTES: {
         auto* out = (size_t*)arg;
-        if (!Process::current->validate_write_typed(out))
+        if (!Process::current()->validate_write_typed(out))
             return -EFAULT;
         *out = framebuffer_size_in_bytes();
         return 0;
     }
     case FB_IOCTL_GET_BUFFER: {
         auto* index = (int*)arg;
-        if (!Process::current->validate_write_typed(index))
+        if (!Process::current()->validate_write_typed(index))
             return -EFAULT;
         *index = 0;
         return 0;
     }
     case FB_IOCTL_GET_RESOLUTION: {
         auto* resolution = (FBResolution*)arg;
-        if (!Process::current->validate_write_typed(resolution))
+        if (!Process::current()->validate_write_typed(resolution))
             return -EFAULT;
         resolution->pitch = m_framebuffer_pitch;
         resolution->width = m_framebuffer_width;
@@ -102,7 +102,7 @@ int MBVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
     }
     case FB_IOCTL_SET_RESOLUTION: {
         auto* resolution = (FBResolution*)arg;
-        if (!Process::current->validate_read_typed(resolution) || !Process::current->validate_write_typed(resolution))
+        if (!Process::current()->validate_read_typed(resolution) || !Process::current()->validate_write_typed(resolution))
             return -EFAULT;
         resolution->pitch = m_framebuffer_pitch;
         resolution->width = m_framebuffer_width;

--- a/Kernel/Devices/PATAChannel.cpp
+++ b/Kernel/Devices/PATAChannel.cpp
@@ -177,7 +177,7 @@ static void print_ide_status(u8 status)
 
 void PATAChannel::wait_for_irq()
 {
-    Thread::current->wait_on(m_irq_queue);
+    Thread::current()->wait_on(m_irq_queue);
     disable_irq();
 }
 

--- a/Kernel/Devices/PATAChannel.cpp
+++ b/Kernel/Devices/PATAChannel.cpp
@@ -294,15 +294,11 @@ bool PATAChannel::ata_read_sectors_with_dma(u32 lba, u16 count, u8* outbuf, bool
     while (m_io_base.offset(ATA_REG_STATUS).in<u8>() & ATA_SR_BSY)
         ;
 
-    u8 devsel = 0xe0;
-    if (slave_request)
-        devsel |= 0x10;
-
     m_control_base.offset(ATA_CTL_CONTROL).out<u8>(0);
-    m_io_base.offset(ATA_REG_HDDEVSEL).out<u8>(devsel | (static_cast<u8>(slave_request) << 4));
+    m_io_base.offset(ATA_REG_HDDEVSEL).out<u8>(0x40 | (static_cast<u8>(slave_request) << 4));
     io_delay();
 
-    m_io_base.offset(ATA_REG_FEATURES).out<u8>(0);
+    m_io_base.offset(ATA_REG_FEATURES).out<u16>(0);
 
     m_io_base.offset(ATA_REG_SECCOUNT0).out<u8>(0);
     m_io_base.offset(ATA_REG_LBA0).out<u8>(0);
@@ -365,15 +361,11 @@ bool PATAChannel::ata_write_sectors_with_dma(u32 lba, u16 count, const u8* inbuf
     while (m_io_base.offset(ATA_REG_STATUS).in<u8>() & ATA_SR_BSY)
         ;
 
-    u8 devsel = 0xe0;
-    if (slave_request)
-        devsel |= 0x10;
-
     m_control_base.offset(ATA_CTL_CONTROL).out<u8>(0);
-    m_io_base.offset(ATA_REG_HDDEVSEL).out<u8>(devsel | (static_cast<u8>(slave_request) << 4));
+    m_io_base.offset(ATA_REG_HDDEVSEL).out<u8>(0x40 | (static_cast<u8>(slave_request) << 4));
     io_delay();
 
-    m_io_base.offset(ATA_REG_FEATURES).out<u8>(0);
+    m_io_base.offset(ATA_REG_FEATURES).out<u16>(0);
 
     m_io_base.offset(ATA_REG_SECCOUNT0).out<u8>(0);
     m_io_base.offset(ATA_REG_LBA0).out<u8>(0);

--- a/Kernel/Devices/PATAChannel.cpp
+++ b/Kernel/Devices/PATAChannel.cpp
@@ -452,7 +452,8 @@ bool PATAChannel::ata_read_sectors(u32 lba, u16 count, u8* outbuf, bool slave_re
     m_io_base.offset(ATA_REG_COMMAND).out<u8>(ATA_CMD_READ_PIO);
 
     for (int i = 0; i < count; i++) {
-        prepare_for_irq();
+        if (i > 0)
+            prepare_for_irq();
         wait_for_irq();
         if (m_device_error)
             return false;

--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -222,7 +222,7 @@ void SB16::handle_irq(const RegisterState&)
 
 void SB16::wait_for_irq()
 {
-    Thread::current->wait_on(m_irq_queue);
+    Thread::current()->wait_on(m_irq_queue);
     disable_irq();
 }
 

--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -133,7 +133,7 @@ ssize_t FIFO::read(FileDescription&, size_t, u8* buffer, ssize_t size)
 ssize_t FIFO::write(FileDescription&, size_t, const u8* buffer, ssize_t size)
 {
     if (!m_readers) {
-        Thread::current->send_signal(SIGPIPE, Process::current);
+        Thread::current()->send_signal(SIGPIPE, Process::current());
         return -EPIPE;
     }
 #ifdef FIFO_DEBUG

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -48,7 +48,7 @@ ssize_t InodeFile::read(FileDescription& description, size_t offset, u8* buffer,
 {
     ssize_t nread = m_inode->read_bytes(offset, count, buffer, &description);
     if (nread > 0)
-        Thread::current->did_file_read(nread);
+        Thread::current()->did_file_read(nread);
     return nread;
 }
 
@@ -57,7 +57,7 @@ ssize_t InodeFile::write(FileDescription& description, size_t offset, const u8* 
     ssize_t nwritten = m_inode->write_bytes(offset, count, data, &description);
     if (nwritten > 0) {
         m_inode->set_mtime(kgettimeofday().tv_sec);
-        Thread::current->did_file_write(nwritten);
+        Thread::current()->did_file_write(nwritten);
     }
     return nwritten;
 }

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -864,6 +864,7 @@ Optional<KBuffer> procfs$all(InodeIdentifier)
             thread_object.add("times_scheduled", thread.times_scheduled());
             thread_object.add("ticks", thread.ticks());
             thread_object.add("state", thread.state_string());
+            thread_object.add("cpu", thread.cpu());
             thread_object.add("priority", thread.priority());
             thread_object.add("effective_priority", thread.effective_priority());
             thread_object.add("syscall_count", thread.syscall_count());

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -59,6 +59,7 @@ class Scheduler;
 class SharedBuffer;
 class Socket;
 template <typename BaseType> class SpinLock;
+class RecursiveSpinLock;
 template <typename BaseType, typename LockType> class ScopedSpinLock;
 class TCPSocket;
 class TTY;

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -58,6 +58,8 @@ class Region;
 class Scheduler;
 class SharedBuffer;
 class Socket;
+template <typename BaseType> class SpinLock;
+template <typename BaseType, typename LockType> class ScopedSpinLock;
 class TCPSocket;
 class TTY;
 class Thread;

--- a/Kernel/Interrupts/APIC.h
+++ b/Kernel/Interrupts/APIC.h
@@ -87,6 +87,7 @@ private:
 
     OwnPtr<Region> m_apic_base;
     NonnullOwnPtrVector<Region> m_apic_ap_stacks;
+    Vector<Processor> m_ap_processor_info;
     AK::Atomic<u32> m_apic_ap_count{0};
     
     static PhysicalAddress get_base();

--- a/Kernel/Lock.cpp
+++ b/Kernel/Lock.cpp
@@ -44,7 +44,6 @@ static bool modes_conflict(Lock::Mode mode1, Lock::Mode mode2)
 void Lock::lock(Mode mode)
 {
     ASSERT(mode != Mode::Unlocked);
-    ASSERT(!Scheduler::is_active());
     if (!are_interrupts_enabled()) {
         klog() << "Interrupts disabled when trying to take Lock{" << m_name << "}";
         dump_backtrace();

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -416,7 +416,7 @@ void E1000NetworkAdapter::send_raw(const u8* data, size_t length)
             sti();
             break;
         }
-        Thread::current->wait_on(m_wait_queue);
+        Thread::current()->wait_on(m_wait_queue);
     }
 #ifdef E1000_DEBUG
     klog() << "E1000: Sent packet, status is now " << String::format("%b", descriptor.status) << "!";

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -111,9 +111,9 @@ KResult IPv4Socket::bind(const sockaddr* user_address, socklen_t address_size)
         return KResult(-EINVAL);
 
     auto requested_local_port = ntohs(address.sin_port);
-    if (!Process::current->is_superuser()) {
+    if (!Process::current()->is_superuser()) {
         if (requested_local_port < 1024) {
-            dbg() << "UID " << Process::current->uid() << " attempted to bind " << class_name() << " to port " << requested_local_port;
+            dbg() << "UID " << Process::current()->uid() << " attempted to bind " << class_name() << " to port " << requested_local_port;
             return KResult(-EACCES);
         }
     }
@@ -232,7 +232,7 @@ ssize_t IPv4Socket::sendto(FileDescription&, const void* data, size_t data_lengt
 
     int nsent = protocol_send(data, data_length);
     if (nsent > 0)
-        Thread::current->did_ipv4_socket_write(nsent);
+        Thread::current()->did_ipv4_socket_write(nsent);
     return nsent;
 }
 
@@ -246,7 +246,7 @@ ssize_t IPv4Socket::receive_byte_buffered(FileDescription& description, void* bu
             return -EAGAIN;
 
         locker.unlock();
-        auto res = Thread::current->block<Thread::ReadBlocker>(description);
+        auto res = Thread::current()->block<Thread::ReadBlocker>(description);
         locker.lock();
 
         if (!m_can_read) {
@@ -261,7 +261,7 @@ ssize_t IPv4Socket::receive_byte_buffered(FileDescription& description, void* bu
     ASSERT(!m_receive_buffer.is_empty());
     int nreceived = m_receive_buffer.read((u8*)buffer, buffer_length);
     if (nreceived > 0)
-        Thread::current->did_ipv4_socket_read((size_t)nreceived);
+        Thread::current()->did_ipv4_socket_read((size_t)nreceived);
 
     m_can_read = !m_receive_buffer.is_empty();
     return nreceived;
@@ -296,7 +296,7 @@ ssize_t IPv4Socket::receive_packet_buffered(FileDescription& description, void* 
         }
 
         locker.unlock();
-        auto res = Thread::current->block<Thread::ReadBlocker>(description);
+        auto res = Thread::current()->block<Thread::ReadBlocker>(description);
         locker.lock();
 
         if (!m_can_read) {
@@ -354,7 +354,7 @@ ssize_t IPv4Socket::recvfrom(FileDescription& description, void* buffer, size_t 
         nreceived = receive_packet_buffered(description, buffer, buffer_length, flags, addr, addr_length);
 
     if (nreceived > 0)
-        Thread::current->did_ipv4_socket_read(nreceived);
+        Thread::current()->did_ipv4_socket_read(nreceived);
     return nreceived;
 }
 
@@ -468,7 +468,7 @@ int IPv4Socket::ioctl(FileDescription&, unsigned request, FlatPtr arg)
 
     auto ioctl_route = [request, arg]() {
         auto* route = (rtentry*)arg;
-        if (!Process::current->validate_read_typed(route))
+        if (!Process::current()->validate_read_typed(route))
             return -EFAULT;
 
         char namebuf[IFNAMSIZ + 1];
@@ -481,7 +481,7 @@ int IPv4Socket::ioctl(FileDescription&, unsigned request, FlatPtr arg)
 
         switch (request) {
         case SIOCADDRT:
-            if (!Process::current->is_superuser())
+            if (!Process::current()->is_superuser())
                 return -EPERM;
             if (route->rt_gateway.sa_family != AF_INET)
                 return -EAFNOSUPPORT;
@@ -500,7 +500,7 @@ int IPv4Socket::ioctl(FileDescription&, unsigned request, FlatPtr arg)
 
     auto ioctl_interface = [request, arg]() {
         auto* ifr = (ifreq*)arg;
-        if (!Process::current->validate_read_typed(ifr))
+        if (!Process::current()->validate_read_typed(ifr))
             return -EFAULT;
 
         char namebuf[IFNAMSIZ + 1];
@@ -513,7 +513,7 @@ int IPv4Socket::ioctl(FileDescription&, unsigned request, FlatPtr arg)
 
         switch (request) {
         case SIOCSIFADDR:
-            if (!Process::current->is_superuser())
+            if (!Process::current()->is_superuser())
                 return -EPERM;
             if (ifr->ifr_addr.sa_family != AF_INET)
                 return -EAFNOSUPPORT;
@@ -521,7 +521,7 @@ int IPv4Socket::ioctl(FileDescription&, unsigned request, FlatPtr arg)
             return 0;
 
         case SIOCSIFNETMASK:
-            if (!Process::current->is_superuser())
+            if (!Process::current()->is_superuser())
                 return -EPERM;
             if (ifr->ifr_addr.sa_family != AF_INET)
                 return -EAFNOSUPPORT;
@@ -529,14 +529,14 @@ int IPv4Socket::ioctl(FileDescription&, unsigned request, FlatPtr arg)
             return 0;
 
         case SIOCGIFADDR:
-            if (!Process::current->validate_write_typed(ifr))
+            if (!Process::current()->validate_write_typed(ifr))
                 return -EFAULT;
             ifr->ifr_addr.sa_family = AF_INET;
             ((sockaddr_in&)ifr->ifr_addr).sin_addr.s_addr = adapter->ipv4_address().to_u32();
             return 0;
 
         case SIOCGIFHWADDR:
-            if (!Process::current->validate_write_typed(ifr))
+            if (!Process::current()->validate_write_typed(ifr))
                 return -EFAULT;
             ifr->ifr_hwaddr.sa_family = AF_INET;
             {

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -63,8 +63,9 @@ LocalSocket::LocalSocket(int type)
     LOCKER(all_sockets().lock());
     all_sockets().resource().append(this);
 
-    m_prebind_uid = Process::current->uid();
-    m_prebind_gid = Process::current->gid();
+    auto current_process = Process::current();
+    m_prebind_uid = current_process->uid();
+    m_prebind_gid = current_process->gid();
     m_prebind_mode = 0666;
 
 #ifdef DEBUG_LOCAL_SOCKET
@@ -110,7 +111,7 @@ KResult LocalSocket::bind(const sockaddr* user_address, socklen_t address_size)
 
     mode_t mode = S_IFSOCK | (m_prebind_mode & 04777);
     UidAndGid owner { m_prebind_uid, m_prebind_gid };
-    auto result = VFS::the().open(path, O_CREAT | O_EXCL | O_NOFOLLOW_NOERROR, mode, Process::current->current_directory(), owner);
+    auto result = VFS::the().open(path, O_CREAT | O_EXCL | O_NOFOLLOW_NOERROR, mode, Process::current()->current_directory(), owner);
     if (result.is_error()) {
         if (result.error() == -EEXIST)
             return KResult(-EADDRINUSE);
@@ -148,7 +149,7 @@ KResult LocalSocket::connect(FileDescription& description, const sockaddr* addre
     dbg() << "LocalSocket{" << this << "} connect(" << safe_address << ")";
 #endif
 
-    auto description_or_error = VFS::the().open(safe_address, O_RDWR, 0, Process::current->current_directory());
+    auto description_or_error = VFS::the().open(safe_address, O_RDWR, 0, Process::current()->current_directory());
     if (description_or_error.is_error())
         return KResult(-ECONNREFUSED);
 
@@ -175,7 +176,7 @@ KResult LocalSocket::connect(FileDescription& description, const sockaddr* addre
         return KSuccess;
     }
 
-    if (Thread::current->block<Thread::ConnectBlocker>(description) != Thread::BlockResult::WokeNormally) {
+    if (Thread::current()->block<Thread::ConnectBlocker>(description) != Thread::BlockResult::WokeNormally) {
         m_connect_side_role = Role::None;
         return KResult(-EINTR);
     }
@@ -265,7 +266,7 @@ ssize_t LocalSocket::sendto(FileDescription& description, const void* data, size
         return -EPIPE;
     ssize_t nwritten = send_buffer_for(description).write((const u8*)data, data_size);
     if (nwritten > 0)
-        Thread::current->did_unix_socket_write(nwritten);
+        Thread::current()->did_unix_socket_write(nwritten);
     return nwritten;
 }
 
@@ -299,7 +300,7 @@ ssize_t LocalSocket::recvfrom(FileDescription& description, void* buffer, size_t
             return -EAGAIN;
         }
     } else if (!can_read(description, 0)) {
-        auto result = Thread::current->block<Thread::ReadBlocker>(description);
+        auto result = Thread::current()->block<Thread::ReadBlocker>(description);
         if (result != Thread::BlockResult::WokeNormally)
             return -EINTR;
     }
@@ -308,7 +309,7 @@ ssize_t LocalSocket::recvfrom(FileDescription& description, void* buffer, size_t
     ASSERT(!buffer_for_me.is_empty());
     int nread = buffer_for_me.read((u8*)buffer, buffer_size);
     if (nread > 0)
-        Thread::current->did_unix_socket_read(nread);
+        Thread::current()->did_unix_socket_read(nread);
     return nread;
 }
 
@@ -389,7 +390,8 @@ KResult LocalSocket::chown(FileDescription&, uid_t uid, gid_t gid)
     if (m_file)
         return m_file->chown(uid, gid);
 
-    if (!Process::current->is_superuser() && (Process::current->euid() != uid || !Process::current->in_group(gid)))
+    auto current_process = Process::current();
+    if (!current_process->is_superuser() && (current_process->euid() != uid || !current_process->in_group(gid)))
         return KResult(-EPERM);
 
     m_prebind_uid = uid;

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -113,7 +113,7 @@ void NetworkTask_main()
     for (;;) {
         size_t packet_size = dequeue_packet(buffer, buffer_size);
         if (!packet_size) {
-            Thread::current->wait_on(packet_wait_queue);
+            Thread::current()->wait_on(packet_wait_queue);
             continue;
         }
         if (packet_size < sizeof(EthernetFrameHeader)) {

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -135,7 +135,7 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source, c
     request.set_sender_protocol_address(adapter->ipv4_address());
     adapter->send({ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }, request);
 
-    (void)Thread::current->block_until("Routing (ARP)", [next_hop_ip] {
+    (void)Thread::current()->block_until("Routing (ARP)", [next_hop_ip] {
         return arp_table().resource().get(next_hop_ip).has_value();
     });
 

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -55,7 +55,7 @@ Socket::Socket(int domain, int type, int protocol)
     , m_type(type)
     , m_protocol(protocol)
 {
-    auto& process = *Process::current;
+    auto& process = *Process::current();
     m_origin = { process.pid(), process.uid(), process.gid() };
 }
 
@@ -82,7 +82,7 @@ RefPtr<Socket> Socket::accept()
 #endif
     auto client = m_pending.take_first();
     ASSERT(!client->is_connected());
-    auto& process = *Process::current;
+    auto& process = *Process::current();
     client->m_acceptor = { process.pid(), process.uid(), process.gid() };
     client->m_connected = true;
     client->m_role = Role::Accepted;

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -372,7 +372,7 @@ KResult TCPSocket::protocol_connect(FileDescription& description, ShouldBlock sh
     m_direction = Direction::Outgoing;
 
     if (should_block == ShouldBlock::Yes) {
-        if (Thread::current->block<Thread::ConnectBlocker>(description) != Thread::BlockResult::WokeNormally)
+        if (Thread::current()->block<Thread::ConnectBlocker>(description) != Thread::BlockResult::WokeNormally)
             return KResult(-EINTR);
         ASSERT(setup_state() == SetupState::Completed);
         if (has_error()) {

--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -67,11 +67,12 @@ KResult PerformanceEventBuffer::append(int type, FlatPtr arg1, FlatPtr arg2)
     asm volatile("movl %%ebp, %%eax"
                  : "=a"(ebp));
     FlatPtr eip;
-    copy_from_user(&eip, (FlatPtr*)&Thread::current->get_register_dump_from_stack().eip);
+    auto current_thread = Thread::current();
+    copy_from_user(&eip, (FlatPtr*)&current_thread->get_register_dump_from_stack().eip);
     Vector<FlatPtr> backtrace;
     {
         SmapDisabler disabler;
-        backtrace = Thread::current->raw_backtrace(ebp, eip);
+        backtrace = current_thread->raw_backtrace(ebp, eip);
     }
     event.stack_size = min(sizeof(event.stack) / sizeof(FlatPtr), static_cast<size_t>(backtrace.size()));
     memcpy(event.stack, backtrace.data(), event.stack_size * sizeof(FlatPtr));

--- a/Kernel/Ptrace.cpp
+++ b/Kernel/Ptrace.cpp
@@ -36,7 +36,7 @@ namespace Ptrace {
 KResultOr<u32> handle_syscall(const Kernel::Syscall::SC_ptrace_params& params, Process& caller)
 {
     if (params.request == PT_TRACE_ME) {
-        if (Thread::current->tracer())
+        if (Thread::current()->tracer())
             return KResult(-EBUSY);
 
         caller.set_wait_for_tracer_at_next_execve(true);

--- a/Kernel/Random.cpp
+++ b/Kernel/Random.cpp
@@ -69,7 +69,7 @@ KernelRng::KernelRng()
 void KernelRng::wait_for_entropy()
 {
     if (!resource().is_ready()) {
-        Thread::current->wait_on(m_seed_queue);
+        Thread::current()->wait_on(m_seed_queue);
     }
 }
 

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -43,28 +43,25 @@ struct SchedulerData;
 extern Thread* g_finalizer;
 extern Thread* g_colonel;
 extern WaitQueue* g_finalizer_wait_queue;
-extern bool g_finalizer_has_work;
+extern Atomic<bool> g_finalizer_has_work;
 extern u64 g_uptime;
 extern SchedulerData* g_scheduler_data;
 extern timeval g_timeofday;
 
 class Scheduler {
 public:
-    static void initialize();
+    static void initialize(u32 cpu);
     static void timer_tick(const RegisterState&);
+    [[noreturn]] static void start();
     static bool pick_next();
     static timeval time_since_boot();
-    static void pick_next_and_switch_now();
-    static void switch_now();
     static bool yield();
     static bool donate_to(Thread*, const char* reason);
     static bool context_switch(Thread&);
-    static void prepare_to_modify_tss(Thread&);
     static Process* colonel();
-    static bool is_active();
     static void beep();
     static void idle_loop();
-    static void stop_idling();
+    static void invoke_async();
 
     template<typename Callback>
     static inline IterationDecision for_each_runnable(Callback);
@@ -74,9 +71,6 @@ public:
 
     static void init_thread(Thread& thread);
     static void update_state_for_thread(Thread& thread);
-
-private:
-    static void prepare_for_iret_to_new_process();
 };
 
 }

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -30,6 +30,7 @@
 #include <AK/Function.h>
 #include <AK/IntrusiveList.h>
 #include <AK/Types.h>
+#include <Kernel/SpinLock.h>
 #include <Kernel/UnixTypes.h>
 
 namespace Kernel {
@@ -41,12 +42,12 @@ struct RegisterState;
 struct SchedulerData;
 
 extern Thread* g_finalizer;
-extern Thread* g_colonel;
 extern WaitQueue* g_finalizer_wait_queue;
 extern Atomic<bool> g_finalizer_has_work;
 extern u64 g_uptime;
 extern SchedulerData* g_scheduler_data;
 extern timeval g_timeofday;
+extern RecursiveSpinLock g_scheduler_lock;
 
 class Scheduler {
 public:

--- a/Kernel/SpinLock.h
+++ b/Kernel/SpinLock.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <AK/Atomic.h>
+#include <Kernel/Forward.h>
+#include <Kernel/Arch/i386/CPU.h>
+
+namespace Kernel {
+
+template <typename BaseType = u32>
+class SpinLock
+{
+    AK::Atomic<BaseType> m_lock{0};
+
+public:
+    SpinLock() = default;
+    SpinLock(const SpinLock&) = delete;
+    SpinLock(SpinLock&&) = delete;
+
+    ALWAYS_INLINE void lock()
+    {
+        BaseType expected;
+        do {
+            expected = 0;
+        } while (!m_lock.compare_exchange_strong(expected, 1, AK::memory_order_acq_rel));
+        
+    }
+
+    ALWAYS_INLINE void unlock()
+    {
+        ASSERT(is_locked());
+        m_lock.store(0, AK::memory_order_release);
+    }
+
+    ALWAYS_INLINE bool is_locked() const
+    {
+        return m_lock.load(AK::memory_order_consume) != 0;
+    }
+
+    ALWAYS_INLINE void initialize()
+    {
+        m_lock.store(0, AK::memory_order_release);
+    }
+};
+
+template <typename BaseType = u32, typename LockType = SpinLock<BaseType>>
+class ScopedSpinLock
+{
+    LockType* m_lock;
+    bool m_have_lock{false};
+    bool m_flag{false};
+
+public:
+    ScopedSpinLock() = delete;
+
+    ScopedSpinLock(LockType& lock):
+        m_lock(&lock)
+    {
+        ASSERT(m_lock);
+        m_flag = cli_and_save_interrupt_flag();
+        m_lock->lock();
+        m_have_lock = true;
+    }
+
+    ScopedSpinLock(ScopedSpinLock&& from):
+        m_lock(from.m_lock),
+        m_have_lock(from.m_have_lock),
+        m_flag(from.m_flag)
+    {
+        from.m_lock = nullptr;
+        from.m_have_lock = false;
+        from.m_flag = false;
+    }
+
+    ScopedSpinLock(const ScopedSpinLock&) = delete;
+
+    ~ScopedSpinLock()
+    {
+        if (m_lock && m_have_lock) {
+            m_lock->unlock();
+            restore_interrupt_flag(m_flag);
+        }
+    }
+
+    ALWAYS_INLINE void lock()
+    {
+        ASSERT(m_lock);
+        ASSERT(!m_have_lock);
+        m_flag = cli_and_save_interrupt_flag();
+        m_lock->lock();
+        m_have_lock = true;
+    }
+
+    ALWAYS_INLINE void unlock()
+    {
+        ASSERT(m_lock);
+        ASSERT(m_have_lock);
+        m_lock->unlock();
+        m_have_lock = false;
+        restore_interrupt_flag(m_flag);
+        m_flag = false;
+    }
+
+    ALWAYS_INLINE bool have_lock() const
+    {
+        return m_have_lock;
+    }
+};
+
+}

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -42,8 +42,9 @@ MasterPTY::MasterPTY(unsigned index)
     , m_index(index)
 {
     m_pts_name = String::format("/dev/pts/%u", m_index);
-    set_uid(Process::current->uid());
-    set_gid(Process::current->gid());
+    auto process = Process::current();
+    set_uid(process->uid());
+    set_gid(process->gid());
 }
 
 MasterPTY::~MasterPTY()

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -39,8 +39,9 @@ SlavePTY::SlavePTY(MasterPTY& master, unsigned index)
     , m_index(index)
 {
     sprintf(m_tty_name, "/dev/pts/%u", m_index);
-    set_uid(Process::current->uid());
-    set_gid(Process::current->gid());
+    auto process = Process::current();
+    set_uid(process->uid());
+    set_gid(process->gid());
     DevPtsFS::register_slave_pty(*this);
     set_size(80, 25);
 }

--- a/Kernel/Tasks/FinalizerTask.cpp
+++ b/Kernel/Tasks/FinalizerTask.cpp
@@ -34,14 +34,12 @@ void FinalizerTask::spawn()
     Process::create_kernel_process(g_finalizer, "FinalizerTask", [] {
         Thread::current->set_priority(THREAD_PRIORITY_LOW);
         for (;;) {
-            {
-                InterruptDisabler disabler;
-                if (!g_finalizer_has_work)
-                    Thread::current->wait_on(*g_finalizer_wait_queue);
-                ASSERT(g_finalizer_has_work);
-                g_finalizer_has_work = false;
-            }
-            Thread::finalize_dying_threads();
+			dbg() << "Finalizer task is running";
+            Thread::current->wait_on(*g_finalizer_wait_queue);
+            
+            bool expected = true;
+            if (g_finalizer_has_work.compare_exchange_strong(expected, false, AK::MemoryOrder::memory_order_acq_rel))
+                Thread::finalize_dying_threads();
         }
     });
 }

--- a/Kernel/Tasks/FinalizerTask.cpp
+++ b/Kernel/Tasks/FinalizerTask.cpp
@@ -32,10 +32,10 @@ namespace Kernel {
 void FinalizerTask::spawn()
 {
     Process::create_kernel_process(g_finalizer, "FinalizerTask", [] {
-        Thread::current->set_priority(THREAD_PRIORITY_LOW);
+        Thread::current()->set_priority(THREAD_PRIORITY_LOW);
         for (;;) {
 			dbg() << "Finalizer task is running";
-            Thread::current->wait_on(*g_finalizer_wait_queue);
+            Thread::current()->wait_on(*g_finalizer_wait_queue);
             
             bool expected = true;
             if (g_finalizer_has_work.compare_exchange_strong(expected, false, AK::MemoryOrder::memory_order_acq_rel))

--- a/Kernel/Tasks/SyncTask.cpp
+++ b/Kernel/Tasks/SyncTask.cpp
@@ -38,7 +38,7 @@ void SyncTask::spawn()
         dbg() << "SyncTask is running";
         for (;;) {
             VFS::the().sync();
-            Thread::current->sleep(1 * TimeManagement::the().ticks_per_second());
+            Thread::current()->sleep(1 * TimeManagement::the().ticks_per_second());
         }
     });
 }

--- a/Kernel/Tasks/SyncTask.cpp
+++ b/Kernel/Tasks/SyncTask.cpp
@@ -35,6 +35,7 @@ void SyncTask::spawn()
 {
     Thread* syncd_thread = nullptr;
     Process::create_kernel_process(syncd_thread, "SyncTask", [] {
+        dbg() << "SyncTask is running";
         for (;;) {
             VFS::the().sync();
             Thread::current->sleep(1 * TimeManagement::the().ticks_per_second());

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -273,6 +273,9 @@ public:
 
     bool in_kernel() const { return (m_tss.cs & 0x03) == 0; }
 
+    u32 cpu() const { return m_cpu.load(AK::MemoryOrder::memory_order_consume); }
+    void set_cpu(u32 cpu) { m_cpu.store(cpu, AK::MemoryOrder::memory_order_release); }
+
     u32 frame_ptr() const { return m_tss.ebp; }
     u32 stack_ptr() const { return m_tss.esp; }
 
@@ -466,6 +469,7 @@ private:
     int m_tid { -1 };
     TSS32 m_tss;
     FarPtr m_far_ptr;
+    Atomic<u32> m_cpu { 0 };
     u32 m_ticks { 0 };
     u32 m_ticks_left { 0 };
     u32 m_times_scheduled { 0 };

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -270,16 +270,16 @@ PageFaultResponse MemoryManager::handle_page_fault(const PageFault& fault)
     ASSERT(Thread::current);
     ScopedSpinLock lock(s_lock);
     if (Processor::current().in_irq()) {
-        dbg() << "CPU[" << Processor::id() << "] BUG! Page fault while handling IRQ! code=" << fault.code() << ", vaddr=" << fault.vaddr() << ", irq level: " << Processor::current().in_irq();
+        dbg() << "CPU[" << Processor::current().id() << "] BUG! Page fault while handling IRQ! code=" << fault.code() << ", vaddr=" << fault.vaddr() << ", irq level: " << Processor::current().in_irq();
         dump_kernel_regions();
         return PageFaultResponse::ShouldCrash;
     }
 #ifdef PAGE_FAULT_DEBUG
-    dbg() << "MM: CPU[" << Processor::id() << "] handle_page_fault(" << String::format("%w", fault.code()) << ") at " << fault.vaddr();
+    dbg() << "MM: CPU[" << Processor::current().id() << "] handle_page_fault(" << String::format("%w", fault.code()) << ") at " << fault.vaddr();
 #endif
     auto* region = region_from_vaddr(fault.vaddr());
     if (!region) {
-        klog() << "CPU[" << Processor::id() << "] NP(error) fault at invalid address " << fault.vaddr();
+        klog() << "CPU[" << Processor::current().id() << "] NP(error) fault at invalid address " << fault.vaddr();
         return PageFaultResponse::ShouldCrash;
     }
 

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -267,7 +267,7 @@ Region* MemoryManager::region_from_vaddr(VirtualAddress vaddr)
 PageFaultResponse MemoryManager::handle_page_fault(const PageFault& fault)
 {
     ASSERT_INTERRUPTS_DISABLED();
-    ASSERT(Thread::current);
+    ASSERT(Thread::current() != nullptr);
     ScopedSpinLock lock(s_lock);
     if (Processor::current().in_irq()) {
         dbg() << "CPU[" << Processor::current().id() << "] BUG! Page fault while handling IRQ! code=" << fault.code() << ", vaddr=" << fault.vaddr() << ", irq level: " << Processor::current().in_irq();
@@ -519,10 +519,11 @@ RefPtr<PhysicalPage> MemoryManager::allocate_supervisor_physical_page()
 
 void MemoryManager::enter_process_paging_scope(Process& process)
 {
-    ASSERT(Thread::current);
+    auto current_thread = Thread::current();
+    ASSERT(current_thread != nullptr);
     ScopedSpinLock lock(s_lock);
 
-    Thread::current->tss().cr3 = process.page_directory().cr3();
+    current_thread->tss().cr3 = process.page_directory().cr3();
     write_cr3(process.page_directory().cr3());
 }
 

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -67,6 +67,10 @@ class SynthFSInode;
 
 #define MM Kernel::MemoryManager::the()
 
+struct MemoryManagerData {
+    SpinLock<u8> m_quickmap_in_use;
+};
+
 class MemoryManager {
     AK_MAKE_ETERNAL
     friend class PageDirectory;
@@ -80,7 +84,12 @@ class MemoryManager {
 public:
     static MemoryManager& the();
 
-    static void initialize();
+    static void initialize(u32 cpu);
+    
+    static inline MemoryManagerData& get_data()
+    {
+        return Processor::current().get_mm_data();
+    }
 
     PageFaultResponse handle_page_fault(const PageFault&);
 
@@ -203,8 +212,6 @@ private:
     InlineLinkedList<VMObject> m_vmobjects;
 
     static RecursiveSpinLock s_lock;
-
-    bool m_quickmap_in_use { false };
 
     RefPtr<PhysicalPage> m_low_pseudo_identity_mapping_pages[4];
 };

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -31,6 +31,7 @@
 #include <AK/String.h>
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/Forward.h>
+#include <Kernel/SpinLock.h>
 #include <Kernel/VM/PhysicalPage.h>
 #include <Kernel/VM/Region.h>
 #include <Kernel/VM/VMObject.h>
@@ -200,6 +201,8 @@ private:
     InlineLinkedList<Region> m_kernel_regions;
 
     InlineLinkedList<VMObject> m_vmobjects;
+
+    static RecursiveSpinLock s_lock;
 
     bool m_quickmap_in_use { false };
 

--- a/Kernel/VM/ProcessPagingScope.cpp
+++ b/Kernel/VM/ProcessPagingScope.cpp
@@ -31,7 +31,7 @@ namespace Kernel {
 
 ProcessPagingScope::ProcessPagingScope(Process& process)
 {
-    ASSERT(Thread::current);
+    ASSERT(Thread::current() != nullptr);
     m_previous_cr3 = read_cr3();
     MM.enter_process_paging_scope(process);
 }
@@ -39,7 +39,7 @@ ProcessPagingScope::ProcessPagingScope(Process& process)
 ProcessPagingScope::~ProcessPagingScope()
 {
     InterruptDisabler disabler;
-    Thread::current->tss().cr3 = m_previous_cr3;
+    Thread::current()->tss().cr3 = m_previous_cr3;
     write_cr3(m_previous_cr3);
 }
 

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -67,7 +67,7 @@ Region::~Region()
 
 NonnullOwnPtr<Region> Region::clone()
 {
-    ASSERT(Process::current);
+    ASSERT(Process::current());
 
     if (m_inherit_mode == InheritMode::ZeroedOnFork) {
         ASSERT(m_mmap);
@@ -367,8 +367,9 @@ PageFaultResponse Region::handle_zero_fault(size_t page_index_in_region)
         return PageFaultResponse::Continue;
     }
 
-    if (Thread::current)
-        Thread::current->did_zero_fault();
+    auto current_thread = Thread::current();
+    if (current_thread != nullptr)
+        current_thread->did_zero_fault();
 
     auto page = MM.allocate_user_physical_page(MemoryManager::ShouldZeroFill::Yes);
     if (page.is_null()) {
@@ -397,8 +398,9 @@ PageFaultResponse Region::handle_cow_fault(size_t page_index_in_region)
         return PageFaultResponse::Continue;
     }
 
-    if (Thread::current)
-        Thread::current->did_cow_fault();
+    auto current_thread = Thread::current();
+    if (current_thread)
+        current_thread->did_cow_fault();
 
 #ifdef PAGE_FAULT_DEBUG
     dbg() << "    >> It's a COW page and it's time to COW!";
@@ -446,8 +448,9 @@ PageFaultResponse Region::handle_inode_fault(size_t page_index_in_region)
         return PageFaultResponse::Continue;
     }
 
-    if (Thread::current)
-        Thread::current->did_inode_fault();
+    auto current_thread = Thread::current();
+    if (current_thread)
+        current_thread->did_inode_fault();
 
 #ifdef MM_DEBUG
     dbg() << "MM: page_in_from_inode ready to read from inode";

--- a/Kernel/VM/Region.h
+++ b/Kernel/VM/Region.h
@@ -29,6 +29,7 @@
 #include <AK/InlineLinkedList.h>
 #include <AK/String.h>
 #include <AK/Weakable.h>
+#include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/Heap/SlabAllocator.h>
 #include <Kernel/VM/RangeAllocator.h>
 #include <Kernel/VM/VMObject.h>

--- a/Kernel/WaitQueue.cpp
+++ b/Kernel/WaitQueue.cpp
@@ -52,7 +52,7 @@ void WaitQueue::wake_one(Atomic<bool>* lock)
         return;
     if (auto* thread = m_threads.take_first())
         thread->wake_from_queue();
-    Scheduler::stop_idling();
+    Scheduler::yield();
 }
 
 void WaitQueue::wake_n(i32 wake_count)
@@ -67,7 +67,7 @@ void WaitQueue::wake_n(i32 wake_count)
             break;
         thread->wake_from_queue();
     }
-    Scheduler::stop_idling();
+    Scheduler::yield();
 }
 
 void WaitQueue::wake_all()
@@ -77,7 +77,7 @@ void WaitQueue::wake_all()
         return;
     while (!m_threads.is_empty())
         m_threads.take_first()->wake_from_queue();
-    Scheduler::stop_idling();
+    Scheduler::yield();
 }
 
 void WaitQueue::clear()

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -310,7 +310,7 @@ void init_stage2()
         hang();
     }
 
-    Process::current->set_root_directory(VFS::the().root_custody());
+    Process::current()->set_root_directory(VFS::the().root_custody());
 
     load_kernel_symbol_table();
 
@@ -329,7 +329,7 @@ void init_stage2()
 
     NetworkTask::spawn();
 
-    Process::current->sys$exit(0);
+    Process::current()->sys$exit(0);
     ASSERT_NOT_REACHED();
 }
 

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -114,7 +114,7 @@ extern "C" [[noreturn]] void init()
     }
 
     CommandLine::initialize(reinterpret_cast<const char*>(low_physical_to_virtual(multiboot_info_ptr->cmdline)));
-    MemoryManager::initialize();
+    MemoryManager::initialize(0);
 
     // Invoke all static global constructors in the kernel.
     // Note that we want to do this as early as possible.
@@ -168,6 +168,7 @@ extern "C" [[noreturn]] void init_ap(u32 cpu, Processor* processor_info)
     klog() << "CPU #" << cpu << " processor_info at " << VirtualAddress(FlatPtr(processor_info));
     cpu_setup(cpu);
     processor_info->initialize(cpu);
+    MemoryManager::initialize(cpu);
 
     APIC::the().enable(cpu);
 

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -172,14 +172,8 @@ extern "C" [[noreturn]] void init_ap(u32 cpu, Processor* processor_info)
 
     APIC::the().enable(cpu);
 
-#if 0
-    Scheduler::idle_loop();
-#else
-    // FIXME: remove once schedule can handle APs
-    cli();
-    for (;;)
-        asm volatile("hlt");
-#endif
+    Scheduler::initialize(cpu);
+    Scheduler::start();
     ASSERT_NOT_REACHED();
 }
 

--- a/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -85,6 +85,7 @@ HashMap<pid_t, Core::ProcessStatistics> ProcessStatisticsReader::get_all()
             thread.name = thread_object.get("name").to_string();
             thread.state = thread_object.get("state").to_string();
             thread.ticks = thread_object.get("ticks").to_u32();
+            thread.cpu = thread_object.get("cpu").to_u32();
             thread.priority = thread_object.get("priority").to_u32();
             thread.effective_priority = thread_object.get("effective_priority").to_u32();
             thread.syscall_count = thread_object.get("syscall_count").to_u32();

--- a/Libraries/LibCore/ProcessStatisticsReader.h
+++ b/Libraries/LibCore/ProcessStatisticsReader.h
@@ -47,6 +47,7 @@ struct ThreadStatistics {
     unsigned file_read_bytes;
     unsigned file_write_bytes;
     String state;
+    u32 cpu;
     u32 priority;
     u32 effective_priority;
     String name;


### PR DESCRIPTION
This is still work in progress:

- [x] Add SpinLock class
- [x] Serialize debug output with new SpinLock class
- [x] Add `Processor` structure and assign it to each CPU using the `fs` segment register
- [x] Get `Scheduler` to work on the BSP using software context switching
- [x] Add some locks to MM, Process, and other places
- [x] Boot each AP all the way into the `Scheduler::idle_loop`
- [x] Expose all processors in `/proc/cpuinfo`
- [x] Add CPU graphs and current processor information to SystemMonitor