### PR TITLE
AK: Decorate AK::OwnPtr::leak_ptr() + AK::NonnullOwnPtr::leak_ptr() with [[nodiscard]]

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -111,7 +111,7 @@ public:
         return *this;
     }
 
-    T* leak_ptr()
+    [[nodiscard]] T* leak_ptr()
     {
         return exchange(m_ptr, nullptr);
     }

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -137,7 +137,7 @@ public:
 
     bool operator!() const { return !m_ptr; }
 
-    T* leak_ptr()
+    [[nodiscard]] T* leak_ptr()
     {
         T* leaked_ptr = m_ptr;
         m_ptr = nullptr;


### PR DESCRIPTION
We should always leak to an observed variable, otherwise
it's an actual leak. This is similar to AK::RefPtr::leak_ref()
which is also marked as [[nodiscard]].