### PR TITLE
LibC: include getopt.h in unistd.h

### DIFF
--- a/Libraries/LibC/unistd.h
+++ b/Libraries/LibC/unistd.h
@@ -37,6 +37,7 @@
 #include <limits.h>
 #include <sys/cdefs.h>
 #include <sys/types.h>
+#include <getopt.h>
 
 __BEGIN_DECLS
 


### PR DESCRIPTION
Added getopt.h to unistd.h as per [this](https://www.man7.org/linux/man-pages/man0/unistd.h.0p.html) and as discussed in serenityos chat on freenode.

I needed it in order to build [libtermkey](http://www.leonerd.org.uk/code/libtermkey/)