### PR TITLE
Kernel: Don't assert if we can't deliver a signal due to thread state

### DIFF
--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -490,7 +490,8 @@ DispatchSignalResult Thread::dispatch_one_pending_signal()
 {
     ASSERT(m_lock.own_lock());
     u32 signal_candidates = pending_signals_for_state() & ~m_signal_mask;
-    ASSERT(signal_candidates);
+    if (signal_candidates == 0)
+        return DispatchSignalResult::Continue;
 
     u8 signal = 1;
     for (; signal < 32; ++signal) {


### PR DESCRIPTION
Fixes an assertion found in #3990