### PR TITLE
LibGUI+js: Highlight JS Extends and Super tokens

### DIFF
--- a/Libraries/LibGUI/JSSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/JSSyntaxHighlighter.cpp
@@ -110,6 +110,7 @@ static TextStyle style_for_token_type(Gfx::Palette palette, JS::TokenType type)
     case JS::TokenType::Const:
     case JS::TokenType::Delete:
     case JS::TokenType::Debugger:
+    case JS::TokenType::Extends:
     case JS::TokenType::Function:
     case JS::TokenType::In:
     case JS::TokenType::Instanceof:
@@ -117,6 +118,7 @@ static TextStyle style_for_token_type(Gfx::Palette palette, JS::TokenType type)
     case JS::TokenType::Let:
     case JS::TokenType::New:
     case JS::TokenType::NullLiteral:
+    case JS::TokenType::Super:
     case JS::TokenType::Typeof:
     case JS::TokenType::Var:
     case JS::TokenType::Void:

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -695,12 +695,14 @@ int main(int argc, char** argv)
                 case JS::TokenType::Const:
                 case JS::TokenType::Debugger:
                 case JS::TokenType::Delete:
+                case JS::TokenType::Extends:
                 case JS::TokenType::Function:
                 case JS::TokenType::In:
                 case JS::TokenType::Instanceof:
                 case JS::TokenType::Interface:
                 case JS::TokenType::Let:
                 case JS::TokenType::New:
+                case JS::TokenType::Super:
                 case JS::TokenType::TemplateLiteralExprStart:
                 case JS::TokenType::TemplateLiteralExprEnd:
                 case JS::TokenType::Throw:


### PR DESCRIPTION
Highlighting reserved words (i.e. `static`) will take some extra work.