### PR TITLE
Introduce strlcpy, clean up wrong str{,n}cpy uses

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -36,10 +36,6 @@
 #    include <inttypes.h>
 #endif
 
-#ifdef KERNEL
-extern "C" char* strstr(const char* haystack, const char* needle);
-#endif
-
 namespace AK {
 
 String::String(const StringView& view)

--- a/AK/String.h
+++ b/AK/String.h
@@ -142,6 +142,7 @@ public:
     bool is_null() const { return !m_impl; }
     ALWAYS_INLINE bool is_empty() const { return length() == 0; }
     ALWAYS_INLINE size_t length() const { return m_impl ? m_impl->length() : 0; }
+    // Includes NUL-terminator, if non-nullptr.
     ALWAYS_INLINE const char* characters() const { return m_impl ? m_impl->characters() : nullptr; }
 
     ALWAYS_INLINE ReadonlyBytes bytes() const { return m_impl ? m_impl->bytes() : nullptr; }

--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -59,6 +59,7 @@ public:
     ~StringImpl();
 
     size_t length() const { return m_length; }
+    // Includes NUL-terminator.
     const char* characters() const { return &m_inline_buffer[0]; }
 
     ALWAYS_INLINE ReadonlyBytes bytes() const { return { characters(), length() }; }

--- a/Kernel/StdLib.cpp
+++ b/Kernel/StdLib.cpp
@@ -97,15 +97,6 @@ const void* memmem(const void* haystack, size_t haystack_length, const void* nee
     return AK::memmem(haystack, haystack_length, needle, needle_length);
 }
 
-char* strcpy(char* dest, const char* src)
-{
-    auto* dest_ptr = dest;
-    auto* src_ptr = src;
-    while ((*dest_ptr++ = *src_ptr++) != '\0')
-        ;
-    return dest;
-}
-
 void memset_user(void* dest_ptr, int c, size_t n)
 {
     ASSERT(Kernel::is_user_range(VirtualAddress(dest_ptr), n));

--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -42,7 +42,6 @@ void copy_from_user(void*, const void*, size_t);
 void memset_user(void*, int, size_t);
 
 void* memcpy(void*, const void*, size_t);
-char* strcpy(char*, const char*);
 int strncmp(const char* s1, const char* s2, size_t n);
 char* strstr(const char* haystack, const char* needle);
 int strcmp(char const*, const char*);
@@ -68,7 +67,6 @@ inline void copy_to_user(T* dest, const T* src)
 {
     copy_to_user(dest, src, sizeof(T));
 }
-
 
 template<typename T>
 inline void copy_from_user(T* dest, Userspace<const T*> src)

--- a/Libraries/LibC/grp.cpp
+++ b/Libraries/LibC/grp.cpp
@@ -135,12 +135,12 @@ next_entry:
     __grdb_entry->gr_passwd = __grdb_entry->passwd_buffer;
     for (size_t i = 0; i < members.size(); ++i) {
         __grdb_entry->members[i] = __grdb_entry->members_buffer[i];
-        strcpy(__grdb_entry->members_buffer[i], members[i].characters());
+        strlcpy(__grdb_entry->members_buffer[i], members[i].characters(), sizeof(__grdb_entry->members_buffer[i]));
     }
     __grdb_entry->members[members.size()] = nullptr;
     __grdb_entry->gr_mem = __grdb_entry->members;
-    strncpy(__grdb_entry->name_buffer, e_name.characters(), GRDB_STR_MAX_LEN - 1);
-    strncpy(__grdb_entry->passwd_buffer, e_passwd.characters(), GRDB_STR_MAX_LEN - 1);
+    strlcpy(__grdb_entry->name_buffer, e_name.characters(), GRDB_STR_MAX_LEN);
+    strlcpy(__grdb_entry->passwd_buffer, e_passwd.characters(), GRDB_STR_MAX_LEN);
     return __grdb_entry;
 }
 

--- a/Libraries/LibC/netdb.cpp
+++ b/Libraries/LibC/netdb.cpp
@@ -86,7 +86,7 @@ static int connect_to_lookup_server()
 
     sockaddr_un address;
     address.sun_family = AF_LOCAL;
-    strcpy(address.sun_path, "/tmp/portal/lookup");
+    strlcpy(address.sun_path, "/tmp/portal/lookup", sizeof(address.sun_path));
 
     if (connect(fd, (const sockaddr*)&address, sizeof(address)) < 0) {
         perror("connect_to_lookup_server");
@@ -102,7 +102,7 @@ hostent* gethostbyname(const char* name)
     if (ipv4_address.has_value()) {
         auto ip4_string = ipv4_address.value().to_string();
         ASSERT(ip4_string.length() < sizeof(__gethostbyname_name_buffer));
-        strncpy(__gethostbyname_name_buffer, ip4_string.characters(), ip4_string.length());
+        strlcpy(__gethostbyname_name_buffer, ip4_string.characters(), sizeof(__gethostbyname_name_buffer));
         __gethostbyname_buffer.h_name = __gethostbyname_name_buffer;
         __gethostbyname_buffer.h_aliases = nullptr;
         __gethostbyname_buffer.h_addrtype = AF_INET;
@@ -152,7 +152,7 @@ hostent* gethostbyname(const char* name)
     if (rc <= 0)
         return nullptr;
 
-    strncpy(__gethostbyname_name_buffer, name, sizeof(__gethostbyaddr_name_buffer) - 1);
+    strlcpy(__gethostbyname_name_buffer, name, sizeof(__gethostbyaddr_name_buffer));
 
     __gethostbyname_buffer.h_name = __gethostbyname_name_buffer;
     __gethostbyname_buffer.h_aliases = nullptr;
@@ -216,7 +216,7 @@ hostent* gethostbyaddr(const void* addr, socklen_t addr_size, int type)
 
     auto& response = responses[0];
 
-    strncpy(__gethostbyaddr_name_buffer, response.characters(), max(sizeof(__gethostbyaddr_name_buffer), response.length()));
+    strlcpy(__gethostbyaddr_name_buffer, response.characters(), sizeof(__gethostbyaddr_name_buffer));
 
     __gethostbyaddr_buffer.h_name = __gethostbyaddr_name_buffer;
     __gethostbyaddr_buffer.h_aliases = nullptr;
@@ -374,7 +374,7 @@ static bool fill_getserv_buffers(char* line, ssize_t read)
         return false;
     }
     if (sizeof(__getserv_name_buffer) >= split_line[0].length() + 1) {
-        strncpy(__getserv_name_buffer, split_line[0].characters(), split_line[0].length() + 1);
+        strlcpy(__getserv_name_buffer, split_line[0].characters(), sizeof(__getserv_name_buffer));
     } else {
         perror("invalid buffer length: service name");
         return false;
@@ -397,7 +397,7 @@ static bool fill_getserv_buffers(char* line, ssize_t read)
     port_protocol_split[1].replace("\n", "", true);
 
     if (sizeof(__getserv_protocol_buffer) >= port_protocol_split[1].length()) {
-        strncpy(__getserv_protocol_buffer, port_protocol_split[1].characters(), port_protocol_split[1].length() + 1);
+        strlcpy(__getserv_protocol_buffer, port_protocol_split[1].characters(), sizeof(__getserv_protocol_buffer));
     } else {
         perror("malformed services file: protocol");
         return false;
@@ -566,7 +566,7 @@ static bool fill_getproto_buffers(char* line, ssize_t read)
         return false;
     }
     if (sizeof(__getproto_name_buffer) >= split_line[0].length() + 1) {
-        strncpy(__getproto_name_buffer, split_line[0].characters(), split_line[0].length() + 1);
+        strlcpy(__getproto_name_buffer, split_line[0].characters(), sizeof(__getproto_name_buffer));
     } else {
         perror("invalid buffer length: protocol name");
         return false;

--- a/Libraries/LibC/pwd.cpp
+++ b/Libraries/LibC/pwd.cpp
@@ -146,11 +146,11 @@ next_entry:
     __pwdb_entry->pw_dir = __pwdb_entry->dir_buffer;
     __pwdb_entry->pw_shell = __pwdb_entry->shell_buffer;
 
-    strncpy(__pwdb_entry->name_buffer, e_name.characters(), PWDB_STR_MAX_LEN - 1);
-    strncpy(__pwdb_entry->passwd_buffer, e_passwd.characters(), PWDB_STR_MAX_LEN - 1);
-    strncpy(__pwdb_entry->gecos_buffer, e_gecos.characters(), PWDB_STR_MAX_LEN - 1);
-    strncpy(__pwdb_entry->dir_buffer, e_dir.characters(), PWDB_STR_MAX_LEN - 1);
-    strncpy(__pwdb_entry->shell_buffer, e_shell.characters(), PWDB_STR_MAX_LEN - 1);
+    strlcpy(__pwdb_entry->name_buffer, e_name.characters(), PWDB_STR_MAX_LEN);
+    strlcpy(__pwdb_entry->passwd_buffer, e_passwd.characters(), PWDB_STR_MAX_LEN);
+    strlcpy(__pwdb_entry->gecos_buffer, e_gecos.characters(), PWDB_STR_MAX_LEN);
+    strlcpy(__pwdb_entry->dir_buffer, e_dir.characters(), PWDB_STR_MAX_LEN);
+    strlcpy(__pwdb_entry->shell_buffer, e_shell.characters(), PWDB_STR_MAX_LEN);
     return __pwdb_entry;
 }
 

--- a/Libraries/LibC/string.cpp
+++ b/Libraries/LibC/string.cpp
@@ -214,6 +214,14 @@ char* strncpy(char* dest, const char* src, size_t n)
     return dest;
 }
 
+size_t strlcpy(char* dest, const char* src, size_t n)
+{
+    (void)dest;
+    (void)src;
+    (void)n;
+    return 42; // TODO
+}
+
 char* strchr(const char* str, int c)
 {
     char ch = c;

--- a/Libraries/LibC/string.cpp
+++ b/Libraries/LibC/string.cpp
@@ -216,10 +216,15 @@ char* strncpy(char* dest, const char* src, size_t n)
 
 size_t strlcpy(char* dest, const char* src, size_t n)
 {
-    (void)dest;
-    (void)src;
-    (void)n;
-    return 42; // TODO
+    size_t i;
+    // Would like to test i < n - 1 here, but n might be 0.
+    for (i = 0; i + 1 < n && src[i] != '\0'; ++i)
+        dest[i] = src[i];
+    if (n)
+        dest[i] = '\0';
+    for (; src[i] != '\0'; ++i)
+        ; // Determine the length of src, don't copy.
+    return i;
 }
 
 char* strchr(const char* str, int c)

--- a/Libraries/LibC/string.cpp
+++ b/Libraries/LibC/string.cpp
@@ -94,13 +94,14 @@ char* strdup(const char* str)
 {
     size_t len = strlen(str);
     char* new_str = (char*)malloc(len + 1);
-    strcpy(new_str, str);
+    memcpy(new_str, str, len);
+    new_str[len] = '\0';
     return new_str;
 }
 
 char* strndup(const char* str, size_t maxlen)
 {
-    size_t len = min(strlen(str), maxlen);
+    size_t len = strnlen(str, maxlen);
     char* new_str = (char*)malloc(len + 1);
     memcpy(new_str, str, len);
     new_str[len] = 0;

--- a/Libraries/LibC/string.h
+++ b/Libraries/LibC/string.h
@@ -48,6 +48,7 @@ void* memset(void*, int, size_t);
 __attribute__((malloc)) char* strdup(const char*);
 __attribute__((malloc)) char* strndup(const char*, size_t);
 char* strcpy(char* dest, const char* src);
+size_t strlcpy(char* dest, const char* src, size_t);
 char* strncpy(char* dest, const char* src, size_t);
 char* strchr(const char*, int c);
 char* strchrnul(const char*, int c);

--- a/Libraries/LibC/time.cpp
+++ b/Libraries/LibC/time.cpp
@@ -185,7 +185,7 @@ size_t strftime(char* destination, size_t max_size, const char* format, const st
         "July", "Auguest", "September", "October", "November", "December"
     };
 
-    StringBuilder builder { max_size - 1 };
+    StringBuilder builder { max_size };
 
     const int format_len = strlen(format);
     for (int i = 0; i < format_len; ++i) {
@@ -307,10 +307,12 @@ size_t strftime(char* destination, size_t max_size, const char* format, const st
                 return 0;
             }
         }
-        if (builder.length() > max_size - 1)
+        if (builder.length() + 1 > max_size)
             return 0;
     }
 
+    if (builder.length() + 1 > max_size)
+        return 0;
     strcpy(destination, builder.build().characters());
     return builder.length();
 }

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -554,7 +554,7 @@ char* getlogin()
 {
     static char __getlogin_buffer[256];
     if (auto* passwd = getpwuid(getuid())) {
-        strncpy(__getlogin_buffer, passwd->pw_name, sizeof(__getlogin_buffer) - 1);
+        strlcpy(__getlogin_buffer, passwd->pw_name, sizeof(__getlogin_buffer));
         endpwent();
         return __getlogin_buffer;
     }

--- a/Libraries/LibCore/LocalServer.cpp
+++ b/Libraries/LibCore/LocalServer.cpp
@@ -121,7 +121,12 @@ bool LocalServer::listen(const String& address)
 #endif
 
     auto socket_address = SocketAddress::local(address);
-    auto un = socket_address.to_sockaddr_un();
+    auto un_optional = socket_address.to_sockaddr_un();
+    if (!un_optional.has_value()) {
+        perror("bind");
+        return false;
+    }
+    auto un = un_optional.value();
     rc = ::bind(m_fd, (const sockaddr*)&un, sizeof(un));
     if (rc < 0) {
         perror("bind");

--- a/Libraries/LibCore/Socket.cpp
+++ b/Libraries/LibCore/Socket.cpp
@@ -111,6 +111,12 @@ bool Socket::connect(const SocketAddress& address)
 
     sockaddr_un saddr;
     saddr.sun_family = AF_LOCAL;
+    auto dest_address = address.to_string();
+    if (dest_address.length() >= sizeof(saddr.sun_path)) {
+        fprintf(stderr, "Core::Socket: Failed to connect() to %s: Path is too long!\n", dest_address.characters());
+        errno = EINVAL;
+        return false;
+    }
     strcpy(saddr.sun_path, address.to_string().characters());
 
     m_destination_address = address;

--- a/Libraries/LibCore/SocketAddress.h
+++ b/Libraries/LibCore/SocketAddress.h
@@ -43,7 +43,7 @@ public:
         Local
     };
 
-    SocketAddress() {}
+    SocketAddress() { }
     SocketAddress(const IPv4Address& address)
         : m_type(Type::IPv4)
         , m_ipv4_address(address)
@@ -82,12 +82,14 @@ public:
         }
     }
 
-    sockaddr_un to_sockaddr_un() const
+    Optional<sockaddr_un> to_sockaddr_un() const
     {
         ASSERT(type() == Type::Local);
         sockaddr_un address;
         address.sun_family = AF_LOCAL;
-        RELEASE_ASSERT(m_local_address.length() < (int)sizeof(address.sun_path));
+        if (m_local_address.length() >= sizeof(address.sun_path)) {
+            return {};
+        }
         strcpy(address.sun_path, m_local_address.characters());
         return address;
     }

--- a/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Services/DHCPClient/DHCPv4Client.cpp
@@ -70,7 +70,7 @@ static void set_params(const InterfaceDescriptor& iface, const IPv4Address& ipv4
 
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
-    strncpy(ifr.ifr_name, iface.m_ifname.characters(), IFNAMSIZ);
+    strlcpy(ifr.ifr_name, iface.m_ifname.characters(), IFNAMSIZ);
 
     // set the IP address
     ifr.ifr_addr.sa_family = AF_INET;

--- a/Userland/Tests/Kernel/bind-local-socket-to-symlink.cpp
+++ b/Userland/Tests/Kernel/bind-local-socket-to-symlink.cpp
@@ -47,7 +47,7 @@ int main(int, char**)
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+    strlcpy(addr.sun_path, path, sizeof(addr.sun_path));
 
     rc = bind(fd, (struct sockaddr*)(&addr), sizeof(addr));
     if (rc < 0 && errno == EADDRINUSE) {

--- a/Userland/Tests/LibC/snprintf-correctness.cpp
+++ b/Userland/Tests/LibC/snprintf-correctness.cpp
@@ -30,9 +30,7 @@
 #include <AK/Random.h>
 #include <AK/StringBuilder.h>
 #include <ctype.h>
-#include <memory.h>
 #include <stdio.h>
-#include <string.h>
 
 struct Testcase {
     const char* dest;

--- a/Userland/Tests/LibC/strlcpy-correctness.cpp
+++ b/Userland/Tests/LibC/strlcpy-correctness.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2020, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/ByteBuffer.h>
+#include <AK/Random.h>
+#include <AK/StringBuilder.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+struct Testcase {
+    const char* dest;
+    size_t dest_n;
+    const char* src;
+    size_t src_n;
+    const char* dest_expected;
+    size_t dest_expected_n; // == dest_n
+};
+
+static String show(const ByteBuffer& buf)
+{
+    StringBuilder builder;
+    for (size_t i = 0; i < buf.size(); ++i) {
+        builder.appendf("%02x", buf[i]);
+    }
+    builder.append(' ');
+    builder.append('(');
+    for (size_t i = 0; i < buf.size(); ++i) {
+        if (isprint(buf[i]))
+            builder.append(buf[i]);
+        else
+            builder.append('_');
+    }
+    builder.append(')');
+    return builder.build();
+}
+
+static const size_t SANDBOX_CANARY_SIZE = 8;
+
+static bool test_single(const Testcase& testcase)
+{
+    // Preconditions:
+    if (testcase.dest_n != testcase.dest_expected_n) {
+        fprintf(stderr, "dest length %zu != expected dest length %zu? Check testcase! (Probably miscounted.)\n",
+            testcase.dest_n, testcase.dest_expected_n);
+        return false;
+    }
+    if (testcase.src_n != strlen(testcase.src)) {
+        fprintf(stderr, "src length %zu != actual src length %zu? src can't contain NUL bytes!\n",
+            testcase.src_n, strlen(testcase.src));
+        return false;
+    }
+
+    // Setup
+    ByteBuffer actual = ByteBuffer::create_uninitialized(SANDBOX_CANARY_SIZE + testcase.dest_n + SANDBOX_CANARY_SIZE);
+    AK::fill_with_random(actual.data(), actual.size());
+    ByteBuffer expected = actual.isolated_copy();
+    ASSERT(actual.offset_pointer(0) != expected.offset_pointer(0));
+    actual.overwrite(SANDBOX_CANARY_SIZE, testcase.dest, testcase.dest_n);
+    expected.overwrite(SANDBOX_CANARY_SIZE, testcase.dest_expected, testcase.dest_expected_n);
+    // "unsigned char" != "char", so we have to convince the compiler to allow this.
+    char* dst = reinterpret_cast<char*>(actual.offset_pointer(SANDBOX_CANARY_SIZE));
+
+    // The actual call:
+    size_t actual_return = strlcpy(dst, testcase.src, testcase.dest_n);
+
+    // Checking the results:
+    bool return_ok = actual_return == testcase.src_n;
+    bool canary_1_ok = actual.slice_view(0, SANDBOX_CANARY_SIZE) == expected.slice_view(0, SANDBOX_CANARY_SIZE);
+    bool main_ok = actual.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n) == expected.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n);
+    bool canary_2_ok = actual.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE) == expected.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE);
+    bool buf_ok = actual == expected;
+
+    // Evaluate gravity:
+    if (buf_ok && (!canary_1_ok || !main_ok || !canary_2_ok)) {
+        fprintf(stderr, "Internal error! (%d != %d | %d | %d)\n",
+            buf_ok, canary_1_ok, main_ok, canary_2_ok);
+        buf_ok = false;
+    }
+    if (!canary_1_ok) {
+        warn() << "Canary 1 overwritten: Expected canary "
+               << show(expected.slice_view(0, SANDBOX_CANARY_SIZE))
+               << ", got "
+               << show(actual.slice_view(0, SANDBOX_CANARY_SIZE))
+               << " instead!";
+    }
+    if (!main_ok) {
+        warn() << "Wrong output: Expected "
+               << show(expected.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n))
+               << "\n          instead, got " // visually align
+               << show(actual.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n));
+    }
+    if (!canary_2_ok) {
+        warn() << "Canary 2 overwritten: Expected "
+               << show(expected.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE))
+               << ", got "
+               << show(actual.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE))
+               << " instead!";
+    }
+    if (!return_ok) {
+        fprintf(stderr, "Wrong return value: Expected %zu, got %zu instead!\n",
+            testcase.src_n, actual_return);
+    }
+
+    return buf_ok && return_ok;
+}
+
+// Drop the NUL terminator added by the C++ compiler.
+#define LITERAL(x) x, (sizeof(x) - 1)
+
+//static Testcase TESTCASES[] = {
+//    // Golden path:
+
+//    // Hitting the border:
+
+//    // Too long:
+//    { LITERAL("Hello World!\0"), LITERAL("Hello Friend!"), LITERAL("Hello Friend\0") },
+//    { LITERAL("Hello World!\0"), LITERAL("This source is just *way* too long!"), LITERAL("This source \0") },
+//    { LITERAL("x"), LITERAL("This source is just *way* too long!"), LITERAL("\0") },
+//    // Other special cases:
+//    { LITERAL(""), LITERAL(""), LITERAL("") },
+//    { LITERAL(""), LITERAL("Empty test"), LITERAL("") },
+//    { LITERAL("x"), LITERAL(""), LITERAL("\0") },
+//    { LITERAL("xx"), LITERAL(""), LITERAL("\0x") },
+//    { LITERAL("xxx"), LITERAL(""), LITERAL("\0xx") },
+//};
+
+TEST_CASE(golden_path)
+{
+    EXPECT(test_single({ LITERAL("Hello World!\0\0\0"), LITERAL("Hello Friend!"), LITERAL("Hello Friend!\0\0") }));
+    EXPECT(test_single({ LITERAL("Hello World!\0\0\0"), LITERAL("Hello Friend!"), LITERAL("Hello Friend!\0\0") }));
+    EXPECT(test_single({ LITERAL("aaaaaaaaaa"), LITERAL("whf"), LITERAL("whf\0aaaaaa") }));
+}
+
+TEST_CASE(exact_fit)
+{
+    EXPECT(test_single({ LITERAL("Hello World!\0\0"), LITERAL("Hello Friend!"), LITERAL("Hello Friend!\0") }));
+    EXPECT(test_single({ LITERAL("AAAA"), LITERAL("aaa"), LITERAL("aaa\0") }));
+}
+
+TEST_CASE(off_by_one)
+{
+    EXPECT(test_single({ LITERAL("AAAAAAAAAA"), LITERAL("BBBBB"), LITERAL("BBBBB\0AAAA") }));
+    EXPECT(test_single({ LITERAL("AAAAAAAAAA"), LITERAL("BBBBBBBCC"), LITERAL("BBBBBBBCC\0") }));
+    EXPECT(test_single({ LITERAL("AAAAAAAAAA"), LITERAL("BBBBBBBCCX"), LITERAL("BBBBBBBCC\0") }));
+    EXPECT(test_single({ LITERAL("AAAAAAAAAA"), LITERAL("BBBBBBBCCXY"), LITERAL("BBBBBBBCC\0") }));
+}
+
+TEST_CASE(nearly_empty)
+{
+    EXPECT(test_single({ LITERAL(""), LITERAL(""), LITERAL("") }));
+    EXPECT(test_single({ LITERAL(""), LITERAL("Empty test"), LITERAL("") }));
+    EXPECT(test_single({ LITERAL("x"), LITERAL(""), LITERAL("\0") }));
+    EXPECT(test_single({ LITERAL("xx"), LITERAL(""), LITERAL("\0x") }));
+    EXPECT(test_single({ LITERAL("x"), LITERAL("y"), LITERAL("\0") }));
+}
+
+static char* const POISON = (char*)1;
+TEST_CASE(to_nullptr)
+{
+    EXPECT_EQ(0u, strlcpy(POISON, "", 0));
+    EXPECT_EQ(1u, strlcpy(POISON, "x", 0));
+    EXPECT(test_single({ LITERAL("Hello World!\0\0\0"), LITERAL("Hello Friend!"), LITERAL("Hello Friend!\0\0") }));
+    EXPECT(test_single({ LITERAL("aaaaaaaaaa"), LITERAL("whf"), LITERAL("whf\0aaaaaa") }));
+}
+
+TEST_MAIN(Sprintf)

--- a/Userland/ifconfig.cpp
+++ b/Userland/ifconfig.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv)
             struct ifreq ifr;
             memset(&ifr, 0, sizeof(ifr));
 
-            strncpy(ifr.ifr_name, ifname.characters(), IFNAMSIZ);
+            strlcpy(ifr.ifr_name, ifname.characters(), IFNAMSIZ);
             ifr.ifr_addr.sa_family = AF_INET;
             ((sockaddr_in&)ifr.ifr_addr).sin_addr.s_addr = address.value().to_in_addr_t();
 
@@ -144,7 +144,7 @@ int main(int argc, char** argv)
             struct ifreq ifr;
             memset(&ifr, 0, sizeof(ifr));
 
-            strncpy(ifr.ifr_name, ifname.characters(), IFNAMSIZ);
+            strlcpy(ifr.ifr_name, ifname.characters(), IFNAMSIZ);
             ifr.ifr_netmask.sa_family = AF_INET;
             ((sockaddr_in&)ifr.ifr_netmask).sin_addr.s_addr = address.value().to_in_addr_t();
 

--- a/Userland/ping.cpp
+++ b/Userland/ping.cpp
@@ -125,7 +125,7 @@ int main(int argc, char** argv)
         ping_packet.header.code = 0;
         ping_packet.header.un.echo.id = htons(pid);
         ping_packet.header.un.echo.sequence = htons(seq++);
-        strcpy(ping_packet.msg, "Hello there!\n");
+        strlcpy(ping_packet.msg, "Hello there!\n", sizeof(ping_packet.msg));
 
         ping_packet.header.checksum = internet_checksum(&ping_packet, sizeof(PingPacket));
 


### PR DESCRIPTION
This PR:
- Fixes five obscure bugs caused by wrong strcpy/strncpy usages (they are pretty hard to trigger)
- Fixes a few unstylish strcpy/strncpy uses that *technically* don't break, but don't look right either
- Introduces strlcpy, a "safer" variant of strncpy, popular with *BSD folks
- Uses it to fix the above stuff

<!-- And contains an easteregg. Hush hush! It's *INCREDIBLY* hard to find. -->

EDIT:

If anyone cares, I left some unsafe-looking usages of strcpy/strncpy in, because it was too convoluted to fix in the same drive-by fashion that I did with the other bugs:
- LibC/scanf.cpp: Lots of manual copying. If there is *one* mistake in there, it all blows up.
- LibC/termcap.cpp: Those usages of `strncpy` look suspicious to me.
- LibCrypto/crypt.cpp: Looks like manual arrangement, but using static offsets. Either they are always correct, or always broken.
- Userland/Tests: Nah.