### PR TITLE
AK: Make the return type of dbgputstr consistent.

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -585,7 +585,7 @@ void vwarn(StringView fmtstr, TypeErasedFormatParams params, bool newline)
 void raw_dbg(StringView string)
 {
     const auto retval = dbgputstr(string.characters_without_null_termination(), string.length());
-    ASSERT(static_cast<size_t>(retval) == string.length());
+    ASSERT(retval == 0);
 }
 void vdbg(StringView fmtstr, TypeErasedFormatParams params, bool newline)
 {

--- a/AK/kstdio.h
+++ b/AK/kstdio.h
@@ -35,7 +35,7 @@
 extern "C" {
 int vdbgprintf(const char* fmt, va_list);
 int dbgprintf(const char* fmt, ...);
-ssize_t dbgputstr(const char*, ssize_t);
+int dbgputstr(const char*, ssize_t);
 int sprintf(char* buf, const char* fmt, ...);
 int snprintf(char* buffer, size_t, const char* fmt, ...);
 }
@@ -44,9 +44,10 @@ int snprintf(char* buffer, size_t, const char* fmt, ...);
 #    include <stdio.h>
 #    define kprintf printf
 #    define dbgprintf(...) fprintf(stderr, __VA_ARGS__)
-inline size_t dbgputstr(const char* characters, ssize_t length)
+inline int dbgputstr(const char* characters, ssize_t length)
 {
-    return fwrite(characters, 1, length, stderr);
+    fwrite(characters, 1, length, stderr);
+    return 0;
 }
 #endif
 template<size_t N>

--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -193,6 +193,8 @@ int main(int argc, char** argv)
 
         new_tab.load(url);
 
+        dbgln("Added new tab {:p}, loading {}", &new_tab, url);
+
         if (activate)
             tab_widget.set_active_widget(&new_tab);
     };

--- a/Libraries/LibC/stdio.cpp
+++ b/Libraries/LibC/stdio.cpp
@@ -1044,7 +1044,7 @@ void dbgputch(char ch)
     syscall(SC_dbgputch, ch);
 }
 
-ssize_t dbgputstr(const char* characters, ssize_t length)
+int dbgputstr(const char* characters, ssize_t length)
 {
     int rc = syscall(SC_dbgputstr, characters, length);
     __RETURN_WITH_ERRNO(rc, rc, -1);

--- a/Libraries/LibC/stdio.h
+++ b/Libraries/LibC/stdio.h
@@ -93,7 +93,7 @@ int fprintf(FILE*, const char* fmt, ...);
 int printf(const char* fmt, ...);
 int dbgprintf(const char* fmt, ...);
 void dbgputch(char);
-ssize_t dbgputstr(const char*, ssize_t);
+int dbgputstr(const char*, ssize_t);
 int sprintf(char* buffer, const char* fmt, ...);
 int snprintf(char* buffer, size_t, const char* fmt, ...);
 int putchar(int ch);


### PR DESCRIPTION
The cause of the crash described in the commit message of 4cf3a1eb41dc74dc97b48e60aa579f9c9135c802 was that `dbgputstr` was behaving inconsistent.

It returned values of type `size_t`, `ssize_t` or `int` depending on which declaration one looked at. It returned zero in some implementations or the number of bytes written in others.

With this pull request, `dbgputstr` simply returns zero to indicate success. Checking the return value of `dbgputstr` is a bit superstitious anyways.
