### PR TITLE
FileManager: Only set ~/Desktop as model root path in desktop mode

### DIFF
--- a/Applications/FileManager/DirectoryView.cpp
+++ b/Applications/FileManager/DirectoryView.cpp
@@ -158,7 +158,8 @@ const GUI::FileSystemModel::Node& DirectoryView::node(const GUI::ModelIndex& ind
 
 void DirectoryView::setup_model()
 {
-    m_model->set_root_path(Core::StandardPaths::desktop_directory());
+    if (is_desktop())
+        m_model->set_root_path(Core::StandardPaths::desktop_directory());
 
     m_model->on_error = [this](int, const char* error_string) {
         auto failed_path = m_model->root_path();


### PR DESCRIPTION
Setting it as model root path in `DirectoryView::setup_model()` for windowed mode as well would cause an issue with the following:

- "open ~/Desktop"
- "FileManager ~/Desktop"
- "Show in FileManager..." from Desktop context menu

When viewing the Desktop as the initial path it would be the same and `on_path_change` wasn't called, leading to various widgets and window properties not being updated.

Fixes #3772.