### PR TITLE
LibWeb: Move bulk of SVG layout logic into Layout nodes

### DIFF
--- a/Libraries/LibGfx/Path.h
+++ b/Libraries/LibGfx/Path.h
@@ -33,6 +33,7 @@
 #include <AK/Vector.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
 
 namespace Gfx {
 
@@ -174,11 +175,20 @@ public:
     const NonnullRefPtrVector<Segment>& segments() const { return m_segments; }
     const auto& split_lines()
     {
-        if (m_split_lines.has_value())
-            return m_split_lines.value();
-        segmentize_path();
-        ASSERT(m_split_lines.has_value());
+        if (!m_split_lines.has_value()) {
+            segmentize_path();
+            ASSERT(m_split_lines.has_value());
+        }
         return m_split_lines.value();
+    }
+
+    const Gfx::FloatRect& bounding_box()
+    {
+        if (!m_bounding_box.has_value()) {
+            segmentize_path();
+            ASSERT(m_bounding_box.has_value());
+        }
+        return m_bounding_box.value();
     }
 
     String to_string() const;
@@ -199,6 +209,7 @@ private:
     NonnullRefPtrVector<Segment> m_segments {};
 
     Optional<Vector<SplitLineSegment>> m_split_lines {};
+    Optional<Gfx::FloatRect> m_bounding_box;
 };
 
 inline const LogStream& operator<<(const LogStream& stream, const Path& path)

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -148,6 +148,9 @@ set(SOURCES
     Layout/LayoutPosition.cpp
     Layout/LayoutReplaced.cpp
     Layout/LayoutSVG.cpp
+    Layout/LayoutSVGGraphics.cpp
+    Layout/LayoutSVGPath.cpp
+    Layout/LayoutSVGSVG.cpp
     Layout/LayoutTable.cpp
     Layout/LayoutTableCell.cpp
     Layout/LayoutTableRow.cpp

--- a/Libraries/LibWeb/Layout/LayoutNode.cpp
+++ b/Libraries/LibWeb/Layout/LayoutNode.cpp
@@ -95,11 +95,15 @@ void LayoutNode::paint(PaintContext& context, PaintPhase phase)
     if (!is_visible())
         return;
 
+    before_children_paint(context, phase);
+
     for_each_child([&](auto& child) {
         if (child.is_box() && downcast<LayoutBox>(child).stacking_context())
             return;
         child.paint(context, phase);
     });
+
+    after_children_paint(context, phase);
 }
 
 HitTestResult LayoutNode::hit_test(const Gfx::IntPoint& position, HitTestType type) const

--- a/Libraries/LibWeb/Layout/LayoutNode.h
+++ b/Libraries/LibWeb/Layout/LayoutNode.h
@@ -122,7 +122,10 @@ public:
         FocusOutline,
         Overlay,
     };
+
+    virtual void before_children_paint(PaintContext&, PaintPhase) {};
     virtual void paint(PaintContext&, PaintPhase);
+    virtual void after_children_paint(PaintContext&, PaintPhase) {};
 
     bool is_floating() const;
     bool is_absolutely_positioned() const;

--- a/Libraries/LibWeb/Layout/LayoutSVG.cpp
+++ b/Libraries/LibWeb/Layout/LayoutSVG.cpp
@@ -31,37 +31,25 @@
 
 namespace Web {
 
-LayoutSVG::LayoutSVG(DOM::Document& document, SVG::SVGSVGElement& element, NonnullRefPtr<CSS::StyleProperties> style)
+LayoutSVG::LayoutSVG(DOM::Document& document, SVG::SVGElement& element, NonnullRefPtr<CSS::StyleProperties> style)
     : LayoutReplaced(document, element, move(style))
 {
 }
 
-void LayoutSVG::layout(LayoutMode layout_mode)
+void LayoutSVG::before_children_paint(PaintContext& context, LayoutNode::PaintPhase phase)
 {
-    set_has_intrinsic_width(true);
-    set_has_intrinsic_height(true);
-    set_intrinsic_width(node().width());
-    set_intrinsic_height(node().height());
-    LayoutReplaced::layout(layout_mode);
+    LayoutNode::before_children_paint(context, phase);
+    if (phase != LayoutNode::PaintPhase::Foreground)
+        return;
+    context.svg_context().save();
 }
 
-void LayoutSVG::paint(PaintContext& context, PaintPhase phase)
+void LayoutSVG::after_children_paint(PaintContext& context, LayoutNode::PaintPhase phase)
 {
-    if (!is_visible())
+    LayoutNode::after_children_paint(context, phase);
+    if (phase != LayoutNode::PaintPhase::Foreground)
         return;
-
-    LayoutReplaced::paint(context, phase);
-
-    if (phase == PaintPhase::Foreground) {
-        if (!context.viewport_rect().intersects(enclosing_int_rect(absolute_rect())))
-            return;
-
-        if (!node().bitmap())
-            node().create_bitmap_as_top_level_svg_element();
-
-        ASSERT(node().bitmap());
-        context.painter().draw_scaled_bitmap(enclosing_int_rect(absolute_rect()), *node().bitmap(), node().bitmap()->rect());
-    }
+    context.svg_context().restore();
 }
 
 }

--- a/Libraries/LibWeb/Layout/LayoutSVG.h
+++ b/Libraries/LibWeb/Layout/LayoutSVG.h
@@ -27,18 +27,18 @@
 #pragma once
 
 #include <LibWeb/Layout/LayoutReplaced.h>
-#include <LibWeb/SVG/SVGSVGElement.h>
+#include <LibWeb/SVG/SVGElement.h>
+#include <LibWeb/SVG/SVGGraphicsElement.h>
 
 namespace Web {
 
 class LayoutSVG : public LayoutReplaced {
 public:
-    LayoutSVG(DOM::Document&, SVG::SVGSVGElement&, NonnullRefPtr<CSS::StyleProperties>);
+    LayoutSVG(DOM::Document&, SVG::SVGElement&, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~LayoutSVG() override = default;
-    virtual void layout(LayoutMode = LayoutMode::Default) override;
-    virtual void paint(PaintContext&, PaintPhase) override;
 
-    SVG::SVGSVGElement& node() { return static_cast<SVG::SVGSVGElement&>(LayoutReplaced::node()); }
+    virtual void before_children_paint(PaintContext& context, PaintPhase phase) override;
+    virtual void after_children_paint(PaintContext& context, PaintPhase phase) override;
 
 private:
     virtual const char* class_name() const override { return "LayoutSVG"; }

--- a/Libraries/LibWeb/Layout/LayoutSVGGraphics.h
+++ b/Libraries/LibWeb/Layout/LayoutSVGGraphics.h
@@ -24,28 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
+#include <LibWeb/Layout/LayoutSVG.h>
+#include <LibWeb/SVG/SVGElement.h>
 #include <LibWeb/SVG/SVGGraphicsElement.h>
 
-namespace Web::SVG {
+namespace Web {
 
-SVGGraphicsElement::SVGGraphicsElement(DOM::Document& document, const FlyString& tag_name)
-    : SVGElement(document, tag_name)
-{
-}
+class LayoutSVGGraphics : public LayoutSVG {
+public:
+    LayoutSVGGraphics(DOM::Document&, SVG::SVGGraphicsElement&, NonnullRefPtr<CSS::StyleProperties>);
+    virtual ~LayoutSVGGraphics() override = default;
 
-void SVGGraphicsElement::parse_attribute(const FlyString& name, const String& value)
-{
-    SVGElement::parse_attribute(name, value);
+    virtual void layout(LayoutMode mode) override;
+    virtual void before_children_paint(PaintContext& context, LayoutNode::PaintPhase phase) override;
 
-    if (name == "fill") {
-        m_fill_color = Gfx::Color::from_string(value).value_or(Color::Transparent);
-    } else if (name == "stroke") {
-        m_stroke_color = Gfx::Color::from_string(value).value_or(Color::Transparent);
-    } else if (name == "stroke-width") {
-        auto result = value.to_int();
-        if (result.has_value())
-            m_stroke_width = result.value();
-    }
-}
+private:
+    virtual const char* class_name() const override { return "LayoutSVGGraphics"; }
+};
 
 }

--- a/Libraries/LibWeb/Layout/LayoutSVGPath.cpp
+++ b/Libraries/LibWeb/Layout/LayoutSVGPath.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibGfx/Painter.h>
+#include <LibWeb/Layout/LayoutSVGPath.h>
+#include <LibWeb/SVG/SVGPathElement.h>
+
+namespace Web {
+
+LayoutSVGPath::LayoutSVGPath(DOM::Document& document, SVG::SVGPathElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
+    : LayoutSVGGraphics(document, element, properties)
+{
+}
+
+void LayoutSVGPath::layout(LayoutNode::LayoutMode mode)
+{
+    auto& bounding_box = node().get_path().bounding_box();
+    set_has_intrinsic_width(true);
+    set_has_intrinsic_height(true);
+    set_intrinsic_width(bounding_box.width());
+    set_intrinsic_height(bounding_box.height());
+    set_offset(bounding_box.top_left());
+    LayoutSVGGraphics::layout(mode);
+}
+
+void LayoutSVGPath::paint(PaintContext& context, LayoutNode::PaintPhase phase)
+{
+    if (!is_visible())
+        return;
+
+    LayoutSVGGraphics::paint(context, phase);
+
+    if (phase != LayoutNode::PaintPhase::Foreground)
+        return;
+
+    auto& path_element = node();
+    auto& path = path_element.get_path();
+
+    // We need to fill the path before applying the stroke, however the filled
+    // path must be closed, whereas the stroke path may not necessary be closed.
+    // Copy the path and close it for filling, but use the previous path for stroke
+    auto closed_path = path;
+    closed_path.close();
+
+    // Fills are computed as though all paths are closed (https://svgwg.org/svg2-draft/painting.html#FillProperties)
+    auto& painter = context.painter();
+    auto& svg_context = context.svg_context();
+
+    auto offset = (absolute_position() - effective_offset()).to_type<int>();
+
+    painter.translate(offset);
+
+    painter.fill_path(
+        closed_path,
+        path_element.fill_color().value_or(svg_context.fill_color()),
+        Gfx::Painter::WindingRule::EvenOdd);
+    painter.stroke_path(
+        path,
+        path_element.stroke_color().value_or(svg_context.stroke_color()),
+        path_element.stroke_width().value_or(svg_context.stroke_width()));
+
+    painter.translate(-offset);
+}
+
+}

--- a/Libraries/LibWeb/Layout/LayoutSVGPath.h
+++ b/Libraries/LibWeb/Layout/LayoutSVGPath.h
@@ -24,28 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibWeb/SVG/SVGGraphicsElement.h>
+#pragma once
 
-namespace Web::SVG {
+#include <LibWeb/Layout/LayoutSVGGraphics.h>
 
-SVGGraphicsElement::SVGGraphicsElement(DOM::Document& document, const FlyString& tag_name)
-    : SVGElement(document, tag_name)
-{
-}
+namespace Web {
 
-void SVGGraphicsElement::parse_attribute(const FlyString& name, const String& value)
-{
-    SVGElement::parse_attribute(name, value);
+class LayoutSVGPath final : public LayoutSVGGraphics {
+public:
+    LayoutSVGPath(DOM::Document&, SVG::SVGPathElement&, NonnullRefPtr<CSS::StyleProperties>);
+    virtual ~LayoutSVGPath() override = default;
 
-    if (name == "fill") {
-        m_fill_color = Gfx::Color::from_string(value).value_or(Color::Transparent);
-    } else if (name == "stroke") {
-        m_stroke_color = Gfx::Color::from_string(value).value_or(Color::Transparent);
-    } else if (name == "stroke-width") {
-        auto result = value.to_int();
-        if (result.has_value())
-            m_stroke_width = result.value();
-    }
-}
+    SVG::SVGPathElement& node() { return downcast<SVG::SVGPathElement>(LayoutSVGGraphics::node()); }
+
+    void layout(LayoutMode mode) override;
+    void paint(PaintContext& context, PaintPhase phase) override;
+
+private:
+    virtual const char* class_name() const override { return "LayoutSVGPath"; }
+};
 
 }

--- a/Libraries/LibWeb/Layout/LayoutSVGSVG.cpp
+++ b/Libraries/LibWeb/Layout/LayoutSVGSVG.cpp
@@ -24,28 +24,40 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibWeb/SVG/SVGGraphicsElement.h>
+#include <LibWeb/Layout/LayoutSVGSVG.h>
 
-namespace Web::SVG {
+namespace Web {
 
-SVGGraphicsElement::SVGGraphicsElement(DOM::Document& document, const FlyString& tag_name)
-    : SVGElement(document, tag_name)
+LayoutSVGSVG::LayoutSVGSVG(DOM::Document& document, SVG::SVGSVGElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
+    : LayoutSVGGraphics(document, element, properties)
 {
 }
 
-void SVGGraphicsElement::parse_attribute(const FlyString& name, const String& value)
+void LayoutSVGSVG::layout(LayoutMode layout_mode)
 {
-    SVGElement::parse_attribute(name, value);
+    set_has_intrinsic_width(true);
+    set_has_intrinsic_height(true);
+    set_intrinsic_width(node().width());
+    set_intrinsic_height(node().height());
+    LayoutSVGGraphics::layout(layout_mode);
+}
 
-    if (name == "fill") {
-        m_fill_color = Gfx::Color::from_string(value).value_or(Color::Transparent);
-    } else if (name == "stroke") {
-        m_stroke_color = Gfx::Color::from_string(value).value_or(Color::Transparent);
-    } else if (name == "stroke-width") {
-        auto result = value.to_int();
-        if (result.has_value())
-            m_stroke_width = result.value();
-    }
+void LayoutSVGSVG::before_children_paint(PaintContext& context, LayoutNode::PaintPhase phase)
+{
+    if (phase != LayoutNode::PaintPhase::Foreground)
+        return;
+
+    if (!context.has_svg_context())
+        context.set_svg_context(SVGContext());
+
+    LayoutSVGGraphics::before_children_paint(context, phase);
+}
+
+void LayoutSVGSVG::after_children_paint(PaintContext& context, LayoutNode::PaintPhase phase)
+{
+    LayoutSVGGraphics::after_children_paint(context, phase);
+    if (phase != LayoutNode::PaintPhase::Foreground)
+        return;
 }
 
 }

--- a/Libraries/LibWeb/Layout/LayoutSVGSVG.h
+++ b/Libraries/LibWeb/Layout/LayoutSVGSVG.h
@@ -24,28 +24,27 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibWeb/SVG/SVGGraphicsElement.h>
+#pragma once
 
-namespace Web::SVG {
+#include <LibWeb/Layout/LayoutSVGGraphics.h>
+#include <LibWeb/SVG/SVGSVGElement.h>
 
-SVGGraphicsElement::SVGGraphicsElement(DOM::Document& document, const FlyString& tag_name)
-    : SVGElement(document, tag_name)
-{
-}
+namespace Web {
 
-void SVGGraphicsElement::parse_attribute(const FlyString& name, const String& value)
-{
-    SVGElement::parse_attribute(name, value);
+class LayoutSVGSVG final : public LayoutSVGGraphics {
+public:
+    LayoutSVGSVG(DOM::Document&, SVG::SVGSVGElement&, NonnullRefPtr<CSS::StyleProperties>);
+    ~LayoutSVGSVG() override = default;
 
-    if (name == "fill") {
-        m_fill_color = Gfx::Color::from_string(value).value_or(Color::Transparent);
-    } else if (name == "stroke") {
-        m_stroke_color = Gfx::Color::from_string(value).value_or(Color::Transparent);
-    } else if (name == "stroke-width") {
-        auto result = value.to_int();
-        if (result.has_value())
-            m_stroke_width = result.value();
-    }
-}
+    SVG::SVGSVGElement& node() { return downcast<SVG::SVGSVGElement>(LayoutSVGGraphics::node()); }
+
+    void layout(LayoutMode = LayoutMode::Default) override;
+
+    void before_children_paint(PaintContext& context, LayoutNode::PaintPhase phase) override;
+    void after_children_paint(PaintContext& context, PaintPhase phase) override;
+
+private:
+    const char* class_name() const override { return "LayoutSVGSVG"; }
+};
 
 }

--- a/Libraries/LibWeb/Painting/PaintContext.h
+++ b/Libraries/LibWeb/Painting/PaintContext.h
@@ -29,6 +29,7 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/Rect.h>
+#include <LibWeb/SVG/SVGContext.h>
 
 namespace Web {
 
@@ -44,6 +45,10 @@ public:
     Gfx::Painter& painter() const { return m_painter; }
     const Palette& palette() const { return m_palette; }
 
+    bool has_svg_context() const { return m_svg_context.has_value(); }
+    SVGContext& svg_context() { return m_svg_context.value(); }
+    void set_svg_context(SVGContext context) { m_svg_context = context; }
+
     bool should_show_line_box_borders() const { return m_should_show_line_box_borders; }
     void set_should_show_line_box_borders(bool value) { m_should_show_line_box_borders = value; }
 
@@ -58,6 +63,7 @@ public:
 private:
     Gfx::Painter& m_painter;
     Palette m_palette;
+    Optional<SVGContext> m_svg_context;
     Gfx::IntRect m_viewport_rect;
     Gfx::IntPoint m_scroll_offset;
     bool m_should_show_line_box_borders { false };

--- a/Libraries/LibWeb/SVG/SVGContext.h
+++ b/Libraries/LibWeb/SVG/SVGContext.h
@@ -32,7 +32,7 @@ class SVGContext {
 public:
     SVGContext()
     {
-        push_state();
+        m_states.append(State());
     }
 
     const Gfx::Color& fill_color() const { return state().fill_color; }
@@ -43,9 +43,8 @@ public:
     void set_stroke_color(Gfx::Color color) { state().stroke_color = color; }
     void set_stroke_width(float width) { state().stroke_width = width; }
 
-    void push_state() { m_states.append(State()); }
-
-    void pop_state() { m_states.take_last(); }
+    void save() { m_states.append(m_states.last()); }
+    void restore() { m_states.take_last(); }
 
 private:
     struct State {

--- a/Libraries/LibWeb/SVG/SVGContext.h
+++ b/Libraries/LibWeb/SVG/SVGContext.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <matthewcolsson@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace Web {
+
+class SVGContext {
+public:
+    SVGContext()
+    {
+        push_state();
+    }
+
+    const Gfx::Color& fill_color() const { return state().fill_color; }
+    const Gfx::Color& stroke_color() const { return state().stroke_color; }
+    float stroke_width() const { return state().stroke_width; }
+
+    void set_fill_color(Gfx::Color color) { state().fill_color = color; }
+    void set_stroke_color(Gfx::Color color) { state().stroke_color = color; }
+    void set_stroke_width(float width) { state().stroke_width = width; }
+
+    void push_state() { m_states.append(State()); }
+
+    void pop_state() { m_states.take_last(); }
+
+private:
+    struct State {
+        Gfx::Color fill_color { Gfx::Color::Black };
+        Gfx::Color stroke_color { Gfx::Color::Transparent };
+        float stroke_width { 1.0 };
+    };
+
+    const State& state() const { return m_states.last(); }
+    State& state() { return m_states.last(); }
+
+    Vector<State> m_states;
+};
+
+}

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -33,18 +33,6 @@
 
 namespace Web::SVG {
 
-struct SVGPaintingContext {
-    Gfx::Color fill_color;
-    Gfx::Color stroke_color;
-    float stroke_width;
-};
-
-static const SVGPaintingContext default_painting_context = {
-    Gfx::Color::Black,
-    Gfx::Color::Black,
-    1.0f
-};
-
 class SVGGraphicsElement : public SVGElement {
 public:
     using WrapperType = Bindings::SVGGraphicsElementWrapper;
@@ -53,9 +41,9 @@ public:
 
     virtual void parse_attribute(const FlyString& name, const String& value) override;
 
-    virtual void paint(Gfx::Painter& painter, const SVGPaintingContext& context) = 0;
-
-    SVGPaintingContext make_painting_context_from(const SVGPaintingContext& context);
+    const Optional<Gfx::Color>& fill_color() const { return m_fill_color; }
+    const Optional<Gfx::Color>& stroke_color() const { return m_stroke_color; }
+    const Optional<float>& stroke_width() const { return m_stroke_width; }
 
 protected:
     Optional<Gfx::Color> m_fill_color;

--- a/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -109,12 +109,16 @@ public:
     SVGPathElement(DOM::Document&, const FlyString& tag_name);
     virtual ~SVGPathElement() override = default;
 
+    virtual RefPtr<LayoutNode> create_layout_node(const CSS::StyleProperties* parent_style) override;
+
     virtual void parse_attribute(const FlyString& name, const String& value) override;
-    virtual void paint(Gfx::Painter& painter, const SVGPaintingContext& context) override;
+
+    Gfx::Path& get_path();
 
 private:
     Vector<PathInstruction> m_instructions;
     Gfx::FloatPoint m_previous_control_point = {};
+    Optional<Gfx::Path> m_path;
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -28,14 +28,12 @@
 #include <LibWeb/CSS/StyleResolver.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
-#include <LibWeb/Layout/LayoutSVG.h>
+#include <LibWeb/Layout/LayoutSVGSVG.h>
 #include <LibWeb/SVG/SVGPathElement.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
 #include <ctype.h>
 
 namespace Web::SVG {
-
-static constexpr auto max_svg_area = 16384 * 16384;
 
 SVGSVGElement::SVGSVGElement(DOM::Document& document, const FlyString& tag_name)
     : SVGGraphicsElement(document, tag_name)
@@ -47,43 +45,7 @@ RefPtr<LayoutNode> SVGSVGElement::create_layout_node(const CSS::StyleProperties*
     auto style = document().style_resolver().resolve_style(*this, parent_style);
     if (style->display() == CSS::Display::None)
         return nullptr;
-    return adopt(*new LayoutSVG(document(), *this, move(style)));
-}
-
-static Gfx::IntSize bitmap_size_for_canvas(const SVGSVGElement& canvas)
-{
-    auto width = canvas.width();
-    auto height = canvas.height();
-
-    Checked<size_t> area = width;
-    area *= height;
-
-    if (area.has_overflow()) {
-        dbg() << "Refusing to create " << width << "x" << height << " svg (overflow)";
-        return {};
-    }
-    if (area.value() > max_svg_area) {
-        dbg() << "Refusing to create " << width << "x" << height << " svg (exceeds maximum size)";
-        return {};
-    }
-    return Gfx::IntSize(width, height);
-}
-
-bool SVGSVGElement::create_bitmap_as_top_level_svg_element()
-{
-    auto size = bitmap_size_for_canvas(*this);
-    if (size.is_empty()) {
-        m_bitmap = nullptr;
-        return false;
-    }
-
-    if (!m_bitmap || m_bitmap->size() != size)
-        m_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::RGBA32, size);
-
-    Gfx::Painter painter(*m_bitmap);
-    paint(painter, make_painting_context_from(default_painting_context));
-
-    return m_bitmap;
+    return adopt(*new LayoutSVGSVG(document(), *this, move(style)));
 }
 
 unsigned SVGSVGElement::width() const
@@ -94,15 +56,6 @@ unsigned SVGSVGElement::width() const
 unsigned SVGSVGElement::height() const
 {
     return attribute(HTML::AttributeNames::height).to_uint().value_or(150);
-}
-
-void SVGSVGElement::paint(Gfx::Painter& painter, const SVGPaintingContext& context)
-{
-    for_each_child([&](Node& child) {
-        if (is<SVGGraphicsElement>(child)) {
-            downcast<SVGGraphicsElement>(child).paint(painter, make_painting_context_from(context));
-        }
-    });
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -39,11 +39,6 @@ public:
 
     virtual RefPtr<LayoutNode> create_layout_node(const CSS::StyleProperties* parent_style) override;
 
-    const RefPtr<Gfx::Bitmap> bitmap() const { return m_bitmap; }
-    bool create_bitmap_as_top_level_svg_element();
-
-    virtual void paint(Gfx::Painter& painter, const SVGPaintingContext& context) override;
-
     unsigned width() const;
     unsigned height() const;
 


### PR DESCRIPTION
This PR introduces layout nodes for each SVG element type, and moves all of the painting logic into those layout nodes. This brings the SVG API more inline with the rest of LibWeb.

Also, the inspector now shows the correct position and size for each SVG element:

<img  width="70%" src="https://i.imgur.com/pBRIyaQ.png" />

(not sure why some of the elements don't have text in the inspector, but that's a problem for another PR)

This is a big change and it took me a long time to figure out how to do this, so I've probably not done it in the best way possible. I'm a LibWeb noob so I'd love all the feedback I can get to make this as good as possible.  Once I get this all figured out, I can finally start adding more SVG features :)