### PR TITLE
AK: Replace some SFINAE with requires clauses, clean up existing ones

### DIFF
--- a/AK/Stream.h
+++ b/AK/Stream.h
@@ -147,14 +147,14 @@ InputStream& operator>>(InputStream& stream, Optional<T>& value)
     return stream;
 }
 
-template<typename Integral, typename EnableIf<IsIntegral<Integral>::value, int>::Type = 0>
-InputStream& operator>>(InputStream& stream, Integral& value)
+template<typename Integral>
+InputStream& operator>>(InputStream& stream, Integral& value) requires IsIntegral<Integral>::value
 {
     stream.read_or_error({ &value, sizeof(value) });
     return stream;
 }
-template<typename Integral, typename EnableIf<IsIntegral<Integral>::value, int>::Type = 0>
-OutputStream& operator<<(OutputStream& stream, Integral value)
+template<typename Integral>
+OutputStream& operator<<(OutputStream& stream, Integral value) requires IsIntegral<Integral>::value
 {
     stream.write_or_error({ &value, sizeof(value) });
     return stream;
@@ -162,30 +162,19 @@ OutputStream& operator<<(OutputStream& stream, Integral value)
 
 #ifndef KERNEL
 
-template<typename FloatingPoint, typename EnableIf<IsFloatingPoint<FloatingPoint>::value, int>::Type = 0>
-InputStream& operator>>(InputStream& stream, FloatingPoint& value)
+template<typename FloatingPoint>
+InputStream& operator>>(InputStream& stream, FloatingPoint& value) requires IsFloatingPoint<FloatingPoint>::value
 {
     stream.read_or_error({ &value, sizeof(value) });
     return stream;
 }
-template<typename FloatingPoint, typename EnableIf<IsFloatingPoint<FloatingPoint>::value, int>::Type = 0>
-OutputStream& operator<<(OutputStream& stream, FloatingPoint value)
+template<typename FloatingPoint>
+OutputStream& operator<<(OutputStream& stream, FloatingPoint value) requires IsFloatingPoint<FloatingPoint>::value
 {
     stream.write_or_error({ &value, sizeof(value) });
     return stream;
 }
 
 #endif
-
-inline InputStream& operator>>(InputStream& stream, bool& value)
-{
-    stream.read_or_error({ &value, sizeof(value) });
-    return stream;
-}
-inline OutputStream& operator<<(OutputStream& stream, bool value)
-{
-    stream.write_or_error({ &value, sizeof(value) });
-    return stream;
-}
 
 }

--- a/AK/String.h
+++ b/AK/String.h
@@ -252,8 +252,8 @@ public:
         return vformatted(fmtstr, VariadicFormatParams { parameters... });
     }
 
-    template<typename T, typename EnableIf<IsArithmetic<T>::value>::Type* = nullptr>
-    static String number(T value) { return formatted("{}", value); }
+    template<typename T>
+    static String number(T value) requires IsArithmetic<T>::value { return formatted("{}", value); }
 
     StringView view() const;
 

--- a/AK/Tests/TestMemoryStream.cpp
+++ b/AK/Tests/TestMemoryStream.cpp
@@ -54,6 +54,28 @@ TEST_CASE(read_an_integer)
     EXPECT_EQ(expected, actual);
 }
 
+TEST_CASE(read_a_bool)
+{
+    bool expected = true, actual;
+
+    InputMemoryStream stream { { &expected, sizeof(expected) } };
+    stream >> actual;
+
+    EXPECT(!stream.has_any_error() && stream.eof());
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_CASE(read_a_double)
+{
+    double expected = 3.141592653589793, actual;
+
+    InputMemoryStream stream { { &expected, sizeof(expected) } };
+    stream >> actual;
+
+    EXPECT(!stream.has_any_error() && stream.eof());
+    EXPECT_EQ(expected, actual);
+}
+
 TEST_CASE(recoverable_error)
 {
     u32 expected = 0x01020304, actual = 0;

--- a/AK/Trie.h
+++ b/AK/Trie.h
@@ -140,9 +140,9 @@ public:
         return const_cast<Trie*>(this)->traverse_until_last_accessible_node(it, end);
     }
 
-    Optional<MetadataType> metadata() const requires(!IsSame<MetadataType, decltype(nullptr)>::value) { return m_metadata; }
-    void set_metadata(MetadataType metadata) requires(!IsSame<MetadataType, decltype(nullptr)>::value) { m_metadata = move(metadata); }
-    const MetadataType& metadata_value() const requires(!IsSame<MetadataType, decltype(nullptr)>::value) { return m_metadata.value(); }
+    Optional<MetadataType> metadata() const requires(!IsNullPointer<MetadataType>::value) { return m_metadata; }
+    void set_metadata(MetadataType metadata) requires(!IsNullPointer<MetadataType>::value) { m_metadata = move(metadata); }
+    const MetadataType& metadata_value() const requires(!IsNullPointer<MetadataType>::value) { return m_metadata.value(); }
 
     const ValueType& value() const { return m_value; }
     ValueType& value() { return m_value; }
@@ -165,7 +165,7 @@ public:
 
     template<typename It, typename ProvideMetadataFunction>
     BaseType& insert(
-        It& it, const It& end, MetadataType metadata, ProvideMetadataFunction provide_missing_metadata) requires(!IsSame<MetadataType, decltype(nullptr)>::value)
+        It& it, const It& end, MetadataType metadata, ProvideMetadataFunction provide_missing_metadata) requires(!IsNullPointer<MetadataType>::value)
     {
         Trie* last_root_node = &traverse_until_last_accessible_node(it, end);
         for (; it != end; ++it)
@@ -175,7 +175,7 @@ public:
     }
 
     template<typename It>
-    BaseType& insert(It& it, const It& end) requires(IsSame<MetadataType, decltype(nullptr)>::value)
+    BaseType& insert(It& it, const It& end) requires(IsNullPointer<MetadataType>::value)
     {
         Trie* last_root_node = &traverse_until_last_accessible_node(it, end);
         for (; it != end; ++it)
@@ -185,14 +185,14 @@ public:
 
     template<typename It, typename ProvideMetadataFunction>
     BaseType& insert(
-        const It& begin, const It& end, MetadataType metadata, ProvideMetadataFunction provide_missing_metadata) requires(!IsSame<MetadataType, decltype(nullptr)>::value)
+        const It& begin, const It& end, MetadataType metadata, ProvideMetadataFunction provide_missing_metadata) requires(!IsNullPointer<MetadataType>::value)
     {
         auto it = begin;
         return insert(it, end, move(metadata), move(provide_missing_metadata));
     }
 
     template<typename It>
-    BaseType& insert(const It& begin, const It& end) requires(IsSame<MetadataType, decltype(nullptr)>::value)
+    BaseType& insert(const It& begin, const It& end) requires(IsNullPointer<MetadataType>::value)
     {
         auto it = begin;
         return insert(it, end);
@@ -231,7 +231,7 @@ public:
     using DetailTrie = Detail::Trie<BaseT, Trie<ValueType, MetadataT, ValueTraits>, ValueType, MetadataT, ValueTraits>;
     using MetadataType = typename DetailTrie::MetadataType;
 
-    Trie(ValueType value, MetadataType metadata) requires(!IsSame<MetadataType, void>::value && !IsSame<MetadataType, decltype(nullptr)>::value)
+    Trie(ValueType value, MetadataType metadata) requires(!IsVoid<MetadataType>::value && !IsNullPointer<MetadataType>::value)
         : DetailTrie(move(value), move(metadata))
     {
     }


### PR DESCRIPTION
Add requires clauses to constraints on InputStream and OutputStream
operator<< / operator>>. Make the constraint on String::number a
requires clause instead of SFINAE. Also, fix some unnecessary IsSame in
Trie where specialized traits exist for the given use cases.

@alimpfard `IsSame<T, decltype(nullptr)>` is a weird way to spell `IsNullPtr<T>` 😉 

Pretty much all of these specific use cases scream "this should use a concept instead of a requires clause". Probably need `clang-format-12` for that to not make a mess of things, though.