### PR TITLE
WindowServer: Fix picking new active window after destroy

### DIFF
--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -475,12 +475,19 @@ void ClientConnection::destroy_window(Window& window, Vector<i32>& destroyed_win
         destroy_window(*child_window, destroyed_window_ids);
     }
 
+    for (auto& accessory_window : window.accessory_windows()) {
+        if (!accessory_window)
+            continue;
+        ASSERT(accessory_window->window_id() != window.window_id());
+        destroy_window(*accessory_window, destroyed_window_ids);
+    }
+
     destroyed_window_ids.append(window.window_id());
 
     if (window.type() == WindowType::MenuApplet)
         AppletManager::the().remove_applet(window);
 
-    window.invalidate();
+    window.destroy();
     remove_child(window);
     m_windows.remove(window.window_id());
 }

--- a/Services/WindowServer/Window.cpp
+++ b/Services/WindowServer/Window.cpp
@@ -126,6 +126,12 @@ Window::~Window()
     WindowManager::the().remove_window(*this);
 }
 
+void Window::destroy()
+{
+    m_destroyed = true;
+    invalidate();
+}
+
 void Window::set_title(const String& title)
 {
     if (m_title == title)
@@ -389,7 +395,7 @@ Window* Window::is_blocked_by_modal_window()
     // A window is blocked if any immediate child, or any child further
     // down the chain is modal
     for (auto& window: m_child_windows) {
-        if (window) {
+        if (window && !window->is_destroyed()) {
             if (window->is_modal())
                 return window;
             

--- a/Services/WindowServer/Window.h
+++ b/Services/WindowServer/Window.h
@@ -254,6 +254,9 @@ public:
     int progress() const { return m_progress; }
     void set_progress(int);
 
+    bool is_destroyed() const { return m_destroyed; }
+    void destroy();
+
 private:
     void handle_mouse_event(const MouseEvent&);
     void update_menu_item_text(PopupMenuItem item);
@@ -287,6 +290,7 @@ private:
     bool m_maximized { false };
     bool m_fullscreen { false };
     bool m_accessory { false };
+    bool m_destroyed { false };
     WindowTileType m_tiled { WindowTileType::None };
     Gfx::IntRect m_untiled_rect;
     bool m_occluded { false };


### PR DESCRIPTION
We need to mark windows as destroyed and not consider them
when picking a new active window. Fixes lost focus after
closing some windows.