### PR TITLE
Make OutputMemoryStream write to static buffers only.

### DIFF
--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -53,7 +53,6 @@ class InputMemoryStream;
 class DuplexMemoryStream;
 class OutputStream;
 class InputBitStream;
-class OutputMemoryStream;
 
 template<size_t Capacity>
 class CircularDuplexStream;
@@ -154,7 +153,6 @@ using AK::LogStream;
 using AK::NonnullOwnPtr;
 using AK::NonnullRefPtr;
 using AK::Optional;
-using AK::OutputMemoryStream;
 using AK::OutputStream;
 using AK::OwnPtr;
 using AK::ReadonlyBytes;

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -53,6 +53,7 @@ class InputMemoryStream;
 class DuplexMemoryStream;
 class OutputStream;
 class InputBitStream;
+class OutputMemoryStream;
 
 template<size_t Capacity>
 class CircularDuplexStream;
@@ -153,6 +154,7 @@ using AK::LogStream;
 using AK::NonnullOwnPtr;
 using AK::NonnullRefPtr;
 using AK::Optional;
+using AK::OutputMemoryStream;
 using AK::OutputStream;
 using AK::OwnPtr;
 using AK::ReadonlyBytes;

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -185,7 +185,7 @@ public:
 
     Optional<size_t> offset_of(ReadonlyBytes value) const
     {
-        if (value.size() > remaining())
+        if (value.size() > size())
             return {};
 
         // First, find which chunk we're in.
@@ -288,7 +288,7 @@ public:
 
     ByteBuffer copy_into_contiguous_buffer() const
     {
-        auto buffer = ByteBuffer::create_uninitialized(remaining());
+        auto buffer = ByteBuffer::create_uninitialized(size());
 
         const auto nread = read_without_consuming(buffer);
         ASSERT(nread == buffer.size());
@@ -299,7 +299,7 @@ public:
     size_t roffset() const { return m_read_offset; }
     size_t woffset() const { return m_write_offset; }
 
-    size_t remaining() const { return m_write_offset - m_read_offset; }
+    size_t size() const { return m_write_offset - m_read_offset; }
 
 private:
     void try_discard_chunks()
@@ -316,24 +316,8 @@ private:
     size_t m_base_offset { 0 };
 };
 
-class OutputMemoryStream final : public OutputStream {
-public:
-    size_t write(ReadonlyBytes bytes) override { return m_stream.write(bytes); }
-    bool write_or_error(ReadonlyBytes bytes) override { return m_stream.write_or_error(bytes); }
-
-    ByteBuffer copy_into_contiguous_buffer() const { return m_stream.copy_into_contiguous_buffer(); }
-
-    Optional<size_t> offset_of(ReadonlyBytes value) const { return m_stream.offset_of(value); }
-
-    size_t size() const { return m_stream.woffset(); }
-
-private:
-    DuplexMemoryStream m_stream;
-};
-
 }
 
 using AK::DuplexMemoryStream;
 using AK::InputMemoryStream;
 using AK::InputStream;
-using AK::OutputMemoryStream;

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -186,6 +186,13 @@ public:
         return true;
     }
 
+    size_t fill_to_end(u8 value)
+    {
+        const auto nwritten = m_bytes.slice(m_offset).fill(value);
+        m_offset += nwritten;
+        return nwritten;
+    }
+
     ReadonlyBytes bytes() const { return { data(), size() }; }
     Bytes bytes() { return { data(), size() }; }
 

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -165,11 +165,12 @@ public:
         return TypedTransfer<typename RemoveConst<T>::Type>::copy(other.data(), data(), count);
     }
 
-    ALWAYS_INLINE void fill(const T& value)
+    ALWAYS_INLINE size_t fill(const T& value)
     {
-        for (size_t idx = 0; idx < size(); ++idx) {
+        for (size_t idx = 0; idx < size(); ++idx)
             data()[idx] = value;
-        }
+
+        return size();
     }
 
     bool contains_slow(const T& value) const

--- a/AK/Tests/TestMemoryStream.cpp
+++ b/AK/Tests/TestMemoryStream.cpp
@@ -129,17 +129,17 @@ TEST_CASE(duplex_large_buffer)
 
     Array<u8, 1024> one_kibibyte;
 
-    EXPECT_EQ(stream.remaining(), 0ul);
+    EXPECT_EQ(stream.size(), 0ul);
 
     for (size_t idx = 0; idx < 256; ++idx)
         stream << one_kibibyte;
 
-    EXPECT_EQ(stream.remaining(), 256 * 1024ul);
+    EXPECT_EQ(stream.size(), 256 * 1024ul);
 
     for (size_t idx = 0; idx < 128; ++idx)
         stream >> one_kibibyte;
 
-    EXPECT_EQ(stream.remaining(), 128 * 1024ul);
+    EXPECT_EQ(stream.size(), 128 * 1024ul);
 
     for (size_t idx = 0; idx < 128; ++idx)
         stream >> one_kibibyte;
@@ -164,7 +164,7 @@ TEST_CASE(write_endian_values)
 {
     const u8 expected[] { 4, 3, 2, 1, 1, 2, 3, 4 };
 
-    OutputMemoryStream stream;
+    DuplexMemoryStream stream;
     stream << LittleEndian<u32> { 0x01020304 } << BigEndian<u32> { 0x01020304 };
 
     EXPECT_EQ(stream.size(), 8u);

--- a/AK/Tests/TestMemoryStream.cpp
+++ b/AK/Tests/TestMemoryStream.cpp
@@ -171,4 +171,27 @@ TEST_CASE(write_endian_values)
     EXPECT(compare({ expected, sizeof(expected) }, stream.copy_into_contiguous_buffer()));
 }
 
+TEST_CASE(new_output_memory_stream)
+{
+    Array<u8, 16> buffer;
+    OutputMemoryStream stream { buffer };
+
+    EXPECT_EQ(stream.size(), 0u);
+    EXPECT_EQ(stream.remaining(), 16u);
+
+    stream << LittleEndian<u16>(0x12'87);
+
+    EXPECT_EQ(stream.size(), 2u);
+    EXPECT_EQ(stream.remaining(), 14u);
+
+    stream << buffer;
+
+    EXPECT(stream.handle_recoverable_error());
+    EXPECT_EQ(stream.size(), 2u);
+    EXPECT_EQ(stream.remaining(), 14u);
+
+    EXPECT_EQ(stream.bytes().data(), buffer.data());
+    EXPECT_EQ(stream.bytes().size(), 2u);
+}
+
 TEST_MAIN(MemoryStream)

--- a/Kernel/UserOrKernelBuffer.h
+++ b/Kernel/UserOrKernelBuffer.h
@@ -80,10 +80,19 @@ public:
     {
         return write(src, 0, len);
     }
+    [[nodiscard]] bool write(ReadonlyBytes bytes)
+    {
+        return write(bytes.data(), bytes.size());
+    }
+
     [[nodiscard]] bool read(void* dest, size_t offset, size_t len) const;
     [[nodiscard]] bool read(void* dest, size_t len) const
     {
         return read(dest, 0, len);
+    }
+    [[nodiscard]] bool read(Bytes bytes) const
+    {
+        return read(bytes.data(), bytes.size());
     }
 
     [[nodiscard]] bool memset(int value, size_t offset, size_t len);

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -307,7 +307,7 @@ Optional<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
 {
     InputMemoryStream memory_stream { bytes };
     DeflateDecompressor deflate_stream { memory_stream };
-    OutputMemoryStream output_stream;
+    DuplexMemoryStream output_stream;
 
     u8 buffer[4096];
     while (!deflate_stream.has_any_error() && !deflate_stream.unreliable_eof()) {

--- a/Libraries/LibCompress/Gzip.cpp
+++ b/Libraries/LibCompress/Gzip.cpp
@@ -164,7 +164,7 @@ Optional<ByteBuffer> GzipDecompressor::decompress_all(ReadonlyBytes bytes)
 {
     InputMemoryStream memory_stream { bytes };
     GzipDecompressor gzip_stream { memory_stream };
-    OutputMemoryStream output_stream;
+    DuplexMemoryStream output_stream;
 
     u8 buffer[4096];
     while (!gzip_stream.has_any_error() && !gzip_stream.unreliable_eof()) {

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -1107,7 +1107,7 @@ void Execute::for_each_entry(RefPtr<Shell> shell, Function<IterationDecision(Ref
             } while (action == Continue);
 
             if (!stream.eof()) {
-                auto entry = ByteBuffer::create_uninitialized(stream.remaining());
+                auto entry = ByteBuffer::create_uninitialized(stream.size());
                 auto rc = stream.read_or_error(entry);
                 ASSERT(rc);
                 callback(create<StringValue>(String::copy(entry)));


### PR DESCRIPTION
I explained my thoughts in the commit message of bc5faddc6c3904ac59f407ac19bb43cde9dda4ab.

My plan was to remove `BufferStream` entirely with this pull request, but I found an issue in `AK/FileStream.h` which I have to fix before I can do this. I'll create another pull request when I get to it.
