### PR TITLE
MemoryManager: Off-by-one error when collecting memory pages.

### DIFF
--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -151,7 +151,7 @@ void MemoryManager::parse_memory_map()
         klog() << "MM: considering memory at " << String::format("%p", (FlatPtr)mmap->addr) << " - " << String::format("%p", (FlatPtr)(mmap->addr + mmap->len));
 #endif
 
-        for (size_t page_base = mmap->addr; page_base < (mmap->addr + mmap->len); page_base += PAGE_SIZE) {
+        for (size_t page_base = mmap->addr; page_base <= (mmap->addr + mmap->len); page_base += PAGE_SIZE) {
             auto addr = PhysicalAddress(page_base);
 
             if (addr.get() < used_range_end.get() && addr.get() >= used_range_start.get())


### PR DESCRIPTION
Notice that we ensured that the size is a multiple of the page size and that there is at least one page there, otherwise, this change would be invalid.

We create an empty region and then expand it:

~~~none
// First iteration.
m_user_physical_regions.append(PhysicalRegion::create(addr, addr));

// Following iterations.
region->expand(region->lower(), addr);
~~~

So if the memory region only has one page, we would end up with an empty region. Thus we need to do one more iteration.