### PR TITLE
LibC: stdlib: Add clearenv() function

### DIFF
--- a/Base/usr/share/man/man3/clearenv.md
+++ b/Base/usr/share/man/man3/clearenv.md
@@ -1,0 +1,34 @@
+## Name
+
+clearenv - clear the environment
+
+## Synopsis
+
+```**c++
+#include <stdlib.h>
+
+clearenv();
+```
+
+## Description
+
+Clears all environment variables and sets the external
+variable `environ` to NULL.
+
+## Return value
+
+The `clearenv()` function returns zero.
+
+## Examples
+
+```c++
+#include <stdlib.h>
+
+int main()
+{
+    clearenv();
+    putenv("PATH=/bin");
+
+    return 0;
+}
+```

--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -289,6 +289,16 @@ int unsetenv(const char* name)
     return 0;
 }
 
+int clearenv()
+{
+    size_t environ_size = 0;
+    for (; environ[environ_size]; ++environ_size) {
+        environ[environ_size] = NULL;
+    }
+    *environ = NULL;
+    return 0;
+}
+
 int setenv(const char* name, const char* value, int overwrite)
 {
     if (!overwrite && getenv(name))

--- a/Libraries/LibC/stdlib.h
+++ b/Libraries/LibC/stdlib.h
@@ -47,6 +47,7 @@ __attribute__((alloc_size(2))) void* realloc(void* ptr, size_t);
 char* getenv(const char* name);
 int putenv(char*);
 int unsetenv(const char*);
+int clearenv(void);
 int setenv(const char* name, const char* value, int overwrite);
 int atoi(const char*);
 long atol(const char*);

--- a/Userland/env.cpp
+++ b/Userland/env.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv)
     for (int idx = 1; idx < argc; ++idx) {
         if (idx == 1) {
             if (StringView { argv[idx] } == "-i" || StringView { argv[idx] } == "--ignore-environment") {
-                *environ = NULL;
+                clearenv();
                 continue;
             }
         }


### PR DESCRIPTION
![env -i](https://user-images.githubusercontent.com/434827/102420219-b9e32100-4055-11eb-9949-b21805e520d6.png)

Part of glibc and old POSIX spec:

* https://linux.die.net/man/3/clearenv

Other implementations for comparison:

* https://github.com/digitalocean/gnulib/blob/master/lib/setenv.c
* https://android.googlesource.com/platform/bionic.git/+/android-4.0.1_r1/libc/bionic/clearenv.c


Public manual pages specify that a return value of zero is used for success and anything else is failure. Yet all implementations I've looked at always return `0`.

**Edit:** I'm not 100% convinced this is a good idea as it pollutes the namespace with a new function name. Other implementations work around this by wrapping the function in `#ifdef LIBC`. On the other hand, specifically nulling each variable in memory is more in line with spec than simply setting `*environ = NULL`, so it's nice to a function for it.
