### PR TITLE
Build: Support make's and ninja's restat optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ add_subdirectory(DevTools/FormCompiler)
 add_subdirectory(Libraries/LibWeb/CodeGenerators)
 add_subdirectory(AK/Tests)
 
+set(write_if_different ${CMAKE_SOURCE_DIR}/Meta/write-only-on-difference.sh)
+
 function(serenity_install_headers target_name)
     file(GLOB_RECURSE headers RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h")
     foreach(header ${headers})
@@ -96,7 +98,7 @@ function(compile_ipc source output)
     set(source ${CMAKE_CURRENT_SOURCE_DIR}/${source})
     add_custom_command(
         OUTPUT ${output}
-        COMMAND IPCCompiler ${source} > ${output}
+        COMMAND ${write_if_different} ${output} ${CMAKE_BINARY_DIR}/DevTools/IPCCompiler/IPCCompiler ${source}
         VERBATIM
         DEPENDS IPCCompiler
         MAIN_DEPENDENCY ${source}

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -146,16 +146,14 @@ function(libweb_js_wrapper class)
     add_wrapper_sources(Bindings/${basename}Wrapper.cpp Bindings/${basename}Wrapper.h)
     add_custom_command(
         OUTPUT Bindings/${basename}Wrapper.h
-        COMMAND /bin/mkdir -p Bindings
-        COMMAND WrapperGenerator --header ${CMAKE_CURRENT_SOURCE_DIR}/${class}.idl > Bindings/${basename}Wrapper.h
+        COMMAND ${write_if_different} Bindings/${basename}Wrapper.h CodeGenerators/WrapperGenerator --header ${CMAKE_CURRENT_SOURCE_DIR}/${class}.idl
         VERBATIM
         DEPENDS WrapperGenerator
         MAIN_DEPENDENCY ${class}.idl
     )
     add_custom_command(
         OUTPUT Bindings/${basename}Wrapper.cpp
-        COMMAND /bin/mkdir -p Bindings
-        COMMAND WrapperGenerator --implementation ${CMAKE_CURRENT_SOURCE_DIR}/${class}.idl > Bindings/${basename}Wrapper.cpp
+        COMMAND ${write_if_different} Bindings/${basename}Wrapper.cpp CodeGenerators/WrapperGenerator --implementation ${CMAKE_CURRENT_SOURCE_DIR}/${class}.idl
         VERBATIM
         DEPENDS WrapperGenerator
         MAIN_DEPENDENCY ${class}.idl
@@ -203,8 +201,7 @@ set(SOURCES ${SOURCES} ${WRAPPER_SOURCES})
 
 add_custom_command(
     OUTPUT CSS/PropertyID.h
-    COMMAND /bin/mkdir -p CSS
-    COMMAND Generate_CSS_PropertyID_h ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Properties.json > CSS/PropertyID.h
+    COMMAND ${write_if_different} CSS/PropertyID.h CodeGenerators/Generate_CSS_PropertyID_h ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Properties.json
     VERBATIM
     DEPENDS Generate_CSS_PropertyID_h
     MAIN_DEPENDENCY CSS/Properties.json
@@ -214,7 +211,7 @@ add_custom_target(generate_PropertyID.h DEPENDS CSS/PropertyID.h)
 add_custom_command(
     OUTPUT CSS/PropertyID.cpp
     COMMAND /bin/mkdir -p CSS
-    COMMAND Generate_CSS_PropertyID_cpp ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Properties.json > CSS/PropertyID.cpp
+    COMMAND ${write_if_different} CSS/PropertyID.cpp CodeGenerators/Generate_CSS_PropertyID_cpp ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Properties.json
     VERBATIM
     DEPENDS Generate_CSS_PropertyID_cpp
     MAIN_DEPENDENCY CSS/Properties.json
@@ -222,9 +219,7 @@ add_custom_command(
 
 add_custom_command(
     OUTPUT CSS/DefaultStyleSheetSource.cpp
-    COMMAND /bin/mkdir -p CSS
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/GenerateStyleSheetSource.sh default_stylesheet_source
-            ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Default.css > CSS/DefaultStyleSheetSource.cpp
+    COMMAND ${write_if_different} CSS/DefaultStyleSheetSource.cpp ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/GenerateStyleSheetSource.sh default_stylesheet_source ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Default.css
     VERBATIM
     DEPENDS Scripts/GenerateStyleSheetSource.sh
     MAIN_DEPENDENCY CSS/Default.css


### PR DESCRIPTION
After running a build command, make by default stat()s the command's
output, and if it wasn't touched, then it cancels all build steps
that were scheduled only because this command was expected to change
the output.

Ninja has the same feature, but it's opt-in behind the per-command
"restat = 1" setting. However, CMake enables it by default for all
custom commands.

Use Meta/write-only-on-difference.sh to write the output to a temporary
file, and then copy the temporary file only to the final location if the
contents of the output have changed since last time.
write-only-on-difference.sh automatically creates the output's parent
directory, so stop doing that in CMake.

Reduces the number of build steps that run after touching a file
in LibCore from 522 to 312.

Since we now no longer trigger the CMake special case "If COMMAND
specifies an executable target name (created by the add_executable()
command), it will automatically be replaced by the location of the
executable created at build time", we now need to use qualified paths to
the generators.

Somewhat related to #2877.

---

Not sure if this is worth it since it's kind of complicated and Serenity builds fairly quickly anyhow.