### PR TITLE
Kernel: Map PCI devices only once during boot

### DIFF
--- a/Kernel/PCI/Access.h
+++ b/Kernel/PCI/Access.h
@@ -63,6 +63,11 @@ public:
 protected:
     virtual void enumerate_hardware(Function<void(Address, ID)>) = 0;
 
+    u8 early_read8_field(Address address, u32 field);
+    u16 early_read16_field(Address address, u32 field);
+    u32 early_read32_field(Address address, u32 field);
+    u16 early_read_type(Address address);
+
     Access();
     Vector<PhysicalID> m_physical_ids;
 };

--- a/Kernel/PCI/IOAccess.cpp
+++ b/Kernel/PCI/IOAccess.cpp
@@ -46,20 +46,17 @@ IOAccess::IOAccess()
 
 u8 IOAccess::read8_field(Address address, u32 field)
 {
-    IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
-    return IO::in8(PCI_VALUE_PORT + (field & 3));
+    return Access::early_read8_field(address, field);
 }
 
 u16 IOAccess::read16_field(Address address, u32 field)
 {
-    IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
-    return IO::in16(PCI_VALUE_PORT + (field & 2));
+    return Access::early_read16_field(address, field);
 }
 
 u32 IOAccess::read32_field(Address address, u32 field)
 {
-    IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
-    return IO::in32(PCI_VALUE_PORT);
+    return Access::early_read32_field(address, field);
 }
 
 void IOAccess::write8_field(Address address, u32 field, u8 value)


### PR DESCRIPTION
In general, it makes more sense (at least to me) to not deal with mapping of a PCI device configuration space (when using the PCI MMIO method) each time we need to access it, but to have it already mapped somewhere in virtual memory space so we can access it almost immediately if needed.

Opinions, suggestions or fixes are very appreciated! :)