### PR TITLE
Kernel: Fix losing PTEs

### DIFF
--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -227,7 +227,8 @@ PageTableEntry& MemoryManager::ensure_pte(PageDirectory& page_directory, Virtual
         pde.set_present(true);
         pde.set_writable(true);
         pde.set_global(&page_directory == m_kernel_page_directory.ptr());
-        page_directory.m_physical_pages.set(page_directory_index, move(page_table));
+        auto result = page_directory.m_physical_pages.set(move(page_table));
+        ASSERT(result == AK::HashSetResult::InsertedNewEntry);
     }
 
     return quickmap_pt(PhysicalAddress((FlatPtr)pde.page_table_base()))[page_table_index];

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -220,6 +220,7 @@ private:
 template<typename Callback>
 void VMObject::for_each_region(Callback callback)
 {
+    ScopedSpinLock lock(s_mm_lock);
     // FIXME: Figure out a better data structure so we don't have to walk every single region every time an inode changes.
     //        Perhaps VMObject could have a Vector<Region*> with all of his mappers?
     for (auto& region : MM.m_user_regions) {

--- a/Kernel/VM/PageDirectory.h
+++ b/Kernel/VM/PageDirectory.h
@@ -66,7 +66,7 @@ private:
     RangeAllocator m_identity_range_allocator;
     RefPtr<PhysicalPage> m_directory_table;
     RefPtr<PhysicalPage> m_directory_pages[4];
-    HashMap<unsigned, RefPtr<PhysicalPage>> m_physical_pages;
+    HashTable<RefPtr<PhysicalPage>> m_physical_pages;
 };
 
 }


### PR DESCRIPTION
We can't use a HashMap with a small key that doesn't guarantee
collisions. Change it to a HashTable instead.
    
Fixes #3254