### PR TITLE
LibJS: Remove a few superfluous exception checks

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1777,9 +1777,6 @@ Value TaggedTemplateLiteral::execute(Interpreter& interpreter, GlobalObject& glo
         raw_strings->indexed_properties().append(value);
     }
     strings->define_property("raw", raw_strings, 0);
-    if (interpreter.exception())
-        return {};
-
     return interpreter.call(tag_function, js_undefined(), move(arguments));
 }
 

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -174,9 +174,9 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::map)
     auto* new_array = Array::create(global_object);
     new_array->indexed_properties().set_array_like_size(initial_length);
     for_each_item(interpreter, global_object, "map", [&](auto index, auto, auto callback_result) {
-        new_array->put(index, callback_result);
         if (interpreter.exception())
             return IterationDecision::Break;
+        new_array->put(index, callback_result);
         return IterationDecision::Continue;
     });
     return Value(new_array);

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -195,11 +195,7 @@ Value Object::get_own_properties(const Object& this_object, GetOwnPropertyReturn
             } else {
                 auto* entry_array = Array::create(global_object());
                 entry_array->define_property(0, js_string(interpreter(), String::number(i)));
-                if (interpreter().exception())
-                    return {};
                 entry_array->define_property(1, js_string(interpreter(), String::format("%c", str[i])));
-                if (interpreter().exception())
-                    return {};
                 properties_array->define_property(i, entry_array);
             }
             if (interpreter().exception())
@@ -222,11 +218,7 @@ Value Object::get_own_properties(const Object& this_object, GetOwnPropertyReturn
         } else {
             auto* entry_array = Array::create(global_object());
             entry_array->define_property(0, js_string(interpreter(), String::number(entry.index())));
-            if (interpreter().exception())
-                return {};
             entry_array->define_property(1, value_and_attributes.value);
-            if (interpreter().exception())
-                return {};
             properties_array->define_property(property_index, entry_array);
         }
         if (interpreter().exception())
@@ -251,11 +243,7 @@ Value Object::get_own_properties(const Object& this_object, GetOwnPropertyReturn
         } else {
             auto* entry_array = Array::create(global_object());
             entry_array->define_property(0, it.key.to_value(interpreter()));
-            if (interpreter().exception())
-                return {};
             entry_array->define_property(1, this_object.get(it.key));
-            if (interpreter().exception())
-                return {};
             properties_array->define_property(property_index, entry_array);
         }
         if (interpreter().exception())


### PR DESCRIPTION
We don't need to check for exceptions when defining properties on an array we literally created ourselves a few lines earlier.