### PR TITLE
LibGUI: Make arrow-left/right with selection move cursor to edge of selection

### DIFF
--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -794,6 +794,15 @@ void TextEditor::keydown_event(KeyEvent& event)
         return;
     }
     if (event.key() == KeyCode::Key_Left) {
+        if (!event.shift() && m_selection.is_valid()) {
+            set_cursor(m_selection.normalized().start());
+            m_selection.clear();
+            did_update_selection();
+            if (!event.ctrl()) {
+                update();
+                return;
+            }
+        }
         if (event.ctrl()) {
             TextPosition new_cursor;
             if (document().has_spans()) {
@@ -836,6 +845,15 @@ void TextEditor::keydown_event(KeyEvent& event)
         return;
     }
     if (event.key() == KeyCode::Key_Right) {
+        if (!event.shift() && m_selection.is_valid()) {
+            set_cursor(m_selection.normalized().end());
+            m_selection.clear();
+            did_update_selection();
+            if (!event.ctrl()) {
+                update();
+                return;
+            }
+        }
         if (event.ctrl()) {
             TextPosition new_cursor;
             if (document().has_spans()) {


### PR DESCRIPTION
This matches behavior on Linux, macOS, Windows, and it makes it possible
to hit ctrl-L arrow-right ctrl-backspace to edit the last component of
an URL in browser, or of the current path in File Manager.

Also make it so that ctrl-left/right does a word movement that starts
at the edge of the selection. This matches Linux and macOS, but not
Windows (which instead does a word movement relative to the cursor,
not the selection edge).