### PR TITLE
FileManager: Implement the cut file operation

### DIFF
--- a/Applications/FileManager/FileUtils.h
+++ b/Applications/FileManager/FileUtils.h
@@ -33,6 +33,7 @@
 
 namespace FileUtils {
 
+void delete_path(const String&, GUI::Window*);
 void delete_paths(const Vector<String>&, bool should_confirm, GUI::Window*);
 int delete_directory(String directory, String& file_that_caused_error);
 bool copy_file_or_directory(const String& src_path, const String& dst_path);

--- a/Applications/FileManager/FileUtils.h
+++ b/Applications/FileManager/FileUtils.h
@@ -33,6 +33,11 @@
 
 namespace FileUtils {
 
+enum class FileOperation {
+    Copy = 0,
+    Cut
+};
+
 void delete_path(const String&, GUI::Window*);
 void delete_paths(const Vector<String>&, bool should_confirm, GUI::Window*);
 int delete_directory(String directory, String& file_that_caused_error);


### PR DESCRIPTION
This exploits the comment lines in the text/uri-list specification: https://tools.ietf.org/rfc/rfc2483.txt (page 11), which might be a bit hackish, but the specification suggests doing the same for other uses ("In applications where one URI has been mapped to a list of URIs, the first line of the text/uri-list response SHOULD be a comment giving the original URI."), so it should be fine.