### PR TITLE
AK: Eradicate remaining calls to AK::out().

### DIFF
--- a/AK/LogStream.h
+++ b/AK/LogStream.h
@@ -139,7 +139,7 @@ private:
     int m_fd { -1 };
 };
 
-inline StdLogStream out() { return StdLogStream(STDOUT_FILENO); }
+[[deprecated("Use AK::outln or AK::new_out instead, AK::new_out will soon be renamed to AK::out.")]] inline StdLogStream out() { return StdLogStream(STDOUT_FILENO); }
 inline StdLogStream warn() { return StdLogStream(STDERR_FILENO); }
 #endif
 

--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -34,54 +34,32 @@
 namespace AK {
 
 class SourceGenerator {
+    AK_MAKE_NONCOPYABLE(SourceGenerator);
+
 public:
     using MappingType = HashMap<StringView, String>;
 
-    explicit SourceGenerator(SourceGenerator& parent, char opening = '@', char closing = '@')
-        : m_parent(&parent)
+    explicit SourceGenerator(StringBuilder& builder, char opening = '@', char closing = '@')
+        : m_builder(builder)
         , m_opening(opening)
         , m_closing(closing)
     {
     }
-    explicit SourceGenerator(char opening = '@', char closing = '@')
-        : m_parent(nullptr)
+    explicit SourceGenerator(StringBuilder& builder, const MappingType& mapping, char opening = '@', char closing = '@')
+        : m_builder(builder)
+        , m_mapping(mapping)
         , m_opening(opening)
         , m_closing(closing)
     {
-        m_builder = new StringBuilder();
     }
+
+    SourceGenerator fork() { return SourceGenerator { m_builder, m_mapping, m_opening, m_closing }; }
 
     void set(StringView key, String value) { m_mapping.set(key, value); }
+    String get(StringView key) const { return m_mapping.get(key).value(); }
 
-    String lookup(StringView key) const
-    {
-        if (auto opt = m_mapping.get(key); opt.has_value())
-            return opt.value();
-
-        if (m_parent == nullptr) {
-            dbgln("Can't find key '{}'", key);
-            ASSERT_NOT_REACHED();
-        }
-
-        return m_parent->lookup(key);
-    }
-
-    String generate() const { return builder().build(); }
-
-    StringBuilder& builder()
-    {
-        if (m_parent)
-            return m_parent->builder();
-        else
-            return *m_builder;
-    }
-    const StringBuilder& builder() const
-    {
-        if (m_parent)
-            return m_parent->builder();
-        else
-            return *m_builder;
-    }
+    StringView as_string_view() const { return m_builder.string_view(); }
+    String as_string() const { return m_builder.build(); }
 
     void append(StringView pattern)
     {
@@ -94,7 +72,7 @@ public:
                 return lexer.consume_while([&](char ch) { return ch != stop; });
             };
 
-            builder().append(consume_until_without_consuming_stop_character(m_opening));
+            m_builder.append(consume_until_without_consuming_stop_character(m_opening));
 
             if (lexer.consume_specific(m_opening)) {
                 const auto placeholder = consume_until_without_consuming_stop_character(m_closing);
@@ -102,7 +80,7 @@ public:
                 if (!lexer.consume_specific(m_closing))
                     ASSERT_NOT_REACHED();
 
-                builder().append(lookup(placeholder));
+                m_builder.append(get(placeholder));
             } else {
                 ASSERT(lexer.is_eof());
             }
@@ -110,9 +88,8 @@ public:
     }
 
 private:
-    SourceGenerator* m_parent;
+    StringBuilder& m_builder;
     MappingType m_mapping;
-    OwnPtr<StringBuilder> m_builder;
     char m_opening, m_closing;
 };
 

--- a/AK/Tests/TestSourceGenerator.cpp
+++ b/AK/Tests/TestSourceGenerator.cpp
@@ -28,19 +28,31 @@
 
 #include <AK/SourceGenerator.h>
 
+TEST_CASE(wrap_builder)
+{
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+
+    generator.append("Hello, World!");
+
+    EXPECT_EQ(builder.string_view(), "Hello, World!");
+}
+
 TEST_CASE(generate_c_code)
 {
-    SourceGenerator generator;
+    StringBuilder builder;
+    SourceGenerator generator { builder };
     generator.set("name", "foo");
 
     generator.append("const char* @name@ (void) { return \"@name@\"; }");
 
-    EXPECT_EQ(generator.generate(), "const char* foo (void) { return \"foo\"; }");
+    EXPECT_EQ(generator.as_string_view(), "const char* foo (void) { return \"foo\"; }");
 }
 
 TEST_CASE(scoped)
 {
-    SourceGenerator global_generator;
+    StringBuilder builder;
+    SourceGenerator global_generator { builder };
 
     global_generator.append("\n");
 
@@ -49,8 +61,7 @@ TEST_CASE(scoped)
     global_generator.append("@foo@ @bar@\n"); // foo-0 bar-0
 
     {
-        SourceGenerator scoped_generator_1 { global_generator };
-
+        auto scoped_generator_1 = global_generator.fork();
         scoped_generator_1.set("bar", "bar-1");
         global_generator.append("@foo@ @bar@\n"); // foo-0 bar-0
     }
@@ -58,28 +69,25 @@ TEST_CASE(scoped)
     global_generator.append("@foo@ @bar@\n"); // foo-0 bar-0
 
     {
-        SourceGenerator scoped_generator_2 { global_generator };
-
+        auto scoped_generator_2 = global_generator.fork();
         scoped_generator_2.set("foo", "foo-2");
         scoped_generator_2.append("@foo@ @bar@\n"); // foo-2 bar-0
 
         {
-            // FIXME: This is never put onto the output?
-
-            SourceGenerator scoped_generator_3 { scoped_generator_2 };
+            auto scoped_generator_3 = scoped_generator_2.fork();
             scoped_generator_3.set("bar", "bar-3");
             scoped_generator_3.append("@foo@ @bar@\n"); // foo-2 bar-3
         }
 
         {
-            SourceGenerator scoped_generator_4 { global_generator };
+            auto scoped_generator_4 = global_generator.fork();
             scoped_generator_4.append("@foo@ @bar@\n"); // foo-0 bar-0
         }
 
         scoped_generator_2.append("@foo@ @bar@\n"); // foo-2 bar-0
     }
 
-    EXPECT_EQ(global_generator.generate(), "\nfoo-0 bar-0\nfoo-0 bar-0\nfoo-0 bar-0\nfoo-2 bar-0\nfoo-2 bar-3\nfoo-0 bar-0\nfoo-2 bar-0\n");
+    EXPECT_EQ(global_generator.as_string_view(), "\nfoo-0 bar-0\nfoo-0 bar-0\nfoo-0 bar-0\nfoo-2 bar-0\nfoo-2 bar-3\nfoo-0 bar-0\nfoo-2 bar-0\n");
 }
 
 TEST_MAIN(SourceGenerator)

--- a/Applications/IRCClient/IRCAppWindow.cpp
+++ b/Applications/IRCClient/IRCAppWindow.cpp
@@ -137,7 +137,7 @@ void IRCAppWindow::setup_actions()
     });
 
     m_close_query_action = GUI::Action::create("Close query", { Mod_Ctrl, Key_D }, Gfx::Bitmap::load_from_file("/res/icons/16x16/irc-close-query.png"), [](auto&) {
-        out() << "FIXME: Implement close-query action";
+        outln("FIXME: Implement close-query action");
     });
 
     m_change_nick_action = GUI::Action::create("Change nickname", Gfx::Bitmap::load_from_file("/res/icons/16x16/irc-nick.png"), [this](auto&) {

--- a/Userland/dirname.cpp
+++ b/Userland/dirname.cpp
@@ -34,6 +34,6 @@ int main(int argc, char** argv)
     args_parser.add_positional_argument(path, "Path", "path");
     args_parser.parse(argc, argv);
 
-    out() << LexicalPath(path).dirname().characters();
+    outln("{}", LexicalPath(path).dirname());
     return 0;
 }

--- a/Userland/disasm.cpp
+++ b/Userland/disasm.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv)
         if (current_symbol < symbols.end() && !current_symbol->contains(virtual_offset)) {
             if (!is_first_symbol && current_instruction_is_in_symbol) {
                 // The previous instruction was part of a symbol that doesn't cover the current instruction, so separate it from the current instruction with a newline.
-                out();
+                outln();
                 current_instruction_is_in_symbol = (current_symbol + 1 < symbols.end() && (current_symbol + 1)->contains(virtual_offset));
             }
 
@@ -134,21 +134,19 @@ int main(int argc, char** argv)
             while (current_symbol + 1 < symbols.end() && !(current_symbol + 1)->contains(virtual_offset) && (current_symbol + 1)->address() <= virtual_offset) {
                 ++current_symbol;
                 if (!is_first_symbol)
-                    out() << "\n(" << current_symbol->name << " (" << String::format("%08x-%08x", current_symbol->address(), current_symbol->address_end()) << "))\n";
+                    outln("\n({} ({:p}-{:p}))\n", current_symbol->name, current_symbol->address(), current_symbol->address_end());
             }
             while (current_symbol + 1 < symbols.end() && (current_symbol + 1)->contains(virtual_offset)) {
                 if (!is_first_symbol && !current_instruction_is_in_symbol)
-                    out();
+                    outln();
                 ++current_symbol;
                 current_instruction_is_in_symbol = true;
-                out() << current_symbol->name << " (" << String::format("%08x-%08x", current_symbol->address(), current_symbol->address_end()) << "):";
+                outln("{} ({:p}-{:p}):", current_symbol->name, current_symbol->address(), current_symbol->address_end());
             }
 
             is_first_symbol = false;
         }
 
-        out() << String::format("%08x", virtual_offset) << "  " << insn.value().to_string(virtual_offset, symbol_provider);
+        outln("{:p}  {}", virtual_offset, insn.value().to_string(virtual_offset, symbol_provider));
     }
-
-    return 0;
 }

--- a/Userland/tar.cpp
+++ b/Userland/tar.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
         }
         for (; !tar_stream.finished(); tar_stream.advance()) {
             if (list || verbose)
-                out() << tar_stream.header().file_name();
+                outln("{}", tar_stream.header().file_name());
 
             if (extract) {
                 Tar::TarFileStream file_stream = tar_stream.file_contents();


### PR DESCRIPTION
I haven't removed `AK::out` yet, because I am expecting merge conflicts. (I mean pretty much everything wants to write to stdout at some point.) Since we build with `-Werror`, marking it with `[[deprecated]]` will produce a helpful error message and we can do the renaming of `AK::new_out` to `AK::out` in a week or so.
