### PR TITLE
LibWeb: Don't allocate XMLHttpRequestConstructor twice

### DIFF
--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -85,8 +85,6 @@ void WindowObject::initialize()
     define_property("location", heap().allocate<LocationObject>(*this, *this), JS::Attribute::Enumerable | JS::Attribute::Configurable);
 
     m_xhr_prototype = heap().allocate<XMLHttpRequestPrototype>(*this, *this);
-    m_xhr_constructor = heap().allocate<XMLHttpRequestConstructor>(*this, *this);
-    m_xhr_constructor->define_property("prototype", m_xhr_prototype, 0);
     add_constructor("XMLHttpRequest", m_xhr_constructor, m_xhr_prototype);
 }
 

--- a/Libraries/LibWeb/Bindings/XMLHttpRequestConstructor.cpp
+++ b/Libraries/LibWeb/Bindings/XMLHttpRequestConstructor.cpp
@@ -26,9 +26,9 @@
 
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/GlobalObject.h>
-#include <LibJS/Runtime/Shape.h>
 #include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/Bindings/XMLHttpRequestConstructor.h>
+#include <LibWeb/Bindings/XMLHttpRequestPrototype.h>
 #include <LibWeb/Bindings/XMLHttpRequestWrapper.h>
 #include <LibWeb/DOM/XMLHttpRequest.h>
 
@@ -41,8 +41,11 @@ XMLHttpRequestConstructor::XMLHttpRequestConstructor(JS::GlobalObject& global_ob
 
 void XMLHttpRequestConstructor::initialize(JS::GlobalObject& global_object)
 {
+    auto& vm = this->vm();
     NativeFunction::initialize(global_object);
-    define_property("length", JS::Value(1), JS::Attribute::Configurable);
+    auto& window = static_cast<WindowObject&>(global_object);
+    define_property(vm.names.prototype, window.xhr_prototype(), 0);
+    define_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);
 
     define_property("UNSENT", JS::Value((i32)XMLHttpRequest::ReadyState::Unsent), JS::Attribute::Enumerable);
     define_property("OPENED", JS::Value((i32)XMLHttpRequest::ReadyState::Opened), JS::Attribute::Enumerable);


### PR DESCRIPTION
`add_constructor()` will already allocate an `XMLHttpRequestConstructor` and update `m_xhr_constructor` accordingly, we don't have to do it ourselves. This is now in line with how all the LibJS constructors work. Also make the XHR constructor responsible for setting its "prototype" property itself, for consistency and fail-proofing. Previously we would only set it on the constructor we allocated manually but which was then thrown away, leading to the property never being set properly.