### PR TITLE
Meta: Cleanup minor stuff

### DIFF
--- a/Applications/SystemMonitor/CMakeLists.txt
+++ b/Applications/SystemMonitor/CMakeLists.txt
@@ -7,8 +7,8 @@ set(SOURCES
     ProcessFileDescriptorMapWidget.cpp
     ProcessMemoryMapWidget.cpp
     ProcessModel.cpp
-    ProcessStackWidget.cpp
     ProcessUnveiledPathsWidget.cpp
+    ThreadStackWidget.cpp
 )
 
 serenity_bin(SystemMonitor)

--- a/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -24,24 +24,45 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "ThreadStackWidget.h"
+#include <AK/ByteBuffer.h>
+#include <LibCore/File.h>
+#include <LibCore/Timer.h>
+#include <LibGUI/BoxLayout.h>
 
-#include <LibGUI/TextEditor.h>
-#include <LibGUI/Widget.h>
+ThreadStackWidget::ThreadStackWidget()
+{
+    set_layout<GUI::VerticalBoxLayout>();
+    layout()->set_margins({ 4, 4, 4, 4 });
+    m_stack_editor = add<GUI::TextEditor>();
+    m_stack_editor->set_mode(GUI::TextEditor::ReadOnly);
 
-class ProcessStackWidget final : public GUI::Widget {
-    C_OBJECT(ProcessStackWidget)
-public:
-    virtual ~ProcessStackWidget() override;
+    m_timer = add<Core::Timer>(1000, [this] { refresh(); });
+}
 
-    void set_ids(pid_t pid, pid_t tid);
-    void refresh();
+ThreadStackWidget::~ThreadStackWidget()
+{
+}
 
-private:
-    ProcessStackWidget();
+void ThreadStackWidget::set_ids(pid_t pid, pid_t tid)
+{
+    if (m_pid == pid && m_tid == tid)
+        return;
+    m_pid = pid;
+    m_tid = tid;
+    refresh();
+}
 
-    pid_t m_pid { -1 };
-    pid_t m_tid { -1 };
-    RefPtr<GUI::TextEditor> m_stack_editor;
-    RefPtr<Core::Timer> m_timer;
-};
+void ThreadStackWidget::refresh()
+{
+    auto file = Core::File::construct(String::format("/proc/%d/stacks/%d", m_pid, m_tid));
+    if (!file->open(Core::IODevice::ReadOnly)) {
+        m_stack_editor->set_text(String::format("Unable to open %s", file->filename().characters()));
+        return;
+    }
+
+    auto new_text = file->read_all();
+    if (m_stack_editor->text() != new_text) {
+        m_stack_editor->set_text(new_text);
+    }
+}

--- a/Applications/SystemMonitor/ThreadStackWidget.h
+++ b/Applications/SystemMonitor/ThreadStackWidget.h
@@ -24,45 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "ProcessStackWidget.h"
-#include <AK/ByteBuffer.h>
-#include <LibCore/File.h>
-#include <LibCore/Timer.h>
-#include <LibGUI/BoxLayout.h>
+#pragma once
 
-ProcessStackWidget::ProcessStackWidget()
-{
-    set_layout<GUI::VerticalBoxLayout>();
-    layout()->set_margins({ 4, 4, 4, 4 });
-    m_stack_editor = add<GUI::TextEditor>();
-    m_stack_editor->set_mode(GUI::TextEditor::ReadOnly);
+#include <LibGUI/TextEditor.h>
+#include <LibGUI/Widget.h>
 
-    m_timer = add<Core::Timer>(1000, [this] { refresh(); });
-}
+class ThreadStackWidget final : public GUI::Widget {
+    C_OBJECT(ThreadStackWidget)
+public:
+    virtual ~ThreadStackWidget() override;
 
-ProcessStackWidget::~ProcessStackWidget()
-{
-}
+    void set_ids(pid_t pid, pid_t tid);
+    void refresh();
 
-void ProcessStackWidget::set_ids(pid_t pid, pid_t tid)
-{
-    if (m_pid == pid && m_tid == tid)
-        return;
-    m_pid = pid;
-    m_tid = tid;
-    refresh();
-}
+private:
+    ThreadStackWidget();
 
-void ProcessStackWidget::refresh()
-{
-    auto file = Core::File::construct(String::format("/proc/%d/stacks/%d", m_pid, m_tid));
-    if (!file->open(Core::IODevice::ReadOnly)) {
-        m_stack_editor->set_text(String::format("Unable to open %s", file->filename().characters()));
-        return;
-    }
-
-    auto new_text = file->read_all();
-    if (m_stack_editor->text() != new_text) {
-        m_stack_editor->set_text(new_text);
-    }
-}
+    pid_t m_pid { -1 };
+    pid_t m_tid { -1 };
+    RefPtr<GUI::TextEditor> m_stack_editor;
+    RefPtr<Core::Timer> m_timer;
+};

--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -31,7 +31,7 @@
 #include "ProcessFileDescriptorMapWidget.h"
 #include "ProcessMemoryMapWidget.h"
 #include "ProcessModel.h"
-#include "ProcessStackWidget.h"
+#include "ThreadStackWidget.h"
 #include "ProcessUnveiledPathsWidget.h"
 #include <LibCore/Timer.h>
 #include <LibGUI/AboutDialog.h>
@@ -316,7 +316,7 @@ int main(int argc, char** argv)
     auto& memory_map_widget = process_tab_widget.add_tab<ProcessMemoryMapWidget>("Memory map");
     auto& open_files_widget = process_tab_widget.add_tab<ProcessFileDescriptorMapWidget>("Open files");
     auto& unveiled_paths_widget = process_tab_widget.add_tab<ProcessUnveiledPathsWidget>("Unveiled paths");
-    auto& stack_widget = process_tab_widget.add_tab<ProcessStackWidget>("Stack");
+    auto& stack_widget = process_tab_widget.add_tab<ThreadStackWidget>("Stack");
 
     process_table_view.on_selection = [&](auto&) {
         auto pid = selected_id(ProcessModel::Column::PID);

--- a/Meta/refresh-serenity-qtcreator.sh
+++ b/Meta/refresh-serenity-qtcreator.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 
+set -e
+
 if [ -z "$SERENITY_ROOT" ]
-then echo "Serenity root not set. Please set environment variable first. E.g. export SERENITY_ROOT=$(git rev-parse --show-toplevel)"
+then
+    SERENITY_ROOT="$(git rev-parse --show-toplevel)"
+    echo "Serenity root not set. This is fine! Other scripts may require you to set the environment variable first, e.g.:"
+    echo "    export SERENITY_ROOT=${SERENITY_ROOT}"
 fi
 
-cd "$SERENITY_ROOT" || exit 1
-find . -name '*.ipc' -or -name '*.cpp' -or -name '*.idl' -or -name '*.c' -or -name '*.h' -or -name '*.S' -or -name '*.css' | grep -Fv Patches/ | grep -Fv Root/ | grep -Fv Ports/ | grep -Fv Toolchain/ | grep -Fv Base/ > serenity.files
+cd "$SERENITY_ROOT"
+
+find . \( -name Base -o -name Patches -o -name Ports -o -name Root -o -name Toolchain \) -prune -o \( -name '*.ipc' -or -name '*.cpp' -or -name '*.idl' -or -name '*.c' -or -name '*.h' -or -name '*.S' -or -name '*.css' \) -print > serenity.files


### PR DESCRIPTION
Sorry for the mixed bag, but I think this is easier than making two trivial PRs.

- SystemMonitor: [You asked for it](https://github.com/SerenityOS/serenity/pull/3095#discussion_r469113354) :)
- `Meta/refresh-serenity-qtcreator.sh`: Can operate without `$SERENITY_ROOT`, and most other scripts get it from Travis or CMake. Building ports still requires it, so the hint should remain.