### PR TITLE
AK::URL: Fix setting the port number in the case it was the last element of the URL

### DIFF
--- a/AK/Tests/TestURL.cpp
+++ b/AK/Tests/TestURL.cpp
@@ -207,4 +207,10 @@ TEST_CASE(trailing_slash_with_complete_url)
     EXPECT_EQ(URL("http://a/b").complete_url("c").to_string(), "http://a/c");
 }
 
+TEST_CASE(trailing_port)
+{
+    URL url("http://example.com:8086");
+    EXPECT_EQ(url.port(), 8086);
+}
+
 TEST_MAIN(URL)

--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -236,6 +236,12 @@ bool URL::parse(const StringView& string)
         m_fragment = String::copy(buffer);
     if (state == State::InDataPayload)
         m_data_payload = urldecode(String::copy(buffer));
+    if (state == State::InPort) {
+        auto port_opt = String::copy(buffer).to_uint();
+        if (port_opt.has_value())
+            m_port = port_opt.value();
+    }
+
     if (m_query.is_null())
         m_query = "";
     if (m_fragment.is_null())


### PR DESCRIPTION
Fixes #4394