### PR TITLE
FontEditor: Draw the baseline in the glyph editor widget

### DIFF
--- a/Applications/FontEditor/FontEditor.cpp
+++ b/Applications/FontEditor/FontEditor.cpp
@@ -304,6 +304,7 @@ FontEditorWidget::FontEditorWidget(const String& path, RefPtr<Gfx::Font>&& edite
 
     baseline_spinbox.on_change = [this, update_demo](int value) {
         m_edited_font->set_baseline(value);
+        m_glyph_editor_widget->update();
         update_demo();
     };
 

--- a/Applications/FontEditor/GlyphEditorWidget.cpp
+++ b/Applications/FontEditor/GlyphEditorWidget.cpp
@@ -58,8 +58,10 @@ void GlyphEditorWidget::paint_event(GUI::PaintEvent& event)
     painter.translate(frame_thickness(), frame_thickness());
 
     painter.translate(-1, -1);
-    for (int y = 1; y < font().glyph_height(); ++y)
-        painter.draw_line({ 0, y * m_scale }, { font().max_glyph_width() * m_scale, y * m_scale }, palette().threed_shadow2());
+    for (int y = 1; y < font().glyph_height(); ++y) {
+        bool bold_line = (y - 1) == font().baseline();
+        painter.draw_line({ 0, y * m_scale }, { font().max_glyph_width() * m_scale, y * m_scale }, palette().threed_shadow2(), bold_line ? 2 : 1);
+    }
 
     for (int x = 1; x < font().max_glyph_width(); ++x)
         painter.draw_line({ x * m_scale, 0 }, { x * m_scale, font().glyph_height() * m_scale }, palette().threed_shadow2());


### PR DESCRIPTION
To make it [easier to determine](https://youtu.be/YjNtCClX6fM?t=1033) where font baselines should go.

**Screenshot:**
![Screenshot_20200920_213023](https://user-images.githubusercontent.com/1627292/93720684-e7b9e600-fb8a-11ea-818d-e422b6ad659f.png)
