### PR TITLE
Build: Expose symbols SECTION_start and SECTION_size for embedded resources

### DIFF
--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -118,9 +118,10 @@ function(embed_resource target section file)
     get_filename_component(asm_file "${file}" NAME)
     set(asm_file "${CMAKE_CURRENT_BINARY_DIR}/${target}-${section}.s")
     get_filename_component(input_file "${file}" ABSOLUTE)
+    file(SIZE "${input_file}" file_size)
     add_custom_command(
         OUTPUT "${asm_file}"
-        COMMAND "${CMAKE_SOURCE_DIR}/Meta/generate-embedded-resource-assembly.sh" "${asm_file}" "${section}" "${input_file}"
+        COMMAND "${CMAKE_SOURCE_DIR}/Meta/generate-embedded-resource-assembly.sh" "${asm_file}" "${section}" "${input_file}" "${file_size}"
         DEPENDS "${input_file}" "${CMAKE_SOURCE_DIR}/Meta/generate-embedded-resource-assembly.sh"
         COMMENT "Generating ${asm_file}"
     )

--- a/Meta/generate-embedded-resource-assembly.sh
+++ b/Meta/generate-embedded-resource-assembly.sh
@@ -12,16 +12,29 @@ shift
 
 rm -f "${OUTPUT_FILE}"
 
-while (( "$#" >= 2)); do
+while (( "$#" >= 3 )); do
     SECTION_NAME="$1"
     INPUT_FILE="$2"
+    FILE_SIZE="$3"
 
     {
-        printf '    .section %s\n' "${SECTION_NAME}"
-        printf '    .type %s, @object\n' "${SECTION_NAME}"
+        printf '    .file "%s"\n' "${OUTPUT_FILE}"
+        printf '    .data\n'
+        printf '    .section %s, "a", @progbits\n' "${SECTION_NAME}"
         printf '    .align 4\n'
+        printf '    .globl %s\n' "${SECTION_NAME}_start"
+        printf '    .type %s, @object\n' "${SECTION_NAME}_start"
+        printf '    .size %s, 4\n' "${SECTION_NAME}_start"
+        printf '%s:\n' "${SECTION_NAME}_start"
         printf '    .incbin "%s"\n' "${INPUT_FILE}"
+        printf '    .section serenity_embedded_resource_info, "a", @progbits\n'
+        printf '    .align 4\n'
+        printf '    .globl %s\n' "${SECTION_NAME}_size"
+        printf '    .type %s, @object\n' "${SECTION_NAME}_size"
+        printf '    .size %s, 4\n' "${SECTION_NAME}_size"
+        printf '%s:\n' "${SECTION_NAME}_size"
+        printf '    .long %s\n' "${FILE_SIZE}"
         printf '\n'
     } >> "${OUTPUT_FILE}"
-    shift 2
+    shift 3
 done


### PR DESCRIPTION
Resources embedded by the embed_resource() function will now also expose a SECTION_start and SECTION_size symbol so the embedded resource can be found by an application without having to parse its own ELF image which is not something applications can currently do from userspace.

This lays the groundwork for LibGUI to use the embedded icons in an application as the default icon, e.g. for a Window.