### PR TITLE
Kernel: Allow killing queued threads

### DIFF
--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -438,11 +438,11 @@ public:
         // to clean up now while we're still holding m_lock
         t.was_unblocked();
 
-        if (t.was_interrupted_by_signal())
-            return BlockResult::InterruptedBySignal;
-
         if (t.was_interrupted_by_death())
             return BlockResult::InterruptedByDeath;
+
+        if (t.was_interrupted_by_signal())
+            return BlockResult::InterruptedBySignal;
 
         return BlockResult::WokeNormally;
     }
@@ -634,6 +634,7 @@ private:
     Blocker* m_blocker { nullptr };
     timespec* m_blocker_timeout { nullptr };
     const char* m_wait_reason { nullptr };
+    WaitQueue* m_queue { nullptr };
 
     Atomic<bool> m_is_active { false };
     bool m_is_joinable { true };


### PR DESCRIPTION
We need to dequeue and wake threads that are waiting if the process
terminates.

Fixes #3603 without the HackStudio fixes in #3606.

There's still a separate remaining issue where the debugee (e.g. "little") doesn't get killed. I believe that's because if a tracer terminates, we don't resume/kill its traced processes.