### PR TITLE
LibJS: Basic implementation of most of Date's constructor arguments

### DIFF
--- a/Kernel/RTC.cpp
+++ b/Kernel/RTC.cpp
@@ -155,7 +155,7 @@ time_t now()
     unsigned year, month, day, hour, minute, second;
     read_registers(year, month, day, hour, minute, second);
 
-    klog() << "RTC: Year: " << year << ", month: " << month << ", day: " << day;
+    klog() << "RTC: Year: " << year << ", month: " << month << ", day: " << day << ", hour: " << hour << ", minute: " << minute << ", second: " << second;
 
     ASSERT(year >= 2018);
 

--- a/Libraries/LibCore/DateTime.h
+++ b/Libraries/LibCore/DateTime.h
@@ -31,6 +31,7 @@
 
 namespace Core {
 
+// Represents a time in local time.
 class DateTime {
 public:
     time_t timestamp() const { return m_timestamp; }

--- a/Libraries/LibJS/Tests/builtins/Date/Date.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.js
@@ -3,3 +3,45 @@ test("basic functionality", () => {
     expect(Date.name === "Date");
     expect(Date.prototype).not.toHaveProperty("length");
 });
+
+test("timestamp constructor", () => {
+    // The timestamp constructor takes a timestamp in milliseconds since the start of the epoch, in UTC.
+
+    // 50 days and 1234 milliseconds after the start of the epoch.
+    // Most Date methods return values in local time, but since timezone offsets are less than 17 days,
+    // these checks will pass in all timezones.
+    let timestamp = 50 * 24 * 60 * 60 * 1000 + 1234;
+
+    let date = new Date(timestamp);
+    expect(date.getTime()).toBe(timestamp); // getTime() returns the timestamp in UTC.
+    expect(date.getMilliseconds()).toBe(234);
+    expect(date.getSeconds()).toBe(1);
+    expect(date.getFullYear()).toBe(1970);
+    expect(date.getMonth()).toBe(1); // Feb
+});
+
+test("tuple constructor", () => {
+    // The tuple constructor takes a date in local time.
+    expect(new Date(2019, 11).getFullYear()).toBe(2019);
+    expect(new Date(2019, 11).getMonth()).toBe(11);
+    expect(new Date(2019, 11).getDate()).toBe(1); // getDay() returns day of week, getDate() returnsn day in month
+    expect(new Date(2019, 11).getHours()).toBe(0);
+    expect(new Date(2019, 11).getMinutes()).toBe(0);
+    expect(new Date(2019, 11).getSeconds()).toBe(0);
+    expect(new Date(2019, 11).getMilliseconds()).toBe(0);
+
+    let date = new Date(2019, 11, 15,  9, 16, 14, 123); // Note: Month is 0-based.
+    expect(date.getFullYear()).toBe(2019);
+    expect(date.getMonth()).toBe(11);
+    expect(date.getDate()).toBe(15);
+    expect(date.getHours()).toBe(9);
+    expect(date.getMinutes()).toBe(16);
+    expect(date.getSeconds()).toBe(14);
+    expect(date.getMilliseconds()).toBe(123);
+
+    // getTime() returns a time stamp in UTC, but we can at least check it's in the right interval, which will be true independent of the local timezone if the range is big enough.
+    let timestamp_lower_bound = 1575072000000;  // 2019-12-01T00:00:00Z
+    let timestamp_upper_bound = 1577750400000;  // 2019-12-31T00:00:00Z
+    expect(date.getTime()).toBeGreaterThan(timestamp_lower_bound);
+    expect(date.getTime()).toBeLessThan(timestamp_upper_bound);
+});


### PR DESCRIPTION
The constructor with a string argument isn't implemented yet, but
this implements the other variants.

The timestamp constructor doens't handle negative timestamps correctly.

Out-of-bound and invalid arguments aren't handled correctly.