### PR TITLE
Consolidate date/time handling code across LibC, LibCore, and Kernel into AK

### DIFF
--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -42,4 +42,13 @@ int day_of_year(int year, unsigned month, int day)
     return day_of_year;
 }
 
+int days_in_month(int year, unsigned month)
+{
+    ASSERT(month >= 1 && month <= 12);
+    if (month == 2)
+        return is_leap_year(year) ? 29 : 28;
+
+    bool is_long_month = (month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12);
+    return is_long_month ? 31 : 30;
+}
 }

--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -51,4 +51,14 @@ int days_in_month(int year, unsigned month)
     bool is_long_month = (month == 1 || month == 3 || month == 5 || month == 7 || month == 8 || month == 10 || month == 12);
     return is_long_month ? 31 : 30;
 }
+
+unsigned day_of_week(int year, unsigned month, int day)
+{
+    ASSERT(month >= 1 && month <= 12);
+    static const int seek_table[] = { 0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4 };
+    if (month < 3)
+        --year;
+
+    return (year + year / 4 - year / 100 + year / 400 + seek_table[month - 1] + day) % 7;
+}
 }

--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Assertions.h>
+#include <AK/Time.h>
+
+namespace AK {
+
+int day_of_year(int year, unsigned month, int day)
+{
+    ASSERT(month >= 1 && month <= 12);
+
+    static const int seek_table[] = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
+    int day_of_year = seek_table[month - 1] + day - 1;
+
+    if (is_leap_year(year) && month >= 3)
+        day_of_year++;
+
+    return day_of_year;
+}
+
+}

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -43,13 +43,18 @@ inline bool is_leap_year(int year)
     return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
 }
 
+inline unsigned days_in_year(int year)
+{
+    return 365 + is_leap_year(year);
+}
+
 inline int years_to_days_since_epoch(int year)
 {
     int days = 0;
     for (int current_year = 1970; current_year < year; ++current_year)
-        days += 365 + is_leap_year(current_year);
+        days += days_in_year(current_year);
     for (int current_year = year; current_year < 1970; ++current_year)
-        days -= 365 + is_leap_year(current_year);
+        days -= days_in_year(current_year);
     return days;
 }
 
@@ -173,6 +178,7 @@ inline bool operator!=(const TimespecType& a, const TimespecType& b)
 
 using AK::day_of_year;
 using AK::days_in_month;
+using AK::days_in_year;
 using AK::is_leap_year;
 using AK::timespec_add;
 using AK::timespec_add_timeval;

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -33,6 +33,16 @@ inline bool is_leap_year(int year)
     return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
 }
 
+inline int years_to_days_since_epoch(int year)
+{
+    int days = 0;
+    for (int current_year = 1970; current_year < year; ++current_year)
+        days += 365 + is_leap_year(current_year);
+    for (int current_year = year; current_year < 1970; ++current_year)
+        days -= 365 + is_leap_year(current_year);
+    return days;
+}
+
 template<typename TimevalType>
 inline void timeval_sub(const TimevalType& a, const TimevalType& b, TimevalType& result)
 {
@@ -160,6 +170,7 @@ using AK::timespec_to_timeval;
 using AK::timeval_add;
 using AK::timeval_sub;
 using AK::timeval_to_timespec;
+using AK::years_to_days_since_epoch;
 using AK::operator<=;
 using AK::operator<;
 using AK::operator>;

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -28,6 +28,11 @@
 
 namespace AK {
 
+inline bool is_leap_year(int year)
+{
+    return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+}
+
 template<typename TimevalType>
 inline void timeval_sub(const TimevalType& a, const TimevalType& b, TimevalType& result)
 {
@@ -146,6 +151,7 @@ inline bool operator!=(const TimespecType& a, const TimespecType& b)
 
 }
 
+using AK::is_leap_year;
 using AK::timespec_add;
 using AK::timespec_add_timeval;
 using AK::timespec_sub;

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -29,6 +29,12 @@
 namespace AK {
 
 // Month and day start at 1. Month must be >= 1 and <= 12.
+// The return value is 0-indexed, that is 0 is Sunday, 1 is Monday, etc.
+// Day may be negative or larger than the number of days
+// in the given month.
+unsigned day_of_week(int year, unsigned month, int day);
+
+// Month and day start at 1. Month must be >= 1 and <= 12.
 // The return value is 0-indexed, that is Jan 1 is day 0.
 // Day may be negative or larger than the number of days
 // in the given month. If day is negative enough, the result
@@ -176,6 +182,7 @@ inline bool operator!=(const TimespecType& a, const TimespecType& b)
 
 }
 
+using AK::day_of_week;
 using AK::day_of_year;
 using AK::days_in_month;
 using AK::days_in_year;

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -35,6 +35,9 @@ namespace AK {
 // can be negative.
 int day_of_year(int year, unsigned month, int day);
 
+// Month starts at 1. Month must be >= 1 and <= 12.
+int days_in_month(int year, unsigned month);
+
 inline bool is_leap_year(int year)
 {
     return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
@@ -169,6 +172,7 @@ inline bool operator!=(const TimespecType& a, const TimespecType& b)
 }
 
 using AK::day_of_year;
+using AK::days_in_month;
 using AK::is_leap_year;
 using AK::timespec_add;
 using AK::timespec_add_timeval;

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -28,6 +28,13 @@
 
 namespace AK {
 
+// Month and day start at 1. Month must be >= 1 and <= 12.
+// The return value is 0-indexed, that is Jan 1 is day 0.
+// Day may be negative or larger than the number of days
+// in the given month. If day is negative enough, the result
+// can be negative.
+int day_of_year(int year, unsigned month, int day);
+
 inline bool is_leap_year(int year)
 {
     return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
@@ -161,6 +168,7 @@ inline bool operator!=(const TimespecType& a, const TimespecType& b)
 
 }
 
+using AK::day_of_year;
 using AK::is_leap_year;
 using AK::timespec_add;
 using AK::timespec_add_timeval;

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -207,6 +207,7 @@ set(AK_SOURCES
     ../AK/StringImpl.cpp
     ../AK/StringUtils.cpp
     ../AK/StringView.cpp
+    ../AK/Time.cpp
 )
 
 set(ELF_SOURCES

--- a/Kernel/RTC.cpp
+++ b/Kernel/RTC.cpp
@@ -93,18 +93,6 @@ static unsigned days_in_months_since_start_of_year(unsigned month, unsigned year
     return days;
 }
 
-static unsigned days_in_years_since_epoch(unsigned year)
-{
-    unsigned days = 0;
-    while (year > 1969) {
-        days += 365;
-        if (is_leap_year(year))
-            ++days;
-        --year;
-    }
-    return days;
-}
-
 static u8 bcd_to_binary(u8 bcd)
 {
     return (bcd & 0x0F) + ((bcd >> 4) * 10);
@@ -160,7 +148,7 @@ time_t now()
 
     ASSERT(year >= 2018);
 
-    return days_in_years_since_epoch(year - 1) * 86400
+    return years_to_days_since_epoch(year) * 86400
         + days_in_months_since_start_of_year(month - 1, year) * 86400
         + (day - 1) * 86400
         + hour * 3600

--- a/Kernel/RTC.cpp
+++ b/Kernel/RTC.cpp
@@ -104,11 +104,8 @@ time_t now()
 
     ASSERT(year >= 2018);
 
-    return years_to_days_since_epoch(year) * 86400
-        + day_of_year(year, month, day) * 86400
-        + hour * 3600
-        + minute * 60
-        + second;
+    time_t days_since_epoch = years_to_days_since_epoch(year) + day_of_year(year, month, day);
+    return ((days_since_epoch * 24 + hour) * 60 + minute) * 60 + second;
 }
 
 }

--- a/Kernel/RTC.cpp
+++ b/Kernel/RTC.cpp
@@ -26,6 +26,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/LogStream.h>
+#include <AK/Time.h>
 #include <Kernel/CMOS.h>
 #include <Kernel/RTC.h>
 
@@ -46,11 +47,6 @@ time_t boot_time()
 static bool update_in_progress()
 {
     return CMOS::read(0x0a) & 0x80;
-}
-
-inline bool is_leap_year(unsigned year)
-{
-    return ((year % 4 == 0) && ((year % 100 != 0) || (year % 400) == 0));
 }
 
 static unsigned days_in_months_since_start_of_year(unsigned month, unsigned year)

--- a/Kernel/RTC.cpp
+++ b/Kernel/RTC.cpp
@@ -49,50 +49,6 @@ static bool update_in_progress()
     return CMOS::read(0x0a) & 0x80;
 }
 
-static unsigned days_in_months_since_start_of_year(unsigned month, unsigned year)
-{
-    ASSERT(month <= 11);
-    unsigned days = 0;
-    switch (month) {
-    case 11:
-        days += 30;
-        [[fallthrough]];
-    case 10:
-        days += 31;
-        [[fallthrough]];
-    case 9:
-        days += 30;
-        [[fallthrough]];
-    case 8:
-        days += 31;
-        [[fallthrough]];
-    case 7:
-        days += 31;
-        [[fallthrough]];
-    case 6:
-        days += 30;
-        [[fallthrough]];
-    case 5:
-        days += 31;
-        [[fallthrough]];
-    case 4:
-        days += 30;
-        [[fallthrough]];
-    case 3:
-        days += 31;
-        [[fallthrough]];
-    case 2:
-        if (is_leap_year(year))
-            days += 29;
-        else
-            days += 28;
-        [[fallthrough]];
-    case 1:
-        days += 31;
-    }
-    return days;
-}
-
 static u8 bcd_to_binary(u8 bcd)
 {
     return (bcd & 0x0F) + ((bcd >> 4) * 10);
@@ -149,8 +105,7 @@ time_t now()
     ASSERT(year >= 2018);
 
     return years_to_days_since_epoch(year) * 86400
-        + days_in_months_since_start_of_year(month - 1, year) * 86400
-        + (day - 1) * 86400
+        + day_of_year(year, month, day) * 86400
         + hour * 3600
         + minute * 60
         + second;

--- a/Libraries/LibC/time.cpp
+++ b/Libraries/LibC/time.cpp
@@ -70,10 +70,10 @@ static void time_to_tm(struct tm* tm, time_t t)
     tm->tm_wday /= __seconds_per_day;
 
     int year = 1970;
-    for (; t >= (365 + is_leap_year(year)) * __seconds_per_day; ++year)
-        t -= (365 + is_leap_year(year)) * __seconds_per_day;
+    for (; t >= days_in_year(year) * __seconds_per_day; ++year)
+        t -= days_in_year(year) * __seconds_per_day;
     for (; t < 0; --year)
-        t += (365 + is_leap_year(year - 1)) * __seconds_per_day;
+        t += days_in_year(year - 1) * __seconds_per_day;
     ASSERT(t >= 0);
 
     int days = t / __seconds_per_day;
@@ -275,7 +275,7 @@ size_t strftime(char* destination, size_t max_size, const char* format, const st
                     if (tm->tm_yday >= 7 - wday_of_year_beginning)
                         --week_number;
                     else {
-                        const int days_of_last_year = 365 + is_leap_year(tm->tm_year + 1900 - 1);
+                        const int days_of_last_year = days_in_year(tm->tm_year + 1900 - 1);
                         const int wday_of_last_year_beginning = (wday_of_year_beginning + 6 * days_of_last_year) % 7;
                         week_number = (days_of_last_year + wday_of_last_year_beginning) / 7 + 1;
                         if (wday_of_last_year_beginning > 3)

--- a/Libraries/LibC/time.cpp
+++ b/Libraries/LibC/time.cpp
@@ -64,11 +64,6 @@ static const int __seconds_per_day = 60 * 60 * 24;
 
 static void time_to_tm(struct tm* tm, time_t t)
 {
-    tm->tm_wday = (4 * __seconds_per_day + t) % (7 * __seconds_per_day); // 1970-01-01 was a Thursday.
-    if (tm->tm_wday < 0)
-        tm->tm_wday += 7 * __seconds_per_day;
-    tm->tm_wday /= __seconds_per_day;
-
     int year = 1970;
     for (; t >= days_in_year(year) * __seconds_per_day; ++year)
         t -= days_in_year(year) * __seconds_per_day;
@@ -89,8 +84,9 @@ static void time_to_tm(struct tm* tm, time_t t)
     for (month = 1; month < 12 && days >= days_in_month(year, month); ++month)
         days -= days_in_month(year, month);
 
-    tm->tm_mon = month - 1;
     tm->tm_mday = days + 1;
+    tm->tm_wday = day_of_week(year, month, tm->tm_mday);
+    tm->tm_mon = month - 1;
 }
 
 static time_t tm_to_time(struct tm* tm, long timezone_adjust_seconds)

--- a/Libraries/LibC/time.cpp
+++ b/Libraries/LibC/time.cpp
@@ -117,13 +117,7 @@ static time_t tm_to_time(struct tm* tm, long timezone_adjust_seconds)
     }
 
     int days = years_to_days_since_epoch(1900 + tm->tm_year);
-
-    tm->tm_yday = tm->tm_mday - 1;
-    for (int month = 0; month < tm->tm_mon; ++month)
-        tm->tm_yday += __days_per_month[month];
-    if (tm->tm_mon > 1 && is_leap_year(1900 + tm->tm_year))
-        ++tm->tm_yday;
-
+    tm->tm_yday = day_of_year(1900 + tm->tm_year, tm->tm_mon + 1, tm->tm_mday);
     days += tm->tm_yday;
 
     int seconds = tm->tm_hour * 3600 + tm->tm_min * 60 + tm->tm_sec;

--- a/Libraries/LibC/time.cpp
+++ b/Libraries/LibC/time.cpp
@@ -60,7 +60,6 @@ char* ctime(const time_t* t)
     return asctime(localtime(t));
 }
 
-static const int __days_per_month[] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 static const int __seconds_per_day = 60 * 60 * 24;
 
 static void time_to_tm(struct tm* tm, time_t t)
@@ -85,16 +84,13 @@ static void time_to_tm(struct tm* tm, time_t t)
     tm->tm_hour = remaining / 60;
     tm->tm_year = year - 1900;
     tm->tm_yday = days;
-    tm->tm_mday = 1;
-    if (is_leap_year(year) && days == 59)
-        ++tm->tm_mday;
-    if (is_leap_year(year) && days >= 59)
-        --days;
+
     int month;
-    for (month = 0; month < 11 && days >= __days_per_month[month]; ++month)
-        days -= __days_per_month[month];
-    tm->tm_mon = month;
-    tm->tm_mday += days;
+    for (month = 1; month < 12 && days >= days_in_month(year, month); ++month)
+        days -= days_in_month(year, month);
+
+    tm->tm_mon = month - 1;
+    tm->tm_mday = days + 1;
 }
 
 static time_t tm_to_time(struct tm* tm, long timezone_adjust_seconds)

--- a/Libraries/LibC/time.cpp
+++ b/Libraries/LibC/time.cpp
@@ -74,16 +74,16 @@ static void time_to_tm(struct tm* tm, time_t t)
         t -= days_in_year(year) * __seconds_per_day;
     for (; t < 0; --year)
         t += days_in_year(year - 1) * __seconds_per_day;
-    ASSERT(t >= 0);
+    tm->tm_year = year - 1900;
 
+    ASSERT(t >= 0);
     int days = t / __seconds_per_day;
+    tm->tm_yday = days;
     int remaining = t % __seconds_per_day;
     tm->tm_sec = remaining % 60;
     remaining /= 60;
     tm->tm_min = remaining % 60;
     tm->tm_hour = remaining / 60;
-    tm->tm_year = year - 1900;
-    tm->tm_yday = days;
 
     int month;
     for (month = 1; month < 12 && days >= days_in_month(year, month); ++month)
@@ -112,12 +112,9 @@ static time_t tm_to_time(struct tm* tm, long timezone_adjust_seconds)
         tm->tm_mon += 12;
     }
 
-    int days = years_to_days_since_epoch(1900 + tm->tm_year);
     tm->tm_yday = day_of_year(1900 + tm->tm_year, tm->tm_mon + 1, tm->tm_mday);
-    days += tm->tm_yday;
-
-    int seconds = tm->tm_hour * 3600 + tm->tm_min * 60 + tm->tm_sec;
-    auto timestamp = static_cast<time_t>(days) * __seconds_per_day + seconds + timezone_adjust_seconds;
+    time_t days_since_epoch = years_to_days_since_epoch(1900 + tm->tm_year) + tm->tm_yday;
+    auto timestamp = ((days_since_epoch * 24 + tm->tm_hour) * 60 + tm->tm_min) * 60 + tm->tm_sec + timezone_adjust_seconds;
     time_to_tm(tm, timestamp);
     return timestamp;
 }

--- a/Libraries/LibC/time.cpp
+++ b/Libraries/LibC/time.cpp
@@ -116,11 +116,7 @@ static time_t tm_to_time(struct tm* tm, long timezone_adjust_seconds)
         tm->tm_mon += 12;
     }
 
-    int days = 0;
-    for (int year = 70; year < tm->tm_year; ++year)
-        days += 365 + is_leap_year(1900 + year);
-    for (int year = tm->tm_year; year < 70; ++year)
-        days -= 365 + is_leap_year(1900 + year);
+    int days = years_to_days_since_epoch(1900 + tm->tm_year);
 
     tm->tm_yday = tm->tm_mday - 1;
     for (int month = 0; month < tm->tm_mon; ++month)

--- a/Libraries/LibCore/DateTime.cpp
+++ b/Libraries/LibCore/DateTime.cpp
@@ -221,7 +221,7 @@ String DateTime::to_string(const String& format) const
                     if (tm.tm_yday >= 7 - wday_of_year_beginning)
                         --week_number;
                     else {
-                        const bool last_year_is_leap = ((tm.tm_year + 1900 - 1) % 4 == 0 && (tm.tm_year + 1900 - 1) % 100 != 0) || (tm.tm_year + 1900 - 1) % 400 == 0;
+                        const bool last_year_is_leap = ::is_leap_year(tm.tm_year + 1900 - 1);
                         const int days_of_last_year = 365 + last_year_is_leap;
                         const int wday_of_last_year_beginning = (wday_of_year_beginning + 6 * days_of_last_year) % 7;
                         week_number = (days_of_last_year + wday_of_last_year_beginning) / 7 + 1;

--- a/Libraries/LibCore/DateTime.cpp
+++ b/Libraries/LibCore/DateTime.cpp
@@ -61,12 +61,7 @@ DateTime DateTime::from_timestamp(time_t timestamp)
 
 unsigned DateTime::weekday() const
 {
-    int target_year = m_year;
-    static const int seek_table[] = { 0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4 };
-    if (m_month < 3)
-        --target_year;
-
-    return (target_year + target_year / 4 - target_year / 100 + target_year / 400 + seek_table[m_month - 1] + m_day) % 7;
+    return ::day_of_week(m_year, m_month, m_day);
 }
 
 unsigned DateTime::days_in_month() const

--- a/Libraries/LibCore/DateTime.cpp
+++ b/Libraries/LibCore/DateTime.cpp
@@ -216,8 +216,7 @@ String DateTime::to_string(const String& format) const
                     if (tm.tm_yday >= 7 - wday_of_year_beginning)
                         --week_number;
                     else {
-                        const bool last_year_is_leap = ::is_leap_year(tm.tm_year + 1900 - 1);
-                        const int days_of_last_year = 365 + last_year_is_leap;
+                        const int days_of_last_year = days_in_year(tm.tm_year + 1900 - 1);
                         const int wday_of_last_year_beginning = (wday_of_year_beginning + 6 * days_of_last_year) % 7;
                         week_number = (days_of_last_year + wday_of_last_year_beginning) / 7 + 1;
                         if (wday_of_last_year_beginning > 3)

--- a/Libraries/LibCore/DateTime.cpp
+++ b/Libraries/LibCore/DateTime.cpp
@@ -81,13 +81,7 @@ unsigned DateTime::days_in_month() const
 
 unsigned DateTime::day_of_year() const
 {
-    static const int seek_table[] = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
-    int day_of_year = seek_table[m_month - 1] + m_day;
-
-    if (is_leap_year() && m_month > 3)
-        day_of_year++;
-
-    return day_of_year - 1;
+    return ::day_of_year(m_year, m_month, m_day);
 }
 
 bool DateTime::is_leap_year() const

--- a/Libraries/LibCore/DateTime.cpp
+++ b/Libraries/LibCore/DateTime.cpp
@@ -71,12 +71,7 @@ unsigned DateTime::weekday() const
 
 unsigned DateTime::days_in_month() const
 {
-    bool is_long_month = (m_month == 1 || m_month == 3 || m_month == 5 || m_month == 7 || m_month == 8 || m_month == 10 || m_month == 12);
-
-    if (m_month == 2)
-        return is_leap_year() ? 29 : 28;
-
-    return is_long_month ? 31 : 30;
+    return ::days_in_month(m_year, m_month);
 }
 
 unsigned DateTime::day_of_year() const

--- a/Libraries/LibCore/DateTime.cpp
+++ b/Libraries/LibCore/DateTime.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/StringBuilder.h>
+#include <AK/Time.h>
 #include <LibCore/DateTime.h>
 #include <sys/time.h>
 #include <time.h>
@@ -91,7 +92,7 @@ unsigned DateTime::day_of_year() const
 
 bool DateTime::is_leap_year() const
 {
-    return ((m_year % 400 == 0) || (m_year % 4 == 0 && m_year % 100 != 0));
+    return ::is_leap_year(m_year);
 }
 
 void DateTime::set_time(unsigned year, unsigned month, unsigned day, unsigned hour, unsigned minute, unsigned second)

--- a/Libraries/LibJS/Tests/builtins/Date/Date.UTC.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.UTC.js
@@ -26,6 +26,10 @@ test("basic functionality", () => {
     expect(Date.UTC(20000, 0)).toBe(568971820800000);
 });
 
+test("leap year", () => {
+    expect(Date.UTC(2020, 2, 1)).toBe(1583020800000);
+});
+
 test("out of range", () => {
     expect(Date.UTC(2020, -20)).toBe(1525132800000);
     expect(Date.UTC(2020, 20)).toBe(1630454400000);

--- a/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCMonth.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.prototype.getUTCMonth.js
@@ -4,4 +4,23 @@ test("basic functionality", () => {
     expect(d.getUTCMonth()).not.toBeNaN();
     expect(d.getUTCMonth()).toBeGreaterThanOrEqual(0);
     expect(d.getUTCMonth()).toBeLessThanOrEqual(11);
+
+    expect(new Date(Date.UTC(2020, 11)).getUTCMonth()).toBe(11);
+});
+
+test("leap years", () => {
+    expect(new Date(Date.UTC(2019, 1, 29)).getUTCDate()).toBe(1);
+    expect(new Date(Date.UTC(2019, 1, 29)).getUTCMonth()).toBe(2);
+    expect(new Date(Date.UTC(2100, 1, 29)).getUTCDate()).toBe(1);
+    expect(new Date(Date.UTC(2100, 1, 29)).getUTCMonth()).toBe(2);
+
+    expect(new Date(Date.UTC(2000, 1, 29)).getUTCDate()).toBe(29);
+    expect(new Date(Date.UTC(2000, 1, 29)).getUTCMonth()).toBe(1);
+    expect(new Date(Date.UTC(2020, 1, 29)).getUTCDate()).toBe(29);
+    expect(new Date(Date.UTC(2020, 1, 29)).getUTCMonth()).toBe(1);
+
+    expect(new Date(Date.UTC(2019, 2, 1)).getUTCDate()).toBe(1);
+    expect(new Date(Date.UTC(2019, 2, 1)).getUTCMonth()).toBe(2);
+    expect(new Date(Date.UTC(2020, 2, 1)).getUTCDate()).toBe(1);
+    expect(new Date(Date.UTC(2020, 2, 1)).getUTCMonth()).toBe(2);
 });


### PR DESCRIPTION
Since the LibC code is tested reasonably well via test-js, this fixes one bug in LibCore (day_of_year was wrong) and possibly fixes one bug in Kernel's RTC.