### PR TITLE
LibJS: Fix possible OOB read during Lexer construction

### DIFF
--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -304,7 +304,7 @@ bool Lexer::is_line_terminator() const
 {
     if (m_current_char == '\n' || m_current_char == '\r')
         return true;
-    if (m_position + 1 < m_source.length()) {
+    if (m_position > 0 && m_position + 1 < m_source.length()) {
         auto three_chars_view = m_source.substring_view(m_position - 1, 3);
         return (three_chars_view == LINE_SEPARATOR) || (three_chars_view == PARAGRAPH_SEPARATOR);
     }


### PR DESCRIPTION
The Lexer constructor calls consume() once, which initializes m_position to be > 0 and sets m_character. consume() calls is_line_terminator(), which wasn't accounting for this state.

See https://github.com/SerenityOS/serenity/issues/4154#issuecomment-733916778.