### PR TITLE
LibTLS: Do not process_message() the finished message twice / Meta+Userland: Run the TLS test too

### DIFF
--- a/Libraries/LibTLS/ClientHandshake.cpp
+++ b/Libraries/LibTLS/ClientHandshake.cpp
@@ -216,7 +216,6 @@ ssize_t TLSv12::handle_finished(const ByteBuffer& buffer, WritePacketStage& writ
     size_t index = 3;
 
     u32 size = buffer[0] * 0x10000 + buffer[1] * 0x100 + buffer[2];
-    index += 3;
 
     if (size < 12) {
 #ifdef TLS_DEBUG
@@ -248,7 +247,7 @@ ssize_t TLSv12::handle_finished(const ByteBuffer& buffer, WritePacketStage& writ
     if (on_tls_ready_to_write)
         on_tls_ready_to_write(*this);
 
-    return handle_message(buffer);
+    return index + size;
 }
 
 void TLSv12::build_random(PacketBuilder& builder)

--- a/Libraries/LibTLS/Record.cpp
+++ b/Libraries/LibTLS/Record.cpp
@@ -156,7 +156,7 @@ ByteBuffer TLSv12::hmac_message(const ReadonlyBytes& buf, const Optional<Readonl
     auto digest = hmac.digest();
     auto mac = ByteBuffer::copy(digest.immutable_data(), digest.data_length());
 #ifdef TLS_DEBUG
-    dbg() << "HMAC of the block for sequence number " << m_context.local_sequence_number;
+    dbg() << "HMAC of the block for sequence number " << sequence_number;
     print_buffer(mac);
 #endif
     return mac;
@@ -242,7 +242,7 @@ ssize_t TLSv12::handle_message(const ByteBuffer& buffer)
         auto hmac = hmac_message({ temp_buf, 5 }, decrypted_span.slice(0, length), mac_size);
         auto message_mac = ByteBuffer::wrap(const_cast<u8*>(message_hmac), mac_size);
         if (hmac != message_mac) {
-            dbg() << "integrity check failed (mac length " << length << ")";
+            dbg() << "integrity check failed (mac length " << mac_size << ")";
             dbg() << "mac received:";
             print_buffer(message_mac);
             dbg() << "mac computed:";

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -94,7 +94,7 @@ if (BUILD_LAGOM)
     target_link_libraries(test-crypto_lagom stdc++)
     add_test(
         NAME Crypto
-        COMMAND test-crypto_lagom test -tc
+        COMMAND test-crypto_lagom test -t -s google.com
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -1730,8 +1730,17 @@ static void tls_test_client_hello()
         if (sent_request)
             return;
         sent_request = true;
-        if (!tls.write("GET / HTTP/1.1\r\nHost: github.com\r\nConnection: close\r\n\r\n"_b)) {
-            FAIL(write() failed);
+        if (!tls.write("GET / HTTP/1.1\r\nHost: "_b)) {
+            FAIL(write(0) failed);
+            loop.quit(0);
+        }
+        auto* the_server = (const u8*)(server ?: DEFAULT_SERVER);
+        if (!tls.write(ByteBuffer::wrap(const_cast<u8*>(the_server), strlen((const char*)the_server)))) {
+            FAIL(write(1) failed);
+            loop.quit(0);
+        }
+        if (!tls.write("\r\nConnection : close\r\n\r\n"_b)) {
+            FAIL(write(2) failed);
             loop.quit(0);
         }
     };
@@ -1761,7 +1770,7 @@ static void tls_test_client_hello()
         FAIL(Connection failure);
         loop.quit(1);
     };
-    if (!tls->connect("github.com", 443)) {
+    if (!tls->connect(server ?: DEFAULT_SERVER, port)) {
         FAIL(connect() failed);
         return;
     }


### PR DESCRIPTION
Fixes #3273, makes the TLS tests run under CI as well.

---

While this _does_ add a point of failure, it'll be a pretty bad day when
google goes down.
And this is unlikely to put a (positive) dent in their incoming
requests, so let's just roll with it until we have our own TLS server.