### PR TITLE
Tests/Kernel: Remove redundant `if`

### DIFF
--- a/Userland/Tests/Kernel/elf-execve-mmap-race.cpp
+++ b/Userland/Tests/Kernel/elf-execve-mmap-race.cpp
@@ -151,8 +151,7 @@ int main()
         if (!fork()) {
         try_again:
             printf("exec\n");
-            if (execl(path, "x", nullptr) < 0) {
-            }
+            execl(path, "x", nullptr);
             goto try_again;
         }
 


### PR DESCRIPTION
Problem:
- If `fork()` fails the system tries to call `execl()`. That will
  either succeed and replace the running process image or it will fail
  and it needs to try again. The `if` is redundant because it will
  only be evaluated if `execl()` fails.

Solution:
- Remove the `if`.