### PR TITLE
FileManager: Apply wallpaper on startup

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -40,6 +40,7 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Clipboard.h>
+#include <LibGUI/Desktop.h>
 #include <LibGUI/FileSystemModel.h>
 #include <LibGUI/InputBox.h>
 #include <LibGUI/Label.h>
@@ -241,6 +242,12 @@ int run_in_desktop_mode(RefPtr<Core::ConfigFile> config, String initial_location
         if (!index.is_valid())
             desktop_view_context_menu->popup(event.screen_position());
     };
+
+    auto wm_config = Core::ConfigFile::get_for_app("WindowManager");
+    auto selected_wallpaper = wm_config->read_entry("Background", "Wallpaper", "");
+    if (!selected_wallpaper.is_empty()) {
+        GUI::Desktop::the().set_wallpaper(selected_wallpaper, false);
+    }
 
     window->show();
     return GUI::Application::the()->exec();

--- a/Libraries/LibGUI/Desktop.cpp
+++ b/Libraries/LibGUI/Desktop.cpp
@@ -64,12 +64,12 @@ void Desktop::set_wallpaper_mode(const StringView& mode)
     WindowServerConnection::the().post_message(Messages::WindowServer::SetWallpaperMode(mode));
 }
 
-bool Desktop::set_wallpaper(const StringView& path)
+bool Desktop::set_wallpaper(const StringView& path, bool save_config)
 {
     WindowServerConnection::the().post_message(Messages::WindowServer::AsyncSetWallpaper(path));
     auto ret_val = WindowServerConnection::the().wait_for_specific_message<Messages::WindowClient::AsyncSetWallpaperFinished>()->success();
 
-    if (ret_val) {
+    if (ret_val && save_config) {
         RefPtr<Core::ConfigFile> config = Core::ConfigFile::get_for_app("WindowManager");
         dbg() << "Saving wallpaper path '" << path << "' to config file at " << config->file_name();
         config->write_entry("Background", "Wallpaper", path);

--- a/Libraries/LibGUI/Desktop.h
+++ b/Libraries/LibGUI/Desktop.h
@@ -43,7 +43,7 @@ public:
     void set_wallpaper_mode(const StringView& mode);
 
     String wallpaper() const;
-    bool set_wallpaper(const StringView& path);
+    bool set_wallpaper(const StringView& path, bool save_config = true);
 
     Gfx::IntRect rect() const { return m_rect; }
 


### PR DESCRIPTION
I noticed that nothing actually applies the wallpaper on startup.
I wasn't sure where to put the responsibility, so I gave it to
the desktop mode file manager.

Also adds a save_config option to set_wallpaper so it doesn't
needlessly save the config.