### PR TITLE
Shell: Make Subshell actually create a subshell / Shell: Set a timeout on Shell-backgrounding

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -138,6 +138,7 @@ if (BUILD_LAGOM)
                 COMMAND shell_lagom "${TEST_PATH}"
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             )
+            set_tests_properties("Shell-${TEST_NAME}" PROPERTIES TIMEOUT 10)
         endforeach()
     endif()
 endif()

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -2055,27 +2055,11 @@ void Sequence::dump(int level) const
 
 RefPtr<Value> Sequence::run(RefPtr<Shell> shell)
 {
-    // If we are to return a job, block on the left one then return the right one.
-    if (would_execute()) {
-        RefPtr<AST::Node> execute_node = create<AST::Execute>(m_left->position(), m_left);
-        auto left_value = execute_node->run(shell);
-        // Some nodes are inherently empty, such as Comments and For loops without bodies,
-        // it is not an error for the value not to be a job.
-        if (left_value && left_value->is_job())
-            shell->block_on_job(static_cast<JobValue*>(left_value.ptr())->job());
-
-        if (m_right->would_execute())
-            return m_right->run(shell);
-
-        execute_node = create<AST::Execute>(m_right->position(), m_right);
-        return execute_node->run(shell);
-    }
-
     auto left = m_left->to_lazy_evaluated_commands(shell);
     // This could happen if a comment is next to a command.
     if (left.size() == 1) {
         auto& command = left.first();
-        if (command.argv.is_empty() && command.redirections.is_empty())
+        if (command.argv.is_empty() && command.redirections.is_empty() && command.next_chain.is_empty())
             return m_right->run(shell);
     }
 
@@ -2139,7 +2123,7 @@ RefPtr<Value> Subshell::run(RefPtr<Shell> shell)
     if (!m_block)
         return create<ListValue>({});
 
-    return m_block->run(shell);
+    return create<AST::CommandSequenceValue>(m_block->to_lazy_evaluated_commands(shell));
 }
 
 void Subshell::highlight_in_editor(Line::Editor& editor, Shell& shell, HighlightMetadata metadata)

--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -1050,7 +1050,6 @@ private:
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual HitTestResult hit_test_position(size_t) override;
     virtual bool is_list() const override { return true; }
-    virtual bool would_execute() const override { return m_left->would_execute() || m_right->would_execute(); }
 
     NonnullRefPtr<Node> m_left;
     NonnullRefPtr<Node> m_right;
@@ -1071,7 +1070,7 @@ private:
     virtual RefPtr<Value> run(RefPtr<Shell>) override;
     virtual void highlight_in_editor(Line::Editor&, Shell&, HighlightMetadata = {}) override;
     virtual HitTestResult hit_test_position(size_t) override;
-    virtual bool would_execute() const override { return true; }
+    virtual bool would_execute() const override { return false; }
 
     RefPtr<AST::Node> m_block;
 };

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -693,7 +693,7 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
         return nullptr;
     }
 
-    auto can_be_run_in_current_process = command.should_wait && !command.pipeline;
+    auto can_be_run_in_current_process = command.should_wait && !command.pipeline && !command.argv.is_empty();
     if (can_be_run_in_current_process && has_function(command.argv.first())) {
         SavedFileDescriptors fds { rewirings };
 


### PR DESCRIPTION
-> https://github.com/SerenityOS/serenity/pull/4410#issuecomment-744592981

Also makes `{ whatever }&` actually work.