### PR TITLE
HackStudio: Open file from argv

### DIFF
--- a/Base/home/anon/LaunchServer.ini
+++ b/Base/home/anon/LaunchServer.ini
@@ -12,6 +12,7 @@ wav=/bin/SoundPlayer
 txt=/bin/TextEditor
 frm=/bin/VisualBuilder
 font=/bin/FontEditor
+hackstudio=/bin/HackStudio
 *=/bin/TextEditor
 
 [Protocol]

--- a/Base/home/anon/js/javascript.files
+++ b/Base/home/anon/js/javascript.files
@@ -1,2 +1,0 @@
-javascript.files
-*.js

--- a/Base/home/anon/js/javascript.hackstudio
+++ b/Base/home/anon/js/javascript.hackstudio
@@ -1,0 +1,2 @@
+javascript.hackstudio
+*.js

--- a/Base/home/anon/little/little.hackstudio
+++ b/Base/home/anon/little/little.hackstudio
@@ -1,4 +1,4 @@
 main.cpp
 Makefile
-little.files
+little.hackstudio
 test.frm

--- a/DevTools/HackStudio/main.cpp
+++ b/DevTools/HackStudio/main.cpp
@@ -189,7 +189,14 @@ int main(int argc, char** argv)
     if (!make_is_available())
         GUI::MessageBox::show(g_window, "The 'make' command is not available. You probably want to install the binutils, gcc, and make ports from the root of the Serenity repository.", "Error", GUI::MessageBox::Type::Error);
 
-    open_project("/home/anon/little/little.hackstudio");
+    String argument_absolute_path;
+    if (argc >= 2)
+        argument_absolute_path = Core::File::real_path_for(argv[1]);
+
+    if (!argument_absolute_path.is_empty() && argument_absolute_path.ends_with(".hackstudio"))
+        open_project(argument_absolute_path);
+    else
+        open_project("/home/anon/little/little.hackstudio");
 
     auto& toolbar_container = widget.add<GUI::ToolBarContainer>();
     auto& toolbar = toolbar_container.add<GUI::ToolBar>();
@@ -684,7 +691,10 @@ int main(int argc, char** argv)
 
     g_open_file = open_file;
 
-    open_file(g_project->default_file());
+    if (!argument_absolute_path.is_empty() && !argument_absolute_path.ends_with(".hackstudio"))
+        open_file(argument_absolute_path);
+    else
+        open_file(g_project->default_file());
 
     update_actions();
     return app->exec();

--- a/DevTools/HackStudio/main.cpp
+++ b/DevTools/HackStudio/main.cpp
@@ -142,7 +142,7 @@ NonnullRefPtr<EditorWrapper> get_editor_of_file(const String& file)
 
 String get_project_executable_path()
 {
-    // e.g /my/project.files => /my/project
+    // e.g /my/project.hackstudio => /my/project
     // TODO: Perhaps a Makefile rule for getting the value of $(PROGRAM) would be better?
     return g_project->path().substring(0, g_project->path().index_of(".").value());
 }
@@ -189,7 +189,7 @@ int main(int argc, char** argv)
     if (!make_is_available())
         GUI::MessageBox::show(g_window, "The 'make' command is not available. You probably want to install the binutils, gcc, and make ports from the root of the Serenity repository.", "Error", GUI::MessageBox::Type::Error);
 
-    open_project("/home/anon/little/little.files");
+    open_project("/home/anon/little/little.hackstudio");
 
     auto& toolbar_container = widget.add<GUI::ToolBarContainer>();
     auto& toolbar = toolbar_container.add<GUI::ToolBar>();


### PR DESCRIPTION
When HackStudio is invoked with one or more arguments it will attempt to treat the first argument as a project or source file and open it accordingly.

When/if HS is updated to have tabs for multiple files opened in parallel it would make sense to take all files from `argv` into account.

Also LaunchServer now associates ~`.files`~ `.hackstudio` files with HackStudio.

---

If you try to open a file that's not a project file as project file it still fails spectacularly (aka assert), but that's a separate (and existing) issue.