### PR TITLE
AK: Properly resolve circular dependency with format and use format in IRCClient.

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -27,9 +27,10 @@
 #include <AK/Format.h>
 #include <AK/GenericLexer.h>
 #include <AK/PrintfImplementation.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 
-namespace AK::Detail::Format {
+namespace {
 
 struct FormatSpecifier {
     StringView flags;
@@ -102,14 +103,11 @@ static bool parse_format_specifier(StringView input, FormatSpecifier& specifier)
     return true;
 }
 
-String format(StringView fmtstr, AK::Span<TypeErasedFormatter> formatters, size_t argument_index)
-{
-    StringBuilder builder;
-    format(builder, fmtstr, formatters, argument_index);
-    return builder.to_string();
-}
+} // namespace
 
-void format(StringBuilder& builder, StringView fmtstr, AK::Span<TypeErasedFormatter> formatters, size_t argument_index)
+namespace AK {
+
+void vformat(StringBuilder& builder, StringView fmtstr, AK::Span<const TypeErasedParameter> parameters, size_t argument_index)
 {
     size_t opening;
     if (!find_next_unescaped(opening, fmtstr, '{')) {
@@ -135,19 +133,24 @@ void format(StringBuilder& builder, StringView fmtstr, AK::Span<TypeErasedFormat
     if (specifier.index == NumericLimits<size_t>::max())
         specifier.index = argument_index++;
 
-    if (specifier.index >= formatters.size())
+    if (specifier.index >= parameters.size())
         ASSERT_NOT_REACHED();
 
-    auto& formatter = formatters[specifier.index];
-    if (!formatter.format(builder, formatter.parameter, specifier.flags))
+    auto& parameter = parameters[specifier.index];
+    if (!parameter.formatter(builder, parameter.value, specifier.flags))
         ASSERT_NOT_REACHED();
 
-    format(builder, fmtstr.substring_view(closing + 1), formatters, argument_index);
+    vformat(builder, fmtstr.substring_view(closing + 1), parameters, argument_index);
 }
 
-} // namespace AK::Detail::Format
-
-namespace AK {
+bool Formatter<StringView>::parse(StringView flags)
+{
+    return flags.is_empty();
+}
+void Formatter<StringView>::format(StringBuilder& builder, StringView value)
+{
+    builder.append(value);
+}
 
 template<typename T>
 bool Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type>::parse(StringView flags)
@@ -159,14 +162,13 @@ bool Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type>::parse(StringVi
 
     auto field_width = lexer.consume_while([](char ch) { return StringView { "0123456789" }.contains(ch); });
     if (field_width.length() > 0)
-        this->field_width = Detail::Format::parse_number(field_width);
+        this->field_width = parse_number(field_width);
 
     if (lexer.consume_specific('x'))
         hexadecimal = true;
 
     return lexer.is_eof();
 }
-
 template<typename T>
 void Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type>::format(StringBuilder& builder, T value)
 {
@@ -180,8 +182,6 @@ void Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type>::format(StringB
         PrintfImplementation::print_i64([&](auto, char ch) { builder.append(ch); }, bufptr, value, false, zero_pad, field_width);
 }
 
-template struct Formatter<StringView>;
-template struct Formatter<String>;
 template struct Formatter<unsigned char, void>;
 template struct Formatter<unsigned short, void>;
 template struct Formatter<unsigned int, void>;
@@ -192,8 +192,6 @@ template struct Formatter<short, void>;
 template struct Formatter<int, void>;
 template struct Formatter<long, void>;
 template struct Formatter<long long, void>;
-
-// C++ is weird.
 template struct Formatter<signed char, void>;
 
 } // namespace AK

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -142,6 +142,12 @@ void vformat(StringBuilder& builder, StringView fmtstr, AK::Span<const TypeErase
 
     vformat(builder, fmtstr.substring_view(closing + 1), parameters, argument_index);
 }
+void vformat(const LogStream& stream, StringView fmtstr, Span<const TypeErasedParameter> parameters)
+{
+    StringBuilder builder;
+    vformat(builder, fmtstr, parameters);
+    stream << builder.to_string();
+}
 
 bool Formatter<StringView>::parse(StringView flags)
 {

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -96,13 +96,13 @@ struct Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type> {
 template<typename... Parameters>
 String format(StringView fmtstr, const Parameters&... parameters)
 {
-    Array formatters { Detail::Format::make_type_erased_formatter(parameters)... };
+    Array<Detail::Format::TypeErasedFormatter, sizeof...(parameters)> formatters { Detail::Format::make_type_erased_formatter(parameters)... };
     return Detail::Format::format(fmtstr, formatters);
 }
 template<typename... Parameters>
 void format(StringBuilder& builder, StringView fmtstr, const Parameters&... parameters)
 {
-    Array formatters { Detail::Format::make_type_erased_formatter(parameters)... };
+    Array<Detail::Format::TypeErasedFormatter, sizeof...(parameters)> formatters { Detail::Format::make_type_erased_formatter(parameters)... };
     Detail::Format::format(builder, fmtstr, formatters);
 }
 

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -92,5 +92,6 @@ Array<TypeErasedParameter, sizeof...(Parameters)> make_type_erased_parameters(co
 }
 
 void vformat(StringBuilder& builder, StringView fmtstr, Span<const TypeErasedParameter>, size_t argument_index = 0);
+void vformat(const LogStream& stream, StringView fmtstr, Span<const TypeErasedParameter>);
 
 } // namespace AK

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -68,6 +68,12 @@ struct Formatter<StringView> {
     bool parse(StringView flags);
     void format(StringBuilder& builder, StringView value);
 };
+template<>
+struct Formatter<const char*> : Formatter<StringView> {
+};
+template<>
+struct Formatter<char*> : Formatter<StringView> {
+};
 template<size_t Size>
 struct Formatter<char[Size]> : Formatter<StringView> {
 };

--- a/AK/LogStream.cpp
+++ b/AK/LogStream.cpp
@@ -27,6 +27,7 @@
 #include <AK/FlyString.h>
 #include <AK/LogStream.h>
 #include <AK/String.h>
+#include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 
 #ifdef KERNEL

--- a/AK/LogStream.h
+++ b/AK/LogStream.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Types.h>
 #include <AK/kmalloc.h>
@@ -206,13 +207,38 @@ DebugLogStream klog();
 
 void dump_bytes(ReadonlyBytes);
 
+#ifndef KERNEL
+template<typename... Parameters>
+void outf(StringView fmtstr, const Parameters&... parameters)
+{
+    const auto type_erased_parameters = make_type_erased_parameters(parameters...);
+    vformat(out(), fmtstr, type_erased_parameters);
+}
+template<typename... Parameters>
+void warnf(StringView fmtstr, const Parameters&... parameters)
+{
+    const auto type_erased_parameters = make_type_erased_parameters(parameters...);
+    vformat(warn(), fmtstr, type_erased_parameters);
+}
+#endif
+
+template<typename... Parameters>
+void dbgf(StringView fmtstr, const Parameters&... parameters)
+{
+    const auto type_erased_parameters = make_type_erased_parameters(parameters...);
+    vformat(dbg(), fmtstr, type_erased_parameters);
+}
+
 }
 
 using AK::dbg;
+using AK::dbgf;
 using AK::klog;
 using AK::LogStream;
 
 #if !defined(KERNEL)
 using AK::out;
+using AK::outf;
 using AK::warn;
+using AK::warnf;
 #endif

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -216,7 +216,7 @@ Optional<unsigned> String::to_uint() const
 }
 
 template<typename T>
-String String::number(T value) { return AK::format("{}", value); }
+String String::number(T value) { return formatted("{}", value); }
 
 template String String::number(unsigned char);
 template String String::number(unsigned short);
@@ -228,8 +228,6 @@ template String String::number(short);
 template String String::number(int);
 template String String::number(long);
 template String String::number(long long);
-
-// C++ is weird.
 template String String::number(signed char);
 
 String String::format(const char* fmt, ...)
@@ -456,6 +454,36 @@ bool String::operator==(const char* cstring) const
 StringView String::view() const
 {
     return { characters(), length() };
+}
+
+InputStream& operator>>(InputStream& stream, String& string)
+{
+    StringBuilder builder;
+
+    for (;;) {
+        char next_char;
+        stream >> next_char;
+
+        if (stream.has_any_error()) {
+            stream.set_fatal_error();
+            string = nullptr;
+            return stream;
+        }
+
+        if (next_char) {
+            builder.append(next_char);
+        } else {
+            string = builder.to_string();
+            return stream;
+        }
+    }
+}
+
+String String::vformatted(StringView fmtstr, Span<const TypeErasedParameter> parameters)
+{
+    StringBuilder builder;
+    vformat(builder, fmtstr, parameters);
+    return builder.to_string();
 }
 
 }

--- a/AK/String.h
+++ b/AK/String.h
@@ -26,10 +26,10 @@
 
 #pragma once
 
+#include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/RefPtr.h>
 #include <AK/Stream.h>
-#include <AK/StringBuilder.h>
 #include <AK/StringImpl.h>
 #include <AK/StringUtils.h>
 #include <AK/Traits.h>
@@ -239,6 +239,15 @@ public:
 
     static String format(const char*, ...);
 
+    static String vformatted(StringView fmtstr, Span<const TypeErasedParameter>);
+
+    template<typename... Parameters>
+    static String formatted(StringView fmtstr, const Parameters&... parameters)
+    {
+        const auto type_erased_parameters = make_type_erased_parameters(parameters...);
+        return vformatted(fmtstr, type_erased_parameters);
+    }
+
     template<typename T>
     static String number(T);
 
@@ -277,28 +286,7 @@ bool operator<=(const char*, const String&);
 
 String escape_html_entities(const StringView& html);
 
-inline InputStream& operator>>(InputStream& stream, String& string)
-{
-    StringBuilder builder;
-
-    for (;;) {
-        char next_char;
-        stream >> next_char;
-
-        if (stream.has_any_error()) {
-            stream.set_fatal_error();
-            string = nullptr;
-            return stream;
-        }
-
-        if (next_char) {
-            builder.append(next_char);
-        } else {
-            string = builder.to_string();
-            return stream;
-        }
-    }
-}
+InputStream& operator>>(InputStream& stream, String& string);
 
 }
 

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/StringView.h>
 #include <stdarg.h>
@@ -48,9 +49,12 @@ public:
     void appendf(const char*, ...);
     void appendvf(const char*, va_list);
 
-    // Implemented in <AK/Format.h> to break circular dependency.
     template<typename... Parameters>
-    void appendff(StringView fmtstr, const Parameters&...);
+    void appendff(StringView fmtstr, const Parameters&... parameters)
+    {
+        const auto type_erased_parameters = make_type_erased_parameters(parameters...);
+        vformat(*this, fmtstr, type_erased_parameters);
+    }
 
     String build() const;
     String to_string() const;

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -26,43 +26,44 @@
 
 #include <AK/TestSuite.h>
 
-#include <AK/Format.h>
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
 
 TEST_CASE(format_string_literals)
 {
-    EXPECT_EQ(AK::format("prefix-{}-suffix", "abc"), "prefix-abc-suffix");
-    EXPECT_EQ(AK::format("{}{}{}", "a", "b", "c"), "abc");
+    EXPECT_EQ(String::formatted("prefix-{}-suffix", "abc"), "prefix-abc-suffix");
+    EXPECT_EQ(String::formatted("{}{}{}", "a", "b", "c"), "abc");
 }
 
 TEST_CASE(format_integers)
 {
-    EXPECT_EQ(AK::format("{}", 42u), "42");
-    EXPECT_EQ(AK::format("{:4}", 42u), "  42");
-    EXPECT_EQ(AK::format("{:08}", 42u), "00000042");
-    // EXPECT_EQ(AK::format("{:7}", -17), "    -17");
-    EXPECT_EQ(AK::format("{}", -17), "-17");
-    EXPECT_EQ(AK::format("{:04}", 13), "0013");
-    EXPECT_EQ(AK::format("{:08x}", 4096), "00001000");
-    EXPECT_EQ(AK::format("{:x}", 0x1111222233334444ull), "1111222233334444");
+    EXPECT_EQ(String::formatted("{}", 42u), "42");
+    EXPECT_EQ(String::formatted("{:4}", 42u), "  42");
+    EXPECT_EQ(String::formatted("{:08}", 42u), "00000042");
+    // EXPECT_EQ(String::formatted("{:7}", -17), "    -17");
+    EXPECT_EQ(String::formatted("{}", -17), "-17");
+    EXPECT_EQ(String::formatted("{:04}", 13), "0013");
+    EXPECT_EQ(String::formatted("{:08x}", 4096), "00001000");
+    EXPECT_EQ(String::formatted("{:x}", 0x1111222233334444ull), "1111222233334444");
 }
 
 TEST_CASE(reorder_format_arguments)
 {
-    EXPECT_EQ(AK::format("{1}{0}", "a", "b"), "ba");
-    EXPECT_EQ(AK::format("{0}{1}", "a", "b"), "ab");
-    EXPECT_EQ(AK::format("{0}{0}{0}", "a", "b"), "aaa");
-    EXPECT_EQ(AK::format("{1}{}{0}", "a", "b", "c"), "baa");
+    EXPECT_EQ(String::formatted("{1}{0}", "a", "b"), "ba");
+    EXPECT_EQ(String::formatted("{0}{1}", "a", "b"), "ab");
+    EXPECT_EQ(String::formatted("{0}{0}{0}", "a", "b"), "aaa");
+    EXPECT_EQ(String::formatted("{1}{}{0}", "a", "b", "c"), "baa");
 }
 
 TEST_CASE(escape_braces)
 {
-    EXPECT_EQ(AK::format("{{{}", "foo"), "{foo");
-    EXPECT_EQ(AK::format("{}}}", "bar"), "bar}");
+    EXPECT_EQ(String::formatted("{{{}", "foo"), "{foo");
+    EXPECT_EQ(String::formatted("{}}}", "bar"), "bar}");
 }
 
 TEST_CASE(everything)
 {
-    EXPECT_EQ(AK::format("{{{:04}/{}/{0:8}/{1}", 42u, "foo"), "{0042/foo/      42/foo");
+    EXPECT_EQ(String::formatted("{{{:04}/{}/{0:8}/{1}", 42u, "foo"), "{0042/foo/      42/foo");
 }
 
 TEST_CASE(string_builder)
@@ -76,7 +77,7 @@ TEST_CASE(string_builder)
 
 TEST_CASE(format_without_arguments)
 {
-    EXPECT_EQ(AK::format("foo"), "foo");
+    EXPECT_EQ(String::formatted("foo"), "foo");
 }
 
 TEST_MAIN(Format)

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -74,4 +74,9 @@ TEST_CASE(string_builder)
     EXPECT_EQ(builder.to_string(), " 42  21 ");
 }
 
+TEST_CASE(format_without_arguments)
+{
+    EXPECT_EQ(AK::format("foo"), "foo");
+}
+
 TEST_MAIN(Format)

--- a/AK/Tests/TestWeakPtr.cpp
+++ b/AK/Tests/TestWeakPtr.cpp
@@ -25,25 +25,26 @@
  */
 
 #include <AK/TestSuite.h>
+
 #include <AK/String.h>
-#include <AK/Weakable.h>
 #include <AK/WeakPtr.h>
+#include <AK/Weakable.h>
 
 #ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-private-field"
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
 
 class SimpleWeakable : public Weakable<SimpleWeakable> {
 public:
-    SimpleWeakable() {}
+    SimpleWeakable() { }
 
 private:
     int m_member { 123 };
 };
 
 #ifdef __clang__
-#pragma clang diagnostic pop
+#    pragma clang diagnostic pop
 #endif
 
 TEST_CASE(basic_weak)
@@ -81,8 +82,6 @@ TEST_CASE(weakptr_move)
     }
 
     EXPECT_EQ(weak2.is_null(), true);
-
-    fprintf(stderr, "ok\n");
 }
 
 TEST_MAIN(WeakPtr)

--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -63,7 +63,7 @@ static String bookmarks_file_path()
 int main(int argc, char** argv)
 {
     if (getuid() == 0) {
-        fprintf(stderr, "Refusing to run as root\n");
+        warn() << "Refusing to run as root";
         return 1;
     }
 

--- a/Applications/IRCClient/IRCAppWindow.cpp
+++ b/Applications/IRCClient/IRCAppWindow.cpp
@@ -40,7 +40,6 @@
 #include <LibGUI/TableView.h>
 #include <LibGUI/ToolBar.h>
 #include <LibGUI/ToolBarContainer.h>
-#include <stdio.h>
 
 static IRCAppWindow* s_the;
 
@@ -138,7 +137,7 @@ void IRCAppWindow::setup_actions()
     });
 
     m_close_query_action = GUI::Action::create("Close query", { Mod_Ctrl, Key_D }, Gfx::Bitmap::load_from_file("/res/icons/16x16/irc-close-query.png"), [](auto&) {
-        printf("FIXME: Implement close-query action\n");
+        out() << "FIXME: Implement close-query action";
     });
 
     m_change_nick_action = GUI::Action::create("Change nickname", Gfx::Bitmap::load_from_file("/res/icons/16x16/irc-nick.png"), [this](auto&) {
@@ -262,7 +261,7 @@ void IRCAppWindow::setup_menus()
     auto menubar = GUI::MenuBar::construct();
     auto& app_menu = menubar->add_menu("IRC Client");
     app_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
-        dbgprintf("Terminal: Quit menu activated!\n");
+        dbg() << "Terminal: Quit menu activated!";
         GUI::Application::the()->quit();
         return;
     }));

--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -73,7 +73,7 @@ IRCClient::IRCClient(String server, int port)
 {
     struct passwd* user_pw = getpwuid(getuid());
     m_socket = Core::TCPSocket::construct(this);
-    m_nickname = m_config->read_entry("User", "Nickname", String::format("%s_seren1ty", user_pw->pw_name));
+    m_nickname = m_config->read_entry("User", "Nickname", String::formatted("{}_seren1ty", user_pw->pw_name));
 
     if (server.is_empty()) {
         m_hostname = m_config->read_entry("Connection", "Server", "");
@@ -134,7 +134,7 @@ void IRCClient::receive_from_server()
         auto line = m_socket->read_line(PAGE_SIZE);
         if (line.is_null()) {
             if (!m_socket->is_connected()) {
-                printf("IRCClient: Connection closed!\n");
+                out() << "IRCClient: Connection closed!";
                 exit(1);
             }
             ASSERT_NOT_REACHED();
@@ -226,48 +226,46 @@ void IRCClient::send(const String& text)
 
 void IRCClient::send_user()
 {
-    send(String::format("USER %s 0 * :%s\r\n", m_nickname.characters(), m_nickname.characters()));
+    send(String::formatted("USER {} 0 * :{}\r\n", m_nickname, m_nickname));
 }
 
 void IRCClient::send_nick()
 {
-    send(String::format("NICK %s\r\n", m_nickname.characters()));
+    send(String::formatted("NICK {}\r\n", m_nickname));
 }
 
 void IRCClient::send_pong(const String& server)
 {
-    send(String::format("PONG %s\r\n", server.characters()));
+    send(String::formatted("PONG {}\r\n", server));
     sleep(1);
 }
 
 void IRCClient::join_channel(const String& channel_name)
 {
-    send(String::format("JOIN %s\r\n", channel_name.characters()));
+    send(String::formatted("JOIN {}\r\n", channel_name));
 }
 
 void IRCClient::part_channel(const String& channel_name)
 {
-    send(String::format("PART %s\r\n", channel_name.characters()));
+    send(String::formatted("PART {}\r\n", channel_name));
 }
 
 void IRCClient::send_whois(const String& nick)
 {
-    send(String::format("WHOIS %s\r\n", nick.characters()));
+    send(String::formatted("WHOIS {}\r\n", nick));
 }
 
 void IRCClient::handle(const Message& msg)
 {
 #ifdef IRC_DEBUG
-    printf("IRCClient::execute: prefix='%s', command='%s', arguments=%zu\n",
-        msg.prefix.characters(),
-        msg.command.characters(),
+    outf("IRCClient::execute: prefix='{}', command='{}', arguments={}",
+        msg.prefix,
+        msg.command,
         msg.arguments.size());
 
-    int i = 0;
-    for (auto& arg : msg.arguments) {
-        printf("    [%d]: %s\n", i, arg.characters());
-        ++i;
-    }
+    size_t index = 0;
+    for (auto& arg : msg.arguments)
+        outf("    [{}]: {}", index++, arg);
 #endif
 
     auto numeric = msg.command.to_uint();
@@ -340,7 +338,7 @@ void IRCClient::handle(const Message& msg)
         return handle_nick(msg);
 
     if (msg.arguments.size() >= 2)
-        add_server_message(String::format("[%s] %s", msg.command.characters(), msg.arguments[1].characters()));
+        add_server_message(String::formatted("[{}] {}", msg.command, msg.arguments[1]));
 }
 
 void IRCClient::add_server_message(const String& text, Color color)
@@ -351,52 +349,52 @@ void IRCClient::add_server_message(const String& text, Color color)
 
 void IRCClient::send_topic(const String& channel_name, const String& text)
 {
-    send(String::format("TOPIC %s :%s\r\n", channel_name.characters(), text.characters()));
+    send(String::formatted("TOPIC {} :{}\r\n", channel_name, text));
 }
 
 void IRCClient::send_invite(const String& channel_name, const String& nick)
 {
-    send(String::format("INVITE %s %s\r\n", nick.characters(), channel_name.characters()));
+    send(String::formatted("INVITE {} {}\r\n", nick, channel_name));
 }
 
 void IRCClient::send_banlist(const String& channel_name)
 {
-    send(String::format("MODE %s +b\r\n", channel_name.characters()));
+    send(String::formatted("MODE {} +b\r\n", channel_name));
 }
 
 void IRCClient::send_voice_user(const String& channel_name, const String& nick)
 {
-    send(String::format("MODE %s +v %s\r\n", channel_name.characters(), nick.characters()));
+    send(String::formatted("MODE {} +v {}\r\n", channel_name, nick));
 }
 
 void IRCClient::send_devoice_user(const String& channel_name, const String& nick)
 {
-    send(String::format("MODE %s -v %s\r\n", channel_name.characters(), nick.characters()));
+    send(String::formatted("MODE {} -v {}\r\n", channel_name, nick));
 }
 
 void IRCClient::send_hop_user(const String& channel_name, const String& nick)
 {
-    send(String::format("MODE %s +h %s\r\n", channel_name.characters(), nick.characters()));
+    send(String::formatted("MODE {} +h {}\r\n", channel_name, nick));
 }
 
 void IRCClient::send_dehop_user(const String& channel_name, const String& nick)
 {
-    send(String::format("MODE %s -h %s\r\n", channel_name.characters(), nick.characters()));
+    send(String::formatted("MODE {} -h {}\r\n", channel_name, nick));
 }
 
 void IRCClient::send_op_user(const String& channel_name, const String& nick)
 {
-    send(String::format("MODE %s +o %s\r\n", channel_name.characters(), nick.characters()));
+    send(String::formatted("MODE {} +o {}\r\n", channel_name, nick));
 }
 
 void IRCClient::send_deop_user(const String& channel_name, const String& nick)
 {
-    send(String::format("MODE %s -o %s\r\n", channel_name.characters(), nick.characters()));
+    send(String::formatted("MODE {} -o {}\r\n", channel_name, nick));
 }
 
 void IRCClient::send_kick(const String& channel_name, const String& nick, const String& comment)
 {
-    send(String::format("KICK %s %s :%s\r\n", channel_name.characters(), nick.characters(), comment.characters()));
+    send(String::formatted("KICK {} {} :{}\r\n", channel_name, nick, comment));
 }
 
 void IRCClient::send_list()
@@ -406,12 +404,12 @@ void IRCClient::send_list()
 
 void IRCClient::send_privmsg(const String& target, const String& text)
 {
-    send(String::format("PRIVMSG %s :%s\r\n", target.characters(), text.characters()));
+    send(String::formatted("PRIVMSG {} :{}\r\n", target, text));
 }
 
 void IRCClient::send_notice(const String& target, const String& text)
 {
-    send(String::format("NOTICE %s :%s\r\n", target.characters(), text.characters()));
+    send(String::formatted("NOTICE {} :{}\r\n", target, text));
 }
 
 void IRCClient::handle_user_input_in_channel(const String& channel_name, const String& input)
@@ -491,11 +489,11 @@ void IRCClient::handle_privmsg_or_notice(const Message& msg, PrivmsgOrNotice typ
     bool is_ctcp = has_ctcp_payload(msg.arguments[1]);
 
 #ifdef IRC_DEBUG
-    printf("handle_privmsg_or_notice: type='%s'%s, sender_nick='%s', target='%s'\n",
+    outf("handle_privmsg_or_notice: type='{}'{}, sender_nick='{}', target='{}'",
         type == PrivmsgOrNotice::Privmsg ? "privmsg" : "notice",
         is_ctcp ? " (ctcp)" : "",
-        sender_nick.characters(),
-        target.characters());
+        sender_nick,
+        target);
 #endif
 
     if (sender_nick.is_empty())
@@ -521,17 +519,10 @@ void IRCClient::handle_privmsg_or_notice(const Message& msg, PrivmsgOrNotice typ
 
         if (ctcp_payload.starts_with("ACTION")) {
             insert_as_raw_message = true;
-            StringBuilder builder;
-            builder.append("* ");
-            builder.append(sender_nick);
-            builder.append(ctcp_payload.substring_view(6, ctcp_payload.length() - 6));
-            message_text = builder.to_string();
+            message_text = String::formatted("* {}{}", sender_nick, ctcp_payload.substring_view(6, ctcp_payload.length() - 6));
             message_color = Color::Magenta;
         } else {
-            StringBuilder builder;
-            builder.append("(CTCP) ");
-            builder.append(ctcp_payload);
-            message_text = builder.to_string();
+            message_text = String::formatted("(CTCP) {}", ctcp_payload);
             message_color = Color::Blue;
         }
     }
@@ -561,7 +552,7 @@ void IRCClient::handle_privmsg_or_notice(const Message& msg, PrivmsgOrNotice typ
         else
             query->add_message(sender_prefix, sender_nick, message_text, message_color);
     } else {
-        add_server_message(String::format("<%s> %s", sender_nick.characters(), message_text.characters()), message_color);
+        add_server_message(String::formatted("<{}> {}", sender_nick, message_text), message_color);
     }
 }
 
@@ -650,7 +641,7 @@ void IRCClient::handle_nick(const Message& msg)
     if (old_nick == m_nickname)
         m_nickname = new_nick;
     if (m_show_nick_change_messages)
-        add_server_message(String::format("~ %s changed nickname to %s", old_nick.characters(), new_nick.characters()));
+        add_server_message(String::formatted("~ {} changed nickname to {}", old_nick, new_nick));
     if (on_nickname_changed)
         on_nickname_changed(new_nick);
     for (auto& it : m_channels) {
@@ -675,16 +666,16 @@ void IRCClient::handle_rpl_welcome(const Message& msg)
     if (msg.arguments.size() < 2)
         return;
     auto& welcome_message = msg.arguments[1];
-    add_server_message(String::format("%s", welcome_message.characters()));
+    add_server_message(welcome_message);
 
     auto channel_str = m_config->read_entry("Connection", "AutoJoinChannels", "");
     if (channel_str.is_empty())
         return;
-    dbgprintf("IRCClient: Channels to autojoin: %s\n", channel_str.characters());
+    dbgf("IRCClient: Channels to autojoin: {}", channel_str);
     auto channels = channel_str.split(',');
     for (auto& channel : channels) {
         join_channel(channel);
-        dbgprintf("IRCClient: Auto joining channel: %s\n", channel.characters());
+        dbgf("IRCClient: Auto joining channel: {}", channel);
     }
 }
 
@@ -732,7 +723,7 @@ void IRCClient::handle_rpl_banlist(const Message& msg)
     auto& mask = msg.arguments[2];
     auto& user = msg.arguments[3];
     auto& datestamp = msg.arguments[4];
-    add_server_message(String::format("* %s: %s on %s by %s", channel.characters(), mask.characters(), datestamp.characters(), user.characters()));
+    add_server_message(String::formatted("* {}: {} on {} by {}", channel, mask, datestamp, user));
 }
 
 void IRCClient::handle_rpl_endofbanlist(const Message&)
@@ -765,7 +756,7 @@ void IRCClient::handle_rpl_whoisoperator(const Message& msg)
     if (msg.arguments.size() < 2)
         return;
     auto& nick = msg.arguments[1];
-    add_server_message(String::format("* %s is an IRC operator", nick.characters()));
+    add_server_message(String::formatted("* {} is an IRC operator", nick));
 }
 
 void IRCClient::handle_rpl_whoisserver(const Message& msg)
@@ -774,7 +765,7 @@ void IRCClient::handle_rpl_whoisserver(const Message& msg)
         return;
     auto& nick = msg.arguments[1];
     auto& server = msg.arguments[2];
-    add_server_message(String::format("* %s is using server %s", nick.characters(), server.characters()));
+    add_server_message(String::formatted("* {} is using server {}", nick, server));
 }
 
 void IRCClient::handle_rpl_whoisuser(const Message& msg)
@@ -787,11 +778,7 @@ void IRCClient::handle_rpl_whoisuser(const Message& msg)
     auto& asterisk = msg.arguments[4];
     auto& realname = msg.arguments[5];
     (void)asterisk;
-    add_server_message(String::format("* %s is %s@%s, real name: %s",
-        nick.characters(),
-        username.characters(),
-        host.characters(),
-        realname.characters()));
+    add_server_message(String::formatted("* {} is {}@{}, real name: {}", nick, username, host, realname));
 }
 
 void IRCClient::handle_rpl_whoisidle(const Message& msg)
@@ -800,7 +787,7 @@ void IRCClient::handle_rpl_whoisidle(const Message& msg)
         return;
     auto& nick = msg.arguments[1];
     auto& secs = msg.arguments[2];
-    add_server_message(String::format("* %s is %s seconds idle", nick.characters(), secs.characters()));
+    add_server_message(String::formatted("* {} is {} seconds idle", nick, secs));
 }
 
 void IRCClient::handle_rpl_whoischannels(const Message& msg)
@@ -809,7 +796,7 @@ void IRCClient::handle_rpl_whoischannels(const Message& msg)
         return;
     auto& nick = msg.arguments[1];
     auto& channel_list = msg.arguments[2];
-    add_server_message(String::format("* %s is in channels %s", nick.characters(), channel_list.characters()));
+    add_server_message(String::formatted("* {} is in channels {}", nick, channel_list));
 }
 
 void IRCClient::handle_rpl_topicwhotime(const Message& msg)
@@ -822,7 +809,7 @@ void IRCClient::handle_rpl_topicwhotime(const Message& msg)
     auto setat_time = setat.to_uint();
     if (setat_time.has_value())
         setat = Core::DateTime::from_timestamp(setat_time.value()).to_string();
-    ensure_channel(channel_name).add_message(String::format("*** (set by %s at %s)", nick.characters(), setat.characters()), Color::Blue);
+    ensure_channel(channel_name).add_message(String::formatted("*** (set by {} at {})", nick, setat), Color::Blue);
 }
 
 void IRCClient::handle_err_nosuchnick(const Message& msg)
@@ -831,7 +818,7 @@ void IRCClient::handle_err_nosuchnick(const Message& msg)
         return;
     auto& nick = msg.arguments[1];
     auto& message = msg.arguments[2];
-    add_server_message(String::format("* %s :%s", nick.characters(), message.characters()));
+    add_server_message(String::formatted("* {} :{}", nick, message));
 }
 
 void IRCClient::handle_err_unknowncommand(const Message& msg)
@@ -839,7 +826,7 @@ void IRCClient::handle_err_unknowncommand(const Message& msg)
     if (msg.arguments.size() < 2)
         return;
     auto& cmd = msg.arguments[1];
-    add_server_message(String::format("* Unknown command: %s", cmd.characters()));
+    add_server_message(String::formatted("* Unknown command: {}", cmd));
 }
 
 void IRCClient::handle_err_nicknameinuse(const Message& msg)
@@ -847,7 +834,7 @@ void IRCClient::handle_err_nicknameinuse(const Message& msg)
     if (msg.arguments.size() < 2)
         return;
     auto& nick = msg.arguments[1];
-    add_server_message(String::format("* %s :Nickname in use", nick.characters()));
+    add_server_message(String::formatted("* {} :Nickname in use", nick));
 }
 
 void IRCClient::register_subwindow(IRCWindow& subwindow)
@@ -885,7 +872,7 @@ void IRCClient::handle_user_command(const String& input)
             return;
         int command_length = command.length() + 1;
         StringView raw_message = input.view().substring_view(command_length, input.view().length() - command_length);
-        send(String::format("%s\r\n", raw_message.to_string().characters()));
+        send(String::formatted("{}\r\n", raw_message));
         return;
     }
     if (command == "/NICK") {
@@ -948,22 +935,19 @@ void IRCClient::handle_user_command(const String& input)
             return;
 
         auto emote = input.view().substring_view_starting_after_substring(parts[0]);
-        StringBuilder builder;
-        builder.append("ACTION");
-        builder.append(emote);
-        auto action_string = builder.to_string();
+        auto action_string = String::formatted("ACTION{}", emote);
         String peer;
         if (window->type() == IRCWindow::Type::Channel) {
             peer = window->channel().name();
-            window->channel().add_message(String::format("* %s%s", m_nickname.characters(), String(emote).characters()), Gfx::Color::Magenta);
+            window->channel().add_message(String::formatted("* {}{}", m_nickname, emote), Gfx::Color::Magenta);
         } else if (window->type() == IRCWindow::Type::Query) {
             peer = window->query().name();
-            window->query().add_message(String::format("* %s%s", m_nickname.characters(), String(emote).characters()), Gfx::Color::Magenta);
+            window->query().add_message(String::formatted("* {}{}", m_nickname, emote), Gfx::Color::Magenta);
         } else {
             return;
         }
 
-        send_ctcp_request(peer, builder.to_string());
+        send_ctcp_request(peer, action_string);
         return;
     }
     if (command == "/TOPIC") {
@@ -1041,7 +1025,7 @@ void IRCClient::handle_user_command(const String& input)
 
 void IRCClient::change_nick(const String& nick)
 {
-    send(String::format("NICK %s\r\n", nick.characters()));
+    send(String::formatted("NICK {}\r\n", nick));
 }
 
 void IRCClient::handle_list_channels_action()
@@ -1169,13 +1153,13 @@ void IRCClient::send_ctcp_request(const StringView& peer, const StringView& payl
 
 void IRCClient::handle_ctcp_request(const StringView& peer, const StringView& payload)
 {
-    dbg() << "handle_ctcp_request: " << payload;
+    dbgf("handle_ctcp_request: {}", payload);
 
     if (payload == "VERSION") {
         auto version = ctcp_version_reply();
         if (version.is_empty())
             return;
-        send_ctcp_response(peer, String::format("VERSION %s", version.characters()));
+        send_ctcp_response(peer, String::formatted("VERSION {}", version));
         return;
     }
 
@@ -1183,7 +1167,7 @@ void IRCClient::handle_ctcp_request(const StringView& peer, const StringView& pa
         auto userinfo = ctcp_userinfo_reply();
         if (userinfo.is_empty())
             return;
-        send_ctcp_response(peer, String::format("USERINFO %s", userinfo.characters()));
+        send_ctcp_response(peer, String::formatted("USERINFO {}", userinfo));
         return;
     }
 
@@ -1191,7 +1175,7 @@ void IRCClient::handle_ctcp_request(const StringView& peer, const StringView& pa
         auto finger = ctcp_finger_reply();
         if (finger.is_empty())
             return;
-        send_ctcp_response(peer, String::format("FINGER %s", finger.characters()));
+        send_ctcp_response(peer, String::formatted("FINGER {}", finger));
         return;
     }
 
@@ -1203,5 +1187,5 @@ void IRCClient::handle_ctcp_request(const StringView& peer, const StringView& pa
 
 void IRCClient::handle_ctcp_response(const StringView& peer, const StringView& payload)
 {
-    dbg() << "handle_ctcp_response(" << peer << "): " << payload;
+    dbgf("handle_ctcp_response({}): {}", peer, payload);
 }

--- a/Applications/IRCClient/main.cpp
+++ b/Applications/IRCClient/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv)
     }
 
     if (getuid() == 0) {
-        fprintf(stderr, "Refusing to run as root\n");
+        warn() << "Refusing to run as root";
         return 1;
     }
 
@@ -54,17 +54,17 @@ int main(int argc, char** argv)
         url = URL::create_with_url_or_path(app->args()[0]);
 
         if (url.protocol().to_lowercase() == "ircs") {
-            fprintf(stderr, "Secure IRC over SSL/TLS (ircs) is not supported\n");
+            warn() << "Secure IRC over SSL/TLS (ircs) is not supported";
             return 1;
         }
 
         if (url.protocol().to_lowercase() != "irc") {
-            fprintf(stderr, "Unsupported protocol\n");
+            warn() << "Unsupported protocol";
             return 1;
         }
 
         if (url.host().is_empty()) {
-            fprintf(stderr, "Invalid URL\n");
+            warn() << "Invalid URL";
             return 1;
         }
 

--- a/Libraries/LibGUI/Clipboard.h
+++ b/Libraries/LibGUI/Clipboard.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/String.h>


### PR DESCRIPTION
I had to change the format stuff a bit, instead of calling `AK::format` we now call `String::formatted` or `StringBuilder::appendff`. The idea is that the `<AK/Format.h>` header now has a much more passive role and only depends on `<AK/StringView.h>` and `<AK/Array.h>` both of which aren't issues. (`AK::format` returned a `String` which forced `<AK/String.h>` to be included.)

I also added helper functions that are the equivalent of `printf`: `outf`, `warnf` and `dbgf`.

Finally, I started replacing a few `printf` usages with the new format functions. I started in IRCClient for no particular reason.
