### PR TITLE
LibGUI+WindowServer: Make tooltips work for menu applets

### DIFF
--- a/Libraries/LibGUI/Widget.cpp
+++ b/Libraries/LibGUI/Widget.cpp
@@ -464,7 +464,10 @@ Gfx::IntRect Widget::window_relative_rect() const
 
 Gfx::IntRect Widget::screen_relative_rect() const
 {
-    return window_relative_rect().translated(window()->position());
+    auto window_position = window()->window_type() == WindowType::MenuApplet
+        ? window()->rect_in_menubar().location()
+        : window()->rect().location();
+    return window_relative_rect().translated(window_position);
 }
 
 Widget* Widget::child_at(const Gfx::IntPoint& point) const

--- a/Libraries/LibGUI/Window.h
+++ b/Libraries/LibGUI/Window.h
@@ -82,6 +82,8 @@ public:
     void set_double_buffering_enabled(bool);
     void set_has_alpha_channel(bool);
     void set_opacity(float);
+
+    WindowType window_type() const { return m_window_type; }
     void set_window_type(WindowType);
 
     int window_id() const { return m_window_id; }

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -901,6 +901,12 @@ void WindowManager::process_mouse_event(MouseEvent& event, Window*& hovered_wind
 
     // FIXME: Now that the menubar has a dedicated window, is this special-casing really necessary?
     if (MenuManager::the().has_open_menu() || menubar_rect().contains(event.position())) {
+        for_each_visible_window_of_type_from_front_to_back(WindowType::MenuApplet, [&](auto& window) {
+            if (!window.rect_in_menubar().contains(event.position()))
+                return IterationDecision::Continue;
+            hovered_window = &window;
+            return IterationDecision::Break;
+        });
         clear_resize_candidate();
         MenuManager::the().dispatch_event(event);
         return;


### PR DESCRIPTION
cc @nico

Lots of debugging, pretty simple fixes. Never have I been so happy about a working tooltip :^)

Allow me to dump some commit messages.

---

**LibGUI: Add Window::window_type()**

We already have `Window::set_window_type()`, so a getter for `m_window_type` makes sense as well.

_Side note, in WindowServer-land this is just called `m_type` and `type()`, but as I'm saying - `set_window_type()` already is a thing, so `window_type()` made sense. (this is required for the next commit, btw)_

---

**LibGUI: Fix Widget::screen_relative_rect() for WindowType::MenuApplet**

This was using `window()->position()`, which is unset for windows with `WindowType::MenuApplet`. Now it checks the window type and then uses `rect_in_menubar()` for `MenuApplet` windows and `rect()` for everything else.

This makes tooltips show up for `MenuApplet` windows, previously they were positioned off-screen :^)

---

**WindowServer: Take MenuApplet windows into account for hovered_window**

This finally makes tooltips on menu applets the same as everywhere else!

Here's what went wrong:
`WindowManager::process_mouse_event()` receives a `Window*&`, determines the hovered window and sets it accordingly. However there's a branch that tests for `menubar_rect().contains(event.position())` and returns early - which resulted in `hovered_window` never being set to any `MenuApplet` window, even hovered ones.

The `hovered_window` result is being used in `WindowManager::event()` and passed to `WindowManager::set_hovered_window()`, which is responsible for creating `WindowLeft` and `WindowEntered` events when the hovered window changes, as a result of the mentioned chain of events this also never happens for `MenuApplet` windows. The `WindowLeft` event would the cause `Window::handle_left_event()` in LibGUI to be called, which unsets the window's hovered widget, which
is necessary for the widget to receive a subsequent `Enter` event - again, all of this never happened.

Now it's working as expected though, so we can start using tooltips on menu applets :^)