### PR TITLE
Kernel: If a VMObject is shared, broadcast page remappings

### DIFF
--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -666,6 +666,7 @@ struct ProcessorMessage {
             void (*free)(void*);
         } callback_with_data;
         struct {
+            const PageDirectory* page_directory;
             u8* ptr;
             size_t page_count;
         } flush_tlb;
@@ -787,7 +788,7 @@ public:
     }
 
     static void flush_tlb_local(VirtualAddress vaddr, size_t page_count);
-    static void flush_tlb(VirtualAddress vaddr, size_t page_count);
+    static void flush_tlb(const PageDirectory*, VirtualAddress, size_t);
 
     Descriptor& get_gdt_entry(u16 selector);
     void flush_gdt();
@@ -991,7 +992,7 @@ public:
     }
     static void smp_unicast(u32 cpu, void (*callback)(), bool async);
     static void smp_unicast(u32 cpu, void (*callback)(void*), void* data, void (*free_data)(void*), bool async);
-    static void smp_broadcast_flush_tlb(VirtualAddress vaddr, size_t page_count);
+    static void smp_broadcast_flush_tlb(const PageDirectory*, VirtualAddress, size_t);
 
     template<typename Callback>
     static void deferred_call_queue(Callback callback)

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -141,7 +141,7 @@ void* Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> user_params)
     }
 
     if (map_anonymous) {
-        auto strategy = map_shared ? AllocationStrategy::AllocateNow : (map_noreserve ? AllocationStrategy::None : AllocationStrategy::Reserve);
+        auto strategy = map_noreserve ? AllocationStrategy::None : AllocationStrategy::Reserve;
         region = allocate_region(range.value(), !name.is_null() ? name : "mmap", prot, strategy);
         if (!region && (!map_fixed && addr != 0))
             region = allocate_region(allocate_range({}, size), !name.is_null() ? name : "mmap", prot, strategy);

--- a/Kernel/Syscalls/shbuf.cpp
+++ b/Kernel/Syscalls/shbuf.cpp
@@ -52,7 +52,7 @@ int Process::sys$shbuf_create(int size, void** buffer)
         return -EINVAL;
     size = PAGE_ROUND_UP(size);
 
-    auto vmobject = AnonymousVMObject::create_with_size(size, AllocationStrategy::AllocateNow);
+    auto vmobject = AnonymousVMObject::create_with_size(size, AllocationStrategy::Reserve);
     if (!vmobject)
         return -ENOMEM;
 

--- a/Kernel/VM/AnonymousVMObject.cpp
+++ b/Kernel/VM/AnonymousVMObject.cpp
@@ -215,7 +215,7 @@ int AnonymousVMObject::purge_impl()
                     } else {
                         klog() << "Purged " << purged_in_range << " pages from region " << region.name() << " (no ownership) at " << region.vaddr_from_page_index(range.base) << " - " << region.vaddr_from_page_index(range.base + range.count);
                     }
-                    region.remap_page_range(range.base, range.count);
+                    region.remap_vmobject_page_range(range.base, range.count);
                 }
             });
         }

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -697,12 +697,12 @@ void MemoryManager::flush_tlb_local(VirtualAddress vaddr, size_t page_count)
     Processor::flush_tlb_local(vaddr, page_count);
 }
 
-void MemoryManager::flush_tlb(VirtualAddress vaddr, size_t page_count)
+void MemoryManager::flush_tlb(const PageDirectory* page_directory, VirtualAddress vaddr, size_t page_count)
 {
 #ifdef MM_DEBUG
     dbg() << "MM: Flush " << page_count << " pages at " << vaddr;
 #endif
-    Processor::flush_tlb(vaddr, page_count);
+    Processor::flush_tlb(page_directory, vaddr, page_count);
 }
 
 extern "C" PageTableEntry boot_pd3_pt1023[1024];

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -184,7 +184,7 @@ private:
     void protect_kernel_image();
     void parse_memory_map();
     static void flush_tlb_local(VirtualAddress, size_t page_count = 1);
-    static void flush_tlb(VirtualAddress, size_t page_count = 1);
+    static void flush_tlb(const PageDirectory*, VirtualAddress, size_t page_count = 1);
 
     static Region* user_region_from_vaddr(Process&, VirtualAddress);
     static Region* kernel_region_from_vaddr(VirtualAddress);

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -282,12 +282,6 @@ bool Region::map_individual_page_impl(size_t page_index)
     if (!page || (!is_readable() && !is_writable())) {
         pte->clear();
     } else {
-        if (is_shared()) {
-            // Shared memory should not be lazily populated!
-            ASSERT(!page->is_shared_zero_page());
-            ASSERT(!page->is_lazy_committed_page());
-        }
-
         pte->set_cache_disabled(!m_cacheable);
         pte->set_physical_page_base(page->paddr().get());
         pte->set_present(true);

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -320,7 +320,7 @@ bool Region::do_remap_vmobject_page_range(size_t page_index, size_t page_count)
         index++;
     }
     if (index > page_index)
-        MM.flush_tlb(vaddr_from_page_index(page_index), index - page_index);
+        MM.flush_tlb(m_page_directory, vaddr_from_page_index(page_index), index - page_index);
     return success;
 }
 
@@ -351,7 +351,7 @@ bool Region::do_remap_vmobject_page(size_t page_index, bool with_flush)
     ASSERT(physical_page(page_index));
     bool success = map_individual_page_impl(page_index);
     if (with_flush)
-        MM.flush_tlb(vaddr_from_page_index(page_index));
+        MM.flush_tlb(m_page_directory, vaddr_from_page_index(page_index));
     return success;
 }
 
@@ -387,7 +387,7 @@ void Region::unmap(ShouldDeallocateVirtualMemoryRange deallocate_range)
         dbg() << "MM: >> Unmapped " << vaddr << " => P" << String::format("%p", page ? page->paddr().get() : 0) << " <<";
 #endif
     }
-    MM.flush_tlb(vaddr(), page_count());
+    MM.flush_tlb(m_page_directory, vaddr(), page_count());
     if (deallocate_range == ShouldDeallocateVirtualMemoryRange::Yes) {
         if (m_page_directory->range_allocator().contains(range()))
             m_page_directory->range_allocator().deallocate(range());
@@ -419,7 +419,7 @@ bool Region::map(PageDirectory& page_directory)
         ++page_index;
     }
     if (page_index > 0) {
-        MM.flush_tlb(vaddr(), page_index);
+        MM.flush_tlb(m_page_directory, vaddr(), page_index);
         return page_index == page_count();
     }
     return false;

--- a/Kernel/VM/VMObject.cpp
+++ b/Kernel/VM/VMObject.cpp
@@ -46,6 +46,7 @@ VMObject::VMObject(size_t size)
 VMObject::~VMObject()
 {
     MM.unregister_vmobject(*this);
+    ASSERT(m_regions_count.load(AK::MemoryOrder::memory_order_relaxed) == 0);
 }
 
 }

--- a/Kernel/VM/VMObject.h
+++ b/Kernel/VM/VMObject.h
@@ -67,6 +67,10 @@ public:
     VMObject* m_next { nullptr };
     VMObject* m_prev { nullptr };
 
+    ALWAYS_INLINE void ref_region() { m_regions_count.fetch_add(1, AK::MemoryOrder::memory_order_relaxed); }
+    ALWAYS_INLINE void unref_region() { m_regions_count.fetch_sub(1, AK::MemoryOrder::memory_order_relaxed); }
+    ALWAYS_INLINE bool is_shared_by_multiple_regions() const { return m_regions_count.load(AK::MemoryOrder::memory_order_relaxed) > 1; }
+
 protected:
     explicit VMObject(size_t);
     explicit VMObject(const VMObject&);
@@ -83,6 +87,8 @@ private:
     VMObject& operator=(const VMObject&) = delete;
     VMObject& operator=(VMObject&&) = delete;
     VMObject(VMObject&&) = delete;
+
+    Atomic<u32> m_regions_count { 0 };
 };
 
 }


### PR DESCRIPTION
If we remap pages (e.g. lazy allocation) inside a VMObject that is
shared among more than one region, broadcast it to any other region
that may be mapping the same page.