### PR TITLE
LibGUI: Remove unused String member

### DIFF
--- a/Libraries/LibGUI/Event.h
+++ b/Libraries/LibGUI/Event.h
@@ -309,7 +309,6 @@ private:
     u8 m_modifiers { 0 };
     u32 m_code_point { 0 };
     u32 m_scancode { 0 };
-    String m_text2;
 };
 
 class MouseEvent final : public Event {


### PR DESCRIPTION
Just a small thing that I noticed a while ago. Nothing ever accesses the field, and `m_text2` appears nowhere else in the entire project. Weird :P