### PR TITLE
Everywhere: Fix typos

### DIFF
--- a/Libraries/LibAudio/WavLoader.cpp
+++ b/Libraries/LibAudio/WavLoader.cpp
@@ -58,7 +58,7 @@ RefPtr<Buffer> WavLoader::get_more_samples(size_t max_bytes_to_read_from_input)
         return nullptr;
 
     auto buffer = Buffer::from_pcm_data(raw_samples, *m_resampler, m_num_channels, m_bits_per_sample);
-    //Buffer contains normalized samples, but m_loaded_samples should containt the ammount of actually loaded samples
+    //Buffer contains normalized samples, but m_loaded_samples should contain the amount of actually loaded samples
     m_loaded_samples += static_cast<int>(max_bytes_to_read_from_input) / (m_num_channels * (m_bits_per_sample / 8));
     m_loaded_samples = min(m_total_samples, m_loaded_samples);
     return buffer;

--- a/Libraries/LibC/netdb.cpp
+++ b/Libraries/LibC/netdb.cpp
@@ -365,7 +365,7 @@ void endservent()
 }
 
 // Fill the service entry buffer with the information contained
-// in the currently read line, returns true if successfull,
+// in the currently read line, returns true if successful,
 // false if failure occurs.
 static bool fill_getserv_buffers(const char* line, ssize_t read)
 {
@@ -376,7 +376,7 @@ static bool fill_getserv_buffers(const char* line, ssize_t read)
 
     // This indicates an incorrect file format.
     // Services file entries should always at least contain
-    // name and port/protocol, seperated by tabs.
+    // name and port/protocol, separated by tabs.
     if (split_line.size() < 2) {
         fprintf(stderr, "getservent(): malformed services file\n");
         return false;

--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -1014,7 +1014,7 @@ unsigned long long strtoull(const char* str, char** endptr, int base)
 
 // Serenity's PRNG is not cryptographically secure. Do not rely on this for
 // any real crypto! These functions (for now) are for compatibility.
-// TODO: In the future, rand can be made determinstic and this not.
+// TODO: In the future, rand can be made deterministic and this not.
 uint32_t arc4random(void)
 {
     char buf[4];

--- a/Libraries/LibC/string.cpp
+++ b/Libraries/LibC/string.cpp
@@ -342,7 +342,7 @@ const char* const sys_errlist[] = {
     "Connection aborted",
     "Connection already in progress",
     "Connection reset",
-    "Desination address required",
+    "Destination address required",
     "Host unreachable",
     "Illegal byte sequence",
     "Message size",

--- a/Libraries/LibC/sys/ptrace.cpp
+++ b/Libraries/LibC/sys/ptrace.cpp
@@ -36,7 +36,7 @@ int ptrace(int request, pid_t tid, void* addr, int data)
 
     // PT_PEEK needs special handling since the syscall wrapper
     // returns the peeked value as an int, which can be negative because of the cast.
-    // When using PT_PEEK, the user can check if an error occured
+    // When using PT_PEEK, the user can check if an error occurred
     // by looking at errno rather than the return value.
 
     u32 out_data;

--- a/Libraries/LibC/syslog.h
+++ b/Libraries/LibC/syslog.h
@@ -53,7 +53,7 @@ struct syslog_data {
 
 /*
  * Many of these facilities don't really make sense anymore, but we keep them
- * for compatability purposes.
+ * for compatibility purposes.
  */
 #define LOG_KERN     ( 0 << 3)
 #define LOG_USER     ( 1 << 3)

--- a/Libraries/LibC/time.cpp
+++ b/Libraries/LibC/time.cpp
@@ -182,7 +182,7 @@ size_t strftime(char* destination, size_t max_size, const char* format, const st
     };
     const char mon_long_names[12][10] = {
         "January", "February", "March", "April", "May", "June",
-        "July", "Auguest", "September", "October", "November", "December"
+        "July", "August", "September", "October", "November", "December"
     };
 
     StringBuilder builder { max_size };

--- a/Libraries/LibChess/UCIEndpoint.cpp
+++ b/Libraries/LibChess/UCIEndpoint.cpp
@@ -96,7 +96,7 @@ NonnullOwnPtr<Command> Endpoint::read_command()
     String line(ReadonlyBytes(m_in->read_line(4096).bytes()), Chomp);
 
 #ifdef UCI_DEBUG
-    dbg() << class_name() << " Recieved UCI Command: " << line;
+    dbg() << class_name() << " Received UCI Command: " << line;
 #endif
 
     if (line == "uci") {

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -110,7 +110,7 @@ u32 CanonicalCode::read_symbol(InputBitStream& stream) const
     for (;;) {
         code_bits = code_bits << 1 | stream.read_bits(1);
 
-        // FIXME: This seems really inefficent, this could be an index into an array instead.
+        // FIXME: This seems really inefficient, this could be an index into an array instead.
         size_t index;
         if (AK::binary_search(m_symbol_codes.span(), code_bits, AK::integral_compare<u32>, &index))
             return m_symbol_values[index];

--- a/Libraries/LibDebug/DebugInfo.cpp
+++ b/Libraries/LibDebug/DebugInfo.cpp
@@ -80,7 +80,7 @@ void DebugInfo::parse_scopes_impl(const Dwarf::DIE& die)
 
         if (!child.get_attribute(Dwarf::Attribute::LowPc).has_value()) {
 #ifdef DEBUG_SPAM
-            dbg() << "DWARF: Couldn't find attribtue LowPc for scope";
+            dbg() << "DWARF: Couldn't find attribute LowPc for scope";
 #endif
             return;
         }
@@ -165,7 +165,7 @@ NonnullOwnPtrVector<DebugInfo::VariableInfo> DebugInfo::get_variables_in_current
 {
     NonnullOwnPtrVector<DebugInfo::VariableInfo> variables;
 
-    // TODO: We can store the scopes in a better data strucutre
+    // TODO: We can store the scopes in a better data structure
     for (const auto& scope : m_scopes) {
         if (regs.eip < scope.address_low || regs.eip >= scope.address_high)
             continue;
@@ -236,7 +236,7 @@ OwnPtr<DebugInfo::VariableInfo> DebugInfo::create_variable_info(const Dwarf::DIE
 
     if (variable_die.tag() == Dwarf::EntryTag::FormalParameter
         && !variable_die.get_attribute(Dwarf::Attribute::Name).has_value()) {
-        // We don't want to display info for unused paramters
+        // We don't want to display info for unused parameters
         return {};
     }
 

--- a/Libraries/LibDebug/DebugSession.cpp
+++ b/Libraries/LibDebug/DebugSession.cpp
@@ -244,7 +244,7 @@ void* DebugSession::single_step()
 {
     // Single stepping works by setting the x86 TRAP flag bit in the eflags register.
     // This flag causes the cpu to enter single-stepping mode, which causes
-    // Interupt 1 (debug interrupt) to be emitted after every instruction.
+    // Interrupt 1 (debug interrupt) to be emitted after every instruction.
     // To single step the program, we set the TRAP flag and continue the debugee.
     // After the debugee has stopped, we clear the TRAP flag.
 

--- a/Libraries/LibDebug/DebugSession.h
+++ b/Libraries/LibDebug/DebugSession.h
@@ -180,7 +180,7 @@ void DebugSession::run(Callback callback)
         }
 
         if (current_breakpoint.has_value()) {
-            // We want to make the breakpoint transparrent to the user of the debugger.
+            // We want to make the breakpoint transparent to the user of the debugger.
             // To achieive this, we perform two rollbacks:
             // 1. Set regs.eip to point at the actual address of the instruction we breaked on.
             //    regs.eip currently points to one byte after the address of the original instruction,
@@ -212,7 +212,7 @@ void DebugSession::run(Callback callback)
 
         // Re-enable the breakpoint if it wasn't removed by the user
         if (current_breakpoint.has_value() && m_breakpoints.contains(current_breakpoint.value().address)) {
-            // The current breakpoint was removed to make it transparrent to the user.
+            // The current breakpoint was removed to make it transparent to the user.
             // We now want to re-enable it - the code execution flow could hit it again.
             // To re-enable the breakpoint, we first perform a single step and execute the
             // instruction of the breakpoint, and then redo the INT3 patch in its first byte.

--- a/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
+++ b/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
@@ -46,8 +46,8 @@ void AbbreviationsMap::populate_map()
     while (!abbreviation_stream.eof()) {
         size_t abbreviation_code = 0;
         abbreviation_stream.read_LEB128_unsigned(abbreviation_code);
-        // An abbrevation code of 0 marks the end of the
-        // abbrevations for a given compilation unit
+        // An abbreviation code of 0 marks the end of the
+        // abbreviations for a given compilation unit
         if (abbreviation_code == 0)
             break;
 

--- a/Libraries/LibDebug/Dwarf/DIE.cpp
+++ b/Libraries/LibDebug/Dwarf/DIE.cpp
@@ -42,7 +42,7 @@ DIE::DIE(const CompilationUnit& unit, u32 offset)
     m_data_offset = stream.offset();
 
     if (m_abbreviation_code == 0) {
-        // An abbrevation code of 0 ( = null DIE entry) means the end of a chain of sibilings
+        // An abbreviation code of 0 ( = null DIE entry) means the end of a chain of siblings
         m_tag = EntryTag::None;
     } else {
         auto abbreviation_info = m_compilation_unit.abbreviations_map().get(m_abbreviation_code);
@@ -218,7 +218,7 @@ void DIE::for_each_child(Function<void(const DIE& child)> callback) const
         }
 
         if (!sibling.has_value()) {
-            // NOTE: According to the spec, the compiler does't have to supply the sibling information.
+            // NOTE: According to the spec, the compiler doesn't have to supply the sibling information.
             // When it doesn't, we have to recursively iterate the current child's children to find where they end
             current_child->for_each_child([&](const DIE& sub_child) {
                 sibling_offset = sub_child.offset() + sub_child.size();

--- a/Libraries/LibGUI/ColorPicker.cpp
+++ b/Libraries/LibGUI/ColorPicker.cpp
@@ -74,7 +74,7 @@ private:
     ColorField(Color color);
 
     Color m_color;
-    // save hue seperately so full white color doesn't reset it to 0
+    // save hue separately so full white color doesn't reset it to 0
     double m_hue;
 
     RefPtr<Gfx::Bitmap> m_color_bitmap;
@@ -518,7 +518,7 @@ void ColorField::set_color(Color color)
         return;
 
     m_color = color;
-    // don't save m_hue here by default, we dont want to set it to 0 in case color is full white
+    // don't save m_hue here by default, we don't want to set it to 0 in case color is full white
     // m_hue = color.to_hsv().hue;
 
     recalculate_position();

--- a/Libraries/LibGfx/BMPLoader.cpp
+++ b/Libraries/LibGfx/BMPLoader.cpp
@@ -470,7 +470,7 @@ static bool decode_bmp_header(BMPLoadingContext& context)
     // value of the file size.
     streamer.drop_bytes(4);
 
-    // Ingore reserved bytes
+    // Ignore reserved bytes
     streamer.drop_bytes(4);
     context.data_offset = streamer.read_u32();
 

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -114,7 +114,7 @@ CallExpression::ThisAndCallee CallExpression::compute_this_and_callee(Interprete
     }
 
     if (m_callee->is_super_expression()) {
-        // If we are calling super, |this| has not been initalized yet, and would not be meaningful to provide.
+        // If we are calling super, |this| has not been initialized yet, and would not be meaningful to provide.
         auto new_target = interpreter.vm().get_new_target();
         ASSERT(new_target.is_function());
         return { js_undefined(), new_target };

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -1757,7 +1757,7 @@ void Parser::consume_or_insert_semicolon()
         return;
     }
     // Insert semicolon if...
-    // ...token is preceeded by one or more newlines
+    // ...token is preceded by one or more newlines
     if (m_parser_state.m_current_token.trivia().contains('\n'))
         return;
     // ...token is a closing curly brace

--- a/Libraries/LibJS/Tests/builtins/Array/Array.prototype.values.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.prototype.values.js
@@ -33,7 +33,7 @@ test("item added to array before exhaustion is accessible", () => {
     expect(it.next()).toEqual({ value: undefined, done: true });
 });
 
-test("item added to array after exhaustion is inaccesible", () => {
+test("item added to array after exhaustion is inaccessible", () => {
     const a = [1, 2];
     const it = a.values();
     expect(it.next()).toEqual({ value: 1, done: false });

--- a/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
+++ b/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
@@ -3,7 +3,7 @@ describe("correct behavior", () => {
         expect(typeof 1n).toBe("bigint");
     });
 
-    test("bigint string coersion", () => {
+    test("bigint string coercion", () => {
         expect("" + 123n).toBe("123");
     });
 

--- a/Libraries/LibJS/Tests/exponentiation-basic.js
+++ b/Libraries/LibJS/Tests/exponentiation-basic.js
@@ -10,7 +10,7 @@ test("regular exponentiation", () => {
     expect((2 ** 3) ** 2).toBe(64);
 });
 
-test("exponentation with negatives", () => {
+test("exponentiation with negatives", () => {
     expect(2 ** -3).toBe(0.125);
     expect((-2) ** 3).toBe(-8);
 
@@ -18,7 +18,7 @@ test("exponentation with negatives", () => {
     // expect("-2 ** 3").not.toEval();
 });
 
-test("exponentation with non-numeric primitives", () => {
+test("exponentiation with non-numeric primitives", () => {
     expect("2" ** "3").toBe(8);
     expect("" ** []).toBe(1);
     expect([] ** null).toBe(1);
@@ -26,7 +26,7 @@ test("exponentation with non-numeric primitives", () => {
     expect(undefined ** null).toBe(1);
 });
 
-test("exponentation that produces NaN", () => {
+test("exponentiation that produces NaN", () => {
     expect(NaN ** 2).toBeNaN();
     expect(2 ** NaN).toBeNaN();
     expect(undefined ** 2).toBeNaN();

--- a/Libraries/LibJS/Tests/functions/arrow-functions.js
+++ b/Libraries/LibJS/Tests/functions/arrow-functions.js
@@ -110,7 +110,7 @@ test("arrow functions in objects", () => {
     expect(foobar.x.z()).toBe(foobar.x);
 });
 
-test("strict mode propogation", () => {
+test("strict mode propagation", () => {
     (() => {
         "use strict";
         expect(isStrictMode()).toBeTrue();

--- a/Libraries/LibJS/Tests/functions/function-default-parameters.js
+++ b/Libraries/LibJS/Tests/functions/function-default-parameters.js
@@ -106,7 +106,7 @@ test("parameter with a function default value", () => {
     expect(arrowFunc(() => 10)).toBe(10);
 });
 
-test("parameter with an arrow function default vlaue", () => {
+test("parameter with an arrow function default value", () => {
     function func(a = () => 5) {
         return a();
     }

--- a/Libraries/LibJS/Tests/functions/function-strict-mode.js
+++ b/Libraries/LibJS/Tests/functions/function-strict-mode.js
@@ -30,7 +30,7 @@ test("use strict with double quotes after statement does not yield strict mode c
     expect(isStrictMode()).toBeFalse();
 });
 
-test("strict mode propogates down the scope chain", () => {
+test("strict mode propagates down the scope chain", () => {
     "use strict";
     expect(isStrictMode()).toBeTrue();
     (function() {
@@ -38,7 +38,7 @@ test("strict mode propogates down the scope chain", () => {
     })();
 });
 
-test("strict mode does not propogate up the scope chain", () => {
+test("strict mode does not propagate up the scope chain", () => {
     expect(isStrictMode()).toBeFalse();
     (function() {
         "use strict";

--- a/Libraries/LibJS/Tests/iterators/array-iterator.js
+++ b/Libraries/LibJS/Tests/iterators/array-iterator.js
@@ -42,7 +42,7 @@ test("item added to array before exhaustion is accessible", () => {
     expect(it.next()).toEqual({ value: undefined, done: true });
 });
 
-test("item added to array after exhaustion is inaccesible", () => {
+test("item added to array after exhaustion is inaccessible", () => {
     const a = [1, 2];
     const it = a[Symbol.iterator]();
     expect(it.next()).toEqual({ value: 1, done: false });

--- a/Libraries/LibTLS/Socket.cpp
+++ b/Libraries/LibTLS/Socket.cpp
@@ -125,7 +125,7 @@ bool TLSv12::common_connect(const struct sockaddr* saddr, socklen_t length)
                     auto timeout_diff = Core::DateTime::now().timestamp() - m_context.handshake_initiation_timestamp;
                     // If the timeout duration was actually within the max wait time (with a margin of error),
                     // we're not operating slow, so the server timed out.
-                    // otherwise, it's our fault that the negotitation is taking too long, so extend the timer :P
+                    // otherwise, it's our fault that the negotiation is taking too long, so extend the timer :P
                     if (timeout_diff < m_max_wait_time_for_handshake_in_seconds + 1) {
                         // The server did not respond fast enough,
                         // time the connection out.

--- a/Libraries/LibUnwind/UnwindBase.h
+++ b/Libraries/LibUnwind/UnwindBase.h
@@ -28,7 +28,7 @@
 
 #include <stdint.h>
 
-// The following defintions and comments are largely pulled from the Itanium Exception handling ABI
+// The following definitions and comments are largely pulled from the Itanium Exception handling ABI
 // Reference: https://itanium-cxx-abi.github.io/cxx-abi/abi-eh.htm, version 1.22
 // This header defines the methods, types, and constants outlined in Level I. Base ABI
 // Also, from the Intel386 psABI version 1.1

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -93,9 +93,9 @@ void Terminal::alter_mode(bool should_set, bool question_param, const ParamVecto
             // Hide cursor command, but doesn't need to be run (for now, because
             // we don't do inverse control codes anyways)
             if (should_set)
-                dbgprintf("Terminal: Hide Cursor escapecode recieved. Not needed: ignored.\n");
+                dbgprintf("Terminal: Hide Cursor escapecode received. Not needed: ignored.\n");
             else
-                dbgprintf("Terminal: Show Cursor escapecode recieved. Not needed: ignored.\n");
+                dbgprintf("Terminal: Show Cursor escapecode received. Not needed: ignored.\n");
             break;
         default:
             break;


### PR DESCRIPTION
Mostly in comments, but sprintf() now prints "August" instead of
"Auguest" so that's something.