### PR TITLE
Kernel: Fix leaking Timer instances

### DIFF
--- a/Kernel/TimerQueue.h
+++ b/Kernel/TimerQueue.h
@@ -97,7 +97,7 @@ public:
     bool cancel_timer(Timer&);
     bool cancel_timer(NonnullRefPtr<Timer>&& timer)
     {
-        return cancel_timer(timer.leak_ref());
+        return cancel_timer(*move(timer));
     }
     void fire();
 


### PR DESCRIPTION
When a Timer is queued we add a reference, so whenever we remove
a timer or fire it we should drop that reference.

Fixes #4382