### PR TITLE
TextEditor: Add basics of a Vim emulator

### DIFF
--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -48,6 +48,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/MenuBar.h>
 #include <LibGUI/MessageBox.h>
+#include <LibGUI/RegularEditingEngine.h>
 #include <LibGUI/ShellSyntaxHighlighter.h>
 #include <LibGUI/Splitter.h>
 #include <LibGUI/StatusBar.h>
@@ -55,6 +56,7 @@
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/ToolBar.h>
 #include <LibGUI/ToolBarContainer.h>
+#include <LibGUI/VimEditingEngine.h>
 #include <LibGfx/Font.h>
 #include <LibMarkdown/Document.h>
 #include <LibWeb/OutOfProcessWebView.h>
@@ -70,6 +72,7 @@ TextEditorWidget::TextEditorWidget()
     m_editor->set_ruler_visible(true);
     m_editor->set_automatic_indentation_enabled(true);
     m_editor->set_line_wrapping_enabled(true);
+    m_editor->set_editing_engine(make<GUI::RegularEditingEngine>());
 
     m_editor->on_change = [this] {
         update_preview();
@@ -272,6 +275,14 @@ TextEditorWidget::TextEditorWidget()
         m_editor->set_focus(true);
     };
 
+    m_vim_emulation_setting_action = GUI::Action::create_checkable("Vim emulation", { Mod_Ctrl | Mod_Shift | Mod_Alt, Key_V }, [&](auto& action) {
+        if (action.is_checked())
+            m_editor->set_editing_engine(make<GUI::VimEditingEngine>());
+        else
+            m_editor->set_editing_engine(make<GUI::RegularEditingEngine>());
+    });
+    m_vim_emulation_setting_action->set_checked(false);
+
     m_find_replace_action = GUI::Action::create("Find/Replace...", { Mod_Ctrl, Key_F }, Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"), [this](auto&) {
         m_find_replace_widget->set_visible(true);
         m_find_widget->set_visible(true);
@@ -380,6 +391,8 @@ TextEditorWidget::TextEditorWidget()
     edit_menu.add_action(m_editor->copy_action());
     edit_menu.add_action(m_editor->paste_action());
     edit_menu.add_action(m_editor->delete_action());
+    edit_menu.add_separator();
+    edit_menu.add_action(*m_vim_emulation_setting_action);
     edit_menu.add_separator();
     edit_menu.add_action(*m_find_replace_action);
     edit_menu.add_action(*m_find_next_action);

--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -134,7 +134,7 @@ TextEditorWidget::TextEditorWidget()
         }
     });
 
-    m_find_regex_action = GUI::Action::create("Find regex", { Mod_Ctrl, Key_R }, [&](auto&) {
+    m_find_regex_action = GUI::Action::create("Find regex", { Mod_Ctrl | Mod_Shift, Key_R }, [&](auto&) {
         m_find_regex_button->set_checked(!m_find_regex_button->is_checked());
         m_find_use_regex = m_find_regex_button->is_checked();
     });

--- a/Applications/TextEditor/TextEditorWidget.h
+++ b/Applications/TextEditor/TextEditorWidget.h
@@ -76,6 +76,7 @@ private:
     RefPtr<GUI::Action> m_save_as_action;
     RefPtr<GUI::Action> m_find_replace_action;
     RefPtr<GUI::Action> m_line_wrapping_setting_action;
+    RefPtr<GUI::Action> m_vim_emulation_setting_action;
 
     RefPtr<GUI::Action> m_find_next_action;
     RefPtr<GUI::Action> m_find_regex_action;

--- a/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/DevTools/HackStudio/HackStudioWidget.cpp
@@ -57,6 +57,7 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
+#include <LibGUI/EditingEngine.h>
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/InputBox.h>
 #include <LibGUI/ItemListModel.h>
@@ -64,6 +65,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/MenuBar.h>
 #include <LibGUI/MessageBox.h>
+#include <LibGUI/RegularEditingEngine.h>
 #include <LibGUI/Splitter.h>
 #include <LibGUI/StackWidget.h>
 #include <LibGUI/TabWidget.h>
@@ -73,6 +75,7 @@
 #include <LibGUI/ToolBar.h>
 #include <LibGUI/ToolBarContainer.h>
 #include <LibGUI/TreeView.h>
+#include <LibGUI/VimEditingEngine.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/FontDatabase.h>
@@ -235,6 +238,7 @@ void HackStudioWidget::open_file(const String& filename)
     current_editor().set_mode(GUI::TextEditor::Editable);
     current_editor().horizontal_scrollbar().set_value(new_project_file->horizontal_scroll_value());
     current_editor().vertical_scrollbar().set_value(new_project_file->vertical_scroll_value());
+    current_editor().set_editing_engine(make<GUI::RegularEditingEngine>());
 
     if (filename.ends_with(".frm")) {
         set_edit_mode(EditMode::Form);
@@ -855,6 +859,17 @@ void HackStudioWidget::create_edit_menubar(GUI::MenuBar& menubar)
     });
     line_wrapping_action->set_checked(current_editor().is_line_wrapping_enabled());
     edit_menu.add_action(line_wrapping_action);
+
+    edit_menu.add_separator();
+
+    auto vim_emulation_setting_action = GUI::Action::create_checkable("Vim emulation", { Mod_Ctrl | Mod_Shift | Mod_Alt, Key_V }, [this](auto& action) {
+        if (action.is_checked())
+            current_editor().set_editing_engine(make<GUI::VimEditingEngine>());
+        else
+            current_editor().set_editing_engine(make<GUI::RegularEditingEngine>());
+    });
+    vim_emulation_setting_action->set_checked(false);
+    edit_menu.add_action(vim_emulation_setting_action);
 }
 
 void HackStudioWidget::create_build_menubar(GUI::MenuBar& menubar)

--- a/Libraries/LibGUI/CMakeLists.txt
+++ b/Libraries/LibGUI/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOURCES
     Dialog.cpp
     DisplayLink.cpp
     DragOperation.cpp
+    EditingEngine.cpp
     EmojiInputDialog.cpp
     Event.cpp
     FileIconProvider.cpp
@@ -69,6 +70,7 @@ set(SOURCES
     ProcessChooser.cpp
     ProgressBar.cpp
     RadioButton.cpp
+    RegularEditingEngine.cpp
     ResizeCorner.cpp
     RunningProcessesModel.cpp
     ScrollBar.cpp
@@ -93,6 +95,7 @@ set(SOURCES
     TreeView.cpp
     UndoStack.cpp
     Variant.cpp
+    VimEditingEngine.cpp
     Widget.cpp
     Window.cpp
     WindowServerConnection.cpp

--- a/Libraries/LibGUI/EditingEngine.cpp
+++ b/Libraries/LibGUI/EditingEngine.cpp
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibGUI/EditingEngine.h>
+#include <LibGUI/Event.h>
+#include <LibGUI/TextEditor.h>
+
+namespace GUI {
+
+EditingEngine::~EditingEngine()
+{
+}
+
+void EditingEngine::attach(TextEditor& editor)
+{
+    ASSERT(!m_editor);
+    m_editor = editor;
+}
+
+void EditingEngine::detach()
+{
+    ASSERT(m_editor);
+    m_editor = nullptr;
+}
+
+bool EditingEngine::on_key(const KeyEvent& event)
+{
+    if (event.key() == KeyCode::Key_Left) {
+        if (!event.shift() && m_editor->selection()->is_valid()) {
+            m_editor->set_cursor(m_editor->selection()->normalized().start());
+            m_editor->selection()->clear();
+            m_editor->did_update_selection();
+            if (!event.ctrl()) {
+                m_editor->update();
+                return true;
+            }
+        }
+        if (event.ctrl()) {
+            move_to_previous_span(event);
+            if (event.shift() && m_editor->selection()->start().is_valid()) {
+                m_editor->selection()->set_end(m_editor->cursor());
+                m_editor->did_update_selection();
+            }
+            return true;
+        }
+        move_one_left(event);
+        if (event.shift() && m_editor->selection()->start().is_valid()) {
+            m_editor->selection()->set_end(m_editor->cursor());
+            m_editor->did_update_selection();
+        }
+        return true;
+    }
+
+    if (event.key() == KeyCode::Key_Right) {
+        if (!event.shift() && m_editor->selection()->is_valid()) {
+            m_editor->set_cursor(m_editor->selection()->normalized().end());
+            m_editor->selection()->clear();
+            m_editor->did_update_selection();
+            if (!event.ctrl()) {
+                m_editor->update();
+                return true;
+            }
+        }
+        if (event.ctrl()) {
+            move_to_next_span(event);
+            return true;
+        }
+        move_one_right(event);
+        if (event.shift() && m_editor->selection()->start().is_valid()) {
+            m_editor->selection()->set_end(m_editor->cursor());
+            m_editor->did_update_selection();
+        }
+        return true;
+    }
+
+    if (event.key() == KeyCode::Key_Up) {
+        move_one_up(event);
+        if (event.shift() && m_editor->selection()->start().is_valid()) {
+            m_editor->selection()->set_end(m_editor->cursor());
+            m_editor->did_update_selection();
+        }
+        return true;
+    }
+
+    if (event.key() == KeyCode::Key_Down) {
+        move_one_down(event);
+        if (event.shift() && m_editor->selection()->start().is_valid()) {
+            m_editor->selection()->set_end(m_editor->cursor());
+            m_editor->did_update_selection();
+        }
+        return true;
+    }
+
+    if (event.key() == KeyCode::Key_Home) {
+        if (event.ctrl()) {
+            m_editor->toggle_selection_if_needed_for_event(event.shift());
+            move_to_first_line();
+            if (event.shift() && m_editor->selection()->start().is_valid()) {
+                m_editor->selection()->set_end(m_editor->cursor());
+                m_editor->did_update_selection();
+            }
+        } else {
+            move_to_line_beginning(event);
+            if (event.shift() && m_editor->selection()->start().is_valid()) {
+                m_editor->selection()->set_end(m_editor->cursor());
+                m_editor->did_update_selection();
+            }
+        }
+        return true;
+    }
+
+    if (event.key() == KeyCode::Key_End) {
+        if (event.ctrl()) {
+            m_editor->toggle_selection_if_needed_for_event(event.shift());
+            move_to_last_line();
+            if (event.shift() && m_editor->selection()->start().is_valid()) {
+                m_editor->selection()->set_end(m_editor->cursor());
+                m_editor->did_update_selection();
+            }
+        } else {
+            move_to_line_end(event);
+            if (event.shift() && m_editor->selection()->start().is_valid()) {
+                m_editor->selection()->set_end(m_editor->cursor());
+                m_editor->did_update_selection();
+            }
+        }
+        return true;
+    }
+
+    if (event.key() == KeyCode::Key_PageUp) {
+        move_page_up(event);
+        if (event.shift() && m_editor->selection()->start().is_valid()) {
+            m_editor->selection()->set_end(m_editor->cursor());
+            m_editor->did_update_selection();
+        }
+        return true;
+    }
+
+    if (event.key() == KeyCode::Key_PageDown) {
+        move_page_down(event);
+        if (event.shift() && m_editor->selection()->start().is_valid()) {
+            m_editor->selection()->set_end(m_editor->cursor());
+            m_editor->did_update_selection();
+        }
+        return true;
+    }
+
+    return false;
+}
+
+void EditingEngine::move_one_left(const KeyEvent& event)
+{
+    if (m_editor->cursor().column() > 0) {
+        int new_column = m_editor->cursor().column() - 1;
+        m_editor->toggle_selection_if_needed_for_event(event.shift());
+        m_editor->set_cursor(m_editor->cursor().line(), new_column);
+    } else if (m_editor->cursor().line() > 0) {
+        int new_line = m_editor->cursor().line() - 1;
+        int new_column = m_editor->lines()[new_line].length();
+        m_editor->toggle_selection_if_needed_for_event(event.shift());
+        m_editor->set_cursor(new_line, new_column);
+    }
+}
+
+void EditingEngine::move_one_right(const KeyEvent& event)
+{
+    int new_line = m_editor->cursor().line();
+    int new_column = m_editor->cursor().column();
+    if (m_editor->cursor().column() < m_editor->current_line().length()) {
+        new_line = m_editor->cursor().line();
+        new_column = m_editor->cursor().column() + 1;
+    } else if (m_editor->cursor().line() != m_editor->line_count() - 1) {
+        new_line = m_editor->cursor().line() + 1;
+        new_column = 0;
+    }
+    m_editor->toggle_selection_if_needed_for_event(event.shift());
+    m_editor->set_cursor(new_line, new_column);
+}
+
+void EditingEngine::move_to_previous_span(const KeyEvent& event)
+{
+    TextPosition new_cursor;
+    if (m_editor->document().has_spans()) {
+        auto span = m_editor->document().first_non_skippable_span_before(m_editor->cursor());
+        if (span.has_value()) {
+            new_cursor = span.value().range.start();
+        } else {
+            // No remaining spans, just use word break calculation
+            new_cursor = m_editor->document().first_word_break_before(m_editor->cursor(), true);
+        }
+    } else {
+        new_cursor = m_editor->document().first_word_break_before(m_editor->cursor(), true);
+    }
+    m_editor->toggle_selection_if_needed_for_event(event.shift());
+    m_editor->set_cursor(new_cursor);
+}
+
+void EditingEngine::move_to_next_span(const KeyEvent& event)
+{
+    TextPosition new_cursor;
+    if (m_editor->document().has_spans()) {
+        auto span = m_editor->document().first_non_skippable_span_after(m_editor->cursor());
+        if (span.has_value()) {
+            new_cursor = span.value().range.start();
+        } else {
+            // No remaining spans, just use word break calculation
+            new_cursor = m_editor->document().first_word_break_after(m_editor->cursor());
+        }
+    } else {
+        new_cursor = m_editor->document().first_word_break_after(m_editor->cursor());
+    }
+    m_editor->toggle_selection_if_needed_for_event(event.shift());
+    m_editor->set_cursor(new_cursor);
+    if (event.shift() && m_editor->selection()->start().is_valid()) {
+        m_editor->selection()->set_end(m_editor->cursor());
+        m_editor->did_update_selection();
+    }
+}
+
+void EditingEngine::move_to_line_beginning(const KeyEvent& event)
+{
+    TextPosition new_cursor;
+    m_editor->toggle_selection_if_needed_for_event(event.shift());
+    if (m_editor->is_line_wrapping_enabled()) {
+        // FIXME: Replicate the first_nonspace_column behavior in wrapping mode.
+        auto home_position = m_editor->cursor_content_rect().location().translated(-m_editor->width(), 0);
+        new_cursor = m_editor->text_position_at_content_position(home_position);
+    } else {
+        size_t first_nonspace_column = m_editor->current_line().first_non_whitespace_column();
+        if (m_editor->cursor().column() == first_nonspace_column) {
+            new_cursor = { m_editor->cursor().line(), 0 };
+        } else {
+            new_cursor = { m_editor->cursor().line(), first_nonspace_column };
+        }
+    }
+    m_editor->set_cursor(new_cursor);
+}
+
+void EditingEngine::move_to_line_end(const KeyEvent& event)
+{
+    TextPosition new_cursor;
+    if (m_editor->is_line_wrapping_enabled()) {
+        auto end_position = m_editor->cursor_content_rect().location().translated(m_editor->width(), 0);
+        new_cursor = m_editor->text_position_at_content_position(end_position);
+    } else {
+        new_cursor = { m_editor->cursor().line(), m_editor->current_line().length() };
+    }
+    m_editor->toggle_selection_if_needed_for_event(event.shift());
+    m_editor->set_cursor(new_cursor);
+}
+
+void EditingEngine::move_one_up(const KeyEvent& event)
+{
+    if (m_editor->cursor().line() > 0 || m_editor->is_line_wrapping_enabled()) {
+        if (event.ctrl() && event.shift()) {
+            move_selected_lines_up();
+            return;
+        }
+        TextPosition new_cursor;
+        if (m_editor->is_line_wrapping_enabled()) {
+            auto position_above = m_editor->cursor_content_rect().location().translated(0, -m_editor->line_height());
+            new_cursor = m_editor->text_position_at_content_position(position_above);
+        } else {
+            size_t new_line = m_editor->cursor().line() - 1;
+            size_t new_column = min(m_editor->cursor().column(), m_editor->line(new_line).length());
+            new_cursor = { new_line, new_column };
+        }
+        m_editor->toggle_selection_if_needed_for_event(event.shift());
+        m_editor->set_cursor(new_cursor);
+    }
+};
+
+void EditingEngine::move_one_down(const KeyEvent& event)
+{
+    if (m_editor->cursor().line() < (m_editor->line_count() - 1) || m_editor->is_line_wrapping_enabled()) {
+        if (event.ctrl() && event.shift()) {
+            move_selected_lines_down();
+            return;
+        }
+        TextPosition new_cursor;
+        if (m_editor->is_line_wrapping_enabled()) {
+            new_cursor = m_editor->text_position_at_content_position(m_editor->cursor_content_rect().location().translated(0, m_editor->line_height()));
+            auto position_below = m_editor->cursor_content_rect().location().translated(0, m_editor->line_height());
+            new_cursor = m_editor->text_position_at_content_position(position_below);
+        } else {
+            size_t new_line = m_editor->cursor().line() + 1;
+            size_t new_column = min(m_editor->cursor().column(), m_editor->line(new_line).length());
+            new_cursor = { new_line, new_column };
+        }
+        m_editor->toggle_selection_if_needed_for_event(event.shift());
+        m_editor->set_cursor(new_cursor);
+    }
+};
+
+void EditingEngine::move_up(const KeyEvent& event, double page_height_factor)
+{
+    if (m_editor->cursor().line() > 0 || m_editor->is_line_wrapping_enabled()) {
+        int pixels = (int)(m_editor->visible_content_rect().height() * page_height_factor);
+
+        TextPosition new_cursor;
+        if (m_editor->is_line_wrapping_enabled()) {
+            auto position_above = m_editor->cursor_content_rect().location().translated(0, -pixels);
+            new_cursor = m_editor->text_position_at_content_position(position_above);
+        } else {
+            size_t page_step = (size_t)pixels / (size_t)m_editor->line_height();
+            size_t new_line = m_editor->cursor().line() < page_step ? 0 : m_editor->cursor().line() - page_step;
+            size_t new_column = min(m_editor->cursor().column(), m_editor->line(new_line).length());
+            new_cursor = { new_line, new_column };
+        }
+        m_editor->toggle_selection_if_needed_for_event(event.shift());
+        m_editor->set_cursor(new_cursor);
+    }
+};
+
+void EditingEngine::move_down(const KeyEvent& event, double page_height_factor)
+{
+    if (m_editor->cursor().line() < (m_editor->line_count() - 1) || m_editor->is_line_wrapping_enabled()) {
+        int pixels = (int)(m_editor->visible_content_rect().height() * page_height_factor);
+        TextPosition new_cursor;
+        if (m_editor->is_line_wrapping_enabled()) {
+            auto position_below = m_editor->cursor_content_rect().location().translated(0, pixels);
+            new_cursor = m_editor->text_position_at_content_position(position_below);
+        } else {
+            size_t new_line = min(m_editor->line_count() - 1, m_editor->cursor().line() + pixels / m_editor->line_height());
+            size_t new_column = min(m_editor->cursor().column(), m_editor->lines()[new_line].length());
+            new_cursor = { new_line, new_column };
+        }
+        m_editor->toggle_selection_if_needed_for_event(event.shift());
+        m_editor->set_cursor(new_cursor);
+    };
+}
+
+void EditingEngine::move_page_up(const KeyEvent& event)
+{
+    move_up(event, 1);
+};
+
+void EditingEngine::move_page_down(const KeyEvent& event)
+{
+    move_down(event, 1);
+};
+
+void EditingEngine::move_to_first_line()
+{
+    m_editor->set_cursor(0, 0);
+};
+
+void EditingEngine::move_to_last_line()
+{
+    m_editor->set_cursor(m_editor->line_count() - 1, m_editor->lines()[m_editor->line_count() - 1].length());
+};
+
+void EditingEngine::get_selection_line_boundaries(size_t& first_line, size_t& last_line)
+{
+    auto selection = m_editor->normalized_selection();
+    if (!selection.is_valid()) {
+        first_line = m_editor->cursor().line();
+        last_line = m_editor->cursor().line();
+        return;
+    }
+    first_line = selection.start().line();
+    last_line = selection.end().line();
+    if (first_line != last_line && selection.end().column() == 0)
+        last_line -= 1;
+}
+
+void EditingEngine::move_selected_lines_up()
+{
+    if (!m_editor->is_editable())
+        return;
+    size_t first_line;
+    size_t last_line;
+    get_selection_line_boundaries(first_line, last_line);
+
+    if (first_line == 0)
+        return;
+
+    auto& lines = m_editor->document().lines();
+    lines.insert((int)last_line, lines.take((int)first_line - 1));
+    m_editor->set_cursor({ first_line - 1, 0 });
+
+    if (m_editor->has_selection()) {
+        m_editor->selection()->set_start({ first_line - 1, 0 });
+        m_editor->selection()->set_end({ last_line - 1, m_editor->line(last_line - 1).length() });
+    }
+
+    m_editor->did_change();
+    m_editor->update();
+}
+
+void EditingEngine::move_selected_lines_down()
+{
+    if (!m_editor->is_editable())
+        return;
+    size_t first_line;
+    size_t last_line;
+    get_selection_line_boundaries(first_line, last_line);
+
+    auto& lines = m_editor->document().lines();
+    ASSERT(lines.size() != 0);
+    if (last_line >= lines.size() - 1)
+        return;
+
+    lines.insert((int)first_line, lines.take((int)last_line + 1));
+    m_editor->set_cursor({ first_line + 1, 0 });
+
+    if (m_editor->has_selection()) {
+        m_editor->selection()->set_start({ first_line + 1, 0 });
+        m_editor->selection()->set_end({ last_line + 1, m_editor->line(last_line + 1).length() });
+    }
+
+    m_editor->did_change();
+    m_editor->update();
+}
+
+void EditingEngine::delete_char()
+{
+    if (!m_editor->is_editable())
+        return;
+    m_editor->do_delete();
+};
+
+void EditingEngine::delete_line()
+{
+    if (!m_editor->is_editable())
+        return;
+    m_editor->delete_current_line();
+};
+
+}

--- a/Libraries/LibGUI/EditingEngine.h
+++ b/Libraries/LibGUI/EditingEngine.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <LibGUI/Event.h>
+#include <LibGUI/TextDocument.h>
+
+namespace GUI {
+
+enum CursorWidth {
+    NARROW,
+    WIDE
+};
+
+class EditingEngine {
+    AK_MAKE_NONCOPYABLE(EditingEngine);
+    AK_MAKE_NONMOVABLE(EditingEngine);
+
+public:
+    virtual ~EditingEngine();
+
+    virtual CursorWidth cursor_width() const { return NARROW; }
+
+    void attach(TextEditor& editor);
+    void detach();
+
+    virtual bool on_key(const KeyEvent& event);
+
+protected:
+    EditingEngine() { }
+
+    WeakPtr<TextEditor> m_editor;
+
+    void move_one_left(const KeyEvent& event);
+    void move_one_right(const KeyEvent& event);
+    void move_one_up(const KeyEvent& event);
+    void move_one_down(const KeyEvent& event);
+    void move_to_previous_span(const KeyEvent& event);
+    void move_to_next_span(const KeyEvent& event);
+    void move_to_line_beginning(const KeyEvent& event);
+    void move_to_line_end(const KeyEvent& event);
+    void move_page_up(const KeyEvent& event);
+    void move_page_down(const KeyEvent& event);
+    void move_to_first_line();
+    void move_to_last_line();
+
+    void move_up(const KeyEvent& event, double page_height_factor);
+    void move_down(const KeyEvent& event, double page_height_factor);
+
+    void get_selection_line_boundaries(size_t& first_line, size_t& last_line);
+
+    void delete_line();
+    void delete_char();
+
+private:
+    void move_selected_lines_up();
+    void move_selected_lines_down();
+};
+
+}

--- a/Libraries/LibGUI/Forward.h
+++ b/Libraries/LibGUI/Forward.h
@@ -42,6 +42,7 @@ class CheckBox;
 class Command;
 class DragEvent;
 class DropEvent;
+class EditingEngine;
 class FileSystemModel;
 class Frame;
 class GroupBox;

--- a/Libraries/LibGUI/RegularEditingEngine.cpp
+++ b/Libraries/LibGUI/RegularEditingEngine.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/QuickSort.h>
+#include <LibGUI/RegularEditingEngine.h>
+#include <LibGUI/TextEditor.h>
+
+namespace GUI {
+
+CursorWidth RegularEditingEngine::cursor_width() const
+{
+    return CursorWidth::NARROW;
+}
+
+bool RegularEditingEngine::on_key(const KeyEvent& event)
+{
+    if (EditingEngine::on_key(event))
+        return true;
+
+    if (event.key() == KeyCode::Key_Escape) {
+        if (m_editor->on_escape_pressed)
+            m_editor->on_escape_pressed();
+        return true;
+    }
+
+    if (event.alt() && event.shift() && event.key() == KeyCode::Key_S) {
+        sort_selected_lines();
+        return true;
+    }
+
+    return false;
+}
+
+static int strcmp_utf32(const u32* s1, const u32* s2, size_t n)
+{
+    while (n-- > 0) {
+        if (*s1++ != *s2++)
+            return s1[-1] < s2[-1] ? -1 : 1;
+    }
+    return 0;
+}
+
+void RegularEditingEngine::sort_selected_lines()
+{
+    if (!m_editor->is_editable())
+        return;
+
+    if (!m_editor->has_selection())
+        return;
+
+    size_t first_line;
+    size_t last_line;
+    get_selection_line_boundaries(first_line, last_line);
+
+    auto& lines = m_editor->document().lines();
+
+    auto start = lines.begin() + (int)first_line;
+    auto end = lines.begin() + (int)last_line + 1;
+
+    quick_sort(start, end, [](auto& a, auto& b) {
+        return strcmp_utf32(a.code_points(), b.code_points(), min(a.length(), b.length())) < 0;
+    });
+
+    m_editor->did_change();
+    m_editor->update();
+}
+
+}

--- a/Libraries/LibGUI/RegularEditingEngine.h
+++ b/Libraries/LibGUI/RegularEditingEngine.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibGUI/EditingEngine.h>
+
+namespace GUI {
+
+class RegularEditingEngine final : public EditingEngine {
+
+public:
+    virtual CursorWidth cursor_width() const override;
+
+    virtual bool on_key(const KeyEvent& event) override;
+
+private:
+    void sort_selected_lines();
+};
+
+}

--- a/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Libraries/LibGUI/VimEditingEngine.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibGUI/Event.h>
+#include <LibGUI/TextEditor.h>
+#include <LibGUI/VimEditingEngine.h>
+
+namespace GUI {
+
+CursorWidth VimEditingEngine::cursor_width() const
+{
+    return m_vim_mode == VimMode::Normal ? CursorWidth::WIDE : CursorWidth::NARROW;
+}
+
+bool VimEditingEngine::on_key(const KeyEvent& event)
+{
+    if (EditingEngine::on_key(event))
+        return true;
+
+    switch (m_vim_mode) {
+    case (VimMode::Insert):
+        return on_key_in_insert_mode(event);
+    case (VimMode::Normal):
+        return on_key_in_normal_mode(event);
+    default:
+        ASSERT_NOT_REACHED();
+    }
+
+    return false;
+}
+
+bool VimEditingEngine::on_key_in_insert_mode(const KeyEvent& event)
+{
+    if (event.key() == KeyCode::Key_Escape || (event.ctrl() && event.key() == KeyCode::Key_LeftBracket) || (event.ctrl() && event.key() == KeyCode::Key_C)) {
+        switch_to_normal_mode();
+        return true;
+    }
+    return false;
+}
+
+bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
+{
+    if (m_previous_key == KeyCode::Key_D) {
+        if (event.key() == KeyCode::Key_D) {
+            delete_line();
+        }
+        m_previous_key = {};
+    } else if (m_previous_key == KeyCode::Key_G) {
+        if (event.key() == KeyCode::Key_G) {
+            move_to_first_line();
+        }
+        m_previous_key = {};
+    } else {
+        // Handle first any key codes that are to be applied regardless of modifiers.
+        switch (event.key()) {
+        case (KeyCode::Key_Dollar):
+            move_to_line_end(event);
+            break;
+        case (KeyCode::Key_Escape):
+            if (m_editor->on_escape_pressed)
+                m_editor->on_escape_pressed();
+            break;
+        default:
+            break;
+        }
+
+        // SHIFT is pressed.
+        if (event.shift() && !event.ctrl() && !event.alt()) {
+            switch (event.key()) {
+            case (KeyCode::Key_A):
+                move_to_line_end(event);
+                switch_to_insert_mode();
+                break;
+            case (KeyCode::Key_G):
+                move_to_last_line();
+                break;
+            case (KeyCode::Key_I):
+                move_to_line_beginning(event);
+                switch_to_insert_mode();
+                break;
+            case (KeyCode::Key_O):
+                move_to_line_beginning(event);
+                m_editor->add_code_point(0x0A);
+                move_one_up(event);
+                switch_to_insert_mode();
+                break;
+            default:
+                break;
+            }
+        }
+
+        // CTRL is pressed.
+        if (event.ctrl() && !event.shift() && !event.alt()) {
+            switch (event.key()) {
+            case (KeyCode::Key_D):
+                move_half_page_down(event);
+                break;
+            case (KeyCode::Key_R):
+                m_editor->redo();
+                break;
+            case (KeyCode::Key_U):
+                move_half_page_up(event);
+                break;
+            default:
+                break;
+            }
+        }
+
+        // No modifier is pressed.
+        if (!event.ctrl() && !event.shift() && !event.alt()) {
+            switch (event.key()) {
+            case (KeyCode::Key_A):
+                move_one_right(event);
+                switch_to_insert_mode();
+                break;
+            case (KeyCode::Key_B):
+                move_to_previous_span(event); // FIXME: This probably isn't 100% correct.
+                break;
+            case (KeyCode::Key_Backspace):
+            case (KeyCode::Key_H):
+            case (KeyCode::Key_Left):
+                move_one_left(event);
+                break;
+            case (KeyCode::Key_D):
+            case (KeyCode::Key_G):
+                m_previous_key = event.key();
+                break;
+            case (KeyCode::Key_Down):
+            case (KeyCode::Key_J):
+                move_one_down(event);
+                break;
+            case (KeyCode::Key_I):
+                switch_to_insert_mode();
+                break;
+            case (KeyCode::Key_K):
+            case (KeyCode::Key_Up):
+                move_one_up(event);
+                break;
+            case (KeyCode::Key_L):
+            case (KeyCode::Key_Right):
+                move_one_right(event);
+                break;
+            case (KeyCode::Key_O):
+                move_to_line_end(event);
+                m_editor->add_code_point(0x0A);
+                switch_to_insert_mode();
+                break;
+            case (KeyCode::Key_U):
+                m_editor->undo();
+                break;
+            case (KeyCode::Key_W):
+                move_to_next_span(event); // FIXME: This probably isn't 100% correct.
+                break;
+            case (KeyCode::Key_X):
+                delete_char();
+                break;
+            case (KeyCode::Key_0):
+                move_to_line_beginning(event);
+                break;
+            default:
+                break;
+            }
+        }
+    }
+    return true;
+}
+
+void VimEditingEngine::switch_to_normal_mode()
+{
+    m_vim_mode = VimMode::Normal;
+    m_editor->reset_cursor_blink();
+};
+
+void VimEditingEngine::switch_to_insert_mode()
+{
+    m_vim_mode = VimMode::Insert;
+    m_editor->reset_cursor_blink();
+};
+
+void VimEditingEngine::move_half_page_up(const KeyEvent& event)
+{
+    move_up(event, 0.5);
+};
+
+void VimEditingEngine::move_half_page_down(const KeyEvent& event)
+{
+    move_down(event, 0.5);
+};
+
+}

--- a/Libraries/LibGUI/VimEditingEngine.h
+++ b/Libraries/LibGUI/VimEditingEngine.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <LibGUI/EditingEngine.h>
+
+namespace GUI {
+
+class VimEditingEngine final : public EditingEngine {
+
+public:
+    virtual CursorWidth cursor_width() const override;
+
+    virtual bool on_key(const KeyEvent& event) override;
+
+private:
+    enum VimMode {
+        Normal,
+        Insert,
+    };
+
+    VimMode m_vim_mode { VimMode::Normal };
+
+    KeyCode m_previous_key {};
+    void switch_to_normal_mode();
+    void switch_to_insert_mode();
+    void move_half_page_up(const KeyEvent& event);
+    void move_half_page_down(const KeyEvent& event);
+
+    bool on_key_in_insert_mode(const KeyEvent& event);
+    bool on_key_in_normal_mode(const KeyEvent& event);
+};
+
+}


### PR DESCRIPTION
This PR adds some basics of Vim emulation to Text Editor and Hack Studio. 

Enable it in the upper menu or via shortcut `CTRL+SHIFT+ALT+V`.