### PR TITLE
CrashReporter: Tweak width of spacer widget by 1px

### DIFF
--- a/Applications/CrashReporter/CrashReporterWindow.gml
+++ b/Applications/CrashReporter/CrashReporterWindow.gml
@@ -92,7 +92,7 @@
         @GUI::Widget {
             horizontal_size_policy: "Fixed"
             vertical_size_policy: "Fill"
-            preferred_width: 378
+            preferred_width: 377
             preferred_height: 0
         }
 


### PR DESCRIPTION
This prevents the shadow of the close button on its right side being cut off.

Fixes #4635.