### PR TITLE
Shell: Resolve aliases in builtin_time

### DIFF
--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -77,7 +77,7 @@ struct Rewiring : public RefCounted<Rewiring> {
 };
 
 struct Redirection : public RefCounted<Redirection> {
-    virtual Result<RefPtr<Rewiring>, String> apply() = 0;
+    virtual Result<RefPtr<Rewiring>, String> apply() const = 0;
     virtual ~Redirection();
     virtual bool is_path_redirection() const { return false; }
     virtual bool is_fd_redirection() const { return false; }
@@ -87,7 +87,7 @@ struct Redirection : public RefCounted<Redirection> {
 struct CloseRedirection : public Redirection {
     int fd { -1 };
 
-    virtual Result<RefPtr<Rewiring>, String> apply() override;
+    virtual Result<RefPtr<Rewiring>, String> apply() const override;
     virtual ~CloseRedirection();
     CloseRedirection(int fd)
         : fd(fd)
@@ -108,7 +108,7 @@ struct PathRedirection : public Redirection {
         ReadWrite,
     } direction { Read };
 
-    virtual Result<RefPtr<Rewiring>, String> apply() override;
+    virtual Result<RefPtr<Rewiring>, String> apply() const override;
     virtual ~PathRedirection();
     PathRedirection(String path, int fd, decltype(direction) direction)
         : path(move(path))
@@ -124,7 +124,7 @@ private:
 struct FdRedirection : public Redirection
     , public Rewiring {
 
-    virtual Result<RefPtr<Rewiring>, String> apply() override { return static_cast<RefPtr<Rewiring>>(this); }
+    virtual Result<RefPtr<Rewiring>, String> apply() const override { return static_cast<RefPtr<Rewiring>>(this); }
     virtual ~FdRedirection();
     FdRedirection(int source, int dest, Rewiring::Close close)
         : Rewiring(source, dest, close)

--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -698,14 +698,17 @@ int Shell::builtin_time(int argc, const char** argv)
     for (auto& arg : args)
         command.argv.append(arg);
 
+    auto commands = expand_aliases({ move(command) });
+
     Core::ElapsedTimer timer;
+    int exit_code = 1;
     timer.start();
-    auto job = run_command(command);
-    if (!job)
-        return 1;
-    block_on_job(job);
+    for (auto& job : run_commands(commands)) {
+        block_on_job(job);
+        exit_code = job->exit_code();
+    }
     fprintf(stderr, "Time: %d ms\n", timer.elapsed());
-    return job->exit_code();
+    return exit_code;
 }
 
 int Shell::builtin_umask(int argc, const char** argv)

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -73,7 +73,8 @@ public:
     constexpr static auto global_init_file_path = "/etc/shellrc";
 
     int run_command(const StringView&);
-    RefPtr<Job> run_command(AST::Command&);
+    RefPtr<Job> run_command(const AST::Command&);
+    Vector<RefPtr<Job>> run_commands(Vector<AST::Command>&);
     bool run_file(const String&, bool explicitly_invoked = true);
     bool run_builtin(int argc, const char** argv, int& retval);
     bool has_builtin(const StringView&) const;
@@ -83,6 +84,7 @@ public:
     static String expand_tilde(const String&);
     static Vector<String> expand_globs(const StringView& path, StringView base);
     static Vector<String> expand_globs(Vector<StringView> path_segments, const StringView& base);
+    Vector<AST::Command> expand_aliases(Vector<AST::Command>);
     String resolve_path(String) const;
     String resolve_alias(const String&) const;
 


### PR DESCRIPTION
This moves out a bunch of execution stuff to Shell and makes builtin_time resolve aliases.

It should be noted that time will respect the Background nodes and not wait for them, this is not necessarily correct according to other shells.
According to bash and zsh:

```sh
alias foo='ls&'
time foo .
# Tries to execute two commands, 'time ls&' and '.'
```
since we treat aliases as "splice into command sequence" rather than "text replace", we would see this behaviour:

```sh
alias foo='ls&'
time foo .
# times the execution of 'ls .&'
```

I personally do not see this as being wrong, but other opinions would be helpful.