### PR TITLE
Kernel: Set up and calibrate APIC timer, and enable timer on all CPUs

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -169,9 +169,9 @@ set(KERNEL_SOURCES
     Tasks/SyncTask.cpp
     Thread.cpp
     ThreadTracer.cpp
+    Time/APICTimer.cpp
     Time/HPET.cpp
     Time/HPETComparator.cpp
-    Time/HardwareTimer.cpp
     Time/PIT.cpp
     Time/RTC.cpp
     Time/TimeManagement.cpp

--- a/Kernel/Interrupts/APIC.h
+++ b/Kernel/Interrupts/APIC.h
@@ -27,9 +27,12 @@
 #pragma once
 
 #include <AK/Types.h>
+#include <Kernel/Time/HardwareTimer.h>
 #include <Kernel/VM/MemoryManager.h>
 
 namespace Kernel {
+
+class APICTimer;
 
 struct LocalAPIC {
     u32 apic_id;
@@ -51,6 +54,17 @@ public:
     static u8 spurious_interrupt_vector();
     Thread* get_idle_thread(u32 cpu) const;
     u32 enabled_processor_count() const { return m_processor_enabled_cnt; }
+
+    APICTimer* initialize_timers(HardwareTimerBase&);
+    APICTimer* get_timer() const { return m_apic_timer; }
+    enum class TimerMode {
+        OneShot,
+        Periodic,
+        TSCDeadline
+    };
+    void setup_local_timer(u32, TimerMode, bool);
+    u32 get_timer_current_count();
+    u32 get_timer_divisor();
 
 private:
     class ICRReg {
@@ -102,6 +116,7 @@ private:
     AK::Atomic<u8> m_apic_ap_continue { 0 };
     u32 m_processor_cnt { 0 };
     u32 m_processor_enabled_cnt { 0 };
+    APICTimer* m_apic_timer { nullptr };
 
     static PhysicalAddress get_base();
     static void set_base(const PhysicalAddress& base);

--- a/Kernel/Interrupts/GenericInterruptHandler.h
+++ b/Kernel/Interrupts/GenericInterruptHandler.h
@@ -65,6 +65,8 @@ protected:
     void change_interrupt_number(u8 number);
     GenericInterruptHandler(u8 interrupt_number, bool disable_remap = false);
 
+    void disable_remap() { m_disable_remap = true; }
+
 private:
     size_t m_invoking_count { 0 };
     u8 m_interrupt_number { 0 };

--- a/Kernel/Time/APICTimer.cpp
+++ b/Kernel/Time/APICTimer.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Kernel/Arch/i386/CPU.h>
+#include <Kernel/IO.h>
+#include <Kernel/Interrupts/APIC.h>
+#include <Kernel/Scheduler.h>
+#include <Kernel/Thread.h>
+#include <Kernel/Time/APICTimer.h>
+#include <Kernel/Time/TimeManagement.h>
+
+namespace Kernel {
+
+#define APIC_TIMER_MEASURE_CPU_CLOCK
+
+APICTimer* APICTimer::initialize(u8 interrupt_number, HardwareTimerBase& calibration_source)
+{
+    auto* timer = new APICTimer(interrupt_number, nullptr);
+    if (!timer->calibrate(calibration_source)) {
+        delete timer;
+        return nullptr;
+    }
+    return timer;
+}
+
+APICTimer::APICTimer(u8 interrupt_number, Function<void(const RegisterState&)> callback)
+    : HardwareTimer<GenericInterruptHandler>(interrupt_number, move(callback))
+{
+    disable_remap();
+}
+
+bool APICTimer::calibrate(HardwareTimerBase& calibration_source)
+{
+    ASSERT_INTERRUPTS_DISABLED();
+
+    klog() << "APICTimer: Using " << calibration_source.model() << " as calibration source";
+
+    auto& apic = APIC::the();
+#ifdef APIC_TIMER_MEASURE_CPU_CLOCK
+    bool supports_tsc = Processor::current().has_feature(CPUFeature::TSC);
+#endif
+
+    // temporarily replace the timer callbacks
+    const size_t ticks_in_100ms = calibration_source.ticks_per_second() / 10;
+    Atomic<size_t> calibration_ticks = 0;
+#ifdef APIC_TIMER_MEASURE_CPU_CLOCK
+    volatile u64 start_tsc = 0, end_tsc = 0;
+#endif
+    volatile u32 start_apic_count = 0, end_apic_count = 0;
+    auto original_source_callback = calibration_source.set_callback([&](const RegisterState&) {
+        u32 current_timer_count = apic.get_timer_current_count();
+#ifdef APIC_TIMER_MEASURE_CPU_CLOCK
+        u64 current_tsc = supports_tsc ? read_tsc() : 0;
+#endif
+
+        auto prev_tick = calibration_ticks.fetch_add(1, AK::memory_order_acq_rel);
+        if (prev_tick == 0) {
+#ifdef APIC_TIMER_MEASURE_CPU_CLOCK
+            start_tsc = current_tsc;
+#endif
+            start_apic_count = current_timer_count;
+        } else if (prev_tick + 1 == ticks_in_100ms) {
+#ifdef APIC_TIMER_MEASURE_CPU_CLOCK
+            end_tsc = current_tsc;
+#endif
+            end_apic_count = current_timer_count;
+        }
+    });
+
+    // Setup a counter that should be much longer than our calibration time.
+    // We don't want the APIC timer to actually fire. We do however want the
+    // calbibration_source timer to fire so that we can read the current
+    // tick count from the APIC timer
+    auto original_callback = set_callback([&](const RegisterState&) {
+        klog() << "APICTimer: Timer fired during calibration!";
+        ASSERT_NOT_REACHED(); // TODO: How should we handle this?
+    });
+    apic.setup_local_timer(0xffffffff, APIC::TimerMode::Periodic, true);
+
+    sti();
+    // Loop for about 100 ms
+    while (calibration_ticks.load(AK::memory_order_relaxed) < ticks_in_100ms)
+        ;
+    cli();
+
+    // Restore timer callbacks
+    calibration_source.set_callback(move(original_source_callback));
+    set_callback(move(original_callback));
+
+    disable_local_timer();
+
+    auto delta_apic_count = end_apic_count - start_apic_count;
+    m_timer_period = (delta_apic_count * apic.get_timer_divisor()) / ticks_in_100ms;
+
+    auto apic_freq = (delta_apic_count * 16) / apic.get_timer_divisor();
+    if (apic_freq < 1000000) {
+        klog() << "APICTimer: Frequency too slow!";
+        return false;
+    }
+    klog() << "APICTimer: Bus clock speed: " << (apic_freq / 1000000) << "." << (apic_freq % 1000000) << " MHz";
+#ifdef APIC_TIMER_MEASURE_CPU_CLOCK
+    if (supports_tsc) {
+        auto delta_tsc = end_tsc - start_tsc;
+        klog() << "APICTimer: CPU clock speed: " << (delta_tsc / 1000000) << "." << (delta_tsc % 1000000) << " MHz";
+    }
+#endif
+
+    enable_local_timer();
+    return true;
+}
+
+void APICTimer::enable_local_timer()
+{
+    APIC::the().setup_local_timer(m_timer_period, m_timer_mode, true);
+}
+
+void APICTimer::disable_local_timer()
+{
+    APIC::the().setup_local_timer(0, APIC::TimerMode::OneShot, false);
+}
+
+size_t APICTimer::ticks_per_second() const
+{
+    return m_frequency;
+}
+
+void APICTimer::set_periodic()
+{
+    // FIXME: Implement it...
+    ASSERT_NOT_REACHED();
+}
+void APICTimer::set_non_periodic()
+{
+    // FIXME: Implement it...
+    ASSERT_NOT_REACHED();
+}
+
+void APICTimer::reset_to_default_ticks_per_second()
+{
+}
+
+bool APICTimer::try_to_set_frequency(size_t frequency)
+{
+    (void)frequency;
+    return true;
+}
+
+bool APICTimer::is_capable_of_frequency(size_t frequency) const
+{
+    (void)frequency;
+    return false;
+}
+
+size_t APICTimer::calculate_nearest_possible_frequency(size_t frequency) const
+{
+    (void)frequency;
+    return 0;
+}
+
+}

--- a/Kernel/Time/HPETComparator.h
+++ b/Kernel/Time/HPETComparator.h
@@ -32,7 +32,7 @@
 #include <Kernel/Time/HardwareTimer.h>
 
 namespace Kernel {
-class HPETComparator final : public HardwareTimer {
+class HPETComparator final : public HardwareTimer<IRQHandler> {
     friend class HPET;
 
 public:

--- a/Kernel/Time/HardwareTimer.h
+++ b/Kernel/Time/HardwareTimer.h
@@ -35,37 +35,114 @@
 namespace Kernel {
 
 enum class HardwareTimerType {
-    i8253 = 0x1,                  /* PIT */
-    RTC = 0x2,                    /* Real Time Clock */
-    HighPrecisionEventTimer = 0x3 /* also known as IA-PC HPET */
+    i8253 = 0x1,                   /* PIT */
+    RTC = 0x2,                     /* Real Time Clock */
+    HighPrecisionEventTimer = 0x3, /* also known as IA-PC HPET */
+    LocalAPICTimer = 0x4           /* Local APIC */
 };
 
-class HardwareTimer
-    : public RefCounted<HardwareTimer>
-    , public IRQHandler {
+template<typename InterruptHandlerType>
+class HardwareTimer;
+
+class HardwareTimerBase
+    : public RefCounted<HardwareTimerBase> {
 public:
-    virtual HardwareTimerType timer_type() const = 0;
+    virtual ~HardwareTimerBase() { }
+
     virtual const char* model() const = 0;
-    virtual const char* purpose() const override;
-
-    void set_callback(Function<void(const RegisterState&)>);
-
-    virtual size_t ticks_per_second() const = 0;
+    virtual HardwareTimerType timer_type() const = 0;
+    virtual Function<void(const RegisterState&)> set_callback(Function<void(const RegisterState&)>) = 0;
 
     virtual bool is_periodic() const = 0;
     virtual bool is_periodic_capable() const = 0;
     virtual void set_periodic() = 0;
     virtual void set_non_periodic() = 0;
 
+    virtual size_t ticks_per_second() const = 0;
+
     virtual void reset_to_default_ticks_per_second() = 0;
     virtual bool try_to_set_frequency(size_t frequency) = 0;
     virtual bool is_capable_of_frequency(size_t frequency) const = 0;
     virtual size_t calculate_nearest_possible_frequency(size_t frequency) const = 0;
+};
+
+template<>
+class HardwareTimer<IRQHandler>
+    : public HardwareTimerBase
+    , public IRQHandler {
+public:
+    virtual const char* purpose() const override
+    {
+        if (TimeManagement::the().is_system_timer(*this))
+            return "System Timer";
+        return model();
+    }
+
+    virtual Function<void(const RegisterState&)> set_callback(Function<void(const RegisterState&)> callback) override
+    {
+        disable_irq();
+        auto previous_callback = move(m_callback);
+        m_callback = move(callback);
+        enable_irq();
+        return previous_callback;
+    }
 
 protected:
-    HardwareTimer(u8 irq_number, Function<void(const RegisterState&)> = nullptr);
-    //^IRQHandler
-    virtual void handle_irq(const RegisterState&) override;
+    HardwareTimer(u8 irq_number, Function<void(const RegisterState&)> callback = nullptr)
+        : IRQHandler(irq_number)
+        , m_callback(move(callback))
+    {
+    }
+
+    virtual void handle_irq(const RegisterState& regs) override
+    {
+        if (m_callback)
+            m_callback(regs);
+    }
+
+    u64 m_frequency { OPTIMAL_TICKS_PER_SECOND_RATE };
+
+private:
+    Function<void(const RegisterState&)> m_callback;
+};
+
+template<>
+class HardwareTimer<GenericInterruptHandler>
+    : public HardwareTimerBase
+    , public GenericInterruptHandler {
+public:
+    virtual const char* purpose() const override
+    {
+        return model();
+    }
+
+    virtual Function<void(const RegisterState&)> set_callback(Function<void(const RegisterState&)> callback) override
+    {
+        auto previous_callback = move(m_callback);
+        m_callback = move(callback);
+        return previous_callback;
+    }
+
+    virtual size_t sharing_devices_count() const override { return 0; }
+    virtual bool is_shared_handler() const override { return false; }
+    virtual bool is_sharing_with_others() const { return false; }
+    virtual HandlerType type() const override { return HandlerType::IRQHandler; }
+    virtual const char* controller() const override { return nullptr; }
+    virtual bool eoi() override;
+
+protected:
+    HardwareTimer(u8 irq_number, Function<void(const RegisterState&)> callback = nullptr)
+        : GenericInterruptHandler(irq_number)
+        , m_callback(move(callback))
+    {
+    }
+
+    virtual void handle_interrupt(const RegisterState& regs) override
+    {
+        if (m_callback)
+            m_callback(regs);
+    }
+
     u64 m_frequency { OPTIMAL_TICKS_PER_SECOND_RATE };
 
 private:

--- a/Kernel/Time/PIT.h
+++ b/Kernel/Time/PIT.h
@@ -52,7 +52,7 @@ namespace Kernel {
 
 #define BASE_FREQUENCY 1193182
 
-class PIT final : public HardwareTimer {
+class PIT final : public HardwareTimer<IRQHandler> {
 public:
     static NonnullRefPtr<PIT> initialize(Function<void(const RegisterState&)>);
     virtual HardwareTimerType timer_type() const override { return HardwareTimerType::i8253; }

--- a/Kernel/Time/RTC.h
+++ b/Kernel/Time/RTC.h
@@ -31,7 +31,7 @@
 #include <Kernel/Time/HardwareTimer.h>
 
 namespace Kernel {
-class RealTimeClock final : public HardwareTimer {
+class RealTimeClock final : public HardwareTimer<IRQHandler> {
 public:
     static NonnullRefPtr<RealTimeClock> create(Function<void(const RegisterState&)> callback);
     virtual HardwareTimerType timer_type() const override { return HardwareTimerType::RTC; }

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -35,7 +35,7 @@ namespace Kernel {
 
 #define OPTIMAL_TICKS_PER_SECOND_RATE 1000
 
-class HardwareTimer;
+class HardwareTimerBase;
 
 class TimeManagement {
     AK_MAKE_ETERNAL;
@@ -43,7 +43,7 @@ class TimeManagement {
 public:
     TimeManagement();
     static bool initialized();
-    static void initialize();
+    static void initialize(u32 cpu);
     static TimeManagement& the();
 
     timespec epoch_time() const;
@@ -53,7 +53,7 @@ public:
     time_t ticks_this_second() const;
     time_t boot_time() const;
 
-    bool is_system_timer(const HardwareTimer&) const;
+    bool is_system_timer(const HardwareTimerBase&) const;
 
     static void update_time(const RegisterState&);
     void increment_time_since_boot(const RegisterState&);
@@ -65,15 +65,16 @@ public:
 private:
     bool probe_and_set_legacy_hardware_timers();
     bool probe_and_set_non_legacy_hardware_timers();
-    Vector<HardwareTimer*> scan_and_initialize_periodic_timers();
-    Vector<HardwareTimer*> scan_for_non_periodic_timers();
-    NonnullRefPtrVector<HardwareTimer> m_hardware_timers;
+    Vector<HardwareTimerBase*> scan_and_initialize_periodic_timers();
+    Vector<HardwareTimerBase*> scan_for_non_periodic_timers();
+    NonnullRefPtrVector<HardwareTimerBase> m_hardware_timers;
+    void set_system_timer(HardwareTimerBase&);
 
     u32 m_ticks_this_second { 0 };
     u32 m_seconds_since_boot { 0 };
     timespec m_epoch_time { 0, 0 };
-    RefPtr<HardwareTimer> m_system_timer;
-    RefPtr<HardwareTimer> m_time_keeper_timer;
+    RefPtr<HardwareTimerBase> m_system_timer;
+    RefPtr<HardwareTimerBase> m_time_keeper_timer;
 };
 
 }

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -149,7 +149,7 @@ extern "C" [[noreturn]] void init()
 
     __stack_chk_guard = get_fast_random<u32>();
 
-    TimeManagement::initialize();
+    TimeManagement::initialize(0);
 
     NullDevice::initialize();
     if (!get_serial_debug())
@@ -208,6 +208,7 @@ extern "C" void init_finished(u32 cpu)
         // TODO: we can reuse the boot stack, maybe for kmalloc()?
     } else {
         APIC::the().init_finished(cpu);
+        TimeManagement::initialize(cpu);
     }
 }
 


### PR DESCRIPTION
This enables the APIC timer on all CPUs, which means Scheduler::timer_tick
is now called on all CPUs independently. We still don't do anything on
the APs as it instantly crashes due to a number of other problems.

You asked for some work in that area, so here is a (small) step forward ;-)