### PR TITLE
Conway: Distribute leftover space equally on all sides

### DIFF
--- a/Games/Conway/Game.cpp
+++ b/Games/Conway/Game.cpp
@@ -103,12 +103,14 @@ void Game::paint_event(GUI::PaintEvent& event)
     painter.fill_rect(event.rect(), m_dead_color);
     auto game_rect = rect();
     auto cell_size = Gfx::IntSize(game_rect.width() / m_columns, game_rect.height() / m_rows);
+    auto x_margin = (game_rect.width() - (cell_size.width() * m_columns)) / 2;
+    auto y_margin = (game_rect.height() - (cell_size.height() * m_rows)) / 2;
 
     for (int y = 0; y < m_rows; y++) {
         for (int x = 0; x < m_columns; x++) {
             Gfx::IntRect rect {
-                x * cell_size.width(),
-                y * cell_size.height(),
+                x * cell_size.width() + x_margin,
+                y * cell_size.height() + y_margin,
                 cell_size.width(),
                 cell_size.height()
             };


### PR DESCRIPTION
This draws the universe centered rather than just putting all leftover space on the right and bottom sides until the window is large enough to be completely filled with cells again.

So, this:

![Peek 2021-01-01 23-14](https://user-images.githubusercontent.com/19366641/103447136-5da01400-4c87-11eb-901f-a0869982911f.gif)

Rather than:

![image](https://user-images.githubusercontent.com/19366641/103447129-52e57f00-4c87-11eb-840f-3335b92e1bfe.png)
