### PR TITLE
Kernel: Take into account the time keeper's frequency (if no HPET)

### DIFF
--- a/Kernel/Time/HardwareTimer.h
+++ b/Kernel/Time/HardwareTimer.h
@@ -58,6 +58,7 @@ public:
     virtual void set_periodic() = 0;
     virtual void set_non_periodic() = 0;
     virtual void disable() = 0;
+    virtual u32 frequency() const = 0;
 
     virtual size_t ticks_per_second() const = 0;
 
@@ -87,6 +88,8 @@ public:
         enable_irq();
         return previous_callback;
     }
+
+    virtual u32 frequency() const override { return (u32)m_frequency; }
 
 protected:
     HardwareTimer(u8 irq_number, Function<void(const RegisterState&)> callback = nullptr)
@@ -130,6 +133,8 @@ public:
     virtual HandlerType type() const override { return HandlerType::IRQHandler; }
     virtual const char* controller() const override { return nullptr; }
     virtual bool eoi() override;
+
+    virtual u32 frequency() const override { return (u32)m_frequency; }
 
 protected:
     HardwareTimer(u8 irq_number, Function<void(const RegisterState&)> callback = nullptr)

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -366,9 +366,8 @@ void TimeManagement::increment_time_since_boot()
     // Compute time adjustment for adjtime. Let the clock run up to 1% fast or slow.
     // That way, adjtime can adjust up to 36 seconds per hour, without time getting very jumpy.
     // Once we have a smarter NTP service that also adjusts the frequency instead of just slewing time, maybe we can lower this.
-    constexpr long NanosPerTick = 1'000'000; // FIXME: Don't assume that one tick is 1 ms.
-    constexpr time_t MaxSlewNanos = NanosPerTick / 100;
-    static_assert(MaxSlewNanos < NanosPerTick);
+    long NanosPerTick = 1'000'000'000 / m_time_keeper_timer->frequency();
+    time_t MaxSlewNanos = NanosPerTick / 100;
 
     u32 update_iteration = m_update1.fetch_add(1, AK::MemoryOrder::memory_order_acquire);
 


### PR DESCRIPTION
The PIT is now also running at a rate of ~250 ticks/second, so rather
than assuming there are 1000 ticks/second we need to query the timer
being used for the actual frequency.

Fixes #4508