### PR TITLE
Kernel: Make BXVGA detection actually detect VBoxVGA

### DIFF
--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -212,7 +212,7 @@ void init_stage2()
     } else {
         bool bxvga_found = false;
         PCI::enumerate([&](const PCI::Address&, PCI::ID id) {
-            if (id.vendor_id == 0x1234 && id.device_id == 0x1111)
+            if ((id.vendor_id == 0x1234 && id.device_id == 0x1111) || (id.vendor_id == 0x80ee && id.device_id == 0xbeef))
                 bxvga_found = true;
         });
 


### PR DESCRIPTION
I decided to play around with trying to run Serenity in VirtualBox.
It crashed WindowServer with a beautiful array of multi-color
flashing letters :^)

![9nAUuUGmrf](https://user-images.githubusercontent.com/25595356/88869379-8587d900-d20a-11ea-8af8-643fcaa644b4.gif)

Skipping getting side-tracked seeing that it chose MBVGA in the
serial debug and trying to debug why it caused such a display,
I finally checked BXVGA.

While find_framebuffer_address checks for VBoxVGA, init_stage2 didn't.
Whoops!

Here's Serenity in VirtualBox!

![VirtualBoxVM_VnCBWCYdEr](https://user-images.githubusercontent.com/25595356/88869479-caac0b00-d20a-11ea-9a01-243b82061298.png)