### PR TITLE
Userland: Tests: Use mkstemp temporary files in tests

### DIFF
--- a/Userland/Tests/Kernel/elf-execve-mmap-race.cpp
+++ b/Userland/Tests/Kernel/elf-execve-mmap-race.cpp
@@ -28,8 +28,10 @@
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -95,9 +97,15 @@ int main()
 
     header.e_entry = 0;
 
-    int fd = open("/tmp/x", O_RDWR | O_CREAT, 0777);
+    char path[] = "/tmp/x.XXXXXX";
+    auto fd = mkstemp(path);
     if (fd < 0) {
-        perror("open");
+        perror("mkstemp");
+        return 1;
+    }
+
+    if (fchmod(fd, 0777) < 0) {
+        perror("chmod");
         return 1;
     }
 
@@ -143,7 +151,7 @@ int main()
         if (!fork()) {
         try_again:
             printf("exec\n");
-            if (execl("/tmp/x", "x", nullptr) < 0) {
+            if (execl(path, "x", nullptr) < 0) {
             }
             goto try_again;
         }

--- a/Userland/Tests/Kernel/filesystem-strips-file-suid-sgid-bits-when-modified.cpp
+++ b/Userland/Tests/Kernel/filesystem-strips-file-suid-sgid-bits-when-modified.cpp
@@ -35,11 +35,11 @@
 
 static void test_change_file_contents()
 {
-    const char* path = "suid";
-
-    int fd = open(path, O_CREAT | O_RDWR, 06755);
+    char path[] = "/tmp/suid.XXXXXX";
+    auto fd = mkstemp(path);
     assert(fd != -1);
     ftruncate(fd, 0);
+    assert(fchmod(fd, 06755) != -1);
 
     char buffer[8];
     memset(&buffer, 0, sizeof(buffer));
@@ -57,11 +57,11 @@ static void test_change_file_contents()
 
 static void test_change_file_ownership()
 {
-    const char* path = "suid";
-
-    int fd = open(path, O_CREAT | O_RDWR, 06755);
+    char path[] = "/tmp/suid.XXXXXX";
+    auto fd = mkstemp(path);
     assert(fd != -1);
     ftruncate(fd, 0);
+    assert(fchmod(fd, 06755) != -1);
 
     fchown(fd, getuid(), getgid());
 
@@ -77,11 +77,11 @@ static void test_change_file_ownership()
 
 static void test_change_file_permissions()
 {
-    const char* path = "suid";
-
-    int fd = open(path, O_CREAT | O_RDWR, 06755);
+    char path[] = "/tmp/suid.XXXXXX";
+    auto fd = mkstemp(path);
     assert(fd != -1);
     ftruncate(fd, 0);
+    assert(fchmod(fd, 06755) != -1);
 
     fchmod(fd, 0755);
 

--- a/Userland/test-gfx-font.cpp
+++ b/Userland/test-gfx-font.cpp
@@ -137,9 +137,10 @@ static void test_write_to_file()
     u8 glyph_width = 1;
     auto font = Gfx::Font::create(glyph_height, glyph_width, true, Gfx::FontTypes::Default);
 
-    const char* font_path = "/tmp/new.font";
-    assert(font->write_to_file(font_path));
-    unlink(font_path);
+    char path[] = "/tmp/new.font.XXXXXX";
+    assert(mkstemp(path) != -1);
+    assert(font->write_to_file(path));
+    unlink(path);
 }
 
 int main(int, char**)


### PR DESCRIPTION
Working on `mkstemp` file descriptors is safer than working on a hard-coded `/tmp/` path or a hard-coded file name in the working directory.

**Edit:** At least it would be, if it were not deterministic ...
