### PR TITLE
Kernel: Briefly resume stopped threads when being killed

### DIFF
--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -270,6 +270,8 @@ public:
     void did_schedule() { ++m_times_scheduled; }
     u32 times_scheduled() const { return m_times_scheduled; }
 
+    void resume_from_stopped();
+
     bool is_stopped() const { return m_state == Stopped; }
     bool is_blocked() const { return m_state == Blocked; }
     bool has_blocker() const


### PR DESCRIPTION
We need to briefly put Stopped threads back into Running state
so that the kernel stacks can get cleaned up when they're being
killed.

Fixes #3130