### PR TITLE
AK: URL encode the components of a URL when stringifying it / LibWeb: Fix named character reference parsing inside attribute values 

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -281,14 +281,14 @@ String URL::to_string() const
             builder.append(String::number(m_port));
         }
     }
-    builder.append(m_path);
+    builder.append(urlencode(m_path, URLEncodeMode::PreserveSpecialCharacters));
     if (!m_query.is_empty()) {
         builder.append('?');
-        builder.append(m_query);
+        builder.append(urlencode(m_query, URLEncodeMode::PreserveSpecialCharacters));
     }
     if (!m_fragment.is_empty()) {
         builder.append('#');
-        builder.append(m_fragment);
+        builder.append(urlencode(m_fragment, URLEncodeMode::PreserveSpecialCharacters));
     }
     return builder.to_string();
 }

--- a/AK/URLParser.h
+++ b/AK/URLParser.h
@@ -30,10 +30,17 @@
 
 namespace AK {
 
-String urlencode(const StringView&);
+enum class URLEncodeMode {
+    PreserveSpecialCharacters,
+    Full,
+};
+
+String urlencode(const StringView&, URLEncodeMode = URLEncodeMode::Full);
+String urlencode(const StringView&, const StringView& safe);
 String urldecode(const StringView&);
 
 }
 
 using AK::urldecode;
 using AK::urlencode;
+using AK::URLEncodeMode;

--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -1544,17 +1544,9 @@ _StartOfFunction:
                     for (auto ch : match.value().entity)
                         m_temporary_buffer.append(ch);
 
-                    if (consumed_as_part_of_an_attribute() && match.value().code_points.last() != ';') {
+                    if (consumed_as_part_of_an_attribute() && !match.value().entity.ends_with(';')) {
                         auto next = peek_code_point(0);
                         if (next.has_value() && (next.value() == '=' || isalnum(next.value()))) {
-                            FLUSH_CODEPOINTS_CONSUMED_AS_A_CHARACTER_REFERENCE;
-                            SWITCH_TO_RETURN_STATE;
-                        }
-                    }
-
-                    if (consumed_as_part_of_an_attribute() && match.value().entity.ends_with(';')) {
-                        auto next_code_point = peek_code_point(0);
-                        if (next_code_point.has_value() && next_code_point.value() == '=') {
                             FLUSH_CODEPOINTS_CONSUMED_AS_A_CHARACTER_REFERENCE;
                             SWITCH_TO_RETURN_STATE;
                         }

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -167,8 +167,6 @@ bool EventHandler::handle_mousedown(const Gfx::IntPoint& position, unsigned butt
         auto url = document->complete_url(href);
         dbg() << "Web::EventHandler: Clicking on a link to " << url;
         if (button == GUI::MouseButton::Left) {
-            auto href = link->href();
-            auto url = document->complete_url(href);
             if (href.starts_with("javascript:")) {
                 document->run_javascript(href.substring_view(11, href.length() - 11));
             } else if (href.starts_with('#')) {


### PR DESCRIPTION
Fixes #3633

Also fixes `<a href="foo&amp;bar">named character references</a>` inside
attribute values (the standard says to check the matched reference, but
we checked the codepoints of the resulting entity).