### PR TITLE
Travis: Marginally faster builds, maybe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 - cmake --version
 
 script:
-- export SERENITY_ROOT=$(pwd)
+- export SERENITY_ROOT="$(pwd)"
 - Meta/lint-shell-scripts.sh
 - Meta/lint-executable-resources.sh
 - Meta/check-style.sh
@@ -43,7 +43,7 @@ script:
 - mkdir -p Build
 - cd Build
 - cmake .. -DBUILD_LAGOM=1
-- make
+- make -j2
 - CTEST_OUTPUT_ON_FAILURE=1 make test
 - cd Meta/Lagom
 - ./test-js

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -197,11 +197,13 @@ pushd "$DIR/Build/"
     unset PKG_CONFIG_LIBDIR # Just in case
 
     pushd binutils
+        echo "XXX configure binutils"
         "$DIR"/Tarballs/binutils-2.33.1/configure --prefix="$PREFIX" \
                                                 --target="$TARGET" \
                                                 --with-sysroot="$SYSROOT" \
                                                 --enable-shared \
-                                                --disable-nls || exit 1
+                                                --disable-nls \
+                                                ${TRY_USE_LOCAL_TOOLCHAIN:+"--quiet"} || exit 1
         if [ "$(uname)" = "Darwin" ]; then
             # under macOS generated makefiles are not resolving the "intl"
             # dependency properly to allow linking its own copy of
@@ -211,6 +213,7 @@ pushd "$DIR/Build/"
             "$MAKE" all-yes
             popd
         fi
+        echo "XXX build binutils"
         "$MAKE" -j "$MAKEJOBS" || exit 1
         "$MAKE" install || exit 1
     popd
@@ -220,13 +223,15 @@ pushd "$DIR/Build/"
             perl -pi -e 's/-no-pie/-nopie/g' "$DIR/Tarballs/gcc-$GCC_VERSION/gcc/configure"
         fi
 
+        echo "XXX configure gcc and libgcc"
         "$DIR/Tarballs/gcc-$GCC_VERSION/configure" --prefix="$PREFIX" \
                                             --target="$TARGET" \
                                             --with-sysroot="$SYSROOT" \
                                             --disable-nls \
                                             --with-newlib \
                                             --enable-shared \
-                                            --enable-languages=c,c++ || exit 1
+                                            --enable-languages=c,c++ \
+                                            ${TRY_USE_LOCAL_TOOLCHAIN:+"--quiet"} || exit 1
 
         echo "XXX build gcc and libgcc"
         "$MAKE" -j "$MAKEJOBS" all-gcc all-target-libgcc || exit 1

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -254,7 +254,7 @@ pushd "$DIR/Build/"
         popd
 
         echo "XXX build libstdc++"
-        "$MAKE" all-target-libstdc++-v3 || exit 1
+        "$MAKE" -j "$MAKEJOBS" all-target-libstdc++-v3 || exit 1
         echo "XXX install libstdc++"
         "$MAKE" install-target-libstdc++-v3 || exit 1
 


### PR DESCRIPTION
At least in theory, this should make it a bit faster:
- Build *Serenity* in parallel
- Build *libstdc++* in parallel
- Less chatty `./configure` output for binutils/gcc

The bulk of the compilation time is gcc/libgcc itself, so this has only little impact, if at all. I tried looking into making gcc build faster, but … no idea. Building gcc is slow. Deal with it. Or fix it. Yes, fix it, please, actually! :P

And this time I let the test complete before making the PR. :)

> Trying to cut down the list of "dependencies", so we can re-use a Toolchain more often. #2917 

That'll come next, eventually, maybe, soon, probably.