### PR TITLE
Multi-instance services & accept socket connections

### DIFF
--- a/Base/usr/share/man/man5/SystemServer.md
+++ b/Base/usr/share/man/man5/SystemServer.md
@@ -28,6 +28,14 @@ describing how to launch and manage this service.
 * `WorkingDirectory` - the working directory in which the service is spawned. By default, services are spawned in the root (`"/"`) directory.
 * `BootModes` - a comma-separated list of boot modes the service should be enabled in. By default, services are only enabled in the "graphical" mode. The current boot mode is read from the kernel command line, and is assumed to be "graphical" if not specified there.
 * `Environment` - a space-separated list of "variable=value" pairs to set in the environment for the service.
+* `MultiInstance` - whether multiple instances of the service can be running simultaneously.
+* `AcceptSocketConnections` - whether SystemServer should accept connections on the socket, and spawn an instance of the service for each client connection.
+
+Note that:
+* `Lazy` requires a `Socket`.
+* `SocketPermissions` require a `Socket`.
+* `MultiInstance` conflicts with `KeepAlive`.
+* `AcceptSocketConnections` requires `Socket`, `Lazy`, and `MultiInstance`.
 
 ## Environment
 

--- a/Base/usr/share/man/man7/SystemServer.md
+++ b/Base/usr/share/man/man7/SystemServer.md
@@ -42,6 +42,10 @@ configured to be *kept alive*, it can even exit after some period of inactivity;
 in this case SystemServer will respawn it again once there is a new connection
 to its socket.
 
+SystemServer can also be configured to accept connections on the socket and
+spawn separate instances of the service for each accepted connection, passing
+the accepted socket to the service process.
+
 ## See also
 
 * [`SystemServer`(5)](../man5/SystemServer.md)

--- a/Services/SystemServer/Service.h
+++ b/Services/SystemServer/Service.h
@@ -47,7 +47,7 @@ public:
 private:
     Service(const Core::ConfigFile&, const StringView& name);
 
-    void spawn();
+    void spawn(int socket_fd = -1);
 
     // Path to the executable. By default this is /bin/{m_name}.
     String m_executable_path;
@@ -62,6 +62,10 @@ private:
     String m_socket_path;
     // File system permissions for the socket.
     mode_t m_socket_permissions { 0 };
+    // Whether we should accept connections on the socket and pass the accepted
+    // (and not listening) socket to the service. This requires a multi-instance
+    // service.
+    bool m_accept_socket_connections { false };
     // Whether we should only spawn this service once somebody connects to the socket.
     bool m_lazy;
     // The name of the user we should run this service as.
@@ -93,4 +97,5 @@ private:
     void resolve_user();
     void setup_socket();
     void setup_notifier();
+    void handle_socket_connection();
 };

--- a/Services/SystemServer/Service.h
+++ b/Services/SystemServer/Service.h
@@ -73,10 +73,12 @@ private:
     String m_working_directory;
     // Boot modes to run this service in. By default, this is the graphical mode.
     Vector<String> m_boot_modes;
+    // Whether several instances of this service can run at once.
+    bool m_multi_instance { false };
     // Environment variables to pass to the service.
     Vector<String> m_environment;
 
-    // PID of the running instance of this service.
+    // For single-instance services, PID of the running instance of this service.
     pid_t m_pid { -1 };
     // An open fd to the socket.
     int m_socket_fd { -1 };

--- a/Services/SystemServer/main.cpp
+++ b/Services/SystemServer/main.cpp
@@ -47,10 +47,10 @@ static void sigchld_handler(int)
     if (!pid)
         return;
 
-    dbg() << "Reaped child with pid " << pid;
+    dbg() << "Reaped child with pid " << pid << ", exist status " << status;
     Service* service = Service::find_by_pid(pid);
     if (service == nullptr) {
-        dbg() << "There was no service with this pid, what is going on?";
+        // This can happen for multi-instance services.
         return;
     }
 


### PR DESCRIPTION
You can now ask SystemServer to not only listen for connections on the socket, but to actually accept them, and to spawn an instance of the service for each client connection. In this case, it's the accepted, not listening, socket that the service processes will receive using socket takeover.

I haven't added a helper like the existing `Core::LocalServer::take_over_from_system_server()` to `Core::LocalSocket`, because I don't want to duplicate the logic, and I have no idea where a shared version of this could live. Suggestions welcome.