### PR TITLE
man pages: Consistently use "Otherwise," in the few places that said "Else,"

### DIFF
--- a/Base/usr/share/man/man2/getresuid.md
+++ b/Base/usr/share/man/man2/getresuid.md
@@ -18,7 +18,7 @@ Returns the real, effective, and saved user or group ID.
 ## Return value
 
 If the call was set successful, returns 0.
-Else, returns -1 and sets `errno` to describe the error.
+Otherwise, returns -1 and sets `errno` to describe the error.
 
 ## Errors
 

--- a/Base/usr/share/man/man2/seteuid.md
+++ b/Base/usr/share/man/man2/seteuid.md
@@ -22,7 +22,7 @@ In particular, `seteuid(geteuid())` will fail if the current effective user ID i
 ## Return value
 
 If the call was set successful, returns 0.
-Else, returns -1 and sets `errno` to describe the error.
+Otherwise, returns -1 and sets `errno` to describe the error.
 
 ## Errors
 

--- a/Base/usr/share/man/man2/setresuid.md
+++ b/Base/usr/share/man/man2/setresuid.md
@@ -22,7 +22,7 @@ For non-superusers, each of the given values has to be equal to any of the curre
 ## Return value
 
 If the call was set successful, returns 0.
-Else, returns -1 and sets `errno` to describe the error.
+Otherwise, returns -1 and sets `errno` to describe the error.
 
 ## Errors
 

--- a/Base/usr/share/man/man2/setuid.md
+++ b/Base/usr/share/man/man2/setuid.md
@@ -20,7 +20,7 @@ For non-superusers, the given ID has to be equal to the current real or effectiv
 ## Return value
 
 If the call was set successful, returns 0.
-Else, returns -1 and sets `errno` to describe the error.
+Otherwise, returns -1 and sets `errno` to describe the error.
 
 ## Errors
 


### PR DESCRIPTION
@bugaevc says this is house style (and `rg -l 'Otherwise' | wc -l` backs that up).