### PR TITLE
LibLine: Add Ctrl-k shortcut

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -914,6 +914,12 @@ void Editor::handle_read_event()
             do_backspace();
             continue;
         }
+        // ^K
+        if (code_point == ctrl('K')) {
+            while (m_cursor < m_buffer.size())
+                do_delete();
+            continue;
+        }
         // ^L
         if (code_point == ctrl('L')) {
             printf("\033[3J\033[H\033[2J"); // Clear screen.


### PR DESCRIPTION
Only does the 'delete to end of line' bit for now.
No yank ring support yet.