### PR TITLE
AK: Don't swap endianness when writing endian wrappers to stream.

### DIFF
--- a/AK/Endian.h
+++ b/AK/Endian.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Forward.h>
 #include <AK/Platform.h>
 
 namespace AK {
@@ -71,9 +72,21 @@ ALWAYS_INLINE T convert_between_host_and_network_endian(T value)
 }
 
 template<typename T>
+class LittleEndian;
+
+template<typename T>
+InputStream& operator>>(InputStream&, LittleEndian<T>&);
+
+template<typename T>
+OutputStream& operator<<(OutputStream&, LittleEndian<T>);
+
+template<typename T>
 class [[gnu::packed]] LittleEndian
 {
 public:
+    friend InputStream& operator>><T>(InputStream&, LittleEndian<T>&);
+    friend OutputStream& operator<<<T>(OutputStream&, LittleEndian<T>);
+
     LittleEndian() { }
 
     LittleEndian(T value)
@@ -88,9 +101,21 @@ private:
 };
 
 template<typename T>
+class BigEndian;
+
+template<typename T>
+InputStream& operator>>(InputStream&, BigEndian<T>&);
+
+template<typename T>
+OutputStream& operator<<(OutputStream&, BigEndian<T>);
+
+template<typename T>
 class [[gnu::packed]] BigEndian
 {
 public:
+    friend InputStream& operator>><T>(InputStream&, BigEndian<T>&);
+    friend OutputStream& operator<<<T>(OutputStream&, BigEndian<T>);
+
     BigEndian() { }
 
     BigEndian(T value)

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -76,33 +76,36 @@ class DuplexStream
     , public OutputStream {
 };
 
+inline InputStream& operator>>(InputStream& stream, Bytes bytes)
+{
+    stream.read_or_error(bytes);
+    return stream;
+}
+inline OutputStream& operator<<(OutputStream& stream, ReadonlyBytes bytes)
+{
+    stream.write_or_error(bytes);
+    return stream;
+}
+
 template<typename T>
 InputStream& operator>>(InputStream& stream, LittleEndian<T>& value)
 {
-    T temporary;
-    stream >> temporary;
-    value = temporary;
-    return stream;
+    return stream >> Bytes { &value.m_value, sizeof(value.m_value) };
 }
 template<typename T>
-InputStream& operator<<(InputStream& stream, LittleEndian<T> value)
+OutputStream& operator<<(OutputStream& stream, LittleEndian<T> value)
 {
-    stream << static_cast<T>(value);
-    return stream;
+    return stream << ReadonlyBytes { &value.m_value, sizeof(value.m_value) };
 }
 template<typename T>
 InputStream& operator>>(InputStream& stream, BigEndian<T>& value)
 {
-    T temporary;
-    stream >> temporary;
-    value = temporary;
-    return stream;
+    return stream >> Bytes { &value.m_value, sizeof(value.m_value) };
 }
 template<typename T>
-InputStream& operator<<(InputStream& stream, BigEndian<T> value)
+OutputStream& operator<<(OutputStream& stream, BigEndian<T> value)
 {
-    stream << static_cast<T>(value);
-    return stream;
+    return stream << ReadonlyBytes { &value.m_value, sizeof(value.m_value) };
 }
 
 template<typename T>
@@ -174,18 +177,6 @@ inline InputStream& operator>>(InputStream& stream, bool& value)
 inline OutputStream& operator<<(OutputStream& stream, bool value)
 {
     stream.write_or_error({ &value, sizeof(value) });
-    return stream;
-}
-
-inline InputStream& operator>>(InputStream& stream, Bytes bytes)
-{
-    stream.read_or_error(bytes);
-    return stream;
-}
-
-inline OutputStream& operator<<(OutputStream& stream, ReadonlyBytes bytes)
-{
-    stream.write_or_error(bytes);
     return stream;
 }
 

--- a/AK/Tests/TestStream.cpp
+++ b/AK/Tests/TestStream.cpp
@@ -181,4 +181,17 @@ TEST_CASE(duplex_wild_seeking)
     EXPECT(stream.eof());
 }
 
+TEST_CASE(read_endian_values)
+{
+    const u8 input[] { 0, 1, 2, 3, 4, 5, 6, 7 };
+    InputMemoryStream stream { { input, sizeof(input) } };
+
+    LittleEndian<u32> value1;
+    BigEndian<u32> value2;
+    stream >> value1 >> value2;
+
+    EXPECT_EQ(value1, 0x03020100u);
+    EXPECT_EQ(value2, 0x04050607u);
+}
+
 TEST_MAIN(Stream)


### PR DESCRIPTION
`LittleEndian<T>` should store it's value with little endianness and then implicitly convert it to the host endianness, `BigEndian<T>` similarly. However, the streaming operators just called the constructors or `static_cast<T>` which swapped the endianness if it didn't match the host endianness.

That actually worked for `LittleEndian<T>` because we have a little endian system, but for `BigEndian<T>` the values were read incorrectly, because the bytes were swapped twice instead of once, the first time in the constructor, the second time in the implicit conversion.

For some reason there was also an `InputStream& operator<<(InputStream&, LittleEndian<T>)` overload, that really should have been `OutputStream&`.
