### PR TITLE
Kernel: Fix sys$join_thread

### DIFF
--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -137,7 +137,7 @@ int Process::sys$join_thread(pid_t tid, Userspace<void**> exit_value)
             break;
         }
         if (result == Thread::BlockResult::InterruptedByDeath)
-            return 0; // we're not going to return back to user mode
+            break;
     }
 
     if (exit_value && !copy_to_user(exit_value, &joinee_exit_value))


### PR DESCRIPTION
Previously, when we unblocked because the joinee has died, we didn't
copy its exit value back to the user.

running `tt` now works as expected, and prints out:
`Okay, joined and got retval=0xdeadbeef`