### PR TITLE
LibWeb: Add element namespace and initial implementation of foreign content parsing

### DIFF
--- a/Applications/Browser/ConsoleWidget.cpp
+++ b/Applications/Browser/ConsoleWidget.cpp
@@ -49,11 +49,11 @@ ConsoleWidget::ConsoleWidget()
 
     auto base_document = adopt(*new Web::DOM::Document);
     base_document->append_child(adopt(*new Web::DOM::DocumentType(base_document)));
-    auto html_element = Web::DOM::create_element(base_document, "html");
+    auto html_element = base_document->create_element("html");
     base_document->append_child(html_element);
-    auto head_element = Web::DOM::create_element(base_document, "head");
+    auto head_element = base_document->create_element("head");
     html_element->append_child(head_element);
-    auto body_element = Web::DOM::create_element(base_document, "body");
+    auto body_element = base_document->create_element("body");
     html_element->append_child(body_element);
     m_output_container = body_element;
 
@@ -149,7 +149,7 @@ void ConsoleWidget::print_source_line(const StringView& source)
 
 void ConsoleWidget::print_html(const StringView& line)
 {
-    auto paragraph = create_element(m_output_container->document(), "p");
+    auto paragraph = m_output_container->document().create_element("p");
     paragraph->set_inner_html(line);
 
     m_output_container->append_child(paragraph);

--- a/Applications/IRCClient/IRCLogBuffer.cpp
+++ b/Applications/IRCClient/IRCLogBuffer.cpp
@@ -42,14 +42,14 @@ IRCLogBuffer::IRCLogBuffer()
 {
     m_document = adopt(*new Web::DOM::Document);
     m_document->append_child(adopt(*new Web::DOM::DocumentType(document())));
-    auto html_element = create_element(document(), "html");
+    auto html_element = m_document->create_element("html");
     m_document->append_child(html_element);
-    auto head_element = create_element(document(), "head");
+    auto head_element = m_document->create_element("head");
     html_element->append_child(head_element);
-    auto style_element = create_element(document(), "style");
+    auto style_element = m_document->create_element("style");
     style_element->append_child(adopt(*new Web::DOM::Text(document(), "div { font-family: Csilla; font-weight: lighter; }")));
     head_element->append_child(style_element);
-    auto body_element = create_element(document(), "body");
+    auto body_element = m_document->create_element("body");
     html_element->append_child(body_element);
     m_container_element = body_element;
 }
@@ -76,7 +76,7 @@ void IRCLogBuffer::add_message(char prefix, const String& name, const String& te
         escape_html_entities(nick_string),
         escape_html_entities(text));
 
-    auto wrapper = Web::DOM::create_element(*m_document, Web::HTML::TagNames::div);
+    auto wrapper = m_document->create_element(Web::HTML::TagNames::div);
     wrapper->set_attribute(Web::HTML::AttributeNames::style, String::formatted("color: {}", color.to_string()));
     wrapper->set_inner_html(html);
     m_container_element->append_child(wrapper);
@@ -90,7 +90,7 @@ void IRCLogBuffer::add_message(const String& text, Color color)
         "<span>{}</span>",
         timestamp_string(),
         escape_html_entities(text));
-    auto wrapper = Web::DOM::create_element(*m_document, Web::HTML::TagNames::div);
+    auto wrapper = m_document->create_element(Web::HTML::TagNames::div);
     wrapper->set_attribute(Web::HTML::AttributeNames::style, String::formatted("color: {}", color.to_string()));
     wrapper->set_inner_html(html);
     m_container_element->append_child(wrapper);

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -166,6 +166,7 @@ set(SOURCES
     Loader/ImageResource.cpp
     Loader/Resource.cpp
     Loader/ResourceLoader.cpp
+    Namespace.cpp
     OutOfProcessWebView.cpp
     Page/EventHandler.cpp
     Page/Frame.cpp

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -54,6 +54,7 @@
 #include <LibWeb/InProcessWebView.h>
 #include <LibWeb/Layout/LayoutDocument.h>
 #include <LibWeb/Layout/LayoutTreeBuilder.h>
+#include <LibWeb/Namespace.h>
 #include <LibWeb/Origin.h>
 #include <LibWeb/Page/Frame.h>
 #include <LibWeb/SVG/TagNames.h>
@@ -435,7 +436,8 @@ JS::Value Document::run_javascript(const StringView& source)
 
 NonnullRefPtr<Element> Document::create_element(const String& tag_name)
 {
-    return DOM::create_element(*this, tag_name);
+    // FIXME: Let namespace be the HTML namespace, if this is an HTML document or this’s content type is "application/xhtml+xml", and null otherwise.
+    return DOM::create_element(*this, tag_name, Namespace::HTML);
 }
 
 NonnullRefPtr<DocumentFragment> Document::create_document_fragment()

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -46,9 +46,9 @@
 
 namespace Web::DOM {
 
-Element::Element(Document& document, const FlyString& tag_name)
+Element::Element(Document& document, const QualifiedName& qualified_name)
     : ParentNode(document, NodeType::ELEMENT_NODE)
-    , m_tag_name(tag_name)
+    , m_qualified_name(qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -34,6 +34,7 @@
 #include <LibWeb/DOM/TagNames.h>
 #include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/Layout/LayoutNode.h>
+#include <LibWeb/QualifiedName.h>
 
 namespace Web::DOM {
 
@@ -44,14 +45,19 @@ class Element
 public:
     using WrapperType = Bindings::ElementWrapper;
 
-    Element(Document&, const FlyString& local_name);
+    Element(Document&, const QualifiedName& qualified_name);
     virtual ~Element() override;
 
-    virtual FlyString node_name() const final { return m_tag_name; }
-    const FlyString& local_name() const { return m_tag_name; }
+    virtual FlyString node_name() const final { return m_qualified_name.local_name(); }
+    const FlyString& local_name() const { return m_qualified_name.local_name(); }
 
     // NOTE: This is for the JS bindings
     const FlyString& tag_name() const { return local_name(); }
+
+    const FlyString& namespace_() const { return m_qualified_name.namespace_(); }
+
+    // NOTE: This is for the JS bindings
+    const FlyString& namespace_uri() const { return namespace_(); }
 
     bool has_attribute(const FlyString& name) const { return !attribute(name).is_null(); }
     String attribute(const FlyString& name) const;
@@ -100,7 +106,7 @@ private:
     Attribute* find_attribute(const FlyString& name);
     const Attribute* find_attribute(const FlyString& name) const;
 
-    FlyString m_tag_name;
+    QualifiedName m_qualified_name;
     Vector<Attribute> m_attributes;
 
     RefPtr<CSS::StyleProperties> m_resolved_style;

--- a/Libraries/LibWeb/DOM/Element.idl
+++ b/Libraries/LibWeb/DOM/Element.idl
@@ -1,5 +1,5 @@
 interface Element : Node {
-
+    readonly attribute DOMString? namespaceURI;
     readonly attribute DOMString tagName;
 
     DOMString? getAttribute(DOMString qualifiedName);
@@ -16,4 +16,3 @@ interface Element : Node {
     readonly attribute Element? nextElementSibling;
     readonly attribute Element? previousElementSibling;
 }
-

--- a/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -101,159 +101,161 @@
 
 namespace Web::DOM {
 
-NonnullRefPtr<Element> create_element(Document& document, const FlyString& tag_name)
+NonnullRefPtr<Element> create_element(Document& document, const FlyString& tag_name, const FlyString& namespace_)
 {
     auto lowercase_tag_name = tag_name.to_lowercase();
+    // FIXME: Add prefix when we support it.
+    auto qualified_name = QualifiedName(tag_name, {}, namespace_);
     if (lowercase_tag_name == HTML::TagNames::a)
-        return adopt(*new HTML::HTMLAnchorElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLAnchorElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::area)
-        return adopt(*new HTML::HTMLAreaElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLAreaElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::audio)
-        return adopt(*new HTML::HTMLAudioElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLAudioElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::base)
-        return adopt(*new HTML::HTMLBaseElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLBaseElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::blink)
-        return adopt(*new HTML::HTMLBlinkElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLBlinkElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::body)
-        return adopt(*new HTML::HTMLBodyElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLBodyElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::br)
-        return adopt(*new HTML::HTMLBRElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLBRElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::button)
-        return adopt(*new HTML::HTMLButtonElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLButtonElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::canvas)
-        return adopt(*new HTML::HTMLCanvasElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLCanvasElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::data)
-        return adopt(*new HTML::HTMLDataElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLDataElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::datalist)
-        return adopt(*new HTML::HTMLDataListElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLDataListElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::details)
-        return adopt(*new HTML::HTMLDetailsElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLDetailsElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::dialog)
-        return adopt(*new HTML::HTMLDialogElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLDialogElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::div)
-        return adopt(*new HTML::HTMLDivElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLDivElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::dl)
-        return adopt(*new HTML::HTMLDListElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLDListElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::embed)
-        return adopt(*new HTML::HTMLEmbedElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLEmbedElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::fieldset)
-        return adopt(*new HTML::HTMLFieldSetElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLFieldSetElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::font)
-        return adopt(*new HTML::HTMLFontElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLFontElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::form)
-        return adopt(*new HTML::HTMLFormElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLFormElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::frame)
-        return adopt(*new HTML::HTMLFrameElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLFrameElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::frameset)
-        return adopt(*new HTML::HTMLFrameSetElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLFrameSetElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::head)
-        return adopt(*new HTML::HTMLHeadElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLHeadElement(document, qualified_name));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::h1, HTML::TagNames::h2, HTML::TagNames::h3, HTML::TagNames::h4, HTML::TagNames::h5, HTML::TagNames::h6))
-        return adopt(*new HTML::HTMLHeadingElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLHeadingElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::hr)
-        return adopt(*new HTML::HTMLHRElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLHRElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::html)
-        return adopt(*new HTML::HTMLHtmlElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLHtmlElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::iframe)
-        return adopt(*new HTML::HTMLIFrameElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLIFrameElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::img)
-        return adopt(*new HTML::HTMLImageElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLImageElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::input)
-        return adopt(*new HTML::HTMLInputElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLInputElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::label)
-        return adopt(*new HTML::HTMLLabelElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLLabelElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::legend)
-        return adopt(*new HTML::HTMLLegendElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLLegendElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::li)
-        return adopt(*new HTML::HTMLLIElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLLIElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::link)
-        return adopt(*new HTML::HTMLLinkElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLLinkElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::map)
-        return adopt(*new HTML::HTMLMapElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLMapElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::marquee)
-        return adopt(*new HTML::HTMLMarqueeElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLMarqueeElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::menu)
-        return adopt(*new HTML::HTMLMenuElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLMenuElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::meta)
-        return adopt(*new HTML::HTMLMetaElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLMetaElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::meter)
-        return adopt(*new HTML::HTMLMeterElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLMeterElement(document, qualified_name));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::ins, HTML::TagNames::del))
-        return adopt(*new HTML::HTMLModElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLModElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::object)
-        return adopt(*new HTML::HTMLObjectElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLObjectElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::ol)
-        return adopt(*new HTML::HTMLOListElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLOListElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::optgroup)
-        return adopt(*new HTML::HTMLOptGroupElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLOptGroupElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::option)
-        return adopt(*new HTML::HTMLOptionElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLOptionElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::output)
-        return adopt(*new HTML::HTMLOutputElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLOutputElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::p)
-        return adopt(*new HTML::HTMLParagraphElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLParagraphElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::param)
-        return adopt(*new HTML::HTMLParamElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLParamElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::picture)
-        return adopt(*new HTML::HTMLPictureElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLPictureElement(document, qualified_name));
     // NOTE: The obsolete elements "listing" and "xmp" are explicitly mapped to HTMLPreElement in the specification.
     if (lowercase_tag_name.is_one_of(HTML::TagNames::pre, HTML::TagNames::listing, HTML::TagNames::xmp))
-        return adopt(*new HTML::HTMLPreElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLPreElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::progress)
-        return adopt(*new HTML::HTMLProgressElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLProgressElement(document, qualified_name));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::blockquote, HTML::TagNames::q))
-        return adopt(*new HTML::HTMLQuoteElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLQuoteElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::script)
-        return adopt(*new HTML::HTMLScriptElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLScriptElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::select)
-        return adopt(*new HTML::HTMLSelectElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLSelectElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::slot)
-        return adopt(*new HTML::HTMLSlotElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLSlotElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::source)
-        return adopt(*new HTML::HTMLSourceElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLSourceElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::span)
-        return adopt(*new HTML::HTMLSpanElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLSpanElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::style)
-        return adopt(*new HTML::HTMLStyleElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLStyleElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::caption)
-        return adopt(*new HTML::HTMLTableCaptionElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLTableCaptionElement(document, qualified_name));
     if (lowercase_tag_name.is_one_of(Web::HTML::TagNames::td, Web::HTML::TagNames::th))
-        return adopt(*new HTML::HTMLTableCellElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLTableCellElement(document, qualified_name));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::colgroup, HTML::TagNames::col))
-        return adopt(*new HTML::HTMLTableColElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLTableColElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::table)
-        return adopt(*new HTML::HTMLTableElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLTableElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::tr)
-        return adopt(*new HTML::HTMLTableRowElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLTableRowElement(document, qualified_name));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::tbody, HTML::TagNames::thead, HTML::TagNames::tfoot))
-        return adopt(*new HTML::HTMLTableSectionElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLTableSectionElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::template_)
-        return adopt(*new HTML::HTMLTemplateElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLTemplateElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::textarea)
-        return adopt(*new HTML::HTMLTextAreaElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLTextAreaElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::time)
-        return adopt(*new HTML::HTMLTimeElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLTimeElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::title)
-        return adopt(*new HTML::HTMLTitleElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLTitleElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::track)
-        return adopt(*new HTML::HTMLTrackElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLTrackElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::ul)
-        return adopt(*new HTML::HTMLUListElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLUListElement(document, qualified_name));
     if (lowercase_tag_name == HTML::TagNames::video)
-        return adopt(*new HTML::HTMLVideoElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLVideoElement(document, qualified_name));
     if (lowercase_tag_name.is_one_of(
             HTML::TagNames::article, HTML::TagNames::section, HTML::TagNames::nav, HTML::TagNames::aside, HTML::TagNames::hgroup, HTML::TagNames::header, HTML::TagNames::footer, HTML::TagNames::address, HTML::TagNames::dt, HTML::TagNames::dd, HTML::TagNames::figure, HTML::TagNames::figcaption, HTML::TagNames::main, HTML::TagNames::em, HTML::TagNames::strong, HTML::TagNames::small, HTML::TagNames::s, HTML::TagNames::cite, HTML::TagNames::dfn, HTML::TagNames::abbr, HTML::TagNames::ruby, HTML::TagNames::rt, HTML::TagNames::rp, HTML::TagNames::code, HTML::TagNames::var, HTML::TagNames::samp, HTML::TagNames::kbd, HTML::TagNames::sub, HTML::TagNames::sup, HTML::TagNames::i, HTML::TagNames::b, HTML::TagNames::u, HTML::TagNames::mark, HTML::TagNames::bdi, HTML::TagNames::bdo, HTML::TagNames::wbr, HTML::TagNames::summary, HTML::TagNames::noscript,
             // Obsolete
             HTML::TagNames::acronym, HTML::TagNames::basefont, HTML::TagNames::big, HTML::TagNames::center, HTML::TagNames::nobr, HTML::TagNames::noembed, HTML::TagNames::noframes, HTML::TagNames::plaintext, HTML::TagNames::rb, HTML::TagNames::rtc, HTML::TagNames::strike, HTML::TagNames::tt))
-        return adopt(*new HTML::HTMLElement(document, lowercase_tag_name));
+        return adopt(*new HTML::HTMLElement(document, qualified_name));
     if (lowercase_tag_name == SVG::TagNames::svg)
-        return adopt(*new SVG::SVGSVGElement(document, lowercase_tag_name));
+        return adopt(*new SVG::SVGSVGElement(document, qualified_name));
     if (lowercase_tag_name == SVG::TagNames::path)
-        return adopt(*new SVG::SVGPathElement(document, lowercase_tag_name));
+        return adopt(*new SVG::SVGPathElement(document, qualified_name));
 
     // FIXME: If name is a valid custom element name, then return HTMLElement.
 
-    return adopt(*new HTML::HTMLUnknownElement(document, lowercase_tag_name));
+    return adopt(*new HTML::HTMLUnknownElement(document, qualified_name));
 }
 
 }

--- a/Libraries/LibWeb/DOM/ElementFactory.h
+++ b/Libraries/LibWeb/DOM/ElementFactory.h
@@ -30,6 +30,6 @@
 
 namespace Web::DOM {
 
-NonnullRefPtr<Element> create_element(Document&, const FlyString& tag_name);
+NonnullRefPtr<Element> create_element(Document&, const FlyString& tag_name, const FlyString& namespace_);
 
 }

--- a/Libraries/LibWeb/DOM/TagNames.cpp
+++ b/Libraries/LibWeb/DOM/TagNames.cpp
@@ -26,9 +26,7 @@
 
 #include <LibWeb/DOM/TagNames.h>
 
-namespace Web {
-namespace HTML {
-namespace TagNames {
+namespace Web::HTML::TagNames {
 
 #define __ENUMERATE_HTML_TAG(name) FlyString name;
 ENUMERATE_HTML_TAGS
@@ -37,7 +35,7 @@ ENUMERATE_HTML_TAGS
     // clang-format off
 // FIXME: clang-format gets confused here. Why?
 [[gnu::constructor]] static void initialize()
-// clang-format off
+// clang-format on
 {
     static bool s_initialized = false;
     if (s_initialized)
@@ -53,6 +51,4 @@ ENUMERATE_HTML_TAGS
     s_initialized = true;
 }
 
-}
-}
 }

--- a/Libraries/LibWeb/DOM/TagNames.h
+++ b/Libraries/LibWeb/DOM/TagNames.h
@@ -28,9 +28,7 @@
 
 #include <AK/FlyString.h>
 
-namespace Web {
-namespace HTML {
-namespace TagNames {
+namespace Web::HTML::TagNames {
 
 #define ENUMERATE_HTML_TAGS          \
     __ENUMERATE_HTML_TAG(a)          \
@@ -177,6 +175,4 @@ namespace TagNames {
 ENUMERATE_HTML_TAGS
 #undef __ENUMERATE_HTML_TAG
 
-}
-}
 }

--- a/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Libraries/LibWeb/HTML/AttributeNames.h
@@ -46,6 +46,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(checked)         \
     __ENUMERATE_HTML_ATTRIBUTE(cite)            \
     __ENUMERATE_HTML_ATTRIBUTE(class_)          \
+    __ENUMERATE_HTML_ATTRIBUTE(color)           \
     __ENUMERATE_HTML_ATTRIBUTE(cols)            \
     __ENUMERATE_HTML_ATTRIBUTE(colspan)         \
     __ENUMERATE_HTML_ATTRIBUTE(content)         \
@@ -57,6 +58,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(defer)           \
     __ENUMERATE_HTML_ATTRIBUTE(direction)       \
     __ENUMERATE_HTML_ATTRIBUTE(dirname)         \
+    __ENUMERATE_HTML_ATTRIBUTE(face)            \
     __ENUMERATE_HTML_ATTRIBUTE(for_)            \
     __ENUMERATE_HTML_ATTRIBUTE(frameborder)     \
     __ENUMERATE_HTML_ATTRIBUTE(headers)         \

--- a/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLAnchorElement::HTMLAnchorElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLAnchorElement::HTMLAnchorElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -34,7 +34,7 @@ class HTMLAnchorElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLAnchorElementWrapper;
 
-    HTMLAnchorElement(DOM::Document&, const FlyString& local_name);
+    HTMLAnchorElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLAnchorElement() override;
 
     String href() const { return attribute(HTML::AttributeNames::href); }

--- a/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLAreaElement::HTMLAreaElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLAreaElement::HTMLAreaElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLAudioElement::HTMLAudioElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLMediaElement(document, tag_name)
+HTMLAudioElement::HTMLAudioElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLMediaElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLAudioElement.h
+++ b/Libraries/LibWeb/HTML/HTMLAudioElement.h
@@ -34,7 +34,7 @@ class HTMLAudioElement final : public HTMLMediaElement {
 public:
     using WrapperType = Bindings::HTMLAudioElementWrapper;
 
-    HTMLAudioElement(DOM::Document&, const FlyString& local_name);
+    HTMLAudioElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLAudioElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLBRElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.cpp
@@ -29,8 +29,8 @@
 
 namespace Web::HTML {
 
-HTMLBRElement::HTMLBRElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLBRElement::HTMLBRElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLBRElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.h
@@ -34,7 +34,7 @@ class HTMLBRElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLBRElementWrapper;
 
-    HTMLBRElement(DOM::Document&, const FlyString& local_name);
+    HTMLBRElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLBRElement() override;
 
     virtual RefPtr<LayoutNode> create_layout_node(const CSS::StyleProperties* parent_style) override;

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLBaseElement::HTMLBaseElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLBaseElement::HTMLBaseElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.h
@@ -34,7 +34,7 @@ class HTMLBaseElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLBaseElementWrapper;
 
-    HTMLBaseElement(DOM::Document&, const FlyString& local_name);
+    HTMLBaseElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLBaseElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLBlinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBlinkElement.cpp
@@ -32,8 +32,8 @@
 
 namespace Web::HTML {
 
-HTMLBlinkElement::HTMLBlinkElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLBlinkElement::HTMLBlinkElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
     , m_timer(Core::Timer::construct())
 {
     m_timer->set_interval(500);

--- a/Libraries/LibWeb/HTML/HTMLBlinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBlinkElement.h
@@ -33,7 +33,7 @@ namespace Web::HTML {
 
 class HTMLBlinkElement final : public HTMLElement {
 public:
-    HTMLBlinkElement(DOM::Document&, const FlyString& local_name);
+    HTMLBlinkElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLBlinkElement() override;
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -31,8 +31,8 @@
 
 namespace Web::HTML {
 
-HTMLBodyElement::HTMLBodyElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLBodyElement::HTMLBodyElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLBodyElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBodyElement.h
@@ -34,7 +34,7 @@ class HTMLBodyElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLBodyElementWrapper;
 
-    HTMLBodyElement(DOM::Document&, const FlyString& local_name);
+    HTMLBodyElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLBodyElement() override;
 
     virtual void parse_attribute(const FlyString&, const String&) override;

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLButtonElement::HTMLButtonElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLButtonElement::HTMLButtonElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -34,7 +34,7 @@ class HTMLButtonElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLButtonElementWrapper;
 
-    HTMLButtonElement(DOM::Document&, const FlyString& local_name);
+    HTMLButtonElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLButtonElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -36,8 +36,8 @@ namespace Web::HTML {
 
 static constexpr auto max_canvas_area = 16384 * 16384;
 
-HTMLCanvasElement::HTMLCanvasElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLCanvasElement::HTMLCanvasElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -38,7 +38,7 @@ class HTMLCanvasElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLCanvasElementWrapper;
 
-    HTMLCanvasElement(DOM::Document&, const FlyString& local_name);
+    HTMLCanvasElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLCanvasElement() override;
 
     const Gfx::Bitmap* bitmap() const { return m_bitmap; }

--- a/Libraries/LibWeb/HTML/HTMLDListElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDListElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLDListElement::HTMLDListElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLDListElement::HTMLDListElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLDListElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDListElement.h
@@ -34,7 +34,7 @@ class HTMLDListElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLDListElementWrapper;
 
-    HTMLDListElement(DOM::Document&, const FlyString& local_name);
+    HTMLDListElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLDListElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLDataElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDataElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLDataElement::HTMLDataElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLDataElement::HTMLDataElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLDataElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDataElement.h
@@ -34,7 +34,7 @@ class HTMLDataElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLDataElementWrapper;
 
-    HTMLDataElement(DOM::Document&, const FlyString& local_name);
+    HTMLDataElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLDataElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLDataListElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDataListElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLDataListElement::HTMLDataListElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLDataListElement::HTMLDataListElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLDataListElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDataListElement.h
@@ -34,7 +34,7 @@ class HTMLDataListElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLDataListElementWrapper;
 
-    HTMLDataListElement(DOM::Document&, const FlyString& local_name);
+    HTMLDataListElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLDataListElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLDetailsElement::HTMLDetailsElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLDetailsElement::HTMLDetailsElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -34,7 +34,7 @@ class HTMLDetailsElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLDetailsElementWrapper;
 
-    HTMLDetailsElement(DOM::Document&, const FlyString& local_name);
+    HTMLDetailsElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLDetailsElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLDialogElement::HTMLDialogElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLDialogElement::HTMLDialogElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -34,7 +34,7 @@ class HTMLDialogElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLDialogElementWrapper;
 
-    HTMLDialogElement(DOM::Document&, const FlyString& local_name);
+    HTMLDialogElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLDialogElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLDivElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDivElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLDivElement::HTMLDivElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLDivElement::HTMLDivElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLDivElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDivElement.h
@@ -34,7 +34,7 @@ class HTMLDivElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLDivElementWrapper;
 
-    HTMLDivElement(DOM::Document&, const FlyString& local_name);
+    HTMLDivElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLDivElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLElement::HTMLElement(DOM::Document& document, const FlyString& tag_name)
-    : Element(document, tag_name)
+HTMLElement::HTMLElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : Element(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -34,7 +34,7 @@ class HTMLElement : public DOM::Element {
 public:
     using WrapperType = Bindings::HTMLElementWrapper;
 
-    HTMLElement(DOM::Document&, const FlyString& local_name);
+    HTMLElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLElement() override;
 
     String title() const { return attribute(HTML::AttributeNames::title); }

--- a/Libraries/LibWeb/HTML/HTMLEmbedElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLEmbedElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLEmbedElement::HTMLEmbedElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLEmbedElement::HTMLEmbedElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLEmbedElement.h
+++ b/Libraries/LibWeb/HTML/HTMLEmbedElement.h
@@ -34,7 +34,7 @@ class HTMLEmbedElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLEmbedElementWrapper;
 
-    HTMLEmbedElement(DOM::Document&, const FlyString& local_name);
+    HTMLEmbedElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLEmbedElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLFieldSetElement::HTMLFieldSetElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLFieldSetElement::HTMLFieldSetElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
@@ -34,7 +34,7 @@ class HTMLFieldSetElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLFieldSetElementWrapper;
 
-    HTMLFieldSetElement(DOM::Document&, const FlyString& local_name);
+    HTMLFieldSetElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLFieldSetElement() override;
 
     const String& type() const

--- a/Libraries/LibWeb/HTML/HTMLFontElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFontElement.cpp
@@ -30,8 +30,8 @@
 
 namespace Web::HTML {
 
-HTMLFontElement::HTMLFontElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLFontElement::HTMLFontElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLFontElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFontElement.h
@@ -32,7 +32,7 @@ namespace Web::HTML {
 
 class HTMLFontElement final : public HTMLElement {
 public:
-    HTMLFontElement(DOM::Document&, const FlyString& local_name);
+    HTMLFontElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLFontElement() override;
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -33,8 +33,8 @@
 
 namespace Web::HTML {
 
-HTMLFormElement::HTMLFormElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLFormElement::HTMLFormElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -35,7 +35,7 @@ class HTMLFormElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLFormElementWrapper;
 
-    HTMLFormElement(DOM::Document&, const FlyString& local_name);
+    HTMLFormElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLFormElement() override;
 
     String action() const { return attribute(HTML::AttributeNames::action); }

--- a/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLFrameElement::HTMLFrameElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLFrameElement::HTMLFrameElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.h
@@ -35,7 +35,7 @@ class HTMLFrameElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLFrameElementWrapper;
 
-    HTMLFrameElement(DOM::Document&, const FlyString& local_name);
+    HTMLFrameElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLFrameElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLFrameSetElement::HTMLFrameSetElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLFrameSetElement::HTMLFrameSetElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
@@ -35,7 +35,7 @@ class HTMLFrameSetElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLFrameSetElementWrapper;
 
-    HTMLFrameSetElement(DOM::Document&, const FlyString& local_name);
+    HTMLFrameSetElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLFrameSetElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLHRElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHRElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLHRElement::HTMLHRElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLHRElement::HTMLHRElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLHRElement.h
+++ b/Libraries/LibWeb/HTML/HTMLHRElement.h
@@ -34,7 +34,7 @@ class HTMLHRElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLHRElementWrapper;
 
-    HTMLHRElement(DOM::Document&, const FlyString& local_name);
+    HTMLHRElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLHRElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLHeadElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHeadElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLHeadElement::HTMLHeadElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLHeadElement::HTMLHeadElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLHeadElement.h
+++ b/Libraries/LibWeb/HTML/HTMLHeadElement.h
@@ -34,7 +34,7 @@ class HTMLHeadElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLHeadElementWrapper;
 
-    HTMLHeadElement(DOM::Document&, const FlyString& local_name);
+    HTMLHeadElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLHeadElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLHeadingElement::HTMLHeadingElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLHeadingElement::HTMLHeadingElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLHeadingElement.h
+++ b/Libraries/LibWeb/HTML/HTMLHeadingElement.h
@@ -34,7 +34,7 @@ class HTMLHeadingElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLHeadingElementWrapper;
 
-    HTMLHeadingElement(DOM::Document&, const FlyString& local_name);
+    HTMLHeadingElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLHeadingElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLHtmlElement::HTMLHtmlElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLHtmlElement::HTMLHtmlElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLHtmlElement.h
+++ b/Libraries/LibWeb/HTML/HTMLHtmlElement.h
@@ -34,7 +34,7 @@ class HTMLHtmlElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLHtmlElementWrapper;
 
-    HTMLHtmlElement(DOM::Document&, const FlyString& local_name);
+    HTMLHtmlElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLHtmlElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -43,8 +43,8 @@
 
 namespace Web::HTML {
 
-HTMLIFrameElement::HTMLIFrameElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLIFrameElement::HTMLIFrameElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -34,7 +34,7 @@ class HTMLIFrameElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLIFrameElementWrapper;
 
-    HTMLIFrameElement(DOM::Document&, const FlyString& local_name);
+    HTMLIFrameElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLIFrameElement() override;
 
     virtual RefPtr<LayoutNode> create_layout_node(const CSS::StyleProperties* parent_style) override;

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -36,8 +36,8 @@
 
 namespace Web::HTML {
 
-HTMLImageElement::HTMLImageElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLImageElement::HTMLImageElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
     m_image_loader.on_load = [this] {
         this->document().update_layout();

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -38,7 +38,7 @@ class HTMLImageElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLImageElementWrapper;
 
-    HTMLImageElement(DOM::Document&, const FlyString& local_name);
+    HTMLImageElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLImageElement() override;
 
     virtual void parse_attribute(const FlyString& name, const String& value) override;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -38,8 +38,8 @@
 
 namespace Web::HTML {
 
-HTMLInputElement::HTMLInputElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLInputElement::HTMLInputElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -34,7 +34,7 @@ class HTMLInputElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLInputElementWrapper;
 
-    HTMLInputElement(DOM::Document&, const FlyString& local_name);
+    HTMLInputElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLInputElement() override;
 
     virtual RefPtr<LayoutNode> create_layout_node(const CSS::StyleProperties* parent_style) override;

--- a/Libraries/LibWeb/HTML/HTMLLIElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLIElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLLIElement::HTMLLIElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLLIElement::HTMLLIElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLLIElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLIElement.h
@@ -34,7 +34,7 @@ class HTMLLIElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLLIElementWrapper;
 
-    HTMLLIElement(DOM::Document&, const FlyString& local_name);
+    HTMLLIElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLLIElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLLabelElement::HTMLLabelElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLLabelElement::HTMLLabelElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLLabelElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLabelElement.h
@@ -34,7 +34,7 @@ class HTMLLabelElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLLabelElementWrapper;
 
-    HTMLLabelElement(DOM::Document&, const FlyString& local_name);
+    HTMLLabelElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLLabelElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLLegendElement::HTMLLegendElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLLegendElement::HTMLLegendElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLLegendElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLegendElement.h
@@ -34,7 +34,7 @@ class HTMLLegendElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLLegendElementWrapper;
 
-    HTMLLegendElement(DOM::Document&, const FlyString& local_name);
+    HTMLLegendElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLLegendElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -34,8 +34,8 @@
 
 namespace Web::HTML {
 
-HTMLLinkElement::HTMLLinkElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLLinkElement::HTMLLinkElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -37,7 +37,7 @@ class HTMLLinkElement final
 public:
     using WrapperType = Bindings::HTMLLinkElementWrapper;
 
-    HTMLLinkElement(DOM::Document&, const FlyString& local_name);
+    HTMLLinkElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLLinkElement() override;
 
     virtual void inserted_into(Node&) override;

--- a/Libraries/LibWeb/HTML/HTMLMapElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMapElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLMapElement::HTMLMapElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLMapElement::HTMLMapElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMapElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMapElement.h
@@ -34,7 +34,7 @@ class HTMLMapElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLMapElementWrapper;
 
-    HTMLMapElement(DOM::Document&, const FlyString& local_name);
+    HTMLMapElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLMapElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLMarqueeElement::HTMLMarqueeElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLMarqueeElement::HTMLMarqueeElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMarqueeElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMarqueeElement.h
@@ -35,7 +35,7 @@ class HTMLMarqueeElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLMarqueeElementWrapper;
 
-    HTMLMarqueeElement(DOM::Document&, const FlyString& local_name);
+    HTMLMarqueeElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLMarqueeElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLMediaElement::HTMLMediaElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLMediaElement::HTMLMediaElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -34,7 +34,7 @@ class HTMLMediaElement : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLMediaElementWrapper;
 
-    HTMLMediaElement(DOM::Document&, const FlyString& local_name);
+    HTMLMediaElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLMediaElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLMenuElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMenuElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLMenuElement::HTMLMenuElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLMenuElement::HTMLMenuElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMenuElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMenuElement.h
@@ -34,7 +34,7 @@ class HTMLMenuElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLMenuElementWrapper;
 
-    HTMLMenuElement(DOM::Document&, const FlyString& local_name);
+    HTMLMenuElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLMenuElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLMetaElement::HTMLMetaElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLMetaElement::HTMLMetaElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMetaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMetaElement.h
@@ -34,7 +34,7 @@ class HTMLMetaElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLMetaElementWrapper;
 
-    HTMLMetaElement(DOM::Document&, const FlyString& local_name);
+    HTMLMetaElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLMetaElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLMeterElement::HTMLMeterElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLMeterElement::HTMLMeterElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMeterElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMeterElement.h
@@ -34,7 +34,7 @@ class HTMLMeterElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLMeterElementWrapper;
 
-    HTMLMeterElement(DOM::Document&, const FlyString& local_name);
+    HTMLMeterElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLMeterElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLModElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLModElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLModElement::HTMLModElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLModElement::HTMLModElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLModElement.h
+++ b/Libraries/LibWeb/HTML/HTMLModElement.h
@@ -34,7 +34,7 @@ class HTMLModElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLModElementWrapper;
 
-    HTMLModElement(DOM::Document&, const FlyString& local_name);
+    HTMLModElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLModElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLOListElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOListElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLOListElement::HTMLOListElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLOListElement::HTMLOListElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLOListElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOListElement.h
@@ -34,7 +34,7 @@ class HTMLOListElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLOListElementWrapper;
 
-    HTMLOListElement(DOM::Document&, const FlyString& local_name);
+    HTMLOListElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLOListElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -35,8 +35,8 @@
 
 namespace Web::HTML {
 
-HTMLObjectElement::HTMLObjectElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLObjectElement::HTMLObjectElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
     m_image_loader.on_load = [this] {
         m_should_show_fallback_content = false;

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -37,7 +37,7 @@ class HTMLObjectElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLObjectElementWrapper;
 
-    HTMLObjectElement(DOM::Document&, const FlyString& local_name);
+    HTMLObjectElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLObjectElement() override;
 
     virtual void parse_attribute(const FlyString& name, const String& value) override;

--- a/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLOptGroupElement::HTMLOptGroupElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLOptGroupElement::HTMLOptGroupElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLOptGroupElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOptGroupElement.h
@@ -34,7 +34,7 @@ class HTMLOptGroupElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLOptGroupElementWrapper;
 
-    HTMLOptGroupElement(DOM::Document&, const FlyString& local_name);
+    HTMLOptGroupElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLOptGroupElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLOptionElement::HTMLOptionElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLOptionElement::HTMLOptionElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -34,7 +34,7 @@ class HTMLOptionElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLOptionElementWrapper;
 
-    HTMLOptionElement(DOM::Document&, const FlyString& local_name);
+    HTMLOptionElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLOptionElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLOutputElement::HTMLOutputElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLOutputElement::HTMLOutputElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.h
@@ -34,7 +34,7 @@ class HTMLOutputElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLOutputElementWrapper;
 
-    HTMLOutputElement(DOM::Document&, const FlyString& local_name);
+    HTMLOutputElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLOutputElement() override;
 
     const String& type() const

--- a/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLParagraphElement::HTMLParagraphElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLParagraphElement::HTMLParagraphElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLParagraphElement.h
+++ b/Libraries/LibWeb/HTML/HTMLParagraphElement.h
@@ -34,7 +34,7 @@ class HTMLParagraphElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLParagraphElementWrapper;
 
-    HTMLParagraphElement(DOM::Document&, const FlyString& local_name);
+    HTMLParagraphElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLParagraphElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLParamElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLParamElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLParamElement::HTMLParamElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLParamElement::HTMLParamElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLParamElement.h
+++ b/Libraries/LibWeb/HTML/HTMLParamElement.h
@@ -34,7 +34,7 @@ class HTMLParamElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLParamElementWrapper;
 
-    HTMLParamElement(DOM::Document&, const FlyString& local_name);
+    HTMLParamElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLParamElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLPictureElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLPictureElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLPictureElement::HTMLPictureElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLPictureElement::HTMLPictureElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLPictureElement.h
+++ b/Libraries/LibWeb/HTML/HTMLPictureElement.h
@@ -34,7 +34,7 @@ class HTMLPictureElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLPictureElementWrapper;
 
-    HTMLPictureElement(DOM::Document&, const FlyString& local_name);
+    HTMLPictureElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLPictureElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLPreElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLPreElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLPreElement::HTMLPreElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLPreElement::HTMLPreElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLPreElement.h
+++ b/Libraries/LibWeb/HTML/HTMLPreElement.h
@@ -34,7 +34,7 @@ class HTMLPreElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLPreElementWrapper;
 
-    HTMLPreElement(DOM::Document&, const FlyString& local_name);
+    HTMLPreElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLPreElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLProgressElement::HTMLProgressElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLProgressElement::HTMLProgressElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.h
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.h
@@ -34,7 +34,7 @@ class HTMLProgressElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLProgressElementWrapper;
 
-    HTMLProgressElement(DOM::Document&, const FlyString& local_name);
+    HTMLProgressElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLProgressElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLQuoteElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLQuoteElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLQuoteElement::HTMLQuoteElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLQuoteElement::HTMLQuoteElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLQuoteElement.h
+++ b/Libraries/LibWeb/HTML/HTMLQuoteElement.h
@@ -34,7 +34,7 @@ class HTMLQuoteElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLQuoteElementWrapper;
 
-    HTMLQuoteElement(DOM::Document&, const FlyString& local_name);
+    HTMLQuoteElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLQuoteElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -34,8 +34,8 @@
 
 namespace Web::HTML {
 
-HTMLScriptElement::HTMLScriptElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLScriptElement::HTMLScriptElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -35,7 +35,7 @@ class HTMLScriptElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLScriptElementWrapper;
 
-    HTMLScriptElement(DOM::Document&, const FlyString& local_name);
+    HTMLScriptElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLScriptElement() override;
 
     bool is_non_blocking() const { return m_non_blocking; }

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLSelectElement::HTMLSelectElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLSelectElement::HTMLSelectElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -34,7 +34,7 @@ class HTMLSelectElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLSelectElementWrapper;
 
-    HTMLSelectElement(DOM::Document&, const FlyString& local_name);
+    HTMLSelectElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLSelectElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLSlotElement::HTMLSlotElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLSlotElement::HTMLSlotElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLSlotElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSlotElement.h
@@ -34,7 +34,7 @@ class HTMLSlotElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLSlotElementWrapper;
 
-    HTMLSlotElement(DOM::Document&, const FlyString& local_name);
+    HTMLSlotElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLSlotElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLSourceElement::HTMLSourceElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLSourceElement::HTMLSourceElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLSourceElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSourceElement.h
@@ -34,7 +34,7 @@ class HTMLSourceElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLSourceElementWrapper;
 
-    HTMLSourceElement(DOM::Document&, const FlyString& local_name);
+    HTMLSourceElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLSourceElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLSpanElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSpanElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLSpanElement::HTMLSpanElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLSpanElement::HTMLSpanElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLSpanElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSpanElement.h
@@ -34,7 +34,7 @@ class HTMLSpanElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLSpanElementWrapper;
 
-    HTMLSpanElement(DOM::Document&, const FlyString& local_name);
+    HTMLSpanElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLSpanElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -32,8 +32,8 @@
 
 namespace Web::HTML {
 
-HTMLStyleElement::HTMLStyleElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLStyleElement::HTMLStyleElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.h
@@ -34,7 +34,7 @@ class HTMLStyleElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLStyleElementWrapper;
 
-    HTMLStyleElement(DOM::Document&, const FlyString& local_name);
+    HTMLStyleElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLStyleElement() override;
 
     virtual void children_changed() override;

--- a/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLTableCaptionElement::HTMLTableCaptionElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLTableCaptionElement::HTMLTableCaptionElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTableCaptionElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTableCaptionElement.h
@@ -34,7 +34,7 @@ class HTMLTableCaptionElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLTableCaptionElementWrapper;
 
-    HTMLTableCaptionElement(DOM::Document&, const FlyString& local_name);
+    HTMLTableCaptionElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLTableCaptionElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -29,8 +29,8 @@
 
 namespace Web::HTML {
 
-HTMLTableCellElement::HTMLTableCellElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLTableCellElement::HTMLTableCellElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTableCellElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTableCellElement.h
@@ -34,7 +34,7 @@ class HTMLTableCellElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLTableCellElementWrapper;
 
-    HTMLTableCellElement(DOM::Document&, const FlyString& local_name);
+    HTMLTableCellElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLTableCellElement() override;
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLTableColElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableColElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLTableColElement::HTMLTableColElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLTableColElement::HTMLTableColElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTableColElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTableColElement.h
@@ -34,7 +34,7 @@ class HTMLTableColElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLTableColElementWrapper;
 
-    HTMLTableColElement(DOM::Document&, const FlyString& local_name);
+    HTMLTableColElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLTableColElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -29,8 +29,8 @@
 
 namespace Web::HTML {
 
-HTMLTableElement::HTMLTableElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLTableElement::HTMLTableElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTableElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.h
@@ -34,7 +34,7 @@ class HTMLTableElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLTableElementWrapper;
 
-    HTMLTableElement(DOM::Document&, const FlyString& local_name);
+    HTMLTableElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLTableElement() override;
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLTableRowElement::HTMLTableRowElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLTableRowElement::HTMLTableRowElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTableRowElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTableRowElement.h
@@ -34,7 +34,7 @@ class HTMLTableRowElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLTableRowElementWrapper;
 
-    HTMLTableRowElement(DOM::Document&, const FlyString& local_name);
+    HTMLTableRowElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLTableRowElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLTableSectionElement::HTMLTableSectionElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLTableSectionElement::HTMLTableSectionElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTableSectionElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTableSectionElement.h
@@ -34,7 +34,7 @@ class HTMLTableSectionElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLTableSectionElementWrapper;
 
-    HTMLTableSectionElement(DOM::Document&, const FlyString& local_name);
+    HTMLTableSectionElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLTableSectionElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
@@ -29,8 +29,8 @@
 
 namespace Web::HTML {
 
-HTMLTemplateElement::HTMLTemplateElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLTemplateElement::HTMLTemplateElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
     m_content = adopt(*new DOM::DocumentFragment(appropriate_template_contents_owner_document(document)));
     m_content->set_host(*this);

--- a/Libraries/LibWeb/HTML/HTMLTemplateElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTemplateElement.h
@@ -35,7 +35,7 @@ class HTMLTemplateElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLTemplateElementWrapper;
 
-    HTMLTemplateElement(DOM::Document&, const FlyString& local_name);
+    HTMLTemplateElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLTemplateElement() override;
 
     NonnullRefPtr<DOM::DocumentFragment> content() { return *m_content; }

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLTextAreaElement::HTMLTextAreaElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLTextAreaElement::HTMLTextAreaElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -34,7 +34,7 @@ class HTMLTextAreaElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLTextAreaElementWrapper;
 
-    HTMLTextAreaElement(DOM::Document&, const FlyString& local_name);
+    HTMLTextAreaElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLTextAreaElement() override;
 
     const String& type() const

--- a/Libraries/LibWeb/HTML/HTMLTimeElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTimeElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLTimeElement::HTMLTimeElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLTimeElement::HTMLTimeElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTimeElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTimeElement.h
@@ -34,7 +34,7 @@ class HTMLTimeElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLTimeElementWrapper;
 
-    HTMLTimeElement(DOM::Document&, const FlyString& local_name);
+    HTMLTimeElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLTimeElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLTitleElement::HTMLTitleElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLTitleElement::HTMLTitleElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTitleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTitleElement.h
@@ -34,7 +34,7 @@ class HTMLTitleElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLTitleElementWrapper;
 
-    HTMLTitleElement(DOM::Document&, const FlyString& local_name);
+    HTMLTitleElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLTitleElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLTrackElement::HTMLTrackElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLTrackElement::HTMLTrackElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTrackElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTrackElement.h
@@ -34,7 +34,7 @@ class HTMLTrackElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLTrackElementWrapper;
 
-    HTMLTrackElement(DOM::Document&, const FlyString& local_name);
+    HTMLTrackElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLTrackElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLUListElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLUListElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLUListElement::HTMLUListElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLUListElement::HTMLUListElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLUListElement.h
+++ b/Libraries/LibWeb/HTML/HTMLUListElement.h
@@ -34,7 +34,7 @@ class HTMLUListElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLUListElementWrapper;
 
-    HTMLUListElement(DOM::Document&, const FlyString& local_name);
+    HTMLUListElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLUListElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLUnknownElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLUnknownElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLUnknownElement::HTMLUnknownElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLElement(document, tag_name)
+HTMLUnknownElement::HTMLUnknownElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLUnknownElement.h
+++ b/Libraries/LibWeb/HTML/HTMLUnknownElement.h
@@ -34,7 +34,7 @@ class HTMLUnknownElement final : public HTMLElement {
 public:
     using WrapperType = Bindings::HTMLUnknownElementWrapper;
 
-    HTMLUnknownElement(DOM::Document&, const FlyString& local_name);
+    HTMLUnknownElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLUnknownElement() override;
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::HTML {
 
-HTMLVideoElement::HTMLVideoElement(DOM::Document& document, const FlyString& tag_name)
-    : HTMLMediaElement(document, tag_name)
+HTMLVideoElement::HTMLVideoElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : HTMLMediaElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -34,7 +34,7 @@ class HTMLVideoElement final : public HTMLMediaElement {
 public:
     using WrapperType = Bindings::HTMLVideoElementWrapper;
 
-    HTMLVideoElement(DOM::Document&, const FlyString& local_name);
+    HTMLVideoElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~HTMLVideoElement() override;
 };
 

--- a/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.h
@@ -117,7 +117,7 @@ private:
     void generate_implied_end_tags(const FlyString& exception = {});
     void generate_all_implied_end_tags_thoroughly();
     bool stack_of_open_elements_has_element_with_tag_name_in_scope(const FlyString& tag_name);
-    NonnullRefPtr<DOM::Element> create_element_for(const HTMLToken&);
+    NonnullRefPtr<DOM::Element> create_element_for(const HTMLToken&, const FlyString& namespace_);
 
     struct AdjustedInsertionLocation {
         RefPtr<DOM::Node> parent;
@@ -128,6 +128,7 @@ private:
 
     DOM::Text* find_character_insertion_node();
     void flush_character_insertions();
+    RefPtr<DOM::Element> insert_foreign_element(const HTMLToken&, const FlyString&);
     RefPtr<DOM::Element> insert_html_element(const HTMLToken&);
     DOM::Element& current_node();
     DOM::Element& node_before_current_node();

--- a/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.h
@@ -81,7 +81,7 @@ public:
 
     InsertionMode insertion_mode() const { return m_insertion_mode; }
 
-    static bool is_special_tag(const FlyString& tag_name);
+    static bool is_special_tag(const FlyString& tag_name, const FlyString& namespace_);
 
 private:
     const char* insertion_mode_name() const;
@@ -131,12 +131,14 @@ private:
     RefPtr<DOM::Element> insert_foreign_element(const HTMLToken&, const FlyString&);
     RefPtr<DOM::Element> insert_html_element(const HTMLToken&);
     DOM::Element& current_node();
+    DOM::Element& adjusted_current_node();
     DOM::Element& node_before_current_node();
     void insert_character(u32 data);
     void insert_comment(HTMLToken&);
     void reconstruct_the_active_formatting_elements();
     void close_a_p_element();
     void process_using_the_rules_for(InsertionMode, HTMLToken&);
+    void process_using_the_rules_for_foreign_content(HTMLToken&);
     void parse_generic_raw_text_element(HTMLToken&);
     void increment_script_nesting_level();
     void decrement_script_nesting_level();
@@ -144,6 +146,7 @@ private:
     void reset_the_insertion_mode_appropriately();
 
     void adjust_mathml_attributes(HTMLToken&);
+    void adjust_svg_tag_names(HTMLToken&);
     void adjust_svg_attributes(HTMLToken&);
     void adjust_foreign_attributes(HTMLToken&);
 

--- a/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -132,6 +132,20 @@ public:
         return {};
     }
 
+    bool has_attribute(const FlyString& attribute_name)
+    {
+        return !attribute(attribute_name).is_null();
+    }
+
+    void adjust_tag_name(const FlyString& old_name, const FlyString& new_name)
+    {
+        ASSERT(is_start_tag() || is_end_tag());
+        if (old_name == m_tag.tag_name.string_view()) {
+            m_tag.tag_name.clear();
+            m_tag.tag_name.append(new_name);
+        }
+    }
+
     void adjust_attribute_name(const FlyString& old_name, const FlyString& new_name)
     {
         ASSERT(is_start_tag() || is_end_tag());

--- a/Libraries/LibWeb/HTML/Parser/ListOfActiveFormattingElements.cpp
+++ b/Libraries/LibWeb/HTML/Parser/ListOfActiveFormattingElements.cpp
@@ -35,6 +35,7 @@ ListOfActiveFormattingElements::~ListOfActiveFormattingElements()
 
 void ListOfActiveFormattingElements::add(DOM::Element& element)
 {
+    // FIXME: Implement the Noah's Ark clause https://html.spec.whatwg.org/multipage/parsing.html#push-onto-the-list-of-active-formatting-elements
     m_entries.append({ element });
 }
 

--- a/Libraries/LibWeb/HTML/Parser/StackOfOpenElements.cpp
+++ b/Libraries/LibWeb/HTML/Parser/StackOfOpenElements.cpp
@@ -127,7 +127,7 @@ DOM::Element* StackOfOpenElements::topmost_special_node_below(const DOM::Element
         auto& element = m_elements[i];
         if (&element == &formatting_element)
             break;
-        if (HTMLDocumentParser::is_special_tag(element.local_name()))
+        if (HTMLDocumentParser::is_special_tag(element.local_name(), element.namespace_()))
             found_element = &element;
     }
     return found_element;

--- a/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -35,6 +35,7 @@
 #include <LibWeb/HTML/Parser/HTMLDocumentParser.h>
 #include <LibWeb/Loader/FrameLoader.h>
 #include <LibWeb/Loader/ResourceLoader.h>
+#include <LibWeb/Namespace.h>
 #include <LibWeb/Page/Frame.h>
 #include <LibWeb/Page/Page.h>
 
@@ -78,7 +79,7 @@ static RefPtr<DOM::Document> create_text_document(const ByteBuffer& data, const 
     auto body_element = document->create_element("body");
     html_element->append_child(body_element);
 
-    auto pre_element = create_element(document, "pre");
+    auto pre_element = document->create_element("pre");
     body_element->append_child(pre_element);
 
     pre_element->append_child(document->create_text_node(String::copy(data)));
@@ -93,22 +94,22 @@ static RefPtr<DOM::Document> create_image_document(const ByteBuffer& data, const
     auto bitmap = image_decoder->bitmap();
     ASSERT(bitmap);
 
-    auto html_element = create_element(document, "html");
+    auto html_element = document->create_element("html");
     document->append_child(html_element);
 
-    auto head_element = create_element(document, "head");
+    auto head_element = document->create_element("head");
     html_element->append_child(head_element);
-    auto title_element = create_element(document, "title");
+    auto title_element = document->create_element("title");
     head_element->append_child(title_element);
 
     auto basename = LexicalPath(url.path()).basename();
     auto title_text = adopt(*new DOM::Text(document, String::format("%s [%dx%d]", basename.characters(), bitmap->width(), bitmap->height())));
     title_element->append_child(title_text);
 
-    auto body_element = create_element(document, "body");
+    auto body_element = document->create_element("body");
     html_element->append_child(body_element);
 
-    auto image_element = create_element(document, "img");
+    auto image_element = document->create_element("img");
     image_element->set_attribute(HTML::AttributeNames::src, url.to_string());
     body_element->append_child(image_element);
 

--- a/Libraries/LibWeb/Namespace.cpp
+++ b/Libraries/LibWeb/Namespace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, The SerenityOS developers.
+ * Copyright (c) 2020, the SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,22 +24,29 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include <LibWeb/Namespace.h>
 
-#include <LibWeb/HTML/HTMLElement.h>
+namespace Web::Namespace {
 
-namespace Web::HTML {
+#define __ENUMERATE_NAMESPACE(name, namespace_) FlyString name;
+ENUMERATE_NAMESPACES
+#undef __ENUMERATE_NAMESPACE
 
-class HTMLAreaElement final : public HTMLElement {
-public:
-    using WrapperType = Bindings::HTMLAreaElementWrapper;
+    // clang-format off
+// FIXME: clang-format gets confused here. Why?
+[[gnu::constructor]] static void initialize()
+// clang-format on
+{
+    static bool s_initialized = false;
+    if (s_initialized)
+        return;
 
-    HTMLAreaElement(DOM::Document&, const QualifiedName& qualified_name);
-    virtual ~HTMLAreaElement() override;
-};
+#define __ENUMERATE_NAMESPACE(name, namespace_) \
+    name = namespace_;
+    ENUMERATE_NAMESPACES
+#undef __ENUMERATE_NAMESPACE
 
+    s_initialized = true;
 }
 
-AK_BEGIN_TYPE_TRAITS(Web::HTML::HTMLAreaElement)
-static bool is_type(const Web::DOM::Node& node) { return node.is_html_element() && downcast<Web::HTML::HTMLElement>(node).local_name() == Web::HTML::TagNames::area; }
-AK_END_TYPE_TRAITS()
+}

--- a/Libraries/LibWeb/Namespace.h
+++ b/Libraries/LibWeb/Namespace.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, The SerenityOS developers.
+ * Copyright (c) 2020, the SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,20 +26,20 @@
 
 #pragma once
 
-#include <LibWeb/HTML/HTMLElement.h>
+#include <AK/FlyString.h>
 
-namespace Web::HTML {
+namespace Web::Namespace {
 
-class HTMLAreaElement final : public HTMLElement {
-public:
-    using WrapperType = Bindings::HTMLAreaElementWrapper;
+#define ENUMERATE_NAMESPACES                                            \
+    __ENUMERATE_NAMESPACE(HTML, "http://www.w3.org/1999/xhtml")         \
+    __ENUMERATE_NAMESPACE(MathML, "http://www.w3.org/1998/Math/MathML") \
+    __ENUMERATE_NAMESPACE(SVG, "http://www.w3.org/2000/svg")            \
+    __ENUMERATE_NAMESPACE(XLink, "http://www.w3.org/1999/xlink")        \
+    __ENUMERATE_NAMESPACE(XML, "http://www.w3.org/XML/1998/namespace")  \
+    __ENUMERATE_NAMESPACE(XMLNS, "http://www.w3.org/2000/xmlns/")
 
-    HTMLAreaElement(DOM::Document&, const QualifiedName& qualified_name);
-    virtual ~HTMLAreaElement() override;
-};
+#define __ENUMERATE_NAMESPACE(name, namespace_) extern FlyString name;
+ENUMERATE_NAMESPACES
+#undef __ENUMERATE_NAMESPACE
 
 }
-
-AK_BEGIN_TYPE_TRAITS(Web::HTML::HTMLAreaElement)
-static bool is_type(const Web::DOM::Node& node) { return node.is_html_element() && downcast<Web::HTML::HTMLElement>(node).local_name() == Web::HTML::TagNames::area; }
-AK_END_TYPE_TRAITS()

--- a/Libraries/LibWeb/QualifiedName.h
+++ b/Libraries/LibWeb/QualifiedName.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, The SerenityOS developers.
+ * Copyright (c) 2020, the SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,20 +26,27 @@
 
 #pragma once
 
-#include <LibWeb/HTML/HTMLElement.h>
+#include <AK/FlyString.h>
 
-namespace Web::HTML {
+namespace Web {
 
-class HTMLAreaElement final : public HTMLElement {
+class QualifiedName {
 public:
-    using WrapperType = Bindings::HTMLAreaElementWrapper;
+    QualifiedName(const FlyString& local_name, const FlyString& prefix, const FlyString& namespace_)
+        : m_local_name(local_name)
+        , m_prefix(prefix)
+        , m_namespace(namespace_)
+    {
+    }
 
-    HTMLAreaElement(DOM::Document&, const QualifiedName& qualified_name);
-    virtual ~HTMLAreaElement() override;
+    const FlyString& local_name() const { return m_local_name; }
+    const FlyString& prefix() const { return m_prefix; }
+    const FlyString& namespace_() const { return m_namespace; }
+
+private:
+    FlyString m_local_name;
+    FlyString m_prefix;
+    FlyString m_namespace;
 };
 
 }
-
-AK_BEGIN_TYPE_TRAITS(Web::HTML::HTMLAreaElement)
-static bool is_type(const Web::DOM::Node& node) { return node.is_html_element() && downcast<Web::HTML::HTMLElement>(node).local_name() == Web::HTML::TagNames::area; }
-AK_END_TYPE_TRAITS()

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::SVG {
 
-SVGElement::SVGElement(DOM::Document& document, const FlyString& tag_name)
-    : Element(document, tag_name)
+SVGElement::SVGElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : Element(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -37,7 +37,7 @@ public:
     virtual bool is_graphics_element() const { return false; }
 
 protected:
-    SVGElement(DOM::Document&, const FlyString& tag_name);
+    SVGElement(DOM::Document&, const QualifiedName& qualified_name);
 
 private:
     virtual bool is_svg_element() const final { return true; }

--- a/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::SVG {
 
-SVGGeometryElement::SVGGeometryElement(DOM::Document& document, const FlyString& tag_name)
-    : SVGGraphicsElement(document, tag_name)
+SVGGeometryElement::SVGGeometryElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : SVGGraphicsElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/SVG/SVGGeometryElement.h
+++ b/Libraries/LibWeb/SVG/SVGGeometryElement.h
@@ -35,7 +35,7 @@ public:
     using WrapperType = Bindings::SVGGeometryElementWrapper;
 
 protected:
-    SVGGeometryElement(DOM::Document& document, const FlyString& tag_name);
+    SVGGeometryElement(DOM::Document& document, const QualifiedName& qualified_name);
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -28,8 +28,8 @@
 
 namespace Web::SVG {
 
-SVGGraphicsElement::SVGGraphicsElement(DOM::Document& document, const FlyString& tag_name)
-    : SVGElement(document, tag_name)
+SVGGraphicsElement::SVGGraphicsElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : SVGElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -37,7 +37,7 @@ class SVGGraphicsElement : public SVGElement {
 public:
     using WrapperType = Bindings::SVGGraphicsElementWrapper;
 
-    SVGGraphicsElement(DOM::Document&, const FlyString& tag_name);
+    SVGGraphicsElement(DOM::Document&, const QualifiedName& qualified_name);
 
     virtual void parse_attribute(const FlyString& name, const String& value) override;
 

--- a/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -425,8 +425,8 @@ bool PathDataParser::match_coordinate() const
     return !done() && (isdigit(ch()) || ch() == '-' || ch() == '+' || ch() == '.');
 }
 
-SVGPathElement::SVGPathElement(DOM::Document& document, const FlyString& tag_name)
-    : SVGGeometryElement(document, tag_name)
+SVGPathElement::SVGPathElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : SVGGeometryElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -106,7 +106,7 @@ class SVGPathElement final : public SVGGeometryElement {
 public:
     using WrapperType = Bindings::SVGPathElementWrapper;
 
-    SVGPathElement(DOM::Document&, const FlyString& tag_name);
+    SVGPathElement(DOM::Document&, const QualifiedName& qualified_name);
     virtual ~SVGPathElement() override = default;
 
     virtual RefPtr<LayoutNode> create_layout_node(const CSS::StyleProperties* parent_style) override;

--- a/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -35,8 +35,8 @@
 
 namespace Web::SVG {
 
-SVGSVGElement::SVGSVGElement(DOM::Document& document, const FlyString& tag_name)
-    : SVGGraphicsElement(document, tag_name)
+SVGSVGElement::SVGSVGElement(DOM::Document& document, const QualifiedName& qualified_name)
+    : SVGGraphicsElement(document, qualified_name)
 {
 }
 

--- a/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -35,7 +35,7 @@ class SVGSVGElement final : public SVGGraphicsElement {
 public:
     using WrapperType = Bindings::SVGSVGElementWrapper;
 
-    SVGSVGElement(DOM::Document&, const FlyString& tag_name);
+    SVGSVGElement(DOM::Document&, const QualifiedName& qualified_name);
 
     virtual RefPtr<LayoutNode> create_layout_node(const CSS::StyleProperties* parent_style) override;
 

--- a/Libraries/LibWeb/SVG/TagNames.cpp
+++ b/Libraries/LibWeb/SVG/TagNames.cpp
@@ -35,7 +35,7 @@ ENUMERATE_SVG_TAGS
     // clang-format off
 // FIXME: clang-format gets confused here. Why?
 [[gnu::constructor]] static void initialize()
-// clang-format off
+// clang-format on
 {
     static bool s_initialized = false;
     if (s_initialized)

--- a/Libraries/LibWeb/SVG/TagNames.h
+++ b/Libraries/LibWeb/SVG/TagNames.h
@@ -31,8 +31,8 @@
 namespace Web::SVG::TagNames {
 
 #define ENUMERATE_SVG_GRAPHICS_TAGS \
-    __ENUMERATE_SVG_TAG(svg)        \
-    __ENUMERATE_SVG_TAG(path)
+    __ENUMERATE_SVG_TAG(path)       \
+    __ENUMERATE_SVG_TAG(svg)
 
 #define ENUMERATE_SVG_TAGS \
     ENUMERATE_SVG_GRAPHICS_TAGS

--- a/Libraries/LibWeb/SVG/TagNames.h
+++ b/Libraries/LibWeb/SVG/TagNames.h
@@ -34,8 +34,12 @@ namespace Web::SVG::TagNames {
     __ENUMERATE_SVG_TAG(path)       \
     __ENUMERATE_SVG_TAG(svg)
 
-#define ENUMERATE_SVG_TAGS \
-    ENUMERATE_SVG_GRAPHICS_TAGS
+#define ENUMERATE_SVG_TAGS             \
+    ENUMERATE_SVG_GRAPHICS_TAGS        \
+    __ENUMERATE_SVG_TAG(desc)          \
+    __ENUMERATE_SVG_TAG(foreignObject) \
+    __ENUMERATE_SVG_TAG(script)        \
+    __ENUMERATE_SVG_TAG(title)
 
 #define __ENUMERATE_SVG_TAG(name) extern FlyString name;
 ENUMERATE_SVG_TAGS

--- a/Libraries/LibWeb/Tests/DOM/Element.js
+++ b/Libraries/LibWeb/Tests/DOM/Element.js
@@ -21,4 +21,19 @@ afterInitialPageLoad(() => {
 how this text
 is interpreted below.  `);
     });
+
+    test("Element.namespaceURI basics", () => {
+        const htmlNamespace = "http://www.w3.org/1999/xhtml";
+        const p = document.getElementsByTagName("p")[0];
+        expect(p.namespaceURI).toBe(htmlNamespace);
+
+        // createElement always sets the namespace to the HTML namespace in HTML documents.
+        const svgElement = document.createElement("svg");
+        expect(svgElement.namespaceURI).toBe(htmlNamespace);
+
+        const svgNamespace = "http://www.w3.org/2000/svg";
+        p.innerHTML = "<svg></svg>";
+        const domSVGElement = p.getElementsByTagName("svg")[0];
+        expect(domSVGElement.namespaceURI).toBe(svgNamespace);
+    });
 });


### PR DESCRIPTION
LibWeb: Use modern namespaces and fix clang-format comments in tag names

-----

LibWeb: Add namespace to Element

-----

LibWeb: Add initial implementation of foreign content parsing

Plus sneak in a FIXME for the list of active formatting elements
and a test for Element.namespaceURI