### PR TITLE
TaskBar: Allow QuickLaunch apps to be added and removed from the taskbar graphically.

### DIFF
--- a/Base/home/anon/.config/LaunchServer.ini
+++ b/Base/home/anon/.config/LaunchServer.ini
@@ -13,6 +13,7 @@ txt=/bin/TextEditor
 font=/bin/FontEditor
 hsp=/bin/HackStudio
 sheets=/bin/Spreadsheet
+af=/bin/AFLaunch
 *=/bin/TextEditor
 
 [Protocol]

--- a/Base/home/anon/.config/Taskbar.ini
+++ b/Base/home/anon/.config/Taskbar.ini
@@ -1,6 +1,6 @@
 [QuickLaunch]
-Browser=Browser.af
-SystemMonitor=SystemMonitor.af
-Terminal=Terminal.af
-FileManager=FileManager.af
-TextEditor=TextEditor.af
+Browser=/res/apps/Browser.af
+SystemMonitor=/res/apps/SystemMonitor.af
+Terminal=/res/apps/Terminal.af
+FileManager=/res/apps/FileManager.af
+TextEditor=/res/apps/TextEditor.af

--- a/Libraries/LibCore/Object.cpp
+++ b/Libraries/LibCore/Object.cpp
@@ -130,6 +130,19 @@ void Object::remove_child(Object& object)
     ASSERT_NOT_REACHED();
 }
 
+void Object::remove_all_children()
+{
+    for (size_t i = 0; i < m_children.size(); ++i) {
+        // NOTE: We protect the child so it survives the handling of ChildRemoved.
+        auto& object = *m_children.ptr_at(i).ptr();
+        NonnullRefPtr<Object> protector = object;
+        object.m_parent = nullptr;
+        Core::ChildEvent child_event(Core::Event::ChildRemoved, object);
+        event(child_event);
+    }
+    m_children.clear();
+}
+
 void Object::timer_event(Core::TimerEvent&)
 {
 }

--- a/Libraries/LibCore/Object.h
+++ b/Libraries/LibCore/Object.h
@@ -105,6 +105,7 @@ public:
     void add_child(Object&);
     void insert_child_before(Object& new_child, Object& before_child);
     void remove_child(Object&);
+    void remove_all_children();
 
     void dump_tree(int indent = 0);
 

--- a/Libraries/LibDesktop/App.cpp
+++ b/Libraries/LibDesktop/App.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020, Peter Elliott <pelliott@ualberta.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibCore/StandardPaths.h>
+#include <LibDesktop/App.h>
+#include <spawn.h>
+
+#ifdef __serenity__
+#    include <serenity.h>
+#endif
+
+namespace Desktop {
+
+App::App(const StringView& path)
+    : m_af_path(path)
+    , m_config_file(Core::ConfigFile::open(path))
+{
+}
+
+String App::name() const
+{
+    return m_config_file->read_entry("App", "Name");
+}
+
+String App::executable() const
+{
+    return m_config_file->read_entry("App", "Executable");
+}
+
+String App::category() const
+{
+    return m_config_file->read_entry("App", "Category");
+}
+
+String App::icon16x16() const
+{
+    return m_config_file->read_entry("Icons", "16x16");
+}
+
+String App::icon32x32() const
+{
+    return m_config_file->read_entry("Icons", "32x32");
+}
+
+#ifdef __serenity__
+int App::launch(bool chdir) const
+{
+    pid_t child_pid;
+    const char* argv[] = { executable().characters(), nullptr };
+
+    auto af_key = String::formatted("AF_PATH={}", af_path().characters());
+    const char* env[] = { af_key.characters(), nullptr };
+
+    String home_directory;
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    if (chdir) {
+        home_directory = Core::StandardPaths::home_directory();
+        posix_spawn_file_actions_addchdir(&actions, home_directory.characters());
+    }
+
+    int rc = posix_spawn(&child_pid, executable().characters(), &actions, nullptr, const_cast<char**>(argv), const_cast<char**>(env));
+    posix_spawn_file_actions_destroy(&actions);
+
+    if (rc)
+        return rc;
+
+    if (disown(child_pid) < 0)
+        return errno;
+
+    return 0;
+}
+#else
+int App::launch(bool chdir) const
+{
+    (void)chdir;
+    ASSERT_NOT_REACHED();
+}
+#endif
+
+bool App::is_well_formed() const
+{
+    return m_config_file->has_key("App", "Name") && m_config_file->has_key("App", "Executable");
+}
+
+}

--- a/Libraries/LibDesktop/App.h
+++ b/Libraries/LibDesktop/App.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, Peter Elliott <pelliott@ualberta.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibCore/ConfigFile.h>
+
+namespace Desktop {
+
+class App {
+public:
+    App(const StringView& path);
+
+    String name() const;
+    String executable() const;
+    String category() const;
+
+    String icon16x16() const;
+    String icon32x32() const;
+
+    const String& af_path() const { return m_af_path; }
+
+    int launch(bool chdir = true) const;
+
+    bool is_well_formed() const;
+
+private:
+    String m_af_path;
+    NonnullRefPtr<Core::ConfigFile> m_config_file;
+};
+
+}

--- a/Libraries/LibDesktop/CMakeLists.txt
+++ b/Libraries/LibDesktop/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     Launcher.cpp
+    App.cpp
 )
 
 set(GENERATED_SOURCES

--- a/Libraries/LibGUI/Event.h
+++ b/Libraries/LibGUI/Event.h
@@ -74,6 +74,7 @@ public:
         WM_WindowStateChanged,
         WM_WindowRectChanged,
         WM_WindowIconBitmapChanged,
+        WM_WindowRequestedPin,
         __End_WM_Events,
     };
 
@@ -183,6 +184,20 @@ public:
 private:
     int m_icon_buffer_id;
     Gfx::IntSize m_icon_size;
+};
+
+class WMWindowRequestedPinEvent : public WMEvent {
+public:
+    WMWindowRequestedPinEvent(int client_id, int window_id, const StringView& af_path)
+        : WMEvent(Event::Type::WM_WindowRequestedPin, client_id, window_id)
+        , m_af_path(af_path)
+    {
+    }
+
+    const String& af_path() const { return m_af_path; }
+
+private:
+    String m_af_path;
 };
 
 class MultiPaintEvent final : public Event {

--- a/Libraries/LibGUI/Window.cpp
+++ b/Libraries/LibGUI/Window.cpp
@@ -27,6 +27,7 @@
 #include <AK/HashMap.h>
 #include <AK/JsonObject.h>
 #include <AK/NeverDestroyed.h>
+#include <AK/Optional.h>
 #include <AK/SharedBuffer.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/MimeData.h>
@@ -110,6 +111,7 @@ void Window::show()
         return;
 
     auto* parent_window = find_parent_window();
+    auto af_path = getenv("AF_PATH");
 
     m_cursor = Gfx::StandardCursor::None;
     auto response = WindowServerConnection::the().send_sync<Messages::WindowServer::CreateWindow>(
@@ -128,7 +130,8 @@ void Window::show()
         m_resize_aspect_ratio,
         (i32)m_window_type,
         m_title_when_windowless,
-        parent_window ? parent_window->window_id() : 0);
+        parent_window ? parent_window->window_id() : 0,
+        (af_path) ? af_path : "");
     m_window_id = response->window_id();
     m_visible = true;
 

--- a/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Libraries/LibGUI/WindowServerConnection.cpp
@@ -289,6 +289,12 @@ void WindowServerConnection::handle(const Messages::WindowClient::WM_WindowIconB
         Core::EventLoop::current().post_event(*window, make<WMWindowIconBitmapChangedEvent>(message.client_id(), message.window_id(), message.icon_buffer_id(), message.icon_size()));
 }
 
+void WindowServerConnection::handle(const Messages::WindowClient::WM_WindowRequestedPin& message)
+{
+    if (auto* window = Window::from_window_id(message.wm_id()))
+        Core::EventLoop::current().post_event(*window, make<WMWindowRequestedPinEvent>(message.client_id(), message.window_id(), message.af_path()));
+}
+
 void WindowServerConnection::handle(const Messages::WindowClient::WM_WindowRemoved& message)
 {
     if (auto* window = Window::from_window_id(message.wm_id()))

--- a/Libraries/LibGUI/WindowServerConnection.h
+++ b/Libraries/LibGUI/WindowServerConnection.h
@@ -69,6 +69,7 @@ private:
     virtual void handle(const Messages::WindowClient::WM_WindowStateChanged&) override;
     virtual void handle(const Messages::WindowClient::WM_WindowIconBitmapChanged&) override;
     virtual void handle(const Messages::WindowClient::WM_WindowRectChanged&) override;
+    virtual void handle(const Messages::WindowClient::WM_WindowRequestedPin&) override;
     virtual void handle(const Messages::WindowClient::AsyncSetWallpaperFinished&) override;
     virtual void handle(const Messages::WindowClient::DragDropped&) override;
     virtual void handle(const Messages::WindowClient::DragAccepted&) override;

--- a/Services/SystemMenu/CMakeLists.txt
+++ b/Services/SystemMenu/CMakeLists.txt
@@ -4,4 +4,4 @@ set(SOURCES
 )
 
 serenity_bin(SystemMenu)
-target_link_libraries(SystemMenu LibGUI)
+target_link_libraries(SystemMenu LibGUI LibDesktop)

--- a/Services/Taskbar/CMakeLists.txt
+++ b/Services/Taskbar/CMakeLists.txt
@@ -6,4 +6,4 @@ set(SOURCES
 )
 
 serenity_bin(Taskbar)
-target_link_libraries(Taskbar LibGUI)
+target_link_libraries(Taskbar LibGUI LibDesktop)

--- a/Services/Taskbar/TaskbarWindow.h
+++ b/Services/Taskbar/TaskbarWindow.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "WindowList.h"
+#include <LibCore/ConfigFile.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 
@@ -39,7 +40,9 @@ public:
     int taskbar_height() const { return 28; }
 
 private:
-    void create_quick_launch_bar();
+    void rebuild_quick_launch_bar();
+    void pin_app(const StringView& af_path);
+    void unpin_app(const StringView& af_path);
     void on_screen_rect_change(const Gfx::IntRect&);
     NonnullRefPtr<GUI::Button> create_button(const WindowIdentifier&);
     void add_window_button(::Window&, const WindowIdentifier&);
@@ -50,4 +53,6 @@ private:
     virtual void wm_event(GUI::WMEvent&) override;
 
     RefPtr<Gfx::Bitmap> m_default_icon;
+    NonnullRefPtr<Core::ConfigFile> m_config;
+    GUI::Frame* m_quick_launch_bar { nullptr };
 };

--- a/Services/Taskbar/main.cpp
+++ b/Services/Taskbar/main.cpp
@@ -32,7 +32,7 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio shared_buffer accept proc exec rpath unix cpath fattr sigaction", nullptr) < 0) {
+    if (pledge("stdio shared_buffer accept proc exec rpath wpath unix cpath fattr sigaction", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
         wait(nullptr);
     });
 
-    if (pledge("stdio shared_buffer accept proc exec rpath", nullptr) < 0) {
+    if (pledge("stdio shared_buffer accept proc exec rpath cpath wpath", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -480,9 +480,11 @@ OwnPtr<Messages::WindowServer::CreateWindowResponse> ClientConnection::handle(co
     window->set_base_size(message.base_size());
     window->set_resize_aspect_ratio(message.resize_aspect_ratio());
     window->invalidate();
+    window->set_af_path(message.af_path());
     if (window->type() == WindowType::MenuApplet)
         AppletManager::the().add_applet(*window);
     m_windows.set(window_id, move(window));
+
     return make<Messages::WindowServer::CreateWindowResponse>(window_id);
 }
 

--- a/Services/WindowServer/Window.cpp
+++ b/Services/WindowServer/Window.cpp
@@ -515,8 +515,10 @@ void Window::ensure_window_menu()
         m_window_menu_maximize_item = maximize_item.ptr();
         m_window_menu->add_item(move(maximize_item));
 
-        auto pin_item = make<MenuItem>(*m_window_menu, 3, "Pin To Taskbar");
-        m_window_menu->add_item(move(pin_item));
+        if (!af_path().is_empty()) {
+            auto pin_item = make<MenuItem>(*m_window_menu, 3, "Pin To Taskbar");
+            m_window_menu->add_item(move(pin_item));
+        }
 
         m_window_menu->add_item(make<MenuItem>(*m_window_menu, MenuItem::Type::Separator));
 

--- a/Services/WindowServer/Window.cpp
+++ b/Services/WindowServer/Window.cpp
@@ -108,7 +108,7 @@ Window::Window(ClientConnection& client, WindowType window_type, int window_id, 
 {
     // FIXME: This should not be hard-coded here.
     if (m_type == WindowType::Taskbar) {
-        m_wm_event_mask = WMEventMask::WindowStateChanges | WMEventMask::WindowRemovals | WMEventMask::WindowIconChanges;
+        m_wm_event_mask = WMEventMask::WindowStateChanges | WMEventMask::WindowRemovals | WMEventMask::WindowIconChanges | WMEventMask::WindowPins;
         m_listens_to_wm_events = true;
     }
 
@@ -515,9 +515,12 @@ void Window::ensure_window_menu()
         m_window_menu_maximize_item = maximize_item.ptr();
         m_window_menu->add_item(move(maximize_item));
 
+        auto pin_item = make<MenuItem>(*m_window_menu, 3, "Pin To Taskbar");
+        m_window_menu->add_item(move(pin_item));
+
         m_window_menu->add_item(make<MenuItem>(*m_window_menu, MenuItem::Type::Separator));
 
-        auto close_item = make<MenuItem>(*m_window_menu, 3, "Close");
+        auto close_item = make<MenuItem>(*m_window_menu, 4, "Close");
         m_window_menu_close_item = close_item.ptr();
         m_window_menu_close_item->set_icon(&close_icon());
         m_window_menu_close_item->set_default(true);
@@ -538,6 +541,9 @@ void Window::ensure_window_menu()
                 WindowManager::the().move_to_front_and_make_active(*this);
                 break;
             case 3:
+                WindowManager::the().tell_wm_listeners_window_pinned(*this);
+                break;
+            case 4:
                 request_close();
                 break;
             }

--- a/Services/WindowServer/Window.h
+++ b/Services/WindowServer/Window.h
@@ -49,6 +49,7 @@ enum WMEventMask {
     WindowStateChanges = 1 << 1,
     WindowIconChanges = 1 << 2,
     WindowRemovals = 1 << 3,
+    WindowPins = 1 << 4,
 };
 
 enum class WindowTileType {
@@ -60,6 +61,7 @@ enum class WindowTileType {
 enum class PopupMenuItem {
     Minimize = 0,
     Maximize,
+    PinToTaskBar,
 };
 
 enum class WindowMenuDefaultAction {

--- a/Services/WindowServer/Window.h
+++ b/Services/WindowServer/Window.h
@@ -287,6 +287,9 @@ public:
     Gfx::DisjointRectSet& transparency_rects() { return m_transparency_rects; }
     Gfx::DisjointRectSet& transparency_wallpaper_rects() { return m_transparency_wallpaper_rects; }
 
+    const String& af_path() const { return m_af_path; }
+    void set_af_path(const StringView& af_path) { m_af_path = af_path; }
+
 private:
     void handle_mouse_event(const MouseEvent&);
     void update_menu_item_text(PopupMenuItem item);
@@ -354,6 +357,7 @@ private:
     MenuItem* m_window_menu_close_item { nullptr };
     int m_minimize_animation_step { -1 };
     int m_progress { -1 };
+    String m_af_path;
 };
 
 }

--- a/Services/WindowServer/WindowClient.ipc
+++ b/Services/WindowServer/WindowClient.ipc
@@ -26,6 +26,7 @@ endpoint WindowClient = 4
     WM_WindowStateChanged(i32 wm_id, i32 client_id, i32 window_id, i32 parent_client_id, i32 parent_window_id, bool is_active, bool is_minimized, bool is_modal, bool is_frameless, i32 window_type, [UTF8] String title, Gfx::IntRect rect, i32 progress) =|
     WM_WindowIconBitmapChanged(i32 wm_id, i32 client_id, i32 window_id, i32 icon_buffer_id, Gfx::IntSize icon_size) =|
     WM_WindowRectChanged(i32 wm_id, i32 client_id, i32 window_id, Gfx::IntRect rect) =|
+    WM_WindowRequestedPin(i32 wm_id, i32 client_id, i32 window_id, [UTF8] String af_path) =|
 
     AsyncSetWallpaperFinished(bool success) =|
 

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -320,6 +320,16 @@ void WindowManager::tell_wm_listener_about_window_icon(Window& listener, Window&
     listener.client()->post_message(Messages::WindowClient::WM_WindowIconBitmapChanged(listener.window_id(), window.client_id(), window.window_id(), window.icon().shbuf_id(), window.icon().size()));
 }
 
+void WindowManager::tell_wm_listener_about_window_pin(Window& listener, Window& window)
+{
+    if (!(listener.wm_event_mask() & WMEventMask::WindowPins))
+        return;
+    if (window.is_internal())
+        return;
+
+    listener.client()->post_message(Messages::WindowClient::WM_WindowRequestedPin(listener.window_id(), window.client_id(), window.window_id()));
+}
+
 void WindowManager::tell_wm_listeners_window_state_changed(Window& window)
 {
     for_each_window_listening_to_wm_events([&](Window& listener) {
@@ -340,6 +350,14 @@ void WindowManager::tell_wm_listeners_window_rect_changed(Window& window)
 {
     for_each_window_listening_to_wm_events([&](Window& listener) {
         tell_wm_listener_about_window_rect(listener, window);
+        return IterationDecision::Continue;
+    });
+}
+
+void WindowManager::tell_wm_listeners_window_pinned(Window& window)
+{
+    for_each_window_listening_to_wm_events([&](Window& listener) {
+        tell_wm_listener_about_window_pin(listener, window);
         return IterationDecision::Continue;
     });
 }

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -327,7 +327,7 @@ void WindowManager::tell_wm_listener_about_window_pin(Window& listener, Window& 
     if (window.is_internal())
         return;
 
-    listener.client()->post_message(Messages::WindowClient::WM_WindowRequestedPin(listener.window_id(), window.client_id(), window.window_id()));
+    listener.client()->post_message(Messages::WindowClient::WM_WindowRequestedPin(listener.window_id(), window.client_id(), window.window_id(), window.af_path()));
 }
 
 void WindowManager::tell_wm_listeners_window_state_changed(Window& window)

--- a/Services/WindowServer/WindowManager.h
+++ b/Services/WindowServer/WindowManager.h
@@ -160,6 +160,7 @@ public:
     void tell_wm_listeners_window_state_changed(Window&);
     void tell_wm_listeners_window_icon_changed(Window&);
     void tell_wm_listeners_window_rect_changed(Window&);
+    void tell_wm_listeners_window_pinned(Window&);
 
     bool is_active_window_or_accessory(Window&) const;
 
@@ -243,6 +244,7 @@ private:
     void tell_wm_listener_about_window(Window& listener, Window&);
     void tell_wm_listener_about_window_icon(Window& listener, Window&);
     void tell_wm_listener_about_window_rect(Window& listener, Window&);
+    void tell_wm_listener_about_window_pin(Window& listener, Window&);
     bool pick_new_active_window(Window*);
 
     void do_move_to_front(Window&, bool, bool);

--- a/Services/WindowServer/WindowServer.ipc
+++ b/Services/WindowServer/WindowServer.ipc
@@ -46,7 +46,8 @@ endpoint WindowServer = 2
         Optional<Gfx::IntSize> resize_aspect_ratio,
         i32 type,
         [UTF8] String title,
-        i32 parent_window_id) => (i32 window_id)
+        i32 parent_window_id,
+        [UTF8] String af_path) => (i32 window_id)
 
     DestroyWindow(i32 window_id) => (Vector<i32> destroyed_window_ids)
 

--- a/Userland/AFLaunch.cpp
+++ b/Userland/AFLaunch.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, Peter Elliott <pelliott@ualberta.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibCore/ArgsParser.h>
+#include <LibDesktop/App.h>
+
+int main(int argc, char** argv)
+{
+    const char* file = nullptr;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_positional_argument(file, "AF file to launch", "file");
+    args_parser.parse(argc, argv);
+
+    Desktop::App app(file);
+
+    if (!app.is_well_formed())
+        return 1;
+
+    app.launch();
+    return 0;
+}

--- a/Userland/CMakeLists.txt
+++ b/Userland/CMakeLists.txt
@@ -15,6 +15,7 @@ foreach(CMD_SRC ${CMD_SOURCES})
     endif()
 endforeach()
 
+target_link_libraries(AFLaunch LibDesktop)
 target_link_libraries(aplay LibAudio)
 target_link_libraries(avol LibAudio)
 target_link_libraries(checksum LibCrypto)


### PR DESCRIPTION
This ended up being more complicated than I expected. Here is a quick rundown of the changes:

- `.af` files are now launched with `Core::App::launch()` which starts the application with the `AF_PATH` environment variable 
- `LibGUI` reads the value of `AF_PATH` and sends it to `WindowServer` when creating a window.
- Context menus for windows now have the option to pin the app to the taskbar.
- When the 'pin' option is clicked, `WindowServer` produces a WM event for WM listeners.
- Taskbar handles the event by adding the application to the taskbar, and saving it.

Closes #4058 