### PR TITLE
sleep: On SIGINT, call default SIGINT handler after printing remaining time

### DIFF
--- a/Userland/sleep.cpp
+++ b/Userland/sleep.cpp
@@ -30,8 +30,10 @@
 #include <string.h>
 #include <unistd.h>
 
+static bool g_interrupted;
 static void handle_sigint(int)
 {
+    g_interrupted = true;
 }
 
 int main(int argc, char** argv)
@@ -47,7 +49,7 @@ int main(int argc, char** argv)
     sa.sa_handler = handle_sigint;
     sigaction(SIGINT, &sa, nullptr);
 
-    if (pledge("stdio", nullptr) < 0) {
+    if (pledge("stdio sigaction", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
@@ -56,5 +58,11 @@ int main(int argc, char** argv)
     if (remaining) {
         printf("Sleep interrupted with %u seconds remaining.\n", remaining);
     }
+
+    if (g_interrupted) {
+        signal(SIGINT, SIG_DFL);
+        raise(SIGINT);
+    }
+
     return 0;
 }


### PR DESCRIPTION
With this, hitting ctrl-c twice in `for i in $(seq 10) { sleep 1 }`
terminates the loop as expected (...well, I'd expect it to quit after
just one ctrl-c, but serenity's shell makes a single ctrl-c only
quit the current loop iteration).

Part of #3419.