### PR TITLE
LibJS: Add a helper for calling JS::Function's with arguments

### DIFF
--- a/Libraries/LibJS/Heap/Heap.cpp
+++ b/Libraries/LibJS/Heap/Heap.cpp
@@ -31,7 +31,6 @@
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Heap/HeapBlock.h>
 #include <LibJS/Interpreter.h>
-#include <LibJS/Runtime/MarkedValueList.h>
 #include <LibJS/Runtime/Object.h>
 #include <setjmp.h>
 #include <stdio.h>

--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -245,7 +245,7 @@ void Interpreter::gather_roots(Badge<Heap>, HashTable<Cell*>& roots)
         roots.set(symbol.value);
 }
 
-Value Interpreter::call(Function& function, Value this_value, Optional<MarkedValueList> arguments)
+Value Interpreter::call_internal(Function& function, Value this_value, Optional<MarkedValueList> arguments)
 {
     ASSERT(!exception());
 

--- a/Libraries/LibJS/Runtime/Accessor.h
+++ b/Libraries/LibJS/Runtime/Accessor.h
@@ -29,7 +29,6 @@
 
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Function.h>
-#include <LibJS/Runtime/MarkedValueList.h>
 
 namespace JS {
 
@@ -63,10 +62,8 @@ public:
     {
         if (!m_setter)
             return;
-        MarkedValueList arguments(interpreter().heap());
-        arguments.append(setter_value);
         // FIXME: It might be nice if we had a way to communicate to our caller if an exception happened after this.
-        (void)interpreter().call(*m_setter, this_value, move(arguments));
+        (void)interpreter().call(*m_setter, this_value, setter_value);
     }
 
     void visit_children(Cell::Visitor& visitor) override

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -35,7 +35,6 @@
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/Function.h>
 #include <LibJS/Runtime/GlobalObject.h>
-#include <LibJS/Runtime/MarkedValueList.h>
 #include <LibJS/Runtime/ObjectPrototype.h>
 #include <LibJS/Runtime/Value.h>
 
@@ -136,12 +135,7 @@ static void for_each_item(Interpreter& interpreter, GlobalObject& global_object,
             value = js_undefined();
         }
 
-        MarkedValueList arguments(interpreter.heap());
-        arguments.append(value);
-        arguments.append(Value((i32)i));
-        arguments.append(this_object);
-
-        auto callback_result = interpreter.call(*callback_function, this_value, move(arguments));
+        auto callback_result = interpreter.call(*callback_function, this_value, value, Value((i32)i), this_object);
         if (interpreter.exception())
             return;
 
@@ -494,13 +488,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::reduce)
         if (value.is_empty())
             continue;
 
-        MarkedValueList arguments(interpreter.heap());
-        arguments.append(accumulator);
-        arguments.append(value);
-        arguments.append(Value((i32)i));
-        arguments.append(this_object);
-
-        accumulator = interpreter.call(*callback_function, this_value, move(arguments));
+        accumulator = interpreter.call(*callback_function, this_value, accumulator, value, Value((i32)i), this_object);
         if (interpreter.exception())
             return {};
     }
@@ -553,13 +541,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::reduce_right)
         if (value.is_empty())
             continue;
 
-        MarkedValueList arguments(interpreter.heap());
-        arguments.append(accumulator);
-        arguments.append(value);
-        arguments.append(Value(i));
-        arguments.append(this_object);
-
-        accumulator = interpreter.call(*callback_function, this_value, move(arguments));
+        accumulator = interpreter.call(*callback_function, this_value, accumulator, value, Value((i32)i), this_object);
         if (interpreter.exception())
             return {};
     }

--- a/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -72,13 +72,10 @@ Object* iterator_next(Object& iterator, Value value)
     }
 
     Value result;
-    if (value.is_empty()) {
+    if (value.is_empty())
         result = interpreter.call(next_method.as_function(), &iterator);
-    } else {
-        MarkedValueList arguments(iterator.heap());
-        arguments.append(value);
-        result = interpreter.call(next_method.as_function(), &iterator, move(arguments));
-    }
+    else
+        result = interpreter.call(next_method.as_function(), &iterator, value);
 
     if (interpreter.exception())
         return {};

--- a/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -56,7 +56,8 @@ JSONObject::~JSONObject()
 {
 }
 
-String JSONObject::stringify_impl(Interpreter& interpreter, GlobalObject& global_object, Value value, Value replacer, Value space) {
+String JSONObject::stringify_impl(Interpreter& interpreter, GlobalObject& global_object, Value value, Value replacer, Value space)
+{
 
     StringifyState state;
 
@@ -154,19 +155,14 @@ String JSONObject::serialize_json_property(Interpreter& interpreter, StringifySt
         if (interpreter.exception())
             return {};
         if (to_json.is_function()) {
-            MarkedValueList arguments(interpreter.heap());
-            arguments.append(js_string(interpreter, key.to_string()));
-            value = interpreter.call(to_json.as_function(), value, move(arguments));
+            value = interpreter.call(to_json.as_function(), value, js_string(interpreter, key.to_string()));
             if (interpreter.exception())
                 return {};
         }
     }
 
     if (state.replacer_function) {
-        MarkedValueList arguments(interpreter.heap());
-        arguments.append(js_string(interpreter, key.to_string()));
-        arguments.append(value);
-        value = interpreter.call(*state.replacer_function, holder, move(arguments));
+        value = interpreter.call(*state.replacer_function, holder, js_string(interpreter, key.to_string()), value);
         if (interpreter.exception())
             return {};
     }
@@ -494,10 +490,8 @@ Value JSONObject::internalize_json_property(Interpreter& interpreter, Object* ho
             }
         }
     }
-    MarkedValueList arguments(interpreter.heap());
-    arguments.append(js_string(interpreter, name.to_string()));
-    arguments.append(value);
-    return interpreter.call(reviver, Value(holder), move(arguments));
+
+    return interpreter.call(reviver, Value(holder), js_string(interpreter, name.to_string()), value);
 }
 
 }

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -708,9 +708,8 @@ Value instance_of(Interpreter& interpreter, Value lhs, Value rhs)
             interpreter.throw_exception<TypeError>(ErrorType::NotAFunction, has_instance_method.to_string_without_side_effects().characters());
             return {};
         }
-        MarkedValueList arguments(interpreter.heap());
-        arguments.append(lhs);
-        return Value(interpreter.call(has_instance_method.as_function(), rhs, move(arguments)).to_boolean());
+
+        return Value(interpreter.call(has_instance_method.as_function(), rhs, lhs).to_boolean());
     }
 
     if (!rhs.is_function()) {

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -28,7 +28,6 @@
 #include <LibJS/AST.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Function.h>
-#include <LibJS/Runtime/MarkedValueList.h>
 #include <LibJS/Runtime/ScriptFunction.h>
 #include <LibWeb/Bindings/EventWrapper.h>
 #include <LibWeb/Bindings/EventWrapperFactory.h>
@@ -38,8 +37,8 @@
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/EventListener.h>
-#include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/DOM/Node.h>
+#include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/Layout/LayoutBlock.h>
 #include <LibWeb/Layout/LayoutDocument.h>
 #include <LibWeb/Layout/LayoutInline.h>
@@ -132,10 +131,8 @@ void Node::dispatch_event(NonnullRefPtr<Event> event)
             dbg() << "calling event listener with this=" << this_value;
 #endif
             auto* event_wrapper = wrap(global_object, *event);
-            JS::MarkedValueList arguments(global_object.heap());
-            arguments.append(event_wrapper);
             auto& interpreter = document().interpreter();
-            (void)interpreter.call(function, this_value, move(arguments));
+            (void)interpreter.call(function, this_value, event_wrapper);
             if (interpreter.exception())
                 interpreter.clear_exception();
         }

--- a/Libraries/LibWeb/DOM/Window.cpp
+++ b/Libraries/LibWeb/DOM/Window.cpp
@@ -28,12 +28,11 @@
 #include <LibGUI/MessageBox.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Function.h>
-#include <LibJS/Runtime/MarkedValueList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Timer.h>
 #include <LibWeb/DOM/Window.h>
-#include <LibWeb/Page/Frame.h>
 #include <LibWeb/InProcessWebView.h>
+#include <LibWeb/Page/Frame.h>
 
 namespace Web::DOM {
 
@@ -122,10 +121,8 @@ i32 Window::request_animation_frame(JS::Function& callback)
     i32 link_id = GUI::DisplayLink::register_callback([handle = make_handle(&callback)](i32 link_id) {
         auto& function = const_cast<JS::Function&>(static_cast<const JS::Function&>(*handle.cell()));
         auto& interpreter = function.interpreter();
-        JS::MarkedValueList arguments(interpreter.heap());
-        arguments.append(JS::Value(fake_timestamp));
         fake_timestamp += 10;
-        (void)interpreter.call(function, {}, move(arguments));
+        (void)interpreter.call(function, {}, JS::Value(fake_timestamp));
         if (interpreter.exception())
             interpreter.clear_exception();
         GUI::DisplayLink::unregister_callback(link_id);

--- a/Libraries/LibWeb/DOM/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/DOM/XMLHttpRequest.cpp
@@ -96,10 +96,8 @@ void XMLHttpRequest::dispatch_event(NonnullRefPtr<DOM::Event> event)
             auto& function = const_cast<DOM::EventListener&>(*listener.listener).function();
             auto& global_object = function.global_object();
             auto* this_value = wrap(global_object, *this);
-            JS::MarkedValueList arguments(global_object.heap());
-            arguments.append(wrap(global_object, *event));
             auto& interpreter = function.interpreter();
-            (void)interpreter.call(function, this_value, move(arguments));
+            (void)interpreter.call(function, this_value, wrap(global_object, *this));
             if (interpreter.exception())
                 interpreter.clear_exception();
         }

--- a/Userland/test-js.cpp
+++ b/Userland/test-js.cpp
@@ -37,7 +37,6 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/JSONObject.h>
-#include <LibJS/Runtime/MarkedValueList.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/time.h>
@@ -265,7 +264,8 @@ JSFileResult TestRunner::run_file_test(const String& test_path)
             printf("Unable to parse test-common.js\n");
             printf("%s\n", result.error().error.to_string().characters());
             printf("%s\n", result.error().hint.characters());
-            cleanup_and_exit();;
+            cleanup_and_exit();
+            ;
         }
         m_test_program = result.value();
     }

--- a/Userland/test-web.cpp
+++ b/Userland/test-web.cpp
@@ -41,10 +41,9 @@
 #include <LibJS/Parser.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/JSONObject.h>
-#include <LibJS/Runtime/MarkedValueList.h>
 #include <LibWeb/HTML/Parser/HTMLDocumentParser.h>
-#include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/InProcessWebView.h>
+#include <LibWeb/Loader/ResourceLoader.h>
 #include <signal.h>
 #include <sys/time.h>
 


### PR DESCRIPTION
The fact that a `MarkedValueList` had to be created and populated was just annoying, so here's an alternative.

cc @linusg 