### PR TITLE
Spreadsheet: Cell types (very basic) and implicit integers

### DIFF
--- a/Applications/Spreadsheet/CMakeLists.txt
+++ b/Applications/Spreadsheet/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(SOURCES
     Cell.cpp
     CellSyntaxHighlighter.cpp
+    CellType/Identity.cpp
+    CellType/Numeric.cpp
+    CellType/String.cpp
+    CellType/Type.cpp
     HelpWindow.cpp
     JSIntegration.cpp
     Spreadsheet.cpp

--- a/Applications/Spreadsheet/CMakeLists.txt
+++ b/Applications/Spreadsheet/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    Cell.cpp
     CellSyntaxHighlighter.cpp
     HelpWindow.cpp
     JSIntegration.cpp

--- a/Applications/Spreadsheet/Cell.cpp
+++ b/Applications/Spreadsheet/Cell.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Cell.h"
+#include "Spreadsheet.h"
+#include <AK/StringBuilder.h>
+
+namespace Spreadsheet {
+
+void Cell::set_data(String new_data)
+{
+    if (data == new_data)
+        return;
+
+    if (new_data.starts_with("=")) {
+        new_data = new_data.substring(1, new_data.length() - 1);
+        kind = Formula;
+    } else {
+        kind = LiteralString;
+    }
+
+    data = move(new_data);
+    dirty = true;
+    evaluated_externally = false;
+}
+
+void Cell::set_data(JS::Value new_data)
+{
+    dirty = true;
+    evaluated_externally = true;
+
+    StringBuilder builder;
+
+    builder.append(new_data.to_string_without_side_effects());
+    data = builder.build();
+
+    evaluated_data = move(new_data);
+}
+
+void Cell::update_data()
+{
+    TemporaryChange cell_change { sheet->current_evaluated_cell(), this };
+    if (!dirty)
+        return;
+
+    dirty = false;
+    if (kind == Formula) {
+        if (!evaluated_externally)
+            evaluated_data = sheet->evaluate(data, this);
+    }
+
+    for (auto& ref : referencing_cells) {
+        if (ref) {
+            ref->dirty = true;
+            ref->update();
+        }
+    }
+}
+
+void Cell::update()
+{
+    sheet->update(*this);
+}
+
+JS::Value Cell::js_data()
+{
+    if (dirty)
+        update();
+
+    if (kind == Formula)
+        return evaluated_data;
+
+    return JS::js_string(sheet->interpreter(), data);
+}
+
+String Cell::source() const
+{
+    StringBuilder builder;
+    if (kind == Formula)
+        builder.append('=');
+    builder.append(data);
+    return builder.to_string();
+}
+
+// FIXME: Find a better way to figure out dependencies
+void Cell::reference_from(Cell* other)
+{
+    if (!other || other == this)
+        return;
+
+    if (!referencing_cells.find([other](auto& ptr) { return ptr.ptr() == other; }).is_end())
+        return;
+
+    referencing_cells.append(other->make_weak_ptr());
+}
+
+}

--- a/Applications/Spreadsheet/Cell.h
+++ b/Applications/Spreadsheet/Cell.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "CellType/Type.h"
 #include "Forward.h"
 #include "JSIntegration.h"
 #include <AK/String.h>
@@ -57,6 +58,16 @@ struct Cell : public Weakable<Cell> {
     void set_data(String new_data);
     void set_data(JS::Value new_data);
 
+    void set_type(const StringView& name);
+    void set_type_metadata(CellTypeMetadata&&);
+
+    String typed_display() const;
+    JS::Value typed_js_data() const;
+
+    const CellType& type() const;
+    const CellTypeMetadata& type_metadata() const { return m_type_metadata; }
+    CellTypeMetadata& type_metadata() { return m_type_metadata; }
+
     String source() const;
 
     JS::Value js_data();
@@ -76,6 +87,8 @@ struct Cell : public Weakable<Cell> {
     Kind kind { LiteralString };
     WeakPtr<Sheet> sheet;
     Vector<WeakPtr<Cell>> referencing_cells;
+    const CellType* m_type { nullptr };
+    CellTypeMetadata m_type_metadata;
 
 private:
     void update_data();

--- a/Applications/Spreadsheet/CellType/Identity.cpp
+++ b/Applications/Spreadsheet/CellType/Identity.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Identity.h"
+#include "../Cell.h"
+#include "../Spreadsheet.h"
+
+namespace Spreadsheet {
+
+IdentityCell::IdentityCell()
+    : CellType("Identity")
+{
+}
+
+IdentityCell::~IdentityCell()
+{
+}
+
+String IdentityCell::display(Cell& cell, const CellTypeMetadata&) const
+{
+    return cell.js_data().to_string_without_side_effects();
+}
+
+JS::Value IdentityCell::js_value(Cell& cell, const CellTypeMetadata&) const
+{
+    return cell.js_data();
+}
+
+}

--- a/Applications/Spreadsheet/CellType/Identity.h
+++ b/Applications/Spreadsheet/CellType/Identity.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+
+namespace Spreadsheet {
+
+class IdentityCell : public CellType {
+
+public:
+    IdentityCell();
+    virtual ~IdentityCell() override;
+    virtual String display(Cell&, const CellTypeMetadata&) const override;
+    virtual JS::Value js_value(Cell&, const CellTypeMetadata&) const override;
+};
+
+}

--- a/Applications/Spreadsheet/CellType/Numeric.cpp
+++ b/Applications/Spreadsheet/CellType/Numeric.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Numeric.h"
+#include "../Cell.h"
+#include "../Spreadsheet.h"
+
+namespace Spreadsheet {
+
+NumericCell::NumericCell()
+    : CellType("Numeric")
+{
+}
+
+NumericCell::~NumericCell()
+{
+}
+
+String NumericCell::display(Cell& cell, const CellTypeMetadata& metadata) const
+{
+    auto value = js_value(cell, metadata);
+    String string;
+    if (metadata.format.is_null())
+        string = value.to_string_without_side_effects();
+    else
+        string = String::format(metadata.format.characters(), value.to_double(cell.sheet->interpreter())); // FIXME: Somehow make this format less dependent on 'double'.
+
+    if (metadata.length >= 0)
+        return string.substring(0, metadata.length);
+
+    return string;
+}
+
+JS::Value NumericCell::js_value(Cell& cell, const CellTypeMetadata&) const
+{
+    return cell.js_data().to_number(cell.sheet->interpreter());
+}
+
+}

--- a/Applications/Spreadsheet/CellType/Numeric.h
+++ b/Applications/Spreadsheet/CellType/Numeric.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+
+namespace Spreadsheet {
+
+class NumericCell : public CellType {
+
+public:
+    NumericCell();
+    virtual ~NumericCell() override;
+    virtual String display(Cell&, const CellTypeMetadata&) const override;
+    virtual JS::Value js_value(Cell&, const CellTypeMetadata&) const override;
+};
+
+}

--- a/Applications/Spreadsheet/CellType/String.cpp
+++ b/Applications/Spreadsheet/CellType/String.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "String.h"
+#include "../Cell.h"
+#include "../Spreadsheet.h"
+
+namespace Spreadsheet {
+
+StringCell::StringCell()
+    : CellType("String")
+{
+}
+
+StringCell::~StringCell()
+{
+}
+
+String StringCell::display(Cell& cell, const CellTypeMetadata& metadata) const
+{
+    auto string = cell.js_data().to_string_without_side_effects();
+    if (metadata.length >= 0)
+        return string.substring(0, metadata.length);
+
+    return string;
+}
+
+JS::Value StringCell::js_value(Cell& cell, const CellTypeMetadata& metadata) const
+{
+    auto string = display(cell, metadata);
+    return JS::js_string(cell.sheet->interpreter(), string);
+}
+
+}

--- a/Applications/Spreadsheet/CellType/String.h
+++ b/Applications/Spreadsheet/CellType/String.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Type.h"
+
+namespace Spreadsheet {
+
+class StringCell : public CellType {
+
+public:
+    StringCell();
+    virtual ~StringCell() override;
+    virtual String display(Cell&, const CellTypeMetadata&) const override;
+    virtual JS::Value js_value(Cell&, const CellTypeMetadata&) const override;
+};
+
+}

--- a/Applications/Spreadsheet/CellType/Type.cpp
+++ b/Applications/Spreadsheet/CellType/Type.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Type.h"
+#include "Identity.h"
+#include "Numeric.h"
+#include "String.h"
+#include <AK/HashMap.h>
+#include <AK/OwnPtr.h>
+
+static HashMap<String, Spreadsheet::CellType*> s_cell_types;
+static Spreadsheet::StringCell s_string_cell;
+static Spreadsheet::NumericCell s_numeric_cell;
+static Spreadsheet::IdentityCell s_identity_cell;
+
+namespace Spreadsheet {
+
+const CellType* CellType::get_by_name(const StringView& name)
+{
+    return s_cell_types.get(name).value_or(nullptr);
+}
+
+CellType::CellType(const StringView& name)
+{
+    ASSERT(!s_cell_types.contains(name));
+    s_cell_types.set(name, this);
+}
+
+}

--- a/Applications/Spreadsheet/CellType/Type.h
+++ b/Applications/Spreadsheet/CellType/Type.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "../Forward.h"
+#include <AK/Forward.h>
+#include <AK/String.h>
+#include <LibJS/Forward.h>
+
+namespace Spreadsheet {
+
+struct CellTypeMetadata {
+    int length { -1 };
+    String format;
+};
+
+class CellType {
+public:
+    static const CellType* get_by_name(const StringView&);
+
+    virtual String display(Cell&, const CellTypeMetadata&) const = 0;
+    virtual JS::Value js_value(Cell&, const CellTypeMetadata&) const = 0;
+    virtual ~CellType() { }
+
+protected:
+    CellType(const StringView& name);
+};
+
+}

--- a/Applications/Spreadsheet/Forward.h
+++ b/Applications/Spreadsheet/Forward.h
@@ -26,49 +26,13 @@
 
 #pragma once
 
-#include "Forward.h"
-#include "Spreadsheet.h"
-#include <AK/NonnullOwnPtrVector.h>
-#include <AK/Result.h>
-
 namespace Spreadsheet {
 
-class Workbook {
-public:
-    Workbook(NonnullRefPtrVector<Sheet>&& sheets);
-
-    Result<bool, String> save(const StringView& filename);
-    Result<bool, String> load(const StringView& filename);
-
-    const String& current_filename() const { return m_current_filename; }
-    bool set_filename(const String& filename);
-
-    bool has_sheets() const { return !m_sheets.is_empty(); }
-
-    const NonnullRefPtrVector<Sheet>& sheets() const { return m_sheets; }
-    NonnullRefPtrVector<Sheet> sheets() { return m_sheets; }
-
-    Sheet& add_sheet(const StringView& name)
-    {
-        auto sheet = Sheet::construct(name, *this);
-        m_sheets.append(sheet);
-        return *sheet;
-    }
-
-    JS::Interpreter& interpreter() { return *m_interpreter; }
-    const JS::Interpreter& interpreter() const { return *m_interpreter; }
-
-    JS::GlobalObject& global_object() { return m_interpreter->global_object(); }
-    const JS::GlobalObject& global_object() const { return m_interpreter->global_object(); }
-
-    WorkbookObject* workbook_object() { return m_workbook_object; }
-
-private:
-    NonnullRefPtrVector<Sheet> m_sheets;
-    NonnullOwnPtr<JS::Interpreter> m_interpreter;
-    WorkbookObject* m_workbook_object { nullptr };
-
-    String m_current_filename;
-};
+struct Cell;
+class Sheet;
+struct Position;
+class Workbook;
+class WorkbookObject;
+class SheetGlobalObject;
 
 }

--- a/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Applications/Spreadsheet/JSIntegration.cpp
@@ -49,7 +49,7 @@ JS::Value SheetGlobalObject::get(const JS::PropertyName& name, JS::Value receive
         if (auto pos = Sheet::parse_cell_name(name.as_string()); pos.has_value()) {
             auto& cell = m_sheet.ensure(pos.value());
             cell.reference_from(m_sheet.current_evaluated_cell());
-            return cell.js_data();
+            return cell.typed_js_data();
         }
     }
 

--- a/Applications/Spreadsheet/JSIntegration.h
+++ b/Applications/Spreadsheet/JSIntegration.h
@@ -26,13 +26,11 @@
 
 #pragma once
 
+#include "Forward.h"
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/GlobalObject.h>
 
 namespace Spreadsheet {
-
-class Sheet;
-class Workbook;
 
 class SheetGlobalObject : public JS::GlobalObject {
     JS_OBJECT(SheetGlobalObject, JS::GlobalObject);

--- a/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -50,34 +50,33 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
         return {};
 
     if (role == GUI::ModelRole::Display) {
-        const auto* value = m_sheet->at({ m_sheet->column(index.column()), (size_t)index.row() });
-        if (!value)
+        const auto* cell = m_sheet->at({ m_sheet->column(index.column()), (size_t)index.row() });
+        if (!cell)
             return String::empty();
 
-        if (value->kind == Spreadsheet::Cell::Formula) {
-            if (auto object = as_error(value->evaluated_data)) {
+        if (cell->kind == Spreadsheet::Cell::Formula) {
+            if (auto object = as_error(cell->evaluated_data)) {
                 StringBuilder builder;
                 auto error = object->get("message").to_string_without_side_effects();
                 builder.append("Error: ");
                 builder.append(error);
                 return builder.to_string();
             }
-            return value->evaluated_data.is_empty() ? "" : value->evaluated_data.to_string_without_side_effects();
         }
 
-        return value->data;
+        return cell->typed_display();
     }
 
     if (role == GUI::ModelRole::TextAlignment)
         return {};
 
     if (role == GUI::ModelRole::ForegroundColor) {
-        const auto* value = m_sheet->at({ m_sheet->column(index.column()), (size_t)index.row() });
-        if (!value)
+        const auto* cell = m_sheet->at({ m_sheet->column(index.column()), (size_t)index.row() });
+        if (!cell)
             return {};
 
-        if (value->kind == Spreadsheet::Cell::Formula) {
-            if (as_error(value->evaluated_data))
+        if (cell->kind == Spreadsheet::Cell::Formula) {
+            if (as_error(cell->evaluated_data))
                 return Color(Color::Red);
         }
 


### PR DESCRIPTION
This adds a generic interface for cell types and hooks it up.
There is no way to set these from the UI, and so they're not saved anywhere yet.
Also implicitly converts numeric values (strictly integers) to numeric javascript values, as `numbery-looking + numbery-looking === string` is not very interesting.

This implicit thingy is probably temporary, until a proper UI is added for these types