### PR TITLE
LibJS: Symbol table fix

### DIFF
--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -111,6 +111,10 @@ public:
 
     Reference get_reference(const FlyString& name);
 
+    Symbol* get_global_symbol(const String& description);
+    Symbol* get_well_known_symbol(const String& description) const;
+    const HashMap<String, Symbol*>& get_well_known_symbol_map(Badge<SymbolConstructor>) const { return m_well_known_symbol_map; };
+
     void gather_roots(Badge<Heap>, HashTable<Cell*>&);
 
     void enter_scope(const ScopeNode&, ArgumentVector, ScopeType, GlobalObject&);
@@ -216,6 +220,9 @@ private:
     Vector<CallFrame> m_call_stack;
 
     Object* m_global_object { nullptr };
+
+    HashMap<String, Symbol*> m_well_known_symbol_map;
+    HashMap<String, Symbol*> m_global_symbol_map;
 
     Exception* m_exception { nullptr };
 

--- a/Libraries/LibJS/Runtime/Symbol.h
+++ b/Libraries/LibJS/Runtime/Symbol.h
@@ -32,6 +32,9 @@
 namespace JS {
 
 class Symbol final : public Cell {
+    AK_MAKE_NONCOPYABLE(Symbol)
+    AK_MAKE_NONMOVABLE(Symbol)
+
 public:
     Symbol(String, bool);
     virtual ~Symbol();

--- a/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -46,21 +46,8 @@ void SymbolConstructor::initialize(Interpreter& interpreter, GlobalObject& globa
     define_native_function("for", for_, 1, Attribute::Writable | Attribute::Configurable);
     define_native_function("keyFor", key_for, 1, Attribute::Writable | Attribute::Configurable);
 
-    SymbolObject::initialize_well_known_symbols(interpreter);
-
-    define_property("iterator", SymbolObject::well_known_iterator(), 0);
-    define_property("asyncIterator", SymbolObject::well_known_async_terator(), 0);
-    define_property("match", SymbolObject::well_known_match(), 0);
-    define_property("matchAll", SymbolObject::well_known_match_all(), 0);
-    define_property("replace", SymbolObject::well_known_replace(), 0);
-    define_property("search", SymbolObject::well_known_search(), 0);
-    define_property("split", SymbolObject::well_known_split(), 0);
-    define_property("hasInstance", SymbolObject::well_known_has_instance(), 0);
-    define_property("isConcatSpreadable", SymbolObject::well_known_is_concat_spreadable(), 0);
-    define_property("unscopables", SymbolObject::well_known_unscopables(), 0);
-    define_property("species", SymbolObject::well_known_species(), 0);
-    define_property("toPrimitive", SymbolObject::well_known_to_primtive(), 0);
-    define_property("toStringTag", SymbolObject::well_known_to_string_tag(), 0);
+    for (auto& entry : interpreter.get_well_known_symbol_map({}))
+        define_property(entry.key, entry.value, 0);
 }
 
 SymbolConstructor::~SymbolConstructor()
@@ -89,7 +76,7 @@ JS_DEFINE_NATIVE_FUNCTION(SymbolConstructor::for_)
         description = interpreter.argument(0).to_string(interpreter);
     }
 
-    return SymbolObject::get_global(interpreter, description);
+    return interpreter.get_global_symbol(description);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(SymbolConstructor::key_for)

--- a/Libraries/LibJS/Runtime/SymbolObject.cpp
+++ b/Libraries/LibJS/Runtime/SymbolObject.cpp
@@ -34,21 +34,6 @@
 
 namespace JS {
 
-HashMap<String, Value> SymbolObject::s_global_symbol_map;
-
-Value SymbolObject::s_well_known_iterator;
-Value SymbolObject::s_well_known_async_terator;
-Value SymbolObject::s_well_known_match;
-Value SymbolObject::s_well_known_match_all;
-Value SymbolObject::s_well_known_replace;
-Value SymbolObject::s_well_known_search;
-Value SymbolObject::s_well_known_split;
-Value SymbolObject::s_well_known_has_instance;
-Value SymbolObject::s_well_known_is_concat_spreadable;
-Value SymbolObject::s_well_known_unscopables;
-Value SymbolObject::s_well_known_species;
-Value SymbolObject::s_well_known_to_primtive;
-Value SymbolObject::s_well_known_to_string_tag;
 
 SymbolObject* SymbolObject::create(GlobalObject& global_object, Symbol& primitive_symbol)
 {
@@ -63,54 +48,6 @@ SymbolObject::SymbolObject(Symbol& symbol, Object& prototype)
 
 SymbolObject::~SymbolObject()
 {
-}
-
-Value SymbolObject::get_global(Interpreter& interpreter, String description)
-{
-    auto global_symbol = s_global_symbol_map.get(description);
-    if (global_symbol.has_value())
-        return global_symbol.value();
-
-    auto symbol = js_symbol(interpreter, description, true);
-    s_global_symbol_map.set(description, symbol);
-    return Value(symbol);
-}
-
-void SymbolObject::initialize_well_known_symbols(Interpreter& interpreter)
-{
-    SymbolObject::s_well_known_iterator = Value(js_symbol(interpreter, "Symbol.iterator", false));
-    SymbolObject::s_well_known_async_terator = Value(js_symbol(interpreter, "Symbol.asyncIterator", false));
-    SymbolObject::s_well_known_match = Value(js_symbol(interpreter, "Symbol.match", false));
-    SymbolObject::s_well_known_match_all = Value(js_symbol(interpreter, "Symbol.matchAll", false));
-    SymbolObject::s_well_known_replace = Value(js_symbol(interpreter, "Symbol.replace", false));
-    SymbolObject::s_well_known_search = Value(js_symbol(interpreter, "Symbol.search", false));
-    SymbolObject::s_well_known_split = Value(js_symbol(interpreter, "Symbol.split", false));
-    SymbolObject::s_well_known_has_instance = Value(js_symbol(interpreter, "Symbol.hasInstance", false));
-    SymbolObject::s_well_known_is_concat_spreadable = Value(js_symbol(interpreter, "Symbol.isConcatSpreadable", false));
-    SymbolObject::s_well_known_unscopables = Value(js_symbol(interpreter, "Symbol.unscopables", false));
-    SymbolObject::s_well_known_species = Value(js_symbol(interpreter, "Symbol.species", false));
-    SymbolObject::s_well_known_to_primtive = Value(js_symbol(interpreter, "Symbol.toPrimitive", false));
-    SymbolObject::s_well_known_to_string_tag = Value(js_symbol(interpreter, "Symbol.toStringTag", false));
-}
-
-void SymbolObject::gather_symbol_roots(HashTable<Cell*>& roots)
-{
-    for (auto& global_symbol : s_global_symbol_map) 
-        roots.set(&global_symbol.value.as_symbol());
-
-    roots.set(&s_well_known_iterator.as_symbol());
-    roots.set(&s_well_known_async_terator.as_symbol());
-    roots.set(&s_well_known_match.as_symbol());
-    roots.set(&s_well_known_match_all.as_symbol());
-    roots.set(&s_well_known_replace.as_symbol());
-    roots.set(&s_well_known_search.as_symbol());
-    roots.set(&s_well_known_split.as_symbol());
-    roots.set(&s_well_known_has_instance.as_symbol());
-    roots.set(&s_well_known_is_concat_spreadable.as_symbol());
-    roots.set(&s_well_known_unscopables.as_symbol());
-    roots.set(&s_well_known_species.as_symbol());
-    roots.set(&s_well_known_to_primtive.as_symbol());
-    roots.set(&s_well_known_to_string_tag.as_symbol());
 }
 
 void SymbolObject::visit_children(Cell::Visitor& visitor)

--- a/Libraries/LibJS/Runtime/SymbolObject.h
+++ b/Libraries/LibJS/Runtime/SymbolObject.h
@@ -46,51 +46,16 @@ public:
     const String& description() const { return m_symbol.description(); }
     bool is_global() const { return m_symbol.is_global(); }
 
-    static Value get_global(Interpreter&, String description);
-
     virtual Value value_of() const override
     {
         return Value(&m_symbol);
     }
-
-    static void initialize_well_known_symbols(Interpreter&);
-    static void gather_symbol_roots(HashTable<Cell*>& roots);
-
-    static Value well_known_iterator() { return s_well_known_iterator; };
-    static Value well_known_async_terator() { return s_well_known_async_terator; };
-    static Value well_known_match() { return s_well_known_match; };
-    static Value well_known_match_all() { return s_well_known_match_all; };
-    static Value well_known_replace() { return s_well_known_replace; };
-    static Value well_known_search() { return s_well_known_search; };
-    static Value well_known_split() { return s_well_known_split; };
-    static Value well_known_has_instance() { return s_well_known_has_instance; };
-    static Value well_known_is_concat_spreadable() { return s_well_known_is_concat_spreadable; };
-    static Value well_known_unscopables() { return s_well_known_unscopables; };
-    static Value well_known_species() { return s_well_known_species; };
-    static Value well_known_to_primtive() { return s_well_known_to_primtive; };
-    static Value well_known_to_string_tag() { return s_well_known_to_string_tag; };
 
 private:
     virtual void visit_children(Visitor&) override;
     virtual bool is_symbol_object() const override { return true; }
 
     Symbol& m_symbol;
-
-    static HashMap<String, Value> s_global_symbol_map;
-
-    static Value s_well_known_iterator;
-    static Value s_well_known_async_terator;
-    static Value s_well_known_match;
-    static Value s_well_known_match_all;
-    static Value s_well_known_replace;
-    static Value s_well_known_search;
-    static Value s_well_known_split;
-    static Value s_well_known_has_instance;
-    static Value s_well_known_is_concat_spreadable;
-    static Value s_well_known_unscopables;
-    static Value s_well_known_species;
-    static Value s_well_known_to_primtive;
-    static Value s_well_known_to_string_tag;
 };
 
 }

--- a/Libraries/LibJS/Tests/builtins/Symbol/Symbol.for.js
+++ b/Libraries/LibJS/Tests/builtins/Symbol/Symbol.for.js
@@ -1,23 +1,23 @@
-// test("basic functionality", () => {
-//   const localSym = Symbol("foo");
-//   const globalSym = Symbol.for("foo");
+test("basic functionality", () => {
+    const localSym = Symbol("foo");
+    const globalSym = Symbol.for("foo");
 
-//   expect(localSym).not.toBe(globalSym);
-//   expect(localSym).not.toBe(Symbol("foo"));
-//   expect(globalSym).not.toBe(Symbol("foo"));
-//   expect(globalSym).toBe(Symbol.for("foo"));
-//   expect(localSym.toString()).toBe("Symbol(foo)");
-//   expect(globalSym.toString()).toBe("Symbol(foo)");
+    expect(localSym).not.toBe(globalSym);
+    expect(localSym).not.toBe(Symbol("foo"));
+    expect(globalSym).not.toBe(Symbol("foo"));
+    expect(globalSym).toBe(Symbol.for("foo"));
+    expect(localSym.toString()).toBe("Symbol(foo)");
+    expect(globalSym.toString()).toBe("Symbol(foo)");
 
-//   expect(Symbol.for(1).description).toBe("1");
-//   expect(Symbol.for(true).description).toBe("true");
-//   expect(Symbol.for({}).description).toBe("[object Object]");
-//   expect(Symbol.for().description).toBe("undefined");
-//   expect(Symbol.for(null).description).toBe("null");
-// });
+    expect(Symbol.for(1).description).toBe("1");
+    expect(Symbol.for(true).description).toBe("true");
+    expect(Symbol.for({}).description).toBe("[object Object]");
+    expect(Symbol.for().description).toBe("undefined");
+    expect(Symbol.for(null).description).toBe("null");
+});
 
-// test("symbol argument throws an error", () => {
-//   expect(() => {
-//     Symbol.for(Symbol());
-//   }).toThrowWithMessage(TypeError, "Cannot convert symbol to string");
-// });
+test("symbol argument throws an error", () => {
+    expect(() => {
+        Symbol.for(Symbol());
+    }).toThrowWithMessage(TypeError, "Cannot convert symbol to string");
+});

--- a/Libraries/LibJS/Tests/builtins/Symbol/Symbol.keyFor.js
+++ b/Libraries/LibJS/Tests/builtins/Symbol/Symbol.keyFor.js
@@ -1,24 +1,24 @@
-// test("basic functionality", () => {
-//   const localSym = Symbol("bar");
-//   const globalSym = Symbol.for("bar");
+test("basic functionality", () => {
+    const localSym = Symbol("foo");
+    const globalSym = Symbol.for("foo");
 
-//   expect(Symbol.keyFor(localSym)).toBeUndefined();
-//   expect(Symbol.keyFor(globalSym)).toBe("bar");
-// });
+    expect(Symbol.keyFor(localSym)).toBeUndefined();
+    expect(Symbol.keyFor(globalSym)).toBe("foo");
+});
 
-// test("bad argument values", () => {
-//   [
-//     [1, "1"],
-//     [null, "null"],
-//     [undefined, "undefined"],
-//     [[], "[object Array]"],
-//     [{}, "[object Object]"],
-//     [true, "true"],
-//     ["foobar", "foobar"],
-//     [function () {}, "[object ScriptFunction]"], // FIXME: Better function stringification
-//   ].forEach(testCase => {
-//     expect(() => {
-//       Symbol.keyFor(testCase[0]);
-//     }).toThrowWithMessage(TypeError, `${testCase[1]} is not a symbol`);
-//   });
-// });
+test("bad argument values", () => {
+    [
+        [1, "1"],
+        [null, "null"],
+        [undefined, "undefined"],
+        [[], "[object Array]"],
+        [{}, "[object Object]"],
+        [true, "true"],
+        ["foobar", "foobar"],
+        [function () {}, "[object ScriptFunction]"], // FIXME: Better function stringification
+    ].forEach(testCase => {
+        expect(() => {
+            Symbol.keyFor(testCase[0]);
+        }).toThrowWithMessage(TypeError, `${testCase[1]} is not a symbol`);
+    });
+});

--- a/Libraries/LibJS/Tests/builtins/Symbol/well-known-symbol-existence.js
+++ b/Libraries/LibJS/Tests/builtins/Symbol/well-known-symbol-existence.js
@@ -1,0 +1,15 @@
+test("basic functionality", () => {
+    expect(Symbol).toHaveProperty("iterator");
+    expect(Symbol).toHaveProperty("asyncIterator");
+    expect(Symbol).toHaveProperty("match");
+    expect(Symbol).toHaveProperty("matchAll");
+    expect(Symbol).toHaveProperty("replace");
+    expect(Symbol).toHaveProperty("search");
+    expect(Symbol).toHaveProperty("split");
+    expect(Symbol).toHaveProperty("hasInstance");
+    expect(Symbol).toHaveProperty("isConcatSpreadable");
+    expect(Symbol).toHaveProperty("unscopables");
+    expect(Symbol).toHaveProperty("species");
+    expect(Symbol).toHaveProperty("toPrimitive");
+    expect(Symbol).toHaveProperty("toStringTag");
+});


### PR DESCRIPTION
This PR moves the global symbol table from a static property on `SymbolObject` to a non-static property on `Interpreter`. Also makes `Symbol` non-copyable and non-movable. Fixes #2709.