### PR TITLE
Shell: Don't execute scripts interactively.

### DIFF
--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -873,6 +873,8 @@ NonnullRefPtrVector<Job> Shell::run_commands(Vector<AST::Command>& commands)
 bool Shell::run_file(const String& filename, bool explicitly_invoked)
 {
     TemporaryChange script_change { current_script, filename };
+    TemporaryChange interactive_change { m_is_interactive, false };
+
     auto file_result = Core::File::open(filename, Core::File::ReadOnly);
     if (file_result.is_error()) {
         if (explicitly_invoked)


### PR DESCRIPTION
The following example should illustrate one issue arising from this:

~~~none
$ echo 'exit 1' > example.sh
$ Shell example.sh
Good-bye!
~~~

This message is meant to be shown to an interactive user, but not in a shell script. With this change, this is done correctly and the message is only shown if the shell is executed interactively:

~~~none
$ Shell
$ exit
Good-bye!
~~~
