### PR TITLE
LibGfx: PNG improvements

### DIFF
--- a/Base/home/anon/www/pngsuite_int_png.html
+++ b/Base/home/anon/www/pngsuite_int_png.html
@@ -1,0 +1,26 @@
+<HTML>
+<HEAD>
+<TITLE>PngSuite - Interlacing / PNG-files</TITLE>
+</HEAD>
+<BODY BGCOLOR="#ede">
+
+<!-- Modified version of http://schaik.com/pngsuite/pngsuite_bas_png.html -->
+
+<BR><IMG SRC="http://schaik.com/pngsuite/basi0g01.png" WIDTH="32" HEIGHT="32"> --- basi0g01 - black & white
+<BR><IMG SRC="http://schaik.com/pngsuite/basi0g02.png" WIDTH="32" HEIGHT="32"> --- basi0g02 - 2 bit (4 level) grayscale
+<BR><IMG SRC="http://schaik.com/pngsuite/basi0g04.png" WIDTH="32" HEIGHT="32"> --- basi0g04 - 4 bit (16 level) grayscale
+<BR><IMG SRC="http://schaik.com/pngsuite/basi0g08.png" WIDTH="32" HEIGHT="32"> --- basi0g08 - 8 bit (256 level) grayscale
+<BR><IMG SRC="http://schaik.com/pngsuite/basi0g16.png" WIDTH="32" HEIGHT="32"> --- basi0g16 - 16 bit (64k level) grayscale
+<BR><IMG SRC="http://schaik.com/pngsuite/basi2c08.png" WIDTH="32" HEIGHT="32"> --- basi2c08 - 3x8 bits rgb color
+<BR><IMG SRC="http://schaik.com/pngsuite/basi2c16.png" WIDTH="32" HEIGHT="32"> --- basi2c16 - 3x16 bits rgb color
+<BR><IMG SRC="http://schaik.com/pngsuite/basi3p01.png" WIDTH="32" HEIGHT="32"> --- basi3p01 - 1 bit (2 color) paletted
+<BR><IMG SRC="http://schaik.com/pngsuite/basi3p02.png" WIDTH="32" HEIGHT="32"> --- basi3p02 - 2 bit (4 color) paletted
+<BR><IMG SRC="http://schaik.com/pngsuite/basi3p04.png" WIDTH="32" HEIGHT="32"> --- basi3p04 - 4 bit (16 color) paletted
+<BR><IMG SRC="http://schaik.com/pngsuite/basi3p08.png" WIDTH="32" HEIGHT="32"> --- basi3p08 - 8 bit (256 color) paletted
+<BR><IMG SRC="http://schaik.com/pngsuite/basi4a08.png" WIDTH="32" HEIGHT="32"> --- basi4a08 - 8 bit grayscale + 8 bit alpha-channel
+<BR><IMG SRC="http://schaik.com/pngsuite/basi4a16.png" WIDTH="32" HEIGHT="32"> --- basi4a16 - 16 bit grayscale + 16 bit alpha-channel
+<BR><IMG SRC="http://schaik.com/pngsuite/basi6a08.png" WIDTH="32" HEIGHT="32"> --- basi6a08 - 3x8 bits rgb color + 8 bit alpha-channel
+<BR><IMG SRC="http://schaik.com/pngsuite/basi6a16.png" WIDTH="32" HEIGHT="32"> --- basi6a16 - 3x16 bits rgb color + 16 bit alpha-channel
+
+</BODY>
+</HTML>

--- a/Base/home/anon/www/pngsuite_siz_png.html
+++ b/Base/home/anon/www/pngsuite_siz_png.html
@@ -7,23 +7,41 @@
 <!-- Modified version of http://schaik.com/pngsuite/pngsuite_siz_png.html -->
 
 <BR><IMG SRC="http://schaik.com/pngsuite/s01n3p01.png" WIDTH="1" HEIGHT="1"> --- s01n3p01 - 1x1 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s01i3p01.png" WIDTH="1" HEIGHT="1"> --- s01i3p01 - 1x1 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s02n3p01.png" WIDTH="2" HEIGHT="2"> --- s02n3p01 - 2x2 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s02i3p01.png" WIDTH="2" HEIGHT="2"> --- s02i3p01 - 2x2 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s03n3p01.png" WIDTH="3" HEIGHT="3"> --- s03n3p01 - 3x3 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s03i3p01.png" WIDTH="3" HEIGHT="3"> --- s03i3p01 - 3x3 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s04n3p01.png" WIDTH="4" HEIGHT="4"> --- s04n3p01 - 4x4 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s04i3p01.png" WIDTH="4" HEIGHT="4"> --- s04i3p01 - 4x4 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s05n3p02.png" WIDTH="5" HEIGHT="5"> --- s05n3p02 - 5x5 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s05i3p02.png" WIDTH="5" HEIGHT="5"> --- s05i3p02 - 5x5 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s06n3p02.png" WIDTH="6" HEIGHT="6"> --- s06n3p02 - 6x6 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s06i3p02.png" WIDTH="6" HEIGHT="6"> --- s06i3p02 - 6x6 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s07n3p02.png" WIDTH="7" HEIGHT="7"> --- s07n3p02 - 7x7 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s07i3p02.png" WIDTH="7" HEIGHT="7"> --- s07i3p02 - 7x7 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s08n3p02.png" WIDTH="8" HEIGHT="8"> --- s08n3p02 - 8x8 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s08i3p02.png" WIDTH="8" HEIGHT="8"> --- s08i3p02 - 8x8 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s09n3p02.png" WIDTH="9" HEIGHT="9"> --- s09n3p02 - 9x9 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s09i3p02.png" WIDTH="9" HEIGHT="9"> --- s09i3p02 - 9x9 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s32n3p04.png" WIDTH="32" HEIGHT="32"> --- s32n3p04 - 32x32 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s32i3p04.png" WIDTH="32" HEIGHT="32"> --- s32i3p04 - 32x32 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s33n3p04.png" WIDTH="33" HEIGHT="33"> --- s33n3p04 - 33x33 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s33i3p04.png" WIDTH="33" HEIGHT="33"> --- s33i3p04 - 33x33 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s34n3p04.png" WIDTH="34" HEIGHT="34"> --- s34n3p04 - 34x34 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s34i3p04.png" WIDTH="34" HEIGHT="34"> --- s34i3p04 - 34x34 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s35n3p04.png" WIDTH="35" HEIGHT="35"> --- s35n3p04 - 35x35 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s35i3p04.png" WIDTH="35" HEIGHT="35"> --- s35i3p04 - 35x35 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s36n3p04.png" WIDTH="36" HEIGHT="36"> --- s36n3p04 - 36x36 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s36i3p04.png" WIDTH="36" HEIGHT="36"> --- s36i3p04 - 36x36 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s37n3p04.png" WIDTH="37" HEIGHT="37"> --- s37n3p04 - 37x37 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s37i3p04.png" WIDTH="37" HEIGHT="37"> --- s37i3p04 - 37x37 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s38n3p04.png" WIDTH="38" HEIGHT="38"> --- s38n3p04 - 38x38 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s38i3p04.png" WIDTH="38" HEIGHT="38"> --- s38i3p04 - 38x38 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s39n3p04.png" WIDTH="39" HEIGHT="39"> --- s39n3p04 - 39x39 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s39i3p04.png" WIDTH="39" HEIGHT="39"> --- s39i3p04 - 39x39 paletted file, interlaced
 <BR><IMG SRC="http://schaik.com/pngsuite/s40n3p04.png" WIDTH="40" HEIGHT="40"> --- s40n3p04 - 40x40 paletted file, no interlacing
+<BR><IMG SRC="http://schaik.com/pngsuite/s40i3p04.png" WIDTH="40" HEIGHT="40"> --- s40i3p04 - 40x40 paletted file, interlaced
 
 </BODY>
 </HTML>

--- a/Base/home/anon/www/welcome.html
+++ b/Base/home/anon/www/welcome.html
@@ -43,6 +43,7 @@ span#ua {
         <li><a href="canvas-path-quadratic-curve.html">canvas path quadratic curve test</a></li>
         <li><a href="pngsuite_siz_png.html">pngsuite odd sizes test</a></li>
         <li><a href="pngsuite_bas_png.html">pngsuite basic formats test</a></li>
+        <li><a href="pngsuite_int_png.html">pngsuite interlacing test</a></li>
         <li><a href="canvas-path.html">canvas path house!</a></li>
         <li><a href="img-canvas.html">canvas drawImage() test</a></li>
         <li><a href="trigonometry.html">canvas + trigonometry functions</a></li>

--- a/Libraries/LibGfx/PNGLoader.cpp
+++ b/Libraries/LibGfx/PNGLoader.cpp
@@ -387,7 +387,7 @@ NEVER_INLINE FLATTEN static void unfilter(PNGLoadingContext& context)
         if (context.bit_depth == 8) {
             unpack_triplets_without_alpha<u8>(context);
         } else if (context.bit_depth == 16) {
-            unpack_grayscale_without_alpha<u16>(context);
+            unpack_triplets_without_alpha<u16>(context);
         } else {
             ASSERT_NOT_REACHED();
         }


### PR DESCRIPTION
I was inspired after watching the ACID2 video on Youtube!
Implement interlaced PNG support. 
Fix an bug in 16-bit RGB PNG decoding I found along the way
Add some interlaced PNG examples for the browser