### PR TITLE
FileManager: Fix TreeView collapsing on file system changes

### DIFF
--- a/Applications/FileManager/DirectoryView.cpp
+++ b/Applications/FileManager/DirectoryView.cpp
@@ -563,6 +563,7 @@ void DirectoryView::handle_drop(const GUI::ModelIndex& index, const GUI::DropEve
     if (!target_node.is_directory())
         return;
 
+    bool had_accepted_drop = false;
     for (auto& url_to_copy : urls) {
         if (!url_to_copy.is_valid() || url_to_copy.path() == target_node.full_path())
             continue;
@@ -573,8 +574,12 @@ void DirectoryView::handle_drop(const GUI::ModelIndex& index, const GUI::DropEve
         if (!FileUtils::copy_file_or_directory(url_to_copy.path(), new_path)) {
             auto error_message = String::formatted("Could not copy {} into {}.", url_to_copy.to_string(), new_path);
             GUI::MessageBox::show(window(), error_message, "File Manager", GUI::MessageBox::Type::Error);
+        } else {
+            had_accepted_drop = true;
         }
     }
-};
+    if (had_accepted_drop)
+        on_accepted_drop();
+}
 
 }

--- a/Applications/FileManager/DirectoryView.h
+++ b/Applications/FileManager/DirectoryView.h
@@ -86,6 +86,7 @@ public:
     Function<void(const GUI::ModelIndex&, const GUI::ContextMenuEvent&)> on_context_menu_request;
     Function<void(const StringView&)> on_status_message;
     Function<void(int done, int total)> on_thumbnail_progress;
+    Function<void()> on_accepted_drop;
 
     enum ViewMode {
         Invalid,


### PR DESCRIPTION
TreeViews using FileSystemModels collapse whenever the file system is changed in any way. This includes creating, dragging, deleting or pasting any files/folders. This commit updates the refresh_tree_view() lambda, which seems to have stopped working at some point, and calls it whenever any of the actions mentioned above are activated.

If it is possible to fix this problem at the treeview level, that is obviously preferred, I looked into it but couldn't find any solution.

Fixes #4289 