### PR TITLE
Meta: Remove catchall lines in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 *
-!*.*
-!*/
 !Makefile
 !LICENSE
 !Base/**


### PR DESCRIPTION
These two lines caused this local .gitignore to supersede all inputs
in any files specified by a user's `core.excludesFile` configuration
since the first match was going to be `!*.*` for any file with a
decimal or any directory. `git check-ignore -v somefile` can be used to
test this.