### PR TITLE
FileManager: Fix missing launch action icons

### DIFF
--- a/Applications/FileManager/DirectoryView.cpp
+++ b/Applications/FileManager/DirectoryView.cpp
@@ -31,6 +31,7 @@
 #include <AK/StringBuilder.h>
 #include <LibCore/MimeData.h>
 #include <LibCore/StandardPaths.h>
+#include <LibGUI/FileIconProvider.h>
 #include <LibGUI/InputBox.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/MessageBox.h>
@@ -45,10 +46,7 @@ namespace FileManager {
 
 NonnullRefPtr<GUI::Action> LauncherHandler::create_launch_action(Function<void(const LauncherHandler&)> launch_handler)
 {
-    RefPtr<Gfx::Bitmap> icon;
-    auto icon_file = details().icons.get("16x16");
-    if (icon_file.has_value())
-        icon = Gfx::Bitmap::load_from_file(icon_file.value());
+    auto icon = GUI::FileIconProvider::icon_for_path(details().executable).bitmap_for_size(16);
     return GUI::Action::create(details().name, move(icon), [this, launch_handler = move(launch_handler)](auto&) {
         launch_handler(*this);
     });

--- a/Libraries/LibDesktop/Launcher.cpp
+++ b/Libraries/LibDesktop/Launcher.cpp
@@ -51,11 +51,6 @@ auto Launcher::Details::from_details_str(const String& details_str) -> NonnullRe
         else if (type_str == "userdefault")
             details->launcher_type = LauncherType::UserDefault;
     }
-    if (auto icons_value = obj.get_ptr("icons")) {
-        icons_value->as_object().for_each_member([&](auto& name, auto& value) {
-            details->icons.set(name, value.to_string());
-        });
-    }
     return details;
 }
 

--- a/Libraries/LibDesktop/Launcher.h
+++ b/Libraries/LibDesktop/Launcher.h
@@ -44,10 +44,8 @@ public:
     };
 
     struct Details : public RefCounted<Details> {
-
         String name;
         String executable;
-        HashMap<String, String> icons;
         LauncherType launcher_type { LauncherType::Default };
 
         static NonnullRefPtr<Details> from_details_str(const String&);

--- a/Services/LaunchServer/Launcher.cpp
+++ b/Services/LaunchServer/Launcher.cpp
@@ -79,12 +79,6 @@ String Handler::to_details_str() const
     default:
         break;
     }
-    if (!icons.is_empty()) {
-        JsonObject icons_obj;
-        for (auto& icon : icons)
-            icons_obj.set(icon.key, icon.value);
-        obj.add("icons", move(icons_obj));
-    }
     obj.finish();
     return builder.build();
 }
@@ -116,14 +110,6 @@ void Launcher::load_handlers(const String& af_dir)
 
         return table;
     };
-    auto load_hashmap = [](auto& af, auto& group) {
-        HashMap<String, String> map;
-        auto keys = af->keys(group);
-        for (auto& key : keys)
-            map.set(key, af->read_entry(group, key));
-
-        return map;
-    };
 
     Core::DirIterator dt(af_dir, Core::DirIterator::SkipDots);
     while (dt.has_next()) {
@@ -136,8 +122,7 @@ void Launcher::load_handlers(const String& af_dir)
         auto app_executable = af->read_entry("App", "Executable");
         auto file_types = load_hashtable(af, "FileTypes");
         auto protocols = load_hashtable(af, "Protocols");
-        auto icons = load_hashmap(af, "Icons");
-        m_handlers.set(app_executable, { Handler::Type::Default, move(app_name), app_executable, move(file_types), move(protocols), move(icons) });
+        m_handlers.set(app_executable, { Handler::Type::Default, move(app_name), app_executable, move(file_types), move(protocols) });
     }
 }
 

--- a/Services/LaunchServer/Launcher.h
+++ b/Services/LaunchServer/Launcher.h
@@ -45,7 +45,6 @@ struct Handler {
     String executable;
     HashTable<String> file_types {};
     HashTable<String> protocols {};
-    HashMap<String, String> icons {};
 
     static String name_from_executable(const StringView&);
     void from_executable(Type, const String&);


### PR DESCRIPTION
I missed this when updating everything to use `GUI::FileIconProvider` rather than loading icons from `.af` files, it broke as a result as none of them have icon info anymore. :^)

e.g. the Browser icon here:

![image](https://user-images.githubusercontent.com/19366641/103142994-dc3c0500-470d-11eb-936e-005a438d0c0f.png)

Also remove empty & unused `icons` from `Desktop::Launcher::Details` and `LaunchServer::Handler`.