### PR TITLE
LibWeb: Add initial support for the history object.

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -171,6 +171,31 @@ Tab::Tab()
         }
     };
 
+    m_page_view->on_history_navigation = [this](auto delta) {
+        if (delta < 0)
+        {
+            if (!m_history.can_go_back(delta))
+                return;
+
+            for (i32 i = delta; i < 0; ++i)
+                m_history.go_back();
+        }
+        else
+        {
+            if (!m_history.can_go_forward(delta))
+                return;
+
+            for (i32 i = delta; i > 0; --i)
+                m_history.go_forward();
+        }
+
+        update_actions();
+        TemporaryChange<bool> change(m_should_push_loads_to_history, false);
+        m_page_view->load(m_history.current());
+    };
+
+    m_page_view->on_get_num_history_entries = [this]() { return m_history.num_entries(); };
+
     m_link_context_menu = GUI::Menu::construct();
     m_link_context_menu->add_action(GUI::Action::create("Open", [this](auto&) {
         m_page_view->on_link_click(m_link_context_menu_href, "", 0);

--- a/Base/home/anon/www/history-navigation.html
+++ b/Base/home/anon/www/history-navigation.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>window.history navigation</title>
+        <style>
+            #gonoparam { background-color: blue; color: white; }
+            #gozerodelta { background-color: purple; color: white; }
+            #back { background-color: white; color: black; }
+            #forward { background-color:darkblue; color: white; }
+        </style>
+    </head>
+    <body>
+    <pre></pre>
+    <div id="gonoparam">Click me to call history.go()!</div>
+    <div id="gozerodelta">Click me to call history.go(0)!</div>
+    <div id="back">Click me to call history.back()!</div>
+    <div id="forward">Click me to call history.forward()!</div>
+    
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            // FIXME: When this handler is called, there is no frame, so Window::num_history_entries returns 0.
+            //        Until this is fixed, I've added a setTimeout to work around it.
+            setTimeout(() => {
+                var pre = document.querySelector("pre");
+                pre.innerHTML = "There are currently " + window.history.length + " entries in the history!\n";
+            }, 50);
+        });
+
+        document.getElementById("gonoparam").addEventListener("mousedown", function() {
+            window.history.go();
+        });
+
+        document.getElementById("gozerodelta").addEventListener("mousedown", function() {
+            window.history.go(0);
+        });
+
+        document.getElementById("back").addEventListener("mousedown", function() {
+            window.history.back();
+        });
+
+        document.getElementById("forward").addEventListener("mousedown", function() {
+            window.history.forward();
+        });
+    </script>
+    </body>
+</html>

--- a/Base/home/anon/www/welcome.html
+++ b/Base/home/anon/www/welcome.html
@@ -28,6 +28,7 @@ span#ua {
     <p>Your user agent is: <b><span id="ua"></span></b></p>
     <p>Some small test pages:</p>
     <ul>
+        <li><a href="history-navigation.html">window.history navigation</a></li>
         <li><a href="margin-collapse-2.html">margin collapsing 2</a></li>
         <li><a href="margin-collapse-1.html">margin collapsing 1</a></li>
         <li><a href="position-absolute-from-edges.html">position: absolute, offset from edges</a></li>

--- a/Libraries/LibWeb/Bindings/HistoryObject.cpp
+++ b/Libraries/LibWeb/Bindings/HistoryObject.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020, Luke Wilde <luke.wilde@live.co.uk>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibWeb/Bindings/HistoryObject.h>
+#include <LibWeb/Bindings/WindowObject.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Window.h>
+
+namespace Web {
+namespace Bindings {
+
+HistoryObject::HistoryObject()
+    : Object(interpreter().global_object().object_prototype())
+{
+    u8 attr = JS::Attribute::Writable | JS::Attribute::Enumerable;
+
+    define_native_function("go", go, 0, attr);
+    define_native_function("back", back, 0, attr);
+    define_native_function("forward", forward, 0, attr);
+
+    define_native_property("length", length_getter, nullptr, JS::Attribute::Configurable);
+}
+
+HistoryObject::~HistoryObject()
+{
+}
+
+JS::Value HistoryObject::go(JS::Interpreter& interpreter)
+{
+    // FIXME: This method should be asynchronous.
+    
+    i32 delta = 0;
+
+    if (interpreter.argument_count() > 0)
+    {
+        delta = interpreter.argument(0).to_i32(interpreter);
+        if (interpreter.exception())
+            return {};
+    }
+
+    auto& window = static_cast<WindowObject&>(interpreter.global_object());
+
+    // FIXME: If document is not fully active, then throw a "SecurityError" DOMException.
+
+    window.impl().did_call_history_navigation({}, delta);
+
+    return JS::js_undefined();
+}
+
+JS::Value HistoryObject::back(JS::Interpreter& interpreter)
+{
+    // FIXME: This method should be asynchronous.
+
+    auto& window = static_cast<WindowObject&>(interpreter.global_object());
+
+    // FIXME: If document is not fully active, then throw a "SecurityError" DOMException.
+
+    window.impl().did_call_history_navigation({}, -1);
+
+    return JS::js_undefined();
+}
+
+JS::Value HistoryObject::forward(JS::Interpreter& interpreter)
+{
+    // FIXME: This method should be asynchronous.
+
+    auto& window = static_cast<WindowObject&>(interpreter.global_object());
+
+    // FIXME: If document is not fully active, then throw a "SecurityError" DOMException.
+
+    window.impl().did_call_history_navigation({}, 1);
+
+    return JS::js_undefined();
+}
+
+JS::Value HistoryObject::length_getter(JS::Interpreter& interpreter)
+{
+    auto& window = static_cast<WindowObject&>(interpreter.global_object());
+
+    return JS::Value((i32)window.impl().num_history_entries({}));
+}
+
+}
+}

--- a/Libraries/LibWeb/Bindings/HistoryObject.h
+++ b/Libraries/LibWeb/Bindings/HistoryObject.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Luke Wilde <luke.wilde@live.co.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,67 +26,26 @@
 
 #pragma once
 
-#include <AK/Optional.h>
-#include <AK/String.h>
-#include <AK/Vector.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibWeb/Forward.h>
 
-template<typename T>
-class History final {
+namespace Web {
+namespace Bindings {
+
+class HistoryObject final : public JS::Object {
 public:
-    void push(const T& item);
-    T current() const;
-
-    void go_back();
-    void go_forward();
-
-    bool can_go_back() { return m_current > 0; }
-    bool can_go_forward() { return m_current + 1 < static_cast<int>(m_items.size()); }
-
-    bool can_go_back(i32 delta) { return m_current + delta >= 0; }
-    bool can_go_forward(i32 delta) { return m_current + delta < static_cast<int>(m_items.size()); }
-
-    void clear();
-
-    size_t num_entries() { return m_items.size(); }
+    HistoryObject();
+    virtual ~HistoryObject() override;
 
 private:
-    Vector<T> m_items;
-    int m_current { -1 };
+    virtual const char* class_name() const override { return "HistoryObject"; }
+
+    static JS::Value go(JS::Interpreter&);
+    static JS::Value back(JS::Interpreter&);
+    static JS::Value forward(JS::Interpreter&);
+
+    static JS::Value length_getter(JS::Interpreter&);
 };
 
-template<typename T>
-inline void History<T>::push(const T& item)
-{
-    m_items.shrink(m_current + 1);
-    m_items.append(item);
-    m_current++;
 }
-
-template<typename T>
-inline T History<T>::current() const
-{
-    if (m_current == -1)
-        return {};
-    return m_items[m_current];
-}
-
-template<typename T>
-inline void History<T>::go_back()
-{
-    ASSERT(can_go_back());
-    m_current--;
-}
-
-template<typename T>
-inline void History<T>::go_forward()
-{
-    ASSERT(can_go_forward());
-    m_current++;
-}
-
-template<typename T>
-inline void History<T>::clear()
-{
-    m_items = {};
-    m_current = -1;
 }

--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -31,6 +31,7 @@
 #include <LibJS/Runtime/Function.h>
 #include <LibJS/Runtime/Shape.h>
 #include <LibWeb/Bindings/DocumentWrapper.h>
+#include <LibWeb/Bindings/HistoryObject.h>
 #include <LibWeb/Bindings/LocationObject.h>
 #include <LibWeb/Bindings/NavigatorObject.h>
 #include <LibWeb/Bindings/WindowObject.h>
@@ -62,6 +63,7 @@ void WindowObject::initialize()
 
     define_property("navigator", heap().allocate<NavigatorObject>(), JS::Attribute::Enumerable | JS::Attribute::Configurable);
     define_property("location", heap().allocate<LocationObject>(), JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_property("history", heap().allocate<HistoryObject>(), JS::Attribute::Enumerable | JS::Attribute::Configurable);
 
     m_xhr_prototype = heap().allocate<XMLHttpRequestPrototype>();
     m_xhr_constructor = heap().allocate<XMLHttpRequestConstructor>();

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     Bindings/EventListenerWrapper.cpp
     Bindings/EventTargetWrapper.cpp
     Bindings/EventWrapper.cpp
+    Bindings/HistoryObject.cpp
     Bindings/HTMLCanvasElementWrapper.cpp
     Bindings/HTMLImageElementWrapper.cpp
     Bindings/ImageDataWrapper.cpp

--- a/Libraries/LibWeb/DOM/Window.cpp
+++ b/Libraries/LibWeb/DOM/Window.cpp
@@ -123,7 +123,29 @@ void Window::did_call_location_reload(Badge<Bindings::LocationObject>)
     auto* frame = document().frame();
     if (!frame)
         return;
+        
+    // FIXME: This causes a history entry, which it shouldn't.
     frame->loader().load(document().url());
+}
+
+void Window::did_call_history_navigation(Badge<Bindings::HistoryObject>, i32 delta)
+{
+    auto* frame = document().frame();
+    if (!frame)
+        return;
+
+    auto& view = static_cast<PageView&>(frame->main_frame().page().client());
+    view.go_to_history_delta(delta);
+}
+
+size_t Window::num_history_entries(Badge<Bindings::HistoryObject>)
+{
+    auto* frame = document().frame();
+    if (!frame)
+        return 0;
+
+    auto& view = static_cast<PageView&>(frame->main_frame().page().client());
+    return view.num_history_entries();
 }
 
 }

--- a/Libraries/LibWeb/DOM/Window.h
+++ b/Libraries/LibWeb/DOM/Window.h
@@ -51,6 +51,9 @@ public:
 
     void did_set_location_href(Badge<Bindings::LocationObject>, const String& new_href);
     void did_call_location_reload(Badge<Bindings::LocationObject>);
+    void did_call_go_with_zero_delta(Badge<Bindings::HistoryObject>);
+    void did_call_history_navigation(Badge<Bindings::HistoryObject>, i32 delta);
+    size_t num_history_entries(Badge<Bindings::HistoryObject>);
 
 private:
     explicit Window(Document&);

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -78,6 +78,7 @@ class ElementWrapper;
 class EventWrapper;
 class EventListenerWrapper;
 class EventTargetWrapper;
+class HistoryObject;
 class HTMLCanvasElementWrapper;
 class HTMLImageElementWrapper;
 class ImageDataWrapper;

--- a/Libraries/LibWeb/PageView.cpp
+++ b/Libraries/LibWeb/PageView.cpp
@@ -364,4 +364,17 @@ void PageView::drop_event(GUI::DropEvent& event)
     ScrollableWidget::drop_event(event);
 }
 
+void PageView::go_to_history_delta(i32 delta) {
+    if (on_history_navigation)
+        on_history_navigation(delta);
+}
+
+size_t PageView::num_history_entries()
+{
+    if (on_get_num_history_entries)
+        return on_get_num_history_entries();
+
+    return 0;
+}
+
 }

--- a/Libraries/LibWeb/PageView.h
+++ b/Libraries/LibWeb/PageView.h
@@ -54,6 +54,9 @@ public:
     const LayoutDocument* layout_root() const;
     LayoutDocument* layout_root();
 
+    void go_to_history_delta(i32);
+    size_t num_history_entries();
+
     void reload();
     bool load(const URL&);
     void scroll_to_anchor(const StringView&);
@@ -71,6 +74,8 @@ public:
     Function<void(const Gfx::Bitmap&)> on_favicon_change;
     Function<void(const URL&)> on_url_drop;
     Function<void(Document*)> on_set_document;
+    Function<void(i32)> on_history_navigation;
+    Function<size_t()> on_get_num_history_entries;
 
     virtual bool accepts_focus() const override { return true; }
 


### PR DESCRIPTION
This adds initial support for window.history. It currently only
includes the navigation functions and the length property.

~~Marked as draft as I forgot the events.~~ Nevermind, the events should also be fired when pressing the back/forward buttons. We simply don't support them quite yet. It should also be asynchronous but that can probably be done another time.

Not sure why the style check is failing.