### PR TITLE
AK: Remove bogus test case for CircularDuplexStream.

### DIFF
--- a/AK/CircularDuplexStream.h
+++ b/AK/CircularDuplexStream.h
@@ -54,7 +54,8 @@ public:
             return false;
         }
 
-        write(bytes);
+        const auto nwritten = write(bytes);
+        ASSERT(nwritten == bytes.size());
         return true;
     }
 

--- a/AK/Tests/TestCircularDuplexStream.cpp
+++ b/AK/Tests/TestCircularDuplexStream.cpp
@@ -60,12 +60,11 @@ TEST_CASE(overwritting_is_well_defined)
     for (size_t idx = 0; idx < capacity; ++idx)
         stream << static_cast<u8>(idx % 256);
 
-    u8 bytes[half_capacity];
-
-    stream >> Bytes { bytes, sizeof(bytes) };
+    Array<u8, half_capacity> buffer;
+    stream >> buffer;
 
     for (size_t idx = 0; idx < half_capacity; ++idx)
-        EXPECT_EQ(bytes[idx], idx % 256);
+        EXPECT_EQ(buffer[idx], idx % 256);
 
     for (size_t idx = 0; idx < half_capacity; ++idx)
         stream << static_cast<u8>(idx % 256);
@@ -81,33 +80,6 @@ TEST_CASE(overwritting_is_well_defined)
     }
 
     EXPECT(stream.eof());
-}
-
-TEST_CASE(of_by_one)
-{
-    constexpr size_t half_capacity = 32;
-    constexpr size_t capacity = half_capacity * 2;
-
-    CircularDuplexStream<capacity> stream;
-
-    for (size_t idx = 0; idx < half_capacity; ++idx)
-        stream << static_cast<u8>(0);
-
-    for (size_t idx = 0; idx < half_capacity; ++idx)
-        stream << static_cast<u8>(1);
-
-    stream.discard_or_error(capacity);
-
-    for (size_t idx = 0; idx < capacity; ++idx) {
-        u8 byte;
-        stream.read({ &byte, sizeof(byte) }, capacity);
-        stream << byte;
-
-        if (idx < half_capacity)
-            EXPECT_EQ(byte, 0);
-        else
-            EXPECT_EQ(byte, 1);
-    }
 }
 
 TEST_MAIN(CircularDuplexStream)


### PR DESCRIPTION
Fixes #4452

Not sure what I was trying to test there exactly, but from what I understand the test does the following:

  - Writing 32 zeroes followed by 32 ones.
  - Discarding 64 bytes (that's everything!)
  - Reading more values from it without checking the return value.
  - Asserting that the value (which failed to be read) was equal to some value.

I am eventually going to clean up the deflate implementation anyways, so if there are issues in `CircularDuplexStream`, I'll surely run into them then. I think it's fairly safe to just remove the test.
