### PR TITLE
Kernel: Remove Process::big_lock

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -278,8 +278,6 @@ void Process::kill_threads_except_self()
         thread.set_should_die();
         return IterationDecision::Continue;
     });
-
-    big_lock().clear_waiters();
 }
 
 void Process::kill_all_threads()

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -406,11 +406,6 @@ public:
         return m_thread_count.load(AK::MemoryOrder::memory_order_consume);
     }
 
-    Lock& big_lock()
-    {
-        return m_big_lock;
-    }
-
     struct ELFBundle {
         OwnPtr<Region> region;
         RefPtr<ELF::Loader> elf_loader;
@@ -578,7 +573,6 @@ private:
     size_t m_master_tls_size { 0 };
     size_t m_master_tls_alignment { 0 };
 
-    Lock m_big_lock { "Process" };
     mutable SpinLock<u32> m_lock;
 
     u64 m_alarm_deadline { 0 };

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -169,7 +169,6 @@ void syscall_handler(TrapFrame* trap)
         ASSERT_NOT_REACHED();
     }
 
-    process.big_lock().lock();
     u32 function = regs.eax;
     u32 arg1 = regs.edx;
     u32 arg2 = regs.ecx;
@@ -180,8 +179,6 @@ void syscall_handler(TrapFrame* trap)
         current_thread->tracer()->set_trace_syscalls(false);
         current_thread->tracer_trap(regs);
     }
-
-    process.big_lock().unlock();
 
     // Check if we're supposed to return to userspace or just die.
     current_thread->die_if_needed();

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -311,7 +311,6 @@ int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Ve
         Profiling::did_exec(path);
 
     new_main_thread->set_state(Thread::State::Runnable);
-    big_lock().force_unlock_if_locked();
     ASSERT_INTERRUPTS_DISABLED();
     ASSERT(Processor::current().in_critical());
     return 0;

--- a/Kernel/Syscalls/sched.cpp
+++ b/Kernel/Syscalls/sched.cpp
@@ -31,7 +31,7 @@ namespace Kernel {
 int Process::sys$yield()
 {
     REQUIRE_PROMISE(stdio);
-    Thread::current()->yield_without_holding_big_lock();
+    Scheduler::yield();
     return 0;
 }
 

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -93,7 +93,6 @@ void Process::sys$exit_thread(Userspace<void*> exit_value)
     auto current_thread = Thread::current();
     current_thread->m_exit_value = reinterpret_cast<void*>(exit_value.ptr());
     current_thread->set_should_die();
-    big_lock().force_unlock_if_locked();
     current_thread->die_if_needed();
     ASSERT_NOT_REACHED();
 }

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -361,7 +361,7 @@ public:
         }
 
         // Yield to the scheduler, and wait for us to resume unblocked.
-        yield_without_holding_big_lock();
+        Scheduler::yield();
 
         ScopedSpinLock lock(m_lock);
         // We should no longer be blocked once we woke up
@@ -533,8 +533,6 @@ private:
 private:
     friend struct SchedulerData;
     friend class WaitQueue;
-    bool unlock_process_if_locked();
-    void relock_process(bool did_unlock);
     String backtrace_impl();
     void reset_fpu_state();
 
@@ -596,7 +594,6 @@ private:
 
     OwnPtr<ThreadTracer> m_tracer;
 
-    void yield_without_holding_big_lock();
     void update_state_for_thread(Thread::State previous_state);
 };
 


### PR DESCRIPTION
We don't really need this lock anymore as we have locks around
everything that needs to be synchronized.