### PR TITLE
Kernel: Fix crash when delivering signal to barely created thread

### DIFF
--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -306,12 +306,6 @@ void Thread::consider_unblock(time_t now_sec, long now_usec)
             unblock();
         return;
     }
-    case Thread::Skip1SchedulerPass:
-        set_state(Thread::Skip0SchedulerPasses);
-        return;
-    case Thread::Skip0SchedulerPasses:
-        set_state(Thread::Runnable);
-        return;
     }
 }
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -306,7 +306,7 @@ int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Ve
     if (was_profiling)
         Profiling::did_exec(path);
 
-    new_main_thread->set_state(Thread::State::Skip1SchedulerPass);
+    new_main_thread->set_state(Thread::State::Runnable);
     big_lock().force_unlock_if_locked();
     ASSERT_INTERRUPTS_DISABLED();
     ASSERT(Processor::current().in_critical());

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -94,7 +94,8 @@ pid_t Process::sys$fork(RegisterState& regs)
         g_processes->prepend(child);
     }
 
-    child_first_thread->set_state(Thread::State::Skip1SchedulerPass);
+    child_first_thread->set_affinity(Thread::current()->affinity());
+    child_first_thread->set_state(Thread::State::Runnable);
     return child->pid().value();
 }
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -114,8 +114,6 @@ public:
         Invalid = 0,
         Runnable,
         Running,
-        Skip1SchedulerPass,
-        Skip0SchedulerPasses,
         Dying,
         Dead,
         Stopped,
@@ -417,7 +415,7 @@ public:
 
     ShouldUnblockThread dispatch_one_pending_signal();
     ShouldUnblockThread dispatch_signal(u8 signal);
-    bool has_unmasked_pending_signals() const { return m_pending_signals & ~m_signal_mask; }
+    bool has_unmasked_pending_signals() const { return m_have_any_unmasked_pending_signals.load(AK::memory_order_consume); }
     void terminate_due_to_signal(u8 signal);
     bool should_ignore_signal(u8 signal) const;
     bool has_signal_handler(u8 signal) const;
@@ -587,6 +585,7 @@ private:
     bool m_dump_backtrace_on_finalization { false };
     bool m_should_die { false };
     bool m_initialized { false };
+    Atomic<bool> m_have_any_unmasked_pending_signals { false };
 
     OwnPtr<ThreadTracer> m_tracer;
 


### PR DESCRIPTION
We need to wait until a thread is fully set up and ready for running
before attempting to deliver a signal. Otherwise we may not have a
user stack yet.

Also, remove the Skip0SchedulerPasses and Skip1SchedulerPass thread
states that we don't really need anymore with software context switching.

Fixes the kernel crash reported in #3419