### PR TITLE
LibWeb: Improve contenteditable attribute.

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -147,6 +147,13 @@ StringView String::substring_view(size_t start, size_t length) const
     return { characters() + start, length };
 }
 
+StringView String::substring_view(size_t start) const
+{
+    ASSERT(m_impl);
+    ASSERT(start <= length());
+    return { characters() + start, length() - start };
+}
+
 Vector<String> String::split(char separator, bool keep_empty) const
 {
     return split_limit(separator, 0, keep_empty);

--- a/AK/String.h
+++ b/AK/String.h
@@ -138,6 +138,7 @@ public:
 
     Vector<StringView> split_view(char separator, bool keep_empty = false) const;
     StringView substring_view(size_t start, size_t length) const;
+    StringView substring_view(size_t start) const;
 
     bool is_null() const { return !m_impl; }
     ALWAYS_INLINE bool is_empty() const { return length() == 0; }

--- a/Base/res/html/misc/contenteditable.html
+++ b/Base/res/html/misc/contenteditable.html
@@ -1,0 +1,8 @@
+<html contenteditable>
+    <body>
+        <h1>Everything on this page should be editable.</h1>
+
+        <p>Here is a paragraph to play with.</p>
+        <p>Another paragraph with a <b>bold</b> element embeded in it.</p>
+    </body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -38,6 +38,7 @@ span#loadtime {
     <p>This page loaded in <b><span id="loadtime"></span></b> ms</p>
     <p>Some small test pages:</p>
     <ul>
+        <li><a href="contenteditable.html">contenteditable</a></li>
         <li><a href="clear-1.html">clearing floats</a></li>
         <li><a href="float-1.html">floating boxes</a></li>
         <li><a href="padding-inline.html">inline elements with padding</a></li>

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -132,6 +132,7 @@ public:
     virtual bool is_global_object() const { return false; }
     virtual bool is_typed_array() const { return false; }
     virtual bool is_array_buffer() const { return false; }
+    virtual bool is_node_wrapper() const { return false; }
 
     virtual const char* class_name() const override { return "Object"; }
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/Bindings/RangeConstructor.cpp
+++ b/Libraries/LibWeb/Bindings/RangeConstructor.cpp
@@ -26,6 +26,7 @@
 
 #include <LibJS/Heap/Heap.h>
 #include <LibWeb/Bindings/RangeConstructor.h>
+#include <LibWeb/Bindings/RangePrototype.h>
 #include <LibWeb/Bindings/RangeWrapper.h>
 #include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/DOM/Range.h>
@@ -39,14 +40,17 @@ RangeConstructor::RangeConstructor(JS::GlobalObject& global_object)
 
 void RangeConstructor::initialize(JS::GlobalObject& global_object)
 {
+    auto& vm = this->vm();
     NativeFunction::initialize(global_object);
-
-    define_property("length", JS::Value(0), JS::Attribute::Configurable);
+    auto& window = static_cast<WindowObject&>(global_object);
+    define_property(vm.names.prototype, window.range_prototype(), 0);
+    define_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
 }
 
 JS::Value RangeConstructor::call()
 {
-    return construct(*this);
+    vm().throw_exception<JS::TypeError>(global_object(), JS::ErrorType::ConstructorWithoutNew, "Range");
+    return {};
 }
 
 JS::Value RangeConstructor::construct(Function&)

--- a/Libraries/LibWeb/Bindings/RangeConstructor.h
+++ b/Libraries/LibWeb/Bindings/RangeConstructor.h
@@ -24,52 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibWeb/DOM/Document.h>
-#include <LibWeb/DOM/Node.h>
-#include <LibWeb/DOM/Range.h>
-#include <LibWeb/DOM/Window.h>
+#pragma once
 
-namespace Web::DOM {
+#include <LibJS/Runtime/NativeFunction.h>
 
-Range::Range(Window& window)
-    : m_start_container(window.document())
-    , m_start_offset(0)
-    , m_end_container(window.document())
-    , m_end_offset(0)
-{
-}
+namespace Web::Bindings {
 
-Range::Range(Node& start_container, size_t start_offset, Node& end_container, size_t end_offset)
-    : m_start_container(start_container)
-    , m_start_offset(start_offset)
-    , m_end_container(end_container)
-    , m_end_offset(end_offset)
-{
-}
+class RangeConstructor final : public JS::NativeFunction {
+public:
+    explicit RangeConstructor(JS::GlobalObject&);
 
-NonnullRefPtr<Range> Range::clone_range() const
-{
-    return adopt(*new Range(const_cast<Node&>(*m_start_container), m_start_offset, const_cast<Node&>(*m_end_container), m_end_offset));
-}
+    void initialize(JS::GlobalObject&) override;
 
-NonnullRefPtr<Range> Range::inverted() const
-{
-    return adopt(*new Range(const_cast<Node&>(*m_end_container), m_end_offset, const_cast<Node&>(*m_start_container), m_start_offset));
-}
+    JS::Value call() override;
+    JS::Value construct(JS::Function& new_target) override;
 
-NonnullRefPtr<Range> Range::normalized() const
-{
-    if (m_start_container.ptr() == m_end_container.ptr()) {
-        if (m_start_offset <= m_end_offset)
-            return clone_range();
-
-        return inverted();
-    }
-
-    if (m_start_container->is_before(m_end_container))
-        return clone_range();
-
-    return inverted();
-}
+private:
+    bool has_constructor() const override { return true; }
+    const char* class_name() const override { return "RangeConstructor"; }
+};
 
 }

--- a/Libraries/LibWeb/Bindings/RangePrototype.cpp
+++ b/Libraries/LibWeb/Bindings/RangePrototype.cpp
@@ -80,8 +80,8 @@ JS_DEFINE_NATIVE_FUNCTION(RangePrototype::set_start)
     if (vm.exception())
         return {};
 
-    if (!static_cast<NodeWrapper*>(arg0)->is_node_wrapper()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotA, "Range");
+    if (!arg0->is_node_wrapper()) {
+        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotA, "Node");
         return {};
     }
 
@@ -103,8 +103,8 @@ JS_DEFINE_NATIVE_FUNCTION(RangePrototype::set_end)
     if (vm.exception())
         return {};
 
-    if (!static_cast<NodeWrapper*>(arg0)->is_node_wrapper()) {
-        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotA, "Range");
+    if (!arg0->is_node_wrapper()) {
+        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotA, "Node");
         return {};
     }
 

--- a/Libraries/LibWeb/Bindings/RangePrototype.cpp
+++ b/Libraries/LibWeb/Bindings/RangePrototype.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Function.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibWeb/Bindings/NodeWrapper.h>
+#include <LibWeb/Bindings/NodeWrapperFactory.h>
+#include <LibWeb/Bindings/RangePrototype.h>
+#include <LibWeb/Bindings/RangeWrapper.h>
+#include <LibWeb/DOM/Range.h>
+
+namespace Web::Bindings {
+
+RangePrototype::RangePrototype(JS::GlobalObject& global_object)
+    : Object(*global_object.object_prototype())
+{
+}
+
+void RangePrototype::initialize(JS::GlobalObject& global_object)
+{
+    auto default_attributes = JS::Attribute::Enumerable | JS::Attribute::Configurable;
+
+    Object::initialize(global_object);
+
+    define_native_function("setStart", set_start, 2);
+    define_native_function("setEnd", set_end, 2);
+    define_native_function("cloneRange", clone_range, 0);
+
+    define_native_property("startContainer", start_container_getter, nullptr, default_attributes);
+    define_native_property("endContainer", end_container_getter, nullptr, default_attributes);
+    define_native_property("startOffset", start_offset_getter, nullptr, default_attributes);
+    define_native_property("endOffset", end_offset_getter, nullptr, default_attributes);
+}
+
+static DOM::Range* impl_from(JS::VM& vm, JS::GlobalObject& global_object)
+{
+    auto* this_object = vm.this_value(global_object).to_object(global_object);
+    if (!this_object)
+        return nullptr;
+    if (StringView("RangeWrapper") != this_object->class_name()) {
+        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotA, "Range");
+        return nullptr;
+    }
+    return &static_cast<RangeWrapper*>(this_object)->impl();
+}
+
+JS_DEFINE_NATIVE_FUNCTION(RangePrototype::set_start)
+{
+    auto* impl = impl_from(vm, global_object);
+    if (!impl)
+        return {};
+
+    auto arg0 = vm.argument(0).to_object(global_object);
+    if (vm.exception())
+        return {};
+    auto arg1 = vm.argument(1).to_number(global_object);
+    if (vm.exception())
+        return {};
+
+    if (!static_cast<NodeWrapper*>(arg0)->is_node_wrapper()) {
+        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotA, "Range");
+        return {};
+    }
+
+    impl->set_start(static_cast<NodeWrapper*>(arg0)->impl(), arg1.as_i32());
+
+    return JS::js_undefined();
+}
+
+JS_DEFINE_NATIVE_FUNCTION(RangePrototype::set_end)
+{
+    auto* impl = impl_from(vm, global_object);
+    if (!impl)
+        return {};
+
+    auto arg0 = vm.argument(0).to_object(global_object);
+    if (vm.exception())
+        return {};
+    auto arg1 = vm.argument(1).to_number(global_object);
+    if (vm.exception())
+        return {};
+
+    if (!static_cast<NodeWrapper*>(arg0)->is_node_wrapper()) {
+        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::NotA, "Range");
+        return {};
+    }
+
+    impl->set_end(static_cast<NodeWrapper*>(arg0)->impl(), arg1.as_i32());
+
+    return JS::js_undefined();
+}
+
+JS_DEFINE_NATIVE_FUNCTION(RangePrototype::clone_range)
+{
+    auto* impl = impl_from(vm, global_object);
+    if (!impl)
+        return {};
+
+    return wrap(global_object, *impl->clone_range());
+}
+
+JS_DEFINE_NATIVE_GETTER(RangePrototype::start_container_getter)
+{
+    auto* impl = impl_from(vm, global_object);
+    if (!impl)
+        return {};
+
+    return wrap(global_object, *impl->start_container());
+}
+
+JS_DEFINE_NATIVE_GETTER(RangePrototype::end_container_getter)
+{
+    auto* impl = impl_from(vm, global_object);
+    if (!impl)
+        return {};
+
+    return wrap(global_object, *impl->end_container());
+}
+
+JS_DEFINE_NATIVE_GETTER(RangePrototype::start_offset_getter)
+{
+    auto* impl = impl_from(vm, global_object);
+    if (!impl)
+        return {};
+
+    return JS::Value(impl->start_offset());
+}
+
+JS_DEFINE_NATIVE_GETTER(RangePrototype::end_offset_getter)
+{
+    auto* impl = impl_from(vm, global_object);
+    if (!impl)
+        return {};
+
+    return JS::Value(impl->end_offset());
+}
+
+}

--- a/Libraries/LibWeb/Bindings/RangePrototype.h
+++ b/Libraries/LibWeb/Bindings/RangePrototype.h
@@ -24,52 +24,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibWeb/DOM/Document.h>
-#include <LibWeb/DOM/Node.h>
-#include <LibWeb/DOM/Range.h>
-#include <LibWeb/DOM/Window.h>
+#pragma once
 
-namespace Web::DOM {
+#include <LibJS/Runtime/Object.h>
 
-Range::Range(Window& window)
-    : m_start_container(window.document())
-    , m_start_offset(0)
-    , m_end_container(window.document())
-    , m_end_offset(0)
-{
-}
+namespace Web::Bindings {
 
-Range::Range(Node& start_container, size_t start_offset, Node& end_container, size_t end_offset)
-    : m_start_container(start_container)
-    , m_start_offset(start_offset)
-    , m_end_container(end_container)
-    , m_end_offset(end_offset)
-{
-}
+class RangePrototype final : public JS::Object {
+    JS_OBJECT(RangePrototype, JS::Object);
 
-NonnullRefPtr<Range> Range::clone_range() const
-{
-    return adopt(*new Range(const_cast<Node&>(*m_start_container), m_start_offset, const_cast<Node&>(*m_end_container), m_end_offset));
-}
+public:
+    explicit RangePrototype(JS::GlobalObject&);
 
-NonnullRefPtr<Range> Range::inverted() const
-{
-    return adopt(*new Range(const_cast<Node&>(*m_end_container), m_end_offset, const_cast<Node&>(*m_start_container), m_start_offset));
-}
+    void initialize(JS::GlobalObject&) override;
 
-NonnullRefPtr<Range> Range::normalized() const
-{
-    if (m_start_container.ptr() == m_end_container.ptr()) {
-        if (m_start_offset <= m_end_offset)
-            return clone_range();
+private:
+    JS_DECLARE_NATIVE_FUNCTION(set_start);
+    JS_DECLARE_NATIVE_FUNCTION(set_end);
+    JS_DECLARE_NATIVE_FUNCTION(clone_range);
 
-        return inverted();
-    }
-
-    if (m_start_container->is_before(m_end_container))
-        return clone_range();
-
-    return inverted();
-}
+    JS_DECLARE_NATIVE_GETTER(start_container_getter);
+    JS_DECLARE_NATIVE_GETTER(end_container_getter);
+    JS_DECLARE_NATIVE_GETTER(start_offset_getter);
+    JS_DECLARE_NATIVE_GETTER(end_offset_getter);
+    JS_DECLARE_NATIVE_GETTER(collapsed_getter);
+};
 
 }

--- a/Libraries/LibWeb/Bindings/RangeWrapper.cpp
+++ b/Libraries/LibWeb/Bindings/RangeWrapper.cpp
@@ -24,52 +24,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibWeb/DOM/Document.h>
-#include <LibWeb/DOM/Node.h>
+#include <LibWeb/Bindings/RangePrototype.h>
+#include <LibWeb/Bindings/RangeWrapper.h>
+#include <LibWeb/Bindings/WindowObject.h>
+#include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/DOM/Range.h>
-#include <LibWeb/DOM/Window.h>
 
-namespace Web::DOM {
+namespace Web::Bindings {
 
-Range::Range(Window& window)
-    : m_start_container(window.document())
-    , m_start_offset(0)
-    , m_end_container(window.document())
-    , m_end_offset(0)
+RangeWrapper::RangeWrapper(JS::GlobalObject& global_object, DOM::Range& impl)
+    : Wrapper(global_object)
+    , m_impl(impl)
 {
+    set_prototype(static_cast<WindowObject&>(global_object).range_prototype());
 }
 
-Range::Range(Node& start_container, size_t start_offset, Node& end_container, size_t end_offset)
-    : m_start_container(start_container)
-    , m_start_offset(start_offset)
-    , m_end_container(end_container)
-    , m_end_offset(end_offset)
+RangeWrapper* wrap(JS::GlobalObject& global_object, DOM::Range& impl)
 {
-}
-
-NonnullRefPtr<Range> Range::clone_range() const
-{
-    return adopt(*new Range(const_cast<Node&>(*m_start_container), m_start_offset, const_cast<Node&>(*m_end_container), m_end_offset));
-}
-
-NonnullRefPtr<Range> Range::inverted() const
-{
-    return adopt(*new Range(const_cast<Node&>(*m_end_container), m_end_offset, const_cast<Node&>(*m_start_container), m_start_offset));
-}
-
-NonnullRefPtr<Range> Range::normalized() const
-{
-    if (m_start_container.ptr() == m_end_container.ptr()) {
-        if (m_start_offset <= m_end_offset)
-            return clone_range();
-
-        return inverted();
-    }
-
-    if (m_start_container->is_before(m_end_container))
-        return clone_range();
-
-    return inverted();
+    return static_cast<RangeWrapper*>(wrap_impl(global_object, impl));
 }
 
 }

--- a/Libraries/LibWeb/Bindings/RangeWrapper.h
+++ b/Libraries/LibWeb/Bindings/RangeWrapper.h
@@ -24,52 +24,25 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibWeb/DOM/Document.h>
-#include <LibWeb/DOM/Node.h>
-#include <LibWeb/DOM/Range.h>
-#include <LibWeb/DOM/Window.h>
+#pragma once
 
-namespace Web::DOM {
+#include <LibWeb/Bindings/Wrapper.h>
 
-Range::Range(Window& window)
-    : m_start_container(window.document())
-    , m_start_offset(0)
-    , m_end_container(window.document())
-    , m_end_offset(0)
-{
-}
+namespace Web::Bindings {
 
-Range::Range(Node& start_container, size_t start_offset, Node& end_container, size_t end_offset)
-    : m_start_container(start_container)
-    , m_start_offset(start_offset)
-    , m_end_container(end_container)
-    , m_end_offset(end_offset)
-{
-}
+class RangeWrapper final : public Wrapper {
+public:
+    RangeWrapper(JS::GlobalObject&, DOM::Range&);
 
-NonnullRefPtr<Range> Range::clone_range() const
-{
-    return adopt(*new Range(const_cast<Node&>(*m_start_container), m_start_offset, const_cast<Node&>(*m_end_container), m_end_offset));
-}
+    DOM::Range& impl() { return m_impl; }
+    const DOM::Range& impl() const { return m_impl; }
 
-NonnullRefPtr<Range> Range::inverted() const
-{
-    return adopt(*new Range(const_cast<Node&>(*m_end_container), m_end_offset, const_cast<Node&>(*m_start_container), m_start_offset));
-}
+private:
+    virtual const char* class_name() const override { return "RangeWrapper"; }
 
-NonnullRefPtr<Range> Range::normalized() const
-{
-    if (m_start_container.ptr() == m_end_container.ptr()) {
-        if (m_start_offset <= m_end_offset)
-            return clone_range();
+    NonnullRefPtr<DOM::Range> m_impl;
+};
 
-        return inverted();
-    }
-
-    if (m_start_container->is_before(m_end_container))
-        return clone_range();
-
-    return inverted();
-}
+RangeWrapper* wrap(JS::GlobalObject&, DOM::Range&);
 
 }

--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -90,8 +90,6 @@ void WindowObject::initialize()
     add_constructor("XMLHttpRequest", m_xhr_constructor, m_xhr_prototype);
 
     m_range_prototype = heap().allocate<RangePrototype>(*this, *this);
-    m_range_constructor = heap().allocate<RangeConstructor>(*this, *this);
-    m_range_constructor->define_property("prototype", m_range_prototype);
     add_constructor("Range", m_range_constructor, m_range_prototype);
 }
 
@@ -104,6 +102,8 @@ void WindowObject::visit_edges(Visitor& visitor)
     GlobalObject::visit_edges(visitor);
     visitor.visit(m_xhr_constructor);
     visitor.visit(m_xhr_prototype);
+    visitor.visit(m_range_constructor);
+    visitor.visit(m_range_prototype);
 }
 
 Origin WindowObject::origin() const

--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -41,6 +41,8 @@
 #include <LibWeb/Bindings/NavigatorObject.h>
 #include <LibWeb/Bindings/NodeWrapperFactory.h>
 #include <LibWeb/Bindings/PerformanceWrapper.h>
+#include <LibWeb/Bindings/RangeConstructor.h>
+#include <LibWeb/Bindings/RangePrototype.h>
 #include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/Bindings/XMLHttpRequestConstructor.h>
 #include <LibWeb/Bindings/XMLHttpRequestPrototype.h>
@@ -86,6 +88,11 @@ void WindowObject::initialize()
 
     m_xhr_prototype = heap().allocate<XMLHttpRequestPrototype>(*this, *this);
     add_constructor("XMLHttpRequest", m_xhr_constructor, m_xhr_prototype);
+
+    m_range_prototype = heap().allocate<RangePrototype>(*this, *this);
+    m_range_constructor = heap().allocate<RangeConstructor>(*this, *this);
+    m_range_constructor->define_property("prototype", m_range_prototype);
+    add_constructor("Range", m_range_constructor, m_range_prototype);
 }
 
 WindowObject::~WindowObject()

--- a/Libraries/LibWeb/Bindings/WindowObject.h
+++ b/Libraries/LibWeb/Bindings/WindowObject.h
@@ -50,6 +50,9 @@ public:
     XMLHttpRequestPrototype* xhr_prototype() { return m_xhr_prototype; }
     XMLHttpRequestConstructor* xhr_constructor() { return m_xhr_constructor; }
 
+    RangePrototype* range_prototype() { return m_range_prototype; }
+    RangeConstructor* range_constructor() { return m_range_constructor; }
+
 private:
     virtual const char* class_name() const override { return "WindowObject"; }
     virtual void visit_edges(Visitor&) override;
@@ -76,6 +79,9 @@ private:
 
     XMLHttpRequestConstructor* m_xhr_constructor { nullptr };
     XMLHttpRequestPrototype* m_xhr_prototype { nullptr };
+
+    RangePrototype* m_range_prototype { nullptr };
+    RangeConstructor* m_range_constructor { nullptr };
 };
 
 }

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -178,6 +178,7 @@ set(SOURCES
     Namespace.cpp
     OutOfProcessWebView.cpp
     Page/EventHandler.cpp
+    Page/EditEventHandler.cpp
     Page/Frame.cpp
     Page/Page.cpp
     Painting/BorderPainting.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -11,6 +11,9 @@ set(SOURCES
     Bindings/XMLHttpRequestConstructor.cpp
     Bindings/XMLHttpRequestPrototype.cpp
     Bindings/XMLHttpRequestWrapper.cpp
+    Bindings/RangeConstructor.cpp
+    Bindings/RangePrototype.cpp
+    Bindings/RangeWrapper.cpp
     CSS/DefaultStyleSheetSource.cpp
     CSS/Length.cpp
     CSS/Parser/CSSParser.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCES
     DOM/Element.cpp
     DOM/ElementFactory.cpp
     DOM/Event.cpp
+    DOM/Range.cpp
     DOM/EventDispatcher.cpp
     DOM/EventListener.cpp
     DOM/EventTarget.cpp

--- a/Libraries/LibWeb/CodeGenerators/CMakeLists.txt
+++ b/Libraries/LibWeb/CodeGenerators/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(Generate_CSS_PropertyID_h Generate_CSS_PropertyID_h.cpp)
 add_executable(Generate_CSS_PropertyID_cpp Generate_CSS_PropertyID_cpp.cpp)
 add_executable(WrapperGenerator WrapperGenerator.cpp)
+target_compile_options(WrapperGenerator PUBLIC -g)
 target_link_libraries(Generate_CSS_PropertyID_h LagomCore)
 target_link_libraries(Generate_CSS_PropertyID_cpp LagomCore)
 target_link_libraries(WrapperGenerator LagomCore)

--- a/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -476,9 +476,8 @@ public:
     }
 
     generator.append(R"~~~(
-    virtual bool is_@wrapper_class:snakecase@() const final { return true; }
-
 private:
+    virtual bool is_@wrapper_class:snakecase@() const final { return true; }
 )~~~");
 
     for (auto& function : interface.functions) {

--- a/Libraries/LibWeb/DOM/Position.cpp
+++ b/Libraries/LibWeb/DOM/Position.cpp
@@ -39,6 +39,24 @@ Position::~Position()
 {
 }
 
+Range Range::normalized() const
+{
+    if (!is_valid())
+        return {};
+
+    if (m_start.node() == m_end.node()) {
+        if (m_start.offset() <= m_end.offset())
+            return *this;
+
+        return { m_end, m_start };
+    }
+
+    if (m_start.node()->is_before(*m_end.node()))
+        return *this;
+
+    return { m_end, m_start };
+}
+
 const LogStream& operator<<(const LogStream& stream, const Position& position)
 {
     if (!position.node())

--- a/Libraries/LibWeb/DOM/Position.cpp
+++ b/Libraries/LibWeb/DOM/Position.cpp
@@ -39,24 +39,6 @@ Position::~Position()
 {
 }
 
-Range Range::normalized() const
-{
-    if (!is_valid())
-        return {};
-
-    if (m_start.node() == m_end.node()) {
-        if (m_start.offset() <= m_end.offset())
-            return *this;
-
-        return { m_end, m_start };
-    }
-
-    if (m_start.node()->is_before(*m_end.node()))
-        return *this;
-
-    return { m_end, m_start };
-}
-
 const LogStream& operator<<(const LogStream& stream, const Position& position)
 {
     if (!position.node())

--- a/Libraries/LibWeb/DOM/Position.h
+++ b/Libraries/LibWeb/DOM/Position.h
@@ -62,6 +62,38 @@ private:
     unsigned m_offset { 0 };
 };
 
+class Range {
+public:
+    Range() = default;
+    Range(const Position& start, const Position& end)
+        : m_start(start)
+        , m_end(end)
+    {
+    }
+
+    bool is_valid() const { return m_start.is_valid() && m_end.is_valid(); }
+
+    void set(const Position& start, const Position& end)
+    {
+        m_start = start;
+        m_end = end;
+    }
+
+    void set_start(const Position& start) { m_start = start; }
+    void set_end(const Position& end) { m_end = end; }
+
+    const Position& start() const { return m_start; }
+    Position& start() { return m_start; }
+
+    const Position& end() const { return m_end; }
+    Position& end() { return m_end; }
+
+    Range normalized() const;
+
+private:
+    Position m_start, m_end;
+};
+
 const LogStream& operator<<(const LogStream&, const Position&);
 
 }

--- a/Libraries/LibWeb/DOM/Position.h
+++ b/Libraries/LibWeb/DOM/Position.h
@@ -62,38 +62,6 @@ private:
     unsigned m_offset { 0 };
 };
 
-class Range {
-public:
-    Range() = default;
-    Range(const Position& start, const Position& end)
-        : m_start(start)
-        , m_end(end)
-    {
-    }
-
-    bool is_valid() const { return m_start.is_valid() && m_end.is_valid(); }
-
-    void set(const Position& start, const Position& end)
-    {
-        m_start = start;
-        m_end = end;
-    }
-
-    void set_start(const Position& start) { m_start = start; }
-    void set_end(const Position& end) { m_end = end; }
-
-    const Position& start() const { return m_start; }
-    Position& start() { return m_start; }
-
-    const Position& end() const { return m_end; }
-    Position& end() { return m_end; }
-
-    Range normalized() const;
-
-private:
-    Position m_start, m_end;
-};
-
 const LogStream& operator<<(const LogStream&, const Position&);
 
 }

--- a/Libraries/LibWeb/DOM/Position.h
+++ b/Libraries/LibWeb/DOM/Position.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/RefPtr.h>
+#include <LibWeb/DOM/Node.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::DOM {
@@ -44,6 +45,7 @@ public:
     const Node* node() const { return m_node; }
 
     unsigned offset() const { return m_offset; }
+    void set_offset(unsigned value) { m_offset = value; }
 
     bool operator==(const Position& other) const
     {

--- a/Libraries/LibWeb/DOM/Range.h
+++ b/Libraries/LibWeb/DOM/Range.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <LibWeb/Bindings/Wrappable.h>
+
+namespace Web::DOM {
+
+class Range final
+    : public RefCounted<Range>
+    , public Bindings::Wrappable {
+public:
+    // using WrapperType = Bindings::RangeWrapper;
+
+    static NonnullRefPtr<Range> create(Document& document)
+    {
+        return adopt(*new Range(document));
+    }
+    static NonnullRefPtr<Range> create(Node& start_container, size_t start_offset, Node& end_container, size_t end_offset)
+    {
+        return adopt(*new Range(start_container, start_offset, end_container, end_offset));
+    }
+
+    Node* start_container() { return m_start_container; }
+    unsigned start_offset() { return m_start_offset; }
+
+    Node* end_container() { return m_end_container; }
+    unsigned end_offset() { return m_end_offset; }
+
+    bool collapsed()
+    {
+        return start_container() == end_container() && start_offset() == end_offset();
+    }
+
+    void set_start(Node& container, JS::Value& offset)
+    {
+        m_start_container = container;
+        m_start_offset = (unsigned)offset.as_i32();
+    }
+
+    void set_end(Node& container, JS::Value& offset)
+    {
+        m_end_container = container;
+        m_end_offset = (unsigned)offset.as_i32();
+    }
+
+    NonnullRefPtr<Range> inverted() const;
+    NonnullRefPtr<Range> normalized() const;
+    NonnullRefPtr<Range> clone_range() const;
+
+private:
+    explicit Range(Document&);
+    Range(Node& start_container, size_t start_offset, Node& end_container, size_t end_offset);
+
+    NonnullRefPtr<Node> m_start_container;
+    unsigned m_start_offset;
+
+    NonnullRefPtr<Node> m_end_container;
+    unsigned m_end_offset;
+};
+
+}

--- a/Libraries/LibWeb/DOM/Range.h
+++ b/Libraries/LibWeb/DOM/Range.h
@@ -28,6 +28,7 @@
 
 #include <AK/RefCounted.h>
 #include <LibWeb/Bindings/Wrappable.h>
+#include <LibWeb/DOM/Node.h>
 
 namespace Web::DOM {
 
@@ -35,16 +36,18 @@ class Range final
     : public RefCounted<Range>
     , public Bindings::Wrappable {
 public:
-    // using WrapperType = Bindings::RangeWrapper;
+    using WrapperType = Bindings::RangeWrapper;
 
-    static NonnullRefPtr<Range> create(Document& document)
+    static NonnullRefPtr<Range> create(Window& window)
     {
-        return adopt(*new Range(document));
+        return adopt(*new Range(window));
     }
     static NonnullRefPtr<Range> create(Node& start_container, size_t start_offset, Node& end_container, size_t end_offset)
     {
         return adopt(*new Range(start_container, start_offset, end_container, end_offset));
     }
+
+    // FIXME: There are a ton of methods missing here.
 
     Node* start_container() { return m_start_container; }
     unsigned start_offset() { return m_start_offset; }
@@ -57,16 +60,16 @@ public:
         return start_container() == end_container() && start_offset() == end_offset();
     }
 
-    void set_start(Node& container, JS::Value& offset)
+    void set_start(Node& container, unsigned offset)
     {
         m_start_container = container;
-        m_start_offset = (unsigned)offset.as_i32();
+        m_start_offset = offset;
     }
 
-    void set_end(Node& container, JS::Value& offset)
+    void set_end(Node& container, unsigned offset)
     {
         m_end_container = container;
-        m_end_offset = (unsigned)offset.as_i32();
+        m_end_offset = offset;
     }
 
     NonnullRefPtr<Range> inverted() const;
@@ -74,7 +77,7 @@ public:
     NonnullRefPtr<Range> clone_range() const;
 
 private:
-    explicit Range(Document&);
+    explicit Range(Window&);
     Range(Node& start_container, size_t start_offset, Node& end_container, size_t end_offset);
 
     NonnullRefPtr<Node> m_start_container;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -288,5 +288,8 @@ class Wrapper;
 class XMLHttpRequestConstructor;
 class XMLHttpRequestPrototype;
 class XMLHttpRequestWrapper;
+class RangeConstructor;
+class RangePrototype;
+class RangeWrapper;
 
 }

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -167,6 +167,7 @@ class ReplacedBox;
 
 namespace Web {
 class EventHandler;
+class EditEventHandler;
 class Frame;
 class FrameLoader;
 class InProcessWebView;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -51,10 +51,10 @@ class MouseEvent;
 class Node;
 class ParentNode;
 class Position;
-class Range;
 class Text;
 class Timer;
 class Window;
+class Range;
 enum class QuirksMode;
 }
 

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -51,6 +51,7 @@ class MouseEvent;
 class Node;
 class ParentNode;
 class Position;
+class Range;
 class Text;
 class Timer;
 class Window;

--- a/Libraries/LibWeb/Layout/LayoutPosition.cpp
+++ b/Libraries/LibWeb/Layout/LayoutPosition.cpp
@@ -53,4 +53,12 @@ LayoutRange LayoutRange::normalized() const
     return { m_end, m_start };
 }
 
+DOM::Range LayoutRange::to_dom_range() const
+{
+    if (!is_valid())
+        return {};
+
+    return { m_start.to_dom_position(), m_end.to_dom_position() };
+}
+
 }

--- a/Libraries/LibWeb/Layout/LayoutPosition.h
+++ b/Libraries/LibWeb/Layout/LayoutPosition.h
@@ -68,6 +68,8 @@ public:
 
     LayoutRange normalized() const;
 
+    DOM::Range to_dom_range() const;
+
 private:
     LayoutPosition m_start;
     LayoutPosition m_end;

--- a/Libraries/LibWeb/Layout/LayoutPosition.h
+++ b/Libraries/LibWeb/Layout/LayoutPosition.h
@@ -68,7 +68,7 @@ public:
 
     LayoutRange normalized() const;
 
-    DOM::Range to_dom_range() const;
+    NonnullRefPtr<DOM::Range> to_dom_range() const;
 
 private:
     LayoutPosition m_start;

--- a/Libraries/LibWeb/Layout/LayoutPosition.h
+++ b/Libraries/LibWeb/Layout/LayoutPosition.h
@@ -27,6 +27,8 @@
 #pragma once
 
 #include <AK/RefPtr.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/Layout/Node.h>
 
 namespace Web::Layout {
 
@@ -35,6 +37,8 @@ class Node;
 struct LayoutPosition {
     RefPtr<Node> layout_node;
     int index_in_node { 0 };
+
+    DOM::Position to_dom_position() const;
 };
 
 class LayoutRange {
@@ -58,7 +62,9 @@ public:
     void set_end(const LayoutPosition& end) { m_end = end; }
 
     const LayoutPosition& start() const { return m_start; }
+    LayoutPosition& start() { return m_start; }
     const LayoutPosition& end() const { return m_end; }
+    LayoutPosition& end() { return m_end; }
 
     LayoutRange normalized() const;
 

--- a/Libraries/LibWeb/Page/EditEventHandler.cpp
+++ b/Libraries/LibWeb/Page/EditEventHandler.cpp
@@ -40,11 +40,6 @@ namespace Web {
 
 void EditEventHandler::handle_delete(DOM::Range range)
 {
-    // FIXME: Deleting nodes seems to mess up the layout tree. Not sure if this is not entirely
-    //        my fault or not my fault at all.
-
-    dump_tree(*m_frame.document());
-
     if (range.start().node() != range.end().node()) {
         if (range.start().node()->parent() == range.end().node()->parent()) {
             // Remove all intermediate nodes.
@@ -85,8 +80,6 @@ void EditEventHandler::handle_delete(DOM::Range range)
     // FIXME: We need to remove stale layout nodes when nodes are removed from the DOM. Currently,
     //        this is the only way to get these to disappear.
     m_frame.document()->force_layout();
-
-    dump_tree(*m_frame.document());
 }
 
 void EditEventHandler::handle_insert(DOM::Position position, u32 code_point)

--- a/Libraries/LibWeb/Page/EditEventHandler.cpp
+++ b/Libraries/LibWeb/Page/EditEventHandler.cpp
@@ -26,6 +26,7 @@
 
 #include <AK/StringBuilder.h>
 #include <LibWeb/DOM/Position.h>
+#include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/Layout/LayoutPosition.h>
 #include <LibWeb/Page/Frame.h>
@@ -39,15 +40,15 @@
 namespace Web {
 
 // This method is quite convoluted but this is necessary to make editing feel intuitive.
-void EditEventHandler::handle_delete(DOM::Range range)
+void EditEventHandler::handle_delete(DOM::Range& range)
 {
-    auto* start = downcast<DOM::Text>(range.start().node());
-    auto* end = downcast<DOM::Text>(range.end().node());
+    auto* start = downcast<DOM::Text>(range.start_container());
+    auto* end = downcast<DOM::Text>(range.end_container());
 
     if (start == end) {
         StringBuilder builder;
-        builder.append(start->data().substring_view(0, range.start().offset()));
-        builder.append(end->data().substring_view(range.end().offset()));
+        builder.append(start->data().substring_view(0, range.start_offset()));
+        builder.append(end->data().substring_view(range.end_offset()));
 
         start->set_data(builder.to_string());
     } else {
@@ -84,8 +85,8 @@ void EditEventHandler::handle_delete(DOM::Range range)
 
         // Join the start and end nodes.
         StringBuilder builder;
-        builder.append(start->data().substring_view(0, range.start().offset()));
-        builder.append(end->data().substring_view(range.end().offset()));
+        builder.append(start->data().substring_view(0, range.start_offset()));
+        builder.append(end->data().substring_view(range.end_offset()));
 
         start->set_data(builder.to_string());
         start->parent()->remove_child(*end);

--- a/Libraries/LibWeb/Page/EditEventHandler.h
+++ b/Libraries/LibWeb/Page/EditEventHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020, the SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,49 +26,24 @@
 
 #pragma once
 
-#include <AK/Forward.h>
-#include <AK/WeakPtr.h>
-#include <Kernel/API/KeyCode.h>
-#include <LibGUI/Forward.h>
-#include <LibGfx/Forward.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/Page/EditEventHandler.h>
 
 namespace Web {
 
-class Frame;
-
-class EventHandler {
+class EditEventHandler {
 public:
-    explicit EventHandler(Badge<Frame>, Frame&);
-    ~EventHandler();
+    explicit EditEventHandler(Frame& frame)
+        : m_frame(frame)
+    {
+    }
 
-    bool handle_mouseup(const Gfx::IntPoint&, unsigned button, unsigned modifiers);
-    bool handle_mousedown(const Gfx::IntPoint&, unsigned button, unsigned modifiers);
-    bool handle_mousemove(const Gfx::IntPoint&, unsigned buttons, unsigned modifiers);
+    virtual ~EditEventHandler() = default;
 
-    bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
-
-    void set_mouse_event_tracking_layout_node(Layout::Node*);
-
-    void set_edit_event_handler(NonnullOwnPtr<EditEventHandler> value) { m_edit_event_handler = move(value); }
+    virtual void handle_delete(DOM::Position);
+    virtual void handle_insert(DOM::Position, u32 code_point);
 
 private:
-    bool focus_next_element();
-    bool focus_previous_element();
-
-    Layout::InitialContainingBlockBox* layout_root();
-    const Layout::InitialContainingBlockBox* layout_root() const;
-
-    void dump_selection(const char* event_name) const;
-
     Frame& m_frame;
-
-    bool m_in_mouse_selection { false };
-
-    WeakPtr<Layout::Node> m_mouse_event_tracking_layout_node;
-
-    NonnullOwnPtr<EditEventHandler> m_edit_event_handler;
 };
 
 }

--- a/Libraries/LibWeb/Page/EditEventHandler.h
+++ b/Libraries/LibWeb/Page/EditEventHandler.h
@@ -40,6 +40,7 @@ public:
     virtual ~EditEventHandler() = default;
 
     virtual void handle_delete(DOM::Position);
+    virtual void handle_delete(DOM::Range);
     virtual void handle_insert(DOM::Position, u32 code_point);
 
 private:

--- a/Libraries/LibWeb/Page/EditEventHandler.h
+++ b/Libraries/LibWeb/Page/EditEventHandler.h
@@ -39,7 +39,7 @@ public:
 
     virtual ~EditEventHandler() = default;
 
-    virtual void handle_delete(DOM::Range);
+    virtual void handle_delete(DOM::Range&);
     virtual void handle_insert(DOM::Position, u32 code_point);
 
 private:

--- a/Libraries/LibWeb/Page/EditEventHandler.h
+++ b/Libraries/LibWeb/Page/EditEventHandler.h
@@ -39,7 +39,6 @@ public:
 
     virtual ~EditEventHandler() = default;
 
-    virtual void handle_delete(DOM::Position);
     virtual void handle_delete(DOM::Range);
     virtual void handle_insert(DOM::Position, u32 code_point);
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -345,16 +345,33 @@ bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_poin
             return focus_next_element();
     }
 
+    if (layout_root()->selection().is_valid()) {
+        auto range = layout_root()->selection().to_dom_range();
+
+        if (key == KeyCode::Key_Backspace) {
+            if (range.start().node()->is_editable()) {
+                m_edit_event_handler->handle_delete(range);
+                return true;
+            }
+        }
+
+        // FIXME: Check if this code point is in the printable character range.
+
+        m_edit_event_handler->handle_delete(range);
+        m_edit_event_handler->handle_insert(m_frame.cursor_position(), code_point);
+        return true;
+    }
+
     if (m_frame.cursor_position().is_valid() && m_frame.cursor_position().node()->is_editable()) {
         if (key == KeyCode::Key_Backspace) {
             m_edit_event_handler->handle_delete(m_frame.cursor_position());
             return true;
         }
 
-        if (code_point) {
-            m_edit_event_handler->handle_insert(m_frame.cursor_position(), code_point);
-            return true;
-        }
+        // FIXME: Check if this code point is in the printable character range.
+
+        m_edit_event_handler->handle_insert(m_frame.cursor_position(), code_point);
+        return true;
     }
 
     return false;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -353,25 +353,21 @@ bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_poin
                 m_edit_event_handler->handle_delete(range);
                 return true;
             }
+        } else {
+            m_edit_event_handler->handle_delete(range);
+            m_edit_event_handler->handle_insert(m_frame.cursor_position(), code_point);
+            return true;
         }
-
-        // FIXME: Check if this code point is in the printable character range.
-
-        m_edit_event_handler->handle_delete(range);
-        m_edit_event_handler->handle_insert(m_frame.cursor_position(), code_point);
-        return true;
     }
 
     if (m_frame.cursor_position().is_valid() && m_frame.cursor_position().node()->is_editable()) {
         if (key == KeyCode::Key_Backspace) {
             m_edit_event_handler->handle_delete(m_frame.cursor_position());
             return true;
+        } else {
+            m_edit_event_handler->handle_insert(m_frame.cursor_position(), code_point);
+            return true;
         }
-
-        // FIXME: Check if this code point is in the printable character range.
-
-        m_edit_event_handler->handle_insert(m_frame.cursor_position(), code_point);
-        return true;
     }
 
     return false;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -422,4 +422,5 @@ void EventHandler::set_mouse_event_tracking_layout_node(Layout::Node* layout_nod
     else
         m_mouse_event_tracking_layout_node = nullptr;
 }
+
 }

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -346,12 +346,14 @@ bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_poin
     }
 
     if (layout_root()->selection().is_valid()) {
-        auto range = layout_root()->selection().to_dom_range();
+        auto range = layout_root()->selection().to_dom_range().normalized();
 
         m_frame.document()->layout_node()->set_selection({});
+
+        // FIXME: This doesn't work for some reason?
         m_frame.set_cursor_position(range.start());
 
-        if (key == KeyCode::Key_Backspace) {
+        if (key == KeyCode::Key_Backspace || key == KeyCode::Key_Delete) {
             if (range.start().node()->is_editable()) {
                 m_edit_event_handler->handle_delete(range);
                 return true;


### PR DESCRIPTION
There doesn't seem to be a specification that dictates how exactly the browser should behave in the presence of "contenteditable".

I've tried to make the behavior feel intuitive. There are some edge cases where no behavior feels "intuitive". Here a list with a few nasty edge cases:

---

The user selects the text starting and ending with the uppercase letter and then presses backspace:

~~~html
<div contenteditable>
    <p>aBc</p>
    <b>cDe</b>
</div>
~~~

The user would expect the remainders of the bold text to stay bold.

Firefox & Chromium:
~~~html
<div contenteditable>
    <p>a<b>e</b></p>
</div>
~~~

Serenity:
~~~html
<div contenteditable>
    <p>ae</p>
</div>
~~~

---

The user selects the text starting and ending with the uppercase letter and then presses backspace:

~~~html
<div contenteditable>
    <p class=a>aBc</p>
    <p class=b>cDe</p>
</div>
~~~

The user would expect both paragraphs to be joined into one but what happens to the classes?

Firefox:
~~~html
<div contenteditable>
    <p class=b>ae</p>
</div>
~~~

Serenity & Chromium:
~~~html
<div contenteditable>
    <p class=a>ae</p>
</div>
~~~
