### PR TITLE
LibHTTP: Fix processing terminating chunk

### DIFF
--- a/Libraries/LibHTTP/Job.h
+++ b/Libraries/LibHTTP/Job.h
@@ -65,8 +65,8 @@ protected:
         InStatus,
         InHeaders,
         InBody,
+        Trailers,
         Finished,
-        AfterChunkedEncodingTrailer,
     };
 
     HttpRequest m_request;


### PR DESCRIPTION
After encountering the terminating chunk we need to read the
trailing headers line by line, until encountering the final
empty line.

Fixes #3197