### PR TITLE
Userland: Add implementation of sponge

### DIFF
--- a/DevTools/UserspaceEmulator/MallocTracer.cpp
+++ b/DevTools/UserspaceEmulator/MallocTracer.cpp
@@ -45,6 +45,8 @@ void MallocTracer::target_did_malloc(Badge<SoftCPU>, FlatPtr address, size_t siz
         ASSERT(existing_mallocation->freed);
         existing_mallocation->size = size;
         existing_mallocation->freed = false;
+        existing_mallocation->malloc_backtrace = Emulator::the().raw_backtrace();
+        existing_mallocation->free_backtrace.clear();
         return;
     }
     m_mallocations.append({ address, size, false, Emulator::the().raw_backtrace(), Vector<FlatPtr>() });

--- a/Userland/spng.cpp
+++ b/Userland/spng.cpp
@@ -1,0 +1,63 @@
+/* 
+ * Copyright (C) 2020 Matthew Graham
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AK/ByteBuffer.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main(int argc, char** argv)
+{
+    if (pledge("stdio wpath cpath rpath", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    auto in_file = Core::File::construct("/dev/stdin");
+    if (!in_file->open(Core::IODevice::ReadOnly)) {
+        perror("open");
+        return 1;
+    }
+    auto output_buffer = in_file->read_all();
+
+    if (pledge("stdio wpath cpath", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    bool append = false;
+    const char* output_file_name = "/dev/stdout";
+
+    Core::ArgsParser parser;
+    parser.add_option(append, "Append input to output file", "append", 'a');
+    parser.add_positional_argument(output_file_name, "Output file", "file", Core::ArgsParser::Required::No);
+    parser.parse(argc, argv);
+
+    auto open_mode = Core::IODevice::WriteOnly;
+    if (append)
+        open_mode = (Core::IODevice::OpenMode)(Core::IODevice::Append | open_mode);
+
+    auto output_file = Core::File::construct(output_file_name);
+    if (!output_file->open(open_mode)) {
+        perror("open");
+        return 1;
+    }
+    output_file->write(output_buffer);
+
+    return 0;
+}

--- a/Userland/spng.cpp
+++ b/Userland/spng.cpp
@@ -31,10 +31,15 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+const char* temp_file_name = "..spng_temp.Uav78GHg";
+
 void print_error_then_exit_on_fail(int result, const char* function_name)
 {
     if (result < 0) {
         perror(function_name);
+        if (access(temp_file_name, F_OK) != -1)
+            if (remove(temp_file_name) < 0)
+                perror("remove");
         exit(1);
     }
 }
@@ -68,7 +73,6 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    const char* temp_file_name = "..spng_temp.Uav78GHg";
     int open_mode = O_WRONLY | O_CREAT;
     if (append)
         open_mode |= O_APPEND;

--- a/Userland/spng.cpp
+++ b/Userland/spng.cpp
@@ -1,18 +1,27 @@
-/* 
- * Copyright (C) 2020 Matthew Graham
+/*
+ * Copyright (c) 2020, Matthew Graham <mjg267106@gmail.com>
+ * All rights reserved.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <AK/ByteBuffer.h>


### PR DESCRIPTION
Sponge is a command from the "moreutils" collection that soaks up all
standard input and outputs it to the desired file. This is a rewrite for
SerenityOS since it's such a simple and useful program. I named it 
"spng" because it is a lot more pleasant to type.