### PR TITLE
LibWeb: Calculate selection based on glyph centers (and handle Unicode properly)

### DIFF
--- a/Libraries/LibWeb/Layout/LineBoxFragment.cpp
+++ b/Libraries/LibWeb/Layout/LineBoxFragment.cpp
@@ -91,11 +91,11 @@ int LineBoxFragment::text_index_at(float x) const
     float width_so_far = 0;
     for (auto it = view.begin(); it != view.end(); ++it) {
         float glyph_width = font.glyph_or_emoji_width(*it);
-        if ((width_so_far + glyph_width + glyph_spacing) > relative_x)
+        if ((width_so_far + (glyph_width + glyph_spacing) / 2) > relative_x)
             return m_start + view.byte_offset_of(it);
         width_so_far += glyph_width + glyph_spacing;
     }
-    return m_start + m_length - 1;
+    return m_start + m_length;
 }
 
 Gfx::FloatRect LineBoxFragment::selection_rect(const Gfx::Font& font) const
@@ -116,6 +116,9 @@ Gfx::FloatRect LineBoxFragment::selection_rect(const Gfx::Font& font) const
     const auto end_index = m_start + m_length;
     auto text = this->text();
 
+    if (selection.start().index_in_node == selection.end().index_in_node)
+        return {};
+
     if (layout_node().selection_state() == LayoutNode::SelectionState::StartAndEnd) {
         // we are in the start/end node (both the same)
         if (start_index > selection.end().index_in_node)
@@ -124,7 +127,7 @@ Gfx::FloatRect LineBoxFragment::selection_rect(const Gfx::Font& font) const
             return {};
 
         auto selection_start_in_this_fragment = max(0, selection.start().index_in_node - m_start);
-        auto selection_end_in_this_fragment = min(m_length, selection.end().index_in_node - m_start + 1);
+        auto selection_end_in_this_fragment = min(m_length, selection.end().index_in_node - m_start);
         auto pixel_distance_to_first_selected_character = font.width(text.substring_view(0, selection_start_in_this_fragment));
         auto pixel_width_of_selection = font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment)) + 1;
 
@@ -156,7 +159,7 @@ Gfx::FloatRect LineBoxFragment::selection_rect(const Gfx::Font& font) const
             return {};
 
         auto selection_start_in_this_fragment = 0;
-        auto selection_end_in_this_fragment = min(selection.end().index_in_node + 1, m_length);
+        auto selection_end_in_this_fragment = min(selection.end().index_in_node, m_length);
         auto pixel_distance_to_first_selected_character = font.width(text.substring_view(0, selection_start_in_this_fragment));
         auto pixel_width_of_selection = font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment)) + 1;
 

--- a/Libraries/LibWeb/Page/Frame.cpp
+++ b/Libraries/LibWeb/Page/Frame.cpp
@@ -26,12 +26,12 @@
 
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
+#include <LibWeb/InProcessWebView.h>
 #include <LibWeb/Layout/LayoutBreak.h>
 #include <LibWeb/Layout/LayoutDocument.h>
 #include <LibWeb/Layout/LayoutText.h>
 #include <LibWeb/Layout/LayoutWidget.h>
 #include <LibWeb/Page/Frame.h>
-#include <LibWeb/InProcessWebView.h>
 
 namespace Web {
 
@@ -221,7 +221,7 @@ String Frame::selected_text() const
     if (selection.start().layout_node == selection.end().layout_node) {
         if (!is<LayoutText>(*selection.start().layout_node))
             return "";
-        return downcast<LayoutText>(*selection.start().layout_node).text_for_rendering().substring(selection.start().index_in_node, selection.end().index_in_node - selection.start().index_in_node + 1);
+        return downcast<LayoutText>(*selection.start().layout_node).text_for_rendering().substring(selection.start().index_in_node, selection.end().index_in_node - selection.start().index_in_node);
     }
 
     // Start node
@@ -246,7 +246,7 @@ String Frame::selected_text() const
     ASSERT(layout_node == selection.end().layout_node);
     if (is<LayoutText>(*layout_node)) {
         auto& text = downcast<LayoutText>(*layout_node).text_for_rendering();
-        builder.append(text.substring(0, selection.end().index_in_node + 1));
+        builder.append(text.substring(0, selection.end().index_in_node));
     }
 
     return builder.to_string();


### PR DESCRIPTION
Previously you had to drag all the way to the end of a glyph to select it; now you just need to drag past the centre, which I think is more consistent with how selections work in LibGUI. This also incidentally fixes #2959.