### PR TITLE
LibJS+js: Support getting last value from "_" variable

### DIFF
--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -70,7 +70,9 @@ Value Interpreter::run(const Statement& statement, ArgumentVector arguments, Sco
     auto& block = static_cast<const ScopeNode&>(statement);
     enter_scope(block, move(arguments), scope_type);
 
-    m_last_value = js_undefined();
+    if (block.children().is_empty())
+        m_last_value = js_undefined();
+
     for (auto& node : block.children()) {
         m_last_value = node.execute(*this);
         if (should_unwind()) {
@@ -176,7 +178,10 @@ Value Interpreter::get_variable(const FlyString& name)
                 return possible_match.value().value;
         }
     }
-    return global_object().get(name);
+    auto value = global_object().get(name);
+    if (m_underscore_is_last_value && name == "_" && value.is_empty())
+        return m_last_value;
+    return value;
 }
 
 Reference Interpreter::get_reference(const FlyString& name)

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -177,6 +177,9 @@ public:
 
     Value last_value() const { return m_last_value; }
 
+    bool underscore_is_last_value() const { return m_underscore_is_last_value; }
+    void set_underscore_is_last_value(bool b) { m_underscore_is_last_value = b; }
+
     Console& console() { return m_console; }
     const Console& console() const { return m_console; }
 
@@ -198,6 +201,8 @@ private:
 
     ScopeType m_unwind_until { ScopeType::None };
     FlyString m_unwind_until_label;
+
+    bool m_underscore_is_last_value { false };
 
     Console m_console;
 };

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -575,6 +575,7 @@ int main(int argc, char** argv)
         ReplConsoleClient console_client(interpreter->console());
         interpreter->console().set_client(console_client);
         interpreter->heap().set_should_collect_on_every_allocation(gc_on_every_allocation);
+        interpreter->set_underscore_is_last_value(true);
         if (test_mode)
             enable_test_mode(*interpreter);
 


### PR DESCRIPTION
As seen in the Node.js, Python, Ruby, ... REPLs:

The interpreter now has an "underscore is last value" flag, which makes `Interpreter::get_variable()` return the last value if:

- The `m_underscore_is_last_value` flag is enabled
- The name of the variable lookup is "_"
- The result of that lookup is an empty value

That means "_" can still be used as a regular variable and will stop doing its magic once anything is assigned to it.

Example REPL session:

```
> 1
1
> _ + _
2
> _ + _
4
> _ = "foo"
"foo"
> 1
1
> _
"foo"
> delete _
true
> 1
1
> _
1
>
```