### PR TITLE
LibLine: Correctly display suggestions on multiline prompts (LibMultipleLines pt.2)

### DIFF
--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -41,6 +41,7 @@
 #include <LibCore/Notifier.h>
 #include <LibCore/Object.h>
 #include <LibLine/Span.h>
+#include <LibLine/StringMetrics.h>
 #include <LibLine/Style.h>
 #include <LibLine/SuggestionDisplay.h>
 #include <LibLine/SuggestionManager.h>
@@ -104,20 +105,6 @@ public:
     const Vector<String>& history() const { return m_history; }
 
     void register_character_input_callback(char ch, Function<bool(Editor&)> callback);
-    struct StringMetrics {
-        Vector<size_t> line_lengths;
-        size_t total_length { 0 };
-        size_t max_line_length { 0 };
-
-        size_t lines_with_addition(const StringMetrics& offset, size_t column_width) const;
-        void reset()
-        {
-            line_lengths.clear();
-            total_length = 0;
-            max_line_length = 0;
-            line_lengths.append(0);
-        }
-    };
     StringMetrics actual_rendered_string_metrics(const StringView&) const;
     StringMetrics actual_rendered_string_metrics(const Utf32View&) const;
 
@@ -313,7 +300,7 @@ private:
     bool should_break_token(Vector<u32, 1024>& buffer, size_t index);
 
     void recalculate_origin();
-    void reposition_cursor();
+    void reposition_cursor(bool to_end = false);
 
     struct CodepointRange {
         size_t start { 0 };

--- a/Libraries/LibLine/StringMetrics.h
+++ b/Libraries/LibLine/StringMetrics.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <AK/Vector.h>
+
+namespace Line {
+
+struct StringMetrics {
+    Vector<size_t> line_lengths;
+    size_t total_length { 0 };
+    size_t max_line_length { 0 };
+
+    size_t lines_with_addition(const StringMetrics& offset, size_t column_width) const;
+    void reset()
+    {
+        line_lengths.clear();
+        total_length = 0;
+        max_line_length = 0;
+        line_lengths.append(0);
+    }
+};
+
+}

--- a/Libraries/LibLine/SuggestionDisplay.h
+++ b/Libraries/LibLine/SuggestionDisplay.h
@@ -28,6 +28,7 @@
 
 #include <AK/Forward.h>
 #include <AK/String.h>
+#include <LibLine/StringMetrics.h>
 #include <LibLine/SuggestionManager.h>
 #include <stdlib.h>
 
@@ -61,9 +62,10 @@ protected:
 
 class XtermSuggestionDisplay : public SuggestionDisplay {
 public:
-    XtermSuggestionDisplay(size_t lines, size_t columns)
+    XtermSuggestionDisplay(size_t lines, size_t columns, const StringMetrics& prompt_metrics)
         : m_num_lines(lines)
         , m_num_columns(columns)
+        , m_prompt_metrics(prompt_metrics)
     {
     }
     virtual ~XtermSuggestionDisplay() override { }
@@ -92,7 +94,7 @@ private:
     size_t m_num_lines { 0 };
     size_t m_num_columns { 0 };
     size_t m_prompt_lines_at_suggestion_initiation { 0 };
-    size_t m_prompt_length { 0 };
+    const StringMetrics& m_prompt_metrics;
 
     struct PageRange {
         size_t start;


### PR DESCRIPTION
This commit plumbs around some information to make sure shown suggestions are placed correctly in the terminal.

To see what the "incorrect" placement looks like, try 
```sh
export PROMPT="
whf$ "
```

and attempt to complete `ls ./`