### PR TITLE
LibJS: Use ES6 do-while ASI rule // Don't parse numeric literals containing 8 or 9 as octal

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -1524,7 +1524,10 @@ NonnullRefPtr<DoWhileStatement> Parser::parse_do_while_statement()
     auto test = parse_expression(0);
 
     consume(TokenType::ParenClose);
-    consume_or_insert_semicolon();
+
+    // Since ES 2015 a missing semicolon is inserted here, despite the regular ASI rules not applying
+    if (match(TokenType::Semicolon))
+        consume();
 
     return create_ast_node<DoWhileStatement>(move(test), move(body));
 }

--- a/Libraries/LibJS/Tests/loops/do-while-basic.js
+++ b/Libraries/LibJS/Tests/loops/do-while-basic.js
@@ -18,3 +18,7 @@ test("exception in test expression", () => {
         do {} while (foo);
     }).toThrow(ReferenceError);
 });
+
+test("automatic semicolon insertion", () => {
+    expect("do {} while (false) foo").toEval();
+});

--- a/Libraries/LibJS/Tests/numeric-literals-basic.js
+++ b/Libraries/LibJS/Tests/numeric-literals-basic.js
@@ -10,6 +10,7 @@ test("octal literals", () => {
     expect(0o10).toBe(8);
     expect(0o10).toBe(8);
     expect(010).toBe(8);
+    expect(089).toBe(89);
 });
 
 test("binary literals", () => {

--- a/Libraries/LibJS/Tests/test-common-tests.js
+++ b/Libraries/LibJS/Tests/test-common-tests.js
@@ -330,7 +330,7 @@ test("toThrowWithMessage", () => {
 // "eval" function
 test("toEval", () => {
     expect("let a = 1").toEval();
-    expect("a < 1").not.toEval();
+    expect("a < 1").toEval();
     expect("&&*^%#%@").not.toEval();
     expect("function foo() { return 1; }; return foo();").toEval();
 });

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -287,7 +287,7 @@ class ExpectationError extends Error {
 
             let threw = false;
             try {
-                new Function(this.target)();
+                new Function(this.target);
             } catch (e) {
                 threw = true;
             }

--- a/Libraries/LibJS/Token.cpp
+++ b/Libraries/LibJS/Token.cpp
@@ -86,7 +86,8 @@ double Token::double_value() const
             return static_cast<double>(strtoul(value_string.characters() + 2, nullptr, 2));
         } else if (isdigit(value_string[1])) {
             // also octal, but syntax error in strict mode
-            return static_cast<double>(strtoul(value_string.characters() + 1, nullptr, 8));
+            if (!m_value.contains('8') && !m_value.contains('9'))
+                return static_cast<double>(strtoul(value_string.characters() + 1, nullptr, 8));
         }
     }
     return strtod(value_string.characters(), nullptr);


### PR DESCRIPTION
Two smol parser fixes.