### PR TITLE
SMP related fixes

### DIFF
--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -2019,9 +2019,7 @@ void __assertion_failed(const char* msg, const char* file, unsigned line, const 
         MM.enter_process_paging_scope(*process);
 
     Kernel::dump_backtrace();
-    asm volatile("hlt");
-    for (;;)
-        ;
+    Processor::halt();
 }
 #endif
 

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -588,7 +588,6 @@ void APIC::setup_local_timer(u32 ticks, TimerMode timer_mode, bool enable)
     default:
         ASSERT_NOT_REACHED();
     }
-    config |= 3; // divide by 16
     write_register(APIC_REG_TIMER_CONFIGURATION, config);
 
     if (timer_mode == TimerMode::Periodic)

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -322,6 +322,7 @@ NonnullRefPtr<Process> Process::create_kernel_process(RefPtr<Thread>& first_thre
         process->ref();
     }
 
+    ScopedSpinLock lock(g_scheduler_lock);
     first_thread->set_affinity(affinity);
     first_thread->set_state(Thread::State::Runnable);
     return process;
@@ -781,6 +782,7 @@ RefPtr<Thread> Process::create_kernel_thread(void (*entry)(), u32 priority, cons
     auto& tss = thread->tss();
     tss.eip = (FlatPtr)entry;
 
+    ScopedSpinLock lock(g_scheduler_lock);
     thread->set_state(Thread::State::Runnable);
     return thread;
 }

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -308,7 +308,10 @@ int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Ve
     if (was_profiling)
         Profiling::did_exec(path);
 
-    new_main_thread->set_state(Thread::State::Runnable);
+    {
+        ScopedSpinLock lock(g_scheduler_lock);
+        new_main_thread->set_state(Thread::State::Runnable);
+    }
     big_lock().force_unlock_if_locked();
     ASSERT_INTERRUPTS_DISABLED();
     ASSERT(Processor::current().in_critical());

--- a/Kernel/Time/APICTimer.cpp
+++ b/Kernel/Time/APICTimer.cpp
@@ -115,7 +115,7 @@ bool APICTimer::calibrate(HardwareTimerBase& calibration_source)
     auto delta_apic_count = end_apic_count - start_apic_count;
     m_timer_period = (delta_apic_count * apic.get_timer_divisor()) / ticks_in_100ms;
 
-    auto apic_freq = (delta_apic_count * 16) / apic.get_timer_divisor();
+    auto apic_freq = (delta_apic_count * apic.get_timer_divisor()) / apic.get_timer_divisor();
     if (apic_freq < 1000000) {
         klog() << "APICTimer: Frequency too slow!";
         return false;


### PR DESCRIPTION
Another small step towards being able to run with this removed:
https://github.com/SerenityOS/serenity/blob/fe615e601a95033c160b464728d8a0c195739f72/Kernel/Scheduler.cpp#L786

Seems like one of the problems once again is `Thread::wait_on` when it's called from a page fault handler in `PATAChannel`. It seems to leave `s_mm_lock` dangling, which then deadlocks...

But it does do a few context switches on both CPUs.