### PR TITLE
LibJS: Make Date.getUTCSeconds() call through to LibC

### DIFF
--- a/Libraries/LibJS/Runtime/Date.cpp
+++ b/Libraries/LibJS/Runtime/Date.cpp
@@ -87,6 +87,11 @@ int Date::utc_month() const
     return to_utc_tm().tm_mon;
 }
 
+int Date::utc_seconds() const
+{
+    return to_utc_tm().tm_sec;
+}
+
 String Date::iso_date_string() const
 {
     auto tm = to_utc_tm();

--- a/Libraries/LibJS/Runtime/Date.h
+++ b/Libraries/LibJS/Runtime/Date.h
@@ -61,7 +61,7 @@ public:
     int utc_milliseconds() const { return milliseconds(); }
     int utc_minutes() const;
     int utc_month() const;
-    int utc_seconds() const { return seconds(); }
+    int utc_seconds() const;
 
     String date_string() const { return m_datetime.to_string("%a %b %d %Y"); }
     // FIXME: Deal with timezones once SerenityOS has a working tzset(3)


### PR DESCRIPTION
The tzset documentation says that TZ allows a per-second local timezone,
so don't be needlessly clever here.

No observable behavior difference at this point, but if we ever
implement tzset, this will have a small effect.