### PR TITLE
LibCore: Rename identifiers that can clash with libc macros

### DIFF
--- a/Libraries/LibCore/File.cpp
+++ b/Libraries/LibCore/File.cpp
@@ -241,7 +241,7 @@ static RefPtr<File> stdin_file;
 static RefPtr<File> stdout_file;
 static RefPtr<File> stderr_file;
 
-NonnullRefPtr<File> File::stdin()
+NonnullRefPtr<File> File::standard_input()
 {
     if (!stdin_file) {
         stdin_file = File::construct();
@@ -250,7 +250,7 @@ NonnullRefPtr<File> File::stdin()
     return *stdin_file;
 }
 
-NonnullRefPtr<File> File::stdout()
+NonnullRefPtr<File> File::standard_output()
 {
     if (!stdout_file) {
         stdout_file = File::construct();
@@ -259,7 +259,7 @@ NonnullRefPtr<File> File::stdout()
     return *stdout_file;
 }
 
-NonnullRefPtr<File> File::stderr()
+NonnullRefPtr<File> File::standard_error()
 {
     if (!stderr_file) {
         stderr_file = File::construct();

--- a/Libraries/LibCore/File.h
+++ b/Libraries/LibCore/File.h
@@ -58,9 +58,9 @@ public:
     };
     bool open(int fd, IODevice::OpenMode, ShouldCloseFileDescriptor);
 
-    static NonnullRefPtr<File> stdin();
-    static NonnullRefPtr<File> stdout();
-    static NonnullRefPtr<File> stderr();
+    static NonnullRefPtr<File> standard_input();
+    static NonnullRefPtr<File> standard_output();
+    static NonnullRefPtr<File> standard_error();
 
 private:
     File(Object* parent = nullptr)

--- a/Libraries/LibCore/FileStream.h
+++ b/Libraries/LibCore/FileStream.h
@@ -128,14 +128,14 @@ public:
         return Buffered<OutputFileStream> { file_result.value() };
     }
 
-    static OutputFileStream stdout()
+    static OutputFileStream standard_output()
     {
-        return OutputFileStream { Core::File::stdout() };
+        return OutputFileStream { Core::File::standard_output() };
     }
 
     static Buffered<OutputFileStream> stdout_buffered()
     {
-        return Buffered<OutputFileStream> { Core::File::stdout() };
+        return Buffered<OutputFileStream> { Core::File::standard_output() };
     }
 
     size_t write(ReadonlyBytes bytes) override

--- a/Services/ChessEngine/main.cpp
+++ b/Services/ChessEngine/main.cpp
@@ -44,6 +44,6 @@ int main()
         return 1;
     }
 
-    auto engine = ChessEngine::construct(Core::File::stdin(), Core::File::stdout());
+    auto engine = ChessEngine::construct(Core::File::standard_input(), Core::File::standard_output());
     return loop.exec();
 }

--- a/Userland/grep.cpp
+++ b/Userland/grep.cpp
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
     };
 
     if (!files.size() && !recursive) {
-        auto stdin_file = Core::File::stdin();
+        auto stdin_file = Core::File::standard_input();
         for (;;) {
             auto line = stdin_file->read_line();
             bool is_binary = line.bytes().contains_slow(0);

--- a/Userland/hexdump.cpp
+++ b/Userland/hexdump.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv)
     RefPtr<Core::File> file;
 
     if (!path) {
-        file = Core::File::stdin();
+        file = Core::File::standard_input();
     } else {
         auto file_or_error = Core::File::open(path, Core::File::ReadOnly);
         if (file_or_error.is_error()) {

--- a/Userland/tar.cpp
+++ b/Userland/tar.cpp
@@ -62,7 +62,7 @@ int main(int argc, char** argv)
     }
 
     if (list || extract) {
-        auto file = Core::File::stdin();
+        auto file = Core::File::standard_input();
 
         if (archive_file) {
             auto maybe_file = Core::File::open(archive_file, Core::IODevice::OpenMode::ReadOnly);


### PR DESCRIPTION
POSIX allows these default streams to be macros, which means that on
such systems (musl libc is one) building Lagom will fail due to the
File::stdin() functions. Undefining them at the top of the file is
enough to fix it.