### PR TITLE
LibGUI: Fix ColorPicker custom color offset

### DIFF
--- a/Libraries/LibGUI/ColorPicker.cpp
+++ b/Libraries/LibGUI/ColorPicker.cpp
@@ -418,7 +418,10 @@ void CustomColorWidget::pick_color_at_position(GUI::MouseEvent& event)
     if (!frame_inner_rect().contains(position))
         return;
 
-    auto color = m_custom_colors->get_pixel(position);
+    // Map actual event position onto scaled bitmap to get the right pixel
+    auto pixel_x = min(position.x() * m_custom_colors->width() / frame_inner_rect().width(), m_custom_colors->width() - 1);
+    auto pixel_y = min(position.y() * m_custom_colors->height() / frame_inner_rect().height(), m_custom_colors->height() - 1);
+    auto color = m_custom_colors->get_pixel({ pixel_x, pixel_y });
     m_last_position = position;
 
     if (on_pick)


### PR DESCRIPTION
Previously the `ColorPicker` would get the custom color directly from the window, this was changed in d7d57884694ad5fda53e865f1b92ef48fddc9ca8 to get the color from the underlying bitmap instead - without taking the bitmap's scaling into effect though, so resulting colors were off by quite a bit.

Fixes #3113.

Before and after:

![image](https://user-images.githubusercontent.com/19366641/90149360-b298c780-dd84-11ea-8512-6e5524d50f99.png)

![image](https://user-images.githubusercontent.com/19366641/90149206-8715dd00-dd84-11ea-8ffe-2f57997c926a.png)
