### PR TITLE
LibDebug: Disable and cleanup DebugSession breakpoints on destruction

### DIFF
--- a/Libraries/LibDebug/DebugSession.cpp
+++ b/Libraries/LibDebug/DebugSession.cpp
@@ -38,6 +38,11 @@ DebugSession::DebugSession(int pid)
 
 DebugSession::~DebugSession()
 {
+    for (const auto& bp : m_breakpoints) {
+        disable_breakpoint(bp.key);
+    }
+    m_breakpoints.clear();
+
     if (!m_is_debugee_dead) {
         if (ptrace(PT_DETACH, m_debugee_pid, 0, 0) < 0) {
             perror("PT_DETACH");


### PR DESCRIPTION
Breakpoints need to be disabled before we detach from the debugee.

I noticed this while looking into the fact that if you continue
executing a program in sdb (/bin/ls) where you had previously
set a breakpoint, it would crash on sdb exit once the debugee died
with an assert on HashMap destruction where we were iterating
while clearing is set. This change also happens to fix this assert.

FYI  @itamar8910 