### PR TITLE
Nicer IRC notifications

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -86,30 +86,26 @@ jobs:
         cat <<"EOF"
         ${{ toJSON(github.event) }}
         EOF
-
+    - name: Generate IRC message
+      if: always()
+      id: ircmsg
+      run: |
+        ${{ github.workspace }}/Meta/mangle_event_for_irc.py <<"EOF"
+        ["${{ github.actor }}", ${{ github.run_id }}, "${{ job.status }}",
+        ${{ toJSON(github.event) }}
+        ]
+        EOF
     - name: IRC result notification (direct push)
       uses: rectalogic/notify-irc@v1
-      if: github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master' && github.event_name == 'push' && !cancelled()
+      if: github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master' && github.event_name == 'push' && !cancelled() && steps.ircmsg.outputs.has_output
       with:
         channel: "#serenityos"
         nickname: serenity-ga
-        message: |-
-          ${{ github.actor }} pushed master on ${{ github.event.compare }}: ${{ job.status }}
-          Subject: ${{ join(github.event.commits[0].message) }} (+ more, maybe)
-          Details: https://github.com/${{ github.repository }}/actions/runs/${{github.run_id}}
-        # There might be hundreds of commits in a push: Printing them all to IRC will fail.
-        # Accessing the last commit is not possible: The python-y '-1' is not understood.
-        # Counting is not available: The config-file language is not Turing complete.
-        # We could write a script just to format the IRC message, but this is getting silly.
-        # https://github.com/SerenityOS/serenity/pull/3980
-
+        message: ${{ steps.ircmsg.outputs.the_line }}
     - name: IRC result notification (PR)
       uses: rectalogic/notify-irc@v1
-      if: github.event_name == 'pull_request' && !cancelled()
+      if: github.repository == 'SerenityOS/serenity' && github.event_name == 'pull_request' && !cancelled() && steps.ircmsg.outputs.has_output
       with:
         channel: "#serenityos"
         nickname: serenity-ga
-        message: |-
-          ${{ github.actor }} ${{ github.event.action }} PR #${{ github.event.pull_request.number }}: ${{ job.status }}
-          Subject: ${{ github.event.pull_request.title }}
-          Details: ${{ github.event.pull_request._links.html.href }}
+        message: ${{ steps.ircmsg.outputs.the_line }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Use GCC 10 instead
       run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
     - name: Check versions
-      run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-10 --version
+      run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-10 --version; python --version; python3 --version
 
     # === PREPARE FOR BUILDING ===
 

--- a/Meta/mangle_event_for_irc.py
+++ b/Meta/mangle_event_for_irc.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+# Must be exactly three lines each!
+# No trailing newline! (I.e. keep it as backslash-newline-tripleapostrophe.)
+TEMPLATE_PUSH = '''\
+{commit}{post_commit} (pushed master: {status}) {compare} https://github.com/SerenityOS/serenity/actions/runs/{run_id}\
+'''
+TEMPLATE_PR = '''\
+{title} ({actor} {action}: {status}) {link} https://github.com/SerenityOS/serenity/actions/runs/{run_id}\
+'''
+
+def compute_lines(wrapper):
+    actor, run_id, raw_status, event = wrapper
+
+    if raw_status == 'success':
+        status = 'The build passed.'
+    elif raw_status == 'failure':
+        status = 'The build failed.'
+    else:
+        status = 'The build {}(?)'.format(raw_status)
+
+    if 'action' not in event:
+        # This is a push.
+        if 'commits' not in event or not event['commits']:
+            show_msg = '??? (No commits in event?!)'
+            post_commit = ''
+        else:
+            commits = event['commits']
+            show_commit = commits[-1]['message']
+            if 'skip ci' in show_commit or 'ci skip' in show_commit:
+                print('User requested to skip IRC notification. Okay!')
+                return False
+            # First line of the last commit:
+            show_msg = show_commit.split('\n')[0]
+            if len(commits) == 1:
+                post_commit = ''
+            elif len(commits) == 2:
+                post_commit = ' (+1 commit)'
+            else:
+                post_commit = ' (+{} commits)'.format(len(commits))
+        return TEMPLATE_PUSH.format(
+            actor=actor,
+            status=status,
+            run_id=run_id,
+            commit=show_msg,
+            post_commit=post_commit,
+            compare=event.get('compare', '???'),
+        )
+    elif 'pull_request' in event:
+        # This is a PR.
+        raw_action = event['action']
+        if raw_action == 'opened':
+            action = 'opened'
+        elif raw_action == 'reopened':
+            action = 'reopened'
+        elif raw_action == 'synchronize':
+            action = 'updated'
+        else:
+            action = '{}(?)'.format(raw_action)
+        if event['pull_request'].get('draft', True):
+            print("This is a draft PR, so IRC won't be notified.")
+            print('Note: No rebuild occurs when the PR is "un-drafted"!')
+            return False
+        return TEMPLATE_PR.format(
+            actor=actor,
+            action=action,
+            status=status,
+            run_id=run_id,
+            title=event['pull_request'].get('title', '???'),
+            link=event['pull_request'].get('_links', dict()).get('html', dict()).get('href', '???'),
+        )
+    else:
+        print('Unrecognized event type?!')
+        return False
+
+
+def run_on(json_string):
+    wrapper = json.loads(json_string)
+    line = compute_lines(wrapper)
+    has_output = bool(line)
+    print('::set-output name=has_output::{}'.format(has_output))
+    print('> ::set-output name=has_output::{}'.format(has_output))
+    if has_output:
+        print('::set-output name=the_line::{}'.format(line))
+        print('> ::set-output name=the_line::{}'.format(line))
+
+
+def run():
+    run_on(sys.stdin.read())
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
# Why?

## Exhibit A

Too harsh:

> (21:55:35) serenity-ga [~serenity-@40.77.71.119] joined.
> (21:55:35) serenity-ga: tomuta opened PR #4012: failure
> // ...
> (22:18:28) thakis: "opened PR: failure" harsh

## Exhibit B

Too long:

> (22:49:46) serenity-ga [~serenity-@23.101.119.170] joined.
> (22:49:46) serenity-ga: awesomekling pushed master on https://github.com/SerenityOS/serenity/compare/a2cfb7eb9473...81b7c072edb7: success
> (22:49:46) serenity-ga: Subject: AK: Use reference algorithms for LEB128 parsing
> (22:49:46) serenity-ga:  
> (22:49:47) serenity-ga: This fixes a bug in signed LEB128 parsing (sign extension stage)
> (22:49:47) serenity-ga: which would sometimes cause debug info to look very strange. (+ more, maybe)
> (22:49:48) serenity-ga: Details: https://github.com/SerenityOS/serenity/actions/runs/352784189
> (22:49:48) serenity-ga left.

## Exhibit C

Too often:

> (22:56:02) linusg: it's
> (22:56:06) linusg: too
> (22:56:09) linusg: verbose
> (22:57:14) BenW: Really? D:
> (22:57:27) BenW: It's just three lines, the old ones were three lines, too.
> (22:58:04) linusg: but the old ones didn't have "opened" and "synchronized" updates
> (22:58:10) linusg: Just "merged"

# This PR

… introduces a python script that nicely formats the IRC notifications. Examples:

```
(22:27:51) serenity-ga [~serenity-@104.43.251.130] joined.
(22:27:51) serenity-ga: BenWiederhake pushed master: The build passed. https://github.com/SerenityOS/serenity/actions/runs/354757809
(22:27:51) serenity-ga: Subject: TMP: Test it (+3 commits)
(22:27:51) serenity-ga: Details: https://github.com/BenWiederhake/serenity/compare/b59e2d43d3a1...bff54ab3e8dc
(22:27:52) serenity-ga left.
(22:33:27) serenity-ga [~serenity-@40.77.97.227] joined.
(22:33:27) serenity-ga: BenWiederhake opened PR #7: The build passed. https://github.com/SerenityOS/serenity/actions/runs/354763806
(22:33:27) serenity-ga: Subject: Please build me!
(22:33:27) serenity-ga: Details: https://github.com/BenWiederhake/serenity/pull/7
(22:33:28) serenity-ga left.
```

It limits the number of lines to three, never "floods" IRC, and makes everything more grammaticallier correctlierly.

# Why not?

## Python

It adds a new dependency, but this dependency is *only* needed for the Github Action. So I don't know how you feel about that.
This is kind of necessary though, because I really don't want to parse JSON with bash. Finally, writing our own programs in Lagom means that many build errors cause the notification(s) to disappear, so I disregarded that, too. Hence my choice for python: Universal enough, and it's already on the Github Actions image anyway.

## Still too verbose

I didn't change anything about the frequency. However, that could be easily tweaked using the `if:` key. For example, we could only send PR notifications for (un)successful builds. Or none. Or decide in the python script (would need three more lines). I slightly prefer what I implemented (notifications for EVERYTHING), and linus is against it. What do you guys think?