### PR TITLE
Everywhere: Consistently use IEC prefixes for memory sizes

### DIFF
--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -39,13 +39,13 @@ static String number_string_with_one_decimal(float number, const char* suffix)
 
 static String human_readable_size(size_t size)
 {
-    if (size < 1 * KB)
+    if (size < 1 * KiB)
         return String::format("%zu bytes", size);
-    if (size < 1 * MB)
-        return number_string_with_one_decimal((float)size / (float)KB, "KB");
-    if (size < 1 * GB)
-        return number_string_with_one_decimal((float)size / (float)MB, "MB");
-    return number_string_with_one_decimal((float)size / (float)GB, "GB");
+    if (size < 1 * MiB)
+        return number_string_with_one_decimal((float)size / (float)KiB, "KB");
+    if (size < 1 * GiB)
+        return number_string_with_one_decimal((float)size / (float)MiB, "MB");
+    return number_string_with_one_decimal((float)size / (float)GiB, "GB");
 }
 
 }

--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -41,12 +41,12 @@ static String number_string_with_one_decimal(float number, const char* suffix)
 static String human_readable_size(size_t size)
 {
     if (size < 1 * KiB)
-        return String::format("%zu bytes", size);
+        return String::format("%zu B", size);
     if (size < 1 * MiB)
-        return number_string_with_one_decimal((float)size / (float)KiB, "KB");
+        return number_string_with_one_decimal((float)size / (float)KiB, "KiB");
     if (size < 1 * GiB)
-        return number_string_with_one_decimal((float)size / (float)MiB, "MB");
-    return number_string_with_one_decimal((float)size / (float)GiB, "GB");
+        return number_string_with_one_decimal((float)size / (float)MiB, "MiB");
+    return number_string_with_one_decimal((float)size / (float)GiB, "GiB");
 }
 
 }

--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -31,6 +31,7 @@
 
 namespace AK {
 
+// FIXME: Remove this hackery once printf() supports floats.
 static String number_string_with_one_decimal(float number, const char* suffix)
 {
     float decimals = number - (int)number;

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -74,9 +74,9 @@ typedef __PTRDIFF_TYPE__ __ptrdiff_t;
 
 typedef Conditional<sizeof(void*) == 8, u64, u32>::Type FlatPtr;
 
-constexpr unsigned KB = 1024;
-constexpr unsigned MB = KB * KB;
-constexpr unsigned GB = KB * KB * KB;
+constexpr unsigned KiB = 1024;
+constexpr unsigned MiB = KiB * KiB;
+constexpr unsigned GiB = KiB * KiB * KiB;
 
 namespace std {
 typedef decltype(nullptr) nullptr_t;

--- a/Applications/SoundPlayer/PlaybackManager.h
+++ b/Applications/SoundPlayer/PlaybackManager.h
@@ -31,7 +31,7 @@
 #include <LibAudio/WavLoader.h>
 #include <LibCore/Timer.h>
 
-#define PLAYBACK_MANAGER_BUFFER_SIZE 64 * KB
+#define PLAYBACK_MANAGER_BUFFER_SIZE 64 * KiB
 #define PLAYBACK_MANAGER_RATE 44100
 
 class PlaybackManager final {

--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -559,7 +559,7 @@ NonnullRefPtr<GUI::Widget> build_graphs_tab()
         memory_graph.set_text_color(Color::Cyan);
         memory_graph.set_graph_color(Color::from_rgb(0x00bbbb));
         memory_graph.text_formatter = [](int value, int max) {
-            return String::format("%d / %d KB", value, max);
+            return String::format("%d / %d KiB", value, max);
         };
 
         self.add<MemoryStatsWidget>(memory_graph);

--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -31,8 +31,9 @@
 #include "ProcessFileDescriptorMapWidget.h"
 #include "ProcessMemoryMapWidget.h"
 #include "ProcessModel.h"
-#include "ThreadStackWidget.h"
 #include "ProcessUnveiledPathsWidget.h"
+#include "ThreadStackWidget.h"
+#include <AK/NumberFormat.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/AboutDialog.h>
 #include <LibGUI/Action.h>
@@ -60,17 +61,6 @@
 #include <spawn.h>
 #include <stdio.h>
 #include <unistd.h>
-
-static String human_readable_size(u32 size)
-{
-    if (size < (64 * KiB))
-        return String::format("%u", size);
-    if (size < MiB)
-        return String::format("%u KB", size / KiB);
-    if (size < GiB)
-        return String::format("%u MB", size / MiB);
-    return String::format("%u GB", size / GiB);
-}
 
 static NonnullRefPtr<GUI::Widget> build_file_systems_tab();
 static NonnullRefPtr<GUI::Widget> build_pci_devices_tab();

--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -63,13 +63,13 @@
 
 static String human_readable_size(u32 size)
 {
-    if (size < (64 * KB))
+    if (size < (64 * KiB))
         return String::format("%u", size);
-    if (size < MB)
-        return String::format("%u KB", size / KB);
-    if (size < GB)
-        return String::format("%u MB", size / MB);
-    return String::format("%u GB", size / GB);
+    if (size < MiB)
+        return String::format("%u KB", size / KiB);
+    if (size < GiB)
+        return String::format("%u MB", size / MiB);
+    return String::format("%u GB", size / GiB);
 }
 
 static NonnullRefPtr<GUI::Widget> build_file_systems_tab();

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -54,7 +54,7 @@
 namespace UserspaceEmulator {
 
 static constexpr u32 stack_location = 0x10000000;
-static constexpr size_t stack_size = 64 * KB;
+static constexpr size_t stack_size = 64 * KiB;
 
 static Emulator* s_the;
 

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -355,7 +355,7 @@ struct SC_create_thread_params {
     // ... ok, if you say so posix. Guess we get to lie to people about guard page size
     unsigned int m_guard_page_size = 0;          // Rounded up to PAGE_SIZE
     unsigned int m_reported_guard_page_size = 0; // The lie we tell callers
-    unsigned int m_stack_size = 4 * MB;          // Default PTHREAD_STACK_MIN
+    unsigned int m_stack_size = 4 * MiB;         // Default PTHREAD_STACK_MIN
     Userspace<void*> m_stack_location;           // nullptr means any, o.w. process virtual address
 };
 

--- a/Kernel/Arch/PC/BIOS.cpp
+++ b/Kernel/Arch/PC/BIOS.cpp
@@ -34,7 +34,7 @@ namespace Kernel {
 MappedROM map_bios()
 {
     MappedROM mapping;
-    mapping.size = 128 * KB;
+    mapping.size = 128 * KiB;
     mapping.paddr = PhysicalAddress(0xe0000);
     mapping.region = MM.allocate_kernel_region(mapping.paddr, PAGE_ROUND_UP(mapping.size), {}, Region::Access::Read);
     return mapping;

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -837,7 +837,7 @@ KResult Plan9FSInode::traverse_as_directory(Function<bool(const FS::DirectoryEnt
         }
 
         u64 offset = 0;
-        u32 count = fs().adjust_buffer_size(8 * MB);
+        u32 count = fs().adjust_buffer_size(8 * MiB);
 
         while (true) {
             Plan9FS::Message message { fs(), Plan9FS::Message::Type::Treaddir };

--- a/Kernel/FileSystem/Plan9FileSystem.h
+++ b/Kernel/FileSystem/Plan9FileSystem.h
@@ -105,7 +105,7 @@ private:
     Atomic<u32> m_next_fid { 1 };
 
     ProtocolVersion m_remote_protocol_version { ProtocolVersion::v9P2000 };
-    size_t m_max_message_size { 4 * KB };
+    size_t m_max_message_size { 4 * KiB };
 
     Lock m_send_lock { "Plan9FS send" };
     Atomic<bool> m_someone_is_reading { false };

--- a/Kernel/Heap/SlabAllocator.cpp
+++ b/Kernel/Heap/SlabAllocator.cpp
@@ -128,10 +128,10 @@ void for_each_allocator(Callback callback)
 
 void slab_alloc_init()
 {
-    s_slab_allocator_16.init(128 * KB);
-    s_slab_allocator_32.init(128 * KB);
-    s_slab_allocator_64.init(512 * KB);
-    s_slab_allocator_128.init(512 * KB);
+    s_slab_allocator_16.init(128 * KiB);
+    s_slab_allocator_32.init(128 * KiB);
+    s_slab_allocator_64.init(512 * KiB);
+    s_slab_allocator_128.init(512 * KiB);
 }
 
 void* slab_alloc(size_t slab_size)

--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -48,12 +48,12 @@ struct AllocationHeader {
     u8 data[0];
 };
 
-#define BASE_PHYSICAL (0xc0000000 + (4 * MB))
+#define BASE_PHYSICAL (0xc0000000 + (4 * MiB))
 #define CHUNK_SIZE 32
-#define POOL_SIZE (3 * MB)
+#define POOL_SIZE (3 * MiB)
 
-#define ETERNAL_BASE_PHYSICAL (0xc0000000 + (2 * MB))
-#define ETERNAL_RANGE_SIZE (2 * MB)
+#define ETERNAL_BASE_PHYSICAL (0xc0000000 + (2 * MiB))
+#define ETERNAL_RANGE_SIZE (2 * MiB)
 
 static u8 alloc_map[POOL_SIZE / CHUNK_SIZE / 8];
 

--- a/Kernel/KBufferBuilder.cpp
+++ b/Kernel/KBufferBuilder.cpp
@@ -45,7 +45,7 @@ KBuffer KBufferBuilder::build()
 }
 
 KBufferBuilder::KBufferBuilder()
-    : m_buffer(KBuffer::create_with_size(4 * MB, Region::Access::Read | Region::Access::Write))
+    : m_buffer(KBuffer::create_with_size(4 * MiB, Region::Access::Read | Region::Access::Write))
 {
 }
 

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -105,7 +105,7 @@ void NetworkTask_main()
         return packet_size;
     };
 
-    size_t buffer_size = 64 * KB;
+    size_t buffer_size = 64 * KiB;
     auto buffer_region = MM.allocate_kernel_region(buffer_size, "Kernel Packet Buffer", Region::Access::Read | Region::Access::Write, false, true);
     auto buffer = (u8*)buffer_region->vaddr().get();
 

--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -33,7 +33,7 @@
 namespace Kernel {
 
 PerformanceEventBuffer::PerformanceEventBuffer()
-    : m_buffer(KBuffer::create_with_size(4 * MB))
+    : m_buffer(KBuffer::create_with_size(4 * MiB))
 {
 }
 

--- a/Kernel/Profiling.cpp
+++ b/Kernel/Profiling.cpp
@@ -64,7 +64,7 @@ void start(Process& process)
     s_pid = process.pid();
 
     if (!s_profiling_buffer) {
-        s_profiling_buffer = RefPtr<KBufferImpl>(KBuffer::create_with_size(8 * MB).impl()).leak_ref();
+        s_profiling_buffer = RefPtr<KBufferImpl>(KBuffer::create_with_size(8 * MiB).impl()).leak_ref();
         s_profiling_buffer->region().commit();
         s_slot_count = s_profiling_buffer->size() / sizeof(Sample);
     }

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -512,7 +512,7 @@ public:
     }
 
     static constexpr u32 default_kernel_stack_size = 65536;
-    static constexpr u32 default_userspace_stack_size = 4 * MB;
+    static constexpr u32 default_userspace_stack_size = 4 * MiB;
 
     ThreadTracer* tracer() { return m_tracer.ptr(); }
     void start_tracing_from(ProcessID tracer);

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -101,8 +101,8 @@ void MemoryManager::parse_memory_map()
         if (mmap->type != MULTIBOOT_MEMORY_AVAILABLE)
             continue;
 
-        // FIXME: Maybe make use of stuff below the 1MB mark?
-        if (mmap->addr < (1 * MB))
+        // FIXME: Maybe make use of stuff below the 1MiB mark?
+        if (mmap->addr < (1 * MiB))
             continue;
 
         if ((mmap->addr + mmap->len) > 0xffffffff)
@@ -131,9 +131,9 @@ void MemoryManager::parse_memory_map()
         for (size_t page_base = mmap->addr; page_base < (mmap->addr + mmap->len); page_base += PAGE_SIZE) {
             auto addr = PhysicalAddress(page_base);
 
-            if (page_base < 7 * MB) {
+            if (page_base < 7 * MiB) {
                 // nothing
-            } else if (page_base >= 7 * MB && page_base < 8 * MB) {
+            } else if (page_base >= 7 * MiB && page_base < 8 * MiB) {
                 if (region.is_null() || !region_is_super || region->upper().offset(PAGE_SIZE) != addr) {
                     m_super_physical_regions.append(PhysicalRegion::create(addr, addr));
                     region = m_super_physical_regions.last();

--- a/Kernel/VM/PageDirectory.cpp
+++ b/Kernel/VM/PageDirectory.cpp
@@ -80,7 +80,7 @@ PageDirectory::PageDirectory(Process& process, const RangeAllocator* parent_rang
     if (parent_range_allocator) {
         m_range_allocator.initialize_from_parent(*parent_range_allocator);
     } else {
-        size_t random_offset = (get_fast_random<u8>() % 32 * MB) & PAGE_MASK;
+        size_t random_offset = (get_fast_random<u8>() % 32 * MiB) & PAGE_MASK;
         u32 base = userspace_range_base + random_offset;
         m_range_allocator.initialize_with_range(VirtualAddress(base), userspace_range_ceiling - base);
     }
@@ -102,7 +102,7 @@ PageDirectory::PageDirectory(Process& process, const RangeAllocator* parent_rang
         MM.unquickmap_page();
     }
 
-    // Clone bottom 2 MB of mappings from kernel_page_directory
+    // Clone bottom 2 MiB of mappings from kernel_page_directory
     PageDirectoryEntry buffer;
     auto* kernel_pd = MM.quickmap_pd(MM.kernel_page_directory(), 0);
     memcpy(&buffer, kernel_pd, sizeof(PageDirectoryEntry));

--- a/Kernel/VM/PageDirectory.cpp
+++ b/Kernel/VM/PageDirectory.cpp
@@ -90,7 +90,7 @@ PageDirectory::PageDirectory(Process& process, const RangeAllocator* parent_rang
     m_directory_pages[0] = MM.allocate_user_physical_page();
     m_directory_pages[1] = MM.allocate_user_physical_page();
     m_directory_pages[2] = MM.allocate_user_physical_page();
-    // Share the top 1 GB of kernel-only mappings (>=3GB or >=0xc0000000)
+    // Share the top 1 GiB of kernel-only mappings (>=3GiB or >=0xc0000000)
     m_directory_pages[3] = MM.kernel_page_directory().m_directory_pages[3];
 
     {

--- a/Libraries/LibAudio/WavLoader.h
+++ b/Libraries/LibAudio/WavLoader.h
@@ -44,7 +44,7 @@ public:
     bool has_error() const { return !m_error_string.is_null(); }
     const char* error_string() { return m_error_string.characters(); }
 
-    RefPtr<Buffer> get_more_samples(size_t max_bytes_to_read_from_input = 128 * KB);
+    RefPtr<Buffer> get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB);
 
     void reset();
     void seek(const int position);

--- a/Libraries/LibC/malloc.cpp
+++ b/Libraries/LibC/malloc.cpp
@@ -73,7 +73,7 @@ static bool s_profiling = false;
 static unsigned short size_classes[] = { 8, 16, 32, 64, 128, 252, 508, 1016, 2036, 4090, 8188, 16376, 32756, 0 };
 static constexpr size_t num_size_classes = sizeof(size_classes) / sizeof(unsigned short);
 
-constexpr size_t block_size = 64 * KB;
+constexpr size_t block_size = 64 * KiB;
 constexpr size_t block_mask = ~(block_size - 1);
 
 struct CommonHeader {

--- a/Libraries/LibGemini/Job.cpp
+++ b/Libraries/LibGemini/Job.cpp
@@ -109,7 +109,7 @@ void Job::on_socket_connected()
         ASSERT(m_state == State::InBody || m_state == State::Finished);
 
         read_while_data_available([&] {
-            auto read_size = 64 * KB;
+            auto read_size = 64 * KiB;
 
             auto payload = receive(read_size);
             if (!payload) {

--- a/Libraries/LibGfx/JPGLoader.cpp
+++ b/Libraries/LibGfx/JPGLoader.cpp
@@ -1206,7 +1206,7 @@ JPGImageDecoderPlugin::JPGImageDecoderPlugin(const u8* data, size_t size)
     m_context = make<JPGLoadingContext>();
     m_context->data = data;
     m_context->data_size = size;
-    m_context->huffman_stream.stream.ensure_capacity(50 * KB);
+    m_context->huffman_stream.stream.ensure_capacity(50 * KiB);
 }
 
 JPGImageDecoderPlugin::~JPGImageDecoderPlugin()

--- a/Libraries/LibHTTP/Job.cpp
+++ b/Libraries/LibHTTP/Job.cpp
@@ -173,7 +173,7 @@ void Job::on_socket_connected()
         ASSERT(can_read());
 
         read_while_data_available([&] {
-            auto read_size = 64 * KB;
+            auto read_size = 64 * KiB;
             if (m_current_chunk_remaining_size.has_value()) {
             read_chunk_size:;
                 auto remaining = m_current_chunk_remaining_size.value();

--- a/Libraries/LibJS/Heap/HeapBlock.h
+++ b/Libraries/LibJS/Heap/HeapBlock.h
@@ -34,7 +34,7 @@ namespace JS {
 
 class HeapBlock {
 public:
-    static constexpr size_t block_size = 16 * KB;
+    static constexpr size_t block_size = 16 * KiB;
     static NonnullOwnPtr<HeapBlock> create_with_cell_size(Heap&, size_t);
 
     void operator delete(void*);

--- a/Libraries/LibPthread/pthread.cpp
+++ b/Libraries/LibPthread/pthread.cpp
@@ -44,9 +44,9 @@ namespace {
 using PthreadAttrImpl = Syscall::SC_create_thread_params;
 } // end anonymous namespace
 
-constexpr size_t required_stack_alignment = 4 * MB;
+constexpr size_t required_stack_alignment = 4 * MiB;
 constexpr size_t highest_reasonable_guard_size = 32 * PAGE_SIZE;
-constexpr size_t highest_reasonable_stack_size = 8 * MB; // That's the default in Ubuntu?
+constexpr size_t highest_reasonable_stack_size = 8 * MiB; // That's the default in Ubuntu?
 
 extern "C" {
 

--- a/MenuApplets/ResourceGraph/main.cpp
+++ b/MenuApplets/ResourceGraph/main.cpp
@@ -80,7 +80,7 @@ private:
             float total_memory = allocated + available;
             float memory = (float)allocated / total_memory;
             m_history.enqueue(memory);
-            m_tooltip = String::format("Memory: %.1f MiB of %.1f MiB in use",(float)allocated / MB, total_memory / MB);
+            m_tooltip = String::format("Memory: %.1f MiB of %.1f MiB in use", (float)allocated / MiB, total_memory / MiB);
             break;
         }
         default:

--- a/Userland/Tests/Kernel/bxvga-mmap-kernel-into-userspace.cpp
+++ b/Userland/Tests/Kernel/bxvga-mmap-kernel-into-userspace.cpp
@@ -69,7 +69,7 @@ int main()
 
     printf("Success! Evil pointer: %p\n", ptr);
 
-    u8* base = &ptr[128 * MB];
+    u8* base = &ptr[128 * MiB];
 
     uintptr_t g_processes = *(uintptr_t*)&base[0x1b51c4];
     printf("base = %p\n", base);

--- a/Userland/allocate.cpp
+++ b/Userland/allocate.cpp
@@ -33,18 +33,20 @@
 
 static void usage(void)
 {
-    printf("usage: allocate [number [unit (B/KB/MB)]]\n");
+    printf("usage: allocate [number [unit (B/KiB/MiB)]]\n");
     exit(1);
 }
 
-enum class Unit { Bytes,
-    KiloBytes,
-    MegaBytes };
+enum class Unit {
+    Bytes,
+    KiB,
+    MiB,
+};
 
 int main(int argc, char** argv)
 {
     int count = 50;
-    auto unit = Unit::MegaBytes;
+    auto unit = Unit::MiB;
 
     if (argc >= 2) {
         auto number = String(argv[1]).to_uint();
@@ -57,10 +59,10 @@ int main(int argc, char** argv)
     if (argc >= 3) {
         if (strcmp(argv[2], "B") == 0)
             unit = Unit::Bytes;
-        else if (strcmp(argv[2], "KB") == 0)
-            unit = Unit::KiloBytes;
-        else if (strcmp(argv[2], "MB") == 0)
-            unit = Unit::MegaBytes;
+        else if (strcmp(argv[2], "KiB") == 0)
+            unit = Unit::KiB;
+        else if (strcmp(argv[2], "MiB") == 0)
+            unit = Unit::MiB;
         else
             usage();
     }
@@ -68,11 +70,11 @@ int main(int argc, char** argv)
     switch (unit) {
     case Unit::Bytes:
         break;
-    case Unit::KiloBytes:
-        count *= 1024;
+    case Unit::KiB:
+        count *= KiB;
         break;
-    case Unit::MegaBytes:
-        count *= 1024 * 1024;
+    case Unit::MiB:
+        count *= MiB;
         break;
     }
 
@@ -87,7 +89,7 @@ int main(int argc, char** argv)
     }
     printf("done in %dms\n", timer.elapsed());
 
-    auto pages = count / 4096;
+    auto pages = count / PAGE_SIZE;
     auto step = pages / 10;
 
     Core::ElapsedTimer timer2;
@@ -96,16 +98,16 @@ int main(int argc, char** argv)
     timer.start();
     timer2.start();
     for (int i = 0; i < pages; ++i) {
-        ptr[i * 4096] = 1;
+        ptr[i * PAGE_SIZE] = 1;
 
         if (i != 0 && (i % step) == 0) {
             auto ms = timer2.elapsed();
             if (ms == 0)
                 ms = 1;
 
-            auto bps = double(step * 4096) / (double(ms) / 1000);
+            auto bps = double(step * PAGE_SIZE) / (double(ms) / 1000);
 
-            printf("step took %dms (%fMB/s)\n", ms, bps / 1024 / 1024);
+            printf("step took %dms (%fMiB/s)\n", ms, bps / MiB);
 
             timer2.start();
         }

--- a/Userland/df.cpp
+++ b/Userland/df.cpp
@@ -58,13 +58,13 @@ static String number_string_with_one_decimal(float number, const char* suffix)
 
 static String human_readable_size(size_t size)
 {
-    if (size < 1 * KB)
+    if (size < 1 * KiB)
         return String::number(size);
-    if (size < 1 * MB)
-        return number_string_with_one_decimal((float)size / (float)KB, "K");
-    if (size < 1 * GB)
-        return number_string_with_one_decimal((float)size / (float)MB, "M");
-    return number_string_with_one_decimal((float)size / (float)GB, "G");
+    if (size < 1 * MiB)
+        return number_string_with_one_decimal((float)size / (float)KiB, "K");
+    if (size < 1 * GiB)
+        return number_string_with_one_decimal((float)size / (float)MiB, "M");
+    return number_string_with_one_decimal((float)size / (float)GiB, "G");
 }
 
 int main(int argc, char** argv)

--- a/Userland/df.cpp
+++ b/Userland/df.cpp
@@ -24,16 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/String.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
+#include <AK/NumberFormat.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
-#include <string.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 static bool flag_human_readable = false;
@@ -47,25 +48,6 @@ struct FileSystem {
     size_t block_size { 0 };
     String mount_point;
 };
-
-// FIXME: Remove this hackery once printf() supports floats.
-// FIXME: Also, we should probably round the sizes in df -h output.
-static String number_string_with_one_decimal(float number, const char* suffix)
-{
-    float decimals = number - (int)number;
-    return String::format("%d.%d%s", (int)number, (int)(decimals * 10), suffix);
-}
-
-static String human_readable_size(size_t size)
-{
-    if (size < 1 * KiB)
-        return String::number(size);
-    if (size < 1 * MiB)
-        return number_string_with_one_decimal((float)size / (float)KiB, "K");
-    if (size < 1 * GiB)
-        return number_string_with_one_decimal((float)size / (float)MiB, "M");
-    return number_string_with_one_decimal((float)size / (float)GiB, "G");
-}
 
 int main(int argc, char** argv)
 {

--- a/Userland/ifconfig.cpp
+++ b/Userland/ifconfig.cpp
@@ -40,12 +40,12 @@
 
 static String si_bytes(unsigned bytes)
 {
-    if (bytes >= GB)
-        return String::format("%fGiB", (double)bytes / (double)GB);
-    if (bytes >= MB)
-        return String::format("%fMiB", (double)bytes / (double)MB);
-    if (bytes >= KB)
-        return String::format("%fkiB", (double)bytes / (double)KB);
+    if (bytes >= GiB)
+        return String::format("%fGiB", (double)bytes / (double)GiB);
+    if (bytes >= MiB)
+        return String::format("%fMiB", (double)bytes / (double)MiB);
+    if (bytes >= KiB)
+        return String::format("%fkiB", (double)bytes / (double)KiB);
     return String::format("%dB", bytes);
 }
 

--- a/Userland/ifconfig.cpp
+++ b/Userland/ifconfig.cpp
@@ -26,6 +26,7 @@
 
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
+#include <AK/NumberFormat.h>
 #include <AK/String.h>
 #include <AK/Types.h>
 #include <LibCore/ArgsParser.h>
@@ -37,17 +38,6 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
-
-static String si_bytes(unsigned bytes)
-{
-    if (bytes >= GiB)
-        return String::format("%fGiB", (double)bytes / (double)GiB);
-    if (bytes >= MiB)
-        return String::format("%fMiB", (double)bytes / (double)MiB);
-    if (bytes >= KiB)
-        return String::format("%fkiB", (double)bytes / (double)KiB);
-    return String::format("%dB", bytes);
-}
 
 int main(int argc, char** argv)
 {
@@ -95,8 +85,8 @@ int main(int argc, char** argv)
             printf("\tnetmask: %s\n", netmask.characters());
             printf("\tgateway: %s\n", gateway.characters());
             printf("\tclass: %s\n", class_name.characters());
-            printf("\tRX: %u packets %u bytes (%s)\n", packets_in, bytes_in, si_bytes(bytes_in).characters());
-            printf("\tTX: %u packets %u bytes (%s)\n", packets_out, bytes_out, si_bytes(bytes_out).characters());
+            printf("\tRX: %u packets %u bytes (%s)\n", packets_in, bytes_in, human_readable_size(bytes_in).characters());
+            printf("\tTX: %u packets %u bytes (%s)\n", packets_out, bytes_out, human_readable_size(bytes_out).characters());
             printf("\tMTU: %u\n", mtu);
             printf("\n");
         });

--- a/Userland/ls.cpp
+++ b/Userland/ls.cpp
@@ -241,13 +241,13 @@ static String number_string_with_one_decimal(float number, const char* suffix)
 
 static String human_readable_size(size_t size)
 {
-    if (size < 1 * KB)
+    if (size < 1 * KiB)
         return String::number(size);
-    if (size < 1 * MB)
-        return number_string_with_one_decimal((float)size / (float)KB, "K");
-    if (size < 1 * GB)
-        return number_string_with_one_decimal((float)size / (float)MB, "M");
-    return number_string_with_one_decimal((float)size / (float)GB, "G");
+    if (size < 1 * MiB)
+        return number_string_with_one_decimal((float)size / (float)KiB, "K");
+    if (size < 1 * GiB)
+        return number_string_with_one_decimal((float)size / (float)MiB, "M");
+    return number_string_with_one_decimal((float)size / (float)GiB, "G");
 }
 
 static bool print_filesystem_object(const String& path, const String& name, const struct stat& st)

--- a/Userland/ls.cpp
+++ b/Userland/ls.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/HashMap.h>
+#include <AK/NumberFormat.h>
 #include <AK/QuickSort.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
@@ -229,25 +230,6 @@ static size_t print_name(const struct stat& st, const String& name, const char* 
     }
 
     return nprinted;
-}
-
-// FIXME: Remove this hackery once printf() supports floats.
-// FIXME: Also, we should probably round the sizes in ls -lh output.
-static String number_string_with_one_decimal(float number, const char* suffix)
-{
-    float decimals = number - (int)number;
-    return String::format("%d.%d%s", (int)number, (int)(decimals * 10), suffix);
-}
-
-static String human_readable_size(size_t size)
-{
-    if (size < 1 * KiB)
-        return String::number(size);
-    if (size < 1 * MiB)
-        return number_string_with_one_decimal((float)size / (float)KiB, "K");
-    if (size < 1 * GiB)
-        return number_string_with_one_decimal((float)size / (float)MiB, "M");
-    return number_string_with_one_decimal((float)size / (float)GiB, "G");
 }
 
 static bool print_filesystem_object(const String& path, const String& name, const struct stat& st)

--- a/Userland/tt.cpp
+++ b/Userland/tt.cpp
@@ -261,7 +261,7 @@ int stack_size_test()
         printf("pthread_attr_setstacksize: %s\n", strerror(rc));
         return 3;
     }
-    printf("Set thread stack size to 8 MB\n");
+    printf("Set thread stack size to 8 MiB\n");
 
     pthread_t thread_id;
     rc = pthread_create(

--- a/Userland/unzip.cpp
+++ b/Userland/unzip.cpp
@@ -156,7 +156,7 @@ static bool unpack_file_for_central_directory_index(off_t central_directory_inde
 int main(int argc, char** argv)
 {
     const char* path;
-    int map_size_limit = 32 * MB;
+    int map_size_limit = 32 * MiB;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(map_size_limit, "Maximum chunk size to map", "map-size-limit", 0, "size");


### PR DESCRIPTION
Windows uses "KB", "MB", "GB" as powers of two.
macOS uses "kB", "MB", "GB" as powers of ten.

"k", "M", "G" are SI standard prefixes that normally refer to powers of ten.

The IEC introduced "KiB", "MiB", "GiB" to unambiguously refer to
powers of two. It admittedly hasn't caught on that much, but it
does have the advantage that it's unabigious what it means.
So let's use it for user-visible sizes in SerenityOS.

(Linux does all of the above in different places, depending on app and
toolkit.)

--

This is admittedly fairly bike-sheddy, sorry. But SerenityOS was already self-inconsistent about this, and making some kind of decision on which style to use and using it consistently is probably a good idea. This was what sounded like the right decision per IRC :)