### PR TITLE
Shell: Avoid waiting for jobs that were *just* unblocked

### DIFF
--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -93,6 +93,7 @@ int Shell::builtin_bg(int argc, const char** argv)
     }
 
     job->set_running_in_background(true);
+    job->set_is_suspended(false);
 
     dbg() << "Resuming " << job->pid() << " (" << job->cmd() << ")";
     fprintf(stderr, "Resuming job %" PRIu64 " - %s\n", job->job_id(), job->cmd().characters());
@@ -339,6 +340,7 @@ int Shell::builtin_fg(int argc, const char** argv)
     }
 
     job->set_running_in_background(false);
+    job->set_is_suspended(false);
 
     dbg() << "Resuming " << job->pid() << " (" << job->cmd() << ")";
     fprintf(stderr, "Resuming job %" PRIu64 " - %s\n", job->job_id(), job->cmd().characters());

--- a/Shell/Job.h
+++ b/Shell/Job.h
@@ -75,6 +75,7 @@ public:
     bool should_be_disowned() const { return m_should_be_disowned; }
     void disown() { m_should_be_disowned = true; }
     bool is_running_in_background() const { return m_running_in_background; }
+    bool is_suspended() const { return m_is_suspended; }
     void unblock() const
     {
         if (!m_exited && on_exit)
@@ -94,6 +95,8 @@ public:
             on_exit(*this);
     }
 
+    void set_is_suspended(bool value) const { m_is_suspended = value; }
+
     void set_running_in_background(bool running_in_background)
     {
         m_running_in_background = running_in_background;
@@ -111,5 +114,6 @@ private:
     int m_exit_code { -1 };
     Core::ElapsedTimer m_command_timer;
     mutable bool m_active { true };
+    mutable bool m_is_suspended { false };
     bool m_should_be_disowned { false };
 };

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -561,16 +561,18 @@ Vector<RefPtr<Job>> Shell::run_commands(Vector<AST::Command>& commands)
         }
 #endif
         auto job = run_command(command);
+        if (!job)
+            continue;
 
         if (command.should_wait) {
             block_on_job(job);
-            jobs_to_wait_for.append(job);
+            if (!job->is_suspended())
+                jobs_to_wait_for.append(job);
         } else {
             if (command.is_pipe_source) {
                 jobs_to_wait_for.append(job);
             } else if (command.should_notify_if_in_background) {
-                if (job)
-                    job->set_running_in_background(true);
+                job->set_running_in_background(true);
                 restore_stdin();
             }
         }

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -121,8 +121,10 @@ int main(int argc, char** argv)
     Core::EventLoop::register_signal(SIGTSTP, [](auto) {
         auto job = s_shell->current_job();
         s_shell->kill_job(job, SIGTSTP);
-        if (job)
+        if (job) {
+            job->set_is_suspended(true);
             job->unblock();
+        }
     });
 
 #ifndef __serenity__


### PR DESCRIPTION
This fixes the issue with C-z not suspending the job on the first try.
...and further signal issues when the suspended job is continued.

Super smart guy figures out a way to wait for a job he just let go of~