### PR TITLE
LibJS: Fix parsing of numeric object keys

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -364,6 +364,15 @@ int String::replace(const String& needle, const String& replacement, bool all_oc
     return positions.size();
 }
 
+String String::reverse() const
+{
+    StringBuilder reversed_string;
+    for (size_t i = length(); i-- > 0;) {
+        reversed_string.append(characters()[i]);
+    }
+    return reversed_string.to_string();
+}
+
 String escape_html_entities(const StringView& html)
 {
     StringBuilder builder;

--- a/AK/String.h
+++ b/AK/String.h
@@ -258,6 +258,7 @@ public:
     StringView view() const;
 
     int replace(const String& needle, const String& replacement, bool all_occurrences = false);
+    String reverse() const;
 
     template<typename T, typename... Rest>
     bool is_one_of(const T& string, Rest... rest) const

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -743,11 +743,9 @@ NonnullRefPtr<Expression> Parser::parse_property_key()
     if (match(TokenType::StringLiteral)) {
         return parse_string_literal(consume());
     } else if (match(TokenType::NumericLiteral)) {
-        // FIXME: "evaluate" key to double value, see https://github.com/SerenityOS/serenity/issues/3717
-        return create_ast_node<StringLiteral>(consume_and_validate_numeric_literal().value());
+        return create_ast_node<NumericLiteral>(consume().double_value());
     } else if (match(TokenType::BigIntLiteral)) {
-        auto value = consume(TokenType::BigIntLiteral).value();
-        return create_ast_node<StringLiteral>(value.substring_view(0, value.length() - 1));
+        return create_ast_node<BigIntLiteral>(consume().value());
     } else if (match(TokenType::BracketOpen)) {
         consume(TokenType::BracketOpen);
         auto result = parse_expression(0);

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -134,15 +134,13 @@ static String double_to_string(double d)
 
     auto number_string = number_string_builder.to_string();
 
-    // HACK: (sunverwerth) I'm not sure how the ECMAScript spec deals with numbers that
-    // can not be exactly represented in IEE754 so I'm cutting off after the 15th fractional digit.
-    // Otherwise 3.14.toString() would come out as "3.140000000000000124344978758017532527446746826171875"
-    // Chrome and Firefox output the expected "3.14" here
+    // FIXME: Remove this hack.
+    // FIXME: Instead find the shortest round-trippable representation.
+    // Remove decimals after the 15th position
     if (end_index > intpart_end + 15) {
         exponent += end_index - intpart_end - 15;
         end_index = intpart_end + 15;
     }
-    // HACK end
 
     // remove leading zeroes
     while (start_index < end_index && number_string[start_index] == '0') {

--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -87,8 +87,7 @@ describe("correct behavior", () => {
     test("floating point keys", () => {
         const math = { 3.14: "pi" };
         expect(math["3.14"]).toBe("pi");
-        // FIXME: Floating point literals are coerced to i32
-        // expect(math[3.14]).toBe("pi");
+        expect(math[3.14]).toBe("pi");
     });
 
     test("keywords as property keys", () => {

--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -39,6 +39,13 @@ describe("correct behavior", () => {
         expect(object[symbol]).toBe(2);
     });
 
+    test("numeric keys", () => {
+        expect({0x10:true}).toBe({16:true});
+        expect({0b10:true}).toBe({2:true});
+        expect({0o10:true}).toBe({8:true});
+        expect({.5:true}).toBe({"0.5":true});
+    });
+
     test("computed properties", () => {
         const foo = "bar";
         const computed = "computed";

--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -40,10 +40,15 @@ describe("correct behavior", () => {
     });
 
     test("numeric keys", () => {
-        expect({0x10:true}).toBe({16:true});
-        expect({0b10:true}).toBe({2:true});
-        expect({0o10:true}).toBe({8:true});
-        expect({.5:true}).toBe({"0.5":true});
+        const hex = {0x10: "16"};
+        const oct = {0o10: "8"};
+        const bin = {0b10: "2"};
+        const float = {.5: "0.5"};
+        
+        expect(hex["16"]).toBe("16");
+        expect(oct["8"]).toBe("8");
+        expect(bin["2"]).toBe("2");
+        expect(float["0.5"]).toBe("0.5");
     });
 
     test("computed properties", () => {


### PR DESCRIPTION
Numeric keys were interpreted as their source text, leading to
something like {0x10:true} to end up as {"0x10":true}
instead of {16:true}