### PR TITLE
Kernel: Tell the bootloader to put us into graphics mode

### DIFF
--- a/Kernel/Arch/i386/Boot/boot.S
+++ b/Kernel/Arch/i386/Boot/boot.S
@@ -1,7 +1,8 @@
 .set MULTIBOOT_MAGIC,         0x1badb002
 .set MULTIBOOT_PAGE_ALIGN,    0x1
 .set MULTIBOOT_MEMORY_INFO,   0x2
-.set multiboot_flags,         MULTIBOOT_PAGE_ALIGN | MULTIBOOT_MEMORY_INFO
+.set MULTIBOOT_VIDEO_MODE,    0x4
+.set multiboot_flags,         MULTIBOOT_PAGE_ALIGN | MULTIBOOT_MEMORY_INFO | MULTIBOOT_VIDEO_MODE
 .set multiboot_checksum,      -(MULTIBOOT_MAGIC + multiboot_flags)
 
 .section .multiboot
@@ -18,6 +19,12 @@
 .long 0x00000000    /* load_end_addr */
 .long 0x00000000    /* bss_end_addr */
 .long 0x00000000    /* entry_addr */
+
+/* for MULTIBOOT_VIDEO_MODE */
+.long 0x00000000    /* mode_type */
+.long 1280          /* width */
+.long 1024          /* height */
+.long 32            /* depth */
 
 .section .stack, "aw", @nobits
 stack_bottom:


### PR DESCRIPTION
Re-adds the section of the Mulitboot header that tells the bootloader to enter graphics mode that I removed while trying to get Serenity to work in VGA text mode. Should fix #2933 