### PR TITLE
Kernel: Fix SlabAllocator initialization

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(KERNEL_HEAP_SOURCES
+    Heap/SlabAllocator.cpp
+    Heap/kmalloc.cpp
+)
+
 set(KERNEL_SOURCES
     ACPI/DynamicParser.cpp
     ACPI/Initialize.cpp
@@ -47,8 +52,6 @@ set(KERNEL_SOURCES
     FileSystem/ProcFS.cpp
     FileSystem/TmpFS.cpp
     FileSystem/VirtualFileSystem.cpp
-    Heap/SlabAllocator.cpp
-    Heap/kmalloc.cpp
     Interrupts/APIC.cpp
     Interrupts/GenericInterruptHandler.cpp
     Interrupts/IOAPIC.cpp
@@ -244,6 +247,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdlib -nostdinc -nostdinc++")
 add_link_options(LINKER:-T ${CMAKE_CURRENT_BINARY_DIR}/linker.ld -nostdlib)
 
 add_library(boot OBJECT Arch/i386/Boot/boot.S)
+add_library(kernel_heap STATIC ${KERNEL_HEAP_SOURCES})
 file(GENERATE OUTPUT linker.ld INPUT linker.ld)
 
 if (${CMAKE_HOST_SYSTEM_NAME} MATCHES SerenityOS)
@@ -255,8 +259,8 @@ else()
 endif()
 
 add_executable(Kernel ${SOURCES})
-target_link_libraries(Kernel gcc stdc++)
-add_dependencies(Kernel boot)
+target_link_libraries(Kernel kernel_heap gcc stdc++)
+add_dependencies(Kernel boot kernel_heap)
 install(TARGETS Kernel RUNTIME DESTINATION boot)
 
 add_custom_command(

--- a/Kernel/Heap/SlabAllocator.cpp
+++ b/Kernel/Heap/SlabAllocator.cpp
@@ -123,6 +123,7 @@ void for_each_allocator(Callback callback)
     callback(s_slab_allocator_16);
     callback(s_slab_allocator_32);
     callback(s_slab_allocator_64);
+    callback(s_slab_allocator_128);
 }
 
 void slab_alloc_init()

--- a/Kernel/Heap/SlabAllocator.cpp
+++ b/Kernel/Heap/SlabAllocator.cpp
@@ -100,12 +100,11 @@ private:
         char padding[templated_slab_size - sizeof(FreeSlab*)];
     };
 
-    // NOTE: These are not default-initialized to prevent an init-time constructor from overwriting them
-    FreeSlab* m_freelist;
+    FreeSlab* m_freelist { nullptr };
     Atomic<size_t> m_num_allocated;
     Atomic<size_t> m_num_free;
-    void* m_base;
-    void* m_end;
+    void* m_base { nullptr };
+    void* m_end { nullptr };
     SpinLock<u32> m_lock;
 
     static_assert(sizeof(FreeSlab) == templated_slab_size);

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -76,6 +76,8 @@
 
 // Defined in the linker script
 typedef void (*ctor_func_t)();
+extern ctor_func_t start_heap_ctors;
+extern ctor_func_t end_heap_ctors;
 extern ctor_func_t start_ctors;
 extern ctor_func_t end_ctors;
 
@@ -107,6 +109,9 @@ extern "C" [[noreturn]] void init()
 
     s_bsp_processor.early_initialize(0);
 
+    // Invoke the constructors needed for the kernel heap
+    for (ctor_func_t* ctor = &start_heap_ctors; ctor < &end_heap_ctors; ctor++)
+        (*ctor)();
     kmalloc_init();
     slab_alloc_init();
 

--- a/Kernel/linker.ld
+++ b/Kernel/linker.ld
@@ -18,6 +18,10 @@ SECTIONS
 
     .rodata ALIGN(4K) : AT (ADDR(.rodata) - 0xc0000000)
     {
+        start_heap_ctors = .;
+        *libkernel_heap.a:*(.ctors)
+        end_heap_ctors = .;
+
         start_ctors = .;
         *(.ctors)
         end_ctors = .;


### PR DESCRIPTION
Since the constructors are invoked after the slab allocator was
initialized, we need to make sure we don't use objects that use
default constructors, as those would mess up the state. An exception
to this is the m_lock, which we manually initialize and it will
then get re-initialized. But since that lock should be not in use
at that time anyway, it should be safe.

Also, for_each_allocator did not include the 128 byte allocator.