### PR TITLE
SystemServer: fix typo (exist -> exit)

### DIFF
--- a/Services/SystemServer/main.cpp
+++ b/Services/SystemServer/main.cpp
@@ -48,7 +48,7 @@ static void sigchld_handler(int)
         return;
 
 #ifdef SYSTEMSERVER_DEBUG
-    dbg() << "Reaped child with pid " << pid << ", exist status " << status;
+    dbg() << "Reaped child with pid " << pid << ", exit status " << status;
 #endif
 
     Service* service = Service::find_by_pid(pid);


### PR DESCRIPTION
Small typo that I noticed on the latest OS hacking video!