### PR TITLE
Kernel: Fix signal delivery when no syscall is made

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -773,7 +773,7 @@ void Process::terminate_due_to_signal(u8 signal)
 {
     ASSERT_INTERRUPTS_DISABLED();
     ASSERT(signal < 32);
-    dbg() << "Terminating due to signal " << signal;
+    dbg() << "Terminating " << *this << " due to signal " << signal;
     m_termination_status = 0;
     m_termination_signal = signal;
     die();

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -274,8 +274,6 @@ public:
     bool has_blocker() const { return m_blocker != nullptr; }
     const Blocker& blocker() const;
 
-    bool in_kernel() const { return (m_tss.cs & 0x03) == 0; }
-
     u32 cpu() const { return m_cpu.load(AK::MemoryOrder::memory_order_consume); }
     void set_cpu(u32 cpu) { m_cpu.store(cpu, AK::MemoryOrder::memory_order_release); }
     u32 affinity() const { return m_cpu_affinity; }


### PR DESCRIPTION
This fixes a regression since introducing software context
switching where the Kernel would not deliver a signal unless the
process is making system calls. This is because the TSS no longer
updates the CS value, so the scheduler never considered delivery
as the process always appeared to be in kernel mode. With software
context switching we can just set up the signal trampoline at
any time and when the processor returns back to user mode it'll
get executed. This should fix e.g. killing programs that are
stuck in some tight loop that doesn't make any system calls and
is only pre-empted by the timer interrupt.

Fixes #2958