### PR TITLE
MenuApplets: Added ability to remove entry from ClipboardHistory

### DIFF
--- a/MenuApplets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/MenuApplets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -99,3 +99,8 @@ void ClipboardHistoryModel::add_item(const GUI::Clipboard::DataAndType& item)
     m_history_items.prepend(item);
     update();
 }
+
+void ClipboardHistoryModel::remove_item(int index)
+{
+    m_history_items.remove(index);
+}

--- a/MenuApplets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/MenuApplets/ClipboardHistory/ClipboardHistoryModel.h
@@ -45,6 +45,7 @@ public:
 
     const GUI::Clipboard::DataAndType& item_at(int index) const { return m_history_items[index]; }
     void add_item(const GUI::Clipboard::DataAndType& item);
+    void remove_item(int index);
 
 private:
     virtual int row_count(const GUI::ModelIndex&) const override { return m_history_items.size(); }

--- a/MenuApplets/ClipboardHistory/main.cpp
+++ b/MenuApplets/ClipboardHistory/main.cpp
@@ -81,8 +81,7 @@ int main(int argc, char* argv[])
 
     auto entry_context_menu = GUI::Menu::construct();
     entry_context_menu->add_action(delete_action);
-    table_view.on_context_menu_request = [&](const GUI::ModelIndex& index, const GUI::ContextMenuEvent& event) {
-        (void)index;
+    table_view.on_context_menu_request = [&](const GUI::ModelIndex&, const GUI::ContextMenuEvent& event) {
         entry_context_menu->popup(event.screen_position());
     };
 

--- a/MenuApplets/ClipboardHistory/main.cpp
+++ b/MenuApplets/ClipboardHistory/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
         GUI::Clipboard::the().set_data(data_and_type.data, data_and_type.mime_type, data_and_type.metadata);
     };
 
-    auto delete_action = GUI::Action::create("Delete", { Mod_None, Key_Delete }, Gfx::Bitmap::load_from_file("/res/icons/16x16/stop-hand.png"), [&](const GUI::Action&) {
+    auto delete_action = GUI::CommonActions::make_delete_action([&](const GUI::Action&) {
         model->remove_item(table_view.selection().first().row());
     });
 

--- a/MenuApplets/ClipboardHistory/main.cpp
+++ b/MenuApplets/ClipboardHistory/main.cpp
@@ -25,8 +25,10 @@
  */
 
 #include "ClipboardHistoryModel.h"
+#include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/ImageWidget.h>
+#include <LibGUI/Menu.h>
 #include <LibGUI/TableView.h>
 #include <LibGUI/Window.h>
 #include <stdio.h>
@@ -71,6 +73,17 @@ int main(int argc, char* argv[])
     table_view.on_activation = [&](const GUI::ModelIndex& index) {
         auto& data_and_type = model->item_at(index.row());
         GUI::Clipboard::the().set_data(data_and_type.data, data_and_type.mime_type, data_and_type.metadata);
+    };
+
+    auto delete_action = GUI::Action::create("Delete", { Mod_None, Key_Delete }, Gfx::Bitmap::load_from_file("/res/icons/16x16/stop-hand.png"), [&](const GUI::Action&) {
+        model->remove_item(table_view.selection().first().row());
+    });
+
+    auto entry_context_menu = GUI::Menu::construct();
+    entry_context_menu->add_action(delete_action);
+    table_view.on_context_menu_request = [&](const GUI::ModelIndex& index, const GUI::ContextMenuEvent& event) {
+        (void)index;
+        entry_context_menu->popup(event.screen_position());
     };
 
     auto applet_window = GUI::Window::construct();


### PR DESCRIPTION
This adds the ability to remove an entry from your ClipboardHistory in the applet. It's working with a context menu by right-clicking on the entry or just select it and press delete.

I hope it's useful :)

Fixes: #4119