### PR TITLE
Lagom: Various fixes to make Lagom run on OSS-Fuzz

### DIFF
--- a/AK/Random.h
+++ b/AK/Random.h
@@ -47,7 +47,7 @@ inline void fill_with_random(void* buffer, size_t length)
 {
 #if defined(__serenity__)
     arc4random_buf(buffer, length);
-#elif defined (OSS_FUZZ)
+#elif defined(OSS_FUZZ)
     (void)buffer;
     (void)length;
 #elif defined(__unix__) or defined(__APPLE__)

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -48,16 +48,8 @@ inline void fill_with_random(void* buffer, size_t length)
 #if defined(__serenity__)
     arc4random_buf(buffer, length);
 #elif defined (OSS_FUZZ)
-    // Ugly hack to get OSS-Fuzz environment working, where we dont have the
-    // getentropy call. We use the conditional because we need buffer and
-    // length to be used.
-    int rc;
-    if (buffer && length) { 
-        rc = -1;
-    } 
-    else {
-        rc = -1;
-    }
+    (void)buffer;
+    (void)length;
 #elif defined(__unix__) or defined(__APPLE__)
     int rc = getentropy(buffer, length);
     (void)rc;

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -47,7 +47,7 @@ inline void fill_with_random(void* buffer, size_t length)
 {
 #if defined(__serenity__)
     arc4random_buf(buffer, length);
-#elif defined (__oss_fuzz__)
+#elif defined (OSS_FUZZ)
     // Ugly hack to get OSS-Fuzz environment working, where we dont have the
     // getentropy call. We use the conditional because we need buffer and
     // length to be used.

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -47,6 +47,17 @@ inline void fill_with_random(void* buffer, size_t length)
 {
 #if defined(__serenity__)
     arc4random_buf(buffer, length);
+#elif define (__oss_fuzz__)
+    // Ugly hack to get OSS-Fuzz environment working, where we dont have the
+    // getentropy call. We use the conditional because we need buffer and
+    // length to be used.
+    int rc;
+    if (buffer && length) { 
+        rc = -1;
+    } 
+    else {
+        rc = -1;
+    }
 #elif defined(__unix__) or defined(__APPLE__)
     int rc = getentropy(buffer, length);
     (void)rc;

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -47,7 +47,7 @@ inline void fill_with_random(void* buffer, size_t length)
 {
 #if defined(__serenity__)
     arc4random_buf(buffer, length);
-#elif define (__oss_fuzz__)
+#elif defined (__oss_fuzz__)
     // Ugly hack to get OSS-Fuzz environment working, where we dont have the
     // getentropy call. We use the conditional because we need buffer and
     // length to be used.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ set(CMAKE_INSTALL_MESSAGE NEVER)
 
 enable_testing()
 
+if (ENABLE_OSS_FUZZ)
+    add_compile_options(__oss_fuzz__=1)
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_custom_target(run

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,6 @@ set(CMAKE_INSTALL_MESSAGE NEVER)
 
 enable_testing()
 
-if (ENABLE_OSS_FUZZ)
-    add_compile_definitions(__oss_fuzz__=1)
-endif()
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_custom_target(run

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_INSTALL_MESSAGE NEVER)
 enable_testing()
 
 if (ENABLE_OSS_FUZZ)
-    add_compile_options(__oss_fuzz__=1)
+    add_compile_definitions(__oss_fuzz__=1)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required (VERSION 3.0)
 project (Lagom)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option -O2 -Wall -Wextra -Werror -std=c++2a -fPIC -g -Wno-deprecated-copy")
+if (NOT ENABLE_OSS_FUZZ)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option -O2 -Wall -Wextra -Werror -std=c++2a -fPIC -g -Wno-deprecated-copy")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a -fPIC -g -Wno-deprecated-copy")
+endif()
+
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wconsumed -Wno-overloaded-virtual")
@@ -65,67 +70,71 @@ include_directories (../../)
 include_directories (../../Libraries/)
 add_library(LagomCore ${LAGOM_CORE_SOURCES})
 
+
+
 if (BUILD_LAGOM)
     add_library(Lagom $<TARGET_OBJECTS:LagomCore> ${LAGOM_MORE_SOURCES})
+    
+    if (NOT ENABLE_OSS_FUZZ) 
+        add_executable(TestApp TestApp.cpp)
+        target_link_libraries(TestApp Lagom)
+        target_link_libraries(TestApp stdc++)
 
-    add_executable(TestApp TestApp.cpp)
-    target_link_libraries(TestApp Lagom)
-    target_link_libraries(TestApp stdc++)
+        add_executable(TestJson TestJson.cpp)
+        target_link_libraries(TestJson Lagom)
+        target_link_libraries(TestJson stdc++)
 
-    add_executable(TestJson TestJson.cpp)
-    target_link_libraries(TestJson Lagom)
-    target_link_libraries(TestJson stdc++)
+        add_executable(adjtime_lagom ../../Userland/adjtime.cpp)
+        set_target_properties(adjtime_lagom PROPERTIES OUTPUT_NAME adjtime)
+        target_link_libraries(adjtime_lagom Lagom)
 
-    add_executable(adjtime_lagom ../../Userland/adjtime.cpp)
-    set_target_properties(adjtime_lagom PROPERTIES OUTPUT_NAME adjtime)
-    target_link_libraries(adjtime_lagom Lagom)
+        add_executable(js_lagom ../../Userland/js.cpp)
+        set_target_properties(js_lagom PROPERTIES OUTPUT_NAME js)
+        target_link_libraries(js_lagom Lagom)
+        target_link_libraries(js_lagom stdc++)
+        target_link_libraries(js_lagom pthread)
 
-    add_executable(js_lagom ../../Userland/js.cpp)
-    set_target_properties(js_lagom PROPERTIES OUTPUT_NAME js)
-    target_link_libraries(js_lagom Lagom)
-    target_link_libraries(js_lagom stdc++)
-    target_link_libraries(js_lagom pthread)
+        add_executable(ntpquery_lagom ../../Userland/ntpquery.cpp)
+        set_target_properties(ntpquery_lagom PROPERTIES OUTPUT_NAME ntpquery)
+        target_link_libraries(ntpquery_lagom Lagom)
 
-    add_executable(ntpquery_lagom ../../Userland/ntpquery.cpp)
-    set_target_properties(ntpquery_lagom PROPERTIES OUTPUT_NAME ntpquery)
-    target_link_libraries(ntpquery_lagom Lagom)
+        add_executable(test-js_lagom ../../Userland/test-js.cpp)
+        set_target_properties(test-js_lagom PROPERTIES OUTPUT_NAME test-js)
+        target_link_libraries(test-js_lagom Lagom)
+        target_link_libraries(test-js_lagom stdc++)
+        target_link_libraries(test-js_lagom pthread)
 
-    add_executable(test-js_lagom ../../Userland/test-js.cpp)
-    set_target_properties(test-js_lagom PROPERTIES OUTPUT_NAME test-js)
-    target_link_libraries(test-js_lagom Lagom)
-    target_link_libraries(test-js_lagom stdc++)
-    target_link_libraries(test-js_lagom pthread)
-
-    add_executable(test-crypto_lagom ../../Userland/test-crypto.cpp)
-    set_target_properties(test-crypto_lagom PROPERTIES OUTPUT_NAME test-crypto)
-    target_link_libraries(test-crypto_lagom Lagom)
-    target_link_libraries(test-crypto_lagom stdc++)
-    add_test(
-        NAME Crypto
-        COMMAND test-crypto_lagom test -t -s google.com --ca-certs-file ../../Base/etc/ca_certs.ini
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-
-    add_executable(disasm_lagom ../../Userland/disasm.cpp)
-    set_target_properties(disasm_lagom PROPERTIES OUTPUT_NAME disasm)
-    target_link_libraries(disasm_lagom Lagom)
-    target_link_libraries(disasm_lagom stdc++)
-
-    add_executable(shell_lagom ${SHELL_SOURCES})
-    set_target_properties(shell_lagom PROPERTIES OUTPUT_NAME shell)
-    target_link_libraries(shell_lagom Lagom)
-    target_link_libraries(shell_lagom stdc++)
-    target_link_libraries(shell_lagom pthread)
-    foreach(TEST_PATH ${SHELL_TESTS})
-        get_filename_component(TEST_NAME ${TEST_PATH} NAME_WE)
+        add_executable(test-crypto_lagom ../../Userland/test-crypto.cpp)
+        set_target_properties(test-crypto_lagom PROPERTIES OUTPUT_NAME test-crypto)
+        target_link_libraries(test-crypto_lagom Lagom)
+        target_link_libraries(test-crypto_lagom stdc++)
         add_test(
-            NAME "Shell-${TEST_NAME}"
-            COMMAND shell_lagom "${TEST_PATH}"
+            NAME Crypto
+            COMMAND test-crypto_lagom test -t -s google.com --ca-certs-file ../../Base/etc/ca_certs.ini
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         )
-    endforeach()
+
+        add_executable(disasm_lagom ../../Userland/disasm.cpp)
+        set_target_properties(disasm_lagom PROPERTIES OUTPUT_NAME disasm)
+        target_link_libraries(disasm_lagom Lagom)
+        target_link_libraries(disasm_lagom stdc++)
+
+        add_executable(shell_lagom ${SHELL_SOURCES})
+        set_target_properties(shell_lagom PROPERTIES OUTPUT_NAME shell)
+        target_link_libraries(shell_lagom Lagom)
+        target_link_libraries(shell_lagom stdc++)
+        target_link_libraries(shell_lagom pthread)
+        foreach(TEST_PATH ${SHELL_TESTS})
+            get_filename_component(TEST_NAME ${TEST_PATH} NAME_WE)
+            add_test(
+                NAME "Shell-${TEST_NAME}"
+                COMMAND shell_lagom "${TEST_PATH}"
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            )
+        endforeach()
+    endif()
 endif()
 
-if (ENABLE_FUZZER_SANITIZER)
+if (ENABLE_FUZZER_SANITIZER OR ENABLE_OSS_FUZZ)
     add_subdirectory(Fuzzers)
 endif()

--- a/Meta/Lagom/Fuzzers/CMakeLists.txt
+++ b/Meta/Lagom/Fuzzers/CMakeLists.txt
@@ -1,12 +1,18 @@
 function(add_simple_fuzzer name)
   add_executable(${name} "${name}.cpp")
-  target_compile_options(${name}
+
+  if (ENABLE_OSS_FUZZ)
+      target_link_libraries(${name}
+          PUBLIC Lagom)
+  else()
+    target_compile_options(${name}
       PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>
       )
-  target_link_libraries(${name}
+    target_link_libraries(${name}
       PUBLIC Lagom
       PRIVATE $<$<C_COMPILER_ID:Clang>:-fsanitize=fuzzer>
       )
+  endif()
 endfunction()
 
 add_simple_fuzzer(FuzzBMPLoader)
@@ -22,6 +28,7 @@ add_simple_fuzzer(FuzzPPMLoader)
 add_simple_fuzzer(FuzzJs)
 add_simple_fuzzer(FuzzMarkdown)
 
+if (NOT ENABLE_OSS_FUZZ)
 add_executable(FuzzilliJs FuzzilliJs.cpp)
 target_compile_options(FuzzilliJs
     PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize-coverage=trace-pc-guard>
@@ -30,3 +37,4 @@ target_link_libraries(FuzzilliJs
     PUBLIC Lagom
     PRIVATE $<$<C_COMPILER_ID:Clang>:-fsanitize-coverage=trace-pc-guard>
     )
+endif()


### PR DESCRIPTION
Contains the various changes needed in the build environment to make OSS-Fuzz work.

There are no changes that break the regular build, i.e. it's only "additions" in case the OSS-Fuzz build is run. 

This PR will make things much easier to maintain from an OSS-Fuzz perspective, as very little - if any - will have to be maintained from the https://github.com/google/oss-fuzz repo. Once this PR is merged in then I will change the OSS-Fuzz repository to reflect the updates in this PR as well as the emails of the various maintainers that have asked to get in the configuration file. 

A few pointers on how to test the oss-fuzz set up locally:

### Build and run oss-fuzz fuzzers
Build and run serenity fuzzers by way of oss-fuzz
```
git clone https://github.com/google/oss-fuzz/
cd oss-fuzz
python3 infra/helper.py build_image serenity
python3 infra/helper.py build_fuzzers serenity
```
These commands will put the fuzzers in a folder in the oss-fuzz repo called: `build/out/serenity`. You can run the binaries in there individually, or simply type:
```
python3 infra/helper.py run_fuzzer serenity FUZZER_NAME
```

### asserts and aborts when fuzzing
Finally, a minor thing I noticed from the bug reports is that several `assert` statements are hit. This is naturally not necessarily a bug as the fuzzer may indicate. However, the fuzzer operates within a single process together with the library it is fuzzing, so if the code that is being fuzzed exits then the fuzzer will also exit and consider it a bug. As such, to make the code "fuzzing friendly" it is preferred to make the target code exit gracefully, i.e. instead of having asserts and aborts then simply return error codes. In this way the fuzzer can do more work - and you also get the benefit of potential malicious input not being able to trigger exits in a library (although this is completely your design decision to make). 