### PR TITLE
Kernel: Implement an asynchronous device request stack

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -14,6 +14,7 @@ set(KERNEL_SOURCES
     CMOS.cpp
     CommandLine.cpp
     Console.cpp
+    Devices/AsyncDeviceRequest.cpp
     Devices/BXVGADevice.cpp
     Devices/BlockDevice.cpp
     Devices/CharacterDevice.cpp

--- a/Kernel/Devices/AsyncDeviceRequest.cpp
+++ b/Kernel/Devices/AsyncDeviceRequest.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Kernel/Devices/AsyncDeviceRequest.h>
+#include <Kernel/Devices/Device.h>
+
+namespace Kernel {
+
+AsyncDeviceRequest::AsyncDeviceRequest(Device& device)
+    : m_device(device)
+    , m_process(*Process::current())
+{
+}
+
+AsyncDeviceRequest::~AsyncDeviceRequest()
+{
+    {
+        ScopedSpinLock lock(m_lock);
+        ASSERT(is_completed_result(m_result));
+        ASSERT(m_sub_requests_pending.is_empty());
+    }
+
+    // We should not need any locking here anymore. The destructor should
+    // only be called until either wait() or cancel() (once implemented) returned.
+    // At that point no sub-request should be adding more requests and all
+    // sub-requests should be completed (either succeeded, failed, or cancelled).
+    // Which means there should be no more pending sub-requests and the
+    // entire AsyncDeviceRequest hirarchy should be immutable.
+    for (auto& sub_request : m_sub_requests_complete) {
+        ASSERT(is_completed_result(sub_request.m_result)); // Shouldn't need any locking anymore
+        ASSERT(sub_request.m_parent_request == this);
+        sub_request.m_parent_request = nullptr;
+    }
+}
+
+void AsyncDeviceRequest::request_finished()
+{
+    if (m_parent_request)
+        m_parent_request->sub_request_finished(*this);
+
+    // Trigger processing the next request
+    m_device.process_next_queued_request({}, *this);
+
+    // Wake anyone who may be waiting
+    m_queue.wake_all();
+}
+
+auto AsyncDeviceRequest::wait(timeval* timeout) -> RequestWaitResult
+{
+    ASSERT(!m_parent_request);
+    auto request_result = get_request_result();
+    if (is_completed_result(request_result))
+        return { request_result, Thread::BlockResult::NotBlocked };
+    auto wait_result = Thread::current()->wait_on(m_queue, name(), timeout);
+    return { get_request_result(), wait_result };
+}
+
+auto AsyncDeviceRequest::get_request_result() const -> RequestResult
+{
+    ScopedSpinLock lock(m_lock);
+    return m_result;
+}
+
+void AsyncDeviceRequest::add_sub_request(NonnullRefPtr<AsyncDeviceRequest> sub_request)
+{
+    // Sub-requests cannot be for the same device
+    ASSERT(&m_device != &sub_request->m_device);
+    ASSERT(sub_request->m_parent_request == nullptr);
+    sub_request->m_parent_request = this;
+
+    bool should_start;
+    {
+        ScopedSpinLock lock(m_lock);
+        ASSERT(!is_completed_result(m_result));
+        m_sub_requests_pending.append(sub_request);
+        should_start = (m_result == Started);
+    }
+    if (should_start)
+        sub_request->do_start();
+}
+
+void AsyncDeviceRequest::sub_request_finished(AsyncDeviceRequest& sub_request)
+{
+    bool all_completed;
+    {
+        ScopedSpinLock lock(m_lock);
+        ASSERT(m_result == Started);
+        size_t index;
+        for (index = 0; index < m_sub_requests_pending.size(); index++) {
+            if (&m_sub_requests_pending[index] == &sub_request) {
+                NonnullRefPtr<AsyncDeviceRequest> request(m_sub_requests_pending[index]);
+                m_sub_requests_pending.remove(index);
+                m_sub_requests_complete.append(move(request));
+                break;
+            }
+        }
+        ASSERT(index < m_sub_requests_pending.size());
+        all_completed = m_sub_requests_pending.is_empty();
+        if (all_completed) {
+            // Aggregate any errors
+            bool any_failures = false;
+            bool any_memory_faults = false;
+            for (index = 0; index < m_sub_requests_complete.size(); index++) {
+                auto& sub_request = m_sub_requests_complete[index];
+                auto sub_result = sub_request.get_request_result();
+                ASSERT(is_completed_result(sub_result));
+                switch (sub_result) {
+                case Failure:
+                    any_failures = true;
+                    break;
+                case MemoryFault:
+                    any_memory_faults = true;
+                    break;
+                default:
+                    break;
+                }
+                if (any_failures && any_memory_faults)
+                    break; // Stop checking if all error conditions were found
+            }
+            if (any_failures)
+                m_result = Failure;
+            else if (any_memory_faults)
+                m_result = MemoryFault;
+            else
+                m_result = Success;
+        }
+    }
+    if (all_completed)
+        request_finished();
+}
+
+void AsyncDeviceRequest::complete(RequestResult result)
+{
+    ASSERT(result == Success || result == Failure || result == MemoryFault);
+    ScopedCritical critical;
+    {
+        ScopedSpinLock lock(m_lock);
+        ASSERT(m_result == Started);
+        m_result = result;
+    }
+    if (Processor::current().in_irq()) {
+        ref(); // Make sure we don't get freed
+        Processor::deferred_call_queue([this]() {
+            request_finished();
+            unref();
+        });
+    } else {
+        request_finished();
+    }
+}
+
+}

--- a/Kernel/Devices/AsyncDeviceRequest.h
+++ b/Kernel/Devices/AsyncDeviceRequest.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtrVector.h>
+#include <Kernel/Process.h>
+#include <Kernel/Thread.h>
+#include <Kernel/UserOrKernelBuffer.h>
+#include <Kernel/VM/ProcessPagingScope.h>
+#include <Kernel/WaitQueue.h>
+
+namespace Kernel {
+
+class Device;
+
+class AsyncDeviceRequest : public RefCounted<AsyncDeviceRequest> {
+    AK_MAKE_NONCOPYABLE(AsyncDeviceRequest);
+    AK_MAKE_NONMOVABLE(AsyncDeviceRequest);
+
+public:
+    enum RequestResult {
+        Pending = 0,
+        Started,
+        Success,
+        Failure,
+        MemoryFault,
+        Cancelled
+    };
+
+    class RequestWaitResult {
+        friend class AsyncDeviceRequest;
+
+    public:
+        RequestResult request_result() const { return m_request_result; }
+        Thread::BlockResult wait_result() const { return m_wait_result; }
+
+    private:
+        RequestWaitResult(RequestResult request_result, Thread::BlockResult wait_result)
+            : m_request_result(request_result)
+            , m_wait_result(wait_result)
+        {
+        }
+
+        RequestResult m_request_result;
+        Thread::BlockResult m_wait_result;
+    };
+
+    virtual ~AsyncDeviceRequest();
+
+    virtual const char* name() const = 0;
+    virtual void start() = 0;
+
+    void add_sub_request(NonnullRefPtr<AsyncDeviceRequest>);
+
+    [[nodiscard]] RequestWaitResult wait(timeval* = nullptr);
+
+    void do_start(Badge<Device>)
+    {
+        do_start();
+    }
+
+    void complete(RequestResult result);
+
+    void set_private(void* priv)
+    {
+        ASSERT(!m_private || !priv);
+        m_private = priv;
+    }
+    void* get_private() const { return m_private; }
+
+    template<typename... Args>
+    [[nodiscard]] bool write_to_buffer(UserOrKernelBuffer& buffer, Args... args)
+    {
+        if (in_target_context(buffer))
+            return buffer.write(forward<Args>(args)...);
+        ProcessPagingScope paging_scope(m_process);
+        return buffer.write(forward<Args>(args)...);
+    }
+
+    template<size_t BUFFER_BYTES, typename... Args>
+    [[nodiscard]] bool write_to_buffer_buffered(UserOrKernelBuffer& buffer, Args... args)
+    {
+        if (in_target_context(buffer))
+            return buffer.write_buffered<BUFFER_BYTES>(forward<Args>(args)...);
+        ProcessPagingScope paging_scope(m_process);
+        return buffer.write_buffered<BUFFER_BYTES>(forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    [[nodiscard]] bool read_from_buffer(const UserOrKernelBuffer& buffer, Args... args)
+    {
+        if (in_target_context(buffer))
+            return buffer.read(forward<Args>(args)...);
+        ProcessPagingScope paging_scope(m_process);
+        return buffer.read(forward<Args>(args)...);
+    }
+
+    template<size_t BUFFER_BYTES, typename... Args>
+    [[nodiscard]] bool read_from_buffer_buffered(const UserOrKernelBuffer& buffer, Args... args)
+    {
+        if (in_target_context(buffer))
+            return buffer.read_buffered<BUFFER_BYTES>(forward<Args>(args)...);
+        ProcessPagingScope paging_scope(m_process);
+        return buffer.read_buffered<BUFFER_BYTES>(forward<Args>(args)...);
+    }
+
+protected:
+    AsyncDeviceRequest(Device&);
+
+    RequestResult get_request_result() const;
+
+private:
+    void sub_request_finished(AsyncDeviceRequest&);
+    void request_finished();
+
+    void do_start()
+    {
+        {
+            ScopedSpinLock lock(m_lock);
+            if (is_completed_result(m_result))
+                return;
+            m_result = Started;
+        }
+        start();
+    }
+
+    bool in_target_context(const UserOrKernelBuffer& buffer) const
+    {
+        if (buffer.is_kernel_buffer())
+            return true;
+        return m_process == Process::current();
+    }
+
+    static bool is_completed_result(RequestResult result)
+    {
+        return result > Started;
+    }
+
+    Device& m_device;
+
+    AsyncDeviceRequest* m_parent_request { nullptr };
+    RequestResult m_result { Pending };
+    NonnullRefPtrVector<AsyncDeviceRequest> m_sub_requests_pending;
+    NonnullRefPtrVector<AsyncDeviceRequest> m_sub_requests_complete;
+    WaitQueue m_queue;
+    NonnullRefPtr<Process> m_process;
+    void* m_private { nullptr };
+    mutable SpinLock<u8> m_lock;
+};
+
+}

--- a/Kernel/Devices/BXVGADevice.h
+++ b/Kernel/Devices/BXVGADevice.h
@@ -48,10 +48,9 @@ private:
     virtual const char* class_name() const override { return "BXVGA"; }
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
+    virtual void start_request(AsyncBlockDeviceRequest& request) override { request.complete(AsyncDeviceRequest::Failure); }
     virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override { return -EINVAL; }
     virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
-    virtual bool read_blocks(unsigned, u16, UserOrKernelBuffer&) override { return false; }
-    virtual bool write_blocks(unsigned, u16, const UserOrKernelBuffer&) override { return false; }
 
     void set_safe_resolution();
 

--- a/Kernel/Devices/BlockDevice.cpp
+++ b/Kernel/Devices/BlockDevice.cpp
@@ -28,18 +28,66 @@
 
 namespace Kernel {
 
+AsyncBlockDeviceRequest::AsyncBlockDeviceRequest(Device& block_device, RequestType request_type, u32 block_index, u32 block_count, const UserOrKernelBuffer& buffer, size_t buffer_size)
+    : AsyncDeviceRequest(block_device)
+    , m_block_device(static_cast<BlockDevice&>(block_device))
+    , m_request_type(request_type)
+    , m_block_index(block_index)
+    , m_block_count(block_count)
+    , m_buffer(buffer)
+    , m_buffer_size(buffer_size)
+{
+}
+
+void AsyncBlockDeviceRequest::start()
+{
+    m_block_device.start_request(*this);
+}
+
 BlockDevice::~BlockDevice()
 {
 }
 
-bool BlockDevice::read_block(unsigned index, UserOrKernelBuffer& buffer) const
+bool BlockDevice::read_block(unsigned index, UserOrKernelBuffer& buffer)
 {
-    return const_cast<BlockDevice*>(this)->read_blocks(index, 1, buffer);
+    auto read_request = make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Read, index, 1, buffer, 512);
+    switch (read_request->wait().request_result()) {
+    case AsyncDeviceRequest::Success:
+        return true;
+    case AsyncDeviceRequest::Failure:
+        dbg() << "BlockDevice::read_block(" << index << ") IO error";
+        break;
+    case AsyncDeviceRequest::MemoryFault:
+        dbg() << "BlockDevice::read_block(" << index << ") EFAULT";
+        break;
+    case AsyncDeviceRequest::Cancelled:
+        dbg() << "BlockDevice::read_block(" << index << ") cancelled";
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+    return false;
 }
 
-bool BlockDevice::write_block(unsigned index, const UserOrKernelBuffer& data)
+bool BlockDevice::write_block(unsigned index, const UserOrKernelBuffer& buffer)
 {
-    return write_blocks(index, 1, data);
+    auto write_request = make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Write, index, 1, buffer, 512);
+    switch (write_request->wait().request_result()) {
+    case AsyncDeviceRequest::Success:
+        return true;
+    case AsyncDeviceRequest::Failure:
+        dbg() << "BlockDevice::write_block(" << index << ") IO error";
+        break;
+    case AsyncDeviceRequest::MemoryFault:
+        dbg() << "BlockDevice::write_block(" << index << ") EFAULT";
+        break;
+    case AsyncDeviceRequest::Cancelled:
+        dbg() << "BlockDevice::write_block(" << index << ") cancelled";
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+    return false;
 }
 
 }

--- a/Kernel/Devices/BlockDevice.h
+++ b/Kernel/Devices/BlockDevice.h
@@ -30,6 +30,46 @@
 
 namespace Kernel {
 
+class BlockDevice;
+
+class AsyncBlockDeviceRequest : public AsyncDeviceRequest {
+public:
+    enum RequestType {
+        Read,
+        Write
+    };
+    AsyncBlockDeviceRequest(Device& block_device, RequestType request_type,
+        u32 block_index, u32 block_count, const UserOrKernelBuffer& buffer, size_t buffer_size);
+
+    RequestType request_type() const { return m_request_type; }
+    u32 block_index() const { return m_block_index; }
+    u32 block_count() const { return m_block_count; }
+    UserOrKernelBuffer& buffer() { return m_buffer; }
+    const UserOrKernelBuffer& buffer() const { return m_buffer; }
+    size_t buffer_size() const { return m_buffer_size; }
+
+    virtual void start() override;
+    virtual const char* name() const override
+    {
+        switch (m_request_type) {
+        case Read:
+            return "BlockDeviceRequest (read)";
+        case Write:
+            return "BlockDeviceRequest (read)";
+        default:
+            ASSERT_NOT_REACHED();
+        }
+    }
+
+private:
+    BlockDevice& m_block_device;
+    const RequestType m_request_type;
+    const u32 m_block_index;
+    const u32 m_block_count;
+    UserOrKernelBuffer m_buffer;
+    const size_t m_buffer_size;
+};
+
 class BlockDevice : public Device {
 public:
     virtual ~BlockDevice() override;
@@ -37,11 +77,10 @@ public:
     size_t block_size() const { return m_block_size; }
     virtual bool is_seekable() const override { return true; }
 
-    bool read_block(unsigned index, UserOrKernelBuffer&) const;
+    bool read_block(unsigned index, UserOrKernelBuffer&);
     bool write_block(unsigned index, const UserOrKernelBuffer&);
 
-    virtual bool read_blocks(unsigned index, u16 count, UserOrKernelBuffer&) = 0;
-    virtual bool write_blocks(unsigned index, u16 count, const UserOrKernelBuffer&) = 0;
+    virtual void start_request(AsyncBlockDeviceRequest&) = 0;
 
 protected:
     BlockDevice(unsigned major, unsigned minor, size_t block_size = PAGE_SIZE)

--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -80,4 +80,21 @@ String Device::absolute_path(const FileDescription&) const
     return absolute_path();
 }
 
+void Device::process_next_queued_request(Badge<AsyncDeviceRequest>, const AsyncDeviceRequest& completed_request)
+{
+    AsyncDeviceRequest* next_request = nullptr;
+
+    {
+        ScopedSpinLock lock(m_requests_lock);
+        ASSERT(!m_requests.is_empty());
+        ASSERT(m_requests.first().ptr() == &completed_request);
+        m_requests.remove(m_requests.begin());
+        if (!m_requests.is_empty())
+            next_request = m_requests.first().ptr();
+    }
+
+    if (next_request)
+        next_request->start();
+}
+
 }

--- a/Kernel/Devices/DiskPartition.cpp
+++ b/Kernel/Devices/DiskPartition.cpp
@@ -48,6 +48,12 @@ DiskPartition::~DiskPartition()
 {
 }
 
+void DiskPartition::start_request(AsyncBlockDeviceRequest& request)
+{
+    request.add_sub_request(m_device->make_request<AsyncBlockDeviceRequest>(request.request_type(),
+        request.block_index() + m_block_offset, request.block_count(), request.buffer(), request.buffer_size()));
+}
+
 KResultOr<size_t> DiskPartition::read(FileDescription& fd, size_t offset, UserOrKernelBuffer& outbuf, size_t len)
 {
     unsigned adjust = m_block_offset * block_size();
@@ -90,24 +96,6 @@ bool DiskPartition::can_write(const FileDescription& fd, size_t offset) const
 #endif
 
     return m_device->can_write(fd, offset + adjust);
-}
-
-bool DiskPartition::read_blocks(unsigned index, u16 count, UserOrKernelBuffer& out)
-{
-#ifdef OFFD_DEBUG
-    klog() << "DiskPartition::read_blocks " << index << " (really: " << (m_block_offset + index) << ") count=" << count;
-#endif
-
-    return m_device->read_blocks(m_block_offset + index, count, out);
-}
-
-bool DiskPartition::write_blocks(unsigned index, u16 count, const UserOrKernelBuffer& data)
-{
-#ifdef OFFD_DEBUG
-    klog() << "DiskPartition::write_blocks " << index << " (really: " << (m_block_offset + index) << ") count=" << count;
-#endif
-
-    return m_device->write_blocks(m_block_offset + index, count, data);
 }
 
 const char* DiskPartition::class_name() const

--- a/Kernel/Devices/DiskPartition.h
+++ b/Kernel/Devices/DiskPartition.h
@@ -36,8 +36,7 @@ public:
     static NonnullRefPtr<DiskPartition> create(BlockDevice&, unsigned block_offset, unsigned block_limit);
     virtual ~DiskPartition();
 
-    virtual bool read_blocks(unsigned index, u16 count, UserOrKernelBuffer&) override;
-    virtual bool write_blocks(unsigned index, u16 count, const UserOrKernelBuffer&) override;
+    virtual void start_request(AsyncBlockDeviceRequest&) override;
 
     // ^BlockDevice
     virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;

--- a/Kernel/Devices/EBRPartitionTable.cpp
+++ b/Kernel/Devices/EBRPartitionTable.cpp
@@ -63,6 +63,9 @@ int EBRPartitionTable::index_of_ebr_container() const
 
 bool EBRPartitionTable::initialize()
 {
+    auto mbr_header_request = m_device->make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Read,
+        0, 1, UserOrKernelBuffer::for_kernel_buffer(m_cached_mbr_header), sizeof(m_cached_mbr_header));
+
     auto mbr_header_buffer = UserOrKernelBuffer::for_kernel_buffer(m_cached_mbr_header);
     if (!m_device->read_block(0, mbr_header_buffer)) {
         return false;

--- a/Kernel/Devices/GPTPartitionTable.cpp
+++ b/Kernel/Devices/GPTPartitionTable.cpp
@@ -84,7 +84,7 @@ RefPtr<DiskPartition> GPTPartitionTable::partition(unsigned index)
 
     GPTPartitionEntry entries[entries_per_sector];
     auto entries_buffer = UserOrKernelBuffer::for_kernel_buffer((u8*)&entries);
-    this->m_device->read_blocks(lba, 1, entries_buffer);
+    this->m_device->read_block(lba, entries_buffer);
     GPTPartitionEntry& entry = entries[((index - 1) % entries_per_sector)];
 
 #ifdef GPT_DEBUG

--- a/Kernel/Devices/MBVGADevice.h
+++ b/Kernel/Devices/MBVGADevice.h
@@ -49,8 +49,7 @@ private:
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
     virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override { return -EINVAL; }
     virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
-    virtual bool read_blocks(unsigned, u16, UserOrKernelBuffer&) override { return false; }
-    virtual bool write_blocks(unsigned, u16, const UserOrKernelBuffer&) override { return false; }
+    virtual void start_request(AsyncBlockDeviceRequest& request) override { request.complete(AsyncDeviceRequest::Failure); }
 
     size_t framebuffer_size_in_bytes() const { return m_framebuffer_pitch * m_framebuffer_height; }
 

--- a/Kernel/Devices/PATADiskDevice.h
+++ b/Kernel/Devices/PATADiskDevice.h
@@ -54,13 +54,10 @@ public:
     static NonnullRefPtr<PATADiskDevice> create(PATAChannel&, DriveType, int major, int minor);
     virtual ~PATADiskDevice() override;
 
-    // ^DiskDevice
-    virtual bool read_blocks(unsigned index, u16 count, UserOrKernelBuffer&) override;
-    virtual bool write_blocks(unsigned index, u16 count, const UserOrKernelBuffer&) override;
-
     void set_drive_geometry(u16, u16, u16);
 
     // ^BlockDevice
+    virtual void start_request(AsyncBlockDeviceRequest&) override;
     virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
@@ -73,11 +70,6 @@ private:
     // ^DiskDevice
     virtual const char* class_name() const override;
 
-    bool wait_for_irq();
-    bool read_sectors_with_dma(u32 lba, u16 count, UserOrKernelBuffer&);
-    bool write_sectors_with_dma(u32 lba, u16 count, const UserOrKernelBuffer&);
-    bool read_sectors(u32 lba, u16 count, UserOrKernelBuffer& buffer);
-    bool write_sectors(u32 lba, u16 count, const UserOrKernelBuffer& data);
     bool is_slave() const;
 
     Lock m_lock { "IDEDiskDevice" };


### PR DESCRIPTION
This allows issuing asynchronous requests for devices and waiting
on the completion of the request. The requests can cascade into
multiple sub-requests.

Since IRQs may complete at any time, if the current process is no
longer the same that started the process, we need to swich the
paging context before accessing user buffers.

Change the PATA driver to use this model.

- [x] Figure out why this crashes with `smp=off`:
```
[colonel(0:0)]: ASSERTION FAILED: handler.type() == HandlerType::SpuriousInterruptHandler

#0  0xc011f41b in halt_this () at ../Kernel/Arch/i386/CPU.cpp:957
#1  Kernel::Processor::halt () at ../Kernel/Arch/i386/CPU.cpp:1934
#2  0xc011eec8 in __assertion_failed () at ../Kernel/Arch/i386/CPU.cpp:2143
#3  0xc014e349 in Kernel::PIC::spurious_eoi ()
    at ../Kernel/Interrupts/PIC.cpp:95
#4  Kernel::PIC::spurious_eoi () at ../Kernel/Interrupts/PIC.cpp:93
#5  0xc014e5fd in Kernel::PIC::eoi () at ../Kernel/Interrupts/PIC.cpp:143
#6  0xc014d057 in Kernel::IRQHandler::eoi ()
    at ../Kernel/Interrupts/IRQHandler.cpp:53
#7  0xc011e023 in interrupt_common_asm_entry ()
```