### PR TITLE
Meta: Add flake8 to lint python files

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -198,3 +198,6 @@ jobs:
       working-directory: ${{ github.workspace }}/Build/Meta/Lagom
       # FIXME: Fix tests on MacOS
       run: DISABLE_DBG_OUTPUT=1 ./test-js || true
+    - name: Run LibCompress tests
+      working-directory: ${{ github.workspace }}/Build/Meta/Lagom
+      run: DISABLE_DBG_OUTPUT=1 ./test-compress

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
 
     # === OS SETUP ===
 
@@ -23,7 +24,7 @@ jobs:
     - name: Purge interfering packages
       # Remove GCC 9 and clang-format 10 (installed by default)
       run: sudo apt-get purge -y gcc-9 g++-9 libstdc++-9-dev clang-format-10
-    - name: Install dependencies
+    - name: Install c++ dependencies
       # These packages are already part of the ubuntu-20.04 image:
       # cmake gcc-10 g++-10 shellcheck libgmp-dev
       # These aren't:
@@ -34,12 +35,16 @@ jobs:
         sudo apt-get install clang-format-11 libstdc++-10-dev libmpfr-dev libmpc-dev ninja-build npm
       # If we ever do any qemu-emulation on Github Actions, we should re-enable this:
       # e2fsprogs qemu-system-i386 qemu-utils
-    - name: Install prettier
-      run: sudo npm install -g prettier
     - name: Use GCC 10 instead
       run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+    - name: Install js dependencies
+      run: sudo npm install -g prettier
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 requests
     - name: Check versions
-      run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-11 --version; prettier --version; python --version; python3 --version; ninja --version
+      run: set +e; g++ --version; g++-10 --version; clang-format-11 --version; prettier --version; python --version; python3 --version; ninja --version; flake8 --version
 
     # === PREPARE FOR BUILDING ===
 

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -21,7 +21,8 @@ for cmd in \
         Meta/lint-executable-resources.sh \
         Meta/lint-ipc-ids.sh \
         Meta/lint-shell-scripts.sh \
-        Meta/lint-prettier.sh; do
+        Meta/lint-prettier.sh \
+        Meta/lint-python.sh; do
     echo "Running ${cmd}... "
     if "${cmd}" "$@"; then
         echo -e "[${GREEN}OK${NC}]: ${cmd}"

--- a/Meta/lint-python.sh
+++ b/Meta/lint-python.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+cd "${script_path}/.." || exit 1
+
+if ! command -v flake8 >/dev/null 2>&1 ; then
+    echo "flake8 is not available. Either skip this script, or install flake8."
+    exit 1
+fi
+
+if [ "$#" -eq "0" ]; then
+    mapfile -t files < <(
+        git ls-files '*.py'
+    )
+else
+    files=()
+    for file in "$@"; do
+        if [[ "${file}" == *".py" ]]; then
+            files+=("${file}")
+        fi
+    done
+fi
+
+if (( ${#files[@]} )); then
+    flake8 "${files[@]}" --max-line-length=120
+else
+    echo "No py files to check."
+fi


### PR DESCRIPTION
Quick copy paste job from the prettier lint shell script to be a python one. Not sure how strictly required that is, because `flake8 .` will recursively find all python files itself? There's currently only like two python files anyway.

Make sure that flake8 is installed in the CI image.

Also, make sure to run the LibCompress tests in MacOS CI.

I have a branch on my fork that tries to do a matrix job, but something about my implementation broke the IRC notifications...
https://github.com/ADKaster/serenity/blob/ci-matrix/.github/workflows/cmake.yml#L135