### PR TITLE
AK: Decorate AK::TriState with [[nodiscard]]

### DIFF
--- a/AK/Types.h
+++ b/AK/Types.h
@@ -62,8 +62,8 @@ typedef i64 int64_t;
 typedef int pid_t;
 
 #else
-#    include <stdint.h>
 #    include <stddef.h>
+#    include <stdint.h>
 #    include <sys/types.h>
 
 #    ifdef __ptrdiff_t
@@ -97,6 +97,8 @@ inline constexpr size_t align_up_to(const size_t value, const size_t alignment)
     return (value + (alignment - 1)) & ~(alignment - 1);
 }
 
-enum class TriState : u8 { False,
+enum class [[nodiscard]] TriState : u8 {
+    False,
     True,
-    Unknown };
+    Unknown
+};


### PR DESCRIPTION
TriState is another type of return code, it's value should always be observed.