### PR TITLE
Kernel/SystemServer: Make text-mode bootable again, fix crash

### DIFF
--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -238,7 +238,9 @@ void VirtualConsole::on_key_pressed(KeyboardDevice::Event event)
         return;
     }
 
-    m_terminal.handle_key_press(event.key, event.code_point, event.flags);
+    Processor::deferred_call_queue([this, event]() {
+        m_terminal.handle_key_press(event.key, event.code_point, event.flags);
+    });
 }
 
 ssize_t VirtualConsole::on_tty_write(const UserOrKernelBuffer& data, ssize_t size)

--- a/Services/SystemServer/main.cpp
+++ b/Services/SystemServer/main.cpp
@@ -110,8 +110,9 @@ static void prepare_devfs()
     }
 
     // FIXME: Find a better way to chown without hardcoding the gid!
+    // This will fail with ENOENT in text mode.
     rc = chown("/dev/fb0", 0, 3);
-    if (rc < 0) {
+    if (rc < 0 && errno != ENOENT) {
         ASSERT_NOT_REACHED();
     }
 


### PR DESCRIPTION
Fix a mistaken assumption in SystemServer that we will always have a frame buffer (don't forget about text mode! :( ).

Also defer key press events in VirtualConsole to be sent to the terminal *after* handling the keyboard IRQ.

This fixes the crash in #4889, but sadly doesn't seem to address #4180 . More terminal hacking needed for that, I think.

Fixes #4889 