### PR TITLE
Deduplicate LibC, test and fix AK

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -228,10 +228,11 @@ public:
         return *this;
     }
 
-    Checked& operator++(int)
+    Checked operator++(int)
     {
+        Checked old { *this };
         add(1);
-        return *this;
+        return old;
     }
 
     template<typename U, typename V>
@@ -278,25 +279,33 @@ private:
 template<typename T>
 inline Checked<T> operator+(const Checked<T>& a, const Checked<T>& b)
 {
-    return Checked<T>(a).add(b);
+    Checked<T> c { a };
+    c.add(b.value());
+    return c;
 }
 
 template<typename T>
 inline Checked<T> operator-(const Checked<T>& a, const Checked<T>& b)
 {
-    return Checked<T>(a).sub(b);
+    Checked<T> c { a };
+    c.sub(b.value());
+    return c;
 }
 
 template<typename T>
 inline Checked<T> operator*(const Checked<T>& a, const Checked<T>& b)
 {
-    return Checked<T>(a).mul(b);
+    Checked<T> c { a };
+    c.mul(b.value());
+    return c;
 }
 
 template<typename T>
 inline Checked<T> operator/(const Checked<T>& a, const Checked<T>& b)
 {
-    return Checked<T>(a).div(b);
+    Checked<T> c { a };
+    c.div(b.value());
+    return c;
 }
 
 template<typename T>

--- a/AK/Tests/TestChecked.cpp
+++ b/AK/Tests/TestChecked.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/Checked.h>
+
+TEST_CASE(address_identity)
+{
+    Checked<int> a = 4;
+    Checked<int> b = 5;
+    EXPECT_EQ(&a == &a, true);
+    EXPECT_EQ(&a == &b, false);
+    EXPECT_EQ(&a != &a, false);
+    EXPECT_EQ(&a != &b, true);
+}
+
+TEST_CASE(operator_identity)
+{
+    Checked<int> a = 4;
+    EXPECT_EQ(a == 4, true);
+    EXPECT_EQ(a == 5, false);
+    EXPECT_EQ(a != 4, false);
+    EXPECT_EQ(a != 5, true);
+}
+
+TEST_CASE(operator_incr)
+{
+    Checked<int> a = 4;
+    EXPECT_EQ(++a, 5);
+    EXPECT_EQ(++a, 6);
+    EXPECT_EQ(++a, 7);
+    EXPECT_EQ(a++, 7);
+    EXPECT_EQ(a++, 8);
+    EXPECT_EQ(a++, 9);
+    EXPECT_EQ(a, 10);
+    // TODO: If decrementing gets supported, test it.
+}
+
+TEST_CASE(operator_cmp)
+{
+    Checked<int> a = 4;
+    EXPECT_EQ(a > 3, true);
+    EXPECT_EQ(a < 3, false);
+    EXPECT_EQ(a >= 3, true);
+    EXPECT_EQ(a <= 3, false);
+    EXPECT_EQ(a > 4, false);
+    EXPECT_EQ(a < 4, false);
+    EXPECT_EQ(a >= 4, true);
+    EXPECT_EQ(a <= 4, true);
+    EXPECT_EQ(a > 5, false);
+    EXPECT_EQ(a < 5, true);
+    EXPECT_EQ(a >= 5, false);
+    EXPECT_EQ(a <= 5, true);
+}
+
+TEST_CASE(operator_arith)
+{
+    Checked<int> a = 12;
+    Checked<int> b = 345;
+    EXPECT_EQ(a + b, 357);
+    EXPECT_EQ(b + a, 357);
+    EXPECT_EQ(a - b, -333);
+    EXPECT_EQ(b - a, 333);
+    EXPECT_EQ(a * b, 4140);
+    EXPECT_EQ(b * a, 4140);
+    EXPECT_EQ(a / b, 0);
+    EXPECT_EQ(b / a, 28);
+}
+
+TEST_MAIN(Checked)

--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -37,6 +37,7 @@
 #include <LibCore/Notifier.h>
 #include <pwd.h>
 #include <stdio.h>
+#include <strings.h>
 
 #define IRC_DEBUG
 

--- a/Libraries/LibC/string.h
+++ b/Libraries/LibC/string.h
@@ -35,8 +35,6 @@ size_t strlen(const char*);
 size_t strnlen(const char*, size_t maxlen);
 int strcmp(const char*, const char*);
 int strncmp(const char*, const char*, size_t);
-int strcasecmp(const char*, const char*);
-int strncasecmp(const char*, const char*, size_t);
 int memcmp(const void*, const void*, size_t);
 void* memcpy(void*, const void*, size_t);
 void* memmove(void*, const void*, size_t);


### PR DESCRIPTION
Small stuff:
- LibC: Deduplicate the headers (`strings.h` is only supposed to provide those few functions, `string.h` is not supposed to define `strcasecmp`)
- AK: Test and fix `Checked<>`, credit goes to `-Weffc++` which I intend to use more often soon.