### PR TITLE
Terminal: Make sure empty hrefs set a null string on Attribute

### DIFF
--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -576,9 +576,14 @@ void Terminal::execute_xterm_command()
         m_client.set_window_title(params[1]);
         break;
     case 8:
-        m_current_attribute.href = params[2];
-        // FIXME: Respect the provided ID
-        m_current_attribute.href_id = String::format("%u", m_next_href_id++);
+        if (params[2].is_empty()) {
+            m_current_attribute.href = String();
+            m_current_attribute.href_id = String();
+        } else {
+            m_current_attribute.href = params[2];
+            // FIXME: Respect the provided ID
+            m_current_attribute.href_id = String::format("%u", m_next_href_id++);
+        }
         break;
     case 9:
         m_client.set_window_progress(numeric_params[1], numeric_params[2]);


### PR DESCRIPTION
Else, we store an empty but allocated string for each Attribute after a
href was emitted (since it's ended by a non-null empty string), which
makes Line objects very expensive to destroy and to modify.

Reduces `disasm /bin/id` from 414ms to 380ms (min-of-5). There's
a lot more perf wins to be had with better href handling (most
lines don't have any hrefs, so instead of storing a string per
Attr, maybe we could have a vector of hrefs per line and int offsets
into that in each Attr for example), but this is a simple, obvious,
and effective improvement, so let's start with this.