### PR TITLE
LibChess: Forbid King moving into check by a pawn on the home rank

### DIFF
--- a/Libraries/LibChess/Chess.h
+++ b/Libraries/LibChess/Chess.h
@@ -159,6 +159,7 @@ public:
 
 private:
     bool is_legal_no_check(const Move&, Colour colour) const;
+    bool is_legal_promotion(const Move&, Colour colour) const;
     bool apply_illegal_move(const Move&, Colour colour);
 
     Piece m_board[8][8];


### PR DESCRIPTION
A player can no longer move the King piece into any position on
their home rank if the move would place the King in check.

A player can also no longer ignore a check position when in check
by a pawn on their home rank. The player must now resolve the check
during their move.

Resolves #3525
Resolves #3526

This issue was caused by `in_check` verifying whether the `Move` would place a king in check. The function called `is_legal_no_check` to determine if a square would place the king in check. However, `is_legal_no_check` is called with `Move.promote_to = Type::None` while performing the check.

When determining a valid move for a pawn (and thus whether the pawn could check the king) the pawn promotion checks were performed before all other checks. Unfortunately, all move verification in `LibChess` is performed on `Move` structs with a default `promote_to` of `Type::None` and a pawn moving to the promotion rank without selecting a piece for promotion is an invalid move.

`LibChess` uses two functions to verify if a move is valid: `is_legal` and `is_legal_no_check`. The `in_check` function uses the latter, and this is the only place the latter is used.

To resolve this issue, as the promotion checking code is not required by `in_check` or `is_legal_no_check`, all promotion checking code was abstracted away into a `is_legal_promotion` function which is called from `is_legal`. Abstracting into a separate `is_legal_promotion` function wasn't necessary (the code could go in `is_legal`), and this `is_legal_promotion` function is only used once, but this approach seemed cleaner than keeping the code inside the `is_legal`.
