### PR TITLE
LibLine: C-V<key> / LibVT: Make the "Negative" attribute work

### DIFF
--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -274,11 +274,11 @@ static inline u8 attribute_to_vga(const VT::Attribute& attribute)
 
     // Background color
     vga_attr &= ~0x70;
-    vga_attr |= xterm_color_to_vga(attribute.background_color) << 8;
+    vga_attr |= xterm_color_to_vga(attribute.effective_background_color()) << 8;
 
     // Foreground color
     vga_attr &= ~0x7;
-    vga_attr |= xterm_color_to_vga(attribute.foreground_color);
+    vga_attr |= xterm_color_to_vga(attribute.effective_foreground_color());
 
     return vga_attr;
 }

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, the SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -261,7 +262,7 @@ private:
         Title = 9,
     };
 
-    static VTState actual_rendered_string_length_step(StringMetrics&, size_t& length, u32, u32, VTState);
+    static VTState actual_rendered_string_length_step(StringMetrics&, size_t, StringMetrics::LineMetrics& current_line, u32, u32, VTState);
 
     enum LoopExitCode {
         Exit = 0,
@@ -456,6 +457,7 @@ private:
 
     enum class InputState {
         Free,
+        Verbatim,
         GotEscape,
         CSIExpectParameter,
         CSIExpectIntermediate,

--- a/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, The SerenityOS developers.
+ * Copyright (c) 2020-2021, The SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,11 +52,11 @@ void XtermSuggestionDisplay::display(const SuggestionManager& manager)
     VT::restore_cursor();
 
     auto spans_entire_line { false };
-    Vector<size_t> lines;
+    Vector<StringMetrics::LineMetrics> lines;
     for (size_t i = 0; i < m_prompt_lines_at_suggestion_initiation - 1; ++i)
-        lines.append(0);
-    lines.append(longest_suggestion_length);
-    auto max_line_count = StringMetrics { move(lines) }.lines_with_addition({ { 0 } }, m_num_columns);
+        lines.append({ {}, 0 });
+    lines.append({ {}, longest_suggestion_length });
+    auto max_line_count = StringMetrics { move(lines) }.lines_with_addition({ { { {}, 0 } } }, m_num_columns);
     if (longest_suggestion_length >= m_num_columns - 2) {
         spans_entire_line = true;
         // We should make enough space for the biggest entry in

--- a/Libraries/LibVT/Line.cpp
+++ b/Libraries/LibVT/Line.cpp
@@ -104,9 +104,9 @@ bool Line::has_only_one_background_color() const
     if (!m_length)
         return true;
     // FIXME: Cache this result?
-    auto color = m_attributes[0].background_color;
+    auto color = m_attributes[0].effective_background_color();
     for (size_t i = 1; i < m_length; ++i) {
-        if (m_attributes[i].background_color != color)
+        if (m_attributes[i].effective_background_color() != color)
             return false;
     }
     return true;

--- a/Libraries/LibVT/Line.h
+++ b/Libraries/LibVT/Line.h
@@ -47,6 +47,9 @@ struct Attribute {
     u32 foreground_color;
     u32 background_color;
 
+    u32 effective_background_color() const { return flags & Negative ? foreground_color : background_color; }
+    u32 effective_foreground_color() const { return flags & Negative ? background_color : foreground_color; }
+
     String href;
     String href_id;
 

--- a/Libraries/LibVT/TerminalWidget.cpp
+++ b/Libraries/LibVT/TerminalWidget.cpp
@@ -343,7 +343,7 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
         if (visual_beep_active)
             painter.clear_rect(row_rect, Color::Red);
         else if (has_only_one_background_color)
-            painter.clear_rect(row_rect, color_from_rgb(line.attributes()[0].background_color).with_alpha(m_opacity));
+            painter.clear_rect(row_rect, color_from_rgb(line.attributes()[0].effective_background_color()).with_alpha(m_opacity));
 
         for (size_t column = 0; column < line.length(); ++column) {
             bool should_reverse_fill_for_cursor_or_selection = m_cursor_blink_state
@@ -354,9 +354,9 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
             auto attribute = line.attributes()[column];
             auto character_rect = glyph_rect(visual_row, column);
             auto cell_rect = character_rect.inflated(0, m_line_spacing);
-            auto text_color = color_from_rgb(should_reverse_fill_for_cursor_or_selection ? attribute.background_color : attribute.foreground_color);
+            auto text_color = color_from_rgb(should_reverse_fill_for_cursor_or_selection ? attribute.effective_background_color() : attribute.effective_foreground_color());
             if ((!visual_beep_active && !has_only_one_background_color) || should_reverse_fill_for_cursor_or_selection) {
-                painter.clear_rect(cell_rect, color_from_rgb(should_reverse_fill_for_cursor_or_selection ? attribute.foreground_color : attribute.background_color).with_alpha(m_opacity));
+                painter.clear_rect(cell_rect, color_from_rgb(should_reverse_fill_for_cursor_or_selection ? attribute.effective_foreground_color() : attribute.effective_background_color()).with_alpha(m_opacity));
             }
 
             enum class UnderlineStyle {
@@ -415,7 +415,7 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
                 && visual_row == row_with_cursor
                 && column == m_terminal.cursor_column();
             should_reverse_fill_for_cursor_or_selection |= selection_contains({ first_row_from_history + visual_row, (int)column });
-            auto text_color = color_from_rgb(should_reverse_fill_for_cursor_or_selection ? attribute.background_color : attribute.foreground_color);
+            auto text_color = color_from_rgb(should_reverse_fill_for_cursor_or_selection ? attribute.effective_background_color() : attribute.effective_foreground_color());
             u32 code_point = line.code_point(column);
 
             if (code_point == ' ')
@@ -440,7 +440,7 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
         auto& cursor_line = m_terminal.line(first_row_from_history + row_with_cursor);
         if (m_terminal.cursor_row() < (m_terminal.rows() - rows_from_history)) {
             auto cell_rect = glyph_rect(row_with_cursor, m_terminal.cursor_column()).inflated(0, m_line_spacing);
-            painter.draw_rect(cell_rect, color_from_rgb(cursor_line.attributes()[m_terminal.cursor_column()].foreground_color));
+            painter.draw_rect(cell_rect, color_from_rgb(cursor_line.attributes()[m_terminal.cursor_column()].effective_foreground_color()));
         }
     }
 }

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -1484,7 +1484,7 @@ void Shell::bring_cursor_to_beginning_of_a_line() const
     String eol_mark = getenv("PROMPT_EOL_MARK");
     if (eol_mark.is_null())
         eol_mark = default_mark;
-    size_t eol_mark_length = Line::Editor::actual_rendered_string_metrics(eol_mark).line_lengths.last();
+    size_t eol_mark_length = Line::Editor::actual_rendered_string_metrics(eol_mark).line_metrics.last().total_length();
     if (eol_mark_length >= ws.ws_col) {
         eol_mark = default_mark;
         eol_mark_length = 1;


### PR DESCRIPTION
A diff of 163 lines just to do:
![shot-2021-01-10_16-46-37](https://user-images.githubusercontent.com/14001776/104124009-8f8a3800-5363-11eb-8513-5ea63608e061.jpg)

---

This commit adds support for inserting in a "verbatim" mode where a
single uninterpreted key is appended to the buffer.
As this allows the user to input control characters, all control
characters except \n (^M) are rendered in their caret form, with
reverse video (SGR 7) applied to it.
To not break cursor movement, the concept of "masked" characters is
introduced to the StringMetrics interface, which can be mostly ignored
by the rest of the system.

It should be noted that unlike some other line editing libraries,
LibLine does _not_ render a hard tab as a tab, but rather as '^I',
which greatly simplifies cursor handling.