### PR TITLE
2048: Better scoring

### DIFF
--- a/Games/2048/2048.cpp
+++ b/Games/2048/2048.cpp
@@ -235,14 +235,6 @@ void TwentyFortyEightGame::keydown_event(GUI::KeyEvent& event)
     case KeyCode::Key_Down:
         new_state.board = reverse(slide_left(reverse(previous_state.board), successful_merge_score));
         break;
-    case KeyCode::Key_U:
-    case KeyCode::Key_Backspace:
-        if (m_states.size() > 1) {
-            m_states.take_last();
-            update();
-        } else {
-            return;
-        }
     default:
         return;
     }
@@ -348,4 +340,13 @@ void TwentyFortyEightGame::game_over()
 int TwentyFortyEightGame::score() const
 {
     return m_states.last().score;
+}
+
+void TwentyFortyEightGame::undo()
+{
+    if (m_states.size() > 1) {
+        m_states.take_last();
+        --m_current_turn;
+        update();
+    }
 }

--- a/Games/2048/2048.h
+++ b/Games/2048/2048.h
@@ -36,6 +36,7 @@ public:
 
     void reset();
     int score() const;
+    void undo();
 
     struct State {
         Vector<Vector<u32>> board;

--- a/Games/2048/2048.h
+++ b/Games/2048/2048.h
@@ -39,6 +39,7 @@ public:
 
     struct State {
         Vector<Vector<u32>> board;
+        size_t score { 0 };
         String score_text;
     };
 
@@ -56,6 +57,7 @@ private:
     int m_rows { 4 };
     int m_columns { 4 };
     u32 m_starting_tile { 2 };
+    size_t m_current_turn { 0 };
 
     Vector<State, 16> m_states;
 };

--- a/Games/2048/main.cpp
+++ b/Games/2048/main.cpp
@@ -75,6 +75,9 @@ int main(int argc, char** argv)
     app_menu.add_action(GUI::Action::create("New game", { Mod_None, Key_F2 }, [&](auto&) {
         game.reset();
     }));
+    app_menu.add_action(GUI::CommonActions::make_undo_action([&](auto&) {
+        game.undo();
+    }));
     app_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
         GUI::Application::the()->quit();
     }));


### PR DESCRIPTION
> The scoring system is a bit lame

No longer!
The added score is logarithmically proportional to the merged tiles, and reversely proportional to the game time (i.e. the more turns you take, the less score you get).

Also moves out the undo action to the app menu.