### PR TITLE
LibJS: Disallow 'with' statement in strict mode

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -328,6 +328,8 @@ NonnullRefPtr<Statement> Parser::parse_statement()
     case TokenType::While:
         return parse_while_statement();
     case TokenType::With:
+        if (m_parser_state.m_strict_mode)
+            syntax_error("'with' statement not allowed in strict mode");
         return parse_with_statement();
     case TokenType::Debugger:
         return parse_debugger_statement();

--- a/Libraries/LibJS/Tests/with-basic.js
+++ b/Libraries/LibJS/Tests/with-basic.js
@@ -18,3 +18,7 @@ test("basic with statement functionality", () => {
 
     expect(bar).toBe(99);
 });
+
+test("syntax error in strict mode", () => {
+    expect("'use strict'; with (foo) {}").not.toEval();
+});


### PR DESCRIPTION
Damage control. :stuck_out_tongue_winking_eye: