### PR TITLE
LibGfx: Handle OOM slightly better

### DIFF
--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -345,6 +345,8 @@ RefPtr<Bitmap> Bitmap::to_bitmap_backed_by_shared_buffer() const
     if (m_shared_buffer)
         return *this;
     auto buffer = SharedBuffer::create_with_size(size_in_bytes());
+    if (!buffer)
+        return nullptr;
     auto bitmap = Bitmap::create_with_shared_buffer(m_format, *buffer, m_size, palette_to_vector());
     if (!bitmap)
         return nullptr;


### PR DESCRIPTION
When create_with_shared_buffer() is called in the next line, the RefPtr::operator* asserts that the RefPtr is not null. That can happen when we're low-ish on memory, and the image is huge.
