### PR TITLE
Userland: Allow unquoted 'filename' values in 'pro'

### DIFF
--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -75,6 +75,11 @@ protected:
     size_t m_index { 0 };
 };
 
+constexpr auto is_any_of(const StringView& values)
+{
+    return [values](auto c) { return values.contains(c); };
+}
+
 // ctype adaptors
 // FIXME: maybe put them in an another file?
 bool is_alpha(char);
@@ -97,6 +102,7 @@ using AK::GenericLexer;
 
 using AK::is_alpha;
 using AK::is_alphanum;
+using AK::is_any_of;
 using AK::is_control;
 using AK::is_digit;
 using AK::is_graphic;

--- a/Userland/pro.cpp
+++ b/Userland/pro.cpp
@@ -43,7 +43,7 @@ public:
     {
         GenericLexer lexer(value);
 
-        lexer.consume_while([](auto c) { return is_whitespace(c); });
+        lexer.ignore_while(is_whitespace);
 
         if (lexer.consume_specific("inline")) {
             m_kind = Kind::Inline;
@@ -55,7 +55,7 @@ public:
         if (lexer.consume_specific("attachment")) {
             m_kind = Kind::Attachment;
             if (lexer.consume_specific(";")) {
-                lexer.consume_while([](auto c) { return is_whitespace(c); });
+                lexer.ignore_while(is_whitespace);
                 if (lexer.consume_specific("filename=")) {
                     m_filename = lexer.consume_quoted_string();
                 } else {
@@ -68,7 +68,7 @@ public:
         if (lexer.consume_specific("form-data")) {
             m_kind = Kind::FormData;
             while (lexer.consume_specific(";")) {
-                lexer.consume_while([](auto c) { return is_whitespace(c); });
+                lexer.ignore_while(is_whitespace);
                 if (lexer.consume_specific("name=")) {
                     m_name = lexer.consume_quoted_string();
                 } else if (lexer.consume_specific("filename=")) {

--- a/Userland/pro.cpp
+++ b/Userland/pro.cpp
@@ -57,7 +57,16 @@ public:
             if (lexer.consume_specific(";")) {
                 lexer.ignore_while(is_whitespace);
                 if (lexer.consume_specific("filename=")) {
-                    m_filename = lexer.consume_quoted_string();
+                    // RFC 2183: "A short (length <= 78 characters)
+                    //            parameter value containing only non-`tspecials' characters SHOULD be
+                    //            represented as a single `token'."
+                    // Some people seem to take this as generic advice of "if it doesn't have special characters,
+                    // it's safe to specify as a single token"
+                    // So let's just be as lenient as possible.
+                    if (lexer.next_is('"'))
+                        m_filename = lexer.consume_quoted_string();
+                    else
+                        m_filename = lexer.consume_until(is_any_of("()<>@,;:\\\"/[]?= "));
                 } else {
                     m_might_be_wrong = true;
                 }
@@ -72,7 +81,10 @@ public:
                 if (lexer.consume_specific("name=")) {
                     m_name = lexer.consume_quoted_string();
                 } else if (lexer.consume_specific("filename=")) {
-                    m_filename = lexer.consume_quoted_string();
+                    if (lexer.next_is('"'))
+                        m_filename = lexer.consume_quoted_string();
+                    else
+                        m_filename = lexer.consume_until(is_any_of("()<>@,;:\\\"/[]?= "));
                 } else {
                     m_might_be_wrong = true;
                 }


### PR DESCRIPTION
- Applies a tip from https://github.com/SerenityOS/serenity/commit/cb7526fca0aa6cb07d279fec93288d0169904bfc#r41907965
- Tries to be a bit more lenient with `filename`