### PR TITLE
AK+TestSuite: Don't assume that the test passed in output.

### DIFF
--- a/AK/TestSuite.h
+++ b/AK/TestSuite.h
@@ -164,7 +164,7 @@ void TestSuite::main(const String& suite_name, int argc, char** argv)
             out() << "    " << test.name();
         }
     } else {
-        out() << "Running " << matching_tests.size() << " cases out of " << m_cases.size();
+        out() << "Running " << matching_tests.size() << " cases out of " << m_cases.size() << ".";
 
         run(matching_tests);
     }
@@ -199,13 +199,13 @@ void TestSuite::run(const NonnullRefPtrVector<TestCase>& tests)
     for (const auto& t : tests) {
         const auto test_type = t.is_benchmark() ? "benchmark" : "test";
 
-        dbg() << "START Running " << test_type << " " << t.name();
+        warnf("Running {} '{}'.", test_type, t.name());
 
         TestElapsedTimer timer;
         t.func()();
         const auto time = timer.elapsed_milliseconds();
 
-        warn() << "\033[32;1mPASS\033[0m: " << time << " ms running " << test_type << " " << t.name();
+        dbgf("Completed {} '{}' in {}ms", test_type, t.name(), time);
 
         if (t.is_benchmark()) {
             m_benchtime += time;


### PR DESCRIPTION
The problem with our test suite is that it can't detect if a test failed. When a test fails we simply write 'FAIL ...' to stderr and move on.

Previously, the test suite would list all tests as passing regardless how many assertions failed. In the future it might be smart to implement this properly but test suites for C++ are always hard to do nicely. (Because C++ execution isn't meant to be embedded.) This will do for now.