### PR TITLE
Remove all calls to AK::warn.

### DIFF
--- a/AK/LogStream.h
+++ b/AK/LogStream.h
@@ -140,7 +140,7 @@ private:
 };
 
 [[deprecated("Use AK::outln or AK::new_out instead, AK::new_out will soon be renamed to AK::out.")]] inline StdLogStream out() { return StdLogStream(STDOUT_FILENO); }
-inline StdLogStream warn() { return StdLogStream(STDERR_FILENO); }
+[[deprecated("Use AK::warnln or AK::new_warn instead, AK::new_warn will soon be renamed to AK::warn.")]] inline StdLogStream warn() { return StdLogStream(STDERR_FILENO); }
 #endif
 
 #ifdef KERNEL

--- a/AK/Tests/TestBinarySearch.cpp
+++ b/AK/Tests/TestBinarySearch.cpp
@@ -108,44 +108,6 @@ TEST_CASE(no_elements)
     EXPECT_EQ(test1, nullptr);
 }
 
-TEST_CASE(huge_char_array)
-{
-    const size_t N = 2147483680;
-    Bytes span { new (std::nothrow) u8[N], N };
-    EXPECT(span.data() != nullptr);
-
-    for (size_t i = 0; i < span.size(); ++i)
-        span[i] = 'a';
-    size_t index = N - 1;
-    for (u8 c = 'z'; c > 'b'; --c)
-        span[index--] = c;
-
-    EXPECT_EQ(span[N - 1], 'z');
-
-    const u8 a = 'a';
-    auto where = binary_search(span, a, AK::integral_compare<u8>);
-    EXPECT(where != nullptr);
-    EXPECT_EQ(*where, 'a');
-
-    const u8 z = 'z';
-    where = binary_search(span, z, AK::integral_compare<u8>);
-    EXPECT(where != nullptr);
-    EXPECT_EQ(*where, 'z');
-
-    size_t near = 0;
-    const u8 tilde = '~';
-    where = binary_search(span, tilde, AK::integral_compare<u8>, &near);
-    EXPECT_EQ(where, nullptr);
-    EXPECT_EQ(near, N - 1);
-
-    const u8 b = 'b';
-    where = binary_search(span, b, AK::integral_compare<u8>, &near);
-    EXPECT_EQ(where, nullptr);
-    EXPECT_EQ(near, N - ('z' - b + 1));
-
-    delete[] span.data();
-}
-
 TEST_CASE(constexpr_array_search)
 {
     constexpr Array<int, 3> array = { 1, 17, 42 };

--- a/AK/Tests/TestNumberFormat.cpp
+++ b/AK/Tests/TestNumberFormat.cpp
@@ -135,13 +135,13 @@ void actual_extremes_8byte();
 template<>
 void actual_extremes_8byte<4>()
 {
-    warn() << "(Skipping 8-byte-size_t test)";
+    warnln("(Skipping 8-byte-size_t test)");
 }
 
 template<>
 void actual_extremes_8byte<8>()
 {
-    warn() << "(Running true 8-byte-size_t test)";
+    warnln("(Running true 8-byte-size_t test)");
     // Your editor might show "implicit conversion" warnings here.
     // This is because your editor thinks the world is 32-bit, but it isn't.
     EXPECT_EQ(human_readable_size(0x100000000ULL), "4.0 GiB");

--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -63,7 +63,7 @@ static String bookmarks_file_path()
 int main(int argc, char** argv)
 {
     if (getuid() == 0) {
-        warn() << "Refusing to run as root";
+        warnln("Refusing to run as root");
         return 1;
     }
 

--- a/Userland/Tests/LibC/snprintf-correctness.cpp
+++ b/Userland/Tests/LibC/snprintf-correctness.cpp
@@ -155,7 +155,7 @@ TEST_CASE(too_long)
 TEST_CASE(special_cases)
 {
     EXPECT(test_single({ LITERAL(""), "Hello Friend!", POISON, 13, LITERAL("") }));
-    EXPECT_EQ(snprintf(nullptr, 0, "Hello, friend!"), 0);
+    EXPECT_EQ(snprintf(nullptr, 0, "Hello, friend!"), 14);
     EXPECT(test_single({ LITERAL(""), "", POISON, 0, LITERAL("") }));
     EXPECT(test_single({ LITERAL("x"), "", POISON, 0, LITERAL("\0") }));
     EXPECT(test_single({ LITERAL("xx"), "", POISON, 0, LITERAL("\0x") }));

--- a/Userland/Tests/LibC/snprintf-correctness.cpp
+++ b/Userland/Tests/LibC/snprintf-correctness.cpp
@@ -46,7 +46,7 @@ static String show(const ByteBuffer& buf)
 {
     StringBuilder builder;
     for (size_t i = 0; i < buf.size(); ++i) {
-        builder.appendf("%02x", buf[i]);
+        builder.appendff("{:02x}", buf[i]);
     }
     builder.append(' ');
     builder.append('(');
@@ -66,8 +66,7 @@ static bool test_single(const Testcase& testcase)
 {
     // Preconditions:
     if (testcase.dest_n != testcase.dest_expected_n) {
-        fprintf(stderr, "dest length %zu != expected dest length %zu? Check testcase! (Probably miscounted.)\n",
-            testcase.dest_n, testcase.dest_expected_n);
+        warnln("dest length {} != expected dest length {}? Check testcase! (Probably miscounted.)", testcase.dest_n, testcase.dest_expected_n);
         return false;
     }
 
@@ -93,33 +92,29 @@ static bool test_single(const Testcase& testcase)
 
     // Evaluate gravity:
     if (buf_ok && (!canary_1_ok || !main_ok || !canary_2_ok)) {
-        fprintf(stderr, "Internal error! (%d != %d | %d | %d)\n",
-            buf_ok, canary_1_ok, main_ok, canary_2_ok);
+        warnln("Internal error! ({} != {} | {} | {})", buf_ok, canary_1_ok, main_ok, canary_2_ok);
         buf_ok = false;
     }
     if (!canary_1_ok) {
-        warn() << "Canary 1 overwritten: Expected canary "
-               << show(expected.slice_view(0, SANDBOX_CANARY_SIZE))
-               << ", got "
-               << show(actual.slice_view(0, SANDBOX_CANARY_SIZE))
-               << " instead!";
+        warnln("Canary 1 overwritten: Expected {}\n"
+               "                   instead got {}",
+            show(expected.slice_view(0, SANDBOX_CANARY_SIZE)),
+            show(actual.slice_view(0, SANDBOX_CANARY_SIZE)));
     }
     if (!main_ok) {
-        warn() << "Wrong output: Expected "
-               << show(expected.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n))
-               << "\n          instead, got " // visually align
-               << show(actual.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n));
+        warnln("Wrong output: Expected {}\n"
+               "          instead, got {}",
+            show(expected.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n)),
+            show(actual.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n)));
     }
     if (!canary_2_ok) {
-        warn() << "Canary 2 overwritten: Expected "
-               << show(expected.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE))
-               << ", got "
-               << show(actual.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE))
-               << " instead!";
+        warnln("Canary 2 overwritten: Expected {}\n"
+               "                  instead, got {}",
+            show(expected.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE)),
+            show(actual.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE)));
     }
     if (!return_ok) {
-        fprintf(stderr, "Wrong return value: Expected %d, got %d instead!\n",
-            testcase.expected_return, actual_return);
+        warnln("Wrong return value: Expected {}, got {} instead!", testcase.expected_return, actual_return);
     }
 
     return buf_ok && return_ok;

--- a/Userland/Tests/LibC/strlcpy-correctness.cpp
+++ b/Userland/Tests/LibC/strlcpy-correctness.cpp
@@ -46,7 +46,7 @@ static String show(const ByteBuffer& buf)
 {
     StringBuilder builder;
     for (size_t i = 0; i < buf.size(); ++i) {
-        builder.appendf("%02x", buf[i]);
+        builder.appendff("{:02x}", buf[i]);
     }
     builder.append(' ');
     builder.append('(');
@@ -66,13 +66,11 @@ static bool test_single(const Testcase& testcase)
 {
     // Preconditions:
     if (testcase.dest_n != testcase.dest_expected_n) {
-        fprintf(stderr, "dest length %zu != expected dest length %zu? Check testcase! (Probably miscounted.)\n",
-            testcase.dest_n, testcase.dest_expected_n);
+        warnln("dest length {} != expected dest length {}? Check testcase! (Probably miscounted.)", testcase.dest_n, testcase.dest_expected_n);
         return false;
     }
     if (testcase.src_n != strlen(testcase.src)) {
-        fprintf(stderr, "src length %zu != actual src length %zu? src can't contain NUL bytes!\n",
-            testcase.src_n, strlen(testcase.src));
+        warnln("src length {} != actual src length {}? src can't contain NUL bytes!", testcase.src_n, strlen(testcase.src));
         return false;
     }
 
@@ -98,33 +96,29 @@ static bool test_single(const Testcase& testcase)
 
     // Evaluate gravity:
     if (buf_ok && (!canary_1_ok || !main_ok || !canary_2_ok)) {
-        fprintf(stderr, "Internal error! (%d != %d | %d | %d)\n",
-            buf_ok, canary_1_ok, main_ok, canary_2_ok);
+        warnln("Internal error! ({} != {} | {} | {})", buf_ok, canary_1_ok, main_ok, canary_2_ok);
         buf_ok = false;
     }
     if (!canary_1_ok) {
-        warn() << "Canary 1 overwritten: Expected canary "
-               << show(expected.slice_view(0, SANDBOX_CANARY_SIZE))
-               << ", got "
-               << show(actual.slice_view(0, SANDBOX_CANARY_SIZE))
-               << " instead!";
+        warnln("Canary 1 overwritten: Expected canary {}\n"
+               "                          instead got {}",
+            show(expected.slice_view(0, SANDBOX_CANARY_SIZE)),
+            show(actual.slice_view(0, SANDBOX_CANARY_SIZE)));
     }
     if (!main_ok) {
-        warn() << "Wrong output: Expected "
-               << show(expected.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n))
-               << "\n          instead, got " // visually align
-               << show(actual.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n));
+        warnln("Wrong output: Expected {}\n"
+               "           instead got {}",
+            show(expected.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n)),
+            show(actual.slice_view(SANDBOX_CANARY_SIZE, testcase.dest_n)));
     }
     if (!canary_2_ok) {
-        warn() << "Canary 2 overwritten: Expected "
-               << show(expected.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE))
-               << ", got "
-               << show(actual.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE))
-               << " instead!";
+        warnln("Canary 2 overwritten: Expected {}\n"
+               "                   instead got {}",
+            show(expected.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE)),
+            show(actual.slice_view(SANDBOX_CANARY_SIZE + testcase.dest_n, SANDBOX_CANARY_SIZE)));
     }
     if (!return_ok) {
-        fprintf(stderr, "Wrong return value: Expected %zu, got %zu instead!\n",
-            testcase.src_n, actual_return);
+        warnln("Wrong return value: Expected {}, got {} instead!", testcase.src_n, actual_return);
     }
 
     return buf_ok && return_ok;

--- a/Userland/env.cpp
+++ b/Userland/env.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
     String filepath = Core::find_executable_in_path(filename);
 
     if (filepath.is_null()) {
-        warn() << "no " << filename << " in path";
+        warnln("no {} in path", filename);
         return 1;
     }
 

--- a/Userland/tar.cpp
+++ b/Userland/tar.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
         InputStream& gzip_input_stream = gzip_stream;
         Tar::TarStream tar_stream((gzip) ? gzip_input_stream : file_input_stream);
         if (!tar_stream.valid()) {
-            warn() << "the provided file is not a well-formatted ustar file";
+            warnln("the provided file is not a well-formatted ustar file");
             return 1;
         }
         for (; !tar_stream.finished(); tar_stream.advance()) {

--- a/Userland/test_io.cpp
+++ b/Userland/test_io.cpp
@@ -298,7 +298,7 @@ static void test_rmdir_root()
 {
     int rc = rmdir("/");
     if (rc != -1 || errno != EBUSY) {
-        warn() << "rmdir(/) didn't fail with EBUSY";
+        warnln("rmdir(/) didn't fail with EBUSY");
         ASSERT_NOT_REACHED();
     }
 }

--- a/Userland/utmpupdate.cpp
+++ b/Userland/utmpupdate.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv)
     args_parser.parse(argc, argv);
 
     if (flag_create && flag_delete) {
-        warn() << "-c and -d are mutually exclusive";
+        warnln("-c and -d are mutually exclusive");
         return 1;
     }
 

--- a/Userland/w.cpp
+++ b/Userland/w.cpp
@@ -65,13 +65,13 @@ int main()
 
     auto file_or_error = Core::File::open("/var/run/utmp", Core::IODevice::ReadOnly);
     if (file_or_error.is_error()) {
-        warn() << "Error: " << file_or_error.error();
+        warnln("Error: {}", file_or_error.error());
         return 1;
     }
     auto& file = *file_or_error.value();
     auto json = JsonValue::from_string(file.read_all());
     if (!json.has_value() || !json.value().is_object()) {
-        warn() << "Error: Could not parse /var/run/utmp";
+        warnln("Error: Could not parse /var/run/utmp");
         return 1;
     }
 


### PR DESCRIPTION
The same as #3828 but for `warn` instead of `out`.

---

I also removed a unit test in `TestBinarySearch.cpp`. That test has been bugging me for a while, it takes about ten seconds to run while all other tests take a few milliseconds. While the test seems really good, I feel like it shouldn't be run by default.

I thought about changing it somehow to make that test only run in Travis, but I feel that would be over engineered, since it's only a single test.

---

I also fixed a broken unit test in `Userland/Tests/LibC/snprintf-correctness.cpp`.
