### PR TITLE
LibGUI: Respecting the previously selected sort oder in HeaderView

### DIFF
--- a/Libraries/LibGUI/HeaderView.cpp
+++ b/Libraries/LibGUI/HeaderView.cpp
@@ -206,7 +206,7 @@ void HeaderView::mouseup_event(MouseEvent& event)
         }
         if (m_pressed_section != -1) {
             if (m_orientation == Gfx::Orientation::Horizontal && section_rect(m_pressed_section).contains(event.position())) {
-                auto new_sort_order = SortOrder::Ascending;
+                auto new_sort_order = m_table_view.sort_order();
                 if (m_table_view.key_column() == m_pressed_section)
                     new_sort_order = m_table_view.sort_order() == SortOrder::Ascending
                         ? SortOrder::Descending


### PR DESCRIPTION
Instead of forcefully setting the sort order to `Ascending` upon column sort, setting it to the previously selected sort order.