### PR TITLE
LibGUI: CommonActions: Add make_help_action common action

### DIFF
--- a/Libraries/LibGUI/Action.cpp
+++ b/Libraries/LibGUI/Action.cpp
@@ -100,6 +100,11 @@ NonnullRefPtr<Action> make_quit_action(Function<void(Action&)> callback)
     return Action::create("Quit", { Mod_Alt, Key_F4 }, move(callback));
 }
 
+NonnullRefPtr<Action> make_help_action(Function<void(Action&)> callback, Core::Object* parent)
+{
+    return Action::create("Contents", { Mod_None, Key_F1 }, Gfx::Bitmap::load_from_file("/res/icons/16x16/app-help.png"), move(callback), parent);
+}
+
 NonnullRefPtr<Action> make_go_back_action(Function<void(Action&)> callback, Core::Object* parent)
 {
     return Action::create("Go back", { Mod_Alt, Key_Left }, Gfx::Bitmap::load_from_file("/res/icons/16x16/go-back.png"), move(callback), parent);

--- a/Libraries/LibGUI/Action.h
+++ b/Libraries/LibGUI/Action.h
@@ -55,6 +55,7 @@ NonnullRefPtr<Action> make_move_to_front_action(Function<void(Action&)>, Core::O
 NonnullRefPtr<Action> make_move_to_back_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_fullscreen_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_quit_action(Function<void(Action&)>);
+NonnullRefPtr<Action> make_help_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_go_back_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_go_forward_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_go_home_action(Function<void(Action&)> callback, Core::Object* parent = nullptr);


### PR DESCRIPTION
Although this action doesn't yet exist in any applications, this will likely be a common action sooner rather than later.

I've been messing around with allowing applications to open their associated man page in the `Help` application (or `TextEditor` as a lazy implementation).

Currently it looks something like this:

```diff
diff --git a/Applications/Help/main.cpp b/Applications/Help/main.cpp
index 2fa09bf31..8e452b2f0 100644
--- a/Applications/Help/main.cpp
+++ b/Applications/Help/main.cpp
@@ -281,11 +281,18 @@ int main(int argc, char* argv[])
     app->set_menubar(move(menubar));
 
     if (term_to_search_for_at_launch) {
-        left_tab_bar.set_active_widget(&search_view);
-        search_box.set_text(term_to_search_for_at_launch);
-        if (auto model = search_list_view.model()) {
-            auto& search_model = *static_cast<GUI::FilteringProxyModel*>(model);
-            search_model.set_filter_term(search_box.text());
+        URL page = URL::create_with_url_or_path(term_to_search_for_at_launch);
+        if (page.is_valid()) {
+            String path = page.path();
+            history.push(path);
+            open_page(path);
+        } else {
+            left_tab_bar.set_active_widget(&search_view);
+            search_box.set_text(term_to_search_for_at_launch);
+            if (auto model = search_list_view.model()) {
+                auto& search_model = *static_cast<GUI::FilteringProxyModel*>(model);
+                search_model.set_filter_term(search_box.text());
+            }
         }
     } else {
         String path = "/usr/share/man/man7/Help-index.md";
diff --git a/Applications/Terminal/main.cpp b/Applications/Terminal/main.cpp
index b48fa61d5..1ad55f832 100644
--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -25,7 +25,9 @@
  */
 
 #include <Applications/Terminal/TerminalSettingsWindowGML.h>
+#include <AK/URL.h>
 #include <LibCore/ArgsParser.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/AboutDialog.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
@@ -471,6 +473,10 @@ int main(int argc, char** argv)
     view_menu.add_action(pick_font_action);
 
     auto& help_menu = menubar->add_menu("Help");
+    help_menu.add_action(GUI::CommonActions::make_help_action([](auto&) {
+        //Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/Terminal.md"));
+        Desktop::Launcher::open(URL::create_with_url_or_path(("help://./usr/share/man/man1/Terminal.md")));
+    }));
     help_menu.add_action(GUI::Action::create("About", [&](auto&) {
         GUI::AboutDialog::show("Terminal", app_icon.bitmap_for_size(32), window);
     }));
diff --git a/Base/home/anon/.config/LaunchServer.ini b/Base/home/anon/.config/LaunchServer.ini
index 2947b9e77..5cb9616a1 100644
--- a/Base/home/anon/.config/LaunchServer.ini
+++ b/Base/home/anon/.config/LaunchServer.ini
@@ -19,3 +19,4 @@ gemini=/bin/Browser
 http=/bin/Browser
 https=/bin/Browser
 irc=/bin/IRCClient
+help=/bin/Help
```

Unfortunately, this does mean opening up every application to access the Launch service, which isn't ideal as it undermines `pledge` and `unveil`.
