### PR TITLE
Userland: Add beep utility

### DIFF
--- a/Base/usr/share/man/man1/beep.md
+++ b/Base/usr/share/man/man1/beep.md
@@ -1,0 +1,19 @@
+## Name
+
+beep - beep the pc speaker
+
+## Synopsis
+
+```sh
+$ beep
+```
+
+## Description
+
+beep allows the user to beep the PC speaker.
+
+## Examples
+
+```sh
+$ beep
+```

--- a/Userland/beep.cpp
+++ b/Userland/beep.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <unistd.h>
+
+int main()
+{
+    sysbeep();
+    return 0;
+}


### PR DESCRIPTION
beep

On my system, both unistd `sysbeep()` and `SC_beep` syscall only create an audible beep when invoked maybe one in 5 times.

If no audible beep is emitted, try opening `Piano`. The beep will play when `Piano` opens.

This issue may be caused by qemu and/or the underlying Ubuntu host OS.

Fortunately, we now have a handy `beep` utility to help debug this!
