### PR TITLE
AK: Add test for the will_be_destroyed and one_ref_left magic functions

### DIFF
--- a/AK/RefCounted.h
+++ b/AK/RefCounted.h
@@ -36,7 +36,7 @@
 namespace AK {
 
 template<class T>
-constexpr auto call_will_be_destroyed_if_present(const T* object) -> decltype(object->will_be_destroyed(), TrueType {})
+constexpr auto call_will_be_destroyed_if_present(const T* object) -> decltype(const_cast<T*>(object)->will_be_destroyed(), TrueType {})
 {
     const_cast<T*>(object)->will_be_destroyed();
     return {};
@@ -48,7 +48,7 @@ constexpr auto call_will_be_destroyed_if_present(...) -> FalseType
 }
 
 template<class T>
-constexpr auto call_one_ref_left_if_present(const T* object) -> decltype(object->one_ref_left(), TrueType {})
+constexpr auto call_one_ref_left_if_present(const T* object) -> decltype(const_cast<T*>(object)->one_ref_left(), TrueType {})
 {
     const_cast<T*>(object)->one_ref_left();
     return {};


### PR DESCRIPTION
Fixes a regression introduced by 5c1b3ce. The commit description there
asserts that the changes allow calling will_be_destroyed and
one_ref_left, which are not required to be const qualified. The
implementation in fact does require the methods to be const qualified,
because we forgot to add the const_cast inside the decltypes :^)