### PR TITLE
Kernel: Don't resume thread into Running state directly on SIGCONT

### DIFF
--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -817,7 +817,8 @@ void Thread::set_state(State new_state)
     }
 
     if (new_state == Stopped) {
-        m_stop_state = m_state;
+        // We don't want to restore to Running state, only Runnable!
+        m_stop_state = m_state != Running ? m_state : Runnable;
     }
 
     m_state = new_state;


### PR DESCRIPTION
We should never resume a thread by directly setting it to Running state.
Instead, if a thread was in Running state when stopped, record the state
as Runnable.

Fixes #4150