### PR TITLE
LibGUI: Stop the automatic autocomplete timer when typing whitespace / Playground: Improve the autocompleted suggestions

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -122,6 +122,8 @@ public:
     String to_lowercase() const;
     String to_uppercase() const;
 
+    bool is_whitespace() const { return StringUtils::is_whitespace(*this); }
+
 #ifndef KERNEL
     String trim_whitespace(TrimMode mode = TrimMode::Both) const
     {

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -31,6 +31,7 @@
 #include <AK/StringUtils.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
+#include <ctype.h>
 
 namespace AK {
 
@@ -302,17 +303,17 @@ bool contains(const StringView& str, const StringView& needle, CaseSensitivity c
     return false;
 }
 
+bool is_whitespace(const StringView& str)
+{
+    for (auto ch : str) {
+        if (!isspace(ch))
+            return false;
+    }
+    return true;
+}
+
 StringView trim_whitespace(const StringView& str, TrimMode mode)
 {
-    auto is_whitespace_character = [](char ch) -> bool {
-        return ch == '\t'
-            || ch == '\n'
-            || ch == '\v'
-            || ch == '\f'
-            || ch == '\r'
-            || ch == ' ';
-    };
-
     size_t substring_start = 0;
     size_t substring_length = str.length();
 
@@ -320,7 +321,7 @@ StringView trim_whitespace(const StringView& str, TrimMode mode)
         for (size_t i = 0; i < str.length(); ++i) {
             if (substring_length == 0)
                 return "";
-            if (!is_whitespace_character(str[i]))
+            if (!isspace(str[i]))
                 break;
             ++substring_start;
             --substring_length;
@@ -331,7 +332,7 @@ StringView trim_whitespace(const StringView& str, TrimMode mode)
         for (size_t i = str.length() - 1; i > 0; --i) {
             if (substring_length == 0)
                 return "";
-            if (!is_whitespace_character(str[i]))
+            if (!isspace(str[i]))
                 break;
             --substring_length;
         }

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -69,6 +69,7 @@ bool equals_ignoring_case(const StringView&, const StringView&);
 bool ends_with(const StringView& a, const StringView& b, CaseSensitivity);
 bool starts_with(const StringView&, const StringView&, CaseSensitivity);
 bool contains(const StringView&, const StringView&, CaseSensitivity);
+bool is_whitespace(const StringView&);
 StringView trim_whitespace(const StringView&, TrimMode mode);
 }
 

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -180,6 +180,8 @@ public:
 
     String to_string() const;
 
+    bool is_whitespace() const { return StringUtils::is_whitespace(*this); }
+
     template<typename T, typename... Rest>
     bool is_one_of(const T& string, Rest... rest) const
     {

--- a/AK/Tests/TestStringUtils.cpp
+++ b/AK/Tests/TestStringUtils.cpp
@@ -287,4 +287,15 @@ TEST_CASE(contains)
     EXPECT(!AK::StringUtils::contains(test_string, "L", CaseSensitivity::CaseInsensitive));
 }
 
+TEST_CASE(is_whitespace)
+{
+    EXPECT(AK::StringUtils::is_whitespace(""));
+    EXPECT(AK::StringUtils::is_whitespace("   "));
+    EXPECT(AK::StringUtils::is_whitespace("  \t"));
+    EXPECT(AK::StringUtils::is_whitespace("  \t\n"));
+    EXPECT(AK::StringUtils::is_whitespace("  \t\n\r\v"));
+    EXPECT(!AK::StringUtils::is_whitespace("  a "));
+    EXPECT(!AK::StringUtils::is_whitespace("a\t"));
+}
+
 TEST_MAIN(StringUtils)

--- a/Libraries/LibCore/Property.h
+++ b/Libraries/LibCore/Property.h
@@ -48,6 +48,7 @@ public:
     JsonValue get() const { return m_getter(); }
 
     const String& name() const { return m_name; }
+    bool is_readonly() const { return !m_setter; }
 
 private:
     String m_name;

--- a/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -103,7 +103,7 @@ AutocompleteBox::~AutocompleteBox() { }
 AutocompleteBox::AutocompleteBox(TextEditor& editor)
     : m_editor(editor)
 {
-    m_popup_window = GUI::Window::construct();
+    m_popup_window = GUI::Window::construct(m_editor->window());
     m_popup_window->set_window_type(GUI::WindowType::Tooltip);
     m_popup_window->set_rect(0, 0, 200, 100);
 

--- a/Libraries/LibGUI/BoxLayout.cpp
+++ b/Libraries/LibGUI/BoxLayout.cpp
@@ -32,6 +32,9 @@
 
 //#define GBOXLAYOUT_DEBUG
 
+REGISTER_WIDGET(GUI, HorizontalBoxLayout)
+REGISTER_WIDGET(GUI, VerticalBoxLayout)
+
 namespace GUI {
 
 BoxLayout::BoxLayout(Orientation orientation)

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -1049,8 +1049,12 @@ void TextEditor::keydown_event(KeyEvent& event)
         StringBuilder sb;
         sb.append_code_point(event.code_point());
 
-        if (should_autocomplete_automatically())
-            m_autocomplete_timer->start();
+        if (should_autocomplete_automatically()) {
+            if (sb.string_view().is_whitespace())
+                m_autocomplete_timer->stop();
+            else
+                m_autocomplete_timer->start();
+        }
         insert_at_cursor_or_replace_selection(sb.to_string());
         return;
     }


### PR DESCRIPTION
Hopefully now less in-your-way than before!

---

There's no reason to bring up autocomplete when the user is just
inserting indentation and spaces and such.

- Now sorted
- Add a "layout" property to GUI::Widget and GUI::Frame
- Only complete Layouts for the values of "layout"
- Don't suggest anything if the only suggestion is what the user has
  already typed