### PR TITLE
UserspaceEmulator: Implement profiling, disown, purge syscalls

### DIFF
--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -395,6 +395,14 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
         return virt$shbuf_seal(arg1);
     case SC_shbuf_set_volatile:
         return virt$shbuf_set_volatile(arg1, arg2);
+    case SC_profiling_enable:
+        return virt$profiling_enable(arg1);
+    case SC_profiling_disable:
+        return virt$profiling_disable(arg1);
+    case SC_disown:
+        return virt$disown(arg1);
+    case SC_purge:
+        return virt$purge(arg1);
     case SC_mmap:
         return virt$mmap(arg1);
     case SC_mount:
@@ -588,6 +596,26 @@ int Emulator::virt$shbuf_set_volatile(int shbuf_id, bool is_volatile)
     auto* region = m_mmu.shbuf_region(shbuf_id);
     ASSERT(region);
     return region->set_volatile(is_volatile);
+}
+
+int Emulator::virt$profiling_enable(pid_t pid)
+{
+    return syscall(SC_profiling_enable, pid);
+}
+
+int Emulator::virt$profiling_disable(pid_t pid)
+{
+    return syscall(SC_profiling_disable, pid);
+}
+
+int Emulator::virt$disown(pid_t pid)
+{
+    return syscall(SC_disown, pid);
+}
+
+int Emulator::virt$purge(int mode)
+{
+    return syscall(SC_purge, mode);
 }
 
 int Emulator::virt$fstat(int fd, FlatPtr statbuf)

--- a/DevTools/UserspaceEmulator/Emulator.h
+++ b/DevTools/UserspaceEmulator/Emulator.h
@@ -98,6 +98,10 @@ private:
     int virt$shbuf_release(int shbuf_id);
     int virt$shbuf_seal(int shbuf_id);
     int virt$shbuf_set_volatile(int shbuf_id, bool);
+    int virt$profiling_enable(pid_t);
+    int virt$profiling_disable(pid_t);
+    int virt$disown(pid_t);
+    int virt$purge(int mode);
     u32 virt$mmap(u32);
     u32 virt$mount(u32);
     u32 virt$munmap(FlatPtr address, u32 size);


### PR DESCRIPTION
Adds a few missing syscalls from `serenity.h`.

This allows us to profile applications inside the emulator and to profile applications which call `disown`:

```
user@ubuntu:~/Desktop/serenity$ grep -rn disown Userland/
Userland/Tests/Kernel/setpgid-across-sessions-without-leader.cpp:79:        const int disown_rc = disown(rc);
Userland/Tests/Kernel/setpgid-across-sessions-without-leader.cpp:80:        if (disown_rc < 0) {
Userland/Tests/Kernel/setpgid-across-sessions-without-leader.cpp:81:            perror("disown");
user@ubuntu:~/Desktop/serenity$ grep -rn disown Services/
Services/LaunchServer/Launcher.cpp:225:        if (disown(child_pid) < 0)
Services/LaunchServer/Launcher.cpp:226:            perror("disown");
Services/Taskbar/TaskbarWindow.cpp:139:                if (disown(pid) < 0)
Services/Taskbar/TaskbarWindow.cpp:140:                    perror("disown");
Services/SystemMenu/main.cpp:170:                if (disown(child_pid) < 0)
Services/SystemMenu/main.cpp:171:                    perror("disown");
Services/SystemMenu/main.cpp:221:            if (disown(child_pid) < 0)
Services/SystemMenu/main.cpp:222:                perror("disown");
Services/SystemMenu/main.cpp:236:            if (disown(child_pid) < 0)
Services/SystemMenu/main.cpp:237:                perror("disown");
user@ubuntu:~/Desktop/serenity$ grep -rn disown Applications/
Applications/QuickShow/main.cpp:124:                    if (disown(child) < 0)
Applications/QuickShow/main.cpp:125:                        perror("disown");
Applications/FileManager/DirectoryView.cpp:445:        if (disown(child) < 0)
Applications/FileManager/DirectoryView.cpp:446:            perror("disown");
Applications/FileManager/DirectoryView.cpp:451:            if (disown(child) < 0)
Applications/FileManager/DirectoryView.cpp:452:                perror("disown");
Applications/FileManager/DirectoryView.cpp:539:            if (disown(pid) < 0)
Applications/FileManager/DirectoryView.cpp:540:                perror("disown");
Applications/Terminal/main.cpp:365:            if (disown(child) < 0)
Applications/Terminal/main.cpp:366:                perror("disown");
Applications/SystemMonitor/main.cpp:237:                    if (disown(child) < 0)
Applications/SystemMonitor/main.cpp:238:                        perror("disown");
Applications/SystemMonitor/main.cpp:253:                    if (disown(child) < 0)
Applications/SystemMonitor/main.cpp:254:                        perror("disown");
```

Also adds `purge`, which I figured I should add while looking at `serenity.h`.
