### PR TITLE
LibRegex: Give the bytecode a chance to run when there's no input

### DIFF
--- a/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Libraries/LibRegex/RegexByteCode.cpp
@@ -700,11 +700,15 @@ const Vector<String> OpCode_Compare::variable_arguments_to_string(Optional<Match
         auto compare_type = (CharacterCompareType)m_bytecode->at(offset++);
         result.empend(String::format("type=%lu [%s]", (size_t)compare_type, character_compare_type_name(compare_type)));
 
+        auto compared_against_string_start_offset = state().string_position > 0 ? state().string_position - 1 : state().string_position;
+
         if (compare_type == CharacterCompareType::Char) {
             char ch = m_bytecode->at(offset++);
             result.empend(String::format("value='%c'", ch));
-            if (!view.is_null())
-                result.empend(String::format("compare against: '%s'", view.substring_view(state().string_position - 1, state().string_position > view.length() ? 0 : 1).to_string().characters()));
+            if (!view.is_null() && view.length() > state().string_position)
+                result.empend(String::format(
+                    "compare against: '%s'",
+                    view.substring_view(compared_against_string_start_offset, state().string_position > view.length() ? 0 : 1).to_string().characters()));
         } else if (compare_type == CharacterCompareType::NamedReference) {
             auto ptr = (const char*)m_bytecode->at(offset++);
             auto length = m_bytecode->at(offset++);
@@ -716,18 +720,24 @@ const Vector<String> OpCode_Compare::variable_arguments_to_string(Optional<Match
             char* str = reinterpret_cast<char*>(m_bytecode->at(offset++));
             auto& length = m_bytecode->at(offset++);
             result.empend(String::format("value=\"%.*s\"", length, str));
-            if (!view.is_null())
-                result.empend(String::format("compare against: \"%s\"", input.value().view.substring_view(state().string_position - 1, state().string_position + length - 1 > view.length() ? 0 : length).to_string().characters()));
+            if (!view.is_null() && view.length() > state().string_position)
+                result.empend(String::format(
+                    "compare against: \"%s\"",
+                    input.value().view.substring_view(compared_against_string_start_offset, compared_against_string_start_offset + length > view.length() ? 0 : length).to_string().characters()));
         } else if (compare_type == CharacterCompareType::CharClass) {
             auto character_class = (CharClass)m_bytecode->at(offset++);
             result.empend(String::format("ch_class=%lu [%s]", (size_t)character_class, character_class_name(character_class)));
-            if (!view.is_null())
-                result.empend(String::format("compare against: '%s'", input.value().view.substring_view(state().string_position - 1, state().string_position > view.length() ? 0 : 1).to_string().characters()));
+            if (!view.is_null() && view.length() > state().string_position)
+                result.empend(String::format(
+                    "compare against: '%s'",
+                    input.value().view.substring_view(compared_against_string_start_offset, state().string_position > view.length() ? 0 : 1).to_string().characters()));
         } else if (compare_type == CharacterCompareType::CharRange) {
             auto value = (CharRange)m_bytecode->at(offset++);
             result.empend(String::format("ch_range='%c'-'%c'", value.from, value.to));
-            if (!view.is_null())
-                result.empend(String::format("compare against: '%s'", input.value().view.substring_view(state().string_position - 1, state().string_position > view.length() ? 0 : 1).to_string().characters()));
+            if (!view.is_null() && view.length() > state().string_position)
+                result.empend(String::format(
+                    "compare against: '%s'",
+                    input.value().view.substring_view(compared_against_string_start_offset, state().string_position > view.length() ? 0 : 1).to_string().characters()));
         }
     }
     return result;

--- a/Libraries/LibRegex/Tests/Regex.cpp
+++ b/Libraries/LibRegex/Tests/Regex.cpp
@@ -535,6 +535,7 @@ TEST_CASE(ECMA262_match)
         { "bar.*(?<=foo)", "barbar", false },
         { "bar.*(?<!foo)", "barbar", true },
         { "((...)X)+", "fooXbarXbazX", true },
+        { "(?:)", "", true },
     };
 
     for (auto& test : tests) {


### PR DESCRIPTION
Fixes #4246. 

@BenWiederhake: if this is merged before you go back to working on #4204, it should fix your little regex test problem; if not, feel free to take 3412851, and I'll remove it from this PR.