### PR TITLE
Kernel: Deemphasize inode identifiers

### DIFF
--- a/Base/usr/share/man/man2/recvfd.md
+++ b/Base/usr/share/man/man2/recvfd.md
@@ -28,6 +28,10 @@ If a file descriptor is successfully received, it is returned as a non-negative 
 * `EINVAL`: `sockfd` does not refer to a connected or accepted socket.
 * `EAGAIN`: There is no file descriptor queued on this socket.
 
+## History
+
+`recvfd()` was first introduced in Plan 9 from User Space.
+
 ## See also
 
 * [`sendfd`(2)](sendfd.md)

--- a/Base/usr/share/man/man2/sendfd.md
+++ b/Base/usr/share/man/man2/sendfd.md
@@ -29,6 +29,10 @@ If a file descriptor is successfully received, it is returned as a positive inte
 * `EINVAL`: `sockfd` does not refer to a connected or accepted socket.
 * `EBUSY`: There are too many file descriptors already waiting to be received by the peer.
 
+## History
+
+`sendfd()` was first introduced in Plan 9 from User Space.
+
 ## See also
 
 * [`recvfd`(2)](recvfd.md)

--- a/Kernel/FileSystem/DevPtsFS.h
+++ b/Kernel/FileSystem/DevPtsFS.h
@@ -36,6 +36,8 @@ class SlavePTY;
 class DevPtsFSInode;
 
 class DevPtsFS final : public FS {
+    friend class DevPtsFSInode;
+
 public:
     virtual ~DevPtsFS() override;
     static NonnullRefPtr<DevPtsFS> create();
@@ -43,9 +45,7 @@ public:
     virtual bool initialize() override;
     virtual const char* class_name() const override { return "DevPtsFS"; }
 
-    virtual InodeIdentifier root_inode() const override;
-    virtual KResultOr<NonnullRefPtr<Inode>> create_inode(InodeIdentifier parent_id, const String& name, mode_t, off_t size, dev_t, uid_t, gid_t) override;
-    virtual KResult create_directory(InodeIdentifier parent_inode, const String& name, mode_t, uid_t, gid_t) override;
+    virtual NonnullRefPtr<Inode> root_inode() const override;
     virtual RefPtr<Inode> get_inode(InodeIdentifier) const override;
 
     static void register_slave_pty(SlavePTY&);
@@ -73,7 +73,8 @@ private:
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
     virtual ssize_t write_bytes(off_t, ssize_t, const u8* buffer, FileDescription*) override;
-    virtual KResult add_child(InodeIdentifier child_id, const StringView& name, mode_t) override;
+    virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
+    virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
     virtual size_t directory_entry_count() const override;
     virtual KResult chmod(mode_t) override;

--- a/Kernel/FileSystem/DevPtsFS.h
+++ b/Kernel/FileSystem/DevPtsFS.h
@@ -46,13 +46,13 @@ public:
     virtual const char* class_name() const override { return "DevPtsFS"; }
 
     virtual NonnullRefPtr<Inode> root_inode() const override;
-    virtual RefPtr<Inode> get_inode(InodeIdentifier) const override;
 
     static void register_slave_pty(SlavePTY&);
     static void unregister_slave_pty(SlavePTY&);
 
 private:
     DevPtsFS();
+    RefPtr<Inode> get_inode(InodeIdentifier) const;
 
     RefPtr<DevPtsFSInode> m_root_inode;
 };

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -63,7 +63,8 @@ private:
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
     virtual ssize_t write_bytes(off_t, ssize_t, const u8* data, FileDescription*) override;
-    virtual KResult add_child(InodeIdentifier child_id, const StringView& name, mode_t) override;
+    virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
+    virtual KResult add_child(Inode& child, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
     virtual int set_atime(time_t) override;
     virtual int set_ctime(time_t) override;
@@ -128,9 +129,9 @@ private:
     bool flush_super_block();
 
     virtual const char* class_name() const override;
-    virtual InodeIdentifier root_inode() const override;
-    virtual KResultOr<NonnullRefPtr<Inode>> create_inode(InodeIdentifier parent_id, const String& name, mode_t, off_t size, dev_t, uid_t, gid_t) override;
-    virtual KResult create_directory(InodeIdentifier parent_inode, const String& name, mode_t, uid_t, gid_t) override;
+    virtual NonnullRefPtr<Inode> root_inode() const override;
+    KResultOr<NonnullRefPtr<Inode>> create_inode(InodeIdentifier parent_id, const String& name, mode_t, off_t size, dev_t, uid_t, gid_t);
+    KResult create_directory(InodeIdentifier parent_inode, const String& name, mode_t, uid_t, gid_t);
     virtual RefPtr<Inode> get_inode(InodeIdentifier) const override;
     virtual void flush_writes() override;
 

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -130,9 +130,9 @@ private:
 
     virtual const char* class_name() const override;
     virtual NonnullRefPtr<Inode> root_inode() const override;
+    RefPtr<Inode> get_inode(InodeIdentifier) const;
     KResultOr<NonnullRefPtr<Inode>> create_inode(InodeIdentifier parent_id, const String& name, mode_t, off_t size, dev_t, uid_t, gid_t);
     KResult create_directory(InodeIdentifier parent_inode, const String& name, mode_t, uid_t, gid_t);
-    virtual RefPtr<Inode> get_inode(InodeIdentifier) const override;
     virtual void flush_writes() override;
 
     BlockIndex first_block_index() const;

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -56,7 +56,7 @@ public:
 
     virtual bool initialize() = 0;
     virtual const char* class_name() const = 0;
-    virtual InodeIdentifier root_inode() const = 0;
+    virtual NonnullRefPtr<Inode> root_inode() const = 0;
     virtual bool supports_watchers() const { return false; }
 
     bool is_readonly() const { return m_readonly; }
@@ -77,9 +77,6 @@ public:
         InodeIdentifier inode;
         u8 file_type { 0 };
     };
-
-    virtual KResultOr<NonnullRefPtr<Inode>> create_inode(InodeIdentifier parent_id, const String& name, mode_t, off_t size, dev_t, uid_t, gid_t) = 0;
-    virtual KResult create_directory(InodeIdentifier parent_inode, const String& name, mode_t, uid_t, gid_t) = 0;
 
     virtual RefPtr<Inode> get_inode(InodeIdentifier) const = 0;
 
@@ -110,11 +107,6 @@ inline FS* InodeIdentifier::fs()
 inline const FS* InodeIdentifier::fs() const
 {
     return FS::from_fsid(m_fsid);
-}
-
-inline bool InodeIdentifier::is_root_inode() const
-{
-    return (*this) == fs()->root_inode();
 }
 
 }

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -78,8 +78,6 @@ public:
         u8 file_type { 0 };
     };
 
-    virtual RefPtr<Inode> get_inode(InodeIdentifier) const = 0;
-
     virtual void flush_writes() { }
 
     size_t block_size() const { return m_block_size; }

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -72,7 +72,8 @@ public:
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntry&)>) const = 0;
     virtual RefPtr<Inode> lookup(StringView name) = 0;
     virtual ssize_t write_bytes(off_t, ssize_t, const u8* data, FileDescription*) = 0;
-    virtual KResult add_child(InodeIdentifier child_id, const StringView& name, mode_t) = 0;
+    virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) = 0;
+    virtual KResult add_child(Inode&, const StringView& name, mode_t) = 0;
     virtual KResult remove_child(const StringView& name) = 0;
     virtual size_t directory_entry_count() const = 0;
     virtual KResult chmod(mode_t) = 0;

--- a/Kernel/FileSystem/InodeIdentifier.h
+++ b/Kernel/FileSystem/InodeIdentifier.h
@@ -62,8 +62,6 @@ public:
         return m_fsid != other.m_fsid || m_index != other.m_index;
     }
 
-    bool is_root_inode() const;
-
     String to_string() const { return String::format("%u:%u", m_fsid, m_index); }
 
 private:

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -716,10 +716,10 @@ Optional<KBuffer> procfs$mounts(InodeIdentifier)
     VFS::the().for_each_mount([&builder](auto& mount) {
         auto& fs = mount.guest_fs();
         builder.appendf("%s @ ", fs.class_name());
-        if (!mount.host().is_valid())
+        if (mount.host() == nullptr)
             builder.appendf("/");
         else {
-            builder.appendf("%u:%u", mount.host().fsid(), mount.host().index());
+            builder.appendf("%u:%u", mount.host()->fsid(), mount.host()->index());
             builder.append(' ');
             builder.append(mount.absolute_path());
         }

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -50,7 +50,6 @@ public:
     virtual const char* class_name() const override;
 
     virtual NonnullRefPtr<Inode> root_inode() const override;
-    virtual RefPtr<Inode> get_inode(InodeIdentifier) const override;
 
     static void add_sys_bool(String&&, Lockable<bool>&, Function<void()>&& notify_callback = nullptr);
     static void add_sys_string(String&&, Lockable<String>&, Function<void()>&& notify_callback = nullptr);
@@ -79,6 +78,7 @@ private:
         InodeIdentifier identifier(unsigned fsid) const;
     };
 
+    RefPtr<Inode> get_inode(InodeIdentifier) const;
     ProcFSDirectoryEntry* get_directory_entry(InodeIdentifier) const;
 
     Vector<ProcFSDirectoryEntry> m_entries;

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -49,11 +49,8 @@ public:
     virtual bool initialize() override;
     virtual const char* class_name() const override;
 
-    virtual InodeIdentifier root_inode() const override;
+    virtual NonnullRefPtr<Inode> root_inode() const override;
     virtual RefPtr<Inode> get_inode(InodeIdentifier) const override;
-
-    virtual KResultOr<NonnullRefPtr<Inode>> create_inode(InodeIdentifier parent_id, const String& name, mode_t, off_t size, dev_t, uid_t, gid_t) override;
-    virtual KResult create_directory(InodeIdentifier parent_id, const String& name, mode_t, uid_t, gid_t) override;
 
     static void add_sys_bool(String&&, Lockable<bool>&, Function<void()>&& notify_callback = nullptr);
     static void add_sys_string(String&&, Lockable<String>&, Function<void()>&& notify_callback = nullptr);
@@ -105,7 +102,8 @@ private:
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
     virtual ssize_t write_bytes(off_t, ssize_t, const u8* buffer, FileDescription*) override;
-    virtual KResult add_child(InodeIdentifier child_id, const StringView& name, mode_t) override;
+    virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
+    virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
     virtual size_t directory_entry_count() const override;
     virtual KResult chmod(mode_t) override;
@@ -131,7 +129,8 @@ private:
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override {};
     virtual ssize_t write_bytes(off_t, ssize_t, const u8*, FileDescription*) override { ASSERT_NOT_REACHED(); }
-    virtual KResult add_child(InodeIdentifier child_id, const StringView& name, mode_t) override;
+    virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
+    virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
     virtual size_t directory_entry_count() const override;
     virtual KResult chmod(mode_t) override { return KResult(-EINVAL); }

--- a/Kernel/FileSystem/TmpFS.h
+++ b/Kernel/FileSystem/TmpFS.h
@@ -49,7 +49,6 @@ public:
     virtual bool supports_watchers() const override { return true; }
 
     virtual NonnullRefPtr<Inode> root_inode() const override;
-    virtual RefPtr<Inode> get_inode(InodeIdentifier) const override;
 
 private:
     TmpFS();
@@ -57,6 +56,7 @@ private:
     RefPtr<TmpFSInode> m_root_inode;
 
     HashMap<unsigned, NonnullRefPtr<TmpFSInode>> m_inodes;
+    RefPtr<Inode> get_inode(InodeIdentifier identifier) const;
     void register_inode(TmpFSInode&);
     void unregister_inode(InodeIdentifier);
 

--- a/Kernel/FileSystem/TmpFS.h
+++ b/Kernel/FileSystem/TmpFS.h
@@ -48,11 +48,8 @@ public:
 
     virtual bool supports_watchers() const override { return true; }
 
-    virtual InodeIdentifier root_inode() const override;
+    virtual NonnullRefPtr<Inode> root_inode() const override;
     virtual RefPtr<Inode> get_inode(InodeIdentifier) const override;
-
-    virtual KResultOr<NonnullRefPtr<Inode>> create_inode(InodeIdentifier parent_id, const String& name, mode_t, off_t size, dev_t, uid_t, gid_t) override;
-    virtual KResult create_directory(InodeIdentifier parent_id, const String& name, mode_t, uid_t, gid_t) override;
 
 private:
     TmpFS();
@@ -83,7 +80,8 @@ public:
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
     virtual ssize_t write_bytes(off_t, ssize_t, const u8* buffer, FileDescription*) override;
-    virtual KResult add_child(InodeIdentifier child_id, const StringView& name, mode_t) override;
+    virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
+    virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
     virtual size_t directory_entry_count() const override;
     virtual KResult chmod(mode_t) override;
@@ -98,6 +96,8 @@ private:
     TmpFSInode(TmpFS& fs, InodeMetadata metadata, InodeIdentifier parent);
     static NonnullRefPtr<TmpFSInode> create(TmpFS&, InodeMetadata metadata, InodeIdentifier parent);
     static NonnullRefPtr<TmpFSInode> create_root(TmpFS&);
+
+    void notify_watchers();
 
     InodeMetadata m_metadata;
     InodeIdentifier m_parent;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -4309,12 +4309,12 @@ int Process::sys$umount(const char* user_mountpoint, size_t mountpoint_length)
     if (mountpoint.is_error())
         return mountpoint.error();
 
-    auto metadata_or_error = VFS::the().lookup_metadata(mountpoint.value(), current_directory());
-    if (metadata_or_error.is_error())
-        return metadata_or_error.error();
+    auto custody_or_error = VFS::the().resolve_path(mountpoint.value(), current_directory());
+    if (custody_or_error.is_error())
+        return custody_or_error.error();
 
-    auto guest_inode_id = metadata_or_error.value().inode;
-    return VFS::the().unmount(guest_inode_id);
+    auto& guest_inode = custody_or_error.value()->inode();
+    return VFS::the().unmount(guest_inode);
 }
 
 void Process::FileDescriptionAndFlags::clear()


### PR DESCRIPTION
These APIs were clearly modeled after Ext2FS internals, and make perfect sense in Ext2FS context. The new APIs are more generic, and map better to the semantics exported to the userspace, where inode identifiers only appear in `stat()` and `readdir()` output, but never in any input.

This will also hopefully reduce the potential for races (see commit https://github.com/SerenityOS/serenity/commit/c44b4d61f350703fcf1bbd8f6e353b9c6c4210c2).

Lastly, this makes it way more viable to implement a filesystem that only synthesizes its inodes lazily when queried, and destroys them when they are no longer in use. With inode identifiers being used to reference inodes, the only choice for such a filesystem is to persist any inode it has given out the identifier for, because it might be queried at any later time. With direct references to inodes, the filesystem will know when the last reference is dropped and the inode can be safely destroyed.