### PR TITLE
LibAudio: Change the API to allow for multiple file formats

### DIFF
--- a/Applications/Piano/Track.cpp
+++ b/Applications/Piano/Track.cpp
@@ -27,7 +27,7 @@
 
 #include "Track.h"
 #include <AK/NumericLimits.h>
-#include <LibAudio/WavLoader.h>
+#include <LibAudio/Loader.h>
 #include <math.h>
 
 Track::Track(const u32& time)
@@ -138,19 +138,19 @@ void Track::reset()
 
 String Track::set_recorded_sample(const StringView& path)
 {
-    Audio::WavLoader wav_loader(path);
-    if (wav_loader.has_error())
-        return String(wav_loader.error_string());
-    auto wav_buffer = wav_loader.get_more_samples(60 * sample_rate * sizeof(Sample)); // 1 minute maximum
+    NonnullRefPtr<Audio::Loader> loader = Audio::Loader::create(path);
+    if (loader->has_error())
+        return String(loader->error_string());
+    auto buffer = loader->get_more_samples(60 * sample_rate * sizeof(Sample)); // 1 minute maximum
 
     if (!m_recorded_sample.is_empty())
         m_recorded_sample.clear();
-    m_recorded_sample.resize(wav_buffer->sample_count());
+    m_recorded_sample.resize(buffer->sample_count());
 
     double peak = 0;
-    for (int i = 0; i < wav_buffer->sample_count(); ++i) {
-        double left_abs = fabs(wav_buffer->samples()[i].left);
-        double right_abs = fabs(wav_buffer->samples()[i].right);
+    for (int i = 0; i < buffer->sample_count(); ++i) {
+        double left_abs = fabs(buffer->samples()[i].left);
+        double right_abs = fabs(buffer->samples()[i].right);
         if (left_abs > peak)
             peak = left_abs;
         if (right_abs > peak)
@@ -158,9 +158,9 @@ String Track::set_recorded_sample(const StringView& path)
     }
 
     if (peak) {
-        for (int i = 0; i < wav_buffer->sample_count(); ++i) {
-            m_recorded_sample[i].left = wav_buffer->samples()[i].left / peak;
-            m_recorded_sample[i].right = wav_buffer->samples()[i].right / peak;
+        for (int i = 0; i < buffer->sample_count(); ++i) {
+            m_recorded_sample[i].left = buffer->samples()[i].left / peak;
+            m_recorded_sample[i].right = buffer->samples()[i].right / peak;
         }
     }
 

--- a/Applications/SoundPlayer/PlaybackManager.cpp
+++ b/Applications/SoundPlayer/PlaybackManager.cpp
@@ -41,10 +41,10 @@ PlaybackManager::~PlaybackManager()
 {
 }
 
-void PlaybackManager::set_loader(OwnPtr<Audio::WavLoader>&& loader)
+void PlaybackManager::set_loader(NonnullRefPtr<Audio::Loader>&& loader)
 {
     stop();
-    m_loader = move(loader);
+    m_loader = loader;
     if (m_loader) {
         m_total_length = m_loader->total_samples() / static_cast<float>(m_loader->sample_rate());
         m_timer->start();

--- a/Applications/SoundPlayer/PlaybackManager.h
+++ b/Applications/SoundPlayer/PlaybackManager.h
@@ -27,8 +27,9 @@
 #pragma once
 
 #include <AK/Vector.h>
+#include <LibAudio/Buffer.h>
 #include <LibAudio/ClientConnection.h>
-#include <LibAudio/WavLoader.h>
+#include <LibAudio/Loader.h>
 #include <LibCore/Timer.h>
 
 #define PLAYBACK_MANAGER_BUFFER_SIZE 64 * KiB
@@ -45,7 +46,7 @@ public:
     void seek(const int position);
     void loop(bool);
     bool toggle_pause();
-    void set_loader(OwnPtr<Audio::WavLoader>&&);
+    void set_loader(NonnullRefPtr<Audio::Loader>&&);
 
     int last_seek() const { return m_last_seek; }
     bool is_paused() const { return m_paused; }
@@ -67,7 +68,7 @@ private:
     size_t m_next_ptr { 0 };
     size_t m_last_seek { 0 };
     float m_total_length { 0 };
-    OwnPtr<Audio::WavLoader> m_loader { nullptr };
+    RefPtr<Audio::Loader> m_loader { nullptr };
     NonnullRefPtr<Audio::ClientConnection> m_connection;
     RefPtr<Audio::Buffer> m_next_buffer;
     RefPtr<Audio::Buffer> m_current_buffer;

--- a/Applications/SoundPlayer/SoundPlayerWidget.cpp
+++ b/Applications/SoundPlayer/SoundPlayerWidget.cpp
@@ -119,15 +119,10 @@ void SoundPlayerWidget::hide_scope(bool hide)
 
 void SoundPlayerWidget::open_file(String path)
 {
-    if (!path.ends_with(".wav")) {
-        GUI::MessageBox::show(window(), "Selected file is not a \".wav\" file!", "Filetype error", GUI::MessageBox::Type::Error);
-        return;
-    }
-
-    OwnPtr<Audio::WavLoader> loader = make<Audio::WavLoader>(path);
+    NonnullRefPtr<Audio::Loader> loader = Audio::Loader::create(path);
     if (loader->has_error()) {
         GUI::MessageBox::show(window(),
-            String::formatted("Failed to load WAV file: {} ({})", path, loader->error_string()),
+            String::formatted("Failed to load audio file: {} ({})", path, loader->error_string()),
             "Filetype error", GUI::MessageBox::Type::Error);
         return;
     }

--- a/Libraries/LibAudio/Buffer.cpp
+++ b/Libraries/LibAudio/Buffer.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibAudio/Buffer.h>
+
+namespace Audio {
+
+template<typename SampleReader>
+static void read_samples_from_stream(InputMemoryStream& stream, SampleReader read_sample, Vector<Sample>& samples, ResampleHelper& resampler, int num_channels)
+{
+    double norm_l = 0;
+    double norm_r = 0;
+
+    switch (num_channels) {
+    case 1:
+        for (;;) {
+            while (resampler.read_sample(norm_l, norm_r)) {
+                samples.append(Sample(norm_l));
+            }
+            norm_l = read_sample(stream);
+
+            if (stream.handle_any_error()) {
+                break;
+            }
+            resampler.process_sample(norm_l, norm_r);
+        }
+        break;
+    case 2:
+        for (;;) {
+            while (resampler.read_sample(norm_l, norm_r)) {
+                samples.append(Sample(norm_l, norm_r));
+            }
+            norm_l = read_sample(stream);
+            norm_r = read_sample(stream);
+
+            if (stream.handle_any_error()) {
+                break;
+            }
+            resampler.process_sample(norm_l, norm_r);
+        }
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+}
+
+static double read_norm_sample_24(InputMemoryStream& stream)
+{
+    u8 byte = 0;
+    stream >> byte;
+    u32 sample1 = byte;
+    stream >> byte;
+    u32 sample2 = byte;
+    stream >> byte;
+    u32 sample3 = byte;
+
+    i32 value = 0;
+    value = sample1 << 8;
+    value |= (sample2 << 16);
+    value |= (sample3 << 24);
+    return double(value) / NumericLimits<i32>::max();
+}
+
+static double read_norm_sample_16(InputMemoryStream& stream)
+{
+    LittleEndian<i16> sample;
+    stream >> sample;
+    return double(sample) / NumericLimits<i16>::max();
+}
+
+static double read_norm_sample_8(InputMemoryStream& stream)
+{
+    u8 sample = 0;
+    stream >> sample;
+    return double(sample) / NumericLimits<u8>::max();
+}
+    
+RefPtr<Buffer> Buffer::from_pcm_data(ReadonlyBytes data, ResampleHelper& resampler, int num_channels, int bits_per_sample)
+{
+    InputMemoryStream stream { data };
+    return from_pcm_stream(stream, resampler, num_channels, bits_per_sample, data.size() / (bits_per_sample / 8));
+}
+
+RefPtr<Buffer> Buffer::from_pcm_stream(InputMemoryStream &stream, ResampleHelper& resampler, int num_channels, int bits_per_sample, int num_samples)
+{
+    Vector<Sample> fdata;
+    fdata.ensure_capacity(num_samples);
+
+    switch (bits_per_sample) {
+    case 8:
+        read_samples_from_stream(stream, read_norm_sample_8, fdata, resampler, num_channels);
+        break;
+    case 16:
+        read_samples_from_stream(stream, read_norm_sample_16, fdata, resampler, num_channels);
+        break;
+    case 24:
+        read_samples_from_stream(stream, read_norm_sample_24, fdata, resampler, num_channels);
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+
+    // We should handle this in a better way above, but for now --
+    // just make sure we're good. Worst case we just write some 0s where they
+    // don't belong.
+    ASSERT(!stream.handle_any_error());
+
+    return Buffer::create_with_samples(move(fdata));
+}
+
+}

--- a/Libraries/LibAudio/Buffer.cpp
+++ b/Libraries/LibAudio/Buffer.cpp
@@ -97,14 +97,14 @@ static double read_norm_sample_8(InputMemoryStream& stream)
     stream >> sample;
     return double(sample) / NumericLimits<u8>::max();
 }
-    
+
 RefPtr<Buffer> Buffer::from_pcm_data(ReadonlyBytes data, ResampleHelper& resampler, int num_channels, int bits_per_sample)
 {
     InputMemoryStream stream { data };
     return from_pcm_stream(stream, resampler, num_channels, bits_per_sample, data.size() / (bits_per_sample / 8));
 }
 
-RefPtr<Buffer> Buffer::from_pcm_stream(InputMemoryStream &stream, ResampleHelper& resampler, int num_channels, int bits_per_sample, int num_samples)
+RefPtr<Buffer> Buffer::from_pcm_stream(InputMemoryStream& stream, ResampleHelper& resampler, int num_channels, int bits_per_sample, int num_samples)
 {
     Vector<Sample> fdata;
     fdata.ensure_capacity(num_samples);

--- a/Libraries/LibAudio/Buffer.h
+++ b/Libraries/LibAudio/Buffer.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/MemoryStream.h>
 #include <AK/SharedBuffer.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
@@ -108,7 +109,8 @@ private:
 // A buffer of audio samples, normalized to 44100hz.
 class Buffer : public RefCounted<Buffer> {
 public:
-    static RefPtr<Buffer> from_pcm_data(ReadonlyBytes, ResampleHelper& resampler, int num_channels, int bits_per_sample);
+    static RefPtr<Buffer> from_pcm_data(ReadonlyBytes data, ResampleHelper& resampler, int num_channels, int bits_per_sample);
+    static RefPtr<Buffer> from_pcm_stream(InputMemoryStream& stream, ResampleHelper& resampler, int num_channels, int bits_per_sample, int num_samples);
     static NonnullRefPtr<Buffer> create_with_samples(Vector<Sample>&& samples)
     {
         return adopt(*new Buffer(move(samples)));

--- a/Libraries/LibAudio/CMakeLists.txt
+++ b/Libraries/LibAudio/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    Buffer.cpp
     ClientConnection.cpp
     Loader.cpp
     WavLoader.cpp

--- a/Libraries/LibAudio/CMakeLists.txt
+++ b/Libraries/LibAudio/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     ClientConnection.cpp
+    Loader.cpp
     WavLoader.cpp
     WavWriter.cpp
 )

--- a/Libraries/LibAudio/Loader.cpp
+++ b/Libraries/LibAudio/Loader.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018-2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibAudio/WavLoader.h>
+
+namespace Audio {
+
+Loader::Loader(const StringView& path)
+{
+    m_plugin = make<WavLoaderPlugin>(path);
+    if (m_plugin->sniff())
+        return;
+    m_plugin = nullptr;
+}
+
+}

--- a/Libraries/LibAudio/Loader.cpp
+++ b/Libraries/LibAudio/Loader.cpp
@@ -36,4 +36,12 @@ Loader::Loader(const StringView& path)
     m_plugin = nullptr;
 }
 
+Loader::Loader(const ByteBuffer& buffer)
+{
+    m_plugin = make<WavLoaderPlugin>(buffer);
+    if (m_plugin->sniff())
+        return;
+    m_plugin = nullptr;
+}
+
 }

--- a/Libraries/LibAudio/Loader.h
+++ b/Libraries/LibAudio/Loader.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2018-2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <AK/StringView.h>
+#include <LibCore/File.h>
+
+namespace Audio {
+
+class LoaderPlugin {
+public:
+    virtual ~LoaderPlugin() { }
+
+    virtual bool sniff() = 0;
+
+    virtual bool has_error() { return false; }
+    virtual const char* error_string() { return ""; }
+
+    virtual RefPtr<Buffer> get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) = 0;
+
+    virtual void reset() = 0;
+    virtual void seek(const int position) = 0;
+
+    virtual int loaded_samples() = 0;
+    virtual int total_samples() = 0;
+    virtual u32 sample_rate() = 0;
+    virtual u16 num_channels() = 0;
+    virtual u16 bits_per_sample() = 0;
+    virtual RefPtr<Core::File> file() = 0;
+};
+
+class Loader : public RefCounted<Loader> {
+public:
+    static NonnullRefPtr<Loader> create(const StringView& path) { return adopt(*new Loader(path)); }
+
+    bool has_error() const { return m_plugin ? m_plugin->has_error() : true; }
+    const char* error_string() const { return m_plugin ? m_plugin->error_string() : "No loader plugin available"; }
+
+    RefPtr<Buffer> get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) const { return m_plugin ? m_plugin->get_more_samples(max_bytes_to_read_from_input) : nullptr; }
+
+    void reset() const
+    {
+        if (m_plugin)
+            m_plugin->reset();
+    }
+    void seek(const int position) const
+    {
+        if (m_plugin)
+            m_plugin->seek(position);
+    }
+
+    int loaded_samples() const { return m_plugin ? m_plugin->loaded_samples() : 0; }
+    int total_samples() const { return m_plugin ? m_plugin->total_samples() : 0; }
+    u32 sample_rate() const { return m_plugin ? m_plugin->sample_rate() : 0; }
+    u16 num_channels() const { return m_plugin ? m_plugin->num_channels() : 0; }
+    u16 bits_per_sample() const { return m_plugin ? m_plugin->bits_per_sample() : 0; }
+    RefPtr<Core::File> file() const { return m_plugin ? m_plugin->file() : nullptr; }
+
+private:
+    Loader(const StringView& path);
+
+    mutable OwnPtr<LoaderPlugin> m_plugin;
+};
+
+}

--- a/Libraries/LibAudio/Loader.h
+++ b/Libraries/LibAudio/Loader.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/StringView.h>
@@ -58,6 +59,7 @@ public:
 class Loader : public RefCounted<Loader> {
 public:
     static NonnullRefPtr<Loader> create(const StringView& path) { return adopt(*new Loader(path)); }
+    static NonnullRefPtr<Loader> create(const ByteBuffer& buffer) { return adopt(*new Loader(buffer)); }
 
     bool has_error() const { return m_plugin ? m_plugin->has_error() : true; }
     const char* error_string() const { return m_plugin ? m_plugin->error_string() : "No loader plugin available"; }
@@ -84,6 +86,7 @@ public:
 
 private:
     Loader(const StringView& path);
+    Loader(const ByteBuffer& buffer);
 
     mutable OwnPtr<LoaderPlugin> m_plugin;
 };

--- a/Libraries/LibAudio/WavLoader.cpp
+++ b/Libraries/LibAudio/WavLoader.cpp
@@ -24,9 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/MemoryStream.h>
 #include <AK/NumericLimits.h>
 #include <AK/OwnPtr.h>
+#include <LibAudio/Buffer.h>
 #include <LibAudio/WavLoader.h>
 #include <LibCore/File.h>
 #include <LibCore/IODeviceStreamReader.h>
@@ -48,6 +48,21 @@ WavLoaderPlugin::WavLoaderPlugin(const StringView& path)
     m_resampler = make<ResampleHelper>(m_sample_rate, 44100);
 }
 
+WavLoaderPlugin::WavLoaderPlugin(const ByteBuffer& buffer)
+{
+    m_stream = make<InputMemoryStream>(buffer);
+    if (!m_stream) {
+        m_error_string = String::formatted("Can't open memory stream");
+        return;
+    }
+
+    valid = parse_header();
+    if (!valid)
+        return;
+
+    m_resampler = make<ResampleHelper>(m_sample_rate, 44100);
+}
+
 bool WavLoaderPlugin::sniff()
 {
     return valid;
@@ -58,14 +73,18 @@ RefPtr<Buffer> WavLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_i
 #ifdef AWAVLOADER_DEBUG
     dbgln("Read WAV of format PCM with num_channels {} sample rate {}, bits per sample {}", m_num_channels, m_sample_rate, m_bits_per_sample);
 #endif
-
-    auto raw_samples = m_file->read(max_bytes_to_read_from_input);
-    if (raw_samples.is_empty())
-        return nullptr;
-
-    auto buffer = Buffer::from_pcm_data(raw_samples, *m_resampler, m_num_channels, m_bits_per_sample);
+    size_t samples_to_read = static_cast<int>(max_bytes_to_read_from_input) / (m_num_channels * (m_bits_per_sample / 8));
+    RefPtr<Buffer> buffer;
+    if (m_file) {
+        auto raw_samples = m_file->read(max_bytes_to_read_from_input);
+        if (raw_samples.is_empty())
+            return nullptr;
+        buffer = Buffer::from_pcm_data(raw_samples, *m_resampler, m_num_channels, m_bits_per_sample);
+    } else {
+        buffer = Buffer::from_pcm_stream(*m_stream, *m_resampler, m_num_channels, m_bits_per_sample, samples_to_read);
+    }
     //Buffer contains normalized samples, but m_loaded_samples should contain the amount of actually loaded samples
-    m_loaded_samples += static_cast<int>(max_bytes_to_read_from_input) / (m_num_channels * (m_bits_per_sample / 8));
+    m_loaded_samples += samples_to_read;
     m_loaded_samples = min(m_total_samples, m_loaded_samples);
     return buffer;
 }
@@ -76,7 +95,12 @@ void WavLoaderPlugin::seek(const int position)
         return;
 
     m_loaded_samples = position;
-    m_file->seek(position * m_num_channels * (m_bits_per_sample / 8));
+    size_t byte_position = position * m_num_channels * (m_bits_per_sample / 8);
+
+    if (m_file)
+        m_file->seek(byte_position);
+    else
+        m_stream->seek(byte_position);
 }
 
 void WavLoaderPlugin::reset()
@@ -86,73 +110,95 @@ void WavLoaderPlugin::reset()
 
 bool WavLoaderPlugin::parse_header()
 {
-    Core::IODeviceStreamReader stream(*m_file);
+    OwnPtr<Core::IODeviceStreamReader> file_stream;
+    bool ok = true;
 
-#define CHECK_OK(msg)                                                              \
-    do {                                                                           \
-        if (stream.handle_read_failure()) {                                        \
-            m_error_string = String::formatted("Premature stream EOF at {}", msg); \
-            return {};                                                             \
-        }                                                                          \
-        if (!ok) {                                                                 \
-            m_error_string = String::formatted("Parsing failed: {}", msg);         \
-            return {};                                                             \
-        } else {                                                                   \
-            dbgln("{} is OK!", msg);                                               \
-        }                                                                          \
+    if (m_file)
+        file_stream = make<Core::IODeviceStreamReader>(*m_file);
+
+    auto read_u8 = [&]() -> u8 {
+        u8 value;
+        if (m_file) {
+            *file_stream >> value;
+            if (file_stream->handle_read_failure()) {
+                ok = false;
+            }
+        }
+        return value;
+    };
+
+    auto read_u16 = [&]() -> u16 {
+        u16 value;
+        if (m_file) {
+            *file_stream >> value;
+            if (file_stream->handle_read_failure()) {
+                ok = false;
+            }
+        }
+        return value;
+    };
+
+    auto read_u32 = [&]() -> u32 {
+        u32 value;
+        if (m_file) {
+            *file_stream >> value;
+            if (file_stream->handle_read_failure()) {
+                ok = false;
+            }
+        }
+        return value;
+    };
+
+#define CHECK_OK(msg)                                                      \
+    do {                                                                   \
+        if (!ok) {                                                         \
+            m_error_string = String::formatted("Parsing failed: {}", msg); \
+            return {};                                                     \
+        }                                                                  \
     } while (0);
 
-    bool ok = true;
-    u32 riff;
-    stream >> riff;
+    u32 riff = read_u32();
     ok = ok && riff == 0x46464952; // "RIFF"
     CHECK_OK("RIFF header");
 
-    u32 sz;
-    stream >> sz;
+    u32 sz = read_u32();
     ok = ok && sz < 1024 * 1024 * 1024; // arbitrary
     CHECK_OK("File size");
     ASSERT(sz < 1024 * 1024 * 1024);
 
-    u32 wave;
-    stream >> wave;
+    u32 wave = read_u32();
     ok = ok && wave == 0x45564157; // "WAVE"
     CHECK_OK("WAVE header");
 
-    u32 fmt_id;
-    stream >> fmt_id;
+    u32 fmt_id = read_u32();
     ok = ok && fmt_id == 0x20746D66; // "FMT"
     CHECK_OK("FMT header");
 
-    u32 fmt_size;
-    stream >> fmt_size;
+    u32 fmt_size = read_u32();
     ok = ok && fmt_size == 16;
     CHECK_OK("FMT size");
     ASSERT(fmt_size == 16);
 
-    u16 audio_format;
-    stream >> audio_format;
+    u16 audio_format = read_u16();
     CHECK_OK("Audio format");     // incomplete read check
     ok = ok && audio_format == 1; // WAVE_FORMAT_PCM
     ASSERT(audio_format == 1);
     CHECK_OK("Audio format"); // value check
 
-    stream >> m_num_channels;
+    m_num_channels = read_u16();
     ok = ok && (m_num_channels == 1 || m_num_channels == 2);
     CHECK_OK("Channel count");
 
-    stream >> m_sample_rate;
+    m_sample_rate = read_u32();
     CHECK_OK("Sample rate");
 
-    u32 byte_rate;
-    stream >> byte_rate;
+    read_u32();
     CHECK_OK("Byte rate");
 
-    u16 block_align;
-    stream >> block_align;
+    read_u16();
     CHECK_OK("Block align");
 
-    stream >> m_bits_per_sample;
+    m_bits_per_sample = read_u16();
     CHECK_OK("Bits per sample"); // incomplete read check
     ok = ok && (m_bits_per_sample == 8 || m_bits_per_sample == 16 || m_bits_per_sample == 24);
     ASSERT(m_bits_per_sample == 8 || m_bits_per_sample == 16 || m_bits_per_sample == 24);
@@ -163,23 +209,22 @@ bool WavLoaderPlugin::parse_header()
     u32 data_sz = 0;
     u8 search_byte = 0;
     while (true) {
-        stream >> search_byte;
+        search_byte = read_u8();
         CHECK_OK("Reading byte searching for data");
         if (search_byte != 0x64) //D
             continue;
 
-        stream >> search_byte;
+        search_byte = read_u8();
         CHECK_OK("Reading next byte searching for data");
         if (search_byte != 0x61) //A
             continue;
 
-        u16 search_remaining = 0;
-        stream >> search_remaining;
+        u16 search_remaining = read_u16();
         CHECK_OK("Reading remaining bytes searching for data");
         if (search_remaining != 0x6174) //TA
             continue;
 
-        stream >> data_sz;
+        data_sz = read_u32();
         found_data = true;
         break;
     }
@@ -193,9 +238,6 @@ bool WavLoaderPlugin::parse_header()
 
     int bytes_per_sample = (m_bits_per_sample / 8) * m_num_channels;
     m_total_samples = data_sz / bytes_per_sample;
-
-    // Just make sure we're good before we read the data...
-    ASSERT(!stream.handle_read_failure());
 
     return true;
 }
@@ -222,107 +264,6 @@ bool ResampleHelper::read_sample(double& next_l, double& next_r)
     }
 
     return false;
-}
-
-template<typename SampleReader>
-static void read_samples_from_stream(InputMemoryStream& stream, SampleReader read_sample, Vector<Sample>& samples, ResampleHelper& resampler, int num_channels)
-{
-    double norm_l = 0;
-    double norm_r = 0;
-
-    switch (num_channels) {
-    case 1:
-        for (;;) {
-            while (resampler.read_sample(norm_l, norm_r)) {
-                samples.append(Sample(norm_l));
-            }
-            norm_l = read_sample(stream);
-
-            if (stream.handle_any_error()) {
-                break;
-            }
-            resampler.process_sample(norm_l, norm_r);
-        }
-        break;
-    case 2:
-        for (;;) {
-            while (resampler.read_sample(norm_l, norm_r)) {
-                samples.append(Sample(norm_l, norm_r));
-            }
-            norm_l = read_sample(stream);
-            norm_r = read_sample(stream);
-
-            if (stream.handle_any_error()) {
-                break;
-            }
-            resampler.process_sample(norm_l, norm_r);
-        }
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-    }
-}
-
-static double read_norm_sample_24(InputMemoryStream& stream)
-{
-    u8 byte = 0;
-    stream >> byte;
-    u32 sample1 = byte;
-    stream >> byte;
-    u32 sample2 = byte;
-    stream >> byte;
-    u32 sample3 = byte;
-
-    i32 value = 0;
-    value = sample1 << 8;
-    value |= (sample2 << 16);
-    value |= (sample3 << 24);
-    return double(value) / NumericLimits<i32>::max();
-}
-
-static double read_norm_sample_16(InputMemoryStream& stream)
-{
-    LittleEndian<i16> sample;
-    stream >> sample;
-    return double(sample) / NumericLimits<i16>::max();
-}
-
-static double read_norm_sample_8(InputMemoryStream& stream)
-{
-    u8 sample = 0;
-    stream >> sample;
-    return double(sample) / NumericLimits<u8>::max();
-}
-
-RefPtr<Buffer> Buffer::from_pcm_data(ReadonlyBytes data, ResampleHelper& resampler, int num_channels, int bits_per_sample)
-{
-    InputMemoryStream stream { data };
-    Vector<Sample> fdata;
-    fdata.ensure_capacity(data.size() / (bits_per_sample / 8));
-#ifdef AWAVLOADER_DEBUG
-    dbgln("Reading {} bits and {} channels, total bytes: {}", bits_per_sample, num_channels, data.size());
-#endif
-
-    switch (bits_per_sample) {
-    case 8:
-        read_samples_from_stream(stream, read_norm_sample_8, fdata, resampler, num_channels);
-        break;
-    case 16:
-        read_samples_from_stream(stream, read_norm_sample_16, fdata, resampler, num_channels);
-        break;
-    case 24:
-        read_samples_from_stream(stream, read_norm_sample_24, fdata, resampler, num_channels);
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-    }
-
-    // We should handle this in a better way above, but for now --
-    // just make sure we're good. Worst case we just write some 0s where they
-    // don't belong.
-    ASSERT(!stream.handle_any_error());
-
-    return Buffer::create_with_samples(move(fdata));
 }
 
 }

--- a/Libraries/LibAudio/WavLoader.h
+++ b/Libraries/LibAudio/WavLoader.h
@@ -31,33 +31,38 @@
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibAudio/Buffer.h>
+#include <LibAudio/Loader.h>
 #include <LibCore/File.h>
 
 namespace Audio {
 class Buffer;
 
 // Parses a WAV file and produces an Audio::Buffer.
-class WavLoader {
+class WavLoaderPlugin : public LoaderPlugin {
 public:
-    explicit WavLoader(const StringView& path);
+    explicit WavLoaderPlugin(const StringView& path);
 
-    bool has_error() const { return !m_error_string.is_null(); }
-    const char* error_string() { return m_error_string.characters(); }
+    virtual bool sniff() override;
 
-    RefPtr<Buffer> get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB);
+    virtual bool has_error() override { return !m_error_string.is_null(); }
+    virtual const char* error_string() override { return m_error_string.characters(); }
 
-    void reset();
-    void seek(const int position);
+    virtual RefPtr<Buffer> get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) override;
 
-    int loaded_samples() const { return m_loaded_samples; }
-    int total_samples() const { return m_total_samples; }
-    u32 sample_rate() const { return m_sample_rate; }
-    u16 num_channels() const { return m_num_channels; }
-    u16 bits_per_sample() const { return m_bits_per_sample; }
-    RefPtr<Core::File> file() const { return m_file; }
+    virtual void reset() override;
+    virtual void seek(const int position) override;
+
+    virtual int loaded_samples() override { return m_loaded_samples; }
+    virtual int total_samples() override { return m_total_samples; }
+    virtual u32 sample_rate() override { return m_sample_rate; }
+    virtual u16 num_channels() override { return m_num_channels; }
+    virtual u16 bits_per_sample() override { return m_bits_per_sample; }
+    virtual RefPtr<Core::File> file() override { return m_file; }
 
 private:
     bool parse_header();
+
+    bool valid { false };
     RefPtr<Core::File> m_file;
     String m_error_string;
     OwnPtr<ResampleHelper> m_resampler;

--- a/Libraries/LibAudio/WavLoader.h
+++ b/Libraries/LibAudio/WavLoader.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
+#include <AK/MemoryStream.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
@@ -40,7 +42,8 @@ class Buffer;
 // Parses a WAV file and produces an Audio::Buffer.
 class WavLoaderPlugin : public LoaderPlugin {
 public:
-    explicit WavLoaderPlugin(const StringView& path);
+    WavLoaderPlugin(const StringView& path);
+    WavLoaderPlugin(const ByteBuffer& buffer);
 
     virtual bool sniff() override;
 
@@ -64,6 +67,7 @@ private:
 
     bool valid { false };
     RefPtr<Core::File> m_file;
+    OwnPtr<InputMemoryStream> m_stream;
     String m_error_string;
     OwnPtr<ResampleHelper> m_resampler;
 

--- a/Userland/aplay.cpp
+++ b/Userland/aplay.cpp
@@ -26,7 +26,7 @@
 
 #include <LibAudio/Buffer.h>
 #include <LibAudio/ClientConnection.h>
-#include <LibAudio/WavLoader.h>
+#include <LibAudio/Loader.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <stdio.h>
@@ -37,7 +37,7 @@ int main(int argc, char** argv)
     bool should_loop = false;
 
     Core::ArgsParser args_parser;
-    args_parser.add_positional_argument(path, "Path to WAV file", "path");
+    args_parser.add_positional_argument(path, "Path to audio file", "path");
     args_parser.add_option(should_loop, "Loop playback", "loop", 'l');
     args_parser.parse(argc, argv);
 
@@ -45,27 +45,27 @@ int main(int argc, char** argv)
 
     auto audio_client = Audio::ClientConnection::construct();
     audio_client->handshake();
-    Audio::WavLoader loader(path);
-    if (loader.has_error()) {
-        fprintf(stderr, "Failed to load WAV file: %s\n", loader.error_string());
+    NonnullRefPtr<Audio::Loader> loader = Audio::Loader::create(path);
+    if (loader->has_error()) {
+        fprintf(stderr, "Failed to load audio file: %s\n", loader->error_string());
         return 1;
     }
 
     printf("\033[34;1m Playing\033[0m: %s\n", path);
     printf("\033[34;1m  Format\033[0m: %u Hz, %u-bit, %s\n",
-        loader.sample_rate(),
-        loader.bits_per_sample(),
-        loader.num_channels() == 1 ? "Mono" : "Stereo");
+        loader->sample_rate(),
+        loader->bits_per_sample(),
+        loader->num_channels() == 1 ? "Mono" : "Stereo");
     printf("\033[34;1mProgress\033[0m: \033[s");
     for (;;) {
-        auto samples = loader.get_more_samples();
+        auto samples = loader->get_more_samples();
         if (samples) {
             printf("\033[u");
-            printf("%d/%d", loader.loaded_samples(), loader.total_samples());
+            printf("%d/%d", loader->loaded_samples(), loader->total_samples());
             fflush(stdout);
             audio_client->enqueue(*samples);
         } else if (should_loop) {
-            loader.reset();
+            loader->reset();
         } else if (audio_client->get_remaining_samples()) {
             sleep(1);
         } else {


### PR DESCRIPTION
This patch adds a generic interface for loading any kind of supported audio file format, instead of just WAV. 