### PR TITLE
AK: Fix the build on macOS

### DIFF
--- a/AK/TestSuite.h
+++ b/AK/TestSuite.h
@@ -28,7 +28,9 @@
 
 #define AK_TEST_SUITE
 
+#ifndef __APPLE__
 extern "C" __attribute__((noreturn)) void abort() noexcept;
+#endif
 
 namespace AK {
 


### PR DESCRIPTION
The `abort` function declaration was conflicting with macOS libc.
