### PR TITLE
Allow arbitrary metadata in coredumps, use it to store assertion messages

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -196,7 +196,8 @@ namespace Kernel {
     S(adjtime)                \
     S(allocate_tls)           \
     S(prctl)                  \
-    S(mremap)
+    S(mremap)                 \
+    S(set_coredump_metadata)
 
 namespace Syscall {
 
@@ -440,6 +441,11 @@ struct SC_ptrace_params {
 struct SC_ptrace_peek_params {
     const u32* address;
     u32* out_data;
+};
+
+struct SC_set_coredump_metadata_params {
+    StringArgument key;
+    StringArgument value;
 };
 
 void initialize();

--- a/Kernel/CoreDump.h
+++ b/Kernel/CoreDump.h
@@ -57,6 +57,7 @@ private:
     ByteBuffer create_notes_process_data() const;
     ByteBuffer create_notes_threads_data() const;
     ByteBuffer create_notes_regions_data() const;
+    ByteBuffer create_notes_metadata_data() const;
 
     NonnullRefPtr<Process> m_process;
     NonnullRefPtr<FileDescription> m_fd;

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -363,6 +363,7 @@ public:
     int sys$disown(ProcessID);
     void* sys$allocate_tls(size_t);
     int sys$prctl(int option, FlatPtr arg1, FlatPtr arg2);
+    int sys$set_coredump_metadata(Userspace<const Syscall::SC_set_coredump_metadata_params*>);
 
     template<bool sockname, typename Params>
     int get_sock_or_peer_name(const Params&);
@@ -499,6 +500,8 @@ public:
     void disowned_by_waiter(Process& process);
     void unblock_waiters(Thread::WaitBlocker::UnblockFlags, u8 signal = 0);
     Thread::WaitBlockCondition& wait_block_condition() { return m_wait_block_condition; }
+
+    const HashMap<String, String>& coredump_metadata() const { return m_coredump_metadata; }
 
 private:
     friend class MemoryManager;
@@ -644,6 +647,8 @@ private:
     bool m_wait_for_tracer_at_next_execve { false };
 
     Thread::WaitBlockCondition m_wait_block_condition;
+
+    HashMap<String, String> m_coredump_metadata;
 };
 
 extern InlineLinkedList<Process>* g_processes;

--- a/Libraries/LibC/assert.cpp
+++ b/Libraries/LibC/assert.cpp
@@ -24,9 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <Kernel/API/Syscall.h>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/internals.h>
 #include <unistd.h>
 
@@ -39,6 +41,13 @@ void __assertion_failed(const char* msg)
     dbgprintf("USERSPACE(%d) ASSERTION FAILED: %s\n", getpid(), msg);
     if (__stdio_is_initialized)
         fprintf(stderr, "ASSERTION FAILED: %s\n", msg);
+
+    Syscall::SC_set_coredump_metadata_params params {
+        { "assertion", strlen("assertion") },
+        { msg, strlen(msg) },
+    };
+    syscall(SC_set_coredump_metadata, &params);
+
     abort();
 }
 #endif

--- a/Libraries/LibCoreDump/Reader.h
+++ b/Libraries/LibCoreDump/Reader.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <AK/MappedFile.h>
 #include <AK/Noncopyable.h>
 #include <AK/OwnPtr.h>
@@ -57,7 +58,8 @@ public:
     Optional<uint32_t> peek_memory(FlatPtr address) const;
     const ELF::Core::MemoryRegionInfo* region_containing(FlatPtr address) const;
 
-    Backtrace backtrace() const;
+    const Backtrace backtrace() const;
+    const HashMap<String, String> metadata() const;
 
 private:
     class NotesEntryIterator {

--- a/Libraries/LibELF/CoreDump.h
+++ b/Libraries/LibELF/CoreDump.h
@@ -39,6 +39,7 @@ struct [[gnu::packed]] NotesEntryHeader
         ProcessInfo,
         ThreadInfo,
         MemoryRegionInfo,
+        Metadata,
     };
     Type type;
 };
@@ -80,6 +81,12 @@ struct [[gnu::packed]] MemoryRegionInfo
             return {};
         return memory_region_name.substring_view(0, memory_region_name.find_first_of(":").value()).to_string();
     }
+};
+
+struct [[gnu::packed]] Metadata
+{
+    NotesEntryHeader header;
+    char json_data[]; // Null terminated
 };
 
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19366641/103357244-fc274c00-4ab2-11eb-9c3d-14f5584bf337.png)

---

This is the first time I'm working on the Kernel & syscalls, so bear with me :)