### PR TITLE
Give cp a `-l` flag, and let `ls -l` print hard link count

### DIFF
--- a/Userland/ls.cpp
+++ b/Userland/ls.cpp
@@ -288,6 +288,8 @@ static bool print_filesystem_object(const String& path, const String& name, cons
     else
         printf("%c", st.st_mode & S_IXOTH ? 'x' : '-');
 
+    printf(" %u", st.st_nlink);
+
     auto username = users.get(st.st_uid);
     if (!flag_print_numeric && username.has_value()) {
         printf(" %7s", username.value().characters());


### PR DESCRIPTION
Inspired by frustration with macOS (https://github.com/nico/hack/blob/master/notes/copydir.md).

