### PR TITLE
LibJS: Use element index as key for array spread in object

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1552,7 +1552,7 @@ Value ObjectExpression::execute(Interpreter& interpreter, GlobalObject& global_o
             if (key.is_array()) {
                 auto& array_to_spread = static_cast<Array&>(key.as_object());
                 for (auto& entry : array_to_spread.indexed_properties()) {
-                    object->indexed_properties().append(entry.value_and_attributes(&array_to_spread).value);
+                    object->indexed_properties().put(object, entry.index(), entry.value_and_attributes(&array_to_spread).value);
                     if (interpreter.exception())
                         return {};
                 }

--- a/Libraries/LibJS/Tests/object-spread.js
+++ b/Libraries/LibJS/Tests/object-spread.js
@@ -53,6 +53,11 @@ test("spread array in object literal", () => {
     testObjStrSpread(obj);
 });
 
+test("spread array with holes in object literal", () => {
+    const obj = { ...[, , "a", , , , "b", "c", , "d", , ,] };
+    expect(obj).toEqual({ 2: "a", 6: "b", 7: "c", 9: "d" });
+});
+
 test("spread string object in object literal", () => {
     const obj = { ...String("abcd") };
     testObjStrSpread(obj);


### PR DESCRIPTION
This fixes spreading of arrays with holes in object literals where the inserted keys are not consecutive numbers.

Fixes #3967.