### PR TITLE
AK: Fix urlencode() with high byte values

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -93,7 +93,7 @@ static inline bool in_userinfo_set(u32 c)
 String urlencode(const StringView& input)
 {
     StringBuilder builder;
-    for (char ch : input) {
+    for (unsigned char ch : input) {
         if (in_userinfo_set((u8)ch)) {
             builder.append('%');
             builder.appendff("{:02X}", ch);


### PR DESCRIPTION
Previously urlencode() would encode bytes above 127 incorrectly, printing
them as negative hex values.