### PR TITLE
LibCrypto: Do not silently ignore key size mismatch

### DIFF
--- a/Libraries/LibCrypto/Cipher/AES.cpp
+++ b/Libraries/LibCrypto/Cipher/AES.cpp
@@ -67,7 +67,7 @@ void AESCipherKey::expand_encrypt_key(const ByteBuffer& user_key, size_t bits)
 
     ASSERT(!user_key.is_null());
     ASSERT(is_valid_key_size(bits));
-    ASSERT(user_key.size() >= bits / 8);
+    ASSERT(user_key.size() == bits / 8);
 
     round_key = round_keys();
 


### PR DESCRIPTION
Before, when the actually passed key was too long, the extra bytes were silently
ignored. This can lead to all sorts of trouble, so ... don't do that.

The original intention was maybe to support non-integer amounts of key bytes.
But that doesn't happen anyway with AES.

CC @nico, in case I misunderstood the intention behind 8d3d0054ed2adeddb79c00d4bd6afeee12510e2d.