### PR TITLE
AK: Fix two more bugs in DuplexMemoryStream.

### DIFF
--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -133,6 +133,15 @@ class WeakPtr;
 template<typename T, size_t inline_capacity = 0>
 class Vector;
 
+template<typename... Parameters>
+void dbgln(const char* fmtstr, const Parameters&...);
+
+template<typename... Parameters>
+void warnln(const char* fmtstr, const Parameters&...);
+
+template<typename... Parameters>
+void outln(const char* fmtstr, const Parameters&...);
+
 }
 
 using AK::Array;

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -289,7 +289,7 @@ public:
             if ((m_write_offset + nwritten) % chunk_size == 0)
                 m_chunks.append(ByteBuffer::create_uninitialized(chunk_size));
 
-            nwritten += bytes.copy_trimmed_to(m_chunks.last().bytes().slice(m_write_offset % chunk_size));
+            nwritten += bytes.slice(nwritten).copy_trimmed_to(m_chunks.last().bytes().slice(m_write_offset % chunk_size));
         }
 
         m_write_offset += nwritten;

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -284,12 +284,14 @@ public:
 
     size_t write(ReadonlyBytes bytes) override
     {
+        // FIXME: This doesn't write around chunk borders correctly?
+
         size_t nwritten = 0;
         while (bytes.size() - nwritten > 0) {
             if ((m_write_offset + nwritten) % chunk_size == 0)
                 m_chunks.append(ByteBuffer::create_uninitialized(chunk_size));
 
-            nwritten += bytes.slice(nwritten).copy_trimmed_to(m_chunks.last().bytes().slice(m_write_offset % chunk_size));
+            nwritten += bytes.slice(nwritten).copy_trimmed_to(m_chunks.last().bytes().slice((m_write_offset + nwritten) % chunk_size));
         }
 
         m_write_offset += nwritten;

--- a/AK/Tests/TestMemoryStream.cpp
+++ b/AK/Tests/TestMemoryStream.cpp
@@ -208,4 +208,12 @@ TEST_CASE(offset_of_out_of_bounds)
     EXPECT(!stream.offset_of(target).has_value());
 }
 
+TEST_CASE(unsigned_integer_underflow_regression)
+{
+    Array<u8, DuplexMemoryStream::chunk_size + 1> buffer;
+
+    DuplexMemoryStream stream;
+    stream << buffer;
+}
+
 TEST_MAIN(MemoryStream)

--- a/AK/Tests/TestMemoryStream.cpp
+++ b/AK/Tests/TestMemoryStream.cpp
@@ -27,6 +27,7 @@
 #include <AK/TestSuite.h>
 
 #include <AK/Array.h>
+#include <AK/LogStream.h>
 #include <AK/MemoryStream.h>
 
 static bool compare(ReadonlyBytes lhs, ReadonlyBytes rhs)
@@ -214,6 +215,23 @@ TEST_CASE(unsigned_integer_underflow_regression)
 
     DuplexMemoryStream stream;
     stream << buffer;
+}
+
+TEST_CASE(offset_calculation_error_regression)
+{
+    Array<u8, DuplexMemoryStream::chunk_size> input, output;
+    input.span().fill(0xff);
+
+    DuplexMemoryStream stream;
+    stream << 0x00000000 << input << 0x00000000;
+
+    stream.discard_or_error(sizeof(int));
+    stream.read(output);
+
+    EXPECT(compare(input, output));
+
+    AK::dump_bytes(input);
+    AK::dump_bytes(output);
 }
 
 TEST_MAIN(MemoryStream)


### PR DESCRIPTION
I wanted to add a test case that reproduced the issue @alimpfard fixed in #4359 and ran into two more bugs while doing so.

It seems that in most cases the offset calculation errors canceled each other out, because they happened both during reading and writing, thus making it appear like everything worked.
