### PR TITLE
Kernel: Fix memory purge clobbering mapped page directory in ensure_pte 

### DIFF
--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -112,7 +112,7 @@ public:
         Yes
     };
 
-    RefPtr<PhysicalPage> allocate_user_physical_page(ShouldZeroFill = ShouldZeroFill::Yes);
+    RefPtr<PhysicalPage> allocate_user_physical_page(ShouldZeroFill = ShouldZeroFill::Yes, bool* did_purge = nullptr);
     RefPtr<PhysicalPage> allocate_supervisor_physical_page();
     NonnullRefPtrVector<PhysicalPage> allocate_contiguous_supervisor_physical_pages(size_t size);
     void deallocate_user_physical_page(const PhysicalPage&);

--- a/Kernel/VM/PurgeableVMObject.cpp
+++ b/Kernel/VM/PurgeableVMObject.cpp
@@ -82,9 +82,12 @@ int PurgeableVMObject::purge_impl()
     }
     m_was_purged = true;
 
-    for_each_region([&](auto& region) {
-        region.remap();
-    });
+    if (purged_page_count > 0) {
+        for_each_region([&](auto& region) {
+            if (&region.vmobject() == this)
+               region.remap();
+        });
+    }
 
     return purged_page_count;
 }

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -144,7 +144,6 @@ bool Region::commit(size_t page_index)
     auto physical_page = MM.allocate_user_physical_page(MemoryManager::ShouldZeroFill::Yes);
     if (!physical_page) {
         klog() << "MM: commit was unable to allocate a physical page";
-        ASSERT_NOT_REACHED();
         return false;
     }
     vmobject_physical_page_entry = move(physical_page);


### PR DESCRIPTION
If allocating a page table triggers purging memory, we need to call
quickmap_pd again to make sure the underlying physical page is
remapped to the correct one. This is needed because purging itself
may trigger calls to ensure_pte as well.

Fixes #3370