### PR TITLE
LibTLS: Read subjectAltName from certificates and use it

### DIFF
--- a/Libraries/LibTLS/Certificate.h
+++ b/Libraries/LibTLS/Certificate.h
@@ -66,8 +66,7 @@ struct Certificate {
     String entity;
     String subject;
     String unit;
-    u8** SAN;
-    u16 SAN_length;
+    Vector<String> SAN;
     u8* ocsp;
     Crypto::UnsignedBigInteger serial_number;
     ByteBuffer sign_key;


### PR DESCRIPTION
As quite a few certificates use this extension, reading and using it to
find matching certificates is fairly useful :^)