### PR TITLE
Meta: Add macOS workflow to CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -136,3 +136,48 @@ jobs:
     - name: Build Lagom with Fuzzers
       working-directory: ${{ github.workspace }}/Meta/Lagom/Build
       run: cmake --build .
+  build_and_test_on_macos:
+    runs-on: macos-11.0
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: brew install coreutils ninja
+    - name: Check versions
+      run: set +e; g++ --version; g++-10 --version; clang --version; clang++ --version; python --version; python3 --version; ninja --version
+    - name: Toolchain cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ github.workspace }}/Toolchain/Cache/
+        # This assumes that *ALL* LibC headers have an impact on the Toolchain.
+        # This is wrong, and causes more Toolchain rebuilds than necessary.
+        # However, we want to avoid false cache hits at all costs.
+        key: ${{ runner.os }}-toolchain-${{ hashFiles('Libraries/LibC/**/*.h', 'Toolchain/Patches/*.patch') }}
+    - name: Restore or regenerate Toolchain
+      run: TRY_USE_LOCAL_TOOLCHAIN=y ${{ github.workspace }}/Toolchain/BuildIt.sh
+
+    # TODO: ccache
+    # https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
+    # https://github.com/cristianadam/HelloWorld/blob/master/.github/workflows/build_cmake.yml
+    - name: Create build environment
+      working-directory: ${{ github.workspace }}
+      # Note that this needs to run *even if* the Toolchain was built,
+      # in order to set options like BUILD_LAGOM.
+      run: |
+        mkdir -p Build
+        cd Build
+        cmake .. -GNinja -DBUILD_LAGOM=1 -DALL_THE_DEBUG_MACROS=1 -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+
+    # === ACTUALLY BUILD AND TEST ===
+
+    - name: Build Serenity and Tests
+      working-directory: ${{ github.workspace }}/Build
+      run: cmake --build .
+    - name: Run CMake tests
+      working-directory: ${{ github.workspace }}/Build
+      run: CTEST_OUTPUT_ON_FAILURE=1 ninja test
+      timeout-minutes: 2
+    - name: Run JS tests
+      working-directory: ${{ github.workspace }}/Build/Meta/Lagom
+      run: DISABLE_DBG_OUTPUT=1 ./test-js

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -267,12 +267,16 @@ pushd "$DIR"
 
         rm -f "${CACHED_TOOLCHAIN_ARCHIVE}"  # Just in case
 
-        # We *most definitely* don't need debug symbols in the linker/compiler.
-        # This cuts the uncompressed size from 1.2 GiB per Toolchain down to about 190 MiB.
-        echo "Stripping executables ..."
-        echo "Before: $(du -sh Local)"
-        find Local/ -type f -executable ! -name '*.la' ! -name '*.sh' ! -name 'mk*' -exec strip {} +
-        echo "After: $(du -sh Local)"
+        # Stripping doesn't seem to work on macOS.
+        # However, this doesn't seem to be necessary on macOS, the uncompressed size is already about 210 MiB.
+        if [ "$(uname)" != "Darwin" ]; then
+            # We *most definitely* don't need debug symbols in the linker/compiler.
+            # This cuts the uncompressed size from 1.2 GiB per Toolchain down to about 190 MiB.
+            echo "Stripping executables ..."
+            echo "Before: $(du -sh Local)"
+            find Local/ -type f -executable ! -name '*.la' ! -name '*.sh' ! -name 'mk*' -exec strip {} +
+            echo "After: $(du -sh Local)"
+        fi
         tar czf "${CACHED_TOOLCHAIN_ARCHIVE}" Local/
 
         echo "Cache (after):"


### PR DESCRIPTION
A good number of contributors use macOS. However, we have a bit of
a tendency of breaking the macOS build without realising it.

Luckily, GitHub Actions does actually supply macOS environments,
so let's use it.

Note that this doesn't currently have any fixes to the macOS build.
I'm not sure what to do with them.

Another thing to note is that this uses Big Sur for the build. They
also provide Catalina, but I just went for the latest. I'm not sure
if this would have any effect.

Plus, they don't seem to provide M1 variants, so this is sadly not
completely relevant to #4541.

Relevant issues: #4483 #4569

Marked as draft because I forgot to mark it as draft.