### PR TITLE
LibGUI: fix GIF animation in ImageWidget

### DIFF
--- a/Libraries/LibGUI/ImageWidget.cpp
+++ b/Libraries/LibGUI/ImageWidget.cpp
@@ -72,7 +72,7 @@ void ImageWidget::animate()
     m_current_frame_index = (m_current_frame_index + 1) % m_image_decoder->frame_count();
 
     const auto& current_frame = m_image_decoder->frame(m_current_frame_index);
-    set_bitmap(current_frame.image);
+    update();
 
     if (current_frame.duration != m_timer->interval()) {
         m_timer->restart(current_frame.duration);


### PR DESCRIPTION
Recent changes to GIF decoder mean that the ImageDecoder::frame method
no longer returns a completely new Bitmap object for each frame, but
instead updates the contents of a single cached Bitmap. Therefore after
advancing the frame we now directly update() instead of calling
set_bitmap which is a null operation if the Bitmap reference has not
changed.