### PR TITLE
Kernel: Decorate KResult with [[nodiscard]] to catch misbehaving callers, and fix and suppress issues it found. 

### DIFF
--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -1477,10 +1477,12 @@ void Ext2FSInode::populate_lookup_cache() const
         return;
     HashMap<String, unsigned> children;
 
-    traverse_as_directory([&children](auto& entry) {
+    KResult result = traverse_as_directory([&children](auto& entry) {
         children.set(String(entry.name, entry.name_length), entry.inode.index());
         return true;
     });
+
+    ASSERT(result.is_success());
 
     if (!m_lookup_cache.is_empty())
         return;

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -1023,7 +1023,9 @@ KResult Ext2FSInode::remove_child(const StringView& name)
     m_lookup_cache.remove(name);
 
     auto child_inode = fs().get_inode(child_id);
-    child_inode->decrement_link_count();
+    result = child_inode->decrement_link_count();
+    if (result.is_error())
+        return result;
 
     did_remove_child(name);
     return KSuccess;

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -187,13 +187,17 @@ ssize_t FileDescription::get_dir_entries(u8* buffer, ssize_t size)
 
     auto temp_buffer = ByteBuffer::create_uninitialized(size_to_allocate);
     BufferStream stream(temp_buffer);
-    VFS::the().traverse_directory_inode(*m_inode, [&stream](auto& entry) {
+    KResult result = VFS::the().traverse_directory_inode(*m_inode, [&stream](auto& entry) {
         stream << (u32)entry.inode.index();
         stream << (u8)entry.file_type;
         stream << (u32)entry.name_length;
         stream << entry.name;
         return true;
     });
+
+    if (result.is_error())
+        result.error();
+
     stream.snip();
 
     if (static_cast<size_t>(size) < temp_buffer.size())

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -70,7 +70,8 @@ FileDescription::~FileDescription()
         socket()->detach(*this);
     if (is_fifo())
         static_cast<FIFO*>(m_file.ptr())->detach(m_fifo_direction);
-    m_file->close();
+    // FIXME: Should this error path be observed somehow?
+    (void)m_file->close();
     m_inode = nullptr;
 }
 

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -636,7 +636,8 @@ Plan9FSInode::~Plan9FSInode()
 {
     Plan9FS::Message clunk_request { fs(), Plan9FS::Message::Type::Tclunk };
     clunk_request << fid();
-    fs().post_message_and_explicitly_ignore_reply(clunk_request);
+    // FIXME: Should we observe this  error somehow?
+    (void)fs().post_message_and_explicitly_ignore_reply(clunk_request);
 }
 
 KResult Plan9FSInode::ensure_open_for_mode(int mode)
@@ -829,7 +830,8 @@ KResult Plan9FSInode::traverse_as_directory(Function<bool(const FS::DirectoryEnt
             if (result.is_error()) {
                 Plan9FS::Message close_message { fs(), Plan9FS::Message::Type::Tclunk };
                 close_message << clone_fid;
-                fs().post_message_and_explicitly_ignore_reply(close_message);
+                // FIXME: Should we observe this error?
+                (void)fs().post_message_and_explicitly_ignore_reply(close_message);
                 return result;
             }
         }
@@ -871,7 +873,8 @@ KResult Plan9FSInode::traverse_as_directory(Function<bool(const FS::DirectoryEnt
 
         Plan9FS::Message close_message { fs(), Plan9FS::Message::Type::Tclunk };
         close_message << clone_fid;
-        fs().post_message_and_explicitly_ignore_reply(close_message);
+        // FIXME: Should we observe this error?
+        (void)fs().post_message_and_explicitly_ignore_reply(close_message);
         return result;
     } else {
         // TODO

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -126,7 +126,7 @@ private:
 
     bool is_vfs_root(InodeIdentifier) const;
 
-    void traverse_directory_inode(Inode&, Function<bool(const FS::DirectoryEntry&)>);
+    KResult traverse_directory_inode(Inode&, Function<bool(const FS::DirectoryEntry&)>);
 
     Mount* find_mount_for_host(Inode&);
     Mount* find_mount_for_host(InodeIdentifier);

--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -35,7 +35,7 @@ enum KSuccessTag {
     KSuccess
 };
 
-class KResult {
+class [[nodiscard]] KResult {
 public:
     ALWAYS_INLINE explicit KResult(int negative_e)
         : m_error(negative_e)

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -138,7 +138,8 @@ void TCPSocket::release_for_accept(RefPtr<TCPSocket> socket)
 {
     ASSERT(m_pending_release_for_accept.contains(socket->tuple()));
     m_pending_release_for_accept.remove(socket->tuple());
-    queue_connection_from(*socket);
+    // FIXME: Should we observe this error somehow?
+    (void)queue_connection_from(*socket);
 }
 
 TCPSocket::TCPSocket(int protocol)

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -384,7 +384,8 @@ bool Scheduler::pick_next()
         }
         if (process.m_alarm_deadline && g_uptime > process.m_alarm_deadline) {
             process.m_alarm_deadline = 0;
-            process.send_signal(SIGALRM, nullptr);
+            // FIXME: Should we observe this signal somehow?
+            (void)process.send_signal(SIGALRM, nullptr);
         }
         return IterationDecision::Continue;
     });

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -246,7 +246,8 @@ int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Ve
     for (size_t i = 0; i < m_fds.size(); ++i) {
         auto& description_and_flags = m_fds[i];
         if (description_and_flags.description() && description_and_flags.flags() & FD_CLOEXEC) {
-            description_and_flags.description()->close();
+            // FIXME: Should this error path be observed somehow?
+            (void)description_and_flags.description()->close();
             description_and_flags = {};
         }
     }

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -55,7 +55,9 @@ void TTY::set_default_termios()
 KResultOr<size_t> TTY::read(FileDescription&, size_t, u8* buffer, size_t size)
 {
     if (Process::current()->pgid() != pgid()) {
-        Process::current()->send_signal(SIGTTIN, nullptr);
+        KResult result = Process::current()->send_signal(SIGTTIN, nullptr);
+        if (result.is_error())
+            return result;
         return KResult(-EINTR);
     }
 
@@ -91,7 +93,9 @@ KResultOr<size_t> TTY::read(FileDescription&, size_t, u8* buffer, size_t size)
 KResultOr<size_t> TTY::write(FileDescription&, size_t, const u8* buffer, size_t size)
 {
     if (Process::current()->pgid() != pgid()) {
-        Process::current()->send_signal(SIGTTOU, nullptr);
+        KResult result = Process::current()->send_signal(SIGTTOU, nullptr);
+        if (result.is_error())
+            return result;
         return KResult(-EINTR);
     }
 

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -55,9 +55,8 @@ void TTY::set_default_termios()
 KResultOr<size_t> TTY::read(FileDescription&, size_t, u8* buffer, size_t size)
 {
     if (Process::current()->pgid() != pgid()) {
-        KResult result = Process::current()->send_signal(SIGTTIN, nullptr);
-        if (result.is_error())
-            return result;
+        // FIXME: Should we propigate this error path somehow?
+        (void)Process::current()->send_signal(SIGTTIN, nullptr);
         return KResult(-EINTR);
     }
 
@@ -93,9 +92,8 @@ KResultOr<size_t> TTY::read(FileDescription&, size_t, u8* buffer, size_t size)
 KResultOr<size_t> TTY::write(FileDescription&, size_t, const u8* buffer, size_t size)
 {
     if (Process::current()->pgid() != pgid()) {
-        KResult result = Process::current()->send_signal(SIGTTOU, nullptr);
-        if (result.is_error())
-            return result;
+        // FIXME: Should we propigate this error path somehow?
+        (void)Process::current()->send_signal(SIGTTOU, nullptr);
         return KResult(-EINTR);
     }
 
@@ -255,7 +253,8 @@ void TTY::generate_signal(int signal)
     InterruptDisabler disabler; // FIXME: Iterate over a set of process handles instead?
     Process::for_each_in_pgrp(pgid(), [&](auto& process) {
         dbg() << tty_name() << ": Send signal " << signal << " to " << process;
-        process.send_signal(signal, nullptr);
+        // FIXME: Should this error be propagated somehow?
+        (void)process.send_signal(signal, nullptr);
         return IterationDecision::Continue;
     });
 }


### PR DESCRIPTION
Continuing off of #2999, this enables [[nodiscard]] for KResult.

There are unfortunately a bunch of dead end paths that require
plumbing error paths throughout the codebase to fix. To get the
warning enabled and stop from new problems being added, I've
suppressed the existing difficult to deal with issues, and left FIXME
bread crumbs so we can hopefully go back and fix them over time. 