### PR TITLE
Meta: Add Github Actions workflow for Lagom with Fuzzers

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -105,3 +105,31 @@ jobs:
         ${{ toJSON(github.event) }}
         ]
         EOF
+  build_lagom_with_fuzzers:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # === OS SETUP ===
+
+    - name: Check versions
+      run: set +e; clang --version; clang++ --version
+
+    # === PREPARE FOR BUILDING ===
+
+    # TODO: ccache
+    # https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
+    # https://github.com/cristianadam/HelloWorld/blob/master/.github/workflows/build_cmake.yml
+    - name: Create build environment
+      working-directory: ${{ github.workspace }}/Meta/Lagom
+      run: |
+        mkdir -p Build
+        cd Build
+        cmake -DBUILD_LAGOM=ON -DENABLE_FUZZER_SANITIZER=ON -DENABLE_ADDRESS_SANITIZER=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ..
+
+    # === ACTUALLY BUILD ===
+
+    - name: Build Lagom with Fuzzers
+      working-directory: ${{ github.workspace }}/Meta/Lagom/Build
+      run: cmake --build . -j2

--- a/Kernel/Random.h
+++ b/Kernel/Random.h
@@ -66,7 +66,7 @@ public:
         // FIXME: More than 2^20 bytes cannot be generated without refreshing the key.
         ASSERT(n < (1 << 20));
 
-        typename CipherType::CTRMode cipher(m_key, KeySize);
+        typename CipherType::CTRMode cipher(m_key, KeySize, Crypto::Cipher::Intent::Encryption);
 
         Bytes buffer_span { buffer, n };
         auto counter_span = m_counter.bytes();

--- a/Libraries/LibCrypto/Cipher/Mode/CTR.h
+++ b/Libraries/LibCrypto/Cipher/Mode/CTR.h
@@ -113,8 +113,10 @@ public:
     // Must intercept `Intent`, because AES must always be set to
     // Encryption, even when decrypting AES-CTR.
     // TODO: How to deal with ciphers that take different arguments?
+    // FIXME: Add back the default intent parameter once clang-11 is the default in GitHub Actions.
+    //        Once added back, remove the parameter where it's constructed in get_random_bytes in Kernel/Random.h.
     template<typename KeyType, typename... Args>
-    explicit constexpr CTR(const KeyType& user_key, size_t key_bits, Intent = Intent::Encryption, Args... args)
+    explicit constexpr CTR(const KeyType& user_key, size_t key_bits, Intent, Args... args)
         : Mode<T>(user_key, key_bits, Intent::Encryption, args...)
     {
     }

--- a/Libraries/LibGfx/Gamma.h
+++ b/Libraries/LibGfx/Gamma.h
@@ -59,7 +59,13 @@ typedef float v4sf __attribute__((vector_size(16)));
 
 // Transform v4sf from gamma2.2 space to linear space
 // Assumes x is in range [0, 1]
+// FIXME: Remove this hack once clang-11 is available as the default in Github Actions.
+//        This is apparently sometime mid-December. https://github.com/actions/virtual-environments/issues/2130
+#        if !defined(__clang__) || __clang_major__ >= 11
 constexpr v4sf gamma_to_linear4(v4sf x)
+#        else
+inline v4sf gamma_to_linear4(v4sf x)
+#        endif
 {
     return (0.8f + 0.2f * x) * x * x;
 }

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -82,7 +82,7 @@ add_library(LagomCore ${LAGOM_CORE_SOURCES})
 if (BUILD_LAGOM)
     add_library(Lagom $<TARGET_OBJECTS:LagomCore> ${LAGOM_MORE_SOURCES})
 
-    if (NOT ENABLE_OSS_FUZZ)
+    if (NOT ENABLE_OSS_FUZZ AND NOT ENABLE_FUZZER_SANITIZER)
         add_executable(TestApp TestApp.cpp)
         target_link_libraries(TestApp Lagom)
         target_link_libraries(TestApp stdc++)

--- a/Meta/Lagom/Fuzzers/CMakeLists.txt
+++ b/Meta/Lagom/Fuzzers/CMakeLists.txt
@@ -31,8 +31,10 @@ add_simple_fuzzer(FuzzRegexECMA262)
 add_simple_fuzzer(FuzzRegexPosixExtended)
 add_simple_fuzzer(FuzzShell)
 
-if (NOT ENABLE_OSS_FUZZ)
+if (NOT ENABLE_OSS_FUZZ AND NOT ENABLE_FUZZER_SANITIZER)
 add_executable(FuzzilliJs FuzzilliJs.cpp)
+# FIXME: For some reason, these option overrides are ignored and FuzzilliJs gets treated
+#        as a regular fuzzer. Once fixed, please remove the "AND NOT ENABLE_FUZZER_SANITIZER" above.
 target_compile_options(FuzzilliJs
     PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize-coverage=trace-pc-guard>
     )


### PR DESCRIPTION
There are cases where Lagom will build with GCC but not Clang.
This often goes unnoticed for a while as we don't often build with
Clang.

However, this is now important to test in CI because of the
OSS-Fuzz integration.

Note that this only tests the build, it does not run any tests.

Case in point, this PR is marked as draft because I'm not sure how
to fix the issue with LibCrypto.

Even though #4176 will disable building most of Lagom for
OSS-Fuzz, it'd still be nice to make sure it still builds with Clang.