### PR TITLE
TextEditor: puts a newline at the end of files

### DIFF
--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -1055,6 +1055,11 @@ bool TextEditor::write_to_file(const StringView& path)
         perror("open");
         return false;
     }
+    
+    if (file_size == 0) {
+        close(fd);
+        return true;
+    }
 
     // Compute the final file size and ftruncate() to make writing fast.
     // FIXME: Remove this once the kernel is smart enough to do this instead.
@@ -1079,10 +1084,17 @@ bool TextEditor::write_to_file(const StringView& path)
                 close(fd);
                 return false;
             }
-        }
-        if (i != line_count() - 1) {
-            char ch = '\n';
-            ssize_t nwritten = write(fd, &ch, 1);
+
+            char newline = '\n';
+            nwritten = write(fd, &newline, 1);
+            if (nwritten != 1) {
+                perror("write");
+                close(fd);
+                return false;
+            }
+        } else if (i == line_count() - 1) {
+            char newline = '\n';
+            ssize_t nwritten = write(fd, &newline, 1);
             if (nwritten != 1) {
                 perror("write");
                 close(fd);

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -1092,7 +1092,9 @@ bool TextEditor::write_to_file(const StringView& path)
                 close(fd);
                 return false;
             }
-        } else if (i == line_count() - 1) {
+        }
+
+        else if (i != line_count() - 1) {
             char newline = '\n';
             ssize_t nwritten = write(fd, &newline, 1);
             if (nwritten != 1) {

--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -1055,11 +1055,6 @@ bool TextEditor::write_to_file(const StringView& path)
         perror("open");
         return false;
     }
-    
-    if (file_size == 0) {
-        close(fd);
-        return true;
-    }
 
     // Compute the final file size and ftruncate() to make writing fast.
     // FIXME: Remove this once the kernel is smart enough to do this instead.
@@ -1067,6 +1062,11 @@ bool TextEditor::write_to_file(const StringView& path)
     for (size_t i = 0; i < line_count(); ++i)
         file_size += line(i).length();
     file_size += line_count() - 1;
+
+    if (file_size == 0) {
+        close(fd);
+        return true;
+    }
 
     int rc = ftruncate(fd, file_size);
     if (rc < 0) {


### PR DESCRIPTION

 - Doesn't write anything to empty files (though the file is still created)
 - Puts a newline at the end of files that do not have one
 - Does not put a newline at the end of files that already end in one

Addresses issue https://github.com/SerenityOS/serenity/issues/4801