### PR TITLE
Kernel: Don't remap IOAPIC registers every time we try to read/write

### DIFF
--- a/Kernel/Interrupts/IOAPIC.cpp
+++ b/Kernel/Interrupts/IOAPIC.cpp
@@ -32,7 +32,6 @@
 #include <Kernel/Interrupts/IOAPIC.h>
 #include <Kernel/Interrupts/InterruptManagement.h>
 #include <Kernel/VM/MemoryManager.h>
-#include <Kernel/VM/TypedMapping.h>
 
 //#define IOAPIC_DEBUG
 
@@ -49,6 +48,7 @@ enum DeliveryMode {
 
 IOAPIC::IOAPIC(PhysicalAddress address, u32 gsi_base)
     : m_address(address)
+    , m_regs(map_typed_writable<ioapic_mmio_regs>(m_address))
     , m_gsi_base(gsi_base)
     , m_id((read_register(0x0) >> 24) & 0xFF)
     , m_version(read_register(0x1) & 0xFF)
@@ -317,21 +317,19 @@ u16 IOAPIC::get_irr() const
 void IOAPIC::write_register(u32 index, u32 value) const
 {
     InterruptDisabler disabler;
-    auto regs = map_typed_writable<ioapic_mmio_regs>(m_address);
-    regs->select = index;
-    regs->window = value;
+    m_regs->select = index;
+    m_regs->window = value;
 #ifdef IOAPIC_DEBUG
-    dbg() << "IOAPIC Writing, Value 0x" << String::format("%x", regs->window) << " @ offset 0x" << String::format("%x", regs->select);
+    dbg() << "IOAPIC Writing, Value 0x" << String::format("%x", m_regs->window) << " @ offset 0x" << String::format("%x", m_regs->select);
 #endif
 }
 u32 IOAPIC::read_register(u32 index) const
 {
     InterruptDisabler disabler;
-    auto regs = map_typed_writable<ioapic_mmio_regs>(m_address);
-    regs->select = index;
+    m_regs->select = index;
 #ifdef IOAPIC_DEBUG
-    dbg() << "IOAPIC Reading, Value 0x" << String::format("%x", regs->window) << " @ offset 0x" << String::format("%x", regs->select);
+    dbg() << "IOAPIC Reading, Value 0x" << String::format("%x", m_regs->window) << " @ offset 0x" << String::format("%x", m_regs->select);
 #endif
-    return regs->window;
+    return m_regs->window;
 }
 }

--- a/Kernel/Interrupts/IOAPIC.h
+++ b/Kernel/Interrupts/IOAPIC.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <Kernel/Interrupts/IRQController.h>
+#include <Kernel/VM/TypedMapping.h>
 
 namespace Kernel {
 struct [[gnu::packed]] ioapic_mmio_regs
@@ -98,6 +99,7 @@ private:
     void isa_identity_map(int index);
 
     PhysicalAddress m_address;
+    mutable TypedMapping<ioapic_mmio_regs> m_regs;
     u32 m_gsi_base;
     u8 m_id;
     u8 m_version;


### PR DESCRIPTION
Remapping these registers every time we try to read from or write to
them causes a lot of SMP broadcasts and a lot of other overhead.
This improves boot time noticeably.

I noticed a difference with 8 CPUs, but a subtle improvement with 4 as well.