### PR TITLE
LibJS: Don't assume value for index < size in IndexedPropertyIterator

### DIFF
--- a/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -262,7 +262,7 @@ bool IndexedPropertyIterator::operator!=(const IndexedPropertyIterator& other) c
 ValueAndAttributes IndexedPropertyIterator::value_and_attributes(Object* this_object, bool evaluate_accessors)
 {
     if (m_index < m_indexed_properties.array_like_size())
-        return m_indexed_properties.get(this_object, m_index, evaluate_accessors).value();
+        return m_indexed_properties.get(this_object, m_index, evaluate_accessors).value_or({});
     return {};
 }
 


### PR DESCRIPTION
This assumption only works for the `m_packed_elements` `Vector` where a missing value at a certain index still returns an empty value, but not for the `m_sparse_elements` `HashMap`, which is being used for indices >= 200 - in that case the `Optional<ValueAndAttributes>` result will not have a value.

This fixes a crash in the js REPL where printing an array with a hole at any index >= 200 would crash.