### PR TITLE
LibWeb: Crash instead of spinning if parse_drawto fails to match

### DIFF
--- a/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -133,6 +133,9 @@ void PathDataParser::parse_drawto() {
         parse_smooth_quadratic_bezier_curveto();
     } else if (match('A') || match('a')) {
         parse_elliptical_arc();
+    } else {
+        dbg() << "PathDataParser::parse_drawto failed to match: '" << ch() << "'";
+        TODO();
     }
 }
 


### PR DESCRIPTION
If parse_drawto fails to match anything, it will spin forever.
Instead, print out the character that failed to match and assert
false.