### PR TITLE
LibGUI: Box button improvement

### DIFF
--- a/Libraries/LibGUI/CMakeLists.txt
+++ b/Libraries/LibGUI/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     ColumnsView.cpp
     ComboBox.cpp
     Command.cpp
+    ControlBoxButton.cpp
     CppLexer.cpp
     CppSyntaxHighlighter.cpp
     Desktop.cpp

--- a/Libraries/LibGUI/ComboBox.cpp
+++ b/Libraries/LibGUI/ComboBox.cpp
@@ -24,8 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibGUI/Button.h>
 #include <LibGUI/ComboBox.h>
+#include <LibGUI/ControlBoxButton.h>
 #include <LibGUI/Desktop.h>
 #include <LibGUI/ListView.h>
 #include <LibGUI/Model.h>
@@ -89,9 +89,8 @@ ComboBox::ComboBox()
             m_open_button->click();
     };
 
-    m_open_button = add<Button>();
+    m_open_button = add<ControlBoxButton>(ControlBoxButton::DownArrow);
     m_open_button->set_focusable(false);
-    m_open_button->set_text("\xE2\xAC\x87"); // DOWNWARDS BLACK ARROW
     m_open_button->on_click = [this](auto) {
         if (m_list_window->is_visible())
             close();

--- a/Libraries/LibGUI/ComboBox.h
+++ b/Libraries/LibGUI/ComboBox.h
@@ -31,6 +31,7 @@
 namespace GUI {
 
 class ComboBoxEditor;
+class ControlBoxButton;
 
 class ComboBox : public Widget {
     C_OBJECT(ComboBox)
@@ -65,7 +66,7 @@ protected:
 
 private:
     RefPtr<ComboBoxEditor> m_editor;
-    RefPtr<Button> m_open_button;
+    RefPtr<ControlBoxButton> m_open_button;
     RefPtr<Window> m_list_window;
     RefPtr<ListView> m_list_view;
     bool m_only_allow_values_from_model { false };

--- a/Libraries/LibGUI/ControlBoxButton.cpp
+++ b/Libraries/LibGUI/ControlBoxButton.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020, Charles Chaucer <thankyouverycool@github>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibGUI/ControlBoxButton.h>
+#include <LibGUI/Painter.h>
+#include <LibGfx/CharacterBitmap.h>
+#include <LibGfx/Palette.h>
+
+namespace GUI {
+
+static const char* s_up_arrow_bitmap_data = {
+    "         "
+    "    #    "
+    "   ###   "
+    "  #####  "
+    " ####### "
+    "         "
+};
+
+static const char* s_down_arrow_bitmap_data = {
+    "         "
+    " ####### "
+    "  #####  "
+    "   ###   "
+    "    #    "
+    "         "
+};
+
+static Gfx::CharacterBitmap* s_up_arrow_bitmap;
+static Gfx::CharacterBitmap* s_down_arrow_bitmap;
+static const int s_bitmap_width = 9;
+static const int s_bitmap_height = 6;
+
+ControlBoxButton::ControlBoxButton(Type type)
+    : m_type(type)
+{
+}
+
+ControlBoxButton::~ControlBoxButton()
+{
+}
+
+void ControlBoxButton::paint_event(PaintEvent& event)
+{
+    Painter painter(*this);
+    painter.add_clip_rect(event.rect());
+
+    Gfx::StylePainter::paint_button(painter, rect(), palette(), Gfx::ButtonStyle::Normal, is_being_pressed(), is_hovered(), is_checked(), is_enabled());
+
+    auto button_location = rect().location().translated((width() - s_bitmap_width) / 2, (height() - s_bitmap_height) / 2);
+
+    if (is_being_pressed())
+        button_location.move_by(1, 1);
+
+    if (type() == UpArrow) {
+        if (!s_up_arrow_bitmap)
+            s_up_arrow_bitmap = &Gfx::CharacterBitmap::create_from_ascii(s_up_arrow_bitmap_data, s_bitmap_width, s_bitmap_height).leak_ref();
+        painter.draw_bitmap(button_location, *s_up_arrow_bitmap, is_enabled() ? palette().button_text() : palette().threed_shadow1());
+    } else {
+        if (!s_down_arrow_bitmap)
+            s_down_arrow_bitmap = &Gfx::CharacterBitmap::create_from_ascii(s_down_arrow_bitmap_data, s_bitmap_width, s_bitmap_height).leak_ref();
+        painter.draw_bitmap(button_location, *s_down_arrow_bitmap, is_enabled() ? palette().button_text() : palette().threed_shadow1());
+    }
+}
+
+}

--- a/Libraries/LibGUI/ControlBoxButton.h
+++ b/Libraries/LibGUI/ControlBoxButton.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, Charles Chaucer <thankyouverycool@github>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibGUI/Button.h>
+
+namespace GUI {
+
+class ControlBoxButton final : public Button {
+    C_OBJECT(ControlBoxButton);
+
+public:
+    enum Type {
+        UpArrow,
+        DownArrow
+    };
+
+    virtual ~ControlBoxButton() override;
+
+private:
+    explicit ControlBoxButton(const Type type);
+    virtual void paint_event(PaintEvent& event) override;
+
+    Type m_type { DownArrow };
+    Type type() const { return m_type; }
+};
+
+}

--- a/Libraries/LibGUI/SpinBox.cpp
+++ b/Libraries/LibGUI/SpinBox.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibGUI/Button.h>
+#include <LibGUI/ControlBoxButton.h>
 #include <LibGUI/SpinBox.h>
 #include <LibGUI/TextBox.h>
 
@@ -41,14 +41,13 @@ SpinBox::SpinBox()
         else
             m_editor->set_text(String::number(m_value));
     };
-    m_increment_button = add<Button>();
+
+    m_increment_button = add<ControlBoxButton>(ControlBoxButton::UpArrow);
     m_increment_button->set_focusable(false);
-    m_increment_button->set_text("\xE2\xAC\x86"); // UPWARDS BLACK ARROW
     m_increment_button->on_click = [this](auto) { set_value(m_value + 1); };
     m_increment_button->set_auto_repeat_interval(150);
-    m_decrement_button = add<Button>();
+    m_decrement_button = add<ControlBoxButton>(ControlBoxButton::DownArrow);
     m_decrement_button->set_focusable(false);
-    m_decrement_button->set_text("\xE2\xAC\x87"); // DOWNWARDS BLACK ARROW
     m_decrement_button->on_click = [this](auto) { set_value(m_value - 1); };
     m_decrement_button->set_auto_repeat_interval(150);
 }

--- a/Libraries/LibGUI/SpinBox.h
+++ b/Libraries/LibGUI/SpinBox.h
@@ -30,6 +30,8 @@
 
 namespace GUI {
 
+class ControlBoxButton;
+
 class SpinBox : public Widget {
     C_OBJECT(SpinBox)
 public:
@@ -55,8 +57,8 @@ protected:
 
 private:
     RefPtr<TextEditor> m_editor;
-    RefPtr<Button> m_increment_button;
-    RefPtr<Button> m_decrement_button;
+    RefPtr<ControlBoxButton> m_increment_button;
+    RefPtr<ControlBoxButton> m_decrement_button;
 
     int m_min { 0 };
     int m_max { 100 };


### PR DESCRIPTION
Lets combo and spin buttons take advantage of current theming independent of emojis.
![controlboxbuttons](https://user-images.githubusercontent.com/66646555/87884138-496aa200-c9da-11ea-9669-a33d53b29d3c.png)
