### PR TITLE
Kernel: Fix assertion statement in GenericInterruptHandler

### DIFF
--- a/Kernel/Interrupts/GenericInterruptHandler.cpp
+++ b/Kernel/Interrupts/GenericInterruptHandler.cpp
@@ -56,7 +56,7 @@ GenericInterruptHandler::~GenericInterruptHandler()
 
 void GenericInterruptHandler::change_interrupt_number(u8 number)
 {
-    ASSERT_INTERRUPTS_ENABLED();
+    ASSERT_INTERRUPTS_DISABLED();
     ASSERT(!m_disable_remap);
     unregister_generic_interrupt_handler(InterruptManagement::acquire_mapped_interrupt_number(interrupt_number()), *this);
     m_interrupt_number = number;


### PR DESCRIPTION
We need to assert if interrupts are not disabled when changing the interrupt number of an interrupt handler.
Before this fix, any change like this would lead to a crash, because we are using InterruptDisabler in IRQHandler::change_irq_number.

Fixes #3531.