### PR TITLE
LibGui+WindowServer: Offset applications that are opened directly on eachother

### DIFF
--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -121,7 +121,8 @@ int main(int argc, char** argv)
     auto bookmarks_bar = Browser::BookmarksBarWidget::construct(Browser::bookmarks_filename, bookmarksbar_enabled);
 
     auto window = GUI::Window::construct();
-    window->set_rect(100, 100, 640, 480);
+    window->move_to_recommended_position(100, 100);
+    window->resize(640, 400);
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-browser.png"));
     window->set_title("Browser");
 

--- a/Applications/Calculator/main.cpp
+++ b/Applications/Calculator/main.cpp
@@ -58,7 +58,8 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     window->set_title("Calculator");
     window->set_resizable(false);
-    window->set_rect({ 300, 200, 254, 213 });
+    window->move_to_recommended_position(300, 200);
+    window->resize(254, 213);
 
     window->set_main_widget<CalculatorWidget>();
 

--- a/Applications/Calendar/main.cpp
+++ b/Applications/Calendar/main.cpp
@@ -58,7 +58,8 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Calendar");
-    window->set_rect(20, 200, 596, 475);
+    window->move_to_recommended_position(20, 200);
+    window->resize(596, 475);
 
     auto& calendar_widget = window->set_main_widget<CalendarWidget>();
     window->show();

--- a/Applications/DisplaySettings/main.cpp
+++ b/Applications/DisplaySettings/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     dbg() << "main window: " << window;
     window->set_title("Display settings");
-    window->move_to(100, 100);
+    window->move_to_recommended_position(100, 100);
     window->resize(360, 390);
     window->set_resizable(false);
     window->set_main_widget(instance->root_widget());

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -248,8 +248,9 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     auto left = config->read_num_entry("Window", "Left", 150);
     auto top = config->read_num_entry("Window", "Top", 75);
     auto width = config->read_num_entry("Window", "Width", 640);
-    auto heigth = config->read_num_entry("Window", "Heigth", 480);
-    window->set_rect({ left, top, width, heigth });
+    auto height = config->read_num_entry("Window", "Heigth", 480);
+    window->move_to_recommended_position(left, top);
+    window->resize(width, height);
 
     auto& widget = window->set_main_widget<GUI::Widget>();
     widget.set_layout<GUI::VerticalBoxLayout>();
@@ -846,7 +847,7 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
                 } else {
                     file_context_menu_action_default_action.clear();
                 }
-                
+
                 if (current_file_handlers.size() > 1) {
                     added_open_menu_items = true;
                     auto& file_open_with_menu = file_context_menu->add_submenu("Open with");

--- a/Applications/FontEditor/main.cpp
+++ b/Applications/FontEditor/main.cpp
@@ -77,16 +77,17 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto set_edited_font = [&](const String& path, RefPtr<Gfx::Font>&& font, Gfx::IntPoint point) {
+    auto set_edited_font = [&](const String& path, RefPtr<Gfx::Font>&& font) {
         // Convert 256 char font to 384 char font.
         if (font->type() == Gfx::FontTypes::Default)
             font->set_type(Gfx::FontTypes::LatinExtendedA);
 
         window->set_title(String::format("%s - Font Editor", path.characters()));
         auto& font_editor_widget = window->set_main_widget<FontEditorWidget>(path, move(font));
-        window->set_rect({ point, { font_editor_widget.preferred_width(), font_editor_widget.preferred_height() } });
+        window->resize({ font_editor_widget.preferred_width(), font_editor_widget.preferred_height() });
     };
-    set_edited_font(path, move(edited_font), { 50, 50 });
+    window->move_to_recommended_position(50, 50);
+    set_edited_font(path, move(edited_font));
 
     auto menubar = GUI::MenuBar::construct();
 
@@ -103,7 +104,7 @@ int main(int argc, char** argv)
             return;
         }
 
-        set_edited_font(open_path.value(), move(new_font), window->position());
+        set_edited_font(open_path.value(), move(new_font));
     }));
     app_menu.add_action(GUI::Action::create("Save", { Mod_Ctrl, Key_S }, Gfx::Bitmap::load_from_file("/res/icons/16x16/save.png"), [&](auto&) {
         FontEditorWidget* editor = static_cast<FontEditorWidget*>(window->main_widget());

--- a/Applications/Help/main.cpp
+++ b/Applications/Help/main.cpp
@@ -86,7 +86,8 @@ int main(int argc, char* argv[])
     auto window = GUI::Window::construct();
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Help");
-    window->set_rect(300, 200, 570, 500);
+    window->move_to_recommended_position(300, 200);
+    window->resize(570, 500);
 
     auto& widget = window->set_main_widget<GUI::Widget>();
     widget.set_layout<GUI::VerticalBoxLayout>();

--- a/Applications/HexEditor/main.cpp
+++ b/Applications/HexEditor/main.cpp
@@ -44,7 +44,8 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Hex Editor");
-    window->set_rect(20, 200, 640, 400);
+    window->move_to_recommended_position(20, 200);
+    window->resize(640, 400);
 
     auto& hex_editor_widget = window->set_main_widget<HexEditorWidget>();
 

--- a/Applications/IRCClient/IRCAppWindow.cpp
+++ b/Applications/IRCClient/IRCAppWindow.cpp
@@ -58,7 +58,8 @@ IRCAppWindow::IRCAppWindow(String server, int port)
     set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-irc-client.png"));
 
     update_title();
-    set_rect(200, 200, 600, 400);
+    move_to_recommended_position(200, 200);
+    resize(640, 400);
     setup_actions();
     setup_menus();
     setup_widgets();

--- a/Applications/KeyboardMapper/main.cpp
+++ b/Applications/KeyboardMapper/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_main_widget<KeyboardMapperWidget>();
     window->resize(775, 315);
-    window->move_to(50, 50);
+    window->move_to_recommended_position(50, 50);
     window->set_resizable(false);
     window->show();
 

--- a/Applications/KeyboardSettings/main.cpp
+++ b/Applications/KeyboardSettings/main.cpp
@@ -90,7 +90,8 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Keyboard settings");
-    window->set_rect(200, 200, 300, 70);
+    window->move_to_recommended_position(200, 200);
+    window->resize(300, 70);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto& root_widget = window->set_main_widget<GUI::Widget>();

--- a/Applications/Piano/main.cpp
+++ b/Applications/Piano/main.cpp
@@ -54,7 +54,8 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     auto& main_widget = window->set_main_widget<MainWidget>(track_manager);
     window->set_title("Piano");
-    window->set_rect(90, 90, 840, 600);
+    window->move_to_recommended_position(90, 90);
+    window->resize(840, 600);
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-piano.png"));
     window->show();
 

--- a/Applications/PixelPaint/main.cpp
+++ b/Applications/PixelPaint/main.cpp
@@ -71,7 +71,8 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("PixelPaint");
-    window->set_rect(40, 100, 950, 570);
+    window->move_to_recommended_position(40, 100);
+    window->resize(950, 570);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto& horizontal_container = window->set_main_widget<GUI::Widget>();

--- a/Applications/QuickShow/main.cpp
+++ b/Applications/QuickShow/main.cpp
@@ -69,7 +69,8 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_double_buffering_enabled(true);
-    window->set_rect(200, 200, 300, 200);
+    window->move_to_recommended_position(200, 200);
+    window->resize(300, 200);
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-image.png"));
     window->set_title("QuickShow");
 

--- a/Applications/SoundPlayer/main.cpp
+++ b/Applications/SoundPlayer/main.cpp
@@ -61,7 +61,8 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     window->set_title("SoundPlayer");
     window->set_resizable(false);
-    window->set_rect(300, 300, 350, 140);
+    window->move_to_recommended_position(300, 300);
+    window->resize(350, 140);
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-sound-player.png"));
 
     auto menubar = GUI::MenuBar::construct();

--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -153,7 +153,8 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("System Monitor");
-    window->set_rect(20, 200, 680, 400);
+    window->move_to_recommended_position(20, 200);
+    window->resize(680, 400);
 
     auto& keeper = window->set_main_widget<GUI::Widget>();
     keeper.set_layout<GUI::VerticalBoxLayout>();

--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -255,7 +255,7 @@ int main(int argc, char** argv)
     terminal.on_title_change = [&](auto& title) {
         window->set_title(title);
     };
-    window->move_to(300, 300);
+    window->move_to_recommended_position(300, 300);
     terminal.apply_size_increments_to_window(*window);
     window->show();
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-terminal.png"));

--- a/Applications/TextEditor/main.cpp
+++ b/Applications/TextEditor/main.cpp
@@ -55,7 +55,8 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Text Editor");
-    window->set_rect(20, 200, 640, 400);
+    window->move_to_recommended_position(20, 200);
+    window->resize(640, 400);
 
     auto& text_widget = window->set_main_widget<TextEditorWidget>();
 

--- a/Libraries/LibGUI/Window.cpp
+++ b/Libraries/LibGUI/Window.cpp
@@ -177,6 +177,13 @@ String Window::title() const
     return WindowServerConnection::the().send_sync<Messages::WindowServer::GetWindowTitle>(m_window_id)->title();
 }
 
+Gfx::IntPoint Window::move_to_recommended_position(const Gfx::IntPoint& point)
+{
+    auto real_position = WindowServerConnection::the().send_sync<Messages::WindowServer::GetRecommendedPosition>(point)->position();
+    move_to(real_position);
+    return real_position;
+}
+
 Gfx::IntRect Window::rect_in_menubar() const
 {
     ASSERT(m_window_type == WindowType::MenuApplet);

--- a/Libraries/LibGUI/Window.h
+++ b/Libraries/LibGUI/Window.h
@@ -116,6 +116,8 @@ public:
 
     void move_to(int x, int y) { move_to({ x, y }); }
     void move_to(const Gfx::IntPoint& point) { set_rect({ point, size() }); }
+    Gfx::IntPoint move_to_recommended_position(int x, int y) { return move_to_recommended_position({ x, y }); }
+    Gfx::IntPoint move_to_recommended_position(const Gfx::IntPoint& point);
 
     void resize(int width, int height) { resize({ width, height }); }
     void resize(const Gfx::IntSize& size) { set_rect({ position(), size }); }

--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -424,6 +424,12 @@ OwnPtr<Messages::WindowServer::GetWindowRectResponse> ClientConnection::handle(c
     return make<Messages::WindowServer::GetWindowRectResponse>(it->value->rect());
 }
 
+OwnPtr<Messages::WindowServer::GetRecommendedPositionResponse> ClientConnection::handle(const Messages::WindowServer::GetRecommendedPosition& message)
+{
+    return make<Messages::WindowServer::GetRecommendedPositionResponse>(
+        WindowManager::the().get_recommended_position(message.desired()));
+}
+
 OwnPtr<Messages::WindowServer::GetWindowRectInMenubarResponse> ClientConnection::handle(const Messages::WindowServer::GetWindowRectInMenubar& message)
 {
     int window_id = message.window_id();

--- a/Services/WindowServer/ClientConnection.h
+++ b/Services/WindowServer/ClientConnection.h
@@ -109,6 +109,7 @@ private:
     virtual OwnPtr<Messages::WindowServer::IsMaximizedResponse> handle(const Messages::WindowServer::IsMaximized&) override;
     virtual OwnPtr<Messages::WindowServer::SetWindowRectResponse> handle(const Messages::WindowServer::SetWindowRect&) override;
     virtual OwnPtr<Messages::WindowServer::GetWindowRectResponse> handle(const Messages::WindowServer::GetWindowRect&) override;
+    virtual OwnPtr<Messages::WindowServer::GetRecommendedPositionResponse> handle(const Messages::WindowServer::GetRecommendedPosition&) override;
     virtual OwnPtr<Messages::WindowServer::GetWindowRectInMenubarResponse> handle(const Messages::WindowServer::GetWindowRectInMenubar&) override;
     virtual void handle(const Messages::WindowServer::InvalidateRect&) override;
     virtual void handle(const Messages::WindowServer::DidFinishPainting&) override;

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -1427,4 +1427,34 @@ void WindowManager::maximize_windows(Window& window, bool maximized)
     });
 }
 
+Gfx::IntPoint WindowManager::get_recommended_position(const Gfx::IntPoint& desired)
+{
+    // FIXME: Find a  better source for the width and height to shift by.
+    Gfx::IntPoint shift(8, palette().window_title_height() + 10);
+    Gfx::IntPoint desired_point = desired;
+
+    // FIXME: Find a better source for this.
+    int taskbar_height = 28;
+    int menubar_height = MenuManager::the().menubar_rect().height();
+
+    bool found_point;
+    do {
+        found_point = true;
+        for_each_window([&](Window& window) {
+            if (window.position() == desired_point) {
+                found_point = false;
+                desired_point += shift;
+                desired_point = { desired_point.x() % Screen::the().width(),
+                    (desired_point.y() >= (Screen::the().height() - taskbar_height))
+                        ? menubar_height + palette().window_title_height()
+                        : desired_point.y() };
+
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+    } while (!found_point);
+
+    return desired_point;
+}
 }

--- a/Services/WindowServer/WindowManager.h
+++ b/Services/WindowServer/WindowManager.h
@@ -185,6 +185,8 @@ public:
     void minimize_windows(Window&, bool);
     void maximize_windows(Window&, bool);
 
+    Gfx::IntPoint get_recommended_position(const Gfx::IntPoint& desired);
+
     template<typename Function>
     void for_each_window_in_modal_stack(Window& window, Function f)
     {

--- a/Services/WindowServer/WindowServer.ipc
+++ b/Services/WindowServer/WindowServer.ipc
@@ -56,6 +56,8 @@ endpoint WindowServer = 2
     SetWindowRect(i32 window_id, Gfx::IntRect rect) => (Gfx::IntRect rect)
     GetWindowRect(i32 window_id) => (Gfx::IntRect rect)
 
+    GetRecommendedPosition(Gfx::IntPoint desired) => (Gfx::IntPoint position)
+
     GetWindowRectInMenubar(i32 window_id) => (Gfx::IntRect rect)
 
     IsMaximized(i32 window_id) => (bool maximized)


### PR DESCRIPTION

If you opened many terminals before they would be right on top of eachother, and it didn't look like anything happened.
This change should make it more obvious when you application opens, and make it easier to grab the old windows.

example:
![2020-07-28-155650_3200x1800_scrot](https://user-images.githubusercontent.com/8095520/88726562-36975200-d0eb-11ea-82f5-38617abef345.png)