### PR TITLE
ntpquery: Minor tweaks

### DIFF
--- a/AK/Random.h
+++ b/AK/Random.h
@@ -62,3 +62,6 @@ inline T get_random()
 }
 
 }
+
+using AK::fill_with_random;
+using AK::get_random;

--- a/Libraries/LibCore/Object.h
+++ b/Libraries/LibCore/Object.h
@@ -67,9 +67,9 @@ class Object
     AK_MAKE_NONCOPYABLE(Object);
     AK_MAKE_NONMOVABLE(Object);
 
-public:
     IntrusiveListNode m_all_objects_list_node;
 
+public:
     virtual ~Object();
 
     virtual const char* class_name() const = 0;

--- a/Userland/ntpquery.cpp
+++ b/Userland/ntpquery.cpp
@@ -250,7 +250,14 @@ int main(int argc, char** argv)
         printf("Precision: %d\n", packet.precision);
         printf("Root delay: %#x\n", ntohl(packet.root_delay));
         printf("Root dispersion: %#x\n", ntohl(packet.root_dispersion));
-        printf("Reference ID: %#x\n", ntohl(packet.reference_id));
+
+        u32 ref_id = ntohl(packet.reference_id);
+        printf("Reference ID: %#x", ref_id);
+        if (packet.stratum == 1) {
+            printf(" ('%c%c%c%c')", (ref_id & 0xff000000) >> 24, (ref_id & 0xff0000) >> 16, (ref_id & 0xff00) >> 8, ref_id & 0xff);
+        }
+        printf("\n");
+
         printf("Reference timestamp:   %#016llx (%s)\n", be64toh(packet.reference_timestamp), format_ntp_timestamp(be64toh(packet.reference_timestamp)).characters());
         printf("Origin timestamp:      %#016llx (%s)\n", origin_timestamp, format_ntp_timestamp(origin_timestamp).characters());
         printf("Receive timestamp:     %#016llx (%s)\n", receive_timestamp, format_ntp_timestamp(receive_timestamp).characters());

--- a/Userland/ntpquery.cpp
+++ b/Userland/ntpquery.cpp
@@ -112,6 +112,15 @@ int main(int argc, char** argv)
     bool set_time = false;
     bool verbose = false;
     // FIXME: Change to serenityos.pool.ntp.org once https://manage.ntppool.org/manage/vendor/zone?a=km5a8h&id=vz-14154g is approved.
+    // Other NTP servers:
+    // - time.nist.gov
+    // - time.apple.com
+    // - time.cloudflare.com (has NTS), https://blog.cloudflare.com/secure-time/
+    // - time.windows.com
+    //
+    // Leap seconds smearing NTP servers:
+    // - time.facebook.com , https://engineering.fb.com/production-engineering/ntp-service/ , sine-smears over 18 hours
+    // - time.google.com , https://developers.google.com/time/smear , linear-smears over 24 hours
     const char* host = "time.google.com";
     Core::ArgsParser args_parser;
     args_parser.add_option(set_time, "Adjust system time (requires root)", "set", 's');


### PR DESCRIPTION
Validate the response header some, and don't send local time to the server.

Also sneak in an unrelated tiny LibCore tweak.