### PR TITLE
LibVT/Terminal: add a scroll length to the TerminalWidget

### DIFF
--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -37,6 +37,7 @@
 #include <LibGUI/MenuBar.h>
 #include <LibGUI/RadioButton.h>
 #include <LibGUI/Slider.h>
+#include <LibGUI/SpinBox.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Font.h>
@@ -138,7 +139,7 @@ RefPtr<GUI::Window> create_settings_window(TerminalWidget& terminal)
     auto window = GUI::Window::construct();
     window->set_title("Terminal Settings");
     window->set_resizable(false);
-    window->set_rect(50, 50, 200, 140);
+    window->set_rect(50, 50, 200, 185);
     window->set_modal(true);
 
     auto& settings = window->set_main_widget<GUI::Widget>();
@@ -174,6 +175,19 @@ RefPtr<GUI::Window> create_settings_window(TerminalWidget& terminal)
 
     slider.set_range(0, 255);
     slider.set_value(terminal.opacity());
+
+    auto& spinbox_container = settings.add<GUI::GroupBox>("Scroll Length");
+    spinbox_container.set_layout<GUI::VerticalBoxLayout>();
+    spinbox_container.layout()->set_margins({ 6, 16, 6, 6 });
+    spinbox_container.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
+    spinbox_container.set_preferred_size(100, 46);
+
+    auto& spinbox = spinbox_container.add<GUI::SpinBox>();
+    spinbox.set_min(1);
+    spinbox.set_value(terminal.scroll_length());
+    spinbox.on_change = [&terminal](int value) {
+        terminal.set_scroll_length(value);
+    };
 
     return window;
 }

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -105,6 +105,7 @@ TerminalWidget::TerminalWidget(int ptm_fd, bool automatic_size_policy, RefPtr<Co
     m_scrollbar->on_change = [this](int) {
         force_repaint();
     };
+    set_scroll_length(m_config->read_num_entry("Window", "ScrollLength", 1));
 
     dbgprintf("Terminal: Load config file from %s\n", m_config->file_name().characters());
     m_cursor_blink_timer->set_interval(m_config->read_num_entry("Text",
@@ -672,13 +673,23 @@ void TerminalWidget::mousewheel_event(GUI::MouseEvent& event)
 {
     if (!is_scrollable())
         return;
-    m_scrollbar->set_value(m_scrollbar->value() + event.wheel_delta());
+    m_scrollbar->set_value(m_scrollbar->value() + event.wheel_delta() * scroll_length());
     GUI::Frame::mousewheel_event(event);
 }
 
 bool TerminalWidget::is_scrollable() const
 {
     return m_scrollbar->is_scrollable();
+}
+
+int TerminalWidget::scroll_length() const
+{
+    return m_scrollbar->step();
+}
+
+void TerminalWidget::set_scroll_length(int length)
+{
+    m_scrollbar->set_step(length);
 }
 
 String TerminalWidget::selected_text() const

--- a/Libraries/LibVT/TerminalWidget.h
+++ b/Libraries/LibVT/TerminalWidget.h
@@ -74,6 +74,8 @@ public:
     VT::Position normalized_selection_end() const;
 
     bool is_scrollable() const;
+    int scroll_length() const;
+    void set_scroll_length(int);
 
     GUI::Action& copy_action() { return *m_copy_action; }
     GUI::Action& paste_action() { return *m_paste_action; }


### PR DESCRIPTION
The scroll length is the number of lines by which the terminal will go up/down when scrolling the mouse wheel once.

### Why
Open a new Terminal and try the following: `ls -l js-tests/`. Now scroll back to the top (only using your mouse).
As you can see, the Terminal scrolls lines one by one, which I think is rather slow.

So I added the possibility the tell the TerminalWidget by how much you want to go up/down with one scroll: the scroll length.
It remains 1 by default in case most people actually like scrolling slowly; else I would recommend setting it between 5 or 7 :)

I also added a `GUI::SpinBox` in the Terminal's settings to adjust the scroll length gracefully. The minimum is clamped to 1 and I left the maximum untouched at 100 (though I can't imagine why anyone would want to scroll so much at once).