### PR TITLE
Breakout: randomize ball start trajectory and position

### DIFF
--- a/Games/Breakout/Game.cpp
+++ b/Games/Breakout/Game.cpp
@@ -168,9 +168,18 @@ void Game::mousemove_event(GUI::MouseEvent& event)
 
 void Game::reset_ball()
 {
+    int position_x_min = (game_width / 2) - 50;
+    int position_x_max = (game_width / 2) + 50;
+    int position_x = arc4random() % (position_x_max - position_x_min + 1) + position_x_min;
+    int position_y = 200;
+    int velocity_x = arc4random() % 3 + 1;
+    int velocity_y = 3 + (3 - velocity_x);
+    if (arc4random() % 2)
+        velocity_x = velocity_x * -1;
+
     m_ball = {};
-    m_ball.position = { 150, 200 };
-    m_ball.velocity = { 3, 3 };
+    m_ball.position = { position_x, position_y };
+    m_ball.velocity = { velocity_x, velocity_y };
 }
 
 void Game::hurt()


### PR DESCRIPTION
The ball X and Y position are no longer hard coded to the following upon initialisation / reset:

```cpp
    m_ball.position = { 150, 200 };
```

The ball X position is now randomized at +/- 50 from the center of the board. The Y position remains at 200.

The ball trajectory is no longer hard coded to the following upon initialisation / reset:

```cpp
    m_ball.velocity = { 3, 3 };
```

Where a X velocity of 3 represented approximately a 45 degree angle to the right (comparatively, -3 would represent a 45 degree angle to the left).

The X velocity is now randomized between -3 and 3 (excluding zero). The Y velocity is adjusted accordingly from a base of 3 based on the X velocity. This is because leaving the Y velocity at 3 results in a slow moving ball when the angle is low. As such, the Y velocity is now `3 + (3 - velocity_x)`.
