### PR TITLE
LibLine: Reset suggestion state on any non-tab key

### DIFF
--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -335,6 +335,7 @@ private:
 
     void refresh_display();
     void cleanup();
+    void cleanup_suggestions();
     void really_quit_event_loop();
 
     void restore()


### PR DESCRIPTION
This fixes the following (and more!):
```sh
$ /bin/dis<tab><tab><backspace><backspace><backspace><backspace><tab>
$ /bink_benchmark
```

P.S. I hate the multi-key input changes, I should someday implement multi-key bindings to get rid of those too...
Not today though.