### PR TITLE
LibJS: Handle getter exception in JSONObject::serialize_json_property()

### DIFF
--- a/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -150,6 +150,8 @@ JS_DEFINE_NATIVE_FUNCTION(JSONObject::stringify)
 String JSONObject::serialize_json_property(Interpreter& interpreter, StringifyState& state, const PropertyName& key, Object* holder)
 {
     auto value = holder->get(key);
+    if (interpreter.exception())
+        return {};
     if (value.is_object()) {
         auto to_json = value.as_object().get("toJSON");
         if (interpreter.exception())

--- a/Libraries/LibJS/Tests/builtins/JSON/JSON.stringify-exception-in-property-getter.js
+++ b/Libraries/LibJS/Tests/builtins/JSON/JSON.stringify-exception-in-property-getter.js
@@ -1,0 +1,10 @@
+test("Issue #3548, exception in property getter with replacer function", () => {
+    const o = {
+        get foo() {
+            throw Error();
+        },
+    };
+    expect(() => {
+        JSON.stringify(o, (_, value) => value);
+    }).toThrow(Error);
+});


### PR DESCRIPTION
In the case of an exception in a property getter function we would not return early, and a subsequent attempt to call the replacer function would crash the interpreter due to `call_internal()` asserting.

Fixes #3548.