### PR TITLE
Everywhere: Type-safer Widget GML

### DIFF
--- a/Applications/Browser/Tab.cpp
+++ b/Applications/Browser/Tab.cpp
@@ -90,10 +90,10 @@ Tab::Tab(Type type)
 {
     load_from_gml(tab_gml);
 
-    m_toolbar_container = static_cast<GUI::ToolBarContainer&>(*find_descendant_by_name("toolbar_container"));
-    auto& toolbar = static_cast<GUI::ToolBar&>(*find_descendant_by_name("toolbar"));
+    m_toolbar_container = *find_descendant_of_type_named<GUI::ToolBarContainer>("toolbar_container");
+    auto& toolbar = *find_descendant_of_type_named<GUI::ToolBar>("toolbar");
 
-    auto& webview_container = *find_descendant_by_name("webview_container");
+    auto& webview_container = *find_descendant_of_type_named<GUI::Widget>("webview_container");
 
     if (m_type == Type::InProcessWebView)
         m_page_view = webview_container.add<Web::InProcessWebView>();
@@ -248,7 +248,7 @@ Tab::Tab(Type type)
         },
         this);
 
-    m_statusbar = static_cast<GUI::StatusBar&>(*find_descendant_by_name("statusbar"));
+    m_statusbar = *find_descendant_of_type_named<GUI::StatusBar>("statusbar");
 
     hooks().on_link_hover = [this](auto& url) {
         if (url.is_valid())

--- a/Applications/Browser/main.cpp
+++ b/Applications/Browser/main.cpp
@@ -140,7 +140,7 @@ int main(int argc, char** argv)
     auto& widget = window->set_main_widget<GUI::Widget>();
     widget.load_from_gml(browser_window_gml);
 
-    auto& tab_widget = static_cast<GUI::TabWidget&>(*widget.find_descendant_by_name("tab_widget"));
+    auto& tab_widget = *widget.find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
 
     auto default_favicon = Gfx::Bitmap::load_from_file("/res/icons/16x16/filetype-html.png");
     ASSERT(default_favicon);

--- a/Applications/CrashReporter/main.cpp
+++ b/Applications/CrashReporter/main.cpp
@@ -139,7 +139,7 @@ int main(int argc, char** argv)
     auto& widget = window->set_main_widget<GUI::Widget>();
     widget.load_from_gml(crash_reporter_window_gml);
 
-    auto& icon_image_widget = static_cast<GUI::ImageWidget&>(*widget.find_descendant_by_name("icon"));
+    auto& icon_image_widget = *widget.find_descendant_of_type_named<GUI::ImageWidget>("icon");
     icon_image_widget.set_bitmap(GUI::FileIconProvider::icon_for_executable(executable_path).bitmap_for_size(32));
 
     auto app_name = LexicalPath(executable_path).basename();
@@ -147,25 +147,25 @@ int main(int argc, char** argv)
     if (af->is_valid())
         app_name = af->name();
 
-    auto& description_label = static_cast<GUI::Label&>(*widget.find_descendant_by_name("description"));
+    auto& description_label = *widget.find_descendant_of_type_named<GUI::Label>("description");
     description_label.set_text(String::formatted("\"{}\" (PID {}) has crashed!", app_name, pid));
 
-    auto& executable_link_label = static_cast<GUI::LinkLabel&>(*widget.find_descendant_by_name("executable_link"));
+    auto& executable_link_label = *widget.find_descendant_of_type_named<GUI::LinkLabel>("executable_link");
     executable_link_label.set_text(LexicalPath::canonicalized_path(executable_path));
     executable_link_label.on_click = [&] {
         Desktop::Launcher::open(URL::create_with_file_protocol(LexicalPath(executable_path).dirname()));
     };
 
-    auto& coredump_link_label = static_cast<GUI::LinkLabel&>(*widget.find_descendant_by_name("coredump_link"));
+    auto& coredump_link_label = *widget.find_descendant_of_type_named<GUI::LinkLabel>("coredump_link");
     coredump_link_label.set_text(LexicalPath::canonicalized_path(coredump_path));
     coredump_link_label.on_click = [&] {
         Desktop::Launcher::open(URL::create_with_file_protocol(LexicalPath(coredump_path).dirname()));
     };
 
-    auto& backtrace_text_editor = static_cast<GUI::TextEditor&>(*widget.find_descendant_by_name("backtrace_text_editor"));
+    auto& backtrace_text_editor = *widget.find_descendant_of_type_named<GUI::TextEditor>("backtrace_text_editor");
     backtrace_text_editor.set_text(backtrace);
 
-    auto& close_button = static_cast<GUI::Button&>(*widget.find_descendant_by_name("close_button"));
+    auto& close_button = *widget.find_descendant_of_type_named<GUI::Button>("close_button");
     close_button.on_click = [&](auto) {
         app->quit();
     };

--- a/Applications/DisplaySettings/DisplaySettings.cpp
+++ b/Applications/DisplaySettings/DisplaySettings.cpp
@@ -93,9 +93,9 @@ void DisplaySettingsWidget::create_frame()
     m_root_widget = GUI::Widget::construct();
     m_root_widget->load_from_gml(display_settings_window_gml);
 
-    m_monitor_widget = static_cast<DisplaySettings::MonitorWidget&>(*m_root_widget->find_descendant_by_name("monitor_widget"));
+    m_monitor_widget = *m_root_widget->find_descendant_of_type_named<DisplaySettings::MonitorWidget>("monitor_widget");
 
-    m_wallpaper_combo = static_cast<GUI::ComboBox&>(*m_root_widget->find_descendant_by_name("wallpaper_combo"));
+    m_wallpaper_combo = *m_root_widget->find_descendant_of_type_named<GUI::ComboBox>("wallpaper_combo");
     m_wallpaper_combo->set_only_allow_values_from_model(true);
     m_wallpaper_combo->set_model(*GUI::ItemListModel<AK::String>::create(m_wallpapers));
     m_wallpaper_combo->on_change = [this](auto& text, const GUI::ModelIndex& index) {
@@ -120,7 +120,7 @@ void DisplaySettingsWidget::create_frame()
         m_monitor_widget->update();
     };
 
-    auto& button = static_cast<GUI::Button&>(*m_root_widget->find_descendant_by_name("wallpaper_open_button"));
+    auto& button = *m_root_widget->find_descendant_of_type_named<GUI::Button>("wallpaper_open_button");
     button.set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/open.png"));
     button.set_button_style(Gfx::ButtonStyle::CoolBar);
     button.on_click = [this](auto) {
@@ -134,7 +134,7 @@ void DisplaySettingsWidget::create_frame()
         m_wallpaper_combo->set_only_allow_values_from_model(true);
     };
 
-    m_mode_combo = static_cast<GUI::ComboBox&>(*m_root_widget->find_descendant_by_name("mode_combo"));
+    m_mode_combo = *m_root_widget->find_descendant_of_type_named<GUI::ComboBox>("mode_combo");
     m_mode_combo->set_only_allow_values_from_model(true);
     m_mode_combo->set_model(*GUI::ItemListModel<AK::String>::create(m_modes));
     m_mode_combo->on_change = [this](auto&, const GUI::ModelIndex& index) {
@@ -142,7 +142,7 @@ void DisplaySettingsWidget::create_frame()
         m_monitor_widget->update();
     };
 
-    m_resolution_combo = static_cast<GUI::ComboBox&>(*m_root_widget->find_descendant_by_name("resolution_combo"));
+    m_resolution_combo = *m_root_widget->find_descendant_of_type_named<GUI::ComboBox>("resolution_combo");
     m_resolution_combo->set_only_allow_values_from_model(true);
     m_resolution_combo->set_model(*GUI::ItemListModel<Gfx::IntSize>::create(m_resolutions));
     m_resolution_combo->on_change = [this](auto&, const GUI::ModelIndex& index) {
@@ -150,7 +150,7 @@ void DisplaySettingsWidget::create_frame()
         m_monitor_widget->update();
     };
 
-    m_color_input = static_cast<GUI::ColorInput&>(*m_root_widget->find_descendant_by_name("color_input"));
+    m_color_input = *m_root_widget->find_descendant_of_type_named<GUI::ColorInput>("color_input");
     m_color_input->set_color_has_alpha_channel(false);
     m_color_input->set_color_picker_title("Select color for desktop");
     m_color_input->on_change = [this] {
@@ -158,18 +158,18 @@ void DisplaySettingsWidget::create_frame()
         m_monitor_widget->update();
     };
 
-    auto& ok_button = static_cast<GUI::Button&>(*m_root_widget->find_descendant_by_name("ok_button"));
+    auto& ok_button = *m_root_widget->find_descendant_of_type_named<GUI::Button>("ok_button");
     ok_button.on_click = [this](auto) {
         send_settings_to_window_server();
         GUI::Application::the()->quit();
     };
 
-    auto& cancel_button = static_cast<GUI::Button&>(*m_root_widget->find_descendant_by_name("cancel_button"));
+    auto& cancel_button = *m_root_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button.on_click = [](auto) {
         GUI::Application::the()->quit();
     };
 
-    auto& apply_button = static_cast<GUI::Button&>(*m_root_widget->find_descendant_by_name("apply_button"));
+    auto& apply_button = *m_root_widget->find_descendant_of_type_named<GUI::Button>("apply_button");
     apply_button.on_click = [this](auto) {
         send_settings_to_window_server();
     };

--- a/Applications/DisplaySettings/MonitorWidget.h
+++ b/Applications/DisplaySettings/MonitorWidget.h
@@ -62,3 +62,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(DisplaySettings::MonitorWidget)

--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -330,23 +330,23 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
 
     widget.load_from_gml(file_manager_window_gml);
 
-    auto& main_toolbar = (GUI::ToolBar&)*widget.find_descendant_by_name("main_toolbar");
-    auto& location_toolbar = (GUI::ToolBar&)*widget.find_descendant_by_name("location_toolbar");
+    auto& main_toolbar = *widget.find_descendant_of_type_named<GUI::ToolBar>("main_toolbar");
+    auto& location_toolbar = *widget.find_descendant_of_type_named<GUI::ToolBar>("location_toolbar");
     location_toolbar.layout()->set_margins({ 6, 3, 6, 3 });
 
-    auto& location_textbox = (GUI::TextBox&)*widget.find_descendant_by_name("location_textbox");
+    auto& location_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("location_textbox");
 
-    auto& breadcrumb_toolbar = (GUI::ToolBar&)*widget.find_descendant_by_name("breadcrumb_toolbar");
+    auto& breadcrumb_toolbar = *widget.find_descendant_of_type_named<GUI::ToolBar>("breadcrumb_toolbar");
     breadcrumb_toolbar.layout()->set_margins({});
-    auto& breadcrumb_bar = (GUI::BreadcrumbBar&)*widget.find_descendant_by_name("breadcrumb_bar");
+    auto& breadcrumb_bar = *widget.find_descendant_of_type_named<GUI::BreadcrumbBar>("breadcrumb_bar");
 
     location_textbox.on_focusout = [&] {
         location_toolbar.set_visible(false);
         breadcrumb_toolbar.set_visible(true);
     };
 
-    auto& splitter = (GUI::HorizontalSplitter&)*widget.find_descendant_by_name("splitter");
-    auto& tree_view = (GUI::TreeView&)*widget.find_descendant_by_name("tree_view");
+    auto& splitter = *widget.find_descendant_of_type_named<GUI::HorizontalSplitter>("splitter");
+    auto& tree_view = *widget.find_descendant_of_type_named<GUI::TreeView>("tree_view");
 
     auto directories_model = GUI::FileSystemModel::create({}, GUI::FileSystemModel::Mode::DirectoriesOnly);
     tree_view.set_model(directories_model);
@@ -369,9 +369,9 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     // Open the root directory. FIXME: This is awkward.
     tree_view.toggle_index(directories_model->index(0, 0, {}));
 
-    auto& statusbar = (GUI::StatusBar&)*widget.find_descendant_by_name("statusbar");
+    auto& statusbar = *widget.find_descendant_of_type_named<GUI::StatusBar>("statusbar");
 
-    auto& progressbar = (GUI::ProgressBar&)*widget.find_descendant_by_name("progressbar");
+    auto& progressbar = *widget.find_descendant_of_type_named<GUI::ProgressBar>("progressbar");
     progressbar.set_format(GUI::ProgressBar::Format::ValueSlashMax);
     progressbar.set_frame_shape(Gfx::FrameShape::Panel);
     progressbar.set_frame_shadow(Gfx::FrameShadow::Sunken);

--- a/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -342,16 +342,16 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, const Vector<Position>& po
     auto& conditional_fmt_tab = tabs.add_tab<GUI::Widget>("Conditional Format");
     conditional_fmt_tab.load_from_gml(cond_fmt_gml);
     {
-        auto& view = static_cast<Spreadsheet::ConditionsView&>(*conditional_fmt_tab.find_descendant_by_name("conditions_view"));
+        auto& view = *conditional_fmt_tab.find_descendant_of_type_named<Spreadsheet::ConditionsView>("conditions_view");
         view.set_formats(&m_conditional_formats);
 
-        auto& add_button = static_cast<GUI::Button&>(*conditional_fmt_tab.find_descendant_by_name("add_button"));
+        auto& add_button = *conditional_fmt_tab.find_descendant_of_type_named<GUI::Button>("add_button");
         add_button.on_click = [&](auto) {
             view.add_format();
         };
 
         // FIXME: Disable this when empty.
-        auto& remove_button = static_cast<GUI::Button&>(*conditional_fmt_tab.find_descendant_by_name("remove_button"));
+        auto& remove_button = *conditional_fmt_tab.find_descendant_of_type_named<GUI::Button>("remove_button");
         remove_button.on_click = [&](auto) {
             view.remove_top();
         };
@@ -415,9 +415,9 @@ ConditionView::ConditionView(ConditionalFormat& fmt)
 {
     load_from_gml(cond_fmt_view_gml);
 
-    auto& fg_input = *static_cast<GUI::ColorInput*>(find_descendant_by_name("foreground_input"));
-    auto& bg_input = *static_cast<GUI::ColorInput*>(find_descendant_by_name("background_input"));
-    auto& formula_editor = *static_cast<GUI::TextEditor*>(find_descendant_by_name("formula_editor"));
+    auto& fg_input = *find_descendant_of_type_named<GUI::ColorInput>("foreground_input");
+    auto& bg_input = *find_descendant_of_type_named<GUI::ColorInput>("background_input");
+    auto& formula_editor = *find_descendant_of_type_named<GUI::TextEditor>("formula_editor");
 
     if (m_format.foreground_color.has_value())
         fg_input.set_color(m_format.foreground_color.value());

--- a/Applications/Spreadsheet/ConditionalFormatting.h
+++ b/Applications/Spreadsheet/ConditionalFormatting.h
@@ -71,3 +71,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(Spreadsheet::ConditionsView)

--- a/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Applications/Spreadsheet/SpreadsheetView.h
@@ -31,7 +31,6 @@
 #include <LibGUI/ModelEditingDelegate.h>
 #include <LibGUI/TableView.h>
 #include <LibGUI/Widget.h>
-#include <string.h>
 
 namespace Spreadsheet {
 
@@ -167,6 +166,4 @@ private:
 
 }
 
-AK_BEGIN_TYPE_TRAITS(Spreadsheet::SpreadsheetView)
-static bool is_type(const Core::Object& object) { return !strcmp(object.class_name(), "SpreadsheetView"); }
-AK_END_TYPE_TRAITS()
+DEFAULT_CORE_OBJECT_TRAITS(Spreadsheet::SpreadsheetView)

--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -188,9 +188,9 @@ static RefPtr<GUI::Window> create_settings_window(TerminalWidget& terminal)
     auto& settings = window->set_main_widget<GUI::Widget>();
     settings.load_from_gml(terminal_settings_window_gml);
 
-    auto& beep_bell_radio = static_cast<GUI::RadioButton&>(*settings.find_descendant_by_name("beep_bell_radio"));
-    auto& visual_bell_radio = static_cast<GUI::RadioButton&>(*settings.find_descendant_by_name("visual_bell_radio"));
-    auto& no_bell_radio = static_cast<GUI::RadioButton&>(*settings.find_descendant_by_name("no_bell_radio"));
+    auto& beep_bell_radio = *settings.find_descendant_of_type_named<GUI::RadioButton>("beep_bell_radio");
+    auto& visual_bell_radio = *settings.find_descendant_of_type_named<GUI::RadioButton>("visual_bell_radio");
+    auto& no_bell_radio = *settings.find_descendant_of_type_named<GUI::RadioButton>("no_bell_radio");
 
     switch (terminal.bell_mode()) {
     case TerminalWidget::BellMode::Visible:
@@ -214,13 +214,13 @@ static RefPtr<GUI::Window> create_settings_window(TerminalWidget& terminal)
         terminal.set_bell_mode(TerminalWidget::BellMode::Disabled);
     };
 
-    auto& slider = static_cast<GUI::OpacitySlider&>(*settings.find_descendant_by_name("background_opacity_slider"));
+    auto& slider = *settings.find_descendant_of_type_named<GUI::OpacitySlider>("background_opacity_slider");
     slider.on_change = [&terminal](int value) {
         terminal.set_opacity(value);
     };
     slider.set_value(terminal.opacity());
 
-    auto& history_size_spinbox = static_cast<GUI::SpinBox&>(*settings.find_descendant_by_name("history_size_spinbox"));
+    auto& history_size_spinbox = *settings.find_descendant_of_type_named<GUI::SpinBox>("history_size_spinbox");
     history_size_spinbox.set_value(terminal.max_history_size());
     history_size_spinbox.on_change = [&terminal](int value) {
         terminal.set_max_history_size(value);

--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -64,9 +64,9 @@ TextEditorWidget::TextEditorWidget()
 {
     load_from_gml(text_editor_window_gml);
 
-    auto& toolbar = static_cast<GUI::ToolBar&>(*find_descendant_by_name("toolbar"));
+    auto& toolbar = *find_descendant_of_type_named<GUI::ToolBar>("toolbar");
 
-    m_editor = static_cast<GUI::TextEditor&>(*find_descendant_by_name("editor"));
+    m_editor = *find_descendant_of_type_named<GUI::TextEditor>("editor");
     m_editor->set_ruler_visible(true);
     m_editor->set_automatic_indentation_enabled(true);
     m_editor->set_line_wrapping_enabled(true);
@@ -86,7 +86,7 @@ TextEditorWidget::TextEditorWidget()
             update_title();
     };
 
-    m_page_view = static_cast<Web::OutOfProcessWebView&>(*find_descendant_by_name("webview"));
+    m_page_view = *find_descendant_of_type_named<Web::OutOfProcessWebView>("webview");
     m_page_view->on_link_hover = [this](auto& url) {
         if (url.is_valid())
             m_statusbar->set_text(url.to_string());
@@ -103,11 +103,11 @@ TextEditorWidget::TextEditorWidget()
         }
     };
 
-    m_find_replace_widget = *find_descendant_by_name("find_replace_widget");
+    m_find_replace_widget = *find_descendant_of_type_named<GUI::Widget>("find_replace_widget");
 
-    m_find_widget = *find_descendant_by_name("find_widget");
+    m_find_widget = *find_descendant_of_type_named<GUI::Widget>("find_widget");
 
-    m_replace_widget = *find_descendant_by_name("replace_widget");
+    m_replace_widget = *find_descendant_of_type_named<GUI::Widget>("replace_widget");
 
     m_find_textbox = m_find_widget->add<GUI::TextBox>();
     m_replace_textbox = m_replace_widget->add<GUI::TextBox>();
@@ -235,10 +235,10 @@ TextEditorWidget::TextEditorWidget()
         }
     });
 
-    m_find_previous_button = static_cast<GUI::Button&>(*find_descendant_by_name("find_previous_button"));
+    m_find_previous_button = *find_descendant_of_type_named<GUI::Button>("find_previous_button");
     m_find_previous_button->set_action(*m_find_previous_action);
 
-    m_find_next_button = static_cast<GUI::Button&>(*find_descendant_by_name("find_next_button"));
+    m_find_next_button = *find_descendant_of_type_named<GUI::Button>("find_next_button");
     m_find_next_button->set_action(*m_find_next_action);
 
     m_find_textbox->on_return_pressed = [this] {
@@ -254,13 +254,13 @@ TextEditorWidget::TextEditorWidget()
         m_editor->set_focus(true);
     };
 
-    m_replace_previous_button = static_cast<GUI::Button&>(*find_descendant_by_name("replace_previous_button"));
+    m_replace_previous_button = *find_descendant_of_type_named<GUI::Button>("replace_previous_button");
     m_replace_previous_button->set_action(*m_replace_previous_action);
 
-    m_replace_next_button = static_cast<GUI::Button&>(*find_descendant_by_name("replace_next_button"));
+    m_replace_next_button = *find_descendant_of_type_named<GUI::Button>("replace_next_button");
     m_replace_next_button->set_action(*m_replace_next_action);
 
-    m_replace_all_button = static_cast<GUI::Button&>(*find_descendant_by_name("replace_all_button"));
+    m_replace_all_button = *find_descendant_of_type_named<GUI::Button>("replace_all_button");
     m_replace_all_button->set_action(*m_replace_all_action);
 
     m_replace_textbox->on_return_pressed = [this] {
@@ -289,7 +289,7 @@ TextEditorWidget::TextEditorWidget()
     m_editor->add_custom_context_menu_action(*m_find_next_action);
     m_editor->add_custom_context_menu_action(*m_find_previous_action);
 
-    m_statusbar = static_cast<GUI::StatusBar&>(*find_descendant_by_name("statusbar"));
+    m_statusbar = *find_descendant_of_type_named<GUI::StatusBar>("statusbar");
 
     m_editor->on_cursor_change = [this] { update_statusbar_cursor_position(); };
 

--- a/DevTools/HackStudio/EditorWrapper.h
+++ b/DevTools/HackStudio/EditorWrapper.h
@@ -59,6 +59,4 @@ private:
 
 }
 
-AK_BEGIN_TYPE_TRAITS(HackStudio::EditorWrapper)
-static bool is_type(const Core::Object& object) { return !strcmp(object.class_name(), "EditorWrapper"); }
-AK_END_TYPE_TRAITS()
+DEFAULT_CORE_OBJECT_TRAITS(HackStudio::EditorWrapper)

--- a/Libraries/LibCore/Object.h
+++ b/Libraries/LibCore/Object.h
@@ -36,6 +36,7 @@
 #include <AK/Weakable.h>
 #include <LibCore/Forward.h>
 #include <LibCore/Property.h>
+#include <string.h>
 
 namespace Core {
 
@@ -46,18 +47,24 @@ enum class TimerShouldFireWhenNotVisible {
     Yes
 };
 
-#define C_OBJECT(klass)                                                \
-public:                                                                \
-    virtual const char* class_name() const override { return #klass; } \
-    template<class... Args>                                            \
-    static inline NonnullRefPtr<klass> construct(Args&&... args)       \
-    {                                                                  \
-        return adopt(*new klass(forward<Args>(args)...));              \
+#define C_OBJECT(klass)                                                     \
+public:                                                                     \
+    virtual const char* class_name() const override { return class_name_; } \
+    static constexpr const char class_name_[] = #klass;                     \
+    template<class... Args>                                                 \
+    static inline NonnullRefPtr<klass> construct(Args&&... args)            \
+    {                                                                       \
+        return adopt(*new klass(forward<Args>(args)...));                   \
     }
 
 #define C_OBJECT_ABSTRACT(klass) \
 public:                          \
     virtual const char* class_name() const override { return #klass; }
+
+#define DEFAULT_CORE_OBJECT_TRAITS(klass)                                                                        \
+    AK_BEGIN_TYPE_TRAITS(klass)                                                                                  \
+    static bool is_type(const Core::Object& object) { return !strcmp(object.class_name(), klass::class_name_); } \
+    AK_END_TYPE_TRAITS()
 
 class Object
     : public RefCounted<Object>

--- a/Libraries/LibCore/Object.h
+++ b/Libraries/LibCore/Object.h
@@ -91,7 +91,13 @@ public:
     }
 
     template<typename T, typename Callback>
-    void for_each_child_of_type(Callback callback);
+    void for_each_child_of_type(Callback callback) requires IsBaseOf<Object, T>::value;
+
+    template<typename T>
+    T* find_child_of_type_named(const String&) requires IsBaseOf<Object, T>::value;
+
+    template<typename T>
+    T* find_descendant_of_type_named(const String&) requires IsBaseOf<Object, T>::value;
 
     bool is_ancestor_of(const Object&) const;
 
@@ -181,13 +187,43 @@ struct Formatter<Core::Object> : Formatter<StringView> {
 
 namespace Core {
 template<typename T, typename Callback>
-inline void Object::for_each_child_of_type(Callback callback)
+inline void Object::for_each_child_of_type(Callback callback) requires IsBaseOf<Object, T>::value
 {
     for_each_child([&](auto& child) {
         if (is<T>(child))
             return callback(downcast<T>(child));
         return IterationDecision::Continue;
     });
+}
+
+template<typename T>
+T* Object::find_child_of_type_named(const String& name) requires IsBaseOf<Object, T>::value
+{
+    T* found_child = nullptr;
+    for_each_child_of_type<T>([&](auto& child) {
+        if (child.name() == name) {
+            found_child = &child;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+
+    return found_child;
+}
+
+template<typename T>
+T* Object::find_descendant_of_type_named(const String& name) requires IsBaseOf<Object, T>::value
+{
+    if (this->name() == name && is<T>(this))
+        return downcast<T>(this);
+    T* found_child = nullptr;
+    for_each_child([&](auto& child) {
+        found_child = child.template find_descendant_of_type_named<T>(name);
+        if (found_child)
+            return IterationDecision::Break;
+        return IterationDecision::Continue;
+    });
+    return found_child;
 }
 
 const LogStream& operator<<(const LogStream&, const Object&);

--- a/Libraries/LibGUI/BreadcrumbBar.h
+++ b/Libraries/LibGUI/BreadcrumbBar.h
@@ -62,3 +62,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::BreadcrumbBar)

--- a/Libraries/LibGUI/Button.h
+++ b/Libraries/LibGUI/Button.h
@@ -72,3 +72,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::Button)

--- a/Libraries/LibGUI/ColorInput.h
+++ b/Libraries/LibGUI/ColorInput.h
@@ -67,3 +67,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::ColorInput)

--- a/Libraries/LibGUI/ComboBox.h
+++ b/Libraries/LibGUI/ComboBox.h
@@ -83,3 +83,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::ComboBox)

--- a/Libraries/LibGUI/FontPicker.cpp
+++ b/Libraries/LibGUI/FontPicker.cpp
@@ -98,19 +98,19 @@ FontPicker::FontPicker(Window* parent_window, const Gfx::Font* current_font, boo
     if (!widget.load_from_gml(font_picker_dialog_gml))
         ASSERT_NOT_REACHED();
 
-    m_family_list_view = static_cast<ListView&>(*widget.find_descendant_by_name("family_list_view"));
+    m_family_list_view = *widget.find_descendant_of_type_named<ListView>("family_list_view");
     m_family_list_view->set_model(ItemListModel<String>::create(m_families));
     m_family_list_view->horizontal_scrollbar().set_visible(false);
 
-    m_weight_list_view = static_cast<ListView&>(*widget.find_descendant_by_name("weight_list_view"));
+    m_weight_list_view = *widget.find_descendant_of_type_named<ListView>("weight_list_view");
     m_weight_list_view->set_model(adopt(*new FontWeightListModel(m_weights)));
     m_weight_list_view->horizontal_scrollbar().set_visible(false);
 
-    m_size_list_view = static_cast<ListView&>(*widget.find_descendant_by_name("size_list_view"));
+    m_size_list_view = *widget.find_descendant_of_type_named<ListView>("size_list_view");
     m_size_list_view->set_model(ItemListModel<int>::create(m_sizes));
     m_size_list_view->horizontal_scrollbar().set_visible(false);
 
-    m_sample_text_label = static_cast<Label&>(*widget.find_descendant_by_name("sample_text_label"));
+    m_sample_text_label = *widget.find_descendant_of_type_named<Label>("sample_text_label");
 
     m_families.clear();
     Gfx::FontDatabase::the().for_each_font([&](auto& font) {
@@ -167,12 +167,12 @@ FontPicker::FontPicker(Window* parent_window, const Gfx::Font* current_font, boo
         update_font();
     };
 
-    auto& ok_button = static_cast<Button&>(*widget.find_descendant_by_name("ok_button"));
+    auto& ok_button = *widget.find_descendant_of_type_named<GUI::Button>("ok_button");
     ok_button.on_click = [this](auto) {
         done(ExecOK);
     };
 
-    auto& cancel_button = static_cast<Button&>(*widget.find_descendant_by_name("cancel_button"));
+    auto& cancel_button = *widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button.on_click = [this](auto) {
         done(ExecCancel);
     };

--- a/Libraries/LibGUI/FontPicker.h
+++ b/Libraries/LibGUI/FontPicker.h
@@ -64,3 +64,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::FontPicker)

--- a/Libraries/LibGUI/ImageWidget.h
+++ b/Libraries/LibGUI/ImageWidget.h
@@ -68,3 +68,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::ImageWidget)

--- a/Libraries/LibGUI/Label.h
+++ b/Libraries/LibGUI/Label.h
@@ -72,3 +72,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::Label)

--- a/Libraries/LibGUI/LinkLabel.h
+++ b/Libraries/LibGUI/LinkLabel.h
@@ -54,3 +54,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::LinkLabel)

--- a/Libraries/LibGUI/ListView.h
+++ b/Libraries/LibGUI/ListView.h
@@ -84,3 +84,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::ListView)

--- a/Libraries/LibGUI/OpacitySlider.h
+++ b/Libraries/LibGUI/OpacitySlider.h
@@ -54,3 +54,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::OpacitySlider)

--- a/Libraries/LibGUI/ProgressBar.h
+++ b/Libraries/LibGUI/ProgressBar.h
@@ -69,3 +69,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::ProgressBar)

--- a/Libraries/LibGUI/SpinBox.h
+++ b/Libraries/LibGUI/SpinBox.h
@@ -65,3 +65,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::SpinBox)

--- a/Libraries/LibGUI/Splitter.h
+++ b/Libraries/LibGUI/Splitter.h
@@ -89,3 +89,7 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::Splitter)
+DEFAULT_CORE_OBJECT_TRAITS(GUI::HorizontalSplitter)
+DEFAULT_CORE_OBJECT_TRAITS(GUI::VerticalSplitter)

--- a/Libraries/LibGUI/StatusBar.h
+++ b/Libraries/LibGUI/StatusBar.h
@@ -52,3 +52,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::StatusBar)

--- a/Libraries/LibGUI/TabWidget.h
+++ b/Libraries/LibGUI/TabWidget.h
@@ -125,3 +125,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::TabWidget)

--- a/Libraries/LibGUI/TableView.h
+++ b/Libraries/LibGUI/TableView.h
@@ -64,3 +64,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::TableView)

--- a/Libraries/LibGUI/TextBox.h
+++ b/Libraries/LibGUI/TextBox.h
@@ -57,3 +57,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::TextBox);

--- a/Libraries/LibGUI/TextEditor.h
+++ b/Libraries/LibGUI/TextEditor.h
@@ -331,3 +331,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::TextEditor)

--- a/Libraries/LibGUI/ToolBar.h
+++ b/Libraries/LibGUI/ToolBar.h
@@ -64,3 +64,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::ToolBar);

--- a/Libraries/LibGUI/ToolBarContainer.h
+++ b/Libraries/LibGUI/ToolBarContainer.h
@@ -52,3 +52,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::ToolBarContainer)

--- a/Libraries/LibGUI/TreeView.h
+++ b/Libraries/LibGUI/TreeView.h
@@ -92,3 +92,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(GUI::TreeView)

--- a/Libraries/LibGUI/Widget.cpp
+++ b/Libraries/LibGUI/Widget.cpp
@@ -1001,33 +1001,6 @@ bool Widget::load_from_json(const JsonObject& json)
     return true;
 }
 
-Widget* Widget::find_child_by_name(const String& name)
-{
-    Widget* found_widget = nullptr;
-    for_each_child_widget([&](auto& child) {
-        if (child.name() == name) {
-            found_widget = &child;
-            return IterationDecision::Break;
-        }
-        return IterationDecision::Continue;
-    });
-    return found_widget;
-}
-
-Widget* Widget::find_descendant_by_name(const String& name)
-{
-    Widget* found_widget = nullptr;
-    if (this->name() == name)
-        return this;
-    for_each_child_widget([&](auto& child) {
-        found_widget = child.find_descendant_by_name(name);
-        if (found_widget)
-            return IterationDecision::Break;
-        return IterationDecision::Continue;
-    });
-    return found_widget;
-}
-
 bool Widget::has_focus_within() const
 {
     auto* window = this->window();

--- a/Libraries/LibGUI/Widget.h
+++ b/Libraries/LibGUI/Widget.h
@@ -305,9 +305,6 @@ public:
 
     bool load_from_gml(const StringView&);
 
-    Widget* find_child_by_name(const String&);
-    Widget* find_descendant_by_name(const String&);
-
 protected:
     Widget();
 

--- a/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Libraries/LibWeb/OutOfProcessWebView.h
@@ -94,3 +94,5 @@ private:
 };
 
 }
+
+DEFAULT_CORE_OBJECT_TRAITS(Web::OutOfProcessWebView)


### PR DESCRIPTION
This patch replaces `GUI::Widget::find_descendant_by_name` with `Core::Object::find_descendant_of_type_named<T>`.

It also leverages AK::Traits::is in order to do so. This requires a few changes:

- Add the finder helper to Core::Object
- Add a helper "default traits" macro to check if a Core::Object is-a T. Are we *sure* dynamic cast is bad? ;) 
- Spray the default trait macro all over the codebase
- ???
- Profit

I'm not sold on the name of the Core::Object helper, so lemme know if there's a better one. Everyone loves a good naming thread.