### PR TITLE
CppLexer: Add a few token types

### DIFF
--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -243,6 +243,17 @@ Vector<CppToken> CppLexer::lex()
         tokens.append(token);
     };
 
+    auto emit_token_equals = [&](auto type, auto equals_type) {
+        if (peek(1) == '=') {
+            begin_token();
+            consume();
+            consume();
+            commit_token(equals_type);
+            return;
+        }
+        emit_token(type);
+    };
+
     auto match_escape_sequence = [&]() -> size_t {
         switch (peek(1)) {
         case '\'':
@@ -336,7 +347,7 @@ Vector<CppToken> CppLexer::lex()
             continue;
         }
         if (ch == '*') {
-            emit_token(CppToken::Type::Asterisk);
+            emit_token_equals(CppToken::Type::Asterisk, CppToken::Type::AsteriskEquals);
             continue;
         }
         if (ch == ';') {

--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -346,8 +346,20 @@ Vector<CppToken> CppLexer::lex()
             emit_token(CppToken::Type::Comma);
             continue;
         }
+        if (ch == '+') {
+            emit_token_equals(CppToken::Type::Plus, CppToken::Type::PlusEquals);
+            continue;
+        }
+        if (ch == '-') {
+            emit_token_equals(CppToken::Type::Minus, CppToken::Type::MinusEquals);
+            continue;
+        }
         if (ch == '*') {
             emit_token_equals(CppToken::Type::Asterisk, CppToken::Type::AsteriskEquals);
+            continue;
+        }
+        if (ch == '=') {
+            emit_token_equals(CppToken::Type::Equals, CppToken::Type::EqualsEquals);
             continue;
         }
         if (ch == ';') {
@@ -420,6 +432,10 @@ Vector<CppToken> CppLexer::lex()
             }
 
             commit_token(CppToken::Type::Comment);
+            continue;
+        }
+        if (ch == '/') {
+            emit_token_equals(CppToken::Type::Slash, CppToken::Type::SlashEquals);
             continue;
         }
         if (ch == '"') {

--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -44,8 +44,16 @@ namespace GUI {
     __TOKEN(LeftBracket)           \
     __TOKEN(RightBracket)          \
     __TOKEN(Comma)                 \
+    __TOKEN(Plus)                  \
+    __TOKEN(PlusEquals)            \
+    __TOKEN(Minus)                 \
+    __TOKEN(MinusEquals)           \
     __TOKEN(Asterisk)              \
     __TOKEN(AsteriskEquals)        \
+    __TOKEN(Slash)                 \
+    __TOKEN(SlashEquals)           \
+    __TOKEN(Equals)                \
+    __TOKEN(EqualsEquals)          \
     __TOKEN(Semicolon)             \
     __TOKEN(DoubleQuotedString)    \
     __TOKEN(SingleQuotedString)    \

--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -45,6 +45,7 @@ namespace GUI {
     __TOKEN(RightBracket)          \
     __TOKEN(Comma)                 \
     __TOKEN(Asterisk)              \
+    __TOKEN(AsteriskEquals)        \
     __TOKEN(Semicolon)             \
     __TOKEN(DoubleQuotedString)    \
     __TOKEN(SingleQuotedString)    \


### PR DESCRIPTION
The main motivation is `=` which I use often in small text programs and which causes a "not yet implemented" log line.