### PR TITLE
Kernel: Flush TLBs concurrently

### DIFF
--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -740,7 +740,8 @@ class Processor {
     static void smp_cleanup_message(ProcessorMessage& msg);
     bool smp_queue_message(ProcessorMessage& msg);
     static void smp_unicast_message(u32 cpu, ProcessorMessage& msg, bool async);
-    static void smp_broadcast_message(ProcessorMessage& msg, bool async);
+    static void smp_broadcast_message(ProcessorMessage& msg);
+    static void smp_broadcast_wait_sync(ProcessorMessage& msg);
     static void smp_broadcast_halt();
 
     void deferred_call_pool_init();


### PR DESCRIPTION
Instead of flushing the TLB on the current processor first and then
notifying the other processors to do the same, notify the others
first, and while waiting on the others flush our own.