### PR TITLE
Docs: Spell CMake correctly in BuildInstructions

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -27,7 +27,7 @@ sudo apt-get install gcc-9 g++-9
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 ```
 
-Ensure your CMake version is >= 3.16 with `cmake --version`. If your package manager doesn't provide you with a suitable version you can download it directly from the [CMake website](https://cmake.org/download).
+Ensure your CMake version is >= 3.16 with `cmake --version`. If your system doesn't provide a suitable version of CMake, you can download a binary release from the [CMake website](https://cmake.org/download).
 
 #### macOS prerequisites
 Make sure you have all the dependencies installed:

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -27,7 +27,7 @@ sudo apt-get install gcc-9 g++-9
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 ```
 
-Ensure your cmake version is >= 3.16 with `cmake --version`. If your package manager doesn't provide you with a suitable version you can download it directly from the [cmake website](https://cmake.org/download).
+Ensure your CMake version is >= 3.16 with `cmake --version`. If your package manager doesn't provide you with a suitable version you can download it directly from the [CMake website](https://cmake.org/download).
 
 #### macOS prerequisites
 Make sure you have all the dependencies installed:


### PR DESCRIPTION
cc @bugaevc (#2562)

Re: apt providing CMake. I'm not quite sure a better wording for this part. From my limited understanding, each package manage has its own set of repositories that supplement those from your distro? So while `apt` might provide something a version 1, `snap` might provide the same package at version 1.5. 