### PR TITLE
Add __progname, err(3) functions.

### DIFF
--- a/Libraries/LibC/CMakeLists.txt
+++ b/Libraries/LibC/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBC_SOURCES
     cxxabi.cpp
     dirent.cpp
     dlfcn.cpp
+    err.cpp
     fcntl.cpp
     getopt.cpp
     grp.cpp

--- a/Libraries/LibC/crt0.cpp
+++ b/Libraries/LibC/crt0.cpp
@@ -54,6 +54,15 @@ int _start(int argc, char** argv, char** env)
     for (size_t i = 0; i < size; i++)
         (*__init_array_start[i])(argc, argv, env);
 
+    if (argc > 0 && argv[0] != nullptr) {
+        __progname = argv[0];
+        for (const char *s = __progname; *s != '\0'; s++) {
+            if (*s == '/') {
+                __progname = s + 1;
+            }
+        }
+    }
+
     int status = main(argc, argv, environ);
 
     exit(status);

--- a/Libraries/LibC/err.cpp
+++ b/Libraries/LibC/err.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <err.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void __internal_warn(int code, const char *fmt, va_list args)
+{
+    int save_errno = errno;
+
+    (void)fprintf(stderr, "%s: ", getprogname());
+    if (fmt != nullptr) {
+        (void)vfprintf(stderr, fmt, args);
+    }
+    if (code != -1) {
+        (void)fprintf(stderr, ": %s", strerror(code));
+    }
+    fputc('\n', stderr);
+
+    errno = save_errno;
+}
+
+extern "C" {
+
+void err(int eval, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    __internal_warn(errno, fmt, args);
+    va_end(args);
+
+    exit(eval);
+}
+
+void verr(int eval, const char *fmt, va_list args)
+{
+    __internal_warn(errno, fmt, args);
+
+    exit(eval);
+}
+
+void errc(int eval, int code, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    __internal_warn(code, fmt, args);
+    va_end(args);
+
+    exit(eval);
+}
+
+void verrc(int eval, int code, const char *fmt, va_list args)
+{
+    __internal_warn(code, fmt, args);
+
+    exit(eval);
+}
+
+void errx(int eval, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    __internal_warn(-1, fmt, args);
+    va_end(args);
+
+    exit(eval);
+}
+
+void verrx(int eval, const char *fmt, va_list args)
+{
+    __internal_warn(-1, fmt, args);
+
+    exit(eval);
+}
+
+void warn(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    __internal_warn(errno, fmt, args);
+    va_end(args);
+}
+
+void vwarn(const char *fmt, va_list args)
+{
+    __internal_warn(errno, fmt, args);
+}
+
+void warnc(int code, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    __internal_warn(code, fmt, args);
+    va_end(args);
+}
+
+void vwarnc(int code, const char *fmt, va_list args)
+{
+    __internal_warn(code, fmt, args);
+}
+
+void warnx(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    __internal_warn(-1, fmt, args);
+    va_end(args);
+}
+
+void vwarnx(const char *fmt, va_list args)
+{
+    __internal_warn(-1, fmt, args);
+}
+
+}

--- a/Libraries/LibC/err.h
+++ b/Libraries/LibC/err.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include <stdarg.h>
+
+__BEGIN_DECLS
+
+__attribute__((noreturn)) void err(int eval, const char *fmt, ...);
+__attribute__((noreturn)) void verr(int eval, const char *fmt, va_list args);
+__attribute__((noreturn)) void errc(int eval, int code, const char *fmt, ...);
+__attribute__((noreturn)) void verrc(int eval, int code, const char *fmt, va_list args);
+__attribute__((noreturn)) void errx(int eval, const char *fmt, ...);
+__attribute__((noreturn)) void verrx(int eval, const char *fmt, va_list args);
+void warn(const char *fmt, ...);
+void vwarn(const char *fmt, va_list args);
+void warnc(int code, const char *fmt, ...);
+void vwarnc(int code, const char *fmt, va_list args);
+void warnx(const char *fmt, ...);
+void vwarnx(const char *fmt, va_list args);
+
+__END_DECLS

--- a/Libraries/LibC/libcinit.cpp
+++ b/Libraries/LibC/libcinit.cpp
@@ -33,6 +33,7 @@ extern "C" {
 
 __thread int errno;
 char** environ;
+const char* __progname;
 bool __environ_is_malloced;
 
 void __libc_init()

--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -350,6 +350,24 @@ int putenv(char* new_var)
     return 0;
 }
 
+const char *getprogname(void)
+{
+    return __progname;
+}
+
+void setprogname(const char *name)
+{
+    char *tmp;
+
+    tmp = strrchr(name, '/');
+    if (tmp == nullptr) {
+        __progname = name;
+    } else {
+        __progname = tmp + 1;
+    }
+
+}
+
 double strtod(const char* str, char** endptr)
 {
     // Parse spaces, sign, and base

--- a/Libraries/LibC/stdlib.h
+++ b/Libraries/LibC/stdlib.h
@@ -78,6 +78,8 @@ size_t mbtowc(wchar_t*, const char*, size_t);
 int wctomb(char*, wchar_t);
 size_t wcstombs(char*, const wchar_t*, size_t);
 char* realpath(const char* pathname, char* buffer);
+const char *getprogname();
+void setprogname(const char *name);
 
 #define RAND_MAX 32767
 int rand();

--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -53,6 +53,7 @@ __BEGIN_DECLS
 #endif
 
 extern char** environ;
+extern const char* __progname;
 
 int get_process_name(char* buffer, int buffer_size);
 int set_process_name(const char* name, size_t name_length);


### PR DESCRIPTION
These commits add a new global string, `__progname`, which contains the basename of the current process.
It also adds the err(3) family error reporting functions.

Both of these are based on existing BSD systems. I ran into some troubles with the dynlib demo, so I can't confirm if it will work there. Seems to compile fine.