### PR TITLE
TCP: Remove unnecessarily defined constructor and destructor

### DIFF
--- a/Kernel/Net/TCP.h
+++ b/Kernel/Net/TCP.h
@@ -44,8 +44,8 @@ struct TCPFlags {
 class [[gnu::packed]] TCPPacket
 {
 public:
-    TCPPacket() { }
-    ~TCPPacket() { }
+    TCPPacket() = default;
+    ~TCPPacket() = default;
 
     size_t header_size() const { return data_offset() * sizeof(u32); }
 


### PR DESCRIPTION
Problem: Defining the destructor violates the "rule of 0" and prevents
the copy/move constructor/assignment operators from being provided by
the compiler.

Solution: Change the constructor and destructor to be the default
compiler-provided definition.