### PR TITLE
RefPtrTraits: struct/class mismatch in forward declaration

### DIFF
--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -113,7 +113,7 @@ template<typename T>
 class Optional;
 
 template<typename T>
-class RefPtrTraits;
+struct RefPtrTraits;
 
 template<typename T, typename PtrTraits = RefPtrTraits<T>>
 class RefPtr;


### PR DESCRIPTION
Problem:
- Building with clang is broken because of the `struct` vs `class`
  mismatch between the definition and declaration.

Solution:
- Change `class` to `struct` in the forward declaration.