### PR TITLE
Kernel: Apply type-checking to PID/TID/PGID/SID, demonstrate and fix bugs

### DIFF
--- a/AK/DistinctNumeric.h
+++ b/AK/DistinctNumeric.h
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2020, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace AK {
+
+/**
+ * This implements a "distinct" numeric type that is intentionally incompatible
+ * to other incantations. The intention is that each "distinct" type that you
+ * want simply gets different values for `fn_length` and `line`. The macros
+ * `TYPEDEF_DISTINCT_NUMERIC_*()` at the bottom of `DistinctNumeric.h`.
+ *
+ * `Incr`, `Cmp`, `Bool`, `Flags`, `Shift`, and `Arith` simply split up the
+ * space of operators into 6 simple categories:
+ * - No matter the values of these, `DistinctNumeric` always implements `==` and `!=`.
+ * - If `Incr` is true, then `++a`, `a++`, `--a`, and `a--` are implemented.
+ * - If `Cmp` is true, then `a>b`, `a<b`, `a>=b`, and `a<=b` are implemented.
+ * - If `Bool` is true, then `!a`, `a&&b`, and `a||b` are implemented (through `operator bool()`.
+ * - If `Flags` is true, then `~a`, `a&b`, `a|b`, `a^b`, `a&=b`, `a|=b`, and `a^=b` are implemented.
+ * - If `Shift` is true, then `a<<b`, `a>>b`, `a<<=b`, `a>>=b` are implemented.
+ * - If `Arith` is true, then `a+b`, `a-b`, `+a`, `-a`, `a*b`, `a/b`, `a%b`, and the respective `a_=b` versions are implemented.
+ * The semantics are always those of the underlying basic type `T`.
+ *
+ * These can be combined arbitrarily. Want a numeric type that supports `++a`
+ * and `a >> b` but not `a > b`? Sure thing, just set
+ * `Incr=true, Cmp=false, Shift=true` and you're done!
+ * Furthermore, some of these overloads make more sense with specific types, like `a&&b` which should be able to operate
+ *
+ * I intentionally decided against overloading `&a` because these shall remain
+ * numeric types.
+ *
+ * The C++20 `operator<=>` would require, among other things `std::weak_equality`.
+ * Since we do not have that, it cannot be implemented.
+ *
+ * The are many operators that do not work on `int`, so I left them out:
+ * `a[b]`, `*a`, `a->b`, `a.b`, `a->*b`, `a.*b`.
+ *
+ * There are many more operators that do not make sense for numerical types,
+ * or cannot be overloaded in the first place. Naturally, they are not implemented.
+ */
+template<typename T, bool Incr, bool Cmp, bool Bool, bool Flags, bool Shift, bool Arith, typename X>
+class DistinctNumeric {
+    typedef DistinctNumeric<T, Incr, Cmp, Bool, Flags, Shift, Arith, X> Self;
+
+public:
+    DistinctNumeric(T value)
+        : m_value { value }
+    {
+    }
+
+    const T& value() const { return m_value; }
+
+    // Always implemented: identity.
+    bool operator==(const Self& other) const
+    {
+        return this->m_value == other.m_value;
+    }
+    bool operator!=(const Self& other) const
+    {
+        return this->m_value != other.m_value;
+    }
+
+    // Only implemented when `Incr` is true:
+    Self& operator++()
+    {
+        static_assert(Incr, "'++a' is only available for DistinctNumeric types with 'Incr'.");
+        this->m_value += 1;
+        return *this;
+    }
+    Self operator++(int)
+    {
+        static_assert(Incr, "'a++' is only available for DistinctNumeric types with 'Incr'.");
+        Self ret = this->m_value;
+        this->m_value += 1;
+        return ret;
+    }
+    Self& operator--()
+    {
+        static_assert(Incr, "'--a' is only available for DistinctNumeric types with 'Incr'.");
+        this->m_value -= 1;
+        return *this;
+    }
+    Self operator--(int)
+    {
+        static_assert(Incr, "'a--' is only available for DistinctNumeric types with 'Incr'.");
+        Self ret = this->m_value;
+        this->m_value -= 1;
+        return ret;
+    }
+
+    // Only implemented when `Cmp` is true:
+    bool operator>(const Self& other) const
+    {
+        static_assert(Cmp, "'a>b' is only available for DistinctNumeric types with 'Cmp'.");
+        return this->m_value > other.m_value;
+    }
+    bool operator<(const Self& other) const
+    {
+        static_assert(Cmp, "'a<b' is only available for DistinctNumeric types with 'Cmp'.");
+        return this->m_value < other.m_value;
+    }
+    bool operator>=(const Self& other) const
+    {
+        static_assert(Cmp, "'a>=b' is only available for DistinctNumeric types with 'Cmp'.");
+        return this->m_value >= other.m_value;
+    }
+    bool operator<=(const Self& other) const
+    {
+        static_assert(Cmp, "'a<=b' is only available for DistinctNumeric types with 'Cmp'.");
+        return this->m_value <= other.m_value;
+    }
+    // 'operator<=>' cannot be implemented. See class comment.
+
+    // Only implemented when `bool` is true:
+    bool operator!() const
+    {
+        static_assert(Bool, "'!a' is only available for DistinctNumeric types with 'Bool'.");
+        return !this->m_value;
+    }
+    bool operator&&(const Self& other) const
+    {
+        static_assert(Bool, "'a&&b' is only available for DistinctNumeric types with 'Bool'.");
+        return this->m_value && other.m_value;
+    }
+    bool operator||(const Self& other) const
+    {
+        static_assert(Bool, "'a||b' is only available for DistinctNumeric types with 'Bool'.");
+        return this->m_value || other.m_value;
+    }
+    // Intentionally don't define `operator bool() const` here. C++ is a bit
+    // overzealos, and whenever there would be a type error, C++ instead tries
+    // to convert to a common int-ish type first. `bool` is int-ish, so
+    // `operator bool() const` would defy the entire point of this class.
+
+    // Only implemented when `Flags` is true:
+    Self operator~() const
+    {
+        static_assert(Flags, "'~a' is only available for DistinctNumeric types with 'Flags'.");
+        return ~this->m_value;
+    }
+    Self operator&(const Self& other) const
+    {
+        static_assert(Flags, "'a&b' is only available for DistinctNumeric types with 'Flags'.");
+        return this->m_value & other.m_value;
+    }
+    Self operator|(const Self& other) const
+    {
+        static_assert(Flags, "'a|b' is only available for DistinctNumeric types with 'Flags'.");
+        return this->m_value | other.m_value;
+    }
+    Self operator^(const Self& other) const
+    {
+        static_assert(Flags, "'a^b' is only available for DistinctNumeric types with 'Flags'.");
+        return this->m_value ^ other.m_value;
+    }
+    Self& operator&=(const Self& other)
+    {
+        static_assert(Flags, "'a&=b' is only available for DistinctNumeric types with 'Flags'.");
+        this->m_value &= other.m_value;
+        return *this;
+    }
+    Self& operator|=(const Self& other)
+    {
+        static_assert(Flags, "'a|=b' is only available for DistinctNumeric types with 'Flags'.");
+        this->m_value |= other.m_value;
+        return *this;
+    }
+    Self& operator^=(const Self& other)
+    {
+        static_assert(Flags, "'a^=b' is only available for DistinctNumeric types with 'Flags'.");
+        this->m_value ^= other.m_value;
+        return *this;
+    }
+
+    // Only implemented when `Shift` is true:
+    // TODO: Should this take `int` instead?
+    Self operator<<(const Self& other) const
+    {
+        static_assert(Shift, "'a<<b' is only available for DistinctNumeric types with 'Shift'.");
+        return this->m_value << other.m_value;
+    }
+    Self operator>>(const Self& other) const
+    {
+        static_assert(Shift, "'a>>b' is only available for DistinctNumeric types with 'Shift'.");
+        return this->m_value >> other.m_value;
+    }
+    Self& operator<<=(const Self& other)
+    {
+        static_assert(Shift, "'a<<=b' is only available for DistinctNumeric types with 'Shift'.");
+        this->m_value <<= other.m_value;
+        return *this;
+    }
+    Self& operator>>=(const Self& other)
+    {
+        static_assert(Shift, "'a>>=b' is only available for DistinctNumeric types with 'Shift'.");
+        this->m_value >>= other.m_value;
+        return *this;
+    }
+
+    // Only implemented when `Arith` is true:
+    Self operator+(const Self& other) const
+    {
+        static_assert(Arith, "'a+b' is only available for DistinctNumeric types with 'Arith'.");
+        return this->m_value + other.m_value;
+    }
+    Self operator-(const Self& other) const
+    {
+        static_assert(Arith, "'a-b' is only available for DistinctNumeric types with 'Arith'.");
+        return this->m_value - other.m_value;
+    }
+    Self operator+() const
+    {
+        static_assert(Arith, "'+a' is only available for DistinctNumeric types with 'Arith'.");
+        return +this->m_value;
+    }
+    Self operator-() const
+    {
+        static_assert(Arith, "'-a' is only available for DistinctNumeric types with 'Arith'.");
+        return -this->m_value;
+    }
+    Self operator*(const Self& other) const
+    {
+        static_assert(Arith, "'a*b' is only available for DistinctNumeric types with 'Arith'.");
+        return this->m_value * other.m_value;
+    }
+    Self operator/(const Self& other) const
+    {
+        static_assert(Arith, "'a/b' is only available for DistinctNumeric types with 'Arith'.");
+        return this->m_value / other.m_value;
+    }
+    Self operator%(const Self& other) const
+    {
+        static_assert(Arith, "'a%b' is only available for DistinctNumeric types with 'Arith'.");
+        return this->m_value % other.m_value;
+    }
+    Self& operator+=(const Self& other)
+    {
+        static_assert(Arith, "'a+=b' is only available for DistinctNumeric types with 'Arith'.");
+        this->m_value += other.m_value;
+        return *this;
+    }
+    Self& operator-=(const Self& other)
+    {
+        static_assert(Arith, "'a+=b' is only available for DistinctNumeric types with 'Arith'.");
+        this->m_value += other.m_value;
+        return *this;
+    }
+    Self& operator*=(const Self& other)
+    {
+        static_assert(Arith, "'a*=b' is only available for DistinctNumeric types with 'Arith'.");
+        this->m_value *= other.m_value;
+        return *this;
+    }
+    Self& operator/=(const Self& other)
+    {
+        static_assert(Arith, "'a/=b' is only available for DistinctNumeric types with 'Arith'.");
+        this->m_value /= other.m_value;
+        return *this;
+    }
+    Self& operator%=(const Self& other)
+    {
+        static_assert(Arith, "'a%=b' is only available for DistinctNumeric types with 'Arith'.");
+        this->m_value %= other.m_value;
+        return *this;
+    }
+
+private:
+    T m_value;
+};
+
+// TODO: When 'consteval' sufficiently-well supported by host compilers, try to
+// provide a more usable interface like this one:
+// https://gist.github.com/alimpfard/a3b750e8c3a2f44fb3a2d32038968ddf
+
+}
+
+#define TYPEDEF_DISTINCT_NUMERIC_GENERAL(T, Incr, Cmp, Bool, Flags, Shift, Arith, NAME) \
+    typedef DistinctNumeric<T, Incr, Cmp, Bool, Flags, Shift, Arith, struct __##NAME##_tag> NAME
+#define TYPEDEF_DISTINCT_ORDERED_ID(T, NAME) TYPEDEF_DISTINCT_NUMERIC_GENERAL(T, false, true, true, false, false, false, NAME)
+// TODO: Further typedef's?
+
+using AK::DistinctNumeric;

--- a/AK/TestSuite.h
+++ b/AK/TestSuite.h
@@ -272,6 +272,7 @@ using AK::TestSuite;
         static_assert(compiletime_lenof(___str(SuiteName)) != 0, "Set SuiteName"); \
         TestSuite::the().main(___str(SuiteName), argc, argv);                      \
         TestSuite::release();                                                      \
+        return 0;                                                                  \
     }
 
 #define assertEqual(one, two)                                                                                                                                              \

--- a/AK/Tests/TestDistinctNumeric.cpp
+++ b/AK/Tests/TestDistinctNumeric.cpp
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2020, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/DistinctNumeric.h>
+#include <AK/TestSuite.h>
+
+template<typename T>
+class ForType {
+public:
+    static void check_size()
+    {
+        TYPEDEF_DISTINCT_NUMERIC_GENERAL(T, false, false, false, false, false, false, TheNumeric);
+        EXPECT_EQ(sizeof(T), sizeof(TheNumeric));
+    }
+};
+
+TEST_CASE(check_size)
+{
+#define CHECK_SIZE_FOR_SIGNABLE(T)         \
+    do {                                   \
+        ForType<signed T>::check_size();   \
+        ForType<unsigned T>::check_size(); \
+    } while (false)
+    CHECK_SIZE_FOR_SIGNABLE(char);
+    CHECK_SIZE_FOR_SIGNABLE(short);
+    CHECK_SIZE_FOR_SIGNABLE(int);
+    CHECK_SIZE_FOR_SIGNABLE(long);
+    CHECK_SIZE_FOR_SIGNABLE(long long);
+    ForType<float>::check_size();
+    ForType<double>::check_size();
+}
+
+TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, false, false, false, false, false, BareNumeric);
+TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, true, false, false, false, false, false, IncrNumeric);
+TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, true, false, false, false, false, CmpNumeric);
+TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, false, true, false, false, false, BoolNumeric);
+TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, false, false, true, false, false, FlagsNumeric);
+TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, false, false, false, true, false, ShiftNumeric);
+TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, false, false, false, false, false, true, ArithNumeric);
+TYPEDEF_DISTINCT_NUMERIC_GENERAL(int, true, true, true, true, true, true, GeneralNumeric);
+
+TEST_CASE(address_identity)
+{
+    BareNumeric a = 4;
+    BareNumeric b = 5;
+    EXPECT_EQ(&a == &a, true);
+    EXPECT_EQ(&a == &b, false);
+    EXPECT_EQ(&a != &a, false);
+    EXPECT_EQ(&a != &b, true);
+}
+
+TEST_CASE(operator_identity)
+{
+    BareNumeric a = 4;
+    BareNumeric b = 5;
+    EXPECT_EQ(a == a, true);
+    EXPECT_EQ(a == b, false);
+    EXPECT_EQ(a != a, false);
+    EXPECT_EQ(a != b, true);
+}
+
+TEST_CASE(operator_incr)
+{
+    IncrNumeric a = 4;
+    IncrNumeric b = 5;
+    IncrNumeric c = 6;
+    EXPECT_EQ(++a, b);
+    EXPECT_EQ(a++, b);
+    EXPECT_EQ(a, c);
+    EXPECT_EQ(--a, b);
+    EXPECT_EQ(a--, b);
+    EXPECT(a != b);
+}
+
+TEST_CASE(operator_cmp)
+{
+    CmpNumeric a = 4;
+    CmpNumeric b = 5;
+    CmpNumeric c = 5;
+    EXPECT_EQ(a > b, false);
+    EXPECT_EQ(a < b, true);
+    EXPECT_EQ(a >= b, false);
+    EXPECT_EQ(a <= b, true);
+    EXPECT_EQ(b > a, true);
+    EXPECT_EQ(b < a, false);
+    EXPECT_EQ(b >= a, true);
+    EXPECT_EQ(b <= a, false);
+    EXPECT_EQ(b > c, false);
+    EXPECT_EQ(b < c, false);
+    EXPECT_EQ(b >= c, true);
+    EXPECT_EQ(b <= c, true);
+}
+
+TEST_CASE(operator_bool)
+{
+    BoolNumeric a = 0;
+    BoolNumeric b = 42;
+    BoolNumeric c = 1337;
+    EXPECT_EQ(!a, true);
+    EXPECT_EQ(!b, false);
+    EXPECT_EQ(!c, false);
+    EXPECT_EQ(a && b, false);
+    EXPECT_EQ(a && c, false);
+    EXPECT_EQ(b && c, true);
+    EXPECT_EQ(a || a, false);
+    EXPECT_EQ(a || b, true);
+    EXPECT_EQ(a || c, true);
+    EXPECT_EQ(b || c, true);
+}
+
+TEST_CASE(operator_flags)
+{
+    FlagsNumeric a = 0;
+    FlagsNumeric b = 0xA60;
+    FlagsNumeric c = 0x03B;
+    EXPECT_EQ(~a, FlagsNumeric(~0x0));
+    EXPECT_EQ(~b, FlagsNumeric(~0xA60));
+    EXPECT_EQ(~c, FlagsNumeric(~0x03B));
+
+    EXPECT_EQ(a & b, b & a);
+    EXPECT_EQ(a & c, c & a);
+    EXPECT_EQ(b & c, c & b);
+    EXPECT_EQ(a | b, b | a);
+    EXPECT_EQ(a | c, c | a);
+    EXPECT_EQ(b | c, c | b);
+    EXPECT_EQ(a ^ b, b ^ a);
+    EXPECT_EQ(a ^ c, c ^ a);
+    EXPECT_EQ(b ^ c, c ^ b);
+
+    EXPECT_EQ(a & b, FlagsNumeric(0x000));
+    EXPECT_EQ(a & c, FlagsNumeric(0x000));
+    EXPECT_EQ(b & c, FlagsNumeric(0x020));
+    EXPECT_EQ(a | b, FlagsNumeric(0xA60));
+    EXPECT_EQ(a | c, FlagsNumeric(0x03B));
+    EXPECT_EQ(b | c, FlagsNumeric(0xA7B));
+    EXPECT_EQ(a ^ b, FlagsNumeric(0xA60));
+    EXPECT_EQ(a ^ c, FlagsNumeric(0x03B));
+    EXPECT_EQ(b ^ c, FlagsNumeric(0xA5B));
+
+    EXPECT_EQ(a &= b, FlagsNumeric(0x000));
+    EXPECT_EQ(a, FlagsNumeric(0x000));
+    EXPECT_EQ(a |= b, FlagsNumeric(0xA60));
+    EXPECT_EQ(a, FlagsNumeric(0xA60));
+    EXPECT_EQ(a &= c, FlagsNumeric(0x020));
+    EXPECT_EQ(a, FlagsNumeric(0x020));
+    EXPECT_EQ(a ^= b, FlagsNumeric(0xA40));
+    EXPECT_EQ(a, FlagsNumeric(0xA40));
+
+    EXPECT_EQ(b, FlagsNumeric(0xA60));
+    EXPECT_EQ(c, FlagsNumeric(0x03B));
+}
+
+TEST_CASE(operator_shift)
+{
+    ShiftNumeric a = 0x040;
+    EXPECT_EQ(a << ShiftNumeric(0), ShiftNumeric(0x040));
+    EXPECT_EQ(a << ShiftNumeric(1), ShiftNumeric(0x080));
+    EXPECT_EQ(a << ShiftNumeric(2), ShiftNumeric(0x100));
+    EXPECT_EQ(a >> ShiftNumeric(0), ShiftNumeric(0x040));
+    EXPECT_EQ(a >> ShiftNumeric(1), ShiftNumeric(0x020));
+    EXPECT_EQ(a >> ShiftNumeric(2), ShiftNumeric(0x010));
+
+    EXPECT_EQ(a <<= ShiftNumeric(5), ShiftNumeric(0x800));
+    EXPECT_EQ(a, ShiftNumeric(0x800));
+    EXPECT_EQ(a >>= ShiftNumeric(8), ShiftNumeric(0x008));
+    EXPECT_EQ(a, ShiftNumeric(0x008));
+}
+
+TEST_CASE(operator_arith)
+{
+    ArithNumeric a = 12;
+    ArithNumeric b = 345;
+    EXPECT_EQ(a + b, ArithNumeric(357));
+    EXPECT_EQ(b + a, ArithNumeric(357));
+    EXPECT_EQ(a - b, ArithNumeric(-333));
+    EXPECT_EQ(b - a, ArithNumeric(333));
+    EXPECT_EQ(+a, ArithNumeric(12));
+    EXPECT_EQ(-a, ArithNumeric(-12));
+    EXPECT_EQ(a * b, ArithNumeric(4140));
+    EXPECT_EQ(b * a, ArithNumeric(4140));
+    EXPECT_EQ(a / b, ArithNumeric(0));
+    EXPECT_EQ(b / a, ArithNumeric(28));
+    EXPECT_EQ(a % b, ArithNumeric(12));
+    EXPECT_EQ(b % a, ArithNumeric(9));
+
+    EXPECT_EQ(a += a, ArithNumeric(24));
+    EXPECT_EQ(a, ArithNumeric(24));
+    EXPECT_EQ(a *= a, ArithNumeric(576));
+    EXPECT_EQ(a, ArithNumeric(576));
+    EXPECT_EQ(a /= a, ArithNumeric(1));
+    EXPECT_EQ(a, ArithNumeric(1));
+    EXPECT_EQ(a %= a, ArithNumeric(0));
+    EXPECT_EQ(a, ArithNumeric(0));
+}
+
+TEST_CASE(composability)
+{
+    GeneralNumeric a = 0;
+    GeneralNumeric b = 1;
+    // Ident
+    EXPECT_EQ(a == a, true);
+    EXPECT_EQ(a == b, false);
+    // Incr
+    EXPECT_EQ(++a, b);
+    EXPECT_EQ(a--, b);
+    EXPECT_EQ(a == b, false);
+    // Cmp
+    EXPECT_EQ(a < b, true);
+    EXPECT_EQ(a >= b, false);
+    // Bool
+    EXPECT_EQ(!a, true);
+    EXPECT_EQ(a && b, false);
+    EXPECT_EQ(a || b, true);
+    // Flags
+    EXPECT_EQ(a & b, GeneralNumeric(0));
+    EXPECT_EQ(a | b, GeneralNumeric(1));
+    // Shift
+    EXPECT_EQ(b << GeneralNumeric(4), GeneralNumeric(0x10));
+    EXPECT_EQ(b >> b, GeneralNumeric(0));
+    // Arith
+    EXPECT_EQ(-b, GeneralNumeric(-1));
+    EXPECT_EQ(a + b, b);
+    EXPECT_EQ(b * GeneralNumeric(42), GeneralNumeric(42));
+}
+
+/*
+ * FIXME: These `negative_*` tests should cause precisely one compilation error
+ * each, and always for the specified reason. Currently we do not have a harness
+ * for that, so in order to run the test you need to set the #define to 1, compile
+ * it, and check the error messages manually.
+ */
+#define COMPILE_NEGATIVE_TESTS 0
+#if COMPILE_NEGATIVE_TESTS
+TEST_CASE(negative_incr)
+{
+    BareNumeric a = 12;
+    a++;
+    // error: static assertion failed: 'a++' is only available for DistinctNumeric types with 'Incr'.
+}
+
+TEST_CASE(negative_cmp)
+{
+    BareNumeric a = 12;
+    (void)(a < a);
+    // error: static assertion failed: 'a<b' is only available for DistinctNumeric types with 'Cmp'.
+}
+
+TEST_CASE(negative_bool)
+{
+    BareNumeric a = 12;
+    (void)!a;
+    // error: static assertion failed: '!a', 'a&&b', 'a||b' and similar operators are only available for DistinctNumeric types with 'Bool'.
+}
+
+TEST_CASE(negative_flags)
+{
+    BareNumeric a = 12;
+    (void)(a & a);
+    // error: static assertion failed: 'a&b' is only available for DistinctNumeric types with 'Flags'.
+}
+
+TEST_CASE(negative_shift)
+{
+    BareNumeric a = 12;
+    (void)(a << a);
+    // error: static assertion failed: 'a<<b' is only available for DistinctNumeric types with 'Shift'.
+}
+
+TEST_CASE(negative_arith)
+{
+    BareNumeric a = 12;
+    (void)(a + a);
+    // error: static assertion failed: 'a+b' is only available for DistinctNumeric types with 'Arith'.
+}
+
+TEST_CASE(negative_incompatible)
+{
+    GeneralNumeric a = 12;
+    ArithNumeric b = 345;
+    // And this is the entire point of `DistinctNumeric`:
+    // Theoretically, the operation *could* be supported, but we declared those int types incompatible.
+    (void)(a + b);
+    // error: no match for ‘operator+’ (operand types are ‘GeneralNumeric’ {aka ‘AK::DistinctNumeric<int, true, true, true, true, true, true, 64, 64>’} and ‘ArithNumeric’ {aka ‘AK::DistinctNumeric<int, false, false, false, false, false, true, 64, 63>’})
+    //    313 |     (void)(a + b);
+    //        |            ~ ^ ~
+    //        |            |   |
+    //        |            |   DistinctNumeric<[...],false,false,false,false,false,[...],[...],63>
+    //        |            DistinctNumeric<[...],true,true,true,true,true,[...],[...],64>
+}
+#endif /* COMPILE_NEGATIVE_TESTS */
+
+TEST_MAIN(DistinctNumeric)

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -440,7 +440,7 @@ struct SC_stat_params {
 
 struct SC_ptrace_params {
     int request;
-    pid_t pid;
+    pid_t tid;
     Userspace<u8*> addr;
     int data;
 };

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -822,9 +822,9 @@ Optional<KBuffer> procfs$all(InodeIdentifier)
         }
 
         process_object.add("pid", process.pid().value());
-        process_object.add("pgid", process.tty() ? process.tty()->pgid() : 0);
-        process_object.add("pgp", process.pgid());
-        process_object.add("sid", process.sid());
+        process_object.add("pgid", process.tty() ? process.tty()->pgid().value() : 0);
+        process_object.add("pgp", process.pgid().value());
+        process_object.add("sid", process.sid().value());
         process_object.add("uid", process.uid());
         process_object.add("gid", process.gid());
         process_object.add("ppid", process.ppid().value());

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -445,7 +445,7 @@ Optional<KBuffer> procfs$profile(InodeIdentifier)
     KBufferBuilder builder;
 
     JsonObjectSerializer object(builder);
-    object.add("pid", Profiling::pid());
+    object.add("pid", Profiling::pid().value());
     object.add("executable", Profiling::executable_path());
 
     auto array = object.add_array("events");
@@ -453,7 +453,7 @@ Optional<KBuffer> procfs$profile(InodeIdentifier)
     Profiling::for_each_sample([&](auto& sample) {
         auto object = array.add_object();
         object.add("type", "sample");
-        object.add("tid", sample.tid);
+        object.add("tid", sample.tid.value());
         object.add("timestamp", sample.timestamp);
         auto frames_array = object.add_array("stack");
         for (size_t i = 0; i < Profiling::max_stack_frame_count; ++i) {

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -56,7 +56,7 @@ Socket::Socket(int domain, int type, int protocol)
     , m_protocol(protocol)
 {
     auto& process = *Process::current();
-    m_origin = { process.pid(), process.uid(), process.gid() };
+    m_origin = { process.pid().value(), process.uid(), process.gid() };
 }
 
 Socket::~Socket()
@@ -83,7 +83,7 @@ RefPtr<Socket> Socket::accept()
     auto client = m_pending.take_first();
     ASSERT(!client->is_connected());
     auto& process = *Process::current();
-    client->m_acceptor = { process.pid(), process.uid(), process.gid() };
+    client->m_acceptor = { process.pid().value(), process.uid(), process.gid() };
     client->m_connected = true;
     client->m_role = Role::Accepted;
     return client;

--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -94,12 +94,12 @@ PerformanceEvent& PerformanceEventBuffer::at(size_t index)
     return events[index];
 }
 
-KBuffer PerformanceEventBuffer::to_json(pid_t pid, const String& executable_path) const
+KBuffer PerformanceEventBuffer::to_json(ProcessID pid, const String& executable_path) const
 {
     KBufferBuilder builder;
 
     JsonObjectSerializer object(builder);
-    object.add("pid", pid);
+    object.add("pid", pid.value());
     object.add("executable", executable_path);
 
     auto array = object.add_array("events");

--- a/Kernel/PerformanceEventBuffer.h
+++ b/Kernel/PerformanceEventBuffer.h
@@ -68,7 +68,7 @@ public:
         return const_cast<PerformanceEventBuffer&>(*this).at(index);
     }
 
-    KBuffer to_json(pid_t, const String& executable_path) const;
+    KBuffer to_json(ProcessID, const String& executable_path) const;
 
 private:
     PerformanceEvent& at(size_t index);

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -834,7 +834,7 @@ KBuffer Process::backtrace() const
 {
     KBufferBuilder builder;
     for_each_thread([&](Thread& thread) {
-        builder.appendf("Thread %d (%s):\n", thread.tid(), thread.name().characters());
+        builder.appendf("Thread %d (%s):\n", thread.tid().value(), thread.name().characters());
         builder.append(thread.backtrace());
         return IterationDecision::Continue;
     });

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -100,7 +100,8 @@ ProcessID Process::allocate_pid()
     // Overflow is UB, and negative PIDs wreck havoc.
     // TODO: Handle PID overflow
     // For example: Use an Atomic<u32>, mask the most significant bit,
-    // retry if PID is already taken as a PID, taken as a TID, or zero.
+    // retry if PID is already taken as a PID, taken as a TID,
+    // takes as a PGID, taken as a SID, or zero.
     return next_pid.fetch_add(1, AK::MemoryOrder::memory_order_acq_rel);
 }
 

--- a/Kernel/Profiling.cpp
+++ b/Kernel/Profiling.cpp
@@ -40,7 +40,7 @@ namespace Profiling {
 static KBufferImpl* s_profiling_buffer;
 static size_t s_slot_count;
 static size_t s_next_slot_index;
-static u32 s_pid;
+static ProcessID s_pid { -1 };
 
 String& executable_path()
 {
@@ -50,7 +50,7 @@ String& executable_path()
     return *path;
 }
 
-u32 pid()
+ProcessID pid()
 {
     return s_pid;
 }
@@ -61,7 +61,7 @@ void start(Process& process)
         executable_path() = process.executable()->absolute_path().impl();
     else
         executable_path() = {};
-    s_pid = process.pid().value(); // FIXME: PID/TID INCOMPLETE
+    s_pid = process.pid();
 
     if (!s_profiling_buffer) {
         s_profiling_buffer = RefPtr<KBufferImpl>(KBuffer::create_with_size(8 * MB).impl()).leak_ref();
@@ -87,6 +87,7 @@ Sample& next_sample_slot()
 
 void stop()
 {
+    // FIXME: This probably shouldn't be empty.
 }
 
 void did_exec(const String& new_executable_path)

--- a/Kernel/Profiling.cpp
+++ b/Kernel/Profiling.cpp
@@ -61,7 +61,7 @@ void start(Process& process)
         executable_path() = process.executable()->absolute_path().impl();
     else
         executable_path() = {};
-    s_pid = process.pid();
+    s_pid = process.pid().value(); // FIXME: PID/TID INCOMPLETE
 
     if (!s_profiling_buffer) {
         s_profiling_buffer = RefPtr<KBufferImpl>(KBuffer::create_with_size(8 * MB).impl()).leak_ref();

--- a/Kernel/Profiling.h
+++ b/Kernel/Profiling.h
@@ -39,13 +39,13 @@ namespace Profiling {
 constexpr size_t max_stack_frame_count = 50;
 
 struct Sample {
-    i32 pid;
-    i32 tid;
+    ProcessID pid;
+    ThreadID tid;
     u64 timestamp;
     u32 frames[max_stack_frame_count];
 };
 
-extern u32 pid();
+extern ProcessID pid();
 extern String& executable_path();
 
 Sample& next_sample_slot();

--- a/Kernel/Ptrace.cpp
+++ b/Kernel/Ptrace.cpp
@@ -43,13 +43,17 @@ KResultOr<u32> handle_syscall(const Kernel::Syscall::SC_ptrace_params& params, P
         return KSuccess;
     }
 
-    if (params.pid == caller.pid().value())
+    // FIXME: PID/TID BUG
+    // This bug allows to request PT_ATTACH (or anything else) the same process, as
+    // long it is not the main thread. Alternatively, if this is desired, then the
+    // bug is that this prevents PT_ATTACH to the main thread from another thread.
+    if (params.tid == caller.pid().value())
         return KResult(-EINVAL);
 
     Thread* peer = nullptr;
     {
         InterruptDisabler disabler;
-        peer = Thread::from_tid(params.pid);
+        peer = Thread::from_tid(params.tid);
     }
     if (!peer)
         return KResult(-ESRCH);

--- a/Kernel/Ptrace.cpp
+++ b/Kernel/Ptrace.cpp
@@ -43,7 +43,7 @@ KResultOr<u32> handle_syscall(const Kernel::Syscall::SC_ptrace_params& params, P
         return KSuccess;
     }
 
-    if (params.pid == caller.pid())
+    if (params.pid == caller.pid().value())
         return KResult(-EINVAL);
 
     Thread* peer = nullptr;

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -684,9 +684,8 @@ void Scheduler::timer_tick(const RegisterState& regs)
         SmapDisabler disabler;
         auto backtrace = current_thread->raw_backtrace(regs.ebp, regs.eip);
         auto& sample = Profiling::next_sample_slot();
-        // FIXME: PID/TID INCOMPLETE
-        sample.pid = current_thread->process().pid().value();
-        sample.tid = current_thread->tid().value();
+        sample.pid = current_thread->process().pid();
+        sample.tid = current_thread->tid();
         sample.timestamp = g_uptime;
         for (size_t i = 0; i < min(backtrace.size(), Profiling::max_stack_frame_count); ++i) {
             sample.frames[i] = backtrace[i];

--- a/Kernel/SharedBuffer.cpp
+++ b/Kernel/SharedBuffer.cpp
@@ -48,13 +48,13 @@ void SharedBuffer::sanity_check(const char* what)
     if (found_refs != m_total_refs) {
         dbg() << what << " sanity -- SharedBuffer{" << this << "} id: " << m_shbuf_id << " has total refs " << m_total_refs << " but we found " << found_refs;
         for (const auto& ref : m_refs) {
-            dbg() << "    ref from pid " << ref.pid << ": refcnt " << ref.count;
+            dbg() << "    ref from pid " << ref.pid.value() << ": refcnt " << ref.count;
         }
         ASSERT_NOT_REACHED();
     }
 }
 
-bool SharedBuffer::is_shared_with(pid_t peer_pid) const
+bool SharedBuffer::is_shared_with(ProcessID peer_pid) const
 {
     LOCKER(shared_buffers().lock(), Lock::Mode::Shared);
     if (m_global)
@@ -102,7 +102,7 @@ void* SharedBuffer::ref_for_process_and_get_address(Process& process)
     ASSERT_NOT_REACHED();
 }
 
-void SharedBuffer::share_with(pid_t peer_pid)
+void SharedBuffer::share_with(ProcessID peer_pid)
 {
     LOCKER(shared_buffers().lock());
     if (m_global)
@@ -146,7 +146,7 @@ void SharedBuffer::deref_for_process(Process& process)
     ASSERT_NOT_REACHED();
 }
 
-void SharedBuffer::disown(pid_t pid)
+void SharedBuffer::disown(ProcessID pid)
 {
     LOCKER(shared_buffers().lock());
     for (size_t i = 0; i < m_refs.size(); ++i) {

--- a/Kernel/SharedBuffer.h
+++ b/Kernel/SharedBuffer.h
@@ -36,12 +36,12 @@ namespace Kernel {
 class SharedBuffer {
 private:
     struct Reference {
-        Reference(pid_t pid)
+        Reference(ProcessID pid)
             : pid(pid)
         {
         }
 
-        pid_t pid;
+        ProcessID pid;
         unsigned count { 0 };
         WeakPtr<Region> region;
     };
@@ -64,12 +64,12 @@ public:
     }
 
     void sanity_check(const char* what);
-    bool is_shared_with(pid_t peer_pid) const;
+    bool is_shared_with(ProcessID peer_pid) const;
     void* ref_for_process_and_get_address(Process& process);
-    void share_with(pid_t peer_pid);
+    void share_with(ProcessID peer_pid);
     void share_globally() { m_global = true; }
     void deref_for_process(Process& process);
-    void disown(pid_t pid);
+    void disown(ProcessID pid);
     size_t size() const { return m_vmobject->size(); }
     void destroy_if_unused();
     void seal();

--- a/Kernel/Syscalls/disown.cpp
+++ b/Kernel/Syscalls/disown.cpp
@@ -28,7 +28,7 @@
 
 namespace Kernel {
 
-int Process::sys$disown(pid_t pid)
+int Process::sys$disown(ProcessID pid)
 {
     REQUIRE_PROMISE(proc);
     auto process = Process::from_pid(pid);

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -282,7 +282,7 @@ int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Ve
     m_master_tls_size = master_tls_size;
     m_master_tls_alignment = master_tls_alignment;
 
-    // FIXME: PID/TID BUG
+    // FIXME: PID/TID ISSUE
     m_pid = new_main_thread->tid().value();
     new_main_thread->make_thread_specific_region({});
     new_main_thread->reset_fpu_state();

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -282,7 +282,8 @@ int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Ve
     m_master_tls_size = master_tls_size;
     m_master_tls_alignment = master_tls_alignment;
 
-    m_pid = new_main_thread->tid();
+    // FIXME: PID/TID BUG
+    m_pid = new_main_thread->tid().value();
     new_main_thread->make_thread_specific_region({});
     new_main_thread->reset_fpu_state();
 
@@ -296,7 +297,7 @@ int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Ve
     tss.eip = m_entry_eip;
     tss.esp = new_userspace_esp;
     tss.cr3 = m_page_directory->cr3();
-    tss.ss2 = m_pid;
+    tss.ss2 = m_pid.value();
 
     if (was_profiling)
         Profiling::did_exec(path);

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -95,7 +95,7 @@ pid_t Process::sys$fork(RegisterState& regs)
     }
 
     child_first_thread->set_state(Thread::State::Skip1SchedulerPass);
-    return child->pid();
+    return child->pid().value();
 }
 
 }

--- a/Kernel/Syscalls/kill.cpp
+++ b/Kernel/Syscalls/kill.cpp
@@ -52,7 +52,8 @@ KResult Process::do_killpg(pid_t pgrp, int signal)
     // Send the signal to all processes in the given group.
     if (pgrp == 0) {
         // Send the signal to our own pgrp.
-        pgrp = pgid();
+        // FIXME: PIF/PGID INCOMPLETE
+        pgrp = pgid().value();
     }
 
     bool group_was_empty = true;

--- a/Kernel/Syscalls/kill.cpp
+++ b/Kernel/Syscalls/kill.cpp
@@ -43,7 +43,7 @@ KResult Process::do_kill(Process& process, int signal)
     return KSuccess;
 }
 
-KResult Process::do_killpg(pid_t pgrp, int signal)
+KResult Process::do_killpg(ProcessGroupID pgrp, int signal)
 {
     InterruptDisabler disabler;
 
@@ -52,8 +52,7 @@ KResult Process::do_killpg(pid_t pgrp, int signal)
     // Send the signal to all processes in the given group.
     if (pgrp == 0) {
         // Send the signal to our own pgrp.
-        // FIXME: PIF/PGID INCOMPLETE
-        pgrp = pgid().value();
+        pgrp = pgid();
     }
 
     bool group_was_empty = true;

--- a/Kernel/Syscalls/process.cpp
+++ b/Kernel/Syscalls/process.cpp
@@ -32,13 +32,13 @@ namespace Kernel {
 pid_t Process::sys$getpid()
 {
     REQUIRE_PROMISE(stdio);
-    return m_pid;
+    return m_pid.value();
 }
 
 pid_t Process::sys$getppid()
 {
     REQUIRE_PROMISE(stdio);
-    return m_ppid;
+    return m_ppid.value();
 }
 
 int Process::sys$set_process_icon(int icon_id)

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -44,7 +44,10 @@ int Process::sys$ptrace(Userspace<const Syscall::SC_ptrace_params*> user_params)
     return result.is_error() ? result.error() : result.value();
 }
 
-bool Process::has_tracee_thread(int tracer_pid) const
+/**
+ * "Does this process have a thread that is currently being traced by the provided process?"
+ */
+bool Process::has_tracee_thread(ProcessID tracer_pid) const
 {
     bool has_tracee = false;
 

--- a/Kernel/Syscalls/shbuf.cpp
+++ b/Kernel/Syscalls/shbuf.cpp
@@ -70,7 +70,7 @@ int Process::sys$shbuf_create(int size, void** buffer)
 int Process::sys$shbuf_allow_pid(int shbuf_id, pid_t peer_pid)
 {
     REQUIRE_PROMISE(shared_buffer);
-    if (!peer_pid || peer_pid < 0 || peer_pid == m_pid)
+    if (!peer_pid || peer_pid < 0 || ProcessID(peer_pid) == m_pid)
         return -EINVAL;
     LOCKER(shared_buffers().lock());
     auto it = shared_buffers().resource().find(shbuf_id);

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -87,7 +87,7 @@ int Process::sys$create_thread(void* (*entry)(void*), Userspace<const Syscall::S
 
     thread->make_thread_specific_region({});
     thread->set_state(Thread::State::Runnable);
-    return thread->tid();
+    return thread->tid().value();
 }
 
 void Process::sys$exit_thread(void* exit_value)
@@ -212,7 +212,7 @@ int Process::sys$get_thread_name(int tid, char* buffer, size_t buffer_size)
 int Process::sys$gettid()
 {
     REQUIRE_PROMISE(stdio);
-    return Thread::current()->tid();
+    return Thread::current()->tid().value();
 }
 
 }

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -73,7 +73,7 @@ int Process::sys$create_thread(void* (*entry)(void*), Userspace<const Syscall::S
     // length + 4 to give space for our extra junk at the end
     StringBuilder builder(m_name.length() + 4);
     builder.append(m_name);
-    builder.appendf("[%d]", thread->tid());
+    builder.appendf("[%d]", thread->tid().value());
     thread->set_name(builder.to_string());
 
     thread->set_priority(requested_thread_priority);
@@ -102,7 +102,7 @@ void Process::sys$exit_thread(void* exit_value)
     ASSERT_NOT_REACHED();
 }
 
-int Process::sys$detach_thread(int tid)
+int Process::sys$detach_thread(pid_t tid)
 {
     REQUIRE_PROMISE(thread);
     InterruptDisabler disabler;
@@ -117,7 +117,7 @@ int Process::sys$detach_thread(int tid)
     return 0;
 }
 
-int Process::sys$join_thread(int tid, void** exit_value)
+int Process::sys$join_thread(pid_t tid, void** exit_value)
 {
     REQUIRE_PROMISE(thread);
     if (exit_value && !validate_write_typed(exit_value))
@@ -169,7 +169,7 @@ int Process::sys$join_thread(int tid, void** exit_value)
     return 0;
 }
 
-int Process::sys$set_thread_name(int tid, const char* user_name, size_t user_name_length)
+int Process::sys$set_thread_name(pid_t tid, const char* user_name, size_t user_name_length)
 {
     REQUIRE_PROMISE(thread);
     auto name = validate_and_copy_string_from_user(user_name, user_name_length);
@@ -188,7 +188,7 @@ int Process::sys$set_thread_name(int tid, const char* user_name, size_t user_nam
     thread->set_name(name);
     return 0;
 }
-int Process::sys$get_thread_name(int tid, char* buffer, size_t buffer_size)
+int Process::sys$get_thread_name(pid_t tid, char* buffer, size_t buffer_size)
 {
     REQUIRE_PROMISE(thread);
     if (buffer_size == 0)

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -50,7 +50,7 @@ public:
     unsigned short rows() const { return m_rows; }
     unsigned short columns() const { return m_columns; }
 
-    pid_t pgid() const;
+    ProcessGroupID pgid() const;
 
     void set_termios(const termios&);
     bool should_generate_signals() const { return m_termios.c_lflag & ISIG; }

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -82,7 +82,7 @@ public:
     explicit Thread(NonnullRefPtr<Process>);
     ~Thread();
 
-    static Thread* from_tid(pid_t);
+    static Thread* from_tid(ThreadID);
     static void finalize_dying_threads();
 
     ThreadID tid() const { return m_tid; }

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -82,11 +82,11 @@ public:
     explicit Thread(NonnullRefPtr<Process>);
     ~Thread();
 
-    static Thread* from_tid(int);
+    static Thread* from_tid(pid_t);
     static void finalize_dying_threads();
 
-    int tid() const { return m_tid; }
-    int pid() const;
+    ThreadID tid() const { return m_tid; }
+    ProcessID pid() const;
 
     void set_priority(u32 p) { m_priority = p; }
     u32 priority() const { return m_priority; }
@@ -236,13 +236,13 @@ public:
 
     class WaitBlocker final : public Blocker {
     public:
-        WaitBlocker(int wait_options, pid_t& waitee_pid);
+        WaitBlocker(int wait_options, ProcessID& waitee_pid);
         virtual bool should_unblock(Thread&) override;
         virtual const char* state_string() const override { return "Waiting"; }
 
     private:
         int m_wait_options { 0 };
-        pid_t& m_waitee_pid;
+        ProcessID& m_waitee_pid;
     };
 
     class SemiPermanentBlocker final : public Blocker {
@@ -512,7 +512,7 @@ public:
     static constexpr u32 default_userspace_stack_size = 4 * MB;
 
     ThreadTracer* tracer() { return m_tracer.ptr(); }
-    void start_tracing_from(pid_t tracer);
+    void start_tracing_from(ProcessID tracer);
     void stop_tracing();
     void tracer_trap(const RegisterState&);
 
@@ -533,7 +533,7 @@ private:
 
     mutable RecursiveSpinLock m_lock;
     NonnullRefPtr<Process> m_process;
-    int m_tid { -1 };
+    ThreadID m_tid { -1 };
     TSS32 m_tss;
     Atomic<u32> m_cpu { 0 };
     u32 m_cpu_affinity { THREAD_AFFINITY_DEFAULT };

--- a/Kernel/ThreadTracer.cpp
+++ b/Kernel/ThreadTracer.cpp
@@ -32,7 +32,7 @@
 
 namespace Kernel {
 
-ThreadTracer::ThreadTracer(pid_t tracer_pid)
+ThreadTracer::ThreadTracer(ProcessID tracer_pid)
     : m_tracer_pid(tracer_pid)
 {
 }

--- a/Kernel/ThreadTracer.h
+++ b/Kernel/ThreadTracer.h
@@ -35,9 +35,9 @@ namespace Kernel {
 
 class ThreadTracer {
 public:
-    static NonnullOwnPtr<ThreadTracer> create(pid_t tracer) { return make<ThreadTracer>(tracer); }
+    static NonnullOwnPtr<ThreadTracer> create(ProcessID tracer) { return make<ThreadTracer>(tracer); }
 
-    pid_t tracer_pid() const { return m_tracer_pid; }
+    ProcessID tracer_pid() const { return m_tracer_pid; }
     bool has_pending_signal(u32 signal) const { return m_pending_signals & (1 << (signal - 1)); }
     void set_signal(u32 signal) { m_pending_signals |= (1 << (signal - 1)); }
     void unset_signal(u32 signal) { m_pending_signals &= ~(1 << (signal - 1)); }
@@ -54,10 +54,10 @@ public:
         return m_regs.value();
     }
 
-    explicit ThreadTracer(pid_t);
+    explicit ThreadTracer(ProcessID);
 
 private:
-    pid_t m_tracer_pid { -1 };
+    ProcessID m_tracer_pid { -1 };
 
     // This is a bitmap for signals that are sent from the tracer to the tracee
     // TODO: Since we do not currently support sending signals

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/DistinctNumeric.h>
 #include <AK/Types.h>
 
 #define O_RDONLY (1 << 0)
@@ -320,6 +321,11 @@ typedef u32 gid_t;
 typedef u32 clock_t;
 typedef u32 socklen_t;
 typedef int pid_t;
+// Avoid interference with AK/Types.h and LibC/sys/types.h by defining *separate* names:
+TYPEDEF_DISTINCT_ORDERED_ID(pid_t, ProcessID);
+TYPEDEF_DISTINCT_ORDERED_ID(pid_t, ThreadID);
+TYPEDEF_DISTINCT_ORDERED_ID(pid_t, SessionID);
+TYPEDEF_DISTINCT_ORDERED_ID(pid_t, ProcessGroupID);
 
 struct tms {
     clock_t tms_utime;

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -336,7 +336,7 @@ void init_stage2()
     tty0->set_graphical(!text_mode);
     Thread* thread = nullptr;
     auto userspace_init = kernel_command_line().lookup("init").value_or("/bin/SystemServer");
-    Process::create_user_process(thread, userspace_init, (uid_t)0, (gid_t)0, (pid_t)0, error, {}, {}, tty0);
+    Process::create_user_process(thread, userspace_init, (uid_t)0, (gid_t)0, ProcessID(0), error, {}, {}, tty0);
     if (error != 0) {
         klog() << "init_stage2: error spawning SystemServer: " << error;
         Processor::halt();

--- a/Libraries/LibC/serenity.cpp
+++ b/Libraries/LibC/serenity.cpp
@@ -60,13 +60,13 @@ int profiling_disable(pid_t pid)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-int set_thread_boost(int tid, int amount)
+int set_thread_boost(pid_t tid, int amount)
 {
     int rc = syscall(SC_set_thread_boost, tid, amount);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-int set_process_boost(int tid, int amount)
+int set_process_boost(pid_t tid, int amount)
 {
     int rc = syscall(SC_set_process_boost, tid, amount);
     __RETURN_WITH_ERRNO(rc, rc, -1);
@@ -136,5 +136,4 @@ int get_stack_bounds(uintptr_t* user_stack_base, size_t* user_stack_size)
     int rc = syscall(SC_get_stack_bounds, user_stack_base, user_stack_size);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
-
 }

--- a/Libraries/LibC/serenity.h
+++ b/Libraries/LibC/serenity.h
@@ -52,7 +52,7 @@ int profiling_disable(pid_t);
 #define THREAD_PRIORITY_HIGH 50
 #define THREAD_PRIORITY_MAX 99
 
-int set_thread_boost(int tid, int amount);
+int set_thread_boost(pid_t tid, int amount);
 int set_process_boost(pid_t, int amount);
 
 #define FUTEX_WAIT 1

--- a/Libraries/LibC/sys/ptrace.cpp
+++ b/Libraries/LibC/sys/ptrace.cpp
@@ -31,7 +31,7 @@
 
 extern "C" {
 
-int ptrace(int request, pid_t pid, void* addr, int data)
+int ptrace(int request, pid_t tid, void* addr, int data)
 {
 
     // PT_PEEK needs special handling since the syscall wrapper
@@ -49,7 +49,7 @@ int ptrace(int request, pid_t pid, void* addr, int data)
 
     Syscall::SC_ptrace_params params {
         request,
-        pid,
+        tid,
         reinterpret_cast<u8*>(addr),
         data
     };

--- a/Libraries/LibC/sys/ptrace.h
+++ b/Libraries/LibC/sys/ptrace.h
@@ -40,6 +40,9 @@ __BEGIN_DECLS
 #define PT_POKE 8
 #define PT_SETREGS 9
 
-int ptrace(int request, pid_t pid, void* addr, int data);
+// FIXME: PID/TID ISSUE
+// Affects the entirety of LibDebug and Userland/strace.cpp.
+// See also Kernel/Ptrace.cpp
+int ptrace(int request, pid_t tid, void* addr, int data);
 
 __END_DECLS

--- a/Libraries/LibCore/ProcessStatisticsReader.h
+++ b/Libraries/LibCore/ProcessStatisticsReader.h
@@ -33,7 +33,7 @@
 namespace Core {
 
 struct ThreadStatistics {
-    int tid;
+    pid_t tid;
     unsigned times_scheduled;
     unsigned ticks;
     unsigned syscall_count;

--- a/Libraries/LibThread/Lock.h
+++ b/Libraries/LibThread/Lock.h
@@ -44,7 +44,7 @@ public:
     void unlock();
 
 private:
-    Atomic<int> m_holder { 0 };
+    Atomic<pid_t> m_holder { 0 };
     u32 m_level { 0 };
 };
 
@@ -65,14 +65,14 @@ private:
 
 ALWAYS_INLINE void Lock::lock()
 {
-    int tid = gettid();
+    pid_t tid = gettid();
     if (m_holder == tid) {
         ++m_level;
         return;
     }
     for (;;) {
         int expected = 0;
-        if (m_holder.compare_exchange_strong(expected, tid, AK::memory_order_acq_rel)) {            
+        if (m_holder.compare_exchange_strong(expected, tid, AK::memory_order_acq_rel)) {
             m_level = 1;
             return;
         }

--- a/Userland/Tests/Kernel/CMakeLists.txt
+++ b/Userland/Tests/Kernel/CMakeLists.txt
@@ -8,6 +8,7 @@ foreach(CMD_SRC ${CMD_SOURCES})
 endforeach()
 
 target_link_libraries(elf-execve-mmap-race LibPthread)
+target_link_libraries(kill-pidtid-confusion LibPthread)
 target_link_libraries(nanosleep-race-outbuf-munmap LibPthread)
 target_link_libraries(null-deref-close-during-select LibPthread)
 target_link_libraries(null-deref-crash-during-pthread_join LibPthread)

--- a/Userland/Tests/Kernel/kill-pidtid-confusion.cpp
+++ b/Userland/Tests/Kernel/kill-pidtid-confusion.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Assertions.h>
+#include <AK/LogStream.h>
+#include <LibPthread/pthread.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+/*
+ * Bug:
+ * If the main thread of a process is no longer alive, it cannot receive
+ * signals anymore. This can manifest as, for example, an unkillable process.
+ *
+ * So what needs to happen:
+ * - There is process P
+ * - It has more than one thread
+ * - The main thread calls thread_exit(), leaving the rest of the threads alive
+ * - Now the process is unkillable!
+ *
+ * Here's how to demonstrate the bug:
+ * - Time 0: PX forks into PZ (mnemonic: Zombie)
+ * - Time 1: PZ's main thread T1 creates a new thread T2
+ * - Time 2: Nothing (T2 could communicate to PX both process and thread ID)
+ *      (most LibC functions crash currently, which is a different bug I suppose.)
+ * - Time 3: T1 calls thread_exit()
+ * - Time 4:
+ *      * PX tries to kill PZ (should work, but doesn't)
+ *      * PX tries to kill PZ using T2's thread ID (shouldn't work, and doesn't)
+ *      * PX outputs all results.
+ */
+
+static constexpr useconds_t STEP_SIZE = 1100000;
+
+static void fork_into(void(fn)())
+{
+    const pid_t rc = fork();
+    if (rc < 0) {
+        perror("fork");
+        exit(1);
+    }
+    if (rc > 0) {
+        return;
+    }
+    fn();
+    dbg() << "child finished (?)";
+    exit(1);
+}
+
+static void thread_into(void* (*fn)(void*))
+{
+    pthread_t tid;
+    const int rc = pthread_create(&tid, nullptr, fn, nullptr);
+    if (rc < 0) {
+        perror("pthread_create");
+        exit(1);
+    }
+}
+
+static void sleep_steps(useconds_t steps)
+{
+    const int rc = usleep(steps * STEP_SIZE);
+    if (rc < 0) {
+        perror("usleep");
+        ASSERT_NOT_REACHED();
+    }
+}
+
+static bool try_kill(pid_t kill_id)
+{
+    int rc = kill(kill_id, SIGTERM);
+    perror("kill");
+    printf("kill rc: %d\n", rc);
+    return rc >= 0;
+}
+
+static void run_pz();
+static void* run_pz_t2_wrap(void* fd_ptr);
+static void run_pz_t2();
+
+int main(int, char**)
+{
+    // This entire function is the entirety of process PX.
+
+    // Time 0: PX forks into PZ (mnemonic: Zombie)
+    dbg() << "PX forks into PZ";
+    fork_into(run_pz);
+    sleep_steps(4);
+
+    // Time 4:
+    dbg() << "Let's hope everything went fine!";
+    pid_t guessed_pid = getpid() + 1;
+    pid_t guessed_tid = guessed_pid + 1;
+    printf("About to kill PID %d, TID %d.\n", guessed_pid, guessed_tid);
+    if (try_kill(guessed_tid)) {
+        printf("FAIL, could kill a thread\n");
+        exit(1);
+    }
+    if (!try_kill(guessed_pid)) {
+        printf("FAIL, could not kill the process\n");
+        exit(1);
+    }
+
+    printf("PASS\n");
+    return 0;
+}
+
+static void run_pz()
+{
+    // Time 0: PX forks into PZ (mnemonic: Zombie)
+    sleep_steps(1);
+
+    // Time 1: PZ's main thread T1 creates a new thread T2
+    dbg() << "PZ calls pthread_create";
+    thread_into(run_pz_t2_wrap);
+    sleep_steps(2);
+
+    // Time 3: T1 calls thread_exit()
+    dbg() << "PZ(T1) calls thread_exit";
+    pthread_exit(nullptr);
+    ASSERT_NOT_REACHED();
+}
+
+static void* run_pz_t2_wrap(void*)
+{
+    run_pz_t2();
+    exit(1);
+}
+
+static void run_pz_t2()
+{
+    // Time 1: PZ's main thread T1 creates a new thread T2
+    sleep_steps(1);
+
+    // Time 2: Nothing
+    // FIXME: For some reason, both printf() and dbg() crash.
+    // This also prevents us from using a pipe to communicate to PX both process and thread ID
+    // dbg() << "T2: I'm alive and well.";
+    sleep_steps(18);
+
+    // Time 20: Cleanup
+    printf("PZ(T2) dies from boredom.\n");
+    exit(0);
+}

--- a/Userland/Tests/Kernel/setpgid-across-sessions-without-leader.cpp
+++ b/Userland/Tests/Kernel/setpgid-across-sessions-without-leader.cpp
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Assertions.h>
+#include <AK/LogStream.h>
+#include <fcntl.h>
+#include <serenity.h>
+#include <stdio.h>
+#include <unistd.h>
+
+/*
+ * Bug:
+ * A process can join a process group across sessions if both process groups
+ * do not have a leader (anymore). This can be used to join a session
+ * illegitimately. (Or, more harmlessly, to change the own PGID to an unused
+ * but arbitrary one, for example the PGID 0xDEADBEEF or the one that's going
+ * to be your program's session ID in the short-term future.)
+ *
+ * So what needs to happen:
+ * - There is session SA
+ * - There is session SB
+ * - There is a Process Group PGA in SA
+ * - There is a Process Group PGB in SB
+ * - PGA does not have a leader
+ * - PGB does not have a leader
+ * - There is a Process PA2 in PGA
+ * - There is a Process PB2 in PGB
+ * - PA2 calls setpgid(0, PGB)
+ * - Now PA2 and PB2 are in the same processgroup, but not in the same session. WHAAAAT! :^)
+ *
+ * Here's how to demonstrate the bug:
+ * - Time 0: PX forks into PA1
+ * - Time 1: PA1 creates a new session (SA) and pgrp (PGA)
+ * - Time 2: PA1 forks into PA2
+ * - Time 3: PA1 dies (PGA now has no leader)
+ *     Note: PA2 never dies. Too much hassle.
+ * - Time 4: PX forks into PB1
+ * - Time 5: PB1 creates a new session (SB) and pgrp (PGB)
+ * - Time 6: PB1 forks into PB2
+ * - Time 7: PB1 dies (PGB now has no leader)
+ * - Time 8: PB2 calls pgrp(0, PGA)
+ *     Note: PB2 writes "1" (exploit successfull) or "0" (bug is fixed) to a pipe
+ * - Time 9: If PX hasn't received any message yet through the pipe, it declares the test as failed (for lack of knowledge). Otherwise, it outputs accordingly.
+ */
+
+static constexpr useconds_t STEP_SIZE = 1100000;
+
+static void fork_into(void (*fn)(void*), void* arg)
+{
+    const pid_t rc = fork();
+    if (rc < 0) {
+        perror("fork");
+        exit(1);
+    }
+    if (rc > 0) {
+        const int disown_rc = disown(rc);
+        if (disown_rc < 0) {
+            perror("disown");
+            dbg() << "This might cause PA1 to remain in the Zombie state, "
+                     "and thus in the process list, meaning the leader is "
+                     "still 'alive' for the purpose of lookup.";
+        }
+        return;
+    }
+    fn(arg);
+    dbg() << "child finished (?)";
+    exit(1);
+}
+
+static void sleep_steps(useconds_t steps)
+{
+    const int rc = usleep(steps * STEP_SIZE);
+    if (rc < 0) {
+        perror("usleep");
+        ASSERT_NOT_REACHED();
+    }
+}
+
+static void run_pa1(void*);
+static void run_pa2(void*);
+static void run_pb1(void*);
+static void run_pb2(void*);
+
+int main(int, char**)
+{
+    // This entire function is the entirety of process PX.
+
+    // Time 0: PX forks into PA1
+    int fds[2];
+    // Serenity doesn't support O_NONBLOCK for pipes yet, so
+    // sadly the test will hang if something goes wrong.
+    if (pipe2(fds, 0) < 0) {
+        perror("pipe");
+        exit(1);
+    }
+    dbg() << "PX starts with SID=" << getsid(0) << ", PGID=" << getpgid(0) << ", PID=" << getpid() << ".";
+    dbg() << "PX forks into PA1";
+    fork_into(run_pa1, nullptr);
+    sleep_steps(4);
+
+    // Time 4: PX forks into PB1
+    dbg() << "PX forks into PB1";
+    fork_into(run_pb1, &(fds[1]));
+    sleep_steps(5);
+
+    // Time 9: If PX hasn't received any message yet through the pipe, it declares
+    // the test as failed (for lack of knowledge). Otherwise, it outputs accordingly.
+    dbg() << "PX reads from pipe";
+    unsigned char buf = 42;
+    ssize_t rc = read(fds[0], &buf, 1);
+    if (rc == 0) {
+        // In fact, we only reach this branch when *all* processes have died,
+        // including this one. So … should be unreachable.
+        printf("DOUBLE FAIL: pipe is closed, but we still have it open.\n"
+               "See debug log, some process probably crashed.\n");
+        exit(1);
+    }
+    if (rc < 0) {
+        if (errno == EAGAIN) {
+            printf("FAIL: pipe has no data. See debug log, some process os probably hanging.\n");
+        } else {
+            perror("read (unknown)");
+        }
+        exit(1);
+    }
+    ASSERT(rc == 1);
+    if (buf == 0) {
+        printf("PASS\n");
+        return 0;
+    }
+    if (buf == 1) {
+        printf("FAIL (exploit successful)\n");
+        return 1;
+    }
+    printf("FAIL, for some reason %c\n", buf);
+
+    return 1;
+}
+
+static void run_pa1(void*)
+{
+    // Time 0: PX forks into PA1
+    sleep_steps(1);
+
+    // Time 1: PA1 creates a new session (SA) and pgrp (PGA)
+    dbg() << "PA1 starts with SID=" << getsid(0) << ", PGID=" << getpgid(0) << ", PID=" << getpid() << ".";
+    dbg() << "PA1 calls setsid()";
+    int rc = setsid();
+    if (rc < 0) {
+        perror("setsid (PA)");
+        ASSERT_NOT_REACHED();
+    }
+    dbg() << "PA1 did setsid() -> PGA=" << rc << ", SA=" << getsid(0) << ", yay!";
+    sleep_steps(1);
+
+    // Time 2: PA1 forks into PA2
+    dbg() << "PA1 forks into PA2";
+    fork_into(run_pa2, nullptr);
+    sleep_steps(1);
+
+    // Time 3: PA1 dies (PGA now has no leader)
+    dbg() << "PA1 dies. You should see a 'Reaped unparented process' "
+             "message with my ID next, OR THIS TEST IS MEANINGLESS "
+             "(see fork_into()).";
+    exit(0);
+}
+
+static void run_pa2(void*)
+{
+    // Time 2: PA1 forks into PA2
+    dbg() << "PA2 starts with SID=" << getsid(0) << ", PGID=" << getpgid(0) << ", PID=" << getpid() << ".";
+    sleep_steps(18);
+
+    // pa_2 never *does* anything.
+    dbg() << "PA2 dies from boredom.";
+    exit(1);
+}
+
+static void run_pb1(void* pipe_fd_ptr)
+{
+    // Time 4: PX forks into PB1
+    sleep_steps(1);
+
+    // Time 5: PB1 creates a new session (SB) and pgrp (PGB)
+    dbg() << "PB1 starts with SID=" << getsid(0) << ", PGID=" << getpgid(0) << ", PID=" << getpid() << ".";
+    dbg() << "PB1 calls setsid()";
+    int rc = setsid();
+    if (rc < 0) {
+        perror("setsid (PB)");
+        ASSERT_NOT_REACHED();
+    }
+    dbg() << "PB1 did setsid() -> PGB=" << rc << ", SB=" << getsid(0) << ", yay!";
+    sleep_steps(1);
+
+    // Time 6: PB1 forks into PB2
+    dbg() << "PB1 forks into PB2";
+    fork_into(run_pb2, pipe_fd_ptr);
+    sleep_steps(1);
+
+    // Time 7: PB1 dies (PGB now has no leader)
+    dbg() << "PB1 dies. You should see a 'Reaped unparented process' "
+             "message with my ID next, OR THIS TEST IS MEANINGLESS "
+             "(see fork_into()).";
+    exit(0);
+}
+
+static void simulate_sid_from_pgid(pid_t pgid)
+{
+    pid_t rc = getpgid(pgid); // Same confusion as in the Kernel
+    int saved_errno = errno;
+    if (rc < 0 && saved_errno == ESRCH) {
+        dbg() << "The old get_sid_from_pgid(" << pgid << ") would return -1";
+    } else if (rc >= 0) {
+        dbg() << "FAIL: Process " << pgid << " still exists?! PGID is " << rc << ".";
+    } else {
+        perror("pgid (probably fail)");
+    }
+}
+
+static void run_pb2(void* pipe_fd_ptr)
+{
+    // Time 6: PB1 forks into PB2
+    sleep_steps(2);
+
+    // Time 8: PB2 calls pgrp(0, PGA)
+    //   Note: PB2 writes "1" (exploit successfull) or "0" (bug is fixed) to a pipe
+    dbg() << "PB2 starts with SID=" << getsid(0) << ", PGID=" << getpgid(0) << ", PID=" << getpid() << ".";
+    dbg() << "PB2 calls pgrp(0, PGA)";
+    int pga = getpid() - 3;
+    dbg() << "PB2: Actually, what is PGA? I guess it's " << pga << "?";
+    simulate_sid_from_pgid(pga);
+    int rc = setpgid(0, pga);
+    unsigned char to_write = 123;
+    if (rc == 0) {
+        dbg() << "PB2: setgpid SUCCESSFUL! CHANGED PGROUP!";
+        to_write = 1;
+    } else {
+        ASSERT(rc == -1);
+        switch (errno) {
+        case EACCES:
+            dbg() << "PB2: Failed with EACCES. Huh?!";
+            to_write = 101;
+            break;
+        case EINVAL:
+            dbg() << "PB2: Failed with EINVAL. Huh?!";
+            to_write = 102;
+            break;
+        case ESRCH:
+            dbg() << "PB2: Failed with ESRCH. Huh?!";
+            to_write = 103;
+            break;
+        case EPERM:
+            dbg() << "PB2: Failed with EPERM. Aww, no exploit today :^)";
+            to_write = 0;
+            break;
+        default:
+            dbg() << "PB2: Failed with errno=" << errno << "?!";
+            perror("setpgid");
+            to_write = 104;
+            break;
+        }
+    }
+
+    dbg() << "PB2 ends with SID=" << getsid(0) << ", PGID=" << getpgid(0) << ", PID=" << getpid() << ".";
+    int* pipe_fd = static_cast<int*>(pipe_fd_ptr);
+    ASSERT(*pipe_fd);
+    rc = write(*pipe_fd, &to_write, 1);
+    if (rc != 1) {
+        dbg() << "Wrote only " << rc << " bytes instead of 1?!";
+        exit(1);
+    }
+    exit(0);
+}


### PR DESCRIPTION
The Kernel used to have many ID-confusion bugs, where it treats some ID as another kind of ID. For example, `Process::send_signal` (on the hotpath for `kill(2)`) would treat the process ID as a thread ID, and misbehave accordingly.

This PR:
- Introduces a new type `DistinctNumeric` that enables type-checking otherwise "identical" types (e.g. `typedef int pid_t` and `typedef int tid_t`), see #3044 for previous discussion.
- Applies this type-checking to the Kernel (and only the Kernel, for sanity). In the process of this, I found a few bugs and weird-looking things, and annotated them accordingly.
- Demonstrates 2 bugs, by creating thests. These tests cannot be automated yet, due to other, unrelated bugs :/
- Fixes 3 ID-confusion bugs (`setpgid`, `tcsetpgrp`, `send_signal`)
- Probably introduces a few new locking issues, although I tried my best to avoid this. Can someone review this? Maybe @bgianfo ?

I know that in theory I should merge the three "PID/___ typing" commits, but they're already hard to read. Also, they provide compiling and working checkpoints for bisecting, in case that's necessary. Therefore, I would like to *not* squash them.