### PR TITLE
Kernel: kmalloc_eternal should align pointers

### DIFF
--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -199,6 +199,8 @@ void kmalloc_init()
 
 void* kmalloc_eternal(size_t size)
 {
+    size = round_up_to_power_of_two(size, sizeof(void*));
+
     ScopedSpinLock lock(s_lock);
     void* ptr = s_next_eternal_ptr;
     s_next_eternal_ptr += size;


### PR DESCRIPTION
Should fix a crash found by @Lubrsi: https://github.com/SerenityOS/serenity/pull/3864#issuecomment-720029166