### PR TITLE
Kernel: Fix HPET timer not firing in Bochs

### DIFF
--- a/Kernel/Time/HPET.h
+++ b/Kernel/Time/HPET.h
@@ -45,15 +45,14 @@ public:
     static bool check_for_exisiting_periodic_timers();
     static HPET& the();
 
-    u64 main_counter_value() const;
     u64 frequency() const;
 
     const NonnullRefPtrVector<HPETComparator>& comparators() const { return m_comparators; }
     void disable(const HPETComparator&);
     void enable(const HPETComparator&);
 
-    void set_periodic_comparator_value(const HPETComparator& comparator, u64 value);
-    void set_non_periodic_comparator_value(const HPETComparator& comparator, u64 value);
+    void update_periodic_comparator_value();
+    void update_non_periodic_comparator_value(const HPETComparator& comparator);
 
     void set_comparator_irq_vector(u8 comparator_number, u8 irq_vector);
 
@@ -64,8 +63,8 @@ public:
     Vector<unsigned> capable_interrupt_numbers(const HPETComparator&);
 
 private:
-    const volatile HPETRegistersBlock& registers() const;
-    volatile HPETRegistersBlock& registers();
+    const HPETRegistersBlock& registers() const;
+    HPETRegistersBlock& registers();
 
     void global_disable();
     void global_enable();

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -225,9 +225,10 @@ bool TimeManagement::probe_and_set_non_legacy_hardware_timers()
     }
 
     m_system_timer->set_callback(Scheduler::timer_tick);
+    m_time_keeper_timer->set_callback(TimeManagement::update_time);
+
     dbg() << "Reset timers";
     m_system_timer->try_to_set_frequency(m_system_timer->calculate_nearest_possible_frequency(1024));
-    m_time_keeper_timer->set_callback(TimeManagement::update_time);
     m_time_keeper_timer->try_to_set_frequency(OPTIMAL_TICKS_PER_SECOND_RATE);
 
     return true;


### PR DESCRIPTION
* Change the register structures to use the volatile keyword explicitly
  on the register values. This avoids accidentally omitting it as any
  access will be guaranteed volatile.
* Don't assume we can read/write 64 bit value to the main counter and
  the comparator. Not all HPET implementations may support this. So,
  just use 32 bit words to access the registers. This ultimately works
  around a bug in Bochs 2.6.11 that loses 32 bits of a 64 bit write to
  a timer's comparator register (it internally writes one half and
  clears the Tn_VAL_SET_CNF bit, and then because it's cleared it
  fails to write the second half).
* Properly calculate the tick duration in calculate_ticks_in_nanoseconds
* As per specification, changing the frequency of one periodic timer
  requires a restart of all periodic timers as it requires the main
  counter to be reset.

I haven't tested if this affects #3893 at all, but I think this is the first time since I started contributing to this project that I can actually boot it (somewhat) in Bochs. The more environments that we can run in, the merrier.

![Screenshot from 2020-11-04 18-10-30](https://user-images.githubusercontent.com/10320822/98194272-383b9780-1edc-11eb-883b-4f3f277b277b.png)

The Bochs bug mentioned is in Bochs 2.6.11 in file bochs/iodev/hpet.cc as of r13997, lines 579 and 590 when called from line 157.