### PR TITLE
Shell: Some bug fixes

### DIFF
--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -1033,7 +1033,7 @@ RefPtr<Value> ForLoop::run(RefPtr<Shell> shell)
         RefPtr<Value> block_value;
 
         {
-            auto frame = shell->push_frame();
+            auto frame = shell->push_frame(String::formatted("for ({})", this));
             shell->set_local_variable(m_variable_name, value);
 
             block_value = m_block->run(shell);
@@ -1585,7 +1585,7 @@ RefPtr<Value> MatchExpr::run(RefPtr<Shell> shell)
         return pattern;
     };
 
-    auto frame = shell->push_frame();
+    auto frame = shell->push_frame(String::formatted("match ({})", this));
     if (!m_expr_name.is_empty())
         shell->set_local_variable(m_expr_name, value);
 

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -359,7 +359,8 @@ String Shell::resolve_path(String path) const
 
 Shell::LocalFrame* Shell::find_frame_containing_local_variable(const String& name)
 {
-    for (auto& frame : m_local_frames) {
+    for (size_t i = m_local_frames.size(); i > 0; --i) {
+        auto& frame = m_local_frames[i - 1];
         if (frame.local_variables.contains(name))
             return &frame;
     }

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -103,8 +103,8 @@ public:
     RefPtr<AST::Value> get_argument(size_t);
     RefPtr<AST::Value> lookup_local_variable(const String&);
     String local_variable_or(const String&, const String&);
-    void set_local_variable(const String&, RefPtr<AST::Value>);
-    void unset_local_variable(const String&);
+    void set_local_variable(const String&, RefPtr<AST::Value>, bool only_in_current_frame = false);
+    void unset_local_variable(const String&, bool only_in_current_frame = false);
 
     void define_function(String name, Vector<String> argnames, RefPtr<AST::Node> body);
     bool has_function(const String&);

--- a/Shell/Tests/function.sh
+++ b/Shell/Tests/function.sh
@@ -24,3 +24,13 @@ if fn 2>/dev/null {
 fn() { echo $0 }
 
 test "$(fn)" = fn || echo '$0' in function not equal to its name && exit 1
+
+# Ensure ARGV does not leak from inner frames.
+fn() {
+    fn2 1 2 3
+    echo $*
+}
+
+fn2() { }
+
+test "$(fn foobar)" = "foobar" || echo 'Frames are somehow messed up in nested functions' && exit 1


### PR DESCRIPTION
Just tiny bug fixes, nothing interesting.
- Don't crash when allocating more than 4 frames (!)
- Don't overwrite other frames' variables
- Don't leak ARGV into other function frames

Also names the frames, pretty handy when debugging, might be interesting to have decent stack traces