### PR TITLE
Give ntpquery a `-s` flag to make it adjust the local clock

### DIFF
--- a/Libraries/LibC/sys/time.h
+++ b/Libraries/LibC/sys/time.h
@@ -43,6 +43,7 @@ struct timezone {
 };
 
 int gettimeofday(struct timeval* __restrict__, void* __restrict__) __attribute__((nonnull(1)));
+int settimeofday(struct timeval* __restrict__, void* __restrict__) __attribute__((nonnull(1)));
 
 static inline void timeradd(const struct timeval* a, const struct timeval* b, struct timeval* out)
 {

--- a/Libraries/LibC/time.cpp
+++ b/Libraries/LibC/time.cpp
@@ -55,6 +55,13 @@ int gettimeofday(struct timeval* __restrict__ tv, void* __restrict__)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+int settimeofday(struct timeval* __restrict__ tv, void* __restrict__)
+{
+    timespec ts;
+    TIMEVAL_TO_TIMESPEC(tv, &ts);
+    return clock_settime(CLOCK_REALTIME, &ts);
+}
+
 char* ctime(const time_t* t)
 {
     return asctime(localtime(t));

--- a/Userland/ntpquery.cpp
+++ b/Userland/ntpquery.cpp
@@ -168,6 +168,7 @@ int main(int argc, char** argv)
 
     socklen_t peer_address_size = sizeof(peer_address);
     rc = recvfrom(fd, &packet, sizeof(packet), 0, (struct sockaddr*)&peer_address, &peer_address_size);
+    gettimeofday(&t, nullptr);
     if (rc < 0) {
         perror("recvfrom");
         return 1;
@@ -176,6 +177,11 @@ int main(int argc, char** argv)
         fprintf(stderr, "incomplete packet recv\n");
         return 1;
     }
+
+    NtpTimestamp origin_timestamp = be64toh(packet.origin_timestamp);
+    NtpTimestamp receive_timestamp = be64toh(packet.receive_timestamp);
+    NtpTimestamp transmit_timestamp = be64toh(packet.transmit_timestamp);
+    NtpTimestamp destination_timestamp = ntp_timestamp_from_timeval(t);
 
     printf("NTP response from %s:\n", inet_ntoa(peer_address.sin_addr));
     printf("Leap Information: %d\n", packet.li_vn_mode >> 6);
@@ -187,8 +193,9 @@ int main(int argc, char** argv)
     printf("Root delay: %#x\n", ntohl(packet.root_delay));
     printf("Root dispersion: %#x\n", ntohl(packet.root_dispersion));
     printf("Reference ID: %#x\n", ntohl(packet.reference_id));
-    printf("Reference timestamp: %#016llx (%s)\n", be64toh(packet.reference_timestamp), format_ntp_timestamp(be64toh(packet.reference_timestamp)).characters());
-    printf("Origin timestamp:    %#016llx (%s)\n", be64toh(packet.origin_timestamp), format_ntp_timestamp(be64toh(packet.origin_timestamp)).characters());
-    printf("Receive timestamp:   %#016llx (%s)\n", be64toh(packet.receive_timestamp), format_ntp_timestamp(be64toh(packet.receive_timestamp)).characters());
-    printf("Transmit timestamp:  %#016llx (%s)\n", be64toh(packet.transmit_timestamp), format_ntp_timestamp(be64toh(packet.transmit_timestamp)).characters());
+    printf("Reference timestamp:   %#016llx (%s)\n", be64toh(packet.reference_timestamp), format_ntp_timestamp(be64toh(packet.reference_timestamp)).characters());
+    printf("Origin timestamp:      %#016llx (%s)\n", origin_timestamp, format_ntp_timestamp(origin_timestamp).characters());
+    printf("Receive timestamp:     %#016llx (%s)\n", receive_timestamp, format_ntp_timestamp(receive_timestamp).characters());
+    printf("Transmit timestamp:    %#016llx (%s)\n", transmit_timestamp, format_ntp_timestamp(transmit_timestamp).characters());
+    printf("Destination timestamp: %#016llx (%s)\n", destination_timestamp, format_ntp_timestamp(destination_timestamp).characters());
 }

--- a/Userland/ntpquery.cpp
+++ b/Userland/ntpquery.cpp
@@ -105,13 +105,10 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    // FIXME: Request serenityos.pool.ntp.org here https://manage.ntppool.org/manage/vendor
-    // and then use that as the default value.
-    // Until then, explicitly pass this as `ntpquery pool.ntp.org`.
-    const char* host = nullptr;
-
+    // FIXME: Change to serenityos.pool.ntp.org once https://manage.ntppool.org/manage/vendor/zone?a=km5a8h&id=vz-14154g is approved.
+    const char* host = "time.google.com";
     Core::ArgsParser args_parser;
-    args_parser.add_positional_argument(host, "NTP server", "host", Core::ArgsParser::Required::Yes);
+    args_parser.add_positional_argument(host, "NTP server", "host", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
 
     auto* hostent = gethostbyname(host);


### PR DESCRIPTION
Also use time.google.com as default NTP server until the pool.ntp.org application is through.

This is a very simple implementation for now. Eventually, I want to add the smooth `adjtime` adjustment if local time isn't too far off, and implement the NTP rfc filtering algorithms, and probably switch to the timespec clock_get/settime functions. But for now, let's go with this.