### PR TITLE
LibGUI: Update color widgets when has_alpha is toggled in ColorPicker

### DIFF
--- a/Libraries/LibGUI/ColorPicker.cpp
+++ b/Libraries/LibGUI/ColorPicker.cpp
@@ -161,6 +161,15 @@ ColorPicker::~ColorPicker()
 {
 }
 
+void ColorPicker::set_color_has_alpha_channel(bool has_alpha)
+{
+    if (m_color_has_alpha_channel == has_alpha)
+        return;
+
+    m_color_has_alpha_channel = has_alpha;
+    update_color_widgets();
+}
+
 void ColorPicker::build_ui()
 {
     auto& root_container = set_main_widget<Widget>();

--- a/Libraries/LibGUI/ColorPicker.h
+++ b/Libraries/LibGUI/ColorPicker.h
@@ -42,7 +42,7 @@ public:
     virtual ~ColorPicker() override;
 
     bool color_has_alpha_channel() const { return m_color_has_alpha_channel; }
-    void set_color_has_alpha_channel(bool has_alpha) { m_color_has_alpha_channel = has_alpha; }
+    void set_color_has_alpha_channel(bool);
     Color color() const { return m_color; }
 
 private:


### PR DESCRIPTION
Fixing a bug where the alpha spinbox wasn't immediately disabled when color_has_alpha_channel was set to false.