### PR TITLE
UserspaceEmulator: Fix page determination

### DIFF
--- a/DevTools/UserspaceEmulator/SoftMMU.cpp
+++ b/DevTools/UserspaceEmulator/SoftMMU.cpp
@@ -48,8 +48,9 @@ void SoftMMU::add_region(NonnullOwnPtr<Region> region)
         m_shbuf_regions.set(static_cast<SharedBufferRegion*>(region.ptr())->shbuf_id(), region.ptr());
 
     size_t first_page_in_region = region->base() / PAGE_SIZE;
-    for (size_t i = 0; i < ceil_div(region->size(), PAGE_SIZE); ++i) {
-        m_page_to_region_map[first_page_in_region + i] = region.ptr();
+    size_t last_page_in_region = (region->base() + region->size() - 1) / PAGE_SIZE;
+    for (size_t page = first_page_in_region; page <= last_page_in_region; ++page) {
+        m_page_to_region_map[page] = region.ptr();
     }
 
     m_regions.append(move(region));


### PR DESCRIPTION
The last page of ELF headers might be unmapped

I was watching the video about (among other things) the [page-address-to-MMU-region lookup map](https://www.youtube.com/watch?v=vYWMLiZKB-Y) and noticed a corner case that wasn't handled properly: In essence, `SoftMMU::add_region` allocates a number of pages, depending on `region->size()`. Specifically, the expression to calculate it is `ceil_div(region->size(), PAGE_SIZE)`. However, that is not enough information to determine how many pages are actually needed!

Example: A region of 3000 bytes is requested. According to the above formula, only one page is allocated. And that's *usually* correct, as nearly all execution paths end up with a `region->base()` that is at least page-aligned (but only for non-obvious reasons).

However, in the video you stumble upon the one path that is the exception: Program headers. Their base address is fixed by the executable file, and therefore may not be page-aligned. Thus, the first few bytes and the last few bytes of our hypothetical 3000 byte region are not on the same page – but the second page never got registered!

Running `ue true` with some extra `dbgln()` results in this:

```
UserspaceEmulator(24): UE: PT_LOAD to 08048000 with 000226c4 bytes
UserspaceEmulator(24): UE: PT_LOAD to 0806b6c4 with 000048c4 bytes
```

Note that the second(?) header actually exhibits this edge-case! Due to some luck, it does not crash here, presumably because `/bin/true` does not access its header data. Anyway, the *potential* for a crash is not good, so let's get rid of it.