### PR TITLE
LibGUI: SpinBox: update the displayed value when set_range() clamps it

### DIFF
--- a/Libraries/LibGUI/SpinBox.cpp
+++ b/Libraries/LibGUI/SpinBox.cpp
@@ -80,8 +80,11 @@ void SpinBox::set_range(int min, int max)
 
     int old_value = m_value;
     m_value = clamp(m_value, m_min, m_max);
-    if (on_change && m_value != old_value)
-        on_change(m_value);
+    if (m_value != old_value) {
+        m_editor->set_text(String::number(m_value));
+        if (on_change)
+            on_change(m_value);
+    }
 
     update();
 }


### PR DESCRIPTION
Consider the following: upon instanciation of a GUI::SpinBox, its internal value and displayed value are both 0. When calling `set_min(1)` on it (same as `set_range(1, max())`), the internal value gets clamped to 1 correctly, but "0" is still displayed by the widget.

The displayed value is now updated accordingly to the internal value when it gets clamped.