### PR TITLE
Ports: add sqlite

### DIFF
--- a/Libraries/LibC/fcntl.h
+++ b/Libraries/LibC/fcntl.h
@@ -97,8 +97,9 @@ int watch_file(const char* path, size_t path_length);
 #define F_RDLCK 0
 #define F_WRLCK 1
 #define F_UNLCK 2
-#define F_SETLK 6
-#define F_SETLKW 7
+#define F_GETLK 6
+#define F_SETLK 7
+#define F_SETLKW 8
 
 struct flock {
     short l_type;

--- a/Ports/sqlite/package.sh
+++ b/Ports/sqlite/package.sh
@@ -1,0 +1,9 @@
+#!/bin/bash ../.port_include.sh
+port=sqlite
+version=3.33.0
+workdir="sqlite-src-3330000"
+useconfigure="true"
+files="https://www.sqlite.org/2020/sqlite-src-3330000.zip sqlite-src-3330000.zip"
+configopts="--target=i686-pc-serenity --with-sysroot=/ --with-build-sysroot=$SERENITY_ROOT/Build/Root
+	--disable-tcl --disable-editline --disable-readline --disable-amalgamation LDFLAGS=-lpthread"
+depends="zlib"

--- a/Ports/sqlite/patches/configure-system.patch
+++ b/Ports/sqlite/patches/configure-system.patch
@@ -1,0 +1,12 @@
+--- sqlite-src-3330000/config.sub.orig	2020-10-10 19:55:46.525171173 +1100
++++ sqlite-src-3330000/config.sub	2020-10-10 19:56:09.155171277 +1100
+@@ -1368,7 +1368,8 @@
+ 	     | powermax* | dnix* | nx6 | nx7 | sei* | dragonfly* \
+ 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
+ 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
+-	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi*)
++	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
++	     | serenity*)
+ 	# Remember, each alternative MUST END IN *, to match a version number.
+ 		;;
+ 	qnx*)

--- a/Ports/sqlite/patches/no-utimes.patch
+++ b/Ports/sqlite/patches/no-utimes.patch
@@ -1,0 +1,18 @@
+--- sqlite-src-3330000/ext/misc/fileio.c.orig	2020-10-10 22:10:06.328544628 +1100
++++ sqlite-src-3330000/ext/misc/fileio.c	2020-10-10 22:10:13.241877994 +1100
+@@ -437,11 +437,10 @@
+     }
+ #else
+     /* Legacy unix */
+-    struct timeval times[2];
+-    times[0].tv_usec = times[1].tv_usec = 0;
+-    times[0].tv_sec = time(0);
+-    times[1].tv_sec = mtime;
+-    if( utimes(zFile, times) ){
++    struct utimbuf timep;
++    timep.actime = time(0);
++    timep.modtime = mtime;
++    if ( utime(zFile, &timep) ){
+       return 1;
+     }
+ #endif


### PR DESCRIPTION
Unfortunately I can't test this due to linker issues:

```
/home/stephen/gits/serenity/Toolchain/Local/lib/gcc/i686-pc-serenity/10.1.0/../../../../i686-pc-serenity/bin/ld: /home/stephen/gits/serenity/Build/Root/usr/lib/libpthread.a(pthread.cpp.o): in function `pthread_attr_init':
./Build/../Libraries/LibPthread/pthread.cpp:240: undefined reference to `operator new(unsigned long)'
/home/stephen/gits/serenity/Toolchain/Local/lib/gcc/i686-pc-serenity/10.1.0/../../../../i686-pc-serenity/bin/ld: /home/stephen/gits/serenity/Build/Root/usr/lib/libpthread.a(pthread.cpp.o): in function `pthread_attr_destroy':
./Build/../Libraries/LibPthread/pthread.cpp:259: undefined reference to `operator delete(void*, unsigned long)'
```

Looking at IRC logs makes me think this is a me thing, but I've verified this happens on a clean build so ¯\\_(ツ)_/¯.