### PR TITLE
Help: Add a button to open the man page on github for editing

### DIFF
--- a/Applications/Help/CMakeLists.txt
+++ b/Applications/Help/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SOURCES
 )
 
 serenity_bin(Help)
-target_link_libraries(Help LibWeb LibMarkdown LibGUI)
+target_link_libraries(Help LibWeb LibMarkdown LibGUI LibDesktop)


### PR DESCRIPTION
Inspired by Sphinx, Cargo, MSDN, etc, add the ability to jump
to the github file edit UI in the browser. The idea being that
users can quickly and easily contribute fixes.