### PR TITLE
Kernel/ProcessorInfo: remove unneeded header file dependency

### DIFF
--- a/Kernel/Arch/i386/ProcessorInfo.cpp
+++ b/Kernel/Arch/i386/ProcessorInfo.cpp
@@ -91,5 +91,3 @@ ProcessorInfo::ProcessorInfo(Processor& processor)
 }
 
 }
-
-#include <AK/String.h>


### PR DESCRIPTION
Seems like a rouge inclusion of header file at the end of ProcessorInfo.cpp