### PR TITLE
Userland: Do not put a trailing space after the resulting pids in pidof

### DIFF
--- a/Userland/pidof.cpp
+++ b/Userland/pidof.cpp
@@ -44,7 +44,7 @@ static int pid_of(const String& process_name, bool single_shot, bool omit_pid, p
     for (auto& it : processes) {
         if (it.value.name == process_name) {
             if (!omit_pid || it.value.pid != pid) {
-                printf("%d ", it.value.pid);
+                printf(" %d" + (displayed_at_least_one ? 0 : 1), it.value.pid);
                 displayed_at_least_one = true;
 
                 if (single_shot)


### PR DESCRIPTION
Minor fix for a minor issue I noticed, `kill -STOP $(pidof SystemMonitor)` will not work, as the shell does not split `$(...)` on spaces, and the results of `$(...)` are not resplit.