### PR TITLE
LibWeb: Remove unused private field m_queued_finish in HttpsJob

### DIFF
--- a/Libraries/LibHTTP/HttpsJob.h
+++ b/Libraries/LibHTTP/HttpsJob.h
@@ -68,7 +68,6 @@ protected:
 
 private:
     RefPtr<TLS::TLSv12> m_socket;
-    bool m_queued_finish { false };
 };
 
 }


### PR DESCRIPTION
Doesn't look like this changed recently, so not sure why clang complains about this now when it didn't earlier.