### PR TITLE
AK: Add missing Bytes::slice call in Buffered<T>.

### DIFF
--- a/AK/Buffered.h
+++ b/AK/Buffered.h
@@ -159,7 +159,7 @@ public:
             flush();
 
             if (bytes.size() - nwritten >= Size)
-                nwritten += m_stream.write_or_error(bytes);
+                nwritten += m_stream.write_or_error(bytes.slice(nwritten));
 
             nwritten += write(bytes.slice(nwritten));
         }


### PR DESCRIPTION
This fixes a bug in `Buffered`, but this isn't enough to completely cover #3666.

The following still saves the font incorrectly and I can't figure out why:

~~~none
cp /res/fonts/Katica10.font .
FontEditor Katica10.font
# Press "Save" and close the window.
FontEditor Katica10.font
# The glyph width is loaded incorrectly. (This is very noticeable because the window no longer fits the screen.)
~~~

---

I'll come back to find this god damn bug, but I am starting to get frustrated. It's probably best to do something else for now.
