### PR TITLE
LibWeb: Complete the URL in href_setter() before trying to load it

### DIFF
--- a/Libraries/LibWeb/Bindings/LocationObject.cpp
+++ b/Libraries/LibWeb/Bindings/LocationObject.cpp
@@ -70,7 +70,12 @@ JS_DEFINE_NATIVE_SETTER(LocationObject::href_setter)
     auto new_href = value.to_string(global_object);
     if (vm.exception())
         return;
-    window.impl().did_set_location_href({}, new_href);
+    auto href_url = window.impl().document().complete_url(new_href);
+    if (!href_url.is_valid()) {
+        vm.throw_exception<JS::URIError>(global_object, String::formatted("Invalid URL '{}'", new_href));
+        return;
+    }
+    window.impl().did_set_location_href({}, href_url);
 }
 
 JS_DEFINE_NATIVE_GETTER(LocationObject::pathname_getter)

--- a/Libraries/LibWeb/DOM/Window.cpp
+++ b/Libraries/LibWeb/DOM/Window.cpp
@@ -148,7 +148,7 @@ void Window::cancel_animation_frame(i32 id)
     GUI::DisplayLink::unregister_callback(id);
 }
 
-void Window::did_set_location_href(Badge<Bindings::LocationObject>, const String& new_href)
+void Window::did_set_location_href(Badge<Bindings::LocationObject>, const URL& new_href)
 {
     auto* frame = document().frame();
     if (!frame)

--- a/Libraries/LibWeb/DOM/Window.h
+++ b/Libraries/LibWeb/DOM/Window.h
@@ -65,7 +65,7 @@ public:
     void clear_timeout(i32);
     void clear_interval(i32);
 
-    void did_set_location_href(Badge<Bindings::LocationObject>, const String& new_href);
+    void did_set_location_href(Badge<Bindings::LocationObject>, const URL& new_href);
     void did_call_location_reload(Badge<Bindings::LocationObject>);
 
     Bindings::WindowObject* wrapper() { return m_wrapper; }


### PR DESCRIPTION
Also note that setting an invalid URL here should raise a JS exception
(and not navigate away).
Fixes #4301.