### PR TITLE
LibGUI: Update TextEditor after triple-click to select

### DIFF
--- a/Libraries/LibGUI/TextEditor.cpp
+++ b/Libraries/LibGUI/TextEditor.cpp
@@ -286,6 +286,8 @@ void TextEditor::mousedown_event(MouseEvent& event)
 
         m_selection.set(start, end);
         set_cursor(end);
+        update();
+        did_update_selection();
         return;
     }
 


### PR DESCRIPTION
Previously, triple-clicking did not visually update `TextEditor`, so there was sometimes a delay in selecting the whole line. For some reason, this delay was only noticeable after triple-clicking the last word in a line. Now, the widget is updated after triple-clicking.