### PR TITLE
Strings

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -106,6 +106,18 @@ String String::empty()
     return StringImpl::the_empty_stringimpl();
 }
 
+bool String::copy_characters_to_buffer(char* buffer, size_t buffer_size) const
+{
+    // We must fit at least the NUL-terminator.
+    ASSERT(buffer_size > 0);
+
+    size_t characters_to_copy = min(length(), buffer_size - 1);
+    __builtin_memcpy(buffer, characters(), characters_to_copy);
+    buffer[characters_to_copy] = 0;
+
+    return characters_to_copy == length();
+}
+
 String String::isolated_copy() const
 {
     if (!m_impl)

--- a/AK/String.h
+++ b/AK/String.h
@@ -146,6 +146,8 @@ public:
     // Includes NUL-terminator, if non-nullptr.
     ALWAYS_INLINE const char* characters() const { return m_impl ? m_impl->characters() : nullptr; }
 
+    [[nodiscard]] bool copy_characters_to_buffer(char* buffer, size_t buffer_size) const;
+
     ALWAYS_INLINE ReadonlyBytes bytes() const { return m_impl ? m_impl->bytes() : nullptr; }
 
     ALWAYS_INLINE const char& operator[](size_t i) const

--- a/Libraries/LibC/netdb.cpp
+++ b/Libraries/LibC/netdb.cpp
@@ -82,9 +82,10 @@ static int connect_to_lookup_server()
         return -1;
     }
 
-    sockaddr_un address;
-    address.sun_family = AF_LOCAL;
-    strlcpy(address.sun_path, "/tmp/portal/lookup", sizeof(address.sun_path));
+    sockaddr_un address {
+        AF_LOCAL,
+        "/tmp/portal/lookup"
+    };
 
     if (connect(fd, (const sockaddr*)&address, sizeof(address)) < 0) {
         perror("connect_to_lookup_server");

--- a/Libraries/LibC/string.h
+++ b/Libraries/LibC/string.h
@@ -33,27 +33,40 @@ __BEGIN_DECLS
 
 size_t strlen(const char*);
 size_t strnlen(const char*, size_t maxlen);
+
 int strcmp(const char*, const char*);
 int strncmp(const char*, const char*, size_t);
+int strcasecmp(const char*, const char*);
+int strncasecmp(const char*, const char*, size_t);
+
 int memcmp(const void*, const void*, size_t);
 void* memcpy(void*, const void*, size_t);
 void* memmove(void*, const void*, size_t);
 void* memchr(const void*, int c, size_t);
 const void* memmem(const void* haystack, size_t, const void* needle, size_t);
+
 void bzero(void*, size_t);
 void bcopy(const void*, void*, size_t);
 void* memset(void*, int, size_t);
+
 __attribute__((malloc)) char* strdup(const char*);
 __attribute__((malloc)) char* strndup(const char*, size_t);
+
+__attribute__((deprecated("use strlcpy or String::copy_characters_to_buffer")))
 char* strcpy(char* dest, const char* src);
-size_t strlcpy(char* dest, const char* src, size_t);
+__attribute__((deprecated("use strlcpy or String::copy_characters_to_buffer")))
 char* strncpy(char* dest, const char* src, size_t);
+__attribute__((warn_unused_result)) size_t strlcpy(char* dest, const char* src, size_t);
+
 char* strchr(const char*, int c);
 char* strchrnul(const char*, int c);
 char* strstr(const char* haystack, const char* needle);
 char* strrchr(const char*, int c);
-char* strcat(char* dest, const char* src);
-char* strncat(char* dest, const char* src, size_t);
+
+__attribute__((deprecated("use strlcat"))) char* strcat(char* dest, const char* src);
+__attribute__((deprecated("use strlcat"))) char* strncat(char* dest, const char* src, size_t);
+__attribute__((warn_unused_result)) size_t strlcat(char* dest, const char* src, size_t);
+
 size_t strspn(const char*, const char* accept);
 size_t strcspn(const char*, const char* reject);
 char* strerror(int errnum);

--- a/Libraries/LibC/termcap.cpp
+++ b/Libraries/LibC/termcap.cpp
@@ -95,6 +95,11 @@ static void ensure_caps()
     caps->set("li", "25");
 }
 
+// Unfortunately, tgetstr() doesn't accept a size argument for the buffer
+// pointed to by area, so we have to use bare strcpy().
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 char* tgetstr(const char* id, char** area)
 {
     ensure_caps();
@@ -112,6 +117,8 @@ char* tgetstr(const char* id, char** area)
     fprintf(stderr, "tgetstr: missing cap id='%s'\n", id);
     return nullptr;
 }
+
+#pragma GCC diagnostic pop
 
 int tgetflag(const char* id)
 {

--- a/Libraries/LibC/time.cpp
+++ b/Libraries/LibC/time.cpp
@@ -304,10 +304,9 @@ size_t strftime(char* destination, size_t max_size, const char* format, const st
             return 0;
     }
 
-    if (builder.length() + 1 > max_size)
-        return 0;
-    strcpy(destination, builder.build().characters());
-    return builder.length();
+    auto str = builder.build();
+    bool fits = str.copy_characters_to_buffer(destination, max_size);
+    return fits ? str.length() : 0;
 }
 
 long timezone = 0;

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -557,14 +557,14 @@ int set_process_icon(int icon_id)
 
 char* getlogin()
 {
-    static char __getlogin_buffer[256];
-    if (auto* passwd = getpwuid(getuid())) {
-        strlcpy(__getlogin_buffer, passwd->pw_name, sizeof(__getlogin_buffer));
+    static String buffer;
+    if (buffer.is_null()) {
+        if (auto* passwd = getpwuid(getuid())) {
+            buffer = String(passwd->pw_name);
+        }
         endpwent();
-        return __getlogin_buffer;
     }
-    endpwent();
-    return nullptr;
+    return const_cast<char*>(buffer.characters());
 }
 
 int ftruncate(int fd, off_t length)

--- a/Libraries/LibCore/Socket.cpp
+++ b/Libraries/LibCore/Socket.cpp
@@ -112,13 +112,12 @@ bool Socket::connect(const SocketAddress& address)
     sockaddr_un saddr;
     saddr.sun_family = AF_LOCAL;
     auto dest_address = address.to_string();
-    if (dest_address.length() >= sizeof(saddr.sun_path)) {
+    bool fits = dest_address.copy_characters_to_buffer(saddr.sun_path, sizeof(saddr.sun_path));
+    if (!fits) {
         fprintf(stderr, "Core::Socket: Failed to connect() to %s: Path is too long!\n", dest_address.characters());
         errno = EINVAL;
         return false;
     }
-    strcpy(saddr.sun_path, address.to_string().characters());
-
     m_destination_address = address;
 
     return common_connect((const sockaddr*)&saddr, sizeof(saddr));

--- a/Libraries/LibCore/SocketAddress.h
+++ b/Libraries/LibCore/SocketAddress.h
@@ -87,10 +87,9 @@ public:
         ASSERT(type() == Type::Local);
         sockaddr_un address;
         address.sun_family = AF_LOCAL;
-        if (m_local_address.length() >= sizeof(address.sun_path)) {
+        bool fits = m_local_address.copy_characters_to_buffer(address.sun_path, sizeof(address.sun_path));
+        if (!fits)
             return {};
-        }
-        strcpy(address.sun_path, m_local_address.characters());
         return address;
     }
 

--- a/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Services/DHCPClient/DHCPv4Client.cpp
@@ -71,7 +71,12 @@ static void set_params(const InterfaceDescriptor& iface, const IPv4Address& ipv4
 
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
-    strlcpy(ifr.ifr_name, iface.m_ifname.characters(), IFNAMSIZ);
+
+    bool fits = iface.m_ifname.copy_characters_to_buffer(ifr.ifr_name, IFNAMSIZ);
+    if (!fits) {
+        dbg() << "Interface name doesn't fit into IFNAMSIZ!";
+        return;
+    }
 
     // set the IP address
     ifr.ifr_addr.sa_family = AF_INET;

--- a/Services/DHCPClient/DHCPv4Client.h
+++ b/Services/DHCPClient/DHCPv4Client.h
@@ -27,9 +27,9 @@
 #pragma once
 
 #include "DHCPv4.h"
-#include <AK/FlyString.h>
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/UDPServer.h>
 #include <LibCore/UDPSocket.h>
@@ -39,7 +39,7 @@
 #include <sys/socket.h>
 
 struct InterfaceDescriptor {
-    FlyString m_ifname;
+    String m_ifname;
     MACAddress m_mac_address;
 };
 

--- a/Userland/Tests/Kernel/bind-local-socket-to-symlink.cpp
+++ b/Userland/Tests/Kernel/bind-local-socket-to-symlink.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Assertions.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -47,7 +48,7 @@ int main(int, char**)
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
-    strlcpy(addr.sun_path, path, sizeof(addr.sun_path));
+    ASSERT(strlcpy(addr.sun_path, path, sizeof(addr.sun_path)) < sizeof(addr.sun_path));
 
     rc = bind(fd, (struct sockaddr*)(&addr), sizeof(addr));
     if (rc < 0 && errno == EADDRINUSE) {

--- a/Userland/Tests/Kernel/elf-symbolication-kernel-read-exploit.cpp
+++ b/Userland/Tests/Kernel/elf-symbolication-kernel-read-exploit.cpp
@@ -37,6 +37,8 @@ asm("haxcode:\n"
 extern "C" void haxcode();
 extern "C" void haxcode_end();
 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 int main()
 {
     char buffer[16384];

--- a/Userland/ifconfig.cpp
+++ b/Userland/ifconfig.cpp
@@ -116,7 +116,11 @@ int main(int argc, char** argv)
             struct ifreq ifr;
             memset(&ifr, 0, sizeof(ifr));
 
-            strlcpy(ifr.ifr_name, ifname.characters(), IFNAMSIZ);
+            bool fits = ifname.copy_characters_to_buffer(ifr.ifr_name, IFNAMSIZ);
+            if (!fits) {
+                fprintf(stderr, "Interface name '%s' is too long\n", ifname.characters());
+                return 1;
+            }
             ifr.ifr_addr.sa_family = AF_INET;
             ((sockaddr_in&)ifr.ifr_addr).sin_addr.s_addr = address.value().to_in_addr_t();
 
@@ -144,7 +148,11 @@ int main(int argc, char** argv)
             struct ifreq ifr;
             memset(&ifr, 0, sizeof(ifr));
 
-            strlcpy(ifr.ifr_name, ifname.characters(), IFNAMSIZ);
+            bool fits = ifname.copy_characters_to_buffer(ifr.ifr_name, IFNAMSIZ);
+            if (!fits) {
+                fprintf(stderr, "Interface name '%s' is too long\n", ifname.characters());
+                return 1;
+            }
             ifr.ifr_netmask.sa_family = AF_INET;
             ((sockaddr_in&)ifr.ifr_netmask).sin_addr.s_addr = address.value().to_in_addr_t();
 

--- a/Userland/passwd.cpp
+++ b/Userland/passwd.cpp
@@ -132,7 +132,7 @@ int main(int argc, char** argv)
     } else {
         auto new_password = Core::get_password("New password: ");
         if (new_password.is_error()) {
-            fprintf(stderr, strerror(new_password.error()));
+            fprintf(stderr, "%s\n", strerror(new_password.error()));
             return 1;
         }
 

--- a/Userland/ping.cpp
+++ b/Userland/ping.cpp
@@ -125,7 +125,10 @@ int main(int argc, char** argv)
         ping_packet.header.code = 0;
         ping_packet.header.un.echo.id = htons(pid);
         ping_packet.header.un.echo.sequence = htons(seq++);
-        strlcpy(ping_packet.msg, "Hello there!\n", sizeof(ping_packet.msg));
+
+        bool fits = String("Hello there!\n").copy_characters_to_buffer(ping_packet.msg, sizeof(ping_packet.msg));
+        // It's a constant string, we can be sure that it fits.
+        ASSERT(fits);
 
         ping_packet.header.checksum = internet_checksum(&ping_packet, sizeof(PingPacket));
 


### PR DESCRIPTION
This is the result of the discussion in https://github.com/SerenityOS/serenity/pull/3275

* Port a bunch of code from `static char buffer[SOME_STATIC_SIZE]` to `static String buffer`
* Add `String::copy_characters_to_buffer()`

    This is a `strcpy()`-like method with actually sane semantics:

    * It accepts a non-empty buffer along with its size in bytes.
    * It copies as much of the string as fits into the buffer.
    * It always null-terminates the result.
    * It returns, as a non-discardable boolean, whether the whole string has been copied.

    Intended usage looks like this:

    ```cpp
    bool fits = string.copy_characters_to_buffer(buffer, sizeof(buffer));
    ```

    and then either

    ```cpp
    if (!fits) {
        fprintf(stderr, "The name does not fit!!11");
        return nullptr;
    }
    ```

    or, if you're sure the buffer is large enough,

    ```cpp
    // I'm totally sure it fits because [reasons go here].
    ASSERT(fits);
    ```

    or if you're feeling extremely adventurous,

    ```cpp
    (void)fits;
    ```

    but don't do that, please.

* Port most of code that used `str*cpy()` to `String::copy_characters_to_buffer()`, handling truncation in one of the ways outlined above. (@BenWiederhake, I'm sorry, but this removes most of the usages of `strlcpy()` that you've added.)

* Deprecate `strcpy()`, `strncpy()`, `strcat()` and `strncat()`, and mark `strlcpy()` and `strlcat()` with `__attribute__((warn_unused_result))`. Since our code is warning-free, this ensures we never misuse those functions.

  Unfortunately, there is a couple of places where we still have to unsafely use those functions; so turn off the warnings for there specifically.

* Misc improvements.

cc @BenWiederhake because you're clearly interested in this, @alimpfard (please review the shit out of me!), and @rthugh02 for netdb changes.

Also, [`passwd` the Userland executable](https://github.com/SerenityOS/serenity/blob/master/Userland/passwd.cpp) doesn't work for me (with these changes, haven't tested without them) — it generates a corrupted `/etc/passwd`. It would seem that's because it keeps a shallow copy of `struct passwd` across `getpwent()` calls (and expects it to keep the same value), which obviously wrong. But maybe there's something else going on, because the resulting file looks even more broken than I would expect it to be from *that*. Are my `passwd` changes playing a role here? cc @Petelliott for that.

![image](https://user-images.githubusercontent.com/10091584/91192460-a145a880-e6fe-11ea-82c4-9f3e7f840ee8.png)
