### PR TITLE
Kernel/Thread: remove unimplemented function

### DIFF
--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -594,8 +594,6 @@ private:
     void update_state_for_thread(Thread::State previous_state);
 };
 
-HashTable<Thread*>& thread_table();
-
 template<typename Callback>
 inline IterationDecision Thread::for_each_living(Callback callback)
 {


### PR DESCRIPTION
HashTable<Thread*>& thread_table();
was declared without ever being implemented