### PR TITLE
LibWeb: Add more bindings and tests, fix small issue with HTMLPreElement

### DIFF
--- a/Libraries/LibWeb/Bindings/NodeWrapperFactory.cpp
+++ b/Libraries/LibWeb/Bindings/NodeWrapperFactory.cpp
@@ -26,8 +26,10 @@
  */
 
 #include <LibWeb/Bindings/CharacterDataWrapper.h>
-#include <LibWeb/Bindings/DocumentTypeWrapper.h>
+#include <LibWeb/Bindings/CommentWrapper.h>
 #include <LibWeb/Bindings/DocumentWrapper.h>
+#include <LibWeb/Bindings/DocumentFragmentWrapper.h>
+#include <LibWeb/Bindings/DocumentTypeWrapper.h>
 #include <LibWeb/Bindings/HTMLAnchorElementWrapper.h>
 #include <LibWeb/Bindings/HTMLAreaElementWrapper.h>
 #include <LibWeb/Bindings/HTMLAudioElementWrapper.h>
@@ -315,6 +317,10 @@ NodeWrapper* wrap(JS::GlobalObject& global_object, DOM::Node& node)
         return static_cast<NodeWrapper*>(wrap_impl(global_object, downcast<HTML::HTMLElement>(node)));
     if (is<DOM::Element>(node))
         return static_cast<NodeWrapper*>(wrap_impl(global_object, downcast<DOM::Element>(node)));
+    if (is<DOM::DocumentFragment>(node))
+        return static_cast<NodeWrapper*>(wrap_impl(global_object, downcast<DOM::DocumentFragment>(node)));
+    if (is<DOM::Comment>(node))
+        return static_cast<NodeWrapper*>(wrap_impl(global_object, downcast<DOM::Comment>(node)));
     if (is<DOM::Text>(node))
         return static_cast<NodeWrapper*>(wrap_impl(global_object, downcast<DOM::Text>(node)));
     if (is<DOM::CharacterData>(node))

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOURCES
     DOM/CharacterData.idl
     DOM/Comment.cpp
     DOM/Document.cpp
+    DOM/DocumentFragment.cpp
     DOM/DocumentType.cpp
     DOM/Element.cpp
     DOM/ElementFactory.cpp
@@ -210,7 +211,9 @@ function(libweb_js_wrapper class)
 endfunction()
 
 libweb_js_wrapper(DOM/CharacterData)
+libweb_js_wrapper(DOM/Comment)
 libweb_js_wrapper(DOM/Document)
+libweb_js_wrapper(DOM/DocumentFragment)
 libweb_js_wrapper(DOM/DocumentType)
 libweb_js_wrapper(DOM/Element)
 libweb_js_wrapper(DOM/Event)

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCES
     DOM/EventListener.cpp
     DOM/EventTarget.cpp
     DOM/Node.cpp
+    DOM/ParentNode.cpp
     DOM/Position.cpp
     DOM/TagNames.cpp
     DOM/Text.cpp

--- a/Libraries/LibWeb/CSS/Parser/CSSParser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/CSSParser.cpp
@@ -58,6 +58,11 @@ ParsingContext::ParsingContext(const DOM::Document& document)
 {
 }
 
+ParsingContext::ParsingContext(const DOM::ParentNode& parent_node)
+    : m_document(&parent_node.document())
+{
+}
+
 bool ParsingContext::in_quirks_mode() const
 {
     return m_document ? m_document->in_quirks_mode() : false;

--- a/Libraries/LibWeb/CSS/Parser/CSSParser.h
+++ b/Libraries/LibWeb/CSS/Parser/CSSParser.h
@@ -34,6 +34,7 @@ class ParsingContext {
 public:
     ParsingContext();
     explicit ParsingContext(const DOM::Document&);
+    explicit ParsingContext(const DOM::ParentNode&);
 
     bool in_quirks_mode() const;
 

--- a/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -486,11 +486,15 @@ void generate_implementation(const IDL::Interface& interface)
     out() << "#include <LibWeb/DOM/Element.h>";
     out() << "#include <LibWeb/HTML/HTMLElement.h>";
     out() << "#include <LibWeb/DOM/EventListener.h>";
+    out() << "#include <LibWeb/Bindings/CommentWrapper.h>";
     out() << "#include <LibWeb/Bindings/DocumentWrapper.h>";
+    out() << "#include <LibWeb/Bindings/DocumentFragmentWrapper.h>";
     out() << "#include <LibWeb/Bindings/DocumentTypeWrapper.h>";
     out() << "#include <LibWeb/Bindings/HTMLCanvasElementWrapper.h>";
+    out() << "#include <LibWeb/Bindings/HTMLHeadElementWrapper.h>";
     out() << "#include <LibWeb/Bindings/HTMLImageElementWrapper.h>";
     out() << "#include <LibWeb/Bindings/ImageDataWrapper.h>";
+    out() << "#include <LibWeb/Bindings/TextWrapper.h>";
     out() << "#include <LibWeb/Bindings/CanvasRenderingContext2DWrapper.h>";
 
     // FIXME: This is a total hack until we can figure out the namespace for a given type somehow.
@@ -681,7 +685,11 @@ void generate_implementation(const IDL::Interface& interface)
         out() << "        return {};";
         if (function.length() > 0) {
             out() << "    if (interpreter.argument_count() < " << function.length() << ")";
-            out() << "        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountMany, \"" << function.name << "\", \"" << function.length() << "\");";
+
+            if (function.length() == 1)
+                out() << "        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountOne, \"" << function.name << "\");";
+            else
+                out() << "        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountMany, \"" << function.name << "\", \"" << function.length() << "\");";
         }
 
         StringBuilder arguments_builder;

--- a/Libraries/LibWeb/DOM/Comment.h
+++ b/Libraries/LibWeb/DOM/Comment.h
@@ -33,6 +33,8 @@ namespace Web::DOM {
 
 class Comment final : public CharacterData {
 public:
+    using WrapperType = Bindings::CommentWrapper;
+
     explicit Comment(Document&, const String&);
     virtual ~Comment() override;
 

--- a/Libraries/LibWeb/DOM/Comment.idl
+++ b/Libraries/LibWeb/DOM/Comment.idl
@@ -1,0 +1,3 @@
+interface Comment : CharacterData {
+
+}

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -89,6 +89,7 @@ public:
     const HTML::HTMLHtmlElement* html_element() const;
     const HTML::HTMLHeadElement* head() const;
     const HTML::HTMLElement* body() const;
+    void set_body(HTML::HTMLElement& new_body);
 
     String title() const;
 
@@ -126,8 +127,6 @@ public:
 
     Vector<const Element*> get_elements_by_name(const String&) const;
     NonnullRefPtrVector<Element> get_elements_by_tag_name(const FlyString&) const;
-    RefPtr<Element> query_selector(const StringView&);
-    NonnullRefPtrVector<Element> query_selector_all(const StringView&);
 
     const String& source() const { return m_source; }
     void set_source(const String& source) { m_source = source; }
@@ -137,7 +136,9 @@ public:
     JS::Value run_javascript(const StringView&);
 
     NonnullRefPtr<Element> create_element(const String& tag_name);
+    NonnullRefPtr<DocumentFragment> create_document_fragment();
     NonnullRefPtr<Text> create_text_node(const String& data);
+    NonnullRefPtr<Comment> create_comment(const String& data);
 
     void set_pending_parsing_blocking_script(Badge<HTML::HTMLScriptElement>, HTML::HTMLScriptElement*);
     HTML::HTMLScriptElement* pending_parsing_blocking_script() { return m_pending_parsing_blocking_script; }

--- a/Libraries/LibWeb/DOM/Document.idl
+++ b/Libraries/LibWeb/DOM/Document.idl
@@ -4,12 +4,17 @@ interface Document : Node {
     Element? querySelector(DOMString selectors);
     ArrayFromVector getElementsByTagName(DOMString tagName);
     ArrayFromVector querySelectorAll(DOMString selectors);
+
     Element createElement(DOMString tagName);
+    DocumentFragment createDocumentFragment();
+    Text createTextNode(DOMString data);
+    Comment createComment(DOMString data);
 
     readonly attribute DOMString compatMode;
     readonly attribute DocumentType? doctype;
 
     readonly attribute Element? documentElement;
-    readonly attribute HTMLElement? body;
+    attribute HTMLElement? body;
+    readonly attribute HTMLHeadElement? head;
 
 }

--- a/Libraries/LibWeb/DOM/DocumentFragment.cpp
+++ b/Libraries/LibWeb/DOM/DocumentFragment.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Luke Wilde <luke.wilde@live.co.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,43 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <LibWeb/DOM/Node.h>
+#include <LibWeb/DOM/DocumentFragment.h>
 
 namespace Web::DOM {
 
-class ParentNode : public Node {
-public:
-    template<typename F> void for_each_child(F) const;
-    template<typename F> void for_each_child(F);
-
-    RefPtr<Element> query_selector(const StringView&);
-    NonnullRefPtrVector<Element> query_selector_all(const StringView&);
-
-protected:
-    ParentNode(Document& document, NodeType type)
-        : Node(document, type)
-    {
-    }
-};
-
-template<typename Callback>
-inline void ParentNode::for_each_child(Callback callback) const
+DocumentFragment::DocumentFragment(Document& document)
+    : ParentNode(document, NodeType::DOCUMENT_FRAGMENT_NODE)
 {
-    for (auto* node = first_child(); node; node = node->next_sibling())
-        callback(*node);
 }
 
-template<typename Callback>
-inline void ParentNode::for_each_child(Callback callback)
+DocumentFragment::~DocumentFragment()
 {
-    for (auto* node = first_child(); node; node = node->next_sibling())
-        callback(*node);
 }
 
 }
-
-AK_BEGIN_TYPE_TRAITS(Web::DOM::ParentNode)
-static bool is_type(const Web::DOM::Node& node) { return node.is_parent_node(); }
-AK_END_TYPE_TRAITS()

--- a/Libraries/LibWeb/DOM/DocumentFragment.h
+++ b/Libraries/LibWeb/DOM/DocumentFragment.h
@@ -36,10 +36,8 @@ class DocumentFragment
     : public ParentNode
     , public NonElementParentNode<DocumentFragment> {
 public:
-    DocumentFragment(Document& document)
-        : ParentNode(document, NodeType::DOCUMENT_FRAGMENT_NODE)
-    {
-    }
+    DocumentFragment(Document& document);
+    virtual ~DocumentFragment() override;
 
     virtual FlyString node_name() const override { return "#document-fragment"; }
 };

--- a/Libraries/LibWeb/DOM/DocumentFragment.idl
+++ b/Libraries/LibWeb/DOM/DocumentFragment.idl
@@ -1,0 +1,7 @@
+interface DocumentFragment : Node {
+
+    Element? getElementById(DOMString id);
+    Element? querySelector(DOMString selectors);
+    ArrayFromVector querySelectorAll(DOMString selectors);
+
+}

--- a/Libraries/LibWeb/DOM/Element.idl
+++ b/Libraries/LibWeb/DOM/Element.idl
@@ -5,6 +5,9 @@ interface Element : Node {
     DOMString? getAttribute(DOMString qualifiedName);
     void setAttribute(DOMString qualifiedName, DOMString value);
 
+    Element? querySelector(DOMString selectors);
+    ArrayFromVector querySelectorAll(DOMString selectors);
+
     attribute DOMString innerHTML;
     [Reflect] attribute DOMString id;
     [Reflect=class] attribute DOMString className;

--- a/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Luke Wilde <luke.wilde@live.co.uk>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,13 +30,6 @@
 #include <LibWeb/Dump.h>
 
 namespace Web::DOM {
-
-void ParentNode::remove_all_children()
-{
-    while (RefPtr<Node> child = first_child()) {
-        remove_child(*child);
-    }
-}
 
 RefPtr<Element> ParentNode::query_selector(const StringView& selector_text)
 {

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -35,7 +35,10 @@ class StyleSheet;
 }
 
 namespace Web::DOM {
+class CharacterData;
+class Comment;
 class Document;
+class DocumentFragment;
 class DocumentType;
 class Element;
 class Event;
@@ -155,6 +158,7 @@ namespace Web::Bindings {
 
 class CanvasRenderingContext2DWrapper;
 class CharacterDataWrapper;
+class CommentWrapper;
 class DocumentTypeWrapper;
 class DocumentWrapper;
 class ElementWrapper;

--- a/Libraries/LibWeb/HTML/HTMLPreElement.h
+++ b/Libraries/LibWeb/HTML/HTMLPreElement.h
@@ -41,5 +41,5 @@ public:
 }
 
 AK_BEGIN_TYPE_TRAITS(Web::HTML::HTMLPreElement)
-static bool is_type(const Web::DOM::Node& node) { return node.is_html_element() && downcast<Web::HTML::HTMLElement>(node).local_name() == Web::HTML::TagNames::pre; }
+static bool is_type(const Web::DOM::Node& node) { return node.is_html_element() && downcast<Web::HTML::HTMLElement>(node).local_name().is_one_of(Web::HTML::TagNames::pre, Web::HTML::TagNames::listing, Web::HTML::TagNames::xmp); }
 AK_END_TYPE_TRAITS()

--- a/Libraries/LibWeb/Tests/DOM/Comment.js
+++ b/Libraries/LibWeb/Tests/DOM/Comment.js
@@ -1,0 +1,15 @@
+loadPage("file:///home/anon/web-tests/Pages/Comment.html");
+
+afterInitialPageLoad(() => {
+    test("Basic functionality", () => {
+        const comment = document.body.firstChild.nextSibling;
+        expect(comment).not.toBeNull();
+
+        // FIXME: Add this in once Comment's constructor is implemented.
+        //expect(comment).toBeInstanceOf(Comment);
+
+        expect(comment.nodeName).toBe("#comment");
+        expect(comment.data).toBe("This is a comment");
+        expect(comment).toHaveLength(17);
+    });
+});

--- a/Libraries/LibWeb/Tests/DOM/Text.js
+++ b/Libraries/LibWeb/Tests/DOM/Text.js
@@ -2,7 +2,12 @@ loadPage("file:///res/html/misc/blank.html");
 
 afterInitialPageLoad(() => {
     test("Basic functionality", () => {
-        var title = document.getElementsByTagName("title")[0];
+        const title = document.getElementsByTagName("title")[0];
+        expect(title).toBeDefined();
+
+        // FIXME: Add this in once Text's constructor is implemented.
+        //expect(title.firstChild).toBeInstanceOf(Text);
+
         expect(title.firstChild.nodeName).toBe("#text");
         expect(title.firstChild.data).toBe("Blank");
         expect(title.firstChild.length).toBe(5);

--- a/Libraries/LibWeb/Tests/DOM/document.createComment.js
+++ b/Libraries/LibWeb/Tests/DOM/document.createComment.js
@@ -1,0 +1,13 @@
+loadPage("file:///res/html/misc/blank.html");
+
+afterInitialPageLoad(() => {
+    test("Basic functionality", () => {
+        const comment = document.createComment("Create Comment Test");
+
+        // FIXME: Add this in once Comment's constructor is implemented.
+        //expect(comment).toBeInstanceOf(Comment);
+        expect(comment.nodeName).toBe("#comment");
+        expect(comment.data).toBe("Create Comment Test");
+        expect(comment.length).toBe(19);
+    });
+});

--- a/Libraries/LibWeb/Tests/DOM/document.createDocumentFragment.js
+++ b/Libraries/LibWeb/Tests/DOM/document.createDocumentFragment.js
@@ -1,0 +1,11 @@
+loadPage("file:///res/html/misc/blank.html");
+
+afterInitialPageLoad(() => {
+    test("Basic functionality", () => {
+        const fragment = document.createDocumentFragment();
+
+        // FIXME: Add this in once DocumentFragment's constructor is implemented.
+        //expect(fragment).toBeInstanceOf(DocumentFragment);
+        expect(fragment.nodeName).toBe("#document-fragment");
+    });
+});

--- a/Libraries/LibWeb/Tests/DOM/document.createTextNode.js
+++ b/Libraries/LibWeb/Tests/DOM/document.createTextNode.js
@@ -1,0 +1,13 @@
+loadPage("file:///res/html/misc/blank.html");
+
+afterInitialPageLoad(() => {
+    test("Basic functionality", () => {
+        const text = document.createTextNode("Create Text Test");
+
+        // FIXME: Add this in once Text's constructor is implemented.
+        //expect(text).toBeInstanceOf(Text);
+        expect(text.nodeName).toBe("#text");
+        expect(text.data).toBe("Create Text Test");
+        expect(text.length).toBe(16);
+    });
+});

--- a/Libraries/LibWeb/Tests/DOM/document.doctype.js
+++ b/Libraries/LibWeb/Tests/DOM/document.doctype.js
@@ -3,7 +3,7 @@ loadPage("file:///res/html/misc/blank.html");
 afterInitialPageLoad(() => {
     test("Basic functionality", () => {
         expect(document.compatMode).toBe("CSS1Compat");
-        expect(document.doctype).not.toBe(null);
+        expect(document.doctype).not.toBeNull();
         expect(document.doctype.name).toBe("html");
         expect(document.doctype.publicId).toBe("");
         expect(document.doctype.systemId).toBe("");
@@ -13,6 +13,6 @@ afterInitialPageLoad(() => {
 
     test("Quirks mode", () => {
         expect(document.compatMode).toBe("BackCompat");
-        expect(document.doctype).toBe(null);
+        expect(document.doctype).toBeNull();
     });
 });

--- a/Libraries/LibWeb/Tests/DOM/document.documentElement.js
+++ b/Libraries/LibWeb/Tests/DOM/document.documentElement.js
@@ -2,7 +2,15 @@ loadPage("file:///res/html/misc/blank.html");
 
 afterInitialPageLoad(() => {
     test("Basic functionality", () => {
-        expect(document.documentElement).not.toBe(null);
+        expect(document.documentElement).not.toBeNull();
+        // FIXME: Add this in once HTMLHtmlElement's constructor is implemented.
+        //expect(document.documentElement).toBeInstanceOf(HTMLHtmlElement);
         expect(document.documentElement.nodeName).toBe("html");
+    });
+
+    // FIXME: Add this in once removeChild is implemented.
+    test.skip("Nullable", () => {
+        document.removeChild(document.documentElement);
+        expect(document.documentElement).toBeNull();
     });
 });

--- a/Libraries/LibWeb/Tests/DOM/mixins/NonElementParentNode.js
+++ b/Libraries/LibWeb/Tests/DOM/mixins/NonElementParentNode.js
@@ -1,0 +1,19 @@
+loadPage("file:///home/anon/web-tests/Pages/ParentNode.html");
+
+afterInitialPageLoad(() => {
+    test("getElementById basics", () => {
+        const unique = document.getElementById("unique");
+        expect(unique).not.toBeNull();
+        expect(unique.nodeName).toBe("div");
+        expect(unique.id).toBe("unique");
+
+        const caseSensitive = document.getElementById("Unique");
+        expect(caseSensitive).toBeNull();
+
+        const firstDuplicate = document.getElementById("dupeId");
+        expect(firstDuplicate).not.toBeNull();
+        expect(firstDuplicate.nodeName).toBe("div");
+        expect(firstDuplicate.id).toBe("dupeId");
+        expect(firstDuplicate.innerHTML).toBe("First ID");
+    });
+});

--- a/Libraries/LibWeb/Tests/DOM/mixins/ParentNode.js
+++ b/Libraries/LibWeb/Tests/DOM/mixins/ParentNode.js
@@ -1,0 +1,25 @@
+loadPage("file:///home/anon/web-tests/Pages/ParentNode.html");
+
+afterInitialPageLoad(() => {
+    test("querySelector basics", () => {
+        const firstDuplicateElement = document.querySelector(".duplicate");
+        expect(firstDuplicateElement).not.toBeNull();
+        expect(firstDuplicateElement.nodeName).toBe("div");
+        expect(firstDuplicateElement.innerHTML).toBe("First");
+
+        const noElement = document.querySelector(".nonexistent");
+        expect(noElement).toBeNull();
+    });
+
+    test("querySelectorAll basics", () => {
+        const allDuplicates = document.querySelectorAll(".duplicate");
+        expect(allDuplicates).toHaveLength(2);
+        expect(allDuplicates[0].nodeName).toBe("div");
+        expect(allDuplicates[0].innerHTML).toBe("First");
+        expect(allDuplicates[1].nodeName).toBe("div");
+        expect(allDuplicates[1].innerHTML).toBe("Second");
+
+        const noElements = document.querySelectorAll(".nonexistent");
+        expect(noElements).toHaveLength(0);
+    });
+});

--- a/Libraries/LibWeb/Tests/HTML/document.body.js
+++ b/Libraries/LibWeb/Tests/HTML/document.body.js
@@ -1,0 +1,55 @@
+loadPage("file:///res/html/misc/blank.html");
+
+afterInitialPageLoad(() => {
+    test("Basic functionality", () => {
+        expect(document.body).not.toBeNull();
+        // FIXME: Add this in once HTMLBodyElement's constructor is implemented.
+        //expect(document.body).toBeInstanceOf(HTMLBodyElement);
+        expect(document.body.nodeName).toBe("body");
+    });
+
+    // FIXME: Add this in once set_body is fully implemented.
+    test.skip("Setting body to a new body element", () => {
+        // Add something to body to see if it's gone afterwards
+        const p = document.createElement("p");
+        document.body.appendChild(p);
+
+        expect(document.body.firstChild).toBe(p);
+
+        const newBody = document.createElement("body");
+        document.body = newBody;
+
+        expect(document.body).not.toBeNull();
+        expect(document.body.nodeName).toBe("body");
+
+        // FIXME: Add this in once HTMLBodyElement's constructor is implemented.
+        //expect(document.body).toBeInstanceOf(HTMLBodyElement);
+
+        expect(document.body.firstChild).toBeNull();
+    });
+
+    // FIXME: Add this in once set_body is fully implemented.
+    test.skip("Setting body to a new frameset element", () => {
+        const newFrameSet = document.createElement("frameset");
+        document.body = newFrameSet;
+
+        expect(document.body).not.toBeNull();
+        expect(document.body.nodeName).toBe("frameset");
+
+        // FIXME: Add this in once HTMLFrameSetElement's constructor is implemented.
+        //expect(document.body).toBeInstanceOf(HTMLFrameSetElement);
+    });
+
+    // FIXME: Add this in once set_body is fully implemented.
+    test.skip("Setting body to an element that isn't body/frameset", () => {
+        expect(() => {
+            document.body = document.createElement("div");
+        }).toThrow(DOMException);
+    });
+
+    // FIXME: Add this in once removeChild is implemented.
+    test.skip("Nullable", () => {
+       document.documentElement.removeChild(document.body);
+       expect(document.body).toBeNull();
+    });
+});

--- a/Libraries/LibWeb/Tests/HTML/document.head.js
+++ b/Libraries/LibWeb/Tests/HTML/document.head.js
@@ -1,0 +1,16 @@
+loadPage("file:///res/html/misc/blank.html");
+
+afterInitialPageLoad(() => {
+    test("Basic functionality", () => {
+        expect(document.head).not.toBeNull();
+        // FIXME: Add this in once HTMLHeadElement's constructor is implemented.
+        //expect(document.head).toBeInstanceOf(HTMLHeadElement);
+        expect(document.head.nodeName).toBe("head");
+    });
+
+    // FIXME: Add this in once removeChild is implemented.
+    test.skip("Nullable", () => {
+        document.documentElement.removeChild(document.head);
+        expect(document.head).toBeNull();
+    });
+});

--- a/Libraries/LibWeb/Tests/Pages/Comment.html
+++ b/Libraries/LibWeb/Tests/Pages/Comment.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<!--This is a comment-->
+</body>
+</html>

--- a/Libraries/LibWeb/Tests/Pages/ParentNode.html
+++ b/Libraries/LibWeb/Tests/Pages/ParentNode.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+    <div class="duplicate">First</div>
+    <div class="duplicate">Second</div>
+    <div id="unique"></div>
+    <div id="dupeId">First ID</div>
+    <div id="dupeId">Second ID</div>
+</body>
+</html>

--- a/Libraries/LibWeb/Tests/libweb_tester.d.ts
+++ b/Libraries/LibWeb/Tests/libweb_tester.d.ts
@@ -1,0 +1,16 @@
+// NOTE: This file is only for syntax highlighting, documentation, etc.
+
+interface LibwebTester {
+    /**
+     * Changes the page to the specified URL. Everything afterwards will refer to the new page.
+     * @param url Page to load.
+     */
+    changePage(url: string): void;
+}
+
+interface Window {
+    /**
+     * Special test object used to ease test development for LibWeb.
+     */
+    readonly libweb_tester: LibwebTester;
+}

--- a/Libraries/LibWeb/Tests/test-common.js
+++ b/Libraries/LibWeb/Tests/test-common.js
@@ -1,8 +1,7 @@
 // NOTE: The tester loads in LibJS's test-common to prevent duplication.
 
 // NOTE: "window.libweb_tester" is set to a special tester object.
-//       The object currently provides the following functions:
-//       - changePage(url) - change page to given URL. Everything afterwards will refer to the new page.
+//       See libweb_tester.d.ts for definitions.
 
 let __PageToLoad__;
 

--- a/Userland/test-web.cpp
+++ b/Userland/test-web.cpp
@@ -193,7 +193,7 @@ static Vector<String> get_test_paths(const String& test_root)
     Vector<String> paths;
 
     iterate_directory_recursively(test_root, [&](const String& file_path) {
-        if (!file_path.ends_with("test-common.js"))
+        if (!file_path.ends_with("test-common.js") && !file_path.ends_with(".html") && !file_path.ends_with(".ts"))
             paths.append(file_path);
     });
 


### PR DESCRIPTION
LibWeb: Make HTMLPreElement's is_type match "listing" and "xmp"

I forgot to add these when I saw that listing and xmp are mapped to
HTMLPreElement.

---

LibWeb: Add Comment and DocumentFragment bindings, move querySelector...

...{All} to ParentNode. Exposes createDocumentFragment and
createComment on Document. Stubs out the document.body setter. 

Also adds ParentNode back :^).

---

LibWeb: Add more document tests, add comment, text and mixin tests

Also adds a TypeScript definition file for the test runner object.
