### PR TITLE
LibWeb: Fix location.reload.length

### DIFF
--- a/Libraries/LibWeb/Bindings/LocationObject.cpp
+++ b/Libraries/LibWeb/Bindings/LocationObject.cpp
@@ -47,7 +47,7 @@ LocationObject::LocationObject()
     define_native_property("search", search_getter, nullptr, attr);
     define_native_property("protocol", protocol_getter, nullptr, attr);
 
-    define_native_function("reload", reload, JS::Attribute::Enumerable);
+    define_native_function("reload", reload, 0, JS::Attribute::Enumerable);
 }
 
 LocationObject::~LocationObject()


### PR DESCRIPTION
This was accidentally being set to JS::Attribute::Enumerable
instead of 0.