### PR TITLE
CMake: Generate SONAME attribute for shared objects (& fix nesalizer port)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,6 @@ foreach(lang ASM C CXX OBJC OBJCXX)
     unset(CMAKE_SHARED_MODULE_LOADER_${lang}_FLAG )
     unset(CMAKE_${lang}_OSX_DEPLOYMENT_TARGET_FLAG)
     unset(CMAKE_${lang}_SYSROOT_FLAG)
-    unset(CMAKE_SHARED_LIBRARY_SONAME_${lang}_FLAG)
 endforeach()
 
 set(CMAKE_INSTALL_NAME_TOOL "true")


### PR DESCRIPTION
The generation of SONAME was disabled in a1e1aa96fb, apparently in order to allow building with Cmake on macOS.
Can someone who builds on macOS test if the change made in this commit actually breaks the macOS build?