### PR TITLE
Inspector: unveil("/bin", "r") so it can show app icons

### DIFF
--- a/DevTools/Inspector/main.cpp
+++ b/DevTools/Inspector/main.cpp
@@ -60,6 +60,11 @@ int main(int argc, char** argv)
         return 1;
     }
 
+    if (unveil("/bin", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
     if (unveil("/tmp", "rwc") < 0) {
         perror("unveil");
         return 1;


### PR DESCRIPTION
Otherwise the list of applications only shows default icons and prints a bunch of unveil spam to the debug console.