### PR TITLE
Toolchain: Bump Ubuntu version to 20.10 in the Dockerfile

### DIFF
--- a/Toolchain/Dockerfile
+++ b/Toolchain/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 
 RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y && apt-get install -y tzdata
 
-RUN apt-get install -y build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs qemu-utils wget genext2fs sudo
+RUN apt-get install -y build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs qemu-utils wget genext2fs sudo ninja-build
 
 RUN mkdir /serenity
 


### PR DESCRIPTION
Bumps Ubuntu version to 20.10 on the Dockerfile on Toolchain, since it's easier to get GCC 10.2.0 by default. Also installs ninja.