### PR TITLE
AudioServer: removed AS prefix from class and file names

### DIFF
--- a/Services/AudioServer/CMakeLists.txt
+++ b/Services/AudioServer/CMakeLists.txt
@@ -2,8 +2,8 @@ compile_ipc(AudioServer.ipc AudioServerEndpoint.h)
 compile_ipc(AudioClient.ipc AudioClientEndpoint.h)
 
 set(SOURCES
-    ASClientConnection.cpp
-    ASMixer.cpp
+    ClientConnection.cpp
+    Mixer.cpp
     main.cpp
     AudioServerEndpoint.h
     AudioClientEndpoint.h

--- a/Services/AudioServer/ClientConnection.h
+++ b/Services/AudioServer/ClientConnection.h
@@ -34,22 +34,24 @@ namespace Audio {
 class Buffer;
 }
 
-class ASBufferQueue;
-class ASMixer;
+namespace AudioServer {
 
-class ASClientConnection final : public IPC::ClientConnection<AudioServerEndpoint>
+class BufferQueue;
+class Mixer;
+
+class ClientConnection final : public IPC::ClientConnection<AudioServerEndpoint>
     , public AudioServerEndpoint {
-    C_OBJECT(ASClientConnection)
+    C_OBJECT(ClientConnection)
 public:
-    explicit ASClientConnection(Core::LocalSocket&, int client_id, ASMixer& mixer);
-    ~ASClientConnection() override;
+    explicit ClientConnection(Core::LocalSocket&, int client_id, Mixer& mixer);
+    ~ClientConnection() override;
 
-    void did_finish_playing_buffer(Badge<ASBufferQueue>, int buffer_id);
-    void did_change_muted_state(Badge<ASMixer>, bool muted);
+    void did_finish_playing_buffer(Badge<BufferQueue>, int buffer_id);
+    void did_change_muted_state(Badge<Mixer>, bool muted);
 
     virtual void die() override;
 
-    static void for_each(Function<void(ASClientConnection&)>);
+    static void for_each(Function<void(ClientConnection&)>);
 
 private:
     virtual OwnPtr<Messages::AudioServer::GreetResponse> handle(const Messages::AudioServer::Greet&) override;
@@ -64,6 +66,8 @@ private:
     virtual OwnPtr<Messages::AudioServer::GetMutedResponse> handle(const Messages::AudioServer::GetMuted&) override;
     virtual OwnPtr<Messages::AudioServer::SetMutedResponse> handle(const Messages::AudioServer::SetMuted&) override;
 
-    ASMixer& m_mixer;
-    RefPtr<ASBufferQueue> m_queue;
+    Mixer& m_mixer;
+    RefPtr<BufferQueue> m_queue;
 };
+
+}

--- a/Services/AudioServer/main.cpp
+++ b/Services/AudioServer/main.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "ASMixer.h"
+#include "Mixer.h"
 #include <LibCore/File.h>
 #include <LibCore/LocalServer.h>
 
@@ -36,7 +36,7 @@ int main(int, char**)
     }
 
     Core::EventLoop event_loop;
-    ASMixer mixer;
+    AudioServer::Mixer mixer;
 
     auto server = Core::LocalServer::construct();
     bool ok = server->take_over_from_system_server();
@@ -49,7 +49,7 @@ int main(int, char**)
         }
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        IPC::new_client_connection<ASClientConnection>(*client_socket, client_id, mixer);
+        IPC::new_client_connection<AudioServer::ClientConnection>(*client_socket, client_id, mixer);
     };
 
     if (pledge("stdio thread shared_buffer accept", nullptr) < 0) {


### PR DESCRIPTION
AudioServer: removed AS prefix from class and file names and moved everything to AudioServer namespace