### PR TITLE
Kernel: Enable VMWareBackdoor immediately at boot

### DIFF
--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -265,6 +265,7 @@ void init_stage2()
     new RandomDevice;
     PTYMultiplexer::initialize();
     new SB16;
+    VMWareBackdoor::the(); // don't wait until first mouse packet
 
     bool force_pio = kernel_command_line().contains("force_pio");
 


### PR DESCRIPTION
Rather than waiting until we get the first mouse packet, enable the
absolute mode immediately. This avoids having to click first to be
able to move the mouse.