### PR TITLE
Meta: Run all lint checks and report failures together

### DIFF
--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -5,19 +5,38 @@ set -e
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.." || exit 1
 
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+FAILURES=0
+
+set +e
+
 for cmd in \
         Meta/check-debug-flags.sh \
         Meta/check-style.sh \
         Meta/lint-executable-resources.sh \
         Meta/lint-ipc-ids.sh \
-        Meta/lint-shell-scripts.sh ; do
-    echo "Running $cmd"
-    "$cmd"
-    echo "$cmd successful"
+        Meta/lint-shell-scripts.sh; do
+    echo "Running $cmd... "
+    if $cmd; then
+	echo -e "[${GREEN}OK${NC}]: ${cmd}"
+    else
+	echo -e "[${RED}FAIL${NC}]: ${cmd}"
+	((FAILURES+=1))
+    fi
 done
 
 echo "Running Meta/lint-clang-format.sh"
-Meta/lint-clang-format.sh --overwrite-inplace && git diff --exit-code
-echo "Meta/lint-clang-format.sh successful"
+if Meta/lint-clang-format.sh --overwrite-inplace && git diff --exit-code; then
+    echo -e "[${GREEN}OK${NC}]: Meta/lint-clang-format.sh"
+else
+    echo -e "[${RED}FAIL${NC}]: Meta/lint-clang-format.sh"
+    ((FAILURES+=1))
+fi
+
 echo "(Not running lint-missing-resources.sh due to high false-positive rate.)"
 echo "(Also look out for check-symbols.sh, which can only be executed after the build!)"
+
+exit ${FAILURES}


### PR DESCRIPTION
Problem:
- The first lint check that fails results in all subsequent checks not
  being run.

Solution:
- Run all the lint checks aggregating the number of failures.
- Return a non-0 exit code if any have failed.