### PR TITLE
Shell: Give the TTY to the foreground process

### DIFF
--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -132,7 +132,7 @@ public:
     Vector<Line::CompletionSuggestion> complete_user(const String&, size_t offset);
     Vector<Line::CompletionSuggestion> complete_option(const String&, const String&, size_t offset);
 
-    void restore_stdin();
+    void restore_ios();
 
     u64 find_last_job_id() const;
     const Job* find_job(u64 id);

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -131,6 +131,7 @@ int main(int argc, char** argv)
     sigset_t blocked;
     sigemptyset(&blocked);
     sigaddset(&blocked, SIGTTOU);
+    sigaddset(&blocked, SIGTTIN);
     pthread_sigmask(SIG_BLOCK, &blocked, NULL);
 #endif
 #ifdef __serenity__


### PR DESCRIPTION
This fixes the bug with the shell not waiting for any foreground process
that attempts to read from the terminal in the Lagom build.

@awesomekling 
> if I run vim in lagom-shell, I can't exit

All you have to do is `:wq`, trust me!

(this works fine with the `SIGTTIN` and `SIGTTOU` patch, but I didn't put it here, I can - if you want)