### PR TITLE
fix overflow and signed/unsigned mixed operations bugs in binary_search

### DIFF
--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -39,15 +39,24 @@ int integral_compare(const T& a, const T& b)
 }
 
 template<typename T, typename Compare>
-T* binary_search(Span<T> haystack, const T& needle, Compare compare = integral_compare, int* nearby_index = nullptr)
+T* binary_search(Span<T> haystack, const T& needle, Compare compare = integral_compare, size_t* nearby_index = nullptr)
 {
-    int low = 0;
-    int high = haystack.size() - 1;
+    if (haystack.size() == 0) {
+        if (nearby_index)
+            *nearby_index = 0;
+        return nullptr;
+    }
+
+    size_t low = 0;
+    size_t high = haystack.size() - 1;
     while (low <= high) {
-        int middle = (low + high) / 2;
+        size_t middle = low + ((high - low) / 2);
         int comparison = compare(needle, haystack[middle]);
         if (comparison < 0)
-            high = middle - 1;
+            if (middle != 0)
+                high = middle - 1;
+            else
+                break;
         else if (comparison > 0)
             low = middle + 1;
         else {
@@ -58,7 +67,7 @@ T* binary_search(Span<T> haystack, const T& needle, Compare compare = integral_c
     }
 
     if (nearby_index)
-        *nearby_index = max(0, min(low, high));
+        *nearby_index = min(low, high);
 
     return nullptr;
 }

--- a/Kernel/VM/RangeAllocator.cpp
+++ b/Kernel/VM/RangeAllocator.cpp
@@ -172,7 +172,7 @@ void RangeAllocator::deallocate(Range range)
 
     ASSERT(!m_available_ranges.is_empty());
 
-    int nearby_index = 0;
+    size_t nearby_index = 0;
     auto* existing_range = binary_search(
         m_available_ranges.span(), range, [](auto& a, auto& b) {
             return a.base().get() - b.end().get();

--- a/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -184,7 +184,7 @@ bool XtermSuggestionDisplay::cleanup()
 size_t XtermSuggestionDisplay::fit_to_page_boundary(size_t selection_index)
 {
     ASSERT(m_pages.size() > 0);
-    int index = 0;
+    size_t index = 0;
 
     auto* match = binary_search(
         m_pages.span(), { selection_index, selection_index }, [](auto& a, auto& b) -> int {


### PR DESCRIPTION
fix for issue #2866 : binary search will fail on large arrays due to overflows and mixed signed/unsigned operations.
fix AK:binarry_search and adjust Kernel/VM/RangeAllocator.cpp and LibLine/XtermSuggestionDisplay.cpp

replaces PR #2837