### PR TITLE
Themes: Update tooltip colors of dark themes

### DIFF
--- a/Base/res/themes/Basalt.ini
+++ b/Base/res/themes/Basalt.ini
@@ -64,8 +64,8 @@ SyntaxControlKeyword=orchid
 SyntaxIdentifier=white
 SyntaxPreprocessorStatement=#ffafff
 SyntaxPreprocessorValue=orange
-Tooltip=#ffffe1
-TooltipText=black
+Tooltip=#1f1f1f
+TooltipText=white
 
 [Metrics]
 TitleHeight=24

--- a/Base/res/themes/Dark.ini
+++ b/Base/res/themes/Dark.ini
@@ -56,5 +56,5 @@ SyntaxControlKeyword=orchid
 SyntaxIdentifier=lightskyblue
 SyntaxPreprocessorStatement=darkgray
 SyntaxPreprocessorValue=orange
-Tooltip=#ffffe1
-TooltipText=black
+Tooltip=#444444
+TooltipText=white

--- a/Base/res/themes/Discord.ini
+++ b/Base/res/themes/Discord.ini
@@ -57,5 +57,5 @@ SyntaxControlKeyword=#021766
 SyntaxIdentifier=#333333
 SyntaxPreprocessorStatement=darkgray
 SyntaxPreprocessorValue=#320073
-Tooltip=#ffffe1
-TooltipText=black
+Tooltip=#23272A
+TooltipText=white

--- a/Base/res/themes/Joi.ini
+++ b/Base/res/themes/Joi.ini
@@ -56,5 +56,5 @@ SyntaxControlKeyword=black
 SyntaxIdentifier=#092e64
 SyntaxPreprocessorStatement=#008080
 SyntaxPreprocessorValue=#800000
-Tooltip=#ffffe1
-TooltipText=black
+Tooltip=#251AAB
+TooltipText=white

--- a/Base/res/themes/Nord.ini
+++ b/Base/res/themes/Nord.ini
@@ -56,5 +56,5 @@ SyntaxControlKeyword=black
 SyntaxIdentifier=#092e64
 SyntaxPreprocessorStatement=#008080
 SyntaxPreprocessorValue=#800000
-Tooltip=#ffffe1
-TooltipText=black
+Tooltip=#4c566a
+TooltipText=white


### PR DESCRIPTION
For themes with primarily light text colors and dark backgrounds the current almost-white background/black text tooltips look a bit out of place. I've changed them to what I believe are sensible colors but theme authors are of course free to tweak further.