### PR TITLE
LibCore: Let DateTime::create()/set_time() take summer time into account

### DIFF
--- a/Libraries/LibCore/DateTime.cpp
+++ b/Libraries/LibCore/DateTime.cpp
@@ -88,6 +88,7 @@ void DateTime::set_time(unsigned year, unsigned month, unsigned day, unsigned ho
     tm.tm_mday = (int)day;
     tm.tm_mon = (int)month - 1;
     tm.tm_year = (int)year - 1900;
+    tm.tm_isdst = -1;
     // mktime() doesn't read tm.tm_wday and tm.tm_yday, no need to fill them in.
 
     m_timestamp = mktime(&tm);


### PR DESCRIPTION
DateTime::create() takes a date/time in local time, but it set
tm_isdst to 0, which meant it was in local winter time always.
Set tm_isdst to -1 so that times during summer time are treated
in summer time, and times in winter time are treated as winter
time (when appropriate). When the time is adjusted backward by
one hour, the same time can be in winter time or summer time,
so this isn't 100% reliable, but for most of the year it should
work fine.

Since LibJS uses DateTime, this means that the Date tuple
ctor (which creates a timestamp from year/month/day/hours/etc
in local time) and getTime() should now have consistent (and
correct) output, which should fix #3327.

In Serenity itself, dst handling (and timezones) are unimplemented
and this doens't have any effect yet, but in Lagom this has an effect.