### PR TITLE
LibJS: IndexedProperties size stuff

### DIFF
--- a/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -346,6 +346,13 @@ void IndexedProperties::append_all(Object* this_object, const IndexedProperties&
     }
 }
 
+void IndexedProperties::set_array_like_size(size_t new_size)
+{
+    if (m_storage->is_simple_storage() && new_size > SPARSE_ARRAY_THRESHOLD)
+        switch_to_generic_storage();
+    m_storage->set_array_like_size(new_size);
+}
+
 Vector<ValueAndAttributes> IndexedProperties::values_unordered() const
 {
     if (m_storage->is_simple_storage()) {

--- a/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -208,6 +208,7 @@ ValueAndAttributes GenericIndexedPropertyStorage::take_last()
 
 void GenericIndexedPropertyStorage::set_array_like_size(size_t new_size)
 {
+    m_array_size = new_size;
     if (new_size < SPARSE_ARRAY_THRESHOLD) {
         m_packed_elements.resize(new_size);
         m_sparse_elements.clear();

--- a/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -162,7 +162,7 @@ public:
     size_t size() const { return m_storage->size(); }
     bool is_empty() const { return size() == 0; }
     size_t array_like_size() const { return m_storage->array_like_size(); }
-    void set_array_like_size(size_t new_size) { m_storage->set_array_like_size(new_size); };
+    void set_array_like_size(size_t);
 
     Vector<ValueAndAttributes> values_unordered() const;
 

--- a/Libraries/LibJS/Tests/builtins/Array/array-simple-and-generic-storage-initialization.js
+++ b/Libraries/LibJS/Tests/builtins/Array/array-simple-and-generic-storage-initialization.js
@@ -1,0 +1,15 @@
+describe("Issue #3382", () => {
+    test("Creating an array with simple storage (<= 200 initial elements)", () => {
+        var a = Array(200);
+        expect(a).toHaveLength(200);
+        expect(a.push("foo")).toBe(201);
+        expect(a).toHaveLength(201);
+    });
+
+    test("Creating an array with generic storage (> 200 initial elements)", () => {
+        var a = Array(201);
+        expect(a).toHaveLength(201);
+        expect(a.push("foo")).toBe(202);
+        expect(a).toHaveLength(202);
+    });
+});


### PR DESCRIPTION
**LibJS: Let set_array_like_size() switch to generic storage if necessary**

This is already considered in `put()`/`insert()`/`append_all()` but not `set_array_like_size()`, which crashed the interpreter with an assertion when creating an array with more than `SPARSE_ARRAY_THRESHOLD` (200) initial elements as the simple storage was being resized beyond its limit.

**LibJS: Actually change size in generic storage's set_array_like_size()**

Looks like an oversight to me - we were not actually setting a new value for `m_array_size`, which would cause arrays created with generic storage to report a `.length` of 0.