### PR TITLE
LibJS: Implement Date.valueOf()

### DIFF
--- a/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -73,6 +73,13 @@ void DatePrototype::initialize(GlobalObject& global_object)
     define_native_function("toLocaleTimeString", to_locale_time_string, 0, attr);
     define_native_function("toTimeString", to_time_string, 0, attr);
     define_native_function("toString", to_string, 0, attr);
+
+    // Aliases.
+    define_native_function("valueOf", get_time, 0, attr);
+    // toJSON() isn't quite an alias for toISOString():
+    // - it returns null instead of throwing RangeError
+    // - its .length is 1, not 0
+    // - it can be transferred to other prototypes
 }
 
 DatePrototype::~DatePrototype()


### PR DESCRIPTION
It does exactly the same thing as Date.getTime().

Also mention that it's technically not 100% correct to alias toJSON() to toISOString() but it's probably close enough that we could do it if we were so inclined.