### PR TITLE
LibJS: Implement String.prototype.split

### DIFF
--- a/Libraries/LibJS/Runtime/StringPrototype.h
+++ b/Libraries/LibJS/Runtime/StringPrototype.h
@@ -61,6 +61,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(concat);
     JS_DECLARE_NATIVE_FUNCTION(includes);
     JS_DECLARE_NATIVE_FUNCTION(slice);
+    JS_DECLARE_NATIVE_FUNCTION(split);
     JS_DECLARE_NATIVE_FUNCTION(last_index_of);
 
     JS_DECLARE_NATIVE_FUNCTION(symbol_iterator);

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -470,6 +470,12 @@ i32 Value::as_i32() const
     return static_cast<i32>(as_double());
 }
 
+u32 Value::as_u32() const
+{
+    ASSERT(as_double() >= 0);
+    return min((double)as_i32(), MAX_U32);
+}
+
 size_t Value::as_size_t() const
 {
     ASSERT(as_double() >= 0);
@@ -492,6 +498,19 @@ i32 Value::to_i32(GlobalObject& global_object) const
     if (number.is_nan() || number.is_infinity())
         return 0;
     return number.as_i32();
+}
+
+u32 Value::to_u32(GlobalObject& global_object) const
+{
+    // 7.1.7 ToUint32, https://tc39.es/ecma262/#sec-touint32
+    auto number = to_number(global_object);
+    if (global_object.vm().exception())
+        return INVALID;
+    if (number.is_nan() || number.is_infinity())
+        return 0;
+    if (number.as_double() <= 0)
+        return 0;
+    return number.as_u32();
 }
 
 size_t Value::to_size_t(GlobalObject& global_object) const

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -36,6 +36,8 @@
 
 // 2 ** 53 - 1
 static constexpr double MAX_ARRAY_LIKE_INDEX = 9007199254740991.0;
+// 2 ** 32 - 1
+static constexpr double MAX_U32 = 4294967295.0;
 
 namespace JS {
 
@@ -241,6 +243,7 @@ public:
     Function& as_function();
 
     i32 as_i32() const;
+    u32 as_u32() const;
     size_t as_size_t() const;
 
     String to_string(GlobalObject&, bool legacy_null_to_empty_string = false) const;
@@ -252,6 +255,7 @@ public:
     BigInt* to_bigint(GlobalObject&) const;
     double to_double(GlobalObject&) const;
     i32 to_i32(GlobalObject&) const;
+    u32 to_u32(GlobalObject&) const;
     size_t to_size_t(GlobalObject&) const;
     size_t to_length(GlobalObject&) const;
     size_t to_index(GlobalObject&) const;

--- a/Libraries/LibJS/Tests/builtins/String/String.prototype.split.js
+++ b/Libraries/LibJS/Tests/builtins/String/String.prototype.split.js
@@ -1,0 +1,35 @@
+test("basic functionality", () => {
+    expect(String.prototype.split).toHaveLength(2);
+
+    expect("hello friends".split()).toEqual(["hello friends"]);
+    expect("hello friends".split("")).toEqual([
+        "h",
+        "e",
+        "l",
+        "l",
+        "o",
+        " ",
+        "f",
+        "r",
+        "i",
+        "e",
+        "n",
+        "d",
+        "s",
+    ]);
+    expect("hello friends".split(" ")).toEqual(["hello", "friends"]);
+
+    expect("a,b,c,d".split(",")).toEqual(["a", "b", "c", "d"]);
+    expect(",a,b,c,d".split(",")).toEqual(["", "a", "b", "c", "d"]);
+    expect("a,b,c,d,".split(",")).toEqual(["a", "b", "c", "d", ""]);
+    expect("a,b,,c,d".split(",")).toEqual(["a", "b", "", "c", "d"]);
+    expect(",a,b,,c,d,".split(",")).toEqual(["", "a", "b", "", "c", "d", ""]);
+    expect(",a,b,,,c,d,".split(",,")).toEqual([",a,b", ",c,d,"]);
+});
+
+test("limits", () => {
+    expect("a b c d".split(" ", 0)).toEqual([]);
+    expect("a b c d".split(" ", 1)).toEqual(["a"]);
+    expect("a b c d".split(" ", 3)).toEqual(["a", "b", "c"]);
+    expect("a b c d".split(" ", 100)).toEqual(["a", "b", "c", "d"]);
+});


### PR DESCRIPTION
This adds a String.prototype.split implementation modelled after 
ECMA262 specification. 

There is a tiny kludge for when the separator is an empty string. 
Basic tests and visiting google.com prove that this is working. 

I will work on the RegExp support tomorrow :^)
