### PR TITLE
LibJS: Start implementing iterable framework, add ArrayIterator

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -383,7 +383,7 @@ Value ForInStatement::execute(Interpreter& interpreter, GlobalObject& global_obj
         return {};
     auto* object = rhs_result.to_object(interpreter, global_object);
     while (object) {
-        auto property_names = object->get_own_properties(*object, Object::GetOwnPropertyReturnMode::Key, true);
+        auto property_names = object->get_own_properties(*object, Object::PropertyKind::Key, true);
         for (auto& property_name : property_names.as_object().indexed_properties()) {
             interpreter.set_variable(variable_name, property_name.value_and_attributes(object).value, global_object);
             if (interpreter.exception())

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -10,6 +10,8 @@ set(SOURCES
     Parser.cpp
     Runtime/Array.cpp
     Runtime/ArrayConstructor.cpp
+    Runtime/ArrayIterator.cpp
+    Runtime/ArrayIteratorPrototype.cpp
     Runtime/ArrayPrototype.cpp
     Runtime/BigInt.cpp
     Runtime/BigIntConstructor.cpp
@@ -34,6 +36,8 @@ set(SOURCES
     Runtime/FunctionPrototype.cpp
     Runtime/GlobalObject.cpp
     Runtime/IndexedProperties.cpp
+    Runtime/IteratorOperations.cpp
+    Runtime/IteratorPrototype.cpp
     Runtime/JSONObject.cpp
     Runtime/LexicalEnvironment.cpp
     Runtime/MarkedValueList.cpp

--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -67,6 +67,10 @@
     __JS_ENUMERATE(TypeError, type_error, TypeErrorPrototype, TypeErrorConstructor)                     \
     __JS_ENUMERATE(URIError, uri_error, URIErrorPrototype, URIErrorConstructor)
 
+#define JS_ENUMERATE_ITERATOR_PROTOTYPES            \
+    __JS_ENUMERATE(Iterator, iterator)              \
+    __JS_ENUMERATE(ArrayIterator, array_iterator)
+
 #define JS_ENUMERATE_BUILTIN_TYPES \
     JS_ENUMERATE_NATIVE_OBJECTS    \
     JS_ENUMERATE_ERROR_SUBCLASSES

--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -75,6 +75,21 @@
     JS_ENUMERATE_NATIVE_OBJECTS    \
     JS_ENUMERATE_ERROR_SUBCLASSES
 
+#define JS_ENUMERATE_WELL_KNOWN_SYMBOLS                        \
+    __JS_ENUMERATE(iterator, iterator)                         \
+    __JS_ENUMERATE(asyncIterator, async_iterator)              \
+    __JS_ENUMERATE(match, match)                               \
+    __JS_ENUMERATE(matchAll, match_all)                        \
+    __JS_ENUMERATE(replace, replace)                           \
+    __JS_ENUMERATE(search, search)                             \
+    __JS_ENUMERATE(split, split)                               \
+    __JS_ENUMERATE(hasInstance, has_instance)                  \
+    __JS_ENUMERATE(isConcatSpreadable, is_concat_spreadable)   \
+    __JS_ENUMERATE(unscopables, unscopables)                   \
+    __JS_ENUMERATE(species, species)                           \
+    __JS_ENUMERATE(toPrimitive, to_primitive)                  \
+    __JS_ENUMERATE(toStringTag, to_string_tag)
+
 namespace JS {
 
 class ASTNode;

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -48,19 +48,10 @@ Interpreter::Interpreter()
     : m_heap(*this)
     , m_console(*this)
 {
-    m_well_known_symbol_map.set("iterator", js_symbol(*this, "Symbol.iterator", false));
-    m_well_known_symbol_map.set("asyncIterator", js_symbol(*this, "Symbol.asyncIterator", false));
-    m_well_known_symbol_map.set("match", js_symbol(*this, "Symbol.match", false));
-    m_well_known_symbol_map.set("matchAll", js_symbol(*this, "Symbol.matchAll", false));
-    m_well_known_symbol_map.set("replace", js_symbol(*this, "Symbol.replace", false));
-    m_well_known_symbol_map.set("search", js_symbol(*this, "Symbol.search", false));
-    m_well_known_symbol_map.set("split", js_symbol(*this, "Symbol.split", false));
-    m_well_known_symbol_map.set("hasInstance", js_symbol(*this, "Symbol.hasInstance", false));
-    m_well_known_symbol_map.set("isConcatSpreadable", js_symbol(*this, "Symbol.isConcatSpreadable", false));
-    m_well_known_symbol_map.set("unscopables", js_symbol(*this, "Symbol.unscopables", false));
-    m_well_known_symbol_map.set("species", js_symbol(*this, "Symbol.species", false));
-    m_well_known_symbol_map.set("toPrimitive", js_symbol(*this, "Symbol.toPrimitive", false));
-    m_well_known_symbol_map.set("toStringTag", js_symbol(*this, "Symbol.toStringTag", false));
+#define __JS_ENUMERATE(SymbolName, snake_name) \
+    m_well_known_symbol_##snake_name = js_symbol(*this, "Symbol." #SymbolName, false);
+    JS_ENUMERATE_WELL_KNOWN_SYMBOLS
+#undef __JS_ENUMERATE
 }
 
 Interpreter::~Interpreter()
@@ -225,12 +216,6 @@ Symbol* Interpreter::get_global_symbol(const String& description)
     return new_global_symbol;
 }
 
-Symbol* Interpreter::get_well_known_symbol(const String& description) const
-{
-    ASSERT(m_well_known_symbol_map.contains(description));
-    return m_well_known_symbol_map.get(description).value();
-}
-
 void Interpreter::gather_roots(Badge<Heap>, HashTable<Cell*>& roots)
 {
     roots.set(m_global_object);
@@ -249,8 +234,10 @@ void Interpreter::gather_roots(Badge<Heap>, HashTable<Cell*>& roots)
         roots.set(call_frame.environment);
     }
 
-    for (auto& symbol : m_well_known_symbol_map)
-        roots.set(symbol.value);
+#define __JS_ENUMERATE(SymbolName, snake_name) \
+    roots.set(well_known_symbol_##snake_name());
+    JS_ENUMERATE_WELL_KNOWN_SYMBOLS
+#undef __JS_ENUMERATE
 
     for (auto& symbol : m_global_symbol_map)
         roots.set(symbol.value);

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -112,8 +112,6 @@ public:
     Reference get_reference(const FlyString& name);
 
     Symbol* get_global_symbol(const String& description);
-    Symbol* get_well_known_symbol(const String& description) const;
-    const HashMap<String, Symbol*>& get_well_known_symbol_map(Badge<SymbolConstructor>) const { return m_well_known_symbol_map; };
 
     void gather_roots(Badge<Heap>, HashTable<Cell*>&);
 
@@ -209,6 +207,11 @@ public:
     const LexicalEnvironment* get_this_environment() const;
     Value get_new_target() const;
 
+#define __JS_ENUMERATE(SymbolName, snake_name) \
+    Symbol* well_known_symbol_##snake_name() const { return m_well_known_symbol_##snake_name; }
+    JS_ENUMERATE_WELL_KNOWN_SYMBOLS
+#undef __JS_ENUMERATE
+
 private:
     Interpreter();
 
@@ -221,9 +224,6 @@ private:
 
     Object* m_global_object { nullptr };
 
-    HashMap<String, Symbol*> m_well_known_symbol_map;
-    HashMap<String, Symbol*> m_global_symbol_map;
-
     Exception* m_exception { nullptr };
 
     ScopeType m_unwind_until { ScopeType::None };
@@ -232,6 +232,13 @@ private:
     bool m_underscore_is_last_value { false };
 
     Console m_console;
+
+    HashMap<String, Symbol*> m_global_symbol_map;
+
+#define __JS_ENUMERATE(SymbolName, snake_name) \
+    Symbol* m_well_known_symbol_##snake_name { nullptr };
+    JS_ENUMERATE_WELL_KNOWN_SYMBOLS
+#undef __JS_ENUMERATE
 };
 
 }

--- a/Libraries/LibJS/Runtime/ArrayIterator.cpp
+++ b/Libraries/LibJS/Runtime/ArrayIterator.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/ArrayIterator.h>
+#include <LibJS/Runtime/GlobalObject.h>
+
+namespace JS {
+
+ArrayIterator* ArrayIterator::create(GlobalObject& global_object, Value array, Object::PropertyKind iteration_kind)
+{
+    return global_object.heap().allocate<ArrayIterator>(global_object, *global_object.array_iterator_prototype(), array, iteration_kind);
+}
+
+ArrayIterator::ArrayIterator(Object& prototype, Value array, Object::PropertyKind iteration_kind)
+    : Object(prototype)
+    , m_array(array)
+    , m_iteration_kind(iteration_kind)
+{
+}
+
+ArrayIterator::~ArrayIterator()
+{
+}
+
+}

--- a/Libraries/LibJS/Runtime/ArrayIterator.h
+++ b/Libraries/LibJS/Runtime/ArrayIterator.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,40 +30,27 @@
 
 namespace JS {
 
-class ArrayPrototype final : public Object {
-    JS_OBJECT(ArrayPrototype, Object);
+class ArrayIterator final : public Object {
+    JS_OBJECT(ArrayIterator, Object);
 
 public:
-    ArrayPrototype(GlobalObject&);
-    virtual void initialize(Interpreter&, GlobalObject&) override;
-    virtual ~ArrayPrototype() override;
+    static ArrayIterator* create(GlobalObject&, Value array, Object::PropertyKind iteration_kind);
+
+    explicit ArrayIterator(Object& prototype, Value array, Object::PropertyKind iteration_kind);
+    virtual ~ArrayIterator() override;
+
+    Value array() const { return m_array; }
+    Object::PropertyKind iteration_kind() const { return m_iteration_kind; }
+    size_t index() const { return m_index; }
 
 private:
-    JS_DECLARE_NATIVE_FUNCTION(filter);
-    JS_DECLARE_NATIVE_FUNCTION(for_each);
-    JS_DECLARE_NATIVE_FUNCTION(map);
-    JS_DECLARE_NATIVE_FUNCTION(pop);
-    JS_DECLARE_NATIVE_FUNCTION(push);
-    JS_DECLARE_NATIVE_FUNCTION(shift);
-    JS_DECLARE_NATIVE_FUNCTION(to_string);
-    JS_DECLARE_NATIVE_FUNCTION(to_locale_string);
-    JS_DECLARE_NATIVE_FUNCTION(unshift);
-    JS_DECLARE_NATIVE_FUNCTION(join);
-    JS_DECLARE_NATIVE_FUNCTION(concat);
-    JS_DECLARE_NATIVE_FUNCTION(slice);
-    JS_DECLARE_NATIVE_FUNCTION(index_of);
-    JS_DECLARE_NATIVE_FUNCTION(reduce);
-    JS_DECLARE_NATIVE_FUNCTION(reduce_right);
-    JS_DECLARE_NATIVE_FUNCTION(reverse);
-    JS_DECLARE_NATIVE_FUNCTION(last_index_of);
-    JS_DECLARE_NATIVE_FUNCTION(includes);
-    JS_DECLARE_NATIVE_FUNCTION(find);
-    JS_DECLARE_NATIVE_FUNCTION(find_index);
-    JS_DECLARE_NATIVE_FUNCTION(some);
-    JS_DECLARE_NATIVE_FUNCTION(every);
-    JS_DECLARE_NATIVE_FUNCTION(splice);
-    JS_DECLARE_NATIVE_FUNCTION(fill);
-    JS_DECLARE_NATIVE_FUNCTION(values);
+    friend class ArrayIteratorPrototype;
+
+    virtual bool is_array_iterator_object() const override { return true; }
+
+    Value m_array;
+    Object::PropertyKind m_iteration_kind;
+    size_t m_index { 0 };
 };
 
 }

--- a/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/ArrayIterator.h>
+#include <LibJS/Runtime/ArrayIteratorPrototype.h>
+#include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/IteratorOperations.h>
+
+namespace JS {
+
+ArrayIteratorPrototype::ArrayIteratorPrototype(GlobalObject& global_object)
+    : Object(*global_object.iterator_prototype())
+{
+}
+
+void ArrayIteratorPrototype::initialize(Interpreter& interpreter, GlobalObject& global_object)
+{
+    Object::initialize(interpreter, global_object);
+    define_native_function("next", next, 0, Attribute::Writable | Attribute::Configurable);
+}
+
+ArrayIteratorPrototype::~ArrayIteratorPrototype()
+{
+}
+
+JS_DEFINE_NATIVE_FUNCTION(ArrayIteratorPrototype::next)
+{
+    auto this_value = interpreter.this_value(global_object);
+    if (!this_value.is_object() || !this_value.as_object().is_array_iterator_object())
+        return interpreter.throw_exception<TypeError>(ErrorType::NotAn, "Array Iterator");
+
+    auto& this_object = this_value.as_object();
+
+    auto& iterator = static_cast<ArrayIterator&>(this_object);
+    auto target_array = iterator.array();
+    if (target_array.is_undefined())
+        return create_iterator_result_object(interpreter, global_object, js_undefined(), true);
+    ASSERT(target_array.is_object());
+    auto& array = target_array.as_object();
+
+    auto index = iterator.index();
+    auto iteration_kind = iterator.iteration_kind();
+    // FIXME: Typed array check
+    auto length = array.indexed_properties().array_like_size();
+
+    if (index >= length) {
+        iterator.m_array = js_undefined();
+        return create_iterator_result_object(interpreter, global_object, js_undefined(), true);
+    }
+
+    iterator.m_index++;
+    if (iteration_kind == Object::PropertyKind::Key)
+        return create_iterator_result_object(interpreter, global_object, Value(static_cast<i32>(index)), false);
+
+    auto value = array.get(index);
+    if (interpreter.exception())
+        return {};
+    if (iteration_kind == Object::PropertyKind::Value)
+        return create_iterator_result_object(interpreter, global_object, value, false);
+
+    auto* entry_array = Array::create(global_object);
+    entry_array->define_property(0, Value(static_cast<i32>(index)));
+    entry_array->define_property(1, value);
+    return create_iterator_result_object(interpreter, global_object, entry_array, false);
+}
+
+}

--- a/Libraries/LibJS/Runtime/ArrayIteratorPrototype.h
+++ b/Libraries/LibJS/Runtime/ArrayIteratorPrototype.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,40 +30,16 @@
 
 namespace JS {
 
-class ArrayPrototype final : public Object {
-    JS_OBJECT(ArrayPrototype, Object);
+class ArrayIteratorPrototype final : public Object {
+    JS_OBJECT(ArrayIteratorPrototype, Object)
 
 public:
-    ArrayPrototype(GlobalObject&);
+    ArrayIteratorPrototype(GlobalObject&);
     virtual void initialize(Interpreter&, GlobalObject&) override;
-    virtual ~ArrayPrototype() override;
+    virtual ~ArrayIteratorPrototype() override;
 
 private:
-    JS_DECLARE_NATIVE_FUNCTION(filter);
-    JS_DECLARE_NATIVE_FUNCTION(for_each);
-    JS_DECLARE_NATIVE_FUNCTION(map);
-    JS_DECLARE_NATIVE_FUNCTION(pop);
-    JS_DECLARE_NATIVE_FUNCTION(push);
-    JS_DECLARE_NATIVE_FUNCTION(shift);
-    JS_DECLARE_NATIVE_FUNCTION(to_string);
-    JS_DECLARE_NATIVE_FUNCTION(to_locale_string);
-    JS_DECLARE_NATIVE_FUNCTION(unshift);
-    JS_DECLARE_NATIVE_FUNCTION(join);
-    JS_DECLARE_NATIVE_FUNCTION(concat);
-    JS_DECLARE_NATIVE_FUNCTION(slice);
-    JS_DECLARE_NATIVE_FUNCTION(index_of);
-    JS_DECLARE_NATIVE_FUNCTION(reduce);
-    JS_DECLARE_NATIVE_FUNCTION(reduce_right);
-    JS_DECLARE_NATIVE_FUNCTION(reverse);
-    JS_DECLARE_NATIVE_FUNCTION(last_index_of);
-    JS_DECLARE_NATIVE_FUNCTION(includes);
-    JS_DECLARE_NATIVE_FUNCTION(find);
-    JS_DECLARE_NATIVE_FUNCTION(find_index);
-    JS_DECLARE_NATIVE_FUNCTION(some);
-    JS_DECLARE_NATIVE_FUNCTION(every);
-    JS_DECLARE_NATIVE_FUNCTION(splice);
-    JS_DECLARE_NATIVE_FUNCTION(fill);
-    JS_DECLARE_NATIVE_FUNCTION(values);
+    JS_DECLARE_NATIVE_FUNCTION(next);
 };
 
 }

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -81,7 +81,7 @@ void ArrayPrototype::initialize(Interpreter& interpreter, GlobalObject& global_o
     // Use define_property here instead of define_native_function so that
     // Object.is(Array.prototype[Symbol.iterator], Array.prototype.values)
     // evaluates to true
-    define_property(interpreter.get_well_known_symbol("iterator"), get("values"), attr);
+    define_property(interpreter.well_known_symbol_iterator(), get("values"), attr);
 }
 
 ArrayPrototype::~ArrayPrototype()

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -182,7 +182,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::map)
     for_each_item(interpreter, global_object, "map", [&](auto index, auto, auto callback_result) {
         if (interpreter.exception())
             return IterationDecision::Break;
-        new_array->put(index, callback_result);
+        new_array->define_property(index, callback_result);
         return IterationDecision::Continue;
     });
     return Value(new_array);

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -28,6 +28,7 @@
 #include <AK/LogStream.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/ArrayConstructor.h>
+#include <LibJS/Runtime/ArrayIteratorPrototype.h>
 #include <LibJS/Runtime/ArrayPrototype.h>
 #include <LibJS/Runtime/BigIntConstructor.h>
 #include <LibJS/Runtime/BigIntPrototype.h>
@@ -41,6 +42,7 @@
 #include <LibJS/Runtime/FunctionConstructor.h>
 #include <LibJS/Runtime/FunctionPrototype.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/IteratorPrototype.h>
 #include <LibJS/Runtime/JSONObject.h>
 #include <LibJS/Runtime/MathObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
@@ -83,6 +85,13 @@ void GlobalObject::initialize()
         m_##snake_name##_prototype = heap().allocate<PrototypeName>(*this, *this);
     JS_ENUMERATE_BUILTIN_TYPES
 #undef __JS_ENUMERATE
+
+#define __JS_ENUMERATE(ClassName, snake_name)                                    \
+    if (!m_##snake_name##_prototype)                                             \
+        m_##snake_name##_prototype = heap().allocate<ClassName##Prototype>(*this, *this);
+    JS_ENUMERATE_ITERATOR_PROTOTYPES
+#undef __JS_ENUMERATE
+
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function("gc", gc, 0, attr);

--- a/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Libraries/LibJS/Runtime/GlobalObject.h
@@ -49,6 +49,11 @@ public:
     JS_ENUMERATE_BUILTIN_TYPES
 #undef __JS_ENUMERATE
 
+#define __JS_ENUMERATE(ClassName, snake_name) \
+    Object* snake_name##_prototype() { return m_##snake_name##_prototype; }
+    JS_ENUMERATE_ITERATOR_PROTOTYPES
+#undef __JS_ENUMERATE
+
 protected:
     virtual void visit_children(Visitor&) override;
 
@@ -68,6 +73,12 @@ private:
     Object* m_##snake_name##_prototype { nullptr };
     JS_ENUMERATE_BUILTIN_TYPES
 #undef __JS_ENUMERATE
+
+#define __JS_ENUMERATE(ClassName, snake_name) \
+    Object* m_##snake_name##_prototype { nullptr };
+    JS_ENUMERATE_ITERATOR_PROTOTYPES
+#undef __JS_ENUMERATE
+
 };
 
 template<typename ConstructorType>

--- a/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibJS/Interpreter.h>
+#include <LibJS/Runtime/IteratorOperations.h>
+
+namespace JS {
+
+Object* get_iterator(Object& obj, String hint, Value method)
+{
+    auto& interpreter = obj.interpreter();
+    ASSERT(hint == "sync" || hint == "async");
+    if (method.is_empty()) {
+        if (hint == "async")
+            TODO();
+        method = obj.get(obj.interpreter().get_well_known_symbol("iterator"));
+        if (interpreter.exception())
+            return {};
+    }
+    if (!method.is_function())
+        TODO();
+    auto iterator = interpreter.call(method.as_function(), &obj);
+    if (interpreter.exception())
+        return {};
+    if (!iterator.is_object())
+        TODO();
+    return &iterator.as_object();
+}
+
+Value iterator_next(Object& iterator, Value value)
+{
+    auto& interpreter = iterator.interpreter();
+    auto next_method = iterator.get("next");
+    if (interpreter.exception())
+        return {};
+
+    ASSERT(next_method.is_function());
+
+    Value result;
+    if (value.is_empty()) {
+        result = interpreter.call(next_method.as_function(), &iterator);
+    } else {
+        MarkedValueList arguments(iterator.heap());
+        arguments.append(value);
+        result = interpreter.call(next_method.as_function(), &iterator, move(arguments));
+    }
+
+    if (interpreter.exception())
+        return {};
+    if (!result.is_object())
+        TODO();
+
+    return result;
+}
+
+bool is_iterator_complete(Object& iterator_result)
+{
+    auto done = iterator_result.get("done");
+    if (iterator_result.interpreter().exception())
+        return false;
+    return done.to_boolean();
+}
+
+Value iterator_value(Object& iterator_result)
+{
+    return iterator_result.get("value");
+}
+
+Value iterator_step(Object& iterator)
+{
+    auto& interpreter = iterator.interpreter();
+    auto result = iterator_next(iterator);
+    if (interpreter.exception())
+        return {};
+    auto done = is_iterator_complete(result.as_object());
+    if (interpreter.exception())
+        return {};
+    if (done)
+        return Value(false);
+    return result;
+}
+
+void iterator_close(Object& iterator)
+{
+    (void)iterator;
+    TODO();
+}
+
+Value create_iterator_result_object(Interpreter& interpreter, GlobalObject& global_object, Value value, bool done)
+{
+    auto* object = Object::create_empty(interpreter, global_object);
+    object->put("value", value);
+    object->put("done", Value(done));
+    return object;
+}
+
+}

--- a/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -112,8 +112,8 @@ void iterator_close(Object& iterator)
 Value create_iterator_result_object(Interpreter& interpreter, GlobalObject& global_object, Value value, bool done)
 {
     auto* object = Object::create_empty(interpreter, global_object);
-    object->put("value", value);
-    object->put("done", Value(done));
+    object->define_property("value", value);
+    object->define_property("done", Value(done));
     return object;
 }
 

--- a/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -36,7 +36,7 @@ Object* get_iterator(Object& obj, String hint, Value method)
     if (method.is_empty()) {
         if (hint == "async")
             TODO();
-        method = obj.get(obj.interpreter().get_well_known_symbol("iterator"));
+        method = obj.get(obj.interpreter().well_known_symbol_iterator());
         if (interpreter.exception())
             return {};
     }

--- a/Libraries/LibJS/Runtime/IteratorOperations.h
+++ b/Libraries/LibJS/Runtime/IteratorOperations.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,40 +30,16 @@
 
 namespace JS {
 
-class ArrayPrototype final : public Object {
-    JS_OBJECT(ArrayPrototype, Object);
+// Common iterator operations defined in ECMA262 7.4
+// https://tc39.es/ecma262/#sec-operations-on-iterator-objects
 
-public:
-    ArrayPrototype(GlobalObject&);
-    virtual void initialize(Interpreter&, GlobalObject&) override;
-    virtual ~ArrayPrototype() override;
+Object* get_iterator(Object& obj, String hint = "sync", Value method = {});
+bool is_iterator_complete(Object& iterator_result);
+Value create_iterator_result_object(Interpreter&, GlobalObject&, Value value, bool done);
 
-private:
-    JS_DECLARE_NATIVE_FUNCTION(filter);
-    JS_DECLARE_NATIVE_FUNCTION(for_each);
-    JS_DECLARE_NATIVE_FUNCTION(map);
-    JS_DECLARE_NATIVE_FUNCTION(pop);
-    JS_DECLARE_NATIVE_FUNCTION(push);
-    JS_DECLARE_NATIVE_FUNCTION(shift);
-    JS_DECLARE_NATIVE_FUNCTION(to_string);
-    JS_DECLARE_NATIVE_FUNCTION(to_locale_string);
-    JS_DECLARE_NATIVE_FUNCTION(unshift);
-    JS_DECLARE_NATIVE_FUNCTION(join);
-    JS_DECLARE_NATIVE_FUNCTION(concat);
-    JS_DECLARE_NATIVE_FUNCTION(slice);
-    JS_DECLARE_NATIVE_FUNCTION(index_of);
-    JS_DECLARE_NATIVE_FUNCTION(reduce);
-    JS_DECLARE_NATIVE_FUNCTION(reduce_right);
-    JS_DECLARE_NATIVE_FUNCTION(reverse);
-    JS_DECLARE_NATIVE_FUNCTION(last_index_of);
-    JS_DECLARE_NATIVE_FUNCTION(includes);
-    JS_DECLARE_NATIVE_FUNCTION(find);
-    JS_DECLARE_NATIVE_FUNCTION(find_index);
-    JS_DECLARE_NATIVE_FUNCTION(some);
-    JS_DECLARE_NATIVE_FUNCTION(every);
-    JS_DECLARE_NATIVE_FUNCTION(splice);
-    JS_DECLARE_NATIVE_FUNCTION(fill);
-    JS_DECLARE_NATIVE_FUNCTION(values);
-};
+Value iterator_next(Object& iterator, Value value = {});
+Value iterator_value(Object& iterator_result);
+Value iterator_step(Object& iterator);
+void iterator_close(Object& iterator);
 
 }

--- a/Libraries/LibJS/Runtime/IteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/IteratorPrototype.cpp
@@ -37,7 +37,7 @@ IteratorPrototype::IteratorPrototype(GlobalObject& global_object)
 void IteratorPrototype::initialize(Interpreter& interpreter, GlobalObject& global_object)
 {
     Object::initialize(interpreter, global_object);
-    define_native_function(interpreter.get_well_known_symbol("iterator"), symbol_iterator, 0, Attribute::Writable | Attribute::Enumerable);
+    define_native_function(interpreter.well_known_symbol_iterator(), symbol_iterator, 0, Attribute::Writable | Attribute::Enumerable);
 }
 
 IteratorPrototype::~IteratorPrototype()

--- a/Libraries/LibJS/Runtime/IteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/IteratorPrototype.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/IteratorPrototype.h>
+
+namespace JS {
+
+IteratorPrototype::IteratorPrototype(GlobalObject& global_object)
+    : Object(*global_object.object_prototype())
+{
+}
+
+void IteratorPrototype::initialize(Interpreter& interpreter, GlobalObject& global_object)
+{
+    Object::initialize(interpreter, global_object);
+    define_native_function(interpreter.get_well_known_symbol("iterator"), symbol_iterator, 0, Attribute::Writable | Attribute::Enumerable);
+}
+
+IteratorPrototype::~IteratorPrototype()
+{
+}
+
+JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::symbol_iterator)
+{
+    auto* this_object = interpreter.this_value(global_object).to_object(interpreter, global_object);
+    if (!this_object)
+        return {};
+    return this_object;
+}
+
+}

--- a/Libraries/LibJS/Runtime/IteratorPrototype.h
+++ b/Libraries/LibJS/Runtime/IteratorPrototype.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,40 +30,16 @@
 
 namespace JS {
 
-class ArrayPrototype final : public Object {
-    JS_OBJECT(ArrayPrototype, Object);
+class IteratorPrototype : public Object {
+    JS_OBJECT(IteratorPrototype, Object)
 
 public:
-    ArrayPrototype(GlobalObject&);
+    IteratorPrototype(GlobalObject&);
     virtual void initialize(Interpreter&, GlobalObject&) override;
-    virtual ~ArrayPrototype() override;
+    virtual ~IteratorPrototype() override;
 
 private:
-    JS_DECLARE_NATIVE_FUNCTION(filter);
-    JS_DECLARE_NATIVE_FUNCTION(for_each);
-    JS_DECLARE_NATIVE_FUNCTION(map);
-    JS_DECLARE_NATIVE_FUNCTION(pop);
-    JS_DECLARE_NATIVE_FUNCTION(push);
-    JS_DECLARE_NATIVE_FUNCTION(shift);
-    JS_DECLARE_NATIVE_FUNCTION(to_string);
-    JS_DECLARE_NATIVE_FUNCTION(to_locale_string);
-    JS_DECLARE_NATIVE_FUNCTION(unshift);
-    JS_DECLARE_NATIVE_FUNCTION(join);
-    JS_DECLARE_NATIVE_FUNCTION(concat);
-    JS_DECLARE_NATIVE_FUNCTION(slice);
-    JS_DECLARE_NATIVE_FUNCTION(index_of);
-    JS_DECLARE_NATIVE_FUNCTION(reduce);
-    JS_DECLARE_NATIVE_FUNCTION(reduce_right);
-    JS_DECLARE_NATIVE_FUNCTION(reverse);
-    JS_DECLARE_NATIVE_FUNCTION(last_index_of);
-    JS_DECLARE_NATIVE_FUNCTION(includes);
-    JS_DECLARE_NATIVE_FUNCTION(find);
-    JS_DECLARE_NATIVE_FUNCTION(find_index);
-    JS_DECLARE_NATIVE_FUNCTION(some);
-    JS_DECLARE_NATIVE_FUNCTION(every);
-    JS_DECLARE_NATIVE_FUNCTION(splice);
-    JS_DECLARE_NATIVE_FUNCTION(fill);
-    JS_DECLARE_NATIVE_FUNCTION(values);
+    JS_DECLARE_NATIVE_FUNCTION(symbol_iterator);
 };
 
 }

--- a/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -433,7 +433,7 @@ Object* JSONObject::parse_json_object(Interpreter& interpreter, GlobalObject& gl
 {
     auto* object = Object::create_empty(interpreter, global_object);
     json_object.for_each_member([&](auto& key, auto& value) {
-        object->put(key, parse_json_value(interpreter, global_object, value));
+        object->define_property(key, parse_json_value(interpreter, global_object, value));
     });
     return object;
 }
@@ -443,7 +443,7 @@ Array* JSONObject::parse_json_array(Interpreter& interpreter, GlobalObject& glob
     auto* array = Array::create(global_object);
     size_t index = 0;
     json_array.for_each([&](auto& value) {
-        array->put(index++, parse_json_value(interpreter, global_object, value));
+        array->define_property(index++, parse_json_value(interpreter, global_object, value));
     });
     return array;
 }

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -179,7 +179,7 @@ Value Object::get_own_property(const Object& this_object, PropertyName property_
     return value_here;
 }
 
-Value Object::get_own_properties(const Object& this_object, GetOwnPropertyReturnMode kind, bool only_enumerable_properties, GetOwnPropertyReturnType return_type) const
+Value Object::get_own_properties(const Object& this_object, PropertyKind kind, bool only_enumerable_properties, GetOwnPropertyReturnType return_type) const
 {
     auto* properties_array = Array::create(global_object());
 
@@ -188,9 +188,9 @@ Value Object::get_own_properties(const Object& this_object, GetOwnPropertyReturn
         auto str = static_cast<const StringObject&>(this_object).primitive_string().string();
 
         for (size_t i = 0; i < str.length(); ++i) {
-            if (kind == GetOwnPropertyReturnMode::Key) {
+            if (kind == PropertyKind::Key) {
                 properties_array->define_property(i, js_string(interpreter(), String::number(i)));
-            } else if (kind == GetOwnPropertyReturnMode::Value) {
+            } else if (kind == PropertyKind::Value) {
                 properties_array->define_property(i, js_string(interpreter(), String::format("%c", str[i])));
             } else {
                 auto* entry_array = Array::create(global_object());
@@ -211,9 +211,9 @@ Value Object::get_own_properties(const Object& this_object, GetOwnPropertyReturn
         if (only_enumerable_properties && !value_and_attributes.attributes.is_enumerable())
             continue;
 
-        if (kind == GetOwnPropertyReturnMode::Key) {
+        if (kind == PropertyKind::Key) {
             properties_array->define_property(property_index, js_string(interpreter(), String::number(entry.index())));
-        } else if (kind == GetOwnPropertyReturnMode::Value) {
+        } else if (kind == PropertyKind::Value) {
             properties_array->define_property(property_index, value_and_attributes.value);
         } else {
             auto* entry_array = Array::create(global_object());
@@ -236,9 +236,9 @@ Value Object::get_own_properties(const Object& this_object, GetOwnPropertyReturn
         if (return_type == GetOwnPropertyReturnType::SymbolOnly && it.key.is_string())
             continue;
 
-        if (kind == GetOwnPropertyReturnMode::Key) {
+        if (kind == PropertyKind::Key) {
             properties_array->define_property(property_index, it.key.to_value(interpreter()));
-        } else if (kind == GetOwnPropertyReturnMode::Value) {
+        } else if (kind == PropertyKind::Value) {
             properties_array->define_property(property_index, this_object.get(it.key));
         } else {
             auto* entry_array = Array::create(global_object());

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -68,7 +68,7 @@ public:
 
     virtual bool inherits(const StringView& class_name) const { return class_name == this->class_name(); }
 
-    enum class GetOwnPropertyReturnMode {
+    enum class PropertyKind {
         Key,
         Value,
         KeyAndValue,
@@ -97,7 +97,7 @@ public:
     virtual bool put(const PropertyName&, Value, Value receiver = {});
 
     Value get_own_property(const Object& this_object, PropertyName, Value receiver) const;
-    Value get_own_properties(const Object& this_object, GetOwnPropertyReturnMode, bool only_enumerable_properties = false, GetOwnPropertyReturnType = GetOwnPropertyReturnType::StringOnly) const;
+    Value get_own_properties(const Object& this_object, PropertyKind, bool only_enumerable_properties = false, GetOwnPropertyReturnType = GetOwnPropertyReturnType::StringOnly) const;
     virtual Optional<PropertyDescriptor> get_own_property_descriptor(const PropertyName&) const;
     Value get_own_property_descriptor_object(const PropertyName&) const;
 

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -123,6 +123,7 @@ public:
     virtual bool is_number_object() const { return false; }
     virtual bool is_symbol_object() const { return false; }
     virtual bool is_bigint_object() const { return false; }
+    virtual bool is_array_iterator_object() const { return false; }
 
     virtual const char* class_name() const override { return "Object"; }
     virtual void visit_children(Cell::Visitor&) override;

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -198,7 +198,7 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::keys)
     if (interpreter.exception())
         return {};
 
-    return obj_arg->get_own_properties(*obj_arg, GetOwnPropertyReturnMode::Key, true);
+    return obj_arg->get_own_properties(*obj_arg, PropertyKind::Key, true);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::values)
@@ -210,7 +210,7 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::values)
     if (interpreter.exception())
         return {};
 
-    return obj_arg->get_own_properties(*obj_arg, GetOwnPropertyReturnMode::Value, true);
+    return obj_arg->get_own_properties(*obj_arg, PropertyKind::Value, true);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::entries)
@@ -222,7 +222,7 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::entries)
     if (interpreter.exception())
         return {};
 
-    return obj_arg->get_own_properties(*obj_arg, GetOwnPropertyReturnMode::KeyAndValue, true);
+    return obj_arg->get_own_properties(*obj_arg, PropertyKind::KeyAndValue, true);
 }
 
 }

--- a/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -233,7 +233,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::own_keys)
     auto* target = get_target_object_from(interpreter, "ownKeys");
     if (!target)
         return {};
-    return target->get_own_properties(*target, GetOwnPropertyReturnMode::Key);
+    return target->get_own_properties(*target, PropertyKind::Key);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ReflectObject::prevent_extensions)

--- a/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -46,8 +46,10 @@ void SymbolConstructor::initialize(Interpreter& interpreter, GlobalObject& globa
     define_native_function("for", for_, 1, Attribute::Writable | Attribute::Configurable);
     define_native_function("keyFor", key_for, 1, Attribute::Writable | Attribute::Configurable);
 
-    for (auto& entry : interpreter.get_well_known_symbol_map({}))
-        define_property(entry.key, entry.value, 0);
+#define __JS_ENUMERATE(SymbolName, snake_name) \
+    define_property(#SymbolName, interpreter.well_known_symbol_##snake_name(), 0);
+    JS_ENUMERATE_WELL_KNOWN_SYMBOLS
+#undef __JS_ENUMERATE
 }
 
 SymbolConstructor::~SymbolConstructor()

--- a/Libraries/LibJS/Tests/builtins/Array/Array.prototype.values.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.prototype.values.js
@@ -1,0 +1,44 @@
+test("length", () => {
+    expect(Array.prototype.values.length).toBe(0);
+});
+
+test("basic functionality", () => {
+    const a = [1, 2, 3];
+    const it = a.values();
+    expect(it.next()).toEqual({ value: 1, done: false });
+    expect(it.next()).toEqual({ value: 2, done: false });
+    expect(it.next()).toEqual({ value: 3, done: false });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+});
+
+test("works when applied to non-object", () => {
+    [true, false, 9, 2n, Symbol()].forEach(primitive => {
+        const it = [].values.call(primitive);
+        expect(it.next()).toEqual({ value: undefined, done: true });
+        expect(it.next()).toEqual({ value: undefined, done: true });
+        expect(it.next()).toEqual({ value: undefined, done: true });
+    });
+});
+
+test("item added to array before exhaustion is accessible", () => {
+    const a = [1, 2];
+    const it = a.values();
+    expect(it.next()).toEqual({ value: 1, done: false });
+    expect(it.next()).toEqual({ value: 2, done: false });
+    a.push(3);
+    expect(it.next()).toEqual({ value: 3, done: false });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+});
+
+test("item added to array after exhaustion is inaccesible", () => {
+    const a = [1, 2];
+    const it = a.values();
+    expect(it.next()).toEqual({ value: 1, done: false });
+    expect(it.next()).toEqual({ value: 2, done: false });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+    a.push(3);
+    expect(it.next()).toEqual({ value: undefined, done: true });
+});

--- a/Libraries/LibJS/Tests/iterators/%IteratorPrototype%.js
+++ b/Libraries/LibJS/Tests/iterators/%IteratorPrototype%.js
@@ -1,0 +1,12 @@
+const getIteratorPrototype = () =>
+    Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+
+test("prototype of %IteratorPrototype% is %ObjectPrototype%", () => {
+    let itProto = getIteratorPrototype();
+    expect(Object.getPrototypeOf(itProto)).toBe(Object.getPrototypeOf({}));
+});
+
+test("@@iterator of %IteratorPrototype% is itself", () => {
+    let itProto = getIteratorPrototype();
+    expect(itProto[Symbol.iterator]()).toBe(itProto);
+});

--- a/Libraries/LibJS/Tests/iterators/array-iterator.js
+++ b/Libraries/LibJS/Tests/iterators/array-iterator.js
@@ -1,0 +1,48 @@
+test("length", () => {
+    expect(Array.prototype[Symbol.iterator].length).toBe(0);
+});
+
+test("same function as Array.prototype.values", () => {
+    expect(Array.prototype[Symbol.iterator]).toBe(Array.prototype.values);
+});
+
+test("basic functionality", () => {
+    const a = [1, 2, 3];
+    const it = a[Symbol.iterator]();
+    expect(it.next()).toEqual({ value: 1, done: false });
+    expect(it.next()).toEqual({ value: 2, done: false });
+    expect(it.next()).toEqual({ value: 3, done: false });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+});
+
+test("works when applied to non-object", () => {
+    [true, false, 9, 2n, Symbol()].forEach(primitive => {
+        const it = [][Symbol.iterator].call(primitive);
+        expect(it.next()).toEqual({ value: undefined, done: true });
+        expect(it.next()).toEqual({ value: undefined, done: true });
+        expect(it.next()).toEqual({ value: undefined, done: true });
+    });
+});
+
+test("item added to array before exhaustion is accessible", () => {
+    const a = [1, 2];
+    const it = a[Symbol.iterator]();
+    expect(it.next()).toEqual({ value: 1, done: false });
+    expect(it.next()).toEqual({ value: 2, done: false });
+    a.push(3);
+    expect(it.next()).toEqual({ value: 3, done: false });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+});
+
+test("item added to array after exhaustion is inaccesible", () => {
+    const a = [1, 2];
+    const it = a[Symbol.iterator]();
+    expect(it.next()).toEqual({ value: 1, done: false });
+    expect(it.next()).toEqual({ value: 2, done: false });
+    expect(it.next()).toEqual({ value: undefined, done: true });
+    a.push(3);
+    expect(it.next()).toEqual({ value: undefined, done: true });
+});


### PR DESCRIPTION
With the addition of symbol keys, work can now be done on starting to implement the well-known symbol functionality. The most important of these well-known symbols is by far `Symbol.iterator`.

This PR adds `IteratorPrototype`, as well as `ArrayIterator` and `ArrayIteratorPrototype`. In the future, sometime after `StringIterator` has also been added, this will allow us to use `Symbol.iterator` directly in `for..of` loops, enabling the use of custom iterator objects. Also makes adding iterator support to native objects much easier (as will have to be done for `Map` and `Set`, when they get added).