### PR TITLE
AK: Add operator* and operator-> overloads in Optional.

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -155,6 +155,12 @@ public:
         return fallback;
     }
 
+    const T& operator*() const { return value(); }
+    T& operator*() { return value(); }
+
+    const T* operator->() const { return &value(); }
+    T* operator->() { return &value(); }
+
 private:
     // Call when we don't want to alter the consume state
     ALWAYS_INLINE const T& value_without_consume_state() const

--- a/AK/Tests/TestOptional.cpp
+++ b/AK/Tests/TestOptional.cpp
@@ -66,4 +66,12 @@ TEST_CASE(optional_leak_1)
     EXPECT_EQ(vec[0].str.value(), "foo");
 }
 
+TEST_CASE(short_notation)
+{
+    Optional<StringView> value = "foo";
+
+    EXPECT_EQ(value->length(), 3u);
+    EXPECT_EQ(*value, "foo");
+}
+
 TEST_MAIN(Optional)


### PR DESCRIPTION
This is a useful abbreviation because it can be quite cumbersome to always spell out `value()`. (When multiple `Optional` variables are involved.)
