### PR TITLE
LibMarkdown: Syntax highlighting for "js" code blocks

### DIFF
--- a/Libraries/LibJS/MarkupGenerator.cpp
+++ b/Libraries/LibJS/MarkupGenerator.cpp
@@ -38,24 +38,11 @@ namespace JS {
 String MarkupGenerator::html_from_source(const StringView& source)
 {
     StringBuilder builder;
-    size_t source_cursor = 0;
-
     auto lexer = Lexer(source);
     for (auto token = lexer.next(); token.type() != TokenType::Eof; token = lexer.next()) {
-        auto length = token.value().length();
-        auto start = token.line_column() - 1;
-
-        if (start > source_cursor) {
-            builder.append(source.substring_view(source_cursor, start - source_cursor));
-        }
-
+        builder.append(token.trivia());
         builder.append(wrap_string_in_style(token.value(), style_type_for_token(token)));
-        source_cursor = start + length;
     }
-
-    if (source_cursor < source.length())
-        builder.append(source.substring_view(source_cursor, source.length() - source_cursor));
-
     return builder.to_string();
 }
 

--- a/Libraries/LibMarkdown/CMakeLists.txt
+++ b/Libraries/LibMarkdown/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SOURCES
 )
 
 serenity_lib(LibMarkdown markdown)
-target_link_libraries(LibMarkdown LibC)
+target_link_libraries(LibMarkdown LibJS)

--- a/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Libraries/LibMarkdown/CodeBlock.cpp
@@ -55,10 +55,10 @@ String CodeBlock::render_to_html() const
     if (style.emph)
         builder.append("<i>");
 
-    if (style_language.is_null())
-        builder.append("<code style=\"white-space: pre;\">");
+    if (style_language.is_empty())
+        builder.append("<code>");
     else
-        builder.appendf("<code style=\"white-space: pre;\" class=\"%s\">", style_language.characters());
+        builder.appendff("<code class=\"{}\">", style_language);
 
     builder.append(escape_html_entities(m_code));
 

--- a/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Libraries/LibMarkdown/CodeBlock.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/StringBuilder.h>
+#include <LibJS/MarkupGenerator.h>
 #include <LibMarkdown/CodeBlock.h>
 
 namespace Markdown {
@@ -60,7 +61,10 @@ String CodeBlock::render_to_html() const
     else
         builder.appendff("<code class=\"{}\">", style_language);
 
-    builder.append(escape_html_entities(m_code));
+    if (style_language == "js")
+        builder.append(JS::MarkupGenerator::html_from_source(m_code));
+    else
+        builder.append(escape_html_entities(m_code));
 
     builder.append("</code>");
 

--- a/Libraries/LibMarkdown/Document.cpp
+++ b/Libraries/LibMarkdown/Document.cpp
@@ -40,7 +40,11 @@ String Document::render_to_html() const
 
     builder.append("<!DOCTYPE html>\n");
     builder.append("<html>\n");
-    builder.append("<head></head>\n");
+    builder.append("<head>\n");
+    builder.append("<style>\n");
+    builder.append("code { white-space: pre; }\n");
+    builder.append("</style>\n");
+    builder.append("</head>\n");
     builder.append("<body>\n");
 
     for (auto& block : m_blocks) {

--- a/Libraries/LibWeb/CSS/Default.css
+++ b/Libraries/LibWeb/CSS/Default.css
@@ -30,7 +30,6 @@ h6 {
 
 pre {
     font-family: Csilla;
-    font-weight: lighter;
     margin-bottom: 8px;
     margin-top: 8px;
     white-space: pre;
@@ -38,7 +37,6 @@ pre {
 
 code {
     font-family: Csilla;
-    font-weight: lighter;
 }
 
 u,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19366641/97786988-1aea8e80-1ba7-11eb-9e89-88527f6ce559.png)

Also teach `JS::MarkupGenerator` to handle multi-line code properly and unbreak `<code>`-elements having monospace fonts.