### PR TITLE
LibGUI: Remove Widget's unused m_{foreground,background}_color

### DIFF
--- a/Demos/DynamicObject/main.cpp
+++ b/Demos/DynamicObject/main.cpp
@@ -59,7 +59,6 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv, [[maybe_unused
 
     auto& main_widget = window->set_main_widget<GUI::Widget>();
     main_widget.set_fill_with_background_color(true);
-    main_widget.set_background_color(Color::White);
     auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
     layout.set_margins({ 4, 4, 4, 4 });
 

--- a/Demos/HelloWorld/main.cpp
+++ b/Demos/HelloWorld/main.cpp
@@ -59,7 +59,6 @@ int main(int argc, char** argv)
 
     auto& main_widget = window->set_main_widget<GUI::Widget>();
     main_widget.set_fill_with_background_color(true);
-    main_widget.set_background_color(Color::White);
     auto& layout = main_widget.set_layout<GUI::VerticalBoxLayout>();
     layout.set_margins({ 4, 4, 4, 4 });
 

--- a/DevTools/HackStudio/FormEditorWidget.cpp
+++ b/DevTools/HackStudio/FormEditorWidget.cpp
@@ -36,7 +36,6 @@ FormEditorWidget::FormEditorWidget()
     : m_tool(make<CursorTool>(*this))
 {
     set_fill_with_background_color(true);
-    set_background_color(Color::MidGray);
 
     m_form_widget = add<FormWidget>();
     m_widget_tree_model = WidgetTreeModel::create(*m_form_widget);

--- a/DevTools/Profiler/ProfileTimelineWidget.cpp
+++ b/DevTools/Profiler/ProfileTimelineWidget.cpp
@@ -31,7 +31,6 @@
 ProfileTimelineWidget::ProfileTimelineWidget(Profile& profile)
     : m_profile(profile)
 {
-    set_background_color(Color::White);
     set_fill_with_background_color(true);
     set_fixed_height(80);
 }

--- a/Games/Minesweeper/Field.cpp
+++ b/Games/Minesweeper/Field.cpp
@@ -252,7 +252,11 @@ void Field::reset()
             square.is_swept = false;
             if (!square.label) {
                 square.label = add<SquareLabel>(square);
-                square.label->set_background_color(Color::from_rgb(0xff4040));
+                // Square with mine will be filled with background color later, i.e. red
+                auto palette = square.label->palette();
+                palette.set_color(Gfx::ColorRole::Base, Color::from_rgb(0xff4040));
+                square.label->set_palette(palette);
+                square.label->set_background_role(Gfx::ColorRole::Base);
             }
             square.label->set_fill_with_background_color(false);
             square.label->set_relative_rect(rect);

--- a/Libraries/LibGUI/Widget.h
+++ b/Libraries/LibGUI/Widget.h
@@ -214,12 +214,6 @@ public:
     Gfx::ColorRole foreground_role() const { return m_foreground_role; }
     void set_foreground_role(Gfx::ColorRole);
 
-    Color background_color() const { return m_background_color; }
-    Color foreground_color() const { return m_foreground_color; }
-
-    void set_background_color(Color color) { m_background_color = color; }
-    void set_foreground_color(Color color) { m_foreground_color = color; }
-
     void set_autofill(bool b) { set_fill_with_background_color(b); }
 
     Window* window()
@@ -359,8 +353,6 @@ private:
     Gfx::IntRect m_relative_rect;
     Gfx::ColorRole m_background_role;
     Gfx::ColorRole m_foreground_role;
-    Color m_background_color;
-    Color m_foreground_color;
     NonnullRefPtr<Gfx::Font> m_font;
     String m_tooltip;
 

--- a/Services/Taskbar/TaskbarWindow.cpp
+++ b/Services/Taskbar/TaskbarWindow.cpp
@@ -206,12 +206,6 @@ void TaskbarWindow::update_window_button(::Window& window, bool show_as_active)
     auto* button = window.button();
     if (!button)
         return;
-
-    if (window.is_minimized()) {
-        button->set_foreground_color(Color::DarkGray);
-    } else {
-        button->set_foreground_color(Color::Black);
-    }
     button->set_text(window.title());
     button->set_checked(show_as_active);
 }


### PR DESCRIPTION
...as well as the few remaining references to set_foreground_color().

These properties are not being used for rendering anymore, presumably
because they completely mess up theming - assigning random white and
gray backgrounds just doesn't work with dark themes.
I've chosen to not replace most of the few remaining uses of this
broken functionality with custom palette colors (the closest
replacement is background_role) for now (except for Minesweeper where
squares with mines are painted red again now), as no one has actually
complained about them being broken, so it must look somewhat decent
(some just look right anyway). :^)

Examples of this are the taskbar buttons, which apparently had a
DarkGray foreground color for minimized windows once - this has since
been replaced with bold/regular font. Another one is the Profiler's
ProfileTimelineWidget, which is supposed to have a white background -
which it didn't have for quite some time, it's grey now (with the
default theme, that is). Doesn't look bad either.