### PR TITLE
Kernel/Net: E1000 interrupt rate register is 32-bit, not 16-bit

### DIFF
--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -184,9 +184,7 @@ E1000NetworkAdapter::E1000NetworkAdapter(PCI::Address address, u8 irq)
     u32 flags = in32(REG_CTRL);
     out32(REG_CTRL, flags | ECTRL_SLU);
 
-    // FIXME: For some reason, this causes an MMIO fault on VirtualBox.
-    //        Removing it allows the system to boot to desktop, but will be hit by an interrupt storm soon after.
-    out16(REG_INTERRUPT_RATE, 6000); // Interrupt rate of 1.536 milliseconds
+    out32(REG_INTERRUPT_RATE, 6000); // Interrupt rate of 1.536 milliseconds
 
     initialize_rx_descriptors();
     initialize_tx_descriptors();


### PR DESCRIPTION
I looked at the spec sheet and noticed that it's 32-bit, not 16-bit.
This fixes E1000 causing an MMIO fault on VirtualBox.

Spec: https://www.intel.com/content/dam/doc/manual/pci-pci-x-family-gbe-controllers-software-dev-manual.pdf
Section 13.4.18