### PR TITLE
js: Improve pretty-printing of various objects

### DIFF
--- a/Libraries/LibJS/Runtime/Function.h
+++ b/Libraries/LibJS/Runtime/Function.h
@@ -50,8 +50,6 @@ public:
 
     virtual void visit_edges(Visitor&) override;
 
-    virtual bool is_script_function() const { return false; }
-
     BoundFunction* bind(Value bound_this_value, Vector<Value> arguments);
 
     Value bound_this() const { return m_bound_this; }

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -117,6 +117,7 @@ public:
     virtual bool is_error() const { return false; }
     virtual bool is_function() const { return false; }
     virtual bool is_native_function() const { return false; }
+    virtual bool is_script_function() const { return false; }
     virtual bool is_bound_function() const { return false; }
     virtual bool is_proxy_object() const { return false; }
     virtual bool is_regexp_object() const { return false; }


### PR DESCRIPTION
For many object types we only ever used the regular `print_object()` in the js REPL - resulting in a useless "{  }".

This patch adds more individual representations for the following types:
- `Boolean`/`Number`/`String` object: print wrapped value
- `ArrayBuffer`: print byteLength and hex-formatted bytes in chunks of 16
- `TypedArray`: print length, byteLength, buffer pointer and values
- `Proxy`: print target and handler

Also improve the existing pretty-printing output:
- More consistency, most objects now follow the format "[Type] ..."
- Some coloring tweaks
- No two spaces in empty arrays & objects

Possible future improvements:
- Add line breaks between elements of long arrays & objects

Closes #4310.

---

Old vs. new:

![image](https://user-images.githubusercontent.com/19366641/101224689-49b4c280-3687-11eb-856f-d549b9278382.png)
![image](https://user-images.githubusercontent.com/19366641/101224891-dd868e80-3687-11eb-8926-0c148a1c753b.png)
