### PR TITLE
Documentation: Only install missing packages for Arch Linux.

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -22,7 +22,7 @@ sudo zypper install curl cmake mpfr-devel libmpc-devel gmp-devel e2fsprogs patch
 
 **Arch Linux / Manjaro**
 ```bash
-sudo pacman -S base-devel cmake curl mpfr libmpc gmp e2fsprogs qemu qemu-arch-extra
+sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs qemu qemu-arch-extra
 ```
 
 **ALT Linux**


### PR DESCRIPTION
By default `pacman -S` will reinstall all the packages that are already installed on the system. Here is a demonstration:

~~~none
$ sudo pacman -S cmake
warning: cmake-3.18.0-3 is up to date -- reinstalling
resolving dependencies...
looking for conflicting packages...

Packages (1) cmake-3.18.0-3

Total Installed Size:  43.01 MiB
Net Upgrade Size:       0.00 MiB
~~~
~~~none
$ sudo pacman -S --needed cmake
warning: cmake-3.18.0-3 is up to date -- skipping
 there is nothing to do
~~~
