### PR TITLE
AK: fix overflow bug in binary_search

### DIFF
--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -63,7 +63,7 @@ T* binary_search(T* haystack, size_t haystack_size, const T& needle, Compare com
     }
 
     if (nearby_index)
-        *nearby_index = max(static_cast<size_t>(0), min(low, high));
+        *nearby_index = min(low, high);
 
     return nullptr;
 }

--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -38,15 +38,21 @@ int integral_compare(const T& a, const T& b)
 }
 
 template<typename T, typename Compare>
-T* binary_search(T* haystack, size_t haystack_size, const T& needle, Compare compare = integral_compare, int* nearby_index = nullptr)
+T* binary_search(T* haystack, size_t haystack_size, const T& needle, Compare compare = integral_compare, size_t* nearby_index = nullptr)
 {
-    int low = 0;
-    int high = haystack_size - 1;
+    if (!haystack || !haystack_size)
+        return nullptr;
+
+    size_t low = 0;
+    size_t high = haystack_size - 1;
     while (low <= high) {
-        int middle = (low + high) / 2;
+        size_t middle = low + ((high - low) / 2);
         int comparison = compare(needle, haystack[middle]);
         if (comparison < 0)
-            high = middle - 1;
+            if (middle != 0)
+                high = middle - 1;
+            else
+                break;
         else if (comparison > 0)
             low = middle + 1;
         else {
@@ -57,7 +63,7 @@ T* binary_search(T* haystack, size_t haystack_size, const T& needle, Compare com
     }
 
     if (nearby_index)
-        *nearby_index = max(0, min(low, high));
+        *nearby_index = max(static_cast<size_t>(0), min(low, high));
 
     return nullptr;
 }

--- a/AK/Tests/TestBinarySearch.cpp
+++ b/AK/Tests/TestBinarySearch.cpp
@@ -28,6 +28,7 @@
 
 #include <AK/BinarySearch.h>
 #include <cstring>
+#include <new>
 
 TEST_CASE(vector_ints)
 {
@@ -104,6 +105,34 @@ TEST_CASE(no_elements)
 
     auto test1 = binary_search(ints.data(), ints.size(), 1, AK::integral_compare<int>);
     EXPECT_EQ(test1, nullptr);
+}
+
+TEST_CASE(huge_char_array)
+{
+    const size_t N = 2147483680;
+    char* v = new (std::nothrow) char[N];
+
+    EXPECT(v != nullptr);
+    for (size_t i = 0; i < N; ++i)
+        v[i] = 'a';
+    size_t index = N - 1;
+    for (char c = 'z'; c > 'a'; --c)
+        v[index--] = c;
+
+    EXPECT_EQ(v[N - 1], 'z');
+
+    auto where = binary_search(v, N, 'a', AK::integral_compare<char>);
+    EXPECT(where != nullptr);
+    EXPECT_EQ(*where, 'a');
+
+    auto z = binary_search(v, N, 'z', AK::integral_compare<char>);
+    EXPECT(z != nullptr);
+    EXPECT_EQ(*z, 'z');
+
+    auto tilde = binary_search(v, N, '~', AK::integral_compare<char>);
+    EXPECT_EQ(tilde, nullptr);
+
+    delete[] v;
 }
 
 TEST_MAIN(BinarySearch)

--- a/Kernel/VM/RangeAllocator.cpp
+++ b/Kernel/VM/RangeAllocator.cpp
@@ -172,7 +172,7 @@ void RangeAllocator::deallocate(Range range)
 
     ASSERT(!m_available_ranges.is_empty());
 
-    int nearby_index = 0;
+    size_t nearby_index = 0;
     auto* existing_range = binary_search(
         m_available_ranges.data(), m_available_ranges.size(), range, [](auto& a, auto& b) {
             return a.base().get() - b.end().get();

--- a/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -184,7 +184,7 @@ bool XtermSuggestionDisplay::cleanup()
 size_t XtermSuggestionDisplay::fit_to_page_boundary(size_t selection_index)
 {
     ASSERT(m_pages.size() > 0);
-    int index = 0;
+    size_t index = 0;
 
     auto* match = binary_search(
         m_pages.data(), m_pages.size(), { selection_index, selection_index }, [](auto& a, auto& b) -> int {


### PR DESCRIPTION
fix for issue #2866 : binary search will fail on large arrays due to overflows and mixed signed/unsigned int operations.