### PR TITLE
CMake: compile_commands.json output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_INSTALL_MESSAGE NEVER)
 
 enable_testing()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 add_custom_target(run
     COMMAND ${CMAKE_SOURCE_DIR}/Meta/run.sh
     USES_TERMINAL


### PR DESCRIPTION
Problem:
- CMake is not outputting `compile_commands.json`.
- `compile_commands.json` is used by build integration tooling such as
  `clang-tidy`.

Solution:
- Enable `CMAKE_EXPORT_COMPILE_COMMANDS` option so that the file is
  output.