### PR TITLE
Refactor and fix bugs in LibCompress.

### DIFF
--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -232,7 +232,7 @@ public:
     {
         size_t nread = 0;
         while (bytes.size() - nread > 0 && m_write_offset - m_read_offset - nread > 0) {
-            const auto chunk_index = (m_read_offset - m_base_offset) / chunk_size;
+            const auto chunk_index = (m_read_offset - m_base_offset + nread) / chunk_size;
             const auto chunk_bytes = m_chunks[chunk_index].bytes().slice(m_read_offset % chunk_size).trim(m_write_offset - m_read_offset - nread);
             nread += chunk_bytes.copy_trimmed_to(bytes.slice(nread));
         }

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -34,7 +34,7 @@
 
 namespace Compress {
 
-const DeflateDecompressor::CanonicalCode& DeflateDecompressor::CanonicalCode::fixed_literal_codes()
+const CanonicalCode& CanonicalCode::fixed_literal_codes()
 {
     static CanonicalCode code;
     static bool initialized = false;
@@ -54,7 +54,7 @@ const DeflateDecompressor::CanonicalCode& DeflateDecompressor::CanonicalCode::fi
     return code;
 }
 
-const DeflateDecompressor::CanonicalCode& DeflateDecompressor::CanonicalCode::fixed_distance_codes()
+const CanonicalCode& CanonicalCode::fixed_distance_codes()
 {
     static CanonicalCode code;
     static bool initialized = false;
@@ -71,7 +71,7 @@ const DeflateDecompressor::CanonicalCode& DeflateDecompressor::CanonicalCode::fi
     return code;
 }
 
-Optional<DeflateDecompressor::CanonicalCode> DeflateDecompressor::CanonicalCode::from_bytes(ReadonlyBytes bytes)
+Optional<CanonicalCode> CanonicalCode::from_bytes(ReadonlyBytes bytes)
 {
     // FIXME: I can't quite follow the algorithm here, but it seems to work.
 
@@ -103,7 +103,7 @@ Optional<DeflateDecompressor::CanonicalCode> DeflateDecompressor::CanonicalCode:
     return code;
 }
 
-u32 DeflateDecompressor::CanonicalCode::read_symbol(InputBitStream& stream) const
+u32 CanonicalCode::read_symbol(InputBitStream& stream) const
 {
     u32 code_bits = 1;
 

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -303,7 +303,7 @@ bool DeflateDecompressor::discard_or_error(size_t count)
 
 bool DeflateDecompressor::eof() const { return m_state == State::Idle && m_read_final_bock; }
 
-ByteBuffer DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
+Optional<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
 {
     InputMemoryStream memory_stream { bytes };
     InputBitStream bit_stream { memory_stream };

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -143,10 +143,10 @@ bool DeflateDecompressor::CompressedBlock::try_read_more()
             return false;
         }
 
-        const auto run_length = m_decompressor.decode_run_length(symbol);
+        const auto length = m_decompressor.decode_length(symbol);
         const auto distance = m_decompressor.decode_distance(m_distance_codes.value().read_symbol(m_decompressor.m_input_stream));
 
-        for (size_t idx = 0; idx < run_length; ++idx) {
+        for (size_t idx = 0; idx < length; ++idx) {
             u8 byte = 0;
             m_decompressor.m_output_stream.read({ &byte, sizeof(byte) }, distance);
             m_decompressor.m_output_stream << byte;
@@ -306,8 +306,7 @@ bool DeflateDecompressor::eof() const { return m_state == State::Idle && m_read_
 Optional<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
 {
     InputMemoryStream memory_stream { bytes };
-    InputBitStream bit_stream { memory_stream };
-    DeflateDecompressor deflate_stream { bit_stream };
+    DeflateDecompressor deflate_stream { memory_stream };
     OutputMemoryStream output_stream;
 
     u8 buffer[4096];
@@ -322,7 +321,7 @@ Optional<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
     return output_stream.copy_into_contiguous_buffer();
 }
 
-u32 DeflateDecompressor::decode_run_length(u32 symbol)
+u32 DeflateDecompressor::decode_length(u32 symbol)
 {
     // FIXME: I can't quite follow the algorithm here, but it seems to work.
 

--- a/Libraries/LibCompress/Deflate.h
+++ b/Libraries/LibCompress/Deflate.h
@@ -94,7 +94,7 @@ public:
     bool discard_or_error(size_t) override;
     bool eof() const override;
 
-    static ByteBuffer decompress_all(ReadonlyBytes);
+    static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
 
 private:
     u32 decode_run_length(u32);

--- a/Libraries/LibCompress/Deflate.h
+++ b/Libraries/LibCompress/Deflate.h
@@ -97,7 +97,7 @@ public:
     static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
 
 private:
-    u32 decode_run_length(u32);
+    u32 decode_length(u32);
     u32 decode_distance(u32);
     void decode_codes(CanonicalCode& literal_code, Optional<CanonicalCode>& distance_code);
 

--- a/Libraries/LibCompress/Deflate.h
+++ b/Libraries/LibCompress/Deflate.h
@@ -34,23 +34,23 @@
 
 namespace Compress {
 
+class CanonicalCode {
+public:
+    CanonicalCode() = default;
+    u32 read_symbol(InputBitStream&) const;
+
+    static const CanonicalCode& fixed_literal_codes();
+    static const CanonicalCode& fixed_distance_codes();
+
+    static Optional<CanonicalCode> from_bytes(ReadonlyBytes);
+
+private:
+    Vector<u32> m_symbol_codes;
+    Vector<u32> m_symbol_values;
+};
+
 class DeflateDecompressor final : public InputStream {
 private:
-    class CanonicalCode {
-    public:
-        CanonicalCode() = default;
-        u32 read_symbol(InputBitStream&) const;
-
-        static const CanonicalCode& fixed_literal_codes();
-        static const CanonicalCode& fixed_distance_codes();
-
-        static Optional<CanonicalCode> from_bytes(ReadonlyBytes);
-
-    private:
-        Vector<u32> m_symbol_codes;
-        Vector<u32> m_symbol_values;
-    };
-
     class CompressedBlock {
     public:
         CompressedBlock(DeflateDecompressor&, CanonicalCode literal_codes, Optional<CanonicalCode> distance_codes);

--- a/Libraries/LibCompress/Gzip.cpp
+++ b/Libraries/LibCompress/Gzip.cpp
@@ -158,7 +158,7 @@ bool GzipDecompressor::discard_or_error(size_t count)
     return true;
 }
 
-ByteBuffer GzipDecompressor::decompress_all(ReadonlyBytes bytes)
+Optional<ByteBuffer> GzipDecompressor::decompress_all(ReadonlyBytes bytes)
 {
     InputMemoryStream memory_stream { bytes };
     GzipDecompressor gzip_stream { memory_stream };

--- a/Libraries/LibCompress/Gzip.h
+++ b/Libraries/LibCompress/Gzip.h
@@ -41,7 +41,7 @@ public:
     bool discard_or_error(size_t) override;
     bool eof() const override;
 
-    static ByteBuffer decompress_all(ReadonlyBytes);
+    static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
 
 private:
     struct [[gnu::packed]] BlockHeader

--- a/Libraries/LibCompress/Zlib.cpp
+++ b/Libraries/LibCompress/Zlib.cpp
@@ -55,9 +55,15 @@ Zlib::Zlib(ReadonlyBytes data)
     m_data_bytes = data.slice(2, data.size() - 2 - 4);
 }
 
-ByteBuffer Zlib::decompress()
+Optional<ByteBuffer> Zlib::decompress()
 {
     return DeflateDecompressor::decompress_all(m_data_bytes);
+}
+
+Optional<ByteBuffer> Zlib::decompress_all(ReadonlyBytes bytes)
+{
+    Zlib zlib { bytes };
+    return zlib.decompress();
 }
 
 u32 Zlib::checksum()

--- a/Libraries/LibCompress/Zlib.h
+++ b/Libraries/LibCompress/Zlib.h
@@ -36,14 +36,10 @@ class Zlib {
 public:
     Zlib(ReadonlyBytes data);
 
-    ByteBuffer decompress();
+    Optional<ByteBuffer> decompress();
     u32 checksum();
 
-    static ByteBuffer decompress_all(ReadonlyBytes bytes)
-    {
-        Zlib zlib { bytes };
-        return zlib.decompress();
-    }
+    static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
 
 private:
     u8 m_compression_method;

--- a/Userland/gunzip.cpp
+++ b/Userland/gunzip.cpp
@@ -55,8 +55,9 @@ int main(int argc, char** argv)
     if (write_to_stdout)
         keep_input_files = true;
 
-    for (StringView filename : filenames) {
-        ASSERT(filename.ends_with(".gz"));
+    for (String filename : filenames) {
+        if (!filename.ends_with(".gz"))
+            filename = String::format("%s.gz", filename);
 
         const auto input_filename = filename;
         const auto output_filename = filename.substring_view(0, filename.length() - 3);

--- a/Userland/test-compress.cpp
+++ b/Userland/test-compress.cpp
@@ -55,7 +55,7 @@ TEST_CASE(deflate_decompress_compressed_block)
     const u8 uncompressed[] = "This is a simple text file :)";
 
     const auto decompressed = Compress::DeflateDecompressor::decompress_all(compressed);
-    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.bytes()));
+    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.value().bytes()));
 }
 
 TEST_CASE(deflate_decompress_uncompressed_block)
@@ -68,7 +68,7 @@ TEST_CASE(deflate_decompress_uncompressed_block)
     const u8 uncompressed[] = "Hello, World!";
 
     const auto decompressed = Compress::DeflateDecompressor::decompress_all(compressed);
-    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.bytes()));
+    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.value().bytes()));
 }
 
 TEST_CASE(deflate_decompress_multiple_blocks)
@@ -85,7 +85,7 @@ TEST_CASE(deflate_decompress_multiple_blocks)
     const u8 uncompressed[] = "The first block is uncompressed and the second block is compressed.";
 
     const auto decompressed = Compress::DeflateDecompressor::decompress_all(compressed);
-    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.bytes()));
+    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.value().bytes()));
 }
 
 TEST_CASE(deflate_decompress_zeroes)
@@ -98,7 +98,7 @@ TEST_CASE(deflate_decompress_zeroes)
     const Array<u8, 4096> uncompressed { 0 };
 
     const auto decompressed = Compress::DeflateDecompressor::decompress_all(compressed);
-    EXPECT(compare(uncompressed, decompressed.bytes()));
+    EXPECT(compare(uncompressed, decompressed.value().bytes()));
 }
 
 TEST_CASE(zlib_decompress_simple)
@@ -113,7 +113,7 @@ TEST_CASE(zlib_decompress_simple)
     const u8 uncompressed[] = "This is a simple text file :)";
 
     const auto decompressed = Compress::Zlib::decompress_all(compressed);
-    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.bytes()));
+    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.value().bytes()));
 }
 
 TEST_CASE(gzip_decompress_simple)
@@ -127,7 +127,7 @@ TEST_CASE(gzip_decompress_simple)
     const u8 uncompressed[] = "word1 abc word2";
 
     const auto decompressed = Compress::GzipDecompressor::decompress_all(compressed);
-    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.bytes()));
+    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.value().bytes()));
 }
 
 TEST_CASE(gzip_decompress_multiple_members)
@@ -143,7 +143,7 @@ TEST_CASE(gzip_decompress_multiple_members)
     const u8 uncompressed[] = "abcabcabcabc";
 
     const auto decompressed = Compress::GzipDecompressor::decompress_all(compressed);
-    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.bytes()));
+    EXPECT(compare({ uncompressed, sizeof(uncompressed) - 1 }, decompressed.value().bytes()));
 }
 
 TEST_CASE(gzip_decompress_zeroes)
@@ -168,7 +168,7 @@ TEST_CASE(gzip_decompress_zeroes)
     const Array<u8, 128 * 1024> uncompressed = { 0 };
 
     const auto decompressed = Compress::GzipDecompressor::decompress_all(compressed);
-    EXPECT(compare(uncompressed, decompressed.bytes()));
+    EXPECT(compare(uncompressed, decompressed.value().bytes()));
 }
 
 TEST_CASE(gzip_decompress_repeat_around_buffer)
@@ -188,7 +188,7 @@ TEST_CASE(gzip_decompress_repeat_around_buffer)
     uncompressed.span().slice(0x7f00, 0x0100).fill(1);
 
     const auto decompressed = Compress::GzipDecompressor::decompress_all(compressed);
-    EXPECT(compare(uncompressed, decompressed.bytes()));
+    EXPECT(compare(uncompressed, decompressed.value().bytes()));
 }
 
 TEST_MAIN(Compress)


### PR DESCRIPTION
There are still a few nasty bugs in the Deflate implementation. I have to be honest, I am having some trouble tracking them down. In the meantime, I found a really really nasty typo in `DuplexMemoryStream::read_without_consuming` and cleaned up some code in general.

I hope that I can remove the Deflate and Gzip implementation in LibCore soon, but that's not possible at the moment.
