### PR TITLE
LibELF: Implement GNU Hashing algorithm for dynamic relocation table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,8 @@ endforeach()
 
 set(CMAKE_INSTALL_NAME_TOOL "")
 set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
-set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-shared")
+set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-shared -Wl,--hash-style=gnu")
+set(CMAKE_CXX_LINK_FLAGS "-Wl,--hash-style=gnu")
 
 # Note: MacOS has different rpath rules from linux.
 # We disable it completely for MacOS hosts to avoid having to track down all the individual flags to unset


### PR DESCRIPTION
This implements the gnu hashing algorithm, as an attempt to mitigate #4609. After running a few applications with this enabled, it appears that this doesn't cut down startup times massively as was hoped, but it does help a bit. I believe that the real performance improvements will come from re-enabling lazy PLT symbol resolution as per #4808.

As a side-note, this doesn't enable gnu hashing for every dynamic object in the SerenityOS build. libgcc_s.so still uses SYSV hashing, and I'm not sure how to change that, so the SYSV hashing code paths are still used for it in userspace programs.