### PR TITLE
Remove [Icons] from .af files

### DIFF
--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -419,6 +419,11 @@ int main(int argc, char** argv)
         return 1;
     }
 
+    if (unveil("/bin", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
     if (unveil("/bin/Terminal", "x") < 0) {
         perror("unveil");
         return 1;

--- a/Base/res/apps/2048.af
+++ b/Base/res/apps/2048.af
@@ -2,7 +2,3 @@
 Name=2048
 Executable=/bin/2048
 Category=Games
-
-[Icons]
-16x16=/res/icons/16x16/app-2048.png
-32x32=/res/icons/32x32/app-2048.png

--- a/Base/res/apps/Breakout.af
+++ b/Base/res/apps/Breakout.af
@@ -2,7 +2,3 @@
 Name=Breakout
 Executable=/bin/Breakout
 Category=Games
-
-[Icons]
-16x16=/res/icons/16x16/app-breakout.png
-32x32=/res/icons/32x32/app-breakout.png

--- a/Base/res/apps/Browser.af
+++ b/Base/res/apps/Browser.af
@@ -3,10 +3,6 @@ Name=Browser
 Executable=/bin/Browser
 Category=Internet
 
-[Icons]
-16x16=/res/icons/16x16/app-browser.png
-32x32=/res/icons/32x32/app-browser.png
-
 [Launcher]
 FileTypes=html,htm,md
 Protocols=gemini,http,https

--- a/Base/res/apps/Calculator.af
+++ b/Base/res/apps/Calculator.af
@@ -2,7 +2,3 @@
 Name=Calculator
 Executable=/bin/Calculator
 Category=Utilities
-
-[Icons]
-16x16=/res/icons/16x16/app-calculator.png
-32x32=

--- a/Base/res/apps/Calendar.af
+++ b/Base/res/apps/Calendar.af
@@ -2,7 +2,3 @@
 Name=Calendar
 Executable=/bin/Calendar
 Category=Utilities
-
-[Icons]
-16x16=/res/icons/16x16/app-calendar.png
-32x32=

--- a/Base/res/apps/Chess.af
+++ b/Base/res/apps/Chess.af
@@ -2,7 +2,3 @@
 Name=Chess
 Executable=/bin/Chess
 Category=Games
-
-[Icons]
-16x16=/res/icons/16x16/app-chess.png
-32x32=/res/icons/32x32/app-chess.png

--- a/Base/res/apps/Cube.af
+++ b/Base/res/apps/Cube.af
@@ -2,7 +2,3 @@
 Name=Cube
 Executable=/bin/Cube
 Category=Demos
-
-[Icons]
-16x16=/res/icons/16x16/app-cube.png
-32x32=/res/icons/32x32/app-cube.png

--- a/Base/res/apps/DisplaySettings.af
+++ b/Base/res/apps/DisplaySettings.af
@@ -2,7 +2,3 @@
 Name=Display settings
 Executable=/bin/DisplaySettings
 Category=Settings
-
-[Icons]
-16x16=/res/icons/16x16/app-display-settings.png
-32x32=/res/icons/32x32/app-display-settings.png

--- a/Base/res/apps/Eyes.af
+++ b/Base/res/apps/Eyes.af
@@ -2,7 +2,3 @@
 Name=Eyes
 Executable=/bin/Eyes
 Category=Demos
-
-[Icons]
-16x16=/res/icons/16x16/app-eyes.png
-32x32=/res/icons/32x32/app-eyes.png

--- a/Base/res/apps/FileManager.af
+++ b/Base/res/apps/FileManager.af
@@ -2,7 +2,3 @@
 Name=File Manager
 Executable=/bin/FileManager
 Category=Utilities
-
-[Icons]
-16x16=/res/icons/16x16/filetype-folder.png
-32x32=/res/icons/32x32/filetype-folder.png

--- a/Base/res/apps/Fire.af
+++ b/Base/res/apps/Fire.af
@@ -2,7 +2,3 @@
 Name=Fire
 Executable=/bin/Fire
 Category=Demos
-
-[Icons]
-16x16=/res/icons/16x16/app-fire.png
-32x32=/res/icons/32x32/app-fire.png

--- a/Base/res/apps/FontEditor.af
+++ b/Base/res/apps/FontEditor.af
@@ -3,9 +3,5 @@ Name=Font Editor
 Executable=/bin/FontEditor
 Category=Development
 
-[Icons]
-16x16=/res/icons/16x16/app-font-editor.png
-32x32=/res/icons/32x32/app-font-editor.png
-
 [Launcher]
 FileTypes=font

--- a/Base/res/apps/HackStudio.af
+++ b/Base/res/apps/HackStudio.af
@@ -2,7 +2,3 @@
 Name=HackStudio
 Executable=/bin/HackStudio
 Category=Development
-
-[Icons]
-16x16=/res/icons/16x16/app-hack-studio.png
-32x32=/res/icons/32x32/app-hack-studio.png

--- a/Base/res/apps/HelloWorld.af
+++ b/Base/res/apps/HelloWorld.af
@@ -2,7 +2,3 @@
 Name=Hello World
 Executable=/bin/HelloWorld
 Category=Demos
-
-[Icons]
-16x16=/res/icons/16x16/app-hello-world.png
-32x32=

--- a/Base/res/apps/Help.af
+++ b/Base/res/apps/Help.af
@@ -2,7 +2,3 @@
 Name=Help
 Executable=/bin/Help
 Category=Utilities
-
-[Icons]
-16x16=/res/icons/16x16/app-help.png
-32x32=/res/icons/32x32/app-help.png

--- a/Base/res/apps/HexEditor.af
+++ b/Base/res/apps/HexEditor.af
@@ -2,7 +2,3 @@
 Name=Hex Editor
 Executable=/bin/HexEditor
 Category=Development
-
-[Icons]
-16x16=/res/icons/16x16/app-hexeditor.png
-32x32=/res/icons/32x32/app-hexeditor.png

--- a/Base/res/apps/IRCClient.af
+++ b/Base/res/apps/IRCClient.af
@@ -3,9 +3,5 @@ Name=IRC Client
 Executable=/bin/IRCClient
 Category=Internet
 
-[Icons]
-16x16=/res/icons/16x16/app-irc-client.png
-32x32=/res/icons/32x32/app-irc-client.png
-
 [Launcher]
 Protocols=irc

--- a/Base/res/apps/Inspector.af
+++ b/Base/res/apps/Inspector.af
@@ -2,7 +2,3 @@
 Name=Inspector
 Executable=/bin/Inspector
 Category=Development
-
-[Icons]
-16x16=/res/icons/16x16/app-inspector.png
-32x32=/res/icons/32x32/app-inspector.png

--- a/Base/res/apps/Keyboard.af
+++ b/Base/res/apps/Keyboard.af
@@ -2,7 +2,3 @@
 Name=Keyboard settings
 Executable=/bin/KeyboardSettings
 Category=Settings
-
-[Icons]
-16x16=/res/icons/16x16/app-keyboard-settings.png
-32x32=/res/icons/32x32/app-keyboard-settings.png

--- a/Base/res/apps/LibGfxDemo.af
+++ b/Base/res/apps/LibGfxDemo.af
@@ -2,7 +2,3 @@
 Name=LibGfx Demo
 Executable=/bin/LibGfxDemo
 Category=Demos
-
-[Icons]
-16x16=/res/icons/16x16/app-libgfx-demo.png
-32x32=/res/icons/32x32/app-libgfx-demo.png

--- a/Base/res/apps/Minesweeper.af
+++ b/Base/res/apps/Minesweeper.af
@@ -2,7 +2,3 @@
 Name=Minesweeper
 Executable=/bin/Minesweeper
 Category=Games
-
-[Icons]
-16x16=/res/icons/16x16/app-minesweeper.png
-32x32=/res/icons/32x32/app-minesweeper.png

--- a/Base/res/apps/Mouse.af
+++ b/Base/res/apps/Mouse.af
@@ -2,7 +2,3 @@
 Name=Mouse
 Executable=/bin/Mouse
 Category=Demos
-
-[Icons]
-16x16=/res/icons/16x16/app-mouse.png
-32x32=/res/icons/32x32/app-mouse.png

--- a/Base/res/apps/Piano.af
+++ b/Base/res/apps/Piano.af
@@ -2,7 +2,3 @@
 Name=Piano
 Executable=/bin/Piano
 Category=Sound
-
-[Icons]
-16x16=/res/icons/16x16/app-piano.png
-32x32=/res/icons/32x32/app-piano.png

--- a/Base/res/apps/PixelPaint.af
+++ b/Base/res/apps/PixelPaint.af
@@ -2,7 +2,3 @@
 Name=PixelPaint
 Executable=/bin/PixelPaint
 Category=Graphics
-
-[Icons]
-16x16=/res/icons/16x16/app-pixel-paint.png
-32x32=/res/icons/32x32/app-pixel-paint.png

--- a/Base/res/apps/Pong.af
+++ b/Base/res/apps/Pong.af
@@ -2,7 +2,3 @@
 Name=Pong
 Executable=/bin/Pong
 Category=Games
-
-[Icons]
-16x16=/res/icons/16x16/app-pong.png
-32x32=/res/icons/32x32/app-pong.png

--- a/Base/res/apps/Profiler.af
+++ b/Base/res/apps/Profiler.af
@@ -2,7 +2,3 @@
 Name=Profiler
 Executable=/bin/Profiler
 Category=Development
-
-[Icons]
-16x16=/res/icons/16x16/app-profiler.png
-32x32=/res/icons/32x32/app-profiler.png

--- a/Base/res/apps/QuickShow.af
+++ b/Base/res/apps/QuickShow.af
@@ -3,9 +3,5 @@ Name=QuickShow
 Executable=/bin/QuickShow
 Category=Graphics
 
-[Icons]
-16x16=/res/icons/16x16/filetype-image.png
-32x32=/res/icons/32x32/filetype-image.png
-
 [Launcher]
 FileTypes=pbm,pgm,png,ppm,gif,jpg,jpeg

--- a/Base/res/apps/Screensaver.af
+++ b/Base/res/apps/Screensaver.af
@@ -2,7 +2,3 @@
 Name=Screensaver
 Executable=/bin/Screensaver
 Category=Demos
-
-[Icons]
-16x16=/res/icons/16x16/app-screensaver.png
-32x32=/res/icons/32x32/app-screensaver.png

--- a/Base/res/apps/Snake.af
+++ b/Base/res/apps/Snake.af
@@ -2,7 +2,3 @@
 Name=Snake
 Executable=/bin/Snake
 Category=Games
-
-[Icons]
-16x16=/res/icons/16x16/app-snake.png
-32x32=/res/icons/32x32/app-snake.png

--- a/Base/res/apps/Solitaire.af
+++ b/Base/res/apps/Solitaire.af
@@ -2,6 +2,3 @@
 Name=Solitaire
 Executable=/bin/Solitaire
 Category=Games
-
-[Icons]
-16x16=/res/icons/16x16/app-solitaire.png

--- a/Base/res/apps/SoundPlayer.af
+++ b/Base/res/apps/SoundPlayer.af
@@ -3,9 +3,5 @@ Name=SoundPlayer
 Executable=/bin/SoundPlayer
 Category=Sound
 
-[Icons]
-16x16=/res/icons/16x16/app-sound-player.png
-32x32=/res/icons/32x32/app-sound-player.png
-
 [Launcher]
 FileTypes=wav

--- a/Base/res/apps/Spreadsheet.af
+++ b/Base/res/apps/Spreadsheet.af
@@ -3,9 +3,5 @@ Name=Spreadsheet
 Executable=/bin/Spreadsheet
 Category=Utilities
 
-[Icons]
-16x16=/res/icons/16x16/app-spreadsheet.png
-32x32=/res/icons/32x32/app-spreadsheet.png
-
 [Launcher]
 FileTypes=sheets

--- a/Base/res/apps/SystemMonitor.af
+++ b/Base/res/apps/SystemMonitor.af
@@ -2,7 +2,3 @@
 Name=System Monitor
 Executable=/bin/SystemMonitor
 Category=Utilities
-
-[Icons]
-16x16=/res/icons/16x16/app-system-monitor.png
-32x32=/res/icons/32x32/app-system-monitor.png

--- a/Base/res/apps/Terminal.af
+++ b/Base/res/apps/Terminal.af
@@ -2,7 +2,3 @@
 Name=Terminal
 Executable=/bin/Terminal
 Category=Utilities
-
-[Icons]
-16x16=/res/icons/16x16/app-terminal.png
-32x32=/res/icons/32x32/app-terminal.png

--- a/Base/res/apps/TextEditor.af
+++ b/Base/res/apps/TextEditor.af
@@ -3,9 +3,5 @@ Name=Text Editor
 Executable=/bin/TextEditor
 Category=Utilities
 
-[Icons]
-16x16=/res/icons/16x16/app-text-editor.png
-32x32=/res/icons/32x32/app-text-editor.png
-
 [Launcher]
 FileTypes=txt,md,html,htm,js,json,ini

--- a/Base/res/apps/ThemeEditor.af
+++ b/Base/res/apps/ThemeEditor.af
@@ -2,7 +2,3 @@
 Name=Theme Editor
 Executable=/bin/ThemeEditor
 Category=Development
-
-[Icons]
-16x16=/res/icons/16x16/app-theme-editor.png
-32x32=

--- a/Base/res/apps/WidgetGallery.af
+++ b/Base/res/apps/WidgetGallery.af
@@ -2,7 +2,3 @@
 Name=Widget Gallery
 Executable=/bin/WidgetGallery
 Category=Demos
-
-[Icons]
-16x16=/res/icons/16x16/app-widget-gallery.png
-32x32=/res/icons/32x32/app-widget-gallery.png

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -39,6 +39,8 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/DragOperation.h>
+#include <LibGUI/FileIconProvider.h>
+#include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/ScrollBar.h>
@@ -858,10 +860,9 @@ void TerminalWidget::context_menu_event(GUI::ContextMenuEvent& event)
             auto af_path = String::format("/res/apps/%s.af", LexicalPath(handler).basename().characters());
             auto af = Core::ConfigFile::open(af_path);
             auto handler_name = af->read_entry("App", "Name", handler);
-            auto handler_icon = af->read_entry("Icons", "16x16", {});
-
-            auto icon = Gfx::Bitmap::load_from_file(handler_icon);
-            auto action = GUI::Action::create(String::format("Open in %s", handler_name.characters()), move(icon), [this, handler](auto&) {
+            auto handler_executable = af->read_entry("App", "Executable");
+            auto handler_icon = GUI::FileIconProvider::icon_for_path(handler_executable).bitmap_for_size(16);
+            auto action = GUI::Action::create(String::format("Open in %s", handler_name.characters()), handler_icon, [this, handler](auto&) {
                 Desktop::Launcher::open(m_context_menu_href, handler);
             });
 

--- a/Services/Taskbar/TaskbarWindow.cpp
+++ b/Services/Taskbar/TaskbarWindow.cpp
@@ -32,7 +32,9 @@
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Desktop.h>
+#include <LibGUI/FileIconProvider.h>
 #include <LibGUI/Frame.h>
+#include <LibGUI/Icon.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
 #include <LibGUI/WindowServerConnection.h>
@@ -114,14 +116,14 @@ void TaskbarWindow::create_quick_launch_bar()
         auto af = Core::ConfigFile::open(af_path);
         auto app_executable = af->read_entry("App", "Executable");
         auto app_name = af->read_entry("App", "Name");
-        auto app_icon_path = af->read_entry("Icons", "16x16");
+        auto app_icon = GUI::FileIconProvider::icon_for_path(app_executable).bitmap_for_size(16);
 
         auto& button = quick_launch_bar.add<GUI::Button>();
         button.set_size_policy(GUI::SizePolicy::Fixed, GUI::SizePolicy::Fixed);
         button.set_preferred_size(24, 24);
         button.set_button_style(Gfx::ButtonStyle::CoolBar);
 
-        button.set_icon(Gfx::Bitmap::load_from_file(app_icon_path));
+        button.set_icon(app_icon);
         button.set_tooltip(app_name);
         button.on_click = [app_executable](auto) {
             pid_t pid = fork();


### PR DESCRIPTION
Move the remaining users of this information over to GUI::FileIconProvider and then remove the `[Icons]` section from all .af files.