### PR TITLE
Kernel: Fix checking BlockResult

### DIFF
--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -250,7 +250,7 @@ ssize_t IPv4Socket::receive_byte_buffered(FileDescription& description, void* bu
         locker.lock();
 
         if (!m_can_read) {
-            if (res != Thread::BlockResult::WokeNormally)
+            if (res.was_interrupted())
                 return -EINTR;
 
             // Unblocked due to timeout.
@@ -300,7 +300,7 @@ ssize_t IPv4Socket::receive_packet_buffered(FileDescription& description, void* 
         locker.lock();
 
         if (!m_can_read) {
-            if (res != Thread::BlockResult::WokeNormally)
+            if (res.was_interrupted())
                 return -EINTR;
 
             // Unblocked due to timeout.

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -176,7 +176,7 @@ KResult LocalSocket::connect(FileDescription& description, const sockaddr* addre
         return KSuccess;
     }
 
-    if (Thread::current()->block<Thread::ConnectBlocker>(description) != Thread::BlockResult::WokeNormally) {
+    if (Thread::current()->block<Thread::ConnectBlocker>(description).was_interrupted()) {
         m_connect_side_role = Role::None;
         return KResult(-EINTR);
     }
@@ -300,8 +300,7 @@ ssize_t LocalSocket::recvfrom(FileDescription& description, void* buffer, size_t
             return -EAGAIN;
         }
     } else if (!can_read(description, 0)) {
-        auto result = Thread::current()->block<Thread::ReadBlocker>(description);
-        if (result != Thread::BlockResult::WokeNormally)
+        if (Thread::current()->block<Thread::ReadBlocker>(description).was_interrupted())
             return -EINTR;
     }
     if (!has_attached_peer(description) && buffer_for_me.is_empty())

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -372,7 +372,7 @@ KResult TCPSocket::protocol_connect(FileDescription& description, ShouldBlock sh
     m_direction = Direction::Outgoing;
 
     if (should_block == ShouldBlock::Yes) {
-        if (Thread::current()->block<Thread::ConnectBlocker>(description) != Thread::BlockResult::WokeNormally)
+        if (Thread::current()->block<Thread::ConnectBlocker>(description).was_interrupted())
             return KResult(-EINTR);
         ASSERT(setup_state() == SetupState::Completed);
         if (has_error()) {

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -300,12 +300,42 @@ public:
     u64 sleep(u32 ticks);
     u64 sleep_until(u64 wakeup_time);
 
-    enum class BlockResult {
-        WokeNormally,
-        NotBlocked,
-        InterruptedBySignal,
-        InterruptedByDeath,
-        InterruptedByTimeout,
+    class BlockResult {
+    public:
+        enum Type {
+            WokeNormally,
+            NotBlocked,
+            InterruptedBySignal,
+            InterruptedByDeath,
+            InterruptedByTimeout,
+        };
+
+        BlockResult() = delete;
+
+        BlockResult(Type type)
+            : m_type(type)
+        {
+        }
+
+        bool operator==(Type type) const
+        {
+            return m_type == type;
+        }
+
+        bool was_interrupted() const
+        {
+            switch (m_type) {
+            case InterruptedBySignal:
+            case InterruptedByDeath:
+            case InterruptedByTimeout:
+                return true;
+            default:
+                return false;
+            }
+        }
+
+    private:
+        Type m_type;
     };
 
     template<typename T, class... Args>


### PR DESCRIPTION
We now have BlockResult::WokeNormally and BlockResult::NotBlocked,
both of which indicate no error. We can no longer just check for
BlockResult::WokeNormally and assume anything else must be an
interruption.

This is related to #2718, but unfortunately not the solution. Still should be fixed, though.