### PR TITLE
Shell: Some formatter/highlighting fixups

### DIFF
--- a/Shell/Formatter.cpp
+++ b/Shell/Formatter.cpp
@@ -140,7 +140,7 @@ void Formatter::visit(const AST::And* node)
 {
     will_visit(node);
     test_and_update_output_cursor(node);
-    auto should_indent = m_parent_node && m_parent_node->class_name() != "And";
+    auto should_indent = m_parent_node && m_parent_node->kind() != AST::Node::Kind::And;
     TemporaryChange<const AST::Node*> parent { m_parent_node, node };
 
     with_added_indent(should_indent ? 1 : 0, [&] {
@@ -370,7 +370,7 @@ void Formatter::visit(const AST::IfCond* node)
 
     if (node->false_branch()) {
         current_builder().append(" else ");
-        if (node->false_branch()->class_name() != "IfCond") {
+        if (node->false_branch()->kind() != AST::Node::Kind::IfCond) {
             in_new_block([&] {
                 node->false_branch()->visit(*this);
             });
@@ -446,7 +446,7 @@ void Formatter::visit(const AST::Or* node)
 {
     will_visit(node);
     test_and_update_output_cursor(node);
-    auto should_indent = m_parent_node && m_parent_node->class_name() != "Or";
+    auto should_indent = m_parent_node && m_parent_node->kind() != AST::Node::Kind::Or;
     TemporaryChange<const AST::Node*> parent { m_parent_node, node };
 
     with_added_indent(should_indent ? 1 : 0, [&] {
@@ -465,7 +465,7 @@ void Formatter::visit(const AST::Pipe* node)
 {
     will_visit(node);
     test_and_update_output_cursor(node);
-    auto should_indent = m_parent_node && m_parent_node->class_name() != "Pipe";
+    auto should_indent = m_parent_node && m_parent_node->kind() != AST::Node::Kind::Pipe;
     TemporaryChange<const AST::Node*> parent { m_parent_node, node };
 
     node->left()->visit(*this);

--- a/Shell/Formatter.cpp
+++ b/Shell/Formatter.cpp
@@ -373,6 +373,7 @@ void Formatter::visit(const AST::MatchExpr* node)
                 option.visit(*this);
             }
 
+            current_builder().append(' ');
             in_new_block([&] {
                 if (entry.body)
                     entry.body->visit(*this);

--- a/Shell/Formatter.h
+++ b/Shell/Formatter.h
@@ -92,6 +92,8 @@ private:
     virtual void visit(const AST::WriteRedirection*) override;
 
     void test_and_update_output_cursor(const AST::Node*);
+    void visited(const AST::Node*);
+    void will_visit(const AST::Node*);
     void insert_separator();
     void insert_indent();
 
@@ -118,6 +120,7 @@ private:
     AST::Node* m_hit_node { nullptr };
 
     const AST::Node* m_parent_node { nullptr };
+    const AST::Node* m_last_visited_node { nullptr };
 
     StringView m_trivia;
 };


### PR DESCRIPTION
Nothing major, just makes the formatted source a bit less condensed.
```
foo


bar

baz
well hello friends && echo 123
```
->
```
foo

bar

baz
well hello friends \
  && echo 123
```

Also fixes the wrong highlight behaviour when a newline is used as sequence separator:
```sh
echo foo
if foo {}
^ This character would previously be bold
```