### PR TITLE
Upgrade clang-format to version 11

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,13 +21,17 @@ jobs:
     # sudo apt-get update -qq
 
     - name: Purge interfering packages
-      # Remove GCC 9 (installed by default)
-      run: sudo apt-get purge -y gcc-9 g++-9 libstdc++-9-dev
+      # Remove GCC 9 and clang-format 10 (installed by default)
+      run: sudo apt-get purge -y gcc-9 g++-9 libstdc++-9-dev clang-format-10
     - name: Install dependencies
       # These packages are already part of the ubuntu-20.04 image:
-      # clang-format-10 cmake gcc-10 g++-10 shellcheck libgmp-dev
+      # cmake gcc-10 g++-10 shellcheck libgmp-dev
       # These aren't:
-      run: sudo apt-get install libstdc++-10-dev libmpfr-dev libmpc-dev ninja-build npm
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
+        sudo apt-get update
+        sudo apt-get install clang-format-11 libstdc++-10-dev libmpfr-dev libmpc-dev ninja-build npm
       # If we ever do any qemu-emulation on Github Actions, we should re-enable this:
       # e2fsprogs qemu-system-i386 qemu-utils
     - name: Install prettier
@@ -35,7 +39,7 @@ jobs:
     - name: Use GCC 10 instead
       run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
     - name: Check versions
-      run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-10 --version; prettier --version; python --version; python3 --version; ninja --version
+      run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-11 --version; prettier --version; python --version; python3 --version; ninja --version
 
     # === PREPARE FOR BUILDING ===
 

--- a/AK/Endian.h
+++ b/AK/Endian.h
@@ -105,8 +105,7 @@ template<typename T>
 OutputStream& operator<<(OutputStream&, LittleEndian<T>);
 
 template<typename T>
-class [[gnu::packed]] LittleEndian
-{
+class [[gnu::packed]] LittleEndian {
 public:
     friend InputStream& operator>><T>(InputStream&, LittleEndian<T>&);
     friend OutputStream& operator<<<T>(OutputStream&, LittleEndian<T>);
@@ -134,8 +133,7 @@ template<typename T>
 OutputStream& operator<<(OutputStream&, BigEndian<T>);
 
 template<typename T>
-class [[gnu::packed]] BigEndian
-{
+class [[gnu::packed]] BigEndian {
 public:
     friend InputStream& operator>><T>(InputStream&, BigEndian<T>&);
     friend OutputStream& operator<<<T>(OutputStream&, BigEndian<T>);

--- a/AK/IPv4Address.h
+++ b/AK/IPv4Address.h
@@ -35,8 +35,7 @@
 
 namespace AK {
 
-class [[gnu::packed]] IPv4Address
-{
+class [[gnu::packed]] IPv4Address {
     enum class SubnetClass : int {
         A = 0,
         B,

--- a/AK/MACAddress.h
+++ b/AK/MACAddress.h
@@ -32,8 +32,7 @@
 #include <AK/String.h>
 #include <AK/Types.h>
 
-class [[gnu::packed]] MACAddress
-{
+class [[gnu::packed]] MACAddress {
     static constexpr size_t s_mac_address_length = 6u;
 
 public:

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -35,8 +35,7 @@
 namespace AK {
 
 template<typename T>
-class alignas(T) [[nodiscard]] Optional
-{
+class alignas(T) [[nodiscard]] Optional {
 public:
     Optional() { }
 
@@ -53,13 +52,13 @@ public:
         new (&m_storage) T(value);
     }
 
-    Optional(T && value)
+    Optional(T&& value)
         : m_has_value(true)
     {
         new (&m_storage) T(move(value));
     }
 
-    Optional(Optional && other)
+    Optional(Optional&& other)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value()) {
@@ -119,7 +118,7 @@ public:
     }
 
     template<typename... Parameters>
-    ALWAYS_INLINE void emplace(Parameters && ... parameters)
+    ALWAYS_INLINE void emplace(Parameters&&... parameters)
     {
         clear();
         m_has_value = true;

--- a/AK/Result.h
+++ b/AK/Result.h
@@ -32,14 +32,13 @@
 namespace AK {
 
 template<typename ValueType, typename ErrorType>
-class [[nodiscard]] Result
-{
+class [[nodiscard]] Result {
 public:
     Result(const ValueType& res)
         : m_result(res)
     {
     }
-    Result(ValueType && res)
+    Result(ValueType&& res)
         : m_result(move(res))
     {
     }
@@ -47,7 +46,7 @@ public:
         : m_error(error)
     {
     }
-    Result(ErrorType && error)
+    Result(ErrorType&& error)
         : m_error(move(error))
     {
     }
@@ -58,19 +57,13 @@ public:
     {
     }
 
-    // FIXME: clang-format gets confused about Result. Why?
-    // clang-format off
     Result(Result&& other)
-        // clang-format on
         : m_result(move(other.m_result))
         , m_error(move(other.m_error))
     {
     }
 
-    // FIXME: clang-format gets confused about Result. Why?
-    // clang-format off
     Result(Result& other)
-        // clang-format on
         : m_result(other.m_result)
         , m_error(other.m_error)
     {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Nobody is perfect, and sometimes we mess things up. That said, here are some goo
 **Do:**
 
 * Write in idiomatic Serenity C++20, using the `AK` containers in all code.
-* Conform to the project coding style found in [CodingStyle.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Please use `clang-format` (version 10 or later) to automatically format C++ files.
+* Conform to the project coding style found in [CodingStyle.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Please use `clang-format` (version 11 or later) to automatically format C++ files.
 * Choose expressive variable, function and class names. Make it as obvious as possible what the code is doing.
 * Split your changes into separate, atomic commits.
 * Make sure your commits are rebased on the master branch.

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -32,7 +32,7 @@ apt-get install curl cmake libmpc-devel gmp-devel e2fsprogs libmpfr-devel patch 
 
 Ensure your gcc version is >= 10 with `gcc --version`. Otherwise, install it.
 
-On Ubuntu it's in the repositories of 20.04 (Focal) - add the `ubuntu-toolchain-r/test` PPA if you're running an older version:
+On Ubuntu it's in the repositories of 20.04 (Focal) and later - add the `ubuntu-toolchain-r/test` PPA if you're running an older version:
 ```bash
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 ```

--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -2,7 +2,7 @@
 
 For low-level styling (spaces, parentheses, brace placement, etc), all code should follow the format specified in `.clang-format` in the project root.
 
-**Important: Make sure you use `clang-format` version 10 or later!**
+**Important: Make sure you use `clang-format` version 11 or later!**
 
 This document describes the coding style used for C++ code in the Serenity Operating System project. All new code should conform to this style.
 

--- a/Documentation/UsingQtCreator.md
+++ b/Documentation/UsingQtCreator.md
@@ -21,7 +21,7 @@ Qt Creator should be set up correctly now, go ahead and explore the project and 
 
 ## Auto-Formatting
 
-You can use `clang-format` to help you with the [style guide](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Before you proceed, check that you're actually using clang-format version 10, as some OSes still ship clang-format version 9 by default.
+You can use `clang-format` to help you with the [style guide](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Before you proceed, check that you're actually using clang-format version 11, as some OSes still ship clang-format version 9 or 10 by default.
 
 - In QtCreator, go to "Help > About Plugins…"
 - Find the `Beautifier (experimental)` row (for example, by typing `beau` into the search)

--- a/Kernel/ACPI/Definitions.h
+++ b/Kernel/ACPI/Definitions.h
@@ -70,8 +70,7 @@ enum class IA_PC_Flags : u8 {
     CMOS_RTC_Not_Present = 1 << 5
 };
 
-struct [[gnu::packed]] HardwareFeatures
-{
+struct [[gnu::packed]] HardwareFeatures {
     bool wbinvd : 1;
     bool wbinvd_flush : 1;
     bool processor_c1 : 1;
@@ -95,8 +94,7 @@ struct [[gnu::packed]] HardwareFeatures
     bool hardware_reduced_acpi : 1;
     bool low_power_s0_idle_capable : 1;
 };
-struct [[gnu::packed]] x86_Specific_Flags
-{
+struct [[gnu::packed]] x86_Specific_Flags {
     bool legacy_devices : 1;
     bool keyboard_8042 : 1;
     bool vga_not_present : 1;
@@ -132,8 +130,7 @@ enum class BitWidth {
 }
 
 namespace Structures {
-struct [[gnu::packed]] RSDPDescriptor
-{
+struct [[gnu::packed]] RSDPDescriptor {
     char sig[8];
     u8 checksum;
     char oem_id[6];
@@ -141,8 +138,7 @@ struct [[gnu::packed]] RSDPDescriptor
     u32 rsdt_ptr;
 };
 
-struct [[gnu::packed]] RSDPDescriptor20
-{
+struct [[gnu::packed]] RSDPDescriptor20 {
     RSDPDescriptor base;
     u32 length;
     u64 xsdt_ptr;
@@ -150,8 +146,7 @@ struct [[gnu::packed]] RSDPDescriptor20
     u8 reserved[3];
 };
 
-struct [[gnu::packed]] SDTHeader
-{
+struct [[gnu::packed]] SDTHeader {
     char sig[4];
     u32 length;
     u8 revision;
@@ -163,20 +158,17 @@ struct [[gnu::packed]] SDTHeader
     u32 creator_revision;
 };
 
-struct [[gnu::packed]] RSDT
-{
+struct [[gnu::packed]] RSDT {
     SDTHeader h;
     u32 table_ptrs[];
 };
 
-struct [[gnu::packed]] XSDT
-{
+struct [[gnu::packed]] XSDT {
     SDTHeader h;
     u64 table_ptrs[];
 };
 
-struct [[gnu::packed]] GenericAddressStructure
-{
+struct [[gnu::packed]] GenericAddressStructure {
     u8 address_space;
     u8 bit_width;
     u8 bit_offset;
@@ -184,8 +176,7 @@ struct [[gnu::packed]] GenericAddressStructure
     u64 address;
 };
 
-struct [[gnu::packed]] HPET
-{
+struct [[gnu::packed]] HPET {
     SDTHeader h;
     u8 hardware_revision_id;
     u8 attributes;
@@ -196,8 +187,7 @@ struct [[gnu::packed]] HPET
     u8 page_protection;
 };
 
-struct [[gnu::packed]] FADT
-{
+struct [[gnu::packed]] FADT {
     SDTHeader h;
     u32 firmware_ctrl;
     u32 dsdt_ptr;
@@ -274,15 +264,13 @@ enum class MADTEntryType {
     GIC_Interrupt_Translation = 0xF
 };
 
-struct [[gnu::packed]] MADTEntryHeader
-{
+struct [[gnu::packed]] MADTEntryHeader {
     u8 type;
     u8 length;
 };
 
 namespace MADTEntries {
-struct [[gnu::packed]] IOAPIC
-{
+struct [[gnu::packed]] IOAPIC {
     MADTEntryHeader h;
     u8 ioapic_id;
     u8 reserved;
@@ -290,16 +278,14 @@ struct [[gnu::packed]] IOAPIC
     u32 gsi_base;
 };
 
-struct [[gnu::packed]] ProcessorLocalAPIC
-{
+struct [[gnu::packed]] ProcessorLocalAPIC {
     MADTEntryHeader h;
     u8 acpi_processor_id;
     u8 apic_id;
     u32 flags;
 };
 
-struct [[gnu::packed]] InterruptSourceOverride
-{
+struct [[gnu::packed]] InterruptSourceOverride {
     MADTEntryHeader h;
     u8 bus;
     u8 source;
@@ -308,22 +294,19 @@ struct [[gnu::packed]] InterruptSourceOverride
 };
 }
 
-struct [[gnu::packed]] MADT
-{
+struct [[gnu::packed]] MADT {
     SDTHeader h;
     u32 lapic_address;
     u32 flags;
     MADTEntryHeader entries[];
 };
 
-struct [[gnu::packed]] AMLTable
-{
+struct [[gnu::packed]] AMLTable {
     SDTHeader h;
     char aml_code[];
 };
 
-struct [[gnu::packed]] PCI_MMIO_Descriptor
-{
+struct [[gnu::packed]] PCI_MMIO_Descriptor {
     u64 base_addr;
     u16 seg_group_number;
     u8 start_pci_bus;
@@ -331,8 +314,7 @@ struct [[gnu::packed]] PCI_MMIO_Descriptor
     u32 reserved;
 };
 
-struct [[gnu::packed]] MCFG
-{
+struct [[gnu::packed]] MCFG {
     SDTHeader header;
     u64 reserved;
     PCI_MMIO_Descriptor descriptors[];

--- a/Kernel/ACPI/MultiProcessorParser.h
+++ b/Kernel/ACPI/MultiProcessorParser.h
@@ -34,8 +34,7 @@
 namespace Kernel {
 namespace MultiProcessor {
 
-struct [[gnu::packed]] FloatingPointer
-{
+struct [[gnu::packed]] FloatingPointer {
     char sig[4];
     u32 physical_address_ptr;
     u8 length;
@@ -44,13 +43,11 @@ struct [[gnu::packed]] FloatingPointer
     u8 feature_info[5];
 };
 
-struct [[gnu::packed]] EntryHeader
-{
+struct [[gnu::packed]] EntryHeader {
     u8 entry_type;
 };
 
-struct [[gnu::packed]] ConfigurationTableHeader
-{
+struct [[gnu::packed]] ConfigurationTableHeader {
     char sig[4];
     u16 length;
     u8 specification_revision;
@@ -78,14 +75,12 @@ enum class ConfigurationTableEntryType {
     CompatibilityBusAddressSpaceModifier = 130
 };
 
-struct [[gnu::packed]] ExtEntryHeader
-{
+struct [[gnu::packed]] ExtEntryHeader {
     u8 entry_type;
     u8 entry_length;
 };
 
-struct [[gnu::packed]] ProcessorEntry
-{
+struct [[gnu::packed]] ProcessorEntry {
     EntryHeader h;
     u8 local_apic_id;
     u8 local_apic_version;
@@ -95,15 +90,13 @@ struct [[gnu::packed]] ProcessorEntry
     u8 reserved[8];
 };
 
-struct [[gnu::packed]] BusEntry
-{
+struct [[gnu::packed]] BusEntry {
     EntryHeader h;
     u8 bus_id;
     char bus_type[6];
 };
 
-struct [[gnu::packed]] IOAPICEntry
-{
+struct [[gnu::packed]] IOAPICEntry {
     EntryHeader h;
     u8 ioapic_id;
     u8 ioapic_version;
@@ -118,8 +111,7 @@ enum class InterruptType {
     ExtINT = 3,
 };
 
-struct [[gnu::packed]] IOInterruptAssignmentEntry
-{
+struct [[gnu::packed]] IOInterruptAssignmentEntry {
     EntryHeader h;
     u8 interrupt_type;
     u8 polarity;
@@ -130,8 +122,7 @@ struct [[gnu::packed]] IOInterruptAssignmentEntry
     u8 destination_ioapic_intin_pin;
 };
 
-struct [[gnu::packed]] LocalInterruptAssignmentEntry
-{
+struct [[gnu::packed]] LocalInterruptAssignmentEntry {
     EntryHeader h;
     u8 interrupt_type;
     u8 polarity;
@@ -148,8 +139,7 @@ enum class SystemAddressType {
     Prefetch = 2,
 };
 
-struct [[gnu::packed]] SystemAddressSpaceMappingEntry
-{
+struct [[gnu::packed]] SystemAddressSpaceMappingEntry {
     ExtEntryHeader h;
     u8 bus_id;
     u8 address_type;
@@ -157,8 +147,7 @@ struct [[gnu::packed]] SystemAddressSpaceMappingEntry
     u64 length;
 };
 
-struct [[gnu::packed]] BusHierarchyDescriptorEntry
-{
+struct [[gnu::packed]] BusHierarchyDescriptorEntry {
     ExtEntryHeader h;
     u8 bus_id;
     u8 bus_info;
@@ -166,8 +155,7 @@ struct [[gnu::packed]] BusHierarchyDescriptorEntry
     u8 reserved[3];
 };
 
-struct [[gnu::packed]] CompatibilityBusAddressSpaceModifierEntry
-{
+struct [[gnu::packed]] CompatibilityBusAddressSpaceModifierEntry {
     ExtEntryHeader h;
     u8 bus_id;
     u8 address_modifier;

--- a/Kernel/API/InodeWatcherEvent.h
+++ b/Kernel/API/InodeWatcherEvent.h
@@ -28,8 +28,7 @@
 
 #include <AK/Types.h>
 
-struct [[gnu::packed]] InodeWatcherEvent
-{
+struct [[gnu::packed]] InodeWatcherEvent {
     enum class Type {
         Invalid = 0,
         Modified,

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -51,14 +51,12 @@ inline u32 get_iopl_from_eflags(u32 eflags)
     return (eflags & iopl_mask) >> 12;
 }
 
-struct [[gnu::packed]] DescriptorTablePointer
-{
+struct [[gnu::packed]] DescriptorTablePointer {
     u16 limit;
     void* address;
 };
 
-struct [[gnu::packed]] TSS32
-{
+struct [[gnu::packed]] TSS32 {
     u16 backlink, __blh;
     u32 esp0;
     u16 ss0, __ss0h;
@@ -78,8 +76,7 @@ struct [[gnu::packed]] TSS32
     u16 trace, iomapbase;
 };
 
-union [[gnu::packed]] Descriptor
-{
+union [[gnu::packed]] Descriptor {
     struct {
         u16 limit_lo;
         u16 base_lo;
@@ -347,15 +344,15 @@ inline u32 read_fs_u32(u32 offset)
     u32 val;
     asm volatile(
         "movl %%fs:%a[off], %k[val]"
-        : [ val ] "=r"(val)
-        : [ off ] "ir"(offset));
+        : [val] "=r"(val)
+        : [off] "ir"(offset));
     return val;
 }
 
 inline void write_fs_u32(u32 offset, u32 val)
 {
     asm volatile(
-        "movl %k[val], %%fs:%a[off]" ::[off] "ir"(offset), [ val ] "ir"(val)
+        "movl %k[val], %%fs:%a[off]" ::[off] "ir"(offset), [val] "ir"(val)
         : "memory");
 }
 
@@ -475,8 +472,7 @@ private:
     VirtualAddress m_vaddr;
 };
 
-struct [[gnu::packed]] RegisterState
-{
+struct [[gnu::packed]] RegisterState {
     u32 ss;
     u32 gs;
     u32 fs;
@@ -539,7 +535,7 @@ static inline bool is_kernel_mode()
     u32 cs;
     asm volatile(
         "movl %%cs, %[cs] \n"
-        : [ cs ] "=g"(cs));
+        : [cs] "=g"(cs));
     return (cs & 3) == 0;
 }
 

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -570,8 +570,7 @@ KResult Plan9FS::do_read(u8* data, size_t size)
 
 KResult Plan9FS::read_and_dispatch_one_message()
 {
-    struct [[gnu::packed]] Header
-    {
+    struct [[gnu::packed]] Header {
         u32 size;
         u8 type;
         u16 tag;

--- a/Kernel/FileSystem/ext2_types.h
+++ b/Kernel/FileSystem/ext2_types.h
@@ -78,8 +78,8 @@ typedef int __s16;
 #            if (2 == 2)
 typedef short __s16;
 #            else
-        ? == error
-        : undefined 16 bit type
+    ? == error
+    : undefined 16 bit type
 #            endif /* SIZEOF_SHORT == 2 */
 #        endif     /* SIZEOF_INT == 2 */
 #    endif         /* __S16_TYPEDEF */
@@ -94,10 +94,10 @@ typedef unsigned int __u32;
 typedef unsigned long __u32;
 #            else
 #                if (2 == 4)
-        typedef unsigned short __u32;
+    typedef unsigned short __u32;
 #                else
-            ? == error
-            : undefined 32 bit type
+        ? == error
+        : undefined 32 bit type
 #                endif /* SIZEOF_SHORT == 4 */
 #            endif     /* SIZEOF_LONG == 4 */
 #        endif         /* SIZEOF_INT == 4 */
@@ -115,8 +115,8 @@ typedef long __s32;
 #                if (2 == 4)
 typedef short __s32;
 #                else
-                ? == error
-                : undefined 32 bit type
+            ? == error
+            : undefined 32 bit type
 #                endif /* SIZEOF_SHORT == 4 */
 #            endif     /* SIZEOF_LONG == 4 */
 #        endif         /* SIZEOF_INT == 4 */

--- a/Kernel/Interrupts/IOAPIC.h
+++ b/Kernel/Interrupts/IOAPIC.h
@@ -30,8 +30,7 @@
 #include <Kernel/VM/TypedMapping.h>
 
 namespace Kernel {
-struct [[gnu::packed]] ioapic_mmio_regs
-{
+struct [[gnu::packed]] ioapic_mmio_regs {
     volatile u32 select;
     u32 reserved[3];
     volatile u32 window;

--- a/Kernel/Interrupts/PIC.cpp
+++ b/Kernel/Interrupts/PIC.cpp
@@ -42,6 +42,7 @@ namespace Kernel {
 #define PIC1_CTL 0xA0
 #define PIC1_CMD 0xA1
 
+// clang-format off
 #define ICW1_ICW4 0x01      /* ICW4 (not) needed */
 #define ICW1_SINGLE 0x02    /* Single (cascade) mode */
 #define ICW1_INTERVAL4 0x04 /* Call address interval 4 (8) */
@@ -53,6 +54,7 @@ namespace Kernel {
 #define ICW4_BUF_SLAVE 0x08  /* Buffered mode/slave */
 #define ICW4_BUF_MASTER 0x0C /* Buffered mode/master */
 #define ICW4_SFNM 0x10       /* Special fully nested (not) */
+// clang-format on
 
 bool inline static is_all_masked(u16 reg)
 {

--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -35,8 +35,7 @@ enum KSuccessTag {
     KSuccess
 };
 
-class [[nodiscard]] KResult
-{
+class [[nodiscard]] KResult {
 public:
     ALWAYS_INLINE explicit KResult(int negative_e)
         : m_error(negative_e)
@@ -62,8 +61,7 @@ private:
 };
 
 template<typename T>
-class alignas(T) [[nodiscard]] KResultOr
-{
+class alignas(T) [[nodiscard]] KResultOr {
 public:
     KResultOr(KResult error)
         : m_error(error)
@@ -71,20 +69,14 @@ public:
     {
     }
 
-    // FIXME: clang-format gets confused about T. Why?
-    // clang-format off
     ALWAYS_INLINE KResultOr(T&& value)
-    // clang-format on
     {
         new (&m_storage) T(move(value));
         m_have_storage = true;
     }
 
     template<typename U>
-    // FIXME: clang-format gets confused about U. Why?
-    // clang-format off
     ALWAYS_INLINE KResultOr(U&& value)
-    // clang-format on
     {
         new (&m_storage) T(move(value));
         m_have_storage = true;

--- a/Kernel/Net/ARP.h
+++ b/Kernel/Net/ARP.h
@@ -46,8 +46,7 @@ struct ARPHardwareType {
     };
 };
 
-class [[gnu::packed]] ARPPacket
-{
+class [[gnu::packed]] ARPPacket {
 public:
     u16 hardware_type() const { return m_hardware_type; }
     void set_hardware_type(u16 w) { m_hardware_type = w; }

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -33,6 +33,7 @@
 
 namespace Kernel {
 
+// clang-format off
 #define REG_CTRL 0x0000
 #define REG_STATUS 0x0008
 #define REG_EEPROM 0x0014
@@ -139,6 +140,7 @@ namespace Kernel {
 #define INTERRUPT_PHYINT (1 << 12)
 #define INTERRUPT_TXD_LOW (1 << 15)
 #define INTERRUPT_SRPD (1 << 16)
+// clang-format on
 
 // https://www.intel.com/content/dam/doc/manual/pci-pci-x-family-gbe-controllers-software-dev-manual.pdf Section 5.2
 static bool is_valid_device_id(u16 device_id)

--- a/Kernel/Net/E1000NetworkAdapter.h
+++ b/Kernel/Net/E1000NetworkAdapter.h
@@ -54,8 +54,7 @@ private:
     virtual void handle_irq(const RegisterState&) override;
     virtual const char* class_name() const override { return "E1000NetworkAdapter"; }
 
-    struct [[gnu::packed]] e1000_rx_desc
-    {
+    struct [[gnu::packed]] e1000_rx_desc {
         volatile uint64_t addr { 0 };
         volatile uint16_t length { 0 };
         volatile uint16_t checksum { 0 };
@@ -64,8 +63,7 @@ private:
         volatile uint16_t special { 0 };
     };
 
-    struct [[gnu::packed]] e1000_tx_desc
-    {
+    struct [[gnu::packed]] e1000_tx_desc {
         volatile uint64_t addr { 0 };
         volatile uint16_t length { 0 };
         volatile uint8_t cso { 0 };

--- a/Kernel/Net/EthernetFrameHeader.h
+++ b/Kernel/Net/EthernetFrameHeader.h
@@ -31,8 +31,7 @@
 
 #pragma GCC diagnostic ignored "-Warray-bounds"
 
-class [[gnu::packed]] EthernetFrameHeader
-{
+class [[gnu::packed]] EthernetFrameHeader {
 public:
     EthernetFrameHeader() { }
     ~EthernetFrameHeader() { }

--- a/Kernel/Net/ICMP.h
+++ b/Kernel/Net/ICMP.h
@@ -36,8 +36,7 @@ struct ICMPType {
     };
 };
 
-class [[gnu::packed]] ICMPHeader
-{
+class [[gnu::packed]] ICMPHeader {
 public:
     ICMPHeader() { }
     ~ICMPHeader() { }
@@ -63,8 +62,7 @@ private:
 
 static_assert(sizeof(ICMPHeader) == 4);
 
-struct [[gnu::packed]] ICMPEchoPacket
-{
+struct [[gnu::packed]] ICMPEchoPacket {
     ICMPHeader header;
     NetworkOrdered<u16> identifier;
     NetworkOrdered<u16> sequence_number;

--- a/Kernel/Net/IPv4.h
+++ b/Kernel/Net/IPv4.h
@@ -47,8 +47,7 @@ enum class IPv4PacketFlags : u16 {
 
 NetworkOrdered<u16> internet_checksum(const void*, size_t);
 
-class [[gnu::packed]] IPv4Packet
-{
+class [[gnu::packed]] IPv4Packet {
 public:
     u8 version() const { return (m_version_and_ihl >> 4) & 0xf; }
     void set_version(u8 version) { m_version_and_ihl = (m_version_and_ihl & 0x0f) | (version << 4); }

--- a/Kernel/Net/TCP.h
+++ b/Kernel/Net/TCP.h
@@ -41,8 +41,7 @@ struct TCPFlags {
     };
 };
 
-class [[gnu::packed]] TCPPacket
-{
+class [[gnu::packed]] TCPPacket {
 public:
     TCPPacket() = default;
     ~TCPPacket() = default;

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -310,8 +310,7 @@ void TCPSocket::receive_tcp_packet(const TCPPacket& packet, u16 size)
 
 NetworkOrdered<u16> TCPSocket::compute_tcp_checksum(const IPv4Address& source, const IPv4Address& destination, const TCPPacket& packet, u16 payload_size)
 {
-    struct [[gnu::packed]] PseudoHeader
-    {
+    struct [[gnu::packed]] PseudoHeader {
         IPv4Address source;
         IPv4Address destination;
         u8 zero;

--- a/Kernel/Net/UDP.h
+++ b/Kernel/Net/UDP.h
@@ -30,8 +30,7 @@
 
 namespace Kernel {
 
-class [[gnu::packed]] UDPPacket
-{
+class [[gnu::packed]] UDPPacket {
 public:
     UDPPacket() { }
     ~UDPPacket() { }

--- a/Kernel/PCI/Definitions.h
+++ b/Kernel/PCI/Definitions.h
@@ -34,6 +34,7 @@
 
 namespace Kernel {
 
+// clang-format off
 #define PCI_VENDOR_ID 0x00            // word
 #define PCI_DEVICE_ID 0x02            // word
 #define PCI_COMMAND 0x04              // word
@@ -66,6 +67,7 @@ namespace Kernel {
 #define PCI_MAX_DEVICES_PER_BUS 32
 #define PCI_MAX_BUSES 256
 #define PCI_MAX_FUNCTIONS_PER_DEVICE 8
+// clang-format on
 
 //#define PCI_DEBUG 1
 

--- a/Kernel/PerformanceEventBuffer.h
+++ b/Kernel/PerformanceEventBuffer.h
@@ -31,20 +31,17 @@
 
 namespace Kernel {
 
-struct [[gnu::packed]] MallocPerformanceEvent
-{
+struct [[gnu::packed]] MallocPerformanceEvent {
     size_t size;
     FlatPtr ptr;
 };
 
-struct [[gnu::packed]] FreePerformanceEvent
-{
+struct [[gnu::packed]] FreePerformanceEvent {
     size_t size;
     FlatPtr ptr;
 };
 
-struct [[gnu::packed]] PerformanceEvent
-{
+struct [[gnu::packed]] PerformanceEvent {
     u8 type { 0 };
     u8 stack_size { 0 };
     u64 timestamp;

--- a/Kernel/Storage/Partition/GUIDPartitionTable.cpp
+++ b/Kernel/Storage/Partition/GUIDPartitionTable.cpp
@@ -37,8 +37,7 @@ namespace Kernel {
 #define GPT_SIGNATURE 0x20494645
 #define BytesPerSector 512
 
-struct [[gnu::packed]] GPTPartitionEntry
-{
+struct [[gnu::packed]] GPTPartitionEntry {
     u8 partition_guid[16];
     u8 unique_guid[16];
 
@@ -49,8 +48,7 @@ struct [[gnu::packed]] GPTPartitionEntry
     char partition_name[72];
 };
 
-struct [[gnu::packed]] GUIDPartitionHeader
-{
+struct [[gnu::packed]] GUIDPartitionHeader {
     u32 sig[2];
     u32 revision;
     u32 header_size;

--- a/Kernel/Storage/Partition/MBRPartitionTable.h
+++ b/Kernel/Storage/Partition/MBRPartitionTable.h
@@ -36,8 +36,7 @@ namespace Kernel {
 
 class MBRPartitionTable : public PartitionTable {
 public:
-    struct [[gnu::packed]] Entry
-    {
+    struct [[gnu::packed]] Entry {
         u8 status;
         u8 chs1[3];
         u8 type;
@@ -45,8 +44,7 @@ public:
         u32 offset;
         u32 length;
     };
-    struct [[gnu::packed]] Header
-    {
+    struct [[gnu::packed]] Header {
         u8 code1[218];
         u16 ts_zero;
         u8 ts_drive;

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -171,8 +171,9 @@ void TTY::emit(u8 ch, bool do_evaluate_block_conditions)
         if (ch == m_termios.c_cc[VSUSP]) {
             dbg() << tty_name() << ": VSUSP pressed!";
             generate_signal(SIGTSTP);
-            if (auto original_process_parent = m_original_process_parent.strong_ref())
+            if (auto original_process_parent = m_original_process_parent.strong_ref()) {
                 [[maybe_unused]] auto rc = original_process_parent->send_signal(SIGCHLD, nullptr);
+            }
             // TODO: Else send it to the session leader maybe?
             return;
         }

--- a/Kernel/Time/HPET.cpp
+++ b/Kernel/Time/HPET.cpp
@@ -65,14 +65,12 @@ enum class TimerConfiguration : u32 {
 };
 };
 
-struct [[gnu::packed]] HPETRegister
-{
+struct [[gnu::packed]] HPETRegister {
     volatile u32 low;
     volatile u32 high;
 };
 
-struct [[gnu::packed]] TimerStructure
-{
+struct [[gnu::packed]] TimerStructure {
     volatile u32 capabilities;
     volatile u32 interrupt_routing;
     HPETRegister comparator_value;
@@ -80,16 +78,14 @@ struct [[gnu::packed]] TimerStructure
     u64 reserved;
 };
 
-struct [[gnu::packed]] HPETCapabilityRegister
-{
+struct [[gnu::packed]] HPETCapabilityRegister {
     // Note: We must do a 32 bit access to offsets 0x0, or 0x4 only, according to HPET spec.
     volatile u32 attributes;
     volatile u32 main_counter_tick_period;
     u64 reserved;
 };
 
-struct [[gnu::packed]] HPETRegistersBlock
-{
+struct [[gnu::packed]] HPETRegistersBlock {
     HPETCapabilityRegister capabilities;
     HPETRegister configuration;
     u64 reserved1;

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -604,6 +604,8 @@ struct ifreq {
         void* ifru_data;
         unsigned int ifru_index;
     } ifr_ifru;
+
+    // clang-format off
 #define ifr_addr ifr_ifru.ifru_addr           // address
 #define ifr_dstaddr ifr_ifru.ifru_dstaddr     // other end of p-to-p link
 #define ifr_broadaddr ifr_ifru.ifru_broadaddr // broadcast address
@@ -620,6 +622,7 @@ struct ifreq {
 #define ifr_index ifr_ifru.ifru_index         // interface index
 #define ifr_llprio ifr_ifru.ifru_metric       // link layer priority
 #define ifr_hwaddr ifr_ifru.ifru_hwaddr       // MAC address
+    // clang-format on
 };
 
 struct rtentry {

--- a/Libraries/LibC/dirent.cpp
+++ b/Libraries/LibC/dirent.cpp
@@ -64,8 +64,7 @@ int closedir(DIR* dirp)
     return rc;
 }
 
-struct [[gnu::packed]] sys_dirent
-{
+struct [[gnu::packed]] sys_dirent {
     ino_t ino;
     u8 file_type;
     size_t namelen;

--- a/Libraries/LibC/net/if.h
+++ b/Libraries/LibC/net/if.h
@@ -47,6 +47,8 @@ struct ifreq {
         void* ifru_data;
         unsigned int ifru_index;
     } ifr_ifru;
+
+    // clang-format off
 #define ifr_addr ifr_ifru.ifru_addr           // address
 #define ifr_dstaddr ifr_ifru.ifru_dstaddr     // other end of p-to-p link
 #define ifr_broadaddr ifr_ifru.ifru_broadaddr // broadcast address
@@ -63,6 +65,7 @@ struct ifreq {
 #define ifr_index ifr_ifru.ifru_index         // interface index
 #define ifr_llprio ifr_ifru.ifru_metric       // link layer priority
 #define ifr_hwaddr ifr_ifru.ifru_hwaddr       // MAC address
+    // clang-format on
 };
 
 __END_DECLS

--- a/Libraries/LibC/regex.h
+++ b/Libraries/LibC/regex.h
@@ -101,6 +101,7 @@ enum __RegexAllFlags {
     __Regex_Last = __Regex_SkipTrimEmptyMatches
 };
 
+// clang-format off
 // Values for the cflags parameter to the regcomp() function:
 #define REG_EXTENDED __Regex_Extended                // Use Extended Regular Expressions.
 #define REG_ICASE __Regex_Insensitive                // Ignore case in match.
@@ -114,6 +115,7 @@ enum __RegexAllFlags {
 
 //static_assert (sizeof(FlagsUnderlyingType) * 8 >= regex::POSIXFlags::Last << 1), "flags type too small")
 #define REG_SEARCH __Regex_Last << 1
+// clang-format on
 
 int regcomp(regex_t*, const char*, int);
 int regexec(const regex_t*, const char*, size_t, regmatch_t[], int);

--- a/Libraries/LibC/sys/arch/i386/regs.h
+++ b/Libraries/LibC/sys/arch/i386/regs.h
@@ -28,8 +28,7 @@
 
 #include <AK/Types.h>
 
-struct [[gnu::packed]] PtraceRegisters
-{
+struct [[gnu::packed]] PtraceRegisters {
     u32 eax;
     u32 ecx;
     u32 edx;

--- a/Libraries/LibCompress/Gzip.h
+++ b/Libraries/LibCompress/Gzip.h
@@ -45,8 +45,7 @@ public:
     static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
 
 private:
-    struct [[gnu::packed]] BlockHeader
-    {
+    struct [[gnu::packed]] BlockHeader {
         u8 identification_1;
         u8 identification_2;
         u8 compression_method;

--- a/Libraries/LibDebug/Dwarf/DwarfTypes.h
+++ b/Libraries/LibDebug/Dwarf/DwarfTypes.h
@@ -30,8 +30,7 @@
 
 namespace Debug::Dwarf {
 
-struct [[gnu::packed]] CompilationUnitHeader
-{
+struct [[gnu::packed]] CompilationUnitHeader {
     u32 length;
     u16 version;
     u32 abbrev_offset;
@@ -287,8 +286,7 @@ enum class AttributeDataForm : u8 {
     AddrX4 = 0x2c
 };
 
-struct [[gnu::packed]] AttributeSpecification
-{
+struct [[gnu::packed]] AttributeSpecification {
     Attribute attribute;
     AttributeDataForm form;
 };

--- a/Libraries/LibDebug/Dwarf/LineProgram.h
+++ b/Libraries/LibDebug/Dwarf/LineProgram.h
@@ -57,8 +57,7 @@ private:
     void handle_standard_opcode(u8 opcode);
     void handle_sepcial_opcode(u8 opcode);
 
-    struct [[gnu::packed]] UnitHeader32
-    {
+    struct [[gnu::packed]] UnitHeader32 {
         u32 length;
         u16 version;
         u32 header_length;

--- a/Libraries/LibELF/AuxiliaryVector.h
+++ b/Libraries/LibELF/AuxiliaryVector.h
@@ -40,6 +40,7 @@ typedef struct
     } a_un;
 } auxv_t;
 
+// clang-format off
 #define AT_NULL 0           /* No length, last entry's a_type has this value */
 #define AT_IGNORE 1         /* Entry has no meaning, a_un undefined */
 #define AT_EXECFD 2         /* a_val contains a file descriptor of the main program image */
@@ -65,6 +66,7 @@ typedef struct
 #define AT_EXECFN 31        /* a_ptr points to file name of executed program */
 #define AT_EXE_BASE 32      /* a_ptr holds base address where main program was loaded into memory */
 #define AT_EXE_SIZE 33      /* a_val holds the size of the main program in memory */
+// clang-format on
 
 namespace ELF {
 

--- a/Libraries/LibELF/CoreDump.h
+++ b/Libraries/LibELF/CoreDump.h
@@ -32,8 +32,7 @@
 
 namespace ELF::Core {
 
-struct [[gnu::packed]] NotesEntryHeader
-{
+struct [[gnu::packed]] NotesEntryHeader {
     enum Type : u8 {
         Null = 0, // Terminates segment
         ProcessInfo,
@@ -44,28 +43,24 @@ struct [[gnu::packed]] NotesEntryHeader
     Type type;
 };
 
-struct [[gnu::packed]] NotesEntry
-{
+struct [[gnu::packed]] NotesEntry {
     NotesEntryHeader header;
     char data[];
 };
 
-struct [[gnu::packed]] ProcessInfo
-{
+struct [[gnu::packed]] ProcessInfo {
     NotesEntryHeader header;
     int pid;
     char executable_path[]; // Null terminated
 };
 
-struct [[gnu::packed]] ThreadInfo
-{
+struct [[gnu::packed]] ThreadInfo {
     NotesEntryHeader header;
     int tid;
     PtraceRegisters regs;
 };
 
-struct [[gnu::packed]] MemoryRegionInfo
-{
+struct [[gnu::packed]] MemoryRegionInfo {
     NotesEntryHeader header;
     uint32_t region_start;
     uint32_t region_end;
@@ -83,8 +78,7 @@ struct [[gnu::packed]] MemoryRegionInfo
     }
 };
 
-struct [[gnu::packed]] Metadata
-{
+struct [[gnu::packed]] Metadata {
     NotesEntryHeader header;
     char json_data[]; // Null terminated
 };

--- a/Libraries/LibGfx/Font.cpp
+++ b/Libraries/LibGfx/Font.cpp
@@ -44,8 +44,7 @@
 
 namespace Gfx {
 
-struct [[gnu::packed]] FontFileHeader
-{
+struct [[gnu::packed]] FontFileHeader {
     char magic[4];
     u8 glyph_width;
     u8 glyph_height;

--- a/Libraries/LibGfx/ICOLoader.cpp
+++ b/Libraries/LibGfx/ICOLoader.cpp
@@ -60,8 +60,7 @@ struct ICONDIRENTRY {
 };
 static_assert(sizeof(ICONDIRENTRY) == 16);
 
-struct [[gnu::packed]] BMPFILEHEADER
-{
+struct [[gnu::packed]] BMPFILEHEADER {
     u8 signature[2];
     u32 size;
     u16 reserved1;
@@ -85,8 +84,7 @@ struct BITMAPINFOHEADER {
 };
 static_assert(sizeof(BITMAPINFOHEADER) == 40);
 
-struct [[gnu::packed]] BMP_ARGB
-{
+struct [[gnu::packed]] BMP_ARGB {
     u8 b;
     u8 g;
     u8 r;

--- a/Libraries/LibGfx/PNGLoader.cpp
+++ b/Libraries/LibGfx/PNGLoader.cpp
@@ -64,8 +64,7 @@ struct Scanline {
     ReadonlyBytes data {};
 };
 
-struct [[gnu::packed]] PaletteEntry
-{
+struct [[gnu::packed]] PaletteEntry {
     u8 r;
     u8 g;
     u8 b;
@@ -73,23 +72,20 @@ struct [[gnu::packed]] PaletteEntry
 };
 
 template<typename T>
-struct [[gnu::packed]] Tuple
-{
+struct [[gnu::packed]] Tuple {
     T gray;
     T a;
 };
 
 template<typename T>
-struct [[gnu::packed]] Triplet
-{
+struct [[gnu::packed]] Triplet {
     T r;
     T g;
     T b;
 };
 
 template<typename T>
-struct [[gnu::packed]] Quad
-{
+struct [[gnu::packed]] Quad {
     T r;
     T g;
     T b;
@@ -227,8 +223,7 @@ ALWAYS_INLINE static u8 paeth_predictor(int a, int b, int c)
     return c;
 }
 
-union [[gnu::packed]] Pixel
-{
+union [[gnu::packed]] Pixel {
     RGBA32 rgba { 0 };
     u8 v[4];
     struct {

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -856,7 +856,8 @@ void Editor::handle_read_event()
             }
             reverse_tab = false;
 
-            auto completion_mode = m_times_tab_pressed == 1 ? SuggestionManager::CompletePrefix : m_times_tab_pressed == 2 ? SuggestionManager::ShowSuggestions : SuggestionManager::CycleSuggestions;
+            auto completion_mode = m_times_tab_pressed == 1 ? SuggestionManager::CompletePrefix : m_times_tab_pressed == 2 ? SuggestionManager::ShowSuggestions
+                                                                                                                           : SuggestionManager::CycleSuggestions;
 
             auto completion_result = m_suggestion_manager.attempt_completion(completion_mode, token_start);
 

--- a/Libraries/LibWeb/HTML/AttributeNames.cpp
+++ b/Libraries/LibWeb/HTML/AttributeNames.cpp
@@ -34,10 +34,7 @@ namespace AttributeNames {
 ENUMERATE_HTML_ATTRIBUTES
 #undef __ENUMERATE_HTML_ATTRIBUTE
 
-    // clang-format off
-// FIXME: clang-format gets confused here. Why?
 [[gnu::constructor]] static void initialize()
-// clang-format off
 {
     static bool s_initialized = false;
     if (s_initialized)

--- a/Libraries/LibWeb/HTML/EventNames.cpp
+++ b/Libraries/LibWeb/HTML/EventNames.cpp
@@ -32,10 +32,7 @@ namespace Web::HTML::EventNames {
 ENUMERATE_HTML_EVENTS
 #undef __ENUMERATE_HTML_EVENT
 
-    // clang-format off
-// FIXME: clang-format gets confused here. Why?
 [[gnu::constructor]] static void initialize()
-// clang-format on
 {
     static bool s_initialized = false;
     if (s_initialized)

--- a/Libraries/LibWeb/HTML/TagNames.cpp
+++ b/Libraries/LibWeb/HTML/TagNames.cpp
@@ -32,10 +32,7 @@ namespace Web::HTML::TagNames {
 ENUMERATE_HTML_TAGS
 #undef __ENUMERATE_HTML_TAG
 
-    // clang-format off
-// FIXME: clang-format gets confused here. Why?
 [[gnu::constructor]] static void initialize()
-// clang-format on
 {
     static bool s_initialized = false;
     if (s_initialized)

--- a/Libraries/LibWeb/Namespace.cpp
+++ b/Libraries/LibWeb/Namespace.cpp
@@ -32,10 +32,7 @@ namespace Web::Namespace {
 ENUMERATE_NAMESPACES
 #undef __ENUMERATE_NAMESPACE
 
-    // clang-format off
-// FIXME: clang-format gets confused here. Why?
 [[gnu::constructor]] static void initialize()
-// clang-format on
 {
     static bool s_initialized = false;
     if (s_initialized)

--- a/Libraries/LibWeb/SVG/TagNames.cpp
+++ b/Libraries/LibWeb/SVG/TagNames.cpp
@@ -32,10 +32,7 @@ namespace Web::SVG::TagNames {
 ENUMERATE_SVG_TAGS
 #undef __ENUMERATE_SVG_TAG
 
-    // clang-format off
-// FIXME: clang-format gets confused here. Why?
 [[gnu::constructor]] static void initialize()
-// clang-format on
 {
     static bool s_initialized = false;
     if (s_initialized)

--- a/Libraries/LibWeb/UIEvents/EventNames.cpp
+++ b/Libraries/LibWeb/UIEvents/EventNames.cpp
@@ -32,10 +32,7 @@ namespace Web::UIEvents::EventNames {
 ENUMERATE_UI_EVENTS
 #undef __ENUMERATE_UI_EVENT
 
-    // clang-format off
-// FIXME: clang-format gets confused here. Why?
 [[gnu::constructor]] static void initialize()
-// clang-format on
 {
     static bool s_initialized = false;
     if (s_initialized)

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -6,17 +6,17 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.." || exit 1
 
 CLANG_FORMAT=false
-if command -v clang-format-10 >/dev/null 2>&1 ; then
-    CLANG_FORMAT=clang-format-10
+if command -v clang-format-11 >/dev/null 2>&1 ; then
+    CLANG_FORMAT=clang-format-11
 elif command -v clang-format >/dev/null 2>&1 ; then
     CLANG_FORMAT=clang-format
-    if ! "${CLANG_FORMAT}" --version | grep -qF ' 10.' ; then
-        echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 10."
+    if ! "${CLANG_FORMAT}" --version | grep -qF ' 11.' ; then
+        echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 11."
         echo "It is very likely that the resulting changes are not what you wanted."
     fi
 else
-    echo "clang-format-10 is not available. Either skip this script, or install clang-format-10."
-    echo "(If you install a package 'clang-format', please make sure it's version 10.)"
+    echo "clang-format-10 is not available. Either skip this script, or install clang-format-11."
+    echo "(If you install a package 'clang-format', please make sure it's version 11.)"
     exit 1
 fi
 

--- a/Services/DHCPClient/DHCPv4.h
+++ b/Services/DHCPClient/DHCPv4.h
@@ -194,8 +194,7 @@ struct ParsedDHCPv4Options {
 
 constexpr auto DHCPV4_OPTION_FIELD_MAX_LENGTH = 312;
 
-class [[gnu::packed]] DHCPv4Packet
-{
+class [[gnu::packed]] DHCPv4Packet {
 public:
     u8 op() const { return m_op; }
     void set_op(DHCPv4Op op) { m_op = (u8)op; }

--- a/Services/LookupServer/DNSPacket.h
+++ b/Services/LookupServer/DNSPacket.h
@@ -29,8 +29,7 @@
 #include <AK/Endian.h>
 #include <AK/Types.h>
 
-class [[gnu::packed]] DNSPacket
-{
+class [[gnu::packed]] DNSPacket {
 public:
     DNSPacket()
         : m_recursion_desired(false)

--- a/Services/LookupServer/DNSResponse.cpp
+++ b/Services/LookupServer/DNSResponse.cpp
@@ -32,8 +32,7 @@
 
 static String parse_dns_name(const u8* data, size_t& offset, size_t max_offset, size_t recursion_level = 0);
 
-class [[gnu::packed]] DNSRecordWithoutName
-{
+class [[gnu::packed]] DNSRecordWithoutName {
 public:
     DNSRecordWithoutName() { }
 

--- a/Userland/Tests/LibC/accuracy-strtod.cpp
+++ b/Userland/Tests/LibC/accuracy-strtod.cpp
@@ -314,10 +314,12 @@ static bool is_strtod_close(strtod_fn_t strtod_fn, const char* test_string, cons
     bool wrong_cns = !error_cns && (actual_consume != expect_consume);
 
     printf(" %s%s%s(%s%2u%s)",
-        ofby1_hex ? TEXT_OFBY1 : wrong_hex ? TEXT_WRONG : "",
+        ofby1_hex ? TEXT_OFBY1 : wrong_hex ? TEXT_WRONG
+                                           : "",
         actual_hex,
         (ofby1_hex || wrong_hex) ? TEXT_RESET : "",
-        error_cns ? TEXT_ERROR : wrong_cns ? TEXT_WRONG : "",
+        error_cns ? TEXT_ERROR : wrong_cns ? TEXT_WRONG
+                                           : "",
         actual_consume,
         (error_cns || wrong_cns) ? TEXT_RESET : "");
 

--- a/Userland/ntpquery.cpp
+++ b/Userland/ntpquery.cpp
@@ -46,8 +46,7 @@
 // The fractional part in the lower 32 bits stores fractional bits times 2 ** 32.
 typedef uint64_t NtpTimestamp;
 
-struct [[gnu::packed]] NtpPacket
-{
+struct [[gnu::packed]] NtpPacket {
     uint8_t li_vn_mode;
     uint8_t stratum;
     int8_t poll;


### PR DESCRIPTION
Compared to version 10 this fixes a bunch of formatting issues, mostly around structs/classes with attributes like `[[gnu::packed]]`, and incorrect insertion of spaces in parameter types (`T &`/`T &&`).
I also removed a bunch of `// clang-format off/on` and `FIXME` comments that are no longer relevant - on the other hand it tried to destroy a couple of neatly formatted comments, so I had to add some as well.