### PR TITLE
CppLexer: Add even more token types

### DIFF
--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -342,6 +342,32 @@ Vector<CppToken> CppLexer::lex()
             emit_token(CppToken::Type::RightBracket);
             continue;
         }
+        if (ch == '<') {
+            begin_token();
+            consume();
+            if (peek() == '<') {
+                consume();
+                if (peek() == '=') {
+                    consume();
+                    commit_token(CppToken::Type::LessLessEquals);
+                    continue;
+                }
+                commit_token(CppToken::Type::LessLess);
+                continue;
+            }
+            if (peek() == '=') {
+                consume();
+                commit_token(CppToken::Type::LessEquals);
+                continue;
+            }
+            if (peek() == '>') {
+                consume();
+                commit_token(CppToken::Type::LessGreater);
+                continue;
+            }
+            commit_token(CppToken::Type::Less);
+            continue;
+        }
         if (ch == ',') {
             emit_token(CppToken::Type::Comma);
             continue;
@@ -356,6 +382,10 @@ Vector<CppToken> CppLexer::lex()
         }
         if (ch == '*') {
             emit_token_equals(CppToken::Type::Asterisk, CppToken::Type::AsteriskEquals);
+            continue;
+        }
+        if (ch == '%') {
+            emit_token_equals(CppToken::Type::Percent, CppToken::Type::PercentEquals);
             continue;
         }
         if (ch == '=') {

--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -422,6 +422,11 @@ Vector<CppToken> CppLexer::lex()
                 commit_token(CppToken::Type::MinusEquals);
                 continue;
             }
+            if (peek() == '>') {
+                consume();
+                commit_token(CppToken::Type::Arrow);
+                continue;
+            }
             commit_token(CppToken::Type::Minus);
             continue;
         }
@@ -491,6 +496,10 @@ Vector<CppToken> CppLexer::lex()
         }
         if (ch == ';') {
             emit_token(CppToken::Type::Semicolon);
+            continue;
+        }
+        if (ch == '.') {
+            emit_token(CppToken::Type::Dot);
             continue;
         }
         if (ch == '#') {

--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -437,6 +437,10 @@ Vector<CppToken> CppLexer::lex()
             emit_token_equals(CppToken::Type::Caret, CppToken::Type::CaretEquals);
             continue;
         }
+        if (ch == '!') {
+            emit_token_equals(CppToken::Type::ExclamationMark, CppToken::Type::ExclamationMarkEquals);
+            continue;
+        }
         if (ch == '=') {
             emit_token_equals(CppToken::Type::Equals, CppToken::Type::EqualsEquals);
             continue;
@@ -471,6 +475,18 @@ Vector<CppToken> CppLexer::lex()
                 continue;
             }
             commit_token(CppToken::Type::Pipe);
+            continue;
+        }
+        if (ch == '~') {
+            emit_token(CppToken::Type::Tilde);
+            continue;
+        }
+        if (ch == '?') {
+            emit_token(CppToken::Type::QuestionMark);
+            continue;
+        }
+        if (ch == ':') {
+            emit_token(CppToken::Type::Colon);
             continue;
         }
         if (ch == ';') {

--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -433,6 +433,10 @@ Vector<CppToken> CppLexer::lex()
             emit_token_equals(CppToken::Type::Percent, CppToken::Type::PercentEquals);
             continue;
         }
+        if (ch == '^') {
+            emit_token_equals(CppToken::Type::Caret, CppToken::Type::CaretEquals);
+            continue;
+        }
         if (ch == '=') {
             emit_token_equals(CppToken::Type::Equals, CppToken::Type::EqualsEquals);
             continue;

--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -424,6 +424,11 @@ Vector<CppToken> CppLexer::lex()
             }
             if (peek() == '>') {
                 consume();
+                if (peek() == '*') {
+                    consume();
+                    commit_token(CppToken::Type::ArrowAsterisk);
+                    continue;
+                }
                 commit_token(CppToken::Type::Arrow);
                 continue;
             }
@@ -491,7 +496,19 @@ Vector<CppToken> CppLexer::lex()
             continue;
         }
         if (ch == ':') {
-            emit_token(CppToken::Type::Colon);
+            begin_token();
+            consume();
+            if (peek() == ':') {
+                consume();
+                if (peek() == '*') {
+                    consume();
+                    commit_token(CppToken::Type::ColonColonAsterisk);
+                    continue;
+                }
+                commit_token(CppToken::Type::ColonColon);
+                continue;
+            }
+            commit_token(CppToken::Type::Colon);
             continue;
         }
         if (ch == ';') {
@@ -499,7 +516,14 @@ Vector<CppToken> CppLexer::lex()
             continue;
         }
         if (ch == '.') {
-            emit_token(CppToken::Type::Dot);
+            begin_token();
+            consume();
+            if (peek() == '*') {
+                consume();
+                commit_token(CppToken::Type::DotAsterisk);
+                continue;
+            }
+            commit_token(CppToken::Type::Dot);
             continue;
         }
         if (ch == '#') {

--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -368,6 +368,27 @@ Vector<CppToken> CppLexer::lex()
             commit_token(CppToken::Type::Less);
             continue;
         }
+        if (ch == '>') {
+            begin_token();
+            consume();
+            if (peek() == '>') {
+                consume();
+                if (peek() == '=') {
+                    consume();
+                    commit_token(CppToken::Type::GreaterGreaterEquals);
+                    continue;
+                }
+                commit_token(CppToken::Type::GreaterGreater);
+                continue;
+            }
+            if (peek() == '=') {
+                consume();
+                commit_token(CppToken::Type::GreaterEquals);
+                continue;
+            }
+            commit_token(CppToken::Type::Greater);
+            continue;
+        }
         if (ch == ',') {
             emit_token(CppToken::Type::Comma);
             continue;

--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -413,6 +413,38 @@ Vector<CppToken> CppLexer::lex()
             emit_token_equals(CppToken::Type::Equals, CppToken::Type::EqualsEquals);
             continue;
         }
+        if (ch == '&') {
+            begin_token();
+            consume();
+            if (peek() == '&') {
+                consume();
+                commit_token(CppToken::Type::AndAnd);
+                continue;
+            }
+            if (peek() == '=') {
+                consume();
+                commit_token(CppToken::Type::AndEquals);
+                continue;
+            }
+            commit_token(CppToken::Type::And);
+            continue;
+        }
+        if (ch == '|') {
+            begin_token();
+            consume();
+            if (peek() == '|') {
+                consume();
+                commit_token(CppToken::Type::PipePipe);
+                continue;
+            }
+            if (peek() == '=') {
+                consume();
+                commit_token(CppToken::Type::PipeEquals);
+                continue;
+            }
+            commit_token(CppToken::Type::Pipe);
+            continue;
+        }
         if (ch == ';') {
             emit_token(CppToken::Type::Semicolon);
             continue;

--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -394,11 +394,35 @@ Vector<CppToken> CppLexer::lex()
             continue;
         }
         if (ch == '+') {
-            emit_token_equals(CppToken::Type::Plus, CppToken::Type::PlusEquals);
+            begin_token();
+            consume();
+            if (peek() == '+') {
+                consume();
+                commit_token(CppToken::Type::PlusPlus);
+                continue;
+            }
+            if (peek() == '=') {
+                consume();
+                commit_token(CppToken::Type::PlusEquals);
+                continue;
+            }
+            commit_token(CppToken::Type::Plus);
             continue;
         }
         if (ch == '-') {
-            emit_token_equals(CppToken::Type::Minus, CppToken::Type::MinusEquals);
+            begin_token();
+            consume();
+            if (peek() == '-') {
+                consume();
+                commit_token(CppToken::Type::MinusMinus);
+                continue;
+            }
+            if (peek() == '=') {
+                consume();
+                commit_token(CppToken::Type::MinusEquals);
+                continue;
+            }
+            commit_token(CppToken::Type::Minus);
             continue;
         }
         if (ch == '*') {

--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -65,6 +65,12 @@ namespace GUI {
     __TOKEN(PercentEquals)         \
     __TOKEN(Equals)                \
     __TOKEN(EqualsEquals)          \
+    __TOKEN(And)                   \
+    __TOKEN(AndAnd)                \
+    __TOKEN(AndEquals)             \
+    __TOKEN(Pipe)                  \
+    __TOKEN(PipePipe)              \
+    __TOKEN(PipeEquals)            \
     __TOKEN(Semicolon)             \
     __TOKEN(DoubleQuotedString)    \
     __TOKEN(SingleQuotedString)    \

--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -80,9 +80,13 @@ namespace GUI {
     __TOKEN(Tilde)                 \
     __TOKEN(QuestionMark)          \
     __TOKEN(Colon)                 \
+    __TOKEN(ColonColon)            \
+    __TOKEN(ColonColonAsterisk)    \
     __TOKEN(Semicolon)             \
     __TOKEN(Dot)                   \
+    __TOKEN(DotAsterisk)           \
     __TOKEN(Arrow)                 \
+    __TOKEN(ArrowAsterisk)         \
     __TOKEN(DoubleQuotedString)    \
     __TOKEN(SingleQuotedString)    \
     __TOKEN(EscapeSequence)        \

--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -65,6 +65,8 @@ namespace GUI {
     __TOKEN(SlashEquals)           \
     __TOKEN(Percent)               \
     __TOKEN(PercentEquals)         \
+    __TOKEN(Caret)                 \
+    __TOKEN(CaretEquals)           \
     __TOKEN(Equals)                \
     __TOKEN(EqualsEquals)          \
     __TOKEN(And)                   \

--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -43,6 +43,15 @@ namespace GUI {
     __TOKEN(RightCurly)            \
     __TOKEN(LeftBracket)           \
     __TOKEN(RightBracket)          \
+    __TOKEN(Less)                  \
+    __TOKEN(Greater)               \
+    __TOKEN(LessEquals)            \
+    __TOKEN(GreaterEquals)         \
+    __TOKEN(LessLess)              \
+    __TOKEN(GreaterGreater)        \
+    __TOKEN(LessLessEquals)        \
+    __TOKEN(GreaterGreaterEquals)  \
+    __TOKEN(LessGreater)           \
     __TOKEN(Comma)                 \
     __TOKEN(Plus)                  \
     __TOKEN(PlusEquals)            \
@@ -52,6 +61,8 @@ namespace GUI {
     __TOKEN(AsteriskEquals)        \
     __TOKEN(Slash)                 \
     __TOKEN(SlashEquals)           \
+    __TOKEN(Percent)               \
+    __TOKEN(PercentEquals)         \
     __TOKEN(Equals)                \
     __TOKEN(EqualsEquals)          \
     __TOKEN(Semicolon)             \

--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -67,6 +67,8 @@ namespace GUI {
     __TOKEN(PercentEquals)         \
     __TOKEN(Caret)                 \
     __TOKEN(CaretEquals)           \
+    __TOKEN(ExclamationMark)       \
+    __TOKEN(ExclamationMarkEquals) \
     __TOKEN(Equals)                \
     __TOKEN(EqualsEquals)          \
     __TOKEN(And)                   \
@@ -75,6 +77,9 @@ namespace GUI {
     __TOKEN(Pipe)                  \
     __TOKEN(PipePipe)              \
     __TOKEN(PipeEquals)            \
+    __TOKEN(Tilde)                 \
+    __TOKEN(QuestionMark)          \
+    __TOKEN(Colon)                 \
     __TOKEN(Semicolon)             \
     __TOKEN(DoubleQuotedString)    \
     __TOKEN(SingleQuotedString)    \

--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -81,6 +81,8 @@ namespace GUI {
     __TOKEN(QuestionMark)          \
     __TOKEN(Colon)                 \
     __TOKEN(Semicolon)             \
+    __TOKEN(Dot)                   \
+    __TOKEN(Arrow)                 \
     __TOKEN(DoubleQuotedString)    \
     __TOKEN(SingleQuotedString)    \
     __TOKEN(EscapeSequence)        \

--- a/Libraries/LibGUI/CppLexer.h
+++ b/Libraries/LibGUI/CppLexer.h
@@ -54,8 +54,10 @@ namespace GUI {
     __TOKEN(LessGreater)           \
     __TOKEN(Comma)                 \
     __TOKEN(Plus)                  \
+    __TOKEN(PlusPlus)              \
     __TOKEN(PlusEquals)            \
     __TOKEN(Minus)                 \
+    __TOKEN(MinusMinus)            \
     __TOKEN(MinusEquals)           \
     __TOKEN(Asterisk)              \
     __TOKEN(AsteriskEquals)        \


### PR DESCRIPTION
This started with things I ran into while writing small test programs, but eventually ended up in the wees with member pointer tokens, so I stopped at that point.