### PR TITLE
probing comparison

### DIFF
--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -87,7 +87,11 @@ class CircularQueue;
 template<typename T>
 struct Traits;
 
-template<typename T, typename = Traits<T>>
+struct LinearProbing;
+struct QuadraticProbing;
+struct DoubleHashProbing;
+
+template<typename T, typename = Traits<T>, typename = LinearProbing>
 class HashTable;
 
 template<typename K, typename V, typename = Traits<K>>


### PR DESCRIPTION
This is what I meant on IRC. On more careful measurement, `ministat` can't find any difference between the 3 schemes. I ran `test-js` 6 times each (with warmup), and the output is

```
$ ministat -A doublehash.txt linear.txt quadratic.txt 
x doublehash.txt
+ linear.txt
* quadratic.txt
    N           Min           Max        Median           Avg        Stddev
x   6           890           991           903         917.5     38.898586
+   6           860           951           898         903.5     36.626493
No difference proven at 95.0% confidence
*   6           850           955           908     903.83333     38.049529
No difference proven at 95.0% confidence
```

So no need to merge this, but maybe it's interesting.