### PR TITLE
LibJS: Support receiver in ProxyObject::get/put()

### DIFF
--- a/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-get.js
+++ b/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-get.js
@@ -40,6 +40,16 @@ describe("[[Get]] trap normal behavior", () => {
         expect(p.test).toBeUndefined();
         expect(p[Symbol.hasInstance]).toBeUndefined();
     });
+
+    test("custom receiver value", () => {
+        let p = new Proxy({}, {
+            get(target, property, receiver) {
+                return receiver;
+            },
+        });
+
+        expect(Reflect.get(p, "foo", 42)).toBe(42);
+    });
 });
 
 describe("[[Get]] invariants", () => {

--- a/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-set.js
+++ b/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-set.js
@@ -43,6 +43,21 @@ describe("[[Set]] trap normal behavior", () => {
         p[Symbol.hasInstance] = "foo"
         expect(p[Symbol.hasInstance]).toBe("foo");
     });
+
+    test("custom receiver value", () => {
+        const o = {};
+        const r = {};
+        let p = new Proxy(o, {
+            set(target, property, value, receiver) {
+                receiver[property] = value;
+                return true;
+            },
+        });
+
+        expect(Reflect.set(p, "foo", 42, r)).toBe(true);
+        expect(o.foo).toBeUndefined();
+        expect(r.foo).toBe(42);
+    });
 });
 
 describe("[[Set]] invariants", () => {


### PR DESCRIPTION
If a receiver is given, e.g. via `Reflect.get/set()`, forward it to the target object's `get()/put()` or use it as last argument of the trap function. The default value is the Proxy object itself.