### PR TITLE
LibRegex: Add bounds check to Lexer::back()

### DIFF
--- a/Libraries/LibRegex/RegexLexer.cpp
+++ b/Libraries/LibRegex/RegexLexer.cpp
@@ -64,8 +64,11 @@ ALWAYS_INLINE char Lexer::peek(size_t offset) const
 
 void Lexer::back(size_t offset)
 {
+    ASSERT(offset <= m_position);
+    if (!offset)
+        return;
     m_position -= offset;
-    m_previous_position = m_position - 1;
+    m_previous_position = (m_position > 0) ? m_position - 1 : 0;
     m_current_char = m_source[m_position];
 }
 


### PR DESCRIPTION
If the offset is zero and we're already at the end of the lexer's input an out of bounds read (`m_source[m_position]`) would occur. Also check that the offset is not more than `m_position` (which should never be the case, and would result in m_position underflowing).

Fixes #4253.