### PR TITLE
AK: Use direct-list-initialization for Vector::empend()

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -398,7 +398,7 @@ public:
     void empend(Args&&... args)
     {
         grow_capacity(m_size + 1);
-        new (slot(m_size)) T(forward<Args>(args)...);
+        new (slot(m_size)) T { forward<Args>(args)... };
         ++m_size;
     }
 

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -1433,8 +1433,8 @@ KResult Ext2FS::create_directory(InodeIdentifier parent_id, const String& name, 
 #endif
 
     Vector<Ext2FSDirectoryEntry> entries;
-    entries.empend(".", inode->identifier(), EXT2_FT_DIR);
-    entries.empend("..", parent_id, EXT2_FT_DIR);
+    entries.empend(".", inode->identifier(), static_cast<u8>(EXT2_FT_DIR));
+    entries.empend("..", parent_id, static_cast<u8>(EXT2_FT_DIR));
 
     bool success = static_cast<Ext2FSInode&>(*inode).write_directory(entries);
     ASSERT(success);

--- a/Libraries/LibRegex/RegexByteCode.h
+++ b/Libraries/LibRegex/RegexByteCode.h
@@ -191,7 +191,7 @@ public:
         ByteCode bytecode;
 
         bytecode.empend(static_cast<ByteCodeValueType>(OpCodeId::Compare));
-        bytecode.empend(1); // number of arguments
+        bytecode.empend(static_cast<u64>(1)); // number of arguments
 
         ByteCode arguments;
 
@@ -209,7 +209,7 @@ public:
         ByteCode bytecode;
 
         bytecode.empend(static_cast<ByteCodeValueType>(OpCodeId::Compare));
-        bytecode.empend(1); // number of arguments
+        bytecode.empend(static_cast<u64>(1)); // number of arguments
 
         ByteCode arguments;
 

--- a/Services/LookupServer/DNSRequest.cpp
+++ b/Services/LookupServer/DNSRequest.cpp
@@ -32,7 +32,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 
-#define C_IN 1
+const u16 C_IN = 1;
 
 DNSRequest::DNSRequest()
     : m_id(arc4random_uniform(UINT16_MAX))


### PR DESCRIPTION
clang trunk with -std=c++20 doesn't seem to properly look for an
aggregate initializer here when the type being constructed is a simple
aggregate (e.g. `struct Thing { int a; int b; };`). This template fails
to compile in a usage added 12/16/2020 in `AK/Trie.h`.

Both forms of initialization are supposed to call the
aggregate-initializers but direct-list-initialization delegating to
aggregate initializers is a new addition in c++20 that might not be
implemented yet.

The other changes are type narrowing issues brought to light by
switching to brace init. All these usages are templates which resolve
their templated arguments to `int` given integer literal inputs and
not the proper types for the type they are constructing. 