### PR TITLE
Kernel: Add some CPU feature flags related to TSC

### DIFF
--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -606,15 +606,18 @@ enum class CPUFeature : u32 {
     SMEP = (1 << 6),
     SSE = (1 << 7),
     TSC = (1 << 8),
-    UMIP = (1 << 9),
-    SEP = (1 << 10),
-    SYSCALL = (1 << 11),
-    MMX = (1 << 12),
-    SSE2 = (1 << 13),
-    SSE3 = (1 << 14),
-    SSSE3 = (1 << 15),
-    SSE4_1 = (1 << 16),
-    SSE4_2 = (1 << 17)
+    RDTSCP = (1 << 9),
+    CONSTANT_TSC = (1 << 10),
+    NONSTOP_TSC = (1 << 11),
+    UMIP = (1 << 12),
+    SEP = (1 << 13),
+    SYSCALL = (1 << 14),
+    MMX = (1 << 15),
+    SSE2 = (1 << 16),
+    SSE3 = (1 << 17),
+    SSSE3 = (1 << 18),
+    SSE4_1 = (1 << 19),
+    SSE4_2 = (1 << 20),
 };
 
 class Thread;

--- a/Services/DHCPClient/DHCPv4Client.h
+++ b/Services/DHCPClient/DHCPv4Client.h
@@ -32,7 +32,6 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/UDPServer.h>
-#include <LibCore/UDPSocket.h>
 #include <net/if.h>
 #include <net/route.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
In case we want to rely more on TSC in time keeping in the future, idk

This adds:

- RDTSCP, for when the RDTSCP instruction is available

- CONSTANT_TSC, for when the TSC has a constant frequency, invariant
  under things like the CPU boosting its frequency.

- NONSTOP_TSC, for when the TSC doesn't pause when the CPU enters
  sleep states.

AMD cpus and newer intel cpus set the INVSTC bit (bit 8 in edx of
extended cpuid 0x8000000008), which implies both CONSTANT_TSC and
NONSTOP_TSC. Some older intel processors have CONSTANT_TSC but not
NONSTOP_TSC; this is set based on cpu model checks.

There isn't a ton of documentation on this, so this follows Linux
terminology and http://blog.tinola.com/?e=54

CONSTANT_TSC:
https://github.com/torvalds/linux/commit/39b3a7910556005a7a0d042ecb7ff98bfa84ea57

NONSTOP_TSC:
https://github.com/torvalds/linux/commit/40fb17152c50a69dc304dd632131c2f41281ce44

qemu disables invtsc (bit 8 in edx of extended cpuid 0x8000000008)
by default even if the host cpu supports it. It can be enabled by
running with `SERENITY_QEMU_CPU=host,migratable=off` set.

--

Also sneak in an unused include removal commit.