### PR TITLE
SystemMonitor: Correctly check error of posix_spawn()

### DIFF
--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -214,7 +214,7 @@ int main(int argc, char** argv)
             auto pid_string = String::format("%d", pid);
             pid_t child;
             const char* argv[] = { "/bin/Profiler", "--pid", pid_string.characters(), nullptr };
-            if (posix_spawn(&child, "/bin/Profiler", nullptr, nullptr, const_cast<char**>(argv), environ) < 0) {
+            if ((errno = posix_spawn(&child, "/bin/Profiler", nullptr, nullptr, const_cast<char**>(argv), environ))) {
                 perror("posix_spawn");
             }
         }


### PR DESCRIPTION
Hooray for using posix_spawn()!

I learned about this API peculiarity long after I started using it
(but before I implemented it in Serenity :) ).

posix_spawn() has a bit of a whacky API in that it doens't return
0 on success and -1 on failure while writing the error code to
errno -- it instead returns 0 on success and the error code on
error.

So assign the return value to errno so that perror() does the
right thing.