### PR TITLE
LibJS: "-->" preceded by token on same line isn't start of HTML-like comment

### DIFF
--- a/Libraries/LibJS/Lexer.h
+++ b/Libraries/LibJS/Lexer.h
@@ -50,7 +50,7 @@ private:
     bool is_line_terminator() const;
     bool is_identifier_start() const;
     bool is_identifier_middle() const;
-    bool is_line_comment_start() const;
+    bool is_line_comment_start(bool line_has_token_yet) const;
     bool is_block_comment_start() const;
     bool is_block_comment_end() const;
     bool is_numeric_literal_start() const;

--- a/Libraries/LibJS/Tests/comments-basic.js
+++ b/Libraries/LibJS/Tests/comments-basic.js
@@ -1,25 +1,29 @@
 test("regular comments", () => {
-    const source = `var i = 0;
-
+    const source = `
+var i = 0;
 // i++;
 /* i++; */
 /*
 i++;
 */
+/**/ i++;
 return i;`;
 
-    expect(source).toEvalTo(0);
+    expect(source).toEvalTo(1);
 });
 
 test("html comments", () => {
-    const source = `var i = 0;
+    const source = `
+var i = 0;
+var j = 0;
 <!-- i++; --> i++;
 <!-- i++;
 i++;
 --> i++;
+/**/ --> i++;
+j --> i++;
 return i;`;
-
-    expect(source).toEvalTo(1);
+    expect(source).toEvalTo(2);
 });
 
 test("unterminated multi-line comment", () => {


### PR DESCRIPTION
B.1.3 HTML-like Comments

The syntax and semantics of 11.4 is extended as follows except that this
extension is not allowed when parsing source code using the goal symbol
Module:

Syntax (only relevant part included)

    SingleLineHTMLCloseComment ::
        LineTerminatorSequence HTMLCloseComment

    HTMLCloseComment ::
        WhiteSpaceSequence[opt] SingleLineDelimitedCommentSequence[opt] --> SingleLineCommentChars[opt]

Fixes #3810.