### PR TITLE
LibHTTP: Be more tolerant about bad chunked encoding trailers

### DIFF
--- a/Libraries/LibHTTP/HttpJob.h
+++ b/Libraries/LibHTTP/HttpJob.h
@@ -51,6 +51,7 @@ public:
     virtual void shutdown() override;
 
 protected:
+    virtual bool should_fail_on_empty_payload() const override { return false; }
     virtual void register_on_ready_to_read(Function<void()>) override;
     virtual void register_on_ready_to_write(Function<void()>) override;
     virtual bool can_read_line() const override;


### PR DESCRIPTION
Some servers (*glares at cloudflare*) like to send two last chunks,
which is strictly against the spec. Let's be more tolerant of this
behaviour.

> that's sad. Big Co should just fix their crappy out of spec program