### PR TITLE
LibC: Make difftime a function

### DIFF
--- a/Libraries/LibC/time.cpp
+++ b/Libraries/LibC/time.cpp
@@ -362,4 +362,9 @@ int clock_getres(clockid_t, struct timespec*)
 {
     ASSERT_NOT_REACHED();
 }
+
+double difftime(time_t t1, time_t t0)
+{
+    return (double)(t1 - t0);
+}
 }

--- a/Libraries/LibC/time.h
+++ b/Libraries/LibC/time.h
@@ -85,6 +85,4 @@ struct tm* localtime_r(const time_t* timep, struct tm* result);
 double difftime(time_t, time_t);
 size_t strftime(char* s, size_t max, const char* format, const struct tm*);
 
-#define difftime(t1, t0) (double)(t1 - t0)
-
 __END_DECLS


### PR DESCRIPTION
The previous define led to issues when compiling some ports, namely zsh
5.8.