### PR TITLE
Svg fixes

### DIFF
--- a/Libraries/LibCore/MimeData.cpp
+++ b/Libraries/LibCore/MimeData.cpp
@@ -87,6 +87,8 @@ String guess_mime_type_based_on_filename(const URL& url)
         return "image/bmp";
     if (lowercase_url.ends_with(".jpg") || lowercase_url.ends_with(".jpeg"))
         return "image/jpeg";
+    if (lowercase_url.ends_with(".svg"))
+        return "image/svg+xml";
     if (lowercase_url.ends_with(".md"))
         return "text/markdown";
     if (lowercase_url.ends_with(".html") || lowercase_url.ends_with(".htm"))

--- a/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -121,6 +121,11 @@ static RefPtr<DOM::Document> create_gemini_document(const ByteBuffer& data, cons
 
 RefPtr<DOM::Document> FrameLoader::create_document_from_mime_type(const ByteBuffer& data, const URL& url, const String& mime_type, const String& encoding)
 {
+    if (mime_type == "text/html" || mime_type == "image/svg+xml") {
+        HTML::HTMLDocumentParser parser(data, encoding);
+        parser.run(url);
+        return parser.document();
+    }
     if (mime_type.starts_with("image/"))
         return create_image_document(data, url);
     if (mime_type == "text/plain")
@@ -129,11 +134,7 @@ RefPtr<DOM::Document> FrameLoader::create_document_from_mime_type(const ByteBuff
         return create_markdown_document(data, url);
     if (mime_type == "text/gemini")
         return create_gemini_document(data, url);
-    if (mime_type == "text/html") {
-        HTML::HTMLDocumentParser parser(data, encoding);
-        parser.run(url);
-        return parser.document();
-    }
+
     return nullptr;
 }
 

--- a/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -150,6 +150,7 @@ void PathDataParser::parse_moveto()
 void PathDataParser::parse_closepath()
 {
     bool absolute = consume() == 'Z';
+    parse_whitespace();
     m_instructions.append({ PathInstructionType::ClosePath, absolute, {} });
 }
 
@@ -182,7 +183,8 @@ void PathDataParser::parse_curveto()
 
     while (true) {
         m_instructions.append({ PathInstructionType::Curve, absolute, parse_coordinate_pair_triplet() });
-        parse_whitespace();
+        if (match_comma_whitespace())
+            parse_comma_whitespace();
         if (!match_coordinate())
             break;
     }
@@ -195,7 +197,8 @@ void PathDataParser::parse_smooth_curveto()
 
     while (true) {
         m_instructions.append({ PathInstructionType::SmoothCurve, absolute, parse_coordinate_pair_double() });
-        parse_whitespace();
+        if (match_comma_whitespace())
+            parse_comma_whitespace();
         if (!match_coordinate())
             break;
     }
@@ -208,7 +211,8 @@ void PathDataParser::parse_quadratic_bezier_curveto()
 
     while (true) {
         m_instructions.append({ PathInstructionType::QuadraticBezierCurve, absolute, parse_coordinate_pair_double() });
-        parse_whitespace();
+        if (match_comma_whitespace())
+            parse_comma_whitespace();
         if (!match_coordinate())
             break;
     }
@@ -221,7 +225,8 @@ void PathDataParser::parse_smooth_quadratic_bezier_curveto()
 
     while (true) {
         m_instructions.append({ PathInstructionType::SmoothQuadraticBezierCurve, absolute, parse_coordinate_pair() });
-        parse_whitespace();
+        if (match_comma_whitespace())
+            parse_comma_whitespace();
         if (!match_coordinate())
             break;
     }
@@ -234,7 +239,8 @@ void PathDataParser::parse_elliptical_arc()
 
     while (true) {
         m_instructions.append({ PathInstructionType::EllipticalArc, absolute, parse_elliptical_arg_argument() });
-        parse_whitespace();
+        if (match_comma_whitespace())
+            parse_comma_whitespace();
         if (!match_coordinate())
             break;
     }

--- a/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -220,7 +220,7 @@ void PathDataParser::parse_smooth_quadratic_bezier_curveto()
     parse_whitespace();
 
     while (true) {
-        m_instructions.append({ PathInstructionType::SmoothQuadraticBezierCurve, absolute, parse_coordinate_pair_double() });
+        m_instructions.append({ PathInstructionType::SmoothQuadraticBezierCurve, absolute, parse_coordinate_pair() });
         parse_whitespace();
         if (!match_coordinate())
             break;

--- a/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -112,6 +112,8 @@ public:
 
 private:
     Vector<PathInstruction> m_instructions;
+    Gfx::FloatPoint m_previous_control_point = {};
+
 };
 
 }


### PR DESCRIPTION
Hi,

i wanted to fix loading heise.de in the browser, with these changes to the SVG parsing, the parsing no longer fails for any svgs loaded on that side.
I also implemented another SVG drawing command, which seems to work at least for a path like:

    <path d="M 10 80 Q 52.5 10, 95 80 T 180 80" stroke="black" fill="transparent"/>
