### PR TITLE
Shell: Runtime errors, break/continue, oddball fixes

### DIFF
--- a/Base/usr/share/man/man5/Shell.md
+++ b/Base/usr/share/man/man5/Shell.md
@@ -221,6 +221,28 @@ $ for * { mv $it 1-$it }
 $ for i in $(seq 1 100) { echo $i >> foo }
 ```
 
+##### Infinite Loops
+Infinite loops (as denoted by the keyword `loop`) can be used to repeat a block until the block runs `break`, or the loop terminates by external sources (interrupts, program exit, and terminating signals).
+
+The behaviour regarding SIGINT and other signals is the same as for loops (mentioned above).
+
+###### Examples
+```sh
+# Keep deleting a file
+loop {
+    rm -f foo
+}
+```
+
+###### Examples
+```sh
+# Iterate over every non-hidden file in the current directory, and prepend '1-' to its name.
+$ for * { mv $it 1-$it }
+
+# Iterate over a sequence and write each element to a file
+$ for i in $(seq 1 100) { echo $i >> foo }
+```
+
 ##### Subshells
 Subshells evaluate a given block in a new instance (fork) of the current shell process. to create a subshell, any valid shell code can be enclosed in braces.
 
@@ -299,7 +321,7 @@ sequence :: variable_decls? or_logical_sequence terminator sequence
           | variable_decls? function_decl (terminator sequence)?
           | variable_decls? terminator sequence
 
-function_decl :: identifier '(' (ws* identifier)* ')' ws* '{' toplevel '}'
+function_decl :: identifier '(' (ws* identifier)* ')' ws* '{' [!c] toplevel '}'
 
 or_logical_sequence :: and_logical_sequence '|' '|' and_logical_sequence
                      | and_logical_sequence
@@ -318,12 +340,19 @@ pipe_sequence :: command '|' pipe_sequence
                | control_structure '|' pipe_sequence
                | control_structure
 
-control_structure :: for_expr
-                   | if_expr
-                   | subshell
-                   | match_expr
+control_structure[c] :: for_expr
+                      | loop_expr
+                      | if_expr
+                      | subshell
+                      | match_expr
+                      | ?c: continuation_control
 
-for_expr :: 'for' ws+ (identifier ' '+ 'in' ws*)? expression ws+ '{' toplevel '}'
+continuation_control :: 'break'
+                      | 'continue'
+
+for_expr :: 'for' ws+ (identifier ' '+ 'in' ws*)? expression ws+ '{' [c] toplevel '}'
+
+loop_expr :: 'loop' ws* '{' [c] toplevel '}'
 
 if_expr :: 'if' ws+ or_logical_sequence ws+ '{' toplevel '}' else_clause?
 

--- a/Libraries/LibGUI/ShellSyntaxHighlighter.cpp
+++ b/Libraries/LibGUI/ShellSyntaxHighlighter.cpp
@@ -190,6 +190,13 @@ private:
         auto& span = span_for_node(node);
         span.color = m_palette.syntax_comment();
     }
+    virtual void visit(const AST::ContinuationControl* node) override
+    {
+        NodeVisitor::visit(node);
+
+        auto& span = span_for_node(node);
+        span.color = m_palette.syntax_control_keyword();
+    }
     virtual void visit(const AST::DynamicEvaluate* node) override
     {
         NodeVisitor::visit(node);

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -1978,7 +1978,7 @@ RefPtr<Value> Range::run(RefPtr<Shell> shell)
                     if (start_int.has_value() && end_int.has_value()) {
                         auto start = start_int.value();
                         auto end = end_int.value();
-                        auto step = start > end ? 1 : -1;
+                        auto step = start > end ? -1 : 1;
                         for (int value = start; value != end; value += step)
                             values.append(create<StringValue>(String::number(value)));
                         // Append the range end too, most shells treat this as inclusive.

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -1034,7 +1034,7 @@ RefPtr<Value> ForLoop::run(RefPtr<Shell> shell)
 
         {
             auto frame = shell->push_frame(String::formatted("for ({})", this));
-            shell->set_local_variable(m_variable_name, value);
+            shell->set_local_variable(m_variable_name, value, true);
 
             block_value = m_block->run(shell);
         }
@@ -1587,7 +1587,7 @@ RefPtr<Value> MatchExpr::run(RefPtr<Shell> shell)
 
     auto frame = shell->push_frame(String::formatted("match ({})", this));
     if (!m_expr_name.is_empty())
-        shell->set_local_variable(m_expr_name, value);
+        shell->set_local_variable(m_expr_name, value, true);
 
     for (auto& entry : m_entries) {
         for (auto& option : entry.options) {
@@ -1598,7 +1598,7 @@ RefPtr<Value> MatchExpr::run(RefPtr<Shell> shell)
                         size_t i = 0;
                         for (auto& name : entry.match_names.value()) {
                             if (spans.size() > i)
-                                shell->set_local_variable(name, create<AST::StringValue>(spans[i]));
+                                shell->set_local_variable(name, create<AST::StringValue>(spans[i]), true);
                             ++i;
                         }
                     }

--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -327,6 +327,23 @@ int Shell::builtin_export(int argc, const char** argv)
     return 0;
 }
 
+int Shell::builtin_glob(int argc, const char** argv)
+{
+    Vector<const char*> globs;
+    Core::ArgsParser parser;
+    parser.add_positional_argument(globs, "Globs to resolve", "glob");
+
+    if (!parser.parse(argc, const_cast<char**>(argv), false))
+        return 1;
+
+    for (auto& glob : globs) {
+        for (auto& expanded : expand_globs(glob, cwd))
+            outln("{}", expanded);
+    }
+
+    return 0;
+}
+
 int Shell::builtin_fg(int argc, const char** argv)
 {
     int job_id = -1;

--- a/Shell/Formatter.h
+++ b/Shell/Formatter.h
@@ -64,6 +64,7 @@ private:
     virtual void visit(const AST::CloseFdRedirection*) override;
     virtual void visit(const AST::CommandLiteral*) override;
     virtual void visit(const AST::Comment*) override;
+    virtual void visit(const AST::ContinuationControl*) override;
     virtual void visit(const AST::DynamicEvaluate*) override;
     virtual void visit(const AST::DoubleQuotedString*) override;
     virtual void visit(const AST::Fd2FdRedirection*) override;

--- a/Shell/Forward.h
+++ b/Shell/Forward.h
@@ -47,6 +47,7 @@ class CastToList;
 class CloseFdRedirection;
 class CommandLiteral;
 class Comment;
+class ContinuationControl;
 class DynamicEvaluate;
 class DoubleQuotedString;
 class Fd2FdRedirection;

--- a/Shell/NodeVisitor.cpp
+++ b/Shell/NodeVisitor.cpp
@@ -84,6 +84,10 @@ void NodeVisitor::visit(const AST::Comment*)
 {
 }
 
+void NodeVisitor::visit(const AST::ContinuationControl*)
+{
+}
+
 void NodeVisitor::visit(const AST::DynamicEvaluate* node)
 {
     node->inner()->visit(*this);
@@ -107,7 +111,8 @@ void NodeVisitor::visit(const AST::FunctionDeclaration* node)
 
 void NodeVisitor::visit(const AST::ForLoop* node)
 {
-    node->iterated_expression()->visit(*this);
+    if (node->iterated_expression())
+        node->iterated_expression()->visit(*this);
     if (node->block())
         node->block()->visit(*this);
 }

--- a/Shell/NodeVisitor.h
+++ b/Shell/NodeVisitor.h
@@ -43,6 +43,7 @@ public:
     virtual void visit(const AST::CloseFdRedirection*);
     virtual void visit(const AST::CommandLiteral*);
     virtual void visit(const AST::Comment*);
+    virtual void visit(const AST::ContinuationControl*);
     virtual void visit(const AST::DynamicEvaluate*);
     virtual void visit(const AST::DoubleQuotedString*);
     virtual void visit(const AST::Fd2FdRedirection*);

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -479,7 +479,7 @@ bool Shell::invoke_function(const AST::Command& command, int& retval)
     size_t index = 0;
     for (auto& arg : function.arguments) {
         ++index;
-        set_local_variable(arg, adopt(*new AST::StringValue(command.argv[index])));
+        set_local_variable(arg, adopt(*new AST::StringValue(command.argv[index])), true);
     }
 
     auto argv = command.argv;

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -201,6 +201,31 @@ public:
         ReadLine,
     };
 
+    enum class ShellError {
+        None,
+        InternalControlFlowBreak,
+        InternalControlFlowContinue,
+        EvaluatedSyntaxError,
+        NonExhaustiveMatchRules,
+        InvalidGlobError,
+    };
+
+    void raise_error(ShellError kind, String description)
+    {
+        m_error = kind;
+        m_error_description = move(description);
+    }
+    bool has_error(ShellError err) const { return m_error == err; }
+    const String& error_description() const { return m_error_description; }
+    ShellError take_error()
+    {
+        auto err = m_error;
+        m_error = ShellError::None;
+        m_error_description = {};
+        return err;
+    }
+    void possibly_print_error() const;
+
 #define __ENUMERATE_SHELL_OPTION(name, default_, description) \
     bool name { default_ };
 
@@ -262,6 +287,9 @@ private:
     bool m_is_interactive { true };
     bool m_is_subshell { false };
     bool m_should_reinstall_signal_handlers { true };
+
+    ShellError m_error { ShellError::None };
+    String m_error_description;
 
     bool m_should_format_live { false };
 

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -47,6 +47,7 @@
     __ENUMERATE_SHELL_BUILTIN(pwd)     \
     __ENUMERATE_SHELL_BUILTIN(exit)    \
     __ENUMERATE_SHELL_BUILTIN(export)  \
+    __ENUMERATE_SHELL_BUILTIN(glob)    \
     __ENUMERATE_SHELL_BUILTIN(unset)   \
     __ENUMERATE_SHELL_BUILTIN(history) \
     __ENUMERATE_SHELL_BUILTIN(umask)   \

--- a/Shell/Tests/function.sh
+++ b/Shell/Tests/function.sh
@@ -34,3 +34,8 @@ fn() {
 fn2() { }
 
 test "$(fn foobar)" = "foobar" || echo 'Frames are somehow messed up in nested functions' && exit 1
+
+fn(xfoo) { }
+xfoo=1
+fn 2
+test $xfoo -eq 1 || echo 'Functions overwrite parent scopes' && exit 1

--- a/Shell/Tests/loop.sh
+++ b/Shell/Tests/loop.sh
@@ -4,6 +4,10 @@ singlecommand_ok=yes
 multicommand_ok=yes
 inlineexec_ok=yes
 implicit_ok=yes
+infinite_ok=''
+break_ok=yes
+continue_ok=yes
+break_in_infinite_ok=''
 
 # Full form
  # Empty
@@ -42,9 +46,32 @@ for ((test 1 = 1) (test 2 = 2)) {
     $it || unset implicit_ok
 }
 
+# Infinite loop
+loop {
+    infinite_ok=yes
+    break
+    unset break_ok
+}
+
+# 'Continue'
+for (1 2 3) {
+    continue
+    unset continue_ok
+}
+
+# 'break' in infinite external loop
+for $(yes) {
+    break_in_infinite_ok=yes
+    break
+}
+
 test $singlecommand_ok || echo Fail: Single command inside for body
 test $multicommand_ok || echo Fail: Multiple commands inside for body
 test $inlineexec_ok || echo Fail: Inline Exec
 test $implicit_ok || echo Fail: implicit iter variable
+test $infinite_ok || echo Fail: infinite loop
+test $break_ok || echo Fail: break
+test $continue_ok || echo Fail: continue
+test $break_in_infinite_ok || echo Fail: break from external infinite loop
 
-test "$singlecommand_ok $multicommand_ok $inlineexec_ok $implicit_ok" = "yes yes yes yes" || exit 1
+test "$singlecommand_ok $multicommand_ok $inlineexec_ok $implicit_ok $infinite_ok $break_ok $continue_ok $break_in_infinite_ok" = "yes yes yes yes yes yes yes yes" || exit 1

--- a/Userland/test.cpp
+++ b/Userland/test.cpp
@@ -416,6 +416,7 @@ static OwnPtr<Condition> parse_simple_expression(char* argv[])
         case 's':
             fatal_error("Unsupported operator \033[1m%s", argv[optind]);
         default:
+            --optind;
             break;
         }
     }


### PR DESCRIPTION
This is just the fix-y and useful parts of #4316.
I haven't decided if I like the variable substitutions from that PR yet.

Also gets mad at the user if a glob matches nothing (as discussed in #4607)