### PR TITLE
Spreadsheet: Always keep the workbook interpreter in VM scope

### DIFF
--- a/Applications/Spreadsheet/Workbook.cpp
+++ b/Applications/Spreadsheet/Workbook.cpp
@@ -48,6 +48,7 @@ static JS::VM& global_vm()
 Workbook::Workbook(NonnullRefPtrVector<Sheet>&& sheets)
     : m_sheets(move(sheets))
     , m_interpreter(JS::Interpreter::create<JS::GlobalObject>(global_vm()))
+    , m_interpreter_scope(JS::VM::InterpreterScope(interpreter()))
 {
     m_workbook_object = interpreter().heap().allocate<WorkbookObject>(global_object(), *this);
     global_object().put("workbook", workbook_object());

--- a/Applications/Spreadsheet/Workbook.h
+++ b/Applications/Spreadsheet/Workbook.h
@@ -66,6 +66,7 @@ public:
 private:
     NonnullRefPtrVector<Sheet> m_sheets;
     NonnullOwnPtr<JS::Interpreter> m_interpreter;
+    JS::VM::InterpreterScope m_interpreter_scope;
     WorkbookObject* m_workbook_object { nullptr };
 
     String m_current_filename;


### PR DESCRIPTION
Fixes #3570.

cc @awesomekling, also please take a look at #3570 