### PR TITLE
LibCore: Add line iterators to IODevice / LibLine: Handle history across multiple concurrent sessions better 

### DIFF
--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -170,6 +170,8 @@ template Optional<u8> convert_to_uint(const StringView& str);
 template Optional<u16> convert_to_uint(const StringView& str);
 template Optional<u32> convert_to_uint(const StringView& str);
 template Optional<u64> convert_to_uint(const StringView& str);
+template Optional<long> convert_to_uint(const StringView& str);
+template Optional<long long> convert_to_uint(const StringView& str);
 
 template<typename T>
 Optional<T> convert_to_uint_from_hex(const StringView& str)

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -243,6 +243,8 @@ template Optional<u8> StringView::to_uint() const;
 template Optional<u16> StringView::to_uint() const;
 template Optional<u32> StringView::to_uint() const;
 template Optional<u64> StringView::to_uint() const;
+template Optional<long> StringView::to_uint() const;
+template Optional<long long> StringView::to_uint() const;
 
 unsigned StringView::hash() const
 {

--- a/Applications/Debugger/main.cpp
+++ b/Applications/Debugger/main.cpp
@@ -269,7 +269,7 @@ int main(int argc, char** argv)
             Optional<Debug::DebugSession::DebugDecision> decision;
 
             if (command.is_empty() && !editor->history().is_empty()) {
-                command = editor->history().last();
+                command = editor->history().last().entry;
             }
             if (command == "cont") {
                 decision = Debug::DebugSession::DebugDecision::Continue;
@@ -300,7 +300,7 @@ int main(int argc, char** argv)
 
             if (success && !command.is_empty()) {
                 // Don't add repeated commands to history
-                if (editor->history().is_empty() || editor->history().last() != command)
+                if (editor->history().is_empty() || editor->history().last().entry != command)
                     editor->add_to_history(command);
             }
             if (!success) {

--- a/Libraries/LibCore/IODevice.cpp
+++ b/Libraries/LibCore/IODevice.cpp
@@ -315,4 +315,22 @@ bool IODevice::write(const StringView& v)
     return write((const u8*)v.characters_without_null_termination(), v.length());
 }
 
+LineIterator::LineIterator(IODevice& device, bool is_end)
+    : m_device(device)
+    , m_is_end(is_end)
+{
+    ++*this;
+}
+
+bool LineIterator::at_end() const
+{
+    return m_device->eof();
+}
+
+LineIterator& LineIterator::operator++()
+{
+    m_buffer = m_device->read_line();
+    return *this;
+}
+
 }

--- a/Libraries/LibCore/IODevice.h
+++ b/Libraries/LibCore/IODevice.h
@@ -31,6 +31,28 @@
 
 namespace Core {
 
+// This is not necessarily a valid iterator in all contexts,
+// if we had concepts, this would be InputIterator, not Copyable, Movable.
+class LineIterator {
+    AK_MAKE_NONCOPYABLE(LineIterator);
+
+public:
+    explicit LineIterator(IODevice&, bool is_end = false);
+
+    bool operator==(const LineIterator& other) const { return &other == this || (at_end() && other.is_end()) || (other.at_end() && is_end()); }
+    bool is_end() const { return m_is_end; }
+    bool at_end() const;
+
+    LineIterator& operator++();
+
+    StringView operator*() const { return m_buffer; }
+
+private:
+    NonnullRefPtr<IODevice> m_device;
+    bool m_is_end { false };
+    String m_buffer;
+};
+
 class IODevice : public Object {
     C_OBJECT_ABSTRACT(IODevice)
 public:
@@ -83,6 +105,9 @@ public:
     virtual bool close();
 
     int printf(const char*, ...);
+
+    LineIterator line_begin() & { return LineIterator(*this); }
+    LineIterator line_end() { return LineIterator(*this, true); }
 
 protected:
     explicit IODevice(Object* parent = nullptr);

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -154,7 +154,7 @@ public:
     void add_to_history(const String& line);
     bool load_history(const String& path);
     bool save_history(const String& path);
-    const Vector<String>& history() const { return m_history; }
+    const auto& history() const { return m_history; }
 
     void register_key_input_callback(const KeyBinding&);
     void register_key_input_callback(Vector<Key> keys, Function<bool(Editor&)> callback) { m_callback_machine.register_key_input_callback(move(keys), move(callback)); }
@@ -451,9 +451,13 @@ private:
     bool m_was_resized { false };
 
     // FIXME: This should be something more take_first()-friendly.
-    Vector<String> m_history;
+    struct HistoryEntry {
+        String entry;
+        time_t timestamp;
+    };
+    Vector<HistoryEntry> m_history;
     size_t m_history_cursor { 0 };
-    size_t m_history_capacity { 100 };
+    size_t m_history_capacity { 1024 };
 
     enum class InputState {
         Free,

--- a/Libraries/LibLine/InternalFunctions.cpp
+++ b/Libraries/LibLine/InternalFunctions.cpp
@@ -425,7 +425,7 @@ void Editor::insert_last_words()
 {
     if (!m_history.is_empty()) {
         // FIXME: This isn't quite right: if the last arg was `"foo bar"` or `foo\ bar` (but not `foo\\ bar`), we should insert that whole arg as last token.
-        if (auto last_words = m_history.last().split_view(' '); !last_words.is_empty())
+        if (auto last_words = m_history.last().entry.split_view(' '); !last_words.is_empty())
             insert(last_words.last());
     }
 }

--- a/Shell/Builtin.cpp
+++ b/Shell/Builtin.cpp
@@ -463,7 +463,7 @@ int Shell::builtin_disown(int argc, const char** argv)
 int Shell::builtin_history(int, const char**)
 {
     for (size_t i = 0; i < m_editor->history().size(); ++i) {
-        printf("%6zu  %s\n", i, m_editor->history()[i].characters());
+        printf("%6zu  %s\n", i, m_editor->history()[i].entry.characters());
     }
     return 0;
 }


### PR DESCRIPTION
- Store history entries as (timestamp)::(entry)\n\n
- Merge the entries together when saving to avoid loss of history
  entries

To ideally make having two concurrently open shells
(or `js` repls or whatever) not overwrite each others' history entries.


(Only applies to users of the lagom version of `shell` and `js`)
it should be noted that the old history format is not going to work anymore, so pls either manually insert newlines between the entries (missing timestamps are okay), or just drop the history file altogether.