### PR TITLE
FileManager: Allow creating desktop shortcut from FileManager

### DIFF
--- a/Applications/FileManager/FileUtils.cpp
+++ b/Applications/FileManager/FileUtils.cpp
@@ -235,6 +235,23 @@ bool copy_file(const String& dst_path, const struct stat& src_stat, Core::File& 
     return true;
 }
 
+bool link_file(const String& src_path, const String& dst_path)
+{
+    int duplicate_count = 0;
+    while (access(get_duplicate_name(dst_path, duplicate_count).characters(), F_OK) == 0) {
+        ++duplicate_count;
+    }
+    if (duplicate_count != 0) {
+        return link_file(src_path, get_duplicate_name(dst_path, duplicate_count));
+    }
+    int rc = symlink(src_path.characters(), dst_path.characters());
+    if (rc < 0) {
+        return false;
+    }
+
+    return true;
+}
+
 String get_duplicate_name(const String& path, int duplicate_count)
 {
     if (duplicate_count == 0) {

--- a/Applications/FileManager/FileUtils.h
+++ b/Applications/FileManager/FileUtils.h
@@ -39,5 +39,6 @@ bool copy_file_or_directory(const String& src_path, const String& dst_path);
 String get_duplicate_name(const String& path, int duplicate_count);
 bool copy_file(const String& dst_path, const struct stat& src_stat, Core::File&);
 bool copy_directory(const String& src_path, const String& dst_path, const struct stat& src_stat);
+bool link_file(const String& src_path, const String& dst_path);
 
 }


### PR DESCRIPTION
This adds the option to create a desktop shortcut from a file or directory in the FileManager.

It'll also do the incrementing (x) if a shortcut is already there.

![20201222_16h00m04s_grim](https://user-images.githubusercontent.com/7910815/102908098-e2608600-446e-11eb-89d3-ebd4fa4c7670.png)
