### PR TITLE
Ports: Use keyserver.ubuntu.com as .sig keyserver.

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -52,7 +52,9 @@ func_defined post_fetch || post_fetch() {
 fetch() {
     if [ "$auth_type" == "sig" ] && [ ! -z "${auth_import_key}" ]; then
         # import gpg key if not existing locally
-        gpg --list-keys $auth_import_key || gpg --recv-key $auth_import_key
+        # The default keyserver keys.openpgp.org prints "new key but contains no user ID - skipped"
+        # and fails. Use a different key server.
+        gpg --list-keys $auth_import_key || gpg --keyserver hkps://keyserver.ubuntu.com --recv-key $auth_import_key
     fi
 
     OLDIFS=$IFS


### PR DESCRIPTION
Increases the number of successfully building ports from
27 to 36 (of 56) on my system.

Before: http://codepad.org/zsED2a52
Now:    http://codepad.org/ms2meH42

See also https://dev.gnupg.org/T4604#127788

(But, as usual, no idea if this is the officially sanctioned way of doing things. The change feels a bit weird, but so does the error message.)