### PR TITLE
LibJS: run-test.sh emits test output if it is not "PASS"

### DIFF
--- a/Libraries/LibJS/Tests/run-tests.sh
+++ b/Libraries/LibJS/Tests/run-tests.sh
@@ -31,6 +31,22 @@ for f in *.js; do
     fi
     echo -ne "\033]9;${count};${test_count}\033\\"
     echo "$f"
+
+    if [ "$result" != "PASS" ]; then
+        if [ -z "$result" ]; then
+            echo -e "    \033[31;1mNo output. Did you forget 'console.log(\"PASS\");'?\033[0m"
+        else
+            readarray -t split_result <<< "$result";
+
+            echo -ne "    \033[31;1mOutput:\033[0m: "
+            echo "${split_result[0]}";
+
+            for (( i = 1; i < ${#split_result[@]}; i++ )); do
+                echo "             ${split_result[i]}"
+            done
+        fi
+    fi
+
     (( ++count ))
 done
 


### PR DESCRIPTION
Previously, debugging a test with `console.log` statements was impossible, because it would just cause the test to fail with no additional output. Now, if the output of a test is not "PASS", the output will be printed under the line where the test failed.

Empty output will have a special message attached to it -- useful when a test author has forgotten to include `console.log("PASS")` at the end of a test.

Preview:

![preview](https://i.imgur.com/b0ZW3Lm.png)