### PR TITLE
WindowServer: Make Menus the input window when showing them

### DIFF
--- a/Services/WindowServer/Menu.cpp
+++ b/Services/WindowServer/Menu.cpp
@@ -284,12 +284,12 @@ MenuItem* Menu::hovered_item() const
     return const_cast<MenuItem*>(&item(m_hovered_item_index));
 }
 
-void Menu::update_for_new_hovered_item()
+void Menu::update_for_new_hovered_item(bool make_input)
 {
     if (hovered_item() && hovered_item()->is_submenu()) {
         ASSERT(menu_window());
         MenuManager::the().close_everyone_not_in_lineage(*hovered_item()->submenu());
-        hovered_item()->submenu()->popup(hovered_item()->rect().top_right().translated(menu_window()->rect().location()));
+        hovered_item()->submenu()->do_popup(hovered_item()->rect().top_right().translated(menu_window()->rect().location()), make_input);
     } else {
         MenuManager::the().close_everyone_not_in_lineage(*this);
         ensure_menu_window().set_visible(true);
@@ -313,7 +313,7 @@ void Menu::descend_into_submenu_at_hovered_item()
     ASSERT(hovered_item());
     auto submenu = hovered_item()->submenu();
     ASSERT(submenu);
-    MenuManager::the().open_menu(*submenu);
+    MenuManager::the().open_menu(*submenu, false);
     submenu->set_hovered_item(0);
     ASSERT(submenu->hovered_item()->type() != MenuItem::Separator);
 }
@@ -384,7 +384,7 @@ void Menu::event(Core::Event& event)
         // Default to the first item on key press if one has not been selected yet
         if (!hovered_item()) {
             m_hovered_item_index = 0;
-            update_for_new_hovered_item();
+            update_for_new_hovered_item(key == Key_Right);
             return;
         }
 
@@ -509,6 +509,11 @@ void Menu::redraw_if_theme_changed()
 
 void Menu::popup(const Gfx::IntPoint& position)
 {
+    do_popup(position, true);
+}
+
+void Menu::do_popup(const Gfx::IntPoint& position, bool make_input)
+{
     if (is_empty()) {
         dbg() << "Menu: Empty menu popup";
         return;
@@ -532,7 +537,7 @@ void Menu::popup(const Gfx::IntPoint& position)
 
     window.move_to(adjusted_pos);
     window.set_visible(true);
-    MenuManager::the().open_menu(*this, false);
+    MenuManager::the().open_menu(*this, make_input);
     WindowManager::the().did_popup_a_menu({});
 }
 

--- a/Services/WindowServer/Menu.h
+++ b/Services/WindowServer/Menu.h
@@ -120,6 +120,7 @@ public:
     void close();
 
     void popup(const Gfx::IntPoint&);
+    void do_popup(const Gfx::IntPoint&, bool);
 
     bool is_menu_ancestor_of(const Menu&) const;
 
@@ -142,7 +143,7 @@ private:
     int item_index_at(const Gfx::IntPoint&);
     int padding_between_text_and_shortcut() const { return 50; }
     void did_activate(MenuItem&);
-    void update_for_new_hovered_item();
+    void update_for_new_hovered_item(bool make_input = false);
 
     ClientConnection* m_client { nullptr };
     int m_menu_id { 0 };

--- a/Services/WindowServer/MenuManager.h
+++ b/Services/WindowServer/MenuManager.h
@@ -56,6 +56,7 @@ public:
 
     Menu* current_menu() { return m_current_menu.ptr(); }
     void set_current_menu(Menu*);
+    void clear_current_menu();
     void open_menu(Menu&, bool as_current_menu = true);
     void toggle_menu(Menu&);
 
@@ -104,6 +105,7 @@ private:
     RefPtr<Window> m_window;
 
     WeakPtr<Menu> m_current_menu;
+    WeakPtr<Window> m_previous_input_window;
     Vector<WeakPtr<Menu>> m_open_menu_stack;
 
     RefPtr<Core::Timer> m_search_timer;

--- a/Services/WindowServer/Window.cpp
+++ b/Services/WindowServer/Window.cpp
@@ -590,6 +590,18 @@ void Window::set_parent_window(Window& parent_window)
         parent_window.add_child_window(*this);
 }
 
+bool Window::is_accessory() const
+{
+    if (!m_accessory)
+        return false;
+    if (parent_window() != nullptr)
+        return true;
+    
+    // If accessory window was unparented, convert to a regular window
+    const_cast<Window*>(this)->set_accessory(false);
+    return false;
+}
+
 bool Window::is_accessory_of(Window& window) const
 {
     if (!is_accessory())

--- a/Services/WindowServer/Window.h
+++ b/Services/WindowServer/Window.h
@@ -244,7 +244,7 @@ public:
     const Vector<WeakPtr<Window>>& accessory_windows() const { return m_accessory_windows; }
 
     void set_accessory(bool accessory) { m_accessory = accessory; }
-    bool is_accessory() const { return m_accessory; }
+    bool is_accessory() const;
     bool is_accessory_of(Window&) const;
 
     void set_frameless(bool frameless) { m_frameless = frameless; }

--- a/Services/WindowServer/WindowManager.h
+++ b/Services/WindowServer/WindowManager.h
@@ -107,7 +107,10 @@ public:
     void start_dnd_drag(ClientConnection&, const String& text, Gfx::Bitmap*, const String& data_type, const String& data);
     void end_dnd_drag();
 
+    Window* active_window() { return m_active_window.ptr(); }
     const Window* active_window() const { return m_active_window.ptr(); }
+    Window* active_input_window() { return m_active_input_window.ptr(); }
+    const Window* active_input_window() const { return m_active_input_window.ptr(); }
     const ClientConnection* active_client() const;
     bool active_window_is_modal() const { return m_active_window && m_active_window->is_modal(); }
 
@@ -145,6 +148,8 @@ public:
     bool set_resolution(int width, int height);
     Gfx::IntSize resolution() const;
 
+    Window* set_active_input_window(Window*);
+    void restore_active_input_window(Window*);
     void set_active_window(Window*, bool make_input = true);
     void set_hovered_button(Button*);
 
@@ -207,7 +212,7 @@ private:
     void tell_wm_listener_about_window(Window& listener, Window&);
     void tell_wm_listener_about_window_icon(Window& listener, Window&);
     void tell_wm_listener_about_window_rect(Window& listener, Window&);
-    void pick_new_active_window(Window&);
+    bool pick_new_active_window(Window*);
 
     void do_move_to_front(Window&, bool, bool);
 


### PR DESCRIPTION
This solves a problem where windows don't receive a WindowInputLeft
event when popup menus are opened. This prevented ComboBox being
closed when right clicking the application on the task bar.