### PR TITLE
LibLine: Support alt-arrow left/right, and ctrl-delete

### DIFF
--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -736,7 +736,10 @@ void Editor::handle_read_event()
                 continue;
             case '~':
                 if (param1 == 3) { // ^[[3~: delete
-                    erase_character_forwards();
+                    if (modifiers == CSIMod::Ctrl)
+                        erase_alnum_word_forwards();
+                    else
+                        erase_character_forwards();
                     m_search_offset = 0;
                     continue;
                 }

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -717,13 +717,13 @@ void Editor::handle_read_event()
                 search_forwards();
                 continue;
             case 'D': // ^[[D: arrow left
-                if (modifiers == CSIMod::Ctrl)
+                if (modifiers == CSIMod::Alt || modifiers == CSIMod::Ctrl)
                     cursor_left_word();
                 else
                     cursor_left_character();
                 continue;
             case 'C': // ^[[C: arrow right
-                if (modifiers == CSIMod::Ctrl)
+                if (modifiers == CSIMod::Alt || modifiers == CSIMod::Ctrl)
                     cursor_right_word();
                 else
                     cursor_right_character();

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -471,8 +471,9 @@ private:
     enum class InputState {
         Free,
         GotEscape,
-        GotEscapeFollowedByLeftBracket,
-        ExpectTerminator,
+        CSIExpectParameter,
+        CSIExpectIntermediate,
+        CSIExpectFinal,
     };
     InputState m_state { InputState::Free };
 

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -1034,6 +1034,12 @@ void Terminal::handle_key_press(KeyCode key, u32 code_point, u8 flags)
         else
             emit_string(String::format("\e[%c", final));
     };
+    auto emit_tilde_with_modifier = [this, modifier_mask](unsigned num) {
+        if (modifier_mask)
+            emit_string(String::format("\e[%d;%d~", num, modifier_mask + 1));
+        else
+            emit_string(String::format("\e[%d~", num));
+    };
 
     switch (key) {
     case KeyCode::Key_Up:
@@ -1049,10 +1055,10 @@ void Terminal::handle_key_press(KeyCode key, u32 code_point, u8 flags)
         emit_final_with_modifier('D');
         return;
     case KeyCode::Key_Insert:
-        emit_string("\033[2~");
+        emit_tilde_with_modifier(2);
         return;
     case KeyCode::Key_Delete:
-        emit_string("\033[3~");
+        emit_tilde_with_modifier(3);
         return;
     case KeyCode::Key_Home:
         emit_final_with_modifier('H');
@@ -1061,10 +1067,10 @@ void Terminal::handle_key_press(KeyCode key, u32 code_point, u8 flags)
         emit_final_with_modifier('F');
         return;
     case KeyCode::Key_PageUp:
-        emit_string("\033[5~");
+        emit_tilde_with_modifier(5);
         return;
     case KeyCode::Key_PageDown:
-        emit_string("\033[6~");
+        emit_tilde_with_modifier(6);
         return;
     default:
         break;

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -1026,19 +1026,27 @@ void Terminal::handle_key_press(KeyCode key, u32 code_point, u8 flags)
     bool ctrl = flags & Mod_Ctrl;
     bool alt = flags & Mod_Alt;
     bool shift = flags & Mod_Shift;
+    unsigned modifier_mask = int(shift) + (int(alt) << 1) + (int(ctrl) << 2);
+
+    auto emit_final_with_modifier = [this, modifier_mask](char final) {
+        if (modifier_mask)
+            emit_string(String::format("\e[1;%d%c", modifier_mask + 1, final));
+        else
+            emit_string(String::format("\e[%c", final));
+    };
 
     switch (key) {
     case KeyCode::Key_Up:
-        emit_string(ctrl ? "\033[OA" : "\033[A");
+        emit_final_with_modifier('A');
         return;
     case KeyCode::Key_Down:
-        emit_string(ctrl ? "\033[OB" : "\033[B");
+        emit_final_with_modifier('B');
         return;
     case KeyCode::Key_Right:
-        emit_string(ctrl ? "\033[OC" : "\033[C");
+        emit_final_with_modifier('C');
         return;
     case KeyCode::Key_Left:
-        emit_string(ctrl ? "\033[OD" : "\033[D");
+        emit_final_with_modifier('D');
         return;
     case KeyCode::Key_Insert:
         emit_string("\033[2~");
@@ -1047,10 +1055,10 @@ void Terminal::handle_key_press(KeyCode key, u32 code_point, u8 flags)
         emit_string("\033[3~");
         return;
     case KeyCode::Key_Home:
-        emit_string("\033[H");
+        emit_final_with_modifier('H');
         return;
     case KeyCode::Key_End:
-        emit_string("\033[F");
+        emit_final_with_modifier('F');
         return;
     case KeyCode::Key_PageUp:
         emit_string("\033[5~");


### PR DESCRIPTION
Requires some gymnastics to better send modifier keys with special keys. Spruces up LibLine's CSI parser to handle CSI parameters and intermediates, changes LibVT to send modifiers as CSI parameter like xterm does, and handles modifiers for some keys in LibLine.

(It's a bit unfortunate that LibLine and Terminal.cpp both contain lots of ANSI escape code machinery. Maybe we can pull that out to some shared place at some point in the future.)