### PR TITLE
Kernel: Improve time keeping and dramatically reduce interrupt load

### DIFF
--- a/Applications/SystemMonitor/ProcessModel.h
+++ b/Applications/SystemMonitor/ProcessModel.h
@@ -116,6 +116,8 @@ private:
         pid_t pgid;
         pid_t sid;
         unsigned times_scheduled;
+        unsigned ticks_user;
+        unsigned ticks_kernel;
         String name;
         String state;
         String user;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -884,7 +884,8 @@ static OwnPtr<KBuffer> procfs$all(InodeIdentifier)
             thread_object.add("tid", thread.tid().value());
             thread_object.add("name", thread.name());
             thread_object.add("times_scheduled", thread.times_scheduled());
-            thread_object.add("ticks", thread.ticks());
+            thread_object.add("ticks_user", thread.ticks_in_user());
+            thread_object.add("ticks_kernel", thread.ticks_in_kernel());
             thread_object.add("state", thread.state_string());
             thread_object.add("cpu", thread.cpu());
             thread_object.add("priority", thread.priority());

--- a/Kernel/Syscalls/alarm.cpp
+++ b/Kernel/Syscalls/alarm.cpp
@@ -46,9 +46,9 @@ unsigned Process::sys$alarm(unsigned seconds)
     }
 
     if (seconds > 0) {
-        auto deadline = TimeManagement::the().current_time(CLOCK_REALTIME).value();
+        auto deadline = TimeManagement::the().current_time(CLOCK_REALTIME_COARSE).value();
         timespec_add(deadline, { seconds, 0 }, deadline);
-        m_alarm_timer = TimerQueue::the().add_timer_without_id(CLOCK_REALTIME, deadline, [this]() {
+        m_alarm_timer = TimerQueue::the().add_timer_without_id(CLOCK_REALTIME_COARSE, deadline, [this]() {
             [[maybe_unused]] auto rc = send_signal(SIGALRM, nullptr);
         });
     }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -400,13 +400,15 @@ void Thread::finalize_dying_threads()
     }
 }
 
-bool Thread::tick()
+bool Thread::tick(bool in_kernel)
 {
-    ++m_ticks;
-    if (tss().cs & 3)
-        ++m_process->m_ticks_in_user;
-    else
+    if (in_kernel) {
         ++m_process->m_ticks_in_kernel;
+        ++m_ticks_in_kernel;
+    } else {
+        ++m_process->m_ticks_in_user;
+        ++m_ticks_in_user;
+    }
     return --m_ticks_left;
 }
 

--- a/Kernel/Time/APICTimer.h
+++ b/Kernel/Time/APICTimer.h
@@ -44,6 +44,7 @@ public:
     virtual bool is_periodic_capable() const override { return true; }
     virtual void set_periodic() override;
     virtual void set_non_periodic() override;
+    virtual void disable() override { }
 
     virtual void reset_to_default_ticks_per_second() override;
     virtual bool try_to_set_frequency(size_t frequency) override;

--- a/Kernel/Time/HPET.h
+++ b/Kernel/Time/HPET.h
@@ -45,7 +45,7 @@ public:
     static bool check_for_exisiting_periodic_timers();
     static HPET& the();
 
-    u64 frequency() const;
+    u64 frequency() const { return m_frequency; }
 
     const NonnullRefPtrVector<HPETComparator>& comparators() const { return m_comparators; }
     void disable(const HPETComparator&);
@@ -58,6 +58,8 @@ public:
 
     void enable_periodic_interrupt(const HPETComparator& comparator);
     void disable_periodic_interrupt(const HPETComparator& comparator);
+
+    u64 update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only);
 
     Vector<unsigned> capable_interrupt_numbers(u8 comparator_number);
     Vector<unsigned> capable_interrupt_numbers(const HPETComparator&);
@@ -80,7 +82,9 @@ private:
     PhysicalAddress m_physical_acpi_hpet_registers;
     OwnPtr<Region> m_hpet_mmio_region;
 
-    u64 m_main_counter_clock_period { 0 };
+    u64 m_main_counter_last_read { 0 };
+    u64 m_main_counter_drift { 0 };
+
     u16 m_vendor_id;
     u16 m_minimum_tick;
     u64 m_frequency;

--- a/Kernel/Time/HPETComparator.h
+++ b/Kernel/Time/HPETComparator.h
@@ -42,6 +42,7 @@ public:
     virtual const char* model() const override { return "HPET"; }
 
     u8 comparator_number() const { return m_comparator_number; }
+    bool is_enabled() const { return m_enabled; }
 
     virtual size_t ticks_per_second() const override;
 
@@ -49,6 +50,7 @@ public:
     virtual bool is_periodic_capable() const override { return m_periodic_capable; }
     virtual void set_periodic() override;
     virtual void set_non_periodic() override;
+    virtual void disable() override;
 
     virtual void reset_to_default_ticks_per_second() override;
     virtual bool try_to_set_frequency(size_t frequency) override;
@@ -61,7 +63,7 @@ private:
     HPETComparator(u8 number, u8 irq, bool periodic_capable);
     bool m_periodic : 1;
     bool m_periodic_capable : 1;
-    bool m_edge_triggered : 1;
+    bool m_enabled : 1;
     u8 m_comparator_number { 0 };
 };
 }

--- a/Kernel/Time/HardwareTimer.h
+++ b/Kernel/Time/HardwareTimer.h
@@ -57,6 +57,7 @@ public:
     virtual bool is_periodic_capable() const = 0;
     virtual void set_periodic() = 0;
     virtual void set_non_periodic() = 0;
+    virtual void disable() = 0;
 
     virtual size_t ticks_per_second() const = 0;
 

--- a/Kernel/Time/PIT.h
+++ b/Kernel/Time/PIT.h
@@ -63,6 +63,7 @@ public:
     virtual bool is_periodic_capable() const override { return true; }
     virtual void set_periodic() override;
     virtual void set_non_periodic() override;
+    virtual void disable() override { }
 
     virtual void reset_to_default_ticks_per_second() override;
     virtual bool try_to_set_frequency(size_t frequency) override;

--- a/Kernel/Time/RTC.h
+++ b/Kernel/Time/RTC.h
@@ -42,6 +42,7 @@ public:
     virtual bool is_periodic_capable() const override { return true; }
     virtual void set_periodic() override { }
     virtual void set_non_periodic() override { }
+    virtual void disable() override { }
 
     virtual void reset_to_default_ticks_per_second() override;
     virtual bool try_to_set_frequency(size_t frequency) override;

--- a/Kernel/TimerQueue.h
+++ b/Kernel/TimerQueue.h
@@ -80,7 +80,7 @@ private:
     }
     bool is_queued() const { return m_queued.load(AK::MemoryOrder::memory_order_relaxed); }
     void set_queued(bool queued) { m_queued.store(queued, AK::MemoryOrder::memory_order_relaxed); }
-    u64 now() const;
+    u64 now(bool) const;
 };
 
 class TimerQueue {
@@ -114,16 +114,16 @@ private:
     {
         switch (timer.m_clock_id) {
         case CLOCK_MONOTONIC:
+        case CLOCK_MONOTONIC_COARSE:
+        case CLOCK_MONOTONIC_RAW:
             return m_timer_queue_monotonic;
         case CLOCK_REALTIME:
+        case CLOCK_REALTIME_COARSE:
             return m_timer_queue_realtime;
         default:
             ASSERT_NOT_REACHED();
         }
     }
-
-    timespec ticks_to_time(clockid_t, u64 ticks) const;
-    u64 time_to_ticks(clockid_t, const timespec&) const;
 
     u64 m_timer_id_count { 0 };
     u64 m_ticks_per_second { 0 };

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -548,6 +548,9 @@ typedef int clockid_t;
 
 #define CLOCK_REALTIME 0
 #define CLOCK_MONOTONIC 1
+#define CLOCK_MONOTONIC_RAW 4
+#define CLOCK_REALTIME_COARSE 5
+#define CLOCK_MONOTONIC_COARSE 6
 #define TIMER_ABSTIME 99
 
 #define UTSNAME_ENTRY_LEN 65

--- a/Libraries/LibC/time.h
+++ b/Libraries/LibC/time.h
@@ -72,6 +72,9 @@ typedef int clockid_t;
 
 #define CLOCK_REALTIME 0
 #define CLOCK_MONOTONIC 1
+#define CLOCK_MONOTONIC_RAW 4
+#define CLOCK_REALTIME_COARSE 5
+#define CLOCK_MONOTONIC_COARSE 6
 #define TIMER_ABSTIME 99
 
 int clock_gettime(clockid_t, struct timespec*);

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -339,7 +339,7 @@ char* getwd(char* buf)
 int sleep(unsigned seconds)
 {
     struct timespec ts = { seconds, 0 };
-    if (clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, nullptr) < 0)
+    if (clock_nanosleep(CLOCK_MONOTONIC_COARSE, 0, &ts, nullptr) < 0)
         return ts.tv_sec;
     return 0;
 }
@@ -347,7 +347,7 @@ int sleep(unsigned seconds)
 int usleep(useconds_t usec)
 {
     struct timespec ts = { (long)(usec / 1000000), (long)(usec % 1000000) * 1000 };
-    return clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, nullptr);
+    return clock_nanosleep(CLOCK_MONOTONIC_COARSE, 0, &ts, nullptr);
 }
 
 int gethostname(char* buffer, size_t size)

--- a/Libraries/LibCore/ElapsedTimer.cpp
+++ b/Libraries/LibCore/ElapsedTimer.cpp
@@ -36,7 +36,7 @@ void ElapsedTimer::start()
 {
     m_valid = true;
     timespec now_spec;
-    clock_gettime(CLOCK_MONOTONIC, &now_spec);
+    clock_gettime(m_precise ? CLOCK_MONOTONIC : CLOCK_MONOTONIC_COARSE, &now_spec);
     m_origin_time.tv_sec = now_spec.tv_sec;
     m_origin_time.tv_usec = now_spec.tv_nsec / 1000;
 }
@@ -46,7 +46,7 @@ int ElapsedTimer::elapsed() const
     ASSERT(is_valid());
     struct timeval now;
     timespec now_spec;
-    clock_gettime(CLOCK_MONOTONIC, &now_spec);
+    clock_gettime(m_precise ? CLOCK_MONOTONIC : CLOCK_MONOTONIC_COARSE, &now_spec);
     now.tv_sec = now_spec.tv_sec;
     now.tv_usec = now_spec.tv_nsec / 1000;
     struct timeval diff;

--- a/Libraries/LibCore/ElapsedTimer.h
+++ b/Libraries/LibCore/ElapsedTimer.h
@@ -32,7 +32,10 @@ namespace Core {
 
 class ElapsedTimer {
 public:
-    ElapsedTimer() { }
+    ElapsedTimer(bool precise = false)
+        : m_precise(precise)
+    {
+    }
 
     bool is_valid() const { return m_valid; }
     void start();
@@ -41,6 +44,7 @@ public:
     const struct timeval& origin_time() const { return m_origin_time; }
 
 private:
+    bool m_precise { false };
     bool m_valid { false };
     struct timeval m_origin_time {
         0, 0

--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -580,7 +580,7 @@ retry:
         auto next_timer_expiration = get_next_timer_expiration();
         if (next_timer_expiration.has_value()) {
             timespec now_spec;
-            clock_gettime(CLOCK_MONOTONIC, &now_spec);
+            clock_gettime(CLOCK_MONOTONIC_COARSE, &now_spec);
             now.tv_sec = now_spec.tv_sec;
             now.tv_usec = now_spec.tv_nsec / 1000;
             timeval_sub(next_timer_expiration.value(), now, timeout);
@@ -631,7 +631,7 @@ try_select_again:
 
     if (!s_timers->is_empty()) {
         timespec now_spec;
-        clock_gettime(CLOCK_MONOTONIC, &now_spec);
+        clock_gettime(CLOCK_MONOTONIC_COARSE, &now_spec);
         now.tv_sec = now_spec.tv_sec;
         now.tv_usec = now_spec.tv_nsec / 1000;
     }
@@ -709,7 +709,7 @@ int EventLoop::register_timer(Object& object, int milliseconds, bool should_relo
     timer->interval = milliseconds;
     timeval now;
     timespec now_spec;
-    clock_gettime(CLOCK_MONOTONIC, &now_spec);
+    clock_gettime(CLOCK_MONOTONIC_COARSE, &now_spec);
     now.tv_sec = now_spec.tv_sec;
     now.tv_usec = now_spec.tv_nsec / 1000;
     timer->reload(now);

--- a/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -85,7 +85,8 @@ HashMap<pid_t, Core::ProcessStatistics> ProcessStatisticsReader::get_all()
             thread.times_scheduled = thread_object.get("times_scheduled").to_u32();
             thread.name = thread_object.get("name").to_string();
             thread.state = thread_object.get("state").to_string();
-            thread.ticks = thread_object.get("ticks").to_u32();
+            thread.ticks_user = thread_object.get("ticks_user").to_u32();
+            thread.ticks_kernel = thread_object.get("ticks_kernel").to_u32();
             thread.cpu = thread_object.get("cpu").to_u32();
             thread.priority = thread_object.get("priority").to_u32();
             thread.effective_priority = thread_object.get("effective_priority").to_u32();

--- a/Libraries/LibCore/ProcessStatisticsReader.h
+++ b/Libraries/LibCore/ProcessStatisticsReader.h
@@ -35,7 +35,8 @@ namespace Core {
 struct ThreadStatistics {
     pid_t tid;
     unsigned times_scheduled;
-    unsigned ticks;
+    unsigned ticks_user;
+    unsigned ticks_kernel;
     unsigned syscall_count;
     unsigned inode_faults;
     unsigned zero_faults;

--- a/Libraries/LibPthread/pthread.cpp
+++ b/Libraries/LibPthread/pthread.cpp
@@ -474,7 +474,7 @@ int pthread_cond_init(pthread_cond_t* cond, const pthread_condattr_t* attr)
 {
     cond->value = 0;
     cond->previous = 0;
-    cond->clockid = attr ? attr->clockid : CLOCK_MONOTONIC;
+    cond->clockid = attr ? attr->clockid : CLOCK_MONOTONIC_COARSE;
     return 0;
 }
 
@@ -502,7 +502,7 @@ int pthread_cond_wait(pthread_cond_t* cond, pthread_mutex_t* mutex)
 
 int pthread_condattr_init(pthread_condattr_t* attr)
 {
-    attr->clockid = CLOCK_MONOTONIC;
+    attr->clockid = CLOCK_MONOTONIC_COARSE;
     return 0;
 }
 

--- a/Libraries/LibPthread/pthread.h
+++ b/Libraries/LibPthread/pthread.h
@@ -82,9 +82,9 @@ int pthread_setschedparam(pthread_t thread, int policy, const struct sched_param
     {                                  \
         0, 0, 0, PTHREAD_MUTEX_DEFAULT \
     }
-#define PTHREAD_COND_INITIALIZER \
-    {                            \
-        0, 0, CLOCK_MONOTONIC    \
+#define PTHREAD_COND_INITIALIZER     \
+    {                                \
+        0, 0, CLOCK_MONOTONIC_COARSE \
     }
 
 int pthread_key_create(pthread_key_t* key, void (*destructor)(void*));

--- a/MenuApplets/ResourceGraph/main.cpp
+++ b/MenuApplets/ResourceGraph/main.cpp
@@ -135,9 +135,9 @@ private:
         for (auto& it : all_processes) {
             for (auto& jt : it.value.threads) {
                 if (it.value.pid == 0)
-                    idle += jt.times_scheduled;
+                    idle += jt.ticks_user + jt.ticks_kernel;
                 else
-                    busy += jt.times_scheduled;
+                    busy += jt.ticks_user + jt.ticks_kernel;
             }
         }
     }

--- a/Userland/watch.cpp
+++ b/Userland/watch.cpp
@@ -56,7 +56,7 @@ static struct timeval get_current_time()
 {
     struct timespec ts;
     struct timeval tv;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
+    clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
     timespec_to_timeval(ts, tv);
     return tv;
 }


### PR DESCRIPTION
This implements a number of changes related to time:
* If a HPET is present, it is now used only as a system timer, unless
  the Local APIC timer is used (in which case the HPET timer will not
  trigger any interrupts at all).
* If a HPET is present, the current time can now be as accurate as the
  chip can be, independently from the system timer. We now query the
  HPET main counter for the current time in CPU #0's system timer
  interrupt, and use that as a base line. If a high precision time is
  queried, that base line is used in combination with quering the HPET
  timer directly, which should give a much more accurate time stamp at
  the expense of more overhead. For faster time stamps, the more coarse
  value based on the last interrupt will be returned. This also means
  that any missed interrupts should not cause the time to drift.
* The default system interrupt rate is reduced to about 250 per second.
* Fix calculation of Thread CPU usage by using the amount of ticks they
  used rather than the number of times a context switch happened.
* Implement CLOCK_REALTIME_COARSE and CLOCK_MONOTONIC_COARSE and use it
  for most cases where precise timestamps are not needed.

For giggles, I tried changing `OPTIMAL_TICKS_PER_SECOND_RATE` to `100` and the system actually works just fine, but I figure `250` is what Linux uses by default, so that's probably a good default. Changing the way CPU usage is calulated became quite apparent the lower I dropped that number, because the perceived cpu usage went way up. With these changes it remains consistent regardless of whether we're running with `100`, `250`, or `1000` per second.

This might also help with #3429. At least theoretically this is now as accurate as HPET can be, and even missed interrupts should not cause any time drift.