### PR TITLE
LibWeb: Implement HTML caption, column group and table insertion modes.

### DIFF
--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -968,7 +968,7 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::form) {
-        if (m_form_element && m_stack_of_open_elements.contains(HTML::TagNames::template_)) {
+        if (m_form_element && !m_stack_of_open_elements.contains(HTML::TagNames::template_)) {
             PARSE_ERROR();
             return;
         }
@@ -1257,7 +1257,7 @@ void HTMLDocumentParser::handle_in_body(HTMLToken& token)
         m_stack_of_open_elements.pop();
         token.acknowledge_self_closing_flag_if_set();
         auto type_attribute = token.attribute(HTML::AttributeNames::type);
-        if (type_attribute.is_null() || type_attribute != "hidden") {
+        if (type_attribute.is_null() || !type_attribute.equals_ignoring_case("hidden")) {
             m_frameset_ok = false;
         }
         return;
@@ -1780,14 +1780,21 @@ void HTMLDocumentParser::handle_in_table(HTMLToken& token)
         fake_tbody_token.m_tag.tag_name.append(HTML::TagNames::tbody);
         insert_html_element(fake_tbody_token);
         m_insertion_mode = InsertionMode::InTableBody;
-        process_using_the_rules_for(InsertionMode::InTableBody, token);
+        process_using_the_rules_for(m_insertion_mode, token);
         return;
     }
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::table) {
         PARSE_ERROR();
-        TODO();
+        if (!m_stack_of_open_elements.has_in_table_scope(HTML::TagNames::table))
+            return;
+
+        m_stack_of_open_elements.pop_until_an_element_with_tag_name_has_been_popped(HTML::TagNames::table);
+
+        reset_the_insertion_mode_appropriately();
+        process_using_the_rules_for(m_insertion_mode, token);
+        return;
     }
-    if (token.is_end_tag()) {
+    if (token.is_end_tag() && token.tag_name() == HTML::TagNames::table) {
         if (!m_stack_of_open_elements.has_in_table_scope(HTML::TagNames::table)) {
             PARSE_ERROR();
             return;
@@ -1798,7 +1805,53 @@ void HTMLDocumentParser::handle_in_table(HTMLToken& token)
         reset_the_insertion_mode_appropriately();
         return;
     }
-    TODO();
+    if (token.is_end_tag() && token.tag_name().is_one_of(HTML::TagNames::body, HTML::TagNames::caption, HTML::TagNames::col, HTML::TagNames::colgroup, HTML::TagNames::html, HTML::TagNames::tbody, HTML::TagNames::td, HTML::TagNames::tfoot, HTML::TagNames::th, HTML::TagNames::thead, HTML::TagNames::tr)) {
+        PARSE_ERROR();
+        return;
+    }
+    if ((token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::style, HTML::TagNames::script, HTML::TagNames::template_))
+         || (token.is_end_tag() && token.tag_name() == HTML::TagNames::template_)) {
+        process_using_the_rules_for(InsertionMode::InHead, token);
+        return;
+    }
+    if (token.is_start_tag() && token.tag_name() == HTML::TagNames::input) {
+        auto type_attribute = token.attribute(HTML::AttributeNames::type);
+        if (type_attribute.is_null() || !type_attribute.equals_ignoring_case("hidden")) {
+            goto AnythingElse;
+        }
+
+        PARSE_ERROR();
+        insert_html_element(token);
+
+        // FIXME: Is this the correct interpretation of "Pop that input element off the stack of open elements."?
+        //        Because this wording is the first time it's seen in the spec.
+        //        Other times it's worded as: "Immediately pop the current node off the stack of open elements."
+        m_stack_of_open_elements.pop();
+        token.acknowledge_self_closing_flag_if_set();
+        return;
+    }
+    if (token.is_start_tag() && token.tag_name() == HTML::TagNames::form) {
+        PARSE_ERROR();
+        if (m_form_element || m_stack_of_open_elements.contains(HTML::TagNames::template_)) {
+            return;
+        }
+
+        m_form_element = to<HTMLFormElement>(insert_html_element(token));
+
+        // FIXME: See previous FIXME, as this is the same situation but for form.
+        m_stack_of_open_elements.pop();
+        return;
+    }
+    if (token.is_end_of_file()) {
+        process_using_the_rules_for(InsertionMode::InBody, token);
+        return;
+    }
+
+AnythingElse:
+    PARSE_ERROR();
+    m_foster_parenting = true;
+    process_using_the_rules_for(InsertionMode::InBody, token);
+    m_foster_parenting = false;
 }
 
 void HTMLDocumentParser::handle_in_select_in_table(HTMLToken& token)

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -149,6 +149,9 @@ void HTMLDocumentParser::process_using_the_rules_for(InsertionMode mode, HTMLTok
     case InsertionMode::InSelect:
         handle_in_select(token);
         break;
+    case InsertionMode::InCaption:
+        handle_in_caption(token);
+        break;
     default:
         ASSERT_NOT_REACHED();
     }
@@ -1739,7 +1742,11 @@ void HTMLDocumentParser::handle_in_table(HTMLToken& token)
         return;
     }
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::caption) {
-        TODO();
+        clear_the_stack_back_to_a_table_context();
+        m_list_of_active_formatting_elements.add_marker();
+        insert_html_element(token);
+        m_insertion_mode = InsertionMode::InCaption;
+        return;
     }
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::colgroup) {
         TODO();
@@ -1905,6 +1912,54 @@ void HTMLDocumentParser::handle_in_select(HTMLToken& token)
     }
 
     PARSE_ERROR();
+}
+
+void HTMLDocumentParser::handle_in_caption(HTMLToken& token)
+{
+    if (token.is_end_tag() && token.tag_name() == HTML::TagNames::caption) {
+        if (!m_stack_of_open_elements.has_in_table_scope(HTML::TagNames::caption)) {
+            PARSE_ERROR();
+            return;
+        }
+
+        generate_implied_end_tags();
+
+        if (current_node().tag_name() != HTML::TagNames::caption)
+            PARSE_ERROR();
+
+        m_stack_of_open_elements.pop_until_an_element_with_tag_name_has_been_popped(HTML::TagNames::caption);
+        m_list_of_active_formatting_elements.clear_up_to_the_last_marker();
+
+        m_insertion_mode = InsertionMode::InTable;
+        return;
+    }
+
+    if ((token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::caption, HTML::TagNames::col, HTML::TagNames::colgroup, HTML::TagNames::tbody, HTML::TagNames::td, HTML::TagNames::tfoot, HTML::TagNames::th, HTML::TagNames::thead, HTML::TagNames::tr))
+         || (token.is_end_tag() && token.tag_name() == HTML::TagNames::table)) {
+        if (!m_stack_of_open_elements.has_in_table_scope(HTML::TagNames::caption)) {
+            PARSE_ERROR();
+            return;
+        }
+
+        generate_implied_end_tags();
+
+        if (current_node().tag_name() != HTML::TagNames::caption)
+            PARSE_ERROR();
+
+        m_stack_of_open_elements.pop_until_an_element_with_tag_name_has_been_popped(HTML::TagNames::caption);
+        m_list_of_active_formatting_elements.clear_up_to_the_last_marker();
+
+        m_insertion_mode = InsertionMode::InTable;
+        process_using_the_rules_for(m_insertion_mode, token);
+        return;
+    }
+
+    if (token.is_end_tag() && token.tag_name().is_one_of(HTML::TagNames::body, HTML::TagNames::col, HTML::TagNames::colgroup, HTML::TagNames::html, HTML::TagNames::tbody, HTML::TagNames::td, HTML::TagNames::tfoot, HTML::TagNames::th, HTML::TagNames::thead, HTML::TagNames::tr)) {
+        PARSE_ERROR();
+        return;
+    }
+
+    process_using_the_rules_for(InsertionMode::InBody, token);
 }
 
 void HTMLDocumentParser::reset_the_insertion_mode_appropriately()

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -152,6 +152,9 @@ void HTMLDocumentParser::process_using_the_rules_for(InsertionMode mode, HTMLTok
     case InsertionMode::InCaption:
         handle_in_caption(token);
         break;
+    case InsertionMode::InColumnGroup:
+        handle_in_column_group(token);
+        break;
     default:
         ASSERT_NOT_REACHED();
     }
@@ -1749,10 +1752,20 @@ void HTMLDocumentParser::handle_in_table(HTMLToken& token)
         return;
     }
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::colgroup) {
-        TODO();
+        clear_the_stack_back_to_a_table_context();
+        insert_html_element(token);
+        m_insertion_mode = InsertionMode::InColumnGroup;
+        return;
     }
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::col) {
-        TODO();
+        clear_the_stack_back_to_a_table_context();
+        HTMLToken fake_colgroup_token;
+        fake_colgroup_token.m_type = HTMLToken::Type::StartTag;
+        fake_colgroup_token.m_tag.tag_name.append(HTML::TagNames::colgroup);
+        insert_html_element(fake_colgroup_token);
+        m_insertion_mode = InsertionMode::InColumnGroup;
+        process_using_the_rules_for(m_insertion_mode, token);
+        return;
     }
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::tbody, HTML::TagNames::tfoot, HTML::TagNames::thead)) {
         clear_the_stack_back_to_a_table_context();
@@ -1960,6 +1973,71 @@ void HTMLDocumentParser::handle_in_caption(HTMLToken& token)
     }
 
     process_using_the_rules_for(InsertionMode::InBody, token);
+}
+
+void HTMLDocumentParser::handle_in_column_group(HTMLToken& token)
+{
+    if (token.is_character() && token.is_parser_whitespace()) {
+        insert_character(token.codepoint());
+        return;
+    }
+
+    if (token.is_comment()) {
+        insert_comment(token);
+        return;
+    }
+
+    if (token.is_doctype()) {
+        PARSE_ERROR();
+        return;
+    }
+
+    if (token.is_start_tag() && token.tag_name() == HTML::TagNames::html) {
+        process_using_the_rules_for(InsertionMode::InBody, token);
+        return;
+    }
+
+    if (token.is_start_tag() && token.tag_name() == HTML::TagNames::col) {
+        insert_html_element(token);
+        m_stack_of_open_elements.pop();
+        token.acknowledge_self_closing_flag_if_set();
+        return;
+    }
+
+    if (token.is_end_tag() && token.tag_name() == HTML::TagNames::colgroup) {
+        if (current_node().tag_name() != HTML::TagNames::colgroup) {
+            PARSE_ERROR();
+            return;
+        }
+
+        m_stack_of_open_elements.pop();
+        m_insertion_mode = InsertionMode::InTable;
+        return;
+    }
+
+    if (token.is_end_tag() && token.tag_name() == HTML::TagNames::col) {
+        PARSE_ERROR();
+        return;
+    }
+
+    if ((token.is_start_tag() || token.is_end_tag()) && token.tag_name() == HTML::TagNames::template_) {
+        process_using_the_rules_for(InsertionMode::InHead, token);
+        return;
+    }
+
+    if (token.is_end_of_file()) {
+        process_using_the_rules_for(InsertionMode::InBody, token);
+        return;
+    }
+
+    if (current_node().tag_name() != HTML::TagNames::colgroup) {
+        PARSE_ERROR();
+        return;
+    }
+
+    m_stack_of_open_elements.pop();
+    m_insertion_mode = InsertionMode::InTable;
+    process_using_the_rules_for(m_insertion_mode, token);
 }
 
 void HTMLDocumentParser::reset_the_insertion_mode_appropriately()

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.h
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.h
@@ -99,6 +99,7 @@ private:
     void handle_in_select_in_table(HTMLToken&);
     void handle_in_select(HTMLToken&);
     void handle_in_caption(HTMLToken&);
+    void handle_in_column_group(HTMLToken&);
 
     void stop_parsing() { m_stop_parsing = true; }
 

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.h
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.h
@@ -98,6 +98,7 @@ private:
     void handle_in_table_text(HTMLToken&);
     void handle_in_select_in_table(HTMLToken&);
     void handle_in_select(HTMLToken&);
+    void handle_in_caption(HTMLToken&);
 
     void stop_parsing() { m_stop_parsing = true; }
 


### PR DESCRIPTION
Implements the "in caption", "in column group" and "in table" insertion modes in the HTML parser.

Also fixes some little mistakes in the "in body" insertion mode that I found whilst cross-referencing.