### PR TITLE
LibCompress: Make the DEFLATE implementation a true stream implemenation.

### DIFF
--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -33,13 +33,13 @@
 namespace AK {
 
 template<typename T>
-int integral_compare(const T& a, const T& b)
+int integral_compare(const typename RemoveConst<T>::Type& a, const typename RemoveConst<T>::Type& b)
 {
     return a - b;
 }
 
 template<typename T, typename Compare>
-T* binary_search(Span<T> haystack, const T& needle, Compare compare = integral_compare, size_t* nearby_index = nullptr)
+T* binary_search(Span<T> haystack, const typename RemoveConst<T>::Type& needle, Compare compare = integral_compare, size_t* nearby_index = nullptr)
 {
     if (haystack.size() == 0) {
         if (nearby_index)

--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/Stream.h>
+
+namespace AK {
+
+class InputBitStream final : public InputStream {
+public:
+    explicit InputBitStream(InputStream& stream)
+        : m_stream(stream)
+    {
+    }
+
+    size_t read(Bytes bytes) override
+    {
+        size_t nread = 0;
+
+        if (bytes.size() >= 1) {
+            if (m_next_byte.has_value()) {
+                bytes[0] = m_next_byte.value();
+                m_next_byte.clear();
+
+                ++nread;
+            }
+        }
+
+        return nread + m_stream.read(bytes.slice(nread));
+    }
+
+    bool read_or_error(Bytes bytes) override
+    {
+        if (read(bytes) != bytes.size()) {
+            m_error = true;
+            return false;
+        }
+
+        return true;
+    }
+
+    bool eof() const override { return !m_next_byte.has_value() && m_stream.eof(); }
+
+    bool discard_or_error(size_t count) override
+    {
+        if (count >= 1) {
+            if (m_next_byte.has_value()) {
+                m_next_byte.clear();
+                --count;
+            }
+        }
+
+        return discard_or_error(count);
+    }
+
+    u32 read_bits(size_t count)
+    {
+        u32 result = 0;
+
+        size_t nread = 0;
+        while (nread < count) {
+            if (m_next_byte.has_value()) {
+                const auto bit = (m_next_byte.value() >> m_bit_offset) & 1;
+                result |= bit << nread;
+                ++nread;
+
+                if (m_bit_offset++ == 7)
+                    m_next_byte.clear();
+            } else if (m_stream.eof()) {
+                m_error = true;
+                return 0;
+            } else {
+                m_stream >> m_next_byte;
+                m_bit_offset = 0;
+            }
+        }
+
+        return result;
+    }
+
+    bool read_bit() { return static_cast<bool>(read_bits(1)); }
+
+    void align_to_byte_boundary()
+    {
+        if (m_next_byte.has_value())
+            m_next_byte.clear();
+    }
+
+private:
+    Optional<u8> m_next_byte;
+    size_t m_bit_offset { 0 };
+    InputStream& m_stream;
+};
+
+}
+
+using AK::InputBitStream;

--- a/AK/CircularDuplexStream.h
+++ b/AK/CircularDuplexStream.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/CircularQueue.h>
+#include <AK/Stream.h>
+
+namespace AK {
+
+// FIXME: There are a lot of raw loops here, that's not necessary an issue but it
+//        has to be verified that the optimizer is able to insert memcpy instead.
+template<size_t Capacity>
+class CircularDuplexStream : public AK::DuplexStream {
+public:
+    size_t write(ReadonlyBytes bytes) override
+    {
+        const auto nwritten = min(bytes.size(), Capacity - m_queue.size());
+
+        for (size_t idx = 0; idx < nwritten; ++idx)
+            m_queue.enqueue(bytes[idx]);
+
+        m_total_written += nwritten;
+        return nwritten;
+    }
+
+    bool write_or_error(ReadonlyBytes bytes) override
+    {
+        if (Capacity - m_queue.size() < bytes.size()) {
+            m_error = true;
+            return false;
+        }
+
+        write(bytes);
+        return true;
+    }
+
+    size_t read(Bytes bytes) override
+    {
+        const auto nread = min(bytes.size(), m_queue.size());
+
+        for (size_t idx = 0; idx < nread; ++idx)
+            bytes[idx] = m_queue.dequeue();
+
+        return nread;
+    }
+
+    size_t read(Bytes bytes, size_t seekback)
+    {
+        ASSERT(seekback <= Capacity);
+
+        if (seekback > m_total_written) {
+            m_error = true;
+            return 0;
+        }
+
+        const auto nread = min(bytes.size(), seekback);
+
+        for (size_t idx = 0; idx < nread; ++idx) {
+            const auto index = (m_total_written - seekback + idx) % Capacity;
+            bytes[idx] = m_queue.m_storage[index];
+        }
+
+        return nread;
+    }
+
+    bool read_or_error(Bytes bytes) override
+    {
+        if (m_queue.size() < bytes.size()) {
+            m_error = true;
+            return false;
+        }
+
+        read(bytes);
+        return true;
+    }
+
+    bool discard_or_error(size_t count) override
+    {
+        if (m_queue.size() < count) {
+            m_error = true;
+            return false;
+        }
+
+        for (size_t idx = 0; idx < count; ++idx)
+            m_queue.dequeue();
+
+        return true;
+    }
+
+    bool eof() const override { return m_queue.size() == 0; }
+
+    size_t remaining_contigous_space() const
+    {
+        return min(Capacity - m_queue.size(), m_queue.capacity() - (m_queue.head_index() + m_queue.size()) % Capacity);
+    }
+
+    Bytes reserve_contigous_space(size_t count)
+    {
+        ASSERT(count <= remaining_contigous_space());
+
+        Bytes bytes { m_queue.m_storage + (m_queue.head_index() + m_queue.size()) % Capacity, count };
+
+        m_queue.m_size += count;
+        m_total_written += count;
+
+        return bytes;
+    }
+
+private:
+    CircularQueue<u8, Capacity> m_queue;
+    size_t m_total_written { 0 };
+};
+
+}
+
+using AK::CircularDuplexStream;

--- a/AK/CircularQueue.h
+++ b/AK/CircularQueue.h
@@ -27,13 +27,15 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Forward.h>
 #include <AK/StdLibExtras.h>
-#include <AK/Types.h>
 
 namespace AK {
 
 template<typename T, size_t Capacity>
 class CircularQueue {
+    friend CircularDuplexStream<Capacity>;
+
 public:
     CircularQueue()
     {

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -51,6 +51,10 @@ class Utf8View;
 class InputStream;
 class InputMemoryStream;
 class DuplexMemoryStream;
+class OutputStream;
+
+template<size_t Capacity>
+class CircularDuplexStream;
 
 template<typename T>
 class Span;
@@ -123,6 +127,7 @@ using AK::Bitmap;
 using AK::BufferStream;
 using AK::ByteBuffer;
 using AK::Bytes;
+using AK::CircularDuplexStream;
 using AK::CircularQueue;
 using AK::DebugLogStream;
 using AK::DoublyLinkedList;
@@ -143,6 +148,7 @@ using AK::LogStream;
 using AK::NonnullOwnPtr;
 using AK::NonnullRefPtr;
 using AK::Optional;
+using AK::OutputStream;
 using AK::OwnPtr;
 using AK::ReadonlyBytes;
 using AK::RefPtr;

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -52,6 +52,7 @@ class InputStream;
 class InputMemoryStream;
 class DuplexMemoryStream;
 class OutputStream;
+class InputBitStream;
 
 template<size_t Capacity>
 class CircularDuplexStream;
@@ -138,6 +139,7 @@ using AK::Function;
 using AK::HashMap;
 using AK::HashTable;
 using AK::InlineLinkedList;
+using AK::InputBitStream;
 using AK::InputMemoryStream;
 using AK::InputStream;
 using AK::IPv4Address;

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -31,6 +31,7 @@
 #include <AK/Endian.h>
 #include <AK/Forward.h>
 #include <AK/MemMem.h>
+#include <AK/Optional.h>
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Vector.h>
@@ -101,6 +102,15 @@ template<typename T>
 InputStream& operator<<(InputStream& stream, BigEndian<T> value)
 {
     stream << static_cast<T>(value);
+    return stream;
+}
+
+template<typename T>
+InputStream& operator>>(InputStream& stream, Optional<T>& value)
+{
+    T temporary;
+    stream >> temporary;
+    value = temporary;
     return stream;
 }
 

--- a/AK/Tests/TestBinarySearch.cpp
+++ b/AK/Tests/TestBinarySearch.cpp
@@ -50,9 +50,9 @@ TEST_CASE(array_doubles)
 {
     double doubles[] = { 1.1, 9.9, 33.33 };
 
-    auto test1 = *binary_search({ doubles, 3 }, 1.1, AK::integral_compare<double>);
-    auto test2 = *binary_search({ doubles, 3 }, 9.9, AK::integral_compare<double>);
-    auto test3 = *binary_search({ doubles, 3 }, 33.33, AK::integral_compare<double>);
+    auto test1 = *binary_search(Span<double> { doubles, 3 }, 1.1, AK::integral_compare<double>);
+    auto test2 = *binary_search(Span<double> { doubles, 3 }, 9.9, AK::integral_compare<double>);
+    auto test3 = *binary_search(Span<double> { doubles, 3 }, 33.33, AK::integral_compare<double>);
     EXPECT_EQ(test1, 1.1);
     EXPECT_EQ(test2, 9.9);
     EXPECT_EQ(test3, 33.33);
@@ -110,7 +110,7 @@ TEST_CASE(no_elements)
 
 TEST_CASE(huge_char_array)
 {
-    const size_t N = 2147483680;    
+    const size_t N = 2147483680;
     Bytes span { new (std::nothrow) u8[N], N };
     EXPECT(span.data() != nullptr);
 

--- a/AK/Tests/TestCircularDuplexStream.cpp
+++ b/AK/Tests/TestCircularDuplexStream.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/CircularDuplexStream.h>
+
+TEST_CASE(works_like_a_queue)
+{
+    constexpr size_t capacity = 32;
+
+    CircularQueue<u8, capacity> queue;
+    CircularDuplexStream<capacity> stream;
+
+    for (size_t idx = 0; idx < capacity; ++idx) {
+        queue.enqueue(static_cast<u8>(idx % 256));
+        stream << static_cast<u8>(idx % 256);
+    }
+
+    for (size_t idx = 0; idx < capacity; ++idx) {
+        u8 byte;
+        stream >> byte;
+
+        EXPECT_EQ(queue.dequeue(), byte);
+    }
+
+    EXPECT(stream.eof());
+}
+
+TEST_CASE(overwritting_is_well_defined)
+{
+    constexpr size_t half_capacity = 16;
+    constexpr size_t capacity = 2 * half_capacity;
+
+    CircularDuplexStream<capacity> stream;
+
+    for (size_t idx = 0; idx < capacity; ++idx)
+        stream << static_cast<u8>(idx % 256);
+
+    u8 bytes[half_capacity];
+
+    stream >> Bytes { bytes, sizeof(bytes) };
+
+    for (size_t idx = 0; idx < half_capacity; ++idx) {
+        EXPECT_EQ(bytes[idx], idx % 256);
+    }
+
+    for (size_t idx = 0; idx < half_capacity; ++idx)
+        stream << static_cast<u8>(idx % 256);
+
+    for (size_t idx = 0; idx < capacity; ++idx) {
+        u8 byte;
+        stream >> byte;
+
+        if (idx < half_capacity)
+            EXPECT_EQ(byte, half_capacity + idx % 256);
+        else
+            EXPECT_EQ(byte, idx % 256 - half_capacity);
+    }
+
+    EXPECT(stream.eof());
+}
+
+TEST_MAIN(CircularDuplexStream)

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -25,352 +25,34 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/BinarySearch.h>
+#include <AK/FixedArray.h>
 #include <AK/LogStream.h>
-#include <AK/Span.h>
-#include <AK/Types.h>
-#include <AK/Vector.h>
+
 #include <LibCompress/Deflate.h>
 
 namespace Compress {
 
-bool DeflateStream::read_next_block() const
+// FIXME: This logic needs to go into the deflate decoder somehow, we don't want
+//        to assert that the input is valid. Instead we need to set m_error on the
+//        stream.
+DeflateDecompressor::CanonicalCode::CanonicalCode(ReadonlyBytes codes)
 {
-    if (m_read_last_block)
-        return false;
+    // FIXME: I can't quite follow the algorithm here, but it seems to work.
 
-    m_read_last_block = m_reader.read_bits(1);
-    auto block_type = m_reader.read_bits(2);
-
-    switch (block_type) {
-    case 0:
-        decompress_uncompressed_block();
-        break;
-    case 1:
-        decompress_static_block();
-        break;
-    case 2:
-        decompress_dynamic_block();
-        break;
-    case 3:
-        dbg() << "Block contains reserved block type...";
-        ASSERT_NOT_REACHED();
-        break;
-    default:
-        dbg() << "Invalid block type was read...";
-        ASSERT_NOT_REACHED();
-        break;
-    }
-
-    return true;
-}
-
-void DeflateStream::decompress_uncompressed_block() const
-{
-    // Align to the next byte boundary.
-    while (m_reader.get_bit_byte_offset() != 0) {
-        m_reader.read();
-    }
-
-    auto length = m_reader.read_bits(16) & 0xFFFF;
-    auto negated_length = m_reader.read_bits(16) & 0xFFFF;
-
-    if ((length ^ 0xFFFF) != negated_length) {
-        dbg() << "Block length is invalid...";
-        ASSERT_NOT_REACHED();
-    }
-
-    for (size_t i = 0; i < length; i++) {
-        auto byte = m_reader.read_byte();
-        if (byte < 0) {
-            dbg() << "Ran out of bytes while reading uncompressed block...";
-            ASSERT_NOT_REACHED();
-        }
-
-        m_intermediate_stream << byte;
-    }
-}
-
-void DeflateStream::decompress_static_block() const
-{
-    decompress_huffman_block(m_literal_length_codes, &m_fixed_distance_codes);
-}
-
-void DeflateStream::decompress_dynamic_block() const
-{
-    auto codes = decode_huffman_codes();
-    if (codes.size() == 2) {
-        decompress_huffman_block(codes[0], &codes[1]);
-    } else {
-        decompress_huffman_block(codes[0], nullptr);
-    }
-}
-
-void DeflateStream::decompress_huffman_block(CanonicalCode& length_codes, CanonicalCode* distance_codes) const
-{
-    for (;;) {
-        u32 symbol = length_codes.next_symbol(m_reader);
-
-        // End of block.
-        if (symbol == 256) {
-            break;
-        }
-
-        // literal byte.
-        if (symbol < 256) {
-            m_intermediate_stream << static_cast<u8>(symbol);
-            continue;
-        }
-
-        // Length and distance for copying.
-        ASSERT(distance_codes);
-
-        auto run = decode_run_length(symbol);
-        if (run < 3 || run > 258) {
-            dbg() << "Invalid run length";
-            ASSERT_NOT_REACHED();
-        }
-
-        auto distance_symbol = distance_codes->next_symbol(m_reader);
-        auto distance = decode_distance(distance_symbol);
-        if (distance < 1 || distance > 32768) {
-            dbg() << "Invalid distance";
-            ASSERT_NOT_REACHED();
-        }
-
-        copy_from_history(distance, run);
-    }
-}
-
-Vector<CanonicalCode> DeflateStream::decode_huffman_codes() const
-{
-    // FIXME: This path is not tested.
-    Vector<CanonicalCode> result;
-
-    auto length_code_count = m_reader.read_bits(5) + 257;
-    auto distance_code_count = m_reader.read_bits(5) + 1;
-
-    size_t length_code_code_length = m_reader.read_bits(4) + 4;
-
-    Vector<u8> code_length_code_length;
-    code_length_code_length.resize(19);
-    code_length_code_length[16] = m_reader.read_bits(3);
-    code_length_code_length[17] = m_reader.read_bits(3);
-    code_length_code_length[18] = m_reader.read_bits(3);
-    code_length_code_length[0] = m_reader.read_bits(3);
-    for (size_t i = 0; i < length_code_code_length; i++) {
-        auto index = (i % 2 == 0) ? (8 + (i / 2)) : (7 - (i / 2));
-        code_length_code_length[index] = m_reader.read_bits(3);
-    }
-
-    auto code_length_code = CanonicalCode(code_length_code_length);
-
-    Vector<u32> code_lens;
-    code_lens.resize(length_code_count + distance_code_count);
-
-    for (size_t index = 0; index < code_lens.capacity();) {
-        auto symbol = code_length_code.next_symbol(m_reader);
-
-        if (symbol <= 15) {
-            code_lens[index] = symbol;
-            index++;
-            continue;
-        }
-
-        u32 run_length;
-        u32 run_value = 0;
-
-        if (symbol == 16) {
-            if (index == 0) {
-                dbg() << "No code length value avaliable";
-                ASSERT_NOT_REACHED();
-            }
-
-            run_length = m_reader.read_bits(2) + 3;
-            run_value = code_lens[index - 1];
-        } else if (symbol == 17) {
-            run_length = m_reader.read_bits(3) + 3;
-        } else if (symbol == 18) {
-            run_length = m_reader.read_bits(7) + 11;
-        } else {
-            dbg() << "Code symbol is out of range!";
-            ASSERT_NOT_REACHED();
-        }
-
-        u32 end = index + run_length;
-        if (end > code_lens.capacity()) {
-            dbg() << "Code run is out of range!";
-            ASSERT_NOT_REACHED();
-        }
-
-        memset(code_lens.data() + index, run_value, run_length);
-        index = end;
-    }
-
-    Vector<u8> literal_codes;
-    literal_codes.resize(length_code_count);
-    memcpy(literal_codes.data(), code_lens.data(), literal_codes.capacity());
-    result.append(CanonicalCode(literal_codes));
-
-    Vector<u8> distance_codes;
-    distance_codes.resize(distance_code_count);
-    memcpy(distance_codes.data(), code_lens.data() + length_code_count, distance_codes.capacity());
-
-    if (distance_code_count == 1 && distance_codes[0] == 0) {
-        return result;
-    }
-
-    u8 one_count = 0;
-    u8 other_count = 0;
-
-    for (size_t i = 0; i < distance_codes.capacity(); i++) {
-        u8 value = distance_codes.at(i);
-
-        if (value == 1) {
-            one_count++;
-        } else if (value > 1) {
-            other_count++;
-        }
-    }
-
-    if (one_count == 1 && other_count == 0) {
-        distance_codes.resize(32);
-        distance_codes[31] = 1;
-    }
-
-    result.append(CanonicalCode(distance_codes));
-    return result;
-}
-
-u32 DeflateStream::decode_run_length(u32 symbol) const
-{
-    if (symbol <= 264) {
-        return symbol - 254;
-    }
-
-    if (symbol <= 284) {
-        auto extra_bits = (symbol - 261) / 4;
-        return ((((symbol - 265) % 4) + 4) << extra_bits) + 3 + m_reader.read_bits(extra_bits);
-    }
-
-    if (symbol == 285) {
-        return 258;
-    }
-
-    dbg() << "Found invalid symbol in run length " << symbol;
-    ASSERT_NOT_REACHED();
-}
-
-u32 DeflateStream::decode_distance(u32 symbol) const
-{
-    if (symbol <= 3) {
-        return symbol + 1;
-    }
-
-    if (symbol <= 29) {
-        auto extra_bits = (symbol / 2) - 1;
-        return (((symbol % 2) + 2) << extra_bits) + 1 + m_reader.read_bits(extra_bits);
-    }
-
-    dbg() << "Found invalid symbol in distance" << symbol;
-    ASSERT_NOT_REACHED();
-}
-
-void DeflateStream::copy_from_history(u32 distance, u32 run) const
-{
-    for (size_t i = 0; i < run; i++) {
-        u8 byte;
-
-        // FIXME: In many cases we can read more than one byte at a time, this should
-        //        be refactored into a while loop. Beware, edge case:
-        //
-        //            // The first four bytes are on the stream already, the other four
-        //            // are written by copy_from_history() itself.
-        //            copy_from_history(4, 8);
-        m_intermediate_stream.read({ &byte, sizeof(byte) }, m_intermediate_stream.woffset() - distance);
-        m_intermediate_stream << byte;
-    }
-}
-
-i8 BitStreamReader::read()
-{
-    if (m_current_byte == -1) {
-        return -1;
-    }
-
-    if (m_remaining_bits == 0) {
-        if (m_data_index + 1 > m_data.size())
-            return -1;
-
-        m_current_byte = m_data.at(m_data_index++);
-        m_remaining_bits = 8;
-    }
-
-    m_remaining_bits--;
-    return (m_current_byte >> (7 - m_remaining_bits)) & 1;
-}
-
-i8 BitStreamReader::read_byte()
-{
-    m_current_byte = 0;
-    m_remaining_bits = 0;
-
-    if (m_data_index + 1 > m_data.size())
-        return -1;
-
-    return m_data.at(m_data_index++);
-}
-
-u8 BitStreamReader::get_bit_byte_offset()
-{
-    return (8 - m_remaining_bits) % 8;
-}
-
-u32 BitStreamReader::read_bits(u8 count)
-{
-    ASSERT(count > 0 && count < 32);
-
-    u32 result = 0;
-    for (size_t i = 0; i < count; i++) {
-        result |= read() << i;
-    }
-    return result;
-}
-
-Vector<u8> DeflateStream::generate_literal_length_codes() const
-{
-    Vector<u8> ll_codes;
-    ll_codes.resize(288);
-    memset(ll_codes.data() + 0, 8, 144 - 0);
-    memset(ll_codes.data() + 144, 9, 256 - 144);
-    memset(ll_codes.data() + 256, 7, 280 - 256);
-    memset(ll_codes.data() + 280, 8, 288 - 280);
-    return ll_codes;
-}
-
-Vector<u8> DeflateStream::generate_fixed_distance_codes() const
-{
-    Vector<u8> fd_codes;
-    fd_codes.resize(32);
-    memset(fd_codes.data(), 5, 32);
-    return fd_codes;
-}
-
-CanonicalCode::CanonicalCode(Vector<u8> codes)
-{
     m_symbol_codes.resize(codes.size());
     m_symbol_values.resize(codes.size());
 
     auto allocated_symbols_count = 0;
     auto next_code = 0;
 
-    for (size_t code_length = 1; code_length <= 15; code_length++) {
+    for (size_t code_length = 1; code_length <= 15; ++code_length) {
         next_code <<= 1;
         auto start_bit = 1 << code_length;
 
-        for (size_t symbol = 0; symbol < codes.size(); symbol++) {
-            if (codes.at(symbol) != code_length) {
+        for (size_t symbol = 0; symbol < codes.size(); ++symbol) {
+            if (codes[symbol] != code_length)
                 continue;
-            }
 
             if (next_code > start_bit) {
                 dbg() << "Canonical code overflows the huffman tree";
@@ -391,38 +73,284 @@ CanonicalCode::CanonicalCode(Vector<u8> codes)
     }
 }
 
-static i32 binary_search(Vector<u32>& heystack, u32 needle)
+const DeflateDecompressor::CanonicalCode& DeflateDecompressor::CanonicalCode::fixed_literal_codes()
 {
-    i32 low = 0;
-    i32 high = heystack.size();
+    static CanonicalCode* code = nullptr;
 
-    while (low <= high) {
-        u32 mid = (low + high) >> 1;
-        u32 value = heystack.at(mid);
+    if (code)
+        return *code;
 
-        if (value < needle) {
-            low = mid + 1;
-        } else if (value > needle) {
-            high = mid - 1;
-        } else {
-            return mid;
-        }
-    }
+    FixedArray<u8> data { 288 };
+    data.bytes().slice(0, 144 - 0).fill(8);
+    data.bytes().slice(144, 256 - 144).fill(9);
+    data.bytes().slice(256, 280 - 256).fill(7);
+    data.bytes().slice(280, 288 - 280).fill(8);
 
-    return -1;
+    code = new CanonicalCode(data);
+    return *code;
 }
 
-u32 CanonicalCode::next_symbol(BitStreamReader& reader)
+const DeflateDecompressor::CanonicalCode& DeflateDecompressor::CanonicalCode::fixed_distance_codes()
 {
-    auto code_bits = 1;
+    static CanonicalCode* code = nullptr;
+
+    if (code)
+        return *code;
+
+    FixedArray<u8> data { 32 };
+    data.bytes().fill(5);
+
+    code = new CanonicalCode(data);
+    return *code;
+}
+
+u32 DeflateDecompressor::CanonicalCode::read_symbol(InputBitStream& stream) const
+{
+    u32 code_bits = 1;
 
     for (;;) {
-        code_bits = code_bits << 1 | reader.read();
-        i32 index = binary_search(m_symbol_codes, code_bits);
-        if (index >= 0) {
-            return m_symbol_values.at(index);
-        }
+        code_bits = code_bits << 1 | stream.read_bits(1);
+
+        size_t index;
+        if (AK::binary_search(m_symbol_codes.span(), code_bits, AK::integral_compare<u32>, &index))
+            return m_symbol_values[index];
     }
+}
+
+DeflateDecompressor::CompressedBlock::CompressedBlock(DeflateDecompressor& decompressor, CanonicalCode literal_codes, Optional<CanonicalCode> distance_codes)
+    : m_decompressor(decompressor)
+    , m_literal_codes(literal_codes)
+    , m_distance_codes(distance_codes)
+{
+}
+
+bool DeflateDecompressor::CompressedBlock::try_read_more()
+{
+    if (m_eof == true)
+        return false;
+
+    const auto symbol = m_literal_codes.read_symbol(m_decompressor.m_input_stream);
+
+    if (symbol < 256) {
+        m_decompressor.m_output_stream << static_cast<u8>(symbol);
+        return true;
+    } else if (symbol == 256) {
+        m_eof = true;
+        return false;
+    } else {
+        ASSERT(m_distance_codes.has_value());
+
+        const auto run_length = m_decompressor.decode_run_length(symbol);
+        const auto distance = m_decompressor.decode_distance(m_distance_codes.value().read_symbol(m_decompressor.m_input_stream));
+
+        auto bytes = m_decompressor.m_output_stream.reserve_contigous_space(run_length);
+        m_decompressor.m_output_stream.read(bytes, distance + bytes.size());
+
+        return true;
+    }
+}
+
+DeflateDecompressor::UncompressedBlock::UncompressedBlock(DeflateDecompressor& decompressor, size_t length)
+    : m_decompressor(decompressor)
+    , m_bytes_remaining(length)
+{
+}
+
+bool DeflateDecompressor::UncompressedBlock::try_read_more()
+{
+    if (m_bytes_remaining == 0)
+        return false;
+
+    const auto nread = min(m_bytes_remaining, m_decompressor.m_output_stream.remaining_contigous_space());
+    m_bytes_remaining -= nread;
+
+    m_decompressor.m_input_stream >> m_decompressor.m_output_stream.reserve_contigous_space(nread);
+
+    return true;
+}
+
+DeflateDecompressor::DeflateDecompressor(InputStream& stream)
+    : m_input_stream(stream)
+{
+}
+
+DeflateDecompressor::~DeflateDecompressor()
+{
+    if (m_state == State::ReadingCompressedBlock)
+        m_compressed_block.~CompressedBlock();
+    if (m_state == State::ReadingUncompressedBlock)
+        m_uncompressed_block.~UncompressedBlock();
+}
+
+size_t DeflateDecompressor::read(Bytes bytes)
+{
+    // FIXME: There are surely a ton of bugs because we don't check for read errors
+    //        very often.
+
+    if (m_state == State::Idle) {
+        if (m_read_final_bock)
+            return 0;
+
+        m_read_final_bock = m_input_stream.read_bit();
+        const auto block_type = m_input_stream.read_bits(2);
+
+        if (block_type == 0b00) {
+            m_input_stream.align_to_byte_boundary();
+
+            LittleEndian<u16> length, negated_length;
+            m_input_stream >> length >> negated_length;
+
+            if ((length ^ 0xffff) != negated_length) {
+                m_error = true;
+                return 0;
+            }
+
+            m_state = State::ReadingUncompressedBlock;
+            new (&m_uncompressed_block) UncompressedBlock(*this, length);
+
+            return read(bytes);
+        }
+
+        if (block_type == 0b01) {
+            m_state = State::ReadingCompressedBlock;
+            new (&m_compressed_block) CompressedBlock(*this, CanonicalCode::fixed_literal_codes(), CanonicalCode::fixed_distance_codes());
+
+            return read(bytes);
+        }
+
+        if (block_type == 0b10) {
+            CanonicalCode literal_codes, distance_codes;
+            decode_codes(literal_codes, distance_codes);
+            new (&m_compressed_block) CompressedBlock(*this, literal_codes, distance_codes);
+
+            return read(bytes);
+        }
+
+        ASSERT_NOT_REACHED();
+    }
+
+    if (m_state == State::ReadingCompressedBlock) {
+        auto nread = m_output_stream.read(bytes);
+
+        while (nread < bytes.size() && m_compressed_block.try_read_more()) {
+            nread += m_output_stream.read(bytes.slice(nread));
+        }
+
+        if (nread == bytes.size())
+            return nread;
+
+        m_compressed_block.~CompressedBlock();
+        m_state = State::Idle;
+
+        return nread + read(bytes.slice(nread));
+    }
+
+    if (m_state == State::ReadingUncompressedBlock) {
+        auto nread = m_output_stream.read(bytes);
+
+        while (nread < bytes.size() && m_uncompressed_block.try_read_more()) {
+            nread += m_output_stream.read(bytes.slice(nread));
+        }
+
+        if (nread == bytes.size())
+            return nread;
+
+        m_uncompressed_block.~UncompressedBlock();
+        m_state = State::Idle;
+
+        return nread + read(bytes.slice(nread));
+    }
+
+    ASSERT_NOT_REACHED();
+}
+
+bool DeflateDecompressor::read_or_error(Bytes bytes)
+{
+    if (read(bytes) < bytes.size()) {
+        m_error = true;
+        return false;
+    }
+
+    return true;
+}
+
+bool DeflateDecompressor::discard_or_error(size_t count)
+{
+    u8 buffer[4096];
+
+    size_t ndiscarded = 0;
+    while (ndiscarded < count) {
+        if (eof()) {
+            m_error = true;
+            return false;
+        }
+
+        ndiscarded += read({ buffer, min<size_t>(count - ndiscarded, 4096) });
+    }
+
+    return true;
+}
+
+bool DeflateDecompressor::eof() const { return m_state == State::Idle && m_read_final_bock; }
+
+ByteBuffer DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
+{
+    InputMemoryStream memory_stream { bytes };
+    InputBitStream bit_stream { memory_stream };
+    DeflateDecompressor deflate_stream { bit_stream };
+
+    auto buffer = ByteBuffer::create_uninitialized(4096);
+
+    size_t nread = 0;
+    while (!deflate_stream.eof()) {
+        nread += deflate_stream.read(buffer.bytes().slice(nread));
+        if (buffer.size() - nread < 4096)
+            buffer.grow(buffer.size() + 4096);
+    }
+
+    buffer.trim(nread);
+    return buffer;
+}
+
+u32 DeflateDecompressor::decode_run_length(u32 symbol)
+{
+    // FIXME: I can't quite follow the algorithm here, but it seems to work.
+
+    if (symbol <= 264)
+        return symbol - 254;
+
+    if (symbol <= 284) {
+        auto extra_bits = (symbol - 261) / 4;
+        return (((symbol - 265) % 4 + 4) << extra_bits) + 3 + m_input_stream.read_bits(extra_bits);
+    }
+
+    if (symbol == 285)
+        return 258;
+
+    ASSERT_NOT_REACHED();
+}
+
+u32 DeflateDecompressor::decode_distance(u32 symbol)
+{
+    // FIXME: I can't quite follow the algorithm here, but it seems to work.
+
+    if (symbol <= 3)
+        return symbol + 1;
+
+    if (symbol <= 29) {
+        auto extra_bits = (symbol / 2) - 1;
+        return ((symbol % 2 + 2) << extra_bits) + 1 + m_input_stream.read_bits(extra_bits);
+    }
+
+    ASSERT_NOT_REACHED();
+}
+
+void DeflateDecompressor::decode_codes(CanonicalCode&, CanonicalCode&)
+{
+    // FIXME: This was already implemented but I removed it because it was quite chaotic and untested.
+    //        I am planning to come back to this. @asynts
+    //        https://github.com/SerenityOS/serenity/blob/208cb995babb13e0af07bb9d3219f0a9fe7bca7d/Libraries/LibCompress/Deflate.cpp#L144-L242
+    TODO();
 }
 
 }

--- a/Libraries/LibCompress/Zlib.cpp
+++ b/Libraries/LibCompress/Zlib.cpp
@@ -55,9 +55,9 @@ Zlib::Zlib(ReadonlyBytes data)
     m_data_bytes = data.slice(2, data.size() - 2 - 4);
 }
 
-Vector<u8> Zlib::decompress()
+ByteBuffer Zlib::decompress()
 {
-    return DeflateStream::decompress_all(m_data_bytes);
+    return DeflateDecompressor::decompress_all(m_data_bytes);
 }
 
 u32 Zlib::checksum()

--- a/Libraries/LibCompress/Zlib.h
+++ b/Libraries/LibCompress/Zlib.h
@@ -26,17 +26,24 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/Span.h>
 #include <AK/Types.h>
-#include <AK/Vector.h>
 
 namespace Compress {
+
 class Zlib {
 public:
     Zlib(ReadonlyBytes data);
 
-    Vector<u8> decompress();
+    ByteBuffer decompress();
     u32 checksum();
+
+    static ByteBuffer decompress_all(ReadonlyBytes bytes)
+    {
+        Zlib zlib { bytes };
+        return zlib.decompress();
+    }
 
 private:
     u8 m_compression_method;


### PR DESCRIPTION
In #3220 I've already tried to make this a stream implementation, but I think I took the wrong approach. It is possible to read a DEFLATE stream while only looking at 64KiB of data at a time, which this implementation now does. (Previously, I read an entire block at once which could be significantly more than 64KiB and required allocating buffers on the heap.)

There are still a few FIXMEs in this implementation but I want to do some other unrelated stuff first.
