### PR TITLE
WindowServer: Fix MenuApplets painting

### DIFF
--- a/Services/WindowServer/AppletManager.cpp
+++ b/Services/WindowServer/AppletManager.cpp
@@ -126,6 +126,8 @@ void AppletManager::draw_applet(const Window& applet)
         return;
 
     Gfx::Painter painter(*MenuManager::the().window().backing_store());
+    Gfx::PainterStateSaver saver(painter);
+    painter.add_clip_rect(applet.rect_in_menubar());
     painter.fill_rect(applet.rect_in_menubar(), WindowManager::the().palette().window());
     painter.blit(applet.rect_in_menubar().location(), *applet.backing_store(), applet.backing_store()->rect());
 }


### PR DESCRIPTION
We need to clip painting to the actual size to prevent corrupting
the area outside of the applet as the backing store is not
guaranteed to be perfectly in sync.

Fixes #3107