### PR TITLE
WindowServer: Redraw MenuApplets on add/delete

### DIFF
--- a/Services/WindowServer/AppletManager.cpp
+++ b/Services/WindowServer/AppletManager.cpp
@@ -83,6 +83,8 @@ void AppletManager::add_applet(Window& applet)
     });
 
     calculate_applet_rects(MenuManager::the().window());
+
+    MenuManager::the().refresh();
 }
 
 void AppletManager::calculate_applet_rects(Window& window)
@@ -105,6 +107,8 @@ void AppletManager::remove_applet(Window& applet)
     m_applets.remove_first_matching([&](auto& entry) {
         return &applet == entry.ptr();
     });
+
+    MenuManager::the().refresh();
 }
 
 void AppletManager::draw()


### PR DESCRIPTION
This fixes a bug by omission: MenuApplets weren't redrawn when one was added/removed. This was sometimes visible after startup, and was always visible immediately after starting a new MenuApplet by hand (e.g. Username.MenuApplet). (See red example.)

Simply invalidating each MenuApplet's new rect (thus causing it to be redrawn) is not enough: The "blank" space in-between also needs to be redrawn. (See yellow example.)

This PR implements that the MenuManager is completely redrawn when a MenuApplet is added/removed. (See gree example.) This may not be the most efficient way of doing it, but since MenuApplets shouldn't constantly be added/removed all the time, this should be enough.

I'm not sure whether `add_applet`/`remove_applet` is the right place to call `MenuManager::the().refresh()`, because I'm not entirely sure about how this all works together ^^'

![applets-cmp](https://user-images.githubusercontent.com/2690845/89111978-0c33f480-d45d-11ea-8c6c-1a11b6ea03d2.png)
