### PR TITLE
Kernel: Allow process creation during low-entropy condition

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -1118,7 +1118,7 @@ Vector<AuxiliaryValue> Process::generate_auxiliary_vector() const
     auxv.append({ AuxiliaryValue::Secure, ((m_uid != m_euid) || (m_gid != m_egid)) ? 1 : 0 });
 
     char random_bytes[16] {};
-    get_good_random_bytes((u8*)random_bytes, sizeof(random_bytes));
+    get_fast_random_bytes((u8*)random_bytes, sizeof(random_bytes));
 
     auxv.append({ AuxiliaryValue::Random, String(random_bytes, sizeof(random_bytes)) });
 


### PR DESCRIPTION
Fixes #2871.

Ignoring the 'securely generated bytes' constraint seems to
be fine for Linux, so it's probably fine for Serenity.

Note that there *might* be more bottlenecks down the road
if Serenity is started in a non-GUI way. Currently though,
loading the GUI seems to generate enough interrupts to
seed the entropy pool, even on my non-RDRAND setup. Yay! :^)