### PR TITLE
ResourceGraph: Fix graph line position calculation

### DIFF
--- a/MenuApplets/ResourceGraph/main.cpp
+++ b/MenuApplets/ResourceGraph/main.cpp
@@ -104,7 +104,7 @@ private:
         for (auto value : m_history) {
             painter.draw_line(
                 { rect.x() + i, rect.bottom() },
-                { rect.x() + i, (int)(rect.height() - (value * (float)rect.height())) },
+                { rect.x() + i, rect.top() + (int)(round(rect.height() - (value * rect.height()))) },
                 m_graph_color);
             ++i;
         }


### PR DESCRIPTION
The calculation was only taking the rect's inner height, but not its top offset into account.

Fixes #3540.