### PR TITLE
Removed an unused variable to successfully run make command

### DIFF
--- a/AK/Tests/Span.cpp
+++ b/AK/Tests/Span.cpp
@@ -39,7 +39,6 @@ TEST_CASE(default_constructor_is_empty)
 TEST_CASE(implicit_converson_to_const)
 {
     Bytes bytes0;
-    ReadonlyBytes bytes1 { bytes0 };
     [[maybe_unused]] ReadonlyBytes bytes2 = bytes0;
     [[maybe_unused]] ReadonlyBytes bytes3 = static_cast<ReadonlyBytes>(bytes2);
 }


### PR DESCRIPTION
When we first try to run the `make` command, it's failing because of the below error. So, removed the unused variable to successfully run `make` command

```
/Users/umasankar/serenity/AK/Tests/Span.cpp:42:19: error: unused variable
      'bytes1' [-Werror,-Wunused-variable]
    ReadonlyBytes bytes1 { bytes0 };
                  ^
1 error generated.
make[2]: *** [AK/Tests/CMakeFiles/Span.dir/Span.cpp.o] Error 1
make[1]: *** [AK/Tests/CMakeFiles/Span.dir/all] Error 2
make: *** [all] Error 2
```