### PR TITLE
TreeNode::insert_before did not update m_previous_sibling

### DIFF
--- a/Libraries/LibWeb/TreeNode.h
+++ b/Libraries/LibWeb/TreeNode.h
@@ -380,6 +380,8 @@ inline void TreeNode<T>::insert_before(NonnullRefPtr<T> node, RefPtr<T> child, b
     node->m_previous_sibling = child->m_previous_sibling;
     node->m_next_sibling = child;
 
+    child->m_previous_sibling = node;
+
     if (m_first_child == child)
         m_first_child = node;
 


### PR DESCRIPTION
The following snippet reproduces the issue:

~~~c++
#include <LibGUI/Application.h>
#include <LibWeb/DOM/Document.h>
#include <LibWeb/DOM/Element.h>

int main(int argc, char** argv)
{
    auto application = GUI::Application::construct(argc, argv);

    auto document = Web::DOM::Document::create();

    auto html_element = document->create_element("html");
    auto head_element = document->create_element("head");
    auto body_element = document->create_element("body");

    document->append_child(html_element);
    html_element->append_child(body_element);
    html_element->insert_before(head_element, body_element);

    // This assertion fails without the patch.
    ASSERT(body_element->previous_sibling() == head_element);
}
~~~

There doesn't seem to be a place for (C++) unit tests in LibWeb, otherwise, I would have added this as test.
