### PR TITLE
AK: Make format avaliable in kernel.

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -182,13 +182,18 @@ void Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type>::format(StringB
 
 template struct Formatter<StringView>;
 template struct Formatter<String>;
-template struct Formatter<u8, void>;
-template struct Formatter<u16, void>;
-template struct Formatter<u32, void>;
-template struct Formatter<u64, void>;
-template struct Formatter<i8, void>;
-template struct Formatter<i16, void>;
-template struct Formatter<i32, void>;
-template struct Formatter<i64, void>;
+template struct Formatter<unsigned char, void>;
+template struct Formatter<unsigned short, void>;
+template struct Formatter<unsigned int, void>;
+template struct Formatter<unsigned long, void>;
+template struct Formatter<unsigned long long, void>;
+template struct Formatter<char, void>;
+template struct Formatter<short, void>;
+template struct Formatter<int, void>;
+template struct Formatter<long, void>;
+template struct Formatter<long long, void>;
+
+// C++ is weird.
+template struct Formatter<signed char, void>;
 
 } // namespace AK

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -71,12 +71,19 @@ static void write_escaped_literal(StringBuilder& builder, StringView literal)
             ++idx;
     }
 }
+
 static size_t parse_number(StringView input)
 {
-    String null_terminated { input };
-    char* endptr;
-    return strtoull(null_terminated.characters(), &endptr, 10);
+    size_t value = 0;
+
+    for (char ch : input) {
+        value *= 10;
+        value += ch - '0';
+    }
+
+    return value;
 }
+
 static bool parse_format_specifier(StringView input, FormatSpecifier& specifier)
 {
     specifier.index = NumericLimits<size_t>::max();

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -100,4 +100,7 @@ String format(StringView fmtstr, const Parameters&... parameters)
     return Detail::Format::format(fmtstr, formatters);
 }
 
-}
+template<typename... Parameters>
+void StringBuilder::appendff(StringView fmtstr, const Parameters&... parameters) { AK::format(*this, fmtstr, parameters...); }
+
+} // namespace AK

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -28,6 +28,7 @@
 
 #include <AK/Array.h>
 #include <AK/String.h>
+#include <AK/StringView.h>
 
 namespace AK {
 

--- a/AK/NeverDestroyed.h
+++ b/AK/NeverDestroyed.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include <AK/Noncopyable.h>
-#include <AK/StdLibExtras.h>
+#include <AK/Types.h>
 
 namespace AK {
 

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -26,11 +26,6 @@
 
 #pragma once
 
-typedef __UINT64_TYPE__ u64;
-typedef __UINT32_TYPE__ u32;
-typedef __UINT16_TYPE__ u16;
-typedef __UINT8_TYPE__ u8;
-
 #define UNUSED_PARAM(x) (void)x
 
 inline constexpr unsigned round_up_to_power_of_two(unsigned value, unsigned power_of_two)
@@ -461,16 +456,19 @@ template<typename T>
 struct __IsIntegral : FalseType {
 };
 template<>
-struct __IsIntegral<u8> : TrueType {
+struct __IsIntegral<unsigned char> : TrueType {
 };
 template<>
-struct __IsIntegral<u16> : TrueType {
+struct __IsIntegral<unsigned short> : TrueType {
 };
 template<>
-struct __IsIntegral<u32> : TrueType {
+struct __IsIntegral<unsigned int> : TrueType {
 };
 template<>
-struct __IsIntegral<u64> : TrueType {
+struct __IsIntegral<unsigned long> : TrueType {
+};
+template<>
+struct __IsIntegral<unsigned long long> : TrueType {
 };
 template<typename T>
 using IsIntegral = __IsIntegral<typename MakeUnsigned<typename RemoveCV<T>::Type>::Type>;

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/FlyString.h>
+#include <AK/Format.h>
 #include <AK/Memory.h>
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
@@ -214,49 +215,22 @@ Optional<unsigned> String::to_uint() const
     return StringUtils::convert_to_uint(view());
 }
 
-String String::number(unsigned long long value)
-{
-    int size;
-    char buffer[32];
-    size = snprintf(buffer, sizeof(buffer), "%llu", value);
-    return String(buffer, size);
-}
+template<typename T>
+String String::number(T value) { return AK::format("{}", value); }
 
-String String::number(unsigned long value)
-{
-    int size;
-    char buffer[32];
-    size = snprintf(buffer, sizeof(buffer), "%lu", value);
-    return String(buffer, size);
-}
+template String String::number(unsigned char);
+template String String::number(unsigned short);
+template String String::number(unsigned int);
+template String String::number(unsigned long);
+template String String::number(unsigned long long);
+template String String::number(char);
+template String String::number(short);
+template String String::number(int);
+template String String::number(long);
+template String String::number(long long);
 
-String String::number(unsigned value)
-{
-    char buffer[32];
-    int size = snprintf(buffer, sizeof(buffer), "%u", value);
-    return String(buffer, size);
-}
-
-String String::number(long long value)
-{
-    char buffer[32];
-    int size = snprintf(buffer, sizeof(buffer), "%lld", value);
-    return String(buffer, size);
-}
-
-String String::number(long value)
-{
-    char buffer[32];
-    int size = snprintf(buffer, sizeof(buffer), "%ld", value);
-    return String(buffer, size);
-}
-
-String String::number(int value)
-{
-    char buffer[32];
-    int size = snprintf(buffer, sizeof(buffer), "%d", value);
-    return String(buffer, size);
-}
+// C++ is weird.
+template String String::number(signed char);
 
 String String::format(const char* fmt, ...)
 {

--- a/AK/String.h
+++ b/AK/String.h
@@ -238,12 +238,9 @@ public:
     }
 
     static String format(const char*, ...);
-    static String number(unsigned);
-    static String number(unsigned long);
-    static String number(unsigned long long);
-    static String number(int);
-    static String number(long);
-    static String number(long long);
+
+    template<typename T>
+    static String number(T);
 
     StringView view() const;
 

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -28,6 +28,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/Forward.h>
+#include <AK/StringView.h>
 #include <stdarg.h>
 
 namespace AK {
@@ -37,7 +38,7 @@ public:
     using OutputType = String;
 
     explicit StringBuilder(size_t initial_capacity = 16);
-    ~StringBuilder() {}
+    ~StringBuilder() { }
 
     void append(const StringView&);
     void append(const Utf32View&);
@@ -46,6 +47,10 @@ public:
     void append(const char*, size_t);
     void appendf(const char*, ...);
     void appendvf(const char*, va_list);
+
+    // Implemented in <AK/Format.h> to break circular dependency.
+    template<typename... Parameters>
+    void appendff(StringView fmtstr, const Parameters&...);
 
     String build() const;
     String to_string() const;

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -43,7 +43,7 @@ TEST_CASE(format_integers)
     EXPECT_EQ(AK::format("{}", -17), "-17");
     EXPECT_EQ(AK::format("{:04}", 13), "0013");
     EXPECT_EQ(AK::format("{:08x}", 4096), "00001000");
-    // EXPECT_EQ(AK::format("{}", 0x1111222233334444ull), "1111222233334444");
+    EXPECT_EQ(AK::format("{:x}", 0x1111222233334444ull), "1111222233334444");
 }
 
 TEST_CASE(reorder_format_arguments)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -209,6 +209,7 @@ set(AK_SOURCES
     ../AK/StringUtils.cpp
     ../AK/StringView.cpp
     ../AK/Time.cpp
+    ../AK/Format.cpp
 )
 
 set(ELF_SOURCES

--- a/Kernel/UserOrKernelBuffer.cpp
+++ b/Kernel/UserOrKernelBuffer.cpp
@@ -46,7 +46,7 @@ String UserOrKernelBuffer::copy_into_string(size_t size) const
         return data_copy;
     }
 
-    return String({ m_buffer, size });
+    return String(ReadonlyBytes { m_buffer, size });
 }
 
 bool UserOrKernelBuffer::write(const void* src, size_t offset, size_t len)
@@ -80,7 +80,7 @@ bool UserOrKernelBuffer::memset(int value, size_t offset, size_t len)
 
     if (is_user_address(VirtualAddress(m_buffer)))
         return memset_user(m_buffer + offset, value, len);
-    
+
     ::memset(m_buffer + offset, value, len);
     return true;
 }


### PR DESCRIPTION
Previously, it was not possible to use `format` in the kernel, this was because of two oversights of mine:

 1. I forgot to add `Format.cpp` to the CMake configuration of the kernel.

 2. I used `strtoull` which isn't available in the kernel.

I also added an method to `StringBuilder` and changed `String::number` to use the new `format`.
