### PR TITLE
AK: Add support for replacement fields to format.

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -40,7 +40,7 @@ struct Formatter;
 
 struct TypeErasedParameter {
     const void* value;
-    void (*formatter)(StringBuilder& builder, const void* value, StringView specifier, Span<const TypeErasedParameter> parameters);
+    void (*formatter)(StringBuilder& builder, const void* value, StringView flags, Span<const TypeErasedParameter> parameters);
 };
 
 } // namespace AK
@@ -48,11 +48,11 @@ struct TypeErasedParameter {
 namespace AK::Detail::Format {
 
 template<typename T>
-void format_value(StringBuilder& builder, const void* value, StringView specifier, AK::Span<const TypeErasedParameter> parameters)
+void format_value(StringBuilder& builder, const void* value, StringView flags, AK::Span<const TypeErasedParameter> parameters)
 {
     Formatter<T> formatter;
 
-    formatter.parse(specifier);
+    formatter.parse(flags);
     formatter.format(builder, *static_cast<const T*>(value), parameters);
 }
 
@@ -103,7 +103,7 @@ struct StandardFormatter {
     size_t m_width = value_not_set;
     size_t m_precision = value_not_set;
 
-    void parse(StringView specifier);
+    void parse(StringView flags);
 };
 
 template<>
@@ -135,7 +135,7 @@ Array<TypeErasedParameter, sizeof...(Parameters)> make_type_erased_parameters(co
     return { TypeErasedParameter { &parameters, Detail::Format::format_value<Parameters> }... };
 }
 
-void vformat(StringBuilder& builder, StringView fmtstr, Span<const TypeErasedParameter>, size_t argument_index = 0);
+void vformat(StringBuilder& builder, StringView fmtstr, Span<const TypeErasedParameter>);
 void vformat(const LogStream& stream, StringView fmtstr, Span<const TypeErasedParameter>);
 
 } // namespace AK

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -113,4 +113,9 @@ TEST_CASE(zero_pad)
     EXPECT_EQ(String::formatted("{:/^010}", 42), "////42////");
 }
 
+TEST_CASE(replacement_field)
+{
+    EXPECT_EQ(String::formatted("{:*>{1}}", 13, static_cast<size_t>(10)), "********13");
+}
+
 TEST_MAIN(Format)

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -116,6 +116,9 @@ TEST_CASE(zero_pad)
 TEST_CASE(replacement_field)
 {
     EXPECT_EQ(String::formatted("{:*>{1}}", 13, static_cast<size_t>(10)), "********13");
+    EXPECT_EQ(String::formatted("{:*<{1}}", 7, 4), "7***");
+    EXPECT_EQ(String::formatted("{:{2}}", -5, 8, 16), "              -5");
+    EXPECT_EQ(String::formatted("{{{:*^{1}}}}", 1, 3), "{*1*}");
 }
 
 TEST_MAIN(Format)


### PR DESCRIPTION
Now it's possible to specify the width with which numbers are formatted dynamically:

~~~c++
String::formatted("{:0{1}}", 1, 3) // 001
~~~

In the `std::format` version it is also possible to take it from the next format specifier implicitly, I do not support this syntax yet:

~~~c++
String::formatted("{:0{}}", 1, 3) // 001
~~~

---

In the future it might be smart to define the repetitive type information stuff using `ENUMERATE_BUILTIN_FORMATTER` macros, but I did not want to do this yet.

It also starts to get quite crowded in the header and implementation. I'll have to do some housekeeping soon.
