### PR TITLE
Fewer crashes, less attack surface, more features, mixed bag

### DIFF
--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -157,6 +157,7 @@ private:
     int virt$set_thread_name(pid_t, FlatPtr, size_t);
     pid_t virt$setsid();
     int virt$watch_file(FlatPtr, size_t);
+    int virt$readlink(FlatPtr);
 
     FlatPtr allocate_vm(size_t size, size_t alignment);
 

--- a/Libraries/LibGUI/Clipboard.cpp
+++ b/Libraries/LibGUI/Clipboard.cpp
@@ -161,7 +161,6 @@ void Clipboard::set_bitmap(const Gfx::Bitmap& bitmap)
     metadata.set("height", String::number(bitmap.height()));
     metadata.set("format", String::number((int)bitmap.format()));
     metadata.set("pitch", String::number(bitmap.pitch()));
-    metadata.set("bpp", String::number(bitmap.bpp()));
     set_data({ bitmap.scanline(0), bitmap.size_in_bytes() }, "image/x-serenityos", metadata);
 }
 

--- a/MenuApplets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/MenuApplets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -51,6 +51,29 @@ String ClipboardHistoryModel::column_name(int column) const
     }
 }
 
+static const char* bpp_for_format_resilient(String format)
+{
+    unsigned format_uint = format.to_uint().value_or(static_cast<unsigned>(Gfx::BitmapFormat::Invalid));
+    // Cannot use Gfx::Bitmap::bpp_for_format here, as we have to accept invalid enum values.
+    switch (static_cast<Gfx::BitmapFormat>(format_uint)) {
+    case Gfx::BitmapFormat::Indexed1:
+        return "1";
+    case Gfx::BitmapFormat::Indexed2:
+        return "2";
+    case Gfx::BitmapFormat::Indexed4:
+        return "4";
+    case Gfx::BitmapFormat::Indexed8:
+        return "8";
+    case Gfx::BitmapFormat::RGB32:
+    case Gfx::BitmapFormat::RGBA32:
+        return "32";
+    case Gfx::BitmapFormat::Invalid:
+        /* fall-through */
+    default:
+        return "?";
+    }
+}
+
 GUI::Variant ClipboardHistoryModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
 {
     if (role != GUI::ModelRole::Display)
@@ -67,7 +90,7 @@ GUI::Variant ClipboardHistoryModel::data(const GUI::ModelIndex& index, GUI::Mode
             builder.append('x');
             builder.append(data_and_type.metadata.get("height").value_or("?"));
             builder.append('x');
-            builder.append(data_and_type.metadata.get("bpp").value_or("?"));
+            builder.append(bpp_for_format_resilient(data_and_type.metadata.get("height").value_or("0")));
             builder.append(" bitmap");
             builder.append("]");
             return builder.to_string();

--- a/Services/WindowServer/Compositor.h
+++ b/Services/WindowServer/Compositor.h
@@ -114,7 +114,7 @@ private:
     Gfx::IntRect m_last_dnd_rect;
     Gfx::IntRect m_last_geometry_label_rect;
 
-    String m_wallpaper_path;
+    String m_wallpaper_path { "" };
     WallpaperMode m_wallpaper_mode { WallpaperMode::Unchecked };
     RefPtr<Gfx::Bitmap> m_wallpaper;
 


### PR DESCRIPTION
The only common theme here is "I ran into these problems while working on something else". As always: If you prefer I make these as multiple PRs, no problem.

- Initialize stuff in WindowServer correctly, which used to crash *other* programs (e.g. `pape -c`)
- Don't rely on the `bpp` metadata value for clipboard images. A misbehaving program was able to set bpps like `33` or `sevenbajillion lol`, which then would show up verbatim in the Clipboard History. (There's more PRs coming for that.)
- UserEmulator, realpath: Handle weird buffer requirements more reasonably. (For example, if the return buffer was too small, UE would just silently, truncate the result, whereas the Kernel would.)
- UserEmulator, readlink: Implement. Now we support such sophisticated programs such as `/bin/readlink`! (And `FileManager` runs a little longer until it runs into the unimplemented syscall `create_thread`.)

If anyone feels like it: `virt$realpath` and `virt$readlink` are very similar, and should probably be abstracted/generalized/put-together somehow.