### PR TITLE
sleep: Make variable written in signal handler volatile

### DIFF
--- a/Userland/sleep.cpp
+++ b/Userland/sleep.cpp
@@ -30,7 +30,7 @@
 #include <string.h>
 #include <unistd.h>
 
-static bool g_interrupted;
+static volatile bool g_interrupted;
 static void handle_sigint(int)
 {
     g_interrupted = true;


### PR DESCRIPTION
No difference in practice, but it's tidier and protects us
if we ever use g_interrupted earlier in main -- in that case,
the compiler might chose to keep the variable in a register without
the volatile.

Found by @bugaevc, thanks!