### PR TITLE
AK: TestSuite: Terminate when ASSERT_NOT_REACHED is called.

### DIFF
--- a/AK/TestSuite.h
+++ b/AK/TestSuite.h
@@ -40,11 +40,17 @@
             fprintf(stderr, "\033[31;1mFAIL\033[0m: %s:%d: RELEASE_ASSERT(%s) failed\n", __FILE__, __LINE__, #x); \
     }
 
-#define ASSERT_NOT_REACHED() \
-    fprintf(stderr, "\033[31;1mFAIL\033[0m: %s:%d: ASSERT_NOT_REACHED() called\n", __FILE__, __LINE__);
+#define ASSERT_NOT_REACHED()                                                                                \
+    {                                                                                                       \
+        fprintf(stderr, "\033[31;1mFAIL\033[0m: %s:%d: ASSERT_NOT_REACHED() called\n", __FILE__, __LINE__); \
+        abort();                                                                                            \
+    }
 
-#define TODO \
-    fprintf(stderr, "\033[31;1mFAIL\033[0m: %s:%d: TODO() called\n", __FILE__, __LINE__);
+#define TODO()                                                                                \
+    {                                                                                         \
+        fprintf(stderr, "\033[31;1mFAIL\033[0m: %s:%d: TODO() called\n", __FILE__, __LINE__); \
+        abort();                                                                              \
+    }
 
 #include <stdio.h>
 


### PR DESCRIPTION
Previously, it would just write something with `FAIL` to `stderr` which
was picked up by CTest. However, some code assumes that
`ASSERT_NOT_REACHED()` doesn't return, for example:

~~~c++
bool foo(int value) {
    switch(value) {
    case 0:
        return true;
    case 1:
        return false;
    default:
        ASSERT_NOT_REACHED();
    }

     // warning: control reaches end of non-void function
}
~~~