### PR TITLE
Userland: env: Add `-i` / `--ignore-environment` arg to clear env

### DIFF
--- a/Userland/env.cpp
+++ b/Userland/env.cpp
@@ -39,6 +39,12 @@ int main(int argc, char** argv)
     const char* filename = nullptr;
 
     for (int idx = 1; idx < argc; ++idx) {
+        if (idx == 1) {
+            if (StringView { argv[idx] } == "-i" || StringView { argv[idx] } == "--ignore-environment") {
+                *environ = NULL;
+                continue;
+            }
+        }
         if (StringView { argv[idx] }.contains('=')) {
             putenv(argv[idx]);
         } else {


### PR DESCRIPTION
![env -i](https://user-images.githubusercontent.com/434827/98951255-1da59600-254e-11eb-93d5-3b16e669a233.png)

Yes, this the world's most inefficient command line parsing. Eventually, the command line parsing should be updated so that usage `--help` can be automatically generated.


