### PR TITLE
AK: Use C++20 concepts to only allow Userspace wrappers of pointers

### DIFF
--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -42,7 +42,7 @@ public:
     operator bool() const { return m_ptr; }
     operator FlatPtr() const { return (FlatPtr)m_ptr; }
 
-#if defined(KERNEL)
+#ifdef KERNEL
     Userspace(FlatPtr ptr)
         : m_ptr(ptr)
     {
@@ -60,7 +60,7 @@ public:
 #endif
 
 private:
-#if defined(KERNEL)
+#ifdef KERNEL
     FlatPtr m_ptr { 0 };
 #else
     T m_ptr { nullptr };

--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -26,11 +26,15 @@
 
 #pragma once
 
+#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 
 namespace AK {
 
 template<typename T>
+concept PointerTypeName = IsPointer<T>::value;
+
+template<PointerTypeName T>
 class Userspace {
 public:
     Userspace() { }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ add_custom_target(check-style
     USES_TERMINAL
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -std=c++2a -fdiagnostics-color=always")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -std=c++2a -fdiagnostics-color=always -fconcepts")
 
 include_directories(Libraries)
 include_directories(.)


### PR DESCRIPTION
It was a bit odd that you could create a `Userspace<int>` and that `Userspace<int>::ptr()` returned an `int` instead of an `int*`.
    
Let's use C++20 concepts to only allow creating `Userspace` objects with pointer types. :^)

We could also rewrite `Userspace<T>` as something like `UserspacePtr<T>` and make it store `m_ptr` (etc.) as a `T*`, but since we are using `Userspace` to also wrap const-pointers and void-pointers we would need to make separate classes for those (something like `ConstUserspacePtr<T>` and `VoidUserspacePtr`).

The C++20 concepts solution is definitely cleaner.

-----------------------------
I also replaced `#if defined(KERNEL)` with `#ifdef KERNEL` in `Userspace.h`.