### PR TITLE
Shell: Do not remove more than 2 dashes from the option being completed

### DIFF
--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -831,7 +831,7 @@ Vector<Line::CompletionSuggestion> Shell::complete_user(const String& name, size
 Vector<Line::CompletionSuggestion> Shell::complete_option(const String& program_name, const String& option, size_t offset)
 {
     size_t start = 0;
-    while (start < option.length() && option[start] == '-')
+    while (start < option.length() && option[start] == '-' && start < 2)
         ++start;
     auto option_pattern = offset > start ? option.substring_view(start, offset - start) : "";
     editor->suggest(offset);


### PR DESCRIPTION
This makes '------inl' a completion request for an option named '----inl' instead of 'inl'.

I wish all diffs were like this, -1,+1