### PR TITLE
WindowServer: Don't enter invalid state when using resize corner.

### DIFF
--- a/Services/WindowServer/WindowManager.cpp
+++ b/Services/WindowServer/WindowManager.cpp
@@ -485,6 +485,8 @@ void WindowManager::start_window_resize(Window& window, const Gfx::IntPoint& pos
     m_resize_origin = position;
     m_resize_window_original_rect = window.rect();
 
+    m_active_input_tracking_window = nullptr;
+
     window.invalidate();
 
     if (hot_area_row == 0 || hot_area_column == 0) {


### PR DESCRIPTION
After resizing a window using its resize corner an extra click is required to return the WM to a correct state.

After initiating a resize of a window using its resize corner, the WM enters an invalid state where the same window is both being resized and marked as being the active input tracking window. When a mouse up event arrives, only the resize operation is ended, but the window remains marked as the active input tracking window.

This patch makes sure the WM does not enter this state where it's doing two things at once.