### PR TITLE
WindowServer: Fix minor flicker with transparent windows

### DIFF
--- a/Services/WindowServer/Compositor.cpp
+++ b/Services/WindowServer/Compositor.cpp
@@ -354,8 +354,10 @@ void Compositor::compose()
                 painter.blit(dst, *backing_store, dirty_rect_in_backing_coordinates, window.opacity());
             }
 
-            for (auto background_rect : window.rect().shatter(backing_rect))
-                painter.fill_rect(background_rect, wm.palette().window());
+            if (window.is_opaque()) {
+                for (auto background_rect : window.rect().shatter(backing_rect))
+                    painter.fill_rect(background_rect, wm.palette().window());
+            }
         };
 
         auto& dirty_rects = window.dirty_rects();


### PR DESCRIPTION
Do not fill the backing store mismatch area with the solid window
color if the window is transparent. This caused some minor flicker
when such a window is e.g. snapped to the left/right or maximized.