### PR TITLE
LibGfx+LibWeb: clone GIF frames instead of returning underlying frame buffer

### DIFF
--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -182,6 +182,25 @@ Bitmap::Bitmap(BitmapFormat format, NonnullRefPtr<SharedBuffer>&& shared_buffer,
         allocate_palette_from_format(m_format, palette);
 }
 
+RefPtr<Gfx::Bitmap> Bitmap::clone() const
+{
+    RefPtr<Gfx::Bitmap> new_bitmap {};
+    if (m_purgeable) {
+        new_bitmap = Bitmap::create_purgeable(format(), size());
+    } else {
+        new_bitmap = Bitmap::create(format(), size());
+    }
+
+    if (!new_bitmap) {
+        return nullptr;
+    }
+
+    ASSERT(size_in_bytes() == new_bitmap->size_in_bytes());
+    memcpy(new_bitmap->scanline(0), scanline(0), size_in_bytes());
+
+    return new_bitmap;
+}
+
 RefPtr<Gfx::Bitmap> Bitmap::rotated(Gfx::RotationDirection rotation_direction) const
 {
     auto w = this->width();

--- a/Libraries/LibGfx/Bitmap.h
+++ b/Libraries/LibGfx/Bitmap.h
@@ -103,6 +103,8 @@ public:
         return false;
     }
 
+    RefPtr<Gfx::Bitmap> clone() const;
+
     RefPtr<Gfx::Bitmap> rotated(Gfx::RotationDirection) const;
     RefPtr<Gfx::Bitmap> flipped(Gfx::Orientation) const;
     RefPtr<Bitmap> to_bitmap_backed_by_shared_buffer() const;

--- a/Libraries/LibGfx/Bitmap.h
+++ b/Libraries/LibGfx/Bitmap.h
@@ -79,6 +79,8 @@ static StorageFormat determine_storage_format(BitmapFormat format)
     }
 }
 
+struct BackingStore;
+
 enum RotationDirection {
     Left,
     Right
@@ -192,7 +194,8 @@ public:
 
     void set_mmap_name(const StringView&);
 
-    size_t size_in_bytes() const { return m_pitch * m_size.height(); }
+    static constexpr size_t size_in_bytes(size_t pitch, int height) { return pitch * height; }
+    size_t size_in_bytes() const { return size_in_bytes(m_pitch, height()); }
 
     Color palette_color(u8 index) const { return Color::from_rgba(m_palette[index]); }
     void set_palette_color(u8 index, Color color) { m_palette[index] = color.value(); }
@@ -223,9 +226,11 @@ private:
         No,
         Yes
     };
-    Bitmap(BitmapFormat, const IntSize&, Purgeable);
+    Bitmap(BitmapFormat, const IntSize&, Purgeable, const BackingStore&);
     Bitmap(BitmapFormat, const IntSize&, size_t pitch, void*);
     Bitmap(BitmapFormat, NonnullRefPtr<SharedBuffer>&&, const IntSize&, const Vector<RGBA32>& palette);
+
+    static Optional<BackingStore> allocate_backing_store(BitmapFormat, const IntSize&, Purgeable);
 
     void allocate_palette_from_format(BitmapFormat, const Vector<RGBA32>& source_palette);
 

--- a/Libraries/LibGfx/GIFLoader.cpp
+++ b/Libraries/LibGfx/GIFLoader.cpp
@@ -709,7 +709,7 @@ ImageFrameDescriptor GIFImageDecoderPlugin::frame(size_t i)
     }
 
     ImageFrameDescriptor frame {};
-    frame.image = m_context->frame_buffer;
+    frame.image = m_context->frame_buffer->clone();
     frame.duration = m_context->images.at(i).duration * 10;
 
     if (frame.duration <= 10) {

--- a/Libraries/LibWeb/Layout/LayoutImage.cpp
+++ b/Libraries/LibWeb/Layout/LayoutImage.cpp
@@ -115,7 +115,7 @@ void LayoutImage::paint(PaintContext& context, PaintPhase phase)
             if (alt.is_empty())
                 alt = image_element.src();
             context.painter().draw_text(enclosing_int_rect(absolute_rect()), alt, Gfx::TextAlignment::Center, specified_style().color_or_fallback(CSS::PropertyID::Color, document(), Color::Black), Gfx::TextElision::Right);
-        } else if (auto* bitmap = m_image_loader.bitmap()) {
+        } else if (auto bitmap = m_image_loader.bitmap()) {
             context.painter().draw_scaled_bitmap(enclosing_int_rect(absolute_rect()), *bitmap, bitmap->rect());
         }
     }

--- a/Libraries/LibWeb/Loader/ImageResource.cpp
+++ b/Libraries/LibWeb/Loader/ImageResource.cpp
@@ -62,10 +62,10 @@ const Gfx::Bitmap* ImageResource::bitmap(size_t frame_index) const
         if (!m_decoder)
             return nullptr;
         if (m_decoder->is_animated())
-            return m_decoder->frame(frame_index).image;
-        return m_decoder->bitmap();
-    }
-    if (!m_decoded_image && !m_has_attempted_decode) {
+            m_decoded_image = m_decoder->frame(frame_index).image;
+        else
+            m_decoded_image = m_decoder->bitmap();
+    } else if (!m_decoded_image && !m_has_attempted_decode) {
         auto image_decoder_client = ImageDecoderClient::Client::construct();
         m_decoded_image = image_decoder_client->decode_image(encoded_data());
         m_has_attempted_decode = true;


### PR DESCRIPTION
This PR:
1. LibGfx: add Bitmap::clone() method
2. LibWeb: use RefPtr instead of raw pointer for ImageResource bitmap refs
3. LibGfx: return clone from frame() instead of underlying framebuffer

Fixes GIF animation in ImageWidget