### PR TITLE
LibGUI: Use on_up_pressed/on_down_pressed events in SpinBox

### DIFF
--- a/Libraries/LibGUI/SpinBox.cpp
+++ b/Libraries/LibGUI/SpinBox.cpp
@@ -41,6 +41,12 @@ SpinBox::SpinBox()
         else
             m_editor->set_text(String::number(m_value));
     };
+    m_editor->on_up_pressed = [this] {
+        set_value(m_value + 1);
+    };
+    m_editor->on_down_pressed = [this] {
+        set_value(m_value - 1);
+    };
 
     m_increment_button = add<ControlBoxButton>(ControlBoxButton::UpArrow);
     m_increment_button->set_focusable(false);
@@ -86,20 +92,6 @@ void SpinBox::set_range(int min, int max)
     }
 
     update();
-}
-
-void SpinBox::keydown_event(KeyEvent& event)
-{
-    if (event.key() == KeyCode::Key_Up) {
-        set_value(m_value + 1);
-        return;
-    }
-    if (event.key() == KeyCode::Key_Down) {
-        set_value(m_value - 1);
-        return;
-    }
-
-    event.ignore();
 }
 
 void SpinBox::mousewheel_event(MouseEvent& event)

--- a/Libraries/LibGUI/SpinBox.h
+++ b/Libraries/LibGUI/SpinBox.h
@@ -51,7 +51,6 @@ public:
 protected:
     SpinBox();
 
-    virtual void keydown_event(KeyEvent&) override;
     virtual void mousewheel_event(MouseEvent&) override;
     virtual void resize_event(ResizeEvent&) override;
 


### PR DESCRIPTION
Fixes keyboard increment/decrement of SpinBox values.

After PR #2412 the TextBox class started not propagating arrow key events to the parent widgets because it handles them itself now. It also added two new events for these arrow keys, so use them instead in SpinBox.