### PR TITLE
 LibIPC: Disable Notifier before closing socket 

### DIFF
--- a/Libraries/LibCore/Notifier.cpp
+++ b/Libraries/LibCore/Notifier.cpp
@@ -46,10 +46,20 @@ Notifier::~Notifier()
 
 void Notifier::set_enabled(bool enabled)
 {
+    if (m_fd < 0)
+        return;
     if (enabled)
         Core::EventLoop::register_notifier({}, *this);
     else
         Core::EventLoop::unregister_notifier({}, *this);
+}
+
+void Notifier::close()
+{
+    if (m_fd < 0)
+        return;
+    set_enabled(false);
+    m_fd = -1;
 }
 
 void Notifier::event(Core::Event& event)

--- a/Libraries/LibCore/Notifier.h
+++ b/Libraries/LibCore/Notifier.h
@@ -48,6 +48,8 @@ public:
     Function<void()> on_ready_to_read;
     Function<void()> on_ready_to_write;
 
+    void close();
+
     int fd() const { return m_fd; }
     unsigned event_mask() const { return m_event_mask; }
     void set_event_mask(unsigned event_mask) { m_event_mask = event_mask; }

--- a/Libraries/LibIPC/Connection.h
+++ b/Libraries/LibIPC/Connection.h
@@ -115,6 +115,7 @@ public:
 
     void shutdown()
     {
+        m_notifier->close();
         m_socket->close();
         die();
     }


### PR DESCRIPTION
Because we're closing a file descriptor, we need to disable any
Notifier that is using it so that the EventLoop does not use invalid
file descriptors.

Fixes #3508