### PR TITLE
Shell: Error out when an expression is nested too deep

### DIFF
--- a/Shell/Parser.cpp
+++ b/Shell/Parser.cpp
@@ -959,6 +959,9 @@ RefPtr<AST::Node> Parser::parse_list_expression()
 RefPtr<AST::Node> Parser::parse_expression()
 {
     auto rule_start = push_start();
+    if (m_rule_start_offsets.size() > max_allowed_nested_rule_depth)
+        return create<AST::SyntaxError>(String::formatted("Expression nested too deep (max allowed is {})", max_allowed_nested_rule_depth));
+
     auto starting_char = peek();
 
     auto read_concat = [&](auto&& expr) -> NonnullRefPtr<AST::Node> {

--- a/Shell/Parser.h
+++ b/Shell/Parser.h
@@ -51,6 +51,7 @@ public:
     SavedOffset save_offset() const;
 
 private:
+    constexpr static size_t max_allowed_nested_rule_depth = 2048;
     RefPtr<AST::Node> parse_toplevel();
     RefPtr<AST::Node> parse_sequence();
     RefPtr<AST::Node> parse_function_decl();


### PR DESCRIPTION
That can happen with too many nested parenthesis, for instance.
This commit sets the maximum allowed limit to 2048 (seems relatively
safe for normal code).
Found by oss-fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28105&q=label%3AProj-serenity