### PR TITLE
Propagate the use of AK::Span though the codebase.

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -86,7 +86,7 @@ ByteBuffer decode_base64(const StringView& input)
     return ByteBuffer::copy(output.data(), output.size());
 }
 
-String encode_base64(const ByteBuffer& input)
+String encode_base64(ReadonlyBytes input)
 {
     StringBuilder output;
 

--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -27,12 +27,13 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/Span.h>
 
 namespace AK {
 
 ByteBuffer decode_base64(const StringView&);
 
-String encode_base64(const ByteBuffer&);
+String encode_base64(ReadonlyBytes);
 
 }
 

--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -29,6 +29,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
+#include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <AK/kmalloc.h>
@@ -71,6 +72,9 @@ public:
     u8* data() { return m_data; }
     const u8* data() const { return m_data; }
 
+    Bytes span() { return { data(), size() }; }
+    ReadonlyBytes span() const { return { data(), size() }; }
+
     u8* offset_pointer(int offset) { return m_data + offset; }
     const u8* offset_pointer(int offset) const { return m_data + offset; }
 
@@ -93,10 +97,10 @@ private:
         Wrap,
         Adopt
     };
-    explicit ByteBufferImpl(size_t); // For ConstructionMode=Uninitialized
+    explicit ByteBufferImpl(size_t);                       // For ConstructionMode=Uninitialized
     ByteBufferImpl(const void*, size_t, ConstructionMode); // For ConstructionMode=Copy
-    ByteBufferImpl(void*, size_t, ConstructionMode); // For ConstructionMode=Wrap/Adopt
-    ByteBufferImpl() {}
+    ByteBufferImpl(void*, size_t, ConstructionMode);       // For ConstructionMode=Wrap/Adopt
+    ByteBufferImpl() { }
 
     u8* m_data { nullptr };
     size_t m_size { 0 };
@@ -105,8 +109,8 @@ private:
 
 class ByteBuffer {
 public:
-    ByteBuffer() {}
-    ByteBuffer(std::nullptr_t) {}
+    ByteBuffer() { }
+    ByteBuffer(std::nullptr_t) { }
     ByteBuffer(const ByteBuffer& other)
         : m_impl(other.m_impl)
     {
@@ -157,6 +161,9 @@ public:
 
     u8* data() { return m_impl ? m_impl->data() : nullptr; }
     const u8* data() const { return m_impl ? m_impl->data() : nullptr; }
+
+    Bytes span() { return m_impl ? m_impl->span() : nullptr; }
+    ReadonlyBytes span() const { return m_impl ? m_impl->span() : nullptr; }
 
     u8* offset_pointer(int offset) { return m_impl ? m_impl->offset_pointer(offset) : nullptr; }
     const u8* offset_pointer(int offset) const { return m_impl ? m_impl->offset_pointer(offset) : nullptr; }

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -150,6 +150,12 @@ public:
         return { this->m_values + start, size };
     }
 
+    ALWAYS_INLINE T* offset(size_t start) const
+    {
+        ASSERT(start < this->m_size);
+        return this->m_values + start;
+    }
+
     ALWAYS_INLINE const T& at(size_t index) const
     {
         ASSERT(index < this->m_size);

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -52,11 +52,6 @@ public:
         , m_size(other.m_size)
     {
     }
-    ALWAYS_INLINE Span(const Span<RemoveConst<T>>& other)
-        : m_values(other.m_values)
-        , m_size(other.m_size)
-    {
-    }
 
     ALWAYS_INLINE const T* data() const { return m_values; }
     ALWAYS_INLINE T* data() { return m_values; }
@@ -113,6 +108,11 @@ public:
     {
         m_size = other.m_size;
         m_values = other.m_values;
+    }
+
+    ALWAYS_INLINE operator Span<const T>() const
+    {
+        return { data(), size() };
     }
 
 protected:

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -109,6 +109,11 @@ public:
 
     using Detail::Span<T>::Span;
 
+    ALWAYS_INLINE Span(std::nullptr_t)
+        : Span()
+    {
+    }
+
     ALWAYS_INLINE Span(const Span& other)
         : Span(other.m_values, other.m_size)
     {

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -144,7 +144,7 @@ public:
 
     ALWAYS_INLINE bool is_empty() const { return this->m_size == 0; }
 
-    ALWAYS_INLINE Span<T> subspan(size_t start, size_t size) const
+    ALWAYS_INLINE Span slice(size_t start, size_t size) const
     {
         ASSERT(start + size <= this->m_size);
         return { this->m_values + start, size };

--- a/AK/String.h
+++ b/AK/String.h
@@ -137,6 +137,9 @@ public:
     ALWAYS_INLINE bool is_empty() const { return length() == 0; }
     ALWAYS_INLINE size_t length() const { return m_impl ? m_impl->length() : 0; }
     ALWAYS_INLINE const char* characters() const { return m_impl ? m_impl->characters() : nullptr; }
+
+    ALWAYS_INLINE ReadonlyBytes bytes() const { return m_impl ? m_impl->bytes() : nullptr; }
+
     ALWAYS_INLINE const char& operator[](size_t i) const
     {
         return (*m_impl)[i];

--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -29,6 +29,7 @@
 #include <AK/Badge.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
+#include <AK/Span.h>
 #include <AK/Types.h>
 #include <AK/kmalloc.h>
 
@@ -58,6 +59,9 @@ public:
 
     size_t length() const { return m_length; }
     const char* characters() const { return &m_inline_buffer[0]; }
+
+    ALWAYS_INLINE ReadonlyBytes bytes() const { return { characters(), length() }; }
+
     const char& operator[](size_t i) const
     {
         ASSERT(i < m_length);

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -29,6 +29,7 @@
 #include <AK/Assertions.h>
 #include <AK/Checked.h>
 #include <AK/Forward.h>
+#include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 #include <AK/StringUtils.h>
 
@@ -63,8 +64,12 @@ public:
 
     bool is_null() const { return !m_characters; }
     bool is_empty() const { return m_length == 0; }
+
     const char* characters_without_null_termination() const { return m_characters; }
     size_t length() const { return m_length; }
+
+    ReadonlyBytes bytes() const { return { m_characters, m_length }; }
+
     const char& operator[](size_t index) const { return m_characters[index]; }
 
     ConstIterator begin() const { return characters_without_null_termination(); }

--- a/AK/Tests/Span.cpp
+++ b/AK/Tests/Span.cpp
@@ -36,6 +36,14 @@ TEST_CASE(default_constructor_is_empty)
     EXPECT(span.is_empty());
 }
 
+TEST_CASE(implicit_converson_to_const)
+{
+    Bytes bytes0;
+    ReadonlyBytes bytes1 { bytes0 };
+    [[maybe_unused]] ReadonlyBytes bytes2 = bytes0;
+    [[maybe_unused]] ReadonlyBytes bytes3 = static_cast<ReadonlyBytes>(bytes2);
+}
+
 TEST_CASE(span_works_with_constant_types)
 {
     const u8 buffer[4] { 1, 2, 3, 4 };

--- a/AK/Tests/Span.cpp
+++ b/AK/Tests/Span.cpp
@@ -113,10 +113,10 @@ TEST_CASE(can_subspan_whole_span)
     u8 buffer[16];
     Bytes bytes { buffer, 16 };
 
-    Bytes subspan = bytes.subspan(0, 16);
+    Bytes slice = bytes.slice(0, 16);
 
-    EXPECT_EQ(subspan.data(), buffer);
-    EXPECT_EQ(subspan.size(), 16u);
+    EXPECT_EQ(slice.data(), buffer);
+    EXPECT_EQ(slice.size(), 16u);
 }
 
 TEST_CASE(can_subspan_as_intended)
@@ -124,11 +124,11 @@ TEST_CASE(can_subspan_as_intended)
     const u16 buffer[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
 
     Span<const u16> span { buffer, 8 };
-    auto subspan = span.subspan(3, 2);
+    auto slice = span.slice(3, 2);
 
-    EXPECT_EQ(subspan.size(), 2u);
-    EXPECT_EQ(subspan[0], 4);
-    EXPECT_EQ(subspan[1], 5);
+    EXPECT_EQ(slice.size(), 2u);
+    EXPECT_EQ(slice[0], 4);
+    EXPECT_EQ(slice[1], 5);
 }
 
 TEST_CASE(span_from_void_pointer)

--- a/AK/Tests/Span.cpp
+++ b/AK/Tests/Span.cpp
@@ -131,4 +131,17 @@ TEST_CASE(can_subspan_as_intended)
     EXPECT_EQ(subspan[1], 5);
 }
 
+TEST_CASE(span_from_void_pointer)
+{
+    int value = 0;
+    [[maybe_unused]] Bytes bytes0 { reinterpret_cast<void*>(value), 4 };
+    [[maybe_unused]] ReadonlyBytes bytes1 { reinterpret_cast<const void*>(value), 4 };
+}
+
+TEST_CASE(span_from_c_string)
+{
+    const char* str = "Serenity";
+    [[maybe_unused]] ReadonlyBytes bytes { str, strlen(str) };
+}
+
 TEST_MAIN(Span)

--- a/AK/Tests/TestBase64.cpp
+++ b/AK/Tests/TestBase64.cpp
@@ -49,7 +49,7 @@ TEST_CASE(test_decode)
 TEST_CASE(test_encode)
 {
     auto encode_equal = [&](const char* input, const char* expected) {
-        auto encoded = encode_base64(ByteBuffer::wrap(input, strlen(input)));
+        auto encoded = encode_base64({ input, strlen(input) });
         EXPECT(encoded == String(expected));
     };
 

--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -215,7 +215,7 @@ void IRCClient::process_line(ByteBuffer&& line)
 
 void IRCClient::send(const String& text)
 {
-    if (!m_socket->send(ByteBuffer::wrap(text.characters(), text.length()))) {
+    if (!m_socket->send(text.bytes())) {
         perror("send");
         exit(1);
     }

--- a/Libraries/LibCore/Socket.cpp
+++ b/Libraries/LibCore/Socket.cpp
@@ -167,7 +167,7 @@ ByteBuffer Socket::receive(int max_size)
     return buffer;
 }
 
-bool Socket::send(const ByteBuffer& data)
+bool Socket::send(ReadonlyBytes data)
 {
     ssize_t nsent = ::send(fd(), data.data(), data.size(), 0);
     if (nsent < 0) {
@@ -182,8 +182,8 @@ void Socket::did_update_fd(int fd)
 {
     if (fd < 0) {
         if (m_read_notifier) {
-             m_read_notifier->remove_from_parent();
-             m_read_notifier = nullptr;
+            m_read_notifier->remove_from_parent();
+            m_read_notifier = nullptr;
         }
         if (m_notifier) {
             m_notifier->remove_from_parent();

--- a/Libraries/LibCore/Socket.h
+++ b/Libraries/LibCore/Socket.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/Span.h>
 #include <LibCore/IODevice.h>
 #include <LibCore/SocketAddress.h>
 
@@ -50,7 +51,7 @@ public:
     bool connect(const SocketAddress&);
 
     ByteBuffer receive(int max_size);
-    bool send(const ByteBuffer&);
+    bool send(ReadonlyBytes);
 
     bool is_connected() const { return m_connected; }
     void set_blocking(bool blocking);

--- a/Libraries/LibCrypto/ASN1/PEM.h
+++ b/Libraries/LibCrypto/ASN1/PEM.h
@@ -26,12 +26,13 @@
 
 #pragma once
 
+#include <AK/Span.h>
 #include <LibCrypto/ASN1/ASN1.h>
 #include <LibCrypto/ASN1/DER.h>
 
 namespace Crypto {
 
-static ByteBuffer decode_pem(const ByteBuffer& data_in, size_t cert_index = 0)
+static ByteBuffer decode_pem(ReadonlyBytes data_in, size_t cert_index = 0)
 {
     size_t i { 0 };
     size_t start_at { 0 };
@@ -61,7 +62,7 @@ static ByteBuffer decode_pem(const ByteBuffer& data_in, size_t cert_index = 0)
                     cert_index--;
                     start_at = 0;
                 } else {
-                    idx = decode_b64(data_in.offset_pointer(start_at), end_idx - start_at, output);
+                    idx = decode_b64(data_in.offset(start_at), end_idx - start_at, output);
                     break;
                 }
             } else

--- a/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -36,10 +36,10 @@ SignedBigInteger SignedBigInteger::import_data(const u8* ptr, size_t length)
     return { move(unsigned_data), sign };
 }
 
-size_t SignedBigInteger::export_data(AK::ByteBuffer& data) const
+size_t SignedBigInteger::export_data(Bytes data) const
 {
     data[0] = m_sign;
-    auto bytes_view = data.slice_view(1, data.size() - 1);
+    auto bytes_view = data.slice(1, data.size() - 1);
     return m_unsigned_data.export_data(bytes_view) + 1;
 }
 

--- a/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -67,8 +67,9 @@ public:
     static SignedBigInteger import_data(const u8* ptr, size_t length);
 
     size_t export_data(AK::ByteBuffer& data) const;
-    size_t export_data(const u8* ptr, size_t length) const
+    size_t export_data(u8* ptr, size_t length) const
     {
+        // Note: ByteBuffer::wrap() does a const_cast!
         auto buffer = ByteBuffer::wrap(ptr, length);
         return export_data(buffer);
     }

--- a/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Span.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 
 namespace Crypto {
@@ -66,13 +67,7 @@ public:
     static SignedBigInteger import_data(const AK::StringView& data) { return import_data((const u8*)data.characters_without_null_termination(), data.length()); }
     static SignedBigInteger import_data(const u8* ptr, size_t length);
 
-    size_t export_data(AK::ByteBuffer& data) const;
-    size_t export_data(u8* ptr, size_t length) const
-    {
-        // Note: ByteBuffer::wrap() does a const_cast!
-        auto buffer = ByteBuffer::wrap(ptr, length);
-        return export_data(buffer);
-    }
+    size_t export_data(Bytes) const;
 
     static SignedBigInteger from_base10(StringView str);
     String to_base10() const;

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -55,7 +55,7 @@ UnsignedBigInteger UnsignedBigInteger::create_invalid()
     return invalid;
 }
 
-size_t UnsignedBigInteger::export_data(AK::ByteBuffer& data) const
+size_t UnsignedBigInteger::export_data(Bytes data) const
 {
     size_t word_count = trimmed_length();
     size_t out = 0;

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -28,6 +28,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/LogStream.h>
+#include <AK/Span.h>
 #include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
@@ -58,13 +59,7 @@ public:
         return UnsignedBigInteger(ptr, length);
     }
 
-    size_t export_data(AK::ByteBuffer& data) const;
-    size_t export_data(u8* ptr, size_t length) const
-    {
-        // Note: ByteBuffer::wrap() does a const_cast!
-        auto buffer = ByteBuffer::wrap(ptr, length);
-        return export_data(buffer);
-    }
+    size_t export_data(Bytes) const;
 
     static UnsignedBigInteger from_base10(const String& str);
     String to_base10() const;

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -59,8 +59,9 @@ public:
     }
 
     size_t export_data(AK::ByteBuffer& data) const;
-    size_t export_data(const u8* ptr, size_t length) const
+    size_t export_data(u8* ptr, size_t length) const
     {
+        // Note: ByteBuffer::wrap() does a const_cast!
         auto buffer = ByteBuffer::wrap(ptr, length);
         return export_data(buffer);
     }

--- a/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Libraries/LibCrypto/PK/RSA.cpp
@@ -125,7 +125,7 @@ void RSA::encrypt(const ByteBuffer& in, ByteBuffer& out)
         return;
     }
     auto exp = NumberTheory::ModularPower(in_integer, m_public_key.public_exponent(), m_public_key.modulus());
-    auto size = exp.export_data(out);
+    auto size = exp.export_data(out.span());
     // FIXME: We should probably not do this...
     if (size != out.size())
         out = out.slice(out.size() - size, size);
@@ -137,7 +137,7 @@ void RSA::decrypt(const ByteBuffer& in, ByteBuffer& out)
 
     auto in_integer = UnsignedBigInteger::import_data(in.data(), in.size());
     auto exp = NumberTheory::ModularPower(in_integer, m_private_key.private_exponent(), m_private_key.modulus());
-    auto size = exp.export_data(out);
+    auto size = exp.export_data(out.span());
 
     auto align = m_private_key.length();
     auto aligned_size = (size + align - 1) / align * align;
@@ -151,7 +151,7 @@ void RSA::sign(const ByteBuffer& in, ByteBuffer& out)
 {
     auto in_integer = UnsignedBigInteger::import_data(in.data(), in.size());
     auto exp = NumberTheory::ModularPower(in_integer, m_private_key.private_exponent(), m_private_key.modulus());
-    auto size = exp.export_data(out);
+    auto size = exp.export_data(out.span());
     out = out.slice(out.size() - size, size);
 }
 
@@ -159,7 +159,7 @@ void RSA::verify(const ByteBuffer& in, ByteBuffer& out)
 {
     auto in_integer = UnsignedBigInteger::import_data(in.data(), in.size());
     auto exp = NumberTheory::ModularPower(in_integer, m_public_key.public_exponent(), m_public_key.modulus());
-    auto size = exp.export_data(out);
+    auto size = exp.export_data(out.span());
     out = out.slice(out.size() - size, size);
 }
 

--- a/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Libraries/LibCrypto/PK/RSA.cpp
@@ -166,7 +166,7 @@ void RSA::verify(const ByteBuffer& in, ByteBuffer& out)
 void RSA::import_private_key(const ByteBuffer& buffer, bool pem)
 {
     // so gods help me, I hate DER
-    auto decoded_buffer = pem ? decode_pem(buffer) : buffer;
+    auto decoded_buffer = pem ? decode_pem(buffer.span()) : buffer;
     auto key = parse_rsa_key(decoded_buffer.span());
     if (!key.private_key.length()) {
         dbg() << "We expected to see a private key, but we found none";
@@ -178,7 +178,7 @@ void RSA::import_private_key(const ByteBuffer& buffer, bool pem)
 void RSA::import_public_key(const ByteBuffer& buffer, bool pem)
 {
     // so gods help me, I hate DER
-    auto decoded_buffer = pem ? decode_pem(buffer) : buffer;
+    auto decoded_buffer = pem ? decode_pem(buffer.span()) : buffer;
     auto key = parse_rsa_key(decoded_buffer.span());
     if (!key.public_key.length()) {
         dbg() << "We expected to see a public key, but we found none";

--- a/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Libraries/LibCrypto/PK/RSA.cpp
@@ -163,11 +163,15 @@ void RSA::verify(const ByteBuffer& in, ByteBuffer& out)
     out = out.slice(out.size() - size, size);
 }
 
-void RSA::import_private_key(const ByteBuffer& buffer, bool pem)
+void RSA::import_private_key(ReadonlyBytes bytes, bool pem)
 {
-    // so gods help me, I hate DER
-    auto decoded_buffer = pem ? decode_pem(buffer.span()) : buffer;
-    auto key = parse_rsa_key(decoded_buffer.span());
+    ByteBuffer buffer;
+    if (pem) {
+        buffer = decode_pem(bytes);
+        bytes = buffer.span();
+    }
+
+    auto key = parse_rsa_key(bytes);
     if (!key.private_key.length()) {
         dbg() << "We expected to see a private key, but we found none";
         ASSERT_NOT_REACHED();
@@ -175,11 +179,15 @@ void RSA::import_private_key(const ByteBuffer& buffer, bool pem)
     m_private_key = key.private_key;
 }
 
-void RSA::import_public_key(const ByteBuffer& buffer, bool pem)
+void RSA::import_public_key(ReadonlyBytes bytes, bool pem)
 {
-    // so gods help me, I hate DER
-    auto decoded_buffer = pem ? decode_pem(buffer.span()) : buffer;
-    auto key = parse_rsa_key(decoded_buffer.span());
+    ByteBuffer buffer;
+    if (pem) {
+        buffer = decode_pem(bytes);
+        bytes = buffer.span();
+    }
+
+    auto key = parse_rsa_key(bytes);
     if (!key.public_key.length()) {
         dbg() << "We expected to see a public key, but we found none";
         ASSERT_NOT_REACHED();

--- a/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Libraries/LibCrypto/PK/RSA.cpp
@@ -33,7 +33,7 @@
 namespace Crypto {
 namespace PK {
 
-RSA::KeyPairType RSA::parse_rsa_key(const ByteBuffer& in)
+RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes in)
 {
     // we are going to assign to at least one of these
     KeyPairType keypair;
@@ -167,7 +167,7 @@ void RSA::import_private_key(const ByteBuffer& buffer, bool pem)
 {
     // so gods help me, I hate DER
     auto decoded_buffer = pem ? decode_pem(buffer) : buffer;
-    auto key = parse_rsa_key(decoded_buffer);
+    auto key = parse_rsa_key(decoded_buffer.span());
     if (!key.private_key.length()) {
         dbg() << "We expected to see a private key, but we found none";
         ASSERT_NOT_REACHED();
@@ -179,7 +179,7 @@ void RSA::import_public_key(const ByteBuffer& buffer, bool pem)
 {
     // so gods help me, I hate DER
     auto decoded_buffer = pem ? decode_pem(buffer) : buffer;
-    auto key = parse_rsa_key(decoded_buffer);
+    auto key = parse_rsa_key(decoded_buffer.span());
     if (!key.public_key.length()) {
         dbg() << "We expected to see a public key, but we found none";
         ASSERT_NOT_REACHED();

--- a/Libraries/LibCrypto/PK/RSA.h
+++ b/Libraries/LibCrypto/PK/RSA.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Span.h>
 #include <AK/Vector.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibCrypto/NumberTheory/ModularFunctions.h>
@@ -119,7 +120,7 @@ class RSA : public PKSystem<RSAPrivateKey<IntegerType>, RSAPublicKey<IntegerType
 public:
     using KeyPairType = RSAKeyPair<PublicKeyType, PrivateKeyType>;
 
-    static KeyPairType parse_rsa_key(const ByteBuffer&);
+    static KeyPairType parse_rsa_key(ReadonlyBytes);
     static KeyPairType generate_key_pair(size_t bits = 256)
     {
         IntegerType e { 65537 }; // :P

--- a/Libraries/LibCrypto/PK/RSA.h
+++ b/Libraries/LibCrypto/PK/RSA.h
@@ -160,13 +160,13 @@ public:
 
     RSA(const ByteBuffer& publicKeyPEM, const ByteBuffer& privateKeyPEM)
     {
-        import_public_key(publicKeyPEM);
-        import_private_key(privateKeyPEM);
+        import_public_key(publicKeyPEM.span());
+        import_private_key(privateKeyPEM.span());
     }
 
     RSA(const StringView& privKeyPEM)
     {
-        import_private_key(ByteBuffer::wrap(privKeyPEM.characters_without_null_termination(), privKeyPEM.length()));
+        import_private_key(privKeyPEM.bytes());
         m_public_key.set(m_private_key.modulus(), m_private_key.public_exponent());
     }
 
@@ -188,8 +188,8 @@ public:
 
     virtual size_t output_size() const override { return m_public_key.length(); }
 
-    void import_public_key(const ByteBuffer& buffer, bool pem = true);
-    void import_private_key(const ByteBuffer& buffer, bool pem = true);
+    void import_public_key(ReadonlyBytes, bool pem = true);
+    void import_private_key(ReadonlyBytes, bool pem = true);
 
     const PrivateKeyType& private_key() const { return m_private_key; }
     const PublicKeyType& public_key() const { return m_public_key; }

--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -28,8 +28,8 @@
 #include <AK/ByteBuffer.h>
 #include <AK/FlyString.h>
 #include <AK/Function.h>
-#include <AK/Utf8View.h>
 #include <AK/String.h>
+#include <AK/Utf8View.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/Function.h>
@@ -278,7 +278,7 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::btoa)
         byte_string.append(codepoint);
     }
 
-    auto encoded = encode_base64(ByteBuffer::wrap(byte_string.data(), byte_string.size()));
+    auto encoded = encode_base64(byte_string.span());
     return JS::js_string(interpreter, move(encoded));
 }
 

--- a/Userland/base64.cpp
+++ b/Userland/base64.cpp
@@ -75,6 +75,6 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    auto encoded = encode_base64(buffer);
+    auto encoded = encode_base64(buffer.span());
     printf("%s\n", encoded.characters());
 }

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -1560,7 +1560,7 @@ void bigint_import_export()
         u8 target_buffer[128];
         AK::fill_with_random(random_bytes, 128);
         auto encoded = Crypto::UnsignedBigInteger::import_data(random_bytes, 128);
-        encoded.export_data(target_buffer, 128);
+        encoded.export_data({ target_buffer, 128 });
         if (memcmp(target_buffer, random_bytes, 128) != 0)
             FAIL(Could not roundtrip);
         else
@@ -1570,7 +1570,7 @@ void bigint_import_export()
         I_TEST((BigInteger | BigEndian Encode / Decode roundtrip));
         u8 target_buffer[128];
         auto encoded = "12345678901234567890"_bigint;
-        auto size = encoded.export_data(target_buffer, 128);
+        auto size = encoded.export_data({ target_buffer, 128 });
         auto decoded = Crypto::UnsignedBigInteger::import_data(target_buffer, size);
         if (encoded != decoded)
             FAIL(Could not roundtrip);
@@ -1590,7 +1590,7 @@ void bigint_import_export()
         I_TEST((BigInteger | BigEndian Export));
         auto number = "448378203247"_bigint;
         char exported[8] { 0 };
-        auto exported_length = number.export_data((u8*)exported, 8);
+        auto exported_length = number.export_data({ exported, 8 });
         if (exported_length == 5 && memcmp(exported + 3, "hello", 5) == 0) {
             PASS;
         } else {
@@ -1877,7 +1877,7 @@ void bigint_signed_import_export()
         random_bytes[0] = 1;
         AK::fill_with_random(random_bytes + 1, 128);
         auto encoded = Crypto::SignedBigInteger::import_data(random_bytes, 129);
-        encoded.export_data(target_buffer, 129);
+        encoded.export_data({ target_buffer, 129 });
         if (memcmp(target_buffer, random_bytes, 129) != 0)
             FAIL(Could not roundtrip);
         else
@@ -1887,7 +1887,7 @@ void bigint_signed_import_export()
         I_TEST((Signed BigInteger | BigEndian Encode / Decode roundtrip));
         u8 target_buffer[128];
         auto encoded = "-12345678901234567890"_sbigint;
-        auto size = encoded.export_data(target_buffer, 128);
+        auto size = encoded.export_data({ target_buffer, 128 });
         auto decoded = Crypto::SignedBigInteger::import_data(target_buffer, size);
         if (encoded != decoded)
             FAIL(Could not roundtrip);


### PR DESCRIPTION
There is this "anti-pattern" in the code base where functions take a `const ByteBuffer&` as input. Even if the input is immutable, it has to be put into a mutable buffer. This is usually done using `ByteBuffer::wrap(const void*, size_t)` which does a `const_cast` internally. The caller has to keep track that such buffers must not be written to (no copy on write!).

This pull request first fixes a few issues with the implementation of `Span` and then changes a few functions to take `ReadonlyBytes` instead of `const ByteBuffer&` or `Bytes` instead of `ByteBuffer&`.

I've mostly focused on eliminating calls to that `wrap` overload, but it can't quite be removed yet, because `BufferStream` has no immutable version.
