### PR TITLE
Kernel: Fix leaking a reference on thread creation

### DIFF
--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -60,7 +60,7 @@ int Process::sys$create_thread(void* (*entry)(void*), Userspace<const Syscall::S
 
     // FIXME: Do something with guard pages?
 
-    auto* thread = new Thread(*this);
+    auto thread = adopt(*new Thread(*this));
 
     // We know this thread is not the main_thread,
     // So give it a unique name until the user calls $set_thread_name on it


### PR DESCRIPTION
New Thread objects should be adopted into a RefPtr upon creation.
If creating a thread failed (e.g. out of memory), releasing the RefPtr
will destruct the partially created object, but in the successful case
the thread will add an additional reference that it keeps until it
finishes execution. Adopting will drop it to 1 when returning from
create_thread, or 0 if the thread could not be fully constructed.