### PR TITLE
LibGUI+SystemMonitor+MenuApplets: Open the correct tab on click

### DIFF
--- a/Libraries/LibGUI/TabWidget.cpp
+++ b/Libraries/LibGUI/TabWidget.cpp
@@ -113,6 +113,15 @@ void TabWidget::set_active_widget(Widget* widget)
     update_bar();
 }
 
+void TabWidget::set_tab_index(int index)
+{
+    if (m_tabs.at(index).widget == m_active_widget)
+        return;
+    set_active_widget(m_tabs.at(index).widget);
+
+    update_bar();
+}
+
 void TabWidget::resize_event(ResizeEvent& event)
 {
     if (!m_active_widget)

--- a/Libraries/LibGUI/TabWidget.h
+++ b/Libraries/LibGUI/TabWidget.h
@@ -48,6 +48,7 @@ public:
     Widget* active_widget() { return m_active_widget.ptr(); }
     const Widget* active_widget() const { return m_active_widget.ptr(); }
     void set_active_widget(Widget*);
+    void set_tab_index(int);
 
     int bar_height() const { return m_bar_visible ? 21 : 0; }
 

--- a/MenuApplets/Network/main.cpp
+++ b/MenuApplets/Network/main.cpp
@@ -60,7 +60,7 @@ private:
             return;
 
         pid_t child_pid;
-        const char* argv[] = { "SystemMonitor", nullptr };
+        const char* argv[] = { "SystemMonitor", "-t", "network", nullptr };
 
         if ((errno = posix_spawn(&child_pid, "/bin/SystemMonitor", nullptr, nullptr, const_cast<char**>(argv), environ))) {
             perror("posix_spawn");

--- a/MenuApplets/ResourceGraph/main.cpp
+++ b/MenuApplets/ResourceGraph/main.cpp
@@ -131,7 +131,7 @@ private:
         if (event.button() != GUI::MouseButton::Left)
             return;
         pid_t child_pid;
-        const char* argv[] = { "SystemMonitor", nullptr };
+        const char* argv[] = { "SystemMonitor", "-t", "graphs", nullptr };
         if ((errno = posix_spawn(&child_pid, "/bin/SystemMonitor", nullptr, nullptr, const_cast<char**>(argv), environ))) {
             perror("posix_spawn");
         } else {


### PR DESCRIPTION
I also added arguments parsing to SystemMonitor so that MenuApplets can open SystemMonitor with either Graphs or Network tab. And I'm blind or I just didn't notice any TabWidget active tab switching using a tab index, so I added it there.
I did it like this because I'm not really sure how should I switch between them using the set_active_widget method.