### PR TITLE
LibJS+AK: Add JSON object, AK JsonParser improvements

### DIFF
--- a/AK/JsonParser.h
+++ b/AK/JsonParser.h
@@ -40,23 +40,24 @@ public:
     {
     }
 
-    JsonValue parse();
+    Optional<JsonValue> parse();
 
 private:
+    Optional<JsonValue> parse_helper();
+
     char peek() const;
     char consume();
     void consume_whitespace();
-    void consume_specific(char expected_ch);
-    void consume_string(const char*);
+    bool consume_specific(char expected_ch);
+    bool consume_string(const char*);
     String consume_quoted_string();
-    JsonArray parse_array();
-    JsonObject parse_object();
-    JsonValue parse_number();
-    JsonValue parse_string();
-    JsonValue parse_false();
-    JsonValue parse_true();
-    JsonValue parse_null();
-    JsonValue parse_undefined();
+    Optional<JsonValue> parse_array();
+    Optional<JsonValue> parse_object();
+    Optional<JsonValue> parse_number();
+    Optional<JsonValue> parse_string();
+    Optional<JsonValue> parse_false();
+    Optional<JsonValue> parse_true();
+    Optional<JsonValue> parse_null();
 
     template<typename C>
     void consume_while(C);

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -75,7 +75,7 @@ void JsonValue::copy_from(const JsonValue& other)
 
 JsonValue::JsonValue(JsonValue&& other)
 {
-    m_type = exchange(other.m_type, Type::Undefined);
+    m_type = exchange(other.m_type, Type::Null);
     m_value.as_string = exchange(other.m_value.as_string, nullptr);
 }
 
@@ -83,7 +83,7 @@ JsonValue& JsonValue::operator=(JsonValue&& other)
 {
     if (this != &other) {
         clear();
-        m_type = exchange(other.m_type, Type::Undefined);
+        m_type = exchange(other.m_type, Type::Null);
         m_value.as_string = exchange(other.m_value.as_string, nullptr);
     }
     return *this;
@@ -247,11 +247,11 @@ void JsonValue::clear()
     default:
         break;
     }
-    m_type = Type::Undefined;
+    m_type = Type::Null;
     m_value.as_string = nullptr;
 }
 
-JsonValue JsonValue::from_string(const StringView& input)
+Optional<JsonValue> JsonValue::from_string(const StringView& input)
 {
     return JsonParser(input).parse();
 }

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -37,7 +37,6 @@ namespace AK {
 class JsonValue {
 public:
     enum class Type {
-        Undefined,
         Null,
         Int32,
         UnsignedInt32,
@@ -52,7 +51,7 @@ public:
         Object,
     };
 
-    static JsonValue from_string(const StringView&);
+    static Optional<JsonValue> from_string(const StringView&);
 
     explicit JsonValue(Type = Type::Null);
     ~JsonValue() { clear(); }
@@ -188,7 +187,6 @@ public:
     }
 
     bool is_null() const { return m_type == Type::Null; }
-    bool is_undefined() const { return m_type == Type::Undefined; }
     bool is_bool() const { return m_type == Type::Bool; }
     bool is_string() const { return m_type == Type::String; }
     bool is_i32() const { return m_type == Type::Int32; }
@@ -246,7 +244,7 @@ private:
     void clear();
     void copy_from(const JsonValue&);
 
-    Type m_type { Type::Undefined };
+    Type m_type { Type::Null };
 
     union {
         StringImpl* as_string { nullptr };

--- a/AK/Tests/TestJSON.cpp
+++ b/AK/Tests/TestJSON.cpp
@@ -48,7 +48,7 @@ TEST_CASE(load_form)
 
     fclose(fp);
 
-    JsonValue form_json = JsonValue::from_string(builder.to_string());
+    JsonValue form_json = JsonValue::from_string(builder.to_string()).value();
 
     EXPECT(form_json.is_object());
 
@@ -87,14 +87,14 @@ BENCHMARK_CASE(load_4chan_catalog)
     auto json_string = builder.to_string();
 
     for (int i = 0; i < 10; ++i) {
-        JsonValue form_json = JsonValue::from_string(json_string);
+        JsonValue form_json = JsonValue::from_string(json_string).value();
         EXPECT(form_json.is_array());
     }
 }
 
 TEST_CASE(json_empty_string)
 {
-    auto json = JsonValue::from_string("\"\"");
+    auto json = JsonValue::from_string("\"\"").value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
     EXPECT_EQ(json.as_string().is_null(), false);
     EXPECT_EQ(json.as_string().is_empty(), true);
@@ -102,7 +102,7 @@ TEST_CASE(json_empty_string)
 
 TEST_CASE(json_utf8_character)
 {
-    auto json = JsonValue::from_string("\"\xc3\x84\"");
+    auto json = JsonValue::from_string("\"\xc3\x84\"").value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
     EXPECT_EQ(json.as_string().is_null(), false);
     EXPECT_EQ(json.as_string().length(), size_t { 2 });

--- a/Applications/SystemMonitor/DevicesModel.cpp
+++ b/Applications/SystemMonitor/DevicesModel.cpp
@@ -127,10 +127,11 @@ void DevicesModel::update()
     if (!proc_devices->open(Core::IODevice::OpenMode::ReadOnly))
         ASSERT_NOT_REACHED();
 
-    auto json = JsonValue::from_string(proc_devices->read_all()).as_array();
+    auto json = JsonValue::from_string(proc_devices->read_all());
+    ASSERT(json.has_value());
 
     m_devices.clear();
-    json.for_each([this](auto& value) {
+    json.value().as_array().for_each([this](auto& value) {
         JsonObject device = value.as_object();
         DeviceInfo device_info;
 

--- a/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -98,7 +98,9 @@ void MemoryStatsWidget::refresh()
         ASSERT_NOT_REACHED();
 
     auto file_contents = proc_memstat->read_all();
-    auto json = JsonValue::from_string(file_contents).as_object();
+    auto json_result = JsonValue::from_string(file_contents);
+    ASSERT(json_result.has_value());
+    auto json = json_result.value().as_object();
 
     unsigned kmalloc_eternal_allocated = json.get("kmalloc_eternal_allocated").to_u32();
     (void)kmalloc_eternal_allocated;

--- a/DevTools/FormCompiler/main.cpp
+++ b/DevTools/FormCompiler/main.cpp
@@ -46,7 +46,9 @@ int main(int argc, char** argv)
     }
 
     auto file_contents = file->read_all();
-    auto json = JsonValue::from_string(file_contents);
+    auto json_result = JsonValue::from_string(file_contents);
+    ASSERT(json_result.has_value());
+    auto json = json_result.value();
 
     if (!json.is_object()) {
         fprintf(stderr, "Malformed input\n");

--- a/DevTools/Inspector/RemoteProcess.cpp
+++ b/DevTools/Inspector/RemoteProcess.cpp
@@ -167,11 +167,12 @@ void RemoteProcess::update()
         dbg() << "Got data size " << length << " and read that many bytes";
 
         auto json_value = JsonValue::from_string(data);
-        ASSERT(json_value.is_object());
+        ASSERT(json_value.has_value());
+        ASSERT(json_value.value().is_object());
 
-        dbg() << "Got JSON response " << json_value.to_string();
+        dbg() << "Got JSON response " << json_value.value().to_string();
 
-        auto& response = json_value.as_object();
+        auto& response = json_value.value().as_object();
 
         auto response_type = response.get("type").as_string_or({});
         if (response_type.is_null())

--- a/DevTools/ProfileViewer/Profile.cpp
+++ b/DevTools/ProfileViewer/Profile.cpp
@@ -172,12 +172,13 @@ OwnPtr<Profile> Profile::load_from_perfcore_file(const StringView& path)
     }
 
     auto json = JsonValue::from_string(file->read_all());
-    if (!json.is_object()) {
+    ASSERT(json.has_value());
+    if (!json.value().is_object()) {
         fprintf(stderr, "Invalid perfcore format (not a JSON object)\n");
         return nullptr;
     }
 
-    auto& object = json.as_object();
+    auto& object = json.value().as_object();
     auto executable_path = object.get("executable").to_string();
 
     MappedFile elf_file(executable_path);

--- a/DevTools/VisualBuilder/VBForm.cpp
+++ b/DevTools/VisualBuilder/VBForm.cpp
@@ -389,14 +389,15 @@ void VBForm::load_from_file(const String& path)
 
     auto file_contents = file->read_all();
     auto form_json = JsonValue::from_string(file_contents);
+    ASSERT(form_json.has_value());
 
-    if (!form_json.is_object()) {
+    if (!form_json.value().is_object()) {
         GUI::MessageBox::show(String::format("Could not parse '%s'", path.characters()), "Error", GUI::MessageBox::Type::Error, GUI::MessageBox::InputType::OK, window());
         return;
     }
 
-    m_name = form_json.as_object().get("name").to_string();
-    auto widgets = form_json.as_object().get("widgets").as_array();
+    m_name = form_json.value().as_object().get("name").to_string();
+    auto widgets = form_json.value().as_object().get("widgets").as_array();
 
     widgets.for_each([&](const JsonValue& widget_value) {
         auto& widget_object = widget_value.as_object();

--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -105,13 +105,13 @@ public:
             auto request = m_socket->read(length);
 
             auto request_json = JsonValue::from_string(request);
-            if (!request_json.is_object()) {
+            if (!request_json.has_value() || !request_json.value().is_object()) {
                 dbg() << "RPC client sent invalid request";
                 shutdown();
                 return;
             }
 
-            handle_request(request_json.as_object());
+            handle_request(request_json.value().as_object());
         };
     }
     virtual ~RPCClient() override

--- a/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -48,7 +48,8 @@ HashMap<pid_t, Core::ProcessStatistics> ProcessStatisticsReader::get_all()
 
     auto file_contents = file->read_all();
     auto json = JsonValue::from_string(file_contents);
-    json.as_array().for_each([&](auto& value) {
+    ASSERT(json.has_value());
+    json.value().as_array().for_each([&](auto& value) {
         const JsonObject& process_object = value.as_object();
         Core::ProcessStatistics process;
 

--- a/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Libraries/LibGUI/JsonArrayModel.cpp
@@ -42,8 +42,9 @@ void JsonArrayModel::update()
 
     auto json = JsonValue::from_string(file->read_all());
 
-    ASSERT(json.is_array());
-    m_array = json.as_array();
+    ASSERT(json.has_value());
+    ASSERT(json.value().is_array());
+    m_array = json.value().as_array();
 
     did_update();
 }

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCES
     Runtime/FunctionPrototype.cpp
     Runtime/GlobalObject.cpp
     Runtime/IndexedProperties.cpp
+    Runtime/JSONObject.cpp
     Runtime/LexicalEnvironment.cpp
     Runtime/MarkedValueList.cpp
     Runtime/MathObject.cpp

--- a/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -81,10 +81,7 @@ Value ArrayConstructor::construct(Interpreter& interpreter)
 Value ArrayConstructor::is_array(Interpreter& interpreter)
 {
     auto value = interpreter.argument(0);
-    if (!value.is_array())
-        return Value(false);
-    // Exclude TypedArray and similar
-    return Value(StringView(value.as_object().class_name()) == "Array");
+    return Value(value.is_array());
 }
 
 Value ArrayConstructor::of(Interpreter& interpreter)

--- a/Libraries/LibJS/Runtime/BooleanPrototype.cpp
+++ b/Libraries/LibJS/Runtime/BooleanPrototype.cpp
@@ -47,7 +47,7 @@ Value BooleanPrototype::to_string(Interpreter& interpreter)
     if (this_object.is_boolean()) {
         return js_string(interpreter.heap(), this_object.as_bool() ? "true" : "false");
     }
-    if (!this_object.is_object() || !this_object.as_object().is_boolean()) {
+    if (!this_object.is_object() || !this_object.as_object().is_boolean_object()) {
         interpreter.throw_exception<TypeError>(ErrorType::NotA, "Boolean");
         return {};
     }
@@ -62,7 +62,7 @@ Value BooleanPrototype::value_of(Interpreter& interpreter)
     if (this_object.is_boolean()) {
         return this_object;
     }
-    if (!this_object.is_object() || !this_object.as_object().is_boolean()) {
+    if (!this_object.is_object() || !this_object.as_object().is_boolean_object()) {
         interpreter.throw_exception<TypeError>(ErrorType::NotA, "Boolean");
         return {};
     }

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -49,6 +49,7 @@
     M(IsNotAEvaluatedFrom, "%s is not a %s (evaluated from '%s')")                                     \
     M(JsonBigInt, "Cannot serialize BigInt value to JSON")                                             \
     M(JsonCircular, "Cannot stringify circular object")                                                \
+    M(JsonMalformed, "Malformed JSON string")                                                          \
     M(NotA, "Not a %s object")                                                                         \
     M(NotACtor, "%s is not a constructor")                                                             \
     M(NotAFunction, "%s is not a function")                                                            \

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -47,6 +47,8 @@
     M(InvalidLeftHandAssignment, "Invalid left-hand side in assignment")                               \
     M(IsNotA, "%s is not a %s")                                                                        \
     M(IsNotAEvaluatedFrom, "%s is not a %s (evaluated from '%s')")                                     \
+    M(JsonBigInt, "Cannot serialize BigInt value to JSON")                                             \
+    M(JsonCircular, "Cannot stringify circular object")                                                \
     M(NotA, "Not a %s object")                                                                         \
     M(NotACtor, "%s is not a constructor")                                                             \
     M(NotAFunction, "%s is not a function")                                                            \

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -41,6 +41,7 @@
 #include <LibJS/Runtime/FunctionConstructor.h>
 #include <LibJS/Runtime/FunctionPrototype.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/JSONObject.h>
 #include <LibJS/Runtime/MathObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/NumberConstructor.h>
@@ -96,6 +97,7 @@ void GlobalObject::initialize()
     define_property("globalThis", this, attr);
     define_property("console", heap().allocate<ConsoleObject>(), attr);
     define_property("Math", heap().allocate<MathObject>(), attr);
+    define_property("JSON", heap().allocate<JSONObject>(), attr);
     define_property("Reflect", heap().allocate<ReflectObject>(), attr);
 
     add_constructor("Array", m_array_constructor, *m_array_prototype);

--- a/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/StringBuilder.h>
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/JSONObject.h>
+#include <LibJS/Runtime/Object.h>
+
+namespace JS {
+
+JSONObject::JSONObject()
+    : Object(interpreter().global_object().object_prototype())
+{
+    u8 attr = Attribute::Writable | Attribute::Configurable;
+    define_native_function("stringify", stringify, 3, attr);
+    define_native_function("parse", parse, 1, attr);
+}
+
+JSONObject::~JSONObject()
+{
+}
+
+Value JSONObject::stringify(Interpreter& interpreter)
+{
+    if (!interpreter.argument_count())
+        return js_undefined();
+    auto value = interpreter.argument(0);
+    auto replacer = interpreter.argument(1);
+    auto space = interpreter.argument(2);
+
+    StringifyState state;
+
+    if (replacer.is_object()) {
+        if (replacer.as_object().is_function()) {
+            state.replacer_function = &replacer.as_function();
+        } else if (replacer.is_array()) {
+            auto& replacer_object = replacer.as_object();
+            auto replacer_length = length_of_array_like(interpreter, replacer);
+            if (interpreter.exception())
+                return {};
+            Vector<String> list;
+            for (size_t i = 0; i < replacer_length; ++i) {
+                auto replacer_value = replacer_object.get(i);
+                if (interpreter.exception())
+                    return {};
+                String item;
+                if (replacer_value.is_string() || replacer_value.is_number()) {
+                    item = replacer_value.to_string(interpreter);
+                    if (interpreter.exception())
+                        return {};
+                } else if (replacer_value.is_object()) {
+                    auto& value_object = replacer_value.as_object();
+                    if (value_object.is_string_object() || value_object.is_number_object()) {
+                        item = value_object.value_of().to_string(interpreter);
+                        if (interpreter.exception())
+                            return { };
+                    }
+                }
+                if (!item.is_null() && !list.contains_slow(item)) {
+                    list.append(item);
+                }
+            }
+            state.property_list = list;
+        }
+    }
+
+    if (space.is_object()) {
+        auto& space_obj = space.as_object();
+        if (space_obj.is_string_object() || space_obj.is_number_object())
+            space = space_obj.value_of();
+    }
+
+    if (space.is_number()) {
+        StringBuilder gap_builder;
+        auto gap_size = min(10, space.as_i32());
+        for (auto i = 0; i < gap_size; ++i)
+            gap_builder.append(' ');
+        state.gap = gap_builder.to_string();
+    } else if (space.is_string()) {
+        auto string = space.as_string().string();
+        if (string.length() <= 10) {
+            state.gap = string;
+        } else {
+            state.gap = string.substring(0, 10);
+        }
+    } else {
+        state.gap = String::empty();
+    }
+
+    auto* wrapper = Object::create_empty(interpreter, interpreter.global_object());
+    wrapper->define_property(String::empty(), value);
+    if (interpreter.exception())
+        return {};
+    auto result = serialize_json_property(interpreter, state, String::empty(), wrapper);
+    if (interpreter.exception())
+        return {};
+    if (result.is_null())
+        return js_undefined();
+    return js_string(interpreter, result);
+}
+
+String JSONObject::serialize_json_property(Interpreter& interpreter, StringifyState& state, const PropertyName& key, Object* holder)
+{
+    auto value = holder->get(key);
+    if (value.is_object()) {
+        auto to_json = value.as_object().get("toJSON");
+        if (interpreter.exception())
+            return {};
+        if (to_json.is_function()) {
+            MarkedValueList arguments(interpreter.heap());
+            arguments.append(js_string(interpreter, key.to_string()));
+            value = interpreter.call(to_json.as_function(), value, move(arguments));
+            if (interpreter.exception())
+                return {};
+        }
+    }
+
+    if (state.replacer_function) {
+        MarkedValueList arguments(interpreter.heap());
+        arguments.values().append(js_string(interpreter, key.to_string()));
+        arguments.values().append(value);
+        value = interpreter.call(*state.replacer_function, holder, move(arguments));
+        if (interpreter.exception())
+            return {};
+    }
+
+    if (value.is_object()) {
+        auto& value_object = value.as_object();
+        if (value_object.is_number_object() || value_object.is_boolean_object() || value_object.is_string_object() || value_object.is_bigint_object())
+            value = value_object.value_of();
+    }
+
+    if (value.is_null())
+        return "null";
+    if (value.is_boolean())
+        return value.as_bool() ? "true" : "false";
+    if (value.is_string())
+        return quote_json_string(value.as_string().string());
+    if (value.is_number()) {
+        if (value.is_finite_number())
+            return value.to_string(interpreter);
+        return "null";
+    }
+    if (value.is_object() && !value.is_function()) {
+        if (value.is_array())
+            return serialize_json_array(interpreter, state, static_cast<Array&>(value.as_object()));
+        return serialize_json_object(interpreter, state, value.as_object());
+    }
+    if (value.is_bigint())
+        interpreter.throw_exception<TypeError>(ErrorType::JsonBigInt);
+    return {};
+}
+
+String JSONObject::serialize_json_object(Interpreter& interpreter, StringifyState& state, Object& object)
+{
+    if (state.seen_objects.contains(&object)) {
+        interpreter.throw_exception<TypeError>(ErrorType::JsonCircular);
+        return {};
+    }
+
+    state.seen_objects.set(&object);
+    String previous_indent = state.indent;
+    state.indent = String::format("%s%s", state.indent.characters(), state.gap.characters());
+    Vector<String> property_strings;
+
+    auto process_property = [&](const PropertyName& key) {
+        auto serialized_property_string = serialize_json_property(interpreter, state, key, &object);
+        if (interpreter.exception())
+            return;
+        if (!serialized_property_string.is_null()) {
+            property_strings.append(String::format(
+                "%s:%s%s",
+                quote_json_string(key.to_string()).characters(),
+                state.gap.is_empty() ? "" : " ",
+                serialized_property_string.characters()
+            ));
+        }
+    };
+
+    if (state.property_list.has_value()) {
+        auto property_list = state.property_list.value();
+        for (auto& property : property_list) {
+            process_property(property);
+            if (interpreter.exception())
+                return {};
+        }
+    } else {
+        for (auto& entry : object.indexed_properties()) {
+            auto value_and_attributes = entry.value_and_attributes(&object);
+            if (!value_and_attributes.attributes.is_enumerable())
+                continue;
+            process_property(entry.index());
+            if (interpreter.exception())
+                return {};
+        }
+        for (auto&[key, metadata] : object.shape().property_table_ordered()) {
+            if (!metadata.attributes.is_enumerable())
+                continue;
+            process_property(key);
+            if (interpreter.exception())
+                return {};
+        }
+    }
+    StringBuilder builder;
+    if (property_strings.is_empty()) {
+        builder.append("{}");
+    } else {
+        bool first = true;
+        builder.append('{');
+        if (state.gap.is_empty()) {
+            for (auto& property_string : property_strings) {
+                if (!first)
+                    builder.append(',');
+                first = false;
+                builder.append(property_string);
+            }
+        } else {
+            builder.append('\n');
+            builder.append(state.indent);
+            auto separator = String::format(",\n%s", state.indent.characters());
+            for (auto& property_string : property_strings) {
+                if (!first)
+                    builder.append(separator);
+                first = false;
+                builder.append(property_string);
+            }
+            builder.append('\n');
+            builder.append(previous_indent);
+        }
+        builder.append('}');
+    }
+
+    state.seen_objects.remove(&object);
+    state.indent = previous_indent;
+    return builder.to_string();
+}
+
+String JSONObject::serialize_json_array(Interpreter& interpreter, StringifyState& state, Object& object)
+{
+    if (state.seen_objects.contains(&object)) {
+        interpreter.throw_exception<TypeError>(ErrorType::JsonCircular);
+        return {};
+    }
+
+    state.seen_objects.set(&object);
+    String previous_indent = state.indent;
+    state.indent = String::format("%s%s", state.indent.characters(), state.gap.characters());
+    Vector<String> property_strings;
+
+    auto length = length_of_array_like(interpreter, Value(&object));
+    if (interpreter.exception())
+        return {};
+    for (size_t i = 0; i < length; ++i) {
+        if (interpreter.exception())
+            return {};
+        auto serialized_property_string = serialize_json_property(interpreter, state, i, &object);
+        if (interpreter.exception())
+            return {};
+        if (serialized_property_string.is_null()) {
+            property_strings.append("null");
+        } else {
+            property_strings.append(serialized_property_string);
+        }
+    }
+
+    StringBuilder builder;
+    if (property_strings.is_empty()) {
+        builder.append("[]");
+    } else {
+        if (state.gap.is_empty()) {
+            builder.append('[');
+            bool first = true;
+            for (auto& property_string : property_strings) {
+                if (!first)
+                    builder.append(',');
+                first = false;
+                builder.append(property_string);
+            }
+            builder.append(']');
+        } else {
+            builder.append("[\n");
+            builder.append(state.indent);
+            auto separator = String::format(",\n%s", state.indent.characters());
+            bool first = true;
+            for (auto& property_string : property_strings) {
+                if (!first)
+                    builder.append(separator);
+                first = false;
+                builder.append(property_string);
+            }
+            builder.append('\n');
+            builder.append(previous_indent);
+            builder.append(']');
+        }
+    }
+
+    state.seen_objects.remove(&object);
+    state.indent = previous_indent;
+    return builder.to_string();
+}
+
+String JSONObject::quote_json_string(String string)
+{
+    // FIXME: Handle UTF16
+    StringBuilder builder;
+    builder.append('"');
+    for (auto& ch : string) {
+        switch (ch) {
+        case '\b':
+            builder.append("\\b");
+            break;
+        case '\t':
+            builder.append("\\t");
+            break;
+        case '\n':
+            builder.append("\\n");
+            break;
+        case '\f':
+            builder.append("\\f");
+            break;
+        case '\r':
+            builder.append("\\r");
+            break;
+        case '"':
+            builder.append("\\\"");
+            break;
+        case '\\':
+            builder.append("\\\\");
+            break;
+        default:
+            if (ch < 0x20) {
+                builder.append("\\u%#08x", ch);
+            } else {
+                builder.append(ch);
+            }
+        }
+    }
+    builder.append('"');
+    return builder.to_string();
+}
+
+Value JSONObject::parse(Interpreter&)
+{
+    return js_undefined();
+}
+
+}

--- a/Libraries/LibJS/Runtime/JSONObject.h
+++ b/Libraries/LibJS/Runtime/JSONObject.h
@@ -26,8 +26,6 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
-
 namespace JS {
 
 class JSONObject final : public Object {
@@ -51,6 +49,12 @@ private:
     static String serialize_json_object(Interpreter&, StringifyState&, Object&);
     static String serialize_json_array(Interpreter&, StringifyState&, Object&);
     static String quote_json_string(String);
+
+    // Parse helpers
+    static Object* parse_json_object(Interpreter&, const JsonObject&);
+    static Array* parse_json_array(Interpreter&, const JsonArray&);
+    static Value parse_json_value(Interpreter&, const JsonValue&);
+    static Value internalize_json_property(Interpreter&, Object* holder, const PropertyName& name, Function& reviver);
 
     static Value stringify(Interpreter&);
     static Value parse(Interpreter&);

--- a/Libraries/LibJS/Runtime/JSONObject.h
+++ b/Libraries/LibJS/Runtime/JSONObject.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Jack Karamanian <karamanian.jack@gmail.com>
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,21 +29,31 @@
 #include <LibJS/Runtime/Object.h>
 
 namespace JS {
-class BooleanObject : public Object {
+
+class JSONObject final : public Object {
 public:
-    static BooleanObject* create(GlobalObject&, bool);
-
-    BooleanObject(bool, Object& prototype);
-    virtual ~BooleanObject() override;
-
-    virtual Value value_of() const override
-    {
-        return Value(m_value);
-    }
+    JSONObject();
+    virtual ~JSONObject() override;
 
 private:
-    virtual const char* class_name() const override { return "BooleanObject"; }
-    virtual bool is_boolean_object() const override { return true; }
-    bool m_value { false };
+    struct StringifyState {
+        Function* replacer_function { nullptr };
+        HashTable<Object*> seen_objects;
+        String indent { String::empty() };
+        String gap;
+        Optional<Vector<String>> property_list;
+    };
+
+    virtual const char* class_name() const override { return "JSONObject"; }
+
+    // Stringify helpers
+    static String serialize_json_property(Interpreter&, StringifyState&, const PropertyName& key, Object* holder);
+    static String serialize_json_object(Interpreter&, StringifyState&, Object&);
+    static String serialize_json_array(Interpreter&, StringifyState&, Object&);
+    static String quote_json_string(String);
+
+    static Value stringify(Interpreter&);
+    static Value parse(Interpreter&);
 };
+
 }

--- a/Libraries/LibJS/Runtime/NumberObject.h
+++ b/Libraries/LibJS/Runtime/NumberObject.h
@@ -37,6 +37,7 @@ public:
     NumberObject(double, Object& prototype);
     virtual ~NumberObject() override;
 
+    virtual bool is_number_object() const override { return true; }
     virtual Value value_of() const override { return Value(m_value); }
 
 private:

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -96,7 +96,6 @@ public:
     virtual Value delete_property(PropertyName);
 
     virtual bool is_array() const { return false; }
-    virtual bool is_boolean() const { return false; }
     virtual bool is_date() const { return false; }
     virtual bool is_error() const { return false; }
     virtual bool is_function() const { return false; }
@@ -105,7 +104,9 @@ public:
     virtual bool is_native_property() const { return false; }
     virtual bool is_proxy_object() const { return false; }
     virtual bool is_regexp_object() const { return false; }
+    virtual bool is_boolean_object() const { return false; }
     virtual bool is_string_object() const { return false; }
+    virtual bool is_number_object() const { return false; }
     virtual bool is_symbol_object() const { return false; }
     virtual bool is_bigint_object() const { return false; }
 

--- a/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Libraries/LibJS/Runtime/ProxyObject.h
@@ -58,6 +58,7 @@ private:
     virtual void visit_children(Visitor&) override;
     virtual const char* class_name() const override { return "ProxyObject"; }
     virtual bool is_proxy_object() const override { return true; }
+    virtual bool is_array() const override { return m_target.is_array(); };
 
     Object& m_target;
     Object& m_handler;

--- a/Libraries/LibJS/Runtime/Uint8ClampedArray.h
+++ b/Libraries/LibJS/Runtime/Uint8ClampedArray.h
@@ -47,7 +47,6 @@ public:
 
 private:
     virtual const char* class_name() const override { return "Uint8ClampedArray"; }
-    virtual bool is_array() const override { return true; }
 
     static Value length_getter(Interpreter&);
 

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -81,6 +81,12 @@ bool Value::is_array() const
     return is_object() && as_object().is_array();
 }
 
+Array& Value::as_array()
+{
+    ASSERT(is_array());
+    return static_cast<Array&>(*m_value.as_object);
+}
+
 bool Value::is_function() const
 {
     return is_object() && as_object().is_function();
@@ -938,6 +944,15 @@ TriState abstract_relation(Interpreter& interpreter, bool left_first, Value lhs,
         return TriState::True;
     else
         return TriState::False;
+}
+
+size_t length_of_array_like(Interpreter& interpreter, Value value)
+{
+    ASSERT(value.is_object());
+    auto result = value.as_object().get("length");
+    if (interpreter.exception())
+        return 0;
+    return result.to_size_t(interpreter);
 }
 
 }

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -220,6 +220,7 @@ public:
         return *m_value.as_bigint;
     }
 
+    Array& as_array();
     Function& as_function();
 
     i32 as_i32() const;
@@ -313,7 +314,8 @@ bool strict_eq(Interpreter&, Value lhs, Value rhs);
 bool same_value(Interpreter&, Value lhs, Value rhs);
 bool same_value_zero(Interpreter&, Value lhs, Value rhs);
 bool same_value_non_numeric(Interpreter&, Value lhs, Value rhs);
-TriState abstract_relation(Interpreter& interpreter, bool left_first, Value lhs, Value rhs);
+TriState abstract_relation(Interpreter&, bool left_first, Value lhs, Value rhs);
+size_t length_of_array_like(Interpreter&, Value);
 
 const LogStream& operator<<(const LogStream&, const Value&);
 

--- a/Libraries/LibJS/Tests/JSON.parse-reviver.js
+++ b/Libraries/LibJS/Tests/JSON.parse-reviver.js
@@ -1,0 +1,15 @@
+load("test-common.js");
+
+try {
+    let string = `{"var1":10,"var2":"hello","var3":{"nested":5}}`;
+
+    let object = JSON.parse(string, (key, value) => typeof value === "number" ? value * 2 : value);
+    assertDeepEquals(object, { var1: 20, var2: "hello", var3: { nested: 10 } });
+
+    object = JSON.parse(string, (key, value) => typeof value === "number" ? undefined : value);
+    assertDeepEquals(object, { var2: "hello", var3: {} });
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/JSON.parse.js
+++ b/Libraries/LibJS/Tests/JSON.parse.js
@@ -1,0 +1,43 @@
+load("test-common.js");
+
+try {
+    assert(JSON.parse.length === 2);
+
+    const properties = [
+        ["5", 5],
+        ["null", null],
+        ["true", true],
+        ["false", false],
+        ['"test"', "test"],
+        ['[1,2,"foo"]', [1, 2, "foo"]],
+        ['{"foo":1,"bar":"baz"}', { foo: 1, bar: "baz" }],
+    ];
+
+    properties.forEach(testCase => {
+        assertDeepEquals(JSON.parse(testCase[0]), testCase[1]);
+    });
+
+    let syntaxErrors = [
+        undefined,
+        NaN,
+        -NaN,
+        Infinity,
+        -Infinity,
+        '{ "foo" }',
+        '{ foo: "bar" }',
+        "[1,2,3,]",
+        "[1,2,3, ]",
+        '{ "foo": "bar",}',
+        '{ "foo": "bar", }',
+    ];
+
+    syntaxErrors.forEach(error => assertThrowsError(() => {
+        JSON.parse(error);
+    }, {
+        error: SyntaxError,
+    }));
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/JSON.stringify-order.js
+++ b/Libraries/LibJS/Tests/JSON.stringify-order.js
@@ -1,0 +1,36 @@
+load("test-common.js");
+
+try {
+    assert(JSON.stringify.length === 3);
+
+    let o = {
+        key1: "key1",
+        key2: "key2",
+        key3: "key3",
+    };
+
+    Object.defineProperty(o, "defined", {
+        enumerable: true,
+        get() {
+            o.prop = "prop";
+            return "defined";
+        },
+    });
+
+    o.key4 = "key4";
+
+    o[2] = 2;
+    o[0] = 0;
+    o[1] = 1;
+
+    delete o.key1;
+    delete o.key3;
+
+    o.key1 = "key1";
+
+    assert(JSON.stringify(o) === '{"0":0,"1":1,"2":2,"key2":"key2","defined":"defined","key4":"key4","key1":"key1"}');
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/JSON.stringify-proxy.js
+++ b/Libraries/LibJS/Tests/JSON.stringify-proxy.js
@@ -1,0 +1,18 @@
+load("test-common.js");
+
+try {
+    let p = new Proxy([], {
+        get(_, key) {
+            if (key === "length")
+                return 3;
+            return Number(key);
+        },
+    });
+
+    assert(JSON.stringify(p) === "[0,1,2]");
+    assert(JSON.stringify([[new Proxy(p, {})]]) === "[[[0,1,2]]]");
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/JSON.stringify-replacer.js
+++ b/Libraries/LibJS/Tests/JSON.stringify-replacer.js
@@ -1,0 +1,39 @@
+load("test-common.js");
+
+try {
+    let o = {
+        var1: "foo",
+        var2: 42,
+        arr: [1, 2, {
+            nested: {
+                hello: "world",
+            },
+            get x() { return 10; }
+        }],
+        obj: {
+            subarr: [3],
+        },
+    };
+
+    let string = JSON.stringify(o, (key, value) => {
+        if (key === "hello")
+            return undefined;
+        if (value === 10)
+            return 20;
+        if (key === "subarr")
+            return [3, 4, 5];
+        return value;
+    });
+
+    assert(string === '{"var1":"foo","var2":42,"arr":[1,2,{"nested":{},"x":20}],"obj":{"subarr":[3,4,5]}}');
+
+    string = JSON.stringify(o, ["var1", "var1", "var2", "obj"]);
+    assert(string == '{"var1":"foo","var2":42,"obj":{}}');
+
+    string = JSON.stringify(o, ["var1", "var1", "var2", "obj", "subarr"]);
+    assert(string == '{"var1":"foo","var2":42,"obj":{"subarr":[3]}}');
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/JSON.stringify-space.js
+++ b/Libraries/LibJS/Tests/JSON.stringify-space.js
@@ -1,0 +1,51 @@
+load("test-common.js");
+
+try {
+    let o = {
+        foo: 1,
+        bar: "baz",
+        qux: {
+            get x() { return 10; },
+            y() { return 20; },
+            arr: [1, 2, 3],
+        }
+    };
+
+    let string = JSON.stringify(o, null, 4);
+    let expected =
+`{
+    "foo": 1,
+    "bar": "baz",
+    "qux": {
+        "x": 10,
+        "arr": [
+            1,
+            2,
+            3
+        ]
+    }
+}`;
+
+    assert(string === expected);
+
+    string = JSON.stringify(o, null, "abcd");
+    expected =
+`{
+abcd"foo": 1,
+abcd"bar": "baz",
+abcd"qux": {
+abcdabcd"x": 10,
+abcdabcd"arr": [
+abcdabcdabcd1,
+abcdabcdabcd2,
+abcdabcdabcd3
+abcdabcd]
+abcd}
+}`;
+
+    assert(string === expected);
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/JSON.stringify.js
+++ b/Libraries/LibJS/Tests/JSON.stringify.js
@@ -1,0 +1,71 @@
+load("test-common.js");
+
+try {
+    assert(JSON.stringify.length === 3);
+
+    assertThrowsError(() => {
+        JSON.stringify(5n);
+    }, {
+        error: TypeError,
+        message: "Cannot serialize BigInt value to JSON",
+    });
+
+    const properties = [
+        [5, "5"],
+        [undefined, undefined],
+        [null, "null"],
+        [NaN, "null"],
+        [-NaN, "null"],
+        [Infinity, "null"],
+        [-Infinity, "null"],
+        [true, "true"],
+        [false, "false"],
+        ["test", '"test"'],
+        [new Number(5), "5"],
+        [new Boolean(false), "false"],
+        [new String("test"), '"test"'],
+        [() => {}, undefined],
+        [[1, 2, "foo"], '[1,2,"foo"]'],
+        [{ foo: 1, bar: "baz", qux() {} }, '{"foo":1,"bar":"baz"}'],
+        [
+            {
+                var1: 1,
+                var2: 2,
+                toJSON(key) {
+                    let o = this;
+                    o.var2 = 10;
+                    return o;
+                }
+            },
+            '{"var1":1,"var2":10}',
+        ],
+    ];
+
+    properties.forEach(testCase => {
+        assert(JSON.stringify(testCase[0]) === testCase[1]);
+    });
+
+    let bad1 = {};
+    bad1.foo = bad1;
+    let bad2 = [];
+    bad2[5] = [[[bad2]]];
+
+    let bad3a = { foo: "bar" };
+    let bad3b = [1, 2, bad3a];
+    bad3a.bad = bad3b;
+
+    [bad1, bad2, bad3a].forEach(bad => assertThrowsError(() => {
+        JSON.stringify(bad);
+    }, {
+        error: TypeError,
+        message: "Cannot stringify circular object",
+    }));
+
+    let o = { foo: "bar" };
+    Object.defineProperty(o, "baz", { value: "qux", enumerable: false });
+    assert(JSON.stringify(o) === '{"foo":"bar"}');
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -92,3 +92,40 @@ const assertVisitsAll = (testFunction, expectedOutput) => {
 function isClose(a, b) {
     return Math.abs(a - b) < 0.000001;
 }
+
+/**
+ * Quick and dirty deep equals method.
+ * @param {*} a First value
+ * @param {*} b Second value
+ */
+function assertDeepEquals(a, b) {
+    assert(deepEquals(a, b));
+}
+
+function deepEquals(a, b) {
+    if (Array.isArray(a))
+        return Array.isArray(b) && deepArrayEquals(a, b);
+    if (typeof a === "object")
+        return typeof b === "object" && deepObjectEquals(a, b);
+    return a === b;
+}
+
+function deepArrayEquals(a, b) {
+    if (a.length !== b.length)
+        return false;
+    for (let i = 0; i < a.length; ++i) {
+        if (!deepEquals(a[i], b[i]))
+            return false;
+    }
+    return true;
+}
+
+function deepObjectEquals(a, b) {
+    if (a === null)
+        return b === null;
+    for (let key of Reflect.ownKeys(a)) {
+        if (!deepEquals(a[key], b[key]))
+            return false;
+    }
+    return true;
+}

--- a/Libraries/LibKeyboard/CharacterMapFile.cpp
+++ b/Libraries/LibKeyboard/CharacterMapFile.cpp
@@ -48,7 +48,9 @@ Optional<CharacterMapData> CharacterMapFile::load_from_file(const String& file_n
     }
 
     auto file_contents = file->read_all();
-    auto json = JsonValue::from_string(file_contents).as_object();
+    auto json_result = JsonValue::from_string(file_contents);
+    ASSERT(json_result.has_value());
+    auto json = json_result.value().as_object();
 
     ByteBuffer map = read_map(json, "map");
     ByteBuffer shift_map = read_map(json, "shift_map");

--- a/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_cpp.cpp
+++ b/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_cpp.cpp
@@ -56,7 +56,8 @@ int main(int argc, char** argv)
         return 1;
 
     auto json = JsonValue::from_string(file->read_all());
-    ASSERT(json.is_object());
+    ASSERT(json.has_value());
+    ASSERT(json.value().is_object());
 
     out() << "#include <AK/Assertions.h>";
     out() << "#include <LibWeb/CSS/PropertyID.h>";
@@ -65,7 +66,7 @@ int main(int argc, char** argv)
 
     out() << "PropertyID property_id_from_string(const StringView& string) {";
 
-    json.as_object().for_each_member([&](auto& name, auto& value) {
+    json.value().as_object().for_each_member([&](auto& name, auto& value) {
         ASSERT(value.is_object());
         out() << "    if (string.equals_ignoring_case(\"" << name << "\"))";
         out() << "        return PropertyID::" << title_casify(name) << ";";
@@ -77,7 +78,7 @@ int main(int argc, char** argv)
 
     out() << "const char* string_from_property_id(PropertyID property_id) {";
     out() << "    switch (property_id) {";
-    json.as_object().for_each_member([&](auto& name, auto& value) {
+    json.value().as_object().for_each_member([&](auto& name, auto& value) {
         ASSERT(value.is_object());
         out() << "    case PropertyID::" << title_casify(name) << ":";
         out() << "        return \"" << name << "\";";

--- a/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
+++ b/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
@@ -56,7 +56,8 @@ int main(int argc, char** argv)
         return 1;
 
     auto json = JsonValue::from_string(file->read_all());
-    ASSERT(json.is_object());
+    ASSERT(json.has_value());
+    ASSERT(json.value().is_object());
 
     out() << "#pragma once";
     out() << "#include <AK/StringView.h>";
@@ -67,7 +68,7 @@ int main(int argc, char** argv)
     out() << "enum class PropertyID {";
     out() << "    Invalid,";
 
-    json.as_object().for_each_member([&](auto& name, auto& value) {
+    json.value().as_object().for_each_member([&](auto& name, auto& value) {
         ASSERT(value.is_object());
         out() << "    " << title_casify(name) << ",";
     });

--- a/MenuApplets/ResourceGraph/main.cpp
+++ b/MenuApplets/ResourceGraph/main.cpp
@@ -140,9 +140,10 @@ private:
             ASSERT_NOT_REACHED();
 
         auto file_contents = proc_memstat->read_all();
-        auto json = JsonValue::from_string(file_contents).as_object();
-        unsigned user_physical_allocated = json.get("user_physical_allocated").to_u32();
-        unsigned user_physical_available = json.get("user_physical_available").to_u32();
+        auto json = JsonValue::from_string(file_contents);
+        ASSERT(json.has_value());
+        unsigned user_physical_allocated = json.value().as_object().get("user_physical_allocated").to_u32();
+        unsigned user_physical_available = json.value().as_object().get("user_physical_available").to_u32();
         allocated = (user_physical_allocated * 4096) / 1024;
         available = (user_physical_available * 4096) / 1024;
     }

--- a/Meta/Lagom/TestJson.cpp
+++ b/Meta/Lagom/TestJson.cpp
@@ -31,7 +31,8 @@
 int main(int, char**)
 {
     auto value = JsonValue::from_string("{\"property\": \"value\"}");
-    printf("parsed: _%s_\n", value.to_string().characters());
-    printf("object.property = '%s'\n", value.as_object().get("property").to_string().characters());
+    ASSERT(value.has_value());
+    printf("parsed: _%s_\n", value.value().to_string().characters());
+    printf("object.property = '%s'\n", value.value().as_object().get("property").to_string().characters());
     return 0;
 }

--- a/Services/DHCPClient/main.cpp
+++ b/Services/DHCPClient/main.cpp
@@ -77,9 +77,10 @@ int main(int argc, char** argv)
     }
 
     auto file_contents = file->read_all();
-    auto json = JsonValue::from_string(file_contents).as_array();
+    auto json = JsonValue::from_string(file_contents);
+    ASSERT(json.has_value());
     Vector<InterfaceDescriptor> ifnames;
-    json.for_each([&ifnames](auto& value) {
+    json.value().as_array().for_each([&ifnames](auto& value) {
         auto if_object = value.as_object();
 
         if (if_object.get("class_name").to_string() == "LoopbackAdapter")

--- a/Userland/arp.cpp
+++ b/Userland/arp.cpp
@@ -39,8 +39,9 @@ int main()
 
     printf("Address          HWaddress\n");
     auto file_contents = file->read_all();
-    auto json = JsonValue::from_string(file_contents).as_array();
-    json.for_each([](auto& value) {
+    auto json = JsonValue::from_string(file_contents);
+    ASSERT(json.has_value());
+    json.value().as_array().for_each([](auto& value) {
         auto if_object = value.as_object();
 
         auto ip_address = if_object.get("ip_address").to_string();

--- a/Userland/df.cpp
+++ b/Userland/df.cpp
@@ -86,7 +86,9 @@ int main(int argc, char** argv)
     }
 
     auto file_contents = file->read_all();
-    auto json = JsonValue::from_string(file_contents).as_array();
+    auto json_result = JsonValue::from_string(file_contents);
+    ASSERT(json_result.has_value());
+    auto json = json_result.value().as_array();
     json.for_each([](auto& value) {
         auto fs_object = value.as_object();
         auto fs = fs_object.get("class_name").to_string();

--- a/Userland/gron.cpp
+++ b/Userland/gron.cpp
@@ -74,6 +74,7 @@ int main(int argc, char** argv)
 
     auto file_contents = file->read_all();
     auto json = JsonValue::from_string(file_contents);
+    ASSERT(json.has_value());
 
     if (use_color) {
         color_name = "\033[33;1m";
@@ -86,7 +87,7 @@ int main(int argc, char** argv)
     }
 
     Vector<String> trail;
-    print("json", json, trail);
+    print("json", json.value(), trail);
     return 0;
 }
 
@@ -116,7 +117,6 @@ static void print(const String& name, const JsonValue& value, Vector<String>& tr
     }
     switch (value.type()) {
     case JsonValue::Type::Null:
-    case JsonValue::Type::Undefined:
         printf("%s", color_null);
         break;
     case JsonValue::Type::Bool:

--- a/Userland/ifconfig.cpp
+++ b/Userland/ifconfig.cpp
@@ -72,8 +72,9 @@ int main(int argc, char** argv)
         }
 
         auto file_contents = file->read_all();
-        auto json = JsonValue::from_string(file_contents).as_array();
-        json.for_each([](auto& value) {
+        auto json = JsonValue::from_string(file_contents);
+        ASSERT(json.has_value());
+        json.value().as_array().for_each([](auto& value) {
             auto if_object = value.as_object();
 
             auto name = if_object.get("name").to_string();

--- a/Userland/jp.cpp
+++ b/Userland/jp.cpp
@@ -63,8 +63,9 @@ int main(int argc, char** argv)
 
     auto file_contents = file->read_all();
     auto json = JsonValue::from_string(file_contents);
+    ASSERT(json.has_value());
 
-    print(json);
+    print(json.value());
     printf("\n");
 
     return 0;
@@ -101,7 +102,7 @@ void print(const JsonValue& value, int indent)
         printf("\033[35;1m");
     else if (value.is_bool())
         printf("\033[32;1m");
-    else if (value.is_null() || value.is_undefined())
+    else if (value.is_null())
         printf("\033[34;1m");
     if (value.is_string())
         putchar('"');

--- a/Userland/lsirq.cpp
+++ b/Userland/lsirq.cpp
@@ -60,8 +60,9 @@ int main(int argc, char** argv)
 
     printf("%4s  %-10s\n", " ", "CPU0");
     auto file_contents = proc_interrupts->read_all();
-    auto json = JsonValue::from_string(file_contents).as_array();
-    json.for_each([](auto& value) {
+    auto json = JsonValue::from_string(file_contents);
+    ASSERT(json.has_value());
+    json.value().as_array().for_each([](auto& value) {
         auto handler = value.as_object();
         auto purpose = handler.get("purpose").to_string();
         auto interrupt = handler.get("interrupt_line").to_string();

--- a/Userland/lspci.cpp
+++ b/Userland/lspci.cpp
@@ -69,8 +69,9 @@ int main(int argc, char** argv)
     }
 
     auto file_contents = proc_pci->read_all();
-    auto json = JsonValue::from_string(file_contents).as_array();
-    json.for_each([db](auto& value) {
+    auto json = JsonValue::from_string(file_contents);
+    ASSERT(json.has_value());
+    json.value().as_array().for_each([db](auto& value) {
         auto dev = value.as_object();
         auto seg = dev.get("seg").to_u32();
         auto bus = dev.get("bus").to_u32();

--- a/Userland/mount.cpp
+++ b/Userland/mount.cpp
@@ -149,9 +149,10 @@ bool print_mounts()
     }
 
     auto content = df->read_all();
-    auto json = JsonValue::from_string(content).as_array();
+    auto json = JsonValue::from_string(content);
+    ASSERT(json.has_value());
 
-    json.for_each([](auto& value) {
+    json.value().as_array().for_each([](auto& value) {
         auto fs_object = value.as_object();
         auto class_name = fs_object.get("class_name").to_string();
         auto mount_point = fs_object.get("mount_point").to_string();


### PR DESCRIPTION
Adds `JSON.{stringify,parse}`, including all of their weird parameters.

AK `JsonParser` improvements:
- Parsing invalid JSON no longer asserts. Instead of asserting when coming across malformed JSON, `JsonParser::parse` now takes a `bool& ok` parameter that can be checked after parsing the JSON. If not passed, it defaults to the old behavior of asserting.
- Disallow trailing commas in JSON objects and arrays
- No longer parse `undefined`, as that is a purely JS thing
- No longer allow non-whitespace after anything consumed by the initial `parse()` call. Examples of things that were valid and no longer are:
    - `6dfz`
    - `{"foo": 1}abcd`
    - `[1,2,3]4`
- `JsonObject.for_each_member` now iterates in original insertion order