### PR TITLE
WindowServer: Fix invalidating window frame

### DIFF
--- a/Services/WindowServer/Window.cpp
+++ b/Services/WindowServer/Window.cpp
@@ -409,21 +409,25 @@ void Window::invalidate(bool invalidate_frame)
     Compositor::the().invalidate_window();
 }
 
-void Window::invalidate(const Gfx::IntRect& rect)
+void Window::invalidate(const Gfx::IntRect& rect, bool with_frame)
 {
     if (type() == WindowType::MenuApplet) {
         AppletManager::the().invalidate_applet(*this, rect);
         return;
     }
 
-    if (invalidate_no_notify(rect))
+    if (invalidate_no_notify(rect, with_frame))
         Compositor::the().invalidate_window();
 }
 
-bool Window::invalidate_no_notify(const Gfx::IntRect& rect)
+bool Window::invalidate_no_notify(const Gfx::IntRect& rect, bool with_frame)
 {
-    if (m_invalidated_all || rect.is_empty())
+    if (rect.is_empty())
         return false;
+    if (m_invalidated_all) {
+        m_invalidated_frame |= with_frame;
+        return false;
+    }
 
     auto outer_rect = frame().rect();
     auto inner_rect = rect;
@@ -434,6 +438,7 @@ bool Window::invalidate_no_notify(const Gfx::IntRect& rect)
         return false;
 
     m_invalidated = true;
+    m_invalidated_frame |= with_frame;
     m_dirty_rects.add(inner_rect.translated(-outer_rect.location()));
     return true;
 }

--- a/Services/WindowServer/Window.h
+++ b/Services/WindowServer/Window.h
@@ -168,8 +168,8 @@ public:
     Gfx::IntSize size() const { return m_rect.size(); }
 
     void invalidate(bool with_frame = true);
-    void invalidate(const Gfx::IntRect&);
-    bool invalidate_no_notify(const Gfx::IntRect& rect);
+    void invalidate(const Gfx::IntRect&, bool with_frame = false);
+    bool invalidate_no_notify(const Gfx::IntRect& rect, bool with_frame = false);
 
     void prepare_dirty_rects();
     void clear_dirty_rects();

--- a/Services/WindowServer/WindowFrame.cpp
+++ b/Services/WindowServer/WindowFrame.cpp
@@ -240,7 +240,7 @@ void WindowFrame::invalidate(Gfx::IntRect relative_rect)
     auto frame_rect = rect();
     auto window_rect = m_window.rect();
     relative_rect.move_by(frame_rect.x() - window_rect.x(), frame_rect.y() - window_rect.y());
-    m_window.invalidate(relative_rect);
+    m_window.invalidate(relative_rect, true);
 }
 
 void WindowFrame::notify_window_rect_changed(const Gfx::IntRect& old_rect, const Gfx::IntRect& new_rect)


### PR DESCRIPTION
When invalidating the frame we need to properly flag that so that
we trigger rendering the frame, even if "all" was flagged as being
invalidated. Otherwise it will only get rendered if anything else
happens to trigger it (such as focus change).

Fixes #3427