### PR TITLE
LibGUI: Do not paint scrollbar button highlight for scrollbars without scrubber

### DIFF
--- a/Libraries/LibGUI/ScrollBar.cpp
+++ b/Libraries/LibGUI/ScrollBar.cpp
@@ -236,7 +236,7 @@ void ScrollBar::paint_event(PaintEvent& event)
     painter.add_clip_rect(event.rect());
 
     Component hovered_component_for_painting = m_hovered_component;
-    if (m_pressed_component != Component::None && m_hovered_component != m_pressed_component)
+    if (!has_scrubber() || (m_pressed_component != Component::None && m_hovered_component != m_pressed_component))
         hovered_component_for_painting = Component::None;
 
     painter.fill_rect_with_dither_pattern(rect(), palette().button().lightened(1.3f), palette().button());


### PR DESCRIPTION
If a scrollbar doesn't have a scrubber (because the view it scrolls is
large enough to display all its contents without scrolling), then
it ignores all clicks. We shouldn't draw a hover highlight that suggests
clickability in that case.