### PR TITLE
AK: Make some tweaks to AK::Span.

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -71,8 +71,8 @@ public:
     u8* data() { return m_data; }
     const u8* data() const { return m_data; }
 
-    Bytes span() { return { data(), size() }; }
-    ReadonlyBytes span() const { return { data(), size() }; }
+    Bytes bytes() { return { data(), size() }; }
+    ReadonlyBytes bytes() const { return { data(), size() }; }
 
     u8* offset_pointer(int offset) { return m_data + offset; }
     const u8* offset_pointer(int offset) const { return m_data + offset; }
@@ -163,8 +163,8 @@ public:
     u8* data() { return m_impl ? m_impl->data() : nullptr; }
     const u8* data() const { return m_impl ? m_impl->data() : nullptr; }
 
-    Bytes span() { return m_impl ? m_impl->span() : nullptr; }
-    ReadonlyBytes span() const { return m_impl ? m_impl->span() : nullptr; }
+    Bytes bytes() { return m_impl ? m_impl->bytes() : nullptr; }
+    ReadonlyBytes bytes() const { return m_impl ? m_impl->bytes() : nullptr; }
 
     u8* offset_pointer(int offset) { return m_impl ? m_impl->offset_pointer(offset) : nullptr; }
     const u8* offset_pointer(int offset) const { return m_impl ? m_impl->offset_pointer(offset) : nullptr; }
@@ -232,6 +232,9 @@ public:
         ASSERT(offset + data_size <= size());
         __builtin_memcpy(this->data() + offset, data, data_size);
     }
+
+    operator Bytes() { return bytes(); }
+    operator ReadonlyBytes() const { return bytes(); }
 
 private:
     explicit ByteBuffer(RefPtr<ByteBufferImpl>&& impl)

--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Span.h>
 #include <AK/Vector.h>
 
 namespace AK {
@@ -33,7 +34,7 @@ namespace AK {
 template<typename T>
 class FixedArray {
 public:
-    FixedArray() {}
+    FixedArray() { }
     explicit FixedArray(size_t size)
         : m_size(size)
     {
@@ -86,6 +87,9 @@ public:
         return m_elements;
     }
 
+    Bytes bytes() { return { data(), size() }; }
+    ReadonlyBytes bytes() const { return { data(), size() }; }
+
     T& operator[](size_t index)
     {
         ASSERT(index < m_size);
@@ -137,6 +141,9 @@ public:
     using ConstIterator = VectorIterator<const FixedArray, const T>;
     ConstIterator begin() const { return ConstIterator(*this, 0); }
     ConstIterator end() const { return ConstIterator(*this, size()); }
+
+    operator Bytes() { return bytes(); }
+    operator ReadonlyBytes() const { return bytes(); }
 
 private:
     size_t m_size { 0 };

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -148,6 +148,12 @@ public:
         return { this->m_values + start, size };
     }
 
+    ALWAYS_INLINE Span slice(size_t start) const
+    {
+        ASSERT(start < this->m_size);
+        return { this->m_values + start, this->m_size - start };
+    }
+
     ALWAYS_INLINE T* offset(size_t start) const
     {
         ASSERT(start < this->m_size);

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -105,8 +105,6 @@ public:
     using Iterator = T*;
     using ConstIterator = const T*;
 
-    static_assert(!IsPointer<T>::value);
-
     using Detail::Span<T>::Span;
 
     ALWAYS_INLINE Span(std::nullptr_t)

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -176,6 +176,13 @@ public:
         __builtin_memmove(other.data(), data(), sizeof(T) * min(size(), other.size()));
     }
 
+    ALWAYS_INLINE void fill(const T& value)
+    {
+        for (size_t idx = 0; idx < size(); ++idx) {
+            data()[idx] = value;
+        }
+    }
+
     ALWAYS_INLINE const T& at(size_t index) const
     {
         ASSERT(index < this->m_size);

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -154,6 +154,28 @@ public:
         return this->m_values + start;
     }
 
+    ALWAYS_INLINE void copy_to(Span other) const
+    {
+        ASSERT(other.size() >= size());
+        __builtin_memcpy(other.data(), data(), sizeof(T) * size());
+    }
+
+    ALWAYS_INLINE void copy_trimmed_to(Span other) const
+    {
+        __builtin_memcpy(other.data(), data(), sizeof(T) * min(size(), other.size()));
+    }
+
+    ALWAYS_INLINE void move_to(Span other) const
+    {
+        ASSERT(other.size() >= size());
+        __builtin_memmove(other.data(), data(), sizeof(T) * size());
+    }
+
+    ALWAYS_INLINE void move_trimmed_to(Span other) const
+    {
+        __builtin_memmove(other.data(), data(), sizeof(T) * min(size(), other.size()));
+    }
+
     ALWAYS_INLINE const T& at(size_t index) const
     {
         ASSERT(index < this->m_size);

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -243,6 +243,9 @@ public:
         return !(*this == other);
     }
 
+    operator Span<T>() { return span(); }
+    operator Span<const T>() const { return span(); }
+
     bool contains_slow(const T& value) const
     {
         for (size_t i = 0; i < size(); ++i) {

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -285,7 +285,7 @@ void handle_icmp(const EthernetFrameHeader& eth, const IPv4Packet& ipv4_packet)
             memcpy(response.payload(), request.payload(), icmp_payload_size);
         response.header.set_checksum(internet_checksum(&response, icmp_packet_size));
         // FIXME: What is the right TTL value here? Is 64 ok? Should we use the same TTL as the echo request?
-        adapter->send_ipv4(eth.source(), ipv4_packet.source(), IPv4Protocol::ICMP, buffer.span(), 64);
+        adapter->send_ipv4(eth.source(), ipv4_packet.source(), IPv4Protocol::ICMP, buffer, 64);
     }
 }
 

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -218,7 +218,7 @@ void TCPSocket::send_tcp_packet(u16 flags, const void* payload, size_t payload_s
 
     routing_decision.adapter->send_ipv4(
         routing_decision.next_hop, peer_address(), IPv4Protocol::TCP,
-        buffer.span(), ttl());
+        buffer, ttl());
 
     m_packets_out++;
     m_bytes_out += buffer.size();
@@ -246,7 +246,7 @@ void TCPSocket::send_outgoing_packets()
 #endif
         routing_decision.adapter->send_ipv4(
             routing_decision.next_hop, peer_address(), IPv4Protocol::TCP,
-            packet.buffer.span(), ttl());
+            packet.buffer, ttl());
 
         m_packets_out++;
         m_bytes_out += packet.buffer.size();

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -102,7 +102,7 @@ KResultOr<size_t> UDPSocket::protocol_send(const void* data, size_t data_length)
     udp_packet.set_length(sizeof(UDPPacket) + data_length);
     memcpy(udp_packet.payload(), data, data_length);
     klog() << "sending as udp packet from " << routing_decision.adapter->ipv4_address().to_string().characters() << ":" << local_port() << " to " << peer_address().to_string().characters() << ":" << peer_port() << "!";
-    routing_decision.adapter->send_ipv4(routing_decision.next_hop, peer_address(), IPv4Protocol::UDP, buffer.span(), ttl());
+    routing_decision.adapter->send_ipv4(routing_decision.next_hop, peer_address(), IPv4Protocol::UDP, buffer, ttl());
     return data_length;
 }
 

--- a/Kernel/Random.h
+++ b/Kernel/Random.h
@@ -69,11 +69,11 @@ public:
         typename CipherType::CTRMode cipher(m_key, KeySize);
 
         Bytes buffer_span { buffer, n };
-        auto counter_span = m_counter.span();
+        auto counter_span = m_counter.bytes();
         cipher.key_stream(buffer_span, counter_span, &counter_span);
 
         // Extract a new key from the prng stream.
-        Bytes key_span = m_key.span();
+        Bytes key_span = m_key.bytes();
         cipher.key_stream(key_span, counter_span, &counter_span);
     }
 

--- a/Libraries/LibCrypto/Cipher/AES.cpp
+++ b/Libraries/LibCrypto/Cipher/AES.cpp
@@ -396,10 +396,10 @@ void AESCipher::decrypt_block(const AESCipherBlock& in, AESCipherBlock& out)
     // clang-format on
 }
 
-void AESCipherBlock::overwrite(const ReadonlyBytes& span)
+void AESCipherBlock::overwrite(ReadonlyBytes bytes)
 {
-    auto data = span.data();
-    auto length = span.size();
+    auto data = bytes.data();
+    auto length = bytes.size();
 
     ASSERT(length <= m_data.size());
     m_data.overwrite(0, data, length);

--- a/Libraries/LibCrypto/Cipher/AES.h
+++ b/Libraries/LibCrypto/Cipher/AES.h
@@ -55,7 +55,7 @@ public:
     virtual const ByteBuffer& data() const override { return m_data; };
 
     virtual void overwrite(const ReadonlyBytes&) override;
-    virtual void overwrite(const ByteBuffer& buffer) override { overwrite(buffer.span()); }
+    virtual void overwrite(const ByteBuffer& buffer) override { overwrite(buffer.bytes()); }
     virtual void overwrite(const u8* data, size_t size) override { overwrite({ data, size }); }
 
     virtual void apply_initialization_vector(const u8* ivec) override

--- a/Libraries/LibCrypto/Cipher/AES.h
+++ b/Libraries/LibCrypto/Cipher/AES.h
@@ -54,8 +54,8 @@ public:
     virtual ByteBuffer get() const override { return m_data; };
     virtual const ByteBuffer& data() const override { return m_data; };
 
-    virtual void overwrite(const ReadonlyBytes&) override;
-    virtual void overwrite(const ByteBuffer& buffer) override { overwrite(buffer.bytes()); }
+    virtual void overwrite(ReadonlyBytes) override;
+    virtual void overwrite(const ByteBuffer& buffer) override { overwrite(buffer); }
     virtual void overwrite(const u8* data, size_t size) override { overwrite({ data, size }); }
 
     virtual void apply_initialization_vector(const u8* ivec) override

--- a/Libraries/LibCrypto/Cipher/Cipher.h
+++ b/Libraries/LibCrypto/Cipher/Cipher.h
@@ -65,7 +65,7 @@ public:
     virtual const ByteBuffer& data() const = 0;
 
     virtual void overwrite(const ReadonlyBytes&) = 0;
-    virtual void overwrite(const ByteBuffer& buffer) { overwrite(buffer.span()); }
+    virtual void overwrite(const ByteBuffer& buffer) { overwrite(buffer.bytes()); }
     virtual void overwrite(const u8* data, size_t size) { overwrite({ data, size }); }
 
     virtual void apply_initialization_vector(const u8* ivec) = 0;

--- a/Libraries/LibCrypto/Cipher/Cipher.h
+++ b/Libraries/LibCrypto/Cipher/Cipher.h
@@ -64,8 +64,8 @@ public:
     virtual ByteBuffer get() const = 0;
     virtual const ByteBuffer& data() const = 0;
 
-    virtual void overwrite(const ReadonlyBytes&) = 0;
-    virtual void overwrite(const ByteBuffer& buffer) { overwrite(buffer.bytes()); }
+    virtual void overwrite(ReadonlyBytes) = 0;
+    virtual void overwrite(const ByteBuffer& buffer) { overwrite(buffer); }
     virtual void overwrite(const u8* data, size_t size) { overwrite({ data, size }); }
 
     virtual void apply_initialization_vector(const u8* ivec) = 0;

--- a/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Libraries/LibCrypto/PK/RSA.cpp
@@ -125,7 +125,7 @@ void RSA::encrypt(const ByteBuffer& in, ByteBuffer& out)
         return;
     }
     auto exp = NumberTheory::ModularPower(in_integer, m_public_key.public_exponent(), m_public_key.modulus());
-    auto size = exp.export_data(out.span());
+    auto size = exp.export_data(out);
     auto outsize = out.size();
     if (size != outsize) {
         dbg() << "POSSIBLE RSA BUG!!! Size mismatch: " << outsize << " requested but " << size << " bytes generated";
@@ -139,7 +139,7 @@ void RSA::decrypt(const ByteBuffer& in, ByteBuffer& out)
 
     auto in_integer = UnsignedBigInteger::import_data(in.data(), in.size());
     auto exp = NumberTheory::ModularPower(in_integer, m_private_key.private_exponent(), m_private_key.modulus());
-    auto size = exp.export_data(out.span());
+    auto size = exp.export_data(out);
 
     auto align = m_private_key.length();
     auto aligned_size = (size + align - 1) / align * align;
@@ -153,7 +153,7 @@ void RSA::sign(const ByteBuffer& in, ByteBuffer& out)
 {
     auto in_integer = UnsignedBigInteger::import_data(in.data(), in.size());
     auto exp = NumberTheory::ModularPower(in_integer, m_private_key.private_exponent(), m_private_key.modulus());
-    auto size = exp.export_data(out.span());
+    auto size = exp.export_data(out);
     out = out.slice(out.size() - size, size);
 }
 
@@ -161,7 +161,7 @@ void RSA::verify(const ByteBuffer& in, ByteBuffer& out)
 {
     auto in_integer = UnsignedBigInteger::import_data(in.data(), in.size());
     auto exp = NumberTheory::ModularPower(in_integer, m_public_key.public_exponent(), m_public_key.modulus());
-    auto size = exp.export_data(out.span());
+    auto size = exp.export_data(out);
     out = out.slice(out.size() - size, size);
 }
 
@@ -170,7 +170,7 @@ void RSA::import_private_key(ReadonlyBytes bytes, bool pem)
     ByteBuffer buffer;
     if (pem) {
         buffer = decode_pem(bytes);
-        bytes = buffer.span();
+        bytes = buffer;
     }
 
     auto key = parse_rsa_key(bytes);
@@ -186,7 +186,7 @@ void RSA::import_public_key(ReadonlyBytes bytes, bool pem)
     ByteBuffer buffer;
     if (pem) {
         buffer = decode_pem(bytes);
-        bytes = buffer.span();
+        bytes = buffer;
     }
 
     auto key = parse_rsa_key(bytes);

--- a/Libraries/LibCrypto/PK/RSA.h
+++ b/Libraries/LibCrypto/PK/RSA.h
@@ -160,8 +160,8 @@ public:
 
     RSA(const ByteBuffer& publicKeyPEM, const ByteBuffer& privateKeyPEM)
     {
-        import_public_key(publicKeyPEM.span());
-        import_private_key(privateKeyPEM.span());
+        import_public_key(publicKeyPEM);
+        import_private_key(privateKeyPEM);
     }
 
     RSA(const StringView& privKeyPEM)

--- a/Libraries/LibDebug/DebugInfo.cpp
+++ b/Libraries/LibDebug/DebugInfo.cpp
@@ -105,7 +105,7 @@ void DebugInfo::prepare_lines()
         return;
 
     auto buffer = section.wrapping_byte_buffer();
-    InputMemoryStream stream { buffer.span() };
+    InputMemoryStream stream { buffer };
 
     Vector<LineProgram::LineInfo> all_lines;
     while (!stream.eof()) {

--- a/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
+++ b/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
@@ -40,7 +40,7 @@ AbbreviationsMap::AbbreviationsMap(const DwarfInfo& dwarf_info, u32 offset)
 
 void AbbreviationsMap::populate_map()
 {
-    InputMemoryStream abbreviation_stream(m_dwarf_info.abbreviation_data().span());
+    InputMemoryStream abbreviation_stream(m_dwarf_info.abbreviation_data());
     abbreviation_stream.discard_or_error(m_offset);
 
     while (!abbreviation_stream.eof()) {

--- a/Libraries/LibDebug/Dwarf/DIE.cpp
+++ b/Libraries/LibDebug/Dwarf/DIE.cpp
@@ -36,7 +36,7 @@ DIE::DIE(const CompilationUnit& unit, u32 offset)
     : m_compilation_unit(unit)
     , m_offset(offset)
 {
-    InputMemoryStream stream(m_compilation_unit.dwarf_info().debug_info_data().span());
+    InputMemoryStream stream(m_compilation_unit.dwarf_info().debug_info_data());
     stream.discard_or_error(m_offset);
     stream.read_LEB128_unsigned(m_abbreviation_code);
     m_data_offset = stream.offset();
@@ -181,7 +181,7 @@ DIE::AttributeValue DIE::get_attribute_value(AttributeDataForm form,
 
 Optional<DIE::AttributeValue> DIE::get_attribute(const Attribute& attribute) const
 {
-    InputMemoryStream stream { m_compilation_unit.dwarf_info().debug_info_data().span() };
+    InputMemoryStream stream { m_compilation_unit.dwarf_info().debug_info_data() };
     stream.discard_or_error(m_data_offset);
 
     auto abbreviation_info = m_compilation_unit.abbreviations_map().get(m_abbreviation_code);

--- a/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -53,7 +53,7 @@ void DwarfInfo::populate_compilation_units()
     if (m_debug_info_data.is_null())
         return;
 
-    InputMemoryStream stream(m_debug_info_data.span());
+    InputMemoryStream stream{ m_debug_info_data };
     while (!stream.eof()) {
         auto unit_offset = stream.offset();
         CompilationUnitHeader compilation_unit_header {};

--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -727,7 +727,7 @@ bool TLSv12::add_client_key(const ByteBuffer& certificate_pem_buffer, const Byte
     if (certificate_pem_buffer.is_empty() || rsa_key.is_empty()) {
         return true;
     }
-    auto decoded_certificate = decode_pem(certificate_pem_buffer.span(), 0);
+    auto decoded_certificate = decode_pem(certificate_pem_buffer, 0);
     if (decoded_certificate.is_empty()) {
         dbg() << "Certificate not PEM";
         return false;

--- a/Userland/base64.cpp
+++ b/Userland/base64.cpp
@@ -75,6 +75,6 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    auto encoded = encode_base64(buffer.span());
+    auto encoded = encode_base64(buffer);
     printf("%s\n", encoded.characters());
 }

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -99,7 +99,7 @@ static int crc32_tests();
 
 // stop listing tests
 
-static void print_buffer(const ReadonlyBytes& buffer, int split)
+static void print_buffer(ReadonlyBytes buffer, int split)
 {
     for (size_t i = 0; i < buffer.size(); ++i) {
         if (split > 0) {

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -201,8 +201,8 @@ static void aes_cbc(const char* message, size_t len)
             Crypto::Cipher::Intent::Encryption);
 
         auto enc = cipher.create_aligned_buffer(buffer.size());
-        auto enc_span = enc.span();
-        cipher.encrypt(buffer.span(), enc_span, iv.span());
+        auto enc_span = enc.bytes();
+        cipher.encrypt(buffer, enc_span, iv);
 
         if (binary)
             printf("%.*s", (int)enc_span.size(), enc_span.data());
@@ -214,8 +214,8 @@ static void aes_cbc(const char* message, size_t len)
             key_bits,
             Crypto::Cipher::Intent::Decryption);
         auto dec = cipher.create_aligned_buffer(buffer.size());
-        auto dec_span = dec.span();
-        cipher.decrypt(buffer.span(), dec_span, iv.span());
+        auto dec_span = dec.bytes();
+        cipher.decrypt(buffer, dec_span, iv);
         printf("%.*s\n", (int)dec_span.size(), dec_span.data());
     }
 }
@@ -588,8 +588,8 @@ static void aes_cbc_test_encrypt()
         auto in = "This is a test! This is another test!"_b;
         auto out = cipher.create_aligned_buffer(in.size());
         auto iv = ByteBuffer::create_zeroed(Crypto::Cipher::AESCipher::block_size());
-        auto out_span = out.span();
-        cipher.encrypt(in.span(), out_span, iv.span());
+        auto out_span = out.bytes();
+        cipher.encrypt(in, out_span, iv);
         if (out.size() != sizeof(result))
             FAIL(size mismatch);
         else if (memcmp(out_span.data(), result, out_span.size()) != 0) {
@@ -652,8 +652,8 @@ static void aes_cbc_test_decrypt()
         auto in = ByteBuffer::copy(result, result_len);
         auto out = cipher.create_aligned_buffer(in.size());
         auto iv = ByteBuffer::create_zeroed(Crypto::Cipher::AESCipher::block_size());
-        auto out_span = out.span();
-        cipher.decrypt(in.span(), out_span, iv.span());
+        auto out_span = out.bytes();
+        cipher.decrypt(in, out_span, iv);
         if (out_span.size() != strlen(true_value)) {
             FAIL(size mismatch);
             printf("Expected %zu bytes but got %zu\n", strlen(true_value), out_span.size());
@@ -728,8 +728,8 @@ static void aes_ctr_test_encrypt()
         // nonce is already included in ivec.
         Crypto::Cipher::AESCipher::CTRMode cipher(key, 8 * key.size(), Crypto::Cipher::Intent::Encryption);
         ByteBuffer out_actual = ByteBuffer::create_zeroed(in.size());
-        Bytes out_span = out_actual.span();
-        cipher.encrypt(in.span(), out_span, ivec.span());
+        Bytes out_span = out_actual.bytes();
+        cipher.encrypt(in, out_span, ivec);
         if (out_expected.size() != out_actual.size()) {
             FAIL(size mismatch);
             printf("Expected %zu bytes but got %zu\n", out_expected.size(), out_span.size());
@@ -923,8 +923,8 @@ static void aes_ctr_test_decrypt()
         // nonce is already included in ivec.
         Crypto::Cipher::AESCipher::CTRMode cipher(key, 8 * key.size(), Crypto::Cipher::Intent::Decryption);
         ByteBuffer out_actual = ByteBuffer::create_zeroed(in.size());
-        auto out_span = out_actual.span();
-        cipher.decrypt(in.span(), out_span, ivec.span());
+        auto out_span = out_actual.bytes();
+        cipher.decrypt(in, out_span, ivec);
         if (out_expected.size() != out_span.size()) {
             FAIL(size mismatch);
             printf("Expected %zu bytes but got %zu\n", out_expected.size(), out_span.size());
@@ -1442,7 +1442,7 @@ static void rsa_test_encrypt()
         rsa.encrypt(data, buf);
         if (memcmp(result, buf.data(), buf.size())) {
             FAIL(Invalid encryption result);
-            print_buffer(buf.span(), 16);
+            print_buffer(buf, 16);
         } else {
             PASS;
         }


### PR DESCRIPTION
This pull request contains a few minor tweaks,

  - renames the `span()` methods on containers to `bytes()` if it is known at compile time that bytes are contained, and

  - adds some utility functions like `Span::copy_to()` or `Span::fill()` that are abstracting for `memcpy()`, `memmove()` and `memset()`.
