### PR TITLE
disasm: For ELF inputs, pass an ELFSymbolProvider to disassembler

### DIFF
--- a/DevTools/Profiler/DisassemblyModel.cpp
+++ b/DevTools/Profiler/DisassemblyModel.cpp
@@ -30,6 +30,7 @@
 #include <LibELF/Loader.h>
 #include <LibGUI/Painter.h>
 #include <LibX86/Disassembler.h>
+#include <LibX86/ELFSymbolProvider.h>
 #include <ctype.h>
 #include <stdio.h>
 
@@ -49,22 +50,6 @@ static Color color_for_percent(int percent)
     ASSERT(percent >= 0 && percent <= 100);
     return heat_gradient().get_pixel(percent, 0);
 }
-
-class ELFSymbolProvider final : public X86::SymbolProvider {
-public:
-    ELFSymbolProvider(ELF::Loader& loader)
-        : m_loader(loader)
-    {
-    }
-
-    virtual String symbolicate(FlatPtr address, u32* offset = nullptr) const
-    {
-        return m_loader.symbolicate(address, offset);
-    }
-
-private:
-    ELF::Loader& m_loader;
-};
 
 DisassemblyModel::DisassemblyModel(Profile& profile, ProfileNode& node)
     : m_profile(profile)
@@ -89,7 +74,7 @@ DisassemblyModel::DisassemblyModel(Profile& profile, ProfileNode& node)
 
     auto view = symbol.value().raw_data();
 
-    ELFSymbolProvider symbol_provider(*elf_loader);
+    X86::ELFSymbolProvider symbol_provider(*elf_loader);
     X86::SimpleInstructionStream stream((const u8*)view.characters_without_null_termination(), view.length());
     X86::Disassembler disassembler(stream);
 

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -32,6 +32,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/LogStream.h>
 #include <Kernel/API/Syscall.h>
+#include <LibX86/ELFSymbolProvider.h>
 #include <fcntl.h>
 #include <serenity.h>
 #include <stdio.h>
@@ -157,25 +158,9 @@ bool Emulator::load_elf()
     return true;
 }
 
-class ELFSymbolProvider final : public X86::SymbolProvider {
-public:
-    ELFSymbolProvider(ELF::Loader& loader)
-        : m_loader(loader)
-    {
-    }
-
-    virtual String symbolicate(FlatPtr address, u32* offset = nullptr) const
-    {
-        return m_loader.symbolicate(address, offset);
-    }
-
-private:
-    ELF::Loader& m_loader;
-};
-
 int Emulator::exec()
 {
-    ELFSymbolProvider symbol_provider(*m_elf);
+    X86::ELFSymbolProvider symbol_provider(*m_elf);
 
     bool trace = false;
 

--- a/Libraries/LibX86/ELFSymbolProvider.h
+++ b/Libraries/LibX86/ELFSymbolProvider.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibELF/Loader.h>
+
+namespace X86 {
+
+class ELFSymbolProvider final : public SymbolProvider {
+public:
+    ELFSymbolProvider(ELF::Loader& loader)
+        : m_loader(loader)
+    {
+    }
+
+    virtual String symbolicate(FlatPtr address, u32* offset = nullptr) const override
+    {
+        return m_loader.symbolicate(address, offset);
+    }
+
+private:
+    ELF::Loader& m_loader;
+};
+}


### PR DESCRIPTION
This lets disasm output contain the symbol names of call and jump
destinations:

    8048111:    e8 88 38 01 00          call   805b99e <__cxa_atexit>
    ...
    8048150:    74 15                   je     8048167 <_start+0x4c>

The latter (the symbol of the current function with an offset) is
arguably more distracting than useful because you usually want to look
at the instruction at the absolute offset in this case, but the former
is very nice to have.

For reasons I do not understand, this cuts the time to run
`disasm /bin/id` in half, from ~1s to ~0.5s.