### PR TITLE
LibWeb: Complete the redirect URL before loading it

### DIFF
--- a/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -212,7 +212,7 @@ void FrameLoader::resource_did_load()
     // FIXME: Also check HTTP status code before redirecting
     auto location = resource()->response_headers().get("Location");
     if (location.has_value()) {
-        load(location.value(), FrameLoader::Type::Navigation);
+        load(url.complete_url(location.value()), FrameLoader::Type::Navigation);
         return;
     }
 


### PR DESCRIPTION
the "Location" header is allowed to be a relative URL (as is the case in our very own WebServer!)