### PR TITLE
Lagom: Add an ELF fuzzer, and tweak the code to survive a few minutes…

### DIFF
--- a/Libraries/LibELF/Image.h
+++ b/Libraries/LibELF/Image.h
@@ -37,7 +37,7 @@ namespace ELF {
 
 class Image {
 public:
-    explicit Image(const u8*, size_t);
+    explicit Image(const u8*, size_t, bool verbose_logging = true);
     ~Image();
     void dump() const;
     bool is_valid() const { return m_valid; }
@@ -206,7 +206,6 @@ public:
     VirtualAddress entry() const { return VirtualAddress(header().e_entry); }
 
 private:
-    bool parse_header();
     const char* raw_data(unsigned offset) const;
     const Elf32_Ehdr& header() const;
     const Elf32_Shdr& section_header(unsigned) const;
@@ -218,6 +217,7 @@ private:
 
     const u8* m_buffer { nullptr };
     size_t m_size { 0 };
+    bool m_verbose_logging { true };
     HashMap<String, unsigned> m_sections;
     bool m_valid { false };
     unsigned m_symbol_table_section_index { 0 };

--- a/Libraries/LibELF/Loader.cpp
+++ b/Libraries/LibELF/Loader.cpp
@@ -40,10 +40,9 @@
 
 namespace ELF {
 
-Loader::Loader(const u8* buffer, size_t size)
-    : m_image(buffer, size)
+Loader::Loader(const u8* buffer, size_t size, bool verbose_logging)
+    : m_image(buffer, size, verbose_logging)
 {
-    m_symbol_count = m_image.symbol_count();
 }
 
 Loader::~Loader()
@@ -57,6 +56,8 @@ bool Loader::load()
 #endif
     if (!m_image.is_valid())
         return false;
+
+    m_symbol_count = m_image.symbol_count();
 
     if (!layout())
         return false;

--- a/Libraries/LibELF/Loader.h
+++ b/Libraries/LibELF/Loader.h
@@ -45,7 +45,7 @@ namespace ELF {
 
 class Loader : public RefCounted<Loader> {
 public:
-    static NonnullRefPtr<Loader> create(const u8* data, size_t size) { return adopt(*new Loader(data, size)); }
+    static NonnullRefPtr<Loader> create(const u8* data, size_t size, bool verbose_logging=true) { return adopt(*new Loader(data, size, verbose_logging)); }
     ~Loader();
 
     bool load();
@@ -68,7 +68,7 @@ public:
     Optional<Image::Symbol> find_symbol(u32 address, u32* offset = nullptr) const;
 
 private:
-    explicit Loader(const u8*, size_t);
+    explicit Loader(const u8*, size_t, bool verbose_logging);
 
     bool layout();
     bool perform_relocations();

--- a/Libraries/LibELF/Validation.cpp
+++ b/Libraries/LibELF/Validation.cpp
@@ -31,99 +31,119 @@
 
 namespace ELF {
 
-bool validate_elf_header(const Elf32_Ehdr& elf_header, size_t file_size)
+bool validate_elf_header(const Elf32_Ehdr& elf_header, size_t file_size, bool verbose)
 {
     if (!IS_ELF(elf_header)) {
-        dbgputstr("File is not an ELF file.\n");
+        if (verbose)
+            dbgputstr("File is not an ELF file.\n");
         return false;
     }
 
     if (ELFCLASS32 != elf_header.e_ident[EI_CLASS]) {
-        dbgputstr("File is not a 32 bit ELF file.\n");
+        if (verbose)
+            dbgputstr("File is not a 32 bit ELF file.\n");
         return false;
     }
 
     if (ELFDATA2LSB != elf_header.e_ident[EI_DATA]) {
-        dbgputstr("File is not a little endian ELF file.\n");
+        if (verbose)
+            dbgputstr("File is not a little endian ELF file.\n");
         return false;
     }
 
     if (EV_CURRENT != elf_header.e_ident[EI_VERSION]) {
-        dbgprintf("File has unrecognized ELF version (%d), expected (%d)!\n", elf_header.e_ident[EI_VERSION], EV_CURRENT);
+        if (verbose)
+            dbgprintf("File has unrecognized ELF version (%d), expected (%d)!\n", elf_header.e_ident[EI_VERSION], EV_CURRENT);
         return false;
     }
 
     if (ELFOSABI_SYSV != elf_header.e_ident[EI_OSABI]) {
-        dbgprintf("File has unknown OS ABI (%d), expected SYSV(0)!\n", elf_header.e_ident[EI_OSABI]);
+        if (verbose)
+            dbgprintf("File has unknown OS ABI (%d), expected SYSV(0)!\n", elf_header.e_ident[EI_OSABI]);
         return false;
     }
 
     if (0 != elf_header.e_ident[EI_ABIVERSION]) {
-        dbgprintf("File has unknown SYSV ABI version (%d)!\n", elf_header.e_ident[EI_ABIVERSION]);
+        if (verbose)
+            dbgprintf("File has unknown SYSV ABI version (%d)!\n", elf_header.e_ident[EI_ABIVERSION]);
         return false;
     }
 
     if (EM_386 != elf_header.e_machine) {
-        dbgprintf("File has unknown machine (%d), expected i386 (3)!\n", elf_header.e_machine);
+        if (verbose)
+            dbgprintf("File has unknown machine (%d), expected i386 (3)!\n", elf_header.e_machine);
         return false;
     }
 
     if (ET_EXEC != elf_header.e_type && ET_DYN != elf_header.e_type && ET_REL != elf_header.e_type) {
-        dbgprintf("File has unloadable ELF type (%d), expected REL (1), EXEC (2) or DYN (3)!\n", elf_header.e_type);
+        if (verbose)
+            dbgprintf("File has unloadable ELF type (%d), expected REL (1), EXEC (2) or DYN (3)!\n", elf_header.e_type);
         return false;
     }
 
     if (EV_CURRENT != elf_header.e_version) {
-        dbgprintf("File has unrecognized ELF version (%d), expected (%d)!\n", elf_header.e_version, EV_CURRENT);
+        if (verbose)
+            dbgprintf("File has unrecognized ELF version (%d), expected (%d)!\n", elf_header.e_version, EV_CURRENT);
         return false;
     }
 
     if (sizeof(Elf32_Ehdr) != elf_header.e_ehsize) {
-        dbgprintf("File has incorrect ELF header size..? (%d), expected (%zu)!\n", elf_header.e_ehsize, sizeof(Elf32_Ehdr));
+        if (verbose)
+            dbgprintf("File has incorrect ELF header size..? (%d), expected (%zu)!\n", elf_header.e_ehsize, sizeof(Elf32_Ehdr));
         return false;
     }
 
     if (elf_header.e_phoff > file_size || elf_header.e_shoff > file_size) {
-        dbgprintf("SHENANIGANS! program header offset (%d) or section header offset (%d) are past the end of the file!\n",
-            elf_header.e_phoff, elf_header.e_shoff);
+        if (verbose) {
+            dbgprintf("SHENANIGANS! program header offset (%d) or section header offset (%d) are past the end of the file!\n",
+                elf_header.e_phoff, elf_header.e_shoff);
+        }
         return false;
     }
 
     if (elf_header.e_phnum != 0 && elf_header.e_phoff != elf_header.e_ehsize) {
-        dbgprintf("File does not have program headers directly after the ELF header? program header offset (%d), expected (%d).\n",
-            elf_header.e_phoff, elf_header.e_ehsize);
+        if (verbose) {
+            dbgprintf("File does not have program headers directly after the ELF header? program header offset (%d), expected (%d).\n",
+                elf_header.e_phoff, elf_header.e_ehsize);
+        }
         return false;
     }
 
     if (0 != elf_header.e_flags) {
-        dbgprintf("File has incorrect ELF header flags...? (%d), expected (%d).\n", elf_header.e_flags, 0);
+        if (verbose)
+            dbgprintf("File has incorrect ELF header flags...? (%d), expected (%d).\n", elf_header.e_flags, 0);
         return false;
     }
 
     if (0 != elf_header.e_phnum && sizeof(Elf32_Phdr) != elf_header.e_phentsize) {
-        dbgprintf("File has incorrect program header size..? (%d), expected (%zu).\n", elf_header.e_phentsize, sizeof(Elf32_Phdr));
+        if (verbose)
+            dbgprintf("File has incorrect program header size..? (%d), expected (%zu).\n", elf_header.e_phentsize, sizeof(Elf32_Phdr));
         return false;
     }
 
     if (sizeof(Elf32_Shdr) != elf_header.e_shentsize) {
-        dbgprintf("File has incorrect section header size..? (%d), expected (%zu).\n", elf_header.e_shentsize, sizeof(Elf32_Shdr));
+        if (verbose)
+            dbgprintf("File has incorrect section header size..? (%d), expected (%zu).\n", elf_header.e_shentsize, sizeof(Elf32_Shdr));
         return false;
     }
 
     size_t end_of_last_program_header = elf_header.e_phoff + (elf_header.e_phnum * elf_header.e_phentsize);
     if (end_of_last_program_header > file_size) {
-        dbgprintf("SHENANIGANS! End of last program header (%zu) is past the end of the file!\n", end_of_last_program_header);
+        if (verbose)
+            dbgprintf("SHENANIGANS! End of last program header (%zu) is past the end of the file!\n", end_of_last_program_header);
         return false;
     }
 
     size_t end_of_last_section_header = elf_header.e_shoff + (elf_header.e_shnum * elf_header.e_shentsize);
     if (end_of_last_section_header > file_size) {
-        dbgprintf("SHENANIGANS! End of last section header (%zu) is past the end of the file!\n", end_of_last_section_header);
+        if (verbose)
+            dbgprintf("SHENANIGANS! End of last section header (%zu) is past the end of the file!\n", end_of_last_section_header);
         return false;
     }
 
     if (elf_header.e_shstrndx >= elf_header.e_shnum) {
-        dbgprintf("SHENANIGANS! Section header string table index (%d) is not a valid index given we have %d section headers!\n", elf_header.e_shstrndx, elf_header.e_shnum);
+        if (verbose)
+            dbgprintf("SHENANIGANS! Section header string table index (%d) is not a valid index given we have %d section headers!\n", elf_header.e_shstrndx, elf_header.e_shnum);
         return false;
     }
 

--- a/Meta/Lagom/Fuzzers/CMakeLists.txt
+++ b/Meta/Lagom/Fuzzers/CMakeLists.txt
@@ -1,8 +1,16 @@
+add_executable(FuzzELF FuzzELF.cpp)
+target_compile_options(FuzzELF
+    PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>
+    )
+target_link_libraries(FuzzELF
+    PUBLIC Lagom
+    PRIVATE $<$<C_COMPILER_ID:Clang>:-fsanitize=fuzzer>
+    )
+
 add_executable(FuzzJs FuzzJs.cpp)
 target_compile_options(FuzzJs
     PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>
     )
-
 target_link_libraries(FuzzJs
     PUBLIC Lagom
     PRIVATE $<$<C_COMPILER_ID:Clang>:-fsanitize=fuzzer>
@@ -12,7 +20,6 @@ add_executable(FuzzMarkdown FuzzMarkdown.cpp)
 target_compile_options(FuzzMarkdown
     PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>
     )
-
 target_link_libraries(FuzzMarkdown
     PUBLIC Lagom
     PRIVATE $<$<C_COMPILER_ID:Clang>:-fsanitize=fuzzer>

--- a/Meta/Lagom/Fuzzers/FuzzELF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzELF.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andrew Kaster <andrewdkaster@gmail.com>
+ * Copyright (c) 2020, the SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,13 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include <LibELF/Loader.h>
+#include <stddef.h>
+#include <stdint.h>
 
-#include <LibELF/exec_elf.h>
-
-namespace ELF {
-
-bool validate_elf_header(const Elf32_Ehdr& elf_header, size_t file_size, bool verbose=true);
-bool validate_program_headers(const Elf32_Ehdr& elf_header, size_t file_size, u8* buffer, size_t buffer_size, String& interpreter_path);
-
-} // end namespace ELF
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    ELF::Loader::create(data, size, /*verbose_logging=*/false);
+    return 0;
+}


### PR DESCRIPTION
… of fuzzing

If a buffer smaller than Elf32_Ehdr was passed to Image, header()
would do an out-of-bounds read.

Make parse() check for that. Make most Image methods assert that the image
is_valid(). For that to work, set m_valid early in Image::parse()
instead of only at its end.

Also reorder a few things so that the fuzzer doesn't hit (valid)
assertions, which were harmless from a security PoV but which still
allowed userspace to crash the kernel with an invalid ELF file.

Make dbgprintf()s configurable at run time so that the fuzzer doesn't
produce lots of logspam.

--

Since I had to make LibELF build in Lagom for the recent disasm change, adding a fuzzer was ~free, so why not. (Fixing the few things it found wasn't free.)