### PR TITLE
LibC: Ensure mkstemp generates a pattern 6 characters in length

### DIFF
--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -186,7 +186,7 @@ __attribute__((warn_unused_result)) int __generate_unique_filename(char* pattern
 
     for (int attempt = 0; attempt < 100; ++attempt) {
         for (int i = 0; i < 6; ++i)
-            pattern[start + i] = random_characters[(rand() % sizeof(random_characters))];
+            pattern[start + i] = random_characters[(rand() % (sizeof(random_characters) - 1))];
         struct stat st;
         int rc = lstat(pattern, &st);
         if (rc < 0 && errno == ENOENT)


### PR DESCRIPTION
Before:

![before](https://user-images.githubusercontent.com/434827/99161351-9753a480-2745-11eb-94db-791e11be29cc.png)


After:

![after](https://user-images.githubusercontent.com/434827/99161451-ab4bd600-2746-11eb-80d0-acd961f8f8ea.png)

Test:

```cpp
/*
 * Copyright (c) 2020, the SerenityOS developers.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
 *
 * 1. Redistributions of source code must retain the above copyright notice, this
 *    list of conditions and the following disclaimer.
 *
 * 2. Redistributions in binary form must reproduce the above copyright notice,
 *    this list of conditions and the following disclaimer in the documentation
 *    and/or other materials provided with the distribution.
 *
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
 * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */

#include <assert.h>
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

#ifndef BUFSIZ
#    define BUFSIZ 4096
#endif

int main()
{
    char result[BUFSIZ];
    for (long i = 0; i < 10; i++) {
        char path[] = "/tmp/asdf.XXXXXX";
        char fd_path[BUFSIZ];
        auto fd = mkstemp(path);
        if (fd == -1) {
            perror("mkstemp");
            break;
        }
        memset(fd_path, 0, sizeof(fd_path));
        sprintf(fd_path, "/proc/self/fd/%d", fd);
        memset(result, 0, sizeof(result));
        readlink(fd_path, result, sizeof(result)-1);
        printf("%s\n", result);
        close(fd);
        unlink(path);
    }

    return 0;
}
```
