### PR TITLE
Shell: Respect the 'PROMPT_EOL_MARK' environment variable / Document the use of environment/local variables

### DIFF
--- a/Base/usr/share/man/man1/Shell.md
+++ b/Base/usr/share/man/man1/Shell.md
@@ -38,3 +38,7 @@ Shell -c 'rm foo*'
 # Execute the contents of a file with some arguments
 Shell foo a b c
 ```
+
+## See also
+
+* [`Shell-vars`(7)](../man7/Shell-vars.md) For details on local and environment variables used by the shell

--- a/Base/usr/share/man/man5/Shell.md
+++ b/Base/usr/share/man/man5/Shell.md
@@ -169,7 +169,7 @@ The general syntax follows the form `for name in expr { sequence }`, and allows 
 
 A for-loop evaluates the _sequence_ once per every element in the _expr_, seetting the local variable _name_ to the element being processed.
 
-The Shell shall cancel the for loop if two consecutive commands are interrupted via any of SIGINT (\^C), SIGQUIT (\^\\) or SIGKILL.
+The Shell shall cancel the for loop if two consecutive commands are interrupted via SIGINT (\^C), and any other terminating signal aborts the loop entirely.
 
 #### Examples
 ```sh

--- a/Base/usr/share/man/man7/Shell-vars.md
+++ b/Base/usr/share/man/man7/Shell-vars.md
@@ -1,0 +1,37 @@
+## Name
+
+Shell Variables - Special local and environment variables used by the Shell
+
+## Description
+
+The Shell uses various variables to allow for customisations of certain behavioural or visual things.
+Such variables can be changed or set by the user to tweak how the shell presents things.
+
+## Behavioural
+
+1. Output interpretations
+
+`IFS` (local)
+
+The value of this variable is used to join lists or split strings into lists, its default value is a newline (`\\n`).
+
+
+## Visual
+
+2. Prompting
+
+`PROMPT` (environment)
+
+The value of this variable is used to generate a prompt, the following escape sequences can be used literally inside the value, and they would expand to their respective values:
+- `\\u` : the current username
+- `\\h` : the current hostname
+- `\\w` : a collapsed path (relative to home) to the current directory
+- `\\p` : the string '$' (or '#' if the user is 'root')
+
+Any other escaped character shall be ignored.
+
+
+`PROMPT_EOL_MARK` (environment)
+
+The value of this variable is used to denote the ends of partial lines (lines with no newline), its default value is '%'.
+

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -1227,7 +1227,7 @@ void VT::clear_to_end_of_line()
     fflush(stderr);
 }
 
-StringMetrics Editor::actual_rendered_string_metrics(const StringView& string) const
+StringMetrics Editor::actual_rendered_string_metrics(const StringView& string)
 {
     size_t length { 0 };
     StringMetrics metrics;
@@ -1251,7 +1251,7 @@ StringMetrics Editor::actual_rendered_string_metrics(const StringView& string) c
     return metrics;
 }
 
-StringMetrics Editor::actual_rendered_string_metrics(const Utf32View& view) const
+StringMetrics Editor::actual_rendered_string_metrics(const Utf32View& view)
 {
     size_t length { 0 };
     StringMetrics metrics;
@@ -1271,7 +1271,7 @@ StringMetrics Editor::actual_rendered_string_metrics(const Utf32View& view) cons
     return metrics;
 }
 
-Editor::VTState Editor::actual_rendered_string_length_step(StringMetrics& metrics, size_t& length, u32 c, u32 next_c, VTState state) const
+Editor::VTState Editor::actual_rendered_string_length_step(StringMetrics& metrics, size_t& length, u32 c, u32 next_c, VTState state)
 {
     switch (state) {
     case Free:

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -173,8 +173,8 @@ public:
     void register_key_input_callback(const KeyBinding&);
     void register_key_input_callback(Key, Function<bool(Editor&)> callback);
 
-    StringMetrics actual_rendered_string_metrics(const StringView&) const;
-    StringMetrics actual_rendered_string_metrics(const Utf32View&) const;
+    static StringMetrics actual_rendered_string_metrics(const StringView&);
+    static StringMetrics actual_rendered_string_metrics(const Utf32View&);
 
     Function<Vector<CompletionSuggestion>(const Editor&)> on_tab_complete;
     Function<void()> on_interrupt_handled;
@@ -275,7 +275,7 @@ private:
         Title = 9,
     };
 
-    VTState actual_rendered_string_length_step(StringMetrics&, size_t& length, u32, u32, VTState) const;
+    static VTState actual_rendered_string_length_step(StringMetrics&, size_t& length, u32, u32, VTState);
 
     // ^Core::Object
     virtual void save_to(JsonObject&) override;

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -1100,11 +1100,20 @@ void Shell::bring_cursor_to_beginning_of_a_line() const
         }
     }
 
-    Line::VT::apply_style(Line::Style { Line::Style::Background(Line::Style::XtermColor::Cyan), Line::Style::Foreground(Line::Style::XtermColor::Black) });
-    putc('%', stderr);
-    Line::VT::apply_style(Line::Style::reset_style());
+    // Black with Cyan background.
+    constexpr auto default_mark = "\e[30;46m%\e[0m";
+    String eol_mark = getenv("PROMPT_EOL_MARK");
+    if (eol_mark.is_null())
+        eol_mark = default_mark;
+    size_t eol_mark_length = Line::Editor::actual_rendered_string_metrics(eol_mark).line_lengths.last();
+    if (eol_mark_length >= ws.ws_col) {
+        eol_mark = default_mark;
+        eol_mark_length = 1;
+    }
 
-    for (auto i = 2; i < ws.ws_col; ++i)
+    fputs(eol_mark.characters(), stderr);
+
+    for (auto i = 1 + eol_mark_length; i < ws.ws_col; ++i)
         putc(' ', stderr);
 
     putc('\r', stderr);


### PR DESCRIPTION
Due to _popular_ demand (lol), the EOL marker is now customisable.
Also adds more documentation in the form of a new shiny manpage.