### PR TITLE
AK: Find a value in any container offering iterators

### DIFF
--- a/AK/DoublyLinkedList.h
+++ b/AK/DoublyLinkedList.h
@@ -65,7 +65,8 @@ private:
         explicit Node(U&& v)
             : value(forward<U>(v))
         {
-            static_assert(IsSame<T, U>::value);
+            static_assert(
+                requires { T(v); }, "Conversion operator is missing.");
         }
         T value;
         Node* next { nullptr };
@@ -113,7 +114,8 @@ public:
     template<typename U>
     void append(U&& value)
     {
-        static_assert(IsSame<T, U>::value);
+        static_assert(
+            requires { T(value); }, "Conversion operator is missing.");
         auto* node = new Node(forward<U>(value));
         if (!m_head) {
             ASSERT(!m_tail);

--- a/AK/Find.h
+++ b/AK/Find.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Traits.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+template<typename TIterator, typename TUnaryPredicate>
+constexpr TIterator find_if(TIterator first, TIterator last, TUnaryPredicate&& pred)
+{
+    for (; first != last; ++first) {
+        if (pred(*first)) {
+            return first;
+        }
+    }
+    return last;
+}
+
+template<typename TIterator, typename T>
+constexpr TIterator find(TIterator first, TIterator last, const T& value)
+{
+    return find_if(first, last, [&](const auto& v) { return Traits<T>::equals(value, v); });
+}
+
+template<typename TIterator, typename T>
+constexpr size_t find_index(TIterator first, TIterator last, const T& value)
+{
+    return find_if(first, last, [&](const auto& v) { return Traits<T>::equals(value, v); }).index();
+}
+
+}

--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Find.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>
@@ -166,38 +167,26 @@ public:
     ConstIterator begin() const { return ConstIterator(m_head); }
     ConstIterator end() const { return {}; }
 
-    template<typename Finder>
-    ConstIterator find(Finder finder) const
+    template<typename TUnaryPredicate>
+    ConstIterator find_if(TUnaryPredicate&& pred) const
     {
-        Node* prev = nullptr;
-        for (auto* node = m_head; node; node = node->next) {
-            if (finder(node->value))
-                return ConstIterator(node, prev);
-            prev = node;
-        }
-        return end();
+        return AK::find_if(begin(), end(), forward<TUnaryPredicate>(pred));
     }
 
-    template<typename Finder>
-    Iterator find(Finder finder)
+    template<typename TUnaryPredicate>
+    Iterator find_if(TUnaryPredicate&& pred)
     {
-        Node* prev = nullptr;
-        for (auto* node = m_head; node; node = node->next) {
-            if (finder(node->value))
-                return Iterator(node, prev);
-            prev = node;
-        }
-        return end();
+        return AK::find_if(begin(), end(), forward<TUnaryPredicate>(pred));
     }
 
     ConstIterator find(const T& value) const
     {
-        return find([&](auto& other) { return Traits<T>::equals(value, other); });
+        return find_if([&](auto& other) { return Traits<T>::equals(value, other); });
     }
 
     Iterator find(const T& value)
     {
-        return find([&](auto& other) { return Traits<T>::equals(value, other); });
+        return find_if([&](auto& other) { return Traits<T>::equals(value, other); });
     }
 
     void remove(Iterator iterator)

--- a/AK/SinglyLinkedListWithCount.h
+++ b/AK/SinglyLinkedListWithCount.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/SinglyLinkedList.h>
+#include <AK/StdLibExtras.h>
 
 namespace AK {
 
@@ -106,16 +107,16 @@ public:
     ConstIterator begin() const { return List::begin(); }
     ConstIterator end() const { return List::end(); }
 
-    template<typename Finder>
-    ConstIterator find(Finder finder) const
+    template<typename TUnaryPredicate>
+    ConstIterator find(TUnaryPredicate&& pred) const
     {
-        return List::find(finder);
+        return List::find_if(forward<TUnaryPredicate>(pred));
     }
 
-    template<typename Finder>
-    Iterator find(Finder finder)
+    template<typename TUnaryPredicate>
+    Iterator find(TUnaryPredicate&& pred)
     {
-        return List::find(finder);
+        return List::find_if(forward<TUnaryPredicate>(pred));
     }
 
     ConstIterator find(const T& value) const

--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(AK_TEST_SOURCES
     TestCircularQueue.cpp
     TestDistinctNumeric.cpp
     TestEndian.cpp
+    TestFind.cpp
     TestFormat.cpp
     TestHashFunctions.cpp
     TestHashMap.cpp

--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(AK_TEST_SOURCES
     TestCircularDuplexStream.cpp
     TestCircularQueue.cpp
     TestDistinctNumeric.cpp
+    TestDoublyLinkedList.cpp
     TestEndian.cpp
     TestFind.cpp
     TestFormat.cpp

--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(AK_TEST_SOURCES
     TestQueue.cpp
     TestQuickSort.cpp
     TestRefPtr.cpp
+    TestSinglyLinkedList.cpp
     TestSourceGenerator.cpp
     TestSpan.cpp
     TestString.cpp

--- a/AK/Tests/TestDoublyLinkedList.cpp
+++ b/AK/Tests/TestDoublyLinkedList.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/DoublyLinkedList.h>
+
+static DoublyLinkedList<int> make_list()
+{
+    DoublyLinkedList<int> list {};
+    list.append(0);
+    list.append(1);
+    list.append(2);
+    list.append(3);
+    list.append(4);
+    list.append(5);
+    list.append(6);
+    list.append(7);
+    list.append(8);
+    list.append(9);
+    return list;
+}
+
+TEST_CASE(should_find_mutable)
+{
+    auto sut = make_list();
+
+    EXPECT_EQ(4, *sut.find(4));
+
+    EXPECT_EQ(sut.end(), sut.find(42));
+}
+
+TEST_CASE(should_find_const)
+{
+    const auto sut = make_list();
+
+    EXPECT_EQ(4, *sut.find(4));
+
+    EXPECT_EQ(sut.end(), sut.find(42));
+}
+
+TEST_MAIN(DoublyLinkedList)

--- a/AK/Tests/TestFind.cpp
+++ b/AK/Tests/TestFind.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/Array.h>
+#include <AK/Find.h>
+#include <AK/Vector.h>
+
+TEST_CASE(should_return_end_if_not_in_container)
+{
+    constexpr AK::Array<int, 10> a {};
+
+    static_assert(a.end() == AK::find(a.begin(), a.end(), 1));
+
+    EXPECT(a.end() == AK::find(a.begin(), a.end(), 1));
+}
+
+TEST_CASE(should_return_iterator_to_first_matching_value_in_container)
+{
+    static constexpr AK::Array<int, 10> a { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+
+    constexpr auto expected = a.begin() + 4;
+
+    static_assert(expected == AK::find(a.begin(), a.end(), 0));
+
+    EXPECT(expected == AK::find(a.begin(), a.end(), 0));
+}
+
+TEST_CASE(should_return_iterator_to_first_predicate_matching_value_in_container)
+{
+    static constexpr AK::Array<int, 10> a { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+
+    constexpr auto expected = a.begin() + 4;
+
+    static_assert(expected == AK::find_if(a.begin(), a.end(), [](auto v) { return v == 0; }));
+
+    EXPECT(expected == AK::find_if(a.begin(), a.end(), [](auto v) { return v == 0; }));
+
+    auto find_me = 8;
+    EXPECT(find_me == *AK::find_if(a.begin(), a.end(), [&](auto v) { return v == find_me; }));
+}
+
+TEST_CASE(should_return_index_to_first_predicate_matching_value_in_container)
+{
+    static constexpr AK::Array<int, 10> a { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+
+    static_assert(4 == AK::find_index(a.begin(), a.end(), 0));
+
+    EXPECT(4 == AK::find_index(a.begin(), a.end(), 0));
+}
+
+TEST_MAIN(Find)

--- a/AK/Tests/TestSinglyLinkedList.cpp
+++ b/AK/Tests/TestSinglyLinkedList.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/SinglyLinkedList.h>
+
+static SinglyLinkedList<int> make_list()
+{
+    SinglyLinkedList<int> list {};
+    list.append(0);
+    list.append(1);
+    list.append(2);
+    list.append(3);
+    list.append(4);
+    list.append(5);
+    list.append(6);
+    list.append(7);
+    list.append(8);
+    list.append(9);
+    return list;
+}
+
+TEST_CASE(should_find_mutable)
+{
+    auto sut = make_list();
+
+    EXPECT_EQ(4, *sut.find(4));
+
+    EXPECT_EQ(sut.end(), sut.find(42));
+}
+
+TEST_CASE(should_find_mutable_with_predicate)
+{
+    auto sut = make_list();
+
+    EXPECT_EQ(4, *sut.find_if([](const auto v) { return v == 4; }));
+
+    EXPECT_EQ(sut.end(), sut.find_if([](const auto v) { return v == 42; }));
+}
+
+TEST_CASE(should_find_const)
+{
+    const auto sut = make_list();
+
+    EXPECT_EQ(4, *sut.find(4));
+
+    EXPECT_EQ(sut.end(), sut.find(42));
+}
+
+TEST_CASE(should_find_const_with_predicate)
+{
+    const auto sut = make_list();
+
+    EXPECT_EQ(4, *sut.find_if([](const auto v) { return v == 4; }));
+
+    EXPECT_EQ(sut.end(), sut.find_if([](const auto v) { return v == 42; }));
+}
+
+TEST_MAIN(SinglyLinkedList)

--- a/AK/Tests/TestVector.cpp
+++ b/AK/Tests/TestVector.cpp
@@ -394,4 +394,30 @@ TEST_CASE(should_compare_vectors_of_different_sizes)
     EXPECT(a != b);
 }
 
+TEST_CASE(should_find_value)
+{
+    AK::Vector<int> v { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+
+    const auto expected = v.begin() + 4;
+
+    EXPECT_EQ(expected, v.find(0));
+}
+
+TEST_CASE(should_find_predicate)
+{
+    AK::Vector<int> v { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+
+    const auto expected = v.begin() + 4;
+
+    EXPECT_EQ(expected, v.find_if([](const auto v) { return v == 0; }));
+}
+
+TEST_CASE(should_find_index)
+{
+    AK::Vector<int> v { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+
+    EXPECT_EQ(4u, v.find_first_index(0).value());
+    EXPECT(!v.find_first_index(42).has_value());
+}
+
 TEST_MAIN(Vector)

--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -35,7 +35,7 @@ template<typename T>
 struct GenericTraits {
     using PeekType = T;
     static constexpr bool is_trivial() { return false; }
-    static bool equals(const T& a, const T& b) { return a == b; }
+    static constexpr bool equals(const T& a, const T& b) { return a == b; }
 };
 
 template<typename T>

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Find.h>
 #include <AK/Forward.h>
 #include <AK/Iterator.h>
 #include <AK/Optional.h>
@@ -538,41 +539,33 @@ public:
     ConstIterator end() const { return ConstIterator::end(*this); }
     Iterator end() { return Iterator::end(*this); }
 
-    template<typename Finder>
-    ConstIterator find(Finder finder) const
+    template<typename TUnaryPredicate>
+    ConstIterator find_if(TUnaryPredicate&& finder) const
     {
-        for (size_t i = 0; i < m_size; ++i) {
-            if (finder(at(i)))
-                return ConstIterator(*this, i);
-        }
-        return end();
+        return AK::find_if(begin(), end(), forward<TUnaryPredicate>(finder));
     }
 
-    template<typename Finder>
-    Iterator find(Finder finder)
+    template<typename TUnaryPredicate>
+    Iterator find_if(TUnaryPredicate&& finder)
     {
-        for (size_t i = 0; i < m_size; ++i) {
-            if (finder(at(i)))
-                return Iterator { *this, i };
-        }
-        return end();
+        return AK::find_if(begin(), end(), forward<TUnaryPredicate>(finder));
     }
 
     ConstIterator find(const T& value) const
     {
-        return find([&](auto& other) { return Traits<T>::equals(value, other); });
+        return AK::find(begin(), end(), value);
     }
 
     Iterator find(const T& value)
     {
-        return find([&](auto& other) { return Traits<T>::equals(value, other); });
+        return AK::find(begin(), end(), value);
     }
 
     Optional<size_t> find_first_index(const T& value)
     {
-        for (size_t i = 0; i < m_size; ++i) {
-            if (Traits<T>::equals(value, at(i)))
-                return i;
+        if (const auto index = AK::find_index(begin(), end(), value);
+            index < size()) {
+            return index;
         }
         return {};
     }

--- a/Applications/Piano/Track.cpp
+++ b/Applications/Piano/Track.cpp
@@ -266,7 +266,7 @@ void Track::set_note(int note, Switch switch_note)
 
 void Track::sync_roll(int note)
 {
-    auto it = m_roll_notes[note].find([&](auto& roll_note) { return roll_note.off_sample > m_time; });
+    auto it = m_roll_notes[note].find_if([&](auto& roll_note) { return roll_note.off_sample > m_time; });
     if (it.is_end())
         m_roll_iters[note] = m_roll_notes[note].begin();
     else

--- a/Applications/Spreadsheet/Cell.cpp
+++ b/Applications/Spreadsheet/Cell.cpp
@@ -187,7 +187,7 @@ void Cell::reference_from(Cell* other)
     if (!other || other == this)
         return;
 
-    if (!m_referencing_cells.find([other](auto& ptr) { return ptr.ptr() == other; }).is_end())
+    if (!m_referencing_cells.find_if([other](const auto& ptr) { return ptr.ptr() == other; }).is_end())
         return;
 
     m_referencing_cells.append(other->make_weak_ptr());

--- a/Applications/Spreadsheet/Readers/XSV.cpp
+++ b/Applications/Spreadsheet/Readers/XSV.cpp
@@ -244,7 +244,7 @@ XSV::Field XSV::read_one_unquoted_field()
 StringView XSV::Row::operator[](StringView name) const
 {
     ASSERT(!m_xsv.m_names.is_empty());
-    auto it = m_xsv.m_names.find([&](auto&& entry) { return name == entry; });
+    auto it = m_xsv.m_names.find_if([&](const auto& entry) { return name == entry; });
     ASSERT(!it.is_end());
 
     return (*this)[it.index()];

--- a/Applications/SystemMonitor/DevicesModel.cpp
+++ b/Applications/SystemMonitor/DevicesModel.cpp
@@ -182,7 +182,7 @@ void DevicesModel::update()
             unsigned _major = major(statbuf.st_rdev);
             unsigned _minor = minor(statbuf.st_rdev);
 
-            auto it = m_devices.find([_major, _minor](auto& device_info) {
+            auto it = m_devices.find_if([_major, _minor](const auto& device_info) {
                 return device_info.major == _major && device_info.minor == _minor;
             });
             if (it != m_devices.end()) {

--- a/DevTools/HackStudio/Debugger/VariablesModel.cpp
+++ b/DevTools/HackStudio/Debugger/VariablesModel.cpp
@@ -80,7 +80,7 @@ static String variable_value_as_string(const Debug::DebugInfo::VariableInfo& var
     if (variable.is_enum_type()) {
         auto value = Debugger::the().session()->peek((u32*)variable_address);
         ASSERT(value.has_value());
-        auto it = variable.type->members.find([enumerator_value = value.value()](auto& enumerator) {
+        auto it = variable.type->members.find_if([&enumerator_value = value.value()](const auto& enumerator) {
             return enumerator->constant_data.as_u32 == enumerator_value;
         });
         ASSERT(!it.is_end());
@@ -116,7 +116,7 @@ static Optional<u32> string_to_variable_value(const StringView& string_value, co
         if (string_value.starts_with(prefix_string))
             string_to_use = string_value.substring_view(prefix_string.length(), string_value.length() - prefix_string.length());
 
-        auto it = variable.type->members.find([string_to_use](auto& enumerator) {
+        auto it = variable.type->members.find_if([string_to_use](const auto& enumerator) {
             return enumerator->name == string_to_use;
         });
 

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -75,7 +75,7 @@ public:
         {
             ScopedSpinLock lock(m_requests_lock);
             was_empty = m_requests.is_empty();
-            m_requests.append(request);
+            m_requests.append(RefPtr<AsyncDeviceRequest>(request));
         }
         if (was_empty)
             request->do_start({});

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -75,7 +75,7 @@ public:
         {
             ScopedSpinLock lock(m_requests_lock);
             was_empty = m_requests.is_empty();
-            m_requests.append(RefPtr<AsyncDeviceRequest>(request));
+            m_requests.append(request);
         }
         if (was_empty)
             request->do_start({});

--- a/Libraries/LibCore/ArgsParser.cpp
+++ b/Libraries/LibCore/ArgsParser.cpp
@@ -109,7 +109,7 @@ bool ArgsParser::parse(int argc, char** argv, bool exit_on_failure)
             index_of_found_long_option = -1;
         } else {
             // It was a short option, look it up.
-            auto it = m_options.find([c](auto& opt) { return c == opt.short_name; });
+            auto it = m_options.find_if([c](auto& opt) { return c == opt.short_name; });
             ASSERT(!it.is_end());
             found_option = &*it;
         }

--- a/Libraries/LibMarkdown/Text.cpp
+++ b/Libraries/LibMarkdown/Text.cpp
@@ -69,7 +69,7 @@ String Text::render_to_html() const
             { "b", &Style::strong },
             { "code", &Style::code }
         };
-        auto it = open_tags.find([&](const String& open_tag) {
+        auto it = open_tags.find_if([&](const String& open_tag) {
             if (open_tag == "a" && current_style.href != span.style.href)
                 return true;
             if (open_tag == "img" && current_style.img != span.style.img)

--- a/Libraries/LibTLS/ClientHandshake.cpp
+++ b/Libraries/LibTLS/ClientHandshake.cpp
@@ -398,7 +398,7 @@ ssize_t TLSv12::handle_payload(ReadonlyBytes vbuffer)
                 }
                 payload_res = handle_certificate(buffer.slice(1, payload_size));
                 if (m_context.certificates.size()) {
-                    auto it = m_context.certificates.find([&](auto& cert) { return cert.is_valid(); });
+                    auto it = m_context.certificates.find_if([](const auto& cert) { return cert.is_valid(); });
 
                     if (it.is_end()) {
                         // no valid certificates

--- a/Services/WindowServer/MenuManager.cpp
+++ b/Services/WindowServer/MenuManager.cpp
@@ -162,7 +162,7 @@ void MenuManager::event(Core::Event& event)
         if (event.type() == Event::KeyDown) {
 
             if (key_event.key() == Key_Left) {
-                auto it = m_open_menu_stack.find([&](auto& other) { return m_current_menu == other.ptr(); });
+                auto it = m_open_menu_stack.find_if([&](const auto& other) { return m_current_menu == other.ptr(); });
                 ASSERT(!it.is_end());
 
                 // Going "back" a menu should be the previous menu in the stack
@@ -390,7 +390,7 @@ void MenuManager::open_menu(Menu& menu, bool as_current_menu)
         menu.menu_window()->set_visible(true);
     }
 
-    if (m_open_menu_stack.find([&menu](auto& other) { return &menu == other.ptr(); }).is_end())
+    if (m_open_menu_stack.find_if([&menu](auto& other) { return &menu == other.ptr(); }).is_end())
         m_open_menu_stack.append(menu);
 
     if (as_current_menu || !current_menu()) {


### PR DESCRIPTION
Problem:                                                              
- `find` is implemented inside of each container. This coupling       
  requires that each container needs to individually provide `find`.  
                                                                      
Solution:                                                             
- Decouple the `find` functionality from the container. This allows   
  provides a `find` algorithm which can work with all                 
  containers. Containers can still provide their own `find` in the    
  case where it can be optimized.                                     
- This also allows for searching sub-ranges of a container rather than
  the entire container as some of the container-specific member       
  functions enforced.                                                 
                                                                      
Note:                                                                 
- @davidstone's talk from 2015 C++Now conference entitled "Functions  
  Want to be Free" encourages this style:                             
  (https://www.youtube.com/watch?v=_lVlC0xzXDc), but it does come at  
  the cost of composability.                                          
- A logical follow-on to this is to provide a mechanism to use a      
  short-hand function which automatically searches the entire         
  container. This could automatically use the container-provided      
  version if available so that functions which provide their own      
  optimized version get the benefit.                                  
