### PR TITLE
Userland: useradd: Add command line option to set user password

### DIFF
--- a/Base/usr/share/man/man8/useradd.md
+++ b/Base/usr/share/man/man8/useradd.md
@@ -10,7 +10,7 @@ useradd - add a new user to the system password file
 
 ## Description
 
-This program uses adds a new user to the system.
+This program adds a new user to the system.
 
 By default, the user will be added to the **users** group (which has a GID of 100).
 
@@ -20,6 +20,7 @@ This program must be run as root.
 
 * `-u`, `--uid` _uid_: The user identifier for the new user. If not specified, an unused UID above `1000` will be auto-generated.
 * `-g`, `--gid` _gid_: The group identifier for the new user. If not specified, it will default to 100 (the **users** group).
+* `-p`, `--password` _password_: The encrypted password for the new user. If not specified, it will default to blank.
 * `-s`, `--shell` _path-to-shell_: The shell binary for this login. The default is `/bin/Shell`. 
 * `-m`, `--create-home`: Create the specified home directory for this new user.
 * `-d`, `--home-dir` _path_: Set the home directory for this user to path. By default, this is `/home/username`, where `username` is the value of login.

--- a/Userland/useradd.cpp
+++ b/Userland/useradd.cpp
@@ -43,6 +43,7 @@ int main(int argc, char** argv)
     int uid = 0;
     int gid = USERS_GID;
     bool create_home_dir = false;
+    const char* password = "";
     const char* shell = DEFAULT_SHELL;
     const char* gecos = "";
     const char* username = nullptr;
@@ -51,6 +52,7 @@ int main(int argc, char** argv)
     args_parser.add_option(home_path, "Home directory for the new user", "home-dir", 'd', "path");
     args_parser.add_option(uid, "User ID (uid) for the new user", "uid", 'u', "uid");
     args_parser.add_option(gid, "Group ID (gid) for the new user", "gid", 'g', "gid");
+    args_parser.add_option(password, "Encrypted password of the new user", "password", 'p', "password");
     args_parser.add_option(create_home_dir, "Create home directory if it does not exist", "create-home", 'm');
     args_parser.add_option(shell, "Path to the default shell binary for the new user", "shell", 's', "path-to-shell");
     args_parser.add_option(gecos, "GECOS name of the new user", "gecos", 'n', "general-info");
@@ -123,6 +125,7 @@ int main(int argc, char** argv)
 
     struct passwd p;
     p.pw_name = const_cast<char*>(username);
+    p.pw_passwd = const_cast<char*>(password);
     p.pw_dir = const_cast<char*>(home.characters());
     p.pw_uid = static_cast<uid_t>(uid);
     p.pw_gid = static_cast<gid_t>(gid);


### PR DESCRIPTION
Prior to this PR, the `useradd` utility failed to initialize the `pw_passwd` member of the `passwd` struct resulting in unexpected behavior. This has been fixed.

Before (lol `DT_JMPREL`) :

![useradd](https://user-images.githubusercontent.com/434827/102754309-e46c0b80-43c0-11eb-93fd-0ce0b13cdb04.png)

After:

![useradd](https://user-images.githubusercontent.com/434827/102754289-db7b3a00-43c0-11eb-90f9-29defe1a5b0c.png)
