### PR TITLE
Switch to Ubuntu Focal Fossa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: bionic
+dist: focal
 
 language: cpp
 
@@ -9,7 +9,6 @@ compiler:
 cache:
   ccache: true
   directories:
-  - /var/cache/apt/archives/*.deb
   - Toolchain/Cache/
 
 notifications:
@@ -23,18 +22,16 @@ notifications:
       - "Details: %{build_url}"
 
 before_install:
-- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 - sudo apt-get update -qq
-- sudo apt-get install -y g++-8 libstdc++-8-dev shellcheck libmpfr-dev libmpc-dev libgmp-dev e2fsprogs qemu-system-i386 qemu-utils
-- sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 90
-- sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 90
-# Travis ships an old cmake 3.12.4. We need cmake >= 3.16.
-# Why would you put binaries there?!
-- sudo rm -rf /usr/local/cmake-*
-- which cmake || true
-- curl -sSf --proto =https --retry 3 --retry-delay 60 https://cmake.org/files/v3.18/cmake-3.18.1-Linux-x86_64.sh > /tmp/cmake-install.sh
-- sudo sh /tmp/cmake-install.sh --skip-license --prefix=/usr
+# These packages are already part of the Travis image:
+#- sudo apt-get install -y g++-9 libstdc++-9-dev cmake shellcheck
+# These aren't:
+- sudo apt-get install -y libmpfr-dev libmpc-dev libgmp-dev
+# If we ever do any qemu-emulation on Travis, we should re-enable this:
+#- e2fsprogs qemu-system-i386 qemu-utils
+- g++ --version
 - cmake --version
+- shellcheck --version
 
 script:
 - export SERENITY_ROOT="$(pwd)"
@@ -57,4 +54,3 @@ script:
 - cd "$SERENITY_ROOT"/Toolchain/Cache
 - du -ch * || true
 - du -sch /home/travis/.ccache/* || true
-- du -sch /var/cache/apt/archives/*.deb || true

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -289,18 +289,10 @@ pushd "$DIR"
         else
             mkdir -p Cache/
             # We *most definitely* don't need debug symbols in the linker/compiler.
-            # This cuts the uncompressed size from 1.2 GiB per Toolchain down to about 250 MiB.
-            pushd "Local/libexec/gcc/i686-pc-serenity/${GCC_VERSION}"
-                for binary in cc1 cc1plus lto1; do
-                    echo "Before: $(du -h "${binary}")"
-                    strip "${binary}"
-                    echo "After: $(du -h "${binary}")"
-                done
-            popd
-            binary=Local/bin/i686-pc-serenity-lto-dump
-            echo "Before: $(du -h "${binary}")"
-            strip "${binary}"
-            echo "After: $(du -h "${binary}")"
+            # This cuts the uncompressed size from 1.2 GiB per Toolchain down to about 190 MiB.
+            echo "Before: $(du -sh Local)"
+            find Local/ -type f -executable ! -name '*.la' ! -name '*.sh' ! -name 'mk*' -exec strip {} +
+            echo "After: $(du -sh Local)"
             tar czf "Cache/ToolchainLocal_${DEPS_HASH}.tar.gz" Local/
         fi
     fi


### PR DESCRIPTION
Travis' support for Ubuntu Focal is getting along quite nicely, we should finally switch to it.

This PR also:
- Gets rid of the PPA and extra caching necessary for a less-than-ancient gcc.
- Gets rid of the manual download and installation of cmake.
- Makes the Toolchain just a little bit smaller, because we can.

Also, @alimpfard suggested that we could automatically run `clang-format`, which should become available more easily on Ubuntu Focal than on Bionic. :)