### PR TITLE
LibX86: malloc a bit less

### DIFF
--- a/Libraries/LibX86/Instruction.h
+++ b/Libraries/LibX86/Instruction.h
@@ -522,7 +522,7 @@ private:
     template<typename InstructionStreamType>
     Instruction(InstructionStreamType&, bool o32, bool a32);
 
-    String to_string_internal(u32 origin, const SymbolProvider*, bool x32) const;
+    void to_string_internal(StringBuilder&, u32 origin, const SymbolProvider*, bool x32) const;
 
     const char* reg8_name() const;
     const char* reg16_name() const;


### PR DESCRIPTION
This reduces malloc()/free() calls in `disasm /bin/id` by 30%
according to LIBC_DUMP_MALLOC_STATS.

No measurable performance change (the number of empty block hits
remains unchanged, and that's what's slow), but maybe a nice
change regardless?

--

The obvious mallocs here come up every few months and I have this branch anyways, so might as well merge it, idk.