### PR TITLE
Kernel: Inherit shared buffers when forking

### DIFF
--- a/Kernel/SharedBuffer.cpp
+++ b/Kernel/SharedBuffer.cpp
@@ -121,6 +121,22 @@ void SharedBuffer::share_with(ProcessID peer_pid)
     sanity_check("share_with (new ref)");
 }
 
+void SharedBuffer::share_all_shared_buffers(Process& from_process, Process& with_process)
+{
+    LOCKER(shared_buffers().lock());
+    for (auto& shbuf : shared_buffers().resource()) {
+        auto& shared_buffer = *shbuf.value;
+        if (shared_buffer.m_global)
+            continue;
+        for (auto& ref : shared_buffer.m_refs) {
+            if (ref.pid == from_process.pid()) {
+                shared_buffer.share_with(with_process.pid());
+                break;
+            }
+        }
+    }
+}
+
 void SharedBuffer::deref_for_process(Process& process)
 {
     LOCKER(shared_buffers().lock());

--- a/Kernel/SharedBuffer.h
+++ b/Kernel/SharedBuffer.h
@@ -70,6 +70,7 @@ public:
     void share_globally() { m_global = true; }
     void deref_for_process(Process& process);
     void disown(ProcessID pid);
+    static void share_all_shared_buffers(Process& from_process, Process& with_process);
     size_t size() const { return m_vmobject->size(); }
     void destroy_if_unused();
     void seal();

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -27,6 +27,7 @@
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/Process.h>
+#include <Kernel/SharedBuffer.h>
 #include <Kernel/VM/Region.h>
 
 //#define FORK_DEBUG
@@ -78,6 +79,8 @@ pid_t Process::sys$fork(RegisterState& regs)
 #ifdef FORK_DEBUG
     dbg() << "fork: child will begin executing at " << String::format("%w", child_tss.cs) << ":" << String::format("%x", child_tss.eip) << " with stack " << String::format("%w", child_tss.ss) << ":" << String::format("%x", child_tss.esp) << ", kstack " << String::format("%w", child_tss.ss0) << ":" << String::format("%x", child_tss.esp0);
 #endif
+
+    SharedBuffer::share_all_shared_buffers(*this, *child);
 
     {
         ScopedSpinLock lock(m_lock);


### PR DESCRIPTION
We need to create a reference for the new PID for each shared buffer
that the process had a reference to. If the process subsequently
get replaced through exec, those references will be dropped again.
But if exec for some reason fails then other code, such as global
destructors could still expect having access to them.

Fixes #4076