### PR TITLE
Browser: Unset location bar icon on load start

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -146,6 +146,7 @@ Tab::Tab()
     };
 
     m_page_view->on_load_start = [this](auto& url) {
+        m_location_box->set_icon(nullptr);
         m_location_box->set_text(url.to_string());
         if (m_should_push_loads_to_history)
             m_history.push(url);


### PR DESCRIPTION
This avoids having a stale icon from a previous page load in the location box if a subsequently visited page doesn't trigger an icon change.

---

Fixes... the bug mentioned in the update video :^)