### PR TITLE
LibJS: Fix "use strict" directive false positives

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -64,6 +64,8 @@ public:
     virtual bool is_call_expression() const { return false; }
     virtual bool is_new_expression() const { return false; }
     virtual bool is_super_expression() const { return false; }
+    virtual bool is_expression_statement() const { return false; };
+    virtual bool is_string_literal() const { return false; };
 
 protected:
     ASTNode() { }
@@ -99,11 +101,15 @@ public:
     {
     }
 
-    Value execute(Interpreter&, GlobalObject&) const override;
-    const char* class_name() const override { return "ExpressionStatement"; }
+    virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
+    virtual bool is_expression_statement() const override { return true; }
+
+    const Expression& expression() const { return m_expression; };
 
 private:
+    virtual const char* class_name() const override { return "ExpressionStatement"; }
+
     NonnullRefPtr<Expression> m_expression;
 };
 
@@ -590,20 +596,24 @@ private:
 
 class StringLiteral final : public Literal {
 public:
-    explicit StringLiteral(String value)
+    explicit StringLiteral(String value, bool is_use_strict_directive = false)
         : m_value(move(value))
+        , m_is_use_strict_directive(is_use_strict_directive)
     {
     }
 
-    StringView value() const { return m_value; }
-
     virtual Value execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
+    virtual bool is_string_literal() const override { return true; };
+
+    StringView value() const { return m_value; }
+    bool is_use_strict_directive() const { return m_is_use_strict_directive; };
 
 private:
     virtual const char* class_name() const override { return "StringLiteral"; }
 
     String m_value;
+    bool m_is_use_strict_directive;
 };
 
 class NullLiteral final : public Literal {

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -164,12 +164,6 @@ private:
     void save_state();
     void load_state();
 
-    enum class UseStrictDirectiveState {
-        None,
-        Looking,
-        Found,
-    };
-
     struct ParserState {
         Lexer m_lexer;
         Token m_current_token;
@@ -177,7 +171,6 @@ private:
         Vector<NonnullRefPtrVector<VariableDeclaration>> m_var_scopes;
         Vector<NonnullRefPtrVector<VariableDeclaration>> m_let_scopes;
         Vector<NonnullRefPtrVector<FunctionDeclaration>> m_function_scopes;
-        UseStrictDirectiveState m_use_strict_directive { UseStrictDirectiveState::None };
         HashTable<StringView> m_labels_in_scope;
         bool m_strict_mode { false };
         bool m_allow_super_property_lookup { false };

--- a/Libraries/LibJS/Tests/use-strict-directive.js
+++ b/Libraries/LibJS/Tests/use-strict-directive.js
@@ -45,4 +45,16 @@ test("invalid 'use strict; directive", () => {
             return isStrictMode();
         })()
     ).toBeFalse();
+    expect(
+        (() => {
+            `"use strict"`;
+            return isStrictMode();
+        })()
+    ).toBeFalse();
+    expect(
+        (() => {
+            "use strict" + 1;
+            return isStrictMode();
+        })()
+    ).toBeFalse();
 });


### PR DESCRIPTION
By having the "is this a use strict directive?" logic in `parse_string_literal()` we would apply it to *any* string literal, which is incorrect and would lead to false positives - e.g.:

    "use strict" + 1
    `"use strict"`
    "\123"; ({"use strict": ...})

Relevant part from the spec which is now implemented properly:

> [...] and where each ExpressionStatement in the sequence consists entirely of a StringLiteral token [...]

I also got rid of `UseStrictDirectiveState` which is not needed anymore.

Fixes #3903.