### PR TITLE
Kernel: Partial usage of Userspace<T> for the poll syscall

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -275,8 +275,8 @@ struct SC_select_params {
 struct SC_poll_params {
     struct pollfd* fds;
     unsigned nfds;
-    const struct timespec* timeout;
-    const u32* sigmask;
+    Userspace<const struct timespec*> timeout;
+    Userspace<const u32*> sigmask;
 };
 
 struct SC_clock_nanosleep_params {

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -231,7 +231,7 @@ public:
     int sys$minherit(void*, size_t, int inherit);
     int sys$purge(int mode);
     int sys$select(const Syscall::SC_select_params*);
-    int sys$poll(const Syscall::SC_poll_params*);
+    int sys$poll(Userspace<const Syscall::SC_poll_params*>);
     ssize_t sys$get_dir_entries(int fd, void*, ssize_t);
     int sys$getcwd(Userspace<char*>, ssize_t);
     int sys$chdir(Userspace<const char*>, size_t);


### PR DESCRIPTION
This change mostly converts poll to Userspace<T> with the caveat
of the fds member of SC_poll_params. It's current usage is a bit
too gnarly for me to take on right now, this appears to need a lot
more love.

In addition to enlightening the syscall to use Userspace<T>, I've
also re-worked most of the handling to use validate_read_and_copy
instead of just directly de-referencing the user pointer. We also
appeared to be missing a re-evaluation of the fds array after the
thread block is awoken.

I separated this from PR #2996 as I thought it deserved a closer review. 