### PR TITLE
Kernel: Fix detecting in what ring a crash happened

### DIFF
--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -1393,7 +1393,7 @@ extern "C" void post_init_finished(void)
 
 void Processor::initialize_context_switching(Thread& initial_thread)
 {
-    ASSERT(initial_thread.process().is_ring0());
+    ASSERT(initial_thread.process().is_kernel_process());
 
     auto& tss = initial_thread.tss();
     m_tss = tss;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -830,7 +830,7 @@ static Optional<KBuffer> procfs$all(InodeIdentifier)
     auto build_process = [&](const Process& process) {
         auto process_object = array.add_object();
 
-        if (process.is_ring3()) {
+        if (process.is_user_process()) {
             StringBuilder pledge_builder;
 
 #define __ENUMERATE_PLEDGE_PROMISE(promise)      \

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -137,17 +137,12 @@ public:
     bool is_profiling() const { return m_profiling; }
     void set_profiling(bool profiling) { m_profiling = profiling; }
 
-    enum RingLevel : u8 {
-        Ring0 = 0,
-        Ring3 = 3,
-    };
-
     KBuffer backtrace() const;
 
     bool is_dead() const { return m_dead; }
 
-    bool is_ring0() const { return m_ring == Ring0; }
-    bool is_ring3() const { return m_ring == Ring3; }
+    bool is_kernel_process() const { return m_is_kernel_process; }
+    bool is_user_process() const { return !m_is_kernel_process; }
 
     PageDirectory& page_directory() { return *m_page_directory; }
     const PageDirectory& page_directory() const { return *m_page_directory; }
@@ -576,7 +571,7 @@ private:
     friend class Scheduler;
     friend class Region;
 
-    Process(Thread*& first_thread, const String& name, uid_t, gid_t, ProcessID ppid, RingLevel, RefPtr<Custody> cwd = nullptr, RefPtr<Custody> executable = nullptr, TTY* = nullptr, Process* fork_parent = nullptr);
+    Process(Thread*& first_thread, const String& name, uid_t, gid_t, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> cwd = nullptr, RefPtr<Custody> executable = nullptr, TTY* = nullptr, Process* fork_parent = nullptr);
     static ProcessID allocate_pid();
 
     Range allocate_range(VirtualAddress, size_t, size_t alignment = PAGE_SIZE);
@@ -654,11 +649,11 @@ private:
     };
     Vector<FileDescriptionAndFlags> m_fds;
 
-    RingLevel m_ring { Ring0 };
     u8 m_termination_status { 0 };
     u8 m_termination_signal { 0 };
     Atomic<u32> m_thread_count { 0 };
 
+    const bool m_is_kernel_process;
     bool m_dead { false };
     bool m_profiling { false };
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -46,7 +46,7 @@ namespace Kernel {
 
 int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Vector<String> arguments, Vector<String> environment, RefPtr<FileDescription> interpreter_description, Thread*& new_main_thread, u32& prev_flags)
 {
-    ASSERT(is_ring3());
+    ASSERT(is_user_process());
     ASSERT(!Processor::current().in_critical());
     auto path = main_program_description->absolute_path();
 #ifdef EXEC_DEBUG

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -37,7 +37,7 @@ pid_t Process::sys$fork(RegisterState& regs)
 {
     REQUIRE_PROMISE(proc);
     Thread* child_first_thread = nullptr;
-    auto* child = new Process(child_first_thread, m_name, m_uid, m_gid, m_pid, m_ring, m_cwd, m_executable, m_tty, this);
+    auto* child = new Process(child_first_thread, m_name, m_uid, m_gid, m_pid, m_is_kernel_process, m_cwd, m_executable, m_tty, this);
     child->m_root_directory = m_root_directory;
     child->m_root_directory_relative_to_global_root = m_root_directory_relative_to_global_root;
     child->m_promises = m_promises;

--- a/Kernel/Syscalls/kill.cpp
+++ b/Kernel/Syscalls/kill.cpp
@@ -34,8 +34,8 @@ KResult Process::do_kill(Process& process, int signal)
     // FIXME: Should setuid processes have some special treatment here?
     if (!is_superuser() && m_euid != process.m_uid && m_uid != process.m_uid)
         return KResult(-EPERM);
-    if (process.is_ring0() && signal == SIGKILL) {
-        klog() << "attempted to send SIGKILL to ring 0 process " << process.name().characters() << "(" << process.pid().value() << ")";
+    if (process.is_kernel_process() && signal == SIGKILL) {
+        klog() << "attempted to send SIGKILL to kernel process " << process.name().characters() << "(" << process.pid().value() << ")";
         return KResult(-EPERM);
     }
     if (signal != 0)

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -68,7 +68,7 @@ Thread::Thread(NonnullRefPtr<Process> process)
     // Only IF is set when a process boots.
     m_tss.eflags = 0x0202;
 
-    if (m_process->is_ring0()) {
+    if (m_process->is_kernel_process()) {
         m_tss.cs = GDT_SELECTOR_CODE0;
         m_tss.ds = GDT_SELECTOR_DATA0;
         m_tss.es = GDT_SELECTOR_DATA0;
@@ -91,7 +91,7 @@ Thread::Thread(NonnullRefPtr<Process> process)
     m_kernel_stack_base = m_kernel_stack_region->vaddr().get();
     m_kernel_stack_top = m_kernel_stack_region->vaddr().offset(default_kernel_stack_size).get() & 0xfffffff8u;
 
-    if (m_process->is_ring0()) {
+    if (m_process->is_kernel_process()) {
         m_tss.esp = m_tss.esp0 = m_kernel_stack_top;
     } else {
         // Ring 3 processes get a separate stack for ring 0.
@@ -504,7 +504,7 @@ ShouldUnblockThread Thread::dispatch_signal(u8 signal)
     ASSERT_INTERRUPTS_DISABLED();
     ASSERT(g_scheduler_lock.own_lock());
     ASSERT(signal > 0 && signal <= 32);
-    ASSERT(!process().is_ring0());
+    ASSERT(process().is_user_process());
 
 #ifdef SIGNAL_DEBUG
     klog() << "signal: dispatch signal " << signal << " to " << *this;


### PR DESCRIPTION
The ring is determined based on the CS register. This fixes crashes
being handled as ring 3 crashes even though EIP/CS clearly showed
that the crash happened in the kernel.