### PR TITLE
Meta: Add .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: meta-lint-ci
+        name: Running Meta/lint-ci.sh to ensure changes will pass linting on CI
+        entry: bash Meta/lint-ci.sh
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
This pre-commit config is quite simple: all it does for now is running the already existing `Meta/lint-ci.sh` script to ensure no changes that won't pass the CI linting step are committed.
Consequently `pass_filenames` is set to `false`, as these scripts will determine which files to check themselves - should this ever become a performance bottleneck, we can update them to accept an optional list of filenames.

It should be noted that using pre-commit for Serenity development is by no means a requirement, but doing so may decrease the number of CI builds failing due to forgotten license headers etc. - especially if you're pushing to `master` directly, rather than going through pull requests *hint hint*.

For info how to install & use pre-commit, see https://pre-commit.com/.

Fixes #2365.

---

Demo:

![image](https://user-images.githubusercontent.com/19366641/101668618-a843bd00-3a48-11eb-9219-1552c8c19651.png)

---

cc @alimpfard