### PR TITLE
Kernel: Make Heap implementation reusable, and make kmalloc expandable

### DIFF
--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -795,17 +795,21 @@ static Optional<KBuffer> procfs$cpuinfo(InodeIdentifier)
 Optional<KBuffer> procfs$memstat(InodeIdentifier)
 {
     InterruptDisabler disabler;
+    
+    kmalloc_stats stats;
+    get_kmalloc_stats(stats);
+    
     KBufferBuilder builder;
     JsonObjectSerializer<KBufferBuilder> json { builder };
-    json.add("kmalloc_allocated", g_kmalloc_bytes_allocated);
-    json.add("kmalloc_available", g_kmalloc_bytes_free);
-    json.add("kmalloc_eternal_allocated", g_kmalloc_bytes_eternal);
+    json.add("kmalloc_allocated", stats.bytes_allocated);
+    json.add("kmalloc_available", stats.bytes_free);
+    json.add("kmalloc_eternal_allocated", stats.bytes_eternal);
     json.add("user_physical_allocated", MM.user_physical_pages_used());
     json.add("user_physical_available", MM.user_physical_pages() - MM.user_physical_pages_used());
     json.add("super_physical_allocated", MM.super_physical_pages_used());
     json.add("super_physical_available", MM.super_physical_pages() - MM.super_physical_pages_used());
-    json.add("kmalloc_call_count", g_kmalloc_call_count);
-    json.add("kfree_call_count", g_kfree_call_count);
+    json.add("kmalloc_call_count", stats.kmalloc_call_count);
+    json.add("kfree_call_count", stats.kfree_call_count);
     slab_alloc_stats([&json](size_t slab_size, size_t num_allocated, size_t num_free) {
         auto prefix = String::format("slab_%zu", slab_size);
         json.add(String::format("%s_num_allocated", prefix.characters()), num_allocated);

--- a/Kernel/Heap/Heap.h
+++ b/Kernel/Heap/Heap.h
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Bitmap.h>
+#include <AK/ScopeGuard.h>
+#include <AK/Vector.h>
+#include <AK/kmalloc.h>
+
+namespace Kernel {
+
+template<size_t CHUNK_SIZE, unsigned HEAP_SCRUB_BYTE_ALLOC = 0, unsigned HEAP_SCRUB_BYTE_FREE = 0>
+class Heap {
+    AK_MAKE_NONCOPYABLE(Heap);
+
+    struct AllocationHeader {
+        size_t allocation_size_in_chunks;
+        u8 data[0];
+    };
+
+    static size_t calculate_chunks(size_t memory_size)
+    {
+        return (sizeof(u8) * memory_size) / (sizeof(u8) * CHUNK_SIZE + 1);
+    }
+
+public:
+    Heap(u8* memory, size_t memory_size)
+        : m_total_chunks(calculate_chunks(memory_size))
+        , m_chunks(memory)
+        , m_bitmap(Bitmap::wrap(memory + m_total_chunks * CHUNK_SIZE, m_total_chunks))
+    {
+        // To keep the alignment of the memory passed in, place the bitmap
+        // at the end of the memory block.
+        ASSERT(m_total_chunks * CHUNK_SIZE + (m_total_chunks + 7) / 8 <= memory_size);
+    }
+    ~Heap()
+    {
+    }
+
+    static size_t calculate_memory_for_bytes(size_t bytes)
+    {
+        size_t needed_chunks = (sizeof(AllocationHeader) + bytes + CHUNK_SIZE - 1) / CHUNK_SIZE;
+        return needed_chunks * CHUNK_SIZE + (needed_chunks + 7) / 8;
+    }
+
+    void* allocate(size_t size)
+    {
+        // We need space for the AllocationHeader at the head of the block.
+        size_t real_size = size + sizeof(AllocationHeader);
+        size_t chunks_needed = (real_size + CHUNK_SIZE - 1) / CHUNK_SIZE;
+
+        if (chunks_needed > free_chunks())
+            return nullptr;
+
+        Optional<size_t> first_chunk;
+
+        // Choose the right politic for allocation.
+        constexpr u32 best_fit_threshold = 128;
+        if (chunks_needed < best_fit_threshold) {
+            first_chunk = m_bitmap.find_first_fit(chunks_needed);
+        } else {
+            first_chunk = m_bitmap.find_best_fit(chunks_needed);
+        }
+
+        if (!first_chunk.has_value())
+            return nullptr;
+
+        auto* a = (AllocationHeader*)(m_chunks + (first_chunk.value() * CHUNK_SIZE));
+        u8* ptr = a->data;
+        a->allocation_size_in_chunks = chunks_needed;
+
+        m_bitmap.set_range(first_chunk.value(), chunks_needed, true);
+
+        m_allocated_chunks += chunks_needed;
+        if constexpr (HEAP_SCRUB_BYTE_ALLOC != 0) {
+            __builtin_memset(ptr, HEAP_SCRUB_BYTE_ALLOC, (chunks_needed * CHUNK_SIZE) - sizeof(AllocationHeader));
+        }
+        return ptr;
+    }
+
+    void deallocate(void* ptr)
+    {
+        if (!ptr)
+            return;
+        auto* a = (AllocationHeader*)((((u8*)ptr) - sizeof(AllocationHeader)));
+        ASSERT((u8*)a >= m_chunks && (u8*)ptr < m_chunks + m_total_chunks * CHUNK_SIZE);
+        ASSERT((u8*)a + a->allocation_size_in_chunks * CHUNK_SIZE <= m_chunks + m_total_chunks * CHUNK_SIZE);
+        FlatPtr start = ((FlatPtr)a - (FlatPtr)m_chunks) / CHUNK_SIZE;
+
+        m_bitmap.set_range(start, a->allocation_size_in_chunks, false);
+
+        ASSERT(m_allocated_chunks >= a->allocation_size_in_chunks);
+        m_allocated_chunks -= a->allocation_size_in_chunks;
+
+        if constexpr (HEAP_SCRUB_BYTE_FREE != 0) {
+            __builtin_memset(a, HEAP_SCRUB_BYTE_FREE, a->allocation_size_in_chunks * CHUNK_SIZE);
+        }
+    }
+
+    template<typename MainHeap>
+    void* reallocate(void* ptr, size_t new_size, MainHeap& h)
+    {
+        if (!ptr)
+            return h.allocate(new_size);
+
+        auto* a = (AllocationHeader*)((((u8*)ptr) - sizeof(AllocationHeader)));
+        ASSERT((u8*)a >= m_chunks && (u8*)ptr < m_chunks + m_total_chunks * CHUNK_SIZE);
+        ASSERT((u8*)a + a->allocation_size_in_chunks * CHUNK_SIZE <= m_chunks + m_total_chunks * CHUNK_SIZE);
+
+        size_t old_size = a->allocation_size_in_chunks * CHUNK_SIZE;
+
+        if (old_size == new_size)
+            return ptr;
+
+        auto* new_ptr = h.allocate(new_size);
+        if (new_ptr)
+            __builtin_memcpy(new_ptr, ptr, min(old_size, new_size));
+        deallocate(ptr);
+        return new_ptr;
+    }
+
+    void* reallocate(void* ptr, size_t new_size)
+    {
+        return reallocate(ptr, new_size, *this);
+    }
+
+    bool contains(const void* ptr) const
+    {
+        const auto* a = (const AllocationHeader*)((((const u8*)ptr) - sizeof(AllocationHeader)));
+        if ((const u8*)a < m_chunks)
+            return false;
+        if ((const u8*)ptr >= m_chunks + m_total_chunks * CHUNK_SIZE)
+            return false;
+        return true;
+    }
+
+    u8* memory() const { return m_chunks; }
+
+    size_t total_chunks() const { return m_total_chunks; }
+    size_t total_bytes() const { return m_total_chunks * CHUNK_SIZE; }
+    size_t free_chunks() const { return m_total_chunks - m_allocated_chunks; };
+    size_t free_bytes() const { return free_chunks() * CHUNK_SIZE; }
+    size_t allocated_chunks() const { return m_allocated_chunks; }
+    size_t allocated_bytes() const { return m_allocated_chunks * CHUNK_SIZE; }
+
+private:
+    size_t m_total_chunks { 0 };
+    size_t m_allocated_chunks { 0 };
+    u8* m_chunks { nullptr };
+    Bitmap m_bitmap;
+};
+
+template<typename ExpandHeap>
+struct ExpandableHeapTraits {
+    static bool add_memory(ExpandHeap& expand, size_t allocation_request)
+    {
+        return expand.add_memory(allocation_request);
+    }
+
+    static bool remove_memory(ExpandHeap& expand, void* memory)
+    {
+        return expand.remove_memory(memory);
+    }
+};
+
+struct DefaultExpandHeap {
+    bool add_memory(size_t)
+    {
+        // Requires explicit implementation
+        return false;
+    }
+
+    bool remove_memory(void*)
+    {
+        return false;
+    }
+};
+
+template<size_t CHUNK_SIZE, unsigned HEAP_SCRUB_BYTE_ALLOC = 0, unsigned HEAP_SCRUB_BYTE_FREE = 0, typename ExpandHeap = DefaultExpandHeap>
+class ExpandableHeap {
+    AK_MAKE_NONCOPYABLE(ExpandableHeap);
+    AK_MAKE_NONMOVABLE(ExpandableHeap);
+
+public:
+    typedef ExpandHeap ExpandHeapType;
+    typedef Heap<CHUNK_SIZE, HEAP_SCRUB_BYTE_ALLOC, HEAP_SCRUB_BYTE_FREE> HeapType;
+
+    struct SubHeap {
+        HeapType heap;
+        SubHeap* next { nullptr };
+
+        template<typename... Args>
+        SubHeap(Args&&... args)
+            : heap(forward<Args>(args)...)
+        {
+        }
+    };
+
+    ExpandableHeap(u8* memory, size_t memory_size, const ExpandHeapType& expand = ExpandHeapType())
+        : m_heaps(memory, memory_size)
+        , m_expand(expand)
+    {
+    }
+    ~ExpandableHeap()
+    {
+        // We don't own the main heap, only remove memory that we added previously
+        SubHeap* next;
+        for (auto* heap = m_heaps.next; heap; heap = next) {
+            next = heap->next;
+
+            heap->~SubHeap();
+            ExpandableHeapTraits<ExpandHeap>::remove_memory(m_expand, (void*)heap);
+        }
+    }
+
+    static size_t calculate_memory_for_bytes(size_t bytes)
+    {
+        return sizeof(SubHeap) + HeapType::calculate_memory_for_bytes(bytes);
+    }
+
+    void* allocate(size_t size)
+    {
+        do {
+            for (auto* subheap = &m_heaps; subheap; subheap = subheap->next) {
+                if (void* ptr = subheap->heap.allocate(size))
+                    return ptr;
+            }
+
+            // We need to loop because we won't know how much memory was added.
+            // Even though we make a best guess how much memory needs to be added,
+            // it doesn't guarantee that enough will be available after adding it.
+            // This is especially true for the kmalloc heap, where adding memory
+            // requires several other objects to be allocated just to be able to
+            // expand the heap.
+        } while (ExpandableHeapTraits<ExpandHeap>::add_memory(m_expand, size));
+        return nullptr;
+    }
+
+    void deallocate(void* ptr)
+    {
+        if (!ptr)
+            return;
+        for (auto* subheap = &m_heaps; subheap; subheap = subheap->next) {
+            if (subheap->heap.contains(ptr)) {
+                subheap->heap.deallocate(ptr);
+                if (subheap->heap.allocated_chunks() == 0 && subheap != &m_heaps) {
+                    // Since remove_memory may free subheap, we need to save the
+                    // next pointer before calling it
+                    auto* next_subheap = subheap->next;
+                    if (ExpandableHeapTraits<ExpandHeap>::remove_memory(m_expand, subheap)) {
+                        auto* subheap2 = m_heaps.next;
+                        auto** subheap_link = &m_heaps.next;
+                        while (subheap2 != subheap) {
+                            subheap_link = &subheap2->next;
+                            subheap2 = subheap2->next;
+                        }
+                        *subheap_link = next_subheap;
+                    }
+                }
+                return;
+            }
+        }
+        ASSERT_NOT_REACHED();
+    }
+
+    void* reallocate(void* ptr, size_t new_size)
+    {
+        if (!ptr)
+            return allocate(new_size);
+        for (auto* subheap = &m_heaps; subheap; subheap = subheap->next) {
+            if (subheap->heap.contains(ptr))
+                return subheap->heap.reallocate(ptr, new_size, *this);
+        }
+        ASSERT_NOT_REACHED();
+    }
+
+    HeapType& add_subheap(void* memory, size_t memory_size)
+    {
+        ASSERT(memory_size > sizeof(SubHeap));
+
+        // Place the SubHeap structure at the beginning of the new memory block
+        memory_size -= sizeof(SubHeap);
+        SubHeap* new_heap = (SubHeap*)memory;
+        new (new_heap) SubHeap((u8*)(new_heap + 1), memory_size);
+
+        // Add the subheap to the list (but leave the main heap where it is)
+        SubHeap* next_heap = m_heaps.next;
+        SubHeap** next_heap_link = &m_heaps.next;
+        while (next_heap) {
+            if (new_heap->heap.memory() < next_heap->heap.memory())
+                break;
+            next_heap_link = &next_heap->next;
+            next_heap = next_heap->next;
+        }
+        new_heap->next = *next_heap_link;
+        *next_heap_link = new_heap;
+        return new_heap->heap;
+    }
+
+    bool contains(const void* ptr) const
+    {
+        for (auto* subheap = &m_heaps; subheap; subheap = subheap->next) {
+            if (subheap->heap.contains(ptr))
+                return true;
+        }
+        return false;
+    }
+
+    size_t total_chunks() const
+    {
+        size_t total = 0;
+        for (auto* subheap = &m_heaps; subheap; subheap = subheap->next)
+            total += subheap->heap.total_chunks();
+        return total;
+    }
+    size_t total_bytes() const { return total_chunks() * CHUNK_SIZE; }
+    size_t free_chunks() const
+    {
+        size_t total = 0;
+        for (auto* subheap = &m_heaps; subheap; subheap = subheap->next)
+            total += subheap->heap.free_chunks();
+        return total;
+    }
+    size_t free_bytes() const { return free_chunks() * CHUNK_SIZE; }
+    size_t allocated_chunks() const
+    {
+        size_t total = 0;
+        for (auto* subheap = &m_heaps; subheap; subheap = subheap->next)
+            total += subheap->heap.allocated_chunks();
+        return total;
+    }
+    size_t allocated_bytes() const { return allocated_chunks() * CHUNK_SIZE; }
+
+private:
+    SubHeap m_heaps;
+    ExpandHeap m_expand;
+};
+
+}

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -60,7 +60,7 @@ Thread::Thread(NonnullRefPtr<Process> process)
     dbg() << "Created new thread " << m_process->name() << "(" << m_process->pid().value() << ":" << m_tid.value() << ")";
 #endif
     set_default_signal_dispositions();
-    m_fpu_state = (FPUState*)kmalloc_aligned(sizeof(FPUState), 16);
+    m_fpu_state = (FPUState*)kmalloc_aligned<16>(sizeof(FPUState));
     reset_fpu_state();
     memset(&m_tss, 0, sizeof(m_tss));
     m_tss.iomapbase = sizeof(TSS32);

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -65,6 +65,11 @@ MemoryManager& MM
     return *s_the;
 }
 
+bool MemoryManager::is_initialized()
+{
+    return s_the != nullptr;
+}
+
 MemoryManager::MemoryManager()
 {
     ScopedSpinLock lock(s_mm_lock);
@@ -282,8 +287,10 @@ void MemoryManager::initialize(u32 cpu)
 #endif
     Processor::current().set_mm_data(*mm_data);
 
-    if (cpu == 0)
+    if (cpu == 0) {
         s_the = new MemoryManager;
+        kmalloc_enable_expand();
+    }
 }
 
 Region* MemoryManager::kernel_region_from_vaddr(VirtualAddress vaddr)

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -86,6 +86,7 @@ class MemoryManager {
 
 public:
     static MemoryManager& the();
+    static bool is_initialized();
 
     static void initialize(u32 cpu);
     


### PR DESCRIPTION
Add an ExpandableHeap and switch kmalloc to use it, which allows
for the kmalloc heap to grow as needed.

In order to make heap expansion to work, we keep around a 1 MiB backup
memory region, because creating a region would require space in the
same heap. This means, the heap will grow as soon as the reported
utilization is less than 1 MiB. It will also return memory if an entire
subheap is no longer needed, although that is rarely possible.

As a fun fact, this boots with as little as a 32 KiB initial heap, which is enough to get `MemoryManager` initialized (after which the kmalloc heap will be expandable).
```c++
#define POOL_SIZE (32 * KiB)
```
![Screenshot from 2020-08-29 16-53-54](https://user-images.githubusercontent.com/10320822/91647504-b9783900-ea18-11ea-8b4a-22cecd16d6fc.png)
![Screenshot from 2020-08-29 16-55-20](https://user-images.githubusercontent.com/10320822/91647506-baa96600-ea18-11ea-8bbd-7ec7f75a282e.png)

