### PR TITLE
Spreadsheet: Invert the drag-selection trigger

### DIFF
--- a/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Applications/Spreadsheet/SpreadsheetView.h
@@ -91,6 +91,7 @@ private:
     virtual void mouseup_event(GUI::MouseEvent&) override;
 
     bool m_should_intercept_drag { false };
+    bool m_has_committed_to_dragging { false };
     GUI::ModelIndex m_starting_selection_index;
 };
 


### PR DESCRIPTION
Make drag-selection the default behaviour, allowing (almost) any part of
the cell to initiate a select.
a small 5x5 rect at the corners of a cell can be used to initiate a
drag-copy instead.
Fixes #4268.