### PR TITLE
LibC+Kernel: Implement SA_SIGINFO for signal actions

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -414,11 +414,15 @@ void signal_trampoline_dummy()
         "push ebp\n"
         "mov ebp, esp\n"
         "push eax\n"          // we have to store eax 'cause it might be the return value from a syscall
-        "sub esp, 4\n"        // align the stack to 16 bytes
+        "sub esp, 12\n"       // TODO: Is this the correct way to align the stack?
+        "mov eax, [ebp+20]\n" // push ucontext_t*
+        "push eax\n"
+        "mov eax, [ebp+16]\n" // push siginfo_t*
+        "push eax\n"
         "mov eax, [ebp+12]\n" // push the signal code
         "push eax\n"
         "call [ebp+8]\n" // call the signal handler
-        "add esp, 8\n"
+        "add esp, 16\n"  // Unroll the stack, such that the bottom of the stack is our register dump
         "mov eax, %P0\n"
         "int 0x82\n" // sigreturn syscall
         "asm_signal_trampoline_end:\n"

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1182,6 +1182,9 @@ private:
     void relock_process(LockMode, u32);
     String backtrace_impl();
     void reset_fpu_state();
+    void setup_signal_stack(u8 signal, u32 old_signal_mask, VirtualAddress handler_vaddr);
+    siginfo_t siginfo_for_signal(u8 signal, const Process* sender) const;
+    ucontext_t ucontext_from_regs(const RegisterState&, u32 old_signal_mask) const;
 
     mutable RecursiveSpinLock m_lock;
     mutable RecursiveSpinLock m_block_lock;

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -28,6 +28,8 @@
 
 #include <AK/DistinctNumeric.h>
 #include <AK/Types.h>
+// FIXME: Move a copy of this somewhere kernel-y. And in Ptrace.h
+#include <LibC/sys/arch/i386/regs.h>
 
 #define O_RDONLY (1 << 0)
 #define O_WRONLY (1 << 1)
@@ -357,6 +359,21 @@ typedef struct siginfo {
     union sigval si_value;
 } siginfo_t;
 
+typedef struct __stack {
+    void* ss_sp;
+    size_t ss_size;
+    int ss_flags;
+} stack_t;
+
+typedef PtraceRegisters mcontext_t;
+
+typedef struct ucontext {
+    struct ucontext* uc_link;
+    sigset_t uc_sigmask;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+} ucontext_t;
+
 struct sigaction {
     union {
         void (*sa_handler)(int);
@@ -375,12 +392,45 @@ struct sigaction {
 #define SIG_UNBLOCK 1
 #define SIG_SETMASK 2
 
+#define ILL_ILLOPC 0
+#define ILL_ILLOPN 1
+#define ILL_ILLADR 2
+#define ILL_ILLTRP 3
+#define ILL_PRVOPC 4
+#define ILL_PRVREG 5
+#define ILL_COPROC 6
+#define ILL_BADSTK 7
+
+#define FPE_INTDIV 0
+#define FPE_INTOVF 1
+#define FPE_FLTDIV 2
+#define FPE_FLTOVF 3
+#define FPE_FLTUND 4
+#define FPE_FLTRES 5
+#define FPE_FLTINV 6
+
+#define SEGV_MAPERR 0
+#define SEGV_ACCERR 1
+
+#define BUS_ADRALN 0
+#define BUS_ADRERR 1
+#define BUS_OBJERR 2
+
+#define TRAP_BRKPT 0
+#define TRAP_TRACE 1
+
 #define CLD_EXITED 0
 #define CLD_KILLED 1
 #define CLD_DUMPED 2
 #define CLD_TRAPPED 3
 #define CLD_STOPPED 4
 #define CLD_CONTINUED 5
+
+#define SI_USER 0x40000000
+#define SI_QUEUE 0x40000001
+#define SI_TIMER 0x40000002
+#define SI_ASYNCIO 0x40000003
+#define SI_MESGQ 0x40000004
 
 #define OFF_T_MAX 2147483647
 

--- a/Libraries/LibC/signal.h
+++ b/Libraries/LibC/signal.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <signal_numbers.h>
+#include <sys/arch/i386/regs.h>
 #include <sys/types.h>
 
 __BEGIN_DECLS
@@ -51,6 +52,21 @@ typedef struct siginfo {
     int si_status;
     union sigval si_value;
 } siginfo_t;
+
+typedef struct __stack {
+    void* ss_sp;
+    size_t ss_size;
+    int ss_flags;
+} stack_t;
+
+typedef PtraceRegisters mcontext_t;
+
+typedef struct ucontext {
+    struct ucontext* uc_link;
+    sigset_t uc_sigmask;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+} ucontext_t;
 
 struct sigaction {
     union {
@@ -99,11 +115,45 @@ extern const char* sys_siglist[NSIG];
 #define SIG_UNBLOCK 1
 #define SIG_SETMASK 2
 
+/* si_codes */
+#define ILL_ILLOPC 0
+#define ILL_ILLOPN 1
+#define ILL_ILLADR 2
+#define ILL_ILLTRP 3
+#define ILL_PRVOPC 4
+#define ILL_PRVREG 5
+#define ILL_COPROC 6
+#define ILL_BADSTK 7
+
+#define FPE_INTDIV 0
+#define FPE_INTOVF 1
+#define FPE_FLTDIV 2
+#define FPE_FLTOVF 3
+#define FPE_FLTUND 4
+#define FPE_FLTRES 5
+#define FPE_FLTINV 6
+
+#define SEGV_MAPERR 0
+#define SEGV_ACCERR 1
+
+#define BUS_ADRALN 0
+#define BUS_ADRERR 1
+#define BUS_OBJERR 2
+
+#define TRAP_BRKPT 0
+#define TRAP_TRACE 1
+
 #define CLD_EXITED 0
 #define CLD_KILLED 1
 #define CLD_DUMPED 2
 #define CLD_TRAPPED 3
 #define CLD_STOPPED 4
 #define CLD_CONTINUED 5
+
+#define SI_USER 0x40000000
+#define SI_QUEUE 0x40000001
+#define SI_TIMER 0x40000002
+#define SI_ASYNCIO 0x40000003
+#define SI_MESGQ 0x40000004
 
 __END_DECLS

--- a/Userland/Tests/Kernel/send-signal-to-self.cpp
+++ b/Userland/Tests/Kernel/send-signal-to-self.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+volatile sig_atomic_t saved_signal = -1;
+volatile bool got_signal = false;
+
+extern void my_handler(int);
+void my_handler(int sig)
+{
+    saved_signal = sig;
+    got_signal = true;
+}
+
+int main()
+{
+    if (SIG_ERR == signal(SIGUSR1, my_handler)) {
+        perror("signal");
+        return 1;
+    }
+
+    sleep(1);
+
+    if (0 != kill(getpid(), SIGUSR1)) {
+        perror("kill");
+        return 2;
+    }
+
+    sleep(1);
+
+    if (!got_signal) {
+        fprintf(stderr, "Where's my signal, bro?\n");
+        return 3;
+    }
+
+    printf("Got signal %d\n", saved_signal);
+
+    return 0;
+}


### PR DESCRIPTION
This patch adds support for SA_SIGINFO signal handlers.

- [x] Add definitions for ucontext_t, stack_t, and siginfo_t::si_code values to `<signal.h>` and `"Kernel/UnixTypes.h"`
- [x] Write test/example program
- [x] Put ucontext_t and siginfo_t on stack in Thread::dispatch_signal(u8)
- [x] Push pointer to stashed ucontext and siginfo onto front(?) of stack next to signal number
- [x] Fumble around in the signal trampoline assembly for an hour or two (Black Magic R Us)
- [x] Implement siginfo in UserspaceEmulator
- [ ] Debug (or put off?) misaligned stack addresses that occur when sending a ton of signals  in rapid succession, to some applications. Especially likely to happen when running applications in UserspaceEmulator.

Note that the implementation here makes every single signal push all of this junk to the stack, instead of just the ones for which an SA_SIGINFO handler was registered. Doing that logic would probably require... even more changes to that signal trampoline assembly. Something I definitely do not want to mess with right now, that stuff is gnarly and confusing.

So, that's a doubling of the "signal stack" overhead (56 --> 116 bytes).

After this set of changes, then we come to terms with the fact that, at `dispatch_signal` time, we have lost a ton of useful information about the signal we're handling. The types of things we can use to fill in the `si_code` field of the siginfo_t. The types of things that could let us dump a lot of interesting backtrace information in userspace on crash 😄.

Reminder to self: make ucontext_t::uc_mcontext equivalent to RegisterDump so that those could possibly be merged? Sounds gnarly as well :/