### PR TITLE
LibC: Prospective fix for openssl build

### DIFF
--- a/Libraries/LibC/sys/socket.h
+++ b/Libraries/LibC/sys/socket.h
@@ -90,7 +90,7 @@ struct ucred {
 
 struct sockaddr_storage {
     union {
-        char data[sizeof(sockaddr_un)];
+        char data[sizeof(struct sockaddr_un)];
         void* alignment;
     };
 };


### PR DESCRIPTION
serenity/Build/Root/usr/include/sys/socket.h:93:26: error: 'sockaddr_un' undeclared here (not in a function)
   93 |         char data[sizeof(sockaddr_un)];
      |                          ^~~~~~~~~~~
make[2]: *** [<builtin>: bss_fd.o] Error 1