### PR TITLE
Build: Preserve hard/symbolic links when building root fs

### DIFF
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -25,8 +25,8 @@ fi
 umask 0022
 
 printf "installing base system... "
-cp -R "$SERENITY_ROOT"/Base/* mnt/
-cp -R Root/* mnt/
+cp -PdR "$SERENITY_ROOT"/Base/* mnt/
+cp -PdR Root/* mnt/
 # If umask was 027 or similar when the repo was cloned,
 # file permissions in Base/ are too restrictive. Restore
 # the permissions needed in the image.


### PR DESCRIPTION
This fixes the issue where there would not be enough space to copy
things when at least the git port and the gcc port are installed.

An alternative to this would be counting hard link sizes towards the disk image size as well, i.e.
```diff
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -19,7 +19,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
 fi

 disk_usage() {
-    du -sm "$1" | cut -f1
+    du -slm "$1" | cut -f1
 }

 DISK_SIZE=$(($(disk_usage "$SERENITY_ROOT/Base") + $(disk_usage Root) + 100))
```

But unless we don't support hard links as created by `cp`, I don't think increasing the disk size for no particular reason is a sensible thing to do :)