### PR TITLE
test-js: Support test262 parser tests

### DIFF
--- a/Base/usr/share/man/man1/test-js.md
+++ b/Base/usr/share/man/man1/test-js.md
@@ -5,7 +5,7 @@ test-js - run the LibJS test suite
 ## Synopsis
 
 ```**sh
-$ test-js [options...]
+$ test-js [options...] [path]
 ```
 
 ## Description
@@ -14,9 +14,18 @@ $ test-js [options...]
 tests are using a custom JavaScript testing framework inspired by
 [Jest](https://jestjs.io) (see [`test-common.js`](/home/anon/js-tests/test-common.js)).
 
+It also supports the [test262 parser tests](https://github.com/tc39/test262-parser-tests).
+
+The test root directory is assumed to be `/home/anon/js-tests`, or `$SERENITY_ROOT/Libraries/LibJS/Tests`
+when using the Lagom build. Optionally you can pass a custom path to `test-js` to override these defaults.
+
+You can disable output from `dbg()` calls by setting the `DISABLE_DBG_OUTPUT` environment variable.
+
 ## Options
 
 * `-t`, `--show-time`: Show duration of each test
+* `-g`, `--collect-often`: Collect garbage after every allocation
+* `--test262-parser-tests`: Run test262 parser tests
 
 ## Examples
 

--- a/Userland/test-js.cpp
+++ b/Userland/test-js.cpp
@@ -636,5 +636,5 @@ int main(int argc, char** argv)
 
     vm = nullptr;
 
-    return 0;
+    return TestRunner::the()->counts().tests_failed > 0 ? 1 : 0;
 }

--- a/Userland/test-js.cpp
+++ b/Userland/test-js.cpp
@@ -567,7 +567,7 @@ void TestRunner::print_test_results() const
         printf("%d passed, ", m_counts.tests_passed);
         print_modifiers({ CLEAR });
     }
-    printf("%d total\n", m_counts.tests_failed + m_counts.tests_passed);
+    printf("%d total\n", m_counts.tests_failed + m_counts.tests_skipped + m_counts.tests_passed);
 
     printf("Files:       %d total\n", m_counts.files_total);
 


### PR DESCRIPTION
The first three commits are general test-js changes:

**test-js: Add argument for explicit test root directory**

> Right now test-js has a hardcoded test root directory when running on Serenity or will get it based on `SERENITY_ROOT` otherwise. Now it is also possible to pass a path to the command which will take precedence over these mechanisms.
> 
> This will also be useful for adding test262 support as those files will not have a default location.

**test-js: Include skipped tests in total test count**

> The current output is a bit strange:
> 
> ```
> Tests:       3 skipped, 979 passed, 979 total
> ```
> 
> This makes more sense to me:
> 
> ```
> Tests:       3 skipped, 979 passed, 982 total
> ```

**test-js: Exit with 1 if any test failed**

Self explanatory. *How does CI fail currently if `test-js` builds one or more LibJS tests fail?!*

**test-js: Support test262 parser tests**

> test-js now has a --test262-parser-tests option. Modules are skipped for now, current results:
> 
> ```
> Test Suites: 1309 failed, 4314 passed, 5623 total
> Tests:       1309 failed, 262 skipped, 4052 passed, 5623 total
> Files:       5361 total
> Time:        ~100ms (Lagom) / 600-800ms (Serenity)
> ```
> 
> For more info, see: https://github.com/tc39/test262-parser-tests

And finally...

**Base: Update test-js(1) man page**