### PR TITLE
Kernel: Allow 'elevating' unveil permissions if implicitly inherited from '/'

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -640,7 +640,7 @@ private:
     u32 m_execpromises { 0 };
 
     VeilState m_veil_state { VeilState::None };
-    UnveilNode m_unveiled_paths { "/", { "/" } };
+    UnveilNode m_unveiled_paths { "/", { .full_path = "/", .unveil_inherited_from_root = true } };
 
     WaitQueue& futex_queue(Userspace<const i32*>);
     HashMap<u32, OwnPtr<WaitQueue>> m_futex_queues;

--- a/Kernel/UnveilNode.h
+++ b/Kernel/UnveilNode.h
@@ -41,15 +41,19 @@ enum UnveilAccess {
     None = 0,
 };
 
+struct UnveilNode;
+
 struct UnveilMetadata {
     String full_path;
     UnveilAccess permissions { None };
     bool explicitly_unveiled { false };
+    bool unveil_inherited_from_root { false }; // true if permissions are inherited from the tree root (/).
 };
 
 struct UnveilNode final : public AK::Trie<String, UnveilMetadata, Traits<String>, UnveilNode> {
     using AK::Trie<String, UnveilMetadata, Traits<String>, UnveilNode>::Trie;
 
+    bool permissions_inherited_from_root() const { return this->metadata_value().unveil_inherited_from_root; }
     bool was_explicitly_unveiled() const { return this->metadata_value().explicitly_unveiled; }
     UnveilAccess permissions() const { return this->metadata_value().permissions; }
     const String& path() const { return this->metadata_value().full_path; }


### PR DESCRIPTION
Makes `Chess` work.

This can happen when an unveil follows another with a path that is a
sub-path of the other one:
```c++
unveil("/home/anon/.config/whoa.ini", "rw");
unveil("/home/anon", "r"); // this would fail, as "/home/anon" inherits
                           // the permissions of "/", which is None.
```