### PR TITLE
AK: Don't return empty StringImpl from create() when char* starts with \0

### DIFF
--- a/AK/StringImpl.cpp
+++ b/AK/StringImpl.cpp
@@ -103,9 +103,6 @@ RefPtr<StringImpl> StringImpl::create(const char* cstring, size_t length, Should
     if (!cstring)
         return nullptr;
 
-    if (!length || !*cstring)
-        return the_empty_stringimpl();
-
     if (should_chomp) {
         while (length) {
             char last_ch = cstring[length - 1];


### PR DESCRIPTION
When creating a `StringImpl` for a C string that starts with a null-byte, we would ignore the explicitly given length and return the empty `StringImpl` - presumably to check for `"\0"`, but this leads to false positives (`"\0foo"`) so let's only care about the length.

This fixes a crash in the JS::Parser if the source code file starts with `\0` (this was a FuzzJS input).

---

Repro:

```cpp
#include <AK/String.h>
#include <AK/StringView.h>

int main()
{
    StringView view1 { "\0foo\0bar", 8 };
    StringView view2 { "foo\0bar", 7 };
    StringView view3 { "foo\0", 4 };
    StringView view4 { "\0foo", 4 };
    StringView view5 { "\0", 1 };
    String string1 { view1 };
    String string2 { view2 };
    String string3 { view3 };
    String string4 { view4 };
    String string5 { view5 };
    dbgln("view1.length(): {}", view1.length());
    dbgln("view2.length(): {}", view2.length());
    dbgln("view3.length(): {}", view3.length());
    dbgln("view4.length(): {}", view4.length());
    dbgln("view5.length(): {}", view5.length());
    dbgln("string1.length(): {}", string1.length());
    dbgln("string2.length(): {}", string2.length());
    dbgln("string3.length(): {}", string3.length());
    dbgln("string4.length(): {}", string4.length());
    dbgln("string5.length(): {}", string5.length());
}
```

```
example(38): view1.length(): 8
example(38): view2.length(): 7
example(38): view3.length(): 4
example(38): view4.length(): 4
example(38): view5.length(): 1
example(38): string1.length(): 0
example(38): string2.length(): 7
example(38): string3.length(): 4
example(38): string4.length(): 0
example(38): string5.length(): 0
```