### PR TITLE
Kernel: Simplify dropping privileges with pledge.

### DIFF
--- a/Applications/About/main.cpp
+++ b/Applications/About/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
 
     auto app = GUI::Application::construct(argc, argv);
 
-    if (pledge("stdio shared_buffer accept rpath", nullptr) < 0) {
+    if (pledge("all -unix -cpath -fattr", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
     Web::ResourceLoader::the();
 
     // FIXME: Once there is a standalone Download Manager, we can drop the "unix" pledge.
-    if (pledge("stdio shared_buffer accept unix cpath rpath wpath", nullptr) < 0) {
+    if (pledge("all -fattr", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Base/usr/share/man/man2/pledge.md
+++ b/Base/usr/share/man/man2/pledge.md
@@ -30,6 +30,7 @@ If the process later attempts to use any system functionality it has previously 
 
 ## Promises
 
+* `all`: Placeholder for all promises that have not been dropped yet. (\*)
 * `stdio`: Basic I/O, memory allocation, information about self, various non-destructive syscalls
 * `thread`: The POSIX threading API (\*)
 * `id`: Ability to change UID/GID
@@ -56,11 +57,34 @@ If the process later attempts to use any system functionality it has previously 
 
 Promises marked with an asterisk (\*) are SerenityOS specific extensions not supported by the original OpenBSD `pledge()`.
 
+Promises starting with a minus sign drop said promise, this is intended to be used with all to drop privileges.
+This is a SerenityOS specific extension and is not supported by the origina OpenBSD `pledge()`.
+
 ## Errors
 
 * `EFAULT`: `promises` and/or `execpromises` are not null and not in readable memory.
 * `EINVAL`: One or more invalid promises were specified.
 * `EPERM`: An attempt to increase capabilities was rejected.
+
+## Examples
+
+```c++
+    if (pledge("stdio rpath", nullptr) < 0) {
+        perror("pledge");
+        exit(1);
+    }
+
+    int fd = open("example.txt", O_RDONLY);
+    if(fd < 0) {
+        perror("open");
+        exit(1);
+    }
+
+    if (pledge("all -rpath", nullptr) < 0) {
+        perror("pledge");
+        exit(1);
+    }
+```
 
 ## History
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -31,6 +31,7 @@
 #include <AK/InlineLinkedList.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/NonnullRefPtrVector.h>
+#include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Userspace.h>
 #include <AK/WeakPtr.h>
@@ -433,11 +434,11 @@ public:
 
     bool has_promises() const
     {
-        return m_promises;
+        return m_promises.has_value();
     }
     bool has_promised(Pledge pledge) const
     {
-        return m_promises & (1u << (u32)pledge);
+        return m_promises.value_or((u32)-1) & (1u << (u32)pledge);
     }
 
     VeilState veil_state() const
@@ -587,8 +588,8 @@ private:
 
     u32 m_priority_boost { 0 };
 
-    u32 m_promises { 0 };
-    u32 m_execpromises { 0 };
+    Optional<u32> m_promises;
+    Optional<u32> m_execpromises;
 
     VeilState m_veil_state { VeilState::None };
     Vector<UnveiledPath> m_unveiled_paths;

--- a/Kernel/Syscalls/pledge.cpp
+++ b/Kernel/Syscalls/pledge.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Optional.h>
 #include <AK/StringView.h>
 #include <Kernel/Process.h>
 
@@ -72,14 +73,14 @@ int Process::sys$pledge(Userspace<const Syscall::SC_pledge_params*> user_params)
         return true;
     };
 
-    u32 new_promises;
-    u32 new_execpromises;
+    Optional<u32> new_promises;
+    Optional<u32> new_execpromises;
 
     if (!promises.is_null()) {
         new_promises = 0;
-        if (!parse_pledge(promises, new_promises))
+        if (!parse_pledge(promises, new_promises.value()))
             return -EINVAL;
-        if (m_promises && (!new_promises || new_promises & ~m_promises))
+        if (new_promises.value() & ~m_promises.value_or((u32)-1))
             return -EPERM;
     } else {
         new_promises = m_promises;
@@ -87,9 +88,9 @@ int Process::sys$pledge(Userspace<const Syscall::SC_pledge_params*> user_params)
 
     if (!execpromises.is_null()) {
         new_execpromises = 0;
-        if (!parse_pledge(execpromises, new_execpromises))
+        if (!parse_pledge(execpromises, new_execpromises.value()))
             return -EINVAL;
-        if (m_execpromises && (!new_execpromises || new_execpromises & ~m_execpromises))
+        if (new_execpromises.value() & ~m_execpromises.value_or((u32)-1))
             return -EPERM;
     } else {
         new_execpromises = m_execpromises;

--- a/Userland/ntpquery.cpp
+++ b/Userland/ntpquery.cpp
@@ -41,7 +41,8 @@
 // The fractional part in the lower 32 bits stores fractional bits times 2 ** 32.
 typedef uint64_t NtpTimestamp;
 
-struct [[gnu::packed]] NtpPacket {
+struct [[gnu::packed]] NtpPacket
+{
     uint8_t li_vn_mode;
     uint8_t stratum;
     int8_t poll;
@@ -115,7 +116,7 @@ int main(int argc, char** argv)
     args_parser.parse(argc, argv);
 
     if (!set_time) {
-        if (pledge("stdio inet dns", nullptr) < 0) {
+        if (pledge("all -settime", nullptr) < 0) {
             perror("pledge");
             return 1;
         }
@@ -127,7 +128,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (pledge(set_time ? "stdio inet settime" : "stdio inet", nullptr) < 0) {
+    if (pledge("all -dns", nullptr) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
Dropping privileges with pledge is painful, you always need to know exactly which privileges you have currently. This is especially bad if privileges are dropped conditionally.

This commit adds the possibility to drop privileges by adding a placeholder "all" promise that expands to all privileges that have not been dropped yet, an example:

~~~c++
pledge("stdio rpath");
int fd = open("example.txt", O_RDONLY);
pledge("all -rpath");

// Using an already opened file descriptor only needs "stdio".
~~~

(Obviously, we should check the return values.) "all" means in this context "stdio rpath" and "-rpath" then only leaves "stdio".

I've tried to make it biased towards dropping permissions, meaning that

 1. `pledge("-stdio stdio", nullptr)` drops stdio.

 2. `pledge("-stdio all", nullptr)` returns `-EPERM` if `stdio` was already dropped.

 3. `pledge("-dns", nullptr)` drops `unix` even though it's just an alias (I dislike this very much.)

Previously valid `pledge()` calls remain valid as well.

---

I've marked this as draft because I am not 100% sure that this is a good idea. I have only adjusted a few application to the new syntax as demonstration, I would go and push these changes into remaining applications in the following weeks.

#### Pro:

  - Explicitly listing all permissions is a annoying and makes it less obvious when permissions are dropped.

  - Conditionally dropping privileges is nasty at best (look at [Userland/ntpquery.cpp][1] for example) this could lead to a bias not to drop privileges for the sake of simplicity.

  - It could drive people to dynamically construct pledge strings using `StringBuilder`.

#### Contra:

  - Previously, it was very visible which permissions are available at any given point in time.

  - Previously, it was easier to spot dangerous permissions like "exec" (it can still be explicitly listed like "all exec -rpath" for example.)

  [1]: https://github.com/SerenityOS/serenity/blob/07d4b41bac1330804ad2bb4cd7656e5c8ca14717/Userland/ntpquery.cpp