### PR TITLE
Meta: Remove default user name from Meta/CLion/run.sh

### DIFF
--- a/Documentation/NotesOnWSL.md
+++ b/Documentation/NotesOnWSL.md
@@ -39,6 +39,6 @@ In a 64-bit machine, it's located at `/mnt/c/Program Files/qemu/qemu-system-i386
 
 - Edit `serenity/Meta/CLion/run.sh`. Set **SERENITY_QEMU_BIN**  to point to the windows installation of `qemu-system-i386.exe`.
 Also verify that the value of **SERENITY_BUILD** is valid.
-In a 64-bit machine, if qemu was installed in the default location you shouldn't need to alter anything.
+In a 64-bit machine, if qemu was installed in the default location you should only need to alter user name in the script.
 
 - Execute `serenity/Meta/CLion/run.sh`.

--- a/Meta/CLion/run.sh
+++ b/Meta/CLion/run.sh
@@ -47,7 +47,7 @@ $SERENITY_EXTRA_QEMU_ARGS
 "
 
 # set this to the Build directory in serenity
-SERENITY_BUILD="/mnt/c/Users/Ragnarok/serenity-project/serenity/Build"
+SERENITY_BUILD="/mnt/c/Users/{user-name-here}/serenity-project/serenity/Build"
 
 cd  "$SERENITY_BUILD" || exit
 make install


### PR DESCRIPTION
`Meta/CLion/run.sh` assumes the user name 'Ragnarok' and sets build directory accordingly. It is a left over from when I was setting up the project for my use. This patch also updates WSL build docs that seem to suggest that `run.sh` requires no modification if serenity is being built on a 64 bit machine :^)