### PR TITLE
AK: Prefer using instead of typedef

### DIFF
--- a/AK/DistinctNumeric.h
+++ b/AK/DistinctNumeric.h
@@ -66,7 +66,7 @@ namespace AK {
  */
 template<typename T, bool Incr, bool Cmp, bool Bool, bool Flags, bool Shift, bool Arith, typename X>
 class DistinctNumeric {
-    typedef DistinctNumeric<T, Incr, Cmp, Bool, Flags, Shift, Arith, X> Self;
+    using Self = DistinctNumeric<T, Incr, Cmp, Bool, Flags, Shift, Arith, X>;
 
 public:
     DistinctNumeric(T value)
@@ -301,8 +301,8 @@ private:
 }
 
 #define TYPEDEF_DISTINCT_NUMERIC_GENERAL(T, Incr, Cmp, Bool, Flags, Shift, Arith, NAME) \
-    typedef DistinctNumeric<T, Incr, Cmp, Bool, Flags, Shift, Arith, struct __##NAME##_tag> NAME
+    using NAME = DistinctNumeric<T, Incr, Cmp, Bool, Flags, Shift, Arith, struct __##NAME##_tag>;
 #define TYPEDEF_DISTINCT_ORDERED_ID(T, NAME) TYPEDEF_DISTINCT_NUMERIC_GENERAL(T, false, true, true, false, false, false, NAME)
-// TODO: Further typedef's?
+// TODO: Further type aliases?
 
 using AK::DistinctNumeric;

--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -67,9 +67,9 @@ public:
     }
     void remove_one_randomly() { m_table.remove(m_table.begin()); }
 
-    typedef HashTable<Entry, EntryTraits> HashTableType;
-    typedef typename HashTableType::Iterator IteratorType;
-    typedef typename HashTableType::ConstIterator ConstIteratorType;
+    using HashTableType = HashTable<Entry, EntryTraits>;
+    using IteratorType = typename HashTableType::Iterator;
+    using ConstIteratorType = typename HashTableType::ConstIterator;
 
     IteratorType begin() { return m_table.begin(); }
     IteratorType end() { return m_table.end(); }

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -45,7 +45,7 @@ class WeakPtr;
 template<typename T>
 class NonnullOwnPtr {
 public:
-    typedef T ElementType;
+    using ElementType = T;
 
     enum AdoptTag { Adopt };
 

--- a/AK/NonnullPtrVector.h
+++ b/AK/NonnullPtrVector.h
@@ -32,8 +32,8 @@ namespace AK {
 
 template<typename PtrType, int inline_capacity = 0>
 class NonnullPtrVector : public Vector<PtrType, inline_capacity> {
-    typedef typename PtrType::ElementType T;
-    typedef Vector<PtrType, inline_capacity> Base;
+    using T = typename PtrType::ElementType;
+    using Base = Vector<PtrType, inline_capacity>;
 
 public:
     NonnullPtrVector()

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -66,7 +66,7 @@ class NonnullRefPtr {
     friend class WeakPtr;
 
 public:
-    typedef T ElementType;
+    using ElementType = T;
 
     enum AdoptTag { Adopt };
 

--- a/AK/RefCounted.h
+++ b/AK/RefCounted.h
@@ -64,7 +64,7 @@ class RefCountedBase {
     AK_MAKE_NONMOVABLE(RefCountedBase);
 
 public:
-    typedef unsigned int RefCountType;
+    using RefCountType = unsigned int;
     using AllowOwnPtr = FalseType;
 
     ALWAYS_INLINE void ref() const
@@ -110,16 +110,6 @@ public:
         }
     }
 };
-
-static constexpr bool is_ref_counted(const RefCountedBase*)
-{
-    return true;
-}
-
-static constexpr bool is_ref_counted(...)
-{
-    return false;
-}
 
 }
 

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -128,7 +128,7 @@ struct RefPtrTraits {
 
     static constexpr FlatPtr default_null_value = 0;
 
-    typedef std::nullptr_t NullType;
+    using NullType = std::nullptr_t;
 };
 
 template<typename T, typename PtrTraits>

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -104,48 +104,48 @@ struct EnableIf {
 
 template<class T>
 struct EnableIf<true, T> {
-    typedef T Type;
+    using Type = T;
 };
 
 template<class T>
 struct AddConst {
-    typedef const T Type;
+    using Type = const T;
 };
 
 template<class T>
 struct RemoveConst {
-    typedef T Type;
+    using Type = T;
 };
 
 template<class T>
 struct RemoveConst<const T> {
-    typedef T Type;
+    using Type = T;
 };
 
 template<class T>
 struct RemoveVolatile {
-    typedef T Type;
+    using Type = T;
 };
 template<class T>
 struct RemoveVolatile<volatile T> {
-    typedef T Type;
+    using Type = T;
 };
 template<class T>
 struct RemoveCV {
-    typedef typename RemoveVolatile<typename RemoveConst<T>::Type>::Type Type;
+    using Type = typename RemoveVolatile<typename RemoveConst<T>::Type>::Type;
 };
 
 template<class T, T v>
 struct IntegralConstant {
     static constexpr T value = v;
-    typedef T ValueType;
-    typedef IntegralConstant Type;
+    using ValueType = T;
+    using Type = IntegralConstant;
     constexpr operator ValueType() const { return value; }
     constexpr ValueType operator()() const { return value; }
 };
 
-typedef IntegralConstant<bool, false> FalseType;
-typedef IntegralConstant<bool, true> TrueType;
+using FalseType = IntegralConstant<bool, false>;
+using TrueType = IntegralConstant<bool, true>;
 template<typename...>
 using VoidType = void;
 
@@ -257,23 +257,23 @@ struct IsRvalueReference<T&&> : TrueType {
 
 template<class T>
 struct RemovePointer {
-    typedef T Type;
+    using Type = T;
 };
 template<class T>
 struct RemovePointer<T*> {
-    typedef T Type;
+    using Type = T;
 };
 template<class T>
 struct RemovePointer<T* const> {
-    typedef T Type;
+    using Type = T;
 };
 template<class T>
 struct RemovePointer<T* volatile> {
-    typedef T Type;
+    using Type = T;
 };
 template<class T>
 struct RemovePointer<T* const volatile> {
-    typedef T Type;
+    using Type = T;
 };
 
 template<typename T, typename U>
@@ -292,12 +292,12 @@ struct IsSame<T, T> {
 
 template<bool condition, class TrueType, class FalseType>
 struct Conditional {
-    typedef TrueType Type;
+    using Type = TrueType;
 };
 
 template<class TrueType, class FalseType>
 struct Conditional<false, TrueType, FalseType> {
-    typedef FalseType Type;
+    using Type = FalseType;
 };
 
 template<typename T>
@@ -306,15 +306,15 @@ struct IsNullPointer : IsSame<decltype(nullptr), typename RemoveCV<T>::Type> {
 
 template<typename T>
 struct RemoveReference {
-    typedef T Type;
+    using Type = T;
 };
 template<class T>
 struct RemoveReference<T&> {
-    typedef T Type;
+    using Type = T;
 };
 template<class T>
 struct RemoveReference<T&&> {
-    typedef T Type;
+    using Type = T;
 };
 
 template<class T>
@@ -335,47 +335,47 @@ struct MakeUnsigned {
 };
 template<>
 struct MakeUnsigned<signed char> {
-    typedef unsigned char Type;
+    using Type = unsigned char;
 };
 template<>
 struct MakeUnsigned<short> {
-    typedef unsigned short Type;
+    using Type = unsigned short;
 };
 template<>
 struct MakeUnsigned<int> {
-    typedef unsigned Type;
+    using Type = unsigned int;
 };
 template<>
 struct MakeUnsigned<long> {
-    typedef unsigned long Type;
+    using Type = unsigned long;
 };
 template<>
 struct MakeUnsigned<long long> {
-    typedef unsigned long long Type;
+    using Type = unsigned long long;
 };
 template<>
 struct MakeUnsigned<unsigned char> {
-    typedef unsigned char Type;
+    using Type = unsigned char;
 };
 template<>
 struct MakeUnsigned<unsigned short> {
-    typedef unsigned short Type;
+    using Type = unsigned short;
 };
 template<>
 struct MakeUnsigned<unsigned int> {
-    typedef unsigned Type;
+    using Type = unsigned int;
 };
 template<>
 struct MakeUnsigned<unsigned long> {
-    typedef unsigned long Type;
+    using Type = unsigned long;
 };
 template<>
 struct MakeUnsigned<unsigned long long> {
-    typedef unsigned long long Type;
+    using Type = unsigned long long;
 };
 template<>
 struct MakeUnsigned<char> {
-    typedef unsigned char Type;
+    using Type = unsigned char;
 };
 
 template<typename T>
@@ -383,47 +383,47 @@ struct MakeSigned {
 };
 template<>
 struct MakeSigned<signed char> {
-    typedef signed char Type;
+    using Type = signed char;
 };
 template<>
 struct MakeSigned<short> {
-    typedef short Type;
+    using Type = short;
 };
 template<>
 struct MakeSigned<int> {
-    typedef int Type;
+    using Type = int;
 };
 template<>
 struct MakeSigned<long> {
-    typedef long Type;
+    using Type = long;
 };
 template<>
 struct MakeSigned<long long> {
-    typedef long long Type;
+    using Type = long long;
 };
 template<>
 struct MakeSigned<unsigned char> {
-    typedef char Type;
+    using Type = char;
 };
 template<>
 struct MakeSigned<unsigned short> {
-    typedef short Type;
+    using Type = short;
 };
 template<>
 struct MakeSigned<unsigned int> {
-    typedef int Type;
+    using Type = int;
 };
 template<>
 struct MakeSigned<unsigned long> {
-    typedef long Type;
+    using Type = long;
 };
 template<>
 struct MakeSigned<unsigned long long> {
-    typedef long long Type;
+    using Type = long long;
 };
 template<>
 struct MakeSigned<char> {
-    typedef signed char Type;
+    using Type = signed char;
 };
 
 template<class T>

--- a/AK/Tests/TestHashMap.cpp
+++ b/AK/Tests/TestHashMap.cpp
@@ -31,7 +31,7 @@
 
 TEST_CASE(construct)
 {
-    typedef HashMap<int, int> IntIntMap;
+    using IntIntMap = HashMap<int, int>;
     EXPECT(IntIntMap().is_empty());
     EXPECT_EQ(IntIntMap().size(), 0u);
 }

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -30,36 +30,36 @@
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
 
-typedef __UINT64_TYPE__ u64;
-typedef __UINT32_TYPE__ u32;
-typedef __UINT16_TYPE__ u16;
-typedef __UINT8_TYPE__ u8;
-typedef __INT64_TYPE__ i64;
-typedef __INT32_TYPE__ i32;
-typedef __INT16_TYPE__ i16;
-typedef __INT8_TYPE__ i8;
+using u64 = __UINT64_TYPE__;
+using u32 = __UINT32_TYPE__;
+using u16 = __UINT16_TYPE__;
+using u8 = __UINT8_TYPE__;
+using i64 = __INT64_TYPE__;
+using i32 = __INT32_TYPE__;
+using i16 = __INT16_TYPE__;
+using i8 = __INT8_TYPE__;
 
 #ifdef __serenity__
 
-typedef __SIZE_TYPE__ size_t;
-typedef MakeSigned<size_t>::Type ssize_t;
+using size_t = __SIZE_TYPE__;
+using ssize_t = MakeSigned<size_t>::Type;
 
-typedef __PTRDIFF_TYPE__ ptrdiff_t;
+using ptrdiff_t = __PTRDIFF_TYPE__;
 
-typedef __INTPTR_TYPE__ intptr_t;
-typedef __UINTPTR_TYPE__ uintptr_t;
+using intptr_t = __INTPTR_TYPE__;
+using uintptr_t = __UINTPTR_TYPE__;
 
-typedef u8 uint8_t;
-typedef u16 uint16_t;
-typedef u32 uint32_t;
-typedef u64 uint64_t;
+using uint8_t = u8;
+using uint16_t = u16;
+using uint32_t = u32;
+using uint64_t = u64;
 
-typedef i8 int8_t;
-typedef i16 int16_t;
-typedef i32 int32_t;
-typedef i64 int64_t;
+using int8_t = i8;
+using int16_t = i16;
+using int32_t = i32;
+using int64_t = i64;
 
-typedef int pid_t;
+using pid_t = int;
 
 #else
 #    include <stddef.h>
@@ -67,19 +67,19 @@ typedef int pid_t;
 #    include <sys/types.h>
 
 #    ifdef __ptrdiff_t
-typedef __PTRDIFF_TYPE__ __ptrdiff_t;
+using __ptrdiff_t = __PTRDIFF_TYPE__;
 #    endif
 
 #endif
 
-typedef Conditional<sizeof(void*) == 8, u64, u32>::Type FlatPtr;
+using FlatPtr = Conditional<sizeof(void*) == 8, u64, u32>::Type;
 
 constexpr unsigned KiB = 1024;
 constexpr unsigned MiB = KiB * KiB;
 constexpr unsigned GiB = KiB * KiB * KiB;
 
 namespace std {
-typedef decltype(nullptr) nullptr_t;
+using nullptr_t = decltype(nullptr);
 }
 
 static constexpr u32 explode_byte(u8 b)

--- a/AK/Utf32View.h
+++ b/AK/Utf32View.h
@@ -81,7 +81,7 @@ private:
 
 class Utf32View {
 public:
-    typedef Utf32CodepointIterator Iterator;
+    using Iterator = Utf32CodepointIterator;
 
     Utf32View() { }
     Utf32View(const u32* code_points, size_t length)

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -61,7 +61,7 @@ private:
 
 class Utf8View {
 public:
-    typedef Utf8CodepointIterator Iterator;
+    using Iterator = Utf8CodepointIterator;
 
     Utf8View() { }
     explicit Utf8View(const String&);


### PR DESCRIPTION
Problem:
- `typedef` is a keyword which comes from C and carries with it old
  syntax that is hard to read.
- Creating type aliases with the `using` keyword allows for easier
  future maintenance because it supports template syntax.
- There is inconsistent use of `typedef` vs `using`.

Solution:
- Use `clang-tidy`'s checker called `modernize-use-using` to update
  the syntax to use the newer syntax.
- Remove unused functions to make `clang-tidy` happy.
- This results in consistency within the codebase.