### PR TITLE
DynamicLoader: Tell the linker to not add a PT_INTERP header

### DIFF
--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -634,12 +634,10 @@ KResultOr<NonnullRefPtr<FileDescription>> Process::find_elf_interpreter_for_exec
             return KResult(-ENOEXEC);
         }
 
-        // FIXME: Uncomment this
-        //        How do we get gcc to not insert an interpreter section to /usr/lib/Loader.so itself?
-        // if (!interpreter_interpreter_path.is_empty()) {
-        //     dbgln("exec({}): Interpreter ({}) has its own interpreter ({})! No thank you!", path, interpreter_description->absolute_path(), interpreter_interpreter_path);
-        //     return KResult(-ELOOP);
-        // }
+        if (!interpreter_interpreter_path.is_empty()) {
+            dbgln("exec({}): Interpreter ({}) has its own interpreter ({})! No thank you!", path, interpreter_description->absolute_path(), interpreter_interpreter_path);
+            return KResult(-ELOOP);
+        }
 
         return interpreter_description;
     }

--- a/Userland/DynamicLoader/CMakeLists.txt
+++ b/Userland/DynamicLoader/CMakeLists.txt
@@ -19,4 +19,5 @@ set(SOURCES ${LOADER_SOURCES} ${AK_SOURCES} ${ELF_SOURCES} ${LIBC_SOURCES1} ${LI
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdlib -pie -fpic -DNO_TLS")
 
 add_executable(Loader.so ${SOURCES})
+target_link_options(Loader.so PRIVATE LINKER:--no-dynamic-linker)
 install(TARGETS Loader.so RUNTIME DESTINATION usr/lib/)


### PR DESCRIPTION
Use the GNU LD option --no-dynamic-linker. This allows uncommenting some
code in the Kernel that gets upset if your ELF interpreter has its own
interpreter.

Turns out Rich Felker of Musl-LibC fame had this question back in 2012 and patched GNU LD to add the option:

https://stackoverflow.com/questions/10465875/is-there-an-option-to-gnu-ld-to-omit-dynamic-linker-pt-interp-completely

@itamar8910 