### PR TITLE
AK: On failed mmap, don't claim that there's a readable page

### DIFF
--- a/AK/MappedFile.cpp
+++ b/AK/MappedFile.cpp
@@ -24,8 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/String.h>
 #include <AK/MappedFile.h>
+#include <AK/String.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/mman.h>
@@ -38,7 +38,6 @@ namespace AK {
 
 MappedFile::MappedFile(const StringView& file_name)
 {
-    m_size = PAGE_SIZE;
     int fd = open_with_path_length(file_name.characters_without_null_termination(), file_name.length(), O_RDONLY | O_CLOEXEC, 0);
 
     if (fd == -1) {

--- a/Userland/disasm.cpp
+++ b/Userland/disasm.cpp
@@ -37,6 +37,10 @@ int main(int argc, char** argv)
     }
 
     MappedFile file(argv[1]);
+    if (!file.is_valid()) {
+        // Already printed some error message.
+        return 1;
+    }
 
     X86::SimpleInstructionStream stream((const u8*)file.data(), file.size());
     X86::Disassembler disassembler(stream);

--- a/Userland/unzip.cpp
+++ b/Userland/unzip.cpp
@@ -183,6 +183,8 @@ int main(int argc, char** argv)
     }
 
     MappedFile mapped_file { zip_file_path };
+    if (!mapped_file.is_valid())
+        return 1;
 
     printf("Archive: %s\n", zip_file_path.characters());
 


### PR DESCRIPTION
Behavior before:

```
 ./disasm --help
open: No such file or directory
Data is at 0xffffffffffffffff, there's 4096 bytes.
Segmentation fault
[$? = 139]
```

That's because the argument `--help` was interpreted as a filename, and the constructor of `MappedFile` sets `m_size` to a page size, even though it already is correctly initialized to 0.

Even more generally, `disasm` forgot to check whether the mmap'd file `.is_valid()`, and now exits with an error before any access is attempted.

Behavior now:
```
$ ./disasm --help
open: No such file or directory
[$? = 1]
```

(In case you're wondering about unzip: That only crashes when there's a race between unzip's `stat()`, the file deletion, and unzip's `MappedFile()`, so I can't easily reproduce that bug.)