### PR TITLE
Minimize animation fixes

### DIFF
--- a/Services/Taskbar/TaskbarButton.cpp
+++ b/Services/Taskbar/TaskbarButton.cpp
@@ -47,13 +47,27 @@ void TaskbarButton::context_menu_event(GUI::ContextMenuEvent&)
     GUI::WindowServerConnection::the().post_message(Messages::WindowServer::WM_PopupWindowMenu(m_identifier.client_id(), m_identifier.window_id(), screen_relative_rect().location()));
 }
 
-void TaskbarButton::resize_event(GUI::ResizeEvent& event)
+void TaskbarButton::update_taskbar_rect()
 {
     GUI::WindowServerConnection::the().post_message(
         Messages::WindowServer::WM_SetWindowTaskbarRect(
             m_identifier.client_id(),
             m_identifier.window_id(),
             screen_relative_rect()));
+}
+
+void TaskbarButton::clear_taskbar_rect()
+{
+    GUI::WindowServerConnection::the().post_message(
+        Messages::WindowServer::WM_SetWindowTaskbarRect(
+            m_identifier.client_id(),
+            m_identifier.window_id(),
+            {}));
+}
+
+void TaskbarButton::resize_event(GUI::ResizeEvent& event)
+{
+    update_taskbar_rect();
     return GUI::Button::resize_event(event);
 }
 

--- a/Services/Taskbar/TaskbarButton.h
+++ b/Services/Taskbar/TaskbarButton.h
@@ -34,6 +34,9 @@ class TaskbarButton final : public GUI::Button {
 public:
     virtual ~TaskbarButton() override;
 
+    void update_taskbar_rect();
+    void clear_taskbar_rect();
+
 private:
     explicit TaskbarButton(const WindowIdentifier&);
 

--- a/Services/Taskbar/TaskbarWindow.h
+++ b/Services/Taskbar/TaskbarWindow.h
@@ -43,7 +43,7 @@ private:
     void on_screen_rect_change(const Gfx::IntRect&);
     NonnullRefPtr<GUI::Button> create_button(const WindowIdentifier&);
     void add_window_button(::Window&, const WindowIdentifier&);
-    void remove_window_button(::Window&);
+    void remove_window_button(::Window&, bool);
     void update_window_button(::Window&, bool);
     ::Window* find_window_owner(::Window&) const;
 

--- a/Services/WindowServer/Window.h
+++ b/Services/WindowServer/Window.h
@@ -153,7 +153,7 @@ public:
     void set_rect(int x, int y, int width, int height) { set_rect({ x, y, width, height }); }
     void set_rect_without_repaint(const Gfx::IntRect&);
 
-    void set_taskbar_rect(const Gfx::IntRect& rect) { m_taskbar_rect = rect; }
+    void set_taskbar_rect(const Gfx::IntRect&);
     const Gfx::IntRect& taskbar_rect() const { return m_taskbar_rect; }
 
     void move_to(const Gfx::IntPoint& position) { set_rect({ position, size() }); }
@@ -221,11 +221,11 @@ public:
     void request_update(const Gfx::IntRect&, bool ignore_occlusion = false);
     Gfx::DisjointRectSet take_pending_paint_rects() { return move(m_pending_paint_rects); }
 
+    bool has_taskbar_rect() const { return m_have_taskbar_rect; };
     bool in_minimize_animation() const { return m_minimize_animation_step != -1; }
-
     int minimize_animation_index() const { return m_minimize_animation_step; }
     void step_minimize_animation() { m_minimize_animation_step += 1; }
-    void start_minimize_animation() { m_minimize_animation_step = 0; }
+    void start_minimize_animation();
     void end_minimize_animation() { m_minimize_animation_step = -1; }
 
     Gfx::IntRect tiled_rect(WindowTileType) const;
@@ -321,6 +321,7 @@ private:
     bool m_accessory { false };
     bool m_destroyed { false };
     bool m_default_positioned { false };
+    bool m_have_taskbar_rect { false };
     bool m_invalidated { true };
     bool m_invalidated_all { true };
     bool m_invalidated_frame { true };

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -228,6 +228,7 @@ void WindowManager::move_to_front_and_make_active(Window& window)
     // active input from any accessory window)
     for_each_window_in_modal_stack(window, [&](auto& w, bool is_stack_top) {
         move_window_to_front(w, is_stack_top, is_stack_top);
+        return IterationDecision::Continue;
     });
 
     Compositor::the().invalidate_occlusions();
@@ -1416,6 +1417,7 @@ void WindowManager::minimize_windows(Window& window, bool minimized)
 {
     for_each_window_in_modal_stack(window, [&](auto& w, bool) {
         w.set_minimized(minimized);
+        return IterationDecision::Continue;
     });
 }
 
@@ -1426,6 +1428,7 @@ void WindowManager::maximize_windows(Window& window, bool maximized)
             w.set_maximized(maximized);
         if (w.is_minimized())
             w.set_minimized(false);
+        return IterationDecision::Continue;
     });
 }
 

--- a/Services/WindowServer/WindowManager.h
+++ b/Services/WindowServer/WindowManager.h
@@ -182,7 +182,7 @@ public:
     void maximize_windows(Window&, bool);
 
     template<typename Function>
-    void for_each_window_in_modal_stack(Window& window, Function f)
+    IterationDecision for_each_window_in_modal_stack(Window& window, Function f)
     {
         auto* blocking_modal_window = window.is_blocked_by_modal_window();
         if (blocking_modal_window || window.is_modal()) {
@@ -198,13 +198,15 @@ public:
             }
             if (!modal_stack.is_empty()) {
                 for (size_t i = modal_stack.size(); i > 0; i--) {
-                    f(*modal_stack[i - 1], false);
+                    IterationDecision decision = f(*modal_stack[i - 1], false);
+                    if (decision != IterationDecision::Continue)
+                        return decision;
                 }
             }
-            f(*modal_stack_top, true);
+            return f(*modal_stack_top, true);
         } else {
             // Not a modal window stack, just "iterate" over this window
-            f(window, true);
+            return f(window, true);
         }
     }
 


### PR DESCRIPTION
This fixes the problem where minimizing a modal window causes the animation to go to/from the top left screen corner