### PR TITLE
LibJS: Fix arrow function parsing issues

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1442,9 +1442,10 @@ void UpdateExpression::dump(int indent) const
     }
 
     ASTNode::dump(indent);
-    print_indent(indent + 1);
-    if (m_prefixed)
+    if (m_prefixed) {
+        print_indent(indent + 1);
         printf("%s\n", op_string);
+    }
     m_argument->dump(indent + 1);
     if (!m_prefixed) {
         print_indent(indent + 1);

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -353,6 +353,10 @@ RefPtr<FunctionExpression> Parser::try_parse_arrow_function_expression(bool expe
             return nullptr;
         parameters.append({ consume().value(), {} });
     }
+    // If there's a newline between the closing paren and arrow it's not a valid arrow function,
+    // ASI should kick in instead (it'll then fail with "Unexpected token Arrow")
+    if (m_parser_state.m_current_token.trivia().contains('\n'))
+        return nullptr;
     if (!match(TokenType::Arrow))
         return nullptr;
     consume();

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -48,6 +48,7 @@ public:
 
     template<typename FunctionNodeType>
     NonnullRefPtr<FunctionNodeType> parse_function_node(bool check_for_function_and_name = true, bool allow_super_property_lookup = false, bool allow_super_constructor_call = false);
+    Vector<FunctionNode::Parameter> parse_function_parameters(int& function_length);
 
     NonnullRefPtr<Statement> parse_statement();
     NonnullRefPtr<BlockStatement> parse_block_statement();

--- a/Libraries/LibJS/Tests/functions/arrow-functions.js
+++ b/Libraries/LibJS/Tests/functions/arrow-functions.js
@@ -160,4 +160,5 @@ test("syntax errors", () => {
     expect("(a b) => {}").not.toEval();
     expect("(a ...b) => {}").not.toEval();
     expect("(a = 1 = 2) => {}").not.toEval();
+    expect("()\n=> {}").not.toEval();
 });

--- a/Libraries/LibJS/Tests/functions/arrow-functions.js
+++ b/Libraries/LibJS/Tests/functions/arrow-functions.js
@@ -148,3 +148,16 @@ test("cannot be constructed", () => {
         new foo();
     }).toThrowWithMessage(TypeError, "foo is not a constructor");
 });
+
+test("syntax errors", () => {
+    expect("a, => {}").not.toEval();
+    expect("(a, => {}").not.toEval();
+    expect("(,) => {}").not.toEval();
+    expect("(,,) => {}").not.toEval();
+    expect("(a,,) => {}").not.toEval();
+    expect("(a,,b) => {}").not.toEval();
+    expect("(a, ...b, ...c) => {}").not.toEval();
+    expect("(a b) => {}").not.toEval();
+    expect("(a ...b) => {}").not.toEval();
+    expect("(a = 1 = 2) => {}").not.toEval();
+});


### PR DESCRIPTION
This fixes a total of 6 test262-parser-tests tests :^)

---

**LibJS: Share parameter parsing between regular and arrow functions**

This simplifies `try_parse_arrow_function_expression()` and fixes a few cases that should not produce an arrow function AST but did:

```
(a,,) => {}
(a b) => {}
(a ...b) => {}
(...b a) => {}
```

The new parsing logic checks whether parens are expected and uses `parse_function_parameters()` if so, rolling back if a new syntax error occurs during that. Otherwise it's just an identifier in which case we parse the single parameter ourselves.

---

**LibJS: Don't parse arrow function with newline between ) and =>**

If there's a newline between the closing paren and arrow it's not a valid arrow function, ASI should kick in instead (it'll then fail with "Unexpected token Arrow")