### PR TITLE
HackStudio: Only refresh Git widget on save if it was initialized

### DIFF
--- a/DevTools/HackStudio/Git/GitWidget.h
+++ b/DevTools/HackStudio/Git/GitWidget.h
@@ -43,10 +43,13 @@ public:
 
     void refresh();
     void set_view_diff_callback(ViewDiffCallback callback);
+    bool initialized() const { return !m_git_repo.is_null(); };
 
 private:
     explicit GitWidget(const LexicalPath& repo_root);
 
+    bool initialize();
+    bool initialize_if_needed();
     void stage_file(const LexicalPath&);
     void unstage_file(const LexicalPath&);
     void commit();

--- a/DevTools/HackStudio/main.cpp
+++ b/DevTools/HackStudio/main.cpp
@@ -489,8 +489,11 @@ static int main_impl(int argc, char** argv)
     auto save_action = GUI::Action::create("Save", { Mod_Ctrl, Key_S }, Gfx::Bitmap::load_from_file("/res/icons/16x16/save.png"), [&](auto&) {
         if (g_currently_open_file.is_empty())
             return;
+
         current_editor().write_to_file(g_currently_open_file);
-        g_git_widget->refresh();
+
+        if (g_git_widget->initialized())
+            g_git_widget->refresh();
     });
 
     toolbar.add_action(new_action);


### PR DESCRIPTION
This fixes an annoyance where the "Do you want to initialize a git repo?" popup would show when saving a file when the user hasn't event interacted with the git widget itself.