### PR TITLE
WindowServer: don't send resize on resolution change unless needed

### DIFF
--- a/Services/WindowServer/Window.cpp
+++ b/Services/WindowServer/Window.cpp
@@ -520,11 +520,20 @@ void Window::recalculate_rect()
         return;
 
     auto old_rect = m_rect;
-    if (m_tiled != WindowTileType::None)
+    bool send_event = true;
+    if (m_tiled != WindowTileType::None) {
         set_rect(tiled_rect(m_tiled));
-    else if (is_maximized())
+    } else if (is_maximized()) {
         set_rect(WindowManager::the().maximized_window_rect(*this));
-    Core::EventLoop::current().post_event(*this, make<ResizeEvent>(old_rect, m_rect));
+    } else if (type() == WindowType::Desktop) {
+        set_rect(WindowManager::the().desktop_rect());
+    } else {
+        send_event = false;
+    }
+
+    if (send_event) {
+        Core::EventLoop::current().post_event(*this, make<ResizeEvent>(old_rect, m_rect));
+    }
 }
 
 void Window::add_child_window(Window& child_window)

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -142,8 +142,6 @@ bool WindowManager::set_resolution(int width, int height)
     });
     if (success) {
         for_each_window([](Window& window) {
-            if (window.type() == WindowType::Desktop)
-                window.set_rect(WindowManager::the().desktop_rect());
             window.recalculate_rect();
             return IterationDecision::Continue;
         });


### PR DESCRIPTION
fixes #2575

The extra ResizeEvent would be handled after on_rect_change, and would
reset the size of main_widget to what it was before the resize.

Bonus: Less unnecessary events.