### PR TITLE
LibJS/Tests: Parse unmodified source in toEval()

### DIFF
--- a/Libraries/LibJS/Tests/automatic-semicolon-insertion.js
+++ b/Libraries/LibJS/Tests/automatic-semicolon-insertion.js
@@ -1,18 +1,18 @@
 test("Issue #1829, if-else without braces or semicolons", () => {
     const source = `if (1)
-    return 1;
+    foo;
 else
-    return 0;
+    bar;
 
 if (1)
-    return 1
+    foo
 else
-    return 0
+    bar
 
 if (1)
-    return 1
+    foo
 else
-    return 0;`;
+    bar;`;
 
     expect(source).toEval();
 });

--- a/Libraries/LibJS/Tests/functions/function-new-target.js
+++ b/Libraries/LibJS/Tests/functions/function-new-target.js
@@ -20,7 +20,6 @@ test("basic functionality", () => {
     expect(new baz().newTarget).toEqual(baz);
 });
 
-// FIXME: This does not work as expected as toEval() places the code inside a function :|
-test.skip("syntax error outside of function", () => {
+test("syntax error outside of function", () => {
     expect("new.target").not.toEval();
 });

--- a/Libraries/LibJS/Tests/test-common-tests.js
+++ b/Libraries/LibJS/Tests/test-common-tests.js
@@ -326,13 +326,11 @@ test("toThrowWithMessage", () => {
     expect(thrower).not.toThrowWithMessage(TypeError, "foo baz");
 });
 
-// FIXME: Will have to change when this matcher changes to use the
-// "eval" function
 test("toEval", () => {
     expect("let a = 1").toEval();
     expect("a < 1").toEval();
     expect("&&*^%#%@").not.toEval();
-    expect("function foo() { return 1; }; return foo();").toEval();
+    expect("function foo() { return 1; }; foo();").toEval();
 });
 
 // FIXME: Will have to change when this matcher changes to use the

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -63,15 +63,24 @@ class ExpectationError extends Error {
 
         toBe(value) {
             this.__doMatcher(() => {
-                this.__expect(Object.is(this.target, value),
-                              () => ("toBe: expected _" + String(value) + "_, got _" + String(this.target) + "_"));
+                this.__expect(
+                    Object.is(this.target, value),
+                    () =>
+                        "toBe: expected _" + String(value) + "_, got _" + String(this.target) + "_"
+                );
             });
         }
 
         // FIXME: Take a precision argument like jest's toBeCloseTo matcher
         toBeCloseTo(value) {
-            this.__expect(typeof this.target === "number", () => "toBeCloseTo: target not of type number");
-            this.__expect(typeof value === "number", () => "toBeCloseTo: argument not of type number");
+            this.__expect(
+                typeof this.target === "number",
+                () => "toBeCloseTo: target not of type number"
+            );
+            this.__expect(
+                typeof value === "number",
+                () => "toBeCloseTo: argument not of type number"
+            );
 
             this.__doMatcher(() => {
                 this.__expect(Math.abs(this.target - value) < 0.000001);
@@ -79,7 +88,10 @@ class ExpectationError extends Error {
         }
 
         toHaveLength(length) {
-            this.__expect(typeof this.target.length === "number", () => "toHaveLength: target.length not of type number");
+            this.__expect(
+                typeof this.target.length === "number",
+                () => "toHaveLength: target.length not of type number"
+            );
 
             this.__doMatcher(() => {
                 this.__expect(Object.is(this.target.length, length));
@@ -139,13 +151,19 @@ class ExpectationError extends Error {
 
         toBeUndefined() {
             this.__doMatcher(() => {
-                this.__expect(this.target === undefined, () => "toBeUndefined: target was not undefined");
+                this.__expect(
+                    this.target === undefined,
+                    () => "toBeUndefined: target was not undefined"
+                );
             });
         }
 
         toBeNaN() {
             this.__doMatcher(() => {
-                this.__expect(isNaN(this.target), () => ("toBeNaN: target was _" + String(this.target) + "_, not NaN"));
+                this.__expect(
+                    isNaN(this.target),
+                    () => "toBeNaN: target was _" + String(this.target) + "_, not NaN"
+                );
             });
         }
 
@@ -388,10 +406,11 @@ class ExpectationError extends Error {
 
         __expect(value, details) {
             if (value !== true) {
-                if (details !== undefined)
-                     throw new ExpectationError(details());
-                else
-                     throw new ExpectationError();
+                if (details !== undefined) {
+                    throw new ExpectationError(details());
+                } else {
+                    throw new ExpectationError();
+                }
             }
         }
     }

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -302,14 +302,8 @@ class ExpectationError extends Error {
         // Test for syntax errors; target must be a string
         toEval() {
             this.__expect(typeof this.target === "string");
-
-            let threw = false;
-            try {
-                new Function(this.target);
-            } catch (e) {
-                threw = true;
-            }
-            this.__expect(this.inverted ? threw : !threw);
+            const success = canParseSource(this.target)
+            this.__expect(this.inverted ? !success : success);
         }
 
         // Must compile regardless of inverted-ness

--- a/Userland/test-js.cpp
+++ b/Userland/test-js.cpp
@@ -106,6 +106,7 @@ private:
     virtual const char* class_name() const override { return "TestRunnerGlobalObject"; }
 
     JS_DECLARE_NATIVE_FUNCTION(is_strict_mode);
+    JS_DECLARE_NATIVE_FUNCTION(can_parse_source);
 };
 
 class TestRunner {
@@ -159,13 +160,25 @@ void TestRunnerGlobalObject::initialize()
     JS::GlobalObject::initialize();
     static FlyString global_property_name { "global" };
     static FlyString is_strict_mode_property_name { "isStrictMode" };
+    static FlyString can_parse_source_property_name { "canParseSource" };
     define_property(global_property_name, this, JS::Attribute::Enumerable);
     define_native_function(is_strict_mode_property_name, is_strict_mode);
+    define_native_function(can_parse_source_property_name, can_parse_source);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(TestRunnerGlobalObject::is_strict_mode)
 {
     return JS::Value(vm.in_strict_mode());
+}
+
+JS_DEFINE_NATIVE_FUNCTION(TestRunnerGlobalObject::can_parse_source)
+{
+    auto source = vm.argument(0).to_string(global_object);
+    if (vm.exception())
+        return {};
+    auto parser = JS::Parser(JS::Lexer(source));
+    parser.parse_program();
+    return JS::Value(!parser.has_errors());
 }
 
 static void cleanup_and_exit()


### PR DESCRIPTION
We need a native function for that, but it allows us to parse the source as given to `toEval()`, without  `Function()` putting it in a function, which can have unintended side effects and makes testing some stuff impossible.