### PR TITLE
Kernel: Clone FileDescriptor on fork

### DIFF
--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -103,6 +103,25 @@ FIFO::~FIFO()
     all_fifos().resource().remove(this);
 }
 
+KResult FIFO::attach(FileDescription& fd, FileDescription* cloned_from)
+{
+    if (cloned_from) {
+        auto direction = cloned_from->fifo_direction();
+        fd.set_fifo_direction({}, direction);
+        attach(direction);
+        return KSuccess;
+    }
+
+    // We don't know the direction of a newly create descriptor,
+    // FIFO::open_direction will set it shortly after
+    return KSuccess;
+}
+
+void FIFO::detach(FileDescription& fd)
+{
+    detach(fd.fifo_direction());
+}
+
 void FIFO::attach(Direction direction)
 {
     if (direction == Direction::Reader) {

--- a/Kernel/FileSystem/FIFO.h
+++ b/Kernel/FileSystem/FIFO.h
@@ -52,11 +52,10 @@ public:
     NonnullRefPtr<FileDescription> open_direction(Direction);
     NonnullRefPtr<FileDescription> open_direction_blocking(Direction);
 
-    void attach(Direction);
-    void detach(Direction);
-
 private:
     // ^File
+    virtual KResult attach(FileDescription&, FileDescription*) override;
+    virtual void detach(FileDescription&) override;
     virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
     virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
     virtual KResult stat(::stat&) const override;
@@ -65,6 +64,9 @@ private:
     virtual String absolute_path(const FileDescription&) const override;
     virtual const char* class_name() const override { return "FIFO"; }
     virtual bool is_fifo() const override { return true; }
+
+    void attach(Direction);
+    void detach(Direction);
 
     explicit FIFO(uid_t);
 

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -78,6 +78,8 @@ public:
     virtual bool can_read(const FileDescription&, size_t) const = 0;
     virtual bool can_write(const FileDescription&, size_t) const = 0;
 
+    virtual KResult attach(FileDescription&, FileDescription*) { return KSuccess; }
+    virtual void detach(FileDescription&) {}
     virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) = 0;
     virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) = 0;
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg);

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -45,6 +45,8 @@ public:
     static NonnullRefPtr<FileDescription> create(File&);
     ~FileDescription();
 
+    RefPtr<FileDescription> clone();
+
     bool is_readable() const { return m_readable; }
     bool is_writable() const { return m_writable; }
 
@@ -132,6 +134,7 @@ public:
 
 private:
     friend class VFS;
+    explicit FileDescription(FileDescription&);
     explicit FileDescription(File&);
     FileDescription(FIFO&, FIFO::Direction);
 
@@ -151,6 +154,7 @@ private:
     bool m_is_directory : 1 { false };
     bool m_should_append : 1 { false };
     bool m_direct : 1 { false };
+    bool m_attach_error : 1 { false };
     FIFO::Direction m_fifo_direction { FIFO::Direction::Neither };
 
     Lock m_lock { "FileDescription" };

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -69,6 +69,8 @@ public:
 
     KResultOr<KBuffer> read_entire(FileDescription* = nullptr) const;
 
+    virtual KResult attach(FileDescription&, FileDescription*) { return KSuccess; }
+    virtual void detach(FileDescription&) {}
     virtual ssize_t read_bytes(off_t, ssize_t, UserOrKernelBuffer& buffer, FileDescription*) const = 0;
     virtual KResult traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)>) const = 0;
     virtual RefPtr<Inode> lookup(StringView name) = 0;

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -168,8 +168,9 @@ KResult IPv4Socket::connect(FileDescription& description, Userspace<const sockad
     return protocol_connect(description, should_block);
 }
 
-void IPv4Socket::attach(FileDescription&)
+KResult IPv4Socket::attach(FileDescription&, FileDescription*)
 {
+    return KSuccess;
 }
 
 void IPv4Socket::detach(FileDescription&)

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -54,7 +54,7 @@ public:
     virtual KResult listen(size_t) override;
     virtual void get_local_address(sockaddr*, socklen_t*) override;
     virtual void get_peer_address(sockaddr*, socklen_t*) override;
-    virtual void attach(FileDescription&) override;
+    virtual KResult attach(FileDescription&, FileDescription*) override;
     virtual void detach(FileDescription&) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -105,8 +105,6 @@ public:
     virtual void get_peer_address(sockaddr*, socklen_t*) = 0;
     virtual bool is_local() const { return false; }
     virtual bool is_ipv4() const { return false; }
-    virtual void attach(FileDescription&) = 0;
-    virtual void detach(FileDescription&) = 0;
     virtual KResultOr<size_t> sendto(FileDescription&, const UserOrKernelBuffer&, size_t, int flags, Userspace<const sockaddr*>, socklen_t) = 0;
     virtual KResultOr<size_t> recvfrom(FileDescription&, UserOrKernelBuffer&, size_t, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>, timeval&) = 0;
 

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -877,4 +877,16 @@ OwnPtr<Process::ELFBundle> Process::elf_bundle() const
     return bundle;
 }
 
+bool Process::FileDescriptionAndFlags::clone_to(FileDescriptionAndFlags& copy)
+{
+    if (m_description) {
+        auto cloned_fd = m_description->clone();
+        if (!cloned_fd)
+            return false;
+        copy.m_description = cloned_fd.release_nonnull();
+    }
+    copy.m_flags = m_flags;
+    return true;
+}
+
 }

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -538,6 +538,8 @@ private:
         void clear();
         void set(NonnullRefPtr<FileDescription>&&, u32 flags = 0);
 
+        bool clone_to(FileDescriptionAndFlags&);
+
     private:
         RefPtr<FileDescription> m_description;
         u32 m_flags { 0 };


### PR DESCRIPTION
A fork inheriting file descriptors from the parent should be able
to use them independently. E.g. a seek in the fork should only affect
the fork but not the parent, and vice versa.

I came across this while working on some `ProcFS` changes for #3396.