### PR TITLE
MACAddress: Use all_of to implement is_zero

### DIFF
--- a/AK/AllOf.h
+++ b/AK/AllOf.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace AK {
+
+constexpr bool all_of(const auto& begin, const auto& end, const auto& predicate)
+{
+    for (auto iter = begin; iter != end; ++iter) {
+        if (!predicate(*iter)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}

--- a/AK/MACAddress.h
+++ b/AK/MACAddress.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/AllOf.h>
 #include <AK/Array.h>
 #include <AK/Assertions.h>
 #include <AK/String.h>
@@ -79,7 +80,7 @@ public:
 
     constexpr bool is_zero() const
     {
-        return m_data[0] == 0 && m_data[1] == 0 && m_data[2] == 0 && m_data[3] == 0 && m_data[4] == 0 && m_data[5] == 0;
+        return AK::all_of(m_data.begin(), m_data.end(), [](const auto octet) { return octet == 0; });
     }
 
 private:

--- a/AK/Tests/TestAllOf.cpp
+++ b/AK/Tests/TestAllOf.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/AllOf.h>
+#include <AK/Array.h>
+
+TEST_CASE(should_determine_if_predicate_applies_to_all_elements_in_container)
+{
+    constexpr AK::Array<int, 10> a {};
+
+    static_assert(AK::all_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
+    static_assert(!AK::all_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
+
+    EXPECT(AK::all_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
+    EXPECT(!AK::all_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
+}
+
+TEST_MAIN(AllOf)


### PR DESCRIPTION
Problem:
- `is_zero()` is implemented by checking each value in the array by
  hand. This is error-prone and less expressive than using an
  algorithm.

Solution:
- Implement `is_zero()` in terms of `all_of`.