### PR TITLE
test-web: Add ability to change page mid-test

### DIFF
--- a/Base/res/html/misc/blank-no-doctype.html
+++ b/Base/res/html/misc/blank-no-doctype.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<title>Blank</title>
+</head>
+<body>
+</body>
+</html>

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.cpp
@@ -117,6 +117,12 @@ HTMLDocumentParser::HTMLDocumentParser(const StringView& input, const String& en
     m_document = adopt(*new Document);
 }
 
+HTMLDocumentParser::HTMLDocumentParser(const StringView& input, const String& encoding, Document& existing_document)
+    : m_tokenizer(input, encoding)
+    , m_document(existing_document)
+{
+}
+
 HTMLDocumentParser::~HTMLDocumentParser()
 {
 }

--- a/Libraries/LibWeb/Parser/HTMLDocumentParser.h
+++ b/Libraries/LibWeb/Parser/HTMLDocumentParser.h
@@ -64,6 +64,7 @@ RefPtr<Document> parse_html_document(const StringView&, const URL&, const String
 class HTMLDocumentParser {
 public:
     HTMLDocumentParser(const StringView& input, const String& encoding);
+    HTMLDocumentParser(const StringView& input, const String& encoding, Document& existing_document);
     ~HTMLDocumentParser();
 
     void run(const URL&);

--- a/Libraries/LibWeb/Tests/Document/Doctype.js
+++ b/Libraries/LibWeb/Tests/Document/Doctype.js
@@ -1,11 +1,18 @@
 loadPage("file:///res/html/misc/blank.html");
 
-afterPageLoad(() => {
+afterInitialPageLoad(() => {
     test("Basic functionality", () => {
         expect(document.compatMode).toBe("CSS1Compat");
-        expect(document.doctype).toBeDefined();
+        expect(document.doctype).not.toBe(null);
         expect(document.doctype.name).toBe("html");
         expect(document.doctype.publicId).toBe("");
         expect(document.doctype.systemId).toBe("");
+    });
+
+    libweb_tester.changePage("file:///res/html/misc/blank-no-doctype.html");
+
+    test("Quirks mode", () => {
+        expect(document.compatMode).toBe("BackCompat");
+        expect(document.doctype).toBe(null);
     });
 });

--- a/Libraries/LibWeb/Tests/Window/Base64.js
+++ b/Libraries/LibWeb/Tests/Window/Base64.js
@@ -1,6 +1,6 @@
 loadPage("file:///res/html/misc/blank.html");
 
-afterPageLoad(() => {
+afterInitialPageLoad(() => {
     test("atob", () => {
         expect(atob("YQ==")).toBe("a");
         expect(atob("YWE=")).toBe("aa");

--- a/Libraries/LibWeb/Tests/test-common.js
+++ b/Libraries/LibWeb/Tests/test-common.js
@@ -1,28 +1,32 @@
 // NOTE: The tester loads in LibJS's test-common to prevent duplication.
 
+// NOTE: "window.libweb_tester" is set to a special tester object.
+//       The object currently provides the following functions:
+//       - changePage(url) - change page to given URL. Everything afterwards will refer to the new page.
+
 let __PageToLoad__;
 
 // This tells the tester which page to load.
 // This will only be checked when we look at which page the test wants to use.
-// Subsequent calls to loadPage in before/after load will be ignored.
+// Subsequent calls to loadPage in before/after initial load will be ignored.
 let loadPage;
 
-let __BeforePageLoad__ = () => {};
+let __BeforeInitialPageLoad__ = () => {};
 
-// This function will be run just before loading the page.
+// This function will be called just before loading the initial page.
 // This is useful for injecting event listeners.
 // Defaults to an empty function.
-let beforePageLoad;
+let beforeInitialPageLoad;
 
-let __AfterPageLoad__ = () => {};
+let __AfterInitialPageLoad__ = () => {};
 
-// This function will be run just after loading the page.
+// This function will be called just after loading the initial page.
 // This is where the main bulk of the tests should be.
 // Defaults to an empty function.
-let afterPageLoad;
+let afterInitialPageLoad;
 
 (() => {
     loadPage = (page) => __PageToLoad__ = page;
-    beforePageLoad = (callback) => __BeforePageLoad__ = callback;
-    afterPageLoad = (callback) => __AfterPageLoad__ = callback;
+    beforeInitialPageLoad = (callback) => __BeforeInitialPageLoad__ = callback;
+    afterInitialPageLoad = (callback) => __AfterInitialPageLoad__ = callback;
 })();


### PR DESCRIPTION
This allows you to not have to write a separate test file
for the same thing but in a different situation.

This doesn't handle when you change the page with location.href
however.

Changes the name of the page load handlers to prevent confusion
with this.