### PR TITLE
Store executable path and PID in coredumps

### DIFF
--- a/Applications/CrashReporter/main.cpp
+++ b/Applications/CrashReporter/main.cpp
@@ -62,6 +62,7 @@ int main(int argc, char** argv)
 
     Optional<CoreDump::Backtrace> backtrace;
     String executable_path;
+    int pid { 0 };
 
     {
         auto coredump = CoreDump::Reader::create(coredump_path);
@@ -72,6 +73,7 @@ int main(int argc, char** argv)
         auto& process_info = coredump->process_info();
         backtrace = coredump->backtrace();
         executable_path = String(process_info.executable_path);
+        pid = process_info.pid;
     }
 
     auto app = GUI::Application::construct(argc, argv);
@@ -122,7 +124,7 @@ int main(int argc, char** argv)
         app_name = af->name();
 
     auto& description_label = static_cast<GUI::Label&>(*widget.find_descendant_by_name("description"));
-    description_label.set_text(String::formatted("\"{}\" has crashed!", app_name));
+    description_label.set_text(String::formatted("\"{}\" (PID {}) has crashed!", app_name, pid));
 
     auto& executable_link_label = static_cast<GUI::LinkLabel&>(*widget.find_descendant_by_name("executable_link"));
     executable_link_label.set_text(LexicalPath::canonicalized_path(executable_path));

--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -208,6 +208,24 @@ KResult CoreDump::write_notes_segment(ByteBuffer& notes_segment)
     return KSuccess;
 }
 
+ByteBuffer CoreDump::create_notes_process_data() const
+{
+    ByteBuffer process_data;
+
+    ELF::Core::ProcessInfo info {};
+    info.header.type = ELF::Core::NotesEntryHeader::Type::ProcessInfo;
+    info.pid = m_process->pid().value();
+
+    process_data.append((void*)&info, sizeof(info));
+
+    auto executable_path = String::empty();
+    if (auto executable = m_process->executable())
+        executable_path = executable->absolute_path();
+    process_data.append(executable_path.characters(), executable_path.length() + 1);
+
+    return process_data;
+}
+
 ByteBuffer CoreDump::create_notes_threads_data() const
 {
     ByteBuffer threads_data;
@@ -259,6 +277,7 @@ ByteBuffer CoreDump::create_notes_segment_data() const
 {
     ByteBuffer notes_buffer;
 
+    notes_buffer += create_notes_process_data();
     notes_buffer += create_notes_threads_data();
     notes_buffer += create_notes_regions_data();
 

--- a/Kernel/CoreDump.h
+++ b/Kernel/CoreDump.h
@@ -54,6 +54,7 @@ private:
     [[nodiscard]] KResult write_notes_segment(ByteBuffer&);
 
     ByteBuffer create_notes_segment_data() const;
+    ByteBuffer create_notes_process_data() const;
     ByteBuffer create_notes_threads_data() const;
     ByteBuffer create_notes_regions_data() const;
 

--- a/Libraries/LibCoreDump/Reader.h
+++ b/Libraries/LibCoreDump/Reader.h
@@ -44,6 +44,8 @@ public:
 
     Reader(OwnPtr<MappedFile>&&);
 
+    const ELF::Core::ProcessInfo& process_info() const;
+
     template<typename Func>
     void for_each_memory_region_info(Func func) const;
 

--- a/Libraries/LibELF/CoreDump.h
+++ b/Libraries/LibELF/CoreDump.h
@@ -36,6 +36,7 @@ struct [[gnu::packed]] NotesEntryHeader
 {
     enum Type : u8 {
         Null = 0, // Terminates segment
+        ProcessInfo,
         ThreadInfo,
         MemoryRegionInfo,
     };
@@ -46,6 +47,13 @@ struct [[gnu::packed]] NotesEntry
 {
     NotesEntryHeader header;
     char data[];
+};
+
+struct [[gnu::packed]] ProcessInfo
+{
+    NotesEntryHeader header;
+    int pid;
+    char executable_path[]; // Null terminated
 };
 
 struct [[gnu::packed]] ThreadInfo


### PR DESCRIPTION
This is a new NotesEntry type which contains information related to the coredump's process:

- PID
- executable path

Having these in the coredump explicitly avoids having to parse them from the coredump filename and backtrace (which sometimes fails, see #4645), respectively.

Also show the PID in CrashReporter.

![image](https://user-images.githubusercontent.com/19366641/103355178-ec593900-4aad-11eb-8a48-597f9a77e740.png)
