### PR TITLE
LibGUI: Fix keyboard shortcut conflicts in TreeView

### DIFF
--- a/Libraries/LibGUI/TreeView.cpp
+++ b/Libraries/LibGUI/TreeView.cpp
@@ -110,13 +110,16 @@ void TreeView::doubleclick_event(MouseEvent& event)
 
 void TreeView::set_open_state_of_all_in_subtree(const ModelIndex& root, bool open)
 {
-    if (root.is_valid())
+    if (root.is_valid()) {
         ensure_metadata_for_index(root).open = open;
+        if (model()->row_count(root)) {
+            if (on_toggle)
+                on_toggle(root, open);
+        }
+    }
     int row_count = model()->row_count(root);
     int column = model()->tree_column();
     for (int row = 0; row < row_count; ++row) {
-        if (on_toggle)
-            on_toggle(root, open);
         auto index = model()->index(row, column, root);
         set_open_state_of_all_in_subtree(index, open);
     }

--- a/Libraries/LibGUI/TreeView.cpp
+++ b/Libraries/LibGUI/TreeView.cpp
@@ -469,7 +469,7 @@ void TreeView::keydown_event(KeyEvent& event)
 
     if (event.key() == KeyCode::Key_Left) {
         if (cursor_index.is_valid() && model()->row_count(cursor_index)) {
-            if (event.alt()) {
+            if (event.ctrl()) {
                 collapse_tree(cursor_index);
                 return;
             }
@@ -489,7 +489,7 @@ void TreeView::keydown_event(KeyEvent& event)
 
     if (event.key() == KeyCode::Key_Right) {
         if (cursor_index.is_valid() && model()->row_count(cursor_index)) {
-            if (event.alt()) {
+            if (event.ctrl()) {
                 expand_tree(cursor_index);
                 return;
             }


### PR DESCRIPTION
Changes the shortcut to expand and collapse subtrees from alt to ctrl+right/left arrows. Current shortcut conflicts with navigation controls in file manager and causes erratic behavior.