### PR TITLE
Meta: Only complain about linter tools if relevant files have changed

### DIFF
--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -5,32 +5,6 @@ set -e
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.." || exit 1
 
-CLANG_FORMAT=false
-if command -v clang-format-11 >/dev/null 2>&1 ; then
-    CLANG_FORMAT=clang-format-11
-elif command -v clang-format >/dev/null 2>&1 ; then
-    CLANG_FORMAT=clang-format
-    if ! "${CLANG_FORMAT}" --version | grep -qF ' 11.' ; then
-        echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 11."
-        echo "It is very likely that the resulting changes are not what you wanted."
-    fi
-else
-    echo "clang-format-10 is not available. Either skip this script, or install clang-format-11."
-    echo "(If you install a package 'clang-format', please make sure it's version 11.)"
-    exit 1
-fi
-
-if [ "$#" -gt "0" ] && [ "x--overwrite-inplace" = "x$1" ] ; then
-    true # The only way to run this script.
-else
-    # Note that this branch also covers --help, -h, -help, -?, etc.
-    echo "USAGE: $0 --overwrite-inplace"
-    echo "The argument is necessary to make you aware that this *will* overwrite your local files."
-    exit 1
-fi
-
-echo "Using ${CLANG_FORMAT}"
-
 if [ "$#" -eq "1" ]; then
     mapfile -t files < <(
         git ls-files -- \
@@ -55,6 +29,32 @@ else
 fi
 
 if (( ${#files[@]} )); then
+    CLANG_FORMAT=false
+    if command -v clang-format-11 >/dev/null 2>&1 ; then
+        CLANG_FORMAT=clang-format-11
+    elif command -v clang-format >/dev/null 2>&1 ; then
+        CLANG_FORMAT=clang-format
+        if ! "${CLANG_FORMAT}" --version | grep -qF ' 11.' ; then
+            echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 11."
+            echo "It is very likely that the resulting changes are not what you wanted."
+        fi
+    else
+        echo "clang-format-11 is not available, but C or C++ files need linting! Either skip this script, or install clang-format-11."
+        echo "(If you install a package 'clang-format', please make sure it's version 11.)"
+        exit 1
+    fi
+
+    if [ "$#" -gt "0" ] && [ "x--overwrite-inplace" = "x$1" ] ; then
+        true # The only way to run this script.
+    else
+        # Note that this branch also covers --help, -h, -help, -?, etc.
+        echo "USAGE: $0 --overwrite-inplace"
+        echo "The argument is necessary to make you aware that this *will* overwrite your local files."
+        exit 1
+    fi
+
+    echo "Using ${CLANG_FORMAT}"
+
     "${CLANG_FORMAT}" -style=file -i "${files[@]}"
     echo "Maybe some files have changed. Sorry, but clang-format doesn't indicate what happened."
 else

--- a/Meta/lint-prettier.sh
+++ b/Meta/lint-prettier.sh
@@ -5,16 +5,6 @@ set -e
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.." || exit 1
 
-if ! command -v prettier >/dev/null 2>&1 ; then
-    echo "prettier is not available. Either skip this script, or install prettier."
-    exit 1
-fi
-
-if ! prettier --version | grep -qF '2.' ; then
-    echo "You are using '$(prettier --version)', which appears to not be prettier 2."
-    exit 1
-fi
-
 if [ "$#" -eq "0" ]; then
     mapfile -t files < <(
         git ls-files \
@@ -32,6 +22,16 @@ else
 fi
 
 if (( ${#files[@]} )); then
+    if ! command -v prettier >/dev/null 2>&1 ; then
+        echo "prettier is not available, but JS files need linting! Either skip this script, or install prettier."
+        exit 1
+    fi
+
+    if ! prettier --version | grep -qF '2.' ; then
+        echo "You are using '$(prettier --version)', which appears to not be prettier 2."
+        exit 1
+    fi
+
     prettier --check "${files[@]}"
 else
     echo "No .js files to check."

--- a/Meta/lint-python.sh
+++ b/Meta/lint-python.sh
@@ -5,11 +5,6 @@ set -e
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.." || exit 1
 
-if ! command -v flake8 >/dev/null 2>&1 ; then
-    echo "flake8 is not available. Either skip this script, or install flake8."
-    exit 1
-fi
-
 if [ "$#" -eq "0" ]; then
     mapfile -t files < <(
         git ls-files '*.py'
@@ -24,6 +19,11 @@ else
 fi
 
 if (( ${#files[@]} )); then
+    if ! command -v flake8 >/dev/null 2>&1 ; then
+        echo "flake8 is not available, but python files need linting! Either skip this script, or install flake8."
+        exit 1
+    fi
+
     flake8 "${files[@]}" --max-line-length=120
 else
     echo "No py files to check."

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -5,11 +5,6 @@ set -eo pipefail
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path/.."
 
-if ! command -v shellcheck &>/dev/null ; then
-    echo "shellcheck is not available. Either skip this script, or install shellcheck."
-    exit 1
-fi
-
 if [ "$#" -eq "0" ]; then
     mapfile -t files < <(
         git ls-files -- \
@@ -28,6 +23,11 @@ else
 fi
 
 if (( ${#files[@]} )); then
+    if ! command -v shellcheck &>/dev/null ; then
+        echo "shellcheck is not available, but shell files need linting! Either skip this script, or install shellcheck."
+        exit 1
+    fi
+
     shellcheck "${files[@]}"
 else
     echo "No .sh files to check."


### PR DESCRIPTION
From the last comment on my previous PR, move the checks for linter tools into the if statement that checks if there's any related files to check.

Result of this is that if you only ever edit shell scripts (why...) you would only need `shellcheck` installed in order to use the pre-commit hook, rather than shellcheck, prettier, clang-format-11, and flake8.

cc @linusg @BenWiederhake 