### PR TITLE
Piano: Make menu bar consistent with other apps

### DIFF
--- a/Applications/Piano/main.cpp
+++ b/Applications/Piano/main.cpp
@@ -95,10 +95,6 @@ int main(int argc, char** argv)
     auto menubar = GUI::MenuBar::construct();
 
     auto& app_menu = menubar->add_menu("Piano");
-    app_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
-        GUI::Application::the()->quit();
-        return;
-    }));
     app_menu.add_action(GUI::Action::create("Export", { Mod_Ctrl, Key_E }, [&](const GUI::Action&) {
         save_path = GUI::FilePicker::get_save_filepath("Untitled", "wav");
         if (!save_path.has_value())
@@ -111,14 +107,19 @@ int main(int argc, char** argv)
         }
         need_to_write_wav = true;
     }));
+    app_menu.add_separator();
+    app_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
+        GUI::Application::the()->quit();
+        return;
+    }));
+
+    auto& edit_menu = menubar->add_menu("Edit");
+    main_widget.add_actions(edit_menu);
 
     auto& help_menu = menubar->add_menu("Help");
     help_menu.add_action(GUI::Action::create("About", [&](const GUI::Action&) {
         GUI::AboutDialog::show("Piano", Gfx::Bitmap::load_from_file("/res/icons/32x32/app-piano.png"), window);
     }));
-
-    auto& edit_menu = menubar->add_menu("Edit");
-    main_widget.add_actions(edit_menu);
 
     app->set_menubar(move(menubar));
 


### PR DESCRIPTION
"Help" should be after "Edit".

The "Quit" menu item should be at the end of the app menu, and
after a separator.