### PR TITLE
LibJS: Fix return statements not working properly in loops

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -269,7 +269,7 @@ Value WhileStatement::execute(Interpreter& interpreter, GlobalObject& global_obj
                 interpreter.vm().stop_unwind();
                 break;
             } else {
-                return js_undefined();
+                return last_value;
             }
         }
     }
@@ -293,7 +293,7 @@ Value DoWhileStatement::execute(Interpreter& interpreter, GlobalObject& global_o
                 interpreter.vm().stop_unwind();
                 break;
             } else {
-                return js_undefined();
+                return last_value;
             }
         }
     } while (m_test->execute(interpreter, global_object).to_boolean());
@@ -343,7 +343,7 @@ Value ForStatement::execute(Interpreter& interpreter, GlobalObject& global_objec
                     interpreter.vm().stop_unwind();
                     break;
                 } else {
-                    return js_undefined();
+                    return last_value;
                 }
             }
             if (m_update) {
@@ -364,7 +364,7 @@ Value ForStatement::execute(Interpreter& interpreter, GlobalObject& global_objec
                     interpreter.vm().stop_unwind();
                     break;
                 } else {
-                    return js_undefined();
+                    return last_value;
                 }
             }
             if (m_update) {
@@ -431,7 +431,7 @@ Value ForInStatement::execute(Interpreter& interpreter, GlobalObject& global_obj
                     interpreter.vm().stop_unwind();
                     break;
                 } else {
-                    return js_undefined();
+                    return last_value;
                 }
             }
         }
@@ -480,8 +480,6 @@ Value ForOfStatement::execute(Interpreter& interpreter, GlobalObject& global_obj
     if (interpreter.exception())
         return {};
 
-    if (interpreter.vm().should_unwind())
-        return js_undefined();
     return last_value;
 }
 

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -262,6 +262,16 @@ Value WhileStatement::execute(Interpreter& interpreter, GlobalObject& global_obj
         last_value = interpreter.execute_statement(global_object, *m_body);
         if (interpreter.exception())
             return {};
+        if (interpreter.vm().should_unwind()) {
+            if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_label)) {
+                interpreter.vm().stop_unwind();
+            } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_label)) {
+                interpreter.vm().stop_unwind();
+                break;
+            } else {
+                return js_undefined();
+            }
+        }
     }
 
     return last_value;
@@ -276,6 +286,16 @@ Value DoWhileStatement::execute(Interpreter& interpreter, GlobalObject& global_o
         last_value = interpreter.execute_statement(global_object, *m_body);
         if (interpreter.exception())
             return {};
+        if (interpreter.vm().should_unwind()) {
+            if (interpreter.vm().should_unwind_until(ScopeType::Continuable, m_label)) {
+                interpreter.vm().stop_unwind();
+            } else if (interpreter.vm().should_unwind_until(ScopeType::Breakable, m_label)) {
+                interpreter.vm().stop_unwind();
+                break;
+            } else {
+                return js_undefined();
+            }
+        }
     } while (m_test->execute(interpreter, global_object).to_boolean());
 
     return last_value;

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -167,7 +167,7 @@ public:
         m_unwind_until_label = label;
     }
     void stop_unwind() { m_unwind_until = ScopeType::None; }
-    bool should_unwind_until(ScopeType type, FlyString label) const
+    bool should_unwind_until(ScopeType type, FlyString label = {}) const
     {
         if (m_unwind_until_label.is_null())
             return m_unwind_until == type;

--- a/Libraries/LibJS/Tests/return.js
+++ b/Libraries/LibJS/Tests/return.js
@@ -1,0 +1,53 @@
+describe("returning from loops", () => {
+    test("returning from while loops", () => {
+        function foo() {
+            while (true) {
+                return 10;
+            }
+        }
+
+        expect(foo()).toBe(10);
+    });
+
+    test("returning from do-while loops", () => {
+        function foo() {
+            do {
+                return 10;
+            } while (true);
+        }
+
+        expect(foo()).toBe(10);
+    });
+
+    test("returning from for loops", () => {
+        function foo() {
+            for (let i = 0; i < 5; i++) {
+                return 10;
+            }
+        }
+
+        expect(foo()).toBe(10);
+    });
+
+    test("returning from for-in loops", () => {
+        function foo() {
+            const o = { a: 1, b: 2 };
+            for (let a in o) {
+                return 10;
+            }
+        }
+
+        expect(foo()).toBe(10);
+    });
+
+    test("returning from for-of loops", () => {
+        function foo() {
+            const o = [1, 2, 3];
+            for (let a of o) {
+                return 10;
+            }
+        }
+
+        expect(foo()).toBe(10);
+    });
+});


### PR DESCRIPTION
And as a bonus: return statements did nothing in while loops! So previously `while (true) { return }` would just loop forever. No clue how that one managed to go unnoticed until now lol.

Fixes #3604