### PR TITLE
ProcFS: JSONify /proc/cpuinfo

### DIFF
--- a/Applications/SystemMonitor/ProcessModel.h
+++ b/Applications/SystemMonitor/ProcessModel.h
@@ -89,14 +89,12 @@ public:
     virtual GUI::Variant data(const GUI::ModelIndex&, Role = Role::Display) const override;
     virtual void update() override;
 
-    struct CpuInfo
-    {
+    struct CpuInfo {
         u32 id;
-        float total_cpu_percent{0.0};
-        HashMap<String, String> values;
-        
-        CpuInfo(u32 id):
-            id(id)
+        float total_cpu_percent { 0.0 };
+
+        CpuInfo(u32 id)
+            : id(id)
         {
         }
     };

--- a/Ports/neofetch/patches/add-serenity-support.patch
+++ b/Ports/neofetch/patches/add-serenity-support.patch
@@ -110,11 +110,11 @@
          ;;
 +
 +        "SerenityOS")
-+            while IFS=":" read -r a b; do
-+                case $a in
-+                    "brandstr") cpu="${b//\"}" ;;
-+                esac
-+            done < /proc/cpuinfo
++            # while IFS=":" read -r a b; do
++            #     case $a in
++            #         "brandstr") cpu="${b//\"}" ;;
++            #     esac
++            # done < /proc/cpuinfo
 +            # `cpu` will contain "@ [speed]GHz" and to be super correct we
 +            # have to cut that off and store it in `speed` only for neofetch
 +            # to append it again later - but that's fine for now this way.


### PR DESCRIPTION
To be more in line with other parts of Serenity's procfs, the "key: value" format of `/proc/cpuinfo` was replaced with JSON, namely an array of objects (one for each core).

The available keys remain the same, though "features" has been changed from a space-separated string to an array of strings.

SystemMonitor has been updated to parse `/proc/cpuinfo` as JSON. CPU detection in neofetch is disabled for now until we can come up with a good JSON parsing tool for the shell.

![image](https://user-images.githubusercontent.com/19366641/87233365-89200100-c3be-11ea-85ea-1702b1b10c17.png)