### PR TITLE
LibJS: Unprefixed octal numbers are a syntax error in strict mode

### DIFF
--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -422,8 +422,7 @@ Token Lexer::next()
                 consume();
                 token_type = TokenType::BigIntLiteral;
             } else if (isdigit(m_current_char)) {
-                // octal without 'O' prefix. Forbidden in 'strict mode'
-                // FIXME: We need to make sure this produces a syntax error when in strict mode
+                // octal without '0o' prefix. Forbidden in 'strict mode'
                 do {
                     consume();
                 } while (isdigit(m_current_char));

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -139,6 +139,7 @@ private:
     void syntax_error(const String& message, size_t line = 0, size_t column = 0);
     Token consume();
     Token consume(TokenType type);
+    Token consume_and_validate_numeric_literal();
     void consume_or_insert_semicolon();
     void save_state();
     void load_state();

--- a/Libraries/LibJS/Tests/numeric-literals-basic.js
+++ b/Libraries/LibJS/Tests/numeric-literals-basic.js
@@ -1,3 +1,6 @@
+// FIXME: Some of the test cases below are duplicated, presumably to test
+// uppercase as well which then got lowercased by Prettier at some point.
+
 test("hex literals", () => {
     expect(0xff).toBe(255);
     expect(0xff).toBe(255);
@@ -6,6 +9,7 @@ test("hex literals", () => {
 test("octal literals", () => {
     expect(0o10).toBe(8);
     expect(0o10).toBe(8);
+    expect(010).toBe(8);
 });
 
 test("binary literals", () => {
@@ -41,4 +45,5 @@ test("invalid numeric literals", () => {
     expect("0x").not.toEval();
     expect("0b").not.toEval();
     expect("0o").not.toEval();
+    expect("'use strict'; 0755").not.toEval();
 });


### PR DESCRIPTION
This fixes a FIXME.