### PR TITLE
Shell: Ignore leading semicolons

### DIFF
--- a/Shell/Parser.cpp
+++ b/Shell/Parser.cpp
@@ -144,7 +144,7 @@ RefPtr<AST::Node> Parser::parse_toplevel()
 
 RefPtr<AST::Node> Parser::parse_sequence()
 {
-    consume_while(is_any_of(" \t\n"));
+    consume_while(is_any_of(" \t\n;")); // ignore whitespaces or terminators without effect.
 
     auto rule_start = push_start();
     auto var_decls = parse_variable_decls();


### PR DESCRIPTION
This makes things like `foo&; bar` behave as expected.
Such behaviour is actually closer to the grammar defined in `Parser.h` anyway :P