### PR TITLE
LibWeb: Fix #include <LibWeb/{DOM => HTML}/AttributeNames.h>

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -25,10 +25,10 @@
  */
 
 #include <LibWeb/CSS/SelectorEngine.h>
-#include <LibWeb/DOM/AttributeNames.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Text.h>
+#include <LibWeb/HTML/AttributeNames.h>
 
 namespace Web::SelectorEngine {
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -38,7 +38,6 @@
 #include <LibWeb/CSS/Parser/CSSParser.h>
 #include <LibWeb/CSS/SelectorEngine.h>
 #include <LibWeb/CSS/StyleResolver.h>
-#include <LibWeb/DOM/AttributeNames.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentType.h>
 #include <LibWeb/DOM/Element.h>
@@ -46,6 +45,7 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/DOM/Window.h>
 #include <LibWeb/Dump.h>
+#include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/HTMLBodyElement.h>
 #include <LibWeb/HTML/HTMLHeadElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -29,10 +29,10 @@
 #include <AK/FlyString.h>
 #include <AK/String.h>
 #include <LibWeb/DOM/Attribute.h>
-#include <LibWeb/DOM/AttributeNames.h>
 #include <LibWeb/DOM/NonDocumentTypeChildNode.h>
 #include <LibWeb/DOM/ParentNode.h>
 #include <LibWeb/DOM/TagNames.h>
+#include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/Layout/LayoutNode.h>
 
 namespace Web::DOM {

--- a/Libraries/LibWeb/DOM/NonElementParentNode.h
+++ b/Libraries/LibWeb/DOM/NonElementParentNode.h
@@ -27,8 +27,8 @@
 #pragma once
 
 #include <AK/Forward.h>
-#include <LibWeb/DOM/AttributeNames.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/TreeNode.h>
 
 namespace Web::DOM {

--- a/Libraries/LibWeb/HTML/AttributeNames.cpp
+++ b/Libraries/LibWeb/HTML/AttributeNames.cpp
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibWeb/DOM/AttributeNames.h>
+#include <LibWeb/HTML/AttributeNames.h>
 
 namespace Web {
 namespace HTML {


### PR DESCRIPTION
This file has been moved from DOM/ to HTML/ in a784090b91139776b26fbac2a8426de3abdea308.

Unbreaks the build :)