### PR TITLE
Kernel: Dequeue dying threads from WaitQueue

### DIFF
--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -521,6 +521,7 @@ public:
 private:
     IntrusiveListNode m_runnable_list_node;
     IntrusiveListNode m_wait_queue_node;
+    WaitQueue* m_wait_queue { nullptr };
 
 private:
     friend class SchedulerData;

--- a/Kernel/WaitQueue.cpp
+++ b/Kernel/WaitQueue.cpp
@@ -56,6 +56,16 @@ bool WaitQueue::enqueue(Thread& thread)
     return true;
 }
 
+bool WaitQueue::dequeue(Thread& thread)
+{
+    ScopedSpinLock queue_lock(m_lock);
+    if (m_threads.contains(thread)) {
+        m_threads.remove(thread);
+        return true;
+    }
+    return false;
+}
+
 void WaitQueue::wake_one(Atomic<bool>* lock)
 {
     ScopedSpinLock queue_lock(m_lock);

--- a/Kernel/WaitQueue.h
+++ b/Kernel/WaitQueue.h
@@ -38,7 +38,9 @@ public:
     WaitQueue();
     ~WaitQueue();
 
+    SpinLock<u32>& get_lock() { return m_lock; }
     bool enqueue(Thread&);
+    bool dequeue(Thread&);
     void wake_one(Atomic<bool>* lock = nullptr);
     void wake_n(u32 wake_count);
     void wake_all();


### PR DESCRIPTION
If a thread is waiting but getting killed, we need to dequeue
the thread from the WaitQueue so that a potential wake before
finalization doesn't happen.

Fixes Piano crashing the system upon exit.