### PR TITLE
LibJS: Handle circular references in Array.prototype.toLocaleString()

### DIFF
--- a/Libraries/LibJS/Tests/builtins/Array/Array.prototype.toLocaleString.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.prototype.toLocaleString.js
@@ -51,4 +51,12 @@ describe("normal behavior", () => {
         expect([o, undefined, o, null, o].toLocaleString()).toBe("o,,o,,o");
         expect(toStringCalled).toBe(3);
     });
+
+    test("array with circular references", () => {
+        const a = ["foo", [], [1, 2, []], ["bar"]];
+        a[1] = a;
+        a[2][2] = a;
+        // [ "foo", <circular>, [ 1, 2, <circular> ], [ "bar" ] ]
+        expect(a.toLocaleString()).toBe("foo,,1,2,,bar");
+    });
 });

--- a/Libraries/LibJS/Tests/builtins/Array/Array.prototype.toString.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.prototype.toString.js
@@ -55,4 +55,12 @@ describe("normal behavior", () => {
         expect([o, undefined, o, null, o].toString()).toBe("o,,o,,o");
         expect(toStringCalled).toBe(3);
     });
+
+    test("array with circular references", () => {
+        const a = ["foo", [], [1, 2, []], ["bar"]];
+        a[1] = a;
+        a[2][2] = a;
+        // [ "foo", <circular>, [ 1, 2, <circular> ], [ "bar" ] ]
+        expect(a.toString()).toBe("foo,,1,2,,bar");
+    });
 });


### PR DESCRIPTION
Also use `ArmedScopeGuard` for removing seen objects to account for early returns.

Fixes #3963.