### PR TITLE
Implement shortest round-trip float to string conversion

### DIFF
--- a/AK/FloatToDigits.cpp
+++ b/AK/FloatToDigits.cpp
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2020, Xavier Cooney <xavier.cooney03@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/FloatToDigits.h>
+#include <AK/StringBuilder.h>
+#include <AK/UnsignedBigInteger.h>
+#include <inttypes.h>
+#include <math.h>
+
+#ifndef KERNEL
+
+namespace AK {
+
+static UnsignedBigInteger binary_shift_big_int(const UnsignedBigInteger& x, int n)
+{
+    // The binary_shift_big_int function from paper
+    if (n >= 0) {
+        return x.shift_left(n);
+    } else {
+        return x.shift_right(n);
+    }
+}
+
+static void append_digit(const UnsignedBigInteger& digit, Vector<int>& digits)
+{
+    ASSERT(!digit.is_invalid() && digit.trimmed_length() <= 1);
+    auto& words = digit.words();
+    if (words.size() == 0) {
+        digits.append(0);
+    } else {
+        digits.append(words[0]);
+    }
+}
+
+static UnsignedBigInteger ceiling_big_int_division(const UnsignedBigInteger& dividend, const UnsignedBigInteger& divisor)
+{
+    auto division_result = dividend.divided_by(divisor);
+    if (division_result.remainder != 0) {
+        // Round up
+        return division_result.quotient.plus(1);
+    } else {
+        return division_result.quotient;
+    }
+}
+
+FloatToDigitsResult double_to_digits(double value, int base, FloatToDigitPrecisionMode cutoff_mode, int cutoff_place)
+{
+    // Perform the Dragon4 algorithm to render a floating point value as a string.
+    // The goal of the process is to be able to do do the conversion without loss,
+    // of information, while representing the value in the fewest characters as possible.
+    // No loss of information implies that a round-trip conversion should result in the same
+    // float value, assuming a correct string-to-float converter. Meeting these requirements is
+    // non-trivial, as for example 0.2 == 0.199999999999999999. Alternatively, if a lower precision
+    // is desired, the value outputted should be the closest possible to the actual value.
+    // This specific algorithm was first published 1990 by Steele and White in "How to print
+    // floating-point numbers accurately". (http://kurtstephens.com/files/p372-steele.pdf).
+    // The performance is not terrible, but relies on sommewhat large big integers.
+    // FIXME: there are newer and better algorithms, such as Grisu3 (which still needs a different
+    // algorithm, such as Dragon4 as a fallback), or Ryū, which are both faster, but more
+    // complicated. A good implementation of one of these algorithms could probably speed up
+    // this process by more than an order of magnitude.
+
+    // Most short variable names in this function, as well as the general structures,
+    // correspond to the 1990 paper.
+
+    ASSERT(cutoff_mode != FloatToDigitPrecisionMode::Relative || cutoff_place <= 0);
+    ASSERT(base >= 2);
+
+    static_assert(sizeof(double) == 8);
+    u8* u8_view_of_value = (u8*)(&value);
+
+    u64 value_bits_as_u64 = 0;
+
+    for (size_t i = 0; i < 8; ++i) {
+        value_bits_as_u64 = (value_bits_as_u64 << 8) | u8_view_of_value[7 - i];
+    }
+
+    u64 ieee754_significand = ((1ULL << 52) - 1) & value_bits_as_u64;
+    value_bits_as_u64 >>= 52;
+    u32 ieee754_exponent = ((1ULL << 11) - 1) & value_bits_as_u64;
+    value_bits_as_u64 >>= 11;
+    u8 ieee754_sign = value_bits_as_u64;
+
+    bool is_positive = ieee754_sign == 0;
+
+    u64 effective_significand, effective_exponent;
+    if (ieee754_exponent == 0x7FF6) {
+        // Either infinity or NaN. Either way, give an empty vector of digits.
+        return FloatToDigitsResult {
+            is_positive, {}, 0
+        };
+    } else if (ieee754_exponent == 0) {
+        // Subnormal
+        effective_significand = ieee754_significand;
+        effective_exponent = 1 - 1024 - 51;
+    } else {
+        // Normal
+        effective_significand = ieee754_significand + (1ULL << 52); // implict 1 in front
+        effective_exponent = static_cast<i64>(ieee754_exponent) - 1024 - 51;
+    }
+
+    // (-1)^ieee754_sign * f * 2^(e - p) = value
+    i64 f = effective_significand;
+    i64 p = 53;
+    i64 e = effective_exponent + p;
+
+    if (f == 0) {
+        Vector<int> output_digits;
+        output_digits.append(0);
+        return FloatToDigitsResult {
+            is_positive, output_digits, 0
+        };
+    }
+
+    UnsignedBigInteger R { static_cast<u32>(f >> 32) };
+    R = R.shift_left(32).bitwise_or((f & ((1ULL << 32) - 1))); // no i64 constructor
+    R = binary_shift_big_int(R, max(e - p, static_cast<i64>(0)));
+
+    UnsignedBigInteger S = binary_shift_big_int(1, max(static_cast<i64>(0), p - e));
+    // R / S == value
+
+    UnsignedBigInteger M_minus = binary_shift_big_int(1, max(static_cast<i64>(0), e - p));
+    UnsignedBigInteger M_plus = M_minus;
+    // M_minus / S == M_plus / S == 2^(e - p)
+
+    // Begin Simple-Fixup procedure
+    bool round_up_flag = false;
+
+    if (f == binary_shift_big_int(1, p - 1)) {
+        M_plus = binary_shift_big_int(M_plus, 1);
+        R = binary_shift_big_int(R, 1);
+        S = binary_shift_big_int(S, 1);
+    }
+
+    auto k = 0;
+
+    while (true) {
+        if (!(R < ceiling_big_int_division(S, base))) {
+            break;
+        }
+        k--;
+        R = R.multiplied_by(base);
+        M_plus = M_plus.multiplied_by(base);
+        M_minus = M_minus.multiplied_by(base);
+    }
+
+    while (!(R.multiplied_by(2).plus(M_plus) < S.multiplied_by(2))) {
+        while (!(R.multiplied_by(2).plus(M_plus) < S.multiplied_by(2))) {
+            S = S.multiplied_by(base);
+            k += 1;
+        }
+        bool needs_cutoff_adjust = false;
+        switch (cutoff_mode) {
+        case FloatToDigitPrecisionMode::None:
+            cutoff_place = k;
+            break;
+        case FloatToDigitPrecisionMode::Absolute:
+            needs_cutoff_adjust = true;
+            break;
+        case FloatToDigitPrecisionMode::Relative:
+            cutoff_place += k;
+            needs_cutoff_adjust = true;
+            break;
+        }
+
+        if (needs_cutoff_adjust) {
+            auto a = cutoff_place - k;
+            auto y = S;
+
+            if (a >= 0) {
+                for (int i = 0; i < a; ++i) {
+                    y = y.multiplied_by(base);
+                }
+            } else {
+                for (int i = 0; i < -a; ++i) {
+                    auto div_res = y.divided_by(base);
+                    if (div_res.remainder != 0) {
+                        div_res.quotient = div_res.quotient.plus(1);
+                    }
+                    y = div_res.quotient;
+                }
+            }
+
+            M_minus = max(y, M_minus);
+            M_plus = max(y, M_plus);
+
+            if (M_plus == y) {
+                round_up_flag = true;
+            }
+        } else {
+            break; // don't need to re-check 2R + M_plus >= 2S, as nothing was changed
+        }
+    }
+
+    // End of Simple-Fixup procedure
+
+    Vector<int> digit_outputs;
+    UnsignedBigInteger U;
+    bool low, high;
+
+    while (true) {
+        k -= 1;
+        auto div_result = R.multiplied_by(base).divided_by(S);
+        U = div_result.quotient;
+        R = div_result.remainder;
+        M_minus = M_minus.multiplied_by(base);
+        M_plus = M_plus.multiplied_by(base);
+        auto two_R = R.multiplied_by(2);
+        low = two_R < M_minus;
+        if (round_up_flag) {
+            high = !(two_R.plus(M_plus) < S.multiplied_by(2));
+        } else {
+            high = S.multiplied_by(2) < two_R.plus(M_plus);
+        }
+
+        if (!(!low && !high && k != cutoff_place)) {
+            break;
+        }
+        append_digit(U, digit_outputs);
+    }
+
+    if (low && !high) {
+        append_digit(U, digit_outputs);
+    } else if (high && !low) {
+        append_digit(U.plus(1), digit_outputs);
+    } else {
+        // If 2R == S, then either digit could be selected, both would be equally correect
+        if (R.multiplied_by(2) < S) {
+            append_digit(U, digit_outputs);
+        } else {
+            append_digit(U.plus(1), digit_outputs);
+        }
+    }
+
+    return { is_positive, digit_outputs, k };
+}
+
+String double_to_string(double value, int base, bool uppercase, FloatToStringMode float_to_string_mode, FloatToDigitPrecisionMode precision_mode, int precision, FormatBuilder::SignMode sign_mode)
+{
+    ASSERT(base >= 2 && base <= 36);
+    ASSERT(base == 10 || float_to_string_mode == FloatToStringMode::Fixed);
+
+    if (isnan(value)) {
+        if (uppercase)
+            return "NAN";
+        else
+            return "nan";
+    } else if (isinf(value)) {
+        if (value > 0) {
+            if (uppercase)
+                return "INF";
+            else
+                return "inf";
+        } else {
+            if (uppercase)
+                return "-INF";
+            else
+                return "-inf";
+        }
+    }
+
+    // Cutoff place has opposite sign to precision
+    auto result = double_to_digits(value, base, precision_mode, -precision);
+    auto& digits = result.digits;
+
+    int leftmost_digit_exponent = result.exponent + digits.size() - 1;
+    int rightmost_digit_exponent = result.exponent;
+
+    bool use_exponential_form = float_to_string_mode == FloatToStringMode::Exponential;
+    if (float_to_string_mode == FloatToStringMode::Shortest) {
+        int total_chars_for_decimal_form = digits.size();
+
+        if (rightmost_digit_exponent > 0) {
+            // trailing zeroes
+            total_chars_for_decimal_form += rightmost_digit_exponent;
+        }
+        if (leftmost_digit_exponent < 0) {
+            // leading zeroes
+            total_chars_for_decimal_form += -leftmost_digit_exponent;
+        }
+        if (rightmost_digit_exponent < 0) {
+            total_chars_for_decimal_form += 1; // decimal point
+        }
+
+        int total_chars_for_exponential_form = digits.size();
+        total_chars_for_exponential_form += 2; // "e+"
+        if (digits.size() > 1) {
+            total_chars_for_exponential_form += 1; // decimal point
+        }
+
+        total_chars_for_exponential_form += String::formatted("{:+}", leftmost_digit_exponent).length();
+
+        if (total_chars_for_exponential_form < total_chars_for_decimal_form) {
+            // Prefer decimal notation over exponential for equal lengths
+            use_exponential_form = true;
+        }
+    }
+
+    auto uppercase_digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    auto lowercase_digits = "0123456789abcdefghijklmnopqrstuvwxyz";
+    auto digit_set_used = uppercase ? uppercase_digits : lowercase_digits;
+
+    StringBuilder builder;
+
+    if (!result.is_positive) {
+        builder.append('-');
+    } else if (sign_mode == FormatBuilder::SignMode::Always) {
+        builder.append('+');
+    } else if (sign_mode == FormatBuilder::SignMode::Reserved) {
+        builder.append(' ');
+    }
+
+    if (use_exponential_form) {
+        for (size_t i = 0; i < digits.size(); ++i) {
+            if (i == 1) {
+                builder.append('.');
+            }
+            ASSERT(0 <= digits[i] && digits[i] <= 35);
+            builder.append(digit_set_used[digits[i]]);
+        }
+
+        builder.append(uppercase ? 'E' : 'e');
+        builder.append(String::formatted("{:+}", leftmost_digit_exponent));
+    } else {
+        for (int exponent = max(0, leftmost_digit_exponent); exponent >= min(0, rightmost_digit_exponent); exponent--) {
+            if (-exponent > precision && precision_mode == FloatToDigitPrecisionMode::Absolute) {
+                // Dragon4 will always output one digit, but that may be too much precision
+                continue;
+            }
+            if (exponent == -1) {
+                builder.append('.');
+            }
+
+            if (rightmost_digit_exponent <= exponent && exponent <= leftmost_digit_exponent) {
+                auto digit_num = -(exponent - leftmost_digit_exponent);
+                ASSERT(0 <= digit_num && digit_num < static_cast<int>(digits.size()));
+                ASSERT(0 <= digits[digit_num] && digits[digit_num] <= 35);
+                builder.append(digit_set_used[digits[digit_num]]);
+            } else {
+                builder.append('0'); // leading or trailing zero
+            }
+        }
+    }
+    if (builder.string_view().length() == 0) {
+        builder.append('0');
+    }
+
+    return builder.to_string();
+}
+
+}
+
+#endif // KERNEL

--- a/AK/FloatToDigits.h
+++ b/AK/FloatToDigits.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, Xavier Cooney <xavier.cooney03@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Format.h>
+#include <AK/Vector.h>
+
+namespace AK {
+
+#ifndef KERNEL
+
+struct FloatToDigitsResult {
+    bool is_positive;
+    Vector<int> digits;
+    int exponent;
+};
+
+enum class FloatToDigitPrecisionMode {
+    None,
+    Absolute,
+    Relative
+};
+
+enum class FloatToStringMode {
+    Shortest,
+    Fixed,
+    Exponential
+};
+
+FloatToDigitsResult double_to_digits(double value, int base, FloatToDigitPrecisionMode, int cutoff_place = 23);
+String double_to_string(double value, int base, bool uppercase, FloatToStringMode, FloatToDigitPrecisionMode, int precision = 23, FormatBuilder::SignMode = FormatBuilder::SignMode::OnlyIfNeeded);
+
+#endif // KERNEL
+
+}

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/FloatToDigits.h>
 #include <AK/Format.h>
 #include <AK/GenericLexer.h>
 #include <AK/String.h>
@@ -607,9 +608,11 @@ void Formatter<double>::format(FormatBuilder& builder, double value)
 {
     u8 base;
     bool upper_case;
+    auto float_to_string_mode = FloatToStringMode::Fixed;
     if (m_mode == Mode::Default || m_mode == Mode::Float) {
         base = 10;
         upper_case = false;
+        float_to_string_mode = FloatToStringMode::Shortest;
     } else if (m_mode == Mode::Hexfloat) {
         base = 16;
         upper_case = false;
@@ -623,7 +626,9 @@ void Formatter<double>::format(FormatBuilder& builder, double value)
     m_width = m_width.value_or(0);
     m_precision = m_precision.value_or(6);
 
-    builder.put_f64(value, base, upper_case, m_align, m_width.value(), m_precision.value(), m_fill, m_sign_mode);
+    auto result = double_to_string(value, base, upper_case, float_to_string_mode, FloatToDigitPrecisionMode::Absolute, m_precision.value(), m_sign_mode);
+
+    builder.put_string(result, m_align, m_width.value(), NumericLimits<size_t>::max(), m_fill);
 }
 void Formatter<float>::format(FormatBuilder& builder, float value)
 {

--- a/AK/SignedBigInteger.cpp
+++ b/AK/SignedBigInteger.cpp
@@ -24,10 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "SignedBigInteger.h"
+#include <AK/SignedBigInteger.h>
 #include <AK/StringBuilder.h>
 
-namespace Crypto {
+namespace AK {
 
 SignedBigInteger SignedBigInteger::import_data(const u8* ptr, size_t length)
 {

--- a/AK/SignedBigInteger.h
+++ b/AK/SignedBigInteger.h
@@ -27,9 +27,9 @@
 #pragma once
 
 #include <AK/Span.h>
-#include <LibCrypto/BigInt/UnsignedBigInteger.h>
+#include <AK/UnsignedBigInteger.h>
 
-namespace Crypto {
+namespace AK {
 
 struct SignedDivisionResult;
 
@@ -135,14 +135,17 @@ private:
 };
 
 struct SignedDivisionResult {
-    Crypto::SignedBigInteger quotient;
-    Crypto::SignedBigInteger remainder;
+    SignedBigInteger quotient;
+    SignedBigInteger remainder;
 };
 
 }
 
+using AK::SignedBigInteger;
+using AK::SignedDivisionResult;
+
 inline const LogStream&
-operator<<(const LogStream& stream, const Crypto::SignedBigInteger value)
+operator<<(const LogStream& stream, const SignedBigInteger value)
 {
     if (value.is_invalid()) {
         stream << "Invalid BigInt";
@@ -155,8 +158,8 @@ operator<<(const LogStream& stream, const Crypto::SignedBigInteger value)
     return stream;
 }
 
-inline Crypto::SignedBigInteger
+inline SignedBigInteger
 operator""_sbigint(const char* string, size_t length)
 {
-    return Crypto::SignedBigInteger::from_base10({ string, length });
+    return SignedBigInteger::from_base10({ string, length });
 }

--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(AK_TEST_SOURCES
     TestCircularQueue.cpp
     TestDistinctNumeric.cpp
     TestEndian.cpp
+    TestFloatToDigits.cpp
     TestFormat.cpp
     TestHashFunctions.cpp
     TestHashMap.cpp

--- a/AK/Tests/TestFloatToDigits.cpp
+++ b/AK/Tests/TestFloatToDigits.cpp
@@ -1,0 +1,129 @@
+#include <AK/TestSuite.h>
+
+#include <AK/FloatToDigits.h>
+#include <math.h>
+
+[[nodiscard]] static bool check_digits_are_equal(Vector<int> a, Vector<int> b)
+{
+    if (a.size() != b.size())
+        return false;
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (a[i] != b[i])
+            return false;
+    }
+    return true;
+}
+
+TEST_CASE(digits_one)
+{
+    auto res = AK::double_to_digits(0x1p+0, 10, AK::FloatToDigitPrecisionMode::None, 0);
+    EXPECT(res.is_positive);
+    EXPECT_EQ(res.exponent, 0);
+    EXPECT(check_digits_are_equal(res.digits, { 1 }));
+}
+
+TEST_CASE(digits_negative_one)
+{
+    auto res = AK::double_to_digits(-0x1p+0, 10, AK::FloatToDigitPrecisionMode::None, 0);
+    EXPECT(!res.is_positive);
+    EXPECT_EQ(res.exponent, 0);
+    EXPECT(check_digits_are_equal(res.digits, { 1 }));
+}
+
+TEST_CASE(digits_subnormal)
+{
+    // 0x0.00000000009c3p-1022 = 1.2347e-320
+    auto res = AK::double_to_digits(0x0.00000000009c3p-1022, 10, AK::FloatToDigitPrecisionMode::None, 0);
+    EXPECT(res.is_positive);
+    EXPECT_EQ(res.exponent, -324);
+    EXPECT(check_digits_are_equal(res.digits, { 1, 2, 3, 4, 7 }));
+}
+
+TEST_CASE(digits_negative_subnormal)
+{
+    auto res = AK::double_to_digits(-0x0.00000000009c3p-1022, 10, AK::FloatToDigitPrecisionMode::None, 0);
+    EXPECT(!res.is_positive);
+    EXPECT_EQ(res.exponent, -324);
+    EXPECT(check_digits_are_equal(res.digits, { 1, 2, 3, 4, 7 }));
+}
+
+TEST_CASE(digits_zero)
+{
+    auto res = AK::double_to_digits(0x0p+0, 10, AK::FloatToDigitPrecisionMode::None, 0);
+    EXPECT(res.is_positive);
+    EXPECT_EQ(res.exponent, 0);
+    EXPECT(check_digits_are_equal(res.digits, { 0 }));
+}
+
+TEST_CASE(digits_negative_zero)
+{
+    auto res = AK::double_to_digits(-0x0p+0, 10, AK::FloatToDigitPrecisionMode::None, 0);
+    EXPECT(!res.is_positive);
+    EXPECT_EQ(res.exponent, 0);
+    EXPECT(check_digits_are_equal(res.digits, { 0 }));
+}
+
+TEST_CASE(str_infinity)
+{
+    EXPECT_EQ("inf", AK::double_to_string(INFINITY, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("INF", AK::double_to_string(INFINITY, 10, true, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("-inf", AK::double_to_string(-INFINITY, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("-INF", AK::double_to_string(-INFINITY, 10, true, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+}
+
+TEST_CASE(str_nan)
+{
+    EXPECT_EQ("nan", AK::double_to_string(NAN, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("NAN", AK::double_to_string(NAN, 10, true, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+}
+
+TEST_CASE(str_one)
+{
+    EXPECT_EQ("1", AK::double_to_string(0x1p+0, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("-1", AK::double_to_string(-0x1p+0, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+}
+
+TEST_CASE(str_sign_mode)
+{
+    EXPECT_EQ("123.45", AK::double_to_string(0x1.edccccccccccdp+6, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("-123.45", AK::double_to_string(-0x1.edccccccccccdp+6, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("+123.45", AK::double_to_string(0x1.edccccccccccdp+6, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None, 23, AK::FormatBuilder::SignMode::Always));
+    EXPECT_EQ(" 123.45", AK::double_to_string(0x1.edccccccccccdp+6, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None, 23, AK::FormatBuilder::SignMode::Reserved));
+}
+
+TEST_CASE(str_test_float_to_str_mode)
+{
+    EXPECT_EQ("3.14e-5", AK::double_to_string(0x1.0766fc8e5b77fp-15, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("0.000314", AK::double_to_string(0x1.4940bbb1f255fp-12, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("3140000", AK::double_to_string(0x1.7f4dp+21, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("3.14e+8", AK::double_to_string(0x1.2b7428p+28, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("7e+0", AK::double_to_string(0x1.cp+2, 10, false, AK::FloatToStringMode::Exponential, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("700000000", AK::double_to_string(0x1.4dc938p+29, 10, false, AK::FloatToStringMode::Fixed, AK::FloatToDigitPrecisionMode::None));
+}
+
+TEST_CASE(str_base)
+{
+    EXPECT_EQ("1111011.011101001111000000001001000100011111011101111", AK::double_to_string(0x1.edd3c02447ddep+6, 2, false, AK::FloatToStringMode::Fixed, AK::FloatToDigitPrecisionMode::None));
+    EXPECT_EQ("3f.gfzvuftmj", AK::double_to_string(0x1.edd3c02447ddep+6, 36, false, AK::FloatToStringMode::Fixed, AK::FloatToDigitPrecisionMode::None));
+}
+
+TEST_CASE(str_precision_relative)
+{
+    EXPECT_EQ("3000", AK::double_to_string(0x1.89ep+11, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::Relative, 1));
+    EXPECT_EQ("3200", AK::double_to_string(0x1.89ep+11, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::Relative, 2));
+    EXPECT_EQ("3150", AK::double_to_string(0x1.89ep+11, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::Relative, 3));
+    EXPECT_EQ("3151", AK::double_to_string(0x1.89ep+11, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::Relative, 4));
+    EXPECT_EQ("3151", AK::double_to_string(0x1.89ep+11, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::Relative, 100));
+}
+
+TEST_CASE(str_precision_absolute)
+{
+    EXPECT_EQ("3150", AK::double_to_string(0x1.89e4d4fdf3b64p+11, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::Absolute, -1));
+    EXPECT_EQ("3151", AK::double_to_string(0x1.89e4d4fdf3b64p+11, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::Absolute, 0));
+    EXPECT_EQ("3151.2", AK::double_to_string(0x1.89e4d4fdf3b64p+11, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::Absolute, 1));
+    EXPECT_EQ("3151.15", AK::double_to_string(0x1.89e4d4fdf3b64p+11, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::Absolute, 2));
+    EXPECT_EQ("3151.151", AK::double_to_string(0x1.89e4d4fdf3b64p+11, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::Absolute, 3));
+    EXPECT_EQ("3151.151", AK::double_to_string(0x1.89e4d4fdf3b64p+11, 10, false, AK::FloatToStringMode::Shortest, AK::FloatToDigitPrecisionMode::Absolute, 100));
+}
+
+TEST_MAIN(FloatToDigits)

--- a/AK/Tests/TestFormat.cpp
+++ b/AK/Tests/TestFormat.cpp
@@ -248,11 +248,11 @@ TEST_CASE(file_descriptor)
 
 TEST_CASE(floating_point_numbers)
 {
-    EXPECT_EQ(String::formatted("{}", 1.12), "1.120000");
-    EXPECT_EQ(String::formatted("{}", 1.), "1.000000");
-    EXPECT_EQ(String::formatted("{:.3}", 1.12), "1.120");
+    EXPECT_EQ(String::formatted("{}", 1.12), "1.12");
+    EXPECT_EQ(String::formatted("{}", 1.), "1");
+    EXPECT_EQ(String::formatted("{:.3}", 1.12), "1.12");
     EXPECT_EQ(String::formatted("{:.1}", 1.12), "1.1");
-    EXPECT_EQ(String::formatted("{}", -1.12), "-1.120000");
+    EXPECT_EQ(String::formatted("{}", -1.12), "-1.12");
 
     // FIXME: There is always the question what we mean with the width field. Do we mean significant digits?
     //        Do we mean the whole width? This is what was the simplest to implement:
@@ -261,12 +261,12 @@ TEST_CASE(floating_point_numbers)
 
 TEST_CASE(no_precision_no_trailing_number)
 {
-    EXPECT_EQ(String::formatted("{:.0}", 0.1), "0.");
+    EXPECT_EQ(String::formatted("{:.0}", 0.1), "0");
 }
 
 TEST_CASE(yay_this_implementation_sucks)
 {
-    EXPECT_EQ(String::formatted("{:.0}", .99999999999), "0.");
+    EXPECT_EQ(String::formatted("{:.0}", .99999999999), "0");
 }
 
 TEST_MAIN(Format)

--- a/AK/UnsignedBigInteger.cpp
+++ b/AK/UnsignedBigInteger.cpp
@@ -24,8 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/UnsignedBigInteger.h>
 #include <AK/StringBuilder.h>
+#include <AK/UnsignedBigInteger.h>
 
 namespace AK {
 
@@ -219,6 +219,28 @@ FLATTEN UnsignedBigInteger UnsignedBigInteger::shift_left(size_t num_bits) const
     shift_left_without_allocation(*this, num_bits, temp_result, temp_plus, output);
 
     return output;
+}
+
+FLATTEN UnsignedBigInteger UnsignedBigInteger::shift_right(size_t num_bits) const
+{
+    // FIXME: This could be more optimised for performance using a similar technique
+    // that's used in shift_left
+
+    UnsignedBigInteger result;
+
+    for (size_t word_index = 0; word_index < trimmed_length(); ++word_index) {
+        for (size_t bit_index = 0; bit_index < BITS_IN_WORD; ++bit_index) {
+            auto bit_value = m_words[word_index] & (1 << bit_index);
+            if (bit_value) {
+                auto new_bit_index = word_index * BITS_IN_WORD + bit_index;
+                if (new_bit_index >= num_bits) {
+                    result.set_bit_inplace(new_bit_index - num_bits);
+                }
+            }
+        }
+    }
+
+    return result;
 }
 
 FLATTEN UnsignedBigInteger UnsignedBigInteger::multiplied_by(const UnsignedBigInteger& other) const

--- a/AK/UnsignedBigInteger.cpp
+++ b/AK/UnsignedBigInteger.cpp
@@ -24,10 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "UnsignedBigInteger.h"
+#include <AK/UnsignedBigInteger.h>
 #include <AK/StringBuilder.h>
 
-namespace Crypto {
+namespace AK {
 
 UnsignedBigInteger::UnsignedBigInteger(const u8* ptr, size_t length)
 {

--- a/AK/UnsignedBigInteger.h
+++ b/AK/UnsignedBigInteger.h
@@ -89,6 +89,7 @@ public:
     UnsignedBigInteger bitwise_xor(const UnsignedBigInteger& other) const;
     UnsignedBigInteger bitwise_not() const;
     UnsignedBigInteger shift_left(size_t num_bits) const;
+    UnsignedBigInteger shift_right(size_t num_bits) const;
     UnsignedBigInteger multiplied_by(const UnsignedBigInteger& other) const;
     UnsignedDivisionResult divided_by(const UnsignedBigInteger& divisor) const;
 

--- a/AK/UnsignedBigInteger.h
+++ b/AK/UnsignedBigInteger.h
@@ -33,7 +33,7 @@
 #include <AK/Types.h>
 #include <AK/Vector.h>
 
-namespace Crypto {
+namespace AK {
 
 struct UnsignedDivisionResult;
 constexpr size_t STARTING_WORD_SIZE = 512;
@@ -125,14 +125,17 @@ private:
 };
 
 struct UnsignedDivisionResult {
-    Crypto::UnsignedBigInteger quotient;
-    Crypto::UnsignedBigInteger remainder;
+    UnsignedBigInteger quotient;
+    UnsignedBigInteger remainder;
 };
 
 }
 
+using AK::UnsignedBigInteger;
+using AK::UnsignedDivisionResult;
+
 inline const LogStream&
-operator<<(const LogStream& stream, const Crypto::UnsignedBigInteger& value)
+operator<<(const LogStream& stream, const UnsignedBigInteger& value)
 {
     if (value.is_invalid()) {
         stream << "Invalid BigInt";
@@ -144,8 +147,8 @@ operator<<(const LogStream& stream, const Crypto::UnsignedBigInteger& value)
     return stream;
 }
 
-inline Crypto::UnsignedBigInteger
+inline UnsignedBigInteger
 operator""_bigint(const char* string, size_t length)
 {
-    return Crypto::UnsignedBigInteger::from_base10({ string, length });
+    return UnsignedBigInteger::from_base10({ string, length });
 }

--- a/Libraries/LibCrypto/ASN1/ASN1.h
+++ b/Libraries/LibCrypto/ASN1/ASN1.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include <AK/Types.h>
-#include <LibCrypto/BigInt/UnsignedBigInteger.h>
+#include <AK/UnsignedBigInteger.h>
 
 namespace Crypto {
 

--- a/Libraries/LibCrypto/ASN1/DER.h
+++ b/Libraries/LibCrypto/ASN1/DER.h
@@ -27,8 +27,8 @@
 #pragma once
 
 #include <AK/Types.h>
+#include <AK/UnsignedBigInteger.h>
 #include <LibCrypto/ASN1/ASN1.h>
-#include <LibCrypto/BigInt/UnsignedBigInteger.h>
 
 namespace Crypto {
 

--- a/Libraries/LibCrypto/Authentication/GHash.cpp
+++ b/Libraries/LibCrypto/Authentication/GHash.cpp
@@ -26,9 +26,9 @@
 
 #include <AK/MemoryStream.h>
 #include <AK/Types.h>
+#include <AK/UnsignedBigInteger.h>
 #include <AK/Vector.h>
 #include <LibCrypto/Authentication/GHash.h>
-#include <LibCrypto/BigInt/UnsignedBigInteger.h>
 
 namespace {
 

--- a/Libraries/LibCrypto/CMakeLists.txt
+++ b/Libraries/LibCrypto/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(SOURCES
     Authentication/GHash.cpp
-    BigInt/SignedBigInteger.cpp
-    BigInt/UnsignedBigInteger.cpp
     Checksum/Adler32.cpp
     Checksum/CRC32.cpp
     Cipher/AES.cpp

--- a/Libraries/LibCrypto/NumberTheory/ModularFunctions.h
+++ b/Libraries/LibCrypto/NumberTheory/ModularFunctions.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include <AK/Random.h>
-#include <LibCrypto/BigInt/UnsignedBigInteger.h>
+#include <AK/UnsignedBigInteger.h>
 
 //#define NT_DEBUG
 

--- a/Libraries/LibCrypto/PK/RSA.h
+++ b/Libraries/LibCrypto/PK/RSA.h
@@ -27,8 +27,8 @@
 #pragma once
 
 #include <AK/Span.h>
+#include <AK/UnsignedBigInteger.h>
 #include <AK/Vector.h>
-#include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibCrypto/NumberTheory/ModularFunctions.h>
 #include <LibCrypto/PK/Code/EMSA_PSS.h>
 #include <LibCrypto/PK/PK.h>

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -28,9 +28,9 @@
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <AK/ScopeGuard.h>
+#include <AK/SignedBigInteger.h>
 #include <AK/StringBuilder.h>
 #include <AK/TemporaryChange.h>
-#include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibJS/AST.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/Accessor.h>
@@ -1470,13 +1470,13 @@ Value UpdateExpression::execute(Interpreter& interpreter, GlobalObject& global_o
         if (old_value.is_number())
             new_value = Value(old_value.as_double() + 1);
         else
-            new_value = js_bigint(interpreter.heap(), old_value.as_bigint().big_integer().plus(Crypto::SignedBigInteger { 1 }));
+            new_value = js_bigint(interpreter.heap(), old_value.as_bigint().big_integer().plus(SignedBigInteger { 1 }));
         break;
     case UpdateOp::Decrement:
         if (old_value.is_number())
             new_value = Value(old_value.as_double() - 1);
         else
-            new_value = js_bigint(interpreter.heap(), old_value.as_bigint().big_integer().minus(Crypto::SignedBigInteger { 1 }));
+            new_value = js_bigint(interpreter.heap(), old_value.as_bigint().big_integer().minus(SignedBigInteger { 1 }));
         break;
     default:
         ASSERT_NOT_REACHED();
@@ -1828,7 +1828,7 @@ Value BigIntLiteral::execute(Interpreter& interpreter, GlobalObject&) const
     interpreter.enter_node(*this);
     ScopeGuard exit_node { [&] { interpreter.exit_node(*this); } };
 
-    return js_bigint(interpreter.heap(), Crypto::SignedBigInteger::from_base10(m_value.substring(0, m_value.length() - 1)));
+    return js_bigint(interpreter.heap(), SignedBigInteger::from_base10(m_value.substring(0, m_value.length() - 1)));
 }
 
 Value BooleanLiteral::execute(Interpreter& interpreter, GlobalObject&) const

--- a/Libraries/LibJS/Runtime/BigInt.cpp
+++ b/Libraries/LibJS/Runtime/BigInt.cpp
@@ -24,13 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LibCrypto/BigInt/SignedBigInteger.h>
+#include <AK/SignedBigInteger.h>
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/BigInt.h>
 
 namespace JS {
 
-BigInt::BigInt(Crypto::SignedBigInteger big_integer)
+BigInt::BigInt(SignedBigInteger big_integer)
     : m_big_integer(move(big_integer))
 {
     ASSERT(!m_big_integer.is_invalid());
@@ -40,7 +40,7 @@ BigInt::~BigInt()
 {
 }
 
-BigInt* js_bigint(Heap& heap, Crypto::SignedBigInteger big_integer)
+BigInt* js_bigint(Heap& heap, SignedBigInteger big_integer)
 {
     return heap.allocate_without_global_object<BigInt>(move(big_integer));
 }

--- a/Libraries/LibJS/Runtime/BigInt.h
+++ b/Libraries/LibJS/Runtime/BigInt.h
@@ -26,25 +26,25 @@
 
 #pragma once
 
-#include <LibCrypto/BigInt/SignedBigInteger.h>
+#include <AK/SignedBigInteger.h>
 #include <LibJS/Runtime/Cell.h>
 
 namespace JS {
 
 class BigInt final : public Cell {
 public:
-    BigInt(Crypto::SignedBigInteger);
+    BigInt(SignedBigInteger);
     virtual ~BigInt();
 
-    const Crypto::SignedBigInteger& big_integer() const { return m_big_integer; }
+    const SignedBigInteger& big_integer() const { return m_big_integer; }
     const String to_string() const { return String::formatted("{}n", m_big_integer.to_base10()); }
 
 private:
     virtual const char* class_name() const override { return "BigInt"; }
 
-    Crypto::SignedBigInteger m_big_integer;
+    SignedBigInteger m_big_integer;
 };
 
-BigInt* js_bigint(Heap&, Crypto::SignedBigInteger);
+BigInt* js_bigint(Heap&, SignedBigInteger);
 
 }

--- a/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -24,8 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/SignedBigInteger.h>
 #include <AK/String.h>
-#include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibJS/Runtime/BigIntConstructor.h>
 #include <LibJS/Runtime/BigIntObject.h>
 #include <LibJS/Runtime/Error.h>
@@ -65,7 +65,7 @@ Value BigIntConstructor::call()
             vm().throw_exception<RangeError>(global_object(), ErrorType::BigIntIntArgument);
             return {};
         }
-        return js_bigint(heap(), Crypto::SignedBigInteger { primitive.as_i32() });
+        return js_bigint(heap(), SignedBigInteger { primitive.as_i32() });
     }
     auto* bigint = vm().argument(0).to_bigint(global_object());
     if (vm().exception())

--- a/Libraries/LibTLS/Certificate.h
+++ b/Libraries/LibTLS/Certificate.h
@@ -30,7 +30,7 @@
 #include <AK/Forward.h>
 #include <AK/Singleton.h>
 #include <AK/Types.h>
-#include <LibCrypto/BigInt/UnsignedBigInteger.h>
+#include <AK/UnsignedBigInteger.h>
 #include <LibCrypto/PK/RSA.h>
 
 namespace TLS {
@@ -50,8 +50,8 @@ struct Certificate {
     CertificateKeyAlgorithm key_algorithm;
     CertificateKeyAlgorithm ec_algorithm;
     ByteBuffer exponent;
-    Crypto::PK::RSAPublicKey<Crypto::UnsignedBigInteger> public_key;
-    Crypto::PK::RSAPrivateKey<Crypto::UnsignedBigInteger> private_key;
+    Crypto::PK::RSAPublicKey<UnsignedBigInteger> public_key;
+    Crypto::PK::RSAPrivateKey<UnsignedBigInteger> private_key;
     String issuer_country;
     String issuer_state;
     String issuer_location;
@@ -68,7 +68,7 @@ struct Certificate {
     String unit;
     Vector<String> SAN;
     u8* ocsp;
-    Crypto::UnsignedBigInteger serial_number;
+    UnsignedBigInteger serial_number;
     ByteBuffer sign_key;
     ByteBuffer fingerprint;
     ByteBuffer der;

--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -273,14 +273,14 @@ static ssize_t _parse_asn1(const Context& context, Certificate& cert, const u8* 
 
                     if (index == 1)
                         cert.public_key.set(
-                            Crypto::UnsignedBigInteger::import_data(buffer + position, length),
+                            UnsignedBigInteger::import_data(buffer + position, length),
                             cert.public_key.public_exponent());
                     else if (index == 2)
                         cert.public_key.set(
                             cert.public_key.modulus(),
-                            Crypto::UnsignedBigInteger::import_data(buffer + position, length));
+                            UnsignedBigInteger::import_data(buffer + position, length));
                 } else if (_asn1_is_field_present(fields, Constants::serial_id)) {
-                    cert.serial_number = Crypto::UnsignedBigInteger::import_data(buffer + position, length);
+                    cert.serial_number = UnsignedBigInteger::import_data(buffer + position, length);
                 }
                 if (_asn1_is_field_present(fields, Constants::version_id)) {
                     if (length == 1)

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -28,12 +28,12 @@
 
 #include "Certificate.h"
 #include <AK/IPv4Address.h>
+#include <AK/UnsignedBigInteger.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/Socket.h>
 #include <LibCore/TCPSocket.h>
 #include <LibCrypto/Authentication/HMAC.h>
-#include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibCrypto/Cipher/AES.h>
 #include <LibCrypto/Hash/HashManager.h>
 #include <LibCrypto/PK/RSA.h>

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -2489,6 +2489,22 @@ static void bigint_bitwise()
             FAIL(Invalid value);
         }
     }
+    {
+        I_TEST((BigInteger | Bit shift right));
+        if ("273811808808105304499849984103569"_bigint.shift_right(42) == "62257597348458444798"_bigint) {
+            PASS;
+        } else {
+            FAIL(Invalid value);
+        }
+    }
+    {
+        I_TEST((BigInteger | Bit shift right to zero));
+        if ("273811808808105304499849984103569"_bigint.shift_right(108) == "0"_bigint) {
+            PASS;
+        } else {
+            FAIL(Invalid value);
+        }
+    }
 }
 
 static void bigint_test_signed_fibo500()

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -25,14 +25,14 @@
  */
 
 #include <AK/Random.h>
+#include <AK/SignedBigInteger.h>
+#include <AK/UnsignedBigInteger.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibCrypto/Authentication/GHash.h>
 #include <LibCrypto/Authentication/HMAC.h>
-#include <LibCrypto/BigInt/SignedBigInteger.h>
-#include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibCrypto/Checksum/Adler32.h>
 #include <LibCrypto/Checksum/CRC32.h>
 #include <LibCrypto/Cipher/AES.h>
@@ -1851,10 +1851,10 @@ static void bigint_test_number_theory()
     }
     {
         struct {
-            Crypto::UnsignedBigInteger base;
-            Crypto::UnsignedBigInteger exp;
-            Crypto::UnsignedBigInteger mod;
-            Crypto::UnsignedBigInteger expected;
+            UnsignedBigInteger base;
+            UnsignedBigInteger exp;
+            UnsignedBigInteger mod;
+            UnsignedBigInteger expected;
         } mod_pow_tests[] = {
             { "2988348162058574136915891421498819466320163312926952423791023078876139"_bigint, "2351399303373464486466122544523690094744975233415544072992656881240319"_bigint, "10000"_bigint, "3059"_bigint },
             { "24231"_bigint, "12448"_bigint, "14679"_bigint, "4428"_bigint },
@@ -1882,7 +1882,7 @@ static void bigint_test_number_theory()
     }
     {
         struct {
-            Crypto::UnsignedBigInteger candidate;
+            UnsignedBigInteger candidate;
             bool expected_result;
         } primality_tests[] = {
             { "1180591620717411303424"_bigint, false },                  // 2**70
@@ -1917,8 +1917,8 @@ static void bigint_test_number_theory()
     }
     {
         struct {
-            Crypto::UnsignedBigInteger min;
-            Crypto::UnsignedBigInteger max;
+            UnsignedBigInteger min;
+            UnsignedBigInteger max;
         } primality_tests[] = {
             { "1"_bigint, "1000000"_bigint },
             { "10000000000"_bigint, "20000000000"_bigint },
@@ -2145,24 +2145,24 @@ static int bigint_tests()
     return g_some_test_failed ? 1 : 0;
 }
 
-static Crypto::UnsignedBigInteger bigint_fibonacci(size_t n)
+static UnsignedBigInteger bigint_fibonacci(size_t n)
 {
-    Crypto::UnsignedBigInteger num1(0);
-    Crypto::UnsignedBigInteger num2(1);
+    UnsignedBigInteger num1(0);
+    UnsignedBigInteger num2(1);
     for (size_t i = 0; i < n; ++i) {
-        Crypto::UnsignedBigInteger t = num1.plus(num2);
+        UnsignedBigInteger t = num1.plus(num2);
         num2 = num1;
         num1 = t;
     }
     return num1;
 }
 
-static Crypto::SignedBigInteger bigint_signed_fibonacci(size_t n)
+static SignedBigInteger bigint_signed_fibonacci(size_t n)
 {
-    Crypto::SignedBigInteger num1(0);
-    Crypto::SignedBigInteger num2(1);
+    SignedBigInteger num1(0);
+    SignedBigInteger num2(1);
     for (size_t i = 0; i < n; ++i) {
-        Crypto::SignedBigInteger t = num1.plus(num2);
+        SignedBigInteger t = num1.plus(num2);
         num2 = num1;
         num1 = t;
     }
@@ -2186,11 +2186,11 @@ static void bigint_addition_edgecases()
 {
     {
         I_TEST((BigInteger | Edge Cases));
-        Crypto::UnsignedBigInteger num1;
-        Crypto::UnsignedBigInteger num2(70);
-        Crypto::UnsignedBigInteger num3 = num1.plus(num2);
+        UnsignedBigInteger num1;
+        UnsignedBigInteger num2(70);
+        UnsignedBigInteger num3 = num1.plus(num2);
         bool pass = (num3 == num2);
-        pass &= (num1 == Crypto::UnsignedBigInteger(0));
+        pass &= (num1 == UnsignedBigInteger(0));
 
         if (pass) {
             PASS;
@@ -2200,8 +2200,8 @@ static void bigint_addition_edgecases()
     }
     {
         I_TEST((BigInteger | Borrow with zero));
-        Crypto::UnsignedBigInteger num1({ UINT32_MAX - 3, UINT32_MAX });
-        Crypto::UnsignedBigInteger num2({ UINT32_MAX - 2, 0 });
+        UnsignedBigInteger num1({ UINT32_MAX - 3, UINT32_MAX });
+        UnsignedBigInteger num2({ UINT32_MAX - 2, 0 });
         if (num1.plus(num2).words() == Vector<u32> { 4294967289, 0, 1 }) {
             PASS;
         } else {
@@ -2214,10 +2214,10 @@ static void bigint_subtraction()
 {
     {
         I_TEST((BigInteger | Simple Subtraction 1));
-        Crypto::UnsignedBigInteger num1(80);
-        Crypto::UnsignedBigInteger num2(70);
+        UnsignedBigInteger num1(80);
+        UnsignedBigInteger num2(70);
 
-        if (num1.minus(num2) == Crypto::UnsignedBigInteger(10)) {
+        if (num1.minus(num2) == UnsignedBigInteger(10)) {
             PASS;
         } else {
             FAIL(Incorrect Result);
@@ -2225,8 +2225,8 @@ static void bigint_subtraction()
     }
     {
         I_TEST((BigInteger | Simple Subtraction 2));
-        Crypto::UnsignedBigInteger num1(50);
-        Crypto::UnsignedBigInteger num2(70);
+        UnsignedBigInteger num1(50);
+        UnsignedBigInteger num2(70);
 
         if (num1.minus(num2).is_invalid()) {
             PASS;
@@ -2236,10 +2236,10 @@ static void bigint_subtraction()
     }
     {
         I_TEST((BigInteger | Subtraction with borrow));
-        Crypto::UnsignedBigInteger num1(UINT32_MAX);
-        Crypto::UnsignedBigInteger num2(1);
-        Crypto::UnsignedBigInteger num3 = num1.plus(num2);
-        Crypto::UnsignedBigInteger result = num3.minus(num2);
+        UnsignedBigInteger num1(UINT32_MAX);
+        UnsignedBigInteger num2(1);
+        UnsignedBigInteger num3 = num1.plus(num2);
+        UnsignedBigInteger result = num3.minus(num2);
         if (result == num1) {
             PASS;
         } else {
@@ -2248,9 +2248,9 @@ static void bigint_subtraction()
     }
     {
         I_TEST((BigInteger | Subtraction with large numbers));
-        Crypto::UnsignedBigInteger num1 = bigint_fibonacci(343);
-        Crypto::UnsignedBigInteger num2 = bigint_fibonacci(218);
-        Crypto::UnsignedBigInteger result = num1.minus(num2);
+        UnsignedBigInteger num1 = bigint_fibonacci(343);
+        UnsignedBigInteger num2 = bigint_fibonacci(218);
+        UnsignedBigInteger result = num1.minus(num2);
         if ((result.plus(num2) == num1)
             && (result.words() == Vector<u32> { 811430588, 2958904896, 1130908877, 2830569969, 3243275482, 3047460725, 774025231, 7990 })) {
             PASS;
@@ -2260,15 +2260,15 @@ static void bigint_subtraction()
     }
     {
         I_TEST((BigInteger | Subtraction with large numbers 2));
-        Crypto::UnsignedBigInteger num1(Vector<u32> { 1483061863, 446680044, 1123294122, 191895498, 3347106536, 16, 0, 0, 0 });
-        Crypto::UnsignedBigInteger num2(Vector<u32> { 4196414175, 1117247942, 1123294122, 191895498, 3347106536, 16 });
-        Crypto::UnsignedBigInteger result = num1.minus(num2);
+        UnsignedBigInteger num1(Vector<u32> { 1483061863, 446680044, 1123294122, 191895498, 3347106536, 16, 0, 0, 0 });
+        UnsignedBigInteger num2(Vector<u32> { 4196414175, 1117247942, 1123294122, 191895498, 3347106536, 16 });
+        UnsignedBigInteger result = num1.minus(num2);
         // this test only verifies that we don't crash on an assertion
         PASS;
     }
     {
         I_TEST((BigInteger | Subtraction Regression 1));
-        auto num = Crypto::UnsignedBigInteger { 1 }.shift_left(256);
+        auto num = UnsignedBigInteger { 1 }.shift_left(256);
         if (num.minus(1).words() == Vector<u32> { 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 0 }) {
             PASS;
         } else {
@@ -2281,9 +2281,9 @@ static void bigint_multiplication()
 {
     {
         I_TEST((BigInteger | Simple Multiplication));
-        Crypto::UnsignedBigInteger num1(8);
-        Crypto::UnsignedBigInteger num2(251);
-        Crypto::UnsignedBigInteger result = num1.multiplied_by(num2);
+        UnsignedBigInteger num1(8);
+        UnsignedBigInteger num2(251);
+        UnsignedBigInteger result = num1.multiplied_by(num2);
         if (result.words() == Vector<u32> { 2008 }) {
             PASS;
         } else {
@@ -2292,9 +2292,9 @@ static void bigint_multiplication()
     }
     {
         I_TEST((BigInteger | Multiplications with big numbers 1));
-        Crypto::UnsignedBigInteger num1 = bigint_fibonacci(200);
-        Crypto::UnsignedBigInteger num2(12345678);
-        Crypto::UnsignedBigInteger result = num1.multiplied_by(num2);
+        UnsignedBigInteger num1 = bigint_fibonacci(200);
+        UnsignedBigInteger num2(12345678);
+        UnsignedBigInteger result = num1.multiplied_by(num2);
         if (result.words() == Vector<u32> { 669961318, 143970113, 4028714974, 3164551305, 1589380278, 2 }) {
             PASS;
         } else {
@@ -2303,9 +2303,9 @@ static void bigint_multiplication()
     }
     {
         I_TEST((BigInteger | Multiplications with big numbers 2));
-        Crypto::UnsignedBigInteger num1 = bigint_fibonacci(200);
-        Crypto::UnsignedBigInteger num2 = bigint_fibonacci(341);
-        Crypto::UnsignedBigInteger result = num1.multiplied_by(num2);
+        UnsignedBigInteger num1 = bigint_fibonacci(200);
+        UnsignedBigInteger num2 = bigint_fibonacci(341);
+        UnsignedBigInteger result = num1.multiplied_by(num2);
         if (result.words() == Vector<u32> { 3017415433, 2741793511, 1957755698, 3731653885, 3154681877, 785762127, 3200178098, 4260616581, 529754471, 3632684436, 1073347813, 2516430 }) {
             PASS;
         } else {
@@ -2317,10 +2317,10 @@ static void bigint_division()
 {
     {
         I_TEST((BigInteger | Simple Division));
-        Crypto::UnsignedBigInteger num1(27194);
-        Crypto::UnsignedBigInteger num2(251);
+        UnsignedBigInteger num1(27194);
+        UnsignedBigInteger num2(251);
         auto result = num1.divided_by(num2);
-        Crypto::UnsignedDivisionResult expected = { Crypto::UnsignedBigInteger(108), Crypto::UnsignedBigInteger(86) };
+        AK::UnsignedDivisionResult expected = { UnsignedBigInteger(108), UnsignedBigInteger(86) };
         if (result.quotient == expected.quotient && result.remainder == expected.remainder) {
             PASS;
         } else {
@@ -2329,12 +2329,12 @@ static void bigint_division()
     }
     {
         I_TEST((BigInteger | Division with big numbers));
-        Crypto::UnsignedBigInteger num1 = bigint_fibonacci(386);
-        Crypto::UnsignedBigInteger num2 = bigint_fibonacci(238);
+        UnsignedBigInteger num1 = bigint_fibonacci(386);
+        UnsignedBigInteger num2 = bigint_fibonacci(238);
         auto result = num1.divided_by(num2);
-        Crypto::UnsignedDivisionResult expected = {
-            Crypto::UnsignedBigInteger(Vector<u32> { 2300984486, 2637503534, 2022805584, 107 }),
-            Crypto::UnsignedBigInteger(Vector<u32> { 1483061863, 446680044, 1123294122, 191895498, 3347106536, 16, 0, 0, 0 })
+        AK::UnsignedDivisionResult expected = {
+            UnsignedBigInteger(Vector<u32> { 2300984486, 2637503534, 2022805584, 107 }),
+            UnsignedBigInteger(Vector<u32> { 1483061863, 446680044, 1123294122, 191895498, 3347106536, 16, 0, 0, 0 })
         };
         if (result.quotient == expected.quotient && result.remainder == expected.remainder) {
             PASS;
@@ -2359,7 +2359,7 @@ static void bigint_base10()
 {
     {
         I_TEST((BigInteger | From String));
-        auto result = Crypto::UnsignedBigInteger::from_base10("57195071295721390579057195715793");
+        auto result = UnsignedBigInteger::from_base10("57195071295721390579057195715793");
         if (result.words() == Vector<u32> { 3806301393, 954919431, 3879607298, 721 }) {
             PASS;
         } else {
@@ -2368,7 +2368,7 @@ static void bigint_base10()
     }
     {
         I_TEST((BigInteger | To String));
-        auto result = Crypto::UnsignedBigInteger { Vector<u32> { 3806301393, 954919431, 3879607298, 721 } }.to_base10();
+        auto result = UnsignedBigInteger { Vector<u32> { 3806301393, 954919431, 3879607298, 721 } }.to_base10();
         if (result == "57195071295721390579057195715793") {
             PASS;
         } else {
@@ -2384,7 +2384,7 @@ static void bigint_import_export()
         u8 random_bytes[128];
         u8 target_buffer[128];
         AK::fill_with_random(random_bytes, 128);
-        auto encoded = Crypto::UnsignedBigInteger::import_data(random_bytes, 128);
+        auto encoded = UnsignedBigInteger::import_data(random_bytes, 128);
         encoded.export_data({ target_buffer, 128 });
         if (memcmp(target_buffer, random_bytes, 128) != 0)
             FAIL(Could not roundtrip);
@@ -2396,7 +2396,7 @@ static void bigint_import_export()
         u8 target_buffer[128];
         auto encoded = "12345678901234567890"_bigint;
         auto size = encoded.export_data({ target_buffer, 128 });
-        auto decoded = Crypto::UnsignedBigInteger::import_data(target_buffer, size);
+        auto decoded = UnsignedBigInteger::import_data(target_buffer, size);
         if (encoded != decoded)
             FAIL(Could not roundtrip);
         else
@@ -2404,7 +2404,7 @@ static void bigint_import_export()
     }
     {
         I_TEST((BigInteger | BigEndian Import));
-        auto number = Crypto::UnsignedBigInteger::import_data("hello");
+        auto number = UnsignedBigInteger::import_data("hello");
         if (number == "448378203247"_bigint) {
             PASS;
         } else {
@@ -2509,8 +2509,8 @@ static void bigint_signed_addition_edgecases()
 {
     {
         I_TEST((Signed BigInteger | Borrow with zero));
-        Crypto::SignedBigInteger num1 { Crypto::UnsignedBigInteger { { UINT32_MAX - 3, UINT32_MAX } }, false };
-        Crypto::SignedBigInteger num2 { Crypto::UnsignedBigInteger { UINT32_MAX - 2 }, false };
+        SignedBigInteger num1 { UnsignedBigInteger { { UINT32_MAX - 3, UINT32_MAX } }, false };
+        SignedBigInteger num2 { UnsignedBigInteger { UINT32_MAX - 2 }, false };
         if (num1.plus(num2).unsigned_value().words() == Vector<u32> { 4294967289, 0, 1 }) {
             PASS;
         } else {
@@ -2519,10 +2519,10 @@ static void bigint_signed_addition_edgecases()
     }
     {
         I_TEST((Signed BigInteger | Addition to other sign));
-        Crypto::SignedBigInteger num1 = INT32_MAX;
-        Crypto::SignedBigInteger num2 = num1;
+        SignedBigInteger num1 = INT32_MAX;
+        SignedBigInteger num2 = num1;
         num2.negate();
-        if (num1.plus(num2) == Crypto::SignedBigInteger { 0 }) {
+        if (num1.plus(num2) == SignedBigInteger { 0 }) {
             PASS;
         } else {
             FAIL(Incorrect Result);
@@ -2534,10 +2534,10 @@ static void bigint_signed_subtraction()
 {
     {
         I_TEST((Signed BigInteger | Simple Subtraction 1));
-        Crypto::SignedBigInteger num1(80);
-        Crypto::SignedBigInteger num2(70);
+        SignedBigInteger num1(80);
+        SignedBigInteger num2(70);
 
-        if (num1.minus(num2) == Crypto::SignedBigInteger(10)) {
+        if (num1.minus(num2) == SignedBigInteger(10)) {
             PASS;
         } else {
             FAIL(Incorrect Result);
@@ -2545,10 +2545,10 @@ static void bigint_signed_subtraction()
     }
     {
         I_TEST((Signed BigInteger | Simple Subtraction 2));
-        Crypto::SignedBigInteger num1(50);
-        Crypto::SignedBigInteger num2(70);
+        SignedBigInteger num1(50);
+        SignedBigInteger num2(70);
 
-        if (num1.minus(num2) == Crypto::SignedBigInteger { -20 }) {
+        if (num1.minus(num2) == SignedBigInteger { -20 }) {
             PASS;
         } else {
             FAIL(Incorrect Result);
@@ -2556,10 +2556,10 @@ static void bigint_signed_subtraction()
     }
     {
         I_TEST((Signed BigInteger | Subtraction with borrow));
-        Crypto::SignedBigInteger num1(Crypto::UnsignedBigInteger { UINT32_MAX });
-        Crypto::SignedBigInteger num2(1);
-        Crypto::SignedBigInteger num3 = num1.plus(num2);
-        Crypto::SignedBigInteger result = num2.minus(num3);
+        SignedBigInteger num1(UnsignedBigInteger { UINT32_MAX });
+        SignedBigInteger num2(1);
+        SignedBigInteger num3 = num1.plus(num2);
+        SignedBigInteger result = num2.minus(num3);
         num1.negate();
         if (result == num1) {
             PASS;
@@ -2569,10 +2569,10 @@ static void bigint_signed_subtraction()
     }
     {
         I_TEST((Signed BigInteger | Subtraction with large numbers));
-        Crypto::SignedBigInteger num1 = bigint_signed_fibonacci(343);
-        Crypto::SignedBigInteger num2 = bigint_signed_fibonacci(218);
-        Crypto::SignedBigInteger result = num2.minus(num1);
-        auto expected = Crypto::UnsignedBigInteger { Vector<u32> { 811430588, 2958904896, 1130908877, 2830569969, 3243275482, 3047460725, 774025231, 7990 } };
+        SignedBigInteger num1 = bigint_signed_fibonacci(343);
+        SignedBigInteger num2 = bigint_signed_fibonacci(218);
+        SignedBigInteger result = num2.minus(num1);
+        auto expected = UnsignedBigInteger { Vector<u32> { 811430588, 2958904896, 1130908877, 2830569969, 3243275482, 3047460725, 774025231, 7990 } };
         if ((result.plus(num1) == num2)
             && (result.unsigned_value() == expected)) {
             PASS;
@@ -2582,9 +2582,9 @@ static void bigint_signed_subtraction()
     }
     {
         I_TEST((Signed BigInteger | Subtraction with large numbers 2));
-        Crypto::SignedBigInteger num1(Crypto::UnsignedBigInteger { Vector<u32> { 1483061863, 446680044, 1123294122, 191895498, 3347106536, 16, 0, 0, 0 } });
-        Crypto::SignedBigInteger num2(Crypto::UnsignedBigInteger { Vector<u32> { 4196414175, 1117247942, 1123294122, 191895498, 3347106536, 16 } });
-        Crypto::SignedBigInteger result = num1.minus(num2);
+        SignedBigInteger num1(UnsignedBigInteger { Vector<u32> { 1483061863, 446680044, 1123294122, 191895498, 3347106536, 16, 0, 0, 0 } });
+        SignedBigInteger num2(UnsignedBigInteger { Vector<u32> { 4196414175, 1117247942, 1123294122, 191895498, 3347106536, 16 } });
+        SignedBigInteger result = num1.minus(num2);
         // this test only verifies that we don't crash on an assertion
         PASS;
     }
@@ -2594,10 +2594,10 @@ static void bigint_signed_multiplication()
 {
     {
         I_TEST((Signed BigInteger | Simple Multiplication));
-        Crypto::SignedBigInteger num1(8);
-        Crypto::SignedBigInteger num2(-251);
-        Crypto::SignedBigInteger result = num1.multiplied_by(num2);
-        if (result == Crypto::SignedBigInteger { -2008 }) {
+        SignedBigInteger num1(8);
+        SignedBigInteger num2(-251);
+        SignedBigInteger result = num1.multiplied_by(num2);
+        if (result == SignedBigInteger { -2008 }) {
             PASS;
         } else {
             FAIL(Incorrect Result);
@@ -2605,9 +2605,9 @@ static void bigint_signed_multiplication()
     }
     {
         I_TEST((Signed BigInteger | Multiplications with big numbers 1));
-        Crypto::SignedBigInteger num1 = bigint_signed_fibonacci(200);
-        Crypto::SignedBigInteger num2(-12345678);
-        Crypto::SignedBigInteger result = num1.multiplied_by(num2);
+        SignedBigInteger num1 = bigint_signed_fibonacci(200);
+        SignedBigInteger num2(-12345678);
+        SignedBigInteger result = num1.multiplied_by(num2);
         if (result.unsigned_value().words() == Vector<u32> { 669961318, 143970113, 4028714974, 3164551305, 1589380278, 2 } && result.is_negative()) {
             PASS;
         } else {
@@ -2616,10 +2616,10 @@ static void bigint_signed_multiplication()
     }
     {
         I_TEST((Signed BigInteger | Multiplications with big numbers 2));
-        Crypto::SignedBigInteger num1 = bigint_signed_fibonacci(200);
-        Crypto::SignedBigInteger num2 = bigint_signed_fibonacci(341);
+        SignedBigInteger num1 = bigint_signed_fibonacci(200);
+        SignedBigInteger num2 = bigint_signed_fibonacci(341);
         num1.negate();
-        Crypto::SignedBigInteger result = num1.multiplied_by(num2);
+        SignedBigInteger result = num1.multiplied_by(num2);
         if (result.unsigned_value().words() == Vector<u32> { 3017415433, 2741793511, 1957755698, 3731653885, 3154681877, 785762127, 3200178098, 4260616581, 529754471, 3632684436, 1073347813, 2516430 } && result.is_negative()) {
             PASS;
         } else {
@@ -2631,10 +2631,10 @@ static void bigint_signed_division()
 {
     {
         I_TEST((Signed BigInteger | Simple Division));
-        Crypto::SignedBigInteger num1(27194);
-        Crypto::SignedBigInteger num2(-251);
+        SignedBigInteger num1(27194);
+        SignedBigInteger num2(-251);
         auto result = num1.divided_by(num2);
-        Crypto::SignedDivisionResult expected = { Crypto::SignedBigInteger(-108), Crypto::SignedBigInteger(86) };
+        AK::SignedDivisionResult expected = { SignedBigInteger(-108), SignedBigInteger(86) };
         if (result.quotient == expected.quotient && result.remainder == expected.remainder) {
             PASS;
         } else {
@@ -2643,13 +2643,13 @@ static void bigint_signed_division()
     }
     {
         I_TEST((Signed BigInteger | Division with big numbers));
-        Crypto::SignedBigInteger num1 = bigint_signed_fibonacci(386);
-        Crypto::SignedBigInteger num2 = bigint_signed_fibonacci(238);
+        SignedBigInteger num1 = bigint_signed_fibonacci(386);
+        SignedBigInteger num2 = bigint_signed_fibonacci(238);
         num1.negate();
         auto result = num1.divided_by(num2);
-        Crypto::SignedDivisionResult expected = {
-            Crypto::SignedBigInteger(Crypto::UnsignedBigInteger { Vector<u32> { 2300984486, 2637503534, 2022805584, 107 } }, true),
-            Crypto::SignedBigInteger(Crypto::UnsignedBigInteger { Vector<u32> { 1483061863, 446680044, 1123294122, 191895498, 3347106536, 16, 0, 0, 0 } }, true)
+        AK::SignedDivisionResult expected = {
+            SignedBigInteger(UnsignedBigInteger { Vector<u32> { 2300984486, 2637503534, 2022805584, 107 } }, true),
+            SignedBigInteger(UnsignedBigInteger { Vector<u32> { 1483061863, 446680044, 1123294122, 191895498, 3347106536, 16, 0, 0, 0 } }, true)
         };
         if (result.quotient == expected.quotient && result.remainder == expected.remainder) {
             PASS;
@@ -2675,7 +2675,7 @@ static void bigint_signed_base10()
 {
     {
         I_TEST((Signed BigInteger | From String));
-        auto result = Crypto::SignedBigInteger::from_base10("-57195071295721390579057195715793");
+        auto result = SignedBigInteger::from_base10("-57195071295721390579057195715793");
         if (result.unsigned_value().words() == Vector<u32> { 3806301393, 954919431, 3879607298, 721 } && result.is_negative()) {
             PASS;
         } else {
@@ -2684,7 +2684,7 @@ static void bigint_signed_base10()
     }
     {
         I_TEST((Signed BigInteger | To String));
-        auto result = Crypto::SignedBigInteger { Crypto::UnsignedBigInteger { Vector<u32> { 3806301393, 954919431, 3879607298, 721 } }, true }.to_base10();
+        auto result = SignedBigInteger { UnsignedBigInteger { Vector<u32> { 3806301393, 954919431, 3879607298, 721 } }, true }.to_base10();
         if (result == "-57195071295721390579057195715793") {
             PASS;
         } else {
@@ -2701,7 +2701,7 @@ static void bigint_signed_import_export()
         u8 target_buffer[129];
         random_bytes[0] = 1;
         AK::fill_with_random(random_bytes + 1, 128);
-        auto encoded = Crypto::SignedBigInteger::import_data(random_bytes, 129);
+        auto encoded = SignedBigInteger::import_data(random_bytes, 129);
         encoded.export_data({ target_buffer, 129 });
         if (memcmp(target_buffer, random_bytes, 129) != 0)
             FAIL(Could not roundtrip);
@@ -2713,7 +2713,7 @@ static void bigint_signed_import_export()
         u8 target_buffer[128];
         auto encoded = "-12345678901234567890"_sbigint;
         auto size = encoded.export_data({ target_buffer, 128 });
-        auto decoded = Crypto::SignedBigInteger::import_data(target_buffer, size);
+        auto decoded = SignedBigInteger::import_data(target_buffer, size);
         if (encoded != decoded)
             FAIL(Could not roundtrip);
         else


### PR DESCRIPTION
This is currently very much WIP, but because it's kind of big I think it'd be good to get some feedback before I finish and polish everything. There's a big comment in `double_to_digits` which should explain most things. So far I've only actually added calls to this code in `Format.cpp`, but I'm halfway done with the adding to the JS engine, but there's also the printf implementation and the calculator which also have their own not-quite-correct float to string conversion. I'm also going to add another mode to `double_to_string` to ensure there are trailing zeroes up to precision, which should allow it to act more like the old formatter and the requirements for printf. The current implementations suffer from information loss, and sometimes an annoying '9999' at the end, but for the most part that probably doesn't matter a whole lot. However, a correct algorithm is needed to meet the JS spec, and also a number of the implementations don't seem to handle somewhat big floats, for example:
![image](https://user-images.githubusercontent.com/16677912/103409179-a5586a00-4bb9-11eb-956b-143b11ed869a.png)
This could probably be correct in some way, but alas no simple multiply/divide by 10 algorithm can correctly get the shortest round-trip representation, thus this PR.

I also had to move `SignedBigInteger` and `UnsignedBigInteger` to AK (from LibCrypto), and I also added a simple `shift_left` method to `UnsignedBigInteger`.