### PR TITLE
HackStudio TerminalWrapper pid checking

### DIFF
--- a/DevTools/HackStudio/TerminalWrapper.cpp
+++ b/DevTools/HackStudio/TerminalWrapper.cpp
@@ -155,8 +155,10 @@ void TerminalWrapper::run_command(const String& command)
         ASSERT_NOT_REACHED();
     }
 
-    // (In parent process)
-    terminal().scroll_to_bottom();
+    if (pid > 0) {
+        // (In parent process)
+        terminal().scroll_to_bottom();
+    }
 }
 
 void TerminalWrapper::kill_running_command()

--- a/DevTools/HackStudio/TerminalWrapper.cpp
+++ b/DevTools/HackStudio/TerminalWrapper.cpp
@@ -155,7 +155,7 @@ void TerminalWrapper::run_command(const String& command)
         ASSERT_NOT_REACHED();
     }
 
-    if (pid > 0) {
+    if (m_pid > 0) {
         // (In parent process)
         terminal().scroll_to_bottom();
     }


### PR DESCRIPTION
There is a condition where fork fails and returns a negative value. This means running the command failed and there is no new information to scroll to.