### PR TITLE
FileManager: Add links in file properties to open links in their real directory

### DIFF
--- a/Applications/FileManager/PropertiesDialog.h
+++ b/Applications/FileManager/PropertiesDialog.h
@@ -45,6 +45,7 @@ private:
     struct PropertyValuePair {
         String property;
         String value;
+        Optional<URL> link = {};
     };
 
     struct PermissionMasks {

--- a/Libraries/LibGUI/CMakeLists.txt
+++ b/Libraries/LibGUI/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SOURCES
     Label.cpp
     Layout.cpp
     LazyWidget.cpp
+    Link.cpp
     ListView.cpp
     Menu.cpp
     MenuBar.cpp

--- a/Libraries/LibGUI/Link.cpp
+++ b/Libraries/LibGUI/Link.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020, Alex McGrath <amk@amk.ie>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibCore/Event.h>
+#include <LibGUI/Event.h>
+#include <LibGUI/Link.h>
+#include <LibGUI/Painter.h>
+#include <LibGUI/Window.h>
+#include <LibGfx/Font.h>
+#include <LibGfx/Palette.h>
+#include <LibGfx/SystemTheme.h>
+
+namespace GUI {
+
+Link::Link(const StringView& text)
+    : Label(text)
+{
+    set_foreground_role(Gfx::ColorRole::Link);
+}
+
+void Link::mousedown_event(MouseEvent&)
+{
+    if (on_click) {
+        on_click();
+    }
+}
+
+void Link::paint_event(PaintEvent& event)
+{
+    Label::paint_event(event);
+    GUI::Painter painter(*this);
+
+    if (m_hovered)
+        painter.draw_line({ 0, rect().bottom() }, { font().width(text()), rect().bottom() },
+            Widget::palette().link());
+}
+
+void Link::enter_event(Core::Event&)
+{
+    m_hovered = true;
+    update();
+}
+
+void Link::leave_event(Core::Event&)
+{
+    m_hovered = false;
+    update();
+}
+
+void Link::second_paint_event(PaintEvent&)
+{
+    if (window()->width() < font().width(text())) {
+        set_tooltip(text());
+    }
+}
+
+void Link::resize_event(ResizeEvent&)
+{
+    if (window()->width() < font().width(text())) {
+        set_tooltip(text());
+    } else {
+        set_tooltip({});
+    }
+}
+
+}

--- a/Libraries/LibGUI/Link.h
+++ b/Libraries/LibGUI/Link.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Alex McGrath <amk@amk.ie>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibGUI/Event.h>
+#include <LibGUI/Label.h>
+
+namespace GUI {
+class Link : public Label {
+    C_OBJECT(Link)
+public:
+    Link(const StringView&);
+    Function<void()> on_click;
+
+private:
+    virtual void mousedown_event(MouseEvent&) override;
+    virtual void paint_event(PaintEvent&) override;
+    virtual void resize_event(ResizeEvent&) override;
+    virtual void second_paint_event(PaintEvent&) override;
+    virtual void enter_event(Core::Event&) override;
+    virtual void leave_event(Core::Event&) override;
+
+    bool m_hovered = false;
+};
+}


### PR DESCRIPTION
This adds a button if a file is a link to open a file manager in the original  files directory
![20201221_14h05m18s_grim](https://user-images.githubusercontent.com/7910815/102785537-11ef8f80-4396-11eb-8ee1-28d258ca17d1.png)

