### PR TITLE
AK + Kernel: Switch IPv4Socket receive queue to new SinglyLinkedListWithCount<T>

### DIFF
--- a/AK/SinglyLinkedListWithCount.h
+++ b/AK/SinglyLinkedListWithCount.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2020, Brian Gianforcaro <b.gianfo@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/SinglyLinkedList.h>
+
+namespace AK {
+
+template<typename T>
+class SinglyLinkedListWithCount : private SinglyLinkedList<T> {
+
+public:
+    SinglyLinkedListWithCount() {}
+    ~SinglyLinkedListWithCount() {}
+
+    using List = SinglyLinkedList<T>;
+
+    using List::is_empty;
+    using List::size_slow;
+
+    inline size_t size() const
+    {
+        return m_count;
+    }
+
+    void clear()
+    {
+        List::clear();
+        m_count = 0;
+    }
+
+    T& first()
+    {
+        return List::first();
+    }
+
+    const T& first() const
+    {
+        return List::first();
+    }
+
+    T& last()
+    {
+        return List::last();
+    }
+
+    const T& last() const
+    {
+        return List::last();
+    }
+
+    T take_first()
+    {
+        m_count--;
+        return List::take_first();
+    }
+
+    void append(const T& value)
+    {
+        m_count++;
+        return SinglyLinkedList<T>::append(value);
+    }
+
+    void append(T&& value)
+    {
+        m_count++;
+        return List::append(move(value));
+    }
+
+    bool contains_slow(const T& value) const
+    {
+        return List::contains_slow(value);
+    }
+
+    using Iterator = List::Iterator;
+    friend Iterator;
+    Iterator begin() { return List::begin(); }
+    Iterator end() { return List::end(); }
+
+    using ConstIterator = List::ConstIterator;
+    friend ConstIterator;
+    ConstIterator begin() const { return List::begin(); }
+    ConstIterator end() const { return List::end(); }
+
+    template<typename Finder>
+    ConstIterator find(Finder finder) const
+    {
+        return List::find(finder);
+    }
+
+    template<typename Finder>
+    Iterator find(Finder finder)
+    {
+        return List::find(finder);
+    }
+
+    ConstIterator find(const T& value) const
+    {
+        return List::find(value);
+    }
+
+    Iterator find(const T& value)
+    {
+        return List::find(value);
+    }
+
+    void remove(Iterator iterator)
+    {
+        m_count--;
+        return List::remove(iterator);
+    }
+
+    void insert_before(Iterator iterator, const T& value)
+    {
+        m_count++;
+        List::insert_before(iterator, value);
+    }
+
+    void insert_before(Iterator iterator, T&& value)
+    {
+        m_count++;
+        List::insert_before(iterator, move(value));
+    }
+
+    void insert_after(Iterator iterator, const T& value)
+    {
+        m_count++;
+        List::insert_after(iterator, value);
+    }
+
+    void insert_after(Iterator iterator, T&& value)
+    {
+        m_count++;
+        List::insert_after(iterator, move(value));
+    }
+
+private:
+    size_t m_count { 0 };
+};
+
+}
+
+using AK::SinglyLinkedListWithCount;

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -285,7 +285,7 @@ KResultOr<size_t> IPv4Socket::receive_packet_buffered(FileDescription& descripti
             packet = m_receive_queue.take_first();
             m_can_read = !m_receive_queue.is_empty();
 #ifdef IPV4_SOCKET_DEBUG
-            dbg() << "IPv4Socket(" << this << "): recvfrom without blocking " << packet.data.value().size() << " bytes, packets in queue: " << m_receive_queue.size_slow();
+            dbg() << "IPv4Socket(" << this << "): recvfrom without blocking " << packet.data.value().size() << " bytes, packets in queue: " << m_receive_queue.size();
 #endif
         }
     }
@@ -311,7 +311,7 @@ KResultOr<size_t> IPv4Socket::receive_packet_buffered(FileDescription& descripti
         packet = m_receive_queue.take_first();
         m_can_read = !m_receive_queue.is_empty();
 #ifdef IPV4_SOCKET_DEBUG
-        dbg() << "IPv4Socket(" << this << "): recvfrom with blocking " << packet.data.value().size() << " bytes, packets in queue: " << m_receive_queue.size_slow();
+        dbg() << "IPv4Socket(" << this << "): recvfrom with blocking " << packet.data.value().size() << " bytes, packets in queue: " << m_receive_queue.size();
 #endif
     }
     ASSERT(packet.data.has_value());
@@ -380,8 +380,7 @@ bool IPv4Socket::did_receive(const IPv4Address& source_address, u16 source_port,
         m_receive_buffer.write(m_scratch_buffer.value().data(), nreceived_or_error.value());
         m_can_read = !m_receive_buffer.is_empty();
     } else {
-        // FIXME: Maybe track the number of packets so we don't have to walk the entire packet queue to count them..
-        if (m_receive_queue.size_slow() > 2000) {
+        if (m_receive_queue.size() > 2000) {
             dbg() << "IPv4Socket(" << this << "): did_receive refusing packet since queue is full.";
             return false;
         }
@@ -393,7 +392,7 @@ bool IPv4Socket::did_receive(const IPv4Address& source_address, u16 source_port,
     if (buffer_mode() == BufferMode::Bytes)
         dbg() << "IPv4Socket(" << this << "): did_receive " << packet_size << " bytes, total_received=" << m_bytes_received;
     else
-        dbg() << "IPv4Socket(" << this << "): did_receive " << packet_size << " bytes, total_received=" << m_bytes_received << ", packets in queue: " << m_receive_queue.size_slow();
+        dbg() << "IPv4Socket(" << this << "): did_receive " << packet_size << " bytes, total_received=" << m_bytes_received << ", packets in queue: " << m_receive_queue.size();
 #endif
     return true;
 }

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
-#include <AK/SinglyLinkedList.h>
+#include <AK/SinglyLinkedListWithCount.h>
 #include <Kernel/DoubleBuffer.h>
 #include <Kernel/KBuffer.h>
 #include <Kernel/Lock.h>
@@ -122,7 +122,7 @@ private:
         Optional<KBuffer> data;
     };
 
-    SinglyLinkedList<ReceivedPacket> m_receive_queue;
+    SinglyLinkedListWithCount<ReceivedPacket> m_receive_queue;
 
     DoubleBuffer m_receive_buffer;
 


### PR DESCRIPTION
Noticed the FIXME while working on something else, death to all O(n) implementations :)

We can avoid walking the packet queue, instead use a linked list with a count.
To do this add a new list type SinglyLinkedListWithCount<T>, which just wraps
SinglyLinkedList<T> and intercepts calls which need to modify the count.