### PR TITLE
LibWeb: Disallow construction of XMLHttpRequest without 'new'

### DIFF
--- a/Libraries/LibWeb/Bindings/XMLHttpRequestConstructor.cpp
+++ b/Libraries/LibWeb/Bindings/XMLHttpRequestConstructor.cpp
@@ -57,7 +57,8 @@ XMLHttpRequestConstructor::~XMLHttpRequestConstructor()
 
 JS::Value XMLHttpRequestConstructor::call()
 {
-    return construct(*this);
+    vm().throw_exception<JS::TypeError>(global_object(), JS::ErrorType::ConstructorWithoutNew, "XMLHttpRequest");
+    return {};
 }
 
 JS::Value XMLHttpRequestConstructor::construct(Function&)


### PR DESCRIPTION
The `XMLHttpRequest` interface only has a constructor and isn't supposed to be callable as a function.

https://xhr.spec.whatwg.org/#constructors