### PR TITLE
LibGUI: Fix two issues with Custom color picking

### DIFF
--- a/Libraries/LibGUI/ColorPicker.cpp
+++ b/Libraries/LibGUI/ColorPicker.cpp
@@ -292,7 +292,9 @@ void ColorPicker::build_ui_custom(Widget& root_container)
     m_html_text->on_change = [this]() {
         auto color_name = m_html_text->text();
         auto optional_color = Color::from_string(color_name);
-        if (optional_color.has_value()) {
+        if (optional_color.has_value() && (!color_name.starts_with("#") || color_name.length() == ((m_color_has_alpha_channel) ? 9 : 7))) {
+            // The color length must be 9/7 (unless it is a name like red), because:
+            //    - If we allowed 5/4 character rgb color, the field would reset to 9/7 characters after you deleted 4/3 characters.
             auto color = optional_color.value();
             if (m_color == color)
                 return;

--- a/Libraries/LibGUI/ColorPicker.cpp
+++ b/Libraries/LibGUI/ColorPicker.cpp
@@ -68,6 +68,7 @@ public:
     Function<void(Color)> on_pick;
     void set_color(Color);
     void set_hue(double);
+    void set_hue_from_pick(double);
 
 private:
     ColorField(Color color);
@@ -469,7 +470,7 @@ CustomColorWidget::CustomColorWidget(Color color)
     auto slider_width = 24 + (m_color_slider->frame_thickness() * 2);
     m_color_slider->set_preferred_size(slider_width, size);
     m_color_slider->on_pick = [this](double value) {
-        m_color_field->set_hue(value);
+        m_color_field->set_hue_from_pick(value);
     };
 }
 
@@ -538,9 +539,13 @@ void ColorField::set_hue(double hue)
     auto color = Color::from_hsv(hsv);
     color.set_alpha(m_color.alpha());
     set_color(color);
+}
 
+void ColorField::set_hue_from_pick(double hue)
+{
+    set_hue(hue);
     if (on_pick)
-        on_pick(color);
+        on_pick(m_color);
 }
 
 void ColorField::pick_color_at_position(GUI::MouseEvent& event)


### PR DESCRIPTION
prior to this PR:
- backspacing the HTML color string wouldn't work past 3 characters, because the color would be recalculated.
- changing an individual RGB value would affect the others, because the color's hue was calculated, and then the color recalculated from the hue.


fixes #3406 