### PR TITLE
Help: Handle external links

### DIFF
--- a/Applications/Help/CMakeLists.txt
+++ b/Applications/Help/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SOURCES
 )
 
 serenity_bin(Help)
-target_link_libraries(Help LibWeb LibMarkdown LibGUI)
+target_link_libraries(Help LibWeb LibMarkdown LibGUI LibDesktop)

--- a/Base/usr/share/man/man1/test-js.md
+++ b/Base/usr/share/man/man1/test-js.md
@@ -12,7 +12,7 @@ $ test-js [options...]
 
 `test-js` runs the LibJS test suite located in `/home/anon/js-tests`. These
 tests are using a custom JavaScript testing framework inspired by
-[Jest](https://jestjs.io) (see `test-common.js` in the same directory).
+[Jest](https://jestjs.io) (see [`test-common.js`](/home/anon/js-tests/test-common.js)).
 
 ## Options
 


### PR DESCRIPTION
Links which do not have the "file" protocol (most commonly links to external websites - http and https) are now not treated as file paths anymore but instead handled by Desktop::Launcher.

Fixes #2727.

cc @bugaevc :)