### PR TITLE
Kernel: Fix mouse lag when VMWareBackdoor absolute mode is enabled

### DIFF
--- a/Kernel/Devices/I8042Controller.cpp
+++ b/Kernel/Devices/I8042Controller.cpp
@@ -149,15 +149,13 @@ void I8042Controller::irq_process_input_buffer(Device)
 {
     ASSERT(Processor::current().in_irq());
 
-    for (;;) {
-        u8 status = IO::in8(I8042_STATUS);
-        if (!(status & I8042_BUFFER_FULL))
-            return;
-        Device data_for_device = ((status & I8042_WHICH_BUFFER) == I8042_MOUSE_BUFFER) ? Device::Mouse : Device::Keyboard;
-        u8 byte = IO::in8(I8042_BUFFER);
-        if (auto* device = m_devices[data_for_device == Device::Keyboard ? 0 : 1].device)
-            device->irq_handle_byte_read(byte);
-    }
+    u8 status = IO::in8(I8042_STATUS);
+    if (!(status & I8042_BUFFER_FULL))
+        return;
+    Device data_for_device = ((status & I8042_WHICH_BUFFER) == I8042_MOUSE_BUFFER) ? Device::Mouse : Device::Keyboard;
+    u8 byte = IO::in8(I8042_BUFFER);
+    if (auto* device = m_devices[data_for_device == Device::Keyboard ? 0 : 1].device)
+        device->irq_handle_byte_read(byte);
 }
 
 void I8042Controller::do_drain()

--- a/Kernel/Devices/PS2MouseDevice.h
+++ b/Kernel/Devices/PS2MouseDevice.h
@@ -85,7 +85,7 @@ private:
 
     I8042Controller& m_controller;
     mutable SpinLock<u8> m_queue_lock;
-    CircularQueue<RawPacket, 100> m_queue;
+    CircularQueue<MousePacket, 100> m_queue;
     u8 m_data_state { 0 };
     RawPacket m_data;
     bool m_has_wheel { false };


### PR DESCRIPTION
We won't be receiving full PS/2 mouse packets when the VMWareBackdoor
absolute mouse mode is enabled. So, read just one byte every time
and retrieve the latest mouse packet from VMWareBackdoor immediately.

Fixes #4086

@awesomekling I'm reverting your change because I'm not sure if that assumption can be made on real hardware. At least haiku is only reading one byte in their IRQ handler.