### PR TITLE
HackStudio: Abstract away language-server details

### DIFF
--- a/DevTools/HackStudio/CMakeLists.txt
+++ b/DevTools/HackStudio/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES
     Git/GitRepo.cpp
     Git/GitWidget.cpp
     HackStudioWidget.cpp
+    LanguageClient.cpp
     Locator.cpp
     ProcessStateWidget.cpp
     Project.cpp

--- a/DevTools/HackStudio/Editor.h
+++ b/DevTools/HackStudio/Editor.h
@@ -29,6 +29,7 @@
 #include "AutoCompleteBox.h"
 #include "CodeDocument.h"
 #include "Debugger/BreakpointCallback.h"
+#include "LanguageClient.h"
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <LibGUI/TextEditor.h>
@@ -107,6 +108,8 @@ private:
     bool m_hovering_link { false };
     bool m_holding_ctrl { false };
     bool m_autocomplete_in_focus { false };
+
+    OwnPtr<LanguageClient> m_language_client;
 };
 
 }

--- a/DevTools/HackStudio/HackStudio.h
+++ b/DevTools/HackStudio/HackStudio.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include "EditorWrapper.h"
-#include "LanguageClients/Cpp/ServerConnection.h"
+#include "LanguageClients/ServerConnections.h"
 #include "Project.h"
 #include <AK/String.h>
 #include <LibGUI/TextEditor.h>
@@ -41,6 +41,5 @@ void open_file(const String&);
 Project& project();
 String currently_open_file();
 void set_current_editor_wrapper(RefPtr<EditorWrapper>);
-LanguageClients::Cpp::ServerConnection& cpp_Language_server_connection();
 
 }

--- a/DevTools/HackStudio/LanguageClient.cpp
+++ b/DevTools/HackStudio/LanguageClient.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "LanguageClient.h"
+#include <AK/String.h>
+#include <AK/Vector.h>
+
+namespace HackStudio {
+
+void ServerConnection::handle(const Messages::LanguageClient::AutoCompleteSuggestions& message)
+{
+    if (m_language_client)
+        m_language_client->provide_autocomplete_suggestions(message.suggestions());
+}
+
+void LanguageClient::open_file(const String& path)
+{
+    m_connection.post_message(Messages::LanguageServer::FileOpened(path));
+}
+
+void LanguageClient::set_file_content(const String& path, const String& content)
+{
+    m_connection.post_message(Messages::LanguageServer::SetFileContent(path, content));
+}
+
+void LanguageClient::insert_text(const String& path, const String& text, size_t line, size_t column)
+{
+    m_connection.post_message(Messages::LanguageServer::FileEditInsertText(path, text, line, column));
+}
+
+void LanguageClient::remove_text(const String& path, size_t from_line, size_t from_column, size_t to_line, size_t to_column)
+{
+    m_connection.post_message(Messages::LanguageServer::FileEditRemoveText(path, from_line, from_column, to_line, to_column));
+}
+
+void LanguageClient::request_autocomplete(const String& path, size_t cursor_line, size_t cursor_column)
+{
+    m_connection.post_message(Messages::LanguageServer::AutoCompleteSuggestions(path, cursor_line, cursor_column));
+}
+
+void LanguageClient::provide_autocomplete_suggestions(const Vector<String>& suggestions)
+{
+    if (on_autocomplete_suggestions)
+        on_autocomplete_suggestions(suggestions);
+
+    // Otherwise, drop it on the floor :shrug:
+}
+
+}

--- a/DevTools/HackStudio/LanguageClient.h
+++ b/DevTools/HackStudio/LanguageClient.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <AK/LexicalPath.h>
+#include <AK/Types.h>
+#include <DevTools/HackStudio/LanguageServers/LanguageClientEndpoint.h>
+#include <DevTools/HackStudio/LanguageServers/LanguageServerEndpoint.h>
+#include <LibIPC/ServerConnection.h>
+
+namespace HackStudio {
+
+class LanguageClient;
+
+class ServerConnection
+    : public IPC::ServerConnection<LanguageClientEndpoint, LanguageServerEndpoint>
+    , public LanguageClientEndpoint {
+public:
+    ServerConnection(const StringView& socket, const StringView& project_path)
+        : IPC::ServerConnection<LanguageClientEndpoint, LanguageServerEndpoint>(*this, socket)
+        , m_project_path(project_path)
+    {
+    }
+
+    void attach(LanguageClient& client)
+    {
+        m_language_client = &client;
+    }
+
+    void detach()
+    {
+        m_language_client = nullptr;
+    }
+
+    virtual void handshake() override
+    {
+        auto response = send_sync<Messages::LanguageServer::Greet>(m_project_path.string());
+        set_my_client_id(response->client_id());
+    }
+
+    template<typename ConcreteType>
+    static NonnullRefPtr<ServerConnection> get_or_create(const String& project_path)
+    {
+        static HashMap<String, NonnullRefPtr<ConcreteType>> s_instances_for_projects;
+        auto key = LexicalPath { project_path }.string();
+        if (auto instance = s_instances_for_projects.get(key); instance.has_value())
+            return *instance.value();
+
+        auto connection = ConcreteType::construct(project_path);
+        connection->handshake();
+        s_instances_for_projects.set(key, *connection);
+        return *connection;
+    }
+
+protected:
+    virtual void handle(const Messages::LanguageClient::AutoCompleteSuggestions&) override;
+
+    LanguageClient* m_language_client { nullptr };
+    LexicalPath m_project_path;
+};
+
+class LanguageClient {
+public:
+    explicit LanguageClient(NonnullRefPtr<ServerConnection>&& connection)
+        : m_connection(*connection)
+        , m_server_connection(move(connection))
+    {
+        m_connection.attach(*this);
+    }
+
+    virtual ~LanguageClient()
+    {
+        m_connection.detach();
+    }
+
+    virtual void open_file(const String& path);
+    virtual void set_file_content(const String& path, const String& content);
+    virtual void insert_text(const String& path, const String& text, size_t line, size_t column);
+    virtual void remove_text(const String& path, size_t from_line, size_t from_column, size_t to_line, size_t to_column);
+    virtual void request_autocomplete(const String& path, size_t cursor_line, size_t cursor_column);
+
+    void provide_autocomplete_suggestions(const Vector<String>&);
+
+    Function<void(Vector<String>)> on_autocomplete_suggestions;
+
+private:
+    ServerConnection& m_connection;
+    NonnullRefPtr<ServerConnection> m_server_connection;
+};
+
+template<typename ServerConnectionT>
+static inline NonnullOwnPtr<LanguageClient> get_language_client(const String& project_path)
+{
+    return make<LanguageClient>(ServerConnection::get_or_create<ServerConnectionT>(project_path));
+}
+
+}

--- a/DevTools/HackStudio/LanguageClients/CMakeLists.txt
+++ b/DevTools/HackStudio/LanguageClients/CMakeLists.txt
@@ -1,1 +1,4 @@
-add_subdirectory(Cpp)
+ set(GENERATED_SOURCES
+    ../../LanguageServers/LanguageServerEndpoint.h
+    ../../LanguageServers/LanguageClientEndpoint.h
+ )

--- a/DevTools/HackStudio/LanguageClients/Cpp/CMakeLists.txt
+++ b/DevTools/HackStudio/LanguageClients/Cpp/CMakeLists.txt
@@ -1,4 +1,0 @@
- set(GENERATED_SOURCES 
-    ../../LanguageServers/Cpp/CppLanguageServerEndpoint.h
-    ../../LanguageServers/Cpp/CppLanguageClientEndpoint.h
- ) 

--- a/DevTools/HackStudio/LanguageServers/CMakeLists.txt
+++ b/DevTools/HackStudio/LanguageServers/CMakeLists.txt
@@ -1,1 +1,4 @@
+compile_ipc(LanguageServer.ipc LanguageServerEndpoint.h)
+compile_ipc(LanguageClient.ipc LanguageClientEndpoint.h)
+
 add_subdirectory(Cpp)

--- a/DevTools/HackStudio/LanguageServers/Cpp/CMakeLists.txt
+++ b/DevTools/HackStudio/LanguageServers/Cpp/CMakeLists.txt
@@ -1,16 +1,15 @@
-compile_ipc(CppLanguageServer.ipc CppLanguageServerEndpoint.h)
-compile_ipc(CppLanguageClient.ipc CppLanguageClientEndpoint.h)
-
 set(SOURCES
     ClientConnection.cpp
     main.cpp
-    CppLanguageServerEndpoint.h
-    CppLanguageClientEndpoint.h
     AutoComplete.cpp
 )
 
+set(GENERATED_SOURCES
+    ../LanguageServerEndpoint.h
+    ../LanguageClientEndpoint.h)
+
 serenity_bin(CppLanguageServer)
 
-# We link with LibGUI because we use GUI::TextDocument to update 
+# We link with LibGUI because we use GUI::TextDocument to update
 # the content of files according to the edit actions we receive over IPC.
 target_link_libraries(CppLanguageServer LibIPC LibCpp LibGUI)

--- a/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
+++ b/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
@@ -28,16 +28,16 @@
 
 #include <AK/HashMap.h>
 #include <AK/LexicalPath.h>
-#include <DevTools/HackStudio/LanguageServers/Cpp/CppLanguageClientEndpoint.h>
-#include <DevTools/HackStudio/LanguageServers/Cpp/CppLanguageServerEndpoint.h>
+#include <DevTools/HackStudio/LanguageServers/LanguageClientEndpoint.h>
+#include <DevTools/HackStudio/LanguageServers/LanguageServerEndpoint.h>
 #include <LibGUI/TextDocument.h>
 #include <LibIPC/ClientConnection.h>
 
 namespace LanguageServers::Cpp {
 
 class ClientConnection final
-    : public IPC::ClientConnection<CppLanguageClientEndpoint, CppLanguageServerEndpoint>
-    , public CppLanguageServerEndpoint {
+    : public IPC::ClientConnection<LanguageClientEndpoint, LanguageServerEndpoint>
+    , public LanguageServerEndpoint {
     C_OBJECT(ClientConnection);
 
 public:
@@ -47,12 +47,12 @@ public:
     virtual void die() override;
 
 private:
-    virtual OwnPtr<Messages::CppLanguageServer::GreetResponse> handle(const Messages::CppLanguageServer::Greet&) override;
-    virtual void handle(const Messages::CppLanguageServer::FileOpened&) override;
-    virtual void handle(const Messages::CppLanguageServer::FileEditInsertText&) override;
-    virtual void handle(const Messages::CppLanguageServer::FileEditRemoveText&) override;
-    virtual void handle(const Messages::CppLanguageServer::SetFileContent&) override;
-    virtual OwnPtr<Messages::CppLanguageServer::AutoCompleteSuggestionsResponse> handle(const Messages::CppLanguageServer::AutoCompleteSuggestions&) override;
+    virtual OwnPtr<Messages::LanguageServer::GreetResponse> handle(const Messages::LanguageServer::Greet&) override;
+    virtual void handle(const Messages::LanguageServer::FileOpened&) override;
+    virtual void handle(const Messages::LanguageServer::FileEditInsertText&) override;
+    virtual void handle(const Messages::LanguageServer::FileEditRemoveText&) override;
+    virtual void handle(const Messages::LanguageServer::SetFileContent&) override;
+    virtual void handle(const Messages::LanguageServer::AutoCompleteSuggestions&) override;
 
     RefPtr<GUI::TextDocument> document_for(const String& file_name);
 

--- a/DevTools/HackStudio/LanguageServers/Cpp/CppLanguageClient.ipc
+++ b/DevTools/HackStudio/LanguageServers/Cpp/CppLanguageClient.ipc
@@ -1,4 +1,0 @@
-endpoint CppLanguageClient = 8002
-{
-    Dummy() =|
-}

--- a/DevTools/HackStudio/LanguageServers/LanguageClient.ipc
+++ b/DevTools/HackStudio/LanguageServers/LanguageClient.ipc
@@ -1,0 +1,4 @@
+endpoint LanguageClient = 8002
+{
+    AutoCompleteSuggestions(Vector<String> suggestions) =|
+}

--- a/DevTools/HackStudio/LanguageServers/LanguageServer.ipc
+++ b/DevTools/HackStudio/LanguageServers/LanguageServer.ipc
@@ -1,4 +1,4 @@
-endpoint CppLanguageServer = 8001
+endpoint LanguageServer = 8001
 {
     Greet(String project_root) => (i32 client_id)
 
@@ -7,5 +7,5 @@ endpoint CppLanguageServer = 8001
     FileEditRemoveText(String file_name, i32 start_line, i32 start_column, i32 end_line, i32 end_column) =|
     SetFileContent(String file_name, String content) =|
 
-    AutoCompleteSuggestions(String file_name, i32 cursor_line, i32 cursor_column) => (Vector<String> suggestions)
+    AutoCompleteSuggestions(String file_name, i32 cursor_line, i32 cursor_column) =|
 }

--- a/DevTools/HackStudio/main.cpp
+++ b/DevTools/HackStudio/main.cpp
@@ -26,7 +26,6 @@
 
 #include "HackStudio.h"
 #include "HackStudioWidget.h"
-#include "LanguageClients/Cpp/ServerConnection.h"
 #include "Project.h"
 #include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>
@@ -52,13 +51,11 @@ using namespace HackStudio;
 
 static RefPtr<GUI::Window> s_window;
 static RefPtr<HackStudioWidget> s_hack_studio_widget;
-static RefPtr<LanguageClients::Cpp::ServerConnection> s_cpp_Language_server_connection;
 
 static bool make_is_available();
 static void update_path_environment_variable();
 static String path_to_project(const String& path_argument_absolute_path);
 static void open_default_project_file(const String& project_path);
-static void initialize_connections_to_language_servers(const String& project_path);
 
 int main(int argc, char** argv)
 {
@@ -94,8 +91,6 @@ int main(int argc, char** argv)
     auto menubar = GUI::MenuBar::construct();
     auto project_path = path_to_project(argument_absolute_path);
     s_hack_studio_widget = s_window->set_main_widget<HackStudioWidget>(project_path);
-
-    initialize_connections_to_language_servers(project_path);
 
     s_hack_studio_widget->initialize_menubar(menubar);
     app->set_menubar(menubar);
@@ -152,13 +147,6 @@ static void open_default_project_file(const String& project_path)
         open_file(s_hack_studio_widget->project().default_file());
 }
 
-static void initialize_connections_to_language_servers(const String& project_path)
-{
-    LexicalPath project_root_dir(LexicalPath(project_path).dirname());
-    s_cpp_Language_server_connection = LanguageClients::Cpp::ServerConnection::construct(project_root_dir.string());
-    s_cpp_Language_server_connection->handshake();
-}
-
 namespace HackStudio {
 
 GUI::TextEditor& current_editor()
@@ -193,12 +181,6 @@ String currently_open_file()
 void set_current_editor_wrapper(RefPtr<EditorWrapper> wrapper)
 {
     s_hack_studio_widget->set_current_editor_wrapper(wrapper);
-}
-
-LanguageClients::Cpp::ServerConnection& cpp_Language_server_connection()
-{
-    ASSERT(s_cpp_Language_server_connection);
-    return *s_cpp_Language_server_connection;
 }
 
 }


### PR DESCRIPTION
This commit moves all the logic that deals with the language server
(from HackStudio) into a LanguageClient class, provides some functions
to make constructing them easier, and makes all language servers use a
singular IPC definition.
Also fixes the FIXME about making autocompletion async.
This makes adding language servers in the future significantly less
duplicate-y, and significantly easier :^)

~~Note about async: For some reason, making it async creates a significant delay between the request (ctrl-space) and the response popping up - this is a TODO for this PR.~~

cc @itamar8910 