### PR TITLE
LibGui: Checking whether Shortcut created from KeyEvent is valid

### DIFF
--- a/Libraries/LibGUI/Widget.cpp
+++ b/Libraries/LibGUI/Widget.cpp
@@ -739,6 +739,11 @@ bool Widget::is_backmost() const
 Action* Widget::action_for_key_event(const KeyEvent& event)
 {
     Shortcut shortcut(event.modifiers(), (KeyCode)event.key());
+
+    if (!shortcut.is_valid()) {
+        return nullptr;
+    }
+
     Action* found_action = nullptr;
     for_each_child_of_type<Action>([&](auto& action) {
         if (action.shortcut() == shortcut) {


### PR DESCRIPTION
Previously GUI::Actions which were contructed without initializing
m_shortcut, would be activated by invalid GUI::Shortcut.

Steps to reproduce:
It was possible to enable TextEditor's markdown preview by pressing
ctrl or alt (cmd/ctrl) keys, which should not happen,
as this Action did not specify a Shortcut.

This fix should apply to all other cases where actions were declared
without specifing Shortcut.