### PR TITLE
LibLine: Don't overwrite stuff when moving origin around

### DIFF
--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -349,10 +349,7 @@ private:
         if (cursor > m_cursor)
             cursor = m_cursor;
         auto buffer_metrics = actual_rendered_string_metrics(buffer_view().substring_view(0, cursor));
-        if (buffer_metrics.line_lengths.size() > 1)
-            return buffer_metrics.line_lengths.last() % m_num_columns;
-
-        return (buffer_metrics.line_lengths.last() + current_prompt_metrics().line_lengths.last()) % m_num_columns;
+        return current_prompt_metrics().offset_with_addition(buffer_metrics, m_num_columns);
     }
 
     void set_origin()

--- a/Libraries/LibLine/StringMetrics.h
+++ b/Libraries/LibLine/StringMetrics.h
@@ -37,6 +37,7 @@ struct StringMetrics {
     size_t max_line_length { 0 };
 
     size_t lines_with_addition(const StringMetrics& offset, size_t column_width) const;
+    size_t offset_with_addition(const StringMetrics& offset, size_t column_width) const;
     void reset()
     {
         line_lengths.clear();

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -1564,7 +1564,6 @@ void Shell::notify_child_event()
                 if (errno == ECHILD) {
                     // The child process went away before we could process its death, just assume it exited all ok.
                     // FIXME: This should never happen, the child should stay around until we do the waitpid above.
-                    dbgln("Child process gone, cannot get exit code for {}", job_id);
                     child_pid = job.pid();
                 } else {
                     ASSERT_NOT_REACHED();


### PR DESCRIPTION
This fixes an issue (mainly) with multiline prompts, where a multiline
prompt would overwrite the lines before it when libline tries to display
it.
To reproduce, set `PROMPT="a\nb\nc> "` in the shell, then press return
a few times.

before:
![shot-2021-01-04_16-41-02](https://user-images.githubusercontent.com/14001776/103538571-a7694400-4eab-11eb-9f53-129dd5050a88.jpg)


after:
![shot-2021-01-04_16-39-16](https://user-images.githubusercontent.com/14001776/103538441-71c45b00-4eab-11eb-9dc7-c73fe26f968f.jpg)
