### PR TITLE
man: Rename manual section 1 to "User programs"

### DIFF
--- a/Base/usr/share/man/man1/man.md
+++ b/Base/usr/share/man/man1/man.md
@@ -19,7 +19,7 @@ the manual page for `man` program itself right now.
 
 The SerenityOS manual is split into the following *sections*, or *chapters*:
 
-1. Command-line programs
+1. User programs
 2. System calls
 3. Libraries
 4. Special files


### PR DESCRIPTION
Keep `man` sections consistent with `Help` sections. ae0320183af44a9a1f2921ac0743afb90976c6ee