### PR TITLE
LibJS: Separate run() into "public" and "private" API, fix TryStatement finalizers, try/catch/except tests

### DIFF
--- a/Libraries/LibJS/Interpreter.h
+++ b/Libraries/LibJS/Interpreter.h
@@ -100,7 +100,9 @@ public:
 
     ~Interpreter();
 
-    Value run(GlobalObject&, const Statement&, ArgumentVector = {}, ScopeType = ScopeType::Block);
+    Value run(GlobalObject&, const Program&);
+
+    Value execute_statement(GlobalObject&, const Statement&, ArgumentVector = {}, ScopeType = ScopeType::Block);
 
     GlobalObject& global_object();
     const GlobalObject& global_object() const;

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -130,7 +130,7 @@ Value ScriptFunction::call(Interpreter& interpreter)
         arguments.append({ parameter.name, value });
         interpreter.current_environment()->set(parameter.name, { value, DeclarationKind::Var });
     }
-    return interpreter.run(global_object(), m_body, arguments, ScopeType::Function);
+    return interpreter.execute_statement(global_object(), m_body, arguments, ScopeType::Function);
 }
 
 Value ScriptFunction::construct(Interpreter& interpreter, Function&)

--- a/Libraries/LibJS/Tests/exception-in-catch-block.js
+++ b/Libraries/LibJS/Tests/exception-in-catch-block.js
@@ -1,0 +1,25 @@
+test("Issue #1992, exception thrown in catch {} block", () => {
+    var tryHasBeenExecuted = false;
+    var catchHasBeenExecuted = false;
+    var finallyHasBeenExecuted = false;
+    expect(() => {
+        try {
+            tryHasBeenExecuted = true;
+            foo();
+            // execution must not reach this step
+            expect().fail();
+        } catch (e) {
+            catchHasBeenExecuted = true;
+            bar();
+            // ...also not this step
+            expect().fail();
+        } finally {
+            finallyHasBeenExecuted = true;
+        }
+        // ...or this step
+        expect().fail();
+    }).toThrow(ReferenceError, "'bar' is not defined");
+    expect(tryHasBeenExecuted).toBeTrue();
+    expect(catchHasBeenExecuted).toBeTrue();
+    expect(finallyHasBeenExecuted).toBeTrue();
+});

--- a/Libraries/LibJS/Tests/try-catch-finally-nested.js
+++ b/Libraries/LibJS/Tests/try-catch-finally-nested.js
@@ -1,0 +1,55 @@
+test("Nested try/catch/finally with exceptions", () => {
+    // This test uses a combination of boolean "checkpoint" flags
+    // and expect().fail() to ensure certain code paths have been
+    // reached and others haven't.
+    var level1TryHasBeenExecuted = false;
+    var level1CatchHasBeenExecuted = false;
+    var level1FinallyHasBeenExecuted = false;
+    var level2TryHasBeenExecuted = false;
+    var level2CatchHasBeenExecuted = false;
+    var level3TryHasBeenExecuted = false;
+    var level3CatchHasBeenExecuted = false;
+    var level3FinallyHasBeenExecuted = false;
+    expect(() => {
+        try {
+            level1TryHasBeenExecuted = true;
+            foo();
+            expect().fail();
+        } catch (e) {
+            level1CatchHasBeenExecuted = true;
+            try {
+                level2TryHasBeenExecuted = true;
+                try {
+                    level3TryHasBeenExecuted = true;
+                    bar();
+                    expect().fail();
+                } catch (e) {
+                    level3CatchHasBeenExecuted = true;
+                } finally {
+                    level3FinallyHasBeenExecuted = true;
+                    baz();
+                    expect().fail();
+                }
+                expect().fail();
+            } catch (e) {
+                level2CatchHasBeenExecuted = true;
+                qux();
+                expect().fail();
+            }
+            expect().fail();
+        } finally {
+            level1FinallyHasBeenExecuted = true;
+            throw Error("Error in final finally");
+            expect().fail();
+        }
+        expect().fail();
+    }).toThrow(Error, "Error in final finally");
+    expect(level1TryHasBeenExecuted).toBeTrue();
+    expect(level1CatchHasBeenExecuted).toBeTrue();
+    expect(level1FinallyHasBeenExecuted).toBeTrue();
+    expect(level2TryHasBeenExecuted).toBeTrue();
+    expect(level2CatchHasBeenExecuted).toBeTrue();
+    expect(level3TryHasBeenExecuted).toBeTrue();
+    expect(level3CatchHasBeenExecuted).toBeTrue();
+    expect(level3FinallyHasBeenExecuted).toBeTrue();
+});

--- a/Libraries/LibJS/Tests/try-catch-finally.js
+++ b/Libraries/LibJS/Tests/try-catch-finally.js
@@ -1,0 +1,163 @@
+test("try/catch without exception", () => {
+    var tryHasBeenExecuted = false;
+    var catchHasBeenExecuted = false;
+    try {
+        tryHasBeenExecuted = true;
+    } catch (e) {
+        catchHasBeenExecuted = true;
+    }
+    expect(tryHasBeenExecuted).toBeTrue();
+    expect(catchHasBeenExecuted).toBeFalse();
+});
+
+test("try/catch with exception in try", () => {
+    var tryHasBeenExecuted = false;
+    var catchHasBeenExecuted = false;
+    var tryError = Error("Error in try");
+    try {
+        tryHasBeenExecuted = true;
+        throw tryError;
+        expect().fail();
+    } catch (e) {
+        catchHasBeenExecuted = true;
+        expect(e).toBe(tryError);
+    }
+    expect(tryHasBeenExecuted).toBeTrue();
+    expect(catchHasBeenExecuted).toBeTrue();
+});
+
+test("try/catch with exception in try and catch", () => {
+    var tryHasBeenExecuted = false;
+    var catchHasBeenExecuted = false;
+    var tryError = Error("Error in try");
+    var catchError = Error("Error in catch");
+    expect(() => {
+        try {
+            tryHasBeenExecuted = true;
+            throw tryError;
+            expect().fail();
+        } catch (e) {
+            catchHasBeenExecuted = true;
+            expect(e).toBe(tryError);
+            throw catchError;
+            expect().fail();
+        }
+    }).toThrow(Error, "Error in catch");
+    expect(tryHasBeenExecuted).toBeTrue();
+    expect(catchHasBeenExecuted).toBeTrue();
+});
+
+test("try/catch/finally without exception", () => {
+    var tryHasBeenExecuted = false;
+    var catchHasBeenExecuted = false;
+    var finallyHasBeenExecuted = false;
+    try {
+        tryHasBeenExecuted = true;
+    } catch (e) {
+        catchHasBeenExecuted = true;
+    } finally {
+        finallyHasBeenExecuted = true;
+    }
+    expect(tryHasBeenExecuted).toBeTrue();
+    expect(catchHasBeenExecuted).toBeFalse();
+    expect(finallyHasBeenExecuted).toBeTrue();
+});
+
+test("try/catch/finally with exception in try and catch", () => {
+    var tryHasBeenExecuted = false;
+    var catchHasBeenExecuted = false;
+    var finallyHasBeenExecuted = false;
+    var tryError = Error("Error in try");
+    var catchError = Error("Error in catch");
+    expect(() => {
+        try {
+            tryHasBeenExecuted = true;
+            throw tryError;
+            expect().fail();
+        } catch (e) {
+            catchHasBeenExecuted = true;
+            expect(e).toBe(tryError);
+            throw catchError;
+            expect().fail();
+        } finally {
+            finallyHasBeenExecuted = true;
+        }
+    }).toThrow(Error, "Error in catch");
+    expect(tryHasBeenExecuted).toBeTrue();
+    expect(catchHasBeenExecuted).toBeTrue();
+    expect(finallyHasBeenExecuted).toBeTrue();
+});
+
+test("try/catch/finally with exception in finally", () => {
+    var tryHasBeenExecuted = false;
+    var catchHasBeenExecuted = false;
+    var finallyHasBeenExecuted = false;
+    var finallyError = Error("Error in finally");
+    expect(() => {
+        try {
+            tryHasBeenExecuted = true;
+        } catch (e) {
+            catchHasBeenExecuted = true;
+        } finally {
+            finallyHasBeenExecuted = true;
+            throw finallyError;
+            expect().fail();
+        }
+    }).toThrow(Error, "Error in finally");
+    expect(tryHasBeenExecuted).toBeTrue();
+    expect(catchHasBeenExecuted).toBeFalse();
+    expect(finallyHasBeenExecuted).toBeTrue();
+});
+
+test("try/catch/finally with exception in try and finally", () => {
+    var tryHasBeenExecuted = false;
+    var catchHasBeenExecuted = false;
+    var finallyHasBeenExecuted = false;
+    var tryError = Error("Error in try");
+    var finallyError = Error("Error in finally");
+    expect(() => {
+        try {
+            tryHasBeenExecuted = true;
+            throw tryError;
+            expect().fail();
+        } catch (e) {
+            catchHasBeenExecuted = true;
+            expect(e).toBe(tryError);
+        } finally {
+            finallyHasBeenExecuted = true;
+            throw finallyError;
+            expect().fail();
+        }
+    }).toThrow(Error, "Error in finally");
+    expect(tryHasBeenExecuted).toBeTrue();
+    expect(catchHasBeenExecuted).toBeTrue();
+    expect(finallyHasBeenExecuted).toBeTrue();
+});
+
+test("try/catch/finally with exception in try, catch and finally", () => {
+    var tryHasBeenExecuted = false;
+    var catchHasBeenExecuted = false;
+    var finallyHasBeenExecuted = false;
+    var tryError = Error("Error in try");
+    var catchError = Error("Error in catch");
+    var finallyError = Error("Error in finally");
+    expect(() => {
+        try {
+            tryHasBeenExecuted = true;
+            throw tryError;
+            expect().fail();
+        } catch (e) {
+            catchHasBeenExecuted = true;
+            expect(e).toBe(tryError);
+            throw catchError;
+            expect().fail();
+        } finally {
+            finallyHasBeenExecuted = true;
+            throw finallyError;
+            expect().fail();
+        }
+    }).toThrow(Error, "Error in finally");
+    expect(tryHasBeenExecuted).toBeTrue();
+    expect(catchHasBeenExecuted).toBeTrue();
+    expect(finallyHasBeenExecuted).toBeTrue();
+});


### PR DESCRIPTION
**LibJS: Extract most of `Interpreter`'s `run()` into `execute_statement()`**

`Interpreter::run()` was so far being used both as the "public API entry point" for running a `JS::Program` as well as internally to execute `JS::Statement`s of all kinds - this is now more distinctly separated.
A program as returned by the parser is still going through `run()`, which is responsible for creating the initial global call frame, but all other statements are executed via `execute_statement()` directly.

Fixes #3437, a regression introduced by adding `ASSERT(!exception())` to `run()` without considering the effects that would have on internal usage.

**LibJS: Stop unwinding and reset exception for `TryStatement` finalizer**

This fixes two issues with running a `TryStatement` finalizer:

- Temporarily store and clear the exception, if any, so we can run the finalizer block statement without it getting in our way, which could have unexpected side effects otherwise (and will likely return early somewhere).
- Stop unwinding so more than one child node of the finalizer `BlockStatement` is executed if an exception has been thrown previously (which would have called `unwind(ScopeType::Try)`). Re-throwing as described above ensures we still unwind after the finalizer, if necessary.

Also add some tests specifically for try/catch/finally blocks, we didn't have any!