### PR TITLE
Meta: make check-style.sh ignore Libraries/LibCore/puff.cpp

### DIFF
--- a/Meta/check-style.sh
+++ b/Meta/check-style.sh
@@ -37,6 +37,7 @@ done < <(git ls-files -- \
     ':!:Kernel/FileSystem/ext2_fs.h' \
     ':!:Libraries/LibC/getopt.cpp' \
     ':!:Libraries/LibCore/puff.h' \
+    ':!:Libraries/LibCore/puff.cpp' \
     ':!:Libraries/LibELF/exec_elf.h' \
 )
 


### PR DESCRIPTION
This file was formerly named `Libraries/LibCore/puff.c` and it was not checked by `check-style.sh` because it only checks .h and .cpp files.

Since this file was not written by us, we shouldn't check its style.

This file was also causing our Travis builds to fail.