### PR TITLE
LibGUI: Add a timer in ProcessChooser to get processes for every 1000ms

### DIFF
--- a/Libraries/LibGUI/ProcessChooser.h
+++ b/Libraries/LibGUI/ProcessChooser.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <LibGUI/Dialog.h>
+#include <LibCore/Timer.h>
 
 namespace GUI {
 
@@ -46,6 +47,10 @@ private:
     String m_window_title;
     String m_button_label;
     RefPtr<Gfx::Bitmap> m_window_icon;
+
+    bool m_refresh_enabled { true };
+    unsigned m_refresh_interval { 1000 };
+    RefPtr<Core::Timer> m_refresh_timer;
 };
 
 }


### PR DESCRIPTION
Added a `timer` in `ProcessChooser` to get the process list for every 150ms.

This PR addresses https://github.com/SerenityOS/serenity/issues/2977#issuecomment-668109216.