### PR TITLE
Everywhere: Continue replacing dbg() dbgln(). (2)

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -396,6 +396,7 @@ template<typename... Parameters>
 void dbgln(StringView fmtstr, const Parameters&... parameters) { vdbgln(fmtstr, VariadicFormatParams { parameters... }); }
 template<typename... Parameters>
 void dbgln(const char* fmtstr, const Parameters&... parameters) { dbgln(StringView { fmtstr }, parameters...); }
+inline void dbgln() { dbgln(""); }
 
 template<typename T, typename = void>
 struct HasFormatter : TrueType {

--- a/Kernel/ACPI/Parser.cpp
+++ b/Kernel/ACPI/Parser.cpp
@@ -161,7 +161,7 @@ void Parser::access_generic_address(const Structures::GenericAddressStructure& s
             dbgln("ACPI Warning: Unknown access size {}", structure.access_size);
             ASSERT(structure.bit_width != (u8)GenericAddressStructure::BitWidth::QWord);
             ASSERT(structure.bit_width != (u8)GenericAddressStructure::BitWidth::Undefined);
-            dbg() << "ACPI: Bit Width - " << structure.bit_width << " bits";
+            dbgln("ACPI: Bit Width - {} bits", structure.bit_width);
             address.out(value, structure.bit_width);
             break;
         }

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -591,7 +591,7 @@ public:
         SplitQword end;
         read_tsc(end.lsw, end.msw);
         uint64_t diff = end.qw - m_start.qw;
-        dbg() << "Stopwatch(" << m_name << "): " << diff << " ticks";
+        dbgln("Stopwatch({}): {} ticks", m_name, diff);
     }
 
 private:

--- a/Kernel/Devices/BXVGADevice.cpp
+++ b/Kernel/Devices/BXVGADevice.cpp
@@ -137,7 +137,7 @@ bool BXVGADevice::set_resolution(size_t width, size_t height)
         return false;
 
     set_resolution_registers(width, height);
-    dbg() << "BXVGADevice resolution set to " << width << "x" << height << " (pitch=" << m_framebuffer_pitch << ")";
+    dbgln("BXVGADevice resolution set to {}x{} (pitch={})", width, height, m_framebuffer_pitch);
 
     m_framebuffer_width = width;
     m_framebuffer_height = height;
@@ -195,7 +195,7 @@ KResultOr<Region*> BXVGADevice::mmap(Process& process, FileDescription&, Virtual
         shared);
     if (!region)
         return KResult(-ENOMEM);
-    dbg() << "BXVGADevice: mmap with size " << region->size() << " at " << region->vaddr();
+    dbgln("BXVGADevice: mmap with size {} at {}", region->size(), region->vaddr());
     return region;
 }
 

--- a/Kernel/Devices/BlockDevice.cpp
+++ b/Kernel/Devices/BlockDevice.cpp
@@ -55,13 +55,13 @@ bool BlockDevice::read_block(unsigned index, UserOrKernelBuffer& buffer)
     case AsyncDeviceRequest::Success:
         return true;
     case AsyncDeviceRequest::Failure:
-        dbg() << "BlockDevice::read_block(" << index << ") IO error";
+        dbgln("BlockDevice::read_block({}) IO error", index);
         break;
     case AsyncDeviceRequest::MemoryFault:
-        dbg() << "BlockDevice::read_block(" << index << ") EFAULT";
+        dbgln("BlockDevice::read_block({}) EFAULT", index);
         break;
     case AsyncDeviceRequest::Cancelled:
-        dbg() << "BlockDevice::read_block(" << index << ") cancelled";
+        dbgln("BlockDevice::read_block({}) cancelled", index);
         break;
     default:
         ASSERT_NOT_REACHED();
@@ -76,13 +76,13 @@ bool BlockDevice::write_block(unsigned index, const UserOrKernelBuffer& buffer)
     case AsyncDeviceRequest::Success:
         return true;
     case AsyncDeviceRequest::Failure:
-        dbg() << "BlockDevice::write_block(" << index << ") IO error";
+        dbgln("BlockDevice::write_block({}) IO error", index);
         break;
     case AsyncDeviceRequest::MemoryFault:
-        dbg() << "BlockDevice::write_block(" << index << ") EFAULT";
+        dbgln("BlockDevice::write_block({}) EFAULT", index);
         break;
     case AsyncDeviceRequest::Cancelled:
-        dbg() << "BlockDevice::write_block(" << index << ") cancelled";
+        dbgln("BlockDevice::write_block({}) cancelled", index);
         break;
     default:
         ASSERT_NOT_REACHED();

--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -59,7 +59,7 @@ Device::Device(unsigned major, unsigned minor)
     u32 device_id = encoded_device(major, minor);
     auto it = all_devices().find(device_id);
     if (it != all_devices().end()) {
-        dbg() << "Already registered " << major << "," << minor << ": " << it->value->class_name();
+        dbgln("Already registered {},{}: {}", major, minor, it->value->class_name());
     }
     ASSERT(!all_devices().contains(device_id));
     all_devices().set(device_id, this);

--- a/Kernel/Devices/I8042Controller.cpp
+++ b/Kernel/Devices/I8042Controller.cpp
@@ -67,7 +67,8 @@ I8042Controller::I8042Controller()
         do_wait_then_write(I8042_BUFFER, configuration);
 
         m_is_dual_channel = (configuration & (1 << 5)) != 0;
-        dbg() << "I8042: " << (m_is_dual_channel ? "Dual" : "Single") << " channel controller";
+        dbgln("I8042: {} channel controller",
+            m_is_dual_channel ? "Dual" : "Single");
 
         // Perform controller self-test
         do_wait_then_write(I8042_STATUS, 0xaa);

--- a/Kernel/Devices/KeyboardDevice.cpp
+++ b/Kernel/Devices/KeyboardDevice.cpp
@@ -408,7 +408,7 @@ void KeyboardDevice::set_maps(const Keyboard::CharacterMapData& character_map_da
 {
     m_character_map.set_character_map_data(character_map_data);
     m_character_map.set_character_map_name(character_map_name);
-    dbg() << "New Character map \"" << character_map_name << "\" passing to client.";
+    dbgln("New Character map '{}' passing to client.", character_map_name);
 }
 
 }

--- a/Kernel/Devices/MBVGADevice.cpp
+++ b/Kernel/Devices/MBVGADevice.cpp
@@ -47,7 +47,7 @@ MBVGADevice::MBVGADevice(PhysicalAddress addr, size_t pitch, size_t width, size_
     , m_framebuffer_width(width)
     , m_framebuffer_height(height)
 {
-    dbg() << "MBVGADevice address=" << addr << ", pitch=" << pitch << ", width=" << width << ", height=" << height;
+    dbgln("MBVGADevice address={}, pitch={}, width={}, height={}", addr, pitch, width, height);
     s_the = this;
 }
 
@@ -71,7 +71,7 @@ KResultOr<Region*> MBVGADevice::mmap(Process& process, FileDescription&, Virtual
         shared);
     if (!region)
         return KResult(-ENOMEM);
-    dbg() << "MBVGADevice: mmap with size " << region->size() << " at " << region->vaddr();
+    dbgln("MBVGADevice: mmap with size {} at {}", region->size(), region->vaddr());
     return region;
 }
 

--- a/Kernel/Devices/PS2MouseDevice.cpp
+++ b/Kernel/Devices/PS2MouseDevice.cpp
@@ -203,7 +203,7 @@ u8 PS2MouseDevice::send_command(u8 command)
 {
     u8 response = m_controller.send_command(I8042Controller::Device::Mouse, command);
     if (response != I8042_ACK)
-        dbg() << "PS2MouseDevice: Command " << (int)command << " got " << (int)response << " but expected ack: " << (int)I8042_ACK;
+        dbgln("PS2MouseDevice: Command {} got {} but expected ack: {}", command, response, I8042_ACK);
     return response;
 }
 
@@ -211,7 +211,7 @@ u8 PS2MouseDevice::send_command(u8 command, u8 data)
 {
     u8 response = m_controller.send_command(I8042Controller::Device::Mouse, command, data);
     if (response != I8042_ACK)
-        dbg() << "PS2MouseDevice: Command " << (int)command << " got " << (int)response << " but expected ack: " << (int)I8042_ACK;
+        dbgln("PS2MouseDevice: Command {} got {} but expected ack: {}", command, response, I8042_ACK);
     return response;
 }
 

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -315,7 +315,7 @@ void BlockBasedFS::flush_writes_impl()
         ++count;
     });
     cache().mark_all_clean();
-    dbg() << class_name() << ": Flushed " << count << " blocks to disk";
+    dbgln("{}: Flushed {} blocks to disk", class_name(), count);
 }
 
 void BlockBasedFS::flush_writes()

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -268,7 +268,7 @@ KResult Inode::prepare_to_write_data()
         return KResult(-EROFS);
     auto metadata = this->metadata();
     if (metadata.is_setuid() || metadata.is_setgid()) {
-        dbg() << "Inode::prepare_to_write_data(): Stripping SUID/SGID bits from " << identifier();
+        dbgln("Inode::prepare_to_write_data(): Stripping SUID/SGID bits from {}", identifier());
         return chmod(metadata.mode & ~(04000 | 02000));
     }
     return KSuccess;

--- a/Kernel/FileSystem/InodeIdentifier.h
+++ b/Kernel/FileSystem/InodeIdentifier.h
@@ -76,3 +76,11 @@ inline const LogStream& operator<<(const LogStream& stream, const InodeIdentifie
 }
 
 }
+
+template<>
+struct AK::Formatter<Kernel::InodeIdentifier> : AK::Formatter<FormatString> {
+    void format(FormatBuilder& builder, Kernel::InodeIdentifier value)
+    {
+        return AK::Formatter<FormatString>::format(builder, "{}:{}", value.fsid(), value.index());
+    }
+};

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -229,7 +229,7 @@ bool Plan9FS::initialize()
     u32 msize;
     StringView remote_protocol_version;
     version_message >> msize >> remote_protocol_version;
-    dbg() << "Remote supports msize=" << msize << " and protocol version " << remote_protocol_version;
+    dbgln("Remote supports msize={} and protocol version {}", msize, remote_protocol_version);
     m_remote_protocol_version = parse_protocol_version(remote_protocol_version);
     m_max_message_size = min(m_max_message_size, (size_t)msize);
 
@@ -602,7 +602,7 @@ KResult Plan9FS::read_and_dispatch_one_message()
         m_completions.remove(header.tag);
         m_completion_blocker.unblock_completed(header.tag);
     } else {
-        dbg() << "Received a 9p message of type " << header.type << " with an unexpected tag " << header.tag << ", dropping";
+        dbgln("Received a 9p message of type {} with an unexpected tag {}, dropping", header.type, header.tag);
     }
 
     return KSuccess;
@@ -625,7 +625,7 @@ KResult Plan9FS::post_message_and_wait_for_a_reply(Message& message)
         return KResult(-EINTR);
 
     if (completion->result.is_error()) {
-        dbg() << "Plan9FS: Message was aborted with error " << completion->result;
+        dbgln("Plan9FS: Message was aborted with error {}", completion->result.error());
         return KResult(-EIO);
     }
 
@@ -642,13 +642,12 @@ KResult Plan9FS::post_message_and_wait_for_a_reply(Message& message)
         // numerical errno in an unspecified encoding; we ignore those too.
         StringView error_name;
         message >> error_name;
-        dbg() << "Plan9FS: Received error name " << error_name;
+        dbgln("Plan9FS: Received error name {}", error_name);
         return KResult(-EIO);
     } else if ((u8)reply_type != (u8)request_type + 1) {
         // Other than those error messages. we only expect the matching reply
         // message type.
-        dbg() << "Plan9FS: Received unexpected message type " << (u8)reply_type
-              << " in response to " << (u8)request_type;
+        dbgln("Plan9FS: Received unexpected message type {} in response to {}", (u8)reply_type, (u8)request_type);
         return KResult(-EIO);
     } else {
         return KSuccess;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -1198,7 +1198,7 @@ void ProcFSInode::did_seek(FileDescription& description, off_t new_offset)
     auto result = refresh_data(description);
     if (result.is_error()) {
         // Subsequent calls to read will return EIO!
-        dbg() << "ProcFS: Could not refresh contents: " << result.error();
+        dbgln("ProcFS: Could not refresh contents: {}", result.error());
     }
 }
 

--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -242,7 +242,7 @@ void* kmalloc_impl(size_t size)
     ++g_kmalloc_call_count;
 
     if (g_dump_kmalloc_stacks && Kernel::g_kernel_symbols_available) {
-        dbg() << "kmalloc(" << size << ")";
+        dbgln("kmalloc({})", size);
         Kernel::dump_backtrace();
     }
 

--- a/Kernel/Interrupts/InterruptManagement.cpp
+++ b/Kernel/Interrupts/InterruptManagement.cpp
@@ -152,9 +152,9 @@ void InterruptManagement::switch_to_pic_mode()
         ASSERT(irq_controller);
         if (irq_controller->type() == IRQControllerType::i82093AA) {
             irq_controller->hard_disable();
-            dbg() << "Interrupts: Detected " << irq_controller->model() << " - Disabled";
+            dbgln("Interrupts: Detected {} - Disabled", irq_controller->model());
         } else {
-            dbg() << "Interrupts: Detected " << irq_controller->model();
+            dbgln("Interrupts: Detected {}", irq_controller->model());
         }
     }
 }
@@ -170,7 +170,7 @@ void InterruptManagement::switch_to_ioapic_mode()
         return;
     }
 
-    dbg() << "Interrupts: MADT @ P " << m_madt.as_ptr();
+    dbgln("Interrupts: MADT @ P {}", m_madt.as_ptr());
     locate_apic_data();
     m_smp_enabled = true;
     if (m_interrupt_controllers.size() == 1) {
@@ -183,9 +183,9 @@ void InterruptManagement::switch_to_ioapic_mode()
         ASSERT(irq_controller);
         if (irq_controller->type() == IRQControllerType::i8259) {
             irq_controller->hard_disable();
-            dbg() << "Interrupts: Detected " << irq_controller->model() << " Disabled";
+            dbgln("Interrupts: Detected {} - Disabled", irq_controller->model());
         } else {
-            dbg() << "Interrupts: Detected " << irq_controller->model();
+            dbgln("Interrupts: Detected {}", irq_controller->model());
         }
     }
 
@@ -213,7 +213,7 @@ void InterruptManagement::locate_apic_data()
         size_t entry_length = madt_entry->length;
         if (madt_entry->type == (u8)ACPI::Structures::MADTEntryType::IOAPIC) {
             auto* ioapic_entry = (const ACPI::Structures::MADTEntries::IOAPIC*)madt_entry;
-            dbg() << "IOAPIC found @ MADT entry " << entry_index << ", MMIO Registers @ " << PhysicalAddress(ioapic_entry->ioapic_address);
+            dbgln("IOAPIC found @ MADT entry {}, MMIO Registers @ {}", entry_index, PhysicalAddress(ioapic_entry->ioapic_address));
             m_interrupt_controllers.resize(1 + irq_controller_count);
             m_interrupt_controllers[irq_controller_count] = adopt(*new IOAPIC(PhysicalAddress(ioapic_entry->ioapic_address), ioapic_entry->gsi_base));
             irq_controller_count++;
@@ -225,7 +225,11 @@ void InterruptManagement::locate_apic_data()
                 interrupt_override_entry->source,
                 interrupt_override_entry->global_system_interrupt,
                 interrupt_override_entry->flags);
-            dbg() << "Interrupts: Overriding INT 0x" << String::format("%x", interrupt_override_entry->source) << " with GSI " << interrupt_override_entry->global_system_interrupt << ", for bus 0x" << String::format("%x", interrupt_override_entry->bus);
+
+            dbgln("Interrupts: Overriding INT {:#x} with GSI {}, for bus {:#x}",
+                interrupt_override_entry->source,
+                interrupt_override_entry->global_system_interrupt,
+                interrupt_override_entry->bus);
         }
         madt_entry = (ACPI::Structures::MADTEntryHeader*)(VirtualAddress(madt_entry).offset(entry_length).get());
         entries_length -= entry_length;

--- a/Kernel/Interrupts/UnhandledInterruptHandler.cpp
+++ b/Kernel/Interrupts/UnhandledInterruptHandler.cpp
@@ -34,13 +34,13 @@ UnhandledInterruptHandler::UnhandledInterruptHandler(u8 interrupt_vector)
 
 void UnhandledInterruptHandler::handle_interrupt(const RegisterState&)
 {
-    dbg() << "Interrupt: Unhandled vector " << interrupt_number() << " was invoked for handle_interrupt(RegisterState&).";
+    dbgln("Interrupt: Unhandled vector {} was invoked for handle_interrupt(RegisterState&).", interrupt_number());
     Processor::halt();
 }
 
 [[noreturn]] bool UnhandledInterruptHandler::eoi()
 {
-    dbg() << "Interrupt: Unhandled vector " << interrupt_number() << " was invoked for eoi().";
+    dbgln("Interrupt: Unhandled vector {} was invoked for eoi().", interrupt_number());
     Processor::halt();
 }
 

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -114,7 +114,7 @@ KResult IPv4Socket::bind(Userspace<const sockaddr*> user_address, socklen_t addr
     auto requested_local_port = ntohs(address.sin_port);
     if (!Process::current()->is_superuser()) {
         if (requested_local_port < 1024) {
-            dbg() << "UID " << Process::current()->uid() << " attempted to bind " << class_name() << " to port " << requested_local_port;
+            dbgln("UID {} attempted to bind {} to port {}", Process::current()->uid(), class_name(), requested_local_port);
             return KResult(-EACCES);
         }
     }
@@ -300,7 +300,7 @@ KResultOr<size_t> IPv4Socket::receive_packet_buffered(FileDescription& descripti
     }
     if (!packet.data.has_value()) {
         if (protocol_is_disconnected()) {
-            dbg() << "IPv4Socket{" << this << "} is protocol-disconnected, returning 0 in recvfrom!";
+            dbgln("IPv4Socket({}) is protocol-disconnected, returning 0 in recvfrom!", this);
             return 0;
         }
 
@@ -394,7 +394,7 @@ bool IPv4Socket::did_receive(const IPv4Address& source_address, u16 source_port,
     if (buffer_mode() == BufferMode::Bytes) {
         size_t space_in_receive_buffer = m_receive_buffer.space_for_writing();
         if (packet_size > space_in_receive_buffer) {
-            dbg() << "IPv4Socket(" << this << "): did_receive refusing packet since buffer is full.";
+            dbgln("IPv4Socket({}): did_receive refusing packet since buffer is full.", this);
             ASSERT(m_can_read);
             return false;
         }
@@ -408,7 +408,7 @@ bool IPv4Socket::did_receive(const IPv4Address& source_address, u16 source_port,
         set_can_read(!m_receive_buffer.is_empty());
     } else {
         if (m_receive_queue.size() > 2000) {
-            dbg() << "IPv4Socket(" << this << "): did_receive refusing packet since queue is full.";
+            dbgln("IPv4Socket({}): did_receive refusing packet since queue is full.", this);
             return false;
         }
         m_receive_queue.append({ source_address, source_port, packet_timestamp, move(packet) });

--- a/Kernel/Net/LoopbackAdapter.cpp
+++ b/Kernel/Net/LoopbackAdapter.cpp
@@ -49,7 +49,7 @@ LoopbackAdapter::~LoopbackAdapter()
 
 void LoopbackAdapter::send_raw(ReadonlyBytes payload)
 {
-    dbg() << "LoopbackAdapter: Sending " << payload.size() << " byte(s) to myself.";
+    dbgln("LoopbackAdapter: Sending {} byte(s) to myself.", payload.size());
     did_receive(payload);
 }
 

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -149,7 +149,7 @@ KResult Socket::setsockopt(int level, int option, Userspace<const void*> user_va
         }
         return KSuccess;
     default:
-        dbg() << "setsockopt(" << option << ") at SOL_SOCKET not implemented.";
+        dbgln("setsockopt({}) at SOL_SOCKET not implemented.", option);
         return KResult(-ENOPROTOOPT);
     }
 }
@@ -226,7 +226,7 @@ KResult Socket::getsockopt(FileDescription&, int level, int option, Userspace<vo
             return KResult(-EFAULT);
         return KSuccess;
     default:
-        dbg() << "getsockopt(" << option << ") at SOL_SOCKET not implemented.";
+        dbgln("setsockopt({}) at SOL_SOCKET not implemented.", option);
         return KResult(-ENOPROTOOPT);
     }
 }

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -465,7 +465,7 @@ void TCPSocket::shut_down_for_writing()
         [[maybe_unused]] auto rc = send_tcp_packet(TCPFlags::FIN | TCPFlags::ACK);
         set_state(State::FinWait1);
     } else {
-        dbg() << " Shutting down TCPSocket for writing but not moving to FinWait1 since state is " << to_string(state());
+        dbgln(" Shutting down TCPSocket for writing but not moving to FinWait1 since state is {}", to_string(state()));
     }
 }
 

--- a/Kernel/Storage/IDEChannel.cpp
+++ b/Kernel/Storage/IDEChannel.cpp
@@ -272,7 +272,7 @@ void IDEChannel::handle_irq(const RegisterState&)
         // trigger page faults
         Processor::deferred_call_queue([this]() {
             if (m_current_request->request_type() == AsyncBlockDeviceRequest::Read) {
-                dbg() << "IDEChannel: Read block " << m_current_request_block_index << "/" << m_current_request->block_count();
+                dbgln("IDEChannel: Read block {}/{}", m_current_request_block_index, m_current_request->block_count());
                 if (ata_do_read_sector()) {
                     if (++m_current_request_block_index >= m_current_request->block_count()) {
                         complete_current_request(AsyncDeviceRequest::Success);
@@ -283,7 +283,7 @@ void IDEChannel::handle_irq(const RegisterState&)
                 }
             } else {
                 if (!m_current_request_flushing_cache) {
-                    dbg() << "IDEChannel: Wrote block " << m_current_request_block_index << "/" << m_current_request->block_count();
+                    dbgln("IDEChannel: Wrote block {}/{}", m_current_request_block_index, m_current_request->block_count());
                     if (++m_current_request_block_index >= m_current_request->block_count()) {
                         // We read the last block, flush cache
                         ASSERT(!m_current_request_flushing_cache);

--- a/Kernel/Storage/Partition/GUIDPartitionTable.cpp
+++ b/Kernel/Storage/Partition/GUIDPartitionTable.cpp
@@ -133,7 +133,7 @@ bool GUIDPartitionTable::initialize()
         Array<u8, 16> unique_guid {};
         unique_guid.span().overwrite(0, entry.unique_guid, unique_guid.size());
         String name = entry.partition_name;
-        dbg() << "Detected GPT partition (entry " << entry_index << ") , offset " << entry.first_lba << " , limit " << entry.last_lba;
+        dbgln("Detected GPT partition (entry={}), offset={}, limit={}", entry_index, entry.first_lba, entry.last_lba);
         m_partitions.append({ entry.first_lba, entry.last_lba, partition_type, unique_guid, entry.attributes, "" });
         raw_byte_index += header().partition_entry_size;
     }

--- a/Kernel/Syscalls/module.cpp
+++ b/Kernel/Syscalls/module.cpp
@@ -86,17 +86,17 @@ int Process::sys$module_load(Userspace<const char*> user_path, size_t path_lengt
             switch (relocation.type()) {
             case R_386_PC32: {
                 // PC-relative relocation
-                dbg() << "PC-relative relocation: " << relocation.symbol().name();
+                dbgln("PC-relative relocation: {}", relocation.symbol().name());
                 u32 symbol_address = address_for_kernel_symbol(relocation.symbol().name());
                 if (symbol_address == 0)
                     missing_symbols = true;
-                dbg() << "   Symbol address: " << (void*)symbol_address;
+                dbgln("   Symbol address: {:p}", symbol_address);
                 ptrdiff_t relative_offset = (char*)symbol_address - ((char*)&patch_ptr + 4);
                 patch_ptr = relative_offset;
                 break;
             }
             case R_386_32: // Absolute relocation
-                dbg() << "Absolute relocation: '" << relocation.symbol().name() << "' value:" << relocation.symbol().value() << ", index:" << relocation.symbol_index();
+                dbgln("Absolute relocation: '{}' value={}, index={}", relocation.symbol().name(), relocation.symbol().value(), relocation.symbol_index());
 
                 if (relocation.symbol().bind() == STB_LOCAL) {
                     auto* section_storage_containing_symbol = section_storage_by_name.get(relocation.symbol().section().name()).value_or(nullptr);
@@ -104,13 +104,13 @@ int Process::sys$module_load(Userspace<const char*> user_path, size_t path_lengt
                     u32 symbol_address = (ptrdiff_t)(section_storage_containing_symbol + relocation.symbol().value());
                     if (symbol_address == 0)
                         missing_symbols = true;
-                    dbg() << "   Symbol address: " << (void*)symbol_address;
+                    dbgln("   Symbol address: {:p}", symbol_address);
                     patch_ptr += symbol_address;
                 } else if (relocation.symbol().bind() == STB_GLOBAL) {
                     u32 symbol_address = address_for_kernel_symbol(relocation.symbol().name());
                     if (symbol_address == 0)
                         missing_symbols = true;
-                    dbg() << "   Symbol address: " << (void*)symbol_address;
+                    dbgln("   Symbol address: {:p}", symbol_address);
                     patch_ptr += symbol_address;
                 } else {
                     ASSERT_NOT_REACHED();
@@ -133,7 +133,7 @@ int Process::sys$module_load(Userspace<const char*> user_path, size_t path_lengt
     }
 
     elf_image->for_each_symbol([&](const ELF::Image::Symbol& symbol) {
-        dbg() << " - " << symbol.type() << " '" << symbol.name() << "' @ " << (void*)symbol.value() << ", size=" << symbol.size();
+        dbgln(" - {} '{}' @ {:p}, size={}", symbol.type(), symbol.name(), symbol.value(), symbol.size());
         if (symbol.name() == "module_init") {
             module->module_init = (ModuleInitPtr)(text_base + symbol.value());
         } else if (symbol.name() == "module_fini") {
@@ -150,7 +150,7 @@ int Process::sys$module_load(Userspace<const char*> user_path, size_t path_lengt
         return -EINVAL;
 
     if (g_modules->contains(module->name)) {
-        dbg() << "a module with the name " << module->name << " is already loaded; please unload it first";
+        dbgln("a module with the name {} is already loaded; please unload it first", module->name);
         return -EEXIST;
     }
 

--- a/Kernel/Syscalls/mount.cpp
+++ b/Kernel/Syscalls/mount.cpp
@@ -57,9 +57,9 @@ int Process::sys$mount(Userspace<const Syscall::SC_mount_params*> user_params)
 
     auto description = file_description(source_fd);
     if (!description.is_null())
-        dbg() << "mount " << fs_type << ": source fd " << source_fd << " @ " << target;
+        dbgln("mount {}: source fd {} @ {}", fs_type, source_fd, target);
     else
-        dbg() << "mount " << fs_type << " @ " << target;
+        dbgln("mount {} @ {}", fs_type, target);
 
     auto custody_or_error = VFS::the().resolve_path(target, current_directory());
     if (custody_or_error.is_error())
@@ -93,7 +93,7 @@ int Process::sys$mount(Userspace<const Syscall::SC_mount_params*> user_params)
             return -ENODEV;
         }
 
-        dbg() << "mount: attempting to mount " << description->absolute_path() << " on " << target;
+        dbgln("mount: attempting to mount {} on {}", description->absolute_path(), target);
 
         fs = Ext2FS::create(*description);
     } else if (fs_type == "9p" || fs_type == "Plan9FS") {
@@ -114,15 +114,15 @@ int Process::sys$mount(Userspace<const Syscall::SC_mount_params*> user_params)
     }
 
     if (!fs->initialize()) {
-        dbg() << "mount: failed to initialize " << fs_type << " filesystem, fd - " << source_fd;
+        dbgln("mount: failed to initialize {} filesystem, fd={}", fs_type, source_fd);
         return -ENODEV;
     }
 
     auto result = VFS::the().mount(fs.release_nonnull(), target_custody, params.flags);
     if (!description.is_null())
-        dbg() << "mount: successfully mounted " << description->absolute_path() << " on " << target;
+        dbgln("mount: successfully mounted {} on {}", description->absolute_path(), target);
     else
-        dbg() << "mount: successfully mounted " << target;
+        dbgln("mount: successfully mounted {}", target);
     return result;
 }
 

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -63,7 +63,7 @@ KResultOr<u32> Process::peek_user_data(Userspace<const u32*> address)
     // process that called PT_PEEK
     ProcessPagingScope scope(*this);
     if (!copy_from_user(&result, address)) {
-        dbg() << "Invalid address for peek_user_data: " << address.ptr();
+        dbgln("Invalid address for peek_user_data: {}", address.ptr());
         return KResult(-EFAULT);
     }
 

--- a/Kernel/Syscalls/select.cpp
+++ b/Kernel/Syscalls/select.cpp
@@ -91,7 +91,7 @@ int Process::sys$select(const Syscall::SC_select_params* user_params)
 
         auto description = file_description(fd);
         if (!description) {
-            dbg() << "sys$select: Bad fd number " << fd;
+            dbgln("sys$select: Bad fd number {}", fd);
             return -EBADF;
         }
         fds_info.append({ description.release_nonnull(), (Thread::FileBlocker::BlockFlags)block_flags });
@@ -183,7 +183,7 @@ int Process::sys$poll(Userspace<const Syscall::SC_poll_params*> user_params)
         auto& pfd = fds_copy[i];
         auto description = file_description(pfd.fd);
         if (!description) {
-            dbg() << "sys$poll: Bad fd number " << pfd.fd;
+            dbgln("sys$poll: Bad fd number {}", pfd.fd);
             return -EBADF;
         }
         u32 block_flags = (u32)Thread::FileBlocker::BlockFlags::Exception; // always want POLLERR, POLLHUP, POLLNVAL

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -154,22 +154,22 @@ void TTY::emit(u8 ch, bool do_evaluate_block_conditions)
 {
     if (should_generate_signals()) {
         if (ch == m_termios.c_cc[VINFO]) {
-            dbg() << tty_name() << ": VINFO pressed!";
+            dbgln("{}: VINFO pressed!", tty_name());
             generate_signal(SIGINFO);
             return;
         }
         if (ch == m_termios.c_cc[VINTR]) {
-            dbg() << tty_name() << ": VINTR pressed!";
+            dbgln("{}: VINTR pressed!", tty_name());
             generate_signal(SIGINT);
             return;
         }
         if (ch == m_termios.c_cc[VQUIT]) {
-            dbg() << tty_name() << ": VQUIT pressed!";
+            dbgln("{}: VQUIT pressed!", tty_name());
             generate_signal(SIGQUIT);
             return;
         }
         if (ch == m_termios.c_cc[VSUSP]) {
-            dbg() << tty_name() << ": VSUSP pressed!";
+            dbgln("{}: VSUSP pressed!", tty_name());
             generate_signal(SIGTSTP);
             if (auto original_process_parent = m_original_process_parent.strong_ref()) {
                 [[maybe_unused]] auto rc = original_process_parent->send_signal(SIGCHLD, nullptr);
@@ -284,10 +284,10 @@ void TTY::generate_signal(int signal)
         return;
     if (should_flush_on_signal())
         flush_input();
-    dbg() << tty_name() << ": Send signal " << signal << " to everyone in pgrp " << pgid().value();
+    dbgln("{}: Send signal {} to everyone in pgrp {}", tty_name(), signal, pgid().value());
     InterruptDisabler disabler; // FIXME: Iterate over a set of process handles instead?
     Process::for_each_in_pgrp(pgid(), [&](auto& process) {
-        dbg() << tty_name() << ": Send signal " << signal << " to " << process;
+        dbgln("{}: Send signal {} to {}", tty_name(), signal, process);
         // FIXME: Should this error be propagated somehow?
         [[maybe_unused]] auto rc = process.send_signal(signal, nullptr);
         return IterationDecision::Continue;

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -100,7 +100,7 @@ void VirtualConsole::switch_to(unsigned index)
         }
         active_console->set_active(false);
     }
-    dbg() << "VC: Switch to " << index << " (" << s_consoles[index] << ")";
+    dbgln("VC: Switch to {} ({})", index, s_consoles[index]);
     s_active_console = index;
     s_consoles[s_active_console]->set_active(true);
 }

--- a/Kernel/Time/HPETComparator.cpp
+++ b/Kernel/Time/HPETComparator.cpp
@@ -101,7 +101,7 @@ bool HPETComparator::try_to_set_frequency(size_t frequency)
 {
     InterruptDisabler disabler;
     if (!is_capable_of_frequency(frequency)) {
-        dbg() << "HPETComparator: not cable of frequency: " << frequency;
+        dbgln("HPETComparator: not cable of frequency: {}", frequency);
         return false;
     }
 

--- a/Kernel/Time/RTC.cpp
+++ b/Kernel/Time/RTC.cpp
@@ -82,10 +82,10 @@ bool RealTimeClock::try_to_set_frequency(size_t frequency)
     disable_irq();
     u8 previous_rate = CMOS::read(0x8A);
     u8 rate = quick_log2(32768 / frequency) + 1;
-    dbg() << "RTC: Set rate to " << rate;
+    dbgln("RTC: Set rate to {}", rate);
     CMOS::write(0x8A, (previous_rate & 0xF0) | rate);
     m_frequency = frequency;
-    dbg() << "RTC: Set frequency to " << frequency << " Hz";
+    dbgln("RTC: Set frequency to {} Hz", frequency);
     enable_irq();
     return true;
 }

--- a/Kernel/VM/AnonymousVMObject.cpp
+++ b/Kernel/VM/AnonymousVMObject.cpp
@@ -90,7 +90,7 @@ NonnullRefPtr<AnonymousVMObject> AnonymousVMObject::create_with_physical_page(Ph
 RefPtr<AnonymousVMObject> AnonymousVMObject::create_for_physical_range(PhysicalAddress paddr, size_t size)
 {
     if (paddr.offset(size) < paddr) {
-        dbg() << "Shenanigans! create_for_physical_range(" << paddr << ", " << size << ") would wrap around";
+        dbgln("Shenanigans! create_for_physical_range({}, {}) would wrap around", paddr, size);
         return nullptr;
     }
     return adopt(*new AnonymousVMObject(paddr, size));
@@ -482,9 +482,11 @@ PageFaultResponse AnonymousVMObject::handle_cow_fault(size_t page_index, Virtual
         void* fault_at;
         if (!safe_memcpy(dest_ptr, vaddr.as_ptr(), PAGE_SIZE, fault_at)) {
             if ((u8*)fault_at >= dest_ptr && (u8*)fault_at <= dest_ptr + PAGE_SIZE)
-                dbg() << "      >> COW: error copying page " << page_slot->paddr() << "/" << vaddr << " to " << page->paddr() << "/" << VirtualAddress(dest_ptr) << ": failed to write to page at " << VirtualAddress(fault_at);
+                dbgln("      >> COW: error copying page {}/{} to {}/{}: failed to write to page at {}",
+                    page_slot->paddr(), vaddr, page->paddr(), VirtualAddress(dest_ptr), VirtualAddress(fault_at));
             else if ((u8*)fault_at >= vaddr.as_ptr() && (u8*)fault_at <= vaddr.as_ptr() + PAGE_SIZE)
-                dbg() << "      >> COW: error copying page " << page_slot->paddr() << "/" << vaddr << " to " << page->paddr() << "/" << VirtualAddress(dest_ptr) << ": failed to read from page at " << VirtualAddress(fault_at);
+                dbgln("      >> COW: error copying page {}/{} to {}/{}: failed to read from page at {}",
+                    page_slot->paddr(), vaddr, page->paddr(), VirtualAddress(dest_ptr), VirtualAddress(fault_at));
             else
                 ASSERT_NOT_REACHED();
         }

--- a/Kernel/VM/InodeVMObject.cpp
+++ b/Kernel/VM/InodeVMObject.cpp
@@ -74,7 +74,7 @@ size_t InodeVMObject::amount_dirty() const
 
 void InodeVMObject::inode_size_changed(Badge<Inode>, size_t old_size, size_t new_size)
 {
-    dbg() << "VMObject::inode_size_changed: {" << m_inode->fsid() << ":" << m_inode->index() << "} " << old_size << " -> " << new_size;
+    dbgln("VMObject::inode_size_changed: ({}:{}) {} -> {}", m_inode->fsid(), m_inode->index(), old_size, new_size);
 
     InterruptDisabler disabler;
 

--- a/Kernel/VM/RangeAllocator.cpp
+++ b/Kernel/VM/RangeAllocator.cpp
@@ -63,9 +63,9 @@ RangeAllocator::~RangeAllocator()
 void RangeAllocator::dump() const
 {
     ASSERT(m_lock.is_locked());
-    dbg() << "RangeAllocator{" << this << "}";
+    dbgln("RangeAllocator({})", this);
     for (auto& range : m_available_ranges) {
-        dbg() << "    " << String::format("%x", range.base().get()) << " -> " << String::format("%x", range.end().get() - 1);
+        dbgln("    {:x} -> {:x}", range.base().get(), range.end().get() - 1);
     }
 }
 
@@ -161,7 +161,7 @@ Range RangeAllocator::allocate_specific(VirtualAddress base, size_t size)
 #endif
         return allocated_range;
     }
-    dbg() << "VRA: Failed to allocate specific range: " << base << "(" << size << ")";
+    dbgln("VRA: Failed to allocate specific range: {}({})", base, size);
     return {};
 }
 

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -437,11 +437,11 @@ PageFaultResponse Region::handle_fault(const PageFault& fault)
     auto page_index_in_region = page_index_from_address(fault.vaddr());
     if (fault.type() == PageFault::Type::PageNotPresent) {
         if (fault.is_read() && !is_readable()) {
-            dbg() << "NP(non-readable) fault in Region{" << this << "}[" << page_index_in_region << "]";
+            dbgln("NP(non-readable) fault in Region({})[{}]", this, page_index_in_region);
             return PageFaultResponse::ShouldCrash;
         }
         if (fault.is_write() && !is_writable()) {
-            dbg() << "NP(non-writable) write fault in Region{" << this << "}[" << page_index_in_region << "] at " << fault.vaddr();
+            dbgln("NP(non-writable) write fault in Region({})[{}] at {}", this, page_index_in_region, fault.vaddr());
             return PageFaultResponse::ShouldCrash;
         }
         if (vmobject().is_inode()) {
@@ -466,7 +466,7 @@ PageFaultResponse Region::handle_fault(const PageFault& fault)
         }
         return handle_zero_fault(page_index_in_region);
 #else
-        dbg() << "BUG! Unexpected NP fault at " << fault.vaddr();
+        dbgln("BUG! Unexpected NP fault at {}", fault.vaddr());
         return PageFaultResponse::ShouldCrash;
 #endif
     }
@@ -484,7 +484,7 @@ PageFaultResponse Region::handle_fault(const PageFault& fault)
         }
         return handle_cow_fault(page_index_in_region);
     }
-    dbg() << "PV(error) fault in Region{" << this << "}[" << page_index_in_region << "] at " << fault.vaddr();
+    dbgln("PV(error) fault in Region({})[{}] at {}", this, page_index_in_region, fault.vaddr());
     return PageFaultResponse::ShouldCrash;
 }
 
@@ -608,7 +608,10 @@ PageFaultResponse Region::handle_inode_fault(size_t page_index_in_region)
         void* fault_at;
         if (!safe_memcpy(dest_ptr, page_buffer, PAGE_SIZE, fault_at)) {
             if ((u8*)fault_at >= dest_ptr && (u8*)fault_at <= dest_ptr + PAGE_SIZE)
-                dbg() << "      >> inode fault: error copying data to " << vmobject_physical_page_entry->paddr() << "/" << VirtualAddress(dest_ptr) << ", failed at " << VirtualAddress(fault_at);
+                dbgln("      >> inode fault: error copying data to {}/{}, failed at {}",
+                    vmobject_physical_page_entry->paddr(),
+                    VirtualAddress(dest_ptr),
+                    VirtualAddress(fault_at));
             else
                 ASSERT_NOT_REACHED();
         }

--- a/Libraries/LibC/malloc.cpp
+++ b/Libraries/LibC/malloc.cpp
@@ -449,24 +449,24 @@ void __malloc_init()
 
 void serenity_dump_malloc_stats()
 {
-    dbg() << "# malloc() calls: " << g_malloc_stats.number_of_malloc_calls;
-    dbg();
-    dbg() << "big alloc hits: " << g_malloc_stats.number_of_big_allocator_hits;
-    dbg() << "big alloc hits that were purged: " << g_malloc_stats.number_of_big_allocator_purge_hits;
-    dbg() << "big allocs: " << g_malloc_stats.number_of_big_allocs;
-    dbg();
-    dbg() << "empty block hits: " << g_malloc_stats.number_of_empty_block_hits;
-    dbg() << "empty block hits that were purged: " << g_malloc_stats.number_of_empty_block_purge_hits;
-    dbg() << "block allocs: " << g_malloc_stats.number_of_block_allocs;
-    dbg() << "filled blocks: " << g_malloc_stats.number_of_blocks_full;
-    dbg();
-    dbg() << "# free() calls: " << g_malloc_stats.number_of_free_calls;
-    dbg();
-    dbg() << "big alloc keeps: " << g_malloc_stats.number_of_big_allocator_keeps;
-    dbg() << "big alloc frees: " << g_malloc_stats.number_of_big_allocator_frees;
-    dbg();
-    dbg() << "full block frees: " << g_malloc_stats.number_of_freed_full_blocks;
-    dbg() << "number of keeps: " << g_malloc_stats.number_of_keeps;
-    dbg() << "number of frees: " << g_malloc_stats.number_of_frees;
+    dbgln("# malloc() calls: {}", g_malloc_stats.number_of_malloc_calls);
+    dbgln();
+    dbgln("big alloc hits: {}", g_malloc_stats.number_of_big_allocator_hits);
+    dbgln("big alloc hits that were purged: {}", g_malloc_stats.number_of_big_allocator_purge_hits);
+    dbgln("big allocs: {}", g_malloc_stats.number_of_big_allocs);
+    dbgln();
+    dbgln("empty block hits: {}", g_malloc_stats.number_of_empty_block_hits);
+    dbgln("empty block hits that were purged: {}", g_malloc_stats.number_of_empty_block_purge_hits);
+    dbgln("block allocs: {}", g_malloc_stats.number_of_block_allocs);
+    dbgln("filled blocks: {}", g_malloc_stats.number_of_blocks_full);
+    dbgln();
+    dbgln("# free() calls: {}", g_malloc_stats.number_of_free_calls);
+    dbgln();
+    dbgln("big alloc keeps: {}", g_malloc_stats.number_of_big_allocator_keeps);
+    dbgln("big alloc frees: {}", g_malloc_stats.number_of_big_allocator_frees);
+    dbgln();
+    dbgln("full block frees: {}", g_malloc_stats.number_of_freed_full_blocks);
+    dbgln("number of keeps: {}", g_malloc_stats.number_of_keeps);
+    dbgln("number of frees: {}", g_malloc_stats.number_of_frees);
 }
 }


### PR DESCRIPTION
Followup to  #4870.

Before:
~~~none
$ grep -rnI 'dbg()' | wc -l
865
~~~

After:
~~~none
$ grep -rnI 'dbg()' | wc -l
731
~~~

---

The majority of the remaining debug statement is enclosed in `#ifdef FOO_DEBUG`, I haven't touched these yet. I am thinking about doing something like `dbgln<enable_foo_debug>()` in these cases but I haven't finished that thought just yet.
