### PR TITLE
CircularQueue: Ensure constructor does not construct any values

### DIFF
--- a/AK/Tests/TestCircularQueue.cpp
+++ b/AK/Tests/TestCircularQueue.cpp
@@ -75,4 +75,16 @@ TEST_CASE(complex_type_clear)
     EXPECT_EQ(strings.size(), 0u);
 }
 
+struct ConstructorCounter {
+    static unsigned s_num_constructor_calls;
+    ConstructorCounter() { ++s_num_constructor_calls; }
+};
+unsigned ConstructorCounter::s_num_constructor_calls = 0;
+
+TEST_CASE(should_not_call_value_type_constructor_when_created)
+{
+    CircularQueue<ConstructorCounter, 10> queue;
+    EXPECT_EQ(0u, ConstructorCounter::s_num_constructor_calls);
+}
+
 TEST_MAIN(CircularQueue)


### PR DESCRIPTION
Problem:
- There is no test which guarantees the CircularQueue does not
  construct any objects of the value type. The goal is to have
  uninitialized memory which can be used.

Solution:
- Add a test requiring that the constructor of the value type is never
  called.