### PR TITLE
LibGUI: Set vertical distance between icons relative to scroll value

### DIFF
--- a/Libraries/LibGUI/IconView.cpp
+++ b/Libraries/LibGUI/IconView.cpp
@@ -524,7 +524,7 @@ void IconView::paint_event(PaintEvent& event)
         auto font = font_for_index(item_data.index);
 
         Gfx::IntRect text_rect = item_data.text_rect;
-        auto icon_translation = translation.y() - 12;
+        auto icon_translation = translation.y() + vertical_scrollbar().value() - 12;
         text_rect.set_height(text_rect.height() > icon_translation ? icon_translation : text_rect.height());
 
         painter.fill_rect(text_rect, background_color);


### PR DESCRIPTION
When calculating the vertical distance between icons, we should take
into account the value of the vertical scrollbar.

![image](https://user-images.githubusercontent.com/5558617/98818216-22b9f680-2423-11eb-9169-cb24dd5afdec.png)

Fixes #4040