### PR TITLE
AK: Cleanup missing includes and #ifdef evaluation

### DIFF
--- a/AK/Buffered.h
+++ b/AK/Buffered.h
@@ -26,7 +26,12 @@
 
 #pragma once
 
+#include <AK/Noncopyable.h>
+#include <AK/Span.h>
+#include <AK/StdLibExtras.h>
 #include <AK/Stream.h>
+#include <AK/Types.h>
+#include <AK/kmalloc.h>
 
 namespace AK {
 

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -30,6 +30,7 @@
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>
+#include <AK/kmalloc.h>
 
 namespace AK {
 

--- a/AK/Singleton.h
+++ b/AK/Singleton.h
@@ -28,6 +28,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/Atomic.h>
+#include <AK/Noncopyable.h>
 #include <AK/kmalloc.h>
 #ifdef KERNEL
 #    include <Kernel/Arch/i386/CPU.h>

--- a/AK/SinglyLinkedListWithCount.h
+++ b/AK/SinglyLinkedListWithCount.h
@@ -96,12 +96,12 @@ public:
         return List::contains_slow(value);
     }
 
-    using Iterator = List::Iterator;
+    using Iterator = typename List::Iterator;
     friend Iterator;
     Iterator begin() { return List::begin(); }
     Iterator end() { return List::end(); }
 
-    using ConstIterator = List::ConstIterator;
+    using ConstIterator = typename List::ConstIterator;
     friend ConstIterator;
     ConstIterator begin() const { return List::begin(); }
     ConstIterator end() const { return List::end(); }

--- a/AK/StackInfo.cpp
+++ b/AK/StackInfo.cpp
@@ -30,7 +30,7 @@
 
 #ifdef __serenity__
 #    include <serenity.h>
-#elif __linux__ or __APPLE__
+#elif defined(__linux__) or defined(__APPLE__)
 #    include <pthread.h>
 #endif
 


### PR DESCRIPTION
Problem:
- Several files have missing includes. This results in complaints from
  `clang-tidy`.
- `#ifdef` is followed by `#elif <value>` which evaluates to `0`.

Solution:
- Add missing includes.
- Change to `#elif defined(<value>)`.