### PR TITLE
LibC: Further stub out tcflow()

### DIFF
--- a/Libraries/LibC/termios.cpp
+++ b/Libraries/LibC/termios.cpp
@@ -53,7 +53,8 @@ int tcsetattr(int fd, int optional_actions, const struct termios* t)
 
 int tcflow([[maybe_unused]] int fd, [[maybe_unused]] int action)
 {
-    ASSERT_NOT_REACHED();
+    errno = EINVAL;
+    return -1;
 }
 
 int tcflush(int fd, int queue_selector)


### PR DESCRIPTION
If I'm reading [POSIX](https://pubs.opengroup.org/onlinepubs/009696799/functions/tcflow.html) right, we can set errno to EINVAL and return -1 if the action is not supported. In theory that means if we don't support any action, we can do so, instead of crashing. This also fixes bash crashing whenever you press ^C.