### PR TITLE
Shell: run test as '['

### DIFF
--- a/Shell/Parser.cpp
+++ b/Shell/Parser.cpp
@@ -450,7 +450,7 @@ RefPtr<AST::Node> Parser::parse_expression()
         return expr;
     };
 
-    if (strchr("&|[]){} ;<>\n", starting_char) != nullptr)
+    if (strchr("&|){} ;<>\n", starting_char) != nullptr)
         return nullptr;
 
     if (isdigit(starting_char)) {
@@ -728,7 +728,7 @@ RefPtr<AST::Node> Parser::parse_bareword()
     auto rule_start = push_start();
     StringBuilder builder;
     auto is_acceptable_bareword_character = [](char c) {
-        return strchr("\\\"'*$&#|()[]{} ?;<>\n", c) == nullptr;
+        return strchr("\\\"'*$&#|(){} ?;<>\n", c) == nullptr;
     };
     while (!at_end()) {
         char ch = peek();

--- a/Userland/test.cpp
+++ b/Userland/test.cpp
@@ -521,6 +521,10 @@ int main(int argc, char* argv[])
         argv[argc] = nullptr;
     }
 
+    // Exit false when no arguments are given.
+    if (argc == 1)
+        return 1;
+
     auto condition = parse_complex_expression(argv);
     if (optind != argc - 1)
         fatal_error("Too many arguments");


### PR DESCRIPTION
Currently the shell treats '[' and ']' as syntax. I am not sure if there are future plans for these, but given that `test` supports invocation as `[` I thought it made sense to allow it.

Bonus: correct behavior for test with no arguments.