### PR TITLE
TextEditor: Ruler fixes

### DIFF
--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -42,6 +42,7 @@
 #include <LibGfx/Palette.h>
 #include <ctype.h>
 #include <fcntl.h>
+#include <math.h>
 #include <stdio.h>
 #include <unistd.h>
 
@@ -328,8 +329,8 @@ int TextEditor::ruler_width() const
 {
     if (!m_ruler_visible)
         return 0;
-    // FIXME: Resize based on needed space.
-    return 5 * font().glyph_width('x') + 4;
+    int line_count_digits = static_cast<int>(log10(line_count())) + 1;
+    return line_count() < 10 ? (line_count_digits + 1) * font().glyph_width('x') + 4 : line_count_digits * font().glyph_width('x') + 4;
 }
 
 Gfx::IntRect TextEditor::ruler_content_rect(size_t line_index) const

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -412,7 +412,7 @@ void TextEditor::paint_event(PaintEvent& event)
             painter.draw_text(
                 ruler_line_rect.shrunken(2, 0).translated(0, m_line_spacing / 2),
                 String::number(i + 1),
-                is_current_line ? Gfx::Font::default_bold_font() : font(),
+                is_current_line && font().has_boldface() ? font().bold_family_font() : font(),
                 Gfx::TextAlignment::TopRight,
                 is_current_line ? palette().ruler_active_text() : palette().ruler_inactive_text());
         }

--- a/Libraries/LibGfx/Font.h
+++ b/Libraries/LibGfx/Font.h
@@ -110,6 +110,10 @@ public:
     bool is_fixed_width() const { return m_fixed_width; }
     void set_fixed_width(bool b) { m_fixed_width = b; }
 
+    const Font& bold_family_font() const { return *m_bold_family_font; }
+    bool has_boldface() const { return m_boldface; }
+    void set_boldface(bool b) { m_boldface = b; }
+
     u8 glyph_spacing() const { return m_glyph_spacing; }
     void set_glyph_spacing(u8 spacing) { m_glyph_spacing = spacing; }
 
@@ -130,6 +134,9 @@ private:
     static RefPtr<Font> load_from_memory(const u8*);
     static size_t glyph_count_by_type(FontTypes type);
 
+    void set_family_fonts();
+    RefPtr<Font> m_bold_family_font;
+
     String m_name;
     FontTypes m_type;
     size_t m_glyph_count { 256 };
@@ -146,6 +153,7 @@ private:
     u8 m_glyph_spacing { 0 };
 
     bool m_fixed_width { false };
+    bool m_boldface { false };
 };
 
 }


### PR DESCRIPTION
Fixes ruler width and boldface glyph issues. Width is now based on the number of digits in the line count plus a 1 digit buffer, similar to gedit, and the ruler tries to match a bold family font when drawing the current line instead of defaulting to Katica.
![ruler](https://user-images.githubusercontent.com/66646555/90336402-b48fa000-dfa9-11ea-96f5-1bd9eefbad4b.png)
