### PR TITLE
LibJS+LibGUI+js: Handle UnterminatedRegexLiteral in syntax highlighters

### DIFF
--- a/Libraries/LibGUI/JSSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/JSSyntaxHighlighter.cpp
@@ -49,6 +49,7 @@ static TextStyle style_for_token_type(Gfx::Palette palette, JS::TokenType type)
     case JS::TokenType::RegexLiteral:
     case JS::TokenType::RegexFlags:
     case JS::TokenType::UnterminatedStringLiteral:
+    case JS::TokenType::UnterminatedRegexLiteral:
         return { palette.syntax_string() };
     case JS::TokenType::BracketClose:
     case JS::TokenType::BracketOpen:

--- a/Libraries/LibJS/MarkupGenerator.cpp
+++ b/Libraries/LibJS/MarkupGenerator.cpp
@@ -226,6 +226,7 @@ MarkupGenerator::StyleType MarkupGenerator::style_type_for_token(Token token)
     case TokenType::RegexLiteral:
     case TokenType::RegexFlags:
     case TokenType::UnterminatedStringLiteral:
+    case TokenType::UnterminatedRegexLiteral:
         return StyleType::String;
     case TokenType::BracketClose:
     case TokenType::BracketOpen:
@@ -330,7 +331,7 @@ MarkupGenerator::StyleType MarkupGenerator::style_type_for_token(Token token)
     case TokenType::Identifier:
         return StyleType::Identifier;
     default:
-        dbg() << "Unknown style type for token" << token.name();
+        dbg() << "Unknown style type for token " << token.name();
         ASSERT_NOT_REACHED();
     }
 }

--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -616,6 +616,7 @@ int main(int argc, char** argv)
                 case JS::TokenType::RegexLiteral:
                 case JS::TokenType::RegexFlags:
                 case JS::TokenType::UnterminatedStringLiteral:
+                case JS::TokenType::UnterminatedRegexLiteral:
                     stylize({ start, end }, { Line::Style::Foreground(Line::Style::XtermColor::Green), Line::Style::Bold });
                     break;
                 case JS::TokenType::BracketClose:


### PR DESCRIPTION
This token was added 2 months later than most others, explaining its absence in all the JS syntax highlighters (they should probably share the list of tokens for each style btw...)