### PR TITLE
Kernel+LibKeyboard+ProcFS: Store and expose the current kernel keymap

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -342,6 +342,7 @@ struct SC_setkeymap_params {
     Userspace<const u32*> shift_map;
     Userspace<const u32*> alt_map;
     Userspace<const u32*> altgr_map;
+    StringArgument map_name;
 };
 
 struct SC_create_thread_params {

--- a/Kernel/Devices/KeyboardDevice.cpp
+++ b/Kernel/Devices/KeyboardDevice.cpp
@@ -391,10 +391,11 @@ KeyboardClient::~KeyboardClient()
 {
 }
 
-void KeyboardDevice::set_maps(Keyboard::CharacterMapData character_map_data)
+void KeyboardDevice::set_maps(const Keyboard::CharacterMapData& character_map_data, const String& character_map_name)
 {
     m_character_map.set_character_map_data(character_map_data);
-    dbg() << "New Character map passing to client.";
+    m_character_map.set_character_map_name(character_map_name);
+    dbg() << "New Character map \"" << character_map_name << "\" passing to client.";
 }
 
 }

--- a/Kernel/Devices/KeyboardDevice.h
+++ b/Kernel/Devices/KeyboardDevice.h
@@ -51,7 +51,9 @@ public:
     KeyboardDevice();
 
     void set_client(KeyboardClient* client) { m_client = client; }
-    void set_maps(Keyboard::CharacterMapData character_map);
+    void set_maps(const Keyboard::CharacterMapData& character_map, const String& character_map_name);
+
+    const String keymap_name() { return m_character_map.character_map_name(); }
 
     // ^CharacterDevice
     virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -33,6 +33,7 @@
 #include <Kernel/CommandLine.h>
 #include <Kernel/Console.h>
 #include <Kernel/Devices/BlockDevice.h>
+#include <Kernel/Devices/KeyboardDevice.h>
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/FileBackedFileSystem.h>
 #include <Kernel/FileSystem/FileDescription.h>
@@ -85,6 +86,7 @@ enum ProcFileType {
     FI_Root_inodes,
     FI_Root_dmesg,
     FI_Root_interrupts,
+    FI_Root_keymap,
     FI_Root_pci,
     FI_Root_devices,
     FI_Root_uptime,
@@ -369,6 +371,15 @@ Optional<KBuffer> procfs$interrupts(InodeIdentifier)
         obj.add("call_count", (unsigned)handler.get_invoking_count());
     });
     array.finish();
+    return builder.build();
+}
+
+Optional<KBuffer> procfs$keymap(InodeIdentifier)
+{
+    KBufferBuilder builder;
+    JsonObjectSerializer<KBufferBuilder> json { builder };
+    json.add("keymap", KeyboardDevice::the().keymap_name());
+    json.finish();
     return builder.build();
 }
 
@@ -1573,6 +1584,7 @@ ProcFS::ProcFS()
     m_entries[FI_Root_self] = { "self", FI_Root_self, false, procfs$self };
     m_entries[FI_Root_pci] = { "pci", FI_Root_pci, false, procfs$pci };
     m_entries[FI_Root_interrupts] = { "interrupts", FI_Root_interrupts, false, procfs$interrupts };
+    m_entries[FI_Root_keymap] = { "keymap", FI_Root_keymap, false, procfs$keymap };
     m_entries[FI_Root_devices] = { "devices", FI_Root_devices, false, procfs$devices };
     m_entries[FI_Root_uptime] = { "uptime", FI_Root_uptime, false, procfs$uptime };
     m_entries[FI_Root_cmdline] = { "cmdline", FI_Root_cmdline, true, procfs$cmdline };

--- a/Kernel/Syscalls/setkeymap.cpp
+++ b/Kernel/Syscalls/setkeymap.cpp
@@ -56,7 +56,16 @@ int Process::sys$setkeymap(Userspace<const Syscall::SC_setkeymap_params*> user_p
     copy_from_user(character_map_data.alt_map, params.alt_map, CHAR_MAP_SIZE * sizeof(u32));
     copy_from_user(character_map_data.altgr_map, params.altgr_map, CHAR_MAP_SIZE * sizeof(u32));
 
-    KeyboardDevice::the().set_maps(character_map_data);
+    auto map_name = get_syscall_path_argument(params.map_name);
+    if (map_name.is_error()) {
+        return map_name.error();
+    }
+    constexpr size_t map_name_max_size = 50;
+    if (map_name.value().length() > map_name_max_size) {
+        return -ENAMETOOLONG;
+    }
+
+    KeyboardDevice::the().set_maps(character_map_data, map_name.value());
     return 0;
 }
 

--- a/Libraries/LibKeyboard/CharacterMap.cpp
+++ b/Libraries/LibKeyboard/CharacterMap.cpp
@@ -36,7 +36,6 @@ namespace Keyboard {
 CharacterMap::CharacterMap(const String& file_name)
 {
 #ifdef KERNEL
-    UNUSED_PARAM(file_name);
     m_character_map_data = default_character_map;
 #else
     auto result = CharacterMapFile::load_from_file(file_name);
@@ -44,13 +43,14 @@ CharacterMap::CharacterMap(const String& file_name)
 
     m_character_map_data = result.value();
 #endif
+    m_character_map_name = file_name;
 }
 
 #ifndef KERNEL
 
 int CharacterMap::set_system_map()
 {
-    Syscall::SC_setkeymap_params params { m_character_map_data.map, m_character_map_data.shift_map, m_character_map_data.alt_map, m_character_map_data.altgr_map };
+    Syscall::SC_setkeymap_params params { m_character_map_data.map, m_character_map_data.shift_map, m_character_map_data.alt_map, m_character_map_data.altgr_map, { m_character_map_name.characters(), m_character_map_name.length() } };
     return syscall(SC_setkeymap, &params);
 }
 
@@ -92,4 +92,13 @@ void CharacterMap::set_character_map_data(CharacterMapData character_map_data)
     m_character_map_data = character_map_data;
 }
 
+void CharacterMap::set_character_map_name(const String& character_map_name)
+{
+    m_character_map_name = character_map_name;
+}
+
+const String CharacterMap::character_map_name()
+{
+    return m_character_map_name;
+}
 }

--- a/Libraries/LibKeyboard/CharacterMap.h
+++ b/Libraries/LibKeyboard/CharacterMap.h
@@ -43,9 +43,13 @@ public:
 
     u32 get_char(KeyEvent);
     void set_character_map_data(CharacterMapData character_map_data);
+    void set_character_map_name(const String& character_map_name);
+
+    const String character_map_name();
 
 private:
     CharacterMapData m_character_map_data;
+    String m_character_map_name;
 };
 
 }


### PR DESCRIPTION
This set of patches enables storing the loaded keymap name in the kernel, and then querying it back by reading from `/proc/keymap`

<p align="left">
  <img src="https://teensyimg.com/images/YuLR5v6vxs.png" width="400">
</p>

Once this PR is merged, I can modify the KeyboardSettings program to show the currently selected keymap.
Resolves #2684 