### PR TITLE
Enforce prettier formatting for JavaScript files

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,13 +27,15 @@ jobs:
       # These packages are already part of the ubuntu-20.04 image:
       # clang-format-10 cmake gcc-10 g++-10 shellcheck libgmp-dev
       # These aren't:
-      run: sudo apt-get install libstdc++-10-dev libmpfr-dev libmpc-dev ninja-build
+      run: sudo apt-get install libstdc++-10-dev libmpfr-dev libmpc-dev ninja-build npm
       # If we ever do any qemu-emulation on Github Actions, we should re-enable this:
       # e2fsprogs qemu-system-i386 qemu-utils
+    - name: Install prettier
+      run: sudo npm install -g prettier
     - name: Use GCC 10 instead
       run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
     - name: Check versions
-      run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-10 --version; python --version; python3 --version; ninja --version
+      run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-10 --version; prettier --version; python --version; python3 --version; ninja --version
 
     # === PREPARE FOR BUILDING ===
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,4 +5,3 @@ repos:
         name: Running Meta/lint-ci.sh to ensure changes will pass linting on CI
         entry: bash Meta/lint-ci.sh
         language: system
-        pass_filenames: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+Base/home/anon/Source/js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,0 @@
-classes/class-expressions.js
-functions/function-strict-mode.js
-new-expression.js

--- a/Base/res/html/misc/welcome.js
+++ b/Base/res/html/misc/welcome.js
@@ -1,3 +1,3 @@
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener("DOMContentLoaded", function () {
     document.getElementById("ua").innerHTML = navigator.userAgent;
 });

--- a/Libraries/LibJS/Tests/arguments-object.js
+++ b/Libraries/LibJS/Tests/arguments-object.js
@@ -13,4 +13,3 @@ test("basic arguments object", () => {
     expect(bar("hello", "friends", ":^)")).toBe("friends");
     expect(bar("hello")).toBe(undefined);
 });
-

--- a/Libraries/LibJS/Tests/builtins/Array/Array.from.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.from.js
@@ -50,8 +50,9 @@ describe("normal behavior", () => {
                     let value = begin - 1;
                     return {
                         next() {
-                            if (value < end)
+                            if (value < end) {
                                 value += 1;
+                            }
                             return { value: value, done: value >= end };
                         },
                     };

--- a/Libraries/LibJS/Tests/builtins/Date/Date.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.js
@@ -37,7 +37,7 @@ test("tuple constructor", () => {
     expect(new Date(2019, 11).getMilliseconds()).toBe(0);
     expect(new Date(2019, 11).getDay()).toBe(0);
 
-    let date = new Date(2019, 11, 15,  9, 16, 14, 123); // Note: Month is 0-based.
+    let date = new Date(2019, 11, 15, 9, 16, 14, 123); // Note: Month is 0-based.
     expect(date.getFullYear()).toBe(2019);
     expect(date.getMonth()).toBe(11);
     expect(date.getDate()).toBe(15);
@@ -48,14 +48,14 @@ test("tuple constructor", () => {
     expect(date.getDay()).toBe(0);
 
     // getTime() returns a time stamp in UTC, but we can at least check it's in the right interval, which will be true independent of the local timezone if the range is big enough.
-    let timestamp_lower_bound = 1575072000000;  // 2019-12-01T00:00:00Z
-    let timestamp_upper_bound = 1577750400000;  // 2019-12-31T00:00:00Z
+    let timestamp_lower_bound = 1575072000000; // 2019-12-01T00:00:00Z
+    let timestamp_upper_bound = 1577750400000; // 2019-12-31T00:00:00Z
     expect(date.getTime()).toBeGreaterThan(timestamp_lower_bound);
     expect(date.getTime()).toBeLessThan(timestamp_upper_bound);
 });
 
 test("tuple constructor overflow", () => {
-    let date = new Date(2019, 13, 33,  30, 70, 80, 2345);
+    let date = new Date(2019, 13, 33, 30, 70, 80, 2345);
     expect(date.getFullYear()).toBe(2020);
     expect(date.getMonth()).toBe(2);
     expect(date.getDate()).toBe(5);
@@ -65,7 +65,7 @@ test("tuple constructor overflow", () => {
     expect(date.getMilliseconds()).toBe(345);
     expect(date.getDay()).toBe(4);
 
-    let date = new Date(2019, -13, -33,  -30, -70, -80, -2345);
+    let date = new Date(2019, -13, -33, -30, -70, -80, -2345);
     expect(date.getFullYear()).toBe(2017);
     expect(date.getMonth()).toBe(9);
     expect(date.getDate()).toBe(26);

--- a/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-get.js
+++ b/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-get.js
@@ -42,11 +42,14 @@ describe("[[Get]] trap normal behavior", () => {
     });
 
     test("custom receiver value", () => {
-        let p = new Proxy({}, {
-            get(target, property, receiver) {
-                return receiver;
-            },
-        });
+        let p = new Proxy(
+            {},
+            {
+                get(target, property, receiver) {
+                    return receiver;
+                },
+            }
+        );
 
         expect(Reflect.get(p, "foo", 42)).toBe(42);
     });

--- a/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-set.js
+++ b/Libraries/LibJS/Tests/builtins/Proxy/Proxy.handler-set.js
@@ -40,7 +40,7 @@ describe("[[Set]] trap normal behavior", () => {
         expect(p.foo).toBe(20);
         p.foo = 10;
         expect(p.foo).toBe(10);
-        p[Symbol.hasInstance] = "foo"
+        p[Symbol.hasInstance] = "foo";
         expect(p[Symbol.hasInstance]).toBe("foo");
     });
 

--- a/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.flags.js
+++ b/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.flags.js
@@ -6,5 +6,6 @@ test("basic functionality", () => {
     expect(/foo/s.flags).toBe("s");
     expect(/foo/u.flags).toBe("u");
     expect(/foo/y.flags).toBe("y");
+    // prettier-ignore
     expect(/foo/sgimyu.flags).toBe("gimsuy");
 });

--- a/Libraries/LibJS/Tests/builtins/String/String.prototype.endsWith.js
+++ b/Libraries/LibJS/Tests/builtins/String/String.prototype.endsWith.js
@@ -34,6 +34,9 @@ test("basic functionality", () => {
     expect(s.endsWith("", -1)).toBeTrue();
     expect(s.endsWith("", 42)).toBeTrue();
     expect("12undefined".endsWith()).toBeTrue();
-    expect(() => s.endsWith(/foobar/)).toThrowWithMessage(TypeError, "searchString is not a string, but a regular expression");
+    expect(() => s.endsWith(/foobar/)).toThrowWithMessage(
+        TypeError,
+        "searchString is not a string, but a regular expression"
+    );
     expect(s.endsWith("bar", undefined)).toBeTrue();
 });

--- a/Libraries/LibJS/Tests/classes/class-expressions.js
+++ b/Libraries/LibJS/Tests/classes/class-expressions.js
@@ -1,14 +1,11 @@
-// This file must not be formatted by prettier. Make sure your IDE
-// respects the .prettierignore file!
-
 test("basic functionality", () => {
     const A = class {
         constructor(x) {
-           this.x = x;
+            this.x = x;
         }
 
         getX() {
-           return this.x * 2;
+            return this.x * 2;
         }
     };
 
@@ -16,6 +13,7 @@ test("basic functionality", () => {
 });
 
 test("inline instantiation", () => {
+    // prettier-ignore
     const a = new class {
         constructor() {
             this.x = 10;
@@ -30,6 +28,7 @@ test("inline instantiation", () => {
 });
 
 test("inline instantiation with argument", () => {
+    // prettier-ignore
     const a = new class {
         constructor(x) {
             this.x = x;
@@ -53,7 +52,7 @@ test("extending class expressions", () => {
             super(y);
             this.y = y * 2;
         }
-    };
+    }
 
     const a = new A(10);
     expect(a.x).toBe(10);
@@ -61,9 +60,9 @@ test("extending class expressions", () => {
 });
 
 test("class expression name", () => {
-    let A = class {}
+    let A = class {};
     expect(A.name).toBe("A");
 
-    let B = class C {}
+    let B = class C {};
     expect(B.name).toBe("C");
 });

--- a/Libraries/LibJS/Tests/functions/function-strict-mode.js
+++ b/Libraries/LibJS/Tests/functions/function-strict-mode.js
@@ -1,6 +1,3 @@
-// This file must not be formatted by prettier. Make sure your IDE
-// respects the .prettierignore file!
-
 test("non strict-mode by default", () => {
     expect(isStrictMode()).toBeFalse();
 });
@@ -10,21 +7,25 @@ test("use strict with double quotes", () => {
     expect(isStrictMode()).toBeTrue();
 });
 
+// prettier-ignore
 test("use strict with single quotes", () => {
     'use strict';
     expect(isStrictMode()).toBeTrue();
 });
 
+// prettier-ignore
 test("use strict with backticks does not yield strict mode", () => {
     `use strict`;
     expect(isStrictMode()).toBeFalse();
 });
 
+// prettier-ignore
 test("use strict with single quotes after statement does not yield strict mode code", () => {
     ;'use strict';
     expect(isStrictMode()).toBeFalse();
 });
 
+// prettier-ignore
 test("use strict with double quotes after statement does not yield strict mode code", () => {
     ;"use strict";
     expect(isStrictMode()).toBeFalse();
@@ -39,14 +40,14 @@ strict";
 test("strict mode propagates down the scope chain", () => {
     "use strict";
     expect(isStrictMode()).toBeTrue();
-    (function() {
+    (function () {
         expect(isStrictMode()).toBeTrue();
     })();
 });
 
 test("strict mode does not propagate up the scope chain", () => {
     expect(isStrictMode()).toBeFalse();
-    (function() {
+    (function () {
         "use strict";
         expect(isStrictMode()).toBeTrue();
     })();

--- a/Libraries/LibJS/Tests/loops/break-basic.js
+++ b/Libraries/LibJS/Tests/loops/break-basic.js
@@ -10,8 +10,9 @@ test("Toplevel break inside loop", () => {
 test("break inside sub-blocks", () => {
     var j = 0;
     for (var i = 0; i < 9; ++i) {
-        if (j == 4)
+        if (j == 4) {
             break;
+        }
         ++j;
     }
     expect(j).toBe(4);

--- a/Libraries/LibJS/Tests/new-expression.js
+++ b/Libraries/LibJS/Tests/new-expression.js
@@ -1,6 +1,4 @@
-// This file must not be formatted by prettier. Make sure your IDE
-// respects the .prettierignore file!
-
+// prettier-ignore
 test("new-expression parsing", () => {
     function Foo() {
         this.x = 1;
@@ -21,6 +19,7 @@ test("new-expression parsing", () => {
     expect(foo).toBe("[object Object]2");
 });
 
+// prettier-ignore
 test("new-expressions with object keys", () => {
     let a = {
         b: function () {

--- a/Libraries/LibJS/Tests/parseInt.js
+++ b/Libraries/LibJS/Tests/parseInt.js
@@ -2,33 +2,33 @@ test("basic parseInt() functionality", () => {
     expect(parseInt("0")).toBe(0);
     expect(parseInt("100")).toBe(100);
     expect(parseInt("1000", 16)).toBe(4096);
-    expect(parseInt('0xF', 16)).toBe(15)
-    expect(parseInt('F', 16)).toBe(15)
-    expect(parseInt('17', 8)).toBe(15)
-    expect(parseInt(021, 8)).toBe(15)
-    expect(parseInt('015', 10)).toBe(15)
-    expect(parseInt(15.99, 10)).toBe(15)
-    expect(parseInt('15,123', 10)).toBe(15)
-    expect(parseInt('FXX123', 16)).toBe(15)
-    expect(parseInt('1111', 2)).toBe(15)
-    expect(parseInt('15 * 3', 10)).toBe(15)
-    expect(parseInt('15e2', 10)).toBe(15)
-    expect(parseInt('15px', 10)).toBe(15)
-    expect(parseInt('12', 13)).toBe(15)
-    expect(parseInt('Hello', 8)).toBeNaN();
-    expect(parseInt('546', 2)).toBeNaN();
-    expect(parseInt('-F', 16)).toBe(-15);
-    expect(parseInt('-0F', 16)).toBe(-15);
-    expect(parseInt('-0XF', 16)).toBe(-15);
+    expect(parseInt("0xF", 16)).toBe(15);
+    expect(parseInt("F", 16)).toBe(15);
+    expect(parseInt("17", 8)).toBe(15);
+    expect(parseInt(021, 8)).toBe(15);
+    expect(parseInt("015", 10)).toBe(15);
+    expect(parseInt(15.99, 10)).toBe(15);
+    expect(parseInt("15,123", 10)).toBe(15);
+    expect(parseInt("FXX123", 16)).toBe(15);
+    expect(parseInt("1111", 2)).toBe(15);
+    expect(parseInt("15 * 3", 10)).toBe(15);
+    expect(parseInt("15e2", 10)).toBe(15);
+    expect(parseInt("15px", 10)).toBe(15);
+    expect(parseInt("12", 13)).toBe(15);
+    expect(parseInt("Hello", 8)).toBeNaN();
+    expect(parseInt("546", 2)).toBeNaN();
+    expect(parseInt("-F", 16)).toBe(-15);
+    expect(parseInt("-0F", 16)).toBe(-15);
+    expect(parseInt("-0XF", 16)).toBe(-15);
     expect(parseInt(-15.1, 10)).toBe(-15);
-    expect(parseInt('-17', 8)).toBe(-15);
-    expect(parseInt('-15', 10)).toBe(-15);
-    expect(parseInt('-1111', 2)).toBe(-15);
-    expect(parseInt('-15e1', 10)).toBe(-15);
-    expect(parseInt('-12', 13)).toBe(-15);
+    expect(parseInt("-17", 8)).toBe(-15);
+    expect(parseInt("-15", 10)).toBe(-15);
+    expect(parseInt("-1111", 2)).toBe(-15);
+    expect(parseInt("-15e1", 10)).toBe(-15);
+    expect(parseInt("-12", 13)).toBe(-15);
     expect(parseInt(4.7, 10)).toBe(4);
-    expect(parseInt('0e0', 16)).toBe(224);
-    expect(parseInt('123_456')).toBe(123);
+    expect(parseInt("0e0", 16)).toBe(224);
+    expect(parseInt("123_456")).toBe(123);
 
     // FIXME: expect(parseInt(4.7 * 1e22, 10)).toBe(4);
     // FIXME: expect(parseInt(0.00000000000434, 10)).toBe(4);
@@ -42,10 +42,18 @@ test("basic parseInt() functionality", () => {
 });
 
 test("parseInt() radix is coerced to a number", () => {
-    const obj = { valueOf() { return 8; } };
-    expect(parseInt('11', obj)).toBe(9);
-    obj.valueOf = function() { return 1; }
-    expect(parseInt('11', obj)).toBeNaN();
-    obj.valueOf = function() { return Infinity; }
-    expect(parseInt('11', obj)).toBe(11);
+    const obj = {
+        valueOf() {
+            return 8;
+        },
+    };
+    expect(parseInt("11", obj)).toBe(9);
+    obj.valueOf = function () {
+        return 1;
+    };
+    expect(parseInt("11", obj)).toBeNaN();
+    obj.valueOf = function () {
+        return Infinity;
+    };
+    expect(parseInt("11", obj)).toBe(11);
 });

--- a/Libraries/LibJS/Tests/strict-mode-blocks.js
+++ b/Libraries/LibJS/Tests/strict-mode-blocks.js
@@ -2,16 +2,19 @@ test("Issue #3641, strict mode should be function- or program-level, not block-l
     function func() {
         expect(isStrictMode()).toBeFalse();
 
+        // prettier-ignore
         {
             "use strict";
             expect(isStrictMode()).toBeFalse();
         }
 
+        // prettier-ignore
         if (true) {
             "use strict";
             expect(isStrictMode()).toBeFalse();
         }
 
+        // prettier-ignore
         do {
             "use strict";
             expect(isStrictMode()).toBeFalse();

--- a/Libraries/LibJS/Tests/strict-mode-errors.js
+++ b/Libraries/LibJS/Tests/strict-mode-errors.js
@@ -7,6 +7,9 @@ test("basic functionality", () => {
         }).toThrowWithMessage(TypeError, "Cannot assign property foo to primitive value");
         expect(() => {
             primitive[Symbol.hasInstance] = 123;
-        }).toThrowWithMessage(TypeError, "Cannot assign property Symbol(Symbol.hasInstance) to primitive value");
+        }).toThrowWithMessage(
+            TypeError,
+            "Cannot assign property Symbol(Symbol.hasInstance) to primitive value"
+        );
     });
 });

--- a/Libraries/LibJS/Tests/string-escapes.js
+++ b/Libraries/LibJS/Tests/string-escapes.js
@@ -40,7 +40,9 @@ describe("octal escapes", () => {
         expect("\5").toBe("\u0005");
         expect("\6").toBe("\u0006");
         expect("\7").toBe("\u0007");
+        // prettier-ignore
         expect("\8").toBe("8");
+        // prettier-ignore
         expect("\9").toBe("9");
         expect("\128").toBe("\n8");
         expect("\141bc").toBe("abc");

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -302,7 +302,7 @@ class ExpectationError extends Error {
         // Test for syntax errors; target must be a string
         toEval() {
             this.__expect(typeof this.target === "string");
-            const success = canParseSource(this.target)
+            const success = canParseSource(this.target);
             this.__expect(this.inverted ? !success : success);
         }
 

--- a/Libraries/LibJS/Tests/use-strict-directive.js
+++ b/Libraries/LibJS/Tests/use-strict-directive.js
@@ -6,6 +6,7 @@ test("valid 'use strict; directive", () => {
         })()
     ).toBeTrue();
     expect(
+        // prettier-ignore
         (() => {
             'use strict';
             return isStrictMode();

--- a/Libraries/LibJS/Tests/with-basic.js
+++ b/Libraries/LibJS/Tests/with-basic.js
@@ -1,5 +1,5 @@
 test("basic with statement functionality", () => {
-    var object = { "foo": 5, "bar": 6, "baz": 7 };
+    var object = { foo: 5, bar: 6, baz: 7 };
     var qux = 1;
 
     var bar = 99;

--- a/Libraries/LibWeb/Tests/HTML/HTMLElement.js
+++ b/Libraries/LibWeb/Tests/HTML/HTMLElement.js
@@ -1,9 +1,9 @@
-loadPage("file:///res/html/misc/welcome.html")
+loadPage("file:///res/html/misc/welcome.html");
 
 afterInitialPageLoad(() => {
-   test("contentEditable attribute", () => {
+    test("contentEditable attribute", () => {
         expect(document.body.contentEditable).toBe("inherit");
         expect(document.firstChild.nextSibling.nodeName).toBe("html");
         expect(document.firstChild.nextSibling.contentEditable).toBe("true");
-   });
+    });
 });

--- a/Libraries/LibWeb/Tests/HTML/HTMLTemplateElement.js
+++ b/Libraries/LibWeb/Tests/HTML/HTMLTemplateElement.js
@@ -4,7 +4,7 @@ afterInitialPageLoad(() => {
     test("Basic functionality", () => {
         const template = document.getElementById("template");
         expect(template).not.toBeNull();
-       
+
         // The contents of a template element are not children of the actual element.
         // The document fragment is not a child of the element either.
         expect(template.firstChild).toBeNull();
@@ -17,7 +17,7 @@ afterInitialPageLoad(() => {
         expect(templateDiv.nodeName).toBe("div");
         expect(templateDiv.textContent).toBe("Hello template!");
     });
-    
+
     test("Templates are inert (e.g. scripts won't run)", () => {
         // The page has a template element with a script element in it.
         // Templates are inert, for example, they won't run scripts.

--- a/Libraries/LibWeb/Tests/HTML/document.body.js
+++ b/Libraries/LibWeb/Tests/HTML/document.body.js
@@ -49,7 +49,7 @@ afterInitialPageLoad(() => {
 
     // FIXME: Add this in once removeChild is implemented.
     test.skip("Nullable", () => {
-       document.documentElement.removeChild(document.body);
-       expect(document.body).toBeNull();
+        document.documentElement.removeChild(document.body);
+        expect(document.body).toBeNull();
     });
 });

--- a/Libraries/LibWeb/Tests/test-common.js
+++ b/Libraries/LibWeb/Tests/test-common.js
@@ -25,7 +25,7 @@ let __AfterInitialPageLoad__ = () => {};
 let afterInitialPageLoad;
 
 (() => {
-    loadPage = (page) => __PageToLoad__ = page;
-    beforeInitialPageLoad = (callback) => __BeforeInitialPageLoad__ = callback;
-    afterInitialPageLoad = (callback) => __AfterInitialPageLoad__ = callback;
+    loadPage = page => (__PageToLoad__ = page);
+    beforeInitialPageLoad = callback => (__BeforeInitialPageLoad__ = callback);
+    afterInitialPageLoad = callback => (__AfterInitialPageLoad__ = callback);
 })();

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -20,17 +20,17 @@ for cmd in \
         Meta/lint-executable-resources.sh \
         Meta/lint-ipc-ids.sh \
         Meta/lint-shell-scripts.sh; do
-    echo "Running $cmd... "
-    if $cmd; then
-	echo -e "[${GREEN}OK${NC}]: ${cmd}"
+    echo "Running ${cmd}... "
+    if "${cmd}" "$@"; then
+        echo -e "[${GREEN}OK${NC}]: ${cmd}"
     else
-	echo -e "[${RED}FAIL${NC}]: ${cmd}"
-	((FAILURES+=1))
+        echo -e "[${RED}FAIL${NC}]: ${cmd}"
+        ((FAILURES+=1))
     fi
 done
 
 echo "Running Meta/lint-clang-format.sh"
-if Meta/lint-clang-format.sh --overwrite-inplace && git diff --exit-code; then
+if Meta/lint-clang-format.sh --overwrite-inplace "$@" && git diff --exit-code; then
     echo -e "[${GREEN}OK${NC}]: Meta/lint-clang-format.sh"
 else
     echo -e "[${RED}FAIL${NC}]: Meta/lint-clang-format.sh"

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -19,7 +19,8 @@ for cmd in \
         Meta/check-style.sh \
         Meta/lint-executable-resources.sh \
         Meta/lint-ipc-ids.sh \
-        Meta/lint-shell-scripts.sh; do
+        Meta/lint-shell-scripts.sh \
+        Meta/lint-prettier.sh; do
     echo "Running ${cmd}... "
     if "${cmd}" "$@"; then
         echo -e "[${GREEN}OK${NC}]: ${cmd}"

--- a/Meta/lint-executable-resources.sh
+++ b/Meta/lint-executable-resources.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
-set -e pipefail
+#!/bin/bash
+
+set -eo pipefail
 
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path/.."

--- a/Meta/lint-ipc-ids.sh
+++ b/Meta/lint-ipc-ids.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
-set -e pipefail
+#!/bin/bash
+
+set -eo pipefail
 
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path/.."

--- a/Meta/lint-missing-resources.sh
+++ b/Meta/lint-missing-resources.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
-set -e pipefail
+#!/bin/bash
+
+set -eo pipefail
 
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path/.."

--- a/Meta/lint-prettier.sh
+++ b/Meta/lint-prettier.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+cd "${script_path}/.." || exit 1
+
+if ! command -v prettier >/dev/null 2>&1 ; then
+    echo "prettier is not available. Either skip this script, or install prettier."
+    exit 1
+fi
+
+if ! prettier --version | grep -qF '2.' ; then
+    echo "You are using '$(prettier --version)', which appears to not be prettier 2."
+    exit 1
+fi
+
+if [ "$#" -eq "0" ]; then
+    mapfile -t files < <(
+        git ls-files \
+            --exclude-from .prettierignore \
+            -- \
+            '*.js'
+    )
+else
+    files=()
+    for file in "$@"; do
+        if [[ "${file}" == *".js" ]]; then
+            files+=("${file}")
+        fi
+    done
+fi
+
+if (( ${#files[@]} )); then
+    prettier --check "${files[@]}"
+else
+    echo "No .js files to check."
+fi

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e pipefail
+
+set -eo pipefail
 
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path/.."


### PR DESCRIPTION
My bash is terrible, suggestions for improvement welcome. pre-commit now requires a working install of prettier.

---

Some background:
We've been using prettier for JavaScript files (mostly LibJS test files) [for a while now](https://freenode.logbot.info/serenityos/20200526#c3977901-c3977933), but it's never been automatically enforced like clang-format is, so it depended on a human reviewer catching inconsistencies - not anymore.