### PR TITLE
Enable "-Wmissing-declarations"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ add_custom_target(check-style
     USES_TERMINAL
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -std=c++2a -fdiagnostics-color=always")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wmissing-declarations -std=c++2a -fdiagnostics-color=always")
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fconcepts")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/DevTools/HackStudio/main.cpp
+++ b/DevTools/HackStudio/main.cpp
@@ -133,7 +133,7 @@ void open_project(String);
 void open_file(const String&);
 bool make_is_available();
 
-EditorWrapper& current_editor_wrapper()
+static EditorWrapper& current_editor_wrapper()
 {
     ASSERT(g_current_editor_wrapper);
     return *g_current_editor_wrapper;
@@ -156,7 +156,7 @@ static String get_full_path_of_serenity_source(const String& file)
     return String::format("%s/%s", serenity_sources_base.string().characters(), relative_path_builder.to_string().characters());
 }
 
-NonnullRefPtr<EditorWrapper> get_editor_of_file(const String& file)
+static NonnullRefPtr<EditorWrapper> get_editor_of_file(const String& file)
 {
     String file_path = file;
 
@@ -177,7 +177,7 @@ static String get_project_executable_path()
     return g_project->path().substring(0, g_project->path().index_of(".").value());
 }
 
-int main_impl(int argc, char** argv)
+static int main_impl(int argc, char** argv)
 {
     if (pledge("stdio tty accept rpath cpath wpath shared_buffer proc exec unix fattr thread", nullptr) < 0) {
         perror("pledge");

--- a/Userland/test-compress.cpp
+++ b/Userland/test-compress.cpp
@@ -29,7 +29,7 @@
 #include <LibCompress/Deflate.h>
 #include <LibCompress/Zlib.h>
 
-bool compare(ReadonlyBytes lhs, ReadonlyBytes rhs)
+static bool compare(ReadonlyBytes lhs, ReadonlyBytes rhs)
 {
     if (lhs.size() != rhs.size())
         return false;


### PR DESCRIPTION
All the heavy lifting was already done in #3096.

From here on, build system and CI will ensure that all new code defines compilation-unit-only code as 'static', and that dead code can be found more easily. Also, this style encourages type checking by suggesting that you put a proper declaration in a shared header.