### PR TITLE
Kernel: Implement FreeBSD's Fortuna algorithm for /dev/random

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -148,12 +148,18 @@ set(KEYBOARD_SOURCES
     ../Libraries/LibKeyboard/CharacterMap.cpp
 )
 
+set(CRYPTO_SOURCES
+    ../Libraries/LibCrypto/Cipher/AES.cpp
+    ../Libraries/LibCrypto/Hash/SHA2.cpp
+)
+
 set(SOURCES
     ${KERNEL_SOURCES}
     ${AK_SOURCES}
     ${ELF_SOURCES}
     ${VT_SOURCES}
     ${KEYBOARD_SOURCES}
+    ${CRYPTO_SOURCES}
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL")

--- a/Kernel/Devices/KeyboardDevice.cpp
+++ b/Kernel/Devices/KeyboardDevice.cpp
@@ -287,6 +287,8 @@ void KeyboardDevice::handle_irq(const RegisterState&)
         u8 ch = raw & 0x7f;
         bool pressed = !(raw & 0x80);
 
+        m_entropy_source.add_random_event(raw);
+
         if (raw == 0xe0) {
             m_has_e0_prefix = true;
             return;

--- a/Kernel/Devices/KeyboardDevice.h
+++ b/Kernel/Devices/KeyboardDevice.h
@@ -32,6 +32,7 @@
 #include <Kernel/Devices/CharacterDevice.h>
 #include <Kernel/Interrupts/IRQHandler.h>
 #include <Kernel/KeyCode.h>
+#include <Kernel/Random.h>
 #include <LibKeyboard/CharacterMap.h>
 
 namespace Kernel {
@@ -82,6 +83,7 @@ private:
     bool m_caps_lock_on { false };
     bool m_num_lock_on { false };
     bool m_has_e0_prefix { false };
+    EntropySource m_entropy_source;
 
     Keyboard::CharacterMap m_character_map = Keyboard::CharacterMap("en");
 };

--- a/Kernel/Devices/PATAChannel.cpp
+++ b/Kernel/Devices/PATAChannel.cpp
@@ -29,9 +29,9 @@
 #include <Kernel/Devices/PATAChannel.h>
 #include <Kernel/Devices/PATADiskDevice.h>
 #include <Kernel/FileSystem/ProcFS.h>
+#include <Kernel/IO.h>
 #include <Kernel/Process.h>
 #include <Kernel/VM/MemoryManager.h>
-#include <Kernel/IO.h>
 
 namespace Kernel {
 
@@ -186,6 +186,9 @@ void PATAChannel::handle_irq(const RegisterState&)
     // FIXME: We might get random interrupts due to malfunctioning hardware, so we should check that we actually requested something to happen.
 
     u8 status = m_io_base.offset(ATA_REG_STATUS).in<u8>();
+
+    m_entropy_source.add_random_event(status);
+
     if (status & ATA_SR_ERR) {
         print_ide_status(status);
         m_device_error = m_io_base.offset(ATA_REG_ERROR).in<u8>();

--- a/Kernel/Devices/PATAChannel.h
+++ b/Kernel/Devices/PATAChannel.h
@@ -44,6 +44,7 @@
 #include <Kernel/PCI/Access.h>
 #include <Kernel/PCI/Device.h>
 #include <Kernel/PhysicalAddress.h>
+#include <Kernel/Random.h>
 #include <Kernel/VM/PhysicalPage.h>
 #include <Kernel/WaitQueue.h>
 
@@ -103,6 +104,7 @@ private:
     RefPtr<PhysicalPage> m_dma_buffer_page;
     IOAddress m_bus_master_base;
     Lockable<bool> m_dma_enabled;
+    EntropySource m_entropy_source;
 
     RefPtr<PATADiskDevice> m_master;
     RefPtr<PATADiskDevice> m_slave;

--- a/Kernel/Devices/PS2MouseDevice.cpp
+++ b/Kernel/Devices/PS2MouseDevice.cpp
@@ -81,6 +81,7 @@ void PS2MouseDevice::handle_irq(const RegisterState&)
         if (backdoor->vmmouse_is_absolute()) {
             IO::in8(I8042_BUFFER);
             auto packet = backdoor->receive_mouse_packet();
+            m_entropy_source.add_random_event(packet);
             if (packet.has_value())
                 m_queue.enqueue(packet.value());
             return;
@@ -99,6 +100,8 @@ void PS2MouseDevice::handle_irq(const RegisterState&)
 #ifdef PS2MOUSE_DEBUG
             dbg() << "PS2Mouse: " << m_data[1] << ", " << m_data[2] << " " << ((m_data[0] & 1) ? "Left" : "") << " " << ((m_data[0] & 2) ? "Right" : "") << " (buffered: " << m_queue.size() << ")";
 #endif
+            m_entropy_source.add_random_event(*(u32*)m_data);
+
             parse_data_packet();
         };
 

--- a/Kernel/Devices/PS2MouseDevice.h
+++ b/Kernel/Devices/PS2MouseDevice.h
@@ -30,6 +30,7 @@
 #include <Kernel/Devices/CharacterDevice.h>
 #include <Kernel/Interrupts/IRQHandler.h>
 #include <Kernel/MousePacket.h>
+#include <Kernel/Random.h>
 
 namespace Kernel {
 
@@ -77,6 +78,7 @@ private:
     u8 m_data[4];
     bool m_has_wheel { false };
     bool m_has_five_buttons { false };
+    EntropySource m_entropy_source;
 };
 
 }

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -204,6 +204,9 @@ void E1000NetworkAdapter::handle_irq(const RegisterState&)
     out32(REG_INTERRUPT_MASK_CLEAR, 0xffffffff);
 
     u32 status = in32(REG_INTERRUPT_CAUSE_READ);
+
+    m_entropy_source.add_random_event(status);
+
     if (status & 4) {
         u32 flags = in32(REG_CTRL);
         out32(REG_CTRL, flags | ECTRL_SLU);

--- a/Kernel/Net/E1000NetworkAdapter.h
+++ b/Kernel/Net/E1000NetworkAdapter.h
@@ -28,11 +28,12 @@
 
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/OwnPtr.h>
+#include <Kernel/IO.h>
 #include <Kernel/Interrupts/IRQHandler.h>
 #include <Kernel/Net/NetworkAdapter.h>
 #include <Kernel/PCI/Access.h>
 #include <Kernel/PCI/Device.h>
-#include <Kernel/IO.h>
+#include <Kernel/Random.h>
 
 namespace Kernel {
 
@@ -103,6 +104,7 @@ private:
     u8 m_interrupt_line { 0 };
     bool m_has_eeprom { false };
     bool m_use_mmio { false };
+    EntropySource m_entropy_source;
 
     static const size_t number_of_rx_descriptors = 32;
     static const size_t number_of_tx_descriptors = 8;

--- a/Kernel/Net/RTL8139NetworkAdapter.cpp
+++ b/Kernel/Net/RTL8139NetworkAdapter.cpp
@@ -184,6 +184,8 @@ void RTL8139NetworkAdapter::handle_irq(const RegisterState&)
         int status = in16(REG_ISR);
         out16(REG_ISR, status);
 
+        m_entropy_source.add_random_event(status);
+
 #ifdef RTL8139_DEBUG
         klog() << "RTL8139NetworkAdapter::handle_irq status=0x" << String::format("%x", status);
 #endif

--- a/Kernel/Net/RTL8139NetworkAdapter.h
+++ b/Kernel/Net/RTL8139NetworkAdapter.h
@@ -27,10 +27,11 @@
 #pragma once
 
 #include <AK/OwnPtr.h>
+#include <Kernel/IO.h>
 #include <Kernel/Net/NetworkAdapter.h>
 #include <Kernel/PCI/Access.h>
 #include <Kernel/PCI/Device.h>
-#include <Kernel/IO.h>
+#include <Kernel/Random.h>
 
 namespace Kernel {
 
@@ -73,5 +74,6 @@ private:
     u8 m_tx_next_buffer { 0 };
     OwnPtr<Region> m_packet_buffer;
     bool m_link_up { false };
+    EntropySource m_entropy_source;
 };
 }

--- a/Kernel/Random.h
+++ b/Kernel/Random.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Peter Elliott <pelliott@ualberta.ca
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,9 +27,97 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
+#include <AK/ByteBuffer.h>
 #include <AK/Types.h>
+#include <Kernel/StdLib.h>
+#include <LibCrypto/Cipher/Cipher.h>
 
 namespace Kernel {
+
+template<typename CipherT, typename HashT, int KeySize>
+class FortunaPRNG {
+    constexpr static size_t pool_count = 32;
+    constexpr static size_t reseed_threshold = 16;
+
+    using CipherType = CipherT;
+    using BlockType = CipherT::BlockType;
+    using HashType = HashT;
+    using DigestType = HashT::DigestType;
+
+public:
+    void get_random_bytes(u8* buffer, size_t n)
+    {
+        if (m_p0_len >= reseed_threshold) {
+            this->reseed();
+        }
+
+        ASSERT(m_counter != 0);
+
+        // FIXME: More than 2^20 bytes cannot be generated without refreshing the key.
+        ASSERT(n < (1 << 20));
+
+        CipherType cipher(m_key, m_key.size());
+
+        size_t block_size = CipherType::BlockSizeInBits / 8;
+
+        for (size_t i = 0; i < n; i += block_size) {
+            this->generate_block(cipher, &buffer[i], min(block_size, n - i));
+        }
+
+        // Extract a new key from the prng stream.
+
+        for (size_t i = 0; i < KeySize; i += block_size) {
+            this->generate_block(cipher, &(m_key[i]), min(block_size, KeySize - i));
+        }
+    }
+
+    template<typename T>
+    void add_random_event(const T& event_data, size_t pool)
+    {
+        pool %= pool_count;
+        if (pool == 0) {
+            m_p0_len++;
+        }
+        m_pools[pool].update(reinterpret_cast<u8*>(&event_data), sizeof(T));
+    }
+
+private:
+    void generate_block(CipherType cipher, u8* buffer, size_t size)
+    {
+        BlockType input((u8*)m_counter, sizeof(m_counter));
+        BlockType output;
+        cipher.encrypt_block(input, output);
+        m_counter++;
+
+        memcpy(buffer, output.get().data(), size);
+    }
+
+    void reseed()
+    {
+        HashType new_key;
+        new_key.update(m_key);
+        for (size_t i = 0; i < pool_count; ++i) {
+            if (m_reseed_number % (1 << i) == 0) {
+                DigestType digest = m_pools[i].digest();
+                new_key.update(digest.immutable_data(), digest.data_length());
+            }
+        }
+        DigestType digest = new_key.digest();
+        m_key = ByteBuffer::copy(digest.immutable_data(),
+            digest.data_length());
+
+        m_counter++;
+        m_reseed_number++;
+        m_p0_len = 0;
+    }
+
+    size_t m_counter { 0 };
+    size_t m_reseed_number { 0 };
+    size_t m_p0_len { 0 };
+    ByteBuffer m_key;
+    HashType m_pools[pool_count];
+};
 
 // NOTE: These API's are primarily about expressing intent/needs in the calling code.
 //       We don't make any guarantees about actual fastness or goodness yet.

--- a/Libraries/LibCrypto/Cipher/AES.h
+++ b/Libraries/LibCrypto/Cipher/AES.h
@@ -30,6 +30,7 @@
 #include <AK/Vector.h>
 #include <LibCrypto/Cipher/Cipher.h>
 #include <LibCrypto/Cipher/Mode/CBC.h>
+#include <LibCrypto/Cipher/Mode/CTR.h>
 
 namespace Crypto {
 namespace Cipher {
@@ -110,6 +111,7 @@ private:
 class AESCipher final : public Cipher<AESCipherKey, AESCipherBlock> {
 public:
     using CBCMode = CBC<AESCipher>;
+    using CTRMode = CTR<AESCipher>;
 
     constexpr static size_t BlockSizeInBits = BlockType::BlockSizeInBits;
 

--- a/Libraries/LibCrypto/Cipher/Mode/CBC.h
+++ b/Libraries/LibCrypto/Cipher/Mode/CBC.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <AK/StringView.h>
 #include <AK/StringBuilder.h>
 #include <LibCrypto/Cipher/Mode/Mode.h>
 

--- a/Libraries/LibCrypto/Cipher/Mode/CTR.h
+++ b/Libraries/LibCrypto/Cipher/Mode/CTR.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2020, Peter Elliott <pelliott@ualberta.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
+#include <AK/StringView.h>
+#include <LibCrypto/Cipher/Mode/Mode.h>
+
+namespace Crypto {
+namespace Cipher {
+
+template<typename T>
+class CTR : public Mode<T> {
+public:
+    constexpr static size_t IVSizeInBits = 128;
+
+    virtual ~CTR() { }
+
+    template<typename... Args>
+    explicit constexpr CTR<T>(Args... args)
+        : Mode<T>(args...)
+    {
+    }
+
+    virtual String class_name() const override
+    {
+        StringBuilder builder;
+        builder.append(this->cipher().class_name());
+        builder.append("_CTR");
+        return builder.build();
+    }
+
+    virtual size_t IV_length() const override { return IVSizeInBits / 8; }
+
+    virtual Optional<ByteBuffer> encrypt(const ByteBuffer& in, ByteBuffer& out, Optional<ByteBuffer> ivec = {}) override
+    {
+        return this->encrypt_or_stream(&in, out, ivec);
+    }
+
+    Optional<ByteBuffer> key_stream(ByteBuffer& out, Optional<ByteBuffer> ivec = {})
+    {
+        return this->encrypt_or_stream(nullptr, out, ivec);
+    }
+
+    virtual void decrypt(const ByteBuffer& in, ByteBuffer& out, Optional<ByteBuffer> ivec = {}) override
+    {
+        (void)in;
+        (void)out;
+        (void)ivec;
+        // FIXME: Implement CTR decryption when it is needed.
+    }
+
+private:
+    static ByteBuffer increment(const ByteBuffer& in)
+    {
+        ByteBuffer new_buffer(in);
+        size_t* num_view = (size_t*)new_buffer.data();
+
+        for (size_t i = 0; i < in.size() / sizeof(size_t); ++i) {
+            if (num_view[i] == (size_t)-1) {
+                num_view[i] = 0;
+            } else {
+                num_view[i]++;
+                break;
+            }
+        }
+        return new_buffer;
+    }
+
+    Optional<ByteBuffer> encrypt_or_stream(const ByteBuffer* in, ByteBuffer& out, Optional<ByteBuffer> ivec)
+    {
+        size_t length;
+        if (in) {
+            ASSERT(in->size() <= out.size());
+            length = in->size();
+            if (length == 0)
+                return {};
+        } else {
+            length = out.size();
+        }
+
+        auto& cipher = this->cipher();
+
+        // FIXME: We should have two of these encrypt/decrypt functions that
+        //        we SFINAE out based on whether the Cipher mode needs an ivec
+        ASSERT(ivec.has_value());
+        auto iv = ivec.value();
+
+        typename T::BlockType block { cipher.padding_mode() };
+        size_t offset { 0 };
+        auto block_size = cipher.block_size();
+
+        while (length > 0) {
+            block.overwrite(iv.slice_view(0, block_size));
+
+            cipher.encrypt_block(block, block);
+            if (in) {
+                block.apply_initialization_vector(in->data() + offset);
+            }
+            auto write_size = min(block_size, length);
+            out.overwrite(offset, block.get().data(), write_size);
+
+            iv = increment(iv);
+            length -= write_size;
+            offset += write_size;
+        }
+
+        return iv;
+    }
+};
+
+}
+}


### PR DESCRIPTION
Serenity's current random implementation directly calls the `rdrand` instruction. This pull request will hopefully provide secure rng for platforms without `rdrand` and to provide additional randomness.

Fortuna does not block, and does not attempt to estimate entropy, making it suitable for both `/dev/random` and `/dev/urandom`.

My implementation is based on [this](https://www.schneier.com/academic/paperfiles/fortuna.pdf#page=8) textbook chapter from  *Cryptography Engineering: Design Principles and Practical Applications*.

Disclaimer: I am not a cryptographer by any means.

- [x] Implement the Fortuna algorithm
- [x] Replace the current random implementation (without changing the API)
- [x] Gather entropy from various drivers
- [x] ~Save some randomness to a seed file so we can generate random numbers right after boot.~

(EDIT: FreeBSD does not implement a seed file, and neither does any other unix I can find. FreeBSD blocks until enough random data is available, however I think it is fine for us to just seed the generator with `rdseed`, and the generator will be reseeded several times during boot anyways.)