### PR TITLE
LibDebug: Add support for the various DW_FORM_block types

### DIFF
--- a/Libraries/LibDebug/DebugInfo.cpp
+++ b/Libraries/LibDebug/DebugInfo.cpp
@@ -204,7 +204,7 @@ static void parse_variable_location(const Dwarf::DIE& variable_die, DebugInfo::V
         }
 
         if (location_info.value().type == Dwarf::DIE::AttributeValue::Type::DwarfExpression) {
-            auto expression_bytes = ByteBuffer::wrap(location_info.value().data.as_dwarf_expression.bytes, location_info.value().data.as_dwarf_expression.length);
+            auto expression_bytes = ByteBuffer::wrap(location_info.value().data.as_raw_bytes.bytes, location_info.value().data.as_raw_bytes.length);
             auto value = Dwarf::Expression::evaluate(expression_bytes, regs);
 
             if (value.type != Dwarf::Expression::Type::None) {

--- a/Libraries/LibDebug/Dwarf/DIE.h
+++ b/Libraries/LibDebug/Dwarf/DIE.h
@@ -52,6 +52,7 @@ public:
             Boolean,
             DwarfExpression,
             SecOffset,
+            RawBytes,
         } type;
 
         union {
@@ -62,7 +63,7 @@ public:
             struct {
                 u32 length;
                 const u8* bytes; // points to bytes in the memory mapped elf image
-            } as_dwarf_expression;
+            } as_raw_bytes;
         } data {};
     };
 


### PR DESCRIPTION
This fixes #2885.

We do not use these new data forms anywhere, but we can now parse them and not crash.