### PR TITLE
LibC / Kernel: Implement seteuid() and friends!

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -2187,48 +2187,6 @@ int Process::sys$setgid(gid_t gid)
     return 0;
 }
 
-int Process::sys$setreuid(uid_t ruid, uid_t euid)
-{
-    REQUIRE_PROMISE(id);
-
-    // This has FreeBSD semantics.
-    // Linux and Solaris also allow id == m_suid.
-    auto ok = [this](uid_t id) { return id == (uid_t)-1 || id == m_uid || id == m_euid; };
-    if ((!ok(ruid) || !ok(euid)) && !is_superuser())
-        return -EPERM;
-
-    if (ruid != (uid_t)-1)
-        m_uid = ruid;
-    if (euid != (uid_t)-1)
-        m_euid = euid;
-
-    if (ruid != (uid_t)-1 || m_euid != m_uid)
-        m_suid = m_euid;
-
-    return 0;
-}
-
-int Process::sys$setregid(gid_t rgid, gid_t egid)
-{
-    REQUIRE_PROMISE(id);
-
-    // This has FreeBSD semantics.
-    // Linux and Solaris also allow id == m_sgid.
-    auto ok = [this](gid_t id) { return id == (gid_t)-1 || id == m_gid || id == m_egid; };
-    if ((!ok(rgid) || !ok(egid)) && !is_superuser())
-        return -EPERM;
-
-    if (rgid != (gid_t)-1)
-        m_gid = rgid;
-    if (egid != (gid_t)-1)
-        m_egid = egid;
-
-    if (rgid != (gid_t)-1 || m_egid != m_gid)
-        m_sgid = m_egid;
-
-    return 0;
-}
-
 int Process::sys$setresuid(uid_t ruid, uid_t euid, uid_t suid)
 {
     REQUIRE_PROMISE(id);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -141,11 +141,13 @@ public:
     pid_t pid() const { return m_pid; }
     pid_t sid() const { return m_sid; }
     pid_t pgid() const { return m_pgid; }
-    uid_t uid() const { return m_uid; }
-    gid_t gid() const { return m_gid; }
     const FixedArray<gid_t>& extra_gids() const { return m_extra_gids; }
     uid_t euid() const { return m_euid; }
     gid_t egid() const { return m_egid; }
+    uid_t uid() const { return m_uid; }
+    gid_t gid() const { return m_gid; }
+    uid_t suid() const { return m_suid; }
+    gid_t sgid() const { return m_sgid; }
     pid_t ppid() const { return m_ppid; }
 
     pid_t exec_tid() const { return m_exec_tid; }
@@ -191,6 +193,8 @@ public:
     gid_t sys$getegid();
     pid_t sys$getpid();
     pid_t sys$getppid();
+    int sys$getresuid(uid_t*, uid_t*, uid_t*);
+    int sys$getresgid(gid_t*, gid_t*, gid_t*);
     mode_t sys$umask(mode_t);
     int sys$open(const Syscall::SC_open_params*);
     int sys$close(int fd);
@@ -240,8 +244,14 @@ public:
     int sys$setgroups(ssize_t, const gid_t*);
     int sys$pipe(int pipefd[2], int flags);
     int sys$killpg(int pgrp, int sig);
-    int sys$setgid(gid_t);
+    int sys$seteuid(uid_t);
+    int sys$setegid(gid_t);
     int sys$setuid(uid_t);
+    int sys$setgid(gid_t);
+    int sys$setreuid(uid_t, uid_t);
+    int sys$setregid(gid_t, gid_t);
+    int sys$setresuid(uid_t, uid_t, uid_t);
+    int sys$setresgid(gid_t, gid_t, gid_t);
     unsigned sys$alarm(unsigned seconds);
     int sys$access(const char* pathname, size_t path_length, int mode);
     int sys$fcntl(int fd, int cmd, u32 extra_arg);
@@ -479,12 +489,15 @@ private:
     String m_name;
 
     pid_t m_pid { 0 };
-    uid_t m_uid { 0 };
-    gid_t m_gid { 0 };
-    uid_t m_euid { 0 };
-    gid_t m_egid { 0 };
     pid_t m_sid { 0 };
     pid_t m_pgid { 0 };
+
+    uid_t m_euid { 0 };
+    gid_t m_egid { 0 };
+    uid_t m_uid { 0 };
+    gid_t m_gid { 0 };
+    uid_t m_suid { 0 };
+    gid_t m_sgid { 0 };
 
     pid_t m_exec_tid { 0 };
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -248,8 +248,6 @@ public:
     int sys$setegid(gid_t);
     int sys$setuid(uid_t);
     int sys$setgid(gid_t);
-    int sys$setreuid(uid_t, uid_t);
-    int sys$setregid(gid_t, gid_t);
     int sys$setresuid(uid_t, uid_t, uid_t);
     int sys$setresgid(gid_t, gid_t, gid_t);
     unsigned sys$alarm(unsigned seconds);

--- a/Kernel/Syscall.h
+++ b/Kernel/Syscall.h
@@ -54,8 +54,13 @@ namespace Kernel {
     __ENUMERATE_SYSCALL(kill)               \
     __ENUMERATE_SYSCALL(getuid)             \
     __ENUMERATE_SYSCALL(exit)               \
+    __ENUMERATE_SYSCALL(geteuid)            \
+    __ENUMERATE_SYSCALL(getegid)            \
     __ENUMERATE_SYSCALL(getgid)             \
     __ENUMERATE_SYSCALL(getpid)             \
+    __ENUMERATE_SYSCALL(getppid)            \
+    __ENUMERATE_SYSCALL(getresuid)          \
+    __ENUMERATE_SYSCALL(getresgid)          \
     __ENUMERATE_SYSCALL(waitid)             \
     __ENUMERATE_SYSCALL(mmap)               \
     __ENUMERATE_SYSCALL(munmap)             \
@@ -78,12 +83,9 @@ namespace Kernel {
     __ENUMERATE_SYSCALL(getpgrp)            \
     __ENUMERATE_SYSCALL(fork)               \
     __ENUMERATE_SYSCALL(execve)             \
-    __ENUMERATE_SYSCALL(geteuid)            \
-    __ENUMERATE_SYSCALL(getegid)            \
     __ENUMERATE_SYSCALL(dup)                \
     __ENUMERATE_SYSCALL(dup2)               \
     __ENUMERATE_SYSCALL(sigaction)          \
-    __ENUMERATE_SYSCALL(getppid)            \
     __ENUMERATE_SYSCALL(umask)              \
     __ENUMERATE_SYSCALL(getgroups)          \
     __ENUMERATE_SYSCALL(setgroups)          \
@@ -92,8 +94,14 @@ namespace Kernel {
     __ENUMERATE_SYSCALL(sigpending)         \
     __ENUMERATE_SYSCALL(pipe)               \
     __ENUMERATE_SYSCALL(killpg)             \
+    __ENUMERATE_SYSCALL(seteuid)            \
+    __ENUMERATE_SYSCALL(setegid)            \
     __ENUMERATE_SYSCALL(setuid)             \
     __ENUMERATE_SYSCALL(setgid)             \
+    __ENUMERATE_SYSCALL(setreuid)           \
+    __ENUMERATE_SYSCALL(setregid)           \
+    __ENUMERATE_SYSCALL(setresuid)          \
+    __ENUMERATE_SYSCALL(setresgid)          \
     __ENUMERATE_SYSCALL(alarm)              \
     __ENUMERATE_SYSCALL(fstat)              \
     __ENUMERATE_SYSCALL(access)             \

--- a/Kernel/Syscall.h
+++ b/Kernel/Syscall.h
@@ -98,8 +98,6 @@ namespace Kernel {
     __ENUMERATE_SYSCALL(setegid)            \
     __ENUMERATE_SYSCALL(setuid)             \
     __ENUMERATE_SYSCALL(setgid)             \
-    __ENUMERATE_SYSCALL(setreuid)           \
-    __ENUMERATE_SYSCALL(setregid)           \
     __ENUMERATE_SYSCALL(setresuid)          \
     __ENUMERATE_SYSCALL(setresgid)          \
     __ENUMERATE_SYSCALL(alarm)              \

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -491,18 +491,6 @@ int setgid(gid_t gid)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-int setreuid(uid_t ruid, uid_t euid)
-{
-    int rc = syscall(SC_setreuid, ruid, euid);
-    __RETURN_WITH_ERRNO(rc, rc, -1);
-}
-
-int setregid(gid_t rgid, gid_t egid)
-{
-    int rc = syscall(SC_setregid, rgid, egid);
-    __RETURN_WITH_ERRNO(rc, rc, -1);
-}
-
 int setresuid(uid_t ruid, uid_t euid, uid_t suid)
 {
     int rc = syscall(SC_setresuid, ruid, euid, suid);

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -177,16 +177,6 @@ int execlp(const char* filename, const char* arg0, ...)
     return execvpe(filename, const_cast<char* const*>(args.data()), environ);
 }
 
-uid_t getuid()
-{
-    return syscall(SC_getuid);
-}
-
-gid_t getgid()
-{
-    return syscall(SC_getgid);
-}
-
 uid_t geteuid()
 {
     return syscall(SC_geteuid);
@@ -197,6 +187,16 @@ gid_t getegid()
     return syscall(SC_getegid);
 }
 
+uid_t getuid()
+{
+    return syscall(SC_getuid);
+}
+
+gid_t getgid()
+{
+    return syscall(SC_getgid);
+}
+
 pid_t getpid()
 {
     return syscall(SC_getpid);
@@ -205,6 +205,16 @@ pid_t getpid()
 pid_t getppid()
 {
     return syscall(SC_getppid);
+}
+
+int getresuid(uid_t* ruid, uid_t* euid, uid_t* suid)
+{
+    return syscall(SC_getresuid, ruid, euid, suid);
+}
+
+int getresgid(gid_t *rgid, gid_t *egid, gid_t *sgid)
+{
+    return syscall(SC_getresgid, rgid, egid, sgid);
 }
 
 pid_t getsid(pid_t pid)
@@ -457,6 +467,18 @@ unsigned int alarm(unsigned int seconds)
     return syscall(SC_alarm, seconds);
 }
 
+int seteuid(uid_t euid)
+{
+    int rc = syscall(SC_seteuid, euid);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+int setegid(gid_t egid)
+{
+    int rc = syscall(SC_setegid, egid);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
 int setuid(uid_t uid)
 {
     int rc = syscall(SC_setuid, uid);
@@ -466,6 +488,30 @@ int setuid(uid_t uid)
 int setgid(gid_t gid)
 {
     int rc = syscall(SC_setgid, gid);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+int setreuid(uid_t ruid, uid_t euid)
+{
+    int rc = syscall(SC_setreuid, ruid, euid);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+int setregid(gid_t rgid, gid_t egid)
+{
+    int rc = syscall(SC_setregid, rgid, egid);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+int setresuid(uid_t ruid, uid_t euid, uid_t suid)
+{
+    int rc = syscall(SC_setresuid, ruid, euid, suid);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+int setresgid(gid_t rgid, gid_t egid, gid_t sgid)
+{
+    int rc = syscall(SC_setresgid, rgid, egid, sgid);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -84,10 +84,18 @@ uid_t getuid();
 gid_t getgid();
 pid_t getpid();
 pid_t getppid();
+int getresuid(uid_t *, uid_t *, uid_t *);
+int getresgid(gid_t *, gid_t *, gid_t *);
 int getgroups(int size, gid_t list[]);
 int setgroups(size_t, const gid_t*);
+int seteuid(uid_t);
+int setegid(gid_t);
 int setuid(uid_t);
 int setgid(gid_t);
+int setreuid(uid_t, uid_t);
+int setregid(gid_t, gid_t);
+int setresuid(uid_t, uid_t, uid_t);
+int setresgid(gid_t, gid_t, gid_t);
 pid_t tcgetpgrp(int fd);
 int tcsetpgrp(int fd, pid_t pgid);
 ssize_t read(int fd, void* buf, size_t count);
@@ -156,6 +164,8 @@ enum {
 #define MS_BIND (1 << 3)
 #define MS_RDONLY (1 << 4)
 #define MS_REMOUNT (1 << 5)
+
+#define _POSIX_SAVED_IDS
 
 /*
  * We aren't fully compliant (don't support policies, and don't have a wide

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -92,8 +92,6 @@ int seteuid(uid_t);
 int setegid(gid_t);
 int setuid(uid_t);
 int setgid(gid_t);
-int setreuid(uid_t, uid_t);
-int setregid(gid_t, gid_t);
 int setresuid(uid_t, uid_t, uid_t);
 int setresgid(gid_t, gid_t, gid_t);
 pid_t tcgetpgrp(int fd);


### PR DESCRIPTION
Add seteuid()/setegid() under _POSIX_SAVED_IDS semantics,
which also requires adding suid and sgid to Process, and
changing setuid()/setgid() to honor these semantics.

The exact semantics aren't specified by POSIX and differ
between different Unix implementations. This patch makes
serenity follow FreeBSD. The 2002 USENIX paper
"Setuid Demystified" explains the differences well.

In addition to seteuid() and setegid() this also adds
setresuid()/setresgid(), and the accessors getresuid()/getresgid().

Also reorder uid/euid functions so that they are the
same order everywhere (namely, the order that
geteuid()/getuid() already have).
