### PR TITLE
Spreadsheet: Less crashy format strings + fg/bg colors

### DIFF
--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -358,7 +358,7 @@ struct PrintfImpl {
     {
         if (state.long_qualifiers >= 2)
             return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), false, state.alternate_form, state.left_pad, state.zero_pad, state.field_width);
-        return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), false, state.alternate_form, state.left_pad, state.zero_pad, state.field_width);
+        return print_hex(m_putch, m_bufptr, NextArgument<u32>()(ap), false, state.alternate_form, state.left_pad, state.zero_pad, state.field_width);
     }
     ALWAYS_INLINE int format_X(const ModifierState& state, ArgumentListRefT ap) const
     {

--- a/Applications/Spreadsheet/CMakeLists.txt
+++ b/Applications/Spreadsheet/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     Cell.cpp
     CellSyntaxHighlighter.cpp
+    CellType/Format.cpp
     CellType/Identity.cpp
     CellType/Numeric.cpp
     CellType/String.cpp

--- a/Applications/Spreadsheet/CellType/Format.h
+++ b/Applications/Spreadsheet/CellType/Format.h
@@ -24,40 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "Numeric.h"
-#include "../Cell.h"
-#include "../Spreadsheet.h"
-#include "Format.h"
+#pragma once
+
+#include <AK/Forward.h>
 
 namespace Spreadsheet {
 
-NumericCell::NumericCell()
-    : CellType("Numeric")
-{
-}
-
-NumericCell::~NumericCell()
-{
-}
-
-String NumericCell::display(Cell& cell, const CellTypeMetadata& metadata) const
-{
-    auto value = js_value(cell, metadata);
-    String string;
-    if (metadata.format.is_null())
-        string = value.to_string_without_side_effects();
-    else
-        string = format_double(metadata.format.characters(), value.to_double(cell.sheet->interpreter()));
-
-    if (metadata.length >= 0)
-        return string.substring(0, metadata.length);
-
-    return string;
-}
-
-JS::Value NumericCell::js_value(Cell& cell, const CellTypeMetadata&) const
-{
-    return cell.js_data().to_number(cell.sheet->interpreter());
-}
+String format_double(const char* format, double value);
 
 }

--- a/Applications/Spreadsheet/CellType/Type.h
+++ b/Applications/Spreadsheet/CellType/Type.h
@@ -29,6 +29,7 @@
 #include "../Forward.h"
 #include <AK/Forward.h>
 #include <AK/String.h>
+#include <LibGfx/Color.h>
 #include <LibGfx/TextAlignment.h>
 #include <LibJS/Forward.h>
 
@@ -38,6 +39,8 @@ struct CellTypeMetadata {
     int length { -1 };
     String format;
     Gfx::TextAlignment alignment { Gfx::TextAlignment::CenterRight };
+    Optional<Gfx::Color> static_foreground_color;
+    Optional<Gfx::Color> static_background_color;
 };
 
 class CellType {

--- a/Applications/Spreadsheet/CellTypeDialog.h
+++ b/Applications/Spreadsheet/CellTypeDialog.h
@@ -60,6 +60,8 @@ private:
     String m_format;
     HorizontalAlignment m_horizontal_alignment { HorizontalAlignment::Right };
     VerticalAlignment m_vertical_alignment { VerticalAlignment::Center };
+    Optional<Color> m_static_foreground_color;
+    Optional<Color> m_static_background_color;
 };
 
 }

--- a/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -85,6 +85,20 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
                 return Color(Color::Red);
         }
 
+        if (auto color = cell->type_metadata().static_foreground_color; color.has_value())
+            return color.value();
+
+        return {};
+    }
+
+    if (role == GUI::ModelRole::BackgroundColor) {
+        const auto* cell = m_sheet->at({ m_sheet->column(index.column()), (size_t)index.row() });
+        if (!cell)
+            return {};
+
+        if (auto color = cell->type_metadata().static_background_color; color.has_value())
+            return color.value();
+
         return {};
     }
 

--- a/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -171,6 +171,9 @@ void SpreadsheetView::TableCellPainter::paint(GUI::Painter& painter, const Gfx::
     // Undo the horizontal padding done by the table view...
     auto cell_rect = rect.inflated(m_table_view.horizontal_padding() * 2, 0);
 
+    if (auto bg = index.data(GUI::ModelRole::BackgroundColor); bg.is_color())
+        painter.fill_rect(cell_rect, bg.as_color());
+
     if (m_table_view.selection().contains(index)) {
         Color fill_color = palette.selection();
         fill_color.set_alpha(80);


### PR DESCRIPTION
Summary of this PR in one image:
![shot-2020-09-12_16-04-51](https://user-images.githubusercontent.com/14001776/92994706-ca917180-f511-11ea-9937-7aa2a3f5bdfc.jpg)

(These are still not saved)