### PR TITLE
AK: fix overflow bug in binary_search

### DIFF
--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -38,13 +38,13 @@ int integral_compare(const T& a, const T& b)
 }
 
 template<typename T, typename Compare>
-T* binary_search(T* haystack, size_t haystack_size, const T& needle, Compare compare = integral_compare, int* nearby_index = nullptr)
+T* binary_search(T* haystack, size_t haystack_size, const T& needle, Compare compare = integral_compare, size_t* nearby_index = nullptr)
 {
-    int low = 0;
-    int high = haystack_size - 1;
+    size_t low = 0;
+    size_t high = haystack_size - 1;
     while (low <= high) {
-        int middle = (low + high) / 2;
-        int comparison = compare(needle, haystack[middle]);
+        size_t middle = low + ((high - low) / 2);
+        size_t comparison = compare(needle, haystack[middle]);
         if (comparison < 0)
             high = middle - 1;
         else if (comparison > 0)

--- a/Kernel/VM/RangeAllocator.cpp
+++ b/Kernel/VM/RangeAllocator.cpp
@@ -172,7 +172,7 @@ void RangeAllocator::deallocate(Range range)
 
     ASSERT(!m_available_ranges.is_empty());
 
-    int nearby_index = 0;
+    size_t nearby_index = 0;
     auto* existing_range = binary_search(
         m_available_ranges.data(), m_available_ranges.size(), range, [](auto& a, auto& b) {
             return a.base().get() - b.end().get();

--- a/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -184,7 +184,7 @@ bool XtermSuggestionDisplay::cleanup()
 size_t XtermSuggestionDisplay::fit_to_page_boundary(size_t selection_index)
 {
     ASSERT(m_pages.size() > 0);
-    int index = 0;
+    size_t index = 0;
 
     auto* match = binary_search(
         m_pages.data(), m_pages.size(), { selection_index, selection_index }, [](auto& a, auto& b) -> int {


### PR DESCRIPTION
fix mixed int/size_t assignment and overflow in computing middle index.