### PR TITLE
AK: Enable format string warnings for AK printf wrappers

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -244,7 +244,7 @@ public:
         return String((const char*)buffer.data(), buffer.size(), should_chomp);
     }
 
-    static String format(const char*, ...);
+    static String format(const char*, ...) __attribute__((format(printf, 1, 2)));
 
     static String vformatted(StringView fmtstr, TypeErasedFormatParams);
 

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -46,7 +46,7 @@ public:
     void append(char);
     void append_code_point(u32);
     void append(const char*, size_t);
-    void appendf(const char*, ...);
+    void appendf(const char*, ...) __attribute__((format(printf, 2, 3)));
     void appendvf(const char*, va_list);
 
     void append_escaped_for_json(const StringView&);

--- a/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/DevTools/UserspaceEmulator/Emulator.cpp
@@ -296,7 +296,7 @@ const MmapRegion* Emulator::find_text_region(FlatPtr address)
 
 String Emulator::create_backtrace_line(FlatPtr address)
 {
-    String minimal = String::format("=={%d}==    %p", getpid(), address);
+    String minimal = String::format("=={%d}==    %p", getpid(), (void*)address);
     const auto* region = find_text_region(address);
     if (!region)
         return minimal;
@@ -322,11 +322,11 @@ String Emulator::create_backtrace_line(FlatPtr address)
     auto& elf = it->value.debug_info->elf();
     String symbol = elf.symbolicate(address - region->base());
 
-    auto line_without_source_info = String::format("=={%d}==    %p  [%s]: %s", getpid(), address, lib_name.characters(), symbol.characters());
+    auto line_without_source_info = String::format("=={%d}==    %p  [%s]: %s", getpid(), (void*)address, lib_name.characters(), symbol.characters());
 
     auto source_position = it->value.debug_info->get_source_position(address - region->base());
     if (source_position.has_value())
-        return String::format("=={%d}==    %p  [%s]: %s (\033[34;1m%s\033[0m:%u)", getpid(), address, lib_name.characters(), symbol.characters(), LexicalPath(source_position.value().file_path).basename().characters(), source_position.value().line_number);
+        return String::format("=={%d}==    %p  [%s]: %s (\033[34;1m%s\033[0m:%zu)", getpid(), (void*)address, lib_name.characters(), symbol.characters(), LexicalPath(source_position.value().file_path).basename().characters(), source_position.value().line_number);
 
     return line_without_source_info;
 }

--- a/Games/Minesweeper/Field.cpp
+++ b/Games/Minesweeper/Field.cpp
@@ -131,7 +131,7 @@ Field::Field(GUI::Label& flag_label, GUI::Label& time_label, GUI::Button& face_b
     m_timer = add<Core::Timer>();
     m_timer->on_timeout = [this] {
         ++m_time_elapsed;
-        m_time_label.set_text(String::format("%u.%u", m_time_elapsed / 10, m_time_elapsed % 10));
+        m_time_label.set_text(String::formatted("{}.{}", m_time_elapsed / 10, m_time_elapsed % 10));
     };
     m_timer->set_interval(100);
     m_mine_bitmap = Gfx::Bitmap::load_from_file("/res/icons/minesweeper/mine.png");

--- a/Kernel/ACPI/Parser.cpp
+++ b/Kernel/ACPI/Parser.cpp
@@ -280,7 +280,7 @@ void Parser::initialize_main_system_description_table()
 #endif
         for (u32 i = 0; i < ((length - sizeof(Structures::SDTHeader)) / sizeof(u64)); i++) {
 #ifdef ACPI_DEBUG
-            dbg() << "ACPI: Found new table [" << i << "], @ V 0x" << String::format("%x", &xsdt.table_ptrs[i]) << " - P 0x" << String::format("%x", xsdt.table_ptrs[i]);
+            dbg() << "ACPI: Found new table [" << i << "], @ V " << String::format("%p", &xsdt.table_ptrs[i]) << " - P 0x" << String::format("%llx", xsdt.table_ptrs[i]);
 #endif
             m_sdt_pointers.append(PhysicalAddress(xsdt.table_ptrs[i]));
         }
@@ -293,7 +293,7 @@ void Parser::initialize_main_system_description_table()
 #endif
         for (u32 i = 0; i < ((length - sizeof(Structures::SDTHeader)) / sizeof(u32)); i++) {
 #ifdef ACPI_DEBUG
-            dbg() << "ACPI: Found new table [" << i << "], @ V 0x" << String::format("%x", &rsdt.table_ptrs[i]) << " - P 0x" << String::format("%x", rsdt.table_ptrs[i]);
+            dbg() << "ACPI: Found new table [" << i << "], @ V " << String::format("%p", &rsdt.table_ptrs[i]) << " - P 0x" << String::format("%x", rsdt.table_ptrs[i]);
 #endif
             m_sdt_pointers.append(PhysicalAddress(rsdt.table_ptrs[i]));
         }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -407,7 +407,7 @@ void Process::dump_regions()
 
     for (auto& sorted_region : sorted_regions) {
         auto& region = *sorted_region;
-        klog() << String::format("%08x", region.vaddr().get()) << " -- " << String::format("%08x", region.vaddr().offset(region.size() - 1).get()) << "    " << String::format("%08x", region.size()) << "    " << (region.is_readable() ? 'R' : ' ') << (region.is_writable() ? 'W' : ' ') << (region.is_executable() ? 'X' : ' ') << (region.is_shared() ? 'S' : ' ') << (region.is_stack() ? 'T' : ' ') << (region.vmobject().is_anonymous() ? 'A' : ' ') << "    " << region.name().characters();
+        klog() << String::format("%08x", region.vaddr().get()) << " -- " << String::format("%08x", region.vaddr().offset(region.size() - 1).get()) << "    " << String::format("%08zx", region.size()) << "    " << (region.is_readable() ? 'R' : ' ') << (region.is_writable() ? 'W' : ' ') << (region.is_executable() ? 'X' : ' ') << (region.is_shared() ? 'S' : ' ') << (region.is_stack() ? 'T' : ' ') << (region.vmobject().is_anonymous() ? 'A' : ' ') << "    " << region.name().characters();
     }
     MM.dump_kernel_regions();
 }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -1000,9 +1000,9 @@ static bool symbolicate(const RecognizedSymbol& symbol, const Process& process, 
     }
     unsigned offset = symbol.address - symbol.symbol->address;
     if (symbol.symbol->address == g_highest_kernel_symbol_address && offset > 4096) {
-        builder.appendf("%p\n", mask_kernel_addresses ? 0xdeadc0de : symbol.address);
+        builder.appendf("%p\n", (void*)(mask_kernel_addresses ? 0xdeadc0de : symbol.address));
     } else {
-        builder.appendf("%p  %s +%u\n", mask_kernel_addresses ? 0xdeadc0de : symbol.address, demangle(symbol.symbol->name).characters(), offset);
+        builder.appendf("%p  %s +%u\n", (void*)(mask_kernel_addresses ? 0xdeadc0de : symbol.address), demangle(symbol.symbol->name).characters(), offset);
     }
     return true;
 }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -805,7 +805,7 @@ DispatchSignalResult Thread::dispatch_signal(u8 signal)
         u32 ret_eflags = state.eflags;
 
 #ifdef SIGNAL_DEBUG
-        klog() << "signal: setting up user stack to return to eip: " << String::format("%p", ret_eip) << " esp: " << String::format("%p", old_esp);
+        klog() << "signal: setting up user stack to return to eip: " << String::format("%p", (void*)ret_eip) << " esp: " << String::format("%p", (void*)old_esp);
 #endif
 
         // Align the stack to 16 bytes.

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -160,7 +160,7 @@ void MemoryManager::parse_memory_map()
         }
 
 #ifdef MM_DEBUG
-        klog() << "MM: considering memory at " << String::format("%p", (FlatPtr)mmap->addr) << " - " << String::format("%p", (FlatPtr)(mmap->addr + mmap->len));
+        klog() << "MM: considering memory at " << String::format("%p", (void*)mmap->addr) << " - " << String::format("%p", (void*)(mmap->addr + mmap->len));
 #endif
 
         for (size_t page_base = mmap->addr; page_base <= (mmap->addr + mmap->len); page_base += PAGE_SIZE) {

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -132,7 +132,7 @@ void MemoryManager::parse_memory_map()
 
     auto* mmap = (multiboot_memory_map_t*)(low_physical_to_virtual(multiboot_info_ptr->mmap_addr));
     for (; (unsigned long)mmap < (low_physical_to_virtual(multiboot_info_ptr->mmap_addr)) + (multiboot_info_ptr->mmap_length); mmap = (multiboot_memory_map_t*)((unsigned long)mmap + mmap->size + sizeof(mmap->size))) {
-        klog() << "MM: Multiboot mmap: base_addr = " << String::format("0x%08x", mmap->addr) << ", length = " << String::format("0x%08x", mmap->len) << ", type = 0x" << String::format("%x", mmap->type);
+        klog() << "MM: Multiboot mmap: base_addr = " << String::format("0x%08llx", mmap->addr) << ", length = " << String::format("0x%08llx", mmap->len) << ", type = 0x" << String::format("%x", mmap->type);
         if (mmap->type != MULTIBOOT_MEMORY_AVAILABLE)
             continue;
 
@@ -145,7 +145,7 @@ void MemoryManager::parse_memory_map()
 
         auto diff = (FlatPtr)mmap->addr % PAGE_SIZE;
         if (diff != 0) {
-            klog() << "MM: got an unaligned region base from the bootloader; correcting " << String::format("%p", mmap->addr) << " by " << diff << " bytes";
+            klog() << "MM: got an unaligned region base from the bootloader; correcting " << String::format("%p", (void*)mmap->addr) << " by " << diff << " bytes";
             diff = PAGE_SIZE - diff;
             mmap->addr += diff;
             mmap->len -= diff;
@@ -883,7 +883,7 @@ void MemoryManager::dump_kernel_regions()
     klog() << "BEGIN       END         SIZE        ACCESS  NAME";
     ScopedSpinLock lock(s_mm_lock);
     for (auto& region : MM.m_kernel_regions) {
-        klog() << String::format("%08x", region.vaddr().get()) << " -- " << String::format("%08x", region.vaddr().offset(region.size() - 1).get()) << "    " << String::format("%08x", region.size()) << "    " << (region.is_readable() ? 'R' : ' ') << (region.is_writable() ? 'W' : ' ') << (region.is_executable() ? 'X' : ' ') << (region.is_shared() ? 'S' : ' ') << (region.is_stack() ? 'T' : ' ') << (region.vmobject().is_anonymous() ? 'A' : ' ') << "    " << region.name().characters();
+        klog() << String::format("%08x", region.vaddr().get()) << " -- " << String::format("%08x", region.vaddr().offset(region.size() - 1).get()) << "    " << String::format("%08zx", region.size()) << "    " << (region.is_readable() ? 'R' : ' ') << (region.is_writable() ? 'W' : ' ') << (region.is_executable() ? 'X' : ' ') << (region.is_shared() ? 'S' : ' ') << (region.is_stack() ? 'T' : ' ') << (region.vmobject().is_anonymous() ? 'A' : ' ') << "    " << region.name().characters();
     }
 }
 

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -384,7 +384,7 @@ void Region::unmap(ShouldDeallocateVirtualMemoryRange deallocate_range)
         MM.release_pte(*m_page_directory, vaddr, i == count - 1);
 #ifdef MM_DEBUG
         auto* page = physical_page(i);
-        dbg() << "MM: >> Unmapped " << vaddr << " => P" << String::format("%p", page ? page->paddr().get() : 0) << " <<";
+        dbg() << "MM: >> Unmapped " << vaddr << " => P" << String::format("%p", (void*)(page ? page->paddr().get() : 0)) << " <<";
 #endif
     }
     MM.flush_tlb(m_page_directory, vaddr(), page_count());

--- a/Libraries/LibDiff/Format.cpp
+++ b/Libraries/LibDiff/Format.cpp
@@ -34,7 +34,7 @@ String generate_only_additions(const String& text)
 {
     auto lines = text.split('\n', true); // Keep empty
     StringBuilder builder;
-    builder.appendf("@@ -1,%zu +1,%zu @@\n", lines.size());
+    builder.appendf("@@ -0,0 +1,%zu @@\n", lines.size());
     for (const auto& line : lines) {
         builder.appendf("+%s\n", line.characters());
     }

--- a/Libraries/LibGfx/JPGLoader.cpp
+++ b/Libraries/LibGfx/JPGLoader.cpp
@@ -232,7 +232,7 @@ static Optional<size_t> read_huffman_bits(HuffmanStreamState& hstream, size_t co
 {
     if (count > (8 * sizeof(size_t))) {
 #ifdef JPG_DEBUG
-        dbg() << String::format("Can't read %i bits at once!", count);
+        dbg() << String::format("Can't read %zu bits at once!", count);
 #endif
         return {};
     }

--- a/Libraries/LibGfx/Triangle.cpp
+++ b/Libraries/LibGfx/Triangle.cpp
@@ -31,7 +31,7 @@ namespace Gfx {
 
 String Triangle::to_string() const
 {
-    return String::format("({},{},{})", m_a, m_b, m_c);
+    return String::formatted("({},{},{})", m_a, m_b, m_c);
 }
 
 const LogStream& operator<<(const LogStream& stream, const Triangle& value)

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -1356,7 +1356,7 @@ String Style::to_string() const
         if (m_foreground.m_is_rgb) {
             builder.join(", ", m_foreground.m_rgb_color);
         } else {
-            builder.appendf("(XtermColor) %d", m_foreground.m_xterm_color);
+            builder.appendf("(XtermColor) %d", (int)m_foreground.m_xterm_color);
         }
         builder.append("), ");
     }
@@ -1366,7 +1366,7 @@ String Style::to_string() const
         if (m_background.m_is_rgb) {
             builder.join(' ', m_background.m_rgb_color);
         } else {
-            builder.appendf("(XtermColor) %d", m_background.m_xterm_color);
+            builder.appendf("(XtermColor) %d", (int)m_background.m_xterm_color);
         }
         builder.append("), ");
     }

--- a/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -153,7 +153,7 @@ void XtermSuggestionDisplay::display(const SuggestionManager& manager)
     if (m_pages.size() > 1) {
         auto left_arrow = page_index > 0 ? '<' : ' ';
         auto right_arrow = page_index < m_pages.size() - 1 ? '>' : ' ';
-        auto string = String::format("%c page %d of %d %c", left_arrow, page_index + 1, m_pages.size(), right_arrow);
+        auto string = String::format("%c page %zu of %zu %c", left_arrow, page_index + 1, m_pages.size(), right_arrow);
 
         if (string.length() > m_num_columns - 1) {
             // This would overflow into the next line, so just don't print an indicator.

--- a/Libraries/LibMarkdown/Heading.cpp
+++ b/Libraries/LibMarkdown/Heading.cpp
@@ -32,9 +32,9 @@ namespace Markdown {
 String Heading::render_to_html() const
 {
     StringBuilder builder;
-    builder.appendf("<h%d>", m_level);
+    builder.appendf("<h%zu>", m_level);
     builder.append(m_text.render_to_html());
-    builder.appendf("</h%d>\n", m_level);
+    builder.appendf("</h%zu>\n", m_level);
     return builder.build();
 }
 

--- a/Libraries/LibMarkdown/Table.cpp
+++ b/Libraries/LibMarkdown/Table.cpp
@@ -32,7 +32,6 @@ namespace Markdown {
 String Table::render_for_terminal(size_t view_width) const
 {
     auto unit_width_length = view_width == 0 ? 4 : ((float)(view_width - m_columns.size()) / (float)m_total_width);
-    StringBuilder format_builder;
     StringBuilder builder;
 
     auto write_aligned = [&](const auto& text, auto width, auto alignment) {
@@ -40,17 +39,13 @@ String Table::render_for_terminal(size_t view_width) const
         for (auto& span : text.spans())
             original_length += span.text.length();
         auto string = text.render_for_terminal();
-        format_builder.clear();
         if (alignment == Alignment::Center) {
             auto padding_length = (width - original_length) / 2;
-            builder.appendf("%*s%s%*s", padding_length, "", string.characters(), padding_length, "");
+            builder.appendf("%*s%s%*s", (int)padding_length, "", string.characters(), (int)padding_length, "");
             if ((width - original_length) % 2)
                 builder.append(' ');
         } else {
-            format_builder.appendf("%%%s%zus", alignment == Alignment::Left ? "-" : "", width + (string.length() - original_length));
-            builder.appendf(
-                format_builder.to_string().characters(),
-                string.characters());
+            builder.appendf(alignment == Alignment::Left ? "%-*s" : "%*s", (int)(width + (string.length() - original_length)), string.characters());
         }
     };
 

--- a/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Libraries/LibRegex/RegexByteCode.cpp
@@ -714,16 +714,16 @@ const Vector<String> OpCode_Compare::variable_arguments_to_string(Optional<Match
         } else if (compare_type == CharacterCompareType::NamedReference) {
             auto ptr = (const char*)m_bytecode->at(offset++);
             auto length = m_bytecode->at(offset++);
-            result.empend(String::format("name='%.*s'", length, ptr));
+            result.empend(String::format("name='%.*s'", (int)length, ptr));
         } else if (compare_type == CharacterCompareType::Reference) {
             auto ref = m_bytecode->at(offset++);
-            result.empend(String::format("number=%lu", ref));
+            result.empend(String::formatted("number={}", ref));
         } else if (compare_type == CharacterCompareType::String) {
             auto& length = m_bytecode->at(offset++);
             StringBuilder str_builder;
             for (size_t i = 0; i < length; ++i)
                 str_builder.append(m_bytecode->at(offset++));
-            result.empend(String::format("value=\"%.*s\"", length, str_builder.string_view().characters_without_null_termination()));
+            result.empend(String::format("value=\"%.*s\"", (int)length, str_builder.string_view().characters_without_null_termination()));
             if (!view.is_null() && view.length() > state().string_position)
                 result.empend(String::format(
                     "compare against: \"%s\"",

--- a/Libraries/LibRegex/RegexByteCode.h
+++ b/Libraries/LibRegex/RegexByteCode.h
@@ -532,7 +532,7 @@ public:
 
     const String to_string() const
     {
-        return String::format("[0x%02X] %s", opcode_id(), name(opcode_id()));
+        return String::format("[0x%02X] %s", (int)opcode_id(), name(opcode_id()));
     }
 
     virtual const String arguments_string() const = 0;
@@ -618,7 +618,7 @@ public:
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
     const String arguments_string() const override
     {
-        return String::format("offset=%i [&%lu]", offset(), state().instruction_position + size() + offset());
+        return String::format("offset=%zd [&%zu]", offset(), state().instruction_position + size() + offset());
     }
 };
 
@@ -634,7 +634,7 @@ public:
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
     const String arguments_string() const override
     {
-        return String::format("offset=%i [&%lu], sp: %lu", offset(), state().instruction_position + size() + offset(), state().string_position);
+        return String::format("offset=%zd [&%zu], sp: %zu", offset(), state().instruction_position + size() + offset(), state().string_position);
     }
 };
 
@@ -650,7 +650,7 @@ public:
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
     const String arguments_string() const override
     {
-        return String::format("offset=%i [&%lu], sp: %lu", offset(), state().instruction_position + size() + offset(), state().string_position);
+        return String::format("offset=%zd [&%zu], sp: %zu", offset(), state().instruction_position + size() + offset(), state().string_position);
     }
 };
 
@@ -689,7 +689,7 @@ public:
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t arguments_count() const { return 1; }
     ALWAYS_INLINE BoundaryCheckType type() const { return static_cast<BoundaryCheckType>(argument(0)); }
-    const String arguments_string() const override { return String::format("kind=%lu (%s)", argument(0), boundary_check_type_name(type())); }
+    const String arguments_string() const override { return String::format("kind=%lu (%s)", (long unsigned int)argument(0), boundary_check_type_name(type())); }
 };
 
 class OpCode_SaveLeftCaptureGroup final : public OpCode {
@@ -748,7 +748,7 @@ public:
     ALWAYS_INLINE size_t length() const { return argument(1); }
     const String arguments_string() const override
     {
-        return String::format("name=%s, length=%lu", name().to_string().characters(), length());
+        return String::format("name=%s, length=%zu", name().to_string().characters(), length());
     }
 };
 

--- a/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -219,6 +219,9 @@ void FrameLoader::load_html(const StringView& html, const URL& url)
     frame().set_document(&parser.document());
 }
 
+// FIXME: Use an actual templating engine (our own one when it's built, preferably
+// with a way to check these usages at compile time)
+
 void FrameLoader::load_error_page(const URL& failed_url, const String& error)
 {
     auto error_page_url = "file:///res/html/error.html";
@@ -226,10 +229,12 @@ void FrameLoader::load_error_page(const URL& failed_url, const String& error)
         error_page_url,
         [this, failed_url, error](auto data, auto&) {
             ASSERT(!data.is_null());
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
             auto html = String::format(
                 String::copy(data).characters(),
                 escape_html_entities(failed_url.to_string()).characters(),
                 escape_html_entities(error).characters());
+#pragma GCC diagnostic pop
             auto document = HTML::parse_html_document(html, failed_url, "utf-8");
             ASSERT(document);
             frame().set_document(document);

--- a/Services/DHCPClient/DHCPv4.h
+++ b/Services/DHCPClient/DHCPv4.h
@@ -173,7 +173,7 @@ struct ParsedDHCPv4Options {
     {
         StringBuilder builder;
         builder.append("DHCP Options (");
-        builder.appendf("%d", options.size());
+        builder.appendf("%zu", options.size());
         builder.append(" entries)\n");
         for (auto& opt : options) {
             builder.appendf("\toption %d (%d bytes):", (u8)opt.key, (u8)opt.value.length);

--- a/Services/SystemServer/main.cpp
+++ b/Services/SystemServer/main.cpp
@@ -130,7 +130,7 @@ static void prepare_devfs()
 
     for (size_t index = 0; index < 4; index++) {
         // FIXME: Find a better way to chown without hardcoding the gid!
-        rc = chown(String::format("/dev/tty%d", index).characters(), 0, 2);
+        rc = chown(String::formatted("/dev/tty{}", index).characters(), 0, 2);
         if (rc < 0) {
             ASSERT_NOT_REACHED();
         }
@@ -138,7 +138,7 @@ static void prepare_devfs()
 
     for (size_t index = 0; index < 4; index++) {
         // FIXME: Find a better way to chown without hardcoding the gid!
-        rc = chown(String::format("/dev/ttyS%d", index).characters(), 0, 2);
+        rc = chown(String::formatted("/dev/ttyS{}", index).characters(), 0, 2);
         if (rc < 0) {
             ASSERT_NOT_REACHED();
         }

--- a/Services/TelnetServer/Command.h
+++ b/Services/TelnetServer/Command.h
@@ -73,7 +73,7 @@ struct Command {
             builder.append("SUPPRESS_GO_AHEAD");
             break;
         default:
-            builder.append(String::format("UNKNOWN<%02x>"));
+            builder.append(String::format("UNKNOWN<%02x>", subcommand));
             break;
         }
 

--- a/Services/WebServer/Client.cpp
+++ b/Services/WebServer/Client.cpp
@@ -227,7 +227,7 @@ void Client::handle_directory_listing(const String& requested_path, const String
         builder.append(escape_html_entities(name));
         builder.append("</a></td><td>&nbsp;</td>");
 
-        builder.appendf("<td>%10d</td><td>&nbsp;</td>", st.st_size);
+        builder.appendf("<td>%10zd</td><td>&nbsp;</td>", st.st_size);
         builder.append("<td>");
         builder.append(Core::DateTime::from_timestamp(st.st_mtime).to_string());
         builder.append("</td>");

--- a/Shell/AST.cpp
+++ b/Shell/AST.cpp
@@ -211,7 +211,7 @@ Vector<Command> Node::to_lazy_evaluated_commands(RefPtr<Shell> shell)
 
 void Node::dump(int level) const
 {
-    print_indented(String::format("%s at %d:%d (from %d.%d to %d.%d)",
+    print_indented(String::formatted("{} at {}:{} (from {}.{} to {}.{})",
                        class_name().characters(),
                        m_position.start_offset,
                        m_position.end_offset,
@@ -1591,9 +1591,9 @@ Join::~Join()
 void MatchExpr::dump(int level) const
 {
     Node::dump(level);
-    print_indented(String::format("(expression)", m_expr_name.characters()), level + 1);
+    print_indented(String::formatted("(expression: {})", m_expr_name.characters()), level + 1);
     m_matched_expr->dump(level + 2);
-    print_indented(String::format("(named: %s)", m_expr_name.characters()), level + 1);
+    print_indented(String::formatted("(named: {})", m_expr_name.characters()), level + 1);
     print_indented("(entries)", level + 1);
     for (auto& entry : m_entries) {
         StringBuilder builder;

--- a/Userland/gunzip.cpp
+++ b/Userland/gunzip.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv)
 
     for (String filename : filenames) {
         if (!filename.ends_with(".gz"))
-            filename = String::format("%s.gz", filename);
+            filename = String::format("%s.gz", filename.characters());
 
         const auto input_filename = filename;
         const auto output_filename = filename.substring_view(0, filename.length() - 3);

--- a/Userland/w.cpp
+++ b/Userland/w.cpp
@@ -107,7 +107,7 @@ int main()
         if (stat(tty.characters(), &st) == 0) {
             auto idle_time = now - st.st_mtime;
             if (idle_time >= 0) {
-                builder.appendf("%ds", idle_time);
+                builder.appendf("%llds", idle_time);
                 idle_string = builder.to_string();
             }
         }

--- a/Userland/watch.cpp
+++ b/Userland/watch.cpp
@@ -45,7 +45,7 @@ static volatile pid_t child_pid = -1;
 static String build_header_string(const Vector<const char*>& command, const struct timeval& interval)
 {
     StringBuilder builder;
-    builder.appendf("Every %d", interval.tv_sec);
+    builder.appendff("Every {}", interval.tv_sec);
     builder.appendf(".%ds: \x1b[1m", interval.tv_usec / 100000);
     builder.join(' ', command);
     builder.append("\x1b[0m");


### PR DESCRIPTION
This enables printf warnings for StringBuilder::appendf and String::format, which are both used quite a lot in the code base. A bunch of bugs have also been caught regarding incorrect printf usage, including some with omitted parameters, some with missing format specifiers and one call to String::format with a String::formatted format string.