### PR TITLE
LibGUI and a bunch of applications: Refactor window centering and use more automatic window placement

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -157,7 +157,7 @@ Tab::Tab(Type type)
     m_link_context_menu->add_separator();
     m_link_context_menu->add_action(GUI::Action::create("Download", [this](auto&) {
         auto window = GUI::Window::construct();
-        window->set_rect(300, 300, 300, 150);
+        window->resize(300, 150);
         auto url = m_link_context_menu_url;
         window->set_title(String::format("0%% of %s", url.basename().characters()));
         window->set_resizable(false);
@@ -262,7 +262,7 @@ Tab::Tab(Type type)
                 editor.set_text(source);
                 editor.set_mode(GUI::TextEditor::ReadOnly);
                 editor.set_ruler_visible(true);
-                window->set_rect(150, 150, 640, 480);
+                window->resize(640, 480);
                 window->set_title(url);
                 window->show();
                 (void)window.leak_ref();
@@ -277,7 +277,7 @@ Tab::Tab(Type type)
             if (m_type == Type::InProcessWebView) {
                 if (!m_dom_inspector_window) {
                     m_dom_inspector_window = GUI::Window::construct();
-                    m_dom_inspector_window->set_rect(100, 100, 300, 500);
+                    m_dom_inspector_window->resize(300, 500);
                     m_dom_inspector_window->set_title("DOM inspector");
                     m_dom_inspector_window->set_main_widget<InspectorWidget>();
                 }
@@ -300,7 +300,7 @@ Tab::Tab(Type type)
             if (m_type == Type::InProcessWebView) {
                 if (!m_console_window) {
                     m_console_window = GUI::Window::construct();
-                    m_console_window->set_rect(100, 100, 500, 300);
+                    m_console_window->resize(500, 300);
                     m_console_window->set_title("JS Console");
                     m_console_window->set_main_widget<ConsoleWidget>();
                 }

--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -139,7 +139,7 @@ static RefPtr<GUI::Window> create_settings_window(TerminalWidget& terminal)
     auto window = GUI::Window::construct();
     window->set_title("Terminal Settings");
     window->set_resizable(false);
-    window->set_rect(50, 50, 200, 185);
+    window->resize(200, 185);
     window->set_modal(true);
 
     auto& settings = window->set_main_widget<GUI::Widget>();

--- a/Applications/Welcome/main.cpp
+++ b/Applications/Welcome/main.cpp
@@ -35,7 +35,6 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
-#include <LibGUI/Desktop.h>
 #include <LibGUI/ImageWidget.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/MessageBox.h>
@@ -156,10 +155,8 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Welcome");
-    Gfx::IntRect window_rect { 0, 0, 640, 360 };
-    window_rect.center_within(GUI::Desktop::the().rect());
-    window->set_resizable(true);
-    window->set_rect(window_rect);
+    window->resize(640, 360);
+    window->center_on_screen();
 
     auto& background = window->set_main_widget<BackgroundWidget>();
     background.set_fill_with_background_color(false);

--- a/Demos/Cube/Cube.cpp
+++ b/Demos/Cube/Cube.cpp
@@ -196,7 +196,7 @@ int main(int argc, char** argv)
     window->set_double_buffering_enabled(true);
     window->set_title("Cube");
     window->set_resizable(false);
-    window->set_rect(100, 100, WIDTH, HEIGHT);
+    window->resize(WIDTH, HEIGHT);
 
     auto& cube = window->set_main_widget<Cube>();
 

--- a/Demos/Eyes/main.cpp
+++ b/Demos/Eyes/main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char* argv[])
     auto window = GUI::Window::construct();
     window->set_title("Eyes");
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-eyes.png"));
-    window->set_rect(350, 270, 75 * (full_rows > 0 ? max_in_row : extra_columns), 100 * (full_rows + (extra_columns > 0 ? 1 : 0)));
+    window->resize(75 * (full_rows > 0 ? max_in_row : extra_columns), 100 * (full_rows + (extra_columns > 0 ? 1 : 0)));
     window->set_has_alpha_channel(true);
 
     auto& eyes = window->set_main_widget<EyesWidget>(num_eyes, full_rows, extra_columns);

--- a/Demos/Fire/Fire.cpp
+++ b/Demos/Fire/Fire.cpp
@@ -228,7 +228,7 @@ int main(int argc, char** argv)
     window->set_double_buffering_enabled(false);
     window->set_title("Fire");
     window->set_resizable(false);
-    window->set_rect(100, 100, 640, 400);
+    window->resize(640, 400);
 
     auto& fire = window->set_main_widget<Fire>();
 

--- a/Demos/HelloWorld/main.cpp
+++ b/Demos/HelloWorld/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
     auto app = GUI::Application::construct(argc, argv);
 
     auto window = GUI::Window::construct();
-    window->set_rect(100, 100, 240, 160);
+    window->resize(240, 160);
     window->set_title("Hello World!");
 
     auto& main_widget = window->set_main_widget<GUI::Widget>();

--- a/Demos/LibGfxDemo/main.cpp
+++ b/Demos/LibGfxDemo/main.cpp
@@ -202,7 +202,7 @@ int main(int argc, char** argv)
     window->set_double_buffering_enabled(true);
     window->set_title("LibGfx Demo");
     window->set_resizable(false);
-    window->set_rect(100, 100, WIDTH, HEIGHT);
+    window->resize(WIDTH, HEIGHT);
     window->set_main_widget<Canvas>();
     window->show();
 

--- a/Demos/WebView/main.cpp
+++ b/Demos/WebView/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
     auto& view = main_widget.add<WebContentView>();
     auto& statusbar = main_widget.add<GUI::StatusBar>();
     window->set_title("WebView");
-    window->set_rect(100, 100, 640, 480);
+    window->resize(640, 480);
     window->show();
 
     view.on_title_change = [&](auto& title) {

--- a/Demos/WidgetGallery/main.cpp
+++ b/Demos/WidgetGallery/main.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
     auto app_icon = GUI::Icon::default_icon("app-widget-gallery");
 
     auto window = GUI::Window::construct();
-    window->set_rect(100, 100, 430, 480);
+    window->resize(430, 480);
     window->set_title("Widget Gallery");
     window->set_icon(app_icon.bitmap_for_size(16));
 

--- a/DevTools/HackStudio/main.cpp
+++ b/DevTools/HackStudio/main.cpp
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
     Function<void()> update_actions;
 
     g_window = GUI::Window::construct();
-    g_window->set_rect(90, 90, 840, 600);
+    g_window->resize(840, 600);
     g_window->set_title("HackStudio");
 
     auto& widget = g_window->set_main_widget<GUI::Widget>();

--- a/DevTools/Inspector/main.cpp
+++ b/DevTools/Inspector/main.cpp
@@ -94,7 +94,7 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Inspector");
-    window->set_rect(150, 150, 685, 500);
+    window->resize(685, 500);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto menubar = GUI::MenuBar::construct();

--- a/DevTools/Profiler/main.cpp
+++ b/DevTools/Profiler/main.cpp
@@ -137,9 +137,8 @@ static bool prompt_to_stop_profiling()
     auto window = GUI::Window::construct();
     window->set_title("Profiling");
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-profiler.png"));
-    Gfx::IntRect window_rect { 0, 0, 320, 200 };
-    window_rect.center_within(GUI::Desktop::the().rect());
-    window->set_rect(window_rect);
+    window->resize(320, 200);
+    window->center_on_screen();
     auto& widget = window->set_main_widget<GUI::Widget>();
     widget.set_fill_with_background_color(true);
     widget.set_layout<GUI::VerticalBoxLayout>();

--- a/DevTools/Profiler/main.cpp
+++ b/DevTools/Profiler/main.cpp
@@ -80,8 +80,8 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("Profiler");
-    window->set_rect(100, 100, 800, 600);
     window->set_icon(app_icon.bitmap_for_size(16));
+    window->resize(800, 600);
 
     auto& main_widget = window->set_main_widget<GUI::Widget>();
     main_widget.set_fill_with_background_color(true);
@@ -136,8 +136,8 @@ static bool prompt_to_stop_profiling()
 {
     auto window = GUI::Window::construct();
     window->set_title("Profiling");
-    window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-profiler.png"));
     window->resize(320, 200);
+    window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-profiler.png"));
     window->center_on_screen();
     auto& widget = window->set_main_widget<GUI::Widget>();
     widget.set_fill_with_background_color(true);

--- a/Games/2048/main.cpp
+++ b/Games/2048/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char** argv)
 
     window->set_double_buffering_enabled(false);
     window->set_title("2048");
-    window->set_rect(100, 100, 324, 336);
+    window->resize(324, 336);
 
     auto& game = window->set_main_widget<TwentyFortyEightGame>();
     game.set_fill_with_background_color(true);

--- a/Games/Minesweeper/main.cpp
+++ b/Games/Minesweeper/main.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
     window->set_resizable(false);
     window->set_title("Minesweeper");
-    window->set_rect(100, 100, 139, 175);
+    window->resize(139, 175);
 
     auto& widget = window->set_main_widget<GUI::Widget>();
     widget.set_layout<GUI::VerticalBoxLayout>();

--- a/Games/Snake/main.cpp
+++ b/Games/Snake/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
 
     window->set_double_buffering_enabled(false);
     window->set_title("Snake");
-    window->set_rect(100, 100, 320, 320);
+    window->resize(320, 320);
 
     auto& game = window->set_main_widget<SnakeGame>();
 

--- a/Games/Solitaire/main.cpp
+++ b/Games/Solitaire/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv)
     auto window = GUI::Window::construct();
 
     window->set_resizable(false);
-    window->set_rect(300, 100, SolitaireWidget::width, SolitaireWidget::height);
+    window->resize(SolitaireWidget::width, SolitaireWidget::height);
 
     auto widget = SolitaireWidget::construct(window, [&](uint32_t score) {
         window->set_title(String::format("Score: %u - Solitaire", score));

--- a/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Libraries/LibGUI/ProcessChooser.cpp
@@ -26,7 +26,6 @@
 
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
-#include <LibGUI/Desktop.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/ProcessChooser.h>
 #include <LibGUI/RunningProcessesModel.h>
@@ -48,9 +47,8 @@ ProcessChooser::ProcessChooser(const StringView& window_title, const StringView&
     else if (parent_window)
         set_icon(parent_window->icon());
 
-    Gfx::IntRect window_rect { 0, 0, 300, 340 };
-    window_rect.center_within(GUI::Desktop::the().rect());
-    set_rect(window_rect);
+    resize(300, 340);
+    center_on_screen();
 
     auto& widget = set_main_widget<GUI::Widget>();
     widget.set_fill_with_background_color(true);

--- a/Libraries/LibGUI/Window.cpp
+++ b/Libraries/LibGUI/Window.cpp
@@ -32,6 +32,7 @@
 #include <LibCore/MimeData.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
+#include <LibGUI/Desktop.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Widget.h>
@@ -210,6 +211,13 @@ void Window::set_rect(const Gfx::IntRect& a_rect)
         m_front_bitmap = nullptr;
     if (m_main_widget)
         m_main_widget->resize(window_rect.size());
+}
+
+void Window::center_on_screen()
+{
+    auto window_rect = rect();
+    window_rect.center_within(Desktop::the().rect());
+    set_rect(window_rect);
 }
 
 void Window::set_window_type(WindowType window_type)

--- a/Libraries/LibGUI/Window.h
+++ b/Libraries/LibGUI/Window.h
@@ -123,6 +123,8 @@ public:
     void resize(int width, int height) { resize({ width, height }); }
     void resize(const Gfx::IntSize& size) { set_rect({ position(), size }); }
 
+    void center_on_screen();
+
     virtual void event(Core::Event&) override;
 
     bool is_visible() const;

--- a/Services/SystemMenu/ShutdownDialog.cpp
+++ b/Services/SystemMenu/ShutdownDialog.cpp
@@ -29,7 +29,6 @@
 #include <AK/Vector.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
-#include <LibGUI/Desktop.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/RadioButton.h>
 #include <LibGUI/Widget.h>
@@ -62,9 +61,8 @@ Vector<char const*> ShutdownDialog::show()
 ShutdownDialog::ShutdownDialog()
     : Dialog(nullptr)
 {
-    Gfx::IntRect rect({ 0, 0, 180, 180 + ((static_cast<int>(options.size()) - 3) * 16) });
-    rect.center_within(GUI::Desktop::the().rect());
-    set_rect(rect);
+    resize(180, 180 + ((static_cast<int>(options.size()) - 3) * 16));
+    center_on_screen();
     set_resizable(false);
     set_title("SerenityOS");
     set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/power.png"));

--- a/Userland/test-web.cpp
+++ b/Userland/test-web.cpp
@@ -649,7 +649,7 @@ int main(int argc, char** argv)
 
     if (show_window) {
         window->set_title("LibWeb Test Window");
-        window->set_rect(100, 100, 640, 480);
+        window->resize(640, 480);
         window->show();
     }
 


### PR DESCRIPTION
**LibGUI: Add and use Window::center_on_screen()**

Various applications were using the same slightly verbose code to center themselves on the screen/desktop:

```cpp
Gfx::IntRect window_rect { 0, 0, width, height };
window_rect.center_within(GUI::Desktop::the().rect());
window->set_rect(window_rect);
```

Which now becomes:

```cpp
window->resize(width, height);
window->center_on_screen();
```

**Misc: Use automatic window positioning in more applications**

This is a follow up to #2936 / d3e3b4a.

Affected programs:
- Applications: Browser (Download, View source, Inspect DOM tree, JS console), Terminal (Settings)
- Demos: Cube, Eyes, Fire, HelloWorld, LibGfxDemo, WebView, WidgetGallery
- DevTools: HackStudio, Inspector, Profiler
- Games: 2048, Minesweeper, Snake, Solitaire
- Userland: test-web

A few have been left out where manual positioning is done on purpose, e.g. ClipboardManager (to be close to the menu bar) or VisualBuilder (to preserve alignment of the multiple application windows).