### PR TITLE
WindowServer: Add support for default MenuItem

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -764,7 +764,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
                 folder_specific_paste_action->set_enabled(should_get_enabled);
                 directory_context_menu->popup(event.screen_position());
             } else {
-                file_context_menu->popup(event.screen_position());
+                file_context_menu->popup(event.screen_position(), open_in_text_editor_action);
             }
         } else {
             directory_view_context_menu->popup(event.screen_position());

--- a/Libraries/LibGUI/Menu.h
+++ b/Libraries/LibGUI/Menu.h
@@ -27,7 +27,9 @@
 #pragma once
 
 #include <AK/NonnullOwnPtrVector.h>
+#include <AK/WeakPtr.h>
 #include <LibCore/Object.h>
+#include <LibGUI/Action.h>
 #include <LibGUI/Forward.h>
 #include <LibGfx/Forward.h>
 
@@ -39,11 +41,7 @@ public:
     explicit Menu(const StringView& name = "");
     virtual ~Menu() override;
 
-    void realize_menu_if_needed()
-    {
-        if (menu_id() == -1)
-            realize_menu();
-    }
+    void realize_menu_if_needed();
 
     static Menu* from_menu_id(int);
     int menu_id() const { return m_menu_id; }
@@ -56,19 +54,20 @@ public:
     void add_separator();
     Menu& add_submenu(const String& name);
 
-    void popup(const Gfx::IntPoint& screen_position);
+    void popup(const Gfx::IntPoint& screen_position, const RefPtr<Action>& default_action = nullptr);
     void dismiss();
 
 private:
     friend class MenuBar;
 
-    int realize_menu();
+    int realize_menu(RefPtr<Action> default_action = nullptr);
     void unrealize_menu();
-    void realize_if_needed();
+    void realize_if_needed(const RefPtr<Action>& default_action);
 
     int m_menu_id { -1 };
     String m_name;
     NonnullOwnPtrVector<MenuItem> m_items;
+    WeakPtr<Action> m_last_default_action;
 };
 
 }

--- a/Libraries/LibGUI/MenuItem.cpp
+++ b/Libraries/LibGUI/MenuItem.cpp
@@ -79,13 +79,22 @@ void MenuItem::set_checked(bool checked)
     update_window_server();
 }
 
+void MenuItem::set_default(bool is_default)
+{
+    ASSERT(is_checkable());
+    if (m_default == is_default)
+        return;
+    m_default = is_default;
+    update_window_server();
+}
+
 void MenuItem::update_window_server()
 {
     if (m_menu_id < 0)
         return;
     auto& action = *m_action;
     auto shortcut_text = action.shortcut().is_valid() ? action.shortcut().to_string() : String();
-    WindowServerConnection::the().send_sync<Messages::WindowServer::UpdateMenuItem>(m_menu_id, m_identifier, -1, action.text(), action.is_enabled(), action.is_checkable(), action.is_checkable() ? action.is_checked() : false, shortcut_text);
+    WindowServerConnection::the().send_sync<Messages::WindowServer::UpdateMenuItem>(m_menu_id, m_identifier, -1, action.text(), action.is_enabled(), action.is_checkable(), action.is_checkable() ? action.is_checked() : false, m_default, shortcut_text);
 }
 
 void MenuItem::set_menu_id(Badge<Menu>, unsigned int menu_id)

--- a/Libraries/LibGUI/MenuItem.h
+++ b/Libraries/LibGUI/MenuItem.h
@@ -47,7 +47,7 @@ public:
     ~MenuItem();
 
     Type type() const { return m_type; }
-    String text() const;
+
     const Action* action() const { return m_action.ptr(); }
     Action* action() { return m_action.ptr(); }
     unsigned identifier() const { return m_identifier; }
@@ -64,6 +64,9 @@ public:
     bool is_enabled() const { return m_enabled; }
     void set_enabled(bool);
 
+    bool is_default() const { return m_default; }
+    void set_default(bool);
+
     void set_menu_id(Badge<Menu>, unsigned menu_id);
     void set_identifier(Badge<Menu>, unsigned identifier);
 
@@ -76,6 +79,7 @@ private:
     bool m_enabled { true };
     bool m_checkable { false };
     bool m_checked { false };
+    bool m_default { false };
     RefPtr<Action> m_action;
     RefPtr<Menu> m_submenu;
 };

--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -648,7 +648,7 @@ void ClientConnection::handle(const Messages::WindowServer::WM_PopupWindowMenu& 
         return;
     }
     auto& window = *(*it).value;
-    window.popup_window_menu(message.screen_position());
+    window.popup_window_menu(message.screen_position(), WindowMenuDefaultAction::BasedOnWindowState);
 }
 
 void ClientConnection::handle(const Messages::WindowServer::WM_StartWindowResize& request)

--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -201,6 +201,8 @@ OwnPtr<Messages::WindowServer::AddMenuItemResponse> ClientConnection::handle(con
     }
     auto& menu = *(*it).value;
     auto menu_item = make<MenuItem>(menu, identifier, message.text(), message.shortcut(), message.enabled(), message.checkable(), message.checked());
+    if (message.is_default())
+        menu_item->set_default(true);
     if (message.icon_buffer_id() != -1) {
         auto icon_buffer = SharedBuffer::create_from_shbuf_id(message.icon_buffer_id());
         if (!icon_buffer)
@@ -260,6 +262,7 @@ OwnPtr<Messages::WindowServer::UpdateMenuItemResponse> ClientConnection::handle(
     menu_item->set_shortcut_text(message.shortcut());
     menu_item->set_enabled(message.enabled());
     menu_item->set_checkable(message.checkable());
+    menu_item->set_default(message.is_default());
     if (message.checkable())
         menu_item->set_checked(message.checked());
     return make<Messages::WindowServer::UpdateMenuItemResponse>();

--- a/Services/WindowServer/Menu.h
+++ b/Services/WindowServer/Menu.h
@@ -87,6 +87,8 @@ public:
     bool is_window_menu_open() { return m_is_window_menu_open; }
     void set_window_menu_open(bool is_open) { m_is_window_menu_open = is_open; }
 
+    bool activate_default();
+
     int content_width() const;
 
     int item_height() const { return 20; }

--- a/Services/WindowServer/MenuItem.cpp
+++ b/Services/WindowServer/MenuItem.cpp
@@ -71,6 +71,14 @@ void MenuItem::set_checked(bool checked)
     m_menu.redraw();
 }
 
+void MenuItem::set_default(bool is_default)
+{
+    if (m_default == is_default)
+        return;
+    m_default = is_default;
+    m_menu.redraw();
+}
+
 Menu* MenuItem::submenu()
 {
     ASSERT(is_submenu());

--- a/Services/WindowServer/MenuItem.h
+++ b/Services/WindowServer/MenuItem.h
@@ -58,6 +58,9 @@ public:
     bool is_checked() const { return m_checked; }
     void set_checked(bool);
 
+    bool is_default() const { return m_default; }
+    void set_default(bool);
+
     String text() const { return m_text; }
     void set_text(const String& text) { m_text = text; }
 
@@ -88,6 +91,7 @@ private:
     bool m_enabled { true };
     bool m_checkable { false };
     bool m_checked { false };
+    bool m_default { false };
     unsigned m_identifier { 0 };
     String m_text;
     String m_shortcut_text;

--- a/Services/WindowServer/Window.h
+++ b/Services/WindowServer/Window.h
@@ -62,6 +62,16 @@ enum class PopupMenuItem {
     Maximize,
 };
 
+enum class WindowMenuDefaultAction {
+    None = 0,
+    BasedOnWindowState,
+    Close,
+    Minimize,
+    Unminimize,
+    Maximize,
+    Restore
+};
+
 class Window final : public Core::Object
     , public InlineLinkedListNode<Window> {
     C_OBJECT(Window)
@@ -70,7 +80,8 @@ public:
     Window(Core::Object&, WindowType);
     virtual ~Window() override;
 
-    void popup_window_menu(const Gfx::IntPoint&);
+    void popup_window_menu(const Gfx::IntPoint&, WindowMenuDefaultAction);
+    void window_menu_activate_default();
     void request_close();
 
     unsigned wm_event_mask() const { return m_wm_event_mask; }
@@ -240,6 +251,7 @@ private:
     void update_menu_item_text(PopupMenuItem item);
     void update_menu_item_enabled(PopupMenuItem item);
     void add_child_window(Window&);
+    void ensure_window_menu();
 
     ClientConnection* m_client { nullptr };
 
@@ -283,6 +295,7 @@ private:
     RefPtr<Menu> m_window_menu;
     MenuItem* m_window_menu_minimize_item { nullptr };
     MenuItem* m_window_menu_maximize_item { nullptr };
+    MenuItem* m_window_menu_close_item { nullptr };
     int m_minimize_animation_step { -1 };
     int m_progress { -1 };
 };

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -666,6 +666,24 @@ void WindowManager::set_cursor_tracking_button(Button* button)
     m_cursor_tracking_button = button ? button->make_weak_ptr() : nullptr;
 }
 
+auto WindowManager::DoubleClickInfo::metadata_for_button(MouseButton button) const -> const ClickMetadata&
+{
+    switch (button) {
+    case MouseButton::Left:
+        return m_left;
+    case MouseButton::Right:
+        return m_right;
+    case MouseButton::Middle:
+        return m_middle;
+    case MouseButton::Back:
+        return m_back;
+    case MouseButton::Forward:
+        return m_forward;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+}
+
 auto WindowManager::DoubleClickInfo::metadata_for_button(MouseButton button) -> ClickMetadata&
 {
     switch (button) {
@@ -686,6 +704,59 @@ auto WindowManager::DoubleClickInfo::metadata_for_button(MouseButton button) -> 
 
 // #define DOUBLECLICK_DEBUG
 
+bool WindowManager::is_considered_doubleclick(const MouseEvent& event, const DoubleClickInfo::ClickMetadata& metadata) const
+{
+    int elapsed_since_last_click = metadata.clock.elapsed();
+    if (elapsed_since_last_click < m_double_click_speed) {
+        auto diff = event.position() - metadata.last_position;
+        auto distance_travelled_squared = diff.x() * diff.x() + diff.y() * diff.y();
+        if (distance_travelled_squared <= (m_max_distance_for_double_click * m_max_distance_for_double_click))
+            return true;
+    }
+    return false;
+}
+
+void WindowManager::start_menu_doubleclick(Window& window, const MouseEvent& event)
+{
+    // This is a special case. Basically, we're trying to determine whether
+    // double clicking on the window menu icon happened. In this case, the
+    // WindowFrame only receives a MouseDown event, and since the window
+    // menu popus up, it does not see the MouseUp event. But, if they subsequently
+    // click there again, the menu is closed and we receive a MouseUp event.
+    // So, in order to be able to detect a double click when a menu is being
+    // opened by the MouseDown event, we need to consider the MouseDown event
+    // as a potential double-click trigger
+    ASSERT(event.type() == Event::MouseDown);
+
+    auto& metadata = m_double_click_info.metadata_for_button(event.button());
+    if (&window != m_double_click_info.m_clicked_window) {
+        // we either haven't clicked anywhere, or we haven't clicked on this
+        // window. set the current click window, and reset the timers.
+#if defined(DOUBLECLICK_DEBUG)
+        dbg() << "Initial mousedown on window " << &window << " for menu (previous was " << m_double_click_info.m_clicked_window << ')';
+#endif
+        m_double_click_info.m_clicked_window = window.make_weak_ptr();
+        m_double_click_info.reset();
+    }
+
+    metadata.last_position = event.position();
+    metadata.clock.start();
+}
+
+bool WindowManager::is_menu_doubleclick(Window& window, const MouseEvent& event) const
+{
+    ASSERT(event.type() == Event::MouseUp);
+
+    if (&window != m_double_click_info.m_clicked_window)
+        return false;
+
+    auto& metadata = m_double_click_info.metadata_for_button(event.button());
+    if (!metadata.clock.is_valid())
+        return false;
+    
+    return is_considered_doubleclick(event, metadata);
+}
+
 void WindowManager::process_event_for_doubleclick(Window& window, MouseEvent& event)
 {
     // We only care about button presses (because otherwise it's not a doubleclick, duh!)
@@ -703,32 +774,20 @@ void WindowManager::process_event_for_doubleclick(Window& window, MouseEvent& ev
 
     auto& metadata = m_double_click_info.metadata_for_button(event.button());
 
-    // if the clock is invalid, we haven't clicked with this button on this
-    // window yet, so there's nothing to do.
-    if (!metadata.clock.is_valid()) {
+    if (!metadata.clock.is_valid() || !is_considered_doubleclick(event, metadata)) {
+        // either the clock is invalid because we haven't clicked on this
+        // button on this window yet, so there's nothing to do, or this
+        // isn't considered to be a double click. either way, restart the
+        // clock
         metadata.clock.start();
     } else {
-        int elapsed_since_last_click = metadata.clock.elapsed();
-        metadata.clock.start();
-        if (elapsed_since_last_click < m_double_click_speed) {
-            auto diff = event.position() - metadata.last_position;
-            auto distance_travelled_squared = diff.x() * diff.x() + diff.y() * diff.y();
-            if (distance_travelled_squared > (m_max_distance_for_double_click * m_max_distance_for_double_click)) {
-                // too far; try again
-                metadata.clock.start();
-            } else {
 #if defined(DOUBLECLICK_DEBUG)
-                dbg() << "Transforming MouseUp to MouseDoubleClick (" << elapsed_since_last_click << " < " << m_double_click_speed << ")!";
+        dbg() << "Transforming MouseUp to MouseDoubleClick (" << elapsed_since_last_click << " < " << m_double_click_speed << ")!";
 #endif
-                event = MouseEvent(Event::MouseDoubleClick, event.position(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
-                // invalidate this now we've delivered a doubleclick, otherwise
-                // tripleclick will deliver two doubleclick events (incorrectly).
-                metadata.clock = {};
-            }
-        } else {
-            // too slow; try again
-            metadata.clock.start();
-        }
+        event = MouseEvent(Event::MouseDoubleClick, event.position(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
+        // invalidate this now we've delivered a doubleclick, otherwise
+        // tripleclick will deliver two doubleclick events (incorrectly).
+        metadata.clock = {};
     }
 
     metadata.last_position = event.position();

--- a/Services/WindowServer/WindowManager.h
+++ b/Services/WindowServer/WindowManager.h
@@ -168,6 +168,9 @@ public:
 
     void did_popup_a_menu(Badge<Menu>);
 
+    void start_menu_doubleclick(Window& window, const MouseEvent& event);
+    bool is_menu_doubleclick(Window& window, const MouseEvent& event) const;
+
 private:
     NonnullRefPtr<Cursor> get_cursor(const String& name);
     NonnullRefPtr<Cursor> get_cursor(const String& name, const Gfx::IntPoint& hotspot);
@@ -219,6 +222,7 @@ private:
             Gfx::IntPoint last_position;
         };
 
+        const ClickMetadata& metadata_for_button(MouseButton) const;
         ClickMetadata& metadata_for_button(MouseButton);
 
         void reset()
@@ -239,6 +243,9 @@ private:
         ClickMetadata m_back;
         ClickMetadata m_forward;
     };
+
+    bool is_considered_doubleclick(const MouseEvent& event, const DoubleClickInfo::ClickMetadata& metadata) const;
+
     DoubleClickInfo m_double_click_info;
     int m_double_click_speed { 0 };
     int m_max_distance_for_double_click { 4 };

--- a/Services/WindowServer/WindowServer.ipc
+++ b/Services/WindowServer/WindowServer.ipc
@@ -21,13 +21,14 @@ endpoint WindowServer = 2
         bool enabled,
         bool checkable,
         bool checked,
+        bool is_default,
         [UTF8] String shortcut,
         i32 icon_buffer_id,
         bool exclusive) => ()
 
     AddMenuSeparator(i32 menu_id) => ()
 
-    UpdateMenuItem(i32 menu_id, i32 identifier, i32 submenu_id, [UTF8] String text, bool enabled, bool checkable, bool checked, [UTF8] String shortcut) => ()
+    UpdateMenuItem(i32 menu_id, i32 identifier, i32 submenu_id, [UTF8] String text, bool enabled, bool checkable, bool checked, bool is_default, [UTF8] String shortcut) => ()
 
     CreateWindow(
         Gfx::IntRect rect,


### PR DESCRIPTION
This allows marking a MenuItem as a default action, e.g. in a
context menu for an action that reflects what e.g. a double click
would perform.

Also enhance the window menu to mark the close action as the
default, and when double clicked perform that action.

I keep finding myself trying to close windows by double clicking on the window menu (I know, bad behavior)... This makes it more "natural" to my habits. No, I haven't used Windows much for a long, long time, but it's hard to get rid of habits...

![Screenshot from 2020-07-07 11-25-47](https://user-images.githubusercontent.com/10320822/86819293-ab272580-c044-11ea-967c-278c6cf08789.png)