### PR TITLE
Everywhere: void arguments to C functions

### DIFF
--- a/AK/Tests/TestSourceGenerator.cpp
+++ b/AK/Tests/TestSourceGenerator.cpp
@@ -44,9 +44,9 @@ TEST_CASE(generate_c_code)
     SourceGenerator generator { builder };
     generator.set("name", "foo");
 
-    generator.append("const char* @name@ () { return \"@name@\"; }");
+    generator.append("const char* @name@ (void) { return \"@name@\"; }");
 
-    EXPECT_EQ(generator.as_string_view(), "const char* foo () { return \"foo\"; }");
+    EXPECT_EQ(generator.as_string_view(), "const char* foo (void) { return \"foo\"; }");
 }
 
 TEST_CASE(scoped)

--- a/Base/usr/share/man/man2/geteuid.md
+++ b/Base/usr/share/man/man2/geteuid.md
@@ -7,8 +7,8 @@ geteuid, getegid - get effective user / group id
 ```**c++
 #include <unistd.h>
 
-uid_t geteuid();
-gid_t getegid();
+uid_t geteuid(void);
+gid_t getegid(void);
 ```
 
 ## Description

--- a/Base/usr/share/man/man2/getuid.md
+++ b/Base/usr/share/man/man2/getuid.md
@@ -7,8 +7,8 @@ getuid, getgid - get real user / group id
 ```**c++
 #include <unistd.h>
 
-uid_t getuid();
-gid_t getgid();
+uid_t getuid(void);
+gid_t getgid(void);
 ```
 
 ## Description

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -1544,8 +1544,8 @@ void signal_trampoline_dummy()
         ".att_syntax" ::"i"(Syscall::SC_sigreturn));
 }
 
-extern "C" void asm_signal_trampoline();
-extern "C" void asm_signal_trampoline_end();
+extern "C" void asm_signal_trampoline(void);
+extern "C" void asm_signal_trampoline_end(void);
 
 void Emulator::setup_signal_trampoline()
 {

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -64,9 +64,9 @@ static GenericInterruptHandler* s_interrupt_handler[GENERIC_INTERRUPT_HANDLERS_C
 extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread);
 extern "C" void context_first_init(Thread* from_thread, Thread* to_thread, TrapFrame* trap);
 extern "C" u32 do_init_context(Thread* thread, u32 flags);
-extern "C" void exit_kernel_thread();
-extern "C" void pre_init_finished();
-extern "C" void post_init_finished();
+extern "C" void exit_kernel_thread(void);
+extern "C" void pre_init_finished(void);
+extern "C" void post_init_finished(void);
 extern "C" void handle_interrupt(TrapFrame*);
 
 #define EH_ENTRY(ec, title)                         \
@@ -1514,7 +1514,7 @@ extern "C" void context_first_init([[maybe_unused]] Thread* from_thread, [[maybe
     Scheduler::leave_on_first_switch(trap->regs->eflags);
 }
 
-extern "C" void thread_context_first_enter();
+extern "C" void thread_context_first_enter(void);
 asm(
 // enter_thread_context returns to here first time a thread is executing
 ".globl thread_context_first_enter \n"
@@ -1530,7 +1530,7 @@ asm(
 "    jmp common_trap_exit \n"
 );
 
-void exit_kernel_thread()
+void exit_kernel_thread(void)
 {
     Thread::current()->exit();
 }
@@ -1675,7 +1675,7 @@ void Processor::assume_context(Thread& thread, u32 flags)
     ASSERT_NOT_REACHED();
 }
 
-extern "C" void pre_init_finished()
+extern "C" void pre_init_finished(void)
 {
     ASSERT(g_scheduler_lock.own_lock());
 
@@ -1688,7 +1688,7 @@ extern "C" void pre_init_finished()
     Scheduler::leave_on_first_switch(prev_flags);
 }
 
-extern "C" void post_init_finished()
+extern "C" void post_init_finished(void)
 {
     // We need to re-acquire the scheduler lock before a context switch
     // transfers control into the idle loop, which needs the lock held

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -210,7 +210,7 @@ void APIC::write_icr(const ICRReg& icr)
 #define APIC_LVT_TRIGGER_LEVEL (1 << 14)
 #define APIC_LVT(iv, dm) (((iv)&0xff) | (((dm)&0x7) << 8))
 
-extern "C" void apic_ap_start();
+extern "C" void apic_ap_start(void);
 extern "C" u16 apic_ap_start_size;
 extern "C" u32 ap_cpu_init_stacks;
 extern "C" u32 ap_cpu_init_processor_info_array;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -426,8 +426,8 @@ void signal_trampoline_dummy()
         ".att_syntax" ::"i"(Syscall::SC_sigreturn));
 }
 
-extern "C" void asm_signal_trampoline();
-extern "C" void asm_signal_trampoline_end();
+extern "C" void asm_signal_trampoline(void);
+extern "C" void asm_signal_trampoline_end(void);
 
 void create_signal_trampolines()
 {

--- a/Libraries/LibC/stdlib.cpp
+++ b/Libraries/LibC/stdlib.cpp
@@ -1021,7 +1021,7 @@ unsigned long long strtoull(const char* str, char** endptr, int base)
 // Serenity's PRNG is not cryptographically secure. Do not rely on this for
 // any real crypto! These functions (for now) are for compatibility.
 // TODO: In the future, rand can be made deterministic and this not.
-uint32_t arc4random()
+uint32_t arc4random(void)
 {
     char buf[4];
     syscall(SC_getrandom, buf, 4, 0);

--- a/Libraries/LibC/stdlib.h
+++ b/Libraries/LibC/stdlib.h
@@ -41,13 +41,13 @@ __BEGIN_DECLS
 __attribute__((malloc)) __attribute__((alloc_size(1))) void* malloc(size_t);
 __attribute__((malloc)) __attribute__((alloc_size(1, 2))) void* calloc(size_t nmemb, size_t);
 size_t malloc_size(void*);
-void serenity_dump_malloc_stats();
+void serenity_dump_malloc_stats(void);
 void free(void*);
 __attribute__((alloc_size(2))) void* realloc(void* ptr, size_t);
 char* getenv(const char* name);
 int putenv(char*);
 int unsetenv(const char*);
-int clearenv();
+int clearenv(void);
 int setenv(const char* name, const char* value, int overwrite);
 int atoi(const char*);
 long atol(const char*);
@@ -87,7 +87,7 @@ void srand(unsigned seed);
 long int random();
 void srandom(unsigned seed);
 
-uint32_t arc4random();
+uint32_t arc4random(void);
 void arc4random_buf(void*, size_t);
 uint32_t arc4random_uniform(uint32_t);
 

--- a/Libraries/LibC/syslog.cpp
+++ b/Libraries/LibC/syslog.cpp
@@ -94,7 +94,7 @@ void closelog_r(struct syslog_data* data)
     data->maskpri = LOG_UPTO(LOG_DEBUG);
 }
 
-void closelog()
+void closelog(void)
 {
     closelog_r(&global_log_data);
 }

--- a/Libraries/LibC/syslog.h
+++ b/Libraries/LibC/syslog.h
@@ -169,7 +169,7 @@ void vsyslog(int, const char* message, va_list);
 void vsyslog_r(int, struct syslog_data* data, const char* message, va_list);
 void openlog(const char*, int, int);
 void openlog_r(const char*, int, int, struct syslog_data*);
-void closelog();
+void closelog(void);
 void closelog_r(struct syslog_data*);
 int setlogmask(int);
 int setlogmask_r(int, struct syslog_data*);

--- a/Libraries/LibELF/DynamicLoader.cpp
+++ b/Libraries/LibELF/DynamicLoader.cpp
@@ -408,7 +408,7 @@ void DynamicLoader::do_relocations(size_t total_tls_size)
 }
 
 // Defined in <arch>/plt_trampoline.S
-extern "C" void _plt_trampoline() __attribute__((visibility("hidden")));
+extern "C" void _plt_trampoline(void) __attribute__((visibility("hidden")));
 
 void DynamicLoader::setup_plt_trampoline()
 {

--- a/Libraries/LibPthread/pthread.h
+++ b/Libraries/LibPthread/pthread.h
@@ -67,7 +67,7 @@ int pthread_attr_setstack(pthread_attr_t* attr, void*, size_t);
 int pthread_attr_getstacksize(const pthread_attr_t*, size_t*);
 int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 
-int pthread_once(pthread_once_t*, void (*)());
+int pthread_once(pthread_once_t*, void (*)(void));
 #define PTHREAD_ONCE_INIT 0
 void* pthread_getspecific(pthread_key_t key);
 int pthread_setspecific(pthread_key_t key, const void* value);
@@ -100,14 +100,14 @@ int pthread_cancel(pthread_t);
 int pthread_cond_destroy(pthread_cond_t*);
 int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, const struct timespec*);
 
-void pthread_testcancel();
+void pthread_testcancel(void);
 
 int pthread_spin_destroy(pthread_spinlock_t*);
 int pthread_spin_init(pthread_spinlock_t*, int);
 int pthread_spin_lock(pthread_spinlock_t*);
 int pthread_spin_trylock(pthread_spinlock_t*);
 int pthread_spin_unlock(pthread_spinlock_t*);
-pthread_t pthread_self();
+pthread_t pthread_self(void);
 int pthread_detach(pthread_t);
 int pthread_equal(pthread_t, pthread_t);
 int pthread_mutexattr_init(pthread_mutexattr_t*);

--- a/Libraries/LibPthread/pthread_once.cpp
+++ b/Libraries/LibPthread/pthread_once.cpp
@@ -37,7 +37,7 @@ enum State : i32 {
     PERFORMING_WITH_WAITERS,
 };
 
-int pthread_once(pthread_once_t* self, void (*callback)())
+int pthread_once(pthread_once_t* self, void (*callback)(void))
 {
     auto& state = reinterpret_cast<Atomic<State>&>(*self);
 


### PR DESCRIPTION
Problem:
- C functions with no arguments require a single `void` in the argument list.

Solution:
- Put the `void` in the argument list of functions in C header files.