### PR TITLE
LibC: Remove unnecessary fallthrough comments.

### DIFF
--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -452,7 +452,6 @@ double strtod(const char* str, char** endptr)
                 digits_usable = true;
                 break;
             case DigitConsumeDecision::PosOverflow:
-                // fallthrough
             case DigitConsumeDecision::NegOverflow:
                 is_a_digit = true;
                 digits_overflow = true;
@@ -509,7 +508,6 @@ double strtod(const char* str, char** endptr)
                     exponent_usable = true;
                     break;
                 case DigitConsumeDecision::PosOverflow:
-                    // fallthrough
                 case DigitConsumeDecision::NegOverflow:
                     is_a_digit = true;
                     exponent_overflow = true;
@@ -901,7 +899,7 @@ long long strtoll(const char* str, char** endptr, int base)
                 // The very first actual digit must pass here:
                 digits_usable = true;
                 break;
-            case DigitConsumeDecision::PosOverflow: // fall-through
+            case DigitConsumeDecision::PosOverflow:
             case DigitConsumeDecision::NegOverflow:
                 is_a_digit = true;
                 overflow = true;
@@ -977,7 +975,7 @@ unsigned long long strtoull(const char* str, char** endptr, int base)
                 // The very first actual digit must pass here:
                 digits_usable = true;
                 break;
-            case DigitConsumeDecision::PosOverflow: // fall-through
+            case DigitConsumeDecision::PosOverflow:
             case DigitConsumeDecision::NegOverflow:
                 is_a_digit = true;
                 overflow = true;


### PR DESCRIPTION
A "fallthrough comment" or `[[fallthrough]]` is only required after non-empty `case`s.

------------------------------

Neither `gcc` nor `clang` will report an `implicit-fallthrough` warning for these lines even if we remove these "fallthrough comments".

 There are already at least 840 instances of us not using a "fallthrough comment" or `[[fallthrough]]` in these situations:
```bash
$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
$ rg -UP $'case .*:\n(?=\\s*case)' | wc -l
842
```
NOTE: 2 of these matches are in `js` files.