### PR TITLE
Shell: Allow redirections and pipes on builtins

### DIFF
--- a/Shell/Execution.h
+++ b/Shell/Execution.h
@@ -26,7 +26,9 @@
 
 #pragma once
 
+#include "Forward.h"
 #include <AK/Forward.h>
+#include <AK/NonnullRefPtrVector.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/ElapsedTimer.h>
@@ -41,4 +43,19 @@ public:
 
 private:
     Vector<int, 32> m_fds;
+};
+
+class SavedFileDescriptors {
+public:
+    SavedFileDescriptors(const NonnullRefPtrVector<AST::Rewiring>&);
+    ~SavedFileDescriptors();
+
+private:
+    struct SavedFileDescriptor {
+        int original { -1 };
+        int saved { -1 };
+    };
+
+    Vector<SavedFileDescriptor> m_saves;
+    FileDescriptionCollector m_collector;
 };

--- a/Shell/Forward.h
+++ b/Shell/Forward.h
@@ -33,5 +33,6 @@ class Node;
 class Value;
 class SyntaxError;
 class Pipeline;
+class Rewiring;
 
 }

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -500,6 +500,10 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
             return nullptr;
     }
 
+    int retval = 0;
+    if (run_builtin(command, rewirings, retval))
+        return nullptr;
+
     Vector<const char*> argv;
     Vector<String> copy_argv = command.argv;
     argv.ensure_capacity(command.argv.size() + 1);
@@ -508,10 +512,6 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
         argv.append(arg.characters());
 
     argv.append(nullptr);
-
-    int retval = 0;
-    if (run_builtin(argv.size() - 1, argv.data(), retval))
-        return nullptr;
 
     int sync_pipe[2];
     if (pipe(sync_pipe) < 0) {

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -78,7 +78,7 @@ public:
     RefPtr<Job> run_command(const AST::Command&);
     NonnullRefPtrVector<Job> run_commands(Vector<AST::Command>&);
     bool run_file(const String&, bool explicitly_invoked = true);
-    bool run_builtin(int argc, const char** argv, int& retval);
+    bool run_builtin(const AST::Command&, const NonnullRefPtrVector<AST::Rewiring>&, int& retval);
     bool has_builtin(const StringView&) const;
     void block_on_job(RefPtr<Job>);
     String prompt() const;

--- a/Shell/Tests/builtin-redir.sh
+++ b/Shell/Tests/builtin-redir.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+rm -rf shell-test
+mkdir -p shell-test
+cd shell-test
+
+    time sleep 1 2>timeerr >timeout
+    cat timeout
+    # We cannot be sure about the values, so just assert that they're not empty.
+    test -n "$(cat timeerr)" || echo "Failure: 'time' stderr output not redirected correctly" && exit 1
+    test -e timeout || echo "Failure: 'time' stdout output not redirected correctly" && exit 1
+
+    time ls 2> /dev/null | head > timeout
+    test -n "$(cat timeout)" || echo "Failure: 'time' stdout not piped correctly" && exit 1
+
+cd ..
+rm -rf shell-test # TODO: Remove this file at the end once we have `trap'


### PR DESCRIPTION
Fixes #3072.

While this does indeed fix that, `time` will still fail to play well with pipes, as the command will run to completion before any other piped command after it is even invoked.
e.g.
```sh
time long-running-command foo bar | head
```
will wait for the entirety of `long-running-command`'s runtime before invoking `head`.