### PR TITLE
AK+Format: Support remaining format specifiers for integers and strings.

### DIFF
--- a/AK/NumericLimits.h
+++ b/AK/NumericLimits.h
@@ -49,6 +49,13 @@ struct NumericLimits<signed char> {
 };
 
 template<>
+struct NumericLimits<char> {
+    static constexpr char min() { return -__SCHAR_MAX__ - 1; }
+    static constexpr char max() { return __SCHAR_MAX__; }
+    static constexpr bool is_signed() { return true; }
+};
+
+template<>
 struct NumericLimits<short> {
     static constexpr short min() { return -__SHRT_MAX__ - 1; }
     static constexpr short max() { return __SHRT_MAX__; }

--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -141,7 +141,7 @@ inline size_t convert_unsigned_to_string(
     };
 
     const auto used_by_field = used_by_significant_digits + used_by_prefix;
-    const auto used_by_padding = static_cast<size_t>(max<ssize_t>(0, static_cast<ssize_t>(width) - static_cast<ssize_t>(used_by_field)));
+    const auto used_by_padding = width < used_by_field ? 0 : width - used_by_field;
 
     if (align == Align::Left) {
         const auto used_by_right_padding = used_by_padding;

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -130,4 +130,10 @@ TEST_CASE(complex_string_specifiers)
     EXPECT_EQ(String::formatted("{:^9}", "abcd"), "  abcd   ");
 }
 
+TEST_CASE(cast_integer_to_character)
+{
+    EXPECT_EQ(String::formatted("{:c}", static_cast<int>('a')), "a");
+    EXPECT_EQ(String::formatted("{:c}", static_cast<unsigned int>('f')), "f");
+}
+
 TEST_MAIN(Format)

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -122,4 +122,12 @@ TEST_CASE(replacement_field)
     EXPECT_EQ(String::formatted("{:0{}}", 1, 3), "001");
 }
 
+TEST_CASE(complex_string_specifiers)
+{
+    EXPECT_EQ(String::formatted("{:.8}", "123456789"), "12345678");
+    EXPECT_EQ(String::formatted("{:9}", "abcd"), "abcd     ");
+    EXPECT_EQ(String::formatted("{:>9}", "abcd"), "     abcd");
+    EXPECT_EQ(String::formatted("{:^9}", "abcd"), "  abcd   ");
+}
+
 TEST_MAIN(Format)


### PR DESCRIPTION
With this pull request it's now possible to use align, width and precision specifiers with strings as well. I also added support for character casts, where other integer types are printed as character (just ASCII, nothing fancy.)

---

The code used for alignment starts to get really redundant, I'll need to clean this up. This is what I am planning to do next.
