### PR TITLE
LibC: Declare pthread_sigmask() in signal.h.

### DIFF
--- a/Libraries/LibC/signal.h
+++ b/Libraries/LibC/signal.h
@@ -64,6 +64,7 @@ struct sigaction {
 int kill(pid_t, int sig);
 int killpg(int pgrp, int sig);
 sighandler_t signal(int sig, sighandler_t);
+int pthread_sigmask(int how, const sigset_t *set, sigset_t *ol_dset);
 int sigaction(int sig, const struct sigaction* act, struct sigaction* old_act);
 int sigemptyset(sigset_t*);
 int sigfillset(sigset_t*);


### PR DESCRIPTION
That's where it's supposed to be declared.