### PR TITLE
shell: implement Shell::is_runnable and highlight commands

### DIFF
--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -367,9 +367,9 @@ RefPtr<Value> BarewordLiteral::run(RefPtr<Shell>)
 void BarewordLiteral::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightMetadata metadata)
 {
     if (metadata.is_first_in_list) {
-        if (shell.is_runnable(m_text))
+        if (shell.is_runnable(m_text)) {
             editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Bold });
-        else {
+        } else {
             editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Foreground(Line::Style::XtermColor::Red) });
         }
 

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -367,9 +367,15 @@ RefPtr<Value> BarewordLiteral::run(RefPtr<Shell>)
 void BarewordLiteral::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightMetadata metadata)
 {
     if (metadata.is_first_in_list) {
-        editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Bold });
+        if (shell.is_runnable(m_text))
+            editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Bold });
+        else {
+            editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Foreground(Line::Style::XtermColor::Red) });
+        }
+
         return;
     }
+
     if (m_text.starts_with('-')) {
         if (m_text == "--") {
             editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Foreground(Line::Style::XtermColor::Green) });

--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -64,20 +64,7 @@ int Shell::builtin_alias(int argc, const char** argv)
             }
         } else {
             m_aliases.set(parts[0], parts[1]);
-            size_t index = 0;
-            auto match = binary_search(
-                cached_path.span(), parts[0], [](const String& name, const String& program) -> int {
-                    return strcmp(name.characters(), program.characters());
-                },
-                &index);
-
-            if (match)
-                continue;
-
-            while (strcmp(cached_path[index].characters(), parts[0].characters()) < 0) {
-                index++;
-            }
-            cached_path.insert(index, parts[0]);
+            add_entry_to_cache(parts[0]);
         }
     }
 

--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -64,6 +64,20 @@ int Shell::builtin_alias(int argc, const char** argv)
             }
         } else {
             m_aliases.set(parts[0], parts[1]);
+            size_t index = 0;
+            auto match = binary_search(
+                cached_path.span(), parts[0], [](const String& name, const String& program) -> int {
+                    return strcmp(name.characters(), program.characters());
+                },
+                &index);
+
+            if (match)
+                continue;
+
+            while (strcmp(cached_path[index].characters(), parts[0].characters()) < 0) {
+                index++;
+            }
+            cached_path.insert(index, parts[0]);
         }
     }
 

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -388,11 +388,6 @@ String Shell::resolve_alias(const String& name) const
 
 bool Shell::is_runnable(const StringView& name)
 {
-    // FIXME: for now, check aliases manually because cached path doesn't get
-    // updated with aliases. Should it?
-    if (!resolve_alias(name).is_null())
-        return true;
-
     if (access(name.to_string().characters(), X_OK) == 0)
         return true;
 

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -795,6 +795,24 @@ void Shell::cache_path()
     quick_sort(cached_path);
 }
 
+void Shell::add_entry_to_cache(const String& entry)
+{
+    size_t index = 0;
+    auto match = binary_search(
+        cached_path.span(), entry, [](const String& name, const String& program) -> int {
+            return strcmp(name.characters(), program.characters());
+        },
+        &index);
+
+    if (match)
+        return;
+
+    while (strcmp(cached_path[index].characters(), entry.characters()) < 0) {
+        index++;
+    }
+    cached_path.insert(index, entry);
+}
+
 void Shell::highlight(Line::Editor& editor) const
 {
     auto line = editor.line();

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -386,6 +386,21 @@ String Shell::resolve_alias(const String& name) const
     return m_aliases.get(name).value_or({});
 }
 
+bool Shell::is_runnable(const StringView& name)
+{
+    // FIXME: for now, check aliases manually because cached path doesn't get
+    // updated with aliases. Should it?
+    if (!resolve_alias(name).is_null())
+        return true;
+
+    if (access(name.to_string().characters(), X_OK) == 0)
+        return true;
+
+    return !!binary_search(cached_path.span(), name.to_string(), [](const String& name, const String& program) -> int {
+        return strcmp(name.characters(), program.characters());
+    });
+}
+
 int Shell::run_command(const StringView& cmd)
 {
     if (cmd.is_empty())

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -73,6 +73,7 @@ public:
     constexpr static auto global_init_file_path = "/etc/shellrc";
 
     int run_command(const StringView&);
+    bool is_runnable(const StringView&);
     RefPtr<Job> run_command(const AST::Command&);
     Vector<RefPtr<Job>> run_commands(Vector<AST::Command>&);
     bool run_file(const String&, bool explicitly_invoked = true);

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -188,6 +188,7 @@ private:
     virtual void save_to(JsonObject&) override;
 
     void cache_path();
+    void add_entry_to_cache(const String&);
     void stop_all_jobs();
     const Job* m_current_job { nullptr };
     LocalFrame* find_frame_containing_local_variable(const String& name);


### PR DESCRIPTION
Hey Serenity!

Inspired from the fish shell, the terminal now highlights the current command based on whether it exists or not (red if it is invalid, and bold white if it's valid).

![serenity-terminal-command-highlight](https://user-images.githubusercontent.com/15224242/89133997-797e7d00-d564-11ea-8023-63d3ad553aea.gif)

I add the method `is_runnable` to the shell. I'm not sure if that's the best name/go to way about it. Feedback more than welcome :slightly_smiling_face: 

Also, the builtin `alias` wasn't refreshing the cache `cached_path` when an aliases was added. That meant that no aliases were cached because the cache is populated *before* the rc files are loaded. So this is fixed (each alias call insert the alias in the cache).

Shouldn't `cached_path` be called `m_cached_path`? Or am i missing something? 

Thanks this awesome project, it's really inspiring :heart: 

