### PR TITLE
AK: Add template argument to all uses of Json{Array,Object}Serializer

### DIFF
--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -96,7 +96,7 @@ private:
 template<typename Builder>
 inline void JsonArray::serialize(Builder& builder) const
 {
-    JsonArraySerializer serializer { builder };
+    JsonArraySerializer<Builder> serializer { builder };
     for_each([&](auto& value) { serializer.add(value); });
 }
 

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -129,7 +129,7 @@ private:
 template<typename Builder>
 inline void JsonObject::serialize(Builder& builder) const
 {
-    JsonObjectSerializer serializer { builder };
+    JsonObjectSerializer<Builder> serializer { builder };
     for_each_member([&](auto& key, auto& value) {
         serializer.add(key, value);
     });

--- a/AK/JsonObjectSerializer.h
+++ b/AK/JsonObjectSerializer.h
@@ -130,13 +130,13 @@ public:
     JsonArraySerializer<Builder> add_array(const StringView& key)
     {
         begin_item(key);
-        return JsonArraySerializer(m_builder);
+        return JsonArraySerializer<Builder>(m_builder);
     }
 
     JsonObjectSerializer<Builder> add_object(const StringView& key)
     {
         begin_item(key);
-        return JsonObjectSerializer(m_builder);
+        return JsonObjectSerializer<Builder>(m_builder);
     }
 
     void finish()
@@ -167,7 +167,7 @@ template<typename Builder>
 JsonObjectSerializer<Builder> JsonArraySerializer<Builder>::add_object()
 {
     begin_item();
-    return JsonObjectSerializer(m_builder);
+    return JsonObjectSerializer<Builder>(m_builder);
 }
 
 }


### PR DESCRIPTION
This makes AK/Json* build properly from "outside" Serenity, i.e. by using Serenity's CMake toolchain file. Without these changes it would fail with "missing template arguments" errors.

---

Disclaimer: I have absolutely no idea what I'm doing, this was all trial and error. Serenity was building fine and still is, but any attempt to `#include <AK/JsonObject.h>` would result in a flood of errors when building something for Serenity but from the outside:

```
[ 50%] Building CXX object CMakeFiles/FooProject.dir/src/main.cpp.obj
In file included from /home/linus/Dev/git/serenity/Build/Root/usr/include/AK/JsonObject.h:30,
                 from /home/linus/Dev/git/FooProject/src/main.cpp:1:
/home/linus/Dev/git/serenity/Build/Root/usr/include/AK/JsonArray.h: In member function 'void AK::JsonArray::serialize(Builder&) const':
/home/linus/Dev/git/serenity/Build/Root/usr/include/AK/JsonArray.h:99:25: error: missing template arguments before 'serializer'
   99 |     JsonArraySerializer serializer { builder };
      |                         ^~~~~~~~~~
```