### PR TITLE
LibGfx: add bounds check before set_pixel call in GIF decoder

### DIFF
--- a/Libraries/LibGfx/Bitmap.h
+++ b/Libraries/LibGfx/Bitmap.h
@@ -300,11 +300,13 @@ inline Color Bitmap::get_pixel(int x, int y) const
 template<>
 inline void Bitmap::set_pixel<StorageFormat::RGB32>(int x, int y, Color color)
 {
+    ASSERT(rect().contains(x, y));
     scanline(y)[x] = color.value();
 }
 template<>
 inline void Bitmap::set_pixel<StorageFormat::RGBA32>(int x, int y, Color color)
 {
+    ASSERT(rect().contains(x, y));
     scanline(y)[x] = color.value(); // drop alpha
 }
 inline void Bitmap::set_pixel(int x, int y, Color color)

--- a/Libraries/LibGfx/GIFLoader.cpp
+++ b/Libraries/LibGfx/GIFLoader.cpp
@@ -355,7 +355,7 @@ static bool decode_frame(GIFLoadingContext& context, size_t frame_index)
                 int x = pixel_index % image.width + image.x;
                 int y = row + image.y;
 
-                if (!image.transparent || color != image.transparency_index) {
+                if (context.frame_buffer->rect().contains(x, y) && (!image.transparent || color != image.transparency_index)) {
                     context.frame_buffer->set_pixel(x, y, c);
                 }
 


### PR DESCRIPTION
Fixes #3484: crash when a GIF frame extends beyond the limits of the
logical screen, causing writes past the end of the frame buffer