### PR TITLE
AK: Ensure dual_pivot_quick_sort does not copy the pivots

### DIFF
--- a/AK/QuickSort.h
+++ b/AK/QuickSort.h
@@ -51,8 +51,8 @@ void dual_pivot_quick_sort(Collection& col, int start, int end, LessThan less_th
     int k = start + 1;
     int g = end - 1;
 
-    auto left_pivot = col[start];
-    auto right_pivot = col[end];
+    auto&& left_pivot = col[start];
+    auto&& right_pivot = col[end];
 
     while (k <= g) {
         if (less_than(col[k], left_pivot)) {

--- a/AK/Tests/TestQuickSort.cpp
+++ b/AK/Tests/TestQuickSort.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/Checked.h>
+#include <AK/Noncopyable.h>
+#include <AK/QuickSort.h>
+#include <AK/StdLibExtras.h>
+
+TEST_CASE(sorts_without_copy)
+{
+    struct NoCopy {
+        AK_MAKE_NONCOPYABLE(NoCopy);
+
+    public:
+        NoCopy() { }
+        NoCopy(NoCopy&&) = default;
+
+        NoCopy& operator=(NoCopy&&) = default;
+
+        int value { 0 };
+    };
+
+    Array<NoCopy, 64> array;
+    for (size_t i = 0; i < 64; ++i)
+        array[i].value = (64 - i) % 32 + 32;
+
+    quick_sort(array, [](auto& a, auto& b) { return a.value < b.value; });
+
+    for (size_t i = 0; i < 63; ++i)
+        EXPECT(array[i].value <= array[i + 1].value);
+}
+
+TEST_MAIN(QuickSort)


### PR DESCRIPTION
Also add a test that would fail to compile if quick_sort tries to copy
anything :P

Sort of a dumb problem that showed up when I was trying to make `NonnullRefPtr<T>` refuse to be constructed from the result of `RefPtr<T>::operator*()` (which turned out to have more false positives than anything).
