### PR TITLE
LibJS: Don't create StringOrSymbol(String) if from_value() fails / Set prototype of GlobalObject to ObjectPrototype

### DIFF
--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -94,6 +94,8 @@ void GlobalObject::initialize()
     static_cast<FunctionPrototype*>(m_function_prototype)->initialize(*this);
     static_cast<ObjectPrototype*>(m_object_prototype)->initialize(*this);
 
+    set_prototype(m_object_prototype);
+
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName) \
     if (!m_##snake_name##_prototype)                                          \
         m_##snake_name##_prototype = heap().allocate<PrototypeName>(*this, *this);

--- a/Libraries/LibJS/Runtime/StringOrSymbol.h
+++ b/Libraries/LibJS/Runtime/StringOrSymbol.h
@@ -37,11 +37,14 @@ class StringOrSymbol {
 public:
     static StringOrSymbol from_value(GlobalObject& global_object, Value value)
     {
+        if (value.is_empty())
+            return {};
         if (value.is_symbol())
             return &value.as_symbol();
-        if (!value.is_empty())
-            return value.to_string(global_object);
-        return {};
+        auto string = value.to_string(global_object);
+        if (string.is_null())
+            return {};
+        return string;
     }
 
     StringOrSymbol() = default;

--- a/Libraries/LibJS/Tests/builtins/Object/Object.prototype.toString.js
+++ b/Libraries/LibJS/Tests/builtins/Object/Object.prototype.toString.js
@@ -15,4 +15,6 @@ test("result for various object types", () => {
     expect(oToString(new Date())).toBe("[object Date]");
     expect(oToString(new RegExp())).toBe("[object RegExp]");
     expect(oToString({})).toBe("[object Object]");
+
+    expect(globalThis.toString()).toBe("[object Object]");
 });


### PR DESCRIPTION
- If `value.to_string()` throws an exception and returns a null string we must create an invalid `StringOrSymbol`, not one from the null string (which `ASSERT()`s).
- As the global object is constructed and initialized in a different way than most other objects we were not setting its prototype! This made things like "`globalThis.toString()`" fail unexpectedly.

Fixes #3960.