### PR TITLE
Meta: Set two minute timeout for CMake tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,6 +79,7 @@ jobs:
     - name: Run CMake tests
       working-directory: ${{ github.workspace }}/Build
       run: CTEST_OUTPUT_ON_FAILURE=1 ninja test
+      timeout-minutes: 2
     - name: Run JS tests
       working-directory: ${{ github.workspace }}/Build/Meta/Lagom
       run: DISABLE_DBG_OUTPUT=1 ./test-js


### PR DESCRIPTION
CMake tests usually takes ~40 seconds. However, sometimes it deadlocks
and is only timed out after the 6 hour time limit.

Let's set a 2 minute timeout to make it fail sooner. 2 minutes instead
of 1 for good measure.