### PR TITLE
AK+LibCrypto+LibTLS+Kernel: Switch the Cipher::Mode interface to use Span

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -176,10 +176,11 @@ public:
         return this->m_values[index];
     }
 
-    ALWAYS_INLINE T& operator=(const T& other)
+    ALWAYS_INLINE Span& operator=(const Span<T>& other)
     {
         this->m_size = other.m_size;
         this->m_values = other.m_values;
+        return *this;
     }
 
     ALWAYS_INLINE operator Span<const T>() const

--- a/Kernel/Random.h
+++ b/Kernel/Random.h
@@ -68,12 +68,13 @@ public:
 
         typename CipherType::CTRMode cipher(m_key, KeySize);
 
-        auto wrapped_buffer = ByteBuffer::wrap(buffer, n);
-        m_counter = cipher.key_stream(wrapped_buffer, m_counter).value();
+        Bytes buffer_span { buffer, n };
+        auto counter_span = m_counter.span();
+        cipher.key_stream(buffer_span, counter_span, &counter_span);
 
         // Extract a new key from the prng stream.
 
-        m_counter = cipher.key_stream(m_key, m_counter).value();
+        cipher.key_stream(buffer_span, counter_span, &counter_span);
     }
 
     template<typename T>

--- a/Libraries/LibCrypto/Authentication/HMAC.h
+++ b/Libraries/LibCrypto/Authentication/HMAC.h
@@ -68,8 +68,11 @@ public:
         m_inner_hasher.update(message, length);
     }
 
+    TagType process(const ReadonlyBytes& span) { return process(span.data(), span.size()); }
     TagType process(const ByteBuffer& buffer) { return process(buffer.data(), buffer.size()); }
     TagType process(const StringView& string) { return process((const u8*)string.characters_without_null_termination(), string.length()); }
+
+    void update(const ReadonlyBytes& span) { return update(span.data(), span.size()); }
     void update(const ByteBuffer& buffer) { return update(buffer.data(), buffer.size()); }
     void update(const StringView& string) { return update((const u8*)string.characters_without_null_termination(), string.length()); }
 

--- a/Libraries/LibCrypto/Cipher/AES.cpp
+++ b/Libraries/LibCrypto/Cipher/AES.cpp
@@ -396,13 +396,11 @@ void AESCipher::decrypt_block(const AESCipherBlock& in, AESCipherBlock& out)
     // clang-format on
 }
 
-void AESCipherBlock::overwrite(const ByteBuffer& buffer)
+void AESCipherBlock::overwrite(const ReadonlyBytes& span)
 {
-    overwrite(buffer.data(), buffer.size());
-}
+    auto data = span.data();
+    auto length = span.size();
 
-void AESCipherBlock::overwrite(const u8* data, size_t length)
-{
     ASSERT(length <= m_data.size());
     m_data.overwrite(0, data, length);
     if (length < m_data.size()) {

--- a/Libraries/LibCrypto/Cipher/AES.h
+++ b/Libraries/LibCrypto/Cipher/AES.h
@@ -46,7 +46,7 @@ public:
     AESCipherBlock(const u8* data, size_t length, PaddingMode mode = PaddingMode::CMS)
         : AESCipherBlock(mode)
     {
-        overwrite(data, length);
+        CipherBlock::overwrite(data, length);
     }
 
     static size_t block_size() { return BlockSizeInBits / 8; };
@@ -54,8 +54,9 @@ public:
     virtual ByteBuffer get() const override { return m_data; };
     virtual const ByteBuffer& data() const override { return m_data; };
 
-    virtual void overwrite(const ByteBuffer&) override;
-    virtual void overwrite(const u8* data, size_t length) override;
+    virtual void overwrite(const ReadonlyBytes&) override;
+    virtual void overwrite(const ByteBuffer& buffer) override { overwrite(buffer.span()); }
+    virtual void overwrite(const u8* data, size_t size) override { overwrite({ data, size }); }
 
     virtual void apply_initialization_vector(const u8* ivec) override
     {

--- a/Libraries/LibCrypto/Cipher/Cipher.h
+++ b/Libraries/LibCrypto/Cipher/Cipher.h
@@ -64,12 +64,14 @@ public:
     virtual ByteBuffer get() const = 0;
     virtual const ByteBuffer& data() const = 0;
 
-    virtual void overwrite(const ByteBuffer&) = 0;
-    virtual void overwrite(const u8*, size_t) = 0;
+    virtual void overwrite(const ReadonlyBytes&) = 0;
+    virtual void overwrite(const ByteBuffer& buffer) { overwrite(buffer.span()); }
+    virtual void overwrite(const u8* data, size_t size) { overwrite({ data, size }); }
 
     virtual void apply_initialization_vector(const u8* ivec) = 0;
 
     PaddingMode padding_mode() const { return m_padding_mode; }
+    void set_padding_mode(PaddingMode mode) { m_padding_mode = mode; }
 
     template<typename T>
     void put(size_t offset, T value)

--- a/Libraries/LibTLS/Record.cpp
+++ b/Libraries/LibTLS/Record.cpp
@@ -77,12 +77,12 @@ void TLSv12::update_packet(ByteBuffer& packet)
 
             if (m_context.crypto.created == 1) {
                 // `buffer' will continue to be encrypted
-                auto buffer = ByteBuffer::create_zeroed(length);
+                auto buffer = ByteBuffer::create_uninitialized(length);
                 size_t buffer_position = 0;
                 auto iv_size = iv_length();
 
                 // We need enough space for a header, iv_length bytes of IV and whatever the packet contains
-                auto ct = ByteBuffer::create_zeroed(length + header_size + iv_size);
+                auto ct = ByteBuffer::create_uninitialized(length + header_size + iv_size);
 
                 // copy the header over
                 ct.overwrite(0, packet.data(), header_size - 2);

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -366,7 +366,7 @@ private:
 
     void consume(const ByteBuffer& record);
 
-    ByteBuffer hmac_message(const ByteBuffer& buf, const Optional<ByteBuffer> buf2, size_t mac_length, bool local = false);
+    ByteBuffer hmac_message(const ReadonlyBytes& buf, const Optional<ReadonlyBytes> buf2, size_t mac_length, bool local = false);
     void ensure_hmac(size_t digest_size, bool local);
 
     void update_packet(ByteBuffer& packet);


### PR DESCRIPTION
Following #3089, this gets rid of more ByteBuffer overhead, bringing the runtime of `disasm /bin/id` down to 2.5 seconds (best of 3)

and also (technically) doubles(-ish) the speed of all AES operations performed through the Mode API.