### PR TITLE
TestTypeTraits: Fix incorrectly namespaced nullptr_t

### DIFF
--- a/AK/Tests/TestTypeTraits.cpp
+++ b/AK/Tests/TestTypeTraits.cpp
@@ -58,7 +58,7 @@ struct Empty {
 TEST_CASE(FundamentalTypeClassification)
 {
     EXPECT_TRAIT_TRUE(IsVoid, void);
-    EXPECT_TRAIT_FALSE(IsVoid, int, Empty, nullptr_t);
+    EXPECT_TRAIT_FALSE(IsVoid, int, Empty, std::nullptr_t);
 
     EXPECT_TRAIT_TRUE(IsNullPointer, std::nullptr_t);
     EXPECT_TRAIT_FALSE(IsNullPointer, void, int, Empty, decltype(0));


### PR DESCRIPTION
Problem:
- Clang ToT fails to build `AK/Tests/TestTypeTraits.cpp` because
  `nullptr_t` is missing the `std` namespace qualifier.

Solution:
- Prepend the namespace qualifier.