### PR TITLE
LibRegex: Fail early if eof seen after '(?'

### DIFF
--- a/Libraries/LibRegex/RegexParser.cpp
+++ b/Libraries/LibRegex/RegexParser.cpp
@@ -741,6 +741,11 @@ bool ECMA262Parser::parse_assertion(ByteCode& stack, [[maybe_unused]] size_t& ma
         if (!try_skip("(?"))
             return false;
 
+        if (done()) {
+            set_error(Error::InvalidCaptureGroup);
+            return false;
+        }
+
         ByteCode assertion_stack;
         size_t length_dummy = 0;
 

--- a/Libraries/LibRegex/Tests/Regex.cpp
+++ b/Libraries/LibRegex/Tests/Regex.cpp
@@ -500,6 +500,7 @@ TEST_CASE(ECMA262_parse)
         { "(?", regex::Error::InvalidCaptureGroup },
         { "\\u1234", regex::Error::NoError, regex::ECMAScriptFlags::Unicode },
         { "[\\u1234]", regex::Error::NoError, regex::ECMAScriptFlags::Unicode },
+        { ",(?", regex::Error::InvalidCaptureGroup }, // #4583
     };
 
     for (auto& test : tests) {


### PR DESCRIPTION
Fixes #4583.