### PR TITLE
Shell: Fix parse mistake in '&&' not being recursive

### DIFF
--- a/AK/Tests/TestString.cpp
+++ b/AK/Tests/TestString.cpp
@@ -87,8 +87,8 @@ TEST_CASE(starts_with)
     EXPECT(!test_string.starts_with('B'));
     EXPECT(test_string.starts_with("ABCDEF"));
     EXPECT(!test_string.starts_with("DEF"));
-    EXPECT(test_string.starts_with("abc",  CaseSensitivity::CaseInsensitive));
-    EXPECT(!test_string.starts_with("abc",  CaseSensitivity::CaseSensitive));
+    EXPECT(test_string.starts_with("abc", CaseSensitivity::CaseInsensitive));
+    EXPECT(!test_string.starts_with("abc", CaseSensitivity::CaseSensitive));
 }
 
 TEST_CASE(ends_with)
@@ -99,8 +99,8 @@ TEST_CASE(ends_with)
     EXPECT(!test_string.ends_with('E'));
     EXPECT(test_string.ends_with("ABCDEF"));
     EXPECT(!test_string.ends_with("ABC"));
-    EXPECT(test_string.ends_with("def",  CaseSensitivity::CaseInsensitive));
-    EXPECT(!test_string.ends_with("def",  CaseSensitivity::CaseSensitive));
+    EXPECT(test_string.ends_with("def", CaseSensitivity::CaseInsensitive));
+    EXPECT(!test_string.ends_with("def", CaseSensitivity::CaseSensitive));
 }
 
 TEST_CASE(copy_string)
@@ -225,15 +225,21 @@ TEST_CASE(split)
     EXPECT_EQ(parts[2], "");
     EXPECT_EQ(parts[3], "");
     EXPECT_EQ(parts[4], "b");
+
+    test = "axxbx";
+    EXPECT_EQ(test.split('x').size(), 2u);
+    EXPECT_EQ(test.split('x', true).size(), 4u);
+    EXPECT_EQ(test.split_view('x').size(), 2u);
+    EXPECT_EQ(test.split_view('x', true).size(), 4u);
 }
 
 TEST_CASE(builder_zero_initial_capacity)
 {
-   StringBuilder builder(0);
-   builder.append("");
-   auto built = builder.build();
-   EXPECT_EQ(built.is_null(), false);
-   EXPECT_EQ(built.length(), 0u);
+    StringBuilder builder(0);
+    builder.append("");
+    auto built = builder.build();
+    EXPECT_EQ(built.is_null(), false);
+    EXPECT_EQ(built.length(), 0u);
 }
 
 TEST_MAIN(String)

--- a/AK/Tests/TestStringView.cpp
+++ b/AK/Tests/TestStringView.cpp
@@ -68,8 +68,8 @@ TEST_CASE(starts_with)
     EXPECT(test_string_view.starts_with("AB"));
     EXPECT(test_string_view.starts_with("ABCDEF"));
     EXPECT(!test_string_view.starts_with("DEF"));
-    EXPECT(test_string_view.starts_with("abc",  CaseSensitivity::CaseInsensitive));
-    EXPECT(!test_string_view.starts_with("abc",  CaseSensitivity::CaseSensitive));
+    EXPECT(test_string_view.starts_with("abc", CaseSensitivity::CaseInsensitive));
+    EXPECT(!test_string_view.starts_with("abc", CaseSensitivity::CaseSensitive));
 }
 
 TEST_CASE(ends_with)
@@ -82,8 +82,8 @@ TEST_CASE(ends_with)
     EXPECT(test_string_view.ends_with("ABCDEF"));
     EXPECT(!test_string_view.ends_with("ABCDE"));
     EXPECT(!test_string_view.ends_with("ABCDEFG"));
-    EXPECT(test_string_view.ends_with("def",  CaseSensitivity::CaseInsensitive));
-    EXPECT(!test_string_view.ends_with("def",  CaseSensitivity::CaseSensitive));
+    EXPECT(test_string_view.ends_with("def", CaseSensitivity::CaseInsensitive));
+    EXPECT(!test_string_view.ends_with("def", CaseSensitivity::CaseSensitive));
 }
 
 TEST_CASE(lines)
@@ -157,5 +157,23 @@ TEST_CASE(find_last_of)
     EXPECT_EQ(test_string_view.find_last_of("fghi").has_value(), false);
 }
 
+TEST_CASE(split_view)
+{
+    StringView test_string_view = "axxbxcxd";
+    EXPECT_EQ(test_string_view.split_view('x'), Vector<StringView>({ "a", "b", "c", "d" }));
+    EXPECT_EQ(test_string_view.split_view('x', true), Vector<StringView>({ "a", "", "b", "c", "d" }));
+    EXPECT_EQ(test_string_view.split_view("x"), Vector<StringView>({ "a", "b", "c", "d" }));
+    EXPECT_EQ(test_string_view.split_view("x", true), Vector<StringView>({ "a", "", "b", "c", "d" }));
+
+    test_string_view = "axxbx";
+    EXPECT_EQ(test_string_view.split_view('x'), Vector<StringView>({ "a", "b" }));
+    EXPECT_EQ(test_string_view.split_view('x', true), Vector<StringView>({ "a", "", "b", "" }));
+    EXPECT_EQ(test_string_view.split_view("x"), Vector<StringView>({ "a", "b" }));
+    EXPECT_EQ(test_string_view.split_view("x", true), Vector<StringView>({ "a", "", "b", "" }));
+
+    test_string_view = "axxbcxxdxx";
+    EXPECT_EQ(test_string_view.split_view("xx"), Vector<StringView>({ "a", "bc", "d" }));
+    EXPECT_EQ(test_string_view.split_view("xx", true), Vector<StringView>({ "a", "bc", "d", "" }));
+}
 
 TEST_MAIN(StringView)

--- a/Shell/Parser.cpp
+++ b/Shell/Parser.cpp
@@ -301,11 +301,11 @@ RefPtr<AST::Node> Parser::parse_and_logical_sequence()
         return pipe_sequence;
     }
 
-    auto right_pipe_sequence = parse_pipe_sequence();
-    if (!right_pipe_sequence)
-        right_pipe_sequence = create<AST::SyntaxError>("Expected an expression after '&&'");
+    auto right_and_sequence = parse_and_logical_sequence();
+    if (!right_and_sequence)
+        right_and_sequence = create<AST::SyntaxError>("Expected an expression after '&&'");
 
-    return create<AST::And>(create<AST::Execute>(move(pipe_sequence)), create<AST::Execute>(move(right_pipe_sequence)));
+    return create<AST::And>(create<AST::Execute>(move(pipe_sequence)), create<AST::Execute>(move(right_and_sequence)));
 }
 
 RefPtr<AST::Node> Parser::parse_pipe_sequence()

--- a/Shell/Tests/valid.sh
+++ b/Shell/Tests/valid.sh
@@ -85,7 +85,7 @@ rm -fr sh-test
 
 # Setopt
 setopt --inline_exec_keep_empty_segments
-test "$(echo "a\n\nb")" = "a  b" || fail inline_exec_keep_empty_segments has no effect
+test "$(echo -n "a\n\nb")" = "a  b" || fail inline_exec_keep_empty_segments has no effect
 
 setopt --no_inline_exec_keep_empty_segments
-test "$(echo "a\n\nb")" = "a b" || fail cannot unset inline_exec_keep_empty_segments
+test "$(echo -n "a\n\nb")" = "a b" || fail cannot unset inline_exec_keep_empty_segments

--- a/Shell/Tests/valid.sh
+++ b/Shell/Tests/valid.sh
@@ -5,6 +5,13 @@
 true || exit 2
 false && exit 2
 
+# Can we chain &&'s?
+false && exit 2 && echo "can't chain &&'s" && exit 2
+
+# Proper precedence between &&'s and ||'s
+false && exit 2 || true && false && exit 2
+
+
 # Sanity check: can we pass arguments to 'test'?
 test yes = yes || exit 2
 

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char** argv)
 #ifndef __serenity__
             if (child_pid == 0) {
                 // Linux: if child didn't "change state", but existed.
-                child_pid = job.value->pid();
+                continue;
             }
 #endif
             if (child_pid == job.value->pid()) {

--- a/Userland/echo.cpp
+++ b/Userland/echo.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <LibCore/ArgsParser.h>
 #include <stdio.h>
 #include <unistd.h>
 
@@ -34,11 +35,20 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    for (int i = 1; i < argc; ++i) {
-        fputs(argv[i], stdout);
-        if (i != argc - 1)
+    Vector<const char*> values;
+    bool no_trailing_newline = false;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(no_trailing_newline, "Do not output a trailing newline", nullptr, 'n');
+    args_parser.add_positional_argument(values, "Values to print out", "string", Core::ArgsParser::Required::No);
+    args_parser.parse(argc, argv);
+
+    for (size_t i = 0; i < values.size(); ++i) {
+        fputs(values[i], stdout);
+        if (i != values.size() - 1)
             fputc(' ', stdout);
     }
-    printf("\n");
+    if (!no_trailing_newline)
+        printf("\n");
     return 0;
 }


### PR DESCRIPTION
This fix brought to you by ~~Raid: Shadow Legends~~ the sudden split of #2824

Try:
```sh
$ foo && bar && baz
```