### PR TITLE
LibJS: Integrate symbols into objects as valid keys

### DIFF
--- a/Libraries/LibJS/MarkupGenerator.cpp
+++ b/Libraries/LibJS/MarkupGenerator.cpp
@@ -146,7 +146,7 @@ void MarkupGenerator::object_to_html(const Object& object, StringBuilder& html_o
 
     size_t index = 0;
     for (auto& it : object.shape().property_table_ordered()) {
-        html_output.append(wrap_string_in_style(String::format("\"%s\"", it.key.characters()), StyleType::String));
+        html_output.append(wrap_string_in_style(String::format("\"%s\"", it.key.to_display_string().characters()), StyleType::String));
         html_output.append(wrap_string_in_style(": ", StyleType::Punctuation));
         value_to_html(object.get_direct(it.value.offset), html_output, seen_objects);
         if (index != object.shape().property_count() - 1)

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -68,10 +68,15 @@ public:
 
     virtual bool inherits(const StringView& class_name) const { return class_name == this->class_name(); }
 
-    enum class GetOwnPropertyMode {
+    enum class GetOwnPropertyReturnMode {
         Key,
         Value,
         KeyAndValue,
+    };
+
+    enum class GetOwnPropertyReturnType {
+        StringOnly,
+        SymbolOnly,
     };
 
     enum class PutOwnPropertyMode {
@@ -84,26 +89,26 @@ public:
 
     GlobalObject& global_object() const { return shape().global_object(); }
 
-    virtual Value get(PropertyName, Value receiver = {}) const;
+    virtual Value get(const PropertyName&, Value receiver = {}) const;
 
-    virtual bool has_property(PropertyName) const;
-    bool has_own_property(PropertyName) const;
+    virtual bool has_property(const PropertyName&) const;
+    bool has_own_property(const PropertyName&) const;
 
-    virtual bool put(PropertyName, Value, Value receiver = {});
+    virtual bool put(const PropertyName&, Value, Value receiver = {});
 
     Value get_own_property(const Object& this_object, PropertyName, Value receiver) const;
-    Value get_own_properties(const Object& this_object, GetOwnPropertyMode, bool only_enumerable_properties = false) const;
-    virtual Optional<PropertyDescriptor> get_own_property_descriptor(PropertyName) const;
-    Value get_own_property_descriptor_object(PropertyName) const;
+    Value get_own_properties(const Object& this_object, GetOwnPropertyReturnMode, bool only_enumerable_properties = false, GetOwnPropertyReturnType = GetOwnPropertyReturnType::StringOnly) const;
+    virtual Optional<PropertyDescriptor> get_own_property_descriptor(const PropertyName&) const;
+    Value get_own_property_descriptor_object(const PropertyName&) const;
 
-    virtual bool define_property(const FlyString& property_name, const Object& descriptor, bool throw_exceptions = true);
-    bool define_property(PropertyName, Value value, PropertyAttributes attributes = default_attributes, bool throw_exceptions = true);
-    bool define_accessor(PropertyName, Function& getter_or_setter, bool is_getter, PropertyAttributes attributes = default_attributes, bool throw_exceptions = true);
+    virtual bool define_property(const StringOrSymbol& property_name, const Object& descriptor, bool throw_exceptions = true);
+    bool define_property(const PropertyName&, Value value, PropertyAttributes attributes = default_attributes, bool throw_exceptions = true);
+    bool define_accessor(const PropertyName&, Function& getter_or_setter, bool is_getter, PropertyAttributes attributes = default_attributes, bool throw_exceptions = true);
 
-    bool define_native_function(const FlyString& property_name, AK::Function<Value(Interpreter&, GlobalObject&)>, i32 length = 0, PropertyAttributes attributes = default_attributes);
-    bool define_native_property(const FlyString& property_name, AK::Function<Value(Interpreter&, GlobalObject&)> getter, AK::Function<void(Interpreter&, GlobalObject&, Value)> setter, PropertyAttributes attributes = default_attributes);
+    bool define_native_function(const StringOrSymbol& property_name, AK::Function<Value(Interpreter&, GlobalObject&)>, i32 length = 0, PropertyAttributes attributes = default_attributes);
+    bool define_native_property(const StringOrSymbol& property_name, AK::Function<Value(Interpreter&, GlobalObject&)> getter, AK::Function<void(Interpreter&, GlobalObject&, Value)> setter, PropertyAttributes attributes = default_attributes);
 
-    virtual Value delete_property(PropertyName);
+    virtual Value delete_property(const PropertyName&);
 
     virtual bool is_array() const { return false; }
     virtual bool is_date() const { return false; }
@@ -140,7 +145,7 @@ public:
     IndexedProperties& indexed_properties() { return m_indexed_properties; }
     void set_indexed_property_elements(Vector<Value>&& values) { m_indexed_properties = IndexedProperties(move(values)); }
 
-    Value invoke(const FlyString& property_name, Optional<MarkedValueList> arguments = {});
+    Value invoke(const StringOrSymbol& property_name, Optional<MarkedValueList> arguments = {});
 
 protected:
     enum class GlobalObjectTag { Tag };
@@ -151,7 +156,7 @@ protected:
 private:
     virtual Value get_by_index(u32 property_index) const;
     virtual bool put_by_index(u32 property_index, Value);
-    bool put_own_property(Object& this_object, const FlyString& property_name, Value, PropertyAttributes attributes, PutOwnPropertyMode = PutOwnPropertyMode::Put, bool throw_exceptions = true);
+    bool put_own_property(Object& this_object, const StringOrSymbol& property_name, Value, PropertyAttributes attributes, PutOwnPropertyMode = PutOwnPropertyMode::Put, bool throw_exceptions = true);
     bool put_own_property_by_index(Object& this_object, u32 property_index, Value, PropertyAttributes attributes, PutOwnPropertyMode = PutOwnPropertyMode::Put, bool throw_exceptions = true);
 
     Value call_native_property_getter(Object* this_object, Value property) const;

--- a/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -213,7 +213,7 @@ bool ProxyObject::prevent_extensions()
     return trap_result;
 }
 
-Optional<PropertyDescriptor> ProxyObject::get_own_property_descriptor(PropertyName name) const
+Optional<PropertyDescriptor> ProxyObject::get_own_property_descriptor(const PropertyName& name) const
 {
     if (m_is_revoked) {
         interpreter().throw_exception<TypeError>(ErrorType::ProxyRevoked);
@@ -270,7 +270,7 @@ Optional<PropertyDescriptor> ProxyObject::get_own_property_descriptor(PropertyNa
     return result_desc;
 }
 
-bool ProxyObject::define_property(const FlyString& property_name, const Object& descriptor, bool throw_exceptions)
+bool ProxyObject::define_property(const StringOrSymbol& property_name, const Object& descriptor, bool throw_exceptions)
 {
     if (m_is_revoked) {
         interpreter().throw_exception<TypeError>(ErrorType::ProxyRevoked);
@@ -287,7 +287,7 @@ bool ProxyObject::define_property(const FlyString& property_name, const Object& 
     }
     MarkedValueList arguments(interpreter().heap());
     arguments.append(Value(&m_target));
-    arguments.append(js_string(interpreter(), property_name));
+    arguments.append(property_name.to_value(interpreter()));
     arguments.append(Value(const_cast<Object*>(&descriptor)));
     auto trap_result = interpreter().call(trap.as_function(), Value(&m_handler), move(arguments)).to_boolean();
     if (interpreter().exception() || !trap_result)
@@ -324,7 +324,7 @@ bool ProxyObject::define_property(const FlyString& property_name, const Object& 
     return true;
 }
 
-bool ProxyObject::has_property(PropertyName name) const
+bool ProxyObject::has_property(const PropertyName& name) const
 {
     if (m_is_revoked) {
         interpreter().throw_exception<TypeError>(ErrorType::ProxyRevoked);
@@ -364,7 +364,7 @@ bool ProxyObject::has_property(PropertyName name) const
     return trap_result;
 }
 
-Value ProxyObject::get(PropertyName name, Value) const
+Value ProxyObject::get(const PropertyName& name, Value) const
 {
     if (m_is_revoked) {
         interpreter().throw_exception<TypeError>(ErrorType::ProxyRevoked);
@@ -396,7 +396,7 @@ Value ProxyObject::get(PropertyName name, Value) const
     return trap_result;
 }
 
-bool ProxyObject::put(PropertyName name, Value value, Value)
+bool ProxyObject::put(const PropertyName& name, Value value, Value)
 {
     if (m_is_revoked) {
         interpreter().throw_exception<TypeError>(ErrorType::ProxyRevoked);
@@ -434,7 +434,7 @@ bool ProxyObject::put(PropertyName name, Value value, Value)
     return true;
 }
 
-Value ProxyObject::delete_property(PropertyName name)
+Value ProxyObject::delete_property(const PropertyName& name)
 {
     if (m_is_revoked) {
         interpreter().throw_exception<TypeError>(ErrorType::ProxyRevoked);

--- a/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Libraries/LibJS/Runtime/ProxyObject.h
@@ -52,12 +52,12 @@ public:
     virtual bool set_prototype(Object* object) override;
     virtual bool is_extensible() const override;
     virtual bool prevent_extensions() override;
-    virtual Optional<PropertyDescriptor> get_own_property_descriptor(PropertyName) const override;
-    virtual bool define_property(const FlyString& property_name, const Object& descriptor, bool throw_exceptions = true) override;
-    virtual bool has_property(PropertyName name) const override;
-    virtual Value get(PropertyName name, Value receiver) const override;
-    virtual bool put(PropertyName name, Value value, Value receiver) override;
-    virtual Value delete_property(PropertyName name) override;
+    virtual Optional<PropertyDescriptor> get_own_property_descriptor(const PropertyName&) const override;
+    virtual bool define_property(const StringOrSymbol& property_name, const Object& descriptor, bool throw_exceptions = true) override;
+    virtual bool has_property(const PropertyName& name) const override;
+    virtual Value get(const PropertyName& name, Value receiver) const override;
+    virtual bool put(const PropertyName& name, Value value, Value receiver) override;
+    virtual Value delete_property(const PropertyName& name) override;
 
     void revoke() { m_is_revoked = true; }
 

--- a/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -145,7 +145,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::define_property)
         return {};
     if (!interpreter.argument(2).is_object())
         return interpreter.throw_exception<TypeError>(ErrorType::ReflectBadDescriptorArgument);
-    auto property_key = interpreter.argument(1).to_string(interpreter);
+    auto property_key = StringOrSymbol::from_value(interpreter, interpreter.argument(1));
     if (interpreter.exception())
         return {};
     auto& descriptor = interpreter.argument(2).as_object();
@@ -162,7 +162,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::delete_property)
         return {};
 
     auto property_key = interpreter.argument(1);
-    auto property_name = PropertyName(property_key.to_string(interpreter));
+    auto property_name = PropertyName::from_value(interpreter, property_key);
     if (interpreter.exception())
         return {};
     auto property_key_number = property_key.to_number(interpreter);
@@ -181,7 +181,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::get)
     auto* target = get_target_object_from(interpreter, "get");
     if (!target)
         return {};
-    auto property_key = interpreter.argument(1).to_string(interpreter);
+    auto property_key = PropertyName::from_value(interpreter, interpreter.argument(1));
     if (interpreter.exception())
         return {};
     Value receiver = {};
@@ -195,7 +195,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::get_own_property_descriptor)
     auto* target = get_target_object_from(interpreter, "getOwnPropertyDescriptor");
     if (!target)
         return {};
-    auto property_key = interpreter.argument(1).to_string(interpreter);
+    auto property_key = PropertyName::from_value(interpreter, interpreter.argument(1));
     if (interpreter.exception())
         return {};
     return target->get_own_property_descriptor_object(property_key);
@@ -214,7 +214,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::has)
     auto* target = get_target_object_from(interpreter, "has");
     if (!target)
         return {};
-    auto property_key = interpreter.argument(1).to_string(interpreter);
+    auto property_key = PropertyName::from_value(interpreter, interpreter.argument(1));
     if (interpreter.exception())
         return {};
     return Value(target->has_property(property_key));
@@ -233,7 +233,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::own_keys)
     auto* target = get_target_object_from(interpreter, "ownKeys");
     if (!target)
         return {};
-    return target->get_own_properties(*target, GetOwnPropertyMode::Key);
+    return target->get_own_properties(*target, GetOwnPropertyReturnMode::Key);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ReflectObject::prevent_extensions)

--- a/Libraries/LibJS/Runtime/StringOrSymbol.h
+++ b/Libraries/LibJS/Runtime/StringOrSymbol.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/PrimitiveString.h>
+#include <LibJS/Runtime/Symbol.h>
+#include <LibJS/Runtime/Value.h>
+
+namespace JS {
+
+class StringOrSymbol {
+public:
+    static StringOrSymbol from_value(Interpreter& interpreter, Value value)
+    {
+        if (value.is_symbol())
+            return &value.as_symbol();
+        if (!value.is_empty())
+            return value.to_string(interpreter);
+        return {};
+    }
+
+    StringOrSymbol() = default;
+
+    StringOrSymbol(const char* chars)
+        : m_ptr(StringImpl::create(chars).leak_ref())
+    {
+    }
+
+    StringOrSymbol(const String& string)
+        : m_ptr(StringImpl::create(string.characters(), string.length()).leak_ref())
+    {
+    }
+
+    StringOrSymbol(const Symbol* symbol)
+        : m_ptr(symbol)
+    {
+        set_symbol_flag();
+    }
+
+    StringOrSymbol(const StringOrSymbol& other)
+    {
+        m_ptr = other.m_ptr;
+    }
+
+    ALWAYS_INLINE bool is_valid() const { return m_ptr != nullptr; }
+    ALWAYS_INLINE bool is_symbol() const { return is_valid() && (bits() & 1ul); }
+    ALWAYS_INLINE bool is_string() const { return is_valid() && !(bits() & 1ul); }
+
+    ALWAYS_INLINE String as_string() const
+    {
+        ASSERT(is_string());
+        return reinterpret_cast<const StringImpl*>(m_ptr);
+    }
+
+    ALWAYS_INLINE const Symbol* as_symbol() const
+    {
+        ASSERT(is_symbol());
+        return reinterpret_cast<const Symbol*>(bits() & ~1ul);
+    }
+
+    String to_display_string() const
+    {
+        if (is_string())
+            return as_string();
+        if (is_symbol())
+            return as_symbol()->to_string();
+        ASSERT_NOT_REACHED();
+    }
+
+    Value to_value(Interpreter& interpreter) const
+    {
+        if (is_string())
+            return js_string(interpreter, as_string());
+        if (is_symbol())
+            return const_cast<Symbol*>(as_symbol());
+        return {};
+    }
+
+    void visit_children(Cell::Visitor& visitor)
+    {
+        if (is_symbol())
+            visitor.visit(const_cast<Symbol*>(as_symbol()));
+    }
+
+    ALWAYS_INLINE bool operator==(const StringOrSymbol& other) const
+    {
+        if (is_string())
+            return other.is_string() && as_string() == other.as_string();
+        if (is_symbol())
+            return other.is_symbol() && as_symbol() == other.as_symbol();
+        return true;
+    }
+
+    StringOrSymbol& operator=(const StringOrSymbol& other)
+    {
+        if (this == &other)
+            return *this;
+        m_ptr = other.m_ptr;
+        return *this;
+    }
+
+private:
+    ALWAYS_INLINE u64 bits() const
+    {
+        return reinterpret_cast<uintptr_t>(m_ptr);
+    }
+
+    ALWAYS_INLINE void set_symbol_flag()
+    {
+        m_ptr = reinterpret_cast<const void*>(bits() | 1ul);
+    }
+
+    const void* m_ptr { nullptr };
+};
+
+}
+
+template<>
+struct AK::Traits<JS::StringOrSymbol> : public GenericTraits<JS::StringOrSymbol> {
+    static unsigned hash(const JS::StringOrSymbol& key)
+    {
+        if (key.is_string())
+            return key.as_string().hash();
+        if (key.is_symbol())
+            return ptr_hash(key.as_symbol());
+        return 0;
+    }
+};

--- a/Libraries/LibJS/Runtime/Symbol.h
+++ b/Libraries/LibJS/Runtime/Symbol.h
@@ -38,13 +38,13 @@ public:
 
     const String& description() const { return m_description; }
     bool is_global() const { return m_is_global; }
-    const String to_string() const { return String::format("Symbol(%s)", description().characters()); }
+    String to_string() const { return String::format("Symbol(%s)", description().characters()); }
 
 private:
     virtual const char* class_name() const override { return "Symbol"; }
 
-    const String m_description;
-    const bool m_is_global;
+    String m_description;
+    bool m_is_global;
 };
 
 Symbol* js_symbol(Heap&, String description, bool is_global);

--- a/Libraries/LibJS/Tests/builtins/Object/Object.entries.js
+++ b/Libraries/LibJS/Tests/builtins/Object/Object.entries.js
@@ -19,6 +19,15 @@ describe("basic functionality", () => {
         ]);
     });
 
+    test("entries with objects with symbol keys", () => {
+        let entries = Object.entries({ foo: 1, [Symbol("bar")]: 2, baz: 3 });
+
+        expect(entries).toEqual([
+            ["foo", 1],
+            ["baz", 3],
+        ]);
+    });
+
     test("entries with array", () => {
         entries = Object.entries(["a", "b", "c"]);
         expect(entries).toEqual([

--- a/Libraries/LibJS/Tests/builtins/Object/Object.getOwnPropertyDescriptor.js
+++ b/Libraries/LibJS/Tests/builtins/Object/Object.getOwnPropertyDescriptor.js
@@ -9,6 +9,18 @@ test("plain property", () => {
     expect(o).not.toHaveSetterProperty("foo");
 });
 
+test("symbol property", () => {
+    let s = Symbol("foo");
+    let o = { [s]: "bar" };
+
+    expect(o).toHaveConfigurableProperty(s);
+    expect(o).toHaveEnumerableProperty(s);
+    expect(o).toHaveWritableProperty(s);
+    expect(o).toHaveValueProperty(s, "bar");
+    expect(o).not.toHaveGetterProperty(s);
+    expect(o).not.toHaveSetterProperty(s);
+});
+
 test("getter property", () => {
     let o = { get foo() {} };
 

--- a/Libraries/LibJS/Tests/builtins/Object/Object.getOwnPropertyNames.js
+++ b/Libraries/LibJS/Tests/builtins/Object/Object.getOwnPropertyNames.js
@@ -7,3 +7,8 @@ test("use with object", () => {
     let names = Object.getOwnPropertyNames({ foo: 1, bar: 2, baz: 3 });
     expect(names).toEqual(["foo", "bar", "baz"]);
 });
+
+test("use with object with symbol keys", () => {
+    let names = Object.getOwnPropertyNames({ foo: 1, [Symbol("bar")]: 2, baz: 3 });
+    expect(names).toEqual(["foo", "baz"]);
+});

--- a/Libraries/LibJS/Tests/builtins/Object/Object.keys.js
+++ b/Libraries/LibJS/Tests/builtins/Object/Object.keys.js
@@ -14,6 +14,11 @@ describe("correct behavior", () => {
         expect(keys).toEqual(["foo", "bar", "baz"]);
     });
 
+    test("object argument with symbol keys", () => {
+        let keys = Object.keys({ foo: 1, [Symbol("bar")]: 2, baz: 3 });
+        expect(keys).toEqual(["foo", "baz"]);
+    });
+
     test("array argument", () => {
         let keys = Object.keys(["a", "b", "c"]);
         expect(keys).toEqual(["0", "1", "2"]);

--- a/Libraries/LibJS/Tests/builtins/Object/Object.values.js
+++ b/Libraries/LibJS/Tests/builtins/Object/Object.values.js
@@ -14,6 +14,11 @@ describe("correct behavior", () => {
         expect(values).toEqual([1, 2, 3]);
     });
 
+    test("object argument with symbol keys", () => {
+        let values = Object.values({ foo: 1, [Symbol("bar")]: 2, baz: 3 });
+        expect(values).toEqual([1, 3]);
+    });
+
     test("array argument", () => {
         let values = Object.values(["a", "b", "c"]);
         expect(values).toEqual(["a", "b", "c"]);

--- a/Libraries/LibJS/Tests/classes/class-getters.js
+++ b/Libraries/LibJS/Tests/classes/class-getters.js
@@ -18,6 +18,8 @@ test("name", () => {
 });
 
 test("extended name syntax", () => {
+    const s = Symbol("foo");
+
     class A {
         get "method with space"() {
             return 1;
@@ -30,12 +32,17 @@ test("extended name syntax", () => {
         get [`he${"llo"}`]() {
             return 3;
         }
+
+        get [s]() {
+            return 4;
+        }
     }
 
     const a = new A();
     expect(a["method with space"]).toBe(1);
     expect(a[12]).toBe(2);
     expect(a.hello).toBe(3);
+    expect(a[s]).toBe(4);
 });
 
 test("inherited getter", () => {

--- a/Libraries/LibJS/Tests/classes/class-setters.js
+++ b/Libraries/LibJS/Tests/classes/class-setters.js
@@ -29,6 +29,8 @@ test("name", () => {
 });
 
 test("extended name syntax", () => {
+    const s = Symbol("foo");
+
     class A {
         set "method with space"(value) {
             this.a = value;
@@ -41,15 +43,21 @@ test("extended name syntax", () => {
         set [`he${"llo"}`](value) {
             this.c = value;
         }
+
+        set [s](value) {
+            this.d = value;
+        }
     }
 
     const a = new A();
     a["method with space"] = 1;
     a[12] = 2;
     a.hello = 3;
+    a[s] = 4;
     expect(a.a).toBe(1);
     expect(a.b).toBe(2);
     expect(a.c).toBe(3);
+    expect(a.d).toBe(4);
 });
 
 test("inherited setter", () => {

--- a/Libraries/LibJS/Tests/classes/class-static-getters.js
+++ b/Libraries/LibJS/Tests/classes/class-static-getters.js
@@ -20,6 +20,8 @@ describe("correct behavior", () => {
     });
 
     test("extended name syntax", () => {
+        const s = Symbol("foo");
+
         class A {
             static get "method with space"() {
                 return 1;
@@ -32,11 +34,16 @@ describe("correct behavior", () => {
             static get [`he${"llo"}`]() {
                 return 3;
             }
+
+            static get [s]() {
+                return 4;
+            }
         }
 
         expect(A["method with space"]).toBe(1);
         expect(A[12]).toBe(2);
         expect(A.hello).toBe(3);
+        expect(A[s]).toBe(4);
     });
 
     test("inherited static getter", () => {

--- a/Libraries/LibJS/Tests/classes/class-static-setters.js
+++ b/Libraries/LibJS/Tests/classes/class-static-setters.js
@@ -27,6 +27,8 @@ describe("correct behavior", () => {
     });
 
     test("extended name syntax", () => {
+        const s = Symbol("foo");
+
         class A {
             static set "method with space"(value) {
                 this.a = value;
@@ -39,14 +41,20 @@ describe("correct behavior", () => {
             static set [`he${"llo"}`](value) {
                 this.c = value;
             }
+
+            static set [s](value) {
+                this.d = value;
+            }
         }
 
         A["method with space"] = 1;
         A[12] = 2;
         A.hello = 3;
+        A[s] = 4;
         expect(A.a).toBe(1);
         expect(A.b).toBe(2);
         expect(A.c).toBe(3);
+        expect(A.d).toBe(4);
     });
 
     test("inherited static setter", () => {

--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -31,6 +31,14 @@ describe("correct behavior", () => {
         expect(o["hello"]).toBe("friends");
     });
 
+    test("symbol keys", () => {
+        let object = {};
+        let symbol = Symbol("foo");
+
+        object[symbol] = 2;
+        expect(object[symbol]).toBe(2);
+    });
+
     test("computed properties", () => {
         const foo = "bar";
         const computed = "computed";

--- a/Libraries/LibJS/Tests/object-method-shorthand.js
+++ b/Libraries/LibJS/Tests/object-method-shorthand.js
@@ -37,3 +37,14 @@ test("computed property method shorthand", () => {
     };
     expect(o[14]()).toBe("bar");
 });
+
+test("symbol computed property shorthand", () => {
+    const s = Symbol("foo");
+    const o = {
+        foo: "bar",
+        [s]() {
+            return this.foo;
+        },
+    };
+    expect(o[s]()).toBe("bar");
+});

--- a/Libraries/LibJS/Tests/object-spread.js
+++ b/Libraries/LibJS/Tests/object-spread.js
@@ -12,7 +12,7 @@ const testObjStrSpread = obj => {
 };
 
 test("spread object literal inside object literal", () => {
-    let obj = {
+    const obj = {
         foo: 0,
         ...{ bar: 1, baz: 2 },
         qux: 3,
@@ -21,19 +21,19 @@ test("spread object literal inside object literal", () => {
 });
 
 test("spread object with assigned property inside object literal", () => {
-    obj = { foo: 0, bar: 1, baz: 2 };
+    const obj = { foo: 0, bar: 1, baz: 2 };
     obj.qux = 3;
     testObjSpread({ ...obj });
 });
 
 test("spread object inside object literal", () => {
     let a = { bar: 1, baz: 2 };
-    obj = { foo: 0, ...a, qux: 3 };
+    const obj = { foo: 0, ...a, qux: 3 };
     testObjSpread(obj);
 });
 
 test("complex nested object spreading", () => {
-    obj = {
+    const obj = {
         ...{},
         ...{
             ...{ foo: 0, bar: 1, baz: 2 },
@@ -44,29 +44,40 @@ test("complex nested object spreading", () => {
 });
 
 test("spread string in object literal", () => {
-    obj = { ..."abcd" };
+    const obj = { ..."abcd" };
     testObjStrSpread(obj);
 });
 
 test("spread array in object literal", () => {
-    obj = { ...["a", "b", "c", "d"] };
+    const obj = { ...["a", "b", "c", "d"] };
     testObjStrSpread(obj);
 });
 
 test("spread string object in object literal", () => {
-    obj = { ...String("abcd") };
+    const obj = { ...String("abcd") };
     testObjStrSpread(obj);
 });
 
 test("spread object with non-enumerable property", () => {
-    a = { foo: 0 };
+    const a = { foo: 0 };
     Object.defineProperty(a, "bar", {
         value: 1,
         enumerable: false,
     });
-    obj = { ...a };
+    const obj = { ...a };
     expect(obj.foo).toBe(0);
     expect(obj).not.toHaveProperty("bar");
+});
+
+test("spread object with symbol keys", () => {
+    const s = Symbol("baz");
+    const a = {
+        foo: "bar",
+        [s]: "qux",
+    };
+    const obj = { ...a };
+    expect(obj.foo).toBe("bar");
+    expect(obj[s]).toBe("qux");
 });
 
 test("spreading non-spreadable values", () => {


### PR DESCRIPTION
This PR finally allows Symbols to be used as object properties alongside strings. This is round two of attempting to implement this feature. The `StringOrSymbol` class is designed to be as memory efficient as possible, being a wrapper around only a single tagged pointer ([see comment here](https://github.com/SerenityOS/serenity/pull/2034#discussion_r418582570)).

I have a few questions though. First of all, for my tagged pointer, I assumed that the lowest bit of a pointer is normally always zero, since that's what I found to be true while testing both inside serenity and on my host machine. Is this a safe assumption to make?

Secondly, I was unable to figure out how to use FlyString'd `StringImpl`s as the comment above suggests. Whenever I tried, I ended up getting `RefCounted` errors. Some help with this would be much appreciated :)

Might have merge conflicts with #2723, not sure, so merge that one first.

cc @linusg 