### PR TITLE
LibJS: Demonstrate and fix weird behaviour with 'break'

### DIFF
--- a/Libraries/LibJS/Interpreter.cpp
+++ b/Libraries/LibJS/Interpreter.cpp
@@ -87,7 +87,7 @@ Value Interpreter::run(GlobalObject& global_object, const Statement& statement, 
     for (auto& node : block.children()) {
         m_last_value = node.execute(*this, global_object);
         if (should_unwind()) {
-            if (should_unwind_until(ScopeType::Breakable, block.label()))
+            if (!block.label().is_null() && should_unwind_until(ScopeType::Breakable, block.label()))
                 stop_unwind();
             break;
         }

--- a/Libraries/LibJS/Tests/loops/break-basic.js
+++ b/Libraries/LibJS/Tests/loops/break-basic.js
@@ -1,0 +1,29 @@
+test("Toplevel break inside loop", () => {
+    var j = 0;
+    for (var i = 0; i < 9; ++i) {
+        break;
+        ++j;
+    }
+    expect(j).toBe(0);
+});
+
+test("break inside sub-blocks", () => {
+    var j = 0;
+    for (var i = 0; i < 9; ++i) {
+        if (j == 4)
+            break;
+        ++j;
+    }
+    expect(j).toBe(4);
+});
+
+test("break inside curly sub-blocks", () => {
+    var j = 0;
+    for (var i = 0; i < 9; ++i) {
+        if (j == 4) {
+            break;
+        }
+        ++j;
+    }
+    expect(j).toBe(4);
+});


### PR DESCRIPTION
This demos and fixes a `break` issue that shows up as this:
```js
var j = 0;
for (var i = 0; i < 9; ++i) {
    if (j == 4) {
        break; // This doesn't break!
    }
}
```

cc @linusg, I have no idea if this is the right fix

(does `test-js` actually fail the CI?
    https://travis-ci.com/github/SerenityOS/serenity/builds/181823301#L3348
    Nope!)