### PR TITLE
LibLine: multi-character keybindings

### DIFF
--- a/AK/GenericLexer.cpp
+++ b/AK/GenericLexer.cpp
@@ -221,21 +221,25 @@ String GenericLexer::consume_and_unescape_string(char escape_char)
     if (view.is_null())
         return {};
 
-    // Transform common escape sequences
-    auto unescape_character = [](char c) {
-        static const char* escape_map = "n\nr\rt\tb\bf\f";
-        for (size_t i = 0; escape_map[i] != '\0'; i += 2)
-            if (c == escape_map[i])
-                return escape_map[i + 1];
-        return c;
-    };
-
     StringBuilder builder;
-    for (size_t i = 0; i < view.length(); ++i) {
-        char c = (view[i] == escape_char) ? unescape_character(view[++i]) : view[i];
-        builder.append(c);
-    }
+    for (size_t i = 0; i < view.length(); ++i)
+        builder.append(consume_escaped_character(escape_char));
     return builder.to_string();
+}
+
+char GenericLexer::consume_escaped_character(char escape_char, const StringView& escape_map)
+{
+    if (!consume_specific(escape_char))
+        return consume();
+
+    auto c = consume();
+
+    for (size_t i = 0; i < escape_map.length(); i += 2) {
+        if (c == escape_map[i])
+            return escape_map[i + 1];
+    }
+
+    return c;
 }
 
 // Ignore a number of characters (1 by default)

--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -52,6 +52,7 @@ public:
     bool consume_specific(char);
     bool consume_specific(StringView);
     bool consume_specific(const char*);
+    char consume_escaped_character(char escape_char = '\\', const StringView& escape_map = "n\nr\rt\tb\bf\f");
     StringView consume(size_t count);
     StringView consume_all();
     StringView consume_line();

--- a/Libraries/LibLine/CMakeLists.txt
+++ b/Libraries/LibLine/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     Editor.cpp
     InternalFunctions.cpp
+    KeyCallbackMachine.cpp
     SuggestionManager.cpp
     XtermSuggestionDisplay.cpp
 )

--- a/Libraries/LibLine/KeyCallbackMachine.cpp
+++ b/Libraries/LibLine/KeyCallbackMachine.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibLine/Editor.h>
+
+namespace {
+constexpr u32 ctrl(char c) { return c & 0x3f; }
+}
+
+namespace Line {
+
+void KeyCallbackMachine::register_key_input_callback(Vector<Key> keys, Function<bool(Editor&)> callback)
+{
+    m_key_callbacks.set(keys, make<KeyCallback>(move(callback)));
+}
+
+void KeyCallbackMachine::key_pressed(Editor& editor, Key key)
+{
+#ifdef CALLBACK_MACHINE_DEBUG
+    dbgln("Key<{}, {}> pressed, seq_length={}, {} things in the matching vector", key.key, key.modifiers, m_sequence_length, m_current_matching_keys.size());
+#endif
+    if (m_sequence_length == 0) {
+        ASSERT(m_current_matching_keys.is_empty());
+
+        for (auto& it : m_key_callbacks) {
+            if (it.key.first() == key)
+                m_current_matching_keys.append(it.key);
+        }
+
+        if (m_current_matching_keys.is_empty()) {
+            m_should_process_this_key = true;
+            return;
+        }
+    }
+
+    ++m_sequence_length;
+    Vector<Vector<Key>> old_macthing_keys;
+    swap(m_current_matching_keys, old_macthing_keys);
+
+    for (auto& okey : old_macthing_keys) {
+        if (okey.size() < m_sequence_length)
+            continue;
+
+        if (okey[m_sequence_length - 1] == key)
+            m_current_matching_keys.append(okey);
+    }
+
+    if (m_current_matching_keys.is_empty()) {
+        // Insert any keys that were captured
+        if (!old_macthing_keys.is_empty()) {
+            auto& keys = old_macthing_keys.first();
+            for (size_t i = 0; i < m_sequence_length - 1; ++i)
+                editor.insert(keys[i].key);
+        }
+        m_sequence_length = 0;
+        m_should_process_this_key = true;
+        return;
+    }
+
+#ifdef CALLBACK_MACHINE_DEBUG
+    dbgln("seq_length={}, matching vector:", m_sequence_length);
+    for (auto& key : m_current_matching_keys) {
+        for (auto& k : key)
+            dbgln("    {}, {}", k.key, k.modifiers);
+        dbgln("");
+    }
+#endif
+
+    m_should_process_this_key = false;
+    for (auto& key : m_current_matching_keys) {
+        if (key.size() == m_sequence_length) {
+            m_should_process_this_key = m_key_callbacks.get(key).value()->callback(editor);
+            m_sequence_length = 0;
+            m_current_matching_keys.clear();
+            return;
+        }
+    }
+}
+
+void KeyCallbackMachine::interrupted(Editor& editor)
+{
+    m_sequence_length = 0;
+    m_current_matching_keys.clear();
+    if (auto callback = m_key_callbacks.get({ ctrl('C') }); callback.has_value())
+        m_should_process_this_key = callback.value()->callback(editor);
+}
+
+}

--- a/Libraries/LibLine/KeyCallbackMachine.h
+++ b/Libraries/LibLine/KeyCallbackMachine.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/HashMap.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+
+namespace Line {
+
+class Editor;
+
+struct Key {
+    enum Modifier : int {
+        None = 0,
+        Alt = 1,
+    };
+
+    int modifiers { None };
+    unsigned key { 0 };
+
+    Key(unsigned c)
+        : modifiers(None)
+        , key(c) {};
+
+    Key(unsigned c, int modifiers)
+        : modifiers(modifiers)
+        , key(c)
+    {
+    }
+
+    bool operator==(const Key& other) const
+    {
+        return other.key == key && other.modifiers == modifiers;
+    }
+
+    bool operator!=(const Key& other) const
+    {
+        return !(*this == other);
+    }
+};
+
+struct KeyCallback {
+    KeyCallback(Function<bool(Editor&)> cb)
+        : callback(move(cb))
+    {
+    }
+    Function<bool(Editor&)> callback;
+};
+
+class KeyCallbackMachine {
+public:
+    void register_key_input_callback(Vector<Key>, Function<bool(Editor&)> callback);
+    void key_pressed(Editor&, Key);
+    void interrupted(Editor&);
+    bool should_process_last_pressed_key() const { return m_should_process_this_key; }
+
+private:
+    HashMap<Vector<Key>, NonnullOwnPtr<KeyCallback>> m_key_callbacks;
+    Vector<Vector<Key>> m_current_matching_keys;
+    size_t m_sequence_length { 0 };
+    bool m_should_process_this_key { true };
+};
+
+}
+
+namespace AK {
+
+template<>
+struct Traits<Line::Key> : public GenericTraits<Line::Key> {
+    static constexpr bool is_trivial() { return true; }
+    static unsigned hash(Line::Key k) { return pair_int_hash(k.key, k.modifiers); }
+};
+
+template<>
+struct Traits<Vector<Line::Key>> : public GenericTraits<Vector<Line::Key>> {
+    static constexpr bool is_trivial() { return false; }
+    static unsigned hash(const Vector<Line::Key>& ks)
+    {
+        unsigned h = 0;
+        for (auto& k : ks)
+            h ^= Traits<Line::Key>::hash(k);
+        return h;
+    }
+};
+
+}


### PR DESCRIPTION
I've always wanted this sort of capability (always felt it missing, vim knows what's up!), so now we can have it.

This PR:
- Adds multi-character bindings (or, to be more specific, multi-stroke bindings), with support for modifiers for each character (cc @nico: "alt" does not seem to be working inside Serenity, it does work on host)
- Adds `GenericLexer::consume_escaped_character()` (cc @benit8)
- Allows escapes in the config file, now you can input literal newlines! (I think `\\\n` is fine until someone figures out how shift+enter or something similar works in VT100)