### PR TITLE
Documentation: Update required GCC version to >= 10

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -30,23 +30,23 @@ sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs qemu qem
 apt-get install curl cmake libmpc-devel gmp-devel e2fsprogs libmpfr-devel patch gcc
 ```
 
-Ensure your gcc version is >= 9 with `gcc --version`. Otherwise, install it (on Ubuntu) with:
+Ensure your gcc version is >= 10 with `gcc --version`. Otherwise, install it.
+
+On Ubuntu it's in the repositories of 20.04 (Focal) - add the `ubuntu-toolchain-r/test` PPA if you're running an older version:
 ```bash
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-sudo apt-get install gcc-9 g++-9
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 ```
 
-On Debian you can install it by switching to the Debian testing branch:
+On Debian you can use the Debian testing branch:
 ```bash
 sudo echo "deb http://http.us.debian.org/debian/ testing non-free contrib main" >> /etc/apt/sources.list
 sudo apt update
 ```
 
-Afterwards you can install gcc-9 with apt like:
+Now on Ubuntu or Debian you can install gcc-10 with apt like this:
 ```bash
-sudo apt install gcc-9 g++-9
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9
+sudo apt install gcc-10 g++-10
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 900 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 ```
 
 If you don't want to stay on the testing branch you can switch back by running:

--- a/Meta/Lagom/ReadMe.md
+++ b/Meta/Lagom/ReadMe.md
@@ -8,10 +8,6 @@ If you want to bring the comfortable Serenity classes with you to another system
 
 *Lagom* is a Swedish word that means "just the right amount." ([Wikipedia](https://en.wikipedia.org/wiki/Lagom))
 
-## Prerequisites
-
-You'll need a compiler as capable as the one used for the toolchain - which might differ from the compiler you used *to compile* the toolchain. Check `GCC_VERSION` in [`BuildIt.sh`](../../Toolchain/BuildIt.sh).
-
 ## Fuzzing
 
 Lagom can be used to fuzz parts of SerenityOS's code base. This requires buildling with `clang`, so it's convenient to use a different build directory for that. Run CMake like this:


### PR DESCRIPTION
I initially thought as long as Lagom is not built >= 9 would be fine, but LagomCore is always built for the code generators.

GCC 10 for everyone, sorry folks.