### PR TITLE
LIBGUI: Add GML properties to calendar widget

### DIFF
--- a/Libraries/LibCore/DateTime.cpp
+++ b/Libraries/LibCore/DateTime.cpp
@@ -27,8 +27,8 @@
 #include <AK/StringBuilder.h>
 #include <AK/Time.h>
 #include <LibCore/DateTime.h>
+#include <ctype.h>
 #include <sys/time.h>
-#include <time.h>
 
 namespace Core {
 
@@ -253,6 +253,107 @@ bool DateTime::is_before(const String& other) const
 {
     auto now_string = String::formatted("{:04}{:02}{:02}{:02}{:02}{:02}Z", year(), month(), weekday(), hour(), minute(), second());
     return __builtin_strcasecmp(now_string.characters(), other.characters()) < 0;
+}
+
+time_t DateTime::parse_simplified_iso8601(const String& iso_8601)
+{
+    // Date.parse() is allowed to accept many formats. We strictly only accept things matching
+    // http://www.ecma-international.org/ecma-262/#sec-date-time-string-format
+    GenericLexer lexer(iso_8601);
+    auto lex_n_digits = [&](size_t n, int& out) {
+        if (lexer.tell_remaining() < n)
+            return false;
+        int r = 0;
+        for (size_t i = 0; i < n; ++i) {
+            char ch = lexer.consume();
+            if (!isdigit(ch))
+                return false;
+            r = 10 * r + ch - '0';
+        }
+        out = r;
+        return true;
+    };
+
+    int year = -1, month = -1, day = -1;
+    int hours = -1, minutes = -1, seconds = -1, milliseconds = -1;
+    char timezone = -1;
+    int timezone_hours = -1, timezone_minutes = -1;
+    auto lex_year = [&]() {
+        if (lexer.consume_specific('+'))
+            return lex_n_digits(6, year);
+        if (lexer.consume_specific('-')) {
+            int absolute_year;
+            if (!lex_n_digits(6, absolute_year))
+                return false;
+            year = -absolute_year;
+            return true;
+        }
+        return lex_n_digits(4, year);
+    };
+    auto lex_month = [&]() { return lex_n_digits(2, month) && month >= 1 && month <= 12; };
+    auto lex_day = [&]() { return lex_n_digits(2, day) && day >= 1 && day <= 31; };
+    auto lex_date = [&]() { return lex_year() && (!lexer.consume_specific('-') || (lex_month() && (!lexer.consume_specific('-') || lex_day()))); };
+
+    auto lex_hours_minutes = [&](int& out_h, int& out_m) {
+        int h, m;
+        if (lex_n_digits(2, h) && h >= 0 && h <= 24 && lexer.consume_specific(':') && lex_n_digits(2, m) && m >= 0 && m <= 59) {
+            out_h = h;
+            out_m = m;
+            return true;
+        }
+        return false;
+    };
+    auto lex_seconds = [&]() { return lex_n_digits(2, seconds) && seconds >= 0 && seconds <= 59; };
+    auto lex_milliseconds = [&]() { return lex_n_digits(3, milliseconds); };
+    auto lex_seconds_milliseconds = [&]() { return lex_seconds() && (!lexer.consume_specific('.') || lex_milliseconds()); };
+    auto lex_timezone = [&]() {
+        if (lexer.consume_specific('+')) {
+            timezone = '+';
+            return lex_hours_minutes(timezone_hours, timezone_minutes);
+        }
+        if (lexer.consume_specific('-')) {
+            timezone = '-';
+            return lex_hours_minutes(timezone_hours, timezone_minutes);
+        }
+        if (lexer.consume_specific('Z'))
+            timezone = 'Z';
+        return true;
+    };
+    auto lex_time = [&]() { return lex_hours_minutes(hours, minutes) && (!lexer.consume_specific(':') || lex_seconds_milliseconds()) && lex_timezone(); };
+
+    if (!lex_date() || (lexer.consume_specific('T') && !lex_time()) || !lexer.is_eof()) {
+        return 0;
+    }
+
+    // We parsed a valid date simplified ISO 8601 string. Values not present in the string are -1.
+    ASSERT(year != -1); // A valid date string always has at least a year.
+    struct tm tm = {};
+    tm.tm_year = year - 1900;
+    tm.tm_mon = month == -1 ? 0 : month - 1;
+    tm.tm_mday = day == -1 ? 1 : day;
+    tm.tm_hour = hours == -1 ? 0 : hours;
+    tm.tm_min = minutes == -1 ? 0 : minutes;
+    tm.tm_sec = seconds == -1 ? 0 : seconds;
+
+    // http://www.ecma-international.org/ecma-262/#sec-date.parse:
+    // "When the UTC offset representation is absent, date-only forms are interpreted as a UTC time and date-time forms are interpreted as a local time."
+    time_t timestamp;
+    if (timezone != -1 || hours == -1)
+        timestamp = timegm(&tm);
+    else
+        timestamp = mktime(&tm);
+
+    if (timezone == '-')
+        timestamp += (timezone_hours * 60 + timezone_minutes) * 60;
+    else if (timezone == '+')
+        timestamp -= (timezone_hours * 60 + timezone_minutes) * 60;
+
+    // FIXME: reject timestamp if resulting value wouldn't fit in a double
+
+    if (milliseconds == -1)
+        milliseconds = 0;
+
+    return 1000.0 * timestamp + milliseconds;
 }
 
 const LogStream& operator<<(const LogStream& stream, const DateTime& value)

--- a/Libraries/LibCore/DateTime.h
+++ b/Libraries/LibCore/DateTime.h
@@ -54,6 +54,7 @@ public:
     static DateTime create(unsigned year, unsigned month = 1, unsigned day = 0, unsigned hour = 0, unsigned minute = 0, unsigned second = 0);
     static DateTime now();
     static DateTime from_timestamp(time_t);
+    static time_t parse_simplified_iso8601(const String& iso_8601);
 
     // FIXME: This should be replaced with a proper comparison
     //        operator when we get the equivalent of strptime

--- a/Libraries/LibGUI/Calendar.h
+++ b/Libraries/LibGUI/Calendar.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021, Glenford Williams <gw_dev@outlook.com>
  * Copyright (c) 2019-2020, Ryan Grieb <ryan.m.grieb@gmail.com>
  * Copyright (c) 2020, the SerenityOS developers.
  * All rights reserved.
@@ -50,20 +51,22 @@ public:
         LongNames
     };
 
-    Calendar(Core::DateTime);
+    Calendar(Core::DateTime dateTime = Core::DateTime::now());
     virtual ~Calendar() override;
 
     unsigned int selected_year() const { return m_selected_year; }
     unsigned int selected_month() const { return m_selected_month; }
     const String selected_calendar_text(bool long_names = ShortNames);
+    void update_tiles();
     void update_tiles(unsigned int target_year, unsigned int target_month);
     void set_selected_calendar(unsigned int year, unsigned int month);
-    void set_selected_date(Core::DateTime date_time) { m_selected_date = date_time; }
+    void set_selected_date(Core::DateTime date_time);
     Core::DateTime selected_date() const { return m_selected_date; }
     void toggle_mode();
     void set_grid(bool grid);
     bool has_grid() { return m_grid; }
     Mode mode() const { return m_mode; }
+    void set_mode(Mode m);
 
     Function<void()> on_calendar_tile_click;
     Function<void()> on_calendar_tile_doubleclick;
@@ -133,6 +136,7 @@ private:
 
     Core::DateTime m_selected_date;
     Core::DateTime m_previous_selected_date;
+    String m_date_format;
     unsigned int m_selected_year { 0 };
     unsigned int m_selected_month { 0 };
     bool m_grid { true };


### PR DESCRIPTION
This pr introduces additional GML properties to the calendar widget.

- grid -bool
- date - string/array
- mode -  enum

![image](https://user-images.githubusercontent.com/1114368/104094909-d8f25e80-5261-11eb-8867-5e45a8ca5cc6.png)


```
@GUI::Widget{

    @GUI::Widget{
        layout: @GUI::HorizontalBoxLayout{}
        @GUI::Widget {
            //October 10 2020
            @GUI::Calendar{
                height : 200
                width: 300
                date: [10,10,2020]
            }
        }
      @GUI::Widget {
                //October 10 2020
                @GUI::Calendar{
                   height : 200
                   width: 300
                   date: "2020-10-10"
                }
            }
    }
    @GUI::Widget{
        layout: @GUI::HorizontalBoxLayout{}

        @GUI::Widget {
            //October 1 2020
            @GUI::Calendar{
               height : 200
               width: 300
               grid: false
            }
        }
        @GUI::Widget {
            //October 1 2020
            @GUI::Calendar{
               height : 200
               width: 300
               mode: "Month"
            }
        }
    }
}
```

edited  to show updated purpose