### PR TITLE
LibGUI: Move widget registrations to the corresponding cpp file

### DIFF
--- a/Libraries/LibGUI/BreadcrumbBar.cpp
+++ b/Libraries/LibGUI/BreadcrumbBar.cpp
@@ -29,6 +29,8 @@
 #include <LibGUI/Button.h>
 #include <LibGfx/Font.h>
 
+REGISTER_WIDGET(GUI, BreadcrumbBar)
+
 namespace GUI {
 
 // FIXME: Move this somewhere else

--- a/Libraries/LibGUI/Button.cpp
+++ b/Libraries/LibGUI/Button.cpp
@@ -34,6 +34,8 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 
+REGISTER_WIDGET(GUI, Button)
+
 namespace GUI {
 
 Button::Button(String text)

--- a/Libraries/LibGUI/CheckBox.cpp
+++ b/Libraries/LibGUI/CheckBox.cpp
@@ -31,6 +31,8 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 
+REGISTER_WIDGET(GUI, CheckBox)
+
 namespace GUI {
 
 static const int s_box_width = 13;

--- a/Libraries/LibGUI/ColorInput.cpp
+++ b/Libraries/LibGUI/ColorInput.cpp
@@ -30,6 +30,8 @@
 #include <LibGUI/Painter.h>
 #include <LibGfx/Palette.h>
 
+REGISTER_WIDGET(GUI, ColorInput)
+
 namespace GUI {
 
 ColorInput::ColorInput()

--- a/Libraries/LibGUI/ComboBox.cpp
+++ b/Libraries/LibGUI/ComboBox.cpp
@@ -33,6 +33,8 @@
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Window.h>
 
+REGISTER_WIDGET(GUI, ComboBox)
+
 namespace GUI {
 
 class ComboBoxEditor final : public TextEditor {

--- a/Libraries/LibGUI/Frame.cpp
+++ b/Libraries/LibGUI/Frame.cpp
@@ -29,6 +29,8 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 
+REGISTER_WIDGET(GUI, Frame)
+
 namespace GUI {
 
 Frame::Frame()

--- a/Libraries/LibGUI/GroupBox.cpp
+++ b/Libraries/LibGUI/GroupBox.cpp
@@ -30,6 +30,8 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 
+REGISTER_WIDGET(GUI, GroupBox)
+
 namespace GUI {
 
 GroupBox::GroupBox(const StringView& title)

--- a/Libraries/LibGUI/ImageWidget.cpp
+++ b/Libraries/LibGUI/ImageWidget.cpp
@@ -30,6 +30,8 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageDecoder.h>
 
+REGISTER_WIDGET(GUI, ImageWidget)
+
 namespace GUI {
 
 ImageWidget::ImageWidget(const StringView&)

--- a/Libraries/LibGUI/Label.cpp
+++ b/Libraries/LibGUI/Label.cpp
@@ -30,6 +30,8 @@
 #include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
 
+REGISTER_WIDGET(GUI, Label)
+
 namespace GUI {
 
 Label::Label(String text)

--- a/Libraries/LibGUI/LinkLabel.cpp
+++ b/Libraries/LibGUI/LinkLabel.cpp
@@ -31,6 +31,8 @@
 #include <LibGfx/Font.h>
 #include <LibGfx/Palette.h>
 
+REGISTER_WIDGET(GUI, LinkLabel)
+
 namespace GUI {
 
 LinkLabel::LinkLabel(String text)

--- a/Libraries/LibGUI/ListView.cpp
+++ b/Libraries/LibGUI/ListView.cpp
@@ -30,6 +30,8 @@
 #include <LibGUI/ScrollBar.h>
 #include <LibGfx/Palette.h>
 
+REGISTER_WIDGET(GUI, ListView)
+
 namespace GUI {
 
 ListView::ListView()

--- a/Libraries/LibGUI/OpacitySlider.cpp
+++ b/Libraries/LibGUI/OpacitySlider.cpp
@@ -29,6 +29,8 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 
+REGISTER_WIDGET(GUI, OpacitySlider)
+
 namespace GUI {
 
 OpacitySlider::OpacitySlider(Gfx::Orientation orientation)

--- a/Libraries/LibGUI/ProgressBar.cpp
+++ b/Libraries/LibGUI/ProgressBar.cpp
@@ -30,6 +30,8 @@
 #include <LibGUI/ProgressBar.h>
 #include <LibGfx/Palette.h>
 
+REGISTER_WIDGET(GUI, ProgressBar)
+
 namespace GUI {
 
 ProgressBar::ProgressBar()

--- a/Libraries/LibGUI/RadioButton.cpp
+++ b/Libraries/LibGUI/RadioButton.cpp
@@ -31,6 +31,8 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 
+REGISTER_WIDGET(GUI, RadioButton)
+
 namespace GUI {
 
 RadioButton::RadioButton(String text)

--- a/Libraries/LibGUI/ScrollBar.cpp
+++ b/Libraries/LibGUI/ScrollBar.cpp
@@ -31,6 +31,8 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 
+REGISTER_WIDGET(GUI, ScrollBar)
+
 namespace GUI {
 
 static const char* s_up_arrow_bitmap_data = {

--- a/Libraries/LibGUI/Slider.cpp
+++ b/Libraries/LibGUI/Slider.cpp
@@ -31,6 +31,10 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 
+REGISTER_WIDGET(GUI, HorizontalSlider)
+REGISTER_WIDGET(GUI, Slider)
+REGISTER_WIDGET(GUI, VerticalSlider)
+
 namespace GUI {
 
 Slider::Slider(Orientation orientation)

--- a/Libraries/LibGUI/SpinBox.cpp
+++ b/Libraries/LibGUI/SpinBox.cpp
@@ -28,6 +28,8 @@
 #include <LibGUI/SpinBox.h>
 #include <LibGUI/TextBox.h>
 
+REGISTER_WIDGET(GUI, SpinBox)
+
 namespace GUI {
 
 SpinBox::SpinBox()

--- a/Libraries/LibGUI/Splitter.cpp
+++ b/Libraries/LibGUI/Splitter.cpp
@@ -30,6 +30,9 @@
 #include <LibGUI/Window.h>
 #include <LibGfx/Palette.h>
 
+REGISTER_WIDGET(GUI, HorizontalSplitter)
+REGISTER_WIDGET(GUI, VerticalSplitter)
+
 namespace GUI {
 
 Splitter::Splitter(Orientation orientation)

--- a/Libraries/LibGUI/StatusBar.cpp
+++ b/Libraries/LibGUI/StatusBar.cpp
@@ -33,6 +33,8 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 
+REGISTER_WIDGET(GUI, StatusBar)
+
 namespace GUI {
 
 StatusBar::StatusBar(int label_count)

--- a/Libraries/LibGUI/TabWidget.cpp
+++ b/Libraries/LibGUI/TabWidget.cpp
@@ -35,6 +35,8 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 
+REGISTER_WIDGET(GUI, TabWidget)
+
 namespace GUI {
 
 TabWidget::TabWidget()

--- a/Libraries/LibGUI/TextBox.cpp
+++ b/Libraries/LibGUI/TextBox.cpp
@@ -26,6 +26,8 @@
 
 #include <LibGUI/TextBox.h>
 
+REGISTER_WIDGET(GUI, TextBox)
+
 namespace GUI {
 
 TextBox::TextBox()

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -51,6 +51,8 @@
 
 //#define DEBUG_TEXTEDITOR
 
+REGISTER_WIDGET(GUI, TextEditor)
+
 namespace GUI {
 
 TextEditor::TextEditor(Type type)

--- a/Libraries/LibGUI/ToolBar.cpp
+++ b/Libraries/LibGUI/ToolBar.cpp
@@ -35,6 +35,8 @@
 #include <LibGUI/ToolBar.h>
 #include <LibGfx/Palette.h>
 
+REGISTER_WIDGET(GUI, ToolBar)
+
 namespace GUI {
 
 ToolBar::ToolBar(Orientation orientation, int button_size)

--- a/Libraries/LibGUI/ToolBarContainer.cpp
+++ b/Libraries/LibGUI/ToolBarContainer.cpp
@@ -30,6 +30,8 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/StylePainter.h>
 
+REGISTER_WIDGET(GUI, ToolBarContainer)
+
 namespace GUI {
 
 void ToolBarContainer::child_event(Core::ChildEvent& event)

--- a/Libraries/LibGUI/TreeView.cpp
+++ b/Libraries/LibGUI/TreeView.cpp
@@ -34,6 +34,8 @@
 
 //#define DEBUG_ITEM_RECTS
 
+REGISTER_WIDGET(GUI, TreeView)
+
 namespace GUI {
 
 struct TreeView::MetadataForIndex {

--- a/Libraries/LibGUI/Widget.cpp
+++ b/Libraries/LibGUI/Widget.cpp
@@ -29,34 +29,11 @@
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
-#include <LibGUI/BreadcrumbBar.h>
-#include <LibGUI/Button.h>
-#include <LibGUI/CheckBox.h>
-#include <LibGUI/ColorInput.h>
-#include <LibGUI/ComboBox.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/GMLParser.h>
-#include <LibGUI/GroupBox.h>
-#include <LibGUI/ImageWidget.h>
-#include <LibGUI/Label.h>
 #include <LibGUI/Layout.h>
-#include <LibGUI/LinkLabel.h>
-#include <LibGUI/ListView.h>
 #include <LibGUI/Menu.h>
-#include <LibGUI/OpacitySlider.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/ProgressBar.h>
-#include <LibGUI/RadioButton.h>
-#include <LibGUI/ScrollBar.h>
-#include <LibGUI/Slider.h>
-#include <LibGUI/SpinBox.h>
-#include <LibGUI/Splitter.h>
-#include <LibGUI/StatusBar.h>
-#include <LibGUI/TabWidget.h>
-#include <LibGUI/TextBox.h>
-#include <LibGUI/ToolBar.h>
-#include <LibGUI/ToolBarContainer.h>
-#include <LibGUI/TreeView.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGUI/WindowServerConnection.h>
@@ -66,37 +43,9 @@
 #include <LibGfx/Palette.h>
 #include <unistd.h>
 
-namespace GUI {
-
-REGISTER_WIDGET(GUI, BreadcrumbBar)
-REGISTER_WIDGET(GUI, Button)
-REGISTER_WIDGET(GUI, CheckBox)
-REGISTER_WIDGET(GUI, ColorInput)
-REGISTER_WIDGET(GUI, ComboBox)
-REGISTER_WIDGET(GUI, Frame)
-REGISTER_WIDGET(GUI, GroupBox)
-REGISTER_WIDGET(GUI, HorizontalSlider)
-REGISTER_WIDGET(GUI, HorizontalSplitter)
-REGISTER_WIDGET(GUI, ImageWidget)
-REGISTER_WIDGET(GUI, Label)
-REGISTER_WIDGET(GUI, LinkLabel)
-REGISTER_WIDGET(GUI, ListView)
-REGISTER_WIDGET(GUI, OpacitySlider)
-REGISTER_WIDGET(GUI, ProgressBar)
-REGISTER_WIDGET(GUI, RadioButton)
-REGISTER_WIDGET(GUI, ScrollBar)
-REGISTER_WIDGET(GUI, Slider)
-REGISTER_WIDGET(GUI, SpinBox)
-REGISTER_WIDGET(GUI, StatusBar)
-REGISTER_WIDGET(GUI, TabWidget)
-REGISTER_WIDGET(GUI, TextBox)
-REGISTER_WIDGET(GUI, TextEditor)
-REGISTER_WIDGET(GUI, ToolBar)
-REGISTER_WIDGET(GUI, ToolBarContainer)
-REGISTER_WIDGET(GUI, TreeView)
-REGISTER_WIDGET(GUI, VerticalSlider)
-REGISTER_WIDGET(GUI, VerticalSplitter)
 REGISTER_WIDGET(GUI, Widget)
+
+namespace GUI {
 
 static HashMap<String, WidgetClassRegistration*>& widget_classes()
 {

--- a/Libraries/LibGUI/Widget.h
+++ b/Libraries/LibGUI/Widget.h
@@ -39,9 +39,10 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/StandardCursor.h>
 
-#define REGISTER_WIDGET(namespace_, class_name)                    \
-    extern GUI::WidgetClassRegistration registration_##class_name; \
-    GUI::WidgetClassRegistration registration_##class_name(#namespace_ "::" #class_name, []() { return namespace_::class_name::construct(); });
+#define REGISTER_WIDGET(namespace_, class_name)                                                                                                 \
+    namespace {                                                                                                                                 \
+    GUI::WidgetClassRegistration registration_##class_name(#namespace_ "::" #class_name, []() { return namespace_::class_name::construct(); }); \
+    }
 
 namespace GUI {
 


### PR DESCRIPTION
This gets a lot of unecessary includes out of Widget.cpp. Doing this
didn't work before, but improvements in the C library and using dynamic
libraries have likely un-broken it :^).

Also, move the registration global object to an anonymous namespace. No
reason it has to be an extern symbol.