### PR TITLE
First few fuzzing fixes

### DIFF
--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -77,7 +77,7 @@ public:
             }
         }
 
-        return discard_or_error(count);
+        return m_stream.discard_or_error(count);
     }
 
     u32 read_bits(size_t count)

--- a/Applications/PixelPaint/BucketTool.cpp
+++ b/Applications/PixelPaint/BucketTool.cpp
@@ -58,10 +58,10 @@ static void flood_fill(Gfx::Bitmap& bitmap, const Gfx::IntPoint& start_position,
     while (!queue.is_empty()) {
         auto position = queue.dequeue();
 
-        if (bitmap.get_pixel<Gfx::BitmapFormat::RGBA32>(position.x(), position.y()) != target_color)
+        if (bitmap.get_pixel<Gfx::StorageFormat::RGBA32>(position.x(), position.y()) != target_color)
             continue;
 
-        bitmap.set_pixel<Gfx::BitmapFormat::RGBA32>(position.x(), position.y(), fill_color);
+        bitmap.set_pixel<Gfx::StorageFormat::RGBA32>(position.x(), position.y(), fill_color);
 
         if (position.x() != 0)
             queue.enqueue(position.translated(-1, 0));

--- a/Applications/PixelPaint/SprayTool.cpp
+++ b/Applications/PixelPaint/SprayTool.cpp
@@ -77,7 +77,7 @@ void SprayTool::paint_it()
             continue;
         if (ypos < 0 || ypos >= bitmap.height())
             continue;
-        bitmap.set_pixel<Gfx::BitmapFormat::RGB32>(xpos, ypos, m_color);
+        bitmap.set_pixel<Gfx::StorageFormat::RGBA32>(xpos, ypos, m_color);
     }
 
     layer->did_modify_bitmap(*m_editor->image());

--- a/Demos/Fire/Fire.cpp
+++ b/Demos/Fire/Fire.cpp
@@ -119,7 +119,7 @@ Fire::Fire()
 
     /* Draw fire "source" on bottom row of pixels */
     for (int i = 0; i < FIRE_WIDTH; i++)
-        bitmap->bits(bitmap->height() - 1)[i] = FIRE_MAX;
+        bitmap->scanline_u8(bitmap->height() - 1)[i] = FIRE_MAX;
 
     /* Set off initital paint event */
     //update();
@@ -157,7 +157,7 @@ void Fire::timer_event(Core::TimerEvent&)
             int rnd = rand() % 3;
 
             /* Calculate new pixel value, don't go below 0 */
-            u8 nv = bitmap->bits(py)[px];
+            u8 nv = bitmap->scanline_u8(py)[px];
             if (nv > 0)
                 nv -= (rnd & 1);
 
@@ -168,7 +168,7 @@ void Fire::timer_event(Core::TimerEvent&)
             else if (epx > FIRE_WIDTH)
                 epx = FIRE_WIDTH;
 
-            bitmap->bits(py - 1)[epx] = nv;
+            bitmap->scanline_u8(py - 1)[epx] = nv;
         }
     }
 
@@ -199,10 +199,10 @@ void Fire::mousemove_event(GUI::MouseEvent& event)
         if (event.y() >= 2 && event.y() < 398 && event.x() <= 638) {
             int ypos = event.y() / 2;
             int xpos = event.x() / 2;
-            bitmap->bits(ypos - 1)[xpos] = FIRE_MAX + 5;
-            bitmap->bits(ypos - 1)[xpos + 1] = FIRE_MAX + 5;
-            bitmap->bits(ypos)[xpos] = FIRE_MAX + 5;
-            bitmap->bits(ypos)[xpos + 1] = FIRE_MAX + 5;
+            bitmap->scanline_u8(ypos - 1)[xpos] = FIRE_MAX + 5;
+            bitmap->scanline_u8(ypos - 1)[xpos + 1] = FIRE_MAX + 5;
+            bitmap->scanline_u8(ypos)[xpos] = FIRE_MAX + 5;
+            bitmap->scanline_u8(ypos)[xpos + 1] = FIRE_MAX + 5;
         }
     }
 

--- a/Libraries/LibGUI/Clipboard.cpp
+++ b/Libraries/LibGUI/Clipboard.cpp
@@ -141,7 +141,7 @@ RefPtr<Gfx::Bitmap> Clipboard::bitmap() const
     if (!format.has_value() || format.value() == 0)
         return nullptr;
 
-    auto clipping_bitmap = Gfx::Bitmap::create_wrapper((Gfx::BitmapFormat)format.value(), { (int)width.value(), (int)height.value() }, pitch.value(), (Gfx::RGBA32*)clipping.data.data());
+    auto clipping_bitmap = Gfx::Bitmap::create_wrapper((Gfx::BitmapFormat)format.value(), { (int)width.value(), (int)height.value() }, pitch.value(), clipping.data.data());
     auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::RGBA32, { (int)width.value(), (int)height.value() });
 
     for (int y = 0; y < clipping_bitmap->height(); ++y) {

--- a/Libraries/LibGUI/Menu.cpp
+++ b/Libraries/LibGUI/Menu.cpp
@@ -118,7 +118,7 @@ static int ensure_realized_icon(IconContainerType& container)
             auto shared_buffer = SharedBuffer::create_with_size(container.icon()->size_in_bytes());
             ASSERT(shared_buffer);
             auto shared_icon = Gfx::Bitmap::create_with_shared_buffer(Gfx::BitmapFormat::RGBA32, *shared_buffer, container.icon()->size());
-            memcpy(shared_buffer->data(), container.icon()->bits(0), container.icon()->size_in_bytes());
+            memcpy(shared_buffer->data(), container.icon()->scanline_u8(0), container.icon()->size_in_bytes());
             shared_buffer->seal();
             shared_buffer->share_with(WindowServerConnection::the().server_pid());
             container.set_icon(shared_icon);

--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -44,11 +44,16 @@
 
 namespace Gfx {
 
-static bool size_would_overflow(BitmapFormat format, const IntSize& size)
+static bool size_would_overflow(BitmapFormat, const IntSize& size)
 {
     if (size.width() < 0 || size.height() < 0)
         return true;
-    return Checked<size_t>::multiplication_would_overflow(size.width(), size.height(), Bitmap::bpp_for_format(format));
+    // This check is a bit arbitrary, but should protect us from most shenanigans:
+    if (size.width() >= 32768 || size.height() >= 32768)
+        return true;
+    // This check is absolutely necessary. Note that Bitmap::Bitmap always stores
+    // data as RGBA32 internally, so currently we ignore the indicated format.
+    return Checked<size_t>::multiplication_would_overflow(size.width(), size.height(), sizeof(RGBA32));
 }
 
 RefPtr<Bitmap> Bitmap::create(BitmapFormat format, const IntSize& size)

--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -86,7 +86,11 @@ Bitmap::Bitmap(BitmapFormat format, const IntSize& size, Purgeable purgeable)
     int map_flags = (MAP_ANONYMOUS | MAP_PRIVATE);
     m_data = (RGBA32*)mmap(nullptr, size_in_bytes(), PROT_READ | PROT_WRITE, map_flags, 0, 0);
 #endif
-    ASSERT(m_data && m_data != (void*)-1);
+    if (m_data == MAP_FAILED) {
+        perror("mmap");
+        ASSERT_NOT_REACHED();
+    }
+    ASSERT(m_data);
     m_needs_munmap = true;
 }
 

--- a/Libraries/LibGfx/Bitmap.h
+++ b/Libraries/LibGfx/Bitmap.h
@@ -93,9 +93,6 @@ public:
     RGBA32* scanline(int y);
     const RGBA32* scanline(int y) const;
 
-    u8* bits(int y);
-    const u8* bits(int y) const;
-
     IntRect rect() const { return { {}, m_size }; }
     IntSize size() const { return m_size; }
     int width() const { return m_size.width(); }
@@ -250,16 +247,6 @@ inline const RGBA32* Bitmap::scanline(int y) const
     return reinterpret_cast<const RGBA32*>(scanline_u8(y));
 }
 
-inline const u8* Bitmap::bits(int y) const
-{
-    return reinterpret_cast<const u8*>(scanline(y));
-}
-
-inline u8* Bitmap::bits(int y)
-{
-    return reinterpret_cast<u8*>(scanline(y));
-}
-
 template<>
 inline Color Bitmap::get_pixel<BitmapFormat::RGB32>(int x, int y) const
 {
@@ -275,25 +262,25 @@ inline Color Bitmap::get_pixel<BitmapFormat::RGBA32>(int x, int y) const
 template<>
 inline Color Bitmap::get_pixel<BitmapFormat::Indexed1>(int x, int y) const
 {
-    return Color::from_rgb(m_palette[bits(y)[x]]);
+    return Color::from_rgb(m_palette[scanline_u8(y)[x]]);
 }
 
 template<>
 inline Color Bitmap::get_pixel<BitmapFormat::Indexed2>(int x, int y) const
 {
-    return Color::from_rgb(m_palette[bits(y)[x]]);
+    return Color::from_rgb(m_palette[scanline_u8(y)[x]]);
 }
 
 template<>
 inline Color Bitmap::get_pixel<BitmapFormat::Indexed4>(int x, int y) const
 {
-    return Color::from_rgb(m_palette[bits(y)[x]]);
+    return Color::from_rgb(m_palette[scanline_u8(y)[x]]);
 }
 
 template<>
 inline Color Bitmap::get_pixel<BitmapFormat::Indexed8>(int x, int y) const
 {
-    return Color::from_rgb(m_palette[bits(y)[x]]);
+    return Color::from_rgb(m_palette[scanline_u8(y)[x]]);
 }
 
 inline Color Bitmap::get_pixel(int x, int y) const

--- a/Libraries/LibGfx/Painter.cpp
+++ b/Libraries/LibGfx/Painter.cpp
@@ -51,13 +51,13 @@ template<BitmapFormat format = BitmapFormat::Invalid>
 ALWAYS_INLINE Color get_pixel(const Gfx::Bitmap& bitmap, int x, int y)
 {
     if constexpr (format == BitmapFormat::Indexed8)
-        return bitmap.palette_color(bitmap.bits(y)[x]);
+        return bitmap.palette_color(bitmap.scanline_u8(y)[x]);
     if constexpr (format == BitmapFormat::Indexed4)
-        return bitmap.palette_color(bitmap.bits(y)[x]);
+        return bitmap.palette_color(bitmap.scanline_u8(y)[x]);
     if constexpr (format == BitmapFormat::Indexed2)
-        return bitmap.palette_color(bitmap.bits(y)[x]);
+        return bitmap.palette_color(bitmap.scanline_u8(y)[x]);
     if constexpr (format == BitmapFormat::Indexed1)
-        return bitmap.palette_color(bitmap.bits(y)[x]);
+        return bitmap.palette_color(bitmap.scanline_u8(y)[x]);
     if constexpr (format == BitmapFormat::RGB32)
         return Color::from_rgb(bitmap.scanline(y)[x]);
     if constexpr (format == BitmapFormat::RGBA32)
@@ -678,7 +678,7 @@ void Painter::blit(const IntPoint& position, const Gfx::Bitmap& source, const In
     }
 
     if (Bitmap::is_indexed(source.format())) {
-        const u8* src = source.bits(src_rect.top() + first_row) + src_rect.left() + first_column;
+        const u8* src = source.scanline_u8(src_rect.top() + first_row) + src_rect.left() + first_column;
         const size_t src_skip = source.pitch();
         for (int row = first_row; row <= last_row; ++row) {
             for (int i = 0; i < clipped_rect.width(); ++i)

--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -248,17 +248,17 @@ bool Lexer::slash_means_division() const
 {
     auto type = m_current_token.type();
     return type == TokenType::BigIntLiteral
-           || type == TokenType::BoolLiteral
-           || type == TokenType::BracketClose
-           || type == TokenType::CurlyClose
-           || type == TokenType::Identifier
-           || type == TokenType::NullLiteral
-           || type == TokenType::NumericLiteral
-           || type == TokenType::ParenClose
-           || type == TokenType::RegexLiteral
-           || type == TokenType::StringLiteral
-           || type == TokenType::TemplateLiteralEnd
-           || type == TokenType::This;
+        || type == TokenType::BoolLiteral
+        || type == TokenType::BracketClose
+        || type == TokenType::CurlyClose
+        || type == TokenType::Identifier
+        || type == TokenType::NullLiteral
+        || type == TokenType::NumericLiteral
+        || type == TokenType::ParenClose
+        || type == TokenType::RegexLiteral
+        || type == TokenType::StringLiteral
+        || type == TokenType::TemplateLiteralEnd
+        || type == TokenType::This;
 }
 
 Token Lexer::next()
@@ -292,6 +292,8 @@ Token Lexer::next()
     }
 
     size_t value_start = m_position;
+    size_t value_start_line_number = m_line_number;
+    size_t value_start_column_number = m_line_column;
     auto token_type = TokenType::Invalid;
 
     if (m_current_token.type() == TokenType::RegexLiteral && !is_eof() && isalpha(m_current_char)) {
@@ -511,8 +513,8 @@ Token Lexer::next()
         token_type,
         m_source.substring_view(trivia_start - 1, value_start - trivia_start),
         m_source.substring_view(value_start - 1, m_position - value_start),
-        m_line_number,
-        m_line_column - m_position + value_start);
+        value_start_line_number,
+        value_start_column_number);
 
     return m_current_token;
 }

--- a/Meta/Lagom/Fuzzers/CMakeLists.txt
+++ b/Meta/Lagom/Fuzzers/CMakeLists.txt
@@ -1,3 +1,12 @@
+add_executable(FuzzBMP FuzzBMP.cpp)
+target_compile_options(FuzzBMP
+    PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>
+    )
+target_link_libraries(FuzzBMP
+    PUBLIC Lagom
+    PRIVATE $<$<C_COMPILER_ID:Clang>:-fsanitize=fuzzer>
+    )
+
 add_executable(FuzzELF FuzzELF.cpp)
 target_compile_options(FuzzELF
     PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>

--- a/Meta/Lagom/Fuzzers/FuzzBMP.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBMP.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibGfx/BMPLoader.h>
+#include <stdio.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    Gfx::BMPImageDecoderPlugin loader { data, size };
+    auto bitmap = loader.bitmap();
+    if (!bitmap)
+        return 1;
+    if (bitmap->width() >= 100000 || bitmap->height() >= 100000) {
+        fprintf(stderr, "Silly bitmap: %dx%d pixels?!\n", bitmap->width(), bitmap->height());
+        ASSERT_NOT_REACHED();
+    }
+    return 0;
+}

--- a/Meta/Lagom/Fuzzers/FuzzJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzJs.cpp
@@ -36,7 +36,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     auto lexer = JS::Lexer(js);
     auto parser = JS::Parser(lexer);
     parser.parse_program();
-    if (parser.has_errors())
-        parser.print_errors();
+    if (parser.has_errors()) {
+        for (auto& error : parser.errors()) {
+            if (error.line >= 100000 || error.column >= 100000) {
+                fprintf(stderr, "%s\n", error.to_string().characters());
+                ASSERT_NOT_REACHED();
+            }
+        }
+    }
     return 0;
 }

--- a/Meta/Lagom/ReadMe.md
+++ b/Meta/Lagom/ReadMe.md
@@ -10,11 +10,38 @@ If you want to bring the comfortable Serenity classes with you to another system
 
 ## Fuzzing
 
-Lagom can be used to fuzz parts of SerenityOS's code base. This requires buildling with `clang`, so it's convenient to use a different build directory for that. Run CMake like so:
+Lagom can be used to fuzz parts of SerenityOS's code base. This requires buildling with `clang`, so it's convenient to use a different build directory for that. Run CMake like this:
 
     # From the root of the SerenityOS checkout:
     mkdir BuildLagom && cd BuildLagom
     cmake -GNinja -DBUILD_LAGOM=ON -DENABLE_FUZZER_SANITIZER=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ..
+    ninja Meta/Lagom/all
+    # Or as a handy rebuild-rerun line:
     ninja FuzzJs && Meta/Lagom/Fuzzers/FuzzJs
 
-clang emits different warnings than gcc, so you'll likely have to remove `-Werror` in CMakeLists.txt and Meta/Lagom/CMakeLIsts.txt.
+Any fuzzing results (particularly slow inputs, crashes, etc.) will be dropped in the current directory.
+
+clang emits different warnings than gcc, so you may have to remove `-Werror` in CMakeLists.txt and Meta/Lagom/CMakeLists.txt.
+
+Fuzzers work better if you give them a fuzz corpus, e.g. `Meta/Lagom/Fuzzers/FuzzBMP ../Base/res/html/misc/bmpsuite_files/rgba32-61754.bmp` Pay attention that LLVM also likes creating new files, don't blindly commit them (yet)!
+
+### Analyzing a crash
+
+LLVM fuzzers have a weird interface. In particular, to see the help, you need to call it with `-help=1`, and it will ignore `--help` and `-help`.
+
+To reproduce a crash, run it like this: `MyFuzzer crash-27480a219572aa5a11b285968a3632a4cf25388e`
+
+To reproduce a crash in gdb, you want to disable various signal handlers, so that gdb sees the actual location of the crash:
+
+```
+$ gdb ./Meta/Lagom/Fuzzers/FuzzBMP
+<... SNIP some output ...>
+(gdb) run -handle_abrt=0 -handle_segv=0 crash-27480a219572aa5a11b285968a3632a4cf25388e
+<... SNIP some output ...>
+FuzzBMP: ../../Libraries/LibGfx/Bitmap.cpp:84: Gfx::Bitmap::Bitmap(Gfx::BitmapFormat, const Gfx::IntSize &, Gfx::Bitmap::Purgeable): Assertion `m_data && m_data != (void*)-1' failed.
+
+Thread 1 "FuzzBMP" received signal SIGABRT, Aborted.
+__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
+50	../sysdeps/unix/sysv/linux/raise.c: File or directory not found.
+(gdb)
+```


### PR DESCRIPTION
This PR contains the first few results of my fuzzing attempts:
- Some more documentation and warning flag fixes
- LibJS: The parser used to sometimes report outrageous positions such as `line: 2, column: 4294967292`, which can lead to memory exhaustion when trying to generate a `source_location_hint`.
- LibGfx: We used to accept images out outrageous sizes – note that 16384×16384×32bit would mean a 1GiB allocation. If any program wants to handle even larger files, it'll have to use a different approach anyway, to avoid memory exhaustion.
- BMP loader: We used to blindly trust a file-internal offset, leading to segmentation fault.

I'm still fuzzing the BMP code, there still are crashes. However, it'll be a while until my next PR, that's why I'm trying to push this.

If you're interested in fuzzing Serenity, I would appreciate if you don't also focus on BMP, or else we just duplicate our efforts needlessly. :P