### PR TITLE
Userland: chroot: Add `--userspec`/`-u` flag to set uid/gid for chroot

### DIFF
--- a/Base/usr/share/man/man8/chroot.md
+++ b/Base/usr/share/man/man8/chroot.md
@@ -24,6 +24,12 @@ Mount options can be given in the same format as for [`mount`(8)](mount.md).
 /
 ```
 
+```sh
+# chroot -u 200:200 /var/chroot
+$ id
+uid=200(nona) gid=200(n/a)
+```
+
 ## See also
 
 * [`chroot`(2)](../man2/chroot.md)

--- a/Userland/chroot.cpp
+++ b/Userland/chroot.cpp
@@ -27,19 +27,40 @@
 #include <AK/StringView.h>
 #include <LibCore/ArgsParser.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 int main(int argc, char** argv)
 {
+    int flags = -1;
+    uid_t chroot_user = 0;
+    gid_t chroot_group = 0;
     const char* path = nullptr;
     const char* program = "/bin/Shell";
-    int flags = -1;
+    const char* userspec = "0:0";
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(path, "New root directory", "path");
     args_parser.add_positional_argument(program, "Program to run", "program", Core::ArgsParser::Required::No);
 
-    Core::ArgsParser::Option option {
+    Core::ArgsParser::Option userspec_option {
+        true,
+        "The uid:gid to use",
+        "userspec",
+        'u',
+        "userpec",
+        [&userspec](const char* s) {
+            Vector<StringView> parts = StringView(s).split_view(':', true);
+            if (parts.size() != 2)
+                return false;
+            userspec = s;
+            return true;
+        }
+    };
+    args_parser.add_option(move(userspec_option));
+
+    Core::ArgsParser::Option mount_options {
         true,
         "Mount options",
         "options",
@@ -69,7 +90,7 @@ int main(int argc, char** argv)
             return true;
         }
     };
-    args_parser.add_option(move(option));
+    args_parser.add_option(move(mount_options));
     args_parser.parse(argc, argv);
 
     if (chroot_with_mount_flags(path, flags) < 0) {
@@ -79,6 +100,22 @@ int main(int argc, char** argv)
 
     if (chdir("/") < 0) {
         perror("chdir(/)");
+        return 1;
+    }
+
+    // Failed parsing will silently fail open (uid=0; gid=0);
+    // 0:0 is also the default when no --userspec argument is provided.
+    auto parts = String(userspec).split(':', true);
+    chroot_user = (uid_t)strtol(parts[0].characters(), nullptr, 10);
+    chroot_group = (uid_t)strtol(parts[1].characters(), nullptr, 10);
+
+    if (setresgid(chroot_group, chroot_group, chroot_group)) {
+        perror("setgid");
+        return 1;
+    }
+
+    if (setresuid(chroot_user, chroot_user, chroot_user)) {
+        perror("setuid");
         return 1;
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/434827/99145691-f7563680-26c4-11eb-86da-ba99507ea881.png)

Test chroot:

```diff
diff --git a/Meta/build-root-filesystem.sh b/Meta/build-root-filesystem.sh
index e2a9addfe..c768f05ef 100755
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -160,6 +160,27 @@ ln -s Shell mnt/bin/sh
 ln -s test mnt/bin/[
 echo "done"
 
+
+printf "creating (insecure) chroot... "
+mkdir mnt/var/chroot/
+mkdir mnt/var/chroot/bin
+cp mnt/bin/Shell mnt/var/chroot/bin/Shell
+cp mnt/bin/Shell mnt/var/chroot/bin/sh
+cp mnt/bin/su mnt/var/chroot/bin/su
+cp mnt/bin/env mnt/var/chroot/bin/env
+cp mnt/bin/id mnt/var/chroot/bin/id
+cp mnt/bin/ls mnt/var/chroot/bin/ls
+cp mnt/bin/cat mnt/var/chroot/bin/cat
+cp mnt/bin/echo mnt/var/chroot/bin/echo
+mkdir mnt/var/chroot/etc
+cp mnt/etc/passwd mnt/var/chroot/etc/passwd
+cp mnt/etc/group mnt/var/chroot/etc/group
+mkdir mnt/var/chroot/tmp
+chmod 1777 mnt/var/chroot/tmp
+chown -R 0:0 mnt/var/chroot
+
+
+
 printf "installing 'checksum' variants... "
 ln -s checksum mnt/bin/md5sum
 ln -s checksum mnt/bin/sha1sum
```
