### PR TITLE
Documentation: Updated gcc version requirement in BuildInstructions.md

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -37,6 +37,24 @@ sudo apt-get install gcc-9 g++-9
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 ```
 
+On Debian you can install it by switching to the Debian testing branch:
+```bash
+sudo echo "deb http://http.us.debian.org/debian/ testing non-free contrib main" >> /etc/apt/sources.list
+sudo apt update
+```
+
+Afterwards you can install gcc-9 with apt like:
+```bash
+sudo apt install gcc-9 g++-9
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9
+```
+
+If you don't want to stay on the testing branch you can switch back by running:
+```bash
+sudo sed -i '$d' /etc/apt/sources.list
+sudo apt update
+```
+
 Ensure your CMake version is >= 3.16 with `cmake --version`. If your system doesn't provide a suitable version of CMake, you can download a binary release from the [CMake website](https://cmake.org/download).
 
 #### macOS prerequisites

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -30,7 +30,7 @@ sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs qemu qem
 apt-get install curl cmake libmpc-devel gmp-devel e2fsprogs libmpfr-devel patch gcc
 ```
 
-Ensure your gcc version is >= 8 with `gcc --version`. Otherwise, install it (on Ubuntu) with:
+Ensure your gcc version is >= 9 with `gcc --version`. Otherwise, install it (on Ubuntu) with:
 ```bash
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get install gcc-9 g++-9


### PR DESCRIPTION
The documentation said gcc >= 8 was needed to build serenity but my current 8.3.0 didn't work. After testing I noticed gcc >= 9 was necessary so I updated the documentation. Gcc-9 is only available on Debian testing so I added instructions for switching to and from Debian testing as well.