### PR TITLE
LibGUI: If drag_data_type is null, return a mousemove_event instead

### DIFF
--- a/Libraries/LibGUI/AbstractView.cpp
+++ b/Libraries/LibGUI/AbstractView.cpp
@@ -265,6 +265,10 @@ void AbstractView::mousemove_event(MouseEvent& event)
     auto hovered_index = index_at_event_position(event.position());
     set_hovered_index(hovered_index);
 
+    auto data_type = m_model->drag_data_type();
+    if (data_type.is_null())
+        return ScrollableWidget::mousemove_event(event);
+
     if (!m_might_drag)
         return ScrollableWidget::mousemove_event(event);
 
@@ -280,7 +284,6 @@ void AbstractView::mousemove_event(MouseEvent& event)
     if (distance_travelled_squared <= drag_distance_threshold)
         return ScrollableWidget::mousemove_event(event);
 
-    auto data_type = m_model->drag_data_type();
     ASSERT(!data_type.is_null());
 
     dbg() << "Initiate drag!";


### PR DESCRIPTION
If drag_data_type is null, return a mousemove_event instead to prevent reaching the ASSERT

In the help program, if a user tried to drag a list item from the left pane, the ASSERT would be True as
  drag_data_type is null.

This shouldn't break existing functionality as it would have reached the gone past the ASSERT anyway if it wasn't null.

---

Should this be fixed in the programs (help, etc) themselves (i.e. not having a null drag_data_type) instead of in LibGUI/AbstractView.cpp, or does it make more sense where I've put it?

Forgive me if I have missed something, I haven't used C++ before, and don't really understand what ASSERTs are for. It looks like it shouldn't be needed anymore though? I have tested a few scenarios, and I haven't experienced any regressions. In future, should I create an issue first? I wasn't sure if it was needed because it was a two line fix. 

Also, feel free to close if it's bad :)

Thanks, 
Joe