### PR TITLE
LibJS: Fix \x escapes of bytes with high bit set

### DIFF
--- a/Libraries/LibJS/Tests/string-escapes.js
+++ b/Libraries/LibJS/Tests/string-escapes.js
@@ -3,6 +3,7 @@ test("hex escapes", () => {
     expect("X55").toBe("X55");
     expect(`\x55`).toBe("U");
     expect(`\X55`).toBe("X55");
+    expect("\xff").toBe(String.fromCharCode(0xff));
 });
 
 test("unicode escapes", () => {
@@ -10,4 +11,5 @@ test("unicode escapes", () => {
     expect(`\u26a0`).toBe("⚠");
     expect("\u{1f41e}").toBe("🐞");
     expect(`\u{1f41e}`).toBe("🐞");
+    expect("\u00ff").toBe(String.fromCharCode(0xff));
 });

--- a/Libraries/LibJS/Token.cpp
+++ b/Libraries/LibJS/Token.cpp
@@ -136,7 +136,7 @@ String Token::string_value(StringValueStatus& status) const
                 auto digit2 = m_value[++i];
                 if (!isxdigit(digit1) || !isxdigit(digit2))
                     return encoding_failure(StringValueStatus::MalformedHexEscape);
-                builder.append(static_cast<char>(hex2int(digit1) * 16 + hex2int(digit2)));
+                builder.append_codepoint(hex2int(digit1) * 16 + hex2int(digit2));
                 break;
             }
             case 'u': {
@@ -174,7 +174,7 @@ String Token::string_value(StringValueStatus& status) const
                     }
                 }
 
-                builder.append({ &code_point, 1 });
+                builder.append_codepoint(code_point);
                 break;
             }
             default:


### PR DESCRIPTION
With this, typing `"\xff"` into Browser's console no longer
makes the app crash.

While here, also make the \u handler call append_codepoint()
instead of calling an overload where it's not immediately clear
which overload is getting called. This has no behavior change.