### PR TITLE
Kernel: Fix SharedBuffer reference counting on fork

### DIFF
--- a/Kernel/SharedBuffer.h
+++ b/Kernel/SharedBuffer.h
@@ -36,8 +36,9 @@ namespace Kernel {
 class SharedBuffer {
 private:
     struct Reference {
-        Reference(ProcessID pid)
+        Reference(ProcessID pid, unsigned count = 0)
             : pid(pid)
+            , count(count)
         {
         }
 
@@ -69,7 +70,7 @@ public:
     void share_with(ProcessID peer_pid);
     void share_globally() { m_global = true; }
     void deref_for_process(Process& process);
-    void disown(ProcessID pid);
+    bool disown(ProcessID pid);
     static void share_all_shared_buffers(Process& from_process, Process& with_process);
     size_t size() const { return m_vmobject->size(); }
     void destroy_if_unused();

--- a/Kernel/Syscalls/shbuf.cpp
+++ b/Kernel/Syscalls/shbuf.cpp
@@ -37,8 +37,12 @@ void Process::disown_all_shared_buffers()
     Vector<SharedBuffer*, 32> buffers_to_disown;
     for (auto& it : shared_buffers().resource())
         buffers_to_disown.append(it.value.ptr());
-    for (auto* shared_buffer : buffers_to_disown)
-        shared_buffer->disown(m_pid);
+    for (auto* shared_buffer : buffers_to_disown) {
+        if (shared_buffer->disown(m_pid)) {
+            shared_buffers().resource().remove(shared_buffer->id());
+            delete shared_buffer;
+        }
+    }
 }
 
 int Process::sys$shbuf_create(int size, void** buffer)


### PR DESCRIPTION
We need to not only add a record for a reference, but we need
to copy the reference count on fork as well, because the code
in the fork assumes that it has the same amount of references,
still.

Also, once all references are dropped when a process is disowned,
delete the shared buffer.

Fixes #4076