### PR TITLE
LibJS: Allow all line terminators to be used for line continuations

### DIFF
--- a/Libraries/LibJS/Tests/functions/function-strict-mode.js
+++ b/Libraries/LibJS/Tests/functions/function-strict-mode.js
@@ -32,7 +32,7 @@ test("use strict with double quotes after statement does not yield strict mode c
 
 test("use strict interrupted by a line continuation does not yield strict mode code", () => {
     "use \
-    strict";
+strict";
     expect(isStrictMode()).toBeFalse();
 });
 

--- a/Libraries/LibJS/Tests/parser-line-terminators.js
+++ b/Libraries/LibJS/Tests/parser-line-terminators.js
@@ -18,13 +18,13 @@ test("CARRIAGE RETURN is a line terminator", () => {
 
 test("LINE SEPARATOR is a line terminator", () => {
     expect(() => {
-        Function(`  @`);
+        Function("  @");
     }).toThrowWithMessage(SyntaxError, "line: 3, column: 1");
 });
 
 test("PARAGRAPH SEPARATOR is a line terminator", () => {
     expect(() => {
-        Function(`  @`);
+        Function("  @");
     }).toThrowWithMessage(SyntaxError, "line: 3, column: 1");
 });
 
@@ -48,6 +48,13 @@ test("LS/PS are allowed in string literal", () => {
 
 test("line terminators can be mixed (but please don't)", () => {
     expect(() => {
-        Function(`\r\ \r\n \n\r@`);
+        Function("\r \r\n \n\r@");
     }).toThrowWithMessage(SyntaxError, "line: 7, column: 1");
+});
+
+test("all line terminators are valid for line continuations", () => {
+    expect(Function('return "a\\\nb"')()).toBe("ab");
+    expect(Function('return "a\\\rb"')()).toBe("ab");
+    expect(Function('return "a\\ b"')()).toBe("ab");
+    expect(Function('return "a\\ b"')()).toBe("ab");
 });

--- a/Libraries/LibJS/Token.cpp
+++ b/Libraries/LibJS/Token.cpp
@@ -157,6 +157,8 @@ String Token::string_value(StringValueStatus& status) const
                 break;
             case '\n':
                 break;
+            case '\r':
+                break;
             case 'x': {
                 if (i + 2 >= m_value.length() - offset)
                     return encoding_failure(StringValueStatus::MalformedHexEscape);
@@ -207,6 +209,14 @@ String Token::string_value(StringValueStatus& status) const
                 break;
             }
             default:
+                if (i + 2 < m_value.length() - offset) {
+                    auto three_chars_view = m_value.substring_view(i, 3);
+                    if (three_chars_view == LINE_SEPARATOR || three_chars_view == PARAGRAPH_SEPARATOR) {
+                        // line continuation with LS or PS
+                        i += 2;
+                        break;
+                    }
+                }
                 if (is_template && (m_value[i] == '$' || m_value[i] == '`')) {
                     builder.append(m_value[i]);
                     break;


### PR DESCRIPTION
Small addition to https://github.com/SerenityOS/serenity/pull/3845: also allow CR/LS/PS, not only LF.