### PR TITLE
LibWeb: Update parser to support more insertion modes

### DIFF
--- a/Libraries/LibWeb/DOM/TagNames.h
+++ b/Libraries/LibWeb/DOM/TagNames.h
@@ -87,6 +87,7 @@ void initialize();
     __ENUMERATE_HTML_TAG(html)       \
     __ENUMERATE_HTML_TAG(i)          \
     __ENUMERATE_HTML_TAG(iframe)     \
+    __ENUMERATE_HTML_TAG(image)      \
     __ENUMERATE_HTML_TAG(img)        \
     __ENUMERATE_HTML_TAG(input)      \
     __ENUMERATE_HTML_TAG(keygen)     \
@@ -95,6 +96,7 @@ void initialize();
     __ENUMERATE_HTML_TAG(listing)    \
     __ENUMERATE_HTML_TAG(main)       \
     __ENUMERATE_HTML_TAG(marquee)    \
+    __ENUMERATE_HTML_TAG(math)       \
     __ENUMERATE_HTML_TAG(menu)       \
     __ENUMERATE_HTML_TAG(meta)       \
     __ENUMERATE_HTML_TAG(nav)        \
@@ -110,6 +112,7 @@ void initialize();
     __ENUMERATE_HTML_TAG(param)      \
     __ENUMERATE_HTML_TAG(plaintext)  \
     __ENUMERATE_HTML_TAG(pre)        \
+    __ENUMERATE_HTML_TAG(ruby)       \
     __ENUMERATE_HTML_TAG(rb)         \
     __ENUMERATE_HTML_TAG(rp)         \
     __ENUMERATE_HTML_TAG(rt)         \
@@ -125,6 +128,7 @@ void initialize();
     __ENUMERATE_HTML_TAG(strong)     \
     __ENUMERATE_HTML_TAG(style)      \
     __ENUMERATE_HTML_TAG(summary)    \
+    __ENUMERATE_HTML_TAG(svg)        \
     __ENUMERATE_HTML_TAG(table)      \
     __ENUMERATE_HTML_TAG(tbody)      \
     __ENUMERATE_HTML_TAG(td)         \

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.h
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.h
@@ -100,6 +100,10 @@ private:
     void handle_in_select(HTMLToken&);
     void handle_in_caption(HTMLToken&);
     void handle_in_column_group(HTMLToken&);
+    void handle_in_template(HTMLToken&);
+    void handle_in_frameset(HTMLToken&);
+    void handle_after_frameset(HTMLToken&);
+    void handle_after_after_frameset(HTMLToken&);
 
     void stop_parsing() { m_stop_parsing = true; }
 
@@ -123,6 +127,10 @@ private:
     size_t script_nesting_level() const { return m_script_nesting_level; }
     void reset_the_insertion_mode_appropriately();
 
+    void adjust_mathml_attributes(HTMLToken&);
+    void adjust_svg_attributes(HTMLToken&);
+    void adjust_foreign_attributes(HTMLToken&);
+
     enum AdoptionAgencyAlgorithmOutcome {
         DoNothing,
         RunAnyOtherEndTagSteps,
@@ -138,6 +146,7 @@ private:
     InsertionMode m_original_insertion_mode { InsertionMode::Initial };
 
     StackOfOpenElements m_stack_of_open_elements;
+    Vector<InsertionMode> m_stack_of_template_insertion_modes;
     ListOfActiveFormattingElements m_list_of_active_formatting_elements;
 
     HTMLTokenizer m_tokenizer;

--- a/Libraries/LibWeb/Parser/HTMLToken.cpp
+++ b/Libraries/LibWeb/Parser/HTMLToken.cpp
@@ -63,7 +63,7 @@ String HTMLToken::to_string() const
         builder.append(m_tag.tag_name.to_string());
         builder.append("', { ");
         for (auto& attribute : m_tag.attributes) {
-            builder.append(attribute.name_builder.to_string());
+            builder.append(attribute.local_name_builder.to_string());
             builder.append("=\"");
             builder.append(attribute.value_builder.to_string());
             builder.append("\" ");

--- a/Libraries/LibWeb/Parser/HTMLToken.h
+++ b/Libraries/LibWeb/Parser/HTMLToken.h
@@ -118,10 +118,38 @@ public:
     {
         ASSERT(is_start_tag() || is_end_tag());
         for (auto& attribute : m_tag.attributes) {
-            if (attribute_name == attribute.name_builder.string_view())
+            if (attribute_name == attribute.local_name_builder.string_view())
                 return attribute.value_builder.string_view();
         }
         return {};
+    }
+
+    void adjust_attribute_name(const FlyString& old_name, const FlyString& new_name)
+    {
+        ASSERT(is_start_tag() || is_end_tag());
+        for (auto& attribute : m_tag.attributes) {
+            if (old_name == attribute.local_name_builder.string_view()) {
+                attribute.local_name_builder.clear();
+                attribute.local_name_builder.append(new_name);
+            }
+        }
+    }
+
+    void adjust_foreign_attribute(const FlyString& old_name, const FlyString& prefix, const FlyString& local_name, const FlyString& namespace_)
+    {
+        ASSERT(is_start_tag() || is_end_tag());
+        for (auto& attribute : m_tag.attributes) {
+            if (old_name == attribute.local_name_builder.string_view()) {
+                attribute.prefix_builder.clear();
+                attribute.prefix_builder.append(prefix);
+
+                attribute.local_name_builder.clear();
+                attribute.local_name_builder.append(local_name);
+
+                attribute.namespace_builder.clear();
+                attribute.namespace_builder.append(namespace_);
+            }
+        }
     }
 
     void drop_attributes()
@@ -136,7 +164,9 @@ public:
 
 private:
     struct AttributeBuilder {
-        StringBuilder name_builder;
+        StringBuilder prefix_builder;
+        StringBuilder local_name_builder;
+        StringBuilder namespace_builder;
         StringBuilder value_builder;
     };
 

--- a/Libraries/LibWeb/Parser/HTMLTokenizer.cpp
+++ b/Libraries/LibWeb/Parser/HTMLTokenizer.cpp
@@ -1037,7 +1037,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_token.m_tag.attributes.last().name_builder.append_codepoint(current_input_character.value());
+                    m_current_token.m_tag.attributes.last().local_name_builder.append_codepoint(current_input_character.value());
                     continue;
                 }
             }


### PR DESCRIPTION
Implements InHeadNoScript, InSelectInTable, InTemplate, InFrameset, AfterFrameset, and AfterAfterFrameset.

Adds a missing case in InHead.

Fills out some `TODO()`s that I found in InHead, AfterHead, InBody

The handling of attributes in MathML and SVG elements feels not correct, but for now I've just expanded the Attribute object...