### PR TITLE
AK: Fix a race condition with WeakPtr<T>::strong_ref and destruction

### DIFF
--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -201,16 +201,40 @@ template<typename T>
 template<typename U>
 inline WeakPtr<U> Weakable<T>::make_weak_ptr() const
 {
-#ifdef DEBUG
-    ASSERT(!m_being_destroyed);
-#endif
+    if constexpr (IsBaseOf<RefCountedBase, T>::value) {
+        // Checking m_being_destroyed isn't sufficient when dealing with
+        // a RefCounted type.The reference count will drop to 0 before the
+        // destructor is invoked and revoke_weak_ptrs is called. So, try
+        // to add a ref (which should fail if the ref count is at 0) so
+        // that we prevent the destructor and revoke_weak_ptrs from being
+        // triggered until we're done.
+        if (!static_cast<const T*>(this)->try_ref())
+            return {};
+    } else {
+        // For non-RefCounted types this means a weak reference can be
+        // obtained until the ~Weakable destructor is invoked!
+        if (m_being_destroyed.load(AK::MemoryOrder::memory_order_acquire))
+            return {};
+    }
     if (!m_link) {
         // There is a small chance that we create a new WeakLink and throw
         // it away because another thread beat us to it. But the window is
         // pretty small and the overhead isn't terrible.
         m_link.assign_if_null(adopt(*new WeakLink(const_cast<T&>(static_cast<const T&>(*this)))));
     }
-    return WeakPtr<U>(m_link);
+
+    WeakPtr<U> weak_ptr(m_link);
+
+    if constexpr (IsBaseOf<RefCountedBase, T>::value) {
+        // Now drop the reference we temporarily added
+        if (static_cast<const T*>(this)->unref()) {
+            // We just dropped the last reference, which should have called
+            // revoke_weak_ptrs, which should have invalidated our weak_ptr
+            ASSERT(!weak_ptr.strong_ref());
+            return {};
+        }
+    }
+    return weak_ptr;
 }
 
 template<typename T>

--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -91,7 +91,7 @@ public:
     {
         object.do_while_locked([&](U* obj) {
             if (obj)
-                obj->template make_weak_ptr<U>().take_link();
+                m_link = obj->template make_weak_ptr<U>().take_link();
         });
     }
 
@@ -100,7 +100,7 @@ public:
     {
         object.do_while_locked([&](U* obj) {
             if (obj)
-                obj->template make_weak_ptr<U>().take_link();
+                m_link = obj->template make_weak_ptr<U>().take_link();
         });
     }
 

--- a/AK/Weakable.h
+++ b/AK/Weakable.h
@@ -30,6 +30,7 @@
 #include "Atomic.h"
 #include "RefCounted.h"
 #include "RefPtr.h"
+#include "StdLibExtras.h"
 #ifdef KERNEL
 #    include <Kernel/Arch/i386/CPU.h>
 #endif
@@ -52,7 +53,7 @@ class WeakLink : public RefCounted<WeakLink> {
     friend class WeakPtr;
 
 public:
-    template<typename T, typename PtrTraits = RefPtrTraits<T>>
+    template<typename T, typename PtrTraits = RefPtrTraits<T>, typename EnableIf<IsBaseOf<RefCountedBase, T>::value>::Type* = nullptr>
     RefPtr<T, PtrTraits> strong_ref() const
     {
         RefPtr<T, PtrTraits> ref;

--- a/Libraries/LibGUI/Application.cpp
+++ b/Libraries/LibGUI/Application.cpp
@@ -72,6 +72,11 @@ static NeverDestroyed<WeakPtr<Application>> s_the;
 
 Application* Application::the()
 {
+    // NOTE: If we don't explicitly call revoke_weak_ptrs() in the
+    // ~Application destructor, we would have to change this to
+    // return s_the->strong_ref().ptr();
+    // This is because this is using the unsafe operator*/operator->
+    // that do not have the ability to check the ref count!
     return *s_the;
 }
 


### PR DESCRIPTION
Since RefPtr<T> decrements the ref counter to 0 and after that starts
destructing the object, there is a window where the ref count is 0
and the weak references have not been revoked.

Also change WeakLink to be able to obtain a strong reference
concurrently and block revoking instead, which should happen a lot
less often.

Fixes #4621

@bcoles Does this solve this issue for you? I haven't tested it a whole lot, but I also haven't run into the crash you're seeing.
@bugaevc Memory order review, please? ;-)