### PR TITLE
Store process termination signal in coredumps and show it in CrashReporter

### DIFF
--- a/Applications/CrashReporter/main.cpp
+++ b/Applications/CrashReporter/main.cpp
@@ -45,6 +45,7 @@
 #include <LibGUI/LinkLabel.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/Window.h>
+#include <string.h>
 
 static String build_backtrace(const CoreDump::Reader& coredump)
 {
@@ -87,6 +88,7 @@ int main(int argc, char** argv)
     String backtrace;
     String executable_path;
     int pid { 0 };
+    u8 termination_signal { 0 };
 
     {
         auto coredump = CoreDump::Reader::create(coredump_path);
@@ -98,6 +100,7 @@ int main(int argc, char** argv)
         backtrace = build_backtrace(*coredump);
         executable_path = String(process_info.executable_path);
         pid = process_info.pid;
+        termination_signal = process_info.termination_signal;
     }
 
     auto app = GUI::Application::construct(argc, argv);
@@ -147,7 +150,7 @@ int main(int argc, char** argv)
         app_name = af->name();
 
     auto& description_label = *widget.find_descendant_of_type_named<GUI::Label>("description");
-    description_label.set_text(String::formatted("\"{}\" (PID {}) has crashed!", app_name, pid));
+    description_label.set_text(String::formatted("\"{}\" (PID {}) has crashed - {} (signal {})", app_name, pid, strsignal(termination_signal), termination_signal));
 
     auto& executable_link_label = *widget.find_descendant_of_type_named<GUI::LinkLabel>("executable_link");
     executable_link_label.set_text(LexicalPath::canonicalized_path(executable_path));

--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -216,6 +216,7 @@ ByteBuffer CoreDump::create_notes_process_data() const
     ELF::Core::ProcessInfo info {};
     info.header.type = ELF::Core::NotesEntryHeader::Type::ProcessInfo;
     info.pid = m_process->pid().value();
+    info.termination_signal = m_process->termination_signal();
 
     process_data.append((void*)&info, sizeof(info));
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -449,6 +449,8 @@ public:
     void terminate_due_to_signal(u8 signal);
     KResult send_signal(u8 signal, Process* sender);
 
+    u8 termination_signal() const { return m_termination_signal; }
+
     u16 thread_count() const
     {
         return m_thread_count.load(AK::MemoryOrder::memory_order_relaxed);

--- a/Libraries/LibELF/CoreDump.h
+++ b/Libraries/LibELF/CoreDump.h
@@ -51,6 +51,7 @@ struct [[gnu::packed]] NotesEntry {
 struct [[gnu::packed]] ProcessInfo {
     NotesEntryHeader header;
     int pid;
+    u8 termination_signal;
     char executable_path[]; // Null terminated
 };
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19366641/103488627-6c650300-4e0e-11eb-9873-bc72fdde3453.png)
