### PR TITLE
LibGemini: Improve rendering of <pre> blocks

### DIFF
--- a/Libraries/LibGemini/Document.cpp
+++ b/Libraries/LibGemini/Document.cpp
@@ -74,6 +74,7 @@ void Document::read_lines(const StringView& source)
             } else {
                 m_lines.append(make<Control>(Control::PreformattedEnd));
             }
+            continue;
         }
 
         if (m_inside_preformatted_block) {

--- a/Libraries/LibGemini/Line.cpp
+++ b/Libraries/LibGemini/Line.cpp
@@ -127,7 +127,7 @@ String Link::render_to_html() const
 String Preformatted::render_to_html() const
 {
     StringBuilder builder;
-    builder.append(escape_html_entities(m_text.substring_view(3, m_text.length() - 3)));
+    builder.append(escape_html_entities(m_text));
     builder.append("\n");
 
     return builder.build();


### PR DESCRIPTION
For

    ```foo
    asdf
    jkl;
    ```bar

we would previously generate

    <pre>foo
    f
    ;
    </pre>
    ```bar

Now we generate

    <pre>
    asdf
    jkl;
    </pre>

* no longer cut off the first 3 characters on most lines.
* don't include the closing ``` line in the output. in addition to
  omitting the '```', this also honors "Any text following the leading
  "```" of a preformat toggle line which toggles preformatted mode off
  MUST be ignored by clients." from the spec
* ignore the alt text after the toggle-on text. the spec leaves it to
  the client what to do with that alt text, but it tends to be metadata,
  and omitting it is simplest for the implementation, so do that.

Improves ascii art on many gemini pages, e.g. gemini://carcosa.net/

@alimpfard 