### PR TITLE
LibMarkdown: Don't parse lines starting with a space as heading

### DIFF
--- a/Libraries/LibMarkdown/Heading.cpp
+++ b/Libraries/LibMarkdown/Heading.cpp
@@ -67,11 +67,12 @@ OwnPtr<Heading> Heading::parse(Vector<StringView>::ConstIterator& lines)
     const StringView& line = *lines;
     size_t level;
 
-    for (level = 0; level < line.length(); level++)
+    for (level = 0; level < line.length(); level++) {
         if (line[level] != '#')
             break;
+    }
 
-    if (level >= line.length() || line[level] != ' ')
+    if (!level || level >= line.length() || line[level] != ' ')
         return nullptr;
 
     StringView title_view = line.substring_view(level + 1, line.length() - level - 1);

--- a/Libraries/LibMarkdown/Heading.h
+++ b/Libraries/LibMarkdown/Heading.h
@@ -40,6 +40,7 @@ public:
         : m_text(move(text))
         , m_level(level)
     {
+        ASSERT(m_level > 0);
     }
     virtual ~Heading() override { }
 


### PR DESCRIPTION
This fixes a bug where lines starting with a space would get parsed as "level 0" headings - it would not find a "#" and therefore never increase the level counter (starting at zero), which then would cause the check for "space after #" pass (again, there is no "#").

Eventually we would get funny results like this:

    <h0>[n-1 spaces]oops!</h0>

Also `ASSERT(level > 0)` in the `Heading` constructor.