### PR TITLE
Meta: QtCreator setup and formatting; and linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
 - export SERENITY_ROOT="$(pwd)"
 - Meta/lint-shell-scripts.sh
 - Meta/lint-executable-resources.sh
+- Meta/lint-ipc-ids.sh
 - Meta/check-style.sh
 - cd Toolchain
 - TRY_USE_LOCAL_TOOLCHAIN=y ./BuildIt.sh

--- a/Documentation/UsingQtCreator.md
+++ b/Documentation/UsingQtCreator.md
@@ -1,11 +1,13 @@
-## Using Qt Creator for working with SerenityOS
+# Using Qt Creator for working with SerenityOS
+
+## Setup
 
 First, make sure you have a working toolchain and can build and run SerenityOS. Go [here](https://github.com/SerenityOS/serenity/blob/master/Documentation/BuildInstructions.md) for instructions for setting that up.
 
 * Install [Qt Creator](https://www.qt.io/offline-installers). You don't need the entire Qt setup, just click 'Qt Creator' on the left side, and install that.
 * Open Qt Creator, select `File -> New File or Project...`
 * Select `Import Existing Project`
-* Give it a name, and navigate to the root of your SerenityOS project checkout. Click Next.
+* Give it a name (some tools assume lower-case `serenity`), and navigate to the root of your SerenityOS project checkout. Click Next.
 * Wait for the file list to generate. This can take a minute or two!
 * Ignore the file list, we will overwrite it later. Click Next.
 * Set `Add to version control` to `<None>`. Click Finish.
@@ -16,3 +18,28 @@ First, make sure you have a working toolchain and can build and run SerenityOS. 
 * Edit the `serenity.includes` file, add the following lines: `.`, `..`, `../..`, `Services/`, `Libraries/`, `Libraries/LibC/`, `Libraries/LibPthread/`, `Libraries/LibM/`, `Toolchain/Local/i686-pc-serenity/include/c++/10.1.0`, `Build/Services/`, `Build/Libraries/`, `AK/`
 
 Qt Creator should be set up correctly now, go ahead and explore the project and try making changes. Have fun! :^)
+
+## Auto-Formatting
+
+You can use `clang-format` to help you with the [style guide](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Before you proceed, check that you're actually using clang-format version 10, as some OSes still ship clang-format version 9 by default.
+
+- In QtCreator, go to "Help > About Plugins…"
+- Find the `Beautifier (experimental)` row (for example, by typing `beau` into the search)
+- Put a checkmark into the box
+- Restart QtCreator if it asks you
+- In QtCreator, go to "Tools > Options…"
+- Type "beau" in the search box, go to "Beautifier > Clang Format"
+- Select the "customized" style, click "edit"
+- Paste the entire content of the file `.clang-format` into the "value" box, and click "OK"
+- In the "Beatifier > General" tab, check "Enable auto format on file save"
+- Select the tool "ClangFormat" if not already selected, and click "OK"
+
+Note that not the entire project is clang-format-clean (yet), so sometimes you will see large diffs.
+Use your own judgement whether you want to include such changes. Generally speaking, if it's a few lines then it's a good idea; if it's the entire file then maybe there's a better way to do it, like doing a separate commit, or just ignoring the clang-format changes.
+
+You may want to read up what `git add -p` does (or `git checkout -p`, to undo).
+
+## Compiler Kits
+
+You can slightly improve how well Qt interprets the code by adding and setting up an appropriate "compiler kit".
+For that you will need to reference the compilers at `Toolchain/Local/bin/i686-pc-serenity-gcc` and `Toolchain/Local/bin/i686-pc-serenity-g++`.

--- a/Meta/lint-ipc-ids.sh
+++ b/Meta/lint-ipc-ids.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e pipefail
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+cd "$script_path/.."
+
+ALL_ENDPOINTS=$(find \( -name Toolchain -o -name Build -o -name .git -o -name Ports \) -prune -o -name '*.ipc' -print0 | xargs -0 grep -P '^endpoint ' | sort -k4 -n)
+
+BAD_ENDPOINTS=$(echo "${ALL_ENDPOINTS}" | cut -d' ' -f4 | uniq -d)
+
+if [ -n "${BAD_ENDPOINTS}" ]
+then
+    echo "This is the full list of all endpoints:"
+    echo "${ALL_ENDPOINTS}"
+    echo "These endpoint IDs are duplicated:"
+    echo "${BAD_ENDPOINTS}"
+    exit 1
+fi


### PR DESCRIPTION
The next one won't be a mixed bag ^^

Thanks to @vkoskiv for the great write-up!

A few months ago I fell into the trap of not naming the Qt project `serenity`, but rather `SerenityOS`, and I want to spare future users from fixing such a blunder. Also, this documents auto-format, and kits.

While watching the video in which you explained IPC I noticed that we have IDs as a fail-safe mechanism to prevent wrong connections, but nowhere do we actually ensure that these IDs are unique. Well, now we do.

Here's how it looks like when the check fails:
```
This is the full list of all endpoints:
./Services/WindowServer/WindowServer.ipc:endpoint WindowServer = 2
./Services/WindowServer/WindowClient.ipc:endpoint WindowClient = 4
./Services/ProtocolServer/ProtocolServer.ipc:endpoint ProtocolServer = 9
./Services/ProtocolServer/ProtocolClient.ipc:endpoint ProtocolClient = 13
./Services/AudioServer/AudioClient.ipc:endpoint AudioClient = 82
./Services/AudioServer/AudioServer.ipc:endpoint AudioServer = 85
./Services/AudioServer/StealthServer.ipc:endpoint EvilServer = 85
./Services/WebContent/WebContentServer.ipc:endpoint WebContentServer = 89
./Services/WebContent/WebContentClient.ipc:endpoint WebContentClient = 90
./Services/NotificationServer/NotificationClient.ipc:endpoint NotificationClient = 92
./Services/NotificationServer/NotificationServer.ipc:endpoint NotificationServer = 95
./Services/LaunchServer/LaunchServer.ipc:endpoint LaunchServer = 101
./Services/LaunchServer/LaunchClient.ipc:endpoint LaunchClient = 102
./Services/Clipboard/ClipboardServer.ipc:endpoint ClipboardServer = 802
./Services/Clipboard/ClipboardClient.ipc:endpoint ClipboardClient = 804
./Services/ImageDecoder/ImageDecoderServer.ipc:endpoint ImageDecoderServer = 7001
./Services/ImageDecoder/ImageDecoderClient.ipc:endpoint ImageDecoderClient = 7002
These endpoint IDs are duplicated:
85
```
In other news: Our ID space is … interesting :)