### PR TITLE
LibC: Randomize the stack check cookie value on initialization

### DIFF
--- a/Libraries/LibC/crt0.cpp
+++ b/Libraries/LibC/crt0.cpp
@@ -33,6 +33,8 @@
 
 extern "C" {
 
+extern u32 __stack_chk_guard;
+
 int main(int, char**, char**);
 
 // Tell the compiler that this may be called from somewhere else.
@@ -40,6 +42,12 @@ int _start(int argc, char** argv, char** env);
 
 int _start(int argc, char** argv, char** env)
 {
+    u32 original_stack_chk = __stack_chk_guard;
+    arc4random_buf(&__stack_chk_guard, sizeof(__stack_chk_guard));
+
+    if (__stack_chk_guard == 0)
+        __stack_chk_guard = original_stack_chk;
+
     environ = env;
     __environ_is_malloced = false;
 
@@ -57,6 +65,11 @@ int _start(int argc, char** argv, char** env)
     int status = main(argc, argv, environ);
 
     exit(status);
+
+    // We should never get here, but if we ever do, make sure to
+    // restore the stack guard to the value we entered _start with.
+    // Then we won't trigger the stack canary check on the way out.
+    __stack_chk_guard = original_stack_chk;
 
     return 20150614;
 }

--- a/Libraries/LibC/crt0_shared.cpp
+++ b/Libraries/LibC/crt0_shared.cpp
@@ -33,6 +33,8 @@
 
 extern "C" {
 
+extern u32 __stack_chk_guard;
+
 int main(int, char**, char**);
 
 extern void __libc_init();
@@ -43,9 +45,20 @@ extern bool __environ_is_malloced;
 int _start(int argc, char** argv, char** env);
 int _start(int argc, char** argv, char** env)
 {
+    u32 original_stack_chk = __stack_chk_guard;
+    arc4random_buf(&__stack_chk_guard, sizeof(__stack_chk_guard));
+
+    if (__stack_chk_guard == 0)
+        __stack_chk_guard = original_stack_chk;
+
     _init();
 
     int status = main(argc, argv, env);
+
+    // Restore the stack guard to the value we entered _start with,
+    // so we don't trigger the stack canary check on the way out.
+    __stack_chk_guard = original_stack_chk;
+
     return status;
 }
 }


### PR DESCRIPTION
Previously we had a static stack check cookie value for LibC.
Now we randomize the cookie value on LibC initialization, this should
help make the stack check more difficult to attack (still possible just
a bigger pain). This should also help to catch more bugs.