### PR TITLE
LibLine: Don't ignore ^C inputs when there are no registered handlers

### DIFF
--- a/Libraries/LibLine/KeyCallbackMachine.cpp
+++ b/Libraries/LibLine/KeyCallbackMachine.cpp
@@ -106,6 +106,8 @@ void KeyCallbackMachine::interrupted(Editor& editor)
     m_current_matching_keys.clear();
     if (auto callback = m_key_callbacks.get({ ctrl('C') }); callback.has_value())
         m_should_process_this_key = callback.value()->callback(editor);
+    else
+        m_should_process_this_key = true;
 }
 
 }


### PR DESCRIPTION
Some people really like their ^C's, let's not make them sad.

\<C-c\> @nico @bcoles: .