### PR TITLE
FontEditor: Don't corrupt nearby glyphs, don't crash on fixed-width

### DIFF
--- a/Applications/Calendar/AddEventDialog.cpp
+++ b/Applications/Calendar/AddEventDialog.cpp
@@ -63,15 +63,11 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     top_container.set_preferred_size(0, 45);
     top_container.layout()->set_margins({ 4, 4, 4, 4 });
 
-    auto make_label = [&](const StringView& text, GUI::Widget& widget, bool bold = false) {
-        auto& label = widget.add<GUI::Label>(text);
-        label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        label.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
-        label.set_preferred_size(0, 14);
-        if (bold)
-            label.set_font(Gfx::Font::default_bold_font());
-    };
-    make_label("Add title & date:", top_container, true);
+    auto& add_label = top_container.add<GUI::Label>("Add title & date:");
+    add_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    add_label.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
+    add_label.set_preferred_size(0, 14);
+    add_label.set_font(Gfx::Font::default_bold_font());
 
     auto& event_title_textbox = top_container.add<GUI::TextBox>();
     event_title_textbox.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);

--- a/Applications/FontEditor/FontEditor.cpp
+++ b/Applications/FontEditor/FontEditor.cpp
@@ -263,7 +263,7 @@ FontEditorWidget::FontEditorWidget(const String& path, RefPtr<Gfx::Font>&& edite
         info_label.set_text(builder.to_string());
     };
 
-    fixed_width_checkbox.on_checked = [&](bool checked) {
+    fixed_width_checkbox.on_checked = [&, update_demo](bool checked) {
         m_edited_font->set_fixed_width(checked);
         glyph_width_spinbox.set_enabled(!m_edited_font->is_fixed_width());
         glyph_width_spinbox.set_value(m_edited_font->glyph_width(m_glyph_map_widget->selected_glyph()));

--- a/Applications/FontEditor/GlyphEditorWidget.cpp
+++ b/Applications/FontEditor/GlyphEditorWidget.cpp
@@ -99,9 +99,9 @@ void GlyphEditorWidget::draw_at_mouse(const GUI::MouseEvent& event)
     int x = (event.x() - 1) / m_scale;
     int y = (event.y() - 1) / m_scale;
     auto bitmap = font().glyph_bitmap(m_glyph);
-    if (x >= bitmap.width())
+    if (x < 0 || x >= bitmap.width())
         return;
-    if (y >= bitmap.height())
+    if (y < 0 || y >= bitmap.height())
         return;
     if (bitmap.bit_at(x, y) == set)
         return;

--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -86,15 +86,9 @@ TextEditorWidget::TextEditorWidget()
             update_title();
     };
 
-    auto update_statusbar_cursor_position = [this] {
-        StringBuilder builder;
-        builder.appendf("Line: %d, Column: %d", m_editor->cursor().line() + 1, m_editor->cursor().column());
-        m_statusbar->set_text(builder.to_string());
-    };
-
     m_page_view = splitter.add<Web::InProcessWebView>();
     m_page_view->set_visible(false);
-    m_page_view->on_link_hover = [this, update_statusbar_cursor_position = move(update_statusbar_cursor_position)](auto& url) {
+    m_page_view->on_link_hover = [this](auto& url) {
         if (url.is_valid())
             m_statusbar->set_text(url.to_string());
         else
@@ -300,9 +294,7 @@ TextEditorWidget::TextEditorWidget()
 
     m_statusbar = add<GUI::StatusBar>();
 
-    m_editor->on_cursor_change = [update_statusbar_cursor_position = move(update_statusbar_cursor_position)] {
-        update_statusbar_cursor_position();
-    };
+    m_editor->on_cursor_change = [this] { update_statusbar_cursor_position(); };
 
     m_new_action = GUI::Action::create("New", { Mod_Ctrl, Key_N }, Gfx::Bitmap::load_from_file("/res/icons/16x16/new.png"), [this](const GUI::Action&) {
         if (m_document_dirty) {
@@ -642,4 +634,11 @@ void TextEditorWidget::update_html_preview()
     auto current_scroll_pos = m_page_view->visible_content_rect();
     m_page_view->load_html(m_editor->text(), URL::create_with_file_protocol(m_path));
     m_page_view->scroll_into_view(current_scroll_pos, true, true);
+}
+
+void TextEditorWidget::update_statusbar_cursor_position()
+{
+    StringBuilder builder;
+    builder.appendf("Line: %d, Column: %d", m_editor->cursor().line() + 1, m_editor->cursor().column());
+    m_statusbar->set_text(builder.to_string());
 }

--- a/Applications/TextEditor/TextEditorWidget.h
+++ b/Applications/TextEditor/TextEditorWidget.h
@@ -60,6 +60,7 @@ private:
     void update_preview();
     void update_markdown_preview();
     void update_html_preview();
+    void update_statusbar_cursor_position();
 
     virtual void drop_event(GUI::DropEvent&) override;
 

--- a/DevTools/VisualBuilder/VBWidgetRegistry.cpp
+++ b/DevTools/VisualBuilder/VBWidgetRegistry.cpp
@@ -154,11 +154,8 @@ static RefPtr<GUI::Widget> build_gwidget(VBWidgetType type, GUI::Widget* parent)
 RefPtr<GUI::Widget> VBWidgetRegistry::build_gwidget(VBWidget& widget, VBWidgetType type, GUI::Widget* parent, NonnullOwnPtrVector<VBProperty>& properties)
 {
     auto gwidget = ::build_gwidget(type, parent);
-    auto add_readonly_property = [&](const String& name, const GUI::Variant& value) {
-        auto property = make<VBProperty>(widget, name, value);
-        property->set_readonly(true);
-        properties.append(move(property));
-    };
-    add_readonly_property("class", to_class_name(type));
+    auto property = make<VBProperty>(widget, "class", to_class_name(type));
+    property->set_readonly(true);
+    properties.append(move(property));
     return gwidget;
 }

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -454,6 +454,8 @@ Vector<Ext2FS::BlockIndex> Ext2FS::block_list_for_inode_impl(const ext2_inode& e
     if (!blocks_remaining)
         return list;
 
+    // Don't need to make copy of add_block, since this capture will only
+    // be called before block_list_for_inode_impl finishes.
     auto process_block_array = [&](unsigned array_block_index, auto&& callback) {
         if (include_block_list_blocks)
             add_block(array_block_index);

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -263,10 +263,9 @@ NonnullRefPtr<Program> Parser::parse_program()
 
 NonnullRefPtr<Statement> Parser::parse_statement()
 {
-    auto statement = [this]() -> NonnullRefPtr<Statement> {
     switch (m_parser_state.m_current_token.type()) {
     case TokenType::Class:
-      return parse_class_declaration();
+        return parse_class_declaration();
     case TokenType::Function: {
         auto declaration = parse_function_node<FunctionDeclaration>();
         m_parser_state.m_function_scopes.last().append(declaration);
@@ -291,7 +290,7 @@ NonnullRefPtr<Statement> Parser::parse_statement()
     case TokenType::Break:
         return parse_break_statement();
     case TokenType::Continue:
-         return parse_continue_statement();
+        return parse_continue_statement();
     case TokenType::Switch:
         return parse_switch_statement();
     case TokenType::Do:
@@ -299,7 +298,7 @@ NonnullRefPtr<Statement> Parser::parse_statement()
     case TokenType::While:
         return parse_while_statement();
     case TokenType::Debugger:
-         return parse_debugger_statement();
+        return parse_debugger_statement();
     case TokenType::Semicolon:
         consume();
         return create_ast_node<EmptyStatement>();
@@ -317,9 +316,7 @@ NonnullRefPtr<Statement> Parser::parse_statement()
         expected("statement (missing switch case)");
         consume();
         return create_ast_node<ErrorStatement>();
-    } }();
-
-    return statement;
+    }
 }
 
 RefPtr<FunctionExpression> Parser::try_parse_arrow_function_expression(bool expect_parens)


### PR DESCRIPTION
Elevator pitch: "Two bugfixes for the price of one PR!" ;)

This PR:
- prevents `GlyphEditor` from drawing into adjacent glyphs when the user just continues dragging the mouse outside of the window.
- fixes FontEditor (which used to crash) when the checkbox for fixed-witdth is used.
- combs through the rest of Serenity for similar "reference to lambda on stack frame" bugs (found none, but maybe it inspires someone to avoid this bug in the future)
- removes a few unnecessary lambdas.

The "reference to lambda on stack frame"-bug is evil because it's a leaky abstraction. On the one hand, the abstraction is that the programmer doesn't need to worry about scopes and lifetimes, the compiler will just copy/reference everything as needed. On the other hand, references to local variables mean that when the lambda is run, it still holds a reference to somewhere inside a stack frame that may *or may not* still be valid! In the case of FontEditor, using the checkbox triggered the "may not" case.

This (potential) bug affects all lambdas that takes its arguments via `[&]` and doesn't pay close attention to what exactly this pulls in. This is one of those bugs that Rust's model of making lifetimes part of the type system would have prevented, btw.