### PR TITLE
DisplaySettings: Remove unnecessary file open for non-paths

### DIFF
--- a/Applications/DisplaySettings/DisplaySettings.cpp
+++ b/Applications/DisplaySettings/DisplaySettings.cpp
@@ -125,7 +125,7 @@ void DisplaySettingsWidget::create_frame()
     m_wallpaper_combo->set_model(*GUI::ItemListModel<AK::String>::create(m_wallpapers));
     m_wallpaper_combo->on_change = [this](auto& text, const GUI::ModelIndex& index) {
         String path = text;
-        if (m_monitor_widget->set_wallpaper(path)) {
+        if (path.starts_with("/") && m_monitor_widget->set_wallpaper(path)) {
             m_monitor_widget->update();
             return;
         }


### PR DESCRIPTION
Currently, every time the wallpaper picker changes, an additional
attempted file load happens on top of the file load to create the
bitmap. The only values that the wallpaper picker can take on are
filenames that can never be valid when loaded without the /res/wallpaper
prefix. To reduce the amount of log spam and speed up wallpaper picking,
this patch only attempts to load wallpapers with slash-prefixed names,
assumed to be the absolute path to that wallpaper. Additional wallpapers
outside of /res/wallpapers/ should still be accessible with this patch,
and the experience is improved for the more common case of selecting a
built-in wallpaper.