### PR TITLE
Kernel: Fix rng regression from bc7a149039

### DIFF
--- a/Kernel/Random.h
+++ b/Kernel/Random.h
@@ -73,8 +73,8 @@ public:
         cipher.key_stream(buffer_span, counter_span, &counter_span);
 
         // Extract a new key from the prng stream.
-
-        cipher.key_stream(buffer_span, counter_span, &counter_span);
+        Bytes key_span = m_key.span();
+        cipher.key_stream(key_span, counter_span, &counter_span);
     }
 
     template<typename T>


### PR DESCRIPTION
@alimpfard @Petelliott Not sure what the implications of this were, but before bc7a149039 this refreshed m_key, so it's probably good if it keeps doing that.