### PR TITLE
Everywhere: Switch from (void) to [[maybe_unused]]

### DIFF
--- a/AK/Random.h
+++ b/AK/Random.h
@@ -43,16 +43,13 @@
 
 namespace AK {
 
-inline void fill_with_random(void* buffer, size_t length)
+inline void fill_with_random([[maybe_unused]] void* buffer, [[maybe_unused]] size_t length)
 {
 #if defined(__serenity__)
     arc4random_buf(buffer, length);
 #elif defined(OSS_FUZZ)
-    (void)buffer;
-    (void)length;
 #elif defined(__unix__) or defined(__APPLE__)
-    int rc = getentropy(buffer, length);
-    (void)rc;
+    [[maybe_unused]] int rc = getentropy(buffer, length);
 #endif
 }
 

--- a/AK/SharedBuffer.cpp
+++ b/AK/SharedBuffer.cpp
@@ -89,7 +89,7 @@ RefPtr<SharedBuffer> SharedBuffer::create_with_size(int size)
     return adopt(*new SharedBuffer(shbuf_id, size, data));
 }
 
-bool SharedBuffer::share_with(pid_t peer)
+bool SharedBuffer::share_with([[maybe_unused]] pid_t peer)
 {
 #    if defined(__serenity__)
     int ret = shbuf_allow_pid(shbuf_id(), peer);
@@ -97,8 +97,6 @@ bool SharedBuffer::share_with(pid_t peer)
         perror("shbuf_allow_pid");
         return false;
     }
-#    else
-    (void)peer;
 #    endif
     return true;
 }

--- a/AK/Singleton.h
+++ b/AK/Singleton.h
@@ -114,7 +114,7 @@ public:
 
     void ensure_instance()
     {
-        (void)ptr();
+        ptr();
     }
 
 private:

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -26,8 +26,6 @@
 
 #pragma once
 
-#define UNUSED_PARAM(x) (void)x
-
 constexpr unsigned round_up_to_power_of_two(unsigned value, unsigned power_of_two)
 {
     return ((value - 1) & ~(power_of_two - 1)) + power_of_two;

--- a/AK/Tests/TestByteBuffer.cpp
+++ b/AK/Tests/TestByteBuffer.cpp
@@ -65,7 +65,7 @@ TEST_CASE(negative_operator_lt)
 {
     ByteBuffer a = ByteBuffer::copy("Hello, world", 10);
     ByteBuffer b = ByteBuffer::copy("Hello, friend", 10);
-    (void)(a < b);
+    [[maybe_unused]] auto res = a < b;
     // error: error: use of deleted function ‘bool AK::ByteBuffer::operator<(const AK::ByteBuffer&) const’
 }
 #endif /* COMPILE_NEGATIVE_TESTS */

--- a/AK/Tests/TestDistinctNumeric.cpp
+++ b/AK/Tests/TestDistinctNumeric.cpp
@@ -264,35 +264,35 @@ TEST_CASE(negative_incr)
 TEST_CASE(negative_cmp)
 {
     BareNumeric a = 12;
-    (void)(a < a);
+    [[maybe_unused]] auto res = (a < a);
     // error: static assertion failed: 'a<b' is only available for DistinctNumeric types with 'Cmp'.
 }
 
 TEST_CASE(negative_bool)
 {
     BareNumeric a = 12;
-    (void)!a;
+    [[maybe_unused]] auto res = !a;
     // error: static assertion failed: '!a', 'a&&b', 'a||b' and similar operators are only available for DistinctNumeric types with 'Bool'.
 }
 
 TEST_CASE(negative_flags)
 {
     BareNumeric a = 12;
-    (void)(a & a);
+    [[maybe_unused]] auto res = (a & a);
     // error: static assertion failed: 'a&b' is only available for DistinctNumeric types with 'Flags'.
 }
 
 TEST_CASE(negative_shift)
 {
     BareNumeric a = 12;
-    (void)(a << a);
+    [[maybe_unused]] auto res = (a << a);
     // error: static assertion failed: 'a<<b' is only available for DistinctNumeric types with 'Shift'.
 }
 
 TEST_CASE(negative_arith)
 {
     BareNumeric a = 12;
-    (void)(a + a);
+    [[maybe_unused]] auto res = (a + a);
     // error: static assertion failed: 'a+b' is only available for DistinctNumeric types with 'Arith'.
 }
 
@@ -302,13 +302,13 @@ TEST_CASE(negative_incompatible)
     ArithNumeric b = 345;
     // And this is the entire point of `DistinctNumeric`:
     // Theoretically, the operation *could* be supported, but we declared those int types incompatible.
-    (void)(a + b);
+    [[maybe_unused]] auto res = (a + b);
     // error: no match for ‘operator+’ (operand types are ‘GeneralNumeric’ {aka ‘AK::DistinctNumeric<int, true, true, true, true, true, true, 64, 64>’} and ‘ArithNumeric’ {aka ‘AK::DistinctNumeric<int, false, false, false, false, false, true, 64, 63>’})
-    //    313 |     (void)(a + b);
-    //        |            ~ ^ ~
-    //        |            |   |
-    //        |            |   DistinctNumeric<[...],false,false,false,false,false,[...],[...],63>
-    //        |            DistinctNumeric<[...],true,true,true,true,true,[...],[...],64>
+    //    313 |     [[maybe_unused]] auto res = (a + b);
+    //        |                                  ~ ^ ~
+    //        |                                  |   |
+    //        |                                  |   DistinctNumeric<[...],false,false,false,false,false,[...],[...],63>
+    //        |                                  DistinctNumeric<[...],true,true,true,true,true,[...],[...],64>
 }
 #endif /* COMPILE_NEGATIVE_TESTS */
 

--- a/AK/Tests/TestJSON.cpp
+++ b/AK/Tests/TestJSON.cpp
@@ -61,9 +61,7 @@ TEST_CASE(load_form)
     widgets.for_each([&](const JsonValue& widget_value) {
         auto& widget_object = widget_value.as_object();
         auto widget_class = widget_object.get("class").as_string();
-        widget_object.for_each_member([&](auto& property_name, const JsonValue& property_value) {
-            (void)property_name;
-            (void)property_value;
+        widget_object.for_each_member([&]([[maybe_unused]] auto& property_name, [[maybe_unused]] const JsonValue& property_value) {
             //dbgprintf("Set property %s.%s to '%s'\n", widget_class.characters(), property_name.characters(), property_value.serialized().characters());
         });
     });

--- a/AK/Tests/TestSourceGenerator.cpp
+++ b/AK/Tests/TestSourceGenerator.cpp
@@ -44,9 +44,9 @@ TEST_CASE(generate_c_code)
     SourceGenerator generator { builder };
     generator.set("name", "foo");
 
-    generator.append("const char* @name@ (void) { return \"@name@\"; }");
+    generator.append("const char* @name@ () { return \"@name@\"; }");
 
-    EXPECT_EQ(generator.as_string_view(), "const char* foo (void) { return \"foo\"; }");
+    EXPECT_EQ(generator.as_string_view(), "const char* foo () { return \"foo\"; }");
 }
 
 TEST_CASE(scoped)

--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -138,8 +138,7 @@ bool Utf8View::validate(size_t& valid_bytes) const
 size_t Utf8View::calculate_length() const
 {
     size_t length = 0;
-    for (auto code_point : *this) {
-        (void)code_point;
+    for ([[maybe_unused]] auto code_point : *this) {
         ++length;
     }
     return length;
@@ -170,7 +169,6 @@ Utf8CodepointIterator& Utf8CodepointIterator::operator++()
     bool first_byte_makes_sense = decode_first_byte(*m_ptr, code_point_length_in_bytes, value);
 
     ASSERT(first_byte_makes_sense);
-    (void)value;
 
     ASSERT(code_point_length_in_bytes <= m_length);
     m_ptr += code_point_length_in_bytes;

--- a/Applications/Browser/DownloadWidget.cpp
+++ b/Applications/Browser/DownloadWidget.cpp
@@ -156,11 +156,8 @@ void DownloadWidget::did_progress(Optional<u32> total_size, u32 downloaded_size)
     }
 }
 
-void DownloadWidget::did_finish(bool success, ReadonlyBytes payload, RefPtr<SharedBuffer> payload_storage, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers)
+void DownloadWidget::did_finish(bool success, [[maybe_unused]] ReadonlyBytes payload, [[maybe_unused]] RefPtr<SharedBuffer> payload_storage, [[maybe_unused]] const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers)
 {
-    (void)payload;
-    (void)payload_storage;
-    (void)response_headers;
     dbg() << "did_finish, success=" << success;
 
     m_close_button->set_enabled(true);

--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -82,7 +82,7 @@ static void start_download(const URL& url)
     window->set_resizable(false);
     window->set_main_widget<DownloadWidget>(url);
     window->show();
-    (void)window.leak_ref();
+    [[maybe_unused]] auto& unused = window.leak_ref();
 }
 
 Tab::Tab(Type type)
@@ -308,7 +308,7 @@ Tab::Tab(Type type)
                 window->set_title(url);
                 window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-text.png"));
                 window->show();
-                (void)window.leak_ref();
+                [[maybe_unused]] auto& unused = window.leak_ref();
             } else {
                 TODO();
             }

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -183,13 +183,12 @@ void show_properties(const String& container_dir_path, const String& path, const
     properties->exec();
 }
 
-int run_in_desktop_mode(RefPtr<Core::ConfigFile> config)
+int run_in_desktop_mode([[maybe_unused]] RefPtr<Core::ConfigFile> config)
 {
     static constexpr const char* process_name = "FileManager (Desktop)";
     set_process_name(process_name, strlen(process_name));
     pthread_setname_np(pthread_self(), process_name);
 
-    (void)config;
     auto window = GUI::Window::construct();
     window->set_title("Desktop Manager");
     window->set_window_type(GUI::WindowType::Desktop);
@@ -198,8 +197,7 @@ int run_in_desktop_mode(RefPtr<Core::ConfigFile> config)
     auto& desktop_widget = window->set_main_widget<FileManager::DesktopWidget>();
     desktop_widget.set_layout<GUI::VerticalBoxLayout>();
 
-    auto& directory_view = desktop_widget.add<DirectoryView>(DirectoryView::Mode::Desktop);
-    (void)directory_view;
+    [[maybe_unused]] auto& directory_view = desktop_widget.add<DirectoryView>(DirectoryView::Mode::Desktop);
 
     auto copy_action = GUI::CommonActions::make_copy_action(
         [&](auto&) {

--- a/Applications/IRCClient/IRCClient.cpp
+++ b/Applications/IRCClient/IRCClient.cpp
@@ -773,9 +773,8 @@ void IRCClient::handle_rpl_whoisuser(const Message& msg)
     auto& nick = msg.arguments[1];
     auto& username = msg.arguments[2];
     auto& host = msg.arguments[3];
-    auto& asterisk = msg.arguments[4];
+    [[maybe_unused]] auto& asterisk = msg.arguments[4];
     auto& realname = msg.arguments[5];
-    (void)asterisk;
     add_server_message(String::formatted("* {} is {}@{}, real name: {}", nick, username, host, realname));
 }
 

--- a/Applications/Piano/RollWidget.cpp
+++ b/Applications/Piano/RollWidget.cpp
@@ -204,9 +204,8 @@ void RollWidget::mousemove_event(GUI::MouseEvent& event)
     update();
 }
 
-void RollWidget::mouseup_event(GUI::MouseEvent& event)
+void RollWidget::mouseup_event([[maybe_unused]] GUI::MouseEvent& event)
 {
-    (void)event;
     m_note_drag_start = {};
     m_note_drag_location = {};
 }

--- a/Applications/QuickShow/QSWidget.cpp
+++ b/Applications/QuickShow/QSWidget.cpp
@@ -200,10 +200,7 @@ void QSWidget::mousedown_event(GUI::MouseEvent& event)
     m_saved_pan_origin = m_pan_origin;
 }
 
-void QSWidget::mouseup_event(GUI::MouseEvent& event)
-{
-    UNUSED_PARAM(event);
-}
+void QSWidget::mouseup_event([[maybe_unused]] GUI::MouseEvent& event) { }
 
 void QSWidget::mousemove_event(GUI::MouseEvent& event)
 {

--- a/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -105,8 +105,7 @@ void MemoryStatsWidget::refresh()
     ASSERT(json_result.has_value());
     auto json = json_result.value().as_object();
 
-    unsigned kmalloc_eternal_allocated = json.get("kmalloc_eternal_allocated").to_u32();
-    (void)kmalloc_eternal_allocated;
+    [[maybe_unused]] unsigned kmalloc_eternal_allocated = json.get("kmalloc_eternal_allocated").to_u32();
     unsigned kmalloc_allocated = json.get("kmalloc_allocated").to_u32();
     unsigned kmalloc_available = json.get("kmalloc_available").to_u32();
     unsigned user_physical_allocated = json.get("user_physical_allocated").to_u32();

--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -278,8 +278,7 @@ int main(int argc, char** argv)
     process_context_menu->add_separator();
     process_context_menu->add_action(profile_action);
     process_context_menu->add_action(inspect_action);
-    process_table_view.on_context_menu_request = [&](const GUI::ModelIndex& index, const GUI::ContextMenuEvent& event) {
-        (void)index;
+    process_table_view.on_context_menu_request = [&]([[maybe_unused]] const GUI::ModelIndex& index, const GUI::ContextMenuEvent& event) {
         process_context_menu->popup(event.screen_position());
     };
 

--- a/Base/usr/share/man/man2/geteuid.md
+++ b/Base/usr/share/man/man2/geteuid.md
@@ -7,8 +7,8 @@ geteuid, getegid - get effective user / group id
 ```**c++
 #include <unistd.h>
 
-uid_t geteuid(void);
-gid_t getegid(void);
+uid_t geteuid();
+gid_t getegid();
 ```
 
 ## Description

--- a/Base/usr/share/man/man2/getuid.md
+++ b/Base/usr/share/man/man2/getuid.md
@@ -7,8 +7,8 @@ getuid, getgid - get real user / group id
 ```**c++
 #include <unistd.h>
 
-uid_t getuid(void);
-gid_t getgid(void);
+uid_t getuid();
+gid_t getgid();
 ```
 
 ## Description

--- a/Demos/DynamicLink/LinkDemo/main.cpp
+++ b/Demos/DynamicLink/LinkDemo/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv, char** envp)
     outln("Global lib variable is {}", *ptr_global);
 
     // Test getting a method from the library and calling it
-    void (*lib_func)(void) = (void (*)(void))dlsym(handle, "global_lib_function");
+    void (*lib_func)() = (void (*)())dlsym(handle, "global_lib_function");
 
     outln("Found global lib function address: {}", lib_func);
 

--- a/Demos/DynamicObject/main.cpp
+++ b/Demos/DynamicObject/main.cpp
@@ -39,12 +39,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-int main(int argc, char** argv, char** env)
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv, [[maybe_unused]] char** env)
 {
-    (void)argc;
-    (void)argv;
-    (void)env;
-
     printf("Well Hello Friends!\n");
     printf("trying to open /etc/fstab for writing..\n");
     int rc = open("/etc/fstab", O_RDWR);

--- a/Demos/WidgetGallery/main.cpp
+++ b/Demos/WidgetGallery/main.cpp
@@ -146,8 +146,7 @@ int main(int argc, char** argv)
 
     auto& radio1 = radio_button_container.add<GUI::RadioButton>("RadioButton 1");
     radio1.set_checked(true);
-    auto& radio2 = radio_button_container.add<GUI::RadioButton>("RadioButton 2");
-    (void)radio2;
+    [[maybe_unused]] auto& radio2 = radio_button_container.add<GUI::RadioButton>("RadioButton 2");
     auto& radio3 = radio_button_container.add<GUI::RadioButton>("RadioButton 3");
     radio3.set_enabled(false);
 
@@ -186,13 +185,11 @@ int main(int argc, char** argv)
     auto& checkbox2 = checkbox_container.add<GUI::CheckBox>("CheckBox 2");
     checkbox2.set_enabled(false);
 
-    auto& label1 = label_container.add<GUI::Label>("Label 1");
-    (void)label1;
+    [[maybe_unused]] auto& label1 = label_container.add<GUI::Label>("Label 1");
     auto& label2 = label_container.add<GUI::Label>("Label 2");
     label2.set_enabled(false);
 
-    auto& spinbox1 = spin_container.add<GUI::SpinBox>();
-    (void)spinbox1;
+    [[maybe_unused]] auto& spinbox1 = spin_container.add<GUI::SpinBox>();
     auto& spinbox2 = spin_container.add<GUI::SpinBox>();
     spinbox2.set_enabled(false);
 
@@ -213,8 +210,7 @@ int main(int argc, char** argv)
     auto& button2 = button_vert1_container.add<GUI::Button>("Button 2");
     button2.set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/kill.png"));
     button2.set_enabled(false);
-    auto& button3 = button_vert2_container.add<GUI::Button>("\xF0\x9F\x98\x88 Button 3");
-    (void)button3;
+    [[maybe_unused]] auto& button3 = button_vert2_container.add<GUI::Button>("\xF0\x9F\x98\x88 Button 3");
     auto& button4 = button_vert2_container.add<GUI::Button>("\xF0\x9F\x8D\x86 Button 4");
     button4.set_enabled(false);
 
@@ -334,8 +330,7 @@ int main(int argc, char** argv)
     horizontal_slider_container2.set_layout<GUI::HorizontalBoxLayout>();
     horizontal_slider_container2.layout()->set_margins({ 4, 4, 4, 4 });
 
-    auto& slider1 = horizontal_slider_container.add<GUI::HorizontalSlider>();
-    (void)slider1;
+    [[maybe_unused]] auto& slider1 = horizontal_slider_container.add<GUI::HorizontalSlider>();
     auto& slider2 = horizontal_slider_container.add<GUI::HorizontalSlider>();
     slider2.set_enabled(false);
     slider2.set_value(50);

--- a/DevTools/HackStudio/TerminalWrapper.cpp
+++ b/DevTools/HackStudio/TerminalWrapper.cpp
@@ -107,13 +107,13 @@ void TerminalWrapper::run_command(const String& command)
         tcsetpgrp(pts_fd, getpid());
 
         // NOTE: It's okay if this fails.
-        (void)ioctl(0, TIOCNOTTY);
+        int rc = ioctl(0, TIOCNOTTY);
 
         close(0);
         close(1);
         close(2);
 
-        int rc = dup2(pts_fd, 0);
+        rc = dup2(pts_fd, 0);
         if (rc < 0) {
             perror("dup2");
             exit(1);
@@ -164,7 +164,7 @@ void TerminalWrapper::kill_running_command()
     ASSERT(m_pid != -1);
 
     // Kill our child process and its whole process group.
-    (void)killpg(m_pid, SIGTERM);
+    [[maybe_unused]] auto rc = killpg(m_pid, SIGTERM);
 }
 
 TerminalWrapper::TerminalWrapper(bool user_spawned)

--- a/DevTools/HackStudio/WidgetTool.cpp
+++ b/DevTools/HackStudio/WidgetTool.cpp
@@ -29,27 +29,23 @@
 
 namespace HackStudio {
 
-void WidgetTool::on_mousedown(GUI::MouseEvent& event)
+void WidgetTool::on_mousedown([[maybe_unused]] GUI::MouseEvent& event)
 {
-    (void)event;
     dbgln("WidgetTool::on_mousedown");
 }
 
-void WidgetTool::on_mouseup(GUI::MouseEvent& event)
+void WidgetTool::on_mouseup([[maybe_unused]] GUI::MouseEvent& event)
 {
-    (void)event;
     dbgln("WidgetTool::on_mouseup");
 }
 
-void WidgetTool::on_mousemove(GUI::MouseEvent& event)
+void WidgetTool::on_mousemove([[maybe_unused]] GUI::MouseEvent& event)
 {
-    (void)event;
     dbgln("WidgetTool::on_mousemove");
 }
 
-void WidgetTool::on_keydown(GUI::KeyEvent& event)
+void WidgetTool::on_keydown([[maybe_unused]] GUI::KeyEvent& event)
 {
-    (void)event;
     dbgln("WidgetTool::on_keydown");
 }
 

--- a/DevTools/Profiler/Profile.cpp
+++ b/DevTools/Profiler/Profile.cpp
@@ -95,9 +95,8 @@ static String symbolicate(FlatPtr eip, const ELF::Core::MemoryRegionInfo* region
     return String::format("[%s] %s", name.characters(), lib_data->lib_elf->symbolicate(eip - region->region_start, &offset).characters());
 }
 
-static String symbolicate_from_coredump(CoreDumpReader& coredump, u32 ptr, u32& offset)
+static String symbolicate_from_coredump(CoreDumpReader& coredump, u32 ptr, [[maybe_unused]] u32& offset)
 {
-    (void)offset;
     auto* region = coredump.region_containing((FlatPtr)ptr);
     if (!region) {
         dbgln("did not find region for eip: {:p}", ptr);

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -1149,10 +1149,8 @@ int Emulator::virt$get_dir_entries(int fd, FlatPtr buffer, ssize_t size)
     return rc;
 }
 
-int Emulator::virt$ioctl(int fd, unsigned request, FlatPtr arg)
+int Emulator::virt$ioctl([[maybe_unused]] int fd, unsigned request, [[maybe_unused]] FlatPtr arg)
 {
-    (void)fd;
-    (void)arg;
     if (request == TIOCGWINSZ) {
         struct winsize ws;
         int rc = syscall(SC_ioctl, fd, TIOCGWINSZ, &ws);
@@ -1493,8 +1491,8 @@ void Emulator::dispatch_one_pending_signal()
 }
 
 // Make sure the compiler doesn't "optimize away" this function:
-extern void signal_trampoline_dummy(void);
-void signal_trampoline_dummy(void)
+extern void signal_trampoline_dummy();
+void signal_trampoline_dummy()
 {
     // The trampoline preserves the current eax, pushes the signal code and
     // then calls the signal handler. We do this because, when interrupting a
@@ -1518,8 +1516,8 @@ void signal_trampoline_dummy(void)
         ".att_syntax" ::"i"(Syscall::SC_sigreturn));
 }
 
-extern "C" void asm_signal_trampoline(void);
-extern "C" void asm_signal_trampoline_end(void);
+extern "C" void asm_signal_trampoline();
+extern "C" void asm_signal_trampoline_end();
 
 void Emulator::setup_signal_trampoline()
 {

--- a/Kernel/Assertions.h
+++ b/Kernel/Assertions.h
@@ -31,7 +31,7 @@
 
 #ifdef DEBUG
 [[noreturn]] void __assertion_failed(const char* msg, const char* file, unsigned line, const char* func);
-#    define ASSERT(expr) (static_cast<bool>(expr) ? (void)0 : __assertion_failed(#    expr, __FILE__, __LINE__, __PRETTY_FUNCTION__))
+#    define ASSERT(expr) (static_cast<bool>(expr) ? void(0) : __assertion_failed(#    expr, __FILE__, __LINE__, __PRETTY_FUNCTION__))
 #    define ASSERT_NOT_REACHED() ASSERT(false)
 #else
 #    define ASSERT(expr)

--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -116,7 +116,7 @@ void CoreDump::write_elf_header()
     elf_file_header.e_shnum = 0;
     elf_file_header.e_shstrndx = SHN_UNDEF;
 
-    (void)m_fd->write(UserOrKernelBuffer::for_kernel_buffer(reinterpret_cast<uint8_t*>(&elf_file_header)), sizeof(Elf32_Ehdr));
+    [[maybe_unused]] auto rc = m_fd->write(UserOrKernelBuffer::for_kernel_buffer(reinterpret_cast<uint8_t*>(&elf_file_header)), sizeof(Elf32_Ehdr));
 }
 
 void CoreDump::write_program_headers(size_t notes_size)
@@ -142,7 +142,7 @@ void CoreDump::write_program_headers(size_t notes_size)
 
         offset += phdr.p_filesz;
 
-        (void)m_fd->write(UserOrKernelBuffer::for_kernel_buffer(reinterpret_cast<uint8_t*>(&phdr)), sizeof(Elf32_Phdr));
+        [[maybe_unused]] auto rc = m_fd->write(UserOrKernelBuffer::for_kernel_buffer(reinterpret_cast<uint8_t*>(&phdr)), sizeof(Elf32_Phdr));
     }
 
     Elf32_Phdr notes_pheader {};
@@ -155,7 +155,7 @@ void CoreDump::write_program_headers(size_t notes_size)
     notes_pheader.p_align = 0;
     notes_pheader.p_flags = 0;
 
-    (void)m_fd->write(UserOrKernelBuffer::for_kernel_buffer(reinterpret_cast<uint8_t*>(&notes_pheader)), sizeof(Elf32_Phdr));
+    [[maybe_unused]] auto rc = m_fd->write(UserOrKernelBuffer::for_kernel_buffer(reinterpret_cast<uint8_t*>(&notes_pheader)), sizeof(Elf32_Phdr));
 }
 
 void CoreDump::write_regions()
@@ -182,14 +182,14 @@ void CoreDump::write_regions()
                 //       (A page may not be backed by a physical page because it has never been faulted in when the process ran).
                 src_buffer = UserOrKernelBuffer::for_kernel_buffer(zero_buffer);
             }
-            (void)m_fd->write(src_buffer.value(), PAGE_SIZE);
+            [[maybe_unused]] auto rc = m_fd->write(src_buffer.value(), PAGE_SIZE);
         }
     }
 }
 
 void CoreDump::write_notes_segment(ByteBuffer& notes_segment)
 {
-    (void)m_fd->write(UserOrKernelBuffer::for_kernel_buffer(notes_segment.data()), notes_segment.size());
+    [[maybe_unused]] auto rc = m_fd->write(UserOrKernelBuffer::for_kernel_buffer(notes_segment.data()), notes_segment.size());
 }
 
 ByteBuffer CoreDump::create_notes_threads_data() const
@@ -264,7 +264,7 @@ void CoreDump::write()
     write_regions();
     write_notes_segment(notes_segment);
 
-    (void)m_fd->chmod(0400); // Make coredump file readable
+    [[maybe_unused]] auto rc = m_fd->chmod(0400); // Make coredump file readable
 }
 
 }

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -290,7 +290,7 @@ void BlockBasedFS::flush_specific_block_if_needed(unsigned index)
             file_description().seek(base_offset, SEEK_SET);
             // FIXME: Should this error path be surfaced somehow?
             auto entry_data_buffer = UserOrKernelBuffer::for_kernel_buffer(entry.data);
-            (void)file_description().write(entry_data_buffer, block_size());
+            [[maybe_unused]] auto rc = file_description().write(entry_data_buffer, block_size());
             cleaned_entries.append(&entry);
         }
     });
@@ -311,7 +311,7 @@ void BlockBasedFS::flush_writes_impl()
         file_description().seek(base_offset, SEEK_SET);
         // FIXME: Should this error path be surfaced somehow?
         auto entry_data_buffer = UserOrKernelBuffer::for_kernel_buffer(entry.data);
-        (void)file_description().write(entry_data_buffer, block_size());
+        [[maybe_unused]] auto rc = file_description().write(entry_data_buffer, block_size());
         ++count;
     });
     cache().mark_all_clean();

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -71,7 +71,7 @@ FileDescription::~FileDescription()
     if (is_fifo())
         static_cast<FIFO*>(m_file.ptr())->detach(m_fifo_direction);
     // FIXME: Should this error path be observed somehow?
-    (void)m_file->close();
+    [[maybe_unused]] auto rc = m_file->close();
     m_inode = nullptr;
 }
 

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -710,7 +710,7 @@ Plan9FSInode::~Plan9FSInode()
     Plan9FS::Message clunk_request { fs(), Plan9FS::Message::Type::Tclunk };
     clunk_request << fid();
     // FIXME: Should we observe this  error somehow?
-    (void)fs().post_message_and_explicitly_ignore_reply(clunk_request);
+    [[maybe_unused]] auto rc = fs().post_message_and_explicitly_ignore_reply(clunk_request);
 }
 
 KResult Plan9FSInode::ensure_open_for_mode(int mode)
@@ -909,7 +909,7 @@ KResult Plan9FSInode::traverse_as_directory(Function<bool(const FS::DirectoryEnt
                 Plan9FS::Message close_message { fs(), Plan9FS::Message::Type::Tclunk };
                 close_message << clone_fid;
                 // FIXME: Should we observe this error?
-                (void)fs().post_message_and_explicitly_ignore_reply(close_message);
+                [[maybe_unused]] auto rc = fs().post_message_and_explicitly_ignore_reply(close_message);
                 return result;
             }
         }
@@ -942,7 +942,7 @@ KResult Plan9FSInode::traverse_as_directory(Function<bool(const FS::DirectoryEnt
         Plan9FS::Message close_message { fs(), Plan9FS::Message::Type::Tclunk };
         close_message << clone_fid;
         // FIXME: Should we observe this error?
-        (void)fs().post_message_and_explicitly_ignore_reply(close_message);
+        [[maybe_unused]] auto rc = fs().post_message_and_explicitly_ignore_reply(close_message);
         return result;
     } else {
         // TODO

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -1647,9 +1647,8 @@ KResult ProcFSInode::add_child(Inode&, const StringView&, mode_t)
     return KResult(-EPERM);
 }
 
-KResult ProcFSInode::remove_child(const StringView& name)
+KResult ProcFSInode::remove_child([[maybe_unused]] const StringView& name)
 {
-    (void)name;
     return KResult(-EPERM);
 }
 

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -210,7 +210,7 @@ void APIC::write_icr(const ICRReg& icr)
 #define APIC_LVT_TRIGGER_LEVEL (1 << 14)
 #define APIC_LVT(iv, dm) (((iv)&0xff) | (((dm)&0x7) << 8))
 
-extern "C" void apic_ap_start(void);
+extern "C" void apic_ap_start();
 extern "C" u16 apic_ap_start_size;
 extern "C" u32 ap_cpu_init_stacks;
 extern "C" u32 ap_cpu_init_processor_info_array;

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -150,7 +150,7 @@ void E1000NetworkAdapter::detect()
         if (id != qemu_bochs_vbox_id)
             return;
         u8 irq = PCI::get_interrupt_line(address);
-        (void)adopt(*new E1000NetworkAdapter(address, irq)).leak_ref();
+        [[maybe_unused]] auto& unused = adopt(*new E1000NetworkAdapter(address, irq)).leak_ref();
     });
 }
 

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -203,11 +203,10 @@ int IPv4Socket::allocate_local_port_if_needed()
     return port;
 }
 
-KResultOr<size_t> IPv4Socket::sendto(FileDescription&, const UserOrKernelBuffer& data, size_t data_length, int flags, Userspace<const sockaddr*> addr, socklen_t addr_length)
+KResultOr<size_t> IPv4Socket::sendto(FileDescription&, const UserOrKernelBuffer& data, size_t data_length, [[maybe_unused]] int flags, Userspace<const sockaddr*> addr, socklen_t addr_length)
 {
     LOCKER(lock());
 
-    (void)flags;
     if (addr && addr_length != sizeof(sockaddr_in))
         return KResult(-EINVAL);
 
@@ -621,7 +620,7 @@ int IPv4Socket::ioctl(FileDescription&, unsigned request, FlatPtr arg)
 
 KResult IPv4Socket::close()
 {
-    (void)shutdown(SHUT_RDWR);
+    [[maybe_unused]] auto rc = shutdown(SHUT_RDWR);
     return KSuccess;
 }
 

--- a/Kernel/Net/RTL8139NetworkAdapter.cpp
+++ b/Kernel/Net/RTL8139NetworkAdapter.cpp
@@ -135,7 +135,7 @@ void RTL8139NetworkAdapter::detect()
         if (id != rtl8139_id)
             return;
         u8 irq = PCI::get_interrupt_line(address);
-        (void)adopt(*new RTL8139NetworkAdapter(address, irq)).leak_ref();
+        [[maybe_unused]] auto& unused = adopt(*new RTL8139NetworkAdapter(address, irq)).leak_ref();
     });
 }
 

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -144,7 +144,7 @@ void TCPSocket::release_for_accept(RefPtr<TCPSocket> socket)
     ASSERT(m_pending_release_for_accept.contains(socket->tuple()));
     m_pending_release_for_accept.remove(socket->tuple());
     // FIXME: Should we observe this error somehow?
-    (void)queue_connection_from(*socket);
+    [[maybe_unused]] auto rc = queue_connection_from(*socket);
 }
 
 TCPSocket::TCPSocket(int protocol)
@@ -167,9 +167,8 @@ NonnullRefPtr<TCPSocket> TCPSocket::create(int protocol)
     return adopt(*new TCPSocket(protocol));
 }
 
-KResultOr<size_t> TCPSocket::protocol_receive(ReadonlyBytes raw_ipv4_packet, UserOrKernelBuffer& buffer, size_t buffer_size, int flags)
+KResultOr<size_t> TCPSocket::protocol_receive(ReadonlyBytes raw_ipv4_packet, UserOrKernelBuffer& buffer, size_t buffer_size, [[maybe_unused]] int flags)
 {
-    (void)flags;
     auto& ipv4_packet = *reinterpret_cast<const IPv4Packet*>(raw_ipv4_packet.data());
     auto& tcp_packet = *static_cast<const TCPPacket*>(ipv4_packet.payload());
     size_t payload_size = raw_ipv4_packet.size() - sizeof(IPv4Packet) - tcp_packet.header_size();
@@ -464,7 +463,7 @@ void TCPSocket::shut_down_for_writing()
 #ifdef TCP_SOCKET_DEBUG
         dbg() << " Sending FIN/ACK from Established and moving into FinWait1";
 #endif
-        (void)send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);
+        [[maybe_unused]] auto rc = send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);
         set_state(State::FinWait1);
     } else {
         dbg() << " Shutting down TCPSocket for writing but not moving to FinWait1 since state is " << to_string(state());
@@ -479,7 +478,7 @@ KResult TCPSocket::close()
 #ifdef TCP_SOCKET_DEBUG
         dbg() << " Sending FIN from CloseWait and moving into LastAck";
 #endif
-        (void)send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);
+        [[maybe_unused]] auto rc = send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);
         set_state(State::LastAck);
     }
 

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -79,9 +79,8 @@ NonnullRefPtr<UDPSocket> UDPSocket::create(int protocol)
     return adopt(*new UDPSocket(protocol));
 }
 
-KResultOr<size_t> UDPSocket::protocol_receive(ReadonlyBytes raw_ipv4_packet, UserOrKernelBuffer& buffer, size_t buffer_size, int flags)
+KResultOr<size_t> UDPSocket::protocol_receive(ReadonlyBytes raw_ipv4_packet, UserOrKernelBuffer& buffer, size_t buffer_size, [[maybe_unused]] int flags)
 {
-    (void)flags;
     auto& ipv4_packet = *(const IPv4Packet*)(raw_ipv4_packet.data());
     auto& udp_packet = *static_cast<const UDPPacket*>(ipv4_packet.payload());
     ASSERT(udp_packet.length() >= sizeof(UDPPacket)); // FIXME: This should be rejected earlier.

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -401,8 +401,8 @@ void Process::dump_regions()
 }
 
 // Make sure the compiler doesn't "optimize away" this function:
-extern void signal_trampoline_dummy(void);
-void signal_trampoline_dummy(void)
+extern void signal_trampoline_dummy();
+void signal_trampoline_dummy()
 {
     // The trampoline preserves the current eax, pushes the signal code and
     // then calls the signal handler. We do this because, when interrupting a
@@ -426,8 +426,8 @@ void signal_trampoline_dummy(void)
         ".att_syntax" ::"i"(Syscall::SC_sigreturn));
 }
 
-extern "C" void asm_signal_trampoline(void);
-extern "C" void asm_signal_trampoline_end(void);
+extern "C" void asm_signal_trampoline();
+extern "C" void asm_signal_trampoline_end();
 
 void create_signal_trampolines()
 {

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -253,14 +253,13 @@ bool Scheduler::yield()
     return true;
 }
 
-bool Scheduler::donate_to_and_switch(Thread* beneficiary, const char* reason)
+bool Scheduler::donate_to_and_switch(Thread* beneficiary, [[maybe_unused]] const char* reason)
 {
     ASSERT(g_scheduler_lock.own_lock());
 
     auto& proc = Processor::current();
     ASSERT(proc.in_critical() == 1);
 
-    (void)reason;
     unsigned ticks_left = Thread::current()->ticks_left();
     if (!beneficiary || beneficiary->state() != Thread::Runnable || ticks_left <= 1)
         return Scheduler::yield();

--- a/Kernel/Syscalls/alarm.cpp
+++ b/Kernel/Syscalls/alarm.cpp
@@ -49,7 +49,7 @@ unsigned Process::sys$alarm(unsigned seconds)
         auto deadline = TimeManagement::the().current_time(CLOCK_REALTIME).value();
         timespec_add(deadline, { seconds, 0 }, deadline);
         m_alarm_timer = TimerQueue::the().add_timer_without_id(CLOCK_REALTIME, deadline, [this]() {
-            (void)send_signal(SIGALRM, nullptr);
+            [[maybe_unused]] auto rc = send_signal(SIGALRM, nullptr);
         });
     }
     return previous_alarm_remaining;

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -371,7 +371,7 @@ int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Ve
         new_main_thread->set_state(Thread::State::Runnable);
     }
     u32 lock_count_to_restore;
-    (void)big_lock().force_unlock_if_locked(lock_count_to_restore);
+    [[maybe_unused]] auto rc = big_lock().force_unlock_if_locked(lock_count_to_restore);
     ASSERT_INTERRUPTS_DISABLED();
     ASSERT(Processor::current().in_critical());
     return 0;

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -57,7 +57,7 @@ KResultOr<size_t> TTY::read(FileDescription&, size_t, UserOrKernelBuffer& buffer
 {
     if (Process::current()->pgid() != pgid()) {
         // FIXME: Should we propagate this error path somehow?
-        (void)Process::current()->send_signal(SIGTTIN, nullptr);
+        [[maybe_unused]] auto rc = Process::current()->send_signal(SIGTTIN, nullptr);
         return KResult(-EINTR);
     }
 
@@ -104,7 +104,7 @@ KResultOr<size_t> TTY::read(FileDescription&, size_t, UserOrKernelBuffer& buffer
 KResultOr<size_t> TTY::write(FileDescription&, size_t, const UserOrKernelBuffer& buffer, size_t size)
 {
     if (Process::current()->pgid() != pgid()) {
-        (void)Process::current()->send_signal(SIGTTOU, nullptr);
+        [[maybe_unused]] auto rc = Process::current()->send_signal(SIGTTOU, nullptr);
         return KResult(-EINTR);
     }
 
@@ -172,7 +172,7 @@ void TTY::emit(u8 ch, bool do_evaluate_block_conditions)
             dbg() << tty_name() << ": VSUSP pressed!";
             generate_signal(SIGTSTP);
             if (auto original_process_parent = m_original_process_parent.strong_ref())
-                (void)original_process_parent->send_signal(SIGCHLD, nullptr);
+                [[maybe_unused]] auto rc = original_process_parent->send_signal(SIGCHLD, nullptr);
             // TODO: Else send it to the session leader maybe?
             return;
         }
@@ -288,7 +288,7 @@ void TTY::generate_signal(int signal)
     Process::for_each_in_pgrp(pgid(), [&](auto& process) {
         dbg() << tty_name() << ": Send signal " << signal << " to " << process;
         // FIXME: Should this error be propagated somehow?
-        (void)process.send_signal(signal, nullptr);
+        [[maybe_unused]] auto rc = process.send_signal(signal, nullptr);
         return IterationDecision::Continue;
     });
 }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -213,7 +213,7 @@ void Thread::die_if_needed()
         return;
 
     u32 unlock_count;
-    (void)unlock_process_if_locked(unlock_count);
+    [[maybe_unused]] auto rc = unlock_process_if_locked(unlock_count);
 
     ScopedCritical critical;
     set_should_die();
@@ -240,7 +240,7 @@ void Thread::exit(void* exit_value)
     m_join_condition.thread_did_exit(exit_value);
     set_should_die();
     u32 unlock_count;
-    (void)unlock_process_if_locked(unlock_count);
+    [[maybe_unused]] auto rc = unlock_process_if_locked(unlock_count);
     die_if_needed();
 }
 

--- a/Kernel/Time/APICTimer.cpp
+++ b/Kernel/Time/APICTimer.cpp
@@ -165,21 +165,18 @@ void APICTimer::reset_to_default_ticks_per_second()
 {
 }
 
-bool APICTimer::try_to_set_frequency(size_t frequency)
+bool APICTimer::try_to_set_frequency([[maybe_unused]] size_t frequency)
 {
-    (void)frequency;
     return true;
 }
 
-bool APICTimer::is_capable_of_frequency(size_t frequency) const
+bool APICTimer::is_capable_of_frequency([[maybe_unused]] size_t frequency) const
 {
-    (void)frequency;
     return false;
 }
 
-size_t APICTimer::calculate_nearest_possible_frequency(size_t frequency) const
+size_t APICTimer::calculate_nearest_possible_frequency([[maybe_unused]] size_t frequency) const
 {
-    (void)frequency;
     return 0;
 }
 

--- a/Kernel/VM/InodeVMObject.cpp
+++ b/Kernel/VM/InodeVMObject.cpp
@@ -89,10 +89,8 @@ void InodeVMObject::inode_size_changed(Badge<Inode>, size_t old_size, size_t new
     });
 }
 
-void InodeVMObject::inode_contents_changed(Badge<Inode>, off_t offset, ssize_t size, const UserOrKernelBuffer& data)
+void InodeVMObject::inode_contents_changed(Badge<Inode>, off_t offset, [[maybe_unused]] ssize_t size, [[maybe_unused]] const UserOrKernelBuffer& data)
 {
-    (void)size;
-    (void)data;
     InterruptDisabler disabler;
     ASSERT(offset >= 0);
 

--- a/Libraries/LibC/assert.h
+++ b/Libraries/LibC/assert.h
@@ -41,7 +41,7 @@ __attribute__((noreturn)) void __assertion_failed(const char* msg);
         } while (0)
 #    define ASSERT_NOT_REACHED() assert(false)
 #else
-#    define assert(expr) ((void)0)
+#    define assert(expr) (void(0))
 #    define ASSERT_NOT_REACHED() CRASH()
 #endif
 

--- a/Libraries/LibC/sched.cpp
+++ b/Libraries/LibC/sched.cpp
@@ -36,15 +36,13 @@ int sched_yield()
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-int sched_get_priority_min(int policy)
+int sched_get_priority_min([[maybe_unused]] int policy)
 {
-    (void)policy;
     return 0; // Idle
 }
 
-int sched_get_priority_max(int policy)
+int sched_get_priority_max([[maybe_unused]] int policy)
 {
-    (void)policy;
     return 3; // High
 }
 

--- a/Libraries/LibC/stdio.cpp
+++ b/Libraries/LibC/stdio.cpp
@@ -1179,15 +1179,13 @@ int vfscanf(FILE* stream, const char* fmt, va_list ap)
     return vsscanf(buffer, fmt, ap);
 }
 
-void flockfile(FILE* filehandle)
+void flockfile([[maybe_unused]] FILE* filehandle)
 {
-    (void)filehandle;
     dbgprintf("FIXME: Implement flockfile()\n");
 }
 
-void funlockfile(FILE* filehandle)
+void funlockfile([[maybe_unused]] FILE* filehandle)
 {
-    (void)filehandle;
     dbgprintf("FIXME: Implement funlockfile()\n");
 }
 

--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -804,11 +804,9 @@ size_t mbstowcs(wchar_t*, const char*, size_t)
     ASSERT_NOT_REACHED();
 }
 
-int mbtowc(wchar_t* wch, const char* data, size_t data_size)
+int mbtowc(wchar_t* wch, const char* data, [[maybe_unused]] size_t data_size)
 {
     // FIXME: This needs a real implementation.
-    UNUSED_PARAM(data_size);
-
     if (wch && data) {
         *wch = *data;
         return 1;
@@ -1023,7 +1021,7 @@ unsigned long long strtoull(const char* str, char** endptr, int base)
 // Serenity's PRNG is not cryptographically secure. Do not rely on this for
 // any real crypto! These functions (for now) are for compatibility.
 // TODO: In the future, rand can be made deterministic and this not.
-uint32_t arc4random(void)
+uint32_t arc4random()
 {
     char buf[4];
     syscall(SC_getrandom, buf, 4, 0);
@@ -1073,15 +1071,13 @@ int posix_openpt(int flags)
     return open("/dev/ptmx", flags);
 }
 
-int grantpt(int fd)
+int grantpt([[maybe_unused]] int fd)
 {
-    (void)fd;
     return 0;
 }
 
-int unlockpt(int fd)
+int unlockpt([[maybe_unused]] int fd)
 {
-    (void)fd;
     return 0;
 }
 }

--- a/Libraries/LibC/stdlib.h
+++ b/Libraries/LibC/stdlib.h
@@ -41,13 +41,13 @@ __BEGIN_DECLS
 __attribute__((malloc)) __attribute__((alloc_size(1))) void* malloc(size_t);
 __attribute__((malloc)) __attribute__((alloc_size(1, 2))) void* calloc(size_t nmemb, size_t);
 size_t malloc_size(void*);
-void serenity_dump_malloc_stats(void);
+void serenity_dump_malloc_stats();
 void free(void*);
 __attribute__((alloc_size(2))) void* realloc(void* ptr, size_t);
 char* getenv(const char* name);
 int putenv(char*);
 int unsetenv(const char*);
-int clearenv(void);
+int clearenv();
 int setenv(const char* name, const char* value, int overwrite);
 int atoi(const char*);
 long atol(const char*);
@@ -87,7 +87,7 @@ void srand(unsigned seed);
 long int random();
 void srandom(unsigned seed);
 
-uint32_t arc4random(void);
+uint32_t arc4random();
 void arc4random_buf(void*, size_t);
 uint32_t arc4random_uniform(uint32_t);
 

--- a/Libraries/LibC/syslog.cpp
+++ b/Libraries/LibC/syslog.cpp
@@ -94,7 +94,7 @@ void closelog_r(struct syslog_data* data)
     data->maskpri = LOG_UPTO(LOG_DEBUG);
 }
 
-void closelog(void)
+void closelog()
 {
     closelog_r(&global_log_data);
 }

--- a/Libraries/LibC/syslog.h
+++ b/Libraries/LibC/syslog.h
@@ -61,8 +61,8 @@ struct syslog_data {
 #define LOG_DAEMON   ( 3 << 3)
 #define LOG_AUTH     ( 4 << 3)
 #define LOG_SYSLOG   ( 5 << 3)
-#define LOG_LPR      ( 6 << 3) 
-#define LOG_NEWS     ( 7 << 3) 
+#define LOG_LPR      ( 6 << 3)
+#define LOG_NEWS     ( 7 << 3)
 #define LOG_UUCP     ( 8 << 3)
 #define LOG_CRON     ( 9 << 3)
 #define LOG_AUTHPRIV (10 << 3)
@@ -169,7 +169,7 @@ void vsyslog(int, const char* message, va_list);
 void vsyslog_r(int, struct syslog_data* data, const char* message, va_list);
 void openlog(const char*, int, int);
 void openlog_r(const char*, int, int, struct syslog_data*);
-void closelog(void);
+void closelog();
 void closelog_r(struct syslog_data*);
 int setlogmask(int);
 int setlogmask_r(int, struct syslog_data*);

--- a/Libraries/LibC/termcap.cpp
+++ b/Libraries/LibC/termcap.cpp
@@ -39,10 +39,8 @@ char PC;
 char* UP;
 char* BC;
 
-int tgetent(char* bp, const char* name)
+int tgetent([[maybe_unused]] char* bp, [[maybe_unused]] const char* name)
 {
-    (void)bp;
-    (void)name;
 #ifdef TERMCAP_DEBUG
     fprintf(stderr, "tgetent: bp=%p, name='%s'\n", bp, name);
 #endif
@@ -120,9 +118,8 @@ char* tgetstr(const char* id, char** area)
 
 #pragma GCC diagnostic pop
 
-int tgetflag(const char* id)
+int tgetflag([[maybe_unused]] const char* id)
 {
-    (void)id;
 #ifdef TERMCAP_DEBUG
     fprintf(stderr, "tgetflag: '%s'\n", id);
 #endif
@@ -143,17 +140,13 @@ int tgetnum(const char* id)
     ASSERT_NOT_REACHED();
 }
 
-char* tgoto(const char* cap, int col, int row)
+char* tgoto([[maybe_unused]] const char* cap, [[maybe_unused]] int col, [[maybe_unused]] int row)
 {
-    (void)cap;
-    (void)col;
-    (void)row;
     ASSERT_NOT_REACHED();
 }
 
-int tputs(const char* str, int affcnt, int (*putc)(int))
+int tputs(const char* str, [[maybe_unused]] int affcnt, int (*putc)(int))
 {
-    (void)affcnt;
     size_t len = strlen(str);
     for (size_t i = 0; i < len; ++i)
         putc(str[i]);

--- a/Libraries/LibC/termios.cpp
+++ b/Libraries/LibC/termios.cpp
@@ -51,10 +51,8 @@ int tcsetattr(int fd, int optional_actions, const struct termios* t)
     return -1;
 }
 
-int tcflow(int fd, int action)
+int tcflow([[maybe_unused]] int fd, [[maybe_unused]] int action)
 {
-    (void)fd;
-    (void)action;
     ASSERT_NOT_REACHED();
 }
 

--- a/Libraries/LibC/ulimit.cpp
+++ b/Libraries/LibC/ulimit.cpp
@@ -31,18 +31,14 @@
 
 extern "C" {
 
-long ulimit(int cmd, long newlimit)
+long ulimit([[maybe_unused]] int cmd, [[maybe_unused]] long newlimit)
 {
-    (void)cmd;
-    (void)newlimit;
     ASSERT_NOT_REACHED();
     return -1;
 }
 
-int getrusage(int who, struct rusage* usage)
+int getrusage([[maybe_unused]] int who, [[maybe_unused]] struct rusage* usage)
 {
-    (void)who;
-    (void)usage;
     dbg() << "LibC: getrusage is not implemented";
     return -1;
 }

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -515,11 +515,8 @@ int mknod(const char* pathname, mode_t mode, dev_t dev)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-long fpathconf(int fd, int name)
+long fpathconf([[maybe_unused]] int fd, [[maybe_unused]] int name)
 {
-    (void)fd;
-    (void)name;
-
     switch (name) {
     case _PC_PATH_MAX:
         return PATH_MAX;
@@ -530,10 +527,8 @@ long fpathconf(int fd, int name)
     ASSERT_NOT_REACHED();
 }
 
-long pathconf(const char* path, int name)
+long pathconf([[maybe_unused]] const char* path, int name)
 {
-    (void)path;
-
     switch (name) {
     case _PC_PATH_MAX:
         return PATH_MAX;
@@ -614,9 +609,8 @@ void sysbeep()
     syscall(SC_beep);
 }
 
-int fsync(int fd)
+int fsync([[maybe_unused]] int fd)
 {
-    UNUSED_PARAM(fd);
     dbgprintf("FIXME: Implement fsync()\n");
     return 0;
 }

--- a/Libraries/LibChess/Chess.cpp
+++ b/Libraries/LibChess/Chess.cpp
@@ -770,8 +770,7 @@ Board::Result Board::game_result() const
         return Result::InsufficientMaterial;
 
     bool are_legal_moves = false;
-    generate_moves([&](Move m) {
-        (void)m;
+    generate_moves([&]([[maybe_unused]] Move m) {
         are_legal_moves = true;
         return IterationDecision::Break;
     });

--- a/Libraries/LibChess/UCICommand.cpp
+++ b/Libraries/LibChess/UCICommand.cpp
@@ -316,9 +316,8 @@ String BestMoveCommand::to_string() const
     return builder.build();
 }
 
-InfoCommand InfoCommand::from_string(const StringView& command)
+InfoCommand InfoCommand::from_string([[maybe_unused]] const StringView& command)
 {
-    (void)command;
     // FIXME: Implement this.
     ASSERT_NOT_REACHED();
 }

--- a/Libraries/LibELF/DynamicLoader.cpp
+++ b/Libraries/LibELF/DynamicLoader.cpp
@@ -391,7 +391,7 @@ void DynamicLoader::do_relocations(size_t total_tls_size)
             // Eagerly BIND_NOW the PLT entries, doing all the symbol looking goodness
             // The patch method returns the address for the LAZY fixup path, but we don't need it here
             VERBOSE("patching plt reloaction: 0x%x\n", relocation.offset_in_section());
-            (void)m_dynamic_object->patch_plt_entry(relocation.offset_in_section());
+            [[maybe_unused]] auto rc = m_dynamic_object->patch_plt_entry(relocation.offset_in_section());
         } else {
             // LAZY-ily bind the PLT slots by just adding the base address to the offsets stored there
             // This avoids doing symbol lookup, which might be expensive
@@ -408,7 +408,7 @@ void DynamicLoader::do_relocations(size_t total_tls_size)
 }
 
 // Defined in <arch>/plt_trampoline.S
-extern "C" void _plt_trampoline(void) __attribute__((visibility("hidden")));
+extern "C" void _plt_trampoline() __attribute__((visibility("hidden")));
 
 void DynamicLoader::setup_plt_trampoline()
 {

--- a/Libraries/LibGUI/JSSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/JSSyntaxHighlighter.cpp
@@ -63,9 +63,8 @@ bool JSSyntaxHighlighter::is_identifier(void* token) const
     return js_token == JS::TokenType::Identifier;
 }
 
-bool JSSyntaxHighlighter::is_navigatable(void* token) const
+bool JSSyntaxHighlighter::is_navigatable([[maybe_unused]] void* token) const
 {
-    (void)token;
     return false;
 }
 

--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -364,13 +364,11 @@ Bitmap::~Bitmap()
     delete[] m_palette;
 }
 
-void Bitmap::set_mmap_name(const StringView& name)
+void Bitmap::set_mmap_name([[maybe_unused]] const StringView& name)
 {
     ASSERT(m_needs_munmap);
 #ifdef __serenity__
     ::set_mmap_name(m_data, size_in_bytes(), name.to_string().characters());
-#else
-    (void)name;
 #endif
 }
 
@@ -431,7 +429,7 @@ ShareableBitmap Bitmap::to_shareable_bitmap(pid_t peer_pid) const
     return ShareableBitmap(*bitmap);
 }
 
-Optional<BackingStore> Bitmap::allocate_backing_store(BitmapFormat format, const IntSize& size, Purgeable purgeable)
+Optional<BackingStore> Bitmap::allocate_backing_store(BitmapFormat format, const IntSize& size, [[maybe_unused]] Purgeable purgeable)
 {
     if (size_would_overflow(format, size))
         return {};
@@ -444,7 +442,6 @@ Optional<BackingStore> Bitmap::allocate_backing_store(BitmapFormat format, const
     int map_flags = purgeable == Purgeable::Yes ? (MAP_PURGEABLE | MAP_PRIVATE) : (MAP_ANONYMOUS | MAP_PRIVATE);
     data = mmap_with_name(nullptr, data_size_in_bytes, PROT_READ | PROT_WRITE, map_flags, 0, 0, String::format("GraphicsBitmap [%dx%d]", size.width(), size.height()).characters());
 #else
-    UNUSED_PARAM(purgeable);
     int map_flags = (MAP_ANONYMOUS | MAP_PRIVATE);
     data = mmap(nullptr, data_size_in_bytes, PROT_READ | PROT_WRITE, map_flags, 0, 0);
 #endif

--- a/Libraries/LibGfx/PBMLoader.cpp
+++ b/Libraries/LibGfx/PBMLoader.cpp
@@ -118,10 +118,8 @@ static int read_number(Streamer& streamer)
     return sb.to_string().to_uint().value_or(0);
 }
 
-static bool read_comment(PBMLoadingContext& context, Streamer& streamer)
+static bool read_comment([[maybe_unused]] PBMLoadingContext& context, Streamer& streamer)
 {
-    (void)context;
-
     bool exist = false;
     u8 byte;
 

--- a/Libraries/LibGfx/PGMLoader.cpp
+++ b/Libraries/LibGfx/PGMLoader.cpp
@@ -135,10 +135,8 @@ static bool read_number(Streamer& streamer, u16* value)
     return true;
 }
 
-static bool read_comment(PGMLoadingContext& context, Streamer& streamer)
+static bool read_comment([[maybe_unused]] PGMLoadingContext& context, Streamer& streamer)
 {
-    (void)context;
-
     bool exist = false;
     u8 byte;
 

--- a/Libraries/LibGfx/PPMLoader.cpp
+++ b/Libraries/LibGfx/PPMLoader.cpp
@@ -138,10 +138,8 @@ static bool read_number(Streamer& streamer, u16* value)
     return true;
 }
 
-static bool read_comment(PPMLoadingContext& context, Streamer& streamer)
+static bool read_comment([[maybe_unused]] PPMLoadingContext& context, Streamer& streamer)
 {
-    (void)context;
-
     bool exist = false;
     u8 byte;
 

--- a/Libraries/LibHTTP/Job.cpp
+++ b/Libraries/LibHTTP/Job.cpp
@@ -271,11 +271,10 @@ void Job::on_socket_connected()
 
                     // we've read everything, now let's get the next chunk
                     size = -1;
-                    auto line = read_line(PAGE_SIZE);
+                    [[maybe_unused]] auto line = read_line(PAGE_SIZE);
 #ifdef JOB_DEBUG
                     dbg() << "Line following (should be empty): _" << line << "_";
 #endif
-                    (void)line;
                 }
                 m_current_chunk_remaining_size = size;
             }

--- a/Libraries/LibIPC/Decoder.cpp
+++ b/Libraries/LibIPC/Decoder.cpp
@@ -166,7 +166,7 @@ bool Decoder::decode(Dictionary& dictionary)
     return true;
 }
 
-bool Decoder::decode(File& file)
+bool Decoder::decode([[maybe_unused]] File& file)
 {
 #ifdef __serenity__
     int fd = recvfd(m_sockfd);
@@ -177,8 +177,7 @@ bool Decoder::decode(File& file)
     file = File(fd);
     return true;
 #else
-    (void)file;
-    (void)m_sockfd;
+    [[maybe_unused]] auto fd = m_sockfd;
     warnln("fd passing is not supported on this platform, sorry :(");
     return false;
 #endif

--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -42,7 +42,7 @@
     JS::Value name([[maybe_unused]] JS::VM& vm, [[maybe_unused]] JS::GlobalObject& global_object)
 
 #define JS_DEFINE_NATIVE_SETTER(name) \
-    void name([[maybe_unused]] JS::VM& vm, [[maybe_unused]] JS::GlobalObject& global_object, JS::Value value)
+    void name([[maybe_unused]] JS::VM& vm, [[maybe_unused]] JS::GlobalObject& global_object, [[maybe_unused]] JS::Value value)
 
 // NOTE: Proxy is not included here as it doesn't have a prototype - m_proxy_constructor is initialized separately.
 #define JS_ENUMERATE_NATIVE_OBJECTS_EXCLUDING_TEMPLATES                                           \

--- a/Libraries/LibJS/Runtime/Accessor.h
+++ b/Libraries/LibJS/Runtime/Accessor.h
@@ -63,7 +63,7 @@ public:
         if (!m_setter)
             return;
         // FIXME: It might be nice if we had a way to communicate to our caller if an exception happened after this.
-        (void)vm().call(*m_setter, this_value, setter_value);
+        [[maybe_unused]] auto rc = vm().call(*m_setter, this_value, setter_value);
     }
 
     void visit_edges(Cell::Visitor& visitor) override

--- a/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -87,9 +87,8 @@ Object* iterator_next(Object& iterator, Value value)
     return &result.as_object();
 }
 
-void iterator_close(Object& iterator)
+void iterator_close([[maybe_unused]] Object& iterator)
 {
-    (void)iterator;
     TODO();
 }
 

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -225,10 +225,7 @@ public:
     template<typename... Args>
     [[nodiscard]] ALWAYS_INLINE Value call(Function& function, Value this_value, Args... args)
     {
-        // Are there any values in this argpack?
-        // args = [] -> if constexpr (false)
-        // args = [x, y, z] -> if constexpr ((void)x, true || ...)
-        if constexpr ((((void)args, true) || ...)) {
+        if constexpr (sizeof...(Args) > 0) {
             MarkedValueList arglist { heap() };
             (..., arglist.append(move(args)));
             return call(function, this_value, move(arglist));

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -1480,7 +1480,7 @@ Vector<size_t, 2> Editor::vt_dsr()
 
     do {
         more_junk_to_read = false;
-        (void)select(1, &readfds, nullptr, nullptr, &timeout);
+        [[maybe_unused]] auto rc = select(1, &readfds, nullptr, nullptr, &timeout);
         if (FD_ISSET(0, &readfds)) {
             auto nread = read(0, buf, 16);
             if (nread < 0) {

--- a/Libraries/LibPthread/pthread.cpp
+++ b/Libraries/LibPthread/pthread.cpp
@@ -460,19 +460,13 @@ int pthread_attr_setstacksize(pthread_attr_t* attributes, size_t stack_size)
     return 0;
 }
 
-int pthread_getschedparam(pthread_t thread, int* policy, struct sched_param* param)
+int pthread_getschedparam([[maybe_unused]] pthread_t thread, [[maybe_unused]] int* policy, [[maybe_unused]] struct sched_param* param)
 {
-    (void)thread;
-    (void)policy;
-    (void)param;
     return 0;
 }
 
-int pthread_setschedparam(pthread_t thread, int policy, const struct sched_param* param)
+int pthread_setschedparam([[maybe_unused]] pthread_t thread, [[maybe_unused]] int policy, [[maybe_unused]] const struct sched_param* param)
 {
-    (void)thread;
-    (void)policy;
-    (void)param;
     return 0;
 }
 

--- a/Libraries/LibPthread/pthread.h
+++ b/Libraries/LibPthread/pthread.h
@@ -67,7 +67,7 @@ int pthread_attr_setstack(pthread_attr_t* attr, void*, size_t);
 int pthread_attr_getstacksize(const pthread_attr_t*, size_t*);
 int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 
-int pthread_once(pthread_once_t*, void (*)(void));
+int pthread_once(pthread_once_t*, void (*)());
 #define PTHREAD_ONCE_INIT 0
 void* pthread_getspecific(pthread_key_t key);
 int pthread_setspecific(pthread_key_t key, const void* value);
@@ -100,14 +100,14 @@ int pthread_cancel(pthread_t);
 int pthread_cond_destroy(pthread_cond_t*);
 int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, const struct timespec*);
 
-void pthread_testcancel(void);
+void pthread_testcancel();
 
 int pthread_spin_destroy(pthread_spinlock_t*);
 int pthread_spin_init(pthread_spinlock_t*, int);
 int pthread_spin_lock(pthread_spinlock_t*);
 int pthread_spin_trylock(pthread_spinlock_t*);
 int pthread_spin_unlock(pthread_spinlock_t*);
-pthread_t pthread_self(void);
+pthread_t pthread_self();
 int pthread_detach(pthread_t);
 int pthread_equal(pthread_t, pthread_t);
 int pthread_mutexattr_init(pthread_mutexattr_t*);

--- a/Libraries/LibPthread/pthread_once.cpp
+++ b/Libraries/LibPthread/pthread_once.cpp
@@ -37,7 +37,7 @@ enum State : i32 {
     PERFORMING_WITH_WAITERS,
 };
 
-int pthread_once(pthread_once_t* self, void (*callback)(void))
+int pthread_once(pthread_once_t* self, void (*callback)())
 {
     auto& state = reinterpret_cast<Atomic<State>&>(*self);
 

--- a/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -337,7 +337,6 @@ JS_DEFINE_NATIVE_GETTER(WindowObject::document_getter)
 JS_DEFINE_NATIVE_SETTER(WindowObject::document_setter)
 {
     // FIXME: Figure out what we should do here. Just ignore attempts to set window.document for now.
-    UNUSED_PARAM(value);
 }
 
 JS_DEFINE_NATIVE_GETTER(WindowObject::performance_getter)

--- a/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -48,10 +48,9 @@ namespace Web::DOM {
 
 // FIXME: This shouldn't be here, as retargeting is not only used by the event dispatcher.
 //        When moving this function, it needs to be generalized. https://dom.spec.whatwg.org/#retarget
-static EventTarget* retarget(EventTarget* left, EventTarget* right)
+static EventTarget* retarget(EventTarget* left, [[maybe_unused]] EventTarget* right)
 {
     // FIXME
-    UNUSED_PARAM(right);
     for (;;) {
         if (!is<Node>(left))
             return left;
@@ -110,7 +109,7 @@ bool EventDispatcher::inner_invoke(Event& event, Vector<EventTarget::EventListen
         auto* this_value = Bindings::wrap(global, *event.current_target());
         auto* wrapped_event = Bindings::wrap(global, event);
         auto& vm = global.vm();
-        (void)vm.call(listener.listener->function(), this_value, wrapped_event);
+        [[maybe_unused]] auto rc = vm.call(listener.listener->function(), this_value, wrapped_event);
         if (vm.exception()) {
             vm.clear_exception();
             // FIXME: Set legacyOutputDidListenersThrowFlag if given. (Only used by IndexedDB currently)

--- a/Libraries/LibWeb/DOM/Window.cpp
+++ b/Libraries/LibWeb/DOM/Window.cpp
@@ -98,7 +98,7 @@ void Window::timer_did_fire(Badge<Timer>, Timer& timer)
         m_timers.remove(timer.id());
     }
 
-    (void)vm.call(timer.callback(), wrapper());
+    [[maybe_unused]] auto rc = vm.call(timer.callback(), wrapper());
     if (vm.exception())
         vm.clear_exception();
 }
@@ -132,7 +132,7 @@ i32 Window::request_animation_frame(JS::Function& callback)
         auto& function = const_cast<JS::Function&>(static_cast<const JS::Function&>(*handle.cell()));
         auto& vm = function.vm();
         fake_timestamp += 10;
-        (void)vm.call(function, {}, JS::Value(fake_timestamp));
+        [[maybe_unused]] auto rc = vm.call(function, {}, JS::Value(fake_timestamp));
         if (vm.exception())
             vm.clear_exception();
         GUI::DisplayLink::unregister_callback(link_id);

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -301,9 +301,8 @@ bool EventHandler::handle_mousemove(const Gfx::IntPoint& position, unsigned butt
     return true;
 }
 
-void EventHandler::dump_selection(const char* event_name) const
+void EventHandler::dump_selection([[maybe_unused]] const char* event_name) const
 {
-    UNUSED_PARAM(event_name);
 #ifdef SELECTION_DEBUG
     dbg() << event_name << " selection start: "
           << layout_root()->selection().start().layout_node << ":" << layout_root()->selection().start().index_in_node << ", end: "

--- a/Libraries/LibWeb/TreeNode.h
+++ b/Libraries/LibWeb/TreeNode.h
@@ -359,7 +359,7 @@ inline void TreeNode<T>::append_child(NonnullRefPtr<T> node, bool notify)
         m_first_child = m_last_child;
     if (notify)
         node->inserted_into(static_cast<T&>(*this));
-    (void)node.leak_ref();
+    [[maybe_unused]] auto& rc = node.leak_ref();
 
     if (notify)
         static_cast<T*>(this)->children_changed();
@@ -394,7 +394,7 @@ inline void TreeNode<T>::insert_before(NonnullRefPtr<T> node, RefPtr<T> child, b
     node->m_parent = static_cast<T*>(this);
     if (notify)
         node->inserted_into(static_cast<T&>(*this));
-    (void)node.leak_ref();
+    [[maybe_unused]] auto& rc = node.leak_ref();
 
     if (notify)
         static_cast<T*>(this)->children_changed();
@@ -416,7 +416,7 @@ inline void TreeNode<T>::prepend_child(NonnullRefPtr<T> node)
     if (!m_last_child)
         m_last_child = m_first_child;
     node->inserted_into(static_cast<T&>(*this));
-    (void)node.leak_ref();
+    [[maybe_unused]] auto& rc = node.leak_ref();
 
     static_cast<T*>(this)->children_changed();
 }

--- a/Meta/Lagom/Fuzzers/FuzzRegexECMA262.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRegexECMA262.cpp
@@ -32,7 +32,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto pattern = AK::StringView(static_cast<const unsigned char*>(data), size);
-    Regex<ECMA262> re(pattern);
-    (void)re;
+    [[maybe_unused]] auto re = Regex<ECMA262>(pattern);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzRegexPosixExtended.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRegexPosixExtended.cpp
@@ -32,7 +32,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto pattern = AK::StringView(static_cast<const unsigned char*>(data), size);
-    Regex<PosixExtended> re(pattern);
-    (void)re;
+    [[maybe_unused]] auto re = Regex<PosixExtended>(pattern);
     return 0;
 }

--- a/Services/DHCPClient/main.cpp
+++ b/Services/DHCPClient/main.cpp
@@ -51,11 +51,8 @@ static MACAddress mac_from_string(const String& str)
     };
 }
 
-int main(int argc, char** argv)
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
-    (void)argc;
-    (void)argv;
-
     if (pledge("stdio unix inet cpath rpath fattr", nullptr) < 0) {
         perror("pledge");
         return 1;

--- a/Services/LaunchServer/main.cpp
+++ b/Services/LaunchServer/main.cpp
@@ -32,11 +32,8 @@
 #include <stdio.h>
 #include <unistd.h>
 
-int main(int argc, char** argv)
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
-    (void)argc;
-    (void)argv;
-
     Core::EventLoop event_loop;
     auto server = Core::LocalServer::construct();
 

--- a/Services/LookupServer/main.cpp
+++ b/Services/LookupServer/main.cpp
@@ -29,11 +29,8 @@
 #include <LibCore/LocalServer.h>
 #include <stdio.h>
 
-int main(int argc, char** argv)
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
-    (void)argc;
-    (void)argv;
-
     if (pledge("stdio accept unix inet cpath rpath fattr", nullptr) < 0) {
         perror("pledge");
         return 1;

--- a/Services/ProtocolServer/main.cpp
+++ b/Services/ProtocolServer/main.cpp
@@ -41,7 +41,7 @@ int main(int, char**)
     }
 
     // Ensure the certificates are read out here.
-    (void)DefaultRootCACertificates::the();
+    [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
 
     Core::EventLoop event_loop;
     // FIXME: Establish a connection to LookupServer and then drop "unix"?
@@ -58,9 +58,9 @@ int main(int, char**)
         return 1;
     }
 
-    (void)*new ProtocolServer::GeminiProtocol;
-    (void)*new ProtocolServer::HttpProtocol;
-    (void)*new ProtocolServer::HttpsProtocol;
+    [[maybe_unused]] auto gemini = new ProtocolServer::GeminiProtocol;
+    [[maybe_unused]] auto http = new ProtocolServer::HttpProtocol;
+    [[maybe_unused]] auto https = new ProtocolServer::HttpsProtocol;
 
     auto socket = Core::LocalSocket::take_over_accepted_socket_from_system_server();
     ASSERT(socket);

--- a/Services/TelnetServer/main.cpp
+++ b/Services/TelnetServer/main.cpp
@@ -57,13 +57,13 @@ static void run_command(int ptm_fd, String command)
         }
 
         // NOTE: It's okay if this fails.
-        (void)ioctl(0, TIOCNOTTY);
+        [[maybe_unused]] auto rc = ioctl(0, TIOCNOTTY);
 
         close(0);
         close(1);
         close(2);
 
-        int rc = dup2(pts_fd, 0);
+        rc = dup2(pts_fd, 0);
         if (rc < 0) {
             perror("dup2");
             exit(1);

--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -361,10 +361,8 @@ void WindowManager::notify_modal_unparented(Window& window)
     tell_wm_listeners_window_state_changed(window);
 }
 
-void WindowManager::notify_rect_changed(Window& window, const Gfx::IntRect& old_rect, const Gfx::IntRect& new_rect)
+void WindowManager::notify_rect_changed(Window& window, [[maybe_unused]] const Gfx::IntRect& old_rect, [[maybe_unused]] const Gfx::IntRect& new_rect)
 {
-    UNUSED_PARAM(old_rect);
-    UNUSED_PARAM(new_rect);
 #ifdef RESIZE_DEBUG
     dbg() << "[WM] Window " << &window << " rect changed " << old_rect << " -> " << new_rect;
 #endif

--- a/Userland/DynamicLoader/main.cpp
+++ b/Userland/DynamicLoader/main.cpp
@@ -188,8 +188,7 @@ static void allocate_tls()
         total_tls_size += data.value->tls_size();
     }
     if (total_tls_size) {
-        void* tls_address = allocate_tls(total_tls_size);
-        (void)tls_address;
+        [[maybe_unused]] void* tls_address = allocate_tls(total_tls_size);
         VERBOSE("from userspace, tls_address: %p", tls_address);
     }
     g_total_tls_size = total_tls_size;
@@ -211,7 +210,7 @@ static void initialize_libc()
 
     res = global_symbol_lookup("__libc_init");
     ASSERT(res.found);
-    typedef void libc_init_func(void);
+    typedef void libc_init_func();
     ((libc_init_func*)res.address)();
 }
 
@@ -262,8 +261,7 @@ static FlatPtr loader_main(auxv_t* auxvp)
     map_dependencies(main_program_name);
 
     VERBOSE("loaded all dependencies");
-    for (auto& lib : g_loaders) {
-        (void)lib;
+    for ([[maybe_unused]] auto& lib : g_loaders) {
         VERBOSE("%s - tls size: $u, tls offset: %u", lib.key.characters(), lib.value->tls_size(), lib.value->tls_offset());
     }
 
@@ -301,8 +299,7 @@ void _start(int argc, char** argv, char** envp)
 
     FlatPtr entry = loader_main(auxvp);
     VERBOSE("Loaded libs:\n");
-    for (auto& obj : g_loaded_objects) {
-        (void)obj;
+    for ([[maybe_unused]] auto& obj : g_loaded_objects) {
         VERBOSE("%s: %p\n", obj.key.characters(), obj.value->base_address().as_ptr());
     }
 

--- a/Userland/Tests/LibC/accuracy-strtod.cpp
+++ b/Userland/Tests/LibC/accuracy-strtod.cpp
@@ -263,11 +263,11 @@ static long long cast_ll(double d)
         long long as_ll;
     };
     typedef char assert_double_8bytes[sizeof(double) == 8 ? 1 : -1];
-    (void)sizeof(assert_double_8bytes);
+    [[maybe_unused]] auto double_size = sizeof(assert_double_8bytes);
     typedef char assert_ll_8bytes[sizeof(long long) == 8 ? 1 : -1];
-    (void)sizeof(assert_ll_8bytes);
+    [[maybe_unused]] auto longlong_size = sizeof(assert_ll_8bytes);
     typedef char assert_readable_8bytes[sizeof(readable_t) == 8 ? 1 : -1];
-    (void)sizeof(assert_readable_8bytes);
+    [[maybe_unused]] auto readable8_size = sizeof(assert_readable_8bytes);
     readable_t readable;
     readable.as_double = d;
     return readable.as_ll;
@@ -280,9 +280,9 @@ static bool is_strtod_close(strtod_fn_t strtod_fn, const char* test_string, cons
         unsigned char as_bytes[8];
     };
     typedef char assert_double_8bytes[sizeof(double) == 8 ? 1 : -1];
-    (void)sizeof(assert_double_8bytes);
+    [[maybe_unused]] auto double_size = sizeof(assert_double_8bytes);
     typedef char assert_readable_8bytes[sizeof(readable_t) == 8 ? 1 : -1];
-    (void)sizeof(assert_readable_8bytes);
+    [[maybe_unused]] auto readable8_size = sizeof(assert_readable_8bytes);
     readable_t readable;
     char* endptr = (char*)0x123;
 

--- a/Userland/allocate.cpp
+++ b/Userland/allocate.cpp
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-static void usage(void)
+static void usage()
 {
     printf("usage: allocate [number [unit (B/KiB/MiB)]]\n");
     exit(1);

--- a/Userland/crash.cpp
+++ b/Userland/crash.cpp
@@ -170,8 +170,7 @@ int main(int argc, char** argv)
         Crash("Division by zero", []() {
             volatile int lala = 10;
             volatile int zero = 0;
-            volatile int test = lala / zero;
-            UNUSED_PARAM(test);
+            [[maybe_unused]] volatile int test = lala / zero;
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }
@@ -196,8 +195,7 @@ int main(int argc, char** argv)
             if (!uninitialized_memory)
                 return Crash::Failure::UnexpectedError;
 
-            volatile auto x = uninitialized_memory[0][0];
-            UNUSED_PARAM(x);
+            [[maybe_unused]] volatile auto x = uninitialized_memory[0][0];
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }
@@ -209,8 +207,7 @@ int main(int argc, char** argv)
                 return Crash::Failure::UnexpectedError;
 
             free(uninitialized_memory);
-            volatile auto x = uninitialized_memory[4][0];
-            UNUSED_PARAM(x);
+            [[maybe_unused]] volatile auto x = uninitialized_memory[4][0];
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }
@@ -305,8 +302,7 @@ int main(int argc, char** argv)
 
             free(ptr);
             dbgprintf("ptr = %p\n", ptr);
-            volatile auto foo = *ptr;
-            UNUSED_PARAM(foo);
+            [[maybe_unused]] volatile auto foo = *ptr;
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }

--- a/Userland/df.cpp
+++ b/Userland/df.cpp
@@ -78,13 +78,10 @@ int main(int argc, char** argv)
         auto fs = fs_object.get("class_name").to_string();
         auto total_block_count = fs_object.get("total_block_count").to_u32();
         auto free_block_count = fs_object.get("free_block_count").to_u32();
-        auto total_inode_count = fs_object.get("total_inode_count").to_u32();
-        auto free_inode_count = fs_object.get("free_inode_count").to_u32();
+        [[maybe_unused]] auto total_inode_count = fs_object.get("total_inode_count").to_u32();
+        [[maybe_unused]] auto free_inode_count = fs_object.get("free_inode_count").to_u32();
         auto block_size = fs_object.get("block_size").to_u32();
         auto mount_point = fs_object.get("mount_point").to_string();
-
-        (void)total_inode_count;
-        (void)free_inode_count;
 
         printf("%-10s", fs.characters());
 

--- a/Userland/dmesg.cpp
+++ b/Userland/dmesg.cpp
@@ -31,7 +31,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-int main(int argc, char** argv)
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
     if (pledge("stdio rpath", nullptr) < 0) {
         perror("pledge");
@@ -45,8 +45,6 @@ int main(int argc, char** argv)
 
     unveil(nullptr, nullptr);
 
-    (void)argc;
-    (void)argv;
     auto f = Core::File::construct("/proc/dmesg");
     if (!f->open(Core::IODevice::ReadOnly)) {
         fprintf(stderr, "open: failed to open /proc/dmesg: %s\n", f->error_string());

--- a/Userland/functrace.cpp
+++ b/Userland/functrace.cpp
@@ -84,7 +84,7 @@ static void print_syscall(PtraceRegisters& regs, size_t depth)
 
 static NonnullOwnPtr<HashMap<void*, X86::Instruction>> instrument_code()
 {
-    (void)demangle("foo"); // Required for linked with __cxa_demangle
+    [[maybe_unused]] auto r = demangle("foo"); // Required for linked with __cxa_demangle
     auto instrumented = make<HashMap<void*, X86::Instruction>>();
     g_debug_session->elf().image().for_each_section_of_type(SHT_PROGBITS, [&](const ELF::Image::Section& section) {
         if (section.name() != ".text")

--- a/Userland/lsirq.cpp
+++ b/Userland/lsirq.cpp
@@ -31,11 +31,8 @@
 #include <LibCore/File.h>
 #include <stdio.h>
 
-int main(int argc, char** argv)
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
-    UNUSED_PARAM(argc);
-    UNUSED_PARAM(argv);
-
     if (pledge("stdio rpath", nullptr) < 0) {
         perror("pledge");
         return 1;

--- a/Userland/lspci.cpp
+++ b/Userland/lspci.cpp
@@ -32,11 +32,8 @@
 #include <LibPCIDB/Database.h>
 #include <stdio.h>
 
-int main(int argc, char** argv)
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
-    UNUSED_PARAM(argc);
-    UNUSED_PARAM(argv);
-
     if (pledge("stdio rpath", nullptr) < 0) {
         perror("pledge");
         return 1;

--- a/Userland/more.cpp
+++ b/Userland/more.cpp
@@ -36,15 +36,12 @@ static void wait_for_key()
     printf("\033[7m--[ more ]--\033[0m");
     fflush(stdout);
     char dummy;
-    (void)read(key_fd, &dummy, 1);
+    [[maybe_unused]] auto rc = read(key_fd, &dummy, 1);
     printf("\n");
 }
 
-int main(int argc, char** argv)
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
-    (void)argc;
-    (void)argv;
-
     if (pledge("stdio rpath tty", nullptr) < 0) {
         perror("pledge");
         return 1;

--- a/Userland/sort.cpp
+++ b/Userland/sort.cpp
@@ -32,15 +32,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-int main(int argc, char** argv)
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
     if (pledge("stdio", nullptr) > 0) {
         perror("pledge");
         return 1;
     }
-
-    UNUSED_PARAM(argc);
-    UNUSED_PARAM(argv);
 
     Vector<String> lines;
 

--- a/Userland/test-web.cpp
+++ b/Userland/test-web.cpp
@@ -364,7 +364,7 @@ JSFileResult TestRunner::run_file_test(const String& test_path)
             new_interpreter.run(new_interpreter.global_object(), *file_program.value());
 
             auto& before_initial_page_load = new_interpreter.vm().get_variable("__BeforeInitialPageLoad__", new_interpreter.global_object()).as_function();
-            (void)new_interpreter.vm().call(before_initial_page_load, JS::js_undefined());
+            [[maybe_unused]] auto rc_before = new_interpreter.vm().call(before_initial_page_load, JS::js_undefined());
             if (new_interpreter.exception())
                 new_interpreter.vm().clear_exception();
 
@@ -374,7 +374,7 @@ JSFileResult TestRunner::run_file_test(const String& test_path)
 
             // Finally run the test by calling "__AfterInitialPageLoad__"
             auto& after_initial_page_load = new_interpreter.vm().get_variable("__AfterInitialPageLoad__", new_interpreter.global_object()).as_function();
-            (void)new_interpreter.vm().call(after_initial_page_load, JS::js_undefined());
+            [[maybe_unused]] auto rc_after = new_interpreter.vm().call(after_initial_page_load, JS::js_undefined());
             if (new_interpreter.exception())
                 new_interpreter.vm().clear_exception();
 

--- a/Userland/w.cpp
+++ b/Userland/w.cpp
@@ -85,8 +85,7 @@ int main()
     json.value().as_object().for_each_member([&](auto& tty, auto& value) {
         const JsonObject& entry = value.as_object();
         auto uid = entry.get("uid").to_u32();
-        auto pid = entry.get("pid").to_i32();
-        (void)pid;
+        [[maybe_unused]] auto pid = entry.get("pid").to_i32();
 
         auto login_time = Core::DateTime::from_timestamp(entry.get("login_at").to_number<time_t>());
         auto login_at = login_time.to_string("%b%d %H:%M:%S");


### PR DESCRIPTION
Problem:
- `(void)` simply casts the expression to void. This is understood to
  indicate that it is ignored, but this is really a compiler trick to
  get the compiler to not generate a warning.

Solution:
- Use the `[[maybe_unused]]` attribute to indicate the value is unused.

Note:
- Functions taking a `(void)` argument list have also been changed to
  `()` because this is not needed and shows up in the same grep
  command.