### PR TITLE
LibGUI: Increase slider acceleration with control

### DIFF
--- a/Libraries/LibGUI/Slider.cpp
+++ b/Libraries/LibGUI/Slider.cpp
@@ -161,7 +161,7 @@ void Slider::mousewheel_event(MouseEvent& event)
 {
     auto acceleration_modifier = m_step;
 
-    if(event.modifiers() == KeyModifier::Mod_Ctrl && knob_size_mode() == KnobSizeMode::Fixed)
+    if (event.modifiers() == KeyModifier::Mod_Ctrl && knob_size_mode() == KnobSizeMode::Fixed)
         acceleration_modifier *= 6;
 
     if (orientation() == Orientation::Horizontal)

--- a/Libraries/LibGUI/Slider.cpp
+++ b/Libraries/LibGUI/Slider.cpp
@@ -159,10 +159,15 @@ void Slider::mouseup_event(MouseEvent& event)
 
 void Slider::mousewheel_event(MouseEvent& event)
 {
+    auto acceleration_modifier = m_step;
+
+    if(event.modifiers() == KeyModifier::Mod_Ctrl && knob_size_mode() == KnobSizeMode::Fixed)
+        acceleration_modifier *= 6;
+
     if (orientation() == Orientation::Horizontal)
-        set_value(value() - event.wheel_delta() * m_step);
+        set_value(value() - event.wheel_delta() * acceleration_modifier);
     else
-        set_value(value() + event.wheel_delta() * m_step);
+        set_value(value() + event.wheel_delta() * acceleration_modifier);
 
     Widget::mousewheel_event(event);
 }


### PR DESCRIPTION
When holding control and scrolling on a slider widget
the scrolling acceleration gets increased.

This can make it faster to get to the knob location
you want to get to :^)

---

I am not too sure about what modifier to use, control
felt natural though
