### PR TITLE
Kernel: Fix assertion when releasing contiguous memory region

### DIFF
--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -450,7 +450,7 @@ RefPtr<PhysicalPage> MemoryManager::allocate_user_physical_page(ShouldZeroFill s
 
 void MemoryManager::deallocate_supervisor_physical_page(PhysicalPage&& page)
 {
-    ASSERT(s_mm_lock.is_locked());
+    ScopedSpinLock lock(s_mm_lock);
     for (auto& region : m_super_physical_regions) {
         if (!region.contains(page)) {
             klog() << "MM: deallocate_supervisor_physical_page: " << page.paddr() << " not in " << region.lower() << " -> " << region.upper();


### PR DESCRIPTION
There is no guarantee that the memory manager lock is held when
physical pages are released, so just acquire the memory manager
lock.