### PR TITLE
ls: print inodes in short output format when -i arg is supplied

### DIFF
--- a/Userland/ls.cpp
+++ b/Userland/ls.cpp
@@ -376,6 +376,9 @@ static bool print_filesystem_object_short(const char* path, const char* name, si
         return false;
     }
 
+    if (flag_show_inode)
+        printf("%08u ", st.st_ino);
+
     *nprinted = print_name(st, name, nullptr, path);
     return true;
 }


### PR DESCRIPTION
Before:

![before](https://user-images.githubusercontent.com/434827/98495588-93320d80-2293-11eb-88f9-1b34fecb946a.png)

After:

![after](https://user-images.githubusercontent.com/434827/98495601-9e853900-2293-11eb-95ac-3e78361c9306.png)

This is consistent with GNU `ls`.

```
user@ubuntu:~/Desktop/serenity$ ls -i
670114 AK            688192 CMakeFiles          670238 Demos          931638 Kernel             670384 MenuApplets  658579 serenity.cflags        658578 serenity.cxxflags  794283 Shell
794018 Applications  670235 CMakeLists.txt      794065 DevTools       670269 Libraries          670407 Meta         658575 serenity.config        657506 serenity.files     794312 Toolchain
794021 Base          670236 CODE_OF_CONDUCT.md  794135 Documentation  670268 LICENSE            794183 Ports        658577 serenity.creator       658574 serenity.includes  794327 Userland
668311 Build         670237 CONTRIBUTING.md     794149 Games          688345 Melkor_ELF_Fuzzer  670454 ReadMe.md    658573 serenity.creator.user  670455 Services
```

```
user@ubuntu:~/Desktop/serenity$ ls -li
total 276
670114 drwxrwxr-x  3 user user  4096 Nov  8 15:03 AK
794018 drwxrwxr-x 25 user user  4096 Nov  2 10:44 Applications
794021 drwxrwxr-x  7 user user  4096 Nov  2 16:29 Base
668311 drwxrwxr-x 16 user user  4096 Nov  8 18:53 Build
688192 drwxrwxr-x 37 user user  4096 Nov  3 18:51 CMakeFiles
670235 -rw-rw-r--  1 user user 10960 Oct 25 01:17 CMakeLists.txt
670236 -rw-rw-r--  1 user user   136 Oct 25 01:17 CODE_OF_CONDUCT.md
670237 -rw-rw-r--  1 user user  4599 Oct 25 01:17 CONTRIBUTING.md
670238 drwxrwxr-x 12 user user  4096 Oct 25 01:17 Demos
794065 drwxrwxr-x  7 user user  4096 Oct 25 01:17 DevTools
794135 drwxrwxr-x  3 user user  4096 Nov  7 17:38 Documentation
794149 drwxrwxr-x  7 user user  4096 Oct 25 01:17 Games
931638 drwxrwxr-x 17 user user  4096 Nov  2 10:21 Kernel
670269 drwxrwxr-x 36 user user  4096 Oct 25 01:17 Libraries
670268 -rw-rw-r--  1 user user  1340 Oct 25 01:17 LICENSE
688345 drwxrwxr-x  6 user user  4096 Nov  7 03:30 Melkor_ELF_Fuzzer
670384 drwxrwxr-x  7 user user  4096 Oct 25 01:17 MenuApplets
670407 drwxrwxr-x  4 user user  4096 Nov  8 03:43 Meta
794183 drwxrwxr-x 66 user user  4096 Nov  7 07:02 Ports
670454 -rw-rw-r--  1 user user  4838 Nov  8 02:01 ReadMe.md
658579 -rw-rw-r--  1 user user     8 Oct 25 16:32 serenity.cflags
658575 -rw-rw-r--  1 user user   180 Oct 25 16:39 serenity.config
658577 -rw-rw-r--  1 user user    10 Oct 25 16:32 serenity.creator
658573 -rw-rw-r--  1 user user 13458 Nov  2 19:03 serenity.creator.user
658578 -rw-rw-r--  1 user user    27 Oct 25 16:40 serenity.cxxflags
657506 -rw-rw-r--  1 user user 87431 Nov  2 19:03 serenity.files
658574 -rw-rw-r--  1 user user 42964 Oct 25 16:41 serenity.includes
670455 drwxrwxr-x 18 user user  4096 Oct 25 01:17 Services
794283 drwxrwxr-x  3 user user  4096 Nov  1 11:01 Shell
794312 drwxrwxr-x  6 user user  4096 Nov  8 02:01 Toolchain
794327 drwxrwxr-x  3 user user  4096 Nov  8 18:53 Userland
user@ubuntu:~/Desktop/serenity$ 
```