### PR TITLE
LibGUI: Tweak FilePicker layout to remove bottom padding

### DIFF
--- a/Libraries/LibGUI/FilePicker.cpp
+++ b/Libraries/LibGUI/FilePicker.cpp
@@ -171,7 +171,7 @@ FilePicker::FilePicker(Mode mode, const StringView& file_name, const StringView&
     lower_container.set_layout<VerticalBoxLayout>();
     lower_container.layout()->set_spacing(4);
     lower_container.set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
-    lower_container.set_preferred_size(0, 60);
+    lower_container.set_preferred_size(0, 45);
 
     auto& filename_container = lower_container.add<Widget>();
     filename_container.set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);


### PR DESCRIPTION
This makes the "Cancel" and "Open" buttons align with the right sidebar's bottom edge.

Before and after:

![image](https://user-images.githubusercontent.com/19366641/86099620-a7792900-baaf-11ea-9263-2ed7178d8a0a.png)
![image](https://user-images.githubusercontent.com/19366641/86100605-fecbc900-bab0-11ea-97a2-abcd5390e9e3.png)
