### PR TITLE
Fix sorting proxy model

### DIFF
--- a/Applications/FileManager/DirectoryView.h
+++ b/Applications/FileManager/DirectoryView.h
@@ -119,6 +119,7 @@ private:
     virtual void on_model_update(unsigned) override;
 
     void handle_activation(const GUI::ModelIndex&);
+    GUI::ModelIndex map_table_view_index(const GUI::ModelIndex&) const;
 
     void set_status_message(const StringView&);
     void update_statusbar();

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -221,6 +221,8 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
         return virt$madvise(arg1, arg2, arg3);
     case SC_open:
         return virt$open(arg1);
+    case SC_pipe:
+        return virt$pipe(arg1, arg2);
     case SC_fcntl:
         return virt$fcntl(arg1, arg2, arg3);
     case SC_getgroups:
@@ -332,6 +334,16 @@ u32 Emulator::virt$open(u32 params_addr)
     if (fd < 0)
         return -errno;
     return fd;
+}
+
+int Emulator::virt$pipe(FlatPtr vm_pipefd, int flags)
+{
+    int pipefd[2];
+    int rc = syscall(SC_pipe, pipefd, flags);
+    if (rc < 0)
+        return rc;
+    mmu().copy_to_vm(vm_pipefd, pipefd, sizeof(pipefd));
+    return rc;
 }
 
 u32 Emulator::virt$munmap(FlatPtr address, u32 size)

--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -70,6 +70,7 @@ private:
     u32 virt$mprotect(FlatPtr, size_t, int);
     u32 virt$madvise(FlatPtr, size_t, int);
     u32 virt$open(u32);
+    int virt$pipe(FlatPtr pipefd, int flags);
     int virt$close(int);
     int virt$get_process_name(FlatPtr buffer, int size);
     int virt$dbgputstr(FlatPtr characters, int length);

--- a/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Libraries/LibGUI/FileSystemModel.cpp
@@ -332,6 +332,7 @@ const FileSystemModel::Node& FileSystemModel::node(const ModelIndex& index) cons
 {
     if (!index.is_valid())
         return *m_root;
+    ASSERT(index.internal_data());
     return *(Node*)index.internal_data();
 }
 

--- a/Libraries/LibGUI/SortingProxyModel.cpp
+++ b/Libraries/LibGUI/SortingProxyModel.cpp
@@ -57,12 +57,14 @@ void SortingProxyModel::on_model_update(unsigned flags)
 
 int SortingProxyModel::row_count(const ModelIndex& index) const
 {
-    return target().row_count(index);
+    auto target_index = map_to_target(index);
+    return target().row_count(target_index);
 }
 
 int SortingProxyModel::column_count(const ModelIndex& index) const
 {
-    return target().column_count(index);
+    auto target_index = map_to_target(index);
+    return target().column_count(target_index);
 }
 
 ModelIndex SortingProxyModel::map_to_target(const ModelIndex& index) const
@@ -74,19 +76,16 @@ ModelIndex SortingProxyModel::map_to_target(const ModelIndex& index) const
     return target().index(m_row_mappings[index.row()], index.column());
 }
 
-String SortingProxyModel::column_name(int index) const
+String SortingProxyModel::column_name(int column) const
 {
-    return target().column_name(index);
+    return target().column_name(column);
 }
 
 Variant SortingProxyModel::data(const ModelIndex& index, Role role) const
 {
     auto target_index = map_to_target(index);
-    if (!target_index.is_valid()) {
-        dbg() << "BUG! SortingProxyModel: Unable to convert " << index << " to target";
-        return {};
-    }
-    return target().data(map_to_target(index), role);
+    ASSERT(target_index.is_valid());
+    return target().data(target_index, role);
 }
 
 void SortingProxyModel::update()


### PR DESCRIPTION
Fix forgetting to map sorting proxy model indexes

Fixes #1440 and #2787 (which are duplicates) :smile:

(Also throwing in `virt$pipe()` for UE)