### PR TITLE
Everywhere: Continue replacing dbg() dbgln(). (3)

### DIFF
--- a/Libraries/LibC/stdio.cpp
+++ b/Libraries/LibC/stdio.cpp
@@ -953,8 +953,8 @@ int snprintf(char* buffer, size_t size, const char* fmt, ...)
 void perror(const char* s)
 {
     int saved_errno = errno;
-    dbg() << "perror(): " << s << ": " << strerror(saved_errno);
-    fprintf(stderr, "%s: %s\n", s, strerror(saved_errno));
+    dbgln("perror(): {}: {}", s, strerror(saved_errno));
+    warnln("{}: {}", s, strerror(saved_errno));
 }
 
 static int parse_mode(const char* mode)
@@ -987,7 +987,7 @@ static int parse_mode(const char* mode)
             // Ok...
             break;
         default:
-            dbg() << "Potentially unsupported fopen mode _" << mode << "_ (because of '" << *ptr << "')";
+            dbgln("Potentially unsupported fopen mode _{}_ (because of '{}')", mode, *ptr);
         }
     }
 

--- a/Libraries/LibC/unistd.cpp
+++ b/Libraries/LibC/unistd.cpp
@@ -133,7 +133,7 @@ int execvpe(const char* filename, char* const argv[], char* const envp[])
         int rc = execve(candidate.characters(), argv, envp);
         if (rc < 0 && errno != ENOENT) {
             errno_rollback.set_override_rollback_value(errno);
-            dbg() << "execvpe() failed on attempt (" << candidate << ") with " << strerror(errno);
+            dbgln("execvpe() failed on attempt ({}) with {}", candidate, strerror(errno));
             return rc;
         }
     }
@@ -146,7 +146,7 @@ int execvp(const char* filename, char* const argv[])
 {
     int rc = execvpe(filename, argv, environ);
     int saved_errno = errno;
-    dbg() << "execvp() about to return " << rc << " with errno=" << saved_errno;
+    dbgln("execvp() about to return {} with errno={}", rc, saved_errno);
     errno = saved_errno;
     return rc;
 }
@@ -708,7 +708,7 @@ ssize_t pread(int fd, void* buf, size_t count, off_t offset)
 
 char* getpass(const char* prompt)
 {
-    dbg() << "FIXME: getpass(\"" << prompt << "\")";
+    dbgln("FIXME: getpass('{}')", prompt);
     ASSERT_NOT_REACHED();
 }
 

--- a/Libraries/LibCore/Gzip.cpp
+++ b/Libraries/LibCore/Gzip.cpp
@@ -50,7 +50,6 @@ static Optional<ByteBuffer> get_gzip_payload(const ByteBuffer& data)
             ASSERT_NOT_REACHED();
             return (u8)0;
         }
-        // dbg() << "read_byte: " << String::format("%x", data[current]);
         return data[current++];
     };
 
@@ -67,7 +66,7 @@ static Optional<ByteBuffer> get_gzip_payload(const ByteBuffer& data)
     // Compression method
     auto method = read_byte();
     if (method != 8) {
-        dbg() << "get_gzip_payload: Wrong compression method = " << method;
+        dbgln("get_gzip_payload: Wrong compression method={}", method);
         return Optional<ByteBuffer>();
     }
 
@@ -79,7 +78,7 @@ static Optional<ByteBuffer> get_gzip_payload(const ByteBuffer& data)
     // FEXTRA
     if (flags & 4) {
         u16 length = read_byte() & read_byte() << 8;
-        dbg() << "get_gzip_payload: Header has FEXTRA flag set. Length = " << length;
+        dbgln("get_gzip_payload: Header has FEXTRA flag set. length={}", length);
         current += length;
     }
 
@@ -155,7 +154,7 @@ Optional<ByteBuffer> Gzip::decompress(const ByteBuffer& data)
 #endif
             destination.grow(destination.size() * 2);
         } else {
-            dbg() << "Gzip::decompress: Error. puff() returned: " << puff_ret;
+            dbgln("Gzip::decompress: Error. puff() returned: {}", puff_ret);
             ASSERT_NOT_REACHED();
         }
     }

--- a/Libraries/LibCore/Socket.cpp
+++ b/Libraries/LibCore/Socket.cpp
@@ -75,7 +75,7 @@ bool Socket::connect(const String& hostname, int port)
 {
     auto* hostent = gethostbyname(hostname.characters());
     if (!hostent) {
-        dbg() << "Socket::connect: Unable to resolve '" << hostname << "'";
+        dbgln("Socket::connect: Unable to resolve '{}'", hostname);
         return false;
     }
 

--- a/Libraries/LibCore/UDPServer.cpp
+++ b/Libraries/LibCore/UDPServer.cpp
@@ -86,7 +86,7 @@ ByteBuffer UDPServer::receive(size_t size, sockaddr_in& in)
     socklen_t in_len = sizeof(in);
     ssize_t rlen = ::recvfrom(m_fd, buf.data(), size, 0, (sockaddr*)&in, &in_len);
     if (rlen < 0) {
-        dbg() << "recvfrom: " << strerror(errno);
+        dbgln("recvfrom: {}", strerror(errno));
         return {};
     }
 

--- a/Libraries/LibCpp/Lexer.cpp
+++ b/Libraries/LibCpp/Lexer.cpp
@@ -780,7 +780,7 @@ Vector<Token> Lexer::lex()
                 commit_token(Token::Type::Identifier);
             continue;
         }
-        dbg() << "Unimplemented token character: " << ch;
+        dbgln("Unimplemented token character: {}", ch);
         emit_token(Token::Type::Unknown);
     }
     return tokens;

--- a/Libraries/LibCrypto/ASN1/DER.h
+++ b/Libraries/LibCrypto/ASN1/DER.h
@@ -35,14 +35,14 @@ namespace Crypto {
 static bool der_decode_integer(const u8* in, size_t length, UnsignedBigInteger& number)
 {
     if (length < 3) {
-        dbg() << "invalid header size";
+        dbgln("invalid header size");
         return false;
     }
 
     size_t x { 0 };
     // must start with 0x02
     if ((in[x++] & 0x1f) != 0x02) {
-        dbg() << "not an integer " << in[x - 1] << " (" << in[x] << " follows)";
+        dbgln("not an integer {} ({} follows)", in[x - 1], in[x]);
         return false;
     }
 
@@ -51,7 +51,7 @@ static bool der_decode_integer(const u8* in, size_t length, UnsignedBigInteger& 
     if ((x & 0x80) == 0) {
         // overflow
         if (x + z > length) {
-            dbg() << "would overflow " << z + x << " > " << length;
+            dbgln("would overflow {} > {}", z + x, length);
             return false;
         }
 
@@ -63,7 +63,7 @@ static bool der_decode_integer(const u8* in, size_t length, UnsignedBigInteger& 
 
         // overflow
         if ((x + z) > length || z > 4 || z == 0) {
-            dbg() << "would overflow " << z + x << " > " << length;
+            dbgln("would overflow {} > {}", z + x, length);
             return false;
         }
 
@@ -74,7 +74,7 @@ static bool der_decode_integer(const u8* in, size_t length, UnsignedBigInteger& 
 
         // overflow
         if (x + y > length) {
-            dbg() << "would overflow " << y + x << " > " << length;
+            dbgln("would overflow {} > {}", y + x, length);
             return false;
         }
 
@@ -84,7 +84,7 @@ static bool der_decode_integer(const u8* in, size_t length, UnsignedBigInteger& 
 
     // see if it's negative
     if (in[x] & 0x80) {
-        dbg() << "negative bigint unsupported in der_decode_integer";
+        dbgln("negative bigint unsupported in der_decode_integer");
         return false;
     }
 
@@ -243,7 +243,7 @@ constexpr static bool der_length_sequence(ASN1::List* list, size_t in_length, si
             y += x;
             break;
         default:
-            dbg() << "Unhandled Kind " << ASN1::kind_name(type);
+            dbgln("Unhandled Kind {}", ASN1::kind_name(type));
             ASSERT_NOT_REACHED();
             break;
         }
@@ -258,7 +258,7 @@ constexpr static bool der_length_sequence(ASN1::List* list, size_t in_length, si
     } else if (y < 16777216ul) {
         y += 5;
     } else {
-        dbg() << "invalid length " << y;
+        dbgln("invalid length {}", y);
         return false;
     }
     *out_length = y;
@@ -268,12 +268,12 @@ constexpr static bool der_length_sequence(ASN1::List* list, size_t in_length, si
 static inline bool der_decode_sequence(const u8* in, size_t in_length, ASN1::List* list, size_t out_length, bool ordered = true)
 {
     if (in_length < 2) {
-        dbg() << "header too small";
+        dbgln("header too small");
         return false; // invalid header
     }
     size_t x { 0 };
     if (in[x++] != 0x30) {
-        dbg() << "not a sequence: " << in[x - 1];
+        dbgln("not a sequence: {}", in[x - 1]);
         return false; // not a sequence
     }
     size_t block_size { 0 };
@@ -282,14 +282,14 @@ static inline bool der_decode_sequence(const u8* in, size_t in_length, ASN1::Lis
         block_size = in[x++];
     } else if (in[x] & 0x80) {
         if ((in[x] < 0x81) || (in[x] > 0x83)) {
-            dbg() << "invalid length element " << in[x];
+            dbgln("invalid length element {}", in[x]);
             return false;
         }
 
         y = in[x++] & 0x7f;
 
         if (x + y > in_length) {
-            dbg() << "would overflow " << x + y << " -> " << in_length;
+            dbgln("would overflow {} > {}", x + y, in_length);
             return false; // overflow
         }
         block_size = 0;
@@ -299,7 +299,7 @@ static inline bool der_decode_sequence(const u8* in, size_t in_length, ASN1::Lis
 
     // overflow
     if (x + block_size > in_length) {
-        dbg() << "would overflow " << x + block_size << " -> " << in_length;
+        dbgln("would overflow {} > {}", x + block_size, in_length);
         return false;
     }
 
@@ -343,7 +343,7 @@ static inline bool der_decode_sequence(const u8* in, size_t in_length, ASN1::Lis
             break;
         case ASN1::Kind::Sequence:
             if ((in[x] & 0x3f) != 0x30) {
-                dbg() << "Not a sequence: " << (in[x] & 0x3f);
+                dbgln("Not a sequence: {}", (in[x] & 0x3f));
                 return false;
             }
             z = in_length;
@@ -357,7 +357,7 @@ static inline bool der_decode_sequence(const u8* in, size_t in_length, ASN1::Lis
             }
             break;
         default:
-            dbg() << "Unhandled ASN1 kind " << ASN1::kind_name(kind);
+            dbgln("Unhandled ASN1 kind {}", ASN1::kind_name(kind));
             ASSERT_NOT_REACHED();
             break;
         }
@@ -369,7 +369,7 @@ static inline bool der_decode_sequence(const u8* in, size_t in_length, ASN1::Lis
     }
     for (size_t i = 0; i < out_length; ++i)
         if (!list[i].used) {
-            dbg() << "index " << i << " was not read";
+            dbgln("index {} was not read", i);
             return false;
         }
 

--- a/Libraries/LibCrypto/ASN1/DER.h
+++ b/Libraries/LibCrypto/ASN1/DER.h
@@ -321,11 +321,11 @@ static inline bool der_decode_sequence(const u8* in, size_t in_length, ASN1::Lis
         case ASN1::Kind::Integer:
             z = in_length;
             if (!der_decode_integer(in + x, z, *(UnsignedBigInteger*)data)) {
-                dbg() << "could not decode an integer";
+                dbgln("could not decode an integer");
                 return false;
             }
             if (!der_length_integer((UnsignedBigInteger*)data, &z)) {
-                dbg() << "could not figure out the length";
+                dbgln("could not figure out the length");
                 return false;
             }
             break;

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -731,3 +731,15 @@ ALWAYS_INLINE u32 UnsignedBigInteger::shift_left_get_one_word(
     return result;
 }
 }
+
+void AK::Formatter<Crypto::UnsignedBigInteger>::format(FormatBuilder& fmtbuilder, const Crypto::UnsignedBigInteger& value)
+{
+    if (value.is_invalid())
+        return Formatter<StringView>::format(fmtbuilder, "invalid");
+
+    StringBuilder builder;
+    for (int i = value.length() - 1; i >= 0; --i)
+        builder.appendff("{}|", value.words()[i]);
+
+    return Formatter<StringView>::format(fmtbuilder, builder.string_view());
+}

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -144,6 +144,11 @@ operator<<(const LogStream& stream, const Crypto::UnsignedBigInteger& value)
     return stream;
 }
 
+template<>
+struct AK::Formatter<Crypto::UnsignedBigInteger> : Formatter<StringView> {
+    void format(FormatBuilder&, const Crypto::UnsignedBigInteger&);
+};
+
 inline Crypto::UnsignedBigInteger
 operator""_bigint(const char* string, size_t length)
 {

--- a/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
+++ b/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
@@ -60,7 +60,7 @@ public:
         AK::fill_with_random(salt, SaltLength);
 
         if (em_length < hash_length + SaltLength + 2) {
-            dbg() << "Ooops...encoding error";
+            dbgln("Ooops...encoding error");
             return;
         }
 

--- a/Libraries/LibCrypto/PK/RSA.h
+++ b/Libraries/LibCrypto/PK/RSA.h
@@ -137,7 +137,7 @@ public:
         auto n = p.multiplied_by(q);
 
         auto d = NumberTheory::ModularInverse(e, lambda);
-        dbg() << "Your keys are Pub{n=" << n << ", e=" << e << "} and Priv{n=" << n << ", d=" << d << "}";
+        dbgln("Your keys are Pub(n={}, e={}) and Priv(n={}, d={})", n, e, n, d);
         RSAKeyPair<PublicKeyType, PrivateKeyType> keys {
             { n, e },
             { n, d, e }

--- a/Libraries/LibCrypto/PK/RSA.h
+++ b/Libraries/LibCrypto/PK/RSA.h
@@ -131,7 +131,7 @@ public:
             p = NumberTheory::random_big_prime(bits / 2);
             q = NumberTheory::random_big_prime(bits / 2);
             lambda = NumberTheory::LCM(p.minus(1), q.minus(1));
-            dbg() << "checking combination p=" << p << ", q=" << q << ", lambda=" << lambda.length();
+            dbgln("checking combination p={}, q={}, lambda={}", p, q, lambda.length());
         } while (!(NumberTheory::GCD(e, lambda) == 1));
 
         auto n = p.multiplied_by(q);

--- a/Libraries/LibELF/DynamicLoader.cpp
+++ b/Libraries/LibELF/DynamicLoader.cpp
@@ -180,7 +180,6 @@ bool DynamicLoader::load_stage_2(unsigned flags, size_t total_tls_size)
 #endif
 
     if (m_dynamic_object->has_text_relocations()) {
-        // dbg() << "Someone linked non -fPIC code into " << m_filename << " :(";
         ASSERT(m_text_segment_load_address.get() != 0);
 
 #ifndef AK_OS_MACOS

--- a/Libraries/LibGUI/ColumnsView.cpp
+++ b/Libraries/LibGUI/ColumnsView.cpp
@@ -188,7 +188,7 @@ void ColumnsView::push_column(const ModelIndex& parent_index)
         if (m_columns[i].parent_index == grandparent)
             break;
         m_columns.shrink(i);
-        dbg() << "Dropping column " << i;
+        dbgln("Dropping column {}", i);
     }
 
     // Add the new column.

--- a/Libraries/LibGUI/Desktop.cpp
+++ b/Libraries/LibGUI/Desktop.cpp
@@ -71,7 +71,7 @@ bool Desktop::set_wallpaper(const StringView& path, bool save_config)
 
     if (ret_val && save_config) {
         RefPtr<Core::ConfigFile> config = Core::ConfigFile::get_for_app("WindowManager");
-        dbg() << "Saving wallpaper path '" << path << "' to config file at " << config->file_name();
+        dbgln("Saving wallpaper path '{}' to config file at {}", path, config->file_name());
         config->write_entry("Background", "Wallpaper", path);
         config->sync();
     }

--- a/Libraries/LibGUI/Dialog.cpp
+++ b/Libraries/LibGUI/Dialog.cpp
@@ -58,7 +58,7 @@ int Dialog::exec()
     show();
     auto result = m_event_loop->exec();
     m_event_loop = nullptr;
-    dbg() << *this << ": Event loop returned with result " << result;
+    dbgln("{}: Event loop returned with result {}", *this, result);
     remove_from_parent();
     return result;
 }
@@ -68,7 +68,7 @@ void Dialog::done(int result)
     if (!m_event_loop)
         return;
     m_result = result;
-    dbg() << *this << ": Quit event loop with result " << result;
+    dbgln("{}: Quit event loop with result {}", *this, result);
     m_event_loop->quit(result);
 }
 

--- a/Libraries/LibGUI/Dialog.h
+++ b/Libraries/LibGUI/Dialog.h
@@ -61,3 +61,7 @@ private:
 };
 
 }
+
+template<>
+struct AK::Formatter<GUI::Dialog> : Formatter<Core::Object> {
+};

--- a/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Libraries/LibGUI/FileSystemModel.cpp
@@ -145,7 +145,7 @@ void FileSystemModel::Node::traverse_if_needed()
         return;
     }
     fcntl(m_watch_fd, F_SETFD, FD_CLOEXEC);
-    dbg() << "Watching " << full_path << " for changes, m_watch_fd = " << m_watch_fd;
+    dbgln("Watching {} for changes, m_watch_fd={}", full_path, m_watch_fd);
     m_notifier = Core::Notifier::construct(m_watch_fd, Core::Notifier::Event::Read);
     m_notifier->on_ready_to_read = [this] {
         char buffer[32];

--- a/Libraries/LibGemini/Line.cpp
+++ b/Libraries/LibGemini/Line.cpp
@@ -80,7 +80,7 @@ String Control::render_to_html() const
     case Kind::UnorderedListEnd:
         return "</ul>";
     default:
-        dbg() << "Unknown control kind _" << m_kind << "_";
+        dbgln("Unknown control kind _{}_", (int)m_kind);
         ASSERT_NOT_REACHED();
         return "";
     }

--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -170,8 +170,13 @@ static bool check_size(const IntSize& size, BitmapFormat format, unsigned actual
     unsigned expected_size_max = round_up_to_power_of_two(expected_size_min, PAGE_SIZE);
     if (expected_size_min > actual_size || actual_size > expected_size_max) {
         // Getting here is most likely an error.
-        dbg() << "Constructing a shared bitmap for format " << (int)format << " and size " << size << ", which demands " << expected_size_min << " bytes, which rounds up to at most " << expected_size_max << ".";
-        dbg() << "However, we were given " << actual_size << " bytes, which is outside this range?! Refusing cowardly.";
+        dbgln("Constructing a shared bitmap for format {} and size {}, which demands {} bytes, which rounds up to at most {}.",
+            static_cast<int>(format),
+            size,
+            expected_size_min,
+            expected_size_max);
+
+        dbgln("However, we were given {} bytes, which is outside this range?! Refusing cowardly.", actual_size);
         return false;
     }
     return true;

--- a/Libraries/LibGfx/BitmapFont.cpp
+++ b/Libraries/LibGfx/BitmapFont.cpp
@@ -167,7 +167,7 @@ size_t BitmapFont::glyph_count_by_type(FontTypes type)
     if (type == FontTypes::LatinExtendedA)
         return 384;
 
-    dbg() << "Unknown font type:" << type;
+    dbgln("Unknown font type: {}", (int)type);
     ASSERT_NOT_REACHED();
 }
 

--- a/Libraries/LibGfx/ShareableBitmap.cpp
+++ b/Libraries/LibGfx/ShareableBitmap.cpp
@@ -62,7 +62,7 @@ bool decode(Decoder& decoder, Gfx::ShareableBitmap& shareable_bitmap)
     if (shbuf_id == -1)
         return true;
 
-    dbg() << "Decoding a ShareableBitmap with shbuf_id=" << shbuf_id << ", size=" << size;
+    dbgln("Decoding a ShareableBitmap with shbuf_id={}, size={}", shbuf_id, size);
 
     auto shared_buffer = SharedBuffer::create_from_shbuf_id(shbuf_id);
     if (!shared_buffer)

--- a/Libraries/LibGfx/SystemTheme.cpp
+++ b/Libraries/LibGfx/SystemTheme.cpp
@@ -79,7 +79,7 @@ RefPtr<SharedBuffer> load_system_theme(const String& path)
             case (int)MetricRole::TitleButtonWidth:
                 return 15;
             default:
-                dbg() << "Metric " << name << " has no fallback value!";
+                dbgln("Metric {} has no fallback value!", name);
                 return 16;
             }
         }

--- a/Libraries/LibRegex/RegexDebug.h
+++ b/Libraries/LibRegex/RegexDebug.h
@@ -64,7 +64,7 @@ public:
         for (;;) {
             auto* opcode = bytecode.get_opcode(state);
             if (!opcode) {
-                dbg() << "Wrong opcode... failed!";
+                dbgln("Wrong opcode... failed!");
                 return;
             }
 

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -274,7 +274,7 @@ public:
     void set_sni(const StringView& sni)
     {
         if (m_context.is_server || m_context.critical_error || m_context.connection_status != ConnectionStatus::Disconnected) {
-            dbg() << "invalid state for set_sni";
+            dbgln("invalid state for set_sni");
             return;
         }
         m_context.SNI = sni;


### PR DESCRIPTION
Follow up to #4870 and #4887.

Before:
~~~none
$ grep -rnI 'dbg()' | wc -l
728
~~~

After:
~~~none
$ grep -rnI 'dbg()' | wc -l
673
~~~
