### PR TITLE
Meta: Provide a way to only update a file if the output changes

### DIFF
--- a/Meta/write-only-on-difference.sh
+++ b/Meta/write-only-on-difference.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+if [ "$#" -lt "2" ]; then
+    echo "USAGE: $0 <file> <cmd...>"
+    exit 1
+fi
+
+DST_FILE="$1"
+shift
+
+# Just in case:
+mkdir -p -- "$(dirname -- "${DST_FILE}")"
+
+cleanup()
+{
+  rm -f -- "${DST_FILE}.tmp"
+}
+trap cleanup 0 1 2 3 6
+
+"$@" > "${DST_FILE}.tmp"
+# If we get here, the command was successful, and we can overwrite the destination.
+
+if ! cmp --quiet -- "${DST_FILE}.tmp" "${DST_FILE}"; then
+    # File changed, need to overwrite:
+    mv -f -- "${DST_FILE}.tmp" "${DST_FILE}"
+fi


### PR DESCRIPTION
This is only useful for build commands that update their destination in all cases
and thus sometimes confuse cmake into rebuilding everything needlessly.

Like #2960 for example :)

New design choices:
- I went with a long name for readability.
- I went with `sh` instead of C++ because it's *much* faster to write, significantly shorter, and easier to proof-read.
- I didn't use `Shell` either, because right now building Lagom is optional, and building `Shell` for the host would make it *necessary*.