### PR TITLE
LibJS: Implement rules for duplicate function parameters

### DIFF
--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -47,6 +47,7 @@ struct FunctionNodeParseOptions {
         AllowSuperConstructorCall = 1 << 2,
         IsGetterFunction = 1 << 3,
         IsSetterFunction = 1 << 4,
+        IsArrowFunction = 1 << 5,
     };
 };
 

--- a/Libraries/LibJS/Tests/builtins/Array/Array.prototype.forEach.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.prototype.forEach.js
@@ -51,7 +51,7 @@ describe("normal behavior", () => {
     test("callback receives array", () => {
         var callbackCalled = 0;
         var a = [1, 2, 3];
-        a.forEach((_, _, array) => {
+        a.forEach((_, __, array) => {
             callbackCalled++;
             expect(a).toEqual(array);
             a.push("test");

--- a/Libraries/LibJS/Tests/functions/function-duplicate-parameters.js
+++ b/Libraries/LibJS/Tests/functions/function-duplicate-parameters.js
@@ -1,0 +1,45 @@
+test("function with duplicate parameter names", () => {
+    function foo(bar, _, bar) {
+        return bar;
+    }
+    expect(foo(1, 2, 3)).toBe(3);
+});
+
+test("syntax errors", () => {
+    // Regular function in strict mode
+    expect(`
+        "use strict";
+        function foo(bar, bar) {}
+    `).not.toEval();
+
+    // Arrow function in strict mode
+    expect(`
+        "use strict";
+        const foo = (bar, bar) => {};
+    `).not.toEval();
+
+    // Arrow function in non-strict mode
+    expect(`
+        const foo = (bar, bar) => {};
+    `).not.toEval();
+
+    // Regular function with rest parameter
+    expect(`
+        function foo(bar, ...bar) {}
+    `).not.toEval();
+
+    // Arrow function with rest parameter
+    expect(`
+        const foo = (bar, ...bar) => {};
+    `).not.toEval();
+
+    // Regular function with default parameter
+    expect(`
+        function foo(bar, bar = 1) {}
+    `).not.toEval();
+
+    // Arrow function with default parameter
+    expect(`
+        const foo = (bar, bar = 1) => {};
+    `).not.toEval();
+});


### PR DESCRIPTION
- A regular function can have duplicate parameters except in strict mode or if its parameter list is not "simple" (has a default or rest parameter)
- An arrow function can never have duplicate parameters

Compared to other engines I opted for more useful syntax error messages than a generic "duplicate parameter name not allowed in this context":

```
"use strict"; function test(foo, foo) {}
                                 ^
Uncaught exception: [SyntaxError]: Duplicate parameter 'foo' not allowed in strict mode (line: 1, column: 34)
```

```
function test(foo, foo = 1) {}
                   ^
Uncaught exception: [SyntaxError]: Duplicate parameter 'foo' not allowed in function with default parameter (line: 1, column: 20)
```

```
function test(foo, ...foo) {}
                      ^
Uncaught exception: [SyntaxError]: Duplicate parameter 'foo' not allowed in function with rest parameter (line: 1, column: 23)
```

```
(foo, foo) => {}
      ^
Uncaught exception: [SyntaxError]: Duplicate parameter 'foo' not allowed in arrow function (line: 1, column: 7)