### PR TITLE
AK: Trim whitespace in StringUtils::convert_to_{int,uint,uint_from_hex}()

### DIFF
--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -98,22 +98,23 @@ bool matches(const StringView& str, const StringView& mask, CaseSensitivity case
 
 Optional<int> convert_to_int(const StringView& str)
 {
-    if (str.is_empty())
+    auto str_trimmed = str.trim_whitespace();
+    if (str_trimmed.is_empty())
         return {};
 
     bool negative = false;
     size_t i = 0;
-    const auto characters = str.characters_without_null_termination();
+    const auto characters = str_trimmed.characters_without_null_termination();
 
     if (characters[0] == '-' || characters[0] == '+') {
-        if (str.length() == 1)
+        if (str_trimmed.length() == 1)
             return {};
         i++;
         negative = (characters[0] == '-');
     }
 
     int value = 0;
-    for (; i < str.length(); i++) {
+    for (; i < str_trimmed.length(); i++) {
         if (characters[i] < '0' || characters[i] > '9')
             return {};
         value = value * 10;
@@ -124,13 +125,14 @@ Optional<int> convert_to_int(const StringView& str)
 
 Optional<unsigned> convert_to_uint(const StringView& str)
 {
-    if (str.is_empty())
+    auto str_trimmed = str.trim_whitespace();
+    if (str_trimmed.is_empty())
         return {};
 
     unsigned value = 0;
-    const auto characters = str.characters_without_null_termination();
+    const auto characters = str_trimmed.characters_without_null_termination();
 
-    for (size_t i = 0; i < str.length(); i++) {
+    for (size_t i = 0; i < str_trimmed.length(); i++) {
         if (characters[i] < '0' || characters[i] > '9')
             return {};
 
@@ -142,14 +144,15 @@ Optional<unsigned> convert_to_uint(const StringView& str)
 
 Optional<unsigned> convert_to_uint_from_hex(const StringView& str)
 {
-    if (str.is_empty())
+    auto str_trimmed = str.trim_whitespace();
+    if (str_trimmed.is_empty())
         return {};
 
     unsigned value = 0;
-    const auto count = str.length();
+    const auto count = str_trimmed.length();
 
     for (size_t i = 0; i < count; i++) {
-        char digit = str[i];
+        char digit = str_trimmed[i];
         u8 digit_val;
 
         if (digit >= '0' && digit <= '9') {

--- a/AK/Tests/TestStringUtils.cpp
+++ b/AK/Tests/TestStringUtils.cpp
@@ -130,6 +130,10 @@ TEST_CASE(convert_to_int)
     actual = AK::StringUtils::convert_to_int("-12345");
     EXPECT_EQ(actual.has_value(), true);
     EXPECT_EQ(actual.value(), -12345);
+
+    actual = AK::StringUtils::convert_to_int(" \t-12345 \n\n");
+    EXPECT_EQ(actual.has_value(), true);
+    EXPECT_EQ(actual.value(), -12345);
 }
 
 TEST_CASE(convert_to_uint)
@@ -168,6 +172,10 @@ TEST_CASE(convert_to_uint)
     EXPECT_EQ(actual.value(), 1u);
 
     actual = AK::StringUtils::convert_to_uint("12345");
+    EXPECT_EQ(actual.has_value(), true);
+    EXPECT_EQ(actual.value(), 12345u);
+
+    actual = AK::StringUtils::convert_to_uint(" \t12345 \n\n");
     EXPECT_EQ(actual.has_value(), true);
     EXPECT_EQ(actual.value(), 12345u);
 }


### PR DESCRIPTION
Personally I found this unintuitive at first, but it is in line with strtol(), Python's int() or JavaScript's parseInt(), so I guess it makes sense.

Fixes #4097.