### PR TITLE
Browser: Page context menu for quick mouse navigation

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -268,8 +268,7 @@ Tab::Tab()
         },
         this));
 
-    auto& inspect_menu = m_menubar->add_menu("Inspect");
-    inspect_menu.add_action(GUI::Action::create(
+    auto view_source_action = GUI::Action::create(
         "View source", { Mod_Ctrl, Key_U }, [this](auto&) {
             ASSERT(m_page_view->document());
             auto url = m_page_view->document()->url().to_string();
@@ -284,8 +283,9 @@ Tab::Tab()
             window->show();
             (void)window.leak_ref();
         },
-        this));
-    inspect_menu.add_action(GUI::Action::create(
+        this);
+
+    auto inspect_dom_tree_action = GUI::Action::create(
         "Inspect DOM tree", { Mod_None, Key_F12 }, [this](auto&) {
             if (!m_dom_inspector_window) {
                 m_dom_inspector_window = GUI::Window::construct();
@@ -298,7 +298,11 @@ Tab::Tab()
             m_dom_inspector_window->show();
             m_dom_inspector_window->move_to_front();
         },
-        this));
+        this);
+
+    auto& inspect_menu = m_menubar->add_menu("Inspect");
+    inspect_menu.add_action(*view_source_action);
+    inspect_menu.add_action(*inspect_dom_tree_action);
 
     inspect_menu.add_action(GUI::Action::create(
         "Open JS Console", { Mod_Ctrl, Key_I }, [this](auto&) {
@@ -356,6 +360,17 @@ Tab::Tab()
     m_tab_context_menu->add_action(GUI::Action::create("Close Tab", [this](auto&) {
         on_tab_close_request(*this);
     }));
+
+    m_page_context_menu = GUI::Menu::construct();
+    m_page_context_menu->add_action(*m_go_back_action);
+    m_page_context_menu->add_action(*m_go_forward_action);
+    m_page_context_menu->add_action(*m_reload_action);
+    m_page_context_menu->add_separator();
+    m_page_context_menu->add_action(*view_source_action);
+    m_page_context_menu->add_action(*inspect_dom_tree_action);
+    m_page_view->on_context_menu_request = [&](auto& screen_position) {
+        m_page_context_menu->popup(screen_position);
+    };
 }
 
 Tab::~Tab()

--- a/Applications/Browser/Tab.h
+++ b/Applications/Browser/Tab.h
@@ -76,6 +76,7 @@ private:
     String m_link_context_menu_href;
 
     RefPtr<GUI::Menu> m_tab_context_menu;
+    RefPtr<GUI::Menu> m_page_context_menu;
 
     String m_title;
     RefPtr<const Gfx::Bitmap> m_icon;

--- a/Libraries/LibWeb/Frame/EventHandler.cpp
+++ b/Libraries/LibWeb/Frame/EventHandler.cpp
@@ -150,6 +150,9 @@ bool EventHandler::handle_mousedown(const Gfx::IntPoint& position, unsigned butt
             dump_selection("MouseDown");
             m_in_mouse_selection = true;
         }
+        else if (button == GUI::MouseButton::Right) {
+            page_client.page_did_request_context_menu(m_frame.to_main_frame_position(position));
+        }
     }
     return true;
 }

--- a/Libraries/LibWeb/Page.h
+++ b/Libraries/LibWeb/Page.h
@@ -74,6 +74,7 @@ public:
     virtual void page_did_start_loading(const URL&) { }
     virtual void page_did_change_selection() { }
     virtual void page_did_request_cursor_change(GUI::StandardCursor) { }
+    virtual void page_did_request_context_menu(const Gfx::IntPoint&) { }
     virtual void page_did_request_link_context_menu(const Gfx::IntPoint&, [[maybe_unused]] const String& href, [[maybe_unused]] const String& target, [[maybe_unused]] unsigned modifiers) { }
     virtual void page_did_click_link([[maybe_unused]] const String& href, [[maybe_unused]] const String& target, [[maybe_unused]] unsigned modifiers) { }
     virtual void page_did_middle_click_link([[maybe_unused]] const String& href, [[maybe_unused]] const String& target, [[maybe_unused]] unsigned modifiers) { }

--- a/Libraries/LibWeb/PageView.cpp
+++ b/Libraries/LibWeb/PageView.cpp
@@ -103,6 +103,12 @@ void PageView::page_did_request_cursor_change(GUI::StandardCursor cursor)
         window()->set_override_cursor(cursor);
 }
 
+void PageView::page_did_request_context_menu(const Gfx::IntPoint& content_position)
+{
+    if (on_context_menu_request)
+        on_context_menu_request(screen_relative_rect().location().translated(to_widget_position(content_position)));
+}
+
 void PageView::page_did_request_link_context_menu(const Gfx::IntPoint& content_position, const String& href, [[maybe_unused]] const String& target, [[maybe_unused]] unsigned modifiers)
 {
     if (on_link_context_menu_request)

--- a/Libraries/LibWeb/PageView.h
+++ b/Libraries/LibWeb/PageView.h
@@ -60,6 +60,7 @@ public:
 
     void set_should_show_line_box_borders(bool value) { m_should_show_line_box_borders = value; }
 
+    Function<void(const Gfx::IntPoint& screen_position)> on_context_menu_request;
     Function<void(const String& href, const String& target, unsigned modifiers)> on_link_click;
     Function<void(const String& href, const Gfx::IntPoint& screen_position)> on_link_context_menu_request;
     Function<void(const String& href)> on_link_middle_click;
@@ -95,6 +96,7 @@ private:
     virtual void page_did_start_loading(const URL&) override;
     virtual void page_did_change_selection() override;
     virtual void page_did_request_cursor_change(GUI::StandardCursor) override;
+    virtual void page_did_request_context_menu(const Gfx::IntPoint&) override;
     virtual void page_did_request_link_context_menu(const Gfx::IntPoint&, const String& href, const String& target, unsigned modifiers) override;
     virtual void page_did_click_link(const String& href, const String& target, unsigned modifiers) override;
     virtual void page_did_middle_click_link(const String& href, const String& target, unsigned modifiers) override;


### PR DESCRIPTION
Add a Web::PageClient callback for right clicking on an area of a page that is not a link.

Browser::Tab uses this to add a context menu for the Back, Forward, Reload, View Source, and Inspect options familiar from right clicking on your favorite non-Serenity Browser :)