### PR TITLE
ClipboardHistory: Fix crash when deleting without selection

### DIFF
--- a/MenuApplets/ClipboardHistory/main.cpp
+++ b/MenuApplets/ClipboardHistory/main.cpp
@@ -85,6 +85,7 @@ int main(int argc, char* argv[])
     auto entry_context_menu = GUI::Menu::construct();
     entry_context_menu->add_action(delete_action);
     table_view.on_context_menu_request = [&](const GUI::ModelIndex&, const GUI::ContextMenuEvent& event) {
+        delete_action->set_enabled(!table_view.selection().is_empty());
         entry_context_menu->popup(event.screen_position());
     };
 


### PR DESCRIPTION
* Fix by only activating the deletion action if we have a selection