### PR TITLE
Kernel: Boot with Partition UUID

### DIFF
--- a/AK/UUID.cpp
+++ b/AK/UUID.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/AllOf.h>
+#include <AK/Hex.h>
+#include <AK/StringBuilder.h>
+#include <AK/UUID.h>
+
+namespace AK {
+UUID::UUID()
+{
+}
+
+UUID::UUID(Array<u8, 16> uuid_buffer)
+{
+    uuid_buffer.span().copy_to(m_uuid_buffer);
+}
+
+void UUID::convert_string_view_to_uuid(const StringView& uuid_string_view)
+{
+    ASSERT(uuid_string_view.length() == 36);
+    auto first_unit = decode_hex(uuid_string_view.substring_view(0, 8));
+    auto second_unit = decode_hex(uuid_string_view.substring_view(9, 4));
+    auto third_unit = decode_hex(uuid_string_view.substring_view(14, 4));
+    auto fourth_unit = decode_hex(uuid_string_view.substring_view(19, 4));
+    auto fifth_unit = decode_hex(uuid_string_view.substring_view(24, 12));
+
+    m_uuid_buffer.span().overwrite(0, first_unit.value().data(), first_unit.value().size());
+    m_uuid_buffer.span().overwrite(4, second_unit.value().data(), second_unit.value().size());
+    m_uuid_buffer.span().overwrite(6, third_unit.value().data(), third_unit.value().size());
+    m_uuid_buffer.span().overwrite(8, fourth_unit.value().data(), fourth_unit.value().size());
+    m_uuid_buffer.span().overwrite(10, fifth_unit.value().data(), fifth_unit.value().size());
+}
+
+UUID::UUID(const StringView& uuid_string_view)
+{
+    convert_string_view_to_uuid(uuid_string_view);
+}
+
+String UUID::to_string() const
+{
+    StringBuilder builder(36);
+    builder.append(encode_hex(m_uuid_buffer.span().trim(4)).view());
+    builder.append('-');
+    builder.append(encode_hex(m_uuid_buffer.span().slice(4).trim(2)).view());
+    builder.append('-');
+    builder.append(encode_hex(m_uuid_buffer.span().slice(6).trim(2)).view());
+    builder.append('-');
+    builder.append(encode_hex(m_uuid_buffer.span().slice(8).trim(2)).view());
+    builder.append('-');
+    builder.append(encode_hex(m_uuid_buffer.span().slice(10).trim(6)).view());
+    return builder.to_string();
+}
+
+bool UUID::operator==(const UUID& other) const
+{
+    for (size_t index = 0; index < 16; index++) {
+        if (m_uuid_buffer[index] != other.m_uuid_buffer[index])
+            return false;
+    }
+    return true;
+}
+
+bool UUID::is_zero() const
+{
+    return all_of(m_uuid_buffer.begin(), m_uuid_buffer.end(), [](const auto octet) { return octet == 0; });
+}
+
+}

--- a/AK/UUID.h
+++ b/AK/UUID.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/ByteBuffer.h>
+#include <AK/StringView.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+class UUID {
+public:
+    UUID();
+    UUID(Array<u8, 16> uuid_buffer);
+    UUID(const StringView&);
+    ~UUID() { }
+
+    bool operator==(const UUID&) const;
+    bool operator!=(const UUID& other) const { return !(*this == other); }
+    bool operator<=(const UUID&) const = delete;
+    bool operator>=(const UUID&) const = delete;
+    bool operator<(const UUID&) const = delete;
+    bool operator>(const UUID&) const = delete;
+
+    String to_string() const;
+    bool is_zero() const;
+
+private:
+    void convert_string_view_to_uuid(const StringView&);
+    void fill_buffer(ByteBuffer);
+
+    Array<u8, 16> m_uuid_buffer {};
+};
+
+}
+
+using AK::UUID;

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -212,8 +212,10 @@ set(KERNEL_SOURCES
 )
 
 set(AK_SOURCES
+    ../AK/ByteBuffer.cpp
     ../AK/FlyString.cpp
     ../AK/GenericLexer.cpp
+    ../AK/Hex.cpp
     ../AK/JsonParser.cpp
     ../AK/JsonValue.cpp
     ../AK/LexicalPath.cpp
@@ -225,6 +227,7 @@ set(AK_SOURCES
     ../AK/StringView.cpp
     ../AK/Time.cpp
     ../AK/Format.cpp
+    ../AK/UUID.cpp
 )
 
 set(ELF_SOURCES

--- a/Kernel/Storage/Partition/DiskPartition.cpp
+++ b/Kernel/Storage/Partition/DiskPartition.cpp
@@ -47,6 +47,11 @@ DiskPartition::~DiskPartition()
 {
 }
 
+const DiskPartitionMetadata& DiskPartition::metadata() const
+{
+    return m_metadata;
+}
+
 void DiskPartition::start_request(AsyncBlockDeviceRequest& request)
 {
     request.add_sub_request(m_device->make_request<AsyncBlockDeviceRequest>(request.request_type(),

--- a/Kernel/Storage/Partition/DiskPartition.h
+++ b/Kernel/Storage/Partition/DiskPartition.h
@@ -48,6 +48,8 @@ public:
     // ^Device
     virtual mode_t required_mode() const override { return 0600; }
 
+    const DiskPartitionMetadata& metadata() const;
+
 private:
     virtual const char* class_name() const override;
 

--- a/Kernel/Storage/Partition/DiskPartitionMetadata.cpp
+++ b/Kernel/Storage/Partition/DiskPartitionMetadata.cpp
@@ -24,31 +24,72 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/AllOf.h>
 #include <Kernel/Storage/Partition/DiskPartitionMetadata.h>
 
 namespace Kernel {
-DiskPartitionMetadata::DiskPartitionMetadata(u64 start_block, u64 end_block, ByteBuffer partition_type)
-    : m_start_block(start_block)
-    , m_end_block(end_block)
-    , m_partition_type(partition_type)
+
+DiskPartitionMetadata::PartitionType::PartitionType(u8 partition_type)
 {
-    ASSERT(!m_partition_type.is_empty());
+    m_partition_type[0] = partition_type;
 }
-DiskPartitionMetadata::DiskPartitionMetadata(u64 start_block, u64 end_block, ByteBuffer partition_guid, ByteBuffer unique_guid, u64 special_attributes, String name)
+DiskPartitionMetadata::PartitionType::PartitionType(Array<u8, 16> partition_type)
+    : m_partition_type_is_uuid(true)
+{
+    m_partition_type.span().overwrite(0, partition_type.data(), partition_type.size());
+}
+UUID DiskPartitionMetadata::PartitionType::to_uuid() const
+{
+    ASSERT(is_uuid());
+    return m_partition_type;
+}
+u8 DiskPartitionMetadata::PartitionType::to_byte_indicator() const
+{
+    ASSERT(!is_uuid());
+    return m_partition_type[0];
+}
+bool DiskPartitionMetadata::PartitionType::is_uuid() const
+{
+    return m_partition_type_is_uuid;
+}
+bool DiskPartitionMetadata::PartitionType::is_valid() const
+{
+    return !all_of(m_partition_type.begin(), m_partition_type.end(), [](const auto octet) { return octet == 0; });
+}
+
+DiskPartitionMetadata::DiskPartitionMetadata(u64 start_block, u64 end_block, u8 partition_type)
     : m_start_block(start_block)
     , m_end_block(end_block)
-    , m_partition_type(partition_guid)
+    , m_type(partition_type)
+{
+
+    ASSERT(m_type.is_valid());
+}
+
+DiskPartitionMetadata::DiskPartitionMetadata(u64 start_block, u64 end_block, Array<u8, 16> partition_type)
+    : m_start_block(start_block)
+    , m_end_block(end_block)
+    , m_type(partition_type)
+{
+
+    ASSERT(m_type.is_valid());
+}
+
+DiskPartitionMetadata::DiskPartitionMetadata(u64 start_block, u64 end_block, Array<u8, 16> partition_type, UUID unique_guid, u64 special_attributes, String name)
+    : m_start_block(start_block)
+    , m_end_block(end_block)
+    , m_type(partition_type)
     , m_unique_guid(unique_guid)
     , m_attributes(special_attributes)
     , m_name(name)
 {
-    ASSERT(!m_partition_type.is_empty());
-    ASSERT(!m_unique_guid.is_empty());
+    ASSERT(m_type.is_valid());
+    ASSERT(!m_unique_guid.is_zero());
 }
 
 DiskPartitionMetadata DiskPartitionMetadata::offset(u64 blocks_count) const
 {
-    return DiskPartitionMetadata({ blocks_count + m_start_block, blocks_count + m_end_block, m_partition_type });
+    return { blocks_count + m_start_block, blocks_count + m_end_block, m_type.m_partition_type };
 }
 
 u64 DiskPartitionMetadata::start_block() const
@@ -71,16 +112,12 @@ Optional<String> DiskPartitionMetadata::name() const
         return {};
     return m_name;
 }
-Optional<ByteBuffer> DiskPartitionMetadata::partition_type() const
+const DiskPartitionMetadata::PartitionType& DiskPartitionMetadata::type() const
 {
-    if (m_partition_type.is_null() || m_partition_type.is_empty())
-        return {};
-    return m_partition_type;
+    return m_type;
 }
-Optional<ByteBuffer> DiskPartitionMetadata::unique_guid() const
+const UUID& DiskPartitionMetadata::unique_guid() const
 {
-    if (m_unique_guid.is_null() || m_unique_guid.is_empty())
-        return {};
     return m_unique_guid;
 }
 

--- a/Kernel/Storage/Partition/DiskPartitionMetadata.h
+++ b/Kernel/Storage/Partition/DiskPartitionMetadata.h
@@ -27,14 +27,33 @@
 #pragma once
 
 #include <AK/RefPtr.h>
+#include <AK/UUID.h>
 #include <Kernel/Devices/BlockDevice.h>
 
 namespace Kernel {
 
 class DiskPartitionMetadata {
+private:
+    class PartitionType {
+        friend class DiskPartitionMetadata;
+
+    public:
+        explicit PartitionType(u8 partition_type);
+        explicit PartitionType(Array<u8, 16> partition_type);
+        UUID to_uuid() const;
+        u8 to_byte_indicator() const;
+        bool is_uuid() const;
+        bool is_valid() const;
+
+    private:
+        Array<u8, 16> m_partition_type {};
+        bool m_partition_type_is_uuid { false };
+    };
+
 public:
-    DiskPartitionMetadata(u64 block_offset, u64 block_limit, ByteBuffer partition_type);
-    DiskPartitionMetadata(u64 block_offset, u64 block_limit, ByteBuffer partition_type, ByteBuffer unique_guid, u64 special_attributes, String name);
+    DiskPartitionMetadata(u64 block_offset, u64 block_limit, u8 partition_type);
+    DiskPartitionMetadata(u64 start_block, u64 end_block, Array<u8, 16> partition_type);
+    DiskPartitionMetadata(u64 block_offset, u64 block_limit, Array<u8, 16> partition_type, UUID unique_guid, u64 special_attributes, String name);
     u64 start_block() const;
     u64 end_block() const;
 
@@ -42,14 +61,14 @@ public:
 
     Optional<u64> special_attributes() const;
     Optional<String> name() const;
-    Optional<ByteBuffer> partition_type() const;
-    Optional<ByteBuffer> unique_guid() const;
+    const PartitionType& type() const;
+    const UUID& unique_guid() const;
 
 private:
     u64 m_start_block;
     u64 m_end_block;
-    ByteBuffer m_partition_type;
-    ByteBuffer m_unique_guid;
+    PartitionType m_type;
+    UUID m_unique_guid {};
     u64 m_attributes { 0 };
     String m_name;
 };

--- a/Kernel/Storage/Partition/GUIDPartitionTable.h
+++ b/Kernel/Storage/Partition/GUIDPartitionTable.h
@@ -46,7 +46,7 @@ public:
     virtual bool is_valid() const override { return m_valid; };
 
 private:
-    bool is_unused_entry(ByteBuffer) const;
+    bool is_unused_entry(Array<u8, 16>) const;
     const GUIDPartitionHeader& header() const;
     bool initialize();
 

--- a/Kernel/Storage/StorageManagement.h
+++ b/Kernel/Storage/StorageManagement.h
@@ -41,9 +41,9 @@ class StorageManagement {
     AK_MAKE_ETERNAL;
 
 public:
-    StorageManagement(String root_device, bool force_pio);
+    StorageManagement(String boot_argument, bool force_pio);
     static bool initialized();
-    static void initialize(String root_device, bool force_pio);
+    static void initialize(String boot_argument, bool force_pio);
     static StorageManagement& the();
 
     NonnullRefPtr<FS> root_filesystem() const;
@@ -51,22 +51,24 @@ public:
     NonnullRefPtrVector<StorageController> ide_controllers() const;
 
 private:
-    NonnullRefPtr<BlockDevice> boot_block_device() const;
+    bool boot_argument_contains_partition_uuid();
 
     NonnullRefPtrVector<StorageController> enumerate_controllers(bool force_pio) const;
     NonnullRefPtrVector<StorageDevice> enumerate_storage_devices() const;
     NonnullRefPtrVector<DiskPartition> enumerate_disk_partitions() const;
 
-    NonnullRefPtr<StorageDevice> determine_boot_device(String root_device) const;
-    NonnullRefPtr<BlockDevice> determine_boot_block_device(String root_device) const;
+    void determine_boot_device();
+    void determine_boot_device_with_partition_uuid();
 
     OwnPtr<PartitionTable> try_to_initialize_partition_table(const StorageDevice&) const;
 
+    RefPtr<BlockDevice> boot_block_device() const;
+
+    String m_boot_argument;
+    RefPtr<BlockDevice> m_boot_block_device { nullptr };
     NonnullRefPtrVector<StorageController> m_controllers;
     NonnullRefPtrVector<StorageDevice> m_storage_devices;
     NonnullRefPtrVector<DiskPartition> m_disk_partitions;
-    NonnullRefPtr<StorageDevice> m_boot_device;
-    NonnullRefPtr<BlockDevice> m_boot_block_device;
 };
 
 }


### PR DESCRIPTION
Very simple, yet a neat feature that we all probably use in our Linux machines.
One can get the partition UUID (I quickly did it with an hex editor, but `cfdisk` also shows this value) of a GUID partition and specify it in a textual representation of a UUID in the kernel boot argument - `root=PARTUUID=123e4567-e89b-12d3-a456-426614174000`. If the kernel finds your partition, it will boot it :)
I used the [wikipedia article about UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier) to understand what is expected from the implementation.