### PR TITLE
rm: Exit with status 0 if stat fails and force is set

### DIFF
--- a/Userland/rm.cpp
+++ b/Userland/rm.cpp
@@ -41,7 +41,7 @@ static int remove(bool recursive, bool force, String path)
     if (lstat(path.characters(), &path_stat) < 0) {
         if (!force)
             perror("lstat");
-        return 1;
+        return force ? 0 : 1;
     }
 
     if (S_ISDIR(path_stat.st_mode) && recursive) {


### PR DESCRIPTION
A `make` target I tried to run attempted to delete a file first with `rm -f path/to/file` since this was the first time I had run it the file did non exist. `make` failed with an error. In this case the expectation was that because `-f` was specified `rm` would not exit with a non-zero status. [POSIX says the following](https://pubs.opengroup.org/onlinepubs/9699919799/toc.htm):

> In general, along with "forcing" the unlink without prompting for permission, it always causes diagnostic messages to be suppressed and **the exit status to be unmodified for nonexistent operands and files that cannot be unlinked**.

This PR makes `rm -f /path/to/file` exit with status 0 even if the file does not exist.