### PR TITLE
Kernel: Add checks for IsTriviallyCopyable to copy_to/from_user

### DIFF
--- a/AK/SharedBuffer.h
+++ b/AK/SharedBuffer.h
@@ -44,8 +44,21 @@ public:
     int shbuf_id() const { return m_shbuf_id; }
     void seal();
     int size() const { return m_size; }
-    void* data() { return m_data; }
-    const void* data() const { return m_data; }
+
+    template<typename T>
+    T* data()
+    {
+        static_assert(IsVoid<T>::value || is_trivial<T>());
+        return (T*)m_data;
+    }
+
+    template<typename T>
+    const T* data() const
+    {
+        static_assert(IsVoid<T>::value || is_trivial<T>());
+        return (const T*)m_data;
+    }
+
     void set_volatile();
     [[nodiscard]] bool set_nonvolatile();
 

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -453,6 +453,18 @@ struct IsBaseOf : public IntegralConstant<bool, __is_base_of(Base, Derived)> {
 };
 
 template<typename T>
+constexpr bool is_trivial()
+{
+    return __is_trivial(T);
+}
+
+template<typename T>
+constexpr bool is_trivially_copyable()
+{
+    return __is_trivially_copyable(T);
+}
+
+template<typename T>
 struct __IsIntegral : FalseType {
 };
 template<>
@@ -502,6 +514,8 @@ using AK::Conditional;
 using AK::declval;
 using AK::exchange;
 using AK::forward;
+using AK::is_trivial;
+using AK::is_trivially_copyable;
 using AK::IsBaseOf;
 using AK::IsClass;
 using AK::IsConst;

--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -61,48 +61,56 @@ inline u16 htons(u16 w) { return (w & 0xff) << 8 | ((w >> 8) & 0xff); }
 template<typename T>
 [[nodiscard]] inline bool copy_from_user(T* dest, const T* src)
 {
+    static_assert(is_trivially_copyable<T>());
     return copy_from_user(dest, src, sizeof(T));
 }
 
 template<typename T>
 [[nodiscard]] inline bool copy_to_user(T* dest, const T* src)
 {
+    static_assert(is_trivially_copyable<T>());
     return copy_to_user(dest, src, sizeof(T));
 }
 
 template<typename T>
 [[nodiscard]] inline bool copy_from_user(T* dest, Userspace<const T*> src)
 {
+    static_assert(is_trivially_copyable<T>());
     return copy_from_user(dest, src.unsafe_userspace_ptr(), sizeof(T));
 }
 
 template<typename T>
 [[nodiscard]] inline bool copy_from_user(T* dest, Userspace<T*> src)
 {
+    static_assert(is_trivially_copyable<T>());
     return copy_from_user(dest, src.unsafe_userspace_ptr(), sizeof(T));
 }
 
 template<typename T>
 [[nodiscard]] inline bool copy_to_user(Userspace<T*> dest, const T* src)
 {
+    static_assert(is_trivially_copyable<T>());
     return copy_to_user(dest.unsafe_userspace_ptr(), src, sizeof(T));
 }
 
 template<typename T>
 [[nodiscard]] inline bool copy_to_user(Userspace<T*> dest, const void* src, size_t size)
 {
+    static_assert(is_trivially_copyable<T>());
     return copy_to_user(dest.unsafe_userspace_ptr(), src, size);
 }
 
 template<typename T>
 [[nodiscard]] inline bool copy_from_user(void* dest, Userspace<const T*> src, size_t size)
 {
+    static_assert(is_trivially_copyable<T>());
     return copy_from_user(dest, src.unsafe_userspace_ptr(), size);
 }
 
 template<typename T>
 [[nodiscard]] inline bool copy_n_from_user(T* dest, const T* src, size_t count)
 {
+    static_assert(is_trivially_copyable<T>());
     Checked size = sizeof(T);
     size *= count;
     if (size.has_overflow())
@@ -113,6 +121,7 @@ template<typename T>
 template<typename T>
 [[nodiscard]] inline bool copy_n_to_user(T* dest, const T* src, size_t count)
 {
+    static_assert(is_trivially_copyable<T>());
     Checked size = sizeof(T);
     size *= count;
     if (size.has_overflow())
@@ -123,6 +132,7 @@ template<typename T>
 template<typename T>
 [[nodiscard]] inline bool copy_n_from_user(T* dest, Userspace<const T*> src, size_t count)
 {
+    static_assert(is_trivially_copyable<T>());
     Checked size = sizeof(T);
     size *= count;
     if (size.has_overflow())
@@ -133,6 +143,7 @@ template<typename T>
 template<typename T>
 [[nodiscard]] inline bool copy_n_to_user(Userspace<T*> dest, const T* src, size_t count)
 {
+    static_assert(is_trivially_copyable<T>());
     Checked size = sizeof(T);
     size *= count;
     if (size.has_overflow())

--- a/Libraries/LibAudio/Buffer.h
+++ b/Libraries/LibAudio/Buffer.h
@@ -120,7 +120,7 @@ public:
 
     const Sample* samples() const { return (const Sample*)data(); }
     int sample_count() const { return m_sample_count; }
-    const void* data() const { return m_buffer->data(); }
+    const void* data() const { return m_buffer->data<void>(); }
     int size_in_bytes() const { return m_sample_count * (int)sizeof(Sample); }
     int shbuf_id() const { return m_buffer->shbuf_id(); }
     SharedBuffer& shared_buffer() { return *m_buffer; }
@@ -130,7 +130,7 @@ private:
         : m_buffer(*SharedBuffer::create_with_size(samples.size() * sizeof(Sample)))
         , m_sample_count(samples.size())
     {
-        memcpy(m_buffer->data(), samples.data(), samples.size() * sizeof(Sample));
+        memcpy(m_buffer->data<void>(), samples.data(), samples.size() * sizeof(Sample));
     }
 
     explicit Buffer(NonnullRefPtr<SharedBuffer>&& buffer, int sample_count)

--- a/Libraries/LibGUI/Clipboard.cpp
+++ b/Libraries/LibGUI/Clipboard.cpp
@@ -90,7 +90,7 @@ Clipboard::DataAndType Clipboard::data_and_type() const
         dbgprintf("GUI::Clipboard::data() clipping contents size is greater than shared buffer size\n");
         return {};
     }
-    auto data = ByteBuffer::copy(shared_buffer->data(), response->data_size());
+    auto data = ByteBuffer::copy(shared_buffer->data<void>(), response->data_size());
     auto type = response->mime_type();
     auto metadata = response->metadata().entries();
     return { data, type, metadata };
@@ -104,7 +104,7 @@ void Clipboard::set_data(ReadonlyBytes data, const String& type, const HashMap<S
         return;
     }
     if (!data.is_empty())
-        memcpy(shared_buffer->data(), data.data(), data.size());
+        memcpy(shared_buffer->data<void>(), data.data(), data.size());
     shared_buffer->seal();
     shared_buffer->share_with(connection().server_pid());
 

--- a/Libraries/LibGUI/Menu.cpp
+++ b/Libraries/LibGUI/Menu.cpp
@@ -118,7 +118,7 @@ static int ensure_realized_icon(IconContainerType& container)
             auto shared_buffer = SharedBuffer::create_with_size(container.icon()->size_in_bytes());
             ASSERT(shared_buffer);
             auto shared_icon = Gfx::Bitmap::create_with_shared_buffer(Gfx::BitmapFormat::RGBA32, *shared_buffer, container.icon()->size());
-            memcpy(shared_buffer->data(), container.icon()->scanline_u8(0), container.icon()->size_in_bytes());
+            memcpy(shared_buffer->template data<u8>(), container.icon()->scanline_u8(0), container.icon()->size_in_bytes());
             shared_buffer->seal();
             shared_buffer->share_with(WindowServerConnection::the().server_pid());
             container.set_icon(shared_icon);

--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -169,7 +169,7 @@ RefPtr<Bitmap> Bitmap::create_with_shared_buffer(BitmapFormat format, NonnullRef
 
 Bitmap::Bitmap(BitmapFormat format, NonnullRefPtr<SharedBuffer>&& shared_buffer, const IntSize& size, const Vector<RGBA32>& palette)
     : m_size(size)
-    , m_data(shared_buffer->data())
+    , m_data(shared_buffer->data<void>())
     , m_pitch(minimum_pitch(size.width(), format))
     , m_format(format)
     , m_shared_buffer(move(shared_buffer))
@@ -255,7 +255,7 @@ RefPtr<Bitmap> Bitmap::to_bitmap_backed_by_shared_buffer() const
     auto bitmap = Bitmap::create_with_shared_buffer(m_format, *buffer, m_size, palette_to_vector());
     if (!bitmap)
         return nullptr;
-    memcpy(buffer->data(), scanline(0), size_in_bytes());
+    memcpy(buffer->data<void>(), scanline(0), size_in_bytes());
     return bitmap;
 }
 

--- a/Libraries/LibGfx/SystemTheme.h
+++ b/Libraries/LibGfx/SystemTheme.h
@@ -143,9 +143,9 @@ enum class PathRole {
 };
 
 struct SystemTheme {
-    Color color[(int)ColorRole::__Count];
+    RGBA32 color[(int)ColorRole::__Count];
     int metric[(int)MetricRole::__Count];
-    String path[(int)PathRole::__Count];
+    char path[(int)PathRole::__Count][256]; // TODO: PATH_MAX?
 };
 
 const SystemTheme& current_system_theme();

--- a/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Libraries/LibImageDecoderClient/Client.cpp
@@ -57,7 +57,7 @@ RefPtr<Gfx::Bitmap> Client::decode_image(const ByteBuffer& encoded_data)
         return nullptr;
     }
 
-    memcpy(encoded_buffer->data(), encoded_data.data(), encoded_data.size());
+    memcpy(encoded_buffer->data<void>(), encoded_data.data(), encoded_data.size());
 
     encoded_buffer->seal();
     encoded_buffer->share_with(server_pid());

--- a/Libraries/LibProtocol/Download.cpp
+++ b/Libraries/LibProtocol/Download.cpp
@@ -50,7 +50,7 @@ void Download::did_finish(Badge<Client>, bool success, Optional<u32> status_code
     RefPtr<SharedBuffer> shared_buffer;
     if (success && shbuf_id != -1) {
         shared_buffer = SharedBuffer::create_from_shbuf_id(shbuf_id);
-        payload = ByteBuffer::wrap(shared_buffer->data(), total_size);
+        payload = ByteBuffer::wrap(shared_buffer->data<void>(), total_size);
     }
 
     // FIXME: It's a bit silly that we copy the response headers here just so we can move them into a HashMap with different traits.

--- a/Services/Clipboard/ClientConnection.cpp
+++ b/Services/Clipboard/ClientConnection.cpp
@@ -83,7 +83,7 @@ OwnPtr<Messages::ClipboardServer::GetClipboardDataResponse> ClientConnection::ha
         //        It would be even nicer if a SharedBuffer could have an arbitrary number of clients..
         RefPtr<SharedBuffer> shared_buffer = SharedBuffer::create_with_size(storage.data_size());
         ASSERT(shared_buffer);
-        memcpy(shared_buffer->data(), storage.data(), storage.data_size());
+        memcpy(shared_buffer->data<void>(), storage.data(), storage.data_size());
         shared_buffer->seal();
         shared_buffer->share_with(client_pid());
         shbuf_id = shared_buffer->shbuf_id();

--- a/Services/Clipboard/Storage.cpp
+++ b/Services/Clipboard/Storage.cpp
@@ -46,7 +46,7 @@ Storage::~Storage()
 
 void Storage::set_data(NonnullRefPtr<SharedBuffer> data, size_t data_size, const String& mime_type, const HashMap<String, String>& metadata)
 {
-    dbg() << "Storage::set_data <- [" << mime_type << "] " << data->data() << " (" << data_size << " bytes)";
+    dbg() << "Storage::set_data <- [" << mime_type << "] " << data->data<void>() << " (" << data_size << " bytes)";
     for (auto& it : metadata) {
         dbg() << "  " << it.key << ": " << it.value;
     }

--- a/Services/Clipboard/Storage.h
+++ b/Services/Clipboard/Storage.h
@@ -47,7 +47,7 @@ public:
     {
         if (!has_data())
             return nullptr;
-        return static_cast<const u8*>(m_shared_buffer->data());
+        return m_shared_buffer->data<u8>();
     }
 
     size_t data_size() const

--- a/Services/ImageDecoder/ClientConnection.cpp
+++ b/Services/ImageDecoder/ClientConnection.cpp
@@ -79,7 +79,7 @@ OwnPtr<Messages::ImageDecoderServer::DecodeImageResponse> ClientConnection::hand
     dbg() << "Trying to decode " << message.encoded_size() << " bytes of image(?) data in shbuf_id=" << message.encoded_shbuf_id() << " (shbuf size: " << encoded_buffer->size() << ")";
 #endif
 
-    auto decoder = Gfx::ImageDecoder::create((const u8*)encoded_buffer->data(), message.encoded_size());
+    auto decoder = Gfx::ImageDecoder::create(encoded_buffer->data<u8>(), message.encoded_size());
     auto bitmap = decoder->bitmap();
 
     if (!bitmap) {

--- a/Services/ProtocolServer/ClientConnection.cpp
+++ b/Services/ProtocolServer/ClientConnection.cpp
@@ -91,7 +91,7 @@ void ClientConnection::did_finish_download(Badge<Download>, Download& download, 
     RefPtr<SharedBuffer> buffer;
     if (success && download.payload().size() > 0 && !download.payload().is_null()) {
         buffer = SharedBuffer::create_with_size(download.payload().size());
-        memcpy(buffer->data(), download.payload().data(), download.payload().size());
+        memcpy(buffer->data<void>(), download.payload().data(), download.payload().size());
         buffer->seal();
         buffer->share_with(client_pid());
         m_shared_buffers.set(buffer->shbuf_id(), buffer);

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -50,7 +50,7 @@ void PageHost::setup_palette()
 {
     // FIXME: Get the proper palette from our peer somehow
     auto buffer = SharedBuffer::create_with_size(sizeof(Gfx::SystemTheme));
-    auto* theme = (Gfx::SystemTheme*)buffer->data();
+    auto* theme = buffer->data<Gfx::SystemTheme>();
     theme->color[(int)Gfx::ColorRole::Window] = Color::Magenta;
     theme->color[(int)Gfx::ColorRole::WindowText] = Color::Cyan;
     m_palette_impl = Gfx::PaletteImpl::create_with_shared_buffer(*buffer);


### PR DESCRIPTION
If we're copying structures, we only ever want to copy trivially
copyable structures.

- [x] We should probably also leverage this for `SharedBuffer` use cases, such as #3650.