### PR TITLE
Shell: Nicer errors + `source'

### DIFF
--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -123,18 +123,6 @@ void AK::Formatter<Shell::AST::Command>::format(FormatBuilder& builder, const Sh
 
 namespace Shell::AST {
 
-template<typename T, typename... Args>
-static inline NonnullRefPtr<T> create(Args... args)
-{
-    return adopt(*new T(args...));
-}
-
-template<typename T>
-static inline NonnullRefPtr<T> create(std::initializer_list<NonnullRefPtr<Value>> arg)
-{
-    return adopt(*new T(arg));
-}
-
 static inline void print_indented(const String& str, int indent)
 {
     for (auto i = 0; i < indent; ++i)
@@ -1829,7 +1817,7 @@ RefPtr<Value> Pipe::run(RefPtr<Shell> shell)
     if (first_in_right.pipeline) {
         last_in_left.pipeline = first_in_right.pipeline;
     } else {
-        auto pipeline = adopt(*new Pipeline);
+        auto pipeline = create<Pipeline>();
         last_in_left.pipeline = pipeline;
         first_in_right.pipeline = pipeline;
     }

--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -225,6 +225,7 @@ struct Command {
 
     mutable RefPtr<Pipeline> pipeline;
     Vector<NodeWithAction> next_chain;
+    Optional<Position> position;
 };
 
 struct HitTestResult {
@@ -258,8 +259,8 @@ public:
     {
     }
 
-    CommandValue(Vector<String> argv)
-        : m_command({ move(argv), {}, true, false, true, false, nullptr, {} })
+    CommandValue(Vector<String> argv, Position position)
+        : m_command({ move(argv), {}, true, false, true, false, nullptr, {}, move(position) })
     {
     }
 
@@ -347,13 +348,15 @@ public:
     virtual Vector<String> resolve_as_list(RefPtr<Shell>) override;
     virtual ~GlobValue();
     virtual bool is_glob() const override { return true; }
-    GlobValue(String glob)
+    GlobValue(String glob, Position position)
         : m_glob(move(glob))
+        , m_generation_position(move(position))
     {
     }
 
 private:
     String m_glob;
+    Position m_generation_position;
 };
 
 class SimpleVariableValue final : public Value {

--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -41,6 +41,18 @@
 
 namespace Shell::AST {
 
+template<typename T, typename... Args>
+static inline NonnullRefPtr<T> create(Args... args)
+{
+    return adopt(*new T(args...));
+}
+
+template<typename T>
+static inline NonnullRefPtr<T> create(std::initializer_list<NonnullRefPtr<Value>> arg)
+{
+    return adopt(*new T(arg));
+}
+
 struct HighlightMetadata {
     bool is_first_in_list { true };
 };

--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -866,10 +866,12 @@ bool Shell::run_builtin(const AST::Command& command, const NonnullRefPtrVector<A
     Core::EventLoop loop;
     setup_signals();
 
-#define __ENUMERATE_SHELL_BUILTIN(builtin)                        \
-    if (name == #builtin) {                                       \
-        retval = builtin_##builtin(argv.size() - 1, argv.data()); \
-        return true;                                              \
+#define __ENUMERATE_SHELL_BUILTIN(builtin)                               \
+    if (name == #builtin) {                                              \
+        retval = builtin_##builtin(argv.size() - 1, argv.data());        \
+        if (!has_error(ShellError::None))                                \
+            raise_error(m_error, m_error_description, command.position); \
+        return true;                                                     \
     }
 
     ENUMERATE_SHELL_BUILTINS();

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -57,6 +57,7 @@
     __ENUMERATE_SHELL_BUILTIN(popd)    \
     __ENUMERATE_SHELL_BUILTIN(setopt)  \
     __ENUMERATE_SHELL_BUILTIN(shift)   \
+    __ENUMERATE_SHELL_BUILTIN(source)  \
     __ENUMERATE_SHELL_BUILTIN(time)    \
     __ENUMERATE_SHELL_BUILTIN(jobs)    \
     __ENUMERATE_SHELL_BUILTIN(disown)  \


### PR DESCRIPTION
Just a nicer error display:
```
❯ serenity-shell test.sh
Shell Syntax Error: Cannot interpolate between 'error' and 'what'!
  0| match foobar {
  1|     *bar as (x) {
  2|         echo "$x", this is a syntax {error..what}
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  3|     }

```