### PR TITLE
AK: Lower the requirements for InputStream::eof and rename it.

### DIFF
--- a/AK/Buffered.h
+++ b/AK/Buffered.h
@@ -77,7 +77,7 @@ public:
         return nread;
     }
 
-    virtual bool read_or_error(Bytes bytes) override
+    bool read_or_error(Bytes bytes) override
     {
         if (read(bytes) < bytes.size()) {
             set_fatal_error();
@@ -87,7 +87,9 @@ public:
         return true;
     }
 
-    virtual bool eof() const
+    bool unreliable_eof() const override { return m_buffer_remaining == 0 && m_stream.unreliable_eof(); }
+
+    bool eof() const
     {
         if (m_buffer_remaining > 0)
             return false;
@@ -97,7 +99,7 @@ public:
         return m_buffer_remaining == 0;
     }
 
-    virtual bool discard_or_error(size_t count) override
+    bool discard_or_error(size_t count) override
     {
         size_t ndiscarded = 0;
         while (ndiscarded < count) {

--- a/AK/CircularDuplexStream.h
+++ b/AK/CircularDuplexStream.h
@@ -112,7 +112,8 @@ public:
         return true;
     }
 
-    bool eof() const override { return m_queue.size() == 0; }
+    bool unreliable_eof() const override { return eof(); }
+    bool eof() const { return m_queue.size() == 0; }
 
     size_t remaining_contigous_space() const
     {

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -40,7 +40,8 @@ public:
     {
     }
 
-    bool eof() const override { return m_offset >= m_bytes.size(); }
+    bool unreliable_eof() const override { return eof(); }
+    bool eof() const { return m_offset >= m_bytes.size(); }
 
     size_t read(Bytes bytes) override
     {
@@ -167,7 +168,8 @@ class DuplexMemoryStream final : public DuplexStream {
 public:
     static constexpr size_t chunk_size = 4 * 1024;
 
-    bool eof() const override { return m_write_offset == m_read_offset; }
+    bool unreliable_eof() const override { return eof(); }
+    bool eof() const { return m_write_offset == m_read_offset; }
 
     bool discard_or_error(size_t count) override
     {

--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -75,10 +75,22 @@ namespace AK {
 
 class InputStream : public virtual AK::Detail::Stream {
 public:
-    // Does nothing and returns zero if there is already an error.
+    // Reads at least one byte unless none are requested or none are avaliable. Does nothing
+    // and returns zero if there is already an error.
     virtual size_t read(Bytes) = 0;
+
+    // If this function returns true, then no more data can be read. If read(Bytes) previously
+    // returned zero even though bytes were requested, then the inverse is true as well.
+    virtual bool unreliable_eof() const = 0;
+
+    // Some streams additionally define a method with the signature:
+    //
+    //     bool eof() const;
+    //
+    // This method has the same semantics as unreliable_eof() but returns true if and only if no
+    // more data can be read. (A failed read is not necessary.)
+
     virtual bool read_or_error(Bytes) = 0;
-    virtual bool eof() const = 0;
     virtual bool discard_or_error(size_t count) = 0;
 };
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -285,15 +285,14 @@ inline InputStream& operator>>(InputStream& stream, String& string)
     StringBuilder builder;
 
     for (;;) {
-        if (stream.eof()) {
-            string = nullptr;
-
-            stream.set_fatal_error();
-            return stream;
-        }
-
         char next_char;
         stream >> next_char;
+
+        if (stream.has_any_error()) {
+            stream.set_fatal_error();
+            string = nullptr;
+            return stream;
+        }
 
         if (next_char) {
             builder.append(next_char);

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -290,7 +290,7 @@ bool DeflateDecompressor::discard_or_error(size_t count)
 
     size_t ndiscarded = 0;
     while (ndiscarded < count) {
-        if (eof()) {
+        if (unreliable_eof()) {
             set_fatal_error();
             return false;
         }
@@ -301,7 +301,7 @@ bool DeflateDecompressor::discard_or_error(size_t count)
     return true;
 }
 
-bool DeflateDecompressor::eof() const { return m_state == State::Idle && m_read_final_bock; }
+bool DeflateDecompressor::unreliable_eof() const { return m_state == State::Idle && m_read_final_bock; }
 
 Optional<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
 {
@@ -310,7 +310,7 @@ Optional<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
     OutputMemoryStream output_stream;
 
     u8 buffer[4096];
-    while (!deflate_stream.has_any_error() && !deflate_stream.eof()) {
+    while (!deflate_stream.has_any_error() && !deflate_stream.unreliable_eof()) {
         const auto nread = deflate_stream.read({ buffer, sizeof(buffer) });
         output_stream.write_or_error({ buffer, nread });
     }

--- a/Libraries/LibCompress/Deflate.h
+++ b/Libraries/LibCompress/Deflate.h
@@ -92,7 +92,8 @@ public:
     size_t read(Bytes) override;
     bool read_or_error(Bytes) override;
     bool discard_or_error(size_t) override;
-    bool eof() const override;
+
+    bool unreliable_eof() const override;
 
     static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
 

--- a/Libraries/LibCompress/Gzip.h
+++ b/Libraries/LibCompress/Gzip.h
@@ -39,7 +39,8 @@ public:
     size_t read(Bytes) override;
     bool read_or_error(Bytes) override;
     bool discard_or_error(size_t) override;
-    bool eof() const override;
+
+    bool unreliable_eof() const override;
 
     static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
 
@@ -87,6 +88,8 @@ private:
 
     InputStream& m_input_stream;
     Optional<Member> m_current_member;
+
+    bool m_eof { false };
 };
 
 }

--- a/Userland/gunzip.cpp
+++ b/Userland/gunzip.cpp
@@ -34,7 +34,7 @@ static void decompress_file(Buffered<Core::InputFileStream>& input_stream, Buffe
 
     u8 buffer[4096];
 
-    while (!gzip_stream.eof()) {
+    while (!gzip_stream.unreliable_eof()) {
         const auto nread = gzip_stream.read({ buffer, sizeof(buffer) });
         output_stream.write_or_error({ buffer, nread });
     }


### PR DESCRIPTION
Consider the following snippet:

~~~c++
void foo(InputStream& stream) {
    if(!stream.eof()) {
        u8 byte;
        stream >> byte;
    }
}
~~~

There is a very subtle bug in this snippet, for some input streams `stream.eof()` might return false even if no more data can be read. In this case an error flag would be set on the stream.

Until now I've always ensured that this is not the case, but this made the implementation unnecessarily complicated. `InputFileStream::eof` had to keep a `ByteBuffer` around just to make this possible. That meant a ton of unnecessary copies just to get a reliable end-of-file check.

In most cases it isn't actually necessary to have a reliable check for end-of-file.

In most other cases a reliable end-of-file check is available anyways because in some cases like `InputMemoryStream` it is very easy to implement.

---

I did a little benchmark with the Gzip implementation and found that decompressing a ~47MiB file took 102753ms with these changes compared to 128411ms before. I only did a single benchmark so this is might not be very representative but that's about a 20% improvement.
