### PR TITLE
AK: Always use memmove instead of memcpy in Span.

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -163,21 +163,10 @@ public:
     ALWAYS_INLINE void copy_to(Span other) const
     {
         ASSERT(other.size() >= size());
-        __builtin_memcpy(other.data(), data(), sizeof(T) * size());
-    }
-
-    ALWAYS_INLINE void copy_trimmed_to(Span other) const
-    {
-        __builtin_memcpy(other.data(), data(), sizeof(T) * min(size(), other.size()));
-    }
-
-    ALWAYS_INLINE void move_to(Span other) const
-    {
-        ASSERT(other.size() >= size());
         __builtin_memmove(other.data(), data(), sizeof(T) * size());
     }
 
-    ALWAYS_INLINE void move_trimmed_to(Span other) const
+    ALWAYS_INLINE void copy_trimmed_to(Span other) const
     {
         __builtin_memmove(other.data(), data(), sizeof(T) * min(size(), other.size()));
     }

--- a/Libraries/LibCrypto/Cipher/AES.h
+++ b/Libraries/LibCrypto/Cipher/AES.h
@@ -55,7 +55,7 @@ public:
     virtual const ByteBuffer& data() const override { return m_data; };
 
     virtual void overwrite(ReadonlyBytes) override;
-    virtual void overwrite(const ByteBuffer& buffer) override { overwrite(buffer); }
+    virtual void overwrite(const ByteBuffer& buffer) override { overwrite(buffer.bytes()); }
     virtual void overwrite(const u8* data, size_t size) override { overwrite({ data, size }); }
 
     virtual void apply_initialization_vector(const u8* ivec) override

--- a/Libraries/LibCrypto/Cipher/Cipher.h
+++ b/Libraries/LibCrypto/Cipher/Cipher.h
@@ -65,7 +65,7 @@ public:
     virtual const ByteBuffer& data() const = 0;
 
     virtual void overwrite(ReadonlyBytes) = 0;
-    virtual void overwrite(const ByteBuffer& buffer) { overwrite(buffer); }
+    virtual void overwrite(const ByteBuffer& buffer) { overwrite(buffer.bytes()); }
     virtual void overwrite(const u8* data, size_t size) { overwrite({ data, size }); }
 
     virtual void apply_initialization_vector(const u8* ivec) = 0;


### PR DESCRIPTION
This pull request fixes some issues with #3166:

  - Calling `memcpy` doesn't offer a big performance improvement on most systems and `memmove` can be safer. https://github.com/SerenityOS/serenity/pull/3166#discussion_r471031704

  - I made a careless mistake when replacing `bytes()` calls with implicit conversions. https://github.com/SerenityOS/serenity/pull/3166#discussion_r471131765