### PR TITLE
LibJS: Disallow 'continue' & 'break' outside of their respective scopes

### DIFF
--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -159,6 +159,8 @@ private:
         bool m_allow_super_property_lookup { false };
         bool m_allow_super_constructor_call { false };
         bool m_in_function_context { false };
+        bool m_in_break_context { false };
+        bool m_in_continue_context { false };
 
         explicit ParserState(Lexer);
     };

--- a/Libraries/LibJS/Tests/break-continue-syntax-errors.js
+++ b/Libraries/LibJS/Tests/break-continue-syntax-errors.js
@@ -1,0 +1,18 @@
+test("'break' syntax errors", () => {
+    expect("break").not.toEval();
+    expect("break label").not.toEval();
+    expect("{ break }").not.toEval();
+    // FIXME: Parser does not throw error on nonexistent label
+    // expect("{ break label }.not.toEval();
+    expect("label: { break label }").toEval();
+});
+
+test("'continue' syntax errors", () => {
+    expect("continue").not.toEval();
+    expect("continue label").not.toEval();
+    expect("{ continue }").not.toEval();
+    expect("{ continue label }").not.toEval();
+    expect("label: { continue label }").not.toEval();
+
+    expect("switch (true) { case true: continue; }").not.toEval();
+});


### PR DESCRIPTION
`continue` is no longer allowed outside of a loop, and an unlabeled `break` is not longer allowed outside of a loop or switch statement. Labeled `break` statements are still allowed everywhere, even if the label does not exist (which will be fixed in a PR after this one is merged since it conflicts).

Fixes #3608