### PR TITLE
Shell: Start adding some alt shortcuts

### DIFF
--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -377,8 +377,8 @@ private:
 
     enum class InputState {
         Free,
-        ExpectBracket,
-        ExpectFinal,
+        GotEscape,
+        GotEscapeFollowedByLeftBracket,
         ExpectTerminator,
     };
     InputState m_state { InputState::Free };


### PR DESCRIPTION
This adds Alt-f to go forward by a word, and Alt-b to go backward
by a word (like ctrl-arrow-left / ctrl-arrow-right already do).

Behind the scenes, alt-key is implemented by sending <esc> followed
by that key, and typing <esc> f/b for moving by a word hence works
too (in all other shells too, not just in Serenity's).

While here, rename some InputState enum values to make the slightly
expanded use of <esc> clearer, and expand a few comments.