### PR TITLE
LibELF: validate_program_headers: Validate p_memsz and p_align

### DIFF
--- a/Libraries/LibELF/Validation.cpp
+++ b/Libraries/LibELF/Validation.cpp
@@ -200,6 +200,20 @@ bool validate_program_headers(const Elf32_Ehdr& elf_header, size_t file_size, co
             return false;
         }
 
+        if (program_header.p_memsz <= 0 && (program_header.p_type == PT_TLS || program_header.p_type == PT_LOAD)) {
+            if (verbose)
+                dbgln("Program header ({}) has invalid size in memory ({})", header_index, program_header.p_memsz);
+            return false;
+        }
+
+        if (program_header.p_type == PT_LOAD && program_header.p_align != PAGE_SIZE) {
+            if (elf_header.e_type != ET_CORE) {
+                if (verbose)
+                    dbgln("Program header ({}) with p_type PT_LOAD has p_align ({}) not equal to page size ({})", header_index, program_header.p_align, PAGE_SIZE);
+                return false;
+            }
+        }
+
         switch (program_header.p_type) {
         case PT_INTERP:
             // We checked above that file_size was >= buffer size. We only care about buffer size anyway, we're trying to read this!


### PR DESCRIPTION
Ensure ELF `p_memsz` and `p_align` program headers are validated during program header validation in `validate_program_headers`.

This prevents execution of malformed ELF objects with invalid `p_memsz` and `p_align` program headers making it all the way through to `Kernel::Process::load_elf_object` only to inevitably crash the kernel due to failed assertions.

This also prevents low privileged users (`nona`) trivially freezing the system by attempting to execute malformed ELF objects.

The logic implemented in this PR mirrors the logic implemented in `load_elf_object`. That is, this validation is designed only to prevent the assertions being hit. There's no guarantee that the assertions implemented in `load_elf_object` are correct, as they may have simply been implemented as "let's just assert and fix it later" and may miss corner cases or may be too restrictive. In other words, the `load_elf_object` validation probably needs a review at some point (in particular, validation surrounding ELF objects of type `PT_INTERP` should be reviewed #4563), at which time the validation in `validate_program_headers` should also be reviewed.

Resolves #4566.
