### PR TITLE
Calculator: Changed 'CE' Button from 'Clear Error' To 'Clear Entry'

### DIFF
--- a/Applications/Calculator/Calculator.cpp
+++ b/Applications/Calculator/Calculator.cpp
@@ -139,4 +139,5 @@ void Calculator::clear_operation()
 {
     m_operation_in_progress = Operation::None;
     m_saved_argument = 0.0;
+    clear_error();
 }

--- a/Applications/Calculator/CalculatorWidget.cpp
+++ b/Applications/Calculator/CalculatorWidget.cpp
@@ -95,7 +95,7 @@ CalculatorWidget::CalculatorWidget()
     m_clear_error_button = add<GUI::Button>();
     m_clear_error_button->set_text("CE");
     m_clear_error_button->on_click = [this](auto) {
-        m_calculator.clear_error();
+        m_keypad.set_value(0.0);
         update_display();
     };
     add_button(*m_clear_error_button, Color::Red);


### PR DESCRIPTION
The CE button on the windows calculator was used to clear the current
entry rather than the current error. This commit changes the
calculator's CE button such that it now clears the current value being
entered into the keypad and errors are now cleared at the end of every
successful operation.

Resolves #4124.