### PR TITLE
ProcFS: pid_vm: Replace duplicated purgeable key with kernel+cacheable

### DIFF
--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -333,7 +333,8 @@ static OwnPtr<KBuffer> procfs$pid_vm(InodeIdentifier identifier)
             if (region.vmobject().is_purgeable()) {
                 region_object.add("volatile", static_cast<const PurgeableVMObject&>(region.vmobject()).is_volatile());
             }
-            region_object.add("purgeable", region.vmobject().is_purgeable());
+            region_object.add("cacheable", region.is_cacheable());
+            region_object.add("kernel", region.is_kernel());
             region_object.add("address", region.vaddr().get());
             region_object.add("size", region.size());
             region_object.add("amount_resident", region.amount_resident());


### PR DESCRIPTION
ProcFS `/proc/<pid>/vm` map info no longer contains two `purgeable` keys.

The second `purgeable` key has been removed and replaced with keys for
`kernel` and `cacheable`.

I have no idea why this key was duplicated. I took a guess that `cacheable` and `kernel` *might* be useful and reasonable replacements.

We don't currently support KASLR, and the kernel is always loaded at the same address, so revealing `is_kernel` does not seem like an issue (for now).

Before:

![before](https://user-images.githubusercontent.com/434827/103039147-38930d80-45c4-11eb-98fb-d77a064dae06.png)

After:

![after](https://user-images.githubusercontent.com/434827/103039156-3af56780-45c4-11eb-9949-a73b73fb62b1.png)
