### PR TITLE
Kernel: Fix APIC timer frequency

### DIFF
--- a/Kernel/Time/APICTimer.cpp
+++ b/Kernel/Time/APICTimer.cpp
@@ -112,7 +112,7 @@ bool APICTimer::calibrate(HardwareTimerBase& calibration_source)
 
     disable_local_timer();
 
-    auto delta_apic_count = end_apic_count - start_apic_count;
+    auto delta_apic_count = start_apic_count - end_apic_count; // The APIC current count register decrements!
     m_timer_period = (delta_apic_count * apic.get_timer_divisor()) / ticks_in_100ms;
 
     auto apic_freq = (delta_apic_count * apic.get_timer_divisor()) / apic.get_timer_divisor();


### PR DESCRIPTION
The APIC current count register decrements on each clock tick.
Fixes the APIC timer firing much less frequently than it should be.