### PR TITLE
Shell: Cancel a running for loop upon receiving any non-SIGINT signal

### DIFF
--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -777,13 +777,15 @@ RefPtr<Value> ForLoop::run(RefPtr<Shell> shell)
             if (!job || job->is_running_in_background())
                 continue;
             shell->block_on_job(job);
-            if (job->signaled()
-                && (job->termination_signal() == SIGINT
-                    || job->termination_signal() == SIGKILL
-                    || job->termination_signal() == SIGQUIT))
-                ++consecutive_interruptions;
-            else
+
+            if (job->signaled()) {
+                if (job->termination_signal() == SIGINT)
+                    ++consecutive_interruptions;
+                else
+                    break;
+            } else {
                 consecutive_interruptions = 0;
+            }
         }
     }
 


### PR DESCRIPTION
And keep the old behaviour of needing two interruptions on SIGINT.
Fixes the `SIGPIPE` issue with https://github.com/SerenityOS/serenity/pull/3077#issuecomment-671513139