### PR TITLE
LibJS: Handle "receiver" argument in Reflect.{get,set}()

### DIFF
--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -84,14 +84,14 @@ public:
 
     GlobalObject& global_object() const { return shape().global_object(); }
 
-    virtual Value get(PropertyName) const;
+    virtual Value get(PropertyName, Value receiver = {}) const;
 
     virtual bool has_property(PropertyName) const;
     bool has_own_property(PropertyName) const;
 
-    virtual bool put(PropertyName, Value);
+    virtual bool put(PropertyName, Value, Value receiver = {});
 
-    Value get_own_property(const Object& this_object, PropertyName) const;
+    Value get_own_property(const Object& this_object, PropertyName, Value receiver) const;
     Value get_own_properties(const Object& this_object, GetOwnPropertyMode, bool only_enumerable_properties = false) const;
     virtual Optional<PropertyDescriptor> get_own_property_descriptor(PropertyName) const;
     Value get_own_property_descriptor_object(PropertyName) const;

--- a/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -363,7 +363,7 @@ bool ProxyObject::has_property(PropertyName name) const
     return trap_result;
 }
 
-Value ProxyObject::get(PropertyName name) const
+Value ProxyObject::get(PropertyName name, Value) const
 {
     if (m_is_revoked) {
         interpreter().throw_exception<TypeError>(ErrorType::ProxyRevoked);
@@ -395,7 +395,7 @@ Value ProxyObject::get(PropertyName name) const
     return trap_result;
 }
 
-bool ProxyObject::put(PropertyName name, Value value)
+bool ProxyObject::put(PropertyName name, Value value, Value)
 {
     if (m_is_revoked) {
         interpreter().throw_exception<TypeError>(ErrorType::ProxyRevoked);

--- a/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Libraries/LibJS/Runtime/ProxyObject.h
@@ -50,8 +50,8 @@ public:
     virtual Optional<PropertyDescriptor> get_own_property_descriptor(PropertyName) const override;
     virtual bool define_property(const FlyString& property_name, const Object& descriptor, bool throw_exceptions = true) override;
     virtual bool has_property(PropertyName name) const override;
-    virtual Value get(PropertyName name) const override;
-    virtual bool put(PropertyName name, Value value) override;
+    virtual Value get(PropertyName name, Value receiver) const override;
+    virtual bool put(PropertyName name, Value value, Value receiver) override;
     virtual Value delete_property(PropertyName name) override;
 
     void revoke() { m_is_revoked = true; }

--- a/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -178,14 +178,16 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::delete_property)
 
 JS_DEFINE_NATIVE_FUNCTION(ReflectObject::get)
 {
-    // FIXME: There's a third argument, receiver, for getters - use it once we have those.
     auto* target = get_target_object_from(interpreter, "get");
     if (!target)
         return {};
     auto property_key = interpreter.argument(1).to_string(interpreter);
     if (interpreter.exception())
         return {};
-    return target->get(property_key).value_or(js_undefined());
+    Value receiver = {};
+    if (interpreter.argument_count() > 2)
+        receiver = interpreter.argument(2);
+    return target->get(property_key, receiver).value_or(js_undefined());
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ReflectObject::get_own_property_descriptor)
@@ -244,7 +246,6 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::prevent_extensions)
 
 JS_DEFINE_NATIVE_FUNCTION(ReflectObject::set)
 {
-    // FIXME: There's a fourth argument, receiver, for setters - use it once we have those.
     auto* target = get_target_object_from(interpreter, "set");
     if (!target)
         return {};
@@ -252,7 +253,10 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::set)
     if (interpreter.exception())
         return {};
     auto value = interpreter.argument(2);
-    return Value(target->put(property_key, value));
+    Value receiver = {};
+    if (interpreter.argument_count() > 3)
+        receiver = interpreter.argument(3);
+    return Value(target->put(property_key, value, receiver));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ReflectObject::set_prototype_of)

--- a/Libraries/LibJS/Tests/Reflect.get.js
+++ b/Libraries/LibJS/Tests/Reflect.get.js
@@ -33,6 +33,23 @@ try {
     assert(Reflect.get(new String("foo"), 2) === "o");
     assert(Reflect.get(new String("foo"), 3) === undefined);
 
+    const foo = {
+        get prop() {
+            this.getPropCalled = true;
+        }
+    };
+    const bar = {};
+    Object.setPrototypeOf(bar, foo);
+
+    assert(foo.getPropCalled === undefined);
+    assert(bar.getPropCalled === undefined);
+    Reflect.get(bar, "prop");
+    assert(foo.getPropCalled === undefined);
+    assert(bar.getPropCalled === true);
+    Reflect.get(bar, "prop", foo);
+    assert(foo.getPropCalled === true);
+    assert(bar.getPropCalled === true);
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);

--- a/Libraries/LibJS/Tests/Reflect.set.js
+++ b/Libraries/LibJS/Tests/Reflect.set.js
@@ -48,6 +48,24 @@ try {
     assert(a[3] === undefined);
     assert(a[4] === "bar");
 
+
+    const foo = {
+        set prop(value) {
+            this.setPropCalled = true;
+        }
+    };
+    const bar = {};
+    Object.setPrototypeOf(bar, foo);
+
+    assert(foo.setPropCalled === undefined);
+    assert(bar.setPropCalled === undefined);
+    Reflect.set(bar, "prop", 42);
+    assert(foo.setPropCalled === undefined);
+    assert(bar.setPropCalled === true);
+    Reflect.set(bar, "prop", 42, foo);
+    assert(foo.setPropCalled === true);
+    assert(bar.setPropCalled === true);
+
     console.log("PASS");
 } catch (e) {
     console.log("FAIL: " + e);


### PR DESCRIPTION
I believe that makes the `Reflect` object 100% complete and ECMAScript compliant?! :nerd_face: