### PR TITLE
LibJS: Fix PropertyName::from_value() for negative and non-int numbers

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1549,8 +1549,6 @@ Value ObjectExpression::execute(Interpreter& interpreter, GlobalObject& global_o
             continue;
         }
 
-        if (interpreter.exception())
-            return {};
         auto value = property.value().execute(interpreter, global_object);
         if (interpreter.exception())
             return {};
@@ -1595,22 +1593,11 @@ PropertyName MemberExpression::computed_property_name(Interpreter& interpreter, 
         ASSERT(m_property->is_identifier());
         return static_cast<const Identifier&>(*m_property).string();
     }
-    auto index = m_property->execute(interpreter, global_object);
+    auto value = m_property->execute(interpreter, global_object);
     if (interpreter.exception())
         return {};
-
-    ASSERT(!index.is_empty());
-
-    if (index.is_integer() && index.as_i32() >= 0)
-        return index.as_i32();
-
-    if (index.is_symbol())
-        return &index.as_symbol();
-
-    auto index_string = index.to_string(global_object);
-    if (interpreter.exception())
-        return {};
-    return index_string;
+    ASSERT(!value.is_empty());
+    return PropertyName::from_value(global_object, value);
 }
 
 String MemberExpression::to_string_approximation() const

--- a/Libraries/LibJS/Runtime/PropertyName.h
+++ b/Libraries/LibJS/Runtime/PropertyName.h
@@ -42,13 +42,13 @@ public:
 
     static PropertyName from_value(GlobalObject& global_object, Value value)
     {
+        if (value.is_empty())
+            return {};
         if (value.is_symbol())
             return &value.as_symbol();
-        if (value.is_number())
+        if (value.is_integer() && value.as_i32() >= 0)
             return value.as_i32();
-        if (!value.is_empty())
-            return value.to_string(global_object);
-        return {};
+        return value.to_string(global_object);
     }
 
     PropertyName() { }

--- a/Libraries/LibJS/Tests/object-expression-computed-property.js
+++ b/Libraries/LibJS/Tests/object-expression-computed-property.js
@@ -1,0 +1,12 @@
+test("Issue #3712, negative/non-int computed property in object expression", () => {
+    const o = {
+        [1.23]: "foo",
+        [-1]: "foo",
+        [NaN]: "foo",
+        [Infinity]: "foo",
+    };
+    expect(o[1.23]).toBe("foo");
+    expect(o[-1]).toBe("foo");
+    expect(o[NaN]).toBe("foo");
+    expect(o[Infinity]).toBe("foo");
+});


### PR DESCRIPTION
It was converting *any* number to an i32 index, which obviously is not correct for negative ints, doubles, infinity and nan.

Fixes #3712.