### PR TITLE
UserspaceEmulator(+Kernel): Some stuff to make starting SystemServer itself from UE possible

### DIFF
--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -353,6 +353,8 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
         return virt$chmod(arg1, arg2, arg3);
     case SC_fchmod:
         return virt$fchmod(arg1, arg2);
+    case SC_fchown:
+        return virt$fchown(arg1, arg2, arg3);
     case SC_accept:
         return virt$accept(arg1, arg2, arg3);
     case SC_setsockopt:
@@ -503,6 +505,11 @@ int Emulator::virt$chmod(FlatPtr path_addr, size_t path_length, mode_t mode)
 int Emulator::virt$fchmod(int fd, mode_t mode)
 {
     return syscall(SC_fchmod, fd, mode);
+}
+
+int Emulator::virt$fchown(int fd, uid_t uid, gid_t gid)
+{
+    return syscall(SC_fchown, fd, uid, gid);
 }
 
 int Emulator::virt$setsockopt(FlatPtr params_addr)

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -531,6 +531,13 @@ int Emulator::virt$setsockopt(FlatPtr params_addr)
         return rc;
     }
 
+    if (params.option == SO_BINDTODEVICE) {
+        auto ifname = mmu().copy_buffer_from_vm((FlatPtr)params.value, params.value_size);
+        params.value = ifname.data();
+        params.value_size = ifname.size();
+        return syscall(SC_setsockopt, &params);
+    }
+
     TODO();
 }
 

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -349,6 +349,8 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
         return virt$dbgputstr(arg1, arg2);
     case SC_dbgputch:
         return virt$dbgputch(arg1);
+    case SC_chmod:
+        return virt$chmod(arg1, arg2, arg3);
     case SC_fchmod:
         return virt$fchmod(arg1, arg2);
     case SC_accept:
@@ -490,6 +492,12 @@ int Emulator::virt$dbgputstr(FlatPtr characters, int length)
     auto buffer = mmu().copy_buffer_from_vm(characters, length);
     dbgputstr((const char*)buffer.data(), buffer.size());
     return 0;
+}
+
+int Emulator::virt$chmod(FlatPtr path_addr, size_t path_length, mode_t mode)
+{
+    auto path = mmu().copy_buffer_from_vm(path_addr, path_length);
+    return syscall(SC_chmod, path.data(), path.size(), mode);
 }
 
 int Emulator::virt$fchmod(int fd, mode_t mode)

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -395,6 +395,8 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
         return virt$sched_setparam(arg1, arg2);
     case SC_set_thread_name:
         return virt$set_thread_name(arg1, arg2, arg3);
+    case SC_setsid:
+        return virt$setsid();
     default:
         reportln("\n=={}==  \033[31;1mUnimplemented syscall: {}\033[0m, {:p}", getpid(), Syscall::to_string((Syscall::Function)function), function);
         dump_backtrace();
@@ -1458,6 +1460,11 @@ int Emulator::virt$set_thread_name(pid_t pid, FlatPtr name_addr, size_t name_len
     auto user_name = mmu().copy_buffer_from_vm(name_addr, name_length);
     auto name = String::formatted("(UE) {}", StringView { user_name.data(), user_name.size() });
     return syscall(SC_set_thread_name, pid, name.characters(), name.length());
+}
+
+pid_t Emulator::virt$setsid()
+{
+    return syscall(SC_setsid);
 }
 
 }

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -1114,11 +1114,11 @@ int Emulator::virt$realpath(FlatPtr params_addr)
     Syscall::SC_realpath_params params;
     mmu().copy_from_vm(&params, params_addr, sizeof(params));
 
-    auto path = String::copy(mmu().copy_buffer_from_vm((FlatPtr)params.path.characters, params.path.length));
+    auto path = mmu().copy_buffer_from_vm((FlatPtr)params.path.characters, params.path.length);
     char host_buffer[PATH_MAX] = {};
 
     Syscall::SC_realpath_params host_params;
-    host_params.path = { path.characters(), path.length() };
+    host_params.path = { (const char*)path.data(), path.size() };
     host_params.buffer = { host_buffer, sizeof(host_buffer) };
     int rc = syscall(SC_realpath, &host_params);
     if (rc < 0)

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -335,6 +335,8 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
         return virt$fcntl(arg1, arg2, arg3);
     case SC_getgroups:
         return virt$getgroups(arg1, arg2);
+    case SC_setgroups:
+        return virt$setgroups(arg1, arg2);
     case SC_lseek:
         return virt$lseek(arg1, arg2, arg3);
     case SC_socket:
@@ -740,6 +742,15 @@ int Emulator::virt$getgroups(ssize_t count, FlatPtr groups)
         return rc;
     mmu().copy_to_vm(groups, buffer.data(), buffer.size());
     return 0;
+}
+
+int Emulator::virt$setgroups(ssize_t count, FlatPtr groups)
+{
+    if (!count)
+        return syscall(SC_setgroups, 0, nullptr);
+
+    auto buffer = mmu().copy_buffer_from_vm(groups, count * sizeof(gid_t));
+    return syscall(SC_setgroups, count, buffer.data());
 }
 
 u32 Emulator::virt$fcntl(int fd, int cmd, u32 arg)

--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "MallocTracer.h"
+#include "Report.h"
 #include "SoftCPU.h"
 #include "SoftMMU.h"
 #include <AK/Types.h>

--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -94,6 +94,7 @@ private:
     int virt$shbuf_seal(int shbuf_id);
     int virt$shbuf_set_volatile(int shbuf_id, bool);
     u32 virt$mmap(u32);
+    u32 virt$mount(u32);
     u32 virt$munmap(FlatPtr address, u32 size);
     u32 virt$gettid();
     u32 virt$getpid();

--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -120,6 +120,7 @@ private:
     int virt$clock_gettime(int, FlatPtr);
     int virt$dbgputstr(FlatPtr characters, int length);
     int virt$dbgputch(char);
+    int virt$chmod(FlatPtr, size_t, mode_t);
     int virt$fchmod(int, mode_t);
     int virt$listen(int, int);
     int virt$kill(pid_t, int);

--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -126,6 +126,7 @@ private:
     int virt$fstat(int, FlatPtr);
     u32 virt$fcntl(int fd, int, u32);
     int virt$getgroups(ssize_t count, FlatPtr);
+    int virt$setgroups(ssize_t count, FlatPtr);
     int virt$lseek(int fd, off_t offset, int whence);
     int virt$socket(int, int, int);
     int virt$getsockopt(FlatPtr);

--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -122,6 +122,7 @@ private:
     int virt$dbgputch(char);
     int virt$chmod(FlatPtr, size_t, mode_t);
     int virt$fchmod(int, mode_t);
+    int virt$fchown(int, uid_t, gid_t);
     int virt$listen(int, int);
     int virt$kill(pid_t, int);
     int virt$fstat(int, FlatPtr);

--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -147,6 +147,8 @@ private:
     int virt$getcwd(FlatPtr buffer, size_t buffer_size);
     int virt$waitid(FlatPtr);
     int virt$getsid(pid_t);
+    int virt$sched_setparam(int, FlatPtr);
+    int virt$sched_getparam(pid_t, FlatPtr);
 
     FlatPtr allocate_vm(size_t size, size_t alignment);
 

--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -153,6 +153,7 @@ private:
     int virt$sched_setparam(int, FlatPtr);
     int virt$sched_getparam(pid_t, FlatPtr);
     int virt$set_thread_name(pid_t, FlatPtr, size_t);
+    pid_t virt$setsid();
 
     FlatPtr allocate_vm(size_t size, size_t alignment);
 

--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -152,6 +152,7 @@ private:
     int virt$getsid(pid_t);
     int virt$sched_setparam(int, FlatPtr);
     int virt$sched_getparam(pid_t, FlatPtr);
+    int virt$set_thread_name(pid_t, FlatPtr, size_t);
 
     FlatPtr allocate_vm(size_t size, size_t alignment);
 

--- a/DevTools/UserspaceEmulator/MmapRegion.cpp
+++ b/DevTools/UserspaceEmulator/MmapRegion.cpp
@@ -68,7 +68,7 @@ MmapRegion::~MmapRegion()
 ValueWithShadow<u8> MmapRegion::read8(FlatPtr offset)
 {
     if (!is_readable()) {
-        warnln("8-bit read from unreadable MmapRegion @ {:p}", base() + offset);
+        reportln("8-bit read from unreadable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -85,7 +85,7 @@ ValueWithShadow<u8> MmapRegion::read8(FlatPtr offset)
 ValueWithShadow<u16> MmapRegion::read16(u32 offset)
 {
     if (!is_readable()) {
-        warnln("16-bit read from unreadable MmapRegion @ {:p}", base() + offset);
+        reportln("16-bit read from unreadable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -102,7 +102,7 @@ ValueWithShadow<u16> MmapRegion::read16(u32 offset)
 ValueWithShadow<u32> MmapRegion::read32(u32 offset)
 {
     if (!is_readable()) {
-        warnln("32-bit read from unreadable MmapRegion @ {:p}", base() + offset);
+        reportln("32-bit read from unreadable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -119,7 +119,7 @@ ValueWithShadow<u32> MmapRegion::read32(u32 offset)
 ValueWithShadow<u64> MmapRegion::read64(u32 offset)
 {
     if (!is_readable()) {
-        warnln("64-bit read from unreadable MmapRegion @ {:p}", base() + offset);
+        reportln("64-bit read from unreadable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -136,7 +136,7 @@ ValueWithShadow<u64> MmapRegion::read64(u32 offset)
 void MmapRegion::write8(u32 offset, ValueWithShadow<u8> value)
 {
     if (!is_writable()) {
-        warnln("8-bit write from unwritable MmapRegion @ {:p}", base() + offset);
+        reportln("8-bit write from unwritable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -154,7 +154,7 @@ void MmapRegion::write8(u32 offset, ValueWithShadow<u8> value)
 void MmapRegion::write16(u32 offset, ValueWithShadow<u16> value)
 {
     if (!is_writable()) {
-        warnln("16-bit write from unwritable MmapRegion @ {:p}", base() + offset);
+        reportln("16-bit write from unwritable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -172,7 +172,7 @@ void MmapRegion::write16(u32 offset, ValueWithShadow<u16> value)
 void MmapRegion::write32(u32 offset, ValueWithShadow<u32> value)
 {
     if (!is_writable()) {
-        warnln("32-bit write from unwritable MmapRegion @ {:p}", base() + offset);
+        reportln("32-bit write from unwritable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }
@@ -191,7 +191,7 @@ void MmapRegion::write32(u32 offset, ValueWithShadow<u32> value)
 void MmapRegion::write64(u32 offset, ValueWithShadow<u64> value)
 {
     if (!is_writable()) {
-        warnln("64-bit write from unwritable MmapRegion @ {:p}", base() + offset);
+        reportln("64-bit write from unwritable MmapRegion @ {:p}", base() + offset);
         Emulator::the().dump_backtrace();
         TODO();
     }

--- a/DevTools/UserspaceEmulator/Report.h
+++ b/DevTools/UserspaceEmulator/Report.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/LogStream.h>
+
+extern bool g_report_to_debug;
+
+template<typename... Ts>
+void reportln(const StringView& format, Ts... args)
+{
+    if (g_report_to_debug)
+        dbgln(format, args...);
+    else
+        warnln(format, args...);
+}

--- a/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -34,11 +34,11 @@
 #    pragma GCC optimize("O3")
 #endif
 
-#define TODO_INSN()                                                                 \
-    do {                                                                            \
-        warnln("\n=={}== Unimplemented instruction: {}\n", getpid(), __FUNCTION__); \
-        m_emulator.dump_backtrace();                                                \
-        _exit(0);                                                                   \
+#define TODO_INSN()                                                                   \
+    do {                                                                              \
+        reportln("\n=={}== Unimplemented instruction: {}\n", getpid(), __FUNCTION__); \
+        m_emulator.dump_backtrace();                                                  \
+        _exit(0);                                                                     \
     } while (0)
 
 //#define MEMORY_DEBUG
@@ -60,7 +60,7 @@ template<typename T>
 void warn_if_uninitialized(T value_with_shadow, const char* message)
 {
     if (value_with_shadow.is_uninitialized()) {
-        dbgln("\033[31;1mWarning! Use of uninitialized value: {}\033[0m\n", message);
+        reportln("\033[31;1mWarning! Use of uninitialized value: {}\033[0m\n", message);
         Emulator::the().dump_backtrace();
     }
 }
@@ -68,7 +68,7 @@ void warn_if_uninitialized(T value_with_shadow, const char* message)
 void SoftCPU::warn_if_flags_tainted(const char* message) const
 {
     if (m_flags_tainted) {
-        warnln("\n=={}==  \033[31;1mConditional depends on uninitialized data\033[0m ({})\n", getpid(), message);
+        reportln("\n=={}==  \033[31;1mConditional depends on uninitialized data\033[0m ({})\n", getpid(), message);
         Emulator::the().dump_backtrace();
     }
 }
@@ -1342,13 +1342,13 @@ void SoftCPU::DIV_RM16(const X86::Instruction& insn)
 {
     auto divisor = insn.modrm().read16(*this, insn);
     if (divisor.value() == 0) {
-        warnln("Divide by zero");
+        reportln("Divide by zero");
         TODO();
     }
     u32 dividend = ((u32)dx().value() << 16) | ax().value();
     auto quotient = dividend / divisor.value();
     if (quotient > NumericLimits<u16>::max()) {
-        warnln("Divide overflow");
+        reportln("Divide overflow");
         TODO();
     }
 
@@ -1363,13 +1363,13 @@ void SoftCPU::DIV_RM32(const X86::Instruction& insn)
 {
     auto divisor = insn.modrm().read32(*this, insn);
     if (divisor.value() == 0) {
-        warnln("Divide by zero");
+        reportln("Divide by zero");
         TODO();
     }
     u64 dividend = ((u64)edx().value() << 32) | eax().value();
     auto quotient = dividend / divisor.value();
     if (quotient > NumericLimits<u32>::max()) {
-        warnln("Divide overflow");
+        reportln("Divide overflow");
         TODO();
     }
 
@@ -1384,13 +1384,13 @@ void SoftCPU::DIV_RM8(const X86::Instruction& insn)
 {
     auto divisor = insn.modrm().read8(*this, insn);
     if (divisor.value() == 0) {
-        warnln("Divide by zero");
+        reportln("Divide by zero");
         TODO();
     }
     u16 dividend = ax().value();
     auto quotient = dividend / divisor.value();
     if (quotient > NumericLimits<u8>::max()) {
-        warnln("Divide overflow");
+        reportln("Divide overflow");
         TODO();
     }
 
@@ -1405,7 +1405,7 @@ void SoftCPU::ENTER32(const X86::Instruction&) { TODO_INSN(); }
 
 void SoftCPU::ESCAPE(const X86::Instruction&)
 {
-    dbgln("FIXME: x87 floating-point support");
+    reportln("FIXME: x87 floating-point support");
     m_emulator.dump_backtrace();
     TODO();
 }
@@ -1546,13 +1546,13 @@ void SoftCPU::IDIV_RM16(const X86::Instruction& insn)
     auto divisor_with_shadow = insn.modrm().read16(*this, insn);
     auto divisor = (i16)divisor_with_shadow.value();
     if (divisor == 0) {
-        warnln("Divide by zero");
+        reportln("Divide by zero");
         TODO();
     }
     i32 dividend = (i32)(((u32)dx().value() << 16) | (u32)ax().value());
     i32 result = dividend / divisor;
     if (result > NumericLimits<i16>::max() || result < NumericLimits<i16>::min()) {
-        warnln("Divide overflow");
+        reportln("Divide overflow");
         TODO();
     }
 
@@ -1566,13 +1566,13 @@ void SoftCPU::IDIV_RM32(const X86::Instruction& insn)
     auto divisor_with_shadow = insn.modrm().read32(*this, insn);
     auto divisor = (i32)divisor_with_shadow.value();
     if (divisor == 0) {
-        warnln("Divide by zero");
+        reportln("Divide by zero");
         TODO();
     }
     i64 dividend = (i64)(((u64)edx().value() << 32) | (u64)eax().value());
     i64 result = dividend / divisor;
     if (result > NumericLimits<i32>::max() || result < NumericLimits<i32>::min()) {
-        warnln("Divide overflow");
+        reportln("Divide overflow");
         TODO();
     }
 
@@ -1586,13 +1586,13 @@ void SoftCPU::IDIV_RM8(const X86::Instruction& insn)
     auto divisor_with_shadow = insn.modrm().read8(*this, insn);
     auto divisor = (i8)divisor_with_shadow.value();
     if (divisor == 0) {
-        warnln("Divide by zero");
+        reportln("Divide by zero");
         TODO();
     }
     i16 dividend = ax().value();
     i16 result = dividend / divisor;
     if (result > NumericLimits<i8>::max() || result < NumericLimits<i8>::min()) {
-        warnln("Divide overflow");
+        reportln("Divide overflow");
         TODO();
     }
 

--- a/DevTools/UserspaceEmulator/SoftMMU.cpp
+++ b/DevTools/UserspaceEmulator/SoftMMU.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "SoftMMU.h"
+#include "Report.h"
 #include "SharedBufferRegion.h"
 #include <AK/ByteBuffer.h>
 
@@ -68,7 +69,7 @@ ValueWithShadow<u8> SoftMMU::read8(X86::LogicalAddress address)
 {
     auto* region = find_region(address);
     if (!region) {
-        warnln("SoftMMU::read8: No region for @ {:p}", address.offset());
+        reportln("SoftMMU::read8: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -79,7 +80,7 @@ ValueWithShadow<u16> SoftMMU::read16(X86::LogicalAddress address)
 {
     auto* region = find_region(address);
     if (!region) {
-        warnln("SoftMMU::read16: No region for @ {:p}", address.offset());
+        reportln("SoftMMU::read16: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -90,7 +91,7 @@ ValueWithShadow<u32> SoftMMU::read32(X86::LogicalAddress address)
 {
     auto* region = find_region(address);
     if (!region) {
-        warnln("SoftMMU::read32: No region for @ {:p}", address.offset());
+        reportln("SoftMMU::read32: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -101,7 +102,7 @@ ValueWithShadow<u64> SoftMMU::read64(X86::LogicalAddress address)
 {
     auto* region = find_region(address);
     if (!region) {
-        warnln("SoftMMU::read64: No region for @ {:p}", address.offset());
+        reportln("SoftMMU::read64: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -112,7 +113,7 @@ void SoftMMU::write8(X86::LogicalAddress address, ValueWithShadow<u8> value)
 {
     auto* region = find_region(address);
     if (!region) {
-        warnln("SoftMMU::write8: No region for @ {:p}", address.offset());
+        reportln("SoftMMU::write8: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -123,7 +124,7 @@ void SoftMMU::write16(X86::LogicalAddress address, ValueWithShadow<u16> value)
 {
     auto* region = find_region(address);
     if (!region) {
-        warnln("SoftMMU::write16: No region for @ {:p}", address.offset());
+        reportln("SoftMMU::write16: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -134,7 +135,7 @@ void SoftMMU::write32(X86::LogicalAddress address, ValueWithShadow<u32> value)
 {
     auto* region = find_region(address);
     if (!region) {
-        warnln("SoftMMU::write32: No region for @ {:p}", address.offset());
+        reportln("SoftMMU::write32: No region for @ {:p}", address.offset());
         TODO();
     }
 
@@ -145,7 +146,7 @@ void SoftMMU::write64(X86::LogicalAddress address, ValueWithShadow<u64> value)
 {
     auto* region = find_region(address);
     if (!region) {
-        warnln("SoftMMU::write64: No region for @ {:p}", address.offset());
+        reportln("SoftMMU::write64: No region for @ {:p}", address.offset());
         TODO();
     }
 

--- a/DevTools/UserspaceEmulator/main.cpp
+++ b/DevTools/UserspaceEmulator/main.cpp
@@ -37,11 +37,14 @@
 #include <pthread.h>
 #include <string.h>
 
+bool g_report_to_debug = false;
+
 int main(int argc, char** argv, char** env)
 {
     Vector<const char*> command;
 
     Core::ArgsParser parser;
+    parser.add_option(g_report_to_debug, "Write reports to the debug log", "report-to-debug", 0);
     parser.add_positional_argument(command, "Command to emulate", "command");
     parser.parse(argc, argv);
 
@@ -49,7 +52,7 @@ int main(int argc, char** argv, char** env)
 
     MappedFile mapped_file(executable_path);
     if (!mapped_file.is_valid()) {
-        warnln("Unable to map {}", executable_path);
+        reportln("Unable to map {}", executable_path);
         return 1;
     }
 
@@ -78,7 +81,7 @@ int main(int argc, char** argv, char** env)
     }
     int rc = pthread_setname_np(pthread_self(), builder.to_string().characters());
     if (rc != 0) {
-        warnln("pthread_setname_np: {}", strerror(rc));
+        reportln("pthread_setname_np: {}", strerror(rc));
         return 1;
     }
     return emulator.exec();

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -358,7 +358,10 @@ void init_stage2()
     tty0->set_graphical(!text_mode);
     RefPtr<Thread> thread;
     auto userspace_init = kernel_command_line().lookup("init").value_or("/bin/SystemServer");
-    Process::create_user_process(thread, userspace_init, (uid_t)0, (gid_t)0, ProcessID(0), error, {}, {}, tty0);
+    auto init_args = kernel_command_line().lookup("init_args").value_or("").split(',');
+    if (!init_args.is_empty())
+        init_args.prepend(userspace_init);
+    Process::create_user_process(thread, userspace_init, (uid_t)0, (gid_t)0, ProcessID(0), error, move(init_args), {}, tty0);
     if (error != 0) {
         klog() << "init_stage2: error spawning SystemServer: " << error;
         Processor::halt();


### PR DESCRIPTION
I saw some SystemServer crash and decided to run it from UE
imagine my surprise when I realised that the `init` kernel argument is just the program name.

> \<wezm> I added a large source tree to Base/home/anon/Source. The resulting disk image is 2.5Gb. Now Serenity crashes on boot. The particular error moves around between builds but it repeatable if the same image is re-run. Are there any tips for debuging kernel issues? I looking in Documentation and searched the IRC log already.
> \<wezm> This is the error I see: paste.gg/p/anonymous/3f250f2558b94f778cdb9bf608803af6

So this PR makes it possible (somewhat) to boot (textmode) with everything running under UE.

Please take a look at the `create_thread` impl, I am almost definitely certain that I've done something very wrong with it.