### PR TITLE
LibJS: Implement Date.getUTC*

### DIFF
--- a/Libraries/LibJS/Runtime/Date.cpp
+++ b/Libraries/LibJS/Runtime/Date.cpp
@@ -49,11 +49,47 @@ Date::~Date()
 {
 }
 
-String Date::iso_date_string() const
+tm Date::to_utc_tm() const
 {
     time_t timestamp = m_datetime.timestamp();
     struct tm tm;
     gmtime_r(&timestamp, &tm);
+    return tm;
+}
+
+int Date::utc_date() const
+{
+    return to_utc_tm().tm_mday;
+}
+
+int Date::utc_day() const
+{
+    return to_utc_tm().tm_wday;
+}
+
+int Date::utc_full_year() const
+{
+    return to_utc_tm().tm_year + 1900;
+}
+
+int Date::utc_hours() const
+{
+    return to_utc_tm().tm_hour;
+}
+
+int Date::utc_minutes() const
+{
+    return to_utc_tm().tm_min;
+}
+
+int Date::utc_month() const
+{
+    return to_utc_tm().tm_mon;
+}
+
+String Date::iso_date_string() const
+{
+    auto tm = to_utc_tm();
     int year = tm.tm_year + 1900;
     int month = tm.tm_mon + 1;
 

--- a/Libraries/LibJS/Runtime/Date.h
+++ b/Libraries/LibJS/Runtime/Date.h
@@ -42,7 +42,17 @@ public:
 
     Core::DateTime& datetime() { return m_datetime; }
     const Core::DateTime& datetime() const { return m_datetime; }
-    u16 milliseconds() { return m_milliseconds; }
+
+    int date() const { return datetime().day(); }
+    int day() const { return datetime().weekday(); }
+    int full_year() const { return datetime().year(); }
+    int hours() const { return datetime().hour(); }
+    u16 milliseconds() const { return m_milliseconds; }
+    int minutes() const { return datetime().minute(); }
+    int month() const { return datetime().month() - 1; }
+    int seconds() const { return datetime().second(); }
+    double time() const { return datetime().timestamp() * 1000.0 + milliseconds(); }
+    int year() const { return datetime().day(); }
 
     String date_string() const { return m_datetime.to_string("%a %b %d %Y"); }
     // FIXME: Deal with timezones once SerenityOS has a working tzset(3)

--- a/Libraries/LibJS/Runtime/Date.h
+++ b/Libraries/LibJS/Runtime/Date.h
@@ -54,6 +54,15 @@ public:
     double time() const { return datetime().timestamp() * 1000.0 + milliseconds(); }
     int year() const { return datetime().day(); }
 
+    int utc_date() const;
+    int utc_day() const;
+    int utc_full_year() const;
+    int utc_hours() const;
+    int utc_milliseconds() const { return milliseconds(); }
+    int utc_minutes() const;
+    int utc_month() const;
+    int utc_seconds() const { return seconds(); }
+
     String date_string() const { return m_datetime.to_string("%a %b %d %Y"); }
     // FIXME: Deal with timezones once SerenityOS has a working tzset(3)
     String time_string() const { return m_datetime.to_string("%T GMT+0000 (UTC)"); }
@@ -75,6 +84,7 @@ public:
     }
 
 private:
+    tm to_utc_tm() const;
     virtual bool is_date() const final { return true; }
 
     Core::DateTime m_datetime;

--- a/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -91,8 +91,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_date)
     auto* this_object = typed_this(interpreter, global_object);
     if (!this_object)
         return {};
-    auto date = this_object->datetime().day();
-    return Value(static_cast<double>(date));
+    return Value(static_cast<double>(this_object->date()));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_day)
@@ -100,8 +99,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_day)
     auto* this_object = typed_this(interpreter, global_object);
     if (!this_object)
         return {};
-    auto day = this_object->datetime().weekday();
-    return Value(static_cast<double>(day));
+    return Value(static_cast<double>(this_object->day()));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_full_year)
@@ -109,8 +107,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_full_year)
     auto* this_object = typed_this(interpreter, global_object);
     if (!this_object)
         return {};
-    auto full_year = this_object->datetime().year();
-    return Value(static_cast<double>(full_year));
+    return Value(static_cast<double>(this_object->full_year()));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_hours)
@@ -118,8 +115,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_hours)
     auto* this_object = typed_this(interpreter, global_object);
     if (!this_object)
         return {};
-    auto hours = this_object->datetime().hour();
-    return Value(static_cast<double>(hours));
+    return Value(static_cast<double>(this_object->hours()));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_milliseconds)
@@ -127,8 +123,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_milliseconds)
     auto* this_object = typed_this(interpreter, global_object);
     if (!this_object)
         return {};
-    auto milliseconds = this_object->milliseconds();
-    return Value(static_cast<double>(milliseconds));
+    return Value(static_cast<double>(this_object->milliseconds()));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_minutes)
@@ -136,8 +131,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_minutes)
     auto* this_object = typed_this(interpreter, global_object);
     if (!this_object)
         return {};
-    auto minutes = this_object->datetime().minute();
-    return Value(static_cast<double>(minutes));
+    return Value(static_cast<double>(this_object->minutes()));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_month)
@@ -145,8 +139,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_month)
     auto* this_object = typed_this(interpreter, global_object);
     if (!this_object)
         return {};
-    auto months = this_object->datetime().month() - 1;
-    return Value(static_cast<double>(months));
+    return Value(static_cast<double>(this_object->month()));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_seconds)
@@ -154,8 +147,7 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_seconds)
     auto* this_object = typed_this(interpreter, global_object);
     if (!this_object)
         return {};
-    auto seconds = this_object->datetime().second();
-    return Value(static_cast<double>(seconds));
+    return Value(static_cast<double>(this_object->seconds()));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_time)

--- a/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -66,6 +66,14 @@ void DatePrototype::initialize(GlobalObject& global_object)
     define_native_function("getMonth", get_month, 0, attr);
     define_native_function("getSeconds", get_seconds, 0, attr);
     define_native_function("getTime", get_time, 0, attr);
+    define_native_function("getUTCDate", get_utc_date, 0, attr);
+    define_native_function("getUTCDay", get_utc_day, 0, attr);
+    define_native_function("getUTCFullYear", get_utc_full_year, 0, attr);
+    define_native_function("getUTCHours", get_utc_hours, 0, attr);
+    define_native_function("getUTCMilliseconds", get_utc_milliseconds, 0, attr);
+    define_native_function("getUTCMinutes", get_utc_minutes, 0, attr);
+    define_native_function("getUTCMonth", get_utc_month, 0, attr);
+    define_native_function("getUTCSeconds", get_utc_seconds, 0, attr);
     define_native_function("toDateString", to_date_string, 0, attr);
     define_native_function("toISOString", to_iso_string, 0, attr);
     define_native_function("toLocaleDateString", to_locale_date_string, 0, attr);
@@ -155,9 +163,71 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_time)
     auto* this_object = typed_this(interpreter, global_object);
     if (!this_object)
         return {};
-    auto seconds = this_object->datetime().timestamp();
-    auto milliseconds = this_object->milliseconds();
-    return Value(static_cast<double>(seconds * 1000 + milliseconds));
+    return Value(this_object->time());
+}
+
+JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_date)
+{
+    auto* this_object = typed_this(interpreter, global_object);
+    if (!this_object)
+        return {};
+    return Value(static_cast<double>(this_object->utc_date()));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_day)
+{
+    auto* this_object = typed_this(interpreter, global_object);
+    if (!this_object)
+        return {};
+    return Value(static_cast<double>(this_object->utc_day()));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_full_year)
+{
+    auto* this_object = typed_this(interpreter, global_object);
+    if (!this_object)
+        return {};
+    return Value(static_cast<double>(this_object->utc_full_year()));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_hours)
+{
+    auto* this_object = typed_this(interpreter, global_object);
+    if (!this_object)
+        return {};
+    return Value(static_cast<double>(this_object->utc_hours()));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_milliseconds)
+{
+    auto* this_object = typed_this(interpreter, global_object);
+    if (!this_object)
+        return {};
+    return Value(static_cast<double>(this_object->utc_milliseconds()));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_month)
+{
+    auto* this_object = typed_this(interpreter, global_object);
+    if (!this_object)
+        return {};
+    return Value(static_cast<double>(this_object->utc_month()));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_minutes)
+{
+    auto* this_object = typed_this(interpreter, global_object);
+    if (!this_object)
+        return {};
+    return Value(static_cast<double>(this_object->utc_minutes()));
+}
+
+JS_DEFINE_NATIVE_FUNCTION(DatePrototype::get_utc_seconds)
+{
+    auto* this_object = typed_this(interpreter, global_object);
+    if (!this_object)
+        return {};
+    return Value(static_cast<double>(this_object->utc_seconds()));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_date_string)

--- a/Libraries/LibJS/Runtime/DatePrototype.h
+++ b/Libraries/LibJS/Runtime/DatePrototype.h
@@ -47,6 +47,14 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(get_month);
     JS_DECLARE_NATIVE_FUNCTION(get_seconds);
     JS_DECLARE_NATIVE_FUNCTION(get_time);
+    JS_DECLARE_NATIVE_FUNCTION(get_utc_date);
+    JS_DECLARE_NATIVE_FUNCTION(get_utc_day);
+    JS_DECLARE_NATIVE_FUNCTION(get_utc_full_year);
+    JS_DECLARE_NATIVE_FUNCTION(get_utc_hours);
+    JS_DECLARE_NATIVE_FUNCTION(get_utc_milliseconds);
+    JS_DECLARE_NATIVE_FUNCTION(get_utc_minutes);
+    JS_DECLARE_NATIVE_FUNCTION(get_utc_month);
+    JS_DECLARE_NATIVE_FUNCTION(get_utc_seconds);
     JS_DECLARE_NATIVE_FUNCTION(to_date_string);
     JS_DECLARE_NATIVE_FUNCTION(to_iso_string);
     JS_DECLARE_NATIVE_FUNCTION(to_locale_date_string);

--- a/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCDate.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCDate.js
@@ -1,0 +1,7 @@
+test("basic functionality", () => {
+    let d = new Date();
+    expect(d.getUTCDate()).toBe(d.getUTCDate());
+    expect(d.getUTCDate()).not.toBeNaN();
+    expect(d.getUTCDate()).toBeGreaterThanOrEqual(1);
+    expect(d.getUTCDate()).toBeLessThanOrEqual(31);
+});

--- a/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCDay.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCDay.js
@@ -1,0 +1,7 @@
+test("basic functionality", () => {
+    var d = new Date();
+    expect(d.getUTCDay()).toBe(d.getUTCDay());
+    expect(d.getUTCDay()).not.toBeNaN();
+    expect(d.getUTCDay()).toBeGreaterThanOrEqual(0);
+    expect(d.getUTCDay()).toBeLessThanOrEqual(6);
+});

--- a/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCFullYear.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCFullYear.js
@@ -1,0 +1,7 @@
+test("basic functionality", () => {
+    var d = new Date();
+    expect(d.getUTCFullYear()).toBe(d.getUTCFullYear());
+    expect(d.getUTCFullYear()).not.toBeNaN();
+    expect(d.getUTCFullYear()).toBe(d.getUTCFullYear());
+    expect(d.getUTCFullYear()).toBeGreaterThanOrEqual(2020);
+});

--- a/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCHours.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCHours.js
@@ -1,0 +1,7 @@
+test("basic functionality", () => {
+    var d = new Date();
+    expect(d.getUTCHours()).toBe(d.getUTCHours());
+    expect(d.getUTCHours()).not.toBeNaN();
+    expect(d.getUTCHours()).toBeGreaterThanOrEqual(0);
+    expect(d.getUTCHours()).toBeLessThanOrEqual(23);
+});

--- a/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCMilliseconds.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCMilliseconds.js
@@ -1,0 +1,7 @@
+test("basic functionality", () => {
+    var d = new Date();
+    expect(d.getUTCMilliseconds()).toBe(d.getUTCMilliseconds());
+    expect(d.getUTCMilliseconds()).not.toBeNaN();
+    expect(d.getUTCMilliseconds()).toBeGreaterThanOrEqual(0);
+    expect(d.getUTCMilliseconds()).toBeLessThanOrEqual(999);
+});

--- a/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCMinutes.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCMinutes.js
@@ -1,0 +1,7 @@
+test("basic functionality", () => {
+    var d = new Date();
+    expect(d.getUTCMinutes()).toBe(d.getUTCMinutes());
+    expect(d.getUTCMinutes()).not.toBeNaN();
+    expect(d.getUTCMinutes()).toBeGreaterThanOrEqual(0);
+    expect(d.getUTCMinutes()).toBeLessThanOrEqual(59);
+});

--- a/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCMonth.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCMonth.js
@@ -1,0 +1,7 @@
+test("basic functionality", () => {
+    var d = new Date();
+    expect(d.getUTCMonth()).toBe(d.getUTCMonth());
+    expect(d.getUTCMonth()).not.toBeNaN();
+    expect(d.getUTCMonth()).toBeGreaterThanOrEqual(0);
+    expect(d.getUTCMonth()).toBeLessThanOrEqual(11);
+});

--- a/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCSeconds.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCSeconds.js
@@ -1,0 +1,7 @@
+test("basic functionality", () => {
+    var d = new Date();
+    expect(d.getUTCSeconds()).toBe(d.getUTCSeconds());
+    expect(d.getUTCSeconds()).not.toBeNaN();
+    expect(d.getUTCSeconds()).toBeGreaterThanOrEqual(0);
+    expect(d.getUTCSeconds()).toBeLessThanOrEqual(59);
+});


### PR DESCRIPTION
The motivation, obviously, is to use Date.getUTCDay() to test the tm_wday field after calling gmtime.