### PR TITLE
Toolchain: Fix building the toolchain on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 *.autosave
 Meta/Lagom/build
 Build
+BuildHost
 build
 CMakeFiles
 Toolchain/Tarballs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,17 @@
 cmake_minimum_required(VERSION 3.16)
+
+if (BUILD_CROSS_OS_PHASE2)
+set(CMAKE_SYSTEM_NAME Generic)
+endif()
+
+if (NOT DEFINED BUILD_HOST_TOOLS_PHASE1)
+set(BUILD_HOST_TOOLS_PHASE1 True)
+endif()
+
+if (NOT DEFINED BUILD_CROSS_OS_PHASE2)
+set(BUILD_CROSS_OS_PHASE2 True)
+endif()
+
 project(SerenityOS C CXX ASM)
 
 if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "")
@@ -45,11 +58,38 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -std=c++2a -fdiagn
 include_directories(Libraries)
 include_directories(.)
 
+if(BUILD_HOST_TOOLS_PHASE1)
+
 add_subdirectory(Meta/Lagom)
 add_subdirectory(DevTools/IPCCompiler)
 add_subdirectory(DevTools/FormCompiler)
 add_subdirectory(Libraries/LibWeb/CodeGenerators)
 add_subdirectory(AK/Tests)
+
+else()
+
+# Fake empty Targets needed when building with a two phase build
+add_custom_target(IPCCompiler)
+add_custom_target(FormCompiler)
+add_custom_target(WrapperGenerator)
+add_custom_target(Generate_CSS_PropertyID_h)
+add_custom_target(Generate_CSS_PropertyID_cpp)
+
+endif()
+
+if(DEFINED BUILD_HOST_TOOLS_LOCATION)
+set(IPC_COMPILER_EXECUTABLE "${BUILD_HOST_TOOLS_LOCATION}/DevTools/IPCCompiler/IPCCompiler")
+set(LIBWEB_WRAPPER_GENERATOR_EXECUTABLE "${BUILD_HOST_TOOLS_LOCATION}/Libraries/LibWeb/CodeGenerators/WrapperGenerator")
+set(LIBWEB_GENERATE_CSS_PROPERTYID_H_EXECUTABLE "${BUILD_HOST_TOOLS_LOCATION}/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h")
+set(LIBWEB_GENERATE_CSS_PROPERTYID_CPP_EXECUTABLE "${BUILD_HOST_TOOLS_LOCATION}/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_cpp")
+else()
+set(IPC_COMPILER_EXECUTABLE "IPCCompiler")
+set(LIBWEB_WRAPPER_GENERATOR_EXECUTABLE "WrapperGenerator")
+set(LIBWEB_GENERATE_CSS_PROPERTYID_H_EXECUTABLE "Generate_CSS_PropertyID_h")
+set(LIBWEB_GENERATE_CSS_PROPERTYID_CPP_EXECUTABLE "Generate_CSS_PropertyID_cpp")
+endif()
+
+if (BUILD_CROSS_OS_PHASE2)
 
 function(serenity_install_headers target_name)
     file(GLOB_RECURSE headers RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h")
@@ -96,7 +136,7 @@ function(compile_ipc source output)
     set(source ${CMAKE_CURRENT_SOURCE_DIR}/${source})
     add_custom_command(
         OUTPUT ${output}
-        COMMAND IPCCompiler ${source} > ${output}
+        COMMAND ${IPC_COMPILER_EXECUTABLE} ${source} > ${output}
         VERBATIM
         DEPENDS IPCCompiler
         MAIN_DEPENDENCY ${source}
@@ -149,3 +189,5 @@ add_subdirectory(MenuApplets)
 add_subdirectory(Shell)
 add_subdirectory(Demos)
 add_subdirectory(Userland)
+
+endif()

--- a/Libraries/LibC/CMakeLists.txt
+++ b/Libraries/LibC/CMakeLists.txt
@@ -55,10 +55,17 @@ set(ELF_SOURCES ${ELF_SOURCES} ../LibELF/Arch/i386/plt_trampoline.S)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSERENITY_LIBC_BUILD")
 
 add_library(crt0 STATIC crt0.cpp)
-add_custom_command(
-    TARGET crt0
-    COMMAND install -D $<TARGET_OBJECTS:crt0> ${CMAKE_INSTALL_PREFIX}/usr/lib/crt0.o
-)
+if(CMAKE_HOST_APPLE)
+    add_custom_command(
+        TARGET crt0
+        COMMAND ginstall -D $<TARGET_OBJECTS:crt0> ${CMAKE_INSTALL_PREFIX}/usr/lib/crt0.o
+    )
+else() 
+    add_custom_command(
+        TARGET crt0
+        COMMAND install -D $<TARGET_OBJECTS:crt0> ${CMAKE_INSTALL_PREFIX}/usr/lib/crt0.o
+    )
+endif()
 
 set(SOURCES ${LIBC_SOURCES} ${AK_SOURCES} ${ELF_SOURCES})
 serenity_libc(LibC c)

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -136,7 +136,7 @@ function(libweb_js_wrapper class)
     add_custom_command(
         OUTPUT Bindings/${class}Wrapper.h
         COMMAND /bin/mkdir -p Bindings
-        COMMAND WrapperGenerator --header ${CMAKE_CURRENT_SOURCE_DIR}/DOM/${class}.idl > Bindings/${class}Wrapper.h
+        COMMAND ${LIBWEB_WRAPPER_GENERATOR_EXECUTABLE} --header ${CMAKE_CURRENT_SOURCE_DIR}/DOM/${class}.idl > Bindings/${class}Wrapper.h
         VERBATIM
         DEPENDS WrapperGenerator
         MAIN_DEPENDENCY DOM/${class}.idl
@@ -144,7 +144,7 @@ function(libweb_js_wrapper class)
     add_custom_command(
         OUTPUT Bindings/${class}Wrapper.cpp
         COMMAND /bin/mkdir -p Bindings
-        COMMAND WrapperGenerator --implementation ${CMAKE_CURRENT_SOURCE_DIR}/DOM/${class}.idl > Bindings/${class}Wrapper.cpp
+        COMMAND ${LIBWEB_WRAPPER_GENERATOR_EXECUTABLE} --implementation ${CMAKE_CURRENT_SOURCE_DIR}/DOM/${class}.idl > Bindings/${class}Wrapper.cpp
         VERBATIM
         DEPENDS WrapperGenerator
         MAIN_DEPENDENCY DOM/${class}.idl
@@ -171,7 +171,7 @@ set(SOURCES ${SOURCES} ${WRAPPER_SOURCES})
 add_custom_command(
     OUTPUT CSS/PropertyID.h
     COMMAND /bin/mkdir -p CSS
-    COMMAND Generate_CSS_PropertyID_h ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Properties.json > CSS/PropertyID.h
+    COMMAND ${LIBWEB_GENERATE_CSS_PROPERTYID_H_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Properties.json > CSS/PropertyID.h
     VERBATIM
     DEPENDS Generate_CSS_PropertyID_h
     MAIN_DEPENDENCY CSS/Properties.json
@@ -181,7 +181,7 @@ add_custom_target(generate_PropertyID.h DEPENDS CSS/PropertyID.h)
 add_custom_command(
     OUTPUT CSS/PropertyID.cpp
     COMMAND /bin/mkdir -p CSS
-    COMMAND Generate_CSS_PropertyID_cpp ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Properties.json > CSS/PropertyID.cpp
+    COMMAND ${LIBWEB_GENERATE_CSS_PROPERTYID_CPP_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Properties.json > CSS/PropertyID.cpp
     VERBATIM
     DEPENDS Generate_CSS_PropertyID_cpp
     MAIN_DEPENDENCY CSS/Properties.json


### PR DESCRIPTION
This PR restores building the toolchain and serenityOS on macOS, fixing #2234.
The root problem is how the current CMake build system has been setup for cross compiling host tools and the actual OS.
This PR builds host tools (IPCCompiler etc.) in a separate CMake invocation and then passes the CMake host tools build output directory to the regular CMake invocation for OS build.
The problem exists because changing compiler in the middle of a single CMake invocation is not supported. In other words targets using different compilers cannot be defined and built in a single CMake invocation.
Unfortunately CMake makes it not so obvious, because it actually allows to change `CMAKE_C_COMPILER` and friends, like currently being done in Serenity root `CMakeLists.txt`. It's not possible, to my knowledge, modifying some other variables impacting the build like the autodetected `CXXFLAGS` that are automatically appended after user specified ones, filled before declaring the `project()` section.
Current single invocation CMake build works on recent Linux because such autodetected flags are compatible enough not to causing problem when passed serenityOS GCC.
On macOS instead (and probably on other hosts as well), if you don't flag the CMake Project as a "cross-compiling" build, by changing `CMAKE_SYSTEM_NAME` before opening the `project()` section, you will get the autodetected `CXXFLAGS` filled with things like `-mmacosx-version-min=10.14` and `-isysroot=...` even when cross compiling using serenity custom GCC (i686-pc-serenity).
In this case serenity GCC will complain about wrong/unknown options and fail to build soon after building host tools.
Of course if you set `CMAKE_SYSTEM_NAME` to something like `Generic` unconditionally, host tools will not compile because macOS system compiler (Apple Clang included inside XCode) will now loose the important autodetected flag (`-isysroot` and `-mmacosx-version-min`).

I am not a CMake expert (because I actually dislike it a lot) and there are obviously many ways and opinions on how to solve this problem, but that's a start ;)

I have tried to make this PR as transparent as possible to avoid breaking current linux build, that still works with a single CMake invocation. I've tested it on a Ubuntu 2020.04 VM and it looks fine.
I think, however, that it could be a good idea splitting the CMake Build in two invocations even when building under Linux, to future-proof the build system when porting it to other unix-es or beyond 😄 
