### PR TITLE
Shell: Add functions (and $0/$1/...)

### DIFF
--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -636,6 +636,28 @@ private:
     int dest_fd { -1 };
 };
 
+class FunctionDeclaration final : public Node {
+public:
+    struct NameWithPosition {
+        String name;
+        Position position;
+    };
+    FunctionDeclaration(Position, NameWithPosition name, Vector<NameWithPosition> argument_names, RefPtr<AST::Node> body);
+    virtual ~FunctionDeclaration();
+
+private:
+    virtual void dump(int level) const override;
+    virtual RefPtr<Value> run(RefPtr<Shell>) override;
+    virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
+    virtual HitTestResult hit_test_position(size_t) override;
+    virtual String class_name() const override { return "FunctionDeclaration"; }
+    virtual bool would_execute() const override { return true; }
+
+    NameWithPosition m_name;
+    Vector<NameWithPosition> m_arguments;
+    RefPtr<AST::Node> m_block;
+};
+
 class ForLoop final : public Node {
 public:
     ForLoop(Position, String variable_name, RefPtr<AST::Node> iterated_expr, RefPtr<AST::Node> block, Optional<size_t> in_kw_position = {});

--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -392,6 +392,7 @@ public:
     virtual bool is_glob() const { return false; }
     virtual bool is_tilde() const { return false; }
     virtual bool is_variable_decls() const { return false; }
+    virtual bool is_simple_variable() const { return false; }
     virtual bool is_syntax_error() const { return m_is_syntax_error; }
 
     virtual bool is_list() const { return false; }
@@ -650,6 +651,7 @@ private:
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual HitTestResult hit_test_position(size_t) override;
+    virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, const HitTestResult&) override;
     virtual String class_name() const override { return "FunctionDeclaration"; }
     virtual bool would_execute() const override { return true; }
 
@@ -849,6 +851,8 @@ public:
     SimpleVariable(Position, String);
     virtual ~SimpleVariable();
 
+    const String& name() const { return m_name; }
+
 private:
     virtual void dump(int level) const override;
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
@@ -856,6 +860,7 @@ private:
     virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, const HitTestResult&) override;
     virtual HitTestResult hit_test_position(size_t) override;
     virtual String class_name() const override { return "SimpleVariable"; }
+    virtual bool is_simple_variable() const override { return true; }
 
     String m_name;
 };

--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -45,6 +45,7 @@ public:
 private:
     RefPtr<AST::Node> parse_toplevel();
     RefPtr<AST::Node> parse_sequence();
+    RefPtr<AST::Node> parse_function_decl();
     RefPtr<AST::Node> parse_and_logical_sequence();
     RefPtr<AST::Node> parse_or_logical_sequence();
     RefPtr<AST::Node> parse_variable_decls();
@@ -109,7 +110,10 @@ toplevel :: sequence?
 sequence :: variable_decls? or_logical_sequence terminator sequence
           | variable_decls? or_logical_sequence '&' sequence
           | variable_decls? or_logical_sequence
+          | variable_decls? function_decl (terminator sequence)?
           | variable_decls? terminator sequence
+
+function_decl :: identifier '(' (ws* identifier)* ')' ws* '{' toplevel '}'
 
 or_logical_sequence :: and_logical_sequence '|' '|' and_logical_sequence
                      | and_logical_sequence

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -591,10 +591,9 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
             return nullptr;
     }
 
-    int retval = 0;
-    if (run_builtin(command, rewirings, retval)) {
+    if (run_builtin(command, rewirings, last_return_code)) {
         for (auto& next_in_chain : command.next_chain)
-            run_tail(next_in_chain, retval);
+            run_tail(next_in_chain, last_return_code);
         return nullptr;
     }
 
@@ -610,9 +609,9 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
             }
         }
 
-        if (invoke_function(command, retval)) {
+        if (invoke_function(command, last_return_code)) {
             for (auto& next_in_chain : command.next_chain)
-                run_tail(next_in_chain, retval);
+                run_tail(next_in_chain, last_return_code);
             return nullptr;
         }
     }

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -92,6 +92,7 @@ public:
     String resolve_path(String) const;
     String resolve_alias(const String&) const;
 
+    RefPtr<AST::Value> get_argument(size_t);
     RefPtr<AST::Value> lookup_local_variable(const String&);
     String local_variable_or(const String&, const String&);
     void set_local_variable(const String&, RefPtr<AST::Value>);
@@ -169,6 +170,8 @@ public:
     CircularQueue<String, 8> cd_history; // FIXME: have a configurable cd history length
     HashMap<u64, NonnullRefPtr<Job>> jobs;
     Vector<String, 256> cached_path;
+
+    String current_script;
 
     enum ShellEventType {
         ReadLine,

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -98,6 +98,10 @@ public:
     void set_local_variable(const String&, RefPtr<AST::Value>);
     void unset_local_variable(const String&);
 
+    void define_function(String name, Vector<String> argnames, RefPtr<AST::Node> body);
+    bool has_function(const String&);
+    bool invoke_function(const AST::Command&, int& retval);
+
     struct LocalFrame {
         HashMap<String, RefPtr<AST::Value>> local_variables;
     };
@@ -224,6 +228,13 @@ private:
     bool m_should_ignore_jobs_on_next_exit { false };
     pid_t m_pid { 0 };
 
+    struct ShellFunction {
+        String name;
+        Vector<String> arguments;
+        RefPtr<AST::Node> body;
+    };
+
+    HashMap<String, ShellFunction> m_functions;
     Vector<LocalFrame> m_local_frames;
     NonnullRefPtrVector<AST::Redirection> m_global_redirections;
 

--- a/Shell/Tests/function.sh
+++ b/Shell/Tests/function.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Syntax ok?
+fn() { echo $* }
+
+# Can we invoke that?
+test "$(fn 1)" = 1 || echo cannot invoke "'fn 1'" && exit 1
+test "$(fn 1 2)" = "1 2" || echo cannot invoke "'fn 1 2'" && exit 1
+
+# With explicit argument names?
+fn(a) { echo $a }
+
+# Can we invoke that?
+test "$(fn 1)" = 1 || echo cannot invoke "'fn 1'" with explicit names && exit 1
+test "$(fn 1 2)" = 1 || echo cannot invoke "'fn 1 2'" with explicit names and extra arguments && exit 1
+
+# Can it fail?
+if fn 2>/dev/null {
+    echo "'fn'" with an explicit argument is not failing with not enough args
+    exit 1
+}
+
+# $0 in function should be its name
+fn() { echo $0 }
+
+test "$(fn)" = fn || echo '$0' in function not equal to its name && exit 1

--- a/Shell/Tests/sigpipe.sh
+++ b/Shell/Tests/sigpipe.sh
@@ -5,9 +5,7 @@
 # created.
 rm -f sigpipe.sh.out
 
-# FIXME: It'd be nice if there was a way to create a subshell that makes
-# fewer assumptions about cwd and the build directory name.
-Build/Meta/Lagom/shell -c 'echo foo && echo bar && echo baz > sigpipe.sh.out' | head -n 1 > /dev/null
+{ echo foo && echo bar && echo baz > sigpipe.sh.out } | head -n 1 > /dev/null
 
 # Failing commands don't make the test fail, just an explicit `exit 1` does.
 # So the test only fails if sigpipe.sh.out exists (since then `exit 1` runs),

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -209,6 +209,8 @@ int main(int argc, char** argv)
 
     parser.parse(argc, argv);
 
+    shell->current_script = argv[0];
+
     if (!skip_rc_files) {
         auto run_rc_file = [&](auto& name) {
             String file_path = name;


### PR DESCRIPTION
An example overview:
```sh
fn(a b c) {
    echo $a $b $c \( $* \)
}
$ fn 1 2 3 4
# 1 2 3 ( 1 2 3 4 )
```

cc @bugaevc - feel free to nitpick, the syntax and semantics are relatively close to other shells :shrug: 