### PR TITLE
js: Print negative zero with minus sign

### DIFF
--- a/Userland/js.cpp
+++ b/Userland/js.cpp
@@ -280,6 +280,8 @@ static void print_value(JS::Value value, HashTable<JS::Object*>& seen_objects)
         printf("\033[34;1m");
     if (value.is_string())
         putchar('"');
+    else if (value.is_negative_zero())
+        putchar('-');
     printf("%s", value.to_string_without_side_effects().characters());
     if (value.is_string())
         putchar('"');


### PR DESCRIPTION
Node.js or the Firefox browser console do this too, and I think it's quite useful.

I decided to not do this on a LibJS level as `Value::to_string()` omits the minus sign so `Value::to_string_without_side_effects()`, which we use in `js`, shouldn't have it either. Since we have `Value::is_negative_zero()` though it's super simple to implement anyway.