### PR TITLE
FilePicker: Remove Duplicate set_title() Call.

### DIFF
--- a/Libraries/LibGUI/FilePicker.cpp
+++ b/Libraries/LibGUI/FilePicker.cpp
@@ -96,7 +96,6 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, Options options, const 
         set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/save.png"));
         break;
     }
-    set_title(m_mode == Mode::Open ? "Open File" : "Save File");
     set_rect(200, 200, 700, 400);
     auto& horizontal_container = set_main_widget<Widget>();
     horizontal_container.set_layout<HorizontalBoxLayout>();


### PR DESCRIPTION
Noticed this after I created PR #4148 see: https://github.com/SerenityOS/serenity/pull/4148#issuecomment-732043486