### PR TITLE
AK: Add missing overload to format.

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -99,6 +99,12 @@ String format(StringView fmtstr, const Parameters&... parameters)
     Array formatters { Detail::Format::make_type_erased_formatter(parameters)... };
     return Detail::Format::format(fmtstr, formatters);
 }
+template<typename... Parameters>
+void format(StringBuilder& builder, StringView fmtstr, const Parameters&... parameters)
+{
+    Array formatters { Detail::Format::make_type_erased_formatter(parameters)... };
+    Detail::Format::format(builder, fmtstr, formatters);
+}
 
 template<typename... Parameters>
 void StringBuilder::appendff(StringView fmtstr, const Parameters&... parameters) { AK::format(*this, fmtstr, parameters...); }

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -65,4 +65,13 @@ TEST_CASE(everything)
     EXPECT_EQ(AK::format("{{{:04}/{}/{0:8}/{1}", 42u, "foo"), "{0042/foo/      42/foo");
 }
 
+TEST_CASE(string_builder)
+{
+    StringBuilder builder;
+    builder.appendff(" {}  ", 42);
+    builder.appendff("{1}{0} ", 1, 2);
+
+    EXPECT_EQ(builder.to_string(), " 42  21 ");
+}
+
 TEST_MAIN(Format)


### PR DESCRIPTION
This overload was added in #3580 because it is used by `StringBuilder::appendff` but I must have lost it during rebasing.
