### PR TITLE
Meta: Fix wonky copyright headers in Tests

### DIFF
--- a/Meta/check-style.sh
+++ b/Meta/check-style.sh
@@ -39,7 +39,6 @@ while IFS= read -r f; do
 done < <(git ls-files -- \
     '*.cpp' \
     '*.h' \
-    ':!:Tests' \
     ':!:Base' \
     ':!:Kernel/FileSystem/ext2_fs.h' \
     ':!:Libraries/LibC/getopt.cpp' \

--- a/Userland/Tests/Kernel/kill-pidtid-confusion.cpp
+++ b/Userland/Tests/Kernel/kill-pidtid-confusion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * Copyright (c) 2020, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/Userland/Tests/Kernel/setpgid-across-sessions-without-leader.cpp
+++ b/Userland/Tests/Kernel/setpgid-across-sessions-without-leader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * Copyright (c) 2020, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
I noticed these issues while researching for #3399. Thankfully, only my own headers are affected, so no "re-signing coordination" is needed.