### PR TITLE
Kernel: Send a SIGCHLD to the parent upon suspension of a process that is controlling a TTY

### DIFF
--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -155,6 +155,10 @@ void TTY::emit(u8 ch)
         if (ch == m_termios.c_cc[VSUSP]) {
             dbg() << tty_name() << ": VSUSP pressed!";
             generate_signal(SIGTSTP);
+            if (auto process = Process::from_pid(m_pgid)) {
+                if (auto parent = Process::from_pid(process->ppid()))
+                    (void)parent->send_signal(SIGCHLD, process);
+            }
             return;
         }
     }
@@ -390,5 +394,4 @@ void TTY::hang_up()
 {
     generate_signal(SIGHUP);
 }
-
 }

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
         Vector<u64> disowned_jobs;
         for (auto& job : jobs) {
             int wstatus = 0;
-            auto child_pid = waitpid(job.value->pid(), &wstatus, WNOHANG);
+            auto child_pid = waitpid(job.value->pid(), &wstatus, WNOHANG | WUNTRACED);
             if (child_pid < 0) {
                 if (errno == ECHILD) {
                     // The child process went away before we could process its death, just assume it exited all ok.
@@ -109,6 +109,7 @@ int main(int argc, char** argv)
                     job.value->set_has_exit(126);
                 } else if (WIFSTOPPED(wstatus)) {
                     job.value->unblock();
+                    job.value->set_is_suspended(true);
                 }
             }
             if (job.value->should_be_disowned())


### PR DESCRIPTION
Fixes the ^Z issue...again.

@nico your idea - send `SIGCHLD` to parent upon suspension.