### PR TITLE
LibThread: remove redundant atomic write/ read from atomic in Lock

### DIFF
--- a/Libraries/LibThread/Lock.h
+++ b/Libraries/LibThread/Lock.h
@@ -72,12 +72,11 @@ ALWAYS_INLINE void Lock::lock()
     }
     for (;;) {
         int expected = 0;
-        if (m_holder.compare_exchange_strong(expected, tid, AK::memory_order_acq_rel)) {
-            m_holder = tid;
+        if (m_holder.compare_exchange_strong(expected, tid, AK::memory_order_acq_rel)) {            
             m_level = 1;
             return;
         }
-        donate(m_holder);
+        donate(expected);
     }
 }
 


### PR DESCRIPTION
`m_holder.compare_exchange_strong(expected, desired, ...)`
will either:
* successfully update the value to desired if it equals expected
 and no need to write the `tid` again.
* or read the current value into expected otherwise.
