### PR TITLE
Kernel: Fix kernel crash in get_dir_entries when buffer was too small.

### DIFF
--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -191,7 +191,7 @@ ssize_t FileDescription::get_dir_entries(UserOrKernelBuffer& buffer, ssize_t siz
     if (result.is_error())
         return result;
 
-    if (static_cast<size_t>(size) < stream.size())
+    if (stream.handle_recoverable_error())
         return -EINVAL;
 
     if (!buffer.write(stream.bytes()))


### PR DESCRIPTION
Before e06362de9487806df92cf2360a42d3eed905b6bf this was a sneaky buffer overflow. `BufferStream` did not do range checking and continued to write past the allocated buffer (the size of which was controlled by the user.)

The issue surfaced after my changes because `OutputMemoryStream` does range checking.

Not sure how exploitable that bug was, directory entries are somewhat controllable by the user but the buffer was on the heap, so exploiting that should be tough.

Funny is that there was actually a check for this and the syscall would return `-EINVAL` but this check happened **after** overflowing the buffer.

Fixes #3502

---

However, there still is an issue with this, in `dirent.cpp`:

https://github.com/SerenityOS/serenity/blob/9a05e69b82f75962beda3ccb42e6746ccf590ee0/Libraries/LibC/dirent.cpp#L106-L108

I don't know enough about ext2 to fix this issue, but that size calculation seems to be wrong.
