### PR TITLE
Base: remove unnecessary Game config files from /home/anon/.config/

### DIFF
--- a/Base/home/anon/.config/Chess.ini
+++ b/Base/home/anon/.config/Chess.ini
@@ -1,7 +1,0 @@
-[Display]
-size=512
-
-[Style]
-BoardTheme=Beige
-PieceSet=stelar7
-Coordinates=1

--- a/Base/home/anon/.config/Minesweeper.ini
+++ b/Base/home/anon/.config/Minesweeper.ini
@@ -1,8 +1,0 @@
-[Minesweeper]
-SingleChording=0
-
-[Game]
-MineCount=10
-Columns=9
-Rows=9
-

--- a/Base/home/anon/.config/Snake.ini
+++ b/Base/home/anon/.config/Snake.ini
@@ -1,3 +1,0 @@
-[Snake]
-HighScore=0
-


### PR DESCRIPTION
Now that the `unveil` issue for file creation has been resolved (#3955) we can remove several default config files (https://github.com/SerenityOS/serenity/pull/3955#issuecomment-722191252 #3942) from anon's home directory. There's no reason to ship these files as they will be generated automatically.

Presuming that the default settings hard coded in an application are sane, and we have no desire to override the default for anon (ie, `/home/anon/.config/IRCClient.ini` is configured to connect to `#serenityos` as this isn't a default setting for `IRCClient`), there's no reason to ship config files for the application in `.config`.

