### PR TITLE
LibLine: Disable editing events while searching; ^R should find matches anywhere in the target line

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -882,7 +882,7 @@ void Editor::cleanup_suggestions()
     m_times_tab_pressed = 0; // Safe to say if we get here, the user didn't press TAB
 }
 
-bool Editor::search(const StringView& phrase, bool allow_empty)
+bool Editor::search(const StringView& phrase, bool allow_empty, bool from_beginning)
 {
 
     int last_matching_offset = -1;
@@ -892,7 +892,8 @@ bool Editor::search(const StringView& phrase, bool allow_empty)
     if (allow_empty || phrase.length() > 0) {
         size_t search_offset = m_search_offset;
         for (size_t i = m_history_cursor; i > 0; --i) {
-            auto contains = m_history[i - 1].starts_with(phrase);
+            auto& entry = m_history[i - 1];
+            auto contains = from_beginning ? entry.starts_with(phrase) : entry.contains(phrase);
             if (contains) {
                 last_matching_offset = i - 1;
                 if (search_offset == 0) {

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -300,7 +300,7 @@ private:
 
     Style find_applicable_style(size_t offset) const;
 
-    bool search(const StringView&, bool allow_empty = false);
+    bool search(const StringView&, bool allow_empty = false, bool from_beginning = true);
     inline void end_search()
     {
         m_is_searching = false;

--- a/Libraries/LibLine/InternalFunctions.cpp
+++ b/Libraries/LibLine/InternalFunctions.cpp
@@ -302,11 +302,19 @@ void Editor::enter_search()
         fflush(stderr);
 
         auto search_prompt = "\x1b[32msearch:\x1b[0m ";
+
+        // While the search editor is active, we do not want editing events.
+        m_is_editing = false;
+
         auto search_string_result = m_search_editor->get_line(search_prompt);
+
+        // Grab where the search origin last was, anything up to this point will be cleared.
+        auto search_end_row = m_search_editor->m_origin_row;
 
         remove_child(*m_search_editor);
         m_search_editor = nullptr;
         m_is_searching = false;
+        m_is_editing = true;
         m_search_offset = 0;
 
         // Re-enable the notifier after discarding the search editor.
@@ -325,7 +333,7 @@ void Editor::enter_search()
         reposition_cursor();
         auto search_metrics = actual_rendered_string_metrics(search_string);
         auto metrics = actual_rendered_string_metrics(search_prompt);
-        VT::clear_lines(0, metrics.lines_with_addition(search_metrics, m_num_columns));
+        VT::clear_lines(0, metrics.lines_with_addition(search_metrics, m_num_columns) + search_end_row - m_origin_row - 1);
 
         reposition_cursor();
 

--- a/Libraries/LibLine/InternalFunctions.cpp
+++ b/Libraries/LibLine/InternalFunctions.cpp
@@ -244,7 +244,7 @@ void Editor::enter_search()
         m_search_editor->on_display_refresh = [this](Editor& search_editor) {
             StringBuilder builder;
             builder.append(Utf32View { search_editor.buffer().data(), search_editor.buffer().size() });
-            if (!search(builder.build())) {
+            if (!search(builder.build(), false, false)) {
                 m_buffer.clear();
                 m_cursor = 0;
             }


### PR DESCRIPTION
This also makes the editor clean as many lines as the searching took,
for instance, in the case of <C-r><C-c>ls<tab>, two lines should be
cleaned, not just one.

Fixes #3413.