### PR TITLE
Kernel: Use Userspace<T> for the futex syscall

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -331,10 +331,10 @@ struct SC_getpeername_params {
 };
 
 struct SC_futex_params {
-    i32* userspace_address;
+    Userspace<const i32*> userspace_address;
     int futex_op;
     i32 val;
-    const timespec* timeout;
+    Userspace<const timespec*> timeout;
 };
 
 struct SC_setkeymap_params {

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -321,7 +321,7 @@ public:
     int sys$module_unload(const char* name, size_t name_length);
     int sys$profiling_enable(pid_t);
     int sys$profiling_disable(pid_t);
-    int sys$futex(const Syscall::SC_futex_params*);
+    int sys$futex(Userspace<const Syscall::SC_futex_params*>);
     int sys$set_thread_boost(int tid, int amount);
     int sys$set_process_boost(pid_t, int amount);
     int sys$chroot(const char* path, size_t path_length, int mount_flags);
@@ -688,7 +688,7 @@ private:
     VeilState m_veil_state { VeilState::None };
     Vector<UnveiledPath> m_unveiled_paths;
 
-    WaitQueue& futex_queue(i32*);
+    WaitQueue& futex_queue(Userspace<const i32*>);
     HashMap<u32, OwnPtr<WaitQueue>> m_futex_queues;
 
     OwnPtr<PerformanceEventBuffer> m_perf_event_buffer;


### PR DESCRIPTION
Utilizie Userspace<T> for the syscall argument itself, as well
as internally in the SC_futex_params struct.

We were double validating the SC_futex_params.timeout validation,
that was removed as well.

I separated this from PR #2996 as I thought it deserved a closer review.