### PR TITLE
ScrollBar: Let clicking the gutter scroll by one page

### DIFF
--- a/Libraries/LibGUI/Event.h
+++ b/Libraries/LibGUI/Event.h
@@ -331,6 +331,10 @@ public:
     int y() const { return m_position.y(); }
     MouseButton button() const { return m_button; }
     unsigned buttons() const { return m_buttons; }
+    bool ctrl() const { return m_modifiers & Mod_Ctrl; }
+    bool alt() const { return m_modifiers & Mod_Alt; }
+    bool shift() const { return m_modifiers & Mod_Shift; }
+    bool logo() const { return m_modifiers & Mod_Logo; }
     unsigned modifiers() const { return m_modifiers; }
     int wheel_delta() const { return m_wheel_delta; }
 

--- a/Libraries/LibGUI/ScrollBar.cpp
+++ b/Libraries/LibGUI/ScrollBar.cpp
@@ -294,19 +294,7 @@ void ScrollBar::mousedown_event(MouseEvent& event)
         return;
     }
 
-    float range_size = m_max - m_min;
-    float available = scrubbable_range_in_pixels();
-
-    float x = ::max(0, event.position().x() - button_width() - button_width() / 2);
-    float y = ::max(0, event.position().y() - button_height() - button_height() / 2);
-
-    float rel_x = x / available;
-    float rel_y = y / available;
-
-    if (orientation() == Orientation::Vertical)
-        set_value(m_min + rel_y * range_size);
-    else
-        set_value(m_min + rel_x * range_size);
+    scroll_to_position(event.position());
 
     m_scrubbing = true;
     m_scrub_start_value = value();
@@ -340,6 +328,24 @@ void ScrollBar::set_automatic_scrolling_active(bool active)
     } else {
         m_automatic_scrolling_timer->stop();
     }
+}
+
+void ScrollBar::scroll_to_position(const Gfx::IntPoint& position)
+{
+    float range_size = m_max - m_min;
+    float available = scrubbable_range_in_pixels();
+
+    float x = ::max(0, position.x() - button_width() - button_width() / 2);
+    float y = ::max(0, position.y() - button_height() - button_height() / 2);
+
+    float rel_x = x / available;
+    float rel_y = y / available;
+
+    if (orientation() == Orientation::Vertical)
+        set_value(m_min + rel_y * range_size);
+    else
+        set_value(m_min + rel_x * range_size);
+
 }
 
 void ScrollBar::mousemove_event(MouseEvent& event)

--- a/Libraries/LibGUI/ScrollBar.cpp
+++ b/Libraries/LibGUI/ScrollBar.cpp
@@ -179,9 +179,9 @@ Gfx::IntRect ScrollBar::increment_gutter_rect() const
 int ScrollBar::scrubbable_range_in_pixels() const
 {
     if (orientation() == Orientation::Vertical)
-        return height() - button_height() * 2 - scrubber_size();
+        return height() - button_height() * 2 - visible_scrubber_size();
     else
-        return width() - button_width() * 2 - scrubber_size();
+        return width() - button_width() * 2 - visible_scrubber_size();
 }
 
 bool ScrollBar::has_scrubber() const
@@ -189,7 +189,7 @@ bool ScrollBar::has_scrubber() const
     return m_max != m_min;
 }
 
-int ScrollBar::scrubber_size() const
+int ScrollBar::visible_scrubber_size() const
 {
     int pixel_range = length(orientation()) - button_size() * 2;
     int value_range = m_max - m_min;
@@ -205,13 +205,13 @@ int ScrollBar::scrubber_size() const
 
 Gfx::IntRect ScrollBar::scrubber_rect() const
 {
-    if (!has_scrubber() || length(orientation()) <= (button_size() * 2) + scrubber_size())
+    if (!has_scrubber() || length(orientation()) <= (button_size() * 2) + visible_scrubber_size())
         return {};
     float x_or_y;
     if (m_value == m_min)
         x_or_y = button_size();
     else if (m_value == m_max)
-        x_or_y = (length(orientation()) - button_size() - scrubber_size()) + 1;
+        x_or_y = (length(orientation()) - button_size() - visible_scrubber_size()) + 1;
     else {
         float range_size = m_max - m_min;
         float available = scrubbable_range_in_pixels();
@@ -220,9 +220,9 @@ Gfx::IntRect ScrollBar::scrubber_rect() const
     }
 
     if (orientation() == Orientation::Vertical)
-        return { 0, (int)x_or_y, button_width(), scrubber_size() };
+        return { 0, (int)x_or_y, button_width(), visible_scrubber_size() };
     else
-        return { (int)x_or_y, 0, scrubber_size(), button_height() };
+        return { (int)x_or_y, 0, visible_scrubber_size(), button_height() };
 }
 
 void ScrollBar::paint_event(PaintEvent& event)

--- a/Libraries/LibGUI/ScrollBar.cpp
+++ b/Libraries/LibGUI/ScrollBar.cpp
@@ -330,22 +330,14 @@ void ScrollBar::set_automatic_scrolling_active(bool active)
     }
 }
 
-void ScrollBar::scroll_to_position(const Gfx::IntPoint& position)
+void ScrollBar::scroll_to_position(const Gfx::IntPoint& click_position)
 {
     float range_size = m_max - m_min;
     float available = scrubbable_range_in_pixels();
 
-    float x = ::max(0, position.x() - button_width() - button_width() / 2);
-    float y = ::max(0, position.y() - button_height() - button_height() / 2);
-
-    float rel_x = x / available;
-    float rel_y = y / available;
-
-    if (orientation() == Orientation::Vertical)
-        set_value(m_min + rel_y * range_size);
-    else
-        set_value(m_min + rel_x * range_size);
-
+    float x_or_y = ::max(0, click_position.primary_offset_for_orientation(orientation()) - button_width() - button_width() / 2);
+    float rel_x_or_y = x_or_y / available;
+    set_value(m_min + rel_x_or_y * range_size);
 }
 
 void ScrollBar::mousemove_event(MouseEvent& event)

--- a/Libraries/LibGUI/ScrollBar.h
+++ b/Libraries/LibGUI/ScrollBar.h
@@ -87,7 +87,7 @@ private:
     Gfx::IntRect decrement_gutter_rect() const;
     Gfx::IntRect increment_gutter_rect() const;
     Gfx::IntRect scrubber_rect() const;
-    int scrubber_size() const;
+    int visible_scrubber_size() const;
     int scrubbable_range_in_pixels() const;
     void on_automatic_scrolling_timer_fired();
     void set_automatic_scrolling_active(bool);

--- a/Libraries/LibGUI/ScrollBar.h
+++ b/Libraries/LibGUI/ScrollBar.h
@@ -92,6 +92,8 @@ private:
     void on_automatic_scrolling_timer_fired();
     void set_automatic_scrolling_active(bool);
 
+    void scroll_to_position(const Gfx::IntPoint&);
+
     int m_min { 0 };
     int m_max { 0 };
     int m_page { 0 };

--- a/Libraries/LibGUI/ScrollBar.h
+++ b/Libraries/LibGUI/ScrollBar.h
@@ -87,12 +87,14 @@ private:
     Gfx::IntRect decrement_gutter_rect() const;
     Gfx::IntRect increment_gutter_rect() const;
     Gfx::IntRect scrubber_rect() const;
+    int unclamped_scrubber_size() const;
     int visible_scrubber_size() const;
     int scrubbable_range_in_pixels() const;
     void on_automatic_scrolling_timer_fired();
     void set_automatic_scrolling_active(bool);
 
     void scroll_to_position(const Gfx::IntPoint&);
+    void scroll_by_page(const Gfx::IntPoint&);
 
     int m_min { 0 };
     int m_max { 0 };

--- a/Libraries/LibGUI/ScrollableWidget.cpp
+++ b/Libraries/LibGUI/ScrollableWidget.cpp
@@ -61,7 +61,7 @@ void ScrollableWidget::mousewheel_event(MouseEvent& event)
         return;
     }
     // FIXME: The wheel delta multiplier should probably come from... somewhere?
-    if (event.modifiers() & Mod_Shift) {
+    if (event.shift()) {
         horizontal_scrollbar().set_value(horizontal_scrollbar().value() + event.wheel_delta() * 60);
     } else {
         vertical_scrollbar().set_value(vertical_scrollbar().value() + event.wheel_delta() * 20);


### PR DESCRIPTION
Shift-clicking has the old behavior of jumping to the click position.

This matches scrollbar behavior in macOS and Windows, and in many Linux apps.

Scrolling by page while the mouse is down isn't implemented yet. For now, this scrolls by one page for every click.