### PR TITLE
LibJS: Implement Proxy [[Call]] and [[Construct]] traps

### DIFF
--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -268,7 +268,7 @@ Value Interpreter::construct(Function& function, Function& new_target, Optional<
     // If we are a Derived constructor, |this| has not been constructed before super is called.
     Value this_value = function.constructor_kind() == Function::ConstructorKind::Base ? new_object : Value {};
     call_frame.this_value = this_value;
-    auto result = function.construct(*this);
+    auto result = function.construct(*this, new_target);
 
     this_value = current_environment()->get_this_binding();
     pop_call_frame();

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -136,6 +136,15 @@ public:
 
     bool in_strict_mode() const { return m_scope_stack.last().scope_node->in_strict_mode(); }
 
+    template<typename Callback>
+    void for_each_argument(Callback callback)
+    {
+        if (m_call_stack.is_empty())
+            return;
+        for (auto& value : m_call_stack.last().arguments)
+            callback(value);
+    }
+
     size_t argument_count() const
     {
         if (m_call_stack.is_empty())

--- a/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -79,7 +79,7 @@ Value ArrayConstructor::call(Interpreter& interpreter)
     return array;
 }
 
-Value ArrayConstructor::construct(Interpreter& interpreter)
+Value ArrayConstructor::construct(Interpreter& interpreter, Function&)
 {
     return call(interpreter);
 }

--- a/Libraries/LibJS/Runtime/ArrayConstructor.h
+++ b/Libraries/LibJS/Runtime/ArrayConstructor.h
@@ -39,7 +39,7 @@ public:
     virtual ~ArrayConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -72,7 +72,7 @@ Value BigIntConstructor::call(Interpreter& interpreter)
     return bigint;
 }
 
-Value BigIntConstructor::construct(Interpreter& interpreter)
+Value BigIntConstructor::construct(Interpreter& interpreter, Function&)
 {
     interpreter.throw_exception<TypeError>(ErrorType::NotAConstructor, "BigInt");
     return {};

--- a/Libraries/LibJS/Runtime/BigIntConstructor.h
+++ b/Libraries/LibJS/Runtime/BigIntConstructor.h
@@ -39,7 +39,7 @@ public:
     virtual ~BigIntConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Runtime/BooleanConstructor.cpp
+++ b/Libraries/LibJS/Runtime/BooleanConstructor.cpp
@@ -54,7 +54,7 @@ Value BooleanConstructor::call(Interpreter& interpreter)
     return Value(interpreter.argument(0).to_boolean());
 }
 
-Value BooleanConstructor::construct(Interpreter& interpreter)
+Value BooleanConstructor::construct(Interpreter& interpreter, Function&)
 {
     return BooleanObject::create(global_object(), interpreter.argument(0).to_boolean());
 }

--- a/Libraries/LibJS/Runtime/BooleanConstructor.h
+++ b/Libraries/LibJS/Runtime/BooleanConstructor.h
@@ -39,7 +39,7 @@ public:
     virtual ~BooleanConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Runtime/BoundFunction.cpp
+++ b/Libraries/LibJS/Runtime/BoundFunction.cpp
@@ -54,14 +54,14 @@ Value BoundFunction::call(Interpreter& interpreter)
     return m_target_function->call(interpreter);
 }
 
-Value BoundFunction::construct(Interpreter& interpreter)
+Value BoundFunction::construct(Interpreter& interpreter, Function& new_target)
 {
     if (auto this_value = interpreter.this_value(global_object()); m_constructor_prototype && this_value.is_object()) {
         this_value.as_object().set_prototype(m_constructor_prototype);
         if (interpreter.exception())
             return {};
     }
-    return m_target_function->construct(interpreter);
+    return m_target_function->construct(interpreter, new_target);
 }
 
 LexicalEnvironment* BoundFunction::create_environment()

--- a/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Libraries/LibJS/Runtime/BoundFunction.h
@@ -40,7 +40,7 @@ public:
 
     virtual Value call(Interpreter& interpreter) override;
 
-    virtual Value construct(Interpreter& interpreter) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
     virtual LexicalEnvironment* create_environment() override;
 

--- a/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -54,13 +54,13 @@ DateConstructor::~DateConstructor()
 
 Value DateConstructor::call(Interpreter& interpreter)
 {
-    auto date = construct(interpreter);
+    auto date = construct(interpreter, *this);
     if (!date.is_object())
         return {};
     return js_string(interpreter, static_cast<Date&>(date.as_object()).string());
 }
 
-Value DateConstructor::construct(Interpreter&)
+Value DateConstructor::construct(Interpreter&, Function&)
 {
     // TODO: Support args
     struct timeval tv;

--- a/Libraries/LibJS/Runtime/DateConstructor.h
+++ b/Libraries/LibJS/Runtime/DateConstructor.h
@@ -39,7 +39,7 @@ public:
     virtual ~DateConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Runtime/ErrorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ErrorConstructor.cpp
@@ -49,10 +49,10 @@ ErrorConstructor::~ErrorConstructor()
 
 Value ErrorConstructor::call(Interpreter& interpreter)
 {
-    return construct(interpreter);
+    return construct(interpreter, *this);
 }
 
-Value ErrorConstructor::construct(Interpreter& interpreter)
+Value ErrorConstructor::construct(Interpreter& interpreter, Function&)
 {
     String message = "";
     if (!interpreter.call_frame().arguments.is_empty() && !interpreter.call_frame().arguments[0].is_undefined()) {
@@ -77,9 +77,9 @@ Value ErrorConstructor::construct(Interpreter& interpreter)
     ConstructorName::~ConstructorName() { }                                                                            \
     Value ConstructorName::call(Interpreter& interpreter)                                                              \
     {                                                                                                                  \
-        return construct(interpreter);                                                                                 \
+        return construct(interpreter, *this);                                                                                 \
     }                                                                                                                  \
-    Value ConstructorName::construct(Interpreter& interpreter)                                                         \
+    Value ConstructorName::construct(Interpreter& interpreter, Function&)                                              \
     {                                                                                                                  \
         String message = "";                                                                                           \
         if (!interpreter.call_frame().arguments.is_empty() && !interpreter.call_frame().arguments[0].is_undefined()) { \

--- a/Libraries/LibJS/Runtime/ErrorConstructor.h
+++ b/Libraries/LibJS/Runtime/ErrorConstructor.h
@@ -40,7 +40,7 @@ public:
     virtual ~ErrorConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }
@@ -55,7 +55,7 @@ private:
         virtual void initialize(Interpreter&, GlobalObject&) override;                            \
         virtual ~ConstructorName() override;                                                      \
         virtual Value call(Interpreter&) override;                                                \
-        virtual Value construct(Interpreter&) override;                                           \
+        virtual Value construct(Interpreter&, Function& new_target) override;                     \
                                                                                                   \
     private:                                                                                      \
         virtual bool has_constructor() const override { return true; }                            \

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -68,7 +68,7 @@
         "Object prototype must not be %s on a super property access")                                  \
     M(ObjectPrototypeWrongType, "Prototype must be an object or null")                                 \
     M(ProxyCallWithNew, "Proxy must be called with the 'new' operator")                                \
-    M(ProxyConstructBadReturnType, "Proxy handler's construct trap violates invariant: must return"    \
+    M(ProxyConstructBadReturnType, "Proxy handler's construct trap violates invariant: must return "   \
         "an object")                                                                                   \
     M(ProxyConstructorBadType, "Expected %s argument of Proxy constructor to be object, got %s")       \
     M(ProxyDefinePropExistingConfigurable, "Proxy handler's defineProperty trap violates "             \

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -68,6 +68,8 @@
         "Object prototype must not be %s on a super property access")                                  \
     M(ObjectPrototypeWrongType, "Prototype must be an object or null")                                 \
     M(ProxyCallWithNew, "Proxy must be called with the 'new' operator")                                \
+    M(ProxyConstructBadReturnType, "Proxy handler's construct trap violates invariant: must return"    \
+        "an object")                                                                                   \
     M(ProxyConstructorBadType, "Expected %s argument of Proxy constructor to be object, got %s")       \
     M(ProxyDefinePropExistingConfigurable, "Proxy handler's defineProperty trap violates "             \
         "invariant: a property cannot be defined as non-configurable if it already exists on the "     \

--- a/Libraries/LibJS/Runtime/Function.h
+++ b/Libraries/LibJS/Runtime/Function.h
@@ -69,7 +69,7 @@ protected:
     Function(Object& prototype, Value bound_this, Vector<Value> bound_arguments);
 
 private:
-    virtual bool is_function() const final { return true; }
+    virtual bool is_function() const override { return true; }
     Value m_bound_this;
     Vector<Value> m_bound_arguments;
     Value m_home_object;

--- a/Libraries/LibJS/Runtime/Function.h
+++ b/Libraries/LibJS/Runtime/Function.h
@@ -44,7 +44,7 @@ public:
     virtual void initialize(Interpreter&, GlobalObject&) override { }
 
     virtual Value call(Interpreter&) = 0;
-    virtual Value construct(Interpreter&) = 0;
+    virtual Value construct(Interpreter&, Function& new_target) = 0;
     virtual const FlyString& name() const = 0;
     virtual LexicalEnvironment* create_environment() = 0;
 

--- a/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -53,10 +53,10 @@ FunctionConstructor::~FunctionConstructor()
 
 Value FunctionConstructor::call(Interpreter& interpreter)
 {
-    return construct(interpreter);
+    return construct(interpreter, *this);
 }
 
-Value FunctionConstructor::construct(Interpreter& interpreter)
+Value FunctionConstructor::construct(Interpreter& interpreter, Function&)
 {
     String parameters_source = "";
     String body_source = "";

--- a/Libraries/LibJS/Runtime/FunctionConstructor.h
+++ b/Libraries/LibJS/Runtime/FunctionConstructor.h
@@ -39,7 +39,7 @@ public:
     virtual ~FunctionConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -63,7 +63,7 @@ Value NativeFunction::call(Interpreter& interpreter)
     return m_native_function(interpreter, global_object());
 }
 
-Value NativeFunction::construct(Interpreter&)
+Value NativeFunction::construct(Interpreter&, Function&)
 {
     return {};
 }

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -42,7 +42,7 @@ public:
     virtual ~NativeFunction() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
     virtual const FlyString& name() const override { return m_name; };
     virtual bool has_constructor() const { return false; }

--- a/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -72,7 +72,7 @@ Value NumberConstructor::call(Interpreter& interpreter)
     return interpreter.argument(0).to_number(interpreter);
 }
 
-Value NumberConstructor::construct(Interpreter& interpreter)
+Value NumberConstructor::construct(Interpreter& interpreter, Function&)
 {
     double number = 0;
     if (interpreter.argument_count()) {

--- a/Libraries/LibJS/Runtime/NumberConstructor.h
+++ b/Libraries/LibJS/Runtime/NumberConstructor.h
@@ -39,7 +39,7 @@ public:
     virtual ~NumberConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -69,7 +69,7 @@ Value ObjectConstructor::call(Interpreter& interpreter)
     return Object::create_empty(interpreter, global_object());
 }
 
-Value ObjectConstructor::construct(Interpreter& interpreter)
+Value ObjectConstructor::construct(Interpreter& interpreter, Function&)
 {
     return call(interpreter);
 }

--- a/Libraries/LibJS/Runtime/ObjectConstructor.h
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.h
@@ -39,7 +39,7 @@ public:
     virtual ~ObjectConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Runtime/ProxyConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ProxyConstructor.cpp
@@ -54,7 +54,7 @@ Value ProxyConstructor::call(Interpreter& interpreter)
     return interpreter.throw_exception<TypeError>(ErrorType::ProxyCallWithNew);
 }
 
-Value ProxyConstructor::construct(Interpreter& interpreter)
+Value ProxyConstructor::construct(Interpreter& interpreter, Function&)
 {
     if (interpreter.argument_count() < 2)
         return interpreter.throw_exception<TypeError>(ErrorType::ProxyTwoArguments);

--- a/Libraries/LibJS/Runtime/ProxyConstructor.h
+++ b/Libraries/LibJS/Runtime/ProxyConstructor.h
@@ -39,7 +39,7 @@ public:
     virtual ~ProxyConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Libraries/LibJS/Runtime/ProxyObject.h
@@ -40,7 +40,7 @@ public:
     virtual ~ProxyObject() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
     virtual const FlyString& name() const override;
     virtual LexicalEnvironment* create_environment() override;
 

--- a/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Libraries/LibJS/Runtime/ProxyObject.h
@@ -26,18 +26,23 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Function.h>
 
 namespace JS {
 
-class ProxyObject : public Object {
-    JS_OBJECT(ProxyObject, Object);
+class ProxyObject final : public Function {
+    JS_OBJECT(ProxyObject, Function);
 
 public:
     static ProxyObject* create(GlobalObject&, Object& target, Object& handler);
 
     ProxyObject(Object& target, Object& handler, Object& prototype);
     virtual ~ProxyObject() override;
+
+    virtual Value call(Interpreter&) override;
+    virtual Value construct(Interpreter&) override;
+    virtual const FlyString& name() const override;
+    virtual LexicalEnvironment* create_environment() override;
 
     const Object& target() const { return m_target; }
     const Object& handler() const { return m_handler; }
@@ -59,6 +64,8 @@ public:
 private:
     virtual void visit_children(Visitor&) override;
     virtual bool is_proxy_object() const override { return true; }
+    virtual bool is_function() const override { return m_target.is_function(); }
+
     virtual bool is_array() const override { return m_target.is_array(); };
 
     Object& m_target;

--- a/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -50,10 +50,10 @@ RegExpConstructor::~RegExpConstructor()
 
 Value RegExpConstructor::call(Interpreter& interpreter)
 {
-    return construct(interpreter);
+    return construct(interpreter, *this);
 }
 
-Value RegExpConstructor::construct(Interpreter& interpreter)
+Value RegExpConstructor::construct(Interpreter& interpreter, Function&)
 {
     if (!interpreter.argument_count())
         return RegExpObject::create(global_object(), "(?:)", "");

--- a/Libraries/LibJS/Runtime/RegExpConstructor.h
+++ b/Libraries/LibJS/Runtime/RegExpConstructor.h
@@ -39,7 +39,7 @@ public:
     virtual ~RegExpConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -133,7 +133,7 @@ Value ScriptFunction::call(Interpreter& interpreter)
     return interpreter.run(global_object(), m_body, arguments, ScopeType::Function);
 }
 
-Value ScriptFunction::construct(Interpreter& interpreter)
+Value ScriptFunction::construct(Interpreter& interpreter, Function&)
 {
     if (m_is_arrow_function)
         return interpreter.throw_exception<TypeError>(ErrorType::NotAConstructor, m_name.characters());

--- a/Libraries/LibJS/Runtime/ScriptFunction.h
+++ b/Libraries/LibJS/Runtime/ScriptFunction.h
@@ -45,7 +45,7 @@ public:
     const Vector<FunctionNode::Parameter>& parameters() const { return m_parameters; };
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
     virtual const FlyString& name() const override { return m_name; };
     void set_name(const FlyString& name) { m_name = name; };

--- a/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -65,7 +65,7 @@ Value StringConstructor::call(Interpreter& interpreter)
     return string;
 }
 
-Value StringConstructor::construct(Interpreter& interpreter)
+Value StringConstructor::construct(Interpreter& interpreter, Function&)
 {
     PrimitiveString* primitive_string = nullptr;
     if (!interpreter.argument_count())

--- a/Libraries/LibJS/Runtime/StringConstructor.h
+++ b/Libraries/LibJS/Runtime/StringConstructor.h
@@ -39,7 +39,7 @@ public:
     virtual ~StringConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -74,7 +74,7 @@ Value SymbolConstructor::call(Interpreter& interpreter)
     return js_symbol(interpreter, interpreter.argument(0).to_string(interpreter), false);
 }
 
-Value SymbolConstructor::construct(Interpreter& interpreter)
+Value SymbolConstructor::construct(Interpreter& interpreter, Function&)
 {
     interpreter.throw_exception<TypeError>(ErrorType::NotAConstructor, "Symbol");
     return {};

--- a/Libraries/LibJS/Runtime/SymbolConstructor.h
+++ b/Libraries/LibJS/Runtime/SymbolConstructor.h
@@ -39,7 +39,7 @@ public:
     virtual ~SymbolConstructor() override;
 
     virtual Value call(Interpreter&) override;
-    virtual Value construct(Interpreter&) override;
+    virtual Value construct(Interpreter&, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Tests/Proxy.handler-apply.js
+++ b/Libraries/LibJS/Tests/Proxy.handler-apply.js
@@ -1,0 +1,39 @@
+load("test-common.js");
+
+try {
+    let p = new Proxy(() => 5, { apply: null });
+    assert(p() === 5);
+    let p = new Proxy(() => 5, { apply: undefined });
+    assert(p() === 5);
+    let p = new Proxy(() => 5, {});
+    assert(p() === 5);
+
+    const f = (a, b) => a + b;
+    const handler = {
+        apply(target, this_, arguments) {
+            assert(target === f);
+            assert(this_ === handler);
+            if (arguments[2])
+                return arguments[0] * arguments[1];
+            return f(...arguments);
+        },
+    };
+    p = new Proxy(f, handler);
+
+    assert(p(2, 4) === 6);
+    assert(p(2, 4, true) === 8);
+
+    // Invariants
+    [{}, [], new Proxy({}, {})].forEach(item => {
+        assertThrowsError(() => {
+            new Proxy(item, {})();
+        }, {
+            error: TypeError,
+            message: "[object ProxyObject] is not a function",
+        });
+    });
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Proxy.handler-construct.js
+++ b/Libraries/LibJS/Tests/Proxy.handler-construct.js
@@ -1,0 +1,43 @@
+load("test-common.js");
+
+try {
+    let p = new Proxy(function() { this.x = 5; }, { construct: null });
+    assert((new p).x === 5);
+    let p = new Proxy(function() { this.x = 5; }, { construct: undefined });
+    assert((new p).x === 5);
+    let p = new Proxy(function() { this.x = 5; }, {});
+    assert((new p).x === 5);
+
+    function f(value) {
+        this.x = value;
+    }
+
+    let p;
+    const handler = {
+        construct(target, arguments, newTarget) {
+            assert(target === f);
+            assert(newTarget === p);
+            if (arguments[1])
+                return Reflect.construct(target, [arguments[0] * 2], newTarget);
+            return Reflect.construct(target, arguments, newTarget);
+        },
+    };
+    p = new Proxy(f, handler);
+
+    assert(new p(15).x === 15);
+    assert(new p(15, true).x === 30);
+
+    // Invariants
+    [{}, [], new Proxy({}, {})].forEach(item => {
+        assertThrowsError(() => {
+            new (new Proxy(item, {}));
+        }, {
+            error: TypeError,
+            message: "[object ProxyObject] is not a constructor",
+        });
+    });
+
+    console.log("PASS");
+} catch (e) {
+    console.log("FAIL: " + e);
+}

--- a/Libraries/LibJS/Tests/Proxy.handler-construct.js
+++ b/Libraries/LibJS/Tests/Proxy.handler-construct.js
@@ -27,6 +27,21 @@ try {
     assert(new p(15).x === 15);
     assert(new p(15, true).x === 30);
 
+    let p;
+    function theNewTarget() {};
+    const handler = {
+        construct(target, arguments, newTarget) {
+            assert(target === f);
+            assert(newTarget === theNewTarget);
+            if (arguments[1])
+                return Reflect.construct(target, [arguments[0] * 2], newTarget);
+            return Reflect.construct(target, arguments, newTarget);
+        },
+    };
+    p = new Proxy(f, handler);
+
+    Reflect.construct(p, [15], theNewTarget);
+
     // Invariants
     [{}, [], new Proxy({}, {})].forEach(item => {
         assertThrowsError(() => {

--- a/Libraries/LibWeb/Bindings/XMLHttpRequestConstructor.cpp
+++ b/Libraries/LibWeb/Bindings/XMLHttpRequestConstructor.cpp
@@ -59,10 +59,10 @@ XMLHttpRequestConstructor::~XMLHttpRequestConstructor()
 
 JS::Value XMLHttpRequestConstructor::call(JS::Interpreter& interpreter)
 {
-    return construct(interpreter);
+    return construct(interpreter, *this);
 }
 
-JS::Value XMLHttpRequestConstructor::construct(JS::Interpreter& interpreter)
+JS::Value XMLHttpRequestConstructor::construct(JS::Interpreter& interpreter, Function&)
 {
     auto& window = static_cast<WindowObject&>(global_object());
     return interpreter.heap().allocate<XMLHttpRequestWrapper>(window, window, XMLHttpRequest::create(window.impl()));

--- a/Libraries/LibWeb/Bindings/XMLHttpRequestConstructor.h
+++ b/Libraries/LibWeb/Bindings/XMLHttpRequestConstructor.h
@@ -38,7 +38,7 @@ public:
     virtual ~XMLHttpRequestConstructor() override;
 
     virtual JS::Value call(JS::Interpreter&) override;
-    virtual JS::Value construct(JS::Interpreter&) override;
+    virtual JS::Value construct(JS::Interpreter& interpreter, Function& new_target) override;
 
 private:
     virtual bool has_constructor() const override { return true; }


### PR DESCRIPTION
In order to do this, Proxy now extends `Function` rather than `Object,` and whether or not it returns true for `is_function()` depends on it's `m_target`. 

A couple of other changes introduced in this PR:
- `Function::construct` now takes a `Function& new_target`, in order to facilitate the Proxy passing into it's handler's`[[Construct]]` trap.
- `Function.{call,construct]()` now take `GlobalObject&`. I was already refactoring these functions, so I figured I might as well just slip that change in here too.

Fixes #2624 