### PR TITLE
Redundant inline specifier on constexpr functions

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -104,7 +104,7 @@ struct TypeBoundsChecker<Destination, Source, true, true, false> {
 };
 
 template<typename Destination, typename Source>
-inline constexpr bool is_within_range(Source value)
+constexpr bool is_within_range(Source value)
 {
     return TypeBoundsChecker<Destination, Source>::is_within_range(value);
 }
@@ -289,7 +289,7 @@ constexpr Checked<T> operator*(const Checked<T>& a, const Checked<T>& b)
 }
 
 template<typename T>
-constexpr inline Checked<T> operator/(const Checked<T>& a, const Checked<T>& b)
+constexpr Checked<T> operator/(const Checked<T>& a, const Checked<T>& b)
 {
     Checked<T> c { a };
     c.div(b.value());

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -28,7 +28,7 @@
 
 #define UNUSED_PARAM(x) (void)x
 
-inline constexpr unsigned round_up_to_power_of_two(unsigned value, unsigned power_of_two)
+constexpr unsigned round_up_to_power_of_two(unsigned value, unsigned power_of_two)
 {
     return ((value - 1) & ~(power_of_two - 1)) + power_of_two;
 }
@@ -45,19 +45,19 @@ constexpr SizeType array_size(T (&)[N])
 }
 
 template<typename T>
-inline constexpr T min(const T& a, const T& b)
+constexpr T min(const T& a, const T& b)
 {
     return b < a ? b : a;
 }
 
 template<typename T>
-inline constexpr T max(const T& a, const T& b)
+constexpr T max(const T& a, const T& b)
 {
     return a < b ? b : a;
 }
 
 template<typename T>
-inline constexpr T clamp(const T& value, const T& min, const T& max)
+constexpr T clamp(const T& value, const T& min, const T& max)
 {
     ASSERT(max >= min);
     if (value > max)
@@ -68,7 +68,7 @@ inline constexpr T clamp(const T& value, const T& min, const T& max)
 }
 
 template<typename T, typename U>
-inline constexpr T ceil_div(T a, U b)
+constexpr T ceil_div(T a, U b)
 {
     static_assert(sizeof(T) == sizeof(U));
     T result = a / b;
@@ -312,13 +312,13 @@ struct RemoveReference<T&&> {
 };
 
 template<class T>
-inline constexpr T&& forward(typename RemoveReference<T>::Type& param)
+constexpr T&& forward(typename RemoveReference<T>::Type& param)
 {
     return static_cast<T&&>(param);
 }
 
 template<class T>
-inline constexpr T&& forward(typename RemoveReference<T>::Type&& param) noexcept
+constexpr T&& forward(typename RemoveReference<T>::Type&& param) noexcept
 {
     static_assert(!IsLvalueReference<T>::value, "Can't forward an rvalue as an lvalue.");
     return static_cast<T&&>(param);
@@ -505,7 +505,7 @@ template<typename... Ts>
 using Void = void;
 
 template<typename... _Ignored>
-inline constexpr auto DependentFalse = false;
+constexpr auto DependentFalse = false;
 
 }
 

--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -116,7 +116,7 @@ private:
     char m_inline_buffer[0];
 };
 
-inline constexpr u32 string_hash(const char* characters, size_t length)
+constexpr u32 string_hash(const char* characters, size_t length)
 {
     u32 hash = 0;
     for (size_t i = 0; i < length; ++i) {

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -92,7 +92,7 @@ static_assert(explode_byte(0x80) == 0x80808080);
 static_assert(explode_byte(0x7f) == 0x7f7f7f7f);
 static_assert(explode_byte(0) == 0);
 
-inline constexpr size_t align_up_to(const size_t value, const size_t alignment)
+constexpr size_t align_up_to(const size_t value, const size_t alignment)
 {
     return (value + (alignment - 1)) & ~(alignment - 1);
 }

--- a/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -74,7 +74,7 @@ void SoftCPU::warn_if_flags_tainted(const char* message) const
 }
 
 template<typename T, typename U>
-inline constexpr T sign_extended_to(U value)
+constexpr T sign_extended_to(U value)
 {
     if (!(value & X86::TypeTrivia<U>::sign_bit))
         return value;

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -205,7 +205,7 @@ enum Function {
         __Count
 };
 
-inline constexpr const char* to_string(Function function)
+constexpr const char* to_string(Function function)
 {
     switch (function) {
 #undef __ENUMERATE_SYSCALL

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -499,7 +499,7 @@ struct [[gnu::aligned(16)]] FPUState
     u8 buffer[512];
 };
 
-inline constexpr FlatPtr page_base_of(FlatPtr address)
+constexpr FlatPtr page_base_of(FlatPtr address)
 {
     return address & PAGE_MASK;
 }
@@ -509,7 +509,7 @@ inline FlatPtr page_base_of(const void* address)
     return page_base_of((FlatPtr)address);
 }
 
-inline constexpr FlatPtr offset_in_page(FlatPtr address)
+constexpr FlatPtr offset_in_page(FlatPtr address)
 {
     return address & (~PAGE_MASK);
 }

--- a/Kernel/FileSystem/InodeMetadata.h
+++ b/Kernel/FileSystem/InodeMetadata.h
@@ -35,7 +35,7 @@ namespace Kernel {
 
 class Process;
 
-inline constexpr u32 encoded_device(unsigned major, unsigned minor)
+constexpr u32 encoded_device(unsigned major, unsigned minor)
 {
     return (minor & 0xff) | (major << 8) | ((minor & ~0xff) << 12);
 }

--- a/Libraries/LibCrypto/Hash/MD5.cpp
+++ b/Libraries/LibCrypto/Hash/MD5.cpp
@@ -27,37 +27,37 @@
 #include <AK/Types.h>
 #include <LibCrypto/Hash/MD5.h>
 
-static constexpr inline u32 F(u32 x, u32 y, u32 z) { return (x & y) | ((~x) & z); };
-static constexpr inline u32 G(u32 x, u32 y, u32 z) { return (x & z) | ((~z) & y); };
-static constexpr inline u32 H(u32 x, u32 y, u32 z) { return x ^ y ^ z; };
-static constexpr inline u32 I(u32 x, u32 y, u32 z) { return y ^ (x | ~z); };
-static constexpr inline u32 ROTATE_LEFT(u32 x, size_t n)
+static constexpr u32 F(u32 x, u32 y, u32 z) { return (x & y) | ((~x) & z); };
+static constexpr u32 G(u32 x, u32 y, u32 z) { return (x & z) | ((~z) & y); };
+static constexpr u32 H(u32 x, u32 y, u32 z) { return x ^ y ^ z; };
+static constexpr u32 I(u32 x, u32 y, u32 z) { return y ^ (x | ~z); };
+static constexpr u32 ROTATE_LEFT(u32 x, size_t n)
 {
     return (x << n) | (x >> (32 - n));
 }
 
-static constexpr inline void round_1(u32& a, u32 b, u32 c, u32 d, u32 x, u32 s, u32 ac)
+static constexpr void round_1(u32& a, u32 b, u32 c, u32 d, u32 x, u32 s, u32 ac)
 {
     a += F(b, c, d) + x + ac;
     a = ROTATE_LEFT(a, s);
     a += b;
 }
 
-static constexpr inline void round_2(u32& a, u32 b, u32 c, u32 d, u32 x, u32 s, u32 ac)
+static constexpr void round_2(u32& a, u32 b, u32 c, u32 d, u32 x, u32 s, u32 ac)
 {
     a += G(b, c, d) + x + ac;
     a = ROTATE_LEFT(a, s);
     a += b;
 }
 
-static constexpr inline void round_3(u32& a, u32 b, u32 c, u32 d, u32 x, u32 s, u32 ac)
+static constexpr void round_3(u32& a, u32 b, u32 c, u32 d, u32 x, u32 s, u32 ac)
 {
     a += H(b, c, d) + x + ac;
     a = ROTATE_LEFT(a, s);
     a += b;
 }
 
-static constexpr inline void round_4(u32& a, u32 b, u32 c, u32 d, u32 x, u32 s, u32 ac)
+static constexpr void round_4(u32& a, u32 b, u32 c, u32 d, u32 x, u32 s, u32 ac)
 {
     a += I(b, c, d) + x + ac;
     a = ROTATE_LEFT(a, s);

--- a/Libraries/LibCrypto/Hash/SHA2.cpp
+++ b/Libraries/LibCrypto/Hash/SHA2.cpp
@@ -29,21 +29,21 @@
 
 namespace Crypto {
 namespace Hash {
-constexpr inline static auto ROTRIGHT(u32 a, size_t b) { return (a >> b) | (a << (32 - b)); }
-constexpr inline static auto CH(u32 x, u32 y, u32 z) { return (x & y) ^ (z & ~x); }
-constexpr inline static auto MAJ(u32 x, u32 y, u32 z) { return (x & y) ^ (x & z) ^ (y & z); }
-constexpr inline static auto EP0(u32 x) { return ROTRIGHT(x, 2) ^ ROTRIGHT(x, 13) ^ ROTRIGHT(x, 22); }
-constexpr inline static auto EP1(u32 x) { return ROTRIGHT(x, 6) ^ ROTRIGHT(x, 11) ^ ROTRIGHT(x, 25); }
-constexpr inline static auto SIGN0(u32 x) { return ROTRIGHT(x, 7) ^ ROTRIGHT(x, 18) ^ (x >> 3); }
-constexpr inline static auto SIGN1(u32 x) { return ROTRIGHT(x, 17) ^ ROTRIGHT(x, 19) ^ (x >> 10); }
+constexpr static auto ROTRIGHT(u32 a, size_t b) { return (a >> b) | (a << (32 - b)); }
+constexpr static auto CH(u32 x, u32 y, u32 z) { return (x & y) ^ (z & ~x); }
+constexpr static auto MAJ(u32 x, u32 y, u32 z) { return (x & y) ^ (x & z) ^ (y & z); }
+constexpr static auto EP0(u32 x) { return ROTRIGHT(x, 2) ^ ROTRIGHT(x, 13) ^ ROTRIGHT(x, 22); }
+constexpr static auto EP1(u32 x) { return ROTRIGHT(x, 6) ^ ROTRIGHT(x, 11) ^ ROTRIGHT(x, 25); }
+constexpr static auto SIGN0(u32 x) { return ROTRIGHT(x, 7) ^ ROTRIGHT(x, 18) ^ (x >> 3); }
+constexpr static auto SIGN1(u32 x) { return ROTRIGHT(x, 17) ^ ROTRIGHT(x, 19) ^ (x >> 10); }
 
-constexpr inline static auto ROTRIGHT(u64 a, size_t b) { return (a >> b) | (a << (64 - b)); }
-constexpr inline static auto CH(u64 x, u64 y, u64 z) { return (x & y) ^ (z & ~x); }
-constexpr inline static auto MAJ(u64 x, u64 y, u64 z) { return (x & y) ^ (x & z) ^ (y & z); }
-constexpr inline static auto EP0(u64 x) { return ROTRIGHT(x, 28) ^ ROTRIGHT(x, 34) ^ ROTRIGHT(x, 39); }
-constexpr inline static auto EP1(u64 x) { return ROTRIGHT(x, 14) ^ ROTRIGHT(x, 18) ^ ROTRIGHT(x, 41); }
-constexpr inline static auto SIGN0(u64 x) { return ROTRIGHT(x, 1) ^ ROTRIGHT(x, 8) ^ (x >> 7); }
-constexpr inline static auto SIGN1(u64 x) { return ROTRIGHT(x, 19) ^ ROTRIGHT(x, 61) ^ (x >> 6); }
+constexpr static auto ROTRIGHT(u64 a, size_t b) { return (a >> b) | (a << (64 - b)); }
+constexpr static auto CH(u64 x, u64 y, u64 z) { return (x & y) ^ (z & ~x); }
+constexpr static auto MAJ(u64 x, u64 y, u64 z) { return (x & y) ^ (x & z) ^ (y & z); }
+constexpr static auto EP0(u64 x) { return ROTRIGHT(x, 28) ^ ROTRIGHT(x, 34) ^ ROTRIGHT(x, 39); }
+constexpr static auto EP1(u64 x) { return ROTRIGHT(x, 14) ^ ROTRIGHT(x, 18) ^ ROTRIGHT(x, 41); }
+constexpr static auto SIGN0(u64 x) { return ROTRIGHT(x, 1) ^ ROTRIGHT(x, 8) ^ (x >> 7); }
+constexpr static auto SIGN1(u64 x) { return ROTRIGHT(x, 19) ^ ROTRIGHT(x, 61) ^ (x >> 6); }
 
 inline void SHA256::transform(const u8* data)
 {

--- a/Libraries/LibGfx/Color.h
+++ b/Libraries/LibGfx/Color.h
@@ -36,7 +36,7 @@ namespace Gfx {
 enum class ColorRole;
 typedef u32 RGBA32;
 
-inline constexpr u32 make_rgb(u8 r, u8 g, u8 b)
+constexpr u32 make_rgb(u8 r, u8 g, u8 b)
 {
     return ((r << 16) | (g << 8) | b);
 }

--- a/Libraries/LibX86/Instruction.h
+++ b/Libraries/LibX86/Instruction.h
@@ -51,7 +51,7 @@ struct TypeTrivia {
 };
 
 template<typename T, typename U>
-inline constexpr T sign_extended_to(U value)
+constexpr T sign_extended_to(U value)
 {
     if (!(value & TypeTrivia<U>::sign_bit))
         return value;

--- a/Userland/mknod.cpp
+++ b/Userland/mknod.cpp
@@ -29,7 +29,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-inline constexpr unsigned encoded_device(unsigned major, unsigned minor)
+constexpr unsigned encoded_device(unsigned major, unsigned minor)
 {
     return (minor & 0xff) | (major << 8) | ((minor & ~0xff) << 12);
 }


### PR DESCRIPTION
Problem:
- `constexpr` functions are decorated with the `inline` specifier
  keyword. This is redundant because `constexpr` functions are
  implicitly `inline`.
- [dcl.constexpr], §7.1.5/2 in the C++11 standard): "constexpr
  functions and constexpr constructors are implicitly inline (7.1.2)".

Solution:
- Remove the redundant `inline` keyword.