### PR TITLE
LibC + LibVT: Implement tgoto() and `@` (ICH) escape sequence (bash fixes)

### DIFF
--- a/Libraries/LibC/termcap.cpp
+++ b/Libraries/LibC/termcap.cpp
@@ -26,6 +26,7 @@
 
 #include <AK/HashMap.h>
 #include <AK/String.h>
+#include <AK/Vector.h>
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -140,9 +141,17 @@ int tgetnum(const char* id)
     ASSERT_NOT_REACHED();
 }
 
+static Vector<char> s_tgoto_buffer;
 char* tgoto([[maybe_unused]] const char* cap, [[maybe_unused]] int col, [[maybe_unused]] int row)
 {
-    ASSERT_NOT_REACHED();
+    auto cap_str = String(cap);
+    cap_str.replace("%p1%d", String::format("%d", col));
+    cap_str.replace("%p2%d", String::format("%d", row));
+
+    s_tgoto_buffer.clear_with_capacity();
+    s_tgoto_buffer.ensure_capacity(cap_str.length());
+    (void)cap_str.copy_characters_to_buffer(s_tgoto_buffer.data(), cap_str.length());
+    return s_tgoto_buffer.data();
 }
 
 int tputs(const char* str, [[maybe_unused]] int affcnt, int (*putc)(int))

--- a/Libraries/LibVT/Terminal.cpp
+++ b/Libraries/LibVT/Terminal.cpp
@@ -704,6 +704,9 @@ void Terminal::execute_escape_sequence(u8 final)
     case 'n':
         DSR(params);
         break;
+    case '@':
+        ICH(params);
+        break;
     default:
         dbgprintf("Terminal::execute_escape_sequence: Unhandled final '%c'\n", final);
         break;
@@ -819,6 +822,28 @@ void Terminal::DSR(const ParamVector& params)
     } else {
         dbg() << "Unknown DSR";
     }
+}
+
+void Terminal::ICH(const ParamVector& params)
+{
+    int num = 0;
+    if (params.size() >= 1) {
+        num = params[0];
+    }
+    if (num == 0)
+        num = 1;
+
+    auto& line = m_lines[m_cursor_row];
+
+    // Move characters after cursor to the right
+    for (int i = line.length() - num; i >= m_cursor_column; --i)
+        line.set_code_point(i + num, line.code_point(i));
+
+    // Fill n characters after cursor with blanks
+    for (int i = 0; i < num; i++)
+        line.set_code_point(m_cursor_column + i, ' ');
+
+    line.set_dirty(true);
 }
 
 void Terminal::on_input(u8 ch)

--- a/Libraries/LibVT/Terminal.h
+++ b/Libraries/LibVT/Terminal.h
@@ -173,6 +173,7 @@ private:
     void IND();
     void RI();
     void DSR(const ParamVector&);
+    void ICH(const ParamVector&);
 
     TerminalClient& m_client;
 


### PR DESCRIPTION
This patch provides a basic implementation of `tgoto()`, and an implementation of the `@` (ICH) escape sequence. This not only removes a crash in `bash` when invoking readline through `^R`, but also appears to be enough to make it function as-expected.