### PR TITLE
LibM: Reimplement some of the functions using FPU

### DIFF
--- a/Libraries/LibJS/Tests/builtins/Math/Math.acosh.js
+++ b/Libraries/LibJS/Tests/builtins/Math/Math.acosh.js
@@ -5,5 +5,5 @@ test("basic functionality", () => {
     expect(Math.acosh(0)).toBeNaN();
     expect(Math.acosh(0.5)).toBeNaN();
     expect(Math.acosh(1)).toBeCloseTo(0);
-    // FIXME: expect(Math.acosh(2)).toBeCloseTo(1.316957);
+    expect(Math.acosh(2)).toBeCloseTo(1.316957);
 });

--- a/Libraries/LibJS/Tests/builtins/Math/Math.asinh.js
+++ b/Libraries/LibJS/Tests/builtins/Math/Math.asinh.js
@@ -2,5 +2,5 @@ test("basic functionality", () => {
     expect(Math.asinh).toHaveLength(1);
 
     expect(Math.asinh(0)).toBeCloseTo(0);
-    // FIXME: expect(Math.asinh(1)).toBeCloseTo(0.881373);
+    expect(Math.asinh(1)).toBeCloseTo(0.881373);
 });

--- a/Libraries/LibJS/Tests/builtins/Math/Math.atanh.js
+++ b/Libraries/LibJS/Tests/builtins/Math/Math.atanh.js
@@ -4,7 +4,7 @@ test("basic functionality", () => {
     expect(Math.atanh(-2)).toBeNaN();
     expect(Math.atanh(2)).toBeNaN();
     expect(Math.atanh(-1)).toBe(-Infinity);
-    // FIXME: expect(Math.atanh(0)).toBe(0);
+    expect(Math.atanh(0)).toBe(0);
     expect(Math.atanh(0.5)).toBeCloseTo(0.549306);
-    // FIXME: expect(Math.atanh(1)).toBe(Infinity);
+    expect(Math.atanh(1)).toBe(Infinity);
 });

--- a/Libraries/LibJS/Tests/builtins/Math/Math.cbrt.js
+++ b/Libraries/LibJS/Tests/builtins/Math/Math.cbrt.js
@@ -2,11 +2,11 @@ test("basic functionality", () => {
     expect(Math.cbrt).toHaveLength(1);
 
     expect(Math.cbrt(NaN)).toBeNaN();
-    // FIXME: expect(Math.cbrt(-1)).toBe(-1);
+    expect(Math.cbrt(-1)).toBe(-1);
     expect(Math.cbrt(-0)).toBe(-0);
-    // FIXME: expect(Math.cbrt(-Infinity)).toBe(-Infinity);
-    // FIXME: expect(Math.cbrt(1)).toBe(1);
-    // FIXME: expect(Math.cbrt(Infinity)).toBe(Infinity);
-    // FIXME: expect(Math.cbrt(null)).toBe(0);
-    // FIXME: expect(Math.cbrt(2)).toBeCloseTo(1.259921));
+    expect(Math.cbrt(-Infinity)).toBe(-Infinity);
+    expect(Math.cbrt(1)).toBe(1);
+    expect(Math.cbrt(Infinity)).toBe(Infinity);
+    expect(Math.cbrt(null)).toBe(0);
+    expect(Math.cbrt(2)).toBeCloseTo(1.259921);
 });

--- a/Libraries/LibJS/Tests/builtins/Math/Math.log.js
+++ b/Libraries/LibJS/Tests/builtins/Math/Math.log.js
@@ -3,7 +3,6 @@ test("basic functionality", () => {
 
     expect(Math.log(-1)).toBe(NaN);
     expect(Math.log(0)).toBe(-Infinity);
-    // FIXME: not precise enough
-    //expect(Math.log(1)).toBe(0);
+    expect(Math.log(1)).toBe(0);
     expect(Math.log(10)).toBeCloseTo(2.302585092994046);
 });

--- a/Libraries/LibJS/Tests/builtins/Math/Math.log10.js
+++ b/Libraries/LibJS/Tests/builtins/Math/Math.log10.js
@@ -1,10 +1,9 @@
 test("basic functionality", () => {
     expect(Math.log10).toHaveLength(1);
 
-    // FIXME: not precise enough
-    // expect(Math.log10(2)).toBeCloseTo(0.3010299956639812);
-    // expect(Math.log10(1)).toBe(0);
+    expect(Math.log10(2)).toBeCloseTo(0.3010299956639812);
+    expect(Math.log10(1)).toBe(0);
     expect(Math.log10(0)).toBe(-Infinity);
     expect(Math.log10(-2)).toBe(NaN);
-    // expect(Math.log10(100000)).toBe(5);
+    expect(Math.log10(100000)).toBe(5);
 });

--- a/Libraries/LibJS/Tests/builtins/Math/Math.log1p.js
+++ b/Libraries/LibJS/Tests/builtins/Math/Math.log1p.js
@@ -3,6 +3,6 @@ test("basic functionality", () => {
 
     expect(Math.log1p(-2)).toBeNaN();
     expect(Math.log1p(-1)).toBe(-Infinity);
-    // FIXME: expect(Math.log1p(0)).toBe(0);
-    // FIXME: expect(Math.log1p(1)).toBeCloseTo(0.693147);
+    expect(Math.log1p(0)).toBe(0);
+    expect(Math.log1p(1)).toBeCloseTo(0.693147);
 });

--- a/Libraries/LibJS/Tests/builtins/Math/Math.log2.js
+++ b/Libraries/LibJS/Tests/builtins/Math/Math.log2.js
@@ -2,10 +2,9 @@ test("basic functionality", () => {
     expect(Math.log2).toHaveLength(1);
 
     expect(Math.log2(3)).toBeCloseTo(1.584962500721156);
-    // FIXME: not precise enough
-    // expect(Math.log2(2)).toBe(1);
-    // expect(Math.log2(1)).toBe(0);
+    expect(Math.log2(2)).toBe(1);
+    expect(Math.log2(1)).toBe(0);
     expect(Math.log2(0)).toBe(-Infinity);
     expect(Math.log2(-2)).toBe(NaN);
-    // expect(Math.log2(1024)).toBe(10);
+    expect(Math.log2(1024)).toBe(10);
 });


### PR DESCRIPTION
In this PR I have changed the implementation of several LibM functions in order to make them more accurate. However, in log functions I had to use an additional pair of fld/fstp because the compiler kept changing the order of loading the constant and loading the argument. I'd be glad if someone could figure out how to do this properly :^)
(Fixes #4543)