### PR TITLE
LibJS: Initial support for classes

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1364,23 +1364,9 @@ Value ObjectExpression::execute(Interpreter& interpreter, GlobalObject& global_o
 
         if (property.type() == ObjectProperty::Type::Getter || property.type() == ObjectProperty::Type::Setter) {
             ASSERT(value.is_function());
-            Accessor* accessor { nullptr };
-            auto property_metadata = object->shape().lookup(key);
-            if (property_metadata.has_value()) {
-                auto existing_property = object->get_direct(property_metadata.value().offset);
-                if (existing_property.is_accessor())
-                    accessor = &existing_property.as_accessor();
-            }
-            if (!accessor) {
-                accessor = Accessor::create(interpreter, global_object, nullptr, nullptr);
-                object->define_property(key, accessor, Attribute::Configurable | Attribute::Enumerable);
-                if (interpreter.exception())
-                    return {};
-            }
-            if (property.type() == ObjectProperty::Type::Getter)
-                accessor->set_getter(&value.as_function());
-            else
-                accessor->set_setter(&value.as_function());
+            object->define_accessor(key, value.as_function(), property.type() == ObjectProperty::Type::Getter, Attribute::Configurable | Attribute::Enumerable);
+            if (interpreter.exception())
+                return {};
         } else {
             object->define_property(key, value);
             if (interpreter.exception())

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -192,6 +192,10 @@ public:
 
     String join_arguments() const;
 
+    Value resolve_this_binding() const;
+    const LexicalEnvironment* get_this_environment() const;
+    Value get_new_target() const;
+
 private:
     Interpreter();
 

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -46,7 +46,7 @@ public:
     NonnullRefPtr<Program> parse_program();
 
     template<typename FunctionNodeType>
-    NonnullRefPtr<FunctionNodeType> parse_function_node(bool check_for_function_and_name = true);
+    NonnullRefPtr<FunctionNodeType> parse_function_node(bool check_for_function_and_name = true, bool allow_super_property_lookup = false, bool allow_super_constructor_call = false);
 
     NonnullRefPtr<Statement> parse_statement();
     NonnullRefPtr<BlockStatement> parse_block_statement();
@@ -80,6 +80,9 @@ public:
     NonnullRefPtr<NewExpression> parse_new_expression();
     RefPtr<FunctionExpression> try_parse_arrow_function_expression(bool expect_parens);
     RefPtr<Statement> try_parse_labelled_statement();
+    NonnullRefPtr<ClassDeclaration> parse_class_declaration();
+    NonnullRefPtr<ClassExpression> parse_class_expression(bool expect_class_name);
+    NonnullRefPtr<Expression> parse_property_key();
 
     struct Error {
         String message;
@@ -126,6 +129,7 @@ private:
     bool match_statement() const;
     bool match_variable_declaration() const;
     bool match_identifier_name() const;
+    bool match_property_key() const;
     bool match(TokenType type) const;
     bool done() const;
     void expected(const char* what);
@@ -151,6 +155,8 @@ private:
         Vector<NonnullRefPtrVector<FunctionDeclaration>> m_function_scopes;
         UseStrictDirectiveState m_use_strict_directive { UseStrictDirectiveState::None };
         bool m_strict_mode { false };
+        bool m_allow_super_property_lookup { false };
+        bool m_allow_super_constructor_call { false };
 
         explicit ParserState(Lexer);
     };

--- a/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -74,7 +74,7 @@ Value BigIntConstructor::call(Interpreter& interpreter)
 
 Value BigIntConstructor::construct(Interpreter& interpreter)
 {
-    interpreter.throw_exception<TypeError>(ErrorType::NotACtor, "BigInt");
+    interpreter.throw_exception<TypeError>(ErrorType::NotAConstructor, "BigInt");
     return {};
 }
 

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -36,6 +36,7 @@
     M(BigIntBadOperatorOtherType, "Cannot use %s operator with BigInt and other type")                 \
     M(BigIntIntArgument, "BigInt argument must be an integer")                                         \
     M(BigIntInvalidValue, "Invalid value for BigInt: %s")                                              \
+    M(ClassDoesNotExtendAConstructorOrNull, "Class extends value %s is not a constructor or null")     \
     M(Convert, "Cannot convert %s to %s")                                                              \
     M(ConvertUndefinedToObject, "Cannot convert undefined to object")                                  \
     M(DescChangeNonConfigurable, "Cannot change attributes of non-configurable property '%s'")         \
@@ -51,7 +52,7 @@
     M(JsonCircular, "Cannot stringify circular object")                                                \
     M(JsonMalformed, "Malformed JSON string")                                                          \
     M(NotA, "Not a %s object")                                                                         \
-    M(NotACtor, "%s is not a constructor")                                                             \
+    M(NotAConstructor, "%s is not a constructor")                                                      \
     M(NotAFunction, "%s is not a function")                                                            \
     M(NotAFunctionNoParam, "Not a function")                                                           \
     M(NotAn, "Not an %s object")                                                                       \
@@ -63,6 +64,8 @@
     M(ObjectSetPrototypeOfReturnedFalse, "Object's [[SetPrototypeOf]] method returned false")          \
     M(ObjectSetPrototypeOfTwoArgs, "Object.setPrototypeOf requires at least two arguments")            \
     M(ObjectPreventExtensionsReturnedFalse, "Object's [[PreventExtensions]] method returned false")    \
+    M(ObjectPrototypeNullOrUndefinedOnSuperPropertyAccess,                                             \
+        "Object prototype must not be %s on a super property access")                                  \
     M(ObjectPrototypeWrongType, "Prototype must be an object or null")                                 \
     M(ProxyCallWithNew, "Proxy must be called with the 'new' operator")                                \
     M(ProxyConstructorBadType, "Expected %s argument of Proxy constructor to be object, got %s")       \
@@ -138,6 +141,8 @@
     M(ReflectBadDescriptorArgument, "Descriptor argument is not an object")                            \
     M(StringRawCannotConvert, "Cannot convert property 'raw' to object from %s")                       \
     M(StringRepeatCountMustBe, "repeat count must be a %s number")                                     \
+    M(ThisHasNotBeenInitialized, "|this| has not been initialized")                                    \
+    M(ThisIsAlreadyInitialized, "|this| is already initialized")                                       \
     M(ToObjectNullOrUndef, "ToObject on null or undefined")                                            \
     M(UnknownIdentifier, "'%s' is not defined")                                                        \
     /* LibWeb bindings */                                                                              \

--- a/Libraries/LibJS/Runtime/Function.h
+++ b/Libraries/LibJS/Runtime/Function.h
@@ -35,6 +35,11 @@ class Function : public Object {
     JS_OBJECT(Function, Object);
 
 public:
+    enum class ConstructorKind {
+        Base,
+        Derived,
+    };
+
     virtual ~Function();
     virtual void initialize(Interpreter&, GlobalObject&) override { }
 
@@ -49,15 +54,15 @@ public:
 
     BoundFunction* bind(Value bound_this_value, Vector<Value> arguments);
 
-    Value bound_this() const
-    {
-        return m_bound_this;
-    }
+    Value bound_this() const { return m_bound_this; }
 
-    const Vector<Value>& bound_arguments() const
-    {
-        return m_bound_arguments;
-    }
+    const Vector<Value>& bound_arguments() const { return m_bound_arguments; }
+
+    Value home_object() const { return m_home_object; }
+    void set_home_object(Value home_object) { m_home_object = home_object; }
+
+    ConstructorKind constructor_kind() const { return m_constructor_kind; };
+    void set_constructor_kind(ConstructorKind constructor_kind) { m_constructor_kind = constructor_kind; }
 
 protected:
     explicit Function(Object& prototype);
@@ -67,6 +72,8 @@ private:
     virtual bool is_function() const final { return true; }
     Value m_bound_this;
     Vector<Value> m_bound_arguments;
+    Value m_home_object;
+    ConstructorKind m_constructor_kind = ConstructorKind::Base;
 };
 
 }

--- a/Libraries/LibJS/Runtime/LexicalEnvironment.h
+++ b/Libraries/LibJS/Runtime/LexicalEnvironment.h
@@ -40,11 +40,27 @@ struct Variable {
 
 class LexicalEnvironment final : public Cell {
 public:
+    enum class ThisBindingStatus {
+        Lexical,
+        Initialized,
+        Uninitialized,
+    };
+
+    enum class EnvironmentRecordType {
+        Declarative,
+        Function,
+        Global,
+        Object,
+        Module,
+    };
+
     LexicalEnvironment();
+    LexicalEnvironment(EnvironmentRecordType);
     LexicalEnvironment(HashMap<FlyString, Variable> variables, LexicalEnvironment* parent);
+    LexicalEnvironment(HashMap<FlyString, Variable> variables, LexicalEnvironment* parent, EnvironmentRecordType);
     virtual ~LexicalEnvironment() override;
 
-    LexicalEnvironment* parent() { return m_parent; }
+    LexicalEnvironment* parent() const { return m_parent; }
 
     Optional<Variable> get(const FlyString&) const;
     void set(const FlyString&, Variable);
@@ -53,12 +69,37 @@ public:
 
     const HashMap<FlyString, Variable>& variables() const { return m_variables; }
 
+    void set_home_object(Value object) { m_home_object = object; }
+    bool has_super_binding() const;
+    Value get_super_base();
+
+    bool has_this_binding() const;
+    ThisBindingStatus this_binding_status() const { return m_this_binding_status; }
+    Value get_this_binding() const;
+    void bind_this_value(Value this_value);
+
+    // Not a standard operation.
+    void replace_this_binding(Value this_value) { m_this_value = this_value; }
+
+    Value new_target() const { return m_new_target; };
+    void set_new_target(Value new_target) { m_new_target = new_target; }
+
+    Function* current_function() const { return m_current_function; }
+    void set_current_function(Function& function) { m_current_function = &function; }
+
 private:
     virtual const char* class_name() const override { return "LexicalEnvironment"; }
     virtual void visit_children(Visitor&) override;
 
     LexicalEnvironment* m_parent { nullptr };
     HashMap<FlyString, Variable> m_variables;
+    EnvironmentRecordType m_environment_record_type = EnvironmentRecordType::Declarative;
+    ThisBindingStatus m_this_binding_status = ThisBindingStatus::Uninitialized;
+    Value m_home_object;
+    Value m_this_value;
+    Value m_new_target;
+    // Corresponds to [[FunctionObject]]
+    Function* m_current_function { nullptr };
 };
 
 }

--- a/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -68,4 +68,9 @@ Value NativeFunction::construct(Interpreter&)
     return {};
 }
 
+LexicalEnvironment* NativeFunction::create_environment()
+{
+    return interpreter().heap().allocate<LexicalEnvironment>(global_object(), LexicalEnvironment::EnvironmentRecordType::Function);
+}
+
 }

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -53,7 +53,7 @@ protected:
 
 private:
     virtual bool is_native_function() const override { return true; }
-    virtual LexicalEnvironment* create_environment() override final { return nullptr; }
+    virtual LexicalEnvironment* create_environment() override final;
 
     FlyString m_name;
     AK::Function<Value(Interpreter&, GlobalObject&)> m_native_function;

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -437,7 +437,7 @@ bool Object::define_accessor(PropertyName property_name, Function& getter_or_set
             accessor = &existing_property.as_accessor();
     }
     if (!accessor) {
-        accessor = Accessor::create(interpreter(), nullptr, nullptr);
+        accessor = Accessor::create(interpreter(), global_object(), nullptr, nullptr);
         bool definition_success = define_property(property_name, accessor, attributes, throw_exceptions);
         if (interpreter().exception())
             return {};

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -98,6 +98,7 @@ public:
 
     virtual bool define_property(const FlyString& property_name, const Object& descriptor, bool throw_exceptions = true);
     bool define_property(PropertyName, Value value, PropertyAttributes attributes = default_attributes, bool throw_exceptions = true);
+    bool define_accessor(PropertyName, Function& getter_or_setter, bool is_getter, PropertyAttributes attributes = default_attributes, bool throw_exceptions = true);
 
     bool define_native_function(const FlyString& property_name, AK::Function<Value(Interpreter&, GlobalObject&)>, i32 length = 0, PropertyAttributes attributes = default_attributes);
     bool define_native_property(const FlyString& property_name, AK::Function<Value(Interpreter&, GlobalObject&)> getter, AK::Function<void(Interpreter&, GlobalObject&, Value)> setter, PropertyAttributes attributes = default_attributes);

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -66,8 +66,11 @@ ScriptFunction::ScriptFunction(GlobalObject& global_object, const FlyString& nam
 void ScriptFunction::initialize(Interpreter& interpreter, GlobalObject& global_object)
 {
     Function::initialize(interpreter, global_object);
-    if (!m_is_arrow_function)
-        define_property("prototype", Object::create_empty(interpreter, global_object), 0);
+    if (!is_arrow_function) {
+        Object* prototype = Object::create_empty(interpreter(), interpreter().global_object());
+        prototype->define_property("constructor", this, Attribute::Writable | Attribute::Configurable);
+        define_property("prototype", prototype, 0);
+    }
     define_native_property("length", length_getter, nullptr, Attribute::Configurable);
     define_native_property("name", name_getter, nullptr, Attribute::Configurable);
 }

--- a/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -76,7 +76,7 @@ Value SymbolConstructor::call(Interpreter& interpreter)
 
 Value SymbolConstructor::construct(Interpreter& interpreter)
 {
-    interpreter.throw_exception<TypeError>(ErrorType::NotACtor, "Symbol");
+    interpreter.throw_exception<TypeError>(ErrorType::NotAConstructor, "Symbol");
     return {};
 }
 

--- a/Libraries/LibJS/Tests/class-basic.js
+++ b/Libraries/LibJS/Tests/class-basic.js
@@ -1,0 +1,248 @@
+load("test-common.js");
+
+try {
+    class X {
+        constructor() {
+            this.x = 3;
+        }
+        getX() {
+            return 3;
+        }
+
+        init() {
+            this.y = 3;
+        }
+    }
+
+    assert(X.name === "X");
+    assert(X.length === 0);
+
+    class Y extends X {
+        init() {
+            super.init();
+            this.y += 3;
+        }
+    }
+
+    assert(new Y().getX() === 3);
+    assert(new Y().x === 3);
+
+    let x = new X();
+    assert(x.x === 3);
+    assert(x.getX() === 3);
+
+    let y = new Y();
+    assert(y.x === 3);
+    assert(y.y === undefined);
+    y.init();
+    assert(y.y === 6);
+    assert(y.hasOwnProperty("y"));
+
+    class Foo {
+        constructor(x) {
+            this.x = x;
+        }
+    }
+    assert(Foo.length === 1);
+
+    class Bar extends Foo {
+        constructor() {
+            super(5);
+        }
+    }
+
+    class Baz {
+        "constructor"() {
+            this.foo = 55;
+            this._bar = 33;
+        }
+
+        get bar() {
+            return this._bar;
+        }
+
+        set bar(value) {
+            this._bar = value;
+        }
+
+        ["get" + "Foo"]() {
+            return this.foo;
+        }
+
+        static get staticFoo() {
+            assert(this === Baz);
+            return 11;
+        }
+    }
+
+
+    let barPropertyDescriptor = Object.getOwnPropertyDescriptor(Baz.prototype, "bar");
+    assert(barPropertyDescriptor.get.name === "get bar");
+    assert(barPropertyDescriptor.set.name === "set bar");
+
+    let baz = new Baz();
+    assert(baz.foo === 55);
+    assert(baz.bar === 33);
+    baz.bar = 22;
+    assert(baz.bar === 22);
+
+    assert(baz.getFoo() === 55);
+    assert(Baz.staticFoo === 11);
+
+    assert(new Bar().x === 5);
+
+    class ExtendsFunction extends function () { this.foo = 22; } { }
+    assert(new ExtendsFunction().foo === 22);
+
+    class ExtendsString extends String { }
+    assert(new ExtendsString() instanceof String);
+    assert(new ExtendsString() instanceof ExtendsString);
+    assert(new ExtendsString("abc").charAt(1) === "b");
+
+    class MyWeirdString extends ExtendsString {
+        charAt(i) {
+            return "#" + super.charAt(i);
+        }
+    }
+    assert(new MyWeirdString("abc").charAt(1) === "#b")
+
+    class ExtendsNull extends null { }
+
+    assertThrowsError(() => {
+        new ExtendsNull();
+    }, {
+        error: ReferenceError
+    });
+    assert(Object.getPrototypeOf(ExtendsNull.prototype) === null);
+
+    class ExtendsClassExpression extends class { constructor(x) { this.x = x; } } {
+        constructor(y) {
+            super(5);
+            this.y = 6;
+        }
+    }
+    let extendsClassExpression = new ExtendsClassExpression();
+    assert(extendsClassExpression.x === 5);
+    assert(extendsClassExpression.y === 6);
+
+    class InStrictMode {
+        constructor() {
+            assert(isStrictMode());
+        }
+
+        method() {
+            assert(isStrictMode());
+        }
+    }
+
+    let resultOfAnExpression = new (class {
+        constructor(x) {
+            this.x = x;
+        }
+        getX() {
+            return this.x + 10;
+        }
+    })(55);
+    assert(resultOfAnExpression.x === 55);
+    assert(resultOfAnExpression.getX() === 65);
+
+    let ClassExpression = class Foo { };
+    assert(ClassExpression.name === "Foo");
+
+    new InStrictMode().method();
+    assert(!isStrictMode());
+
+    assertIsSyntaxError(`
+        class GetterWithArgument {
+            get foo(bar) {
+                return 0;
+            }
+        }
+    `);
+
+    assertIsSyntaxError(`
+        class SetterWithNoArgumetns {
+            set foo() {
+            }
+        }
+    `);
+
+    assertIsSyntaxError(`
+        class SetterWithMoreThanOneArgument {
+            set foo(bar, baz) {
+            }
+        }
+    `);
+
+    assertIsSyntaxError(`
+        class FooBase {}
+        class IsASyntaxError extends FooBase {
+            bar() {
+                function f() { super.baz; }
+            }
+        }
+    `);
+
+    assertIsSyntaxError(`
+        class NoBaseSuper {
+            constructor() {
+                super();
+            }
+        }
+    `);
+
+    assertThrowsError(() => {
+        class BadExtends extends 3 { }
+
+    }, {
+        error: TypeError
+    });
+
+    assertThrowsError(() => {
+        class BadExtends extends undefined { }
+    }, {
+        error: TypeError
+    });
+
+    class SuperNotASyntaxError {
+        bar() {
+            () => { super.baz };
+        }
+    }
+
+    class SuperNoBasePropertyLookup {
+        constructor() {
+            super.foo;
+        }
+    }
+
+    assertThrowsError(() => {
+        class Base { }
+        class DerivedDoesntCallSuper extends Base {
+            constructor() {
+                this;
+            }
+        }
+
+        new DerivedDoesntCallSuper();
+    }, {
+        error: ReferenceError,
+    });
+    assertThrowsError(() => {
+        class Base { }
+        class CallsSuperTwice extends Base {
+            constructor() {
+                super();
+                super();
+            }
+        }
+
+        new CallsSuperTwice();
+    }, {
+        error: ReferenceError,
+    });
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/constructor-basic.js
+++ b/Libraries/LibJS/Tests/constructor-basic.js
@@ -1,7 +1,17 @@
-function Foo() {
-    this.x = 123;
-}
+load("test-common.js");
 
-var foo = new Foo();
-if (foo.x === 123)
-    console.log("PASS");
+try {
+  function Foo() {
+      this.x = 123;
+  }
+
+  assert(Foo.prototype.constructor === Foo);
+
+  var foo = new Foo();
+  assert(foo.constructor === Foo);
+  assert(foo.x === 123);
+
+  console.log("PASS");
+} catch (e) {
+  console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -70,6 +70,22 @@ try {
     assert(a[2] === 3);
     assert(o4.test === undefined);
 
+    var base = {
+        getNumber() {
+            return 10;
+        }
+    };
+
+    var derived = {
+        getNumber() {
+            return 20 + super.getNumber();
+        }
+    };
+
+    Object.setPrototypeOf(derived, base)
+    assert(derived.getNumber() === 30);
+
+    assertIsSyntaxError("({ foo: function() { super.bar; } })")
     assertIsSyntaxError("({ get ...foo })");
     assertIsSyntaxError("({ get... foo })");
     assertIsSyntaxError("({ get foo })");


### PR DESCRIPTION
This PR adds an initial implementation of classes.
A small example:
![image](https://user-images.githubusercontent.com/792121/84068467-99dbf200-a98e-11ea-82ba-7932eea4baf7.png)


TODO:
- [x] Computed method names
- [x] Getter and setter methods
- [x] Class expressions
- [x] Allow `super` in object literal methods
- [x] Require the `super` constructor to be called before properties on `this` are used in a class constructor
- [x] Don't allow use of `super` outside of class/object methods or class constructors
- [x] Clean up the code
- [x] Handle exceptions and parse errors
- [x] Add more tests
- [x] Dump the class AST

Non-goals for now:
- Class fields and private fields, i.e.
```js
class Foo {
  bar = "baz";
  #privateBar = "private field";
}
```