### PR TITLE
LibGUI: ProcessChooser sort fix

### DIFF
--- a/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Libraries/LibGUI/ProcessChooser.cpp
@@ -58,8 +58,8 @@ ProcessChooser::ProcessChooser(const StringView& window_title, const StringView&
     m_table_view = widget.add<GUI::TableView>();
     auto sorting_model = GUI::SortingProxyModel::create(RunningProcessesModel::create());
     sorting_model->set_sort_role(GUI::ModelRole::Display);
-    m_table_view->set_key_column_and_sort_order(RunningProcessesModel::Column::PID, GUI::SortOrder::Descending);
     m_table_view->set_model(sorting_model);
+    m_table_view->set_key_column_and_sort_order(RunningProcessesModel::Column::PID, GUI::SortOrder::Descending);
 
     m_table_view->on_activation = [this](const ModelIndex& index) { set_pid_from_index_and_close(index); };
 


### PR DESCRIPTION
We are setting the sort order before model was set to the table. Because of this, table is not sorting upon launch of `Inspector`.

In order to make the sort work properly, need to set the sort order after model was set (just like in all other places).