### PR TITLE
LibJS: Unterminated multi line comments are a syntax error

### DIFF
--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -505,8 +505,10 @@ Token Lexer::next()
                     is_invalid_numeric_literal = !consume_exponent();
             }
         }
-        if (is_invalid_numeric_literal)
+        if (is_invalid_numeric_literal) {
             token_type = TokenType::Invalid;
+            token_message = "Invalid numeric literal";
+        }
     } else if (m_current_char == '"' || m_current_char == '\'') {
         char stop_char = m_current_char;
         consume();

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -1917,7 +1917,10 @@ Token Parser::consume_and_validate_numeric_literal()
 
 void Parser::expected(const char* what)
 {
-    syntax_error(String::formatted("Unexpected token {}. Expected {}", m_parser_state.m_current_token.name(), what));
+    auto message = m_parser_state.m_current_token.message();
+    if (message.is_empty())
+        message = String::formatted("Unexpected token {}. Expected {}", m_parser_state.m_current_token.name(), what);
+    syntax_error(message);
 }
 
 void Parser::syntax_error(const String& message, size_t line, size_t column)

--- a/Libraries/LibJS/Tests/comments-basic.js
+++ b/Libraries/LibJS/Tests/comments-basic.js
@@ -21,3 +21,11 @@ return i;`;
 
     expect(source).toEvalTo(1);
 });
+
+test("unterminated multi-line comment", () => {
+    expect("/*").not.toEval();
+    expect("/**").not.toEval();
+    expect("/*/").not.toEval();
+    expect("/* foo").not.toEval();
+    expect("foo /*").not.toEval();
+});

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -181,8 +181,9 @@ enum class TokenCategory {
 
 class Token {
 public:
-    Token(TokenType type, StringView trivia, StringView value, size_t line_number, size_t line_column)
+    Token(TokenType type, String message, StringView trivia, StringView value, size_t line_number, size_t line_column)
         : m_type(type)
+        , m_message(message)
         , m_trivia(trivia)
         , m_value(value)
         , m_line_number(line_number)
@@ -196,6 +197,7 @@ public:
     const char* name() const;
     static const char* name(TokenType);
 
+    const String& message() const { return m_message; }
     const StringView& trivia() const { return m_trivia; }
     const StringView& value() const { return m_value; }
     size_t line_number() const { return m_line_number; }
@@ -217,6 +219,7 @@ public:
 
 private:
     TokenType m_type;
+    String m_message;
     StringView m_trivia;
     StringView m_value;
     size_t m_line_number;


### PR DESCRIPTION
This fixes the annoying fact that we used to just accept unterminated multi-line comments (also 10 more test262-parser-tests tests).

I hope this concept is sane, if you'd rather want these to be individual invalid tokens we can do that, but I'd prefer not to.