### PR TITLE
SystemMonitor: TCP sequence numbers appeared negative every so often.

### DIFF
--- a/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Libraries/LibGUI/JsonArrayModel.cpp
@@ -107,7 +107,7 @@ Variant JsonArrayModel::data(const ModelIndex& index, ModelRole role) const
         if (field_spec.massage_for_display)
             return field_spec.massage_for_display(object);
         if (data.is_number())
-            return data.to_i32();
+            return data;
         return object.get(json_field_name).to_string();
     }
 

--- a/Libraries/LibGUI/JsonArrayModel.h
+++ b/Libraries/LibGUI/JsonArrayModel.h
@@ -64,7 +64,7 @@ public:
         return adopt(*new JsonArrayModel(json_path, move(fields)));
     }
 
-    virtual ~JsonArrayModel() override {}
+    virtual ~JsonArrayModel() override { }
 
     virtual int row_count(const ModelIndex& = ModelIndex()) const override { return m_array.size(); }
     virtual int column_count(const ModelIndex& = ModelIndex()) const override { return m_fields.size(); }


### PR DESCRIPTION
Here is what I mean:

![Screenshot from 2020-09-20 21-04-46](https://user-images.githubusercontent.com/31994781/93719799-349abe00-fb85-11ea-9359-dbf8a9bc92b1.png)


Since TCP sequence numbers are randomly chosen 32-bit numbers, it often happened that the most significant bit was set. The cast to a 32-bit signed integer then made the number negative.
