### PR TITLE
LibGUI: Fix OOB read in Clipboard::set_data()

### DIFF
--- a/Libraries/LibGUI/Clipboard.cpp
+++ b/Libraries/LibGUI/Clipboard.cpp
@@ -98,15 +98,13 @@ Clipboard::DataAndType Clipboard::data_and_type() const
 
 void Clipboard::set_data(ReadonlyBytes data, const String& type, const HashMap<String, String>& metadata)
 {
-    auto shared_buffer = SharedBuffer::create_with_size(data.size() + 1);
+    auto shared_buffer = SharedBuffer::create_with_size(data.size());
     if (!shared_buffer) {
         dbgprintf("GUI::Clipboard::set_data() failed to create a shared buffer\n");
         return;
     }
     if (!data.is_empty())
-        memcpy(shared_buffer->data(), data.data(), data.size() + 1);
-    else
-        ((u8*)shared_buffer->data())[0] = '\0';
+        memcpy(shared_buffer->data(), data.data(), data.size());
     shared_buffer->seal();
     shared_buffer->share_with(connection().server_pid());
 


### PR DESCRIPTION
> https://github.com/SerenityOS/serenity/commit/51146e30750141f5e604ef2df3ba4a721c0d7149#r42067196

@awesomekling Not sure how this didn't blow up while you were making it.

The data coming in is no longer a `String`, and we shouldn't null-terminate it anyway.