### PR TITLE
NotificationServer: Reposition notifications on screen resolution change

### DIFF
--- a/Services/NotificationServer/NotificationWindow.cpp
+++ b/Services/NotificationServer/NotificationWindow.cpp
@@ -41,7 +41,7 @@ namespace NotificationServer {
 
 static Vector<RefPtr<NotificationWindow>> s_windows;
 
-static void update_notification_window_locations()
+void update_notification_window_locations()
 {
     Gfx::IntRect last_window_rect;
     for (auto& window : s_windows) {

--- a/Services/NotificationServer/NotificationWindow.h
+++ b/Services/NotificationServer/NotificationWindow.h
@@ -30,6 +30,8 @@
 
 namespace NotificationServer {
 
+void update_notification_window_locations();
+
 class NotificationWindow final : public GUI::Window {
     C_OBJECT(NotificationWindow);
 

--- a/Services/NotificationServer/main.cpp
+++ b/Services/NotificationServer/main.cpp
@@ -25,8 +25,10 @@
  */
 
 #include "ClientConnection.h"
+#include "NotificationWindow.h"
 #include <LibCore/LocalServer.h>
 #include <LibGUI/Application.h>
+#include <LibGUI/Desktop.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -65,6 +67,8 @@ int main(int argc, char** argv)
         perror("pledge");
         return 1;
     }
+
+    GUI::Desktop::the().on_rect_change = [](auto&) { NotificationServer::update_notification_window_locations(); };
 
     return app->exec();
 }


### PR DESCRIPTION
Previously notifications were (partially) drawn outside the screen rect if
they were created before changing the screen resolution to smaller
dimensions. This prevented the user from dismissing the notification as the
close button was no longer clickable.

See also issue #4751.

I'm not sure if it's a good idea to simply expose the previously static `update_notification_window_locations` function? Perhaps this should be a static method of the `NotificationWindow` class instead? I don't have too much experience with C++, so I don't know if this would be an idiomatic way of doing this.