### PR TITLE
Shell: Add support for ARGV (and $*, $#)

### DIFF
--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -1998,6 +1998,7 @@ RefPtr<Value> SimpleVariableValue::resolve_without_cast(RefPtr<Shell> shell)
 SpecialVariableValue::~SpecialVariableValue()
 {
 }
+
 Vector<String> SpecialVariableValue::resolve_as_list(RefPtr<Shell> shell)
 {
     switch (m_name) {
@@ -2005,6 +2006,19 @@ Vector<String> SpecialVariableValue::resolve_as_list(RefPtr<Shell> shell)
         return { String::number(shell->last_return_code) };
     case '$':
         return { String::number(getpid()) };
+    case '*':
+        if (auto argv = shell->lookup_local_variable("ARGV"))
+            return argv->resolve_as_list(shell);
+        return {};
+    case '#':
+        if (auto argv = shell->lookup_local_variable("ARGV")) {
+            if (argv->is_list()) {
+                auto list_argv = static_cast<AST::ListValue*>(argv.ptr());
+                return { String::number(list_argv->values().size()) };
+            }
+            return { "1" };
+        }
+        return { "0" };
     default:
         return { "" };
     }

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -540,7 +540,7 @@ void CloseFdRedirection::dump(int level) const
 RefPtr<Value> CloseFdRedirection::run(RefPtr<Shell>)
 {
     Command command;
-    command.redirections.append(*new CloseRedirection(m_fd));
+    command.redirections.append(adopt(*new CloseRedirection(m_fd)));
     return create<CommandValue>(move(command));
 }
 
@@ -1116,8 +1116,8 @@ RefPtr<Value> Pipe::run(RefPtr<Shell> shell)
 
     auto pipe_write_end = new FdRedirection(STDIN_FILENO, -1, Rewiring::Close::Destination);
     auto pipe_read_end = new FdRedirection(STDOUT_FILENO, -1, pipe_write_end, Rewiring::Close::RefreshDestination);
-    first_in_right.redirections.append(*pipe_write_end);
-    last_in_left.redirections.append(*pipe_read_end);
+    first_in_right.redirections.append(adopt(*pipe_write_end));
+    last_in_left.redirections.append(adopt(*pipe_read_end));
     last_in_left.should_wait = false;
     last_in_left.is_pipe_source = true;
 
@@ -1232,7 +1232,7 @@ RefPtr<Value> ReadRedirection::run(RefPtr<Shell> shell)
     StringBuilder builder;
     builder.join(" ", path_segments);
 
-    command.redirections.append(*new PathRedirection(builder.to_string(), m_fd, PathRedirection::Read));
+    command.redirections.append(adopt(*new PathRedirection(builder.to_string(), m_fd, PathRedirection::Read)));
     return create<CommandValue>(move(command));
 }
 
@@ -1259,7 +1259,7 @@ RefPtr<Value> ReadWriteRedirection::run(RefPtr<Shell> shell)
     StringBuilder builder;
     builder.join(" ", path_segments);
 
-    command.redirections.append(*new PathRedirection(builder.to_string(), m_fd, PathRedirection::ReadWrite));
+    command.redirections.append(adopt(*new PathRedirection(builder.to_string(), m_fd, PathRedirection::ReadWrite)));
     return create<CommandValue>(move(command));
 }
 
@@ -1752,7 +1752,7 @@ RefPtr<Value> WriteAppendRedirection::run(RefPtr<Shell> shell)
     StringBuilder builder;
     builder.join(" ", path_segments);
 
-    command.redirections.append(*new PathRedirection(builder.to_string(), m_fd, PathRedirection::WriteAppend));
+    command.redirections.append(adopt(*new PathRedirection(builder.to_string(), m_fd, PathRedirection::WriteAppend)));
     return create<CommandValue>(move(command));
 }
 
@@ -1779,7 +1779,7 @@ RefPtr<Value> WriteRedirection::run(RefPtr<Shell> shell)
     StringBuilder builder;
     builder.join(" ", path_segments);
 
-    command.redirections.append(*new PathRedirection(builder.to_string(), m_fd, PathRedirection::Write));
+    command.redirections.append(adopt(*new PathRedirection(builder.to_string(), m_fd, PathRedirection::Write)));
     return create<CommandValue>(move(command));
 }
 

--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -233,6 +233,7 @@ public:
     }
 
     const Vector<RefPtr<Value>>& values() const { return m_contained_values; }
+    Vector<RefPtr<Value>>& values() { return m_contained_values; }
 
 private:
     Vector<RefPtr<Value>> m_contained_values;

--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -677,6 +677,40 @@ int Shell::builtin_setopt(int argc, const char** argv)
     return 0;
 }
 
+int Shell::builtin_shift(int argc, const char** argv)
+{
+    int count = 1;
+
+    Core::ArgsParser parser;
+    parser.add_positional_argument(count, "Shift count", "count", Core::ArgsParser::Required::No);
+
+    if (!parser.parse(argc, const_cast<char**>(argv), false))
+        return 1;
+
+    if (count < 1)
+        return 0;
+
+    auto argv_ = lookup_local_variable("ARGV");
+    if (!argv_) {
+        fprintf(stderr, "shift: ARGV is unset\n");
+        return 1;
+    }
+
+    if (!argv_->is_list())
+        argv_ = *new AST::ListValue({ argv_ });
+
+    auto& values = static_cast<AST::ListValue*>(argv_.ptr())->values();
+    if ((size_t)count > values.size()) {
+        fprintf(stderr, "shift: shift count must not be greater than %zu\n", values.size());
+        return 1;
+    }
+
+    for (auto i = 0; i < count; ++i)
+        values.take_first();
+
+    return 0;
+}
+
 int Shell::builtin_time(int argc, const char** argv)
 {
     Vector<const char*> args;

--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -697,7 +697,7 @@ int Shell::builtin_shift(int argc, const char** argv)
     }
 
     if (!argv_->is_list())
-        argv_ = *new AST::ListValue({ argv_ });
+        argv_ = adopt(*new AST::ListValue({ argv_ }));
 
     auto& values = static_cast<AST::ListValue*>(argv_.ptr())->values();
     if ((size_t)count > values.size()) {

--- a/Shell/Parser.cpp
+++ b/Shell/Parser.cpp
@@ -772,6 +772,8 @@ RefPtr<AST::Node> Parser::parse_variable()
     switch (peek()) {
     case '$':
     case '?':
+    case '*':
+    case '#':
         return create<AST::SpecialVariable>(consume()); // Variable Special
     default:
         break;

--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -162,6 +162,8 @@ dquoted_string_inner :: '\' . dquoted_string_inner?       {concat}
 variable :: '$' identifier
           | '$' '$'
           | '$' '?'
+          | '$' '*'
+          | '$' '#'
           | ...
 
 comment :: '#' [^\n]*

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -287,8 +287,8 @@ Vector<AST::Command> Shell::expand_aliases(Vector<AST::Command> initial_commands
                         auto* ast = static_cast<AST::Execute*>(subcommand_ast.ptr());
                         subcommand_ast = ast->command();
                     }
-                    AST::Node& substitute = *new AST::Join(subcommand_ast->position(), subcommand_ast, *new AST::CommandLiteral(subcommand_ast->position(), command));
-                    for (auto& subst_command : substitute.run(*this)->resolve_as_commands(*this)) {
+                    RefPtr<AST::Node> substitute = adopt(*new AST::Join(subcommand_ast->position(), subcommand_ast, adopt(*new AST::CommandLiteral(subcommand_ast->position(), command))));
+                    for (auto& subst_command : substitute->run(*this)->resolve_as_commands(*this)) {
                         if (!subst_command.argv.is_empty() && subst_command.argv.first() == argv0) // Disallow an alias resolving to itself.
                             commands.append(subst_command);
                         else
@@ -586,8 +586,7 @@ Vector<RefPtr<Job>> Shell::run_commands(Vector<AST::Command>& commands)
                 auto path_redir = (const AST::PathRedirection*)redir.ptr();
                 dbg() << "redir path " << (int)path_redir->direction << " " << path_redir->path << " <-> " << path_redir->fd;
             } else if (redir->is_fd_redirection()) {
-                auto fd_redir = (const AST::FdRedirection*)redir.ptr();
-                dbg() << "redir fd " << fd_redir->source_fd << " -> " << fd_redir->dest_fd;
+                dbg() << "redir fd " << redir->source_fd << " -> " << redir->dest_fd;
             } else if (redir->is_close_redirection()) {
                 auto close_redir = (const AST::CloseRedirection*)redir.ptr();
                 dbg() << "close fd " << close_redir->fd;

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -53,6 +53,7 @@
     __ENUMERATE_SHELL_BUILTIN(pushd)   \
     __ENUMERATE_SHELL_BUILTIN(popd)    \
     __ENUMERATE_SHELL_BUILTIN(setopt)  \
+    __ENUMERATE_SHELL_BUILTIN(shift)   \
     __ENUMERATE_SHELL_BUILTIN(time)    \
     __ENUMERATE_SHELL_BUILTIN(jobs)    \
     __ENUMERATE_SHELL_BUILTIN(disown)  \

--- a/Shell/Tests/special-vars.sh
+++ b/Shell/Tests/special-vars.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+test "$*" = "" || echo "Fail: Argv list not empty" && exit 1
+test "$#" -eq 0 || echo "Fail: Argv list empty but count non-zero" && exit 1
+test "$ARGV" = "$*" || echo "Fail: \$ARGV not equal to \$*" && exit 1
+
+ARGV=(1 2 3)
+test "$#" -eq 3 || echo "Fail: Assignment to ARGV does not affect \$#" && exit 1
+test "$*" = "1 2 3" || echo "Fail: Assignment to ARGV does not affect \$*" && exit 1
+
+shift
+test "$*" = "2 3" || echo "Fail: 'shift' does not work correctly" && exit 1
+
+shift 2
+test "$*" = "" || echo "Fail: 'shift 2' does not work correctly" && exit 1

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -187,7 +187,7 @@ int main(int argc, char** argv)
         Vector<String> args;
         for (auto* arg : script_args)
             args.empend(arg);
-        shell->set_local_variable("ARGV", *new AST::ListValue(move(args)));
+        shell->set_local_variable("ARGV", adopt(*new AST::ListValue(move(args))));
     }
 
     if (command_to_run) {

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -159,12 +159,14 @@ int main(int argc, char** argv)
 
     const char* command_to_run = nullptr;
     const char* file_to_read_from = nullptr;
+    Vector<const char*> script_args;
     bool skip_rc_files = false;
 
     Core::ArgsParser parser;
     parser.add_option(command_to_run, "String to read commands from", "command-string", 'c', "command-string");
-    parser.add_positional_argument(file_to_read_from, "File to read commands from", "file", Core::ArgsParser::Required::No);
     parser.add_option(skip_rc_files, "Skip running shellrc files", "skip-shellrc", 0);
+    parser.add_positional_argument(file_to_read_from, "File to read commands from", "file", Core::ArgsParser::Required::No);
+    parser.add_positional_argument(script_args, "Extra argumets to pass to the script (via $* and co)", "argument", Core::ArgsParser::Required::No);
 
     parser.parse(argc, argv);
 
@@ -179,6 +181,13 @@ int main(int argc, char** argv)
         };
         run_rc_file(Shell::global_init_file_path);
         run_rc_file(Shell::local_init_file_path);
+    }
+
+    {
+        Vector<String> args;
+        for (auto* arg : script_args)
+            args.empend(arg);
+        shell->set_local_variable("ARGV", *new AST::ListValue(move(args)));
     }
 
     if (command_to_run) {


### PR DESCRIPTION
This patchset also adds the 'shift' builtin, as well as the usual tests.
closes #2948.

It should be noted that this does not adopt the '`$*` is a string, and `$@` is a list` idea, `$*` is a list and `$@` is currently not defined.

more gritty details:
- `$*` is an alias for `$ARGV`, which can be redefined by the user.
- `$#` is an alias for the size of `$ARGV` (we do not yet support any way of checking for list length inside the shell)
- the `shift` builtin also works on `$ARGV`.
- a non-list `$ARGV` is treated as a list containing that only that element.

cc @bugaevc (if you have any input on this)