### PR TITLE
HackStudio: Basic autocomplete for C++

### DIFF
--- a/DevTools/HackStudio/AutoCompleteBox.cpp
+++ b/DevTools/HackStudio/AutoCompleteBox.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "AutoCompleteBox.h"
+#include "Editor.h"
+#include <LibGUI/Model.h>
+#include <LibGUI/TableView.h>
+#include <LibGUI/Window.h>
+#include <LibGfx/Bitmap.h>
+
+namespace HackStudio {
+
+static RefPtr<Gfx::Bitmap> s_cplusplus_icon;
+
+class AutoCompleteSuggestionModel final : public GUI::Model {
+public:
+    explicit AutoCompleteSuggestionModel(Vector<String>&& suggestions)
+        : m_suggestions(move(suggestions))
+    {
+    }
+
+    enum Column {
+        Icon,
+        Name,
+        __Column_Count,
+    };
+
+    virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_suggestions.size(); }
+    virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Column_Count; }
+    virtual GUI::Variant data(const GUI::ModelIndex& index, GUI::ModelRole role) const override
+    {
+        auto& suggestion = m_suggestions.at(index.row());
+        if (role == GUI::ModelRole::Display) {
+            if (index.column() == Column::Name) {
+                return suggestion;
+            }
+            if (index.column() == Column::Icon) {
+                // TODO: Have separate icons for fields, functions, methods etc
+                if (suggestion.ends_with(".cpp"))
+                    return *s_cplusplus_icon;
+                return *s_cplusplus_icon;
+            }
+        }
+        return {};
+    }
+    virtual void update() override {};
+
+private:
+    Vector<String> m_suggestions;
+};
+
+AutoCompleteBox::~AutoCompleteBox() {}
+
+AutoCompleteBox::AutoCompleteBox(WeakPtr<Editor> editor)
+    : m_editor(move(editor))
+{
+    if (!s_cplusplus_icon) {
+        s_cplusplus_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-cplusplus.png");
+    }
+
+    m_popup_window = GUI::Window::construct();
+    m_popup_window->set_window_type(GUI::WindowType::Tooltip);
+    m_popup_window->set_rect(0, 0, 200, 100);
+
+    m_suggestion_view = m_popup_window->set_main_widget<GUI::TableView>();
+    m_suggestion_view->set_column_headers_visible(false);
+}
+
+void AutoCompleteBox::update_suggestions(String partial_input, Vector<String>&& suggestions)
+{
+    m_partial_input = partial_input;
+    if (suggestions.is_empty())
+        return;
+
+    bool has_suggestions = !suggestions.is_empty();
+    m_suggestion_view->set_model(adopt(*new AutoCompleteSuggestionModel(move(suggestions))));
+
+    if (!has_suggestions)
+        m_suggestion_view->selection().clear();
+    else
+        m_suggestion_view->selection().set(m_suggestion_view->model()->index(0));
+}
+
+void AutoCompleteBox::show(Gfx::IntPoint suggstion_box_location)
+{
+    m_popup_window->move_to(suggstion_box_location);
+    m_popup_window->show();
+}
+
+void AutoCompleteBox::close()
+{
+    m_partial_input.empty();
+    m_popup_window->hide();
+}
+
+void AutoCompleteBox::next_suggestion()
+{
+    GUI::ModelIndex new_index = m_suggestion_view->selection().first();
+    if (new_index.is_valid())
+        new_index = m_suggestion_view->model()->index(new_index.row() + 1);
+    else
+        new_index = m_suggestion_view->model()->index(0);
+
+    if (m_suggestion_view->model()->is_valid(new_index)) {
+        m_suggestion_view->selection().set(new_index);
+        m_suggestion_view->scroll_into_view(new_index, Orientation::Vertical);
+    }
+}
+
+void AutoCompleteBox::previous_suggestion()
+{
+    GUI::ModelIndex new_index = m_suggestion_view->selection().first();
+    if (new_index.is_valid())
+        new_index = m_suggestion_view->model()->index(new_index.row() - 1);
+    else
+        new_index = m_suggestion_view->model()->index(0);
+
+    if (m_suggestion_view->model()->is_valid(new_index)) {
+        m_suggestion_view->selection().set(new_index);
+        m_suggestion_view->scroll_into_view(new_index, Orientation::Vertical);
+    }
+}
+
+void AutoCompleteBox::apply_suggestion()
+{
+    if (m_editor.is_null())
+        return;
+
+    auto selected_index = m_suggestion_view->selection().first();
+    if (!selected_index.is_valid())
+        return;
+
+    auto suggestion_index = m_suggestion_view->model()->index(selected_index.row(), AutoCompleteSuggestionModel::Column::Name);
+    auto suggestion = suggestion_index.data().to_string();
+
+    ASSERT(!m_partial_input.is_null());
+    ASSERT(suggestion.starts_with(m_partial_input));
+
+    auto completion = suggestion.substring(m_partial_input.length(), suggestion.length() - m_partial_input.length());
+    m_editor->insert_at_cursor_or_replace_selection(completion);
+}
+
+};

--- a/DevTools/HackStudio/AutoCompleteBox.h
+++ b/DevTools/HackStudio/AutoCompleteBox.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/WeakPtr.h>
+#include <LibGUI/Widget.h>
+
+namespace HackStudio {
+
+class Editor;
+class AutoCompleteBox final {
+public:
+    explicit AutoCompleteBox(WeakPtr<Editor>);
+    ~AutoCompleteBox();
+
+    void update_suggestions(const String partial_input, Vector<String>&& suggestions);
+    void show(Gfx::IntPoint suggstion_box_location);
+    void close();
+
+    void next_suggestion();
+    void previous_suggestion();
+    void apply_suggestion();
+
+private:
+    void complete_suggestion(const GUI::ModelIndex&);
+
+    WeakPtr<Editor> m_editor;
+    RefPtr<GUI::Window> m_popup_window;
+    RefPtr<GUI::TableView> m_suggestion_view;
+    String m_partial_input;
+};
+}

--- a/DevTools/HackStudio/CMakeLists.txt
+++ b/DevTools/HackStudio/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     CodeDocument.cpp
+    CppAutoComplete.cpp
     CursorTool.cpp
     Debugger/BacktraceModel.cpp
     Debugger/DebugInfoWidget.cpp

--- a/DevTools/HackStudio/CMakeLists.txt
+++ b/DevTools/HackStudio/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    AutoCompleteBox.cpp
     CodeDocument.cpp
     CppAutoComplete.cpp
     CursorTool.cpp

--- a/DevTools/HackStudio/CppAutoComplete.cpp
+++ b/DevTools/HackStudio/CppAutoComplete.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CppAutoComplete.h"
+#include <AK/HashTable.h>
+#include <LibGUI/CppLexer.h>
+
+// #define DEBUG_AUTOCOMPLETE
+
+namespace HackStudio {
+Vector<String> CppAutoComplete::get_suggestions(const String& code, GUI::TextPosition autocomplete_position)
+{
+    auto lines = code.split('\n', true);
+    GUI::CppLexer lexer(code);
+    auto tokens = lexer.lex();
+
+    auto index_of_target_token = token_in_position(tokens, autocomplete_position);
+    if (!index_of_target_token.has_value())
+        return {};
+
+    auto suggestions = identifier_prefixes(lines, tokens, index_of_target_token.value());
+
+#ifdef DEBUG_AUTOCOMPLETE
+    for (auto& suggestion : suggestions) {
+        dbg() << "suggestion: " << suggestion;
+    }
+#endif
+
+    return suggestions;
+}
+
+String CppAutoComplete::text_of_token(const Vector<String> lines, const GUI::CppToken& token)
+{
+    return lines[token.m_start.line].substring(token.m_start.column, token.m_end.column - token.m_start.column + 1);
+}
+
+Optional<size_t> CppAutoComplete::token_in_position(const Vector<GUI::CppToken>& tokens, GUI::TextPosition position)
+{
+    for (size_t token_index = 0; token_index < tokens.size(); ++token_index) {
+        auto& token = tokens[token_index];
+        if (token.m_start.line != position.line())
+            continue;
+        if (token.m_start.column > position.column() || token.m_end.column < position.column())
+            continue;
+        return token_index;
+    }
+    return {};
+}
+
+Vector<String> CppAutoComplete::identifier_prefixes(const Vector<String> lines, const Vector<GUI::CppToken>& tokens, size_t target_token_index)
+{
+    auto partial_input = text_of_token(lines, tokens[target_token_index]);
+    Vector<String> suggestions;
+
+    HashTable<String> suggestions_lookup; // To avoid duplicate results
+
+    for (size_t i = 0; i < target_token_index; ++i) {
+        auto& token = tokens[i];
+        if (token.m_type != GUI::CppToken::Type::Identifier)
+            continue;
+        auto text = text_of_token(lines, token);
+        if (text.starts_with(partial_input) && !suggestions_lookup.contains(text)) {
+            suggestions_lookup.set(text);
+            suggestions.append(text);
+        }
+    }
+    return suggestions;
+}
+};

--- a/DevTools/HackStudio/CppAutoComplete.h
+++ b/DevTools/HackStudio/CppAutoComplete.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibGUI/CppLexer.h>
+#include <LibGUI/TextPosition.h>
+
+namespace HackStudio {
+class CppAutoComplete {
+public:
+    CppAutoComplete() = delete;
+
+    static Vector<String> get_suggestions(const String& code, GUI::TextPosition autocomplete_position);
+
+private:
+    static Optional<size_t> token_in_position(const Vector<GUI::CppToken>&, GUI::TextPosition);
+    static String text_of_token(const Vector<String> lines, const GUI::CppToken&);
+    static Vector<String> identifier_prefixes(const Vector<String> lines, const Vector<GUI::CppToken>&, size_t target_token_index);
+};
+};

--- a/DevTools/HackStudio/Editor.h
+++ b/DevTools/HackStudio/Editor.h
@@ -26,9 +26,11 @@
 
 #pragma once
 
+#include "AutoCompleteBox.h"
 #include "CodeDocument.h"
 #include "Debugger/BreakpointCallback.h"
 #include <AK/Optional.h>
+#include <AK/OwnPtr.h>
 #include <LibGUI/TextEditor.h>
 #include <LibWeb/Forward.h>
 
@@ -78,15 +80,28 @@ private:
     static const Gfx::Bitmap& breakpoint_icon_bitmap();
     static const Gfx::Bitmap& current_position_icon_bitmap();
 
+    struct AutoCompleteRequestData {
+        GUI::TextPosition position;
+        String partial_input;
+    };
+
+    Optional<AutoCompleteRequestData> get_autocomplete_request_data();
+
+    void update_autocomplete(const AutoCompleteRequestData&);
+    void show_autocomplete(const AutoCompleteRequestData&);
+    void close_autocomplete();
+
     explicit Editor();
 
     RefPtr<GUI::Window> m_documentation_tooltip_window;
+    OwnPtr<AutoCompleteBox> m_autocomplete_box;
     RefPtr<Web::InProcessWebView> m_documentation_page_view;
     String m_last_parsed_token;
     GUI::TextPosition m_previous_text_position { 0, 0 };
     bool m_hovering_editor { false };
     bool m_hovering_link { false };
     bool m_holding_ctrl { false };
+    bool m_autocomplete_in_focus { false };
 };
 
 }

--- a/Libraries/LibGUI/TextEditor.h
+++ b/Libraries/LibGUI/TextEditor.h
@@ -183,6 +183,8 @@ protected:
 
     TextPosition text_position_at(const Gfx::IntPoint&) const;
     bool ruler_visible() const { return m_ruler_visible; }
+    Gfx::IntRect content_rect_for_position(const TextPosition&) const;
+    int ruler_width() const;
 
 private:
     friend class TextDocumentLine;
@@ -228,7 +230,6 @@ private:
     Gfx::IntRect line_content_rect(size_t item_index) const;
     Gfx::IntRect line_widget_rect(size_t line_index) const;
     Gfx::IntRect cursor_content_rect() const;
-    Gfx::IntRect content_rect_for_position(const TextPosition&) const;
     void update_cursor();
     const NonnullOwnPtrVector<TextDocumentLine>& lines() const { return document().lines(); }
     NonnullOwnPtrVector<TextDocumentLine>& lines() { return document().lines(); }
@@ -236,7 +237,6 @@ private:
     const TextDocumentLine& line(size_t index) const { return document().line(index); }
     TextDocumentLine& current_line() { return line(m_cursor.line()); }
     const TextDocumentLine& current_line() const { return line(m_cursor.line()); }
-    int ruler_width() const;
     void toggle_selection_if_needed_for_event(const KeyEvent&);
     void delete_selection();
     void did_update_selection();


### PR DESCRIPTION
This adds basic autocomplete for C++ in HackStudio, triggered with `Ctrl+Space`.

Nothing fancy here, using the `CppLexer` to find identifiers that match with what the user wants to complete.

In the future, it would be interesting to have some sort of Language Server which would have more sophisticated logic than what we currently do.

Screenshot:
![hs-autocomplete](https://user-images.githubusercontent.com/9247514/93718474-3ebcbc80-fb85-11ea-9c75-2babbbfc0eae.png)

