### PR TITLE
LibVT+Terminal: Add the option to disable the bell

### DIFF
--- a/Base/home/anon/.config/Terminal.ini
+++ b/Base/home/anon/.config/Terminal.ini
@@ -2,5 +2,5 @@
 Command=
 [Window]
 Opacity=255
-AudibleBeep=0
+Bell=Visible
 ScrollLength=4

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -812,7 +812,10 @@ void TerminalWidget::terminal_did_resize(u16 columns, u16 rows)
 
 void TerminalWidget::beep()
 {
-    if (m_should_beep) {
+    if (m_bell_mode == BellMode::Disabled) {
+        return;
+    }
+    if (m_bell_mode == BellMode::AudibleBeep) {
         sysbeep();
         return;
     }

--- a/Libraries/LibVT/TerminalWidget.h
+++ b/Libraries/LibVT/TerminalWidget.h
@@ -61,8 +61,15 @@ public:
 
     void set_opacity(u8);
     float opacity() { return m_opacity; };
-    bool should_beep() { return m_should_beep; }
-    void set_should_beep(bool sb) { m_should_beep = sb; };
+
+    enum class BellMode {
+        Visible,
+        AudibleBeep,
+        Disabled
+    };
+
+    BellMode bell_mode() { return m_bell_mode; }
+    void set_bell_mode(BellMode bm) { m_bell_mode = bm; };
 
     RefPtr<Core::ConfigFile> config() const { return m_config; }
 
@@ -151,7 +158,7 @@ private:
     // Snapshot of m_hovered_href when opening a context menu for a hyperlink.
     String m_context_menu_href;
 
-    bool m_should_beep { false };
+    BellMode m_bell_mode { BellMode::Visible };
     bool m_belling { false };
     bool m_alt_key_held { false };
     bool m_rectangle_selection { false };


### PR DESCRIPTION
This adds the option to disable the bell in the terminal settings so the red flash/beep doesnt have to happen.

![20201219_21h52m20s_grim](https://user-images.githubusercontent.com/7910815/102700347-7e5a7980-4244-11eb-8da1-c309cef0e026.png)
