### PR TITLE
Kernel: Remove unnecessary class member in UHCIController

### DIFF
--- a/Kernel/Devices/UHCIController.h
+++ b/Kernel/Devices/UHCIController.h
@@ -63,7 +63,6 @@ private:
 
     virtual void handle_irq(const RegisterState&) override;
 
-    PCI::Address m_address;
     IOAddress m_io_base;
 };
 


### PR DESCRIPTION
The `m_address` member is not needed, since `PCI::Device` already has one.