### PR TITLE
Streams: Better error handling; move memory streams into their own header.

### DIFF
--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -57,7 +57,7 @@ public:
     bool read_or_error(Bytes bytes) override
     {
         if (read(bytes) != bytes.size()) {
-            m_error = true;
+            set_fatal_error();
             return false;
         }
 
@@ -92,7 +92,7 @@ public:
                 if (m_bit_offset++ == 7)
                     m_next_byte.clear();
             } else if (m_stream.eof()) {
-                m_error = true;
+                set_fatal_error();
                 return 0;
             } else {
                 m_stream >> m_next_byte;

--- a/AK/CircularDuplexStream.h
+++ b/AK/CircularDuplexStream.h
@@ -50,7 +50,7 @@ public:
     bool write_or_error(ReadonlyBytes bytes) override
     {
         if (Capacity - m_queue.size() < bytes.size()) {
-            m_error = true;
+            set_recoverable_error();
             return false;
         }
 
@@ -70,10 +70,8 @@ public:
 
     size_t read(Bytes bytes, size_t seekback)
     {
-        ASSERT(seekback <= Capacity);
-
-        if (seekback > m_total_written) {
-            m_error = true;
+        if (seekback > Capacity || seekback > m_total_written) {
+            set_recoverable_error();
             return 0;
         }
 
@@ -90,7 +88,7 @@ public:
     bool read_or_error(Bytes bytes) override
     {
         if (m_queue.size() < bytes.size()) {
-            m_error = true;
+            set_recoverable_error();
             return false;
         }
 
@@ -101,7 +99,7 @@ public:
     bool discard_or_error(size_t count) override
     {
         if (m_queue.size() < count) {
-            m_error = true;
+            set_recoverable_error();
             return false;
         }
 

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -53,6 +53,7 @@ class InputMemoryStream;
 class DuplexMemoryStream;
 class OutputStream;
 class InputBitStream;
+class OutputMemoryStream;
 
 template<size_t Capacity>
 class CircularDuplexStream;
@@ -150,6 +151,7 @@ using AK::LogStream;
 using AK::NonnullOwnPtr;
 using AK::NonnullRefPtr;
 using AK::Optional;
+using AK::OutputMemoryStream;
 using AK::OutputStream;
 using AK::OwnPtr;
 using AK::ReadonlyBytes;

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -308,8 +308,24 @@ private:
     size_t m_base_offset { 0 };
 };
 
+class OutputMemoryStream final : public OutputStream {
+public:
+    size_t write(ReadonlyBytes bytes) override { return m_stream.write(bytes); }
+    bool write_or_error(ReadonlyBytes bytes) override { return m_stream.write_or_error(bytes); }
+
+    ByteBuffer copy_into_contiguous_buffer() const { return m_stream.copy_into_contiguous_buffer(); }
+
+    Optional<size_t> offset_of(ReadonlyBytes value) const { return m_stream.offset_of(value); }
+
+    size_t size() const { return m_stream.woffset(); }
+
+private:
+    DuplexMemoryStream m_stream;
+};
+
 }
 
 using AK::DuplexMemoryStream;
 using AK::InputMemoryStream;
 using AK::InputStream;
+using AK::OutputMemoryStream;

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/MemMem.h>
+#include <AK/Stream.h>
+#include <AK/Vector.h>
+
+namespace AK {
+
+class InputMemoryStream final : public InputStream {
+public:
+    InputMemoryStream(ReadonlyBytes bytes)
+        : m_bytes(bytes)
+    {
+    }
+
+    bool eof() const override { return m_offset >= m_bytes.size(); }
+
+    size_t read(Bytes bytes) override
+    {
+        const auto count = min(bytes.size(), remaining());
+        __builtin_memcpy(bytes.data(), m_bytes.data() + m_offset, count);
+        m_offset += count;
+        return count;
+    }
+
+    bool read_or_error(Bytes bytes) override
+    {
+        if (remaining() < bytes.size()) {
+            set_recoverable_error();
+            return false;
+        }
+
+        __builtin_memcpy(bytes.data(), m_bytes.data() + m_offset, bytes.size());
+        m_offset += bytes.size();
+        return true;
+    }
+
+    bool discard_or_error(size_t count) override
+    {
+        if (remaining() < count) {
+            set_recoverable_error();
+            return false;
+        }
+
+        m_offset += count;
+        return true;
+    }
+
+    void seek(size_t offset)
+    {
+        ASSERT(offset < m_bytes.size());
+        m_offset = offset;
+    }
+
+    u8 peek_or_error() const
+    {
+        if (remaining() == 0) {
+            set_recoverable_error();
+            return 0;
+        }
+
+        return m_bytes[m_offset];
+    }
+
+    // LEB128 is a variable-length encoding for integers
+    bool read_LEB128_unsigned(size_t& result)
+    {
+        const auto backup = m_offset;
+
+        result = 0;
+        size_t num_bytes = 0;
+        while (true) {
+            // Note. The implementation in AK::BufferStream::read_LEB128_unsigned read one
+            //       past the end, this is fixed here.
+            if (eof()) {
+                m_offset = backup;
+                set_recoverable_error();
+                return false;
+            }
+
+            const u8 byte = m_bytes[m_offset];
+            result = (result) | (static_cast<size_t>(byte & ~(1 << 7)) << (num_bytes * 7));
+            ++m_offset;
+            if (!(byte & (1 << 7)))
+                break;
+            ++num_bytes;
+        }
+
+        return true;
+    }
+
+    // LEB128 is a variable-length encoding for integers
+    bool read_LEB128_signed(ssize_t& result)
+    {
+        const auto backup = m_offset;
+
+        result = 0;
+        size_t num_bytes = 0;
+        u8 byte = 0;
+
+        do {
+            // Note. The implementation in AK::BufferStream::read_LEB128_unsigned read one
+            //       past the end, this is fixed here.
+            if (eof()) {
+                m_offset = backup;
+                set_recoverable_error();
+                return false;
+            }
+
+            byte = m_bytes[m_offset];
+            result = (result) | (static_cast<size_t>(byte & ~(1 << 7)) << (num_bytes * 7));
+            ++m_offset;
+            ++num_bytes;
+        } while (byte & (1 << 7));
+
+        if (num_bytes * 7 < sizeof(size_t) * 4 && (byte & 0x40)) {
+            // sign extend
+            result |= ((size_t)(-1) << (num_bytes * 7));
+        }
+
+        return true;
+    }
+
+    ReadonlyBytes bytes() const { return m_bytes; }
+    size_t offset() const { return m_offset; }
+    size_t remaining() const { return m_bytes.size() - m_offset; }
+
+private:
+    ReadonlyBytes m_bytes;
+    size_t m_offset { 0 };
+};
+
+// All data written to this stream can be read from it. Reading and writing is done
+// using different offsets, meaning that it is not necessary to seek to the start
+// before reading; this behaviour differs from BufferStream.
+class DuplexMemoryStream final : public DuplexStream {
+public:
+    static constexpr size_t chunk_size = 4 * 1024;
+
+    bool eof() const override { return m_write_offset == m_read_offset; }
+
+    bool discard_or_error(size_t count) override
+    {
+        if (m_write_offset - m_read_offset < count) {
+            set_recoverable_error();
+            return false;
+        }
+
+        m_read_offset += count;
+        try_discard_chunks();
+        return true;
+    }
+
+    Optional<size_t> offset_of(ReadonlyBytes value) const
+    {
+        if (value.size() > remaining())
+            return {};
+
+        // First, find which chunk we're in.
+        auto chunk_index = (m_read_offset - m_base_offset) / chunk_size;
+        auto last_written_chunk_index = (m_write_offset - m_base_offset) / chunk_size;
+        auto first_chunk_index = chunk_index;
+        auto last_written_chunk_offset = m_write_offset % chunk_size;
+        auto first_chunk_offset = m_read_offset % chunk_size;
+        size_t last_chunk_offset = 0;
+        auto found_value = false;
+
+        for (; chunk_index <= last_written_chunk_index; ++chunk_index) {
+            auto chunk_bytes = m_chunks[chunk_index].bytes();
+            size_t chunk_offset = 0;
+            if (chunk_index == last_written_chunk_index) {
+                chunk_bytes = chunk_bytes.slice(0, last_written_chunk_offset);
+            }
+            if (chunk_index == first_chunk_index) {
+                chunk_bytes = chunk_bytes.slice(first_chunk_offset);
+                chunk_offset = first_chunk_offset;
+            }
+
+            // See if 'value' is in this chunk,
+            auto position = AK::memmem(chunk_bytes.data(), chunk_bytes.size(), value.data(), value.size());
+            if (!position)
+                continue; // Not in this chunk either :(
+
+            // We found it!
+            found_value = true;
+            last_chunk_offset = (const u8*)position - chunk_bytes.data() + chunk_offset;
+            break;
+        }
+
+        if (found_value) {
+            if (first_chunk_index == chunk_index)
+                return last_chunk_offset - first_chunk_offset;
+
+            return (chunk_index - first_chunk_index) * chunk_size + last_chunk_offset - first_chunk_offset;
+        }
+
+        // No dice.
+        return {};
+    }
+
+    size_t read(Bytes bytes) override
+    {
+        size_t nread = 0;
+        while (bytes.size() - nread > 0 && m_write_offset - m_read_offset - nread > 0) {
+            const auto chunk_index = (m_read_offset - m_base_offset) / chunk_size;
+            const auto chunk_bytes = m_chunks[chunk_index].bytes().slice(m_read_offset % chunk_size).trim(m_write_offset - m_read_offset - nread);
+            nread += chunk_bytes.copy_trimmed_to(bytes.slice(nread));
+        }
+
+        m_read_offset += nread;
+
+        try_discard_chunks();
+
+        return nread;
+    }
+
+    bool read_or_error(Bytes bytes) override
+    {
+        if (m_write_offset - m_read_offset < bytes.size()) {
+            set_recoverable_error();
+            return false;
+        }
+
+        read(bytes);
+        return true;
+    }
+
+    size_t write(ReadonlyBytes bytes) override
+    {
+        size_t nwritten = 0;
+        while (bytes.size() - nwritten > 0) {
+            if ((m_write_offset + nwritten) % chunk_size == 0)
+                m_chunks.append(ByteBuffer::create_uninitialized(chunk_size));
+
+            nwritten += bytes.copy_trimmed_to(m_chunks.last().bytes().slice(m_write_offset % chunk_size));
+        }
+
+        m_write_offset += nwritten;
+        return nwritten;
+    }
+
+    bool write_or_error(ReadonlyBytes bytes) override
+    {
+        write(bytes);
+        return true;
+    }
+
+    size_t roffset() const { return m_read_offset; }
+    size_t woffset() const { return m_write_offset; }
+
+    size_t remaining() const { return m_write_offset - m_read_offset; }
+
+private:
+    void try_discard_chunks()
+    {
+        while (m_read_offset - m_base_offset >= chunk_size) {
+            m_chunks.take_first();
+            m_base_offset += chunk_size;
+        }
+    }
+
+    Vector<ByteBuffer> m_chunks;
+    size_t m_write_offset { 0 };
+    size_t m_read_offset { 0 };
+    size_t m_base_offset { 0 };
+};
+
+}
+
+using AK::DuplexMemoryStream;
+using AK::InputMemoryStream;
+using AK::InputStream;

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -26,15 +26,12 @@
 
 #pragma once
 
-#include <AK/ByteBuffer.h>
 #include <AK/Concepts.h>
 #include <AK/Endian.h>
 #include <AK/Forward.h>
-#include <AK/MemMem.h>
 #include <AK/Optional.h>
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
-#include <AK/Vector.h>
 
 namespace AK::Detail {
 
@@ -116,6 +113,7 @@ OutputStream& operator<<(OutputStream& stream, LittleEndian<T> value)
 {
     return stream << ReadonlyBytes { &value.m_value, sizeof(value.m_value) };
 }
+
 template<typename T>
 InputStream& operator>>(InputStream& stream, BigEndian<T>& value)
 {
@@ -136,22 +134,13 @@ InputStream& operator>>(InputStream& stream, Optional<T>& value)
     return stream;
 }
 
-#if defined(__cpp_concepts) && !defined(__COVERITY__)
-template<Concepts::Integral Integral>
-#else
 template<typename Integral, typename EnableIf<IsIntegral<Integral>::value, int>::Type = 0>
-#endif
 InputStream& operator>>(InputStream& stream, Integral& value)
 {
     stream.read_or_error({ &value, sizeof(value) });
     return stream;
 }
-
-#if defined(__cpp_concepts) && !defined(__COVERITY__)
-template<Concepts::Integral Integral>
-#else
 template<typename Integral, typename EnableIf<IsIntegral<Integral>::value, int>::Type = 0>
-#endif
 OutputStream& operator<<(OutputStream& stream, Integral value)
 {
     stream.write_or_error({ &value, sizeof(value) });
@@ -160,24 +149,13 @@ OutputStream& operator<<(OutputStream& stream, Integral value)
 
 #ifndef KERNEL
 
-// FIXME: clang-format adds spaces before the #if for some reason.
-// clang-format off
-#if defined(__cpp_concepts) && !defined(__COVERITY__)
-template<Concepts::FloatingPoint FloatingPoint>
-#else
 template<typename FloatingPoint, typename EnableIf<IsFloatingPoint<FloatingPoint>::value, int>::Type = 0>
-#endif
 InputStream& operator>>(InputStream& stream, FloatingPoint& value)
 {
     stream.read_or_error({ &value, sizeof(value) });
     return stream;
 }
-
-#if defined(__cpp_concepts) && !defined(__COVERITY__)
-template<Concepts::FloatingPoint FloatingPoint>
-#else
 template<typename FloatingPoint, typename EnableIf<IsFloatingPoint<FloatingPoint>::value, int>::Type = 0>
-#endif
 OutputStream& operator<<(OutputStream& stream, FloatingPoint value)
 {
     stream.write_or_error({ &value, sizeof(value) });
@@ -185,281 +163,16 @@ OutputStream& operator<<(OutputStream& stream, FloatingPoint value)
 }
 
 #endif
-// clang-format on
 
 inline InputStream& operator>>(InputStream& stream, bool& value)
 {
     stream.read_or_error({ &value, sizeof(value) });
     return stream;
 }
-
 inline OutputStream& operator<<(OutputStream& stream, bool value)
 {
     stream.write_or_error({ &value, sizeof(value) });
     return stream;
 }
 
-class InputMemoryStream final : public InputStream {
-public:
-    InputMemoryStream(ReadonlyBytes bytes)
-        : m_bytes(bytes)
-    {
-    }
-
-    bool eof() const override { return m_offset >= m_bytes.size(); }
-
-    size_t read(Bytes bytes) override
-    {
-        const auto count = min(bytes.size(), remaining());
-        __builtin_memcpy(bytes.data(), m_bytes.data() + m_offset, count);
-        m_offset += count;
-        return count;
-    }
-
-    bool read_or_error(Bytes bytes) override
-    {
-        if (remaining() < bytes.size()) {
-            set_recoverable_error();
-            return false;
-        }
-
-        __builtin_memcpy(bytes.data(), m_bytes.data() + m_offset, bytes.size());
-        m_offset += bytes.size();
-        return true;
-    }
-
-    bool discard_or_error(size_t count) override
-    {
-        if (remaining() < count) {
-            set_recoverable_error();
-            return false;
-        }
-
-        m_offset += count;
-        return true;
-    }
-
-    void seek(size_t offset)
-    {
-        ASSERT(offset < m_bytes.size());
-        m_offset = offset;
-    }
-
-    u8 peek_or_error() const
-    {
-        if (remaining() == 0) {
-            set_recoverable_error();
-            return 0;
-        }
-
-        return m_bytes[m_offset];
-    }
-
-    // LEB128 is a variable-length encoding for integers
-    bool read_LEB128_unsigned(size_t& result)
-    {
-        const auto backup = m_offset;
-
-        result = 0;
-        size_t num_bytes = 0;
-        while (true) {
-            // Note. The implementation in AK::BufferStream::read_LEB128_unsigned read one
-            //       past the end, this is fixed here.
-            if (eof()) {
-                m_offset = backup;
-                set_recoverable_error();
-                return false;
-            }
-
-            const u8 byte = m_bytes[m_offset];
-            result = (result) | (static_cast<size_t>(byte & ~(1 << 7)) << (num_bytes * 7));
-            ++m_offset;
-            if (!(byte & (1 << 7)))
-                break;
-            ++num_bytes;
-        }
-
-        return true;
-    }
-
-    // LEB128 is a variable-length encoding for integers
-    bool read_LEB128_signed(ssize_t& result)
-    {
-        const auto backup = m_offset;
-
-        result = 0;
-        size_t num_bytes = 0;
-        u8 byte = 0;
-
-        do {
-            // Note. The implementation in AK::BufferStream::read_LEB128_unsigned read one
-            //       past the end, this is fixed here.
-            if (eof()) {
-                m_offset = backup;
-                set_recoverable_error();
-                return false;
-            }
-
-            byte = m_bytes[m_offset];
-            result = (result) | (static_cast<size_t>(byte & ~(1 << 7)) << (num_bytes * 7));
-            ++m_offset;
-            ++num_bytes;
-        } while (byte & (1 << 7));
-
-        if (num_bytes * 7 < sizeof(size_t) * 4 && (byte & 0x40)) {
-            // sign extend
-            result |= ((size_t)(-1) << (num_bytes * 7));
-        }
-
-        return true;
-    }
-
-    ReadonlyBytes bytes() const { return m_bytes; }
-    size_t offset() const { return m_offset; }
-    size_t remaining() const { return m_bytes.size() - m_offset; }
-
-private:
-    ReadonlyBytes m_bytes;
-    size_t m_offset { 0 };
-};
-
-// All data written to this stream can be read from it. Reading and writing is done
-// using different offsets, meaning that it is not necessary to seek to the start
-// before reading; this behaviour differs from BufferStream.
-class DuplexMemoryStream final : public DuplexStream {
-public:
-    static constexpr size_t chunk_size = 4 * 1024;
-
-    bool eof() const override { return m_write_offset == m_read_offset; }
-
-    bool discard_or_error(size_t count) override
-    {
-        if (m_write_offset - m_read_offset < count) {
-            set_recoverable_error();
-            return false;
-        }
-
-        m_read_offset += count;
-        try_discard_chunks();
-        return true;
-    }
-
-    Optional<size_t> offset_of(ReadonlyBytes value) const
-    {
-        if (value.size() > remaining())
-            return {};
-
-        // First, find which chunk we're in.
-        auto chunk_index = (m_read_offset - m_base_offset) / chunk_size;
-        auto last_written_chunk_index = (m_write_offset - m_base_offset) / chunk_size;
-        auto first_chunk_index = chunk_index;
-        auto last_written_chunk_offset = m_write_offset % chunk_size;
-        auto first_chunk_offset = m_read_offset % chunk_size;
-        size_t last_chunk_offset = 0;
-        auto found_value = false;
-
-        for (; chunk_index <= last_written_chunk_index; ++chunk_index) {
-            auto chunk_bytes = m_chunks[chunk_index].bytes();
-            size_t chunk_offset = 0;
-            if (chunk_index == last_written_chunk_index) {
-                chunk_bytes = chunk_bytes.slice(0, last_written_chunk_offset);
-            }
-            if (chunk_index == first_chunk_index) {
-                chunk_bytes = chunk_bytes.slice(first_chunk_offset);
-                chunk_offset = first_chunk_offset;
-            }
-
-            // See if 'value' is in this chunk,
-            auto position = AK::memmem(chunk_bytes.data(), chunk_bytes.size(), value.data(), value.size());
-            if (!position)
-                continue; // Not in this chunk either :(
-
-            // We found it!
-            found_value = true;
-            last_chunk_offset = (const u8*)position - chunk_bytes.data() + chunk_offset;
-            break;
-        }
-
-        if (found_value) {
-            if (first_chunk_index == chunk_index)
-                return last_chunk_offset - first_chunk_offset;
-
-            return (chunk_index - first_chunk_index) * chunk_size + last_chunk_offset - first_chunk_offset;
-        }
-
-        // No dice.
-        return {};
-    }
-
-    size_t read(Bytes bytes) override
-    {
-        size_t nread = 0;
-        while (bytes.size() - nread > 0 && m_write_offset - m_read_offset - nread > 0) {
-            const auto chunk_index = (m_read_offset - m_base_offset) / chunk_size;
-            const auto chunk_bytes = m_chunks[chunk_index].bytes().slice(m_read_offset % chunk_size).trim(m_write_offset - m_read_offset - nread);
-            nread += chunk_bytes.copy_trimmed_to(bytes.slice(nread));
-        }
-
-        m_read_offset += nread;
-
-        try_discard_chunks();
-
-        return nread;
-    }
-
-    bool read_or_error(Bytes bytes) override
-    {
-        if (m_write_offset - m_read_offset < bytes.size()) {
-            set_recoverable_error();
-            return false;
-        }
-
-        read(bytes);
-        return true;
-    }
-
-    size_t write(ReadonlyBytes bytes) override
-    {
-        size_t nwritten = 0;
-        while (bytes.size() - nwritten > 0) {
-            if ((m_write_offset + nwritten) % chunk_size == 0)
-                m_chunks.append(ByteBuffer::create_uninitialized(chunk_size));
-
-            nwritten += bytes.copy_trimmed_to(m_chunks.last().bytes().slice(m_write_offset % chunk_size));
-        }
-
-        m_write_offset += nwritten;
-        return nwritten;
-    }
-
-    bool write_or_error(ReadonlyBytes bytes) override
-    {
-        write(bytes);
-        return true;
-    }
-
-    size_t roffset() const { return m_read_offset; }
-    size_t woffset() const { return m_write_offset; }
-
-    size_t remaining() const { return m_write_offset - m_read_offset; }
-
-private:
-    void try_discard_chunks()
-    {
-        while (m_read_offset - m_base_offset >= chunk_size) {
-            m_chunks.take_first();
-            m_base_offset += chunk_size;
-        }
-    }
-
-    Vector<ByteBuffer> m_chunks;
-    size_t m_write_offset { 0 };
-    size_t m_read_offset { 0 };
-    size_t m_base_offset { 0 };
-};
-
 }
-
-using AK::DuplexMemoryStream;
-using AK::InputMemoryStream;
-using AK::InputStream;

--- a/AK/String.h
+++ b/AK/String.h
@@ -288,8 +288,7 @@ inline InputStream& operator>>(InputStream& stream, String& string)
         if (stream.eof()) {
             string = nullptr;
 
-            // FIXME: We need an InputStream::set_error_flag method.
-            stream.discard_or_error(1);
+            stream.set_fatal_error();
             return stream;
         }
 

--- a/AK/Tests/TestMemoryStream.cpp
+++ b/AK/Tests/TestMemoryStream.cpp
@@ -160,4 +160,15 @@ TEST_CASE(read_endian_values)
     EXPECT_EQ(value2, 0x04050607u);
 }
 
+TEST_CASE(write_endian_values)
+{
+    const u8 expected[] { 4, 3, 2, 1, 1, 2, 3, 4 };
+
+    OutputMemoryStream stream;
+    stream << LittleEndian<u32> { 0x01020304 } << BigEndian<u32> { 0x01020304 };
+
+    EXPECT_EQ(stream.size(), 8u);
+    EXPECT(compare({ expected, sizeof(expected) }, stream.copy_into_contiguous_buffer()));
+}
+
 TEST_MAIN(MemoryStream)

--- a/AK/Tests/TestMemoryStream.cpp
+++ b/AK/Tests/TestMemoryStream.cpp
@@ -27,7 +27,7 @@
 #include <AK/TestSuite.h>
 
 #include <AK/FixedArray.h>
-#include <AK/Stream.h>
+#include <AK/MemoryStream.h>
 
 static bool compare(ReadonlyBytes lhs, ReadonlyBytes rhs)
 {
@@ -160,4 +160,4 @@ TEST_CASE(read_endian_values)
     EXPECT_EQ(value2, 0x04050607u);
 }
 
-TEST_MAIN(Stream)
+TEST_MAIN(MemoryStream)

--- a/AK/Tests/TestStream.cpp
+++ b/AK/Tests/TestStream.cpp
@@ -49,7 +49,7 @@ TEST_CASE(read_an_integer)
     InputMemoryStream stream { { &expected, sizeof(expected) } };
     stream >> actual;
 
-    EXPECT(!stream.has_error() && stream.eof());
+    EXPECT(!stream.has_any_error() && stream.eof());
     EXPECT_EQ(expected, actual);
 }
 
@@ -60,15 +60,15 @@ TEST_CASE(recoverable_error)
 
     InputMemoryStream stream { { &expected, sizeof(expected) } };
 
-    EXPECT(!stream.has_error() && !stream.eof());
+    EXPECT(!stream.has_any_error() && !stream.eof());
     stream >> to_large_value;
-    EXPECT(stream.has_error() && !stream.eof());
+    EXPECT(stream.has_recoverable_error() && !stream.eof());
 
-    EXPECT(stream.handle_error());
-    EXPECT(!stream.has_error() && !stream.eof());
+    EXPECT(stream.handle_recoverable_error());
+    EXPECT(!stream.has_any_error() && !stream.eof());
 
     stream >> actual;
-    EXPECT(!stream.has_error() && stream.eof());
+    EXPECT(!stream.has_any_error() && stream.eof());
     EXPECT_EQ(expected, actual);
 }
 
@@ -79,7 +79,7 @@ TEST_CASE(chain_stream_operator)
     InputMemoryStream stream { { expected, sizeof(expected) } };
 
     stream >> actual[0] >> actual[1] >> actual[2] >> actual[3];
-    EXPECT(!stream.has_error() && stream.eof());
+    EXPECT(!stream.has_any_error() && stream.eof());
 
     EXPECT(compare({ expected, sizeof(expected) }, { actual, sizeof(actual) }));
 }
@@ -95,17 +95,17 @@ TEST_CASE(seeking_slicing_offset)
     InputMemoryStream stream { { input, sizeof(input) } };
 
     stream >> Bytes { actual0, sizeof(actual0) };
-    EXPECT(!stream.has_error() && !stream.eof());
+    EXPECT(!stream.has_any_error() && !stream.eof());
     EXPECT(compare({ expected0, sizeof(expected0) }, { actual0, sizeof(actual0) }));
 
     stream.seek(4);
     stream >> Bytes { actual1, sizeof(actual1) };
-    EXPECT(!stream.has_error() && stream.eof());
+    EXPECT(!stream.has_any_error() && stream.eof());
     EXPECT(compare({ expected1, sizeof(expected1) }, { actual1, sizeof(actual1) }));
 
     stream.seek(1);
     stream >> Bytes { actual2, sizeof(actual2) };
-    EXPECT(!stream.has_error() && !stream.eof());
+    EXPECT(!stream.has_any_error() && !stream.eof());
     EXPECT(compare({ expected2, sizeof(expected2) }, { actual2, sizeof(actual2) }));
 }
 

--- a/AK/Tests/TestStream.cpp
+++ b/AK/Tests/TestStream.cpp
@@ -123,7 +123,7 @@ TEST_CASE(duplex_simple)
     EXPECT(stream.eof());
 }
 
-TEST_CASE(duplex_seek_into_history)
+TEST_CASE(duplex_large_buffer)
 {
     DuplexMemoryStream stream;
 
@@ -131,53 +131,19 @@ TEST_CASE(duplex_seek_into_history)
 
     EXPECT_EQ(stream.remaining(), 0ul);
 
-    for (size_t idx = 0; idx < 256; ++idx) {
+    for (size_t idx = 0; idx < 256; ++idx)
         stream << one_kibibyte;
-    }
 
     EXPECT_EQ(stream.remaining(), 256 * 1024ul);
 
-    for (size_t idx = 0; idx < 128; ++idx) {
+    for (size_t idx = 0; idx < 128; ++idx)
         stream >> one_kibibyte;
-    }
 
     EXPECT_EQ(stream.remaining(), 128 * 1024ul);
 
-    // We now have 128KiB on the stream. Because the stream has a
-    // history size of 64KiB, we should be able to seek to 64KiB.
-    static_assert(DuplexMemoryStream::history_size == 64 * 1024);
-    stream.rseek(64 * 1024);
-
-    EXPECT_EQ(stream.remaining(), 192 * 1024ul);
-
-    for (size_t idx = 0; idx < 192; ++idx) {
+    for (size_t idx = 0; idx < 128; ++idx)
         stream >> one_kibibyte;
-    }
 
-    EXPECT(stream.eof());
-}
-
-TEST_CASE(duplex_wild_seeking)
-{
-    DuplexMemoryStream stream;
-
-    int input0 = 42, input1 = 13, input2 = -12;
-    int output0, output1, output2;
-
-    stream << input2;
-    stream << input0 << input1;
-    stream.rseek(0);
-    stream << input2 << input0;
-
-    stream.rseek(4);
-    stream >> output0 >> output1 >> output2;
-
-    EXPECT(!stream.eof());
-    EXPECT_EQ(input0, output0);
-    EXPECT_EQ(input1, output1);
-    EXPECT_EQ(input2, output2);
-
-    stream.discard_or_error(4);
     EXPECT(stream.eof());
 }
 

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -28,6 +28,7 @@
 #include <AK/BinarySearch.h>
 #include <AK/FixedArray.h>
 #include <AK/LogStream.h>
+#include <AK/MemoryStream.h>
 
 #include <LibCompress/Deflate.h>
 

--- a/Libraries/LibCompress/Gzip.cpp
+++ b/Libraries/LibCompress/Gzip.cpp
@@ -26,6 +26,7 @@
 
 #include <LibCompress/Gzip.h>
 
+#include <AK/MemoryStream.h>
 #include <AK/String.h>
 
 namespace Compress {

--- a/Libraries/LibCompress/Gzip.cpp
+++ b/Libraries/LibCompress/Gzip.cpp
@@ -77,12 +77,12 @@ size_t GzipDecompressor::read(Bytes bytes)
             m_input_stream >> crc32 >> input_size;
 
             if (crc32 != current_member().m_checksum.digest()) {
-                m_error = true;
+                set_fatal_error();
                 return 0;
             }
 
             if (input_size != current_member().m_nread) {
-                m_error = true;
+                set_fatal_error();
                 return 0;
             }
 
@@ -101,7 +101,7 @@ size_t GzipDecompressor::read(Bytes bytes)
         m_input_stream >> Bytes { &header, sizeof(header) };
 
         if (!header.valid_magic_number() || !header.supported_by_implementation()) {
-            m_error = true;
+            set_fatal_error();
             return 0;
         }
 
@@ -129,7 +129,7 @@ size_t GzipDecompressor::read(Bytes bytes)
 bool GzipDecompressor::read_or_error(Bytes bytes)
 {
     if (read(bytes) < bytes.size()) {
-        m_error = true;
+        set_fatal_error();
         return false;
     }
 
@@ -143,7 +143,7 @@ bool GzipDecompressor::discard_or_error(size_t count)
     size_t ndiscarded = 0;
     while (ndiscarded < count) {
         if (eof()) {
-            m_error = true;
+            set_fatal_error();
             return false;
         }
 

--- a/Libraries/LibCore/FileStream.h
+++ b/Libraries/LibCore/FileStream.h
@@ -63,7 +63,7 @@ public:
 
         while (nread < bytes.size() && !eof()) {
             if (m_file->has_error()) {
-                m_error = true;
+                set_fatal_error();
                 return 0;
             }
 
@@ -77,7 +77,7 @@ public:
     bool read_or_error(Bytes bytes) override
     {
         if (read(bytes) < bytes.size()) {
-            m_error = true;
+            set_fatal_error();
             return false;
         }
 
@@ -93,7 +93,7 @@ public:
             ndiscarded += read({ buffer, min<size_t>(count - ndiscarded, sizeof(buffer)) });
 
         if (eof()) {
-            m_error = true;
+            set_fatal_error();
             return false;
         }
 
@@ -116,7 +116,7 @@ public:
     void close()
     {
         if (!m_file->close())
-            m_error = true;
+            set_fatal_error();
     }
 
 private:
@@ -153,7 +153,7 @@ public:
     size_t write(ReadonlyBytes bytes) override
     {
         if (!m_file->write(bytes.data(), bytes.size())) {
-            m_error = true;
+            set_fatal_error();
             return 0;
         }
 
@@ -163,7 +163,7 @@ public:
     bool write_or_error(ReadonlyBytes bytes) override
     {
         if (write(bytes) < bytes.size()) {
-            m_error = true;
+            set_fatal_error();
             return false;
         }
 
@@ -173,7 +173,7 @@ public:
     void close()
     {
         if (!m_file->close())
-            m_error = true;
+            set_fatal_error();
     }
 
 private:

--- a/Libraries/LibDebug/DebugInfo.cpp
+++ b/Libraries/LibDebug/DebugInfo.cpp
@@ -25,8 +25,8 @@
  */
 
 #include "DebugInfo.h"
+#include <AK/MemoryStream.h>
 #include <AK/QuickSort.h>
-#include <AK/Stream.h>
 #include <LibDebug/Dwarf/CompilationUnit.h>
 #include <LibDebug/Dwarf/DwarfInfo.h>
 #include <LibDebug/Dwarf/Expression.h>

--- a/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
+++ b/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
@@ -27,7 +27,7 @@
 #include "AbbreviationsMap.h"
 #include "DwarfInfo.h"
 
-#include <AK/Stream.h>
+#include <AK/MemoryStream.h>
 
 namespace Debug::Dwarf {
 

--- a/Libraries/LibDebug/Dwarf/DIE.cpp
+++ b/Libraries/LibDebug/Dwarf/DIE.cpp
@@ -28,7 +28,7 @@
 #include "CompilationUnit.h"
 #include "DwarfInfo.h"
 #include <AK/ByteBuffer.h>
-#include <AK/Stream.h>
+#include <AK/MemoryStream.h>
 
 namespace Debug::Dwarf {
 

--- a/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -26,7 +26,7 @@
 
 #include "DwarfInfo.h"
 
-#include <AK/Stream.h>
+#include <AK/MemoryStream.h>
 
 namespace Debug::Dwarf {
 
@@ -53,7 +53,7 @@ void DwarfInfo::populate_compilation_units()
     if (m_debug_info_data.is_null())
         return;
 
-    InputMemoryStream stream{ m_debug_info_data };
+    InputMemoryStream stream { m_debug_info_data };
     while (!stream.eof()) {
         auto unit_offset = stream.offset();
         CompilationUnitHeader compilation_unit_header {};

--- a/Libraries/LibDebug/Dwarf/Expression.cpp
+++ b/Libraries/LibDebug/Dwarf/Expression.cpp
@@ -25,7 +25,7 @@
  */
 #include "Expression.h"
 
-#include <AK/Stream.h>
+#include <AK/MemoryStream.h>
 
 #include <sys/arch/i386/regs.h>
 

--- a/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -66,9 +66,9 @@ void LineProgram::parse_source_directories()
 #endif
         m_source_directories.append(move(directory));
     }
-    m_stream.handle_error();
+    m_stream.handle_recoverable_error();
     m_stream.discard_or_error(1);
-    ASSERT(!m_stream.handle_error());
+    ASSERT(!m_stream.has_any_error());
 }
 
 void LineProgram::parse_source_files()
@@ -88,7 +88,7 @@ void LineProgram::parse_source_files()
         m_source_files.append({ file_name, directory_index });
     }
     m_stream.discard_or_error(1);
-    ASSERT(!m_stream.handle_error());
+    ASSERT(!m_stream.has_any_error());
 }
 
 void LineProgram::append_to_line_info()

--- a/Libraries/LibDebug/Dwarf/LineProgram.h
+++ b/Libraries/LibDebug/Dwarf/LineProgram.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <AK/Stream.h>
+#include <AK/MemoryStream.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 
@@ -57,7 +57,8 @@ private:
     void handle_standard_opcode(u8 opcode);
     void handle_sepcial_opcode(u8 opcode);
 
-    struct [[gnu::packed]] UnitHeader32 {
+    struct [[gnu::packed]] UnitHeader32
+    {
         u32 length;
         u16 version;
         u32 header_length;

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -26,6 +26,7 @@
 
 #include "AST.h"
 #include "Shell.h"
+#include <AK/MemoryStream.h>
 #include <AK/ScopeGuard.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>


### PR DESCRIPTION
Streams like `InputMemoryStream` and `DeflateDecompressor` have slightly different semantics. If you try to read 4096 byte from an `InputMemoryStream` that only has 1024 bytes, then it will fail, but you can still go on because the stream is still in a well defined state. Doing the same with `DeflateDecompressor` leaves the stream in a not so well defined state because some of the data could have been consumed already, the stream is left in an undefined state.

That's why I am adding `has_fatal_error` and `has_recoverable_error` instead of a single `has_error`.

