### PR TITLE
LibGUI: Improve Iconview selection performance

### DIFF
--- a/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Applications/Browser/BookmarksBarWidget.cpp
@@ -88,16 +88,18 @@ BookmarksBarWidget::BookmarksBarWidget(const String& bookmarks_file, bool enable
 
 BookmarksBarWidget::~BookmarksBarWidget()
 {
+    if (m_model)
+        m_model->unregister_client(*this);
 }
 
 void BookmarksBarWidget::set_model(RefPtr<GUI::Model> model)
 {
     if (model == m_model)
         return;
+    if (m_model)
+        m_model->unregister_client(*this);
     m_model = move(model);
-    m_model->on_update = [&]() {
-        did_update_model();
-    };
+    m_model->register_client(*this);
 }
 
 void BookmarksBarWidget::resize_event(GUI::ResizeEvent& event)
@@ -106,7 +108,7 @@ void BookmarksBarWidget::resize_event(GUI::ResizeEvent& event)
     update_content_size();
 }
 
-void BookmarksBarWidget::did_update_model()
+void BookmarksBarWidget::on_model_update(unsigned)
 {
     for (auto* child : child_widgets()) {
         child->remove_from_parent();

--- a/Applications/Browser/BookmarksBarWidget.h
+++ b/Applications/Browser/BookmarksBarWidget.h
@@ -27,11 +27,13 @@
 #pragma once
 
 #include <LibGUI/Forward.h>
+#include <LibGUI/Model.h>
 #include <LibGUI/Widget.h>
 
 namespace Browser {
 
-class BookmarksBarWidget final : public GUI::Widget {
+class BookmarksBarWidget final : public GUI::Widget
+    , private GUI::ModelClient {
     C_OBJECT(BookmarksBarWidget)
 public:
     static BookmarksBarWidget& the();
@@ -52,7 +54,7 @@ public:
 private:
     BookmarksBarWidget(const String&, bool enabled);
 
-    virtual void did_update_model();
+    virtual void on_model_update(unsigned) override;
     virtual void resize_event(GUI::ResizeEvent&) override;
 
     void update_content_size();

--- a/Applications/FileManager/DirectoryView.cpp
+++ b/Applications/FileManager/DirectoryView.cpp
@@ -95,16 +95,7 @@ DirectoryView::DirectoryView()
             on_path_change(model().root_path());
     };
 
-    //  NOTE: We're using the on_update hook on the GUI::SortingProxyModel here instead of
-    //        the GUI::FileSystemModel's hook. This is because GUI::SortingProxyModel has already
-    //        installed an on_update hook on the GUI::FileSystemModel internally.
-    // FIXME: This is an unfortunate design. We should come up with something better.
-    m_table_view->model()->on_update = [this] {
-        for_each_view_implementation([](auto& view) {
-            view.selection().clear();
-        });
-        update_statusbar();
-    };
+    m_model->register_client(*this);
 
     m_model->on_thumbnail_progress = [this](int done, int total) {
         if (on_thumbnail_progress)
@@ -169,6 +160,17 @@ DirectoryView::DirectoryView()
 
 DirectoryView::~DirectoryView()
 {
+    m_model->unregister_client(*this);
+}
+
+void DirectoryView::on_model_update(unsigned flags)
+{
+    if (flags & GUI::Model::UpdateFlag::InvalidateAllIndexes) {
+        for_each_view_implementation([](auto& view) {
+            view.selection().clear();
+        });
+    }
+    update_statusbar();
 }
 
 void DirectoryView::set_view_mode(ViewMode mode)

--- a/Applications/FileManager/DirectoryView.h
+++ b/Applications/FileManager/DirectoryView.h
@@ -34,7 +34,8 @@
 #include <LibGUI/TableView.h>
 #include <sys/stat.h>
 
-class DirectoryView final : public GUI::StackWidget {
+class DirectoryView final : public GUI::StackWidget
+    , private GUI::ModelClient {
     C_OBJECT(DirectoryView)
 public:
     virtual ~DirectoryView() override;
@@ -93,6 +94,8 @@ public:
 private:
     DirectoryView();
     const GUI::FileSystemModel& model() const { return *m_model; }
+
+    virtual void on_model_update(unsigned) override;
 
     void handle_activation(const GUI::ModelIndex&);
 

--- a/Libraries/LibGUI/AbstractView.cpp
+++ b/Libraries/LibGUI/AbstractView.cpp
@@ -375,4 +375,16 @@ void AbstractView::drop_event(DropEvent& event)
         on_drop(index, event);
 }
 
+void AbstractView::set_multi_select(bool multi_select)
+{
+    if (m_multi_select == multi_select)
+        return;
+    m_multi_select = multi_select;
+    if (!multi_select && m_selection.size() > 1) {
+        auto first_selected = m_selection.first();
+        m_selection.clear();
+        m_selection.set(first_selected);
+    }
+}
+
 }

--- a/Libraries/LibGUI/AbstractView.cpp
+++ b/Libraries/LibGUI/AbstractView.cpp
@@ -65,10 +65,35 @@ void AbstractView::did_update_model(unsigned flags)
     m_edit_index = {};
     m_hovered_index = {};
     if (!model() || (flags & GUI::Model::InvalidateAllIndexes)) {
-        selection().clear();
+        clear_selection();
     } else {
         selection().remove_matching([this](auto& index) { return !model()->is_valid(index); });
     }
+}
+
+void AbstractView::clear_selection()
+{
+    m_selection.clear();
+}
+
+void AbstractView::set_selection(const ModelIndex& new_index)
+{
+    m_selection.set(new_index);
+}
+
+void AbstractView::add_selection(const ModelIndex& new_index)
+{
+    m_selection.add(new_index);
+}
+
+void AbstractView::remove_selection(const ModelIndex& new_index)
+{
+    m_selection.remove(new_index);
+}
+
+void AbstractView::toggle_selection(const ModelIndex& new_index)
+{
+    m_selection.toggle(new_index);
 }
 
 void AbstractView::did_update_selection()
@@ -182,14 +207,14 @@ void AbstractView::mousedown_event(MouseEvent& event)
     m_might_drag = false;
 
     if (!index.is_valid()) {
-        m_selection.clear();
+        clear_selection();
     } else if (event.modifiers() & Mod_Ctrl) {
-        m_selection.toggle(index);
+        toggle_selection(index);
     } else if (event.button() == MouseButton::Left && m_selection.contains(index) && !m_model->drag_data_type().is_null()) {
         // We might be starting a drag, so don't throw away other selected items yet.
         m_might_drag = true;
     } else {
-        m_selection.set(index);
+        set_selection(index);
     }
 
     update();
@@ -294,9 +319,9 @@ void AbstractView::mouseup_event(MouseEvent& event)
         // Since we're here, it was not that; so fix up the selection now.
         auto index = index_at_event_position(event.position());
         if (index.is_valid())
-            m_selection.set(index);
+            set_selection(index);
         else
-            m_selection.clear();
+            clear_selection();
         m_might_drag = false;
         update();
     }
@@ -315,9 +340,9 @@ void AbstractView::doubleclick_event(MouseEvent& event)
     auto index = index_at_event_position(event.position());
 
     if (!index.is_valid())
-        m_selection.clear();
+        clear_selection();
     else if (!m_selection.contains(index))
-        m_selection.set(index);
+        set_selection(index);
 
     activate_selected();
 }
@@ -330,9 +355,9 @@ void AbstractView::context_menu_event(ContextMenuEvent& event)
     auto index = index_at_event_position(event.position());
 
     if (index.is_valid())
-        m_selection.add(index);
+        add_selection(index);
     else
-        selection().clear();
+        clear_selection();
 
     if (on_context_menu_request)
         on_context_menu_request(index, event);

--- a/Libraries/LibGUI/AbstractView.h
+++ b/Libraries/LibGUI/AbstractView.h
@@ -47,6 +47,9 @@ public:
     bool is_editable() const { return m_editable; }
     void set_editable(bool editable) { m_editable = editable; }
 
+    bool is_multi_select() const { return m_multi_select; }
+    void set_multi_select(bool);
+
     virtual bool accepts_focus() const override { return true; }
     virtual void did_update_model(unsigned flags);
     virtual void did_update_selection();
@@ -110,6 +113,7 @@ private:
     OwnPtr<ModelEditingDelegate> m_editing_delegate;
     ModelSelection m_selection;
     bool m_activates_on_selection { false };
+    bool m_multi_select { true };
 };
 
 }

--- a/Libraries/LibGUI/AbstractView.h
+++ b/Libraries/LibGUI/AbstractView.h
@@ -83,6 +83,12 @@ protected:
     virtual void drop_event(DropEvent&) override;
     virtual void leave_event(Core::Event&) override;
 
+    virtual void clear_selection();
+    virtual void set_selection(const ModelIndex&);
+    virtual void add_selection(const ModelIndex&);
+    virtual void remove_selection(const ModelIndex&);
+    virtual void toggle_selection(const ModelIndex&);
+
     virtual void did_scroll() override;
     void set_hovered_index(const ModelIndex&);
     void activate(const ModelIndex&);

--- a/Libraries/LibGUI/FilePicker.h
+++ b/Libraries/LibGUI/FilePicker.h
@@ -31,10 +31,11 @@
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/Dialog.h>
 #include <LibGUI/Image.h>
+#include <LibGUI/Model.h>
 
 namespace GUI {
 
-class FilePicker final : public Dialog {
+class FilePicker final : public Dialog, private ModelClient {
     C_OBJECT(FilePicker)
 public:
     enum class Mode {
@@ -55,6 +56,8 @@ private:
     void clear_preview();
     void on_file_return();
 
+    virtual void on_model_update(unsigned) override;
+
     FilePicker(Mode type = Mode::Open, const StringView& file_name = "Untitled", const StringView& path = Core::StandardPaths::home_directory(), Window* parent_window = nullptr);
 
     static String ok_button_name(Mode mode)
@@ -74,6 +77,7 @@ private:
     LexicalPath m_selected_file;
 
     RefPtr<TextBox> m_filename_textbox;
+    RefPtr<TextBox> m_location_textbox;
     RefPtr<Frame> m_preview_container;
     RefPtr<Image> m_preview_image;
     RefPtr<Label> m_preview_name_label;

--- a/Libraries/LibGUI/FilePicker.h
+++ b/Libraries/LibGUI/FilePicker.h
@@ -40,11 +40,21 @@ class FilePicker final : public Dialog, private ModelClient {
 public:
     enum class Mode {
         Open,
+        OpenMultiple,
         Save
     };
 
-    static Optional<String> get_open_filepath(const String& window_title = {});
-    static Optional<String> get_save_filepath(const String& title, const String& extension);
+    enum class Options : unsigned {
+        None = 0,
+        DisablePreview = (1 << 0)
+    };
+
+    static Optional<String> get_open_filepath(Options options)
+    {
+        return get_open_filepath({}, options);
+    }
+    static Optional<String> get_open_filepath(const String& window_title = {}, Options options = Options::None);
+    static Optional<String> get_save_filepath(const String& title, const String& extension, Options options = Options::None);
     static bool file_exists(const StringView& path);
 
     virtual ~FilePicker() override;
@@ -52,18 +62,20 @@ public:
     LexicalPath selected_file() const { return m_selected_file; }
 
 private:
+    bool have_preview() const { return m_preview_container; }
     void set_preview(const LexicalPath&);
     void clear_preview();
     void on_file_return();
 
     virtual void on_model_update(unsigned) override;
 
-    FilePicker(Mode type = Mode::Open, const StringView& file_name = "Untitled", const StringView& path = Core::StandardPaths::home_directory(), Window* parent_window = nullptr);
+    FilePicker(Mode type = Mode::Open, Options = Options::None, const StringView& file_name = "Untitled", const StringView& path = Core::StandardPaths::home_directory(), Window* parent_window = nullptr);
 
     static String ok_button_name(Mode mode)
     {
         switch (mode) {
         case Mode::Open:
+        case Mode::OpenMultiple:
             return "Open";
         case Mode::Save:
             return "Save";

--- a/Libraries/LibGUI/Forward.h
+++ b/Libraries/LibGUI/Forward.h
@@ -61,6 +61,7 @@ class Painter;
 class ResizeCorner;
 class ScrollBar;
 class Slider;
+class SortingProxyModel;
 class SpinBox;
 class Splitter;
 class StackWidget;

--- a/Libraries/LibGUI/IconView.cpp
+++ b/Libraries/LibGUI/IconView.cpp
@@ -221,9 +221,11 @@ void IconView::mousedown_event(MouseEvent& event)
     auto adjusted_position = to_content_position(event.position());
 
     m_might_drag = false;
-    m_rubber_banding = true;
-    m_rubber_band_origin = adjusted_position;
-    m_rubber_band_current = adjusted_position;
+    if (is_multi_select()) {
+        m_rubber_banding = true;
+        m_rubber_band_origin = adjusted_position;
+        m_rubber_band_current = adjusted_position;
+    }
 }
 
 void IconView::mouseup_event(MouseEvent& event)

--- a/Libraries/LibGUI/Model.cpp
+++ b/Libraries/LibGUI/Model.cpp
@@ -55,8 +55,9 @@ void Model::for_each_view(Function<void(AbstractView&)> callback)
 
 void Model::did_update(unsigned flags)
 {
-    if (on_update)
-        on_update();
+    for (auto* client : m_clients)
+        client->on_model_update(flags);
+
     for_each_view([&](auto& view) {
         view.did_update_model(flags);
     });
@@ -80,6 +81,16 @@ ModelIndex Model::sibling(int row, int column, const ModelIndex& parent) const
 bool Model::accepts_drag(const ModelIndex&, const StringView&)
 {
     return false;
+}
+
+void Model::register_client(ModelClient& client)
+{
+    m_clients.set(&client);
+}
+
+void Model::unregister_client(ModelClient& client)
+{
+    m_clients.remove(&client);
 }
 
 }

--- a/Libraries/LibGUI/Model.h
+++ b/Libraries/LibGUI/Model.h
@@ -44,6 +44,13 @@ enum class SortOrder {
     Descending
 };
 
+class ModelClient {
+public:
+    virtual ~ModelClient() { }
+
+    virtual void on_model_update(unsigned flags) = 0;
+};
+
 class Model : public RefCounted<Model> {
 public:
     enum UpdateFlag {
@@ -95,7 +102,8 @@ public:
     void register_view(Badge<AbstractView>, AbstractView&);
     void unregister_view(Badge<AbstractView>, AbstractView&);
 
-    Function<void()> on_update;
+    void register_client(ModelClient&);
+    void unregister_client(ModelClient&);
 
 protected:
     Model();
@@ -107,6 +115,7 @@ protected:
 
 private:
     HashTable<AbstractView*> m_views;
+    HashTable<ModelClient*> m_clients;
 };
 
 inline ModelIndex ModelIndex::parent() const

--- a/Libraries/LibGUI/ModelSelection.cpp
+++ b/Libraries/LibGUI/ModelSelection.cpp
@@ -38,8 +38,11 @@ void ModelSelection::remove_matching(Function<bool(const ModelIndex&)> filter)
         if (filter(index))
             to_remove.append(index);
     }
-    for (auto& index : to_remove)
-        m_indexes.remove(index);
+    if (!to_remove.is_empty()) {
+        for (auto& index : to_remove)
+            m_indexes.remove(index);
+        notify_selection_changed();
+    }
 }
 
 void ModelSelection::set(const ModelIndex& index)
@@ -49,7 +52,7 @@ void ModelSelection::set(const ModelIndex& index)
         return;
     m_indexes.clear();
     m_indexes.set(index);
-    m_view.notify_selection_changed({});
+    notify_selection_changed();
 }
 
 void ModelSelection::add(const ModelIndex& index)
@@ -58,7 +61,7 @@ void ModelSelection::add(const ModelIndex& index)
     if (m_indexes.contains(index))
         return;
     m_indexes.set(index);
-    m_view.notify_selection_changed({});
+    notify_selection_changed();
 }
 
 void ModelSelection::toggle(const ModelIndex& index)
@@ -68,7 +71,7 @@ void ModelSelection::toggle(const ModelIndex& index)
         m_indexes.remove(index);
     else
         m_indexes.set(index);
-    m_view.notify_selection_changed({});
+    notify_selection_changed();
 }
 
 bool ModelSelection::remove(const ModelIndex& index)
@@ -77,7 +80,7 @@ bool ModelSelection::remove(const ModelIndex& index)
     if (!m_indexes.contains(index))
         return false;
     m_indexes.remove(index);
-    m_view.notify_selection_changed({});
+    notify_selection_changed();
     return true;
 }
 
@@ -86,7 +89,17 @@ void ModelSelection::clear()
     if (m_indexes.is_empty())
         return;
     m_indexes.clear();
-    m_view.notify_selection_changed({});
+    notify_selection_changed();
+}
+
+void ModelSelection::notify_selection_changed()
+{
+    if (!m_disable_notify) {
+        m_view.notify_selection_changed({});
+        m_notify_pending = false;
+    } else {
+        m_notify_pending = true;
+    }
 }
 
 }

--- a/Libraries/LibGUI/ModelSelection.h
+++ b/Libraries/LibGUI/ModelSelection.h
@@ -26,7 +26,9 @@
 
 #pragma once
 
+#include <AK/Badge.h>
 #include <AK/HashTable.h>
+#include <AK/TemporaryChange.h>
 #include <AK/Vector.h>
 #include <LibGUI/ModelIndex.h>
 
@@ -91,9 +93,25 @@ public:
 
     void remove_matching(Function<bool(const ModelIndex&)>);
 
+    template<typename Function>
+    void change_from_model(Badge<SortingProxyModel>, Function f)
+    {
+        {
+            TemporaryChange change(m_disable_notify, true);
+            m_notify_pending = false;
+            f(*this);
+        }
+        if (m_notify_pending)
+            notify_selection_changed();
+    }
+
 private:
+    void notify_selection_changed();
+
     AbstractView& m_view;
     HashTable<ModelIndex> m_indexes;
+    bool m_disable_notify { false };
+    bool m_notify_pending { false };
 };
 
 }

--- a/Libraries/LibGUI/MultiView.cpp
+++ b/Libraries/LibGUI/MultiView.cpp
@@ -108,6 +108,7 @@ MultiView::MultiView()
 
     build_actions();
     set_view_mode(ViewMode::Icon);
+    apply_multi_select();
 }
 
 MultiView::~MultiView()
@@ -192,6 +193,23 @@ void MultiView::build_actions()
 #ifdef MULTIVIEW_WITH_COLUMNSVIEW
     m_view_type_action_group->add_action(*m_view_as_columns_action);
 #endif
+}
+
+void MultiView::apply_multi_select()
+{
+    m_table_view->set_multi_select(m_multi_select);
+    m_icon_view->set_multi_select(m_multi_select);
+#ifdef MULTIVIEW_WITH_COLUMNSVIEW
+    //m_columns_view->set_multi_select(m_multi_select);
+#endif
+}
+
+void MultiView::set_multi_select(bool multi_select)
+{
+    if (m_multi_select == multi_select)
+        return;
+    m_multi_select = multi_select;
+    apply_multi_select();
 }
 
 }

--- a/Libraries/LibGUI/MultiView.h
+++ b/Libraries/LibGUI/MultiView.h
@@ -103,10 +103,14 @@ public:
     Action& view_as_columns_action() { return *m_view_as_columns_action; }
 #endif
 
+    bool is_multi_select() const { return m_multi_select; }
+    void set_multi_select(bool);
+
 private:
     MultiView();
 
     void build_actions();
+    void apply_multi_select();
 
     ViewMode m_view_mode { Invalid };
     int m_model_column { 0 };
@@ -126,6 +130,8 @@ private:
 #endif
 
     OwnPtr<ActionGroup> m_view_type_action_group;
+
+    bool m_multi_select { true };
 };
 
 }

--- a/Libraries/LibGUI/SortingProxyModel.h
+++ b/Libraries/LibGUI/SortingProxyModel.h
@@ -30,7 +30,8 @@
 
 namespace GUI {
 
-class SortingProxyModel final : public Model {
+class SortingProxyModel final : public Model
+    , private ModelClient {
 public:
     static NonnullRefPtr<SortingProxyModel> create(NonnullRefPtr<Model>&& model) { return adopt(*new SortingProxyModel(move(model))); }
     virtual ~SortingProxyModel() override;
@@ -55,10 +56,12 @@ public:
 private:
     explicit SortingProxyModel(NonnullRefPtr<Model>&&);
 
+    virtual void on_model_update(unsigned) override;
+
     Model& target() { return *m_target; }
     const Model& target() const { return *m_target; }
 
-    void resort();
+    void resort(unsigned flags = Model::UpdateFlag::DontInvalidateIndexes);
 
     void set_sorting_case_sensitive(bool b) { m_sorting_case_sensitive = b; }
     bool is_sorting_case_sensitive() { return m_sorting_case_sensitive; }
@@ -69,6 +72,7 @@ private:
     SortOrder m_sort_order { SortOrder::Ascending };
     Role m_sort_role { Role::Sort };
     bool m_sorting_case_sensitive { false };
+    bool m_sorting { false };
 };
 
 }


### PR DESCRIPTION
This implements the following optimizations:

* Rather than clearing a HashTable of selected items and re-populating
  it every time the selection rectangle changes, determine the delta
  by only examining the items that might be in the area where the
  selection may have changed compared to the previous area. Then
  only add/remove selection items as needed.

* When painting, only query and paint the items actually visible.
  Also, keep a local cache of item information such as calculated
  rectangles and selection state, so it doesn't have to be calculated
  over and over again.

Watch the CPU graph on the top right. The CPU usage on the previous implementation spiked very quickly and the system becomes laggy once the mouse is moved around rather quickly.

Before:
![iconview_selection_before](https://user-images.githubusercontent.com/10320822/87224757-07d85800-c345-11ea-9d3d-4a6d9effdb44.gif)

After:
![iconview_selection_after](https://user-images.githubusercontent.com/10320822/87224778-41a95e80-c345-11ea-80c1-239b3c99e8c1.gif)

