### PR TITLE
Help: Support loading help page by file path as command line argument

### DIFF
--- a/Applications/Terminal/main.cpp
+++ b/Applications/Terminal/main.cpp
@@ -24,8 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/URL.h>
 #include <Applications/Terminal/TerminalSettingsWindowGML.h>
 #include <LibCore/ArgsParser.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/AboutDialog.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
@@ -471,6 +473,9 @@ int main(int argc, char** argv)
     view_menu.add_action(pick_font_action);
 
     auto& help_menu = menubar->add_menu("Help");
+    help_menu.add_action(GUI::CommonActions::make_help_action([](auto&) {
+        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/Terminal.md"), "/bin/Help");
+    }));
     help_menu.add_action(GUI::Action::create("About", [&](auto&) {
         GUI::AboutDialog::show("Terminal", app_icon.bitmap_for_size(32), window);
     }));


### PR DESCRIPTION
This facilitates opening help pages from within an application by pressing `F1` (using `LibGUI::CommonActions.make_help_action`) to launch the `Help` application with the associated page.

![Terminal Help](https://user-images.githubusercontent.com/434827/103470932-55ea8780-4dcd-11eb-89bf-7a86e5bc98ab.png)

Unfortunately, applications wishing to invoke `Help` in this manner must `#include <LibDesktop/Launcher.h>` and `unveil("/tmp/portal/launch")`. `Desktop::Launcher::open` does not support `String` arguments, only `URL`, so each invoking application must also `#include <AK/URL.h>`. This isn't ideal.

The changes to the `Help` command line parsing still permit the previous behavior of performing a search. If the argument is a valid path to a man page then it will be loaded. If not, it will be searched.
