### PR TITLE
LibGUI: Fix image preview size in FilePicker for large images

### DIFF
--- a/Libraries/LibGUI/FilePicker.cpp
+++ b/Libraries/LibGUI/FilePicker.cpp
@@ -248,10 +248,10 @@ FilePicker::FilePicker(Mode mode, const StringView& file_name, const StringView&
     preview_container.set_layout<VerticalBoxLayout>();
     preview_container.layout()->set_margins({ 8, 8, 8, 8 });
 
-    m_preview_image_label = preview_container.add<Image>();
-    m_preview_image_label->set_should_stretch(true);
-    m_preview_image_label->set_size_policy(SizePolicy::Fixed, SizePolicy::Fixed);
-    m_preview_image_label->set_preferred_size(160, 160);
+    m_preview_image = preview_container.add<Image>();
+    m_preview_image->set_should_stretch(true);
+    m_preview_image->set_auto_resize(false);
+    m_preview_image->set_preferred_size(160, 160);
 
     m_preview_name_label = preview_container.add<Label>();
     m_preview_name_label->set_font(Gfx::Font::default_bold_font());
@@ -275,17 +275,17 @@ void FilePicker::set_preview(const LexicalPath& path)
             clear_preview();
             return;
         }
-        bool should_stretch = bitmap->width() > m_preview_image_label->width() || bitmap->height() > m_preview_image_label->height();
+        bool should_stretch = bitmap->width() > m_preview_image->width() || bitmap->height() > m_preview_image->height();
         m_preview_name_label->set_text(path.basename());
         m_preview_geometry_label->set_text(bitmap->size().to_string());
-        m_preview_image_label->set_should_stretch(should_stretch);
-        m_preview_image_label->set_bitmap(move(bitmap));
+        m_preview_image->set_should_stretch(should_stretch);
+        m_preview_image->set_bitmap(move(bitmap));
     }
 }
 
 void FilePicker::clear_preview()
 {
-    m_preview_image_label->set_bitmap(nullptr);
+    m_preview_image->set_bitmap(nullptr);
     m_preview_name_label->set_text(String::empty());
     m_preview_geometry_label->set_text(String::empty());
 }

--- a/Libraries/LibGUI/FilePicker.h
+++ b/Libraries/LibGUI/FilePicker.h
@@ -74,7 +74,7 @@ private:
     LexicalPath m_selected_file;
 
     RefPtr<TextBox> m_filename_textbox;
-    RefPtr<Image> m_preview_image_label;
+    RefPtr<Image> m_preview_image;
     RefPtr<Label> m_preview_name_label;
     RefPtr<Label> m_preview_geometry_label;
     Mode m_mode { Mode::Open };


### PR DESCRIPTION
Image preview widget overflow to other widgets in FilePicker dialog when image is larger than 160px.  Also change the ImagePreview widget variable name for align to naming standards.