### PR TITLE
IPv4: Truncate raw socket reads past buffer length

### DIFF
--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -338,9 +338,9 @@ KResultOr<size_t> IPv4Socket::receive_packet_buffered(FileDescription& descripti
     }
 
     if (type() == SOCK_RAW) {
-        ASSERT(buffer_length >= ipv4_packet.payload_size());
-        memcpy(buffer, ipv4_packet.payload(), ipv4_packet.payload_size());
-        return ipv4_packet.payload_size();
+        size_t bytes_written = min((size_t) ipv4_packet.payload_size(), buffer_length);
+        memcpy(buffer, ipv4_packet.payload(), bytes_written);
+        return bytes_written;
     }
 
     return protocol_receive(packet.data.value(), buffer, buffer_length, flags);


### PR DESCRIPTION
In addition to being the proper POSIX etiquette, it seems like a bad idea
for issues like the one seen in #3428 to result in a kernel crash. This patch
replaces the current behavior of failing on insufficient buffer size to truncating
SOCK_RAW messages to the buffer size. This will have to change if/when MSG_PEEK
is implemented, but for now this behavior is more compliant and logical than
just bailing.

Magic GitHub incantation test: Closes #3428