### PR TITLE
LibJS: Use array-like size for IndexedProperties::is_empty()

### DIFF
--- a/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -161,8 +161,7 @@ public:
     IndexedPropertyIterator begin(bool skip_empty = true) const { return IndexedPropertyIterator(*this, 0, skip_empty); };
     IndexedPropertyIterator end() const { return IndexedPropertyIterator(*this, array_like_size(), false); };
 
-    size_t size() const { return m_storage->size(); }
-    bool is_empty() const { return size() == 0; }
+    bool is_empty() const { return array_like_size() == 0; }
     size_t array_like_size() const { return m_storage->array_like_size(); }
     void set_array_like_size(size_t);
 

--- a/Libraries/LibJS/Tests/builtins/Array/Array.prototype.pop.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.prototype.pop.js
@@ -7,6 +7,12 @@ describe("normal behavior", () => {
         var a = [1, 2, 3];
         expect(a.pop()).toBe(3);
         expect(a).toEqual([1, 2]);
+        expect(a.pop()).toBe(2);
+        expect(a).toEqual([1]);
+        expect(a.pop()).toBe(1);
+        expect(a).toEqual([]);
+        expect(a.pop()).toBeUndefined();
+        expect(a).toEqual([]);
     });
 
     test("empty array", () => {


### PR DESCRIPTION
Some things, like (the non-generic version of) `Array.prototype.pop()`, check `is_empty()` to determine whether an action, like removing elements, can be performed. We need to know the array-like size for that, not the size of the underlying storage, which can be different - and is not something `IndexedProperties` should expose so I removed its `size()`.

Fixes #3948.