### PR TITLE
Kernel: Decorate KResultOr with [[nodiscard]] to catch misbehaving callers, and fix existing issues. 

### DIFF
--- a/Kernel/FileSystem/DevPtsFS.cpp
+++ b/Kernel/FileSystem/DevPtsFS.cpp
@@ -153,7 +153,7 @@ KResult DevPtsFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEn
     return KSuccess;
 }
 
-size_t DevPtsFSInode::directory_entry_count() const
+KResultOr<size_t> DevPtsFSInode::directory_entry_count() const
 {
     ASSERT(identifier().index() == 1);
 

--- a/Kernel/FileSystem/DevPtsFS.h
+++ b/Kernel/FileSystem/DevPtsFS.h
@@ -76,7 +76,7 @@ private:
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
-    virtual size_t directory_entry_count() const override;
+    virtual KResultOr<size_t> directory_entry_count() const override;
     virtual KResult chmod(mode_t) override;
     virtual KResult chown(uid_t, gid_t) override;
 

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -1562,7 +1562,7 @@ void Ext2FS::uncache_inode(InodeIndex index)
     m_inode_cache.remove(index);
 }
 
-size_t Ext2FSInode::directory_entry_count() const
+KResultOr<size_t> Ext2FSInode::directory_entry_count() const
 {
     ASSERT(is_directory());
     LOCKER(m_lock);

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -71,7 +71,7 @@ private:
     virtual int set_mtime(time_t) override;
     virtual KResult increment_link_count() override;
     virtual KResult decrement_link_count() override;
-    virtual size_t directory_entry_count() const override;
+    virtual KResultOr<size_t> directory_entry_count() const override;
     virtual KResult chmod(mode_t) override;
     virtual KResult chown(uid_t, gid_t) override;
     virtual KResult truncate(u64) override;

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -76,7 +76,7 @@ public:
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) = 0;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) = 0;
     virtual KResult remove_child(const StringView& name) = 0;
-    virtual size_t directory_entry_count() const = 0;
+    virtual KResultOr<size_t> directory_entry_count() const = 0;
     virtual KResult chmod(mode_t) = 0;
     virtual KResult chown(uid_t, gid_t) = 0;
     virtual KResult truncate(u64) { return KSuccess; }

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -794,13 +794,17 @@ void Plan9FSInode::flush_metadata()
     // Do nothing.
 }
 
-size_t Plan9FSInode::directory_entry_count() const
+KResultOr<size_t> Plan9FSInode::directory_entry_count() const
 {
     size_t count = 0;
-    traverse_as_directory([&count](const FS::DirectoryEntry&) {
+    KResult result = traverse_as_directory([&count](const FS::DirectoryEntry&) {
         count++;
         return true;
     });
+
+    if (result.is_error())
+        return result;
+
     return count;
 }
 

--- a/Kernel/FileSystem/Plan9FileSystem.h
+++ b/Kernel/FileSystem/Plan9FileSystem.h
@@ -131,7 +131,7 @@ public:
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
-    virtual size_t directory_entry_count() const override;
+    virtual KResultOr<size_t> directory_entry_count() const override;
     virtual KResult chmod(mode_t) override;
     virtual KResult chown(uid_t, gid_t) override;
     virtual KResult truncate(u64) override;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -1515,10 +1515,10 @@ RefPtr<Inode> ProcFSProxyInode::lookup(StringView name)
     return m_fd->inode()->lookup(name);
 }
 
-size_t ProcFSProxyInode::directory_entry_count() const
+KResultOr<size_t> ProcFSProxyInode::directory_entry_count() const
 {
     if (!m_fd->inode())
-        return 0;
+        return KResult(-EINVAL);
     return m_fd->inode()->directory_entry_count();
 }
 
@@ -1538,14 +1538,18 @@ KResult ProcFSInode::remove_child(const StringView& name)
     return KResult(-EPERM);
 }
 
-size_t ProcFSInode::directory_entry_count() const
+KResultOr<size_t> ProcFSInode::directory_entry_count() const
 {
     ASSERT(is_directory());
     size_t count = 0;
-    traverse_as_directory([&count](const FS::DirectoryEntry&) {
+    KResult result = traverse_as_directory([&count](const FS::DirectoryEntry&) {
         ++count;
         return true;
     });
+
+    if (result.is_error())
+        return result;
+
     return count;
 }
 

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -105,7 +105,7 @@ private:
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
-    virtual size_t directory_entry_count() const override;
+    virtual KResultOr<size_t> directory_entry_count() const override;
     virtual KResult chmod(mode_t) override;
     virtual KResult chown(uid_t, gid_t) override;
     virtual KResultOr<NonnullRefPtr<Custody>> resolve_as_link(Custody& base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0) const override;
@@ -132,7 +132,7 @@ private:
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
-    virtual size_t directory_entry_count() const override;
+    virtual KResultOr<size_t> directory_entry_count() const override;
     virtual KResult chmod(mode_t) override { return KResult(-EINVAL); }
     virtual KResult chown(uid_t, gid_t) override { return KResult(-EINVAL); }
     virtual KResultOr<NonnullRefPtr<Custody>> resolve_as_link(Custody&, RefPtr<Custody>*, int, int) const override { ASSERT_NOT_REACHED(); }

--- a/Kernel/FileSystem/TmpFS.cpp
+++ b/Kernel/FileSystem/TmpFS.cpp
@@ -219,7 +219,7 @@ RefPtr<Inode> TmpFSInode::lookup(StringView name)
     return fs().get_inode(it->value.entry.inode);
 }
 
-size_t TmpFSInode::directory_entry_count() const
+KResultOr<size_t> TmpFSInode::directory_entry_count() const
 {
     LOCKER(m_lock, Lock::Mode::Shared);
     ASSERT(is_directory());

--- a/Kernel/FileSystem/TmpFS.h
+++ b/Kernel/FileSystem/TmpFS.h
@@ -83,7 +83,7 @@ public:
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
-    virtual size_t directory_entry_count() const override;
+    virtual KResultOr<size_t> directory_entry_count() const override;
     virtual KResult chmod(mode_t) override;
     virtual KResult chown(uid_t, gid_t) override;
     virtual KResult truncate(u64) override;

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -731,7 +731,11 @@ KResult VFS::rmdir(StringView path, Custody& base)
     if (!parent_inode.metadata().may_write(*Process::current()))
         return KResult(-EACCES);
 
-    if (inode.directory_entry_count() != 2)
+    KResultOr<size_t> dir_count_result = inode.directory_entry_count();
+    if (dir_count_result.is_error())
+        return dir_count_result.result();
+
+    if (dir_count_result.value() != 2)
         return KResult(-ENOTEMPTY);
 
     if (custody.is_readonly())

--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -61,7 +61,7 @@ private:
 };
 
 template<typename T>
-class alignas(T) KResultOr {
+class alignas(T) [[nodiscard]] KResultOr {
 public:
     KResultOr(KResult error)
         : m_error(error)


### PR DESCRIPTION
The [[nodiscard]] decorator enables us to have the compile emit a
warning anytime the decorated type or function's return value isn't
observed. It's very useful for catching error checking bugs in systems
which use C style error handling. This change enables it for KResultOr<T>

In order to get this to compile clean I've fixed all of the Inode::directory_entry_count()
implementations to return KResultOr<size_t> so that we can properly observe and handle
all of paths which were missing the observation of KResultOr<T> return values.

I was looking at decorating KResult with [[nodiscard]] as well, but that cleanup
is a much larger chore that will need to be tackled separately.  