### PR TITLE
LibJS: Function declarations in if statement clauses

### DIFF
--- a/Libraries/LibJS/Tests/if-statement-function-declaration.js
+++ b/Libraries/LibJS/Tests/if-statement-function-declaration.js
@@ -1,0 +1,41 @@
+describe("function declarations in if statement clauses", () => {
+    test("if clause", () => {
+        if (true) function foo() {}
+        if (false) function bar() {}
+        expect(typeof globalThis.foo).toBe("function");
+        expect(typeof globalThis.bar).toBe("undefined");
+    });
+
+    test("else clause", () => {
+        if (false);
+        else function foo() {}
+        if (true);
+        else function bar() {}
+        expect(typeof globalThis.foo).toBe("function");
+        expect(typeof globalThis.bar).toBe("undefined");
+    });
+
+    test("if and else clause", () => {
+        if (true) function foo() {}
+        else function bar() {}
+        expect(typeof globalThis.foo).toBe("function");
+        expect(typeof globalThis.bar).toBe("undefined");
+    });
+
+    test("syntax error in strict mode", () => {
+        expect(`
+            "use strict";
+            if (true) function foo() {}
+        `).not.toEval();
+        expect(`
+            "use strict";
+            if (false);
+            else function foo() {}
+        `).not.toEval();
+        expect(`
+            "use strict";
+            if (false) function foo() {}
+            else function bar() {}
+        `).not.toEval();
+    });
+});


### PR DESCRIPTION
https://tc39.es/ecma262/#sec-functiondeclarations-in-ifstatement-statement-clauses

B.3.4 FunctionDeclarations in IfStatement Statement Clauses

The following augments the IfStatement production in 13.6:

    IfStatement[Yield, Await, Return] :
        if ( Expression[+In, ?Yield, ?Await] ) FunctionDeclaration[?Yield, ?Await, ~Default] else Statement[?Yield, ?Await, ?Return]
        if ( Expression[+In, ?Yield, ?Await] ) Statement[?Yield, ?Await, ?Return] else FunctionDeclaration[?Yield, ?Await, ~Default]
        if ( Expression[+In, ?Yield, ?Await] ) FunctionDeclaration[?Yield, ?Await, ~Default] else FunctionDeclaration[?Yield, ?Await, ~Default]
        if ( Expression[+In, ?Yield, ?Await] ) FunctionDeclaration[?Yield, ?Await, ~Default]

This production only applies when parsing non-strict code. Code matching
this production is processed as if each matching occurrence of
FunctionDeclaration[?Yield, ?Await, ~Default] was the sole
StatementListItem of a BlockStatement occupying that position in the
source code. The semantics of such a synthetic BlockStatement includes
the web legacy compatibility semantics specified in B.3.3.

---

Fixes... well, you know :)