### PR TITLE
Shave off a few minutes of every single build (starting next week)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,8 @@ script:
 - CTEST_OUTPUT_ON_FAILURE=1 make test
 - cd Meta/Lagom
 - ./test-js
+# These feel like they should go into a script. However, that would be a Travis-specific script, and this is *the* right place for travis-specific stuff.
 - cd "$SERENITY_ROOT"/Toolchain/Cache
 - du -ch * || true
+- du -sch /home/travis/.ccache/* || true
+- du -sch /var/cache/apt/archives/*.deb || true

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -79,7 +79,7 @@ pushd "$DIR"
 
         DEPS_CONFIG="
             uname=$(uname),TARGET=${TARGET},
-            BuildItHash=$($MD5SUM $(basename $0)),
+            BuildItHash=$($MD5SUM "$(basename "$0")"),
             MAKE=${MAKE},MD5SUM=${MD5SUM},NPROC=${NPROC},
             CC=${CC},CXX=${CXX},with_gmp=${with_gmp},LDFLAGS=${LDFLAGS},
             BINUTILS_VERSION=${BINUTILS_VERSION},BINUTILS_MD5SUM=${BINUTILS_MD5SUM},
@@ -106,6 +106,9 @@ pushd "$DIR"
                 # Travis preserves timestamps. Don't ask me why, but it does.
                 # We can exploit this to get an easy approximation of recent-ness.
                 # Our purging algorithm is simple: keep only the newest X entries.
+                # Note that `find` doesn't easily support ordering by date,
+                # and we control the filenames anyway.
+                # shellcheck disable=SC2012
                 ls -t | tail "-n+${KEEP_CACHE_COUNT}" | xargs -r rm -v
                 echo "After deletion:"
                 ls -l


### PR DESCRIPTION
6.5 minutes of each build is just network traffic due to the large cache. This cuts down the size of each future item in the Toolchain cache. As the Toolchain cache rotates, those 6.5 minutes should gradually go down to about 2 minutes.

This is not a lot, but it adds up. It should become especially noticable when the Toolchain doesn't need to be rebuilt.

Avenues I didn't explore yet but plan to do so in future PRs:
- Trying to cut down the list of "dependencies", so we can re-use a Toolchain more often.
- Figuring out why building the Toolchain takes double the time with gcc10 than with gcc9.