### PR TITLE
LibC: fix realloc in case of allocation failure

### DIFF
--- a/Libraries/LibC/malloc.cpp
+++ b/Libraries/LibC/malloc.cpp
@@ -405,7 +405,8 @@ void* calloc(size_t count, size_t size)
 {
     size_t new_size = count * size;
     auto* ptr = malloc(new_size);
-    memset(ptr, 0, new_size);
+    if (ptr)
+        memset(ptr, 0, new_size);
     return ptr;
 }
 
@@ -426,13 +427,18 @@ void* realloc(void* ptr, size_t size)
 {
     if (!ptr)
         return malloc(size);
+    if (!size)
+        return nullptr;
+
     LOCKER(malloc_lock());
     auto existing_allocation_size = malloc_size(ptr);
     if (size <= existing_allocation_size)
         return ptr;
     auto* new_ptr = malloc(size);
-    memcpy(new_ptr, ptr, min(existing_allocation_size, size));
-    free(ptr);
+    if (new_ptr) {
+        memcpy(new_ptr, ptr, min(existing_allocation_size, size));
+        free(ptr);
+    }
     return new_ptr;
 }
 

--- a/Libraries/LibC/stdlib.h
+++ b/Libraries/LibC/stdlib.h
@@ -42,7 +42,7 @@ __attribute__((malloc)) __attribute__((alloc_size(1))) void* malloc(size_t);
 __attribute__((malloc)) __attribute__((alloc_size(1, 2))) void* calloc(size_t nmemb, size_t);
 size_t malloc_size(void*);
 void free(void*);
-void* realloc(void* ptr, size_t);
+__attribute__((alloc_size(2))) void* realloc(void* ptr, size_t);
 char* getenv(const char* name);
 int putenv(char*);
 int unsetenv(const char*);


### PR DESCRIPTION
If the space cannot be allocated, the original memory block shall remain
unchanged and the function should return null