### PR TITLE
Minesweeper: Fix inverted Single-Click Chording setting

### DIFF
--- a/Games/Minesweeper/main.cpp
+++ b/Games/Minesweeper/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
     app_menu.add_separator();
 
     auto chord_toggler_action = GUI::Action::create_checkable("Single-click chording", [&](auto& action) {
-        field.set_single_chording(!action.is_checked());
+        field.set_single_chording(action.is_checked());
     });
     chord_toggler_action->set_checked(field.is_single_chording());
 


### PR DESCRIPTION
This was introduced by 705cee528a803b1671d16eeaf222d3318708500b, where the '!' was copied from the previous implementation, but the behavior was not.

I would like to apply for the record of smallest PR in serenity :^)