### PR TITLE
LibWeb+WebContent: IFrame related fixes

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -246,7 +246,8 @@ void Document::layout()
     m_layout_root->layout();
     m_layout_root->set_needs_display();
 
-    frame()->page().client().page_did_layout();
+    if (frame()->is_main_frame())
+        frame()->page().client().page_did_layout();
 }
 
 void Document::update_style()

--- a/Libraries/LibWeb/DOM/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/DOM/HTMLIFrameElement.cpp
@@ -79,7 +79,7 @@ void HTMLIFrameElement::load_src(const String& value)
         return;
     }
 
-    m_hosted_frame->loader().load(url);
+    m_hosted_frame->loader().load(url, FrameLoader::Type::IFrame);
 }
 
 const Document* HTMLIFrameElement::hosted_document() const

--- a/Libraries/LibWeb/DOM/Window.cpp
+++ b/Libraries/LibWeb/DOM/Window.cpp
@@ -142,7 +142,7 @@ void Window::did_set_location_href(Badge<Bindings::LocationObject>, const String
     auto* frame = document().frame();
     if (!frame)
         return;
-    frame->loader().load(new_href);
+    frame->loader().load(new_href, FrameLoader::Type::Navigation);
 }
 
 void Window::did_call_location_reload(Badge<Bindings::LocationObject>)
@@ -150,7 +150,7 @@ void Window::did_call_location_reload(Badge<Bindings::LocationObject>)
     auto* frame = document().frame();
     if (!frame)
         return;
-    frame->loader().load(document().url());
+    frame->loader().load(document().url(), FrameLoader::Type::Reload);
 }
 
 }

--- a/Libraries/LibWeb/Frame/EventHandler.cpp
+++ b/Libraries/LibWeb/Frame/EventHandler.cpp
@@ -141,7 +141,7 @@ bool EventHandler::handle_mousedown(const Gfx::IntPoint& position, unsigned butt
                     page_client.page_did_click_link(url, link->target(), modifiers);
                 } else {
                     // FIXME: Handle different targets!
-                    m_frame.loader().load(url);
+                    m_frame.loader().load(url, FrameLoader::Type::Navigation);
                 }
             }
         } else if (button == GUI::MouseButton::Right) {

--- a/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -137,7 +137,7 @@ RefPtr<Document> FrameLoader::create_document_from_mime_type(const ByteBuffer& d
     return nullptr;
 }
 
-bool FrameLoader::load(const URL& url)
+bool FrameLoader::load(const URL& url, Type type)
 {
     dbg() << "FrameLoader::load: " << url;
 
@@ -150,9 +150,10 @@ bool FrameLoader::load(const URL& url)
     request.set_url(url);
     set_resource(ResourceLoader::the().load_resource(Resource::Type::Generic, request));
 
-    frame().page().client().page_did_start_loading(url);
+    if (type == Type::Navigation)
+        frame().page().client().page_did_start_loading(url);
 
-    if (url.protocol() != "file" && url.protocol() != "about") {
+    if (type != Type::IFrame && url.protocol() != "file" && url.protocol() != "about") {
         URL favicon_url;
         favicon_url.set_protocol(url.protocol());
         favicon_url.set_host(url.host());
@@ -211,7 +212,7 @@ void FrameLoader::resource_did_load()
     // FIXME: Also check HTTP status code before redirecting
     auto location = resource()->response_headers().get("Location");
     if (location.has_value()) {
-        load(location.value());
+        load(location.value(), FrameLoader::Type::Navigation);
         return;
     }
 

--- a/Libraries/LibWeb/Loader/FrameLoader.h
+++ b/Libraries/LibWeb/Loader/FrameLoader.h
@@ -35,10 +35,16 @@ namespace Web {
 class FrameLoader final
     : public ResourceClient {
 public:
+    enum class Type {
+        Navigation,
+        Reload,
+        IFrame,
+    };
+
     explicit FrameLoader(Frame&);
     ~FrameLoader();
 
-    bool load(const URL&);
+    bool load(const URL&, Type);
 
     Frame& frame() { return m_frame; }
     const Frame& frame() const { return m_frame; }

--- a/Libraries/LibWeb/Page.cpp
+++ b/Libraries/LibWeb/Page.cpp
@@ -42,7 +42,7 @@ Page::~Page()
 
 void Page::load(const URL& url)
 {
-    main_frame().loader().load(url);
+    main_frame().loader().load(url, FrameLoader::Type::Navigation);
 }
 
 Gfx::Palette Page::palette() const

--- a/Libraries/LibWeb/PageView.cpp
+++ b/Libraries/LibWeb/PageView.cpp
@@ -160,6 +160,7 @@ String PageView::selected_text() const
 
 void PageView::page_did_layout()
 {
+    ASSERT(layout_root());
     set_content_size(layout_root()->size().to_int_size());
 }
 
@@ -392,7 +393,7 @@ bool PageView::load(const URL& url)
     if (window())
         window()->set_override_cursor(GUI::StandardCursor::None);
 
-    return page().main_frame().loader().load(url);
+    return page().main_frame().loader().load(url, FrameLoader::Type::Navigation);
 }
 
 const LayoutDocument* PageView::layout_root() const


### PR DESCRIPTION
Debugging https://github.com/SerenityOS/serenity/issues/2649 uncovered:

- that the history is adding all iframe urls
- going back/forward can cause the iframe's document to be laid out prior to the main frame's document (leading to a crash).