### PR TITLE
AudioServer: Lock the process veil after startup

### DIFF
--- a/Services/AudioServer/main.cpp
+++ b/Services/AudioServer/main.cpp
@@ -57,5 +57,7 @@ int main(int, char**)
         return 1;
     }
 
+    unveil(nullptr, nullptr);
+
     return event_loop.exec();
 }


### PR DESCRIPTION
We can't do any file syscalls anyway because of the reduction of pledges,
so we might as well lock the veil anyway.