### PR TITLE
Kernel: Fix reading RTC

### DIFF
--- a/Kernel/RTC.cpp
+++ b/Kernel/RTC.cpp
@@ -128,17 +128,22 @@ void read_registers(unsigned& year, unsigned& month, unsigned& day, unsigned& ho
     month = CMOS::read(0x08);
     year = CMOS::read(0x09);
 
+    bool is_pm = hour & 0x80;
+
     if (!(status_b & 0x04)) {
         second = bcd_to_binary(second);
         minute = bcd_to_binary(minute);
-        hour = bcd_to_binary(hour & 0x70);
+        hour = bcd_to_binary(hour & 0x7F);
         day = bcd_to_binary(day);
         month = bcd_to_binary(month);
         year = bcd_to_binary(year);
     }
 
-    if (!(status_b & 0x02) && (hour & 0x80)) {
-        hour = ((hour & 0x7F) + 12) % 24;
+    if (!(status_b & 0x02)) {
+        // In the 12 hour clock, midnight and noon are 12, not 0. Map it to 0.
+        hour %= 12;
+        if (is_pm)
+            hour += 12;
     }
 
     year += 2000;


### PR DESCRIPTION
The CMOS sets bit 2 (0x4) if times are binary, if it's not
set they're in BCD.

The CMOS sets bit 1 (0x1) if hours are on a 12 hour clock.
In that case, the highest bit in the hour byte is set for
PM times (both in binary and BCD times).

Three bugs:

1. The lower 7 bits were masked off incorrectly when calling
   bcd_to_binary(). Use 0x7F as mask, not 0x70.

2. The highest bit to check if a time was PM was checked after
   BCD conversion of the low 7 bits, which clobbered that bit.
   Do the check before BCD conversion.

3. In the 12 hour clock, midnight and noon are "12", so those
   need to be converted to 0 even if for non-PM times (else
   midnight is "12", not "0").

With this, SerenityOS consistently shows UTC as the current time,
as it should.

If folks want it to display local time instead, they can get this
by adding `-rtc base=localtime` to Meta/run.sh -- but a better fix
would be to add timezone management and convert from UTC system
clock to the user timezone at display time.