### PR TITLE
Kernel: More Userspace<T> conversion progress

### DIFF
--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -957,7 +957,7 @@ int Emulator::virt$execve(FlatPtr params_addr)
     auto copy_string_list = [this](auto& output_vector, auto& string_list) {
         for (size_t i = 0; i < string_list.length; ++i) {
             Syscall::StringArgument string;
-            mmu().copy_from_vm(&string, (FlatPtr)&string_list.strings[i], sizeof(string));
+            mmu().copy_from_vm(&string, (FlatPtr)&string_list.strings.ptr()[i], sizeof(string));
             output_vector.append(String::copy(mmu().copy_buffer_from_vm((FlatPtr)string.characters, string.length)));
         }
     };

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -241,7 +241,7 @@ struct ImmutableBufferArgument {
 };
 
 struct StringListArgument {
-    StringArgument* strings { nullptr };
+    Userspace<StringArgument*> strings { };
     size_t length { 0 };
 };
 

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -98,7 +98,7 @@ void IPv4Socket::get_peer_address(sockaddr* address, socklen_t* address_size)
     *address_size = sizeof(sockaddr_in);
 }
 
-KResult IPv4Socket::bind(const sockaddr* user_address, socklen_t address_size)
+KResult IPv4Socket::bind(Userspace<const sockaddr*> user_address, socklen_t address_size)
 {
     ASSERT(setup_state() == SetupState::Unstarted);
     if (address_size != sizeof(sockaddr_in))

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -49,7 +49,7 @@ public:
     static Lockable<HashTable<IPv4Socket*>>& all_sockets();
 
     virtual KResult close() override;
-    virtual KResult bind(const sockaddr*, socklen_t) override;
+    virtual KResult bind(Userspace<const sockaddr*>, socklen_t) override;
     virtual KResult connect(FileDescription&, const sockaddr*, socklen_t, ShouldBlock = ShouldBlock::Yes) override;
     virtual KResult listen(size_t) override;
     virtual void get_local_address(sockaddr*, socklen_t*) override;

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -91,7 +91,7 @@ void LocalSocket::get_peer_address(sockaddr* address, socklen_t* address_size)
     get_local_address(address, address_size);
 }
 
-KResult LocalSocket::bind(const sockaddr* user_address, socklen_t address_size)
+KResult LocalSocket::bind(Userspace<const sockaddr*> user_address, socklen_t address_size)
 {
     ASSERT(setup_state() == SetupState::Unstarted);
     if (address_size != sizeof(sockaddr_un))

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -51,7 +51,7 @@ public:
     String absolute_path(const FileDescription& description) const override;
 
     // ^Socket
-    virtual KResult bind(const sockaddr*, socklen_t) override;
+    virtual KResult bind(Userspace<const sockaddr*>, socklen_t) override;
     virtual KResult connect(FileDescription&, const sockaddr*, socklen_t, ShouldBlock = ShouldBlock::Yes) override;
     virtual KResult listen(size_t) override;
     virtual void get_local_address(sockaddr*, socklen_t*) override;

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -98,7 +98,7 @@ public:
 
     KResult shutdown(int how);
 
-    virtual KResult bind(const sockaddr*, socklen_t) = 0;
+    virtual KResult bind(Userspace<const sockaddr*>, socklen_t) = 0;
     virtual KResult connect(FileDescription&, const sockaddr*, socklen_t, ShouldBlock) = 0;
     virtual KResult listen(size_t) = 0;
     virtual void get_local_address(sockaddr*, socklen_t*) = 0;

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -247,7 +247,7 @@ public:
     int sys$sleep(unsigned seconds);
     int sys$usleep(useconds_t usec);
     int sys$gettimeofday(Userspace<timeval*>);
-    int sys$clock_gettime(clockid_t, timespec*);
+    int sys$clock_gettime(clockid_t, Userspace<timespec*>);
     int sys$clock_settime(clockid_t, timespec*);
     int sys$clock_nanosleep(Userspace<const Syscall::SC_clock_nanosleep_params*>);
     int sys$gethostname(char*, ssize_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -251,7 +251,7 @@ public:
     int sys$clock_settime(clockid_t, Userspace<const timespec*>);
     int sys$clock_nanosleep(Userspace<const Syscall::SC_clock_nanosleep_params*>);
     int sys$gethostname(Userspace<char*>, ssize_t);
-    int sys$sethostname(const char*, ssize_t);
+    int sys$sethostname(Userspace<const char*>, ssize_t);
     int sys$uname(utsname*);
     int sys$readlink(Userspace<const Syscall::SC_readlink_params*>);
     int sys$ttyname(int fd, Userspace<char*>, size_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -309,7 +309,7 @@ public:
     int sys$join_thread(pid_t tid, void** exit_value);
     int sys$detach_thread(pid_t tid);
     int sys$set_thread_name(pid_t tid, Userspace<const char*> buffer, size_t buffer_size);
-    int sys$get_thread_name(pid_t tid, char* buffer, size_t buffer_size);
+    int sys$get_thread_name(pid_t tid, Userspace<char*> buffer, size_t buffer_size);
     int sys$rename(Userspace<const Syscall::SC_rename_params*>);
     int sys$mknod(Userspace<const Syscall::SC_mknod_params*>);
     int sys$shbuf_create(int, void** buffer);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -305,7 +305,7 @@ public:
     int sys$sched_setparam(pid_t pid, Userspace<const struct sched_param*>);
     int sys$sched_getparam(pid_t pid, Userspace<struct sched_param*>);
     int sys$create_thread(void* (*)(void*), Userspace<const Syscall::SC_create_thread_params*>);
-    void sys$exit_thread(void*);
+    void sys$exit_thread(Userspace<void*>);
     int sys$join_thread(pid_t tid, Userspace<void**> exit_value);
     int sys$detach_thread(pid_t tid);
     int sys$set_thread_name(pid_t tid, Userspace<const char*> buffer, size_t buffer_size);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -306,7 +306,7 @@ public:
     int sys$sched_getparam(pid_t pid, Userspace<struct sched_param*>);
     int sys$create_thread(void* (*)(void*), Userspace<const Syscall::SC_create_thread_params*>);
     void sys$exit_thread(void*);
-    int sys$join_thread(pid_t tid, void** exit_value);
+    int sys$join_thread(pid_t tid, Userspace<void**> exit_value);
     int sys$detach_thread(pid_t tid);
     int sys$set_thread_name(pid_t tid, Userspace<const char*> buffer, size_t buffer_size);
     int sys$get_thread_name(pid_t tid, Userspace<char*> buffer, size_t buffer_size);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -263,7 +263,7 @@ public:
     int sys$sigaction(int signum, const sigaction* act, sigaction* old_act);
     int sys$sigprocmask(int how, const sigset_t* set, sigset_t* old_set);
     int sys$sigpending(sigset_t*);
-    int sys$getgroups(ssize_t, gid_t*);
+    int sys$getgroups(ssize_t, Userspace<gid_t*>);
     int sys$setgroups(ssize_t, Userspace<const gid_t*>);
     int sys$pipe(int pipefd[2], int flags);
     int sys$killpg(pid_t pgrp, int sig);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -278,7 +278,7 @@ public:
     int sys$fcntl(int fd, int cmd, u32 extra_arg);
     int sys$ioctl(int fd, unsigned request, FlatPtr arg);
     int sys$mkdir(Userspace<const char*> pathname, size_t path_length, mode_t mode);
-    clock_t sys$times(tms*);
+    clock_t sys$times(Userspace<tms*>);
     int sys$utime(Userspace<const char*> pathname, size_t path_length, Userspace<const struct utimbuf*>);
     int sys$link(Userspace<const Syscall::SC_link_params*>);
     int sys$unlink(const char* pathname, size_t path_length);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -224,7 +224,7 @@ public:
     ssize_t sys$read(int fd, Userspace<u8*>, ssize_t);
     ssize_t sys$write(int fd, const u8*, ssize_t);
     ssize_t sys$writev(int fd, const struct iovec* iov, int iov_count);
-    int sys$fstat(int fd, stat*);
+    int sys$fstat(int fd, Userspace<stat*>);
     int sys$stat(Userspace<const Syscall::SC_stat_params*>);
     int sys$lseek(int fd, off_t, int whence);
     int sys$kill(pid_t pid_or_pgid, int sig);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -332,7 +332,7 @@ public:
     int sys$futex(Userspace<const Syscall::SC_futex_params*>);
     int sys$set_thread_boost(pid_t tid, int amount);
     int sys$set_process_boost(pid_t, int amount);
-    int sys$chroot(const char* path, size_t path_length, int mount_flags);
+    int sys$chroot(Userspace<const char*> path, size_t path_length, int mount_flags);
     int sys$pledge(Userspace<const Syscall::SC_pledge_params*>);
     int sys$unveil(Userspace<const Syscall::SC_unveil_params*>);
     int sys$perf_event(int type, FlatPtr arg1, FlatPtr arg2);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -291,7 +291,7 @@ public:
     int sys$chown(Userspace<const Syscall::SC_chown_params*>);
     int sys$fchown(int fd, uid_t, gid_t);
     int sys$socket(int domain, int type, int protocol);
-    int sys$bind(int sockfd, const sockaddr* addr, socklen_t);
+    int sys$bind(int sockfd, Userspace<const sockaddr*> addr, socklen_t);
     int sys$listen(int sockfd, int backlog);
     int sys$accept(int sockfd, sockaddr*, socklen_t*);
     int sys$connect(int sockfd, const sockaddr*, socklen_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -250,7 +250,7 @@ public:
     int sys$clock_gettime(clockid_t, Userspace<timespec*>);
     int sys$clock_settime(clockid_t, Userspace<const timespec*>);
     int sys$clock_nanosleep(Userspace<const Syscall::SC_clock_nanosleep_params*>);
-    int sys$gethostname(char*, ssize_t);
+    int sys$gethostname(Userspace<char*>, ssize_t);
     int sys$sethostname(const char*, ssize_t);
     int sys$uname(utsname*);
     int sys$readlink(Userspace<const Syscall::SC_readlink_params*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -285,7 +285,7 @@ public:
     int sys$symlink(Userspace<const Syscall::SC_symlink_params*>);
     int sys$rmdir(Userspace<const char*> pathname, size_t path_length);
     int sys$mount(Userspace<const Syscall::SC_mount_params*>);
-    int sys$umount(const char* mountpoint, size_t mountpoint_length);
+    int sys$umount(Userspace<const char*> mountpoint, size_t mountpoint_length);
     int sys$chmod(const char* pathname, size_t path_length, mode_t);
     int sys$fchmod(int fd, mode_t);
     int sys$chown(Userspace<const Syscall::SC_chown_params*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -293,7 +293,7 @@ public:
     int sys$socket(int domain, int type, int protocol);
     int sys$bind(int sockfd, Userspace<const sockaddr*> addr, socklen_t);
     int sys$listen(int sockfd, int backlog);
-    int sys$accept(int sockfd, sockaddr*, socklen_t*);
+    int sys$accept(int sockfd, Userspace<sockaddr*>, Userspace<socklen_t*>);
     int sys$connect(int sockfd, const sockaddr*, socklen_t);
     int sys$shutdown(int sockfd, int how);
     ssize_t sys$sendto(const Syscall::SC_sendto_params*);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -323,7 +323,7 @@ public:
     int sys$reboot();
     int sys$set_process_icon(int icon_id);
     int sys$realpath(Userspace<const Syscall::SC_realpath_params*>);
-    ssize_t sys$getrandom(void*, size_t, unsigned int);
+    ssize_t sys$getrandom(Userspace<void*>, size_t, unsigned int);
     int sys$setkeymap(Userspace<const Syscall::SC_setkeymap_params*>);
     int sys$module_load(const char* path, size_t path_length);
     int sys$module_unload(const char* name, size_t name_length);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -257,7 +257,7 @@ public:
     int sys$ttyname(int fd, Userspace<char*>, size_t);
     int sys$ptsname(int fd, Userspace<char*>, size_t);
     pid_t sys$fork(RegisterState&);
-    int sys$execve(const Syscall::SC_execve_params*);
+    int sys$execve(Userspace<const Syscall::SC_execve_params*>);
     int sys$dup(int oldfd);
     int sys$dup2(int oldfd, int newfd);
     int sys$sigaction(int signum, const sigaction* act, sigaction* old_act);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -325,7 +325,7 @@ public:
     int sys$realpath(Userspace<const Syscall::SC_realpath_params*>);
     ssize_t sys$getrandom(Userspace<void*>, size_t, unsigned int);
     int sys$setkeymap(Userspace<const Syscall::SC_setkeymap_params*>);
-    int sys$module_load(const char* path, size_t path_length);
+    int sys$module_load(Userspace<const char*> path, size_t path_length);
     int sys$module_unload(const char* name, size_t name_length);
     int sys$profiling_enable(pid_t);
     int sys$profiling_disable(pid_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -217,7 +217,7 @@ public:
     pid_t sys$getpid();
     pid_t sys$getppid();
     int sys$getresuid(Userspace<uid_t*>, Userspace<uid_t*>, Userspace<uid_t*>);
-    int sys$getresgid(gid_t*, gid_t*, gid_t*);
+    int sys$getresgid(Userspace<gid_t*>, Userspace<gid_t*>, Userspace<gid_t*>);
     mode_t sys$umask(mode_t);
     int sys$open(Userspace<const Syscall::SC_open_params*>);
     int sys$close(int fd);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -261,7 +261,7 @@ public:
     int sys$dup(int oldfd);
     int sys$dup2(int oldfd, int newfd);
     int sys$sigaction(int signum, const sigaction* act, sigaction* old_act);
-    int sys$sigprocmask(int how, const sigset_t* set, sigset_t* old_set);
+    int sys$sigprocmask(int how, Userspace<const sigset_t*> set, Userspace<sigset_t*> old_set);
     int sys$sigpending(sigset_t*);
     int sys$getgroups(ssize_t, Userspace<gid_t*>);
     int sys$setgroups(ssize_t, Userspace<const gid_t*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -248,7 +248,7 @@ public:
     int sys$usleep(useconds_t usec);
     int sys$gettimeofday(Userspace<timeval*>);
     int sys$clock_gettime(clockid_t, Userspace<timespec*>);
-    int sys$clock_settime(clockid_t, timespec*);
+    int sys$clock_settime(clockid_t, const timespec*);
     int sys$clock_nanosleep(Userspace<const Syscall::SC_clock_nanosleep_params*>);
     int sys$gethostname(char*, ssize_t);
     int sys$sethostname(const char*, ssize_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -326,7 +326,7 @@ public:
     ssize_t sys$getrandom(Userspace<void*>, size_t, unsigned int);
     int sys$setkeymap(Userspace<const Syscall::SC_setkeymap_params*>);
     int sys$module_load(Userspace<const char*> path, size_t path_length);
-    int sys$module_unload(const char* name, size_t name_length);
+    int sys$module_unload(Userspace<const char*> name, size_t name_length);
     int sys$profiling_enable(pid_t);
     int sys$profiling_disable(pid_t);
     int sys$futex(Userspace<const Syscall::SC_futex_params*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -264,7 +264,7 @@ public:
     int sys$sigprocmask(int how, const sigset_t* set, sigset_t* old_set);
     int sys$sigpending(sigset_t*);
     int sys$getgroups(ssize_t, gid_t*);
-    int sys$setgroups(ssize_t, const gid_t*);
+    int sys$setgroups(ssize_t, Userspace<const gid_t*>);
     int sys$pipe(int pipefd[2], int flags);
     int sys$killpg(pid_t pgrp, int sig);
     int sys$seteuid(uid_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -262,7 +262,7 @@ public:
     int sys$dup2(int oldfd, int newfd);
     int sys$sigaction(int signum, const sigaction* act, sigaction* old_act);
     int sys$sigprocmask(int how, Userspace<const sigset_t*> set, Userspace<sigset_t*> old_set);
-    int sys$sigpending(sigset_t*);
+    int sys$sigpending(Userspace<sigset_t*>);
     int sys$getgroups(ssize_t, Userspace<gid_t*>);
     int sys$setgroups(ssize_t, Userspace<const gid_t*>);
     int sys$pipe(int pipefd[2], int flags);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -294,7 +294,7 @@ public:
     int sys$bind(int sockfd, Userspace<const sockaddr*> addr, socklen_t);
     int sys$listen(int sockfd, int backlog);
     int sys$accept(int sockfd, Userspace<sockaddr*>, Userspace<socklen_t*>);
-    int sys$connect(int sockfd, const sockaddr*, socklen_t);
+    int sys$connect(int sockfd, Userspace<const sockaddr*>, socklen_t);
     int sys$shutdown(int sockfd, int how);
     ssize_t sys$sendto(const Syscall::SC_sendto_params*);
     ssize_t sys$recvfrom(const Syscall::SC_recvfrom_params*);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -308,7 +308,7 @@ public:
     void sys$exit_thread(void*);
     int sys$join_thread(pid_t tid, void** exit_value);
     int sys$detach_thread(pid_t tid);
-    int sys$set_thread_name(pid_t tid, const char* buffer, size_t buffer_size);
+    int sys$set_thread_name(pid_t tid, Userspace<const char*> buffer, size_t buffer_size);
     int sys$get_thread_name(pid_t tid, char* buffer, size_t buffer_size);
     int sys$rename(Userspace<const Syscall::SC_rename_params*>);
     int sys$mknod(Userspace<const Syscall::SC_mknod_params*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -281,7 +281,7 @@ public:
     clock_t sys$times(Userspace<tms*>);
     int sys$utime(Userspace<const char*> pathname, size_t path_length, Userspace<const struct utimbuf*>);
     int sys$link(Userspace<const Syscall::SC_link_params*>);
-    int sys$unlink(const char* pathname, size_t path_length);
+    int sys$unlink(Userspace<const char*> pathname, size_t path_length);
     int sys$symlink(Userspace<const Syscall::SC_symlink_params*>);
     int sys$rmdir(Userspace<const char*> pathname, size_t path_length);
     int sys$mount(Userspace<const Syscall::SC_mount_params*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -252,7 +252,7 @@ public:
     int sys$clock_nanosleep(Userspace<const Syscall::SC_clock_nanosleep_params*>);
     int sys$gethostname(Userspace<char*>, ssize_t);
     int sys$sethostname(Userspace<const char*>, ssize_t);
-    int sys$uname(utsname*);
+    int sys$uname(Userspace<utsname*>);
     int sys$readlink(Userspace<const Syscall::SC_readlink_params*>);
     int sys$ttyname(int fd, Userspace<char*>, size_t);
     int sys$ptsname(int fd, Userspace<char*>, size_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -315,7 +315,7 @@ public:
     int sys$shbuf_create(int, void** buffer);
     int sys$shbuf_allow_pid(int, pid_t peer_pid);
     int sys$shbuf_allow_all(int);
-    void* sys$shbuf_get(int shbuf_id, size_t* size);
+    void* sys$shbuf_get(int shbuf_id, Userspace<size_t*> size);
     int sys$shbuf_release(int shbuf_id);
     int sys$shbuf_seal(int shbuf_id);
     int sys$shbuf_set_volatile(int shbuf_id, bool);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -216,7 +216,7 @@ public:
     gid_t sys$getegid();
     pid_t sys$getpid();
     pid_t sys$getppid();
-    int sys$getresuid(uid_t*, uid_t*, uid_t*);
+    int sys$getresuid(Userspace<uid_t*>, Userspace<uid_t*>, Userspace<uid_t*>);
     int sys$getresgid(gid_t*, gid_t*, gid_t*);
     mode_t sys$umask(mode_t);
     int sys$open(Userspace<const Syscall::SC_open_params*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -286,7 +286,7 @@ public:
     int sys$rmdir(Userspace<const char*> pathname, size_t path_length);
     int sys$mount(Userspace<const Syscall::SC_mount_params*>);
     int sys$umount(Userspace<const char*> mountpoint, size_t mountpoint_length);
-    int sys$chmod(const char* pathname, size_t path_length, mode_t);
+    int sys$chmod(Userspace<const char*> pathname, size_t path_length, mode_t);
     int sys$fchmod(int fd, mode_t);
     int sys$chown(Userspace<const Syscall::SC_chown_params*>);
     int sys$fchown(int fd, uid_t, gid_t);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -248,7 +248,7 @@ public:
     int sys$usleep(useconds_t usec);
     int sys$gettimeofday(Userspace<timeval*>);
     int sys$clock_gettime(clockid_t, Userspace<timespec*>);
-    int sys$clock_settime(clockid_t, const timespec*);
+    int sys$clock_settime(clockid_t, Userspace<const timespec*>);
     int sys$clock_nanosleep(Userspace<const Syscall::SC_clock_nanosleep_params*>);
     int sys$gethostname(char*, ssize_t);
     int sys$sethostname(const char*, ssize_t);

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -95,7 +95,7 @@ int handle(RegisterState& regs, u32 function, u32 arg1, u32 arg2, u32 arg3)
         if (function == SC_exit)
             process.sys$exit((int)arg1);
         else
-            process.sys$exit_thread((void*)arg1);
+            process.sys$exit_thread(arg1);
         ASSERT_NOT_REACHED();
         return 0;
     }

--- a/Kernel/Syscalls/chmod.cpp
+++ b/Kernel/Syscalls/chmod.cpp
@@ -31,7 +31,7 @@
 
 namespace Kernel {
 
-int Process::sys$chmod(const char* user_path, size_t path_length, mode_t mode)
+int Process::sys$chmod(Userspace<const char*> user_path, size_t path_length, mode_t mode)
 {
     REQUIRE_PROMISE(fattr);
     auto path = get_syscall_path_argument(user_path, path_length);

--- a/Kernel/Syscalls/chroot.cpp
+++ b/Kernel/Syscalls/chroot.cpp
@@ -31,7 +31,7 @@
 
 namespace Kernel {
 
-int Process::sys$chroot(const char* user_path, size_t path_length, int mount_flags)
+int Process::sys$chroot(Userspace<const char*> user_path, size_t path_length, int mount_flags)
 {
     if (!is_superuser())
         return -EPERM;

--- a/Kernel/Syscalls/clock.cpp
+++ b/Kernel/Syscalls/clock.cpp
@@ -54,7 +54,7 @@ int Process::sys$clock_gettime(clockid_t clock_id, Userspace<timespec*> user_ts)
     return 0;
 }
 
-int Process::sys$clock_settime(clockid_t clock_id, timespec* user_ts)
+int Process::sys$clock_settime(clockid_t clock_id, const timespec* user_ts)
 {
     REQUIRE_PROMISE(settime);
 

--- a/Kernel/Syscalls/clock.cpp
+++ b/Kernel/Syscalls/clock.cpp
@@ -29,14 +29,13 @@
 
 namespace Kernel {
 
-int Process::sys$clock_gettime(clockid_t clock_id, timespec* user_ts)
+int Process::sys$clock_gettime(clockid_t clock_id, Userspace<timespec*> user_ts)
 {
     REQUIRE_PROMISE(stdio);
     if (!validate_write_typed(user_ts))
         return -EFAULT;
 
-    timespec ts;
-    memset(&ts, 0, sizeof(ts));
+    timespec ts = {};
 
     switch (clock_id) {
     case CLOCK_MONOTONIC:

--- a/Kernel/Syscalls/clock.cpp
+++ b/Kernel/Syscalls/clock.cpp
@@ -54,7 +54,7 @@ int Process::sys$clock_gettime(clockid_t clock_id, Userspace<timespec*> user_ts)
     return 0;
 }
 
-int Process::sys$clock_settime(clockid_t clock_id, const timespec* user_ts)
+int Process::sys$clock_settime(clockid_t clock_id, Userspace<const timespec*> user_ts)
 {
     REQUIRE_PROMISE(settime);
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -544,7 +544,7 @@ int Process::exec(String path, Vector<String> arguments, Vector<String> environm
     return 0;
 }
 
-int Process::sys$execve(const Syscall::SC_execve_params* user_params)
+int Process::sys$execve(Userspace<const Syscall::SC_execve_params*> user_params)
 {
     REQUIRE_PROMISE(exec);
 
@@ -568,14 +568,14 @@ int Process::sys$execve(const Syscall::SC_execve_params* user_params)
         path = path_arg.value();
     }
 
-    auto copy_user_strings = [&](const auto& list, auto& output) {
+    auto copy_user_strings = [this](const auto& list, auto& output) {
         if (!list.length)
             return true;
         if (!validate_read_typed(list.strings, list.length))
             return false;
         Vector<Syscall::StringArgument, 32> strings;
         strings.resize(list.length);
-        copy_from_user(strings.data(), list.strings, list.length * sizeof(Syscall::StringArgument));
+        copy_from_user(strings.data(), list.strings.unsafe_userspace_ptr(), list.length * sizeof(Syscall::StringArgument));
         for (size_t i = 0; i < list.length; ++i) {
             auto string = validate_and_copy_string_from_user(strings[i]);
             if (string.is_null())

--- a/Kernel/Syscalls/getrandom.cpp
+++ b/Kernel/Syscalls/getrandom.cpp
@@ -32,7 +32,7 @@ namespace Kernel {
 // We don't use the flag yet, but we could use it for distinguishing
 // random source like Linux, unlike the OpenBSD equivalent. However, if we
 // do, we should be able of the caveats that Linux has dealt with.
-ssize_t Process::sys$getrandom(void* buffer, size_t buffer_size, [[maybe_unused]] unsigned flags)
+ssize_t Process::sys$getrandom(Userspace<void*> buffer, size_t buffer_size, [[maybe_unused]] unsigned flags)
 {
     REQUIRE_PROMISE(stdio);
     if (buffer_size <= 0)
@@ -42,7 +42,8 @@ ssize_t Process::sys$getrandom(void* buffer, size_t buffer_size, [[maybe_unused]
         return -EFAULT;
 
     SmapDisabler disabler;
-    get_good_random_bytes((u8*)buffer, buffer_size);
+    // FIXME: We should really push Userspace<T> down through the interface.
+    get_good_random_bytes((u8*)buffer.ptr(), buffer_size);
     return 0;
 }
 

--- a/Kernel/Syscalls/getuid.cpp
+++ b/Kernel/Syscalls/getuid.cpp
@@ -63,7 +63,7 @@ int Process::sys$getresuid(Userspace<uid_t*> ruid, Userspace<uid_t*> euid, Users
     return 0;
 }
 
-int Process::sys$getresgid(gid_t* rgid, gid_t* egid, gid_t* sgid)
+int Process::sys$getresgid(Userspace<gid_t*> rgid, Userspace<gid_t*> egid, Userspace<gid_t*> sgid)
 {
     REQUIRE_PROMISE(stdio);
     if (!validate_write_typed(rgid) || !validate_write_typed(egid) || !validate_write_typed(sgid))

--- a/Kernel/Syscalls/getuid.cpp
+++ b/Kernel/Syscalls/getuid.cpp
@@ -52,7 +52,7 @@ gid_t Process::sys$getegid()
     return m_egid;
 }
 
-int Process::sys$getresuid(uid_t* ruid, uid_t* euid, uid_t* suid)
+int Process::sys$getresuid(Userspace<uid_t*> ruid, Userspace<uid_t*> euid, Userspace<uid_t*> suid)
 {
     REQUIRE_PROMISE(stdio);
     if (!validate_write_typed(ruid) || !validate_write_typed(euid) || !validate_write_typed(suid))

--- a/Kernel/Syscalls/getuid.cpp
+++ b/Kernel/Syscalls/getuid.cpp
@@ -74,7 +74,7 @@ int Process::sys$getresgid(gid_t* rgid, gid_t* egid, gid_t* sgid)
     return 0;
 }
 
-int Process::sys$getgroups(ssize_t count, gid_t* user_gids)
+int Process::sys$getgroups(ssize_t count, Userspace<gid_t*> user_gids)
 {
     REQUIRE_PROMISE(stdio);
     if (count < 0)

--- a/Kernel/Syscalls/hostname.cpp
+++ b/Kernel/Syscalls/hostname.cpp
@@ -31,7 +31,7 @@ namespace Kernel {
 extern String* g_hostname;
 extern Lock* g_hostname_lock;
 
-int Process::sys$gethostname(char* buffer, ssize_t size)
+int Process::sys$gethostname(Userspace<char*> buffer, ssize_t size)
 {
     REQUIRE_PROMISE(stdio);
     if (size < 0)

--- a/Kernel/Syscalls/hostname.cpp
+++ b/Kernel/Syscalls/hostname.cpp
@@ -45,7 +45,7 @@ int Process::sys$gethostname(Userspace<char*> buffer, ssize_t size)
     return 0;
 }
 
-int Process::sys$sethostname(const char* hostname, ssize_t length)
+int Process::sys$sethostname(Userspace<const char*> hostname, ssize_t length)
 {
     REQUIRE_NO_PROMISES;
     if (!is_superuser())

--- a/Kernel/Syscalls/module.cpp
+++ b/Kernel/Syscalls/module.cpp
@@ -163,7 +163,7 @@ int Process::sys$module_load(Userspace<const char*> user_path, size_t path_lengt
     return 0;
 }
 
-int Process::sys$module_unload(const char* user_name, size_t name_length)
+int Process::sys$module_unload(Userspace<const char*> user_name, size_t name_length)
 {
     if (!is_superuser())
         return -EPERM;

--- a/Kernel/Syscalls/module.cpp
+++ b/Kernel/Syscalls/module.cpp
@@ -35,7 +35,7 @@ namespace Kernel {
 
 extern HashMap<String, OwnPtr<Module>>* g_modules;
 
-int Process::sys$module_load(const char* user_path, size_t path_length)
+int Process::sys$module_load(Userspace<const char*> user_path, size_t path_length)
 {
     if (!is_superuser())
         return -EPERM;

--- a/Kernel/Syscalls/mount.cpp
+++ b/Kernel/Syscalls/mount.cpp
@@ -122,7 +122,7 @@ int Process::sys$mount(Userspace<const Syscall::SC_mount_params*> user_params)
     return result;
 }
 
-int Process::sys$umount(const char* user_mountpoint, size_t mountpoint_length)
+int Process::sys$umount(Userspace<const char*> user_mountpoint, size_t mountpoint_length)
 {
     if (!is_superuser())
         return -EPERM;

--- a/Kernel/Syscalls/setuid.cpp
+++ b/Kernel/Syscalls/setuid.cpp
@@ -118,7 +118,7 @@ int Process::sys$setresgid(gid_t rgid, gid_t egid, gid_t sgid)
     return 0;
 }
 
-int Process::sys$setgroups(ssize_t count, const gid_t* user_gids)
+int Process::sys$setgroups(ssize_t count, Userspace<const gid_t*> user_gids)
 {
     REQUIRE_PROMISE(id);
     if (count < 0)

--- a/Kernel/Syscalls/shbuf.cpp
+++ b/Kernel/Syscalls/shbuf.cpp
@@ -120,7 +120,7 @@ int Process::sys$shbuf_release(int shbuf_id)
     return 0;
 }
 
-void* Process::sys$shbuf_get(int shbuf_id, size_t* user_size)
+void* Process::sys$shbuf_get(int shbuf_id, Userspace<size_t*> user_size)
 {
     REQUIRE_PROMISE(shared_buffer);
     if (user_size && !validate_write_typed(user_size))

--- a/Kernel/Syscalls/sigaction.cpp
+++ b/Kernel/Syscalls/sigaction.cpp
@@ -28,7 +28,7 @@
 
 namespace Kernel {
 
-int Process::sys$sigprocmask(int how, const sigset_t* set, sigset_t* old_set)
+int Process::sys$sigprocmask(int how, Userspace<const sigset_t*> set, Userspace<sigset_t*> old_set)
 {
     REQUIRE_PROMISE(sigaction);
     auto current_thread = Thread::current();

--- a/Kernel/Syscalls/sigaction.cpp
+++ b/Kernel/Syscalls/sigaction.cpp
@@ -59,7 +59,7 @@ int Process::sys$sigprocmask(int how, Userspace<const sigset_t*> set, Userspace<
     return 0;
 }
 
-int Process::sys$sigpending(sigset_t* set)
+int Process::sys$sigpending(Userspace<sigset_t*> set)
 {
     REQUIRE_PROMISE(stdio);
     if (!validate_write_typed(set))

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -63,7 +63,7 @@ int Process::sys$socket(int domain, int type, int protocol)
     return fd;
 }
 
-int Process::sys$bind(int sockfd, const sockaddr* address, socklen_t address_length)
+int Process::sys$bind(int sockfd, Userspace<const sockaddr*> address, socklen_t address_length)
 {
     if (!validate_read(address, address_length))
         return -EFAULT;

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -149,7 +149,7 @@ int Process::sys$accept(int accepting_socket_fd, Userspace<sockaddr*> user_addre
     return accepted_socket_fd;
 }
 
-int Process::sys$connect(int sockfd, const sockaddr* user_address, socklen_t user_address_size)
+int Process::sys$connect(int sockfd, Userspace<const sockaddr*> user_address, socklen_t user_address_size)
 {
     if (!validate_read(user_address, user_address_size))
         return -EFAULT;

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -93,7 +93,7 @@ int Process::sys$listen(int sockfd, int backlog)
     return socket.listen(backlog);
 }
 
-int Process::sys$accept(int accepting_socket_fd, sockaddr* user_address, socklen_t* user_address_size)
+int Process::sys$accept(int accepting_socket_fd, Userspace<sockaddr*> user_address, Userspace<socklen_t*> user_address_size)
 {
     REQUIRE_PROMISE(accept);
 
@@ -101,7 +101,8 @@ int Process::sys$accept(int accepting_socket_fd, sockaddr* user_address, socklen
     if (user_address) {
         if (!validate_write_typed(user_address_size))
             return -EFAULT;
-        copy_from_user(&address_size, user_address_size);
+        if (!validate_read_and_copy_typed(&address_size, user_address_size))
+            return -EFAULT;
         if (!validate_write(user_address, address_size))
             return -EFAULT;
     }

--- a/Kernel/Syscalls/stat.cpp
+++ b/Kernel/Syscalls/stat.cpp
@@ -31,7 +31,7 @@
 
 namespace Kernel {
 
-int Process::sys$fstat(int fd, stat* user_statbuf)
+int Process::sys$fstat(int fd, Userspace<stat*> user_statbuf)
 {
     REQUIRE_PROMISE(stdio);
     if (!validate_write_typed(user_statbuf))
@@ -39,8 +39,7 @@ int Process::sys$fstat(int fd, stat* user_statbuf)
     auto description = file_description(fd);
     if (!description)
         return -EBADF;
-    stat buffer;
-    memset(&buffer, 0, sizeof(buffer));
+    stat buffer = {};
     int rc = description->fstat(buffer);
     copy_to_user(user_statbuf, &buffer);
     return rc;

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -189,7 +189,7 @@ int Process::sys$set_thread_name(pid_t tid, Userspace<const char*> user_name, si
     return 0;
 }
 
-int Process::sys$get_thread_name(pid_t tid, char* buffer, size_t buffer_size)
+int Process::sys$get_thread_name(pid_t tid, Userspace<char*> buffer, size_t buffer_size)
 {
     REQUIRE_PROMISE(thread);
     if (buffer_size == 0)

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -90,12 +90,12 @@ int Process::sys$create_thread(void* (*entry)(void*), Userspace<const Syscall::S
     return thread->tid().value();
 }
 
-void Process::sys$exit_thread(void* exit_value)
+void Process::sys$exit_thread(Userspace<void*> exit_value)
 {
     REQUIRE_PROMISE(thread);
     cli();
     auto current_thread = Thread::current();
-    current_thread->m_exit_value = exit_value;
+    current_thread->m_exit_value = reinterpret_cast<void*>(exit_value.ptr());
     current_thread->set_should_die();
     big_lock().force_unlock_if_locked();
     current_thread->die_if_needed();

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -117,7 +117,7 @@ int Process::sys$detach_thread(pid_t tid)
     return 0;
 }
 
-int Process::sys$join_thread(pid_t tid, void** exit_value)
+int Process::sys$join_thread(pid_t tid, Userspace<void**> exit_value)
 {
     REQUIRE_PROMISE(thread);
     if (exit_value && !validate_write_typed(exit_value))

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -169,7 +169,7 @@ int Process::sys$join_thread(pid_t tid, void** exit_value)
     return 0;
 }
 
-int Process::sys$set_thread_name(pid_t tid, const char* user_name, size_t user_name_length)
+int Process::sys$set_thread_name(pid_t tid, Userspace<const char*> user_name, size_t user_name_length)
 {
     REQUIRE_PROMISE(thread);
     auto name = validate_and_copy_string_from_user(user_name, user_name_length);
@@ -188,6 +188,7 @@ int Process::sys$set_thread_name(pid_t tid, const char* user_name, size_t user_n
     thread->set_name(name);
     return 0;
 }
+
 int Process::sys$get_thread_name(pid_t tid, char* buffer, size_t buffer_size)
 {
     REQUIRE_PROMISE(thread);

--- a/Kernel/Syscalls/times.cpp
+++ b/Kernel/Syscalls/times.cpp
@@ -28,15 +28,20 @@
 
 namespace Kernel {
 
-clock_t Process::sys$times(tms* times)
+clock_t Process::sys$times(Userspace<tms*> user_times)
 {
     REQUIRE_PROMISE(stdio);
-    if (!validate_write_typed(times))
+    if (!validate_write_typed(user_times))
         return -EFAULT;
-    copy_to_user(&times->tms_utime, &m_ticks_in_user);
-    copy_to_user(&times->tms_stime, &m_ticks_in_kernel);
-    copy_to_user(&times->tms_cutime, &m_ticks_in_user_for_dead_children);
-    copy_to_user(&times->tms_cstime, &m_ticks_in_kernel_for_dead_children);
+
+    tms times = {};
+    times.tms_utime = m_ticks_in_user;
+    times.tms_stime = m_ticks_in_kernel;
+    times.tms_cutime = m_ticks_in_user_for_dead_children;
+    times.tms_cstime = m_ticks_in_kernel_for_dead_children;
+
+    copy_to_user(user_times, &times);
+
     return g_uptime & 0x7fffffff;
 }
 

--- a/Kernel/Syscalls/unlink.cpp
+++ b/Kernel/Syscalls/unlink.cpp
@@ -30,7 +30,7 @@
 
 namespace Kernel {
 
-int Process::sys$unlink(const char* user_path, size_t path_length)
+int Process::sys$unlink(Userspace<const char*> user_path, size_t path_length)
 {
     REQUIRE_PROMISE(cpath);
     if (!validate_read(user_path, path_length))

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -94,8 +94,8 @@ int execve(const char* filename, char* const argv[], char* const envp[])
     auto copy_strings = [&](auto& vec, size_t count, auto& output) {
         output.length = count;
         for (size_t i = 0; vec[i]; ++i) {
-            output.strings[i].characters = vec[i];
-            output.strings[i].length = strlen(vec[i]);
+            output.strings.ptr()[i].characters = vec[i];
+            output.strings.ptr()[i].length = strlen(vec[i]);
         }
     };
 


### PR DESCRIPTION
Converts the following syscalls:
- execve 
- setgroups
- getgroups
- time 
- getresuid 
- getresgid
- clock_gettime
- clock_settime
- gethostname
- sethostname
- uname
- fstat
- sigprocmask
- sigpending
- unlink
- umount 
- chmod 
- bind
- accept 
- connect
- set_thread_name
- get_thread_name
- shbuf_get
- getrandom
- module_load
- module_unload
- chroot
- join_thread
- exit_thread 