### PR TITLE
Breakout: Add player lives game mechanic and pause functionality

### DIFF
--- a/Games/Breakout/Game.h
+++ b/Games/Breakout/Game.h
@@ -39,6 +39,8 @@ public:
 
     virtual ~Game() override;
 
+    void set_paused(bool paused);
+
 private:
     Game();
 
@@ -94,7 +96,11 @@ private:
         }
     };
 
+    bool m_paused;
+    int m_lives;
     int m_board;
+    long m_pause_count;
+    bool m_cheater;
     Ball m_ball;
     Paddle m_paddle;
     Vector<Brick> m_bricks;

--- a/Games/Breakout/main.cpp
+++ b/Games/Breakout/main.cpp
@@ -59,16 +59,24 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->resize(Breakout::Game::game_width, Breakout::Game::game_height);
+    window->set_resizable(false);
+    window->set_double_buffering_enabled(false);
+    window->set_title("Breakout");
     auto app_icon = GUI::Icon::default_icon("app-breakout");
     window->set_icon(app_icon.bitmap_for_size(16));
-    window->set_title("Breakout");
-    window->set_double_buffering_enabled(false);
-    window->set_main_widget<Breakout::Game>();
+    auto& game = window->set_main_widget<Breakout::Game>();
     window->show();
 
     auto menubar = GUI::MenuBar::construct();
 
     auto& app_menu = menubar->add_menu("Breakout");
+    app_menu.add_action(GUI::Action::create_checkable("Pause", { {}, Key_P }, [&](auto& action) {
+        game.set_paused(action.is_checked());
+        return;
+    }));
+
+    app_menu.add_separator();
+
     app_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
         GUI::Application::the()->quit();
         return;


### PR DESCRIPTION
This PR removes the challenge of exiting Breakout and introduces challenge by limiting the number of player lives (`3` by default).

Prior to this PR, due to the excessive use of messages boxes, attempting to exit Breakout required waiting until the ball was in flight then making a mad dash for the exit. The invisible mouse cursor complicated this dance.

This PR adds pause functionality (by pressing the `P` key) to pause the game and re-enable the mouse cursor.

![Breakout paused](https://user-images.githubusercontent.com/434827/102700213-a2977400-429f-11eb-846b-5d89ceef7058.png)

This introduced the ability to cheat by pause-scumming (excessive use of pausing, or simply holding the `P` key to slow down the game). Primitive cheat detection detects this behavior and informs the player that they have cheated themselves once a threshold of pauses has been met (`50` by default).

![Breakout cheater](https://user-images.githubusercontent.com/434827/102700219-a6c39180-429f-11eb-8100-4da25a8a9ca1.png)
