### PR TITLE
Kernel: Consolidate timeout logic

### DIFF
--- a/AK/Time.h
+++ b/AK/Time.h
@@ -61,11 +61,33 @@ inline void timespec_sub(const TimespecType& a, const TimespecType& b, TimespecT
     }
 }
 
+template<typename TimespecType, typename TimevalType>
+inline void timespec_sub_timeval(const TimespecType& a, const TimevalType& b, TimespecType& result)
+{
+    result.tv_sec = a.tv_sec - b.tv_sec;
+    result.tv_nsec = a.tv_nsec - b.tv_usec * 1000;
+    if (result.tv_nsec < 0) {
+        --result.tv_sec;
+        result.tv_nsec += 1'000'000'000;
+    }
+}
+
 template<typename TimespecType>
 inline void timespec_add(const TimespecType& a, const TimespecType& b, TimespecType& result)
 {
     result.tv_sec = a.tv_sec + b.tv_sec;
     result.tv_nsec = a.tv_nsec + b.tv_nsec;
+    if (result.tv_nsec >= 1000'000'000) {
+        ++result.tv_sec;
+        result.tv_nsec -= 1000'000'000;
+    }
+}
+
+template<typename TimespecType, typename TimevalType>
+inline void timespec_add_timeval(const TimespecType& a, const TimevalType& b, TimespecType& result)
+{
+    result.tv_sec = a.tv_sec + b.tv_sec;
+    result.tv_nsec = a.tv_nsec + b.tv_usec * 1000;
     if (result.tv_nsec >= 1000'000'000) {
         ++result.tv_sec;
         result.tv_nsec -= 1000'000'000;
@@ -86,11 +108,55 @@ inline void timespec_to_timeval(const TimespecType& ts, TimevalType& tv)
     tv.tv_usec = ts.tv_nsec / 1000;
 }
 
+template<typename TimespecType>
+inline bool operator>=(const TimespecType& a, const TimespecType& b)
+{
+    return a.tv_sec > b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_nsec >= b.tv_nsec);
+}
+
+template<typename TimespecType>
+inline bool operator>(const TimespecType& a, const TimespecType& b)
+{
+    return a.tv_sec > b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_nsec > b.tv_nsec);
+}
+
+template<typename TimespecType>
+inline bool operator<(const TimespecType& a, const TimespecType& b)
+{
+    return a.tv_sec < b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_nsec < b.tv_nsec);
+}
+
+template<typename TimespecType>
+inline bool operator<=(const TimespecType& a, const TimespecType& b)
+{
+    return a.tv_sec < b.tv_sec || (a.tv_sec == b.tv_sec && a.tv_nsec <= b.tv_nsec);
+}
+
+template<typename TimespecType>
+inline bool operator==(const TimespecType& a, const TimespecType& b)
+{
+    return a.tv_sec == b.tv_sec && a.tv_nsec == b.tv_nsec;
+}
+
+template<typename TimespecType>
+inline bool operator!=(const TimespecType& a, const TimespecType& b)
+{
+    return a.tv_sec != b.tv_sec || a.tv_nsec != b.tv_nsec;
+}
+
 }
 
 using AK::timespec_add;
+using AK::timespec_add_timeval;
 using AK::timespec_sub;
+using AK::timespec_sub_timeval;
 using AK::timespec_to_timeval;
 using AK::timeval_add;
 using AK::timeval_sub;
 using AK::timeval_to_timespec;
+using AK::operator<=;
+using AK::operator<;
+using AK::operator>;
+using AK::operator>=;
+using AK::operator==;
+using AK::operator!=;

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -423,7 +423,7 @@ KResult Plan9FS::post_message(Message& message)
 
     while (size > 0) {
         if (!description.can_write()) {
-            if (Thread::current()->block<Thread::WriteBlocker>(description).was_interrupted())
+            if (Thread::current()->block<Thread::WriteBlocker>(nullptr, description).was_interrupted())
                 return KResult(-EINTR);
         }
         ssize_t nwritten = description.write(data, size);
@@ -441,7 +441,7 @@ KResult Plan9FS::do_read(u8* data, size_t size)
     auto& description = file_description();
     while (size > 0) {
         if (!description.can_read()) {
-            if (Thread::current()->block<Thread::ReadBlocker>(description).was_interrupted())
+            if (Thread::current()->block<Thread::ReadBlocker>(nullptr, description).was_interrupted())
                 return KResult(-EINTR);
         }
         ssize_t nread = description.read(data, size);
@@ -524,7 +524,7 @@ KResult Plan9FS::wait_for_specific_message(u16 tag, Message& out_message)
     // Block until either:
     // * Someone else reads the message we're waiting for, and hands it to us;
     // * Or we become the one to read and dispatch messages.
-    if (Thread::current()->block<Plan9FS::Blocker>(completion).was_interrupted()) {
+    if (Thread::current()->block<Plan9FS::Blocker>(nullptr, completion).was_interrupted()) {
         LOCKER(m_lock);
         m_completions.remove(tag);
         return KResult(-EINTR);

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -246,7 +246,7 @@ ssize_t IPv4Socket::receive_byte_buffered(FileDescription& description, void* bu
             return -EAGAIN;
 
         locker.unlock();
-        auto res = Thread::current()->block<Thread::ReadBlocker>(description);
+        auto res = Thread::current()->block<Thread::ReadBlocker>(nullptr, description);
         locker.lock();
 
         if (!m_can_read) {
@@ -296,7 +296,7 @@ ssize_t IPv4Socket::receive_packet_buffered(FileDescription& description, void* 
         }
 
         locker.unlock();
-        auto res = Thread::current()->block<Thread::ReadBlocker>(description);
+        auto res = Thread::current()->block<Thread::ReadBlocker>(nullptr, description);
         locker.lock();
 
         if (!m_can_read) {

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -176,7 +176,7 @@ KResult LocalSocket::connect(FileDescription& description, const sockaddr* addre
         return KSuccess;
     }
 
-    if (Thread::current()->block<Thread::ConnectBlocker>(description).was_interrupted()) {
+    if (Thread::current()->block<Thread::ConnectBlocker>(nullptr, description).was_interrupted()) {
         m_connect_side_role = Role::None;
         return KResult(-EINTR);
     }
@@ -300,7 +300,7 @@ ssize_t LocalSocket::recvfrom(FileDescription& description, void* buffer, size_t
             return -EAGAIN;
         }
     } else if (!can_read(description, 0)) {
-        if (Thread::current()->block<Thread::ReadBlocker>(description).was_interrupted())
+        if (Thread::current()->block<Thread::ReadBlocker>(nullptr, description).was_interrupted())
             return -EINTR;
     }
     if (!has_attached_peer(description) && buffer_for_me.is_empty())

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -372,7 +372,7 @@ KResult TCPSocket::protocol_connect(FileDescription& description, ShouldBlock sh
     m_direction = Direction::Outgoing;
 
     if (should_block == ShouldBlock::Yes) {
-        if (Thread::current()->block<Thread::ConnectBlocker>(description).was_interrupted())
+        if (Thread::current()->block<Thread::ConnectBlocker>(nullptr, description).was_interrupted())
             return KResult(-EINTR);
         ASSERT(setup_state() == SetupState::Completed);
         if (has_error()) {

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -179,7 +179,7 @@ void syscall_handler(TrapFrame* trap)
     current_thread->die_if_needed();
 
     if (current_thread->has_unmasked_pending_signals())
-        (void)current_thread->block<Thread::SemiPermanentBlocker>(Thread::SemiPermanentBlocker::Reason::Signal);
+        (void)current_thread->block<Thread::SemiPermanentBlocker>(nullptr, Thread::SemiPermanentBlocker::Reason::Signal);
 }
 
 }

--- a/Kernel/Syscalls/kill.cpp
+++ b/Kernel/Syscalls/kill.cpp
@@ -113,7 +113,7 @@ KResult Process::do_killself(int signal)
     auto current_thread = Thread::current();
     if (!current_thread->should_ignore_signal(signal)) {
         current_thread->send_signal(signal, this);
-        (void)current_thread->block<Thread::SemiPermanentBlocker>(Thread::SemiPermanentBlocker::Reason::Signal);
+        (void)current_thread->block<Thread::SemiPermanentBlocker>(nullptr, Thread::SemiPermanentBlocker::Reason::Signal);
     }
 
     return KSuccess;

--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -50,7 +50,7 @@ ssize_t Process::sys$read(int fd, Userspace<u8*> buffer, ssize_t size)
         return -EISDIR;
     if (description->is_blocking()) {
         if (!description->can_read()) {
-            if (Thread::current()->block<Thread::ReadBlocker>(*description).was_interrupted())
+            if (Thread::current()->block<Thread::ReadBlocker>(nullptr, *description).was_interrupted())
                 return -EINTR;
             if (!description->can_read())
                 return -EAGAIN;

--- a/Kernel/Syscalls/select.cpp
+++ b/Kernel/Syscalls/select.cpp
@@ -105,7 +105,7 @@ int Process::sys$select(const Syscall::SC_select_params* params)
 #endif
 
     if (!timeout || select_has_timeout) {
-        if (current_thread->block<Thread::SelectBlocker>(computed_timeout, select_has_timeout, rfds, wfds, efds).was_interrupted())
+        if (current_thread->block<Thread::SelectBlocker>(select_has_timeout ? &computed_timeout : nullptr, rfds, wfds, efds).was_interrupted())
             return -EINTR;
         // While we blocked, the process lock was dropped. This gave other threads
         // the opportunity to mess with the memory. For example, it could free the
@@ -191,7 +191,7 @@ int Process::sys$poll(const Syscall::SC_poll_params* params)
 #endif
 
     if (!timeout || has_timeout) {
-        if (current_thread->block<Thread::SelectBlocker>(actual_timeout, has_timeout, rfds, wfds, Thread::SelectBlocker::FDVector()).was_interrupted())
+        if (current_thread->block<Thread::SelectBlocker>(has_timeout ? &actual_timeout : nullptr, rfds, wfds, Thread::SelectBlocker::FDVector()).was_interrupted())
             return -EINTR;
     }
 

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -118,7 +118,7 @@ int Process::sys$accept(int accepting_socket_fd, sockaddr* user_address, socklen
 
     if (!socket.can_accept()) {
         if (accepting_socket_description->is_blocking()) {
-            if (Thread::current()->block<Thread::AcceptBlocker>(*accepting_socket_description).was_interrupted())
+            if (Thread::current()->block<Thread::AcceptBlocker>(nullptr, *accepting_socket_description).was_interrupted())
                 return -EINTR;
         } else {
             return -EAGAIN;

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -146,7 +146,7 @@ int Process::sys$join_thread(int tid, void** exit_value)
 
     // NOTE: pthread_join() cannot be interrupted by signals. Only by death.
     for (;;) {
-        auto result = current_thread->block<Thread::JoinBlocker>(*thread, joinee_exit_value);
+        auto result = current_thread->block<Thread::JoinBlocker>(nullptr, *thread, joinee_exit_value);
         if (result == Thread::BlockResult::InterruptedByDeath) {
             // NOTE: This cleans things up so that Thread::finalize() won't
             //       get confused about a missing joiner when finalizing the joinee.

--- a/Kernel/Syscalls/waitid.cpp
+++ b/Kernel/Syscalls/waitid.cpp
@@ -48,7 +48,7 @@ KResultOr<siginfo_t> Process::do_waitid(idtype_t idtype, int id, int options)
         return KResult(-EINVAL);
     }
 
-    if (Thread::current()->block<Thread::WaitBlocker>(options, waitee_pid).was_interrupted())
+    if (Thread::current()->block<Thread::WaitBlocker>(nullptr, options, waitee_pid).was_interrupted())
         return KResult(-EINTR);
 
     ScopedSpinLock lock(g_processes_lock);

--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -100,7 +100,7 @@ ssize_t Process::do_write(FileDescription& description, const u8* data, int data
 #ifdef IO_DEBUG
             dbg() << "block write on " << description.absolute_path();
 #endif
-            if (Thread::current()->block<Thread::WriteBlocker>(description).was_interrupted()) {
+            if (Thread::current()->block<Thread::WriteBlocker>(nullptr, description).was_interrupted()) {
                 if (nwritten == 0)
                     return -EINTR;
             }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -209,7 +209,7 @@ u64 Thread::sleep(u64 ticks)
 {
     ASSERT(state() == Thread::Running);
     u64 wakeup_time = g_uptime + ticks;
-    auto ret = Thread::current()->block<Thread::SleepBlocker>(wakeup_time);
+    auto ret = Thread::current()->block<Thread::SleepBlocker>(nullptr, wakeup_time);
     if (wakeup_time > g_uptime) {
         ASSERT(ret.was_interrupted());
     }
@@ -219,7 +219,7 @@ u64 Thread::sleep(u64 ticks)
 u64 Thread::sleep_until(u64 wakeup_time)
 {
     ASSERT(state() == Thread::Running);
-    auto ret = Thread::current()->block<Thread::SleepBlocker>(wakeup_time);
+    auto ret = Thread::current()->block<Thread::SleepBlocker>(nullptr, wakeup_time);
     if (wakeup_time > g_uptime)
         ASSERT(ret.was_interrupted());
     return wakeup_time;


### PR DESCRIPTION
Allow passing in an optional timeout to Thread::block and move
the timeout check out of Thread::Blocker. This way all Blockers
implicitly support timeouts and don't need to implement it
themselves. Do however allow them to override timeouts (e.g.
for sockets).