### PR TITLE
open: Resolve the realpath before passing it to URL()

### DIFF
--- a/Userland/open.cpp
+++ b/Userland/open.cpp
@@ -28,6 +28,7 @@
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/File.h>
 #include <LibDesktop/Launcher.h>
 #include <string.h>
 
@@ -42,17 +43,20 @@ int main(int argc, char* argv[])
     bool all_ok = true;
 
     for (auto& url_or_path : urls_or_paths) {
-        URL url = URL::create_with_url_or_path(url_or_path);
-        if (url.protocol() == "file" && !url.path().starts_with('/')) {
-            if (auto* path = realpath(url.path().characters(), nullptr)) {
-                url.set_path(path);
-                free(path);
-            } else {
-                fprintf(stderr, "Failed to open '%s': %s\n", url.path().characters(), strerror(errno));
-                all_ok = false;
-                continue;
-            }
+        String path;
+        auto realpath_errno = 0;
+        if (path = Core::File::real_path_for(url_or_path); path.is_null()) {
+            realpath_errno = errno; // This *should* be preserved from Core::File::real_path_for().
+            path = url_or_path;
         }
+
+        URL url = URL::create_with_url_or_path(path);
+        if (url.protocol() == "file" && realpath_errno) {
+            fprintf(stderr, "Failed to open '%s': %s\n", url.path().characters(), strerror(realpath_errno));
+            all_ok = false;
+            continue;
+        }
+
         if (!Desktop::Launcher::open(url)) {
             fprintf(stderr, "Failed to open '%s'\n", url.path().characters());
             all_ok = false;


### PR DESCRIPTION
...which runs it through LexicalPath.
Fixes #3016.