### PR TITLE
LibGUI: Update active tooltip when source widget changes the label

### DIFF
--- a/Libraries/LibGUI/Application.cpp
+++ b/Libraries/LibGUI/Application.cpp
@@ -115,7 +115,7 @@ public:
     {
         // FIXME: Add some kind of GUI::Label auto-sizing feature.
         int text_width = m_label->font().width(tooltip);
-        set_rect(100, 100, text_width + 10, m_label->font().glyph_height() + 8);
+        set_rect(rect().x(), rect().y(), text_width + 10, m_label->font().glyph_height() + 8);
         m_label->set_text(tooltip);
     }
 
@@ -134,8 +134,9 @@ private:
     RefPtr<Label> m_label;
 };
 
-void Application::show_tooltip(const StringView& tooltip, const Gfx::IntPoint& screen_location)
+void Application::show_tooltip(const StringView& tooltip, const Gfx::IntPoint& screen_location, const Widget* tooltip_source_widget)
 {
+    m_tooltip_source_widget = tooltip_source_widget;
     if (!m_tooltip_window) {
         m_tooltip_window = TooltipWindow::construct();
         m_tooltip_window->set_double_buffering_enabled(false);
@@ -159,6 +160,7 @@ void Application::show_tooltip(const StringView& tooltip, const Gfx::IntPoint& s
 
 void Application::hide_tooltip()
 {
+    m_tooltip_source_widget = nullptr;
     if (m_tooltip_window) {
         m_tooltip_window->hide();
         m_tooltip_window = nullptr;

--- a/Libraries/LibGUI/Application.h
+++ b/Libraries/LibGUI/Application.h
@@ -32,6 +32,7 @@
 #include <LibCore/Object.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Shortcut.h>
+#include <LibGUI/Widget.h>
 #include <LibGfx/Forward.h>
 
 namespace GUI {
@@ -53,8 +54,9 @@ public:
     void register_global_shortcut_action(Badge<Action>, Action&);
     void unregister_global_shortcut_action(Badge<Action>, Action&);
 
-    void show_tooltip(const StringView&, const Gfx::IntPoint& screen_location);
+    void show_tooltip(const StringView&, const Gfx::IntPoint& screen_location, const Widget* tooltip_source_widget);
     void hide_tooltip();
+    Widget* tooltip_source_widget() { return m_tooltip_source_widget; };
 
     bool quit_when_last_window_deleted() const { return m_quit_when_last_window_deleted; }
     void set_quit_when_last_window_deleted(bool b) { m_quit_when_last_window_deleted = b; }
@@ -82,6 +84,7 @@ private:
     HashMap<Shortcut, Action*> m_global_shortcut_actions;
     class TooltipWindow;
     RefPtr<TooltipWindow> m_tooltip_window;
+    RefPtr<Widget> m_tooltip_source_widget;
     bool m_quit_when_last_window_deleted { true };
     bool m_focus_debugging_enabled { false };
     String m_invoked_as;

--- a/Libraries/LibGUI/Widget.cpp
+++ b/Libraries/LibGUI/Widget.cpp
@@ -317,8 +317,7 @@ void Widget::handle_mousedoubleclick_event(MouseEvent& event)
 
 void Widget::handle_enter_event(Core::Event& event)
 {
-    if (has_tooltip())
-        Application::the()->show_tooltip(m_tooltip, screen_relative_rect().center().translated(0, height() / 2));
+    show_tooltip();
     enter_event(event);
 }
 
@@ -841,6 +840,19 @@ Gfx::IntRect Widget::content_rect() const
     rect.set_width(rect.width() - (m_content_margins.left() + m_content_margins.right()));
     rect.set_height(rect.height() - (m_content_margins.top() + m_content_margins.bottom()));
     return rect;
+}
+
+void Widget::set_tooltip(const StringView& tooltip)
+{
+    m_tooltip = tooltip;
+    if (GUI::Application::the()->tooltip_source_widget() == this)
+        show_tooltip();
+}
+
+void Widget::show_tooltip()
+{
+    if (has_tooltip())
+        Application::the()->show_tooltip(m_tooltip, screen_relative_rect().center().translated(0, height() / 2), this);
 }
 
 }

--- a/Libraries/LibGUI/Widget.h
+++ b/Libraries/LibGUI/Widget.h
@@ -28,6 +28,7 @@
 
 #include <AK/String.h>
 #include <LibCore/Object.h>
+#include <LibGUI/Application.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Margins.h>
@@ -113,7 +114,7 @@ public:
 
     bool has_tooltip() const { return !m_tooltip.is_empty(); }
     String tooltip() const { return m_tooltip; }
-    void set_tooltip(const StringView& tooltip) { m_tooltip = tooltip; }
+    void set_tooltip(const StringView&);
 
     bool is_enabled() const { return m_enabled; }
     void set_enabled(bool);
@@ -312,6 +313,8 @@ private:
     void handle_leave_event(Core::Event&);
     void focus_previous_widget(FocusSource);
     void focus_next_widget(FocusSource);
+
+    void show_tooltip();
 
     Window* m_window { nullptr };
     RefPtr<Layout> m_layout;

--- a/Libraries/LibWeb/PageView.cpp
+++ b/Libraries/LibWeb/PageView.cpp
@@ -183,7 +183,7 @@ void PageView::page_did_middle_click_link(const URL& url, const String& target, 
 
 void PageView::page_did_enter_tooltip_area(const Gfx::IntPoint& content_position, const String& title)
 {
-    GUI::Application::the()->show_tooltip(title, screen_relative_rect().location().translated(to_widget_position(content_position)));
+    GUI::Application::the()->show_tooltip(title, screen_relative_rect().location().translated(to_widget_position(content_position)), nullptr);
 }
 
 void PageView::page_did_leave_tooltip_area()


### PR DESCRIPTION
`Application::show_tooltip()` now keeps track of the application's active tooltip source widget so it can be updated while being shown when the same widget updates its tooltip label.
`Application::hide_tooltip()` will unset the tooltip source widget, respectively.

This is pretty useful for the `ResourceGraph` applet's tooltips!

Also re-use the `Application::TooltipWindow`'s rect position in its `set_tooltip()` method to avoid flickering from the window temporarily being moved to 100, 100 and the position adjusted moments later.

---

Demo:

![tooltip](https://user-images.githubusercontent.com/19366641/90310243-36bb8e00-def0-11ea-80f0-e462068a36ea.gif)