### PR TITLE
Kernel: Fix heap expansion loop

### DIFF
--- a/Kernel/Heap/Heap.h
+++ b/Kernel/Heap/Heap.h
@@ -257,6 +257,7 @@ public:
 
     void* allocate(size_t size)
     {
+        int attempt = 0;
         do {
             for (auto* subheap = &m_heaps; subheap; subheap = subheap->next) {
                 if (void* ptr = subheap->heap.allocate(size))
@@ -269,6 +270,10 @@ public:
             // This is especially true for the kmalloc heap, where adding memory
             // requires several other objects to be allocated just to be able to
             // expand the heap.
+
+            // To avoid an infinite expansion loop, limit to two attempts
+            if (attempt++ >= 2)
+                break;
         } while (expand_memory(size));
         return nullptr;
     }


### PR DESCRIPTION
By being a bit too greedy and only allocating how much we need for
the failing allocation, we can end up in an infinite loop trying
to expand the heap further. That's because there are other allocations
(e.g. logging, vmobjects, regions, ...) that happen before we finally
retry the failed allocation request.

Also fix allocating in page size increments, which lead to an assertion
when the heap had to grow more than the 1 MiB backup.