### PR TITLE
Shell: Explicitly declare 'environ' to make macOS Lagom build happy

### DIFF
--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -31,7 +31,9 @@
 #include <inttypes.h>
 #include <signal.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
+extern char** environ;
 extern RefPtr<Line::Editor> editor;
 
 int Shell::builtin_alias(int argc, const char** argv)

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -52,6 +52,7 @@
 
 static bool s_disable_hyperlinks = false;
 extern RefPtr<Line::Editor> editor;
+extern char** environ;
 
 //#define SH_DEBUG
 


### PR DESCRIPTION
~It is a mystery how this ever compiled successfully...~
(`environ` is not declared in Builtin.cpp when compiling ~with clang~ Lagom on macOS)