### PR TITLE
LibGUI: Fix ComboBox desktop intersection rect

### DIFF
--- a/Libraries/LibGUI/ComboBox.cpp
+++ b/Libraries/LibGUI/ComboBox.cpp
@@ -186,8 +186,13 @@ void ComboBox::open()
         model()->row_count() * m_list_view->item_height() + m_list_view->frame_thickness() * 2
     };
 
+    auto taskbar_height = GUI::Desktop::the().taskbar_height();
+    auto menubar_height = GUI::Desktop::the().menubar_height();
+    // NOTE: This is so the combobox bottom edge exactly fits the taskbar's
+    //       top edge - the value was found through trial and error though.
+    auto offset = 8;
     Gfx::IntRect list_window_rect { my_screen_rect.bottom_left(), size };
-    list_window_rect.intersect(Desktop::the().rect().shrunken(0, 128));
+    list_window_rect.intersect(Desktop::the().rect().shrunken(0, taskbar_height + menubar_height + offset));
 
     if (m_list_view->hover_highlighting())
         m_list_view->set_last_valid_hovered_index({});

--- a/Libraries/LibGUI/Desktop.h
+++ b/Libraries/LibGUI/Desktop.h
@@ -46,6 +46,10 @@ public:
     bool set_wallpaper(const StringView& path);
 
     Gfx::IntRect rect() const { return m_rect; }
+
+    int taskbar_height() const { return 28; }
+    int menubar_height() const { return 19; }
+
     void did_receive_screen_rect(Badge<WindowServerConnection>, const Gfx::IntRect&);
 
     Function<void(const Gfx::IntRect&)> on_rect_change;


### PR DESCRIPTION
Subtracting 128 from the desktop rect's height was far to much and and leading to weird rendering issues - now it's calculated exactly from taskbar and menubar heights as well as a little additional offset to make it fit perfectly.

Fixes #3115.

![image](https://user-images.githubusercontent.com/19366641/90141500-7ad95200-dd7b-11ea-8994-11327f7e2268.png)
