### PR TITLE
LibGfx: SIMD optimized alpha blending

### DIFF
--- a/AK/SIMD.h
+++ b/AK/SIMD.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace AK::SIMD {
+
+using i8x2 = i8 __attribute__((vector_size(2)));
+using i8x4 = i8 __attribute__((vector_size(4)));
+using i8x8 = i8 __attribute__((vector_size(8)));
+using i8x16 = i8 __attribute__((vector_size(16)));
+using i8x32 = i8 __attribute__((vector_size(32)));
+
+using i16x2 = i16 __attribute__((vector_size(4)));
+using i16x4 = i16 __attribute__((vector_size(8)));
+using i16x8 = i16 __attribute__((vector_size(16)));
+using i16x16 = i16 __attribute__((vector_size(32)));
+
+using i32x2 = i32 __attribute__((vector_size(8)));
+using i32x4 = i32 __attribute__((vector_size(16)));
+using i32x8 = i32 __attribute__((vector_size(32)));
+
+using i64x2 = i64 __attribute__((vector_size(16)));
+using i64x4 = i64 __attribute__((vector_size(32)));
+
+using u8x2 = u8 __attribute__((vector_size(2)));
+using u8x4 = u8 __attribute__((vector_size(4)));
+using u8x8 = u8 __attribute__((vector_size(8)));
+using u8x16 = u8 __attribute__((vector_size(16)));
+using u8x32 = u8 __attribute__((vector_size(32)));
+
+using u16x2 = u16 __attribute__((vector_size(4)));
+using u16x4 = u16 __attribute__((vector_size(8)));
+using u16x8 = u16 __attribute__((vector_size(16)));
+using u16x16 = u16 __attribute__((vector_size(32)));
+
+using u32x2 = u32 __attribute__((vector_size(8)));
+using u32x4 = u32 __attribute__((vector_size(16)));
+using u32x8 = u32 __attribute__((vector_size(32)));
+
+using u64x2 = u64 __attribute__((vector_size(16)));
+using u64x4 = u64 __attribute__((vector_size(32)));
+
+using f32x2 = float __attribute__((vector_size(8)));
+using f32x4 = float __attribute__((vector_size(16)));
+using f32x8 = float __attribute__((vector_size(32)));
+
+using f64x2 = double __attribute__((vector_size(16)));
+using f64x4 = double __attribute__((vector_size(32)));
+
+}


### PR DESCRIPTION
Add SIMD optimized alpha blending. Also, make Gamma.h a bit nicer (and refactor some stuff that shouldn't be in there out of it).

Preliminary benchmarking shows that this makes Color::blend() about twice as fast on my machine.

Fixes #69.