### PR TITLE
LibGUI: Use new Bitmap::minimum_pitch method

### DIFF
--- a/Libraries/LibGUI/Window.cpp
+++ b/Libraries/LibGUI/Window.cpp
@@ -635,7 +635,7 @@ RefPtr<Gfx::Bitmap> Window::create_shared_bitmap(Gfx::BitmapFormat format, const
 {
     ASSERT(WindowServerConnection::the().server_pid());
     ASSERT(!size.is_empty());
-    size_t pitch = round_up_to_power_of_two(size.width() * sizeof(Gfx::RGBA32), 16);
+    size_t pitch = Gfx::Bitmap::minimum_pitch(size.width(), format);
     size_t size_in_bytes = size.height() * pitch;
     auto shared_buffer = SharedBuffer::create_with_size(size_in_bytes);
     ASSERT(shared_buffer);

--- a/Libraries/LibGfx/Painter.cpp
+++ b/Libraries/LibGfx/Painter.cpp
@@ -68,6 +68,7 @@ ALWAYS_INLINE Color get_pixel(const Gfx::Bitmap& bitmap, int x, int y)
 Painter::Painter(Gfx::Bitmap& bitmap)
     : m_target(bitmap)
 {
+    ASSERT(bitmap.format() == Gfx::BitmapFormat::RGB32 || bitmap.format() == Gfx::BitmapFormat::RGBA32);
     m_state_stack.append(State());
     state().font = &Font::default_font();
     state().clip_rect = { { 0, 0 }, bitmap.size() };


### PR DESCRIPTION
Also, make sure that the painter actually draws on a RGB(A) bitmap.

Closes #3460.