### PR TITLE
AK: Make RefPtr, NonnullRefPtr, WeakPtr thread safe

### DIFF
--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -113,6 +113,9 @@ template<typename T>
 class Optional;
 
 template<typename T>
+class RefPtrTraits;
+
+template<typename T, typename PtrTraits = RefPtrTraits<T>>
 class RefPtr;
 
 template<typename T>

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -35,7 +35,7 @@
 
 namespace AK {
 
-template<typename T>
+template<typename T, typename PtrTraits>
 class RefPtr;
 template<typename T>
 class NonnullRefPtr;
@@ -85,14 +85,14 @@ public:
     template<typename U>
     NonnullOwnPtr& operator=(const NonnullOwnPtr<U>&) = delete;
 
-    template<typename U>
-    NonnullOwnPtr(const RefPtr<U>&) = delete;
+    template<typename U, typename PtrTraits = RefPtrTraits<U>>
+    NonnullOwnPtr(const RefPtr<U, PtrTraits>&) = delete;
     template<typename U>
     NonnullOwnPtr(const NonnullRefPtr<U>&) = delete;
     template<typename U>
     NonnullOwnPtr(const WeakPtr<U>&) = delete;
-    template<typename U>
-    NonnullOwnPtr& operator=(const RefPtr<U>&) = delete;
+    template<typename U, typename PtrTraits = RefPtrTraits<U>>
+    NonnullOwnPtr& operator=(const RefPtr<U, PtrTraits>&) = delete;
     template<typename U>
     NonnullOwnPtr& operator=(const NonnullRefPtr<U>&) = delete;
     template<typename U>

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -35,7 +35,7 @@ namespace AK {
 
 template<typename T>
 class OwnPtr;
-template<typename T>
+template<typename T, typename PtrTraits>
 class RefPtr;
 
 template<typename T>

--- a/AK/RefCounted.h
+++ b/AK/RefCounted.h
@@ -69,26 +69,26 @@ public:
 
     ALWAYS_INLINE void ref() const
     {
-        auto old_ref_count = m_ref_count++;
+        auto old_ref_count = m_ref_count.fetch_add(1, AK::MemoryOrder::memory_order_relaxed);
         ASSERT(old_ref_count > 0);
         ASSERT(!Checked<RefCountType>::addition_would_overflow(old_ref_count, 1));
     }
 
     ALWAYS_INLINE RefCountType ref_count() const
     {
-        return m_ref_count;
+        return m_ref_count.load(AK::MemoryOrder::memory_order_relaxed);
     }
 
 protected:
     RefCountedBase() { }
     ALWAYS_INLINE ~RefCountedBase()
     {
-        ASSERT(m_ref_count == 0);
+        ASSERT(m_ref_count.load(AK::MemoryOrder::memory_order_relaxed) == 0);
     }
 
     ALWAYS_INLINE RefCountType deref_base() const
     {
-        auto old_ref_count = m_ref_count--;
+        auto old_ref_count = m_ref_count.fetch_sub(1, AK::MemoryOrder::memory_order_acq_rel);
         ASSERT(old_ref_count > 0);
         return old_ref_count - 1;
     }

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -299,6 +299,11 @@ struct Conditional<false, TrueType, FalseType> {
 };
 
 template<typename T>
+struct IsNullPointer : IsSame<decltype(nullptr), typename RemoveCV<T>::Type> {
+};
+
+
+template<typename T>
 struct RemoveReference {
     typedef T Type;
 };

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -146,6 +146,8 @@ struct IntegralConstant {
 
 typedef IntegralConstant<bool, false> FalseType;
 typedef IntegralConstant<bool, true> TrueType;
+template<typename...>
+using VoidType = void;
 
 template<class T>
 struct IsLvalueReference : FalseType {
@@ -301,7 +303,6 @@ struct Conditional<false, TrueType, FalseType> {
 template<typename T>
 struct IsNullPointer : IsSame<decltype(nullptr), typename RemoveCV<T>::Type> {
 };
-
 
 template<typename T>
 struct RemoveReference {

--- a/AK/Tests/TestWeakPtr.cpp
+++ b/AK/Tests/TestWeakPtr.cpp
@@ -35,7 +35,8 @@
 #    pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
 
-class SimpleWeakable : public Weakable<SimpleWeakable> {
+class SimpleWeakable : public Weakable<SimpleWeakable>
+    , public RefCounted<SimpleWeakable> {
 public:
     SimpleWeakable() { }
 
@@ -53,18 +54,18 @@ TEST_CASE(basic_weak)
     WeakPtr<SimpleWeakable> weak2;
 
     {
-        SimpleWeakable simple;
-        weak1 = simple.make_weak_ptr();
-        weak2 = simple.make_weak_ptr();
+        auto simple = adopt(*new SimpleWeakable);
+        weak1 = simple;
+        weak2 = simple;
         EXPECT_EQ(weak1.is_null(), false);
         EXPECT_EQ(weak2.is_null(), false);
-        EXPECT_EQ(weak1.ptr(), &simple);
-        EXPECT_EQ(weak1.ptr(), weak2.ptr());
+        EXPECT_EQ(weak1.strong_ref().ptr(), simple.ptr());
+        EXPECT_EQ(weak1.strong_ref().ptr(), weak2.strong_ref().ptr());
     }
 
     EXPECT_EQ(weak1.is_null(), true);
-    EXPECT_EQ(weak1.ptr(), nullptr);
-    EXPECT_EQ(weak1.ptr(), weak2.ptr());
+    EXPECT_EQ(weak1.strong_ref().ptr(), nullptr);
+    EXPECT_EQ(weak1.strong_ref().ptr(), weak2.strong_ref().ptr());
 }
 
 TEST_CASE(weakptr_move)
@@ -73,12 +74,12 @@ TEST_CASE(weakptr_move)
     WeakPtr<SimpleWeakable> weak2;
 
     {
-        SimpleWeakable simple;
-        weak1 = simple.make_weak_ptr();
+        auto simple = adopt(*new SimpleWeakable);
+        weak1 = simple;
         weak2 = move(weak1);
         EXPECT_EQ(weak1.is_null(), true);
         EXPECT_EQ(weak2.is_null(), false);
-        EXPECT_EQ(weak2.ptr(), &simple);
+        EXPECT_EQ(weak2.strong_ref().ptr(), simple.ptr());
     }
 
     EXPECT_EQ(weak2.is_null(), true);

--- a/Applications/PixelPaint/Tool.cpp
+++ b/Applications/PixelPaint/Tool.cpp
@@ -40,7 +40,7 @@ Tool::~Tool()
 
 void Tool::setup(ImageEditor& editor)
 {
-    m_editor = editor.make_weak_ptr();
+    m_editor = editor;
 }
 
 void Tool::set_action(GUI::Action* action)

--- a/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Applications/Spreadsheet/Spreadsheet.cpp
@@ -345,12 +345,12 @@ RefPtr<Sheet> Sheet::from_json(const JsonObject& object, Workbook& workbook)
         OwnPtr<Cell> cell;
         switch (kind) {
         case Cell::LiteralString:
-            cell = make<Cell>(obj.get("value").to_string(), position, sheet->make_weak_ptr());
+            cell = make<Cell>(obj.get("value").to_string(), position, *sheet);
             break;
         case Cell::Formula: {
             auto& interpreter = sheet->interpreter();
             auto value = interpreter.vm().call(parse_function, json, JS::js_string(interpreter.heap(), obj.get("value").as_string()));
-            cell = make<Cell>(obj.get("source").to_string(), move(value), position, sheet->make_weak_ptr());
+            cell = make<Cell>(obj.get("source").to_string(), move(value), position, *sheet);
             break;
         }
         }

--- a/Applications/Spreadsheet/Spreadsheet.h
+++ b/Applications/Spreadsheet/Spreadsheet.h
@@ -82,7 +82,7 @@ public:
         if (auto cell = at(position))
             return *cell;
 
-        m_cells.set(position, make<Cell>(String::empty(), position, make_weak_ptr()));
+        m_cells.set(position, make<Cell>(String::empty(), position, *this));
         return *at(position);
     }
 

--- a/DevTools/HackStudio/Editor.cpp
+++ b/DevTools/HackStudio/Editor.cpp
@@ -61,7 +61,7 @@ Editor::Editor()
     m_documentation_tooltip_window->set_window_type(GUI::WindowType::Tooltip);
     m_documentation_page_view = m_documentation_tooltip_window->set_main_widget<Web::OutOfProcessWebView>();
 
-    m_autocomplete_box = make<AutoCompleteBox>(make_weak_ptr());
+    m_autocomplete_box = make<AutoCompleteBox>(*this);
 }
 
 Editor::~Editor()

--- a/Kernel/FileSystem/DevPtsFS.cpp
+++ b/Kernel/FileSystem/DevPtsFS.cpp
@@ -113,7 +113,7 @@ DevPtsFSInode::DevPtsFSInode(DevPtsFS& fs, unsigned index, SlavePTY* pty)
     : Inode(fs, index)
 {
     if (pty)
-        m_pty = pty->make_weak_ptr();
+        m_pty = *pty;
 }
 
 DevPtsFSInode::~DevPtsFSInode()
@@ -132,9 +132,9 @@ ssize_t DevPtsFSInode::write_bytes(off_t, ssize_t, const UserOrKernelBuffer&, Fi
 
 InodeMetadata DevPtsFSInode::metadata() const
 {
-    if (m_pty) {
+    if (auto pty = m_pty.strong_ref()) {
         auto metadata = m_metadata;
-        metadata.mtime = m_pty->time_of_last_write();
+        metadata.mtime = pty->time_of_last_write();
         return metadata;
     }
     return m_metadata;

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -129,14 +129,14 @@ void Inode::will_be_destroyed()
 
 void Inode::inode_contents_changed(off_t offset, ssize_t size, const UserOrKernelBuffer& data)
 {
-    if (m_shared_vmobject)
-        m_shared_vmobject->inode_contents_changed({}, offset, size, data);
+    if (auto shared_vmobject = this->shared_vmobject())
+        shared_vmobject->inode_contents_changed({}, offset, size, data);
 }
 
 void Inode::inode_size_changed(size_t old_size, size_t new_size)
 {
-    if (m_shared_vmobject)
-        m_shared_vmobject->inode_size_changed({}, old_size, new_size);
+    if (auto shared_vmobject = this->shared_vmobject())
+        shared_vmobject->inode_size_changed({}, old_size, new_size);
 }
 
 int Inode::set_atime(time_t)
@@ -166,7 +166,7 @@ KResult Inode::decrement_link_count()
 
 void Inode::set_shared_vmobject(SharedInodeVMObject& vmobject)
 {
-    m_shared_vmobject = vmobject.make_weak_ptr();
+    m_shared_vmobject = vmobject;
 }
 
 bool Inode::bind_socket(LocalSocket& socket)
@@ -258,6 +258,21 @@ KResult Inode::prepare_to_write_data()
         return chmod(metadata.mode & ~(04000 | 02000));
     }
     return KSuccess;
+}
+
+RefPtr<SharedInodeVMObject> Inode::shared_vmobject()
+{
+    return m_shared_vmobject.strong_ref();
+}
+
+RefPtr<SharedInodeVMObject> Inode::shared_vmobject() const
+{
+    return m_shared_vmobject.strong_ref();
+}
+
+bool Inode::is_shared_vmobject(const SharedInodeVMObject& other) const
+{
+    return m_shared_vmobject.unsafe_ptr() == &other;
 }
 
 }

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -102,8 +102,9 @@ public:
     void will_be_destroyed();
 
     void set_shared_vmobject(SharedInodeVMObject&);
-    SharedInodeVMObject* shared_vmobject() { return m_shared_vmobject.ptr(); }
-    const SharedInodeVMObject* shared_vmobject() const { return m_shared_vmobject.ptr(); }
+    RefPtr<SharedInodeVMObject> shared_vmobject();
+    RefPtr<SharedInodeVMObject> shared_vmobject() const;
+    bool is_shared_vmobject(const SharedInodeVMObject&) const;
 
     static InlineLinkedList<Inode>& all_with_lock();
     static void sync();

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -130,7 +130,7 @@ RefPtr<TCPSocket> TCPSocket::create_client(const IPv4Address& new_local_address,
 void TCPSocket::release_to_originator()
 {
     ASSERT(!!m_originator);
-    m_originator->release_for_accept(this);
+    m_originator.strong_ref()->release_for_accept(this);
 }
 
 void TCPSocket::release_for_accept(RefPtr<TCPSocket> socket)

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -159,7 +159,7 @@ public:
     static Lockable<HashMap<IPv4SocketTuple, RefPtr<TCPSocket>>>& closing_sockets();
 
     RefPtr<TCPSocket> create_client(const IPv4Address& local_address, u16 local_port, const IPv4Address& peer_address, u16 peer_port);
-    void set_originator(TCPSocket& originator) { m_originator = originator.make_weak_ptr(); }
+    void set_originator(TCPSocket& originator) { m_originator = originator; }
     bool has_originator() { return !!m_originator; }
     void release_to_originator();
     void release_for_accept(RefPtr<TCPSocket>);

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -194,7 +194,7 @@ bool Process::deallocate_region(Region& region)
     OwnPtr<Region> region_protector;
     ScopedSpinLock lock(m_lock);
 
-    if (m_region_lookup_cache.region == &region)
+    if (m_region_lookup_cache.region.unsafe_ptr() == &region)
         m_region_lookup_cache.region = nullptr;
     for (size_t i = 0; i < m_regions.size(); ++i) {
         if (&m_regions[i] == &region) {
@@ -209,13 +209,13 @@ Region* Process::find_region_from_range(const Range& range)
 {
     ScopedSpinLock lock(m_lock);
     if (m_region_lookup_cache.range == range && m_region_lookup_cache.region)
-        return m_region_lookup_cache.region;
+        return m_region_lookup_cache.region.unsafe_ptr();
 
     size_t size = PAGE_ROUND_UP(range.size());
     for (auto& region : m_regions) {
         if (region.vaddr() == range.base() && region.size() == size) {
             m_region_lookup_cache.range = range;
-            m_region_lookup_cache.region = region.make_weak_ptr();
+            m_region_lookup_cache.region = region;
             return &region;
         }
     }

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -88,8 +88,8 @@ pid_t Process::sys$fork(RegisterState& regs)
             auto& child_region = child->add_region(region.clone());
             child_region.map(child->page_directory());
 
-            if (&region == m_master_tls_region)
-                child->m_master_tls_region = child_region.make_weak_ptr();
+            if (&region == m_master_tls_region.unsafe_ptr())
+                child->m_master_tls_region = child_region;
         }
 
         ScopedSpinLock processes_lock(g_processes_lock);

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -51,7 +51,12 @@ public:
     unsigned short rows() const { return m_rows; }
     unsigned short columns() const { return m_columns; }
 
-    ProcessGroupID pgid() const { return m_pg ? m_pg->pgid() : 0; }
+    ProcessGroupID pgid() const
+    {
+        if (auto pg = m_pg.strong_ref())
+            return pg->pgid();
+        return 0;
+    }
 
     void set_termios(const termios&);
     bool should_generate_signals() const { return m_termios.c_lflag & ISIG; }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -978,7 +978,7 @@ KResult Thread::make_thread_specific_region(Badge<Process>)
     m_thread_specific_data = VirtualAddress(thread_specific_data);
     thread_specific_data->self = thread_specific_data;
     if (process().m_master_tls_size)
-        memcpy(thread_local_storage, process().m_master_tls_region->vaddr().as_ptr(), process().m_master_tls_size);
+        memcpy(thread_local_storage, process().m_master_tls_region.unsafe_ptr()->vaddr().as_ptr(), process().m_master_tls_size);
     return KSuccess;
 }
 

--- a/Kernel/VM/SharedInodeVMObject.cpp
+++ b/Kernel/VM/SharedInodeVMObject.cpp
@@ -58,7 +58,7 @@ SharedInodeVMObject::SharedInodeVMObject(const SharedInodeVMObject& other)
 
 SharedInodeVMObject::~SharedInodeVMObject()
 {
-    ASSERT(inode().shared_vmobject() == this);
+    ASSERT(inode().is_shared_vmobject(*this));
 }
 
 }

--- a/Libraries/LibCore/Event.cpp
+++ b/Libraries/LibCore/Event.cpp
@@ -40,4 +40,32 @@ ChildEvent::~ChildEvent()
 {
 }
 
+Object* ChildEvent::child()
+{
+    if (auto ref = m_child.strong_ref())
+        return ref.ptr();
+    return nullptr;
+}
+
+const Object* ChildEvent::child() const
+{
+    if (auto ref = m_child.strong_ref())
+        return ref.ptr();
+    return nullptr;
+}
+
+Object* ChildEvent::insertion_before_child()
+{
+    if (auto ref = m_insertion_before_child.strong_ref())
+        return ref.ptr();
+    return nullptr;
+}
+
+const Object* ChildEvent::insertion_before_child() const
+{
+    if (auto ref = m_insertion_before_child.strong_ref())
+        return ref.ptr();
+    return nullptr;
+}
+
 }

--- a/Libraries/LibCore/Event.h
+++ b/Libraries/LibCore/Event.h
@@ -130,11 +130,11 @@ public:
     ChildEvent(Type, Object& child, Object* insertion_before_child = nullptr);
     ~ChildEvent();
 
-    Object* child() { return m_child.ptr(); }
-    const Object* child() const { return m_child.ptr(); }
+    Object* child();
+    const Object* child() const;
 
-    Object* insertion_before_child() { return m_insertion_before_child.ptr(); }
-    const Object* insertion_before_child() const { return m_insertion_before_child.ptr(); }
+    Object* insertion_before_child();
+    const Object* insertion_before_child() const;
 
 private:
     WeakPtr<Object> m_child;

--- a/Libraries/LibGUI/Application.cpp
+++ b/Libraries/LibGUI/Application.cpp
@@ -50,7 +50,7 @@ Application* Application::the()
 Application::Application(int argc, char** argv)
 {
     ASSERT(!*s_the);
-    *s_the = make_weak_ptr();
+    *s_the = *this;
     m_event_loop = make<Core::EventLoop>();
     WindowServerConnection::the();
     Clipboard::initialize({});

--- a/Libraries/LibGUI/Button.cpp
+++ b/Libraries/LibGUI/Button.cpp
@@ -129,7 +129,7 @@ void Button::context_menu_event(ContextMenuEvent& context_menu_event)
 
 void Button::set_action(Action& action)
 {
-    m_action = action.make_weak_ptr();
+    m_action = action;
     action.register_button({}, *this);
     set_enabled(action.is_enabled());
     set_checkable(action.is_checkable());

--- a/Libraries/LibGUI/Layout.cpp
+++ b/Libraries/LibGUI/Layout.cpp
@@ -82,7 +82,7 @@ void Layout::notify_adopted(Badge<Widget>, Widget& widget)
 {
     if (m_owner == &widget)
         return;
-    m_owner = widget.make_weak_ptr();
+    m_owner = widget;
 }
 
 void Layout::notify_disowned(Badge<Widget>, Widget& widget)
@@ -117,7 +117,7 @@ void Layout::add_widget(Widget& widget)
 {
     Entry entry;
     entry.type = Entry::Type::Widget;
-    entry.widget = widget.make_weak_ptr();
+    entry.widget = widget;
     add_entry(move(entry));
 }
 
@@ -125,7 +125,7 @@ void Layout::insert_widget_before(Widget& widget, Widget& before_widget)
 {
     Entry entry;
     entry.type = Entry::Type::Widget;
-    entry.widget = widget.make_weak_ptr();
+    entry.widget = widget;
     m_entries.insert_before_matching(move(entry), [&](auto& existing_entry) {
         return existing_entry.type == Entry::Type::Widget && existing_entry.widget.ptr() == &before_widget;
     });

--- a/Libraries/LibGUI/Menu.cpp
+++ b/Libraries/LibGUI/Menu.cpp
@@ -162,7 +162,7 @@ int Menu::realize_menu(RefPtr<Action> default_action)
         }
     }
     all_menus().set(m_menu_id, this);
-    m_last_default_action = default_action ? default_action->make_weak_ptr() : nullptr;
+    m_last_default_action = default_action;
     return m_menu_id;
 }
 

--- a/Libraries/LibGUI/Splitter.cpp
+++ b/Libraries/LibGUI/Splitter.cpp
@@ -124,8 +124,8 @@ void Splitter::mousedown_event(MouseEvent& event)
     if (!get_resize_candidates_at(event.position(), first, second))
         return;
 
-    m_first_resizee = first->make_weak_ptr();
-    m_second_resizee = second->make_weak_ptr();
+    m_first_resizee = *first;
+    m_second_resizee = *second;
     m_first_resizee_start_size = first->size();
     m_second_resizee_start_size = second->size();
     m_resize_origin = event.position();

--- a/Libraries/LibGUI/SyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/SyntaxHighlighter.cpp
@@ -128,7 +128,7 @@ void SyntaxHighlighter::highlight_matching_token_pair()
 void SyntaxHighlighter::attach(TextEditor& editor)
 {
     ASSERT(!m_editor);
-    m_editor = editor.make_weak_ptr();
+    m_editor = editor;
 }
 
 void SyntaxHighlighter::detach()

--- a/Libraries/LibGUI/Widget.cpp
+++ b/Libraries/LibGUI/Widget.cpp
@@ -533,10 +533,7 @@ void Widget::set_focus_proxy(Widget* proxy)
     if (m_focus_proxy == proxy)
         return;
 
-    if (proxy)
-        m_focus_proxy = proxy->make_weak_ptr();
-    else
-        m_focus_proxy = nullptr;
+    m_focus_proxy = proxy;
 }
 
 FocusPolicy Widget::focus_policy() const

--- a/Libraries/LibGUI/Window.cpp
+++ b/Libraries/LibGUI/Window.cpp
@@ -297,7 +297,7 @@ void Window::handle_mouse_event(MouseEvent& event)
     ASSERT(result.widget);
     set_hovered_widget(result.widget);
     if (event.buttons() != 0 && !m_automatic_cursor_tracking_widget)
-        m_automatic_cursor_tracking_widget = result.widget->make_weak_ptr();
+        m_automatic_cursor_tracking_widget = *result.widget;
     if (result.widget != m_global_cursor_tracking_widget.ptr())
         return result.widget->dispatch_event(*local_event, this);
     return;
@@ -562,7 +562,7 @@ void Window::set_focused_widget(Widget* widget, FocusSource source)
         Core::EventLoop::current().post_event(*m_focused_widget, make<FocusEvent>(Event::FocusOut, source));
         m_focused_widget->update();
     }
-    m_focused_widget = widget ? widget->make_weak_ptr() : nullptr;
+    m_focused_widget = widget;
     if (m_focused_widget) {
         Core::EventLoop::current().post_event(*m_focused_widget, make<FocusEvent>(Event::FocusIn, source));
         m_focused_widget->update();
@@ -573,14 +573,14 @@ void Window::set_global_cursor_tracking_widget(Widget* widget)
 {
     if (widget == m_global_cursor_tracking_widget)
         return;
-    m_global_cursor_tracking_widget = widget ? widget->make_weak_ptr() : nullptr;
+    m_global_cursor_tracking_widget = widget;
 }
 
 void Window::set_automatic_cursor_tracking_widget(Widget* widget)
 {
     if (widget == m_automatic_cursor_tracking_widget)
         return;
-    m_automatic_cursor_tracking_widget = widget ? widget->make_weak_ptr() : nullptr;
+    m_automatic_cursor_tracking_widget = widget;
 }
 
 void Window::set_has_alpha_channel(bool value)
@@ -621,7 +621,7 @@ void Window::set_hovered_widget(Widget* widget)
     if (m_hovered_widget)
         Core::EventLoop::current().post_event(*m_hovered_widget, make<Event>(Event::Leave));
 
-    m_hovered_widget = widget ? widget->make_weak_ptr() : nullptr;
+    m_hovered_widget = widget;
 
     if (m_hovered_widget)
         Core::EventLoop::current().post_event(*m_hovered_widget, make<Event>(Event::Enter));

--- a/Libraries/LibProtocol/Download.cpp
+++ b/Libraries/LibProtocol/Download.cpp
@@ -31,7 +31,7 @@
 namespace Protocol {
 
 Download::Download(Client& client, i32 download_id)
-    : m_client(client.make_weak_ptr())
+    : m_client(client)
     , m_download_id(download_id)
 {
 }

--- a/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -290,7 +290,7 @@ Color IdentifierStyleValue::to_color(const DOM::Document& document) const
 ImageStyleValue::ImageStyleValue(const URL& url, DOM::Document& document)
     : StyleValue(Type::Image)
     , m_url(url)
-    , m_document(document.make_weak_ptr())
+    , m_document(document)
 {
     LoadRequest request;
     request.set_url(url);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -234,7 +234,7 @@ String Document::title() const
 
 void Document::attach_to_frame(Badge<Frame>, Frame& frame)
 {
-    m_frame = frame.make_weak_ptr();
+    m_frame = frame;
     for_each_in_subtree([&](auto& node) {
         node.document_did_attach_to_frame(frame);
         return IterationDecision::Continue;
@@ -584,10 +584,7 @@ void Document::set_focused_element(Element* element)
     if (m_focused_element == element)
         return;
 
-    if (element)
-        m_focused_element = element->make_weak_ptr();
-    else
-        m_focused_element = nullptr;
+    m_focused_element = element;
 
     if (m_layout_root)
         m_layout_root->set_needs_display();

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -35,7 +35,7 @@
 namespace Web::HTML {
 
 CanvasRenderingContext2D::CanvasRenderingContext2D(HTMLCanvasElement& element)
-    : m_element(element.make_weak_ptr())
+    : m_element(element)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -45,7 +45,7 @@ HTMLScriptElement::~HTMLScriptElement()
 
 void HTMLScriptElement::set_parser_document(Badge<HTMLDocumentParser>, DOM::Document& document)
 {
-    m_parser_document = document.make_weak_ptr();
+    m_parser_document = document;
 }
 
 void HTMLScriptElement::set_non_blocking(Badge<HTMLDocumentParser>, bool non_blocking)
@@ -82,12 +82,12 @@ void HTMLScriptElement::prepare_script(Badge<HTMLDocumentParser>)
     // FIXME: Check the "type" and "language" attributes
 
     if (parser_document) {
-        m_parser_document = parser_document->make_weak_ptr();
+        m_parser_document = *parser_document;
         m_non_blocking = false;
     }
 
     m_already_started = true;
-    m_preparation_time_document = document().make_weak_ptr();
+    m_preparation_time_document = document();
 
     if (parser_document && parser_document.ptr() != m_preparation_time_document.ptr()) {
         return;

--- a/Libraries/LibWeb/Page/Frame.cpp
+++ b/Libraries/LibWeb/Page/Frame.cpp
@@ -40,7 +40,7 @@ Frame::Frame(DOM::Element& host_element, Frame& main_frame)
     , m_main_frame(main_frame)
     , m_loader(*this)
     , m_event_handler({}, *this)
-    , m_host_element(host_element.make_weak_ptr())
+    , m_host_element(host_element)
 {
     setup();
 }

--- a/Services/AudioServer/Mixer.cpp
+++ b/Services/AudioServer/Mixer.cpp
@@ -148,7 +148,7 @@ void Mixer::set_muted(bool muted)
 }
 
 BufferQueue::BufferQueue(ClientConnection& client)
-    : m_client(client.make_weak_ptr())
+    : m_client(client)
 {
 }
 

--- a/Services/WindowServer/AppletManager.cpp
+++ b/Services/WindowServer/AppletManager.cpp
@@ -69,7 +69,7 @@ void AppletManager::event(Core::Event& event)
 
 void AppletManager::add_applet(Window& applet)
 {
-    m_applets.append(applet.make_weak_ptr());
+    m_applets.append(applet);
 
     // Prune any dead weak pointers from the applet list.
     m_applets.remove_all_matching([](auto& entry) {

--- a/Services/WindowServer/Menu.h
+++ b/Services/WindowServer/Menu.h
@@ -83,7 +83,7 @@ public:
     Window& ensure_menu_window();
 
     Window* window_menu_of() { return m_window_menu_of; }
-    void set_window_menu_of(Window& window) { m_window_menu_of = window.make_weak_ptr(); }
+    void set_window_menu_of(Window& window) { m_window_menu_of = window; }
     bool is_window_menu_open() { return m_is_window_menu_open; }
     void set_window_menu_open(bool is_open) { m_is_window_menu_open = is_open; }
 

--- a/Services/WindowServer/MenuManager.cpp
+++ b/Services/WindowServer/MenuManager.cpp
@@ -392,7 +392,7 @@ void MenuManager::open_menu(Menu& menu, bool as_current_menu)
     }
 
     if (m_open_menu_stack.find([&menu](auto& other) { return &menu == other.ptr(); }).is_end())
-        m_open_menu_stack.append(menu.make_weak_ptr());
+        m_open_menu_stack.append(menu);
 
     if (as_current_menu || !current_menu()) {
         // Only make this menu the current menu if requested, or if no
@@ -429,13 +429,13 @@ void MenuManager::set_current_menu(Menu* menu)
     m_current_search.clear();
 
     Menu* previous_current_menu = m_current_menu;
-    m_current_menu = menu->make_weak_ptr();
+    m_current_menu = menu;
 
     auto& wm = WindowManager::the();
     if (!previous_current_menu) {
         // When opening the first menu, store the current active input window
         if (auto* active_input = wm.active_input_window())
-            m_previous_input_window = active_input->make_weak_ptr();
+            m_previous_input_window = *active_input;
         else
             m_previous_input_window = nullptr;
     }
@@ -457,7 +457,7 @@ Gfx::IntRect MenuManager::menubar_rect() const
 void MenuManager::set_current_menubar(MenuBar* menubar)
 {
     if (menubar)
-        m_current_menubar = menubar->make_weak_ptr();
+        m_current_menubar = *menubar;
     else
         m_current_menubar = nullptr;
 #ifdef DEBUG_MENUS
@@ -485,7 +485,7 @@ void MenuManager::close_menubar(MenuBar& menubar)
 
 void MenuManager::set_system_menu(Menu& menu)
 {
-    m_system_menu = menu.make_weak_ptr();
+    m_system_menu = menu;
     set_current_menubar(m_current_menubar);
 }
 

--- a/Services/WindowServer/Window.cpp
+++ b/Services/WindowServer/Window.cpp
@@ -659,18 +659,18 @@ void Window::recalculate_rect()
 
 void Window::add_child_window(Window& child_window)
 {
-    m_child_windows.append(child_window.make_weak_ptr());
+    m_child_windows.append(child_window);
 }
 
 void Window::add_accessory_window(Window& accessory_window)
 {
-    m_accessory_windows.append(accessory_window.make_weak_ptr());
+    m_accessory_windows.append(accessory_window);
 }
 
 void Window::set_parent_window(Window& parent_window)
 {
     ASSERT(!m_parent_window);
-    m_parent_window = parent_window.make_weak_ptr();
+    m_parent_window = parent_window;
     if (m_accessory)
         parent_window.add_accessory_window(*this);
     else

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -444,7 +444,7 @@ void WindowManager::start_window_move(Window& window, const MouseEvent& event)
     dbg() << "[WM] Begin moving Window{" << &window << "}";
 #endif
     move_to_front_and_make_active(window);
-    m_move_window = window.make_weak_ptr();
+    m_move_window = window;
     m_move_window->set_default_positioned(false);
     m_move_origin = event.position();
     m_move_window_origin = window.position();
@@ -478,7 +478,7 @@ void WindowManager::start_window_resize(Window& window, const Gfx::IntPoint& pos
     dbg() << "[WM] Begin resizing Window{" << &window << "}";
 #endif
     m_resizing_mouse_button = button;
-    m_resize_window = window.make_weak_ptr();
+    m_resize_window = window;
     m_resize_origin = position;
     m_resize_window_original_rect = window.rect();
 
@@ -739,7 +739,7 @@ bool WindowManager::process_ongoing_drag(MouseEvent& event, Window*& hovered_win
 
 void WindowManager::set_cursor_tracking_button(Button* button)
 {
-    m_cursor_tracking_button = button ? button->make_weak_ptr() : nullptr;
+    m_cursor_tracking_button = button;
 }
 
 auto WindowManager::DoubleClickInfo::metadata_for_button(MouseButton button) const -> const ClickMetadata&
@@ -811,7 +811,7 @@ void WindowManager::start_menu_doubleclick(Window& window, const MouseEvent& eve
 #if defined(DOUBLECLICK_DEBUG)
         dbg() << "Initial mousedown on window " << &window << " for menu (previous was " << m_double_click_info.m_clicked_window << ')';
 #endif
-        m_double_click_info.m_clicked_window = window.make_weak_ptr();
+        m_double_click_info.m_clicked_window = window;
         m_double_click_info.reset();
     }
 
@@ -844,7 +844,7 @@ void WindowManager::process_event_for_doubleclick(Window& window, MouseEvent& ev
 #if defined(DOUBLECLICK_DEBUG)
         dbg() << "Initial mouseup on window " << &window << " (previous was " << m_double_click_info.m_clicked_window << ')';
 #endif
-        m_double_click_info.m_clicked_window = window.make_weak_ptr();
+        m_double_click_info.m_clicked_window = window;
         m_double_click_info.reset();
     }
 
@@ -994,7 +994,7 @@ void WindowManager::process_mouse_event(MouseEvent& event, Window*& hovered_wind
                     auto translated_event = event.translated(-window.position());
                     deliver_mouse_event(window, translated_event);
                     if (event.type() == Event::MouseDown) {
-                        m_active_input_tracking_window = window.make_weak_ptr();
+                        m_active_input_tracking_window = window;
                     }
                 }
                 return;
@@ -1135,7 +1135,7 @@ void WindowManager::set_highlight_window(Window* window)
         return;
     if (auto* previous_highlight_window = m_highlight_window.ptr())
         previous_highlight_window->invalidate();
-    m_highlight_window = window ? window->make_weak_ptr() : nullptr;
+    m_highlight_window = window;
     if (m_highlight_window)
         m_highlight_window->invalidate();
 }
@@ -1179,7 +1179,7 @@ Window* WindowManager::set_active_input_window(Window* window)
         Core::EventLoop::current().post_event(*previous_input_window, make<Event>(Event::WindowInputLeft));
 
     if (window) {
-        m_active_input_window = window->make_weak_ptr();
+        m_active_input_window = *window;
         Core::EventLoop::current().post_event(*window, make<Event>(Event::WindowInputEntered));
     } else {
         m_active_input_window = nullptr;
@@ -1230,7 +1230,7 @@ void WindowManager::set_active_window(Window* window, bool make_input)
     }
 
     if (window) {
-        m_active_window = window->make_weak_ptr();
+        m_active_window = *window;
         active_client = m_active_window->client();
         Core::EventLoop::current().post_event(*m_active_window, make<Event>(Event::WindowActivated));
         m_active_window->invalidate();
@@ -1260,7 +1260,7 @@ void WindowManager::set_hovered_window(Window* window)
     if (m_hovered_window)
         Core::EventLoop::current().post_event(*m_hovered_window, make<Event>(Event::WindowLeft));
 
-    m_hovered_window = window ? window->make_weak_ptr() : nullptr;
+    m_hovered_window = window;
 
     if (m_hovered_window)
         Core::EventLoop::current().post_event(*m_hovered_window, make<Event>(Event::WindowEntered));
@@ -1314,12 +1314,12 @@ const Cursor& WindowManager::active_cursor() const
 
 void WindowManager::set_hovered_button(Button* button)
 {
-    m_hovered_button = button ? button->make_weak_ptr() : nullptr;
+    m_hovered_button = button;
 }
 
 void WindowManager::set_resize_candidate(Window& window, ResizeDirection direction)
 {
-    m_resize_candidate = window.make_weak_ptr();
+    m_resize_candidate = window;
     m_resize_direction = direction;
 }
 
@@ -1358,7 +1358,7 @@ Gfx::IntRect WindowManager::maximized_window_rect(const Window& window) const
 void WindowManager::start_dnd_drag(ClientConnection& client, const String& text, Gfx::Bitmap* bitmap, const Core::MimeData& mime_data)
 {
     ASSERT(!m_dnd_client);
-    m_dnd_client = client.make_weak_ptr();
+    m_dnd_client = client;
     m_dnd_text = text;
     m_dnd_bitmap = bitmap;
     m_dnd_mime_data = mime_data;

--- a/Services/WindowServer/WindowSwitcher.cpp
+++ b/Services/WindowServer/WindowSwitcher.cpp
@@ -230,7 +230,7 @@ void WindowSwitcher::refresh()
             longest_title_width = max(longest_title_width, wm.font().width(window.title()));
             if (selected_window == &window)
                 m_selected_index = m_windows.size();
-            m_windows.append(window.make_weak_ptr());
+            m_windows.append(window);
             return IterationDecision::Continue;
         },
         true);


### PR DESCRIPTION
This makes most operations thread safe, especially so that they
can safely be used in the Kernel. This includes obtaining a strong
reference from a weak reference, which now requires an explicit
call to WeakPtr::strong_ref(). Another major change is that
Weakable::make_weak_ref() may require the explicit target type.
Previously we used reinterpret_cast in WeakPtr, assuming that it
can be properly converted. But WeakPtr does not necessarily have
the knowledge to be able to do this. Instead, we now ask the class
itself to deliver a WeakPtr to the type that we want.

Also, WeakLink is no longer specific to a target type. The reason
for this is that we want to be able to safely convert e.g. WeakPtr<T>
to WeakPtr<U>, and before this we just reinterpret_cast the internal
WeakLink<T> to WeakLink<U>, which is a bold assumption that it would
actually produce the correct code. Instead, WeakLink now operates
on just a raw pointer and we only make those constructors/operators
available if we can verify that it can be safely cast.

In order to guarantee thread safety, we now use the least significant
bit in the pointer for locking purposes. This also means that only
properly aligned pointers can be used.

This will facilitate with #3864 and may also help with the crash in #3990