### PR TITLE
LibLine: Add binding for Alt-.

### DIFF
--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -149,6 +149,7 @@ public:
 
     void clear_line();
     void insert(const String&);
+    void insert(const StringView&);
     void insert(const Utf32View&);
     void insert(const u32);
     void stylize(const Span&, const Style&);


### PR DESCRIPTION
This one's even useful, doubly so since Shell doesn't support `!$` yet.