### PR TITLE
Kernel: Prevent recursive calls into the scheduler

### DIFF
--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -56,6 +56,7 @@ class Range;
 class RangeAllocator;
 class Region;
 class Scheduler;
+class SchedulerPerProcessorData;
 class SharedBuffer;
 class Socket;
 template<typename BaseType>

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -680,7 +680,7 @@ private:
     size_t m_master_tls_alignment { 0 };
 
     Lock m_big_lock { "Process" };
-    SpinLock<u32> m_lock;
+    mutable SpinLock<u32> m_lock;
 
     u64 m_alarm_deadline { 0 };
 

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -62,6 +62,9 @@ public:
     static bool donate_to(Thread*, const char* reason);
     static bool context_switch(Thread*);
     static void enter_current(Thread& prev_thread);
+    static void leave_on_first_switch(u32 flags);
+    static void prepare_after_exec();
+    static void prepare_for_idle_loop();
     static Process* colonel();
     static void beep();
     static void idle_loop();

--- a/Kernel/Syscalls/kill.cpp
+++ b/Kernel/Syscalls/kill.cpp
@@ -139,7 +139,7 @@ int Process::sys$kill(pid_t pid, int signal)
         return do_killself(signal);
     }
     ScopedSpinLock lock(g_processes_lock);
-    auto* peer = Process::from_pid(pid);
+    auto peer = Process::from_pid(pid);
     if (!peer)
         return -ESRCH;
     return do_kill(*peer, signal);

--- a/Kernel/Syscalls/profiling.cpp
+++ b/Kernel/Syscalls/profiling.cpp
@@ -33,7 +33,7 @@ int Process::sys$profiling_enable(pid_t pid)
 {
     REQUIRE_NO_PROMISES;
     ScopedSpinLock lock(g_processes_lock);
-    auto* process = Process::from_pid(pid);
+    auto process = Process::from_pid(pid);
     if (!process)
         return -ESRCH;
     if (process->is_dead())
@@ -48,7 +48,7 @@ int Process::sys$profiling_enable(pid_t pid)
 int Process::sys$profiling_disable(pid_t pid)
 {
     ScopedSpinLock lock(g_processes_lock);
-    auto* process = Process::from_pid(pid);
+    auto process = Process::from_pid(pid);
     if (!process)
         return -ESRCH;
     if (!is_superuser() && process->uid() != m_uid)

--- a/Kernel/Syscalls/sched.cpp
+++ b/Kernel/Syscalls/sched.cpp
@@ -120,7 +120,7 @@ int Process::sys$set_process_boost(pid_t pid, int amount)
     if (amount < 0 || amount > 20)
         return -EINVAL;
     ScopedSpinLock lock(g_processes_lock);
-    auto* process = Process::from_pid(pid);
+    auto process = Process::from_pid(pid);
     if (!process || process->is_dead())
         return -ESRCH;
     if (!is_superuser() && process->uid() != euid())

--- a/Kernel/Syscalls/setpgid.cpp
+++ b/Kernel/Syscalls/setpgid.cpp
@@ -35,7 +35,7 @@ pid_t Process::sys$getsid(pid_t pid)
     if (pid == 0)
         return m_sid;
     ScopedSpinLock lock(g_processes_lock);
-    auto* process = Process::from_pid(pid);
+    auto process = Process::from_pid(pid);
     if (!process)
         return -ESRCH;
     if (m_sid != process->m_sid)
@@ -66,7 +66,7 @@ pid_t Process::sys$getpgid(pid_t pid)
     if (pid == 0)
         return m_pgid;
     ScopedSpinLock lock(g_processes_lock); // FIXME: Use a ProcessHandle
-    auto* process = Process::from_pid(pid);
+    auto process = Process::from_pid(pid);
     if (!process)
         return -ESRCH;
     return process->m_pgid;
@@ -81,7 +81,7 @@ pid_t Process::sys$getpgrp()
 static pid_t get_sid_from_pgid(pid_t pgid)
 {
     ScopedSpinLock lock(g_processes_lock);
-    auto* group_leader = Process::from_pid(pgid);
+    auto group_leader = Process::from_pid(pgid);
     if (!group_leader)
         return -1;
     return group_leader->sid();
@@ -96,7 +96,7 @@ int Process::sys$setpgid(pid_t specified_pid, pid_t specified_pgid)
         // The value of the pgid argument is less than 0, or is not a value supported by the implementation.
         return -EINVAL;
     }
-    auto* process = Process::from_pid(pid);
+    auto process = Process::from_pid(pid);
     if (!process)
         return -ESRCH;
     if (process != this && process->ppid() != m_pid) {

--- a/Kernel/Syscalls/shbuf.cpp
+++ b/Kernel/Syscalls/shbuf.cpp
@@ -81,7 +81,7 @@ int Process::sys$shbuf_allow_pid(int shbuf_id, pid_t peer_pid)
         return -EPERM;
     {
         ScopedSpinLock lock(g_processes_lock);
-        auto* peer = Process::from_pid(peer_pid);
+        auto peer = Process::from_pid(peer_pid);
         if (!peer)
             return -ESRCH;
     }

--- a/Kernel/Syscalls/waitid.cpp
+++ b/Kernel/Syscalls/waitid.cpp
@@ -54,7 +54,7 @@ KResultOr<siginfo_t> Process::do_waitid(idtype_t idtype, int id, int options)
     ScopedSpinLock lock(g_processes_lock);
 
     // NOTE: If waitee was -1, m_waitee_pid will have been filled in by the scheduler.
-    Process* waitee_process = Process::from_pid(waitee_pid);
+    auto waitee_process = Process::from_pid(waitee_pid);
     if (!waitee_process)
         return KResult(-ECHILD);
 

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -303,7 +303,7 @@ int TTY::ioctl(FileDescription&, unsigned request, FlatPtr arg)
             return -EINVAL;
         {
             InterruptDisabler disabler;
-            auto* process = Process::from_pid(pgid);
+            auto process = Process::from_pid(pgid);
             if (!process)
                 return -EPERM;
             if (pgid != process->pgid())


### PR DESCRIPTION
Upon leaving a critical section (such as a SpinLock) we need to
check if we're already asynchronously invoking the Scheduler.
Otherwise we might end up triggering another context switch
as soon as leaving the scheduler lock.