### PR TITLE
Browser: add urls to browser history on load start

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -132,6 +132,12 @@ Tab::Tab(Type type)
     hooks().on_load_start = [this](auto& url) {
         m_location_box->set_icon(nullptr);
         m_location_box->set_text(url.to_string());
+
+        // don't add to history if back or forward is pressed
+        if (!m_is_history_navigation)
+            m_history.push(url);
+        m_is_history_navigation = false;
+
         update_actions();
         update_bookmark_button(url.to_string());
     };
@@ -393,8 +399,7 @@ Tab::~Tab()
 
 void Tab::load(const URL& url, LoadType load_type)
 {
-    if (load_type == LoadType::Normal)
-        m_history.push(url);
+    m_is_history_navigation = (load_type == LoadType::HistoryNavigation);
 
     if (m_type == Type::InProcessWebView)
         m_page_view->load(url);

--- a/Applications/Browser/Tab.h
+++ b/Applications/Browser/Tab.h
@@ -109,6 +109,8 @@ private:
 
     String m_title;
     RefPtr<const Gfx::Bitmap> m_icon;
+
+    bool m_is_history_navigation { false };
 };
 
 URL url_from_user_input(const String& input);


### PR DESCRIPTION
urls were previously added to history in the Tab::load()
function, which excluded the setter on window.location.href.
This commit adds all urls to browser history when the page loads,
as long as the load_type is not LoadType::HistoryNavigation.

Closes #3148