### PR TITLE
ProcFS+SystemMonitor: Better support for multi-threaded applications

### DIFF
--- a/Applications/SystemMonitor/CMakeLists.txt
+++ b/Applications/SystemMonitor/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SOURCES
     ProcessFileDescriptorMapWidget.cpp
     ProcessMemoryMapWidget.cpp
     ProcessModel.cpp
-    ProcessStacksWidget.cpp
+    ProcessStackWidget.cpp
     ProcessUnveiledPathsWidget.cpp
 )
 

--- a/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Applications/SystemMonitor/ProcessModel.cpp
@@ -90,6 +90,12 @@ String ProcessModel::column_name(int column) const
         return "PID";
     case Column::TID:
         return "TID";
+    case Column::PPID:
+        return "PPID";
+    case Column::PGID:
+        return "PGID";
+    case Column::SID:
+        return "SID";
     case Column::State:
         return "State";
     case Column::User:
@@ -165,6 +171,9 @@ GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, Role role) const
             return Gfx::TextAlignment::CenterLeft;
         case Column::PID:
         case Column::TID:
+        case Column::PPID:
+        case Column::PGID:
+        case Column::SID:
         case Column::Priority:
         case Column::EffectivePriority:
         case Column::Virtual:
@@ -202,6 +211,12 @@ GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, Role role) const
             return thread.current_state.pid;
         case Column::TID:
             return thread.current_state.tid;
+        case Column::PPID:
+            return thread.current_state.ppid;
+        case Column::PGID:
+            return thread.current_state.pgid;
+        case Column::SID:
+            return thread.current_state.sid;
         case Column::State:
             return thread.current_state.state;
         case Column::User:
@@ -273,6 +288,12 @@ GUI::Variant ProcessModel::data(const GUI::ModelIndex& index, Role role) const
             return thread.current_state.pid;
         case Column::TID:
             return thread.current_state.tid;
+        case Column::PPID:
+            return thread.current_state.ppid;
+        case Column::PGID:
+            return thread.current_state.pgid;
+        case Column::SID:
+            return thread.current_state.sid;
         case Column::State:
             return thread.current_state.state;
         case Column::User:
@@ -366,7 +387,10 @@ void ProcessModel::update()
 
             state.name = thread.name;
 
+            state.ppid = it.value.ppid;
             state.tid = thread.tid;
+            state.pgid = it.value.pgid;
+            state.sid = it.value.sid;
             state.times_scheduled = thread.times_scheduled;
             state.cpu = thread.cpu;
             state.priority = thread.priority;

--- a/Applications/SystemMonitor/ProcessModel.h
+++ b/Applications/SystemMonitor/ProcessModel.h
@@ -57,6 +57,9 @@ public:
         User,
         PID,
         TID,
+        PPID,
+        PGID,
+        SID,
         Virtual,
         Physical,
         DirtyPrivate,
@@ -107,8 +110,11 @@ private:
     ProcessModel();
 
     struct ThreadState {
-        int tid;
+        pid_t tid;
         pid_t pid;
+        pid_t ppid;
+        pid_t pgid;
+        pid_t sid;
         unsigned times_scheduled;
         String name;
         String state;

--- a/Applications/SystemMonitor/ProcessStackWidget.h
+++ b/Applications/SystemMonitor/ProcessStackWidget.h
@@ -24,44 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "ProcessStacksWidget.h"
-#include <AK/ByteBuffer.h>
-#include <LibCore/File.h>
-#include <LibCore/Timer.h>
-#include <LibGUI/BoxLayout.h>
+#pragma once
 
-ProcessStacksWidget::ProcessStacksWidget()
-{
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 4, 4, 4, 4 });
-    m_stacks_editor = add<GUI::TextEditor>();
-    m_stacks_editor->set_mode(GUI::TextEditor::ReadOnly);
+#include <LibGUI/TextEditor.h>
+#include <LibGUI/Widget.h>
 
-    m_timer = add<Core::Timer>(1000, [this] { refresh(); });
-}
+class ProcessStackWidget final : public GUI::Widget {
+    C_OBJECT(ProcessStackWidget)
+public:
+    virtual ~ProcessStackWidget() override;
 
-ProcessStacksWidget::~ProcessStacksWidget()
-{
-}
+    void set_ids(pid_t pid, pid_t tid);
+    void refresh();
 
-void ProcessStacksWidget::set_pid(pid_t pid)
-{
-    if (m_pid == pid)
-        return;
-    m_pid = pid;
-    refresh();
-}
+private:
+    ProcessStackWidget();
 
-void ProcessStacksWidget::refresh()
-{
-    auto file = Core::File::construct(String::format("/proc/%d/stack", m_pid));
-    if (!file->open(Core::IODevice::ReadOnly)) {
-        m_stacks_editor->set_text(String::format("Unable to open %s", file->filename().characters()));
-        return;
-    }
-
-    auto new_text = file->read_all();
-    if (m_stacks_editor->text() != new_text) {
-        m_stacks_editor->set_text(new_text);
-    }
-}
+    pid_t m_pid { -1 };
+    pid_t m_tid { -1 };
+    RefPtr<GUI::TextEditor> m_stack_editor;
+    RefPtr<Core::Timer> m_timer;
+};


### PR DESCRIPTION
This was my big secret plan behind #3057: Properly displaying stacks in SystemMonitor. :^)

Backstory: When trying to figure out what SystemMonitor was doing, I tried among other things using "kill" on a multi-threaded application, and ran into one of the bugs fixed by #3057 (PID/TID confusion in the `kill` syscall). Now that I know that SystemMonitor lists Threads, not processes, it is much clearer how to handle stacks!

Explanation: Until now, the "Stacks" tab displayed all stacks of a process, in plaintext format. This is a bit unwieldy. Because SystemMonitor lists the individual threads as distinct rows, the "Stack" (now singular) tab should instead show only a single stack: That of the selected thread.
The data comes from ProcFS, so now the individual stacks get listed as files in the new directory `/proc/<pid>/stacks/`. Thus, other tools automatically have access to this interface. (I found nothing that used `/proc/stacks`, so no changes needed.)

I considered and disregarded alternative designs:
- Putting it all into `/proc/all`: Total overkill, and would unnecessarily bloat that already-large file.
- Changing `/proc/<pid>/stack` to a JSON file: Kinda silly when the stacks themselves aren't JSON.
- Changing `/proc/<pid>/stack` to a JSON file, and changing all backtraces to JSON: Too much work, and the only real use currently is SystemMonitor, so the format of the individual stacks are fine already.