### PR TITLE
LibGUI: Clear selection if right-clicking item that isn't selected

### DIFF
--- a/Libraries/LibGUI/AbstractView.cpp
+++ b/Libraries/LibGUI/AbstractView.cpp
@@ -224,7 +224,9 @@ void AbstractView::mousedown_event(MouseEvent& event)
     } else if (event.button() == MouseButton::Left && m_selection.contains(index) && !m_model->drag_data_type().is_null()) {
         // We might be starting a drag, so don't throw away other selected items yet.
         m_might_drag = true;
-    } else if (event.button() != MouseButton::Right) {
+    } else if (event.button() == MouseButton::Right) {
+        set_cursor(index, SelectionUpdate::ClearIfNotSelected);
+    } else {
         set_cursor(index, SelectionUpdate::Set);
     }
 
@@ -427,6 +429,10 @@ void AbstractView::set_cursor(ModelIndex index, SelectionUpdate selection_update
             set_selection(index);
         else if (selection_update == SelectionUpdate::Ctrl)
             toggle_selection(index);
+        else if (selection_update == SelectionUpdate::ClearIfNotSelected) {
+            if (!m_selection.contains(index))
+                clear_selection();
+        }
 
         // FIXME: Support the other SelectionUpdate types
 

--- a/Libraries/LibGUI/AbstractView.h
+++ b/Libraries/LibGUI/AbstractView.h
@@ -52,6 +52,7 @@ public:
         Set,
         Shift,
         Ctrl,
+        ClearIfNotSelected
     };
 
     virtual void move_cursor(CursorMovement, SelectionUpdate) { }


### PR DESCRIPTION
If we're right-clicking on an item that isn't currently selected, clear
the selection first.

Fixes #3665