### PR TITLE
Meta: Verify all AK test files are listed in CMake

### DIFF
--- a/Meta/check-ak-test-files.sh
+++ b/Meta/check-ak-test-files.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eo pipefail
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+cd "${script_path}/.."
+
+MISSING_FILES=n
+
+while IFS= read -r FILENAME; do
+    # Simply search whether the CMakeLists.txt *ever* mention the test files.
+    if ! grep -qP "${FILENAME}" AK/Tests/CMakeLists.txt ; then
+        echo "AK/Tests/CMakeLists.txt is missing the test file ${FILENAME}"
+        MISSING_FILES=y
+    fi
+done < <(
+    git ls-files 'AK/Tests/Test*.cpp' | xargs -i basename {}
+)
+
+if [ "n" != "${MISSING_FILES}" ] ; then
+    echo "Some files are missing from the AK/Tests/CMakeLists.txt."
+    echo "If a new test file is being added, ensure it is in the CMakeLists.txt."
+    echo "This ensures the new tests are always run."
+    exit 1
+fi

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -6,6 +6,7 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.." || exit 1
 
 for cmd in \
+        Meta/check-ak-test-files.sh \
         Meta/check-debug-flags.sh \
         Meta/check-style.sh \
         Meta/lint-executable-resources.sh \


### PR DESCRIPTION
Problem:
- It is possible for a new test file to be added to the `AK/Tests`
  directory without being added to the corresponding
  `CMakeLists.txt`. This results in the tests not being run.

Solution:
- As part of CI linting, verify that all the `AK/Tests/Test*.cpp`
  files are mentioned in the `CMakeLists.txt`.