### PR TITLE
FileManager: Remove extra semicolon added by mistake.

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -926,7 +926,6 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
         if (!target_node.is_directory())
             return;
         copy_urls_to_directory(event.mime_data().urls(), target_node.full_path());
-        ;
     };
 
     directory_view.open(initial_location);


### PR DESCRIPTION
I noticed this while watching the Andreas's most recent video. :^)

https://youtu.be/dc726k_my2c?t=812