### PR TITLE
Kernel: Implement FIFOs/named pipes

### DIFF
--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -60,6 +60,35 @@ NonnullRefPtr<FileDescription> FIFO::open_direction(FIFO::Direction direction)
     return description;
 }
 
+NonnullRefPtr<FileDescription> FIFO::open_direction_blocking(FIFO::Direction direction)
+{
+    Locker locker(m_open_lock);
+
+    auto description = open_direction(direction);
+
+    if (direction == Direction::Reader) {
+        m_read_open_queue.wake_all();
+
+        if (m_writers == 0) {
+            locker.unlock();
+            Thread::current()->wait_on(m_write_open_queue, "FIFO");
+            locker.lock();
+        }
+    }
+
+    if (direction == Direction::Writer) {
+        m_write_open_queue.wake_all();
+
+        if (m_readers == 0) {
+            locker.unlock();
+            Thread::current()->wait_on(m_read_open_queue, "FIFO");
+            locker.lock();
+        }
+    }
+
+    return description;
+}
+
 FIFO::FIFO(uid_t uid)
     : m_uid(uid)
 {

--- a/Kernel/FileSystem/FIFO.h
+++ b/Kernel/FileSystem/FIFO.h
@@ -28,7 +28,9 @@
 
 #include <Kernel/DoubleBuffer.h>
 #include <Kernel/FileSystem/File.h>
+#include <Kernel/Lock.h>
 #include <Kernel/UnixTypes.h>
+#include <Kernel/WaitQueue.h>
 
 namespace Kernel {
 
@@ -48,6 +50,7 @@ public:
     uid_t uid() const { return m_uid; }
 
     NonnullRefPtr<FileDescription> open_direction(Direction);
+    NonnullRefPtr<FileDescription> open_direction_blocking(Direction);
 
     void attach(Direction);
     void detach(Direction);
@@ -71,6 +74,10 @@ private:
     uid_t m_uid { 0 };
 
     int m_fifo_id { 0 };
+
+    WaitQueue m_read_open_queue;
+    WaitQueue m_write_open_queue;
+    Lock m_open_lock;
 };
 
 }

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -205,6 +205,18 @@ void Inode::unregister_watcher(Badge<InodeWatcher>, InodeWatcher& watcher)
     m_watchers.remove(&watcher);
 }
 
+FIFO& Inode::fifo()
+{
+    ASSERT(metadata().is_fifo());
+
+    // FIXME: Release m_fifo when it is closed by all readers and writers
+    if (!m_fifo)
+        m_fifo = FIFO::create(metadata().uid);
+
+    ASSERT(m_fifo);
+    return *m_fifo;
+}
+
 void Inode::set_metadata_dirty(bool metadata_dirty)
 {
     if (m_metadata_dirty == metadata_dirty)

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -32,6 +32,7 @@
 #include <AK/RefCounted.h>
 #include <AK/String.h>
 #include <AK/WeakPtr.h>
+#include <Kernel/FileSystem/FIFO.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/FileSystem/InodeIdentifier.h>
 #include <Kernel/FileSystem/InodeMetadata.h>
@@ -111,6 +112,8 @@ public:
     void register_watcher(Badge<InodeWatcher>, InodeWatcher&);
     void unregister_watcher(Badge<InodeWatcher>, InodeWatcher&);
 
+    FIFO& fifo();
+
     // For InlineLinkedListNode.
     Inode* m_next { nullptr };
     Inode* m_prev { nullptr };
@@ -134,6 +137,7 @@ private:
     RefPtr<LocalSocket> m_socket;
     HashTable<InodeWatcher*> m_watchers;
     bool m_metadata_dirty { false };
+    RefPtr<FIFO> m_fifo;
 };
 
 }

--- a/Libraries/LibC/stat.cpp
+++ b/Libraries/LibC/stat.cpp
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 extern "C" {
 
@@ -62,5 +63,10 @@ int fchmod(int fd, mode_t mode)
 {
     int rc = syscall(SC_fchmod, fd, mode);
     __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+int mkfifo(const char* pathname, mode_t mode)
+{
+    return mknod(pathname, mode | S_IFIFO, 0);
 }
 }

--- a/Libraries/LibC/sys/stat.h
+++ b/Libraries/LibC/sys/stat.h
@@ -60,6 +60,7 @@ mode_t umask(mode_t);
 int chmod(const char* pathname, mode_t);
 int fchmod(int fd, mode_t);
 int mkdir(const char* pathname, mode_t);
+int mkfifo(const char* pathname, mode_t);
 
 inline dev_t makedev(unsigned int major, unsigned int minor) { return (minor & 0xffu) | (major << 8u) | ((minor & ~0xffu) << 12u); }
 inline unsigned int major(dev_t dev) { return (dev & 0xfff00u) >> 8u; }

--- a/Userland/mkfifo.cpp
+++ b/Userland/mkfifo.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, Peter Elliott <pelliott@ualberta.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibCore/ArgsParser.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(int argc, char** argv)
+{
+    if (pledge("stdio dpath", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    mode_t mode = 0666;
+    Vector<const char*> paths;
+
+    Core::ArgsParser args_parser;
+    // FIXME: add -m for file modes
+    args_parser.add_positional_argument(paths, "Paths of FIFOs to create", "paths");
+    args_parser.parse(argc, argv);
+
+    int exit_code = 0;
+
+    for (auto path : paths) {
+        if (mkfifo(path, mode) < 0) {
+            perror("mkfifo");
+            exit_code = 1;
+        }
+    }
+
+    return exit_code;
+}

--- a/Userland/mknod.cpp
+++ b/Userland/mknod.cpp
@@ -36,7 +36,7 @@ inline constexpr unsigned encoded_device(unsigned major, unsigned minor)
 
 static int usage()
 {
-    printf("usage: mknod <name> <c|b|p> <major> <minor>\n");
+    printf("usage: mknod <name> <c|b|p> [<major> <minor>]\n");
     return 0;
 }
 
@@ -47,10 +47,16 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    // FIXME: When invoked with type "p", no need for major/minor numbers.
     // FIXME: Add some kind of option for specifying the file permissions.
-    if (argc != 5)
+    if (argc < 3)
         return usage();
+
+    if (argv[2][0] == 'p') {
+        if (argc != 3)
+            return usage();
+    } else if (argc != 5) {
+        return usage();
+    }
 
     const char* name = argv[1];
     mode_t mode = 0666;
@@ -69,8 +75,12 @@ int main(int argc, char** argv)
         return usage();
     }
 
-    int major = atoi(argv[3]);
-    int minor = atoi(argv[4]);
+    int major = 0;
+    int minor = 0;
+    if (argc == 5) {
+        major = atoi(argv[3]);
+        minor = atoi(argv[4]);
+    }
 
     int rc = mknod(name, mode, encoded_device(major, minor));
     if (rc < 0) {


### PR DESCRIPTION
This pull request implements FIFOs/named pipes.

- [x] Opening a named pipe opens a pipe instead of a regular file.
- [x] Opening a named pipe blocks until the other end is open.
- [x] Allow `mknod(1)` with no major/minor numbers when opening a named pipe.
- [x] ~~`mkfifo(2)`~~ `mkfifo(3)`
- [x] `mkfifo(1)`

closes #203