### PR TITLE
LibJS: Lex and parse regex literals, add RegExp objects

### DIFF
--- a/Libraries/LibGUI/JSSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/JSSyntaxHighlighter.cpp
@@ -46,6 +46,7 @@ static TextStyle style_for_token_type(Gfx::Palette palette, JS::TokenType type)
     case JS::TokenType::TemplateLiteralEnd:
     case JS::TokenType::TemplateLiteralString:
     case JS::TokenType::RegexLiteral:
+    case JS::TokenType::RegexFlags:
     case JS::TokenType::UnterminatedStringLiteral:
         return { palette.syntax_string() };
     case JS::TokenType::BracketClose:

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -39,6 +39,7 @@
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/Reference.h>
+#include <LibJS/Runtime/RegExpObject.h>
 #include <LibJS/Runtime/ScriptFunction.h>
 #include <LibJS/Runtime/Shape.h>
 #include <LibJS/Runtime/StringObject.h>
@@ -1427,6 +1428,17 @@ Value BooleanLiteral::execute(Interpreter&) const
 Value NullLiteral::execute(Interpreter&) const
 {
     return js_null();
+}
+
+void RegExpLiteral::dump(int indent) const
+{
+    print_indent(indent);
+    printf("%s (/%s/%s)\n", class_name(), content().characters(), flags().characters());
+}
+
+Value RegExpLiteral::execute(Interpreter& interpreter) const
+{
+    return RegExpObject::create(interpreter.global_object(), content(), flags());
 }
 
 void ArrayExpression::dump(int indent) const

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -585,6 +585,27 @@ private:
     virtual const char* class_name() const override { return "NullLiteral"; }
 };
 
+class RegExpLiteral final : public Literal {
+public:
+    explicit RegExpLiteral(String content, String flags)
+        : m_content(content)
+        , m_flags(flags)
+    {
+    }
+
+    virtual Value execute(Interpreter&) const override;
+    virtual void dump(int indent) const override;
+
+    const String& content() const { return m_content; }
+    const String& flags() const { return m_flags; }
+
+private:
+    virtual const char* class_name() const override { return "RegExpLiteral"; }
+
+    String m_content;
+    String m_flags;
+};
+
 class Identifier final : public Expression {
 public:
     explicit Identifier(const FlyString& string)

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -47,6 +47,9 @@ set(SOURCES
     Runtime/ProxyPrototype.cpp
     Runtime/Reference.cpp
     Runtime/ReflectObject.cpp
+    Runtime/RegExpConstructor.cpp
+    Runtime/RegExpObject.cpp
+    Runtime/RegExpPrototype.cpp
     Runtime/ScriptFunction.cpp
     Runtime/Shape.cpp
     Runtime/StringConstructor.cpp

--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -35,6 +35,7 @@
     __JS_ENUMERATE(NumberObject, number, NumberPrototype, NumberConstructor)     \
     __JS_ENUMERATE(Object, object, ObjectPrototype, ObjectConstructor)           \
     __JS_ENUMERATE(ProxyObject, proxy, ProxyPrototype, ProxyConstructor)         \
+    __JS_ENUMERATE(RegExpObject, regexp, RegExpPrototype, RegExpConstructor)     \
     __JS_ENUMERATE(StringObject, string, StringPrototype, StringConstructor)     \
     __JS_ENUMERATE(SymbolObject, symbol, SymbolPrototype, SymbolConstructor)
 

--- a/Libraries/LibJS/MarkupGenerator.cpp
+++ b/Libraries/LibJS/MarkupGenerator.cpp
@@ -223,6 +223,7 @@ MarkupGenerator::StyleType MarkupGenerator::style_type_for_token(Token token)
     case TokenType::TemplateLiteralEnd:
     case TokenType::TemplateLiteralString:
     case TokenType::RegexLiteral:
+    case TokenType::RegexFlags:
     case TokenType::UnterminatedStringLiteral:
         return StyleType::String;
     case TokenType::BracketClose:

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -464,6 +464,8 @@ NonnullRefPtr<Expression> Parser::parse_primary_expression()
         return parse_function_node<FunctionExpression>();
     case TokenType::BracketOpen:
         return parse_array_expression();
+    case TokenType::RegexLiteral:
+        return parse_regexp_literal();
     case TokenType::TemplateLiteralStart:
         return parse_template_literal(false);
     case TokenType::New:
@@ -473,6 +475,13 @@ NonnullRefPtr<Expression> Parser::parse_primary_expression()
         consume();
         return create_ast_node<ErrorExpression>();
     }
+}
+
+NonnullRefPtr<RegExpLiteral> Parser::parse_regexp_literal()
+{
+    auto content = consume().value();
+    auto flags = match(TokenType::RegexFlags) ? consume().value() : "";
+    return create_ast_node<RegExpLiteral>(content.substring_view(1, content.length() - 2), flags);
 }
 
 NonnullRefPtr<Expression> Parser::parse_unary_prefixed_expression()
@@ -1449,6 +1458,7 @@ bool Parser::match_expression() const
         || type == TokenType::ParenOpen
         || type == TokenType::Function
         || type == TokenType::This
+        || type == TokenType::RegexLiteral
         || match_unary_prefixed_expression();
 }
 

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -70,6 +70,7 @@ public:
     NonnullRefPtr<Expression> parse_expression(int min_precedence, Associativity associate = Associativity::Right, Vector<TokenType> forbidden = {});
     NonnullRefPtr<Expression> parse_primary_expression();
     NonnullRefPtr<Expression> parse_unary_prefixed_expression();
+    NonnullRefPtr<RegExpLiteral> parse_regexp_literal();
     NonnullRefPtr<ObjectExpression> parse_object_expression();
     NonnullRefPtr<ArrayExpression> parse_array_expression();
     NonnullRefPtr<StringLiteral> parse_string_literal(Token token);

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -26,8 +26,6 @@
  */
 
 #include <AK/LogStream.h>
-#include <AK/String.h>
-#include <LibJS/Heap/Heap.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/ArrayConstructor.h>
 #include <LibJS/Runtime/ArrayPrototype.h>
@@ -36,13 +34,11 @@
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibJS/Runtime/DateConstructor.h>
 #include <LibJS/Runtime/DatePrototype.h>
-#include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/ErrorConstructor.h>
 #include <LibJS/Runtime/ErrorPrototype.h>
 #include <LibJS/Runtime/FunctionConstructor.h>
 #include <LibJS/Runtime/FunctionPrototype.h>
 #include <LibJS/Runtime/GlobalObject.h>
-#include <LibJS/Runtime/LexicalEnvironment.h>
 #include <LibJS/Runtime/MathObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/NumberConstructor.h>
@@ -53,6 +49,8 @@
 #include <LibJS/Runtime/ProxyConstructor.h>
 #include <LibJS/Runtime/ProxyPrototype.h>
 #include <LibJS/Runtime/ReflectObject.h>
+#include <LibJS/Runtime/RegExpConstructor.h>
+#include <LibJS/Runtime/RegExpPrototype.h>
 #include <LibJS/Runtime/Shape.h>
 #include <LibJS/Runtime/StringConstructor.h>
 #include <LibJS/Runtime/StringPrototype.h>
@@ -106,6 +104,7 @@ void GlobalObject::initialize()
     add_constructor("Number", m_number_constructor, *m_number_prototype);
     add_constructor("Object", m_object_constructor, *m_object_prototype);
     add_constructor("Proxy", m_proxy_constructor, *m_proxy_prototype);
+    add_constructor("RegExp", m_regexp_constructor, *m_regexp_prototype);
     add_constructor("String", m_string_constructor, *m_string_prototype);
     add_constructor("Symbol", m_symbol_constructor, *m_symbol_prototype);
 

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -102,6 +102,7 @@ public:
     virtual bool is_bound_function() const { return false; }
     virtual bool is_native_property() const { return false; }
     virtual bool is_proxy_object() const { return false; }
+    virtual bool is_regexp_object() const { return false; }
     virtual bool is_string_object() const { return false; }
     virtual bool is_symbol_object() const { return false; }
 

--- a/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@gmx.de>
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,56 +24,41 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "Token.h"
-
-#include <AK/HashMap.h>
-#include <AK/String.h>
-#include <AK/StringView.h>
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/RegExpConstructor.h>
+#include <LibJS/Runtime/RegExpObject.h>
 
 namespace JS {
 
-class Lexer {
-public:
-    explicit Lexer(StringView source);
+RegExpConstructor::RegExpConstructor()
+    : NativeFunction("RegExp", *interpreter().global_object().function_prototype())
+{
+    define_property("prototype", interpreter().global_object().regexp_prototype(), 0);
+    define_property("length", Value(2), Attribute::Configurable);
+}
 
-    Token next();
+RegExpConstructor::~RegExpConstructor()
+{
+}
 
-private:
-    void consume();
-    void consume_exponent();
-    bool is_eof() const;
-    bool is_identifier_start() const;
-    bool is_identifier_middle() const;
-    bool is_line_comment_start() const;
-    bool is_block_comment_start() const;
-    bool is_block_comment_end() const;
-    bool is_numeric_literal_start() const;
-    bool match(char, char) const;
-    bool match(char, char, char) const;
-    bool match(char, char, char, char) const;
-    bool slash_means_division() const;
+Value RegExpConstructor::call(Interpreter& interpreter)
+{
+    return construct(interpreter);
+}
 
-    StringView m_source;
-    size_t m_position { 0 };
-    Token m_current_token;
-    int m_current_char { 0 };
-    size_t m_line_number { 1 };
-    size_t m_line_column { 0 };
-
-    bool m_regex_is_in_character_class { false };
-
-    struct TemplateState {
-        bool in_expr;
-        u8 open_bracket_count;
-    };
-    Vector<TemplateState> m_template_states;
-
-    static HashMap<String, TokenType> s_keywords;
-    static HashMap<String, TokenType> s_three_char_tokens;
-    static HashMap<String, TokenType> s_two_char_tokens;
-    static HashMap<char, TokenType> s_single_char_tokens;
-};
+Value RegExpConstructor::construct(Interpreter& interpreter)
+{
+    if (!interpreter.argument_count())
+        return RegExpObject::create(interpreter.global_object(), "(?:)", "");
+    auto contents = interpreter.argument(0).to_string(interpreter);
+    if (interpreter.exception())
+        return {};
+    auto flags = interpreter.argument_count() > 1 ? interpreter.argument(1).to_string(interpreter) : "";
+    if (interpreter.exception())
+        return {};
+    return RegExpObject::create(interpreter.global_object(), contents, flags);
+}
 
 }

--- a/Libraries/LibJS/Runtime/RegExpConstructor.h
+++ b/Libraries/LibJS/Runtime/RegExpConstructor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@gmx.de>
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,54 +26,21 @@
 
 #pragma once
 
-#include "Token.h"
-
-#include <AK/HashMap.h>
-#include <AK/String.h>
-#include <AK/StringView.h>
+#include <LibJS/Runtime/NativeFunction.h>
 
 namespace JS {
 
-class Lexer {
+class RegExpConstructor final : public NativeFunction {
 public:
-    explicit Lexer(StringView source);
+    RegExpConstructor();
+    virtual ~RegExpConstructor() override;
 
-    Token next();
+    virtual Value call(Interpreter&) override;
+    virtual Value construct(Interpreter&) override;
 
 private:
-    void consume();
-    void consume_exponent();
-    bool is_eof() const;
-    bool is_identifier_start() const;
-    bool is_identifier_middle() const;
-    bool is_line_comment_start() const;
-    bool is_block_comment_start() const;
-    bool is_block_comment_end() const;
-    bool is_numeric_literal_start() const;
-    bool match(char, char) const;
-    bool match(char, char, char) const;
-    bool match(char, char, char, char) const;
-    bool slash_means_division() const;
-
-    StringView m_source;
-    size_t m_position { 0 };
-    Token m_current_token;
-    int m_current_char { 0 };
-    size_t m_line_number { 1 };
-    size_t m_line_column { 0 };
-
-    bool m_regex_is_in_character_class { false };
-
-    struct TemplateState {
-        bool in_expr;
-        u8 open_bracket_count;
-    };
-    Vector<TemplateState> m_template_states;
-
-    static HashMap<String, TokenType> s_keywords;
-    static HashMap<String, TokenType> s_three_char_tokens;
-    static HashMap<String, TokenType> s_two_char_tokens;
-    static HashMap<char, TokenType> s_single_char_tokens;
+    virtual bool has_constructor() const override { return true; }
+    virtual const char* class_name() const override { return "RegExpConstructor"; }
 };
 
 }

--- a/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@gmx.de>
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,56 +24,36 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include <AK/StringBuilder.h>
+#include <LibJS/Heap/Heap.h>
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/PrimitiveString.h>
+#include <LibJS/Runtime/RegExpObject.h>
+#include <LibJS/Runtime/Value.h>
 
-#include "Token.h"
-
-#include <AK/HashMap.h>
-#include <AK/String.h>
-#include <AK/StringView.h>
 
 namespace JS {
 
-class Lexer {
-public:
-    explicit Lexer(StringView source);
+RegExpObject* RegExpObject::create(GlobalObject& global_object, String content, String flags)
+{
+    return global_object.heap().allocate<RegExpObject>(content, flags, *global_object.regexp_prototype());
+}
 
-    Token next();
+RegExpObject::RegExpObject(String content, String flags, Object& prototype)
+    : Object(&prototype)
+    , m_content(content)
+    , m_flags(flags)
+{
+}
 
-private:
-    void consume();
-    void consume_exponent();
-    bool is_eof() const;
-    bool is_identifier_start() const;
-    bool is_identifier_middle() const;
-    bool is_line_comment_start() const;
-    bool is_block_comment_start() const;
-    bool is_block_comment_end() const;
-    bool is_numeric_literal_start() const;
-    bool match(char, char) const;
-    bool match(char, char, char) const;
-    bool match(char, char, char, char) const;
-    bool slash_means_division() const;
+RegExpObject::~RegExpObject()
+{
+}
 
-    StringView m_source;
-    size_t m_position { 0 };
-    Token m_current_token;
-    int m_current_char { 0 };
-    size_t m_line_number { 1 };
-    size_t m_line_column { 0 };
-
-    bool m_regex_is_in_character_class { false };
-
-    struct TemplateState {
-        bool in_expr;
-        u8 open_bracket_count;
-    };
-    Vector<TemplateState> m_template_states;
-
-    static HashMap<String, TokenType> s_keywords;
-    static HashMap<String, TokenType> s_three_char_tokens;
-    static HashMap<String, TokenType> s_two_char_tokens;
-    static HashMap<char, TokenType> s_single_char_tokens;
-};
+Value RegExpObject::to_string() const
+{
+    return js_string(interpreter(), String::format("/%s/%s", content().characters(), flags().characters()));
+}
 
 }

--- a/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Libraries/LibJS/Runtime/RegExpObject.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@gmx.de>
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,54 +26,29 @@
 
 #pragma once
 
-#include "Token.h"
-
-#include <AK/HashMap.h>
-#include <AK/String.h>
-#include <AK/StringView.h>
+#include <LibJS/AST.h>
+#include <LibJS/Runtime/Object.h>
 
 namespace JS {
 
-class Lexer {
+class RegExpObject : public Object {
 public:
-    explicit Lexer(StringView source);
+    static RegExpObject* create(GlobalObject&, String content, String flags);
 
-    Token next();
+    RegExpObject(String content, String flags, Object& prototype);
+    virtual ~RegExpObject() override;
+
+    const String& content() const { return m_content; }
+    const String& flags() const { return m_flags; }
+
+    Value to_string() const override;
 
 private:
-    void consume();
-    void consume_exponent();
-    bool is_eof() const;
-    bool is_identifier_start() const;
-    bool is_identifier_middle() const;
-    bool is_line_comment_start() const;
-    bool is_block_comment_start() const;
-    bool is_block_comment_end() const;
-    bool is_numeric_literal_start() const;
-    bool match(char, char) const;
-    bool match(char, char, char) const;
-    bool match(char, char, char, char) const;
-    bool slash_means_division() const;
+    virtual const char* class_name() const override { return "RegExpObject"; }
+    virtual bool is_regexp_object() const override { return true; }
 
-    StringView m_source;
-    size_t m_position { 0 };
-    Token m_current_token;
-    int m_current_char { 0 };
-    size_t m_line_number { 1 };
-    size_t m_line_column { 0 };
-
-    bool m_regex_is_in_character_class { false };
-
-    struct TemplateState {
-        bool in_expr;
-        u8 open_bracket_count;
-    };
-    Vector<TemplateState> m_template_states;
-
-    static HashMap<String, TokenType> s_keywords;
-    static HashMap<String, TokenType> s_three_char_tokens;
-    static HashMap<String, TokenType> s_two_char_tokens;
-    static HashMap<char, TokenType> s_single_char_tokens;
+    String m_content;
+    String m_flags;
 };
 
 }

--- a/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@gmx.de>
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,56 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "Token.h"
-
-#include <AK/HashMap.h>
-#include <AK/String.h>
-#include <AK/StringView.h>
+#include <AK/Function.h>
+#include <AK/StringBuilder.h>
+#include <LibJS/Heap/Heap.h>
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/PrimitiveString.h>
+#include <LibJS/Runtime/RegExpObject.h>
+#include <LibJS/Runtime/RegExpPrototype.h>
 
 namespace JS {
 
-class Lexer {
-public:
-    explicit Lexer(StringView source);
+RegExpPrototype::RegExpPrototype()
+    : RegExpObject({}, {}, *interpreter().global_object().object_prototype())
+{
+}
 
-    Token next();
-
-private:
-    void consume();
-    void consume_exponent();
-    bool is_eof() const;
-    bool is_identifier_start() const;
-    bool is_identifier_middle() const;
-    bool is_line_comment_start() const;
-    bool is_block_comment_start() const;
-    bool is_block_comment_end() const;
-    bool is_numeric_literal_start() const;
-    bool match(char, char) const;
-    bool match(char, char, char) const;
-    bool match(char, char, char, char) const;
-    bool slash_means_division() const;
-
-    StringView m_source;
-    size_t m_position { 0 };
-    Token m_current_token;
-    int m_current_char { 0 };
-    size_t m_line_number { 1 };
-    size_t m_line_column { 0 };
-
-    bool m_regex_is_in_character_class { false };
-
-    struct TemplateState {
-        bool in_expr;
-        u8 open_bracket_count;
-    };
-    Vector<TemplateState> m_template_states;
-
-    static HashMap<String, TokenType> s_keywords;
-    static HashMap<String, TokenType> s_three_char_tokens;
-    static HashMap<String, TokenType> s_two_char_tokens;
-    static HashMap<char, TokenType> s_single_char_tokens;
-};
+RegExpPrototype::~RegExpPrototype()
+{
+}
 
 }

--- a/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@gmx.de>
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,54 +26,17 @@
 
 #pragma once
 
-#include "Token.h"
-
-#include <AK/HashMap.h>
-#include <AK/String.h>
-#include <AK/StringView.h>
+#include <LibJS/Runtime/RegExpObject.h>
 
 namespace JS {
 
-class Lexer {
+class RegExpPrototype final : public RegExpObject {
 public:
-    explicit Lexer(StringView source);
-
-    Token next();
+    RegExpPrototype();
+    virtual ~RegExpPrototype() override;
 
 private:
-    void consume();
-    void consume_exponent();
-    bool is_eof() const;
-    bool is_identifier_start() const;
-    bool is_identifier_middle() const;
-    bool is_line_comment_start() const;
-    bool is_block_comment_start() const;
-    bool is_block_comment_end() const;
-    bool is_numeric_literal_start() const;
-    bool match(char, char) const;
-    bool match(char, char, char) const;
-    bool match(char, char, char, char) const;
-    bool slash_means_division() const;
-
-    StringView m_source;
-    size_t m_position { 0 };
-    Token m_current_token;
-    int m_current_char { 0 };
-    size_t m_line_number { 1 };
-    size_t m_line_column { 0 };
-
-    bool m_regex_is_in_character_class { false };
-
-    struct TemplateState {
-        bool in_expr;
-        u8 open_bracket_count;
-    };
-    Vector<TemplateState> m_template_states;
-
-    static HashMap<String, TokenType> s_keywords;
-    static HashMap<String, TokenType> s_three_char_tokens;
-    static HashMap<String, TokenType> s_two_char_tokens;
-    static HashMap<char, TokenType> s_single_char_tokens;
+    virtual const char* class_name() const override { return "RegExpPrototype"; }
 };
 
 }

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -113,6 +113,7 @@ namespace JS {
     __ENUMERATE_JS_TOKEN(QuestionMark)                \
     __ENUMERATE_JS_TOKEN(QuestionMarkPeriod)          \
     __ENUMERATE_JS_TOKEN(RegexLiteral)                \
+    __ENUMERATE_JS_TOKEN(RegexFlags)                  \
     __ENUMERATE_JS_TOKEN(Return)                      \
     __ENUMERATE_JS_TOKEN(Semicolon)                   \
     __ENUMERATE_JS_TOKEN(ShiftLeft)                   \
@@ -138,6 +139,7 @@ namespace JS {
     __ENUMERATE_JS_TOKEN(Typeof)                      \
     __ENUMERATE_JS_TOKEN(UnsignedShiftRight)          \
     __ENUMERATE_JS_TOKEN(UnsignedShiftRightEquals)    \
+    __ENUMERATE_JS_TOKEN(UnterminatedRegexLiteral)    \
     __ENUMERATE_JS_TOKEN(UnterminatedStringLiteral)   \
     __ENUMERATE_JS_TOKEN(UnterminatedTemplateLiteral) \
     __ENUMERATE_JS_TOKEN(Var)                         \

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -40,6 +40,7 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/PrimitiveString.h>
+#include <LibJS/Runtime/RegExpObject.h>
 #include <LibJS/Runtime/Shape.h>
 #include <LibJS/Runtime/Value.h>
 #include <LibLine/Editor.h>
@@ -224,6 +225,12 @@ static void print_error(const JS::Object& object, HashTable<JS::Object*>&)
         printf(": %s", error.message().characters());
 }
 
+static void print_regexp(const JS::Object& object, HashTable<JS::Object*>&)
+{
+    auto& regexp = static_cast<const JS::RegExpObject&>(object);
+    printf("\033[34;1m/%s/%s\033[0m", regexp.content().characters(), regexp.flags().characters());
+}
+
 void print_value(JS::Value value, HashTable<JS::Object*>& seen_objects)
 {
     if (value.is_empty()) {
@@ -252,6 +259,8 @@ void print_value(JS::Value value, HashTable<JS::Object*>& seen_objects)
             return print_date(object, seen_objects);
         if (object.is_error())
             return print_error(object, seen_objects);
+        if (object.is_regexp_object())
+            return print_regexp(object, seen_objects);
         return print_object(object, seen_objects);
     }
 
@@ -618,6 +627,7 @@ int main(int argc, char** argv)
                 case JS::TokenType::TemplateLiteralEnd:
                 case JS::TokenType::TemplateLiteralString:
                 case JS::TokenType::RegexLiteral:
+                case JS::TokenType::RegexFlags:
                 case JS::TokenType::UnterminatedStringLiteral:
                     stylize({ start, end }, { Line::Style::Foreground(Line::Style::XtermColor::Green), Line::Style::Bold });
                     break;


### PR DESCRIPTION
This adds regex lexing/parsing, as well as a relatively empty `RegExpObject`. The purpose of this patch is to allow the engine to not get hung up on parsing regexes. This will aid in finding new syntax errors (say, from google or twitter) without having to replace all of their regexes first!

The objects added in this PR aren't perfect, but the primary point of this PR is to do the lexing and parsing. The objects can be ironed out in future PRs when LibRegex gets added.