### PR TITLE
AK + Libraries + Applications + Games + DevTools: Coverity static analysis fixes

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -30,10 +30,14 @@
 
 namespace AK::Concepts {
 
+#if defined(__cpp_concepts) && !defined(__COVERITY__)
+
 template<typename T>
 concept Integral = IsIntegral<T>::value;
 
 template<typename T>
 concept FloatingPoint = IsFloatingPoint<T>::value;
+
+#endif
 
 }

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -62,7 +62,11 @@ public:
     virtual bool discard_or_error(size_t count) = 0;
 };
 
+#if defined(__cpp_concepts) && !defined(__COVERITY__)
 template<Concepts::Integral Integral>
+#else
+template<typename Integral, typename EnableIf<IsIntegral<Integral>::value, int>::Type = 0>
+#endif
 InputStream& operator>>(InputStream& stream, Integral& value)
 {
     stream.read_or_error({ &value, sizeof(value) });
@@ -70,12 +74,18 @@ InputStream& operator>>(InputStream& stream, Integral& value)
 }
 
 #ifndef KERNEL
+
+#if defined(__cpp_concepts) && !defined(__COVERITY__)
 template<Concepts::FloatingPoint FloatingPoint>
+#else
+template<typename FloatingPoint, typename EnableIf<IsFloatingPoint<FloatingPoint>::value, int>::Type = 0>
+#endif
 InputStream& operator>>(InputStream& stream, FloatingPoint& value)
 {
     stream.read_or_error({ &value, sizeof(value) });
     return stream;
 }
+
 #endif
 
 inline InputStream& operator>>(InputStream& stream, bool& value)

--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -33,12 +33,12 @@ namespace AK {
 
 // HACK: This is just here to make syntax highlighting work in Qt Creator.
 //       Once it supports C++20 concepts, we can remove this.
-#ifdef __clang__
-template<typename T>
-#else
+#if defined(__cpp_concepts) && !defined(__COVERITY__)
 template<typename T>
 concept PointerTypeName = IsPointer<T>::value;
 template<PointerTypeName T>
+#else
+template<typename T, typename EnableIf<IsPointer<T>::value, int>::Type = 0>
 #endif
 
 class Userspace {

--- a/Applications/FileManager/FileUtils.cpp
+++ b/Applications/FileManager/FileUtils.cpp
@@ -26,6 +26,7 @@
 
 #include "FileUtils.h"
 #include <AK/LexicalPath.h>
+#include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/DirIterator.h>
 #include <stdio.h>
@@ -85,6 +86,8 @@ bool copy_file_or_directory(const String& src_path, const String& dst_path)
     if (src_fd < 0) {
         return false;
     }
+
+    ScopeGuard close_fd_guard([src_fd]() { close(src_fd); });
 
     struct stat src_stat;
     int rc = fstat(src_fd, &src_stat);

--- a/Applications/FileManager/FileUtils.cpp
+++ b/Applications/FileManager/FileUtils.cpp
@@ -144,6 +144,8 @@ bool copy_file(const String& src_path, const String& dst_path, const struct stat
         }
     }
 
+    ScopeGuard close_fd_guard([dst_fd]() { close(dst_fd); });
+
     if (src_stat.st_size > 0) {
         if (ftruncate(dst_fd, src_stat.st_size) < 0) {
             perror("cp: ftruncate");
@@ -180,7 +182,6 @@ bool copy_file(const String& src_path, const String& dst_path, const struct stat
     }
 
     close(src_fd);
-    close(dst_fd);
     return true;
 }
 

--- a/Applications/Piano/RollWidget.h
+++ b/Applications/Piano/RollWidget.h
@@ -46,8 +46,8 @@ private:
 
     TrackManager& m_track_manager;
 
-    int m_roll_width;
-    int m_num_notes;
-    double m_note_width;
+    int m_roll_width { 0 };
+    int m_num_notes { 0 };
+    double m_note_width { 0.0 };
     int m_zoom_level { 1 };
 };

--- a/Applications/SoundPlayer/SoundPlayerWidget.h
+++ b/Applications/SoundPlayer/SoundPlayerWidget.h
@@ -79,7 +79,7 @@ private:
     GUI::Window& m_window;
     NonnullRefPtr<Audio::ClientConnection> m_connection;
     PlaybackManager m_manager;
-    float m_sample_ratio;
+    float m_sample_ratio { 1.0 };
     RefPtr<GUI::Label> m_status;
     RefPtr<GUI::Label> m_elapsed;
     RefPtr<GUI::Label> m_remaining;

--- a/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Applications/SystemMonitor/ProcessModel.cpp
@@ -393,6 +393,7 @@ void ProcessModel::update()
             state.sid = it.value.sid;
             state.times_scheduled = thread.times_scheduled;
             state.cpu = thread.cpu;
+            state.cpu_percent = 0;
             state.priority = thread.priority;
             state.effective_priority = thread.effective_priority;
             state.state = thread.state;

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -927,10 +927,7 @@ int Emulator::virt$ioctl(int fd, unsigned request, FlatPtr arg)
     if (request == TCSETS) {
         struct termios termios;
         mmu().copy_from_vm(&termios, arg, sizeof(termios));
-        int rc = syscall(SC_ioctl, fd, request, &termios);
-        if (rc < 0)
-            return rc;
-        return rc;
+        return syscall(SC_ioctl, fd, request, &termios);
     }
     dbg() << "Unsupported ioctl: " << request;
     dump_backtrace();

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -648,9 +648,9 @@ int Emulator::virt$select(FlatPtr params_addr)
     Syscall::SC_select_params params;
     mmu().copy_from_vm(&params, params_addr, sizeof(params));
 
-    fd_set readfds;
-    fd_set writefds;
-    fd_set exceptfds;
+    fd_set readfds {};
+    fd_set writefds {};
+    fd_set exceptfds {};
     struct timespec timeout;
     u32 sigmask;
 

--- a/DevTools/UserspaceEmulator/MallocTracer.cpp
+++ b/DevTools/UserspaceEmulator/MallocTracer.cpp
@@ -138,7 +138,7 @@ void MallocTracer::audit_read(FlatPtr address, size_t size)
         Emulator::the().dump_backtrace();
         report("==%d==  Address is %zu byte(s) into block of size %zu, allocated at:\n", getpid(), offset_into_mallocation, mallocation->size);
         Emulator::the().dump_backtrace(mallocation->malloc_backtrace);
-        report("==%d==  Later freed at:\n", getpid(), offset_into_mallocation, mallocation->size);
+        report("==%d==  Later freed at:\n", getpid());
         Emulator::the().dump_backtrace(mallocation->free_backtrace);
         return;
     }
@@ -173,7 +173,7 @@ void MallocTracer::audit_write(FlatPtr address, size_t size)
         Emulator::the().dump_backtrace();
         report("==%d==  Address is %zu byte(s) into block of size %zu, allocated at:\n", getpid(), offset_into_mallocation, mallocation->size);
         Emulator::the().dump_backtrace(mallocation->malloc_backtrace);
-        report("==%d==  Later freed at:\n", getpid(), offset_into_mallocation, mallocation->size);
+        report("==%d==  Later freed at:\n", getpid());
         Emulator::the().dump_backtrace(mallocation->free_backtrace);
         return;
     }

--- a/Games/Chess/PromotionDialog.cpp
+++ b/Games/Chess/PromotionDialog.cpp
@@ -31,6 +31,7 @@
 
 PromotionDialog::PromotionDialog(ChessWidget& chess_widget)
     : Dialog(chess_widget.window())
+    , m_selected_piece(Chess::Type::None)
 {
     set_title("Choose piece to promote to");
     resize(70 * 4, 70);

--- a/Libraries/LibC/fcntl.cpp
+++ b/Libraries/LibC/fcntl.cpp
@@ -38,6 +38,7 @@ int fcntl(int fd, int cmd, ...)
     va_start(ap, cmd);
     u32 extra_arg = va_arg(ap, u32);
     int rc = syscall(SC_fcntl, fd, cmd, extra_arg);
+    va_end(ap);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Libraries/LibC/ioctl.cpp
+++ b/Libraries/LibC/ioctl.cpp
@@ -38,6 +38,7 @@ int ioctl(int fd, unsigned request, ...)
     va_start(ap, request);
     unsigned arg = va_arg(ap, unsigned);
     int rc = syscall(SC_ioctl, fd, request, arg);
+    va_end(ap);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 }

--- a/Libraries/LibCompress/Zlib.cpp
+++ b/Libraries/LibCompress/Zlib.cpp
@@ -45,6 +45,7 @@ Zlib::Zlib(ReadonlyBytes data)
     m_check_bits = flags & 0xF;
     m_has_dictionary = (flags >> 5) & 0x1;
     m_compression_level = (flags >> 6) & 0x3;
+    m_checksum = 0;
 
     ASSERT(m_compression_method == 8);
     ASSERT(m_compression_info == 7);

--- a/Libraries/LibCore/SocketAddress.h
+++ b/Libraries/LibCore/SocketAddress.h
@@ -95,7 +95,7 @@ public:
     sockaddr_in to_sockaddr_in() const
     {
         ASSERT(type() == Type::IPv4);
-        sockaddr_in address;
+        sockaddr_in address {};
         address.sin_family = AF_INET;
         address.sin_addr.s_addr = m_ipv4_address.to_in_addr_t();
         address.sin_port = htons(m_port);

--- a/Libraries/LibELF/DynamicLoader.h
+++ b/Libraries/LibELF/DynamicLoader.h
@@ -91,7 +91,7 @@ private:
         u32 required_load_size() { return ALIGN_ROUND_UP(m_program_header.p_memsz, m_program_header.p_align); }
 
     private:
-        Elf32_Phdr m_program_header; // Explictly a copy of the PHDR in the image
+        Elf32_Phdr m_program_header; // Explicitly a copy of the PHDR in the image
     };
 
     explicit DynamicLoader(const char* filename, int fd, size_t file_size);
@@ -115,7 +115,7 @@ private:
     OwnPtr<DynamicObject> m_dynamic_object;
 
     VirtualAddress m_text_segment_load_address;
-    size_t m_text_segment_size;
+    size_t m_text_segment_size { 0 };
 
     VirtualAddress m_tls_segment_address;
     VirtualAddress m_dynamic_section_address;

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -359,7 +359,8 @@ private:
     HashMap<char, NonnullOwnPtr<KeyCallback>> m_key_callbacks;
 
     // TODO: handle signals internally.
-    struct termios m_termios, m_default_termios;
+    struct termios m_termios {};
+    struct termios m_default_termios {};
     bool m_was_interrupted { false };
     bool m_was_resized { false };
 

--- a/Libraries/LibThread/Thread.h
+++ b/Libraries/LibThread/Thread.h
@@ -45,7 +45,7 @@ public:
 
 private:
     Function<int()> m_action;
-    pthread_t m_tid;
+    pthread_t m_tid { 0 };
     String m_thread_name;
 };
 

--- a/Libraries/LibWeb/Layout/LayoutNode.h
+++ b/Libraries/LibWeb/Layout/LayoutNode.h
@@ -176,7 +176,6 @@ private:
 
     NonnullRefPtr<CSS::StyleProperties> m_specified_style;
     CSS::Position m_position;
-    CSS::TextAlign m_text_align;
 };
 
 class LayoutNodeWithStyleAndBoxModelMetrics : public LayoutNodeWithStyle {

--- a/Userland/more.cpp
+++ b/Userland/more.cpp
@@ -36,7 +36,7 @@ static void wait_for_key()
     printf("\033[7m--[ more ]--\033[0m");
     fflush(stdout);
     char dummy;
-    read(key_fd, &dummy, 1);
+    (void)read(key_fd, &dummy, 1);
     printf("\n");
 }
 


### PR DESCRIPTION
This is a collection of fixes to:
- Get Serenity Userspace building with the Coverity static analysis tools, as it doesn't support C++ concepts.
- Fix an initial set of issues found by the one off build + upload I did of the latest Serenity master branch.

There do seem to be some false positives, like double free's being detected around usage of NonnullRefPtr<T>, and other C++ template types. 

Reference: https://scan.coverity.com/projects/serenityos-serenity