### PR TITLE
AK: Really disallow making OwnPtrs from refcounted types

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -52,7 +52,9 @@ public:
     NonnullOwnPtr(AdoptTag, T& ptr)
         : m_ptr(&ptr)
     {
-        static_assert(!is_ref_counted((const T*)nullptr), "Use RefPtr<> for RefCounted types");
+        static_assert(
+            requires { requires typename T::AllowOwnPtr()(); } || !requires(T obj) { requires !typename T::AllowOwnPtr()(); obj.ref(); obj.unref(); },
+            "Use NonnullRefPtr<> for RefCounted types");
     }
     NonnullOwnPtr(NonnullOwnPtr&& other)
         : m_ptr(other.leak_ptr())

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -38,7 +38,9 @@ public:
     explicit OwnPtr(T* ptr)
         : m_ptr(ptr)
     {
-        static_assert(!is_ref_counted((const T*)nullptr), "Use RefPtr<> for RefCounted types");
+        static_assert(
+            requires { requires typename T::AllowOwnPtr()(); } || !requires(T obj) { requires !typename T::AllowOwnPtr()(); obj.ref(); obj.unref(); },
+            "Use RefPtr<> for RefCounted types");
     }
     OwnPtr(OwnPtr&& other)
         : m_ptr(other.leak_ptr())

--- a/AK/RefCounted.h
+++ b/AK/RefCounted.h
@@ -65,6 +65,7 @@ class RefCountedBase {
 
 public:
     typedef unsigned int RefCountType;
+    using AllowOwnPtr = FalseType;
 
     ALWAYS_INLINE void ref() const
     {

--- a/Libraries/LibWeb/HighResolutionTime/Performance.h
+++ b/Libraries/LibWeb/HighResolutionTime/Performance.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/StdLibExtras.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/DOM/EventTarget.h>
@@ -37,6 +38,7 @@ class Performance final
     , public Bindings::Wrappable {
 public:
     using WrapperType = Bindings::PerformanceWrapper;
+    using AllowOwnPtr = AK::TrueType;
 
     explicit Performance(DOM::Window&);
     ~Performance();


### PR DESCRIPTION
- if the type has a typedef `AllowOwnPtr', respect that
- if not, disallow construction if both of `ref()' and `unref()' are present.

Note that in the second case, if a type only defines \`ref()' or only
defines \`unref()', an OwnPtr can be created, as a RefPtr of that type
would be ill-formed.

cc @bugaevc and @awesomekling.