### PR TITLE
LibELF: Reject ELF with program header p_filesz larger than p_memsz

### DIFF
--- a/Libraries/LibELF/Validation.cpp
+++ b/Libraries/LibELF/Validation.cpp
@@ -193,6 +193,13 @@ bool validate_program_headers(const Elf32_Ehdr& elf_header, size_t file_size, co
 
     for (size_t header_index = 0; header_index < num_program_headers; ++header_index) {
         auto& program_header = program_header_begin[header_index];
+
+        if (program_header.p_filesz > program_header.p_memsz) {
+            if (verbose)
+                dbgln("Program header ({}) has p_filesz ({}) larger than p_memsz ({})", header_index, program_header.p_filesz, program_header.p_memsz);
+            return false;
+        }
+
         switch (program_header.p_type) {
         case PT_INTERP:
             // We checked above that file_size was >= buffer size. We only care about buffer size anyway, we're trying to read this!


### PR DESCRIPTION
The `PT_LOAD` load section of the [Linux man page for elf](https://man7.org/linux/man-pages/man5/elf.5.html) states:

> The file size may not be larger than the memory size.

It seems to imply that this is only relevant for program headers with type `PT_LOAD`. ~~Apparently coredumps have a hardcoded memsz of zero (https://github.com/SerenityOS/serenity/pull/4576#issuecomment-751510304), so we can't apply this check to all program headers, even though that would probably make sense.~~ There's no immediately obvious reason why we can't apply this to all program headers. However, the tradeoff is that we won't be able to parse malformed ELF files, or coredumps files from other systems, which have `p_filesz` larger than `p_memsz`.

After this patch, the following program will now be rejected:

```cpp
#include <LibELF/exec_elf.h>
#include <fcntl.h>
#include <stdio.h>
#include <string.h>
#include <unistd.h>

#pragma GCC diagnostic ignored "-Wdeprecated-declarations"

int main()
{
    char buffer[0x2000];

    auto& header = *(Elf32_Ehdr*)buffer;
    header.e_ident[EI_MAG0] = ELFMAG0;
    header.e_ident[EI_MAG1] = ELFMAG1;
    header.e_ident[EI_MAG2] = ELFMAG2;
    header.e_ident[EI_MAG3] = ELFMAG3;
    header.e_ident[EI_CLASS] = ELFCLASS32;
    header.e_ident[EI_DATA] = ELFDATA2LSB;
    header.e_ident[EI_VERSION] = EV_CURRENT;
    header.e_ident[EI_OSABI] = ELFOSABI_SYSV;
    header.e_ident[EI_ABIVERSION] = 0;
    header.e_type = ET_EXEC;
    header.e_version = EV_CURRENT;
    header.e_ehsize = sizeof(Elf32_Ehdr);
    header.e_machine = EM_386;
    header.e_shentsize = sizeof(Elf32_Shdr);

    header.e_phnum = 1;
    header.e_phoff = 52;
    header.e_phentsize = sizeof(Elf32_Phdr);

    auto* ph = (Elf32_Phdr*)(&buffer[header.e_phoff]);
    ph[0].p_flags = PF_R | PF_X;
    ph[0].p_align = PAGE_SIZE;
    ph[0].p_vaddr = 0x000000d4;
    ph[0].p_type = PT_LOAD;
    ph[0].p_memsz = 0;  // crash
    ph[0].p_offset = 0x1000;
    ph[0].p_filesz = 0x1000;

    /* inaccurate and unrelated */
    header.e_shnum = 3;
    header.e_shoff = 1024;
    header.e_shstrndx = 2;
    header.e_entry = 1024;

    int fd = open("x", O_RDWR | O_CREAT, 0777);
    if (fd < 0) {
        perror("open");
        return 1;
    }

    int nwritten = write(fd, buffer, sizeof(buffer));
    if (nwritten < 0) {
        perror("write");
        return 1;
    }

    if (execl("/home/anon/x", "x", nullptr) < 0) {
        perror("execl");
        return 1;
    }

    return 0;
}
```

```
[elf-crash(27:27)]: Program header (0) PT_LOAD has p_filesz (4096) larger than p_memsz (0)
[elf-crash(27:27)]: exec(/home/anon/x): File has invalid ELF Program headers
elf-crash(27): perror(): execl: Exec format error
Shell(24): Job entry "elf-crash" deleted in 148 ms
```
