### PR TITLE
LibGUI: Clear selection after focusin event

### DIFF
--- a/Libraries/LibGUI/AbstractView.cpp
+++ b/Libraries/LibGUI/AbstractView.cpp
@@ -710,8 +710,10 @@ void AbstractView::focusin_event(FocusEvent& event)
 {
     ScrollableWidget::focusin_event(event);
 
-    if (model() && !cursor_index().is_valid())
+    if (model() && !cursor_index().is_valid()) {
         move_cursor(CursorMovement::Home, SelectionUpdate::None);
+        clear_selection();
+    }
 }
 
 }


### PR DESCRIPTION
After moving the cursor to the home position, clear the selection.

Fixes #3925.