### PR TITLE
AK+ProtocolServer: Properly close download stream fd's

### DIFF
--- a/AK/FileStream.h
+++ b/AK/FileStream.h
@@ -54,8 +54,9 @@ public:
     ~InputFileStream()
     {
         if (m_file) {
+            fflush(m_file);
             if (m_owned)
-                fflush(m_file);
+                fclose(m_file);
         }
     }
 

--- a/Libraries/LibIPC/Message.cpp
+++ b/Libraries/LibIPC/Message.cpp
@@ -34,6 +34,8 @@ Message::Message()
 
 Message::~Message()
 {
+    if (on_destruction)
+        on_destruction();
 }
 
 }

--- a/Libraries/LibIPC/Message.h
+++ b/Libraries/LibIPC/Message.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Function.h>
 #include <AK/Vector.h>
 
 namespace IPC {
@@ -43,6 +44,8 @@ public:
     virtual int message_id() const = 0;
     virtual const char* message_name() const = 0;
     virtual MessageBuffer encode() const = 0;
+
+    Function<void()> on_destruction;
 
 protected:
     Message();

--- a/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -171,7 +171,6 @@ bool FrameLoader::load(const LoadRequest& request, Type type)
         return true;
 
     if (url.protocol() == "http" || url.protocol() == "https") {
-#if 0
         URL favicon_url;
         favicon_url.set_protocol(url.protocol());
         favicon_url.set_host(url.host());
@@ -192,7 +191,6 @@ bool FrameLoader::load(const LoadRequest& request, Type type)
                 if (auto* page = frame().page())
                     page->client().page_did_change_favicon(*bitmap);
             });
-#endif
     }
 
     return true;

--- a/Services/ProtocolServer/ClientConnection.cpp
+++ b/Services/ProtocolServer/ClientConnection.cpp
@@ -72,7 +72,9 @@ OwnPtr<Messages::ProtocolServer::StartDownloadResponse> ClientConnection::handle
     auto id = download->id();
     auto fd = download->download_fd();
     m_downloads.set(id, move(download));
-    return make<Messages::ProtocolServer::StartDownloadResponse>(id, fd);
+    auto response = make<Messages::ProtocolServer::StartDownloadResponse>(id, fd);
+    response->on_destruction = [fd] { close(fd); };
+    return response;
 }
 
 OwnPtr<Messages::ProtocolServer::StopDownloadResponse> ClientConnection::handle(const Messages::ProtocolServer::StopDownload& message)


### PR DESCRIPTION
```
< kling> CxByte: ProtocolServer(27): Protocol: pipe() failed: Too many open files
(snip)
< kling> max fds per process right now is uh.. 64 i think
(snip)
< kling> clicked on a link on google.com
< kling> the "privacy" link at the bottom
```

This PR exchanges that error for `assertion failed: child.is_inline()`
while it doesn't actually fix the matter at hand, it should be much harder to actually make a ProtocolServer instance use up all 64 available fds now.

Also re-enables favicons. oops.