### PR TITLE
Spreadsheet: Reduce top bar default height

### DIFF
--- a/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -48,7 +48,7 @@ SpreadsheetWidget::SpreadsheetWidget(NonnullRefPtrVector<Sheet>&& sheets, bool s
 
     auto& top_bar = container.add<GUI::Frame>();
     top_bar.set_layout<GUI::HorizontalBoxLayout>().set_spacing(1);
-    top_bar.set_preferred_size(0, 50);
+    top_bar.set_preferred_size(0, 26);
     top_bar.set_size_policy(GUI::SizePolicy::Fill, GUI::SizePolicy::Fixed);
     auto& current_cell_label = top_bar.add<GUI::Label>("");
     current_cell_label.set_preferred_size(50, 0);


### PR DESCRIPTION
50px is a bit extreme, it's down to 26px high now. Still a bit larger than a regular `GUI::TextBox` but enough to look decent, even with the help button in there.

Closes #3905.

![image](https://user-images.githubusercontent.com/19366641/101991587-b4788600-3ca5-11eb-8cde-16477f0db76d.png)

cc @alimpfard, does this look ok to you?