### PR TITLE
LibKeyboard+HexEditor: Ignore control keys in text mode

### DIFF
--- a/Applications/HexEditor/HexEditor.cpp
+++ b/Applications/HexEditor/HexEditor.cpp
@@ -447,8 +447,11 @@ void HexEditor::text_mode_keydown_event(GUI::KeyEvent& event)
     ASSERT(m_position >= 0);
     ASSERT(m_position < static_cast<int>(m_buffer.size()));
 
+    if (event.code_point() == 0) // This is a control key
+        return;
+
     m_tracked_changes.set(m_position, m_buffer.data()[m_position]);
-    m_buffer.data()[m_position] = (u8)event.text().characters()[0]; // save the first 4 bits, OR the new value in the last 4
+    m_buffer.data()[m_position] = event.code_point();
     if (m_position + 1 < static_cast<int>(m_buffer.size()))
         m_position++;
     m_byte_position = 0;

--- a/Libraries/LibKeyboard/CharacterMap.cpp
+++ b/Libraries/LibKeyboard/CharacterMap.cpp
@@ -82,6 +82,10 @@ u32 CharacterMap::get_char(KeyEvent event)
     if (event.e0_prefix && event.key == Key_Slash) {
         // If Key_Slash (scancode = 0x35) mapped to other form "/", we fix num pad key of "/" with this case.
         code_point = '/';
+    } else if (event.e0_prefix) {
+        // Except for `keypad-/`, all e0 scan codes are not actually characters. i.e., `keypad-0` and
+        // `Insert` have the same scancode except for the prefix, but insert should not have a code_point.
+        code_point = 0;
     }
 
     return code_point;


### PR DESCRIPTION
Fixes a bug in the HexEditor in which control keys were interpreted as null bytes, and also fixes a bug in LibKeyboard which assigned `code_point`s to e0-prefixed control keys.