### PR TITLE
Kernel: TimerQueue::cancel_timer needs to wait if timer is executing

### DIFF
--- a/AK/InlineLinkedList.h
+++ b/AK/InlineLinkedList.h
@@ -120,6 +120,8 @@ public:
     void append(T*);
     void remove(T*);
     void append(InlineLinkedList<T>&);
+    void insert_before(T*, T*);
+    void insert_after(T*, T*);
 
     bool contains_slow(T* value) const
     {
@@ -128,6 +130,17 @@ public:
                 return true;
         }
         return false;
+    }
+
+    template<typename F>
+    IterationDecision for_each(F func) const
+    {
+        for (T* node = m_head; node; node = node->next()) {
+            IterationDecision decision = func(*node);
+            if (decision != IterationDecision::Continue)
+                return decision;
+        }
+        return IterationDecision::Continue;
     }
 
     using Iterator = InlineLinkedListIterator<T>;
@@ -197,6 +210,50 @@ inline void InlineLinkedList<T>::append(T* node)
     node->set_prev(m_tail);
     node->set_next(0);
     m_tail = node;
+}
+
+template<typename T>
+inline void InlineLinkedList<T>::insert_before(T* before_node, T* node)
+{
+    ASSERT(before_node);
+    ASSERT(node);
+    ASSERT(before_node != node);
+    ASSERT(!is_empty());
+    if (m_head == before_node) {
+        ASSERT(!before_node->prev());
+        m_head = node;
+        node->set_prev(0);
+        node->set_next(before_node);
+        before_node->set_prev(node);
+    } else {
+        ASSERT(before_node->prev());
+        node->set_prev(before_node->prev());
+        before_node->prev()->set_next(node);
+        node->set_next(before_node);
+        before_node->set_prev(node);
+    }
+}
+
+template<typename T>
+inline void InlineLinkedList<T>::insert_after(T* after_node, T* node)
+{
+    ASSERT(after_node);
+    ASSERT(node);
+    ASSERT(after_node != node);
+    ASSERT(!is_empty());
+    if (m_tail == after_node) {
+        ASSERT(!after_node->next());
+        m_tail = node;
+        node->set_prev(after_node);
+        node->set_next(0);
+        after_node->set_next(node);
+    } else {
+        ASSERT(after_node->next());
+        node->set_prev(after_node);
+        node->set_next(after_node->next());
+        after_node->next()->set_prev(node);
+        after_node->set_next(node);
+    }
 }
 
 template<typename T>

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -367,6 +367,7 @@ Process::Process(RefPtr<Thread>& first_thread, const String& name, uid_t uid, gi
 Process::~Process()
 {
     ASSERT(thread_count() == 0); // all threads should have been finalized
+    ASSERT(!m_alarm_timer);
 
     {
         ScopedSpinLock processses_lock(g_processes_lock);
@@ -596,6 +597,8 @@ void Process::finalize(Thread& last_thread)
         }
     }
 
+    if (m_alarm_timer)
+        TimerQueue::the().cancel_timer(m_alarm_timer.release_nonnull());
     m_fds.clear();
     m_tty = nullptr;
     m_executable = nullptr;

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -611,7 +611,7 @@ private:
     Lock m_big_lock { "Process" };
     mutable SpinLock<u32> m_lock;
 
-    u64 m_alarm_deadline { 0 };
+    RefPtr<Timer> m_alarm_timer;
 
     int m_icon_id { -1 };
 

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -137,15 +137,6 @@ bool Scheduler::pick_next()
         current_thread->set_state(Thread::Dying);
     }
 
-    Process::for_each([&](Process& process) {
-        if (process.m_alarm_deadline && TimeManagement::the().uptime_ms() > process.m_alarm_deadline) {
-            process.m_alarm_deadline = 0;
-            // FIXME: Should we observe this signal somehow?
-            (void)process.send_signal(SIGALRM, nullptr);
-        }
-        return IterationDecision::Continue;
-    });
-
 #ifdef SCHEDULER_RUNNABLE_DEBUG
     dbg() << "Scheduler[" << Processor::current().id() << "]: Non-runnables:";
     Scheduler::for_each_nonrunnable([&](Thread& thread) -> IterationDecision {

--- a/Kernel/Syscalls/alarm.cpp
+++ b/Kernel/Syscalls/alarm.cpp
@@ -46,9 +46,9 @@ unsigned Process::sys$alarm(unsigned seconds)
     }
 
     if (seconds > 0) {
-        auto deadline = TimeManagement::the().monotonic_time(); // TODO: should be using CLOCK_REALTIME
+        auto deadline = TimeManagement::the().current_time(CLOCK_REALTIME).value();
         timespec_add(deadline, { seconds, 0 }, deadline);
-        m_alarm_timer = TimerQueue::the().add_timer_without_id(deadline, [this]() {
+        m_alarm_timer = TimerQueue::the().add_timer_without_id(CLOCK_REALTIME, deadline, [this]() {
             (void)send_signal(SIGALRM, nullptr);
         });
     }

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -197,7 +197,7 @@ auto Thread::WriteBlocker::override_timeout(const BlockTimeout& timeout) -> cons
     if (description.is_socket()) {
         auto& socket = *description.socket();
         if (socket.has_send_timeout()) {
-            m_timeout = BlockTimeout(false, &socket.send_timeout(), timeout.start_time());
+            m_timeout = BlockTimeout(false, &socket.send_timeout(), timeout.start_time(), timeout.clock_id());
             if (timeout.is_infinite() || (!m_timeout.is_infinite() && m_timeout.absolute_time() < timeout.absolute_time()))
                 return m_timeout;
         }
@@ -216,7 +216,7 @@ auto Thread::ReadBlocker::override_timeout(const BlockTimeout& timeout) -> const
     if (description.is_socket()) {
         auto& socket = *description.socket();
         if (socket.has_receive_timeout()) {
-            m_timeout = BlockTimeout(false, &socket.receive_timeout(), timeout.start_time());
+            m_timeout = BlockTimeout(false, &socket.receive_timeout(), timeout.start_time(), timeout.clock_id());
             if (timeout.is_infinite() || (!m_timeout.is_infinite() && m_timeout.absolute_time() < timeout.absolute_time()))
                 return m_timeout;
         }
@@ -256,7 +256,7 @@ void Thread::SleepBlocker::calculate_remaining()
 {
     if (!m_remaining)
         return;
-    auto time_now = TimeManagement::the().monotonic_time();
+    auto time_now = TimeManagement::the().current_time(m_deadline.clock_id()).value();
     if (time_now < m_deadline.absolute_time())
         timespec_sub(m_deadline.absolute_time(), time_now, *m_remaining);
     else

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -52,6 +52,18 @@ TimeManagement& TimeManagement::the()
     return *s_the;
 }
 
+KResultOr<timespec> TimeManagement::current_time(clockid_t clock_id) const
+{
+    switch (clock_id) {
+    case CLOCK_MONOTONIC:
+        return monotonic_time();
+    case CLOCK_REALTIME:
+        return epoch_time();
+    default:
+        return KResult(EINVAL);
+    }
+}
+
 bool TimeManagement::is_system_timer(const HardwareTimerBase& timer) const
 {
     return &timer == m_system_timer.ptr();

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -29,6 +29,7 @@
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/RefPtr.h>
 #include <AK/Types.h>
+#include <Kernel/KResult.h>
 #include <Kernel/UnixTypes.h>
 
 namespace Kernel {
@@ -49,6 +50,7 @@ public:
     static timespec ticks_to_time(u64 ticks, time_t ticks_per_second);
     static u64 time_to_ticks(const timespec& tspec, time_t ticks_per_second);
 
+    KResultOr<timespec> current_time(clockid_t clock_id) const;
     timespec monotonic_time() const;
     timespec epoch_time() const;
     void set_epoch_time(timespec);

--- a/Kernel/TimerQueue.h
+++ b/Kernel/TimerQueue.h
@@ -53,9 +53,12 @@ public:
         ASSERT(!is_queued());
     }
 
+    timespec remaining() const;
+
 private:
     TimerId m_id;
     u64 m_expires;
+    u64 m_remaining { 0 };
     Function<void()> m_callback;
     Timer* m_next { nullptr };
     Timer* m_prev { nullptr };
@@ -88,6 +91,7 @@ public:
     RefPtr<Timer> add_timer_without_id(const timespec& timeout, Function<void()>&& callback);
     TimerId add_timer(timeval& timeout, Function<void()>&& callback);
     bool cancel_timer(TimerId id);
+    bool cancel_timer(Timer&);
     bool cancel_timer(NonnullRefPtr<Timer>&& timer)
     {
         return cancel_timer(timer.leak_ref());
@@ -95,7 +99,7 @@ public:
     void fire();
 
 private:
-    bool cancel_timer(Timer&);
+    void remove_timer_locked(Timer&);
     void update_next_timer_due();
     void add_timer_locked(NonnullRefPtr<Timer>);
 


### PR DESCRIPTION
We need to be able to guarantee that a timer won't be executing after
TimerQueue::cancel_timer returns. In the case of multiple processors
this means that we may need to wait while the timer handler finishes
execution on another core.

This also fixes a problem in Thread::block and Thread::wait_on where
theoretically the timer could execute after the function returned
and the Thread disappeared.
