### PR TITLE
MenuApplets: Keymap Switcher

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -73,6 +73,11 @@ User=clipboard
 KeepAlive=1
 User=anon
 
+[Keymap.MenuApplet]
+Priority=low
+KeepAlive=1
+User=anon
+
 [Clock.MenuApplet]
 KeepAlive=1
 Priority=low

--- a/Base/etc/WindowServer/WindowServer.ini
+++ b/Base/etc/WindowServer/WindowServer.ini
@@ -28,4 +28,4 @@ DoubleClickSpeed=250
 Mode=scaled
 
 [Applet]
-Order=Clock,ClipboardHistory,Audio,CPUGraph,MemoryGraph,UserName
+Order=Keymap,Clock,ClipboardHistory,Audio,CPUGraph,MemoryGraph,UserName

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -164,6 +164,7 @@ namespace Kernel {
     S(fchdir)                 \
     S(getrandom)              \
     S(setkeymap)              \
+    S(get_keymap_name)        \
     S(clock_gettime)          \
     S(clock_settime)          \
     S(clock_nanosleep)        \

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -110,6 +110,7 @@ set(KERNEL_SOURCES
     Syscalls/ftruncate.cpp
     Syscalls/futex.cpp
     Syscalls/get_dir_entries.cpp
+    Syscalls/get_keymap_name.cpp
     Syscalls/get_stack_bounds.cpp
     Syscalls/getrandom.cpp
     Syscalls/getuid.cpp

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -319,6 +319,7 @@ public:
     int sys$realpath(Userspace<const Syscall::SC_realpath_params*>);
     ssize_t sys$getrandom(Userspace<void*>, size_t, unsigned int);
     int sys$setkeymap(Userspace<const Syscall::SC_setkeymap_params*>);
+    int sys$get_keymap_name(Userspace<char*> buffer, size_t buffer_size);
     int sys$module_load(Userspace<const char*> path, size_t path_length);
     int sys$module_unload(Userspace<const char*> name, size_t name_length);
     int sys$profiling_enable(pid_t);

--- a/Kernel/Syscalls/get_keymap_name.cpp
+++ b/Kernel/Syscalls/get_keymap_name.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018-2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Kernel/Devices/KeyboardDevice.h>
+#include <Kernel/Process.h>
+
+namespace Kernel {
+
+int Process::sys$get_keymap_name(Userspace<char*> buffer, size_t buffer_size)
+{
+    REQUIRE_PROMISE(stdio);
+    const String keymap_name = KeyboardDevice::the().keymap_name();
+
+    if (keymap_name.length() + 1 > buffer_size)
+        return -ENAMETOOLONG;
+
+    if (!copy_to_user(buffer, keymap_name.characters(), keymap_name.length() + 1))
+        return -EFAULT;
+
+    return 0;
+}
+
+}

--- a/Libraries/LibC/serenity.cpp
+++ b/Libraries/LibC/serenity.cpp
@@ -136,4 +136,11 @@ int get_stack_bounds(uintptr_t* user_stack_base, size_t* user_stack_size)
     int rc = syscall(SC_get_stack_bounds, user_stack_base, user_stack_size);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
+
+int get_keymap_name(char* buffer, size_t buffer_size)
+{
+    int rc = syscall(SC_get_keymap_name, buffer, buffer_size);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
 }

--- a/Libraries/LibC/serenity.cpp
+++ b/Libraries/LibC/serenity.cpp
@@ -142,5 +142,4 @@ int get_keymap_name(char* buffer, size_t buffer_size)
     int rc = syscall(SC_get_keymap_name, buffer, buffer_size);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
-
 }

--- a/Libraries/LibC/serenity.h
+++ b/Libraries/LibC/serenity.h
@@ -72,6 +72,8 @@ int perf_event(int type, uintptr_t arg1, uintptr_t arg2);
 
 int get_stack_bounds(uintptr_t* user_stack_base, size_t* user_stack_size);
 
+int get_keymap_name(char* buffer, size_t buffer_size);
+
 ALWAYS_INLINE void send_secret_data_to_userspace_emulator(uintptr_t data1, uintptr_t data2, uintptr_t data3)
 {
     asm volatile(

--- a/MenuApplets/CMakeLists.txt
+++ b/MenuApplets/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(Audio)
 add_subdirectory(ClipboardHistory)
 add_subdirectory(Clock)
+add_subdirectory(Keymap)
 add_subdirectory(ResourceGraph)
 add_subdirectory(UserName)

--- a/MenuApplets/Keymap/CMakeLists.txt
+++ b/MenuApplets/Keymap/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(SOURCES
+    main.cpp
+)
+
+serenity_bin(Keymap.MenuApplet)
+target_link_libraries(Keymap.MenuApplet LibGUI LibGfx LibKeyboard)

--- a/MenuApplets/Keymap/main.cpp
+++ b/MenuApplets/Keymap/main.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibGUI/Application.h>
+#include <LibGUI/Painter.h>
+#include <LibGUI/Window.h>
+#include <LibGfx/Font.h>
+#include <LibGfx/Palette.h>
+#include <LibKeyboard/CharacterMap.h>
+#include <serenity.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <time.h>
+
+class KeymapWidget final : public GUI::Widget {
+    C_OBJECT(KeymapWidget)
+public:
+    KeymapWidget()
+    {
+        update_keymap_name();
+        start_timer(5000);
+    }
+
+    virtual ~KeymapWidget() override { }
+
+    int get_width()
+    {
+        return m_keymap_name_width + menubar_menu_margin();
+    }
+
+private:
+    static int menubar_menu_margin() { return 4; }
+
+    virtual void paint_event(GUI::PaintEvent& event) override
+    {
+        GUI::Painter painter(*this);
+        painter.fill_rect(event.rect(), palette().window());
+        painter.draw_text(event.rect(), m_keymap_name, Gfx::Font::default_bold_font(), Gfx::TextAlignment::Center, palette().window_text());
+    }
+
+    virtual void mousedown_event(GUI::MouseEvent& event) override
+    {
+        if (event.button() != GUI::MouseButton::Left)
+            return;
+        pid_t child_pid;
+        const char* argv[] = { "KeyboardSettings", nullptr };
+        if ((errno = posix_spawn(&child_pid, "/bin/KeyboardSettings", nullptr, nullptr, const_cast<char**>(argv), environ))) {
+            perror("posix_spawn");
+        } else {
+            if (disown(child_pid) < 0)
+                perror("disown");
+        }
+    }
+
+    virtual void timer_event(Core::TimerEvent&) override
+    {
+        update_keymap_name();
+    }
+
+    void update_keymap_name()
+    {
+        char buf[24];
+        if (get_keymap_name(buf, 24) < 0) {
+            perror("get_keymap_name");
+            m_keymap_name = "??";
+            return;
+        }
+
+        String new_name = String(buf).substring(0, 2).to_uppercase();
+        if (new_name != m_keymap_name) {
+            m_keymap_name = new_name;
+            m_keymap_name_width = Gfx::Font::default_bold_font().width(m_keymap_name);
+            update();
+        }
+    }
+
+    String m_keymap_name;
+    int m_keymap_name_width;
+};
+
+int main(int argc, char** argv)
+{
+    if (pledge("stdio shared_buffer accept rpath unix cpath fattr exec proc", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    auto app = GUI::Application::construct(argc, argv);
+
+    if (pledge("stdio shared_buffer accept rpath exec proc", nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    auto window = GUI::Window::construct();
+    window->set_title("Clock");
+    window->set_window_type(GUI::WindowType::MenuApplet);
+
+    auto& widget = window->set_main_widget<KeymapWidget>();
+    window->resize(widget.get_width(), 16);
+    window->show();
+
+    if (unveil("/res", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil("/bin/KeyboardSettings", "x") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    unveil(nullptr, nullptr);
+
+    return app->exec();
+}


### PR DESCRIPTION
This PR adds a new MenuApplet: "Keymap". It displays current keymap name (first 2 characters of it). If you click on it, it opens KeyboardSettings.

It's now updated every 5 seconds.

Screenshot:
![Screenshot](https://user-images.githubusercontent.com/42967349/94843746-6d585400-041d-11eb-9229-06a9b5b0b0b1.png)

Note: I think it will be better to handle keymaps in WindowServer instead of Kernel. We can then broadcast messages about keymap change (and then handle it properly e.g updating display in Keymap applet)

