### PR TITLE
AK+Format: Remove TypeErasedFormatParams& from format function.

### DIFF
--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -263,9 +263,9 @@ private:
 
 template<>
 struct Formatter<JsonValue> : Formatter<StringView> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const JsonValue& value)
+    void format(FormatBuilder& builder, const JsonValue& value)
     {
-        Formatter<StringView>::format(params, builder, value.to_string());
+        Formatter<StringView>::format(builder, value.to_string());
     }
 };
 

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -66,9 +66,9 @@ private:
 
 template<>
 struct Formatter<LexicalPath> : Formatter<StringView> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const LexicalPath& value)
+    void format(FormatBuilder& builder, const LexicalPath& value)
     {
-        Formatter<StringView>::format(params, builder, value.string());
+        Formatter<StringView>::format(builder, value.string());
     }
 };
 

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -197,9 +197,9 @@ inline void swap(NonnullOwnPtr<T>& a, NonnullOwnPtr<U>& b)
 
 template<typename T>
 struct Formatter<NonnullOwnPtr<T>> : Formatter<const T*> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const NonnullOwnPtr<T>& value)
+    void format(FormatBuilder& builder, const NonnullOwnPtr<T>& value)
     {
-        Formatter<const T*>::format(params, builder, value.ptr());
+        Formatter<const T*>::format(builder, value.ptr());
     }
 };
 

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -348,9 +348,9 @@ inline const LogStream& operator<<(const LogStream& stream, const NonnullRefPtr<
 
 template<typename T>
 struct Formatter<NonnullRefPtr<T>> : Formatter<const T*> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const NonnullRefPtr<T>& value)
+    void format(FormatBuilder& builder, const NonnullRefPtr<T>& value)
     {
-        Formatter<const T*>::format(params, builder, value.ptr());
+        Formatter<const T*>::format(builder, value.ptr());
     }
 };
 

--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -132,9 +132,9 @@ constexpr u32 string_hash(const char* characters, size_t length)
 
 template<>
 struct Formatter<StringImpl> : Formatter<StringView> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const StringImpl& value)
+    void format(FormatBuilder& builder, const StringImpl& value)
     {
-        Formatter<StringView>::format(params, builder, { value.characters(), value.length() });
+        Formatter<StringView>::format(builder, { value.characters(), value.length() });
     }
 };
 

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -213,9 +213,9 @@ struct B {
 };
 template<>
 struct AK::Formatter<B> : Formatter<StringView> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, B)
+    void format(FormatBuilder& builder, B)
     {
-        Formatter<StringView>::format(params, builder, "B");
+        Formatter<StringView>::format(builder, "B");
     }
 };
 

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -106,9 +106,9 @@ inline const LogStream& operator<<(const LogStream& stream, const URL& value)
 
 template<>
 struct Formatter<URL> : Formatter<StringView> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const URL& value)
+    void format(FormatBuilder& builder, const URL& value)
     {
-        Formatter<StringView>::format(params, builder, value.to_string());
+        Formatter<StringView>::format(builder, value.to_string());
     }
 };
 

--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -226,13 +226,13 @@ inline const LogStream& operator<<(const LogStream& stream, const WeakPtr<T>& va
 
 template<typename T>
 struct Formatter<WeakPtr<T>> : Formatter<const T*> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const WeakPtr<T>& value)
+    void format(FormatBuilder& builder, const WeakPtr<T>& value)
     {
 #ifdef KERNEL
         auto ref = value.strong_ref();
-        Formatter<const T*>::format(params, builder, ref.ptr());
+        Formatter<const T*>::format(builder, ref.ptr());
 #else
-        Formatter<const T*>::format(params, builder, value.ptr());
+        Formatter<const T*>::format(builder, value.ptr());
 #endif
     }
 };

--- a/DevTools/UserspaceEmulator/ValueWithShadow.h
+++ b/DevTools/UserspaceEmulator/ValueWithShadow.h
@@ -164,8 +164,8 @@ inline void ValueAndShadowReference<T>::operator=(const ValueWithShadow<T>& othe
 
 template<typename T>
 struct AK::Formatter<UserspaceEmulator::ValueWithShadow<T>> : AK::Formatter<T> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, UserspaceEmulator::ValueWithShadow<T> value)
+    void format(FormatBuilder& builder, UserspaceEmulator::ValueWithShadow<T> value)
     {
-        return Formatter<T>::format(params, builder, value.value());
+        return Formatter<T>::format(builder, value.value());
     }
 };

--- a/Kernel/VirtualAddress.cpp
+++ b/Kernel/VirtualAddress.cpp
@@ -28,9 +28,9 @@
 #include <Kernel/VirtualAddress.h>
 
 namespace AK {
-void Formatter<VirtualAddress>::format(TypeErasedFormatParams& params, FormatBuilder& builder, const VirtualAddress& value)
+void Formatter<VirtualAddress>::format(FormatBuilder& builder, const VirtualAddress& value)
 {
-    Formatter<StringView>::format(params, builder, String::formatted("V{:p}", value.get()));
+    Formatter<StringView>::format(builder, String::formatted("V{:p}", value.get()));
 }
 
 }

--- a/Kernel/VirtualAddress.h
+++ b/Kernel/VirtualAddress.h
@@ -77,8 +77,10 @@ inline const LogStream& operator<<(const LogStream& stream, VirtualAddress value
 }
 
 namespace AK {
+
 template<>
 struct Formatter<VirtualAddress> : Formatter<StringView> {
-    void format(TypeErasedFormatParams&, FormatBuilder&, const VirtualAddress&);
+    void format(FormatBuilder&, const VirtualAddress&);
 };
+
 }

--- a/Libraries/LibCore/Object.cpp
+++ b/Libraries/LibCore/Object.cpp
@@ -273,9 +273,9 @@ const LogStream& operator<<(const LogStream& stream, const Object& object)
 
 namespace AK {
 
-void Formatter<Core::Object>::format(TypeErasedFormatParams& params, FormatBuilder& builder, const Core::Object& value)
+void Formatter<Core::Object>::format(FormatBuilder& builder, const Core::Object& value)
 {
-    Formatter<StringView>::format(params, builder, String::formatted("{}({})", value.class_name(), &value));
+    Formatter<StringView>::format(builder, String::formatted("{}({})", value.class_name(), &value));
 }
 
 }

--- a/Libraries/LibCore/Object.h
+++ b/Libraries/LibCore/Object.h
@@ -174,7 +174,7 @@ private:
 namespace AK {
 template<>
 struct Formatter<Core::Object> : Formatter<StringView> {
-    void format(TypeErasedFormatParams&, FormatBuilder&, const Core::Object&);
+    void format(FormatBuilder&, const Core::Object&);
 };
 }
 

--- a/Libraries/LibGUI/ModelIndex.cpp
+++ b/Libraries/LibGUI/ModelIndex.cpp
@@ -50,14 +50,14 @@ const LogStream& operator<<(const LogStream& stream, const ModelIndex& value)
 
 namespace AK {
 
-void Formatter<GUI::ModelIndex>::format(TypeErasedFormatParams& params, FormatBuilder& builder, const GUI::ModelIndex& value)
+void Formatter<GUI::ModelIndex>::format(FormatBuilder& builder, const GUI::ModelIndex& value)
 {
     Formatter<StringView> formatter { *this };
 
     if (value.internal_data())
-        formatter.format(params, builder, String::formatted("ModelIndex({},{},{:p})", value.row(), value.column(), value.internal_data()));
+        formatter.format(builder, String::formatted("ModelIndex({},{},{:p})", value.row(), value.column(), value.internal_data()));
     else
-        formatter.format(params, builder, String::formatted("ModelIndex({},{})", value.row(), value.column()));
+        formatter.format(builder, String::formatted("ModelIndex({},{})", value.row(), value.column()));
 }
 
 }

--- a/Libraries/LibGUI/ModelIndex.h
+++ b/Libraries/LibGUI/ModelIndex.h
@@ -83,7 +83,7 @@ namespace AK {
 
 template<>
 struct Formatter<GUI::ModelIndex> : Formatter<StringView> {
-    void format(TypeErasedFormatParams&, FormatBuilder&, const GUI::ModelIndex&);
+    void format(FormatBuilder&, const GUI::ModelIndex&);
 };
 
 template<>

--- a/Libraries/LibGUI/TextPosition.h
+++ b/Libraries/LibGUI/TextPosition.h
@@ -70,12 +70,12 @@ namespace AK {
 
 template<>
 struct Formatter<GUI::TextPosition> : Formatter<StringView> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const GUI::TextPosition& value)
+    void format(FormatBuilder& builder, const GUI::TextPosition& value)
     {
         if (value.is_valid())
-            Formatter<StringView>::format(params, builder, String::formatted("({},{})", value.line(), value.column()));
+            Formatter<StringView>::format(builder, String::formatted("({},{})", value.line(), value.column()));
         else
-            Formatter<StringView>::format(params, builder, "GUI::TextPosition(Invalid)");
+            Formatter<StringView>::format(builder, "GUI::TextPosition(Invalid)");
     }
 };
 

--- a/Libraries/LibGUI/TextRange.h
+++ b/Libraries/LibGUI/TextRange.h
@@ -98,12 +98,12 @@ namespace AK {
 
 template<>
 struct Formatter<GUI::TextRange> : Formatter<StringView> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const GUI::TextRange& value)
+    void format(FormatBuilder& builder, const GUI::TextRange& value)
     {
         if (value.is_valid())
-            Formatter<StringView>::format(params, builder, String::formatted("{}-{}", value.start(), value.end()));
+            Formatter<StringView>::format(builder, String::formatted("{}-{}", value.start(), value.end()));
         else
-            Formatter<StringView>::format(params, builder, "GUI::TextRange(Invalid)");
+            Formatter<StringView>::format(builder, "GUI::TextRange(Invalid)");
     }
 };
 

--- a/Libraries/LibGfx/Color.cpp
+++ b/Libraries/LibGfx/Color.cpp
@@ -434,7 +434,7 @@ bool IPC::decode(IPC::Decoder& decoder, Color& color)
     return true;
 }
 
-void AK::Formatter<Gfx::Color>::format(TypeErasedFormatParams& params, FormatBuilder& builder, const Gfx::Color& value)
+void AK::Formatter<Gfx::Color>::format(FormatBuilder& builder, const Gfx::Color& value)
 {
-    Formatter<StringView>::format(params, builder, value.to_string());
+    Formatter<StringView>::format(builder, value.to_string());
 }

--- a/Libraries/LibGfx/Color.h
+++ b/Libraries/LibGfx/Color.h
@@ -317,13 +317,17 @@ const LogStream& operator<<(const LogStream&, Color);
 using Gfx::Color;
 
 namespace AK {
+
 template<>
 struct Formatter<Gfx::Color> : public Formatter<StringView> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const Gfx::Color& value);
+    void format(FormatBuilder& builder, const Gfx::Color& value);
 };
+
 }
 
 namespace IPC {
+
 bool encode(Encoder&, const Gfx::Color&);
 bool decode(Decoder&, Gfx::Color&);
+
 }

--- a/Libraries/LibGfx/Rect.h
+++ b/Libraries/LibGfx/Rect.h
@@ -455,9 +455,9 @@ namespace AK {
 
 template<typename T>
 struct Formatter<Gfx::Rect<T>> : Formatter<StringView> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const Gfx::Rect<T>& value)
+    void format(FormatBuilder& builder, const Gfx::Rect<T>& value)
     {
-        Formatter<StringView>::format(params, builder, value.to_string());
+        Formatter<StringView>::format(builder, value.to_string());
     }
 };
 

--- a/Libraries/LibJS/Runtime/Cell.h
+++ b/Libraries/LibJS/Runtime/Cell.h
@@ -78,12 +78,12 @@ namespace AK {
 
 template<>
 struct Formatter<JS::Cell> : Formatter<StringView> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const JS::Cell* cell)
+    void format(FormatBuilder& builder, const JS::Cell* cell)
     {
         if (!cell)
-            Formatter<StringView>::format(params, builder, "Cell{nullptr}");
+            Formatter<StringView>::format(builder, "Cell{nullptr}");
         else
-            Formatter<StringView>::format(params, builder, String::formatted("{}{{{}}}", cell->class_name(), static_cast<const void*>(cell)));
+            Formatter<StringView>::format(builder, String::formatted("{}{{{}}}", cell->class_name(), static_cast<const void*>(cell)));
     }
 };
 

--- a/Libraries/LibJS/Runtime/PropertyAttributes.h
+++ b/Libraries/LibJS/Runtime/PropertyAttributes.h
@@ -95,9 +95,9 @@ namespace AK {
 
 template<>
 struct Formatter<JS::PropertyAttributes> : Formatter<u8> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const JS::PropertyAttributes& attributes)
+    void format(FormatBuilder& builder, const JS::PropertyAttributes& attributes)
     {
-        Formatter<u8>::format(params, builder, attributes.bits());
+        Formatter<u8>::format(builder, attributes.bits());
     }
 };
 

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -345,9 +345,9 @@ namespace AK {
 
 template<>
 struct Formatter<JS::Value> : Formatter<StringView> {
-    void format(TypeErasedFormatParams& params, FormatBuilder& builder, const JS::Value& value)
+    void format(FormatBuilder& builder, const JS::Value& value)
     {
-        Formatter<StringView>::format(params, builder, value.is_empty() ? "<empty>" : value.to_string_without_side_effects());
+        Formatter<StringView>::format(builder, value.is_empty() ? "<empty>" : value.to_string_without_side_effects());
     }
 };
 

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -37,7 +37,7 @@
 
 //#define EXECUTE_DEBUG
 
-void AK::Formatter<Shell::AST::Command>::format(TypeErasedFormatParams&, FormatBuilder& builder, const Shell::AST::Command& value)
+void AK::Formatter<Shell::AST::Command>::format(FormatBuilder& builder, const Shell::AST::Command& value)
 {
     if (m_sign_mode != FormatBuilder::SignMode::Default)
         ASSERT_NOT_REACHED();
@@ -47,7 +47,9 @@ void AK::Formatter<Shell::AST::Command>::format(TypeErasedFormatParams&, FormatB
         ASSERT_NOT_REACHED();
     if (m_mode != Mode::Default && m_mode != Mode::String)
         ASSERT_NOT_REACHED();
-    if (m_width != value_not_set && m_precision != value_not_set)
+    if (m_width.has_value())
+        ASSERT_NOT_REACHED();
+    if (m_precision.has_value())
         ASSERT_NOT_REACHED();
 
     if (value.argv.is_empty()) {

--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -1301,7 +1301,7 @@ struct Formatter<Shell::AST::Command> : StandardFormatter {
     {
     }
 
-    void format(TypeErasedFormatParams&, FormatBuilder&, const Shell::AST::Command& value);
+    void format(FormatBuilder&, const Shell::AST::Command& value);
 };
 
 }


### PR DESCRIPTION
This pull request simplifies the formatter API by no longer passing the type erased parameters to the `Formatter<T>::format` function. (Note, that the `Formatter<T>::parse` function still has access to this information.)

I also used `Optional<size_t>` for the width and precision values instead of abusing `NumericLimits<size_t>::max()` to indicate the absence of a value.
