### PR TITLE
Shell: Add (basic) support for history event designators

### DIFF
--- a/Userland/Shell/Formatter.h
+++ b/Userland/Shell/Formatter.h
@@ -71,6 +71,7 @@ private:
     virtual void visit(const AST::FunctionDeclaration*) override;
     virtual void visit(const AST::ForLoop*) override;
     virtual void visit(const AST::Glob*) override;
+    virtual void visit(const AST::HistoryEvent*) override;
     virtual void visit(const AST::Execute*) override;
     virtual void visit(const AST::IfCond*) override;
     virtual void visit(const AST::Join*) override;

--- a/Userland/Shell/Forward.h
+++ b/Userland/Shell/Forward.h
@@ -54,6 +54,7 @@ class Fd2FdRedirection;
 class FunctionDeclaration;
 class ForLoop;
 class Glob;
+class HistoryEvent;
 class Execute;
 class IfCond;
 class Join;

--- a/Userland/Shell/NodeVisitor.cpp
+++ b/Userland/Shell/NodeVisitor.cpp
@@ -121,6 +121,10 @@ void NodeVisitor::visit(const AST::Glob*)
 {
 }
 
+void NodeVisitor::visit(const AST::HistoryEvent*)
+{
+}
+
 void NodeVisitor::visit(const AST::Execute* node)
 {
     node->command()->visit(*this);

--- a/Userland/Shell/NodeVisitor.h
+++ b/Userland/Shell/NodeVisitor.h
@@ -50,6 +50,7 @@ public:
     virtual void visit(const AST::FunctionDeclaration*);
     virtual void visit(const AST::ForLoop*);
     virtual void visit(const AST::Glob*);
+    virtual void visit(const AST::HistoryEvent*);
     virtual void visit(const AST::Execute*);
     virtual void visit(const AST::IfCond*);
     virtual void visit(const AST::Join*);

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -109,6 +109,8 @@ public:
     String resolve_path(String) const;
     String resolve_alias(const String&) const;
 
+    static bool has_history_event(StringView);
+
     RefPtr<AST::Value> get_argument(size_t);
     RefPtr<AST::Value> lookup_local_variable(const String&);
     String local_variable_or(const String&, const String&);
@@ -153,6 +155,7 @@ public:
     [[nodiscard]] Frame push_frame(String name);
     void pop_frame();
 
+    static String escape_token_for_double_quotes(const String& token);
     static String escape_token_for_single_quotes(const String& token);
     static String escape_token(const String& token);
     static String unescape_token(const String& token);


### PR DESCRIPTION
This is a (very basic) implementation of history events, up to what seemed reasonable to have - i.e. no modifiers.

~~There are quite a few surprises here that are worth mentioning:~~
- ~~Execute nodes (such as `$(...)`) are not well-behaved when expanding history events~~
- ~~Any side-effect (even outside the substituted range) may or may not happen, depending on whether it's lazy or not~~
- ~~redirections and such are not substituted (`echo foo > bar`, `sudo !!` -> `sudo echo foo` - the `> bar` is lost)~~

Very important note to remember, unlike bash, this does not split actual words, but rather singular expressions, so index 1 in `echo > foo` is `> foo`, not `>`.
Bash (and whatever copies it) isn't very consistent with this concept of "words", `$(foo bar baz)` is a "word" (and so is `$( foo bar baz )`), but `> foo` is two words. figure _that_ out.

With that said, the errors are really nice:
```
[test@turingcomplete] ~/Workspace/serenity/Build
❯ echo !yo
Shell Syntax Error: History event did not match any entry
  0| echo !yo
~~~~~~~~~~~^^
  1|


[test@turingcomplete] ~/Workspace/serenity/Build
❯ echo !!:0-100
History entry resolved to 'clear'
Shell Syntax Error: History word index out of bounds
  0| echo !!:0-100
~~~~~~~~~~~~~~~^^^
  1|


[test@turingcomplete] ~/Workspace/serenity/Build
❯ echo !10:^-10
History entry resolved to 'ninja'
Shell Syntax Error: History word index out of bounds
  0| echo !10:^-10
~~~~~~~~~~~~~~~~^^
  1|

```