### PR TITLE
InputFileStream: Incorrectly defaulted constructor

### DIFF
--- a/Libraries/LibCore/FileStream.h
+++ b/Libraries/LibCore/FileStream.h
@@ -93,8 +93,6 @@ public:
     }
 
 private:
-    InputFileStream() = default;
-
     NonnullRefPtr<File> m_file;
 };
 


### PR DESCRIPTION
Problem:
- The default constructor is is deleted because NonnullRefPtr has no
  default constructor and there is a member variable of that type, but
  the function is set as `= default`.

Solution:
- Remove the code because the function is actually deleted implicitly.