### PR TITLE
Ports: Add initial stress-ng port to find bugs in serenity

### DIFF
--- a/Libraries/LibC/inttypes.h
+++ b/Libraries/LibC/inttypes.h
@@ -65,3 +65,6 @@
 #define SCNdMAX __PRI64_PREFIX "d"
 #define SCNoMAX __PRI64_PREFIX "o"
 #define SCNuMAX __PRI64_PREFIX "u"
+
+#define SCNu64 __PRI64_PREFIX "u"
+#define SCNd64 __PRI64_PREFIX "d"

--- a/Ports/stress-ng/package.sh
+++ b/Ports/stress-ng/package.sh
@@ -1,0 +1,10 @@
+#!/bin/bash ../.port_include.sh
+port=stress-ng
+version=0.11.23
+workdir=stress-ng-${version}
+files="https://github.com/ColinIanKing/stress-ng/archive/V${version}.tar.gz stress-ng-${version}.tar.gz"
+installopts="DESTDIR=$SERENITY_ROOT/Build/Root"
+
+build() {
+    run make STATIC=1
+}

--- a/Ports/stress-ng/patches/0001-build-sytem-patch.diff
+++ b/Ports/stress-ng/patches/0001-build-sytem-patch.diff
@@ -1,0 +1,130 @@
+diff -ur stress-ng-master/Makefile stress-ng-master-2/Makefile
+--- stress-ng-master/Makefile	2020-11-07 10:52:22.000000000 -0800
++++ stress-ng-master-2/Makefile	2020-11-08 23:36:28.587668500 -0800
+@@ -21,7 +21,7 @@
+ # Codename "synthetic system strainer"
+ #
+ 
+-CFLAGS += -Wall -Wextra -DVERSION='"$(VERSION)"' -O2 -std=gnu99
++CFLAGS += -Wall -Wextra -DVERSION='"$(VERSION)"' -O2 -std=gnu99 -Wno-old-style-declaration
+ 
+ #
+ # Pedantic flags
+@@ -89,7 +89,6 @@
+ 	stress-close.c \
+ 	stress-context.c \
+ 	stress-copy-file.c \
+-	stress-cpu.c \
+ 	stress-cpu-online.c \
+ 	stress-crypt.c \
+ 	stress-cyclic.c \
+@@ -99,7 +98,6 @@
+ 	stress-dev.c \
+ 	stress-dev-shm.c \
+ 	stress-dir.c \
+-	stress-dirdeep.c \
+ 	stress-dnotify.c \
+ 	stress-dup.c \
+ 	stress-dynlib.c \
+@@ -132,19 +130,16 @@
+ 	stress-hdd.c \
+ 	stress-heapsort.c \
+ 	stress-hrtimers.c \
+-	stress-hsearch.c \
+ 	stress-icache.c \
+ 	stress-icmp-flood.c \
+ 	stress-idle-page.c \
+ 	stress-inode-flags.c \
+ 	stress-inotify.c \
+-	stress-iomix.c \
+ 	stress-ioport.c \
+ 	stress-ioprio.c \
+ 	stress-iosync.c \
+ 	stress-io-uring.c \
+ 	stress-ipsec-mb.c \
+-	stress-itimer.c \
+ 	stress-judy.c \
+ 	stress-kcmp.c \
+ 	stress-key.c \
+@@ -158,7 +153,6 @@
+ 	stress-lockofd.c \
+ 	stress-longjmp.c \
+ 	stress-loop.c \
+-	stress-lsearch.c \
+ 	stress-madvise.c \
+ 	stress-malloc.c \
+ 	stress-matrix.c \
+@@ -222,22 +216,16 @@
+ 	stress-rename.c \
+ 	stress-resources.c \
+ 	stress-revio.c \
+-	stress-rlimit.c \
+-	stress-rmap.c \
+ 	stress-rtc.c \
+ 	stress-sctp.c \
+-	stress-schedpolicy.c \
+ 	stress-seal.c \
+ 	stress-seccomp.c \
+ 	stress-seek.c \
+ 	stress-sem.c \
+-	stress-sem-sysv.c \
+ 	stress-sendfile.c \
+ 	stress-session.c \
+-	stress-set.c \
+ 	stress-shellsort.c \
+ 	stress-shm.c \
+-	stress-shm-sysv.c \
+ 	stress-sigabrt.c \
+ 	stress-sigchld.c \
+ 	stress-sigfd.c \
+@@ -257,7 +245,6 @@
+ 	stress-sockabuse.c \
+ 	stress-sockdiag.c \
+ 	stress-sockfd.c \
+-	stress-sockpair.c \
+ 	stress-sockmany.c \
+ 	stress-softlockup.c \
+ 	stress-spawn.c \
+@@ -269,7 +256,6 @@
+ 	stress-swap.c \
+ 	stress-switch.c \
+ 	stress-sync-file.c \
+-	stress-sysbadaddr.c \
+ 	stress-sysinfo.c \
+ 	stress-sysinval.c \
+ 	stress-sysfs.c \
+@@ -280,7 +266,6 @@
+ 	stress-tmpfs.c \
+ 	stress-tree.c \
+ 	stress-tsc.c \
+-	stress-tsearch.c \
+ 	stress-tun.c \
+ 	stress-udp.c \
+ 	stress-udp-flood.c \
+@@ -288,11 +273,9 @@
+ 	stress-uprobe.c \
+ 	stress-urandom.c \
+ 	stress-userfaultfd.c \
+-	stress-utime.c \
+ 	stress-vdso.c \
+ 	stress-vecmath.c \
+ 	stress-verity.c \
+-	stress-vforkmany.c \
+ 	stress-vm.c \
+ 	stress-vm-addr.c \
+ 	stress-vm-rw.c \
+@@ -474,12 +457,6 @@
+ 	./stress-ng --seq 0 -t 15 --pathological --verbose --times --tz --metrics
+ 
+ .PHONY: install
+-install: stress-ng stress-ng.1.gz
++install: stress-ng
+ 	mkdir -p ${DESTDIR}${BINDIR}
+ 	cp stress-ng ${DESTDIR}${BINDIR}
+-	mkdir -p ${DESTDIR}${MANDIR}
+-	cp stress-ng.1.gz ${DESTDIR}${MANDIR}
+-	mkdir -p ${DESTDIR}${JOBDIR}
+-	cp -rp example-jobs/*.job ${DESTDIR}${JOBDIR}
+-	mkdir -p ${DESTDIR}${BASHDIR}
+-	cp bash-completion/stress-ng ${DESTDIR}${BASHDIR}
+

--- a/Ports/stress-ng/patches/0002-missing-types-and-functionality.diff
+++ b/Ports/stress-ng/patches/0002-missing-types-and-functionality.diff
@@ -1,0 +1,177 @@
+diff -ur stress-ng-master/core-helper.c stress-ng-master-2/core-helper.c
+--- stress-ng-master/core-helper.c	2020-11-07 10:52:22.000000000 -0800
++++ stress-ng-master-2/core-helper.c	2020-11-08 23:17:03.777668500 -0800
+@@ -1102,7 +1102,7 @@
+  */
+ uint64_t stress_get_prime64(const uint64_t n)
+ {
+-	static uint p = 1009;
++	static uint64_t p = 1009;
+ 
+ 	if (n != p)
+ 		return p;
+@@ -1149,6 +1149,9 @@
+  */
+ size_t stress_get_file_limit(void)
+ {
++	/* Just return a constant for serenity */
++	return 65536;
++#if 0
+ 	struct rlimit rlim;
+ 	size_t i, opened = 0, max = 65536;	/* initial guess */
+ 
+@@ -1161,6 +1164,7 @@
+ 			opened++;
+ 	}
+ 	return max - opened;
++#endif
+ }
+ 
+ /*
+@@ -2026,3 +2030,8 @@
+ 	return 0;
+ #endif
+ }
++
++int pause(void)
++{
++	asm ("pause");
++}
+diff -ur stress-ng-master/core-job.c stress-ng-master-2/core-job.c
+--- stress-ng-master/core-job.c	2020-11-07 10:52:22.000000000 -0800
++++ stress-ng-master-2/core-job.c	2020-11-08 22:32:06.607668500 -0800
+@@ -28,7 +28,7 @@
+ #define RUN_SEQUENTIAL	(0x01)
+ #define RUN_PARALLEL	(0x02)
+ 
+-#define ISBLANK(ch)	isblank((int)(ch))
++#define ISBLANK(ch)	(ch == ' ' || ch == '\t')
+ 
+ /*
+  *  stress_chop()
+diff -ur stress-ng-master/core-limit.c stress-ng-master-2/core-limit.c
+--- stress-ng-master/core-limit.c	2020-11-07 10:52:22.000000000 -0800
++++ stress-ng-master-2/core-limit.c	2020-11-08 22:32:39.497668500 -0800
+@@ -80,6 +80,7 @@
+  */
+ void stress_set_max_limits(void)
+ {
++#if 0
+ 	size_t i;
+ 	struct rlimit rlim;
+ 
+@@ -90,6 +91,7 @@
+ 		(void)setrlimit(limits[i], &rlim);
+ 	}
+ 
++#endif
+ #if defined(RLIMIT_NOFILE)
+ 	{
+ 		uint64_t max_fd = 0;
+diff -ur stress-ng-master/core-net.c stress-ng-master-2/core-net.c
+--- stress-ng-master/core-net.c	2020-11-07 10:52:22.000000000 -0800
++++ stress-ng-master-2/core-net.c	2020-11-08 22:33:09.007668500 -0800
+@@ -32,7 +32,6 @@
+ 
+ static const stress_domain_t domains[] = {
+ 	{ "ipv4",	AF_INET,	DOMAIN_INET },
+-	{ "ipv6",	AF_INET6,	DOMAIN_INET6 },
+ 	{ "unix",	AF_UNIX,	DOMAIN_UNIX },
+ };
+ 
+diff -ur stress-ng-master/core-sched.c stress-ng-master-2/core-sched.c
+--- stress-ng-master/core-sched.c	2020-11-07 10:52:22.000000000 -0800
++++ stress-ng-master-2/core-sched.c	2020-11-08 23:21:44.497668500 -0800
+@@ -263,6 +263,7 @@
+ 			pr_dbg("%s: setting scheduler class '%s'\n", prefix, sched_name);
+ 		break;
+ 	}
++#if 0
+ 	rc = sched_setscheduler(pid, sched, &param);
+ 	if (rc < 0) {
+ 		rc = -errno;
+@@ -273,6 +274,7 @@
+ 				errno, strerror(errno));
+ 		return rc;
+ 	}
++#endif
+ 	return 0;
+ }
+ #endif
+diff -ur stress-ng-master/stress-chown.c stress-ng-master-2/stress-chown.c
+--- stress-ng-master/stress-chown.c	2020-11-07 10:52:22.000000000 -0800
++++ stress-ng-master-2/stress-chown.c	2020-11-08 22:35:41.107668500 -0800
+@@ -219,6 +219,9 @@
+ 				pr_fail("%s: chown %s failed, errno=%d (%s)\n",
+ 					args->name, filename, errno, strerror(errno));
+ 		}
++
++/* No lchown support in serenity */
++#if 0
+ 		ret = do_chown(lchown, filename, cap_chown, uid, gid);
+ 		if (ret < 0) {
+ 			if (ret == -ENOENT || ret == -ENOTDIR) {
+@@ -233,6 +236,7 @@
+ 				pr_fail("%s: chown %s failed, errno=%d (%s)\n",
+ 					args->name, filename, errno, strerror(errno));
+ 		}
++#endif
+ 		inc_counter(args);
+ 	} while (keep_stressing());
+ 
+diff -ur stress-ng-master/stress-cyclic.c stress-ng-master-2/stress-cyclic.c
+--- stress-ng-master/stress-cyclic.c	2020-11-07 10:52:22.000000000 -0800
++++ stress-ng-master-2/stress-cyclic.c	2020-11-08 22:37:33.407668500 -0800
+@@ -587,7 +587,11 @@
+ 	const stress_cyclic_method_info_t *cyclic_method = &cyclic_methods[0];
+ 	const uint32_t num_instances = args->num_instances;
+ 	struct sigaction old_action_xcpu;
++
++/* No RLIMIT_CPU support in serenity */
++#if 0
+ 	struct rlimit rlim;
++#endif
+ 	pid_t pid;
+ 	NOCLOBBER uint64_t timeout;
+ 	uint64_t cyclic_sleep = DEFAULT_DELAY_NS;
+@@ -692,6 +696,8 @@
+ 		} while (keep_stressing() && count < num_instances);
+ #endif
+ 
++/* No RLIMIT_CPU support in serenity */
++#if 0
+ 		/*
+ 		 * We run the stressor as a child so that
+ 		 * if we the hard time timits the child is
+@@ -701,6 +707,7 @@
+ 		rlim.rlim_cur = timeout;
+ 		rlim.rlim_max = timeout;
+ 		(void)setrlimit(RLIMIT_CPU, &rlim);
++#endif
+ 
+ #if defined(RLIMIT_RTTIME)
+ 		rlim.rlim_cur = 1000000 * timeout;
+diff -ur stress-ng-master/stress-dirdeep.c stress-ng-master-2/stress-dirdeep.c
+--- stress-ng-master/stress-dirdeep.c	2020-11-07 10:52:22.000000000 -0800
++++ stress-ng-master-2/stress-dirdeep.c	2020-11-08 22:38:40.877668500 -0800
+@@ -98,7 +98,7 @@
+ 	errno = 0;
+ 	if (mkdir(path, S_IRUSR | S_IWUSR | S_IXUSR) < 0) {
+ 		if ((errno == ENOSPC) || (errno == ENOMEM) ||
+-		    (errno == ENAMETOOLONG) || (errno == EDQUOT) ||
++		    (errno == ENAMETOOLONG) ||
+ 		    (errno == EMLINK)) {
+ 			return;
+ 		}
+diff -ur stress-ng-master/stress-epoll.c stress-ng-master-2/stress-epoll.c
+--- stress-ng-master/stress-epoll.c	2020-11-07 10:52:22.000000000 -0800
++++ stress-ng-master-2/stress-epoll.c	2020-11-08 22:39:49.607668500 -0800
+@@ -85,7 +85,6 @@
+ 
+ 	switch (epoll_domain) {
+ 	case AF_INET:
+-	case AF_INET6:
+ 		max_servers = 4;
+ 		break;
+ 	case AF_UNIX:
+

--- a/Ports/stress-ng/patches/0003-missing-networking-functionality.diff
+++ b/Ports/stress-ng/patches/0003-missing-networking-functionality.diff
@@ -1,0 +1,96 @@
+diff -ur a/stress-sock.c b/stress-sock.c
+--- a/stress-sock.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-sock.c	2020-11-08 22:51:33.327668500 -0800
+@@ -422,7 +422,7 @@
+ 					&cpu, &optlen);
+ 			}
+ #endif
+-			if (socket_domain == AF_INET || socket_domain == AF_INET6) {
++			if (socket_domain == AF_INET) {
+ 				int val, ret;
+ 				socklen_t optlen;
+ 
+@@ -756,6 +756,8 @@
+ 				(void)close(sfd);
+ 				break;
+ 			}
++
++#if defined(SO_SNDBUF)
+ 			len = sizeof(sndbuf);
+ 			if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, &len) < 0) {
+ 				pr_fail("%s: getsockopt failed, errno=%d (%s)\n",
+@@ -763,6 +765,8 @@
+ 				(void)close(sfd);
+ 				break;
+ 			}
++#endif
++
+ #if defined(SOL_TCP) && defined(TCP_QUICKACK)
+ 			{
+ 				int ret, one = 1;
+diff -ur a/stress-sockabuse.c b/stress-sockabuse.c
+--- a/stress-sockabuse.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-sockabuse.c	2020-11-08 22:52:27.297668500 -0800
+@@ -278,6 +278,7 @@
+ 					(void)close(sfd);
+ 					break;
+ 				}
++#if defined(SO_SNDBUF)
+ 				len = sizeof(sndbuf);
+ 				if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, &len) < 0) {
+ 					pr_fail("%s: getsockopt failed, errno=%d (%s)\n",
+@@ -285,6 +286,7 @@
+ 					(void)close(sfd);
+ 					break;
+ 				}
++#endif
+ 				(void)memset(buf, 'A' + (get_counter(args) % 26), sizeof(buf));
+ 
+ 				n = send(sfd, buf, sizeof(buf), 0);
+diff -ur a/stress-sockmany.c b/stress-sockmany.c
+--- a/stress-sockmany.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-sockmany.c	2020-11-08 22:53:06.247668500 -0800
+@@ -221,6 +221,7 @@
+ 				(void)close(sfd);
+ 				break;
+ 			}
++#if defined(SO_SNDBUF)
+ 			len = sizeof(sndbuf);
+ 			if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, &len) < 0) {
+ 				pr_fail("%s: getsockopt failed, errno=%d (%s)\n",
+@@ -228,6 +229,8 @@
+ 				(void)close(sfd);
+ 				break;
+ 			}
++#endif
++
+ #if defined(SOL_TCP) && defined(TCP_QUICKACK)
+ 			{
+ 				int ret, one = 1;
+diff -ur a/stress-resources.c b/stress-resources.c
+--- a/stress-resources.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-resources.c	2020-11-08 23:20:35.227668500 -0800
+@@ -130,7 +130,7 @@
+ 	size_t i, n;
+ 	size_t shmall, freemem, totalmem, freeswap;
+ 	const pid_t pid = getpid();
+-	static const int domains[] = { AF_INET, AF_INET6 };
++	static const int domains[] = { AF_INET };
+ 	static const int types[] = { SOCK_STREAM, SOCK_DGRAM };
+ 	static stress_info_t info[MAX_LOOPS];
+ #if defined(O_NOATIME)
+@@ -309,11 +309,13 @@
+ 		if (!keep_stressing_flag())
+ 			break;
+ 
++#if 0
+ 		if (socketpair(AF_UNIX, SOCK_STREAM, 0,
+ 			info[i].fd_socketpair) < 0) {
+ 			info[i].fd_socketpair[0] = -1;
+ 			info[i].fd_socketpair[1] = -1;
+ 		}
++#endif
+ 
+ #if defined(HAVE_USERFAULTFD)
+ 		info[i].fd_uf = shim_userfaultfd(0);
+d

--- a/Ports/stress-ng/patches/0004-memory-related.diff
+++ b/Ports/stress-ng/patches/0004-memory-related.diff
@@ -1,0 +1,110 @@
+diff -ur a/stress-stack.c b/stress-stack.c
+--- a/stress-stack.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-stack.c	2020-11-08 22:55:15.567668500 -0800
+@@ -98,6 +98,7 @@
+ {
+ 	char *start_ptr = shim_sbrk(0);
+ 	void *altstack;
++	size_t SIGSTKSZ = 9000;
+ 	ssize_t altstack_size = (SIGSTKSZ +
+ 				 STACK_ALIGNMENT +
+ 				 args->page_size) & ~(args->page_size -1);
+diff -ur a/stress-str.c b/stress-str.c
+--- a/stress-str.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-str.c	2020-11-08 22:55:55.887668500 -0800
+@@ -597,8 +597,6 @@
+ 	{ "all",		stress_str_all,		NULL },	/* Special "all test */
+ 
+ #if defined(HAVE_STRINGS_H)
+-	{ "index",		stress_index,		index },
+-	{ "rindex",		stress_rindex,		rindex  },
+ 	{ "strcasecmp",		stress_strcasecmp,	strcasecmp },
+ #endif
+ #if defined(HAVE_STRLCAT)
+diff -ur a/stress-vm.c b/stress-vm.c
+--- a/stress-vm.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-vm.c	2020-11-08 22:58:41.267668500 -0800
+@@ -2124,7 +2124,7 @@
+ 
+ 	ret = stress_oomable_child(args, &context, stress_vm_child, STRESS_OOMABLE_NORMAL);
+ 
+-	(void)shim_msync(context.bit_error_count, page_size, MS_SYNC);
++	(void)shim_msync(context.bit_error_count, page_size, 0);
+ 	if (*context.bit_error_count > 0) {
+ 		pr_fail("%s: detected %" PRIu64 " bit errors while "
+ 			"stressing memory\n",
+diff -ur a/stress-sigsegv.c b/stress-sigsegv.c
+--- a/stress-sigsegv.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-sigsegv.c	2020-11-08 22:50:22.327668500 -0800
+@@ -143,11 +143,13 @@
+ 				pr_fail("%s: expecting SIGSEGV/SIGILL/SIGBUS, got %s instead\n",
+ 					args->name, strsignal(signo));
+ 			}
++#if 0
+ 			if (verify && (signo == SIGBUS) && (code != SEGV_ACCERR)) {
+ 				pr_fail("%s: expecting SIGBUS si_code SEGV_ACCERR (%d), got %d instead\n",
+ 					args->name, SEGV_ACCERR, code);
+ 			}
+ #endif
++#endif
+ 			inc_counter(args);
+ 		} else {
+ #if defined(SA_SIGINFO)
+diff -ur a/stress-link.c b/stress-link.c
+--- a/stress-link.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-link.c	2020-11-08 22:44:34.267668500 -0800
+@@ -97,8 +97,7 @@
+ 			(void)stress_temp_filename_args(args,
+ 				newpath, sizeof(newpath), i);
+ 			if (linkfunc(oldpath, newpath) < 0) {
+-				if ((errno == EDQUOT) ||
+-				    (errno == ENOMEM) ||
++				if ((errno == ENOMEM) ||
+ 				    (errno == ENOSPC)) {
+ 					/* Try again */
+ 					continue;
+diff -ur a/stress-mmap.c b/stress-mmap.c
+--- a/stress-mmap.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-mmap.c	2020-11-08 22:45:51.767668500 -0800
+@@ -243,7 +243,9 @@
+ 	const bool mmap_file = context->mmap_file;
+ 	const int fd = context->fd;
+ 	int no_mem_retries = 0;
++#if 0
+ 	const int ms_flags = context->mmap_async ? MS_ASYNC : MS_SYNC;
++#endif
+ 	uint8_t *mapped, **mappings;
+ 
+ 	mapped = calloc(pages4k, sizeof(*mapped));
+@@ -322,7 +324,7 @@
+ 		no_mem_retries = 0;
+ 		if (mmap_file) {
+ 			(void)memset(buf, 0xff, sz);
+-			(void)shim_msync((void *)buf, sz, ms_flags);
++			(void)shim_msync((void *)buf, sz, 0);
+ 		}
+ 		(void)stress_madvise_random(buf, sz);
+ 		(void)stress_mincore_touch_pages(buf, context->mmap_bytes);
+@@ -424,7 +426,7 @@
+ 								"not contain expected data\n", args->name, page_size);
+ 						if (mmap_file) {
+ 							(void)memset(mappings[page], n, page_size);
+-							(void)shim_msync((void *)mappings[page], page_size, ms_flags);
++							(void)shim_msync((void *)mappings[page], page_size, 0);
+ #if defined(FALLOC_FL_KEEP_SIZE) && defined(FALLOC_FL_PUNCH_HOLE)
+ 							(void)shim_fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+ 								offset, page_size);
+diff -ur a/stress-mmapmany.c b/stress-mmapmany.c
+--- a/stress-mmapmany.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-mmapmany.c	2020-11-08 22:47:27.567668500 -0800
+@@ -35,7 +35,8 @@
+ static int stress_mmapmany_child(const stress_args_t *args, void *context)
+ {
+ 	const size_t page_size = args->page_size;
+-	ssize_t max = sysconf(_SC_MAPPED_FILES);
++	/* Just make up a constant for Serenity */
++	ssize_t max = 6400; 
+ 	uint8_t **mappings;
+ 	max = STRESS_MAXIMUM(max, MMAP_MAX);
+ 
+d

--- a/Ports/stress-ng/patches/0005-misc-fixups.diff
+++ b/Ports/stress-ng/patches/0005-misc-fixups.diff
@@ -1,0 +1,581 @@
+diff -ur a/stress-fork.c b/stress-fork.c
+--- a/stress-fork.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-fork.c	2020-11-08 23:05:17.627668500 -0800
+@@ -198,6 +198,7 @@
+ }
+ 
+ 
++#if 0
+ /*
+  *  stress_vfork()
+  *	stress by vforking and exiting
+@@ -218,16 +219,13 @@
+ 	return stress_fork_fn(args, vfork, "vfork", vfork_max);
+ }
+ STRESS_PRAGMA_POP
++#endif
+ 
+ static const stress_opt_set_func_t fork_opt_set_funcs[] = {
+ 	{ OPT_fork_max,		stress_set_fork_max },
+ 	{ 0,			NULL }
+ };
+ 
+-static const stress_opt_set_func_t vfork_opt_set_funcs[] = {
+-	{ OPT_vfork_max,	stress_set_vfork_max },
+-	{ 0,			NULL }
+-};
+ 
+ stressor_info_t stress_fork_info = {
+ 	.stressor = stress_fork,
+@@ -236,9 +234,16 @@
+ 	.help = fork_help
+ };
+ 
++#if 0
++static const stress_opt_set_func_t vfork_opt_set_funcs[] = {
++	{ OPT_vfork_max,	stress_set_vfork_max },
++	{ 0,			NULL }
++};
++
+ stressor_info_t stress_vfork_info = {
+ 	.stressor = stress_vfork,
+ 	.class = CLASS_SCHEDULER | CLASS_OS,
+ 	.opt_set_funcs = vfork_opt_set_funcs,
+ 	.help = vfork_help
+ };
++#endif
+diff -ur a/stress-get.c b/stress-get.c
+--- a/stress-get.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-get.c	2020-11-08 22:42:06.027668500 -0800
+@@ -162,7 +162,9 @@
+ #endif
+ 		struct timeval tv;
+ 		struct timezone tz;
++#if 0
+ 		struct rlimit rlim;
++#endif
+ 		time_t t, t1, t2;
+ 		pid_t pid;
+ 		gid_t gid;
+@@ -324,6 +326,8 @@
+ 			check_do_run();
+ 		}
+ #endif
++
++#if 0
+ 		/* Invalid getrlimit syscall and ignoring failure */
+ 		(void)getrlimit(INT_MAX, &rlim);
+ 
+@@ -334,6 +338,7 @@
+ 					args->name, i, errno, strerror(errno));
+ 			check_do_run();
+ 		}
++#endif 0
+ 
+ #if defined(__NR_ugetrlimit)
+ 		/*
+diff -ur a/stress-hdd.c b/stress-hdd.c
+--- a/stress-hdd.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-hdd.c	2020-11-08 23:19:59.907668500 -0800
+@@ -277,11 +277,11 @@
+ #endif
+ 		default:
+ 			/* 50% */
+-			return readv(fd, iov, HDD_IO_VEC_MAX);
++			break;
+ 		}
+-	} else {
+-		return read(fd, buf, count);
+-	}
++	} 
++
++	return read(fd, buf, count);
+ }
+ 
+ 
+diff -ur a/stress-ng.c b/stress-ng.c
+--- a/stress-ng.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-ng.c	2020-11-08 23:29:08.447668500 -0800
+@@ -321,10 +321,6 @@
+ 	{ "dir",	1,	0,	OPT_dir },
+ 	{ "dir-ops",	1,	0,	OPT_dir_ops },
+ 	{ "dir-dirs",	1,	0,	OPT_dir_dirs },
+-	{ "dirdeep",	1,	0,	OPT_dirdeep },
+-	{ "dirdeep-ops",1,	0,	OPT_dirdeep_ops },
+-	{ "dirdeep-dirs",1,	0,	OPT_dirdeep_dirs },
+-	{ "dirdeep-inodes",1,	0,	OPT_dirdeep_inodes },
+ 	{ "dry-run",	0,	0,	OPT_dry_run },
+ 	{ "dnotify",	1,	0,	OPT_dnotify },
+ 	{ "dnotify-ops",1,	0,	OPT_dnotify_ops },
+@@ -409,9 +405,6 @@
+ 	{ "hrtimers",	1,	0,	OPT_hrtimers },
+ 	{ "hrtimers-ops",1,	0,	OPT_hrtimers_ops },
+ 	{ "help",	0,	0,	OPT_help },
+-	{ "hsearch",	1,	0,	OPT_hsearch },
+-	{ "hsearch-ops",1,	0,	OPT_hsearch_ops },
+-	{ "hsearch-size",1,	0,	OPT_hsearch_size },
+ 	{ "icache",	1,	0,	OPT_icache },
+ 	{ "icache-ops",	1,	0,	OPT_icache_ops },
+ 	{ "icmp-flood",	1,	0,	OPT_icmp_flood },
+@@ -425,9 +418,6 @@
+ 	{ "inotify-ops",1,	0,	OPT_inotify_ops },
+ 	{ "io",		1,	0,	OPT_io },
+ 	{ "io-ops",	1,	0,	OPT_io_ops },
+-	{ "iomix",	1,	0,	OPT_iomix },
+-	{ "iomix-bytes",1,	0,	OPT_iomix_bytes },
+-	{ "iomix-ops",	1,	0,	OPT_iomix_ops },
+ 	{ "ionice-class",1,	0,	OPT_ionice_class },
+ 	{ "ionice-level",1,	0,	OPT_ionice_level },
+ 	{ "ioport",	1,	0,	OPT_ioport },
+@@ -440,10 +430,6 @@
+ 	{ "ipsec-mb",	1,	0,	OPT_ipsec_mb },
+ 	{ "ipsec-mb-ops",1,	0,	OPT_ipsec_mb_ops },
+ 	{ "ipsec-mb-feature",1,	0,	OPT_ipsec_mb_feature },
+-	{ "itimer",	1,	0,	OPT_itimer },
+-	{ "itimer-ops",	1,	0,	OPT_itimer_ops },
+-	{ "itimer-freq",1,	0,	OPT_itimer_freq },
+-	{ "itimer-rand",0,	0,	OPT_itimer_rand },
+ 	{ "job",	1,	0,	OPT_job },
+ 	{ "judy",	1,	0,	OPT_judy },
+ 	{ "judy-ops",	1,	0,	OPT_judy_ops },
+@@ -477,9 +463,6 @@
+ 	{ "longjmp-ops",1,	0,	OPT_longjmp_ops },
+ 	{ "loop",	1,	0,	OPT_loop },
+ 	{ "loop-ops",	1,	0,	OPT_loop_ops },
+-	{ "lsearch",	1,	0,	OPT_lsearch },
+-	{ "lsearch-ops",1,	0,	OPT_lsearch_ops },
+-	{ "lsearch-size",1,	0,	OPT_lsearch_size },
+ 	{ "madvise",	1,	0,	OPT_madvise },
+ 	{ "madvise-ops",1,	0,	OPT_madvise_ops },
+ 	{ "malloc",	1,	0,	OPT_malloc },
+@@ -669,21 +652,14 @@
+ 	{ "revio-ops",	1,	0,	OPT_revio_ops },
+ 	{ "revio-opts",	1,	0,	OPT_revio_opts },
+ 	{ "revio-bytes",1,	0,	OPT_revio_bytes },
+-	{ "rlimit",	1,	0,	OPT_rlimit },
+-	{ "rlimit-ops",	1,	0,	OPT_rlimit_ops },
+-	{ "rmap",	1,	0,	OPT_rmap },
+-	{ "rmap-ops",	1,	0,	OPT_rmap_ops },
+ 	{ "rtc",	1,	0,	OPT_rtc },
+ 	{ "rtc-ops",	1,	0,	OPT_rtc_ops },
+ 	{ "sched",	1,	0,	OPT_sched },
+ 	{ "sched-prio",	1,	0,	OPT_sched_prio },
+-	{ "schedpolicy",1,	0,	OPT_schedpolicy },
+-	{ "schedpolicy-ops",1,	0,	OPT_schedpolicy_ops },
+ 	{ "sched-period",1,	0,	OPT_sched_period },
+ 	{ "sched-runtime",1,	0,	OPT_sched_runtime },
+ 	{ "sched-deadline",1,	0,	OPT_sched_deadline },
+ 	{ "sched-reclaim",0,    0,      OPT_sched_reclaim },
+-	{ "schedpolicy",1,	0,	OPT_schedpolicy },
+ 	{ "sctp",	1,	0,	OPT_sctp },
+ 	{ "sctp-ops",	1,	0,	OPT_sctp_ops },
+ 	{ "sctp-domain",1,	0,	OPT_sctp_domain },
+@@ -699,17 +675,12 @@
+ 	{ "sem",	1,	0,	OPT_sem },
+ 	{ "sem-ops",	1,	0,	OPT_sem_ops },
+ 	{ "sem-procs",	1,	0,	OPT_sem_procs },
+-	{ "sem-sysv",	1,	0,	OPT_sem_sysv },
+-	{ "sem-sysv-ops",1,	0,	OPT_sem_sysv_ops },
+-	{ "sem-sysv-procs",1,	0,	OPT_sem_sysv_procs },
+ 	{ "sendfile",	1,	0,	OPT_sendfile },
+ 	{ "sendfile-ops",1,	0,	OPT_sendfile_ops },
+ 	{ "sendfile-size",1,	0,	OPT_sendfile_size },
+ 	{ "sequential",	1,	0,	OPT_sequential },
+ 	{ "session",	1,	0,	OPT_session },
+ 	{ "session-ops",1,	0,	OPT_session_ops },
+-	{ "set",	1,	0,	OPT_set },
+-	{ "set-ops",	1,	0,	OPT_set_ops },
+ 	{ "shellsort",	1,	0,	OPT_shellsort },
+ 	{ "shellsort-ops",1,	0,	OPT_shellsort_ops },
+ 	{ "shellsort-size",1,	0,	OPT_shellsort_integers },
+@@ -717,10 +688,6 @@
+ 	{ "shm-ops",	1,	0,	OPT_shm_ops },
+ 	{ "shm-bytes",	1,	0,	OPT_shm_bytes },
+ 	{ "shm-objs",	1,	0,	OPT_shm_objects },
+-	{ "shm-sysv",	1,	0,	OPT_shm_sysv },
+-	{ "shm-sysv-ops",1,	0,	OPT_shm_sysv_ops },
+-	{ "shm-sysv-bytes",1,	0,	OPT_shm_sysv_bytes },
+-	{ "shm-sysv-segs",1,	0,	OPT_shm_sysv_segments },
+ 	{ "sigabrt",	1,	0,	OPT_sigabrt },
+ 	{ "sigabrt-ops",1,	0,	OPT_sigabrt_ops },
+ 	{ "sigchld",	1,	0,	OPT_sigchld },
+@@ -769,8 +736,6 @@
+ 	{ "sockfd-port",1,	0,	OPT_sockfd_port },
+ 	{ "sockmany",	1,	0,	OPT_sockmany },
+ 	{ "sockmany-ops",1,	0,	OPT_sockmany_ops },
+-	{ "sockpair",	1,	0,	OPT_sockpair },
+-	{ "sockpair-ops",1,	0,	OPT_sockpair_ops },
+ 	{ "softlockup",	1,	0,	OPT_softlockup },
+ 	{ "softlockup-ops",1,	0,	OPT_softlockup_ops },
+ 	{ "spawn",	1,	0,	OPT_spawn },
+@@ -802,8 +767,6 @@
+ 	{ "sync-file",	1,	0,	OPT_sync_file },
+ 	{ "sync-file-ops", 1,	0,	OPT_sync_file_ops },
+ 	{ "sync-file-bytes", 1,	0,	OPT_sync_file_bytes },
+-	{ "sysbadaddr",	1,	0,	OPT_sysbadaddr },
+-	{ "sysbadaddr-ops",1,	0,	OPT_sysbadaddr_ops },
+ 	{ "sysfs",	1,	0,	OPT_sysfs },
+ 	{ "sysfs-ops",1,	0,	OPT_sysfs_ops },
+ 	{ "sysinfo",	1,	0,	OPT_sysinfo },
+@@ -839,9 +802,6 @@
+ 	{ "tree-size",	1,	0,	OPT_tree_size },
+ 	{ "tsc",	1,	0,	OPT_tsc },
+ 	{ "tsc-ops",	1,	0,	OPT_tsc_ops },
+-	{ "tsearch",	1,	0,	OPT_tsearch },
+-	{ "tsearch-ops",1,	0,	OPT_tsearch_ops },
+-	{ "tsearch-size",1,	0,	OPT_tsearch_size },
+ 	{ "thrash",	0,	0,	OPT_thrash },
+ 	{ "times",	0,	0,	OPT_times },
+ 	{ "timestamp",	0,	0,	OPT_timestamp },
+@@ -866,9 +826,6 @@
+ 	{ "userfaultfd",1,	0,	OPT_userfaultfd },
+ 	{ "userfaultfd-ops",1,	0,	OPT_userfaultfd_ops },
+ 	{ "userfaultfd-bytes",1,0,	OPT_userfaultfd_bytes },
+-	{ "utime",	1,	0,	OPT_utime },
+-	{ "utime-ops",	1,	0,	OPT_utime_ops },
+-	{ "utime-fsync",0,	0,	OPT_utime_fsync },
+ 	{ "vdso",	1,	0,	OPT_vdso },
+ 	{ "vdso-ops",	1,	0,	OPT_vdso_ops },
+ 	{ "vdso-func",	1,	0,	OPT_vdso_func },
+@@ -879,11 +836,6 @@
+ 	{ "verity",	1,	0,	OPT_verity },
+ 	{ "verity-ops",	1,	0,	OPT_verity_ops },
+ 	{ "version",	0,	0,	OPT_version },
+-	{ "vfork",	1,	0,	OPT_vfork },
+-	{ "vfork-ops",	1,	0,	OPT_vfork_ops },
+-	{ "vfork-max",	1,	0,	OPT_vfork_max },
+-	{ "vforkmany",	1,	0,	OPT_vforkmany },
+-	{ "vforkmany-ops", 1,	0,	OPT_vforkmany_ops },
+ 	{ "vm",		1,	0,	OPT_vm },
+ 	{ "vm-bytes",	1,	0,	OPT_vm_bytes },
+ 	{ "vm-hang",	1,	0,	OPT_vm_hang },
+@@ -2964,6 +2916,7 @@
+  */
+ static inline void stress_mlock_executable(void)
+ {
++#if 0
+ #if defined(MLOCKED_SECTION)
+ 	extern void *__start_mlocked_text;
+ 	extern void *__stop_mlocked_text;
+@@ -2973,6 +2926,7 @@
+ 	stress_mlock_region(&__start_mlocked_text, &__stop_mlocked_text);
+ 	stress_mlock_region(&__start_mlocked_data, &__stop_mlocked_data);
+ #endif
++#endif
+ }
+ 
+ int main(int argc, char **argv, char **envp)
+diff -ur a/stress-ng.h b/stress-ng.h
+--- a/stress-ng.h	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-ng.h	2020-11-08 23:25:40.027668500 -0800
+@@ -56,7 +56,6 @@
+ #include <math.h>
+ #include <pwd.h>
+ #include <sched.h>
+-#include <search.h>
+ #include <setjmp.h>
+ #include <signal.h>
+ #include <stdarg.h>
+@@ -1093,14 +1092,6 @@
+ #define PACKED
+ #endif
+ 
+-/* force inlining hint */
+-#if defined(__GNUC__) && NEED_GNUC(3,4,0)	/* or possibly earlier */ \
+- && ((!defined(__s390__) && !defined(__s390x__)) || NEED_GNUC(6,0,1))
+-#define ALWAYS_INLINE	__attribute__ ((always_inline))
+-#else
+-#define ALWAYS_INLINE
+-#endif
+-
+ /* force no inlining hint */
+ #if defined(__GNUC__) && NEED_GNUC(3,4,0)	/* or possibly earier */
+ #define NOINLINE	__attribute__ ((noinline))
+@@ -2230,7 +2221,6 @@
+ 		uint64_t timeout[STRESS_PROCS_MAX];	/* Shared futex timeouts */
+ 	} futex;
+ 	struct {
+-		key_t key_id;				/* System V semaphore key id */
+ 		int sem_id;				/* System V semaphore id */
+ 		bool init;				/* System V semaphore initialized */
+ 	} sem_sysv;
+@@ -2288,7 +2278,6 @@
+ 	MACRO(close)		\
+ 	MACRO(context)		\
+ 	MACRO(copy_file)	\
+-	MACRO(cpu)		\
+ 	MACRO(cpu_online)	\
+ 	MACRO(crypt)		\
+ 	MACRO(cyclic)		\
+@@ -2298,7 +2287,6 @@
+ 	MACRO(dev)		\
+ 	MACRO(dev_shm)		\
+ 	MACRO(dir)		\
+-	MACRO(dirdeep)		\
+ 	MACRO(dnotify)		\
+ 	MACRO(dup)		\
+ 	MACRO(dynlib)		\
+@@ -2331,19 +2319,16 @@
+ 	MACRO(hdd)		\
+ 	MACRO(heapsort)		\
+ 	MACRO(hrtimers)		\
+-	MACRO(hsearch)		\
+ 	MACRO(icache)		\
+ 	MACRO(icmp_flood)	\
+ 	MACRO(idle_page)	\
+ 	MACRO(inode_flags)	\
+ 	MACRO(inotify)		\
+ 	MACRO(io)		\
+-	MACRO(iomix)		\
+ 	MACRO(ioport)		\
+ 	MACRO(ioprio)		\
+ 	MACRO(io_uring)		\
+ 	MACRO(ipsec_mb)		\
+-	MACRO(itimer)		\
+ 	MACRO(judy)		\
+ 	MACRO(kcmp)		\
+ 	MACRO(key)		\
+@@ -2357,7 +2342,6 @@
+ 	MACRO(lockofd)		\
+ 	MACRO(longjmp)		\
+ 	MACRO(loop)		\
+-	MACRO(lsearch)		\
+ 	MACRO(madvise)		\
+ 	MACRO(malloc)		\
+ 	MACRO(matrix)		\
+@@ -2421,22 +2405,16 @@
+ 	MACRO(rename)		\
+ 	MACRO(resources)	\
+ 	MACRO(revio)		\
+-	MACRO(rlimit)		\
+-	MACRO(rmap)		\
+ 	MACRO(rtc)		\
+-	MACRO(schedpolicy)	\
+ 	MACRO(sctp)		\
+ 	MACRO(seal)		\
+ 	MACRO(seccomp)		\
+ 	MACRO(seek)		\
+ 	MACRO(sem)		\
+-	MACRO(sem_sysv)		\
+ 	MACRO(sendfile)		\
+ 	MACRO(session)		\
+-	MACRO(set)		\
+ 	MACRO(shellsort)	\
+ 	MACRO(shm)		\
+-	MACRO(shm_sysv)		\
+ 	MACRO(sigabrt)		\
+ 	MACRO(sigchld)		\
+ 	MACRO(sigfd)		\
+@@ -2456,7 +2434,6 @@
+ 	MACRO(sockabuse)	\
+ 	MACRO(sockdiag)		\
+ 	MACRO(sockfd)		\
+-	MACRO(sockpair)		\
+ 	MACRO(sockmany)		\
+ 	MACRO(softlockup)	\
+ 	MACRO(spawn)		\
+@@ -2469,7 +2446,6 @@
+ 	MACRO(switch)		\
+ 	MACRO(symlink)		\
+ 	MACRO(sync_file)	\
+-	MACRO(sysbadaddr)	\
+ 	MACRO(sysinfo)		\
+ 	MACRO(sysinval)		\
+ 	MACRO(sysfs)		\
+@@ -2480,7 +2456,6 @@
+ 	MACRO(tmpfs)		\
+ 	MACRO(tree)		\
+ 	MACRO(tsc)		\
+-	MACRO(tsearch)		\
+ 	MACRO(tun)		\
+ 	MACRO(udp)		\
+ 	MACRO(udp_flood)	\
+@@ -2488,12 +2463,9 @@
+ 	MACRO(uprobe)		\
+ 	MACRO(urandom)		\
+ 	MACRO(userfaultfd)	\
+-	MACRO(utime)		\
+ 	MACRO(vdso)		\
+ 	MACRO(vecmath)		\
+ 	MACRO(verity)		\
+-	MACRO(vfork)		\
+-	MACRO(vforkmany)	\
+ 	MACRO(vm)		\
+ 	MACRO(vm_addr)		\
+ 	MACRO(vm_rw)		\
+@@ -2709,11 +2681,6 @@
+ 	OPT_dir_ops,
+ 	OPT_dir_dirs,
+ 
+-	OPT_dirdeep,
+-	OPT_dirdeep_ops,
+-	OPT_dirdeep_dirs,
+-	OPT_dirdeep_inodes,
+-
+ 	OPT_dnotify,
+ 	OPT_dnotify_ops,
+ 
+@@ -2825,10 +2792,6 @@
+ 	OPT_hrtimers,
+ 	OPT_hrtimers_ops,
+ 
+-	OPT_hsearch,
+-	OPT_hsearch_ops,
+-	OPT_hsearch_size,
+-
+ 	OPT_icache,
+ 	OPT_icache_ops,
+ 
+@@ -2846,10 +2809,6 @@
+ 	OPT_inotify,
+ 	OPT_inotify_ops,
+ 
+-	OPT_iomix,
+-	OPT_iomix_bytes,
+-	OPT_iomix_ops,
+-
+ 	OPT_ioport,
+ 	OPT_ioport_ops,
+ 	OPT_ioport_opts,
+@@ -2869,11 +2828,6 @@
+ 	OPT_ipsec_mb_ops,
+ 	OPT_ipsec_mb_feature,
+ 
+-	OPT_itimer,
+-	OPT_itimer_ops,
+-	OPT_itimer_freq,
+-	OPT_itimer_rand,
+-
+ 	OPT_judy,
+ 	OPT_judy_ops,
+ 	OPT_judy_size,
+@@ -2919,10 +2873,6 @@
+ 	OPT_loop,
+ 	OPT_loop_ops,
+ 
+-	OPT_lsearch,
+-	OPT_lsearch_ops,
+-	OPT_lsearch_size,
+-
+ 	OPT_madvise,
+ 	OPT_madvise_ops,
+ 
+@@ -3170,9 +3120,6 @@
+ 	OPT_revio_opts,
+ 	OPT_revio_bytes,
+ 
+-	OPT_rlimit,
+-	OPT_rlimit_ops,
+-
+ 	OPT_rmap,
+ 	OPT_rmap_ops,
+ 
+@@ -3182,9 +3129,6 @@
+ 	OPT_sched,
+ 	OPT_sched_prio,
+ 
+-	OPT_schedpolicy,
+-	OPT_schedpolicy_ops,
+-
+ 	OPT_sched_period,
+ 	OPT_sched_runtime,
+ 	OPT_sched_deadline,
+@@ -3214,16 +3158,9 @@
+ 	OPT_sem_ops,
+ 	OPT_sem_procs,
+ 
+-	OPT_sem_sysv,
+-	OPT_sem_sysv_ops,
+-	OPT_sem_sysv_procs,
+-
+ 	OPT_session,
+ 	OPT_session_ops,
+ 
+-	OPT_set,
+-	OPT_set_ops,
+-
+ 	OPT_shellsort,
+ 	OPT_shellsort_ops,
+ 	OPT_shellsort_integers,
+@@ -3233,11 +3170,6 @@
+ 	OPT_shm_bytes,
+ 	OPT_shm_objects,
+ 
+-	OPT_shm_sysv,
+-	OPT_shm_sysv_ops,
+-	OPT_shm_sysv_bytes,
+-	OPT_shm_sysv_segments,
+-
+ 	OPT_sequential,
+ 
+ 	OPT_sigabrt,
+@@ -3307,9 +3239,6 @@
+ 	OPT_sockmany,
+ 	OPT_sockmany_ops,
+ 
+-	OPT_sockpair,
+-	OPT_sockpair_ops,
+-
+ 	OPT_softlockup,
+ 	OPT_softlockup_ops,
+ 
+@@ -3352,9 +3281,6 @@
+ 	OPT_sync_file_ops,
+ 	OPT_sync_file_bytes,
+ 
+-	OPT_sysbadaddr,
+-	OPT_sysbadaddr_ops,
+-
+ 	OPT_sysinfo,
+ 	OPT_sysinfo_ops,
+ 
+@@ -3408,10 +3334,6 @@
+ 	OPT_tsc,
+ 	OPT_tsc_ops,
+ 
+-	OPT_tsearch,
+-	OPT_tsearch_ops,
+-	OPT_tsearch_size,
+-
+ 	OPT_tun,
+ 	OPT_tun_ops,
+ 	OPT_tun_tap,
+@@ -3438,10 +3360,6 @@
+ 	OPT_userfaultfd_ops,
+ 	OPT_userfaultfd_bytes,
+ 
+-	OPT_utime,
+-	OPT_utime_ops,
+-	OPT_utime_fsync,
+-
+ 	OPT_vdso,
+ 	OPT_vdso_ops,
+ 	OPT_vdso_func,
+@@ -3454,13 +3372,6 @@
+ 	OPT_verity,
+ 	OPT_verity_ops,
+ 
+-	OPT_vfork,
+-	OPT_vfork_ops,
+-	OPT_vfork_max,
+-
+-	OPT_vforkmany,
+-	OPT_vforkmany_ops,
+-
+ 	OPT_vm_bytes,
+ 	OPT_vm_hang,
+ 	OPT_vm_keep,
+iff -ur a/stress-schedpolicy.c b/stress-schedpolicy.c
+--- a/stress-schedpolicy.c	2020-11-07 10:52:22.000000000 -0800
++++ b/stress-schedpolicy.c	2020-11-08 23:22:11.257668500 -0800
+@@ -117,7 +117,9 @@
+ 		case SCHED_OTHER:
+ #endif
+ 			param.sched_priority = 0;
++#if 0
+ 			ret = sched_setscheduler(pid, new_policy, &param);
++#endif
+ 			break;
+ #if defined(SCHED_RR)
+ 		case SCHED_RR:
+


### PR DESCRIPTION
This is a very WIP port bringing [stress-ng](https://kernel.ubuntu.com/~cking/stress-ng/) to SerenityOS.

stress-ng is great at doing multi-workload stress testing, this allows it to
find unique and interesting intermixed pairs of stressful operations which cause bugs.

This initial port just rips out all non applicable functionality to get the port to compile.