### PR TITLE
CircularQueue: constexpr support

### DIFF
--- a/AK/CircularDuplexStream.h
+++ b/AK/CircularDuplexStream.h
@@ -124,7 +124,7 @@ public:
     {
         ASSERT(count <= remaining_contigous_space());
 
-        Bytes bytes { m_queue.m_storage + (m_queue.head_index() + m_queue.size()) % Capacity, count };
+        Bytes bytes { m_queue.m_storage.data() + (m_queue.head_index() + m_queue.size()) % Capacity, count };
 
         m_queue.m_size += count;
         m_total_written += count;

--- a/AK/CircularQueue.h
+++ b/AK/CircularQueue.h
@@ -37,16 +37,19 @@ class CircularQueue {
     friend CircularDuplexStream<Capacity>;
 
 public:
-    CircularQueue()
+    constexpr CircularQueue() = default;
+    constexpr CircularQueue(const Array<T, Capacity * sizeof(T)>&& a)
+        : m_storage(a)
+        , m_size(Capacity)
     {
     }
 
-    ~CircularQueue()
+    constexpr ~CircularQueue()
     {
         clear();
     }
 
-    void clear()
+    constexpr void clear()
     {
         for (size_t i = 0; i < m_size; ++i)
             elements()[(m_head + i) % Capacity].~T();
@@ -55,49 +58,46 @@ public:
         m_size = 0;
     }
 
-    bool is_empty() const { return !m_size; }
-    size_t size() const { return m_size; }
+    constexpr bool is_empty() const { return !m_size; }
+    constexpr size_t size() const { return m_size; }
 
-    size_t capacity() const { return Capacity; }
+    constexpr size_t capacity() const { return Capacity; }
 
-    void enqueue(T&& value)
+    constexpr void enqueue(T&& value)
     {
         auto& slot = elements()[(m_head + m_size) % Capacity];
-        if (m_size == Capacity)
-            slot.~T();
-
-        new (&slot) T(move(value));
+        slot = value;
         if (m_size == Capacity)
             m_head = (m_head + 1) % Capacity;
         else
             ++m_size;
     }
 
-    void enqueue(const T& value)
+    constexpr void enqueue(const T& value)
     {
         enqueue(T(value));
     }
 
-    T dequeue()
+    constexpr T dequeue()
     {
         ASSERT(!is_empty());
         auto& slot = elements()[m_head];
         T value = move(slot);
-        slot.~T();
         m_head = (m_head + 1) % Capacity;
         --m_size;
         return value;
     }
 
-    const T& at(size_t index) const { return elements()[(m_head + index) % Capacity]; }
+    constexpr const T& at(size_t index) const { return elements()[(m_head + index) % Capacity]; }
 
-    const T& first() const { return at(0); }
-    const T& last() const { return at(size() - 1); }
+    constexpr const T& first() const { return at(0); }
+    constexpr const T& last() const { return at(size() - 1); }
 
     class ConstIterator {
     public:
-        bool operator!=(const ConstIterator& other) { return m_index != other.m_index; }
-        ConstIterator& operator++()
+        constexpr bool operator==(const ConstIterator& other) const { return m_index == other.m_index; }
+        constexpr bool operator!=(const ConstIterator& other) const { return m_index != other.m_index; }
+        constexpr ConstIterator& operator++()
         {
             m_index = (m_index + 1) % Capacity;
             if (m_index == m_queue.m_head)
@@ -105,11 +105,11 @@ public:
             return *this;
         }
 
-        const T& operator*() const { return m_queue.elements()[m_index]; }
+        constexpr const T& operator*() const { return m_queue.elements()[m_index]; }
 
     private:
         friend class CircularQueue;
-        ConstIterator(const CircularQueue& queue, const size_t index)
+        constexpr ConstIterator(const CircularQueue& queue, const size_t index)
             : m_queue(queue)
             , m_index(index)
         {
@@ -118,17 +118,17 @@ public:
         size_t m_index { 0 };
     };
 
-    ConstIterator begin() const { return ConstIterator(*this, m_head); }
-    ConstIterator end() const { return ConstIterator(*this, size()); }
+    constexpr ConstIterator begin() const { return ConstIterator(*this, m_head); }
+    constexpr ConstIterator end() const { return ConstIterator(*this, size()); }
 
-    size_t head_index() const { return m_head; }
+    constexpr size_t head_index() const { return m_head; }
 
 protected:
-    T* elements() { return reinterpret_cast<T*>(m_storage); }
-    const T* elements() const { return reinterpret_cast<const T*>(m_storage); }
+    constexpr T* elements() { return &m_storage[0]; }
+    constexpr const T* elements() const { return &m_storage[0]; }
 
     friend class ConstIterator;
-    alignas(T) u8 m_storage[sizeof(T) * Capacity];
+    alignas(T) Array<T, sizeof(T) * Capacity> m_storage {};
     size_t m_size { 0 };
     size_t m_head { 0 };
 };

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -82,7 +82,7 @@ inline constexpr T ceil_div(T a, U b)
 #    pragma clang diagnostic ignored "-Wconsumed"
 #endif
 template<typename T>
-inline T&& move(T& arg)
+constexpr T&& move(T& arg)
 {
     return static_cast<T&&>(arg);
 }

--- a/AK/Tests/TestCircularQueue.cpp
+++ b/AK/Tests/TestCircularQueue.cpp
@@ -75,4 +75,63 @@ TEST_CASE(complex_type_clear)
     EXPECT_EQ(strings.size(), 0u);
 }
 
+TEST_CASE(constexpr_construction)
+{
+    constexpr CircularQueue<int, 3> ints {};
+
+    static_assert(ints.is_empty());
+    static_assert(0u == ints.size());
+    static_assert(0u == ints.head_index());
+    static_assert(3 == ints.capacity());
+
+    static_assert(ints.begin() == ints.end());
+}
+
+TEST_CASE(constexpr_basic_operations)
+{
+    constexpr auto ints = [] {
+        CircularQueue<int, 3> ints = { { 1, 2, 3 } };
+        ints.dequeue();
+        return ints;
+    }();
+
+    static_assert(!ints.is_empty());
+    static_assert(2u == ints.size());
+    static_assert(1u == ints.head_index());
+    static_assert(3 == ints.capacity());
+
+    static_assert(2 == *ints.begin());
+    static_assert(3 == *(++ints.begin()));
+
+    static_assert(2 == ints.at(0));
+    static_assert(2 == ints.first());
+
+    static_assert(3 == ints.at(1));
+    static_assert(3 == ints.last());
+}
+
+TEST_CASE(constexpr_wrap_operations)
+{
+    constexpr auto ints = [] {
+        CircularQueue<int, 3> ints = { { 1, 2, 3 } };
+        ints.enqueue(4);
+        ints.dequeue();
+        return ints;
+    }();
+
+    static_assert(!ints.is_empty());
+    static_assert(2u == ints.size());
+    static_assert(2u == ints.head_index());
+    static_assert(3 == ints.capacity());
+
+    static_assert(3 == *ints.begin());
+    static_assert(4 == *(++ints.begin()));
+
+    static_assert(3 == ints.at(0));
+    static_assert(3 == ints.first());
+
+    static_assert(4 == ints.at(1));
+    static_assert(4 == ints.last());
+}
+
 TEST_MAIN(CircularQueue)


### PR DESCRIPTION
Problem:
- `CircularQueue` is not `constexpr` capable.

Solution:
- Add `constexpr` support to `AK::move()`.
- Add `constexpr` decoration to all member functions.
- Remove placement `new` in favor of simple `move` assignment.
- Remove explicit calls to destructor in favor of `move` assignment
  and let the underlying object call the destructor on subobjects if
  needed.
- Switch to `Array` instead of C-style array so that the type can be
  directly referenced without the need for `reinterpret_cast`.
- Add tests to ensure the compile-time evaluation.