### PR TITLE
SystemMonitor: Add Interrupts tab

### DIFF
--- a/Applications/SystemMonitor/CMakeLists.txt
+++ b/Applications/SystemMonitor/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     DevicesModel.cpp
     GraphWidget.cpp
+    InterruptsWidget.cpp
     main.cpp
     MemoryStatsWidget.cpp
     NetworkStatisticsWidget.cpp

--- a/Applications/SystemMonitor/InterruptsWidget.cpp
+++ b/Applications/SystemMonitor/InterruptsWidget.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "InterruptsWidget.h"
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/GroupBox.h>
+#include <LibGUI/JsonArrayModel.h>
+#include <LibGUI/SortingProxyModel.h>
+#include <LibGUI/TableView.h>
+
+InterruptsWidget::InterruptsWidget()
+{
+    on_first_show = [this](auto&) {
+        set_layout<GUI::VerticalBoxLayout>();
+        layout()->set_margins({ 4, 4, 4, 4 });
+
+        Vector<GUI::JsonArrayModel::FieldSpec> interrupts_field;
+        interrupts_field.empend("interrupt_line", "Line", Gfx::TextAlignment::CenterRight);
+        interrupts_field.empend("purpose", "Purpose", Gfx::TextAlignment::CenterLeft);
+        interrupts_field.empend("controller", "Controller", Gfx::TextAlignment::CenterLeft);
+        interrupts_field.empend("cpu_handler", "CPU Handler", Gfx::TextAlignment::CenterRight);
+        interrupts_field.empend("device_sharing", "# Devices Sharing", Gfx::TextAlignment::CenterRight);
+        interrupts_field.empend("call_count", "Call Count", Gfx::TextAlignment::CenterRight);
+
+        m_interrupt_table_view = add<GUI::TableView>();
+        m_interrupt_model = GUI::JsonArrayModel::create("/proc/interrupts", move(interrupts_field));
+        m_interrupt_table_view->set_model(GUI::SortingProxyModel::create(*m_interrupt_model));
+
+        m_update_timer = add<Core::Timer>(
+            1000, [this] {
+                update_model();
+            });
+
+        update_model();
+    };
+}
+
+InterruptsWidget::~InterruptsWidget()
+{
+}
+
+void InterruptsWidget::update_model()
+{
+    m_interrupt_table_view->model()->update();
+}

--- a/Applications/SystemMonitor/InterruptsWidget.h
+++ b/Applications/SystemMonitor/InterruptsWidget.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibCore/Timer.h>
+#include <LibGUI/LazyWidget.h>
+
+class InterruptsWidget final : public GUI::LazyWidget {
+    C_OBJECT(InterruptsWidget)
+public:
+    virtual ~InterruptsWidget() override;
+
+private:
+    InterruptsWidget();
+    void update_model();
+
+    RefPtr<GUI::TableView> m_interrupt_table_view;
+    RefPtr<GUI::JsonArrayModel> m_interrupt_model;
+    RefPtr<Core::Timer> m_update_timer;
+};

--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -26,6 +26,7 @@
 
 #include "DevicesModel.h"
 #include "GraphWidget.h"
+#include "InterruptsWidget.h"
 #include "MemoryStatsWidget.h"
 #include "NetworkStatisticsWidget.h"
 #include "ProcessFileDescriptorMapWidget.h"
@@ -178,6 +179,9 @@ int main(int argc, char** argv)
     tabwidget.add_widget("Network", network_stats_widget);
 
     tabwidget.add_widget("Processors", build_processors_tab());
+
+    auto interrupts_widget = InterruptsWidget::construct();
+    tabwidget.add_widget("Interrupts", interrupts_widget);
 
     process_table_container.set_layout<GUI::VerticalBoxLayout>();
     process_table_container.layout()->set_spacing(0);


### PR DESCRIPTION
I was looking through the proc folder, noticed this and thought
"why not?"

It's setup as an updating model because of the call count, however,
the call count doesn't appear to be working right now.

Demo:
![vmplayer_FZbbRXjmsW](https://user-images.githubusercontent.com/25595356/100794615-b7f24e80-3415-11eb-9645-2835eb948d5b.png)

