### PR TITLE
AK: Decorate Optional<T> with [[nodisard]], suppress issues it found. 

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -34,7 +34,7 @@
 namespace AK {
 
 template<typename T>
-class alignas(T) Optional {
+class alignas(T) [[nodiscard]] Optional {
 public:
     Optional() {}
 

--- a/Libraries/LibCrypto/Cipher/Mode/CTR.h
+++ b/Libraries/LibCrypto/Cipher/Mode/CTR.h
@@ -129,7 +129,7 @@ public:
     virtual void decrypt(const ByteBuffer& in, ByteBuffer& out, Optional<ByteBuffer> ivec = {}) override
     {
         // XOR (and thus CTR) is the most symmetric mode.
-        this->encrypt(in, out, ivec);
+        (void)this->encrypt(in, out, ivec);
     }
 
 private:

--- a/Libraries/LibTLS/Record.cpp
+++ b/Libraries/LibTLS/Record.cpp
@@ -117,7 +117,7 @@ void TLSv12::update_packet(ByteBuffer& packet)
                 auto view = ct.slice_view(header_size + iv_size, length);
 
                 // encrypt the message
-                m_aes_local->encrypt(buffer, view, iv);
+                (void)m_aes_local->encrypt(buffer, view, iv);
 
                 // store the correct ciphertext length into the packet
                 u16 ct_length = (u16)ct.size() - header_size;

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -197,7 +197,7 @@ void aes_cbc(const char* message, size_t len)
         Crypto::Cipher::AESCipher::CBCMode cipher(ByteBuffer::wrap(secret_key, strlen(secret_key)), key_bits, Crypto::Cipher::Intent::Encryption);
 
         auto enc = cipher.create_aligned_buffer(buffer.size());
-        cipher.encrypt(buffer, enc, iv);
+        (void)cipher.encrypt(buffer, enc, iv);
 
         if (binary)
             printf("%.*s", (int)enc.size(), enc.data());
@@ -579,7 +579,7 @@ void aes_cbc_test_encrypt()
         auto in = "This is a test! This is another test!"_b;
         auto out = cipher.create_aligned_buffer(in.size());
         auto iv = ByteBuffer::create_zeroed(Crypto::Cipher::AESCipher::block_size());
-        cipher.encrypt(in, out, iv);
+        (void)cipher.encrypt(in, out, iv);
         if (out.size() != sizeof(result))
             FAIL(size mismatch);
         else if (memcmp(out.data(), result, out.size()) != 0) {


### PR DESCRIPTION
Continuing off of #2999 and #3001 this enables [[nodiscard]] for AK::Optional.

CC @alimpfard for the LibTLS / test-crypto suppressions
CC @BenWiederhake  for the LibCrypto CTR.h suppressions. 