### PR TITLE
AudioServer: Mixer: limit max volume to 100

### DIFF
--- a/Services/AudioServer/Mixer.cpp
+++ b/Services/AudioServer/Mixer.cpp
@@ -131,7 +131,10 @@ void Mixer::mix()
 
 void Mixer::set_main_volume(int volume)
 {
-    m_main_volume = volume;
+    if (volume > 100)
+        m_main_volume = 100;
+    else
+        m_main_volume = volume;
     ClientConnection::for_each([volume](ClientConnection& client) {
         client.did_change_main_mix_volume({}, volume);
     });


### PR DESCRIPTION
Prior to this PR it was possible to set system volume to maxint using `avol` or IPC. It hurt.
