### PR TITLE
Toolchain: Disable exceptions by default (& fix gcc port)

### DIFF
--- a/Toolchain/Patches/gcc.patch
+++ b/Toolchain/Patches/gcc.patch
@@ -102,7 +102,7 @@ diff -ruN a/gcc/config/arm/serenity-elf.h b/gcc/config/arm/serenity-elf.h
 diff -ruN a/gcc/config/serenity.h b/gcc/config/serenity.h
 --- a/gcc/config/serenity.h	1970-01-01 02:00:00.000000000 +0200
 +++ b/gcc/config/serenity.h	2020-12-12 10:43:35.280270540 +0200
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,37 @@
 +/* Useful if you wish to make target-specific GCC changes. */
 +#undef TARGET_SERENITY
 +#define TARGET_SERENITY 1
@@ -123,6 +123,12 @@ diff -ruN a/gcc/config/serenity.h b/gcc/config/serenity.h
 +
 +#undef LINK_SPEC
 +#define LINK_SPEC "%{shared:-shared} %{static:-static} %{!static: %{rdynamic:-export-dynamic} %{!fbuilding-libgcc:-lgcc_s -dynamic-linker /usr/lib/Loader.so}}"
++
++#undef CC1_SPEC
++#define CC1_SPEC "-fno-exceptions"
++
++#undef CC1PLUS_SPEC
++#define CC1PLUS_SPEC "-fno-exceptions"
 +
 +/* Additional predefined macros. */
 +#undef TARGET_OS_CPP_BUILTINS


### PR DESCRIPTION
Before this, the gcc port hanged on exit, when executing `_fini`.
(More specifically, it hanged somewhere inside `__deregister_frame_info_bases` in `libgcc`)