### PR TITLE
(do not merge) make `ninja image` not require sudo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ add_custom_target(image
     DEPENDS qemu-image
 )
 add_custom_target(qemu-image
-    COMMAND ${CMAKE_COMMAND} -E env "SERENITY_ROOT=${CMAKE_SOURCE_DIR}" ${CMAKE_SOURCE_DIR}/Meta/build-image-qemu.sh
+    COMMAND ${CMAKE_COMMAND} -E env "SERENITY_ROOT=${CMAKE_SOURCE_DIR}" fakeroot ${CMAKE_SOURCE_DIR}/Meta/build-image-qemu2.sh
     BYPRODUCTS ${CMAKE_BINARY_DIR}/_disk_image
     USES_TERMINAL
 )

--- a/Meta/build-image-qemu2.sh
+++ b/Meta/build-image-qemu2.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -e
+
+die() {
+    echo "die: $*"
+    exit 1
+}
+
+echo "setting up disk image..."
+qemu-img create _disk_image "${DISK_SIZE:-600}"m || die "could not create disk image"
+echo "done"
+
+cleanup() {
+    if [ -d mnt ]; then
+        printf "unmounting filesystem... "
+        rm -rf mnt
+        echo "done"
+    fi
+}
+trap cleanup EXIT
+
+mkdir mnt
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+"$script_path/build-root-filesystem.sh"
+
+printf "creating new filesystem... "
+mke2fs -q -I 128 -d mnt _disk_image || die "could not create filesystem"
+echo "done"
+

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -25,7 +25,9 @@ umask 0022
 
 printf "installing base system... "
 cp -R "$SERENITY_ROOT"/Base/* mnt/
-cp -R Root/* mnt/
+#cp -R Root/* mnt/
+(cd Root && tar cf - .) | (cd mnt/ && tar xvf - > /dev/null)
+#rsync -a Root/ mnt/
 # If umask was 027 or similar when the repo was cloned,
 # file permissions in Base/ are too restrictive. Restore
 # the permissions needed in the image.


### PR DESCRIPTION
It's low-key annoying that `ninja image` prompts for a password every now and then, so I tried to fix that.

Here's what I have so far:
- Use mke2fs's `-d` switch to create the ext2 from an existing directory
- Run build-root-filesystem.sh under fakeroot so it can run mknod
- Run build-root-filesystem.sh first, mk2efs 2nd

The good: It works!
The bad: It's 50% slower -- 5.2s instead of 3.5s on my system. Slower enough to be noticeable.

I also noodled around with namespacing (`unshare -r` and then trying to mount in there) but didn't manage to hold things right.

So not ready for merge, but maybe someone else sees this and has an idea how to improve on it to make it usable.

(I found all the per-os branches in buid-iamge-qemu.sh confusing, so I made a copy and deleted all the non-linux bits and edited that. Since this is just a proof of concept, it makes the concept a bit easier to see.)