### PR TITLE
WindowServer+MouseSettings: Add a configurable primary mouse button setting

### DIFF
--- a/Applications/FontEditor/GlyphEditorWidget.cpp
+++ b/Applications/FontEditor/GlyphEditorWidget.cpp
@@ -89,14 +89,14 @@ void GlyphEditorWidget::mousedown_event(GUI::MouseEvent& event)
 
 void GlyphEditorWidget::mousemove_event(GUI::MouseEvent& event)
 {
-    if (event.buttons() & (GUI::MouseButton::Left | GUI::MouseButton::Right))
+    if (event.buttons() & (GUI::MouseButton::Primary | GUI::MouseButton::Secondary))
         draw_at_mouse(event);
 }
 
 void GlyphEditorWidget::draw_at_mouse(const GUI::MouseEvent& event)
 {
-    bool set = event.buttons() & GUI::MouseButton::Left;
-    bool unset = event.buttons() & GUI::MouseButton::Right;
+    bool set = event.buttons() & GUI::MouseButton::Primary;
+    bool unset = event.buttons() & GUI::MouseButton::Secondary;
     if (!(set ^ unset))
         return;
     int x = (event.x() - 1) / m_scale;

--- a/Applications/HexEditor/HexEditor.cpp
+++ b/Applications/HexEditor/HexEditor.cpp
@@ -196,7 +196,7 @@ void HexEditor::set_content_length(int length)
 
 void HexEditor::mousedown_event(GUI::MouseEvent& event)
 {
-    if (event.button() != GUI::MouseButton::Left) {
+    if (event.button() != GUI::MouseButton::Primary) {
         return;
     }
 
@@ -313,7 +313,7 @@ void HexEditor::mousemove_event(GUI::MouseEvent& event)
 
 void HexEditor::mouseup_event(GUI::MouseEvent& event)
 {
-    if (event.button() == GUI::MouseButton::Left) {
+    if (event.button() == GUI::MouseButton::Primary) {
         if (m_in_drag_select) {
             if (m_selection_end < m_selection_start) {
                 // lets flip these around

--- a/Applications/Piano/KeysWidget.cpp
+++ b/Applications/Piano/KeysWidget.cpp
@@ -288,7 +288,7 @@ int KeysWidget::note_for_event_position(const Gfx::IntPoint& a_point) const
 
 void KeysWidget::mousedown_event(GUI::MouseEvent& event)
 {
-    if (event.button() != GUI::MouseButton::Left)
+    if (event.button() != GUI::MouseButton::Primary)
         return;
 
     m_mouse_down = true;
@@ -301,7 +301,7 @@ void KeysWidget::mousedown_event(GUI::MouseEvent& event)
 
 void KeysWidget::mouseup_event(GUI::MouseEvent& event)
 {
-    if (event.button() != GUI::MouseButton::Left)
+    if (event.button() != GUI::MouseButton::Primary)
         return;
 
     m_mouse_down = false;

--- a/Applications/PixelPaint/BrushTool.cpp
+++ b/Applications/PixelPaint/BrushTool.cpp
@@ -48,7 +48,7 @@ BrushTool::~BrushTool()
 
 void BrushTool::on_mousedown(Layer&, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
-    if (event.button() != GUI::MouseButton::Left && event.button() != GUI::MouseButton::Right)
+    if (event.button() != GUI::MouseButton::Primary && event.button() != GUI::MouseButton::Secondary)
         return;
 
     m_last_position = event.position();
@@ -56,7 +56,7 @@ void BrushTool::on_mousedown(Layer&, GUI::MouseEvent& event, GUI::MouseEvent&)
 
 void BrushTool::on_mousemove(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
-    if (!(event.buttons() & GUI::MouseButton::Left || event.buttons() & GUI::MouseButton::Right))
+    if (!(event.buttons() & GUI::MouseButton::Primary || event.buttons() & GUI::MouseButton::Secondary))
         return;
 
     draw_line(layer.bitmap(), m_editor->color_for(event), m_last_position, event.position());

--- a/Applications/PixelPaint/EllipseTool.cpp
+++ b/Applications/PixelPaint/EllipseTool.cpp
@@ -56,7 +56,7 @@ void EllipseTool::draw_using(GUI::Painter& painter, const Gfx::IntRect& ellipse_
 
 void EllipseTool::on_mousedown(Layer&, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
-    if (event.button() != GUI::MouseButton::Left && event.button() != GUI::MouseButton::Right)
+    if (event.button() != GUI::MouseButton::Primary && event.button() != GUI::MouseButton::Secondary)
         return;
 
     if (m_drawing_button != GUI::MouseButton::None)

--- a/Applications/PixelPaint/EraseTool.cpp
+++ b/Applications/PixelPaint/EraseTool.cpp
@@ -54,7 +54,7 @@ Gfx::IntRect EraseTool::build_rect(const Gfx::IntPoint& pos, const Gfx::IntRect&
 
 void EraseTool::on_mousedown(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
-    if (event.button() != GUI::MouseButton::Left && event.button() != GUI::MouseButton::Right)
+    if (event.button() != GUI::MouseButton::Primary && event.button() != GUI::MouseButton::Secondary)
         return;
     Gfx::IntRect r = build_rect(event.position(), layer.rect());
     GUI::Painter painter(layer.bitmap());
@@ -64,7 +64,7 @@ void EraseTool::on_mousedown(Layer& layer, GUI::MouseEvent& event, GUI::MouseEve
 
 void EraseTool::on_mousemove(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
-    if (event.buttons() & GUI::MouseButton::Left || event.buttons() & GUI::MouseButton::Right) {
+    if (event.buttons() & GUI::MouseButton::Primary || event.buttons() & GUI::MouseButton::Secondary) {
         Gfx::IntRect r = build_rect(event.position(), layer.rect());
         GUI::Painter painter(layer.bitmap());
         painter.clear_rect(r, get_color());
@@ -74,7 +74,7 @@ void EraseTool::on_mousemove(Layer& layer, GUI::MouseEvent& event, GUI::MouseEve
 
 void EraseTool::on_mouseup(Layer&, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
-    if (event.button() != GUI::MouseButton::Left && event.button() != GUI::MouseButton::Right)
+    if (event.button() != GUI::MouseButton::Primary && event.button() != GUI::MouseButton::Secondary)
         return;
     m_editor->did_complete_action();
 }

--- a/Applications/PixelPaint/ImageEditor.cpp
+++ b/Applications/PixelPaint/ImageEditor.cpp
@@ -336,18 +336,18 @@ void ImageEditor::layers_did_change()
 
 Color ImageEditor::color_for(GUI::MouseButton button) const
 {
-    if (button == GUI::MouseButton::Left)
+    if (button == GUI::MouseButton::Primary)
         return m_primary_color;
-    if (button == GUI::MouseButton::Right)
+    if (button == GUI::MouseButton::Secondary)
         return m_secondary_color;
     ASSERT_NOT_REACHED();
 }
 
 Color ImageEditor::color_for(const GUI::MouseEvent& event) const
 {
-    if (event.buttons() & GUI::MouseButton::Left)
+    if (event.buttons() & GUI::MouseButton::Primary)
         return m_primary_color;
-    if (event.buttons() & GUI::MouseButton::Right)
+    if (event.buttons() & GUI::MouseButton::Secondary)
         return m_secondary_color;
     ASSERT_NOT_REACHED();
 }

--- a/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Applications/PixelPaint/LayerListWidget.cpp
@@ -134,7 +134,7 @@ void LayerListWidget::mousedown_event(GUI::MouseEvent& event)
 {
     if (!m_image)
         return;
-    if (event.button() != GUI::MouseButton::Left)
+    if (event.button() != GUI::MouseButton::Primary)
         return;
     auto gadget_index = gadget_at(event.position());
     if (!gadget_index.has_value()) {
@@ -170,7 +170,7 @@ void LayerListWidget::mouseup_event(GUI::MouseEvent& event)
 {
     if (!m_image)
         return;
-    if (event.button() != GUI::MouseButton::Left)
+    if (event.button() != GUI::MouseButton::Primary)
         return;
     if (!m_moving_gadget_index.has_value())
         return;

--- a/Applications/PixelPaint/LineTool.cpp
+++ b/Applications/PixelPaint/LineTool.cpp
@@ -57,7 +57,7 @@ LineTool::~LineTool()
 
 void LineTool::on_mousedown(Layer&, GUI::MouseEvent& layer_event, GUI::MouseEvent&)
 {
-    if (layer_event.button() != GUI::MouseButton::Left && layer_event.button() != GUI::MouseButton::Right)
+    if (layer_event.button() != GUI::MouseButton::Primary && layer_event.button() != GUI::MouseButton::Secondary)
         return;
 
     if (m_drawing_button != GUI::MouseButton::None)

--- a/Applications/PixelPaint/MoveTool.cpp
+++ b/Applications/PixelPaint/MoveTool.cpp
@@ -45,7 +45,7 @@ MoveTool::~MoveTool()
 
 void MoveTool::on_mousedown(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent& image_event)
 {
-    if (event.button() != GUI::MouseButton::Left)
+    if (event.button() != GUI::MouseButton::Primary)
         return;
     if (!layer.rect().contains(event.position()))
         return;
@@ -66,7 +66,7 @@ void MoveTool::on_mousemove(Layer&, GUI::MouseEvent&, GUI::MouseEvent& image_eve
 
 void MoveTool::on_mouseup(Layer&, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
-    if (event.button() != GUI::MouseButton::Left)
+    if (event.button() != GUI::MouseButton::Primary)
         return;
     m_layer_being_moved = nullptr;
     m_editor->window()->set_cursor(Gfx::StandardCursor::None);

--- a/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Applications/PixelPaint/PaletteWidget.cpp
@@ -48,7 +48,7 @@ public:
 
     virtual void mousedown_event(GUI::MouseEvent& event) override
     {
-        if (event.modifiers() & KeyModifier::Mod_Ctrl && event.button() == GUI::MouseButton::Left) {
+        if (event.modifiers() & KeyModifier::Mod_Ctrl && event.button() == GUI::MouseButton::Primary) {
             auto dialog = GUI::ColorPicker::construct(m_color, window());
             if (dialog->exec() == GUI::Dialog::ExecOK) {
                 m_color = dialog->color();
@@ -60,9 +60,9 @@ public:
             return;
         }
 
-        if (event.button() == GUI::MouseButton::Left)
+        if (event.button() == GUI::MouseButton::Primary)
             m_palette_widget.set_primary_color(m_color);
-        else if (event.button() == GUI::MouseButton::Right)
+        else if (event.button() == GUI::MouseButton::Secondary)
             m_palette_widget.set_secondary_color(m_color);
     }
 

--- a/Applications/PixelPaint/PenTool.cpp
+++ b/Applications/PixelPaint/PenTool.cpp
@@ -46,7 +46,7 @@ PenTool::~PenTool()
 
 void PenTool::on_mousedown(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
-    if (event.button() != GUI::MouseButton::Left && event.button() != GUI::MouseButton::Right)
+    if (event.button() != GUI::MouseButton::Primary && event.button() != GUI::MouseButton::Secondary)
         return;
 
     GUI::Painter painter(layer.bitmap());
@@ -57,7 +57,7 @@ void PenTool::on_mousedown(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent
 
 void PenTool::on_mouseup(Layer&, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
-    if (event.button() == GUI::MouseButton::Left || event.button() == GUI::MouseButton::Right) {
+    if (event.button() == GUI::MouseButton::Primary || event.button() == GUI::MouseButton::Secondary) {
         m_last_drawing_event_position = { -1, -1 };
         m_editor->did_complete_action();
     }
@@ -65,7 +65,7 @@ void PenTool::on_mouseup(Layer&, GUI::MouseEvent& event, GUI::MouseEvent&)
 
 void PenTool::on_mousemove(Layer& layer, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
-    if (!(event.buttons() & GUI::MouseButton::Left || event.buttons() & GUI::MouseButton::Right))
+    if (!(event.buttons() & GUI::MouseButton::Primary || event.buttons() & GUI::MouseButton::Secondary))
         return;
     GUI::Painter painter(layer.bitmap());
 

--- a/Applications/PixelPaint/PickerTool.cpp
+++ b/Applications/PixelPaint/PickerTool.cpp
@@ -44,9 +44,9 @@ void PickerTool::on_mousedown(Layer& layer, GUI::MouseEvent& event, GUI::MouseEv
     if (!layer.rect().contains(event.position()))
         return;
     auto color = layer.bitmap().get_pixel(event.position());
-    if (event.button() == GUI::MouseButton::Left)
+    if (event.button() == GUI::MouseButton::Primary)
         m_editor->set_primary_color(color);
-    else if (event.button() == GUI::MouseButton::Right)
+    else if (event.button() == GUI::MouseButton::Secondary)
         m_editor->set_secondary_color(color);
 }
 

--- a/Applications/PixelPaint/RectangleTool.cpp
+++ b/Applications/PixelPaint/RectangleTool.cpp
@@ -62,7 +62,7 @@ void RectangleTool::draw_using(GUI::Painter& painter, const Gfx::IntRect& rect)
 
 void RectangleTool::on_mousedown(Layer&, GUI::MouseEvent& event, GUI::MouseEvent&)
 {
-    if (event.button() != GUI::MouseButton::Left && event.button() != GUI::MouseButton::Right)
+    if (event.button() != GUI::MouseButton::Primary && event.button() != GUI::MouseButton::Secondary)
         return;
 
     if (m_drawing_button != GUI::MouseButton::None)

--- a/Applications/QuickShow/QSWidget.cpp
+++ b/Applications/QuickShow/QSWidget.cpp
@@ -194,7 +194,7 @@ void QSWidget::paint_event(GUI::PaintEvent& event)
 
 void QSWidget::mousedown_event(GUI::MouseEvent& event)
 {
-    if (event.button() != GUI::MouseButton::Left)
+    if (event.button() != GUI::MouseButton::Primary)
         return;
     m_click_position = event.position();
     m_saved_pan_origin = m_pan_origin;
@@ -204,7 +204,7 @@ void QSWidget::mouseup_event([[maybe_unused]] GUI::MouseEvent& event) { }
 
 void QSWidget::mousemove_event(GUI::MouseEvent& event)
 {
-    if (!(event.buttons() & GUI::MouseButton::Left))
+    if (!(event.buttons() & GUI::MouseButton::Primary))
         return;
 
     auto delta = event.position() - m_click_position;

--- a/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -90,7 +90,7 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
         sheet.disable_updates();
         ScopeGuard sheet_update_enabler { [&] { sheet.enable_updates(); } };
 
-        auto holding_left_button = !!(event.buttons() & GUI::MouseButton::Left);
+        auto holding_left_button = !!(event.buttons() & GUI::MouseButton::Primary);
         auto rect = content_rect(index);
         auto distance = rect.center().absolute_relative_distance_to(event.position());
         if (distance.x() >= rect.width() / 2 - 5 && distance.y() >= rect.height() / 2 - 5) {

--- a/Base/etc/WindowServer/WindowServer.ini
+++ b/Base/etc/WindowServer/WindowServer.ini
@@ -8,6 +8,7 @@ Name=Default
 [Mouse]
 AccelerationFactor=1.0
 ScrollStepSize=4
+PrimaryButton=1
 
 [Cursor]
 Hidden=/res/cursors/hidden.png

--- a/Demos/Fire/Fire.cpp
+++ b/Demos/Fire/Fire.cpp
@@ -181,7 +181,7 @@ void Fire::timer_event(Core::TimerEvent&)
 
 void Fire::mousedown_event(GUI::MouseEvent& event)
 {
-    if (event.button() == GUI::MouseButton::Left)
+    if (event.button() == GUI::MouseButton::Primary)
         dragging = true;
 
     return GUI::Widget::mousedown_event(event);
@@ -206,7 +206,7 @@ void Fire::mousemove_event(GUI::MouseEvent& event)
 
 void Fire::mouseup_event(GUI::MouseEvent& event)
 {
-    if (event.button() == GUI::MouseButton::Left)
+    if (event.button() == GUI::MouseButton::Primary)
         dragging = false;
 
     return GUI::Widget::mouseup_event(event);

--- a/Demos/Mouse/main.cpp
+++ b/Demos/Mouse/main.cpp
@@ -91,12 +91,12 @@ public:
 
         painter.stroke_path(path, Color::Black, 1);
 
-        if (m_buttons & GUI::MouseButton::Left) {
+        if (m_buttons & GUI::MouseButton::Primary) {
             painter.fill_rect({ 31, 21, 34, 44 }, Color::Blue);
             painter.draw_triangle({ 30, 21 }, { 65, 21 }, { 65, 12 }, Color::Blue);
         }
 
-        if (m_buttons & GUI::MouseButton::Right) {
+        if (m_buttons & GUI::MouseButton::Secondary) {
             painter.fill_rect({ 96, 21, 34, 44 }, Color::Blue);
             painter.draw_triangle({ 96, 12 }, { 96, 21 }, { 132, 21 }, Color::Blue);
         }

--- a/Demos/Mouse/main.cpp
+++ b/Demos/Mouse/main.cpp
@@ -35,8 +35,10 @@
 #include <LibGUI/Painter.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
+#include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Path.h>
+#include <WindowServer/Screen.h>
 
 #include <math.h>
 
@@ -91,12 +93,14 @@ public:
 
         painter.stroke_path(path, Color::Black, 1);
 
-        if (m_buttons & GUI::MouseButton::Primary) {
+        auto primary_button = static_cast<WindowServer::RawMouseButton>(GUI::WindowServerConnection::the().send_sync<Messages::WindowServer::GetPrimaryMouseButton>()->button());
+
+        if ((primary_button == WindowServer::RawMouseButton::Left && m_buttons & GUI::MouseButton::Primary) || (primary_button == WindowServer::RawMouseButton::Right && m_buttons & GUI::MouseButton::Secondary)) {
             painter.fill_rect({ 31, 21, 34, 44 }, Color::Blue);
             painter.draw_triangle({ 30, 21 }, { 65, 21 }, { 65, 12 }, Color::Blue);
         }
 
-        if (m_buttons & GUI::MouseButton::Secondary) {
+        if ((primary_button == WindowServer::RawMouseButton::Left && m_buttons & GUI::MouseButton::Secondary) || (primary_button == WindowServer::RawMouseButton::Right && m_buttons & GUI::MouseButton::Primary)) {
             painter.fill_rect({ 96, 21, 34, 44 }, Color::Blue);
             painter.draw_triangle({ 96, 12 }, { 96, 21 }, { 132, 21 }, Color::Blue);
         }

--- a/DevTools/HackStudio/CursorTool.cpp
+++ b/DevTools/HackStudio/CursorTool.cpp
@@ -43,7 +43,7 @@ void CursorTool::on_mousedown(GUI::MouseEvent& event)
     auto& form_widget = m_editor.form_widget();
     auto result = form_widget.hit_test(event.position(), GUI::Widget::ShouldRespectGreediness::No);
 
-    if (event.button() == GUI::MouseButton::Left) {
+    if (event.button() == GUI::MouseButton::Primary) {
         if (result.widget && result.widget != &form_widget) {
             if (event.modifiers() & Mod_Ctrl) {
                 m_editor.selection().toggle(*result.widget);
@@ -79,7 +79,7 @@ void CursorTool::on_mouseup(GUI::MouseEvent& event)
 #ifdef DEBUG_CURSOR_TOOL
     dbgln("CursorTool::on_mouseup");
 #endif
-    if (event.button() == GUI::MouseButton::Left) {
+    if (event.button() == GUI::MouseButton::Primary) {
         auto& form_widget = m_editor.form_widget();
         auto result = form_widget.hit_test(event.position(), GUI::Widget::ShouldRespectGreediness::No);
         if (!m_dragging && !(event.modifiers() & Mod_Ctrl)) {
@@ -107,7 +107,7 @@ void CursorTool::on_mousemove(GUI::MouseEvent& event)
         return;
     }
 
-    if (!m_dragging && event.buttons() & GUI::MouseButton::Left && event.position() != m_drag_origin) {
+    if (!m_dragging && event.buttons() & GUI::MouseButton::Primary && event.position() != m_drag_origin) {
         auto result = form_widget.hit_test(event.position(), GUI::Widget::ShouldRespectGreediness::No);
         if (result.widget && result.widget != &form_widget) {
             if (!m_editor.selection().contains(*result.widget)) {

--- a/DevTools/HackStudio/Editor.cpp
+++ b/DevTools/HackStudio/Editor.cpp
@@ -273,7 +273,7 @@ void Editor::mousedown_event(GUI::MouseEvent& event)
 
     auto text_position = text_position_at(event.position());
     auto ruler_line_rect = ruler_content_rect(text_position.line());
-    if (event.button() == GUI::MouseButton::Left && event.position().x() < ruler_line_rect.width()) {
+    if (event.button() == GUI::MouseButton::Primary && event.position().x() < ruler_line_rect.width()) {
         if (!breakpoint_lines().contains_slow(text_position.line())) {
             breakpoint_lines().append(text_position.line());
             Debugger::on_breakpoint_change(wrapper().filename_label().text(), text_position.line(), BreakpointChange::Added);

--- a/DevTools/HackStudio/Git/GitFilesView.cpp
+++ b/DevTools/HackStudio/Git/GitFilesView.cpp
@@ -57,7 +57,7 @@ GitFilesView::GitFilesView(GitFileActionCallback callback, NonnullRefPtr<Gfx::Bi
 
 void GitFilesView::mousedown_event(GUI::MouseEvent& event)
 {
-    if (event.button() != GUI::MouseButton::Left) {
+    if (event.button() != GUI::MouseButton::Primary) {
         ListView::mousedown_event(event);
         return;
     }

--- a/DevTools/Profiler/ProfileTimelineWidget.cpp
+++ b/DevTools/Profiler/ProfileTimelineWidget.cpp
@@ -80,7 +80,7 @@ u64 ProfileTimelineWidget::timestamp_at_x(int x) const
 
 void ProfileTimelineWidget::mousedown_event(GUI::MouseEvent& event)
 {
-    if (event.button() != GUI::MouseButton::Left)
+    if (event.button() != GUI::MouseButton::Primary)
         return;
 
     m_selecting = true;
@@ -102,7 +102,7 @@ void ProfileTimelineWidget::mousemove_event(GUI::MouseEvent& event)
 
 void ProfileTimelineWidget::mouseup_event(GUI::MouseEvent& event)
 {
-    if (event.button() != GUI::MouseButton::Left)
+    if (event.button() != GUI::MouseButton::Primary)
         return;
 
     m_selecting = false;

--- a/Games/Chess/ChessWidget.cpp
+++ b/Games/Chess/ChessWidget.cpp
@@ -167,7 +167,7 @@ void ChessWidget::mousedown_event(GUI::MouseEvent& event)
 {
     GUI::Widget::mousedown_event(event);
 
-    if (event.button() == GUI::MouseButton::Right) {
+    if (event.button() == GUI::MouseButton::Secondary) {
         m_current_marking.from = mouse_to_square(event);
         return;
     }
@@ -188,7 +188,7 @@ void ChessWidget::mouseup_event(GUI::MouseEvent& event)
 {
     GUI::Widget::mouseup_event(event);
 
-    if (event.button() == GUI::MouseButton::Right) {
+    if (event.button() == GUI::MouseButton::Secondary) {
         m_current_marking.secondary_color = event.shift();
         m_current_marking.alternate_color = event.ctrl();
         m_current_marking.to = mouse_to_square(event);

--- a/Games/Minesweeper/Field.cpp
+++ b/Games/Minesweeper/Field.cpp
@@ -44,7 +44,7 @@ public:
 
     virtual void mousedown_event(GUI::MouseEvent& event) override
     {
-        if (event.button() == GUI::MouseButton::Right) {
+        if (event.button() == GUI::MouseButton::Secondary) {
             if (on_right_click)
                 on_right_click();
         }
@@ -67,8 +67,8 @@ public:
 
     virtual void mousedown_event(GUI::MouseEvent& event) override
     {
-        if (event.button() == GUI::MouseButton::Right || event.button() == GUI::MouseButton::Left) {
-            if (event.buttons() == (GUI::MouseButton::Right | GUI::MouseButton::Left) || m_square.field->is_single_chording()) {
+        if (event.button() == GUI::MouseButton::Secondary || event.button() == GUI::MouseButton::Primary) {
+            if (event.buttons() == (GUI::MouseButton::Secondary | GUI::MouseButton::Primary) || m_square.field->is_single_chording()) {
                 m_chord = true;
                 m_square.field->set_chord_preview(m_square, true);
             }
@@ -99,7 +99,7 @@ public:
     virtual void mouseup_event(GUI::MouseEvent& event) override
     {
         if (m_chord) {
-            if (event.button() == GUI::MouseButton::Left || event.button() == GUI::MouseButton::Right) {
+            if (event.button() == GUI::MouseButton::Primary || event.button() == GUI::MouseButton::Secondary) {
                 if (rect().contains(event.position())) {
                     if (on_chord_click)
                         on_chord_click();

--- a/Libraries/LibGUI/AbstractButton.cpp
+++ b/Libraries/LibGUI/AbstractButton.cpp
@@ -99,7 +99,7 @@ void AbstractButton::mousemove_event(MouseEvent& event)
 {
     bool is_over = rect().contains(event.position());
     m_hovered = is_over;
-    if (event.buttons() & MouseButton::Left) {
+    if (event.buttons() & MouseButton::Primary) {
         bool being_pressed = is_over;
         if (being_pressed != m_being_pressed) {
             m_being_pressed = being_pressed;
@@ -117,7 +117,7 @@ void AbstractButton::mousemove_event(MouseEvent& event)
 
 void AbstractButton::mousedown_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Left) {
+    if (event.button() == MouseButton::Primary) {
         m_being_pressed = true;
         update();
 
@@ -131,7 +131,7 @@ void AbstractButton::mousedown_event(MouseEvent& event)
 
 void AbstractButton::mouseup_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Left) {
+    if (event.button() == MouseButton::Primary) {
         bool was_auto_repeating = m_auto_repeat_timer->is_active();
         m_auto_repeat_timer->stop();
         bool was_being_pressed = m_being_pressed;

--- a/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Libraries/LibGUI/AbstractTableView.cpp
@@ -176,7 +176,7 @@ void AbstractTableView::mousedown_event(MouseEvent& event)
     if (!model())
         return AbstractView::mousedown_event(event);
 
-    if (event.button() != MouseButton::Left)
+    if (event.button() != MouseButton::Primary)
         return AbstractView::mousedown_event(event);
 
     bool is_toggle;

--- a/Libraries/LibGUI/AbstractView.cpp
+++ b/Libraries/LibGUI/AbstractView.cpp
@@ -227,7 +227,7 @@ void AbstractView::mousedown_event(MouseEvent& event)
     if (!model())
         return;
 
-    if (event.button() == MouseButton::Left)
+    if (event.button() == MouseButton::Primary)
         m_left_mousedown_position = event.position();
 
     auto index = index_at_event_position(event.position());
@@ -239,10 +239,10 @@ void AbstractView::mousedown_event(MouseEvent& event)
         set_cursor(index, SelectionUpdate::Ctrl);
     } else if (event.modifiers() & Mod_Shift) {
         set_cursor(index, SelectionUpdate::Shift);
-    } else if (event.button() == MouseButton::Left && m_selection.contains(index) && !m_model->drag_data_type().is_null()) {
+    } else if (event.button() == MouseButton::Primary && m_selection.contains(index) && !m_model->drag_data_type().is_null()) {
         // We might be starting a drag, so don't throw away other selected items yet.
         m_might_drag = true;
-    } else if (event.button() == MouseButton::Right) {
+    } else if (event.button() == MouseButton::Secondary) {
         set_cursor(index, SelectionUpdate::ClearIfNotSelected);
     } else {
         set_cursor(index, SelectionUpdate::Set);
@@ -283,7 +283,7 @@ void AbstractView::mousemove_event(MouseEvent& event)
     if (!m_might_drag)
         return ScrollableWidget::mousemove_event(event);
 
-    if (!(event.buttons() & MouseButton::Left) || m_selection.is_empty()) {
+    if (!(event.buttons() & MouseButton::Primary) || m_selection.is_empty()) {
         m_might_drag = false;
         return ScrollableWidget::mousemove_event(event);
     }
@@ -354,7 +354,7 @@ void AbstractView::doubleclick_event(MouseEvent& event)
     if (!model())
         return;
 
-    if (event.button() != MouseButton::Left)
+    if (event.button() != MouseButton::Primary)
         return;
 
     m_might_drag = false;

--- a/Libraries/LibGUI/ColorInput.cpp
+++ b/Libraries/LibGUI/ColorInput.cpp
@@ -77,7 +77,7 @@ void ColorInput::set_color(Color color)
 
 void ColorInput::mousedown_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Left && color_rect().contains(event.position())) {
+    if (event.button() == MouseButton::Primary && color_rect().contains(event.position())) {
         m_may_be_color_rect_click = true;
         return;
     }
@@ -87,7 +87,7 @@ void ColorInput::mousedown_event(MouseEvent& event)
 
 void ColorInput::mouseup_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Left) {
+    if (event.button() == MouseButton::Primary) {
         bool is_color_rect_click = m_may_be_color_rect_click && color_rect().contains(event.position());
         m_may_be_color_rect_click = false;
         if (is_color_rect_click) {

--- a/Libraries/LibGUI/ColorPicker.cpp
+++ b/Libraries/LibGUI/ColorPicker.cpp
@@ -558,7 +558,7 @@ void ColorField::pick_color_at_position(GUI::MouseEvent& event)
 
 void ColorField::mousedown_event(GUI::MouseEvent& event)
 {
-    if (event.button() == GUI::MouseButton::Left) {
+    if (event.button() == GUI::MouseButton::Primary) {
         m_being_pressed = true;
         pick_color_at_position(event);
     }
@@ -566,7 +566,7 @@ void ColorField::mousedown_event(GUI::MouseEvent& event)
 
 void ColorField::mouseup_event(GUI::MouseEvent& event)
 {
-    if (event.button() == GUI::MouseButton::Left) {
+    if (event.button() == GUI::MouseButton::Primary) {
         m_being_pressed = false;
         pick_color_at_position(event);
     }
@@ -574,7 +574,7 @@ void ColorField::mouseup_event(GUI::MouseEvent& event)
 
 void ColorField::mousemove_event(GUI::MouseEvent& event)
 {
-    if (event.buttons() & GUI::MouseButton::Left)
+    if (event.buttons() & GUI::MouseButton::Primary)
         pick_color_at_position(event);
 }
 
@@ -652,7 +652,7 @@ void ColorSlider::pick_value_at_position(GUI::MouseEvent& event)
 
 void ColorSlider::mousedown_event(GUI::MouseEvent& event)
 {
-    if (event.button() == GUI::MouseButton::Left) {
+    if (event.button() == GUI::MouseButton::Primary) {
         m_being_pressed = true;
         pick_value_at_position(event);
     }
@@ -660,7 +660,7 @@ void ColorSlider::mousedown_event(GUI::MouseEvent& event)
 
 void ColorSlider::mouseup_event(GUI::MouseEvent& event)
 {
-    if (event.button() == GUI::MouseButton::Left) {
+    if (event.button() == GUI::MouseButton::Primary) {
         m_being_pressed = false;
         pick_value_at_position(event);
     }
@@ -668,7 +668,7 @@ void ColorSlider::mouseup_event(GUI::MouseEvent& event)
 
 void ColorSlider::mousemove_event(GUI::MouseEvent& event)
 {
-    if (event.buttons() & GUI::MouseButton::Left)
+    if (event.buttons() & GUI::MouseButton::Primary)
         pick_value_at_position(event);
 }
 

--- a/Libraries/LibGUI/ColumnsView.cpp
+++ b/Libraries/LibGUI/ColumnsView.cpp
@@ -259,7 +259,7 @@ void ColumnsView::mousedown_event(MouseEvent& event)
     if (!model())
         return;
 
-    if (event.button() != MouseButton::Left)
+    if (event.button() != MouseButton::Primary)
         return;
 
     auto index = index_at_event_position(event.position());

--- a/Libraries/LibGUI/Event.h
+++ b/Libraries/LibGUI/Event.h
@@ -268,8 +268,8 @@ public:
 
 enum MouseButton : u8 {
     None = 0,
-    Left = 1,
-    Right = 2,
+    Primary = 1,
+    Secondary = 2,
     Middle = 4,
     Back = 8,
     Forward = 16,

--- a/Libraries/LibGUI/HeaderView.cpp
+++ b/Libraries/LibGUI/HeaderView.cpp
@@ -196,7 +196,7 @@ void HeaderView::mousemove_event(MouseEvent& event)
 
 void HeaderView::mouseup_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Left) {
+    if (event.button() == MouseButton::Primary) {
         if (m_in_section_resize) {
             if (!section_resize_grabbable_rect(m_resizing_section).contains(event.position()))
                 set_override_cursor(Gfx::StandardCursor::None);

--- a/Libraries/LibGUI/IconView.cpp
+++ b/Libraries/LibGUI/IconView.cpp
@@ -228,7 +228,7 @@ void IconView::mousedown_event(MouseEvent& event)
     if (!model())
         return AbstractView::mousedown_event(event);
 
-    if (event.button() != MouseButton::Left)
+    if (event.button() != MouseButton::Primary)
         return AbstractView::mousedown_event(event);
 
     auto index = index_at_event_position(event.position());
@@ -256,7 +256,7 @@ void IconView::mousedown_event(MouseEvent& event)
 
 void IconView::mouseup_event(MouseEvent& event)
 {
-    if (m_rubber_banding && event.button() == MouseButton::Left) {
+    if (m_rubber_banding && event.button() == MouseButton::Primary) {
         m_rubber_banding = false;
         if (m_out_of_view_timer)
             m_out_of_view_timer->stop();

--- a/Libraries/LibGUI/OpacitySlider.cpp
+++ b/Libraries/LibGUI/OpacitySlider.cpp
@@ -129,7 +129,7 @@ int OpacitySlider::value_at(const Gfx::IntPoint& position) const
 
 void OpacitySlider::mousedown_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Left) {
+    if (event.button() == MouseButton::Primary) {
         m_dragging = true;
         set_value(value_at(event.position()));
         return;
@@ -148,7 +148,7 @@ void OpacitySlider::mousemove_event(MouseEvent& event)
 
 void OpacitySlider::mouseup_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Left) {
+    if (event.button() == MouseButton::Primary) {
         m_dragging = false;
         return;
     }

--- a/Libraries/LibGUI/ResizeCorner.cpp
+++ b/Libraries/LibGUI/ResizeCorner.cpp
@@ -105,7 +105,7 @@ void ResizeCorner::paint_event(PaintEvent& event)
 
 void ResizeCorner::mousedown_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Left)
+    if (event.button() == MouseButton::Primary)
         window()->start_wm_resize();
     Widget::mousedown_event(event);
 }

--- a/Libraries/LibGUI/ScrollBar.cpp
+++ b/Libraries/LibGUI/ScrollBar.cpp
@@ -255,7 +255,7 @@ void ScrollBar::on_automatic_scrolling_timer_fired()
 
 void ScrollBar::mousedown_event(MouseEvent& event)
 {
-    if (event.button() != MouseButton::Left)
+    if (event.button() != MouseButton::Primary)
         return;
     if (!has_scrubber())
         return;
@@ -294,7 +294,7 @@ void ScrollBar::mousedown_event(MouseEvent& event)
 
 void ScrollBar::mouseup_event(MouseEvent& event)
 {
-    if (event.button() != MouseButton::Left)
+    if (event.button() != MouseButton::Primary)
         return;
     set_automatic_scrolling_active(false, Component::None);
     update();

--- a/Libraries/LibGUI/Slider.cpp
+++ b/Libraries/LibGUI/Slider.cpp
@@ -97,7 +97,7 @@ Gfx::IntRect Slider::knob_rect() const
 
 void Slider::mousedown_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Left) {
+    if (event.button() == MouseButton::Primary) {
         if (knob_rect().contains(event.position())) {
             m_dragging = true;
             m_drag_origin = event.position();
@@ -129,7 +129,7 @@ void Slider::mousemove_event(MouseEvent& event)
 
 void Slider::mouseup_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Left) {
+    if (event.button() == MouseButton::Primary) {
         m_dragging = false;
         return;
     }

--- a/Libraries/LibGUI/Splitter.cpp
+++ b/Libraries/LibGUI/Splitter.cpp
@@ -115,7 +115,7 @@ bool Splitter::get_resize_candidates_at(const Gfx::IntPoint& position, Widget*& 
 
 void Splitter::mousedown_event(MouseEvent& event)
 {
-    if (event.button() != MouseButton::Left)
+    if (event.button() != MouseButton::Primary)
         return;
     m_resizing = true;
 
@@ -203,7 +203,7 @@ void Splitter::did_layout()
 
 void Splitter::mouseup_event(MouseEvent& event)
 {
-    if (event.button() != MouseButton::Left)
+    if (event.button() != MouseButton::Primary)
         return;
     m_resizing = false;
     m_first_resizee = nullptr;

--- a/Libraries/LibGUI/TabWidget.cpp
+++ b/Libraries/LibGUI/TabWidget.cpp
@@ -305,7 +305,7 @@ void TabWidget::mousedown_event(MouseEvent& event)
         auto button_rect = this->button_rect(i);
         if (!button_rect.contains(event.position()))
             continue;
-        if (event.button() == MouseButton::Left) {
+        if (event.button() == MouseButton::Primary) {
             set_active_widget(m_tabs[i].widget);
         } else if (event.button() == MouseButton::Middle) {
             auto* widget = m_tabs[i].widget;

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -212,7 +212,7 @@ TextPosition TextEditor::text_position_at(const Gfx::IntPoint& a_position) const
 
 void TextEditor::doubleclick_event(MouseEvent& event)
 {
-    if (event.button() != MouseButton::Left)
+    if (event.button() != MouseButton::Primary)
         return;
 
     if (is_displayonly())
@@ -249,7 +249,7 @@ void TextEditor::doubleclick_event(MouseEvent& event)
 
 void TextEditor::mousedown_event(MouseEvent& event)
 {
-    if (event.button() != MouseButton::Left) {
+    if (event.button() != MouseButton::Primary) {
         return;
     }
 
@@ -307,7 +307,7 @@ void TextEditor::mousedown_event(MouseEvent& event)
 
 void TextEditor::mouseup_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Left) {
+    if (event.button() == MouseButton::Primary) {
         if (m_in_drag_select) {
             m_in_drag_select = false;
         }

--- a/Libraries/LibGUI/TreeView.cpp
+++ b/Libraries/LibGUI/TreeView.cpp
@@ -98,7 +98,7 @@ void TreeView::doubleclick_event(MouseEvent& event)
     if (!index.is_valid())
         return;
 
-    if (event.button() == MouseButton::Left) {
+    if (event.button() == MouseButton::Primary) {
         set_cursor(index, SelectionUpdate::Set);
 
         if (model.row_count(index))

--- a/Libraries/LibGUI/Widget.cpp
+++ b/Libraries/LibGUI/Widget.cpp
@@ -387,7 +387,7 @@ void Widget::handle_mousedown_event(MouseEvent& event)
     if (((unsigned)focus_policy() & (unsigned)FocusPolicy::ClickFocus))
         set_focus(true, FocusSource::Mouse);
     mousedown_event(event);
-    if (event.button() == MouseButton::Right) {
+    if (event.button() == MouseButton::Secondary) {
         ContextMenuEvent c_event(event.position(), screen_relative_rect().location().translated(event.position()));
         context_menu_event(c_event);
     }

--- a/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Libraries/LibGUI/WindowServerConnection.cpp
@@ -215,9 +215,9 @@ static MouseButton to_gmousebutton(u32 button)
     case 0:
         return MouseButton::None;
     case 1:
-        return MouseButton::Left;
+        return MouseButton::Primary;
     case 2:
-        return MouseButton::Right;
+        return MouseButton::Secondary;
     case 4:
         return MouseButton::Middle;
     case 8:

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -655,7 +655,7 @@ VT::Range TerminalWidget::find_previous(const StringView& needle, const VT::Posi
 
 void TerminalWidget::doubleclick_event(GUI::MouseEvent& event)
 {
-    if (event.button() == GUI::MouseButton::Left) {
+    if (event.button() == GUI::MouseButton::Primary) {
         m_triple_click_timer.start();
 
         auto position = buffer_position_at(event.position());
@@ -704,7 +704,7 @@ void TerminalWidget::copy()
 
 void TerminalWidget::mouseup_event(GUI::MouseEvent& event)
 {
-    if (event.button() == GUI::MouseButton::Left) {
+    if (event.button() == GUI::MouseButton::Primary) {
         auto attribute = m_terminal.attribute_at(buffer_position_at(event.position()));
         if (!m_active_href_id.is_null() && attribute.href_id == m_active_href_id) {
             dbgln("Open hyperlinked URL: '{}'", attribute.href);
@@ -721,7 +721,7 @@ void TerminalWidget::mouseup_event(GUI::MouseEvent& event)
 
 void TerminalWidget::mousedown_event(GUI::MouseEvent& event)
 {
-    if (event.button() == GUI::MouseButton::Left) {
+    if (event.button() == GUI::MouseButton::Primary) {
         m_left_mousedown_position = event.position();
 
         auto attribute = m_terminal.attribute_at(buffer_position_at(event.position()));
@@ -774,7 +774,7 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
         update();
     }
 
-    if (!(event.buttons() & GUI::MouseButton::Left))
+    if (!(event.buttons() & GUI::MouseButton::Primary))
         return;
 
     if (!m_active_href_id.is_null()) {

--- a/Libraries/LibWeb/Layout/ButtonBox.cpp
+++ b/Libraries/LibWeb/Layout/ButtonBox.cpp
@@ -73,7 +73,7 @@ void ButtonBox::paint(PaintContext& context, PaintPhase phase)
 
 void ButtonBox::handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned)
 {
-    if (button != GUI::MouseButton::Left || !dom_node().enabled())
+    if (button != GUI::MouseButton::Primary || !dom_node().enabled())
         return;
 
     m_being_pressed = true;
@@ -85,7 +85,7 @@ void ButtonBox::handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsi
 
 void ButtonBox::handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint& position, unsigned button, unsigned)
 {
-    if (!m_tracking_mouse || button != GUI::MouseButton::Left || !dom_node().enabled())
+    if (!m_tracking_mouse || button != GUI::MouseButton::Primary || !dom_node().enabled())
         return;
 
     // NOTE: Handling the click may run arbitrary JS, which could disappear this node.

--- a/Libraries/LibWeb/Layout/CheckBox.cpp
+++ b/Libraries/LibWeb/Layout/CheckBox.cpp
@@ -60,7 +60,7 @@ void CheckBox::paint(PaintContext& context, PaintPhase phase)
 
 void CheckBox::handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned)
 {
-    if (button != GUI::MouseButton::Left || !dom_node().enabled())
+    if (button != GUI::MouseButton::Primary || !dom_node().enabled())
         return;
 
     m_being_pressed = true;
@@ -72,7 +72,7 @@ void CheckBox::handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsig
 
 void CheckBox::handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint& position, unsigned button, unsigned)
 {
-    if (!m_tracking_mouse || button != GUI::MouseButton::Left || !dom_node().enabled())
+    if (!m_tracking_mouse || button != GUI::MouseButton::Primary || !dom_node().enabled())
         return;
 
     // NOTE: Changing the checked state of the DOM node may run arbitrary JS, which could disappear this node.

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -110,7 +110,7 @@ bool EventHandler::handle_mouseup(const Gfx::IntPoint& position, unsigned button
         handled_event = true;
     }
 
-    if (button == GUI::MouseButton::Left) {
+    if (button == GUI::MouseButton::Primary) {
         dump_selection("MouseUp");
         m_in_mouse_selection = false;
     }
@@ -163,7 +163,7 @@ bool EventHandler::handle_mousedown(const Gfx::IntPoint& position, unsigned butt
     if (!layout_root() || layout_root() != node->document().layout_node())
         return true;
 
-    if (button == GUI::MouseButton::Right && is<HTML::HTMLImageElement>(*node)) {
+    if (button == GUI::MouseButton::Secondary && is<HTML::HTMLImageElement>(*node)) {
         auto& image_element = downcast<HTML::HTMLImageElement>(*node);
         auto image_url = image_element.document().complete_url(image_element.src());
         if (auto* page = m_frame.page())
@@ -175,7 +175,7 @@ bool EventHandler::handle_mousedown(const Gfx::IntPoint& position, unsigned butt
         auto href = link->href();
         auto url = document->complete_url(href);
         dbg() << "Web::EventHandler: Clicking on a link to " << url;
-        if (button == GUI::MouseButton::Left) {
+        if (button == GUI::MouseButton::Primary) {
             auto href = link->href();
             auto url = document->complete_url(href);
             if (href.starts_with("javascript:")) {
@@ -192,7 +192,7 @@ bool EventHandler::handle_mousedown(const Gfx::IntPoint& position, unsigned butt
                     m_frame.loader().load(url, FrameLoader::Type::Navigation);
                 }
             }
-        } else if (button == GUI::MouseButton::Right) {
+        } else if (button == GUI::MouseButton::Secondary) {
             if (auto* page = m_frame.page())
                 page->client().page_did_request_link_context_menu(m_frame.to_main_frame_position(position), url, link->target(), modifiers);
         } else if (button == GUI::MouseButton::Middle) {
@@ -200,7 +200,7 @@ bool EventHandler::handle_mousedown(const Gfx::IntPoint& position, unsigned butt
                 page->client().page_did_middle_click_link(url, link->target(), modifiers);
         }
     } else {
-        if (button == GUI::MouseButton::Left) {
+        if (button == GUI::MouseButton::Primary) {
             auto result = layout_root()->hit_test(position, Layout::HitTestType::TextCursor);
             if (result.layout_node && result.layout_node->dom_node()) {
                 m_frame.set_cursor_position(DOM::Position(*node, result.index_in_node));
@@ -208,7 +208,7 @@ bool EventHandler::handle_mousedown(const Gfx::IntPoint& position, unsigned butt
                 dump_selection("MouseDown");
                 m_in_mouse_selection = true;
             }
-        } else if (button == GUI::MouseButton::Right) {
+        } else if (button == GUI::MouseButton::Secondary) {
             if (auto* page = m_frame.page())
                 page->client().page_did_request_context_menu(m_frame.to_main_frame_position(position));
         }

--- a/MenuApplets/Audio/main.cpp
+++ b/MenuApplets/Audio/main.cpp
@@ -127,14 +127,14 @@ public:
 private:
     virtual void mousedown_event(GUI::MouseEvent& event) override
     {
-        if (event.button() == GUI::MouseButton::Left) {
+        if (event.button() == GUI::MouseButton::Primary) {
             if (!m_slider_window->is_visible())
                 open();
             else
                 close();
             return;
         }
-        if (event.button() == GUI::MouseButton::Right) {
+        if (event.button() == GUI::MouseButton::Secondary) {
             m_audio_client->set_muted(!m_audio_muted);
             update();
         }

--- a/MenuApplets/Clock/main.cpp
+++ b/MenuApplets/Clock/main.cpp
@@ -223,7 +223,7 @@ private:
 
     virtual void mousedown_event(GUI::MouseEvent& event) override
     {
-        if (event.button() != GUI::MouseButton::Left) {
+        if (event.button() != GUI::MouseButton::Primary) {
             return;
         } else {
             if (!m_calendar_window->is_visible())

--- a/MenuApplets/Network/main.cpp
+++ b/MenuApplets/Network/main.cpp
@@ -56,7 +56,7 @@ private:
 
     virtual void mousedown_event(GUI::MouseEvent& event) override
     {
-        if (event.button() != GUI::MouseButton::Left)
+        if (event.button() != GUI::MouseButton::Primary)
             return;
 
         pid_t child_pid;

--- a/MenuApplets/ResourceGraph/main.cpp
+++ b/MenuApplets/ResourceGraph/main.cpp
@@ -113,7 +113,7 @@ private:
 
     virtual void mousedown_event(GUI::MouseEvent& event) override
     {
-        if (event.button() != GUI::MouseButton::Left)
+        if (event.button() != GUI::MouseButton::Primary)
             return;
         pid_t child_pid;
         const char* argv[] = { "SystemMonitor", nullptr };

--- a/Services/WindowServer/Button.cpp
+++ b/Services/WindowServer/Button.cpp
@@ -62,14 +62,14 @@ void Button::on_mouse_event(const MouseEvent& event)
 {
     auto& wm = WindowManager::the();
 
-    if (event.type() == Event::MouseDown && event.button() == MouseButton::Left) {
+    if (event.type() == Event::MouseDown && event.button() == MouseButton::Primary) {
         m_pressed = true;
         wm.set_cursor_tracking_button(this);
         m_frame.invalidate(m_relative_rect);
         return;
     }
 
-    if (event.type() == Event::MouseUp && event.button() == MouseButton::Left) {
+    if (event.type() == Event::MouseUp && event.button() == MouseButton::Primary) {
         if (wm.cursor_tracking_button() != this)
             return;
         wm.set_cursor_tracking_button(nullptr);
@@ -98,7 +98,7 @@ void Button::on_mouse_event(const MouseEvent& event)
             m_frame.invalidate(m_relative_rect);
     }
 
-    if (event.type() == Event::MouseMove && event.buttons() & (unsigned)MouseButton::Left) {
+    if (event.type() == Event::MouseMove && event.buttons() & (unsigned)MouseButton::Primary) {
         if (wm.cursor_tracking_button() != this)
             return;
         bool old_pressed = m_pressed;

--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -701,7 +701,7 @@ void ClientConnection::handle(const Messages::WindowServer::WM_StartWindowResize
     auto& window = *(*it).value;
     // FIXME: We are cheating a bit here by using the current cursor location and hard-coding the left button.
     //        Maybe the client should be allowed to specify what initiated this request?
-    WindowManager::the().start_window_resize(window, Screen::the().cursor_location(), MouseButton::Left);
+    WindowManager::the().start_window_resize(window, Screen::the().cursor_location(), MouseButton::Primary);
 }
 
 void ClientConnection::handle(const Messages::WindowServer::WM_SetWindowMinimized& message)

--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -911,6 +911,20 @@ OwnPtr<Messages::WindowServer::GetScrollStepSizeResponse> ClientConnection::hand
     return make<Messages::WindowServer::GetScrollStepSizeResponse>(Screen::the().scroll_step_size());
 }
 
+OwnPtr<Messages::WindowServer::SetPrimaryMouseButtonResponse> ClientConnection::handle(const Messages::WindowServer::SetPrimaryMouseButton& message)
+{
+    if (message.button() != static_cast<u32>(RawMouseButton::Left) && message.button() != static_cast<u32>(RawMouseButton::Right)) {
+        did_misbehave("SetPrimaryMouseButton with invalid button");
+        return nullptr;
+    }
+    WindowManager::the().set_primary_mouse_button(static_cast<RawMouseButton>(message.button()));
+    return make<Messages::WindowServer::SetPrimaryMouseButtonResponse>();
+}
+OwnPtr<Messages::WindowServer::GetPrimaryMouseButtonResponse> ClientConnection::handle(const Messages::WindowServer::GetPrimaryMouseButton&)
+{
+    return make<Messages::WindowServer::GetPrimaryMouseButtonResponse>(static_cast<u32>(Screen::the().primary_mouse_button()));
+}
+
 void ClientConnection::set_unresponsive(bool unresponsive)
 {
     if (m_unresponsive == unresponsive)

--- a/Services/WindowServer/ClientConnection.h
+++ b/Services/WindowServer/ClientConnection.h
@@ -149,6 +149,8 @@ private:
     virtual OwnPtr<Messages::WindowServer::GetMouseAccelerationResponse> handle(const Messages::WindowServer::GetMouseAcceleration&) override;
     virtual OwnPtr<Messages::WindowServer::SetScrollStepSizeResponse> handle(const Messages::WindowServer::SetScrollStepSize&) override;
     virtual OwnPtr<Messages::WindowServer::GetScrollStepSizeResponse> handle(const Messages::WindowServer::GetScrollStepSize&) override;
+    virtual OwnPtr<Messages::WindowServer::SetPrimaryMouseButtonResponse> handle(const Messages::WindowServer::SetPrimaryMouseButton&) override;
+    virtual OwnPtr<Messages::WindowServer::GetPrimaryMouseButtonResponse> handle(const Messages::WindowServer::GetPrimaryMouseButton&) override;
 
     Window* window_from_id(i32 window_id);
 

--- a/Services/WindowServer/Event.h
+++ b/Services/WindowServer/Event.h
@@ -70,8 +70,8 @@ public:
 
 enum class MouseButton : u8 {
     None = 0,
-    Left = 1,
-    Right = 2,
+    Primary = 1,
+    Secondary = 2,
     Middle = 4,
     Back = 8,
     Forward = 16,

--- a/Services/WindowServer/MenuManager.cpp
+++ b/Services/WindowServer/MenuManager.cpp
@@ -271,7 +271,7 @@ void MenuManager::handle_menu_mouse_event(Menu& menu, const MouseEvent& event)
     bool is_hover_with_any_menu_open = event.type() == MouseEvent::MouseMove
         && has_open_menu()
         && (m_open_menu_stack.first()->menubar() || m_open_menu_stack.first() == m_system_menu.ptr());
-    bool is_mousedown_with_left_button = event.type() == MouseEvent::MouseDown && event.button() == MouseButton::Left;
+    bool is_mousedown_with_left_button = event.type() == MouseEvent::MouseDown && event.button() == MouseButton::Primary;
     bool should_open_menu = &menu != m_current_menu && (is_hover_with_any_menu_open || is_mousedown_with_left_button);
 
     if (is_mousedown_with_left_button)

--- a/Services/WindowServer/Screen.h
+++ b/Services/WindowServer/Screen.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "Event.h"
 #include <Kernel/API/KeyCode.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Rect.h>
@@ -38,6 +39,15 @@ namespace WindowServer {
 const double mouse_accel_max = 3.5;
 const double mouse_accel_min = 0.5;
 const unsigned scroll_step_size_min = 1;
+
+enum class RawMouseButton : u8 {
+    None = 0,
+    Left = 1,
+    Right = 2,
+    Middle = 4,
+    Back = 8,
+    Forward = 16,
+};
 
 class Screen {
 public:
@@ -67,6 +77,9 @@ public:
     unsigned scroll_step_size() const { return m_scroll_step_size; }
     void set_scroll_step_size(unsigned);
 
+    RawMouseButton primary_mouse_button() const { return m_primary_mouse_button; }
+    void set_primary_mouse_button(RawMouseButton);
+
     void on_receive_mouse_data(const MousePacket&);
     void on_receive_keyboard_data(::KeyEvent);
 
@@ -88,6 +101,7 @@ private:
     unsigned m_modifiers { 0 };
     double m_acceleration_factor { 1.0 };
     unsigned m_scroll_step_size { 1 };
+    RawMouseButton m_primary_mouse_button { RawMouseButton::Left };
 };
 
 inline Gfx::RGBA32* Screen::scanline(int y)

--- a/Services/WindowServer/WindowFrame.cpp
+++ b/Services/WindowServer/WindowFrame.cpp
@@ -282,7 +282,7 @@ void WindowFrame::on_mouse_event(const MouseEvent& event)
             return;
 
         if (title_bar_icon_rect().contains(event.position())) {
-            if (event.type() == Event::MouseDown && (event.button() == MouseButton::Left || event.button() == MouseButton::Right)) {
+            if (event.type() == Event::MouseDown && (event.button() == MouseButton::Primary || event.button() == MouseButton::Secondary)) {
                 // Manually start a potential double click. Since we're opening
                 // a menu, we will only receive the MouseDown event, so we
                 // need to record that fact. If the user subsequently clicks
@@ -297,7 +297,7 @@ void WindowFrame::on_mouse_event(const MouseEvent& event)
 
                 m_window.popup_window_menu(title_bar_rect().bottom_left().translated(rect().location()), WindowMenuDefaultAction::Close);
                 return;
-            } else if (event.type() == Event::MouseUp && event.button() == MouseButton::Left) {
+            } else if (event.type() == Event::MouseUp && event.button() == MouseButton::Primary) {
                 // Since the MouseDown event opened a menu, another MouseUp
                 // from the second click outside the menu wouldn't be considered
                 // a double click, so let's manually check if it would otherwise
@@ -329,12 +329,12 @@ void WindowFrame::on_mouse_event(const MouseEvent& event)
                 return button.on_mouse_event(event.translated(-button.relative_rect().location()));
         }
         if (event.type() == Event::MouseDown) {
-            if (m_window.type() == WindowType::Normal && event.button() == MouseButton::Right) {
+            if (m_window.type() == WindowType::Normal && event.button() == MouseButton::Secondary) {
                 auto default_action = m_window.is_maximized() ? WindowMenuDefaultAction::Restore : WindowMenuDefaultAction::Maximize;
                 m_window.popup_window_menu(event.position().translated(rect().location()), default_action);
                 return;
             }
-            if (m_window.is_movable() && event.button() == MouseButton::Left)
+            if (m_window.is_movable() && event.button() == MouseButton::Primary)
                 wm.start_window_move(m_window, event.translated(rect().location()));
         }
         return;
@@ -357,7 +357,7 @@ void WindowFrame::on_mouse_event(const MouseEvent& event)
         return;
     }
 
-    if (m_window.is_resizable() && event.type() == Event::MouseDown && event.button() == MouseButton::Left)
+    if (m_window.is_resizable() && event.type() == Event::MouseDown && event.button() == MouseButton::Primary)
         wm.start_window_resize(m_window, event.translated(rect().location()));
 }
 }

--- a/Services/WindowServer/WindowManager.h
+++ b/Services/WindowServer/WindowManager.h
@@ -41,6 +41,7 @@
 #include <WindowServer/Event.h>
 #include <WindowServer/MenuBar.h>
 #include <WindowServer/MenuManager.h>
+#include <WindowServer/Screen.h>
 #include <WindowServer/Window.h>
 #include <WindowServer/WindowSwitcher.h>
 #include <WindowServer/WindowType.h>
@@ -147,6 +148,7 @@ public:
 
     void set_acceleration_factor(double);
     void set_scroll_step_size(unsigned);
+    void set_primary_mouse_button(RawMouseButton);
 
     Window* set_active_input_window(Window*);
     void restore_active_input_window(Window*);

--- a/Services/WindowServer/WindowServer.ipc
+++ b/Services/WindowServer/WindowServer.ipc
@@ -113,5 +113,8 @@ endpoint WindowServer = 2
     SetScrollStepSize(u32 step_size) => ()
     GetScrollStepSize() => (u32 step_size)
 
+    SetPrimaryMouseButton(u32 button) => ()
+    GetPrimaryMouseButton() => (u32 button)
+
     Pong() =|
 }

--- a/Services/WindowServer/main.cpp
+++ b/Services/WindowServer/main.cpp
@@ -93,6 +93,7 @@ int main(int, char**)
         wm_config->read_num_entry("Screen", "Height", 768));
     screen.set_acceleration_factor(atof(wm_config->read_entry("Mouse", "AccelerationFactor", "1.0").characters()));
     screen.set_scroll_step_size(wm_config->read_num_entry("Mouse", "ScrollStepSize", 4));
+    screen.set_primary_mouse_button(static_cast<WindowServer::RawMouseButton>(wm_config->read_num_entry("Mouse", "PrimaryButton", static_cast<int>(WindowServer::RawMouseButton::Left))));
     WindowServer::Compositor::the();
     auto wm = WindowServer::WindowManager::construct(*palette);
     auto am = WindowServer::AppletManager::construct();


### PR DESCRIPTION
![primary](https://user-images.githubusercontent.com/16208640/103423827-940b5f80-4bb1-11eb-893a-33919c8507c6.gif)
This PR adds a configurable (via MouseSettings) primary mouse button setting in WindowServer which will eventually allow
us to accommodate left handed serenity os users, but considerable work has to be done in the various user-facing parts of serenity to switch from hardcoded is MouseButton::Left checks to is_primary checks (Should i start work on that in this PR or another one?).

Note: i feel like some parts of the code in this one are a bit awkward (especially in the UI side), so i'd be happy to hear code quality improvement suggestions :)