### PR TITLE
LibJS: Integrate iterator protocol into language features

### DIFF
--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -40,7 +40,6 @@
     M(Convert, "Cannot convert %s to %s")                                                              \
     M(ConvertUndefinedToObject, "Cannot convert undefined to object")                                  \
     M(DescChangeNonConfigurable, "Cannot change attributes of non-configurable property '%s'")         \
-    M(ForOfNotIterable, "for..of right-hand side must be iterable")                                    \
     M(FunctionArgsNotObject, "Argument array must be an object")                                       \
     M(InOperatorWithObject, "'in' operator must be used on an object")                                 \
     M(InstanceOfOperatorBadPrototype, "Prototype property of %s is not an object")                     \
@@ -48,6 +47,9 @@
     M(InvalidLeftHandAssignment, "Invalid left-hand side in assignment")                               \
     M(IsNotA, "%s is not a %s")                                                                        \
     M(IsNotAEvaluatedFrom, "%s is not a %s (evaluated from '%s')")                                     \
+    M(IterableNextBadReturn, "iterator.next() returned a non-object value")                            \
+    M(IterableNextNotAFunction, "'next' property on returned object from Symbol.iterator method is "   \
+        "not a function")                                                                              \
     M(JsonBigInt, "Cannot serialize BigInt value to JSON")                                             \
     M(JsonCircular, "Cannot stringify circular object")                                                \
     M(JsonMalformed, "Malformed JSON string")                                                          \

--- a/Libraries/LibJS/Runtime/IteratorOperations.h
+++ b/Libraries/LibJS/Runtime/IteratorOperations.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Function.h>
 #include <LibJS/Runtime/Object.h>
 
 namespace JS {
@@ -33,13 +34,13 @@ namespace JS {
 // Common iterator operations defined in ECMA262 7.4
 // https://tc39.es/ecma262/#sec-operations-on-iterator-objects
 
-Object* get_iterator(Object& obj, String hint = "sync", Value method = {});
+Object* get_iterator(GlobalObject&, Value value, String hint = "sync", Value method = {});
 bool is_iterator_complete(Object& iterator_result);
 Value create_iterator_result_object(Interpreter&, GlobalObject&, Value value, bool done);
 
-Value iterator_next(Object& iterator, Value value = {});
-Value iterator_value(Object& iterator_result);
-Value iterator_step(Object& iterator);
+Object* iterator_next(Object& iterator, Value value = {});
 void iterator_close(Object& iterator);
+
+void get_iterator_values(GlobalObject&, Value value, AK::Function<IterationDecision(Value&)> callback);
 
 }

--- a/Libraries/LibJS/Tests/functions/function-spread.js
+++ b/Libraries/LibJS/Tests/functions/function-spread.js
@@ -13,6 +13,24 @@ test("basic functionality", () => {
     expect(foo(..."abc")).toBe("c");
 });
 
+test("spreading custom iterable", () => {
+    let o = {
+        [Symbol.iterator]() {
+            return {
+                i: 0,
+                next() {
+                    if (this.i++ === 3) {
+                        return { done: true };
+                    }
+                    return { value: this.i };
+                },
+            };
+        },
+    };
+
+    expect(Math.max(...o)).toBe(3);
+});
+
 test("spreading non iterable", () => {
     expect(() => {
         [...1];

--- a/Libraries/LibJS/Tests/object-spread.js
+++ b/Libraries/LibJS/Tests/object-spread.js
@@ -91,3 +91,22 @@ test("spreading non-spreadable values", () => {
     };
     expect(Object.getOwnPropertyNames(empty)).toHaveLength(0);
 });
+
+test("respects custom Symbol.iterator method", () => {
+    let o = {
+        [Symbol.iterator]() {
+            return {
+                i: 0,
+                next() {
+                    if (this.i++ == 3) {
+                        return { done: true };
+                    }
+                    return { value: this.i, done: false };
+                },
+            };
+        },
+    };
+
+    let a = [...o];
+    expect(a).toEqual([1, 2, 3]);
+});

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -200,7 +200,6 @@ class ExpectationError extends Error {
 
         toContain(item) {
             this.__doMatcher(() => {
-                // FIXME: Iterator check
                 for (let element of this.target) {
                     if (item === element) return;
                 }
@@ -211,7 +210,6 @@ class ExpectationError extends Error {
 
         toContainEqual(item) {
             this.__doMatcher(() => {
-                // FIXME: Iterator check
                 for (let element of this.target) {
                     if (deepEquals(item, element)) return;
                 }


### PR DESCRIPTION
Finally use `Symbol.iterator` protocol in language features :) currently only used in for-of loops and spread expressions, but will have more uses later (Maps, Sets, `Array.from`, etc).

Allows cool stuff like this:
```js
let o = {
  [Symbol.iterator]() {
    return {
      i: 0,
      next() {
        if (this.i++ === 3) 
          return { done: true };
        return { value: this.i };
      }
    }
  }
}

console.log(Math.max(...o)); // 3
```