### PR TITLE
LibJS: Don't create "valid" PropertyName from null string

### DIFF
--- a/Libraries/LibJS/Runtime/PropertyName.h
+++ b/Libraries/LibJS/Runtime/PropertyName.h
@@ -48,7 +48,10 @@ public:
             return &value.as_symbol();
         if (value.is_integer() && value.as_i32() >= 0)
             return value.as_i32();
-        return value.to_string(global_object);
+        auto string = value.to_string(global_object);
+        if (string.is_null())
+            return {};
+        return string;
     }
 
     PropertyName() { }
@@ -70,18 +73,21 @@ public:
         : m_type(Type::String)
         , m_string(FlyString(string))
     {
+        ASSERT(!string.is_null());
     }
 
     PropertyName(const FlyString& string)
         : m_type(Type::String)
         , m_string(string)
     {
+        ASSERT(!string.is_null());
     }
 
     PropertyName(Symbol* symbol)
         : m_type(Type::Symbol)
         , m_symbol(symbol)
     {
+        ASSERT(symbol);
     }
 
     PropertyName(const StringOrSymbol& string_or_symbol)

--- a/Libraries/LibJS/Tests/computed-property-throws.js
+++ b/Libraries/LibJS/Tests/computed-property-throws.js
@@ -6,3 +6,14 @@ test("Issue #3459, exception in computed property expression", () => {
         "foo"[bar]();
     }).toThrow(ReferenceError);
 });
+
+test("Issue #3941, exception in computed property's toString()", () => {
+    expect(() => {
+        const o = {
+            toString() {
+                throw Error();
+            },
+        };
+        "foo"[o];
+    }).toThrow(Error);
+});


### PR DESCRIPTION
When `value.to_string()` throws an exception it returns a null string in which case we must not construct a valid `PropertyName`.

Also `ASSERT` in `PropertyName(String)` and `PropertyName(FlyString)` to prevent this from happening in the future.

Fixes #3941.