### PR TITLE
Kernel: Move timers from scheduler

### DIFF
--- a/Kernel/Devices/AsyncDeviceRequest.cpp
+++ b/Kernel/Devices/AsyncDeviceRequest.cpp
@@ -74,7 +74,7 @@ auto AsyncDeviceRequest::wait(timeval* timeout) -> RequestWaitResult
     auto request_result = get_request_result();
     if (is_completed_result(request_result))
         return { request_result, Thread::BlockResult::NotBlocked };
-    auto wait_result = Thread::current()->wait_on(m_queue, name(), timeout);
+    auto wait_result = Thread::current()->wait_on(m_queue, name(), Thread::BlockTimeout(false, timeout));
     return { get_request_result(), wait_result };
 }
 

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -431,7 +431,7 @@ static Optional<KBuffer> procfs$devices(InodeIdentifier)
 static Optional<KBuffer> procfs$uptime(InodeIdentifier)
 {
     KBufferBuilder builder;
-    builder.appendf("%u\n", (g_uptime / 1000));
+    builder.appendf("%llu\n", TimeManagement::the().uptime_ms() / 1000);
     return builder.build();
 }
 

--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -81,7 +81,7 @@ KResult PerformanceEventBuffer::append(int type, FlatPtr arg1, FlatPtr arg2)
         dbg() << "    " << (void*)event.stack[i];
 #endif
 
-    event.timestamp = g_uptime;
+    event.timestamp = TimeManagement::the().uptime_ms();
     at(m_count++) = event;
     return KSuccess;
 }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -519,7 +519,7 @@ int Process::alloc_fd(int first_candidate_fd)
 
 timeval kgettimeofday()
 {
-    return g_timeofday;
+    return TimeManagement::now_as_timeval();
 }
 
 void kgettimeofday(timeval& tv)

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -31,6 +31,7 @@
 #include <AK/IntrusiveList.h>
 #include <AK/Types.h>
 #include <Kernel/SpinLock.h>
+#include <Kernel/Time/TimeManagement.h>
 #include <Kernel/UnixTypes.h>
 
 namespace Kernel {
@@ -44,9 +45,7 @@ struct SchedulerData;
 extern Thread* g_finalizer;
 extern WaitQueue* g_finalizer_wait_queue;
 extern Atomic<bool> g_finalizer_has_work;
-extern u64 g_uptime;
 extern SchedulerData* g_scheduler_data;
-extern timeval g_timeofday;
 extern RecursiveSpinLock g_scheduler_lock;
 
 class Scheduler {
@@ -57,7 +56,6 @@ public:
     static void timer_tick(const RegisterState&);
     [[noreturn]] static void start();
     static bool pick_next();
-    static timeval time_since_boot();
     static bool yield();
     static bool donate_to_and_switch(Thread*, const char* reason);
     static bool donate_to(RefPtr<Thread>&, const char* reason);

--- a/Kernel/Syscalls/alarm.cpp
+++ b/Kernel/Syscalls/alarm.cpp
@@ -33,14 +33,15 @@ unsigned Process::sys$alarm(unsigned seconds)
 {
     REQUIRE_PROMISE(stdio);
     unsigned previous_alarm_remaining = 0;
-    if (m_alarm_deadline && m_alarm_deadline > g_uptime) {
-        previous_alarm_remaining = (m_alarm_deadline - g_uptime) / TimeManagement::the().ticks_per_second();
+    auto uptime = TimeManagement::the().uptime_ms();
+    if (m_alarm_deadline && m_alarm_deadline > uptime) {
+        previous_alarm_remaining = m_alarm_deadline - uptime;
     }
     if (!seconds) {
         m_alarm_deadline = 0;
         return previous_alarm_remaining;
     }
-    m_alarm_deadline = g_uptime + seconds * TimeManagement::the().ticks_per_second();
+    m_alarm_deadline = uptime + seconds * 1000;
     return previous_alarm_remaining;
 }
 

--- a/Kernel/Syscalls/beep.cpp
+++ b/Kernel/Syscalls/beep.cpp
@@ -32,9 +32,9 @@ namespace Kernel {
 int Process::sys$beep()
 {
     PCSpeaker::tone_on(440);
-    u64 wakeup_time = Thread::current()->sleep(100);
+    auto result = Thread::current()->sleep({ 0, 200 });
     PCSpeaker::tone_off();
-    if (wakeup_time > g_uptime)
+    if (result.was_interrupted())
         return -EINTR;
     return 0;
 }

--- a/Kernel/Syscalls/times.cpp
+++ b/Kernel/Syscalls/times.cpp
@@ -40,7 +40,7 @@ clock_t Process::sys$times(Userspace<tms*> user_times)
     if (!copy_to_user(user_times, &times))
         return -EFAULT;
 
-    return g_uptime & 0x7fffffff;
+    return TimeManagement::the().uptime_ms() & 0x7fffffff;
 }
 
 }

--- a/Kernel/Tasks/SyncTask.cpp
+++ b/Kernel/Tasks/SyncTask.cpp
@@ -38,7 +38,7 @@ void SyncTask::spawn()
         dbg() << "SyncTask is running";
         for (;;) {
             VFS::the().sync();
-            Thread::current()->sleep(1 * TimeManagement::the().ticks_per_second());
+            Thread::current()->sleep({ 1, 0 });
         }
     });
 }

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -46,11 +46,13 @@ public:
     static void initialize(u32 cpu);
     static TimeManagement& the();
 
+    static timespec ticks_to_time(u64 ticks, time_t ticks_per_second);
+    static u64 time_to_ticks(const timespec& tspec, time_t ticks_per_second);
+
+    timespec monotonic_time() const;
     timespec epoch_time() const;
     void set_epoch_time(timespec);
-    time_t seconds_since_boot() const;
     time_t ticks_per_second() const;
-    time_t ticks_this_second() const;
     time_t boot_time() const;
 
     bool is_system_timer(const HardwareTimerBase&) const;
@@ -60,6 +62,8 @@ public:
 
     static bool is_hpet_periodic_mode_allowed();
 
+    u64 uptime_ms() const;
+    u64 monotonic_ticks() const;
     static timeval now_as_timeval();
 
     timespec remaining_epoch_time_adjustment() const { return m_remaining_epoch_time_adjustment; }
@@ -72,11 +76,16 @@ private:
     Vector<HardwareTimerBase*> scan_for_non_periodic_timers();
     NonnullRefPtrVector<HardwareTimerBase> m_hardware_timers;
     void set_system_timer(HardwareTimerBase&);
+    static void timer_tick(const RegisterState&);
 
+    // Variables between m_update1 and m_update2 are synchronized
+    Atomic<u32> m_update1 { 0 };
     u32 m_ticks_this_second { 0 };
     u32 m_seconds_since_boot { 0 };
     timespec m_epoch_time { 0, 0 };
     timespec m_remaining_epoch_time_adjustment { 0, 0 };
+    Atomic<u32> m_update2 { 0 };
+
     RefPtr<HardwareTimerBase> m_system_timer;
     RefPtr<HardwareTimerBase> m_time_keeper_timer;
 };

--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -584,7 +584,7 @@ retry:
             now.tv_sec = now_spec.tv_sec;
             now.tv_usec = now_spec.tv_nsec / 1000;
             timeval_sub(next_timer_expiration.value(), now, timeout);
-            if (timeout.tv_sec < 0) {
+            if (timeout.tv_sec < 0 || (timeout.tv_sec == 0 && timeout.tv_usec < 0)) {
                 timeout.tv_sec = 0;
                 timeout.tv_usec = 0;
             }


### PR DESCRIPTION
In order to make more meaningful progress with #3864 there are two major things that need re-architecturing:

1. Timers/timeouts should not be handled in the `Scheduler`
2. Block conditions should not be evaluated in the `Scheduler`

The reason is that the scheduler needs to be as lean as possible. But not only that, doing these things in the Scheduler poses some major problems because they involve a lot of locks, which means there is high potential for deadlocks with multiple processors accessing them.

This PR aims to solve 1) only.

- [x] Figure out why timers (`select` timeouts?) don't fire as expected, e.g. clock applet doesn't update, Fire application doesn't render unless you move the mouse over the window, etc
- [x] Fix system time being off (0 epoch)
