### PR TITLE
LibJS: Require initializer for 'const' variable declaration

### DIFF
--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -66,7 +66,7 @@ public:
     NonnullRefPtr<BlockStatement> parse_block_statement();
     NonnullRefPtr<BlockStatement> parse_block_statement(bool& is_strict);
     NonnullRefPtr<ReturnStatement> parse_return_statement();
-    NonnullRefPtr<VariableDeclaration> parse_variable_declaration(bool with_semicolon = true);
+    NonnullRefPtr<VariableDeclaration> parse_variable_declaration(bool for_loop_variable_declaration = false);
     NonnullRefPtr<Statement> parse_for_statement();
     NonnullRefPtr<Statement> parse_for_in_of_statement(NonnullRefPtr<ASTNode> lhs);
     NonnullRefPtr<IfStatement> parse_if_statement();

--- a/Libraries/LibJS/Tests/const-declaration-missing-initializer.js
+++ b/Libraries/LibJS/Tests/const-declaration-missing-initializer.js
@@ -1,0 +1,5 @@
+test("missing initializer in 'const' variable declaration is syntax error", () => {
+    expect("const foo").not.toEval();
+    expect("const foo = 1, bar").not.toEval();
+    expect("const foo = 1, bar, baz = 2").not.toEval();
+});


### PR DESCRIPTION
sharing the parsing of variable declarations between "regular" ones, for-loop and for..in/of-loop ones probably makes this a bit more complicated than necessary; we should overhaul that part at some point IMO.