### PR TITLE
AK: Add initial stubs for C++ name demangling

### DIFF
--- a/AK/TestSuite.h
+++ b/AK/TestSuite.h
@@ -284,6 +284,17 @@ using AK::TestSuite;
         }                                                                                                                                                                  \
     } while (0)
 
+#define assertNotEqual(one, two)                                                                                                                                              \
+    do {                                                                                                                                                                   \
+        auto ___aev1 = one;                                                                                                                                                \
+        auto ___aev2 = two;                                                                                                                                                \
+        if (___aev1 == ___aev2) {                                                                                                                                          \
+            dbg() << "\033[31;1mFAIL\033[0m: " __FILE__ ":" << __LINE__ << ": assertNotEqual(" ___str(one) ", " ___str(two) ") failed"; \
+        }                                                                                                                                                                  \
+    } while (0)
+
 #define EXPECT_EQ(one, two) assertEqual(one, two)
+#define EXPECT_NE(one, two) assertNotEqual(one, two)
 
 #define EXPECT(one) assertEqual(one, true)
+#define EXPECT_FALSE(one) assertEqual(one, false)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -195,6 +195,7 @@ set(KERNEL_SOURCES
 )
 
 set(AK_SOURCES
+    ../AK/Demangle.cpp
     ../AK/FlyString.cpp
     ../AK/GenericLexer.cpp
     ../AK/JsonParser.cpp


### PR DESCRIPTION
Many subsystems in Serenity could benefit from functional C++
name demangling. Debug logger stack traces, the profile viewer
the serenity debugger, etc.

This starts framing out that functionality, so it can be filled
in over time.