### PR TITLE
Kernel/LibCore: Time without syscalls

### DIFF
--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -31,6 +31,7 @@
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/Arch/i386/ProcessorInfo.h>
 #include <Kernel/Arch/i386/ISRStubs.h>
+#include <Kernel/GlobalPage.h>
 #include <Kernel/Interrupts/APIC.h>
 #include <Kernel/Interrupts/GenericInterruptHandler.h>
 #include <Kernel/Interrupts/IRQHandler.h>
@@ -923,7 +924,7 @@ void Processor::write_raw_gdt_entry(u16 selector, u32 low, u32 high)
     if (i > m_gdt_length) {
         m_gdt_length = i + 1;
         ASSERT(m_gdt_length <= sizeof(m_gdt) / sizeof(m_gdt[0]));
-        m_gdtr.limit = (m_gdt_length + 1) * 8 - 1;
+        m_gdtr.limit = m_gdt_length * 8 - 1;
     }
     m_gdt[i].low = low;
     m_gdt[i].high = high;

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -36,6 +36,7 @@ class DiskCache;
 class DoubleBuffer;
 class File;
 class FileDescription;
+struct GlobalPage;
 class IPv4Socket;
 class Inode;
 class InodeIdentifier;

--- a/Kernel/GlobalPage.h
+++ b/Kernel/GlobalPage.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include <AK/Atomic.h>
+#include <AK/Types.h>
+#if defined(KERNEL)
+#    include <Kernel/UnixTypes.h>
+#else
+#    include <limits.h>
+#    include <stdint.h>
+#    include <sys/time.h>
+#endif
+
+#if defined(KERNEL)
+#    define global_page() \
+        (*(reinterpret_cast<::GlobalPage*>(0xffe00000)))
+#    define global_page_user() \
+        FlatPtr(0x00800000 - PAGE_SIZE)
+#else
+#    define global_page() \
+        (*(reinterpret_cast<const ::GlobalPage*>(0x007ff000)))
+#endif
+
+struct GlobalPage {
+    volatile Atomic<u32> time_update1 { 0 };
+    volatile time_t epoch_time { 0 };
+    volatile time_t seconds_since_boot { 0 };
+    volatile suseconds_t useconds { 0 };
+    volatile Atomic<u32> time_update2 { 0 };
+
+    inline timeval read_timeofday() const
+    {
+        timeval tv;
+        u32 up1;
+        do {
+            up1 = time_update1.load(AK::MemoryOrder::memory_order_consume);
+            tv.tv_sec = epoch_time;
+            tv.tv_usec = useconds;
+        } while (up1 != time_update2.load(AK::MemoryOrder::memory_order_consume));
+        return tv;
+    }
+
+    inline timespec read_monotonic() const
+    {
+        timespec ts;
+        u32 up1;
+        do {
+            up1 = time_update1.load(AK::MemoryOrder::memory_order_consume);
+            ts.tv_sec = seconds_since_boot;
+            ts.tv_nsec = useconds;
+        } while (up1 != time_update2.load(AK::MemoryOrder::memory_order_consume));
+        ts.tv_nsec *= 1000;
+        return ts;
+    }
+
+    inline timespec read_realtime() const
+    {
+        timespec ts;
+        u32 up1;
+        do {
+            up1 = time_update1.load(AK::MemoryOrder::memory_order_consume);
+            ts.tv_sec = epoch_time;
+            ts.tv_nsec = useconds;
+        } while (up1 != time_update2.load(AK::MemoryOrder::memory_order_consume));
+        ts.tv_nsec *= 1000;
+        return ts;
+    }
+
+#if defined(KERNEL)
+    inline void write_time(time_t epoch_time, time_t seconds_since_boot, suseconds_t useconds)
+    {
+        u32 up2 = time_update1.fetch_add(1u, AK::MemoryOrder::memory_order_acq_rel) + 1;
+        this->epoch_time = epoch_time;
+        this->seconds_since_boot = seconds_since_boot;
+        this->useconds = useconds;
+        time_update2.store(up2, AK::MemoryOrder::memory_order_release);
+    }
+#endif
+};

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -46,7 +46,6 @@ extern WaitQueue* g_finalizer_wait_queue;
 extern Atomic<bool> g_finalizer_has_work;
 extern u64 g_uptime;
 extern SchedulerData* g_scheduler_data;
-extern timeval g_timeofday;
 extern RecursiveSpinLock g_scheduler_lock;
 
 class Scheduler {
@@ -55,7 +54,6 @@ public:
     static void timer_tick(const RegisterState&);
     [[noreturn]] static void start();
     static bool pick_next();
-    static timeval time_since_boot();
     static bool yield();
     static bool donate_to(Thread*, const char* reason);
     static bool context_switch(Thread&);

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -46,12 +46,13 @@ public:
     static void initialize();
     static TimeManagement& the();
 
-    time_t epoch_time() const;
     void set_epoch_time(time_t);
     time_t seconds_since_boot() const;
     time_t ticks_per_second() const;
-    time_t ticks_this_second() const;
+    timeval time_since_boot() const;
     time_t boot_time() const;
+    timespec monotonic_time() const;
+    timespec real_time() const;
 
     bool is_system_timer(const HardwareTimer&) const;
 
@@ -59,8 +60,6 @@ public:
     void increment_time_since_boot(const RegisterState&);
 
     static bool is_hpet_periodic_mode_allowed();
-
-    static timeval now_as_timeval();
 
 private:
     explicit TimeManagement(bool probe_non_legacy_hardware_timers);

--- a/Kernel/VM/PhysicalPage.h
+++ b/Kernel/VM/PhysicalPage.h
@@ -63,7 +63,9 @@ public:
 
     u32 ref_count() const { return m_ref_count; }
 
+    bool is_shared_page() const;
     bool is_shared_zero_page() const;
+    bool is_shared_global_page() const;
 
 private:
     PhysicalPage(PhysicalAddress paddr, bool supervisor, bool may_return_to_freelist = true);

--- a/Kernel/VM/PurgeableVMObject.cpp
+++ b/Kernel/VM/PurgeableVMObject.cpp
@@ -74,7 +74,7 @@ int PurgeableVMObject::purge_impl()
         return 0;
     int purged_page_count = 0;
     for (size_t i = 0; i < m_physical_pages.size(); ++i) {
-        if (m_physical_pages[i] && !m_physical_pages[i]->is_shared_zero_page())
+        if (m_physical_pages[i] && !m_physical_pages[i]->is_shared_page())
             ++purged_page_count;
         m_physical_pages[i] = MM.shared_zero_page();
     }

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -133,7 +133,7 @@ bool Region::commit(size_t page_index)
     ASSERT(vmobject().is_anonymous() || vmobject().is_purgeable());
     InterruptDisabler disabler;
     auto& vmobject_physical_page_entry = physical_page_slot(page_index);
-    if (!vmobject_physical_page_entry.is_null() && !vmobject_physical_page_entry->is_shared_zero_page())
+    if (!vmobject_physical_page_entry.is_null() && !vmobject_physical_page_entry->is_shared_page())
         return true;
     auto physical_page = MM.allocate_user_physical_page(MemoryManager::ShouldZeroFill::Yes);
     if (!physical_page) {
@@ -168,7 +168,7 @@ size_t Region::amount_resident() const
     size_t bytes = 0;
     for (size_t i = 0; i < page_count(); ++i) {
         auto* page = physical_page(i);
-        if (page && !page->is_shared_zero_page())
+        if (page && !page->is_shared_page())
             bytes += PAGE_SIZE;
     }
     return bytes;
@@ -179,7 +179,7 @@ size_t Region::amount_shared() const
     size_t bytes = 0;
     for (size_t i = 0; i < page_count(); ++i) {
         auto* page = physical_page(i);
-        if (page && page->ref_count() > 1 && !page->is_shared_zero_page())
+        if (page && page->ref_count() > 1 && !page->is_shared_page())
             bytes += PAGE_SIZE;
     }
     return bytes;
@@ -202,7 +202,7 @@ NonnullOwnPtr<Region> Region::create_kernel_only(const Range& range, NonnullRefP
 bool Region::should_cow(size_t page_index) const
 {
     auto* page = physical_page(page_index);
-    if (page && page->is_shared_zero_page())
+    if (page && page->is_shared_page())
         return true;
     if (m_shared)
         return false;

--- a/Libraries/LibCore/CMakeLists.txt
+++ b/Libraries/LibCore/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     SocketAddress.cpp
     Socket.cpp
     StandardPaths.cpp
+    SystemTime.cpp
     TCPServer.cpp
     TCPSocket.cpp
     Timer.cpp

--- a/Libraries/LibCore/DateTime.cpp
+++ b/Libraries/LibCore/DateTime.cpp
@@ -26,6 +26,7 @@
 
 #include <AK/StringBuilder.h>
 #include <LibCore/DateTime.h>
+#include <LibCore/SystemTime.h>
 #include <sys/time.h>
 #include <time.h>
 
@@ -33,7 +34,7 @@ namespace Core {
 
 DateTime DateTime::now()
 {
-    return from_timestamp(time(nullptr));
+    return from_timestamp(SystemTime::timeofday().tv_sec);
 }
 
 DateTime DateTime::create(unsigned year, unsigned month, unsigned day, unsigned hour, unsigned minute, unsigned second)

--- a/Libraries/LibCore/ElapsedTimer.cpp
+++ b/Libraries/LibCore/ElapsedTimer.cpp
@@ -27,6 +27,7 @@
 #include <AK/Assertions.h>
 #include <AK/Time.h>
 #include <LibCore/ElapsedTimer.h>
+#include <LibCore/SystemTime.h>
 #include <sys/time.h>
 #include <time.h>
 
@@ -35,8 +36,7 @@ namespace Core {
 void ElapsedTimer::start()
 {
     m_valid = true;
-    timespec now_spec;
-    clock_gettime(CLOCK_MONOTONIC, &now_spec);
+    timespec now_spec = SystemTime::monotonic();
     m_start_time.tv_sec = now_spec.tv_sec;
     m_start_time.tv_usec = now_spec.tv_nsec / 1000;
 }
@@ -45,8 +45,7 @@ int ElapsedTimer::elapsed() const
 {
     ASSERT(is_valid());
     struct timeval now;
-    timespec now_spec;
-    clock_gettime(CLOCK_MONOTONIC, &now_spec);
+    timespec now_spec = SystemTime::monotonic();
     now.tv_sec = now_spec.tv_sec;
     now.tv_usec = now_spec.tv_nsec / 1000;
     struct timeval diff;

--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -37,6 +37,7 @@
 #include <LibCore/Notifier.h>
 #include <LibCore/Object.h>
 #include <LibCore/SyscallUtils.h>
+#include <LibCore/SystemTime.h>
 #include <LibThread/Lock.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -447,8 +448,7 @@ void EventLoop::wait_for_event(WaitMode mode)
     if (mode == WaitMode::WaitForEvents && queued_events_is_empty) {
         auto next_timer_expiration = get_next_timer_expiration();
         if (next_timer_expiration.has_value()) {
-            timespec now_spec;
-            clock_gettime(CLOCK_MONOTONIC, &now_spec);
+            timespec now_spec = SystemTime::monotonic();
             now.tv_sec = now_spec.tv_sec;
             now.tv_usec = now_spec.tv_nsec / 1000;
             timeval_sub(next_timer_expiration.value(), now, timeout);
@@ -473,8 +473,7 @@ void EventLoop::wait_for_event(WaitMode mode)
     }
 
     if (!s_timers->is_empty()) {
-        timespec now_spec;
-        clock_gettime(CLOCK_MONOTONIC, &now_spec);
+        timespec now_spec = SystemTime::monotonic();
         now.tv_sec = now_spec.tv_sec;
         now.tv_usec = now_spec.tv_nsec / 1000;
     }
@@ -550,8 +549,7 @@ int EventLoop::register_timer(Object& object, int milliseconds, bool should_relo
     timer->owner = object.make_weak_ptr();
     timer->interval = milliseconds;
     timeval now;
-    timespec now_spec;
-    clock_gettime(CLOCK_MONOTONIC, &now_spec);
+    timespec now_spec = SystemTime::monotonic();
     now.tv_sec = now_spec.tv_sec;
     now.tv_usec = now_spec.tv_nsec / 1000;
     timer->reload(now);

--- a/Libraries/LibCore/SystemTime.cpp
+++ b/Libraries/LibCore/SystemTime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,39 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include <Kernel/GlobalPage.h>
+#include <LibCore/SystemTime.h>
 
 namespace Core {
 
-class ArgsParser;
-class ChildEvent;
-class ConfigFile;
-class CustomEvent;
-class DateTime;
-class DirIterator;
-class ElapsedTimer;
-class Event;
-class EventLoop;
-class File;
-class IODevice;
-class LocalServer;
-class LocalSocket;
-class MimeData;
-class NetworkJob;
-class NetworkResponse;
-class Notifier;
-class Object;
-class ProcessStatisticsReader;
-class Socket;
-class SocketAddress;
-class SystemTime;
-class TCPServer;
-class TCPSocket;
-class Timer;
-class TimerEvent;
-class UDPServer;
-class UDPSocket;
+timeval SystemTime::timeofday()
+{
+    return global_page().read_timeofday();
+}
 
-enum class TimerShouldFireWhenNotVisible;
+timespec SystemTime::monotonic()
+{
+    return global_page().read_monotonic();
+}
+
+timespec SystemTime::realtime()
+{
+    return global_page().read_realtime();
+}
 
 }

--- a/Libraries/LibCore/SystemTime.h
+++ b/Libraries/LibCore/SystemTime.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,37 +26,15 @@
 
 #pragma once
 
+#include <sys/time.h>
+
 namespace Core {
 
-class ArgsParser;
-class ChildEvent;
-class ConfigFile;
-class CustomEvent;
-class DateTime;
-class DirIterator;
-class ElapsedTimer;
-class Event;
-class EventLoop;
-class File;
-class IODevice;
-class LocalServer;
-class LocalSocket;
-class MimeData;
-class NetworkJob;
-class NetworkResponse;
-class Notifier;
-class Object;
-class ProcessStatisticsReader;
-class Socket;
-class SocketAddress;
-class SystemTime;
-class TCPServer;
-class TCPSocket;
-class Timer;
-class TimerEvent;
-class UDPServer;
-class UDPSocket;
-
-enum class TimerShouldFireWhenNotVisible;
+class SystemTime {
+public:
+    static timeval timeofday();
+    static timespec monotonic();
+    static timespec realtime();
+};
 
 }

--- a/MenuApplets/Clock/main.cpp
+++ b/MenuApplets/Clock/main.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <LibCore/Timer.h>
+#include <LibCore/SystemTime.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Widget.h>
@@ -43,7 +44,7 @@ public:
 
         m_timer = add<Core::Timer>(1000, [this] {
             static time_t last_update_time;
-            time_t now = time(nullptr);
+            time_t now = Core::SystemTime::realtime().tv_sec;
             if (now != last_update_time) {
                 tick_clock();
                 last_update_time = now;
@@ -63,7 +64,7 @@ private:
 
     virtual void paint_event(GUI::PaintEvent& event) override
     {
-        time_t now = time(nullptr);
+        time_t now = Core::SystemTime::realtime().tv_sec;
         auto* tm = localtime(&now);
 
         auto time_text = String::format("%4u-%02u-%02u %02u:%02u:%02u",


### PR DESCRIPTION
This provides a way for the Kernel to share data with usermode that requires no system calls. Some OSs like Windows use this technique for certain data. Time is a good example.