### PR TITLE
Kernel: Fix some SMP related flaws that caused crashes or hangs during boot

### DIFF
--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -976,8 +976,6 @@ void Processor::initialize(u32 cpu)
         if (cpu >= s_processors->size())
             s_processors->resize(cpu + 1);
         (*s_processors)[cpu] = this;
-
-        klog() << "CPU[" << cpu << "]: initialized Processor at " << VirtualAddress(FlatPtr(this));
     }
 }
 
@@ -1330,6 +1328,27 @@ void Processor::assume_context(Thread& thread, u32 flags)
     ASSERT_NOT_REACHED();
 }
 
+extern "C" void pre_init_finished(void)
+{
+    ASSERT(g_scheduler_lock.own_lock());
+
+    // The target flags will get restored upon leaving the trap
+    u32 prev_flags = cpu_flags();
+    g_scheduler_lock.unlock(prev_flags);
+
+    // We because init_finished() will wait on the other APs, we need
+    // to release the scheduler lock so that the other APs can also get
+    // to this point
+}
+
+extern "C" void post_init_finished(void)
+{
+    // We need to re-acquire the scheduler lock before a context switch
+    // transfers control into the idle loop, which needs the lock held
+    ASSERT(!g_scheduler_lock.own_lock());
+    g_scheduler_lock.lock();
+}
+
 void Processor::initialize_context_switching(Thread& initial_thread)
 {
     ASSERT(initial_thread.process().is_ring0());
@@ -1354,9 +1373,11 @@ void Processor::initialize_context_switching(Thread& initial_thread)
         "addl $20, %%ebx \n" // calculate pointer to TrapFrame
         "pushl %%ebx \n"
         "cld \n"
-        "pushl %[cpu] \n"
+        "pushl %[cpu] \n" // push argument for init_finished before register is clobbered
+        "call pre_init_finished \n"
         "call init_finished \n"
         "addl $4, %%esp \n"
+        "call post_init_finished \n"
         "call enter_trap_no_irq \n"
         "addl $4, %%esp \n"
         "lret \n"

--- a/Kernel/Interrupts/APIC.h
+++ b/Kernel/Interrupts/APIC.h
@@ -96,7 +96,6 @@ private:
     };
 
     OwnPtr<Region> m_apic_base;
-    Vector<OwnPtr<Region>> m_apic_ap_stacks;
     Vector<OwnPtr<Processor>> m_ap_processor_info;
     Vector<Thread*> m_ap_idle_threads;
     AK::Atomic<u8> m_apic_ap_count{0};

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -166,10 +166,7 @@ extern "C" [[noreturn]] void init_ap(u32 cpu, Processor* processor_info)
 {
     processor_info->early_initialize(cpu);
 
-    klog() << "CPU #" << cpu << " processor_info at " << VirtualAddress(FlatPtr(processor_info));
-
     processor_info->initialize(cpu);
-    APIC::the().enable(cpu);
     MemoryManager::initialize(cpu);
 
     Scheduler::set_idle_thread(APIC::the().get_idle_thread(cpu));
@@ -184,7 +181,6 @@ extern "C" [[noreturn]] void init_ap(u32 cpu, Processor* processor_info)
 //
 extern "C" void init_finished(u32 cpu)
 {
-    klog() << "CPU #" << cpu << " finished initialization";
     if (cpu == 0) {
         // TODO: we can reuse the boot stack, maybe for kmalloc()?
     } else {


### PR DESCRIPTION
We need to halt the BSP briefly until all APs are ready for the
first context switch, but we can't hold the same spinlock by all
of them while doing so. So, while the APs are waiting on each other
they need to release the scheduler lock, and then once signaled
re-acquire it. Should solve some timing dependent hangs or crashes,
most easily observed using qemu with kvm disabled.