### PR TITLE
FileSystem: Fix file_type bug from #3333

### DIFF
--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -855,7 +855,7 @@ ssize_t Ext2FSInode::write_bytes(off_t offset, ssize_t count, const u8* data, Fi
     return nwritten;
 }
 
-u8 Ext2FSInode::file_type_for_directory_entry(const ext2_dir_entry_2& entry)
+u8 Ext2FS::internal_file_type_to_directory_entry_type(const DirectoryEntryView& entry) const
 {
     switch (entry.file_type) {
     case EXT2_FT_REG_FILE:
@@ -869,7 +869,7 @@ u8 Ext2FSInode::file_type_for_directory_entry(const ext2_dir_entry_2& entry)
     case EXT2_FT_FIFO:
         return DT_FIFO;
     case EXT2_FT_SOCK:
-        return EXT2_FT_SOCK;
+        return DT_SOCK;
     case EXT2_FT_SYMLINK:
         return DT_LNK;
     default:
@@ -899,7 +899,7 @@ KResult Ext2FSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntr
 #ifdef EXT2_DEBUG
             dbg() << "Ext2Inode::traverse_as_directory: " << entry->inode << ", name_len: " << entry->name_len << ", rec_len: " << entry->rec_len << ", file_type: " << entry->file_type << ", name: " << String(entry->name, entry->name_len);
 #endif
-            if (!callback({ { entry->name, entry->name_len }, { fsid(), entry->inode }, file_type_for_directory_entry(*entry) }))
+            if (!callback({ { entry->name, entry->name_len }, { fsid(), entry->inode }, entry->file_type }))
                 break;
         }
         entry = (ext2_dir_entry_2*)((char*)entry + entry->rec_len);

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -110,6 +110,8 @@ public:
 
     virtual bool supports_watchers() const override { return true; }
 
+    virtual u8 internal_file_type_to_directory_entry_type(const DirectoryEntryView& entry) const override;
+
 private:
     typedef unsigned BlockIndex;
     typedef unsigned GroupIndex;

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -188,9 +188,9 @@ ssize_t FileDescription::get_dir_entries(u8* buffer, ssize_t size)
 
     auto temp_buffer = ByteBuffer::create_uninitialized(size_to_allocate);
     BufferStream stream(temp_buffer);
-    KResult result = VFS::the().traverse_directory_inode(*m_inode, [&stream](auto& entry) {
+    KResult result = VFS::the().traverse_directory_inode(*m_inode, [&stream, this](auto& entry) {
         stream << (u32)entry.inode.index();
-        stream << (u8)entry.file_type;
+        stream << m_inode->fs().internal_file_type_to_directory_entry_type(entry);
         stream << (u32)entry.name.length();
         stream << entry.name;
         return true;

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -77,11 +77,14 @@ public:
         u8 file_type { 0 };
     };
 
-    virtual void flush_writes() { }
+    virtual void flush_writes() {}
 
     size_t block_size() const { return m_block_size; }
 
     virtual bool is_file_backed() const { return false; }
+
+    // Converts file types that are used internally by the filesystem to DT_* types
+    virtual u8 internal_file_type_to_directory_entry_type(const DirectoryEntryView& entry) const { return entry.file_type; }
 
 protected:
     FS();


### PR DESCRIPTION
So turns out my fix from #3333 introduced a bug which caused corruption of the ext2fs data :scream: 
This should fix it. I had to `rm Build/_disk_image` to get a fresh ext2fs image.
This also fixes the issue with directories in the git port.