### PR TITLE
Shell: Stop a for loop upon receiving two consecutive interruptions

### DIFF
--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -105,10 +105,10 @@ int main(int argc, char** argv)
             }
 #endif
             if (child_pid == job.pid()) {
-                if (WIFEXITED(wstatus)) {
+                if (WIFSIGNALED(wstatus) && !WIFSTOPPED(wstatus)) {
+                    job.set_signalled(WTERMSIG(wstatus));
+                } else if (WIFEXITED(wstatus)) {
                     job.set_has_exit(WEXITSTATUS(wstatus));
-                } else if (WIFSIGNALED(wstatus) && !WIFSTOPPED(wstatus)) {
-                    job.set_has_exit(126);
                 } else if (WIFSTOPPED(wstatus)) {
                     job.unblock();
                     job.set_is_suspended(true);


### PR DESCRIPTION
This does not work perfectly (just like every other shell...), if the
running program handles the signal (SIGINT in this case) and quits
cleanly, the shell cannot detect the interruption.
This is the case with our `sleep(1)` (<- @awesomekling):
```sh
for $(seq 1 100) { sleep 1 } # This can only be terminated via ^\ (and not ^C)
```