### PR TITLE
Add __portable_abort() with well defined signature.

### DIFF
--- a/AK/Platform.cpp
+++ b/AK/Platform.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, the SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,65 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include <AK/Platform.h>
+#include <stdlib.h>
 
-#ifdef __i386__
-#    define AK_ARCH_I386 1
-#endif
-
-#ifdef __x86_64__
-#    define AK_ARCH_X86_64 1
-#endif
-
-#define ARCH(arch) (defined(AK_ARCH_##arch) && AK_ARCH_##arch)
-
-#ifdef ALWAYS_INLINE
-#    undef ALWAYS_INLINE
-#endif
-#define ALWAYS_INLINE [[gnu::always_inline]] inline
-
-#ifdef NEVER_INLINE
-#    undef NEVER_INLINE
-#endif
-#define NEVER_INLINE [[gnu::noinline]]
-
-#ifdef FLATTEN
-#    undef FLATTEN
-#endif
-#define FLATTEN [[gnu::flatten]]
-
-#ifndef __serenity__
-#    define PAGE_SIZE sysconf(_SC_PAGESIZE)
-
-#    include <errno.h>
-#    include <fcntl.h>
-#    include <stdlib.h>
-#    include <string.h>
-inline int open_with_path_length(const char* path, size_t path_length, int options, mode_t mode)
-{
-    auto* tmp = (char*)malloc(path_length + 1);
-    memcpy(tmp, path, path_length);
-    tmp[path_length] = '\0';
-    int fd = open(tmp, options, mode);
-    int saved_errno = errno;
-    free(tmp);
-    errno = saved_errno;
-    return fd;
-}
-#endif
-
-ALWAYS_INLINE int count_trailing_zeroes_32(unsigned int val)
-{
-#if defined(__GNUC__) || defined(__clang__)
-    return __builtin_ctz(val);
-#else
-    for (u8 i = 0; i < 32; ++i) {
-        if ((val >> i) & 1) {
-            return i;
-        }
-    }
-    return 0;
-#endif
-}
-
-[[noreturn]] void __portable_abort();
+void __portable_abort() { abort(); }

--- a/AK/TestSuite.h
+++ b/AK/TestSuite.h
@@ -28,7 +28,7 @@
 
 #define AK_TEST_SUITE
 
-extern "C" __attribute__((noreturn)) void abort() noexcept;
+[[noreturn]] void __portable_abort();
 
 namespace AK {
 
@@ -54,13 +54,13 @@ using AK::warnln;
 #define ASSERT_NOT_REACHED()                                                                           \
     do {                                                                                               \
         ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: ASSERT_NOT_REACHED() called", __FILE__, __LINE__); \
-        ::abort();                                                                                     \
+        ::__portable_abort();                                                                          \
     } while (false)
 
 #define TODO()                                                                                   \
     do {                                                                                         \
         ::AK::warnln(stderr, "\033[31;1mFAIL\033[0m: {}:{}: TODO() called", __FILE__, __LINE__); \
-        ::abort();                                                                               \
+        ::__portable_abort();                                                                    \
     } while (false)
 
 #include <AK/Format.h>

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -1999,12 +1999,9 @@ void Processor::set_thread_specific(u8* data, size_t len)
 
 }
 
-#ifdef DEBUG
-void __assertion_failed(const char* msg, const char* file, unsigned line, const char* func)
+void __portable_abort()
 {
     asm volatile("cli");
-    klog() << "ASSERTION FAILED: " << msg << "\n"
-           << file << ":" << line << " in " << func;
 
     // Switch back to the current process's page tables if there are any.
     // Otherwise stack walking will be a disaster.
@@ -2016,6 +2013,15 @@ void __assertion_failed(const char* msg, const char* file, unsigned line, const 
     asm volatile("hlt");
     for (;;)
         ;
+}
+
+#ifdef DEBUG
+void __assertion_failed(const char* msg, const char* file, unsigned line, const char* func)
+{
+    asm volatile("cli");
+    klog() << "ASSERTION FAILED: " << msg << "\n" << file << ":" << line << " in " << func;
+
+    __portable_abort();
 }
 #endif
 


### PR DESCRIPTION
The signatures of `::abort` and `std::abort` are inconsistent among standard library implementations.

https://github.com/SerenityOS/serenity/commit/1d96d5eea44ea4813d947cca9bd84cf10733d927#r43069456

In some standard library implementations `::abort` is marked with `noexcept`, in others it is not. Similarly, the signature of `std::abort` sometimes is marked with `extern "C"` and sometimes not, this is how stdlibc++ does it:

~~~c++
extern "C" void abort(void) throw() __attribute((noreturn));

namespace std {
     // Implicitly inherits C linkage.
     using ::abort;
}
~~~

I am not 100% sure about the libstdc++ stuff because it's difficult to follow the include paths of these GNU-ish headers, but it's really weird for sure.

---

@sv-ochis Can you verify that this builds on MacOS?
