### PR TITLE
LibTLS: Count the mac size towards the packet length in CBC mode

### DIFF
--- a/Libraries/LibTLS/Record.cpp
+++ b/Libraries/LibTLS/Record.cpp
@@ -77,10 +77,10 @@ void TLSv12::update_packet(ByteBuffer& packet)
                 // If the length is already a multiple a block_size,
                 // an entire block of padding is added.
                 // In short, we _never_ have no padding.
-                padding = block_size - length % block_size;
-                length += padding;
                 mac_size = mac_length();
                 length += mac_size;
+                padding = block_size - length % block_size;
+                length += padding;
             } else {
                 block_size = m_aes_local.gcm->cipher().block_size();
                 padding = 0;


### PR DESCRIPTION
This is a regression introduced in 1172746, where the padding would be
done without accounting for the added MAC bytes.
Fixes #4098.