### PR TITLE
Meta: some minor tweaks to build-image-*.sh scripts to allow running `make grub-image` without `sudo`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_INSTALL_MESSAGE NEVER)
 enable_testing()
 
 add_custom_target(image
-    COMMAND ${CMAKE_COMMAND} -E env "SERENITY_ROOT=${CMAKE_SOURCE_DIR}" ${CMAKE_SOURCE_DIR}/Meta/sync.sh
+    COMMAND ${CMAKE_COMMAND} -E env "SERENITY_ROOT=${CMAKE_SOURCE_DIR}" ${CMAKE_SOURCE_DIR}/Meta/build-image-qemu.sh
     BYPRODUCTS ${CMAKE_BINARY_DIR}/_disk_image
     USES_TERMINAL
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,17 +12,19 @@ set(CMAKE_INSTALL_MESSAGE NEVER)
 
 enable_testing()
 
-add_custom_target(image
-    COMMAND ${CMAKE_COMMAND} -E env "SERENITY_ROOT=${CMAKE_SOURCE_DIR}" ${CMAKE_SOURCE_DIR}/Meta/build-image-qemu.sh
-    BYPRODUCTS ${CMAKE_BINARY_DIR}/_disk_image
-    USES_TERMINAL
-)
-
 add_custom_target(run
     COMMAND ${CMAKE_SOURCE_DIR}/Meta/run.sh
     USES_TERMINAL
 )
 
+add_custom_target(image
+    DEPENDS qemu-image
+)
+add_custom_target(qemu-image
+    COMMAND ${CMAKE_COMMAND} -E env "SERENITY_ROOT=${CMAKE_SOURCE_DIR}" ${CMAKE_SOURCE_DIR}/Meta/build-image-qemu.sh
+    BYPRODUCTS ${CMAKE_BINARY_DIR}/_disk_image
+    USES_TERMINAL
+)
 add_custom_target(grub-image
     COMMAND ${CMAKE_COMMAND} -E env "SERENITY_ROOT=${CMAKE_SOURCE_DIR}" ${CMAKE_SOURCE_DIR}/Meta/build-image-grub.sh
     BYPRODUCTS ${CMAKE_BINARY_DIR}/grub_disk_image

--- a/Documentation/INSTALL.md
+++ b/Documentation/INSTALL.md
@@ -17,7 +17,7 @@ At present there is no real GPU support so don't expect OpenGL, Vulkan nor accel
 
 ## Creating a Serenity GRUB disk image
 
-Before creating a Serenity disk image, you need to build the OS as described in the [SerenityOS build instructions](https://github.com/SerenityOS/serenity/blob/master/Documentation/BuildInstructions.md). Follow those instructions up to and including running **make install**. After the OS has built, run **sudo make grub-image** to create a new file called **grub_disk_image** that has GRUB2 installed that can be booted on a real PC.
+Before creating a Serenity disk image, you need to build the OS as described in the [SerenityOS build instructions](https://github.com/SerenityOS/serenity/blob/master/Documentation/BuildInstructions.md). Follow those instructions up to and including running **make install**. After the OS has built, run **make grub-image** to create a new file called **grub_disk_image** that has GRUB2 installed that can be booted on a real PC.
 
 The final step is copying **grub_disk_image** onto the disk you wish to boot Serenity off using a command such as:
 

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -8,7 +8,7 @@ die() {
 }
 
 if [ "$(id -u)" != 0 ]; then
-    die "this script needs to run as root"
+    exec sudo -E -- "$0" "$@" || die "this script needs to run as root"
 fi
 
 grub=$(command -v grub-install 2>/dev/null) || true

--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -9,6 +9,8 @@ die() {
 
 if [ "$(id -u)" != 0 ]; then
     exec sudo -E -- "$0" "$@" || die "this script needs to run as root"
+else
+    : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi
 
 grub=$(command -v grub-install 2>/dev/null) || true

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -8,8 +8,9 @@ die() {
 }
 
 if [ "$(id -u)" != 0 ]; then
-    die "this script needs to run as root"
+    exec sudo -E -- "$0" "$@" || die "this script needs to run as root"
 fi
+
 if [ "$(uname -s)" = "Darwin" ]; then
     export PATH="/usr/local/opt/e2fsprogs/bin:$PATH"
     export PATH="/usr/local/opt/e2fsprogs/sbin:$PATH"

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -9,6 +9,8 @@ die() {
 
 if [ "$(id -u)" != 0 ]; then
     exec sudo -E -- "$0" "$@" || die "this script needs to run as root"
+else
+    : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi
 
 if [ "$(uname -s)" = "Darwin" ]; then

--- a/Meta/sync.sh
+++ b/Meta/sync.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -e
-
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-
-sudo -E PATH="$PATH" "$script_path/build-image-qemu.sh"


### PR DESCRIPTION
Now, if `[ $(id -u) != 0 ]` returns success, `build-image-*.sh` scripts will try to `exec` themselves with `sudo`.

```sh
if [ "$(id -u)" != 0 ]; then
    exec sudo -E -- "$0" "$@" || die "this script needs to run as root"
fi
```

This change allows running `make grub-image` without `sudo`.

Since `build-image-qemu.sh` will now `exec` itself with `sudo` if the user is not `root`, `sync.sh` is no longer needed.