### PR TITLE
LibWeb: Fix some SVG crashes/hangs

### DIFF
--- a/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -85,10 +85,12 @@ private:
     float parse_fractional_constant();
     float parse_number();
     float parse_flag();
+    // -1 if negative, +1 otherwise
+    int parse_sign();
 
     bool match_whitespace() const;
     bool match_comma_whitespace() const;
-    bool match_number() const;
+    bool match_coordinate() const;
     bool match(char c) const { return !done() && ch() == c; }
 
     bool done() const { return m_cursor >= m_source.length(); }


### PR DESCRIPTION
- `parse_flag` now only parses one digit instead of consuming an entirely valid number
- `match_number` => `match_coordinate`
- `match_coordinate` now returns true if `ch()` is `.`
- `parse_number` no longer matches a `+`/`-`
- Don't crash when encountering one of the three unsupported path commands. Instead, just skip them. No reason to crash the browser over a silly SVG element

Bonus: check out these SVGs! They're a little rough around the edges, but it's better than nothing :)

![a](https://i.imgur.com/rutvmNA.png)

Fixes #2945 and the hang observed in #2958