### PR TITLE
TextEditor: Jump to word break when deleting and holding Ctrl modifier

### DIFF
--- a/Libraries/LibGUI/TextDocument.cpp
+++ b/Libraries/LibGUI/TextDocument.cpp
@@ -442,8 +442,8 @@ TextPosition TextDocument::first_word_break_before(const TextPosition& position,
     auto is_start_alphanumeric = isalnum(line.codepoints()[target.column() - (start_at_column_before ? 1 : 0)]);
 
     while (target.column() > 0) {
-        auto next_codepoint = line.codepoints()[target.column() - 1];
-        if ((is_start_alphanumeric && !isalnum(next_codepoint)) || (!is_start_alphanumeric && isalnum(next_codepoint)))
+        auto prev_codepoint = line.codepoints()[target.column() - 1];
+        if ((is_start_alphanumeric && !isalnum(prev_codepoint)) || (!is_start_alphanumeric && isalnum(prev_codepoint)))
             break;
         target.set_column(target.column() - 1);
     }

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -895,7 +895,10 @@ void TextEditor::keydown_event(KeyEvent& event)
         }
         if (m_cursor.column() > 0) {
             int erase_count = 1;
-            if (current_line().first_non_whitespace_column() >= m_cursor.column()) {
+            if (event.modifiers() == Mod_Ctrl) {
+                auto word_break_pos = document().first_word_break_before(m_cursor, true);
+                erase_count = m_cursor.column() - word_break_pos.column();
+            } else if (current_line().first_non_whitespace_column() >= m_cursor.column()) {
                 int new_column;
                 if (m_cursor.column() % m_soft_tab_width == 0)
                     new_column = m_cursor.column() - m_soft_tab_width;


### PR DESCRIPTION
I often use this shortcut for quicker text editing. Thought it'd be useful for Serenity as well.