### PR TITLE
Ports: Use "jq" in neofetch for /proc/{cpuinfo,memstat}

### DIFF
--- a/Ports/neofetch/package.sh
+++ b/Ports/neofetch/package.sh
@@ -2,5 +2,5 @@
 port=neofetch
 version=7.0.0
 useconfigure=false
-depends=bash
+depends="bash jq"
 files="https://github.com/dylanaraps/neofetch/archive/${version}.tar.gz neofetch-${version}.tar.gz"

--- a/Ports/neofetch/patches/add-serenity-support.patch
+++ b/Ports/neofetch/patches/add-serenity-support.patch
@@ -1,5 +1,5 @@
 --- neofetch-7.0.0/neofetch	2020-03-08 10:23:36.000000000 +0000
-+++ neofetch-7.0.0/neofetch	2020-07-11 22:28:44.926009278 +0100
++++ neofetch-7.0.0/neofetch	2020-07-12 00:42:11.171106931 +0100
 @@ -775,7 +775,7 @@
  #       PostMarketOS, Proxmox, Puppy, PureOS, Qubes, Radix, Raspbian,
  #       Reborn_OS, Redstar, Redcore, Redhat, Refracted_Devuan, Regata,
@@ -104,17 +104,13 @@
  
              # Get CPU speed.
              if [[ -d "$speed_dir" ]]; then
-@@ -2201,6 +2212,17 @@
+@@ -2201,6 +2212,13 @@
              cpu="$(awk -F':' '/CPU:/ {printf $2}' /kern/cpuinfo)"
              speed="$(awk -F '[:.M]' '/Clocking:/ {printf $2}' /kern/cpuinfo)"
          ;;
 +
 +        "SerenityOS")
-+            # while IFS=":" read -r a b; do
-+            #     case $a in
-+            #         "brandstr") cpu="${b//\"}" ;;
-+            #     esac
-+            # done < /proc/cpuinfo
++            cpu="$(jq -r '.[0].brandstr' /proc/cpuinfo)"
 +            # `cpu` will contain "@ [speed]GHz" and to be super correct we
 +            # have to cut that off and store it in `speed` only for neofetch
 +            # to append it again later - but that's fine for now this way.
@@ -122,24 +118,23 @@
      esac
  
      # Remove un-needed patterns from cpu output.
-@@ -2585,6 +2607,16 @@
+@@ -2585,6 +2603,15 @@
              mem_used="$((mem_used / 1024))"
          ;;
  
 +        "SerenityOS")
-+            while IFS=":" read -d "," -r a b; do
-+                case $a in
-+                    "\"user_physical_allocated\"") mem_used="$((b * 4096 / 1024 / 1024))" ;;
-+                    "\"user_physical_available\"") mem_free="$((b * 4096 / 1024 / 1024))" ;;
-+                esac
-+            done < /proc/memstat
++            memstat="$(cat /proc/memstat)"
++            user_physical_allocated="$(echo $memstat | jq .user_physical_allocated)"
++            user_physical_available="$(echo $memstat | jq .user_physical_available)"
++            mem_used="$((user_physical_allocated * 4096 / 1024 / 1024))"
++            mem_free="$((user_physical_available * 4096 / 1024 / 1024))"
 +            mem_total="$((mem_used + mem_free))"
 +        ;;
 +
      esac
  
      [[ "$memory_percent" == "on" ]] && ((mem_perc=mem_used * 100 / mem_total))
-@@ -3027,6 +3059,13 @@
+@@ -3027,6 +3054,13 @@
              theme="${theme/ '[Plasma]'}"
          fi
      fi
@@ -153,15 +148,15 @@
  }
  
  get_theme() {
-@@ -3035,6 +3074,7 @@
+@@ -3035,6 +3069,7 @@
      gconf="gtk_theme"
      xfconf="/Net/ThemeName"
      kde="Name"
-+    serenity="Name"
++    serenity=
  
      get_style
  }
-@@ -3045,6 +3085,7 @@
+@@ -3045,6 +3080,7 @@
      gconf="icon_theme"
      xfconf="/Net/IconThemeName"
      kde="Theme"
@@ -169,7 +164,7 @@
  
      get_style
      icons="$theme"
-@@ -3074,6 +3115,8 @@
+@@ -3074,6 +3110,8 @@
          *)              term="${TERM_PROGRAM/\.app}" ;;
      esac
  
@@ -178,7 +173,7 @@
      # Most likely TosWin2 on FreeMiNT - quick check
      [[ "$TERM" == "tw52" || "$TERM" == "tw100" ]] && term="TosWin2"
      [[ "$SSH_CONNECTION" ]] && term="$SSH_TTY"
-@@ -3637,10 +3680,10 @@
+@@ -3637,10 +3675,10 @@
  }
  
  get_public_ip() {
@@ -193,7 +188,7 @@
  
      if [[ -z "$public_ip" ]] && type -p drill >/dev/null; then
          public_ip="$(drill myip.opendns.com @resolver1.opendns.com | \
-@@ -3785,13 +3828,13 @@
+@@ -3785,13 +3823,13 @@
  }
  
  print_ascii() {
@@ -214,7 +209,7 @@
  
      # Set locale to get correct padding.
      LC_ALL="$sys_locale"
-@@ -4549,8 +4592,8 @@
+@@ -4549,8 +4587,8 @@
              padding=${xrdb/*internalBorder:}
              padding=${padding/$'\n'*}
  
@@ -225,7 +220,7 @@
          ;;
      esac
  }
-@@ -4834,7 +4877,7 @@
+@@ -4834,7 +4872,7 @@
                                  PostMarketOS, Proxmox, Puppy, PureOS, Qubes, Radix, Raspbian,
                                  Reborn_OS, Redstar, Redcore, Redhat, Refracted_Devuan, Regata,
                                  Rosa, sabotage, Sabayon, Sailfish, SalentOS, Scientific, Septor,
@@ -234,7 +229,7 @@
                                  Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
                                  openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
                                  Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE, Ubuntu-Studio, Ubuntu,
-@@ -9097,6 +9140,34 @@
+@@ -9097,6 +9135,34 @@
  EOF
          ;;
  


### PR DESCRIPTION
Now that a "jq" port is available we can re-enable CPU name detection in neofetch and don't need to use "read" for extracting values from `/proc/memstat` anymore :^)