### PR TITLE
Demos: Screensaver: Disable double buffering and hide cursor

### DIFF
--- a/Demos/Screensaver/Screensaver.cpp
+++ b/Demos/Screensaver/Screensaver.cpp
@@ -152,7 +152,7 @@ int main(int argc, char** argv)
     }
 
     auto window = GUI::Window::construct();
-    window->set_double_buffering_enabled(true);
+    window->set_double_buffering_enabled(false);
     window->set_title("Screensaver");
     window->set_resizable(false);
     window->set_fullscreen(true);
@@ -164,6 +164,8 @@ int main(int argc, char** argv)
 
     auto app_icon = GUI::Icon::default_icon("app-screensaver");
     window->set_icon(app_icon.bitmap_for_size(16));
+    window->set_cursor(Gfx::StandardCursor::Hidden);
+    window->update();
 
     return app->exec();
 }


### PR DESCRIPTION
WIP

~~`Screensaver` failed to draw when run in full screen (default) when double buffering was enabled. This PR disables double buffering.~~

~~Note: this change doesn't actually hide the cursor until the cursor is redrawn. Hiding the cursor (with `Gfx::StandardCursor::Hidden`) doesn't cause the cursor to be redrawn until the mouse is moved. `Screensaver` exits as soon as the mouse is moved, rendering this change pointless. I guess it's nice to express the intent in code even if it doesn't work?~~
