### PR TITLE
ls: Add colored output for set-gid files

### DIFF
--- a/Userland/ls.cpp
+++ b/Userland/ls.cpp
@@ -194,6 +194,8 @@ static size_t print_name(const struct stat& st, const String& name, const char* 
             begin_color = "\033[42;30;1m";
         else if (st.st_mode & S_ISUID)
             begin_color = "\033[41;1m";
+        else if (st.st_mode & S_ISGID)
+            begin_color = "\033[43;1m";
         else if (S_ISLNK(st.st_mode))
             begin_color = "\033[36;1m";
         else if (S_ISDIR(st.st_mode))


### PR DESCRIPTION
I vaguely recall there was a decision to not make set-gid files colored when color output was added originally.

However, we didn't have any set-gid executable files back then.

"Wait I thought `utmpupdate` was suid? Oh right it's sgid. Wait why isn't it highlighted?"

![image](https://user-images.githubusercontent.com/434827/97836851-46998000-1d31-11eb-8073-b1e495c1569c.png)
