### PR TITLE
LibVT: Use the 'U+FFFD replacement character' to indicate a parsing error

### DIFF
--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -829,7 +829,7 @@ void Terminal::on_input(u8 ch)
 
     auto fail_utf8_parse = [this] {
         m_parser_state = Normal;
-        on_code_point('%');
+        on_code_point(U'�');
     };
 
     auto advance_utf8_parse = [this, ch] {


### PR DESCRIPTION
Based on this recommendation in the Unicode standard:
https://www.unicode.org/versions/Unicode13.0.0/ch23.pdf (Page 32)

This is a small (and optional) change, it mainly helps differentiating parse errors from actual percentage characters.