### PR TITLE
LibGUI: Only show FilePicker preview pane on demand

### DIFF
--- a/Libraries/LibGUI/FilePicker.cpp
+++ b/Libraries/LibGUI/FilePicker.cpp
@@ -242,23 +242,24 @@ FilePicker::FilePicker(Mode mode, const StringView& file_name, const StringView&
         }
     };
 
-    auto& preview_container = horizontal_container.add<Frame>();
-    preview_container.set_size_policy(SizePolicy::Fixed, SizePolicy::Fill);
-    preview_container.set_preferred_size(180, 0);
-    preview_container.set_layout<VerticalBoxLayout>();
-    preview_container.layout()->set_margins({ 8, 8, 8, 8 });
+    m_preview_container = horizontal_container.add<Frame>();
+    m_preview_container->set_visible(false);
+    m_preview_container->set_size_policy(SizePolicy::Fixed, SizePolicy::Fill);
+    m_preview_container->set_preferred_size(180, 0);
+    m_preview_container->set_layout<VerticalBoxLayout>();
+    m_preview_container->layout()->set_margins({ 8, 8, 8, 8 });
 
-    m_preview_image = preview_container.add<Image>();
+    m_preview_image = m_preview_container->add<Image>();
     m_preview_image->set_should_stretch(true);
     m_preview_image->set_auto_resize(false);
     m_preview_image->set_preferred_size(160, 160);
 
-    m_preview_name_label = preview_container.add<Label>();
+    m_preview_name_label = m_preview_container->add<Label>();
     m_preview_name_label->set_font(Gfx::Font::default_bold_font());
     m_preview_name_label->set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
     m_preview_name_label->set_preferred_size(0, m_preview_name_label->font().glyph_height());
 
-    m_preview_geometry_label = preview_container.add<Label>();
+    m_preview_geometry_label = m_preview_container->add<Label>();
     m_preview_geometry_label->set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
     m_preview_geometry_label->set_preferred_size(0, m_preview_name_label->font().glyph_height());
 }
@@ -280,6 +281,7 @@ void FilePicker::set_preview(const LexicalPath& path)
         m_preview_geometry_label->set_text(bitmap->size().to_string());
         m_preview_image->set_should_stretch(should_stretch);
         m_preview_image->set_bitmap(move(bitmap));
+        m_preview_container->set_visible(true);
     }
 }
 
@@ -288,6 +290,7 @@ void FilePicker::clear_preview()
     m_preview_image->set_bitmap(nullptr);
     m_preview_name_label->set_text(String::empty());
     m_preview_geometry_label->set_text(String::empty());
+    m_preview_container->set_visible(false);
 }
 
 void FilePicker::on_file_return()

--- a/Libraries/LibGUI/FilePicker.h
+++ b/Libraries/LibGUI/FilePicker.h
@@ -74,6 +74,7 @@ private:
     LexicalPath m_selected_file;
 
     RefPtr<TextBox> m_filename_textbox;
+    RefPtr<Frame> m_preview_container;
     RefPtr<Image> m_preview_image;
     RefPtr<Label> m_preview_name_label;
     RefPtr<Label> m_preview_geometry_label;


### PR DESCRIPTION
`FilePicker::set_preview()` and `FilePicker::clear_preview()` now show and hide the preview pane respectively.

![image](https://user-images.githubusercontent.com/19366641/86104228-afd46280-bab5-11ea-94af-e7b55fa9856e.png)
![image](https://user-images.githubusercontent.com/19366641/86104259-b95dca80-bab5-11ea-8c4a-c1bbec7e86ad.png)
