### PR TITLE
LibJS: Do not revisit already visited values in update_function_name()

### DIFF
--- a/Libraries/LibJS/Tests/functions/function-name.js
+++ b/Libraries/LibJS/Tests/functions/function-name.js
@@ -48,3 +48,10 @@ test("names of native functions", () => {
     expect((console.debug.name = "warn")).toBe("warn");
     expect(console.debug.name).toBe("debug");
 });
+
+test("cyclic members should not cause infinite recursion (#3471)", () => {
+    let a = [() => 4];
+    a[1] = a;
+    a = a;
+    expect(a[0].name).toBe("a");
+});


### PR DESCRIPTION
Fixes #3471, adds a test.

cc @linusg - I think you wrote that `update_function_name()`.