### PR TITLE
AK: Make binary_search signature more generic.

### DIFF
--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -32,14 +32,16 @@
 
 namespace AK {
 
-template<typename T>
-constexpr int integral_compare(const typename RemoveConst<T>::Type& a, const typename RemoveConst<T>::Type& b)
-{
-    return a - b;
-}
+struct IntegralComparator {
+    constexpr auto operator()(auto& lhs, auto& rhs) { return lhs - rhs; }
+};
 
-template<typename T, typename Compare>
-constexpr T* binary_search(Span<T> haystack, const typename RemoveConst<T>::Type& needle, Compare compare = integral_compare, size_t* nearby_index = nullptr)
+template<typename Container, typename Needle, typename Comparator = IntegralComparator>
+constexpr auto binary_search(
+    Container&& haystack,
+    Needle&& needle,
+    size_t* nearby_index = nullptr,
+    Comparator comparator = Comparator {}) -> decltype(&haystack[0])
 {
     if (haystack.size() == 0) {
         if (nearby_index)
@@ -51,7 +53,7 @@ constexpr T* binary_search(Span<T> haystack, const typename RemoveConst<T>::Type
     size_t high = haystack.size() - 1;
     while (low <= high) {
         size_t middle = low + ((high - low) / 2);
-        int comparison = compare(needle, haystack[middle]);
+        auto comparison = comparator(needle, haystack[middle]);
         if (comparison < 0)
             if (middle != 0)
                 high = middle - 1;

--- a/Kernel/VM/RangeAllocator.cpp
+++ b/Kernel/VM/RangeAllocator.cpp
@@ -181,10 +181,10 @@ void RangeAllocator::deallocate(Range range)
 
     size_t nearby_index = 0;
     auto* existing_range = binary_search(
-        m_available_ranges.span(), range, [](auto& a, auto& b) {
-            return a.base().get() - b.end().get();
-        },
-        &nearby_index);
+        m_available_ranges.span(),
+        range,
+        &nearby_index,
+        [](auto& a, auto& b) { return a.base().get() - b.end().get(); });
 
     size_t inserted_index = 0;
     if (existing_range) {

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -112,7 +112,7 @@ u32 CanonicalCode::read_symbol(InputBitStream& stream) const
 
         // FIXME: This seems really inefficient, this could be an index into an array instead.
         size_t index;
-        if (AK::binary_search(m_symbol_codes.span(), code_bits, AK::integral_compare<u32>, &index))
+        if (AK::binary_search(m_symbol_codes.span(), code_bits, &index))
             return m_symbol_values[index];
     }
 }

--- a/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -187,12 +187,14 @@ size_t XtermSuggestionDisplay::fit_to_page_boundary(size_t selection_index)
     size_t index = 0;
 
     auto* match = binary_search(
-        m_pages.span(), { selection_index, selection_index }, [](auto& a, auto& b) -> int {
+        m_pages.span(),
+        PageRange { selection_index, selection_index },
+        &index,
+        [](auto& a, auto& b) -> int {
             if (a.start >= b.start && a.start < b.end)
                 return 0;
             return a.start - b.start;
-        },
-        &index);
+        });
 
     if (!match)
         return m_pages.size() - 1;

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -543,9 +543,11 @@ bool Shell::is_runnable(const StringView& name)
     if (access(name.to_string().characters(), X_OK) == 0)
         return true;
 
-    return !!binary_search(cached_path.span(), name.to_string(), [](const String& name, const String& program) -> int {
-        return strcmp(name.characters(), program.characters());
-    });
+    return binary_search(
+        cached_path.span(),
+        name.to_string(),
+        nullptr,
+        [](auto& name, auto& program) { return strcmp(name.characters(), program.characters()); });
 }
 
 int Shell::run_command(const StringView& cmd)
@@ -1143,10 +1145,10 @@ void Shell::add_entry_to_cache(const String& entry)
 {
     size_t index = 0;
     auto match = binary_search(
-        cached_path.span(), entry, [](const String& name, const String& program) -> int {
-            return strcmp(name.characters(), program.characters());
-        },
-        &index);
+        cached_path.span(),
+        entry,
+        &index,
+        [](auto& name, auto& program) { return strcmp(name.characters(), program.characters()); });
 
     if (match)
         return;
@@ -1252,9 +1254,11 @@ Vector<Line::CompletionSuggestion> Shell::complete_path(const String& base, cons
 
 Vector<Line::CompletionSuggestion> Shell::complete_program_name(const String& name, size_t offset)
 {
-    auto match = binary_search(cached_path.span(), name, [](const String& name, const String& program) -> int {
-        return strncmp(name.characters(), program.characters(), name.length());
-    });
+    auto match = binary_search(
+        cached_path.span(),
+        name,
+        nullptr,
+        [](auto& name, auto& program) { return strncmp(name.characters(), program.characters(), name.length()); });
 
     if (!match)
         return complete_path("", name, offset);


### PR DESCRIPTION
There are quite a few template shenanigans here to unpack:

  - The return type depends on the container type and is quite difficult to write down exactly. Here it is deduced by `decltype(haystack[0])` which is a bit of a hack but seems to work reliable.

  - The `container` parameter has the type `Container&&` because we need to accept lvalue and rvalue references here. Same for the `needle` parameter.

  - Previously, the `needle` parameter was deduced from the `container` type and this caused problems with stuff like `NonnullOwnPtr` and `OwnPtr` being different types.

  - Previously, the default value for `compare` did not work because the compiler was not able to deduce the type of `Compare`. Now the default parameter is passed as default template parameter and the default constructor makes this work.
