### PR TITLE
LibJS: Integrate Symbol.hasInstance

### DIFF
--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -43,7 +43,7 @@
     M(ForOfNotIterable, "for..of right-hand side must be iterable")                                    \
     M(FunctionArgsNotObject, "Argument array must be an object")                                       \
     M(InOperatorWithObject, "'in' operator must be used on an object")                                 \
-    M(InstanceOfOperatorBadPrototype, "Prototype property of %s is not an object")                     \
+    M(InstanceOfOperatorBadPrototype, "'prototype' property of %s is not an object")                   \
     M(InvalidAssignToConst, "Invalid assignment to const variable")                                    \
     M(InvalidLeftHandAssignment, "Invalid left-hand side in assignment")                               \
     M(IsNotA, "%s is not a %s")                                                                        \

--- a/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -51,6 +51,7 @@ void FunctionPrototype::initialize(Interpreter& interpreter, GlobalObject& globa
     define_native_function("bind", bind, 1, attr);
     define_native_function("call", call, 1, attr);
     define_native_function("toString", to_string, 0, attr);
+    define_native_function(interpreter.well_known_symbol_has_instance(), symbol_has_instance, 1, 0);
     define_property("length", Value(0), Attribute::Configurable);
     define_property("name", js_string(heap(), ""), Attribute::Configurable);
 }
@@ -165,6 +166,17 @@ JS_DEFINE_NATIVE_FUNCTION(FunctionPrototype::to_string)
         function_parameters.characters(),
         function_body.characters());
     return js_string(interpreter, function_source);
+}
+
+JS_DEFINE_NATIVE_FUNCTION(FunctionPrototype::symbol_has_instance)
+{
+    auto* this_object = interpreter.this_value(global_object).to_object(interpreter, global_object);
+    if (!this_object)
+        return {};
+    if (!this_object->is_function())
+        return interpreter.throw_exception<TypeError>(ErrorType::NotA, "Function");
+
+    return ordinary_has_instance(interpreter, interpreter.argument(0), this_object);
 }
 
 }

--- a/Libraries/LibJS/Runtime/FunctionPrototype.h
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.h
@@ -43,6 +43,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(bind);
     JS_DECLARE_NATIVE_FUNCTION(call);
     JS_DECLARE_NATIVE_FUNCTION(to_string);
+    JS_DECLARE_NATIVE_FUNCTION(symbol_has_instance);
 };
 
 }

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -323,6 +323,7 @@ Value mod(Interpreter&, Value lhs, Value rhs);
 Value exp(Interpreter&, Value lhs, Value rhs);
 Value in(Interpreter&, Value lhs, Value rhs);
 Value instance_of(Interpreter&, Value lhs, Value rhs);
+Value ordinary_has_instance(Interpreter& interpreter, Value lhs, Value rhs);
 
 bool abstract_eq(Interpreter&, Value lhs, Value rhs);
 bool strict_eq(Interpreter&, Value lhs, Value rhs);

--- a/Libraries/LibJS/Tests/builtins/Function/Function.prototype.@@hasInstance.js
+++ b/Libraries/LibJS/Tests/builtins/Function/Function.prototype.@@hasInstance.js
@@ -1,0 +1,8 @@
+test("basic functionality", () => {
+    expect(Function.prototype[Symbol.hasInstance]).toHaveLength(1);
+
+    function Foo() {}
+    const foo = new Foo();
+
+    expect(Function.prototype[Symbol.hasInstance].call(Foo, foo)).toBeTrue();
+});

--- a/Libraries/LibJS/Tests/custom-@@hasInstance.js
+++ b/Libraries/LibJS/Tests/custom-@@hasInstance.js
@@ -1,0 +1,9 @@
+test("basic functionality", () => {
+    function Foo() {}
+    Foo[Symbol.hasInstance] = value => {
+        return value === 2;
+    };
+
+    expect(new Foo() instanceof Foo).toBeFalse();
+    expect(2 instanceof Foo).toBeTrue();
+});


### PR DESCRIPTION
Introduces a spec-compliant `instanceof` operation, and implements `Symbol.hasInstance` where necessary (only in `FunctionPrototype`). Allows functions to have custom control over the behavior of `instanceof`.