### PR TITLE
Shell: Restore the terminal PGID before printing out job status on exit

### DIFF
--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -98,6 +98,7 @@ int Shell::builtin_bg(int argc, const char** argv)
     }
 
     job->set_running_in_background(true);
+    job->set_should_announce_exit(true);
     job->set_is_suspended(false);
 
     dbgln("Resuming {} ({})", job->pid(), job->cmd());

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -871,6 +871,8 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
     job->on_exit = [this](auto job) {
         if (!job->exited())
             return;
+
+        restore_ios();
         if (job->is_running_in_background() && job->should_announce_exit())
             warnln("Shell: Job {} ({}) exited\n", job->job_id(), job->cmd().characters());
         else if (job->signaled() && job->should_announce_signal())


### PR DESCRIPTION
> \< kling\> CxByte: i hav bug report for u
> \< kling\> CxByte: cat\<enter\>\<ctrl+c\>
> \< kling\> :)

This fixes the assert tripping when interrupting a foreground job.
Also make `bg` mark the job as 'should announce exit'.