### PR TITLE
Kernel: CoreDump::write_program_headers: set NOTE p_memsz to p_filesz

### DIFF
--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -159,7 +159,7 @@ KResult CoreDump::write_program_headers(size_t notes_size)
     notes_pheader.p_vaddr = 0;
     notes_pheader.p_paddr = 0;
     notes_pheader.p_filesz = notes_size;
-    notes_pheader.p_memsz = 0;
+    notes_pheader.p_memsz = notes_size;
     notes_pheader.p_align = 0;
     notes_pheader.p_flags = 0;
 


### PR DESCRIPTION
Resolves #4577

I'm not sure if this necessary or a good idea. Linux also appears to set `memsz` as zero:

https://elixir.bootlin.com/linux/latest/source/fs/binfmt_elf.c#L1492