### PR TITLE
Kernel: Remove flawed SharedInodeVMObject assertion

### DIFF
--- a/Kernel/VM/SharedInodeVMObject.cpp
+++ b/Kernel/VM/SharedInodeVMObject.cpp
@@ -56,9 +56,4 @@ SharedInodeVMObject::SharedInodeVMObject(const SharedInodeVMObject& other)
 {
 }
 
-SharedInodeVMObject::~SharedInodeVMObject()
-{
-    ASSERT(inode().is_shared_vmobject(*this));
-}
-
 }

--- a/Kernel/VM/SharedInodeVMObject.h
+++ b/Kernel/VM/SharedInodeVMObject.h
@@ -36,8 +36,6 @@ class SharedInodeVMObject final : public InodeVMObject {
     AK_MAKE_NONMOVABLE(SharedInodeVMObject);
 
 public:
-    virtual ~SharedInodeVMObject() override;
-
     static NonnullRefPtr<SharedInodeVMObject> create_with_inode(Inode&);
     virtual NonnullRefPtr<VMObject> clone() override;
 


### PR DESCRIPTION
This assertion cannot be safely/reliably made in the
~SharedInodeVMObject destructor. The problem is that
Inode::is_shared_vmobject holds a weak reference to the instance
that is being destroyed (ref count 0). Checking the pointer using
WeakPtr::unsafe_ptr will produce nullptr depending on timing in
this case, and WeakPtr::safe_ref will reliably produce a nullptr
as soon as the reference count drops to 0. The only case where
this assertion could succeed is when WeakPtr::unsafe_ptr returned
the pointer because it won the race against revoking it. And
because WeakPtr::safe_ref will always return a nullptr, we cannot
reliably assert this from the ~SharedInodeVMObject destructor.

Fixes #4621