### PR TITLE
Kernel: Consolidate the various BlockCondition::unblock variants

### DIFF
--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -58,7 +58,7 @@ public:
     void unblock()
     {
         ScopedSpinLock lock(m_lock);
-        do_unblock([&](auto& b, void* data) {
+        do_unblock([&](auto& b, void* data, bool&) {
             ASSERT(b.blocker_type() == Thread::Blocker::Type::File);
             auto& blocker = static_cast<Thread::FileBlocker&>(b);
             return blocker.unblock(false, data);

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -469,7 +469,7 @@ bool Plan9FS::Plan9FSBlockCondition::should_add_blocker(Thread::Blocker& b, void
 
 void Plan9FS::Plan9FSBlockCondition::unblock_completed(u16 tag)
 {
-    unblock([&](Thread::Blocker& b, void*) {
+    unblock([&](Thread::Blocker& b, void*, bool&) {
         ASSERT(b.blocker_type() == Thread::Blocker::Type::Plan9FS);
         auto& blocker = static_cast<Blocker&>(b);
         return blocker.unblock(tag);
@@ -478,7 +478,7 @@ void Plan9FS::Plan9FSBlockCondition::unblock_completed(u16 tag)
 
 void Plan9FS::Plan9FSBlockCondition::unblock_all()
 {
-    BlockCondition::unblock_all([&](Thread::Blocker& b, void*) {
+    unblock([&](Thread::Blocker& b, void*, bool&) {
         ASSERT(b.blocker_type() == Thread::Blocker::Type::Plan9FS);
         auto& blocker = static_cast<Blocker&>(b);
         return blocker.unblock();

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -77,7 +77,7 @@ class ARPTableBlockCondition : public Thread::BlockCondition {
 public:
     void unblock(const IPv4Address& ip_addr, const MACAddress& addr)
     {
-        unblock_all([&](auto& b, void*) {
+        BlockCondition::unblock([&](auto& b, void*, bool&) {
             ASSERT(b.blocker_type() == Thread::Blocker::Type::Routing);
             auto& blocker = static_cast<ARPTableBlocker&>(b);
             return blocker.unblock(false, ip_addr, addr);

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -440,7 +440,7 @@ void Thread::WaitBlockCondition::disowned_by_waiter(Process& process)
     for (size_t i = 0; i < m_processes.size();) {
         auto& info = m_processes[i];
         if (info.process == &process) {
-            do_unblock([&](Blocker& b, void*) {
+            do_unblock([&](Blocker& b, void*, bool&) {
                 ASSERT(b.blocker_type() == Blocker::Type::Wait);
                 auto& blocker = static_cast<WaitBlocker&>(b);
                 bool did_unblock = blocker.unblock(info.process, WaitBlocker::UnblockFlags::Disowned, 0, false);
@@ -479,7 +479,7 @@ bool Thread::WaitBlockCondition::unblock(Process& process, WaitBlocker::UnblockF
         }
     }
 
-    do_unblock([&](Blocker& b, void*) {
+    do_unblock([&](Blocker& b, void*, bool&) {
         ASSERT(b.blocker_type() == Blocker::Type::Wait);
         auto& blocker = static_cast<WaitBlocker&>(b);
         if (was_waited_already && blocker.is_wait())


### PR DESCRIPTION
The unblock_all variant used to ASSERT if a blocker didn't unblock,
but it wasn't clear from the name that it would do that. Because
the BlockCondition already asserts that no blockers are left at
destruction time, it would still catch blockers that haven't been
unblocked for whatever reason.

Fixes #4496