### PR TITLE
LibGfx: Extraction of Streamer from P*MLoader

### DIFF
--- a/Libraries/LibGfx/PBMLoader.cpp
+++ b/Libraries/LibGfx/PBMLoader.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "PBMLoader.h"
+#include "Streamer.h"
 #include <AK/Endian.h>
 #include <AK/LexicalPath.h>
 #include <AK/MappedFile.h>
@@ -57,48 +58,6 @@ struct PBMLoadingContext {
     int width { -1 };
     int height { -1 };
     RefPtr<Gfx::Bitmap> bitmap;
-};
-
-class Streamer {
-public:
-    Streamer(const u8* data, size_t size)
-        : m_data_ptr(data)
-        , m_size_remaining(size)
-    {
-    }
-
-    template<typename T>
-    bool read(T& value)
-    {
-        if (m_size_remaining < sizeof(T))
-            return false;
-        value = *((const NetworkOrdered<T>*)m_data_ptr);
-        m_data_ptr += sizeof(T);
-        m_size_remaining -= sizeof(T);
-        return true;
-    }
-
-    bool read_bytes(u8* buffer, size_t count)
-    {
-        if (m_size_remaining < count)
-            return false;
-        memcpy(buffer, m_data_ptr, count);
-        m_data_ptr += count;
-        m_size_remaining -= count;
-        return true;
-    }
-
-    bool at_end() const { return !m_size_remaining; }
-
-    void step_back()
-    {
-        m_data_ptr -= 1;
-        m_size_remaining += 1;
-    }
-
-private:
-    const u8* m_data_ptr { nullptr };
-    size_t m_size_remaining { 0 };
 };
 
 static int read_number(Streamer& streamer)

--- a/Libraries/LibGfx/PGMLoader.cpp
+++ b/Libraries/LibGfx/PGMLoader.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "PGMLoader.h"
+#include "Streamer.h"
 #include <AK/Endian.h>
 #include <AK/LexicalPath.h>
 #include <AK/MappedFile.h>
@@ -59,48 +60,6 @@ struct PGMLoadingContext {
     u16 height { 0 };
     u16 max_val { 0 };
     RefPtr<Gfx::Bitmap> bitmap;
-};
-
-class Streamer {
-public:
-    Streamer(const u8* data, size_t size)
-        : m_data_ptr(data)
-        , m_size_remaining(size)
-    {
-    }
-
-    template<typename T>
-    bool read(T& value)
-    {
-        if (m_size_remaining < sizeof(T))
-            return false;
-        value = *((const NetworkOrdered<T>*)m_data_ptr);
-        m_data_ptr += sizeof(T);
-        m_size_remaining -= sizeof(T);
-        return true;
-    }
-
-    bool read_bytes(u8* buffer, size_t count)
-    {
-        if (m_size_remaining < count)
-            return false;
-        memcpy(buffer, m_data_ptr, count);
-        m_data_ptr += count;
-        m_size_remaining -= count;
-        return true;
-    }
-
-    bool at_end() const { return !m_size_remaining; }
-
-    void step_back()
-    {
-        m_data_ptr -= 1;
-        m_size_remaining += 1;
-    }
-
-private:
-    const u8* m_data_ptr { nullptr };
-    size_t m_size_remaining { 0 };
 };
 
 ALWAYS_INLINE static Color adjust_color(u16 max_val, Color& color)

--- a/Libraries/LibGfx/PPMLoader.cpp
+++ b/Libraries/LibGfx/PPMLoader.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "PPMLoader.h"
+#include "Streamer.h"
 #include <AK/Endian.h>
 #include <AK/LexicalPath.h>
 #include <AK/MappedFile.h>
@@ -62,48 +63,6 @@ struct PPMLoadingContext {
     u16 height { 0 };
     u16 max_val { 0 };
     RefPtr<Gfx::Bitmap> bitmap;
-};
-
-class Streamer {
-public:
-    Streamer(const u8* data, size_t size)
-        : m_data_ptr(data)
-        , m_size_remaining(size)
-    {
-    }
-
-    template<typename T>
-    bool read(T& value)
-    {
-        if (m_size_remaining < sizeof(T))
-            return false;
-        value = *((const NetworkOrdered<T>*)m_data_ptr);
-        m_data_ptr += sizeof(T);
-        m_size_remaining -= sizeof(T);
-        return true;
-    }
-
-    bool read_bytes(u8* buffer, size_t count)
-    {
-        if (m_size_remaining < count)
-            return false;
-        memcpy(buffer, m_data_ptr, count);
-        m_data_ptr += count;
-        m_size_remaining -= count;
-        return true;
-    }
-
-    bool at_end() const { return !m_size_remaining; }
-
-    void step_back()
-    {
-        m_data_ptr -= 1;
-        m_size_remaining += 1;
-    }
-
-private:
-    const u8* m_data_ptr { nullptr };
-    size_t m_size_remaining { 0 };
 };
 
 ALWAYS_INLINE static Color adjust_color(u16 max_val, Color& color)

--- a/Libraries/LibGfx/Streamer.h
+++ b/Libraries/LibGfx/Streamer.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020, Hüseyin ASLITÜRK <asliturk@hotmail.com>, the SerenityOS developers
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/Endian.h>
+#include <AK/Types.h>
+#include <string.h>
+
+namespace Gfx {
+
+class Streamer {
+public:
+    constexpr Streamer(const u8* data, size_t size)
+        : m_data_ptr(data)
+        , m_size_remaining(size)
+    {
+    }
+
+    template<typename T>
+    constexpr bool read(T& value)
+    {
+        AK::Array<u8, sizeof(T)> network_buffer {};
+        auto network_value = new (network_buffer.data()) AK::NetworkOrdered<T> {};
+        auto res = read_bytes(network_buffer.data(), sizeof(T));
+        value = T(*network_value);
+        return res;
+    }
+
+    constexpr bool read_bytes(u8* buffer, size_t count)
+    {
+        if (m_size_remaining < count) {
+            return false;
+        }
+        memcpy(buffer, m_data_ptr, count);
+        m_data_ptr += count;
+        m_size_remaining -= count;
+        return true;
+    }
+
+    constexpr bool at_end() const { return !m_size_remaining; }
+
+    constexpr void step_back()
+    {
+        m_data_ptr -= 1;
+        m_size_remaining += 1;
+    }
+
+private:
+    const u8* m_data_ptr { nullptr };
+    size_t m_size_remaining { 0 };
+};
+
+}


### PR DESCRIPTION
Problem:
- `Streamer` is the same in [PBM,PGM,PPM]Loader class implementations.

Solution:
- Extract it to its own header file to reduce maintenance burden.
- Implement `read` in terms of `read_bytes` to make the class "DRY".
- Decorate all functions with `constexpr`.