### PR TITLE
Kernel+Loader.so: Allow dynamic executables without an interpreter

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -429,7 +429,7 @@ public:
         Yes,
     };
 
-    KResultOr<LoadResult> load(NonnullRefPtr<FileDescription> main_program_description, RefPtr<FileDescription> interpreter_description);
+    KResultOr<LoadResult> load(NonnullRefPtr<FileDescription> main_program_description, RefPtr<FileDescription> interpreter_description, bool is_dynamic);
     KResultOr<LoadResult> load_elf_object(FileDescription& object_description, FlatPtr load_offset, ShouldAllocateTls);
 
     bool is_superuser() const
@@ -519,10 +519,10 @@ private:
     void kill_threads_except_self();
     void kill_all_threads();
 
-    int do_exec(NonnullRefPtr<FileDescription> main_program_description, Vector<String> arguments, Vector<String> environment, RefPtr<FileDescription> interpreter_description, Thread*& new_main_thread, u32& prev_flags);
+    int do_exec(NonnullRefPtr<FileDescription> main_program_description, Vector<String> arguments, Vector<String> environment, RefPtr<FileDescription> interpreter_description, Thread*& new_main_thread, u32& prev_flags, bool is_dynamic);
     ssize_t do_write(FileDescription&, const UserOrKernelBuffer&, size_t);
 
-    KResultOr<NonnullRefPtr<FileDescription>> find_elf_interpreter_for_executable(const String& path, char (&first_page)[PAGE_SIZE], int nread, size_t file_size);
+    KResultOr<RefPtr<FileDescription>> find_elf_interpreter_for_executable(const String& path, char (&first_page)[PAGE_SIZE], int nread, size_t file_size);
 
     int alloc_fd(int first_candidate_fd = 0);
     void disown_all_shared_buffers();

--- a/Userland/DynamicLoader/main.cpp
+++ b/Userland/DynamicLoader/main.cpp
@@ -143,8 +143,6 @@ void _start(int argc, char** argv, char** envp)
             main_program_name = (const char*)auxvp->a_un.a_ptr;
         }
     }
-    ASSERT(main_program_fd >= 0);
-    ASSERT(!main_program_name.is_null());
 
     if (main_program_name == "/usr/lib/Loader.so") {
         // We've been invoked directly as an executable rather than as the
@@ -154,6 +152,9 @@ void _start(int argc, char** argv, char** envp)
         display_help();
         _exit(1);
     }
+
+    ASSERT(main_program_fd >= 0);
+    ASSERT(!main_program_name.is_empty());
 
     ELF::DynamicLinker::linker_main(move(main_program_name), main_program_fd, argc, argv, envp);
     ASSERT_NOT_REACHED();


### PR DESCRIPTION
Commit a3a9016701e487a5ca92d83b8cff179a190cdeb2 removed the PT_INTERP header
from Loader.so which cleaned up some kernel code in execve. Unfortunately
it prevents Loader.so from being run as an executable