### PR TITLE
Crypto: Remove foo.response file created by testing

### DIFF
--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -2060,14 +2060,6 @@ static void tls_test_client_hello()
     };
     tls->on_tls_finished = [&] {
         PASS;
-        auto file = Core::File::open("foo.response", Core::IODevice::WriteOnly);
-        if (file.is_error()) {
-            printf("Can't write there, %s\n", file.error().characters());
-            loop.quit(2);
-            return;
-        }
-        file.value()->write(contents);
-        file.value()->close();
         loop.quit(0);
     };
     tls->on_tls_error = [&](TLS::AlertDescription) {


### PR DESCRIPTION
Problem:
- Test creates a file and leaves it in the source tree.

Solution:
- Remove the creation of the file since it is never checked.