### PR TITLE
AK: Fix OOB access in DuplexMemoryStream::offset_of()

### DIFF
--- a/AK/Tests/TestMemoryStream.cpp
+++ b/AK/Tests/TestMemoryStream.cpp
@@ -194,4 +194,18 @@ TEST_CASE(new_output_memory_stream)
     EXPECT_EQ(stream.bytes().size(), 2u);
 }
 
+TEST_CASE(offset_of_out_of_bounds)
+{
+    Array<u8, 4> target { 0xff, 0xff, 0xff, 0xff };
+
+    Array<u8, DuplexMemoryStream::chunk_size> whole_chunk;
+    whole_chunk.span().fill(0);
+
+    DuplexMemoryStream stream;
+
+    stream << whole_chunk;
+
+    EXPECT(!stream.offset_of(target).has_value());
+}
+
 TEST_MAIN(MemoryStream)


### PR DESCRIPTION
This fixes an OOB access when the last read/written chunk is empty (as we _just_
started on a new chunk).
Found via human fuzzing in the shell:
```sh
for $(cat /dev/urandom) {
    clear
    match $it {
        ?* as (x) {
            echo $x
            sleep 1
        }
    }
}
```
would assert at some point.