### PR TITLE
Use curl instead of wget for Toolchain/BuildIt*.

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -36,7 +36,6 @@ brew install coreutils
 brew tap discoteq/discoteq
 brew install flock
 brew install qemu
-brew install wget
 brew install e2fsprogs
 brew install m4
 brew install autoconf

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -117,7 +117,7 @@ pushd "$DIR/Tarballs"
     echo "bu md5='$md5'"
     if [ ! -e $BINUTILS_PKG ] || [ "$md5" != ${BINUTILS_MD5SUM} ] ; then
         rm -f $BINUTILS_PKG
-        wget "$BINUTILS_BASE_URL/$BINUTILS_PKG"
+        curl -LO "$BINUTILS_BASE_URL/$BINUTILS_PKG"
     else
         echo "Skipped downloading binutils"
     fi
@@ -126,7 +126,7 @@ pushd "$DIR/Tarballs"
     echo "gc md5='$md5'"
     if [ ! -e $GCC_PKG ] || [ "$md5" != ${GCC_MD5SUM} ] ; then
         rm -f $GCC_PKG
-        wget "$GCC_BASE_URL/$GCC_NAME/$GCC_PKG"
+        curl -LO "$GCC_BASE_URL/$GCC_NAME/$GCC_PKG"
     else
         echo "Skipped downloading gcc"
     fi

--- a/Toolchain/BuildIt_x86_64.sh
+++ b/Toolchain/BuildIt_x86_64.sh
@@ -52,7 +52,7 @@ pushd "$DIR/Tarballs"
     echo "bu md5='$md5'"
     if [ ! -e $BINUTILS_PKG ] || [ "$md5" != ${BINUTILS_MD5SUM} ] ; then
         rm -f $BINUTILS_PKG
-        wget "$BINUTILS_BASE_URL/$BINUTILS_PKG"
+        curl -LO "$BINUTILS_BASE_URL/$BINUTILS_PKG"
     else
         echo "Skipped downloading binutils"
     fi
@@ -61,7 +61,7 @@ pushd "$DIR/Tarballs"
     echo "gc md5='$md5'"
     if [ ! -e $GCC_PKG ] || [ "$md5" != ${GCC_MD5SUM} ] ; then
         rm -f $GCC_PKG
-        wget "$GCC_BASE_URL/$GCC_NAME/$GCC_PKG"
+        curl -LO "$GCC_BASE_URL/$GCC_NAME/$GCC_PKG"
     else
         echo "Skipped downloading gcc"
     fi


### PR DESCRIPTION
- For Linux: curl is already listed as a dependency;
- For macOS: curl is pre-installed;
- For OpenBSD and FreeBSD: curl is a dependecy of git.