### PR TITLE
More (final?) posix_spawn tweaks

### DIFF
--- a/Libraries/LibC/spawn.cpp
+++ b/Libraries/LibC/spawn.cpp
@@ -56,23 +56,23 @@ extern "C" {
         if (flags & POSIX_SPAWN_RESETIDS) {
             if (seteuid(getuid()) < 0) {
                 perror("posix_spawn seteuid");
-                exit(127);
+                _exit(127);
             }
             if (setegid(getgid()) < 0) {
                 perror("posix_spawn setegid");
-                exit(127);
+                _exit(127);
             }
         }
         if (flags & POSIX_SPAWN_SETPGROUP) {
             if (setpgid(0, attr->pgroup) < 0) {
                 perror("posix_spawn setpgid");
-                exit(127);
+                _exit(127);
             }
         }
         if (flags & POSIX_SPAWN_SETSCHEDPARAM) {
             if (sched_setparam(0, &attr->schedparam) < 0) {
                 perror("posix_spawn sched_setparam");
-                exit(127);
+                _exit(127);
             }
         }
         if (flags & POSIX_SPAWN_SETSIGDEF) {
@@ -85,20 +85,20 @@ extern "C" {
             for (int i = 0; i < NSIG; ++i) {
                 if (sigismember(&sigdefault, i) && sigaction(i, &default_action, nullptr) < 0) {
                     perror("posix_spawn sigaction");
-                    exit(127);
+                    _exit(127);
                 }
             }
         }
         if (flags & POSIX_SPAWN_SETSIGMASK) {
             if (sigprocmask(SIG_SETMASK, &attr->sigmask, nullptr) < 0) {
                 perror("posix_spawn sigprocmask");
-                exit(127);
+                _exit(127);
             }
         }
         if (flags & POSIX_SPAWN_SETSID) {
             if (setsid() < 0) {
                 perror("posix_spawn setsid");
-                exit(127);
+                _exit(127);
             }
         }
 
@@ -109,14 +109,14 @@ extern "C" {
         for (const auto& action : file_actions->state->actions) {
             if (action() < 0) {
                 perror("posix_spawn file action");
-                exit(127);
+                _exit(127);
             }
         }
     }
 
     exec(path, argv, envp);
     perror("posix_spawn exec");
-    exit(127);
+    _exit(127);
 }
 
 int posix_spawn(pid_t* out_pid, const char* path, const posix_spawn_file_actions_t* file_actions, const posix_spawnattr_t* attr, char* const argv[], char* const envp[])

--- a/Libraries/LibC/spawn.cpp
+++ b/Libraries/LibC/spawn.cpp
@@ -90,7 +90,7 @@ extern "C" {
             }
         }
         if (flags & POSIX_SPAWN_SETSIGMASK) {
-            if (sigprocmask(SIG_SETMASK, &attr->sigmask, nullptr) != 0) {
+            if (sigprocmask(SIG_SETMASK, &attr->sigmask, nullptr) < 0) {
                 perror("posix_spawn sigprocmask");
                 exit(127);
             }

--- a/Libraries/LibC/spawn.cpp
+++ b/Libraries/LibC/spawn.cpp
@@ -95,6 +95,12 @@ extern "C" {
                 exit(127);
             }
         }
+        if (flags & POSIX_SPAWN_SETSID) {
+            if (setsid() < 0) {
+                perror("posix_spawn setsid");
+                exit(127);
+            }
+        }
 
         // FIXME: POSIX_SPAWN_SETSCHEDULER
     }
@@ -232,7 +238,7 @@ int posix_spawnattr_init(posix_spawnattr_t* attr)
 
 int posix_spawnattr_setflags(posix_spawnattr_t* attr, short flags)
 {
-    if (flags & ~(POSIX_SPAWN_RESETIDS | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSCHEDPARAM | POSIX_SPAWN_SETSCHEDULER | POSIX_SPAWN_SETSIGDEF | POSIX_SPAWN_SETSIGMASK))
+    if (flags & ~(POSIX_SPAWN_RESETIDS | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSCHEDPARAM | POSIX_SPAWN_SETSCHEDULER | POSIX_SPAWN_SETSIGDEF | POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSID))
         return EINVAL;
 
     attr->flags = flags;

--- a/Libraries/LibC/spawn.cpp
+++ b/Libraries/LibC/spawn.cpp
@@ -147,6 +147,18 @@ int posix_spawnp(pid_t* out_pid, const char* path, const posix_spawn_file_action
     posix_spawn_child(path, file_actions, attr, argv, envp, execvpe);
 }
 
+int posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t* actions, const char* path)
+{
+    actions->state->actions.append([path]() { return chdir(path); });
+    return 0;
+}
+
+int posix_spawn_file_actions_addfchdir(posix_spawn_file_actions_t* actions, int fd)
+{
+    actions->state->actions.append([fd]() { return fchdir(fd); });
+    return 0;
+}
+
 int posix_spawn_file_actions_addclose(posix_spawn_file_actions_t* actions, int fd)
 {
     actions->state->actions.append([fd]() { return close(fd); });

--- a/Libraries/LibC/spawn.h
+++ b/Libraries/LibC/spawn.h
@@ -50,7 +50,11 @@ enum {
 
     POSIX_SPAWN_SETSIGDEF = 1 << 4,
     POSIX_SPAWN_SETSIGMASK = 1 << 5,
+
+    POSIX_SPAWN_SETSID = 1 << 6,
 };
+
+#define POSIX_SPAWN_SETSID POSIX_SPAWN_SETSID
 
 struct posix_spawn_file_actions_state;
 typedef struct {

--- a/Libraries/LibC/spawn.h
+++ b/Libraries/LibC/spawn.h
@@ -73,6 +73,8 @@ typedef struct {
 int posix_spawn(pid_t*, const char*, const posix_spawn_file_actions_t*, const posix_spawnattr_t*, char* const[], char* const[]);
 int posix_spawnp(pid_t*, const char*, const posix_spawn_file_actions_t*, const posix_spawnattr_t*, char* const[], char* const[]);
 
+int posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t*, const char*);
+int posix_spawn_file_actions_addfchdir(posix_spawn_file_actions_t*, int);
 int posix_spawn_file_actions_addclose(posix_spawn_file_actions_t*, int);
 int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t*, int old_fd, int new_fd);
 int posix_spawn_file_actions_addopen(posix_spawn_file_actions_t*, int fd, const char*, int flags, mode_t);


### PR DESCRIPTION
- add 2 extensions (both accepted in the upstream posix for future standardization from what I understand -- see links in commit messages):
-- `POSIX_SPAWN_SETSIGMASK`
-- `posix_spaw_fileactions_add(f)chdir()`
- use _exit instead of exit
- one minor formatting tweak