### PR TITLE
Shell: Move the first command in a pipeline to the pipeline pgid too

### DIFF
--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -622,12 +622,14 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
     }
 
     pid_t pgid = is_first ? child : (command.pipeline ? command.pipeline->pgid : child);
-    if (!m_is_subshell && command.should_wait) {
+    if ((!m_is_subshell && command.should_wait) || command.pipeline) {
         if (setpgid(child, pgid) < 0)
             perror("setpgid");
 
-        tcsetpgrp(STDOUT_FILENO, pgid);
-        tcsetpgrp(STDIN_FILENO, pgid);
+        if (!m_is_subshell) {
+            tcsetpgrp(STDOUT_FILENO, pgid);
+            tcsetpgrp(STDIN_FILENO, pgid);
+        }
     }
 
     while (write(sync_pipe[1], "x", 1) < 0) {


### PR DESCRIPTION
This process is supposed to be the session leader of the pipeline
process group, we can't *not* move it into that group :P

Fixes the `Operation not permitted` thing over on #3468 