### PR TITLE
Userland: Fix a signal race condition

### DIFF
--- a/Userland/sleep.cpp
+++ b/Userland/sleep.cpp
@@ -59,10 +59,9 @@ int main(int argc, char** argv)
         printf("Sleep interrupted with %u seconds remaining.\n", remaining);
     }
 
-    if (g_interrupted) {
-        signal(SIGINT, SIG_DFL);
+    signal(SIGINT, SIG_DFL);
+    if (g_interrupted)
         raise(SIGINT);
-    }
 
     return 0;
 }


### PR DESCRIPTION
It has been possible for a signal to arrive in between us checking
g_interrupted and exiting - sucessfully, even though we were interrupted.

This way, if a signal arrives before we reset the disposition, we
will reliably check for it later; if it arrives afterwards, it'll
kill us automatically.