### PR TITLE
FileManager: Toggle location bar on breadcrumb bar double-click

### DIFF
--- a/Applications/FileManager/main.cpp
+++ b/Applications/FileManager/main.cpp
@@ -634,18 +634,19 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     view_menu.add_separator();
     view_menu.add_action(action_show_dotfiles);
 
+    auto go_to_location_action = GUI::Action::create("Go to location...", { Mod_Ctrl, Key_L }, [&](auto&) {
+        location_toolbar.set_visible(true);
+        breadcrumb_toolbar.set_visible(false);
+        location_textbox.select_all();
+        location_textbox.set_focus(true);
+    });
+
     auto& go_menu = menubar->add_menu("Go");
     go_menu.add_action(go_back_action);
     go_menu.add_action(go_forward_action);
     go_menu.add_action(open_parent_directory_action);
     go_menu.add_action(go_home_action);
-    go_menu.add_action(GUI::Action::create(
-        "Go to location...", { Mod_Ctrl, Key_L }, [&](auto&) {
-            location_toolbar.set_visible(true);
-            breadcrumb_toolbar.set_visible(false);
-            location_textbox.select_all();
-            location_textbox.set_focus(true);
-        }));
+    go_menu.add_action(go_to_location_action);
 
     auto& help_menu = menubar->add_menu("Help");
     help_menu.add_action(GUI::CommonActions::make_about_action("File Manager", GUI::Icon::default_icon("filetype-folder")));
@@ -922,6 +923,10 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
     breadcrumb_bar.on_segment_drag_enter = [&](size_t, GUI::DragEvent& event) {
         if (event.mime_types().contains_slow("text/uri-list"))
             event.accept();
+    };
+
+    breadcrumb_bar.on_doubleclick = [&](const GUI::MouseEvent&) {
+        go_to_location_action->activate();
     };
 
     tree_view.on_drop = [&](const GUI::ModelIndex& index, const GUI::DropEvent& event) {

--- a/Libraries/LibGUI/BreadcrumbBar.cpp
+++ b/Libraries/LibGUI/BreadcrumbBar.cpp
@@ -139,4 +139,10 @@ void BreadcrumbBar::set_selected_segment(Optional<size_t> index)
     segment.button->set_checked(true);
 }
 
+void BreadcrumbBar::doubleclick_event(MouseEvent& event)
+{
+    if (on_doubleclick)
+        on_doubleclick(event);
+}
+
 }

--- a/Libraries/LibGUI/BreadcrumbBar.h
+++ b/Libraries/LibGUI/BreadcrumbBar.h
@@ -48,6 +48,7 @@ public:
     Function<void(size_t index)> on_segment_click;
     Function<void(size_t index, DropEvent&)> on_segment_drop;
     Function<void(size_t index, DragEvent&)> on_segment_drag_enter;
+    Function<void(MouseEvent& event)> on_doubleclick;
 
 private:
     BreadcrumbBar();
@@ -61,6 +62,8 @@ private:
 
     Vector<Segment> m_segments;
     Optional<size_t> m_selected_segment;
+
+    virtual void doubleclick_event(GUI::MouseEvent&) override;
 };
 
 }


### PR DESCRIPTION
Howdy all. One thing that immediately struck me about the new breadcrumb bar in FileManager is that double-clicking did not result in toggling to a location bar - I'm not sure where my mind's picked it up, but clicking/double clicking whitespace to toggle seems like a 'natural' behavior that I more or less expect from a breadcrumb bar.

I thought it would be cool to implement this, but do be warned this would be my first time changing the interface of a LibGUI component, so please please be gentle. 🤓 I added an 'on_toggle' event to BreadcrumbBar which is fired when the underlying widget is double-clicked. Double-clicking a BreadcrumbBar Button does not fire the event, only double-clicking the whitespace in the bar does. In FileManager, I separated out the 'go to location' action from an inline instantiation into a local definition (`go_to_location_action`) in the `run_in_windowed_mode` method, following logically similar actions like `copy_action`. The `on_toggle` event on BreadcrumbBar is then attached to, calling `activate` on `go_to_location_action` when `on_toggle` is fired. 

Please do let me know if there's anything silly I've done :) Cheers