### PR TITLE
LibProtocol/ProtocolServer/Browser/pro: Make ProtocolServer stream downloaded data when and where possible

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -123,6 +123,7 @@ public:
     static ByteBuffer create_uninitialized(size_t size) { return ByteBuffer(ByteBufferImpl::create_uninitialized(size)); }
     static ByteBuffer create_zeroed(size_t size) { return ByteBuffer(ByteBufferImpl::create_zeroed(size)); }
     static ByteBuffer copy(const void* data, size_t size) { return ByteBuffer(ByteBufferImpl::copy(data, size)); }
+    static ByteBuffer copy(ReadonlyBytes bytes) { return ByteBuffer(ByteBufferImpl::copy(bytes.data(), bytes.size())); }
 
     ~ByteBuffer() { clear(); }
     void clear() { m_impl = nullptr; }

--- a/AK/FileStream.h
+++ b/AK/FileStream.h
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Stream.h>
+#ifndef KERNEL
+#    include <AK/LogStream.h>
+#    include <errno.h>
+#    include <stdio.h>
+
+namespace AK {
+
+class InputFileStream : public InputStream {
+public:
+    explicit InputFileStream(int fd)
+        : m_file(fdopen(fd, "r"))
+        , m_owned(true)
+    {
+        if (!m_file)
+            set_fatal_error();
+    }
+
+    explicit InputFileStream(FILE* fp)
+        : m_file(fp)
+    {
+        if (!m_file)
+            set_fatal_error();
+    }
+
+    ~InputFileStream()
+    {
+        if (m_file) {
+            if (m_owned)
+                fflush(m_file);
+        }
+    }
+
+    bool unreliable_eof() const override { return eof(); }
+    bool eof() const { return feof(m_file); }
+
+    size_t read(Bytes bytes) override
+    {
+        if (has_any_error())
+            return 0;
+        return fread(bytes.data(), sizeof(u8), bytes.size(), m_file);
+    }
+
+    bool read_or_error(Bytes bytes) override
+    {
+        if (has_any_error())
+            return false;
+        auto size = read(bytes);
+        if (size < bytes.size()) {
+            set_recoverable_error();
+            return false;
+        }
+        return true;
+    }
+    bool discard_or_error(size_t count) override
+    {
+        if (fseek(m_file, count, SEEK_CUR) == 0)
+            return true;
+
+        // TODO: Why not ferror(m_file)?
+        if (errno != ESPIPE)
+            return false;
+
+        char buf[4];
+        size_t i = 0;
+        while (i < count) {
+            auto size = min(count - i, 4ul);
+            if (read({ buf, size }) < size) {
+                // Can't reset here.
+                return false;
+            }
+            i += size;
+        }
+
+        return true;
+    }
+
+    bool seek(size_t offset, int whence = SEEK_SET)
+    {
+        return fseek(m_file, offset, whence) == 0;
+    }
+
+    virtual bool handle_any_error() override
+    {
+        clearerr(m_file);
+        return Stream::handle_any_error();
+    }
+
+    void make_unbuffered()
+    {
+        setvbuf(m_file, nullptr, _IONBF, 0);
+    }
+
+private:
+    FILE* m_file { nullptr };
+    bool m_owned { false };
+};
+
+class OutputFileStream : public OutputStream {
+public:
+    explicit OutputFileStream(int fd)
+        : m_file(fdopen(fd, "w"))
+        , m_owned(true)
+    {
+        if (!m_file)
+            set_fatal_error();
+    }
+
+    explicit OutputFileStream(FILE* fp)
+        : m_file(fp)
+    {
+        if (!m_file)
+            set_fatal_error();
+    }
+
+    ~OutputFileStream()
+    {
+        if (m_file) {
+            fflush(m_file);
+            if (m_owned)
+                fclose(m_file);
+        }
+    }
+
+    size_t write(ReadonlyBytes bytes) override
+    {
+        auto nwritten = fwrite(bytes.data(), sizeof(u8), bytes.size(), m_file);
+        m_bytes_written += nwritten;
+        return nwritten;
+    }
+
+    bool write_or_error(ReadonlyBytes bytes) override
+    {
+        auto nwritten = write(bytes);
+        if (nwritten < bytes.size()) {
+            set_recoverable_error();
+            return false;
+        }
+        return true;
+    }
+
+    size_t size() const { return m_bytes_written; }
+
+    virtual bool handle_any_error() override
+    {
+        clearerr(m_file);
+        return Stream::handle_any_error();
+    }
+
+    void make_unbuffered()
+    {
+        setvbuf(m_file, nullptr, _IONBF, 0);
+    }
+
+private:
+    FILE* m_file { nullptr };
+    size_t m_bytes_written { 0 };
+    bool m_owned { false };
+};
+
+}
+
+using AK::InputFileStream;
+using AK::OutputFileStream;
+
+#endif

--- a/Applications/Browser/DownloadWidget.cpp
+++ b/Applications/Browser/DownloadWidget.cpp
@@ -29,6 +29,7 @@
 #include <AK/SharedBuffer.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/File.h>
+#include <LibCore/FileStream.h>
 #include <LibCore/StandardPaths.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/BoxLayout.h>
@@ -61,9 +62,19 @@ DownloadWidget::DownloadWidget(const URL& url)
     m_download->on_progress = [this](Optional<u32> total_size, u32 downloaded_size) {
         did_progress(total_size.value(), downloaded_size);
     };
-    m_download->on_finish = [this](bool success, auto payload, auto payload_storage, auto& response_headers, auto) {
-        did_finish(success, payload, payload_storage, response_headers);
-    };
+
+    {
+        auto file_or_error = Core::File::open(m_destination_path, Core::IODevice::WriteOnly);
+        if (file_or_error.is_error()) {
+            GUI::MessageBox::show(window(), String::formatted("Cannot open {} for writing", m_destination_path), "Download failed", GUI::MessageBox::Type::Error);
+            window()->close();
+            return;
+        }
+        m_output_file_stream = make<Core::OutputFileStream>(*file_or_error.value());
+    }
+
+    m_download->on_finish = [this](bool success, auto) { did_finish(success); };
+    m_download->stream_into(*m_output_file_stream);
 
     set_fill_with_background_color(true);
     auto& layout = set_layout<GUI::VerticalBoxLayout>();
@@ -156,7 +167,7 @@ void DownloadWidget::did_progress(Optional<u32> total_size, u32 downloaded_size)
     }
 }
 
-void DownloadWidget::did_finish(bool success, [[maybe_unused]] ReadonlyBytes payload, [[maybe_unused]] RefPtr<SharedBuffer> payload_storage, [[maybe_unused]] const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers)
+void DownloadWidget::did_finish(bool success)
 {
     dbg() << "did_finish, success=" << success;
 
@@ -173,17 +184,6 @@ void DownloadWidget::did_finish(bool success, [[maybe_unused]] ReadonlyBytes pay
         window()->close();
         return;
     }
-
-    auto file_or_error = Core::File::open(m_destination_path, Core::IODevice::WriteOnly);
-    if (file_or_error.is_error()) {
-        GUI::MessageBox::show(window(), String::formatted("Cannot open {} for writing", m_destination_path), "Download failed", GUI::MessageBox::Type::Error);
-        window()->close();
-        return;
-    }
-
-    auto& file = *file_or_error.value();
-    bool write_success = file.write(payload.data(), payload.size());
-    ASSERT(write_success);
 }
 
 }

--- a/Applications/Browser/DownloadWidget.h
+++ b/Applications/Browser/DownloadWidget.h
@@ -28,6 +28,7 @@
 
 #include <AK/URL.h>
 #include <LibCore/ElapsedTimer.h>
+#include <LibCore/FileStream.h>
 #include <LibGUI/ProgressBar.h>
 #include <LibGUI/Widget.h>
 #include <LibProtocol/Download.h>
@@ -44,7 +45,7 @@ private:
     explicit DownloadWidget(const URL&);
 
     void did_progress(Optional<u32> total_size, u32 downloaded_size);
-    void did_finish(bool success, ReadonlyBytes payload, RefPtr<SharedBuffer> payload_storage, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers);
+    void did_finish(bool success);
 
     URL m_url;
     String m_destination_path;
@@ -53,6 +54,7 @@ private:
     RefPtr<GUI::Label> m_progress_label;
     RefPtr<GUI::Button> m_cancel_button;
     RefPtr<GUI::Button> m_close_button;
+    OwnPtr<Core::OutputFileStream> m_output_file_stream;
     Core::ElapsedTimer m_elapsed_timer;
 };
 

--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (pledge("stdio shared_buffer accept unix cpath rpath wpath fattr", nullptr) < 0) {
+    if (pledge("stdio shared_buffer accept unix cpath rpath wpath fattr sendfd recvfd", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
@@ -86,7 +86,7 @@ int main(int argc, char** argv)
     Web::ResourceLoader::the();
 
     // FIXME: Once there is a standalone Download Manager, we can drop the "unix" pledge.
-    if (pledge("stdio shared_buffer accept unix cpath rpath wpath", nullptr) < 0) {
+    if (pledge("stdio shared_buffer accept unix cpath rpath wpath sendfd recvfd", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Base/etc/ca_certs.ini
+++ b/Base/etc/ca_certs.ini
@@ -1,3 +1,5 @@
+[Server CA 1B]
+country=US
 
 [PKIACCV]
 country=ES

--- a/Libraries/LibCore/NetworkJob.cpp
+++ b/Libraries/LibCore/NetworkJob.cpp
@@ -32,7 +32,8 @@
 
 namespace Core {
 
-NetworkJob::NetworkJob()
+NetworkJob::NetworkJob(OutputStream& output_stream)
+    : m_output_stream(output_stream)
 {
 }
 

--- a/Libraries/LibCore/NetworkResponse.cpp
+++ b/Libraries/LibCore/NetworkResponse.cpp
@@ -28,8 +28,7 @@
 
 namespace Core {
 
-NetworkResponse::NetworkResponse(ByteBuffer&& payload)
-    : m_payload(payload)
+NetworkResponse::NetworkResponse()
 {
 }
 

--- a/Libraries/LibCore/NetworkResponse.h
+++ b/Libraries/LibCore/NetworkResponse.h
@@ -36,13 +36,11 @@ public:
     virtual ~NetworkResponse();
 
     bool is_error() const { return m_error; }
-    const ByteBuffer& payload() const { return m_payload; }
 
 protected:
-    explicit NetworkResponse(ByteBuffer&&);
+    explicit NetworkResponse();
 
     bool m_error { false };
-    ByteBuffer m_payload;
 };
 
 }

--- a/Libraries/LibGemini/GeminiJob.cpp
+++ b/Libraries/LibGemini/GeminiJob.cpp
@@ -142,9 +142,9 @@ bool GeminiJob::eof() const
     return m_socket->eof();
 }
 
-bool GeminiJob::write(const ByteBuffer& data)
+bool GeminiJob::write(ReadonlyBytes bytes)
 {
-    return m_socket->write(data);
+    return m_socket->write(bytes);
 }
 
 }

--- a/Libraries/LibGemini/GeminiJob.h
+++ b/Libraries/LibGemini/GeminiJob.h
@@ -37,8 +37,8 @@ namespace Gemini {
 class GeminiJob final : public Job {
     C_OBJECT(GeminiJob)
 public:
-    explicit GeminiJob(const GeminiRequest& request, const Vector<Certificate>* override_certificates = nullptr)
-        : Job(request)
+    explicit GeminiJob(const GeminiRequest& request, OutputStream& output_stream, const Vector<Certificate>* override_certificates = nullptr)
+        : Job(request, output_stream)
         , m_override_ca_certificates(override_certificates)
     {
     }
@@ -61,7 +61,7 @@ protected:
     virtual bool can_read() const override;
     virtual ByteBuffer receive(size_t) override;
     virtual bool eof() const override;
-    virtual bool write(const ByteBuffer&) override;
+    virtual bool write(ReadonlyBytes) override;
     virtual bool is_established() const override { return m_socket->is_established(); }
     virtual bool should_fail_on_empty_payload() const override { return false; }
     virtual void read_while_data_available(Function<IterationDecision()>) override;

--- a/Libraries/LibGemini/GeminiResponse.cpp
+++ b/Libraries/LibGemini/GeminiResponse.cpp
@@ -28,9 +28,8 @@
 
 namespace Gemini {
 
-GeminiResponse::GeminiResponse(int status, String meta, ByteBuffer&& payload)
-    : Core::NetworkResponse(move(payload))
-    , m_status(status)
+GeminiResponse::GeminiResponse(int status, String meta)
+    : m_status(status)
     , m_meta(meta)
 {
 }

--- a/Libraries/LibGemini/GeminiResponse.h
+++ b/Libraries/LibGemini/GeminiResponse.h
@@ -34,16 +34,16 @@ namespace Gemini {
 class GeminiResponse : public Core::NetworkResponse {
 public:
     virtual ~GeminiResponse() override;
-    static NonnullRefPtr<GeminiResponse> create(int status, String meta, ByteBuffer&& payload)
+    static NonnullRefPtr<GeminiResponse> create(int status, String meta)
     {
-        return adopt(*new GeminiResponse(status, meta, move(payload)));
+        return adopt(*new GeminiResponse(status, meta));
     }
 
     int status() const { return m_status; }
     String meta() const { return m_meta; }
 
 private:
-    GeminiResponse(int status, String, ByteBuffer&&);
+    GeminiResponse(int status, String);
 
     int m_status { 0 };
     String m_meta;

--- a/Libraries/LibGemini/Job.h
+++ b/Libraries/LibGemini/Job.h
@@ -36,7 +36,7 @@ namespace Gemini {
 
 class Job : public Core::NetworkJob {
 public:
-    explicit Job(const GeminiRequest&);
+    explicit Job(const GeminiRequest&, OutputStream&);
     virtual ~Job() override;
 
     virtual void start() override = 0;
@@ -48,6 +48,7 @@ public:
 protected:
     void finish_up();
     void on_socket_connected();
+    void flush_received_buffers();
     virtual void register_on_ready_to_read(Function<void()>) = 0;
     virtual void register_on_ready_to_write(Function<void()>) = 0;
     virtual bool can_read_line() const = 0;
@@ -55,7 +56,7 @@ protected:
     virtual bool can_read() const = 0;
     virtual ByteBuffer receive(size_t) = 0;
     virtual bool eof() const = 0;
-    virtual bool write(const ByteBuffer&) = 0;
+    virtual bool write(ReadonlyBytes) = 0;
     virtual bool is_established() const = 0;
     virtual bool should_fail_on_empty_payload() const { return false; }
     virtual void read_while_data_available(Function<IterationDecision()> read) { read(); };
@@ -70,7 +71,7 @@ protected:
     State m_state { State::InStatus };
     int m_status { -1 };
     String m_meta;
-    Vector<ByteBuffer> m_received_buffers;
+    Vector<ByteBuffer, 2> m_received_buffers;
     size_t m_received_size { 0 };
     bool m_sent_data { false };
     bool m_should_have_payload { false };

--- a/Libraries/LibHTTP/HttpJob.cpp
+++ b/Libraries/LibHTTP/HttpJob.cpp
@@ -98,9 +98,9 @@ bool HttpJob::eof() const
     return m_socket->eof();
 }
 
-bool HttpJob::write(const ByteBuffer& data)
+bool HttpJob::write(ReadonlyBytes bytes)
 {
-    return m_socket->write(data);
+    return m_socket->write(bytes);
 }
 
 }

--- a/Libraries/LibHTTP/HttpJob.h
+++ b/Libraries/LibHTTP/HttpJob.h
@@ -38,8 +38,8 @@ namespace HTTP {
 class HttpJob final : public Job {
     C_OBJECT(HttpJob)
 public:
-    explicit HttpJob(const HttpRequest& request)
-        : Job(request)
+    explicit HttpJob(const HttpRequest& request, OutputStream& output_stream)
+        : Job(request, output_stream)
     {
     }
 
@@ -59,7 +59,7 @@ protected:
     virtual bool can_read() const override;
     virtual ByteBuffer receive(size_t) override;
     virtual bool eof() const override;
-    virtual bool write(const ByteBuffer&) override;
+    virtual bool write(ReadonlyBytes) override;
     virtual bool is_established() const override { return true; }
 
 private:

--- a/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Libraries/LibHTTP/HttpRequest.cpp
@@ -71,11 +71,12 @@ ByteBuffer HttpRequest::to_raw_request() const
         builder.append(header.value);
         builder.append("\r\n");
     }
-    builder.append("Connection: close\r\n\r\n");
+    builder.append("Connection: close\r\n");
     if (!m_body.is_empty()) {
+        builder.appendff("Content-Length: {}\r\n\r\n", m_body.size());
         builder.append((const char*)m_body.data(), m_body.size());
-        builder.append("\r\n");
     }
+    builder.append("\r\n");
     return builder.to_byte_buffer();
 }
 

--- a/Libraries/LibHTTP/HttpRequest.h
+++ b/Libraries/LibHTTP/HttpRequest.h
@@ -62,7 +62,8 @@ public:
     void set_method(Method method) { m_method = method; }
 
     const ByteBuffer& body() const { return m_body; }
-    void set_body(const ByteBuffer& body) { m_body = body; }
+    void set_body(ReadonlyBytes body) { m_body = ByteBuffer::copy(body); }
+    void set_body(ByteBuffer&& body) { m_body = move(body); }
 
     String method_name() const;
     ByteBuffer to_raw_request() const;

--- a/Libraries/LibHTTP/HttpResponse.cpp
+++ b/Libraries/LibHTTP/HttpResponse.cpp
@@ -28,9 +28,8 @@
 
 namespace HTTP {
 
-HttpResponse::HttpResponse(int code, HashMap<String, String, CaseInsensitiveStringTraits>&& headers, ByteBuffer&& payload)
-    : Core::NetworkResponse(move(payload))
-    , m_code(code)
+HttpResponse::HttpResponse(int code, HashMap<String, String, CaseInsensitiveStringTraits>&& headers)
+    : m_code(code)
     , m_headers(move(headers))
 {
 }

--- a/Libraries/LibHTTP/HttpResponse.h
+++ b/Libraries/LibHTTP/HttpResponse.h
@@ -35,16 +35,16 @@ namespace HTTP {
 class HttpResponse : public Core::NetworkResponse {
 public:
     virtual ~HttpResponse() override;
-    static NonnullRefPtr<HttpResponse> create(int code, HashMap<String, String, CaseInsensitiveStringTraits>&& headers, ByteBuffer&& payload)
+    static NonnullRefPtr<HttpResponse> create(int code, HashMap<String, String, CaseInsensitiveStringTraits>&& headers)
     {
-        return adopt(*new HttpResponse(code, move(headers), move(payload)));
+        return adopt(*new HttpResponse(code, move(headers)));
     }
 
     int code() const { return m_code; }
     const HashMap<String, String, CaseInsensitiveStringTraits>& headers() const { return m_headers; }
 
 private:
-    HttpResponse(int code, HashMap<String, String, CaseInsensitiveStringTraits>&&, ByteBuffer&&);
+    HttpResponse(int code, HashMap<String, String, CaseInsensitiveStringTraits>&&);
 
     int m_code { 0 };
     HashMap<String, String, CaseInsensitiveStringTraits> m_headers;

--- a/Libraries/LibHTTP/HttpsJob.cpp
+++ b/Libraries/LibHTTP/HttpsJob.cpp
@@ -143,7 +143,7 @@ bool HttpsJob::eof() const
     return m_socket->eof();
 }
 
-bool HttpsJob::write(const ByteBuffer& data)
+bool HttpsJob::write(ReadonlyBytes data)
 {
     return m_socket->write(data);
 }

--- a/Libraries/LibHTTP/HttpsJob.h
+++ b/Libraries/LibHTTP/HttpsJob.h
@@ -38,8 +38,8 @@ namespace HTTP {
 class HttpsJob final : public Job {
     C_OBJECT(HttpsJob)
 public:
-    explicit HttpsJob(const HttpRequest& request, const Vector<Certificate>* override_certs = nullptr)
-        : Job(request)
+    explicit HttpsJob(const HttpRequest& request, OutputStream& output_stream, const Vector<Certificate>* override_certs = nullptr)
+        : Job(request, output_stream)
         , m_override_ca_certificates(override_certs)
     {
     }
@@ -62,7 +62,7 @@ protected:
     virtual bool can_read() const override;
     virtual ByteBuffer receive(size_t) override;
     virtual bool eof() const override;
-    virtual bool write(const ByteBuffer&) override;
+    virtual bool write(ReadonlyBytes) override;
     virtual bool is_established() const override { return m_socket->is_established(); }
     virtual bool should_fail_on_empty_payload() const override { return false; }
     virtual void read_while_data_available(Function<IterationDecision()>) override;

--- a/Libraries/LibHTTP/Job.cpp
+++ b/Libraries/LibHTTP/Job.cpp
@@ -68,13 +68,43 @@ static ByteBuffer handle_content_encoding(const ByteBuffer& buf, const String& c
     return buf;
 }
 
-Job::Job(const HttpRequest& request)
-    : m_request(request)
+Job::Job(const HttpRequest& request, OutputStream& output_stream)
+    : Core::NetworkJob(output_stream)
+    , m_request(request)
 {
 }
 
 Job::~Job()
 {
+}
+
+void Job::flush_received_buffers()
+{
+    if (!m_can_stream_response || m_buffered_size == 0)
+        return;
+#ifdef JOB_DEBUG
+    dbg() << "Job: Flushing received buffers: have " << m_buffered_size << " bytes in " << m_received_buffers.size() << " buffers";
+#endif
+    for (size_t i = 0; i < m_received_buffers.size(); ++i) {
+        auto& payload = m_received_buffers[i];
+        auto written = do_write(payload);
+        m_buffered_size -= written;
+        if (written == payload.size()) {
+            // FIXME: Make this a take-first-friendly object?
+            m_received_buffers.take_first();
+            --i;
+            continue;
+        }
+        ASSERT(written < payload.size());
+        payload = payload.slice(written, payload.size() - written);
+#ifdef JOB_DEBUG
+        dbg() << "Job: Flushing received buffers done: have " << m_buffered_size << " bytes in " << m_received_buffers.size() << " buffers";
+#endif
+        return;
+    }
+#ifdef JOB_DEBUG
+    dbg() << "Job: Flushing received buffers done: have " << m_buffered_size << " bytes in " << m_received_buffers.size() << " buffers";
+#endif
 }
 
 void Job::on_socket_connected()
@@ -135,6 +165,8 @@ void Job::on_socket_connected()
                 if (m_state == State::Trailers) {
                     return finish_up();
                 } else {
+                    if (on_headers_received)
+                        on_headers_received(m_headers, m_code > 0 ? m_code : Optional<u32> {});
                     m_state = State::InBody;
                 }
                 return;
@@ -163,6 +195,13 @@ void Job::on_socket_connected()
             }
             auto value = line.substring(name.length() + 2, line.length() - name.length() - 2);
             m_headers.set(name, value);
+            if (name.equals_ignoring_case("Content-Encoding")) {
+                // Assume that any content-encoding means that we can't decode it as a stream :(
+#ifdef JOB_DEBUG
+                dbg() << "Content-Encoding " << value << " detected, cannot stream output :(";
+#endif
+                m_can_stream_response = false;
+            }
 #ifdef JOB_DEBUG
             dbg() << "Job: [" << name << "] = '" << value << "'";
 #endif
@@ -252,7 +291,9 @@ void Job::on_socket_connected()
             }
 
             m_received_buffers.append(payload);
+            m_buffered_size += payload.size();
             m_received_size += payload.size();
+            flush_received_buffers();
 
             if (m_current_chunk_remaining_size.has_value()) {
                 auto size = m_current_chunk_remaining_size.value() - payload.size();
@@ -313,20 +354,37 @@ void Job::on_socket_connected()
 void Job::finish_up()
 {
     m_state = State::Finished;
-    auto flattened_buffer = ByteBuffer::create_uninitialized(m_received_size);
-    u8* flat_ptr = flattened_buffer.data();
-    for (auto& received_buffer : m_received_buffers) {
-        memcpy(flat_ptr, received_buffer.data(), received_buffer.size());
-        flat_ptr += received_buffer.size();
-    }
-    m_received_buffers.clear();
+    if (!m_can_stream_response) {
+        auto flattened_buffer = ByteBuffer::create_uninitialized(m_received_size);
+        u8* flat_ptr = flattened_buffer.data();
+        for (auto& received_buffer : m_received_buffers) {
+            memcpy(flat_ptr, received_buffer.data(), received_buffer.size());
+            flat_ptr += received_buffer.size();
+        }
+        m_received_buffers.clear();
 
-    auto content_encoding = m_headers.get("Content-Encoding");
-    if (content_encoding.has_value()) {
-        flattened_buffer = handle_content_encoding(flattened_buffer, content_encoding.value());
+        // For the time being, we cannot stream stuff with content-encoding set to _anything_.
+        auto content_encoding = m_headers.get("Content-Encoding");
+        if (content_encoding.has_value()) {
+            flattened_buffer = handle_content_encoding(flattened_buffer, content_encoding.value());
+        }
+
+        m_buffered_size = flattened_buffer.size();
+        m_received_buffers.append(move(flattened_buffer));
+        m_can_stream_response = true;
     }
 
-    auto response = HttpResponse::create(m_code, move(m_headers), move(flattened_buffer));
+    flush_received_buffers();
+    if (m_buffered_size != 0) {
+        // FIXME: What do we do? ignore it?
+        //        "Transmission failed" is not strictly correct, but let's roll with it for now.
+        deferred_invoke([this](auto&) {
+            did_fail(Error::TransmissionFailed);
+        });
+        return;
+    }
+
+    auto response = HttpResponse::create(m_code, move(m_headers));
     deferred_invoke([this, response](auto&) {
         did_finish(move(response));
     });

--- a/Libraries/LibHTTP/Job.h
+++ b/Libraries/LibHTTP/Job.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/FileStream.h>
 #include <AK/HashMap.h>
 #include <AK/Optional.h>
 #include <LibCore/NetworkJob.h>
@@ -37,7 +38,7 @@ namespace HTTP {
 
 class Job : public Core::NetworkJob {
 public:
-    explicit Job(const HttpRequest&);
+    explicit Job(const HttpRequest&, OutputStream&);
     virtual ~Job() override;
 
     virtual void start() override = 0;
@@ -49,6 +50,7 @@ public:
 protected:
     void finish_up();
     void on_socket_connected();
+    void flush_received_buffers();
     virtual void register_on_ready_to_read(Function<void()>) = 0;
     virtual void register_on_ready_to_write(Function<void()>) = 0;
     virtual bool can_read_line() const = 0;
@@ -56,7 +58,7 @@ protected:
     virtual bool can_read() const = 0;
     virtual ByteBuffer receive(size_t) = 0;
     virtual bool eof() const = 0;
-    virtual bool write(const ByteBuffer&) = 0;
+    virtual bool write(ReadonlyBytes) = 0;
     virtual bool is_established() const = 0;
     virtual bool should_fail_on_empty_payload() const { return true; }
     virtual void read_while_data_available(Function<IterationDecision()> read) { read(); };
@@ -73,11 +75,13 @@ protected:
     State m_state { State::InStatus };
     int m_code { -1 };
     HashMap<String, String, CaseInsensitiveStringTraits> m_headers;
-    Vector<ByteBuffer> m_received_buffers;
+    Vector<ByteBuffer, 2> m_received_buffers;
+    size_t m_buffered_size { 0 };
     size_t m_received_size { 0 };
     bool m_sent_data { 0 };
     Optional<ssize_t> m_current_chunk_remaining_size;
     Optional<size_t> m_current_chunk_total_size;
+    bool m_can_stream_response { true };
 };
 
 }

--- a/Libraries/LibProtocol/Client.h
+++ b/Libraries/LibProtocol/Client.h
@@ -44,7 +44,8 @@ public:
     virtual void handshake() override;
 
     bool is_supported_protocol(const String&);
-    RefPtr<Download> start_download(const String& method, const String& url, const HashMap<String, String>& request_headers = {}, const ByteBuffer& request_body = {});
+    template<typename RequestHashMapTraits = Traits<String>>
+    RefPtr<Download> start_download(const String& method, const String& url, const HashMap<String, String, RequestHashMapTraits>& request_headers = {}, ReadonlyBytes request_body = {});
 
     bool stop_download(Badge<Download>, Download&);
     bool set_certificate(Badge<Download>, Download&, String, String);
@@ -55,6 +56,7 @@ private:
     virtual void handle(const Messages::ProtocolClient::DownloadProgress&) override;
     virtual void handle(const Messages::ProtocolClient::DownloadFinished&) override;
     virtual OwnPtr<Messages::ProtocolClient::CertificateRequestedResponse> handle(const Messages::ProtocolClient::CertificateRequested&) override;
+    virtual void handle(const Messages::ProtocolClient::HeadersBecameAvailable&) override;
 
     HashMap<i32, RefPtr<Download>> m_downloads;
 };

--- a/Libraries/LibProtocol/Download.h
+++ b/Libraries/LibProtocol/Download.h
@@ -28,10 +28,13 @@
 
 #include <AK/Badge.h>
 #include <AK/ByteBuffer.h>
+#include <AK/FileStream.h>
 #include <AK/Function.h>
+#include <AK/MemoryStream.h>
 #include <AK/RefCounted.h>
 #include <AK/String.h>
 #include <AK/WeakPtr.h>
+#include <LibCore/Notifier.h>
 #include <LibIPC/Forward.h>
 
 namespace Protocol {
@@ -51,20 +54,65 @@ public:
     }
 
     int id() const { return m_download_id; }
+    int fd() const { return m_fd; }
     bool stop();
 
-    Function<void(bool success, ReadonlyBytes payload, RefPtr<SharedBuffer> payload_storage, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> status_code)> on_finish;
+    void stream_into(OutputStream&);
+
+    bool should_buffer_all_input() const { return m_should_buffer_all_input; }
+    /// Note: Will override `on_finish', and `on_headers_received', and expects `on_buffered_download_finish' to be set!
+    void set_should_buffer_all_input(bool);
+
+    /// Note: Must be set before `set_should_buffer_all_input(true)`.
+    Function<void(bool success, u32 total_size, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> response_code, ReadonlyBytes payload)> on_buffered_download_finish;
+    Function<void(bool success, u32 total_size)> on_finish;
     Function<void(Optional<u32> total_size, u32 downloaded_size)> on_progress;
+    Function<void(const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> response_code)> on_headers_received;
     Function<CertificateAndKey()> on_certificate_requested;
 
-    void did_finish(Badge<Client>, bool success, Optional<u32> status_code, u32 total_size, i32 shbuf_id, const IPC::Dictionary& response_headers);
+    void did_finish(Badge<Client>, bool success, u32 total_size);
     void did_progress(Badge<Client>, Optional<u32> total_size, u32 downloaded_size);
+    void did_receive_headers(Badge<Client>, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers, Optional<u32> response_code);
     void did_request_certificates(Badge<Client>);
+
+    RefPtr<Core::Notifier>& write_notifier(Badge<Client>) { return m_write_notifier; }
+    void set_download_fd(Badge<Client>, int fd) { m_fd = fd; }
 
 private:
     explicit Download(Client&, i32 download_id);
     WeakPtr<Client> m_client;
     int m_download_id { -1 };
+    RefPtr<Core::Notifier> m_write_notifier;
+    int m_fd { -1 };
+    bool m_should_buffer_all_input { false };
+
+    struct InternalBufferedData {
+        InternalBufferedData(int fd)
+            : read_stream(fd)
+        {
+        }
+
+        InputFileStream read_stream;
+        DuplexMemoryStream payload_stream;
+        HashMap<String, String, CaseInsensitiveStringTraits> response_headers;
+        Optional<u32> response_code;
+    };
+
+    struct InternalStreamData {
+        InternalStreamData(int fd)
+            : read_stream(fd)
+        {
+        }
+
+        InputFileStream read_stream;
+        RefPtr<Core::Notifier> read_notifier;
+        bool success;
+        u32 total_size { 0 };
+        bool download_done { false };
+    };
+
+    OwnPtr<InternalBufferedData> m_internal_buffered_data;
+    OwnPtr<InternalStreamData> m_internal_stream_data;
 };
 
 }

--- a/Libraries/LibWeb/DOM/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/DOM/XMLHttpRequest.cpp
@@ -92,10 +92,10 @@ void XMLHttpRequest::send()
     // we need to make ResourceLoader give us more detailed updates than just "done" and "error".
     ResourceLoader::the().load(
         m_window->document().complete_url(m_url),
-        [weak_this = make_weak_ptr()](auto& data, auto&) {
+        [weak_this = make_weak_ptr()](auto data, auto&) {
             if (!weak_this)
                 return;
-            const_cast<XMLHttpRequest&>(*weak_this).m_response = data;
+            const_cast<XMLHttpRequest&>(*weak_this).m_response = ByteBuffer::copy(data);
             const_cast<XMLHttpRequest&>(*weak_this).set_ready_state(ReadyState::Done);
             const_cast<XMLHttpRequest&>(*weak_this).dispatch_event(DOM::Event::create(HTML::EventNames::load));
         },

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -128,7 +128,7 @@ void HTMLScriptElement::prepare_script(Badge<HTMLDocumentParser>)
         // FIXME: This load should be made asynchronous and the parser should spin an event loop etc.
         ResourceLoader::the().load_sync(
             url,
-            [this, url](auto& data, auto&) {
+            [this, url](auto data, auto&) {
                 if (data.is_null()) {
                     dbg() << "HTMLScriptElement: Failed to load " << url;
                     return;

--- a/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -171,6 +171,7 @@ bool FrameLoader::load(const LoadRequest& request, Type type)
         return true;
 
     if (url.protocol() == "http" || url.protocol() == "https") {
+#if 0
         URL favicon_url;
         favicon_url.set_protocol(url.protocol());
         favicon_url.set_host(url.host());
@@ -191,6 +192,7 @@ bool FrameLoader::load(const LoadRequest& request, Type type)
                 if (auto* page = frame().page())
                     page->client().page_did_change_favicon(*bitmap);
             });
+#endif
     }
 
     return true;

--- a/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Libraries/LibWeb/Loader/Resource.cpp
@@ -84,10 +84,10 @@ static String mime_type_from_content_type(const String& content_type)
     return content_type;
 }
 
-void Resource::did_load(Badge<ResourceLoader>, const ByteBuffer& data, const HashMap<String, String, CaseInsensitiveStringTraits>& headers)
+void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, const HashMap<String, String, CaseInsensitiveStringTraits>& headers)
 {
     ASSERT(!m_loaded);
-    m_encoded_data = data;
+    m_encoded_data = ByteBuffer::copy(data);
     m_response_headers = headers;
     m_loaded = true;
 

--- a/Libraries/LibWeb/Loader/Resource.h
+++ b/Libraries/LibWeb/Loader/Resource.h
@@ -77,7 +77,7 @@ public:
 
     void for_each_client(Function<void(ResourceClient&)>);
 
-    void did_load(Badge<ResourceLoader>, const ByteBuffer& data, const HashMap<String, String, CaseInsensitiveStringTraits>& headers);
+    void did_load(Badge<ResourceLoader>, ReadonlyBytes data, const HashMap<String, String, CaseInsensitiveStringTraits>& headers);
     void did_fail(Badge<ResourceLoader>, const String& error);
 
 protected:

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -44,9 +44,9 @@ public:
 
     RefPtr<Resource> load_resource(Resource::Type, const LoadRequest&);
 
-    void load(const LoadRequest&, Function<void(const ByteBuffer&, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers)> success_callback, Function<void(const String&)> error_callback = nullptr);
-    void load(const URL&, Function<void(const ByteBuffer&, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers)> success_callback, Function<void(const String&)> error_callback = nullptr);
-    void load_sync(const URL&, Function<void(const ByteBuffer&, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers)> success_callback, Function<void(const String&)> error_callback = nullptr);
+    void load(const LoadRequest&, Function<void(ReadonlyBytes, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers)> success_callback, Function<void(const String&)> error_callback = nullptr);
+    void load(const URL&, Function<void(ReadonlyBytes, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers)> success_callback, Function<void(const String&)> error_callback = nullptr);
+    void load_sync(const URL&, Function<void(ReadonlyBytes, const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers)> success_callback, Function<void(const String&)> error_callback = nullptr);
 
     Function<void()> on_load_counter_change;
 

--- a/Services/ProtocolServer/ClientConnection.h
+++ b/Services/ProtocolServer/ClientConnection.h
@@ -45,6 +45,7 @@ public:
 
     virtual void die() override;
 
+    void did_receive_headers(Badge<Download>, Download&);
     void did_finish_download(Badge<Download>, Download&, bool success);
     void did_progress_download(Badge<Download>, Download&);
     void did_request_certificates(Badge<Download>, Download&);
@@ -54,11 +55,9 @@ private:
     virtual OwnPtr<Messages::ProtocolServer::IsSupportedProtocolResponse> handle(const Messages::ProtocolServer::IsSupportedProtocol&) override;
     virtual OwnPtr<Messages::ProtocolServer::StartDownloadResponse> handle(const Messages::ProtocolServer::StartDownload&) override;
     virtual OwnPtr<Messages::ProtocolServer::StopDownloadResponse> handle(const Messages::ProtocolServer::StopDownload&) override;
-    virtual OwnPtr<Messages::ProtocolServer::DisownSharedBufferResponse> handle(const Messages::ProtocolServer::DisownSharedBuffer&) override;
-    virtual OwnPtr<Messages::ProtocolServer::SetCertificateResponse> handle(const Messages::ProtocolServer::SetCertificate&);
+    virtual OwnPtr<Messages::ProtocolServer::SetCertificateResponse> handle(const Messages::ProtocolServer::SetCertificate&) override;
 
     HashMap<i32, OwnPtr<Download>> m_downloads;
-    HashMap<i32, RefPtr<AK::SharedBuffer>> m_shared_buffers;
 };
 
 }

--- a/Services/ProtocolServer/Download.cpp
+++ b/Services/ProtocolServer/Download.cpp
@@ -33,9 +33,10 @@ namespace ProtocolServer {
 // FIXME: What about rollover?
 static i32 s_next_id = 1;
 
-Download::Download(ClientConnection& client)
+Download::Download(ClientConnection& client, NonnullOwnPtr<OutputFileStream>&& output_stream)
     : m_client(client)
     , m_id(s_next_id++)
+    , m_output_stream(move(output_stream))
 {
 }
 
@@ -48,15 +49,10 @@ void Download::stop()
     m_client.did_finish_download({}, *this, false);
 }
 
-void Download::set_payload(const ByteBuffer& payload)
-{
-    m_payload = payload;
-    m_total_size = payload.size();
-}
-
 void Download::set_response_headers(const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers)
 {
     m_response_headers = response_headers;
+    m_client.did_receive_headers({}, *this);
 }
 
 void Download::set_certificate(String, String)

--- a/Services/ProtocolServer/GeminiDownload.h
+++ b/Services/ProtocolServer/GeminiDownload.h
@@ -36,10 +36,10 @@ namespace ProtocolServer {
 class GeminiDownload final : public Download {
 public:
     virtual ~GeminiDownload() override;
-    static NonnullOwnPtr<GeminiDownload> create_with_job(Badge<GeminiProtocol>, ClientConnection&, NonnullRefPtr<Gemini::GeminiJob>);
+    static NonnullOwnPtr<GeminiDownload> create_with_job(Badge<GeminiProtocol>, ClientConnection&, NonnullRefPtr<Gemini::GeminiJob>, NonnullOwnPtr<OutputFileStream>&&);
 
 private:
-    explicit GeminiDownload(ClientConnection&, NonnullRefPtr<Gemini::GeminiJob>);
+    explicit GeminiDownload(ClientConnection&, NonnullRefPtr<Gemini::GeminiJob>, NonnullOwnPtr<OutputFileStream>&&);
 
     virtual void set_certificate(String certificate, String key) override;
 

--- a/Services/ProtocolServer/GeminiProtocol.h
+++ b/Services/ProtocolServer/GeminiProtocol.h
@@ -35,7 +35,7 @@ public:
     GeminiProtocol();
     virtual ~GeminiProtocol() override;
 
-    virtual OwnPtr<Download> start_download(ClientConnection&, const String& method, const URL&, const HashMap<String, String>&, const ByteBuffer& request_body) override;
+    virtual OwnPtr<Download> start_download(ClientConnection&, const String& method, const URL&, const HashMap<String, String>&, ReadonlyBytes body) override;
 };
 
 }

--- a/Services/ProtocolServer/HttpDownload.h
+++ b/Services/ProtocolServer/HttpDownload.h
@@ -36,10 +36,10 @@ namespace ProtocolServer {
 class HttpDownload final : public Download {
 public:
     virtual ~HttpDownload() override;
-    static NonnullOwnPtr<HttpDownload> create_with_job(Badge<HttpProtocol>, ClientConnection&, NonnullRefPtr<HTTP::HttpJob>);
+    static NonnullOwnPtr<HttpDownload> create_with_job(Badge<HttpProtocol>, ClientConnection&, NonnullRefPtr<HTTP::HttpJob>, NonnullOwnPtr<OutputFileStream>&&);
 
 private:
-    explicit HttpDownload(ClientConnection&, NonnullRefPtr<HTTP::HttpJob>);
+    explicit HttpDownload(ClientConnection&, NonnullRefPtr<HTTP::HttpJob>, NonnullOwnPtr<OutputFileStream>&&);
 
     NonnullRefPtr<HTTP::HttpJob> m_job;
 };

--- a/Services/ProtocolServer/HttpProtocol.h
+++ b/Services/ProtocolServer/HttpProtocol.h
@@ -35,7 +35,7 @@ public:
     HttpProtocol();
     virtual ~HttpProtocol() override;
 
-    virtual OwnPtr<Download> start_download(ClientConnection&, const String& method, const URL&, const HashMap<String, String>& headers, const ByteBuffer& request_body) override;
+    virtual OwnPtr<Download> start_download(ClientConnection&, const String& method, const URL&, const HashMap<String, String>& headers, ReadonlyBytes body) override;
 };
 
 }

--- a/Services/ProtocolServer/HttpsDownload.h
+++ b/Services/ProtocolServer/HttpsDownload.h
@@ -36,10 +36,10 @@ namespace ProtocolServer {
 class HttpsDownload final : public Download {
 public:
     virtual ~HttpsDownload() override;
-    static NonnullOwnPtr<HttpsDownload> create_with_job(Badge<HttpsProtocol>, ClientConnection&, NonnullRefPtr<HTTP::HttpsJob>);
+    static NonnullOwnPtr<HttpsDownload> create_with_job(Badge<HttpsProtocol>, ClientConnection&, NonnullRefPtr<HTTP::HttpsJob>, NonnullOwnPtr<OutputFileStream>&&);
 
 private:
-    explicit HttpsDownload(ClientConnection&, NonnullRefPtr<HTTP::HttpsJob>);
+    explicit HttpsDownload(ClientConnection&, NonnullRefPtr<HTTP::HttpsJob>, NonnullOwnPtr<OutputFileStream>&&);
 
     virtual void set_certificate(String certificate, String key) override;
 

--- a/Services/ProtocolServer/HttpsProtocol.cpp
+++ b/Services/ProtocolServer/HttpsProtocol.cpp
@@ -40,7 +40,7 @@ HttpsProtocol::~HttpsProtocol()
 {
 }
 
-OwnPtr<Download> HttpsProtocol::start_download(ClientConnection& client, const String& method, const URL& url, const HashMap<String, String>& headers, const ByteBuffer& request_body)
+OwnPtr<Download> HttpsProtocol::start_download(ClientConnection& client, const String& method, const URL& url, const HashMap<String, String>& headers, ReadonlyBytes body)
 {
     HTTP::HttpRequest request;
     if (method.equals_ignoring_case("post"))
@@ -49,9 +49,19 @@ OwnPtr<Download> HttpsProtocol::start_download(ClientConnection& client, const S
         request.set_method(HTTP::HttpRequest::Method::GET);
     request.set_url(url);
     request.set_headers(headers);
-    request.set_body(request_body);
-    auto job = HTTP::HttpsJob::construct(request);
-    auto download = HttpsDownload::create_with_job({}, client, (HTTP::HttpsJob&)*job);
+    request.set_body(body);
+
+    int fd_pair[2] { 0 };
+    if (pipe(fd_pair) != 0) {
+        auto saved_errno = errno;
+        dbgln("Protocol: pipe() failed: {}", strerror(saved_errno));
+        return nullptr;
+    }
+    auto output_stream = make<OutputFileStream>(fd_pair[1]);
+    output_stream->make_unbuffered();
+    auto job = HTTP::HttpsJob::construct(request, *output_stream);
+    auto download = HttpsDownload::create_with_job({}, client, (HTTP::HttpsJob&)*job, move(output_stream));
+    download->set_download_fd(fd_pair[0]);
     job->start();
     return download;
 }

--- a/Services/ProtocolServer/HttpsProtocol.h
+++ b/Services/ProtocolServer/HttpsProtocol.h
@@ -35,7 +35,7 @@ public:
     HttpsProtocol();
     virtual ~HttpsProtocol() override;
 
-    virtual OwnPtr<Download> start_download(ClientConnection&, const String& method, const URL&, const HashMap<String, String>& headers, const ByteBuffer& request_body) override;
+    virtual OwnPtr<Download> start_download(ClientConnection&, const String& method, const URL&, const HashMap<String, String>& headers, ReadonlyBytes body) override;
 };
 
 }

--- a/Services/ProtocolServer/Protocol.h
+++ b/Services/ProtocolServer/Protocol.h
@@ -37,7 +37,7 @@ public:
     virtual ~Protocol();
 
     const String& name() const { return m_name; }
-    virtual OwnPtr<Download> start_download(ClientConnection&, const String& method, const URL&, const HashMap<String, String>& headers, const ByteBuffer& request_body) = 0;
+    virtual OwnPtr<Download> start_download(ClientConnection&, const String& method, const URL&, const HashMap<String, String>& headers, ReadonlyBytes body) = 0;
 
     static Protocol* find_by_name(const String&);
 

--- a/Services/ProtocolServer/ProtocolClient.ipc
+++ b/Services/ProtocolServer/ProtocolClient.ipc
@@ -2,7 +2,8 @@ endpoint ProtocolClient = 13
 {
     // Download notifications
     DownloadProgress(i32 download_id, Optional<u32> total_size, u32 downloaded_size) =|
-    DownloadFinished(i32 download_id, bool success, Optional<u32> status_code, u32 total_size, i32 shbuf_id, IPC::Dictionary response_headers) =|
+    DownloadFinished(i32 download_id, bool success, u32 total_size) =|
+    HeadersBecameAvailable(i32 download_id, IPC::Dictionary response_headers, Optional<u32> status_code) =|
 
     // Certificate requests
     CertificateRequested(i32 download_id) => ()

--- a/Services/ProtocolServer/ProtocolServer.ipc
+++ b/Services/ProtocolServer/ProtocolServer.ipc
@@ -3,14 +3,11 @@ endpoint ProtocolServer = 9
     // Basic protocol
     Greet() => (i32 client_id)
 
-    // FIXME: It would be nice if the kernel provided a way to avoid this
-    DisownSharedBuffer(i32 shbuf_id) => ()
-
     // Test if a specific protocol is supported, e.g "http"
     IsSupportedProtocol(String protocol) => (bool supported)
 
     // Download API
-    StartDownload(String method, URL url, IPC::Dictionary request_headers, String request_body) => (i32 download_id)
+    StartDownload(String method, URL url, IPC::Dictionary request_headers, ByteBuffer request_body) => (i32 download_id, IPC::File response_fd)
     StopDownload(i32 download_id) => (bool success)
     SetCertificate(i32 download_id, String certificate, String key) => (bool success)
 }

--- a/Services/ProtocolServer/main.cpp
+++ b/Services/ProtocolServer/main.cpp
@@ -35,7 +35,7 @@
 
 int main(int, char**)
 {
-    if (pledge("stdio inet shared_buffer accept unix rpath cpath fattr", nullptr) < 0) {
+    if (pledge("stdio inet shared_buffer accept unix rpath cpath fattr sendfd recvfd", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
@@ -45,7 +45,7 @@ int main(int, char**)
 
     Core::EventLoop event_loop;
     // FIXME: Establish a connection to LookupServer and then drop "unix"?
-    if (pledge("stdio inet shared_buffer accept unix", nullptr) < 0) {
+    if (pledge("stdio inet shared_buffer accept unix sendfd recvfd", nullptr) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
What:
- Currently, ProtocolServer buffers the downloaded data until the download is finished, and then passes it along (by copying it into a shared buffer no less!) to its user
- In a good deal of situations, this is wasteful, and in some other situations, it makes no sense (e.g. when downloading a huge file to disk via `DownloadWidget` or `pro`)
- This PR makes ProtocolServer shove data down a pipe, and its user read it from the pipe (as the download is progressing) - if possible

Why:
- pipe `pro`'s output to `/dev/null` and laugh like a maniac
- Actually download huge files
- Open up the path for people that want to have fun with streaming downloads
- Make the API better in general
- Copy less stuff!

When:
- After some cleanups and some more extensive tests :)

cc @bugaevc @awesomekling and maybe @deoxxa (you asked to see the resulting API - this is most likely what it looks like)