### PR TITLE
SystemMonitor: Make graphs look nice with dark themes

### DIFF
--- a/Applications/SystemMonitor/GraphWidget.cpp
+++ b/Applications/SystemMonitor/GraphWidget.cpp
@@ -27,7 +27,9 @@
 #include "GraphWidget.h"
 #include <LibGUI/Painter.h>
 #include <LibGfx/Font.h>
+#include <LibGfx/Palette.h>
 #include <LibGfx/Path.h>
+#include <LibGfx/SystemTheme.h>
 
 GraphWidget::GraphWidget()
 {
@@ -49,7 +51,7 @@ void GraphWidget::paint_event(GUI::PaintEvent& event)
     GUI::Painter painter(*this);
     painter.add_clip_rect(event.rect());
     painter.add_clip_rect(frame_inner_rect());
-    painter.fill_rect(event.rect(), m_background_color);
+    painter.fill_rect(event.rect(), palette().color(ColorRole::Base));
 
     auto inner_rect = frame_inner_rect();
     float scale = (float)inner_rect.height() / (float)m_max;

--- a/Applications/SystemMonitor/GraphWidget.h
+++ b/Applications/SystemMonitor/GraphWidget.h
@@ -39,8 +39,6 @@ public:
 
     void add_value(Vector<int, 1>&&);
 
-    void set_background_color(Color color) { m_background_color = color; }
-
     struct ValueFormat {
         Color line_color { Color::Transparent };
         Color background_color { Color::Transparent };
@@ -63,7 +61,6 @@ private:
     int m_max { 100 };
     Vector<ValueFormat, 1> m_value_format;
     CircularQueue<Vector<int, 1>, 4000> m_values;
-    Color m_background_color { Color::Black };
     bool m_stack_values { false };
 
     Vector<Gfx::IntPoint, 1> m_calculated_points;

--- a/Applications/SystemMonitor/main.cpp
+++ b/Applications/SystemMonitor/main.cpp
@@ -579,17 +579,16 @@ NonnullRefPtr<GUI::Widget> build_graphs_tab()
         for (size_t i = 0; i < ProcessModel::the().cpus().size(); i++) {
             auto& cpu_graph = cpu_graph_group_box.add<GraphWidget>();
             cpu_graph.set_max(100);
-            cpu_graph.set_background_color(Color::White);
             cpu_graph.set_value_format(0, {
                                               .line_color = Color::Blue,
-                                              .background_color = Color::from_rgb(0xaaaaff),
+                                              .background_color = Color(Color::Blue).with_alpha(70),
                                               .text_formatter = [](int value) {
                                                   return String::formatted("Total: {}%", value);
                                               },
                                           });
             cpu_graph.set_value_format(1, {
                                               .line_color = Color::Red,
-                                              .background_color = Color::from_rgb(0xffaaaa),
+                                              .background_color = Color(Color::Red).with_alpha(70),
                                               .text_formatter = [](int value) {
                                                   return String::formatted("Kernel: {}%", value);
                                               },
@@ -606,25 +605,24 @@ NonnullRefPtr<GUI::Widget> build_graphs_tab()
         memory_graph_group_box.layout()->set_margins({ 6, 16, 6, 6 });
         memory_graph_group_box.set_fixed_height(120);
         auto& memory_graph = memory_graph_group_box.add<GraphWidget>();
-        memory_graph.set_background_color(Color::White);
         memory_graph.set_stack_values(true);
         memory_graph.set_value_format(0, {
                                              .line_color = Color::from_rgb(0x619910),
-                                             .background_color = Color::from_rgb(0xbbffbb),
+                                             .background_color = Color::from_rgb(0x619910).with_alpha(70),
                                              .text_formatter = [&memory_graph](int value) {
                                                  return String::formatted("Committed: {} KiB", value);
                                              },
                                          });
         memory_graph.set_value_format(1, {
                                              .line_color = Color::Blue,
-                                             .background_color = Color::from_rgb(0xaaaaff),
+                                             .background_color = Color(Color::Blue).with_alpha(70),
                                              .text_formatter = [&memory_graph](int value) {
                                                  return String::formatted("Allocated: {} KiB", value);
                                              },
                                          });
         memory_graph.set_value_format(2, {
                                              .line_color = Color::Red,
-                                             .background_color = Color::from_rgb(0xffaaaa),
+                                             .background_color = Color(Color::Red).with_alpha(70),
                                              .text_formatter = [&memory_graph](int value) {
                                                  return String::formatted("Kernel heap: {} KiB", value);
                                              },

--- a/Libraries/LibGfx/Painter.cpp
+++ b/Libraries/LibGfx/Painter.cpp
@@ -1157,8 +1157,10 @@ ALWAYS_INLINE void Painter::fill_scanline_with_draw_op(int y, int x, int width, 
 
 void Painter::draw_pixel(const IntPoint& position, Color color, int thickness)
 {
-    if (thickness == 1)
-        return set_pixel_with_draw_op(m_target->scanline(position.y())[position.x()], color);
+    if (thickness == 1) {
+        auto& pixel = m_target->scanline(position.y())[position.x()];
+        return set_pixel_with_draw_op(pixel, Color::from_rgba(pixel).blend(color));
+    }
     IntRect rect { position.translated(-(thickness / 2), -(thickness / 2)), { thickness, thickness } };
     fill_rect(rect.translated(-state().translation), color);
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19366641/104137801-d26a0100-539f-11eb-800e-f97ef92b46ab.png)

![image](https://user-images.githubusercontent.com/19366641/104137822-f0376600-539f-11eb-9442-e80af09fb59c.png)

![image](https://user-images.githubusercontent.com/19366641/104137832-004f4580-53a0-11eb-8298-d40fdf0be637.png)

The Default theme remains unaffected, although the line background opacity may be slightly different.

![image](https://user-images.githubusercontent.com/19366641/104137858-355b9800-53a0-11eb-9fc5-015dff68e621.png)
