### PR TITLE
Kernel: Always return from Thread::wait_on

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -273,10 +273,6 @@ void Process::kill_threads_except_self()
         // At this point, we have no joiner anymore
         thread.m_joiner = nullptr;
         thread.set_should_die();
-
-        if (thread.state() != Thread::State::Dead)
-            thread.set_state(Thread::State::Dying);
-
         return IterationDecision::Continue;
     });
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -392,6 +392,7 @@ public:
     // Tell this thread to unblock if needed,
     // gracefully unwind the stack and die.
     void set_should_die();
+    bool should_die() const { return m_should_die; }
     void die_if_needed();
 
     bool tick();
@@ -521,7 +522,6 @@ public:
 private:
     IntrusiveListNode m_runnable_list_node;
     IntrusiveListNode m_wait_queue_node;
-    WaitQueue* m_wait_queue { nullptr };
 
 private:
     friend class SchedulerData;


### PR DESCRIPTION
We need to always return from Thread::wait_on, even when a thread
is being killed. This is necessary so that the kernel call stack
can clean up and release references held by it. Then, right before
transitioning back to user mode, we check if the thread is
supposed to die, and at that point change the thread state to
Dying to prevent further scheduling of this thread.

This addresses some possible resource leaks similar to #3073