### PR TITLE
cmake: Make setting CMAKE_BUILD_TYPE an error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.16)
 project(SerenityOS C CXX ASM)
 
+if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "")
+  message(FATAL
+    ": Don't use CMAKE_BUILD_TYPE when building serenity.\n"
+    "The default build type is optimized with debug info and asserts enabled,\n"
+    "and that's all there is.")
+endif()
+
 enable_testing()
 
 add_custom_target(image


### PR DESCRIPTION
Not sure if this is correct!

I tried setting it to Release, then noticed that it didn't build
due to gcc's optimizer-level dependent warnings and -Werror, then
started fixing the warnings for a bit (all false positives),
then looked at the global CMakeLists.txt and realized that the
default build is aleady using compiler optimizations. It looks like
people aren't supposed to change this, so make that explicit to
be friendly to people familiar with cmake but new to serenity.