### PR TITLE
Kernel: Make Thread refcounted

### DIFF
--- a/AK/InlineLinkedList.h
+++ b/AK/InlineLinkedList.h
@@ -217,6 +217,9 @@ inline void InlineLinkedList<T>::remove(T* node)
         ASSERT(node == m_tail);
         m_tail = node->prev();
     }
+
+    node->set_next(0);
+    node->set_prev(0);
 }
 
 template<typename T>

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -61,7 +61,7 @@ static void handle_tcp(const IPv4Packet&, const timeval& packet_timestamp);
 
 void NetworkTask::spawn()
 {
-    Thread* thread = nullptr;
+    RefPtr<Thread> thread;
     Process::create_kernel_process(thread, "NetworkTask", NetworkTask_main);
 }
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -125,14 +125,14 @@ public:
         return current_thread ? &current_thread->process() : nullptr;
     }
 
-    static NonnullRefPtr<Process> create_kernel_process(Thread*& first_thread, String&& name, void (*entry)(), u32 affinity = THREAD_AFFINITY_DEFAULT);
-    static RefPtr<Process> create_user_process(Thread*& first_thread, const String& path, uid_t, gid_t, ProcessID ppid, int& error, Vector<String>&& arguments = Vector<String>(), Vector<String>&& environment = Vector<String>(), TTY* = nullptr);
+    static NonnullRefPtr<Process> create_kernel_process(RefPtr<Thread>& first_thread, String&& name, void (*entry)(), u32 affinity = THREAD_AFFINITY_DEFAULT);
+    static RefPtr<Process> create_user_process(RefPtr<Thread>& first_thread, const String& path, uid_t, gid_t, ProcessID ppid, int& error, Vector<String>&& arguments = Vector<String>(), Vector<String>&& environment = Vector<String>(), TTY* = nullptr);
     ~Process();
 
     static Vector<ProcessID> all_pids();
     static AK::NonnullRefPtrVector<Process> all_processes();
 
-    Thread* create_kernel_thread(void (*entry)(), u32 priority, const String& name, u32 affinity = THREAD_AFFINITY_DEFAULT, bool joinable = true);
+    RefPtr<Thread> create_kernel_thread(void (*entry)(), u32 priority, const String& name, u32 affinity = THREAD_AFFINITY_DEFAULT, bool joinable = true);
 
     bool is_profiling() const { return m_profiling; }
     void set_profiling(bool profiling) { m_profiling = profiling; }
@@ -466,7 +466,7 @@ private:
     friend class Scheduler;
     friend class Region;
 
-    Process(Thread*& first_thread, const String& name, uid_t, gid_t, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> cwd = nullptr, RefPtr<Custody> executable = nullptr, TTY* = nullptr, Process* fork_parent = nullptr);
+    Process(RefPtr<Thread>& first_thread, const String& name, uid_t, gid_t, ProcessID ppid, bool is_kernel_process, RefPtr<Custody> cwd = nullptr, RefPtr<Custody> executable = nullptr, TTY* = nullptr, Process* fork_parent = nullptr);
     static ProcessID allocate_pid();
 
     Range allocate_range(VirtualAddress, size_t, size_t alignment = PAGE_SIZE);

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -60,7 +60,7 @@ public:
     static timeval time_since_boot();
     static bool yield();
     static bool donate_to_and_switch(Thread*, const char* reason);
-    static bool donate_to(Thread*, const char* reason);
+    static bool donate_to(RefPtr<Thread>&, const char* reason);
     static bool context_switch(Thread*);
     static void enter_current(Thread& prev_thread);
     static void leave_on_first_switch(u32 flags);

--- a/Kernel/Syscalls/sched.cpp
+++ b/Kernel/Syscalls/sched.cpp
@@ -40,8 +40,12 @@ int Process::sys$donate(pid_t tid)
     REQUIRE_PROMISE(stdio);
     if (tid < 0)
         return -EINVAL;
-    InterruptDisabler disabler;
-    auto* thread = Thread::from_tid(tid);
+
+    // We don't strictly need to grab the scheduler lock here, but it
+    // will close a race where we can find the thread but it disappears
+    // before we call Scheduler::donate_to.
+    ScopedSpinLock lock(g_scheduler_lock);
+    auto thread = Thread::from_tid(tid);
     if (!thread || thread->pid() != pid())
         return -ESRCH;
     Scheduler::donate_to(thread, "sys$donate");
@@ -55,8 +59,11 @@ int Process::sys$sched_setparam(int pid, Userspace<const struct sched_param*> us
     if (!copy_from_user(&desired_param, user_param))
         return -EFAULT;
 
-    InterruptDisabler disabler;
+    if (desired_param.sched_priority < THREAD_PRIORITY_MIN || desired_param.sched_priority > THREAD_PRIORITY_MAX)
+        return -EINVAL;
+
     auto* peer = Thread::current();
+    ScopedSpinLock lock(g_scheduler_lock);
     if (pid != 0)
         peer = Thread::from_tid(pid);
 
@@ -66,9 +73,6 @@ int Process::sys$sched_setparam(int pid, Userspace<const struct sched_param*> us
     if (!is_superuser() && m_euid != peer->process().m_uid && m_uid != peer->process().m_uid)
         return -EPERM;
 
-    if (desired_param.sched_priority < THREAD_PRIORITY_MIN || desired_param.sched_priority > THREAD_PRIORITY_MAX)
-        return -EINVAL;
-
     peer->set_priority((u32)desired_param.sched_priority);
     return 0;
 }
@@ -76,22 +80,27 @@ int Process::sys$sched_setparam(int pid, Userspace<const struct sched_param*> us
 int Process::sys$sched_getparam(pid_t pid, Userspace<struct sched_param*> user_param)
 {
     REQUIRE_PROMISE(proc);
-    InterruptDisabler disabler;
-    auto* peer = Thread::current();
-    if (pid != 0) {
-        // FIXME: PID/TID BUG
-        // The entire process is supposed to be affected.
-        peer = Thread::from_tid(pid);
+    int priority;
+    {
+        auto* peer = Thread::current();
+        ScopedSpinLock lock(g_scheduler_lock);
+        if (pid != 0) {
+            // FIXME: PID/TID BUG
+            // The entire process is supposed to be affected.
+            peer = Thread::from_tid(pid);
+        }
+
+        if (!peer)
+            return -ESRCH;
+
+        if (!is_superuser() && m_euid != peer->process().m_uid && m_uid != peer->process().m_uid)
+            return -EPERM;
+
+        priority = (int)peer->priority();
     }
 
-    if (!peer)
-        return -ESRCH;
-
-    if (!is_superuser() && m_euid != peer->process().m_uid && m_uid != peer->process().m_uid)
-        return -EPERM;
-
     struct sched_param param {
-        (int)peer->priority()
+        priority
     };
     if (!copy_to_user(user_param, &param))
         return -EFAULT;
@@ -103,8 +112,8 @@ int Process::sys$set_thread_boost(pid_t tid, int amount)
     REQUIRE_PROMISE(proc);
     if (amount < 0 || amount > 20)
         return -EINVAL;
-    InterruptDisabler disabler;
-    auto* thread = Thread::from_tid(tid);
+    ScopedSpinLock lock(g_scheduler_lock);
+    auto thread = Thread::from_tid(tid);
     if (!thread)
         return -ESRCH;
     if (thread->state() == Thread::State::Dead || thread->state() == Thread::State::Dying)

--- a/Kernel/Tasks/FinalizerTask.cpp
+++ b/Kernel/Tasks/FinalizerTask.cpp
@@ -31,7 +31,8 @@ namespace Kernel {
 
 void FinalizerTask::spawn()
 {
-    Process::create_kernel_process(g_finalizer, "FinalizerTask", [] {
+    RefPtr<Thread> finalizer_thread;
+    Process::create_kernel_process(finalizer_thread, "FinalizerTask", [] {
         Thread::current()->set_priority(THREAD_PRIORITY_LOW);
         for (;;) {
             Thread::current()->wait_on(*g_finalizer_wait_queue, "FinalizerTask");
@@ -41,6 +42,7 @@ void FinalizerTask::spawn()
                 Thread::finalize_dying_threads();
         }
     });
+    g_finalizer = finalizer_thread;
 }
 
 }

--- a/Kernel/Tasks/SyncTask.cpp
+++ b/Kernel/Tasks/SyncTask.cpp
@@ -33,7 +33,7 @@ namespace Kernel {
 
 void SyncTask::spawn()
 {
-    Thread* syncd_thread = nullptr;
+    RefPtr<Thread> syncd_thread;
     Process::create_kernel_process(syncd_thread, "SyncTask", [] {
         dbg() << "SyncTask is running";
         for (;;) {


### PR DESCRIPTION
Similar to Process, we need to make Thread refcounted. This will solve
problems that will appear once we schedule threads on more than one
processor. This allows us to hold onto threads without necessarily
holding the scheduler lock for the entire duration.