### PR TITLE
Shell: Fix fd leak with pipes

### DIFF
--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -535,6 +535,10 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
                 perror("dup2(run)");
                 return nullptr;
             }
+            // dest_fd is closed via the `fds` collector, but rewiring.other_pipe_end->dest_fd
+            // isn't yet in that collector when the first child spawns.
+            if (rewiring.other_pipe_end && close(rewiring.other_pipe_end->dest_fd) < 0)
+                perror("close other pipe end");
         }
 
         fds.collect();


### PR DESCRIPTION
Fixes the problem reported in #3073. While trying to write a test
for this, I thought I'd use

    Shell -c 'for i in $(seq 100) { echo $i }' | head -n 1

but that makes the cpu spin at 100% and doesn't terminate even
with this fix here. But at least piping disasm into head now works.