### PR TITLE
Shell: Put children in their own process groups and fix job control 

### DIFF
--- a/Shell/Job.h
+++ b/Shell/Job.h
@@ -75,6 +75,11 @@ public:
     bool should_be_disowned() const { return m_should_be_disowned; }
     void disown() { m_should_be_disowned = true; }
     bool is_running_in_background() const { return m_running_in_background; }
+    void unblock() const
+    {
+        if (!m_exited && on_exit)
+            on_exit(*this);
+    }
     Function<void(RefPtr<Job>)> on_exit;
 
     Core::ElapsedTimer& timer() { return m_command_timer; }

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -435,6 +435,7 @@ RefPtr<Job> Shell::run_command(AST::Command& command)
         return nullptr;
     }
     if (child == 0) {
+        setpgid(0, 0);
         tcsetattr(0, TCSANOW, &default_termios);
         for (auto& rewiring : rewirings) {
 #ifdef SH_DEBUG
@@ -484,6 +485,8 @@ RefPtr<Job> Shell::run_command(AST::Command& command)
     jobs.set((u64)child, job);
 
     job->on_exit = [](auto job) {
+        if (!job->exited())
+            return;
         if (job->is_running_in_background())
             fprintf(stderr, "Shell: Job %d(%s) exited\n", job->pid(), job->cmd().characters());
         job->disown();
@@ -516,6 +519,8 @@ void Shell::restore_stdin()
 
 void Shell::block_on_job(RefPtr<Job> job)
 {
+    TemporaryChange<const Job*> current_job { m_current_job, job.ptr() };
+
     if (!job)
         return;
 
@@ -969,18 +974,10 @@ void Shell::stop_all_jobs()
 #ifdef SH_DEBUG
                 dbg() << "Job " << entry.value->pid() << " is not running in background";
 #endif
-                if (killpg(entry.value->pgid(), SIGCONT) < 0) {
-                    perror("killpg(CONT)");
-                }
+                kill_job(entry.value, SIGCONT);
             }
 
-            if (killpg(entry.value->pgid(), SIGHUP) < 0) {
-                perror("killpg(HUP)");
-            }
-
-            if (killpg(entry.value->pgid(), SIGTERM) < 0) {
-                perror("killpg(TERM)");
-            }
+            kill_job(entry.value, SIGHUP);
         }
 
         usleep(10000); // Wait for a bit before killing the job
@@ -1015,6 +1012,15 @@ const Job* Shell::find_job(u64 id)
             return entry.value;
     }
     return nullptr;
+}
+
+void Shell::kill_job(const Job* job, int sig)
+{
+    if (!job)
+        return;
+
+    if (killpg(job->pgid(), sig) < 0)
+        perror("killpg(job)");
 }
 
 void Shell::save_to(JsonObject& object)

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -109,6 +109,8 @@ public:
 
     u64 find_last_job_id() const;
     const Job* find_job(u64 id);
+    const Job* current_job() const { return m_current_job; }
+    void kill_job(const Job*, int sig);
 
     String get_history_path();
     void load_history();
@@ -161,6 +163,7 @@ private:
 
     void cache_path();
     void stop_all_jobs();
+    const Job* m_current_job { nullptr };
 
     virtual void custom_event(Core::CustomEvent&) override;
 


### PR DESCRIPTION
This commit fixes job control by putting children in their own process
group, and proxying TTY signals to active jobs.
This also cleans up the code around builtin_disown a bit to use
the newer job interfaces.