### PR TITLE
LibC: Add fseeko/ftello

### DIFF
--- a/Libraries/LibC/stdio.cpp
+++ b/Libraries/LibC/stdio.cpp
@@ -71,8 +71,8 @@ public:
     bool gets(u8*, size_t);
     bool ungetc(u8 byte) { return m_buffer.enqueue_front(byte); }
 
-    int seek(long offset, int whence);
-    long tell();
+    int seek(off_t offset, int whence);
+    off_t tell();
 
     pid_t popen_child() { return m_popen_child; }
     void set_popen_child(pid_t child_pid) { m_popen_child = child_pid; }
@@ -392,7 +392,7 @@ bool FILE::gets(u8* data, size_t size)
     return total_read > 0;
 }
 
-int FILE::seek(long offset, int whence)
+int FILE::seek(off_t offset, int whence)
 {
     bool ok = flush();
     if (!ok)
@@ -408,7 +408,7 @@ int FILE::seek(long offset, int whence)
     return 0;
 }
 
-long FILE::tell()
+off_t FILE::tell()
 {
     bool ok = flush();
     if (!ok)
@@ -795,7 +795,19 @@ int fseek(FILE* stream, long offset, int whence)
     return stream->seek(offset, whence);
 }
 
+int fseeko(FILE* stream, off_t offset, int whence)
+{
+    ASSERT(stream);
+    return stream->seek(offset, whence);
+}
+
 long ftell(FILE* stream)
+{
+    ASSERT(stream);
+    return stream->tell();
+}
+
+off_t ftello(FILE* stream)
 {
     ASSERT(stream);
     return stream->tell();
@@ -806,7 +818,7 @@ int fgetpos(FILE* stream, fpos_t* pos)
     ASSERT(stream);
     ASSERT(pos);
 
-    long val = stream->tell();
+    off_t val = stream->tell();
     if (val == -1L)
         return 1;
 
@@ -819,7 +831,7 @@ int fsetpos(FILE* stream, const fpos_t* pos)
     ASSERT(stream);
     ASSERT(pos);
 
-    return stream->seek((long)*pos, SEEK_SET);
+    return stream->seek(*pos, SEEK_SET);
 }
 
 void rewind(FILE* stream)

--- a/Libraries/LibC/stdio.h
+++ b/Libraries/LibC/stdio.h
@@ -55,12 +55,14 @@ extern FILE* stdin;
 extern FILE* stdout;
 extern FILE* stderr;
 
-typedef long fpos_t;
+typedef off_t fpos_t;
 
 int fseek(FILE*, long offset, int whence);
+int fseeko(FILE*, off_t offset, int whence);
 int fgetpos(FILE*, fpos_t*);
 int fsetpos(FILE*, const fpos_t*);
 long ftell(FILE*);
+off_t ftello(FILE*);
 char* fgets(char* buffer, int size, FILE*);
 int fputc(int ch, FILE*);
 int fileno(FILE*);


### PR DESCRIPTION
This changes the signatures for FILE::seek and FILE::tell, to use
`off_t` as they use lseek internally. `fpos_t` is also redefined to use
`off_t`.

Dr. POSIX says that fpos_t is:

> A non-array type containing all information needed to specify uniquely
> every position within a file.

In practice, most *NIX typedef it to `off_t`, or a struct containing an
`off_t` and some internal state.

Addresses 1/2 of #853.