### PR TITLE
Kernel: Fix race condition using thread safe singelton

### DIFF
--- a/AK/Atomic.h
+++ b/AK/Atomic.h
@@ -85,7 +85,6 @@ template<typename T, typename V = typename RemoveVolatile<T>::Type>
         return __atomic_compare_exchange_n(const_cast<V**>(var), &expected, nullptr, false, order, order);
 }
 
-
 template<typename T>
 static inline T atomic_fetch_add(volatile T* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
 {
@@ -148,7 +147,7 @@ static inline void atomic_store(volatile T** var, std::nullptr_t, MemoryOrder or
 
 template<typename T>
 class Atomic {
-    T m_value { 0 };
+    T m_value { T {} };
 
 public:
     Atomic() noexcept = default;

--- a/AK/FlyString.cpp
+++ b/AK/FlyString.cpp
@@ -27,6 +27,7 @@
 #include <AK/FlyString.h>
 #include <AK/HashTable.h>
 #include <AK/Optional.h>
+#include <AK/Singleton.h>
 #include <AK/String.h>
 #include <AK/StringUtils.h>
 #include <AK/StringView.h>
@@ -49,10 +50,7 @@ struct FlyStringImplTraits : public AK::Traits<StringImpl*> {
 
 static HashTable<StringImpl*, FlyStringImplTraits>& fly_impls()
 {
-    static HashTable<StringImpl*, FlyStringImplTraits>* table;
-    if (!table)
-        table = new HashTable<StringImpl*, FlyStringImplTraits>;
-    return *table;
+    return Singleton<HashTable<StringImpl*, FlyStringImplTraits>>::the();
 }
 
 void FlyString::did_destroy_impl(Badge<StringImpl>, StringImpl& impl)

--- a/AK/Singleton.h
+++ b/AK/Singleton.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, Muhammad Zahalqa <m@tryfinally.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Atomic.h>
+#include <AK/StdLibExtras.h>
+
+namespace AK {
+
+template<typename T>
+struct CreateOnHeap {
+    template<typename... Args>
+    T* operator()(Args&&... args) { return new T(forward<Args>(args)...); }
+};
+
+template<typename T, template<typename C> class Creator = CreateOnHeap>
+class Singleton final {
+    Singleton() = delete;
+    Singleton(Singleton const&) = delete;
+    Singleton(Singleton&&) = delete;
+    Singleton& operator=(Singleton const&) = delete;
+    Singleton& operator=(Singleton&&) = delete;
+
+    enum CreationPhase {
+        NO_INSTANCE,
+        CREATING_INSTANCE,
+        READY_INSTANCE
+    };
+
+public:
+    template<typename... Args>
+    static T& the(Args&&... args)
+    {
+        T* instance = m_instance.load(memory_order_acquire);
+        if (instance)
+            return *instance;
+
+        CreationPhase phase = NO_INSTANCE;
+        if (m_creation_phase.compare_exchange_strong(phase, CREATING_INSTANCE, AK::memory_order_acq_rel)) {
+            // Creator<T> creator;
+            instance = Creator<T>()(forward<Args>(args)...);
+            m_instance.store(instance, AK::memory_order_release);
+            m_creation_phase.store(READY_INSTANCE, AK::memory_order_release);
+        } else {
+            do {
+                __builtin_ia32_pause();
+            } while (READY_INSTANCE != m_creation_phase.load(AK::memory_order_acquire));
+            instance = m_instance.load(AK::memory_order_acquire);
+        }
+
+        return *instance;
+    }
+
+private:
+    static Atomic<T*> m_instance;
+    static Atomic<CreationPhase> m_creation_phase;
+};
+
+template<typename T, template<typename C> class Create>
+Atomic<T*> Singleton<T, Create>::m_instance = nullptr;
+
+template<typename T, template<typename C> class Create>
+Atomic<typename Singleton<T, Create>::CreationPhase> Singleton<T, Create>::m_creation_phase = Singleton::NO_INSTANCE;
+
+}
+
+using AK::Singleton;

--- a/AK/Tests/TestSingelton.cpp
+++ b/AK/Tests/TestSingelton.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, Muhammad Zahalqa <m@tryfinally.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/HashMap.h>
+#include <AK/HashTable.h>
+#include <AK/Singleton.h>
+#include <AK/String.h>
+
+class Uno {
+public:
+    Uno(int c)
+        : m_count(c)
+    {
+    }
+
+    int count() const { return m_count; }
+
+private:
+    int m_count;
+};
+
+TEST_CASE(ther_can_be_only_one)
+{
+    auto& c = Singleton<Uno>::the(42);
+    auto& d = Singleton<Uno>::the(1000);
+
+    EXPECT_EQ(c.count(), 42);
+    EXPECT_EQ(d.count(), 42);
+    EXPECT_EQ(&c, &d);
+}
+
+TEST_CASE(ther_can_be_only_one_hashmap_string_int)
+{
+    auto& map1 = Singleton<HashMap<String, int>>::the();
+    auto& map2 = Singleton<HashMap<String, int>>::the();
+    EXPECT_EQ(&map1, &map2);
+
+    map1.set("C++", 17);
+    map1.set("Java", 14);
+    map2.set("Fortran", 77);
+    EXPECT_EQ(map1.size(), 3u);
+    EXPECT_EQ(map1.size(), map2.size());
+}
+
+TEST_CASE(two_distinct_singeltons)
+{
+    auto& map1 = Singleton<HashTable<String>>::the(100);
+    map1.set("SerenityOS");
+    map1.set("BeOS");
+    map1.set("Os9");
+    EXPECT_EQ(map1.size(), 3u);
+    EXPECT_EQ(map1.capacity(), 100u);
+
+    auto& map2 = Singleton<HashTable<int>>::the(42);
+    map2.set(42);
+    EXPECT_EQ(map2.size(), 1u);
+    EXPECT_EQ(map2.capacity(), 42u);
+    Singleton<HashTable<int>>::the().set(888);
+    Singleton<HashTable<int>>::the().set(111);
+    EXPECT_EQ(map2.size(), 3u);
+}
+
+TEST_MAIN(Signelton)

--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -24,19 +24,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Singleton.h>
 #include <Kernel/Devices/Device.h>
 #include <Kernel/FileSystem/InodeMetadata.h>
 #include <LibC/errno_numbers.h>
 
 namespace Kernel {
 
-static HashMap<u32, Device*>* s_all_devices;
-
 HashMap<u32, Device*>& Device::all_devices()
 {
-    if (s_all_devices == nullptr)
-        s_all_devices = new HashMap<u32, Device*>;
-    return *s_all_devices;
+    return Singleton<HashMap<u32, Device*>>::the();
 }
 
 void Device::for_each(Function<void(Device&)> callback)

--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/HashTable.h>
+#include <AK/Singleton.h>
 #include <AK/StdLibExtras.h>
 #include <AK/StringView.h>
 #include <Kernel/FileSystem/FIFO.h>
@@ -39,10 +40,7 @@ namespace Kernel {
 
 static Lockable<HashTable<FIFO*>>& all_fifos()
 {
-    static Lockable<HashTable<FIFO*>>* s_table;
-    if (!s_table)
-        s_table = new Lockable<HashTable<FIFO*>>;
-    return *s_table;
+    return Singleton<Lockable<HashTable<FIFO*>>>::the();
 }
 
 static int s_next_fifo_id = 1;

--- a/Kernel/FileSystem/FileSystem.cpp
+++ b/Kernel/FileSystem/FileSystem.cpp
@@ -26,6 +26,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/HashMap.h>
+#include <AK/Singleton.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <Kernel/FileSystem/FileSystem.h>
@@ -37,13 +38,10 @@
 namespace Kernel {
 
 static u32 s_lastFileSystemID;
-static HashMap<u32, FS*>* s_fs_map;
 
 static HashMap<u32, FS*>& all_fses()
 {
-    if (!s_fs_map)
-        s_fs_map = new HashMap<u32, FS*>();
-    return *s_fs_map;
+    return Singleton<HashMap<u32, FS*>>::the();
 }
 
 FS::FS()

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Singleton.h>
 #include <AK/StringBuilder.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/Net/ARP.h>
@@ -47,10 +48,7 @@ namespace Kernel {
 
 Lockable<HashTable<IPv4Socket*>>& IPv4Socket::all_sockets()
 {
-    static Lockable<HashTable<IPv4Socket*>>* s_table;
-    if (!s_table)
-        s_table = new Lockable<HashTable<IPv4Socket*>>;
-    return *s_table;
+    return Singleton<Lockable<HashTable<IPv4Socket*>>>::the();
 }
 
 KResultOr<NonnullRefPtr<Socket>> IPv4Socket::create(int type, int protocol)

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Singleton.h>
 #include <AK/StringBuilder.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
@@ -39,10 +40,7 @@ namespace Kernel {
 
 Lockable<InlineLinkedList<LocalSocket>>& LocalSocket::all_sockets()
 {
-    static Lockable<InlineLinkedList<LocalSocket>>* s_list;
-    if (!s_list)
-        s_list = new Lockable<InlineLinkedList<LocalSocket>>();
-    return *s_list;
+    return Singleton<Lockable<InlineLinkedList<LocalSocket>>>::the();
 }
 
 void LocalSocket::for_each(Function<void(const LocalSocket&)> callback)
@@ -348,7 +346,6 @@ KResult LocalSocket::getsockopt(FileDescription& description, int level, int opt
 {
     if (level != SOL_SOCKET)
         return Socket::getsockopt(description, level, option, value, value_size);
-
 
     socklen_t size;
     if (!Process::current()->validate_read_and_copy_typed(&size, value_size))

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/HashTable.h>
+#include <AK/Singleton.h>
 #include <AK/StringBuilder.h>
 #include <Kernel/Heap/kmalloc.h>
 #include <Kernel/Lock.h>
@@ -39,10 +40,7 @@ namespace Kernel {
 
 static Lockable<HashTable<NetworkAdapter*>>& all_adapters()
 {
-    static Lockable<HashTable<NetworkAdapter*>>* table;
-    if (!table)
-        table = new Lockable<HashTable<NetworkAdapter*>>;
-    return *table;
+    return Singleton<Lockable<HashTable<NetworkAdapter*>>>::the();
 }
 
 void NetworkAdapter::for_each(Function<void(NetworkAdapter&)> callback)

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/HashMap.h>
+#include <AK/Singleton.h>
 #include <Kernel/Net/LoopbackAdapter.h>
 #include <Kernel/Net/Routing.h>
 #include <Kernel/Thread.h>
@@ -35,10 +36,7 @@ namespace Kernel {
 
 Lockable<HashMap<IPv4Address, MACAddress>>& arp_table()
 {
-    static Lockable<HashMap<IPv4Address, MACAddress>>* the;
-    if (!the)
-        the = new Lockable<HashMap<IPv4Address, MACAddress>>;
-    return *the;
+    return Singleton<Lockable<HashMap<IPv4Address, MACAddress>>>::the();
 }
 
 bool RoutingDecision::is_zero() const

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Singleton.h>
 #include <AK/Time.h>
 #include <Kernel/Devices/RandomDevice.h>
 #include <Kernel/FileSystem/FileDescription.h>
@@ -64,18 +65,12 @@ void TCPSocket::set_state(State new_state)
 
 Lockable<HashMap<IPv4SocketTuple, RefPtr<TCPSocket>>>& TCPSocket::closing_sockets()
 {
-    static Lockable<HashMap<IPv4SocketTuple, RefPtr<TCPSocket>>>* s_map;
-    if (!s_map)
-        s_map = new Lockable<HashMap<IPv4SocketTuple, RefPtr<TCPSocket>>>;
-    return *s_map;
+    return Singleton<Lockable<HashMap<IPv4SocketTuple, RefPtr<TCPSocket>>>>::the();
 }
 
 Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>& TCPSocket::sockets_by_tuple()
 {
-    static Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>* s_map;
-    if (!s_map)
-        s_map = new Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>;
-    return *s_map;
+    return Singleton<Lockable<HashMap<IPv4SocketTuple, TCPSocket*>>>::the();
 }
 
 RefPtr<TCPSocket> TCPSocket::from_tuple(const IPv4SocketTuple& tuple)

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Singleton.h>
 #include <Kernel/Devices/RandomDevice.h>
 #include <Kernel/Net/NetworkAdapter.h>
 #include <Kernel/Net/Routing.h>
@@ -43,10 +44,7 @@ void UDPSocket::for_each(Function<void(const UDPSocket&)> callback)
 
 Lockable<HashMap<u16, UDPSocket*>>& UDPSocket::sockets_by_port()
 {
-    static Lockable<HashMap<u16, UDPSocket*>>* s_map;
-    if (!s_map)
-        s_map = new Lockable<HashMap<u16, UDPSocket*>>;
-    return *s_map;
+    return Singleton<Lockable<HashMap<u16, UDPSocket*>>>::the();
 }
 
 SocketHandle<UDPSocket> UDPSocket::from_port(u16 port)

--- a/Kernel/SharedBuffer.cpp
+++ b/Kernel/SharedBuffer.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Singleton.h>
 #include <Kernel/Process.h>
 #include <Kernel/SharedBuffer.h>
 
@@ -31,10 +32,7 @@ namespace Kernel {
 
 Lockable<HashMap<int, NonnullOwnPtr<SharedBuffer>>>& shared_buffers()
 {
-    static Lockable<HashMap<int, NonnullOwnPtr<SharedBuffer>>>* map;
-    if (!map)
-        map = new Lockable<HashMap<int, NonnullOwnPtr<SharedBuffer>>>;
-    return *map;
+    return Singleton<Lockable<HashMap<int, NonnullOwnPtr<SharedBuffer>>>>::the();
 }
 
 void SharedBuffer::sanity_check(const char* what)


### PR DESCRIPTION
- [x] Modify Atomic to support Atomic enums
- [x] Implement thread safe singleton usable from both kernel and userland + Unit test
singleton uses atomic acquire/release memory order for performance
- [x] fix #3226 
- [x] fix other race condition in kernel
- [x] fix one race in AK FlyString