### PR TITLE
LibGUI: Clip rubber band to IconView widget content area

### DIFF
--- a/Libraries/LibGUI/IconView.cpp
+++ b/Libraries/LibGUI/IconView.cpp
@@ -471,6 +471,7 @@ void IconView::second_paint_event(PaintEvent& event)
 
     Painter painter(*this);
     painter.add_clip_rect(event.rect());
+    painter.add_clip_rect(widget_inner_rect());
     painter.translate(frame_thickness(), frame_thickness());
     painter.translate(-horizontal_scrollbar().value(), -vertical_scrollbar().value());
 


### PR DESCRIPTION
Change the clip rect for the rubber band painter to widget_inner_rect
This ensures the rubber band is not drawn over the scrollbars.

![image](https://user-images.githubusercontent.com/5558617/98305876-963eac80-1fba-11eb-856a-257643a0b0ae.png)

Fixes #3926