### PR TITLE
TextEditor: Implemented word wrapping

### DIFF
--- a/Userland/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Userland/Applications/TextEditor/TextEditorWidget.cpp
@@ -70,7 +70,6 @@ TextEditorWidget::TextEditorWidget()
     m_editor = *find_descendant_of_type_named<GUI::TextEditor>("editor");
     m_editor->set_ruler_visible(true);
     m_editor->set_automatic_indentation_enabled(true);
-    m_editor->set_line_wrapping_enabled(true);
     m_editor->set_editing_engine(make<GUI::RegularEditingEngine>());
 
     m_editor->on_change = [this] {
@@ -364,11 +363,6 @@ TextEditorWidget::TextEditorWidget()
         m_save_as_action->activate();
     });
 
-    m_line_wrapping_setting_action = GUI::Action::create_checkable("Line wrapping", [&](auto& action) {
-        m_editor->set_line_wrapping_enabled(action.is_checked());
-    });
-    m_line_wrapping_setting_action->set_checked(m_editor->is_line_wrapping_enabled());
-
     auto menubar = GUI::MenuBar::construct();
     auto& app_menu = menubar->add_menu("Text Editor");
     app_menu.add_action(*m_new_action);
@@ -434,7 +428,29 @@ TextEditorWidget::TextEditorWidget()
         }));
 
     view_menu.add_separator();
-    view_menu.add_action(*m_line_wrapping_setting_action);
+
+    m_wrapping_mode_actions.set_exclusive(true);
+    auto& wrapping_mode_menu = view_menu.add_submenu("Wrapping mode");
+    m_no_wrapping_action = GUI::Action::create_checkable("No wrapping", [&](auto&) {
+        m_editor->set_wrapping_mode(GUI::TextEditor::WrappingMode::NoWrap);
+    });
+    m_wrap_anywhere_action = GUI::Action::create_checkable("Wrap anywhere", [&](auto&) {
+        m_editor->set_wrapping_mode(GUI::TextEditor::WrappingMode::WrapAnywhere);
+    });
+    m_wrap_at_words_action = GUI::Action::create_checkable("Wrap at words", [&](auto&) {
+        m_editor->set_wrapping_mode(GUI::TextEditor::WrappingMode::WrapAtWords);
+    });
+
+    m_wrapping_mode_actions.add_action(*m_no_wrapping_action);
+    m_wrapping_mode_actions.add_action(*m_wrap_anywhere_action);
+    m_wrapping_mode_actions.add_action(*m_wrap_at_words_action);
+
+    wrapping_mode_menu.add_action(*m_no_wrapping_action);
+    wrapping_mode_menu.add_action(*m_wrap_anywhere_action);
+    wrapping_mode_menu.add_action(*m_wrap_at_words_action);
+
+    m_wrap_anywhere_action->set_checked(true);
+
     view_menu.add_separator();
     view_menu.add_action(*m_no_preview_action);
     view_menu.add_action(*m_markdown_preview_action);

--- a/Userland/Applications/TextEditor/TextEditorWidget.h
+++ b/Userland/Applications/TextEditor/TextEditorWidget.h
@@ -75,7 +75,6 @@ private:
     RefPtr<GUI::Action> m_save_action;
     RefPtr<GUI::Action> m_save_as_action;
     RefPtr<GUI::Action> m_find_replace_action;
-    RefPtr<GUI::Action> m_line_wrapping_setting_action;
     RefPtr<GUI::Action> m_vim_emulation_setting_action;
 
     RefPtr<GUI::Action> m_find_next_action;
@@ -103,6 +102,11 @@ private:
     RefPtr<GUI::Widget> m_find_replace_widget;
     RefPtr<GUI::Widget> m_find_widget;
     RefPtr<GUI::Widget> m_replace_widget;
+
+    GUI::ActionGroup m_wrapping_mode_actions;
+    RefPtr<GUI::Action> m_no_wrapping_action;
+    RefPtr<GUI::Action> m_wrap_anywhere_action;
+    RefPtr<GUI::Action> m_wrap_at_words_action;
 
     GUI::ActionGroup syntax_actions;
     RefPtr<GUI::Action> m_plain_text_highlight;

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -56,7 +56,6 @@ EditorWrapper::EditorWrapper()
 
     m_editor = add<Editor>();
     m_editor->set_ruler_visible(true);
-    m_editor->set_line_wrapping_enabled(true);
     m_editor->set_automatic_indentation_enabled(true);
 
     m_editor->on_cursor_change = [this] {

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -852,13 +852,30 @@ void HackStudioWidget::create_edit_menubar(GUI::MenuBar& menubar)
 
     edit_menu.add_separator();
 
-    auto line_wrapping_action = GUI::Action::create_checkable("Line wrapping", [this](auto& action) {
-        for (auto& wrapper : m_all_editor_wrappers) {
-            wrapper.editor().set_line_wrapping_enabled(action.is_checked());
-        }
+    m_wrapping_mode_actions.set_exclusive(true);
+    auto& wrapping_mode_menu = edit_menu.add_submenu("Wrapping mode");
+    m_no_wrapping_action = GUI::Action::create_checkable("No wrapping", [&](auto&) {
+        for (auto& wrapper : m_all_editor_wrappers)
+            wrapper.editor().set_wrapping_mode(GUI::TextEditor::WrappingMode::NoWrap);
     });
-    line_wrapping_action->set_checked(current_editor().is_line_wrapping_enabled());
-    edit_menu.add_action(line_wrapping_action);
+    m_wrap_anywhere_action = GUI::Action::create_checkable("Wrap anywhere", [&](auto&) {
+        for (auto& wrapper : m_all_editor_wrappers)
+            wrapper.editor().set_wrapping_mode(GUI::TextEditor::WrappingMode::WrapAnywhere);
+    });
+    m_wrap_at_words_action = GUI::Action::create_checkable("Wrap at words", [&](auto&) {
+        for (auto& wrapper : m_all_editor_wrappers)
+            wrapper.editor().set_wrapping_mode(GUI::TextEditor::WrappingMode::WrapAtWords);
+    });
+
+    m_wrapping_mode_actions.add_action(*m_no_wrapping_action);
+    m_wrapping_mode_actions.add_action(*m_wrap_anywhere_action);
+    m_wrapping_mode_actions.add_action(*m_wrap_at_words_action);
+
+    wrapping_mode_menu.add_action(*m_no_wrapping_action);
+    wrapping_mode_menu.add_action(*m_wrap_anywhere_action);
+    wrapping_mode_menu.add_action(*m_wrap_at_words_action);
+
+    m_wrap_anywhere_action->set_checked(true);
 
     edit_menu.add_separator();
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -39,6 +39,7 @@
 #include "Project.h"
 #include "ProjectFile.h"
 #include "TerminalWrapper.h"
+#include <LibGUI/ActionGroup.h>
 #include <LibGUI/ScrollBar.h>
 #include <LibGUI/Splitter.h>
 #include <LibGUI/Widget.h>
@@ -167,5 +168,10 @@ private:
     RefPtr<GUI::Action> m_debug_action;
     RefPtr<GUI::Action> m_build_action;
     RefPtr<GUI::Action> m_run_action;
+
+    GUI::ActionGroup m_wrapping_mode_actions;
+    RefPtr<GUI::Action> m_no_wrapping_action;
+    RefPtr<GUI::Action> m_wrap_anywhere_action;
+    RefPtr<GUI::Action> m_wrap_at_words_action;
 };
 }

--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -244,7 +244,7 @@ void EditingEngine::move_to_line_beginning(const KeyEvent& event)
 {
     TextPosition new_cursor;
     m_editor->toggle_selection_if_needed_for_event(event.shift());
-    if (m_editor->is_line_wrapping_enabled()) {
+    if (m_editor->is_wrapping_enabled()) {
         // FIXME: Replicate the first_nonspace_column behavior in wrapping mode.
         auto home_position = m_editor->cursor_content_rect().location().translated(-m_editor->width(), 0);
         new_cursor = m_editor->text_position_at_content_position(home_position);
@@ -262,7 +262,7 @@ void EditingEngine::move_to_line_beginning(const KeyEvent& event)
 void EditingEngine::move_to_line_end(const KeyEvent& event)
 {
     TextPosition new_cursor;
-    if (m_editor->is_line_wrapping_enabled()) {
+    if (m_editor->is_wrapping_enabled()) {
         auto end_position = m_editor->cursor_content_rect().location().translated(m_editor->width(), 0);
         new_cursor = m_editor->text_position_at_content_position(end_position);
     } else {
@@ -274,13 +274,13 @@ void EditingEngine::move_to_line_end(const KeyEvent& event)
 
 void EditingEngine::move_one_up(const KeyEvent& event)
 {
-    if (m_editor->cursor().line() > 0 || m_editor->is_line_wrapping_enabled()) {
+    if (m_editor->cursor().line() > 0 || m_editor->is_wrapping_enabled()) {
         if (event.ctrl() && event.shift()) {
             move_selected_lines_up();
             return;
         }
         TextPosition new_cursor;
-        if (m_editor->is_line_wrapping_enabled()) {
+        if (m_editor->is_wrapping_enabled()) {
             auto position_above = m_editor->cursor_content_rect().location().translated(0, -m_editor->line_height());
             new_cursor = m_editor->text_position_at_content_position(position_above);
         } else {
@@ -295,13 +295,13 @@ void EditingEngine::move_one_up(const KeyEvent& event)
 
 void EditingEngine::move_one_down(const KeyEvent& event)
 {
-    if (m_editor->cursor().line() < (m_editor->line_count() - 1) || m_editor->is_line_wrapping_enabled()) {
+    if (m_editor->cursor().line() < (m_editor->line_count() - 1) || m_editor->is_wrapping_enabled()) {
         if (event.ctrl() && event.shift()) {
             move_selected_lines_down();
             return;
         }
         TextPosition new_cursor;
-        if (m_editor->is_line_wrapping_enabled()) {
+        if (m_editor->is_wrapping_enabled()) {
             new_cursor = m_editor->text_position_at_content_position(m_editor->cursor_content_rect().location().translated(0, m_editor->line_height()));
             auto position_below = m_editor->cursor_content_rect().location().translated(0, m_editor->line_height());
             new_cursor = m_editor->text_position_at_content_position(position_below);
@@ -317,11 +317,11 @@ void EditingEngine::move_one_down(const KeyEvent& event)
 
 void EditingEngine::move_up(const KeyEvent& event, double page_height_factor)
 {
-    if (m_editor->cursor().line() > 0 || m_editor->is_line_wrapping_enabled()) {
+    if (m_editor->cursor().line() > 0 || m_editor->is_wrapping_enabled()) {
         int pixels = (int)(m_editor->visible_content_rect().height() * page_height_factor);
 
         TextPosition new_cursor;
-        if (m_editor->is_line_wrapping_enabled()) {
+        if (m_editor->is_wrapping_enabled()) {
             auto position_above = m_editor->cursor_content_rect().location().translated(0, -pixels);
             new_cursor = m_editor->text_position_at_content_position(position_above);
         } else {
@@ -337,10 +337,10 @@ void EditingEngine::move_up(const KeyEvent& event, double page_height_factor)
 
 void EditingEngine::move_down(const KeyEvent& event, double page_height_factor)
 {
-    if (m_editor->cursor().line() < (m_editor->line_count() - 1) || m_editor->is_line_wrapping_enabled()) {
+    if (m_editor->cursor().line() < (m_editor->line_count() - 1) || m_editor->is_wrapping_enabled()) {
         int pixels = (int)(m_editor->visible_content_rect().height() * page_height_factor);
         TextPosition new_cursor;
-        if (m_editor->is_line_wrapping_enabled()) {
+        if (m_editor->is_wrapping_enabled()) {
             auto position_below = m_editor->cursor_content_rect().location().translated(0, pixels);
             new_cursor = m_editor->text_position_at_content_position(position_below);
         } else {

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -56,6 +56,12 @@ public:
         DisplayOnly
     };
 
+    enum WrappingMode {
+        NoWrap,
+        WrapAnywhere,
+        WrapAtWords
+    };
+
     virtual ~TextEditor() override;
 
     const TextDocument& document() const { return *m_document; }
@@ -80,8 +86,9 @@ public:
 
     virtual int soft_tab_width() const final { return m_soft_tab_width; }
 
-    bool is_line_wrapping_enabled() const { return m_line_wrapping_enabled; }
-    void set_line_wrapping_enabled(bool);
+    WrappingMode wrapping_mode() const { return m_wrapping_mode; }
+    bool is_wrapping_enabled() const { return m_wrapping_mode != WrappingMode::NoWrap; }
+    void set_wrapping_mode(WrappingMode);
 
     Gfx::TextAlignment text_alignment() const { return m_text_alignment; }
     void set_text_alignment(Gfx::TextAlignment);
@@ -299,7 +306,7 @@ private:
     bool m_ruler_visible { false };
     bool m_has_pending_change_notification { false };
     bool m_automatic_indentation_enabled { false };
-    bool m_line_wrapping_enabled { false };
+    WrappingMode m_wrapping_mode { WrappingMode::WrapAnywhere };
     bool m_has_visible_list { false };
     bool m_visualize_trailing_whitespace { true };
     int m_line_spacing { 4 };


### PR DESCRIPTION
Add a new wrapping mode to the TextEditor that will wrap lines at the
spaces between words.

Replace the previous menubar checkbox 'Wrapping Mode' in HackStudio and
the TextEditor with an exclusive submenu which allows switching between
'No wrapping', 'Wrap anywhere' and 'Wrap at words'. 'Wrap anywhere' (the
new 'Wrap lines') is still the default mode.

Setting the wrapping mode in the constructors of the TextEditorWidget
and HackStudio has been removed, it is now set when constructing the
menubar actions.

Closes #4788 