### PR TITLE
Base: Add ls man page documentation

### DIFF
--- a/Base/usr/share/man/man1/ls.md
+++ b/Base/usr/share/man/man1/ls.md
@@ -1,0 +1,47 @@
+## Name
+
+ls - list directory contents
+
+## Synopsis
+
+```**sh
+$ ls [options...] [path...]
+```
+
+## Description
+
+`ls` lists directory contents and attributes.
+
+If no *path* argument is provided the current working directory is used.
+
+## Options
+
+* `--help`: Display this message
+* `-a`, `--all`: Show dotfiles
+* `-A`: Do not list implied . and .. directories
+* `-l`, `--long`: Display long info
+* `-t`: Sort files by timestamp
+* `-r`, `--reverse`: Reverse sort order
+* `-G`: Use pretty colors
+* `-i`, `--inode`: Show inode ids
+* `-n`, `--numeric-uid-gid`: In long format, display numeric UID/GID
+* `-h`, `--human-readable`: Print human-readable sizes
+* `-K`, `--no-hyperlinks`: Disable hyperlinks
+
+## Arguments
+
+* path: Directory to list
+
+## Examples
+
+```sh
+# List contents of working directory
+$ ls
+# List contents of working directory including hidden dot files
+$ ls -la
+# List contents of /etc/ directory
+$ ls /etc
+# List contents of /etc/ directory including hidden dot files
+$ ls -la /etc
+```
+


### PR DESCRIPTION
Note, this `man` page contains details for the `-A` flag which has not yet been implemented. (Pending #4016)

![Help ls](https://user-images.githubusercontent.com/434827/98627309-0a38d600-2368-11eb-80ce-f7d2665ec3d5.png)

