### PR TITLE
LibGemini: Fix crash on Link lines without explicit link text

### DIFF
--- a/Libraries/LibGemini/Document.h
+++ b/Libraries/LibGemini/Document.h
@@ -89,7 +89,7 @@ public:
 
 private:
     URL m_url;
-    StringView m_name;
+    String m_name;
 };
 
 class Preformatted : public Line {

--- a/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -38,6 +38,8 @@
 #include <LibWeb/Page/Frame.h>
 #include <LibWeb/Page/Page.h>
 
+//#define GEMINI_DEBUG 1
+
 namespace Web {
 
 FrameLoader::FrameLoader(Frame& frame)
@@ -115,9 +117,16 @@ static RefPtr<DOM::Document> create_image_document(const ByteBuffer& data, const
 
 static RefPtr<DOM::Document> create_gemini_document(const ByteBuffer& data, const URL& url)
 {
-    auto gemini_document = Gemini::Document::parse({ (const char*)data.data(), data.size() }, url);
+    StringView gemini_data { data };
+    auto gemini_document = Gemini::Document::parse(gemini_data, url);
+    String html_data = gemini_document->render_to_html();
 
-    return HTML::parse_html_document(gemini_document->render_to_html(), url, "utf-8");
+#if GEMINI_DEBUG
+    dbgln("Gemini data:\n\"\"\"{}\"\"\"", gemini_data);
+    dbgln("Converted to HTML:\n\"\"\"{}\"\"\"", html_data);
+#endif
+
+    return HTML::parse_html_document(move(html_data), url, "utf-8");
 }
 
 RefPtr<DOM::Document> FrameLoader::create_document_from_mime_type(const ByteBuffer& data, const URL& url, const String& mime_type, const String& encoding)

--- a/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -115,9 +115,9 @@ static RefPtr<DOM::Document> create_image_document(const ByteBuffer& data, const
 
 static RefPtr<DOM::Document> create_gemini_document(const ByteBuffer& data, const URL& url)
 {
-    auto markdown_document = Gemini::Document::parse({ (const char*)data.data(), data.size() }, url);
+    auto gemini_document = Gemini::Document::parse({ (const char*)data.data(), data.size() }, url);
 
-    return HTML::parse_html_document(markdown_document->render_to_html(), url, "utf-8");
+    return HTML::parse_html_document(gemini_document->render_to_html(), url, "utf-8");
 }
 
 RefPtr<DOM::Document> FrameLoader::create_document_from_mime_type(const ByteBuffer& data, const URL& url, const String& mime_type, const String& encoding)


### PR DESCRIPTION
Link::Link() does:

    if (m_name.is_null())
        m_name = m_url.to_string();

This tries to set the link text to the link url if there's no
explicit link text, but m_url.to_string() returns a temporary
string object, and m_name was a StringView, so this ended
pointing to invalid memory. This made the converted HTML
contain garbage data as link text, which made LibWeb crash.

(LibWeb probably shouldn't crash on links with garbage link
text, but in this case it helped identify a bug, so let's keep
that crash around since real web pages won't trigger it and
it's kind of useful to find bugs like this one.)

Makes gemini://rawtext.club/ no longer crash Browser.