### PR TITLE
AK: Don't forward declare abort.

### DIFF
--- a/AK/TestSuite.h
+++ b/AK/TestSuite.h
@@ -28,8 +28,6 @@
 
 #define AK_TEST_SUITE
 
-extern "C" __attribute__((noreturn)) void abort() noexcept;
-
 namespace AK {
 
 template<typename... Parameters>
@@ -62,6 +60,8 @@ using AK::warnln;
         ::AK::warnln(stderr, "\033[31;1mFAIL\033[0m: {}:{}: TODO() called", __FILE__, __LINE__); \
         ::abort();                                                                               \
     } while (false)
+
+#include <stdlib.h>
 
 #include <AK/Format.h>
 #include <AK/Function.h>


### PR DESCRIPTION
I wanted to reopen #3723 but I could not because I force pushed the abort branch before reopening it, GitHub does not like that.

I am following @bugaevc's suggestion here: [#3760 (comment)](https://github.com/SerenityOS/serenity/pull/3760#issuecomment-708257134).
