### PR TITLE
Kernel: Add I8042Controller to detect and manage PS/2 devices

### DIFF
--- a/Kernel/ACPI/Parser.cpp
+++ b/Kernel/ACPI/Parser.cpp
@@ -104,7 +104,7 @@ void Parser::init_fadt()
     klog() << "ACPI: Fixed ACPI data, Revision " << sdt->h.revision << ", Length " << sdt->h.length << " bytes";
     klog() << "ACPI: DSDT " << PhysicalAddress(sdt->dsdt_ptr);
     m_x86_specific_flags.cmos_rtc_not_present = (sdt->ia_pc_boot_arch_flags & (u8)FADTFlags::IA_PC_Flags::CMOS_RTC_Not_Present);
-    m_x86_specific_flags.keyboard_8042 = (sdt->ia_pc_boot_arch_flags & (u8)FADTFlags::IA_PC_Flags::PS2_8042);
+    m_x86_specific_flags.keyboard_8042 = (sdt->h.revision <= 1) || (sdt->ia_pc_boot_arch_flags & (u8)FADTFlags::IA_PC_Flags::PS2_8042);
     m_x86_specific_flags.legacy_devices = (sdt->ia_pc_boot_arch_flags & (u8)FADTFlags::IA_PC_Flags::Legacy_Devices);
     m_x86_specific_flags.msi_not_supported = (sdt->ia_pc_boot_arch_flags & (u8)FADTFlags::IA_PC_Flags::MSI_Not_Supported);
     m_x86_specific_flags.vga_not_present = (sdt->ia_pc_boot_arch_flags & (u8)FADTFlags::IA_PC_Flags::VGA_Not_Present);

--- a/Kernel/ACPI/Parser.h
+++ b/Kernel/ACPI/Parser.h
@@ -54,6 +54,11 @@ public:
     virtual void try_acpi_shutdown();
     virtual bool can_shutdown() { return false; }
 
+    virtual bool have_8042() const
+    {
+        return m_x86_specific_flags.keyboard_8042;
+    }
+
     const FADTFlags::HardwareFeatures& hardware_features() const { return m_hardware_flags; }
     const FADTFlags::x86_Specific_Flags& x86_specific_flags() const { return m_x86_specific_flags; }
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -22,6 +22,7 @@ set(KERNEL_SOURCES
     Devices/EBRPartitionTable.cpp
     Devices/FullDevice.cpp
     Devices/GPTPartitionTable.cpp
+    Devices/I8042Controller.cpp
     Devices/KeyboardDevice.cpp
     Devices/MBRPartitionTable.cpp
     Devices/MBVGADevice.cpp

--- a/Kernel/Devices/I8042Controller.cpp
+++ b/Kernel/Devices/I8042Controller.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Kernel/ACPI/Parser.h>
+#include <Kernel/Devices/KeyboardDevice.h>
+#include <Kernel/Devices/PS2MouseDevice.h>
+#include <Kernel/IO.h>
+
+namespace Kernel {
+
+static I8042Controller* s_the;
+
+void I8042Controller::initialize()
+{
+    if (ACPI::Parser::the()->have_8042())
+        new I8042Controller;
+}
+
+I8042Controller& I8042Controller::the()
+{
+    ASSERT(s_the);
+    return *s_the;
+}
+
+I8042Controller::I8042Controller()
+{
+    ASSERT(!s_the);
+    s_the = this;
+
+    u8 configuration;
+    {
+        ScopedSpinLock lock(m_lock);
+        // Disable devices
+        do_wait_then_write(I8042_STATUS, 0xad);
+        do_wait_then_write(I8042_STATUS, 0xa7); // ignored if it doesn't exist
+
+        // Drain buffers
+        do_drain();
+
+        do_wait_then_write(I8042_STATUS, 0x20);
+        configuration = do_wait_then_read(I8042_BUFFER);
+        do_wait_then_write(I8042_STATUS, 0x60);
+        configuration &= ~3; // Disable IRQs for all
+        do_wait_then_write(I8042_BUFFER, configuration);
+
+        m_is_dual_channel = (configuration & (1 << 5)) != 0;
+        dbg() << "I8042: " << (m_is_dual_channel ? "Dual" : "Single") << " channel controller";
+
+        // Perform controller self-test
+        do_wait_then_write(I8042_STATUS, 0xaa);
+        if (do_wait_then_read(I8042_BUFFER) == 0x55) {
+            // Restore configuration in case the controller reset
+            do_wait_then_write(I8042_STATUS, 0x60);
+            do_wait_then_write(I8042_BUFFER, configuration);
+        } else {
+            dbg() << "I8042: Controller self test failed";
+        }
+
+        // Test ports and enable them if available
+        do_wait_then_write(I8042_STATUS, 0xab); // test
+        m_devices[0].available = (do_wait_then_read(I8042_BUFFER) == 0);
+
+        if (m_devices[0].available) {
+            do_wait_then_write(I8042_STATUS, 0xae); //enable
+            configuration |= 1;
+            configuration &= ~(1 << 4);
+        } else {
+            dbg() << "I8042: Keyboard port not available";
+        }
+
+        if (m_is_dual_channel) {
+            do_wait_then_write(I8042_STATUS, 0xa9); // test
+            m_devices[1].available = (do_wait_then_read(I8042_BUFFER) == 0);
+            if (m_devices[1].available) {
+                do_wait_then_write(I8042_STATUS, 0xa8); // enable
+                configuration |= 2;
+                configuration &= ~(1 << 5);
+            } else {
+                dbg() << "I8042: Mouse port not available";
+            }
+        }
+
+        // Enable IRQs for the ports that are usable
+        if (m_devices[0].available || m_devices[1].available) {
+            configuration &= ~0x30; // renable clocks
+            do_wait_then_write(I8042_STATUS, 0x60);
+            do_wait_then_write(I8042_BUFFER, configuration);
+        }
+    }
+
+    // Try to detect and initialize the devices
+    if (m_devices[0].available) {
+        if (KeyboardDevice::the().initialize()) {
+            m_devices[0].device = &KeyboardDevice::the();
+        } else {
+            dbg() << "I8042: Keyboard device failed to initialize, disable";
+            m_devices[0].available = false;
+            configuration &= ~1;
+            configuration |= 1 << 4;
+            ScopedSpinLock lock(m_lock);
+            do_wait_then_write(I8042_STATUS, 0x60);
+            do_wait_then_write(I8042_BUFFER, configuration);
+        }
+    }
+    if (m_devices[1].available) {
+        if (PS2MouseDevice::the().initialize()) {
+            m_devices[1].device = &PS2MouseDevice::the();
+        } else {
+            dbg() << "I8042: Mouse device failed to initialize, disable";
+            m_devices[1].available = false;
+            configuration |= 1 << 5;
+            ScopedSpinLock lock(m_lock);
+            do_wait_then_write(I8042_STATUS, 0x60);
+            do_wait_then_write(I8042_BUFFER, configuration);
+        }
+    }
+
+    // Enable IRQs after both are detected and initialized
+    if (m_devices[0].device)
+        m_devices[0].device->enable_interrupts();
+    if (m_devices[1].device)
+        m_devices[1].device->enable_interrupts();
+}
+
+void I8042Controller::irq_process_input_buffer(Device)
+{
+    ASSERT(Processor::current().in_irq());
+
+    u8 status = IO::in8(I8042_STATUS);
+    if (!(status & I8042_BUFFER_FULL))
+        return;
+    Device data_for_device = ((status & I8042_WHICH_BUFFER) == I8042_MOUSE_BUFFER) ? Device::Mouse : Device::Keyboard;
+    u8 byte = IO::in8(I8042_BUFFER);
+    if (auto* device = m_devices[data_for_device == Device::Keyboard ? 0 : 1].device)
+        device->irq_handle_byte_read(byte);
+}
+
+void I8042Controller::do_drain()
+{
+    for (;;) {
+        u8 status = IO::in8(I8042_STATUS);
+        if (!(status & I8042_BUFFER_FULL))
+            return;
+        IO::in8(I8042_BUFFER);
+    }
+}
+
+bool I8042Controller::do_reset_device(Device device)
+{
+    ASSERT(device != Device::None);
+    ASSERT(m_lock.is_locked());
+
+    ASSERT(!Processor::current().in_irq());
+    if (do_send_command(device, 0xff) != I8042_ACK)
+        return false;
+    // Wait until we get the self-test result
+    return do_wait_then_read(I8042_BUFFER) == 0xaa;
+}
+
+u8 I8042Controller::do_send_command(Device device, u8 command)
+{
+    ASSERT(device != Device::None);
+    ASSERT(m_lock.is_locked());
+
+    ASSERT(!Processor::current().in_irq());
+
+    return do_write_to_device(device, command);
+}
+
+u8 I8042Controller::do_send_command(Device device, u8 command, u8 data)
+{
+    ASSERT(device != Device::None);
+    ASSERT(m_lock.is_locked());
+
+    ASSERT(!Processor::current().in_irq());
+
+    u8 response = do_write_to_device(device, command);
+    if (response == I8042_ACK)
+        response = do_write_to_device(device, data);
+    return response;
+}
+
+u8 I8042Controller::do_write_to_device(Device device, u8 data)
+{
+    ASSERT(device != Device::None);
+    ASSERT(m_lock.is_locked());
+
+    ASSERT(!Processor::current().in_irq());
+
+    int attempts = 0;
+    u8 response;
+    do {
+        if (device != Device::Keyboard) {
+            prepare_for_output();
+            IO::out8(I8042_STATUS, 0xd4);
+        }
+        prepare_for_output();
+        IO::out8(I8042_BUFFER, data);
+
+        response = do_wait_then_read(I8042_BUFFER);
+    } while (response == I8042_RESEND && ++attempts < 3);
+    if (attempts >= 3)
+        dbg() << "Failed to write byte to device, gave up";
+    return response;
+}
+
+u8 I8042Controller::do_read_from_device(Device device)
+{
+    ASSERT(device != Device::None);
+
+    prepare_for_input(device);
+    return IO::in8(I8042_BUFFER);
+}
+
+void I8042Controller::prepare_for_input(Device device)
+{
+    ASSERT(m_lock.is_locked());
+    const u8 buffer_type = device == Device::Keyboard ? I8042_KEYBOARD_BUFFER : I8042_MOUSE_BUFFER;
+    for (;;) {
+        u8 status = IO::in8(I8042_STATUS);
+        if ((status & I8042_BUFFER_FULL) && (device == Device::None || ((status & I8042_WHICH_BUFFER) == buffer_type)))
+            return;
+    }
+}
+
+void I8042Controller::prepare_for_output()
+{
+    ASSERT(m_lock.is_locked());
+    for (;;) {
+        if (!(IO::in8(I8042_STATUS) & 2))
+            return;
+    }
+}
+
+void I8042Controller::do_wait_then_write(u8 port, u8 data)
+{
+    ASSERT(m_lock.is_locked());
+    prepare_for_output();
+    IO::out8(port, data);
+}
+
+u8 I8042Controller::do_wait_then_read(u8 port)
+{
+    ASSERT(m_lock.is_locked());
+    prepare_for_input(Device::None);
+    return IO::in8(port);
+}
+
+}

--- a/Kernel/Devices/I8042Controller.h
+++ b/Kernel/Devices/I8042Controller.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <Kernel/SpinLock.h>
+
+namespace Kernel {
+
+#define I8042_BUFFER 0x60
+#define I8042_STATUS 0x64
+#define I8042_ACK 0xFA
+#define I8042_RESEND 0xFE
+#define I8042_BUFFER_FULL 0x01
+
+#define I8042_WHICH_BUFFER 0x20
+
+#define I8042_KEYBOARD_BUFFER 0x00
+#define I8042_MOUSE_BUFFER 0x20
+
+class I8042Device {
+public:
+    virtual ~I8042Device() { }
+
+    virtual void irq_handle_byte_read(u8 byte) = 0;
+    virtual void enable_interrupts() = 0;
+};
+
+class I8042Controller {
+public:
+    enum class Device {
+        None = 0,
+        Keyboard,
+        Mouse
+    };
+
+    static void initialize();
+    static I8042Controller& the();
+
+    bool reset_device(Device device)
+    {
+        ScopedSpinLock lock(m_lock);
+        return do_reset_device(device);
+    }
+
+    u8 send_command(Device device, u8 command)
+    {
+        ScopedSpinLock lock(m_lock);
+        return do_send_command(device, command);
+    }
+    u8 send_command(Device device, u8 command, u8 data)
+    {
+        ScopedSpinLock lock(m_lock);
+        return do_send_command(device, command, data);
+    }
+
+    u8 read_from_device(Device device)
+    {
+        ScopedSpinLock lock(m_lock);
+        return do_read_from_device(device);
+    }
+
+    void wait_then_write(u8 port, u8 data)
+    {
+        ScopedSpinLock lock(m_lock);
+        do_wait_then_write(port, data);
+    }
+
+    u8 wait_then_read(u8 port)
+    {
+        ScopedSpinLock lock(m_lock);
+        return do_wait_then_read(port);
+    }
+
+    void prepare_for_output();
+    void prepare_for_input(Device);
+
+    void irq_process_input_buffer(Device);
+
+private:
+    I8042Controller();
+    void do_drain();
+    bool do_reset_device(Device device);
+    u8 do_send_command(Device device, u8 data);
+    u8 do_send_command(Device device, u8 command, u8 data);
+    u8 do_write_to_device(Device device, u8 data);
+    u8 do_read_from_device(Device device);
+    void do_wait_then_write(u8 port, u8 data);
+    u8 do_wait_then_read(u8 port);
+
+    static int device_to_deviceinfo_index(Device device)
+    {
+        ASSERT(device != Device::None);
+        return (device == Device::Keyboard) ? 0 : 1;
+    }
+
+    struct DeviceInfo {
+        I8042Device* device { nullptr };
+        bool available { false };
+    };
+
+    SpinLock<u8> m_lock;
+    bool m_is_dual_channel { false };
+    DeviceInfo m_devices[2];
+};
+
+}

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -36,13 +36,12 @@
 #include <Kernel/Devices/EBRPartitionTable.h>
 #include <Kernel/Devices/FullDevice.h>
 #include <Kernel/Devices/GPTPartitionTable.h>
-#include <Kernel/Devices/KeyboardDevice.h>
+#include <Kernel/Devices/I8042Controller.h>
 #include <Kernel/Devices/MBRPartitionTable.h>
 #include <Kernel/Devices/MBVGADevice.h>
 #include <Kernel/Devices/NullDevice.h>
 #include <Kernel/Devices/PATAChannel.h>
 #include <Kernel/Devices/PATADiskDevice.h>
-#include <Kernel/Devices/PS2MouseDevice.h>
 #include <Kernel/Devices/RandomDevice.h>
 #include <Kernel/Devices/SB16.h>
 #include <Kernel/Devices/SerialDevice.h>
@@ -141,8 +140,7 @@ extern "C" [[noreturn]] void init()
     ACPI::initialize();
 
     VFS::initialize();
-    KeyboardDevice::initialize();
-    PS2MouseDevice::create();
+    I8042Controller::initialize();
     Console::initialize();
 
     klog() << "Starting SerenityOS...";


### PR DESCRIPTION
Inspired by the problems I ran into with the HPET changes that I hoped would maybe help with #3893...

Rework the PS/2 keyboard and mouse drivers to use a common 8042
controller driver. Also, reset and reconfigure the 8042 controller
as they are not guaranteed to be in the state that we expect.

- [x] Detect and initialize keyboard/mouse in qemu, bochs and vmware
- [x] Keyboard not working at all
- [x] Pressing keyboard key not triggering irq and breaks mouse (qemu, bochs, vmware)
- [x] Mouse not moving at all in bochs