### PR TITLE
Alpha preview in ColorPicker and transparency grid changes

### DIFF
--- a/Applications/PixelPaint/ImageEditor.cpp
+++ b/Applications/PixelPaint/ImageEditor.cpp
@@ -64,7 +64,7 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
     painter.add_clip_rect(event.rect());
     painter.add_clip_rect(frame_inner_rect());
 
-    painter.fill_rect_with_checkerboard(rect(), { 8, 8 }, palette().base().darkened(0.9), palette().base());
+    Gfx::StylePainter::paint_transparency_grid(painter, rect(), palette());
 
     if (m_image) {
         painter.draw_rect(m_editor_image_rect.inflated(2, 2), Color::Black);

--- a/Applications/QuickShow/QSWidget.cpp
+++ b/Applications/QuickShow/QSWidget.cpp
@@ -186,7 +186,7 @@ void QSWidget::paint_event(GUI::PaintEvent& event)
     painter.add_clip_rect(event.rect());
     painter.add_clip_rect(frame_inner_rect());
 
-    painter.fill_rect_with_checkerboard(frame_inner_rect(), { 8, 8 }, palette().base().darkened(0.9), palette().base());
+    Gfx::StylePainter::paint_transparency_grid(painter, frame_inner_rect(), palette());
 
     if (!m_bitmap.is_null())
         painter.draw_scaled_bitmap(m_bitmap_rect, *m_bitmap, m_bitmap->rect());

--- a/Libraries/LibGUI/ColorPicker.cpp
+++ b/Libraries/LibGUI/ColorPicker.cpp
@@ -118,6 +118,19 @@ private:
     virtual void resize_event(ResizeEvent&) override;
 };
 
+class ColorPreview final : public GUI::Widget {
+    C_OBJECT(ColorPreview);
+
+public:
+    void set_color(Color);
+
+private:
+    ColorPreview(Color);
+
+    Color m_color;
+    virtual void paint_event(GUI::PaintEvent&) override;
+};
+
 class CustomColorWidget final : public GUI::Widget {
     C_OBJECT(CustomColorWidget);
 
@@ -258,20 +271,10 @@ void ColorPicker::build_ui_custom(Widget& root_container)
     preview_container.set_preferred_size(0, 128);
 
     // Current color
-    auto& current_color_widget = preview_container.add<Widget>();
-    current_color_widget.set_fill_with_background_color(true);
-
-    auto pal1 = current_color_widget.palette();
-    pal1.set_color(ColorRole::Background, m_color);
-    current_color_widget.set_palette(pal1);
+    preview_container.add<ColorPreview>(m_color);
 
     // Preview selected color
-    m_preview_widget = preview_container.add<Widget>();
-    m_preview_widget->set_fill_with_background_color(true);
-
-    auto pal2 = m_preview_widget->palette();
-    pal2.set_color(ColorRole::Background, m_color);
-    m_preview_widget->set_palette(pal2);
+    m_preview_widget = preview_container.add<ColorPreview>(m_color);
 
     vertical_container.layout()->add_spacer();
 
@@ -368,10 +371,7 @@ void ColorPicker::build_ui_custom(Widget& root_container)
 
 void ColorPicker::update_color_widgets()
 {
-    auto pal = m_preview_widget->palette();
-    pal.set_color(ColorRole::Background, m_color);
-    m_preview_widget->set_palette(pal);
-    m_preview_widget->update();
+    m_preview_widget->set_color(m_color);
 
     m_html_text->set_text(m_color_has_alpha_channel ? m_color.to_string() : m_color.to_string_without_alpha());
 
@@ -701,6 +701,34 @@ void ColorSlider::paint_event(GUI::PaintEvent& event)
 void ColorSlider::resize_event(ResizeEvent&)
 {
     recalculate_position();
+}
+
+ColorPreview::ColorPreview(Color color)
+    : m_color(color)
+{
+}
+
+void ColorPreview::set_color(Color color)
+{
+    if (m_color == color)
+        return;
+
+    m_color = color;
+    update();
+}
+
+void ColorPreview::paint_event(PaintEvent& event)
+{
+    Painter painter(*this);
+    painter.add_clip_rect(event.rect());
+
+    if (m_color.alpha() < 255) {
+        Gfx::StylePainter::paint_transparency_grid(painter, rect(), palette());
+        painter.fill_rect(rect(), m_color);
+        painter.fill_rect({ 0, 0, rect().width() / 4, rect().height() }, m_color.with_alpha(255));
+    } else {
+        painter.fill_rect(rect(), m_color);
+    }
 }
 
 }

--- a/Libraries/LibGUI/ColorPicker.h
+++ b/Libraries/LibGUI/ColorPicker.h
@@ -32,6 +32,7 @@
 namespace GUI {
 
 class ColorButton;
+class ColorPreview;
 class CustomColorWidget;
 
 class ColorPicker final : public Dialog {
@@ -58,7 +59,7 @@ private:
 
     Vector<ColorButton*> m_color_widgets;
     RefPtr<CustomColorWidget> m_custom_color;
-    RefPtr<Widget> m_preview_widget;
+    RefPtr<ColorPreview> m_preview_widget;
     RefPtr<TextBox> m_html_text;
     RefPtr<SpinBox> m_red_spinbox;
     RefPtr<SpinBox> m_green_spinbox;

--- a/Libraries/LibGfx/ClassicStylePainter.cpp
+++ b/Libraries/LibGfx/ClassicStylePainter.cpp
@@ -380,4 +380,9 @@ void ClassicStylePainter::paint_check_box(Painter& painter, const IntRect& rect,
     }
 }
 
+void ClassicStylePainter::paint_transparency_grid(Painter& painter, const IntRect& rect, const Palette& palette)
+{
+    painter.fill_rect_with_checkerboard(rect, { 8, 8 }, palette.base().darkened(0.9), palette.base());
+}
+
 }

--- a/Libraries/LibGfx/ClassicStylePainter.h
+++ b/Libraries/LibGfx/ClassicStylePainter.h
@@ -43,6 +43,7 @@ public:
     void paint_progress_bar(Painter&, const IntRect&, const Palette&, int min, int max, int value, const StringView& text) override;
     void paint_radio_button(Painter&, const IntRect&, const Palette&, bool is_checked, bool is_being_pressed) override;
     void paint_check_box(Painter&, const IntRect&, const Palette&, bool is_enabled, bool is_checked, bool is_being_pressed) override;
+    void paint_transparency_grid(Painter&, const IntRect&, const Palette&) override;
 };
 
 }

--- a/Libraries/LibGfx/StylePainter.cpp
+++ b/Libraries/LibGfx/StylePainter.cpp
@@ -78,4 +78,9 @@ void StylePainter::paint_check_box(Painter& painter, const IntRect& rect, const 
     current().paint_check_box(painter, rect, palette, is_enabled, is_checked, is_being_pressed);
 }
 
+void StylePainter::paint_transparency_grid(Painter& painter, const IntRect& rect, const Palette& palette)
+{
+    current().paint_transparency_grid(painter, rect, palette);
+}
+
 }

--- a/Libraries/LibGfx/StylePainter.h
+++ b/Libraries/LibGfx/StylePainter.h
@@ -62,6 +62,7 @@ public:
     virtual void paint_progress_bar(Painter&, const IntRect&, const Palette&, int min, int max, int value, const StringView& text) = 0;
     virtual void paint_radio_button(Painter&, const IntRect&, const Palette&, bool is_checked, bool is_being_pressed) = 0;
     virtual void paint_check_box(Painter&, const IntRect&, const Palette&, bool is_enabled, bool is_checked, bool is_being_pressed) = 0;
+    virtual void paint_transparency_grid(Painter&, const IntRect&, const Palette&) = 0;
 
 protected:
     BaseStylePainter() { }
@@ -80,6 +81,7 @@ public:
     static void paint_progress_bar(Painter&, const IntRect&, const Palette&, int min, int max, int value, const StringView& text);
     static void paint_radio_button(Painter&, const IntRect&, const Palette&, bool is_checked, bool is_being_pressed);
     static void paint_check_box(Painter&, const IntRect&, const Palette&, bool is_enabled, bool is_checked, bool is_being_pressed);
+    static void paint_transparency_grid(Painter&, const IntRect&, const Palette&);
 };
 
 }


### PR DESCRIPTION
How the color preview looks after these changes:
![](https://user-images.githubusercontent.com/1627292/94283665-96767180-ff51-11ea-9433-dcdff2632ca2.png)
