### PR TITLE
CppLexer: Correctly highlight hex escapes in string and char literals

### DIFF
--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -287,11 +287,8 @@ Vector<CppToken> CppLexer::lex()
         }
         case 'x': {
             size_t hex_digits = 0;
-            for (size_t i = 0; i < 2; ++i) {
-                if (!isxdigit(peek(2 + i)))
-                    break;
+            while (isxdigit(peek(2 + hex_digits)))
                 ++hex_digits;
-            }
             return 2 + hex_digits;
         }
         case 'u': {


### PR DESCRIPTION
\x consumes all hex digits following it. (If the resulting number
then doesn't fit in the character type, the compiler emits an
error.)

\x would be much more convenient to use if it was always followed
by exactly two hex digits (with \u and \U for higher codepoints),
but that's sadly not the world we live in.