### PR TITLE
LibELF: Add missing case for DT_RPATH

### DIFF
--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -1,4 +1,44 @@
-file(GLOB AK_TEST_SOURCES CONFIGURE_DEPENDS "*.cpp")
+set(AK_TEST_SOURCES
+    TestAllOf.cpp
+    TestArray.cpp
+    TestAtomic.cpp
+    TestBase64.cpp
+    TestBinarySearch.cpp
+    TestBitmap.cpp
+    TestByteBuffer.cpp
+    TestChecked.cpp
+    TestCircularDeque.cpp
+    TestCircularDuplexStream.cpp
+    TestCircularQueue.cpp
+    TestDistinctNumeric.cpp
+    TestEndian.cpp
+    TestFormat.cpp
+    TestHashFunctions.cpp
+    TestHashMap.cpp
+    TestIPv4Address.cpp
+    TestJSON.cpp
+    TestLexicalPath.cpp
+    TestMACAddress.cpp
+    TestMemMem.cpp
+    TestMemoryStream.cpp
+    TestNeverDestroyed.cpp
+    TestNonnullRefPtr.cpp
+    TestNumberFormat.cpp
+    TestOptional.cpp
+    TestQueue.cpp
+    TestQuickSort.cpp
+    TestRefPtr.cpp
+    TestSourceGenerator.cpp
+    TestSpan.cpp
+    TestString.cpp
+    TestStringUtils.cpp
+    TestStringView.cpp
+    TestTypedTransfer.cpp
+    TestURL.cpp
+    TestUtf8.cpp
+    TestVector.cpp
+    TestWeakPtr.cpp
+)
 
 foreach(source ${AK_TEST_SOURCES})
     get_filename_component(name ${source} NAME_WE)

--- a/Libraries/LibELF/DynamicObject.cpp
+++ b/Libraries/LibELF/DynamicObject.cpp
@@ -160,6 +160,10 @@ void DynamicObject::parse()
         case DT_NEEDED:
             // We handle these in for_each_needed_library
             break;
+        case DT_RPATH:
+        case DT_RUNPATH:
+            // FIXME: Implement RPATH/RUNPATH handling in DynamicLoader
+            break;
         default:
             dbgprintf("DynamicObject: DYNAMIC tag handling not implemented for DT_%s\n", name_for_dtag(entry.tag()));
             printf("DynamicObject: DYNAMIC tag handling not implemented for DT_%s\n", name_for_dtag(entry.tag()));


### PR DESCRIPTION
SystemServer crashes on boot when built on macOS when
this is missing. See issue [#4418](https://github.com/SerenityOS/serenity/issues/4418).

This is the laziest way to fix this. DT_RPATH should probably be handled
correctly but I don't know enough about the ELF format to do this.