### PR TITLE
Meta: Add .cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Toolchain/Local
 .ccls-cache
 .DS_Store
 compile_commands.json
+.cache
 .clang_complete
 .clangd
 *Endpoint.h


### PR DESCRIPTION
The current version of clangd on my machine uses `.cache/clangd` and not `.clangd` anymore so let's add that to `.gitignore` as well.