### PR TITLE
WindowServer: Fix traversing modal stack

### DIFF
--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -475,12 +475,19 @@ void ClientConnection::destroy_window(Window& window, Vector<i32>& destroyed_win
         destroy_window(*child_window, destroyed_window_ids);
     }
 
+    for (auto& accessory_window : window.accessory_windows()) {
+        if (!accessory_window)
+            continue;
+        ASSERT(accessory_window->window_id() != window.window_id());
+        destroy_window(*accessory_window, destroyed_window_ids);
+    }
+
     destroyed_window_ids.append(window.window_id());
 
     if (window.type() == WindowType::MenuApplet)
         AppletManager::the().remove_applet(window);
 
-    window.invalidate();
+    window.destroy();
     remove_child(window);
     m_windows.remove(window.window_id());
 }

--- a/Services/WindowServer/Window.cpp
+++ b/Services/WindowServer/Window.cpp
@@ -634,4 +634,17 @@ void Window::set_progress(int progress)
     WindowManager::the().notify_progress_changed(*this);
 }
 
+bool Window::is_descendant_of(Window& window) const
+{
+    for (auto* parent = parent_window(); parent; parent = parent->parent_window()) {
+        if (parent == &window)
+            return true;
+        for (auto& accessory : parent->accessory_windows()) {
+            if (accessory == &window)
+                return true;
+        }
+    }
+    return false;
+}
+
 }

--- a/Services/WindowServer/Window.cpp
+++ b/Services/WindowServer/Window.cpp
@@ -126,6 +126,12 @@ Window::~Window()
     WindowManager::the().remove_window(*this);
 }
 
+void Window::destroy()
+{
+    m_destroyed = true;
+    invalidate();
+}
+
 void Window::set_title(const String& title)
 {
     if (m_title == title)
@@ -389,7 +395,7 @@ Window* Window::is_blocked_by_modal_window()
     // A window is blocked if any immediate child, or any child further
     // down the chain is modal
     for (auto& window: m_child_windows) {
-        if (window) {
+        if (window && !window->is_destroyed()) {
             if (window->is_modal())
                 return window;
             

--- a/Services/WindowServer/Window.h
+++ b/Services/WindowServer/Window.h
@@ -256,6 +256,9 @@ public:
     int progress() const { return m_progress; }
     void set_progress(int);
 
+    bool is_destroyed() const { return m_destroyed; }
+    void destroy();
+
 private:
     void handle_mouse_event(const MouseEvent&);
     void update_menu_item_text(PopupMenuItem item);
@@ -289,6 +292,7 @@ private:
     bool m_maximized { false };
     bool m_fullscreen { false };
     bool m_accessory { false };
+    bool m_destroyed { false };
     WindowTileType m_tiled { WindowTileType::None };
     Gfx::IntRect m_untiled_rect;
     bool m_occluded { false };

--- a/Services/WindowServer/Window.h
+++ b/Services/WindowServer/Window.h
@@ -244,6 +244,8 @@ public:
     Vector<WeakPtr<Window>>& accessory_windows() { return m_accessory_windows; }
     const Vector<WeakPtr<Window>>& accessory_windows() const { return m_accessory_windows; }
 
+    bool is_descendant_of(Window&) const;
+
     void set_accessory(bool accessory) { m_accessory = accessory; }
     bool is_accessory() const;
     bool is_accessory_of(Window&) const;

--- a/Services/WindowServer/WindowManager.h
+++ b/Services/WindowServer/WindowManager.h
@@ -193,7 +193,8 @@ public:
             Vector<Window*> modal_stack;
             auto* modal_stack_top = blocking_modal_window ? blocking_modal_window : &window;
             for (auto* parent = modal_stack_top->parent_window(); parent; parent = parent->parent_window()) {
-                if (parent->is_blocked_by_modal_window() != modal_stack_top)
+                auto* blocked_by = parent->is_blocked_by_modal_window();
+                if (!blocked_by || (blocked_by != modal_stack_top && !modal_stack_top->is_descendant_of(*blocked_by)))
                     break;
                 modal_stack.append(parent);
                 if (!parent->is_modal())


### PR DESCRIPTION
When walking the modal window stack upwards, we need to check if
the top modal window is still a descendant of the window that
the parent is blocked by. Fixes not all windows being brought to
the front when trying to active a parent in the middle of the
modal window stack.