### PR TITLE
Shell: Add Alt-d binding to forward-delete a word

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -797,6 +797,7 @@ void Editor::handle_read_event()
         }
         m_times_tab_pressed = 0; // Safe to say if we get here, the user didn't press TAB
 
+        // Normally ^W. `stty werase \^n` can change it to ^N (or something else), but Serenity doesn't have `stty` yet.
         if (code_point == m_termios.c_cc[VWERASE]) {
             bool has_seen_nonspace = false;
             while (m_cursor > 0) {
@@ -810,6 +811,7 @@ void Editor::handle_read_event()
             }
             continue;
         }
+        // Normally ^U. `stty kill \^n` can change it to ^N (or something else), but Serenity doesn't have `stty` yet.
         if (code_point == m_termios.c_cc[VKILL]) {
             for (size_t i = 0; i < m_cursor; ++i)
                 remove_at_index(0);

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -571,6 +571,21 @@ void Editor::handle_read_event()
                 do_cursor_left(Word);
                 m_state = InputState::Free;
                 continue;
+            case 'd': // ^[d: alt-d
+            {
+                bool has_seen_nonspace = false;
+                while (m_cursor < m_buffer.size()) {
+                    if (isspace(m_buffer[m_cursor])) {
+                        if (has_seen_nonspace)
+                            break;
+                    } else {
+                        has_seen_nonspace = true;
+                    }
+                    do_delete();
+                }
+                m_state = InputState::Free;
+                continue;
+            }
             case 'f': // ^[f: alt-f
                 do_cursor_right(Word);
                 m_state = InputState::Free;


### PR DESCRIPTION
Also add comments with the usual (and, currently, always) bindings for VWERASE and VKILL.