### PR TITLE
Kernel: Move block condition evaluation out of the Scheduler

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -170,6 +170,7 @@ set(KERNEL_SOURCES
     Tasks/FinalizerTask.cpp
     Tasks/SyncTask.cpp
     Thread.cpp
+    ThreadBlockers.cpp
     ThreadTracer.cpp
     Time/APICTimer.cpp
     Time/HPET.cpp

--- a/Kernel/Devices/AsyncDeviceRequest.cpp
+++ b/Kernel/Devices/AsyncDeviceRequest.cpp
@@ -74,7 +74,7 @@ auto AsyncDeviceRequest::wait(timeval* timeout) -> RequestWaitResult
     auto request_result = get_request_result();
     if (is_completed_result(request_result))
         return { request_result, Thread::BlockResult::NotBlocked };
-    auto wait_result = Thread::current()->wait_on(m_queue, name(), timeout);
+    auto wait_result = Thread::current()->wait_on(m_queue, name(), Thread::BlockTimeout(false, timeout));
     return { get_request_result(), wait_result };
 }
 

--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -95,6 +95,8 @@ void Device::process_next_queued_request(Badge<AsyncDeviceRequest>, const AsyncD
 
     if (next_request)
         next_request->start();
+
+    evaluate_block_conditions();
 }
 
 }

--- a/Kernel/Devices/KeyboardDevice.cpp
+++ b/Kernel/Devices/KeyboardDevice.cpp
@@ -272,6 +272,8 @@ void KeyboardDevice::key_state_changed(u8 scan_code, bool pressed)
     }
 
     m_has_e0_prefix = false;
+
+    evaluate_block_conditions();
 }
 
 void KeyboardDevice::handle_irq(const RegisterState&)

--- a/Kernel/DoubleBuffer.cpp
+++ b/Kernel/DoubleBuffer.cpp
@@ -70,6 +70,8 @@ ssize_t DoubleBuffer::write(const UserOrKernelBuffer& data, size_t size)
     compute_lockfree_metadata();
     if (!data.read(write_ptr, bytes_to_write))
         return -EFAULT;
+    if (m_unblock_callback && !m_empty)
+        m_unblock_callback();
     return (ssize_t)bytes_to_write;
 }
 
@@ -88,6 +90,8 @@ ssize_t DoubleBuffer::read(UserOrKernelBuffer& data, size_t size)
         return -EFAULT;
     m_read_buffer_index += nread;
     compute_lockfree_metadata();
+    if (m_unblock_callback && m_space_for_writing > 0)
+        m_unblock_callback();
     return (ssize_t)nread;
 }
 

--- a/Kernel/DoubleBuffer.h
+++ b/Kernel/DoubleBuffer.h
@@ -29,6 +29,7 @@
 #include <AK/Types.h>
 #include <Kernel/KBuffer.h>
 #include <Kernel/Lock.h>
+#include <Kernel/Thread.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
 namespace Kernel {
@@ -53,6 +54,12 @@ public:
 
     size_t space_for_writing() const { return m_space_for_writing; }
 
+    void set_unblock_callback(Function<void()> callback)
+    {
+        ASSERT(!m_unblock_callback);
+        m_unblock_callback = move(callback);
+    }
+
 private:
     void flip();
     void compute_lockfree_metadata();
@@ -68,6 +75,7 @@ private:
     InnerBuffer m_buffer2;
 
     KBuffer m_storage;
+    Function<void()> m_unblock_callback;
     size_t m_capacity { 0 };
     size_t m_read_buffer_index { 0 };
     size_t m_space_for_writing { 0 };

--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -31,6 +31,7 @@
 namespace Kernel {
 
 File::File()
+    : m_block_condition(*this)
 {
 }
 

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -45,6 +45,8 @@ public:
     static NonnullRefPtr<FileDescription> create(File&);
     ~FileDescription();
 
+    Thread::FileBlocker::BlockFlags should_unblock(Thread::FileBlocker::BlockFlags) const;
+
     bool is_readable() const { return m_readable; }
     bool is_writable() const { return m_writable; }
 
@@ -130,10 +132,17 @@ public:
 
     KResult chown(uid_t, gid_t);
 
+    FileBlockCondition& block_condition();
+
 private:
     friend class VFS;
     explicit FileDescription(File&);
     FileDescription(FIFO&, FIFO::Direction);
+
+    void evaluate_block_conditions()
+    {
+        block_condition().unblock();
+    }
 
     RefPtr<Custody> m_custody;
     RefPtr<Inode> m_inode;

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -47,8 +47,10 @@ InodeFile::~InodeFile()
 KResultOr<size_t> InodeFile::read(FileDescription& description, size_t offset, UserOrKernelBuffer& buffer, size_t count)
 {
     ssize_t nread = m_inode->read_bytes(offset, count, buffer, &description);
-    if (nread > 0)
+    if (nread > 0) {
         Thread::current()->did_file_read(nread);
+        evaluate_block_conditions();
+    }
     if (nread < 0)
         return KResult(nread);
     return nread;
@@ -60,6 +62,7 @@ KResultOr<size_t> InodeFile::write(FileDescription& description, size_t offset, 
     if (nwritten > 0) {
         m_inode->set_mtime(kgettimeofday().tv_sec);
         Thread::current()->did_file_write(nwritten);
+        evaluate_block_conditions();
     }
     if (nwritten < 0)
         return KResult(nwritten);

--- a/Kernel/FileSystem/InodeWatcher.cpp
+++ b/Kernel/FileSystem/InodeWatcher.cpp
@@ -78,6 +78,7 @@ KResultOr<size_t> InodeWatcher::read(FileDescription&, size_t, UserOrKernelBuffe
     });
     if (nwritten < 0)
         return KResult(nwritten);
+    evaluate_block_conditions();
     return bytes_to_write;
 }
 
@@ -97,18 +98,21 @@ void InodeWatcher::notify_inode_event(Badge<Inode>, Event::Type event_type)
 {
     LOCKER(m_lock);
     m_queue.enqueue({ event_type });
+    evaluate_block_conditions();
 }
 
 void InodeWatcher::notify_child_added(Badge<Inode>, const InodeIdentifier& child_id)
 {
     LOCKER(m_lock);
     m_queue.enqueue({ Event::Type::ChildAdded, child_id.index() });
+    evaluate_block_conditions();
 }
 
 void InodeWatcher::notify_child_removed(Badge<Inode>, const InodeIdentifier& child_id)
 {
     LOCKER(m_lock);
     m_queue.enqueue({ Event::Type::ChildRemoved, child_id.index() });
+    evaluate_block_conditions();
 }
 
 }

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -431,7 +431,7 @@ static Optional<KBuffer> procfs$devices(InodeIdentifier)
 static Optional<KBuffer> procfs$uptime(InodeIdentifier)
 {
     KBufferBuilder builder;
-    builder.appendf("%u\n", (g_uptime / 1000));
+    builder.appendf("%llu\n", TimeManagement::the().uptime_ms() / 1000);
     return builder.build();
 }
 

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -51,6 +51,7 @@ class PerformanceEventBuffer;
 class PhysicalPage;
 class PhysicalRegion;
 class Process;
+class ProcessGroup;
 class ThreadTracer;
 class Range;
 class RangeAllocator;

--- a/Kernel/Lock.h
+++ b/Kernel/Lock.h
@@ -72,7 +72,7 @@ private:
     // the lock is unlocked, it just means we don't know which threads hold it.
     // When locked exclusively, this is always the one thread that holds the
     // lock.
-    Thread* m_holder { nullptr };
+    RefPtr<Thread> m_holder;
 };
 
 class Locker {

--- a/Kernel/Net/IPv4Socket.h
+++ b/Kernel/Net/IPv4Socket.h
@@ -113,6 +113,8 @@ private:
     KResultOr<size_t> receive_byte_buffered(FileDescription&, UserOrKernelBuffer& buffer, size_t buffer_length, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>);
     KResultOr<size_t> receive_packet_buffered(FileDescription&, UserOrKernelBuffer& buffer, size_t buffer_length, int flags, Userspace<sockaddr*>, Userspace<socklen_t*>, timeval&);
 
+    void set_can_read(bool);
+
     IPv4Address m_local_address;
     IPv4Address m_peer_address;
 

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -77,6 +77,14 @@ private:
     NonnullRefPtrVector<FileDescription>& sendfd_queue_for(const FileDescription&);
     NonnullRefPtrVector<FileDescription>& recvfd_queue_for(const FileDescription&);
 
+    void set_connect_side_role(Role connect_side_role, bool force_evaluate_block_conditions = false)
+    {
+        auto previous = m_connect_side_role;
+        m_connect_side_role = connect_side_role;
+        if (previous != m_connect_side_role || force_evaluate_block_conditions)
+            evaluate_block_conditions();
+    }
+
     // An open socket file on the filesystem.
     RefPtr<FileDescription> m_file;
 

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -57,15 +57,15 @@ static void handle_icmp(const EthernetFrameHeader&, const IPv4Packet&, const tim
 static void handle_udp(const IPv4Packet&, const timeval& packet_timestamp);
 static void handle_tcp(const IPv4Packet&, const timeval& packet_timestamp);
 
-[[noreturn]] static void NetworkTask_main();
+[[noreturn]] static void NetworkTask_main(void*);
 
 void NetworkTask::spawn()
 {
     RefPtr<Thread> thread;
-    Process::create_kernel_process(thread, "NetworkTask", NetworkTask_main);
+    Process::create_kernel_process(thread, "NetworkTask", NetworkTask_main, nullptr);
 }
 
-void NetworkTask_main()
+void NetworkTask_main(void*)
 {
     WaitQueue packet_wait_queue;
     u8 octet = 15;

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -187,13 +187,7 @@ void handle_arp(const EthernetFrameHeader& eth, size_t frame_size)
         // Someone has this IPv4 address. I guess we can try to remember that.
         // FIXME: Protect against ARP spamming.
         // FIXME: Support static ARP table entries.
-        LOCKER(arp_table().lock());
-        arp_table().resource().set(packet.sender_protocol_address(), packet.sender_hardware_address());
-
-        klog() << "ARP table (" << arp_table().resource().size() << " entries):";
-        for (auto& it : arp_table().resource()) {
-            klog() << it.value.to_string().characters() << " :: " << it.key.to_string().characters();
-        }
+        update_arp_table(packet.sender_protocol_address(), packet.sender_hardware_address());
     }
 
     if (packet.operation() == ARPOperation::Request) {

--- a/Kernel/Net/Routing.h
+++ b/Kernel/Net/Routing.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <Kernel/Net/NetworkAdapter.h>
+#include <Kernel/Thread.h>
 
 namespace Kernel {
 
@@ -37,6 +38,7 @@ struct RoutingDecision {
     bool is_zero() const;
 };
 
+void update_arp_table(const IPv4Address&, const MACAddress&);
 RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source, const RefPtr<NetworkAdapter> through = nullptr);
 
 Lockable<HashMap<IPv4Address, MACAddress>>& arp_table();

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -70,6 +70,7 @@ void Socket::set_setup_state(SetupState new_setup_state)
 #endif
 
     m_setup_state = new_setup_state;
+    evaluate_block_conditions();
 }
 
 RefPtr<Socket> Socket::accept()
@@ -86,6 +87,8 @@ RefPtr<Socket> Socket::accept()
     client->m_acceptor = { process.pid().value(), process.uid(), process.gid() };
     client->m_connected = true;
     client->m_role = Role::Accepted;
+    if (!m_pending.is_empty())
+        evaluate_block_conditions();
     return client;
 }
 
@@ -98,6 +101,7 @@ KResult Socket::queue_connection_from(NonnullRefPtr<Socket> peer)
     if (m_pending.size() >= m_backlog)
         return KResult(-ECONNREFUSED);
     m_pending.append(peer);
+    evaluate_block_conditions();
     return KSuccess;
 }
 

--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -81,7 +81,7 @@ KResult PerformanceEventBuffer::append(int type, FlatPtr arg1, FlatPtr arg2)
         dbg() << "    " << (void*)event.stack[i];
 #endif
 
-    event.timestamp = g_uptime;
+    event.timestamp = TimeManagement::the().uptime_ms();
     at(m_count++) = event;
     return KSuccess;
 }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -519,7 +519,7 @@ int Process::alloc_fd(int first_candidate_fd)
 
 timeval kgettimeofday()
 {
-    return g_timeofday;
+    return TimeManagement::now_as_timeval();
 }
 
 void kgettimeofday(timeval& tv)

--- a/Kernel/ProcessGroup.cpp
+++ b/Kernel/ProcessGroup.cpp
@@ -50,13 +50,15 @@ NonnullRefPtr<ProcessGroup> ProcessGroup::create(ProcessGroupID pgid)
 
 NonnullRefPtr<ProcessGroup> ProcessGroup::find_or_create(ProcessGroupID pgid)
 {
+    ScopedSpinLock lock(g_process_groups_lock);
+
     if (auto existing = from_pgid(pgid))
-        return *existing;
+        return existing.release_nonnull();
 
     return create(pgid);
 }
 
-ProcessGroup* ProcessGroup::from_pgid(ProcessGroupID pgid)
+RefPtr<ProcessGroup> ProcessGroup::from_pgid(ProcessGroupID pgid)
 {
     ScopedSpinLock lock(g_process_groups_lock);
 

--- a/Kernel/ProcessGroup.h
+++ b/Kernel/ProcessGroup.h
@@ -50,7 +50,7 @@ public:
 
     static NonnullRefPtr<ProcessGroup> create(ProcessGroupID);
     static NonnullRefPtr<ProcessGroup> find_or_create(ProcessGroupID);
-    static ProcessGroup* from_pgid(ProcessGroupID);
+    static RefPtr<ProcessGroup> from_pgid(ProcessGroupID);
 
     const ProcessGroupID& pgid() const { return m_pgid; }
 

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -311,7 +311,7 @@ bool Scheduler::donate_to(RefPtr<Thread>& beneficiary, const char* reason)
     ASSERT(!proc.in_irq());
 
     if (proc.in_critical() > 1) {
-        scheduler_data.m_pending_beneficiary = *beneficiary; // Save the beneficiary
+        scheduler_data.m_pending_beneficiary = beneficiary; // Save the beneficiary
         scheduler_data.m_pending_donate_reason = reason;
         proc.invoke_scheduler_async();
         return false;

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -754,7 +754,7 @@ void Scheduler::initialize()
     g_finalizer_wait_queue = new WaitQueue;
 
     g_finalizer_has_work.store(false, AK::MemoryOrder::memory_order_release);
-    s_colonel_process = &Process::create_kernel_process(idle_thread, "colonel", idle_loop, 1).leak_ref();
+    s_colonel_process = &Process::create_kernel_process(idle_thread, "colonel", idle_loop, nullptr, 1).leak_ref();
     ASSERT(s_colonel_process);
     ASSERT(idle_thread);
     idle_thread->set_priority(THREAD_PRIORITY_MIN);
@@ -776,7 +776,7 @@ Thread* Scheduler::create_ap_idle_thread(u32 cpu)
     ASSERT(Processor::current().id() == 0);
 
     ASSERT(s_colonel_process);
-    Thread* idle_thread = s_colonel_process->create_kernel_thread(idle_loop, THREAD_PRIORITY_MIN, String::format("idle thread #%u", cpu), 1 << cpu, false);
+    Thread* idle_thread = s_colonel_process->create_kernel_thread(idle_loop, nullptr, THREAD_PRIORITY_MIN, String::format("idle thread #%u", cpu), 1 << cpu, false);
     ASSERT(idle_thread);
     return idle_thread;
 }
@@ -832,7 +832,7 @@ void Scheduler::notify_finalizer()
         g_finalizer_wait_queue->wake_all();
 }
 
-void Scheduler::idle_loop()
+void Scheduler::idle_loop(void*)
 {
     dbg() << "Scheduler[" << Processor::current().id() << "]: idle loop running";
     ASSERT(are_interrupts_enabled());

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -66,7 +66,7 @@ public:
     static void prepare_for_idle_loop();
     static Process* colonel();
     static void beep();
-    static void idle_loop();
+    static void idle_loop(void*);
     static void invoke_async();
     static void notify_finalizer();
 

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -31,6 +31,7 @@
 #include <AK/IntrusiveList.h>
 #include <AK/Types.h>
 #include <Kernel/SpinLock.h>
+#include <Kernel/Time/TimeManagement.h>
 #include <Kernel/UnixTypes.h>
 
 namespace Kernel {
@@ -44,9 +45,7 @@ struct SchedulerData;
 extern Thread* g_finalizer;
 extern WaitQueue* g_finalizer_wait_queue;
 extern Atomic<bool> g_finalizer_has_work;
-extern u64 g_uptime;
 extern SchedulerData* g_scheduler_data;
-extern timeval g_timeofday;
 extern RecursiveSpinLock g_scheduler_lock;
 
 class Scheduler {
@@ -57,7 +56,6 @@ public:
     static void timer_tick(const RegisterState&);
     [[noreturn]] static void start();
     static bool pick_next();
-    static timeval time_since_boot();
     static bool yield();
     static bool donate_to_and_switch(Thread*, const char* reason);
     static bool donate_to(RefPtr<Thread>&, const char* reason);

--- a/Kernel/Syscalls/alarm.cpp
+++ b/Kernel/Syscalls/alarm.cpp
@@ -33,14 +33,15 @@ unsigned Process::sys$alarm(unsigned seconds)
 {
     REQUIRE_PROMISE(stdio);
     unsigned previous_alarm_remaining = 0;
-    if (m_alarm_deadline && m_alarm_deadline > g_uptime) {
-        previous_alarm_remaining = (m_alarm_deadline - g_uptime) / TimeManagement::the().ticks_per_second();
+    auto uptime = TimeManagement::the().uptime_ms();
+    if (m_alarm_deadline && m_alarm_deadline > uptime) {
+        previous_alarm_remaining = m_alarm_deadline - uptime;
     }
     if (!seconds) {
         m_alarm_deadline = 0;
         return previous_alarm_remaining;
     }
-    m_alarm_deadline = g_uptime + seconds * TimeManagement::the().ticks_per_second();
+    m_alarm_deadline = uptime + seconds * 1000;
     return previous_alarm_remaining;
 }
 

--- a/Kernel/Syscalls/beep.cpp
+++ b/Kernel/Syscalls/beep.cpp
@@ -32,9 +32,9 @@ namespace Kernel {
 int Process::sys$beep()
 {
     PCSpeaker::tone_on(440);
-    u64 wakeup_time = Thread::current()->sleep(100);
+    auto result = Thread::current()->sleep({ 0, 200 });
     PCSpeaker::tone_off();
-    if (wakeup_time > g_uptime)
+    if (result.was_interrupted())
         return -EINTR;
     return 0;
 }

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -568,9 +568,6 @@ int Process::sys$execve(Userspace<const Syscall::SC_execve_params*> user_params)
     if (params.arguments.length > ARG_MAX || params.environment.length > ARG_MAX)
         return -E2BIG;
 
-    if (wait_for_tracer_at_next_execve())
-        Thread::current()->send_urgent_signal_to_self(SIGSTOP);
-
     String path;
     {
         auto path_arg = get_syscall_path_argument(params.path);

--- a/Kernel/Syscalls/kill.cpp
+++ b/Kernel/Syscalls/kill.cpp
@@ -111,10 +111,8 @@ KResult Process::do_killself(int signal)
         return KSuccess;
 
     auto current_thread = Thread::current();
-    if (!current_thread->should_ignore_signal(signal)) {
+    if (!current_thread->should_ignore_signal(signal))
         current_thread->send_signal(signal, this);
-        (void)current_thread->block<Thread::SemiPermanentBlocker>(nullptr, Thread::SemiPermanentBlocker::Reason::Signal);
-    }
 
     return KSuccess;
 }

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -112,7 +112,8 @@ int Process::sys$accept(int accepting_socket_fd, Userspace<sockaddr*> user_addre
 
     if (!socket.can_accept()) {
         if (accepting_socket_description->is_blocking()) {
-            if (Thread::current()->block<Thread::AcceptBlocker>(nullptr, *accepting_socket_description).was_interrupted())
+            auto unblock_flags = Thread::FileBlocker::BlockFlags::None;
+            if (Thread::current()->block<Thread::AcceptBlocker>(nullptr, *accepting_socket_description, unblock_flags).was_interrupted())
                 return -EINTR;
         } else {
             return -EAGAIN;

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -93,11 +93,7 @@ void Process::sys$exit_thread(Userspace<void*> exit_value)
 {
     REQUIRE_PROMISE(thread);
     cli();
-    auto current_thread = Thread::current();
-    current_thread->m_exit_value = reinterpret_cast<void*>(exit_value.ptr());
-    current_thread->set_should_die();
-    big_lock().force_unlock_if_locked();
-    current_thread->die_if_needed();
+    Thread::current()->exit(reinterpret_cast<void*>(exit_value.ptr()));
     ASSERT_NOT_REACHED();
 }
 

--- a/Kernel/Syscalls/times.cpp
+++ b/Kernel/Syscalls/times.cpp
@@ -40,7 +40,7 @@ clock_t Process::sys$times(Userspace<tms*> user_times)
     if (!copy_to_user(user_times, &times))
         return -EFAULT;
 
-    return g_uptime & 0x7fffffff;
+    return TimeManagement::the().uptime_ms() & 0x7fffffff;
 }
 
 }

--- a/Kernel/Syscalls/waitid.cpp
+++ b/Kernel/Syscalls/waitid.cpp
@@ -32,74 +32,20 @@ namespace Kernel {
 
 KResultOr<siginfo_t> Process::do_waitid(idtype_t idtype, int id, int options)
 {
-    if (idtype == P_PID) {
-        ScopedSpinLock lock(g_processes_lock);
-        if (idtype == P_PID && !Process::from_pid(id))
-            return KResult(-ECHILD);
-        // FIXME: Race: After 'lock' releases, the 'id' process might vanish.
-        // If that is not a problem, why check for it?
-        // If it is a problem, let's fix it! (Eventually.)
-    }
-
-    ProcessID waitee_pid { 0 };
-
-    // FIXME: WaitBlocker should support idtype/id specs directly.
-    if (idtype == P_ALL) {
-        waitee_pid = -1;
-    } else if (idtype == P_PID) {
-        waitee_pid = id;
-    } else {
-        // FIXME: Implement other PID specs.
+    switch (idtype) {
+    case P_ALL:
+    case P_PID:
+    case P_PGID:
+        break;
+    default:
         return KResult(-EINVAL);
     }
 
-    if (Thread::current()->block<Thread::WaitBlocker>(nullptr, options, waitee_pid).was_interrupted())
+    KResultOr<siginfo_t> result = KResult(KSuccess);
+    if (Thread::current()->block<Thread::WaitBlocker>(nullptr, options, idtype, id, result).was_interrupted())
         return KResult(-EINTR);
-
-    ScopedSpinLock lock(g_processes_lock);
-
-    // NOTE: If waitee was -1, m_waitee_pid will have been filled in by the scheduler.
-    auto waitee_process = Process::from_pid(waitee_pid);
-    if (!waitee_process)
-        return KResult(-ECHILD);
-
-    ASSERT(waitee_process);
-    if (waitee_process->is_dead()) {
-        return reap(*waitee_process);
-    } else {
-        // FIXME: PID/TID BUG
-        // Make sure to hold the scheduler lock so that we operate on a consistent state
-        ScopedSpinLock scheduler_lock(g_scheduler_lock);
-        auto waitee_thread = Thread::from_tid(waitee_pid.value());
-        if (!waitee_thread)
-            return KResult(-ECHILD);
-        ASSERT((options & WNOHANG) || waitee_thread->state() == Thread::State::Stopped);
-        siginfo_t siginfo;
-        memset(&siginfo, 0, sizeof(siginfo));
-        siginfo.si_signo = SIGCHLD;
-        siginfo.si_pid = waitee_process->pid().value();
-        siginfo.si_uid = waitee_process->uid();
-
-        switch (waitee_thread->state()) {
-        case Thread::State::Stopped:
-            siginfo.si_code = CLD_STOPPED;
-            break;
-        case Thread::State::Running:
-        case Thread::State::Runnable:
-        case Thread::State::Blocked:
-        case Thread::State::Dying:
-        case Thread::State::Dead:
-        case Thread::State::Queued:
-            siginfo.si_code = CLD_CONTINUED;
-            break;
-        default:
-            ASSERT_NOT_REACHED();
-            break;
-        }
-
-        siginfo.si_status = waitee_thread->m_stop_signal;
-        return siginfo;
-    }
+    ASSERT(!result.is_error() || (options & WNOHANG) || result.error() != KSuccess);
+    return result;
 }
 
 pid_t Process::sys$waitid(Userspace<const Syscall::SC_waitid_params*> user_params)

--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -96,10 +96,12 @@ ssize_t Process::do_write(FileDescription& description, const UserOrKernelBuffer
                 ASSERT(total_nwritten > 0);
                 return total_nwritten;
             }
-            if (Thread::current()->block<Thread::WriteBlocker>(nullptr, description).was_interrupted()) {
+            auto unblock_flags = Thread::FileBlocker::BlockFlags::None;
+            if (Thread::current()->block<Thread::WriteBlocker>(nullptr, description, unblock_flags).was_interrupted()) {
                 if (total_nwritten == 0)
                     return -EINTR;
             }
+            // TODO: handle exceptions in unblock_flags
         }
         auto nwritten_or_error = description.write(data.offset(total_nwritten), data_size - total_nwritten);
         if (nwritten_or_error.is_error()) {

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -45,6 +45,11 @@ MasterPTY::MasterPTY(unsigned index)
     auto process = Process::current();
     set_uid(process->uid());
     set_gid(process->gid());
+
+    m_buffer.set_unblock_callback([this]() {
+        if (m_slave)
+            evaluate_block_conditions();
+    });
 }
 
 MasterPTY::~MasterPTY()

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -71,10 +71,11 @@ void SlavePTY::on_master_write(const UserOrKernelBuffer& buffer, ssize_t size)
 {
     ssize_t nread = buffer.read_buffered<128>(size, [&](const u8* data, size_t data_size) {
         for (size_t i = 0; i < data_size; ++i)
-            emit(data[i]);
+            emit(data[i], false);
         return (ssize_t)data_size;
     });
-    (void)nread;
+    if (nread > 0)
+        evaluate_block_conditions();
 }
 
 ssize_t SlavePTY::on_tty_write(const UserOrKernelBuffer& data, ssize_t size)
@@ -106,6 +107,11 @@ KResult SlavePTY::close()
 {
     m_master->notify_slave_closed({});
     return KSuccess;
+}
+
+FileBlockCondition& SlavePTY::block_condition()
+{
+    return m_master->block_condition();
 }
 
 }

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -42,6 +42,8 @@ public:
 
     time_t time_of_last_write() const { return m_time_of_last_write; }
 
+    virtual FileBlockCondition& block_condition() override;
+
 private:
     // ^TTY
     virtual String tty_name() const override;

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -72,7 +72,7 @@ protected:
     void set_size(unsigned short columns, unsigned short rows);
 
     TTY(unsigned major, unsigned minor);
-    void emit(u8);
+    void emit(u8, bool do_evaluate_block_conditions = false);
     virtual void echo(u8) = 0;
 
     bool can_do_backspace() const;

--- a/Kernel/Tasks/FinalizerTask.cpp
+++ b/Kernel/Tasks/FinalizerTask.cpp
@@ -32,16 +32,17 @@ namespace Kernel {
 void FinalizerTask::spawn()
 {
     RefPtr<Thread> finalizer_thread;
-    Process::create_kernel_process(finalizer_thread, "FinalizerTask", [](void*) {
-        Thread::current()->set_priority(THREAD_PRIORITY_LOW);
-        for (;;) {
-            Thread::current()->wait_on(*g_finalizer_wait_queue, "FinalizerTask");
+    Process::create_kernel_process(
+        finalizer_thread, "FinalizerTask", [](void*) {
+            Thread::current()->set_priority(THREAD_PRIORITY_LOW);
+            for (;;) {
+                Thread::current()->wait_on(*g_finalizer_wait_queue, "FinalizerTask");
 
-            bool expected = true;
-            if (g_finalizer_has_work.compare_exchange_strong(expected, false, AK::MemoryOrder::memory_order_acq_rel))
-                Thread::finalize_dying_threads();
-        }
-    }, nullptr);
+                if (g_finalizer_has_work.exchange(false, AK::MemoryOrder::memory_order_acq_rel) == true)
+                    Thread::finalize_dying_threads();
+            }
+        },
+        nullptr);
     g_finalizer = finalizer_thread;
 }
 

--- a/Kernel/Tasks/FinalizerTask.cpp
+++ b/Kernel/Tasks/FinalizerTask.cpp
@@ -32,7 +32,7 @@ namespace Kernel {
 void FinalizerTask::spawn()
 {
     RefPtr<Thread> finalizer_thread;
-    Process::create_kernel_process(finalizer_thread, "FinalizerTask", [] {
+    Process::create_kernel_process(finalizer_thread, "FinalizerTask", [](void*) {
         Thread::current()->set_priority(THREAD_PRIORITY_LOW);
         for (;;) {
             Thread::current()->wait_on(*g_finalizer_wait_queue, "FinalizerTask");
@@ -41,7 +41,7 @@ void FinalizerTask::spawn()
             if (g_finalizer_has_work.compare_exchange_strong(expected, false, AK::MemoryOrder::memory_order_acq_rel))
                 Thread::finalize_dying_threads();
         }
-    });
+    }, nullptr);
     g_finalizer = finalizer_thread;
 }
 

--- a/Kernel/Tasks/SyncTask.cpp
+++ b/Kernel/Tasks/SyncTask.cpp
@@ -38,7 +38,7 @@ void SyncTask::spawn()
         dbg() << "SyncTask is running";
         for (;;) {
             VFS::the().sync();
-            Thread::current()->sleep(1 * TimeManagement::the().ticks_per_second());
+            Thread::current()->sleep({ 1, 0 });
         }
     });
 }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -215,6 +215,15 @@ void Thread::die_if_needed()
     ASSERT_NOT_REACHED();
 }
 
+void Thread::exit(void* exit_value)
+{
+    ASSERT(Thread::current() == this);
+    m_exit_value = exit_value;
+    set_should_die();
+    unlock_process_if_locked();
+    die_if_needed();
+}
+
 void Thread::yield_without_holding_big_lock()
 {
     bool did_unlock = unlock_process_if_locked();

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -26,6 +26,7 @@
 
 #include <AK/Demangle.h>
 #include <AK/StringBuilder.h>
+#include <AK/Time.h>
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/KSyms.h>
@@ -247,15 +248,16 @@ void Thread::relock_process(bool did_unlock)
     Processor::current().restore_critical(prev_crit, prev_flags);
 }
 
-u64 Thread::sleep(u64 ticks)
+auto Thread::sleep(const timespec& duration, timespec* remaining_time) -> BlockResult
 {
     ASSERT(state() == Thread::Running);
-    u64 wakeup_time = g_uptime + ticks;
-    auto ret = Thread::current()->block<Thread::SleepBlocker>(nullptr, wakeup_time);
-    if (wakeup_time > g_uptime) {
-        ASSERT(ret.was_interrupted());
-    }
-    return wakeup_time;
+    return Thread::current()->block<Thread::SleepBlocker>(nullptr, Thread::BlockTimeout(false, &duration), remaining_time);
+}
+
+auto Thread::sleep_until(const timespec& deadline) -> BlockResult
+{
+    ASSERT(state() == Thread::Running);
+    return Thread::current()->block<Thread::SleepBlocker>(nullptr, Thread::BlockTimeout(true, &deadline));
 }
 
 const char* Thread::state_string() const
@@ -990,10 +992,12 @@ const LogStream& operator<<(const LogStream& stream, const Thread& value)
     return stream << value.process().name() << "(" << value.pid().value() << ":" << value.tid().value() << ")";
 }
 
-Thread::BlockResult Thread::wait_on(WaitQueue& queue, const char* reason, timeval* timeout, Atomic<bool>* lock, RefPtr<Thread> beneficiary)
+Thread::BlockResult Thread::wait_on(WaitQueue& queue, const char* reason, const BlockTimeout& timeout, Atomic<bool>* lock, RefPtr<Thread> beneficiary)
 {
     auto* current_thread = Thread::current();
-    TimerId timer_id {};
+    RefPtr<Timer> timer;
+    bool block_finished = false;
+    bool did_timeout = false;
     bool did_unlock;
 
     {
@@ -1004,6 +1008,25 @@ Thread::BlockResult Thread::wait_on(WaitQueue& queue, const char* reason, timeva
         // we need to wait until the scheduler lock is released again
         {
             ScopedSpinLock sched_lock(g_scheduler_lock);
+            if (!timeout.is_infinite()) {
+                timer = TimerQueue::the().add_timer_without_id(timeout.absolute_time(), [&]() {
+                    // NOTE: this may execute on the same or any other processor!
+                    ScopedSpinLock lock(g_scheduler_lock);
+                    if (!block_finished) {
+                        did_timeout = true;
+                        wake_from_queue();
+                    }
+                });
+                if (!timer) {
+                    dbg() << "wait_on timed out before blocking";
+                    // We timed out already, don't block
+                    // The API contract guarantees we return with interrupts enabled,
+                    // regardless of how we got called
+                    critical.set_interrupt_flag_on_destruction(true);
+                    return BlockResult::InterruptedByTimeout;
+                }
+            }
+
             // m_queue can only be accessed safely if g_scheduler_lock is held!
             m_queue = &queue;
             if (!queue.enqueue(*current_thread)) {
@@ -1014,7 +1037,6 @@ Thread::BlockResult Thread::wait_on(WaitQueue& queue, const char* reason, timeva
                 // The API contract guarantees we return with interrupts enabled,
                 // regardless of how we got called
                 critical.set_interrupt_flag_on_destruction(true);
-
                 return BlockResult::NotBlocked;
             }
 
@@ -1023,12 +1045,6 @@ Thread::BlockResult Thread::wait_on(WaitQueue& queue, const char* reason, timeva
                 *lock = false;
             set_state(State::Queued);
             m_wait_reason = reason;
-
-            if (timeout) {
-                timer_id = TimerQueue::the().add_timer(*timeout, [&]() {
-                    wake_from_queue();
-                });
-            }
 
             // Yield and wait for the queue to wake us up again.
             if (beneficiary)
@@ -1058,6 +1074,7 @@ Thread::BlockResult Thread::wait_on(WaitQueue& queue, const char* reason, timeva
         // To be able to look at m_wait_queue_node we once again need the
         // scheduler lock, which is held when we insert into the queue
         ScopedSpinLock sched_lock(g_scheduler_lock);
+        block_finished = true;
 
         if (m_queue) {
             ASSERT(m_queue == &queue);
@@ -1071,10 +1088,13 @@ Thread::BlockResult Thread::wait_on(WaitQueue& queue, const char* reason, timeva
             // In this case, the queue should not contain us anymore.
             result = BlockResult::InterruptedByDeath;
         }
+    }
 
-        // Make sure we cancel the timer if woke normally.
-        if (timeout && !result.was_interrupted())
-            TimerQueue::the().cancel_timer(timer_id);
+    if (timer && !did_timeout) {
+        // Cancel the timer while not holding any locks. This allows
+        // the timer function to complete before we remove it
+        // (e.g. if it's on another processor)
+        TimerQueue::the().cancel_timer(timer.release_nonnull());
     }
 
     // The API contract guarantees we return with interrupts enabled,

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -572,6 +572,8 @@ public:
     bool should_die() const { return m_should_die; }
     void die_if_needed();
 
+    void exit(void* = nullptr);
+
     bool tick();
     void set_ticks_left(u32 t) { m_ticks_left = t; }
     u32 ticks_left() const { return m_ticks_left; }

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -1,0 +1,656 @@
+/*
+ * Copyright (c) 2020, The SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Kernel/FileSystem/FileDescription.h>
+#include <Kernel/Net/Socket.h>
+#include <Kernel/Process.h>
+#include <Kernel/Scheduler.h>
+#include <Kernel/Thread.h>
+
+namespace Kernel {
+
+bool Thread::Blocker::set_block_condition(Thread::BlockCondition& block_condition, void* data)
+{
+    ASSERT(!m_block_condition);
+    if (block_condition.add_blocker(*this, data)) {
+        m_block_condition = &block_condition;
+        m_block_data = data;
+        return true;
+    }
+    return false;
+}
+
+Thread::Blocker::~Blocker()
+{
+    ScopedSpinLock lock(m_lock);
+    if (m_block_condition)
+        m_block_condition->remove_blocker(*this, m_block_data);
+}
+
+void Thread::Blocker::begin_blocking(Badge<Thread>)
+{
+    ScopedSpinLock lock(m_lock);
+    ASSERT(!m_is_blocking);
+    ASSERT(!m_blocked_thread);
+    m_blocked_thread = Thread::current();
+    m_is_blocking = true;
+}
+
+auto Thread::Blocker::end_blocking(Badge<Thread>, bool did_timeout) -> BlockResult
+{
+    ScopedSpinLock lock(m_lock);
+    // if m_is_blocking is false here, some thread forced to
+    // unblock us when we get here. This is only called from the
+    // thread that was blocked.
+    ASSERT(Thread::current() == m_blocked_thread);
+    m_is_blocking = false;
+    m_blocked_thread = nullptr;
+
+    was_unblocked(did_timeout);
+    return block_result();
+}
+
+Thread::JoinBlocker::JoinBlocker(Thread& joinee, KResult& try_join_result, void*& joinee_exit_value)
+    : m_joinee(joinee)
+    , m_joinee_exit_value(joinee_exit_value)
+{
+    {
+        // We need to hold our lock to avoid a race where try_join succeeds
+        // but the joinee is joining immediately
+        ScopedSpinLock lock(m_lock);
+        try_join_result = joinee.try_join(*this);
+        m_join_error = try_join_result.is_error();
+    }
+    if (!set_block_condition(joinee.m_join_condition))
+        m_should_block = false;
+}
+
+void Thread::JoinBlocker::not_blocking(bool timeout_in_past)
+{
+    if (!m_should_block) {
+        // set_block_condition returned false, so unblock was already called
+        ASSERT(!timeout_in_past);
+        return;
+    }
+    // If we should have blocked but got here it must have been that the
+    // timeout was already in the past. So we need to ask the BlockCondition
+    // to supply us the information. We cannot hold the lock as unblock
+    // could be called by the BlockCondition at any time!
+    ASSERT(timeout_in_past);
+    m_joinee->m_join_condition.try_unblock(*this);
+}
+
+bool Thread::JoinBlocker::unblock(void* value, bool from_add_blocker)
+{
+    {
+        ScopedSpinLock lock(m_lock);
+        if (m_did_unblock)
+            return false;
+        m_did_unblock = true;
+        m_joinee_exit_value = value;
+        do_set_interrupted_by_death();
+    }
+
+    if (!from_add_blocker)
+        unblock_from_blocker();
+    return true;
+}
+
+Thread::FileDescriptionBlocker::FileDescriptionBlocker(FileDescription& description, BlockFlags flags, BlockFlags& unblocked_flags)
+    : m_blocked_description(description)
+    , m_flags(flags)
+    , m_unblocked_flags(unblocked_flags)
+{
+    m_unblocked_flags = BlockFlags::None;
+
+    if (!set_block_condition(description.block_condition()))
+        m_should_block = false;
+}
+
+bool Thread::FileDescriptionBlocker::unblock(bool from_add_blocker, void*)
+{
+    auto unblock_flags = m_blocked_description->should_unblock(m_flags);
+    if (unblock_flags == BlockFlags::None)
+        return false;
+
+    {
+        ScopedSpinLock lock(m_lock);
+        if (m_did_unblock)
+            return false;
+        m_did_unblock = true;
+        m_unblocked_flags = unblock_flags;
+    }
+
+    if (!from_add_blocker)
+        unblock_from_blocker();
+    return true;
+}
+
+void Thread::FileDescriptionBlocker::not_blocking(bool timeout_in_past)
+{
+    if (!m_should_block) {
+        // set_block_condition returned false, so unblock was already called
+        ASSERT(!timeout_in_past);
+        return;
+    }
+    // If we should have blocked but got here it must have been that the
+    // timeout was already in the past. So we need to ask the BlockCondition
+    // to supply us the information. We cannot hold the lock as unblock
+    // could be called by the BlockCondition at any time!
+    ASSERT(timeout_in_past);
+
+    // Just call unblock here because we will query the file description
+    // for the data and don't need any input from the FileBlockCondition.
+    // However, it's possible that if timeout_in_past is true then FileBlockCondition
+    // may call us at any given time, so our call to unblock here may fail.
+    // Either way, unblock will be called at least once, which provides
+    // all the data we need.
+    unblock(false, nullptr);
+}
+
+const FileDescription& Thread::FileDescriptionBlocker::blocked_description() const
+{
+    return m_blocked_description;
+}
+
+Thread::AcceptBlocker::AcceptBlocker(FileDescription& description, BlockFlags& unblocked_flags)
+    : FileDescriptionBlocker(description, (BlockFlags)((u32)BlockFlags::Accept | (u32)BlockFlags::Exception), unblocked_flags)
+{
+}
+
+Thread::ConnectBlocker::ConnectBlocker(FileDescription& description, BlockFlags& unblocked_flags)
+    : FileDescriptionBlocker(description, (BlockFlags)((u32)BlockFlags::Connect | (u32)BlockFlags::Exception), unblocked_flags)
+{
+}
+
+Thread::WriteBlocker::WriteBlocker(FileDescription& description, BlockFlags& unblocked_flags)
+    : FileDescriptionBlocker(description, (BlockFlags)((u32)BlockFlags::Write | (u32)BlockFlags::Exception), unblocked_flags)
+{
+}
+
+auto Thread::WriteBlocker::override_timeout(const BlockTimeout& timeout) -> const BlockTimeout&
+{
+    auto& description = blocked_description();
+    if (description.is_socket()) {
+        auto& socket = *description.socket();
+        if (socket.has_send_timeout()) {
+            m_timeout = BlockTimeout(false, &socket.send_timeout(), timeout.start_time());
+            if (timeout.is_infinite() || (!m_timeout.is_infinite() && m_timeout.absolute_time() < timeout.absolute_time()))
+                return m_timeout;
+        }
+    }
+    return timeout;
+}
+
+Thread::ReadBlocker::ReadBlocker(FileDescription& description, BlockFlags& unblocked_flags)
+    : FileDescriptionBlocker(description, (BlockFlags)((u32)BlockFlags::Read | (u32)BlockFlags::Exception), unblocked_flags)
+{
+}
+
+auto Thread::ReadBlocker::override_timeout(const BlockTimeout& timeout) -> const BlockTimeout&
+{
+    auto& description = blocked_description();
+    if (description.is_socket()) {
+        auto& socket = *description.socket();
+        if (socket.has_receive_timeout()) {
+            m_timeout = BlockTimeout(false, &socket.receive_timeout(), timeout.start_time());
+            if (timeout.is_infinite() || (!m_timeout.is_infinite() && m_timeout.absolute_time() < timeout.absolute_time()))
+                return m_timeout;
+        }
+    }
+    return timeout;
+}
+
+Thread::SleepBlocker::SleepBlocker(const BlockTimeout& deadline, timespec* remaining)
+    : m_deadline(deadline)
+    , m_remaining(remaining)
+{
+}
+
+auto Thread::SleepBlocker::override_timeout(const BlockTimeout& timeout) -> const BlockTimeout&
+{
+    ASSERT(timeout.is_infinite()); // A timeout should not be provided
+    // To simplify things only use the sleep deadline.
+    return m_deadline;
+}
+
+void Thread::SleepBlocker::not_blocking(bool timeout_in_past)
+{
+    // SleepBlocker::should_block should always return true, so timeout
+    // in the past is the only valid case when this function is called
+    ASSERT(timeout_in_past);
+    calculate_remaining();
+}
+
+void Thread::SleepBlocker::was_unblocked(bool did_timeout)
+{
+    Blocker::was_unblocked(did_timeout);
+
+    calculate_remaining();
+}
+
+void Thread::SleepBlocker::calculate_remaining()
+{
+    if (!m_remaining)
+        return;
+    auto time_now = TimeManagement::the().monotonic_time();
+    if (time_now < m_deadline.absolute_time())
+        timespec_sub(m_deadline.absolute_time(), time_now, *m_remaining);
+    else
+        *m_remaining = {};
+}
+
+Thread::BlockResult Thread::SleepBlocker::block_result()
+{
+    auto result = Blocker::block_result();
+    if (result == Thread::BlockResult::InterruptedByTimeout)
+        return Thread::BlockResult::WokeNormally;
+    return result;
+}
+
+Thread::SelectBlocker::SelectBlocker(FDVector& fds)
+    : m_fds(fds)
+{
+    for (auto& fd_entry : m_fds) {
+        fd_entry.unblocked_flags = FileBlocker::BlockFlags::None;
+
+        if (!m_should_block)
+            continue;
+        if (!fd_entry.description->block_condition().add_blocker(*this, &fd_entry))
+            m_should_block = false;
+        m_registered_count++;
+    }
+}
+
+Thread::SelectBlocker::~SelectBlocker()
+{
+    if (m_registered_count > 0) {
+        for (auto& fd_entry : m_fds) {
+            fd_entry.description->block_condition().remove_blocker(*this, &fd_entry);
+            if (--m_registered_count == 0)
+                break;
+        }
+    }
+}
+
+void Thread::SelectBlocker::not_blocking(bool timeout_in_past)
+{
+    // Either the timeout was in the past or we didn't add all blockers
+    ASSERT(timeout_in_past || !m_should_block);
+    ScopedSpinLock lock(m_lock);
+    if (!m_did_unblock) {
+        m_did_unblock = true;
+        if (!timeout_in_past) {
+            auto count = collect_unblocked_flags();
+            ASSERT(count > 0);
+        }
+    }
+}
+
+bool Thread::SelectBlocker::unblock(bool from_add_blocker, void* data)
+{
+    ASSERT(data); // data is a pointer to an entry in the m_fds vector
+    auto& fd_info = *static_cast<FDInfo*>(data);
+
+    {
+        ScopedSpinLock lock(m_lock);
+        if (m_did_unblock)
+            return false;
+
+        auto unblock_flags = fd_info.description->should_unblock(fd_info.block_flags);
+        if (unblock_flags == BlockFlags::None)
+            return false;
+
+        m_did_unblock = true;
+
+        // We need to store unblock_flags here, otherwise someone else
+        // affecting this file descriptor could change the information
+        // between now and when was_unblocked is called!
+        fd_info.unblocked_flags = unblock_flags;
+    }
+
+    // Only do this once for the first one
+    if (!from_add_blocker)
+        unblock_from_blocker();
+    return true;
+}
+
+size_t Thread::SelectBlocker::collect_unblocked_flags()
+{
+    size_t count = 0;
+    for (auto& fd_entry : m_fds) {
+        ASSERT(fd_entry.block_flags != FileBlocker::BlockFlags::None);
+
+        // unblock will have set at least the first descriptor's unblock
+        // flags that triggered the unblock. Make sure we don't discard that
+        // information as it may have changed by now!
+        if (fd_entry.unblocked_flags == FileBlocker::BlockFlags::None)
+            fd_entry.unblocked_flags = fd_entry.description->should_unblock(fd_entry.block_flags);
+
+        if (fd_entry.unblocked_flags != FileBlocker::BlockFlags::None)
+            count++;
+    }
+    return count;
+}
+
+void Thread::SelectBlocker::was_unblocked(bool did_timeout)
+{
+    Blocker::was_unblocked(did_timeout);
+    if (!did_timeout && !was_interrupted()) {
+        {
+            ScopedSpinLock lock(m_lock);
+            ASSERT(m_did_unblock);
+        }
+        size_t count = collect_unblocked_flags();
+        // If we were blocked and didn't time out, we should have at least one unblocked fd!
+        ASSERT(count > 0);
+    }
+}
+
+void Thread::WaitBlockCondition::try_unblock(Thread::WaitBlocker& blocker)
+{
+    ScopedSpinLock lock(m_lock);
+    // We if we have any processes pending
+    for (size_t i = 0; i < m_threads.size(); i++) {
+        auto& info = m_threads[i];
+        // We need to call unblock as if we were called from add_blocker
+        // so that we don't trigger a context switch by yielding!
+        if (info.was_waited && blocker.is_wait())
+            continue; // This state was already waited on, do not unblock
+        if (blocker.unblock(info.thread, info.flags, info.signal, true)) {
+            if (blocker.is_wait()) {
+                if (info.flags == Thread::WaitBlocker::UnblockFlags::Terminated)
+                    m_threads.remove(i);
+                else
+                    info.was_waited = true;
+            }
+            break;
+        }
+    }
+}
+
+bool Thread::WaitBlockCondition::unblock(Thread& thread, WaitBlocker::UnblockFlags flags, u8 signal)
+{
+    bool did_unblock_any = false;
+    bool did_wait = false;
+    bool was_waited_already = false;
+
+    ScopedSpinLock lock(m_lock);
+    if (m_finalized)
+        return false;
+    if (flags != WaitBlocker::UnblockFlags::Terminated) {
+        // First check if this state was already waited on
+        for (auto& info : m_threads) {
+            if (info.thread == &thread) {
+                was_waited_already = info.was_waited;
+                break;
+            }
+        }
+    }
+
+    do_unblock([&](Blocker& b, void*) {
+        ASSERT(b.blocker_type() == Blocker::Type::Wait);
+        auto& blocker = static_cast<WaitBlocker&>(b);
+        if (was_waited_already && blocker.is_wait())
+            return false; // This state was already waited on, do not unblock
+        if (blocker.unblock(thread, flags, signal, false)) {
+            did_wait |= blocker.is_wait(); // anyone requesting a wait
+            did_unblock_any = true;
+            return true;
+        }
+        return false;
+    });
+
+    // If no one has waited (yet), or this wasn't a wait, or if it's anything other than
+    // UnblockFlags::Terminated then add it to your list
+    if (!did_unblock_any || !did_wait || flags != WaitBlocker::UnblockFlags::Terminated) {
+        bool updated_existing = false;
+        for (auto& info : m_threads) {
+            if (info.thread == &thread) {
+                ASSERT(info.flags != WaitBlocker::UnblockFlags::Terminated);
+                info.flags = flags;
+                info.signal = signal;
+                info.was_waited = did_wait;
+                updated_existing = true;
+                break;
+            }
+        }
+        if (!updated_existing)
+            m_threads.append(ThreadBlockInfo(thread, flags, signal));
+    }
+    return did_unblock_any;
+}
+
+bool Thread::WaitBlockCondition::should_add_blocker(Blocker& b, void*)
+{
+    // NOTE: m_lock is held already!
+    if (m_finalized)
+        return false;
+    ASSERT(b.blocker_type() == Blocker::Type::Wait);
+    auto& blocker = static_cast<WaitBlocker&>(b);
+    // See if we can match any process immediately
+    for (size_t i = 0; i < m_threads.size(); i++) {
+        auto& info = m_threads[i];
+        if (blocker.unblock(info.thread, info.flags, info.signal, true)) {
+            // Only remove the entry if UnblockFlags::Terminated
+            if (info.flags == Thread::WaitBlocker::UnblockFlags::Terminated && blocker.is_wait())
+                m_threads.remove(i);
+            return false;
+        }
+    }
+    return true;
+}
+
+void Thread::WaitBlockCondition::finalize()
+{
+    ScopedSpinLock lock(m_lock);
+    ASSERT(!m_finalized);
+    m_finalized = true;
+
+    // Clear the list of threads here so we can drop the references to them
+    m_threads.clear();
+
+    // No more waiters, drop the last reference immediately. This may
+    // cause us to be destructed ourselves!
+    ASSERT(m_process.ref_count() > 0);
+    m_process.unref();
+}
+
+Thread::WaitBlocker::WaitBlocker(int wait_options, idtype_t id_type, pid_t id, KResultOr<siginfo_t>& result)
+    : m_wait_options(wait_options)
+    , m_id_type(id_type)
+    , m_waitee_id(id)
+    , m_result(result)
+    , m_should_block(!(m_wait_options & WNOHANG))
+{
+    switch (id_type) {
+    case P_PID: {
+        m_waitee = Process::from_pid(m_waitee_id);
+        if (!m_waitee || m_waitee->ppid() != Process::current()->pid()) {
+            m_result = KResult(-ECHILD);
+            m_error = true;
+            return;
+        }
+        break;
+    }
+    case P_PGID: {
+        m_waitee_group = ProcessGroup::from_pgid(m_waitee_id);
+        if (!m_waitee_group) {
+            m_result = KResult(-ECHILD);
+            m_error = true;
+            return;
+        }
+        break;
+    }
+    case P_ALL:
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+
+    // NOTE: unblock may be called within set_block_condition, in which
+    // case it means that we already have a match without having to block.
+    // In that case set_block_condition will return false.
+    if (m_error || !set_block_condition(Process::current()->wait_block_condition()))
+        m_should_block = false;
+}
+
+void Thread::WaitBlocker::not_blocking(bool timeout_in_past)
+{
+    ASSERT(timeout_in_past || !m_should_block);
+    if (!m_error)
+        Process::current()->wait_block_condition().try_unblock(*this);
+}
+
+void Thread::WaitBlocker::was_unblocked(bool)
+{
+    bool got_sigchld, try_unblock;
+    {
+        ScopedSpinLock lock(m_lock);
+        try_unblock = !m_did_unblock;
+        got_sigchld = m_got_sigchild;
+    }
+
+    if (try_unblock)
+        Process::current()->wait_block_condition().try_unblock(*this);
+
+    // If we were interrupted by SIGCHLD (which gets special handling
+    // here) we're not going to return with EINTR. But we're going to
+    // deliver SIGCHLD (only) here.
+    auto* current_thread = Thread::current();
+    if (got_sigchld && current_thread->state() != State::Stopped)
+        current_thread->try_dispatch_one_pending_signal(SIGCHLD);
+}
+
+void Thread::WaitBlocker::do_set_result(const siginfo_t& result)
+{
+    ASSERT(!m_did_unblock);
+    m_did_unblock = true;
+    m_result = result;
+
+    if (do_get_interrupted_by_signal() == SIGCHLD) {
+        // This makes it so that wait() will return normally despite the
+        // fact that SIGCHLD was delivered. Calling do_clear_interrupted_by_signal
+        // will disable dispatching signals in Thread::block and prevent
+        // it from returning with EINTR. We will then manually dispatch
+        // SIGCHLD (and only SIGCHLD) in was_unblocked.
+        m_got_sigchild = true;
+        do_clear_interrupted_by_signal();
+    }
+}
+
+bool Thread::WaitBlocker::unblock(Thread& thread, UnblockFlags flags, u8 signal, bool from_add_blocker)
+{
+    ASSERT(flags != UnblockFlags::Terminated || signal == 0); // signal argument should be ignored for Terminated
+
+    auto& process = thread.process();
+    switch (m_id_type) {
+    case P_PID:
+        ASSERT(m_waitee);
+        if (process.pid() != m_waitee_id && thread.tid() != m_waitee_id) // TODO: pid/tid
+            return false;
+        break;
+    case P_PGID:
+        ASSERT(m_waitee_group);
+        if (process.pgid() != m_waitee_group->pgid())
+            return false;
+        break;
+    case P_ALL:
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+
+    switch (flags) {
+    case UnblockFlags::Terminated:
+        if (!(m_wait_options & WEXITED))
+            return false;
+        break;
+    case UnblockFlags::Stopped:
+        if (!(m_wait_options & WSTOPPED))
+            return false;
+        if (!(m_wait_options & WUNTRACED) && !thread.is_traced())
+            return false;
+        break;
+    case UnblockFlags::Continued:
+        if (!(m_wait_options & WCONTINUED))
+            return false;
+        if (!(m_wait_options & WUNTRACED) && !thread.is_traced())
+            return false;
+        break;
+    }
+
+    if (flags == UnblockFlags::Terminated) {
+        ASSERT(process.is_dead());
+
+        ScopedSpinLock lock(m_lock);
+        if (m_did_unblock)
+            return false;
+        // Up until this point, this function may have been called
+        // more than once!
+        do_set_result(process.wait_info());
+    } else {
+        siginfo_t siginfo;
+        memset(&siginfo, 0, sizeof(siginfo));
+        {
+            ScopedSpinLock lock(g_scheduler_lock);
+            // We need to gather the information before we release the sheduler lock!
+            siginfo.si_signo = SIGCHLD;
+            siginfo.si_pid = thread.tid().value();
+            siginfo.si_uid = process.uid();
+            siginfo.si_status = signal;
+
+            switch (flags) {
+            case UnblockFlags::Terminated:
+                ASSERT_NOT_REACHED();
+            case UnblockFlags::Stopped:
+                siginfo.si_code = CLD_STOPPED;
+                break;
+            case UnblockFlags::Continued:
+                siginfo.si_code = CLD_CONTINUED;
+                break;
+            }
+        }
+
+        ScopedSpinLock lock(m_lock);
+        if (m_did_unblock)
+            return false;
+        // Up until this point, this function may have been called
+        // more than once!
+        do_set_result(siginfo);
+    }
+
+    if (!from_add_blocker) {
+        // Only call unblock if we weren't called from within set_block_condition!
+        unblock_from_blocker();
+    }
+    // Because this may be called from add_blocker, in which case we should
+    // not be actually trying to unblock the thread (because it hasn't actually
+    // been blocked yet), we need to return true anyway
+    return true;
+}
+
+}

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -46,11 +46,13 @@ public:
     static void initialize(u32 cpu);
     static TimeManagement& the();
 
+    static timespec ticks_to_time(u64 ticks, time_t ticks_per_second);
+    static u64 time_to_ticks(const timespec& tspec, time_t ticks_per_second);
+
+    timespec monotonic_time() const;
     timespec epoch_time() const;
     void set_epoch_time(timespec);
-    time_t seconds_since_boot() const;
     time_t ticks_per_second() const;
-    time_t ticks_this_second() const;
     time_t boot_time() const;
 
     bool is_system_timer(const HardwareTimerBase&) const;
@@ -60,6 +62,8 @@ public:
 
     static bool is_hpet_periodic_mode_allowed();
 
+    u64 uptime_ms() const;
+    u64 monotonic_ticks() const;
     static timeval now_as_timeval();
 
     timespec remaining_epoch_time_adjustment() const { return m_remaining_epoch_time_adjustment; }
@@ -72,11 +76,16 @@ private:
     Vector<HardwareTimerBase*> scan_for_non_periodic_timers();
     NonnullRefPtrVector<HardwareTimerBase> m_hardware_timers;
     void set_system_timer(HardwareTimerBase&);
+    static void timer_tick(const RegisterState&);
 
+    // Variables between m_update1 and m_update2 are synchronized
+    Atomic<u32> m_update1 { 0 };
     u32 m_ticks_this_second { 0 };
     u32 m_seconds_since_boot { 0 };
     timespec m_epoch_time { 0, 0 };
     timespec m_remaining_epoch_time_adjustment { 0, 0 };
+    Atomic<u32> m_update2 { 0 };
+
     RefPtr<HardwareTimerBase> m_system_timer;
     RefPtr<HardwareTimerBase> m_time_keeper_timer;
 };

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -71,6 +71,7 @@ enum {
 #define WSTOPPED WUNTRACED
 #define WEXITED 4
 #define WCONTINUED 8
+#define WNOWAIT 0x1000000
 
 #define R_OK 4
 #define W_OK 2
@@ -427,11 +428,12 @@ struct stat {
 };
 
 #define POLLIN (1u << 0)
-#define POLLPRI (1u << 2)
-#define POLLOUT (1u << 3)
-#define POLLERR (1u << 4)
-#define POLLHUP (1u << 5)
-#define POLLNVAL (1u << 6)
+#define POLLPRI (1u << 1)
+#define POLLOUT (1u << 2)
+#define POLLERR (1u << 3)
+#define POLLHUP (1u << 4)
+#define POLLNVAL (1u << 5)
+#define POLLRDHUP (1u << 13)
 
 struct pollfd {
     int fd;

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -86,7 +86,7 @@ u32 __stack_chk_guard;
 
 namespace Kernel {
 
-[[noreturn]] static void init_stage2();
+[[noreturn]] static void init_stage2(void*);
 static void setup_serial_debug();
 
 // boot.S expects these functions precisely this this. We declare them here
@@ -168,7 +168,7 @@ extern "C" [[noreturn]] void init()
 
     {
         RefPtr<Thread> init_stage2_thread;
-        Process::create_kernel_process(init_stage2_thread, "init_stage2", init_stage2);
+        Process::create_kernel_process(init_stage2_thread, "init_stage2", init_stage2, nullptr);
         // We need to make sure we drop the reference for init_stage2_thread
         // before calling into Scheduler::start, otherwise we will have a
         // dangling Thread that never gets cleaned up
@@ -210,7 +210,7 @@ extern "C" void init_finished(u32 cpu)
     }
 }
 
-void init_stage2()
+void init_stage2(void*)
 {
     if (APIC::initialized() && APIC::the().enabled_processor_count() > 1) {
         // We can't start the APs until we have a scheduler up and running.

--- a/Libraries/LibC/poll.h
+++ b/Libraries/LibC/poll.h
@@ -32,11 +32,12 @@
 __BEGIN_DECLS
 
 #define POLLIN (1u << 0)
-#define POLLPRI (1u << 2)
-#define POLLOUT (1u << 3)
-#define POLLERR (1u << 4)
-#define POLLHUP (1u << 5)
-#define POLLNVAL (1u << 6)
+#define POLLPRI (1u << 1)
+#define POLLOUT (1u << 2)
+#define POLLERR (1u << 3)
+#define POLLHUP (1u << 4)
+#define POLLNVAL (1u << 5)
+#define POLLRDHUP (1u << 13)
 
 struct pollfd {
     int fd;

--- a/Libraries/LibC/sys/wait.h
+++ b/Libraries/LibC/sys/wait.h
@@ -44,6 +44,7 @@ __BEGIN_DECLS
 #define WSTOPPED WUNTRACED
 #define WEXITED 4
 #define WCONTINUED 8
+#define WNOWAIT 0x1000000
 
 typedef enum {
     P_ALL = 1,

--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -584,7 +584,7 @@ retry:
             now.tv_sec = now_spec.tv_sec;
             now.tv_usec = now_spec.tv_nsec / 1000;
             timeval_sub(next_timer_expiration.value(), now, timeout);
-            if (timeout.tv_sec < 0) {
+            if (timeout.tv_sec < 0 || (timeout.tv_sec == 0 && timeout.tv_usec < 0)) {
                 timeout.tv_sec = 0;
                 timeout.tv_usec = 0;
             }


### PR DESCRIPTION
_This gets us another step closer to being able to make progress with #3864._

This makes the Scheduler a lot leaner by not having to evaluate
block conditions every time it is invoked. Instead evaluate them as
the states change, and unblock threads at that point.

- [x] Fix the various bugs that keep things from working
- [x] Figure out why Terminal only shows a "%" and doesn't accept input
- [x] Fix stopping/resuming processes
- [x] Fix g++ not exiting in HackStudio (`ReadBlocker` not unblocking)
- [x] Fix strace hanging (some problems with `WaitBlocker` and signal delivery/handling)
- [x] Validate that the 9p file system driver is still working
- [x] Reap unwaited child processes (zombies) when the parent exits