### PR TITLE
AllOf: Common iterator types

### DIFF
--- a/AK/AllOf.h
+++ b/AK/AllOf.h
@@ -26,9 +26,15 @@
 
 #pragma once
 
+#include <AK/Iterator.h>
+
 namespace AK {
 
-constexpr bool all_of(const auto& begin, const auto& end, const auto& predicate)
+template<typename Container, typename ValueType>
+constexpr bool all_of(
+    const SimpleIterator<Container, ValueType>& begin,
+    const SimpleIterator<Container, ValueType>& end,
+    const auto& predicate)
 {
     for (auto iter = begin; iter != end; ++iter) {
         if (!predicate(*iter)) {


### PR DESCRIPTION
Problem:
- Interface is too permissive. It permits iterators of different types
  as long as they are comparable.

Solution:
- Require iterators be the same type.