### PR TITLE
Ports: Add ninja

### DIFF
--- a/Ports/ninja/package.sh
+++ b/Ports/ninja/package.sh
@@ -1,0 +1,17 @@
+#!/bin/bash ../.port_include.sh
+port=ninja
+version=1.8.2
+workdir=ninja-1.8.2
+files="https://github.com/ninja-build/ninja/archive/v1.8.2.tar.gz ninja-v1.8.2.tar.gz"
+
+build() {
+    CXX=i686-pc-serenity-g++ CXXFLAGS="--sysroot=${SERENITY_ROOT}/Build/Root" \
+    LDFLAGS="--sysroot=${SERENITY_ROOT}/Build/Root" \
+    # platform=linux is close enough.
+    run ./configure.py --bootstrap --platform=linux --force-pselect
+    strip "${workdir}/ninja"
+}
+
+install() {
+    cp "${workdir}/ninja" "${SERENITY_ROOT}/Build/Root/usr/local/bin/ninja"
+}

--- a/Ports/ninja/patches/crossbuild.patch
+++ b/Ports/ninja/patches/crossbuild.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.py b/configure.py
+index a443748..064e9df 100755
+--- a/configure.py
++++ b/configure.py
+@@ -657,7 +657,7 @@ n.build('all', 'phony', all_targets)
+ n.close()
+ print('wrote %s.' % BUILD_FILENAME)
+ 
+-if options.bootstrap:
++if options.bootstrap and False:
+     print('bootstrap complete.  rebuilding...')
+ 
+     rebuild_args = []

--- a/Ports/ninja/patches/loadavg.patch
+++ b/Ports/ninja/patches/loadavg.patch
@@ -1,0 +1,19 @@
+diff --git a/src/util.cc b/src/util.cc
+index ae94d34..72cf501 100644
+--- a/src/util.cc
++++ b/src/util.cc
+@@ -566,11 +566,14 @@ double GetLoadAverage() {
+ #else
+ double GetLoadAverage() {
+   double loadavg[3] = { 0.0f, 0.0f, 0.0f };
++  /*
++   * FIXME: serenity way of getting loadavg
+   if (getloadavg(loadavg, 3) < 0) {
+     // Maybe we should return an error here or the availability of
+     // getloadavg(3) should be checked when ninja is configured.
+     return -0.0f;
+   }
++  */
+   return loadavg[0];
+ }
+ #endif // _WIN32

--- a/Ports/ninja/patches/nproc.patch
+++ b/Ports/ninja/patches/nproc.patch
@@ -1,0 +1,13 @@
+diff --git a/src/util.cc b/src/util.cc
+index ae94d34..72cf501 100644
+--- a/src/util.cc
++++ b/src/util.cc
+@@ -476,7 +476,7 @@ int GetProcessorCount() {
+   GetNativeSystemInfo(&info);
+   return info.dwNumberOfProcessors;
+ #else
+-  return sysconf(_SC_NPROCESSORS_ONLN);
++  return 1;  // FIXME: serenity way of saying sysconf(_SC_NPROCESSORS_ONLN);
+ #endif
+ }
+ 

--- a/Ports/ninja/patches/sys-select-for-pselect.patch
+++ b/Ports/ninja/patches/sys-select-for-pselect.patch
@@ -1,0 +1,24 @@
+diff --git a/src/subprocess-posix.cc b/src/subprocess-posix.cc
+index 1de22c3..02b1b7e 100644
+--- a/src/subprocess-posix.cc
++++ b/src/subprocess-posix.cc
+@@ -17,13 +17,18 @@
+ #include <assert.h>
+ #include <errno.h>
+ #include <fcntl.h>
+-#include <poll.h>
+ #include <unistd.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <sys/wait.h>
+ #include <spawn.h>
+ 
++#if defined(USE_PPOLL)
++#include <poll.h>
++#else
++#include <sys/select.h>
++#endif
++
+ extern char** environ;
+ 
+ #include "util.h"

--- a/Ports/ninja/patches/unistd-for-stat.patch
+++ b/Ports/ninja/patches/unistd-for-stat.patch
@@ -1,0 +1,12 @@
+diff --git a/src/disk_interface.cc b/src/disk_interface.cc
+index 28530b1..4da9a38 100644
+--- a/src/disk_interface.cc
++++ b/src/disk_interface.cc
+@@ -21,6 +21,7 @@
+ #include <string.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <unistd.h>
+ 
+ #ifdef _WIN32
+ #include <sstream>


### PR DESCRIPTION
- 1.8.2 for now, newer versions need high-res timestamp file APIs
  which serenity doesn't have yet
- pselect() instead of ppoll() for now, same reason (depends on #2609)
- no good default for -j yet (see nproc.patch)
- `-l` probably doesn't work yet (see loadavg.patch), but I've never
  used that anyways
- some minor include patches that I've also sent upstream

Other than that, this seems to work reasonably well. It currently
produces some spam on stdout from probably the shell.