### PR TITLE
Fix broken IRC notification for drafts and skips

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -97,7 +97,7 @@ jobs:
         EOF
     - name: IRC result notification (direct push)
       uses: rectalogic/notify-irc@v1
-      if: github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master' && github.event_name == 'push' && !cancelled() && steps.ircmsg.outputs.has_output
+      if: github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master' && github.event_name == 'push' && !cancelled() && steps.ircmsg.outputs.has_output == 'True'
       with:
         channel: "#serenityos"
         nickname: serenity-ga


### PR DESCRIPTION
For example https://github.com/SerenityOS/serenity/actions/runs/363042604

```
(11:29:34) serenity-ga [~serenity-@40.76.9.91] joined.
(11:29:34) serenity-ga:  
(11:29:34) serenity-ga left.
(11:29:42) kling:  
(11:30:18) \0:  
(11:33:49) serenity-ga [~serenity-@40.76.9.91] joined.
(11:33:49) serenity-ga:  
(11:33:49) serenity-ga left.
```

I previously only disabled *generating* the text, but totally forgot to *actually* disable the notification. D'oh!