### PR TITLE
Taskbar: Wait on all waitable children in SIGCHLD handler

### DIFF
--- a/Libraries/LibGUI/Application.h
+++ b/Libraries/LibGUI/Application.h
@@ -74,6 +74,8 @@ public:
 
     bool focus_debugging_enabled() const { return m_focus_debugging_enabled; }
 
+    Core::EventLoop& event_loop() { return *m_event_loop; }
+
 private:
     Application(int argc, char** argv);
 

--- a/Services/Taskbar/main.cpp
+++ b/Services/Taskbar/main.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "TaskbarWindow.h"
+#include <LibCore/EventLoop.h>
 #include <LibGUI/Application.h>
 #include <signal.h>
 #include <stdio.h>
@@ -38,10 +39,10 @@ int main(int argc, char** argv)
     }
 
     auto app = GUI::Application::construct(argc, argv);
-
-    signal(SIGCHLD, [](int signo) {
-        (void)signo;
-        wait(nullptr);
+    app->event_loop().register_signal(SIGCHLD, [](int) {
+        // Wait all available children
+        while (waitpid(-1, nullptr, WNOHANG) > 0)
+            ;
     });
 
     if (pledge("stdio shared_buffer accept proc exec rpath", nullptr) < 0) {


### PR DESCRIPTION
We need to call waitpid until no more waitable children are available.
This is necessary because SIGCHLD signals may coalesce into one when
multiple children terminate almost simultaneously.

Also, switch to EventLoop's asynchronous signal handling mechanism,
which allows more complex operations in the signal handler.