### PR TITLE
Build: Make things build with clang without needing local changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,12 @@ add_custom_target(check-style
     USES_TERMINAL
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -std=c++2a -fdiagnostics-color=always -fconcepts")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++2a -fdiagnostics-color=always")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fconcepts")
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual")
+endif()
 
 include_directories(Libraries)
 include_directories(.)

--- a/Libraries/LibGemini/GeminiJob.h
+++ b/Libraries/LibGemini/GeminiJob.h
@@ -67,7 +67,6 @@ protected:
 
 private:
     RefPtr<TLS::TLSv12> m_socket;
-    bool m_queued_finish { false };
 };
 
 }

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -53,7 +53,7 @@ Editor::Editor(Configuration configuration)
     m_always_refresh = configuration.refresh_behaviour == Configuration::RefreshBehaviour::Eager;
     m_pending_chars = ByteBuffer::create_uninitialized(0);
     get_terminal_size();
-    m_suggestion_display = make<XtermSuggestionDisplay>(m_num_lines, m_num_columns, m_cached_prompt_metrics);
+    m_suggestion_display = make<XtermSuggestionDisplay>(m_num_lines, m_num_columns);
 }
 
 Editor::~Editor()

--- a/Libraries/LibLine/SuggestionDisplay.h
+++ b/Libraries/LibLine/SuggestionDisplay.h
@@ -62,10 +62,9 @@ protected:
 
 class XtermSuggestionDisplay : public SuggestionDisplay {
 public:
-    XtermSuggestionDisplay(size_t lines, size_t columns, const StringMetrics& prompt_metrics)
+    XtermSuggestionDisplay(size_t lines, size_t columns)
         : m_num_lines(lines)
         , m_num_columns(columns)
-        , m_prompt_metrics(prompt_metrics)
     {
     }
     virtual ~XtermSuggestionDisplay() override { }
@@ -94,7 +93,6 @@ private:
     size_t m_num_lines { 0 };
     size_t m_num_columns { 0 };
     size_t m_prompt_lines_at_suggestion_initiation { 0 };
-    const StringMetrics& m_prompt_metrics;
 
     struct PageRange {
         size_t start;

--- a/Libraries/LibX86/Instruction.h
+++ b/Libraries/LibX86/Instruction.h
@@ -419,7 +419,6 @@ private:
     u32 evaluate_sib(const CPU&, SegmentRegister& default_segment) const;
 
     unsigned m_register_index { 0xffffffff };
-    SegmentRegister m_segment;
     union {
         u32 m_offset32 { 0 };
         u16 m_offset16;
@@ -539,7 +538,6 @@ private:
     mutable MemoryOrRegisterReference m_modrm;
 
     InstructionDescriptor* m_descriptor { nullptr };
-    InstructionHandler m_handler { nullptr };
 };
 
 template<typename CPU>

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -1,10 +1,13 @@
 cmake_minimum_required (VERSION 3.0)
 project (Lagom)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -Wall -Wextra -Werror -std=c++2a -fPIC -g -Wno-deprecated-copy")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -Wall -Wextra -Werror -std=c++2a -fPIC -g")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy")
+endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wconsumed")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wconsumed -Wno-overloaded-virtual")
 
     option(ENABLE_ADDRESS_SANITIZER "Enable address sanitizer testing in gcc/clang" FALSE)
     if (ENABLE_ADDRESS_SANITIZER)


### PR DESCRIPTION
Useful for sanitizer fuzzer builds.

clang doesn't have a -fconcepts switch (I'm guessing it just enables
concepts automatically with -std=c++2a, but I haven't checked),
and at least the version on my system doesn't understand
-Wno-deprecated-move, so pass these two flags only to gcc.
In return, disable -Woverloaded-virtual which fires in many places.

Fix the handful of -Wunused-private-field warnings that clang emitted.

--

Fixing the -Woverloaded-virtual warnings is imho worthwhile too, but I don't feel like doing that right now.