### PR TITLE
Userland: Fix typo in 'pro' help

### DIFF
--- a/Userland/pro.cpp
+++ b/Userland/pro.cpp
@@ -146,7 +146,9 @@ int main(int argc, char** argv)
     bool save_at_provided_name = false;
 
     Core::ArgsParser args_parser;
-    args_parser.set_general_help("Download file from arbitrary ");
+    args_parser.set_general_help(
+        "Download a file from an arbitrary URL. This command uses ProtocolServer, "
+        "and thus supports at least http, https, and gemini.");
     args_parser.add_option(save_at_provided_name, "Write to a file named as the remote file", nullptr, 'O');
     args_parser.add_positional_argument(url_str, "URL to download from", "url");
     args_parser.parse(argc, argv);


### PR DESCRIPTION
> (13:48:45) CxByte: BenW: It seems this sentence https://github.com/SerenityOS/serenity/commit/4ec77ba929ed13ed639b803aebb9aa61b1353443#diff-5ebd330de6f9759046097d5dbaf47048fe4441877a11c66c42c680e51ece0a92
> (14:12:07) BenW: Huh, apparently I forgot to

I added the rest of the  


;)