### PR TITLE
Playground: Add help documentation

### DIFF
--- a/Base/usr/share/man/man1/Playground.md
+++ b/Base/usr/share/man/man1/Playground.md
@@ -1,0 +1,28 @@
+## Name
+
+Playground - GUI Markup Language (GML) editor
+
+## Synopsis
+
+```**sh
+$ Playground
+```
+
+## Description
+
+Playground facilitates development of graphical user interfaces (GUI)
+for Serenity applications using GUI Markup Language (GML) to compose
+a layout for GUI widgets and set widget attributes.
+
+The specified widgets are automatically rendered in a live preview
+window, allowing rapid prototyping and development of application GUIs.
+
+## Examples
+
+```sh
+$ Playground
+```
+
+## See also
+
+* [`gml-format`(1)](../man1/gml-format.md) For automated GML formatting

--- a/Base/usr/share/man/man1/gml-format.md
+++ b/Base/usr/share/man/man1/gml-format.md
@@ -1,0 +1,23 @@
+## Name
+
+gml-format - automated GUI Markup Language (GML) formatter
+
+## Synopsis
+
+```**sh
+$ gml-format [--inplace] [path...]
+```
+
+## Description
+
+`gml-format` formats GUI Markup Language (GML) files.
+
+## Options
+
+* `-i`, `--inplace`: Write formatted contents back to file rather than standard output
+
+## Examples
+
+```sh
+$ gml-format -i /home/anon/example.gml
+```

--- a/DevTools/Playground/CMakeLists.txt
+++ b/DevTools/Playground/CMakeLists.txt
@@ -3,4 +3,4 @@ set(SOURCES
 )
 
 serenity_app(Playground ICON app-playground)
-target_link_libraries(Playground LibGUI)
+target_link_libraries(Playground LibDesktop LibGUI)


### PR DESCRIPTION
I'm sure that there's a lot more to be done on the documentation. Perhaps a GML file format man page (category 5) would be a good idea too.

This PR is more about wiring up the help menu.
