### PR TITLE
Add run.sh, to make it easy to run SerenityOS for the first time

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Script to make it easy to build and run Serenity OS for the first time.
+# Old friends already know what to do.
+#
+set -e
+cd Toolchain
+./BuildIt.sh
+cd ../Build
+cmake -GNinja ..
+ninja
+ninja install
+ninja image
+ninja run


### PR DESCRIPTION
Hi,

Some users might just want to give SerenityOS a spin, without being a developer. And some developers might want an easier and more streamlined way to check out the `master` branch and run the OS on a new computer.

This PR just adds a tiny little `run.sh` script in the root folder, that builds and runs SerenityOS in QEMU.

Dependencies still needs to be installed manually, but I believe this lowers the threshold for new users.

(I was not sure if I should submit this, since it's such a small thing, but I found it useful. I will fully understand if it's rejected).

Best regards!