### PR TITLE
Fix the build on FreeBSD

### DIFF
--- a/AK/Random.h
+++ b/AK/Random.h
@@ -33,7 +33,7 @@
 #    include <stdlib.h>
 #endif
 
-#if defined(__linux__)
+#if defined(__unix__)
 #    include <unistd.h>
 #endif
 
@@ -47,7 +47,7 @@ inline void fill_with_random(void* buffer, size_t length)
 {
 #if defined(__serenity__)
     arc4random_buf(buffer, length);
-#elif defined(__linux__) or defined(__APPLE__)
+#elif defined(__unix__) or defined(__APPLE__)
     int rc = getentropy(buffer, length);
     (void)rc;
 #endif

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -54,7 +54,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
 elif [ "$(uname -s)" = "OpenBSD" ]; then
     mount -t ext2fs "/dev/${VND}i" mnt/ || die "could not mount filesystem"
 elif [ "$(uname -s)" = "FreeBSD" ]; then
-    fuse-ext2 -o rw+ "/dev/${MD}" mnt/ || die "could not mount filesystem"
+    fuse-ext2 -o rw+,direct_io "/dev/${MD}" mnt/ || die "could not mount filesystem"
 else
     if ! mount _disk_image mnt/ ; then
         if command -v genext2fs 1>/dev/null ; then

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -12,10 +12,11 @@ window_gid=13
 
 CP="cp"
 
-# cp on macOS does not support the -d option.
+# cp on macOS and BSD systems do not support the -d option.
 # gcp comes with coreutils, which is already a dependency.
-if [ "$(uname -s)" = "Darwin" ]; then
-	CP=gcp
+OS="$(uname -s)"
+if [ "$OS" = "Darwin" ] || echo "$OS" | grep -qe 'BSD$'; then
+	CP="gcp"
 fi
 
 die() {

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -42,6 +42,8 @@ elif [ "$(uname -s)" = "FreeBSD" ]; then
     MAKE=gmake
     MD5SUM="md5 -q"
     NPROC="sysctl -n hw.ncpu"
+    export with_gmp=/usr/local
+    export with_mpfr=/usr/local
 fi
 
 git_patch=

--- a/Toolchain/BuildIt_x86_64.sh
+++ b/Toolchain/BuildIt_x86_64.sh
@@ -28,6 +28,8 @@ elif [ "$(uname -s)" = "FreeBSD" ]; then
     MAKE=gmake
     MD5SUM="md5 -q"
     NPROC="sysctl -n hw.ncpu"
+    export with_gmp=/usr/local
+    export with_mpfr=/usr/local
 fi
 
 echo PREFIX is "$PREFIX"


### PR DESCRIPTION
Hi, this is all it took to be able to build and run SerenityOS on FreeBSD 12-STABLE, with consideration for other Unix systems.

Have a good day!