### PR TITLE
AK: Remove unnecessary clang-format off comments.

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -30,14 +30,10 @@
 
 namespace AK::Concepts {
 
-// clang-format off
-
 template<typename T>
 concept Integral = IsIntegral<T>::value;
 
 template<typename T>
 concept FloatingPoint = IsFloatingPoint<T>::value;
-
-// clang-format on
 
 }

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -62,8 +62,6 @@ public:
     virtual bool discard_or_error(size_t count) = 0;
 };
 
-// clang-format off
-
 template<Concepts::Integral Integral>
 InputStream& operator>>(InputStream& stream, Integral& value)
 {
@@ -79,8 +77,6 @@ InputStream& operator>>(InputStream& stream, FloatingPoint& value)
     return stream;
 }
 #endif
-
-// clang-format on
 
 inline InputStream& operator>>(InputStream& stream, bool& value)
 {


### PR DESCRIPTION
I originally had issues with `clang-format` formatting concepts related stuff incorrectly, but it seems to work now. I use Clang Format 10.0.1.

https://github.com/SerenityOS/serenity/pull/3007#discussion_r466461933
