### PR TITLE
Kernel: Use Userspace<T> for the open / gettimeofday / clock_nanosleep / waitid / mmap / readlink / set_mmap_name syscalls

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -282,8 +282,8 @@ struct SC_poll_params {
 struct SC_clock_nanosleep_params {
     int clock_id;
     int flags;
-    const struct timespec* requested_sleep;
-    struct timespec* remaining_sleep;
+    Userspace<const struct timespec*> requested_sleep;
+    Userspace<struct timespec*> remaining_sleep;
 };
 
 struct SC_sendto_params {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -355,7 +355,7 @@ struct SC_create_thread_params {
     unsigned int m_guard_page_size = 0;          // Rounded up to PAGE_SIZE
     unsigned int m_reported_guard_page_size = 0; // The lie we tell callers
     unsigned int m_stack_size = 4 * MB;          // Default PTHREAD_STACK_MIN
-    void* m_stack_location = nullptr;            // nullptr means any, o.w. process virtual address
+    Userspace<void*> m_stack_location;           // nullptr means any, o.w. process virtual address
 };
 
 struct SC_realpath_params {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -427,7 +427,7 @@ struct SC_unveil_params {
 struct SC_waitid_params {
     int idtype;
     int id;
-    struct siginfo* infop;
+    Userspace<struct siginfo*> infop;
     int options;
 };
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -222,7 +222,7 @@ public:
     int sys$kill(pid_t pid, int sig);
     [[noreturn]] void sys$exit(int status);
     int sys$sigreturn(RegisterState& registers);
-    pid_t sys$waitid(const Syscall::SC_waitid_params*);
+    pid_t sys$waitid(Userspace<const Syscall::SC_waitid_params*>);
     void* sys$mmap(const Syscall::SC_mmap_params*);
     int sys$munmap(void*, size_t size);
     int sys$set_mmap_name(const Syscall::SC_set_mmap_name_params*);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -302,7 +302,7 @@ public:
     int sys$detach_thread(int tid);
     int sys$set_thread_name(int tid, const char* buffer, size_t buffer_size);
     int sys$get_thread_name(int tid, char* buffer, size_t buffer_size);
-    int sys$rename(const Syscall::SC_rename_params*);
+    int sys$rename(Userspace<const Syscall::SC_rename_params*>);
     int sys$mknod(Userspace<const Syscall::SC_mknod_params*>);
     int sys$shbuf_create(int, void** buffer);
     int sys$shbuf_allow_pid(int, pid_t peer_pid);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -223,7 +223,7 @@ public:
     [[noreturn]] void sys$exit(int status);
     int sys$sigreturn(RegisterState& registers);
     pid_t sys$waitid(Userspace<const Syscall::SC_waitid_params*>);
-    void* sys$mmap(const Syscall::SC_mmap_params*);
+    void* sys$mmap(Userspace<const Syscall::SC_mmap_params*>);
     int sys$munmap(void*, size_t size);
     int sys$set_mmap_name(const Syscall::SC_set_mmap_name_params*);
     int sys$mprotect(void*, size_t, int prot);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -303,7 +303,7 @@ public:
     int sys$set_thread_name(int tid, const char* buffer, size_t buffer_size);
     int sys$get_thread_name(int tid, char* buffer, size_t buffer_size);
     int sys$rename(const Syscall::SC_rename_params*);
-    int sys$mknod(const Syscall::SC_mknod_params*);
+    int sys$mknod(Userspace<const Syscall::SC_mknod_params*>);
     int sys$shbuf_create(int, void** buffer);
     int sys$shbuf_allow_pid(int, pid_t peer_pid);
     int sys$shbuf_allow_all(int);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -211,7 +211,7 @@ public:
     int sys$getresuid(uid_t*, uid_t*, uid_t*);
     int sys$getresgid(gid_t*, gid_t*, gid_t*);
     mode_t sys$umask(mode_t);
-    int sys$open(const Syscall::SC_open_params*);
+    int sys$open(Userspace<const Syscall::SC_open_params*>);
     int sys$close(int fd);
     ssize_t sys$read(int fd, Userspace<u8*>, ssize_t);
     ssize_t sys$write(int fd, const u8*, ssize_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -238,7 +238,7 @@ public:
     int sys$fchdir(int fd);
     int sys$sleep(unsigned seconds);
     int sys$usleep(useconds_t usec);
-    int sys$gettimeofday(timeval*);
+    int sys$gettimeofday(Userspace<timeval*>);
     int sys$clock_gettime(clockid_t, timespec*);
     int sys$clock_settime(clockid_t, timespec*);
     int sys$clock_nanosleep(const Syscall::SC_clock_nanosleep_params*);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -225,7 +225,7 @@ public:
     pid_t sys$waitid(Userspace<const Syscall::SC_waitid_params*>);
     void* sys$mmap(Userspace<const Syscall::SC_mmap_params*>);
     int sys$munmap(void*, size_t size);
-    int sys$set_mmap_name(const Syscall::SC_set_mmap_name_params*);
+    int sys$set_mmap_name(Userspace<const Syscall::SC_set_mmap_name_params*>);
     int sys$mprotect(void*, size_t, int prot);
     int sys$madvise(void*, size_t, int advice);
     int sys$minherit(void*, size_t, int inherit);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -241,7 +241,7 @@ public:
     int sys$gettimeofday(Userspace<timeval*>);
     int sys$clock_gettime(clockid_t, timespec*);
     int sys$clock_settime(clockid_t, timespec*);
-    int sys$clock_nanosleep(const Syscall::SC_clock_nanosleep_params*);
+    int sys$clock_nanosleep(Userspace<const Syscall::SC_clock_nanosleep_params*>);
     int sys$gethostname(char*, ssize_t);
     int sys$sethostname(const char*, ssize_t);
     int sys$uname(utsname*);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -296,7 +296,7 @@ public:
     int sys$getpeername(const Syscall::SC_getpeername_params*);
     int sys$sched_setparam(pid_t pid, Userspace<const struct sched_param*>);
     int sys$sched_getparam(pid_t pid, Userspace<struct sched_param*>);
-    int sys$create_thread(void* (*)(void*), const Syscall::SC_create_thread_params*);
+    int sys$create_thread(void* (*)(void*), Userspace<const Syscall::SC_create_thread_params*>);
     void sys$exit_thread(void*);
     int sys$join_thread(int tid, void** exit_value);
     int sys$detach_thread(int tid);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -245,7 +245,7 @@ public:
     int sys$gethostname(char*, ssize_t);
     int sys$sethostname(const char*, ssize_t);
     int sys$uname(utsname*);
-    int sys$readlink(const Syscall::SC_readlink_params*);
+    int sys$readlink(Userspace<const Syscall::SC_readlink_params*>);
     int sys$ttyname(int fd, Userspace<char*>, size_t);
     int sys$ptsname(int fd, Userspace<char*>, size_t);
     pid_t sys$fork(RegisterState&);

--- a/Kernel/Syscalls/clock.cpp
+++ b/Kernel/Syscalls/clock.cpp
@@ -134,7 +134,7 @@ int Process::sys$clock_nanosleep(const Syscall::SC_clock_nanosleep_params* user_
     }
 }
 
-int Process::sys$gettimeofday(timeval* user_tv)
+int Process::sys$gettimeofday(Userspace<timeval*> user_tv)
 {
     REQUIRE_PROMISE(stdio);
     if (!validate_write_typed(user_tv))

--- a/Kernel/Syscalls/clock.cpp
+++ b/Kernel/Syscalls/clock.cpp
@@ -76,7 +76,7 @@ int Process::sys$clock_settime(clockid_t clock_id, timespec* user_ts)
     return 0;
 }
 
-int Process::sys$clock_nanosleep(const Syscall::SC_clock_nanosleep_params* user_params)
+int Process::sys$clock_nanosleep(Userspace<const Syscall::SC_clock_nanosleep_params*> user_params)
 {
     REQUIRE_PROMISE(stdio);
 
@@ -118,8 +118,7 @@ int Process::sys$clock_nanosleep(const Syscall::SC_clock_nanosleep_params* user_
                     return -EFAULT;
                 }
 
-                timespec remaining_sleep;
-                memset(&remaining_sleep, 0, sizeof(timespec));
+                timespec remaining_sleep = {};
                 remaining_sleep.tv_sec = ticks_left / TimeManagement::the().ticks_per_second();
                 ticks_left -= remaining_sleep.tv_sec * TimeManagement::the().ticks_per_second();
                 remaining_sleep.tv_nsec = ticks_left * 1000000000 / TimeManagement::the().ticks_per_second();

--- a/Kernel/Syscalls/mknod.cpp
+++ b/Kernel/Syscalls/mknod.cpp
@@ -30,7 +30,7 @@
 
 namespace Kernel {
 
-int Process::sys$mknod(const Syscall::SC_mknod_params* user_params)
+int Process::sys$mknod(Userspace<const Syscall::SC_mknod_params*> user_params)
 {
     REQUIRE_PROMISE(dpath);
     Syscall::SC_mknod_params params;

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -331,7 +331,7 @@ int Process::sys$minherit(void* address, size_t size, int inherit)
     return -EINVAL;
 }
 
-int Process::sys$set_mmap_name(const Syscall::SC_set_mmap_name_params* user_params)
+int Process::sys$set_mmap_name(Userspace<const Syscall::SC_set_mmap_name_params*> user_params)
 {
     REQUIRE_PROMISE(stdio);
 

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -76,7 +76,7 @@ static bool validate_inode_mmap_prot(const Process& process, int prot, const Ino
     return true;
 }
 
-void* Process::sys$mmap(const Syscall::SC_mmap_params* user_params)
+void* Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> user_params)
 {
     REQUIRE_PROMISE(stdio);
 

--- a/Kernel/Syscalls/open.cpp
+++ b/Kernel/Syscalls/open.cpp
@@ -31,7 +31,7 @@
 
 namespace Kernel {
 
-int Process::sys$open(const Syscall::SC_open_params* user_params)
+int Process::sys$open(Userspace<const Syscall::SC_open_params*> user_params)
 {
     Syscall::SC_open_params params;
     if (!validate_read_and_copy_typed(&params, user_params))

--- a/Kernel/Syscalls/readlink.cpp
+++ b/Kernel/Syscalls/readlink.cpp
@@ -31,7 +31,7 @@
 
 namespace Kernel {
 
-int Process::sys$readlink(const Syscall::SC_readlink_params* user_params)
+int Process::sys$readlink(Userspace<const Syscall::SC_readlink_params*> user_params)
 {
     REQUIRE_PROMISE(rpath);
 

--- a/Kernel/Syscalls/rename.cpp
+++ b/Kernel/Syscalls/rename.cpp
@@ -30,7 +30,7 @@
 
 namespace Kernel {
 
-int Process::sys$rename(const Syscall::SC_rename_params* user_params)
+int Process::sys$rename(Userspace<const Syscall::SC_rename_params*> user_params)
 {
     REQUIRE_PROMISE(cpath);
     Syscall::SC_rename_params params;

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -33,7 +33,7 @@
 
 namespace Kernel {
 
-int Process::sys$create_thread(void* (*entry)(void*), const Syscall::SC_create_thread_params* user_params)
+int Process::sys$create_thread(void* (*entry)(void*), Userspace<const Syscall::SC_create_thread_params*> user_params)
 {
     REQUIRE_PROMISE(thread);
     if (!validate_read((const void*)entry, sizeof(void*)))
@@ -45,13 +45,13 @@ int Process::sys$create_thread(void* (*entry)(void*), const Syscall::SC_create_t
 
     unsigned detach_state = params.m_detach_state;
     int schedule_priority = params.m_schedule_priority;
-    void* stack_location = params.m_stack_location;
+    Userspace<void*> stack_location = params.m_stack_location;
     unsigned stack_size = params.m_stack_size;
 
     if (!validate_write(stack_location, stack_size))
         return -EFAULT;
 
-    u32 user_stack_address = reinterpret_cast<u32>(stack_location) + stack_size;
+    u32 user_stack_address = reinterpret_cast<u32>(stack_location.ptr()) + stack_size;
 
     if (!MM.validate_user_stack(*this, VirtualAddress(user_stack_address - 4)))
         return -EFAULT;

--- a/Kernel/Syscalls/waitid.cpp
+++ b/Kernel/Syscalls/waitid.cpp
@@ -93,7 +93,7 @@ KResultOr<siginfo_t> Process::do_waitid(idtype_t idtype, int id, int options)
     }
 }
 
-pid_t Process::sys$waitid(const Syscall::SC_waitid_params* user_params)
+pid_t Process::sys$waitid(Userspace<const Syscall::SC_waitid_params*> user_params)
 {
     REQUIRE_PROMISE(proc);
 

--- a/Libraries/LibPthread/pthread.cpp
+++ b/Libraries/LibPthread/pthread.cpp
@@ -383,7 +383,7 @@ int pthread_attr_getstack(const pthread_attr_t* attributes, void** p_stack_ptr, 
     if (!attributes_impl || !p_stack_ptr || !p_stack_size)
         return EINVAL;
 
-    *p_stack_ptr = attributes_impl->m_stack_location;
+    *p_stack_ptr = attributes_impl->m_stack_location.ptr();
     *p_stack_size = attributes_impl->m_stack_size;
 
     return 0;


### PR DESCRIPTION
Moe progress on Userspace<T> adoption.