### PR TITLE
Base64: Pre-allocate size of input and output

### DIFF
--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -26,10 +26,16 @@
 
 #pragma once
 
-#include <AK/Forward.h>
+#include <AK/ByteBuffer.h>
 #include <AK/Span.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
 
 namespace AK {
+
+size_t calculate_base64_decoded_length(const StringView&);
+
+size_t calculate_base64_encoded_length(ReadonlyBytes);
 
 ByteBuffer decode_base64(const StringView&);
 

--- a/AK/Tests/TestBase64.cpp
+++ b/AK/Tests/TestBase64.cpp
@@ -35,6 +35,7 @@ TEST_CASE(test_decode)
     auto decode_equal = [&](const char* input, const char* expected) {
         auto decoded = decode_base64(StringView(input));
         EXPECT(String::copy(decoded) == String(expected));
+        EXPECT(StringView(expected).length() <= calculate_base64_decoded_length(StringView(input).bytes()));
     };
 
     decode_equal("", "");
@@ -51,6 +52,7 @@ TEST_CASE(test_encode)
     auto encode_equal = [&](const char* input, const char* expected) {
         auto encoded = encode_base64({ input, strlen(input) });
         EXPECT(encoded == String(expected));
+        EXPECT_EQ(StringView(expected).length(), calculate_base64_encoded_length(StringView(input).bytes()));
     };
 
     encode_equal("", "");


### PR DESCRIPTION
Problem:
- Output of decode and encode grow as the decode and encode
  happen. This is inefficient because a large size will require many
  reallocations.
- `const` qualifiers are missing on variables which are not intended
  to change.

Solution:
- Since the size of the decoded or encoded message is known prior to
  starting, calculate the size and set the output to that size
  immediately. All appends will not incur the reallocation overhead.
- Add `const` qualifiers to show intent.