### PR TITLE
AK: Don't keep equal JsonObject keys in the order vector twice

### DIFF
--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -100,8 +100,9 @@ public:
 
     void set(const String& key, JsonValue value)
     {
+        if (m_members.set(key, move(value)) == HashSetResult::ReplacedExistingEntry)
+            m_order.remove(m_order.find_first_index(key).value());
         m_order.append(key);
-        m_members.set(key, move(value));
     }
 
     template<typename Callback>

--- a/AK/Tests/TestJSON.cpp
+++ b/AK/Tests/TestJSON.cpp
@@ -106,7 +106,7 @@ TEST_CASE(json_string)
     EXPECT_EQ(json.type(), JsonValue::Type::String);
     EXPECT_EQ(json.as_string().is_null(), false);
     EXPECT_EQ(json.as_string().length(), size_t { 1 });
-    EXPECT_EQ(json.as_string() ==  "A", true);
+    EXPECT_EQ(json.as_string() == "A", true);
 }
 
 TEST_CASE(json_utf8_character)
@@ -115,7 +115,7 @@ TEST_CASE(json_utf8_character)
     EXPECT_EQ(json.type(), JsonValue::Type::String);
     EXPECT_EQ(json.as_string().is_null(), false);
     EXPECT_EQ(json.as_string().length(), size_t { 1 });
-    EXPECT_EQ(json.as_string() ==  "A", true);
+    EXPECT_EQ(json.as_string() == "A", true);
 }
 
 TEST_CASE(json_utf8_multibyte)
@@ -124,8 +124,8 @@ TEST_CASE(json_utf8_multibyte)
     EXPECT_EQ(json.type(), JsonValue::Type::String);
     EXPECT_EQ(json.as_string().is_null(), false);
     EXPECT_EQ(json.as_string().length(), size_t { 2 });
-    EXPECT_EQ(json.as_string() ==  "š", true);
-    EXPECT_EQ(json.as_string() ==  "\xc5\xa1", true);
+    EXPECT_EQ(json.as_string() == "š", true);
+    EXPECT_EQ(json.as_string() == "\xc5\xa1", true);
 }
 
 TEST_CASE(json_64_bit_value)
@@ -134,6 +134,15 @@ TEST_CASE(json_64_bit_value)
     JsonValue big_json_value(big_value);
     JsonValue big_json_value_copy = big_json_value;
     EXPECT_EQ(big_json_value.as_u64(), big_json_value_copy.as_u64());
+}
+
+TEST_CASE(json_duplicate_keys)
+{
+    JsonObject json;
+    json.set("test", "foo");
+    json.set("test", "bar");
+    json.set("test", "baz");
+    EXPECT_EQ(json.to_string(), "{\"test\":\"baz\"}");
 }
 
 TEST_MAIN(JSON)


### PR DESCRIPTION
Fixes #3069.