### PR TITLE
Kernel: Make Random work on CPUs without rdrand

### DIFF
--- a/Kernel/VM/PageDirectory.cpp
+++ b/Kernel/VM/PageDirectory.cpp
@@ -79,7 +79,7 @@ PageDirectory::PageDirectory(Process& process, const RangeAllocator* parent_rang
     if (parent_range_allocator) {
         m_range_allocator.initialize_from_parent(*parent_range_allocator);
     } else {
-        size_t random_offset = (get_good_random<u32>() % 32 * MB) & PAGE_MASK;
+        size_t random_offset = (get_fast_random<u32>() % 32 * MB) & PAGE_MASK;
         u32 base = userspace_range_base + random_offset;
         m_range_allocator.initialize_with_range(VirtualAddress(base), userspace_range_ceiling - base);
     }

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -131,7 +131,7 @@ extern "C" [[noreturn]] void init()
 
     klog() << "Starting SerenityOS...";
 
-    __stack_chk_guard = get_good_random<u32>();
+    __stack_chk_guard = get_fast_random<u32>();
 
     TimeManagement::initialize();
 
@@ -169,7 +169,7 @@ extern "C" [[noreturn]] void init()
 extern "C" [[noreturn]] void init_ap(u32 cpu)
 {
     APIC::the().enable(cpu);
-    
+
 #if 0
     Scheduler::idle_loop();
 #else


### PR DESCRIPTION
- If rdseed is not available, fallback to rdrand.
- If rdrand is not available, block when user needs good random, and use insecure PRNG when user needs fast random.

Fixes #2634 