### PR TITLE
LibJS: Fix parsing of invalid numeric literals

### DIFF
--- a/Libraries/LibJS/Lexer.h
+++ b/Libraries/LibJS/Lexer.h
@@ -42,7 +42,10 @@ public:
 
 private:
     void consume();
-    void consume_exponent();
+    bool consume_exponent();
+    bool consume_octal_number();
+    bool consume_hexadecimal_number();
+    bool consume_binary_number();
     bool is_eof() const;
     bool is_identifier_start() const;
     bool is_identifier_middle() const;

--- a/Libraries/LibJS/Tests/numeric-literals-basic.js
+++ b/Libraries/LibJS/Tests/numeric-literals-basic.js
@@ -35,3 +35,10 @@ test("accessing properties of decimal numbers", () => {
     expect((1.1).foo).toBe("foo");
     expect((0.1).foo).toBe("foo");
 });
+
+test("invalid numeric literals", () => {
+    expect("1e").not.toEval();
+    expect("0x").not.toEval();
+    expect("0b").not.toEval();
+    expect("0o").not.toEval();
+});


### PR DESCRIPTION
i.e. "1e" "0x" "0b" "0o" used to be parsed as valid literals.
They now produce invalid tokens. Fixes #3716