### PR TITLE
Shell: Add 'match' expressions

### DIFF
--- a/Base/usr/share/man/man5/Shell.md
+++ b/Base/usr/share/man/man5/Shell.md
@@ -60,6 +60,8 @@ The following tokens:
 * `in` as a syntactic element of a `for` expression
 * `if` in command name position, or after the `else` keyword
 * `else` after a partial `if` expression
+* `match` in command name position
+* `as` as part of a `match` expression
 
 ##### Special characters
 Any of the following:
@@ -249,6 +251,28 @@ fn(a b c) {
 
 $ fn 1 2 3 4
 # 1 2 3 ( 1 2 3 4 )
+```
+
+##### Match Expressions
+The pattern matching construct `match` shall choose from a sequence of patterns, and execute the corresponding action in a new frame.
+The choice is done by matching the result of the _matched expression_ (after expansion) against the _patterns_ (expanded down to either globs or literals).
+Multiple _patterns_ can be attributed to a single given action by delimiting them with a pipe ('|') symbol.
+
+The expanded _matched expression_ can optionally be given a name using the `as name` clause after the _matched expression_, with which it may be accessible in the action clauses.
+
+######
+```sh
+# Match the result of running 'make_some_value' (which is a list when captured by $(...))
+match "$(make_some_value)" as value {
+    (hello*) { echo "Hi!" }
+    (say\ *) { echo "No, I will not $value" }
+}
+
+# Match the result of running 'make_some_value', cast to a string.
+match "$(make_some_value)" {
+    hello* { echo "Hi!" }
+    say\ * { echo "No, I will not!" }
+}
 ```
 
 ## Formal Grammar

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -2316,6 +2316,9 @@ GlobValue::~GlobValue()
 }
 Vector<String> GlobValue::resolve_as_list(RefPtr<Shell> shell)
 {
+    if (!shell)
+        return { m_glob };
+
     return shell->expand_globs(m_glob, shell->cwd);
 }
 
@@ -2324,6 +2327,9 @@ SimpleVariableValue::~SimpleVariableValue()
 }
 Vector<String> SimpleVariableValue::resolve_as_list(RefPtr<Shell> shell)
 {
+    if (!shell)
+        return {};
+
     if (auto value = resolve_without_cast(shell); value != this)
         return value->resolve_as_list(shell);
 
@@ -2341,6 +2347,8 @@ Vector<String> SimpleVariableValue::resolve_as_list(RefPtr<Shell> shell)
 
 NonnullRefPtr<Value> SimpleVariableValue::resolve_without_cast(RefPtr<Shell> shell)
 {
+    ASSERT(shell);
+
     if (auto value = shell->lookup_local_variable(m_name))
         return value.release_nonnull();
     return *this;
@@ -2352,6 +2360,9 @@ SpecialVariableValue::~SpecialVariableValue()
 
 Vector<String> SpecialVariableValue::resolve_as_list(RefPtr<Shell> shell)
 {
+    if (!shell)
+        return {};
+
     switch (m_name) {
     case '?':
         return { String::number(shell->last_return_code) };
@@ -2383,6 +2394,10 @@ Vector<String> TildeValue::resolve_as_list(RefPtr<Shell> shell)
     StringBuilder builder;
     builder.append("~");
     builder.append(m_username);
+
+    if (!shell)
+        return { builder.to_string() };
+
     return { shell->expand_tilde(builder.to_string()) };
 }
 

--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -757,6 +757,31 @@ private:
     RefPtr<Node> m_right;
 };
 
+struct MatchEntry {
+    NonnullRefPtrVector<Node> options;
+    Vector<Position> pipe_positions;
+    RefPtr<Node> body;
+};
+
+class MatchExpr final : public Node {
+public:
+    MatchExpr(Position, RefPtr<Node> expr, String name, Optional<Position> as_position, Vector<MatchEntry> entries);
+    virtual ~MatchExpr();
+
+private:
+    virtual void dump(int level) const override;
+    virtual RefPtr<Value> run(RefPtr<Shell>) override;
+    virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
+    virtual HitTestResult hit_test_position(size_t) override;
+    virtual String class_name() const override { return "MatchExpr"; }
+    virtual bool would_execute() const override { return true; }
+
+    RefPtr<Node> m_matched_expr;
+    String m_expr_name;
+    Optional<Position> m_as_position;
+    Vector<MatchEntry> m_entries;
+};
+
 class Or final : public Node {
 public:
     Or(Position, RefPtr<Node>, RefPtr<Node>);

--- a/Shell/Parser.cpp
+++ b/Shell/Parser.cpp
@@ -58,12 +58,16 @@ bool Parser::expect(char ch)
 
 bool Parser::expect(const StringView& expected)
 {
+    auto offset_at_start = m_offset;
+
     if (expected.length() + m_offset > m_input.length())
         return false;
 
     for (size_t i = 0; i < expected.length(); ++i) {
-        if (peek() != expected[i])
+        if (peek() != expected[i]) {
+            m_offset = offset_at_start;
             return false;
+        }
 
         consume();
     }

--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -55,6 +55,9 @@ private:
     RefPtr<AST::Node> parse_for_loop();
     RefPtr<AST::Node> parse_if_expr();
     RefPtr<AST::Node> parse_subshell();
+    RefPtr<AST::Node> parse_match_expr();
+    AST::MatchEntry parse_match_entry();
+    RefPtr<AST::Node> parse_match_pattern();
     RefPtr<AST::Node> parse_redirection();
     RefPtr<AST::Node> parse_list_expression();
     RefPtr<AST::Node> parse_expression();
@@ -135,6 +138,7 @@ pipe_sequence :: command '|' pipe_sequence
 control_structure :: for_expr
                    | if_expr
                    | subshell
+                   | match_expr
 
 for_expr :: 'for' ws+ (identifier ' '+ 'in' ws*)? expression ws+ '{' toplevel '}'
 
@@ -144,6 +148,12 @@ else_clause :: else '{' toplevel '}'
              | else if_expr
 
 subshell :: '{' toplevel '}'
+
+match_expr :: 'match' ws+ expression ws* ('as' ws+ identifier)? '{' match_entry* '}'
+
+match_entry :: match_pattern ws* '{' toplevel '}'
+
+match_pattern :: expression (ws* '|' ws* expression)*
 
 command :: redirection command
          | list_expression command?

--- a/Shell/Tests/match.sh
+++ b/Shell/Tests/match.sh
@@ -1,0 +1,53 @@
+#!/bin/Shell
+
+result=no
+match hello {
+    he* { result=yes }
+    * { result=fail }
+};
+
+test "$result" = yes || echo invalid result $result for normal string match, single option && exit 1
+
+result=no
+match hello {
+    he* | f* { result=yes }
+    * { result=fail }
+};
+
+test "$result" = yes || echo invalid result $result for normal string match, multiple options && exit 1
+
+result=no
+match (well hello friends) {
+    (* *) { result=fail }
+    (* * *) { result=yes }
+    * { result=fail }
+};
+
+test "$result" = yes || echo invalid result $result for list match && exit 1
+
+result=no
+match yes as v {
+    () { result=fail }
+    (*) { result=yes }
+    * { result=$v }
+};
+
+test "$result" = yes || echo invalid result $result for match with name && exit 1
+
+result=no
+# $(...) is a list, $(echo) should be an empty list, not an empty string
+match $(echo) {
+    * { result=fail }
+    () { result=yes }
+};
+
+test "$result" = yes || echo invalid result $result for list subst match && exit 1
+
+result=no
+# "$(...)" is a string, "$(echo)" should be an empty string, not an empty list
+match "$(echo)" {
+    * { result=yes }
+    () { result=fail }
+};
+
+test "$result" = yes || echo invalid result $result for string subst match && exit 1


### PR DESCRIPTION
This PR adds an equivalent to the sh 'case' construct, except it's
much more pleasing to look at and write:
```sh
match "$something" {
    p1 { echo "p1!" }
    p2 { echo "p2!" }
    *  { echo "string catch-all!" }
}
```
is the equivalent of:
```sh
case $something in
    p1)
        echo "p1!"
        ;;
    p2)
        echo "p2!"
        ;;
    *)
        echo "catch-all!"
        ;;
esac
```

Since our shell does not treat lists as strings, matching lists is also
possible:

```sh
match (1foo 2foo foo3) {
    (?foo 2* *) { echo wowzers! }
    (* * *) { echo 3-element list catch-all }
}
```

~(draft until I write a manpage entry for it)~