### PR TITLE
TextEditor: Go-to-line now shows line in middle of view

### DIFF
--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -96,9 +96,25 @@ void TextEditor::create_actions()
             "Go to line...", { Mod_Ctrl, Key_L }, Gfx::Bitmap::load_from_file("/res/icons/16x16/go-forward.png"), [this](auto&) {
                 String value;
                 if (InputBox::show(value, window(), "Line:", "Go to line") == InputBox::ExecOK) {
-                    auto line_number = value.to_uint();
-                    if (line_number.has_value())
-                        set_cursor(line_number.value() - 1, 0);
+                    auto line_target = value.to_uint();
+                    if (line_target.has_value()) {
+                        u_int index_max = line_count() - 1;
+                        auto line_index = line_target.value() - 1;
+                        set_cursor(line_index, 0);
+
+                        if (line_index > 1 && line_index < index_max) {
+                            int headroom = frame_inner_rect().height() / 3;
+                            do {
+                                auto line_data = m_line_visual_data[line_index];
+                                headroom -= line_data.visual_rect.height();
+                                line_index--;
+                            } while (line_index > 0 && headroom > 0);
+
+                            Gfx::IntRect rect = { 0, line_content_rect(line_index).y(),
+                                1, frame_inner_rect().height() };
+                            scroll_into_view(rect, true, true);
+                        }
+                    }
                 }
             },
             this);

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -98,22 +98,7 @@ void TextEditor::create_actions()
                 if (InputBox::show(value, window(), "Line:", "Go to line") == InputBox::ExecOK) {
                     auto line_target = value.to_uint();
                     if (line_target.has_value()) {
-                        u_int index_max = line_count() - 1;
-                        auto line_index = line_target.value() - 1;
-                        set_cursor(line_index, 0);
-
-                        if (line_index > 1 && line_index < index_max) {
-                            int headroom = frame_inner_rect().height() / 3;
-                            do {
-                                auto line_data = m_line_visual_data[line_index];
-                                headroom -= line_data.visual_rect.height();
-                                line_index--;
-                            } while (line_index > 0 && headroom > 0);
-
-                            Gfx::IntRect rect = { 0, line_content_rect(line_index).y(),
-                                1, frame_inner_rect().height() };
-                            scroll_into_view(rect, true, true);
-                        }
+                        set_cursor_and_focus_line(line_target.value() - 1, 0);
                     }
                 }
             },
@@ -1170,6 +1155,24 @@ Gfx::IntRect TextEditor::line_content_rect(size_t line_index) const
         font().width(line.view()),
         line_height()
     };
+}
+
+void TextEditor::set_cursor_and_focus_line(size_t line, size_t column)
+{
+    u_int index_max = line_count() - 1;
+    set_cursor(line, column);
+    if (line > 1 && line < index_max) {
+        int headroom = frame_inner_rect().height() / 3;
+        do {
+            auto line_data = m_line_visual_data[line];
+            headroom -= line_data.visual_rect.height();
+            line--;
+        } while (line > 0 && headroom > 0);
+
+        Gfx::IntRect rect = { 0, line_content_rect(line).y(),
+            1, frame_inner_rect().height() };
+        scroll_into_view(rect, false, true);
+    }
 }
 
 void TextEditor::update_cursor()

--- a/Libraries/LibGUI/TextEditor.h
+++ b/Libraries/LibGUI/TextEditor.h
@@ -154,6 +154,7 @@ public:
 
     void add_custom_context_menu_action(Action&);
 
+    void set_cursor_and_focus_line(size_t line, size_t column);
     void set_cursor(size_t line, size_t column);
     void set_cursor(const TextPosition&);
 


### PR DESCRIPTION
As requested in Andreas' recent Breakout video, this PR makes Go-to-line jump more nicely such that the desired line is displayed 1/3rd of the way down the view rather than right at the extremes.