### PR TITLE
Kernel: Make copy_to/from_user safe and remove unnecessary checks

### DIFF
--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -930,7 +930,7 @@ int Emulator::virt$execve(FlatPtr params_addr)
     auto copy_string_list = [this](auto& output_vector, auto& string_list) {
         for (size_t i = 0; i < string_list.length; ++i) {
             Syscall::StringArgument string;
-            mmu().copy_from_vm(&string, (FlatPtr)&string_list.strings.ptr()[i], sizeof(string));
+            mmu().copy_from_vm(&string, (FlatPtr)&string_list.strings[i], sizeof(string));
             output_vector.append(String::copy(mmu().copy_buffer_from_vm((FlatPtr)string.characters, string.length)));
         }
     };
@@ -1307,7 +1307,7 @@ int Emulator::virt$waitid(FlatPtr params_addr)
     }
 
     if (params.infop)
-        mmu().copy_to_vm(params.infop, &info, sizeof(info));
+        mmu().copy_to_vm((FlatPtr)params.infop, &info, sizeof(info));
 
     return rc;
 }

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -222,7 +222,7 @@ inline constexpr const char* to_string(Function function)
 
 #ifdef __serenity__
 struct StringArgument {
-    Userspace<const char*> characters;
+    const char* characters;
     size_t length { 0 };
 };
 
@@ -239,7 +239,7 @@ struct ImmutableBufferArgument {
 };
 
 struct StringListArgument {
-    Userspace<StringArgument*> strings {};
+    StringArgument* strings {};
     size_t length { 0 };
 };
 
@@ -273,22 +273,22 @@ struct SC_select_params {
 struct SC_poll_params {
     struct pollfd* fds;
     unsigned nfds;
-    Userspace<const struct timespec*> timeout;
-    Userspace<const u32*> sigmask;
+    const struct timespec* timeout;
+    const u32* sigmask;
 };
 
 struct SC_clock_nanosleep_params {
     int clock_id;
     int flags;
-    Userspace<const struct timespec*> requested_sleep;
-    Userspace<struct timespec*> remaining_sleep;
+    const struct timespec* requested_sleep;
+    struct timespec* remaining_sleep;
 };
 
 struct SC_sendto_params {
     int sockfd;
     ImmutableBufferArgument<void, size_t> data;
     int flags;
-    Userspace<const sockaddr*> addr;
+    const sockaddr* addr;
     socklen_t addr_length;
 };
 
@@ -296,50 +296,50 @@ struct SC_recvfrom_params {
     int sockfd;
     MutableBufferArgument<void, size_t> buffer;
     int flags;
-    Userspace<sockaddr*> addr;
-    Userspace<socklen_t*> addr_length;
+    sockaddr* addr;
+    socklen_t* addr_length;
 };
 
 struct SC_getsockopt_params {
     int sockfd;
     int level;
     int option;
-    Userspace<void*> value;
-    Userspace<socklen_t*> value_size;
+    void* value;
+    socklen_t* value_size;
 };
 
 struct SC_setsockopt_params {
     int sockfd;
     int level;
     int option;
-    Userspace<const void*> value;
+    const void* value;
     socklen_t value_size;
 };
 
 struct SC_getsockname_params {
     int sockfd;
-    Userspace<sockaddr*> addr;
-    Userspace<socklen_t*> addrlen;
+    sockaddr* addr;
+    socklen_t* addrlen;
 };
 
 struct SC_getpeername_params {
     int sockfd;
-    Userspace<sockaddr*> addr;
-    Userspace<socklen_t*> addrlen;
+    sockaddr* addr;
+    socklen_t* addrlen;
 };
 
 struct SC_futex_params {
-    Userspace<const i32*> userspace_address;
+    const i32* userspace_address;
     int futex_op;
     i32 val;
-    Userspace<const timespec*> timeout;
+    const timespec* timeout;
 };
 
 struct SC_setkeymap_params {
-    Userspace<const u32*> map;
-    Userspace<const u32*> shift_map;
-    Userspace<const u32*> alt_map;
-    Userspace<const u32*> altgr_map;
+    const u32* map;
+    const u32* shift_map;
+    const u32* alt_map;
+    const u32* altgr_map;
     StringArgument map_name;
 };
 
@@ -354,7 +354,7 @@ struct SC_create_thread_params {
     unsigned int m_guard_page_size = 0;          // Rounded up to PAGE_SIZE
     unsigned int m_reported_guard_page_size = 0; // The lie we tell callers
     unsigned int m_stack_size = 4 * MiB;         // Default PTHREAD_STACK_MIN
-    Userspace<void*> m_stack_location;           // nullptr means any, o.w. process virtual address
+    void* m_stack_location;           // nullptr means any, o.w. process virtual address
 };
 
 struct SC_realpath_params {
@@ -426,26 +426,26 @@ struct SC_unveil_params {
 struct SC_waitid_params {
     int idtype;
     int id;
-    Userspace<struct siginfo*> infop;
+    struct siginfo* infop;
     int options;
 };
 
 struct SC_stat_params {
     StringArgument path;
-    Userspace<struct stat*> statbuf;
+    struct stat* statbuf;
     bool follow_symlinks;
 };
 
 struct SC_ptrace_params {
     int request;
     pid_t tid;
-    Userspace<u8*> addr;
+    u8* addr;
     int data;
 };
 
 struct SC_ptrace_peek_params {
-    Userspace<const u32*> address;
-    Userspace<u32*> out_data;
+    const u32* address;
+    u32* out_data;
 };
 
 void initialize();

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -226,6 +226,7 @@ extern "C" u8* safe_memset_2_faulted;
 
 bool safe_memcpy(void* dest_ptr, const void* src_ptr, size_t n, void*& fault_at)
 {
+    fault_at = nullptr;
     size_t dest = (size_t)dest_ptr;
     size_t src = (size_t)src_ptr;
     size_t remainder;
@@ -233,7 +234,6 @@ bool safe_memcpy(void* dest_ptr, const void* src_ptr, size_t n, void*& fault_at)
     if (!(dest & 0x3) && !(src & 0x3) && n >= 12) {
         size_t size_ts = n / sizeof(size_t);
         asm volatile(
-            "xor %[fault_at], %[fault_at] \n"
             ".global safe_memcpy_ins_1 \n"
             "safe_memcpy_ins_1: \n"
             "rep movsl \n"
@@ -256,7 +256,6 @@ bool safe_memcpy(void* dest_ptr, const void* src_ptr, size_t n, void*& fault_at)
         }
     }
     asm volatile(
-        "xor %[fault_at], %[fault_at] \n"
         ".global safe_memcpy_ins_2 \n"
         "safe_memcpy_ins_2: \n"
         "rep movsb \n"
@@ -277,8 +276,8 @@ bool safe_memcpy(void* dest_ptr, const void* src_ptr, size_t n, void*& fault_at)
 ssize_t safe_strnlen(const char* str, size_t max_n, void*& fault_at)
 {
     ssize_t count = 0;
+    fault_at = nullptr;
     asm volatile(
-        "xor %[fault_at], %[fault_at] \n"
         "1: \n"
         "test %[max_n], %[max_n] \n"
         "je 2f \n"
@@ -307,6 +306,7 @@ ssize_t safe_strnlen(const char* str, size_t max_n, void*& fault_at)
 
 bool safe_memset(void* dest_ptr, int c, size_t n, void*& fault_at)
 {
+    fault_at = nullptr;
     size_t dest = (size_t)dest_ptr;
     size_t remainder;
     // FIXME: Support starting at an unaligned address.
@@ -316,7 +316,6 @@ bool safe_memset(void* dest_ptr, int c, size_t n, void*& fault_at)
         expanded_c |= expanded_c << 8;
         expanded_c |= expanded_c << 16;
         asm volatile(
-            "xor %[fault_at], %[fault_at] \n"
             ".global safe_memset_ins_1 \n"
             "safe_memset_ins_1: \n"
             "rep stosl \n"
@@ -338,7 +337,6 @@ bool safe_memset(void* dest_ptr, int c, size_t n, void*& fault_at)
         }
     }
     asm volatile(
-        "xor %[fault_at], %[fault_at] \n"
         ".global safe_memset_ins_2 \n"
         "safe_memset_ins_2: \n"
         "rep stosb \n"

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -279,6 +279,10 @@ void flush_idt();
 void load_task_register(u16 selector);
 void handle_crash(RegisterState&, const char* description, int signal, bool out_of_memory = false);
 
+[[nodiscard]] bool safe_memcpy(void* dest_ptr, const void* src_ptr, size_t n, void*& fault_at);
+[[nodiscard]] ssize_t safe_strnlen(const char* str, size_t max_n, void*& fault_at);
+[[nodiscard]] bool safe_memset(void* dest_ptr, int c, size_t n, void*& fault_at);
+
 #define LSW(x) ((u32)(x)&0xFFFF)
 #define MSW(x) (((u32)(x) >> 16) & 0xFFFF)
 #define LSB(x) ((x)&0xFF)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -176,6 +176,7 @@ set(KERNEL_SOURCES
     Time/RTC.cpp
     Time/TimeManagement.cpp
     TimerQueue.cpp
+    UserOrKernelBuffer.cpp
     VM/AnonymousVMObject.cpp
     VM/ContiguousVMObject.cpp
     VM/InodeVMObject.cpp

--- a/Kernel/Console.h
+++ b/Kernel/Console.h
@@ -43,8 +43,8 @@ public:
     // ^CharacterDevice
     virtual bool can_read(const Kernel::FileDescription&, size_t) const override;
     virtual bool can_write(const Kernel::FileDescription&, size_t) const override { return true; }
-    virtual Kernel::KResultOr<size_t> read(Kernel::FileDescription&, size_t, u8*, size_t) override;
-    virtual Kernel::KResultOr<size_t> write(Kernel::FileDescription&, size_t, const u8*, size_t) override;
+    virtual Kernel::KResultOr<size_t> read(Kernel::FileDescription&, size_t, Kernel::UserOrKernelBuffer&, size_t) override;
+    virtual Kernel::KResultOr<size_t> write(Kernel::FileDescription&, size_t, const Kernel::UserOrKernelBuffer&, size_t) override;
     virtual const char* class_name() const override { return "Console"; }
 
     void put_char(char);

--- a/Kernel/Devices/BXVGADevice.cpp
+++ b/Kernel/Devices/BXVGADevice.cpp
@@ -203,18 +203,16 @@ int BXVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
     switch (request) {
     case FB_IOCTL_GET_SIZE_IN_BYTES: {
         auto* out = (size_t*)arg;
-        if (!Process::current()->validate_write_typed(out))
-            return -EFAULT;
         size_t value = framebuffer_size_in_bytes();
-        copy_to_user(out, &value);
+        if (!copy_to_user(out, &value))
+            return -EFAULT;
         return 0;
     }
     case FB_IOCTL_GET_BUFFER: {
         auto* index = (int*)arg;
-        if (!Process::current()->validate_write_typed(index))
-            return -EFAULT;
         int value = m_y_offset == 0 ? 0 : 1;
-        copy_to_user(index, &value);
+        if (!copy_to_user(index, &value))
+            return -EFAULT;
         return 0;
     }
     case FB_IOCTL_SET_BUFFER: {
@@ -225,21 +223,18 @@ int BXVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
     }
     case FB_IOCTL_GET_RESOLUTION: {
         auto* user_resolution = (FBResolution*)arg;
-        if (!Process::current()->validate_write_typed(user_resolution))
-            return -EFAULT;
         FBResolution resolution;
         resolution.pitch = m_framebuffer_pitch;
         resolution.width = m_framebuffer_width;
         resolution.height = m_framebuffer_height;
-        copy_to_user(user_resolution, &resolution);
+        if (!copy_to_user(user_resolution, &resolution))
+            return -EFAULT;
         return 0;
     }
     case FB_IOCTL_SET_RESOLUTION: {
         auto* user_resolution = (FBResolution*)arg;
-        if (!Process::current()->validate_write_typed(user_resolution))
-            return -EFAULT;
         FBResolution resolution;
-        if (!Process::current()->validate_read_and_copy_typed(&resolution, user_resolution))
+        if (!copy_from_user(&resolution, user_resolution))
             return -EFAULT;
         if (resolution.width > MAX_RESOLUTION_WIDTH || resolution.height > MAX_RESOLUTION_HEIGHT)
             return -EINVAL;
@@ -250,7 +245,8 @@ int BXVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
             resolution.pitch = m_framebuffer_pitch;
             resolution.width = m_framebuffer_width;
             resolution.height = m_framebuffer_height;
-            copy_to_user(user_resolution, &resolution);
+            if (!copy_to_user(user_resolution, &resolution))
+                return -EFAULT;
             return -EINVAL;
         }
 #ifdef BXVGA_DEBUG
@@ -259,7 +255,8 @@ int BXVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
         resolution.pitch = m_framebuffer_pitch;
         resolution.width = m_framebuffer_width;
         resolution.height = m_framebuffer_height;
-        copy_to_user(user_resolution, &resolution);
+        if (!copy_to_user(user_resolution, &resolution))
+            return -EFAULT;
         return 0;
     }
     default:

--- a/Kernel/Devices/BXVGADevice.h
+++ b/Kernel/Devices/BXVGADevice.h
@@ -48,10 +48,10 @@ private:
     virtual const char* class_name() const override { return "BXVGA"; }
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override { return -EINVAL; }
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override { return -EINVAL; }
-    virtual bool read_blocks(unsigned, u16, u8*) override { return false; }
-    virtual bool write_blocks(unsigned, u16, const u8*) override { return false; }
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override { return -EINVAL; }
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
+    virtual bool read_blocks(unsigned, u16, UserOrKernelBuffer&) override { return false; }
+    virtual bool write_blocks(unsigned, u16, const UserOrKernelBuffer&) override { return false; }
 
     void set_safe_resolution();
 

--- a/Kernel/Devices/BlockDevice.cpp
+++ b/Kernel/Devices/BlockDevice.cpp
@@ -32,17 +32,17 @@ BlockDevice::~BlockDevice()
 {
 }
 
-bool BlockDevice::read_block(unsigned index, u8* buffer) const
+bool BlockDevice::read_block(unsigned index, UserOrKernelBuffer& buffer) const
 {
     return const_cast<BlockDevice*>(this)->read_blocks(index, 1, buffer);
 }
 
-bool BlockDevice::write_block(unsigned index, const u8* data)
+bool BlockDevice::write_block(unsigned index, const UserOrKernelBuffer& data)
 {
     return write_blocks(index, 1, data);
 }
 
-bool BlockDevice::read_raw(u32 offset, unsigned length, u8* out) const
+bool BlockDevice::read_raw(u32 offset, unsigned length, UserOrKernelBuffer& out) const
 {
     ASSERT((offset % block_size()) == 0);
     ASSERT((length % block_size()) == 0);
@@ -51,7 +51,7 @@ bool BlockDevice::read_raw(u32 offset, unsigned length, u8* out) const
     return const_cast<BlockDevice*>(this)->read_blocks(first_block, end_block - first_block, out);
 }
 
-bool BlockDevice::write_raw(u32 offset, unsigned length, const u8* in)
+bool BlockDevice::write_raw(u32 offset, unsigned length, const UserOrKernelBuffer& in)
 {
     ASSERT((offset % block_size()) == 0);
     ASSERT((length % block_size()) == 0);

--- a/Kernel/Devices/BlockDevice.h
+++ b/Kernel/Devices/BlockDevice.h
@@ -37,13 +37,13 @@ public:
     size_t block_size() const { return m_block_size; }
     virtual bool is_seekable() const override { return true; }
 
-    bool read_block(unsigned index, u8*) const;
-    bool write_block(unsigned index, const u8*);
-    bool read_raw(u32 offset, unsigned length, u8*) const;
-    bool write_raw(u32 offset, unsigned length, const u8*);
+    bool read_block(unsigned index, UserOrKernelBuffer&) const;
+    bool write_block(unsigned index, const UserOrKernelBuffer&);
+    bool read_raw(u32 offset, unsigned length, UserOrKernelBuffer&) const;
+    bool write_raw(u32 offset, unsigned length, const UserOrKernelBuffer&);
 
-    virtual bool read_blocks(unsigned index, u16 count, u8*) = 0;
-    virtual bool write_blocks(unsigned index, u16 count, const u8*) = 0;
+    virtual bool read_blocks(unsigned index, u16 count, UserOrKernelBuffer&) = 0;
+    virtual bool write_blocks(unsigned index, u16 count, const UserOrKernelBuffer&) = 0;
 
 protected:
     BlockDevice(unsigned major, unsigned minor, size_t block_size = PAGE_SIZE)

--- a/Kernel/Devices/DiskPartition.cpp
+++ b/Kernel/Devices/DiskPartition.cpp
@@ -48,7 +48,7 @@ DiskPartition::~DiskPartition()
 {
 }
 
-KResultOr<size_t> DiskPartition::read(FileDescription& fd, size_t offset, u8* outbuf, size_t len)
+KResultOr<size_t> DiskPartition::read(FileDescription& fd, size_t offset, UserOrKernelBuffer& outbuf, size_t len)
 {
     unsigned adjust = m_block_offset * block_size();
 
@@ -70,7 +70,7 @@ bool DiskPartition::can_read(const FileDescription& fd, size_t offset) const
     return m_device->can_read(fd, offset + adjust);
 }
 
-KResultOr<size_t> DiskPartition::write(FileDescription& fd, size_t offset, const u8* inbuf, size_t len)
+KResultOr<size_t> DiskPartition::write(FileDescription& fd, size_t offset, const UserOrKernelBuffer& inbuf, size_t len)
 {
     unsigned adjust = m_block_offset * block_size();
 
@@ -92,7 +92,7 @@ bool DiskPartition::can_write(const FileDescription& fd, size_t offset) const
     return m_device->can_write(fd, offset + adjust);
 }
 
-bool DiskPartition::read_blocks(unsigned index, u16 count, u8* out)
+bool DiskPartition::read_blocks(unsigned index, u16 count, UserOrKernelBuffer& out)
 {
 #ifdef OFFD_DEBUG
     klog() << "DiskPartition::read_blocks " << index << " (really: " << (m_block_offset + index) << ") count=" << count;
@@ -101,7 +101,7 @@ bool DiskPartition::read_blocks(unsigned index, u16 count, u8* out)
     return m_device->read_blocks(m_block_offset + index, count, out);
 }
 
-bool DiskPartition::write_blocks(unsigned index, u16 count, const u8* data)
+bool DiskPartition::write_blocks(unsigned index, u16 count, const UserOrKernelBuffer& data)
 {
 #ifdef OFFD_DEBUG
     klog() << "DiskPartition::write_blocks " << index << " (really: " << (m_block_offset + index) << ") count=" << count;

--- a/Kernel/Devices/DiskPartition.h
+++ b/Kernel/Devices/DiskPartition.h
@@ -36,13 +36,13 @@ public:
     static NonnullRefPtr<DiskPartition> create(BlockDevice&, unsigned block_offset, unsigned block_limit);
     virtual ~DiskPartition();
 
-    virtual bool read_blocks(unsigned index, u16 count, u8*) override;
-    virtual bool write_blocks(unsigned index, u16 count, const u8*) override;
+    virtual bool read_blocks(unsigned index, u16 count, UserOrKernelBuffer&) override;
+    virtual bool write_blocks(unsigned index, u16 count, const UserOrKernelBuffer&) override;
 
     // ^BlockDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override;
 
 private:

--- a/Kernel/Devices/EBRPartitionTable.cpp
+++ b/Kernel/Devices/EBRPartitionTable.cpp
@@ -63,7 +63,8 @@ int EBRPartitionTable::index_of_ebr_container() const
 
 bool EBRPartitionTable::initialize()
 {
-    if (!m_device->read_block(0, m_cached_mbr_header)) {
+    auto mbr_header_buffer = UserOrKernelBuffer::for_kernel_buffer(m_cached_mbr_header);
+    if (!m_device->read_block(0, mbr_header_buffer)) {
         return false;
     }
     auto& header = this->header();
@@ -80,7 +81,8 @@ bool EBRPartitionTable::initialize()
     }
 
     auto& ebr_entry = header.entry[m_ebr_container_id - 1];
-    if (!m_device->read_block(ebr_entry.offset, m_cached_ebr_header)) {
+    auto ebr_header_buffer = UserOrKernelBuffer::for_kernel_buffer(m_cached_ebr_header);
+    if (!m_device->read_block(ebr_entry.offset, ebr_header_buffer)) {
         return false;
     }
     size_t index = 1;
@@ -89,7 +91,7 @@ bool EBRPartitionTable::initialize()
             break;
         }
         index++;
-        if (!m_device->read_block(ebr_extension().next_chained_ebr_extension.offset, m_cached_ebr_header)) {
+        if (!m_device->read_block(ebr_extension().next_chained_ebr_extension.offset, ebr_header_buffer)) {
             return false;
         }
     }
@@ -140,7 +142,8 @@ RefPtr<DiskPartition> EBRPartitionTable::get_extended_partition(unsigned index)
     klog() << "EBRPartitionTable::partition: Extended partition, offset 0x" << String::format("%x", ebr_entry.offset) << ", type " << String::format("%x", ebr_entry.type);
 #endif
 
-    if (!m_device->read_block(ebr_entry.offset, m_cached_ebr_header)) {
+    auto ebr_header_buffer = UserOrKernelBuffer::for_kernel_buffer(m_cached_ebr_header);
+    if (!m_device->read_block(ebr_entry.offset, ebr_header_buffer)) {
         return nullptr;
     }
     size_t i = 0;
@@ -154,7 +157,7 @@ RefPtr<DiskPartition> EBRPartitionTable::get_extended_partition(unsigned index)
         }
 
         i++;
-        if (!m_device->read_block(ebr_extension().next_chained_ebr_extension.offset, m_cached_ebr_header)) {
+        if (!m_device->read_block(ebr_extension().next_chained_ebr_extension.offset, ebr_header_buffer)) {
             return nullptr;
         }
     }

--- a/Kernel/Devices/FullDevice.cpp
+++ b/Kernel/Devices/FullDevice.cpp
@@ -46,14 +46,15 @@ bool FullDevice::can_read(const FileDescription&, size_t) const
     return true;
 }
 
-KResultOr<size_t> FullDevice::read(FileDescription&, size_t, u8* buffer, size_t size)
+KResultOr<size_t> FullDevice::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
 {
     ssize_t count = min(static_cast<size_t>(PAGE_SIZE), size);
-    memset(buffer, 0, count);
+    if (!buffer.memset(0, count))
+        return KResult(-EFAULT);
     return count;
 }
 
-KResultOr<size_t> FullDevice::write(FileDescription&, size_t, const u8*, size_t size)
+KResultOr<size_t> FullDevice::write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t size)
 {
     if (size == 0)
         return 0;

--- a/Kernel/Devices/FullDevice.h
+++ b/Kernel/Devices/FullDevice.h
@@ -38,8 +38,8 @@ public:
 
 private:
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
     virtual const char* class_name() const override { return "FullDevice"; }

--- a/Kernel/Devices/GPTPartitionTable.cpp
+++ b/Kernel/Devices/GPTPartitionTable.cpp
@@ -49,7 +49,8 @@ const GPTPartitionHeader& GPTPartitionTable::header() const
 
 bool GPTPartitionTable::initialize()
 {
-    if (!m_device->read_block(1, m_cached_header)) {
+    auto header_buffer = UserOrKernelBuffer::for_kernel_buffer(m_cached_header);
+    if (!m_device->read_block(1, header_buffer)) {
         return false;
     }
 
@@ -82,7 +83,8 @@ RefPtr<DiskPartition> GPTPartitionTable::partition(unsigned index)
     u8 entries_per_sector = BytesPerSector / header.partition_entry_size;
 
     GPTPartitionEntry entries[entries_per_sector];
-    this->m_device->read_blocks(lba, 1, (u8*)&entries);
+    auto entries_buffer = UserOrKernelBuffer::for_kernel_buffer((u8*)&entries);
+    this->m_device->read_blocks(lba, 1, entries_buffer);
     GPTPartitionEntry& entry = entries[((index - 1) % entries_per_sector)];
 
 #ifdef GPT_DEBUG

--- a/Kernel/Devices/KeyboardDevice.h
+++ b/Kernel/Devices/KeyboardDevice.h
@@ -57,9 +57,9 @@ public:
     const String keymap_name() { return m_character_map.character_map_name(); }
 
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 
     virtual const char* purpose() const override { return class_name(); }

--- a/Kernel/Devices/MBRPartitionTable.cpp
+++ b/Kernel/Devices/MBRPartitionTable.cpp
@@ -49,7 +49,8 @@ const MBRPartitionHeader& MBRPartitionTable::header() const
 
 bool MBRPartitionTable::initialize()
 {
-    if (!m_device->read_block(0, m_cached_header)) {
+    auto header_buffer = UserOrKernelBuffer::for_kernel_buffer(m_cached_header);
+    if (!m_device->read_block(0, header_buffer)) {
         return false;
     }
 

--- a/Kernel/Devices/MBVGADevice.cpp
+++ b/Kernel/Devices/MBVGADevice.cpp
@@ -79,40 +79,36 @@ int MBVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
     switch (request) {
     case FB_IOCTL_GET_SIZE_IN_BYTES: {
         auto* out = (size_t*)arg;
-        if (!Process::current()->validate_write_typed(out))
-            return -EFAULT;
         size_t value = framebuffer_size_in_bytes();
-        copy_to_user(out, &value);
+        if (!copy_to_user(out, &value))
+            return -EFAULT;
         return 0;
     }
     case FB_IOCTL_GET_BUFFER: {
         auto* index = (int*)arg;
-        if (!Process::current()->validate_write_typed(index))
-            return -EFAULT;
         int value = 0;
-        copy_to_user(index, &value);
+        if (!copy_to_user(index, &value))
+            return -EFAULT;
         return 0;
     }
     case FB_IOCTL_GET_RESOLUTION: {
         auto* user_resolution = (FBResolution*)arg;
-        if (!Process::current()->validate_write_typed(user_resolution))
-            return -EFAULT;
         FBResolution resolution;
         resolution.pitch = m_framebuffer_pitch;
         resolution.width = m_framebuffer_width;
         resolution.height = m_framebuffer_height;
-        copy_to_user(user_resolution, &resolution);
+        if (!copy_to_user(user_resolution, &resolution))
+            return -EFAULT;
         return 0;
     }
     case FB_IOCTL_SET_RESOLUTION: {
         auto* user_resolution = (FBResolution*)arg;
-        if (!Process::current()->validate_read_typed(user_resolution) || !Process::current()->validate_write_typed(user_resolution))
-            return -EFAULT;
         FBResolution resolution;
         resolution.pitch = m_framebuffer_pitch;
         resolution.width = m_framebuffer_width;
         resolution.height = m_framebuffer_height;
-        copy_to_user(user_resolution, &resolution);
+        if (!copy_to_user(user_resolution, &resolution))
+            return -EFAULT;
         return 0;
     }
     default:

--- a/Kernel/Devices/MBVGADevice.h
+++ b/Kernel/Devices/MBVGADevice.h
@@ -47,10 +47,10 @@ private:
     virtual const char* class_name() const override { return "MBVGA"; }
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override { return -EINVAL; }
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override { return -EINVAL; }
-    virtual bool read_blocks(unsigned, u16, u8*) override { return false; }
-    virtual bool write_blocks(unsigned, u16, const u8*) override { return false; }
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override { return -EINVAL; }
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
+    virtual bool read_blocks(unsigned, u16, UserOrKernelBuffer&) override { return false; }
+    virtual bool write_blocks(unsigned, u16, const UserOrKernelBuffer&) override { return false; }
 
     size_t framebuffer_size_in_bytes() const { return m_framebuffer_pitch * m_framebuffer_height; }
 

--- a/Kernel/Devices/NullDevice.cpp
+++ b/Kernel/Devices/NullDevice.cpp
@@ -56,12 +56,12 @@ bool NullDevice::can_read(const FileDescription&, size_t) const
     return true;
 }
 
-KResultOr<size_t> NullDevice::read(FileDescription&, size_t, u8*, size_t)
+KResultOr<size_t> NullDevice::read(FileDescription&, size_t, UserOrKernelBuffer&, size_t)
 {
     return 0;
 }
 
-KResultOr<size_t> NullDevice::write(FileDescription&, size_t, const u8*, size_t buffer_size)
+KResultOr<size_t> NullDevice::write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t buffer_size)
 {
     return min(static_cast<size_t>(PAGE_SIZE), buffer_size);
 }

--- a/Kernel/Devices/NullDevice.h
+++ b/Kernel/Devices/NullDevice.h
@@ -41,8 +41,8 @@ public:
 
 private:
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual const char* class_name() const override { return "NullDevice"; }

--- a/Kernel/Devices/PATAChannel.h
+++ b/Kernel/Devices/PATAChannel.h
@@ -84,10 +84,10 @@ private:
     void detect_disks();
 
     void wait_for_irq();
-    bool ata_read_sectors_with_dma(u32, u16, u8*, bool);
-    bool ata_write_sectors_with_dma(u32, u16, const u8*, bool);
-    bool ata_read_sectors(u32, u16, u8*, bool);
-    bool ata_write_sectors(u32, u16, const u8*, bool);
+    bool ata_read_sectors_with_dma(u32, u16, UserOrKernelBuffer&, bool);
+    bool ata_write_sectors_with_dma(u32, u16, const UserOrKernelBuffer&, bool);
+    bool ata_read_sectors(u32, u16, UserOrKernelBuffer&, bool);
+    bool ata_write_sectors(u32, u16, const UserOrKernelBuffer&, bool);
 
     inline void prepare_for_irq();
 

--- a/Kernel/Devices/PATADiskDevice.h
+++ b/Kernel/Devices/PATADiskDevice.h
@@ -55,15 +55,15 @@ public:
     virtual ~PATADiskDevice() override;
 
     // ^DiskDevice
-    virtual bool read_blocks(unsigned index, u16 count, u8*) override;
-    virtual bool write_blocks(unsigned index, u16 count, const u8*) override;
+    virtual bool read_blocks(unsigned index, u16 count, UserOrKernelBuffer&) override;
+    virtual bool write_blocks(unsigned index, u16 count, const UserOrKernelBuffer&) override;
 
     void set_drive_geometry(u16, u16, u16);
 
     // ^BlockDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override;
 
 protected:
@@ -74,10 +74,10 @@ private:
     virtual const char* class_name() const override;
 
     bool wait_for_irq();
-    bool read_sectors_with_dma(u32 lba, u16 count, u8*);
-    bool write_sectors_with_dma(u32 lba, u16 count, const u8*);
-    bool read_sectors(u32 lba, u16 count, u8* buffer);
-    bool write_sectors(u32 lba, u16 count, const u8* data);
+    bool read_sectors_with_dma(u32 lba, u16 count, UserOrKernelBuffer&);
+    bool write_sectors_with_dma(u32 lba, u16 count, const UserOrKernelBuffer&);
+    bool read_sectors(u32 lba, u16 count, UserOrKernelBuffer& buffer);
+    bool write_sectors(u32 lba, u16 count, const UserOrKernelBuffer& data);
     bool is_slave() const;
 
     Lock m_lock { "IDEDiskDevice" };

--- a/Kernel/Devices/PS2MouseDevice.cpp
+++ b/Kernel/Devices/PS2MouseDevice.cpp
@@ -336,7 +336,7 @@ bool PS2MouseDevice::can_read(const FileDescription&, size_t) const
     return !m_queue.is_empty();
 }
 
-KResultOr<size_t> PS2MouseDevice::read(FileDescription&, size_t, u8* buffer, size_t size)
+KResultOr<size_t> PS2MouseDevice::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
 {
     ASSERT(size > 0);
     size_t nread = 0;
@@ -349,14 +349,15 @@ KResultOr<size_t> PS2MouseDevice::read(FileDescription&, size_t, u8* buffer, siz
         dbg() << "PS2 Mouse Read: Filter packets";
 #endif
         size_t bytes_read_from_packet = min(remaining_space_in_buffer, sizeof(MousePacket));
-        memcpy(buffer + nread, &packet, bytes_read_from_packet);
+        if (!buffer.write(&packet, nread, bytes_read_from_packet))
+            return KResult(-EFAULT);
         nread += bytes_read_from_packet;
         remaining_space_in_buffer -= bytes_read_from_packet;
     }
     return nread;
 }
 
-KResultOr<size_t> PS2MouseDevice::write(FileDescription&, size_t, const u8*, size_t)
+KResultOr<size_t> PS2MouseDevice::write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t)
 {
     return 0;
 }

--- a/Kernel/Devices/PS2MouseDevice.h
+++ b/Kernel/Devices/PS2MouseDevice.h
@@ -45,8 +45,8 @@ public:
 
     // ^CharacterDevice
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 
     virtual const char* purpose() const override { return class_name(); }

--- a/Kernel/Devices/RandomDevice.h
+++ b/Kernel/Devices/RandomDevice.h
@@ -38,8 +38,8 @@ public:
 
 private:
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
     virtual const char* class_name() const override { return "RandomDevice"; }

--- a/Kernel/Devices/SB16.h
+++ b/Kernel/Devices/SB16.h
@@ -47,8 +47,8 @@ public:
 
     // ^CharacterDevice
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 
     virtual const char* purpose() const override { return class_name(); }

--- a/Kernel/Devices/SerialDevice.h
+++ b/Kernel/Devices/SerialDevice.h
@@ -43,9 +43,9 @@ public:
 
     // ^CharacterDevice
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
 
     enum InterruptEnable {
         LowPowerMode = 0x01 << 5,

--- a/Kernel/Devices/ZeroDevice.cpp
+++ b/Kernel/Devices/ZeroDevice.cpp
@@ -44,14 +44,15 @@ bool ZeroDevice::can_read(const FileDescription&, size_t) const
     return true;
 }
 
-KResultOr<size_t> ZeroDevice::read(FileDescription&, size_t, u8* buffer, size_t size)
+KResultOr<size_t> ZeroDevice::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
 {
     ssize_t count = min(static_cast<size_t>(PAGE_SIZE), size);
-    memset(buffer, 0, count);
+    if (!buffer.memset(0, count))
+        return KResult(-EFAULT);
     return count;
 }
 
-KResultOr<size_t> ZeroDevice::write(FileDescription&, size_t, const u8*, size_t size)
+KResultOr<size_t> ZeroDevice::write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t size)
 {
     return min(static_cast<size_t>(PAGE_SIZE), size);
 }

--- a/Kernel/Devices/ZeroDevice.h
+++ b/Kernel/Devices/ZeroDevice.h
@@ -38,8 +38,8 @@ public:
 
 private:
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
     virtual const char* class_name() const override { return "ZeroDevice"; }

--- a/Kernel/DoubleBuffer.cpp
+++ b/Kernel/DoubleBuffer.cpp
@@ -58,7 +58,7 @@ void DoubleBuffer::flip()
     compute_lockfree_metadata();
 }
 
-size_t DoubleBuffer::write(const u8* data, size_t size)
+ssize_t DoubleBuffer::write(const UserOrKernelBuffer& data, size_t size)
 {
     if (!size)
         return 0;
@@ -68,11 +68,12 @@ size_t DoubleBuffer::write(const u8* data, size_t size)
     u8* write_ptr = m_write_buffer->data + m_write_buffer->size;
     m_write_buffer->size += bytes_to_write;
     compute_lockfree_metadata();
-    memcpy(write_ptr, data, bytes_to_write);
-    return bytes_to_write;
+    if (!data.read(write_ptr, bytes_to_write))
+        return -EFAULT;
+    return (ssize_t)bytes_to_write;
 }
 
-size_t DoubleBuffer::read(u8* data, size_t size)
+ssize_t DoubleBuffer::read(UserOrKernelBuffer& data, size_t size)
 {
     if (!size)
         return 0;
@@ -83,10 +84,11 @@ size_t DoubleBuffer::read(u8* data, size_t size)
     if (m_read_buffer_index >= m_read_buffer->size)
         return 0;
     size_t nread = min(m_read_buffer->size - m_read_buffer_index, size);
-    memcpy(data, m_read_buffer->data + m_read_buffer_index, nread);
+    if (!data.write(m_read_buffer->data + m_read_buffer_index, nread))
+        return -EFAULT;
     m_read_buffer_index += nread;
     compute_lockfree_metadata();
-    return nread;
+    return (ssize_t)nread;
 }
 
 }

--- a/Kernel/DoubleBuffer.h
+++ b/Kernel/DoubleBuffer.h
@@ -29,6 +29,7 @@
 #include <AK/Types.h>
 #include <Kernel/KBuffer.h>
 #include <Kernel/Lock.h>
+#include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
 
@@ -36,8 +37,17 @@ class DoubleBuffer {
 public:
     explicit DoubleBuffer(size_t capacity = 65536);
 
-    size_t write(const u8*, size_t);
-    size_t read(u8*, size_t);
+    [[nodiscard]] ssize_t write(const UserOrKernelBuffer&, size_t);
+    [[nodiscard]] ssize_t write(const u8* data, size_t size)
+    {
+        return write(UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>(data)), size);
+    }
+    [[nodiscard]] ssize_t read(UserOrKernelBuffer&, size_t);
+    [[nodiscard]] ssize_t read(u8* data, size_t size)
+    {
+        auto buffer = UserOrKernelBuffer::for_kernel_buffer(data);
+        return read(buffer, size);
+    }
 
     bool is_empty() const { return m_empty; }
 

--- a/Kernel/FileSystem/BlockBasedFileSystem.h
+++ b/Kernel/FileSystem/BlockBasedFileSystem.h
@@ -42,17 +42,17 @@ public:
 protected:
     explicit BlockBasedFS(FileDescription&);
 
-    bool read_block(unsigned index, u8* buffer, size_t count, size_t offset = 0, bool allow_cache = true) const;
-    bool read_blocks(unsigned index, unsigned count, u8* buffer, bool allow_cache = true) const;
+    int read_block(unsigned index, UserOrKernelBuffer* buffer, size_t count, size_t offset = 0, bool allow_cache = true) const;
+    int read_blocks(unsigned index, unsigned count, UserOrKernelBuffer& buffer, bool allow_cache = true) const;
 
-    bool raw_read(unsigned index, u8* buffer);
-    bool raw_write(unsigned index, const u8* buffer);
+    bool raw_read(unsigned index, UserOrKernelBuffer& buffer);
+    bool raw_write(unsigned index, const UserOrKernelBuffer& buffer);
 
-    bool raw_read_blocks(unsigned index, size_t count, u8* buffer);
-    bool raw_write_blocks(unsigned index, size_t count, const u8* buffer);
+    bool raw_read_blocks(unsigned index, size_t count, UserOrKernelBuffer& buffer);
+    bool raw_write_blocks(unsigned index, size_t count, const UserOrKernelBuffer& buffer);
 
-    bool write_block(unsigned index, const u8* buffer, size_t count, size_t offset = 0, bool allow_cache = true);
-    bool write_blocks(unsigned index, unsigned count, const u8*, bool allow_cache = true);
+    int write_block(unsigned index, const UserOrKernelBuffer& buffer, size_t count, size_t offset = 0, bool allow_cache = true);
+    int write_blocks(unsigned index, unsigned count, const UserOrKernelBuffer&, bool allow_cache = true);
 
     size_t m_logical_block_size { 512 };
 

--- a/Kernel/FileSystem/DevPtsFS.cpp
+++ b/Kernel/FileSystem/DevPtsFS.cpp
@@ -120,12 +120,12 @@ DevPtsFSInode::~DevPtsFSInode()
 {
 }
 
-ssize_t DevPtsFSInode::read_bytes(off_t, ssize_t, u8*, FileDescription*) const
+ssize_t DevPtsFSInode::read_bytes(off_t, ssize_t, UserOrKernelBuffer&, FileDescription*) const
 {
     ASSERT_NOT_REACHED();
 }
 
-ssize_t DevPtsFSInode::write_bytes(off_t, ssize_t, const u8*, FileDescription*)
+ssize_t DevPtsFSInode::write_bytes(off_t, ssize_t, const UserOrKernelBuffer&, FileDescription*)
 {
     ASSERT_NOT_REACHED();
 }

--- a/Kernel/FileSystem/DevPtsFS.h
+++ b/Kernel/FileSystem/DevPtsFS.h
@@ -67,12 +67,12 @@ private:
     DevPtsFSInode(DevPtsFS&, unsigned index, SlavePTY*);
 
     // ^Inode
-    virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const override;
+    virtual ssize_t read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
-    virtual ssize_t write_bytes(off_t, ssize_t, const u8* buffer, FileDescription*) override;
+    virtual ssize_t write_bytes(off_t, ssize_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -58,12 +58,12 @@ public:
 
 private:
     // ^Inode
-    virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const override;
+    virtual ssize_t read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
-    virtual ssize_t write_bytes(off_t, ssize_t, const u8* data, FileDescription*) override;
+    virtual ssize_t write_bytes(off_t, ssize_t, const UserOrKernelBuffer& data, FileDescription*) override;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode& child, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;

--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -145,14 +145,14 @@ bool FIFO::can_write(const FileDescription&, size_t) const
     return m_buffer.space_for_writing() || !m_readers;
 }
 
-KResultOr<size_t> FIFO::read(FileDescription&, size_t, u8* buffer, size_t size)
+KResultOr<size_t> FIFO::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
 {
     if (!m_writers && m_buffer.is_empty())
         return 0;
     return m_buffer.read(buffer, size);
 }
 
-KResultOr<size_t> FIFO::write(FileDescription&, size_t, const u8* buffer, size_t size)
+KResultOr<size_t> FIFO::write(FileDescription&, size_t, const UserOrKernelBuffer& buffer, size_t size)
 {
     if (!m_readers) {
         Thread::current()->send_signal(SIGPIPE, Process::current());

--- a/Kernel/FileSystem/FIFO.h
+++ b/Kernel/FileSystem/FIFO.h
@@ -57,8 +57,8 @@ public:
 
 private:
     // ^File
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
     virtual KResult stat(::stat&) const override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -34,6 +34,7 @@
 #include <Kernel/Forward.h>
 #include <Kernel/KResult.h>
 #include <Kernel/UnixTypes.h>
+#include <Kernel/UserOrKernelBuffer.h>
 #include <Kernel/VirtualAddress.h>
 
 namespace Kernel {
@@ -77,8 +78,8 @@ public:
     virtual bool can_read(const FileDescription&, size_t) const = 0;
     virtual bool can_write(const FileDescription&, size_t) const = 0;
 
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) = 0;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) = 0;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) = 0;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) = 0;
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg);
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, VirtualAddress preferred_vaddr, size_t offset, size_t size, int prot, bool shared);
     virtual KResult stat(::stat&) const { return KResult(-EBADF); }

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -60,8 +60,8 @@ public:
     KResult close();
 
     off_t seek(off_t, int whence);
-    KResultOr<size_t> read(u8*, size_t);
-    KResultOr<size_t> write(const u8* data, size_t);
+    KResultOr<size_t> read(UserOrKernelBuffer&, size_t);
+    KResultOr<size_t> write(const UserOrKernelBuffer& data, size_t);
     KResult stat(::stat&);
 
     KResult chmod(mode_t);
@@ -69,7 +69,7 @@ public:
     bool can_read() const;
     bool can_write() const;
 
-    ssize_t get_dir_entries(u8* buffer, ssize_t);
+    ssize_t get_dir_entries(UserOrKernelBuffer& buffer, ssize_t);
 
     KResultOr<KBuffer> read_entire_file();
 

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -34,6 +34,7 @@
 #include <Kernel/KResult.h>
 #include <Kernel/Lock.h>
 #include <Kernel/UnixTypes.h>
+#include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
 

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -69,10 +69,10 @@ public:
 
     KResultOr<KBuffer> read_entire(FileDescription* = nullptr) const;
 
-    virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const = 0;
+    virtual ssize_t read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const = 0;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const = 0;
     virtual RefPtr<Inode> lookup(StringView name) = 0;
-    virtual ssize_t write_bytes(off_t, ssize_t, const u8* data, FileDescription*) = 0;
+    virtual ssize_t write_bytes(off_t, ssize_t, const UserOrKernelBuffer& data, FileDescription*) = 0;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) = 0;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) = 0;
     virtual KResult remove_child(const StringView& name) = 0;
@@ -122,7 +122,7 @@ public:
 protected:
     Inode(FS& fs, unsigned index);
     void set_metadata_dirty(bool);
-    void inode_contents_changed(off_t, ssize_t, const u8*);
+    void inode_contents_changed(off_t, ssize_t, const UserOrKernelBuffer&);
     void inode_size_changed(size_t old_size, size_t new_size);
     KResult prepare_to_write_data();
 

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -44,7 +44,7 @@ InodeFile::~InodeFile()
 {
 }
 
-KResultOr<size_t> InodeFile::read(FileDescription& description, size_t offset, u8* buffer, size_t count)
+KResultOr<size_t> InodeFile::read(FileDescription& description, size_t offset, UserOrKernelBuffer& buffer, size_t count)
 {
     ssize_t nread = m_inode->read_bytes(offset, count, buffer, &description);
     if (nread > 0)
@@ -54,7 +54,7 @@ KResultOr<size_t> InodeFile::read(FileDescription& description, size_t offset, u
     return nread;
 }
 
-KResultOr<size_t> InodeFile::write(FileDescription& description, size_t offset, const u8* data, size_t count)
+KResultOr<size_t> InodeFile::write(FileDescription& description, size_t offset, const UserOrKernelBuffer& data, size_t count)
 {
     ssize_t nwritten = m_inode->write_bytes(offset, count, data, &description);
     if (nwritten > 0) {

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -47,8 +47,8 @@ public:
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, VirtualAddress preferred_vaddr, size_t offset, size_t size, int prot, bool shared) override;
 
     virtual String absolute_path(const FileDescription&) const override;

--- a/Kernel/FileSystem/InodeWatcher.h
+++ b/Kernel/FileSystem/InodeWatcher.h
@@ -55,8 +55,8 @@ public:
 
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual String absolute_path(const FileDescription&) const override;
     virtual const char* class_name() const override { return "InodeWatcher"; };
 

--- a/Kernel/FileSystem/Plan9FileSystem.h
+++ b/Kernel/FileSystem/Plan9FileSystem.h
@@ -124,8 +124,8 @@ public:
     // ^Inode
     virtual InodeMetadata metadata() const override;
     virtual void flush_metadata() override;
-    virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const override;
-    virtual ssize_t write_bytes(off_t, ssize_t, const u8* data, FileDescription*) override;
+    virtual ssize_t read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
+    virtual ssize_t write_bytes(off_t, ssize_t, const UserOrKernelBuffer& data, FileDescription*) override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -976,21 +976,33 @@ static ByteBuffer read_sys_bool(InodeIdentifier inode_id)
     return buffer;
 }
 
-static ssize_t write_sys_bool(InodeIdentifier inode_id, const ByteBuffer& data)
+static ssize_t write_sys_bool(InodeIdentifier inode_id, const UserOrKernelBuffer& buffer, size_t size)
 {
     auto& variable = SysVariable::for_inode(inode_id);
     ASSERT(variable.type == SysVariable::Type::Boolean);
 
-    if (data.is_empty() || !(data[0] == '0' || data[0] == '1'))
-        return data.size();
+    char value = 0;
+    bool did_read = false;
+    ssize_t nread = buffer.read_buffered<1>(1, [&](const u8* data, size_t) {
+        if (did_read)
+            return 0;
+        value = (char)data[0];
+        did_read = true;
+        return 1;
+    });
+    if (nread < 0)
+        return nread;
+    ASSERT(nread == 0 || (nread == 1 && did_read));
+    if (nread == 0 || !(value == '0' || value == '1'))
+        return (ssize_t)size;
 
     auto* lockable_bool = reinterpret_cast<Lockable<bool>*>(variable.address);
     {
         LOCKER(lockable_bool->lock());
-        lockable_bool->resource() = data[0] == '1';
+        lockable_bool->resource() = value == '1';
     }
     variable.notify();
-    return data.size();
+    return (ssize_t)size;
 }
 
 static ByteBuffer read_sys_string(InodeIdentifier inode_id)
@@ -1003,18 +1015,22 @@ static ByteBuffer read_sys_string(InodeIdentifier inode_id)
     return lockable_string->resource().to_byte_buffer();
 }
 
-static ssize_t write_sys_string(InodeIdentifier inode_id, const ByteBuffer& data)
+static ssize_t write_sys_string(InodeIdentifier inode_id, const UserOrKernelBuffer& buffer, size_t size)
 {
     auto& variable = SysVariable::for_inode(inode_id);
     ASSERT(variable.type == SysVariable::Type::String);
 
+    auto string_copy = buffer.copy_into_string(size);
+    if (string_copy.is_null())
+        return -EFAULT;
+
     {
         auto* lockable_string = reinterpret_cast<Lockable<String>*>(variable.address);
         LOCKER(lockable_string->lock());
-        lockable_string->resource() = String((const char*)data.data(), data.size());
+        lockable_string->resource() = move(string_copy);
     }
     variable.notify();
-    return data.size();
+    return (ssize_t)size;
 }
 
 void ProcFS::add_sys_bool(String&& name, Lockable<bool>& var, Function<void()>&& notify_callback)
@@ -1180,13 +1196,13 @@ InodeMetadata ProcFSInode::metadata() const
     return metadata;
 }
 
-ssize_t ProcFSInode::read_bytes(off_t offset, ssize_t count, u8* buffer, FileDescription* description) const
+ssize_t ProcFSInode::read_bytes(off_t offset, ssize_t count, UserOrKernelBuffer& buffer, FileDescription* description) const
 {
 #ifdef PROCFS_DEBUG
     dbg() << "ProcFS: read_bytes " << index();
 #endif
     ASSERT(offset >= 0);
-    ASSERT(buffer);
+    ASSERT(buffer.user_or_kernel_ptr());
 
     auto* directory_entry = fs().get_directory_entry(identifier());
 
@@ -1240,7 +1256,8 @@ ssize_t ProcFSInode::read_bytes(off_t offset, ssize_t count, u8* buffer, FileDes
         return 0;
 
     ssize_t nread = min(static_cast<off_t>(data.value().size() - offset), static_cast<off_t>(count));
-    memcpy(buffer, data.value().data() + offset, nread);
+    if (!buffer.write(data.value().data() + offset, nread))
+        return -EFAULT;
     if (nread == 0 && description && description->generator_cache().has_value())
         description->generator_cache().clear();
 
@@ -1461,7 +1478,7 @@ void ProcFSInode::flush_metadata()
 {
 }
 
-ssize_t ProcFSInode::write_bytes(off_t offset, ssize_t size, const u8* buffer, FileDescription*)
+ssize_t ProcFSInode::write_bytes(off_t offset, ssize_t size, const UserOrKernelBuffer& buffer, FileDescription*)
 {
     auto result = prepare_to_write_data();
     if (result.is_error())
@@ -1469,8 +1486,8 @@ ssize_t ProcFSInode::write_bytes(off_t offset, ssize_t size, const u8* buffer, F
 
     auto* directory_entry = fs().get_directory_entry(identifier());
 
-    Function<ssize_t(InodeIdentifier, const ByteBuffer&)> callback_tmp;
-    Function<ssize_t(InodeIdentifier, const ByteBuffer&)>* write_callback { nullptr };
+    Function<ssize_t(InodeIdentifier, const UserOrKernelBuffer&, size_t)> callback_tmp;
+    Function<ssize_t(InodeIdentifier, const UserOrKernelBuffer&, size_t)>* write_callback { nullptr };
 
     if (directory_entry == nullptr) {
         if (to_proc_parent_directory(identifier()) == PDI_Root_sys) {
@@ -1496,9 +1513,10 @@ ssize_t ProcFSInode::write_bytes(off_t offset, ssize_t size, const u8* buffer, F
     ASSERT(is_persistent_inode(identifier()));
     // FIXME: Being able to write into ProcFS at a non-zero offset seems like something we should maybe support..
     ASSERT(offset == 0);
-    bool success = (*write_callback)(identifier(), ByteBuffer::wrap(const_cast<u8*>(buffer), size));
-    ASSERT(success);
-    return 0;
+    ssize_t nwritten = (*write_callback)(identifier(), buffer, (size_t)size);
+    if (nwritten < 0)
+        klog() << "ProcFS: Writing " << size << " bytes failed: " << nwritten;
+    return nwritten;
 }
 
 KResultOr<NonnullRefPtr<Custody>> ProcFSInode::resolve_as_link(Custody& base, RefPtr<Custody>* out_parent, int options, int symlink_recursion_level) const

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -59,7 +59,7 @@ private:
 
     struct ProcFSDirectoryEntry {
         ProcFSDirectoryEntry() { }
-        ProcFSDirectoryEntry(const char* a_name, unsigned a_proc_file_type, bool a_supervisor_only, Function<Optional<KBuffer>(InodeIdentifier)>&& a_read_callback = nullptr, Function<ssize_t(InodeIdentifier, const ByteBuffer&)>&& a_write_callback = nullptr, RefPtr<ProcFSInode>&& a_inode = nullptr)
+        ProcFSDirectoryEntry(const char* a_name, unsigned a_proc_file_type, bool a_supervisor_only, Function<Optional<KBuffer>(InodeIdentifier)>&& a_read_callback = nullptr, Function<ssize_t(InodeIdentifier, const UserOrKernelBuffer&, size_t)>&& a_write_callback = nullptr, RefPtr<ProcFSInode>&& a_inode = nullptr)
             : name(a_name)
             , proc_file_type(a_proc_file_type)
             , supervisor_only(a_supervisor_only)
@@ -73,7 +73,7 @@ private:
         unsigned proc_file_type { 0 };
         bool supervisor_only { false };
         Function<Optional<KBuffer>(InodeIdentifier)> read_callback;
-        Function<ssize_t(InodeIdentifier, const ByteBuffer&)> write_callback;
+        Function<ssize_t(InodeIdentifier, const UserOrKernelBuffer&, size_t)> write_callback;
         RefPtr<ProcFSInode> inode;
         InodeIdentifier identifier(unsigned fsid) const;
     };
@@ -96,12 +96,12 @@ public:
 
 private:
     // ^Inode
-    virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const override;
+    virtual ssize_t read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
-    virtual ssize_t write_bytes(off_t, ssize_t, const u8* buffer, FileDescription*) override;
+    virtual ssize_t write_bytes(off_t, ssize_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;
@@ -123,12 +123,12 @@ public:
 
 private:
     // ^Inode
-    virtual ssize_t read_bytes(off_t, ssize_t, u8*, FileDescription*) const override { ASSERT_NOT_REACHED(); }
+    virtual ssize_t read_bytes(off_t, ssize_t, UserOrKernelBuffer&, FileDescription*) const override { ASSERT_NOT_REACHED(); }
     virtual InodeMetadata metadata() const override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override { ASSERT_NOT_REACHED(); }
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override {};
-    virtual ssize_t write_bytes(off_t, ssize_t, const u8*, FileDescription*) override { ASSERT_NOT_REACHED(); }
+    virtual ssize_t write_bytes(off_t, ssize_t, const UserOrKernelBuffer&, FileDescription*) override { ASSERT_NOT_REACHED(); }
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;

--- a/Kernel/FileSystem/TmpFS.h
+++ b/Kernel/FileSystem/TmpFS.h
@@ -74,12 +74,12 @@ public:
     const TmpFS& fs() const { return static_cast<const TmpFS&>(Inode::fs()); }
 
     // ^Inode
-    virtual ssize_t read_bytes(off_t, ssize_t, u8* buffer, FileDescription*) const override;
+    virtual ssize_t read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const override;
     virtual InodeMetadata metadata() const override;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const override;
     virtual RefPtr<Inode> lookup(StringView name) override;
     virtual void flush_metadata() override;
-    virtual ssize_t write_bytes(off_t, ssize_t, const u8* buffer, FileDescription*) override;
+    virtual ssize_t write_bytes(off_t, ssize_t, const UserOrKernelBuffer& buffer, FileDescription*) override;
     virtual KResultOr<NonnullRefPtr<Inode>> create_child(const String& name, mode_t, dev_t, uid_t, gid_t) override;
     virtual KResult add_child(Inode&, const StringView& name, mode_t) override;
     virtual KResult remove_child(const StringView& name) override;

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -707,7 +707,8 @@ KResult VFS::symlink(StringView target, StringView linkpath, Custody& base)
     if (inode_or_error.is_error())
         return inode_or_error.error();
     auto& inode = inode_or_error.value();
-    ssize_t nwritten = inode->write_bytes(0, target.length(), (const u8*)target.characters_without_null_termination(), nullptr);
+    auto target_buffer = UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>((const u8*)target.characters_without_null_termination()));
+    ssize_t nwritten = inode->write_bytes(0, target.length(), target_buffer, nullptr);
     if (nwritten < 0)
         return KResult(nwritten);
     return KSuccess;

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -68,6 +68,7 @@ class TCPSocket;
 class TTY;
 class Thread;
 class UDPSocket;
+class UserOrKernelBuffer;
 class VFS;
 class VMObject;
 class WaitQueue;

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -50,7 +50,7 @@ public:
 
     virtual KResult close() override;
     virtual KResult bind(Userspace<const sockaddr*>, socklen_t) override;
-    virtual KResult connect(FileDescription&, const sockaddr*, socklen_t, ShouldBlock = ShouldBlock::Yes) override;
+    virtual KResult connect(FileDescription&, Userspace<const sockaddr*>, socklen_t, ShouldBlock = ShouldBlock::Yes) override;
     virtual KResult listen(size_t) override;
     virtual void get_local_address(sockaddr*, socklen_t*) override;
     virtual void get_peer_address(sockaddr*, socklen_t*) override;
@@ -58,8 +58,8 @@ public:
     virtual void detach(FileDescription&) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> sendto(FileDescription&, const void*, size_t, int, Userspace<const sockaddr*>, socklen_t) override;
-    virtual KResultOr<size_t> recvfrom(FileDescription&, void*, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>) override;
+    virtual KResultOr<size_t> sendto(FileDescription&, const UserOrKernelBuffer&, size_t, int, Userspace<const sockaddr*>, socklen_t) override;
+    virtual KResultOr<size_t> recvfrom(FileDescription&, UserOrKernelBuffer&, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>) override;
     virtual KResult setsockopt(int level, int option, Userspace<const void*>, socklen_t) override;
     virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>) override;
 
@@ -96,8 +96,8 @@ protected:
 
     virtual KResult protocol_bind() { return KSuccess; }
     virtual KResult protocol_listen() { return KSuccess; }
-    virtual KResultOr<size_t> protocol_receive(const KBuffer&, void*, size_t, int) { return -ENOTIMPL; }
-    virtual KResultOr<size_t> protocol_send(const void*, size_t) { return -ENOTIMPL; }
+    virtual KResultOr<size_t> protocol_receive(const KBuffer&, UserOrKernelBuffer&, size_t, int) { return -ENOTIMPL; }
+    virtual KResultOr<size_t> protocol_send(const UserOrKernelBuffer&, size_t) { return -ENOTIMPL; }
     virtual KResult protocol_connect(FileDescription&, ShouldBlock) { return KSuccess; }
     virtual int protocol_allocate_local_port() { return 0; }
     virtual bool protocol_is_disconnected() const { return false; }
@@ -110,8 +110,8 @@ protected:
 private:
     virtual bool is_ipv4() const override { return true; }
 
-    KResultOr<size_t> receive_byte_buffered(FileDescription&, void* buffer, size_t buffer_length, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>);
-    KResultOr<size_t> receive_packet_buffered(FileDescription&, void* buffer, size_t buffer_length, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>);
+    KResultOr<size_t> receive_byte_buffered(FileDescription&, UserOrKernelBuffer& buffer, size_t buffer_length, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>);
+    KResultOr<size_t> receive_packet_buffered(FileDescription&, UserOrKernelBuffer& buffer, size_t buffer_length, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>);
 
     IPv4Address m_local_address;
     IPv4Address m_peer_address;

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -52,7 +52,7 @@ public:
 
     // ^Socket
     virtual KResult bind(Userspace<const sockaddr*>, socklen_t) override;
-    virtual KResult connect(FileDescription&, const sockaddr*, socklen_t, ShouldBlock = ShouldBlock::Yes) override;
+    virtual KResult connect(FileDescription&, Userspace<const sockaddr*>, socklen_t, ShouldBlock = ShouldBlock::Yes) override;
     virtual KResult listen(size_t) override;
     virtual void get_local_address(sockaddr*, socklen_t*) override;
     virtual void get_peer_address(sockaddr*, socklen_t*) override;
@@ -60,8 +60,8 @@ public:
     virtual void detach(FileDescription&) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> sendto(FileDescription&, const void*, size_t, int, Userspace<const sockaddr*>, socklen_t) override;
-    virtual KResultOr<size_t> recvfrom(FileDescription&, void*, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>) override;
+    virtual KResultOr<size_t> sendto(FileDescription&, const UserOrKernelBuffer&, size_t, int, Userspace<const sockaddr*>, socklen_t) override;
+    virtual KResultOr<size_t> recvfrom(FileDescription&, UserOrKernelBuffer&, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>) override;
     virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>) override;
     virtual KResult chown(FileDescription&, uid_t, gid_t) override;
     virtual KResult chmod(FileDescription&, mode_t) override;

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -37,6 +37,7 @@
 #include <Kernel/Net/ARP.h>
 #include <Kernel/Net/ICMP.h>
 #include <Kernel/Net/IPv4.h>
+#include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
 
@@ -63,8 +64,8 @@ public:
     void set_ipv4_gateway(const IPv4Address&);
 
     void send(const MACAddress&, const ARPPacket&);
-    void send_ipv4(const MACAddress&, const IPv4Address&, IPv4Protocol, ReadonlyBytes payload, u8 ttl);
-    void send_ipv4_fragmented(const MACAddress&, const IPv4Address&, IPv4Protocol, ReadonlyBytes payload, u8 ttl);
+    int send_ipv4(const MACAddress&, const IPv4Address&, IPv4Protocol, const UserOrKernelBuffer& payload, size_t payload_size, u8 ttl);
+    int send_ipv4_fragmented(const MACAddress&, const IPv4Address&, IPv4Protocol, const UserOrKernelBuffer& payload, size_t payload_size, u8 ttl);
 
     size_t dequeue_packet(u8* buffer, size_t buffer_size);
 

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -99,7 +99,7 @@ public:
     KResult shutdown(int how);
 
     virtual KResult bind(Userspace<const sockaddr*>, socklen_t) = 0;
-    virtual KResult connect(FileDescription&, const sockaddr*, socklen_t, ShouldBlock) = 0;
+    virtual KResult connect(FileDescription&, Userspace<const sockaddr*>, socklen_t, ShouldBlock) = 0;
     virtual KResult listen(size_t) = 0;
     virtual void get_local_address(sockaddr*, socklen_t*) = 0;
     virtual void get_peer_address(sockaddr*, socklen_t*) = 0;
@@ -107,8 +107,8 @@ public:
     virtual bool is_ipv4() const { return false; }
     virtual void attach(FileDescription&) = 0;
     virtual void detach(FileDescription&) = 0;
-    virtual KResultOr<size_t> sendto(FileDescription&, const void*, size_t, int flags, Userspace<const sockaddr*>, socklen_t) = 0;
-    virtual KResultOr<size_t> recvfrom(FileDescription&, void*, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>) = 0;
+    virtual KResultOr<size_t> sendto(FileDescription&, const UserOrKernelBuffer&, size_t, int flags, Userspace<const sockaddr*>, socklen_t) = 0;
+    virtual KResultOr<size_t> recvfrom(FileDescription&, UserOrKernelBuffer&, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>) = 0;
 
     virtual KResult setsockopt(int level, int option, Userspace<const void*>, socklen_t);
     virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>);
@@ -124,8 +124,8 @@ public:
     Lock& lock() { return m_lock; }
 
     // ^File
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override final;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override final;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override final;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override final;
     virtual KResult stat(::stat&) const override;
     virtual String absolute_path(const FileDescription&) const override = 0;
 

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -161,7 +161,7 @@ NonnullRefPtr<TCPSocket> TCPSocket::create(int protocol)
     return adopt(*new TCPSocket(protocol));
 }
 
-KResultOr<size_t> TCPSocket::protocol_receive(const KBuffer& packet_buffer, void* buffer, size_t buffer_size, int flags)
+KResultOr<size_t> TCPSocket::protocol_receive(const KBuffer& packet_buffer, UserOrKernelBuffer& buffer, size_t buffer_size, int flags)
 {
     (void)flags;
     auto& ipv4_packet = *(const IPv4Packet*)(packet_buffer.data());
@@ -171,17 +171,20 @@ KResultOr<size_t> TCPSocket::protocol_receive(const KBuffer& packet_buffer, void
     klog() << "payload_size " << payload_size << ", will it fit in " << buffer_size << "?";
 #endif
     ASSERT(buffer_size >= payload_size);
-    memcpy(buffer, tcp_packet.payload(), payload_size);
+    if (!buffer.write(tcp_packet.payload(), payload_size))
+        return KResult(-EFAULT);
     return payload_size;
 }
 
-KResultOr<size_t> TCPSocket::protocol_send(const void* data, size_t data_length)
+KResultOr<size_t> TCPSocket::protocol_send(const UserOrKernelBuffer& data, size_t data_length)
 {
-    send_tcp_packet(TCPFlags::PUSH | TCPFlags::ACK, data, data_length);
+    int err = send_tcp_packet(TCPFlags::PUSH | TCPFlags::ACK, &data, data_length);
+    if (err < 0)
+        return KResult(err);
     return data_length;
 }
 
-void TCPSocket::send_tcp_packet(u16 flags, const void* payload, size_t payload_size)
+int TCPSocket::send_tcp_packet(u16 flags, const UserOrKernelBuffer* payload, size_t payload_size)
 {
     auto buffer = ByteBuffer::create_zeroed(sizeof(TCPPacket) + payload_size);
     auto& tcp_packet = *(TCPPacket*)(buffer.data());
@@ -196,31 +199,37 @@ void TCPSocket::send_tcp_packet(u16 flags, const void* payload, size_t payload_s
     if (flags & TCPFlags::ACK)
         tcp_packet.set_ack_number(m_ack_number);
 
+    if (payload && !payload->read(tcp_packet.payload(), payload_size))
+        return -EFAULT;
+
     if (flags & TCPFlags::SYN) {
         ++m_sequence_number;
     } else {
         m_sequence_number += payload_size;
     }
 
-    memcpy(tcp_packet.payload(), payload, payload_size);
     tcp_packet.set_checksum(compute_tcp_checksum(local_address(), peer_address(), tcp_packet, payload_size));
 
     if (tcp_packet.has_syn() || payload_size > 0) {
         LOCKER(m_not_acked_lock);
         m_not_acked.append({ m_sequence_number, move(buffer) });
         send_outgoing_packets();
-        return;
+        return 0;
     }
 
     auto routing_decision = route_to(peer_address(), local_address(), bound_interface());
     ASSERT(!routing_decision.is_zero());
 
-    routing_decision.adapter->send_ipv4(
+    auto packet_buffer = UserOrKernelBuffer::for_kernel_buffer(buffer.data());
+    int err = routing_decision.adapter->send_ipv4(
         routing_decision.next_hop, peer_address(), IPv4Protocol::TCP,
-        buffer, ttl());
+        packet_buffer, buffer.size(), ttl());
+    if (err < 0)
+        return err;
 
     m_packets_out++;
     m_bytes_out += buffer.size();
+    return 0;
 }
 
 void TCPSocket::send_outgoing_packets()
@@ -243,12 +252,17 @@ void TCPSocket::send_outgoing_packets()
         auto& tcp_packet = *(TCPPacket*)(packet.buffer.data());
         klog() << "sending tcp packet from " << local_address().to_string().characters() << ":" << local_port() << " to " << peer_address().to_string().characters() << ":" << peer_port() << " with (" << (tcp_packet.has_syn() ? "SYN " : "") << (tcp_packet.has_ack() ? "ACK " : "") << (tcp_packet.has_fin() ? "FIN " : "") << (tcp_packet.has_rst() ? "RST " : "") << ") seq_no=" << tcp_packet.sequence_number() << ", ack_no=" << tcp_packet.ack_number() << ", tx_counter=" << packet.tx_counter;
 #endif
-        routing_decision.adapter->send_ipv4(
+        auto packet_buffer = UserOrKernelBuffer::for_kernel_buffer(packet.buffer.data());
+        int err = routing_decision.adapter->send_ipv4(
             routing_decision.next_hop, peer_address(), IPv4Protocol::TCP,
-            packet.buffer, ttl());
-
-        m_packets_out++;
-        m_bytes_out += packet.buffer.size();
+            packet_buffer, packet.buffer.size(), ttl());
+        if (err < 0) {
+            auto& tcp_packet = *(TCPPacket*)(packet.buffer.data());
+            klog() << "Error (" << err << ") sending tcp packet from " << local_address().to_string().characters() << ":" << local_port() << " to " << peer_address().to_string().characters() << ":" << peer_port() << " with (" << (tcp_packet.has_syn() ? "SYN " : "") << (tcp_packet.has_ack() ? "ACK " : "") << (tcp_packet.has_fin() ? "FIN " : "") << (tcp_packet.has_rst() ? "RST " : "") << ") seq_no=" << tcp_packet.sequence_number() << ", ack_no=" << tcp_packet.ack_number() << ", tx_counter=" << packet.tx_counter;
+        } else {
+            m_packets_out++;
+            m_bytes_out += packet.buffer.size();
+        }
     }
 }
 
@@ -366,7 +380,9 @@ KResult TCPSocket::protocol_connect(FileDescription& description, ShouldBlock sh
     m_ack_number = 0;
 
     set_setup_state(SetupState::InProgress);
-    send_tcp_packet(TCPFlags::SYN);
+    int err = send_tcp_packet(TCPFlags::SYN);
+    if (err < 0)
+        return KResult(err);
     m_state = State::SynSent;
     m_role = Role::Connecting;
     m_direction = Direction::Outgoing;
@@ -433,7 +449,7 @@ void TCPSocket::shut_down_for_writing()
 #ifdef TCP_SOCKET_DEBUG
         dbg() << " Sending FIN/ACK from Established and moving into FinWait1";
 #endif
-        send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);
+        (void)send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);
         set_state(State::FinWait1);
     } else {
         dbg() << " Shutting down TCPSocket for writing but not moving to FinWait1 since state is " << to_string(state());
@@ -447,7 +463,7 @@ KResult TCPSocket::close()
 #ifdef TCP_SOCKET_DEBUG
         dbg() << " Sending FIN from CloseWait and moving into LastAck";
 #endif
-        send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);
+        (void)send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);
         set_state(State::LastAck);
     }
 

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -148,7 +148,7 @@ public:
     u32 packets_out() const { return m_packets_out; }
     u32 bytes_out() const { return m_bytes_out; }
 
-    void send_tcp_packet(u16 flags, const void* = nullptr, size_t = 0);
+    [[nodiscard]] int send_tcp_packet(u16 flags, const UserOrKernelBuffer* = nullptr, size_t = 0);
     void send_outgoing_packets();
     void receive_tcp_packet(const TCPPacket&, u16 size);
 
@@ -177,8 +177,8 @@ private:
 
     virtual void shut_down_for_writing() override;
 
-    virtual KResultOr<size_t> protocol_receive(const KBuffer&, void* buffer, size_t buffer_size, int flags) override;
-    virtual KResultOr<size_t> protocol_send(const void*, size_t) override;
+    virtual KResultOr<size_t> protocol_receive(const KBuffer&, UserOrKernelBuffer& buffer, size_t buffer_size, int flags) override;
+    virtual KResultOr<size_t> protocol_send(const UserOrKernelBuffer&, size_t) override;
     virtual KResult protocol_connect(FileDescription&, ShouldBlock) override;
     virtual int protocol_allocate_local_port() override;
     virtual bool protocol_is_disconnected() const override;

--- a/Kernel/Net/UDPSocket.h
+++ b/Kernel/Net/UDPSocket.h
@@ -43,8 +43,8 @@ private:
     virtual const char* class_name() const override { return "UDPSocket"; }
     static Lockable<HashMap<u16, UDPSocket*>>& sockets_by_port();
 
-    virtual KResultOr<size_t> protocol_receive(const KBuffer&, void* buffer, size_t buffer_size, int flags) override;
-    virtual KResultOr<size_t> protocol_send(const void*, size_t) override;
+    virtual KResultOr<size_t> protocol_receive(const KBuffer&, UserOrKernelBuffer& buffer, size_t buffer_size, int flags) override;
+    virtual KResultOr<size_t> protocol_send(const UserOrKernelBuffer&, size_t) override;
     virtual KResult protocol_connect(FileDescription&, ShouldBlock) override;
     virtual int protocol_allocate_local_port() override;
     virtual KResult protocol_bind() override;

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -651,7 +651,7 @@ void Scheduler::initialize()
     ASSERT(s_colonel_process);
     ASSERT(idle_thread);
     idle_thread->set_priority(THREAD_PRIORITY_MIN);
-    idle_thread->set_name("idle thread #0");
+    idle_thread->set_name(StringView("idle thread #0"));
 
     set_idle_thread(idle_thread);
 }

--- a/Kernel/StdLib.cpp
+++ b/Kernel/StdLib.cpp
@@ -35,27 +35,68 @@
 
 String copy_string_from_user(const char* user_str, size_t user_str_size)
 {
+    bool is_user = Kernel::is_user_range(VirtualAddress(user_str), user_str_size);
+    ASSERT(is_user); // For now assert to catch bugs, but technically not an error
+    if (!is_user)
+        return {};
     Kernel::SmapDisabler disabler;
-    size_t length = strnlen(user_str, user_str_size);
-    return String(user_str, length);
+    void* fault_at;
+    ssize_t length = Kernel::safe_strnlen(user_str, user_str_size, fault_at);
+    if (length < 0) {
+        klog() << "copy_string_from_user(" << user_str << ", " << user_str_size << ") failed at " << VirtualAddress(fault_at) << " (strnlen)";
+        return {};
+    }
+    if (length == 0)
+        return String::empty();
+
+    char* buffer;
+    auto copied_string = StringImpl::create_uninitialized((size_t)length, buffer);
+    if (!Kernel::safe_memcpy(buffer, user_str, (size_t)length, fault_at)) {
+        klog() << "copy_string_from_user(" << user_str << ", " << user_str_size << ") failed at " << VirtualAddress(fault_at) << " (memcpy)";
+        return {};
+    }
+    return copied_string;
+}
+
+String copy_string_from_user(Userspace<const char*> user_str, size_t user_str_size)
+{
+    return copy_string_from_user(user_str.unsafe_userspace_ptr(), user_str_size);
 }
 
 extern "C" {
 
-void copy_to_user(void* dest_ptr, const void* src_ptr, size_t n)
+bool copy_to_user(void* dest_ptr, const void* src_ptr, size_t n)
 {
-    ASSERT(Kernel::is_user_range(VirtualAddress(dest_ptr), n));
+    bool is_user = Kernel::is_user_range(VirtualAddress(dest_ptr), n);
+    ASSERT(is_user); // For now assert to catch bugs, but technically not an error
+    if (!is_user)
+        return false;
     ASSERT(!Kernel::is_user_range(VirtualAddress(src_ptr), n));
     Kernel::SmapDisabler disabler;
-    memcpy(dest_ptr, src_ptr, n);
+    void* fault_at;
+    if (!Kernel::safe_memcpy(dest_ptr, src_ptr, n, fault_at)) {
+        ASSERT(VirtualAddress(fault_at) >= VirtualAddress(dest_ptr) && VirtualAddress(fault_at) <= VirtualAddress((FlatPtr)dest_ptr + n));
+        klog() << "copy_to_user(" << dest_ptr << ", " << src_ptr << ", " << n << ") failed at " << VirtualAddress(fault_at);
+        return false;
+    }
+    return true;
 }
 
-void copy_from_user(void* dest_ptr, const void* src_ptr, size_t n)
+bool copy_from_user(void* dest_ptr, const void* src_ptr, size_t n)
 {
-    ASSERT(Kernel::is_user_range(VirtualAddress(src_ptr), n));
+    bool is_user = Kernel::is_user_range(VirtualAddress(src_ptr), n);
+    ASSERT(is_user); // For now assert to catch bugs, but technically not an error
+    if (!is_user)
+        return false;
     ASSERT(!Kernel::is_user_range(VirtualAddress(dest_ptr), n));
     Kernel::SmapDisabler disabler;
-    memcpy(dest_ptr, src_ptr, n);
+    void* fault_at;
+    if (!Kernel::safe_memcpy(dest_ptr, src_ptr, n, fault_at)) {
+        ASSERT(VirtualAddress(fault_at) >= VirtualAddress(src_ptr) && VirtualAddress(fault_at) <= VirtualAddress((FlatPtr)src_ptr + n));
+        klog() << "copy_from_user(" << dest_ptr << ", " << src_ptr << ", " << n << ") failed at " << VirtualAddress(fault_at);
+        return false;
+    }
+    return true;
 }
 
 void* memcpy(void* dest_ptr, const void* src_ptr, size_t n)
@@ -97,11 +138,19 @@ const void* memmem(const void* haystack, size_t haystack_length, const void* nee
     return AK::memmem(haystack, haystack_length, needle, needle_length);
 }
 
-void memset_user(void* dest_ptr, int c, size_t n)
+[[nodiscard]] bool memset_user(void* dest_ptr, int c, size_t n)
 {
-    ASSERT(Kernel::is_user_range(VirtualAddress(dest_ptr), n));
+    bool is_user = Kernel::is_user_range(VirtualAddress(dest_ptr), n);
+    ASSERT(is_user); // For now assert to catch bugs, but technically not an error
+    if (!is_user)
+        return false;
     Kernel::SmapDisabler disabler;
-    memset(dest_ptr, c, n);
+    void* fault_at;
+    if (!Kernel::safe_memset(dest_ptr, c, n, fault_at)) {
+        klog() << "memset(" << dest_ptr << ", " << n << ") failed at " << VirtualAddress(fault_at);
+        return false;
+    }
+    return true;
 }
 
 void* memset(void* dest_ptr, int c, size_t n)

--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Checked.h>
 #include <AK/Forward.h>
 #include <AK/Userspace.h>
 
@@ -34,12 +35,13 @@ struct StringArgument;
 }
 
 String copy_string_from_user(const char*, size_t);
+String copy_string_from_user(Userspace<const char*>, size_t);
 
 extern "C" {
 
-void copy_to_user(void*, const void*, size_t);
-void copy_from_user(void*, const void*, size_t);
-void memset_user(void*, int, size_t);
+[[nodiscard]] bool copy_to_user(void*, const void*, size_t);
+[[nodiscard]] bool copy_from_user(void*, const void*, size_t);
+[[nodiscard]] bool memset_user(void*, int, size_t);
 
 void* memcpy(void*, const void*, size_t);
 int strncmp(const char* s1, const char* s2, size_t n);
@@ -57,37 +59,77 @@ inline u16 htons(u16 w) { return (w & 0xff) << 8 | ((w >> 8) & 0xff); }
 }
 
 template<typename T>
-inline void copy_from_user(T* dest, const T* src)
+[[nodiscard]] inline bool copy_from_user(T* dest, const T* src)
 {
-    copy_from_user(dest, src, sizeof(T));
+    return copy_from_user(dest, src, sizeof(T));
 }
 
 template<typename T>
-inline void copy_to_user(T* dest, const T* src)
+[[nodiscard]] inline bool copy_to_user(T* dest, const T* src)
 {
-    copy_to_user(dest, src, sizeof(T));
+    return copy_to_user(dest, src, sizeof(T));
 }
 
 template<typename T>
-inline void copy_from_user(T* dest, Userspace<const T*> src)
+[[nodiscard]] inline bool copy_from_user(T* dest, Userspace<const T*> src)
 {
-    copy_from_user(dest, src.unsafe_userspace_ptr(), sizeof(T));
+    return copy_from_user(dest, src.unsafe_userspace_ptr(), sizeof(T));
 }
 
 template<typename T>
-inline void copy_to_user(Userspace<T*> dest, const T* src)
+[[nodiscard]] inline bool copy_to_user(Userspace<T*> dest, const T* src)
 {
-    copy_to_user(dest.unsafe_userspace_ptr(), src, sizeof(T));
+    return copy_to_user(dest.unsafe_userspace_ptr(), src, sizeof(T));
 }
 
 template<typename T>
-inline void copy_to_user(Userspace<T*> dest, const void* src, size_t size)
+[[nodiscard]] inline bool copy_to_user(Userspace<T*> dest, const void* src, size_t size)
 {
-    copy_to_user(dest.unsafe_userspace_ptr(), src, size);
+    return copy_to_user(dest.unsafe_userspace_ptr(), src, size);
 }
 
 template<typename T>
-inline void copy_from_user(void* dest, Userspace<const T*> src, size_t size)
+[[nodiscard]] inline bool copy_from_user(void* dest, Userspace<const T*> src, size_t size)
 {
-    copy_from_user(dest, src.unsafe_userspace_ptr(), size);
+    return copy_from_user(dest, src.unsafe_userspace_ptr(), size);
+}
+
+template<typename T>
+[[nodiscard]] inline bool copy_n_from_user(T* dest, const T* src, size_t count)
+{
+    Checked size = sizeof(T);
+    size *= count;
+    if (size.has_overflow())
+        return false;
+    return copy_from_user(dest, src, sizeof(T) * count);
+}
+
+template<typename T>
+[[nodiscard]] inline bool copy_n_to_user(T* dest, const T* src, size_t count)
+{
+    Checked size = sizeof(T);
+    size *= count;
+    if (size.has_overflow())
+        return false;
+    return copy_to_user(dest, src, sizeof(T) * count);
+}
+
+template<typename T>
+[[nodiscard]] inline bool copy_n_from_user(T* dest, Userspace<const T*> src, size_t count)
+{
+    Checked size = sizeof(T);
+    size *= count;
+    if (size.has_overflow())
+        return false;
+    return copy_from_user(dest, src.unsafe_userspace_ptr(), sizeof(T) * count);
+}
+
+template<typename T>
+[[nodiscard]] inline bool copy_n_to_user(Userspace<T*> dest, const T* src, size_t count)
+{
+    Checked size = sizeof(T);
+    size *= count;
+    if (size.has_overflow())
+        return false;
+    return copy_to_user(dest.unsafe_userspace_ptr(), src, sizeof(T) * count);
 }

--- a/Kernel/Syscalls/chdir.cpp
+++ b/Kernel/Syscalls/chdir.cpp
@@ -66,12 +66,11 @@ int Process::sys$getcwd(Userspace<char*> buffer, ssize_t size)
     REQUIRE_PROMISE(rpath);
     if (size < 0)
         return -EINVAL;
-    if (!validate_write(buffer, size))
-        return -EFAULT;
     auto path = current_directory().absolute_path();
     if ((size_t)size < path.length() + 1)
         return -ERANGE;
-    copy_to_user(buffer, path.characters(), path.length() + 1);
+    if (!copy_to_user(buffer, path.characters(), path.length() + 1))
+        return -EFAULT;
     return 0;
 }
 

--- a/Kernel/Syscalls/chown.cpp
+++ b/Kernel/Syscalls/chown.cpp
@@ -42,7 +42,7 @@ int Process::sys$chown(Userspace<const Syscall::SC_chown_params*> user_params)
 {
     REQUIRE_PROMISE(chown);
     Syscall::SC_chown_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
+    if (!copy_from_user(&params, user_params))
         return -EFAULT;
     auto path = get_syscall_path_argument(params.path);
     if (path.is_error())

--- a/Kernel/Syscalls/get_dir_entries.cpp
+++ b/Kernel/Syscalls/get_dir_entries.cpp
@@ -34,12 +34,13 @@ ssize_t Process::sys$get_dir_entries(int fd, void* buffer, ssize_t size)
     REQUIRE_PROMISE(stdio);
     if (size < 0)
         return -EINVAL;
-    if (!validate_write(buffer, size))
-        return -EFAULT;
     auto description = file_description(fd);
     if (!description)
         return -EBADF;
-    return description->get_dir_entries((u8*)buffer, size);
+    auto user_buffer = UserOrKernelBuffer::for_user_buffer((u8*)buffer, size);
+    if (!user_buffer.has_value())
+        return -EFAULT;
+    return description->get_dir_entries(user_buffer.value(), size);
 }
 
 }

--- a/Kernel/Syscalls/getuid.cpp
+++ b/Kernel/Syscalls/getuid.cpp
@@ -55,22 +55,16 @@ gid_t Process::sys$getegid()
 int Process::sys$getresuid(Userspace<uid_t*> ruid, Userspace<uid_t*> euid, Userspace<uid_t*> suid)
 {
     REQUIRE_PROMISE(stdio);
-    if (!validate_write_typed(ruid) || !validate_write_typed(euid) || !validate_write_typed(suid))
+    if (!copy_to_user(ruid, &m_uid) || !copy_to_user(euid, &m_euid) || !copy_to_user(suid, &m_suid))
         return -EFAULT;
-    copy_to_user(ruid, &m_uid);
-    copy_to_user(euid, &m_euid);
-    copy_to_user(suid, &m_suid);
     return 0;
 }
 
 int Process::sys$getresgid(Userspace<gid_t*> rgid, Userspace<gid_t*> egid, Userspace<gid_t*> sgid)
 {
     REQUIRE_PROMISE(stdio);
-    if (!validate_write_typed(rgid) || !validate_write_typed(egid) || !validate_write_typed(sgid))
+    if (!copy_to_user(rgid, &m_gid) || !copy_to_user(egid, &m_egid) || !copy_to_user(sgid, &m_sgid))
         return -EFAULT;
-    copy_to_user(rgid, &m_gid);
-    copy_to_user(egid, &m_egid);
-    copy_to_user(sgid, &m_sgid);
     return 0;
 }
 
@@ -83,10 +77,9 @@ int Process::sys$getgroups(ssize_t count, Userspace<gid_t*> user_gids)
         return m_extra_gids.size();
     if (count != (int)m_extra_gids.size())
         return -EINVAL;
-    if (!validate_write_typed(user_gids, m_extra_gids.size()))
-        return -EFAULT;
 
-    copy_to_user(user_gids, m_extra_gids.data(), sizeof(gid_t) * count);
+    if (!copy_to_user(user_gids, m_extra_gids.data(), sizeof(gid_t) * count))
+        return -EFAULT;
     return 0;
 }
 

--- a/Kernel/Syscalls/link.cpp
+++ b/Kernel/Syscalls/link.cpp
@@ -34,11 +34,13 @@ int Process::sys$link(Userspace<const Syscall::SC_link_params*> user_params)
 {
     REQUIRE_PROMISE(cpath);
     Syscall::SC_link_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
+    if (!copy_from_user(&params, user_params))
         return -EFAULT;
-    auto old_path = validate_and_copy_string_from_user(params.old_path);
-    auto new_path = validate_and_copy_string_from_user(params.new_path);
-    if (old_path.is_null() || new_path.is_null())
+    auto old_path = copy_string_from_user(params.old_path);
+    if (old_path.is_null())
+        return -EFAULT;
+    auto new_path = copy_string_from_user(params.new_path);
+    if (new_path.is_null())
         return -EFAULT;
     return VFS::the().link(old_path, new_path, current_directory());
 }
@@ -47,7 +49,7 @@ int Process::sys$symlink(Userspace<const Syscall::SC_symlink_params*> user_param
 {
     REQUIRE_PROMISE(cpath);
     Syscall::SC_symlink_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
+    if (!copy_from_user(&params, user_params))
         return -EFAULT;
     auto target = get_syscall_path_argument(params.target);
     if (target.is_error())

--- a/Kernel/Syscalls/mknod.cpp
+++ b/Kernel/Syscalls/mknod.cpp
@@ -34,7 +34,7 @@ int Process::sys$mknod(Userspace<const Syscall::SC_mknod_params*> user_params)
 {
     REQUIRE_PROMISE(dpath);
     Syscall::SC_mknod_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
+    if (!copy_from_user(&params, user_params))
         return -EFAULT;
     if (!is_superuser() && !is_regular_file(params.mode) && !is_fifo(params.mode) && !is_socket(params.mode))
         return -EPERM;

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -81,7 +81,7 @@ void* Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> user_params)
     REQUIRE_PROMISE(stdio);
 
     Syscall::SC_mmap_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
+    if (!copy_from_user(&params, user_params))
         return (void*)-EFAULT;
 
     void* addr = (void*)params.addr;
@@ -102,7 +102,7 @@ void* Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> user_params)
     if (params.name.characters) {
         if (params.name.length > PATH_MAX)
             return (void*)-ENAMETOOLONG;
-        name = validate_and_copy_string_from_user(params.name);
+        name = copy_string_from_user(params.name);
         if (name.is_null())
             return (void*)-EFAULT;
     }
@@ -336,13 +336,13 @@ int Process::sys$set_mmap_name(Userspace<const Syscall::SC_set_mmap_name_params*
     REQUIRE_PROMISE(stdio);
 
     Syscall::SC_set_mmap_name_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
+    if (!copy_from_user(&params, user_params))
         return -EFAULT;
 
     if (params.name.length > PATH_MAX)
         return -ENAMETOOLONG;
 
-    auto name = validate_and_copy_string_from_user(params.name);
+    auto name = copy_string_from_user(params.name);
     if (name.is_null())
         return -EFAULT;
 
@@ -351,7 +351,7 @@ int Process::sys$set_mmap_name(Userspace<const Syscall::SC_set_mmap_name_params*
         return -EINVAL;
     if (!region->is_mmap())
         return -EPERM;
-    region->set_name(name);
+    region->set_name(move(name));
     return 0;
 }
 

--- a/Kernel/Syscalls/module.cpp
+++ b/Kernel/Syscalls/module.cpp
@@ -169,7 +169,7 @@ int Process::sys$module_unload(Userspace<const char*> user_name, size_t name_len
 
     REQUIRE_NO_PROMISES;
 
-    auto module_name = validate_and_copy_string_from_user(user_name, name_length);
+    auto module_name = copy_string_from_user(user_name, name_length);
     if (module_name.is_null())
         return -EFAULT;
 

--- a/Kernel/Syscalls/open.cpp
+++ b/Kernel/Syscalls/open.cpp
@@ -34,7 +34,7 @@ namespace Kernel {
 int Process::sys$open(Userspace<const Syscall::SC_open_params*> user_params)
 {
     Syscall::SC_open_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
+    if (!copy_from_user(&params, user_params))
         return -EFAULT;
 
     int dirfd = params.dirfd;

--- a/Kernel/Syscalls/pledge.cpp
+++ b/Kernel/Syscalls/pledge.cpp
@@ -32,7 +32,7 @@ namespace Kernel {
 int Process::sys$pledge(Userspace<const Syscall::SC_pledge_params*> user_params)
 {
     Syscall::SC_pledge_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
+    if (!copy_from_user(&params, user_params))
         return -EFAULT;
 
     if (params.promises.length > 1024 || params.execpromises.length > 1024)
@@ -40,14 +40,14 @@ int Process::sys$pledge(Userspace<const Syscall::SC_pledge_params*> user_params)
 
     String promises;
     if (params.promises.characters) {
-        promises = validate_and_copy_string_from_user(params.promises);
+        auto promises = copy_string_from_user(params.promises);
         if (promises.is_null())
             return -EFAULT;
     }
 
     String execpromises;
     if (params.execpromises.characters) {
-        execpromises = validate_and_copy_string_from_user(params.execpromises);
+        execpromises = copy_string_from_user(params.execpromises);
         if (execpromises.is_null())
             return -EFAULT;
     }

--- a/Kernel/Syscalls/process.cpp
+++ b/Kernel/Syscalls/process.cpp
@@ -58,13 +58,11 @@ int Process::sys$set_process_icon(int icon_id)
 int Process::sys$get_process_name(Userspace<char*> buffer, size_t buffer_size)
 {
     REQUIRE_PROMISE(stdio);
-    if (!validate_write(buffer, buffer_size))
-        return -EFAULT;
-
     if (m_name.length() + 1 > buffer_size)
         return -ENAMETOOLONG;
 
-    copy_to_user(buffer, m_name.characters(), m_name.length() + 1);
+    if (!copy_to_user(buffer, m_name.characters(), m_name.length() + 1))
+        return -EFAULT;
     return 0;
 }
 
@@ -73,7 +71,7 @@ int Process::sys$set_process_name(Userspace<const char*> user_name, size_t user_
     REQUIRE_PROMISE(proc);
     if (user_name_length > 256)
         return -ENAMETOOLONG;
-    auto name = validate_and_copy_string_from_user(user_name, user_name_length);
+    auto name = copy_string_from_user(user_name, user_name_length);
     if (name.is_null())
         return -EFAULT;
     m_name = move(name);

--- a/Kernel/Syscalls/realpath.cpp
+++ b/Kernel/Syscalls/realpath.cpp
@@ -36,10 +36,7 @@ int Process::sys$realpath(Userspace<const Syscall::SC_realpath_params*> user_par
     REQUIRE_PROMISE(rpath);
 
     Syscall::SC_realpath_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
-        return -EFAULT;
-
-    if (!validate_write(params.buffer.data, params.buffer.size))
+    if (!copy_from_user(&params, user_params))
         return -EFAULT;
 
     auto path = get_syscall_path_argument(params.path);
@@ -55,7 +52,8 @@ int Process::sys$realpath(Userspace<const Syscall::SC_realpath_params*> user_par
     if (absolute_path.length() + 1 > params.buffer.size)
         return -ENAMETOOLONG;
 
-    copy_to_user(params.buffer.data, absolute_path.characters(), absolute_path.length() + 1);
+    if (!copy_to_user(params.buffer.data, absolute_path.characters(), absolute_path.length() + 1))
+        return -EFAULT;
     return 0;
 };
 

--- a/Kernel/Syscalls/rename.cpp
+++ b/Kernel/Syscalls/rename.cpp
@@ -34,7 +34,7 @@ int Process::sys$rename(Userspace<const Syscall::SC_rename_params*> user_params)
 {
     REQUIRE_PROMISE(cpath);
     Syscall::SC_rename_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
+    if (!copy_from_user(&params, user_params))
         return -EFAULT;
     auto old_path = get_syscall_path_argument(params.old_path);
     if (old_path.is_error())

--- a/Kernel/Syscalls/sched.cpp
+++ b/Kernel/Syscalls/sched.cpp
@@ -51,11 +51,9 @@ int Process::sys$donate(pid_t tid)
 int Process::sys$sched_setparam(int pid, Userspace<const struct sched_param*> user_param)
 {
     REQUIRE_PROMISE(proc);
-    if (!validate_read_typed(user_param))
-        return -EFAULT;
-
     struct sched_param desired_param;
-    copy_from_user(&desired_param, user_param);
+    if (!copy_from_user(&desired_param, user_param))
+        return -EFAULT;
 
     InterruptDisabler disabler;
     auto* peer = Thread::current();
@@ -78,9 +76,6 @@ int Process::sys$sched_setparam(int pid, Userspace<const struct sched_param*> us
 int Process::sys$sched_getparam(pid_t pid, Userspace<struct sched_param*> user_param)
 {
     REQUIRE_PROMISE(proc);
-    if (!validate_write_typed(user_param))
-        return -EFAULT;
-
     InterruptDisabler disabler;
     auto* peer = Thread::current();
     if (pid != 0) {
@@ -98,7 +93,8 @@ int Process::sys$sched_getparam(pid_t pid, Userspace<struct sched_param*> user_p
     struct sched_param param {
         (int)peer->priority()
     };
-    copy_to_user(user_param, &param);
+    if (!copy_to_user(user_param, &param))
+        return -EFAULT;
     return 0;
 }
 

--- a/Kernel/Syscalls/setkeymap.cpp
+++ b/Kernel/Syscalls/setkeymap.cpp
@@ -37,24 +37,19 @@ int Process::sys$setkeymap(Userspace<const Syscall::SC_setkeymap_params*> user_p
         return -EPERM;
 
     Syscall::SC_setkeymap_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
+    if (!copy_from_user(&params, user_params))
         return -EFAULT;
 
     Keyboard::CharacterMapData character_map_data;
 
-    if (!validate_read(params.map, CHAR_MAP_SIZE))
+    if (!copy_from_user(character_map_data.map, params.map, CHAR_MAP_SIZE * sizeof(u32)))
         return -EFAULT;
-    if (!validate_read(params.shift_map, CHAR_MAP_SIZE))
+    if (!copy_from_user(character_map_data.shift_map, params.shift_map, CHAR_MAP_SIZE * sizeof(u32)))
         return -EFAULT;
-    if (!validate_read(params.alt_map, CHAR_MAP_SIZE))
+    if (!copy_from_user(character_map_data.alt_map, params.alt_map, CHAR_MAP_SIZE * sizeof(u32)))
         return -EFAULT;
-    if (!validate_read(params.altgr_map, CHAR_MAP_SIZE))
+    if (!copy_from_user(character_map_data.altgr_map, params.altgr_map, CHAR_MAP_SIZE * sizeof(u32)))
         return -EFAULT;
-
-    copy_from_user(character_map_data.map, params.map, CHAR_MAP_SIZE * sizeof(u32));
-    copy_from_user(character_map_data.shift_map, params.shift_map, CHAR_MAP_SIZE * sizeof(u32));
-    copy_from_user(character_map_data.alt_map, params.alt_map, CHAR_MAP_SIZE * sizeof(u32));
-    copy_from_user(character_map_data.altgr_map, params.altgr_map, CHAR_MAP_SIZE * sizeof(u32));
 
     auto map_name = get_syscall_path_argument(params.map_name);
     if (map_name.is_error()) {

--- a/Kernel/Syscalls/times.cpp
+++ b/Kernel/Syscalls/times.cpp
@@ -31,16 +31,14 @@ namespace Kernel {
 clock_t Process::sys$times(Userspace<tms*> user_times)
 {
     REQUIRE_PROMISE(stdio);
-    if (!validate_write_typed(user_times))
-        return -EFAULT;
-
     tms times = {};
     times.tms_utime = m_ticks_in_user;
     times.tms_stime = m_ticks_in_kernel;
     times.tms_cutime = m_ticks_in_user_for_dead_children;
     times.tms_cstime = m_ticks_in_kernel_for_dead_children;
 
-    copy_to_user(user_times, &times);
+    if (!copy_to_user(user_times, &times))
+        return -EFAULT;
 
     return g_uptime & 0x7fffffff;
 }

--- a/Kernel/Syscalls/ttyname.cpp
+++ b/Kernel/Syscalls/ttyname.cpp
@@ -34,8 +34,6 @@ namespace Kernel {
 int Process::sys$ttyname(int fd, Userspace<char*> buffer, size_t size)
 {
     REQUIRE_PROMISE(tty);
-    if (!validate_write(buffer, size))
-        return -EFAULT;
     auto description = file_description(fd);
     if (!description)
         return -EBADF;
@@ -44,15 +42,14 @@ int Process::sys$ttyname(int fd, Userspace<char*> buffer, size_t size)
     auto tty_name = description->tty()->tty_name();
     if (size < tty_name.length() + 1)
         return -ERANGE;
-    copy_to_user(buffer, tty_name.characters(), tty_name.length() + 1);
+    if (!copy_to_user(buffer, tty_name.characters(), tty_name.length() + 1))
+        return -EFAULT;
     return 0;
 }
 
 int Process::sys$ptsname(int fd, Userspace<char*> buffer, size_t size)
 {
     REQUIRE_PROMISE(tty);
-    if (!validate_write(buffer, size))
-        return -EFAULT;
     auto description = file_description(fd);
     if (!description)
         return -EBADF;
@@ -62,7 +59,8 @@ int Process::sys$ptsname(int fd, Userspace<char*> buffer, size_t size)
     auto pts_name = master_pty->pts_name();
     if (size < pts_name.length() + 1)
         return -ERANGE;
-    copy_to_user(buffer, pts_name.characters(), pts_name.length() + 1);
+    if (!copy_to_user(buffer, pts_name.characters(), pts_name.length() + 1))
+        return -EFAULT;
     return 0;
 }
 

--- a/Kernel/Syscalls/uname.cpp
+++ b/Kernel/Syscalls/uname.cpp
@@ -34,9 +34,6 @@ int Process::sys$uname(Userspace<utsname*> buf)
     extern Lock* g_hostname_lock;
 
     REQUIRE_PROMISE(stdio);
-    if (!validate_write_typed(buf))
-        return -EFAULT;
-
 
     LOCKER(*g_hostname_lock, Lock::Mode::Shared);
     if (g_hostname->length() + 1 > sizeof(utsname::nodename))
@@ -45,11 +42,16 @@ int Process::sys$uname(Userspace<utsname*> buf)
     // We have already validated the entire utsname struct at this
     // point, there is no need to re-validate every write to the struct.
     utsname* user_buf = buf.unsafe_userspace_ptr();
-    copy_to_user(user_buf->sysname, "SerenityOS", 11);
-    copy_to_user(user_buf->release, "1.0-dev", 8);
-    copy_to_user(user_buf->version, "FIXME", 6);
-    copy_to_user(user_buf->machine, "i686", 5);
-    copy_to_user(user_buf->nodename, g_hostname->characters(), g_hostname->length() + 1);
+    if (!copy_to_user(user_buf->sysname, "SerenityOS", 11))
+        return -EFAULT;
+    if (!copy_to_user(user_buf->release, "1.0-dev", 8))
+        return -EFAULT;
+    if (!copy_to_user(user_buf->version, "FIXME", 6))
+        return -EFAULT;
+    if (!copy_to_user(user_buf->machine, "i686", 5))
+        return -EFAULT;
+    if (!copy_to_user(user_buf->nodename, g_hostname->characters(), g_hostname->length() + 1))
+        return -EFAULT;
     return 0;
 }
 

--- a/Kernel/Syscalls/unlink.cpp
+++ b/Kernel/Syscalls/unlink.cpp
@@ -33,8 +33,6 @@ namespace Kernel {
 int Process::sys$unlink(Userspace<const char*> user_path, size_t path_length)
 {
     REQUIRE_PROMISE(cpath);
-    if (!validate_read(user_path, path_length))
-        return -EFAULT;
     auto path = get_syscall_path_argument(user_path, path_length);
     if (path.is_error())
         return path.error();

--- a/Kernel/Syscalls/unveil.cpp
+++ b/Kernel/Syscalls/unveil.cpp
@@ -34,7 +34,7 @@ namespace Kernel {
 int Process::sys$unveil(Userspace<const Syscall::SC_unveil_params*> user_params)
 {
     Syscall::SC_unveil_params params;
-    if (!validate_read_and_copy_typed(&params, user_params))
+    if (!copy_from_user(&params, user_params))
         return -EFAULT;
 
     if (!params.path.characters && !params.permissions.characters) {
@@ -66,7 +66,7 @@ int Process::sys$unveil(Userspace<const Syscall::SC_unveil_params*> user_params)
     auto& custody = custody_or_error.value();
     auto new_unveiled_path = custody->absolute_path();
 
-    auto permissions = validate_and_copy_string_from_user(params.permissions);
+    auto permissions = copy_string_from_user(params.permissions);
     if (permissions.is_null())
         return -EFAULT;
 

--- a/Kernel/Syscalls/utime.cpp
+++ b/Kernel/Syscalls/utime.cpp
@@ -33,14 +33,13 @@ namespace Kernel {
 int Process::sys$utime(Userspace<const char*> user_path, size_t path_length, Userspace<const struct utimbuf*> user_buf)
 {
     REQUIRE_PROMISE(fattr);
-    if (user_buf && !validate_read_typed(user_buf))
-        return -EFAULT;
     auto path = get_syscall_path_argument(user_path, path_length);
     if (path.is_error())
         return path.error();
     utimbuf buf;
     if (user_buf) {
-        copy_from_user(&buf, user_buf);
+        if (!copy_from_user(&buf, user_buf))
+            return -EFAULT;
     } else {
         auto now = kgettimeofday();
         buf = { now.tv_sec, now.tv_sec };

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -60,14 +60,14 @@ String MasterPTY::pts_name() const
     return m_pts_name;
 }
 
-KResultOr<size_t> MasterPTY::read(FileDescription&, size_t, u8* buffer, size_t size)
+KResultOr<size_t> MasterPTY::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
 {
     if (!m_slave && m_buffer.is_empty())
         return 0;
     return m_buffer.read(buffer, size);
 }
 
-KResultOr<size_t> MasterPTY::write(FileDescription&, size_t, const u8* buffer, size_t size)
+KResultOr<size_t> MasterPTY::write(FileDescription&, size_t, const UserOrKernelBuffer& buffer, size_t size)
 {
     if (!m_slave)
         return KResult(-EIO);
@@ -98,12 +98,11 @@ void MasterPTY::notify_slave_closed(Badge<SlavePTY>)
         m_slave = nullptr;
 }
 
-ssize_t MasterPTY::on_slave_write(const u8* data, ssize_t size)
+ssize_t MasterPTY::on_slave_write(const UserOrKernelBuffer& data, ssize_t size)
 {
     if (m_closed)
         return -EIO;
-    m_buffer.write(data, size);
-    return size;
+    return m_buffer.write(data, size);
 }
 
 bool MasterPTY::can_write_from_slave() const

--- a/Kernel/TTY/MasterPTY.h
+++ b/Kernel/TTY/MasterPTY.h
@@ -41,7 +41,7 @@ public:
 
     unsigned index() const { return m_index; }
     String pts_name() const;
-    ssize_t on_slave_write(const u8*, ssize_t);
+    ssize_t on_slave_write(const UserOrKernelBuffer&, ssize_t);
     bool can_write_from_slave() const;
     void notify_slave_closed(Badge<SlavePTY>);
     bool is_closed() const { return m_closed; }
@@ -50,8 +50,8 @@ public:
 
 private:
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual KResult close() override;

--- a/Kernel/TTY/PTYMultiplexer.h
+++ b/Kernel/TTY/PTYMultiplexer.h
@@ -48,8 +48,8 @@ public:
 
     // ^CharacterDevice
     virtual KResultOr<NonnullRefPtr<FileDescription>> open(int options) override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override { return 0; }
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override { return 0; }
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override { return 0; }
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override { return 0; }
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -37,7 +37,7 @@ class SlavePTY final : public TTY {
 public:
     virtual ~SlavePTY() override;
 
-    void on_master_write(const u8*, ssize_t);
+    void on_master_write(const UserOrKernelBuffer&, ssize_t);
     unsigned index() const { return m_index; }
 
     time_t time_of_last_write() const { return m_time_of_last_write; }
@@ -45,12 +45,12 @@ public:
 private:
     // ^TTY
     virtual String tty_name() const override;
-    virtual ssize_t on_tty_write(const u8*, ssize_t) override;
+    virtual ssize_t on_tty_write(const UserOrKernelBuffer&, ssize_t) override;
     virtual void echo(u8) override;
 
     // ^CharacterDevice
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual const char* class_name() const override { return "SlavePTY"; }
     virtual KResult close() override;

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -39,8 +39,8 @@ class TTY : public CharacterDevice {
 public:
     virtual ~TTY() override;
 
-    virtual KResultOr<size_t> read(FileDescription&, size_t, u8*, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const u8*, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override final;
@@ -63,7 +63,7 @@ public:
     void hang_up();
 
 protected:
-    virtual ssize_t on_tty_write(const u8*, ssize_t) = 0;
+    virtual ssize_t on_tty_write(const UserOrKernelBuffer&, ssize_t) = 0;
     void set_size(unsigned short columns, unsigned short rows);
 
     TTY(unsigned major, unsigned minor);

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -54,7 +54,7 @@ private:
     virtual void on_key_pressed(KeyboardDevice::Event) override;
 
     // ^TTY
-    virtual ssize_t on_tty_write(const u8*, ssize_t) override;
+    virtual ssize_t on_tty_write(const UserOrKernelBuffer&, ssize_t) override;
     virtual String tty_name() const override { return m_tty_name; }
     virtual void echo(u8) override;
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -107,6 +107,7 @@ public:
 
     const String& name() const { return m_name; }
     void set_name(const StringView& s) { m_name = s; }
+    void set_name(String&& name) { m_name = move(name); }
 
     void finalize();
 
@@ -430,7 +431,7 @@ public:
     FPUState& fpu_state() { return *m_fpu_state; }
 
     void set_default_signal_dispositions();
-    void push_value_on_stack(FlatPtr);
+    bool push_value_on_stack(FlatPtr);
 
     u32 make_userspace_stack_for_main_thread(Vector<String> arguments, Vector<String> environment, Vector<AuxiliaryValue>);
 

--- a/Kernel/UserOrKernelBuffer.cpp
+++ b/Kernel/UserOrKernelBuffer.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Kernel/UserOrKernelBuffer.h>
+#include <Kernel/VM/MemoryManager.h>
+
+namespace Kernel {
+
+bool UserOrKernelBuffer::is_kernel_buffer() const
+{
+    return !is_user_address(VirtualAddress(m_buffer));
+}
+
+String UserOrKernelBuffer::copy_into_string(size_t size) const
+{
+    if (!m_buffer)
+        return {};
+    if (is_user_address(VirtualAddress(m_buffer))) {
+        char* buffer;
+        auto data_copy = StringImpl::create_uninitialized(size, buffer);
+        if (!copy_from_user(buffer, m_buffer, size))
+            return {};
+        return data_copy;
+    }
+
+    return String({ m_buffer, size });
+}
+
+bool UserOrKernelBuffer::write(const void* src, size_t offset, size_t len)
+{
+    if (!m_buffer)
+        return false;
+
+    if (is_user_address(VirtualAddress(m_buffer)))
+        return copy_to_user(m_buffer + offset, src, len);
+
+    memcpy(m_buffer + offset, src, len);
+    return true;
+}
+
+bool UserOrKernelBuffer::read(void* dest, size_t offset, size_t len) const
+{
+    if (!m_buffer)
+        return false;
+
+    if (is_user_address(VirtualAddress(m_buffer)))
+        return copy_from_user(dest, m_buffer + offset, len);
+
+    memcpy(dest, m_buffer + offset, len);
+    return true;
+}
+
+bool UserOrKernelBuffer::memset(int value, size_t offset, size_t len)
+{
+    if (!m_buffer)
+        return false;
+
+    if (is_user_address(VirtualAddress(m_buffer)))
+        return memset_user(m_buffer + offset, value, len);
+    
+    ::memset(m_buffer + offset, value, len);
+    return true;
+}
+
+}

--- a/Kernel/UserOrKernelBuffer.h
+++ b/Kernel/UserOrKernelBuffer.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/Types.h>
+#include <AK/Userspace.h>
+#include <Kernel/StdLib.h>
+#include <Kernel/UnixTypes.h>
+#include <Kernel/VM/MemoryManager.h>
+#include <LibC/errno_numbers.h>
+
+namespace Kernel {
+
+class UserOrKernelBuffer {
+public:
+    UserOrKernelBuffer() = delete;
+
+    static UserOrKernelBuffer for_kernel_buffer(u8* kernel_buffer)
+    {
+        ASSERT(!kernel_buffer || !is_user_address(VirtualAddress(kernel_buffer)));
+        return UserOrKernelBuffer(kernel_buffer);
+    }
+
+    static Optional<UserOrKernelBuffer> for_user_buffer(u8* user_buffer, size_t size)
+    {
+        if (user_buffer && !is_user_range(VirtualAddress(user_buffer), size))
+            return {};
+        return UserOrKernelBuffer(user_buffer);
+    }
+
+    template<typename UserspaceType>
+    static Optional<UserOrKernelBuffer> for_user_buffer(UserspaceType userspace, size_t size)
+    {
+        if (!is_user_range(VirtualAddress(userspace.unsafe_userspace_ptr()), size))
+            return {};
+        return UserOrKernelBuffer(const_cast<u8*>((const u8*)userspace.unsafe_userspace_ptr()));
+    }
+
+    bool is_kernel_buffer() const;
+    const void* user_or_kernel_ptr() const { return m_buffer; }
+
+    UserOrKernelBuffer offset(ssize_t offset) const
+    {
+        if (!m_buffer)
+            return *this;
+        UserOrKernelBuffer offset_buffer = *this;
+        offset_buffer.m_buffer += offset;
+        ASSERT(offset_buffer.is_kernel_buffer() == is_kernel_buffer());
+        return offset_buffer;
+    }
+
+    String copy_into_string(size_t size) const;
+    [[nodiscard]] bool write(const void* src, size_t offset, size_t len);
+    [[nodiscard]] bool write(const void* src, size_t len)
+    {
+        return write(src, 0, len);
+    }
+    [[nodiscard]] bool read(void* dest, size_t offset, size_t len) const;
+    [[nodiscard]] bool read(void* dest, size_t len) const
+    {
+        return read(dest, 0, len);
+    }
+
+    [[nodiscard]] bool memset(int value, size_t offset, size_t len);
+    [[nodiscard]] bool memset(int value, size_t len)
+    {
+        return memset(value, 0, len);
+    }
+
+    template<size_t BUFFER_BYTES, typename F>
+    [[nodiscard]] ssize_t write_buffered(size_t offset, size_t len, F f)
+    {
+        if (!m_buffer)
+            return -EFAULT;
+        if (is_kernel_buffer()) {
+            // We're transferring directly to a kernel buffer, bypass
+            return f(m_buffer + offset, len);
+        }
+
+        // The purpose of using a buffer on the stack is that we can
+        // avoid a bunch of small (e.g. 1-byte) copy_to_user calls
+        u8 buffer[BUFFER_BYTES];
+        size_t nwritten = 0;
+        while (nwritten < len) {
+            auto to_copy = min(sizeof(buffer), len - nwritten);
+            ssize_t copied = f(buffer, to_copy);
+            if (copied < 0)
+                return copied;
+            ASSERT((size_t)copied <= to_copy);
+            if (!write(buffer, nwritten, (size_t)copied))
+                return -EFAULT;
+            nwritten += (size_t)copied;
+            if ((size_t)copied < to_copy)
+                break;
+        }
+        return (ssize_t)nwritten;
+    }
+    template<size_t BUFFER_BYTES, typename F>
+    [[nodiscard]] ssize_t write_buffered(size_t len, F f)
+    {
+        return write_buffered<BUFFER_BYTES, F>(0, len, f);
+    }
+
+    template<size_t BUFFER_BYTES, typename F>
+    [[nodiscard]] ssize_t read_buffered(size_t offset, size_t len, F f) const
+    {
+        if (!m_buffer)
+            return -EFAULT;
+        if (is_kernel_buffer()) {
+            // We're transferring directly from a kernel buffer, bypass
+            return f(m_buffer + offset, len);
+        }
+
+        // The purpose of using a buffer on the stack is that we can
+        // avoid a bunch of small (e.g. 1-byte) copy_from_user calls
+        u8 buffer[BUFFER_BYTES];
+        size_t nread = 0;
+        while (nread < len) {
+            auto to_copy = min(sizeof(buffer), len - nread);
+            if (!read(buffer, nread, to_copy))
+                return -EFAULT;
+            ssize_t copied = f(buffer, to_copy);
+            if (copied < 0)
+                return copied;
+            ASSERT((size_t)copied <= to_copy);
+            nread += (size_t)copied;
+            if ((size_t)copied < to_copy)
+                break;
+        }
+        return nread;
+    }
+    template<size_t BUFFER_BYTES, typename F>
+    [[nodiscard]] ssize_t read_buffered(size_t len, F f) const
+    {
+        return read_buffered<BUFFER_BYTES, F>(0, len, f);
+    }
+
+private:
+    explicit UserOrKernelBuffer(u8* buffer)
+        : m_buffer(buffer)
+    {
+    }
+
+    u8* m_buffer;
+};
+
+}

--- a/Kernel/VM/InodeVMObject.cpp
+++ b/Kernel/VM/InodeVMObject.cpp
@@ -89,7 +89,7 @@ void InodeVMObject::inode_size_changed(Badge<Inode>, size_t old_size, size_t new
     });
 }
 
-void InodeVMObject::inode_contents_changed(Badge<Inode>, off_t offset, ssize_t size, const u8* data)
+void InodeVMObject::inode_contents_changed(Badge<Inode>, off_t offset, ssize_t size, const UserOrKernelBuffer& data)
 {
     (void)size;
     (void)data;

--- a/Kernel/VM/InodeVMObject.h
+++ b/Kernel/VM/InodeVMObject.h
@@ -39,7 +39,7 @@ public:
     Inode& inode() { return *m_inode; }
     const Inode& inode() const { return *m_inode; }
 
-    void inode_contents_changed(Badge<Inode>, off_t, ssize_t, const u8*);
+    void inode_contents_changed(Badge<Inode>, off_t, ssize_t, const UserOrKernelBuffer&);
     void inode_size_changed(Badge<Inode>, size_t old_size, size_t new_size);
 
     size_t amount_dirty() const;

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -767,39 +767,6 @@ bool MemoryManager::validate_user_stack(const Process& process, VirtualAddress v
     return region && region->is_user_accessible() && region->is_stack();
 }
 
-bool MemoryManager::validate_kernel_read(const Process& process, VirtualAddress vaddr, size_t size) const
-{
-    ScopedSpinLock lock(s_mm_lock);
-    return validate_range<AccessSpace::Kernel, AccessType::Read>(process, vaddr, size);
-}
-
-bool MemoryManager::can_read_without_faulting(const Process& process, VirtualAddress vaddr, size_t size) const
-{
-    // FIXME: Use the size argument!
-    UNUSED_PARAM(size);
-    ScopedSpinLock lock(s_mm_lock);
-    auto* pte = const_cast<MemoryManager*>(this)->pte(process.page_directory(), vaddr);
-    if (!pte)
-        return false;
-    return pte->is_present();
-}
-
-bool MemoryManager::validate_user_read(const Process& process, VirtualAddress vaddr, size_t size) const
-{
-    if (!is_user_address(vaddr))
-        return false;
-    ScopedSpinLock lock(s_mm_lock);
-    return validate_range<AccessSpace::User, AccessType::Read>(process, vaddr, size);
-}
-
-bool MemoryManager::validate_user_write(const Process& process, VirtualAddress vaddr, size_t size) const
-{
-    if (!is_user_address(vaddr))
-        return false;
-    ScopedSpinLock lock(s_mm_lock);
-    return validate_range<AccessSpace::User, AccessType::Write>(process, vaddr, size);
-}
-
 void MemoryManager::register_vmobject(VMObject& vmobject)
 {
     ScopedSpinLock lock(s_mm_lock);

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -100,12 +100,6 @@ public:
     void enter_process_paging_scope(Process&);
 
     bool validate_user_stack(const Process&, VirtualAddress) const;
-    bool validate_user_read(const Process&, VirtualAddress, size_t) const;
-    bool validate_user_write(const Process&, VirtualAddress, size_t) const;
-
-    bool validate_kernel_read(const Process&, VirtualAddress, size_t) const;
-
-    bool can_read_without_faulting(const Process&, VirtualAddress, size_t) const;
 
     enum class ShouldZeroFill {
         No,

--- a/Kernel/VM/Region.h
+++ b/Kernel/VM/Region.h
@@ -79,6 +79,7 @@ public:
     unsigned access() const { return m_access; }
 
     void set_name(const String& name) { m_name = name; }
+    void set_name(String&& name) { m_name = move(name); }
 
     const VMObject& vmobject() const { return *m_vmobject; }
     VMObject& vmobject() { return *m_vmobject; }

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -96,8 +96,8 @@ int execve(const char* filename, char* const argv[], char* const envp[])
     auto copy_strings = [&](auto& vec, size_t count, auto& output) {
         output.length = count;
         for (size_t i = 0; vec[i]; ++i) {
-            output.strings.ptr()[i].characters = vec[i];
-            output.strings.ptr()[i].length = strlen(vec[i]);
+            output.strings[i].characters = vec[i];
+            output.strings[i].length = strlen(vec[i]);
         }
     };
 

--- a/Libraries/LibELF/Loader.cpp
+++ b/Libraries/LibELF/Loader.cpp
@@ -81,7 +81,10 @@ bool Loader::layout()
                 failed = true;
                 return;
             }
-            do_memcpy(tls_image, program_header.raw_data(), program_header.size_in_image());
+            if (!do_memcpy(tls_image, program_header.raw_data(), program_header.size_in_image())) {
+                failed = false;
+                return;
+            }
 #endif
             return;
         }
@@ -117,7 +120,10 @@ bool Loader::layout()
             //     Accessing it would definitely be a bug.
             auto page_offset = program_header.vaddr();
             page_offset.mask(~PAGE_MASK);
-            do_memcpy((u8*)allocated_section + page_offset.get(), program_header.raw_data(), program_header.size_in_image());
+            if (!do_memcpy((u8*)allocated_section + page_offset.get(), program_header.raw_data(), program_header.size_in_image())) {
+                failed = false;
+                return;
+            }
         } else {
             auto* mapped_section = map_section_hook(
                 program_header.vaddr(),

--- a/Libraries/LibPthread/pthread.cpp
+++ b/Libraries/LibPthread/pthread.cpp
@@ -383,7 +383,7 @@ int pthread_attr_getstack(const pthread_attr_t* attributes, void** p_stack_ptr, 
     if (!attributes_impl || !p_stack_ptr || !p_stack_size)
         return EINVAL;
 
-    *p_stack_ptr = attributes_impl->m_stack_location.ptr();
+    *p_stack_ptr = attributes_impl->m_stack_location;
     *p_stack_size = attributes_impl->m_stack_size;
 
     return 0;


### PR DESCRIPTION
Since the CPU already does almost all necessary validation steps
for us, we don't really need to attempt to do this. Doing it
ourselves doesn't really work very reliably, because we'd have to
account for other processors modifying virtual memory, and we'd
have to account for e.g. pages not being able to be allocated
due to insufficient resources.

So change the copy_to/from_user (and associated helper functions)
to use the new safe_memcpy, which will return whether it succeeded
or not. The only manual validation step needed (which the CPU
can't perform for us) is making sure the pointers provided by user
mode aren't pointing to kernel mappings.

To make it easier to read/write from/to either kernel or user mode
data add the UserOrKernelBuffer helper class, which will internally
either use copy_from/to_user or directly memcpy, or pass the data
through directly using a temporary buffer on the stack.

This is needed to be able to continue the work started in #3396