### PR TITLE
Meta: lint-shell-scripts: Exit if shellcheck is not installed

### DIFF
--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -4,6 +4,11 @@ set -e pipefail
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path/.."
 
+if ! command -v shellcheck &>/dev/null ; then
+    echo "shellcheck is not available. Either skip this script, or install shellcheck."
+    exit 1
+fi
+
 ERRORS=()
 
 while IFS= read -r f; do


### PR DESCRIPTION
# Before

```
$ ./Meta/lint-shell-scripts.sh 
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
./Meta/lint-shell-scripts.sh: line 12: shellcheck: command not found
Files failing shellcheck: Kernel/mkmap.sh Libraries/LibWeb/Scripts/GenerateStyleSheetSource.sh Meta/CLion/run.sh Meta/build-image-grub.sh Meta/build-image-qemu.sh Meta/build-root-filesystem.sh Meta/check-style.sh Meta/check-symbols.sh Meta/debug-kernel.sh Meta/lint-clang-format.sh Meta/lint-executable-resources.sh Meta/lint-ipc-ids.sh Meta/lint-missing-resources.sh Meta/lint-shell-scripts.sh Meta/refresh-serenity-qtcreator.sh Meta/run.sh Meta/text-to-cpp-string.sh Meta/write-only-on-difference.sh
```

# After

```
$ ./Meta/lint-shell-scripts.sh 
shellcheck is not available. Either skip this script, or install shellcheck.
```

# With shellcheck installed

```
$ ./Meta/lint-shell-scripts.sh 
[OK]: successfully linted Kernel/mkmap.sh
[OK]: successfully linted Libraries/LibWeb/Scripts/GenerateStyleSheetSource.sh
[OK]: successfully linted Meta/CLion/run.sh
[OK]: successfully linted Meta/build-image-grub.sh
[OK]: successfully linted Meta/build-image-qemu.sh
[OK]: successfully linted Meta/build-root-filesystem.sh
[OK]: successfully linted Meta/check-style.sh
[OK]: successfully linted Meta/check-symbols.sh
[OK]: successfully linted Meta/debug-kernel.sh
[OK]: successfully linted Meta/lint-clang-format.sh
[OK]: successfully linted Meta/lint-executable-resources.sh
[OK]: successfully linted Meta/lint-ipc-ids.sh
[OK]: successfully linted Meta/lint-missing-resources.sh
[OK]: successfully linted Meta/lint-shell-scripts.sh
[OK]: successfully linted Meta/refresh-serenity-qtcreator.sh
[OK]: successfully linted Meta/run.sh
[OK]: successfully linted Meta/text-to-cpp-string.sh
[OK]: successfully linted Meta/write-only-on-difference.sh
```
