### PR TITLE
LibWeb: Remove duplicate `if` branch in `parse_html_fragment`.

### DIFF
--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -2621,9 +2621,6 @@ NonnullRefPtrVector<Node> HTMLDocumentParser::parse_html_fragment(Element& conte
     } else if (context_element.tag_name().is_one_of(HTML::TagNames::noscript)) {
         if (context_element.document().is_scripting_enabled())
             parser.m_tokenizer.switch_to({}, HTMLTokenizer::State::RAWTEXT);
-    } else if (context_element.tag_name().is_one_of(HTML::TagNames::noscript)) {
-        if (context_element.document().is_scripting_enabled())
-            parser.m_tokenizer.switch_to({}, HTMLTokenizer::State::RAWTEXT);
     } else if (context_element.tag_name().is_one_of(HTML::TagNames::plaintext)) {
         parser.m_tokenizer.switch_to({}, HTMLTokenizer::State::PLAINTEXT);
     }


### PR DESCRIPTION
In the video I noticed that one `if` branch is duplicate of its predecessor.
This PR just removes the duplicated if check.