### PR TITLE
Shell: Don't run commands with failing redirections

### DIFF
--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -606,7 +606,7 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
         if (rewiring_result.is_error()) {
             if (!rewiring_result.error().is_empty())
                 fprintf(stderr, "error: %s\n", rewiring_result.error().characters());
-            return IterationDecision::Continue;
+            return IterationDecision::Break;
         }
         auto& rewiring = rewiring_result.value();
 


### PR DESCRIPTION
Fixes #3423.

---

cc @alimpfard - this seems too easy to be true, but it also makes sense???