### PR TITLE
LibGUI: Make scrollbars keep scrolling by page while clicking the gutter

### DIFF
--- a/Libraries/LibGUI/ScrollBar.cpp
+++ b/Libraries/LibGUI/ScrollBar.cpp
@@ -269,6 +269,10 @@ void ScrollBar::on_automatic_scrolling_timer_fired()
         set_value(value() + m_step);
         return;
     }
+    if (m_automatic_scrolling_kind == AutomaticScrollingKind::Gutter && component_at_position(m_last_mouse_position) == Component::Gutter) {
+        scroll_by_page(m_last_mouse_position);
+        return;
+    }
 }
 
 void ScrollBar::mousedown_event(MouseEvent& event)
@@ -308,8 +312,8 @@ void ScrollBar::mousedown_event(MouseEvent& event)
     ASSERT(!event.shift());
 
     ASSERT(clicked_component == Component::Gutter);
-    // FIXME: If scrolling by page, scroll every second or so while mouse is down.
-    scroll_by_page(event.position());
+    set_automatic_scrolling_active(true, AutomaticScrollingKind::Gutter);
+    update();
 }
 
 void ScrollBar::mouseup_event(MouseEvent& event)
@@ -333,6 +337,10 @@ void ScrollBar::mousewheel_event(MouseEvent& event)
 void ScrollBar::set_automatic_scrolling_active(bool active, AutomaticScrollingKind kind)
 {
     m_automatic_scrolling_kind = kind;
+    if (m_automatic_scrolling_kind == AutomaticScrollingKind::Gutter)
+        m_automatic_scrolling_timer->set_interval(200);
+    else
+        m_automatic_scrolling_timer->set_interval(100);
 
     if (active) {
         on_automatic_scrolling_timer_fired();

--- a/Libraries/LibGUI/ScrollBar.cpp
+++ b/Libraries/LibGUI/ScrollBar.cpp
@@ -377,7 +377,7 @@ ScrollBar::Component ScrollBar::component_at_position(const Gfx::IntPoint& posit
     return Component::Invalid;
 }
 
-void ScrollBar::mousemove_event(MouseEvent& event)
+void ScrollBar::update_hovered_component(const Gfx::IntPoint& position)
 {
     auto old_hovered_component = m_hovered_component;
     m_hovered_component = component_at_position(event.position());
@@ -389,6 +389,11 @@ void ScrollBar::mousemove_event(MouseEvent& event)
         else if (m_automatic_scrolling_kind == AutomaticScrollingKind::IncrementButton)
             set_automatic_scrolling_active(m_hovered_component == Component::IncrementButton, m_automatic_scrolling_kind);
     }
+}
+
+void ScrollBar::mousemove_event(MouseEvent& event)
+{
+    update_hovered_component(event.position());
     if (!m_scrubbing)
         return;
     float delta = orientation() == Orientation::Vertical ? (event.y() - m_scrub_origin.y()) : (event.x() - m_scrub_origin.x());

--- a/Libraries/LibGUI/ScrollBar.cpp
+++ b/Libraries/LibGUI/ScrollBar.cpp
@@ -261,11 +261,11 @@ void ScrollBar::paint_event(PaintEvent& event)
 
 void ScrollBar::on_automatic_scrolling_timer_fired()
 {
-    if (m_automatic_scrolling_kind == AutomaticScrollingKind::DecrementButton) {
+    if (m_automatic_scrolling_kind == AutomaticScrollingKind::DecrementButton && component_at_position(m_last_mouse_position) == Component::DecrementButton) {
         set_value(value() - m_step);
         return;
     }
-    if (m_automatic_scrolling_kind == AutomaticScrollingKind::IncrementButton) {
+    if (m_automatic_scrolling_kind == AutomaticScrollingKind::IncrementButton && component_at_position(m_last_mouse_position) == Component::IncrementButton) {
         set_value(value() + m_step);
         return;
     }
@@ -278,7 +278,8 @@ void ScrollBar::mousedown_event(MouseEvent& event)
     if (!has_scrubber())
         return;
 
-    Component clicked_component = component_at_position(event.position());
+    m_last_mouse_position = event.position();
+    Component clicked_component = component_at_position(m_last_mouse_position);
 
     if (clicked_component == Component::DecrementButton) {
         set_automatic_scrolling_active(true, AutomaticScrollingKind::DecrementButton);
@@ -377,23 +378,15 @@ ScrollBar::Component ScrollBar::component_at_position(const Gfx::IntPoint& posit
     return Component::Invalid;
 }
 
-void ScrollBar::update_hovered_component(const Gfx::IntPoint& position)
-{
-    auto old_hovered_component = m_hovered_component;
-    m_hovered_component = component_at_position(event.position());
-    if (old_hovered_component != m_hovered_component) {
-        update();
-
-        if (m_automatic_scrolling_kind == AutomaticScrollingKind::DecrementButton)
-            set_automatic_scrolling_active(m_hovered_component == Component::DecrementButton, m_automatic_scrolling_kind);
-        else if (m_automatic_scrolling_kind == AutomaticScrollingKind::IncrementButton)
-            set_automatic_scrolling_active(m_hovered_component == Component::IncrementButton, m_automatic_scrolling_kind);
-    }
-}
-
 void ScrollBar::mousemove_event(MouseEvent& event)
 {
-    update_hovered_component(event.position());
+    m_last_mouse_position = event.position();
+
+    auto old_hovered_component = m_hovered_component;
+    m_hovered_component = component_at_position(m_last_mouse_position);
+    if (old_hovered_component != m_hovered_component) {
+        update();
+    }
     if (!m_scrubbing)
         return;
     float delta = orientation() == Orientation::Vertical ? (event.y() - m_scrub_origin.y()) : (event.x() - m_scrub_origin.x());

--- a/Libraries/LibGUI/ScrollBar.h
+++ b/Libraries/LibGUI/ScrollBar.h
@@ -103,6 +103,7 @@ private:
     void scroll_by_page(const Gfx::IntPoint&);
 
     Component component_at_position(const Gfx::IntPoint&);
+    void update_hovered_component(const Gfx::IntPoint&);
 
     int m_min { 0 };
     int m_max { 0 };

--- a/Libraries/LibGUI/ScrollBar.h
+++ b/Libraries/LibGUI/ScrollBar.h
@@ -118,6 +118,7 @@ private:
 
     Gfx::Orientation m_orientation { Gfx::Orientation::Vertical };
     Component m_hovered_component { Component::Invalid };
+    Gfx::IntPoint m_last_mouse_position;
     bool m_scrubber_in_use { false };
 
     AutomaticScrollingKind m_automatic_scrolling_kind { AutomaticScrollingKind::None };

--- a/Libraries/LibGUI/ScrollBar.h
+++ b/Libraries/LibGUI/ScrollBar.h
@@ -102,6 +102,8 @@ private:
     void scroll_to_position(const Gfx::IntPoint&);
     void scroll_by_page(const Gfx::IntPoint&);
 
+    Component component_at_position(const Gfx::IntPoint&);
+
     int m_min { 0 };
     int m_max { 0 };
     int m_page { 0 };

--- a/Libraries/LibGUI/ScrollBar.h
+++ b/Libraries/LibGUI/ScrollBar.h
@@ -82,6 +82,7 @@ private:
         None = 0,
         DecrementButton,
         IncrementButton,
+        Gutter,
     };
 
     int default_button_size() const { return 16; }
@@ -103,7 +104,6 @@ private:
     void scroll_by_page(const Gfx::IntPoint&);
 
     Component component_at_position(const Gfx::IntPoint&);
-    void update_hovered_component(const Gfx::IntPoint&);
 
     int m_min { 0 };
     int m_max { 0 };


### PR DESCRIPTION
I'm happy about the "always keep the timer on" change, it makes things (imho) much easier to understand. My local branch where I didn't do this has much more subtle behavior.