### PR TITLE
WindowServer: Fixes for modal windows

### DIFF
--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -689,16 +689,6 @@ OwnPtr<Messages::WindowServer::GreetResponse> ClientConnection::handle(const Mes
     return make<Messages::WindowServer::GreetResponse>(client_id(), Screen::the().rect(), Gfx::current_system_theme_buffer_id());
 }
 
-bool ClientConnection::is_showing_modal_window() const
-{
-    for (auto& it : m_windows) {
-        auto& window = *it.value;
-        if (window.is_visible() && window.is_modal())
-            return true;
-    }
-    return false;
-}
-
 void ClientConnection::handle(const Messages::WindowServer::WM_SetWindowTaskbarRect& message)
 {
     auto* client = ClientConnection::from_client_id(message.client_id());

--- a/Services/WindowServer/ClientConnection.h
+++ b/Services/WindowServer/ClientConnection.h
@@ -61,8 +61,6 @@ public:
 
     MenuBar* app_menubar() { return m_app_menubar.ptr(); }
 
-    bool is_showing_modal_window() const;
-
     void notify_about_new_screen_rect(const Gfx::IntRect&);
     void post_paint_message(Window&, bool ignore_occlusion = false);
 

--- a/Services/WindowServer/Window.cpp
+++ b/Services/WindowServer/Window.cpp
@@ -387,16 +387,20 @@ bool Window::is_active() const
     return WindowManager::the().active_window() == this;
 }
 
-bool Window::is_blocked_by_modal_window() const
+Window* Window::is_blocked_by_modal_window()
 {
-    bool is_any_modal = false;
-    const Window* next = this;
-    while (!is_any_modal && next) {
-        is_any_modal = next->is_modal();
-        next = next->parent_window();
+    // A window is blocked if any immediate child, or any child further
+    // down the chain is modal
+    for (auto& window: m_child_windows) {
+        if (window) {
+            if (window->is_modal())
+                return window;
+            
+            if (auto* blocking_modal_window = window->is_blocked_by_modal_window())
+                return blocking_modal_window;
+        }
     }
-
-    return !is_any_modal && client() && client()->is_showing_modal_window();
+    return nullptr;
 }
 
 void Window::set_default_icon()

--- a/Services/WindowServer/Window.h
+++ b/Services/WindowServer/Window.h
@@ -116,7 +116,7 @@ public:
     WindowFrame& frame() { return m_frame; }
     const WindowFrame& frame() const { return m_frame; }
 
-    bool is_blocked_by_modal_window() const;
+    Window* is_blocked_by_modal_window();
 
     bool listens_to_wm_events() const { return m_listens_to_wm_events; }
 
@@ -145,7 +145,7 @@ public:
     bool is_visible() const { return m_visible; }
     void set_visible(bool);
 
-    bool is_modal() const { return m_modal; }
+    bool is_modal() const { return m_modal && m_parent_window; }
 
     Gfx::IntRect rect() const { return m_rect; }
     void set_rect(const Gfx::IntRect&);

--- a/Services/WindowServer/WindowManager.h
+++ b/Services/WindowServer/WindowManager.h
@@ -112,7 +112,6 @@ public:
     Window* active_input_window() { return m_active_input_window.ptr(); }
     const Window* active_input_window() const { return m_active_input_window.ptr(); }
     const ClientConnection* active_client() const;
-    bool active_window_is_modal() const { return m_active_window && m_active_window->is_modal(); }
 
     const Window* highlight_window() const { return m_highlight_window.ptr(); }
     void set_highlight_window(Window*);


### PR DESCRIPTION
This fixes a few problems with modal windows:

* If any child window, or any child window further down the
  tree is considered modal, then all windows in that chain
  are modal.
* When trying to activate a window blocked by a modal child
  bring the entire stack of modal windows to the front and
  activate the modal window.
* A window is modal if it has a parent and it's flagged as
  modal, regardless of whether the ClientConnection has
  created modal windows.

This technically supports diverging modal window trees as well,
where two modal windows share the same parent, allowing both to
be activated (including for input) but not the parent. And it
should also support modal window stacks of arbitrary depth.