### PR TITLE
LibJS: Make Interpreter::throw_exception() a void function

### DIFF
--- a/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Applications/Spreadsheet/Spreadsheet.cpp
@@ -88,13 +88,15 @@ public:
 
     static JS_DEFINE_NATIVE_FUNCTION(parse_cell_name)
     {
-        if (interpreter.argument_count() != 1)
-            return interpreter.throw_exception<JS::TypeError>("Expected exactly one argument to parse_cell_name()");
-
+        if (interpreter.argument_count() != 1) {
+            interpreter.throw_exception<JS::TypeError>("Expected exactly one argument to parse_cell_name()");
+            return {};
+        }
         auto name_value = interpreter.argument(0);
-        if (!name_value.is_string())
-            return interpreter.throw_exception<JS::TypeError>("Expected a String argument to parse_cell_name()");
-
+        if (!name_value.is_string()) {
+            interpreter.throw_exception<JS::TypeError>("Expected a String argument to parse_cell_name()");
+            return {};
+        }
         auto position = Sheet::parse_cell_name(name_value.as_string().string());
         if (!position.has_value())
             return JS::js_undefined();

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -324,7 +324,7 @@ Value Interpreter::construct(Function& function, Function& new_target, Optional<
     return this_value;
 }
 
-Value Interpreter::throw_exception(Exception* exception)
+void Interpreter::throw_exception(Exception* exception)
 {
 #ifdef INTERPRETER_DEBUG
     if (exception->value().is_object() && exception->value().as_object().is_error()) {
@@ -341,7 +341,6 @@ Value Interpreter::throw_exception(Exception* exception)
 #endif
     m_exception = exception;
     unwind(ScopeType::Try);
-    return {};
 }
 
 GlobalObject& Interpreter::global_object()

--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -176,19 +176,19 @@ public:
     void clear_exception() { m_exception = nullptr; }
 
     template<typename T, typename... Args>
-    Value throw_exception(Args&&... args)
+    void throw_exception(Args&&... args)
     {
         return throw_exception(T::create(global_object(), forward<Args>(args)...));
     }
 
-    Value throw_exception(Exception*);
-    Value throw_exception(Value value)
+    void throw_exception(Exception*);
+    void throw_exception(Value value)
     {
         return throw_exception(heap().allocate<Exception>(global_object(), value));
     }
 
     template<typename T, typename... Args>
-    Value throw_exception(ErrorType type, Args&&... args)
+    void throw_exception(ErrorType type, Args&&... args)
     {
         return throw_exception(T::create(global_object(), String::format(type.message(), forward<Args>(args)...)));
     }

--- a/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
@@ -53,11 +53,11 @@ ArrayIteratorPrototype::~ArrayIteratorPrototype()
 JS_DEFINE_NATIVE_FUNCTION(ArrayIteratorPrototype::next)
 {
     auto this_value = interpreter.this_value(global_object);
-    if (!this_value.is_object() || !this_value.as_object().is_array_iterator_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotAn, "Array Iterator");
-
+    if (!this_value.is_object() || !this_value.as_object().is_array_iterator_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotAn, "Array Iterator");
+        return {};
+    }
     auto& this_object = this_value.as_object();
-
     auto& iterator = static_cast<ArrayIterator&>(this_object);
     auto target_array = iterator.array();
     if (target_array.is_undefined())

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -204,8 +204,10 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::push)
         return {};
     auto argument_count = interpreter.argument_count();
     auto new_length = length + argument_count;
-    if (new_length > MAX_ARRAY_LIKE_INDEX)
-        return interpreter.throw_exception<TypeError>(ErrorType::ArrayMaxSize);
+    if (new_length > MAX_ARRAY_LIKE_INDEX) {
+        interpreter.throw_exception<TypeError>(ErrorType::ArrayMaxSize);
+        return {};
+    }
     for (size_t i = 0; i < argument_count; ++i) {
         this_object->put(length + i, interpreter.argument(i));
         if (interpreter.exception())
@@ -744,8 +746,10 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::splice)
 
     size_t new_length = initial_length + insert_count - actual_delete_count;
 
-    if (new_length > MAX_ARRAY_LIKE_INDEX)
-        return interpreter.throw_exception<TypeError>(ErrorType::ArrayMaxSize);
+    if (new_length > MAX_ARRAY_LIKE_INDEX) {
+        interpreter.throw_exception<TypeError>(ErrorType::ArrayMaxSize);
+        return {};
+    }
 
     auto removed_elements = Array::create(global_object);
 

--- a/Libraries/LibJS/Runtime/ErrorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ErrorPrototype.cpp
@@ -58,8 +58,10 @@ JS_DEFINE_NATIVE_GETTER(ErrorPrototype::name_getter)
     auto* this_object = interpreter.this_value(global_object).to_object(interpreter, global_object);
     if (!this_object)
         return {};
-    if (!this_object->is_error())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotAn, "Error");
+    if (!this_object->is_error()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotAn, "Error");
+        return {};
+    }
     return js_string(interpreter, static_cast<const Error*>(this_object)->name());
 }
 
@@ -83,15 +85,19 @@ JS_DEFINE_NATIVE_GETTER(ErrorPrototype::message_getter)
     auto* this_object = interpreter.this_value(global_object).to_object(interpreter, global_object);
     if (!this_object)
         return {};
-    if (!this_object->is_error())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotAn, "Error");
+    if (!this_object->is_error()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotAn, "Error");
+        return {};
+    }
     return js_string(interpreter, static_cast<const Error*>(this_object)->message());
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ErrorPrototype::to_string)
 {
-    if (!interpreter.this_value(global_object).is_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotAnObject, interpreter.this_value(global_object).to_string_without_side_effects().characters());
+    if (!interpreter.this_value(global_object).is_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotAnObject, interpreter.this_value(global_object).to_string_without_side_effects().characters());
+        return {};
+    }
     auto& this_object = interpreter.this_value(global_object).as_object();
 
     String name = "Error";
@@ -123,10 +129,10 @@ JS_DEFINE_NATIVE_FUNCTION(ErrorPrototype::to_string)
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName) \
     PrototypeName::PrototypeName(GlobalObject& global_object)                 \
-        : Object(*global_object.error_prototype())                             \
+        : Object(*global_object.error_prototype())                            \
     {                                                                         \
     }                                                                         \
-    PrototypeName::~PrototypeName() { }
+    PrototypeName::~PrototypeName() {}
 
 JS_ENUMERATE_ERROR_SUBCLASSES
 #undef __JS_ENUMERATE

--- a/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -65,15 +65,19 @@ JS_DEFINE_NATIVE_FUNCTION(FunctionPrototype::apply)
     auto* this_object = interpreter.this_value(global_object).to_object(interpreter, global_object);
     if (!this_object)
         return {};
-    if (!this_object->is_function())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotA, "Function");
+    if (!this_object->is_function()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotA, "Function");
+        return {};
+    }
     auto& function = static_cast<Function&>(*this_object);
     auto this_arg = interpreter.argument(0);
     auto arg_array = interpreter.argument(1);
     if (arg_array.is_null() || arg_array.is_undefined())
         return interpreter.call(function, this_arg);
-    if (!arg_array.is_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::FunctionArgsNotObject);
+    if (!arg_array.is_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::FunctionArgsNotObject);
+        return {};
+    }
     auto length_property = arg_array.as_object().get("length");
     if (interpreter.exception())
         return {};
@@ -95,9 +99,10 @@ JS_DEFINE_NATIVE_FUNCTION(FunctionPrototype::bind)
     auto* this_object = interpreter.this_value(global_object).to_object(interpreter, global_object);
     if (!this_object)
         return {};
-    if (!this_object->is_function())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotA, "Function");
-
+    if (!this_object->is_function()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotA, "Function");
+        return {};
+    }
     auto& this_function = static_cast<Function&>(*this_object);
     auto bound_this_arg = interpreter.argument(0);
 
@@ -115,8 +120,10 @@ JS_DEFINE_NATIVE_FUNCTION(FunctionPrototype::call)
     auto* this_object = interpreter.this_value(global_object).to_object(interpreter, global_object);
     if (!this_object)
         return {};
-    if (!this_object->is_function())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotA, "Function");
+    if (!this_object->is_function()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotA, "Function");
+        return {};
+    }
     auto& function = static_cast<Function&>(*this_object);
     auto this_arg = interpreter.argument(0);
     MarkedValueList arguments(interpreter.heap());
@@ -132,9 +139,10 @@ JS_DEFINE_NATIVE_FUNCTION(FunctionPrototype::to_string)
     auto* this_object = interpreter.this_value(global_object).to_object(interpreter, global_object);
     if (!this_object)
         return {};
-    if (!this_object->is_function())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotA, "Function");
-
+    if (!this_object->is_function()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotA, "Function");
+        return {};
+    }
     String function_name = static_cast<Function*>(this_object)->name();
     String function_parameters = "";
     String function_body;
@@ -173,9 +181,10 @@ JS_DEFINE_NATIVE_FUNCTION(FunctionPrototype::symbol_has_instance)
     auto* this_object = interpreter.this_value(global_object).to_object(interpreter, global_object);
     if (!this_object)
         return {};
-    if (!this_object->is_function())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotA, "Function");
-
+    if (!this_object->is_function()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotA, "Function");
+        return {};
+    }
     return ordinary_has_instance(interpreter, interpreter.argument(0), this_object);
 }
 

--- a/Libraries/LibJS/Runtime/LexicalEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/LexicalEnvironment.cpp
@@ -112,9 +112,10 @@ bool LexicalEnvironment::has_this_binding() const
 Value LexicalEnvironment::get_this_binding() const
 {
     ASSERT(has_this_binding());
-    if (this_binding_status() == ThisBindingStatus::Uninitialized)
-        return interpreter().throw_exception<ReferenceError>(ErrorType::ThisHasNotBeenInitialized);
-
+    if (this_binding_status() == ThisBindingStatus::Uninitialized) {
+        interpreter().throw_exception<ReferenceError>(ErrorType::ThisHasNotBeenInitialized);
+        return {};
+    }
     return m_this_value;
 }
 

--- a/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -67,7 +67,8 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_string)
     } else if (this_value.is_object() && this_value.as_object().is_number_object()) {
         number_value = static_cast<NumberObject&>(this_value.as_object()).value_of();
     } else {
-        return interpreter.throw_exception<TypeError>(ErrorType::NumberIncompatibleThis, "toString");
+        interpreter.throw_exception<TypeError>(ErrorType::NumberIncompatibleThis, "toString");
+        return {};
     }
 
     int radix;
@@ -78,8 +79,10 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_string)
         radix = argument.to_i32(interpreter);
     }
 
-    if (interpreter.exception() || radix < 2 || radix > 36)
-        return interpreter.throw_exception<RangeError>(ErrorType::InvalidRadix);
+    if (interpreter.exception() || radix < 2 || radix > 36) {
+        interpreter.throw_exception<RangeError>(ErrorType::InvalidRadix);
+        return {};
+    }
 
     if (number_value.is_positive_infinity())
         return js_string(interpreter, "Infinity");

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -105,8 +105,10 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::get_prototype_of)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::set_prototype_of)
 {
-    if (interpreter.argument_count() < 2)
-        return interpreter.throw_exception<TypeError>(ErrorType::ObjectSetPrototypeOfTwoArgs);
+    if (interpreter.argument_count() < 2) {
+        interpreter.throw_exception<TypeError>(ErrorType::ObjectSetPrototypeOfTwoArgs);
+        return {};
+    }
     auto* object = interpreter.argument(0).to_object(interpreter, global_object);
     if (interpreter.exception())
         return {};
@@ -162,10 +164,14 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::get_own_property_descriptor)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::define_property_)
 {
-    if (!interpreter.argument(0).is_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotAnObject, "Object argument");
-    if (!interpreter.argument(2).is_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotAnObject, "Descriptor argument");
+    if (!interpreter.argument(0).is_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotAnObject, "Object argument");
+        return {};
+    }
+    if (!interpreter.argument(2).is_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotAnObject, "Descriptor argument");
+        return {};
+    }
     auto& object = interpreter.argument(0).as_object();
     auto property_key = StringOrSymbol::from_value(interpreter, interpreter.argument(1));
     if (interpreter.exception())
@@ -191,8 +197,10 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::is)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::keys)
 {
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<TypeError>(ErrorType::ConvertUndefinedToObject);
+    if (!interpreter.argument_count()) {
+        interpreter.throw_exception<TypeError>(ErrorType::ConvertUndefinedToObject);
+        return {};
+    }
 
     auto* obj_arg = interpreter.argument(0).to_object(interpreter, global_object);
     if (interpreter.exception())
@@ -203,9 +211,10 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::keys)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::values)
 {
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<TypeError>(ErrorType::ConvertUndefinedToObject);
-
+    if (!interpreter.argument_count()) {
+        interpreter.throw_exception<TypeError>(ErrorType::ConvertUndefinedToObject);
+        return {};
+    }
     auto* obj_arg = interpreter.argument(0).to_object(interpreter, global_object);
     if (interpreter.exception())
         return {};
@@ -215,9 +224,10 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::values)
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectConstructor::entries)
 {
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<TypeError>(ErrorType::ConvertUndefinedToObject);
-
+    if (!interpreter.argument_count()) {
+        interpreter.throw_exception<TypeError>(ErrorType::ConvertUndefinedToObject);
+        return {};
+    }
     auto* obj_arg = interpreter.argument(0).to_object(interpreter, global_object);
     if (interpreter.exception())
         return {};

--- a/Libraries/LibJS/Runtime/ProxyConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ProxyConstructor.cpp
@@ -51,22 +51,28 @@ ProxyConstructor::~ProxyConstructor()
 
 Value ProxyConstructor::call(Interpreter& interpreter)
 {
-    return interpreter.throw_exception<TypeError>(ErrorType::ProxyCallWithNew);
+    interpreter.throw_exception<TypeError>(ErrorType::ProxyCallWithNew);
+    return {};
 }
 
 Value ProxyConstructor::construct(Interpreter& interpreter, Function&)
 {
-    if (interpreter.argument_count() < 2)
-        return interpreter.throw_exception<TypeError>(ErrorType::ProxyTwoArguments);
+    if (interpreter.argument_count() < 2) {
+        interpreter.throw_exception<TypeError>(ErrorType::ProxyTwoArguments);
+        return {};
+    }
 
     auto target = interpreter.argument(0);
     auto handler = interpreter.argument(1);
 
-    if (!target.is_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::ProxyConstructorBadType, "target", target.to_string_without_side_effects().characters());
-    if (!handler.is_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::ProxyConstructorBadType, "handler", handler.to_string_without_side_effects().characters());
-
+    if (!target.is_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::ProxyConstructorBadType, "target", target.to_string_without_side_effects().characters());
+        return {};
+    }
+    if (!handler.is_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::ProxyConstructorBadType, "handler", handler.to_string_without_side_effects().characters());
+        return {};
+    }
     return ProxyObject::create(global_object(), target.as_object(), handler.as_object());
 }
 

--- a/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -143,8 +143,10 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::define_property)
     auto* target = get_target_object_from(interpreter, "defineProperty");
     if (!target)
         return {};
-    if (!interpreter.argument(2).is_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::ReflectBadDescriptorArgument);
+    if (!interpreter.argument(2).is_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::ReflectBadDescriptorArgument);
+        return {};
+    }
     auto property_key = StringOrSymbol::from_value(interpreter, interpreter.argument(1));
     if (interpreter.exception())
         return {};

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -135,8 +135,10 @@ Value ScriptFunction::call(Interpreter& interpreter)
 
 Value ScriptFunction::construct(Interpreter& interpreter, Function&)
 {
-    if (m_is_arrow_function)
-        return interpreter.throw_exception<TypeError>(ErrorType::NotAConstructor, m_name.characters());
+    if (m_is_arrow_function) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotAConstructor, m_name.characters());
+        return {};
+    }
     return call(interpreter);
 }
 

--- a/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
@@ -53,8 +53,10 @@ StringIteratorPrototype::~StringIteratorPrototype()
 JS_DEFINE_NATIVE_FUNCTION(StringIteratorPrototype::next)
 {
     auto this_value = interpreter.this_value(global_object);
-    if (!this_value.is_object() || !this_value.as_object().is_string_iterator_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotA, "String Iterator");
+    if (!this_value.is_object() || !this_value.as_object().is_string_iterator_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotA, "String Iterator");
+        return {};
+    }
 
     auto& this_object = this_value.as_object();
     auto& iterator = static_cast<StringIterator&>(this_object);

--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -140,10 +140,14 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::repeat)
     auto count_value = interpreter.argument(0).to_number(interpreter);
     if (interpreter.exception())
         return {};
-    if (count_value.as_double() < 0)
-        return interpreter.throw_exception<RangeError>(ErrorType::StringRepeatCountMustBe, "positive");
-    if (count_value.is_infinity())
-        return interpreter.throw_exception<RangeError>(ErrorType::StringRepeatCountMustBe, "finite");
+    if (count_value.as_double() < 0) {
+        interpreter.throw_exception<RangeError>(ErrorType::StringRepeatCountMustBe, "positive");
+        return {};
+    }
+    if (count_value.is_infinity()) {
+        interpreter.throw_exception<RangeError>(ErrorType::StringRepeatCountMustBe, "finite");
+        return {};
+    }
     auto count = count_value.to_size_t(interpreter);
     if (interpreter.exception())
         return {};
@@ -455,8 +459,10 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::last_index_of)
 JS_DEFINE_NATIVE_FUNCTION(StringPrototype::symbol_iterator)
 {
     auto this_object = interpreter.this_value(global_object);
-    if (this_object.is_undefined() || this_object.is_null())
-        return interpreter.throw_exception<TypeError>(ErrorType::ToObjectNullOrUndef);
+    if (this_object.is_undefined() || this_object.is_null()) {
+        interpreter.throw_exception<TypeError>(ErrorType::ToObjectNullOrUndef);
+        return {};
+    }
 
     auto string = this_object.to_string(interpreter);
     if (interpreter.exception())

--- a/Libraries/LibJS/Runtime/Uint8ClampedArray.cpp
+++ b/Libraries/LibJS/Runtime/Uint8ClampedArray.cpp
@@ -58,8 +58,10 @@ JS_DEFINE_NATIVE_GETTER(Uint8ClampedArray::length_getter)
     auto* this_object = interpreter.this_value(global_object).to_object(interpreter, global_object);
     if (!this_object)
         return {};
-    if (StringView(this_object->class_name()) != "Uint8ClampedArray")
-        return interpreter.throw_exception<TypeError>(ErrorType::NotA, "Uint8ClampedArray");
+    if (StringView(this_object->class_name()) != "Uint8ClampedArray") {
+        interpreter.throw_exception<TypeError>(ErrorType::NotA, "Uint8ClampedArray");
+        return {};
+    }
     return Value(static_cast<const Uint8ClampedArray*>(this_object)->length());
 }
 

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -686,8 +686,10 @@ Value exp(Interpreter& interpreter, Value lhs, Value rhs)
 
 Value in(Interpreter& interpreter, Value lhs, Value rhs)
 {
-    if (!rhs.is_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::InOperatorWithObject);
+    if (!rhs.is_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::InOperatorWithObject);
+        return {};
+    }
     auto lhs_string = lhs.to_string(interpreter);
     if (interpreter.exception())
         return {};
@@ -696,22 +698,25 @@ Value in(Interpreter& interpreter, Value lhs, Value rhs)
 
 Value instance_of(Interpreter& interpreter, Value lhs, Value rhs)
 {
-    if (!rhs.is_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotAnObject, rhs.to_string_without_side_effects().characters());
-
+    if (!rhs.is_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotAnObject, rhs.to_string_without_side_effects().characters());
+        return {};
+    }
     auto has_instance_method = rhs.as_object().get(interpreter.well_known_symbol_has_instance());
     if (!has_instance_method.is_empty()) {
-        if (!has_instance_method.is_function())
-            return interpreter.throw_exception<TypeError>(ErrorType::NotAFunction, has_instance_method.to_string_without_side_effects().characters());
-
+        if (!has_instance_method.is_function()) {
+            interpreter.throw_exception<TypeError>(ErrorType::NotAFunction, has_instance_method.to_string_without_side_effects().characters());
+            return {};
+        }
         MarkedValueList arguments(interpreter.heap());
         arguments.append(lhs);
         return Value(interpreter.call(has_instance_method.as_function(), rhs, move(arguments)).to_boolean());
     }
 
-    if (!rhs.is_function())
-        return interpreter.throw_exception<TypeError>(ErrorType::NotAFunction, rhs.to_string_without_side_effects().characters());
-
+    if (!rhs.is_function()) {
+        interpreter.throw_exception<TypeError>(ErrorType::NotAFunction, rhs.to_string_without_side_effects().characters());
+        return {};
+    }
     return ordinary_has_instance(interpreter, lhs, rhs);
 }
 
@@ -734,9 +739,10 @@ Value ordinary_has_instance(Interpreter& interpreter, Value lhs, Value rhs)
     if (interpreter.exception())
         return {};
 
-    if (!rhs_prototype.is_object())
-        return interpreter.throw_exception<TypeError>(ErrorType::InstanceOfOperatorBadPrototype, rhs_prototype.to_string_without_side_effects().characters());
-
+    if (!rhs_prototype.is_object()) {
+        interpreter.throw_exception<TypeError>(ErrorType::InstanceOfOperatorBadPrototype, rhs_prototype.to_string_without_side_effects().characters());
+        return {};
+    }
     while (true) {
         lhs_object = lhs_object->prototype();
         if (interpreter.exception())

--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -139,14 +139,17 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::set_interval)
     auto* impl = impl_from(interpreter, global_object);
     if (!impl)
         return {};
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountAtLeastOne, "setInterval");
+    if (!interpreter.argument_count()) {
+        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountAtLeastOne, "setInterval");
+        return {};
+    }
     auto* callback_object = interpreter.argument(0).to_object(interpreter, global_object);
     if (!callback_object)
         return {};
-    if (!callback_object->is_function())
-        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::NotAFunctionNoParam);
-
+    if (!callback_object->is_function()) {
+        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::NotAFunctionNoParam);
+        return {};
+    }
     i32 interval = 0;
     if (interpreter.argument_count() >= 2) {
         interval = interpreter.argument(1).to_i32(interpreter);
@@ -165,14 +168,17 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::set_timeout)
     auto* impl = impl_from(interpreter, global_object);
     if (!impl)
         return {};
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountAtLeastOne, "setTimeout");
+    if (!interpreter.argument_count()) {
+        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountAtLeastOne, "setTimeout");
+        return {};
+    }
     auto* callback_object = interpreter.argument(0).to_object(interpreter, global_object);
     if (!callback_object)
         return {};
-    if (!callback_object->is_function())
-        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::NotAFunctionNoParam);
-
+    if (!callback_object->is_function()) {
+        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::NotAFunctionNoParam);
+        return {};
+    }
     i32 interval = 0;
     if (interpreter.argument_count() >= 2) {
         interval = interpreter.argument(1).to_i32(interpreter);
@@ -191,8 +197,10 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::clear_timeout)
     auto* impl = impl_from(interpreter, global_object);
     if (!impl)
         return {};
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountAtLeastOne, "clearTimeout");
+    if (!interpreter.argument_count()) {
+        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountAtLeastOne, "clearTimeout");
+        return {};
+    }
     i32 timer_id = interpreter.argument(0).to_i32(interpreter);
     if (interpreter.exception())
         return {};
@@ -205,8 +213,10 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::clear_interval)
     auto* impl = impl_from(interpreter, global_object);
     if (!impl)
         return {};
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountAtLeastOne, "clearInterval");
+    if (!interpreter.argument_count()) {
+        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountAtLeastOne, "clearInterval");
+        return {};
+    }
     i32 timer_id = interpreter.argument(0).to_i32(interpreter);
     if (interpreter.exception())
         return {};
@@ -219,13 +229,17 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::request_animation_frame)
     auto* impl = impl_from(interpreter, global_object);
     if (!impl)
         return {};
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountOne, "requestAnimationFrame");
+    if (!interpreter.argument_count()) {
+        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountOne, "requestAnimationFrame");
+        return {};
+    }
     auto* callback_object = interpreter.argument(0).to_object(interpreter, global_object);
     if (!callback_object)
         return {};
-    if (!callback_object->is_function())
-        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::NotAFunctionNoParam);
+    if (!callback_object->is_function()) {
+        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::NotAFunctionNoParam);
+        return {};
+    }
     return JS::Value(impl->request_animation_frame(*static_cast<JS::Function*>(callback_object)));
 }
 
@@ -234,8 +248,10 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::cancel_animation_frame)
     auto* impl = impl_from(interpreter, global_object);
     if (!impl)
         return {};
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountOne, "cancelAnimationFrame");
+    if (!interpreter.argument_count()) {
+        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountOne, "cancelAnimationFrame");
+        return {};
+    }
     auto id = interpreter.argument(0).to_i32(interpreter);
     if (interpreter.exception())
         return {};
@@ -248,8 +264,10 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::atob)
     auto* impl = impl_from(interpreter, global_object);
     if (!impl)
         return {};
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountOne, "atob");
+    if (!interpreter.argument_count()) {
+        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountOne, "atob");
+        return {};
+    }
     auto string = interpreter.argument(0).to_string(interpreter);
     if (interpreter.exception())
         return {};
@@ -264,8 +282,10 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::btoa)
     auto* impl = impl_from(interpreter, global_object);
     if (!impl)
         return {};
-    if (!interpreter.argument_count())
-        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountOne, "btoa");
+    if (!interpreter.argument_count()) {
+        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountOne, "btoa");
+        return {};
+    }
     auto string = interpreter.argument(0).to_string(interpreter);
     if (interpreter.exception())
         return {};
@@ -273,8 +293,10 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::btoa)
     Vector<u8> byte_string;
     byte_string.ensure_capacity(string.length());
     for (u32 code_point : Utf8View(string)) {
-        if (code_point > 0xff)
-            return interpreter.throw_exception<JS::InvalidCharacterError>(JS::ErrorType::NotAByteString, "btoa");
+        if (code_point > 0xff) {
+            interpreter.throw_exception<JS::InvalidCharacterError>(JS::ErrorType::NotAByteString, "btoa");
+            return {};
+        }
         byte_string.append(code_point);
     }
 

--- a/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -645,12 +645,13 @@ void generate_implementation(const IDL::Interface& interface)
         out() << "    if (!impl)";
         out() << "        return {};";
         if (function.length() > 0) {
-            out() << "    if (interpreter.argument_count() < " << function.length() << ")";
-
+            out() << "    if (interpreter.argument_count() < " << function.length() << ") {";
             if (function.length() == 1)
-                out() << "        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountOne, \"" << function.name << "\");";
+                out() << "        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountOne, \"" << function.name << "\");";
             else
-                out() << "        return interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountMany, \"" << function.name << "\", \"" << function.length() << "\");";
+                out() << "        interpreter.throw_exception<JS::TypeError>(JS::ErrorType::BadArgCountMany, \"" << function.name << "\", \"" << function.length() << "\");";
+            out() << "        return {};";
+            out() << "    }";
         }
 
         StringBuilder arguments_builder;


### PR DESCRIPTION
The motivation for this change is twofold:
    
- Returning a `JS::Value` is misleading as one would expect it to carry some meaningful information, like maybe the error object that's being created, but in fact it is always empty. Supposedly to serve as a shortcut for the common case of "throw and return empty value", but that's just leading us to my second point.
- Inconsistent usage / coding style: as of this commit there are 114 uses of `throw_exception()` discarding its return value and 55 uses directly returning the call result (in LibJS, not counting LibWeb); with the first style often having a more explicit empty value (or `nullptr` in some cases) return anyway. One more line to always make the return value obvious is should be worth it.
    
So now it's basically always these steps, which is already being used in the majority of cases (as outlined above):
    
- Throw an exception. This mutates interpreter state by updating `m_exception` and unwinding, but doesn't return anything.
- Let the caller explicitly return an empty value, `nullptr` or anything else itself.