### PR TITLE
TextEditor: Preserve preview scroll position across page refreshes

### DIFF
--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -606,11 +606,15 @@ void TextEditorWidget::update_markdown_preview()
     auto document = Markdown::Document::parse(m_editor->text());
     if (document) {
         auto html = document->render_to_html();
+        auto current_scroll_pos = m_page_view->visible_content_rect();
         m_page_view->load_html(html, URL::create_with_file_protocol(m_path));
+        m_page_view->scroll_into_view(current_scroll_pos, true, true);
     }
 }
 
 void TextEditorWidget::update_html_preview()
 {
+    auto current_scroll_pos = m_page_view->visible_content_rect();
     m_page_view->load_html(m_editor->text(), URL::create_with_file_protocol(m_path));
+    m_page_view->scroll_into_view(current_scroll_pos, true, true);
 }


### PR DESCRIPTION
This is a tiny fix to make the text editor preview pane not scroll to the top every time it refreshes. This makes editing long documents with the TextEditor much more pleasant.