### PR TITLE
LibJS: Handle symbol PropertyName in primitive assignment error

### DIFF
--- a/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Libraries/LibJS/Runtime/Reference.cpp
@@ -50,7 +50,7 @@ void Reference::put(GlobalObject& global_object, Value value)
     }
 
     if (!base().is_object() && vm.in_strict_mode()) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::ReferencePrimitiveAssignment, m_name.to_string());
+        vm.throw_exception<TypeError>(global_object, ErrorType::ReferencePrimitiveAssignment, m_name.to_value(global_object.vm()).to_string_without_side_effects());
         return;
     }
 

--- a/Libraries/LibJS/Tests/strict-mode-errors.js
+++ b/Libraries/LibJS/Tests/strict-mode-errors.js
@@ -5,5 +5,8 @@ test("basic functionality", () => {
         expect(() => {
             primitive.foo = "bar";
         }).toThrowWithMessage(TypeError, "Cannot assign property foo to primitive value");
+        expect(() => {
+            primitive[Symbol.hasInstance] = 123;
+        }).toThrowWithMessage(TypeError, "Cannot assign property Symbol(Symbol.hasInstance) to primitive value");
     });
 });


### PR DESCRIPTION
We can't just `to_string()` the `PropertyName`, it might be a symbol.
Instead `to_value()` it and then use `to_string_without_side_effects()` as usual.

Fixes #4062.