### PR TITLE
LaunchServer: Add hsp=/bin/HackStudio file association to config

### DIFF
--- a/Base/home/anon/.config/LaunchServer.ini
+++ b/Base/home/anon/.config/LaunchServer.ini
@@ -11,7 +11,7 @@ html=/bin/Browser
 wav=/bin/SoundPlayer
 txt=/bin/TextEditor
 font=/bin/FontEditor
-hackstudio=/bin/HackStudio
+hsp=/bin/HackStudio
 sheets=/bin/Spreadsheet
 *=/bin/TextEditor
 


### PR DESCRIPTION
I've never seen `.hackstudio` used as a file extension for HackStudio projects. Let's replace the default file association in anon's LaunchServer config with `.hsp` which is currently used by the `little` example project.

**Edit:** Prior to this change, opening `.hsp` files in FileManager works, but `.hsp` files cannot be opened by clicking the file in Terminal. FileManager has its own hard-coded file associations outside of LaunchServer. (Perhaps this should be changed?)

https://www.youtube.com/watch?v=rRGu8DVrlHQ#t=44m15s
