### PR TITLE
TestArray: constexpr_sum using span

### DIFF
--- a/AK/Tests/TestArray.cpp
+++ b/AK/Tests/TestArray.cpp
@@ -28,12 +28,10 @@
 
 #include <AK/Array.h>
 
-// FIXME: Use Span<const int> as soon as Span has all the constexpr stuff too.
-template<size_t Size>
-static constexpr int constexpr_sum(const Array<int, Size>& array)
+static constexpr int constexpr_sum(const Span<const int> span)
 {
     int sum = 0;
-    for (auto value : array)
+    for (auto value : span)
         sum += value;
 
     return sum;


### PR DESCRIPTION
Problem:
- `constexpr_sum` is implemented using `Array` which means the
  function needs to be a function template so that the size can be
  deduced.

Solution:
- Change the `Array` function argument to a `Span` since `Span` now is
  `constexpr`.