### PR TITLE
Add Buffered<T> to add buffering to byte streams.

### DIFF
--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -40,8 +40,10 @@ public:
 
     size_t read(Bytes bytes) override
     {
-        size_t nread = 0;
+        if (has_any_error())
+            return 0;
 
+        size_t nread = 0;
         if (bytes.size() >= 1) {
             if (m_next_byte.has_value()) {
                 bytes[0] = m_next_byte.value();

--- a/AK/Buffered.h
+++ b/AK/Buffered.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Stream.h>
+
+namespace AK {
+
+// FIXME: Implement Buffered<T> for DuplexStream.
+
+template<typename StreamType, size_t Size = 4096, typename = void>
+class Buffered;
+
+template<typename StreamType, size_t Size>
+class Buffered<StreamType, Size, typename EnableIf<IsBaseOf<InputStream, StreamType>::value>::Type> final : public InputStream {
+public:
+    template<typename... Parameters>
+    explicit Buffered(Parameters&&... parameters)
+        : m_stream(forward<Parameters>(parameters)...)
+    {
+    }
+
+    bool has_recoverable_error() const override { return m_stream.has_recoverable_error(); }
+    bool has_fatal_error() const override { return m_stream.has_fatal_error(); }
+    bool has_any_error() const override { return m_stream.has_any_error(); }
+
+    bool handle_recoverable_error() override { return m_stream.handle_recoverable_error(); }
+    bool handle_fatal_error() override { return m_stream.handle_fatal_error(); }
+    bool handle_any_error() override { return m_stream.handle_any_error(); }
+
+    void set_recoverable_error() const override { return m_stream.set_recoverable_error(); }
+    void set_fatal_error() const override { return m_stream.set_fatal_error(); }
+
+    size_t read(Bytes bytes) override
+    {
+        auto nread = buffer().trim(m_buffer_remaining).copy_trimmed_to(bytes);
+
+        m_buffer_remaining -= nread;
+        buffer().slice(nread, m_buffer_remaining).copy_to(buffer());
+
+        if (nread < bytes.size()) {
+            m_buffer_remaining = m_stream.read(buffer());
+
+            if (m_buffer_remaining == 0)
+                return nread;
+
+            nread += read(bytes.slice(nread));
+        }
+
+        return nread;
+    }
+
+    virtual bool read_or_error(Bytes bytes) override
+    {
+        if (read(bytes) < bytes.size()) {
+            set_fatal_error();
+            return false;
+        }
+
+        return true;
+    }
+
+    virtual bool eof() const
+    {
+        if (m_buffer_remaining > 0)
+            return false;
+
+        m_buffer_remaining = m_stream.read(buffer());
+
+        return m_buffer_remaining == 0;
+    }
+
+    virtual bool discard_or_error(size_t count) override
+    {
+        size_t ndiscarded = 0;
+        while (ndiscarded < count) {
+            u8 dummy[Size];
+
+            if (!read_or_error({ dummy, min(Size, count - ndiscarded) }))
+                return false;
+
+            ndiscarded += min(Size, count - ndiscarded);
+        }
+
+        return true;
+    }
+
+private:
+    Bytes buffer() const { return { m_buffer, Size }; }
+
+    mutable StreamType m_stream;
+    mutable u8 m_buffer[Size];
+    mutable size_t m_buffer_remaining { 0 };
+};
+
+template<typename StreamType, size_t Size>
+class Buffered<StreamType, Size, typename EnableIf<IsBaseOf<OutputStream, StreamType>::value>::Type> final : public OutputStream {
+public:
+    template<typename... Parameters>
+    explicit Buffered(Parameters&&... parameters)
+        : m_stream(forward<Parameters>(parameters)...)
+    {
+    }
+
+    ~Buffered()
+    {
+        flush();
+    }
+
+    bool has_recoverable_error() const override { return m_stream.has_recoverable_error(); }
+    bool has_fatal_error() const override { return m_stream.has_fatal_error(); }
+    bool has_any_error() const override { return m_stream.has_any_error(); }
+
+    bool handle_recoverable_error() override { return m_stream.handle_recoverable_error(); }
+    bool handle_fatal_error() override { return m_stream.handle_fatal_error(); }
+    bool handle_any_error() override { return m_stream.handle_any_error(); }
+
+    void set_recoverable_error() const override { return m_stream.set_recoverable_error(); }
+    void set_fatal_error() const override { return m_stream.set_fatal_error(); }
+
+    size_t write(ReadonlyBytes bytes) override
+    {
+        if (has_any_error())
+            return 0;
+
+        auto nwritten = bytes.copy_trimmed_to(buffer().slice(m_buffered));
+        m_buffered += nwritten;
+
+        if (m_buffered == Size) {
+            flush();
+
+            if (bytes.size() - nwritten >= Size)
+                nwritten += m_stream.write_or_error(bytes);
+
+            nwritten += write(bytes.slice(nwritten));
+        }
+
+        return nwritten;
+    }
+
+    bool write_or_error(ReadonlyBytes bytes) override
+    {
+        write(bytes);
+        return true;
+    }
+
+    void flush()
+    {
+        m_stream.write_or_error({ m_buffer, m_buffered });
+        m_buffered = 0;
+    }
+
+private:
+    Bytes buffer() { return { m_buffer, Size }; }
+
+    StreamType m_stream;
+    u8 m_buffer[Size];
+    size_t m_buffered { 0 };
+};
+
+}
+
+using AK::Buffered;

--- a/AK/Buffered.h
+++ b/AK/Buffered.h
@@ -57,6 +57,9 @@ public:
 
     size_t read(Bytes bytes) override
     {
+        if (has_any_error())
+            return 0;
+
         auto nread = buffer().trim(m_buffer_remaining).copy_trimmed_to(bytes);
 
         m_buffer_remaining -= nread;

--- a/AK/CircularDuplexStream.h
+++ b/AK/CircularDuplexStream.h
@@ -60,6 +60,9 @@ public:
 
     size_t read(Bytes bytes) override
     {
+        if (has_any_error())
+            return 0;
+
         const auto nread = min(bytes.size(), m_queue.size());
 
         for (size_t idx = 0; idx < nread; ++idx)

--- a/AK/LogStream.h
+++ b/AK/LogStream.h
@@ -177,6 +177,12 @@ const LogStream& operator<<(const LogStream&, double);
 const LogStream& operator<<(const LogStream&, float);
 #endif
 
+template<typename T>
+const LogStream& operator<<(const LogStream& stream, Span<T> span)
+{
+    return stream << "{ " << span.data() << ", " << span.size() << " }";
+}
+
 const LogStream& operator<<(const LogStream&, const void*);
 
 inline const LogStream& operator<<(const LogStream& stream, char value)

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -44,6 +44,9 @@ public:
 
     size_t read(Bytes bytes) override
     {
+        if (has_any_error())
+            return 0;
+
         const auto count = min(bytes.size(), remaining());
         __builtin_memcpy(bytes.data(), m_bytes.data() + m_offset, count);
         m_offset += count;
@@ -239,6 +242,9 @@ public:
 
     size_t read(Bytes bytes) override
     {
+        if (has_any_error())
+            return 0;
+
         const auto nread = read_without_consuming(bytes);
 
         m_read_offset += nread;

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -75,6 +75,7 @@ namespace AK {
 
 class InputStream : public virtual AK::Detail::Stream {
 public:
+    // Does nothing and returns zero if there is already an error.
     virtual size_t read(Bytes) = 0;
     virtual bool read_or_error(Bytes) = 0;
     virtual bool eof() const = 0;

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -39,17 +39,17 @@ class Stream {
 public:
     virtual ~Stream() { ASSERT(!has_any_error()); }
 
-    bool has_recoverable_error() const { return m_recoverable_error; }
-    bool has_fatal_error() const { return m_fatal_error; }
-    bool has_any_error() const { return has_recoverable_error() || has_fatal_error(); }
+    virtual bool has_recoverable_error() const { return m_recoverable_error; }
+    virtual bool has_fatal_error() const { return m_fatal_error; }
+    virtual bool has_any_error() const { return has_recoverable_error() || has_fatal_error(); }
 
-    bool handle_recoverable_error()
+    virtual bool handle_recoverable_error()
     {
         ASSERT(!has_fatal_error());
         return exchange(m_recoverable_error, false);
     }
-    bool handle_fatal_error() { return exchange(m_fatal_error, false); }
-    bool handle_any_error()
+    virtual bool handle_fatal_error() { return exchange(m_fatal_error, false); }
+    virtual bool handle_any_error()
     {
         if (has_any_error()) {
             m_recoverable_error = false;
@@ -61,8 +61,8 @@ public:
         return false;
     }
 
-    void set_recoverable_error() const { m_recoverable_error = true; }
-    void set_fatal_error() const { m_fatal_error = true; }
+    virtual void set_recoverable_error() const { m_recoverable_error = true; }
+    virtual void set_fatal_error() const { m_fatal_error = true; }
 
 private:
     mutable bool m_recoverable_error { false };

--- a/AK/Tests/TestCircularDuplexStream.cpp
+++ b/AK/Tests/TestCircularDuplexStream.cpp
@@ -64,9 +64,8 @@ TEST_CASE(overwritting_is_well_defined)
 
     stream >> Bytes { bytes, sizeof(bytes) };
 
-    for (size_t idx = 0; idx < half_capacity; ++idx) {
+    for (size_t idx = 0; idx < half_capacity; ++idx)
         EXPECT_EQ(bytes[idx], idx % 256);
-    }
 
     for (size_t idx = 0; idx < half_capacity; ++idx)
         stream << static_cast<u8>(idx % 256);
@@ -82,6 +81,33 @@ TEST_CASE(overwritting_is_well_defined)
     }
 
     EXPECT(stream.eof());
+}
+
+TEST_CASE(of_by_one)
+{
+    constexpr size_t half_capacity = 32;
+    constexpr size_t capacity = half_capacity * 2;
+
+    CircularDuplexStream<capacity> stream;
+
+    for (size_t idx = 0; idx < half_capacity; ++idx)
+        stream << static_cast<u8>(0);
+
+    for (size_t idx = 0; idx < half_capacity; ++idx)
+        stream << static_cast<u8>(1);
+
+    stream.discard_or_error(capacity);
+
+    for (size_t idx = 0; idx < capacity; ++idx) {
+        u8 byte;
+        stream.read({ &byte, sizeof(byte) }, capacity);
+        stream << byte;
+
+        if (idx < half_capacity)
+            EXPECT_EQ(byte, 0);
+        else
+            EXPECT_EQ(byte, 1);
+    }
 }
 
 TEST_MAIN(CircularDuplexStream)

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -189,8 +189,8 @@ DeflateDecompressor::~DeflateDecompressor()
 
 size_t DeflateDecompressor::read(Bytes bytes)
 {
-    // FIXME: There are surely a ton of bugs because we don't check for read errors
-    //        very often.
+    if (has_any_error())
+        return 0;
 
     if (m_state == State::Idle) {
         if (m_read_final_bock)

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -110,6 +110,7 @@ u32 DeflateDecompressor::CanonicalCode::read_symbol(InputBitStream& stream) cons
     for (;;) {
         code_bits = code_bits << 1 | stream.read_bits(1);
 
+        // FIXME: This seems really inefficent, this could be an index into an array instead.
         size_t index;
         if (AK::binary_search(m_symbol_codes.span(), code_bits, AK::integral_compare<u32>, &index))
             return m_symbol_values[index];
@@ -405,7 +406,7 @@ void DeflateDecompressor::decode_codes(CanonicalCode& literal_code, Optional<Can
                 return;
             }
 
-            auto nrepeat = 3 + m_input_stream.read_bits(3);
+            auto nrepeat = 3 + m_input_stream.read_bits(2);
             for (size_t j = 0; j < nrepeat; ++j)
                 code_lengths.append(code_lengths.last());
         }

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -233,7 +233,8 @@ size_t DeflateDecompressor::read(Bytes bytes)
             return read(bytes);
         }
 
-        ASSERT_NOT_REACHED();
+        set_fatal_error();
+        return 0;
     }
 
     if (m_state == State::ReadingCompressedBlock) {

--- a/Libraries/LibCompress/Gzip.cpp
+++ b/Libraries/LibCompress/Gzip.cpp
@@ -78,6 +78,8 @@ size_t GzipDecompressor::read(Bytes bytes)
             m_input_stream >> crc32 >> input_size;
 
             if (crc32 != current_member().m_checksum.digest()) {
+                // FIXME: Somehow the checksum is incorrect?
+
                 set_fatal_error();
                 return 0;
             }

--- a/Libraries/LibCompress/Gzip.cpp
+++ b/Libraries/LibCompress/Gzip.cpp
@@ -68,6 +68,9 @@ GzipDecompressor::~GzipDecompressor()
 // FIXME: Again, there are surely a ton of bugs because the code doesn't check for read errors.
 size_t GzipDecompressor::read(Bytes bytes)
 {
+    if (has_any_error())
+        return 0;
+
     if (m_current_member.has_value()) {
         size_t nread = current_member().m_stream.read(bytes);
         current_member().m_checksum.update(bytes.trim(nread));

--- a/Libraries/LibCompress/Gzip.cpp
+++ b/Libraries/LibCompress/Gzip.cpp
@@ -97,7 +97,6 @@ size_t GzipDecompressor::read(Bytes bytes)
         if (m_input_stream.eof())
             return 0;
 
-        // FIXME: This fails with the new changes?
         BlockHeader header;
         m_input_stream >> Bytes { &header, sizeof(header) };
 

--- a/Libraries/LibCore/FileStream.h
+++ b/Libraries/LibCore/FileStream.h
@@ -65,6 +65,9 @@ public:
 
     size_t read(Bytes bytes) override
     {
+        if (has_any_error())
+            return 0;
+
         auto nread = m_buffered.bytes().copy_trimmed_to(bytes);
 
         m_buffered.bytes().slice(nread, m_buffered.size() - nread).copy_to(m_buffered);

--- a/Libraries/LibCore/FileStream.h
+++ b/Libraries/LibCore/FileStream.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Buffered.h>
 #include <AK/Stream.h>
 #include <LibCore/File.h>
 
@@ -48,6 +49,18 @@ public:
             return file_result.error();
 
         return InputFileStream { file_result.value() };
+    }
+
+    static Result<Buffered<InputFileStream>, String> open_buffered(StringView filename, IODevice::OpenMode mode = IODevice::OpenMode::ReadOnly, mode_t permissions = 0644)
+    {
+        ASSERT((mode & 0xf) == IODevice::OpenMode::ReadOnly || (mode & 0xf) == IODevice::OpenMode::ReadWrite);
+
+        auto file_result = File::open(filename, mode, permissions);
+
+        if (file_result.is_error())
+            return file_result.error();
+
+        return Buffered<InputFileStream> { file_result.value() };
     }
 
     size_t read(Bytes bytes) override
@@ -145,9 +158,26 @@ public:
         return OutputFileStream { file_result.value() };
     }
 
+    static Result<Buffered<OutputFileStream>, String> open_buffered(StringView filename, IODevice::OpenMode mode = IODevice::OpenMode::WriteOnly, mode_t permissions = 0644)
+    {
+        ASSERT((mode & 0xf) == IODevice::OpenMode::WriteOnly || (mode & 0xf) == IODevice::OpenMode::ReadWrite);
+
+        auto file_result = File::open(filename, mode, permissions);
+
+        if (file_result.is_error())
+            return file_result.error();
+
+        return Buffered<OutputFileStream> { file_result.value() };
+    }
+
     static OutputFileStream stdout()
     {
         return OutputFileStream { Core::File::stdout() };
+    }
+
+    static Buffered<OutputFileStream> stdout_buffered()
+    {
+        return Buffered<OutputFileStream> { Core::File::stdout() };
     }
 
     size_t write(ReadonlyBytes bytes) override


### PR DESCRIPTION
This is more of a collection of loosely related stuff.

  - I added a `Buffered<T>` template that adds buffering to any class that inherits from `InputStream` or `OutputStream`.

  - I've tried to get the Gzip implementation to a state where it can correctly decompress usual files (as opposed to files constructed to test one specific behavior.) I already found and fixed a few bugs but there seems to be a bug buried in `DeflateDecompressor::decode_distance` still.

  - I also accumulated a few unit tests that I wrote to track down errors.

It started to become annoying to rebase so I thought I'd merge some of it.
