### PR TITLE
AK: Add default memory order as template argument for Atomic<T>

### DIFF
--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -70,7 +70,7 @@ class SimpleIterator;
 using ReadonlyBytes = Span<const u8>;
 using Bytes = Span<u8>;
 
-template<typename T>
+template<typename T, AK::MemoryOrder DefaultMemoryOrder>
 class Atomic;
 
 template<typename T>

--- a/AK/RefCounted.h
+++ b/AK/RefCounted.h
@@ -74,7 +74,7 @@ public:
         ASSERT(!Checked<RefCountType>::addition_would_overflow(old_ref_count, 1));
     }
 
-    ALWAYS_INLINE bool try_ref() const
+    [[nodiscard]] ALWAYS_INLINE bool try_ref() const
     {
         RefCountType expected = m_ref_count.load(AK::MemoryOrder::memory_order_relaxed);
         for (;;) {

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -102,3 +102,16 @@ enum class [[nodiscard]] TriState : u8 {
     True,
     Unknown
 };
+
+namespace AK {
+
+enum MemoryOrder {
+    memory_order_relaxed = __ATOMIC_RELAXED,
+    memory_order_consume = __ATOMIC_CONSUME,
+    memory_order_acquire = __ATOMIC_ACQUIRE,
+    memory_order_release = __ATOMIC_RELEASE,
+    memory_order_acq_rel = __ATOMIC_ACQ_REL,
+    memory_order_seq_cst = __ATOMIC_SEQ_CST
+};
+
+}

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -679,7 +679,7 @@ void Plan9FS::thread_main()
             dbg() << "Plan9FS: Thread terminating, error reading";
             return;
         }
-    } while (!m_thread_shutdown.load(AK::MemoryOrder::memory_order_relaxed));
+    } while (!m_thread_shutdown);
     dbg() << "Plan9FS: Thread terminating";
 }
 

--- a/Kernel/FileSystem/Plan9FileSystem.h
+++ b/Kernel/FileSystem/Plan9FileSystem.h
@@ -162,7 +162,7 @@ private:
     SpinLock<u8> m_thread_lock;
     RefPtr<Thread> m_thread;
     Atomic<bool> m_thread_running { false };
-    Atomic<bool> m_thread_shutdown { false };
+    Atomic<bool, AK::MemoryOrder::memory_order_relaxed> m_thread_shutdown { false };
 };
 
 class Plan9FSInode final : public Inode {

--- a/Kernel/Interrupts/GenericInterruptHandler.h
+++ b/Kernel/Interrupts/GenericInterruptHandler.h
@@ -48,7 +48,7 @@ public:
 
     u8 interrupt_number() const { return m_interrupt_number; }
 
-    size_t get_invoking_count() const { return m_invoking_count.load(AK::MemoryOrder::memory_order_relaxed); }
+    size_t get_invoking_count() const { return m_invoking_count; }
 
     virtual size_t sharing_devices_count() const = 0;
     virtual bool is_shared_handler() const = 0;
@@ -61,7 +61,7 @@ public:
     virtual bool eoi() = 0;
     ALWAYS_INLINE void increment_invoking_counter()
     {
-        m_invoking_count.fetch_add(1, AK::MemoryOrder::memory_order_relaxed);
+        m_invoking_count++;
     }
 
 protected:
@@ -71,7 +71,7 @@ protected:
     void disable_remap() { m_disable_remap = true; }
 
 private:
-    Atomic<u32> m_invoking_count { 0 };
+    Atomic<u32, AK::MemoryOrder::memory_order_relaxed> m_invoking_count { 0 };
     u8 m_interrupt_number { 0 };
     bool m_disable_remap { false };
 };

--- a/Kernel/Lock.h
+++ b/Kernel/Lock.h
@@ -58,7 +58,7 @@ public:
     void unlock();
     [[nodiscard]] Mode force_unlock_if_locked(u32&);
     void restore_lock(Mode, u32);
-    bool is_locked() const { return m_mode.load(AK::MemoryOrder::memory_order_relaxed) != Mode::Unlocked; }
+    bool is_locked() const { return m_mode != Mode::Unlocked; }
     void clear_waiters();
 
     const char* name() const { return m_name; }
@@ -81,7 +81,7 @@ private:
     Atomic<bool> m_lock { false };
     const char* m_name { nullptr };
     WaitQueue m_queue;
-    Atomic<Mode> m_mode { Mode::Unlocked };
+    Atomic<Mode, AK::MemoryOrder::memory_order_relaxed> m_mode { Mode::Unlocked };
 
     // When locked exclusively, only the thread already holding the lock can
     // lock it again. When locked in shared mode, any thread can do that.

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -154,8 +154,8 @@ public:
 
     bool is_dead() const { return m_dead; }
 
-    bool is_stopped() const { return m_is_stopped.load(AK::MemoryOrder::memory_order_relaxed); }
-    bool set_stopped(bool stopped) { return m_is_stopped.exchange(stopped, AK::MemoryOrder::memory_order_relaxed); }
+    bool is_stopped() const { return m_is_stopped; }
+    bool set_stopped(bool stopped) { return m_is_stopped.exchange(stopped); }
 
     bool is_kernel_process() const { return m_is_kernel_process; }
     bool is_user_process() const { return !m_is_kernel_process; }
@@ -595,7 +595,7 @@ private:
     const bool m_is_kernel_process;
     bool m_dead { false };
     bool m_profiling { false };
-    Atomic<bool> m_is_stopped { false };
+    Atomic<bool, AK::MemoryOrder::memory_order_relaxed> m_is_stopped { false };
     bool m_should_dump_core { false };
 
     RefPtr<Custody> m_executable;

--- a/Kernel/TimerQueue.h
+++ b/Kernel/TimerQueue.h
@@ -64,7 +64,7 @@ private:
     Function<void()> m_callback;
     Timer* m_next { nullptr };
     Timer* m_prev { nullptr };
-    Atomic<bool> m_queued { false };
+    Atomic<bool, AK::MemoryOrder::memory_order_relaxed> m_queued { false };
 
     bool operator<(const Timer& rhs) const
     {
@@ -78,8 +78,8 @@ private:
     {
         return m_id == rhs.m_id;
     }
-    bool is_queued() const { return m_queued.load(AK::MemoryOrder::memory_order_relaxed); }
-    void set_queued(bool queued) { m_queued.store(queued, AK::MemoryOrder::memory_order_relaxed); }
+    bool is_queued() const { return m_queued; }
+    void set_queued(bool queued) { m_queued = queued; }
     u64 now(bool) const;
 };
 

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -205,7 +205,7 @@ void MemoryManager::parse_memory_map()
     ASSERT(m_user_physical_pages > 0);
 
     // We start out with no committed pages
-    m_user_physical_pages_uncommitted = m_user_physical_pages;
+    m_user_physical_pages_uncommitted = m_user_physical_pages.load();
 }
 
 PageTableEntry* MemoryManager::pte(PageDirectory& page_directory, VirtualAddress vaddr)

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -208,12 +208,12 @@ private:
     RefPtr<PhysicalPage> m_shared_zero_page;
     RefPtr<PhysicalPage> m_lazy_committed_page;
 
-    unsigned m_user_physical_pages { 0 };
-    unsigned m_user_physical_pages_used { 0 };
-    unsigned m_user_physical_pages_committed { 0 };
-    unsigned m_user_physical_pages_uncommitted { 0 };
-    unsigned m_super_physical_pages { 0 };
-    unsigned m_super_physical_pages_used { 0 };
+    Atomic<unsigned, AK::MemoryOrder::memory_order_relaxed> m_user_physical_pages { 0 };
+    Atomic<unsigned, AK::MemoryOrder::memory_order_relaxed> m_user_physical_pages_used { 0 };
+    Atomic<unsigned, AK::MemoryOrder::memory_order_relaxed> m_user_physical_pages_committed { 0 };
+    Atomic<unsigned, AK::MemoryOrder::memory_order_relaxed> m_user_physical_pages_uncommitted { 0 };
+    Atomic<unsigned, AK::MemoryOrder::memory_order_relaxed> m_super_physical_pages { 0 };
+    Atomic<unsigned, AK::MemoryOrder::memory_order_relaxed> m_super_physical_pages_used { 0 };
 
     NonnullRefPtrVector<PhysicalRegion> m_user_physical_regions;
     NonnullRefPtrVector<PhysicalRegion> m_super_physical_regions;

--- a/Kernel/VM/VMObject.h
+++ b/Kernel/VM/VMObject.h
@@ -67,9 +67,9 @@ public:
     VMObject* m_next { nullptr };
     VMObject* m_prev { nullptr };
 
-    ALWAYS_INLINE void ref_region() { m_regions_count.fetch_add(1, AK::MemoryOrder::memory_order_relaxed); }
-    ALWAYS_INLINE void unref_region() { m_regions_count.fetch_sub(1, AK::MemoryOrder::memory_order_relaxed); }
-    ALWAYS_INLINE bool is_shared_by_multiple_regions() const { return m_regions_count.load(AK::MemoryOrder::memory_order_relaxed) > 1; }
+    ALWAYS_INLINE void ref_region() { m_regions_count++; }
+    ALWAYS_INLINE void unref_region() { m_regions_count--; }
+    ALWAYS_INLINE bool is_shared_by_multiple_regions() const { return m_regions_count > 1; }
 
 protected:
     explicit VMObject(size_t);
@@ -88,7 +88,7 @@ private:
     VMObject& operator=(VMObject&&) = delete;
     VMObject(VMObject&&) = delete;
 
-    Atomic<u32> m_regions_count { 0 };
+    Atomic<u32, AK::MemoryOrder::memory_order_relaxed> m_regions_count { 0 };
 };
 
 }


### PR DESCRIPTION
This is useful for collecting statistics, e.g.
Atomic<unsigned, MemoryOrder::memory_order_relaxed> would allow
using operators such as ++ to use relaxed semantics throughout
without having to explicitly call fetch_add with the memory order.