### PR TITLE
AK+Buffered: Call write instead of write_or_error.

### DIFF
--- a/AK/Buffered.h
+++ b/AK/Buffered.h
@@ -178,7 +178,7 @@ public:
             flush();
 
             if (bytes.size() - nwritten >= Size)
-                nwritten += m_stream.write_or_error(bytes.slice(nwritten));
+                nwritten += m_stream.write(bytes.slice(nwritten));
 
             nwritten += write(bytes.slice(nwritten));
         }

--- a/AK/Result.h
+++ b/AK/Result.h
@@ -39,9 +39,16 @@ public:
         : m_result(res)
     {
     }
-
+    Result(ValueType && res)
+        : m_result(move(res))
+    {
+    }
     Result(const ErrorType& error)
         : m_error(error)
+    {
+    }
+    Result(ErrorType && error)
+        : m_error(move(error))
     {
     }
 


### PR DESCRIPTION
Fixes #3666.

This pull request makes `Buffered` non-copyable, this did not cause any issues as far as I know but it shouldn't be copyable anyways.

The actual fix is the following:

~~~diff
diff --git a/AK/Buffered.h b/AK/Buffered.h
index 3c62862ef..d4a98cd15 100644
--- a/AK/Buffered.h
+++ b/AK/Buffered.h
@@ -182,7 +182,7 @@ public:
             flush();
 
             if (bytes.size() - nwritten >= Size)
-                nwritten += m_stream.write_or_error(bytes.slice(nwritten));
+                nwritten += m_stream.write(bytes.slice(nwritten));
 
             nwritten += write(bytes.slice(nwritten));
         }
~~~

Notice that `write_or_error` returns a `bool` which is converted into `size_t`.

---

Thanks @xTibor for pointing this out. https://github.com/SerenityOS/serenity/issues/3666#issuecomment-703130854
