### PR TITLE
CppLexer: Actually give raw strings type RawString

### DIFF
--- a/Libraries/LibGUI/CppLexer.cpp
+++ b/Libraries/LibGUI/CppLexer.cpp
@@ -655,7 +655,7 @@ Vector<CppToken> CppLexer::lex()
                     }
                 }
             }
-            commit_token(CppToken::Type::DoubleQuotedString);
+            commit_token(CppToken::Type::RawString);
             continue;
         }
         if (size_t prefix = match_string_prefix('\''); prefix > 0) {


### PR DESCRIPTION
This fixes a regrettable mistake in 9ee1edae2aefcb95e.
No behavior change.