### PR TITLE
Spreadsheet: Some cleanups and "stability improvements" :P

### DIFF
--- a/Applications/Spreadsheet/Cell.h
+++ b/Applications/Spreadsheet/Cell.h
@@ -67,6 +67,10 @@ struct Cell : public Weakable<Cell> {
     void set_data(String new_data);
     void set_data(JS::Value new_data);
     bool dirty() const { return m_dirty; }
+    void clear_dirty() { m_dirty = false; }
+
+    void set_exception(JS::Exception* exc) { m_js_exception = exc; }
+    JS::Exception* exception() const { return m_js_exception; }
 
     const String& data() const { return m_data; }
     const JS::Value& evaluated_data() const { return m_evaluated_data; }
@@ -117,6 +121,7 @@ private:
     bool m_evaluated_externally { false };
     String m_data;
     JS::Value m_evaluated_data;
+    JS::Exception* m_js_exception { nullptr };
     Kind m_kind { LiteralString };
     WeakPtr<Sheet> m_sheet;
     Vector<WeakPtr<Cell>> m_referencing_cells;

--- a/Applications/Spreadsheet/Cell.h
+++ b/Applications/Spreadsheet/Cell.h
@@ -84,8 +84,10 @@ struct Cell : public Weakable<Cell> {
     const Position& position() const { return m_position; }
     void set_position(Position position, Badge<Sheet>)
     {
-        m_dirty = true;
-        m_position = move(position);
+        if (position != m_position) {
+            m_dirty = true;
+            m_position = move(position);
+        }
     }
 
     const Format& evaluated_formats() const { return m_evaluated_formats; }

--- a/Applications/Spreadsheet/CellType/Date.cpp
+++ b/Applications/Spreadsheet/CellType/Date.cpp
@@ -43,7 +43,7 @@ DateCell::~DateCell()
 String DateCell::display(Cell& cell, const CellTypeMetadata& metadata) const
 {
     auto timestamp = js_value(cell, metadata);
-    auto string = Core::DateTime::from_timestamp(timestamp.to_i32(cell.sheet->global_object())).to_string(metadata.format.is_empty() ? "%Y-%m-%d %H:%M:%S" : metadata.format.characters());
+    auto string = Core::DateTime::from_timestamp(timestamp.to_i32(cell.sheet().global_object())).to_string(metadata.format.is_empty() ? "%Y-%m-%d %H:%M:%S" : metadata.format.characters());
 
     if (metadata.length >= 0)
         return string.substring(0, metadata.length);
@@ -53,7 +53,7 @@ String DateCell::display(Cell& cell, const CellTypeMetadata& metadata) const
 
 JS::Value DateCell::js_value(Cell& cell, const CellTypeMetadata&) const
 {
-    auto value = cell.js_data().to_double(cell.sheet->global_object());
+    auto value = cell.js_data().to_double(cell.sheet().global_object());
     return JS::Value(value / 1000); // Turn it to seconds
 }
 

--- a/Applications/Spreadsheet/CellType/Date.cpp
+++ b/Applications/Spreadsheet/CellType/Date.cpp
@@ -27,6 +27,7 @@
 #include "Date.h"
 #include "../Cell.h"
 #include "../Spreadsheet.h"
+#include <AK/ScopeGuard.h>
 #include <LibCore/DateTime.h>
 
 namespace Spreadsheet {
@@ -42,6 +43,12 @@ DateCell::~DateCell()
 
 String DateCell::display(Cell& cell, const CellTypeMetadata& metadata) const
 {
+    ScopeGuard propagate_exception { [&cell] {
+        if (auto exc = cell.sheet().interpreter().exception()) {
+            cell.sheet().interpreter().vm().clear_exception();
+            cell.set_exception(exc);
+        }
+    } };
     auto timestamp = js_value(cell, metadata);
     auto string = Core::DateTime::from_timestamp(timestamp.to_i32(cell.sheet().global_object())).to_string(metadata.format.is_empty() ? "%Y-%m-%d %H:%M:%S" : metadata.format.characters());
 
@@ -53,7 +60,8 @@ String DateCell::display(Cell& cell, const CellTypeMetadata& metadata) const
 
 JS::Value DateCell::js_value(Cell& cell, const CellTypeMetadata&) const
 {
-    auto value = cell.js_data().to_double(cell.sheet().global_object());
+    auto js_data = cell.js_data();
+    auto value = js_data.to_double(cell.sheet().global_object());
     return JS::Value(value / 1000); // Turn it to seconds
 }
 

--- a/Applications/Spreadsheet/CellType/Numeric.cpp
+++ b/Applications/Spreadsheet/CellType/Numeric.cpp
@@ -28,6 +28,7 @@
 #include "../Cell.h"
 #include "../Spreadsheet.h"
 #include "Format.h"
+#include <AK/ScopeGuard.h>
 
 namespace Spreadsheet {
 
@@ -42,6 +43,12 @@ NumericCell::~NumericCell()
 
 String NumericCell::display(Cell& cell, const CellTypeMetadata& metadata) const
 {
+    ScopeGuard propagate_exception { [&cell] {
+        if (auto exc = cell.sheet().interpreter().exception()) {
+            cell.sheet().interpreter().vm().clear_exception();
+            cell.set_exception(exc);
+        }
+    } };
     auto value = js_value(cell, metadata);
     String string;
     if (metadata.format.is_empty())
@@ -57,6 +64,12 @@ String NumericCell::display(Cell& cell, const CellTypeMetadata& metadata) const
 
 JS::Value NumericCell::js_value(Cell& cell, const CellTypeMetadata&) const
 {
+    ScopeGuard propagate_exception { [&cell] {
+        if (auto exc = cell.sheet().interpreter().exception()) {
+            cell.sheet().interpreter().vm().clear_exception();
+            cell.set_exception(exc);
+        }
+    } };
     return cell.js_data().to_number(cell.sheet().global_object());
 }
 

--- a/Applications/Spreadsheet/CellType/Numeric.cpp
+++ b/Applications/Spreadsheet/CellType/Numeric.cpp
@@ -47,7 +47,7 @@ String NumericCell::display(Cell& cell, const CellTypeMetadata& metadata) const
     if (metadata.format.is_empty())
         string = value.to_string_without_side_effects();
     else
-        string = format_double(metadata.format.characters(), value.to_double(cell.sheet->global_object()));
+        string = format_double(metadata.format.characters(), value.to_double(cell.sheet().global_object()));
 
     if (metadata.length >= 0)
         return string.substring(0, metadata.length);
@@ -57,7 +57,7 @@ String NumericCell::display(Cell& cell, const CellTypeMetadata& metadata) const
 
 JS::Value NumericCell::js_value(Cell& cell, const CellTypeMetadata&) const
 {
-    return cell.js_data().to_number(cell.sheet->global_object());
+    return cell.js_data().to_number(cell.sheet().global_object());
 }
 
 }

--- a/Applications/Spreadsheet/CellType/String.cpp
+++ b/Applications/Spreadsheet/CellType/String.cpp
@@ -51,7 +51,7 @@ String StringCell::display(Cell& cell, const CellTypeMetadata& metadata) const
 JS::Value StringCell::js_value(Cell& cell, const CellTypeMetadata& metadata) const
 {
     auto string = display(cell, metadata);
-    return JS::js_string(cell.sheet->interpreter().heap(), string);
+    return JS::js_string(cell.sheet().interpreter().heap(), string);
 }
 
 }

--- a/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Applications/Spreadsheet/JSIntegration.cpp
@@ -87,6 +87,16 @@ void SheetGlobalObject::initialize()
     define_native_function("column_index", column_index, 1);
 }
 
+void SheetGlobalObject::visit_edges(Visitor& visitor)
+{
+    GlobalObject::visit_edges(visitor);
+    for (auto& it : m_sheet.cells()) {
+        if (it.value->exception())
+            visitor.visit(it.value->exception());
+        visitor.visit(it.value->evaluated_data());
+    }
+}
+
 JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::parse_cell_name)
 {
     if (vm.argument_count() != 1) {
@@ -229,6 +239,13 @@ void WorkbookObject::initialize(JS::GlobalObject& global_object)
 {
     Object::initialize(global_object);
     define_native_function("sheet", sheet, 1);
+}
+
+void WorkbookObject::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    for (auto& sheet : m_workbook.sheets())
+        visitor.visit(&sheet.global_object());
 }
 
 JS_DEFINE_NATIVE_FUNCTION(WorkbookObject::sheet)

--- a/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Applications/Spreadsheet/JSIntegration.cpp
@@ -151,7 +151,7 @@ JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::current_cell_position)
 
 JS_DEFINE_NATIVE_FUNCTION(SheetGlobalObject::column_index)
 {
-    if (vm.argument_count() != 2) {
+    if (vm.argument_count() != 1) {
         vm.throw_exception<JS::TypeError>(global_object, "Expected exactly one argument to column_index()");
         return {};
     }

--- a/Applications/Spreadsheet/JSIntegration.h
+++ b/Applications/Spreadsheet/JSIntegration.h
@@ -50,6 +50,7 @@ public:
     JS_DECLARE_NATIVE_FUNCTION(column_arithmetic);
 
 private:
+    virtual void visit_edges(Visitor&) override;
     Sheet& m_sheet;
 };
 
@@ -66,6 +67,7 @@ public:
     JS_DECLARE_NATIVE_FUNCTION(sheet);
 
 private:
+    virtual void visit_edges(Visitor&) override;
     Workbook& m_workbook;
 };
 

--- a/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Applications/Spreadsheet/Spreadsheet.cpp
@@ -248,6 +248,9 @@ Optional<String> Sheet::column_arithmetic(const StringView& column_name, int off
     if (!maybe_index.has_value())
         return {};
 
+    if (offset < 0 && maybe_index.value() < (size_t)(0 - offset))
+        return m_columns.first();
+
     auto index = maybe_index.value() + offset;
     if (m_columns.size() > index)
         return m_columns[index];

--- a/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Applications/Spreadsheet/Spreadsheet.cpp
@@ -373,8 +373,6 @@ RefPtr<Sheet> Sheet::from_json(const JsonObject& object, Workbook& workbook)
     auto sheet = adopt(*new Sheet(workbook));
     auto rows = object.get("rows").to_u32(default_row_count);
     auto columns = object.get("columns");
-    if (!columns.is_array())
-        return nullptr;
     auto name = object.get("name").as_string_or("Sheet");
 
     sheet->set_name(name);
@@ -383,10 +381,12 @@ RefPtr<Sheet> Sheet::from_json(const JsonObject& object, Workbook& workbook)
         sheet->add_row();
 
     // FIXME: Better error checking.
-    columns.as_array().for_each([&](auto& value) {
-        sheet->m_columns.append(value.as_string());
-        return IterationDecision::Continue;
-    });
+    if (columns.is_array()) {
+        columns.as_array().for_each([&](auto& value) {
+            sheet->m_columns.append(value.as_string());
+            return IterationDecision::Continue;
+        });
+    }
 
     if (sheet->m_columns.size() < default_column_count && sheet->columns_are_standard()) {
         for (size_t i = sheet->m_columns.size(); i < default_column_count; ++i)

--- a/Applications/Spreadsheet/Spreadsheet.h
+++ b/Applications/Spreadsheet/Spreadsheet.h
@@ -118,7 +118,11 @@ public:
     void update();
     void update(Cell&);
 
-    JS::Value evaluate(const StringView&, Cell* = nullptr);
+    struct ValueAndException {
+        JS::Value value;
+        JS::Exception* exception { nullptr };
+    };
+    ValueAndException evaluate(const StringView&, Cell* = nullptr);
     JS::Interpreter& interpreter() const;
     SheetGlobalObject& global_object() const { return *m_global_object; }
 

--- a/Applications/Spreadsheet/Spreadsheet.h
+++ b/Applications/Spreadsheet/Spreadsheet.h
@@ -117,6 +117,15 @@ public:
 
     void update();
     void update(Cell&);
+    void disable_updates() { m_should_ignore_updates = true; }
+    void enable_updates()
+    {
+        m_should_ignore_updates = false;
+        if (m_update_requested) {
+            m_update_requested = false;
+            update();
+        }
+    }
 
     struct ValueAndException {
         JS::Value value;
@@ -154,6 +163,8 @@ private:
     Cell* m_current_cell_being_evaluated { nullptr };
 
     HashTable<Cell*> m_visited_cells_in_update;
+    bool m_should_ignore_updates { false };
+    bool m_update_requested { false };
 };
 
 }

--- a/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -57,8 +57,8 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
         if (!cell)
             return String::empty();
 
-        if (cell->kind == Spreadsheet::Cell::Formula) {
-            if (auto object = as_error(cell->evaluated_data)) {
+        if (cell->kind() == Spreadsheet::Cell::Formula) {
+            if (auto object = as_error(cell->evaluated_data())) {
                 StringBuilder builder;
                 auto error = object->get("message").to_string_without_side_effects();
                 builder.append("Error: ");
@@ -86,8 +86,8 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
         if (!cell)
             return {};
 
-        if (cell->kind == Spreadsheet::Cell::Formula) {
-            if (as_error(cell->evaluated_data))
+        if (cell->kind() == Spreadsheet::Cell::Formula) {
+            if (as_error(cell->evaluated_data()))
                 return Color(Color::Red);
         }
 

--- a/Applications/Spreadsheet/SpreadsheetModel.h
+++ b/Applications/Spreadsheet/SpreadsheetModel.h
@@ -46,6 +46,7 @@ public:
     virtual void update() override;
     virtual bool is_column_sortable(int) const override { return false; }
     virtual StringView drag_data_type() const override { return "text/x-spreadsheet-data"; }
+    Sheet& sheet() { return *m_sheet; }
 
 private:
     explicit SheetModel(Sheet& sheet)

--- a/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -86,6 +86,10 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
         if (!index.is_valid())
             return TableView::mousemove_event(event);
 
+        auto& sheet = static_cast<SheetModel&>(*model).sheet();
+        sheet.disable_updates();
+        ScopeGuard sheet_update_enabler { [&] { sheet.enable_updates(); } };
+
         auto holding_left_button = !!(event.buttons() & GUI::MouseButton::Left);
         auto rect = content_rect(index);
         auto distance = rect.center().absolute_relative_distance_to(event.position());

--- a/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -69,6 +69,8 @@ private:
     RefPtr<GUI::Label> m_current_cell_label;
     RefPtr<GUI::TextEditor> m_cell_value_editor;
     RefPtr<GUI::TabWidget> m_tab_widget;
+    RefPtr<GUI::Menu> m_tab_context_menu;
+    RefPtr<SpreadsheetView> m_tab_context_menu_sheet_view;
     bool m_should_change_selected_cells { false };
 
     OwnPtr<Workbook> m_workbook;

--- a/Applications/Spreadsheet/main.cpp
+++ b/Applications/Spreadsheet/main.cpp
@@ -181,7 +181,7 @@ int main(int argc, char* argv[])
             if (!first)
                 text_builder.append('\t');
             if (cell_data)
-                text_builder.append(cell_data->data);
+                text_builder.append(cell_data->data());
             first = false;
         }
         HashMap<String, String> metadata;

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -51,7 +51,7 @@
 
 namespace JS {
 
-static void update_function_name(Value value, const FlyString& name, HashTable<const JS::Cell*>& visited)
+static void update_function_name(Value value, const FlyString& name, HashTable<JS::Cell*>& visited)
 {
     if (!value.is_object())
         return;
@@ -73,7 +73,7 @@ static void update_function_name(Value value, const FlyString& name, HashTable<c
 
 static void update_function_name(Value value, const FlyString& name)
 {
-    HashTable<const JS::Cell*> visited;
+    HashTable<JS::Cell*> visited;
     update_function_name(value, name, visited);
 }
 

--- a/Libraries/LibJS/Heap/Handle.h
+++ b/Libraries/LibJS/Heap/Handle.h
@@ -65,6 +65,8 @@ public:
     T* cell() { return static_cast<T*>(m_impl->cell()); }
     const T* cell() const { return static_cast<const T*>(m_impl->cell()); }
 
+    bool is_null() const { return m_impl.is_null(); }
+
 private:
     explicit Handle(NonnullRefPtr<HandleImpl> impl)
         : m_impl(move(impl))


### PR DESCRIPTION
In this PR:
- Spreadsheet can once again load whatever it has saved
- Stop treating `Cell` as a struct, it has clearly outlived that stage
- Renaming sheets
- Crash-no-mo (put stored `JS::Cell`s inside handles)
- make `here().left()` no longer try to make `(size_t)-1` columns when entered in the leftmost cell of a row
- Don't update unrelated cells just because they have a deep dependency chain

