### PR TITLE
LibJS+LibRegex: Error message improvements

### DIFF
--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -146,7 +146,7 @@
     M(ReflectBadArgumentsList, "Arguments list must be an object")                                                                      \
     M(ReflectBadNewTarget, "Optional third argument of Reflect.construct() must be a constructor")                                      \
     M(ReflectBadDescriptorArgument, "Descriptor argument is not an object")                                                             \
-    M(RegExpCompileError, "RegExp compile error: '{}'")                                                                                 \
+    M(RegExpCompileError, "RegExp compile error: {}")                                                                                   \
     M(RegExpObjectBadFlag, "Invalid RegExp flag '{}'")                                                                                  \
     M(RegExpObjectRepeatedFlag, "Repeated RegExp flag '{}'")                                                                            \
     M(StringRawCannotConvert, "Cannot convert property 'raw' to object from {}")                                                        \

--- a/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Libraries/LibRegex/RegexMatcher.cpp
@@ -45,11 +45,8 @@ Regex<Parser>::Regex(StringView pattern, typename ParserTraits<Parser>::OptionsT
     Parser parser(lexer, regex_options);
     parser_result = parser.parse();
 
-    if (parser_result.error == regex::Error::NoError) {
+    if (parser_result.error == regex::Error::NoError)
         matcher = make<Matcher<Parser>>(*this, regex_options);
-    } else {
-        fprintf(stderr, "%s\n", error_string().characters());
-    }
 }
 
 template<class Parser>

--- a/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Libraries/LibRegex/RegexMatcher.cpp
@@ -67,7 +67,7 @@ String Regex<Parser>::error_string(Optional<String> message) const
     for (size_t i = 0; i < parser_result.error_token.position(); ++i)
         eb.append(" ");
 
-    eb.appendf("^---- %s\n", message.value_or(get_error_string(parser_result.error)).characters());
+    eb.appendf("^---- %s", message.value_or(get_error_string(parser_result.error)).characters());
     return eb.build();
 }
 

--- a/Libraries/LibRegex/Tests/RegexLibC.cpp
+++ b/Libraries/LibRegex/Tests/RegexLibC.cpp
@@ -1079,7 +1079,7 @@ TEST_CASE(error_message)
     char buf[1024];
     size_t buflen = 1024;
     auto len = regerror(0, &regex, buf, buflen);
-    String expected = "Error during parsing of regular expression:\n    ^[A-Z0-9[a-z._%+-]{1,64}@[A-Za-z0-9-]{1,63}\\.{1,125}[A-Za-z]{2,63}$\n             ^---- [ ] imbalance.\n";
+    String expected = "Error during parsing of regular expression:\n    ^[A-Z0-9[a-z._%+-]{1,64}@[A-Za-z0-9-]{1,63}\\.{1,125}[A-Za-z]{2,63}$\n             ^---- [ ] imbalance.";
     for (size_t i = 0; i < len; ++i) {
         EXPECT_EQ(buf[i], expected[i]);
     }


### PR DESCRIPTION
From:

```
> RegExp("[")
Error during parsing of regular expression:
    [
     ^---- [ ] imbalance.

Uncaught exception: [SyntaxError]: RegExp compile error: 'Error during parsing of regular expression:
    [
     ^---- [ ] imbalance.
'
 -> RegExp
 -> (global execution context)
```

To:

```
> RegExp("[")
Uncaught exception: [SyntaxError]: RegExp compile error: Error during parsing of regular expression:
    [
     ^---- [ ] imbalance.
 -> RegExp
 -> (global execution context)
```