### PR TITLE
LibWeb: Assume URLs ending in / serve html content :^)

### DIFF
--- a/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Libraries/LibWeb/Loader/Resource.cpp
@@ -87,6 +87,8 @@ static String guess_mime_type_based_on_filename(const URL& url)
         return "text/markdown";
     if (url.path().ends_with(".html") || url.path().ends_with(".htm"))
         return "text/html";
+    if (url.path().ends_with("/"))
+        return "text/html";
     return "text/plain";
 }
 


### PR DESCRIPTION
Its a common thing to url rewrite `file.html` to `/file/` (or just `/file`), so lets assume those are serving HTML content.

We might just want to assume that its html by default instead?

Fixes #2601 :)