### PR TITLE
Color picker improvements

### DIFF
--- a/Libraries/LibGUI/ColorPicker.cpp
+++ b/Libraries/LibGUI/ColorPicker.cpp
@@ -245,18 +245,31 @@ void ColorPicker::build_ui_custom(Widget& root_container)
     auto& vertical_container = horizontal_container.add<Widget>();
     vertical_container.set_size_policy(SizePolicy::Fixed, SizePolicy::Fill);
     vertical_container.set_layout<VerticalBoxLayout>();
-    vertical_container.layout()->set_margins({ 4, 0, 0, 0 });
-    vertical_container.set_preferred_size(150, 0);
+    vertical_container.layout()->set_margins({ 12, 0, 0, 0 });
+    vertical_container.set_preferred_size(128, 0);
 
-    // Preview
-    m_preview_widget = vertical_container.add<Frame>();
-    m_preview_widget->set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
-    m_preview_widget->set_preferred_size(0, 150);
+    auto& preview_container = vertical_container.add<Frame>();
+    preview_container.set_size_policy(SizePolicy::Fill, SizePolicy::Fixed);
+    preview_container.set_layout<VerticalBoxLayout>();
+    preview_container.layout()->set_margins({ 2, 2, 2, 2 });
+    preview_container.layout()->set_spacing(0);
+    preview_container.set_preferred_size(0, 128);
+
+    // Current color
+    auto& current_color_widget = preview_container.add<Widget>();
+    current_color_widget.set_fill_with_background_color(true);
+
+    auto pal1 = current_color_widget.palette();
+    pal1.set_color(ColorRole::Background, m_color);
+    current_color_widget.set_palette(pal1);
+
+    // Preview selected color
+    m_preview_widget = preview_container.add<Widget>();
     m_preview_widget->set_fill_with_background_color(true);
 
-    auto pal = m_preview_widget->palette();
-    pal.set_color(ColorRole::Background, m_color);
-    m_preview_widget->set_palette(pal);
+    auto pal2 = m_preview_widget->palette();
+    pal2.set_color(ColorRole::Background, m_color);
+    m_preview_widget->set_palette(pal2);
 
     vertical_container.layout()->add_spacer();
 

--- a/Libraries/LibGUI/ColorPicker.cpp
+++ b/Libraries/LibGUI/ColorPicker.cpp
@@ -139,7 +139,7 @@ ColorPicker::ColorPicker(Color color, Window* parent_window, String title)
     set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/color-chooser.png"));
     set_title(title);
     set_resizable(false);
-    resize(500, 326);
+    resize(458, 326);
 
     build_ui();
 }
@@ -246,7 +246,7 @@ void ColorPicker::build_ui_custom(Widget& root_container)
     auto& vertical_container = horizontal_container.add<Widget>();
     vertical_container.set_size_policy(SizePolicy::Fixed, SizePolicy::Fill);
     vertical_container.set_layout<VerticalBoxLayout>();
-    vertical_container.layout()->set_margins({ 12, 0, 0, 0 });
+    vertical_container.layout()->set_margins({ 8, 0, 0, 0 });
     vertical_container.set_preferred_size(128, 0);
 
     auto& preview_container = vertical_container.add<Frame>();

--- a/Libraries/LibGUI/ColorPicker.h
+++ b/Libraries/LibGUI/ColorPicker.h
@@ -58,7 +58,7 @@ private:
 
     Vector<ColorButton*> m_color_widgets;
     RefPtr<CustomColorWidget> m_custom_color;
-    RefPtr<Frame> m_preview_widget;
+    RefPtr<Widget> m_preview_widget;
     RefPtr<TextBox> m_html_text;
     RefPtr<SpinBox> m_red_spinbox;
     RefPtr<SpinBox> m_green_spinbox;

--- a/Libraries/LibGUI/ColorPicker.h
+++ b/Libraries/LibGUI/ColorPicker.h
@@ -63,6 +63,7 @@ private:
     RefPtr<SpinBox> m_red_spinbox;
     RefPtr<SpinBox> m_green_spinbox;
     RefPtr<SpinBox> m_blue_spinbox;
+    RefPtr<SpinBox> m_alpha_spinbox;
 };
 
 }

--- a/Libraries/LibGfx/Color.h
+++ b/Libraries/LibGfx/Color.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/Forward.h>
 #include <AK/StdLibExtras.h>
 #include <LibIPC/Forward.h>
@@ -196,14 +197,17 @@ public:
         if (hsv.hue >= 360.0)
             hsv.hue -= 360.0;
 
-        hsv.hue /= 360.0;
-
         if (!max)
             hsv.saturation = 0;
         else
             hsv.saturation = chroma / max;
 
         hsv.value = max;
+
+        ASSERT(hsv.hue >= 0.0 && hsv.hue < 360.0);
+        ASSERT(hsv.saturation >= 0.0 && hsv.saturation <= 1.0);
+        ASSERT(hsv.value >= 0.0 && hsv.value <= 1.0);
+
         return hsv;
     }
 
@@ -214,9 +218,13 @@ public:
 
     static Color from_hsv(const HSV& hsv)
     {
-        double hue = hsv.hue * 2.0;
-        double saturation = hsv.saturation / 255.0;
-        double value = hsv.value / 255.0;
+        ASSERT(hsv.hue >= 0.0 && hsv.hue < 360.0);
+        ASSERT(hsv.saturation >= 0.0 && hsv.saturation <= 1.0);
+        ASSERT(hsv.value >= 0.0 && hsv.value <= 1.0);
+
+        double hue = hsv.hue;
+        double saturation = hsv.saturation;
+        double value = hsv.value;
 
         int high = static_cast<int>(hue / 60.0) % 6;
         double f = (hue / 60.0) - high;

--- a/Libraries/LibGfx/Painter.cpp
+++ b/Libraries/LibGfx/Painter.cpp
@@ -1569,7 +1569,7 @@ void Painter::fill_path(Path& path, Color color, WindingRule winding_rule)
 #ifdef FILL_PATH_DEBUG
     size_t i { 0 };
     for (auto& segment : segments)
-        draw_line(segment.from, segment.to, Color::from_hsv(++i / segments.size() * 255, 255, 255), 1);
+        draw_line(segment.from, segment.to, Color::from_hsv(++i / segments.size() * 360.0, 1.0, 1.0), 1);
 #endif
 }
 


### PR DESCRIPTION
Here are some improvements to the color picker widget:
- current color is auto-selected and it's position marked in the custom color picker field
- the full color field was trying to represent a 3D HSV color vector in 2D space, so i replaced it with a 2D color field and a hue slider
- improved color selections in the color field, you can now drag out of the field and selection will stay constrained to the edge
- marked the selected color position with a black line with a white border for better visibility on all colors
- added a preview of the current and new colors for comparison
- added a spinbox for alpha channel when color picker has alpha enabled
- changed some sizes and margins

![color-picker](https://user-images.githubusercontent.com/2662937/91229049-8b99a880-e729-11ea-83ba-dc9d55990337.png)
