### PR TITLE
LibCompress: Add GzipDecompressor implemenation and gunzip fontend.

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -34,9 +34,10 @@
 namespace AK {
 
 template<typename T>
-class alignas(T) [[nodiscard]] Optional {
+class alignas(T) [[nodiscard]] Optional
+{
 public:
-    Optional() {}
+    Optional() { }
 
     Optional(const T& value)
         : m_has_value(true)
@@ -51,13 +52,13 @@ public:
         new (&m_storage) T(value);
     }
 
-    Optional(T&& value)
+    Optional(T && value)
         : m_has_value(true)
     {
         new (&m_storage) T(move(value));
     }
 
-    Optional(Optional&& other)
+    Optional(Optional && other)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value()) {
@@ -114,6 +115,14 @@ public:
             value().~T();
             m_has_value = false;
         }
+    }
+
+    template<typename... Parameters>
+    ALWAYS_INLINE void emplace(Parameters && ... parameters)
+    {
+        clear();
+        m_has_value = true;
+        new (&m_storage) T(forward<Parameters>(parameters)...);
     }
 
     ALWAYS_INLINE bool has_value() const { return m_has_value; }

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -190,8 +190,6 @@ inline OutputStream& operator<<(OutputStream& stream, ReadonlyBytes bytes)
 }
 
 class InputMemoryStream final : public InputStream {
-    friend InputMemoryStream& operator>>(InputMemoryStream& stream, String& string);
-
 public:
     InputMemoryStream(ReadonlyBytes bytes)
         : m_bytes(bytes)

--- a/AK/String.h
+++ b/AK/String.h
@@ -29,6 +29,7 @@
 #include <AK/Forward.h>
 #include <AK/RefPtr.h>
 #include <AK/Stream.h>
+#include <AK/StringBuilder.h>
 #include <AK/StringImpl.h>
 #include <AK/StringUtils.h>
 #include <AK/Traits.h>
@@ -277,26 +278,29 @@ bool operator<=(const char*, const String&);
 
 String escape_html_entities(const StringView& html);
 
-inline InputMemoryStream& operator>>(InputMemoryStream& stream, String& string)
+inline InputStream& operator>>(InputStream& stream, String& string)
 {
-    // FIXME: There was some talking about a generic lexer class?
+    StringBuilder builder;
 
-    const auto start = stream.offset();
+    for (;;) {
+        if (stream.eof()) {
+            string = nullptr;
 
-    while (!stream.eof() && stream.m_bytes[stream.m_offset]) {
-        ++stream.m_offset;
+            // FIXME: We need an InputStream::set_error_flag method.
+            stream.discard_or_error(1);
+            return stream;
+        }
+
+        char next_char;
+        stream >> next_char;
+
+        if (next_char) {
+            builder.append(next_char);
+        } else {
+            string = builder.to_string();
+            return stream;
+        }
     }
-
-    if (stream.eof()) {
-        stream.m_error = true;
-        stream.m_offset = start;
-        string = nullptr;
-    } else {
-        string = String { stream.bytes().slice(start, stream.offset() - start) };
-        ++stream.m_offset;
-    }
-
-    return stream;
 }
 
 }

--- a/Libraries/LibCompress/CMakeLists.txt
+++ b/Libraries/LibCompress/CMakeLists.txt
@@ -1,7 +1,8 @@
 set(SOURCES
     Deflate.cpp
     Zlib.cpp
+    Gzip.cpp
 )
 
 serenity_lib(LibCompress compression)
-target_link_libraries(LibCompress LibC)
+target_link_libraries(LibCompress LibC LibCrypto)

--- a/Libraries/LibCompress/Gzip.cpp
+++ b/Libraries/LibCompress/Gzip.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibCompress/Gzip.h>
+
+#include <AK/String.h>
+
+namespace Compress {
+
+bool GzipDecompressor::BlockHeader::valid_magic_number() const
+{
+    return identification_1 == 0x1f && identification_2 == 0x8b;
+}
+
+bool GzipDecompressor::BlockHeader::supported_by_implementation() const
+{
+    if (compression_method != 0x08) {
+        // RFC 1952 does not define any compression methods other than deflate.
+        return false;
+    }
+
+    if (flags > Flags::MAX) {
+        // RFC 1952 does not define any more flags.
+        return false;
+    }
+
+    if (flags & Flags::FHCRC) {
+        TODO();
+    }
+
+    return true;
+}
+
+GzipDecompressor::GzipDecompressor(InputStream& stream)
+    : m_input_stream(stream)
+{
+}
+
+GzipDecompressor::~GzipDecompressor()
+{
+    m_current_member.clear();
+}
+
+// FIXME: Again, there are surely a ton of bugs because the code doesn't check for read errors.
+size_t GzipDecompressor::read(Bytes bytes)
+{
+    if (m_current_member.has_value()) {
+        size_t nread = current_member().m_stream.read(bytes);
+        current_member().m_checksum.update(bytes.trim(nread));
+        current_member().m_nread += nread;
+
+        if (nread < bytes.size()) {
+            LittleEndian<u32> crc32, input_size;
+            m_input_stream >> crc32 >> input_size;
+
+            if (crc32 != current_member().m_checksum.digest()) {
+                m_error = true;
+                return 0;
+            }
+
+            if (input_size != current_member().m_nread) {
+                m_error = true;
+                return 0;
+            }
+
+            m_current_member.clear();
+
+            return nread + read(bytes.slice(nread));
+        }
+
+        return nread;
+    } else {
+        if (m_input_stream.eof())
+            return 0;
+
+        // FIXME: This fails with the new changes?
+        BlockHeader header;
+        m_input_stream >> Bytes { &header, sizeof(header) };
+
+        if (!header.valid_magic_number() || !header.supported_by_implementation()) {
+            m_error = true;
+            return 0;
+        }
+
+        if (header.flags & Flags::FEXTRA) {
+            LittleEndian<u16> subfield_id, length;
+            m_input_stream >> subfield_id >> length;
+            m_input_stream.discard_or_error(length);
+        }
+
+        if (header.flags & Flags::FNAME) {
+            String original_filename;
+            m_input_stream >> original_filename;
+        }
+
+        if (header.flags & Flags::FCOMMENT) {
+            String comment;
+            m_input_stream >> comment;
+        }
+
+        m_current_member.emplace(header, m_input_stream);
+        return read(bytes);
+    }
+}
+
+bool GzipDecompressor::read_or_error(Bytes bytes)
+{
+    if (read(bytes) < bytes.size()) {
+        m_error = true;
+        return false;
+    }
+
+    return true;
+}
+
+bool GzipDecompressor::discard_or_error(size_t count)
+{
+    u8 buffer[4096];
+
+    size_t ndiscarded = 0;
+    while (ndiscarded < count) {
+        if (eof()) {
+            m_error = true;
+            return false;
+        }
+
+        ndiscarded += read({ buffer, min<size_t>(count - ndiscarded, sizeof(buffer)) });
+    }
+
+    return true;
+}
+
+ByteBuffer GzipDecompressor::decompress_all(ReadonlyBytes bytes)
+{
+    InputMemoryStream memory_stream { bytes };
+    GzipDecompressor gzip_stream { memory_stream };
+
+    auto buffer = ByteBuffer::create_uninitialized(4096);
+
+    size_t nread = 0;
+    while (!gzip_stream.eof()) {
+        nread += gzip_stream.read(buffer.bytes().slice(nread));
+
+        if (buffer.size() - nread < 4096)
+            buffer.grow(buffer.size() + 4096);
+    }
+
+    buffer.trim(nread);
+    return buffer;
+}
+
+bool GzipDecompressor::eof() const
+{
+    if (m_current_member.has_value()) {
+        // FIXME: There is an ugly edge case where we read the whole deflate block
+        //        but haven't read CRC32 and ISIZE.
+        return current_member().m_stream.eof() && m_input_stream.eof();
+    } else {
+        return m_input_stream.eof();
+    }
+}
+
+}

--- a/Libraries/LibCompress/Gzip.h
+++ b/Libraries/LibCompress/Gzip.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibCompress/Deflate.h>
+#include <LibCrypto/Checksum/CRC32.h>
+
+namespace Compress {
+
+class GzipDecompressor final : public InputStream {
+public:
+    GzipDecompressor(InputStream&);
+    ~GzipDecompressor();
+
+    size_t read(Bytes) override;
+    bool read_or_error(Bytes) override;
+    bool discard_or_error(size_t) override;
+    bool eof() const override;
+
+    static ByteBuffer decompress_all(ReadonlyBytes);
+
+private:
+    struct [[gnu::packed]] BlockHeader
+    {
+        u8 identification_1;
+        u8 identification_2;
+        u8 compression_method;
+        u8 flags;
+        LittleEndian<u32> modification_time;
+        u8 extra_flags;
+        u8 operating_system;
+
+        bool valid_magic_number() const;
+        bool supported_by_implementation() const;
+    };
+
+    struct Flags {
+        static constexpr u8 FTEXT = 1 << 0;
+        static constexpr u8 FHCRC = 1 << 1;
+        static constexpr u8 FEXTRA = 1 << 2;
+        static constexpr u8 FNAME = 1 << 3;
+        static constexpr u8 FCOMMENT = 1 << 4;
+
+        static constexpr u8 MAX = FTEXT | FHCRC | FEXTRA | FNAME | FCOMMENT;
+    };
+
+    class Member {
+    public:
+        Member(BlockHeader header, InputStream& stream)
+            : m_header(header)
+            , m_stream(stream)
+        {
+        }
+
+        BlockHeader m_header;
+        DeflateDecompressor m_stream;
+        Crypto::Checksum::CRC32 m_checksum;
+        size_t m_nread { 0 };
+    };
+
+    const Member& current_member() const { return m_current_member.value(); }
+    Member& current_member() { return m_current_member.value(); }
+
+    InputStream& m_input_stream;
+    Optional<Member> m_current_member;
+};
+
+}

--- a/Libraries/LibCore/FileStream.h
+++ b/Libraries/LibCore/FileStream.h
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Stream.h>
+#include <LibCore/File.h>
+
+namespace Core {
+
+class InputFileStream final : public InputStream {
+public:
+    explicit InputFileStream(NonnullRefPtr<File> file)
+        : m_file(file)
+    {
+    }
+
+    static Result<InputFileStream, String> open(StringView filename, IODevice::OpenMode mode = IODevice::OpenMode::ReadOnly, mode_t permissions = 0644)
+    {
+        ASSERT((mode & 0xf) == IODevice::OpenMode::ReadOnly || (mode & 0xf) == IODevice::OpenMode::ReadWrite);
+
+        auto file_result = File::open(filename, mode, permissions);
+
+        if (file_result.is_error())
+            return file_result.error();
+
+        return InputFileStream { file_result.value() };
+    }
+
+    size_t read(Bytes bytes) override
+    {
+        size_t nread = 0;
+
+        if (!m_buffered.is_empty()) {
+            nread += m_buffered.bytes().copy_trimmed_to(bytes);
+
+            m_buffered.bytes().slice(nread).copy_to(m_buffered);
+            m_buffered.trim(m_buffered.size() - nread);
+        }
+
+        while (nread < bytes.size() && !eof()) {
+            if (m_file->has_error()) {
+                m_error = true;
+                return 0;
+            }
+
+            const auto buffer = m_file->read(bytes.size() - nread);
+            nread += buffer.bytes().copy_to(bytes.slice(nread));
+        }
+
+        return nread;
+    }
+
+    bool read_or_error(Bytes bytes) override
+    {
+        if (read(bytes) < bytes.size()) {
+            m_error = true;
+            return false;
+        }
+
+        return true;
+    }
+
+    bool discard_or_error(size_t count) override
+    {
+        u8 buffer[4096];
+
+        size_t ndiscarded = 0;
+        while (ndiscarded < count && !eof())
+            ndiscarded += read({ buffer, min<size_t>(count - ndiscarded, sizeof(buffer)) });
+
+        if (eof()) {
+            m_error = true;
+            return false;
+        }
+
+        return true;
+    }
+
+    bool eof() const override
+    {
+        if (m_buffered.size() > 0)
+            return false;
+
+        if (m_file->eof())
+            return true;
+
+        m_buffered = m_file->read(4096);
+
+        return m_buffered.size() == 0;
+    }
+
+    void close()
+    {
+        if (!m_file->close())
+            m_error = true;
+    }
+
+private:
+    InputFileStream() = default;
+
+    mutable NonnullRefPtr<File> m_file;
+    mutable ByteBuffer m_buffered;
+};
+
+class OutputFileStream : public OutputStream {
+public:
+    explicit OutputFileStream(NonnullRefPtr<File> file)
+        : m_file(file)
+    {
+    }
+
+    static Result<OutputFileStream, String> open(StringView filename, IODevice::OpenMode mode = IODevice::OpenMode::WriteOnly, mode_t permissions = 0644)
+    {
+        ASSERT((mode & 0xf) == IODevice::OpenMode::WriteOnly || (mode & 0xf) == IODevice::OpenMode::ReadWrite);
+
+        auto file_result = File::open(filename, mode, permissions);
+
+        if (file_result.is_error())
+            return file_result.error();
+
+        return OutputFileStream { file_result.value() };
+    }
+
+    static OutputFileStream stdout()
+    {
+        return OutputFileStream { Core::File::stdout() };
+    }
+
+    size_t write(ReadonlyBytes bytes) override
+    {
+        if (!m_file->write(bytes.data(), bytes.size())) {
+            m_error = true;
+            return 0;
+        }
+
+        return bytes.size();
+    }
+
+    bool write_or_error(ReadonlyBytes bytes) override
+    {
+        if (write(bytes) < bytes.size()) {
+            m_error = true;
+            return false;
+        }
+
+        return true;
+    }
+
+    void close()
+    {
+        if (!m_file->close())
+            m_error = true;
+    }
+
+private:
+    NonnullRefPtr<File> m_file;
+};
+
+}

--- a/Userland/CMakeLists.txt
+++ b/Userland/CMakeLists.txt
@@ -39,5 +39,6 @@ target_link_libraries(test-compress LibCompress)
 target_link_libraries(test-js LibJS LibLine LibCore)
 target_link_libraries(test-web LibWeb)
 target_link_libraries(tt LibPthread)
+target_link_libraries(gunzip LibCompress)
 
 add_subdirectory(Tests)

--- a/Userland/gunzip.cpp
+++ b/Userland/gunzip.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibCompress/Gzip.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/FileStream.h>
+
+static void decompress_file(Core::InputFileStream input_stream, Core::OutputFileStream output_stream)
+{
+    auto gzip_stream = Compress::GzipDecompressor { input_stream };
+
+    u8 buffer[4096];
+
+    while (!gzip_stream.eof()) {
+        const auto nread = gzip_stream.read({ buffer, sizeof(buffer) });
+        output_stream.write_or_error({ buffer, nread });
+    }
+
+    input_stream.close();
+    output_stream.close();
+}
+
+int main(int argc, char** argv)
+{
+    Vector<const char*> filenames;
+    bool keep_input_files { false };
+    bool write_to_stdout { false };
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(keep_input_files, "Keep (don't delete) input files", "keep", 'k');
+    args_parser.add_option(write_to_stdout, "Write to stdout, keep original files unchanged", "stdout", 'c');
+    args_parser.add_positional_argument(filenames, "File to decompress", "FILE");
+    args_parser.parse(argc, argv);
+
+    if (write_to_stdout)
+        keep_input_files = true;
+
+    for (StringView filename : filenames) {
+        ASSERT(filename.ends_with(".gz"));
+
+        const auto input_filename = filename;
+        const auto output_filename = filename.substring_view(0, filename.length() - 3);
+
+        auto input_stream_result = Core::InputFileStream::open(input_filename);
+
+        if (write_to_stdout) {
+            decompress_file(input_stream_result.value(), Core::OutputFileStream::stdout());
+        } else {
+            auto output_stream_result = Core::OutputFileStream::open(output_filename);
+            decompress_file(input_stream_result.value(), output_stream_result.value());
+        }
+
+        if (!keep_input_files) {
+            const auto retval = unlink(String { input_filename }.characters());
+            ASSERT(retval == 0);
+        }
+    }
+}

--- a/Userland/test-compress.cpp
+++ b/Userland/test-compress.cpp
@@ -27,6 +27,7 @@
 #include <AK/TestSuite.h>
 
 #include <LibCompress/Deflate.h>
+#include <LibCompress/Gzip.h>
 #include <LibCompress/Zlib.h>
 
 static bool compare(ReadonlyBytes lhs, ReadonlyBytes rhs)
@@ -116,6 +117,39 @@ TEST_CASE(zlib_decompress_simple)
     const u8 uncompressed[] = "This is a simple text file :)";
 
     const auto decompressed = Compress::Zlib::decompress_all({ compressed, sizeof(compressed) });
+    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.bytes()));
+}
+
+TEST_CASE(gzip_decompress_simple)
+{
+    const u8 compressed[] = {
+        0x1f, 0x8b, 0x08, 0x00, 0x77, 0xff, 0x47, 0x5f, 0x02, 0xff, 0x2b, 0xcf,
+        0x2f, 0x4a, 0x31, 0x54, 0x48, 0x4c, 0x4a, 0x56, 0x28, 0x07, 0xb2, 0x8c,
+        0x00, 0xc2, 0x1d, 0x22, 0x15, 0x0f, 0x00, 0x00, 0x00
+    };
+
+    const u8 uncompressed[] = "word1 abc word2";
+
+    const auto decompressed = Compress::GzipDecompressor::decompress_all({ compressed, sizeof(compressed) });
+
+    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.bytes()));
+}
+
+TEST_CASE(gzip_multiple_members)
+{
+
+    const u8 compressed[] = {
+        0x1f, 0x8b, 0x08, 0x00, 0xe0, 0x03, 0x48, 0x5f, 0x02, 0xff, 0x4b, 0x4c,
+        0x4a, 0x4e, 0x4c, 0x4a, 0x06, 0x00, 0x4c, 0x99, 0x6e, 0x72, 0x06, 0x00,
+        0x00, 0x00, 0x1f, 0x8b, 0x08, 0x00, 0xe0, 0x03, 0x48, 0x5f, 0x02, 0xff,
+        0x4b, 0x4c, 0x4a, 0x4e, 0x4c, 0x4a, 0x06, 0x00, 0x4c, 0x99, 0x6e, 0x72,
+        0x06, 0x00, 0x00, 0x00
+    };
+
+    const u8 uncompressed[] = "abcabcabcabc";
+
+    const auto decompressed = Compress::GzipDecompressor::decompress_all({ compressed, sizeof(compressed) });
+
     EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.bytes()));
 }
 


### PR DESCRIPTION
I am totally aware that there is another Gzip implementation in `Libraries/LibCore/Gzip.h` but I can't remove that until dynamic blocks are supported by the deflate implementation. The days of `Libraries/LibCore/puff.h` are counted too.

---

Currently, the deflate implementation doesn't support dynamic blocks which are very commonly used. Typically, very short files use fixed blocks, I've setup one such file for testing here: [simple-gzip-file.gz][1]. The following should produce "abcabc":
~~~none
pro http://static.asynts.com/08/29/simple-gzip-file.gz > simple-gzip-file.gz
gunzip -c simple-gzip-file.gz
~~~

  [1]: http://static.asynts.com/08/29/simple-gzip-file.gz
