### PR TITLE
Implement AK::Span which is like std::span and represents a contiguous sequence of objects.

### DIFF
--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
@@ -38,10 +39,10 @@ int integral_compare(const T& a, const T& b)
 }
 
 template<typename T, typename Compare>
-T* binary_search(T* haystack, size_t haystack_size, const T& needle, Compare compare = integral_compare, int* nearby_index = nullptr)
+T* binary_search(Span<T> haystack, const T& needle, Compare compare = integral_compare, int* nearby_index = nullptr)
 {
     int low = 0;
-    int high = haystack_size - 1;
+    int high = haystack.size() - 1;
     while (low <= high) {
         int middle = (low + high) / 2;
         int comparison = compare(needle, haystack[middle]);

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -50,6 +50,12 @@ class Utf32View;
 class Utf8View;
 
 template<typename T>
+class Span;
+
+using ReadonlyBytes = Span<const u8>;
+using Bytes = Span<u8>;
+
+template<typename T>
 class Atomic;
 
 template<typename T>
@@ -113,6 +119,7 @@ using AK::Badge;
 using AK::Bitmap;
 using AK::BufferStream;
 using AK::ByteBuffer;
+using AK::Bytes;
 using AK::CircularQueue;
 using AK::DebugLogStream;
 using AK::DoublyLinkedList;
@@ -131,9 +138,11 @@ using AK::NonnullOwnPtr;
 using AK::NonnullRefPtr;
 using AK::Optional;
 using AK::OwnPtr;
+using AK::ReadonlyBytes;
 using AK::RefPtr;
 using AK::SharedBuffer;
 using AK::SinglyLinkedList;
+using AK::Span;
 using AK::String;
 using AK::StringBuilder;
 using AK::StringImpl;

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/Checked.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+template<typename T>
+class Span {
+public:
+    using Iterator = T*;
+    using ConstIterator = const T*;
+
+    static_assert(!IsPointer<T>::value);
+
+    ALWAYS_INLINE Span() = default;
+    ALWAYS_INLINE Span(T* values, size_t size)
+        : m_values(values)
+        , m_size(size)
+    {
+        ASSERT(!Checked<uintptr_t>::addition_would_overflow((uintptr_t)values, size * sizeof(T)));
+    }
+    ALWAYS_INLINE Span(const Span& other)
+        : m_values(other.m_values)
+        , m_size(other.m_size)
+    {
+    }
+    ALWAYS_INLINE Span(const Span<RemoveConst<T>>& other)
+        : m_values(other.m_values)
+        , m_size(other.m_size)
+    {
+    }
+
+    ALWAYS_INLINE const T* data() const { return m_values; }
+    ALWAYS_INLINE T* data() { return m_values; }
+
+    ALWAYS_INLINE ConstIterator begin() const
+    {
+        return m_values;
+    }
+    ALWAYS_INLINE ConstIterator end() const
+    {
+        return begin() + m_size;
+    }
+
+    ALWAYS_INLINE Iterator begin()
+    {
+        return m_values;
+    }
+    ALWAYS_INLINE Iterator end()
+    {
+        return begin() + m_size;
+    }
+
+    ALWAYS_INLINE size_t size() const { return m_size; }
+
+    ALWAYS_INLINE bool is_empty() const { return m_size == 0; }
+
+    ALWAYS_INLINE Span<T> subspan(size_t start, size_t size) const
+    {
+        ASSERT(start + size <= m_size);
+        return { m_values + start, size };
+    }
+
+    ALWAYS_INLINE const T& at(size_t index) const
+    {
+        ASSERT(index < m_size);
+        return m_values[index];
+    }
+    ALWAYS_INLINE T& at(size_t index)
+    {
+        ASSERT(index < m_size);
+        return m_values[index];
+    }
+
+    ALWAYS_INLINE T& operator[](size_t index) const
+    {
+        return m_values[index];
+    }
+    ALWAYS_INLINE T& operator[](size_t index)
+    {
+        return m_values[index];
+    }
+
+    ALWAYS_INLINE T& operator=(const T& other)
+    {
+        m_size = other.m_size;
+        m_values = other.m_values;
+    }
+
+protected:
+    T* m_values { nullptr };
+    size_t m_size { 0 };
+};
+
+using ReadonlyBytes = Span<const u8>;
+using Bytes = Span<u8>;
+
+}
+
+using AK::Bytes;
+using AK::ReadonlyBytes;
+using AK::Span;

--- a/AK/Tests/Span.cpp
+++ b/AK/Tests/Span.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/Checked.h>
+#include <AK/Span.h>
+#include <AK/StdLibExtras.h>
+
+TEST_CASE(default_constructor_is_empty)
+{
+    Span<int> span;
+    EXPECT(span.is_empty());
+}
+
+TEST_CASE(span_works_with_constant_types)
+{
+    const u8 buffer[4] { 1, 2, 3, 4 };
+    ReadonlyBytes bytes { buffer, 4 };
+
+    EXPECT(AK::IsConst<AK::RemoveReference<decltype(bytes[1])>::Type>::value);
+    EXPECT_EQ(bytes[2], 3);
+}
+
+TEST_CASE(span_works_with_mutable_types)
+{
+    u8 buffer[4] { 1, 2, 3, 4 };
+    Bytes bytes { buffer, 4 };
+
+    EXPECT_EQ(bytes[2], 3);
+    ++bytes[2];
+    EXPECT_EQ(bytes[2], 4);
+}
+
+TEST_CASE(iterator_behaves_like_loop)
+{
+    u8 buffer[256];
+    for (int idx = 0; idx < 256; ++idx) {
+        buffer[idx] = static_cast<u8>(idx);
+    }
+
+    Bytes bytes { buffer, 256 };
+    size_t idx = 0;
+    for (auto iter = bytes.begin(); iter < bytes.end(); ++iter) {
+        EXPECT_EQ(*iter, buffer[idx]);
+
+        ++idx;
+    }
+}
+
+TEST_CASE(modifying_is_possible)
+{
+    int values_before[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    int values_after[8] = { 7, 6, 5, 4, 3, 2, 1, 0 };
+
+    Span<int> span { values_before, 8 };
+    for (auto& value : span) {
+        value = 8 - value;
+    }
+
+    for (int idx = 0; idx < 8; ++idx) {
+        EXPECT_EQ(values_before[idx], values_after[idx]);
+    }
+}
+
+TEST_CASE(at_and_index_operator_return_same_value)
+{
+    u8 buffer[256];
+    for (int idx = 0; idx < 256; ++idx) {
+        buffer[idx] = static_cast<u8>(idx);
+    }
+
+    Bytes bytes { buffer, 256 };
+    for (int idx = 0; idx < 256; ++idx) {
+        EXPECT_EQ(buffer[idx], bytes[idx]);
+        EXPECT_EQ(bytes[idx], bytes.at(idx));
+    }
+}
+
+TEST_CASE(can_subspan_whole_span)
+{
+    u8 buffer[16];
+    Bytes bytes { buffer, 16 };
+
+    Bytes subspan = bytes.subspan(0, 16);
+
+    EXPECT_EQ(subspan.data(), buffer);
+    EXPECT_EQ(subspan.size(), 16u);
+}
+
+TEST_CASE(can_subspan_as_intended)
+{
+    const u16 buffer[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+    Span<const u16> span { buffer, 8 };
+    auto subspan = span.subspan(3, 2);
+
+    EXPECT_EQ(subspan.size(), 2u);
+    EXPECT_EQ(subspan[0], 4);
+    EXPECT_EQ(subspan[1], 5);
+}
+
+TEST_MAIN(Span)

--- a/AK/Tests/TestBinarySearch.cpp
+++ b/AK/Tests/TestBinarySearch.cpp
@@ -36,9 +36,9 @@ TEST_CASE(vector_ints)
     ints.append(2);
     ints.append(3);
 
-    auto test1 = *binary_search(ints.data(), ints.size(), 1, AK::integral_compare<int>);
-    auto test2 = *binary_search(ints.data(), ints.size(), 2, AK::integral_compare<int>);
-    auto test3 = *binary_search(ints.data(), ints.size(), 3, AK::integral_compare<int>);
+    auto test1 = *binary_search(ints.span(), 1, AK::integral_compare<int>);
+    auto test2 = *binary_search(ints.span(), 2, AK::integral_compare<int>);
+    auto test3 = *binary_search(ints.span(), 3, AK::integral_compare<int>);
     EXPECT_EQ(test1, 1);
     EXPECT_EQ(test2, 2);
     EXPECT_EQ(test3, 3);
@@ -48,9 +48,9 @@ TEST_CASE(array_doubles)
 {
     double doubles[] = { 1.1, 9.9, 33.33 };
 
-    auto test1 = *binary_search(doubles, 3, 1.1, AK::integral_compare<double>);
-    auto test2 = *binary_search(doubles, 3, 9.9, AK::integral_compare<double>);
-    auto test3 = *binary_search(doubles, 3, 33.33, AK::integral_compare<double>);
+    auto test1 = *binary_search({ doubles, 3 }, 1.1, AK::integral_compare<double>);
+    auto test2 = *binary_search({ doubles, 3 }, 9.9, AK::integral_compare<double>);
+    auto test3 = *binary_search({ doubles, 3 }, 33.33, AK::integral_compare<double>);
     EXPECT_EQ(test1, 1.1);
     EXPECT_EQ(test2, 9.9);
     EXPECT_EQ(test3, 33.33);
@@ -66,9 +66,9 @@ TEST_CASE(vector_strings)
     auto string_compare = [](const String& a, const String& b) -> int {
         return strcmp(a.characters(), b.characters());
     };
-    auto test1 = *binary_search(strings.data(), strings.size(), String("bat"), string_compare);
-    auto test2 = *binary_search(strings.data(), strings.size(), String("cat"), string_compare);
-    auto test3 = *binary_search(strings.data(), strings.size(), String("dog"), string_compare);
+    auto test1 = *binary_search(strings.span(), String("bat"), string_compare);
+    auto test2 = *binary_search(strings.span(), String("cat"), string_compare);
+    auto test3 = *binary_search(strings.span(), String("dog"), string_compare);
     EXPECT_EQ(test1, String("bat"));
     EXPECT_EQ(test2, String("cat"));
     EXPECT_EQ(test3, String("dog"));
@@ -79,7 +79,7 @@ TEST_CASE(single_element)
     Vector<int> ints;
     ints.append(1);
 
-    auto test1 = *binary_search(ints.data(), ints.size(), 1, AK::integral_compare<int>);
+    auto test1 = *binary_search(ints.span(), 1, AK::integral_compare<int>);
     EXPECT_EQ(test1, 1);
 }
 
@@ -90,9 +90,9 @@ TEST_CASE(not_found)
     ints.append(2);
     ints.append(3);
 
-    auto test1 = binary_search(ints.data(), ints.size(), -1, AK::integral_compare<int>);
-    auto test2 = binary_search(ints.data(), ints.size(), 0, AK::integral_compare<int>);
-    auto test3 = binary_search(ints.data(), ints.size(), 4, AK::integral_compare<int>);
+    auto test1 = binary_search(ints.span(), -1, AK::integral_compare<int>);
+    auto test2 = binary_search(ints.span(), 0, AK::integral_compare<int>);
+    auto test3 = binary_search(ints.span(), 4, AK::integral_compare<int>);
     EXPECT_EQ(test1, nullptr);
     EXPECT_EQ(test2, nullptr);
     EXPECT_EQ(test3, nullptr);
@@ -102,7 +102,7 @@ TEST_CASE(no_elements)
 {
     Vector<int> ints;
 
-    auto test1 = binary_search(ints.data(), ints.size(), 1, AK::integral_compare<int>);
+    auto test1 = binary_search(ints.span(), 1, AK::integral_compare<int>);
     EXPECT_EQ(test1, nullptr);
 }
 

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -29,6 +29,7 @@
 #include <AK/Assertions.h>
 #include <AK/Forward.h>
 #include <AK/Optional.h>
+#include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Traits.h>
 #include <AK/kmalloc.h>
@@ -185,6 +186,9 @@ public:
         TypedTransfer<T>::copy(data(), other.data(), other.size());
         m_size = other.size();
     }
+
+    Span<T> span() { return { data(), size() }; }
+    Span<const T> span() const { return { data(), size() }; }
 
     // FIXME: What about assigning from a vector with lower inline capacity?
     Vector& operator=(Vector&& other)

--- a/Kernel/VM/RangeAllocator.cpp
+++ b/Kernel/VM/RangeAllocator.cpp
@@ -174,7 +174,7 @@ void RangeAllocator::deallocate(Range range)
 
     int nearby_index = 0;
     auto* existing_range = binary_search(
-        m_available_ranges.data(), m_available_ranges.size(), range, [](auto& a, auto& b) {
+        m_available_ranges.span(), range, [](auto& a, auto& b) {
             return a.base().get() - b.end().get();
         },
         &nearby_index);

--- a/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -187,7 +187,7 @@ size_t XtermSuggestionDisplay::fit_to_page_boundary(size_t selection_index)
     int index = 0;
 
     auto* match = binary_search(
-        m_pages.data(), m_pages.size(), { selection_index, selection_index }, [](auto& a, auto& b) -> int {
+        m_pages.span(), { selection_index, selection_index }, [](auto& a, auto& b) -> int {
             if (a.start >= b.start && a.start < b.end)
                 return 0;
             return a.start - b.start;

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -878,7 +878,7 @@ Vector<Line::CompletionSuggestion> Shell::complete_path(const String& base, cons
 
 Vector<Line::CompletionSuggestion> Shell::complete_program_name(const String& name, size_t offset)
 {
-    auto match = binary_search(cached_path.data(), cached_path.size(), name, [](const String& name, const String& program) -> int {
+    auto match = binary_search(cached_path.span(), name, [](const String& name, const String& program) -> int {
         return strncmp(name.characters(), program.characters(), name.length());
     });
 

--- a/Userland/allocate.cpp
+++ b/Userland/allocate.cpp
@@ -37,14 +37,14 @@ void usage(void)
     exit(1);
 }
 
-enum Unit { Bytes,
+enum class Unit { Bytes,
     KiloBytes,
     MegaBytes };
 
 int main(int argc, char** argv)
 {
     int count = 50;
-    Unit unit = MegaBytes;
+    auto unit = Unit::MegaBytes;
 
     if (argc >= 2) {
         auto number = String(argv[1]).to_uint();
@@ -56,22 +56,22 @@ int main(int argc, char** argv)
 
     if (argc >= 3) {
         if (strcmp(argv[2], "B") == 0)
-            unit = Bytes;
+            unit = Unit::Bytes;
         else if (strcmp(argv[2], "KB") == 0)
-            unit = KiloBytes;
+            unit = Unit::KiloBytes;
         else if (strcmp(argv[2], "MB") == 0)
-            unit = MegaBytes;
+            unit = Unit::MegaBytes;
         else
             usage();
     }
 
     switch (unit) {
-    case Bytes:
+    case Unit::Bytes:
         break;
-    case KiloBytes:
+    case Unit::KiloBytes:
         count *= 1024;
         break;
-    case MegaBytes:
+    case Unit::MegaBytes:
         count *= 1024 * 1024;
         break;
     }


### PR DESCRIPTION
There are functions in the code base that have signatures like `void foo(int* values, size_t count)`. With `AK::Span` these parameter pairs could be replaced with a single parameter, for example `void foo(Span<int> values)`.

I added a commit that changes the signature of `AK::binary_search` to use this new class. I wasn't sure if it would be a good idea to dig though the code base and start changing a ton of function signatures to use this new class, but this should at least demonstrate the usage of this class.

I can edit this pull request or create follow up pull requests that change some code to use this class, especially `AK::ByteBuffer` could benefit from this.

---

There is one drawback with this class, the following won't compile:

~~~c++
Span<int> foo(void* values, size_t count) {
    // error: invalid conversion from 'void*' to 'int*'
    return { values, count };
}
~~~

There are a few places where this could be problematic, but these could be fixed using `reinterpret_cast` or by propagating `Span` further.

