### PR TITLE
Formatter: Remove extraneous char definition

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -640,7 +640,6 @@ template struct Formatter<unsigned short, void>;
 template struct Formatter<unsigned int, void>;
 template struct Formatter<unsigned long, void>;
 template struct Formatter<unsigned long long, void>;
-template struct Formatter<char, void>;
 template struct Formatter<short, void>;
 template struct Formatter<int, void>;
 template struct Formatter<long, void>;


### PR DESCRIPTION
Formatter is specialized in the header file. The definition in the
implementation file is extraneous and has no effect. Simply removing
it so that there is no confusion.