### PR TITLE
HexEditor: Make single-character selection display the correct start/end 

### DIFF
--- a/Applications/HexEditor/HexEditor.cpp
+++ b/Applications/HexEditor/HexEditor.cpp
@@ -217,7 +217,7 @@ void HexEditor::mousedown_event(GUI::MouseEvent& event)
         auto byte_y = (absolute_y - hex_start_y) / line_height();
         auto offset = (byte_y * m_bytes_per_row) + byte_x;
 
-        if (offset < 0 || offset > static_cast<int>(m_buffer.size()))
+        if (offset < 0 || offset >= static_cast<int>(m_buffer.size()))
             return;
 
 #ifdef HEX_DEBUG
@@ -239,7 +239,7 @@ void HexEditor::mousedown_event(GUI::MouseEvent& event)
         auto byte_y = (absolute_y - text_start_y) / line_height();
         auto offset = (byte_y * m_bytes_per_row) + byte_x;
 
-        if (offset < 0 || offset > static_cast<int>(m_buffer.size()))
+        if (offset < 0 || offset >= static_cast<int>(m_buffer.size()))
             return;
 
 #ifdef HEX_DEBUG

--- a/Applications/HexEditor/HexEditor.cpp
+++ b/Applications/HexEditor/HexEditor.cpp
@@ -229,7 +229,7 @@ void HexEditor::mousedown_event(GUI::MouseEvent& event)
         m_position = offset;
         m_in_drag_select = true;
         m_selection_start = offset;
-        m_selection_end = -1;
+        m_selection_end = offset;
         update();
         update_status();
     }
@@ -250,7 +250,7 @@ void HexEditor::mousedown_event(GUI::MouseEvent& event)
         m_byte_position = 0;
         m_in_drag_select = true;
         m_selection_start = offset;
-        m_selection_end = -1;
+        m_selection_end = offset;
         m_edit_mode = EditMode::Text;
         update();
         update_status();
@@ -314,10 +314,7 @@ void HexEditor::mouseup_event(GUI::MouseEvent& event)
 {
     if (event.button() == GUI::MouseButton::Left) {
         if (m_in_drag_select) {
-            if (m_selection_end == -1 || m_selection_start == -1) {
-                m_selection_start = -1;
-                m_selection_end = -1;
-            } else if (m_selection_end < m_selection_start) {
+            if (m_selection_end < m_selection_start) {
                 // lets flip these around
                 auto start = m_selection_end;
                 m_selection_end = m_selection_start;

--- a/Applications/HexEditor/HexEditor.h
+++ b/Applications/HexEditor/HexEditor.h
@@ -82,8 +82,8 @@ private:
     int m_bytes_per_row { 16 };
     ByteBuffer m_buffer;
     bool m_in_drag_select { false };
-    int m_selection_start { -1 };
-    int m_selection_end { -1 };
+    int m_selection_start { 0 };
+    int m_selection_end { 0 };
     HashMap<int, u8> m_tracked_changes;
     int m_position { 0 };
     int m_byte_position { 0 }; // 0 or 1


### PR DESCRIPTION
Previously, when you clicked a single character, the `Selection Start` and `Selection End` showed values -1 / -1. This PR makes it so the actual cell number is displayed in both values.

This PR also disables selecting the (non-existing) cell after the last one,  and select the first cell on startup.

Fixes #3555 