### PR TITLE
LibThread/LibPthread: Key destruction and Thread::join

### DIFF
--- a/AK/Result.h
+++ b/AK/Result.h
@@ -38,14 +38,17 @@ public:
         : m_result(res)
     {
     }
+
     Result(ValueType&& res)
         : m_result(move(res))
     {
     }
+
     Result(const ErrorType& error)
         : m_error(error)
     {
     }
+
     Result(ErrorType&& error)
         : m_error(move(error))
     {
@@ -57,21 +60,9 @@ public:
     {
     }
 
-    Result(Result&& other)
-        : m_result(move(other.m_result))
-        , m_error(move(other.m_error))
-    {
-    }
-
-    Result(Result& other)
-        : m_result(other.m_result)
-        , m_error(other.m_error)
-    {
-    }
-
-    ~Result()
-    {
-    }
+    Result(Result&& other) = default;
+    Result(const Result& other) = default;
+    ~Result() = default;
 
     ValueType& value()
     {
@@ -90,6 +81,39 @@ public:
 
 private:
     Optional<ValueType> m_result;
+    Optional<ErrorType> m_error;
+};
+
+// Partial specialization for void value type
+template<typename ErrorType>
+class [[nodiscard]] Result<void, ErrorType> {
+public:
+    Result(const ErrorType& error)
+        : m_error(error)
+    {
+    }
+
+    Result(ErrorType&& error)
+        : m_error(move(error))
+    {
+    }
+
+    Result() = default;
+    Result(Result&& other) = default;
+    Result(const Result& other) = default;
+    ~Result() = default;
+
+    ErrorType& error()
+    {
+        return m_error.value();
+    }
+
+    bool is_error() const
+    {
+        return m_error.has_value();
+    }
+
+private:
     Optional<ErrorType> m_error;
 };
 

--- a/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/DevTools/HackStudio/HackStudioWidget.cpp
@@ -920,11 +920,10 @@ HackStudioWidget::~HackStudioWidget()
 {
     if (!m_debugger_thread.is_null()) {
         Debugger::the().set_requested_debugger_action(Debugger::DebuggerAction::Exit);
-        void* retval;
         dbgln("Waiting for debugger thread to terminate");
-        int rc = pthread_join(m_debugger_thread->tid(), &retval);
-        if (rc < 0) {
-            perror("pthread_join");
+        auto rc = m_debugger_thread->join();
+        if (rc.is_error()) {
+            warnln("pthread_join: {}", strerror(rc.error().value()));
             dbgln("error joining debugger thread");
         }
     }

--- a/Libraries/LibPthread/pthread.h
+++ b/Libraries/LibPthread/pthread.h
@@ -87,6 +87,9 @@ int pthread_setschedparam(pthread_t thread, int policy, const struct sched_param
         0, 0, CLOCK_MONOTONIC_COARSE \
     }
 
+#define PTHREAD_KEYS_MAX 64
+#define PTHREAD_DESTRUCTOR_ITERATIONS 4
+
 int pthread_key_create(pthread_key_t* key, void (*destructor)(void*));
 int pthread_key_delete(pthread_key_t key);
 int pthread_cond_broadcast(pthread_cond_t*);

--- a/Userland/test-pthread.cpp
+++ b/Userland/test-pthread.cpp
@@ -48,7 +48,7 @@ static void test_once()
         threads.last().start();
     }
     for (auto& thread : threads)
-        thread.join();
+        [[maybe_unused]] auto res = thread.join();
 
     ASSERT(v.size() == 1);
 }


### PR DESCRIPTION
LibPthread: Destroy pthread_keys on thread/program exit

Currently, keys are destroyed either via global destructors, with the
s_key_destroyer object, or in exit_thread. exit_thread is invoked by
pthread_exit, and transitively by pthread_create, via the
pthread_create_helper that ensures all threads created with the pthread
API properly clean up for themselves when they exit gracefully.

A future patch might make s_key_destroyer a C++11 thread_local instead,
assuming we get thread_local and thread_local destructors working.

LibThread: Make Thread::join return the ret from pthread_join, and take a void* for the thread's return value.

Change the only caller of pthread_join to use the new and improved Thread::join API.

cc @bugaevc 