### PR TITLE
LibMarkdown: Add support for Tables

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -337,44 +337,6 @@ int String::replace(const String& needle, const String& replacement, bool all_oc
     return positions.size();
 }
 
-String String::trim_whitespace(TrimMode mode) const
-{
-    auto is_whitespace_character = [](char ch) -> bool {
-        return ch == '\t'
-            || ch == '\n'
-            || ch == '\v'
-            || ch == '\f'
-            || ch == '\r'
-            || ch == ' ';
-    };
-
-    size_t substring_start = 0;
-    size_t substring_length = length();
-
-    if (mode == TrimMode::Left || mode == TrimMode::Both) {
-        for (size_t i = 0; i < length(); ++i) {
-            if (substring_length == 0)
-                return "";
-            if (!is_whitespace_character(characters()[i]))
-                break;
-            ++substring_start;
-            --substring_length;
-        }
-    }
-
-    if (mode == TrimMode::Right || mode == TrimMode::Both) {
-        for (size_t i = length() - 1; i > 0; --i) {
-            if (substring_length == 0)
-                return "";
-            if (!is_whitespace_character(characters()[i]))
-                break;
-            --substring_length;
-        }
-    }
-
-    return substring(substring_start, substring_length);
-}
-
 String escape_html_entities(const StringView& html)
 {
     StringBuilder builder;

--- a/AK/String.h
+++ b/AK/String.h
@@ -119,12 +119,12 @@ public:
     String to_lowercase() const;
     String to_uppercase() const;
 
-    enum class TrimMode {
-        Left,
-        Right,
-        Both
-    };
-    String trim_whitespace(TrimMode mode = TrimMode::Both) const;
+#ifndef KERNEL
+    String trim_whitespace(TrimMode mode = TrimMode::Both) const
+    {
+        return StringUtils::trim_whitespace(StringView { characters(), length() }, mode);
+    }
+#endif
 
     bool equals_ignoring_case(const StringView&) const;
 

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -227,6 +227,43 @@ bool starts_with(const StringView& str, const StringView& start, CaseSensitivity
     return true;
 }
 
+StringView trim_whitespace(const StringView& str, TrimMode mode)
+{
+    auto is_whitespace_character = [](char ch) -> bool {
+        return ch == '\t'
+            || ch == '\n'
+            || ch == '\v'
+            || ch == '\f'
+            || ch == '\r'
+            || ch == ' ';
+    };
+
+    size_t substring_start = 0;
+    size_t substring_length = str.length();
+
+    if (mode == TrimMode::Left || mode == TrimMode::Both) {
+        for (size_t i = 0; i < str.length(); ++i) {
+            if (substring_length == 0)
+                return "";
+            if (!is_whitespace_character(str[i]))
+                break;
+            ++substring_start;
+            --substring_length;
+        }
+    }
+
+    if (mode == TrimMode::Right || mode == TrimMode::Both) {
+        for (size_t i = str.length() - 1; i > 0; --i) {
+            if (substring_length == 0)
+                return "";
+            if (!is_whitespace_character(str[i]))
+                break;
+            --substring_length;
+        }
+    }
+
+    return str.substring_view(substring_start, substring_length);
+}
 }
 
 }

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -36,6 +36,12 @@ enum class CaseSensitivity {
     CaseSensitive,
 };
 
+enum class TrimMode {
+    Left,
+    Right,
+    Both
+};
+
 namespace StringUtils {
 
 bool matches(const StringView& str, const StringView& mask, CaseSensitivity = CaseSensitivity::CaseInsensitive);
@@ -45,8 +51,10 @@ Optional<unsigned> convert_to_uint_from_hex(const StringView&);
 bool equals_ignoring_case(const StringView&, const StringView&);
 bool ends_with(const StringView& a, const StringView& b, CaseSensitivity);
 bool starts_with(const StringView&, const StringView&, CaseSensitivity);
+StringView trim_whitespace(const StringView&, TrimMode mode);
 }
 
 }
 
 using AK::CaseSensitivity;
+using AK::TrimMode;

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -91,6 +91,8 @@ public:
     bool contains(const StringView&) const;
     bool equals_ignoring_case(const StringView& other) const;
 
+    StringView trim_whitespace(TrimMode mode = TrimMode::Both) const { return StringUtils::trim_whitespace(*this, mode); }
+
     Optional<size_t> find_first_of(char) const;
     Optional<size_t> find_first_of(const StringView&) const;
 

--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -282,7 +282,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::trim)
     auto string = ak_string_from(vm, global_object);
     if (string.is_null())
         return {};
-    return js_string(vm, string.trim_whitespace(String::TrimMode::Both));
+    return js_string(vm, string.trim_whitespace(TrimMode::Both));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(StringPrototype::trim_start)
@@ -290,7 +290,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::trim_start)
     auto string = ak_string_from(vm, global_object);
     if (string.is_null())
         return {};
-    return js_string(vm, string.trim_whitespace(String::TrimMode::Left));
+    return js_string(vm, string.trim_whitespace(TrimMode::Left));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(StringPrototype::trim_end)
@@ -298,7 +298,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::trim_end)
     auto string = ak_string_from(vm, global_object);
     if (string.is_null())
         return {};
-    return js_string(vm, string.trim_whitespace(String::TrimMode::Right));
+    return js_string(vm, string.trim_whitespace(TrimMode::Right));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(StringPrototype::concat)

--- a/Libraries/LibMarkdown/Block.h
+++ b/Libraries/LibMarkdown/Block.h
@@ -36,7 +36,7 @@ public:
     virtual ~Block() { }
 
     virtual String render_to_html() const = 0;
-    virtual String render_for_terminal() const = 0;
+    virtual String render_for_terminal(size_t view_width = 0) const = 0;
 };
 
 }

--- a/Libraries/LibMarkdown/CMakeLists.txt
+++ b/Libraries/LibMarkdown/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     Heading.cpp
     List.cpp
     Paragraph.cpp
+    Table.cpp
     Text.cpp
 )
 

--- a/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Libraries/LibMarkdown/CodeBlock.cpp
@@ -74,7 +74,7 @@ String CodeBlock::render_to_html() const
     return builder.build();
 }
 
-String CodeBlock::render_for_terminal() const
+String CodeBlock::render_for_terminal(size_t) const
 {
     StringBuilder builder;
 

--- a/Libraries/LibMarkdown/CodeBlock.h
+++ b/Libraries/LibMarkdown/CodeBlock.h
@@ -42,7 +42,7 @@ public:
     virtual ~CodeBlock() override { }
 
     virtual String render_to_html() const override;
-    virtual String render_for_terminal() const override;
+    virtual String render_for_terminal(size_t view_width = 0) const override;
     static OwnPtr<CodeBlock> parse(Vector<StringView>::ConstIterator& lines);
 
 private:

--- a/Libraries/LibMarkdown/Document.cpp
+++ b/Libraries/LibMarkdown/Document.cpp
@@ -52,12 +52,12 @@ String Document::render_to_html() const
     return builder.build();
 }
 
-String Document::render_for_terminal() const
+String Document::render_for_terminal(size_t view_width) const
 {
     StringBuilder builder;
 
     for (auto& block : m_blocks) {
-        auto s = block.render_for_terminal();
+        auto s = block.render_for_terminal(view_width);
         builder.append(s);
     }
 

--- a/Libraries/LibMarkdown/Document.cpp
+++ b/Libraries/LibMarkdown/Document.cpp
@@ -30,6 +30,7 @@
 #include <LibMarkdown/Heading.h>
 #include <LibMarkdown/List.h>
 #include <LibMarkdown/Paragraph.h>
+#include <LibMarkdown/Table.h>
 
 namespace Markdown {
 
@@ -90,7 +91,8 @@ OwnPtr<Document> Document::parse(const StringView& str)
             continue;
         }
 
-        bool any = helper<List>(lines, blocks) || helper<Paragraph>(lines, blocks) || helper<CodeBlock>(lines, blocks) || helper<Heading>(lines, blocks);
+        bool any = helper<Table>(lines, blocks) || helper<List>(lines, blocks) || helper<Paragraph>(lines, blocks)
+            || helper<CodeBlock>(lines, blocks) || helper<Heading>(lines, blocks);
 
         if (!any)
             return nullptr;

--- a/Libraries/LibMarkdown/Document.h
+++ b/Libraries/LibMarkdown/Document.h
@@ -35,7 +35,7 @@ namespace Markdown {
 class Document final {
 public:
     String render_to_html() const;
-    String render_for_terminal() const;
+    String render_for_terminal(size_t view_width = 0) const;
 
     static OwnPtr<Document> parse(const StringView&);
 

--- a/Libraries/LibMarkdown/Heading.cpp
+++ b/Libraries/LibMarkdown/Heading.cpp
@@ -38,7 +38,7 @@ String Heading::render_to_html() const
     return builder.build();
 }
 
-String Heading::render_for_terminal() const
+String Heading::render_for_terminal(size_t) const
 {
     StringBuilder builder;
 

--- a/Libraries/LibMarkdown/Heading.h
+++ b/Libraries/LibMarkdown/Heading.h
@@ -44,7 +44,7 @@ public:
     virtual ~Heading() override { }
 
     virtual String render_to_html() const override;
-    virtual String render_for_terminal() const override;
+    virtual String render_for_terminal(size_t view_width = 0) const override;
     static OwnPtr<Heading> parse(Vector<StringView>::ConstIterator& lines);
 
 private:

--- a/Libraries/LibMarkdown/List.cpp
+++ b/Libraries/LibMarkdown/List.cpp
@@ -47,7 +47,7 @@ String List::render_to_html() const
     return builder.build();
 }
 
-String List::render_for_terminal() const
+String List::render_for_terminal(size_t) const
 {
     StringBuilder builder;
 

--- a/Libraries/LibMarkdown/List.h
+++ b/Libraries/LibMarkdown/List.h
@@ -43,7 +43,7 @@ public:
     virtual ~List() override { }
 
     virtual String render_to_html() const override;
-    virtual String render_for_terminal() const override;
+    virtual String render_for_terminal(size_t view_width = 0) const override;
 
     static OwnPtr<List> parse(Vector<StringView>::ConstIterator& lines);
 

--- a/Libraries/LibMarkdown/Paragraph.cpp
+++ b/Libraries/LibMarkdown/Paragraph.cpp
@@ -38,7 +38,7 @@ String Paragraph::render_to_html() const
     return builder.build();
 }
 
-String Paragraph::render_for_terminal() const
+String Paragraph::render_for_terminal(size_t) const
 {
     StringBuilder builder;
     builder.append(m_text.render_for_terminal());

--- a/Libraries/LibMarkdown/Paragraph.h
+++ b/Libraries/LibMarkdown/Paragraph.h
@@ -41,7 +41,7 @@ public:
     virtual ~Paragraph() override { }
 
     virtual String render_to_html() const override;
-    virtual String render_for_terminal() const override;
+    virtual String render_for_terminal(size_t view_width = 0) const override;
     static OwnPtr<Paragraph> parse(Vector<StringView>::ConstIterator& lines);
 
 private:

--- a/Libraries/LibMarkdown/Paragraph.h
+++ b/Libraries/LibMarkdown/Paragraph.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/NonnullOwnPtrVector.h>
 #include <AK/OwnPtr.h>
 #include <LibMarkdown/Block.h>
 #include <LibMarkdown/Text.h>
@@ -34,18 +35,34 @@ namespace Markdown {
 
 class Paragraph final : public Block {
 public:
-    explicit Paragraph(Text&& text)
-        : m_text(move(text))
+    class Line {
+    public:
+        explicit Line(Text&& text)
+            : m_text(move(text))
+        {
+        }
+
+        static OwnPtr<Line> parse(Vector<StringView>::ConstIterator& lines);
+        const Text& text() const { return m_text; }
+
+    private:
+        Text m_text;
+    };
+
+    Paragraph(NonnullOwnPtrVector<Line>&& lines)
+        : m_lines(move(lines))
     {
     }
+
     virtual ~Paragraph() override { }
 
     virtual String render_to_html() const override;
     virtual String render_for_terminal(size_t view_width = 0) const override;
-    static OwnPtr<Paragraph> parse(Vector<StringView>::ConstIterator& lines);
+
+    void add_line(NonnullOwnPtr<Line>&& line);
 
 private:
-    Text m_text;
+    NonnullOwnPtrVector<Line> m_lines;
 };
 
 }

--- a/Libraries/LibMarkdown/Table.cpp
+++ b/Libraries/LibMarkdown/Table.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/StringBuilder.h>
+#include <LibMarkdown/Table.h>
+
+namespace Markdown {
+
+String Table::render_for_terminal(size_t view_width) const
+{
+    auto unit_width_length = view_width == 0 ? 4 : ((float)(view_width - m_columns.size()) / (float)m_total_width);
+    StringBuilder format_builder;
+    StringBuilder builder;
+
+    auto write_aligned = [&](const auto& text, auto width, auto alignment) {
+        size_t original_length = 0;
+        for (auto& span : text.spans())
+            original_length += span.text.length();
+        auto string = text.render_for_terminal();
+        format_builder.clear();
+        if (alignment == Alignment::Center) {
+            auto padding_length = (width - original_length) / 2;
+            builder.appendf("%*s%s%*s", padding_length, "", string.characters(), padding_length, "");
+            if ((width - original_length) % 2)
+                builder.append(' ');
+        } else {
+            format_builder.appendf("%%%s%zus", alignment == Alignment::Left ? "-" : "", width + (string.length() - original_length));
+            builder.appendf(
+                format_builder.to_string().characters(),
+                string.characters());
+        }
+    };
+
+    bool first = true;
+    for (auto& col : m_columns) {
+        if (!first)
+            builder.append('|');
+        first = false;
+        size_t width = col.relative_width * unit_width_length;
+        write_aligned(col.header, width, col.alignment);
+    }
+
+    builder.append("\n");
+    for (size_t i = 0; i < view_width; ++i)
+        builder.append('-');
+    builder.append("\n");
+
+    for (size_t i = 0; i < m_row_count; ++i) {
+        bool first = true;
+        for (auto& col : m_columns) {
+            ASSERT(i < col.rows.size());
+            auto& cell = col.rows[i];
+
+            if (!first)
+                builder.append('|');
+            first = false;
+
+            size_t width = col.relative_width * unit_width_length;
+            write_aligned(cell, width, col.alignment);
+        }
+        builder.append("\n");
+    }
+
+    return builder.to_string();
+}
+
+String Table::render_to_html() const
+{
+    StringBuilder builder;
+
+    builder.append("<table>");
+    builder.append("<thead>");
+    builder.append("<tr>");
+    for (auto& column : m_columns) {
+        builder.append("<th>");
+        builder.append(column.header.render_to_html());
+        builder.append("</th>");
+    }
+    builder.append("</tr>");
+    builder.append("</thead>");
+    builder.append("<tbody>");
+    for (size_t i = 0; i < m_row_count; ++i) {
+        builder.append("<tr>");
+        for (auto& column : m_columns) {
+            ASSERT(i < column.rows.size());
+            builder.append("<td>");
+            builder.append(column.rows[i].render_to_html());
+            builder.append("</td>");
+        }
+        builder.append("</tr>");
+    }
+    builder.append("</tbody>");
+    builder.append("</table>");
+
+    return builder.to_string();
+}
+
+OwnPtr<Table> Table::parse(Vector<StringView>::ConstIterator& lines)
+{
+    auto peek_it = lines;
+    auto first_line = *peek_it;
+    if (!first_line.starts_with('|'))
+        return nullptr;
+
+    ++peek_it;
+
+    if (peek_it.is_end())
+        return nullptr;
+
+    auto header_segments = first_line.split_view('|', true);
+    auto header_delimiters = peek_it->split_view('|', true);
+
+    if (!header_segments.is_empty())
+        header_segments.take_first();
+    if (!header_segments.is_empty() && header_segments.last().is_empty())
+        header_segments.take_last();
+
+    if (!header_delimiters.is_empty())
+        header_delimiters.take_first();
+    if (!header_delimiters.is_empty() && header_delimiters.last().is_empty())
+        header_delimiters.take_last();
+
+    ++peek_it;
+
+    if (header_delimiters.size() != header_segments.size())
+        return nullptr;
+
+    if (header_delimiters.is_empty())
+        return nullptr;
+
+    size_t total_width = 0;
+
+    auto table = make<Table>();
+    table->m_columns.resize(header_delimiters.size());
+
+    for (size_t i = 0; i < header_segments.size(); ++i) {
+        auto text_option = Text::parse(header_segments[i]);
+        if (!text_option.has_value())
+            return nullptr; // An invalid 'text' in the header should just fail the table parse.
+
+        auto text = text_option.release_value();
+        auto& column = table->m_columns[i];
+
+        column.header = move(text);
+
+        auto delimiter = header_delimiters[i].trim_whitespace();
+
+        auto align_left = delimiter.starts_with(':');
+        auto align_right = delimiter != ":" && delimiter.ends_with(':');
+
+        if (align_left)
+            delimiter = delimiter.substring_view(1, delimiter.length() - 1);
+        if (align_right)
+            delimiter = delimiter.substring_view(0, delimiter.length() - 1);
+
+        if (align_left && align_right)
+            column.alignment = Alignment::Center;
+        else if (align_right)
+            column.alignment = Alignment::Right;
+        else
+            column.alignment = Alignment::Left;
+
+        size_t relative_width = delimiter.length();
+        for (auto ch : delimiter) {
+            if (ch != '-') {
+                dbg() << "Invalid character _" << ch << "_ in table heading delimiter (ignored)";
+                --relative_width;
+            }
+        }
+
+        column.relative_width = relative_width;
+        total_width += relative_width;
+    }
+
+    table->m_total_width = total_width;
+
+    for (off_t i = 0; i < peek_it - lines; ++i)
+        ++lines;
+
+    size_t row_count = 0;
+    ++lines;
+    while (!lines.is_end()) {
+        auto& line = *lines;
+        if (!line.starts_with('|'))
+            break;
+
+        ++lines;
+
+        auto segments = line.split_view('|', true);
+        segments.take_first();
+        if (!segments.is_empty() && segments.last().is_empty())
+            segments.take_last();
+        ++row_count;
+
+        for (size_t i = 0; i < header_segments.size(); ++i) {
+            if (i >= segments.size()) {
+                // Ran out of segments, but still have headers.
+                // Just make an empty cell.
+                table->m_columns[i].rows.append(Text { "" });
+            } else {
+                auto text_option = Text::parse(segments[i]);
+                // We treat an invalid 'text' as a literal.
+                if (text_option.has_value()) {
+                    auto text = text_option.release_value();
+                    table->m_columns[i].rows.append(move(text));
+                } else {
+                    table->m_columns[i].rows.append(Text { segments[i] });
+                }
+            }
+        }
+    }
+
+    table->m_row_count = row_count;
+
+    return move(table);
+}
+
+}

--- a/Libraries/LibMarkdown/Table.h
+++ b/Libraries/LibMarkdown/Table.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/NonnullOwnPtrVector.h>
+#include <AK/OwnPtr.h>
+#include <LibMarkdown/Block.h>
+#include <LibMarkdown/Text.h>
+
+namespace Markdown {
+
+class Table final : public Block {
+public:
+    enum class Alignment {
+        Center,
+        Left,
+        Right,
+    };
+
+    struct Column {
+        Text header;
+        Vector<Text> rows;
+        Alignment alignment { Alignment::Left };
+        size_t relative_width { 0 };
+    };
+
+    Table() { }
+    virtual ~Table() override { }
+
+    virtual String render_to_html() const override;
+    virtual String render_for_terminal(size_t view_width = 0) const override;
+    static OwnPtr<Table> parse(Vector<StringView>::ConstIterator& lines);
+
+private:
+    Vector<Column> m_columns;
+    size_t m_total_width { 1 };
+    size_t m_row_count { 0 };
+};
+
+}

--- a/Libraries/LibMarkdown/Text.cpp
+++ b/Libraries/LibMarkdown/Text.cpp
@@ -47,6 +47,11 @@ static String unescape(const StringView& text)
     return builder.build();
 }
 
+Text::Text(String&& text)
+{
+    m_spans.append({ move(text), Style {} });
+}
+
 String Text::render_to_html() const
 {
     StringBuilder builder;

--- a/Libraries/LibMarkdown/Text.h
+++ b/Libraries/LibMarkdown/Text.h
@@ -50,6 +50,9 @@ public:
     };
 
     Text(Text&& text) = default;
+    Text() = default;
+
+    Text& operator=(Text&&) = default;
 
     const Vector<Span>& spans() const { return m_spans; }
 

--- a/Libraries/LibMarkdown/Text.h
+++ b/Libraries/LibMarkdown/Text.h
@@ -49,6 +49,7 @@ public:
         Style style;
     };
 
+    explicit Text(String&& text);
     Text(Text&& text) = default;
     Text() = default;
 

--- a/Userland/md.cpp
+++ b/Userland/md.cpp
@@ -32,22 +32,38 @@
 #include <LibMarkdown/Document.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
 
 int main(int argc, char* argv[])
 {
-    if (pledge("stdio rpath", nullptr) < 0) {
+    if (pledge("stdio rpath tty", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
 
     const char* file_name = nullptr;
     bool html = false;
+    int view_width = 0;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(html, "Render to HTML rather than for the terminal", "html", 'H');
+    args_parser.add_option(view_width, "Viewport width for the terminal (defaults to current terminal width)", "view-width", 0, "width");
     args_parser.add_positional_argument(file_name, "Path to Markdown file", "path", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
 
+    if (!html && view_width == 0) {
+        if (isatty(STDOUT_FILENO)) {
+            struct winsize ws;
+            if (ioctl(STDERR_FILENO, TIOCGWINSZ, &ws) < 0)
+                view_width = 80;
+            else
+                view_width = ws.ws_col;
+
+        } else {
+            view_width = 80;
+        }
+    }
     auto file = Core::File::construct();
     bool success;
     if (file_name == nullptr) {
@@ -77,6 +93,6 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    String res = html ? document->render_to_html() : document->render_for_terminal();
+    String res = html ? document->render_to_html() : document->render_for_terminal(view_width);
     printf("%s", res.characters());
 }


### PR DESCRIPTION
I've wanted this for ages, I figured I might as well add it.
I'm not entirely sure what our markdown is based on, but some comments lead me to believe that it is loosely based on CommonMark, without the HTML support. regardless, I think tables are pretty useful to have.

cc @bugaevc - Also note the comment about `Text::parse()`.