### PR TITLE
AK+Format: Add formatters for boolean and pointer values and replace a few usages.

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -460,6 +460,17 @@ void Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type>::format(StringB
         PrintfImplementation::convert_signed_to_string(value, builder, base, m_alternative_form, upper_case, m_zero_pad, align, width, m_fill, sign_mode);
 }
 
+void Formatter<bool>::format(StringBuilder& builder, bool value, FormatterContext& context)
+{
+    if (m_mode == Mode::Binary || m_mode == Mode::BinaryUppercase || m_mode == Mode::Decimal || m_mode == Mode::Octal || m_mode == Mode::Hexadecimal || m_mode == Mode::HexadecimalUppercase) {
+        Formatter<u8> formatter { *this };
+        return formatter.format(builder, static_cast<u8>(value), context);
+    } else {
+        Formatter<StringView> formatter { *this };
+        formatter.format(builder, value ? "true" : "false", context);
+    }
+}
+
 template struct Formatter<unsigned char, void>;
 template struct Formatter<unsigned short, void>;
 template struct Formatter<unsigned int, void>;

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -367,6 +367,22 @@ void Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type>::format(StringB
     if (m_precision != value_not_set)
         ASSERT_NOT_REACHED();
 
+    if (m_mode == Mode::Pointer) {
+        if (m_sign != Sign::Default)
+            ASSERT_NOT_REACHED();
+        if (m_align != Align::Default)
+            ASSERT_NOT_REACHED();
+        if (m_alternative_form)
+            ASSERT_NOT_REACHED();
+        if (m_width != value_not_set)
+            ASSERT_NOT_REACHED();
+
+        m_mode = Mode::Hexadecimal;
+        m_alternative_form = true;
+        m_width = 2 * sizeof(void*) + 2;
+        m_zero_pad = true;
+    }
+
     u8 base = 0;
     bool upper_case = false;
     if (m_mode == Mode::Binary) {
@@ -389,7 +405,7 @@ void Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type>::format(StringB
         ASSERT_NOT_REACHED();
     }
 
-    auto width = decode_value(m_width, context);
+    const auto width = decode_value(m_width, context);
 
     const auto put_padding = [&](size_t amount, char fill) {
         for (size_t i = 0; i < amount; ++i)

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -198,6 +198,15 @@ struct Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type> : StandardFor
     void format(StringBuilder&, T value, FormatterContext&);
 };
 
+template<typename T>
+struct Formatter<T*> : StandardFormatter {
+    void format(StringBuilder& builder, T* value, FormatterContext& context)
+    {
+        Formatter<FlatPtr> formatter { *this };
+        formatter.format(builder, reinterpret_cast<FlatPtr>(value), context);
+    }
+};
+
 template<>
 struct Formatter<bool> : StandardFormatter {
     void format(StringBuilder&, bool value, FormatterContext&);

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -166,6 +166,12 @@ struct StandardFormatter {
 
 template<>
 struct Formatter<StringView> : StandardFormatter {
+    Formatter() { }
+    explicit Formatter(StandardFormatter formatter)
+        : StandardFormatter(formatter)
+    {
+    }
+
     void format(StringBuilder& builder, StringView value, FormatterContext&);
 };
 template<>
@@ -183,7 +189,18 @@ struct Formatter<String> : Formatter<StringView> {
 
 template<typename T>
 struct Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type> : StandardFormatter {
+    Formatter() { }
+    explicit Formatter(StandardFormatter formatter)
+        : StandardFormatter(formatter)
+    {
+    }
+
     void format(StringBuilder&, T value, FormatterContext&);
+};
+
+template<>
+struct Formatter<bool> : StandardFormatter {
+    void format(StringBuilder&, bool value, FormatterContext&);
 };
 
 template<typename... Parameters>

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -147,4 +147,19 @@ TEST_CASE(boolean_values)
     EXPECT_EQ(String::formatted("{:#08x}", true), "0x000001");
 }
 
+TEST_CASE(pointers)
+{
+    void* ptr = reinterpret_cast<void*>(0x4000);
+
+    if (sizeof(void*) == 4) {
+        EXPECT_EQ(String::formatted("{:p}", 32), "0x00000020");
+        EXPECT_EQ(String::formatted("{:p}", ptr), "0x00004000");
+    } else if (sizeof(void*) == 8) {
+        EXPECT_EQ(String::formatted("{:p}", 32), "0x0000000000000020");
+        EXPECT_EQ(String::formatted("{:p}", ptr), "0x0000000000004000");
+    } else {
+        ASSERT_NOT_REACHED();
+    }
+}
+
 TEST_MAIN(Format)

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -136,4 +136,15 @@ TEST_CASE(cast_integer_to_character)
     EXPECT_EQ(String::formatted("{:c}", static_cast<unsigned int>('f')), "f");
 }
 
+TEST_CASE(boolean_values)
+{
+    EXPECT_EQ(String::formatted("{}", true), "true");
+    EXPECT_EQ(String::formatted("{}", false), "false");
+    EXPECT_EQ(String::formatted("{:6}", true), "true  ");
+    EXPECT_EQ(String::formatted("{:>4}", false), "false");
+    EXPECT_EQ(String::formatted("{:d}", false), "0");
+    EXPECT_EQ(String::formatted("{:d}", true), "1");
+    EXPECT_EQ(String::formatted("{:#08x}", true), "0x000001");
+}
+
 TEST_MAIN(Format)

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -234,7 +234,7 @@ void Emulator::dump_backtrace()
 u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
 {
 #ifdef DEBUG_SPAM
-    dbgprintf("Syscall: %s (%x)\n", Syscall::to_string((Syscall::Function)function), function);
+    dbgf("Syscall: {} ({:x})", Syscall::to_string((Syscall::Function)function), function);
 #endif
     switch (function) {
     case SC_chdir:
@@ -379,7 +379,7 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
     case SC_fork:
         return virt$fork();
     default:
-        report("\n==%d==  \033[31;1mUnimplemented syscall: %s\033[0m, %p\n", getpid(), Syscall::to_string((Syscall::Function)function));
+        warnf("\n=={}==  \033[31;1mUnimplemented syscall: {}\033[0m, {:p}", getpid(), Syscall::to_string((Syscall::Function)function), function);
         dump_backtrace();
         TODO();
     }
@@ -950,7 +950,7 @@ int Emulator::virt$ioctl(int fd, unsigned request, FlatPtr arg)
         mmu().copy_from_vm(&termios, arg, sizeof(termios));
         return syscall(SC_ioctl, fd, request, &termios);
     }
-    dbg() << "Unsupported ioctl: " << request;
+    dbgf("Unsupported ioctl: {}", request);
     dump_backtrace();
     TODO();
 }
@@ -983,11 +983,10 @@ int Emulator::virt$execve(FlatPtr params_addr)
     copy_string_list(arguments, params.arguments);
     copy_string_list(environment, params.environment);
 
-    report("\n");
-    report("==%d==  \033[33;1mSyscall:\033[0m execve\n", getpid());
-    report("==%d==  @ %s\n", getpid(), path.characters());
+    warnf("\n=={}==  \033[33;1mSyscall:\033[0m execve", getpid());
+    warnf("=={}==  @ {}", getpid(), path);
     for (auto& argument : arguments)
-        report("==%d==    - %s\n", getpid(), argument.characters());
+        warnf("=={}==    - {}", getpid(), argument);
 
     Vector<char*> argv;
     Vector<char*> envp;
@@ -1200,7 +1199,7 @@ void Emulator::dispatch_one_pending_signal()
         auto action = default_signal_action(signum);
         if (action == DefaultSignalAction::Ignore)
             return;
-        report("\n==%d== Got signal %d (%s), no handler registered\n", getpid(), signum, strsignal(signum));
+        warnf("\n=={}== Got signal {} ({}), no handler registered", getpid(), signum, strsignal(signum));
         m_shutdown = true;
         return;
     }
@@ -1210,7 +1209,7 @@ void Emulator::dispatch_one_pending_signal()
         return;
     }
 
-    report("\n==%d== Got signal %d (%s), handler at %p\n", getpid(), signum, strsignal(signum), handler.handler);
+    warnf("\n=={}== Got signal {} ({}), handler at {:p}", getpid(), signum, strsignal(signum), handler.handler);
 
     auto old_esp = m_cpu.esp();
 

--- a/DevTools/UserspaceEmulator/MmapRegion.cpp
+++ b/DevTools/UserspaceEmulator/MmapRegion.cpp
@@ -68,7 +68,7 @@ MmapRegion::~MmapRegion()
 ValueWithShadow<u8> MmapRegion::read8(FlatPtr offset)
 {
     if (!is_readable()) {
-        warn() << "8-bit read from unreadable MmapRegion @ " << (const void*)(base() + offset);
+        warnf("8-bit read from unreadable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -85,7 +85,7 @@ ValueWithShadow<u8> MmapRegion::read8(FlatPtr offset)
 ValueWithShadow<u16> MmapRegion::read16(u32 offset)
 {
     if (!is_readable()) {
-        warn() << "16-bit from unreadable MmapRegion @ " << (const void*)(base() + offset);
+        warnf("16-bit read from unreadable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -102,7 +102,7 @@ ValueWithShadow<u16> MmapRegion::read16(u32 offset)
 ValueWithShadow<u32> MmapRegion::read32(u32 offset)
 {
     if (!is_readable()) {
-        warn() << "32-bit read from unreadable MmapRegion @ " << (const void*)(base() + offset);
+        warnf("32-bit read from unreadable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -119,7 +119,7 @@ ValueWithShadow<u32> MmapRegion::read32(u32 offset)
 ValueWithShadow<u64> MmapRegion::read64(u32 offset)
 {
     if (!is_readable()) {
-        warn() << "64-bit read from unreadable MmapRegion @ " << (const void*)(base() + offset);
+        warnf("64-bit read from unreadable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -136,7 +136,7 @@ ValueWithShadow<u64> MmapRegion::read64(u32 offset)
 void MmapRegion::write8(u32 offset, ValueWithShadow<u8> value)
 {
     if (!is_writable()) {
-        warn() << "8-bit write to unreadable MmapRegion @ " << (const void*)(base() + offset);
+        warnf("8-bit write from unwritable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -154,7 +154,7 @@ void MmapRegion::write8(u32 offset, ValueWithShadow<u8> value)
 void MmapRegion::write16(u32 offset, ValueWithShadow<u16> value)
 {
     if (!is_writable()) {
-        warn() << "16-bit write to unreadable MmapRegion @ " << (const void*)(base() + offset);
+        warnf("16-bit write from unwritable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -172,7 +172,7 @@ void MmapRegion::write16(u32 offset, ValueWithShadow<u16> value)
 void MmapRegion::write32(u32 offset, ValueWithShadow<u32> value)
 {
     if (!is_writable()) {
-        warn() << "32-bit write to unreadable MmapRegion @ " << (const void*)(base() + offset);
+        warnf("32-bit write from unwritable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -191,7 +191,7 @@ void MmapRegion::write32(u32 offset, ValueWithShadow<u32> value)
 void MmapRegion::write64(u32 offset, ValueWithShadow<u64> value)
 {
     if (!is_writable()) {
-        warn() << "64-bit write to unreadable MmapRegion @ " << (const void*)(base() + offset);
+        warnf("64-bit write from unwritable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }

--- a/DevTools/UserspaceEmulator/SoftMMU.cpp
+++ b/DevTools/UserspaceEmulator/SoftMMU.cpp
@@ -68,7 +68,7 @@ ValueWithShadow<u8> SoftMMU::read8(X86::LogicalAddress address)
 {
     auto* region = find_region(address);
     if (!region) {
-        warn() << "SoftMMU::read8: No region for @" << (const void*)address.offset();
+        warnf("SoftMMU::read8: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -79,7 +79,7 @@ ValueWithShadow<u16> SoftMMU::read16(X86::LogicalAddress address)
 {
     auto* region = find_region(address);
     if (!region) {
-        warn() << "SoftMMU::read16: No region for @" << (const void*)address.offset();
+        warnf("SoftMMU::read16: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -90,7 +90,7 @@ ValueWithShadow<u32> SoftMMU::read32(X86::LogicalAddress address)
 {
     auto* region = find_region(address);
     if (!region) {
-        warn() << "SoftMMU::read32: No region for @" << (const void*)address.offset();
+        warnf("SoftMMU::read32: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -101,7 +101,7 @@ ValueWithShadow<u64> SoftMMU::read64(X86::LogicalAddress address)
 {
     auto* region = find_region(address);
     if (!region) {
-        warn() << "SoftMMU::read64: No region for @" << (const void*)address.offset();
+        warnf("SoftMMU::read64: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -112,7 +112,7 @@ void SoftMMU::write8(X86::LogicalAddress address, ValueWithShadow<u8> value)
 {
     auto* region = find_region(address);
     if (!region) {
-        warn() << "SoftMMU::write8: No region for @" << (const void*)address.offset();
+        warnf("SoftMMU::write8: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -123,7 +123,7 @@ void SoftMMU::write16(X86::LogicalAddress address, ValueWithShadow<u16> value)
 {
     auto* region = find_region(address);
     if (!region) {
-        warn() << "SoftMMU::write16: No region for @" << (const void*)address.offset();
+        warnf("SoftMMU::write16: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -134,7 +134,7 @@ void SoftMMU::write32(X86::LogicalAddress address, ValueWithShadow<u32> value)
 {
     auto* region = find_region(address);
     if (!region) {
-        warn() << "SoftMMU::write32: No region for @" << (const void*)address.offset();
+        warnf("SoftMMU::write32: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -145,7 +145,7 @@ void SoftMMU::write64(X86::LogicalAddress address, ValueWithShadow<u64> value)
 {
     auto* region = find_region(address);
     if (!region) {
-        warn() << "SoftMMU::write64: No region for @" << (const void*)address.offset();
+        warnf("SoftMMU::write64: No region for @ {:p}", address.offset());
         TODO();
     }
 

--- a/DevTools/UserspaceEmulator/ValueWithShadow.h
+++ b/DevTools/UserspaceEmulator/ValueWithShadow.h
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Format.h>
 #include <AK/Platform.h>
 
 #pragma once
@@ -160,3 +161,11 @@ inline void ValueAndShadowReference<T>::operator=(const ValueWithShadow<T>& othe
 }
 
 }
+
+template<typename T>
+struct AK::Formatter<UserspaceEmulator::ValueWithShadow<T>> : AK::Formatter<T> {
+    void format(StringBuilder& builder, UserspaceEmulator::ValueWithShadow<T> value, FormatterContext& context)
+    {
+        return Formatter<T>::format(builder, value.value(), context);
+    }
+};


### PR DESCRIPTION
This pull request adds formatters for boolean and pointer values which I somehow forgot about when creating #3640.

I also replaced almost all printf calls with format calls. There are a few missing, but they aren't trivially replaceable because `warnf` always appends a newline like `warn` or generally any `LogStream`. I am not 100% sure what is the best way to fix this so, I left it open for the future.
