### PR TITLE
Kernel: Fix thread donation hanging the system

### DIFF
--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -59,6 +59,7 @@ public:
     static bool pick_next();
     static timeval time_since_boot();
     static bool yield();
+    static bool donate_to_and_switch(Thread*, const char* reason);
     static bool donate_to(Thread*, const char* reason);
     static bool context_switch(Thread*);
     static void enter_current(Thread& prev_thread);

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -857,7 +857,11 @@ String Thread::backtrace_impl()
     Vector<RecognizedSymbol, 128> recognized_symbols;
 
     auto& process = const_cast<Process&>(this->process());
-    auto elf_bundle = process.elf_bundle();
+    OwnPtr<Process::ELFBundle> elf_bundle;
+    if (!Processor::current().in_irq()) {
+        // If we're handling IRQs we can't really safely symbolicate
+        elf_bundle = process.elf_bundle();
+    }
     ProcessPagingScope paging_scope(process);
 
     // To prevent a context switch involving this thread, which may happen


### PR DESCRIPTION
Fixes two flaws in the thread donation logic: Scheduler::donate_to
would never really donate, but just trigger a deferred yield. And
that deferred yield never actually donated to the beneficiary.

So, when we can't immediately donate, we need to save the beneficiary
and use this information as soon as we can perform the deferred
context switch.

Fixes #3495