### PR TITLE
LibGUI: WidgetScrollable scrolls horizontally when shift is pressed

### DIFF
--- a/Libraries/LibGUI/ScrollableWidget.cpp
+++ b/Libraries/LibGUI/ScrollableWidget.cpp
@@ -61,7 +61,11 @@ void ScrollableWidget::mousewheel_event(MouseEvent& event)
         return;
     }
     // FIXME: The wheel delta multiplier should probably come from... somewhere?
-    vertical_scrollbar().set_value(vertical_scrollbar().value() + event.wheel_delta() * 20);
+    if (event.modifiers() & Mod_Shift) {
+        horizontal_scrollbar().set_value(horizontal_scrollbar().value() + event.wheel_delta() * 60);
+    } else {
+        vertical_scrollbar().set_value(vertical_scrollbar().value() + event.wheel_delta() * 20);
+    }
 }
 
 void ScrollableWidget::custom_layout()


### PR DESCRIPTION
If you want to scroll horizontally, just press `shift` and then the scroll wheel will move the horizontal scroll bar.

`shift` is the standard modifier I think, and that's how it works in firefox on ubuntu.

![serenity-horizontal-scroll](https://user-images.githubusercontent.com/15224242/89138103-c3279180-d57d-11ea-9d0d-f73d147f8cf8.gif)
