### PR TITLE
LibGfx: Return correct color for palette.hover_highlight()

### DIFF
--- a/Libraries/LibGfx/Palette.h
+++ b/Libraries/LibGfx/Palette.h
@@ -91,7 +91,7 @@ public:
     Color threed_highlight() const { return color(ColorRole::ThreedHighlight); }
     Color threed_shadow1() const { return color(ColorRole::ThreedShadow1); }
     Color threed_shadow2() const { return color(ColorRole::ThreedShadow2); }
-    Color hover_highlight() const { return color(ColorRole::ThreedHighlight); }
+    Color hover_highlight() const { return color(ColorRole::HoverHighlight); }
     Color rubber_band_fill() const { return color(ColorRole::RubberBandFill); }
     Color rubber_band_border() const { return color(ColorRole::RubberBandBorder); }
     Color ruler() const { return color(ColorRole::Ruler); }


### PR DESCRIPTION
Now correctly returns HoverHighlight instead of ThreedHighlight.