### PR TITLE
LibWeb+LibJS: Clear exceptions in each Document::run_javascript() call / Assert when exception is not cleared before Interpreter::run()

### DIFF
--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -60,6 +60,8 @@ Interpreter::~Interpreter()
 
 Value Interpreter::run(GlobalObject& global_object, const Statement& statement, ArgumentVector arguments, ScopeType scope_type)
 {
+    ASSERT(!exception());
+
     if (statement.is_program()) {
         if (m_call_stack.is_empty()) {
             CallFrame global_call_frame;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -436,7 +436,11 @@ JS::Value Document::run_javascript(const StringView& source)
         parser.print_errors();
         return JS::js_undefined();
     }
-    return document().interpreter().run(document().interpreter().global_object(), *program);
+    auto& interpreter = document().interpreter();
+    auto result = interpreter.run(interpreter.global_object(), *program);
+    if (interpreter.exception())
+        interpreter.clear_exception();
+    return result;
 }
 
 NonnullRefPtr<Element> Document::create_element(const String& tag_name)


### PR DESCRIPTION
**LibWeb: Clear exceptions in each Document::run_javascript() call**

We don't want to carry over exceptions across multiple `Document::run_javascript()` calls as `Interpreter::run()` and every of its exception checks will get confused - in this case there would be an exception, but not because a certain action failed.

Real-life example:

```html
<script>var a = {}; a.test()</script>
<script>alert("It worked!")</script>
```

The above HTML will invoke `Document::run_javascript()` twice, the first call will result in a `TypeError`, which is still stored during the second call. The interpreter will eventually call the following functions (in order) for the `alert()` invocation:

- `Identifier::execute()`
- `Interpreter::get_variable()`
- `Object::get()` (on the global object)

That last `Object::get()` call has an exception check which is triggered as we still carry around the exception from earlier - and eventually returns an empty value.

Long story short, the second script will wrongly fail with "ReferenceError, 'alert' is not defined".

**LibJS: Assert when exception is not cleared before Interpreter::run()**

This is to prevent bugs like #3091 (fixed in 04d47ea) in the future; we generally
don't want `Interpreter::run()` to be called if the interpreter still has an exception stored. Sure, it could clear those itself but letting users of the interpreter do it explicitly seems sensible.