### PR TITLE
LibGUI: Get executable file icon from embedded ELF sections

### DIFF
--- a/Applications/Browser/CMakeLists.txt
+++ b/Applications/Browser/CMakeLists.txt
@@ -15,5 +15,5 @@ set(SOURCES
     TabGML.h
 )
 
-serenity_bin(Browser)
+serenity_app(Browser ICON app-browser)
 target_link_libraries(Browser LibWeb LibProtocol LibGUI LibDesktop)

--- a/Applications/Calculator/CMakeLists.txt
+++ b/Applications/Calculator/CMakeLists.txt
@@ -5,5 +5,5 @@ set(SOURCES
     Keypad.cpp
 )
 
-serenity_bin(Calculator)
+serenity_app(Calculator ICON app-calculator)
 target_link_libraries(Calculator LibGUI)

--- a/Applications/Calendar/CMakeLists.txt
+++ b/Applications/Calendar/CMakeLists.txt
@@ -3,5 +3,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(Calendar)
+serenity_app(Calendar ICON app-calendar)
 target_link_libraries(Calendar LibGUI)

--- a/Applications/DisplaySettings/CMakeLists.txt
+++ b/Applications/DisplaySettings/CMakeLists.txt
@@ -4,5 +4,5 @@ set(SOURCES
     MonitorWidget.cpp
 )
 
-serenity_bin(DisplaySettings)
+serenity_app(DisplaySettings ICON app-display-settings)
 target_link_libraries(DisplaySettings LibGUI)

--- a/Applications/FileManager/CMakeLists.txt
+++ b/Applications/FileManager/CMakeLists.txt
@@ -9,5 +9,5 @@ set(SOURCES
     PropertiesDialog.cpp
 )
 
-serenity_bin(FileManager)
+serenity_app(FileManager ICON filetype-folder)
 target_link_libraries(FileManager LibGUI LibDesktop)

--- a/Applications/FontEditor/CMakeLists.txt
+++ b/Applications/FontEditor/CMakeLists.txt
@@ -7,5 +7,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(FontEditor)
+serenity_app(FontEditor ICON app-font-editor)
 target_link_libraries(FontEditor LibGUI LibGfx)

--- a/Applications/Help/CMakeLists.txt
+++ b/Applications/Help/CMakeLists.txt
@@ -6,5 +6,5 @@ set(SOURCES
     ManualSectionNode.cpp
 )
 
-serenity_bin(Help)
+serenity_app(Help ICON app-help)
 target_link_libraries(Help LibWeb LibMarkdown LibGUI LibDesktop)

--- a/Applications/HexEditor/CMakeLists.txt
+++ b/Applications/HexEditor/CMakeLists.txt
@@ -4,5 +4,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(HexEditor)
+serenity_app(HexEditor ICON app-hexeditor)
 target_link_libraries(HexEditor LibGUI)

--- a/Applications/IRCClient/CMakeLists.txt
+++ b/Applications/IRCClient/CMakeLists.txt
@@ -10,5 +10,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(IRCClient)
+serenity_app(IRCClient ICON app-irc-client)
 target_link_libraries(IRCClient LibWeb LibGUI)

--- a/Applications/KeyboardSettings/CMakeLists.txt
+++ b/Applications/KeyboardSettings/CMakeLists.txt
@@ -2,5 +2,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(KeyboardSettings)
+serenity_app(KeyboardSettings ICON app-keyboard-settings)
 target_link_libraries(KeyboardSettings LibGUI LibKeyboard)

--- a/Applications/Piano/CMakeLists.txt
+++ b/Applications/Piano/CMakeLists.txt
@@ -10,5 +10,5 @@ set(SOURCES
     WaveWidget.cpp
 )
 
-serenity_bin(Piano)
+serenity_app(Piano ICON app-piano)
 target_link_libraries(Piano LibAudio LibGUI)

--- a/Applications/PixelPaint/CMakeLists.txt
+++ b/Applications/PixelPaint/CMakeLists.txt
@@ -23,5 +23,5 @@ set(SOURCES
     Tool.cpp
 )
 
-serenity_bin(PixelPaint)
+serenity_app(PixelPaint ICON app-pixel-paint)
 target_link_libraries(PixelPaint LibGUI LibGfx)

--- a/Applications/QuickShow/CMakeLists.txt
+++ b/Applications/QuickShow/CMakeLists.txt
@@ -3,5 +3,5 @@ set(SOURCES
     QSWidget.cpp
 )
 
-serenity_bin(QuickShow)
+serenity_app(QuickShow ICON filetype-image)
 target_link_libraries(QuickShow LibGUI LibGfx)

--- a/Applications/SoundPlayer/CMakeLists.txt
+++ b/Applications/SoundPlayer/CMakeLists.txt
@@ -5,5 +5,5 @@ set(SOURCES
     SoundPlayerWidget.cpp
 )
 
-serenity_bin(SoundPlayer)
+serenity_app(SoundPlayer ICON app-sound-player)
 target_link_libraries(SoundPlayer LibAudio LibGUI)

--- a/Applications/Spreadsheet/CMakeLists.txt
+++ b/Applications/Spreadsheet/CMakeLists.txt
@@ -24,5 +24,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(Spreadsheet)
+serenity_app(Spreadsheet ICON app-spreadsheet)
 target_link_libraries(Spreadsheet LibGUI LibJS LibWeb)

--- a/Applications/SystemMonitor/CMakeLists.txt
+++ b/Applications/SystemMonitor/CMakeLists.txt
@@ -12,5 +12,5 @@ set(SOURCES
     ThreadStackWidget.cpp
 )
 
-serenity_bin(SystemMonitor)
+serenity_app(SystemMonitor ICON app-system-monitor)
 target_link_libraries(SystemMonitor LibGUI LibPCIDB)

--- a/Applications/Terminal/CMakeLists.txt
+++ b/Applications/Terminal/CMakeLists.txt
@@ -2,5 +2,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(Terminal)
+serenity_app(Terminal ICON app-terminal)
 target_link_libraries(Terminal LibGUI LibVT)

--- a/Applications/TextEditor/CMakeLists.txt
+++ b/Applications/TextEditor/CMakeLists.txt
@@ -6,5 +6,5 @@ set(SOURCES
     MainWindowGML.h
 )
 
-serenity_bin(TextEditor)
+serenity_app(TextEditor ICON app-text-editor)
 target_link_libraries(TextEditor LibWeb LibMarkdown LibGUI LibShell LibRegex LibDesktop)

--- a/Applications/ThemeEditor/CMakeLists.txt
+++ b/Applications/ThemeEditor/CMakeLists.txt
@@ -3,5 +3,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(ThemeEditor)
+serenity_app(ThemeEditor ICON app-theme-editor)
 target_link_libraries(ThemeEditor LibGUI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,23 @@ function(serenity_bin target_name)
     serenity_generated_sources(${target_name})
 endfunction()
 
+function(serenity_app target_name)
+    cmake_parse_arguments(SERENITY_APP "" "ICON" "" ${ARGN})
+
+    serenity_bin("${target_name}")
+    set(small_icon "${CMAKE_SOURCE_DIR}/Base/res/icons/16x16/${SERENITY_APP_ICON}.png")
+    set(medium_icon "${CMAKE_SOURCE_DIR}/Base/res/icons/32x32/${SERENITY_APP_ICON}.png")
+    
+    if (EXISTS "${small_icon}")
+        embed_resource("${target_name}" serenity_icon_s "${small_icon}")
+    endif()
+    if (EXISTS "${medium_icon}")
+        embed_resource("${target_name}" serenity_icon_m "${medium_icon}")
+    endif()
+
+    # TODO: Issue warnings if the app icons don't exist
+endfunction()
+
 function(compile_gml source output string_name)
     set(source ${CMAKE_CURRENT_SOURCE_DIR}/${source})
     add_custom_command(
@@ -189,6 +206,19 @@ function(compile_ipc source output)
     )
     get_filename_component(output_name ${output} NAME)
     add_custom_target(generate_${output_name} DEPENDS ${output})
+endfunction()
+
+function(embed_resource target section file)
+    get_filename_component(asm_file "${file}" NAME)
+    set(asm_file "${CMAKE_CURRENT_BINARY_DIR}/${target}-${section}.s")
+    get_filename_component(input_file "${file}" ABSOLUTE)
+    add_custom_command(
+        OUTPUT "${asm_file}"
+        COMMAND "${CMAKE_SOURCE_DIR}/Meta/generate-embedded-resource-assembly.sh" "${asm_file}" "${section}" "${input_file}" 
+        DEPENDS "${input_file}" "${CMAKE_SOURCE_DIR}/Meta/generate-embedded-resource-assembly.sh"
+        COMMENT "Generating ${asm_file}"
+    )
+    target_sources("${target}" PRIVATE "${asm_file}")
 endfunction()
 
 find_program(CCACHE_PROGRAM ccache)

--- a/Demos/Cube/CMakeLists.txt
+++ b/Demos/Cube/CMakeLists.txt
@@ -2,5 +2,5 @@ set(SOURCES
     Cube.cpp
 )
 
-serenity_bin(Cube)
+serenity_app(Cube ICON app-cube)
 target_link_libraries(Cube LibGUI)

--- a/Demos/Eyes/CMakeLists.txt
+++ b/Demos/Eyes/CMakeLists.txt
@@ -3,5 +3,5 @@ set(SOURCES
     EyesWidget.cpp
 )
 
-serenity_bin(Eyes)
+serenity_app(Eyes ICON app-eyes)
 target_link_libraries(Eyes LibGUI LibGfx)

--- a/Demos/Fire/CMakeLists.txt
+++ b/Demos/Fire/CMakeLists.txt
@@ -2,5 +2,5 @@ set(SOURCES
     Fire.cpp
 )
 
-serenity_bin(Fire)
+serenity_app(Fire ICON app-fire)
 target_link_libraries(Fire LibGUI LibCore LibGfx)

--- a/Demos/HelloWorld/CMakeLists.txt
+++ b/Demos/HelloWorld/CMakeLists.txt
@@ -2,5 +2,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(HelloWorld)
+serenity_app(HelloWorld ICON app-hello-world)
 target_link_libraries(HelloWorld LibGUI)

--- a/Demos/LibGfxDemo/CMakeLists.txt
+++ b/Demos/LibGfxDemo/CMakeLists.txt
@@ -2,5 +2,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(LibGfxDemo)
+serenity_app(LibGfxDemo ICON app-libgfx-demo)
 target_link_libraries(LibGfxDemo LibGUI LibIPC LibGfx LibCore)

--- a/Demos/Mouse/CMakeLists.txt
+++ b/Demos/Mouse/CMakeLists.txt
@@ -2,5 +2,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(Mouse)
+serenity_app(Mouse ICON app-mouse)
 target_link_libraries(Mouse LibGUI LibGfx)

--- a/Demos/Screensaver/CMakeLists.txt
+++ b/Demos/Screensaver/CMakeLists.txt
@@ -2,5 +2,5 @@ set(SOURCES
     Screensaver.cpp
 )
 
-serenity_bin(Screensaver)
+serenity_app(Screensaver ICON app-screensaver)
 target_link_libraries(Screensaver LibGUI LibCore LibGfx)

--- a/Demos/WidgetGallery/CMakeLists.txt
+++ b/Demos/WidgetGallery/CMakeLists.txt
@@ -2,5 +2,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(WidgetGallery)
+serenity_app(WidgetGallery ICON app-widget-gallery)
 target_link_libraries(WidgetGallery LibGUI)

--- a/DevTools/HackStudio/CMakeLists.txt
+++ b/DevTools/HackStudio/CMakeLists.txt
@@ -33,6 +33,6 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(HackStudio)
+serenity_app(HackStudio ICON app-hack-studio)
 target_link_libraries(HackStudio LibWeb LibMarkdown LibGUI LibGfx LibCore LibVT LibDebug LibX86 LibDiff LibShell)
 add_dependencies(HackStudio CppLanguageServer)

--- a/DevTools/Inspector/CMakeLists.txt
+++ b/DevTools/Inspector/CMakeLists.txt
@@ -6,5 +6,5 @@ set(SOURCES
     RemoteProcess.cpp
 )
 
-serenity_bin(Inspector)
+serenity_app(Inspector ICON app-inspector)
 target_link_libraries(Inspector LibGUI)

--- a/DevTools/Profiler/CMakeLists.txt
+++ b/DevTools/Profiler/CMakeLists.txt
@@ -6,5 +6,5 @@ set(SOURCES
     ProfileTimelineWidget.cpp
 )
 
-serenity_bin(Profiler)
+serenity_app(Profiler ICON app-profiler)
 target_link_libraries(Profiler LibGUI LibX86 LibCoreDump)

--- a/Games/2048/CMakeLists.txt
+++ b/Games/2048/CMakeLists.txt
@@ -5,5 +5,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(2048)
+serenity_app(2048 ICON app-2048)
 target_link_libraries(2048 LibGUI)

--- a/Games/Breakout/CMakeLists.txt
+++ b/Games/Breakout/CMakeLists.txt
@@ -4,5 +4,5 @@ set(SOURCES
     LevelSelectDialog.cpp
 )
 
-serenity_bin(Breakout)
+serenity_app(Breakout ICON app-breakout)
 target_link_libraries(Breakout LibGUI)

--- a/Games/Chess/CMakeLists.txt
+++ b/Games/Chess/CMakeLists.txt
@@ -5,5 +5,5 @@ set(SOURCES
     Engine.cpp
 )
 
-serenity_bin(Chess)
+serenity_app(Chess ICON app-chess)
 target_link_libraries(Chess LibChess LibGUI LibCore)

--- a/Games/Minesweeper/CMakeLists.txt
+++ b/Games/Minesweeper/CMakeLists.txt
@@ -3,5 +3,5 @@ set(SOURCES
     main.cpp
 )
 
-serenity_bin(Minesweeper)
+serenity_app(Minesweeper ICON app-minesweeper)
 target_link_libraries(Minesweeper LibGUI)

--- a/Games/Pong/CMakeLists.txt
+++ b/Games/Pong/CMakeLists.txt
@@ -3,5 +3,5 @@ set(SOURCES
     Game.cpp
 )
 
-serenity_bin(Pong)
+serenity_app(Pong ICON app-pong)
 target_link_libraries(Pong LibGUI)

--- a/Games/Snake/CMakeLists.txt
+++ b/Games/Snake/CMakeLists.txt
@@ -3,5 +3,5 @@ set(SOURCES
     SnakeGame.cpp
 )
 
-serenity_bin(Snake)
+serenity_app(Snake ICON app-snake)
 target_link_libraries(Snake LibGUI)

--- a/Games/Solitaire/CMakeLists.txt
+++ b/Games/Solitaire/CMakeLists.txt
@@ -5,5 +5,5 @@ set(SOURCES
     SolitaireWidget.cpp
 )
 
-serenity_bin(Solitaire)
+serenity_app(Solitaire ICON app-solitaire)
 target_link_libraries(Solitaire LibGUI LibGfx LibCore)

--- a/Meta/generate-embedded-resource-assembly.sh
+++ b/Meta/generate-embedded-resource-assembly.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "ERROR: No output file specified"
+    exit 1
+fi
+
+OUTPUT_FILE="$1"
+shift
+
+rm -f "${OUTPUT_FILE}"
+
+while (( "$#" >= 2)); do
+    SECTION_NAME="$1"
+    INPUT_FILE="$2"
+
+    {
+        printf '    .section %s\n' "${SECTION_NAME}"
+        printf '    .type %s, @object\n' "${SECTION_NAME}"
+        printf '    .align 4\n'
+        printf '    .incbin "%s"\n' "${INPUT_FILE}"
+        printf '\n'
+    } >> "${OUTPUT_FILE}"
+    shift 2
+done


### PR DESCRIPTION
Inspired by Andreas' recent [OS Hacking: Improving symlink and app icons in the file manager](https://www.youtube.com/watch?v=UmF0Y33mSCo) video I tried running with the idea of allowing executable files to embed icon information as custom ELF sections which can then be retrieved in LibGUI.

This works by generating a small GNU Assembler file for each icon to insert it into a custom section called `serenity_icon_s` for the 16x16 icon, and `serenity_icon_m` for the 32x32 icon. The `FileIconProvider` then tries to extract these sections using `ELF::Image` and parse them as PNGs to build the executable file icon. The default executable icon is used if a section is missing, if the section cannot be parsed as a PNG, or if the file isn't an ELF executable.

Additionally I've added a `serenity_app` CMake function which defines a new `serenity_bin` target and allows an icon name to be specified. For example:
```
serenity_app(Browser ICON app-browser)
```
will define a binary called `Browser` using `serenity_bin`, and embed the icons `/res/icons/16x16/app-browser.png` and `/res/icons/32x32/app-browser.png` into the executable. If a specified PNG doesn't exist then it is not embedded (for example `Calculator`). Ideally I would like to issue a warning here but CMake seems to only show the first instance of `message(WARNING)` messages from a given source location.

The resulting binaries have the required ELF sections:
```
[william@Pluto Build]$ readelf --sections Applications/Browser/Browser
There are 30 section headers, starting at offset 0xbc540:

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .interp           PROGBITS        000000d4 0000d4 000013 00   A  0   0  1
  [ 2] .hash             HASH            000000e8 0000e8 000a78 04   A  3   0  4
  [ 3] .dynsym           DYNSYM          00000b60 000b60 001950 10   A  4   1  4
  [ 4] .dynstr           STRTAB          000024b0 0024b0 004f62 00   A  0   0  1
  [ 5] .rel.dyn          REL             00007414 007414 001078 08   A  3   0  4
  [ 6] .rel.plt          REL             0000848c 00848c 000758 08  AI  3  15  4
  [ 7] .plt              PROGBITS        00008bf0 008bf0 000ec0 04  AX  0   0 16
  [ 8] .text             PROGBITS        00009ab0 009ab0 013dfd 00  AX  0   0  2
  [ 9] .rodata           PROGBITS        0001d8c0 01d8c0 00137d 00   A  0   0 32
  [10] .eh_frame         PROGBITS        0001ec40 01ec40 000000 00   A  0   0  4
  [11] .init_array       INIT_ARRAY      0001fc40 01ec40 000014 04  WA  0   0  4
  [12] .data.rel.ro      PROGBITS        0001fc54 01ec54 000aec 00  WA  0   0  4
  [13] .dynamic          DYNAMIC         00020740 01f740 000190 08  WA  4   0  4
  [14] .got              PROGBITS        000208d0 01f8d0 00001c 04  WA  0   0  4
  [15] .got.plt          PROGBITS        000208ec 01f8ec 0003b8 04  WA  0   0  4
  [16] .bss              NOBITS          00020ca4 01fca4 00001c 00  WA  0   0  4
  [17] .comment          PROGBITS        00000000 01fca4 000012 01  MS  0   0  1
  [18] serenity_icon_s   PROGBITS        00000000 01fcb8 00027a 00      0   0  4
  [19] serenity_icon_m   PROGBITS        00000000 01ff34 0005e1 00      0   0  4
  [20] .debug_aranges    PROGBITS        00000000 020515 0009d0 00      0   0  1
  [21] .debug_info       PROGBITS        00000000 020ee5 02ddf0 00      0   0  1
  [22] .debug_abbrev     PROGBITS        00000000 04ecd5 0020ac 00      0   0  1
  [23] .debug_line       PROGBITS        00000000 050d81 0115b5 00      0   0  1
  [24] .debug_frame      PROGBITS        00000000 062338 0051e0 00      0   0  4
  [25] .debug_str        PROGBITS        00000000 067518 038c7c 01  MS  0   0  1
  [26] .debug_ranges     PROGBITS        00000000 0a0194 00a7c8 00      0   0  1
  [27] .symtab           SYMTAB          00000000 0aa95c 003a10 10     28 392  4
  [28] .strtab           STRTAB          00000000 0ae36c 00e0b5 00      0   0  1
  [29] .shstrtab         STRTAB          00000000 0bc421 00011c 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
  L (link order), O (extra OS processing required), G (group), T (TLS),
  C (compressed), x (unknown), o (OS specific), E (exclude),
  p (processor specific)
```

and the contents of the resulting section are identical to the original PNGs
```
[william@Pluto Build]$ diff -qs ../Base/res/icons/32x32/app-browser.png <(objcopy --dump-section serenity_icon_m=/dev/stdout Applications/Browser/Browser)
Files ../Base/res/icons/32x32/app-browser.png and /dev/fd/63 are identical
```