### PR TITLE
Everywhere: Move AppFile from LibGUI to LibDesktop

### DIFF
--- a/Libraries/LibDesktop/AppFile.cpp
+++ b/Libraries/LibDesktop/AppFile.cpp
@@ -28,9 +28,9 @@
 #include <AK/Vector.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DirIterator.h>
-#include <LibGUI/AppFile.h>
+#include <LibDesktop/AppFile.h>
 
-namespace GUI {
+namespace Desktop {
 
 NonnullRefPtr<AppFile> AppFile::get_for_app(const StringView& app_name)
 {

--- a/Libraries/LibDesktop/AppFile.h
+++ b/Libraries/LibDesktop/AppFile.h
@@ -30,7 +30,7 @@
 #include <LibGUI/FileIconProvider.h>
 #include <LibGUI/Icon.h>
 
-namespace GUI {
+namespace Desktop {
 
 class AppFile : public RefCounted<AppFile> {
 public:
@@ -49,7 +49,7 @@ public:
     Vector<String> launcher_file_types() const;
     Vector<String> launcher_protocols() const;
 
-    Icon icon() const { return FileIconProvider::icon_for_path(executable()); };
+    GUI::Icon icon() const { return GUI::FileIconProvider::icon_for_path(executable()); };
 
 private:
     explicit AppFile(const StringView& path);

--- a/Libraries/LibDesktop/CMakeLists.txt
+++ b/Libraries/LibDesktop/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    AppFile.cpp
     Launcher.cpp
 )
 
@@ -8,4 +9,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_lib(LibDesktop desktop)
-target_link_libraries(LibDesktop LibIPC)
+target_link_libraries(LibDesktop LibCore LibIPC LibGUI)

--- a/Libraries/LibGUI/CMakeLists.txt
+++ b/Libraries/LibGUI/CMakeLists.txt
@@ -5,7 +5,6 @@ set(SOURCES
     AbstractView.cpp
     Action.cpp
     ActionGroup.cpp
-    AppFile.cpp
     Application.cpp
     BoxLayout.cpp
     Button.cpp

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -34,9 +34,9 @@
 #include <AK/Utf8View.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/MimeData.h>
+#include <LibDesktop/AppFile.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
-#include <LibGUI/AppFile.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/DragOperation.h>
@@ -858,7 +858,7 @@ void TerminalWidget::context_menu_event(GUI::ContextMenuEvent& event)
         // Then add them to the context menu.
         // FIXME: Adapt this code when we actually support calling LaunchServer with a specific handler in mind.
         for (auto& handler : handlers) {
-            auto af = GUI::AppFile::get_for_app(LexicalPath(handler).basename());
+            auto af = Desktop::AppFile::get_for_app(LexicalPath(handler).basename());
             if (!af->is_valid())
                 continue;
             auto action = GUI::Action::create(String::formatted("Open in {}", af->name()), af->icon().bitmap_for_size(16), [this, handler](auto&) {

--- a/Services/LaunchServer/CMakeLists.txt
+++ b/Services/LaunchServer/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
 )
 
 serenity_bin(LaunchServer)
-target_link_libraries(LaunchServer LibCore LibIPC LibGUI)
+target_link_libraries(LaunchServer LibCore LibIPC LibDesktop)

--- a/Services/LaunchServer/Launcher.cpp
+++ b/Services/LaunchServer/Launcher.cpp
@@ -32,7 +32,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ConfigFile.h>
-#include <LibGUI/AppFile.h>
+#include <LibDesktop/AppFile.h>
 #include <serenity.h>
 #include <spawn.h>
 #include <stdio.h>
@@ -97,7 +97,7 @@ Launcher& Launcher::the()
 
 void Launcher::load_handlers(const String& af_dir)
 {
-    GUI::AppFile::for_each([&](auto af) {
+    Desktop::AppFile::for_each([&](auto af) {
         auto app_name = af->name();
         auto app_executable = af->executable();
         HashTable<String> file_types;

--- a/Services/LaunchServer/Launcher.h
+++ b/Services/LaunchServer/Launcher.h
@@ -30,7 +30,7 @@
 #include <AK/HashTable.h>
 #include <AK/URL.h>
 #include <LibCore/ConfigFile.h>
-#include <LibGUI/AppFile.h>
+#include <LibDesktop/AppFile.h>
 
 namespace LaunchServer {
 
@@ -57,7 +57,7 @@ public:
     Launcher();
     static Launcher& the();
 
-    void load_handlers(const String& af_dir = GUI::AppFile::APP_FILES_DIRECTORY);
+    void load_handlers(const String& af_dir = Desktop::AppFile::APP_FILES_DIRECTORY);
     void load_config(const Core::ConfigFile&);
     bool open_url(const URL&, const String& handler_name);
     Vector<String> handlers_for_url(const URL&);

--- a/Services/SystemMenu/CMakeLists.txt
+++ b/Services/SystemMenu/CMakeLists.txt
@@ -4,4 +4,4 @@ set(SOURCES
 )
 
 serenity_bin(SystemMenu)
-target_link_libraries(SystemMenu LibGUI)
+target_link_libraries(SystemMenu LibGUI LibDesktop)

--- a/Services/SystemMenu/main.cpp
+++ b/Services/SystemMenu/main.cpp
@@ -30,9 +30,9 @@
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/StandardPaths.h>
+#include <LibDesktop/AppFile.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
-#include <LibGUI/AppFile.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/FileIconProvider.h>
 #include <LibGUI/Icon.h>
@@ -103,7 +103,7 @@ int main(int argc, char** argv)
 Vector<String> discover_apps_and_categories()
 {
     HashTable<String> seen_app_categories;
-    GUI::AppFile::for_each([&](auto af) {
+    Desktop::AppFile::for_each([&](auto af) {
         g_apps.append({ af->executable(), af->name(), af->category() });
         seen_app_categories.set(af->category());
     });

--- a/Services/Taskbar/CMakeLists.txt
+++ b/Services/Taskbar/CMakeLists.txt
@@ -6,4 +6,4 @@ set(SOURCES
 )
 
 serenity_bin(Taskbar)
-target_link_libraries(Taskbar LibGUI)
+target_link_libraries(Taskbar LibGUI LibDesktop)

--- a/Services/Taskbar/TaskbarWindow.cpp
+++ b/Services/Taskbar/TaskbarWindow.cpp
@@ -29,7 +29,7 @@
 #include <AK/SharedBuffer.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/StandardPaths.h>
-#include <LibGUI/AppFile.h>
+#include <LibDesktop/AppFile.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Desktop.h>
@@ -111,8 +111,8 @@ void TaskbarWindow::create_quick_launch_bar()
     // FIXME: Core::ConfigFile does not keep the order of the entries.
     for (auto& name : config->keys(quick_launch)) {
         auto af_name = config->read_entry(quick_launch, name);
-        auto af_path = String::formatted("{}/{}", GUI::AppFile::APP_FILES_DIRECTORY, af_name);
-        auto af = GUI::AppFile::open(af_path);
+        auto af_path = String::formatted("{}/{}", Desktop::AppFile::APP_FILES_DIRECTORY, af_name);
+        auto af = Desktop::AppFile::open(af_path);
         if (!af->is_valid())
             continue;
         auto app_executable = af->executable();


### PR DESCRIPTION
This was mentioned in #4574, and the more I think about it the more it feels just right - let's move it there! :^)
Having to link LaunchServer against LibGUI explicitly should've been telling enough...