### PR TITLE
UserspaceEmulator: Fix off-by-one in code cache access

### DIFF
--- a/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/DevTools/UserspaceEmulator/SoftCPU.h
@@ -1137,7 +1137,7 @@ ALWAYS_INLINE u8 SoftCPU::read8()
 
 ALWAYS_INLINE u16 SoftCPU::read16()
 {
-    if (!m_cached_code_ptr || (m_cached_code_ptr + 2) >= m_cached_code_end)
+    if (!m_cached_code_ptr || (m_cached_code_ptr + 1) >= m_cached_code_end)
         update_code_cache();
 
     u16 value = *reinterpret_cast<const u16*>(m_cached_code_ptr);
@@ -1148,7 +1148,7 @@ ALWAYS_INLINE u16 SoftCPU::read16()
 
 ALWAYS_INLINE u32 SoftCPU::read32()
 {
-    if (!m_cached_code_ptr || (m_cached_code_ptr + 4) >= m_cached_code_end)
+    if (!m_cached_code_ptr || (m_cached_code_ptr + 3) >= m_cached_code_end)
         update_code_cache();
 
     u32 value = *reinterpret_cast<const u32*>(m_cached_code_ptr);
@@ -1159,7 +1159,7 @@ ALWAYS_INLINE u32 SoftCPU::read32()
 
 ALWAYS_INLINE u64 SoftCPU::read64()
 {
-    if (!m_cached_code_ptr || (m_cached_code_ptr + 8) >= m_cached_code_end)
+    if (!m_cached_code_ptr || (m_cached_code_ptr + 7) >= m_cached_code_end)
         update_code_cache();
 
     u64 value = *reinterpret_cast<const u64*>(m_cached_code_ptr);


### PR DESCRIPTION
m_cached_code_end points at the first invalid byte, so we need to
update the cache if the last byte we want to read points at the
end or past it.  Previously we updated the cache 1 byte prematurely in
read16, read32, read64 (but not in read8).

Noticed by reading the code (the code looked different from read8() and
the other 3).  I didn't find anything that actually hit this case.

--

I hope I'm updating the right functions. I think read8() is right and the others are wrong, but maybe it's the other way round. It is probably unknowable!