### PR TITLE
CMake: Remove file globbing in AK/Tests

### DIFF
--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -1,4 +1,44 @@
-file(GLOB AK_TEST_SOURCES CONFIGURE_DEPENDS "*.cpp")
+set(AK_TEST_SOURCES
+    TestAllOf.cpp
+    TestArray.cpp
+    TestAtomic.cpp
+    TestBase64.cpp
+    TestBinarySearch.cpp
+    TestBitmap.cpp
+    TestByteBuffer.cpp
+    TestChecked.cpp
+    TestCircularDeque.cpp
+    TestCircularDuplexStream.cpp
+    TestCircularQueue.cpp
+    TestDistinctNumeric.cpp
+    TestEndian.cpp
+    TestFormat.cpp
+    TestHashFunctions.cpp
+    TestHashMap.cpp
+    TestIPv4Address.cpp
+    TestJSON.cpp
+    TestLexicalPath.cpp
+    TestMACAddress.cpp
+    TestMemMem.cpp
+    TestMemoryStream.cpp
+    TestNeverDestroyed.cpp
+    TestNonnullRefPtr.cpp
+    TestNumberFormat.cpp
+    TestOptional.cpp
+    TestQueue.cpp
+    TestQuickSort.cpp
+    TestRefPtr.cpp
+    TestSourceGenerator.cpp
+    TestSpan.cpp
+    TestString.cpp
+    TestStringUtils.cpp
+    TestStringView.cpp
+    TestTypedTransfer.cpp
+    TestURL.cpp
+    TestUtf8.cpp
+    TestVector.cpp
+    TestWeakPtr.cpp
+)
 
 foreach(source ${AK_TEST_SOURCES})
     get_filename_component(name ${source} NAME_WE)


### PR DESCRIPTION
Problem:
- File globbing is performed at the time of build system
  generation. Any files which are not there at that time are not
  included. So, when a new file is added it is not built unless the
  build system is recreated.

Solution:
- Remove globbing from AK/Tests directory in favor of explicitly
  listing the files.