### PR TITLE
test-js: Set test root correctly when specified as positional arg / Use new format functions

### DIFF
--- a/Userland/test-js.cpp
+++ b/Userland/test-js.cpp
@@ -731,7 +731,9 @@ int main(int argc, char** argv)
 
     String test_root;
 
-    if (!specified_test_root) {
+    if (specified_test_root) {
+        test_root = String { specified_test_root };
+    } else {
 #ifdef __serenity__
         test_root = "/home/anon/js-tests";
 #else


### PR DESCRIPTION
When a test root path was given to test-js it was never used, causing test-js to always fail.

Also update everything to the new format functions (except for one call to `snprintf()` a version of that using the new formatting would be neat...).