### PR TITLE
LibM: Add implementation of ldexpf

### DIFF
--- a/Libraries/LibM/math.cpp
+++ b/Libraries/LibM/math.cpp
@@ -144,6 +144,13 @@ double ldexp(double x, int exp) NOEXCEPT
     return x * val;
 }
 
+float ldexpf(float x, int exp) NOEXCEPT
+{
+    // FIXME: Please fix me. I am naive.
+    float val = powf(2, exp);
+    return x * val;
+}
+
 double tanh(double x) NOEXCEPT
 {
     if (x > 0) {


### PR DESCRIPTION
There was a declaration for `ldexpf` in math.h, but no actual implementation. This adds an implementation that does basically the same thing as `ldexp`, but with floats and `powf` instead of doubles and `pow`.