### PR TITLE
fd passing and unveil('b')

### DIFF
--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -66,7 +66,7 @@ public:
         GenericLexer lexer { pattern };
 
         while (!lexer.is_eof()) {
-            // FIXME: It is a bit inconvinient, that 'consume_until' also consumes the 'stop' character, this makes
+            // FIXME: It is a bit inconvenient, that 'consume_until' also consumes the 'stop' character, this makes
             //        the method less generic because there is no way to check if the 'stop' character ever appeared.
             const auto consume_until_without_consuming_stop_character = [&](char stop) {
                 return lexer.consume_while([&](char ch) { return ch != stop; });

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -447,6 +447,16 @@ public:
         m_size += other_size;
     }
 
+    void prepend(const T* values, size_t count)
+    {
+        if (!count)
+            return;
+        grow_capacity(size() + count);
+        TypedTransfer<T>::move(slot(count), slot(0), m_size);
+        TypedTransfer<T>::copy(slot(0), values, count);
+        m_size += count;
+    }
+
     void append(const T* values, size_t count)
     {
         if (!count)

--- a/Base/usr/share/man/man2/unveil.md
+++ b/Base/usr/share/man/man2/unveil.md
@@ -28,6 +28,7 @@ include the following characters:
 * `w`: May write to a file at this path
 * `x`: May execute a program image at this path
 * `c`: May create or remove a file at this path
+* `b`: May browse directories at this path
 
 A single `unveil()` call may specify multiple permission characters at once.
 Subsequent `unveil()` calls may take away permissions from the ones allowed
@@ -77,6 +78,9 @@ unveil("/etc/WindowServer/WindowServer.ini", "rwc");
 
 // Allow the process to execute Calendar:
 unveil("/bin/Calendar", "x");
+
+// Allow the process to browse files from /usr/share:
+unveil("/usr/share", "b");
 
 // Disallow any further veil manipulation:
 unveil(nullptr, nullptr);

--- a/DevTools/HackStudio/LanguageClient.cpp
+++ b/DevTools/HackStudio/LanguageClient.cpp
@@ -36,9 +36,9 @@ void ServerConnection::handle(const Messages::LanguageClient::AutoCompleteSugges
         m_language_client->provide_autocomplete_suggestions(message.suggestions());
 }
 
-void LanguageClient::open_file(const String& path)
+void LanguageClient::open_file(const String& path, int fd)
 {
-    m_connection.post_message(Messages::LanguageServer::FileOpened(path));
+    m_connection.post_message(Messages::LanguageServer::FileOpened(path, fd));
 }
 
 void LanguageClient::set_file_content(const String& path, const String& content)

--- a/DevTools/HackStudio/LanguageClients/ServerConnections.h
+++ b/DevTools/HackStudio/LanguageClients/ServerConnections.h
@@ -32,16 +32,16 @@
 #include <DevTools/HackStudio/LanguageServers/LanguageServerEndpoint.h>
 #include <LibIPC/ServerConnection.h>
 
-#define LANGUAGE_CLIENT(namespace_, socket_name)                                               \
-    namespace namespace_ {                                                                     \
-    class ServerConnection : public HackStudio::ServerConnection {                             \
-        C_OBJECT(ServerConnection)                                                             \
-    private:                                                                                   \
-        ServerConnection(const String& project_path)                                           \
-            : HackStudio::ServerConnection("/tmp/portal/language/" #socket_name, project_path) \
-        {                                                                                      \
-        }                                                                                      \
-    };                                                                                         \
+#define LANGUAGE_CLIENT(namespace_, socket_name)                                 \
+    namespace namespace_ {                                                       \
+    class ServerConnection : public HackStudio::ServerConnection {               \
+        C_OBJECT(ServerConnection)                                               \
+    private:                                                                     \
+        ServerConnection()                                                       \
+            : HackStudio::ServerConnection("/tmp/portal/language/" #socket_name) \
+        {                                                                        \
+        }                                                                        \
+    };                                                                           \
     }
 
 namespace LanguageClients {

--- a/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.cpp
+++ b/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.cpp
@@ -53,12 +53,8 @@ void ClientConnection::die()
     exit(0);
 }
 
-OwnPtr<Messages::LanguageServer::GreetResponse> ClientConnection::handle(const Messages::LanguageServer::Greet& message)
+OwnPtr<Messages::LanguageServer::GreetResponse> ClientConnection::handle(const Messages::LanguageServer::Greet&)
 {
-    m_project_root = LexicalPath(message.project_root());
-#ifdef DEBUG_CPP_LANGUAGE_SERVER
-    dbgln("project_root: {}", m_project_root);
-#endif
     return make<Messages::LanguageServer::GreetResponse>(client_id());
 }
 
@@ -81,16 +77,11 @@ static DefaultDocumentClient s_default_document_client;
 
 void ClientConnection::handle(const Messages::LanguageServer::FileOpened& message)
 {
-    LexicalPath file_path(String::formatted("{}/{}", m_project_root, message.file_name()));
-#ifdef DEBUG_CPP_LANGUAGE_SERVER
-    dbgln("FileOpened: {}", file_path);
-#endif
-
-    auto file = Core::File::construct(file_path.string());
-    if (!file->open(Core::IODevice::ReadOnly)) {
+    auto file = Core::File::construct(this);
+    if (!file->open(message.file().fd(), Core::IODevice::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes)) {
         errno = file->error();
         perror("open");
-        dbgln("Failed to open project file: {}", file_path);
+        dbgln("Failed to open project file");
         return;
     }
     auto content = file->read_all();

--- a/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
+++ b/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
@@ -58,7 +58,6 @@ private:
 
     RefPtr<GUI::TextDocument> document_for(const String& file_name);
 
-    LexicalPath m_project_root;
     HashMap<String, NonnullRefPtr<GUI::TextDocument>> m_open_files;
 };
 

--- a/DevTools/HackStudio/LanguageServers/Cpp/main.cpp
+++ b/DevTools/HackStudio/LanguageServers/Cpp/main.cpp
@@ -36,15 +36,19 @@
 int main(int, char**)
 {
     Core::EventLoop event_loop;
-    if (pledge("stdio unix rpath", nullptr) < 0) {
+    if (pledge("stdio unix recvfd", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
 
     auto socket = Core::LocalSocket::take_over_accepted_socket_from_system_server();
     IPC::new_client_connection<LanguageServers::Cpp::ClientConnection>(socket.release_nonnull(), 1);
-    if (pledge("stdio rpath", nullptr) < 0) {
+    if (pledge("stdio recvfd", nullptr) < 0) {
         perror("pledge");
+        return 1;
+    }
+    if (unveil(nullptr, nullptr) < 0) {
+        perror("unveil");
         return 1;
     }
     return event_loop.exec();

--- a/DevTools/HackStudio/LanguageServers/LanguageServer.ipc
+++ b/DevTools/HackStudio/LanguageServers/LanguageServer.ipc
@@ -1,8 +1,8 @@
 endpoint LanguageServer = 8001
 {
-    Greet(String project_root) => (i32 client_id)
+    Greet() => (i32 client_id)
 
-    FileOpened(String file_name) =|
+    FileOpened(String file_name, IPC::File file) =|
     FileEditInsertText(String file_name, String text, i32 start_line, i32 start_column) =|
     FileEditRemoveText(String file_name, i32 start_line, i32 start_column, i32 end_line, i32 end_column) =|
     SetFileContent(String file_name, String content) =|

--- a/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.h
+++ b/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.h
@@ -59,7 +59,6 @@ private:
 
     RefPtr<GUI::TextDocument> document_for(const String& file_name);
 
-    LexicalPath m_project_root;
     HashMap<String, NonnullRefPtr<GUI::TextDocument>> m_open_files;
 
     AutoComplete m_autocomplete;

--- a/DevTools/HackStudio/main.cpp
+++ b/DevTools/HackStudio/main.cpp
@@ -59,14 +59,14 @@ static void open_default_project_file(const String& project_path);
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio tty accept rpath cpath wpath shared_buffer proc exec unix fattr thread unix", nullptr) < 0) {
+    if (pledge("stdio tty accept rpath cpath wpath shared_buffer proc exec unix fattr thread unix sendfd", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
 
     auto app = GUI::Application::construct(argc, argv);
 
-    if (pledge("stdio tty accept rpath cpath wpath shared_buffer proc exec fattr thread unix", nullptr) < 0) {
+    if (pledge("stdio tty accept rpath cpath wpath shared_buffer proc exec fattr thread unix sendfd", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/DevTools/IPCCompiler/main.cpp
+++ b/DevTools/IPCCompiler/main.cpp
@@ -217,6 +217,7 @@ int main(int argc, char** argv)
 #include <LibIPC/Dictionary.h>
 #include <LibIPC/Encoder.h>
 #include <LibIPC/Endpoint.h>
+#include <LibIPC/File.h>
 #include <LibIPC/Message.h>
 )~~~");
 
@@ -318,9 +319,9 @@ public:
     static i32 static_message_id() { return (int)MessageID::@message.name@; }
     virtual const char* message_name() const override { return "@endpoint.name@::@message.name@"; }
 
-    static OwnPtr<@message.name@> decode(InputMemoryStream& stream)
+    static OwnPtr<@message.name@> decode(InputMemoryStream& stream, int sockfd)
     {
-        IPC::Decoder decoder { stream };
+        IPC::Decoder decoder { stream, sockfd };
 )~~~");
 
             for (auto& parameter : parameters) {
@@ -436,7 +437,7 @@ public:
     static String static_name() { return "@endpoint.name@"; }
     virtual String name() const override { return "@endpoint.name@"; }
 
-    static OwnPtr<IPC::Message> decode_message(const ByteBuffer& buffer)
+    static OwnPtr<IPC::Message> decode_message(const ByteBuffer& buffer, int sockfd)
     {
         InputMemoryStream stream { buffer };
         i32 message_endpoint_magic = 0;
@@ -488,7 +489,7 @@ public:
 
                 message_generator.append(R"~~~(
         case (int)Messages::@endpoint.name@::MessageID::@message.name@:
-            message = Messages::@endpoint.name@::@message.name@::decode(stream);
+            message = Messages::@endpoint.name@::@message.name@::decode(stream, sockfd);
             break;
 )~~~");
             };

--- a/DevTools/IPCCompiler/main.cpp
+++ b/DevTools/IPCCompiler/main.cpp
@@ -318,9 +318,9 @@ public:
     static i32 static_message_id() { return (int)MessageID::@message.name@; }
     virtual const char* message_name() const override { return "@endpoint.name@::@message.name@"; }
 
-    static OwnPtr<@message.name@> decode(InputMemoryStream& stream, size_t& size_in_bytes)
+    static OwnPtr<@message.name@> decode(InputMemoryStream& stream)
     {
-        IPC::Decoder decoder {stream};
+        IPC::Decoder decoder { stream };
 )~~~");
 
             for (auto& parameter : parameters) {
@@ -359,7 +359,6 @@ public:
             message_generator.set("message.constructor_call_parameters", builder.build());
 
             message_generator.append(R"~~~(
-        size_in_bytes = stream.offset();
         return make<@message.name@>(@message.constructor_call_parameters@);
     }
 )~~~");
@@ -437,7 +436,7 @@ public:
     static String static_name() { return "@endpoint.name@"; }
     virtual String name() const override { return "@endpoint.name@"; }
 
-    static OwnPtr<IPC::Message> decode_message(const ByteBuffer& buffer, size_t& size_in_bytes)
+    static OwnPtr<IPC::Message> decode_message(const ByteBuffer& buffer)
     {
         InputMemoryStream stream { buffer };
         i32 message_endpoint_magic = 0;
@@ -489,7 +488,7 @@ public:
 
                 message_generator.append(R"~~~(
         case (int)Messages::@endpoint.name@::MessageID::@message.name@:
-            message = Messages::@endpoint.name@::@message.name@::decode(stream, size_in_bytes);
+            message = Messages::@endpoint.name@::@message.name@::decode(stream);
             break;
 )~~~");
             };

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -644,6 +644,8 @@ static Optional<KBuffer> procfs$pid_unveil(InodeIdentifier identifier)
             permissions_builder.append('x');
         if (unveiled_path.permissions & UnveiledPath::Access::CreateOrRemove)
             permissions_builder.append('c');
+        if (unveiled_path.permissions & UnveiledPath::Access::Browse)
+            permissions_builder.append('b');
         obj.add("permissions", permissions_builder.to_string());
     }
     array.finish();

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -101,6 +101,7 @@ struct UnveiledPath {
         Write = 2,
         Execute = 4,
         CreateOrRemove = 8,
+        Browse = 16,
     };
 
     String path;

--- a/Kernel/Syscalls/unveil.cpp
+++ b/Kernel/Syscalls/unveil.cpp
@@ -49,7 +49,7 @@ int Process::sys$unveil(Userspace<const Syscall::SC_unveil_params*> user_params)
     if (!params.path.characters || !params.permissions.characters)
         return -EINVAL;
 
-    if (params.permissions.length > 4)
+    if (params.permissions.length > 5)
         return -EINVAL;
 
     auto path = get_syscall_path_argument(params.path);
@@ -78,6 +78,9 @@ int Process::sys$unveil(Userspace<const Syscall::SC_unveil_params*> user_params)
             break;
         case 'c':
             new_permissions |= UnveiledPath::Access::CreateOrRemove;
+            break;
+        case 'b':
+            new_permissions |= UnveiledPath::Access::Browse;
             break;
         default:
             return -EINVAL;

--- a/Libraries/LibIPC/Decoder.cpp
+++ b/Libraries/LibIPC/Decoder.cpp
@@ -28,6 +28,9 @@
 #include <AK/URL.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Dictionary.h>
+#include <LibIPC/File.h>
+#include <string.h>
+#include <sys/socket.h>
 
 namespace IPC {
 
@@ -161,6 +164,23 @@ bool Decoder::decode(Dictionary& dictionary)
     }
 
     return true;
+}
+
+bool Decoder::decode(File& file)
+{
+#ifdef __serenity__
+    int fd = recvfd(m_sockfd);
+    if (fd < 0) {
+        dbgln("recvfd: {}", strerror(errno));
+        return false;
+    }
+    file = File(fd);
+    return true;
+#else
+    (void)file;
+    warnln("fd passing is not supported on this platform, sorry :(");
+    return false;
+#endif
 }
 
 }

--- a/Libraries/LibIPC/Decoder.h
+++ b/Libraries/LibIPC/Decoder.h
@@ -44,8 +44,9 @@ inline bool decode(Decoder&, T&)
 
 class Decoder {
 public:
-    explicit Decoder(InputMemoryStream& stream)
+    Decoder(InputMemoryStream& stream, int sockfd)
         : m_stream(stream)
+        , m_sockfd(sockfd)
     {
     }
 
@@ -63,6 +64,7 @@ public:
     bool decode(ByteBuffer&);
     bool decode(URL&);
     bool decode(Dictionary&);
+    bool decode(File&);
     template<typename K, typename V>
     bool decode(HashMap<K, V>& hashmap)
     {
@@ -124,6 +126,7 @@ public:
 
 private:
     InputMemoryStream& m_stream;
+    int m_sockfd { -1 };
 };
 
 }

--- a/Libraries/LibIPC/Encoder.cpp
+++ b/Libraries/LibIPC/Encoder.cpp
@@ -29,6 +29,7 @@
 #include <AK/URL.h>
 #include <LibIPC/Dictionary.h>
 #include <LibIPC/Encoder.h>
+#include <LibIPC/File.h>
 
 namespace IPC {
 
@@ -39,77 +40,77 @@ Encoder& Encoder::operator<<(bool value)
 
 Encoder& Encoder::operator<<(u8 value)
 {
-    m_buffer.append(value);
+    m_buffer.data.append(value);
     return *this;
 }
 
 Encoder& Encoder::operator<<(u16 value)
 {
-    m_buffer.ensure_capacity(m_buffer.size() + 2);
-    m_buffer.unchecked_append((u8)value);
-    m_buffer.unchecked_append((u8)(value >> 8));
+    m_buffer.data.ensure_capacity(m_buffer.data.size() + 2);
+    m_buffer.data.unchecked_append((u8)value);
+    m_buffer.data.unchecked_append((u8)(value >> 8));
     return *this;
 }
 
 Encoder& Encoder::operator<<(u32 value)
 {
-    m_buffer.ensure_capacity(m_buffer.size() + 4);
-    m_buffer.unchecked_append((u8)value);
-    m_buffer.unchecked_append((u8)(value >> 8));
-    m_buffer.unchecked_append((u8)(value >> 16));
-    m_buffer.unchecked_append((u8)(value >> 24));
+    m_buffer.data.ensure_capacity(m_buffer.data.size() + 4);
+    m_buffer.data.unchecked_append((u8)value);
+    m_buffer.data.unchecked_append((u8)(value >> 8));
+    m_buffer.data.unchecked_append((u8)(value >> 16));
+    m_buffer.data.unchecked_append((u8)(value >> 24));
     return *this;
 }
 
 Encoder& Encoder::operator<<(u64 value)
 {
-    m_buffer.ensure_capacity(m_buffer.size() + 8);
-    m_buffer.unchecked_append((u8)value);
-    m_buffer.unchecked_append((u8)(value >> 8));
-    m_buffer.unchecked_append((u8)(value >> 16));
-    m_buffer.unchecked_append((u8)(value >> 24));
-    m_buffer.unchecked_append((u8)(value >> 32));
-    m_buffer.unchecked_append((u8)(value >> 40));
-    m_buffer.unchecked_append((u8)(value >> 48));
-    m_buffer.unchecked_append((u8)(value >> 56));
+    m_buffer.data.ensure_capacity(m_buffer.data.size() + 8);
+    m_buffer.data.unchecked_append((u8)value);
+    m_buffer.data.unchecked_append((u8)(value >> 8));
+    m_buffer.data.unchecked_append((u8)(value >> 16));
+    m_buffer.data.unchecked_append((u8)(value >> 24));
+    m_buffer.data.unchecked_append((u8)(value >> 32));
+    m_buffer.data.unchecked_append((u8)(value >> 40));
+    m_buffer.data.unchecked_append((u8)(value >> 48));
+    m_buffer.data.unchecked_append((u8)(value >> 56));
     return *this;
 }
 
 Encoder& Encoder::operator<<(i8 value)
 {
-    m_buffer.append((u8)value);
+    m_buffer.data.append((u8)value);
     return *this;
 }
 
 Encoder& Encoder::operator<<(i16 value)
 {
-    m_buffer.ensure_capacity(m_buffer.size() + 2);
-    m_buffer.unchecked_append((u8)value);
-    m_buffer.unchecked_append((u8)(value >> 8));
+    m_buffer.data.ensure_capacity(m_buffer.data.size() + 2);
+    m_buffer.data.unchecked_append((u8)value);
+    m_buffer.data.unchecked_append((u8)(value >> 8));
     return *this;
 }
 
 Encoder& Encoder::operator<<(i32 value)
 {
-    m_buffer.ensure_capacity(m_buffer.size() + 4);
-    m_buffer.unchecked_append((u8)value);
-    m_buffer.unchecked_append((u8)(value >> 8));
-    m_buffer.unchecked_append((u8)(value >> 16));
-    m_buffer.unchecked_append((u8)(value >> 24));
+    m_buffer.data.ensure_capacity(m_buffer.data.size() + 4);
+    m_buffer.data.unchecked_append((u8)value);
+    m_buffer.data.unchecked_append((u8)(value >> 8));
+    m_buffer.data.unchecked_append((u8)(value >> 16));
+    m_buffer.data.unchecked_append((u8)(value >> 24));
     return *this;
 }
 
 Encoder& Encoder::operator<<(i64 value)
 {
-    m_buffer.ensure_capacity(m_buffer.size() + 8);
-    m_buffer.unchecked_append((u8)value);
-    m_buffer.unchecked_append((u8)(value >> 8));
-    m_buffer.unchecked_append((u8)(value >> 16));
-    m_buffer.unchecked_append((u8)(value >> 24));
-    m_buffer.unchecked_append((u8)(value >> 32));
-    m_buffer.unchecked_append((u8)(value >> 40));
-    m_buffer.unchecked_append((u8)(value >> 48));
-    m_buffer.unchecked_append((u8)(value >> 56));
+    m_buffer.data.ensure_capacity(m_buffer.data.size() + 8);
+    m_buffer.data.unchecked_append((u8)value);
+    m_buffer.data.unchecked_append((u8)(value >> 8));
+    m_buffer.data.unchecked_append((u8)(value >> 16));
+    m_buffer.data.unchecked_append((u8)(value >> 24));
+    m_buffer.data.unchecked_append((u8)(value >> 32));
+    m_buffer.data.unchecked_append((u8)(value >> 40));
+    m_buffer.data.unchecked_append((u8)(value >> 48));
+    m_buffer.data.unchecked_append((u8)(value >> 56));
     return *this;
 }
 
@@ -130,7 +131,7 @@ Encoder& Encoder::operator<<(const char* value)
 
 Encoder& Encoder::operator<<(const StringView& value)
 {
-    m_buffer.append((const u8*)value.characters_without_null_termination(), value.length());
+    m_buffer.data.append((const u8*)value.characters_without_null_termination(), value.length());
     return *this;
 }
 
@@ -145,7 +146,7 @@ Encoder& Encoder::operator<<(const String& value)
 Encoder& Encoder::operator<<(const ByteBuffer& value)
 {
     *this << static_cast<i32>(value.size());
-    m_buffer.append(value.data(), value.size());
+    m_buffer.data.append(value.data(), value.size());
     return *this;
 }
 
@@ -160,6 +161,12 @@ Encoder& Encoder::operator<<(const Dictionary& dictionary)
     dictionary.for_each_entry([this](auto& key, auto& value) {
         *this << key << value;
     });
+    return *this;
+}
+
+Encoder& Encoder::operator<<(const File& file)
+{
+    m_buffer.fds.append(file.fd());
     return *this;
 }
 

--- a/Libraries/LibIPC/Encoder.h
+++ b/Libraries/LibIPC/Encoder.h
@@ -61,6 +61,7 @@ public:
     Encoder& operator<<(const ByteBuffer&);
     Encoder& operator<<(const URL&);
     Encoder& operator<<(const Dictionary&);
+    Encoder& operator<<(const File&);
     template<typename K, typename V>
     Encoder& operator<<(const HashMap<K, V>& hashmap)
     {

--- a/Libraries/LibIPC/File.h
+++ b/Libraries/LibIPC/File.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, Sergey Bugaev <bugaevc@serenityos.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,10 +28,22 @@
 
 namespace IPC {
 
-class Decoder;
-class Dictionary;
-class Encoder;
-class Message;
-class File;
+class File {
+public:
+    // Must have a default constructor, because LibIPC
+    // default-constructs arguments prior to decoding them.
+    File() { }
+
+    // Intentionally not `explicit`.
+    File(int fd)
+        : m_fd(fd)
+    {
+    }
+
+    int fd() const { return m_fd; }
+
+private:
+    int m_fd { -1 };
+};
 
 }

--- a/Libraries/LibIPC/Message.h
+++ b/Libraries/LibIPC/Message.h
@@ -30,7 +30,10 @@
 
 namespace IPC {
 
-typedef Vector<u8, 1024> MessageBuffer;
+struct MessageBuffer {
+    Vector<u8, 1024> data;
+    Vector<int> fds;
+};
 
 class Message {
 public:


### PR DESCRIPTION
* Prepend IPC messages with their sizes to make dealing with partial messages a little bit less involved
* `IPC::File` lets you easily pass an open fd over IPC (https://github.com/SerenityOS/serenity/issues/3643, cc @itamar8910)
    * I went with a real type instead of introducing a magical `fd` specifier
    * Using an `IPC::` type instead of say LibC's `FILE` seems more in line with other LibIPC types, and keeps the wrapper very thin (`IPC::File` is *just* a wrapper over an fd, it does not imply anything else). But I'm certainly open to arguments here :slightly_smiling_face:
* Use it in HackStudio language servers (as discussed in https://github.com/SerenityOS/serenity/issues/3643)
    * This means the C++ language server no longer needs any FS access :tada:
    * But the Shell language server wants to complete file paths
        * Add `unveil('b')` permission that lets you just browse directories, but not read any non-directories. To be exact, you can `open(O_RDONLY | O_DIRECTORY)` with *either* `r` or `b`, but the `open()` call will fail with `ENOTDIR` if it's not a directory because of `O_DIRECTORY`.
        * Use that in the Shell language server to browse (but not read!) the whole file system. cc @alimpfard