### PR TITLE
ClipboardHistory: Prevent crash when clicking empty row

### DIFF
--- a/MenuApplets/ClipboardHistory/main.cpp
+++ b/MenuApplets/ClipboardHistory/main.cpp
@@ -69,6 +69,8 @@ int main(int argc, char* argv[])
     };
 
     table_view.on_activation = [&](const GUI::ModelIndex& index) {
+        if (!index.is_valid())
+            return;
         auto& data_and_type = model->item_at(index.row());
         GUI::Clipboard::the().set_data(data_and_type.data, data_and_type.mime_type, data_and_type.metadata);
     };


### PR DESCRIPTION
Added an index.is_valid() check to the on_activation method which
prevents vector.at(-1) from being called and triggering an assertion
failure.