### PR TITLE
Meta: Calculate image size based on size of Build/Root and Base

### DIFF
--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -23,6 +23,12 @@ if [ -z "$grub" ]; then
 fi
 echo "using grub-install at ${grub}"
 
+disk_usage() {
+    du -sm $1 | cut -f1
+}
+
+DISK_SIZE=$(($(disk_usage "$SERENITY_ROOT/Base") + $(disk_usage Root) + 300))
+
 echo "setting up disk image..."
 dd if=/dev/zero of=grub_disk_image bs=1M count="${DISK_SIZE:-800}" status=none || die "couldn't create disk image"
 chown "$SUDO_UID":"$SUDO_GID" grub_disk_image || die "couldn't adjust permissions on disk image"

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -17,6 +17,13 @@ if [ "$(uname -s)" = "Darwin" ]; then
     export PATH="/usr/local/opt/e2fsprogs/bin:$PATH"
     export PATH="/usr/local/opt/e2fsprogs/sbin:$PATH"
 fi
+
+disk_usage() {
+    du -sm $1 | cut -f1
+}
+
+DISK_SIZE=$(($(disk_usage "$SERENITY_ROOT/Base") + $(disk_usage Root) + 100))
+
 echo "setting up disk image..."
 qemu-img create _disk_image "${DISK_SIZE:-600}"m || die "could not create disk image"
 chown "$SUDO_UID":"$SUDO_GID" _disk_image || die "could not adjust permissions on disk image"


### PR DESCRIPTION
This reduces the size of the default build, while allowing people to install as many ports as they want, without having to manually specify disk size.