### PR TITLE
Kernel: Return ENOMEM in more places

### DIFF
--- a/Kernel/Devices/BXVGADevice.cpp
+++ b/Kernel/Devices/BXVGADevice.cpp
@@ -192,8 +192,9 @@ KResultOr<Region*> BXVGADevice::mmap(Process& process, FileDescription&, Virtual
         0,
         "BXVGA Framebuffer",
         prot);
+    if (!region)
+        return KResult(-ENOMEM);
     dbg() << "BXVGADevice: mmap with size " << region->size() << " at " << region->vaddr();
-    ASSERT(region);
     return region;
 }
 

--- a/Kernel/Devices/MBVGADevice.cpp
+++ b/Kernel/Devices/MBVGADevice.cpp
@@ -68,8 +68,9 @@ KResultOr<Region*> MBVGADevice::mmap(Process& process, FileDescription&, Virtual
         0,
         "MBVGA Framebuffer",
         prot);
+    if (!region)
+        return KResult(-ENOMEM);
     dbg() << "MBVGADevice: mmap with size " << region->size() << " at " << region->vaddr();
-    ASSERT(region);
     return region;
 }
 

--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -235,8 +235,12 @@ KResultOr<size_t> SB16::write(FileDescription&, size_t, const UserOrKernelBuffer
 {
     if (!m_dma_region) {
         auto page = MM.allocate_supervisor_physical_page();
+        if (!page)
+            return KResult(-ENOMEM);
         auto vmobject = AnonymousVMObject::create_with_physical_page(*page);
         m_dma_region = MM.allocate_kernel_region_with_vmobject(*vmobject, PAGE_SIZE, "SB16 DMA buffer", Region::Access::Write);
+        if (!m_dma_region)
+            return KResult(-ENOMEM);
     }
 
 #ifdef SB16_DEBUG
@@ -245,7 +249,7 @@ KResultOr<size_t> SB16::write(FileDescription&, size_t, const UserOrKernelBuffer
     ASSERT(length <= PAGE_SIZE);
     const int BLOCK_SIZE = 32 * 1024;
     if (length > BLOCK_SIZE) {
-        return -ENOSPC;
+        return KResult(-ENOSPC);
     }
 
     u8 mode = (u8)SampleFormat::Signed | (u8)SampleFormat::Stereo;

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -244,6 +244,10 @@ bool APIC::init_bsp()
     set_base(apic_base);
 
     m_apic_base = MM.allocate_kernel_region(apic_base.page_base(), PAGE_ROUND_UP(1), {}, Region::Access::Read | Region::Access::Write);
+    if (!m_apic_base) {
+        klog() << "APIC: Failed to allocate memory for APIC base";
+        return false;
+    }
 
     auto rsdp = ACPI::StaticParsing::find_rsdp();
     if (!rsdp.has_value()) {

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -79,7 +79,9 @@ int Process::sys$create_thread(void* (*entry)(void*), Userspace<const Syscall::S
     tss.cr3 = page_directory().cr3();
     tss.esp = (u32)user_stack_address;
 
-    thread->make_thread_specific_region({});
+    auto tsr_result = thread->make_thread_specific_region({});
+    if (tsr_result.is_error())
+        return tsr_result.error();
     thread->set_state(Thread::State::Runnable);
     return thread->tid().value();
 }

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -433,9 +433,9 @@ public:
     void set_default_signal_dispositions();
     bool push_value_on_stack(FlatPtr);
 
-    u32 make_userspace_stack_for_main_thread(Vector<String> arguments, Vector<String> environment, Vector<AuxiliaryValue>);
+    KResultOr<u32> make_userspace_stack_for_main_thread(Vector<String> arguments, Vector<String> environment, Vector<AuxiliaryValue>);
 
-    void make_thread_specific_region(Badge<Process>);
+    KResult make_thread_specific_region(Badge<Process>);
 
     unsigned syscall_count() const { return m_syscall_count; }
     void did_syscall() { ++m_syscall_count; }

--- a/Kernel/VM/PhysicalRegion.cpp
+++ b/Kernel/VM/PhysicalRegion.cpp
@@ -105,7 +105,8 @@ Optional<unsigned> PhysicalRegion::find_one_free_page()
         return {};
     }
     auto free_index = m_bitmap.find_one_anywhere_unset(m_free_hint);
-    ASSERT(free_index.has_value());
+    if (!free_index.has_value())
+        return {};
   
     auto page_index = free_index.value();
     m_bitmap.set(page_index, true);


### PR DESCRIPTION
There are plenty of places in the kernel that aren't
checking if they actually got their allocation.

This fixes some of them, but definitely not all.

Fixes #3390
Fixes #3391

Also, let's make find_one_free_page() return nullptr
if it doesn't get a free index. This stops the kernel
crashing when out of memory and allows memory purging
to take place again.

Fixes #3487