### PR TITLE
LibGUI: Don't center dialog within parent if window is not visible

### DIFF
--- a/Libraries/LibGUI/Dialog.cpp
+++ b/Libraries/LibGUI/Dialog.cpp
@@ -25,7 +25,6 @@
  */
 
 #include <LibCore/EventLoop.h>
-#include <LibGUI/Desktop.h>
 #include <LibGUI/Dialog.h>
 #include <LibGUI/Event.h>
 
@@ -45,14 +44,18 @@ int Dialog::exec()
 {
     ASSERT(!m_event_loop);
     m_event_loop = make<Core::EventLoop>();
-    auto new_rect = rect();
     if (parent() && parent()->is_window()) {
         auto& parent_window = *static_cast<Window*>(parent());
-        new_rect.center_within(parent_window.rect());
+        if (parent_window.is_visible()) {
+            auto new_rect = rect();
+            new_rect.center_within(parent_window.rect());
+            set_rect(new_rect);
+        } else {
+            center_on_screen();
+        }
     } else {
-        new_rect.center_within(Desktop::the().rect());
+        center_on_screen();
     }
-    set_rect(new_rect);
     show();
     auto result = m_event_loop->exec();
     m_event_loop = nullptr;


### PR DESCRIPTION
Windows have an initial off-screen rect, so when a dialog is created and shown before its parent window, in which it is centered, it would be invisible to the user.

Fixes #3172.