### PR TITLE
LibJS: Fix crashing exception in Value::ordinary_has_instance()

### DIFF
--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -711,8 +711,10 @@ Value instance_of(GlobalObject& global_object, Value lhs, Value rhs)
             vm.throw_exception<TypeError>(global_object, ErrorType::NotAFunction, has_instance_method.to_string_without_side_effects());
             return {};
         }
-
-        return Value(vm.call(has_instance_method.as_function(), rhs, lhs).to_boolean());
+        auto has_instance_result = vm.call(has_instance_method.as_function(), rhs, lhs);
+        if (vm.exception())
+            return {};
+        return Value(has_instance_result.to_boolean());
     }
 
     if (!rhs.is_function()) {
@@ -743,7 +745,7 @@ Value ordinary_has_instance(GlobalObject& global_object, Value lhs, Value rhs)
         return {};
 
     if (!rhs_prototype.is_object()) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::InstanceOfOperatorBadPrototype, rhs_prototype.to_string_without_side_effects());
+        vm.throw_exception<TypeError>(global_object, ErrorType::InstanceOfOperatorBadPrototype, rhs.to_string_without_side_effects());
         return {};
     }
     while (true) {

--- a/Libraries/LibJS/Tests/operators/instanceof-basic.js
+++ b/Libraries/LibJS/Tests/operators/instanceof-basic.js
@@ -22,3 +22,15 @@ test("derived ES5 classes", () => {
     expect(d instanceof Derived).toBeTrue();
     expect(d instanceof Base).toBeTrue();
 });
+
+test("issue #3930, instanceof on arrow function", () => {
+    function f() {}
+    const a = () => {};
+
+    expect(() => {
+        f instanceof a;
+    }).toThrow(TypeError);
+    expect(() => {
+        a instanceof a;
+    }).toThrow(TypeError);
+});


### PR DESCRIPTION
Two issues:

- `throw_exception()` with `ErrorType::InstanceOfOperatorBadPrototype` would receive `rhs_prototype.to_string_without_side_effects()`, which would `ASSERT_NOT_REACHED()` as `to_string_without_side_effects()` must not be called on an empty value. It should (and now does) receive the RHS value instead as the message is "'prototype' property of {} is not an object".
- `Value::instance_of()` was missing an exception check after calling `has_instance_method`, `to_boolean()` on an empty value result would crash as well.

Fixes #3930.