### PR TITLE
Services: Fix typos

### DIFF
--- a/Services/Clipboard/main.cpp
+++ b/Services/Clipboard/main.cpp
@@ -58,7 +58,7 @@ int main(int, char**)
     server->on_ready_to_accept = [&] {
         auto client_socket = server->accept();
         if (!client_socket) {
-            dbg() << "ProtocolServer: accept failed.";
+            dbg() << "Clipboard: accept failed.";
             return;
         }
         static int s_next_client_id = 0;

--- a/Services/LaunchServer/Launcher.cpp
+++ b/Services/LaunchServer/Launcher.cpp
@@ -319,6 +319,6 @@ bool Launcher::open_file_url(const URL& url)
     String extension = {};
     if (extension_parts.size() > 1)
         extension = extension_parts.last();
-    return open_with_user_preferences(m_file_handlers, extension, url.path(), "/bin/TextEdit");
+    return open_with_user_preferences(m_file_handlers, extension, url.path(), "/bin/TextEditor");
 }
 }


### PR DESCRIPTION
A tiny commit. I fixed these ages ago and am tired of seeing the untracked changes.

`ProtocolServer` in `Clipboard` was left over copy pasta.

For `LaunchServer`,  I'm not sure if this code path will usually ever be reached, as `file` is a known protocol with an associated handler. Nonetheless, `/bin/TextEdit` is not a thing which exists.
