### PR TITLE
LibCore: Rename File::ShouldCloseFile{Description => Descriptor}

### DIFF
--- a/Games/Chess/Engine.cpp
+++ b/Games/Chess/Engine.cpp
@@ -69,11 +69,11 @@ Engine::Engine(const StringView& command)
     close(rpipefds[1]);
 
     auto infile = Core::File::construct();
-    infile->open(rpipefds[0], Core::IODevice::ReadOnly, Core::File::ShouldCloseFileDescription::Yes);
+    infile->open(rpipefds[0], Core::IODevice::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes);
     set_in(infile);
 
     auto outfile = Core::File::construct();
-    outfile->open(wpipefds[1], Core::IODevice::WriteOnly, Core::File::ShouldCloseFileDescription::Yes);
+    outfile->open(wpipefds[1], Core::IODevice::WriteOnly, Core::File::ShouldCloseFileDescriptor::Yes);
     set_out(outfile);
 
     send_command(Chess::UCI::UCICommand());

--- a/Libraries/LibCore/Command.cpp
+++ b/Libraries/LibCore/Command.cpp
@@ -101,7 +101,7 @@ String command(const String& program, const Vector<String>& arguments, Optional<
 
     auto read_all_from_pipe = [](int pipe[2]) {
         auto result_file = Core::File::construct();
-        if (!result_file->open(pipe[0], Core::IODevice::ReadOnly, Core::File::ShouldCloseFileDescription::Yes)) {
+        if (!result_file->open(pipe[0], Core::IODevice::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes)) {
             perror("open");
             ASSERT_NOT_REACHED();
         }

--- a/Libraries/LibCore/File.cpp
+++ b/Libraries/LibCore/File.cpp
@@ -55,11 +55,11 @@ File::File(const StringView& filename, Object* parent)
 
 File::~File()
 {
-    if (m_should_close_file_descriptor == ShouldCloseFileDescription::Yes && mode() != NotOpen)
+    if (m_should_close_file_descriptor == ShouldCloseFileDescriptor::Yes && mode() != NotOpen)
         close();
 }
 
-bool File::open(int fd, IODevice::OpenMode mode, ShouldCloseFileDescription should_close)
+bool File::open(int fd, IODevice::OpenMode mode, ShouldCloseFileDescriptor should_close)
 {
     set_fd(fd);
     set_mode(mode);
@@ -245,7 +245,7 @@ NonnullRefPtr<File> File::stdin()
 {
     if (!stdin_file) {
         stdin_file = File::construct();
-        stdin_file->open(STDIN_FILENO, IODevice::ReadOnly, ShouldCloseFileDescription::No);
+        stdin_file->open(STDIN_FILENO, IODevice::ReadOnly, ShouldCloseFileDescriptor::No);
     }
     return *stdin_file;
 }
@@ -254,7 +254,7 @@ NonnullRefPtr<File> File::stdout()
 {
     if (!stdout_file) {
         stdout_file = File::construct();
-        stdout_file->open(STDOUT_FILENO, IODevice::WriteOnly, ShouldCloseFileDescription::No);
+        stdout_file->open(STDOUT_FILENO, IODevice::WriteOnly, ShouldCloseFileDescriptor::No);
     }
     return *stdout_file;
 }
@@ -263,7 +263,7 @@ NonnullRefPtr<File> File::stderr()
 {
     if (!stderr_file) {
         stderr_file = File::construct();
-        stderr_file->open(STDERR_FILENO, IODevice::WriteOnly, ShouldCloseFileDescription::No);
+        stderr_file->open(STDERR_FILENO, IODevice::WriteOnly, ShouldCloseFileDescriptor::No);
     }
     return *stderr_file;
 }

--- a/Libraries/LibCore/File.h
+++ b/Libraries/LibCore/File.h
@@ -52,11 +52,11 @@ public:
 
     virtual bool open(IODevice::OpenMode) override;
 
-    enum class ShouldCloseFileDescription {
+    enum class ShouldCloseFileDescriptor {
         No = 0,
         Yes
     };
-    bool open(int fd, IODevice::OpenMode, ShouldCloseFileDescription);
+    bool open(int fd, IODevice::OpenMode, ShouldCloseFileDescriptor);
 
     static NonnullRefPtr<File> stdin();
     static NonnullRefPtr<File> stdout();
@@ -72,7 +72,7 @@ private:
     bool open_impl(IODevice::OpenMode, mode_t);
 
     String m_filename;
-    ShouldCloseFileDescription m_should_close_file_descriptor { ShouldCloseFileDescription::Yes };
+    ShouldCloseFileDescriptor m_should_close_file_descriptor { ShouldCloseFileDescriptor::Yes };
 };
 
 }

--- a/Userland/base64.cpp
+++ b/Userland/base64.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
         bool success = file->open(
             STDIN_FILENO,
             Core::IODevice::OpenMode::ReadOnly,
-            Core::File::ShouldCloseFileDescription::Yes);
+            Core::File::ShouldCloseFileDescriptor::Yes);
         ASSERT(success);
         buffer = file->read_all();
     } else {

--- a/Userland/checksum.cpp
+++ b/Userland/checksum.cpp
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
 
     for (auto path : paths) {
         if (StringView { path } == "-") {
-            success = file->open(STDIN_FILENO, Core::IODevice::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescription::No);
+            success = file->open(STDIN_FILENO, Core::IODevice::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::No);
         } else {
             file->set_filename(path);
             success = file->open(Core::IODevice::OpenMode::ReadOnly);

--- a/Userland/copy.cpp
+++ b/Userland/copy.cpp
@@ -58,7 +58,7 @@ static Options parse_options(int argc, char* argv[])
         bool success = c_stdin->open(
             STDIN_FILENO,
             Core::IODevice::OpenMode::ReadOnly,
-            Core::File::ShouldCloseFileDescription::No);
+            Core::File::ShouldCloseFileDescriptor::No);
         ASSERT(success);
         auto buffer = c_stdin->read_all();
         dbg() << "Read size " << buffer.size();

--- a/Userland/html.cpp
+++ b/Userland/html.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
     URL url;
     bool success;
     if (argc < 2) {
-        success = f->open(STDIN_FILENO, Core::IODevice::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescription::No);
+        success = f->open(STDIN_FILENO, Core::IODevice::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::No);
     } else {
         url = URL::create_with_file_protocol(argv[1]);
         f->set_filename(argv[1]);

--- a/Userland/md.cpp
+++ b/Userland/md.cpp
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
     auto file = Core::File::construct();
     bool success;
     if (file_name == nullptr) {
-        success = file->open(STDIN_FILENO, Core::IODevice::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescription::No);
+        success = file->open(STDIN_FILENO, Core::IODevice::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::No);
     } else {
         file->set_filename(file_name);
         success = file->open(Core::IODevice::OpenMode::ReadOnly);


### PR DESCRIPTION
From https://youtu.be/YNSAZIW3EM0?t=1474:

> Hmm... I don't think that name is right! From the perspective of userspace, this is a file descriptor. File description is what the kernel internally keeps track of, but as far as userspace is concerned, he just has a file descriptor. [...] Maybe that name should be changed."

`Core::File` even has a member of this enum type... called `m_should_close_file_descriptor` - so let's just rename it :^)