### PR TITLE
FilePicker: Increase location box height by 2px and add folder icon

### DIFF
--- a/Libraries/LibGUI/FilePicker.cpp
+++ b/Libraries/LibGUI/FilePicker.cpp
@@ -110,6 +110,7 @@ FilePicker::FilePicker(Mode mode, const StringView& file_name, const StringView&
     location_textbox.set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
     location_textbox.set_preferred_size(0, 22);
     location_textbox.set_text(path);
+    location_textbox.set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-folder.png"));
 
     m_view = vertical_container.add<MultiView>();
     m_view->set_model(SortingProxyModel::create(*m_model));

--- a/Libraries/LibGUI/FilePicker.cpp
+++ b/Libraries/LibGUI/FilePicker.cpp
@@ -93,7 +93,7 @@ FilePicker::FilePicker(Mode mode, const StringView& file_name, const StringView&
 
     auto& upper_container = vertical_container.add<Widget>();
     upper_container.set_layout<HorizontalBoxLayout>();
-    upper_container.layout()->set_spacing(4);
+    upper_container.layout()->set_spacing(2);
     upper_container.set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
     upper_container.set_preferred_size(0, 26);
 
@@ -108,7 +108,7 @@ FilePicker::FilePicker(Mode mode, const StringView& file_name, const StringView&
 
     auto& location_textbox = upper_container.add<TextBox>();
     location_textbox.set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
-    location_textbox.set_preferred_size(0, 20);
+    location_textbox.set_preferred_size(0, 22);
     location_textbox.set_text(path);
 
     m_view = vertical_container.add<MultiView>();


### PR DESCRIPTION
This brings it closer to FileManager again, which also had these two changes recently.

Before and after:

![image](https://user-images.githubusercontent.com/19366641/86413433-22616000-bcb9-11ea-9a00-552a35c56443.png)

![image](https://user-images.githubusercontent.com/19366641/86413437-242b2380-bcb9-11ea-84fc-416dc9dd332b.png)
