### PR TITLE
AK: Replace LogStream operator for ReadonlyBytes with dump_bytes function.

### DIFF
--- a/AK/LogStream.cpp
+++ b/AK/LogStream.cpp
@@ -209,7 +209,7 @@ const LogStream& operator<<(const LogStream& stream, float value)
 
 #endif
 
-const LogStream& operator<<(const LogStream& stream, ReadonlyBytes bytes)
+void dump_bytes(ReadonlyBytes bytes)
 {
     StringBuilder builder;
 
@@ -247,7 +247,7 @@ const LogStream& operator<<(const LogStream& stream, ReadonlyBytes bytes)
 
     builder.append(" }");
 
-    return stream << builder.to_string();
+    dbg() << builder.to_string();
 }
 
 }

--- a/AK/LogStream.h
+++ b/AK/LogStream.h
@@ -184,7 +184,6 @@ const LogStream& operator<<(const LogStream& stream, Span<T> span)
 }
 
 const LogStream& operator<<(const LogStream&, const void*);
-const LogStream& operator<<(const LogStream&, ReadonlyBytes);
 
 inline const LogStream& operator<<(const LogStream& stream, char value)
 {
@@ -204,6 +203,8 @@ KernelLogStream klog();
 #else
 DebugLogStream klog();
 #endif
+
+void dump_bytes(ReadonlyBytes);
 
 }
 


### PR DESCRIPTION
This pull request fixes a bug I introduced in #3409.

It wasn't actually possible to call

~~~c++
const LogStream& operator<<(const LogStream&, ReadonlyBytes);
~~~

because it was shadowed by

~~~c++
template<typename T>
const LogStream& operator<<(const LogStream& stream, Span<T> span);
~~~

not sure how I didn't notice when I added the overload.

It would be possible to use SFINAE to disable the other overload, however, I think it is better to use a different function entirely because the output can be very verbose:

~~~c++
void dump_bytes(ReadonlyBytes);
~~~

(I originally wanted to put the implementation into `Span.cpp` but that file didn't exist yet and it seemed unnecessary for one small function.)
