### PR TITLE
LibC: __generate_unique_filename(): Replace rand() with arc4random()

### DIFF
--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -186,7 +186,7 @@ __attribute__((warn_unused_result)) int __generate_unique_filename(char* pattern
 
     for (int attempt = 0; attempt < 100; ++attempt) {
         for (int i = 0; i < 6; ++i)
-            pattern[start + i] = random_characters[(rand() % (sizeof(random_characters) - 1))];
+            pattern[start + i] = random_characters[(arc4random() % (sizeof(random_characters) - 1))];
         struct stat st;
         int rc = lstat(pattern, &st);
         if (rc < 0 && errno == ENOENT)


### PR DESCRIPTION
LibC stdlib `arc4random()` uses the `getrandom` system call which
uses `KernelRng::get_good_random_bytes`.

This ensures that filenames generated using functions such as
`mkstemp()` are suitably randomised and are no longer predictable.

Resolves #4089.
