### PR TITLE
LibThread+Piano: Make Piano not crash on exit anymore

### DIFF
--- a/Applications/Piano/main.cpp
+++ b/Applications/Piano/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char** argv)
         }
 
         Array<Sample, sample_count> buffer;
-        for (;;) {
+        while (!Core::EventLoop::current().was_exit_requested()) {
             track_manager.fill_buffer(buffer);
             audio->write(reinterpret_cast<u8*>(buffer.data()), buffer_size);
             Core::EventLoop::current().post_event(main_widget, make<Core::CustomEvent>(0));
@@ -101,6 +101,7 @@ int main(int argc, char** argv)
                 wav_writer.finalize();
             }
         }
+        return 0;
     });
     audio_thread->start();
 

--- a/Applications/Piano/main.cpp
+++ b/Applications/Piano/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
     Optional<String> save_path;
     bool need_to_write_wav = false;
 
-    LibThread::Thread audio_thread([&] {
+    auto audio_thread = LibThread::Thread::construct([&] {
         auto audio = Core::File::construct("/dev/audio");
         if (!audio->open(Core::IODevice::WriteOnly)) {
             dbgln("Can't open audio device: {}", audio->error_string());
@@ -102,7 +102,7 @@ int main(int argc, char** argv)
             }
         }
     });
-    audio_thread.start();
+    audio_thread->start();
 
     auto menubar = GUI::MenuBar::construct();
 

--- a/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/DevTools/HackStudio/HackStudioWidget.cpp
@@ -512,7 +512,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_debug_action()
         }
 
         Debugger::the().set_executable_path(get_project_executable_path());
-        m_debugger_thread = adopt(*new LibThread::Thread(Debugger::start_static));
+        m_debugger_thread = LibThread::Thread::construct(Debugger::start_static);
         m_debugger_thread->start();
     });
 }

--- a/Libraries/LibAudio/WavWriter.cpp
+++ b/Libraries/LibAudio/WavWriter.cpp
@@ -70,9 +70,11 @@ void WavWriter::finalize()
 {
     ASSERT(!m_finalized);
     m_finalized = true;
-    m_file->seek(0);
-    write_header();
-    m_file->close();
+    if (m_file) {
+        m_file->seek(0);
+        write_header();
+        m_file->close();
+    }
     m_data_sz = 0;
 }
 

--- a/Libraries/LibThread/Thread.cpp
+++ b/Libraries/LibThread/Thread.cpp
@@ -26,6 +26,7 @@
 
 #include <LibThread/Thread.h>
 #include <pthread.h>
+#include <string.h>
 #include <unistd.h>
 
 LibThread::Thread::Thread(Function<int()> action, StringView thread_name)
@@ -39,7 +40,7 @@ LibThread::Thread::~Thread()
 {
     if (m_tid) {
         dbg() << "trying to destroy a running thread!";
-        ASSERT_NOT_REACHED();
+        join();
     }
 }
 
@@ -66,7 +67,11 @@ void LibThread::Thread::start()
 
 void LibThread::Thread::join()
 {
-    pthread_join(m_tid, nullptr);
+    int rc = pthread_join(m_tid, nullptr);
+    if (rc == 0)
+        m_tid = 0;
+    else
+        warnln("pthread_join: {}", strerror(rc));
 }
 
 void LibThread::Thread::quit(void* code)

--- a/Libraries/LibThread/Thread.h
+++ b/Libraries/LibThread/Thread.h
@@ -37,7 +37,6 @@ class Thread final : public Core::Object {
     C_OBJECT(Thread);
 
 public:
-    explicit Thread(Function<int()> action, StringView thread_name = nullptr);
     virtual ~Thread();
 
     void start();
@@ -46,6 +45,7 @@ public:
     pthread_t tid() const { return m_tid; }
 
 private:
+    explicit Thread(Function<int()> action, StringView thread_name = nullptr);
     Function<int()> m_action;
     pthread_t m_tid { 0 };
     String m_thread_name;

--- a/Services/AudioServer/Mixer.cpp
+++ b/Services/AudioServer/Mixer.cpp
@@ -35,12 +35,12 @@ namespace AudioServer {
 
 Mixer::Mixer()
     : m_device(Core::File::construct("/dev/audio", this))
-    , m_sound_thread(
+    , m_sound_thread(LibThread::Thread::construct(
           [this] {
               mix();
               return 0;
           },
-          "AudioServer[mixer]")
+          "AudioServer[mixer]"))
 {
     if (!m_device->open(Core::IODevice::WriteOnly)) {
         dbgprintf("Can't open audio device: %s\n", m_device->error_string());
@@ -52,7 +52,7 @@ Mixer::Mixer()
 
     m_zero_filled_buffer = (u8*)malloc(4096);
     bzero(m_zero_filled_buffer, 4096);
-    m_sound_thread.start();
+    m_sound_thread->start();
 }
 
 Mixer::~Mixer()

--- a/Services/AudioServer/Mixer.h
+++ b/Services/AudioServer/Mixer.h
@@ -132,7 +132,7 @@ private:
 
     RefPtr<Core::File> m_device;
 
-    LibThread::Thread m_sound_thread;
+    NonnullRefPtr<LibThread::Thread> m_sound_thread;
 
     bool m_muted { false };
     int m_main_volume { 100 };


### PR DESCRIPTION
Hide the constructor of Thread, as it is a C_OBJECT. As far as *why* it needs to be a C_OBJECT, I have no idea, but the fact that it is one, and some users were constructing them on the stack is a big yikes. Make its constructor private and have all the callers use Thread::construct instead.

Give Thread jthread semantics. It will be joined on destruction. All callers except Piano are Services that have infinite loops in their Threads. Which... eh? Should probably be a way to gracefully exit those guys.

Make the thread in Piano exit when the Core::EventLoop it is using to post "custom event 0" for samples decides it's time to exit. In practice this means when Application::the().event_loop exits at the end of main. Because of the join-y semantics we changed in Thread, this works with a sad debug message instead of crashing horribly.