### PR TITLE
ProtocolServer+LibTLS: (very basic) Client Certificates

### DIFF
--- a/Libraries/LibCrypto/ASN1/PEM.h
+++ b/Libraries/LibCrypto/ASN1/PEM.h
@@ -46,7 +46,7 @@ static ByteBuffer decode_pem(ReadonlyBytes data_in, size_t cert_index = 0)
             continue;
 
         if (data_in[i] != '-') {
-            // read entire line
+            // Read entire line.
             while ((i < input_length) && (data_in[i] != '\n'))
                 i++;
             continue;
@@ -54,7 +54,7 @@ static ByteBuffer decode_pem(ReadonlyBytes data_in, size_t cert_index = 0)
 
         if (data_in[i] == '-') {
             auto end_idx = i;
-            //read until end of line
+            // Read until end of line.
             while ((i < input_length) && (data_in[i] != '\n'))
                 i++;
             if (start_at) {

--- a/Libraries/LibGemini/GeminiJob.h
+++ b/Libraries/LibGemini/GeminiJob.h
@@ -48,6 +48,9 @@ public:
 
     virtual void start() override;
     virtual void shutdown() override;
+    void set_certificate(String certificate, String key);
+
+    Function<void(GeminiJob&)> on_certificate_requested;
 
 protected:
     virtual void register_on_ready_to_read(Function<void()>) override;

--- a/Libraries/LibHTTP/HttpsJob.h
+++ b/Libraries/LibHTTP/HttpsJob.h
@@ -49,6 +49,9 @@ public:
 
     virtual void start() override;
     virtual void shutdown() override;
+    void set_certificate(String certificate, String key);
+
+    Function<void(HttpsJob&)> on_certificate_requested;
 
 protected:
     virtual void register_on_ready_to_read(Function<void()>) override;

--- a/Libraries/LibProtocol/Client.cpp
+++ b/Libraries/LibProtocol/Client.cpp
@@ -68,6 +68,13 @@ bool Client::stop_download(Badge<Download>, Download& download)
     return send_sync<Messages::ProtocolServer::StopDownload>(download.id())->success();
 }
 
+bool Client::set_certificate(Badge<Download>, Download& download, String certificate, String key)
+{
+    if (!m_downloads.contains(download.id()))
+        return false;
+    return send_sync<Messages::ProtocolServer::SetCertificate>(download.id(), move(certificate), move(key))->success();
+}
+
 void Client::handle(const Messages::ProtocolClient::DownloadFinished& message)
 {
     RefPtr<Download> download;
@@ -83,6 +90,15 @@ void Client::handle(const Messages::ProtocolClient::DownloadProgress& message)
     if (auto download = const_cast<Download*>(m_downloads.get(message.download_id()).value_or(nullptr))) {
         download->did_progress({}, message.total_size(), message.downloaded_size());
     }
+}
+
+OwnPtr<Messages::ProtocolClient::CertificateRequestedResponse> Client::handle(const Messages::ProtocolClient::CertificateRequested& message)
+{
+    if (auto download = const_cast<Download*>(m_downloads.get(message.download_id()).value_or(nullptr))) {
+        download->did_request_certificates({});
+    }
+
+    return make<Messages::ProtocolClient::CertificateRequestedResponse>();
 }
 
 }

--- a/Libraries/LibProtocol/Client.h
+++ b/Libraries/LibProtocol/Client.h
@@ -46,14 +46,15 @@ public:
     bool is_supported_protocol(const String&);
     RefPtr<Download> start_download(const String& url, const HashMap<String, String>& request_headers = {});
 
-
     bool stop_download(Badge<Download>, Download&);
+    bool set_certificate(Badge<Download>, Download&, String, String);
 
 private:
     Client();
 
     virtual void handle(const Messages::ProtocolClient::DownloadProgress&) override;
     virtual void handle(const Messages::ProtocolClient::DownloadFinished&) override;
+    virtual OwnPtr<Messages::ProtocolClient::CertificateRequestedResponse> handle(const Messages::ProtocolClient::CertificateRequested&) override;
 
     HashMap<i32, RefPtr<Download>> m_downloads;
 };

--- a/Libraries/LibProtocol/Download.cpp
+++ b/Libraries/LibProtocol/Download.cpp
@@ -67,4 +67,14 @@ void Download::did_progress(Badge<Client>, Optional<u32> total_size, u32 downloa
     if (on_progress)
         on_progress(total_size, downloaded_size);
 }
+
+void Download::did_request_certificates(Badge<Client>)
+{
+    if (on_certificate_requested) {
+        auto result = on_certificate_requested();
+        if (!m_client->set_certificate({}, *this, result.certificate, result.key)) {
+            dbg() << "Download: set_certificate failed";
+        }
+    }
+}
 }

--- a/Libraries/LibProtocol/Download.h
+++ b/Libraries/LibProtocol/Download.h
@@ -40,6 +40,11 @@ class Client;
 
 class Download : public RefCounted<Download> {
 public:
+    struct CertificateAndKey {
+        String certificate;
+        String key;
+    };
+
     static NonnullRefPtr<Download> create_from_id(Badge<Client>, Client& client, i32 download_id)
     {
         return adopt(*new Download(client, download_id));
@@ -50,9 +55,11 @@ public:
 
     Function<void(bool success, const ByteBuffer& payload, RefPtr<SharedBuffer> payload_storage, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> status_code)> on_finish;
     Function<void(Optional<u32> total_size, u32 downloaded_size)> on_progress;
+    Function<CertificateAndKey()> on_certificate_requested;
 
     void did_finish(Badge<Client>, bool success, Optional<u32> status_code, u32 total_size, i32 shbuf_id, const IPC::Dictionary& response_headers);
     void did_progress(Badge<Client>, Optional<u32> total_size, u32 downloaded_size);
+    void did_request_certificates(Badge<Client>);
 
 private:
     explicit Download(Client&, i32 download_id);

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -206,6 +206,7 @@ struct Certificate {
     CertificateKeyAlgorithm ec_algorithm;
     ByteBuffer exponent;
     Crypto::PK::RSAPublicKey<Crypto::UnsignedBigInteger> public_key;
+    Crypto::PK::RSAPrivateKey<Crypto::UnsignedBigInteger> private_key;
     String issuer_country;
     String issuer_state;
     String issuer_location;
@@ -318,6 +319,13 @@ public:
     bool load_certificates(const ByteBuffer& pem_buffer);
     bool load_private_key(const ByteBuffer& pem_buffer);
 
+    bool add_client_key(const ByteBuffer& certificate_pem_buffer, const ByteBuffer& key_pem_buffer);
+    bool add_client_key(Certificate certificate)
+    {
+        m_context.client_certificates.append(move(certificate));
+        return true;
+    }
+
     ByteBuffer finish_build();
 
     const StringView& alpn() const { return m_context.negotiated_alpn; }
@@ -349,6 +357,7 @@ public:
     Function<void(AlertDescription)> on_tls_error;
     Function<void()> on_tls_connected;
     Function<void()> on_tls_finished;
+    Function<void(TLSv12&)> on_tls_certificate_request;
 
 private:
     explicit TLSv12(Core::Object* parent, Version version = Version::V12);

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -179,6 +179,9 @@ void ResourceLoader::load(const URL& url, Function<void(const ByteBuffer&, const
             }
             success_callback(ByteBuffer::copy(payload.data(), payload.size()), response_headers);
         };
+        download->on_certificate_requested = []() -> Protocol::Download::CertificateAndKey {
+            return {};
+        };
         ++m_pending_loads;
         if (on_load_counter_change)
             on_load_counter_change();

--- a/Services/ProtocolServer/ClientConnection.h
+++ b/Services/ProtocolServer/ClientConnection.h
@@ -28,8 +28,8 @@
 
 #include <AK/HashMap.h>
 #include <LibIPC/ClientConnection.h>
-#include <ProtocolServer/ProtocolServerEndpoint.h>
 #include <ProtocolServer/Forward.h>
+#include <ProtocolServer/ProtocolServerEndpoint.h>
 
 namespace ProtocolServer {
 
@@ -46,6 +46,7 @@ public:
 
     void did_finish_download(Badge<Download>, Download&, bool success);
     void did_progress_download(Badge<Download>, Download&);
+    void did_request_certificates(Badge<Download>, Download&);
 
 private:
     virtual OwnPtr<Messages::ProtocolServer::GreetResponse> handle(const Messages::ProtocolServer::Greet&) override;
@@ -53,6 +54,7 @@ private:
     virtual OwnPtr<Messages::ProtocolServer::StartDownloadResponse> handle(const Messages::ProtocolServer::StartDownload&) override;
     virtual OwnPtr<Messages::ProtocolServer::StopDownloadResponse> handle(const Messages::ProtocolServer::StopDownload&) override;
     virtual OwnPtr<Messages::ProtocolServer::DisownSharedBufferResponse> handle(const Messages::ProtocolServer::DisownSharedBuffer&) override;
+    virtual OwnPtr<Messages::ProtocolServer::SetCertificateResponse> handle(const Messages::ProtocolServer::SetCertificate&);
 
     HashMap<i32, OwnPtr<Download>> m_downloads;
     HashMap<i32, RefPtr<AK::SharedBuffer>> m_shared_buffers;

--- a/Services/ProtocolServer/Download.cpp
+++ b/Services/ProtocolServer/Download.cpp
@@ -25,8 +25,8 @@
  */
 
 #include <AK/Badge.h>
-#include <ProtocolServer/Download.h>
 #include <ProtocolServer/ClientConnection.h>
+#include <ProtocolServer/Download.h>
 
 namespace ProtocolServer {
 
@@ -59,6 +59,10 @@ void Download::set_response_headers(const HashMap<String, String, CaseInsensitiv
     m_response_headers = response_headers;
 }
 
+void Download::set_certificate(String, String)
+{
+}
+
 void Download::did_finish(bool success)
 {
     m_client.did_finish_download({}, *this, success);
@@ -69,6 +73,11 @@ void Download::did_progress(Optional<u32> total_size, u32 downloaded_size)
     m_total_size = total_size;
     m_downloaded_size = downloaded_size;
     m_client.did_progress_download({}, *this);
+}
+
+void Download::did_request_certificates()
+{
+    m_client.did_request_certificates({}, *this);
 }
 
 }

--- a/Services/ProtocolServer/Download.h
+++ b/Services/ProtocolServer/Download.h
@@ -49,6 +49,7 @@ public:
     const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers() const { return m_response_headers; }
 
     void stop();
+    virtual void set_certificate(String, String);
 
 protected:
     explicit Download(ClientConnection&);
@@ -56,6 +57,7 @@ protected:
     void did_finish(bool success);
     void did_progress(Optional<u32> total_size, u32 downloaded_size);
     void set_status_code(u32 status_code) { m_status_code = status_code; }
+    void did_request_certificates();
     void set_payload(const ByteBuffer&);
     void set_response_headers(const HashMap<String, String, CaseInsensitiveStringTraits>&);
 

--- a/Services/ProtocolServer/Forward.h
+++ b/Services/ProtocolServer/Forward.h
@@ -31,7 +31,9 @@ namespace ProtocolServer {
 class ClientConnection;
 class Download;
 class GeminiProtocol;
+class HttpDownload;
 class HttpProtocol;
+class HttpsDownload;
 class HttpsProtocol;
 class Protocol;
 

--- a/Services/ProtocolServer/GeminiDownload.cpp
+++ b/Services/ProtocolServer/GeminiDownload.cpp
@@ -59,6 +59,14 @@ GeminiDownload::GeminiDownload(ClientConnection& client, NonnullRefPtr<Gemini::G
     m_job->on_progress = [this](Optional<u32> total, u32 current) {
         did_progress(total, current);
     };
+    m_job->on_certificate_requested = [this](auto&) {
+        did_request_certificates();
+    };
+}
+
+void GeminiDownload::set_certificate(String certificate, String key)
+{
+    m_job->set_certificate(move(certificate), move(key));
 }
 
 GeminiDownload::~GeminiDownload()

--- a/Services/ProtocolServer/GeminiDownload.h
+++ b/Services/ProtocolServer/GeminiDownload.h
@@ -41,6 +41,8 @@ public:
 private:
     explicit GeminiDownload(ClientConnection&, NonnullRefPtr<Gemini::GeminiJob>);
 
+    virtual void set_certificate(String certificate, String key) override;
+
     NonnullRefPtr<Gemini::GeminiJob> m_job;
 };
 

--- a/Services/ProtocolServer/HttpsDownload.cpp
+++ b/Services/ProtocolServer/HttpsDownload.cpp
@@ -51,6 +51,14 @@ HttpsDownload::HttpsDownload(ClientConnection& client, NonnullRefPtr<HTTP::Https
     m_job->on_progress = [this](Optional<u32> total, u32 current) {
         did_progress(total, current);
     };
+    m_job->on_certificate_requested = [this](auto&) {
+        did_request_certificates();
+    };
+}
+
+void HttpsDownload::set_certificate(String certificate, String key)
+{
+    m_job->set_certificate(move(certificate), move(key));
 }
 
 HttpsDownload::~HttpsDownload()

--- a/Services/ProtocolServer/HttpsDownload.h
+++ b/Services/ProtocolServer/HttpsDownload.h
@@ -41,6 +41,8 @@ public:
 private:
     explicit HttpsDownload(ClientConnection&, NonnullRefPtr<HTTP::HttpsJob>);
 
+    virtual void set_certificate(String certificate, String key) override;
+
     NonnullRefPtr<HTTP::HttpsJob> m_job;
 };
 

--- a/Services/ProtocolServer/ProtocolClient.ipc
+++ b/Services/ProtocolServer/ProtocolClient.ipc
@@ -3,4 +3,7 @@ endpoint ProtocolClient = 13
     // Download notifications
     DownloadProgress(i32 download_id, Optional<u32> total_size, u32 downloaded_size) =|
     DownloadFinished(i32 download_id, bool success, Optional<u32> status_code, u32 total_size, i32 shbuf_id, IPC::Dictionary response_headers) =|
+
+    // Certificate requests
+    CertificateRequested(i32 download_id) => ()
 }

--- a/Services/ProtocolServer/ProtocolServer.ipc
+++ b/Services/ProtocolServer/ProtocolServer.ipc
@@ -12,4 +12,5 @@ endpoint ProtocolServer = 9
     // Download API
     StartDownload(URL url, IPC::Dictionary request_headers) => (i32 download_id)
     StopDownload(i32 download_id) => (bool success)
+    SetCertificate(i32 download_id, String certificate, String key) => (bool success)
 }


### PR DESCRIPTION
This PR adds support for client certificates (but does not yet send any) and pipes certificate requests all the way from LibTLS to ProtocolServer clients.

This makes gemini work again (with a few more sites to boot!)