### PR TITLE
Shell: Run function declarations in the current process

### DIFF
--- a/Shell/AST.h
+++ b/Shell/AST.h
@@ -429,6 +429,7 @@ public:
 
     virtual bool is_list() const { return false; }
     virtual bool would_execute() const { return false; }
+    virtual bool should_override_execution_in_current_process() const { return false; }
 
     const Position& position() const { return m_position; }
     void set_is_syntax_error(const SyntaxError& error_node)
@@ -829,6 +830,7 @@ private:
     virtual HitTestResult hit_test_position(size_t) override;
     virtual Vector<Line::CompletionSuggestion> complete_for_editor(Shell&, size_t, const HitTestResult&) override;
     virtual bool would_execute() const override { return true; }
+    virtual bool should_override_execution_in_current_process() const override { return true; }
 
     NameWithPosition m_name;
     Vector<NameWithPosition> m_arguments;

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -729,6 +729,12 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
         }
     }
 
+    if (command.argv.is_empty() && !command.next_chain.is_empty() && command.should_immediately_execute_next && command.next_chain.first().node->should_override_execution_in_current_process()) {
+        for (auto& next_in_chain : command.next_chain)
+            run_tail(command, next_in_chain, last_return_code);
+        return nullptr;
+    }
+
     Vector<const char*> argv;
     Vector<String> copy_argv = command.argv;
     argv.ensure_capacity(command.argv.size() + 1);


### PR DESCRIPTION
Fixes #4817

Turns out things with no explicit specialisation fall back to the default behaviour. who'd have thought