### PR TITLE
Kernel+LibELF: Use hex instead of decimal for stack offsets in back traces

### DIFF
--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -171,7 +171,7 @@ NEVER_INLINE static void dump_backtrace_impl(FlatPtr base_pointer, bool use_ksym
         if (symbol.symbol->address == g_highest_kernel_symbol_address && offset > 4096)
             dbgln("{:p}", symbol.address);
         else
-            dbgln("{:p}  {} +{}", symbol.address, demangle(symbol.symbol->name), offset);
+            dbgln("{:p}  {} +0x{:x}", symbol.address, demangle(symbol.symbol->name), offset);
     }
 }
 

--- a/Libraries/LibELF/Image.cpp
+++ b/Libraries/LibELF/Image.cpp
@@ -397,7 +397,7 @@ String Image::symbolicate(u32 address, u32* out_offset) const
                 *out_offset = address - symbol.address;
                 return demangled_name;
             }
-            return String::format("%s +%u", demangled_name.characters(), address - symbol.address);
+            return String::format("%s +0x%x", demangled_name.characters(), address - symbol.address);
         }
     }
     if (out_offset)


### PR DESCRIPTION
Hex is the de facto format for representing memory addresses, make backtraces conform to that convention.