### PR TITLE
Move TypedTransfer<T> into it's own header and use it in Span.

### DIFF
--- a/AK/Tests/TestTypedTransfer.cpp
+++ b/AK/Tests/TestTypedTransfer.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/Array.h>
+#include <AK/TypedTransfer.h>
+
+struct NonPrimitiveIntWrapper {
+    NonPrimitiveIntWrapper(int value)
+        : m_value(value)
+    {
+    }
+
+    int m_value;
+};
+
+TEST_CASE(overlapping_source_and_destination_1)
+{
+    const Array<NonPrimitiveIntWrapper, 6> expected { 3, 4, 5, 6, 5, 6 };
+
+    Array<NonPrimitiveIntWrapper, 6> actual { 1, 2, 3, 4, 5, 6 };
+    AK::TypedTransfer<NonPrimitiveIntWrapper>::copy(actual.data(), actual.data() + 2, 4);
+
+    for (size_t i = 0; i < 6; ++i)
+        EXPECT_EQ(actual[i].m_value, expected[i].m_value);
+}
+
+TEST_CASE(overlapping_source_and_destination_2)
+{
+    const Array<NonPrimitiveIntWrapper, 6> expected { 1, 2, 1, 2, 3, 4 };
+
+    Array<NonPrimitiveIntWrapper, 6> actual { 1, 2, 3, 4, 5, 6 };
+    AK::TypedTransfer<NonPrimitiveIntWrapper>::copy(actual.data() + 2, actual.data(), 4);
+
+    for (size_t i = 0; i < 6; ++i)
+        EXPECT_EQ(actual[i].m_value, expected[i].m_value);
+}
+
+TEST_MAIN(TypedTransfer)

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Traits.h>
+
+namespace AK {
+
+template<typename T>
+class TypedTransfer {
+public:
+    static size_t move(T* destination, T* source, size_t count)
+    {
+        if constexpr (Traits<T>::is_trivial()) {
+            __builtin_memmove(destination, source, count * sizeof(T));
+            return count;
+        }
+
+        for (size_t i = 0; i < count; ++i) {
+            if (destination <= source)
+                new (&destination[i]) T(AK::move(source[i]));
+            else
+                new (&destination[count - i - 1]) T(AK::move(source[count - i - 1]));
+        }
+
+        return count;
+    }
+
+    static size_t copy(T* destination, const T* source, size_t count)
+    {
+        if constexpr (Traits<T>::is_trivial()) {
+            __builtin_memmove(destination, source, count * sizeof(T));
+            return count;
+        }
+
+        for (size_t i = 0; i < count; ++i) {
+            if (destination <= source)
+                new (&destination[i]) T(source[i]);
+            else
+                new (&destination[count - i - 1]) T(source[count - i - 1]);
+        }
+
+        return count;
+    }
+
+    static bool compare(const T* a, const T* b, size_t count)
+    {
+        if constexpr (Traits<T>::is_trivial())
+            return !__builtin_memcmp(a, b, count * sizeof(T));
+
+        for (size_t i = 0; i < count; ++i) {
+            if (a[i] != b[i])
+                return false;
+        }
+
+        return true;
+    }
+};
+
+}

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -33,6 +33,7 @@
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Traits.h>
+#include <AK/TypedTransfer.h>
 #include <AK/kmalloc.h>
 
 // NOTE: We can't include <initializer_list> during the toolchain bootstrap,
@@ -47,49 +48,6 @@
 #endif
 
 namespace AK {
-
-template<typename T>
-class TypedTransfer {
-public:
-    static void move(T* destination, T* source, size_t count)
-    {
-        if (!count)
-            return;
-        if constexpr (Traits<T>::is_trivial()) {
-            __builtin_memmove(destination, source, count * sizeof(T));
-            return;
-        }
-        for (size_t i = 0; i < count; ++i)
-            new (&destination[i]) T(AK::move(source[i]));
-    }
-
-    static void copy(T* destination, const T* source, size_t count)
-    {
-        if (!count)
-            return;
-        if constexpr (Traits<T>::is_trivial()) {
-            __builtin_memmove(destination, source, count * sizeof(T));
-            return;
-        }
-        for (size_t i = 0; i < count; ++i)
-            new (&destination[i]) T(source[i]);
-    }
-
-    static bool compare(const T* a, const T* b, size_t count)
-    {
-        if (!count)
-            return true;
-
-        if constexpr (Traits<T>::is_trivial())
-            return !__builtin_memcmp(a, b, count * sizeof(T));
-
-        for (size_t i = 0; i < count; ++i) {
-            if (a[i] != b[i])
-                return false;
-        }
-        return true;
-    }
-};
 
 template<typename T, size_t inline_capacity>
 class Vector {


### PR DESCRIPTION
Previously, `Span::copy_to` would not call copy or move constructors, now it does.

I also made a semantic change in `TypedTransfer<T>::copy` and `TypedTransfer<T>::move`:

~~~diff
-        for (size_t i = 0; i < count; ++i)
-            new (&destination[i]) T(AK::move(source[i]));
+        for (size_t i = 0; i <= count; ++i) {
+            if(destination < source)
+                new (&destination[i]) T(AK::move(source[i]));
+            else
+                new (&destination[count - i - 1]) T(AK::move(source[count - i - 1]));
+        }
~~~

Without this additional check, copying overlapping `source` and `destination` would lead to issues. I added a test that would fail in that case.
