### PR TITLE
Shell+SystemMenu: Launch SystemMenu apps by execing them in the user's shell

### DIFF
--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -256,6 +256,15 @@ int Shell::builtin_dirs(int argc, const char** argv)
     return 0;
 }
 
+int Shell::builtin_exec(int argc, const char** argv)
+{
+    Vector<const char*> argv_vector;
+    argv_vector.append(argv + 1, argc - 1);
+    argv_vector.append(nullptr);
+
+    execute_process(move(argv_vector));
+}
+
 int Shell::builtin_exit(int argc, const char** argv)
 {
     int exit_code = 0;

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -785,42 +785,7 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
         // We no longer need the jobs here.
         jobs.clear();
 
-        int rc = execvp(argv[0], const_cast<char* const*>(argv.data()));
-        if (rc < 0) {
-            int saved_errno = errno;
-            struct stat st;
-            if (stat(argv[0], &st)) {
-                fprintf(stderr, "stat(%s): %s\n", argv[0], strerror(errno));
-                _exit(126);
-            }
-            if (!(st.st_mode & S_IXUSR)) {
-                fprintf(stderr, "%s: Not executable\n", argv[0]);
-                _exit(126);
-            }
-            if (saved_errno == ENOENT) {
-                int shebang_fd = open(argv[0], O_RDONLY);
-                auto close_argv = ScopeGuard([shebang_fd]() { if (shebang_fd >= 0)  close(shebang_fd); });
-                char shebang[256] {};
-                ssize_t num_read = -1;
-                if ((shebang_fd >= 0) && ((num_read = read(shebang_fd, shebang, sizeof(shebang))) >= 2) && (StringView(shebang).starts_with("#!"))) {
-                    StringView shebang_path_view(&shebang[2], num_read - 2);
-                    Optional<size_t> newline_pos = shebang_path_view.find_first_of("\n\r");
-                    shebang[newline_pos.has_value() ? (newline_pos.value() + 2) : num_read] = '\0';
-                    argv[0] = shebang;
-                    int rc = execvp(argv[0], const_cast<char* const*>(argv.data()));
-                    if (rc < 0)
-                        fprintf(stderr, "%s: Invalid interpreter \"%s\": %s\n", argv[0], &shebang[2], strerror(errno));
-                } else
-                    fprintf(stderr, "%s: Command not found.\n", argv[0]);
-            } else {
-                if (S_ISDIR(st.st_mode)) {
-                    fprintf(stderr, "Shell: %s: Is a directory\n", argv[0]);
-                    _exit(126);
-                }
-                fprintf(stderr, "execvp(%s): %s\n", argv[0], strerror(saved_errno));
-            }
-            _exit(126);
-        }
+        execute_process(move(argv));
         ASSERT_NOT_REACHED();
     }
 
@@ -887,6 +852,47 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
     fds.collect();
 
     return *job;
+}
+
+void Shell::execute_process(Vector<const char*>&& argv)
+{
+    int rc = execvp(argv[0], const_cast<char* const*>(argv.data()));
+    if (rc < 0) {
+        int saved_errno = errno;
+        struct stat st;
+        if (stat(argv[0], &st)) {
+            fprintf(stderr, "stat(%s): %s\n", argv[0], strerror(errno));
+            _exit(126);
+        }
+        if (!(st.st_mode & S_IXUSR)) {
+            fprintf(stderr, "%s: Not executable\n", argv[0]);
+            _exit(126);
+        }
+        if (saved_errno == ENOENT) {
+            int shebang_fd = open(argv[0], O_RDONLY);
+            auto close_argv = ScopeGuard([shebang_fd]() { if (shebang_fd >= 0)  close(shebang_fd); });
+            char shebang[256] {};
+            ssize_t num_read = -1;
+            if ((shebang_fd >= 0) && ((num_read = read(shebang_fd, shebang, sizeof(shebang))) >= 2) && (StringView(shebang).starts_with("#!"))) {
+                StringView shebang_path_view(&shebang[2], num_read - 2);
+                Optional<size_t> newline_pos = shebang_path_view.find_first_of("\n\r");
+                shebang[newline_pos.has_value() ? (newline_pos.value() + 2) : num_read] = '\0';
+                argv[0] = shebang;
+                int rc = execvp(argv[0], const_cast<char* const*>(argv.data()));
+                if (rc < 0)
+                    fprintf(stderr, "%s: Invalid interpreter \"%s\": %s\n", argv[0], &shebang[2], strerror(errno));
+            } else
+                fprintf(stderr, "%s: Command not found.\n", argv[0]);
+        } else {
+            if (S_ISDIR(st.st_mode)) {
+                fprintf(stderr, "Shell: %s: Is a directory\n", argv[0]);
+                _exit(126);
+            }
+            fprintf(stderr, "execvp(%s): %s\n", argv[0], strerror(saved_errno));
+        }
+        _exit(126);
+    }
+    ASSERT_NOT_REACHED();
 }
 
 void Shell::run_tail(const AST::Command& invoking_command, const AST::NodeWithAction& next_in_chain, int head_exit_code)

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -45,6 +45,7 @@
     __ENUMERATE_SHELL_BUILTIN(cd)      \
     __ENUMERATE_SHELL_BUILTIN(cdh)     \
     __ENUMERATE_SHELL_BUILTIN(pwd)     \
+    __ENUMERATE_SHELL_BUILTIN(exec)    \
     __ENUMERATE_SHELL_BUILTIN(exit)    \
     __ENUMERATE_SHELL_BUILTIN(export)  \
     __ENUMERATE_SHELL_BUILTIN(unset)   \
@@ -92,6 +93,8 @@ public:
     void block_on_job(RefPtr<Job>);
     void block_on_pipeline(RefPtr<AST::Pipeline>);
     String prompt() const;
+
+    [[noreturn]] void execute_process(Vector<const char*>&& argv);
 
     static String expand_tilde(const String&);
     static Vector<String> expand_globs(const StringView& path, StringView base);


### PR DESCRIPTION
Currently the environment for the `SystemMenu` process is empty because the user's shell is not invoked at any point during its startup sequence. Consequentially any processes that are launched from the `SystemMenu` inherit an empty environment and do not run the user's shell profile. This can lead to issues such as #4484 where common environment variables such as `HOME` are absent from the program's environment.

This PR adds a very basic `exec` builtin to `Shell` and causes `SystemMenu` to launch all executables via the user's shell by running `$SHELL -c "exec <Executable>"`. Currently we don't support passing additional arguments to programs being launched `SystemMenu` so this is fine for now, but this will need rethinking if we ever support additional arguments.

This behaviour can be opted-out of by specifying `UseShell=false` in the `App` section of the appropriate `.af` file.