### PR TITLE
LibWeb: Expose window.self and window.frames

### DIFF
--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -59,6 +59,8 @@ void WindowObject::initialize()
     GlobalObject::initialize();
 
     define_property("window", this, JS::Attribute::Enumerable);
+    define_property("frames", this, JS::Attribute::Enumerable);
+    define_property("self", this, JS::Attribute::Enumerable);
     define_native_property("document", document_getter, document_setter, JS::Attribute::Enumerable);
     define_native_function("alert", alert);
     define_native_function("confirm", confirm);

--- a/Libraries/LibWeb/Tests/Window/window.window_frames_self.js
+++ b/Libraries/LibWeb/Tests/Window/window.window_frames_self.js
@@ -1,0 +1,8 @@
+loadPage("file:///res/html/misc/blank.html");
+
+afterInitialPageLoad(() => {
+    test("window.{window,frames,self} all return the Window object", () => {
+        expect(window.window).toBe(window.frames);
+        expect(window.window).toBe(window.self);
+    });
+});


### PR DESCRIPTION
"self" is a way to refer to the global object that will work in both
a window context and a web worker context.

"frames" apparently used to return a list of frame objects according
to MDN, but it now just returns the window object.