### PR TITLE
ProtocolServer: Use an empty Optional<IPC::File> to pass along "no fd"

### DIFF
--- a/Libraries/LibProtocol/Client.cpp
+++ b/Libraries/LibProtocol/Client.cpp
@@ -57,9 +57,9 @@ RefPtr<Download> Client::start_download(const String& method, const String& url,
 
     auto response = send_sync<Messages::ProtocolServer::StartDownload>(method, url, header_dictionary, ByteBuffer::copy(request_body));
     auto download_id = response->download_id();
-    auto response_fd = response->response_fd().fd();
-    if (download_id < 0 || response_fd < 0)
+    if (download_id < 0 || !response->response_fd().has_value())
         return nullptr;
+    auto response_fd = response->response_fd().value().fd();
     auto download = Download::create_from_id({}, *this, download_id);
     download->set_download_fd({}, response_fd);
     m_downloads.set(download_id, download);

--- a/Services/ProtocolServer/ClientConnection.cpp
+++ b/Services/ProtocolServer/ClientConnection.cpp
@@ -62,13 +62,13 @@ OwnPtr<Messages::ProtocolServer::StartDownloadResponse> ClientConnection::handle
 {
     URL url(message.url());
     if (!url.is_valid())
-        return make<Messages::ProtocolServer::StartDownloadResponse>(-1, -1);
+        return make<Messages::ProtocolServer::StartDownloadResponse>(-1, Optional<IPC::File> {});
     auto* protocol = Protocol::find_by_name(url.protocol());
     if (!protocol)
-        return make<Messages::ProtocolServer::StartDownloadResponse>(-1, -1);
+        return make<Messages::ProtocolServer::StartDownloadResponse>(-1, Optional<IPC::File> {});
     auto download = protocol->start_download(*this, message.method(), url, message.request_headers().entries(), message.request_body());
     if (!download)
-        return make<Messages::ProtocolServer::StartDownloadResponse>(-1, -1);
+        return make<Messages::ProtocolServer::StartDownloadResponse>(-1, Optional<IPC::File> {});
     auto id = download->id();
     auto fd = download->download_fd();
     m_downloads.set(id, move(download));

--- a/Services/ProtocolServer/ProtocolServer.ipc
+++ b/Services/ProtocolServer/ProtocolServer.ipc
@@ -7,7 +7,7 @@ endpoint ProtocolServer = 9
     IsSupportedProtocol(String protocol) => (bool supported)
 
     // Download API
-    StartDownload(String method, URL url, IPC::Dictionary request_headers, ByteBuffer request_body) => (i32 download_id, IPC::File response_fd)
+    StartDownload(String method, URL url, IPC::Dictionary request_headers, ByteBuffer request_body) => (i32 download_id, Optional<IPC::File> response_fd)
     StopDownload(i32 download_id) => (bool success)
     SetCertificate(i32 download_id, String certificate, String key) => (bool success)
 }


### PR DESCRIPTION
Passing `-1` wouldn't work, as these are passed to `sendfd()'.
Fixes #4706.

(it's really cool that `Optional<IPC::File>` actually works!)