### PR TITLE
LibCore: ConfFile::read_entry should not sneakily write default entries

### DIFF
--- a/Libraries/LibCore/ConfigFile.cpp
+++ b/Libraries/LibCore/ConfigFile.cpp
@@ -114,7 +114,6 @@ void ConfigFile::reparse()
 String ConfigFile::read_entry(const String& group, const String& key, const String& default_value) const
 {
     if (!has_key(group, key)) {
-        const_cast<ConfigFile&>(*this).write_entry(group, key, default_value);
         return default_value;
     }
     auto it = m_groups.find(group);
@@ -125,7 +124,6 @@ String ConfigFile::read_entry(const String& group, const String& key, const Stri
 int ConfigFile::read_num_entry(const String& group, const String& key, int default_value) const
 {
     if (!has_key(group, key)) {
-        const_cast<ConfigFile&>(*this).write_num_entry(group, key, default_value);
         return default_value;
     }
 


### PR DESCRIPTION
I noticed on boot of latest master, WindowServer was getting an veil error:

    [WindowServer(13:13)]: Rejecting path '/res/themes/Default.ini' since it hasn't been unveiled with 'c' permission.
    [WindowServer(13:13)]: 0xc014367f  _ZN6Kernel3VFS34validate_path_against_process_veilEN2AK10StringViewEi +681
    [WindowServer(13:13)]: 0xc01439d7  _ZN6Kernel3VFS12resolve_pathEN2AK10StringViewERNS_7CustodyEPNS1_6RefPtrIS3_EEii +163
    [WindowServer(13:13)]: 0xc0143d03  _ZN6Kernel3VFS4openEN2AK10StringViewEitRNS_7CustodyENS1_8OptionalINS_9UidAndGidEEE +121
    [WindowServer(13:13)]: 0xc016fbc4  _ZN6Kernel7Process8sys$openEPKNS_7Syscall14SC_open_paramsE +854
    [WindowServer(13:13)]: 0xc0164af8  syscall_handler +1320
    [WindowServer(13:13)]: 0xc0164541  syscall_asm_entry +49
    [WindowServer(13:13)]: 0x08097ca0  open_with_path_length +24
    [WindowServer(13:13)]: 0x08097cf8  open +63
    [WindowServer(13:13)]: 0x080a3c59  fopen +31
    [WindowServer(13:13)]: 0x0806abf0  _ZN4Core10ConfigFile4syncEv +48
    [WindowServer(13:13)]: 0x0806af6a  _ZN4Core10ConfigFileD2Ev +16
    [WindowServer(13:13)]: 0x08093e2a  _ZN3Gfx17load_system_themeERKN2AK6StringE +1869
    [WindowServer(13:13)]: 0x08048633  main +491
    [WindowServer(13:13)]: 0x08048dae  _start +94

With some digging I found out that the ConfigFile class was causing
trying to flush writes of default values, not present in the .ini
file back to disk on destruction of the object.

This sneaky behavior from ConfigFile seems to violate the public facing
semantics of the function (it's const). It also makes it very hard to reason
about the system with technologies like unveil where we are trying to
explicitly state what is exposed to apps, how those exposed items can be
used.

The functionality also doesn't seem to be all that useful, as we'll just
return the default value from the API's anyway.

This change removes the write back of default values.