### PR TITLE
LibJS: Don't save rule start positions along with the parser state

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -367,7 +367,6 @@ RefPtr<FunctionExpression> Parser::try_parse_arrow_function_expression(bool expe
 
     ArmedScopeGuard state_rollback_guard = [&] {
         m_parser_state.m_var_scopes.take_last();
-        rule_start.disable();
         load_state();
     };
 
@@ -434,6 +433,7 @@ RefPtr<FunctionExpression> Parser::try_parse_arrow_function_expression(bool expe
 
     if (!function_body_result.is_null()) {
         state_rollback_guard.disarm();
+        discard_saved_state();
         auto body = function_body_result.release_nonnull();
         return create_ast_node<FunctionExpression>({ rule_start.position(), position() }, "", move(body), move(parameters), function_length, m_parser_state.m_var_scopes.take_last(), is_strict, true);
     }
@@ -446,7 +446,6 @@ RefPtr<Statement> Parser::try_parse_labelled_statement()
     save_state();
     auto rule_start = push_start();
     ArmedScopeGuard state_rollback_guard = [&] {
-        rule_start.disable();
         load_state();
     };
 
@@ -463,6 +462,7 @@ RefPtr<Statement> Parser::try_parse_labelled_statement()
 
     statement->set_label(identifier);
     state_rollback_guard.disarm();
+    discard_saved_state();
     return statement;
 }
 
@@ -471,7 +471,6 @@ RefPtr<MetaProperty> Parser::try_parse_new_target_expression()
     save_state();
     auto rule_start = push_start();
     ArmedScopeGuard state_rollback_guard = [&] {
-        rule_start.disable();
         load_state();
     };
 
@@ -485,6 +484,7 @@ RefPtr<MetaProperty> Parser::try_parse_new_target_expression()
         return {};
 
     state_rollback_guard.disarm();
+    discard_saved_state();
     return create_ast_node<MetaProperty>({ rule_start.position(), position() }, MetaProperty::Type::NewTarget);
 }
 
@@ -2039,6 +2039,11 @@ void Parser::load_state()
 {
     ASSERT(!m_saved_state.is_empty());
     m_parser_state = m_saved_state.take_last();
+}
+
+void Parser::discard_saved_state()
+{
+    m_saved_state.take_last();
 }
 
 }

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -169,6 +169,7 @@ private:
     void consume_or_insert_semicolon();
     void save_state();
     void load_state();
+    void discard_saved_state();
     Position position() const;
 
     struct RulePosition {
@@ -180,25 +181,21 @@ private:
             : m_parser(parser)
             , m_position(position)
         {
-            m_parser.m_parser_state.m_rule_starts.append(position);
+            m_parser.m_rule_starts.append(position);
         }
 
         ~RulePosition()
         {
-            if (!m_enabled)
-                return;
-            auto last = m_parser.m_parser_state.m_rule_starts.take_last();
+            auto last = m_parser.m_rule_starts.take_last();
             ASSERT(last.line == m_position.line);
             ASSERT(last.column == m_position.column);
         }
 
         const Position& position() const { return m_position; }
-        void disable() { m_enabled = false; }
 
     private:
         Parser& m_parser;
         Position m_position;
-        bool m_enabled { true };
     };
 
     [[nodiscard]] RulePosition push_start() { return { *this, position() }; }
@@ -210,7 +207,6 @@ private:
         Vector<NonnullRefPtrVector<VariableDeclaration>> m_var_scopes;
         Vector<NonnullRefPtrVector<VariableDeclaration>> m_let_scopes;
         Vector<NonnullRefPtrVector<FunctionDeclaration>> m_function_scopes;
-        Vector<Position> m_rule_starts;
         HashTable<StringView> m_labels_in_scope;
         bool m_strict_mode { false };
         bool m_allow_super_property_lookup { false };
@@ -224,6 +220,7 @@ private:
         explicit ParserState(Lexer);
     };
 
+    Vector<Position> m_rule_starts;
     ParserState m_parser_state;
     Vector<ParserState> m_saved_state;
 };


### PR DESCRIPTION
This fixes #4617.
Also fixes the small problem where some save states would be leaked.

I did check Patreon, and it seemed to be fixed (though it was very busy at the end allocating stuff, not sure about that bit)