### PR TITLE
Toolchain: Allow building using CMake on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,22 @@ set(CMAKE_RANLIB ${TOOLCHAIN_PREFIX}ranlib)
 set(CMAKE_STRIP ${TOOLCHAIN_PREFIX}strip)
 set(CMAKE_AR ${TOOLCHAIN_PREFIX}ar)
 
+foreach(lang ASM C CXX OBJC OBJCXX)
+    unset(CMAKE_${lang}_OSX_COMPATIBILITY_VERSION_FLAG)
+    unset(CMAKE_${lang}_OSX_CURRENT_VERSION_FLAG)
+    unset(CMAKE_${lang}_LINK_FLAGS)
+    unset(CMAKE_SHARED_LIBRARY_CREATE_${lang}_FLAGS)
+    unset(CMAKE_SHARED_MODULE_CREATE_${lang}_FLAGS)
+    unset(CMAKE_SHARED_MODULE_LOADER_${lang}_FLAG )
+    unset(CMAKE_${lang}_OSX_DEPLOYMENT_TARGET_FLAG)
+    unset(CMAKE_${lang}_SYSROOT_FLAG)
+    unset(CMAKE_SHARED_LIBRARY_SONAME_${lang}_FLAG)
+endforeach()
+
+set(CMAKE_INSTALL_NAME_TOOL "true")
+set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-shared")
+
 #FIXME: -fstack-protector
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os -Wno-sized-deallocation -fno-sized-deallocation -fno-exceptions -fno-rtti -Wno-address-of-packed-member -Wundef -Wcast-qual -Wwrite-strings -Wimplicit-fallthrough -Wno-nonnull-compare -Wno-deprecated-copy -Wno-expansion-to-defined")

--- a/Libraries/LibC/CMakeLists.txt
+++ b/Libraries/LibC/CMakeLists.txt
@@ -54,10 +54,15 @@ set(ELF_SOURCES ${ELF_SOURCES} ../LibELF/Arch/i386/plt_trampoline.S)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSERENITY_LIBC_BUILD")
 
+find_program(INSTALL_COMMAND ginstall)
+if(NOT INSTALL_COMMAND)
+    set(INSTALL_COMMAND install)
+endif()
+
 add_library(crt0 STATIC crt0.cpp)
 add_custom_command(
     TARGET crt0
-    COMMAND install -D $<TARGET_OBJECTS:crt0> ${CMAKE_INSTALL_PREFIX}/usr/lib/crt0.o
+    COMMAND ${INSTALL_COMMAND} -D $<TARGET_OBJECTS:crt0> ${CMAKE_INSTALL_PREFIX}/usr/lib/crt0.o
 )
 
 set(SOURCES ${LIBC_SOURCES} ${AK_SOURCES} ${ELF_SOURCES})


### PR DESCRIPTION
This is a single phase build patch to allow compiling on macOS.
This is based on @bugaevc base patch as discussed in #2519 and effectively replaces that PR.
I have been fixing a few other compile / linking issues and I've been changing `BuildIt.sh` to make it work even without bash 4 installed.