### PR TITLE
Piano: Drag to create different lengths of notes

### DIFF
--- a/Applications/Piano/KeysWidget.cpp
+++ b/Applications/Piano/KeysWidget.cpp
@@ -63,6 +63,17 @@ void KeysWidget::set_key(int key, Switch switch_key)
     m_track_manager.set_note_current_octave(key, switch_key);
 }
 
+bool KeysWidget::note_is_set(int note) const
+{
+    if (note < m_track_manager.octave_base())
+        return false;
+
+    if (note >= m_track_manager.octave_base() + note_count)
+        return false;
+
+    return m_key_on[note - m_track_manager.octave_base()] != 0;
+}
+
 int KeysWidget::key_code_to_key(int key_code) const
 {
     switch (key_code) {

--- a/Applications/Piano/KeysWidget.h
+++ b/Applications/Piano/KeysWidget.h
@@ -41,6 +41,7 @@ public:
     int mouse_note() const;
 
     void set_key(int key, Switch);
+    bool note_is_set(int note) const;
 
 private:
     explicit KeysWidget(TrackManager&);

--- a/Applications/Piano/MainWidget.cpp
+++ b/Applications/Piano/MainWidget.cpp
@@ -69,6 +69,8 @@ MainWidget::MainWidget(TrackManager& track_manager)
     m_knobs_widget = m_keys_and_knobs_container->add<KnobsWidget>(track_manager, *this);
     m_knobs_widget->set_size_policy(GUI::SizePolicy::Fixed, GUI::SizePolicy::Fill);
     m_knobs_widget->set_preferred_size(350, 0);
+
+    m_roll_widget->set_keys_widget(m_keys_widget);
 }
 
 MainWidget::~MainWidget()

--- a/Applications/Piano/Music.h
+++ b/Applications/Piano/Music.h
@@ -208,6 +208,21 @@ constexpr int beats_per_bar = 4;
 constexpr int notes_per_beat = 4;
 constexpr int roll_length = (sample_rate / (beats_per_minute / 60)) * beats_per_bar;
 
+constexpr const char* note_names[] = {
+    "C",
+    "C#",
+    "D",
+    "D#",
+    "E",
+    "F",
+    "F#",
+    "G",
+    "G#",
+    "A",
+    "A#",
+    "B",
+};
+
 // Equal temperament, A = 440Hz
 // We calculate note frequencies relative to A4:
 // 440.0 * pow(pow(2.0, 1.0 / 12.0), N)

--- a/Applications/Piano/RollWidget.cpp
+++ b/Applications/Piano/RollWidget.cpp
@@ -29,6 +29,7 @@
 #include "TrackManager.h"
 #include <LibGUI/Painter.h>
 #include <LibGUI/ScrollBar.h>
+#include <LibGfx/Font.h>
 #include <math.h>
 
 constexpr int note_height = 20;
@@ -122,6 +123,7 @@ void RollWidget::paint_event(GUI::PaintEvent& event)
     painter.translate(horizontal_note_offset_remainder, note_offset_remainder);
 
     for (int note = note_count - (note_offset + notes_to_paint); note <= (note_count - 1) - note_offset; ++note) {
+        int y = ((note_count - 1) - note) * note_height;
         for (auto roll_note : m_track_manager.current_track().roll_notes(note)) {
             int x = m_roll_width * (static_cast<double>(roll_note.on_sample) / roll_length);
             int width = m_roll_width * (static_cast<double>(roll_note.length()) / roll_length);
@@ -130,13 +132,19 @@ void RollWidget::paint_event(GUI::PaintEvent& event)
             if (width < 2)
                 width = 2;
 
-            int y = ((note_count - 1) - note) * note_height;
             int height = note_height;
 
             Gfx::IntRect rect(x, y, width, height);
             painter.fill_rect(rect, note_pressed_color);
             painter.draw_rect(rect, Color::Black);
         }
+        Gfx::IntRect note_name_rect(3, y, 1, note_height);
+        const char* note_name = note_names[note % notes_per_octave];
+
+        painter.draw_text(note_name_rect, note_name, Gfx::TextAlignment::CenterLeft);
+        note_name_rect.move_by(Gfx::Font::default_font().width(note_name) + 2, 0);
+        if (note % notes_per_octave == 0)
+            painter.draw_text(note_name_rect, String::formatted("{}", note / notes_per_octave + 1), Gfx::TextAlignment::CenterLeft);
     }
 
     int x = m_roll_width * (static_cast<double>(m_track_manager.time()) / roll_length);

--- a/Applications/Piano/RollWidget.cpp
+++ b/Applications/Piano/RollWidget.cpp
@@ -92,6 +92,8 @@ void RollWidget::paint_event(GUI::PaintEvent& event)
 
     for (int y = 0; y < notes_to_paint; ++y) {
         int y_pos = y * note_height;
+
+        int note = (note_count - note_offset - 1) - y;
         for (int x = 0; x < horizontal_notes_to_paint; ++x) {
             // This is needed to avoid rounding errors. You can't just use
             // m_note_width as the width.
@@ -104,6 +106,9 @@ void RollWidget::paint_event(GUI::PaintEvent& event)
                 painter.fill_rect(rect, Color::LightGray);
             else
                 painter.fill_rect(rect, Color::White);
+
+            if (keys_widget() && keys_widget()->note_is_set(note))
+                painter.fill_rect(rect, note_pressed_color.with_alpha(128));
 
             painter.draw_line(rect.top_right(), rect.bottom_right(), Color::Black);
             painter.draw_line(rect.bottom_left(), rect.bottom_right(), Color::Black);

--- a/Applications/Piano/RollWidget.h
+++ b/Applications/Piano/RollWidget.h
@@ -46,6 +46,8 @@ private:
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent& event) override;
+    virtual void mousemove_event(GUI::MouseEvent& event) override;
+    virtual void mouseup_event(GUI::MouseEvent& event) override;
     virtual void mousewheel_event(GUI::MouseEvent&) override;
 
     TrackManager& m_track_manager;
@@ -55,4 +57,8 @@ private:
     int m_num_notes { 0 };
     double m_note_width { 0.0 };
     int m_zoom_level { 1 };
+
+    Optional<Gfx::IntPoint> m_note_drag_start;
+    Optional<RollNote> m_note_drag_location;
+    int m_drag_note;
 };

--- a/Applications/Piano/RollWidget.h
+++ b/Applications/Piano/RollWidget.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "KeysWidget.h"
 #include "Music.h"
 #include <LibGUI/ScrollableWidget.h>
 
@@ -37,6 +38,9 @@ class RollWidget final : public GUI::ScrollableWidget {
 public:
     virtual ~RollWidget() override;
 
+    const KeysWidget* keys_widget() const { return m_keys_widget; }
+    void set_keys_widget(const KeysWidget* widget) { m_keys_widget = widget; }
+
 private:
     explicit RollWidget(TrackManager&);
 
@@ -45,6 +49,7 @@ private:
     virtual void mousewheel_event(GUI::MouseEvent&) override;
 
     TrackManager& m_track_manager;
+    const KeysWidget* m_keys_widget;
 
     int m_roll_width { 0 };
     int m_num_notes { 0 };

--- a/Applications/Piano/Track.cpp
+++ b/Applications/Piano/Track.cpp
@@ -287,7 +287,7 @@ void Track::set_roll_note(int note, u32 on_sample, u32 off_sample)
             sync_roll(note);
             return;
         }
-        if (it->on_sample == new_roll_note.on_sample && it->off_sample == new_roll_note.off_sample) {
+        if (it->on_sample <= new_roll_note.on_sample && it->off_sample >= new_roll_note.on_sample) {
             if (m_time >= it->on_sample && m_time <= it->off_sample)
                 set_note(note, Off);
             m_roll_notes[note].remove(it);
@@ -300,12 +300,6 @@ void Track::set_roll_note(int note, u32 on_sample, u32 off_sample)
             m_roll_notes[note].remove(it);
             it = m_roll_notes[note].begin();
             continue;
-        }
-        if (it->on_sample < new_roll_note.on_sample && it->off_sample >= new_roll_note.on_sample) {
-            if (m_time >= new_roll_note.off_sample && m_time <= it->off_sample)
-                set_note(note, Off);
-            it->off_sample = new_roll_note.on_sample - 1;
-            ASSERT(it->length() >= 2);
         }
         ++it;
     }

--- a/Libraries/LibGfx/Color.h
+++ b/Libraries/LibGfx/Color.h
@@ -117,7 +117,7 @@ public:
         m_value |= value;
     }
 
-    Color with_alpha(u8 alpha)
+    Color with_alpha(u8 alpha) const
     {
         return Color((m_value & 0x00ffffff) | alpha << 24);
     }


### PR DESCRIPTION
Also, bonus UI changes:
- When you press a key it will also be highlighted in the roll widget.
- Note names and octaves are displayed on the roll widget.

![2020-10-11-143629_3200x1800_scrot](https://user-images.githubusercontent.com/8095520/95689648-683e9600-0bcf-11eb-9575-6eb4d440f243.png)
