### PR TITLE
Shell: Wait for *a* child to change state when receiving a SIGCHLD

### DIFF
--- a/Shell/Job.h
+++ b/Shell/Job.h
@@ -52,7 +52,8 @@ public:
 #ifdef JOB_TIME_INFO
         if (m_active) {
             auto elapsed = m_command_timer.elapsed();
-            dbg() << "Command \"" << m_cmd << "\" finished in " << elapsed << " ms";
+            // Don't mistake this for the command!
+            dbg() << "Job entry \"" << m_cmd << "\" deleted in " << elapsed << " ms";
         }
 #endif
     }

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -158,6 +158,8 @@ public:
 
     bool read_single_line();
 
+    void notify_child_event();
+
     struct termios termios;
     struct termios default_termios;
     bool was_interrupted { false };

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -133,10 +133,23 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    if (getsid(getpid()) == 0) {
+    auto pid = getpid();
+    if (auto sid = getsid(pid); sid == 0) {
         if (setsid() < 0) {
             perror("setsid");
             // Let's just hope that it's ok.
+        }
+    } else if (sid != pid) {
+        if (getpgid(pid) != pid) {
+            dbgf("We were already in a session with sid={} (we are {}), let's do some gymnastics", sid, pid);
+            if (setpgid(pid, sid) < 0) {
+                auto strerr = strerror(errno);
+                dbgf("couldn't setpgid: {}", strerr);
+            }
+            if (setsid() < 0) {
+                auto strerr = strerror(errno);
+                dbgf("couldn't setsid: {}", strerr);
+            }
         }
     }
 

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -34,7 +34,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/wait.h>
 
 RefPtr<Line::Editor> editor;
 Shell* s_shell;


### PR DESCRIPTION
(take 2 - apparently you can't reopen PRs when you force-push to the branch)

This really just works around the core issue, which is that we have no
reliable way to know exactly who raised the signal (yet).
Fixes #3645, in a very weird way - although seems like bash also does something very similar (unless I'm just incapable of reading code with shit indentation) in its job control.

This is not a particularly good way to deal with the problem, but it does fix the aforementioned issue for me.

cc @awesomekling - would be nice to get `SA_SIGINFO`, even if just `si_pid` is present.

~Draft for now, I don't like this solution at all~ I can't really think of a better solution short of using `si_pid` from sigaction, but we don't have that.