### PR TITLE
LibDebug: Fix crash when debugging short lived programs

### DIFF
--- a/Libraries/LibDebug/DebugSession.cpp
+++ b/Libraries/LibDebug/DebugSession.cpp
@@ -64,6 +64,11 @@ OwnPtr<DebugSession> DebugSession::exec_and_attach(const String& command)
 {
     int pid = fork();
 
+    if (pid < 0) {
+        perror("fork");
+        exit(1);
+    }
+
     if (!pid) {
         if (ptrace(PT_TRACE_ME, 0, 0, 0) < 0) {
             perror("PT_TRACE_ME");
@@ -90,16 +95,6 @@ OwnPtr<DebugSession> DebugSession::exec_and_attach(const String& command)
 
     if (ptrace(PT_ATTACH, pid, 0, 0) < 0) {
         perror("PT_ATTACH");
-        return nullptr;
-    }
-
-    if (waitpid(pid, nullptr, WSTOPPED) != pid) {
-        perror("waitpid");
-        return nullptr;
-    }
-
-    if (ptrace(PT_CONTINUE, pid, 0, 0) < 0) {
-        perror("continue");
         return nullptr;
     }
 


### PR DESCRIPTION
Fixes #4327.

I believe these waitpid/ptrace calls are unnecessary, since the tracee waits till it starts executing execvp before it allows a tracer to attach based on my understanding. This fixes the debugger & functrace, but It would be nice to get other eyes on this to make sure I haven't misunderstood how it works.