### PR TITLE
Chess: Add missing default config file in .config :^)

### DIFF
--- a/Base/home/anon/.config/Chess.ini
+++ b/Base/home/anon/.config/Chess.ini
@@ -1,0 +1,7 @@
+[Display]
+size=512
+
+[Style]
+BoardTheme=Beige
+PieceSet=stelar7
+Coordinates=1


### PR DESCRIPTION
Following 9f8a8e07c2d25009268830c51f58c052a8f6936b, let's add a default
`.ini` to prevent `unveil` from failing.