### PR TITLE
Shell: Allow redirection of (most) builtins to work

### DIFF
--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -78,7 +78,7 @@ public:
     RefPtr<Job> run_command(const AST::Command&);
     NonnullRefPtrVector<Job> run_commands(Vector<AST::Command>&);
     bool run_file(const String&, bool explicitly_invoked = true);
-    bool run_builtin(int argc, const char** argv, int& retval);
+    bool run_builtin(const AST::Command&, const NonnullRefPtrVector<AST::Rewiring>&, int& retval);
     bool has_builtin(const StringView&) const;
     void block_on_job(RefPtr<Job>);
     String prompt() const;
@@ -197,7 +197,7 @@ private:
     virtual void custom_event(Core::CustomEvent&) override;
 
 #define __ENUMERATE_SHELL_BUILTIN(builtin) \
-    int builtin_##builtin(int argc, const char** argv);
+    int builtin_##builtin(const AST::Command&, const NonnullRefPtrVector<AST::Rewiring>&);
 
     ENUMERATE_SHELL_BUILTINS();
 


### PR DESCRIPTION
Theoretically closes #3072 in a way I do not like.
Some builtins cannot safely accept redirections (e.g. `fg`), and some cannot be redirected in a meaningful way (e.g. `bg`), these are all disallowed here.

It should be noted that this is still WIP and very likely not the best way to solve this particular issue.

As an aside, I really like the idea of `fork_and_resolve()` here (do some setup, run given function, return the value)

---

Some examples to try:
```sh
$ time ls | head > stuff
...
$ dirs > dirs
```