### PR TITLE
TextEditor: Use ArgsParser and allow the user to specify preview mode

### DIFF
--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -497,12 +497,14 @@ void TextEditorWidget::set_path(const LexicalPath& lexical_path)
         m_plain_text_highlight->activate();
     }
 
-    if (m_extension == "md")
-        set_preview_mode(PreviewMode::Markdown);
-    else if (m_extension == "html")
-        set_preview_mode(PreviewMode::HTML);
-    else
-        set_preview_mode(PreviewMode::None);
+    if (m_auto_detect_preview_mode) {
+        if (m_extension == "md")
+            set_preview_mode(PreviewMode::Markdown);
+        else if (m_extension == "html")
+            set_preview_mode(PreviewMode::HTML);
+        else
+            set_preview_mode(PreviewMode::None);
+    }
 
     update_title();
 }

--- a/Applications/TextEditor/TextEditorWidget.h
+++ b/Applications/TextEditor/TextEditorWidget.h
@@ -51,6 +51,7 @@ public:
     };
 
     void set_preview_mode(PreviewMode);
+    void set_auto_detect_preview_mode(bool value) { m_auto_detect_preview_mode = value; }
 
 private:
     TextEditorWidget();
@@ -107,6 +108,7 @@ private:
 
     bool m_document_dirty { false };
     bool m_document_opening { false };
+    bool m_auto_detect_preview_mode { false };
 
     PreviewMode m_preview_mode { PreviewMode::None };
 };

--- a/Applications/TextEditor/main.cpp
+++ b/Applications/TextEditor/main.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "TextEditorWidget.h"
+#include <LibCore/ArgsParser.h>
 #include <LibGfx/Bitmap.h>
 #include <stdio.h>
 
@@ -42,6 +43,16 @@ int main(int argc, char** argv)
         return 1;
     }
 
+    const char* preview_mode = "auto";
+    const char* file_to_edit = nullptr;
+    Core::ArgsParser parser;
+    parser.add_option(preview_mode, "Preview mode, one of 'none', 'html', 'markdown', 'auto'", "preview-mode", '\0', "mode");
+    parser.add_positional_argument(file_to_edit, "File to edit", "file", Core::ArgsParser::Required::No);
+
+    parser.parse(argc, argv);
+
+    StringView preview_mode_view = preview_mode;
+
     auto window = GUI::Window::construct();
     window->set_title("Text Editor");
     window->set_rect(20, 200, 640, 400);
@@ -56,8 +67,21 @@ int main(int argc, char** argv)
         return GUI::Window::CloseRequestDecision::StayOpen;
     };
 
-    if (argc >= 2)
-        text_widget.open_sesame(argv[1]);
+    if (preview_mode_view == "auto") {
+        text_widget.set_auto_detect_preview_mode(true);
+    } else if (preview_mode_view == "markdown") {
+        text_widget.set_preview_mode(TextEditorWidget::PreviewMode::Markdown);
+    } else if (preview_mode_view == "html") {
+        text_widget.set_preview_mode(TextEditorWidget::PreviewMode::HTML);
+    } else if (preview_mode_view == "none") {
+        text_widget.set_preview_mode(TextEditorWidget::PreviewMode::None);
+    } else {
+        fprintf(stderr, "Invalid mode '%s'\n", preview_mode);
+        return 1;
+    }
+
+    if (file_to_edit)
+        text_widget.open_sesame(file_to_edit);
 
     window->show();
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-text-editor.png"));


### PR DESCRIPTION
This makes looking at HTML files that somehow fail a little less painful by allowing the user to actually _see_ the html.

TL;DR, I tried to look at what twitter.com serves and had to wait forever for the preview to load.
sidenote: when can we have DoH? I'm tired of mounting /etc rw and changing the nameserver to my local doh proxy...