### PR TITLE
Applications: Use application icons for dialog windows

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -306,6 +306,7 @@ Tab::Tab(Type type)
                 editor.set_ruler_visible(true);
                 window->resize(640, 480);
                 window->set_title(url);
+                window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-text.png"));
                 window->show();
                 (void)window.leak_ref();
             } else {
@@ -321,6 +322,7 @@ Tab::Tab(Type type)
                     m_dom_inspector_window = GUI::Window::construct();
                     m_dom_inspector_window->resize(300, 500);
                     m_dom_inspector_window->set_title("DOM inspector");
+                    m_dom_inspector_window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/inspector-object.png"));
                     m_dom_inspector_window->set_main_widget<InspectorWidget>();
                 }
                 auto* inspector_widget = static_cast<InspectorWidget*>(m_dom_inspector_window->main_widget());
@@ -344,6 +346,7 @@ Tab::Tab(Type type)
                     m_console_window = GUI::Window::construct();
                     m_console_window->resize(500, 300);
                     m_console_window->set_title("JS Console");
+                    m_console_window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-javascript.png"));
                     m_console_window->set_main_widget<ConsoleWidget>();
                 }
                 auto* console_widget = static_cast<ConsoleWidget*>(m_console_window->main_widget());

--- a/Applications/PixelPaint/CreateNewLayerDialog.cpp
+++ b/Applications/PixelPaint/CreateNewLayerDialog.cpp
@@ -37,6 +37,7 @@ CreateNewLayerDialog::CreateNewLayerDialog(const Gfx::IntSize& suggested_size, G
     : Dialog(parent_window)
 {
     set_title("Create new layer");
+    set_icon(parent_window->icon());
     resize(200, 200);
 
     auto& main_widget = set_main_widget<GUI::Widget>();

--- a/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -61,6 +61,7 @@ CellTypeDialog::CellTypeDialog(const Vector<Position>& positions, Sheet& sheet, 
         builder.appendff("Format {} Cells", positions.size());
 
     set_title(builder.string_view());
+    set_icon(parent->icon());
     resize(285, 360);
 
     auto& main_widget = set_main_widget<GUI::Widget>();

--- a/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Applications/Spreadsheet/HelpWindow.cpp
@@ -81,6 +81,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
 {
     resize(530, 365);
     set_title("Spreadsheet Functions Help");
+    set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-help.png"));
 
     auto& widget = set_main_widget<GUI::Widget>();
     widget.set_layout<GUI::VerticalBoxLayout>().set_margins({ 4, 4, 4, 4 });

--- a/Games/Chess/PromotionDialog.cpp
+++ b/Games/Chess/PromotionDialog.cpp
@@ -34,6 +34,7 @@ PromotionDialog::PromotionDialog(ChessWidget& chess_widget)
     , m_selected_piece(Chess::Type::None)
 {
     set_title("Choose piece to promote to");
+    set_icon(chess_widget.window()->icon());
     resize(70 * 4, 70);
 
     auto& main_widget = set_main_widget<GUI::Frame>();


### PR DESCRIPTION
A bunch of application dialog windows were using the default window icon.

While this is reminiscent of My First Win32 app (aka `Project1`), this was an oversight rather than a deliberate style choice.
