### PR TITLE
LibJS: break or continue with nonexistent label is a syntax error

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -187,6 +187,11 @@ private:
     size_t m_length { 0 };
 };
 
+template<>
+struct Traits<StringView> : public GenericTraits<String> {
+    static unsigned hash(const StringView& s) { return s.hash(); }
+};
+
 }
 
 using AK::StringView;

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/HashTable.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/StringBuilder.h>
 #include <LibJS/AST.h>
@@ -155,6 +156,7 @@ private:
         Vector<NonnullRefPtrVector<VariableDeclaration>> m_let_scopes;
         Vector<NonnullRefPtrVector<FunctionDeclaration>> m_function_scopes;
         UseStrictDirectiveState m_use_strict_directive { UseStrictDirectiveState::None };
+        HashTable<StringView> m_labels_in_scope;
         bool m_strict_mode { false };
         bool m_allow_super_property_lookup { false };
         bool m_allow_super_constructor_call { false };

--- a/Libraries/LibJS/Tests/break-continue-syntax-errors.js
+++ b/Libraries/LibJS/Tests/break-continue-syntax-errors.js
@@ -2,8 +2,7 @@ test("'break' syntax errors", () => {
     expect("break").not.toEval();
     expect("break label").not.toEval();
     expect("{ break }").not.toEval();
-    // FIXME: Parser does not throw error on nonexistent label
-    // expect("{ break label }.not.toEval();
+    expect("{ break label }").not.toEval();
     expect("label: { break label }").toEval();
 });
 

--- a/Libraries/LibJS/Tests/labels.js
+++ b/Libraries/LibJS/Tests/labels.js
@@ -37,3 +37,11 @@ test("labeled for loop with continue", () => {
     }
     expect(counter).toBe(6);
 });
+
+test("invalid label across scope", () => {
+    expect(`
+        label: {
+            (() => { break label; });
+        }
+    `).not.toEval();
+});


### PR DESCRIPTION
Fixes #3714.