### PR TITLE
Userland: Fix nc by not memset()'ing the input address char*

### DIFF
--- a/Userland/nc.cpp
+++ b/Userland/nc.cpp
@@ -133,7 +133,7 @@ int main(int argc, char** argv)
         char addr_str[100];
 
         struct sockaddr_in dst_addr;
-        memset(&addr, 0, sizeof(addr));
+        memset(&dst_addr, 0, sizeof(dst_addr));
 
         dst_addr.sin_family = AF_INET;
         dst_addr.sin_port = htons(port);


### PR DESCRIPTION
We were accidentally calling `memset()` on "`addr`" (the input `char*`), not "`dst_addr`" (the target `struct sockaddr_in`), which was causing a simple "`nc localhost 8000`" to crash.

Fixes #2908.