### PR TITLE
AK+Format: Accept all integer types in replacement fields.

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -60,25 +60,36 @@ struct TypeErasedParameter {
         Custom
     };
 
+    static Type get_type_from_size(size_t size, bool is_unsigned)
+    {
+        if (is_unsigned) {
+            if (size == 1)
+                return Type::UInt8;
+            if (size == 2)
+                return Type::UInt16;
+            if (size == 4)
+                return Type::UInt32;
+            if (size == 8)
+                return Type::UInt64;
+        } else {
+            if (size == 1)
+                return Type::Int8;
+            if (size == 2)
+                return Type::Int16;
+            if (size == 4)
+                return Type::Int32;
+            if (size == 8)
+                return Type::Int64;
+        }
+
+        ASSERT_NOT_REACHED();
+    }
+
     template<typename T>
     static Type get_type()
     {
-        if (IsSame<T, u8>::value)
-            return Type::UInt8;
-        if (IsSame<T, u16>::value)
-            return Type::UInt16;
-        if (IsSame<T, u32>::value)
-            return Type::UInt32;
-        if (IsSame<T, u64>::value)
-            return Type::UInt64;
-        if (IsSame<T, i8>::value)
-            return Type::Int8;
-        if (IsSame<T, i16>::value)
-            return Type::Int16;
-        if (IsSame<T, i32>::value)
-            return Type::Int32;
-        if (IsSame<T, i64>::value)
-            return Type::Int64;
+        if (IsIntegral<T>::value)
+            return get_type_from_size(sizeof(T), IsUnsigned<T>::value);
 
         return Type::Custom;
     }

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -326,6 +326,7 @@ constexpr T&& forward(typename RemoveReference<T>::Type&& param) noexcept
 
 template<typename T>
 struct MakeUnsigned {
+    using Type = void;
 };
 template<>
 struct MakeUnsigned<signed char> {
@@ -506,6 +507,9 @@ using Void = void;
 
 template<typename... _Ignored>
 constexpr auto DependentFalse = false;
+
+template<typename T>
+using IsUnsigned = IsSame<T, MakeUnsigned<T>>;
 
 }
 

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -29,6 +29,12 @@
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 
+TEST_CASE(is_integral_works_properly)
+{
+    EXPECT(!IsIntegral<const char*>::value);
+    EXPECT(IsIntegral<unsigned long>::value);
+}
+
 TEST_CASE(format_string_literals)
 {
     EXPECT_EQ(String::formatted("prefix-{}-suffix", "abc"), "prefix-abc-suffix");
@@ -122,6 +128,11 @@ TEST_CASE(replacement_field)
     EXPECT_EQ(String::formatted("{:{2}}", -5, 8, 16), "              -5");
     EXPECT_EQ(String::formatted("{{{:*^{1}}}}", 1, 3), "{*1*}");
     EXPECT_EQ(String::formatted("{:0{}}", 1, 3), "001");
+}
+
+TEST_CASE(replacement_field_regression)
+{
+    EXPECT_EQ(String::formatted("{:{}}", "", static_cast<unsigned long>(6)), "      ");
 }
 
 TEST_CASE(complex_string_specifiers)


### PR DESCRIPTION
This should make `TestFormat` pass on MacOS I rely on @ADKaster or someone else with MacOS to verify this. Refer to my answer in https://github.com/SerenityOS/serenity/issues/4592#issuecomment-751706082.

I also had to fix some type traits because it wasn't possible to evaluate `IsIntegral<T>` for types that were not integers because it used `MakeUnsigned<T>` internally which did not return something sensible when presented with a non-integer type.
