### PR TITLE
LibGfx: fix transparency issues in GIFDecoder

### DIFF
--- a/Libraries/LibGfx/GIFLoader.cpp
+++ b/Libraries/LibGfx/GIFLoader.cpp
@@ -292,11 +292,6 @@ static bool decode_frames_up_to_index(GIFLoadingContext& context, size_t frame_i
         }
 
         int pixel_index = 0;
-        RGB transparent_color { 0, 0, 0 };
-        if (image.transparent) {
-            transparent_color = context.logical_screen.color_map[image.transparency_index];
-        }
-
         while (true) {
             Optional<u16> code = decoder.next_code();
             if (!code.has_value()) {
@@ -321,13 +316,14 @@ static bool decode_frames_up_to_index(GIFLoadingContext& context, size_t frame_i
 
                 Color c = Color(rgb.r, rgb.g, rgb.b);
 
-                if (image.transparent) {
-                    if (rgb.r == transparent_color.r && rgb.g == transparent_color.g && rgb.b == transparent_color.b) {
-                        c.set_alpha(0);
-                    }
+                if (image.transparent && color == image.transparency_index) {
+                    c.set_alpha(0);
                 }
 
-                image.bitmap->set_pixel(x, y, c);
+                if (!image.transparent || image.disposal_method == ImageDescriptor::DisposalMethod::None || color != image.transparency_index) {
+                    image.bitmap->set_pixel(x, y, c);
+                }
+
                 ++pixel_index;
             }
         }


### PR DESCRIPTION
This fixes #2990 caused by transparent pixels in GIF animation frames having their alpha values incorrectly set to zero, allowing the background behind the GIF to show through, instead of the previous animation frame.

Additionally, transparent pixels are now correctly identified based on their index matching the image transparency index, instead of their color values.

Lastly, the disposal method on a GIF animation frame now correctly applies to rendering of the next frame, which fixes issues with the RestoreBackground disposal method not working when applied to first frame.

Google Doodle from 05/08/2020 now renders correctly:

![transparentgif](https://user-images.githubusercontent.com/328124/90066894-3fd90f00-dce6-11ea-9d18-2c128055edc5.gif)
