### PR TITLE
LibGUI: Multiple on_update handlers for Model

### DIFF
--- a/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Applications/Browser/BookmarksBarWidget.cpp
@@ -88,16 +88,20 @@ BookmarksBarWidget::BookmarksBarWidget(const String& bookmarks_file, bool enable
 
 BookmarksBarWidget::~BookmarksBarWidget()
 {
+    if (m_model)
+        m_model->unregister_update(m_model_update_id);
 }
 
 void BookmarksBarWidget::set_model(RefPtr<GUI::Model> model)
 {
     if (model == m_model)
         return;
+    if (m_model)
+        m_model->unregister_update(m_model_update_id);
     m_model = move(model);
-    m_model->on_update = [&]() {
+    m_model_update_id = m_model->register_update([&](unsigned) {
         did_update_model();
-    };
+    });
 }
 
 void BookmarksBarWidget::resize_event(GUI::ResizeEvent& event)

--- a/Applications/Browser/BookmarksBarWidget.h
+++ b/Applications/Browser/BookmarksBarWidget.h
@@ -58,6 +58,7 @@ private:
     void update_content_size();
 
     RefPtr<GUI::Model> m_model;
+    int m_model_update_id { 0 };
     RefPtr<GUI::Button> m_additional;
     RefPtr<GUI::Widget> m_separator;
     RefPtr<GUI::Menu> m_additional_menu;

--- a/Applications/FileManager/DirectoryView.h
+++ b/Applications/FileManager/DirectoryView.h
@@ -102,6 +102,7 @@ private:
     ViewMode m_view_mode { Invalid };
 
     NonnullRefPtr<GUI::FileSystemModel> m_model;
+    int m_model_update_id { 0 };
     size_t m_path_history_position { 0 };
     Vector<String> m_path_history;
     void add_path_to_history(const StringView& path);

--- a/Libraries/LibGUI/FilePicker.cpp
+++ b/Libraries/LibGUI/FilePicker.cpp
@@ -123,10 +123,10 @@ FilePicker::FilePicker(Mode mode, const StringView& file_name, const StringView&
     m_view->set_column_hidden(FileSystemModel::Column::SymlinkTarget, true);
     m_model->set_root_path(path);
 
-    m_model->on_update = [&] {
+    m_model_update_id = m_model->register_update([&](unsigned) {
         location_textbox.set_text(m_model->root_path());
         clear_preview();
-    };
+    });
 
     location_textbox.on_return_pressed = [&] {
         m_model->set_root_path(location_textbox.text());
@@ -270,6 +270,7 @@ FilePicker::FilePicker(Mode mode, const StringView& file_name, const StringView&
 
 FilePicker::~FilePicker()
 {
+    m_model->unregister_update(m_model_update_id);
 }
 
 void FilePicker::set_preview(const LexicalPath& path)

--- a/Libraries/LibGUI/FilePicker.h
+++ b/Libraries/LibGUI/FilePicker.h
@@ -71,6 +71,7 @@ private:
 
     RefPtr<MultiView> m_view;
     NonnullRefPtr<FileSystemModel> m_model;
+    int m_model_update_id { 0 };
     LexicalPath m_selected_file;
 
     RefPtr<TextBox> m_filename_textbox;

--- a/Libraries/LibGUI/Model.h
+++ b/Libraries/LibGUI/Model.h
@@ -95,7 +95,8 @@ public:
     void register_view(Badge<AbstractView>, AbstractView&);
     void unregister_view(Badge<AbstractView>, AbstractView&);
 
-    Function<void()> on_update;
+    int register_update(Function<void(unsigned)>);
+    void unregister_update(int);
 
 protected:
     Model();
@@ -107,6 +108,7 @@ protected:
 
 private:
     HashTable<AbstractView*> m_views;
+    Vector<Function<void(unsigned)>> m_on_update;
 };
 
 inline ModelIndex ModelIndex::parent() const

--- a/Libraries/LibGUI/ModelSelection.cpp
+++ b/Libraries/LibGUI/ModelSelection.cpp
@@ -38,8 +38,11 @@ void ModelSelection::remove_matching(Function<bool(const ModelIndex&)> filter)
         if (filter(index))
             to_remove.append(index);
     }
-    for (auto& index : to_remove)
-        m_indexes.remove(index);
+    if (!to_remove.is_empty()) {
+        for (auto& index : to_remove)
+            m_indexes.remove(index);
+        m_view.notify_selection_changed({});
+    }
 }
 
 void ModelSelection::set(const ModelIndex& index)

--- a/Libraries/LibGUI/SortingProxyModel.h
+++ b/Libraries/LibGUI/SortingProxyModel.h
@@ -58,17 +58,21 @@ private:
     Model& target() { return *m_target; }
     const Model& target() const { return *m_target; }
 
+    void check_if_cache_needs_update() const;
     void resort();
 
     void set_sorting_case_sensitive(bool b) { m_sorting_case_sensitive = b; }
     bool is_sorting_case_sensitive() { return m_sorting_case_sensitive; }
 
     NonnullRefPtr<Model> m_target;
+    int m_target_update_id { 0 };
     Vector<int> m_row_mappings;
     int m_key_column { -1 };
     SortOrder m_sort_order { SortOrder::Ascending };
     Role m_sort_role { Role::Sort };
     bool m_sorting_case_sensitive { false };
+    bool m_need_to_update_cache { true };
+    bool m_sorting { false };
 };
 
 }


### PR DESCRIPTION
This solves a problem where the SortingProxyModel doesn't
receive the on_update call because other code overwrote
the handler later on.

Also, SortingProxyModel needs to lazily re-populate its
cache. Doing so in the on_update handler may not have any
items available yet, so merely flag it to require another
resort/cache update when accessed again.