### PR TITLE
CMake: Make the install step more zen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "")
     "and that's all there is.")
 endif()
 
+set(CMAKE_INSTALL_MESSAGE NEVER)
+
 enable_testing()
 
 add_custom_target(image


### PR DESCRIPTION
The "Installing $foo..." messages are just noise, so turn them off.

Not sure how folks feel about this; personally I haven't found the 'installing' messages useful so far.

If others do like them, there's also LAZY which at least turns off the "$foo is up-to-date" messages which maybe more people can agree on are useless.