### PR TITLE
LibLine: Do not ignore Ctrl-C when buffer is empty

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -563,16 +563,11 @@ void Editor::handle_interrupt_event()
         }
     }
 
-    if (!m_buffer.is_empty()) {
-        fprintf(stderr, "^C");
-        fflush(stderr);
-    }
+    fprintf(stderr, "^C");
+    fflush(stderr);
 
     if (on_interrupt_handled)
         on_interrupt_handled();
-
-    if (m_buffer.is_empty())
-        return;
 
     m_buffer.clear();
     m_cursor = 0;


### PR DESCRIPTION
I am told that this is how people test their shells.
That's bizarre to me, but sure :^)

_/me puts bug back_