### PR TITLE
Kernel: Use Userspace<T> for mount / chown / getpeername / getsockname / setsockopt / getsockopt / realpath

### DIFF
--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -73,6 +73,18 @@ private:
 #endif
 };
 
+template<typename T, typename U>
+inline Userspace<T> static_ptr_cast(const Userspace<U>& ptr)
+{
+#ifdef KERNEL
+    auto casted_ptr = static_cast<T>(ptr.unsafe_userspace_ptr());
+#else
+    auto casted_ptr = static_cast<T>(ptr.ptr());
+#endif
+    return Userspace<T>((FlatPtr)casted_ptr);
+}
+
 }
 
 using AK::Userspace;
+using AK::static_ptr_cast;

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -314,7 +314,7 @@ struct SC_setsockopt_params {
     int sockfd;
     int level;
     int option;
-    const void* value;
+    Userspace<const void*> value;
     socklen_t value_size;
 };
 

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -320,8 +320,8 @@ struct SC_setsockopt_params {
 
 struct SC_getsockname_params {
     int sockfd;
-    sockaddr* addr;
-    socklen_t* addrlen;
+    Userspace<sockaddr*> addr;
+    Userspace<socklen_t*> addrlen;
 };
 
 struct SC_getpeername_params {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -326,8 +326,8 @@ struct SC_getsockname_params {
 
 struct SC_getpeername_params {
     int sockfd;
-    sockaddr* addr;
-    socklen_t* addrlen;
+    Userspace<sockaddr*> addr;
+    Userspace<socklen_t*> addrlen;
 };
 
 struct SC_futex_params {

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -306,8 +306,8 @@ struct SC_getsockopt_params {
     int sockfd;
     int level;
     int option;
-    void* value;
-    socklen_t* value_size;
+    Userspace<void*> value;
+    Userspace<socklen_t*> value_size;
 };
 
 struct SC_setsockopt_params {

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -429,7 +429,7 @@ String IPv4Socket::absolute_path(const FileDescription&) const
     return builder.to_string();
 }
 
-KResult IPv4Socket::setsockopt(int level, int option, const void* user_value, socklen_t user_value_size)
+KResult IPv4Socket::setsockopt(int level, int option, Userspace<const void*> user_value, socklen_t user_value_size)
 {
     if (level != IPPROTO_IP)
         return Socket::setsockopt(level, option, user_value, user_value_size);
@@ -439,7 +439,7 @@ KResult IPv4Socket::setsockopt(int level, int option, const void* user_value, so
         if (user_value_size < sizeof(int))
             return KResult(-EINVAL);
         int value;
-        if (!Process::current()->validate_read_and_copy_typed(&value, (const int*)user_value))
+        if (!Process::current()->validate_read_and_copy_typed(&value, static_ptr_cast<const int*>(user_value)))
             return KResult(-EFAULT);
         if (value < 0 || value > 255)
             return KResult(-EINVAL);

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -61,7 +61,7 @@ public:
     virtual KResultOr<size_t> sendto(FileDescription&, const void*, size_t, int, const sockaddr*, socklen_t) override;
     virtual KResultOr<size_t> recvfrom(FileDescription&, void*, size_t, int flags, sockaddr*, socklen_t*) override;
     virtual KResult setsockopt(int level, int option, Userspace<const void*>, socklen_t) override;
-    virtual KResult getsockopt(FileDescription&, int level, int option, void*, socklen_t*) override;
+    virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>) override;
 
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
 

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -60,7 +60,7 @@ public:
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual KResultOr<size_t> sendto(FileDescription&, const void*, size_t, int, const sockaddr*, socklen_t) override;
     virtual KResultOr<size_t> recvfrom(FileDescription&, void*, size_t, int flags, sockaddr*, socklen_t*) override;
-    virtual KResult setsockopt(int level, int option, const void*, socklen_t) override;
+    virtual KResult setsockopt(int level, int option, Userspace<const void*>, socklen_t) override;
     virtual KResult getsockopt(FileDescription&, int level, int option, void*, socklen_t*) override;
 
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -62,7 +62,7 @@ public:
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual KResultOr<size_t> sendto(FileDescription&, const void*, size_t, int, const sockaddr*, socklen_t) override;
     virtual KResultOr<size_t> recvfrom(FileDescription&, void*, size_t, int flags, sockaddr*, socklen_t*) override;
-    virtual KResult getsockopt(FileDescription&, int level, int option, void*, socklen_t*) override;
+    virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>) override;
     virtual KResult chown(FileDescription&, uid_t, gid_t) override;
     virtual KResult chmod(FileDescription&, mode_t) override;
 

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -137,40 +137,52 @@ KResult Socket::setsockopt(int level, int option, Userspace<const void*> user_va
     }
 }
 
-KResult Socket::getsockopt(FileDescription&, int level, int option, void* value, socklen_t* value_size)
+KResult Socket::getsockopt(FileDescription&, int level, int option, Userspace<void*> value, Userspace<socklen_t*> value_size)
 {
+    socklen_t size;
+    if (!Process::current()->validate_read_and_copy_typed(&size, value_size))
+        return KResult(-EFAULT);
+
     ASSERT(level == SOL_SOCKET);
     switch (option) {
     case SO_SNDTIMEO:
-        if (*value_size < sizeof(timeval))
+        if (size < sizeof(timeval))
             return KResult(-EINVAL);
-        *(timeval*)value = m_send_timeout;
-        *value_size = sizeof(timeval);
+        copy_to_user(static_ptr_cast<timeval*>(value), &m_send_timeout);
+        size = sizeof(timeval);
+        copy_to_user(value_size, &size);
         return KSuccess;
     case SO_RCVTIMEO:
-        if (*value_size < sizeof(timeval))
+        if (size < sizeof(timeval))
             return KResult(-EINVAL);
-        *(timeval*)value = m_receive_timeout;
-        *value_size = sizeof(timeval);
+        copy_to_user(static_ptr_cast<timeval*>(value), &m_receive_timeout);
+        size = sizeof(timeval);
+        copy_to_user(value_size, &size);
         return KSuccess;
-    case SO_ERROR:
-        if (*value_size < sizeof(int))
+    case SO_ERROR: {
+        if (size < sizeof(int))
             return KResult(-EINVAL);
         dbg() << "getsockopt(SO_ERROR): FIXME!";
-        *(int*)value = 0;
-        *value_size = sizeof(int);
+        int errno = 0;
+        copy_to_user(static_ptr_cast<int*>(value), &errno);
+        size = sizeof(int);
+        copy_to_user(value_size, &size);
         return KSuccess;
+    }
     case SO_BINDTODEVICE:
-        if (*value_size < IFNAMSIZ)
+        if (size < IFNAMSIZ)
             return KResult(-EINVAL);
         if (m_bound_interface) {
             const auto& name = m_bound_interface->name();
             auto length = name.length() + 1;
-            memcpy(value, name.characters(), length);
-            *value_size = length;
+            copy_to_user(static_ptr_cast<char*>(value), name.characters(), length);
+            size = length;
+            copy_to_user(value_size, &size);
             return KSuccess;
         } else {
-            *value_size = 0;
+            size = 0;
+            copy_to_user(value_size, &size);
+
             return KResult(-EFAULT);
         }
     default:

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -111,7 +111,7 @@ public:
     virtual KResultOr<size_t> recvfrom(FileDescription&, void*, size_t, int flags, sockaddr*, socklen_t*) = 0;
 
     virtual KResult setsockopt(int level, int option, Userspace<const void*>, socklen_t);
-    virtual KResult getsockopt(FileDescription&, int level, int option, void*, socklen_t*);
+    virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>);
 
     pid_t origin_pid() const { return m_origin.pid; }
     uid_t origin_uid() const { return m_origin.uid; }

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -110,7 +110,7 @@ public:
     virtual KResultOr<size_t> sendto(FileDescription&, const void*, size_t, int flags, const sockaddr*, socklen_t) = 0;
     virtual KResultOr<size_t> recvfrom(FileDescription&, void*, size_t, int flags, sockaddr*, socklen_t*) = 0;
 
-    virtual KResult setsockopt(int level, int option, const void*, socklen_t);
+    virtual KResult setsockopt(int level, int option, Userspace<const void*>, socklen_t);
     virtual KResult getsockopt(FileDescription&, int level, int option, void*, socklen_t*);
 
     pid_t origin_pid() const { return m_origin.pid; }

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -297,7 +297,7 @@ public:
     ssize_t sys$recvfrom(const Syscall::SC_recvfrom_params*);
     int sys$getsockopt(const Syscall::SC_getsockopt_params*);
     int sys$setsockopt(const Syscall::SC_setsockopt_params*);
-    int sys$getsockname(const Syscall::SC_getsockname_params*);
+    int sys$getsockname(Userspace<const Syscall::SC_getsockname_params*>);
     int sys$getpeername(Userspace<const Syscall::SC_getpeername_params*>);
     int sys$sched_setparam(pid_t pid, Userspace<const struct sched_param*>);
     int sys$sched_getparam(pid_t pid, Userspace<struct sched_param*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -296,7 +296,7 @@ public:
     ssize_t sys$sendto(const Syscall::SC_sendto_params*);
     ssize_t sys$recvfrom(const Syscall::SC_recvfrom_params*);
     int sys$getsockopt(const Syscall::SC_getsockopt_params*);
-    int sys$setsockopt(const Syscall::SC_setsockopt_params*);
+    int sys$setsockopt(Userspace<const Syscall::SC_setsockopt_params*>);
     int sys$getsockname(Userspace<const Syscall::SC_getsockname_params*>);
     int sys$getpeername(Userspace<const Syscall::SC_getpeername_params*>);
     int sys$sched_setparam(pid_t pid, Userspace<const struct sched_param*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -281,7 +281,7 @@ public:
     int sys$unlink(const char* pathname, size_t path_length);
     int sys$symlink(Userspace<const Syscall::SC_symlink_params*>);
     int sys$rmdir(Userspace<const char*> pathname, size_t path_length);
-    int sys$mount(const Syscall::SC_mount_params*);
+    int sys$mount(Userspace<const Syscall::SC_mount_params*>);
     int sys$umount(const char* mountpoint, size_t mountpoint_length);
     int sys$chmod(const char* pathname, size_t path_length, mode_t);
     int sys$fchmod(int fd, mode_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -298,7 +298,7 @@ public:
     int sys$getsockopt(const Syscall::SC_getsockopt_params*);
     int sys$setsockopt(const Syscall::SC_setsockopt_params*);
     int sys$getsockname(const Syscall::SC_getsockname_params*);
-    int sys$getpeername(const Syscall::SC_getpeername_params*);
+    int sys$getpeername(Userspace<const Syscall::SC_getpeername_params*>);
     int sys$sched_setparam(pid_t pid, Userspace<const struct sched_param*>);
     int sys$sched_getparam(pid_t pid, Userspace<struct sched_param*>);
     int sys$create_thread(void* (*)(void*), Userspace<const Syscall::SC_create_thread_params*>);
@@ -420,6 +420,13 @@ public:
             copy_from_user(dest, src);
         }
         return validated;
+    }
+
+    template<typename T>
+    [[nodiscard]] bool validate_read_and_copy_typed(T* dest, Userspace<T*> src)
+    {
+        Userspace<const T*> const_src { src.ptr() };
+        return validate_read_and_copy_typed(dest, const_src);
     }
 
     template<typename T>

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -319,7 +319,7 @@ public:
     int sys$halt();
     int sys$reboot();
     int sys$set_process_icon(int icon_id);
-    int sys$realpath(const Syscall::SC_realpath_params*);
+    int sys$realpath(Userspace<const Syscall::SC_realpath_params*>);
     ssize_t sys$getrandom(void*, size_t, unsigned int);
     int sys$setkeymap(Userspace<const Syscall::SC_setkeymap_params*>);
     int sys$module_load(const char* path, size_t path_length);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -285,7 +285,7 @@ public:
     int sys$umount(const char* mountpoint, size_t mountpoint_length);
     int sys$chmod(const char* pathname, size_t path_length, mode_t);
     int sys$fchmod(int fd, mode_t);
-    int sys$chown(const Syscall::SC_chown_params*);
+    int sys$chown(Userspace<const Syscall::SC_chown_params*>);
     int sys$fchown(int fd, uid_t, gid_t);
     int sys$socket(int domain, int type, int protocol);
     int sys$bind(int sockfd, const sockaddr* addr, socklen_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -295,7 +295,7 @@ public:
     int sys$shutdown(int sockfd, int how);
     ssize_t sys$sendto(const Syscall::SC_sendto_params*);
     ssize_t sys$recvfrom(const Syscall::SC_recvfrom_params*);
-    int sys$getsockopt(const Syscall::SC_getsockopt_params*);
+    int sys$getsockopt(Userspace<const Syscall::SC_getsockopt_params*>);
     int sys$setsockopt(Userspace<const Syscall::SC_setsockopt_params*>);
     int sys$getsockname(Userspace<const Syscall::SC_getsockname_params*>);
     int sys$getpeername(Userspace<const Syscall::SC_getpeername_params*>);

--- a/Kernel/Syscalls/chown.cpp
+++ b/Kernel/Syscalls/chown.cpp
@@ -38,7 +38,7 @@ int Process::sys$fchown(int fd, uid_t uid, gid_t gid)
     return description->chown(uid, gid);
 }
 
-int Process::sys$chown(const Syscall::SC_chown_params* user_params)
+int Process::sys$chown(Userspace<const Syscall::SC_chown_params*> user_params)
 {
     REQUIRE_PROMISE(chown);
     Syscall::SC_chown_params params;

--- a/Kernel/Syscalls/mount.cpp
+++ b/Kernel/Syscalls/mount.cpp
@@ -35,7 +35,7 @@
 
 namespace Kernel {
 
-int Process::sys$mount(const Syscall::SC_mount_params* user_params)
+int Process::sys$mount(Userspace<const Syscall::SC_mount_params*> user_params)
 {
     if (!is_superuser())
         return -EPERM;

--- a/Kernel/Syscalls/realpath.cpp
+++ b/Kernel/Syscalls/realpath.cpp
@@ -31,7 +31,7 @@
 
 namespace Kernel {
 
-int Process::sys$realpath(const Syscall::SC_realpath_params* user_params)
+int Process::sys$realpath(Userspace<const Syscall::SC_realpath_params*> user_params)
 {
     REQUIRE_PROMISE(rpath);
 

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -300,7 +300,7 @@ int Process::get_sock_or_peer_name(const Params& params)
     return 0;
 }
 
-int Process::sys$getsockname(const Syscall::SC_getsockname_params* user_params)
+int Process::sys$getsockname(Userspace<const Syscall::SC_getsockname_params*> user_params)
 {
     Syscall::SC_getsockname_params params;
     if (!validate_read_and_copy_typed(&params, user_params))

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -308,7 +308,7 @@ int Process::sys$getsockname(const Syscall::SC_getsockname_params* user_params)
     return get_sock_or_peer_name<true>(params);
 }
 
-int Process::sys$getpeername(const Syscall::SC_getpeername_params* user_params)
+int Process::sys$getpeername(Userspace<const Syscall::SC_getpeername_params*> user_params)
 {
     Syscall::SC_getpeername_params params;
     if (!validate_read_and_copy_typed(&params, user_params))

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -348,7 +348,7 @@ int Process::sys$getsockopt(const Syscall::SC_getsockopt_params* params)
     return socket.getsockopt(*description, level, option, value, value_size);
 }
 
-int Process::sys$setsockopt(const Syscall::SC_setsockopt_params* user_params)
+int Process::sys$setsockopt(Userspace<const Syscall::SC_setsockopt_params*> user_params)
 {
     Syscall::SC_setsockopt_params params;
     if (!validate_read_and_copy_typed(&params, user_params))


### PR DESCRIPTION
More progress on Userspace<T> conversion, as well as the addition of AK::static_ptr_cast for Userspace<T> to support the conversion. 