### PR TITLE
LibPThread: Make pthread_exit a noreturn function 

### DIFF
--- a/Libraries/LibPthread/pthread.cpp
+++ b/Libraries/LibPthread/pthread.cpp
@@ -83,6 +83,7 @@ static int create_thread(void* (*entry)(void*), void* argument, PthreadAttrImpl*
     return syscall(SC_create_thread, pthread_create_helper, thread_params);
 }
 
+[[noreturn]] 	
 static void exit_thread(void* code)
 {
     syscall(SC_exit_thread, code);

--- a/Libraries/LibPthread/pthread.h
+++ b/Libraries/LibPthread/pthread.h
@@ -35,7 +35,7 @@
 __BEGIN_DECLS
 
 int pthread_create(pthread_t*, pthread_attr_t*, void* (*)(void*), void*);
-void pthread_exit(void*);
+void pthread_exit(void*) __attribute__ ((noreturn));
 int pthread_kill(pthread_t, int);
 void pthread_cleanup_push(void (*)(void*), void*);
 void pthread_cleanup_pop(int);

--- a/Libraries/LibThread/Thread.cpp
+++ b/Libraries/LibThread/Thread.cpp
@@ -51,8 +51,7 @@ void LibThread::Thread::start()
         [](void* arg) -> void* {
             Thread* self = static_cast<Thread*>(arg);
             size_t exit_code = self->m_action();
-            self->m_tid = 0;
-            pthread_exit((void*)exit_code);
+            self->m_tid = 0;            
             return (void*)exit_code;
         },
         static_cast<void*>(this));


### PR DESCRIPTION
LibPThread: mark pthread_exit a noreturn function using compiler attributes
LibThread: remove a call to pthread_exit from Thread::start lambda expression
                  as it make the return from the lambda unreachable.
                 Thread function should either call pthread_exit or return a status at end of function. 