### PR TITLE
LibLine+Shell: Remove unused split_mechanism

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -903,7 +903,7 @@ void Editor::handle_read_event()
                 // Disable our own notifier so as to avoid interfering with the search editor.
                 m_notifier->set_enabled(false);
 
-                m_search_editor = Editor::construct(Configuration { Configuration::Eager, m_configuration.split_mechanism }); // Has anyone seen 'Inception'?
+                m_search_editor = Editor::construct(Configuration { Configuration::Eager }); // Has anyone seen 'Inception'?
                 add_child(*m_search_editor);
 
                 m_search_editor->on_display_refresh = [this](Editor& search_editor) {
@@ -1621,19 +1621,6 @@ String Editor::line(size_t up_to_index) const
     builder.append(Utf32View { m_buffer.data(), min(m_buffer.size(), up_to_index) });
     return builder.build();
 }
-
-bool Editor::should_break_token(Vector<u32, 1024>& buffer, size_t index)
-{
-    switch (m_configuration.split_mechanism) {
-    case Configuration::TokenSplitMechanism::Spaces:
-        return buffer[index] == ' ';
-    case Configuration::TokenSplitMechanism::UnescapedSpaces:
-        return buffer[index] == ' ' && (index == 0 || buffer[index - 1] != '\\');
-    }
-
-    ASSERT_NOT_REACHED();
-    return true;
-};
 
 void Editor::remove_at_index(size_t index)
 {

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -52,10 +52,6 @@
 namespace Line {
 
 struct Configuration {
-    enum TokenSplitMechanism {
-        Spaces,
-        UnescapedSpaces,
-    };
     enum RefreshBehaviour {
         Lazy,
         Eager,
@@ -79,11 +75,9 @@ struct Configuration {
     }
 
     void set(RefreshBehaviour refresh) { refresh_behaviour = refresh; }
-    void set(TokenSplitMechanism split) { split_mechanism = split; }
     void set(OperationMode mode) { operation_mode = mode; }
 
     RefreshBehaviour refresh_behaviour { RefreshBehaviour::Lazy };
-    TokenSplitMechanism split_mechanism { TokenSplitMechanism::Spaces };
     OperationMode operation_mode { OperationMode::Unset };
 };
 
@@ -300,8 +294,6 @@ private:
         m_origin_column = col;
         m_suggestion_display->set_origin(row, col, {});
     }
-
-    bool should_break_token(Vector<u32, 1024>& buffer, size_t index);
 
     void recalculate_origin();
     void reposition_cursor(bool to_end = false);

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -144,7 +144,7 @@ int main(int argc, char** argv)
     }
 #endif
 
-    editor = Line::Editor::construct(Line::Configuration { Line::Configuration::UnescapedSpaces });
+    editor = Line::Editor::construct(Line::Configuration {});
 
     auto shell = Shell::construct();
     s_shell = shell.ptr();


### PR DESCRIPTION
It was only read in should_break_token(), which had no callers.
should_break_token() also got `foo\\ bar` and `"foo bar"` wrong.