### PR TITLE
LibJS: Implement Symbol.toStringTag

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
@@ -42,6 +42,8 @@ void ArrayIteratorPrototype::initialize(Interpreter& interpreter, GlobalObject& 
 {
     Object::initialize(interpreter, global_object);
     define_native_function("next", next, 0, Attribute::Writable | Attribute::Configurable);
+
+    define_property(interpreter.well_known_symbol_to_string_tag(), js_string(interpreter, "Array Iterator"), Attribute::Configurable);
 }
 
 ArrayIteratorPrototype::~ArrayIteratorPrototype()

--- a/Libraries/LibJS/Runtime/BigIntPrototype.cpp
+++ b/Libraries/LibJS/Runtime/BigIntPrototype.cpp
@@ -44,6 +44,8 @@ void BigIntPrototype::initialize(Interpreter& interpreter, GlobalObject& global_
     define_native_function("toString", to_string, 0, attr);
     define_native_function("toLocaleString", to_locale_string, 0, attr);
     define_native_function("valueOf", value_of, 0, attr);
+
+    define_property(interpreter.well_known_symbol_to_string_tag(), js_string(interpreter, "BigInt"), Attribute::Configurable);
 }
 
 BigIntPrototype::~BigIntPrototype()

--- a/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -48,6 +48,8 @@ void JSONObject::initialize(Interpreter& interpreter, GlobalObject& global_objec
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function("stringify", stringify, 3, attr);
     define_native_function("parse", parse, 2, attr);
+
+    define_property(interpreter.well_known_symbol_to_string_tag(), js_string(interpreter, "JSON"), Attribute::Configurable);
 }
 
 JSONObject::~JSONObject()

--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -74,6 +74,8 @@ void MathObject::initialize(Interpreter& interpreter, GlobalObject& global_objec
     define_property("PI", Value(M_PI), 0);
     define_property("SQRT1_2", Value(M_SQRT1_2), 0);
     define_property("SQRT2", Value(M_SQRT2), 0);
+
+    define_property(interpreter.well_known_symbol_to_string_tag(), js_string(interpreter, "Math"), Attribute::Configurable);
 }
 
 MathObject::~MathObject()

--- a/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -68,10 +68,43 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::has_own_property)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::to_string)
 {
-    auto* this_object = interpreter.this_value(global_object).to_object(interpreter, global_object);
+    auto this_value = interpreter.this_value(global_object);
+
+    if (this_value.is_undefined())
+        return js_string(interpreter, "[object Undefined]");
+    if (this_value.is_null())
+        return js_string(interpreter, "[object Null]");
+
+    auto* this_object = this_value.to_object(interpreter, global_object);
     if (!this_object)
         return {};
-    return js_string(interpreter, String::format("[object %s]", this_object->class_name()));
+
+    String tag;
+    auto to_string_tag = this_object->get(interpreter.well_known_symbol_to_string_tag());
+    
+    if (to_string_tag.is_string()) {
+        tag = to_string_tag.as_string().string();
+    } else if (this_object->is_array()) {
+        tag = "Array";
+    } else if (this_object->is_function()) {
+        tag = "Function";
+    } else if (this_object->is_error()) {
+        tag = "Error";
+    } else if (this_object->is_boolean_object()) {
+        tag = "Boolean";
+    } else if (this_object->is_number_object()) {
+        tag = "Number";
+    } else if (this_object->is_string_object()) {
+        tag = "String";
+    } else if (this_object->is_date()) {
+        tag = "Date";
+    } else if (this_object->is_regexp_object()) {
+        tag = "RegExp";
+    } else {
+        tag = "Object";
+    }
+
+    return js_string(interpreter, String::format("[object %s]", tag.characters()));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::to_locale_string)

--- a/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Libraries/LibJS/Runtime/ProxyObject.h
@@ -64,8 +64,8 @@ public:
 private:
     virtual void visit_children(Visitor&) override;
     virtual bool is_proxy_object() const override { return true; }
-    virtual bool is_function() const override { return m_target.is_function(); }
 
+    virtual bool is_function() const override { return m_target.is_function(); }
     virtual bool is_array() const override { return m_target.is_array(); };
 
     Object& m_target;

--- a/Libraries/LibJS/Runtime/SymbolPrototype.cpp
+++ b/Libraries/LibJS/Runtime/SymbolPrototype.cpp
@@ -50,6 +50,8 @@ void SymbolPrototype::initialize(Interpreter& interpreter, GlobalObject& global_
     define_native_property("description", description_getter, nullptr, Attribute::Configurable);
     define_native_function("toString", to_string, 0, Attribute::Writable | Attribute::Configurable);
     define_native_function("valueOf", value_of, 0, Attribute::Writable | Attribute::Configurable);
+
+    define_property(interpreter.well_known_symbol_to_string_tag(), js_string(interpreter, "Symbol"), Attribute::Configurable);
 }
 
 SymbolPrototype::~SymbolPrototype()

--- a/Libraries/LibJS/Tests/builtins/Array/Array.prototype.toLocaleString.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.prototype.toLocaleString.js
@@ -16,9 +16,7 @@ describe("normal behavior", () => {
     });
 
     test("number stringification differs from regular toString, for now", () => {
-        expect([1, 2, 3].toLocaleString()).toBe(
-            "[object NumberObject],[object NumberObject],[object NumberObject]"
-        );
+        expect([1, 2, 3].toLocaleString()).toBe("[object Number],[object Number],[object Number]");
     });
 
     test("null and undefined result in empty strings", () => {

--- a/Libraries/LibJS/Tests/builtins/BigInt/BigInt.prototype.@@toStringTag.js
+++ b/Libraries/LibJS/Tests/builtins/BigInt/BigInt.prototype.@@toStringTag.js
@@ -1,0 +1,3 @@
+test("basic functionality", () => {
+    expect(BigInt.prototype[Symbol.toStringTag]).toBe("BigInt");
+});

--- a/Libraries/LibJS/Tests/builtins/JSON/JSON.@@toStringTag.js
+++ b/Libraries/LibJS/Tests/builtins/JSON/JSON.@@toStringTag.js
@@ -1,0 +1,4 @@
+test("basic functionality", () => {
+    expect(JSON[Symbol.toStringTag]).toBe("JSON");
+    expect(JSON.toString()).toBe("[object JSON]");
+});

--- a/Libraries/LibJS/Tests/builtins/Math/Math.@@toStringTag.js
+++ b/Libraries/LibJS/Tests/builtins/Math/Math.@@toStringTag.js
@@ -1,0 +1,4 @@
+test("basic functionality", () => {
+    expect(Math[Symbol.toStringTag]).toBe("Math");
+    expect(Math.toString()).toBe("[object Math]");
+});

--- a/Libraries/LibJS/Tests/builtins/Object/Object.prototype.toString.js
+++ b/Libraries/LibJS/Tests/builtins/Object/Object.prototype.toString.js
@@ -1,8 +1,18 @@
-test("basic functionality", () => {
+test("length", () => {
     expect(Object.prototype.toString).toHaveLength(0);
-    // FIXME: The tag is ObjectPrototype, but should be Object
-    // expect(Object.prototype.toString()).toBe("[object Object]");
-    expect({ foo: 1 }.toString()).toBe("[object Object]");
-    expect([].toString()).toBe("");
-    expect(Object.prototype.toString.call([])).toBe("[object Array]");
+});
+
+test("result for various object types", () => {
+    const oToString = o => Object.prototype.toString.call(o);
+
+    expect(oToString(undefined)).toBe("[object Undefined]");
+    expect(oToString(null)).toBe("[object Null]");
+    expect(oToString([])).toBe("[object Array]");
+    expect(oToString(function () {})).toBe("[object Function]");
+    expect(oToString(new Error())).toBe("[object Error]");
+    expect(oToString(new Boolean())).toBe("[object Boolean]");
+    expect(oToString(new Number())).toBe("[object Number]");
+    expect(oToString(new Date())).toBe("[object Date]");
+    expect(oToString(new RegExp())).toBe("[object RegExp]");
+    expect(oToString({})).toBe("[object Object]");
 });

--- a/Libraries/LibJS/Tests/builtins/Symbol/Symbol.prototype.@@toStringTag.js
+++ b/Libraries/LibJS/Tests/builtins/Symbol/Symbol.prototype.@@toStringTag.js
@@ -1,0 +1,3 @@
+test("basic functionality", () => {
+    expect(Symbol.prototype[Symbol.toStringTag]).toBe("Symbol");
+});

--- a/Libraries/LibJS/Tests/custom-@@toStringTag.js
+++ b/Libraries/LibJS/Tests/custom-@@toStringTag.js
@@ -1,0 +1,26 @@
+test("inside objects", () => {
+    const o = {
+        [Symbol.toStringTag]: "hello friends",
+    };
+
+    expect(o.toString()).toBe("[object hello friends]");
+});
+
+test("inside classes", () => {
+    class A {
+        constructor() {
+            this[Symbol.toStringTag] = "hello friends";
+        }
+    }
+
+    const a = new A();
+    expect(a.toString()).toBe("[object hello friends]");
+});
+
+test("non-string values are ignored", () => {
+    const o = {
+        [Symbol.toStringTag]: [1, 2, 3],
+    };
+
+    expect(o.toString()).toBe("[object Object]");
+});

--- a/Libraries/LibJS/Tests/iterators/array-iterator.js
+++ b/Libraries/LibJS/Tests/iterators/array-iterator.js
@@ -2,6 +2,11 @@ test("length", () => {
     expect(Array.prototype[Symbol.iterator].length).toBe(0);
 });
 
+test("@@toStringTag", () => {
+    expect([].values()[Symbol.toStringTag]).toBe("Array Iterator");
+    expect([].values().toString()).toBe("[object Array Iterator]");
+});
+
 test("same function as Array.prototype.values", () => {
     expect(Array.prototype[Symbol.iterator]).toBe(Array.prototype.values);
 });


### PR DESCRIPTION
This PR changes `Object.prototype.toString` to be spec-compliant, and implements `Symbol.toStringTag` into objects where necessary.