### PR TITLE
Allow executing binaries from PATH with env.

### DIFF
--- a/DevTools/UserspaceEmulator/main.cpp
+++ b/DevTools/UserspaceEmulator/main.cpp
@@ -30,7 +30,7 @@
 #include <AK/LogStream.h>
 #include <AK/MappedFile.h>
 #include <AK/StringBuilder.h>
-#include <LibCore/ArgsParser.h>
+#include <LibCore/DirIterator.h>
 #include <LibELF/Loader.h>
 #include <getopt.h>
 #include <pthread.h>
@@ -39,12 +39,11 @@
 int main(int argc, char** argv, char** env)
 {
     if (argc == 1) {
-        out() << "usage: UserspaceEmulator <command>";
+        out() << "Usage: UserspaceEmulator <command>";
         return 0;
     }
 
-    // FIXME: Allow specifying any command in $PATH instead of requiring a full executable path.
-    const char* executable_path = argv[1];
+    auto executable_path = Core::find_executable_in_path(argv[1]);
 
     MappedFile mapped_file(executable_path);
     if (!mapped_file.is_valid()) {

--- a/Libraries/LibCore/DirIterator.cpp
+++ b/Libraries/LibCore/DirIterator.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <LibCore/DirIterator.h>
+#include <AK/Vector.h>
 #include <errno.h>
 
 namespace Core {
@@ -96,6 +97,25 @@ String DirIterator::next_path()
 String DirIterator::next_full_path()
 {
     return String::format("%s/%s", m_path.characters(), next_path().characters());
+}
+
+String find_executable_in_path(String filename)
+{
+    if (filename.starts_with('/')) {
+        if (access(filename.characters(), X_OK) == 0)
+            return filename;
+
+        return {};
+    }
+
+    for (auto directory : StringView { getenv("PATH") }.split_view(':')) {
+        auto fullpath = String::format("%s/%s", directory, filename);
+
+        if (access(fullpath.characters(), X_OK) == 0)
+            return fullpath;
+    }
+
+    return {};
 }
 
 }

--- a/Libraries/LibCore/DirIterator.h
+++ b/Libraries/LibCore/DirIterator.h
@@ -60,4 +60,6 @@ private:
     bool advance_next();
 };
 
+String find_executable_in_path(String filename);
+
 }

--- a/Userland/which.cpp
+++ b/Userland/which.cpp
@@ -24,11 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/String.h>
-#include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/DirIterator.h>
 #include <stdio.h>
-#include <unistd.h>
 
 int main(int argc, char** argv)
 {
@@ -43,18 +41,12 @@ int main(int argc, char** argv)
     args_parser.add_positional_argument(filename, "Name of executable", "executable");
     args_parser.parse(argc, argv);
 
-    String path = getenv("PATH");
-    if (path.is_empty())
-        path = "/bin:/usr/bin";
-
-    auto parts = path.split(':');
-    for (auto& part : parts) {
-        auto candidate = String::format("%s/%s", part.characters(), filename);
-        if(access(candidate.characters(), X_OK) == 0) {
-            printf("%s\n", candidate.characters());
-            return 0;
-        }
+    auto fullpath = Core::find_executable_in_path(filename);
+    if (fullpath.is_null()) {
+        printf("no '%s' in path\n", filename);
+        return 1;
     }
 
-    return 1;
+    printf("%s\n", fullpath.characters());
+    return 0;
 }


### PR DESCRIPTION
Adds two new features to `/bin/env`:

 1. `env FOO=bar` sets the environment variable `FOO` to `bar` before doing anything else.

 2. `env foo` looks up `foo` in `PATH` and then executes it.

This is useful for shebangs:

~~~none
#!/bin/env Shell
echo "Hello, World"
~~~

(The following would not work because the interpreter is not looked up on the path:)

~~~none
#!Shell
echo "Hello, World"
~~~
