### PR TITLE
LibGUI: ComboBox improvements

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -261,7 +261,7 @@ Tab::Tab(Type type)
                 auto window = GUI::Window::construct();
                 auto& editor = window->set_main_widget<GUI::TextEditor>();
                 editor.set_text(source);
-                editor.set_readonly(true);
+                editor.set_mode(GUI::TextEditor::ReadOnly);
                 editor.set_ruler_visible(true);
                 window->set_rect(150, 150, 640, 480);
                 window->set_title(url);

--- a/Applications/SystemMonitor/ProcessStacksWidget.cpp
+++ b/Applications/SystemMonitor/ProcessStacksWidget.cpp
@@ -35,7 +35,7 @@ ProcessStacksWidget::ProcessStacksWidget()
     set_layout<GUI::VerticalBoxLayout>();
     layout()->set_margins({ 4, 4, 4, 4 });
     m_stacks_editor = add<GUI::TextEditor>();
-    m_stacks_editor->set_readonly(true);
+    m_stacks_editor->set_mode(GUI::TextEditor::ReadOnly);
 
     m_timer = add<Core::Timer>(1000, [this] { refresh(); });
 }

--- a/DevTools/HackStudio/main.cpp
+++ b/DevTools/HackStudio/main.cpp
@@ -734,11 +734,11 @@ void open_file(const String& filename)
     auto project_file = g_project->get_file(filename);
     if (project_file) {
         current_editor().set_document(const_cast<GUI::TextDocument&>(project_file->document()));
-        current_editor().set_readonly(false);
+        current_editor().set_mode(GUI::TextEditor::Editable);
     } else {
         auto external_file = ProjectFile::construct_with_name(filename);
         current_editor().set_document(const_cast<GUI::TextDocument&>(external_file->document()));
-        current_editor().set_readonly(true);
+        current_editor().set_mode(GUI::TextEditor::ReadOnly);
     }
 
     if (filename.ends_with(".cpp") || filename.ends_with(".h"))

--- a/Libraries/LibGUI/AbstractView.cpp
+++ b/Libraries/LibGUI/AbstractView.cpp
@@ -225,6 +225,16 @@ void AbstractView::set_hovered_index(const ModelIndex& index)
     if (m_hovered_index == index)
         return;
     m_hovered_index = index;
+    if (m_hovered_index.is_valid())
+        m_last_valid_hovered_index = m_hovered_index;
+    update();
+}
+
+void AbstractView::set_last_valid_hovered_index(const ModelIndex& index)
+{
+    if (m_last_valid_hovered_index == index)
+        return;
+    m_last_valid_hovered_index = index;
     update();
 }
 
@@ -325,6 +335,9 @@ void AbstractView::mouseup_event(MouseEvent& event)
         m_might_drag = false;
         update();
     }
+
+    if (activates_on_selection())
+        activate_selected();
 }
 
 void AbstractView::doubleclick_event(MouseEvent& event)

--- a/Libraries/LibGUI/AbstractView.h
+++ b/Libraries/LibGUI/AbstractView.h
@@ -74,6 +74,8 @@ public:
 
     NonnullRefPtr<Gfx::Font> font_for_index(const ModelIndex&) const;
 
+    void set_last_valid_hovered_index(const ModelIndex&);
+
 protected:
     AbstractView();
     virtual ~AbstractView() override;
@@ -107,6 +109,7 @@ protected:
     bool m_might_drag { false };
 
     ModelIndex m_hovered_index;
+    ModelIndex m_last_valid_hovered_index;
 
 private:
     RefPtr<Model> m_model;

--- a/Libraries/LibGUI/ComboBox.cpp
+++ b/Libraries/LibGUI/ComboBox.cpp
@@ -177,7 +177,7 @@ void ComboBox::set_only_allow_values_from_model(bool b)
     if (m_only_allow_values_from_model == b)
         return;
     m_only_allow_values_from_model = b;
-    m_editor->set_readonly(m_only_allow_values_from_model);
+    m_editor->set_mode(m_only_allow_values_from_model ? TextEditor::DisplayOnly : TextEditor::Editable);
 }
 
 Model* ComboBox::model()

--- a/Libraries/LibGUI/ListView.h
+++ b/Libraries/LibGUI/ListView.h
@@ -40,6 +40,9 @@ public:
     bool alternating_row_colors() const { return m_alternating_row_colors; }
     void set_alternating_row_colors(bool b) { m_alternating_row_colors = b; }
 
+    bool hover_highlighting() const { return m_hover_highlighting; }
+    void set_hover_highlighting(bool b) { m_hover_highlighting = b; }
+
     int horizontal_padding() const { return m_horizontal_padding; }
 
     void scroll_into_view(const ModelIndex&, Orientation);
@@ -55,6 +58,8 @@ public:
     virtual void select_all() override;
 
     void move_selection(int steps);
+
+    Function<void()> on_escape_pressed;
 
 private:
     ListView();
@@ -72,6 +77,7 @@ private:
     int m_horizontal_padding { 2 };
     int m_model_column { 0 };
     bool m_alternating_row_colors { true };
+    bool m_hover_highlighting { false };
 };
 
 }

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -700,6 +700,10 @@ void TextEditor::keydown_event(KeyEvent& event)
             }
         }
         return;
+    } else if (event.key() == KeyCode::Key_Up) {
+        if (on_up_pressed)
+            on_up_pressed();
+        return;
     }
     if (is_multi_line() && event.key() == KeyCode::Key_Down) {
         if (m_cursor.line() < (line_count() - 1)) {
@@ -717,6 +721,10 @@ void TextEditor::keydown_event(KeyEvent& event)
             }
         }
         return;
+    } else if (event.key() == KeyCode::Key_Down) {
+        if (on_down_pressed)
+            on_down_pressed();
+        return;
     }
     if (is_multi_line() && event.key() == KeyCode::Key_PageUp) {
         if (m_cursor.line() > 0) {
@@ -731,6 +739,10 @@ void TextEditor::keydown_event(KeyEvent& event)
             }
         }
         return;
+    } else if (event.key() == KeyCode::Key_PageUp) {
+        if (on_pageup_pressed)
+            on_pageup_pressed();
+        return;
     }
     if (is_multi_line() && event.key() == KeyCode::Key_PageDown) {
         if (m_cursor.line() < (line_count() - 1)) {
@@ -743,6 +755,10 @@ void TextEditor::keydown_event(KeyEvent& event)
                 did_update_selection();
             }
         }
+        return;
+    } else if (event.key() == KeyCode::Key_PageDown) {
+        if (on_pagedown_pressed)
+            on_pagedown_pressed();
         return;
     }
     if (event.key() == KeyCode::Key_Left) {

--- a/Libraries/LibGUI/TextEditor.h
+++ b/Libraries/LibGUI/TextEditor.h
@@ -127,8 +127,13 @@ public:
     void redo() { document().redo(); }
 
     Function<void()> on_change;
+    Function<void()> on_mousedown;
     Function<void()> on_return_pressed;
     Function<void()> on_escape_pressed;
+    Function<void()> on_up_pressed;
+    Function<void()> on_down_pressed;
+    Function<void()> on_pageup_pressed;
+    Function<void()> on_pagedown_pressed;
 
     Action& undo_action() { return *m_undo_action; }
     Action& redo_action() { return *m_redo_action; }

--- a/Libraries/LibGUI/TextEditor.h
+++ b/Libraries/LibGUI/TextEditor.h
@@ -46,6 +46,13 @@ public:
         MultiLine,
         SingleLine
     };
+
+    enum Mode {
+        Editable,
+        ReadOnly,
+        DisplayOnly
+    };
+
     virtual ~TextEditor() override;
 
     const TextDocument& document() const { return *m_document; }
@@ -53,8 +60,10 @@ public:
 
     void set_document(TextDocument&);
 
-    bool is_readonly() const { return m_readonly; }
-    void set_readonly(bool);
+    bool has_visible_list() const { return m_has_visible_list; }
+    void set_has_visible_list(bool);
+    bool has_open_button() const { return m_has_open_button; }
+    void set_has_open_button(bool);
 
     virtual bool is_automatic_indentation_enabled() const final { return m_automatic_indentation_enabled; }
     void set_automatic_indentation_enabled(bool enabled) { m_automatic_indentation_enabled = enabled; }
@@ -70,6 +79,12 @@ public:
     Type type() const { return m_type; }
     bool is_single_line() const { return m_type == SingleLine; }
     bool is_multi_line() const { return m_type == MultiLine; }
+
+    Mode mode() const { return m_mode; }
+    bool is_editable() const { return m_mode == Editable; }
+    bool is_readonly() const { return m_mode == ReadOnly; }
+    bool is_displayonly() const { return m_mode == DisplayOnly; }
+    void set_mode(const Mode);
 
     bool is_ruler_visible() const { return m_ruler_visible; }
     void set_ruler_visible(bool b) { m_ruler_visible = b; }
@@ -153,7 +168,7 @@ protected:
     virtual void context_menu_event(ContextMenuEvent&) override;
     virtual void resize_event(ResizeEvent&) override;
     virtual void theme_change_event(ThemeChangeEvent&) override;
-    virtual void cursor_did_change() {}
+    virtual void cursor_did_change() { }
     Gfx::IntRect ruler_content_rect(size_t line) const;
 
     TextPosition text_position_at(const Gfx::IntPoint&) const;
@@ -182,6 +197,7 @@ private:
 
     int icon_size() const { return 16; }
     int icon_padding() const { return 2; }
+    int button_padding() const { return m_has_open_button ? 17 : 2; }
 
     class ReflowDeferrer {
     public:
@@ -194,6 +210,7 @@ private:
         {
             m_editor.undefer_reflow();
         }
+
     private:
         TextEditor& m_editor;
     };
@@ -238,6 +255,7 @@ private:
     }
 
     Type m_type { MultiLine };
+    Mode m_mode { Editable };
 
     TextPosition m_cursor;
     Gfx::TextAlignment m_text_alignment { Gfx::TextAlignment::CenterLeft };
@@ -247,7 +265,8 @@ private:
     bool m_has_pending_change_notification { false };
     bool m_automatic_indentation_enabled { false };
     bool m_line_wrapping_enabled { false };
-    bool m_readonly { false };
+    bool m_has_visible_list { false };
+    bool m_has_open_button { false };
     int m_line_spacing { 4 };
     size_t m_soft_tab_width { 4 };
     int m_horizontal_content_padding { 3 };

--- a/Libraries/LibGUI/Window.cpp
+++ b/Libraries/LibGUI/Window.cpp
@@ -329,6 +329,8 @@ void Window::event(Core::Event& event)
 
     if (event.type() == Event::WindowBecameActive || event.type() == Event::WindowBecameInactive) {
         m_is_active = event.type() == Event::WindowBecameActive;
+        if (on_activity_change)
+            on_activity_change(m_is_active);
         if (m_main_widget)
             m_main_widget->dispatch_event(event, this);
         if (m_focused_widget)

--- a/Libraries/LibGUI/Window.h
+++ b/Libraries/LibGUI/Window.h
@@ -98,6 +98,7 @@ public:
     };
 
     Function<CloseRequestDecision()> on_close_request;
+    Function<void(const bool is_active)> on_activity_change;
 
     int x() const { return rect().x(); }
     int y() const { return rect().y(); }


### PR DESCRIPTION
A few new visual effects and keyboard controls for combo boxes, making them look and operate more like classic drop-down lists when read-only. The selected/hovered row is now highlighted and the list closes when the item is activated or the widget loses focus.
![combobox](https://user-images.githubusercontent.com/66646555/87365121-6a974280-c543-11ea-8da5-4964107298b0.gif)
