### PR TITLE
LibJS: Some copy elisions and MVL interface niceties

### DIFF
--- a/Libraries/LibJS/Console.cpp
+++ b/Libraries/LibJS/Console.cpp
@@ -123,7 +123,7 @@ bool Console::counter_reset(String label)
 Vector<String> ConsoleClient::get_trace() const
 {
     Vector<String> trace;
-    auto call_stack = m_console.interpreter().call_stack();
+    auto& call_stack = m_console.interpreter().call_stack();
     // -2 to skip the console.trace() call frame
     for (ssize_t i = call_stack.size() - 2; i >= 0; --i)
         trace.append(call_stack[i].function_name);

--- a/Libraries/LibJS/Runtime/Exception.cpp
+++ b/Libraries/LibJS/Runtime/Exception.cpp
@@ -32,7 +32,7 @@ namespace JS {
 Exception::Exception(Value value)
     : m_value(value)
 {
-    auto call_stack = interpreter().call_stack();
+    auto& call_stack = interpreter().call_stack();
     for (ssize_t i = call_stack.size() - 1; i >= 0; --i) {
         auto function_name = call_stack[i].function_name;
         if (function_name.is_empty())

--- a/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -318,7 +318,7 @@ void IndexedProperties::insert(u32 index, Value value, PropertyAttributes attrib
     m_storage->insert(index, value, attributes);
 }
 
-ValueAndAttributes IndexedProperties::take_first(Object *this_object)
+ValueAndAttributes IndexedProperties::take_first(Object* this_object)
 {
     auto first = m_storage->take_first();
     if (first.value.is_accessor())
@@ -326,7 +326,7 @@ ValueAndAttributes IndexedProperties::take_first(Object *this_object)
     return first;
 }
 
-ValueAndAttributes IndexedProperties::take_last(Object *this_object)
+ValueAndAttributes IndexedProperties::take_last(Object* this_object)
 {
     auto last = m_storage->take_last();
     if (last.value.is_accessor())

--- a/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -83,7 +83,7 @@ public:
     virtual void set_array_like_size(size_t new_size) override;
 
     virtual bool is_simple_storage() const override { return true; }
-    Vector<Value> elements() const { return m_packed_elements; }
+    const Vector<Value>& elements() const { return m_packed_elements; }
 
 private:
     friend GenericIndexedPropertyStorage;
@@ -109,8 +109,8 @@ public:
     virtual size_t array_like_size() const override { return m_array_size; }
     virtual void set_array_like_size(size_t new_size) override;
 
-    Vector<ValueAndAttributes> packed_elements() const { return m_packed_elements; }
-    HashMap<u32, ValueAndAttributes> sparse_elements() const { return m_sparse_elements; }
+    const Vector<ValueAndAttributes>& packed_elements() const { return m_packed_elements; }
+    const HashMap<u32, ValueAndAttributes>& sparse_elements() const { return m_sparse_elements; }
 
 private:
     size_t m_array_size { 0 };

--- a/Libraries/LibJS/Runtime/MarkedValueList.cpp
+++ b/Libraries/LibJS/Runtime/MarkedValueList.cpp
@@ -36,8 +36,8 @@ MarkedValueList::MarkedValueList(Heap& heap)
 }
 
 MarkedValueList::MarkedValueList(MarkedValueList&& other)
-    : m_heap(other.m_heap)
-    , m_values(move(other.m_values))
+    : AK::Vector<Value, 32>(move(static_cast<Vector<Value, 32>&>(other)))
+    , m_heap(other.m_heap)
 {
     m_heap.did_create_marked_value_list({}, *this);
 }
@@ -45,11 +45,6 @@ MarkedValueList::MarkedValueList(MarkedValueList&& other)
 MarkedValueList::~MarkedValueList()
 {
     m_heap.did_destroy_marked_value_list({}, *this);
-}
-
-void MarkedValueList::append(Value value)
-{
-    m_values.append(value);
 }
 
 }

--- a/Libraries/LibJS/Runtime/MarkedValueList.h
+++ b/Libraries/LibJS/Runtime/MarkedValueList.h
@@ -33,7 +33,7 @@
 
 namespace JS {
 
-class MarkedValueList {
+class MarkedValueList : public AK::Vector<Value, 32> {
     AK_MAKE_NONCOPYABLE(MarkedValueList);
 
 public:
@@ -43,16 +43,16 @@ public:
 
     MarkedValueList& operator=(MarkedValueList&&) = delete;
 
-    bool is_empty() const { return m_values.is_empty(); }
-    size_t size() const { return m_values.size(); }
-    void clear() { m_values.clear(); }
-    Vector<Value, 32>& values() { return m_values; }
+    Vector<Value, 32>& values() { return *this; }
 
-    void append(Value);
+    MarkedValueList copy() const
+    {
+        MarkedValueList copy { m_heap };
+        copy.append(*this);
+        return copy;
+    }
 
 private:
     Heap& m_heap;
-    Vector<Value, 32> m_values;
 };
-
 }


### PR DESCRIPTION
This commit also eliminates quite a few unnecessary copies of Vectors.

Why redo Vector features, or forward calls when we can just inherit from Vector

cc @linusg - in case I messed some required copy up.