### PR TITLE
ClipboardHistoryModel: Prevent duplicate rows

### DIFF
--- a/MenuApplets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/MenuApplets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -89,13 +89,9 @@ void ClipboardHistoryModel::update()
 
 void ClipboardHistoryModel::add_item(const GUI::Clipboard::DataAndType& item)
 {
-    for (size_t i = 0; i < m_history_items.size(); i++) {
-        auto& existing = m_history_items.at(i);
-        if (existing.data == item.data && existing.mime_type == item.mime_type) {
-            m_history_items.remove(i);
-            break;
-        }
-    }
+    m_history_items.remove_first_matching([&](GUI::Clipboard::DataAndType& existing) {
+        return existing.data == item.data && existing.mime_type == item.mime_type;
+    });
 
     if (m_history_items.size() == m_history_limit)
         m_history_items.take_last();

--- a/MenuApplets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/MenuApplets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -89,8 +89,17 @@ void ClipboardHistoryModel::update()
 
 void ClipboardHistoryModel::add_item(const GUI::Clipboard::DataAndType& item)
 {
+    for (size_t i = 0; i < m_history_items.size(); i++) {
+        auto& existing = m_history_items.at(i);
+        if (existing.data == item.data && existing.mime_type == item.mime_type) {
+            m_history_items.remove(i);
+            break;
+        }
+    }
+
     if (m_history_items.size() == m_history_limit)
         m_history_items.take_last();
+
     m_history_items.prepend(item);
     update();
 }


### PR DESCRIPTION
Prevents the adding of items to the ClipboardHistoryModel if the raw data and mime_type of the item being added is the same as another item already in the list.

Resolves #4033 