### PR TITLE
Build: Emit paths in macros and debug sections relative to repo root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-shared")
 #FIXME: -fstack-protector
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os -g1 -fno-exceptions -fno-rtti -Wno-address-of-packed-member -Wundef -Wcast-qual -Wwrite-strings -Wimplicit-fallthrough -Wno-nonnull-compare -Wno-deprecated-copy -Wno-expansion-to-defined")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffile-prefix-map=${CMAKE_SOURCE_DIR}=.")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG -DSANITIZE_PTRS")
 add_link_options(--sysroot ${CMAKE_BINARY_DIR}/Root)


### PR DESCRIPTION
To avoid including paths from the build environment in the binaries. A step towards having reproducible builds.

This is kinda an experimental change, needs some testing before merge. (May cause issues with debuggers.)