### PR TITLE
SinglyLinkedList: Remove unused includes

### DIFF
--- a/Applications/PixelPaint/BucketTool.cpp
+++ b/Applications/PixelPaint/BucketTool.cpp
@@ -28,7 +28,6 @@
 #include "ImageEditor.h"
 #include "Layer.h"
 #include <AK/Queue.h>
-#include <AK/SinglyLinkedList.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Rect.h>

--- a/Applications/PixelPaint/SprayTool.cpp
+++ b/Applications/PixelPaint/SprayTool.cpp
@@ -28,7 +28,6 @@
 #include "ImageEditor.h"
 #include "Layer.h"
 #include <AK/Queue.h>
-#include <AK/SinglyLinkedList.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>

--- a/Kernel/Net/IPv4SocketTuple.h
+++ b/Kernel/Net/IPv4SocketTuple.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <AK/HashMap.h>
-#include <AK/SinglyLinkedList.h>
 #include <Kernel/DoubleBuffer.h>
 #include <Kernel/KBuffer.h>
 #include <Kernel/Lock.h>

--- a/Kernel/WaitQueue.h
+++ b/Kernel/WaitQueue.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <AK/Atomic.h>
-#include <AK/SinglyLinkedList.h>
 #include <Kernel/SpinLock.h>
 #include <Kernel/Thread.h>
 


### PR DESCRIPTION
Several files include `AK/SinglyLinkedList.h` without using
it. Removing it to simplify.