### PR TITLE
LibJS: Parse line continuations in string literals properly

### DIFF
--- a/Libraries/LibJS/Tests/functions/function-strict-mode.js
+++ b/Libraries/LibJS/Tests/functions/function-strict-mode.js
@@ -30,6 +30,12 @@ test("use strict with double quotes after statement does not yield strict mode c
     expect(isStrictMode()).toBeFalse();
 });
 
+test("use strict interrupted by a line continuation does not yield strict mode code", () => {
+    "use \
+    strict";
+    expect(isStrictMode()).toBeFalse();
+});
+
 test("strict mode propagates down the scope chain", () => {
     "use strict";
     expect(isStrictMode()).toBeTrue();

--- a/Libraries/LibJS/Tests/template-literals.js
+++ b/Libraries/LibJS/Tests/template-literals.js
@@ -53,6 +53,13 @@ test("newline literals (not characters)", () => {
     ).toBe("foo\n    bar");
 });
 
+test("line continuation in literals (not characters)", () => {
+    expect(
+        `foo\
+    bar`
+    ).toBe("foo    bar");
+});
+
 test("reference error from expressions", () => {
     expect(() => `${b}`).toThrowWithMessage(ReferenceError, "'b' is not defined");
 });

--- a/Libraries/LibJS/Tests/test-common-tests.js
+++ b/Libraries/LibJS/Tests/test-common-tests.js
@@ -53,6 +53,9 @@ test("toHaveLength", () => {
     expect([1]).toHaveLength(1);
     expect({ length: 1 }).toHaveLength(1);
 
+    expect("a\
+b").toHaveLength(2);
+
     expect(() => {
         expect(1).toHaveLength();
     }).toThrow(ExpectationError);

--- a/Libraries/LibJS/Token.cpp
+++ b/Libraries/LibJS/Token.cpp
@@ -155,6 +155,8 @@ String Token::string_value(StringValueStatus& status) const
             case '\\':
                 builder.append('\\');
                 break;
+            case '\n':
+                break;
             case 'x': {
                 if (i + 2 >= m_value.length() - offset)
                     return encoding_failure(StringValueStatus::MalformedHexEscape);


### PR DESCRIPTION
Newlines after line continuation were inserted into the string 
literals. This patch makes the parser ignore the newlines after \ and
also makes it so that "use strict" containing a line continuation is 
not a valid "use strict".

Fixes #3816
