### PR TITLE
Add a AudioDevice class to be used as a base for sound cards

### DIFF
--- a/AK/Debug.h.in
+++ b/AK/Debug.h.in
@@ -26,6 +26,10 @@
 
 #pragma once
 
+#ifndef AUDIODEVICE_DEBUG
+#cmakedefine01 AUDIODEVICE_DEBUG
+#endif
+
 #ifndef AUTOCOMPLETE_DEBUG
 #cmakedefine01 AUTOCOMPLETE_DEBUG
 #endif

--- a/Kernel/API/AudioDevice.h
+++ b/Kernel/API/AudioDevice.h
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+#include <stddef.h>
+#include <stdarg.h>
+#include <sys/ioctl.h>
+
+namespace Audio {
+
+namespace PCM {
+
+enum class SampleFormat {
+    Unknown = 0,
+    S8_LE,
+    S8_BE,
+    S16_LE,
+    S16_BE,
+    S24_LE,
+    S24_BE,
+    S24_32_LE,
+    S24_32_BE,
+    S32_LE,
+    S32_BE,
+    U8_LE,
+    U8_BE,
+    U16_LE,
+    U16_BE,
+    U24_LE,
+    U24_BE,
+    U24_32_LE,
+    U24_32_BE,
+    U32_LE,
+    U32_BE,
+    F32_LE,
+    F32_BE,
+    F64_LE,
+    F64_BE,
+};
+
+ALWAYS_INLINE bool is_little_endian(SampleFormat format)
+{
+    switch (format) {
+    case SampleFormat::S8_LE:
+    case SampleFormat::S16_LE:
+    case SampleFormat::S24_LE:
+    case SampleFormat::S24_32_LE:
+    case SampleFormat::S32_LE:
+    case SampleFormat::U8_LE:
+    case SampleFormat::U16_LE:
+    case SampleFormat::U24_LE:
+    case SampleFormat::U24_32_LE:
+    case SampleFormat::U32_LE:
+    case SampleFormat::F32_LE:
+    case SampleFormat::F64_LE:
+        return true;
+    default:
+        return false;
+    }
+}
+
+ALWAYS_INLINE bool is_big_endian(SampleFormat format)
+{
+    switch (format) {
+    case SampleFormat::S8_BE:
+    case SampleFormat::S16_BE:
+    case SampleFormat::S24_BE:
+    case SampleFormat::S24_32_BE:
+    case SampleFormat::S32_BE:
+    case SampleFormat::U8_BE:
+    case SampleFormat::U16_BE:
+    case SampleFormat::U24_BE:
+    case SampleFormat::U24_32_BE:
+    case SampleFormat::U32_BE:
+    case SampleFormat::F32_BE:
+    case SampleFormat::F64_BE:
+        return true;
+    default:
+        return false;
+    }
+}
+
+ALWAYS_INLINE bool is_signed(SampleFormat format)
+{
+    switch (format) {
+    case SampleFormat::S8_LE:
+    case SampleFormat::S8_BE:
+    case SampleFormat::S16_LE:
+    case SampleFormat::S16_BE:
+    case SampleFormat::S24_LE:
+    case SampleFormat::S24_BE:
+    case SampleFormat::S24_32_LE:
+    case SampleFormat::S24_32_BE:
+    case SampleFormat::S32_LE:
+    case SampleFormat::S32_BE:
+        return true;
+    default:
+        return false;
+    }
+}
+
+ALWAYS_INLINE bool is_unsigned(SampleFormat format)
+{
+    switch (format) {
+    case SampleFormat::U8_LE:
+    case SampleFormat::U8_BE:
+    case SampleFormat::U16_LE:
+    case SampleFormat::U16_BE:
+    case SampleFormat::U24_LE:
+    case SampleFormat::U24_BE:
+    case SampleFormat::U24_32_LE:
+    case SampleFormat::U24_32_BE:
+    case SampleFormat::U32_LE:
+    case SampleFormat::U32_BE:
+        return true;
+    default:
+        return false;
+    }
+}
+
+ALWAYS_INLINE bool is_float(SampleFormat format)
+{
+    switch (format) {
+    case SampleFormat::F32_LE:
+    case SampleFormat::F32_BE:
+    case SampleFormat::F64_LE:
+    case SampleFormat::F64_BE:
+        return true;
+    default:
+        return false;
+    }
+}
+
+ALWAYS_INLINE size_t bytes_per_sample(SampleFormat format)
+{
+    switch (format) {
+    case SampleFormat::S8_LE:
+    case SampleFormat::S8_BE:
+    case SampleFormat::U8_LE:
+    case SampleFormat::U8_BE:
+        return 1;
+    case SampleFormat::S16_LE:
+    case SampleFormat::S16_BE:
+    case SampleFormat::U16_LE:
+    case SampleFormat::U16_BE:
+        return 2;
+    case SampleFormat::S24_LE:
+    case SampleFormat::S24_BE:
+    case SampleFormat::U24_LE:
+    case SampleFormat::U24_BE:
+        return 3;
+    case SampleFormat::S32_LE:
+    case SampleFormat::S32_BE:
+    case SampleFormat::U32_LE:
+    case SampleFormat::U32_BE:
+    case SampleFormat::S24_32_LE:
+    case SampleFormat::S24_32_BE:
+    case SampleFormat::U24_32_LE:
+    case SampleFormat::U24_32_BE:
+    case SampleFormat::F32_LE:
+    case SampleFormat::F32_BE:
+        return 4;
+    case SampleFormat::F64_LE:
+    case SampleFormat::F64_BE:
+        return 8;
+    default:
+        return 0;
+    }
+}
+
+ALWAYS_INLINE size_t significant_bits_per_sample(SampleFormat format)
+{
+    switch (format) {
+    case SampleFormat::S8_LE:
+    case SampleFormat::S8_BE:
+    case SampleFormat::U8_LE:
+    case SampleFormat::U8_BE:
+        return 8;
+    case SampleFormat::S16_LE:
+    case SampleFormat::S16_BE:
+    case SampleFormat::U16_LE:
+    case SampleFormat::U16_BE:
+        return 16;
+    case SampleFormat::S24_LE:
+    case SampleFormat::S24_BE:
+    case SampleFormat::U24_LE:
+    case SampleFormat::U24_BE:
+    case SampleFormat::S24_32_LE:
+    case SampleFormat::S24_32_BE:
+    case SampleFormat::U24_32_LE:
+    case SampleFormat::U24_32_BE:
+        return 24;
+    case SampleFormat::S32_LE:
+    case SampleFormat::S32_BE:
+    case SampleFormat::U32_LE:
+    case SampleFormat::U32_BE:
+    case SampleFormat::F32_LE:
+    case SampleFormat::F32_BE:
+        return 32;
+    case SampleFormat::F64_LE:
+    case SampleFormat::F64_BE:
+        return 64;
+    default:
+        return 0;
+    }
+}
+
+ALWAYS_INLINE size_t bytes_per_frame(SampleFormat format, unsigned channels)
+{
+    return bytes_per_sample(format) * channels;
+}
+
+ALWAYS_INLINE size_t bytes_per_second(unsigned rate, SampleFormat format, unsigned channels)
+{
+    return rate * bytes_per_frame(format, channels);
+}
+
+ALWAYS_INLINE u64 time_to_frames(u64 ns, unsigned rate)
+{
+    // TODO: deal with overflows
+    return ((u64)rate * ns) / 1000000000ull;
+}
+
+ALWAYS_INLINE u64 frames_to_time(u64 frames, unsigned rate)
+{
+    // TODO: deal with overflows
+    return (frames * 1000000000ull) / (u64)rate;
+}
+
+enum class SampleLayout {
+    Unknown = 0,
+    Interleaved,
+    NonInterleaved,
+};
+
+}
+
+struct IOCtlJsonParams {
+    const void* in_buffer;
+    size_t in_buffer_size;
+    void* out_buffer;
+    size_t out_buffer_size;
+};
+
+struct IOCtlSetPCMHwParams {
+    PCM::SampleFormat format { PCM::SampleFormat::Unknown };
+    PCM::SampleLayout layout { PCM::SampleLayout::Unknown };
+    unsigned rate { 0 };
+    unsigned channels { 0 };
+    unsigned periods { 0 };
+    unsigned periods_trigger { 0 };
+    u64 period_ns { 0 };
+
+    bool is_null() const
+    {
+        // NOTE: periods_trigger may be 0!
+        return format == PCM::SampleFormat::Unknown
+            || layout == PCM::SampleLayout::Unknown
+            || rate == 0
+            || channels == 0
+            || periods == 0
+            || period_ns == 0;
+    }
+};
+
+enum class StreamType {
+    Unknown = 0,
+    Playback,
+    Record
+};
+
+enum class IOCtl {
+    SELECT_STREAM,
+    GET_PCM_HW_PARAMS,
+    SET_PCM_HW_PARAMS,
+    PCM_PREPARE,
+};
+
+template<typename ParamType>
+ALWAYS_INLINE int audio_ioctl(int fd, IOCtl request, ParamType& params)
+{
+    return ::ioctl(fd, (unsigned)request, &params);
+}
+
+ALWAYS_INLINE int audio_ioctl(int fd, IOCtl request, unsigned arg)
+{
+    return ::ioctl(fd, (unsigned)request, (FlatPtr)arg);
+}
+
+}

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -27,6 +27,7 @@ set(KERNEL_SOURCES
     CoreDump.cpp
     DMI.cpp
     Devices/AsyncDeviceRequest.cpp
+    Devices/AudioDevice.cpp
     Devices/BXVGADevice.cpp
     Devices/BlockDevice.cpp
     Devices/CharacterDevice.cpp

--- a/Kernel/Devices/AudioDevice.cpp
+++ b/Kernel/Devices/AudioDevice.cpp
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#define AUDIODEVICE_DEBUG 1
+#include <AK/Debug.h>
+#include <AK/Format.h>
+#include <AK/JsonObjectSerializer.h>
+#include <AK/ScopeGuard.h>
+#include <Kernel/Devices/AudioDevice.h>
+#include <Kernel/KBufferBuilder.h>
+#include <Kernel/VM/AnonymousVMObject.h>
+
+namespace Kernel {
+
+AsyncAudioDeviceRequest::AsyncAudioDeviceRequest(Device& audio_device, RequestType request_type, unsigned stream, const UserOrKernelBuffer& buffer, size_t buffer_size)
+    : AsyncDeviceRequest(audio_device)
+    , m_audio_device(static_cast<AudioDevice&>(audio_device))
+    , m_request_type(request_type)
+    , m_stream(stream)
+    , m_buffer(buffer)
+    , m_buffer_size(buffer_size)
+{
+}
+
+void AsyncAudioDeviceRequest::start()
+{
+    m_audio_device.start_request(*this);
+}
+
+void AudioDevice::start_request(AsyncAudioDeviceRequest& request)
+{
+    if (request.stream() >= m_streams.size()) {
+        dbgln("AudioDevice::start_request: No such stream: {}", request.stream());
+        request.complete(AsyncDeviceRequest::Failure);
+        return;
+    }
+    auto& stream = stream_for_request(request);
+    switch (stream.type) {
+    case Audio::StreamType::Playback:
+        if (request.request_type() != AsyncAudioDeviceRequest::RequestType::Write) {
+            dbgln("AudioDevice::start_request: Can only write to stream {}", request.stream());
+            request.complete(AsyncDeviceRequest::Failure);
+            return;
+        }
+        break;
+    case Audio::StreamType::Record:
+        if (request.request_type() != AsyncAudioDeviceRequest::RequestType::Read) {
+            dbgln("AudioDevice::start_request: Can only read from stream {}", request.stream());
+            request.complete(AsyncDeviceRequest::Failure);
+            return;
+        }
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    ScopedSpinLock lock(m_request_lock);
+    ScopeGuard log_guard([&] {
+        dbgln_if(AUDIODEVICE_DEBUG, "<-- AudioDevice::start_request");
+    });
+    dbgln_if(AUDIODEVICE_DEBUG, "AudioDevice::start_request for stream {}", request.stream());
+    if (stream.state != Stream::State::Prepared && stream.state != Stream::State::Running) {
+        dbgln("AudioDevice::start_request: Stream {} not prepared or not in running state", request.stream());
+        request.complete(AsyncDeviceRequest::Failure);
+        return;
+    }
+    stream.current_request = &request;
+    stream.request_buffer_offset = 0;
+    if (stream.type == Audio::StreamType::Playback) {
+        dbgln("AudioDevice::start_request processing buffers -->");
+        while (do_transfer_request_buffer_playback(stream))
+            ;
+        dbgln("<-- AudioDevice::start_request processing buffers");
+    } else {
+        // TODO: Implement
+        VERIFY_NOT_REACHED();
+    }
+}
+
+bool AudioDevice::do_transfer_request_buffer_playback(Stream& stream)
+{
+    // This function copies up to one period of data until the next period boundary
+    VERIFY(stream.buffer_read_offset <= stream.buffer_write_offset);
+    VERIFY(stream.buffer_read_offset % stream.bytes_per_period == 0);
+    size_t available_space = stream.bytes_all_periods - (stream.buffer_write_offset - stream.buffer_read_offset);
+    dbgln("write offset {} read offset {} available {}", stream.buffer_write_offset, stream.buffer_read_offset, available_space);
+    if (available_space == 0)
+        return false;
+    size_t period_offset = stream.buffer_write_offset % stream.bytes_per_period;
+    size_t bytes_to_copy = stream.bytes_per_period - period_offset;
+    VERIFY(bytes_to_copy <= available_space);
+    size_t request_bytes_remaining = stream.current_request->buffer_size() - stream.request_buffer_offset;
+    bool write_to_dma = false;
+    bool period_full = false;
+    if (bytes_to_copy > request_bytes_remaining)
+        bytes_to_copy = request_bytes_remaining;
+    else
+        period_full = true;
+    u8* dest_ptr;
+    if (stream.dma_periods > 0 && stream.buffer_write_offset - stream.buffer_read_offset < stream.bytes_per_period * stream.dma_periods) {
+        // Either we're too close to consuming those periods or we haven't triggered playback,
+        // write directly to the dma buffer
+        dest_ptr = playback_current_dma_period(stream, true) + period_offset;
+        write_to_dma = true;
+        dbgln("AudioDevice::do_transfer_request_buffer_playback writing {} bytes to dma at offset {}", bytes_to_copy, period_offset);
+    } else {
+        dest_ptr = stream.buffer_region->vaddr().as_ptr();
+        dest_ptr += stream.buffer_write_offset % stream.bytes_all_periods;
+        dbgln("AudioDevice::do_transfer_request_buffer_playback writing {} bytes to buffer at offset {}", bytes_to_copy, period_offset);
+    }
+
+    if (!stream.current_request->buffer().read(dest_ptr, bytes_to_copy)) {
+        complete_current_request(stream, AsyncDeviceRequest::RequestResult::MemoryFault);
+        return false;
+    }
+
+    stream.buffer_write_offset += bytes_to_copy;
+    stream.request_buffer_offset += bytes_to_copy;
+
+    if (stream.state == Stream::State::Prepared && period_full && (stream.current.periods_trigger == 0 || stream.buffer_write_offset / stream.bytes_per_period == stream.current.periods_trigger)) {
+        if (!period_full && stream.current.periods_trigger == 0) {
+            dbgln("AudioDevice::do_transfer_request_buffer_playback triggering playback with incomplete period, will cause glitches!");
+            __builtin_memset(dest_ptr + bytes_to_copy, 0, stream.bytes_per_period - bytes_to_copy); // TODO: silence samples
+            // TODO: we should probably stop playback after we run out of data and trigger an xrun instead
+        }
+        transferred_to_dma_buffer(stream, false);
+        dbgln("Triggering playback");
+        stream.state = Stream::State::Running;
+        Processor::current().deferred_call_queue([this, &stream] {
+            trigger_playback(stream);
+        });
+    } else if (period_full && write_to_dma) {
+        // Tell the driver to advance to the next dma buffer
+        transferred_to_dma_buffer(stream, stream.state == Stream::State::Running);
+        dbgln("in state {}", (int)stream.state);
+    }
+    if (stream.request_buffer_offset >= stream.current_request->buffer_size()) {
+        complete_current_request(stream, AsyncDeviceRequest::RequestResult::Success);
+        return false; // This doesn't indicate an error!
+    }
+    return true;
+}
+
+void AudioDevice::finished_playing_period(Stream& stream)
+{
+    // NOTE: this may be called from the interrupt handler!
+    VERIFY(m_request_lock.is_locked());
+    VERIFY(stream.buffer_write_offset >= stream.buffer_read_offset);
+    size_t have_bytes = stream.buffer_write_offset - stream.buffer_read_offset;
+    if (have_bytes > stream.bytes_per_period)
+        have_bytes = stream.bytes_per_period;
+    dbgln("finished_playing_period write: {} read: {} have bytes: {} period: {} bytes", stream.buffer_write_offset, stream.buffer_read_offset, have_bytes, stream.bytes_per_period);
+    size_t period_offset = stream.buffer_read_offset % stream.bytes_all_periods;
+    u8* period_to_read = stream.buffer_region->vaddr().offset(period_offset).as_ptr();
+    stream.buffer_read_offset += stream.bytes_per_period;
+    u8* dma_write_ptr = playback_current_dma_period(stream, true);
+    if (have_bytes > 0)
+        __builtin_memcpy(dma_write_ptr, period_to_read, have_bytes);
+    if (have_bytes < stream.bytes_per_period) {
+        u8* zero_ptr = dma_write_ptr + have_bytes;
+        dbgln("Fill {} bytes at {} with silence", stream.bytes_per_period - have_bytes, VirtualAddress(zero_ptr));
+        __builtin_memset(zero_ptr, 0, stream.bytes_per_period - have_bytes); // TODO: silence samples
+
+        // TODO: schedule xrun after this is played
+        stream.buffer_write_offset = stream.buffer_read_offset;
+        transferred_to_dma_buffer(stream, false); // advances periods written
+        dbgln("AudioDevice::finished_playing_period writer too slow!");
+    } else {
+        dbgln("AudioDevice::finished_playing_period");
+    }
+
+    transferred_to_dma_buffer(stream, true);
+}
+
+void AudioDevice::complete_current_request(Stream& stream, AsyncDeviceRequest::RequestResult result)
+{
+    // NOTE: this may be called from the interrupt handler!
+    VERIFY(stream.current_request);
+    VERIFY(m_request_lock.is_locked());
+
+    // Now schedule reading back the buffer as soon as we leave the irq handler.
+    // This is important so that we can safely write the buffer back,
+    // which could cause page faults.
+    m_work_queue.queue([this, result, &stream]() {
+        ScopedSpinLock lock(m_request_lock);
+        VERIFY(stream.current_request);
+        auto& request = *stream.current_request;
+        stream.current_request = nullptr;
+
+        dbgln_if(AUDIODEVICE_DEBUG, "AudioDevice::complete_current_request stream: {} result: {}", request.stream(), (int)result);
+
+        request.complete(result);
+    });
+}
+
+KResultOr<size_t> AudioDevice::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t buffer_size)
+{
+    unsigned stream = 0; // TODO: get from FileDescription?
+    auto read_request = make_request<AsyncAudioDeviceRequest>(AsyncAudioDeviceRequest::Read, stream, buffer, buffer_size);
+    auto result = read_request->wait();
+    if (result.wait_result().was_interrupted())
+        return EINTR;
+    switch (result.request_result()) {
+    case AsyncDeviceRequest::Failure:
+    case AsyncDeviceRequest::Cancelled:
+        return EIO;
+    case AsyncDeviceRequest::MemoryFault:
+        return EFAULT;
+    default:
+        break;
+    }
+    return read_request->result_size();
+}
+
+KResultOr<size_t> AudioDevice::write(FileDescription&, u64, const UserOrKernelBuffer& buffer, size_t buffer_size)
+{
+    unsigned stream = 0; // TODO: get from FileDescription?
+    auto write_request = make_request<AsyncAudioDeviceRequest>(AsyncAudioDeviceRequest::Write, stream, buffer, buffer_size);
+    auto result = write_request->wait();
+    if (result.wait_result().was_interrupted())
+        return EINTR;
+    switch (result.request_result()) {
+    case AsyncDeviceRequest::Failure:
+    case AsyncDeviceRequest::Cancelled:
+        return EIO;
+    case AsyncDeviceRequest::MemoryFault:
+        return EFAULT;
+    default:
+        break;
+    }
+    return write_request->result_size();
+}
+
+int AudioDevice::handle_json_ioctl(FileDescription&, unsigned request, Audio::IOCtlJsonParams& params)
+{
+    String in;
+    if (params.in_buffer) {
+        in = copy_string_from_user((const char*)params.in_buffer, params.in_buffer_size);
+        if (in.is_null())
+            return -EFAULT;
+    }
+
+    KBufferBuilder builder;
+
+    switch ((Audio::IOCtl)request) {
+    case Audio::IOCtl::GET_PCM_HW_PARAMS: {
+        JsonArraySerializer<KBufferBuilder> json { builder };
+        auto build_params = [&](size_t stream_index, const Stream& stream) {
+            if (stream.supported.is_null())
+                return;
+            auto out_obj = json.add_object();
+            out_obj.add("name", stream.name);
+            out_obj.add("index", stream_index);
+            out_obj.add("type", (unsigned)stream.type);
+            auto supported_obj = out_obj.add_object("supported");
+            {
+                auto array = supported_obj.add_array("formats");
+                for (size_t i = 0; stream.supported.formats[i] != Audio::PCM::SampleFormat::Unknown; i++)
+                    array.add((unsigned)stream.supported.formats[i]);
+            }
+            {
+                auto array = supported_obj.add_array("layouts");
+                for (size_t i = 0; stream.supported.layouts[i] != Audio::PCM::SampleLayout::Unknown; i++)
+                    array.add((unsigned)stream.supported.layouts[i]);
+            }
+            {
+                auto array = supported_obj.add_array("rates");
+                for (size_t i = 0; stream.supported.rates[i] != 0; i++)
+                    array.add((unsigned)stream.supported.rates[i]);
+            }
+            {
+                auto array = supported_obj.add_array("channels");
+                for (size_t i = 0; stream.supported.channels[i] != 0; i++)
+                    array.add((unsigned)stream.supported.channels[i]);
+            }
+            supported_obj.add("periods_min", stream.supported.periods_min);
+            supported_obj.add("periods_max", stream.supported.periods_max);
+            supported_obj.finish();
+            if (!stream.current.is_null()) {
+                auto current_obj = out_obj.add_object("current");
+                current_obj.add("format", (unsigned)stream.current.format);
+                current_obj.add("layout", (unsigned)stream.current.layout);
+                current_obj.add("rate", (unsigned)stream.current.rate);
+                current_obj.add("channels", (unsigned)stream.current.channels);
+                current_obj.add("periods", (unsigned)stream.current.periods);
+                current_obj.add("periods_trigger", (unsigned)stream.current.periods_trigger);
+                current_obj.add("period_ns", stream.current.period_ns);
+                current_obj.finish();
+            }
+        };
+        for (size_t i = 0; i < m_streams.size(); i++)
+            build_params(i, m_streams[i]);
+        json.finish();
+        break;
+    }
+    default:
+        return -EINVAL;
+    }
+
+    auto generated_data = builder.build();
+    if (!generated_data)
+        return -ENOMEM;
+    auto available_buffer_size = params.out_buffer_size;
+    params.out_buffer_size = generated_data->size();
+    if (available_buffer_size > generated_data->size()) {
+        auto user_buffer = UserOrKernelBuffer::for_user_buffer((u8*)params.out_buffer, params.out_buffer_size);
+        if (!user_buffer.has_value())
+            return -EFAULT;
+        if (!user_buffer.value().write(generated_data->data(), params.out_buffer_size))
+            return -EFAULT;
+    }
+    return 0;
+}
+
+bool AudioDevice::setup_pcm_periods_buffers(Stream& stream)
+{
+    stream.bytes_per_period = (size_t)Audio::PCM::time_to_frames(stream.current.period_ns, stream.current.rate)
+        * Audio::PCM::bytes_per_frame(stream.current.format, stream.current.channels);
+    stream.bytes_all_periods = stream.bytes_per_period * stream.current.periods;
+
+    dbgln_if(AUDIODEVICE_DEBUG, "AudioDevice::setup_pcm_periods_buffers bytes_per_period: {} periods: {}", stream.bytes_per_period, stream.current.periods);
+
+    size_t total_bytes = stream.bytes_per_period * stream.current.periods;
+    stream.buffer_region = MM.allocate_kernel_region(page_round_up(total_bytes), "Audio Device Buffer", Region::Access::Read | Region::Access::Write);
+    if (!stream.buffer_region) {
+        dbgln_if(AUDIODEVICE_DEBUG, "AudioDevice::setup_pcm_periods_buffers failed to set up period buffers");
+        return false;
+    }
+    stream.buffer_write_offset = 0;
+    stream.buffer_read_offset = 0;
+    return true;
+}
+
+template<typename EntryType, EntryType LastValue>
+static bool is_in_list(const EntryType* list, EntryType find_value)
+{
+    for (size_t i = 0; list[i] != LastValue; i++) {
+        if (list[i] == find_value)
+            return true;
+    }
+    return false;
+}
+
+bool AudioDevice::is_valid_pcm_configuration(const CurrentPCM& config, const SupportedPCM& supported)
+{
+    if (!is_in_list<Audio::PCM::SampleFormat, Audio::PCM::SampleFormat::Unknown>(supported.formats, config.format))
+        return false;
+    if (!is_in_list<Audio::PCM::SampleLayout, Audio::PCM::SampleLayout::Unknown>(supported.layouts, config.layout))
+        return false;
+    if (!is_in_list<unsigned, 0>(supported.rates, config.rate))
+        return false;
+    if (!is_in_list<unsigned, 0>(supported.channels, config.channels))
+        return false;
+    if (config.periods < supported.periods_min || config.periods > supported.periods_max)
+        return false;
+    if (config.periods_trigger != 0 && (config.periods_trigger < supported.periods_min || config.periods_trigger > supported.periods_max))
+        return false;
+    return true;
+}
+
+bool AudioDevice::set_hw_params(Stream& stream, const Audio::IOCtlSetPCMHwParams& params)
+{
+    auto new_conf = stream.current;
+    if (params.format != Audio::PCM::SampleFormat::Unknown)
+        new_conf.format = params.format;
+    if (params.layout != Audio::PCM::SampleLayout::Unknown)
+        new_conf.layout = params.layout;
+    if (params.rate != 0)
+        new_conf.rate = params.rate;
+    if (params.periods != 0)
+        new_conf.periods = params.periods;
+    
+    new_conf.periods_trigger = params.periods_trigger;
+    if (params.period_ns != 0)
+        new_conf.period_ns = params.period_ns;
+    // Validate that it's within the supported spec
+    if (!is_valid_pcm_configuration(new_conf, stream.supported)) {
+        dbgln_if(AUDIODEVICE_DEBUG, "AudioDevice::set_hw_params cannot set hw params: unsupported value");
+        return false;
+    }
+    // Check if the device can handle the combination
+    if (!can_support_pcm_configuration(stream, new_conf)) {
+        dbgln_if(AUDIODEVICE_DEBUG, "AudioDevice::set_hw_params cannot set hw params: unsupported combination");
+        return false;
+    }
+
+    stream.current = new_conf;
+    return true;
+}
+
+bool AudioDevice::pcm_prepare(Stream& stream)
+{
+    if (!setup_pcm_periods_buffers(stream)) {
+        dbgln("AudioDevice::pcm_prepare: Failed to setup period buffers");
+        return false;
+    }
+    if (!do_initialize(stream)) {
+        dbgln("AudioDevice::pcm_prepare: Failed to initialize stream");
+        return false;
+    }
+    stream.state = Stream::State::Prepared;
+    return true;
+}
+
+int AudioDevice::ioctl(FileDescription& description, unsigned request, FlatPtr arg)
+{
+    Stream* stream = &m_streams[0]; // TODO: get from description (may be null if not selected yet)
+    dbgln_if(AUDIODEVICE_DEBUG, "AudioDevice::ioctl {}", request);
+
+    switch ((Audio::IOCtl)request) {
+    case Audio::IOCtl::GET_PCM_HW_PARAMS: {
+        auto* user_params = (Audio::IOCtlJsonParams*)arg;
+        Audio::IOCtlJsonParams params;
+        if (!copy_from_user(&params, user_params))
+            return -EINVAL;
+        int result = handle_json_ioctl(description, request, params);
+        if (!copy_to_user(user_params, &params))
+            return -EFAULT;
+        return result;
+    }
+    case Audio::IOCtl::SELECT_STREAM: {
+        unsigned stream_index = (unsigned)arg;
+        (void)stream_index; // TODO: save m_streams[stream_index] in description
+        stream->state = Stream::State::Setup;
+        return 0;
+    }
+    case Audio::IOCtl::SET_PCM_HW_PARAMS: {
+        dbgln("SET_PCM_HW_PARAMS?");
+        if (!stream || stream->state != Stream::State::Setup)
+            return -EINVAL;
+        Audio::IOCtlSetPCMHwParams params;
+        if (!copy_from_user(&params, (Audio::IOCtlSetPCMHwParams*)arg))
+            return -EINVAL;
+        dbgln("SET_PCM_HW_PARAMS...");
+        return set_hw_params(*stream, params) ? 0 : -EINVAL;
+    }
+    case Audio::IOCtl::PCM_PREPARE: {
+        dbgln("PCM_PREPARE?");
+        if (!stream || stream->state != Stream::State::Setup)
+            return -EINVAL;
+        dbgln("PCM_PREPARE...");
+        return pcm_prepare(*stream) ? 0 : -EINVAL;
+    }
+    default:
+        return -EINVAL;
+    }
+}
+
+}

--- a/Kernel/Devices/AudioDevice.h
+++ b/Kernel/Devices/AudioDevice.h
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/API/AudioDevice.h>
+#include <Kernel/Devices/AsyncDeviceRequest.h>
+#include <Kernel/Devices/CharacterDevice.h>
+#include <Kernel/WorkQueue.h>
+
+namespace Kernel {
+
+class AudioDevice;
+
+class AsyncAudioDeviceRequest : public AsyncDeviceRequest {
+public:
+    enum RequestType {
+        Read,
+        Write
+    };
+    AsyncAudioDeviceRequest(Device& audio_device, RequestType request_type, unsigned stream, const UserOrKernelBuffer& buffer, size_t buffer_size);
+
+    RequestType request_type() const { return m_request_type; }
+    unsigned stream() const { return m_stream; }
+    UserOrKernelBuffer& buffer() { return m_buffer; }
+    const UserOrKernelBuffer& buffer() const { return m_buffer; }
+    size_t buffer_size() const { return m_buffer_size; }
+    size_t result_size() const { return m_result_size; }
+
+    virtual void start() override;
+    virtual const char* name() const override
+    {
+        switch (m_request_type) {
+        case Read:
+            return "AudioDeviceRequest (read)";
+        case Write:
+            return "AudioDeviceRequest (write)";
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+private:
+    AudioDevice& m_audio_device;
+    const RequestType m_request_type;
+    const unsigned m_stream;
+    UserOrKernelBuffer m_buffer;
+    const size_t m_buffer_size;
+    size_t m_result_size { 0 };
+};
+
+class AudioDevice : public CharacterDevice {
+public:
+    // ^CharacterDevice
+    virtual bool can_read(const FileDescription&, size_t) const override { return false; }
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
+    virtual bool can_write(const FileDescription&, size_t) const override { return true; }
+
+    virtual int ioctl(FileDescription&, unsigned, FlatPtr) override;
+
+    void start_request(AsyncAudioDeviceRequest&);
+
+protected:
+    AudioDevice(unsigned major, unsigned minor)
+        : CharacterDevice(major, minor)
+        , m_work_queue("AudioDevice")
+    {
+    }
+
+    struct SupportedPCM {
+        const Audio::PCM::SampleFormat* formats { nullptr };
+        const Audio::PCM::SampleLayout* layouts { nullptr };
+        const unsigned* rates { nullptr };
+        const unsigned* channels { nullptr };
+        unsigned periods_min { 0 };
+        unsigned periods_max { 0 };
+
+        bool is_null() const
+        {
+            return !formats || !layouts || !rates || !channels || periods_min == 0 || periods_max == 0;
+        }
+    };
+    struct CurrentPCM {
+        Audio::PCM::SampleFormat format { Audio::PCM::SampleFormat::Unknown };
+        Audio::PCM::SampleLayout layout { Audio::PCM::SampleLayout::Unknown };
+        unsigned rate { 0 };
+        unsigned channels { 0 };
+        unsigned periods { 0 };
+        unsigned periods_trigger { 0 };
+        u64 period_ns { 0 };
+
+        bool is_null() const
+        {
+            return format == Audio::PCM::SampleFormat::Unknown || layout == Audio::PCM::SampleLayout::Unknown
+                || rate == 0 || channels == 0 || periods == 0 || periods_trigger == 0 || period_ns == 0;
+        }
+    };
+    struct Stream {
+        enum class State {
+            Uninitialized = 0,
+            Setup,
+            Prepared,
+            Running,
+        };
+        const char* name { nullptr };
+        void* private_data { nullptr };
+        Audio::StreamType type { Audio::StreamType::Unknown };
+        SupportedPCM supported;
+        CurrentPCM current;
+        State state { State::Uninitialized };
+        size_t dma_periods { 0 };
+        OwnPtr<Region> dma_region { };
+
+        size_t bytes_per_period { 0 };
+        size_t bytes_all_periods { 0 };
+        OwnPtr<Region> buffer_region { };
+        size_t buffer_write_offset { 0 }; // points to where the next write will write to
+        size_t buffer_read_offset { 0 }; // points to where the next read will start
+
+        AsyncAudioDeviceRequest* current_request { nullptr };
+        size_t request_buffer_offset { 0 };
+    };
+
+    Stream& stream_for_request(AsyncAudioDeviceRequest& request)
+    {
+        return m_streams[request.stream()];
+    }
+
+    virtual bool can_support_pcm_configuration(Stream&, const CurrentPCM&) { return false; }
+
+    void complete_current_request(Stream&, AsyncDeviceRequest::RequestResult);
+    void finished_playing_period(Stream&);
+
+    virtual bool do_initialize(Stream&) = 0;
+    virtual void trigger_playback(Stream&) = 0;
+    virtual void transferred_to_dma_buffer(Stream&, bool) = 0;
+    virtual u8* playback_current_dma_period(Stream&, bool) = 0;
+
+    SpinLock<u8> m_request_lock;
+    Vector<Stream, 1> m_streams;
+    OwnPtr<Region> m_periods;
+    WorkQueue m_work_queue;
+
+private:
+    int handle_json_ioctl(FileDescription&, unsigned, Audio::IOCtlJsonParams&);
+    bool set_hw_params(Stream&, const Audio::IOCtlSetPCMHwParams&);
+    bool pcm_prepare(Stream&);
+    static bool is_valid_pcm_configuration(const CurrentPCM&, const SupportedPCM&);
+    bool setup_pcm_periods_buffers(Stream&);
+    bool do_transfer_request_buffer_playback(Stream&);
+};
+
+}

--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -25,12 +25,14 @@
  */
 
 #include <AK/Memory.h>
+#include <AK/ScopeGuard.h>
 #include <AK/Singleton.h>
 #include <AK/StringView.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Devices/SB16.h>
 #include <Kernel/IO.h>
 #include <Kernel/Thread.h>
+#include <Kernel/UserOrKernelBuffer.h>
 #include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/MemoryManager.h>
 
@@ -71,17 +73,44 @@ void SB16::set_sample_rate(uint16_t hz)
     dsp_write(0x41); // output
     dsp_write((u8)(hz >> 8));
     dsp_write((u8)hz);
-    dsp_write(0x42); // input
-    dsp_write((u8)(hz >> 8));
-    dsp_write((u8)hz);
 }
 
 static AK::Singleton<SB16> s_the;
+static const Audio::PCM::SampleFormat s_supported_formats[] = { Audio::PCM::SampleFormat::S16_LE, Audio::PCM::SampleFormat::U16_LE, Audio::PCM::SampleFormat::Unknown };
+static const Audio::PCM::SampleLayout s_supported_layouts[] = { Audio::PCM::SampleLayout::Interleaved, Audio::PCM::SampleLayout::Unknown };
+static const unsigned s_supported_rates[] = { 44100, 48000, 0 };
+static const unsigned s_supported_channels[] = { 1, 2 };
 
 UNMAP_AFTER_INIT SB16::SB16()
     : IRQHandler(SB16_DEFAULT_IRQ)
-    , CharacterDevice(42, 42) // ### ?
+    , AudioDevice(42, 42) // ### ?
 {
+    m_stream_private.resize(1);
+    m_streams.append(Stream {
+        .name = "speaker",
+        .private_data = (void*)&m_stream_private[0],
+        .type = Audio::StreamType::Playback,
+        .supported = {
+            .formats = s_supported_formats,
+            .layouts = s_supported_layouts,
+            .rates = s_supported_rates,
+            .channels = s_supported_channels,
+            .periods_min = 2,
+            .periods_max = 8,
+        },
+        .current = {
+            .format = Audio::PCM::SampleFormat::S16_LE,
+            .layout = Audio::PCM::SampleLayout::Interleaved,
+            .rate = 44100,
+            .channels = 2,
+            .periods = 3,
+            .periods_trigger = 2,
+        },
+        .dma_periods = 2,
+    });
+
+    m_streams[0].current.period_ns = calculate_period_time(m_streams[0].current);
+
     initialize();
 }
 
@@ -102,6 +131,16 @@ UNMAP_AFTER_INIT void SB16::detect()
     SB16::create();
 }
 
+u64 SB16::calculate_period_time(const CurrentPCM& config)
+{
+    // We set up a DMA transfer for 2 periods. The size of that is limited.
+    // calculate how much time one of these periods equals to
+    constexpr size_t maximum_bytes = 65536;
+    size_t maximum_frames = maximum_bytes / Audio::PCM::bytes_per_frame(config.format, config.channels);
+    maximum_frames /= 2;
+    return Audio::PCM::frames_to_time(maximum_frames, config.rate);
+}
+
 UNMAP_AFTER_INIT void SB16::create()
 {
     s_the.ensure_instance();
@@ -112,13 +151,25 @@ SB16& SB16::the()
     return *s_the;
 }
 
+void SB16::write_mixer_reg(u8 index, u8 value)
+{
+    IO::out8(m_port + 4, index);
+    IO::out8(m_port + 5, value);
+}
+
+u8 SB16::read_mixer_reg(u8 index) const
+{
+    IO::out8(m_port + 4, index);
+    return IO::in8(m_port + 5);
+}
+
 UNMAP_AFTER_INIT void SB16::initialize()
 {
     disable_irq();
 
-    IO::out8(0x226, 1);
+    IO::out8(m_port + 6, 1);
     IO::delay(32);
-    IO::out8(0x226, 0);
+    IO::out8(m_port + 6, 0);
 
     auto data = dsp_read();
     if (data != 0xaa) {
@@ -132,7 +183,8 @@ UNMAP_AFTER_INIT void SB16::initialize()
     auto vmin = dsp_read();
 
     dmesgln("SB16: Found version {}.{}", m_major_version, vmin);
-    set_irq_register(SB16_DEFAULT_IRQ);
+    set_irq_line(SB16_DEFAULT_IRQ);
+    set_dma_channels();
     dmesgln("SB16: IRQ {}", get_irq_line());
 }
 
@@ -141,7 +193,7 @@ void SB16::set_irq_register(u8 irq_number)
     u8 bitmask;
     switch (irq_number) {
     case 2:
-        bitmask = 0;
+        bitmask = 0b1;
         break;
     case 5:
         bitmask = 0b10;
@@ -155,14 +207,12 @@ void SB16::set_irq_register(u8 irq_number)
     default:
         VERIFY_NOT_REACHED();
     }
-    IO::out8(0x224, 0x80);
-    IO::out8(0x225, bitmask);
+    write_mixer_reg(0x80, bitmask);
 }
 
 u8 SB16::get_irq_line()
 {
-    IO::out8(0x224, 0x80);
-    u8 bitmask = IO::in8(0x225);
+    u8 bitmask = read_mixer_reg(0x80);
     switch (bitmask) {
     case 0:
         return 2;
@@ -184,113 +234,179 @@ void SB16::set_irq_line(u8 irq_number)
     change_irq_number(irq_number);
 }
 
-bool SB16::can_read(const FileDescription&, size_t) const
+void SB16::set_dma_channels()
 {
-    return false;
+    write_mixer_reg(0x81, (1 << 5) | (1 << 1)); // 16 bit dma | 8 bit dma
 }
 
-KResultOr<size_t> SB16::read(FileDescription&, u64, UserOrKernelBuffer&, size_t)
+bool SB16::can_support_pcm_configuration(Stream&, const CurrentPCM& config)
 {
-    return 0;
+    // TODO: Validate overflows...
+    size_t bytes_per_second = Audio::PCM::bytes_per_frame(config.format, config.channels) * config.rate;
+    dbgln("SB16 bytes per second: {}", bytes_per_second);
+    return true;
 }
 
-void SB16::dma_start(uint32_t length)
+bool SB16::allocate_dma_region(Stream& stream)
 {
-    const auto addr = m_dma_region->physical_page(0)->paddr().get();
-    const u8 channel = 5; // 16-bit samples use DMA channel 5 (on the master DMA controller)
-    const u8 mode = 0x48;
+    VERIFY(stream.dma_periods > 0);
+    VERIFY(stream.bytes_per_period > 0);
+
+    stream.dma_region = nullptr; // free it first
+    size_t exact_size = stream.dma_periods * stream.bytes_per_period;
+    size_t size = page_round_up(exact_size);
+    auto access = stream.type == Audio::StreamType::Playback ? Region::Access::Write : Region::Access::Read;
+    if (size > PAGE_SIZE) {
+        // Must not cross a 64k boundary and limited to 64k
+        stream.dma_region = MM.allocate_contiguous_kernel_region(size, "Audio DMA buffer", access, 64 * KiB);
+        if (stream.dma_region) {
+            auto paddr_first = stream.dma_region->physical_page(0)->paddr().get();
+            VERIFY(!(paddr_first & 0xffff));
+            auto paddr_last = stream.dma_region->physical_page(stream.dma_region->size() / PAGE_SIZE - 1)->paddr().get();
+            VERIFY((paddr_first & ~0xffff) == (paddr_last & ~0xffff)); // must not cross a 64k boundary
+        }
+    } else {
+        auto page = MM.allocate_supervisor_physical_page();
+        if (!page)
+            return false;
+
+        auto vmobject = AnonymousVMObject::create_with_physical_page(*page);
+        stream.dma_region = MM.allocate_kernel_region_with_vmobject(*vmobject, PAGE_SIZE, "Audio DMA buffer", access);
+    }
+    dbgln("SB16: Mapped DMA region: {} - {} ({} bytes) split into {} periods with {} bytes each", stream.dma_region->vaddr(), stream.dma_region->vaddr().offset(exact_size), exact_size, stream.dma_periods, stream.bytes_per_period);
+    return stream.dma_region;
+}
+
+bool SB16::do_initialize(Stream& stream)
+{
+    if (m_active_stream)
+        return false;
+    if (!allocate_dma_region(stream))
+        return false;
+
+    m_active_stream = &stream;
+    m_is16bit = Audio::PCM::bytes_per_sample(stream.current.format) == 2;
+    return true;
+}
+
+void SB16::trigger_playback(Stream& stream)
+{
+    dbgln("SB16::trigger_playback");
+    VERIFY(m_active_stream);
+
+    u8 mode = 0;
+    if (Audio::PCM::is_signed(stream.current.format))
+        mode |= (u8)SampleFormat::Signed;
+    if (stream.current.channels == 2)
+        mode |= (u8)SampleFormat::Stereo;
+
+    // Setup the entire dma buffer
+    setup_dma(stream, stream.bytes_per_period * stream.dma_periods);
+    set_sample_rate(stream.current.rate);
+
+    // Transfer only one period at a time
+    dsp_transfer_block(stream, stream.bytes_per_period);
+
+    enable_irq();
+}
+
+void SB16::transferred_to_dma_buffer(Stream& stream, bool is_playing)
+{
+    auto& priv = stream_private(stream);
+    auto& period_counter = is_playing ? priv.periods_read : priv.periods_written;
+    period_counter++;
+    dbgln("SB16::transferred_to_dma_buffer {}: periods read {} written {}", is_playing ? "playing" : "recording", priv.periods_read, priv.periods_written);
+    if (is_playing)
+        VERIFY(priv.periods_written - priv.periods_read <= stream.dma_periods);
+}
+
+PhysicalAddress SB16::playback_current_dma_period_paddr(Stream& stream, bool is_write)
+{
+    auto& priv = stream_private(stream);
+    size_t offset = ((is_write ? priv.periods_written : priv.periods_read) % stream.dma_periods) * stream.bytes_per_period;
+    dbgln("Physical DMA address offset: {} ({})", offset, is_write ? "write" : "read");
+    return stream.dma_region->physical_page(0)->paddr().offset(offset);
+}
+
+u8* SB16::playback_current_dma_period(Stream& stream, bool is_write)
+{
+    auto& priv = stream_private(stream);
+    size_t offset = ((is_write ? priv.periods_written : priv.periods_read) % stream.dma_periods) * stream.bytes_per_period;
+    dbgln("DMA mapped address offset: {} ({}) => {}", offset, is_write ? "write" : "read", stream.dma_region->vaddr().offset(offset));
+    return stream.dma_region->vaddr().as_ptr() + offset;
+}
+
+void SB16::setup_dma(Stream& stream, u32 length)
+{
+    const auto addr = playback_current_dma_period_paddr(stream, false).get();
+    dbgln("Setup DMA read {} ({} bytes)", VirtualAddress(playback_current_dma_period(stream, false)), length);
+    const u8 channel = m_is16bit ? 5 : 1; // 16-bit samples use DMA channel 5 (on the master DMA controller)
 
     // Disable the DMA channel
-    IO::out8(0xd4, 4 + (channel % 4));
+    IO::out8(m_is16bit ? 0xd4 : 0x0a, 4 + (channel % 4));
 
     // Clear the byte pointer flip-flop
-    IO::out8(0xd8, 0);
+    IO::out8(m_is16bit ? 0xd8 : 0x0c, 0);
 
     // Write the DMA mode for the transfer
-    IO::out8(0xd6, (channel % 4) | mode);
-
-    // Write the offset of the buffer
-    u16 offset = (addr / 2) % 65536;
-    IO::out8(0xc4, (u8)offset);
-    IO::out8(0xc4, (u8)(offset >> 8));
+    IO::out8(m_is16bit ? 0xd6 : 0x0b, (channel % 4) | 0x58);
 
     // Write the transfer length
-    IO::out8(0xc6, (u8)(length - 1));
-    IO::out8(0xc6, (u8)((length - 1) >> 8));
+    auto transfer_length = (m_is16bit ? length / 2 : length) - 1;
+    IO::out8(m_is16bit ? 0xc6 : 0x03, (u8)transfer_length);
+    IO::out8(m_is16bit ? 0xc6 : 0x03, (u8)(transfer_length >> 8));
 
-    // Write the buffer
-    IO::out8(0x8b, addr >> 16);
+    // Write the buffer addresss
+    auto offset = (m_is16bit ? addr / 2 : addr) % 65536;
+    IO::out8(m_is16bit ? 0x8b : 0x83, addr >> 16);
+    IO::out8(m_is16bit ? 0xc4 : 0x02, (u8)offset);
+    IO::out8(m_is16bit ? 0xc4 : 0x02, (u8)(offset >> 8));
 
     // Enable the DMA channel
-    IO::out8(0xd4, (channel % 4));
+    IO::out8(m_is16bit ? 0xd4 : 0x0a, (channel % 4));
+}
+
+void SB16::dsp_transfer_block(Stream& stream, u32 length)
+{
+    u8 mode = 0;
+    if (Audio::PCM::is_signed(stream.current.format))
+        mode |= (u8)SampleFormat::Signed;
+    if (stream.current.channels == 2)
+        mode |= (u8)SampleFormat::Stereo;
+
+    auto sample_count = (m_is16bit ? length / 2 : length) - 1;
+    dbgln("SB16: dsp_transfer_block {} samples", sample_count);
+    dsp_write(m_is16bit ? 0xb6 : 0xc6);
+    dsp_write(mode);
+    dsp_write((u8)sample_count);
+    dsp_write((u8)(sample_count >> 8));
 }
 
 void SB16::handle_irq(const RegisterState&)
 {
-    // Stop sound output ready for the next block.
-    dsp_write(0xd5);
-
-    IO::in8(DSP_STATUS); // 8 bit interrupt
-    if (m_major_version >= 4)
-        IO::in8(DSP_R_ACK); // 16 bit interrupt
-
-    m_irq_queue.wake_all();
-}
-
-void SB16::wait_for_irq()
-{
-    m_irq_queue.wait_forever("SB16");
-    disable_irq();
-}
-
-KResultOr<size_t> SB16::write(FileDescription&, u64, const UserOrKernelBuffer& data, size_t length)
-{
-    if (!m_dma_region) {
-        auto page = MM.allocate_supervisor_physical_page();
-        if (!page)
-            return ENOMEM;
-        auto vmobject = AnonymousVMObject::create_with_physical_page(*page);
-        m_dma_region = MM.allocate_kernel_region_with_vmobject(*vmobject, PAGE_SIZE, "SB16 DMA buffer", Region::Access::Write);
-        if (!m_dma_region)
-            return ENOMEM;
+    u8 irq_status = read_mixer_reg(0x82);
+    if (!(irq_status & 3)) {
+        dbgln("SB16: ignore irq");
+        return;
     }
 
-    dbgln_if(SB16_DEBUG, "SB16: Writing buffer of {} bytes", length);
-
-    VERIFY(length <= PAGE_SIZE);
-    const int BLOCK_SIZE = 32 * 1024;
-    if (length > BLOCK_SIZE) {
-        return ENOSPC;
+    ScopedSpinLock lock(m_request_lock);
+    dbgln("SB16::handle_irq -->");
+    ScopeGuard log_guard([&] {
+        dbgln("<--SB16::handle_irq");
+    });
+    if (m_active_stream) {
+        finished_playing_period(*m_active_stream);
+        dsp_transfer_block(*m_active_stream, m_active_stream->bytes_per_period);
+    } else {
+        dsp_write(m_is16bit ? 0xd5 : 0xd0);
     }
 
-    u8 mode = (u8)SampleFormat::Signed | (u8)SampleFormat::Stereo;
-
-    const int sample_rate = 44100;
-    set_sample_rate(sample_rate);
-    if (!data.read(m_dma_region->vaddr().as_ptr(), length))
-        return EFAULT;
-    dma_start(length);
-
-    // 16-bit single-cycle output.
-    // FIXME: Implement auto-initialized output.
-    u8 command = 0xb0;
-
-    u16 sample_count = length / sizeof(i16);
-    if (mode & (u8)SampleFormat::Stereo)
-        sample_count /= 2;
-
-    sample_count -= 1;
-
-    cli();
-    enable_irq();
-
-    dsp_write(command);
-    dsp_write(mode);
-    dsp_write((u8)sample_count);
-    dsp_write((u8)(sample_count >> 8));
-
-    wait_for_irq();
-    return length;
+    // acknowledge irq
+    if (irq_status & 1)
+        IO::in8(m_port + 0xe); // ack 8 bit
+    if (irq_status & 2)
+        IO::in8(m_port + 0xf); // ack 16 bit
 }
 
 }

--- a/Meta/CMake/all_the_debug_macros.cmake
+++ b/Meta/CMake/all_the_debug_macros.cmake
@@ -173,6 +173,7 @@ set(SYSCALL_1_DEBUG ON)
 set(RSA_PARSE_DEBUG ON)
 set(LINE_EDITOR_DEBUG ON)
 set(LANGUAGE_SERVER_DEBUG ON)
+set(AUDIODEVICE_DEBUG ON)
 
 # False positive: DEBUG is a flag but it works differently.
 # set(DEBUG ON)

--- a/Userland/Libraries/LibAudio/CMakeLists.txt
+++ b/Userland/Libraries/LibAudio/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     Buffer.cpp
     ClientConnection.cpp
+    Device.cpp
     Loader.cpp
     WavLoader.cpp
     WavWriter.cpp

--- a/Userland/Libraries/LibAudio/Device.cpp
+++ b/Userland/Libraries/LibAudio/Device.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Debug.h>
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <AK/JsonParser.h>
+#include <LibAudio/Device.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+namespace Audio {
+
+void Device::Stream::parse(unsigned stream_index, const JsonObject& stream_obj)
+{
+    m_index = stream_index;
+
+    m_name = stream_obj.get("name").to_string();
+    m_type = (StreamType)stream_obj.get("type").to_u32();
+
+    auto& supported_obj = stream_obj.get_ptr("supported")->as_object();
+    auto& supported_formats = supported_obj.get_ptr("formats")->as_array();
+    m_supported_formats.clear_with_capacity();
+    m_supported_formats.ensure_capacity(supported_formats.size());
+    supported_formats.for_each([&](auto& value) {
+        m_supported_formats.append((PCM::SampleFormat)value.to_u32());
+    });
+    auto& supported_layouts = supported_obj.get_ptr("layouts")->as_array();
+    m_supported_layouts.clear_with_capacity();
+    m_supported_layouts.ensure_capacity(supported_layouts.size());
+    supported_layouts.for_each([&](auto& value) {
+        m_supported_layouts.append((PCM::SampleLayout)value.to_u32());
+    });
+    auto& supported_rates = supported_obj.get_ptr("rates")->as_array();
+    m_supported_rates.clear_with_capacity();
+    m_supported_rates.ensure_capacity(supported_rates.size());
+    supported_rates.for_each([&](auto& value) {
+        m_supported_rates.append(value.to_u32());
+    });
+    auto& supported_channels = supported_obj.get_ptr("channels")->as_array();
+    m_supported_channels.clear_with_capacity();
+    m_supported_channels.ensure_capacity(supported_channels.size());
+    supported_channels.for_each([&](auto& value) {
+        m_supported_channels.append(value.to_u32());
+    });
+    if (auto* current_value = stream_obj.get_ptr("current")) {
+        auto& current_obj = current_value->as_object();
+        m_current_params.format = (PCM::SampleFormat)current_obj.get("format").to_u32();
+        m_current_params.layout = (PCM::SampleLayout)current_obj.get("layout").to_u32();
+        m_current_params.rate = current_obj.get("rate").to_u32();
+        m_current_params.channels = current_obj.get("channels").to_u32();
+        m_current_params.periods = current_obj.get("periods").to_u32();
+        m_current_params.periods_trigger = current_obj.get("periods_triggr").to_u32();
+        m_current_params.period_ns = current_obj.get("period_ns").to_number<u64>();
+    } else {
+        m_current_params = {};
+    }
+}
+
+bool Device::Stream::set_format(PCM::SampleFormat format)
+{
+    m_current_params.format = format;
+    return m_device.set_pcm_hw_params();
+}
+
+bool Device::Stream::set_layout(PCM::SampleLayout layout)
+{
+    m_current_params.layout = layout;
+    return m_device.set_pcm_hw_params();
+}
+
+bool Device::Stream::set_rate(unsigned rate)
+{
+    m_current_params.rate = rate;
+    return m_device.set_pcm_hw_params();
+}
+
+bool Device::Stream::set_channels(unsigned channels)
+{
+    m_current_params.channels = channels;
+    return m_device.set_pcm_hw_params();
+}
+
+Device::Device(const StringView& filename, Object* parent)
+    : IODevice(parent)
+    , m_filename(filename)
+{
+}
+
+auto Device::find_stream(unsigned stream_index) -> Stream*
+{
+    for (auto& stream : m_streams) {
+        if (stream.index() == stream_index)
+            return &stream;
+    }
+    return nullptr;
+}
+
+bool Device::open(IODevice::OpenMode mode)
+{
+    return open_impl(mode, 0666);
+}
+
+bool Device::close()
+{
+    auto result = IODevice::close();
+    m_state = State::Closed;
+    m_selected_stream = 0;
+    return result;
+}
+
+int Device::json_ioctl(Audio::IOCtl request, const StringView& in, String* out)
+{
+    Audio::IOCtlJsonParams params { };
+    Vector<char, 1024> buffer;
+    if (out)
+        buffer.resize(1024);
+
+    int result = 0;
+    int attempts = 0;
+    for (;;) {
+        if (!in.is_null()) {
+            params.in_buffer = in.characters_without_null_termination();
+            params.in_buffer_size = in.length();
+        }
+        if (out) {
+            params.out_buffer = &buffer[0];
+            params.out_buffer_size = buffer.size();
+        }
+
+        result = audio_ioctl(fd(), request, params);
+        if (!out || result >= 0 || result != -EINVAL)
+            break;
+        if (++attempts >= 2) {
+            dbgln("Giving up on sending audio ioctl: {}", (unsigned)request);
+            return -EINVAL;
+        }
+        // See if we should grow the buffer and retry
+        if (params.out_buffer_size > buffer.size())
+            buffer.resize(params.out_buffer_size);
+    }
+    if (out && result >= 0) {
+        if (params.out_buffer_size > 0) {
+            *out = String((const char*)params.out_buffer, params.out_buffer_size);
+        } else {
+            *out = String::empty();
+        }
+    }
+    return result;
+}
+
+bool Device::open_impl(IODevice::OpenMode mode, mode_t permissions)
+{
+    if (m_state >= Device::State::Open && !close())
+        return false;
+
+    VERIFY(!m_filename.is_null());
+    int flags = 0;
+    if ((mode & IODevice::ReadWrite) == IODevice::ReadWrite) {
+        flags |= O_RDWR | O_CREAT | O_APPEND;
+    } else if (mode & IODevice::ReadOnly) {
+        flags |= O_RDONLY;
+    } else if (mode & IODevice::WriteOnly) {
+        flags |= O_WRONLY | O_CREAT | O_APPEND;
+    }
+    if (mode & IODevice::Truncate)
+        flags |= O_TRUNC;
+    int fd = ::open(m_filename.characters(), flags, permissions);
+    if (fd < 0) {
+        set_error(errno);
+        return false;
+    }
+
+    set_fd(fd);
+    set_mode(mode);
+
+    m_state = Device::State::Open;
+    if (!get_pcm_hw_params()) {
+        close();
+        return false;
+    }
+    return true;
+}
+
+bool Device::get_pcm_hw_params()
+{
+    if (m_state < Device::State::Open)
+        return false;
+
+    String hw_params;
+    if (json_ioctl(Audio::IOCtl::GET_PCM_HW_PARAMS, nullptr, &hw_params) < 0) {
+        dbgln("GET_PCM_HW_PARAMS failed");
+        return false;
+    }
+    dbgln("GET_PCM_HW_PARAMS returned: '{}'", hw_params);
+    auto json = JsonValue::from_string(hw_params);
+    VERIFY(json.has_value());
+    const JsonArray& streams_array = json.value().as_array();
+
+    // TODO: remove no longer existing streams
+    streams_array.for_each([&](auto& value) {
+        const auto& stream_obj = value.as_object();
+        unsigned stream_index = stream_obj.get("index").to_u32();
+        if (auto* existing_stream = find_stream(stream_index)) {
+            existing_stream->parse(stream_index, stream_obj);
+        } else {
+            Stream new_stream(*this);
+            new_stream.parse(stream_index, stream_obj);
+            m_streams.append(move(new_stream));
+        }
+    });
+    return true;
+}
+
+bool Device::set_pcm_hw_params()
+{
+    if (m_state < Device::State::Selected)
+        return false;
+
+    auto* stream = find_stream(m_selected_stream);
+    if (!stream)
+        return false;
+
+    if (audio_ioctl(fd(), Audio::IOCtl::SET_PCM_HW_PARAMS, stream->m_current_params) < 0) {
+        dbgln("Failed to set hw params");
+        // NOTE: We don't want to call get_pcm_hw_params here because that
+        // would wipe out all current params. In this case the caller should
+        // either revert to the setting used before, or pick another one.
+        m_state = Device::State::Selected;
+        return false;
+    }
+
+    // Now get the latest values
+    bool result = get_pcm_hw_params();
+    stream = find_stream(m_selected_stream);
+    if (stream) {
+        // the stream is still there
+        m_state = stream->is_setup() ? Device::State::Setup : Device::State::Selected;
+    } else {
+        // The stream is gone now...
+        m_state = Device::State::Open;
+        m_selected_stream = 0;
+    }
+    return result;
+}
+
+bool Device::pcm_prepare()
+{
+    if (m_state != Device::State::Setup)
+        return false;
+    if (audio_ioctl(fd(), Audio::IOCtl::PCM_PREPARE, 0) < 0) {
+        dbgln("PCM_PREPARE failed");
+        return false;
+    }
+    m_state = Device::State::Prepared;
+    return true;
+}
+
+bool Device::select_stream(const Stream& stream)
+{
+    if (m_state != Device::State::Open)
+        return false;
+
+    if (audio_ioctl(fd(), Audio::IOCtl::SELECT_STREAM, stream.index()) < 0) {
+        dbgln("SELECT_STREAM failed");
+        return false;
+    }
+    m_state = stream.is_setup() ? Device::State::Setup : Device::State::Selected;
+    m_selected_stream = stream.index();
+    return true;
+}
+
+bool Device::select_stream(unsigned stream_index)
+{
+    auto* stream = find_stream(stream_index);
+    if (!stream)
+        return false;
+    return select_stream(*stream);
+}
+
+}

--- a/Userland/Libraries/LibAudio/Device.h
+++ b/Userland/Libraries/LibAudio/Device.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/API/AudioDevice.h>
+#include <LibCore/IODevice.h>
+
+class JsonObject;
+
+namespace Audio {
+
+class Device : public Core::IODevice {
+    C_OBJECT(Device)
+public:
+    enum class State {
+        Closed = 0,
+        Open,
+        Selected,
+        Setup,
+        Prepared,
+        Running,
+        XRun
+    };
+
+    class Stream {
+        friend class Device;
+    public:
+        unsigned index() const { return m_index; }
+        const String& name() const { return m_name; }
+        StreamType type() const { return m_type; }
+        const Vector<PCM::SampleFormat>& supported_formats() const { return m_supported_formats; }
+        const Vector<PCM::SampleLayout>& supported_layouts() const { return m_supported_layouts; }
+        const Vector<unsigned>& supported_rates() const { return m_supported_rates; }
+        const Vector<unsigned>& supported_channels() const { return m_supported_channels; }
+
+        bool is_setup() const
+        {
+            return !m_current_params.is_null();
+        }
+
+        PCM::SampleFormat format() const { return m_current_params.format; }
+        bool set_format(PCM::SampleFormat);
+        PCM::SampleLayout layout() const { return m_current_params.layout; }
+        bool set_layout(PCM::SampleLayout);
+        unsigned rate() const { return m_current_params.rate; }
+        bool set_rate(unsigned);
+        unsigned channels() const { return m_current_params.channels; }
+        bool set_channels(unsigned);
+
+    private:
+        Stream(Device& device)
+            : m_device(device)
+        {
+        }
+        void parse(unsigned, const JsonObject&);
+
+        Device& m_device;
+        unsigned m_index { 0 };
+        String m_name;
+        StreamType m_type { StreamType::Unknown };
+        Vector<PCM::SampleFormat> m_supported_formats;
+        Vector<PCM::SampleLayout> m_supported_layouts;
+        Vector<unsigned> m_supported_rates;
+        Vector<unsigned> m_supported_channels;
+
+        Audio::IOCtlSetPCMHwParams m_current_params;
+    };
+
+    virtual bool open(IODevice::OpenMode) override;
+    virtual bool close() override;
+
+    bool select_stream(const Stream&);
+    bool select_stream(unsigned);
+    bool get_pcm_hw_params();
+    bool set_pcm_hw_params();
+    bool pcm_prepare();
+
+    template<typename F>
+    IterationDecision for_each_stream(F f) const
+    {
+        for (const auto& stream : m_streams) {
+            IterationDecision decision = f(stream);
+            if (decision != IterationDecision::Continue)
+                return decision;
+        }
+        return IterationDecision::Continue;
+    }
+
+private:
+    Device(Object* parent = nullptr)
+        : IODevice(parent)
+    {
+    }
+    explicit Device(const StringView&, Object* parent = nullptr);
+
+    bool open_impl(IODevice::OpenMode, mode_t);
+    int json_ioctl(Audio::IOCtl, const StringView&, String*);
+    Stream* find_stream(unsigned);
+
+    String m_filename;
+    State m_state { State::Closed };
+    unsigned m_selected_stream { 0 };
+    Vector<Stream, 1> m_streams;
+};
+
+}

--- a/Userland/Services/AudioServer/CMakeLists.txt
+++ b/Userland/Services/AudioServer/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
 )
 
 serenity_bin(AudioServer)
-target_link_libraries(AudioServer LibCore LibThread LibIPC)
+target_link_libraries(AudioServer LibAudio LibCore LibThread LibIPC)

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -35,6 +35,7 @@
 #include <AK/RefCounted.h>
 #include <AK/WeakPtr.h>
 #include <LibAudio/Buffer.h>
+#include <LibAudio/Device.h>
 #include <LibCore/File.h>
 #include <LibThread/Lock.h>
 #include <LibThread/Thread.h>
@@ -130,10 +131,11 @@ private:
     pthread_mutex_t m_pending_mutex;
     pthread_cond_t m_pending_cond;
 
-    RefPtr<Core::File> m_device;
+    RefPtr<Audio::Device> m_device;
 
     NonnullRefPtr<LibThread::Thread> m_sound_thread;
 
+    bool m_running { false };
     bool m_muted { false };
     int m_main_volume { 100 };
 


### PR DESCRIPTION
_This is still very much work in progress... Based on #4320_

- [ ] Figure out why `SB16` locks up the system as soon as playback is triggered

This implements a framework for negotiating audio features and various
settings between LibAudio and kernel drivers. By implementing most
features in the new abstract AudioDevice, implementing new sound card
drivers is greatly simplified while still maintaining compatibility
with LibAudio.

Also add an Audio::Device class to LibAudio that will take care
of the interaction with all drivers that are based on the AudioDevice
class.

Last but not least, update AudioServer to use the Audio::Device class.