### PR TITLE
LibJS: Handle circular references in Array.prototype.join()

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -316,15 +316,15 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::join)
     auto* this_object = vm.this_value(global_object).to_object(global_object);
     if (!this_object)
         return {};
+    auto length = get_length(vm, *this_object);
+    if (vm.exception())
+        return {};
     String separator = ",";
-    if (vm.argument_count()) {
+    if (!vm.argument(0).is_undefined()) {
         separator = vm.argument(0).to_string(global_object);
         if (vm.exception())
             return {};
     }
-    auto length = get_length(vm, *this_object);
-    if (vm.exception())
-        return {};
     StringBuilder builder;
     for (size_t i = 0; i < length; ++i) {
         if (i > 0)

--- a/Libraries/LibJS/Tests/builtins/Array/Array.prototype.join.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.prototype.join.js
@@ -14,3 +14,11 @@ test("basic functionality", () => {
     expect([1, null, 2, undefined, 3].join()).toBe("1,,2,,3");
     expect(Array(3).join()).toBe(",,");
 });
+
+test("circular references", () => {
+    const a = ["foo", [], [1, 2, []], ["bar"]];
+    a[1] = a;
+    a[2][2] = a;
+    // [ "foo", <circular>, [ 1, 2, <circular> ], [ "bar" ] ]
+    expect(a.join()).toBe("foo,,1,2,,bar");
+});

--- a/Libraries/LibJS/Tests/builtins/Array/Array.prototype.join.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.prototype.join.js
@@ -4,6 +4,7 @@ test("length is 1", () => {
 
 test("basic functionality", () => {
     expect(["hello", "friends"].join()).toBe("hello,friends");
+    expect(["hello", "friends"].join(undefined)).toBe("hello,friends");
     expect(["hello", "friends"].join(" ")).toBe("hello friends");
     expect(["hello", "friends", "foo"].join("~", "#")).toBe("hello~friends~foo");
     expect([].join()).toBe("");


### PR DESCRIPTION
(see commit messages for details). Fixes #3929.