### PR TITLE
LibGUI+WindowServer: MimeData in DragOperation / Spreadsheet: Copying ranges of cells

### DIFF
--- a/Applications/Spreadsheet/Spreadsheet.h
+++ b/Applications/Spreadsheet/Spreadsheet.h
@@ -51,6 +51,11 @@ public:
 
     Cell* from_url(const URL&);
     const Cell* from_url(const URL& url) const { return const_cast<Sheet*>(this)->from_url(url); }
+    Optional<Position> position_from_url(const URL& url) const;
+
+    /// Resolve 'offset' to an absolute position assuming 'base' is at 'offset_base'.
+    /// Effectively, "Walk the distance between 'offset' and 'offset_base' away from 'base'".
+    Position offset_relative_to(const Position& base, const Position& offset, const Position& offset_base) const;
 
     JsonObject to_json() const;
     static RefPtr<Sheet> from_json(const JsonObject&, Workbook&);
@@ -87,6 +92,14 @@ public:
     size_t row_count() const { return m_rows; }
     size_t column_count() const { return m_columns.size(); }
     const Vector<String>& columns() const { return m_columns; }
+    const String& column(size_t index)
+    {
+        for (size_t i = column_count(); i < index; ++i)
+            add_column();
+
+        ASSERT(column_count() > index);
+        return m_columns[index];
+    }
     const String& column(size_t index) const
     {
         ASSERT(column_count() > index);
@@ -104,6 +117,8 @@ public:
     bool has_been_visited(Cell* cell) const { return m_visited_cells_in_update.contains(cell); }
 
     const Workbook& workbook() const { return m_workbook; }
+
+    void copy_cells(Vector<Position> from, Vector<Position> to, Optional<Position> resolve_relative_to = {});
 
 private:
     explicit Sheet(Workbook&);

--- a/Applications/Spreadsheet/SpreadsheetModel.h
+++ b/Applications/Spreadsheet/SpreadsheetModel.h
@@ -40,6 +40,7 @@ public:
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_sheet->column_count(); }
     virtual String column_name(int) const override;
     virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
+    virtual RefPtr<Core::MimeData> mime_data(const GUI::ModelSelection&) const override;
     virtual bool is_editable(const GUI::ModelIndex&) const override;
     virtual void set_data(const GUI::ModelIndex&, const GUI::Variant&) override;
     virtual void update() override;

--- a/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Applications/Spreadsheet/SpreadsheetView.h
@@ -29,6 +29,7 @@
 #include "Spreadsheet.h"
 #include <LibGUI/AbstractTableView.h>
 #include <LibGUI/ModelEditingDelegate.h>
+#include <LibGUI/TableView.h>
 #include <LibGUI/Widget.h>
 #include <string.h>
 
@@ -86,6 +87,11 @@ public:
 
     const Sheet& sheet() const { return *m_sheet; }
     Sheet& sheet() { return *m_sheet; }
+
+    const GUI::ModelIndex* cursor() const
+    {
+        return &m_table_view->cursor_index();
+    }
 
     Function<void(Vector<Position>&&)> on_selection_changed;
     Function<void()> on_selection_dropped;

--- a/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -114,6 +114,7 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
                 m_cell_value_editor->on_change = [&] {
                     cell.set_data(m_cell_value_editor->text());
                     m_selected_view->sheet().update();
+                    update();
                 };
                 m_cell_value_editor->set_enabled(true);
                 return;
@@ -139,6 +140,7 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
                     for (auto* cell : cells)
                         cell->set_data(m_cell_value_editor->text());
                     m_selected_view->sheet().update();
+                    update();
                 }
             };
             m_cell_value_editor->set_enabled(true);

--- a/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -52,6 +52,14 @@ public:
     Workbook& workbook() { return *m_workbook; }
     const Workbook& workbook() const { return *m_workbook; }
 
+    const GUI::ModelIndex* current_selection_cursor() const
+    {
+        if (!m_selected_view)
+            return nullptr;
+
+        return m_selected_view->cursor();
+    }
+
 private:
     explicit SpreadsheetWidget(NonnullRefPtrVector<Sheet>&& sheets = {}, bool should_add_sheet_if_empty = true);
 

--- a/Libraries/LibCore/MimeData.h
+++ b/Libraries/LibCore/MimeData.h
@@ -55,8 +55,14 @@ public:
     Vector<URL> urls() const;
     void set_urls(const Vector<URL>&);
 
+    const HashMap<String, ByteBuffer>& all_data() const { return m_data; }
+
 private:
     MimeData() { }
+    explicit MimeData(const HashMap<String, ByteBuffer>& data)
+        : m_data(data)
+    {
+    }
 
     HashMap<String, ByteBuffer> m_data;
 };

--- a/Libraries/LibGUI/AbstractView.cpp
+++ b/Libraries/LibGUI/AbstractView.cpp
@@ -288,6 +288,14 @@ void AbstractView::mousemove_event(MouseEvent& event)
 
     ASSERT(!data_type.is_null());
 
+    if (m_is_dragging)
+        return;
+
+    // An event might sneak in between us constructing the drag operation and the
+    // event loop exec at the end of `drag_operation->exec()' if the user is fast enough.
+    // Prevent this by just ignoring later drag initiations (until the current drag operation ends).
+    TemporaryChange dragging { m_is_dragging, true };
+
     dbg() << "Initiate drag!";
     auto drag_operation = DragOperation::construct();
 

--- a/Libraries/LibGUI/AbstractView.cpp
+++ b/Libraries/LibGUI/AbstractView.cpp
@@ -291,33 +291,7 @@ void AbstractView::mousemove_event(MouseEvent& event)
     dbg() << "Initiate drag!";
     auto drag_operation = DragOperation::construct();
 
-    RefPtr<Gfx::Bitmap> bitmap;
-
-    StringBuilder text_builder;
-    StringBuilder data_builder;
-    bool first = true;
-    m_selection.for_each_index([&](auto& index) {
-        auto text_data = index.data();
-        if (!first)
-            text_builder.append(", ");
-        text_builder.append(text_data.to_string());
-
-        auto drag_data = index.data(ModelRole::DragData);
-        data_builder.append(drag_data.to_string());
-        data_builder.append('\n');
-
-        first = false;
-
-        if (!bitmap) {
-            Variant icon_data = index.data(ModelRole::Icon);
-            if (icon_data.is_icon())
-                bitmap = icon_data.as_icon().bitmap_for_size(32);
-        }
-    });
-
-    drag_operation->set_text(text_builder.to_string());
-    drag_operation->set_bitmap(bitmap);
-    drag_operation->set_data(data_type, data_builder.to_string());
+    drag_operation->set_mime_data(m_model->mime_data(m_selection));
 
     auto outcome = drag_operation->exec();
 

--- a/Libraries/LibGUI/AbstractView.h
+++ b/Libraries/LibGUI/AbstractView.h
@@ -186,6 +186,7 @@ private:
     bool m_activates_on_selection { false };
     bool m_multi_select { true };
     bool m_tab_key_navigation_enabled { false };
+    bool m_is_dragging { false };
 };
 
 }

--- a/Libraries/LibGUI/DragOperation.h
+++ b/Libraries/LibGUI/DragOperation.h
@@ -44,13 +44,10 @@ public:
 
     virtual ~DragOperation() override;
 
-    void set_text(const String& text) { m_text = text; }
-    void set_bitmap(const Gfx::Bitmap* bitmap) { m_bitmap = bitmap; }
-    void set_data(const String& data_type, const String& data)
-    {
-        m_data_type = data_type;
-        m_data = data;
-    }
+    void set_mime_data(RefPtr<Core::MimeData> mime_data) { m_mime_data = move(mime_data); }
+    void set_text(const String& text);
+    void set_bitmap(const Gfx::Bitmap* bitmap);
+    void set_data(const String& data_type, const String& data);
 
     Outcome exec();
     Outcome outcome() const { return m_outcome; }
@@ -66,10 +63,7 @@ private:
 
     OwnPtr<Core::EventLoop> m_event_loop;
     Outcome m_outcome { Outcome::None };
-    String m_text;
-    String m_data_type;
-    String m_data;
-    RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<Core::MimeData> m_mime_data;
 };
 
 }

--- a/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Libraries/LibGUI/FileSystemModel.cpp
@@ -403,7 +403,7 @@ Variant FileSystemModel::data(const ModelIndex& index, ModelRole role) const
         return node.full_path();
     }
 
-    if (role == ModelRole::DragData) {
+    if (role == ModelRole::MimeData) {
         if (index.column() == Column::Name) {
             StringBuilder builder;
             builder.append("file://");

--- a/Libraries/LibGUI/Model.h
+++ b/Libraries/LibGUI/Model.h
@@ -31,8 +31,10 @@
 #include <AK/HashTable.h>
 #include <AK/RefCounted.h>
 #include <AK/String.h>
+#include <LibCore/MimeData.h>
 #include <LibGUI/ModelIndex.h>
 #include <LibGUI/ModelRole.h>
+#include <LibGUI/ModelSelection.h>
 #include <LibGUI/Variant.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/TextAlignment.h>
@@ -93,6 +95,7 @@ public:
     }
 
     virtual StringView drag_data_type() const { return {}; }
+    virtual RefPtr<Core::MimeData> mime_data(const ModelSelection&) const;
 
     void register_view(Badge<AbstractView>, AbstractView&);
     void unregister_view(Badge<AbstractView>, AbstractView&);

--- a/Libraries/LibGUI/ModelRole.h
+++ b/Libraries/LibGUI/ModelRole.h
@@ -35,7 +35,7 @@ enum class ModelRole {
     BackgroundColor,
     Icon,
     Font,
-    DragData,
+    MimeData,
     TextAlignment,
     Search,
     Custom = 0x100, // Applications are free to use roles above this number as they please

--- a/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Libraries/LibGUI/WindowServerConnection.cpp
@@ -307,8 +307,7 @@ void WindowServerConnection::handle(const Messages::WindowClient::AsyncSetWallpa
 void WindowServerConnection::handle(const Messages::WindowClient::DragDropped& message)
 {
     if (auto* window = Window::from_window_id(message.window_id())) {
-        auto mime_data = Core::MimeData::construct();
-        mime_data->set_data(message.data_type(), message.data().to_byte_buffer());
+        auto mime_data = Core::MimeData::construct(message.mime_data());
         Core::EventLoop::current().post_event(*window, make<DropEvent>(message.mouse_position(), message.text(), mime_data));
     }
 }

--- a/Libraries/LibGfx/Bitmap.h
+++ b/Libraries/LibGfx/Bitmap.h
@@ -94,6 +94,7 @@ public:
     static RefPtr<Bitmap> load_from_file(const StringView& path);
     static RefPtr<Bitmap> create_with_shared_buffer(BitmapFormat, NonnullRefPtr<SharedBuffer>&&, const IntSize&);
     static RefPtr<Bitmap> create_with_shared_buffer(BitmapFormat, NonnullRefPtr<SharedBuffer>&&, const IntSize&, const Vector<RGBA32>& palette);
+    static RefPtr<Bitmap> create_from_serialized_byte_buffer(ByteBuffer&& buffer);
     static bool is_path_a_supported_image_format(const StringView& path)
     {
 #define __ENUMERATE_IMAGE_FORMAT(Name, Ext) \
@@ -110,6 +111,7 @@ public:
     RefPtr<Gfx::Bitmap> rotated(Gfx::RotationDirection) const;
     RefPtr<Gfx::Bitmap> flipped(Gfx::Orientation) const;
     RefPtr<Bitmap> to_bitmap_backed_by_shared_buffer() const;
+    ByteBuffer serialize_to_byte_buffer() const;
 
     ShareableBitmap to_shareable_bitmap(pid_t peer_pid = -1) const;
 

--- a/Libraries/LibIPC/Decoder.cpp
+++ b/Libraries/LibIPC/Decoder.cpp
@@ -112,6 +112,25 @@ bool Decoder::decode(String& value)
     return !m_stream.handle_any_error();
 }
 
+bool Decoder::decode(ByteBuffer& value)
+{
+    i32 length = 0;
+    m_stream >> length;
+    if (m_stream.handle_any_error())
+        return false;
+    if (length < 0) {
+        value = {};
+        return true;
+    }
+    if (length == 0) {
+        value = ByteBuffer::create_uninitialized(0);
+        return true;
+    }
+    value = ByteBuffer::create_uninitialized(length);
+    m_stream >> value.bytes();
+    return !m_stream.handle_any_error();
+}
+
 bool Decoder::decode(URL& value)
 {
     String string;

--- a/Libraries/LibIPC/Decoder.h
+++ b/Libraries/LibIPC/Decoder.h
@@ -60,8 +60,29 @@ public:
     bool decode(i64&);
     bool decode(float&);
     bool decode(String&);
+    bool decode(ByteBuffer&);
     bool decode(URL&);
     bool decode(Dictionary&);
+    template<typename K, typename V>
+    bool decode(HashMap<K, V>& hashmap)
+    {
+        u32 size;
+        if (!decode(size) || size > NumericLimits<i32>::max())
+            return false;
+
+        for (size_t i = 0; i < size; ++i) {
+            K key;
+            if (!decode(key))
+                return false;
+
+            V value;
+            if (!decode(value))
+                return false;
+
+            hashmap.set(move(key), move(value));
+        }
+        return true;
+    }
 
     template<typename T>
     bool decode(T& value)

--- a/Libraries/LibIPC/Encoder.cpp
+++ b/Libraries/LibIPC/Encoder.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/ByteBuffer.h>
 #include <AK/String.h>
 #include <AK/URL.h>
 #include <LibIPC/Dictionary.h>
@@ -139,6 +140,13 @@ Encoder& Encoder::operator<<(const String& value)
         return *this << (i32)-1;
     *this << static_cast<i32>(value.length());
     return *this << value.view();
+}
+
+Encoder& Encoder::operator<<(const ByteBuffer& value)
+{
+    *this << static_cast<i32>(value.size());
+    m_buffer.append(value.data(), value.size());
+    return *this;
 }
 
 Encoder& Encoder::operator<<(const URL& value)

--- a/Libraries/LibIPC/Encoder.h
+++ b/Libraries/LibIPC/Encoder.h
@@ -58,8 +58,19 @@ public:
     Encoder& operator<<(const char*);
     Encoder& operator<<(const StringView&);
     Encoder& operator<<(const String&);
+    Encoder& operator<<(const ByteBuffer&);
     Encoder& operator<<(const URL&);
     Encoder& operator<<(const Dictionary&);
+    template<typename K, typename V>
+    Encoder& operator<<(const HashMap<K, V>& hashmap)
+    {
+        *this << (u32)hashmap.size();
+        for (auto it : hashmap) {
+            *this << it.key;
+            *this << it.value;
+        }
+        return *this;
+    }
 
     template<typename T>
     Encoder& operator<<(const Vector<T>& vector)

--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -755,7 +755,7 @@ OwnPtr<Messages::WindowServer::StartDragResponse> ClientConnection::handle(const
         bitmap = Gfx::Bitmap::create_with_shared_buffer(Gfx::BitmapFormat::RGBA32, *shared_buffer, message.bitmap_size());
     }
 
-    wm.start_dnd_drag(*this, message.text(), bitmap, message.data_type(), message.data());
+    wm.start_dnd_drag(*this, message.text(), bitmap, Core::MimeData::construct(message.mime_data()));
     return make<Messages::WindowServer::StartDragResponse>(true);
 }
 

--- a/Services/WindowServer/Event.h
+++ b/Services/WindowServer/Event.h
@@ -29,6 +29,7 @@
 #include <AK/String.h>
 #include <Kernel/API/KeyCode.h>
 #include <LibCore/Event.h>
+#include <LibCore/MimeData.h>
 #include <LibGfx/Rect.h>
 #include <WindowServer/Cursor.h>
 #include <WindowServer/WindowType.h>
@@ -128,7 +129,7 @@ public:
     const String& drag_data_type() const { return m_drag_data_type; }
 
     void set_drag(bool b) { m_drag = b; }
-    void set_drag_data_type(const String& drag_data_type) { m_drag_data_type = drag_data_type; }
+    void set_mime_data(const Core::MimeData& mime_data) { m_mime_data = mime_data; }
 
     MouseEvent translated(const Gfx::IntPoint& delta) const { return MouseEvent((Type)type(), m_position.translated(delta), m_buttons, m_button, m_modifiers, m_wheel_delta); }
 
@@ -140,6 +141,7 @@ private:
     int m_wheel_delta { 0 };
     bool m_drag { false };
     String m_drag_data_type;
+    RefPtr<const Core::MimeData> m_mime_data;
 };
 
 class ResizeEvent final : public Event {

--- a/Services/WindowServer/WindowClient.ipc
+++ b/Services/WindowServer/WindowClient.ipc
@@ -32,7 +32,7 @@ endpoint WindowClient = 4
     DragAccepted() =|
     DragCancelled() =|
 
-    DragDropped(i32 window_id, Gfx::IntPoint mouse_position, [UTF8] String text, String data_type, String data) =|
+    DragDropped(i32 window_id, Gfx::IntPoint mouse_position, [UTF8] String text, HashMap<String,ByteBuffer> mime_data) =|
 
     UpdateSystemTheme(i32 system_theme_buffer_id) =|
 

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -705,7 +705,7 @@ bool WindowManager::process_ongoing_drag(MouseEvent& event, Window*& hovered_win
             hovered_window = &window;
             auto translated_event = event.translated(-window.position());
             translated_event.set_drag(true);
-            translated_event.set_drag_data_type(m_dnd_data_type);
+            translated_event.set_mime_data(*m_dnd_mime_data);
             deliver_mouse_event(window, translated_event);
             return IterationDecision::Break;
         });
@@ -727,7 +727,7 @@ bool WindowManager::process_ongoing_drag(MouseEvent& event, Window*& hovered_win
         m_dnd_client->post_message(Messages::WindowClient::DragAccepted());
         if (hovered_window->client()) {
             auto translated_event = event.translated(-hovered_window->position());
-            hovered_window->client()->post_message(Messages::WindowClient::DragDropped(hovered_window->window_id(), translated_event.position(), m_dnd_text, m_dnd_data_type, m_dnd_data));
+            hovered_window->client()->post_message(Messages::WindowClient::DragDropped(hovered_window->window_id(), translated_event.position(), m_dnd_text, m_dnd_mime_data->all_data()));
         }
     } else {
         m_dnd_client->post_message(Messages::WindowClient::DragCancelled());
@@ -1355,14 +1355,13 @@ Gfx::IntRect WindowManager::maximized_window_rect(const Window& window) const
     return rect;
 }
 
-void WindowManager::start_dnd_drag(ClientConnection& client, const String& text, Gfx::Bitmap* bitmap, const String& data_type, const String& data)
+void WindowManager::start_dnd_drag(ClientConnection& client, const String& text, Gfx::Bitmap* bitmap, const Core::MimeData& mime_data)
 {
     ASSERT(!m_dnd_client);
     m_dnd_client = client.make_weak_ptr();
     m_dnd_text = text;
     m_dnd_bitmap = bitmap;
-    m_dnd_data_type = data_type;
-    m_dnd_data = data;
+    m_dnd_mime_data = mime_data;
     Compositor::the().invalidate_cursor();
     m_active_input_tracking_window = nullptr;
 }

--- a/Services/WindowServer/WindowManager.h
+++ b/Services/WindowServer/WindowManager.h
@@ -100,12 +100,11 @@ public:
 
     const ClientConnection* dnd_client() const { return m_dnd_client.ptr(); }
     const String& dnd_text() const { return m_dnd_text; }
-    const String& dnd_data_type() const { return m_dnd_data_type; }
-    const String& dnd_data() const { return m_dnd_data; }
+    const Core::MimeData& dnd_mime_data() const { return *m_dnd_mime_data; }
     const Gfx::Bitmap* dnd_bitmap() const { return m_dnd_bitmap; }
     Gfx::IntRect dnd_rect() const;
 
-    void start_dnd_drag(ClientConnection&, const String& text, Gfx::Bitmap*, const String& data_type, const String& data);
+    void start_dnd_drag(ClientConnection&, const String& text, Gfx::Bitmap*, const Core::MimeData&);
     void end_dnd_drag();
 
     Window* active_window() { return m_active_window.ptr(); }
@@ -331,8 +330,7 @@ private:
 
     WeakPtr<ClientConnection> m_dnd_client;
     String m_dnd_text;
-    String m_dnd_data_type;
-    String m_dnd_data;
+    RefPtr<Core::MimeData> m_dnd_mime_data;
     RefPtr<Gfx::Bitmap> m_dnd_bitmap;
 };
 

--- a/Services/WindowServer/WindowServer.ipc
+++ b/Services/WindowServer/WindowServer.ipc
@@ -94,7 +94,7 @@ endpoint WindowServer = 2
     SetWindowCursor(i32 window_id, i32 cursor_type) => ()
     SetWindowCustomCursor(i32 window_id, Gfx::ShareableBitmap cursor) => ()
 
-    StartDrag([UTF8] String text, String data_type, String data, i32 bitmap_id, Gfx::IntSize bitmap_size) => (bool started)
+    StartDrag([UTF8] String text, HashMap<String,ByteBuffer> mime_data, i32 bitmap_id, Gfx::IntSize bitmap_size) => (bool started)
 
     SetSystemTheme(String theme_path, [UTF8] String theme_name) => (bool success)
     GetSystemTheme() => ([UTF8] String theme_name)


### PR DESCRIPTION
Finally closes #3906.
This messes with WindowServer and drag&drop, but it should not have caused any changes to its existing behaviour.

In action (pardon the crappy gif, this is my first time making one like this :P)
![out](https://user-images.githubusercontent.com/14001776/98450462-25ca9380-2152-11eb-8f9d-d00c5aa4b8bf.gif)

---

cc @awesomekling for the LibGUI changes, I'm sure there's _something_.

- [x] Figure out why that `!s_current_drag_operation` assertion sometimes trips 