### PR TITLE
LibVT: Make Terminal::scroll_up() O(1) in size of history by using a circular buffer

### DIFF
--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -52,6 +52,8 @@ void Terminal::clear()
 void Terminal::clear_including_history()
 {
     m_history.clear();
+    m_history_start = 0;
+
     clear();
 
     m_client.terminal_history_changed();
@@ -738,9 +740,7 @@ void Terminal::scroll_up()
     invalidate_cursor();
     if (m_scroll_region_top == 0) {
         auto line = move(m_lines.ptr_at(m_scroll_region_top));
-        m_history.append(move(line));
-        while (m_history.size() > max_history_size())
-            m_history.take_first();
+        add_line_to_history(move(line));
         m_client.terminal_history_changed();
     }
     m_lines.remove(m_scroll_region_top);

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -96,7 +96,7 @@ public:
     }
 
     size_t max_history_size() const { return 500; }
-    const NonnullOwnPtrVector<Line>& history() const { return m_history; }
+    size_t history_size() const { return m_history.size(); }
 
     void inject_string(const StringView&);
     void handle_key_press(KeyCode, u32, u8 flags);

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -76,7 +76,7 @@ public:
     Line& line(size_t index)
     {
         if (index < m_history.size())
-            return m_history[index];
+            return m_history[(m_history_start + index) % m_history.size()];
         return m_lines[index - m_history.size()];
     }
     const Line& line(size_t index) const
@@ -154,7 +154,19 @@ private:
 
     TerminalClient& m_client;
 
+    size_t m_history_start = 0;
     NonnullOwnPtrVector<Line> m_history;
+    void add_line_to_history(NonnullOwnPtr<Line>&& line)
+    {
+        if (m_history.size() < max_history_size()) {
+            ASSERT(m_history_start == 0);
+            m_history.append(move(line));
+            return;
+        }
+        m_history.ptr_at(m_history_start) = move(line);
+        m_history_start = (m_history_start + 1) % m_history.size();
+    }
+
     NonnullOwnPtrVector<Line> m_lines;
 
     size_t m_scroll_region_top { 0 };

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -274,11 +274,11 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
     invalidate_cursor();
 
     int rows_from_history = 0;
-    int first_row_from_history = m_terminal.history().size();
+    int first_row_from_history = m_terminal.history_size();
     int row_with_cursor = m_terminal.cursor_row();
     if (m_scrollbar->value() != m_scrollbar->max()) {
         rows_from_history = min((int)m_terminal.rows(), m_scrollbar->max() - m_scrollbar->value());
-        first_row_from_history = m_terminal.history().size() - (m_scrollbar->max() - m_scrollbar->value());
+        first_row_from_history = m_terminal.history_size() - (m_scrollbar->max() - m_scrollbar->value());
         row_with_cursor = m_terminal.cursor_row() + rows_from_history;
     }
 
@@ -742,7 +742,7 @@ int TerminalWidget::last_selection_column_on_row(int row) const
 void TerminalWidget::terminal_history_changed()
 {
     bool was_max = m_scrollbar->value() == m_scrollbar->max();
-    m_scrollbar->set_max(m_terminal.history().size());
+    m_scrollbar->set_max(m_terminal.history_size());
     if (was_max)
         m_scrollbar->set_value(m_scrollbar->max());
     m_scrollbar->update();


### PR DESCRIPTION
Reduces time to run `disasm /bin/id` with the default terminal window size from 530ms to 409ms (min-of-5) on my system.

I likely want to do something very similar to m_lines, but I'm out of evening. Probably want to extract some kind of CircularVectorView or similar after that's done. (The existing Circular classes in AK don't quite do what I need, as far as I can tell.)