### PR TITLE
 Shell: Add a 'for' loop 

### DIFF
--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -578,6 +578,24 @@ private:
     int dest_fd { -1 };
 };
 
+class ForLoop final : public Node {
+public:
+    ForLoop(Position, String variable_name, RefPtr<AST::Node> iterated_expr, RefPtr<AST::Node> block, Optional<size_t> in_kw_position = {});
+    virtual ~ForLoop();
+
+private:
+    virtual void dump(int level) const override;
+    virtual RefPtr<Value> run(RefPtr<Shell>) override;
+    virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
+    virtual HitTestResult hit_test_position(size_t) override;
+    virtual String class_name() const override { return "ForLoop"; }
+
+    String m_variable_name;
+    RefPtr<AST::Node> m_iterated_expression;
+    RefPtr<AST::Node> m_block;
+    Optional<size_t> m_in_kw_position;
+};
+
 class Glob final : public Node {
 public:
     Glob(Position, String);

--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -164,6 +164,7 @@ public:
     virtual bool is_job() const { return false; }
     virtual bool is_list() const { return false; }
     virtual bool is_string() const { return false; }
+    virtual bool is_list_without_resolution() const { return false; }
 };
 
 class CommandValue final : public Value {
@@ -221,13 +222,17 @@ private:
 class ListValue final : public Value {
 public:
     virtual Vector<String> resolve_as_list(RefPtr<Shell>) override;
+    virtual RefPtr<Value> resolve_without_cast(RefPtr<Shell>) override;
     virtual ~ListValue();
     virtual bool is_list() const override { return true; }
+    virtual bool is_list_without_resolution() const override { return true; }
     ListValue(Vector<String> values);
     ListValue(Vector<RefPtr<Value>> values)
         : m_contained_values(move(values))
     {
     }
+
+    const Vector<RefPtr<Value>>& values() const { return m_contained_values; }
 
 private:
     Vector<RefPtr<Value>> m_contained_values;
@@ -389,7 +394,7 @@ private:
 
 class ListConcatenate final : public Node {
 public:
-    ListConcatenate(Position, RefPtr<Node>, RefPtr<Node>);
+    ListConcatenate(Position, Vector<RefPtr<Node>>);
     virtual ~ListConcatenate();
 
 private:
@@ -401,8 +406,7 @@ private:
     virtual bool is_list() const override { return true; }
     virtual RefPtr<Node> leftmost_trivial_literal() const override;
 
-    RefPtr<Node> m_element;
-    RefPtr<Node> m_list;
+    Vector<RefPtr<Node>> m_list;
 };
 
 class Background final : public Node {

--- a/Shell/Parser.cpp
+++ b/Shell/Parser.cpp
@@ -420,19 +420,19 @@ RefPtr<AST::Node> Parser::parse_list_expression()
     consume_while(is_whitespace);
 
     auto rule_start = push_start();
+    Vector<RefPtr<AST::Node>> nodes;
 
-    auto expr = parse_expression();
-    if (!expr)
+    do {
+        auto expr = parse_expression();
+        if (!expr)
+            break;
+        nodes.append(move(expr));
+    } while (!consume_while(is_whitespace).is_empty());
+
+    if (nodes.is_empty())
         return nullptr;
 
-    if (consume_while(is_whitespace).is_empty())
-        return expr;
-
-    auto list = parse_list_expression();
-    if (!list)
-        return create<AST::CastToList>(move(expr));
-
-    return create<AST::ListConcatenate>(move(expr), move(list)); // Join Element List
+    return create<AST::ListConcatenate>(move(nodes)); // Concatenate List
 }
 
 RefPtr<AST::Node> Parser::parse_expression()

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -318,10 +318,21 @@ String Shell::resolve_path(String path) const
     return Core::File::real_path_for(path);
 }
 
+Shell::LocalFrame* Shell::find_frame_containing_local_variable(const String& name)
+{
+    for (auto& frame : m_local_frames) {
+        if (frame.local_variables.contains(name))
+            return &frame;
+    }
+    return nullptr;
+}
+
 RefPtr<AST::Value> Shell::lookup_local_variable(const String& name)
 {
-    auto value = m_local_variables.get(name).value_or(nullptr);
-    return value;
+    if (auto* frame = find_frame_containing_local_variable(name))
+        return frame->local_variables.get(name).value();
+
+    return nullptr;
 }
 
 String Shell::local_variable_or(const String& name, const String& replacement)
@@ -337,12 +348,36 @@ String Shell::local_variable_or(const String& name, const String& replacement)
 
 void Shell::set_local_variable(const String& name, RefPtr<AST::Value> value)
 {
-    m_local_variables.set(name, move(value));
+    if (auto* frame = find_frame_containing_local_variable(name))
+        frame->local_variables.set(name, move(value));
+    else
+        m_local_frames.last().local_variables.set(name, move(value));
 }
 
 void Shell::unset_local_variable(const String& name)
 {
-    m_local_variables.remove(name);
+    if (auto* frame = find_frame_containing_local_variable(name))
+        frame->local_variables.remove(name);
+}
+
+Shell::Frame Shell::push_frame()
+{
+    m_local_frames.empend();
+    return { m_local_frames, m_local_frames.last() };
+}
+
+void Shell::pop_frame()
+{
+    ASSERT(m_local_frames.size() > 1);
+    m_local_frames.take_last();
+}
+
+Shell::Frame::~Frame()
+{
+    if (!should_destroy_frame)
+        return;
+    ASSERT(&frames.last() == &frame);
+    frames.take_last();
 }
 
 String Shell::resolve_alias(const String& name) const
@@ -876,9 +911,11 @@ Vector<Line::CompletionSuggestion> Shell::complete_variable(const String& name, 
     editor->suggest(offset);
 
     // Look at local variables.
-    for (auto& variable : m_local_variables) {
-        if (variable.key.starts_with(pattern))
-            suggestions.append(variable.key);
+    for (auto& frame : m_local_frames) {
+        for (auto& variable : frame.local_variables) {
+            if (variable.key.starts_with(pattern) && !suggestions.contains_slow(variable.key))
+                suggestions.append(variable.key);
+        }
     }
 
     // Look at the environment.
@@ -1011,6 +1048,8 @@ Shell::Shell()
     uid = getuid();
     tcsetpgrp(0, getpgrp());
     m_pid = getpid();
+
+    push_frame().leak_frame();
 
     int rc = gethostname(hostname, Shell::HostNameSize);
     if (rc < 0)

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -360,18 +360,18 @@ int Shell::run_command(const StringView& cmd)
     if (!command)
         return 0;
 
-    if (command->is_syntax_error()) {
-        auto& error_node = command->syntax_error_node();
-        auto& position = error_node.position();
-        fprintf(stderr, "Shell: Syntax error in command: %s\n", error_node.error_text().characters());
-        fprintf(stderr, "Around '%.*s'\n", (int)min(position.end_offset - position.start_offset, (size_t)10), cmd.characters_without_null_termination() + position.start_offset);
-        return 1;
-    }
-
 #ifdef SH_DEBUG
     dbg() << "Command follows";
     command->dump(0);
 #endif
+
+    if (command->is_syntax_error()) {
+        auto& error_node = command->syntax_error_node();
+        auto& position = error_node.position();
+        fprintf(stderr, "Shell: Syntax error in command: %s\n", error_node.error_text().characters());
+        fprintf(stderr, "Around '%.*s' at %zu:%zu\n", (int)min(position.end_offset - position.start_offset, (size_t)10), cmd.characters_without_null_termination() + position.start_offset, position.start_offset, position.end_offset);
+        return 1;
+    }
 
     tcgetattr(0, &termios);
 

--- a/Shell/Tests/loop.sh
+++ b/Shell/Tests/loop.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+singlecommand_ok=yes
+multicommand_ok=yes
+inlineexec_ok=yes
+implicit_ok=yes
+
+# Full form
+ # Empty
+for x in () { }
+
+ # Empty block but nonempty list
+for x in (1 2 3) { }
+
+ # Single command in block
+for cmd in ((test 1 = 1) (test 2 = 2)) {
+    $cmd || unset singlecommand_ok
+}
+
+ # Multiple commands in block
+for cmd in ((test 1 = 1) (test 2 = 2)) {
+    test -z "$cmd"
+    test -z "$cmd" && unset multicommand_ok
+
+}
+
+ # $(...) as iterable expression
+test_file=sh-test-1
+echo 1 > $test_file
+echo 2 >> $test_file
+echo 3 >> $test_file
+echo 4 >> $test_file
+lst=()
+for line in $(cat $test_file) {
+    lst=($lst $line)
+}
+test "$lst" = "1 2 3 4" || unset inlineexec_ok
+rm $test_file
+
+# Implicit var
+for ((test 1 = 1) (test 2 = 2)) {
+    $it || unset implicit_ok
+}
+
+test $singlecommand_ok || echo Fail: Single command inside for body
+test $multicommand_ok || echo Fail: Multiple commands inside for body
+test $inlineexec_ok || echo Fail: Inline Exec
+test $implicit_ok || echo Fail: implicit iter variable
+
+test "$singlecommand_ok $multicommand_ok $inlineexec_ok $implicit_ok" = "yes yes yes yes" || exit 1


### PR DESCRIPTION
Closes #2760.

The syntax I went with is:
- `for <expr> { sequence }`
- `for <ident> in <expr> { sequence }`

the braces are mandatory, and in the first one, the value is implicitly called `it`.
This PR also adds variable frames, because a proper language is a good language :^)