### PR TITLE
AK: Add Type trait tests

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -372,6 +372,22 @@ template<>
 struct MakeUnsigned<char> {
     using Type = unsigned char;
 };
+template<>
+struct MakeUnsigned<char8_t> {
+    using Type = char8_t;
+};
+template<>
+struct MakeUnsigned<char16_t> {
+    using Type = char16_t;
+};
+template<>
+struct MakeUnsigned<char32_t> {
+    using Type = char32_t;
+};
+template<>
+struct MakeUnsigned<bool> {
+    using Type = bool;
+};
 
 template<typename T>
 struct MakeSigned {
@@ -469,7 +485,19 @@ template<typename T>
 struct __IsIntegral : FalseType {
 };
 template<>
+struct __IsIntegral<bool> : TrueType {
+};
+template<>
 struct __IsIntegral<unsigned char> : TrueType {
+};
+template<>
+struct __IsIntegral<char8_t> : TrueType {
+};
+template<>
+struct __IsIntegral<char16_t> : TrueType {
+};
+template<>
+struct __IsIntegral<char32_t> : TrueType {
 };
 template<>
 struct __IsIntegral<unsigned short> : TrueType {
@@ -494,6 +522,9 @@ struct __IsFloatingPoint<float> : TrueType {
 };
 template<>
 struct __IsFloatingPoint<double> : TrueType {
+};
+template<>
+struct __IsFloatingPoint<long double> : TrueType {
 };
 template<typename T>
 using IsFloatingPoint = __IsFloatingPoint<typename RemoveCV<T>::Type>;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -511,6 +511,12 @@ constexpr auto DependentFalse = false;
 template<typename T>
 using IsUnsigned = IsSame<T, MakeUnsigned<T>>;
 
+template<typename T>
+using IsArithmetic = IntegralConstant<bool, IsIntegral<T>::value || IsFloatingPoint<T>::value>;
+
+template<typename T>
+using IsFundamental = IntegralConstant<bool, IsArithmetic<T>::value || IsVoid<T>::value || IsNullPointer<T>::value>;
+
 }
 
 using AK::AddConst;
@@ -524,9 +530,12 @@ using AK::exchange;
 using AK::forward;
 using AK::is_trivial;
 using AK::is_trivially_copyable;
+using AK::IsArithmetic;
 using AK::IsBaseOf;
 using AK::IsClass;
 using AK::IsConst;
+using AK::IsFundamental;
+using AK::IsNullPointer;
 using AK::IsSame;
 using AK::IsUnion;
 using AK::IsVoid;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -517,6 +517,30 @@ using IsArithmetic = IntegralConstant<bool, IsIntegral<T>::value || IsFloatingPo
 template<typename T>
 using IsFundamental = IntegralConstant<bool, IsArithmetic<T>::value || IsVoid<T>::value || IsNullPointer<T>::value>;
 
+template<typename T, T... Ts>
+struct IntegerSequence {
+    using Type = T;
+    static constexpr unsigned size() noexcept { return sizeof...(Ts); };
+};
+
+template<unsigned... Indices>
+using IndexSequence = IntegerSequence<unsigned, Indices...>;
+
+template<typename T, T N, T... Ts>
+auto make_integer_sequence_impl()
+{
+    if constexpr (N == 0)
+        return IntegerSequence<T, Ts...> {};
+    else
+        return make_integer_sequence_impl<T, N - 1, N - 1, Ts...>();
+}
+
+template<typename T, T N>
+using MakeIntegerSequence = decltype(make_integer_sequence_impl<T, N>());
+
+template<unsigned N>
+using MakeIndexSequence = MakeIntegerSequence<unsigned, N>;
+
 }
 
 using AK::AddConst;
@@ -528,6 +552,8 @@ using AK::declval;
 using AK::DependentFalse;
 using AK::exchange;
 using AK::forward;
+using AK::IndexSequence;
+using AK::IntegerSequence;
 using AK::is_trivial;
 using AK::is_trivially_copyable;
 using AK::IsArithmetic;
@@ -539,6 +565,8 @@ using AK::IsNullPointer;
 using AK::IsSame;
 using AK::IsUnion;
 using AK::IsVoid;
+using AK::MakeIndexSequence;
+using AK::MakeIntegerSequence;
 using AK::MakeSigned;
 using AK::MakeUnsigned;
 using AK::max;

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -239,21 +239,6 @@ template Optional<u16> String::to_uint() const;
 template Optional<u32> String::to_uint() const;
 template Optional<u64> String::to_uint() const;
 
-template<typename T>
-String String::number(T value) { return formatted("{}", value); }
-
-template String String::number(unsigned char);
-template String String::number(unsigned short);
-template String String::number(unsigned int);
-template String String::number(unsigned long);
-template String String::number(unsigned long long);
-template String String::number(char);
-template String String::number(short);
-template String String::number(int);
-template String String::number(long);
-template String String::number(long long);
-template String String::number(signed char);
-
 String String::format(const char* fmt, ...)
 {
     StringBuilder builder;

--- a/AK/String.h
+++ b/AK/String.h
@@ -252,8 +252,8 @@ public:
         return vformatted(fmtstr, VariadicFormatParams { parameters... });
     }
 
-    template<typename T>
-    static String number(T);
+    template<typename T, typename EnableIf<IsArithmetic<T>::value>::Type* = nullptr>
+    static String number(T value) { return formatted("{}", value); }
 
     StringView view() const;
 

--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(AK_TEST_SOURCES
     TestFormat.cpp
     TestHashFunctions.cpp
     TestHashMap.cpp
+    TestIndexSequence.cpp
     TestIPv4Address.cpp
     TestJSON.cpp
     TestLexicalPath.cpp
@@ -35,6 +36,7 @@ set(AK_TEST_SOURCES
     TestStringView.cpp
     TestTrie.cpp
     TestTypedTransfer.cpp
+    TestTypeTraits.cpp
     TestURL.cpp
     TestUtf8.cpp
     TestVector.cpp

--- a/AK/Tests/TestIndexSequence.cpp
+++ b/AK/Tests/TestIndexSequence.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/StdLibExtras.h>
+#include <AK/TestSuite.h>
+#include <AK/TypeList.h>
+
+template<typename F, typename... Args>
+F for_each_argument(F f, Args&&... args)
+{
+    (f(forward<Args>(args)), ...);
+    return f;
+}
+
+template<typename T, T... ints>
+void verify_sequence(IntegerSequence<T, ints...> seq, std::initializer_list<T> expected)
+{
+    EXPECT_EQ(seq.size(), expected.size());
+    for_each_argument([idx = expected.begin()](T t) mutable { EXPECT_EQ(t, *(idx++)); }, ints...);
+}
+
+TEST_CASE(TestIndexSequence)
+{
+    constexpr auto integer_seq1 = IntegerSequence<int, 0, 1, 2, 3, 4> {};
+    constexpr auto integer_seq2 = MakeIntegerSequence<int, 5> {};
+    static_assert(IsSame<decltype(integer_seq1), decltype(integer_seq2)>::value, "");
+
+    static_assert(integer_seq1.size() == 5, "");
+    static_assert(integer_seq2.size() == 5, "");
+
+    constexpr auto index_seq1 = IndexSequence<0, 1, 2> {};
+    constexpr auto index_seq2 = MakeIndexSequence<3> {};
+    static_assert(IsSame<decltype(index_seq1), decltype(index_seq2)>::value, "");
+
+    verify_sequence(MakeIndexSequence<10> {}, std::initializer_list<unsigned> { 0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 9U });
+    verify_sequence(MakeIntegerSequence<long, 16> {}, std::initializer_list<long> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
+}
+
+TEST_CASE(TypeList)
+{
+    using MyTypes = TypeList<int, bool, char>;
+    static_assert(IsSame<MyTypes::Type<0>, int>::value, "");
+    static_assert(IsSame<MyTypes::Type<1>, bool>::value, "");
+    static_assert(IsSame<MyTypes::Type<2>, char>::value, "");
+}
+
+TEST_MAIN(IndexSequence);

--- a/AK/Tests/TestTrie.cpp
+++ b/AK/Tests/TestTrie.cpp
@@ -87,4 +87,4 @@ TEST_CASE(iterate)
     }
 }
 
-TEST_MAIN(AllOf)
+TEST_MAIN(Trie)

--- a/AK/Tests/TestTypeTraits.cpp
+++ b/AK/Tests/TestTypeTraits.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/StdLibExtras.h>
+#include <AK/TestSuite.h>
+#include <AK/TypeList.h>
+
+#define STATIC_EXPECT_EQ(lhs, rhs) \
+    static_assert(IsSame<lhs, rhs>::value, "");
+
+#define STATIC_EXPECT_FALSE(Expression) \
+    static_assert(!Expression::value, "");
+
+#define STATIC_EXPECT_TRUE(Expression) \
+    static_assert(Expression::value, "");
+
+#define EXPECT_TRAIT_TRUE(trait, ...)                                     \
+    for_each_type<TypeList<__VA_ARGS__>>([]<typename T>(TypeWrapper<T>) { \
+        STATIC_EXPECT_TRUE(trait<T>);                                     \
+    })
+
+#define EXPECT_TRAIT_FALSE(trait, ...)                                    \
+    for_each_type<TypeList<__VA_ARGS__>>([]<typename T>(TypeWrapper<T>) { \
+        STATIC_EXPECT_FALSE(trait<T>);                                    \
+    })
+
+#define EXPECT_EQ_WITH_TRAIT(trait, ListA, ListB)                                                   \
+    for_each_type_zipped<ListA, ListB>([]<typename A, typename B>(TypeWrapper<A>, TypeWrapper<B>) { \
+        STATIC_EXPECT_EQ(typename trait<A>::Type, B);                                               \
+    })
+
+struct Empty {
+};
+
+TEST_CASE(FundamentalTypeClassification)
+{
+    EXPECT_TRAIT_TRUE(IsVoid, void);
+    EXPECT_TRAIT_FALSE(IsVoid, int, Empty, nullptr_t);
+
+    EXPECT_TRAIT_TRUE(IsNullPointer, std::nullptr_t);
+    EXPECT_TRAIT_FALSE(IsNullPointer, void, int, Empty, decltype(0));
+
+    EXPECT_TRAIT_TRUE(IsFloatingPoint, float, double, long double);
+    EXPECT_TRAIT_FALSE(IsFloatingPoint, int, Empty, std::nullptr_t, void);
+
+    EXPECT_TRAIT_TRUE(IsArithmetic, float, double, long double, bool, size_t);
+    EXPECT_TRAIT_TRUE(IsArithmetic, char, signed char, unsigned char, char8_t, char16_t, char32_t);
+    EXPECT_TRAIT_TRUE(IsArithmetic, short, int, long, long long);
+    EXPECT_TRAIT_TRUE(IsArithmetic, unsigned short, unsigned int, unsigned long, unsigned long long);
+
+    EXPECT_TRAIT_FALSE(IsArithmetic, void, std::nullptr_t, Empty);
+
+    EXPECT_TRAIT_TRUE(IsFundamental, void, std::nullptr_t);
+    EXPECT_TRAIT_TRUE(IsFundamental, float, double, long double, bool, size_t);
+    EXPECT_TRAIT_TRUE(IsFundamental, char, signed char, unsigned char, char8_t, char16_t, char32_t);
+    EXPECT_TRAIT_TRUE(IsFundamental, short, int, long, long long);
+    EXPECT_TRAIT_TRUE(IsFundamental, unsigned short, unsigned int, unsigned long, unsigned long long);
+
+    EXPECT_TRAIT_FALSE(IsFundamental, Empty, int*, int&);
+}
+
+TEST_CASE(AddConst)
+{
+    // clang-format off
+    using NoConstList =  TypeList<int,       const int, Empty,       const Empty>;
+    using YesConstList = TypeList<const int, const int, const Empty, const Empty>;
+    // clang-format on
+
+    EXPECT_EQ_WITH_TRAIT(AddConst, NoConstList, YesConstList);
+}
+
+TEST_MAIN(TypeTraits)

--- a/AK/TypeList.h
+++ b/AK/TypeList.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/StdLibExtras.h>
+
+namespace AK {
+
+template<typename... Types>
+struct TypeList;
+
+template<unsigned Index, typename List>
+struct TypeListElement;
+
+template<unsigned Index, typename Head, typename... Tail>
+struct TypeListElement<Index, TypeList<Head, Tail...>>
+    : TypeListElement<Index - 1, TypeList<Tail...>> {
+};
+
+template<typename Head, typename... Tail>
+struct TypeListElement<0, TypeList<Head, Tail...>> {
+    using Type = Head;
+};
+
+template<typename... Types>
+struct TypeList {
+    static constexpr unsigned size = sizeof...(Types);
+
+    template<unsigned N>
+    using Type = typename TypeListElement<N, TypeList<Types...>>::Type;
+};
+
+template<typename T>
+struct TypeWrapper {
+    using Type = T;
+};
+
+template<typename List, typename F, unsigned... Indexes>
+constexpr void for_each_type_impl(F&& f, IndexSequence<Indexes...>)
+{
+    (forward<F>(f)(TypeWrapper<typename List::Type<Indexes>> {}), ...);
+}
+
+template<typename List, typename F>
+constexpr void for_each_type(F&& f)
+{
+    for_each_type_impl<List>(forward<F>(f), MakeIndexSequence<List::size> {});
+}
+
+template<typename ListA, typename ListB, typename F, unsigned... Indexes>
+constexpr void for_each_type_zipped_impl(F&& f, IndexSequence<Indexes...>)
+{
+    (forward<F>(f)(TypeWrapper<typename ListA::Type<Indexes>> {}, TypeWrapper<typename ListB::Type<Indexes>> {}), ...);
+}
+
+template<typename ListA, typename ListB, typename F>
+constexpr void for_each_type_zipped(F&& f)
+{
+    static_assert(ListA::size == ListB::size, "Can't zip TypeLists that aren't the same size!");
+    for_each_type_zipped_impl<ListA, ListB>(forward<F>(f), MakeIndexSequence<ListA::size> {});
+}
+
+}
+
+using AK::for_each_type;
+using AK::for_each_type_zipped;
+using AK::TypeList;
+using AK::TypeListElement;
+using AK::TypeWrapper;


### PR DESCRIPTION
Add some tests for type traits.

I think I had a bit too much fun with the metaprogramming.

But! Now there's a reasonable way to test all those type traits in AK/StdLibExtras.h. And, if someone wants, AK::TypeList would make a decent starting point for an AK::Tuple :eyes: