### PR TITLE
Kernel:Interrupts/ remove unneeded Hashtable.h from SpuriousInterruptHandler.h

### DIFF
--- a/Kernel/Interrupts/SpuriousInterruptHandler.h
+++ b/Kernel/Interrupts/SpuriousInterruptHandler.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <AK/HashTable.h>
 #include <AK/OwnPtr.h>
 #include <AK/Types.h>
 #include <Kernel/Arch/i386/CPU.h>


### PR DESCRIPTION
AK/HashTable,h is not needed  from SpuriousInterruptHandler