### PR TITLE
LibGUI: Draw contiguous frame if GroupBox title is left empty

### DIFF
--- a/Libraries/LibGUI/GroupBox.cpp
+++ b/Libraries/LibGUI/GroupBox.cpp
@@ -52,9 +52,11 @@ void GroupBox::paint_event(PaintEvent& event)
     };
     Gfx::StylePainter::paint_frame(painter, frame_rect, palette(), Gfx::FrameShape::Box, Gfx::FrameShadow::Sunken, 2);
 
-    Gfx::IntRect text_rect { 4, 0, font().width(m_title) + 6, font().glyph_height() };
-    painter.fill_rect(text_rect, palette().button());
-    painter.draw_text(text_rect, m_title, Gfx::TextAlignment::Center, palette().button_text());
+    if (!m_title.is_empty()) {
+        Gfx::IntRect text_rect { 4, 0, font().width(m_title) + 6, font().glyph_height() };
+        painter.fill_rect(text_rect, palette().button());
+        painter.draw_text(text_rect, m_title, Gfx::TextAlignment::Center, palette().button_text());
+    }
 }
 
 void GroupBox::set_title(const StringView& title)


### PR DESCRIPTION
à la VB6