### PR TITLE
Shell: Implement a very basic exec builtin

### DIFF
--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -256,6 +256,20 @@ int Shell::builtin_dirs(int argc, const char** argv)
     return 0;
 }
 
+int Shell::builtin_exec(int argc, const char** argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "Shell: No command given to exec\n");
+        return 1;
+    }
+
+    Vector<const char*> argv_vector;
+    argv_vector.append(argv + 1, argc - 1);
+    argv_vector.append(nullptr);
+
+    execute_process(move(argv_vector));
+}
+
 int Shell::builtin_exit(int argc, const char** argv)
 {
     int exit_code = 0;

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -45,6 +45,7 @@
     __ENUMERATE_SHELL_BUILTIN(cd)      \
     __ENUMERATE_SHELL_BUILTIN(cdh)     \
     __ENUMERATE_SHELL_BUILTIN(pwd)     \
+    __ENUMERATE_SHELL_BUILTIN(exec)    \
     __ENUMERATE_SHELL_BUILTIN(exit)    \
     __ENUMERATE_SHELL_BUILTIN(export)  \
     __ENUMERATE_SHELL_BUILTIN(glob)    \
@@ -252,6 +253,8 @@ private:
 
     void run_tail(RefPtr<Job>);
     void run_tail(const AST::Command&, const AST::NodeWithAction&, int head_exit_code);
+
+    [[noreturn]] void execute_process(Vector<const char*>&& argv);
 
     virtual void custom_event(Core::CustomEvent&) override;
 


### PR DESCRIPTION
Other shells also support a number of other options with exec and some have special behaviour when calling exec with no arguments except redirections.

This PR only supports the basic case of replacing the Shell process (or LibShell host process) with the provided command.

This is the `exec` builtin I originally presented in #4498 spun out as a separate PR.