### PR TITLE
Chess: Add FEN copy, replay functionality, PGN import, board markings

### DIFF
--- a/Games/Chess/ChessWidget.cpp
+++ b/Games/Chess/ChessWidget.cpp
@@ -292,6 +292,11 @@ void ChessWidget::maybe_input_engine_move()
     });
 }
 
+String ChessWidget::get_fen() const
+{
+    return m_board.to_fen();
+}
+
 bool ChessWidget::export_pgn(const StringView& export_path) const
 {
     auto file_or_error = Core::File::open(export_path, Core::File::WriteOnly);

--- a/Games/Chess/ChessWidget.h
+++ b/Games/Chess/ChessWidget.h
@@ -62,6 +62,7 @@ public:
     void set_drag_enabled(bool e) { m_drag_enabled = e; }
     RefPtr<Gfx::Bitmap> get_piece_graphic(const Chess::Piece& piece) const;
 
+    String get_fen() const;
     bool export_pgn(const StringView& export_path) const;
 
     void resign();

--- a/Games/Chess/ChessWidget.h
+++ b/Games/Chess/ChessWidget.h
@@ -67,6 +67,7 @@ public:
     RefPtr<Gfx::Bitmap> get_piece_graphic(const Chess::Piece& piece) const;
 
     String get_fen() const;
+    bool import_pgn(const StringView& import_path);
     bool export_pgn(const StringView& export_path) const;
 
     void resign();

--- a/Games/Chess/ChessWidget.h
+++ b/Games/Chess/ChessWidget.h
@@ -100,13 +100,40 @@ public:
     void set_coordinates(bool coordinates) { m_coordinates = coordinates; }
     bool coordinates() const { return m_coordinates; }
 
+    struct BoardMarking {
+        Chess::Square from { 50, 50 };
+        Chess::Square to { 50, 50 };
+        bool alternate_color { false };
+        bool secondary_color { false };
+        enum class Type {
+            Square,
+            Arrow,
+            None
+        };
+        Type type() const
+        {
+            if (from.in_bounds() && to.in_bounds() && from != to)
+                return Type::Arrow;
+            else if ((from.in_bounds() && !to.in_bounds()) || (from.in_bounds() && to.in_bounds() && from == to))
+                return Type::Square;
+
+            return Type::None;
+        }
+        bool operator==(const BoardMarking& other) const { return from == other.from && to == other.to; }
+    };
+
 private:
     Chess::Board m_board;
     Chess::Board m_board_playback;
     bool m_playback { false };
     size_t m_playback_move_number { 0 };
+    BoardMarking m_current_marking;
+    Vector<BoardMarking> m_board_markings;
     BoardTheme m_board_theme { "Beige", Color::from_rgb(0xb58863), Color::from_rgb(0xf0d9b5) };
     Color m_move_highlight_color { Color::from_rgba(0x66ccee00) };
+    Color m_marking_primary_color { Color::from_rgba(0x66ff0000) };
+    Color m_marking_alternate_color { Color::from_rgba(0x66ffaa00) };
+    Color m_marking_secondary_color { Color::from_rgba(0x6655dd55) };
     Chess::Colour m_side { Chess::Colour::White };
     HashMap<Chess::Piece, RefPtr<Gfx::Bitmap>> m_pieces;
     String m_piece_set;

--- a/Games/Chess/ChessWidget.h
+++ b/Games/Chess/ChessWidget.h
@@ -46,9 +46,13 @@ public:
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void mouseup_event(GUI::MouseEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;
+    virtual void keydown_event(GUI::KeyEvent&) override;
 
     Chess::Board& board() { return m_board; };
     const Chess::Board& board() const { return m_board; };
+
+    Chess::Board& board_playback() { return m_board_playback; };
+    const Chess::Board& board_playback() const { return m_board_playback; };
 
     Chess::Colour side() const { return m_side; };
     void set_side(Chess::Colour side) { m_side = side; };
@@ -79,6 +83,15 @@ public:
     void set_board_theme(const BoardTheme& theme) { m_board_theme = theme; }
     void set_board_theme(const StringView& name);
 
+    enum class PlaybackDirection {
+        First,
+        Backward,
+        Forward,
+        Last
+    };
+
+    void playback_move(PlaybackDirection);
+
     void set_engine(RefPtr<Engine> engine) { m_engine = engine; }
 
     void maybe_input_engine_move();
@@ -88,6 +101,9 @@ public:
 
 private:
     Chess::Board m_board;
+    Chess::Board m_board_playback;
+    bool m_playback { false };
+    size_t m_playback_move_number { 0 };
     BoardTheme m_board_theme { "Beige", Color::from_rgb(0xb58863), Color::from_rgb(0xf0d9b5) };
     Color m_move_highlight_color { Color::from_rgba(0x66ccee00) };
     Chess::Colour m_side { Chess::Colour::White };

--- a/Games/Chess/main.cpp
+++ b/Games/Chess/main.cpp
@@ -30,6 +30,7 @@
 #include <LibGUI/AboutDialog.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
+#include <LibGUI/Clipboard.h>
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>
@@ -120,6 +121,10 @@ int main(int argc, char** argv)
         }
 
         dbgln("Exported PGN file to {}", export_path.value());
+    }));
+    app_menu.add_action(GUI::Action::create("Copy FEN", { Mod_Ctrl, Key_C }, [&](auto&) {
+        GUI::Clipboard::the().set_data(widget.get_fen().bytes());
+        GUI::MessageBox::show(window, "Board state copied to clipboard as FEN.", "Copy FEN", GUI::MessageBox::Type::Information);
     }));
     app_menu.add_separator();
 

--- a/Games/Chess/main.cpp
+++ b/Games/Chess/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (unveil(Core::StandardPaths::home_directory().characters(), "wcb") < 0) {
+    if (unveil(Core::StandardPaths::home_directory().characters(), "wcbr") < 0) {
         perror("unveil");
         return 1;
     }
@@ -107,7 +107,17 @@ int main(int argc, char** argv)
     app_menu.add_separator();
 
     app_menu.add_action(GUI::Action::create("Import PGN...", { Mod_Ctrl, Key_O }, [&](auto&) {
-        GUI::MessageBox::show(window, "Feature not yet available.", "TODO", GUI::MessageBox::Type::Information);
+        Optional<String> import_path = GUI::FilePicker::get_open_filepath(window);
+
+        if (!import_path.has_value())
+            return;
+
+        if (!widget.import_pgn(import_path.value())) {
+            GUI::MessageBox::show(window, "Unable to import game.\n", "Error", GUI::MessageBox::Type::Error);
+            return;
+        }
+
+        dbgln("Imported PGN file from {}", import_path.value());
     }));
     app_menu.add_action(GUI::Action::create("Export PGN...", { Mod_Ctrl, Key_S }, [&](auto&) {
         Optional<String> export_path = GUI::FilePicker::get_save_filepath(window, "Untitled", "pgn");

--- a/Games/Chess/main.cpp
+++ b/Games/Chess/main.cpp
@@ -100,15 +100,15 @@ int main(int argc, char** argv)
     app_menu.add_action(GUI::Action::create("Resign", { Mod_None, Key_F3 }, [&](auto&) {
         widget.resign();
     }));
-    app_menu.add_action(GUI::Action::create("Flip Board", { Mod_None, Key_F4 }, [&](auto&) {
+    app_menu.add_action(GUI::Action::create("Flip Board", { Mod_Ctrl, Key_F }, [&](auto&) {
         widget.flip_board();
     }));
     app_menu.add_separator();
 
-    app_menu.add_action(GUI::Action::create("Import PGN...", { Mod_None, Key_F6 }, [&](auto&) {
+    app_menu.add_action(GUI::Action::create("Import PGN...", { Mod_Ctrl, Key_O }, [&](auto&) {
         GUI::MessageBox::show(window, "Feature not yet available.", "TODO", GUI::MessageBox::Type::Information);
     }));
-    app_menu.add_action(GUI::Action::create("Export PGN...", { Mod_None, Key_F7 }, [&](auto&) {
+    app_menu.add_action(GUI::Action::create("Export PGN...", { Mod_Ctrl, Key_S }, [&](auto&) {
         Optional<String> export_path = GUI::FilePicker::get_save_filepath(window, "Untitled", "pgn");
 
         if (!export_path.has_value())

--- a/Libraries/LibChess/Chess.h
+++ b/Libraries/LibChess/Chess.h
@@ -139,6 +139,8 @@ public:
     bool apply_move(const Move&, Colour colour = Colour::None);
     const Optional<Move>& last_move() const { return m_last_move; }
 
+    String to_fen() const;
+
     enum class Result {
         CheckMate,
         StaleMate,
@@ -180,6 +182,7 @@ private:
     Colour m_resigned { Colour::None };
     Optional<Move> m_last_move;
     int m_moves_since_capture { 0 };
+    int m_moves_since_pawn_advance { 0 };
 
     bool m_white_can_castle_kingside { true };
     bool m_white_can_castle_queenside { true };

--- a/Libraries/LibChess/Chess.h
+++ b/Libraries/LibChess/Chess.h
@@ -101,6 +101,8 @@ struct Square {
     String to_algebraic() const;
 };
 
+class Board;
+
 struct Move {
     Square from;
     Square to;
@@ -111,7 +113,7 @@ struct Move {
     bool is_capture = false;
     bool is_ambiguous = false;
     Square ambiguous { 50, 50 };
-    Move(const StringView& algebraic);
+    Move(const StringView& long_algebraic);
     Move(const Square& from, const Square& to, const Type& promote_to = Type::None)
         : from(from)
         , to(to)
@@ -120,6 +122,7 @@ struct Move {
     }
     bool operator==(const Move& other) const { return from == other.from && to == other.to && promote_to == other.promote_to; }
 
+    static Move from_algebraic(const StringView& algebraic, const Colour turn, const Board& board);
     String to_long_algebraic() const;
     String to_algebraic() const;
 };


### PR DESCRIPTION
With this PR I'm looking to add some features to SerenityOS Chess that are present in most popular chess platforms, which would make the program more capable.
This includes:
    + Copy board state as FEN string
    + Replay moves and navigate move history with arrow keys
    + Import games using PGN files to replay and analyze them
    + Highlight squares and draw arrows on the board for illustration

Please notify me about any issues you may (and probably will) find, I'm glad to get to them as soon as possible and try to resolve them.   : )