### PR TITLE
Span: constexpr support

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -38,9 +38,9 @@ namespace Detail {
 template<typename T>
 class Span {
 public:
-    ALWAYS_INLINE Span() = default;
+    ALWAYS_INLINE constexpr Span() = default;
 
-    ALWAYS_INLINE Span(T* values, size_t size)
+    ALWAYS_INLINE constexpr Span(T* values, size_t size)
         : m_values(values)
         , m_size(size)
     {
@@ -54,9 +54,9 @@ protected:
 template<>
 class Span<u8> {
 public:
-    ALWAYS_INLINE Span() = default;
+    ALWAYS_INLINE constexpr Span() = default;
 
-    ALWAYS_INLINE Span(u8* values, size_t size)
+    ALWAYS_INLINE constexpr Span(u8* values, size_t size)
         : m_values(values)
         , m_size(size)
     {
@@ -75,9 +75,9 @@ protected:
 template<>
 class Span<const u8> {
 public:
-    ALWAYS_INLINE Span() = default;
+    ALWAYS_INLINE constexpr Span() = default;
 
-    ALWAYS_INLINE Span(const u8* values, size_t size)
+    ALWAYS_INLINE constexpr Span(const u8* values, size_t size)
         : m_values(values)
         , m_size(size)
     {
@@ -105,18 +105,18 @@ class Span : public Detail::Span<T> {
 public:
     using Detail::Span<T>::Span;
 
-    ALWAYS_INLINE Span(std::nullptr_t)
+    ALWAYS_INLINE constexpr Span(std::nullptr_t)
         : Span()
     {
     }
 
-    ALWAYS_INLINE Span(const Span& other)
+    ALWAYS_INLINE constexpr Span(const Span& other)
         : Span(other.m_values, other.m_size)
     {
     }
 
-    ALWAYS_INLINE const T* data() const { return this->m_values; }
-    ALWAYS_INLINE T* data() { return this->m_values; }
+    ALWAYS_INLINE constexpr const T* data() const { return this->m_values; }
+    ALWAYS_INLINE constexpr T* data() { return this->m_values; }
 
     using ConstIterator = SimpleIterator<const Span, const T>;
     using Iterator = SimpleIterator<Span, T>;
@@ -127,45 +127,45 @@ public:
     constexpr ConstIterator end() const { return ConstIterator::end(*this); }
     constexpr Iterator end() { return Iterator::end(*this); }
 
-    ALWAYS_INLINE size_t size() const { return this->m_size; }
+    ALWAYS_INLINE constexpr size_t size() const { return this->m_size; }
 
-    ALWAYS_INLINE bool is_empty() const { return this->m_size == 0; }
+    ALWAYS_INLINE constexpr bool is_empty() const { return this->m_size == 0; }
 
-    ALWAYS_INLINE Span slice(size_t start, size_t length) const
+    ALWAYS_INLINE constexpr Span slice(size_t start, size_t length) const
     {
         ASSERT(start + length <= size());
         return { this->m_values + start, length };
     }
-    ALWAYS_INLINE Span slice(size_t start) const
+    ALWAYS_INLINE constexpr Span slice(size_t start) const
     {
         ASSERT(start <= size());
         return { this->m_values + start, size() - start };
     }
 
-    ALWAYS_INLINE Span trim(size_t length) const
+    ALWAYS_INLINE constexpr Span trim(size_t length) const
     {
         return { this->m_values, min(size(), length) };
     }
 
-    ALWAYS_INLINE T* offset(size_t start) const
+    ALWAYS_INLINE constexpr T* offset(size_t start) const
     {
         ASSERT(start < this->m_size);
         return this->m_values + start;
     }
 
-    ALWAYS_INLINE size_t copy_to(Span<typename RemoveConst<T>::Type> other) const
+    ALWAYS_INLINE constexpr size_t copy_to(Span<typename RemoveConst<T>::Type> other) const
     {
         ASSERT(other.size() >= size());
         return TypedTransfer<typename RemoveConst<T>::Type>::copy(other.data(), data(), size());
     }
 
-    ALWAYS_INLINE size_t copy_trimmed_to(Span<typename RemoveConst<T>::Type> other) const
+    ALWAYS_INLINE constexpr size_t copy_trimmed_to(Span<typename RemoveConst<T>::Type> other) const
     {
         const auto count = min(size(), other.size());
         return TypedTransfer<typename RemoveConst<T>::Type>::copy(other.data(), data(), count);
     }
 
-    ALWAYS_INLINE size_t fill(const T& value)
+    ALWAYS_INLINE constexpr size_t fill(const T& value)
     {
         for (size_t idx = 0; idx < size(); ++idx)
             data()[idx] = value;
@@ -173,7 +173,7 @@ public:
         return size();
     }
 
-    bool contains_slow(const T& value) const
+    bool constexpr contains_slow(const T& value) const
     {
         for (size_t i = 0; i < size(); ++i) {
             if (at(i) == value)
@@ -182,34 +182,34 @@ public:
         return false;
     }
 
-    ALWAYS_INLINE const T& at(size_t index) const
+    ALWAYS_INLINE constexpr const T& at(size_t index) const
     {
         ASSERT(index < this->m_size);
         return this->m_values[index];
     }
-    ALWAYS_INLINE T& at(size_t index)
+    ALWAYS_INLINE constexpr T& at(size_t index)
     {
         ASSERT(index < this->m_size);
         return this->m_values[index];
     }
 
-    ALWAYS_INLINE T& operator[](size_t index) const
+    ALWAYS_INLINE constexpr T& operator[](size_t index) const
     {
         return this->m_values[index];
     }
-    ALWAYS_INLINE T& operator[](size_t index)
+    ALWAYS_INLINE constexpr T& operator[](size_t index)
     {
         return this->m_values[index];
     }
 
-    ALWAYS_INLINE Span& operator=(const Span<T>& other)
+    ALWAYS_INLINE constexpr Span& operator=(const Span<T>& other)
     {
         this->m_size = other.m_size;
         this->m_values = other.m_values;
         return *this;
     }
 
-    bool operator==(Span<const T> other) const
+    constexpr bool operator==(Span<const T> other) const
     {
         if (size() != other.size())
             return false;
@@ -217,7 +217,7 @@ public:
         return TypedTransfer<T>::compare(data(), other.data(), size());
     }
 
-    ALWAYS_INLINE operator Span<const T>() const
+    ALWAYS_INLINE constexpr operator Span<const T>() const
     {
         return { data(), size() };
     }

--- a/AK/Tests/TestSpan.cpp
+++ b/AK/Tests/TestSpan.cpp
@@ -30,26 +30,26 @@
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 
-TEST_CASE(default_constructor_is_empty)
+TEST_CASE(constexpr_default_constructor_is_empty)
 {
-    Span<int> span;
-    EXPECT(span.is_empty());
+    constexpr Span<int> span;
+    static_assert(span.is_empty(), "Default constructed span should be empty.");
 }
 
 TEST_CASE(implicit_converson_to_const)
 {
-    Bytes bytes0;
-    [[maybe_unused]] ReadonlyBytes bytes2 = bytes0;
-    [[maybe_unused]] ReadonlyBytes bytes3 = static_cast<ReadonlyBytes>(bytes2);
+    constexpr Bytes bytes0;
+    [[maybe_unused]] constexpr ReadonlyBytes bytes2 = bytes0;
+    [[maybe_unused]] constexpr ReadonlyBytes bytes3 = static_cast<ReadonlyBytes>(bytes2);
 }
 
 TEST_CASE(span_works_with_constant_types)
 {
-    const u8 buffer[4] { 1, 2, 3, 4 };
-    ReadonlyBytes bytes { buffer, 4 };
+    static constexpr u8 buffer[4] { 1, 2, 3, 4 };
+    constexpr ReadonlyBytes bytes { buffer, 4 };
 
-    EXPECT(AK::IsConst<AK::RemoveReference<decltype(bytes[1])>::Type>::value);
-    EXPECT_EQ(bytes[2], 3);
+    static_assert(AK::IsConst<AK::RemoveReference<decltype(bytes[1])>::Type>::value);
+    static_assert(bytes[2] == 3);
 }
 
 TEST_CASE(span_works_with_mutable_types)
@@ -109,25 +109,25 @@ TEST_CASE(at_and_index_operator_return_same_value)
 
 TEST_CASE(can_subspan_whole_span)
 {
-    u8 buffer[16];
-    Bytes bytes { buffer, 16 };
+    static constexpr u8 buffer[16] {};
+    constexpr ReadonlyBytes bytes { buffer, 16 };
 
-    Bytes slice = bytes.slice(0, 16);
+    constexpr auto slice = bytes.slice(0, 16);
 
-    EXPECT_EQ(slice.data(), buffer);
-    EXPECT_EQ(slice.size(), 16u);
+    static_assert(slice.data() == buffer);
+    static_assert(slice.size() == 16u);
 }
 
 TEST_CASE(can_subspan_as_intended)
 {
-    const u16 buffer[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
+    static constexpr u16 buffer[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
 
-    Span<const u16> span { buffer, 8 };
-    auto slice = span.slice(3, 2);
+    constexpr Span<const u16> span { buffer, 8 };
+    constexpr auto slice = span.slice(3, 2);
 
-    EXPECT_EQ(slice.size(), 2u);
-    EXPECT_EQ(slice[0], 4);
-    EXPECT_EQ(slice[1], 5);
+    static_assert(slice.size() == 2u);
+    static_assert(slice[0] == 4);
+    static_assert(slice[1] == 5);
 }
 
 TEST_CASE(span_from_void_pointer)


### PR DESCRIPTION
Problem:
- `Span` is not `constexpr` aware.

Solution:
- Add `constexpr` support for all parts that do not require
  `reinterpret_cast`.
- Modify tests which use the `constexpr` functions.