### PR TITLE
LibWeb: Make sure that head and body always get the HTML element

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -132,9 +132,17 @@ const Element* Document::document_element() const
     return first_child_of_type<Element>();
 }
 
-const HTML::HTMLHeadElement* Document::head() const
+const HTML::HTMLHtmlElement* Document::html_element() const
 {
     auto* html = document_element();
+    if (is<HTML::HTMLHtmlElement>(html))
+        return downcast<HTML::HTMLHtmlElement>(html);
+    return nullptr;
+}
+
+const HTML::HTMLHeadElement* Document::head() const
+{
+    auto* html = html_element();
     if (!html)
         return nullptr;
     return html->first_child_of_type<HTML::HTMLHeadElement>();
@@ -142,7 +150,7 @@ const HTML::HTMLHeadElement* Document::head() const
 
 const HTML::HTMLElement* Document::body() const
 {
-    auto* html = document_element();
+    auto* html = html_element();
     if (!html)
         return nullptr;
     return html->first_child_of_type<HTML::HTMLBodyElement>();

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -86,6 +86,7 @@ public:
     const Node* inspected_node() const { return m_inspected_node; }
 
     const Element* document_element() const;
+    const HTML::HTMLHtmlElement* html_element() const;
     const HTML::HTMLHeadElement* head() const;
     const HTML::HTMLElement* body() const;
 


### PR DESCRIPTION
Now that document element returns a generic DOM element, we need to
make sure head and body get a html element. 

The spec just says to check if the document element is a html element,
so let's do that.