### PR TITLE
LibJS: Forward receiver value to native property getters/setters

### DIFF
--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -167,8 +167,8 @@ private:
     bool put_own_property(Object& this_object, const StringOrSymbol& property_name, Value, PropertyAttributes attributes, PutOwnPropertyMode = PutOwnPropertyMode::Put, bool throw_exceptions = true);
     bool put_own_property_by_index(Object& this_object, u32 property_index, Value, PropertyAttributes attributes, PutOwnPropertyMode = PutOwnPropertyMode::Put, bool throw_exceptions = true);
 
-    Value call_native_property_getter(Object* this_object, Value property) const;
-    void call_native_property_setter(Object* this_object, Value property, Value) const;
+    Value call_native_property_getter(Object* this_object, NativeProperty& property) const;
+    void call_native_property_setter(Object* this_object, NativeProperty& property, Value) const;
 
     void set_shape(Shape&);
 

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -97,7 +97,7 @@ public:
 
     virtual bool put(const PropertyName&, Value, Value receiver = {});
 
-    Value get_own_property(const Object& this_object, PropertyName, Value receiver) const;
+    Value get_own_property(const PropertyName&, Value receiver) const;
     Value get_own_properties(const Object& this_object, PropertyKind, bool only_enumerable_properties = false, GetOwnPropertyReturnType = GetOwnPropertyReturnType::StringOnly) const;
     virtual Optional<PropertyDescriptor> get_own_property_descriptor(const PropertyName&) const;
     Value get_own_property_descriptor_object(const PropertyName&) const;
@@ -167,8 +167,8 @@ private:
     bool put_own_property(Object& this_object, const StringOrSymbol& property_name, Value, PropertyAttributes attributes, PutOwnPropertyMode = PutOwnPropertyMode::Put, bool throw_exceptions = true);
     bool put_own_property_by_index(Object& this_object, u32 property_index, Value, PropertyAttributes attributes, PutOwnPropertyMode = PutOwnPropertyMode::Put, bool throw_exceptions = true);
 
-    Value call_native_property_getter(Object* this_object, NativeProperty& property) const;
-    void call_native_property_setter(Object* this_object, NativeProperty& property, Value) const;
+    Value call_native_property_getter(NativeProperty& property, Value this_value) const;
+    void call_native_property_setter(NativeProperty& property, Value this_value, Value) const;
 
     void set_shape(Shape&);
 

--- a/Libraries/LibJS/Tests/builtins/Reflect/Reflect.get.js
+++ b/Libraries/LibJS/Tests/builtins/Reflect/Reflect.get.js
@@ -60,4 +60,8 @@ describe("normal behavior", () => {
         expect(foo.getPropCalled).toBeTrue();
         expect(bar.getPropCalled).toBeTrue();
     });
+
+    test("native getter function", () => {
+        expect(Reflect.get(String.prototype, "length", "foo")).toBe(3);
+    });
 });

--- a/Libraries/LibJS/Tests/builtins/Reflect/Reflect.set.js
+++ b/Libraries/LibJS/Tests/builtins/Reflect/Reflect.set.js
@@ -93,4 +93,10 @@ describe("normal behavior", () => {
         expect(foo.setPropCalled).toBeTrue();
         expect(bar.setPropCalled).toBeTrue();
     });
+
+    test("native setter function", () => {
+        const e = new Error();
+        Reflect.set(Error.prototype, "name", "Foo", e);
+        expect(e.name).toBe("Foo");
+    });
 });


### PR DESCRIPTION
e.g.

```js
Reflect.get(String.prototype, "length", "foo");
// used to return 0, now 3
```