### PR TITLE
Shell: Fix job control and backgrounding

### DIFF
--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -519,6 +519,26 @@ void EventLoop::unregister_signal(int handler_id)
         s_signal_handlers.remove(remove_signo);
 }
 
+void EventLoop::notify_forked(ForkEvent event)
+{
+    switch (event) {
+    case ForkEvent::Child:
+        s_main_event_loop = nullptr;
+        s_event_loop_stack->clear();
+        s_timers->clear();
+        s_notifiers->clear();
+        s_signal_handlers.clear();
+        s_handling_signal = 0;
+        s_next_signal_id = 0;
+        s_pid = 0;
+        s_rpc_server = nullptr;
+        s_rpc_clients.clear();
+        return;
+    }
+
+    ASSERT_NOT_REACHED();
+}
+
 void EventLoop::wait_for_event(WaitMode mode)
 {
     fd_set rfds;

--- a/Libraries/LibCore/EventLoop.h
+++ b/Libraries/LibCore/EventLoop.h
@@ -81,6 +81,13 @@ public:
     static int register_signal(int signo, Function<void(int)> handler);
     static void unregister_signal(int handler_id);
 
+    // Note: Boost uses Parent/Child/Prepare, but we don't really have anything
+    //       interesting to do in the parent or before forking.
+    enum class ForkEvent {
+        Child,
+    };
+    static void notify_forked(ForkEvent);
+
 private:
     bool start_rpc_server();
     void wait_for_event(WaitMode);
@@ -102,8 +109,8 @@ private:
 
     class SignalHandlers {
         AK_MAKE_NONCOPYABLE(SignalHandlers);
-    public:
 
+    public:
         SignalHandlers(SignalHandlers&& from)
             : m_signo(from.m_signo)
             , m_original_handler(from.m_original_handler)

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -73,7 +73,7 @@ static inline Vector<Command> join_commands(Vector<Command> left, Vector<Command
 
     command.should_wait = first_in_right.should_wait && last_in_left.should_wait;
     command.is_pipe_source = first_in_right.is_pipe_source;
-    command.should_notify_if_in_background = first_in_right.should_wait && last_in_left.should_notify_if_in_background;
+    command.should_notify_if_in_background = first_in_right.should_notify_if_in_background || last_in_left.should_notify_if_in_background;
 
     Vector<Command> commands;
     commands.append(left);

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -1569,6 +1569,51 @@ Sequence::~Sequence()
 {
 }
 
+void Subshell::dump(int level) const
+{
+    Node::dump(level);
+    if (m_block)
+        m_block->dump(level + 1);
+}
+
+RefPtr<Value> Subshell::run(RefPtr<Shell> shell)
+{
+    if (!m_block)
+        return create<ListValue>({});
+
+    return m_block->run(shell);
+}
+
+void Subshell::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightMetadata metadata)
+{
+    metadata.is_first_in_list = true;
+    if (m_block)
+        m_block->highlight_in_editor(editor, shell, metadata);
+}
+
+HitTestResult Subshell::hit_test_position(size_t offset)
+{
+    if (!position().contains(offset))
+        return {};
+
+    if (m_block)
+        return m_block->hit_test_position(offset);
+
+    return {};
+}
+
+Subshell::Subshell(Position position, RefPtr<Node> block)
+    : Node(move(position))
+    , m_block(block)
+{
+    if (m_block && m_block->is_syntax_error())
+        set_is_syntax_error(m_block->syntax_error_node());
+}
+
+Subshell::~Subshell()
+{
+}
+
 void SimpleVariable::dump(int level) const
 {
     Node::dump(level);

--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -196,6 +196,7 @@ struct Command {
     bool should_wait { true };
     bool is_pipe_source { false };
     bool should_notify_if_in_background { true };
+    bool should_immediately_execute_next { false };
 
     mutable RefPtr<Pipeline> pipeline;
     Vector<NodeWithAction> next_chain;
@@ -233,7 +234,7 @@ public:
     }
 
     CommandValue(Vector<String> argv)
-        : m_command({ move(argv), {}, true, false, true, nullptr, {} })
+        : m_command({ move(argv), {}, true, false, true, false, nullptr, {} })
     {
     }
 
@@ -409,6 +410,8 @@ public:
     }
 
     virtual RefPtr<Node> leftmost_trivial_literal() const { return nullptr; }
+
+    Vector<Command> to_lazy_evaluated_commands(RefPtr<Shell> shell);
 
 protected:
     Position m_position;

--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -806,6 +806,22 @@ private:
     RefPtr<Node> m_right;
 };
 
+class Subshell final : public Node {
+public:
+    Subshell(Position, RefPtr<Node> block);
+    virtual ~Subshell();
+
+private:
+    virtual void dump(int level) const override;
+    virtual RefPtr<Value> run(RefPtr<Shell>) override;
+    virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
+    virtual HitTestResult hit_test_position(size_t) override;
+    virtual String class_name() const override { return "Subshell"; }
+    virtual bool would_execute() const override { return true; }
+
+    RefPtr<AST::Node> m_block;
+};
+
 class SimpleVariable final : public Node {
 public:
     SimpleVariable(Position, String);

--- a/Shell/Forward.h
+++ b/Shell/Forward.h
@@ -29,10 +29,11 @@
 class Shell;
 namespace AST {
 
+struct Command;
 class Node;
 class Value;
 class SyntaxError;
 class Pipeline;
-class Rewiring;
+struct Rewiring;
 
 }

--- a/Shell/Parser.cpp
+++ b/Shell/Parser.cpp
@@ -283,7 +283,7 @@ RefPtr<AST::Node> Parser::parse_or_logical_sequence()
     if (!right_and_sequence)
         right_and_sequence = create<AST::SyntaxError>("Expected an expression after '||'");
 
-    return create<AST::Or>(create<AST::Execute>(move(and_sequence)), create<AST::Execute>(move(right_and_sequence)));
+    return create<AST::Or>(move(and_sequence), move(right_and_sequence));
 }
 
 RefPtr<AST::Node> Parser::parse_and_logical_sequence()
@@ -305,7 +305,7 @@ RefPtr<AST::Node> Parser::parse_and_logical_sequence()
     if (!right_and_sequence)
         right_and_sequence = create<AST::SyntaxError>("Expected an expression after '&&'");
 
-    return create<AST::And>(create<AST::Execute>(move(pipe_sequence)), create<AST::Execute>(move(right_and_sequence)));
+    return create<AST::And>(move(pipe_sequence), move(right_and_sequence));
 }
 
 RefPtr<AST::Node> Parser::parse_pipe_sequence()

--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -107,7 +107,6 @@ toplevel :: sequence?
 
 sequence :: variable_decls? or_logical_sequence terminator sequence
           | variable_decls? or_logical_sequence '&' sequence
-          | variable_decls? control_structure terminator sequence
           | variable_decls? or_logical_sequence
           | variable_decls? terminator sequence
 
@@ -125,6 +124,8 @@ variable_decls :: identifier '=' expression (' '+ variable_decls)? ' '*
 
 pipe_sequence :: command '|' pipe_sequence
                | command
+               | control_structure '|' pipe_sequence
+               | control_structure
 
 control_structure :: for_expr
                    | if_expr

--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -53,6 +53,7 @@ private:
     RefPtr<AST::Node> parse_control_structure();
     RefPtr<AST::Node> parse_for_loop();
     RefPtr<AST::Node> parse_if_expr();
+    RefPtr<AST::Node> parse_subshell();
     RefPtr<AST::Node> parse_redirection();
     RefPtr<AST::Node> parse_list_expression();
     RefPtr<AST::Node> parse_expression();
@@ -129,12 +130,16 @@ pipe_sequence :: command '|' pipe_sequence
 
 control_structure :: for_expr
                    | if_expr
+                   | subshell
+
 for_expr :: 'for' ws+ (identifier ' '+ 'in' ws*)? expression ws+ '{' toplevel '}'
 
 if_expr :: 'if' ws+ or_logical_sequence ws+ '{' toplevel '}' else_clause?
 
 else_clause :: else '{' toplevel '}'
              | else if_expr
+
+subshell :: '{' toplevel '}'
 
 command :: redirection command
          | list_expression command?

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -699,11 +699,9 @@ NonnullRefPtrVector<Job> Shell::run_commands(Vector<AST::Command>& commands)
         if (command.should_wait) {
             block_on_job(job);
         } else {
-            if (command.is_pipe_source) {
-                job->set_running_in_background(true);
-            } else if (command.should_notify_if_in_background) {
+            job->set_running_in_background(true);
+            if (!command.is_pipe_source && command.should_notify_if_in_background)
                 job->set_should_announce_exit(true);
-            }
         }
     }
 
@@ -759,9 +757,6 @@ void Shell::block_on_job(RefPtr<Job> job)
         return;
 
     loop.exec();
-
-    if (job->is_suspended())
-        job->print_status(Job::PrintStatusMode::Basic);
 }
 
 String Shell::get_history_path()

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -73,6 +73,8 @@ public:
     constexpr static auto local_init_file_path = "~/.shellrc";
     constexpr static auto global_init_file_path = "/etc/shellrc";
 
+    void setup_signals();
+
     int run_command(const StringView&);
     bool is_runnable(const StringView&);
     RefPtr<Job> run_command(const AST::Command&);
@@ -224,6 +226,7 @@ private:
 
     HashMap<String, String> m_aliases;
     bool m_is_interactive { true };
+    bool m_is_subshell { false };
 };
 
 static constexpr bool is_word_character(char c)

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -195,6 +195,9 @@ private:
     const Job* m_current_job { nullptr };
     LocalFrame* find_frame_containing_local_variable(const String& name);
 
+    void run_tail(RefPtr<Job>);
+    void run_tail(const AST::NodeWithAction&, int head_exit_code);
+
     virtual void custom_event(Core::CustomEvent&) override;
 
 #define __ENUMERATE_SHELL_BUILTIN(builtin) \

--- a/Shell/Tests/control-structure-as-command.sh
+++ b/Shell/Tests/control-structure-as-command.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+setopt --verbose
+
+rm -rf shell-test 2> /dev/null
+mkdir shell-test
+cd shell-test
+
+    touch a b c
+
+    # Can we do logical stuff with control structures?
+    ls && for $(seq 1) { echo yes > listing }
+    test "$(cat listing)" = "yes" || echo for cannot appear as second part of '&&' && exit 1
+    rm listing
+
+    # FIXME: This should work!
+    # for $(seq 1) { echo yes > listing } && echo HELLO!
+    # test "$(cat listing)" = "yes" || echo for cannot appear as first part of '&&' && exit 1
+    # rm listing
+
+    # Can we pipe things into and from control structures?
+    ls | if true { cat > listing }
+    test "$(cat listing)" = "a b c" || echo if cannot be correctly redirected to && exit 1
+    rm listing
+
+    ls | for $(seq 1) { cat > listing }
+    test "$(cat listing)" = "a b c" || echo for cannot be correctly redirected to && exit 1
+    rm listing
+
+    for $(seq 4) { echo $it } | cat > listing
+    test "$(cat listing)" = "1 2 3 4" || echo for cannot be correctly redirected from && exit 1
+    rm listing
+
+    if true { echo TRUE! } | cat > listing
+    test "$(cat listing)" = "TRUE!" || echo if cannot be correctly redirected from && exit 1
+    rm listing
+
+cd ..
+rm -rf shell-test

--- a/Shell/Tests/if.sh
+++ b/Shell/Tests/if.sh
@@ -1,13 +1,17 @@
 #!/bin/sh
 
+setopt --verbose
+
 if test 1 -eq 1 {
     # Are comments ok?
     # Basic 'if' structure, empty block.
     if true {
     } else {
+        echo "if true runs false branch"
         exit 2
     }
     if false {
+        echo "if false runs true branch"
         exit 2
     } else {
     }

--- a/Shell/Tests/subshell.sh
+++ b/Shell/Tests/subshell.sh
@@ -1,0 +1,28 @@
+#/bin/sh
+
+setopt --verbose
+
+rm -rf shell-test
+mkdir shell-test
+cd shell-test
+
+    # Simple sequence (grouping)
+    { echo test > testfile }
+    test "$(cat testfile)" = "test" || echo cannot write to file in subshell && exit 1
+
+    # Simple sequence - many commands
+    { echo test1 > testfile; echo test2 > testfile }
+    test "$(cat testfile)" = "test2" || echo cannot write to file in subshell 2 && exit 1
+
+
+    # Does it exit with the last exit code?
+    { test -z "a" }
+    exitcode=$?
+    test "$exitcode" -eq 1 || echo exits with $exitcode when it should exit with 1 && exit 1
+
+    { test -z "a" || echo test }
+    exitcode=$?
+    test "$exitcode" -eq 0 || echo exits with $exitcode when it should exit with 0 && exit 1
+
+cd ..
+rm -rf shell-test

--- a/Shell/Tests/valid.sh
+++ b/Shell/Tests/valid.sh
@@ -23,69 +23,69 @@ test "$(echo yes)" = yes || exit 2
 alias fail="echo Failure: "
 
 # Redirections.
-test -z "$(echo foo > /dev/null)" || fail direct path redirection
-test -z "$(echo foo 2> /dev/null 1>&2)" || fail indirect redirection
-test -n "$(echo foo 2> /dev/null)" || fail fds interfere with each other
+test -z "$(echo foo > /dev/null)" || fail direct path redirection && exit 2
+test -z "$(echo foo 2> /dev/null 1>&2)" || fail indirect redirection && exit 2
+test -n "$(echo foo 2> /dev/null)" || fail fds interfere with each other && exit 2
 
 # Argument unpack
-test "$(echo (yes))" = yes || fail arguments inside bare lists
-test "$(echo (no)() yes)" = yes || fail arguments inside juxtaposition: empty
-test "$(echo (y)(es))" = yes || fail arguments inside juxtaposition: list
-test "$(echo "y"es)" = yes || fail arguments inside juxtaposition: string
+test "$(echo (yes))" = yes || fail arguments inside bare lists && exit 2
+test "$(echo (no)() yes)" = yes || fail arguments inside juxtaposition: empty && exit 2
+test "$(echo (y)(es))" = yes || fail arguments inside juxtaposition: list && exit 2
+test "$(echo "y"es)" = yes || fail arguments inside juxtaposition: string && exit 2
 
 # String substitution
 foo=yes
-test "$(echo $foo)" = yes || fail simple string var lookup
-test "$(echo "$foo")" = yes || fail stringified string var lookup
+test "$(echo $foo)" = yes || fail simple string var lookup && exit 2
+test "$(echo "$foo")" = yes || fail stringified string var lookup && exit 2
 
 # List substitution
 foo=(yes)
 # Static lookup, as list
-test "$(echo $foo)" = yes || fail simple list var lookup
+test "$(echo $foo)" = yes || fail simple list var lookup && exit 2
 # Static lookup, stringified
-test "$(echo "$foo")" = yes || fail stringified list var lookup
+test "$(echo "$foo")" = yes || fail stringified list var lookup && exit 2
 # Dynamic lookup through static expression
-test "$(echo $'foo')" = yes || fail dynamic lookup through static exp
+test "$(echo $'foo')" = yes || fail dynamic lookup through static exp && exit 2
 # Dynamic lookup through dynamic expression
 ref_to_foo=foo
-test "$(echo $"$ref_to_foo")" = yes || fail dynamic lookup through dynamic exp
+test "$(echo $"$ref_to_foo")" = yes || fail dynamic lookup through dynamic exp && exit 2
 
 # More redirections
 echo test > /tmp/sh-test
-test "$(cat /tmp/sh-test)" = test || fail simple path redirect
+test "$(cat /tmp/sh-test)" = test || fail simple path redirect && exit 2
 rm /tmp/sh-test
 
 # 'brace' expansions
-test "$(echo x(yes no))" = "xyes xno" || fail simple juxtaposition expansion
-test "$(echo (y n)(es o))" = "yes yo nes no" || fail list-list juxtaposition expansion
-test "$(echo ()(foo bar baz))" = "" || fail empty expansion
+test "$(echo x(yes no))" = "xyes xno" || fail simple juxtaposition expansion && exit 2
+test "$(echo (y n)(es o))" = "yes yo nes no" || fail list-list juxtaposition expansion && exit 2
+test "$(echo ()(foo bar baz))" = "" || fail empty expansion && exit 2
 
 # Variables inside commands
 to_devnull=(>/dev/null)
-test "$(echo hewwo $to_devnull)" = "" || fail variable containing simple command
+test "$(echo hewwo $to_devnull)" = "" || fail variable containing simple command && exit 2
 
 word_count=(() | wc -w)
-test "$(echo well hello friends $word_count)" -eq 3 || fail variable containing pipeline
+test "$(echo well hello friends $word_count)" -eq 3 || fail variable containing pipeline && exit 2
 
 # Globs
 mkdir sh-test
 pushd sh-test
     touch (a b c)(d e f)
-    test "$(echo a*)" = "ad ae af" || fail '*' glob expansion
-    test "$(echo a?)" = "ad ae af" || fail '?' glob expansion
+    test "$(echo a*)" = "ad ae af" || fail '*' glob expansion && exit 2
+    test "$(echo a?)" = "ad ae af" || fail '?' glob expansion && exit 2
 
     glob_in_var='*'
-    test "$(echo $glob_in_var)" = '*' || fail substituted string acts as glob
+    test "$(echo $glob_in_var)" = '*' || fail substituted string acts as glob && exit 2
 
-    test "$(echo (a*))" = "ad ae af" || fail globs in lists resolve wrong
-    test "$(echo x(a*))" = "xad xae xaf" || fail globs in lists do not resolve to lists
-    test "$(echo "foo"a*)" = "fooad fooae fooaf" || fail globs join to dquoted strings
+    test "$(echo (a*))" = "ad ae af" || fail globs in lists resolve wrong && exit 2
+    test "$(echo x(a*))" = "xad xae xaf" || fail globs in lists do not resolve to lists && exit 2
+    test "$(echo "foo"a*)" = "fooad fooae fooaf" || fail globs join to dquoted strings && exit 2
 popd
 rm -fr sh-test
 
 # Setopt
 setopt --inline_exec_keep_empty_segments
-test "$(echo -n "a\n\nb")" = "a  b" || fail inline_exec_keep_empty_segments has no effect
+test "$(echo -n "a\n\nb")" = "a  b" || fail inline_exec_keep_empty_segments has no effect && exit 2
 
 setopt --no_inline_exec_keep_empty_segments
-test "$(echo -n "a\n\nb")" = "a b" || fail cannot unset inline_exec_keep_empty_segments
+test "$(echo -n "a\n\nb")" = "a b" || fail cannot unset inline_exec_keep_empty_segments && exit 2


### PR DESCRIPTION
Let's fix some job control stuff

Things that this PR aims to fix:
- [x] Allowing more things in background
    - [x] And / Or
    - [x] Entire pipelines
    - [x] control structures
    - [x] subshells (they were free at this point)
- [x] Fixing job control stuff
    - [x] that weird duplication bug as seen in the latest update video
- [x] Resetting event loops across forks without upsetting any deities 
---

To make lazy execution possible (which is required for putting logic in the background), I'm gonna make nodes evaluate to thunks  in (what I know as) weak head-normal form, so the transition might be a bit ugly - if someone has better ideas, please do tell!