### PR TITLE
AK: Rename new_out/new_warn to out/warn; Add formatter for floating point numbers.

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -157,7 +157,22 @@ public:
         char fill = ' ',
         SignMode sign_mode = SignMode::OnlyIfNeeded);
 
-    const StringBuilder& builder() const { return m_builder; }
+#ifndef KERNEL
+    void put_f64(
+        double value,
+        u8 base = 10,
+        bool upper_case = false,
+        Align align = Align::Right,
+        size_t min_width = 0,
+        size_t precision = 6,
+        char fill = ' ',
+        SignMode sign_mode = SignMode::OnlyIfNeeded);
+#endif
+
+    const StringBuilder& builder() const
+    {
+        return m_builder;
+    }
     StringBuilder& builder() { return m_builder; }
 
 private:
@@ -218,6 +233,9 @@ struct StandardFormatter {
         Character,
         String,
         Pointer,
+        Float,
+        Hexfloat,
+        HexfloatUppercase,
     };
 
     static constexpr size_t value_not_set = NumericLimits<size_t>::max();
@@ -302,6 +320,23 @@ template<>
 struct Formatter<bool> : StandardFormatter {
     void format(TypeErasedFormatParams&, FormatBuilder&, bool value);
 };
+
+#ifndef KERNEL
+template<>
+struct Formatter<float> : StandardFormatter {
+    void format(TypeErasedFormatParams&, FormatBuilder&, float value);
+};
+template<>
+struct Formatter<double> : StandardFormatter {
+    Formatter() { }
+    explicit Formatter(StandardFormatter formatter)
+        : StandardFormatter(formatter)
+    {
+    }
+
+    void format(TypeErasedFormatParams&, FormatBuilder&, double value);
+};
+#endif
 
 void vformat(StringBuilder& builder, StringView fmtstr, TypeErasedFormatParams);
 void vformat(const LogStream& stream, StringView fmtstr, TypeErasedFormatParams);

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -309,27 +309,24 @@ void vformat(const LogStream& stream, StringView fmtstr, TypeErasedFormatParams)
 #ifndef KERNEL
 void vout(FILE*, StringView fmtstr, TypeErasedFormatParams, bool newline = false);
 
-// FIXME: Rename 'new_out' to 'out' when the name becomes avaliable.
 template<typename... Parameters>
-void new_out(FILE* file, StringView fmtstr, const Parameters&... parameters) { vout(file, fmtstr, VariadicFormatParams { parameters... }); }
+void out(FILE* file, StringView fmtstr, const Parameters&... parameters) { vout(file, fmtstr, VariadicFormatParams { parameters... }); }
 template<typename... Parameters>
 void outln(FILE* file, StringView fmtstr, const Parameters&... parameters) { vout(file, fmtstr, VariadicFormatParams { parameters... }, true); }
 template<typename... Parameters>
 void outln(FILE* file, const char* fmtstr, const Parameters&... parameters) { vout(file, fmtstr, VariadicFormatParams { parameters... }, true); }
 inline void outln(FILE* file) { fputc('\n', file); }
 
-// FIXME: Rename 'new_out' to 'out' when the name becomes avaliable.
 template<typename... Parameters>
-void new_out(StringView fmtstr, const Parameters&... parameters) { new_out(stdout, fmtstr, parameters...); }
+void out(StringView fmtstr, const Parameters&... parameters) { out(stdout, fmtstr, parameters...); }
 template<typename... Parameters>
 void outln(StringView fmtstr, const Parameters&... parameters) { outln(stdout, fmtstr, parameters...); }
 template<typename... Parameters>
 void outln(const char* fmtstr, const Parameters&... parameters) { outln(stdout, fmtstr, parameters...); }
 inline void outln() { outln(stdout); }
 
-// FIXME: Rename 'new_warn' to 'warn' when the name becomes avaliable.
 template<typename... Parameters>
-void new_warn(StringView fmtstr, const Parameters&... parameters) { new_out(stderr, fmtstr, parameters...); }
+void warn(StringView fmtstr, const Parameters&... parameters) { out(stderr, fmtstr, parameters...); }
 template<typename... Parameters>
 void warnln(StringView fmtstr, const Parameters&... parameters) { outln(stderr, fmtstr, parameters...); }
 template<typename... Parameters>
@@ -385,10 +382,10 @@ struct Formatter<FormatIfSupported<T>> : __FormatIfSupported<T, HasFormatter<T>:
 } // namespace AK
 
 #ifndef KERNEL
-using AK::new_out;
+using AK::out;
 using AK::outln;
 
-using AK::new_warn;
+using AK::warn;
 using AK::warnln;
 #endif
 

--- a/AK/LogStream.cpp
+++ b/AK/LogStream.cpp
@@ -186,20 +186,6 @@ bool DebugLogStream::is_enabled()
 bool DebugLogStream::s_enabled = true;
 
 #ifndef KERNEL
-StdLogStream::~StdLogStream()
-{
-    char newline = '\n';
-    write(&newline, 1);
-}
-
-void StdLogStream::write(const char* characters, int length) const
-{
-    if (::write(m_fd, characters, length) < 0) {
-        perror("StdLogStream::write");
-        ASSERT_NOT_REACHED();
-    }
-}
-
 const LogStream& operator<<(const LogStream& stream, double value)
 {
     return stream << String::format("%.4f", value);
@@ -209,7 +195,6 @@ const LogStream& operator<<(const LogStream& stream, float value)
 {
     return stream << String::format("%.4f", value);
 }
-
 #endif
 
 void dump_bytes(ReadonlyBytes bytes)

--- a/AK/LogStream.h
+++ b/AK/LogStream.h
@@ -125,24 +125,6 @@ private:
     static bool s_enabled;
 };
 
-#if !defined(KERNEL)
-class StdLogStream final : public LogStream {
-public:
-    StdLogStream(int fd)
-        : m_fd(fd)
-    {
-    }
-    virtual ~StdLogStream() override;
-    virtual void write(const char* characters, int length) const override;
-
-private:
-    int m_fd { -1 };
-};
-
-[[deprecated("Use AK::outln or AK::new_out instead, AK::new_out will soon be renamed to AK::out.")]] inline StdLogStream out() { return StdLogStream(STDOUT_FILENO); }
-[[deprecated("Use AK::warnln or AK::new_warn instead, AK::new_warn will soon be renamed to AK::warn.")]] inline StdLogStream warn() { return StdLogStream(STDERR_FILENO); }
-#endif
-
 #ifdef KERNEL
 class KernelLogStream final : public BufferedLogStream {
 public:
@@ -212,8 +194,3 @@ void dump_bytes(ReadonlyBytes);
 using AK::dbg;
 using AK::klog;
 using AK::LogStream;
-
-#if !defined(KERNEL)
-using AK::out;
-using AK::warn;
-#endif

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -235,4 +235,27 @@ TEST_CASE(file_descriptor)
     fclose(file);
 }
 
+TEST_CASE(floating_point_numbers)
+{
+    EXPECT_EQ(String::formatted("{}", 1.12), "1.120000");
+    EXPECT_EQ(String::formatted("{}", 1.), "1.000000");
+    EXPECT_EQ(String::formatted("{:.3}", 1.12), "1.120");
+    EXPECT_EQ(String::formatted("{:.1}", 1.12), "1.1");
+    EXPECT_EQ(String::formatted("{}", -1.12), "-1.120000");
+
+    // FIXME: There is always the question what we mean with the width field. Do we mean significant digits?
+    //        Do we mean the whole width? This is what was the simplest to implement:
+    EXPECT_EQ(String::formatted("{:x>5.1}", 1.12), "xx1.1");
+}
+
+TEST_CASE(no_precision_no_trailing_number)
+{
+    EXPECT_EQ(String::formatted("{:.0}", 0.1), "0.");
+}
+
+TEST_CASE(yay_this_implementation_sucks)
+{
+    EXPECT_EQ(String::formatted("{:.0}", .99999999999), "0.");
+}
+
 TEST_MAIN(Format)

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -222,7 +222,7 @@ TEST_CASE(file_descriptor)
     FILE* file = fdopen(fd, "w+");
 
     outln(file, "{}", "Hello, World!");
-    new_out(file, "foo");
+    out(file, "foo");
     outln(file, "bar");
 
     rewind(file);

--- a/Applications/Debugger/main.cpp
+++ b/Applications/Debugger/main.cpp
@@ -150,14 +150,14 @@ static bool handle_breakpoint_command(const String& command)
 
 static void print_help()
 {
-    new_out("Options:\n"
-            "cont - Continue execution\n"
-            "si - step to the next instruction\n"
-            "sl - step to the next source line\n"
-            "line - show the position of the current instruction in the source code\n"
-            "regs - Print registers\n"
-            "dis [number of instructions] - Print disassembly\n"
-            "bp <address/symbol/file:line> - Insert a breakpoint\n");
+    out("Options:\n"
+        "cont - Continue execution\n"
+        "si - step to the next instruction\n"
+        "sl - step to the next source line\n"
+        "line - show the position of the current instruction in the source code\n"
+        "regs - Print registers\n"
+        "dis [number of instructions] - Print disassembly\n"
+        "bp <address/symbol/file:line> - Insert a breakpoint\n");
 }
 
 int main(int argc, char** argv)

--- a/Demos/DynamicLink/LinkDemo/main.cpp
+++ b/Demos/DynamicLink/LinkDemo/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv, char** envp)
             auto byte_ptr = (uint8_t*)auxvp->a_un.a_ptr;
             outln("    My Random bytes are: ");
             for (size_t i = 0; i < 16; ++i)
-                new_out("{:#02x} ", byte_ptr[i]);
+                out("{:#02x} ", byte_ptr[i]);
             outln();
         }
     }

--- a/DevTools/HackStudio/Project.cpp
+++ b/DevTools/HackStudio/Project.cpp
@@ -373,7 +373,7 @@ void Project::rebuild_tree()
 #if 0
     Function<void(ProjectTreeNode&, int indent)> dump_tree = [&](ProjectTreeNode& node, int indent) {
         for (int i = 0; i < indent; ++i)
-            new_out(" ");
+            out(" ");
         if (node.name.is_null())
             outln("(null)");
         else

--- a/Libraries/LibCore/ArgsParser.cpp
+++ b/Libraries/LibCore/ArgsParser.cpp
@@ -181,28 +181,28 @@ bool ArgsParser::parse(int argc, char** argv, bool exit_on_failure)
 
 void ArgsParser::print_usage(FILE* file, const char* argv0)
 {
-    new_out(file, "Usage:\n\t\033[1m{}\033[0m", argv0);
+    out(file, "Usage:\n\t\033[1m{}\033[0m", argv0);
 
     for (auto& opt : m_options) {
         if (opt.long_name && !strcmp(opt.long_name, "help"))
             continue;
         if (opt.requires_argument)
-            new_out(file, " [{} {}]", opt.name_for_display(), opt.value_name);
+            out(file, " [{} {}]", opt.name_for_display(), opt.value_name);
         else
-            new_out(file, " [{}]", opt.name_for_display());
+            out(file, " [{}]", opt.name_for_display());
     }
     for (auto& arg : m_positional_args) {
         bool required = arg.min_values > 0;
         bool repeated = arg.max_values > 1;
 
         if (required && repeated)
-            new_out(file, " <{}...>", arg.name);
+            out(file, " <{}...>", arg.name);
         else if (required && !repeated)
-            new_out(file, " <{}>", arg.name);
+            out(file, " <{}>", arg.name);
         else if (!required && repeated)
-            new_out(file, " [{}...]", arg.name);
+            out(file, " [{}...]", arg.name);
         else if (!required && !repeated)
-            new_out(file, " [{}]", arg.name);
+            out(file, " [{}]", arg.name);
     }
     outln(file);
 
@@ -212,25 +212,25 @@ void ArgsParser::print_usage(FILE* file, const char* argv0)
         auto print_argument = [&]() {
             if (opt.value_name) {
                 if (opt.requires_argument)
-                    new_out(file, " {}", opt.value_name);
+                    out(file, " {}", opt.value_name);
                 else
-                    new_out(file, " [{}]", opt.value_name);
+                    out(file, " [{}]", opt.value_name);
             }
         };
-        new_out(file, "\t");
+        out(file, "\t");
         if (opt.short_name) {
-            new_out(file, "\033[1m-{}\033[0m", opt.short_name);
+            out(file, "\033[1m-{}\033[0m", opt.short_name);
             print_argument();
         }
         if (opt.short_name && opt.long_name)
-            new_out(file, ", ");
+            out(file, ", ");
         if (opt.long_name) {
-            new_out(file, "\033[1m--{}\033[0m", opt.long_name);
+            out(file, "\033[1m--{}\033[0m", opt.long_name);
             print_argument();
         }
 
         if (opt.help_string)
-            new_out(file, "\t{}", opt.help_string);
+            out(file, "\t{}", opt.help_string);
         outln(file);
     }
 
@@ -238,9 +238,9 @@ void ArgsParser::print_usage(FILE* file, const char* argv0)
         outln(file, "\nArguments:");
 
     for (auto& arg : m_positional_args) {
-        new_out(file, "\t\033[1m{}\033[0m", arg.name);
+        out(file, "\t\033[1m{}\033[0m", arg.name);
         if (arg.help_string)
-            new_out(file, "\t{}", arg.help_string);
+            out(file, "\t{}", arg.help_string);
         outln(file);
     }
 }

--- a/Userland/expr.cpp
+++ b/Userland/expr.cpp
@@ -47,9 +47,9 @@ Print the value of EXPRESSION to standard output.)");
 template<typename... Args>
 [[noreturn]] void fail(Args&&... args)
 {
-    new_warn("ERROR: \e[31m");
+    warn("ERROR: \e[31m");
     warnln(args...);
-    new_warn("\e[0m");
+    warn("\e[0m");
     exit(1);
 }
 

--- a/Userland/functrace.cpp
+++ b/Userland/functrace.cpp
@@ -61,7 +61,7 @@ static void handle_sigint(int)
 static void print_function_call(String function_name, size_t depth)
 {
     for (size_t i = 0; i < depth; ++i) {
-        new_out("  ");
+        out("  ");
     }
     outln("=> {}", function_name);
 }

--- a/Userland/kill.cpp
+++ b/Userland/kill.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
         for (size_t i = 0; i < NSIG; ++i) {
             if (i && !(i % 5))
                 outln("");
-            new_out("{:2}) {:10}", i, getsignalname(i));
+            out("{:2}) {:10}", i, getsignalname(i));
         }
         outln("");
         return 0;

--- a/Userland/tree.cpp
+++ b/Userland/tree.cpp
@@ -51,11 +51,11 @@ static void print_directory_tree(const String& root_path, int depth, const Strin
         } else {
             root_indent_string = "";
         }
-        new_out("{}|-- ", root_indent_string);
+        out("{}|-- ", root_indent_string);
     }
 
     String root_dir_name = AK::LexicalPath(root_path).basename();
-    new_out("\033[34;1m{}\033[0m\n", root_dir_name);
+    out("\033[34;1m{}\033[0m\n", root_dir_name);
 
     if (depth >= max_depth) {
         return;


### PR DESCRIPTION
Floating point from/to string conversion is a very complex topic. I just added the most basic implementation I could think of which is slightly different from the stuff in `<AK/PrintfImplementation.h>`.
