### PR TITLE
Shell: Fixes / LibRegex: replace() / AK: faster iterator memmem() 

### DIFF
--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -109,6 +109,12 @@ class NonnullRefPtr;
 template<typename T>
 class NonnullOwnPtr;
 
+template<typename T, int inline_capacity = 0>
+class NonnullRefPtrVector;
+
+template<typename T, int inline_capacity = 0>
+class NonnullOwnPtrVector;
+
 template<typename T>
 class Optional;
 
@@ -154,7 +160,9 @@ using AK::JsonObject;
 using AK::JsonValue;
 using AK::LogStream;
 using AK::NonnullOwnPtr;
+using AK::NonnullOwnPtrVector;
 using AK::NonnullRefPtr;
+using AK::NonnullRefPtrVector;
 using AK::Optional;
 using AK::OutputMemoryStream;
 using AK::OutputStream;

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -252,7 +252,7 @@ public:
         size_t nread = 0;
         while (bytes.size() - nread > 0 && m_write_offset - m_read_offset - nread > 0) {
             const auto chunk_index = (m_read_offset - m_base_offset + nread) / chunk_size;
-            const auto chunk_bytes = m_chunks[chunk_index].bytes().slice(m_read_offset % chunk_size).trim(m_write_offset - m_read_offset - nread);
+            const auto chunk_bytes = m_chunks[chunk_index].bytes().slice((m_read_offset + nread) % chunk_size).trim(m_write_offset - m_read_offset - nread);
             nread += chunk_bytes.copy_trimmed_to(bytes.slice(nread));
         }
 
@@ -279,8 +279,7 @@ public:
             return false;
         }
 
-        read(bytes);
-        return true;
+        return read(bytes) == bytes.size();
     }
 
     size_t write(ReadonlyBytes bytes) override

--- a/AK/NonnullOwnPtrVector.h
+++ b/AK/NonnullOwnPtrVector.h
@@ -31,7 +31,7 @@
 
 namespace AK {
 
-template<typename T, int inline_capacity = 0>
+template<typename T, int inline_capacity>
 class NonnullOwnPtrVector : public NonnullPtrVector<NonnullOwnPtr<T>, inline_capacity> {
 };
 

--- a/AK/NonnullRefPtrVector.h
+++ b/AK/NonnullRefPtrVector.h
@@ -31,7 +31,7 @@
 
 namespace AK {
 
-template<typename T, int inline_capacity = 0>
+template<typename T, int inline_capacity>
 class NonnullRefPtrVector : public NonnullPtrVector<NonnullRefPtr<T>, inline_capacity> {
 };
 

--- a/AK/Tests/TestMemMem.cpp
+++ b/AK/Tests/TestMemMem.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/MemMem.h>
+
+TEST_CASE(bitap)
+{
+    Array<u8, 8> haystack { 1, 0, 1, 2, 3, 4, 5, 0 };
+    Array<u8, 4> needle_0 { 2, 3, 4, 5 };
+    Array<u8, 4> needle_1 { 1, 2, 3, 4 };
+    Array<u8, 4> needle_2 { 3, 4, 5, 0 };
+    Array<u8, 4> needle_3 { 3, 4, 5, 6 };
+
+    auto result_0 = AK::memmem(haystack.data(), haystack.size(), needle_0.data(), needle_0.size());
+    auto result_1 = AK::memmem(haystack.data(), haystack.size(), needle_1.data(), needle_1.size());
+    auto result_2 = AK::memmem(haystack.data(), haystack.size(), needle_2.data(), needle_2.size());
+    auto result_3 = AK::memmem(haystack.data(), haystack.size(), needle_3.data(), needle_3.size());
+
+    EXPECT_EQ(result_0, &haystack[3]);
+    EXPECT_EQ(result_1, &haystack[2]);
+    EXPECT_EQ(result_2, &haystack[4]);
+    EXPECT_EQ(result_3, nullptr);
+}
+
+TEST_CASE(kmp_one_chunk)
+{
+    Array<u8, 8> haystack { 1, 0, 1, 2, 3, 4, 5, 0 };
+    Array<Array<u8, 8>, 1> haystack_arr { haystack };
+    Array<u8, 4> needle_0 { 2, 3, 4, 5 };
+    Array<u8, 4> needle_1 { 1, 2, 3, 4 };
+    Array<u8, 4> needle_2 { 3, 4, 5, 0 };
+    Array<u8, 4> needle_3 { 3, 4, 5, 6 };
+
+    auto result_0 = AK::memmem(haystack_arr.begin(), haystack_arr.end(), needle_0);
+    auto result_1 = AK::memmem(haystack_arr.begin(), haystack_arr.end(), needle_1);
+    auto result_2 = AK::memmem(haystack_arr.begin(), haystack_arr.end(), needle_2);
+    auto result_3 = AK::memmem(haystack_arr.begin(), haystack_arr.end(), needle_3);
+
+    EXPECT_EQ(result_0.value_or(9), 3u);
+    EXPECT_EQ(result_1.value_or(9), 2u);
+    EXPECT_EQ(result_2.value_or(9), 4u);
+    EXPECT(!result_3.has_value());
+}
+
+TEST_CASE(kmp_two_chunks)
+{
+    Array<u8, 4> haystack_first_half { 1, 0, 1, 2 }, haystack_second_half { 3, 4, 5, 0 };
+    Array<Array<u8, 4>, 2> haystack { haystack_first_half, haystack_second_half };
+    Array<u8, 4> needle_0 { 2, 3, 4, 5 };
+    Array<u8, 4> needle_1 { 1, 2, 3, 4 };
+    Array<u8, 4> needle_2 { 3, 4, 5, 0 };
+    Array<u8, 4> needle_3 { 3, 4, 5, 6 };
+
+    auto result_0 = AK::memmem(haystack.begin(), haystack.end(), needle_0);
+    auto result_1 = AK::memmem(haystack.begin(), haystack.end(), needle_1);
+    auto result_2 = AK::memmem(haystack.begin(), haystack.end(), needle_2);
+    auto result_3 = AK::memmem(haystack.begin(), haystack.end(), needle_3);
+
+    EXPECT_EQ(result_0.value_or(9), 3u);
+    EXPECT_EQ(result_1.value_or(9), 2u);
+    EXPECT_EQ(result_2.value_or(9), 4u);
+    EXPECT(!result_3.has_value());
+}
+
+TEST_MAIN(MemMem)

--- a/Libraries/LibRegex/Tests/Regex.cpp
+++ b/Libraries/LibRegex/Tests/Regex.cpp
@@ -563,4 +563,37 @@ TEST_CASE(ECMA262_match)
     }
 }
 
+TEST_CASE(replace)
+{
+    struct _test {
+        const char* pattern;
+        const char* replacement;
+        const char* subject;
+        const char* expected;
+        ECMAScriptFlags options {};
+    };
+
+    constexpr _test tests[] {
+        { "foo(.+)", "aaa", "test", "test" },
+        { "foo(.+)", "test\\1", "foobar", "testbar" },
+        { "foo(.+)", "\\2\\1", "foobar", "\\2bar" },
+        { "foo(.+)", "\\\\\\1", "foobar", "\\bar" },
+        { "foo(.)", "a\\1", "fooxfooy", "axay", ECMAScriptFlags::Multiline },
+    };
+
+    for (auto& test : tests) {
+        Regex<ECMA262> re(test.pattern, test.options);
+#ifdef REGEX_DEBUG
+        dbg() << "\n";
+        RegexDebug regex_dbg(stderr);
+        regex_dbg.print_raw_bytecode(re);
+        regex_dbg.print_header();
+        regex_dbg.print_bytecode(re);
+        dbg() << "\n";
+#endif
+        EXPECT_EQ(re.parser_result.error, Error::NoError);
+        EXPECT_EQ(re.replace(test.subject, test.replacement), test.expected);
+    }
+}
+
 TEST_MAIN(Regex)

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -2481,6 +2481,10 @@ StringPartCompose::~StringPartCompose()
 void SyntaxError::dump(int level) const
 {
     Node::dump(level);
+    print_indented("(Error text)", level + 1);
+    print_indented(m_syntax_error_text, level + 2);
+    print_indented("(Can be recovered from)", level + 1);
+    print_indented(String::formatted("{}", m_is_continuable), level + 2);
 }
 
 RefPtr<Value> SyntaxError::run(RefPtr<Shell>)
@@ -2494,9 +2498,10 @@ void SyntaxError::highlight_in_editor(Line::Editor& editor, Shell&, HighlightMet
     editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Foreground(Line::Style::XtermColor::Red), Line::Style::Bold });
 }
 
-SyntaxError::SyntaxError(Position position, String error)
+SyntaxError::SyntaxError(Position position, String error, bool is_continuable)
     : Node(move(position))
     , m_syntax_error_text(move(error))
+    , m_is_continuable(is_continuable)
 {
     m_is_syntax_error = true;
 }

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -1153,7 +1153,7 @@ void Execute::for_each_entry(RefPtr<Shell> shell, Function<IterationDecision(Non
         int pipefd[2];
         int rc = pipe(pipefd);
         if (rc < 0) {
-            dbg() << "Error: cannot pipe(): " << strerror(errno);
+            dbgln("Error: cannot pipe(): {}", strerror(errno));
             return;
         }
         auto& last_in_commands = commands.last();
@@ -1233,7 +1233,7 @@ void Execute::for_each_entry(RefPtr<Shell> shell, Function<IterationDecision(Non
                     }
                     if (saved_errno == 0)
                         continue;
-                    dbg() << "read() failed: " << strerror(saved_errno);
+                    dbgln("read() failed: {}", strerror(saved_errno));
                     break;
                 }
                 if (read_size == 0)
@@ -1253,7 +1253,7 @@ void Execute::for_each_entry(RefPtr<Shell> shell, Function<IterationDecision(Non
         notifier->on_ready_to_read = nullptr;
 
         if (close(pipefd[0]) < 0) {
-            dbg() << "close() failed: " << strerror(errno);
+            dbgln("close() failed: {}", strerror(errno));
         }
 
         if (!stream.eof()) {
@@ -1611,7 +1611,7 @@ RefPtr<Value> MatchExpr::run(RefPtr<Shell> shell)
     }
 
     // FIXME: Somehow raise an error in the shell.
-    dbg() << "Non-exhaustive match rules!";
+    dbgln("Non-exhaustive match rules!");
     return create<AST::ListValue>({});
 }
 
@@ -2489,7 +2489,8 @@ void SyntaxError::dump(int level) const
 
 RefPtr<Value> SyntaxError::run(RefPtr<Shell>)
 {
-    dbg() << "SYNTAX ERROR AAAA";
+    dbgln("SYNTAX ERROR executed from");
+    dump(1);
     return create<StringValue>("");
 }
 
@@ -2897,7 +2898,7 @@ Result<NonnullRefPtr<Rewiring>, String> PathRedirection::apply() const
     auto check_fd_and_return = [my_fd = this->fd](int fd, const String& path) -> Result<NonnullRefPtr<Rewiring>, String> {
         if (fd < 0) {
             String error = strerror(errno);
-            dbg() << "open() failed for '" << path << "' with " << error;
+            dbgln("open() failed for '{}' with {}", path, error);
             return error;
         }
         return adopt(*new Rewiring(fd, my_fd, Rewiring::Close::Old));

--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -418,8 +418,10 @@ public:
     const Position& position() const { return m_position; }
     void set_is_syntax_error(const SyntaxError& error_node)
     {
-        m_is_syntax_error = true;
-        m_syntax_error_node = error_node;
+        if (!m_is_syntax_error) {
+            m_is_syntax_error = true;
+            m_syntax_error_node = error_node;
+        }
     }
     virtual const SyntaxError& syntax_error_node() const
     {
@@ -1174,11 +1176,12 @@ private:
 
 class SyntaxError final : public Node {
 public:
-    SyntaxError(Position, String);
+    SyntaxError(Position, String, bool is_continuable = false);
     virtual ~SyntaxError();
     virtual void visit(NodeVisitor& visitor) override { visitor.visit(this); }
 
     const String& error_text() const { return m_syntax_error_text; }
+    bool is_continuable() const { return m_is_continuable; }
 
 private:
     NODE(SyntaxError);
@@ -1190,6 +1193,7 @@ private:
     virtual const SyntaxError& syntax_error_node() const override;
 
     String m_syntax_error_text;
+    bool m_is_continuable { false };
 };
 
 class Tilde final : public Node {

--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -27,6 +27,7 @@
 #include "Shell.h"
 #include <AK/LexicalPath.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <inttypes.h>
 #include <signal.h>
@@ -829,6 +830,9 @@ bool Shell::run_builtin(const AST::Command& command, const NonnullRefPtrVector<A
             return false;
         }
     }
+
+    Core::EventLoop loop;
+    setup_signals();
 
 #define __ENUMERATE_SHELL_BUILTIN(builtin)                        \
     if (name == #builtin) {                                       \

--- a/Shell/Job.h
+++ b/Shell/Job.h
@@ -84,6 +84,7 @@ public:
     void disown() { m_should_be_disowned = true; }
     bool is_running_in_background() const { return m_running_in_background; }
     bool should_announce_exit() const { return m_should_announce_exit; }
+    bool should_announce_signal() const { return m_should_announce_signal; }
     bool is_suspended() const { return m_is_suspended; }
     void unblock() const;
 
@@ -100,6 +101,7 @@ public:
     }
 
     void set_should_announce_exit(bool value) { m_should_announce_exit = value; }
+    void set_should_announce_signal(bool value) { m_should_announce_signal = value; }
 
     void deactivate() const { m_active = false; }
 
@@ -121,6 +123,7 @@ private:
     bool m_exited { false };
     bool m_running_in_background { false };
     bool m_should_announce_exit { false };
+    bool m_should_announce_signal { true };
     int m_exit_code { -1 };
     int m_term_sig { -1 };
     Core::ElapsedTimer m_command_timer;

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -853,7 +853,9 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
         if (!job->exited())
             return;
         if (job->is_running_in_background() && job->should_announce_exit())
-            fprintf(stderr, "Shell: Job %" PRIu64 "(%s) exited\n", job->job_id(), job->cmd().characters());
+            warnln("Shell: Job {} ({}) exited\n", job->job_id(), job->cmd().characters());
+        else if (job->signaled() && job->should_announce_signal())
+            warnln("Shell: Job {} ({}) {}\n", job->job_id(), job->cmd().characters(), strsignal(job->termination_signal()));
 
         last_return_code = job->exit_code();
         job->disown();

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -817,13 +817,13 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
 
     pid_t pgid = is_first ? child : (command.pipeline ? command.pipeline->pgid : child);
     if ((!m_is_subshell && command.should_wait) || command.pipeline) {
-        if (setpgid(child, pgid) < 0)
+        if (setpgid(child, pgid) < 0 && m_is_interactive)
             perror("setpgid");
 
         if (!m_is_subshell) {
-            if (tcsetpgrp(STDOUT_FILENO, pgid) != 0)
+            if (tcsetpgrp(STDOUT_FILENO, pgid) != 0 && m_is_interactive)
                 perror("tcsetpgrp(OUT)");
-            if (tcsetpgrp(STDIN_FILENO, pgid) != 0)
+            if (tcsetpgrp(STDIN_FILENO, pgid) != 0 && m_is_interactive)
                 perror("tcsetpgrp(IN)");
         }
     }

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -816,7 +816,7 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
     }
 
     pid_t pgid = is_first ? child : (command.pipeline ? command.pipeline->pgid : child);
-    if ((!m_is_subshell && command.should_wait) || command.pipeline) {
+    if (!m_is_subshell || command.pipeline) {
         if (setpgid(child, pgid) < 0 && m_is_interactive)
             perror("setpgid");
 

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -244,7 +244,6 @@ private:
 #undef __ENUMERATE_SHELL_BUILTIN
     };
 
-    StringBuilder m_complete_line_builder;
     bool m_should_ignore_jobs_on_next_exit { false };
     pid_t m_pid { 0 };
 
@@ -267,6 +266,8 @@ private:
     RefPtr<Line::Editor> m_editor;
 
     bool m_default_constructed { false };
+
+    mutable bool m_last_continuation_state { false }; // false == not needed.
 };
 
 static constexpr bool is_word_character(char c)

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -260,6 +260,7 @@ private:
     HashMap<String, String> m_aliases;
     bool m_is_interactive { true };
     bool m_is_subshell { false };
+    bool m_should_reinstall_signal_handlers { true };
 
     bool m_should_format_live { false };
 

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -175,7 +175,7 @@ int main(int argc, char** argv)
     }
 
     if (command_to_run) {
-        dbgprintf("sh -c '%s'\n", command_to_run);
+        dbgln("sh -c '{}'\n", command_to_run);
         shell->run_command(command_to_run);
         return 0;
     }

--- a/Shell/main.cpp
+++ b/Shell/main.cpp
@@ -61,6 +61,7 @@ int main(int argc, char** argv)
     });
 
     editor = Line::Editor::construct();
+    editor->initialize();
 
     auto shell = Shell::Shell::construct(*editor);
     s_shell = shell.ptr();
@@ -81,7 +82,6 @@ int main(int argc, char** argv)
     }
 #endif
 
-    editor->initialize();
     shell->termios = editor->termios();
     shell->default_termios = editor->default_termios();
 


### PR DESCRIPTION
This is the non-experimental stuff from #4316, since that branch is super duper WIP right now :P
In this PR:
- Shell: Continue the prompt when <return>'d and a syntax error that can be recovered from exists
    - In practice, this means clean multiline input for most scenarios
- Shell: Make less EventLoop's, especially when they're not needed
- Shell: Also show termination signal
- Shell: Fix #4345 
- LibRegex: `Regex<T>::replace()` (fairly basic)
- AK: `memmem()` for iterators `memmem(const T& begin, const T& end, ...)` with a bunch of `requires` for nicer errors
- AK: Fix reading across chunks in `DuplexMemoryStream`
- Shell: Fix #4358 (sneaky boi)

This is one huge PR...