### PR TITLE
AK: Allow trailing '*'s in a glob pattern to match nothing

### DIFF
--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -93,6 +93,14 @@ bool matches(const StringView& str, const StringView& mask, CaseSensitivity case
         ++mask_ptr;
     }
 
+    if (string_ptr == string_end) {
+        // Allow ending '*' to contain nothing.
+        while (mask_ptr != mask_end && *mask_ptr == '*') {
+            record_span(string_ptr - string_start, 0);
+            ++mask_ptr;
+        }
+    }
+
     return string_ptr == string_end && mask_ptr == mask_end;
 }
 

--- a/AK/Tests/TestStringUtils.cpp
+++ b/AK/Tests/TestStringUtils.cpp
@@ -86,6 +86,14 @@ TEST_CASE(matches_with_positions)
     EXPECT_EQ(spans, Vector<AK::MaskSpan>({ { 1, 3 } }));
 }
 
+// #4607
+TEST_CASE(matches_trailing)
+{
+    EXPECT(AK::StringUtils::matches("ab", "ab*"));
+    EXPECT(AK::StringUtils::matches("ab", "ab****"));
+    EXPECT(AK::StringUtils::matches("ab", "*ab****"));
+}
+
 TEST_CASE(convert_to_int)
 {
     auto value = AK::StringUtils::convert_to_int(StringView());


### PR DESCRIPTION
Fixes part of #4607.