### PR TITLE
LibJS: Regex fixes

### DIFF
--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -418,6 +418,29 @@ Token Lexer::next()
             consume();
             token_type = TokenType::StringLiteral;
         }
+    } else if (m_current_char == '/' && !slash_means_division()) {
+        consume();
+        token_type = TokenType::RegexLiteral;
+
+        while (!is_eof()) {
+            if (m_current_char == '[') {
+                m_regex_is_in_character_class = true;
+            } else if (m_current_char == ']') {
+                m_regex_is_in_character_class = false;
+            } else if (!m_regex_is_in_character_class && m_current_char == '/') {
+                break;
+            }
+
+            if (match('\\', '/') || match('\\', '[') || match('\\', '\\') || (m_regex_is_in_character_class && match('\\', ']')))
+                consume();
+            consume();
+        }
+
+        if (is_eof()) {
+            token_type = TokenType::UnterminatedRegexLiteral;
+        } else {
+            consume();
+        }
     } else if (m_current_char == EOF) {
         token_type = TokenType::Eof;
     } else {
@@ -473,28 +496,6 @@ Token Lexer::next()
         if (!found_four_char_token && !found_three_char_token && !found_two_char_token && !found_one_char_token) {
             consume();
             token_type = TokenType::Invalid;
-        } else if (token_type == TokenType::Slash && !slash_means_division()) {
-            token_type = TokenType::RegexLiteral;
-
-            while (!is_eof()) {
-                if (m_current_char == '[') {
-                    m_regex_is_in_character_class = true;
-                } else if (m_current_char == ']') {
-                    m_regex_is_in_character_class = false;
-                } else if (!m_regex_is_in_character_class && m_current_char == '/') {
-                    break;
-                }
-
-                if (match('\\', '/') || match('\\', '[') || match('\\', '\\') || (m_regex_is_in_character_class && match('\\', ']')))
-                    consume();
-                consume();
-            }
-
-            if (is_eof()) {
-                token_type = TokenType::UnterminatedRegexLiteral;
-            } else {
-                consume();
-            }
         }
     }
 

--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -485,7 +485,7 @@ Token Lexer::next()
                     break;
                 }
 
-                if (match('\\', '/') || match('\\', '[') || (m_regex_is_in_character_class && match('\\', ']')))
+                if (match('\\', '/') || match('\\', '[') || match('\\', '\\') || (m_regex_is_in_character_class && match('\\', ']')))
                     consume();
                 consume();
             }


### PR DESCRIPTION
- Fix `/=/` parsing into a `SlashEquals` token instead of a `RegexLiteral`
- Fix incorrectly handling an escaped backslash (`/\\/`)