### PR TITLE
some fpu support for ue

### DIFF
--- a/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -1474,7 +1474,6 @@ void SoftCPU::FLDCW(const X86::Instruction& insn)
 
 void SoftCPU::FLD1(const X86::Instruction&)
 {
-dbg() << "fld1";
     fpu_push(1.0);
 }
 
@@ -1483,7 +1482,12 @@ void SoftCPU::FLDL2E(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FLDPI(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FLDLG2(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FLDLN2(const X86::Instruction&) { TODO_INSN(); }
-void SoftCPU::FLDZ(const X86::Instruction&) { TODO_INSN(); }
+
+void SoftCPU::FLDZ(const X86::Instruction&)
+{
+    fpu_push(0.0);
+}
+
 void SoftCPU::FNSTENV(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::F2XM1(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FYL2X(const X86::Instruction&) { TODO_INSN(); }
@@ -1555,11 +1559,27 @@ void SoftCPU::FSUB_RM64(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FSUBR_RM64(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FDIV_RM64(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FDIVR_RM64(const X86::Instruction&) { TODO_INSN(); }
-void SoftCPU::FLD_RM64(const X86::Instruction&) { TODO_INSN(); }
+
+void SoftCPU::FLD_RM64(const X86::Instruction& insn)
+{
+dbg() << "fld";
+    auto new_f64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
+    // FIXME: Respect shadow values
+    fpu_push(bit_cast<double>(new_f64.value()));
+}
+
 void SoftCPU::FFREE(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FISTTP_RM64(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FST_RM64(const X86::Instruction&) { TODO_INSN(); }
-void SoftCPU::FSTP_RM64(const X86::Instruction&) { TODO_INSN(); }
+
+void SoftCPU::FSTP_RM64(const X86::Instruction& insn)
+{
+dbg() << "fstp";
+    double f64 = (double)fpu_pop();
+    // FIXME: Respect shadow values
+    insn.modrm().write64(*this, insn, shadow_wrap_as_initialized(bit_cast<u64>(f64)));
+}
+
 void SoftCPU::FRSTOR(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FUCOM(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FUCOMP(const X86::Instruction&) { TODO_INSN(); }
@@ -1587,7 +1607,14 @@ void SoftCPU::FIST_RM16(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FISTP_RM16(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FBLD_M80(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FNSTSW_AX(const X86::Instruction&) { TODO_INSN(); }
-void SoftCPU::FILD_RM64(const X86::Instruction&) { TODO_INSN(); }
+
+void SoftCPU::FILD_RM64(const X86::Instruction& insn)
+{
+    auto new_s64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
+    // FIXME: Respect shadow values
+    fpu_push((long double)(int64_t)new_s64.value());
+}
+
 void SoftCPU::FUCOMIP(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FBSTP_M80(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FCOMIP(const X86::Instruction&) { TODO_INSN(); }

--- a/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -1424,9 +1424,11 @@ void SoftCPU::ESCAPE(const X86::Instruction&)
 
 void SoftCPU::FADD_RM32(const X86::Instruction& insn)
 {
+dbg() << "fadd";
     // XXX look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem32 ops
     // XXX in the meantime, assert this has a mem arg
-    auto new_f32 = read_memory32({ segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS)), insn.imm_address() });
+    //auto new_f32 = read_memory32({ segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS)), insn.imm_address() });
+    auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
     // FIXME: Respect shadow values
     float f32 = m_fpu[(m_fpu_top++) % 8] = bit_cast<float>(new_f32.value());
     m_fpu[m_fpu_top % 8] = m_fpu[(m_fpu_top - 1) % 8] + bit_cast<float>(f32);
@@ -1443,6 +1445,7 @@ void SoftCPU::FDIVR_RM32(const X86::Instruction&) { TODO_INSN(); }
 
 void SoftCPU::FLD_RM32(const X86::Instruction& insn)
 {
+dbg() << "fld";
     //auto new_f32 = read_memory32({ segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS)), insn.imm_address() });
     auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
     // FIXME: Respect shadow values
@@ -1455,6 +1458,7 @@ void SoftCPU::FNOP(const X86::Instruction&) { TODO_INSN(); }
 
 void SoftCPU::FSTP_RM32(const X86::Instruction& insn)
 {
+dbg() << "fstp";
     float f32 = m_fpu[(m_fpu_top--) % 8];
     // FIXME: Respect shadow values
     //write_memory32({ segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS)), insn.imm_address() }, shadow_wrap_as_initialized(bit_cast<u32>(f32)));
@@ -1474,6 +1478,7 @@ void SoftCPU::FLDCW(const X86::Instruction& insn)
 
 void SoftCPU::FLD1(const X86::Instruction&)
 {
+dbg() << "fld1";
     m_fpu[(m_fpu_top++) % 8] = 1.0;
 }
 
@@ -1528,11 +1533,13 @@ void SoftCPU::FCMOVNBE(const X86::Instruction&) { TODO_INSN(); }
 
 void SoftCPU::FISTP_RM32(const X86::Instruction& insn)
 {
+dbg() << "fistp";
     float f32 = m_fpu[(m_fpu_top--) % 8];
     // FIXME: Respect rounding mode in m_fpu_cw.
     int32_t i32 = static_cast<int32_t>(f32);
     // FIXME: Respect shadow values
-    write_memory32({ segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS)), insn.imm_address() }, shadow_wrap_as_initialized(bit_cast<u32>(i32)));
+    //write_memory32({ segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS)), insn.imm_address() }, shadow_wrap_as_initialized(bit_cast<u32>(i32)));
+    insn.modrm().write32(*this, insn, shadow_wrap_as_initialized(bit_cast<u32>(i32)));
 }
 
 void SoftCPU::FCMOVNU(const X86::Instruction&) { TODO_INSN(); }

--- a/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -1552,7 +1552,17 @@ void SoftCPU::FUCOMI(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FCOMI(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FSTP_RM80(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FADD_RM64(const X86::Instruction&) { TODO_INSN(); }
-void SoftCPU::FMUL_RM64(const X86::Instruction&) { TODO_INSN(); }
+
+void SoftCPU::FMUL_RM64(const X86::Instruction& insn)
+{
+    // XXX look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem32 ops
+    // XXX in the meantime, assert this has a mem arg
+    auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+    // FIXME: Respect shadow values
+    float f32 = bit_cast<float>(new_f32.value());
+    fpu_set(0, fpu_get(0) * f32);
+}
+
 void SoftCPU::FCOM_RM64(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FCOMP_RM64(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FSUB_RM64(const X86::Instruction&) { TODO_INSN(); }
@@ -1570,7 +1580,13 @@ dbg() << "fld";
 
 void SoftCPU::FFREE(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FISTTP_RM64(const X86::Instruction&) { TODO_INSN(); }
-void SoftCPU::FST_RM64(const X86::Instruction&) { TODO_INSN(); }
+
+void SoftCPU::FST_RM64(const X86::Instruction& insn)
+{
+    double f64 = (double)fpu_get(0);
+    // FIXME: Respect shadow values
+    insn.modrm().write64(*this, insn, shadow_wrap_as_initialized(bit_cast<u64>(f64)));
+}
 
 void SoftCPU::FSTP_RM64(const X86::Instruction& insn)
 {
@@ -1588,14 +1604,26 @@ void SoftCPU::FNSTSW(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FIADD_RM16(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FADDP(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FIMUL_RM16(const X86::Instruction&) { TODO_INSN(); }
-void SoftCPU::FMULP(const X86::Instruction&) { TODO_INSN(); }
+
+void SoftCPU::FMULP(const X86::Instruction&)
+{
+    fpu_set(1, fpu_get(1) * fpu_get(0));
+    fpu_pop();
+}
+
 void SoftCPU::FICOM_RM16(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FICOMP_RM16(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FCOMPP(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FISUB_RM16(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FSUBRP(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FISUBR_RM16(const X86::Instruction&) { TODO_INSN(); }
-void SoftCPU::FSUBP(const X86::Instruction&) { TODO_INSN(); }
+
+void SoftCPU::FSUBP(const X86::Instruction&)
+{
+    fpu_set(1, fpu_get(1) - fpu_get(0));
+    fpu_pop();
+}
+
 void SoftCPU::FIDIV_RM16(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FDIVRP(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FIDIVR_RM16(const X86::Instruction&) { TODO_INSN(); }

--- a/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -1429,7 +1429,6 @@ void SoftCPU::bt() const
 
 void SoftCPU::FADD_RM32(const X86::Instruction& insn)
 {
-dbg() << "fadd";
     // XXX look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem32 ops
     if (insn.modrm().is_register()) {
         fpu_set(0, fpu_get(insn.modrm().register_index()) + fpu_get(0));
@@ -1446,7 +1445,6 @@ void SoftCPU::FMUL_RM32(const X86::Instruction& insn)
     // XXX look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem32 ops
     if (insn.modrm().is_register()) {
         fpu_set(0, fpu_get(0) * fpu_get(insn.modrm().register_index()));
-dbg() << "fmul.32: " << (double)fpu_get(0);
     } else {
         auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
         // FIXME: Respect shadow values
@@ -1492,7 +1490,6 @@ void SoftCPU::FLD_RM32(const X86::Instruction& insn)
         auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
         // FIXME: Respect shadow values
         fpu_push(bit_cast<float>(new_f32.value()));
-dbg() << "fld.32: " << (double)fpu_get(0);
     }
 }
 
@@ -1541,7 +1538,6 @@ void SoftCPU::FLDLN2(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FLDZ(const X86::Instruction&)
 {
     fpu_push(0.0);
-dbg() << "fldz, stack top " << m_fpu_top;
 }
 
 void SoftCPU::FNSTENV(const X86::Instruction&) { TODO_INSN(); }
@@ -1655,7 +1651,6 @@ void SoftCPU::FMUL_RM64(const X86::Instruction& insn)
     // XXX look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem64 ops
     if (insn.modrm().is_register()) {
         fpu_set(insn.modrm().register_index(), fpu_get(insn.modrm().register_index()) * fpu_get(0));
-dbg() << "fmul.64: " << (double)fpu_get(insn.modrm().register_index()) << " (" << insn.modrm().register_index() << ")";
     } else {
         auto new_f64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
         // FIXME: Respect shadow values
@@ -1696,7 +1691,6 @@ void SoftCPU::FLD_RM64(const X86::Instruction& insn)
     auto new_f64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
     // FIXME: Respect shadow values
     fpu_push(bit_cast<double>(new_f64.value()));
-dbg() << "fld64: " << (double)fpu_get(0);
 }
 
 void SoftCPU::FFREE(const X86::Instruction&) { TODO_INSN(); }
@@ -1705,20 +1699,16 @@ void SoftCPU::FISTTP_RM64(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FST_RM64(const X86::Instruction& insn)
 {
     if (insn.modrm().is_register()) {
-//dbg() << "fst.reg: " << insn.modrm().register_index();
-//bt();
         fpu_set(insn.modrm().register_index(), fpu_get(0));
     } else {
         // FIXME: Respect shadow values
         double f64 = (double)fpu_get(0);
         insn.modrm().write64(*this, insn, shadow_wrap_as_initialized(bit_cast<u64>(f64)));
-//dbg() << "fst.64: " << f64;
     }
 }
 
 void SoftCPU::FSTP_RM64(const X86::Instruction& insn)
 {
-dbg() << "fstp64, stack top: " << m_fpu_top;
     FST_RM64(insn);
     fpu_pop();
 }
@@ -1747,7 +1737,6 @@ void SoftCPU::FIMUL_RM16(const X86::Instruction& insn)
 
 void SoftCPU::FMULP(const X86::Instruction& insn)
 {
-dbg() << "fmulp";
     ASSERT(insn.modrm().is_register());
     fpu_set(insn.modrm().register_index(), fpu_get(insn.modrm().register_index()) * fpu_get(0));
     fpu_pop();
@@ -1764,7 +1753,6 @@ void SoftCPU::FSUBP(const X86::Instruction& insn)
 {
     ASSERT(insn.modrm().is_register());
     fpu_set(insn.modrm().register_index(), fpu_get(insn.modrm().register_index()) - fpu_get(0));
-dbg() << "fsubp: " << (double)fpu_get(insn.modrm().register_index());
     fpu_pop();
 }
 
@@ -1794,7 +1782,6 @@ void SoftCPU::FILD_RM16(const X86::Instruction& insn)
     auto new_s16 = insn.modrm().read16<ValueWithShadow<u16>>(*this, insn);
     // FIXME: Respect shadow values
     fpu_push((long double)(int16_t)new_s16.value());
-dbg() << "fild.16: " << (double)fpu_get(0);
 }
 
 void SoftCPU::FFREEP(const X86::Instruction&) { TODO_INSN(); }
@@ -1820,7 +1807,6 @@ void SoftCPU::FILD_RM64(const X86::Instruction& insn)
     auto new_s64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
     // FIXME: Respect shadow values
     fpu_push((long double)(int64_t)new_s64.value());
-dbg() << "fild: " << (double)fpu_get(0);
 }
 
 void SoftCPU::FUCOMIP(const X86::Instruction& insn)
@@ -1835,7 +1821,6 @@ void SoftCPU::FCOMIP(const X86::Instruction& insn)
 {
     FCOMI(insn);
     fpu_pop();
-dbg() << "fcomip, stack top: " << m_fpu_top;
 }
 
 void SoftCPU::FISTP_RM64(const X86::Instruction& insn)

--- a/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -1427,12 +1427,10 @@ void SoftCPU::FADD_RM32(const X86::Instruction& insn)
 dbg() << "fadd";
     // XXX look at ::INC_foo for how mem/reg stuff is handled, and use that here too to make sure this is only called for mem32 ops
     // XXX in the meantime, assert this has a mem arg
-    //auto new_f32 = read_memory32({ segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS)), insn.imm_address() });
     auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
     // FIXME: Respect shadow values
-    float f32 = m_fpu[(m_fpu_top++) % 8] = bit_cast<float>(new_f32.value());
-    m_fpu[m_fpu_top % 8] = m_fpu[(m_fpu_top - 1) % 8] + bit_cast<float>(f32);
-    m_fpu_top++;
+    float f32 = bit_cast<float>(new_f32.value());
+    fpu_set(0, fpu_get(0) + f32);
 }
 
 void SoftCPU::FMUL_RM32(const X86::Instruction&) { TODO_INSN(); }
@@ -1446,10 +1444,9 @@ void SoftCPU::FDIVR_RM32(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FLD_RM32(const X86::Instruction& insn)
 {
 dbg() << "fld";
-    //auto new_f32 = read_memory32({ segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS)), insn.imm_address() });
     auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
     // FIXME: Respect shadow values
-    m_fpu[(m_fpu_top++) % 8] = bit_cast<float>(new_f32.value());
+    fpu_push(bit_cast<float>(new_f32.value()));
 }
 
 void SoftCPU::FXCH(const X86::Instruction&) { TODO_INSN(); }
@@ -1459,9 +1456,8 @@ void SoftCPU::FNOP(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FSTP_RM32(const X86::Instruction& insn)
 {
 dbg() << "fstp";
-    float f32 = m_fpu[(m_fpu_top--) % 8];
+    float f32 = (float)fpu_pop();
     // FIXME: Respect shadow values
-    //write_memory32({ segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS)), insn.imm_address() }, shadow_wrap_as_initialized(bit_cast<u32>(f32)));
     insn.modrm().write32(*this, insn, shadow_wrap_as_initialized(bit_cast<u32>(f32)));
 }
 
@@ -1479,7 +1475,7 @@ void SoftCPU::FLDCW(const X86::Instruction& insn)
 void SoftCPU::FLD1(const X86::Instruction&)
 {
 dbg() << "fld1";
-    m_fpu[(m_fpu_top++) % 8] = 1.0;
+    fpu_push(1.0);
 }
 
 void SoftCPU::FLDL2T(const X86::Instruction&) { TODO_INSN(); }
@@ -1534,11 +1530,10 @@ void SoftCPU::FCMOVNBE(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FISTP_RM32(const X86::Instruction& insn)
 {
 dbg() << "fistp";
-    float f32 = m_fpu[(m_fpu_top--) % 8];
+    float f32 = fpu_pop();
     // FIXME: Respect rounding mode in m_fpu_cw.
     int32_t i32 = static_cast<int32_t>(f32);
     // FIXME: Respect shadow values
-    //write_memory32({ segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS)), insn.imm_address() }, shadow_wrap_as_initialized(bit_cast<u32>(i32)));
     insn.modrm().write32(*this, insn, shadow_wrap_as_initialized(bit_cast<u32>(i32)));
 }
 

--- a/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -1627,7 +1627,15 @@ void SoftCPU::FISUB_RM32(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FISUBR_RM32(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FUCOMPP(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FIDIV_RM32(const X86::Instruction&) { TODO_INSN(); }
-void SoftCPU::FIDIVR_RM32(const X86::Instruction&) { TODO_INSN(); }
+
+void SoftCPU::FIDIVR_RM32(const X86::Instruction& insn)
+{
+    ASSERT(!insn.modrm().is_register());
+    auto new_s32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+    // FIXME: Respect shadow values
+    // FIXME: Raise IA on 0 / _=0, raise Z on finite / +-0
+    fpu_set(0, (long double)(int32_t)new_s32.value() / fpu_get(0));
+}
 
 void SoftCPU::FILD_RM32(const X86::Instruction& insn)
 {

--- a/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -1434,7 +1434,7 @@ void SoftCPU::FADD_RM32(const X86::Instruction& insn)
     if (insn.modrm().is_register()) {
         fpu_set(0, fpu_get(insn.modrm().register_index()) + fpu_get(0));
     } else {
-        auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+        auto new_f32 = insn.modrm().read32(*this, insn);
         // FIXME: Respect shadow values
         auto f32 = bit_cast<float>(new_f32.value());
         fpu_set(0, fpu_get(0) + f32);
@@ -1447,7 +1447,7 @@ void SoftCPU::FMUL_RM32(const X86::Instruction& insn)
     if (insn.modrm().is_register()) {
         fpu_set(0, fpu_get(0) * fpu_get(insn.modrm().register_index()));
     } else {
-        auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+        auto new_f32 = insn.modrm().read32(*this, insn);
         // FIXME: Respect shadow values
         auto f32 = bit_cast<float>(new_f32.value());
         fpu_set(0, fpu_get(0) * f32);
@@ -1462,7 +1462,7 @@ void SoftCPU::FSUB_RM32(const X86::Instruction& insn)
     if (insn.modrm().is_register()) {
         fpu_set(0, fpu_get(0) - fpu_get(insn.modrm().register_index()));
     } else {
-        auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+        auto new_f32 = insn.modrm().read32(*this, insn);
         // FIXME: Respect shadow values
         auto f32 = bit_cast<float>(new_f32.value());
         fpu_set(0, fpu_get(0) - f32);
@@ -1474,7 +1474,7 @@ void SoftCPU::FSUBR_RM32(const X86::Instruction& insn)
     if (insn.modrm().is_register()) {
         fpu_set(0, fpu_get(insn.modrm().register_index()) - fpu_get(0));
     } else {
-        auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+        auto new_f32 = insn.modrm().read32(*this, insn);
         // FIXME: Respect shadow values
         auto f32 = bit_cast<float>(new_f32.value());
         fpu_set(0, f32 - fpu_get(0));
@@ -1486,7 +1486,7 @@ void SoftCPU::FDIV_RM32(const X86::Instruction& insn)
     if (insn.modrm().is_register()) {
         fpu_set(0, fpu_get(0) / fpu_get(insn.modrm().register_index()));
     } else {
-        auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+        auto new_f32 = insn.modrm().read32(*this, insn);
         // FIXME: Respect shadow values
         auto f32 = bit_cast<float>(new_f32.value());
         // FIXME: Raise IA on + infinity / +-infinitiy, +-0 / +-0, raise Z on finite / +-0
@@ -1499,7 +1499,7 @@ void SoftCPU::FDIVR_RM32(const X86::Instruction& insn)
     if (insn.modrm().is_register()) {
         fpu_set(0, fpu_get(insn.modrm().register_index()) / fpu_get(0));
     } else {
-        auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+        auto new_f32 = insn.modrm().read32(*this, insn);
         // FIXME: Respect shadow values
         auto f32 = bit_cast<float>(new_f32.value());
         // FIXME: Raise IA on + infinity / +-infinitiy, +-0 / +-0, raise Z on finite / +-0
@@ -1512,7 +1512,7 @@ void SoftCPU::FLD_RM32(const X86::Instruction& insn)
     if (insn.modrm().is_register()) {
         fpu_push(fpu_get(insn.modrm().register_index()));
     } else {
-        auto new_f32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+        auto new_f32 = insn.modrm().read32(*this, insn);
         // FIXME: Respect shadow values
         fpu_push(bit_cast<float>(new_f32.value()));
     }
@@ -1613,7 +1613,7 @@ void SoftCPU::FCMOVB(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FIMUL_RM32(const X86::Instruction& insn)
 {
     ASSERT(!insn.modrm().is_register());
-    auto new_s32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+    auto new_s32 = insn.modrm().read32(*this, insn);
     // FIXME: Respect shadow values
     fpu_set(0, fpu_get(0) * (long double)(int32_t)new_s32.value());
 }
@@ -1631,7 +1631,7 @@ void SoftCPU::FIDIV_RM32(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FIDIVR_RM32(const X86::Instruction& insn)
 {
     ASSERT(!insn.modrm().is_register());
-    auto new_s32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+    auto new_s32 = insn.modrm().read32(*this, insn);
     // FIXME: Respect shadow values
     // FIXME: Raise IA on 0 / _=0, raise Z on finite / +-0
     fpu_set(0, (long double)(int32_t)new_s32.value() / fpu_get(0));
@@ -1640,7 +1640,7 @@ void SoftCPU::FIDIVR_RM32(const X86::Instruction& insn)
 void SoftCPU::FILD_RM32(const X86::Instruction& insn)
 {
     ASSERT(!insn.modrm().is_register());
-    auto new_s32 = insn.modrm().read32<ValueWithShadow<u32>>(*this, insn);
+    auto new_s32 = insn.modrm().read32(*this, insn);
     // FIXME: Respect shadow values
     fpu_push((long double)(int32_t)new_s32.value());
 }
@@ -1704,7 +1704,7 @@ void SoftCPU::FADD_RM64(const X86::Instruction& insn)
     if (insn.modrm().is_register()) {
         fpu_set(insn.modrm().register_index(), fpu_get(insn.modrm().register_index()) + fpu_get(0));
     } else {
-        auto new_f64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
+        auto new_f64 = insn.modrm().read64(*this, insn);
         // FIXME: Respect shadow values
         auto f64 = bit_cast<double>(new_f64.value());
         fpu_set(0, fpu_get(0) + f64);
@@ -1717,7 +1717,7 @@ void SoftCPU::FMUL_RM64(const X86::Instruction& insn)
     if (insn.modrm().is_register()) {
         fpu_set(insn.modrm().register_index(), fpu_get(insn.modrm().register_index()) * fpu_get(0));
     } else {
-        auto new_f64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
+        auto new_f64 = insn.modrm().read64(*this, insn);
         // FIXME: Respect shadow values
         auto f64 = bit_cast<double>(new_f64.value());
         fpu_set(0, fpu_get(0) * f64);
@@ -1731,7 +1731,7 @@ void SoftCPU::FSUB_RM64(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FSUBR_RM64(const X86::Instruction& insn)
 {
     ASSERT(!insn.modrm().is_register()); // FIXME
-    auto new_f64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
+    auto new_f64 = insn.modrm().read64(*this, insn);
     // FIXME: Respect shadow values
     auto f64 = bit_cast<double>(new_f64.value());
     fpu_set(0, f64 - fpu_get(0));
@@ -1741,7 +1741,7 @@ dbg() << "fsub.64: " << (double)fpu_get(0);
 void SoftCPU::FDIV_RM64(const X86::Instruction& insn)
 {
     ASSERT(!insn.modrm().is_register()); // FIXME
-    auto new_f64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
+    auto new_f64 = insn.modrm().read64(*this, insn);
     // FIXME: Respect shadow values
     auto f64 = bit_cast<double>(new_f64.value());
     // FIXME: Raise IA on + infinity / +-infinitiy, +-0 / +-0, raise Z on finite / +-0
@@ -1755,7 +1755,7 @@ void SoftCPU::FDIVR_RM64(const X86::Instruction& insn)
         //fpu_set(insn.modrm().register_index(), fpu_get(0) / fpu_get(insn.modrm().register_index()));
         fpu_set(insn.modrm().register_index(), fpu_get(insn.modrm().register_index()) / fpu_get(0));
     } else {
-        auto new_f64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
+        auto new_f64 = insn.modrm().read64(*this, insn);
         // FIXME: Respect shadow values
         auto f64 = bit_cast<double>(new_f64.value());
         // FIXME: Raise IA on + infinity / +-infinitiy, +-0 / +-0, raise Z on finite / +-0
@@ -1766,7 +1766,7 @@ void SoftCPU::FDIVR_RM64(const X86::Instruction& insn)
 void SoftCPU::FLD_RM64(const X86::Instruction& insn)
 {
     ASSERT(!insn.modrm().is_register());
-    auto new_f64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
+    auto new_f64 = insn.modrm().read64(*this, insn);
     // FIXME: Respect shadow values
     fpu_push(bit_cast<double>(new_f64.value()));
 }
@@ -1808,7 +1808,7 @@ void SoftCPU::FADDP(const X86::Instruction& insn)
 void SoftCPU::FIMUL_RM16(const X86::Instruction& insn)
 {
     ASSERT(!insn.modrm().is_register());
-    auto new_s16 = insn.modrm().read16<ValueWithShadow<u16>>(*this, insn);
+    auto new_s16 = insn.modrm().read16(*this, insn);
     // FIXME: Respect shadow values
     fpu_set(0, fpu_get(0) * (long double)(int16_t)new_s16.value());
 }
@@ -1864,7 +1864,7 @@ void SoftCPU::FDIVP(const X86::Instruction& insn)
 void SoftCPU::FILD_RM16(const X86::Instruction& insn)
 {
     ASSERT(!insn.modrm().is_register());
-    auto new_s16 = insn.modrm().read16<ValueWithShadow<u16>>(*this, insn);
+    auto new_s16 = insn.modrm().read16(*this, insn);
     // FIXME: Respect shadow values
     fpu_push((long double)(int16_t)new_s16.value());
 }
@@ -1889,7 +1889,7 @@ void SoftCPU::FNSTSW_AX(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::FILD_RM64(const X86::Instruction& insn)
 {
     ASSERT(!insn.modrm().is_register());
-    auto new_s64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
+    auto new_s64 = insn.modrm().read64(*this, insn);
     // FIXME: Respect shadow values
     fpu_push((long double)(int64_t)new_s64.value());
 }

--- a/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -1743,7 +1743,9 @@ void SoftCPU::FDIV_RM64(const X86::Instruction& insn)
 void SoftCPU::FDIVR_RM64(const X86::Instruction& insn)
 {
     if (insn.modrm().is_register()) {
-        fpu_set(insn.modrm().register_index(), fpu_get(0) / fpu_get(insn.modrm().register_index()));
+        // XXX this is FDIVR, Instruction decodes this weirdly
+        //fpu_set(insn.modrm().register_index(), fpu_get(0) / fpu_get(insn.modrm().register_index()));
+        fpu_set(insn.modrm().register_index(), fpu_get(insn.modrm().register_index()) / fpu_get(0));
     } else {
         auto new_f64 = insn.modrm().read64<ValueWithShadow<u64>>(*this, insn);
         // FIXME: Respect shadow values

--- a/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/DevTools/UserspaceEmulator/SoftCPU.h
@@ -1122,12 +1122,16 @@ private:
 
     long double m_fpu[8];
     // FIXME: Shadow for m_fpu.
+
+    // FIXME: Use bits 11 to 13 in the FPU status word for this.
     unsigned m_fpu_top { ~0u };
+
     void fpu_push(long double n) { ++m_fpu_top; fpu_set(0, n); }
     long double fpu_pop() { auto n = fpu_get(0); m_fpu_top--; return n; }
     long double fpu_get(int i) { return m_fpu[m_fpu_top + i]; }
     void fpu_set(int i, long double n) { m_fpu[m_fpu_top + i] = n; }
 
+    // FIXME: Or just something like m_flags_tainted?
     ValueWithShadow<u16> m_fpu_cw { 0, 0 };
 
     const u8* m_cached_code_ptr { nullptr };

--- a/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/DevTools/UserspaceEmulator/SoftCPU.h
@@ -1122,7 +1122,11 @@ private:
 
     long double m_fpu[8];
     // FIXME: Shadow for m_fpu.
-    u8 m_fpu_top { 0 };
+    u8 m_fpu_top { 255 };
+    void fpu_push(long double n) { m_fpu[++m_fpu_top] = n; }
+    long double fpu_pop() { return m_fpu[m_fpu_top--]; }
+    long double fpu_get(int i) { return m_fpu[m_fpu_top + i]; }
+    void fpu_set(int i, long double n) { m_fpu[m_fpu_top + i] = n; }
 
     ValueWithShadow<u16> m_fpu_cw { 0, 0 };
 

--- a/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/DevTools/UserspaceEmulator/SoftCPU.h
@@ -1108,6 +1108,7 @@ private:
 
 private:
     Emulator& m_emulator;
+    void bt() const;
 
     PartAddressableRegister m_gpr[8];
     PartAddressableRegister m_gpr_shadow[8];
@@ -1124,12 +1125,17 @@ private:
     // FIXME: Shadow for m_fpu.
 
     // FIXME: Use bits 11 to 13 in the FPU status word for this.
-    unsigned m_fpu_top { ~0u };
+    int m_fpu_top { -1 };
 
     void fpu_push(long double n) { ++m_fpu_top; fpu_set(0, n); }
     long double fpu_pop() { auto n = fpu_get(0); m_fpu_top--; return n; }
-    long double fpu_get(int i) { return m_fpu[m_fpu_top + i]; }
-    void fpu_set(int i, long double n) { m_fpu[m_fpu_top + i] = n; }
+    long double fpu_get(int i) { ASSERT(i >= 0 && i <= m_fpu_top); return m_fpu[m_fpu_top - i]; }
+    void fpu_set(int i, long double n) {
+        //if (i < 0 || i > m_fpu_top)
+            //bt();
+        ASSERT(i >= 0 && i <= m_fpu_top);
+        m_fpu[m_fpu_top - i] = n;
+    }
 
     // FIXME: Or just something like m_flags_tainted?
     ValueWithShadow<u16> m_fpu_cw { 0, 0 };

--- a/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/DevTools/UserspaceEmulator/SoftCPU.h
@@ -1120,6 +1120,10 @@ private:
     u32 m_eip { 0 };
     u32 m_base_eip { 0 };
 
+    long double m_fpu[8];
+    // FIXME: Shadow for m_fpu.
+    u8 m_fpu_top { 0 };
+
     ValueWithShadow<u16> m_fpu_cw { 0, 0 };
 
     const u8* m_cached_code_ptr { nullptr };

--- a/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/DevTools/UserspaceEmulator/SoftCPU.h
@@ -1122,9 +1122,9 @@ private:
 
     long double m_fpu[8];
     // FIXME: Shadow for m_fpu.
-    u8 m_fpu_top { 255 };
-    void fpu_push(long double n) { m_fpu[++m_fpu_top] = n; }
-    long double fpu_pop() { return m_fpu[m_fpu_top--]; }
+    unsigned m_fpu_top { ~0u };
+    void fpu_push(long double n) { ++m_fpu_top; fpu_set(0, n); }
+    long double fpu_pop() { auto n = fpu_get(0); m_fpu_top--; return n; }
     long double fpu_get(int i) { return m_fpu[m_fpu_top + i]; }
     void fpu_set(int i, long double n) { m_fpu[m_fpu_top + i] = n; }
 
@@ -1139,6 +1139,7 @@ private:
 
 ALWAYS_INLINE u8 SoftCPU::read8()
 {
+    // FIXME: + 1?
     if (!m_cached_code_ptr || m_cached_code_ptr >= m_cached_code_end)
         update_code_cache();
 


### PR DESCRIPTION
Part of #3329.

This is nowhere near done. It doesn't implement fpu exceptions, quiet/signaling nans, exception on div by 0, correct rounding modes, or even most fpu instructions (no fsave/frestore, fnstsw doesn't return anything, ...). It generally assumes that things work fine and aren't weird or corner-case-y. It *can* run ntpclient and TextEditor. 

Things to do to get this mergeable (in addition to removing debug logging, and cleaning up the commits):

- [ ] Come up with a shadow handling strategy for fpu words. The FPU registers are 80-bit wide so per-bit shadow state gets smeared out immediately. Probably just keep a single "is valid" bit per register and set that if any input bit is invalid and use it to taint outputs?

- [ ] Probably replace all bit_cast<> calls with just reinterpret_cast pointer cast + deref? That seems what most other places do, but something like bit_cast<> is what the standard wants us to do.

- [ ] Many of the instructions I did implement explicitly check `modrm().is_register()`, which looks wrong -- Instruction.cpp should probably use different InstructionFormats and call different functions for register and memory operands (?). Or maybe this is fine as-is; not sure what the desired design here is. Most other existing instruction handlers don't have this check though.

@awesomekling Input on these 3 points would be appreciated :)