### PR TITLE
AK: Enhance the GenericLexer and add explanatory comments

### DIFF
--- a/AK/GenericLexer.cpp
+++ b/AK/GenericLexer.cpp
@@ -269,56 +269,14 @@ void GenericLexer::ignore_until(const char* stop)
 }
 
 // Ignore characters until `condition` return true
-// We don't skip the stop character as it may not be a single value
+// We don't skip the stop character as it may not be a unique value
 void GenericLexer::ignore_until(Condition condition)
 {
     while (!is_eof() && !condition(peek()))
         m_index++;
 }
 
-bool is_control(char c)
-{
-    return (c >= 0 && c <= 31) || c == 127;
-}
-
-bool is_whitespace(char c)
-{
-    return (c >= '\t' && c <= '\r') || c == ' ';
-}
-
-bool is_lowercase(char c)
-{
-    return c >= 'a' && c <= 'z';
-}
-
-bool is_uppercase(char c)
-{
-    return c >= 'A' && c <= 'Z';
-}
-
-bool is_digit(char c)
-{
-    return c >= '0' && c <= '9';
-}
-
-bool is_punctuation(char c)
-{
-    return (c >= '!' && c <= '/')
-        || (c >= ':' && c <= '@')
-        || (c >= '[' && c <= '`')
-        || (c >= '{' && c <= '~');
-}
-
-bool is_printable(char c)
-{
-    return c >= ' ' && c <= '~';
-}
-
-bool is_graphic(char c)
-{
-    return c > ' ' && c <= '~';
-}
-
+// CType adapters
 bool is_alpha(char c)
 {
     return is_lowercase(c) || is_uppercase(c);
@@ -329,6 +287,21 @@ bool is_alphanum(char c)
     return is_alpha(c) || is_digit(c);
 }
 
+bool is_control(char c)
+{
+    return (c >= 0 && c <= 31) || c == 127;
+}
+
+bool is_digit(char c)
+{
+    return c >= '0' && c <= '9';
+}
+
+bool is_graphic(char c)
+{
+    return c > ' ' && c <= '~';
+}
+
 bool is_hex_digit(char c)
 {
     return is_digit(c)
@@ -336,14 +309,42 @@ bool is_hex_digit(char c)
         || (c >= 'a' && c <= 'f');
 }
 
-bool is_quote(char c)
+bool is_lowercase(char c)
 {
-    return c == '\'' || c == '"';
+    return c >= 'a' && c <= 'z';
 }
 
 bool is_path_separator(char c)
 {
     return c == '/' || c == '\\';
+}
+
+bool is_printable(char c)
+{
+    return c >= ' ' && c <= '~';
+}
+
+bool is_punctuation(char c)
+{
+    return (c >= '!' && c <= '/')
+        || (c >= ':' && c <= '@')
+        || (c >= '[' && c <= '`')
+        || (c >= '{' && c <= '~');
+}
+
+bool is_quote(char c)
+{
+    return c == '\'' || c == '"';
+}
+
+bool is_uppercase(char c)
+{
+    return c >= 'A' && c <= 'Z';
+}
+
+bool is_whitespace(char c)
+{
+    return (c >= '\t' && c <= '\r') || c == ' ';
 }
 
 }

--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 
 namespace AK {
@@ -36,7 +37,7 @@ public:
     explicit GenericLexer(const StringView& input);
     virtual ~GenericLexer();
 
-	// A lambda/function can be used to match characters as the user pleases
+    // A lambda/function can be used to match characters as the user pleases
     using Condition = Function<bool(char)>;
 
     size_t tell() const { return m_index; }
@@ -64,8 +65,8 @@ public:
     StringView consume_until(char);
     StringView consume_until(const char*);
     StringView consume_until(Condition);
-    // FIXME: provide an escape character
-    StringView consume_quoted_string();
+    StringView consume_quoted_string(char escape_char = 0);
+    String consume_and_unescape_string(char escape_char = '\\');
 
     void ignore(size_t count = 1);
     void ignore_while(Condition);

--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -36,6 +36,7 @@ public:
     explicit GenericLexer(const StringView& input);
     virtual ~GenericLexer();
 
+	// A lambda/function can be used to match characters as the user pleases
     using Condition = Function<bool(char)>;
 
     size_t tell() const { return m_index; }
@@ -82,8 +83,13 @@ constexpr auto is_any_of(const StringView& values)
     return [values](auto c) { return values.contains(c); };
 }
 
-// ctype adaptors
-// FIXME: maybe put them in an another file?
+/*
+ * CType adapters: pass them as Conditions to a GenericLexer's methods
+ * Examples:
+ *   - `if (lexer.next_is(is_digit))`
+ *   - `auto name = lexer.consume_while(is_alphanum);
+ *   - `lexer.ignore_until(is_any_of("<^>"))`
+ */
 bool is_alpha(char);
 bool is_alphanum(char);
 bool is_control(char);


### PR DESCRIPTION
I thought it would be useful to _document_ the ctype adapters as I have not seen them used where they could have been. I also took the chance to spice up the string consumption methods.

I was wondering if handling hexadecimal escape sequences would be good too? (Like the `JsonParser` does in its `consume_and_unescape_string()` method). Let me know if that seems useful.