### PR TITLE
Kernel: Add g_cpu_supports_rdseed

### DIFF
--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -714,6 +714,7 @@ bool g_cpu_supports_nx;
 bool g_cpu_supports_pae;
 bool g_cpu_supports_pge;
 bool g_cpu_supports_rdrand;
+bool g_cpu_supports_rdseed;
 bool g_cpu_supports_smap;
 bool g_cpu_supports_smep;
 bool g_cpu_supports_sse;
@@ -736,6 +737,7 @@ void cpu_detect()
     g_cpu_supports_smap = (extended_features.ebx() & (1 << 20));
     g_cpu_supports_smep = (extended_features.ebx() & (1 << 7));
     g_cpu_supports_umip = (extended_features.ecx() & (1 << 2));
+    g_cpu_supports_rdseed = (extended_features.ebx() & (1 << 18));
 }
 
 void cpu_setup()

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -588,6 +588,7 @@ extern bool g_cpu_supports_nx;
 extern bool g_cpu_supports_pae;
 extern bool g_cpu_supports_pge;
 extern bool g_cpu_supports_rdrand;
+extern bool g_cpu_supports_rdseed;
 extern bool g_cpu_supports_smap;
 extern bool g_cpu_supports_smep;
 extern bool g_cpu_supports_sse;

--- a/Kernel/Random.cpp
+++ b/Kernel/Random.cpp
@@ -44,7 +44,7 @@ KernelRng& KernelRng::the()
 
 KernelRng::KernelRng()
 {
-    if (g_cpu_supports_rdrand) {
+    if (g_cpu_supports_rdseed) {
         for (size_t i = 0; i < resource().pool_count * resource().reseed_threshold; ++i) {
             u32 value = 0;
             asm volatile(


### PR DESCRIPTION
CPUs which support RDRAND do not necessarily support RDSEED. This
introduces a flag g_cpu_supports_rdseed which is set appropriately
by CPUID. This causes Haswell CPUs in particular (and probably a lot
of AMD chips) to now fail to boot with #2634, rather than an illegal
instruction.

It seems like the KernelRng needs either an initial reseed call or
more random events added before the first call to get_good_random,
in order to prevent that issue, but I don't feel qualified to make that kind
of change to the crypto code.

Apologies in advance if I've screwed up some kind of contribution etiquette, 
as this is my first interaction with the project.