### PR TITLE
Shell: "variable substitutions" (but actually readable)

### DIFF
--- a/Libraries/LibGUI/ShellSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/ShellSyntaxHighlighter.cpp
@@ -31,6 +31,7 @@
 #include <LibGfx/Palette.h>
 #include <Shell/NodeVisitor.h>
 #include <Shell/Parser.h>
+#include <Shell/Shell.h>
 
 namespace GUI {
 

--- a/Shell/CMakeLists.txt
+++ b/Shell/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     AST.cpp
     Builtin.cpp
     Formatter.cpp
+    ImmediateFunctions.cpp
     Job.cpp
     NodeVisitor.cpp
     Parser.cpp
@@ -9,7 +10,7 @@ set(SOURCES
 )
 
 serenity_lib(LibShell shell)
-target_link_libraries(LibShell LibCore LibLine)
+target_link_libraries(LibShell LibCore LibLine LibRegex)
 
 set(SOURCES
     main.cpp

--- a/Shell/Formatter.cpp
+++ b/Shell/Formatter.cpp
@@ -27,6 +27,7 @@
 #include "Formatter.h"
 #include "AST.h"
 #include "Parser.h"
+#include "Shell.h"
 #include <AK/TemporaryChange.h>
 
 namespace Shell {
@@ -203,6 +204,24 @@ void Formatter::visit(const AST::BraceExpansion* node)
             current_builder().append(',');
         first = false;
         entry.visit(*this);
+    }
+
+    current_builder().append('}');
+    visited(node);
+}
+
+void Formatter::visit(const AST::BracedImmediateExpression* node)
+{
+    will_visit(node);
+    test_and_update_output_cursor(node);
+    current_builder().append("${");
+
+    TemporaryChange<const AST::Node*> parent { m_parent_node, node };
+    current_builder().append(node->function());
+
+    for (auto& argument : node->arguments()) {
+        current_builder().append(' ');
+        argument.visit(*this);
     }
 
     current_builder().append('}');

--- a/Shell/Formatter.h
+++ b/Shell/Formatter.h
@@ -59,6 +59,7 @@ private:
     virtual void visit(const AST::Background*) override;
     virtual void visit(const AST::BarewordLiteral*) override;
     virtual void visit(const AST::BraceExpansion*) override;
+    virtual void visit(const AST::BracedImmediateExpression*) override;
     virtual void visit(const AST::CastToCommand*) override;
     virtual void visit(const AST::CastToList*) override;
     virtual void visit(const AST::CloseFdRedirection*) override;

--- a/Shell/Forward.h
+++ b/Shell/Forward.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <AK/Forward.h>
+
 namespace Shell::AST {
 
 struct Command;
@@ -42,6 +44,7 @@ class ListConcatenate;
 class Background;
 class BarewordLiteral;
 class BraceExpansion;
+class BracedImmediateExpression;
 class CastToCommand;
 class CastToList;
 class CloseFdRedirection;
@@ -70,6 +73,7 @@ class Juxtaposition;
 class StringLiteral;
 class StringPartCompose;
 class SyntaxError;
+class SyntheticNode;
 class Tilde;
 class VariableDeclarations;
 class WriteAppendRedirection;
@@ -80,5 +84,4 @@ class WriteRedirection;
 namespace Shell {
 
 class Shell;
-
 }

--- a/Shell/ImmediateFunctions.cpp
+++ b/Shell/ImmediateFunctions.cpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ImmediateFunctions.h"
+#include "Shell.h"
+#include <LibRegex/Regex.h>
+
+namespace Shell {
+
+Array<ImmediateFunctionType, ImmediateFunction::_Count> s_immediate_functions;
+
+void ensure_immediate_functions()
+{
+    static bool initialized = false;
+    if (initialized)
+        return;
+
+    initialized = true;
+
+#define IMMEDIATE_FUNCTION(fn, defn) \
+    s_immediate_functions[ImmediateFunction::fn] = [](Shell & shell, NonnullRefPtrVector<AST::Node> arguments, Function<IterationDecision(NonnullRefPtr<AST::Node>)> callback) -> void defn;
+
+    IMMEDIATE_FUNCTION(count, {
+        for (auto& argument : arguments) {
+            size_t count = 0;
+            argument.for_each_entry(shell, [&](auto) {
+                ++count;
+                return IterationDecision::Continue;
+            });
+            if (callback(AST::create<AST::StringLiteral>(argument.position(), String::number(count))) == IterationDecision::Break)
+                break;
+        }
+    });
+
+    IMMEDIATE_FUNCTION(length, {
+        for (auto& argument : arguments) {
+            size_t length = 0;
+            auto list = argument.run(shell)->resolve_as_list(shell);
+            bool first = true;
+            for (auto& entry : list) {
+                if (!first)
+                    ++length; // space.
+                first = false;
+                length += entry.length();
+            }
+            if (callback(AST::create<AST::StringLiteral>(argument.position(), String::number(length))) == IterationDecision::Break)
+                break;
+        }
+    });
+
+    IMMEDIATE_FUNCTION(nth, {
+        if (arguments.size() < 2)
+            return;
+
+        auto index_string = arguments.take_first()->run(shell)->resolve_as_list(shell).first();
+        auto index = index_string.to_uint().value_or(0);
+        for (auto& argument : arguments) {
+            size_t current_index = 0;
+            argument.for_each_entry(shell, [&](auto value) {
+                if (current_index++ == index) {
+                    callback(AST::create<AST::SyntheticNode>(argument.position(), move(value)));
+                    return IterationDecision::Break;
+                }
+                return IterationDecision::Continue;
+            });
+        }
+    });
+
+    IMMEDIATE_FUNCTION(substring, {
+        if (arguments.size() < 3)
+            return;
+
+        auto start_index_string = arguments.take_first()->run(shell)->resolve_as_list(shell).first();
+        auto start_index = start_index_string.to_uint().value_or(0);
+        auto length_string = arguments.take_first()->run(shell)->resolve_as_list(shell).first();
+        auto length = length_string.to_uint().value_or(0);
+        for (auto& argument : arguments) {
+            auto list = argument.run(shell)->resolve_as_list(shell);
+            if (list.is_empty())
+                continue;
+            if (list.size() == 1) {
+                auto corrected_length = (length + start_index <= list.first().length()) ? length : list.first().length() - start_index;
+                if (start_index < list.first().length())
+                    callback(AST::create<AST::StringLiteral>(argument.position(), list.first().substring_view(start_index, corrected_length)));
+                continue;
+            }
+            StringBuilder data;
+            data.join(' ', list);
+
+            auto str = data.string_view();
+            auto corrected_length = (length + start_index <= str.length()) ? length : str.length() - start_index;
+            if (start_index < str.length())
+                callback(AST::create<AST::StringLiteral>(argument.position(), str.substring_view(start_index, corrected_length)));
+        }
+    });
+
+    IMMEDIATE_FUNCTION(slice, {
+        if (arguments.size() < 3)
+            return;
+
+        auto start_index_string = arguments.take_first()->run(shell)->resolve_as_list(shell).first();
+        auto start_index = start_index_string.to_uint().value_or(0);
+        auto length_string = arguments.take_first()->run(shell)->resolve_as_list(shell).first();
+        auto length = length_string.to_uint().value_or(0);
+        auto end_index = start_index + length;
+        for (auto& argument : arguments) {
+            size_t current_index = 0;
+            argument.for_each_entry(shell, [&](auto value) {
+                if (current_index >= start_index && current_index < end_index)
+                    callback(AST::create<AST::SyntheticNode>(argument.position(), move(value)));
+                if (current_index >= end_index)
+                    return IterationDecision::Break;
+                ++current_index;
+                return IterationDecision::Continue;
+            });
+        }
+    });
+
+    IMMEDIATE_FUNCTION(remove_prefix, {
+        if (arguments.size() < 2)
+            return;
+
+        auto prefix = arguments.take_first()->run(shell)->resolve_as_list(shell).first();
+        for (auto& argument : arguments) {
+            argument.for_each_entry(shell, [&](auto value) {
+                auto list = value->resolve_as_list(shell);
+                StringBuilder data;
+                data.join(' ', list);
+                auto view = data.string_view();
+                if (view.starts_with(prefix))
+                    view = view.substring_view(prefix.length());
+                callback(AST::create<AST::StringLiteral>(argument.position(), view));
+                return IterationDecision::Continue;
+            });
+        }
+    });
+
+    IMMEDIATE_FUNCTION(remove_suffix, {
+        if (arguments.size() < 2)
+            return;
+
+        auto prefix = arguments.take_first()->run(shell)->resolve_as_list(shell).first();
+        for (auto& argument : arguments) {
+            argument.for_each_entry(shell, [&](auto value) {
+                auto list = value->resolve_as_list(shell);
+                StringBuilder data;
+                data.join(' ', list);
+                auto view = data.string_view();
+                if (view.ends_with(prefix))
+                    view = view.substring_view(0, view.length() - prefix.length());
+                callback(AST::create<AST::StringLiteral>(argument.position(), view));
+                return IterationDecision::Continue;
+            });
+        }
+    });
+
+    IMMEDIATE_FUNCTION(regex_replace, {
+        if (arguments.size() < 2)
+            return;
+
+        auto pattern_node = arguments.take_first();
+        auto pattern = pattern_node->run(shell)->resolve_as_list(shell).first();
+        auto re = Regex<ECMA262>(pattern);
+        if (re.parser_result.error != regex::Error::NoError) {
+            callback(AST::create<AST::SyntaxError>(pattern_node->position(), re.error_string()));
+            return;
+        }
+        auto replacement = arguments.take_first()->run(shell)->resolve_as_list(shell).first();
+        for (auto& argument : arguments) {
+            argument.for_each_entry(shell, [&](auto value) {
+                auto list = value->resolve_as_list(shell);
+                StringBuilder data;
+                data.join(' ', list);
+                auto string = re.replace(data.string_view(), replacement, ECMAScriptFlags::Multiline);
+                callback(AST::create<AST::StringLiteral>(argument.position(), move(string)));
+                return IterationDecision::Continue;
+            });
+        }
+    });
+
+    IMMEDIATE_FUNCTION(filter_glob, {
+        if (arguments.size() < 2)
+            return;
+
+        auto glob = arguments.take_first()->run(shell)->resolve_as_list(shell).first();
+        for (auto& argument : arguments) {
+            argument.for_each_entry(shell, [&](auto value) {
+                auto list = value->resolve_as_list(shell);
+                StringBuilder data;
+                data.join(' ', list);
+                auto view = data.string_view();
+                if (view.matches(glob))
+                    callback(AST::create<AST::StringLiteral>(argument.position(), view));
+                return IterationDecision::Continue;
+            });
+        }
+    });
+}
+
+}

--- a/Shell/ImmediateFunctions.h
+++ b/Shell/ImmediateFunctions.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Forward.h"
+#include <AK/Array.h>
+#include <AK/Function.h>
+#include <AK/StringView.h>
+
+namespace Shell {
+
+using ImmediateFunctionType = Function<void(Shell&, NonnullRefPtrVector<AST::Node>, Function<IterationDecision(NonnullRefPtr<AST::Node>)>)>;
+
+void ensure_immediate_functions();
+
+#define ENUMERATE_SHELL_IMMEDIATE_FUNCTIONS()           \
+    __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(count)         \
+    __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(length)        \
+    __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(nth)           \
+    __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(substring)     \
+    __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(slice)         \
+    __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(remove_suffix) \
+    __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(remove_prefix) \
+    __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(regex_replace) \
+    __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(filter_glob)
+
+enum ImmediateFunction : u32 {
+#define __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(name) \
+    name,
+
+    ENUMERATE_SHELL_IMMEDIATE_FUNCTIONS()
+
+#undef __ENUMERATE_SHELL_IMMEDIATE_FUNCTION
+        _Count,
+    Invalid,
+};
+
+extern Array<ImmediateFunctionType, ImmediateFunction::_Count> s_immediate_functions;
+
+inline auto immediate_functions() -> decltype(s_immediate_functions)&
+{
+    ensure_immediate_functions();
+    return s_immediate_functions;
+}
+
+inline ImmediateFunctionType* immediate_function(ImmediateFunction fn)
+{
+    ensure_immediate_functions();
+    if ((u32)fn >= ImmediateFunction::_Count)
+        return nullptr;
+    return &s_immediate_functions[(u32)fn];
+}
+
+inline ImmediateFunction immediate_function_by_name(const StringView& fn_name)
+{
+    ensure_immediate_functions();
+#define __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(name) \
+    if (fn_name == #name)                          \
+        return ImmediateFunction::name;
+
+    ENUMERATE_SHELL_IMMEDIATE_FUNCTIONS()
+
+#undef __ENUMERATE_SHELL_IMMEDIATE_FUNCTION
+
+    return ImmediateFunction::Invalid;
+}
+
+}

--- a/Shell/NodeVisitor.cpp
+++ b/Shell/NodeVisitor.cpp
@@ -61,6 +61,12 @@ void NodeVisitor::visit(const AST::BraceExpansion* node)
         entry.visit(*this);
 }
 
+void NodeVisitor::visit(const AST::BracedImmediateExpression* node)
+{
+    for (auto& entry : node->arguments())
+        entry.visit(*this);
+}
+
 void NodeVisitor::visit(const AST::CastToCommand* node)
 {
     node->inner()->visit(*this);

--- a/Shell/NodeVisitor.h
+++ b/Shell/NodeVisitor.h
@@ -38,6 +38,7 @@ public:
     virtual void visit(const AST::Background*);
     virtual void visit(const AST::BarewordLiteral*);
     virtual void visit(const AST::BraceExpansion*);
+    virtual void visit(const AST::BracedImmediateExpression*);
     virtual void visit(const AST::CastToCommand*);
     virtual void visit(const AST::CastToList*);
     virtual void visit(const AST::CloseFdRedirection*);

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "ImmediateFunctions.h"
 #include "Job.h"
 #include "Parser.h"
 #include <AK/CircularQueue.h>
@@ -69,7 +70,6 @@
 namespace Shell {
 
 class Shell;
-
 class Shell : public Core::Object {
     C_OBJECT(Shell);
 
@@ -154,6 +154,7 @@ public:
     Vector<Line::CompletionSuggestion> complete();
     Vector<Line::CompletionSuggestion> complete_path(const String& base, const String&, size_t offset);
     Vector<Line::CompletionSuggestion> complete_program_name(const String&, size_t offset);
+    Vector<Line::CompletionSuggestion> complete_immediate_function_name(const String&, size_t offset);
     Vector<Line::CompletionSuggestion> complete_variable(const String&, size_t offset);
     Vector<Line::CompletionSuggestion> complete_user(const String&, size_t offset);
     Vector<Line::CompletionSuggestion> complete_option(const String&, const String&, size_t offset);

--- a/Shell/Tests/immediate.sh
+++ b/Shell/Tests/immediate.sh
@@ -1,0 +1,39 @@
+fail() {
+    echo FAIL: $*
+    exit 1
+}
+
+a=(1 2 3)
+b=(3 4 5)
+test ${count $a} -eq 3 || fail \'count\' with single arg returned invalid value
+test "${count $a $b}" = "3 3" || fail \'count\' with multiple args returned invalid value\(s\)
+
+test ${length foo} -eq 3 || fail \'length\' of string invalid
+a=(foo bar)
+# length(list) -> length(String-Join(list))
+test ${length $a} -eq 7 || fail \'length\' of list invalid
+
+a=(1 2 3)
+b=(3 4 5)
+test "${nth 1 $a $b}" = "2 4" || fail \'nth\' invalid
+# out of bounds FIXME: should this somehow fail or just be ()?
+test "${nth 4 $a}" = "" || fail \'nth\' out of bounds invalid
+
+test "${substring 1 3 'xwhf!'}" = "whf" || fail \'substring\' invalid
+# out of bounds FIXME: should this instead somehow fail or just be ''?
+test "${substring 1 5 'xwhf!'}" = "whf!" || fail \'substring\' out of bounds invalid
+
+test "${slice 1 3 (x w h f !)}" = "w h f" || fail \'slice\' invalid
+# out of bounds FIXME: should this instead somehow fail or just be ()?
+test "${slice 1 5 (x w h f !)}" = "w h f !" || fail \'slice\' out of bounds invalid
+
+test "${remove_prefix foo foo.txt foo.sh bar.foo}" = ".txt .sh bar.foo" || fail \'remove_prefix\' invalid
+
+test "${remove_suffix .txt foo.txt bar.txt .txt.sh}" = "foo bar .txt.sh" || fail \'remove_suffix\' invalid
+
+test "${regex_replace 'f(.)\1' '\1\1f' foo fxx bar afoo fyyx}" = "oof xxf bar aoof yyfx" || fail \'regex_replace\' invalid
+
+test "${regex_replace 'f(.)\1' '\1\1f' (foo fxx bar afoo fyyx)}" = "oof xxf bar aoof yyfx" || fail \'regex_replace\' on list invalid
+
+# FIXME: should this skip out on evaluating a literal glob?
+test "${filter_glob '*.sh' (a.sh bsh c.txt .sh)}" = "a.sh .sh" || fail \'filter_glob\' invalid


### PR DESCRIPTION
TL;DR:
```sh
# bashy:
${#foo[@]}
# better:
${count $foo}

# bashy
${foo%.txt}
# better:
${remove_suffix .txt $foo}
```

(these are also a little peculiar, as they can rewrite the AST as opposed to just returning new values)