### PR TITLE
Implement most of recvmsg(), sendmsg(), add SO_TIMESTAMP, use it in ntpquery

### DIFF
--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -490,10 +490,10 @@ int Emulator::virt$setsockopt(FlatPtr params_addr)
     Syscall::SC_setsockopt_params params;
     mmu().copy_from_vm(&params, params_addr, sizeof(params));
 
-    if (params.option == SO_RCVTIMEO) {
+    if (params.option == SO_RCVTIMEO || params.option == SO_TIMESTAMP) {
         auto host_value_buffer = ByteBuffer::create_zeroed(params.value_size);
         mmu().copy_from_vm(host_value_buffer.data(), (FlatPtr)params.value, params.value_size);
-        int rc = setsockopt(params.sockfd, params.level, SO_RCVTIMEO, host_value_buffer.data(), host_value_buffer.size());
+        int rc = setsockopt(params.sockfd, params.level, params.option, host_value_buffer.data(), host_value_buffer.size());
         if (rc < 0)
             return -errno;
         return rc;

--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -131,8 +131,8 @@ private:
     int virt$select(FlatPtr);
     int virt$accept(int sockfd, FlatPtr address, FlatPtr address_length);
     int virt$bind(int sockfd, FlatPtr address, socklen_t address_length);
-    int virt$recvfrom(FlatPtr);
-    int virt$sendto(FlatPtr);
+    int virt$recvmsg(int sockfd, FlatPtr msg_addr, int flags);
+    int virt$sendmsg(int sockfd, FlatPtr msg_addr, int flags);
     int virt$connect(int sockfd, FlatPtr address, socklen_t address_size);
     void virt$exit(int);
     ssize_t virt$getrandom(FlatPtr buffer, size_t buffer_size, unsigned int flags);

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -130,8 +130,8 @@ namespace Kernel {
     S(fchmod)                 \
     S(symlink)                \
     S(shbuf_seal)             \
-    S(sendto)                 \
-    S(recvfrom)               \
+    S(sendmsg)                \
+    S(recvmsg)                \
     S(getsockopt)             \
     S(setsockopt)             \
     S(create_thread)          \
@@ -282,22 +282,6 @@ struct SC_clock_nanosleep_params {
     int flags;
     const struct timespec* requested_sleep;
     struct timespec* remaining_sleep;
-};
-
-struct SC_sendto_params {
-    int sockfd;
-    ImmutableBufferArgument<void, size_t> data;
-    int flags;
-    const sockaddr* addr;
-    socklen_t addr_length;
-};
-
-struct SC_recvfrom_params {
-    int sockfd;
-    MutableBufferArgument<void, size_t> buffer;
-    int flags;
-    sockaddr* addr;
-    socklen_t* addr_length;
 };
 
 struct SC_getsockopt_params {

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -59,13 +59,13 @@ public:
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual KResultOr<size_t> sendto(FileDescription&, const UserOrKernelBuffer&, size_t, int, Userspace<const sockaddr*>, socklen_t) override;
-    virtual KResultOr<size_t> recvfrom(FileDescription&, UserOrKernelBuffer&, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>) override;
+    virtual KResultOr<size_t> recvfrom(FileDescription&, UserOrKernelBuffer&, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>, timeval&) override;
     virtual KResult setsockopt(int level, int option, Userspace<const void*>, socklen_t) override;
     virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>) override;
 
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
 
-    bool did_receive(const IPv4Address& peer_address, u16 peer_port, KBuffer&&);
+    bool did_receive(const IPv4Address& peer_address, u16 peer_port, KBuffer&&, const timeval&);
 
     const IPv4Address& local_address() const { return m_local_address; }
     u16 local_port() const { return m_local_port; }
@@ -111,7 +111,7 @@ private:
     virtual bool is_ipv4() const override { return true; }
 
     KResultOr<size_t> receive_byte_buffered(FileDescription&, UserOrKernelBuffer& buffer, size_t buffer_length, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>);
-    KResultOr<size_t> receive_packet_buffered(FileDescription&, UserOrKernelBuffer& buffer, size_t buffer_length, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>);
+    KResultOr<size_t> receive_packet_buffered(FileDescription&, UserOrKernelBuffer& buffer, size_t buffer_length, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>, timeval&);
 
     IPv4Address m_local_address;
     IPv4Address m_peer_address;
@@ -119,6 +119,7 @@ private:
     struct ReceivedPacket {
         IPv4Address peer_address;
         u16 peer_port;
+        timeval timestamp;
         Optional<KBuffer> data;
     };
 

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -298,7 +298,7 @@ DoubleBuffer& LocalSocket::send_buffer_for(FileDescription& description)
     ASSERT_NOT_REACHED();
 }
 
-KResultOr<size_t> LocalSocket::recvfrom(FileDescription& description, UserOrKernelBuffer& buffer, size_t buffer_size, int, Userspace<sockaddr*>, Userspace<socklen_t*>)
+KResultOr<size_t> LocalSocket::recvfrom(FileDescription& description, UserOrKernelBuffer& buffer, size_t buffer_size, int, Userspace<sockaddr*>, Userspace<socklen_t*>, timeval&)
 {
     auto& buffer_for_me = receive_buffer_for(description);
     if (!description.is_blocking()) {

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -61,7 +61,7 @@ public:
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual KResultOr<size_t> sendto(FileDescription&, const UserOrKernelBuffer&, size_t, int, Userspace<const sockaddr*>, socklen_t) override;
-    virtual KResultOr<size_t> recvfrom(FileDescription&, UserOrKernelBuffer&, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>) override;
+    virtual KResultOr<size_t> recvfrom(FileDescription&, UserOrKernelBuffer&, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>, timeval&) override;
     virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>) override;
     virtual KResult chown(FileDescription&, uid_t, gid_t) override;
     virtual KResult chmod(FileDescription&, mode_t) override;

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -67,7 +67,7 @@ public:
     int send_ipv4(const MACAddress&, const IPv4Address&, IPv4Protocol, const UserOrKernelBuffer& payload, size_t payload_size, u8 ttl);
     int send_ipv4_fragmented(const MACAddress&, const IPv4Address&, IPv4Protocol, const UserOrKernelBuffer& payload, size_t payload_size, u8 ttl);
 
-    size_t dequeue_packet(u8* buffer, size_t buffer_size);
+    size_t dequeue_packet(u8* buffer, size_t buffer_size, timeval& packet_timestamp);
 
     bool has_queued_packets() const { return !m_packet_queue.is_empty(); }
 
@@ -93,7 +93,13 @@ private:
     IPv4Address m_ipv4_address;
     IPv4Address m_ipv4_netmask;
     IPv4Address m_ipv4_gateway;
-    SinglyLinkedList<KBuffer> m_packet_queue;
+
+    struct PacketWithTimestamp {
+        KBuffer packet;
+        timeval timestamp;
+    };
+
+    SinglyLinkedList<PacketWithTimestamp> m_packet_queue;
     SinglyLinkedList<KBuffer> m_unused_packet_buffers;
     size_t m_unused_packet_buffers_count { 0 };
     String m_name;

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -206,7 +206,8 @@ KResultOr<size_t> Socket::read(FileDescription& description, size_t, UserOrKerne
 {
     if (is_shut_down_for_reading())
         return 0;
-    return recvfrom(description, buffer, size, 0, {}, 0);
+    timeval tv;
+    return recvfrom(description, buffer, size, 0, {}, 0, tv);
 }
 
 KResultOr<size_t> Socket::write(FileDescription& description, size_t, const UserOrKernelBuffer& data, size_t size)

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -135,6 +135,8 @@ public:
     bool has_send_timeout() const { return m_send_timeout.tv_sec || m_send_timeout.tv_usec; }
     const timeval& send_timeout() const { return m_send_timeout; }
 
+    bool wants_timestamp() const { return m_timestamp; }
+
 protected:
     Socket(int domain, int type, int protocol);
 
@@ -172,6 +174,7 @@ private:
 
     timeval m_receive_timeout { 0, 0 };
     timeval m_send_timeout { 0, 0 };
+    int m_timestamp { 0 };
 
     NonnullRefPtrVector<Socket> m_pending;
 };

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -108,7 +108,7 @@ public:
     virtual void attach(FileDescription&) = 0;
     virtual void detach(FileDescription&) = 0;
     virtual KResultOr<size_t> sendto(FileDescription&, const UserOrKernelBuffer&, size_t, int flags, Userspace<const sockaddr*>, socklen_t) = 0;
-    virtual KResultOr<size_t> recvfrom(FileDescription&, UserOrKernelBuffer&, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>) = 0;
+    virtual KResultOr<size_t> recvfrom(FileDescription&, UserOrKernelBuffer&, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>, timeval&) = 0;
 
     virtual KResult setsockopt(int level, int option, Userspace<const void*>, socklen_t);
     virtual KResult getsockopt(FileDescription&, int level, int option, Userspace<void*>, Userspace<socklen_t*>);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -290,8 +290,8 @@ public:
     int sys$accept(int sockfd, Userspace<sockaddr*>, Userspace<socklen_t*>);
     int sys$connect(int sockfd, Userspace<const sockaddr*>, socklen_t);
     int sys$shutdown(int sockfd, int how);
-    ssize_t sys$sendto(Userspace<const Syscall::SC_sendto_params*>);
-    ssize_t sys$recvfrom(Userspace<const Syscall::SC_recvfrom_params*>);
+    ssize_t sys$sendmsg(int sockfd, Userspace<const struct msghdr*>, int flags);
+    ssize_t sys$recvmsg(int sockfd, Userspace<struct msghdr*>, int flags);
     int sys$getsockopt(Userspace<const Syscall::SC_getsockopt_params*>);
     int sys$setsockopt(Userspace<const Syscall::SC_setsockopt_params*>);
     int sys$getsockname(Userspace<const Syscall::SC_getsockname_params*>);

--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -77,6 +77,12 @@ template<typename T>
 }
 
 template<typename T>
+[[nodiscard]] inline bool copy_from_user(T* dest, Userspace<T*> src)
+{
+    return copy_from_user(dest, src.unsafe_userspace_ptr(), sizeof(T));
+}
+
+template<typename T>
 [[nodiscard]] inline bool copy_to_user(Userspace<T*> dest, const T* src)
 {
     return copy_to_user(dest.unsafe_userspace_ptr(), src, sizeof(T));

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -249,7 +249,8 @@ ssize_t Process::sys$recvmsg(int sockfd, Userspace<struct msghdr*> user_msg, int
     auto data_buffer = UserOrKernelBuffer::for_user_buffer((u8*)iovs[0].iov_base, iovs[0].iov_len);
     if (!data_buffer.has_value())
         return -EFAULT;
-    auto result = socket.recvfrom(*description, data_buffer.value(), iovs[0].iov_len, flags, user_addr, user_addr_length);
+    timeval timestamp = { 0, 0 };
+    auto result = socket.recvfrom(*description, data_buffer.value(), iovs[0].iov_len, flags, user_addr, user_addr_length, timestamp);
     if (flags & MSG_DONTWAIT)
         description->set_blocking(original_blocking);
 

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -458,6 +458,7 @@ struct pollfd {
 #define SHUT_RDWR 3
 
 #define MSG_TRUNC 0x1
+#define MSG_CTRUNC 0x2
 #define MSG_DONTWAIT 0x40
 
 #define SOL_SOCKET 1
@@ -471,6 +472,11 @@ enum {
     SO_REUSEADDR,
     SO_BINDTODEVICE,
     SO_KEEPALIVE,
+    SO_TIMESTAMP,
+};
+
+enum {
+    SCM_TIMESTAMP,
 };
 
 #define IPPROTO_IP 0
@@ -554,6 +560,12 @@ struct utsname {
 struct iovec {
     void* iov_base;
     size_t iov_len;
+};
+
+struct cmsghdr {
+    socklen_t cmsg_len;
+    int cmsg_level;
+    int cmsg_type;
 };
 
 struct msghdr {

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -457,6 +457,7 @@ struct pollfd {
 #define SHUT_WR 2
 #define SHUT_RDWR 3
 
+#define MSG_TRUNC 0x1
 #define MSG_DONTWAIT 0x40
 
 #define SOL_SOCKET 1
@@ -550,6 +551,16 @@ struct utsname {
 struct iovec {
     void* iov_base;
     size_t iov_len;
+};
+
+struct msghdr {
+    void* msg_name;
+    socklen_t msg_namelen;
+    struct iovec* msg_iov;
+    int msg_iovlen;
+    void* msg_control;
+    socklen_t msg_controllen;
+    int msg_flags;
 };
 
 struct sched_param {

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -462,13 +462,16 @@ struct pollfd {
 
 #define SOL_SOCKET 1
 
-#define SO_RCVTIMEO 1
-#define SO_SNDTIMEO 2
-#define SO_ERROR 4
-#define SO_PEERCRED 5
-#define SO_REUSEADDR 6
-#define SO_BINDTODEVICE 7
-#define SO_KEEPALIVE 9
+enum {
+    SO_RCVTIMEO,
+    SO_SNDTIMEO,
+    SO_TYPE,
+    SO_ERROR,
+    SO_PEERCRED,
+    SO_REUSEADDR,
+    SO_BINDTODEVICE,
+    SO_KEEPALIVE,
+};
 
 #define IPPROTO_IP 0
 #define IPPROTO_ICMP 1

--- a/Libraries/LibC/sys/socket.h
+++ b/Libraries/LibC/sys/socket.h
@@ -90,14 +90,24 @@ struct ucred {
 #define SOL_SOCKET 1
 #define SOMAXCONN 128
 
-#define SO_RCVTIMEO 1
-#define SO_SNDTIMEO 2
-#define SO_TYPE 3
-#define SO_ERROR 4
-#define SO_PEERCRED 5
-#define SO_REUSEADDR 6
-#define SO_BINDTODEVICE 7
-#define SO_KEEPALIVE 9
+enum {
+    SO_RCVTIMEO,
+    SO_SNDTIMEO,
+    SO_TYPE,
+    SO_ERROR,
+    SO_PEERCRED,
+    SO_REUSEADDR,
+    SO_BINDTODEVICE,
+    SO_KEEPALIVE,
+};
+#define SO_RCVTIMEO SO_RCVTIMEO
+#define SO_SNDTIMEO SO_SNDTIMEO
+#define SO_TYPE SO_TYPE
+#define SO_ERROR SO_ERROR
+#define SO_PEERCRED SO_PEERCRED
+#define SO_REUSEADDR SO_REUSEADDR
+#define SO_BINDTODEVICE SO_BINDTODEVICE
+#define SO_KEEPALIVE SO_KEEPALIVE
 
 struct sockaddr_storage {
     union {

--- a/Libraries/LibC/sys/socket.h
+++ b/Libraries/LibC/sys/socket.h
@@ -61,9 +61,20 @@ __BEGIN_DECLS
 #define IPPROTO_TCP 6
 #define IPPROTO_UDP 17
 
+#define MSG_TRUNC 0x1
 #define MSG_DONTWAIT 0x40
 
 typedef uint16_t sa_family_t;
+
+struct msghdr {
+    void* msg_name;
+    socklen_t msg_namelen;
+    struct iovec* msg_iov;
+    int msg_iovlen;
+    void* msg_control;
+    socklen_t msg_controllen;
+    int msg_flags;
+};
 
 struct sockaddr {
     sa_family_t sa_family;
@@ -102,8 +113,10 @@ int accept(int sockfd, struct sockaddr*, socklen_t*);
 int connect(int sockfd, const struct sockaddr*, socklen_t);
 int shutdown(int sockfd, int how);
 ssize_t send(int sockfd, const void*, size_t, int flags);
+ssize_t sendmsg(int sockfd, const struct msghdr*, int flags);
 ssize_t sendto(int sockfd, const void*, size_t, int flags, const struct sockaddr*, socklen_t);
 ssize_t recv(int sockfd, void*, size_t, int flags);
+ssize_t recvmsg(int sockfd, struct msghdr*, int flags);
 ssize_t recvfrom(int sockfd, void*, size_t, int flags, struct sockaddr*, socklen_t*);
 int getsockopt(int sockfd, int level, int option, void*, socklen_t*);
 int setsockopt(int sockfd, int level, int option, const void*, socklen_t);


### PR DESCRIPTION
I went with SO_TIMESTAMP instead of SIOCGSTAMP since it seems more common (the BSDs have SO_TIMESTAMP; SIOCGSTAMP looks like it's maybe linux-only), and if a socket is used for more than one recv() it needs fewer syscalls too.

sendmsg() and recvmsg() aren't the most easy-on-the-eyes APIs, but they're POSIX, so it seems good to grow support for them. I didn't implement full iovec support since I don't need that part at the moment, and the existing iovec stuff in the kernel is a bit bolted on. Maybe I'll clean it up and add readv in the future. That's also why the Socket-level in-kernel api is still recvfrom() / sendto().

The in-kernel network adapter now records timestamps for all incoming packets. I believe that matches Linux, and it's arguably useful for adding in-kernel latency metrics later on.

--

I'm still somewhat new to all the copy_to_user() / copy_from_user() stuff both in kernel and in UserspaceEmulator, so it's probably worth having a closer look at those parts. Everything seems to work, but it's possible I'm doing overly roundabout things there.

This ended up being quite a lot of code for what feels like not much feature, but I suppose that's the nature of network code.