### PR TITLE
AK::HashTable exception safety

### DIFF
--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -100,16 +100,12 @@ public:
 
     HashTable& operator=(const HashTable& other)
     {
-        if (this != &other) {
-            clear();
-            rehash(other.capacity());
-            for (auto& it : other)
-                set(it);
-        }
+        HashTable temporary(other);
+        swap(*this, temporary);
         return *this;
     }
 
-    HashTable(HashTable&& other)
+    HashTable(HashTable&& other) noexcept
         : m_buckets(other.m_buckets)
         , m_size(other.m_size)
         , m_capacity(other.m_capacity)
@@ -121,15 +117,9 @@ public:
         other.m_buckets = nullptr;
     }
 
-    HashTable& operator=(HashTable&& other)
+    HashTable& operator=(HashTable&& other) noexcept
     {
-        if (this != &other) {
-            clear();
-            m_buckets = exchange(other.m_buckets, nullptr);
-            m_size = exchange(other.m_size, 0);
-            m_capacity = exchange(other.m_capacity, 0);
-            m_deleted_count = exchange(other.m_deleted_count, 0);
-        }
+        swap(*this, other);
         return *this;
     }
 

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -89,7 +89,19 @@ class HashTable {
 public:
     HashTable() { }
     HashTable(size_t capacity) { rehash(capacity); }
-    ~HashTable() { clear(); }
+
+    ~HashTable()
+    {
+        if (!m_buckets)
+            return;
+
+        for (size_t i = 0; i < m_capacity; ++i) {
+            if (m_buckets[i].used)
+                m_buckets[i].slot()->~T();
+        }
+
+        kfree(m_buckets);
+    }
 
     HashTable(const HashTable& other)
     {
@@ -188,19 +200,7 @@ public:
 
     void clear()
     {
-        if (!m_buckets)
-            return;
-
-        for (size_t i = 0; i < m_capacity; ++i) {
-            if (m_buckets[i].used)
-                m_buckets[i].slot()->~T();
-        }
-
-        kfree(m_buckets);
-        m_buckets = nullptr;
-        m_capacity = 0;
-        m_size = 0;
-        m_deleted_count = 0;
+        *this = HashTable();
     }
 
     HashSetResult set(T&& value)

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -133,6 +133,14 @@ public:
         return *this;
     }
 
+    friend void swap(HashTable& a, HashTable& b) noexcept
+    {
+        swap(a.m_buckets, b.m_buckets);
+        swap(a.m_size, b.m_size);
+        swap(a.m_capacity, b.m_capacity);
+        swap(a.m_deleted_count, b.m_deleted_count);
+    }
+
     bool is_empty() const { return !m_size; }
     size_t size() const { return m_size; }
     size_t capacity() const { return m_capacity; }


### PR DESCRIPTION
Hello,

this PR hopefully improves `AK::HashTable` exception safety. I also included small refactor in the destructor, removing some writes to memory. I am not sure about the impact on performance. I would love to add some benchmark, but I am not sure how.

First contribution, I am a big fan :^)