### PR TITLE
LibGUI: Don't change the actual combobox value while hovering it

### DIFF
--- a/Libraries/LibGUI/ComboBox.h
+++ b/Libraries/LibGUI/ComboBox.h
@@ -26,7 +26,9 @@
 
 #pragma once
 
+#include <LibGUI/AbstractView.h>
 #include <LibGUI/Frame.h>
+#include <LibGUI/Model.h>
 
 namespace GUI {
 
@@ -67,11 +69,17 @@ protected:
     virtual void resize_event(ResizeEvent&) override;
 
 private:
+    void selection_updated(const ModelIndex&);
+    void navigate(AbstractView::CursorMovement);
+    void navigate_relative(int);
+
     RefPtr<ComboBoxEditor> m_editor;
     RefPtr<ControlBoxButton> m_open_button;
     RefPtr<Window> m_list_window;
     RefPtr<ListView> m_list_view;
+    Optional<ModelIndex> m_selected_index;
     bool m_only_allow_values_from_model { false };
+    bool m_updating_model { false };
 };
 
 }

--- a/Libraries/LibGUI/ListView.cpp
+++ b/Libraries/LibGUI/ListView.cpp
@@ -213,7 +213,19 @@ void ListView::move_cursor_relative(int steps, SelectionUpdate selection_update)
     auto& model = *this->model();
     ModelIndex new_index;
     if (cursor_index().is_valid()) {
-        new_index = model.index(cursor_index().row() + steps, cursor_index().column());
+        auto row = cursor_index().row();
+        if (steps > 0) {
+            if (row + steps >= model.row_count())
+                row = model.row_count() - 1;
+            else
+                row += steps;
+        } else if (steps < 0) {
+            if (row < -steps)
+                row = 0;
+            else
+                row += steps;
+        }
+        new_index = model.index(row, cursor_index().column());
     } else {
         new_index = model.index(0, 0);
     }


### PR DESCRIPTION
We don't want to trigger an actual selection change until either
confirming the new selection by keyboard or clicking on it.
Dismissing the dropdown should have no effect on the current
selection.

Fixes #4657