### PR TITLE
LibGUI: Use set_cursor() in TextEditor::set_document()

### DIFF
--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -1659,7 +1659,7 @@ void TextEditor::set_document(TextDocument& document)
     for (size_t i = 0; i < m_document->line_count(); ++i) {
         m_line_visual_data.append(make<LineVisualData>());
     }
-    m_cursor = { 0, 0 };
+    set_cursor(0, 0);
     if (has_selection())
         m_selection.clear();
     recompute_all_visual_lines();


### PR DESCRIPTION
Instead of setting `m_cursor` directly to reset the cursor position, `TextEditor::set_document()` now uses `set_cursor()` which will call cursor change callback functions, if any.

This fixes a bug in HackStudio where the cursor information text would not update immediately after changing the active `TextDocument`, even though the cursor is always visibly being reset to 0, 0.

---

*screenshot of that bug:*

![image](https://user-images.githubusercontent.com/19366641/89431641-7b9d3300-d740-11ea-85ff-9c9952950a00.png)