### PR TITLE
Kernel: Release page tables when no longer needed

### DIFF
--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -140,6 +140,7 @@ public:
         m_raw |= value & 0xfffff000;
     }
 
+    bool is_null() const { return m_raw == 0; }
     void clear() { m_raw = 0; }
 
     u64 raw() const { return m_raw; }
@@ -234,6 +235,7 @@ public:
     bool is_execute_disabled() const { return raw() & NoExecute; }
     void set_execute_disabled(bool b) { set_bit(NoExecute, b); }
 
+    bool is_null() const { return m_raw == 0; }
     void clear() { m_raw = 0; }
 
     void set_bit(u64 bit, bool value)

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -193,8 +193,9 @@ private:
     PageDirectoryEntry* quickmap_pd(PageDirectory&, size_t pdpt_index);
     PageTableEntry* quickmap_pt(PhysicalAddress);
 
-    const PageTableEntry* pte(const PageDirectory&, VirtualAddress);
+    PageTableEntry* pte(const PageDirectory&, VirtualAddress);
     PageTableEntry& ensure_pte(PageDirectory&, VirtualAddress);
+    void release_pte(PageDirectory&, VirtualAddress, bool);
 
     RefPtr<PageDirectory> m_kernel_page_directory;
     RefPtr<PhysicalPage> m_low_page_table;

--- a/Kernel/VM/PageDirectory.h
+++ b/Kernel/VM/PageDirectory.h
@@ -66,7 +66,7 @@ private:
     RangeAllocator m_identity_range_allocator;
     RefPtr<PhysicalPage> m_directory_table;
     RefPtr<PhysicalPage> m_directory_pages[4];
-    HashTable<RefPtr<PhysicalPage>> m_physical_pages;
+    HashMap<u32, RefPtr<PhysicalPage>> m_page_tables;
 };
 
 }

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -266,10 +266,10 @@ void Region::unmap(ShouldDeallocateVirtualMemoryRange deallocate_range)
 {
     ScopedSpinLock lock(s_mm_lock);
     ASSERT(m_page_directory);
-    for (size_t i = 0; i < page_count(); ++i) {
+    size_t count = page_count();
+    for (size_t i = 0; i < count; ++i) {
         auto vaddr = vaddr_from_page_index(i);
-        auto& pte = MM.ensure_pte(*m_page_directory, vaddr);
-        pte.clear();
+        MM.release_pte(*m_page_directory, vaddr, i == count - 1);
 #ifdef MM_DEBUG
         auto* page = physical_page(i);
         dbg() << "MM: >> Unmapped " << vaddr << " => P" << String::format("%p", page ? page->paddr().get() : 0) << " <<";


### PR DESCRIPTION
When unmapping regions, check if page tables can be freed.

This is a follow-up change for #3254.

Turns out, it it should have remained a `HashMap`. This brings it back but uses a more appropriate key, which we can use to free page tables that are no longer needed. I believe turning it into a `HashTable` introduced a page table leak because we would never free page tables unless the entire `PageDirectory` was freed (process terminated).