### PR TITLE
WindowServer: Automatic window placement

### DIFF
--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
     auto bookmarks_bar = Browser::BookmarksBarWidget::construct(Browser::bookmarks_filename, bookmarksbar_enabled);
 
     auto window = GUI::Window::construct();
-    window->set_rect(100, 100, 640, 480);
+    window->resize(640, 480);
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-browser.png"));
     window->set_title("Browser");
 

--- a/Applications/Calculator/main.cpp
+++ b/Applications/Calculator/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     window->set_title("Calculator");
     window->set_resizable(false);
-    window->set_rect({ 300, 200, 254, 213 });
+    window->resize(254, 213);
 
     window->set_main_widget<CalculatorWidget>();
 

--- a/Applications/Calendar/main.cpp
+++ b/Applications/Calendar/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Calendar");
-    window->set_rect(20, 200, 596, 475);
+    window->resize(596, 475);
 
     auto& calendar_widget = window->set_main_widget<CalendarWidget>();
     window->show();

--- a/Applications/DisplaySettings/main.cpp
+++ b/Applications/DisplaySettings/main.cpp
@@ -56,7 +56,6 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     dbg() << "main window: " << window;
     window->set_title("Display settings");
-    window->move_to(100, 100);
     window->resize(360, 390);
     window->set_resizable(false);
     window->set_main_widget(instance->root_widget());

--- a/Applications/FontEditor/main.cpp
+++ b/Applications/FontEditor/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv)
         auto& font_editor_widget = window->set_main_widget<FontEditorWidget>(path, move(font));
         window->set_rect({ point, { font_editor_widget.preferred_width(), font_editor_widget.preferred_height() } });
     };
-    set_edited_font(path, move(edited_font), { 50, 50 });
+    set_edited_font(path, move(edited_font), window->position());
 
     auto menubar = GUI::MenuBar::construct();
 

--- a/Applications/Help/main.cpp
+++ b/Applications/Help/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
     auto window = GUI::Window::construct();
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Help");
-    window->set_rect(300, 200, 570, 500);
+    window->resize(570, 500);
 
     auto& widget = window->set_main_widget<GUI::Widget>();
     widget.set_layout<GUI::VerticalBoxLayout>();

--- a/Applications/HexEditor/main.cpp
+++ b/Applications/HexEditor/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Hex Editor");
-    window->set_rect(20, 200, 640, 400);
+    window->resize(640, 400);
 
     auto& hex_editor_widget = window->set_main_widget<HexEditorWidget>();
 

--- a/Applications/IRCClient/IRCAppWindow.cpp
+++ b/Applications/IRCClient/IRCAppWindow.cpp
@@ -58,7 +58,7 @@ IRCAppWindow::IRCAppWindow(String server, int port)
     set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-irc-client.png"));
 
     update_title();
-    set_rect(200, 200, 600, 400);
+    resize(600, 400);
     setup_actions();
     setup_menus();
     setup_widgets();

--- a/Applications/KeyboardMapper/main.cpp
+++ b/Applications/KeyboardMapper/main.cpp
@@ -50,7 +50,6 @@ int main(int argc, char** argv)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_main_widget<KeyboardMapperWidget>();
     window->resize(775, 315);
-    window->move_to(50, 50);
     window->set_resizable(false);
     window->show();
 

--- a/Applications/KeyboardSettings/main.cpp
+++ b/Applications/KeyboardSettings/main.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Keyboard settings");
-    window->set_rect(200, 200, 300, 70);
+    window->resize(300, 70);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto& root_widget = window->set_main_widget<GUI::Widget>();

--- a/Applications/Piano/main.cpp
+++ b/Applications/Piano/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     auto& main_widget = window->set_main_widget<MainWidget>(track_manager);
     window->set_title("Piano");
-    window->set_rect(90, 90, 840, 600);
+    window->resize(840, 600);
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-piano.png"));
     window->show();
 

--- a/Applications/PixelPaint/main.cpp
+++ b/Applications/PixelPaint/main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("PixelPaint");
-    window->set_rect(40, 100, 950, 570);
+    window->resize(950, 570);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto& horizontal_container = window->set_main_widget<GUI::Widget>();

--- a/Applications/QuickShow/main.cpp
+++ b/Applications/QuickShow/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_double_buffering_enabled(true);
-    window->set_rect(200, 200, 300, 200);
+    window->resize(300, 200);
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-image.png"));
     window->set_title("QuickShow");
 

--- a/Applications/SoundPlayer/main.cpp
+++ b/Applications/SoundPlayer/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     window->set_title("SoundPlayer");
     window->set_resizable(false);
-    window->set_rect(300, 300, 350, 140);
+    window->resize(350, 140);
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-sound-player.png"));
 
     auto menubar = GUI::MenuBar::construct();

--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -153,7 +153,7 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("System Monitor");
-    window->set_rect(20, 200, 680, 400);
+    window->resize(680, 400);
 
     auto& keeper = window->set_main_widget<GUI::Widget>();
     keeper.set_layout<GUI::VerticalBoxLayout>();

--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -255,7 +255,6 @@ int main(int argc, char** argv)
     terminal.on_title_change = [&](auto& title) {
         window->set_title(title);
     };
-    window->move_to(300, 300);
     terminal.apply_size_increments_to_window(*window);
     window->show();
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-terminal.png"));

--- a/Applications/TextEditor/main.cpp
+++ b/Applications/TextEditor/main.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Text Editor");
-    window->set_rect(20, 200, 640, 400);
+    window->resize(640, 400);
 
     auto& text_widget = window->set_main_widget<TextEditorWidget>();
 

--- a/Libraries/LibGUI/Window.cpp
+++ b/Libraries/LibGUI/Window.cpp
@@ -62,7 +62,7 @@ Window::Window(Core::Object* parent)
     : Core::Object(parent)
 {
     all_windows->set(this);
-    m_rect_when_windowless = { 100, 400, 140, 140 };
+    m_rect_when_windowless = { -5000, -5000, 140, 140 };
     m_title_when_windowless = "GUI::Window";
 }
 
@@ -95,6 +95,7 @@ void Window::show()
     m_override_cursor = StandardCursor::None;
     auto response = WindowServerConnection::the().send_sync<Messages::WindowServer::CreateWindow>(
         m_rect_when_windowless,
+        !m_moved_by_client,
         m_has_alpha_channel,
         m_modal,
         m_minimizable,
@@ -192,6 +193,10 @@ Gfx::IntRect Window::rect() const
 
 void Window::set_rect(const Gfx::IntRect& a_rect)
 {
+    if (a_rect.location() != m_rect_when_windowless.location()) {
+        m_moved_by_client = true;
+    }
+
     m_rect_when_windowless = a_rect;
     if (!is_visible()) {
         if (m_main_widget)

--- a/Libraries/LibGUI/Window.h
+++ b/Libraries/LibGUI/Window.h
@@ -262,6 +262,7 @@ private:
     bool m_visible_for_timer_purposes { true };
     bool m_visible { false };
     bool m_accessory { false };
+    bool m_moved_by_client { false };
 };
 
 }

--- a/Services/WindowServer/Window.cpp
+++ b/Services/WindowServer/Window.cpp
@@ -273,6 +273,7 @@ void Window::set_maximized(bool maximized)
     }
     m_frame.did_set_maximized({}, maximized);
     Core::EventLoop::current().post_event(*this, make<ResizeEvent>(old_rect, m_rect));
+    set_default_positioned(false);
 }
 
 void Window::set_resizable(bool resizable)
@@ -398,7 +399,7 @@ Window* Window::is_blocked_by_modal_window()
         if (window && !window->is_destroyed()) {
             if (window->is_modal())
                 return window;
-            
+
             if (auto* blocking_modal_window = window->is_blocked_by_modal_window())
                 return blocking_modal_window;
         }
@@ -601,7 +602,7 @@ bool Window::is_accessory() const
         return false;
     if (parent_window() != nullptr)
         return true;
-    
+
     // If accessory window was unparented, convert to a regular window
     const_cast<Window*>(this)->set_accessory(false);
     return false;

--- a/Services/WindowServer/Window.h
+++ b/Services/WindowServer/Window.h
@@ -259,6 +259,9 @@ public:
     bool is_destroyed() const { return m_destroyed; }
     void destroy();
 
+    bool default_positioned() const { return m_default_positioned; }
+    void set_default_positioned(bool p) { m_default_positioned = p; }
+
 private:
     void handle_mouse_event(const MouseEvent&);
     void update_menu_item_text(PopupMenuItem item);
@@ -293,6 +296,7 @@ private:
     bool m_fullscreen { false };
     bool m_accessory { false };
     bool m_destroyed { false };
+    bool m_default_positioned { false };
     WindowTileType m_tiled { WindowTileType::None };
     Gfx::IntRect m_untiled_rect;
     bool m_occluded { false };

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -442,6 +442,7 @@ void WindowManager::start_window_move(Window& window, const MouseEvent& event)
 #endif
     move_to_front_and_make_active(window);
     m_move_window = window.make_weak_ptr();
+    m_move_window->set_default_positioned(false);
     m_move_origin = event.position();
     m_move_window_origin = window.position();
     window.invalidate();
@@ -479,6 +480,10 @@ void WindowManager::start_window_resize(Window& window, const Gfx::IntPoint& pos
     m_resize_window_original_rect = window.rect();
 
     window.invalidate();
+
+    if (hot_area_row == 0 || hot_area_column == 0) {
+        m_resize_window->set_default_positioned(false);
+    }
 }
 
 void WindowManager::start_window_resize(Window& window, const MouseEvent& event)
@@ -1427,4 +1432,34 @@ void WindowManager::maximize_windows(Window& window, bool maximized)
     });
 }
 
+Gfx::IntPoint WindowManager::get_recommended_window_position(const Gfx::IntPoint& desired)
+{
+    // FIXME: Find a  better source for the width and height to shift by.
+    Gfx::IntPoint shift(8, palette().window_title_height() + 10);
+
+    // FIXME: Find a better source for this.
+    int taskbar_height = 28;
+    int menubar_height = MenuManager::the().menubar_rect().height();
+
+    const Window* overlap_window = nullptr;
+    for_each_visible_window_of_type_from_front_to_back(WindowType::Normal, [&](Window& window) {
+        if (window.default_positioned() && (!overlap_window || overlap_window->window_id() < window.window_id())) {
+            overlap_window = &window;
+        }
+        return IterationDecision::Continue;
+    });
+
+    Gfx::IntPoint point;
+    if (overlap_window) {
+        point = overlap_window->position() + shift;
+        point = { point.x() % Screen::the().width(),
+            (point.y() >= (Screen::the().height() - taskbar_height))
+                ? menubar_height + palette().window_title_height()
+                : point.y() };
+    } else {
+        point = desired;
+    }
+
+    return point;
+}
 }

--- a/Services/WindowServer/WindowManager.h
+++ b/Services/WindowServer/WindowManager.h
@@ -212,6 +212,8 @@ public:
         }
     }
 
+    Gfx::IntPoint get_recommended_window_position(const Gfx::IntPoint& desired);
+
 private:
     NonnullRefPtr<Cursor> get_cursor(const String& name);
     NonnullRefPtr<Cursor> get_cursor(const String& name, const Gfx::IntPoint& hotspot);

--- a/Services/WindowServer/WindowServer.ipc
+++ b/Services/WindowServer/WindowServer.ipc
@@ -32,6 +32,7 @@ endpoint WindowServer = 2
 
     CreateWindow(
         Gfx::IntRect rect,
+        bool auto_position,
         bool has_alpha_channel,
         bool modal,
         bool minimizable,


### PR DESCRIPTION
This is a follow up to #2916.

The new behavior is as follows:
- Windows that have been created without a set position are assigned one
  by WindowServer.
- The assigned position is either offset from the last window that is
  still in an assigned position, or a default position if no such window
  is available.

When there are no windows in their default position, new windows are opened at [100,100] currently, but I'm open to better suggestions  of where to put them.