### PR TITLE
LibGUI: Pad row/column headers of AbstractTableView

### DIFF
--- a/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Libraries/LibGUI/AbstractTableView.cpp
@@ -346,15 +346,25 @@ void AbstractTableView::did_scroll()
 void AbstractTableView::layout_headers()
 {
     if (column_header().is_visible()) {
-        int x = frame_thickness() + (row_header().is_visible() ? row_header().width() : 0) + -horizontal_scrollbar().value();
+        int row_header_width = row_header().is_visible() ? row_header().width() : 0;
+        int vertical_scrollbar_width = vertical_scrollbar().is_visible() ? vertical_scrollbar().width() : 0;
+
+        int x = frame_thickness() + row_header_width - horizontal_scrollbar().value();
         int y = frame_thickness();
-        column_header().set_relative_rect(x, y, content_width(), column_header().preferred_size().height());
+        int width = AK::max(content_width(), rect().width() - frame_thickness() * 2 - row_header_width - vertical_scrollbar_width);
+
+        column_header().set_relative_rect(x, y, width, column_header().preferred_size().height());
     }
 
     if (row_header().is_visible()) {
+        int column_header_height = column_header().is_visible() ? column_header().height() : 0;
+        int horizontal_scrollbar_height = horizontal_scrollbar().is_visible() ? horizontal_scrollbar().height() : 0;
+
         int x = frame_thickness();
-        int y = (frame_thickness() + (column_header().is_visible() ? column_header().height() : 0)) + -vertical_scrollbar().value();
-        row_header().set_relative_rect(x, y, row_header().preferred_size().width(), content_height());
+        int y = frame_thickness() + column_header_height - vertical_scrollbar().value();
+        int height = AK::max(content_height(), rect().height() - frame_thickness() * 2 - column_header_height - horizontal_scrollbar_height);
+
+        row_header().set_relative_rect(x, y, row_header().preferred_size().width(), height);
     }
 
     if (row_header().is_visible() && column_header().is_visible()) {

--- a/Libraries/LibGUI/HeaderView.cpp
+++ b/Libraries/LibGUI/HeaderView.cpp
@@ -254,6 +254,11 @@ void HeaderView::paint_horizontal(Painter& painter)
         painter.draw_text(text_rect, text, font(), section_alignment(section), palette().button_text());
         x_offset += section_width + horizontal_padding() * 2;
     }
+
+    if (x_offset < rect().right()) {
+        Gfx::IntRect cell_rect(x_offset, 0, width() - x_offset, height());
+        Gfx::StylePainter::paint_button(painter, cell_rect, palette(), Gfx::ButtonStyle::Normal, false, false);
+    }
 }
 
 void HeaderView::paint_vertical(Painter& painter)
@@ -276,6 +281,11 @@ void HeaderView::paint_vertical(Painter& painter)
             text_rect.move_by(1, 1);
         painter.draw_text(text_rect, text, font(), section_alignment(section), palette().button_text());
         y_offset += section_size;
+    }
+
+    if (y_offset < rect().bottom()) {
+        Gfx::IntRect cell_rect(0, y_offset, width(), height() - y_offset);
+        Gfx::StylePainter::paint_button(painter, cell_rect, palette(), Gfx::ButtonStyle::Normal, false, false);
     }
 }
 


### PR DESCRIPTION
How the table headers look after this patch:
![Screenshot_20200920_165812](https://user-images.githubusercontent.com/1627292/93714698-cd6d1180-fb64-11ea-903b-fe841a2ec92b.png)
