### PR TITLE
AK: Simplify constructors and conversions from nullptr_t

### DIFF
--- a/AK/Badge.h
+++ b/AK/Badge.h
@@ -31,7 +31,7 @@ namespace AK {
 template<typename T>
 class Badge {
     friend T;
-    Badge() { }
+    constexpr Badge() = default;
 
     Badge(const Badge&) = delete;
     Badge& operator=(const Badge&) = delete;

--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/NonnullRefPtr.h>
+#include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Span.h>
@@ -42,6 +43,7 @@ public:
     static NonnullRefPtr<ByteBufferImpl> create_zeroed(size_t);
     static NonnullRefPtr<ByteBufferImpl> copy(const void*, size_t);
 
+    ByteBufferImpl() = delete;
     ~ByteBufferImpl() { clear(); }
 
     void clear()
@@ -92,7 +94,6 @@ public:
 private:
     explicit ByteBufferImpl(size_t);
     ByteBufferImpl(const void*, size_t);
-    ByteBufferImpl() { }
 
     u8* m_data { nullptr };
     size_t m_size { 0 };
@@ -100,8 +101,7 @@ private:
 
 class ByteBuffer {
 public:
-    ByteBuffer() { }
-    ByteBuffer(std::nullptr_t) { }
+    ByteBuffer() = default;
     ByteBuffer(const ByteBuffer& other)
         : m_impl(other.m_impl)
     {
@@ -159,11 +159,35 @@ public:
     u8* data() { return m_impl ? m_impl->data() : nullptr; }
     const u8* data() const { return m_impl ? m_impl->data() : nullptr; }
 
-    Bytes bytes() { return m_impl ? m_impl->bytes() : nullptr; }
-    ReadonlyBytes bytes() const { return m_impl ? m_impl->bytes() : nullptr; }
+    Bytes bytes()
+    {
+        if (m_impl) {
+            return m_impl->bytes();
+        }
+        return {};
+    }
+    ReadonlyBytes bytes() const
+    {
+        if (m_impl) {
+            return m_impl->bytes();
+        }
+        return {};
+    }
 
-    Span<u8> span() { return m_impl ? m_impl->span() : nullptr; }
-    Span<const u8> span() const { return m_impl ? m_impl->span() : nullptr; }
+    Span<u8> span()
+    {
+        if (m_impl) {
+            return m_impl->span();
+        }
+        return {};
+    }
+    Span<const u8> span() const
+    {
+        if (m_impl) {
+            return m_impl->span();
+        }
+        return {};
+    }
 
     u8* offset_pointer(int offset) { return m_impl ? m_impl->offset_pointer(offset) : nullptr; }
     const u8* offset_pointer(int offset) const { return m_impl ? m_impl->offset_pointer(offset) : nullptr; }

--- a/AK/DoublyLinkedList.h
+++ b/AK/DoublyLinkedList.h
@@ -74,7 +74,7 @@ private:
     };
 
 public:
-    DoublyLinkedList() { }
+    DoublyLinkedList() = default;
     ~DoublyLinkedList() { clear(); }
 
     bool is_empty() const { return !m_head; }

--- a/AK/Endian.h
+++ b/AK/Endian.h
@@ -110,7 +110,7 @@ public:
     friend InputStream& operator>><T>(InputStream&, LittleEndian<T>&);
     friend OutputStream& operator<<<T>(OutputStream&, LittleEndian<T>);
 
-    constexpr LittleEndian() { }
+    constexpr LittleEndian() = default;
 
     constexpr LittleEndian(T value)
         : m_value(convert_between_host_and_little_endian(value))

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -32,7 +32,7 @@ namespace AK {
 
 class FlyString {
 public:
-    FlyString() { }
+    FlyString() = default;
     FlyString(const FlyString& other)
         : m_impl(other.impl())
     {

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -266,7 +266,7 @@ struct StandardFormatter {
 
 template<typename T>
 struct Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type> : StandardFormatter {
-    Formatter() { }
+    Formatter() = default;
     explicit Formatter(StandardFormatter formatter)
         : StandardFormatter(formatter)
     {
@@ -277,7 +277,7 @@ struct Formatter<T, typename EnableIf<IsIntegral<T>::value>::Type> : StandardFor
 
 template<>
 struct Formatter<StringView> : StandardFormatter {
-    Formatter() { }
+    Formatter() = default;
     explicit Formatter(StandardFormatter formatter)
         : StandardFormatter(formatter)
     {
@@ -338,7 +338,7 @@ struct Formatter<float> : StandardFormatter {
 };
 template<>
 struct Formatter<double> : StandardFormatter {
-    Formatter() { }
+    Formatter() = default;
     explicit Formatter(StandardFormatter formatter)
         : StandardFormatter(formatter)
     {

--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -54,7 +54,7 @@ private:
     };
 
 public:
-    HashMap() { }
+    HashMap() = default;
 
 #ifndef SERENITY_LIBC_BUILD
     HashMap(std::initializer_list<Entry> list)

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -87,7 +87,7 @@ class HashTable {
     };
 
 public:
-    HashTable() { }
+    HashTable() = default;
     HashTable(size_t capacity) { rehash(capacity); }
 
     ~HashTable()

--- a/AK/IDAllocator.h
+++ b/AK/IDAllocator.h
@@ -34,8 +34,8 @@ namespace AK {
 class IDAllocator {
 
 public:
-    IDAllocator() { }
-    ~IDAllocator() { }
+    IDAllocator() = default;
+    ~IDAllocator() = default;
 
     int allocate()
     {

--- a/AK/InlineLinkedList.h
+++ b/AK/InlineLinkedList.h
@@ -104,7 +104,7 @@ inline T* InlineLinkedListNode<T>::next() const
 template<typename T>
 class InlineLinkedList {
 public:
-    InlineLinkedList() { }
+    InlineLinkedList() = default;
 
     bool is_empty() const { return !m_head; }
     size_t size_slow() const;

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -34,8 +34,8 @@ namespace AK {
 
 class JsonArray {
 public:
-    JsonArray() { }
-    ~JsonArray() { }
+    JsonArray() = default;
+    ~JsonArray() = default;
 
     JsonArray(const JsonArray& other)
         : m_values(other.m_values)

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -37,8 +37,8 @@ namespace AK {
 
 class JsonObject {
 public:
-    JsonObject() { }
-    ~JsonObject() { }
+    JsonObject() = default;
+    ~JsonObject() = default;
 
     JsonObject(const JsonObject& other)
         : m_order(other.m_order)

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -33,7 +33,7 @@ namespace AK {
 
 class LexicalPath {
 public:
-    LexicalPath() { }
+    LexicalPath() = default;
     explicit LexicalPath(const StringView&);
 
     bool is_valid() const { return m_is_valid; }

--- a/AK/LogStream.h
+++ b/AK/LogStream.h
@@ -49,7 +49,7 @@ public:
 #endif
     {
     }
-    virtual ~LogStream() { }
+    virtual ~LogStream() = default;
 
     virtual void write(const char*, int) const = 0;
 
@@ -94,7 +94,7 @@ protected:
     bool empty() const { return m_size == 0; }
 
 public:
-    BufferedLogStream() { }
+    BufferedLogStream() = default;
 
     virtual ~BufferedLogStream() override
     {
@@ -114,7 +114,7 @@ public:
 
 class DebugLogStream final : public BufferedLogStream {
 public:
-    DebugLogStream() { }
+    DebugLogStream() = default;
     virtual ~DebugLogStream() override;
 
     // DebugLogStream only checks `enabled` and possibly generates output while the destructor runs.
@@ -128,7 +128,7 @@ private:
 #ifdef KERNEL
 class KernelLogStream final : public BufferedLogStream {
 public:
-    KernelLogStream() { }
+    KernelLogStream() = default;
     virtual ~KernelLogStream() override;
 };
 #endif

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -37,7 +37,7 @@ namespace AK {
 template<typename T>
 class alignas(T) [[nodiscard]] Optional {
 public:
-    Optional() { }
+    Optional() = default;
 
     Optional(const T& value)
         : m_has_value(true)

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -34,7 +34,7 @@ namespace AK {
 template<typename T>
 class OwnPtr {
 public:
-    OwnPtr() { }
+    OwnPtr() = default;
     explicit OwnPtr(T* ptr)
         : m_ptr(ptr)
     {
@@ -57,7 +57,6 @@ public:
         : m_ptr(other.leak_ptr())
     {
     }
-    OwnPtr(std::nullptr_t) {};
     ~OwnPtr()
     {
         clear();

--- a/AK/Queue.h
+++ b/AK/Queue.h
@@ -35,8 +35,8 @@ namespace AK {
 template<typename T, int segment_size = 1000>
 class Queue {
 public:
-    Queue() { }
-    ~Queue() { }
+    Queue() = default;
+    ~Queue() = default;
 
     size_t size() const { return m_size; }
     bool is_empty() const { return m_size == 0; }

--- a/AK/RefCounted.h
+++ b/AK/RefCounted.h
@@ -92,7 +92,7 @@ public:
     }
 
 protected:
-    RefCountedBase() { }
+    RefCountedBase() = default;
     ALWAYS_INLINE ~RefCountedBase()
     {
         ASSERT(m_ref_count.load(AK::MemoryOrder::memory_order_relaxed) == 0);

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -143,7 +143,7 @@ public:
         Adopt
     };
 
-    RefPtr() { }
+    RefPtr() = default;
     RefPtr(const T* ptr)
         : m_bits(PtrTraits::as_bits(const_cast<T*>(ptr)))
     {
@@ -205,7 +205,6 @@ public:
             m_bits.store(0xe0e0e0e0, AK::MemoryOrder::memory_order_relaxed);
 #endif
     }
-    RefPtr(std::nullptr_t) { }
 
     template<typename U>
     RefPtr(const OwnPtr<U>&) = delete;

--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -37,7 +37,7 @@ namespace AK {
 template<typename ListType, typename ElementType>
 class SinglyLinkedListIterator {
 public:
-    SinglyLinkedListIterator() { }
+    SinglyLinkedListIterator() = default;
     bool operator!=(const SinglyLinkedListIterator& other) const { return m_node != other.m_node; }
     SinglyLinkedListIterator& operator++()
     {
@@ -78,7 +78,7 @@ private:
     };
 
 public:
-    SinglyLinkedList() { }
+    SinglyLinkedList() = default;
     ~SinglyLinkedList() { clear(); }
 
     bool is_empty() const { return !head(); }

--- a/AK/SinglyLinkedListWithCount.h
+++ b/AK/SinglyLinkedListWithCount.h
@@ -35,8 +35,8 @@ template<typename T>
 class SinglyLinkedListWithCount : private SinglyLinkedList<T> {
 
 public:
-    SinglyLinkedListWithCount() { }
-    ~SinglyLinkedListWithCount() { }
+    SinglyLinkedListWithCount() = default;
+    ~SinglyLinkedListWithCount() = default;
 
     using List = SinglyLinkedList<T>;
 

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -105,10 +105,7 @@ class Span : public Detail::Span<T> {
 public:
     using Detail::Span<T>::Span;
 
-    ALWAYS_INLINE constexpr Span(std::nullptr_t)
-        : Span()
-    {
-    }
+    constexpr Span() = default;
 
     ALWAYS_INLINE constexpr Span(const Span& other)
         : Span(other.m_values, other.m_size)

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -213,7 +213,7 @@ Vector<StringView> String::split_view(const char separator, bool keep_empty) con
 ByteBuffer String::to_byte_buffer() const
 {
     if (!m_impl)
-        return nullptr;
+        return {};
     return ByteBuffer::copy(reinterpret_cast<const u8*>(characters()), length());
 }
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -58,9 +58,9 @@ namespace AK {
 
 class String {
 public:
-    ~String() { }
+    ~String() = default;
 
-    String() { }
+    String() = default;
     String(const StringView&);
 
     String(const String& other)
@@ -153,7 +153,13 @@ public:
 
     [[nodiscard]] bool copy_characters_to_buffer(char* buffer, size_t buffer_size) const;
 
-    ALWAYS_INLINE ReadonlyBytes bytes() const { return m_impl ? m_impl->bytes() : nullptr; }
+    ALWAYS_INLINE ReadonlyBytes bytes() const
+    {
+        if (m_impl) {
+            return m_impl->bytes();
+        }
+        return {};
+    }
 
     ALWAYS_INLINE const char& operator[](size_t i) const
     {

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -39,7 +39,7 @@ public:
     using OutputType = String;
 
     explicit StringBuilder(size_t initial_capacity = inline_capacity);
-    ~StringBuilder() { }
+    ~StringBuilder() = default;
 
     void append(const StringView&);
     void append(const Utf32View&);

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -37,7 +37,7 @@ namespace AK {
 
 class StringView {
 public:
-    ALWAYS_INLINE constexpr StringView() { }
+    ALWAYS_INLINE constexpr StringView() = default;
     ALWAYS_INLINE constexpr StringView(const char* characters, size_t length)
         : m_characters(characters)
         , m_length(length)

--- a/AK/Tests/TestQuickSort.cpp
+++ b/AK/Tests/TestQuickSort.cpp
@@ -37,7 +37,7 @@ TEST_CASE(sorts_without_copy)
         AK_MAKE_NONCOPYABLE(NoCopy);
 
     public:
-        NoCopy() { }
+        NoCopy() = default;
         NoCopy(NoCopy&&) = default;
 
         NoCopy& operator=(NoCopy&&) = default;

--- a/AK/Tests/TestWeakPtr.cpp
+++ b/AK/Tests/TestWeakPtr.cpp
@@ -38,7 +38,7 @@
 class SimpleWeakable : public Weakable<SimpleWeakable>
     , public RefCounted<SimpleWeakable> {
 public:
-    SimpleWeakable() { }
+    SimpleWeakable() = default;
 
 private:
     int m_member { 123 };

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -35,7 +35,7 @@ namespace AK {
 
 class URL {
 public:
-    URL() { }
+    URL() = default;
     URL(const StringView&);
     URL(const char* string)
         : URL(StringView(string))

--- a/AK/UUID.h
+++ b/AK/UUID.h
@@ -38,7 +38,7 @@ public:
     UUID();
     UUID(Array<u8, 16> uuid_buffer);
     UUID(const StringView&);
-    ~UUID() { }
+    ~UUID() = default;
 
     bool operator==(const UUID&) const;
     bool operator!=(const UUID& other) const { return !(*this == other); }

--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -44,7 +44,7 @@ template<typename T, typename EnableIf<IsPointer<T>::value, int>::Type = 0>
 
 class Userspace {
 public:
-    Userspace() { }
+    Userspace() = default;
 
     operator bool() const { return m_ptr; }
     operator FlatPtr() const { return (FlatPtr)m_ptr; }

--- a/AK/Utf32View.h
+++ b/AK/Utf32View.h
@@ -38,8 +38,8 @@ class Utf32CodepointIterator {
     friend class Utf32View;
 
 public:
-    Utf32CodepointIterator() { }
-    ~Utf32CodepointIterator() { }
+    Utf32CodepointIterator() = default;
+    ~Utf32CodepointIterator() = default;
 
     bool operator==(const Utf32CodepointIterator& other) const
     {
@@ -83,7 +83,7 @@ class Utf32View {
 public:
     using Iterator = Utf32CodepointIterator;
 
-    Utf32View() { }
+    Utf32View() = default;
     Utf32View(const u32* code_points, size_t length)
         : m_code_points(code_points)
         , m_length(length)

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -37,8 +37,8 @@ class Utf8CodepointIterator {
     friend class Utf8View;
 
 public:
-    Utf8CodepointIterator() { }
-    ~Utf8CodepointIterator() { }
+    Utf8CodepointIterator() = default;
+    ~Utf8CodepointIterator() = default;
 
     bool operator==(const Utf8CodepointIterator&) const;
     bool operator!=(const Utf8CodepointIterator&) const;
@@ -63,11 +63,11 @@ class Utf8View {
 public:
     using Iterator = Utf8CodepointIterator;
 
-    Utf8View() { }
+    Utf8View() = default;
     explicit Utf8View(const String&);
     explicit Utf8View(const StringView&);
     explicit Utf8View(const char*);
-    ~Utf8View() { }
+    ~Utf8View() = default;
 
     const StringView& as_string() const { return m_string; }
 

--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -37,8 +37,7 @@ class WeakPtr {
     friend class Weakable;
 
 public:
-    WeakPtr() { }
-    WeakPtr(std::nullptr_t) { }
+    WeakPtr() = default;
 
     template<typename U, typename EnableIf<IsBaseOf<T, U>::value>::Type* = nullptr>
     WeakPtr(const WeakPtr<U>& other)
@@ -260,6 +259,15 @@ struct Formatter<WeakPtr<T>> : Formatter<const T*> {
 #endif
     }
 };
+
+template<typename T>
+WeakPtr<T> try_make_weak_ptr(const T* ptr)
+{
+    if (ptr) {
+        return ptr->template make_weak_ptr<T>();
+    }
+    return {};
+}
 
 }
 

--- a/AK/Weakable.h
+++ b/AK/Weakable.h
@@ -130,7 +130,7 @@ public:
     WeakPtr<U> make_weak_ptr() const;
 
 protected:
-    Weakable() { }
+    Weakable() = default;
 
     ~Weakable()
     {

--- a/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Applications/TextEditor/TextEditorWidget.cpp
@@ -445,7 +445,7 @@ TextEditorWidget::TextEditorWidget()
 
     auto& syntax_menu = view_menu.add_submenu("Syntax");
     m_plain_text_highlight = GUI::Action::create_checkable("Plain text", [&](auto&) {
-        m_editor->set_syntax_highlighter(nullptr);
+        m_editor->set_syntax_highlighter({});
         m_editor->update();
     });
     m_plain_text_highlight->set_checked(true);

--- a/DevTools/HackStudio/Editor.cpp
+++ b/DevTools/HackStudio/Editor.cpp
@@ -436,7 +436,7 @@ void Editor::set_document(GUI::TextDocument& doc)
         m_language_client = get_language_client<LanguageClients::Shell::ServerConnection>(project().root_path());
         break;
     default:
-        set_syntax_highlighter(nullptr);
+        set_syntax_highlighter({});
     }
 
     if (m_language_client) {

--- a/DevTools/HackStudio/Project.cpp
+++ b/DevTools/HackStudio/Project.cpp
@@ -43,7 +43,7 @@ Project::~Project()
 OwnPtr<Project> Project::open_with_root_path(const String& root_path)
 {
     if (!Core::File::is_directory(root_path))
-        return nullptr;
+        return {};
     return adopt_own(*new Project(root_path));
 }
 

--- a/DevTools/IPCCompiler/main.cpp
+++ b/DevTools/IPCCompiler/main.cpp
@@ -337,13 +337,13 @@ public:
                 parameter_generator.append(R"~~~(
         @parameter.type@ @parameter.name@ = @parameter.initial_value@;
         if (!decoder.decode(@parameter.name@))
-            return nullptr;
+            return {};
 )~~~");
 
                 if (parameter.attributes.contains_slow("UTF8")) {
                     parameter_generator.append(R"~~~(
         if (!Utf8View(@parameter.name@).validate())
-            return nullptr;
+            return {};
 )~~~");
                 }
             }
@@ -449,7 +449,7 @@ public:
 )~~~");
 #endif
         endpoint_generator.append(R"~~~(
-            return nullptr;
+            return {};
         }
 
         if (message_endpoint_magic != @endpoint.magic@) {
@@ -460,7 +460,7 @@ public:
 )~~~");
 #endif
         endpoint_generator.append(R"~~~(
-            return nullptr;
+            return {};
         }
 
         i32 message_id = 0;
@@ -473,7 +473,7 @@ public:
 )~~~");
 #endif
         endpoint_generator.append(R"~~~(
-            return nullptr;
+            return {};
         }
 
         OwnPtr<IPC::Message> message;
@@ -507,7 +507,7 @@ public:
 )~~~");
 #endif
         endpoint_generator.append(R"~~~(
-            return nullptr;
+            return {};
         }
 
         if (stream.handle_any_error()) {
@@ -518,7 +518,7 @@ public:
 )~~~");
 #endif
         endpoint_generator.append(R"~~~(
-            return nullptr;
+            return {};
         }
 
         return message;
@@ -543,7 +543,7 @@ public:
                 } else {
                     message_generator.append(R"~~~(
             handle(static_cast<const Messages::@endpoint.name@::@message.name@&>(message));
-            return nullptr;
+            return {};
 )~~~");
                 }
             };
@@ -553,7 +553,7 @@ public:
         }
         endpoint_generator.append(R"~~~(
         default:
-            return nullptr;
+            return {};
         }
     }
 )~~~");

--- a/DevTools/Profiler/Profile.cpp
+++ b/DevTools/Profiler/Profile.cpp
@@ -368,7 +368,7 @@ Profile::LibraryMetadata::LibraryMetadata(JsonArray regions)
 
         auto file_or_error = MappedFile::map(path);
         if (file_or_error.is_error()) {
-            m_libraries.set(name, nullptr);
+            m_libraries.set(name, {});
             continue;
         }
         auto elf = ELF::Image(file_or_error.value()->bytes());

--- a/Kernel/ACPI/MultiProcessorParser.cpp
+++ b/Kernel/ACPI/MultiProcessorParser.cpp
@@ -41,7 +41,7 @@ OwnPtr<MultiProcessorParser> MultiProcessorParser::autodetect()
 {
     auto floating_pointer = find_floating_pointer();
     if (!floating_pointer.has_value())
-        return nullptr;
+        return {};
     return adopt_own(*new MultiProcessorParser(floating_pointer.value()));
 }
 

--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -45,12 +45,12 @@ OwnPtr<CoreDump> CoreDump::create(NonnullRefPtr<Process> process, const String& 
 {
     if (!process->is_dumpable()) {
         dbgln("Refusing to generate CoreDump for non-dumpable process {}", process->pid().value());
-        return nullptr;
+        return {};
     }
 
     auto fd = create_target_file(process, output_path);
     if (!fd)
-        return nullptr;
+        return {};
     return adopt_own(*new CoreDump(move(process), fd.release_nonnull()));
 }
 

--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -227,7 +227,7 @@ void SB16::handle_irq(const RegisterState&)
 
 void SB16::wait_for_irq()
 {
-    m_irq_queue.wait_on(nullptr, "SB16");
+    m_irq_queue.wait_on({}, "SB16");
     disable_irq();
 }
 

--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -75,7 +75,7 @@ KResultOr<NonnullRefPtr<FileDescription>> FIFO::open_direction_blocking(FIFO::Di
 
         if (m_writers == 0) {
             locker.unlock();
-            m_write_open_queue.wait_on(nullptr, "FIFO");
+            m_write_open_queue.wait_on({}, "FIFO");
             locker.lock();
         }
     }
@@ -85,7 +85,7 @@ KResultOr<NonnullRefPtr<FileDescription>> FIFO::open_direction_blocking(FIFO::Di
 
         if (m_readers == 0) {
             locker.unlock();
-            m_read_open_queue.wait_on(nullptr, "FIFO");
+            m_read_open_queue.wait_on({}, "FIFO");
             locker.lock();
         }
     }

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -531,7 +531,7 @@ KResult Plan9FS::post_message(Message& message, RefPtr<ReceiveCompletion> comple
     while (size > 0) {
         if (!description.can_write()) {
             auto unblock_flags = Thread::FileBlocker::BlockFlags::None;
-            if (Thread::current()->block<Thread::WriteBlocker>(nullptr, description, unblock_flags).was_interrupted())
+            if (Thread::current()->block<Thread::WriteBlocker>({}, description, unblock_flags).was_interrupted())
                 return KResult(-EINTR);
         }
         auto data_buffer = UserOrKernelBuffer::for_kernel_buffer(const_cast<u8*>(data));
@@ -552,7 +552,7 @@ KResult Plan9FS::do_read(u8* data, size_t size)
     while (size > 0) {
         if (!description.can_read()) {
             auto unblock_flags = Thread::FileBlocker::BlockFlags::None;
-            if (Thread::current()->block<Thread::ReadBlocker>(nullptr, description, unblock_flags).was_interrupted())
+            if (Thread::current()->block<Thread::ReadBlocker>({}, description, unblock_flags).was_interrupted())
                 return KResult(-EINTR);
         }
         auto data_buffer = UserOrKernelBuffer::for_kernel_buffer(data);
@@ -621,7 +621,7 @@ KResult Plan9FS::post_message_and_wait_for_a_reply(Message& message)
     auto result = post_message(message, completion);
     if (result.is_error())
         return result;
-    if (Thread::current()->block<Plan9FS::Blocker>(nullptr, *this, message, completion).was_interrupted())
+    if (Thread::current()->block<Plan9FS::Blocker>({}, *this, message, completion).was_interrupted())
         return KResult(-EINTR);
 
     if (completion->result.is_error()) {

--- a/Kernel/KBuffer.h
+++ b/Kernel/KBuffer.h
@@ -128,7 +128,7 @@ public:
     {
         auto impl = KBufferImpl::try_create_with_size(size, access, name, strategy);
         if (!impl)
-            return nullptr;
+            return {};
         return adopt_own(*new KBuffer(impl.release_nonnull()));
     }
 
@@ -136,7 +136,7 @@ public:
     {
         auto impl = KBufferImpl::try_create_with_bytes(bytes, access, name, strategy);
         if (!impl)
-            return nullptr;
+            return {};
         return adopt_own(*new KBuffer(impl.release_nonnull()));
     }
 

--- a/Kernel/Lock.cpp
+++ b/Kernel/Lock.cpp
@@ -123,7 +123,7 @@ void Lock::lock(Mode mode)
                     ASSERT_NOT_REACHED();
                 }
                 m_lock.store(false, AK::memory_order_release);
-            } while (m_queue.wait_on(nullptr, m_name) == Thread::BlockResult::NotBlocked);
+            } while (m_queue.wait_on({}, m_name) == Thread::BlockResult::NotBlocked);
         } else {
             // I don't know *who* is using "m_lock", so just yield.
             Scheduler::yield_from_critical();

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -457,7 +457,7 @@ void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
             sti();
             break;
         }
-        m_wait_queue.wait_on(nullptr, "E1000NetworkAdapter");
+        m_wait_queue.wait_on({}, "E1000NetworkAdapter");
     }
 #ifdef E1000_DEBUG
     dbgln("E1000: Sent packet, status is now {:#02x}!", (u8)descriptor.status);

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -255,7 +255,7 @@ KResultOr<size_t> IPv4Socket::receive_byte_buffered(FileDescription& description
 
         locker.unlock();
         auto unblocked_flags = Thread::FileDescriptionBlocker::BlockFlags::None;
-        auto res = Thread::current()->block<Thread::ReadBlocker>(nullptr, description, unblocked_flags);
+        auto res = Thread::current()->block<Thread::ReadBlocker>({}, description, unblocked_flags);
         locker.lock();
 
         if (!((u32)unblocked_flags & (u32)Thread::FileDescriptionBlocker::BlockFlags::Read)) {
@@ -306,7 +306,7 @@ KResultOr<size_t> IPv4Socket::receive_packet_buffered(FileDescription& descripti
 
         locker.unlock();
         auto unblocked_flags = Thread::FileDescriptionBlocker::BlockFlags::None;
-        auto res = Thread::current()->block<Thread::ReadBlocker>(nullptr, description, unblocked_flags);
+        auto res = Thread::current()->block<Thread::ReadBlocker>({}, description, unblocked_flags);
         locker.lock();
 
         if (!((u32)unblocked_flags & (u32)Thread::FileDescriptionBlocker::BlockFlags::Read)) {

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -192,7 +192,7 @@ KResult LocalSocket::connect(FileDescription& description, Userspace<const socka
     }
 
     auto unblock_flags = Thread::FileDescriptionBlocker::BlockFlags::None;
-    if (Thread::current()->block<Thread::ConnectBlocker>(nullptr, description, unblock_flags).was_interrupted()) {
+    if (Thread::current()->block<Thread::ConnectBlocker>({}, description, unblock_flags).was_interrupted()) {
         set_connect_side_role(Role::None);
         return KResult(-EINTR);
     }
@@ -329,7 +329,7 @@ KResultOr<size_t> LocalSocket::recvfrom(FileDescription& description, UserOrKern
         }
     } else if (!can_read(description, 0)) {
         auto unblock_flags = Thread::FileDescriptionBlocker::BlockFlags::None;
-        if (Thread::current()->block<Thread::ReadBlocker>(nullptr, description, unblock_flags).was_interrupted())
+        if (Thread::current()->block<Thread::ReadBlocker>({}, description, unblock_flags).was_interrupted())
             return KResult(-EINTR);
     }
     if (!has_attached_peer(description) && socket_buffer->is_empty())

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -114,7 +114,7 @@ void NetworkTask_main(void*)
     for (;;) {
         size_t packet_size = dequeue_packet(buffer, buffer_size, packet_timestamp);
         if (!packet_size) {
-            packet_wait_queue.wait_on(nullptr, "NetworkTask");
+            packet_wait_queue.wait_on({}, "NetworkTask");
             continue;
         }
         if (packet_size < sizeof(EthernetFrameHeader)) {

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -230,7 +230,7 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source, c
     adapter->send({ 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }, request);
 
     Optional<MACAddress> addr;
-    if (!Thread::current()->block<ARPTableBlocker>(nullptr, next_hop_ip, addr).was_interrupted()) {
+    if (!Thread::current()->block<ARPTableBlocker>({}, next_hop_ip, addr).was_interrupted()) {
         if (addr.has_value()) {
 #ifdef ROUTING_DEBUG
             klog() << "Routing: Got ARP response using adapter " << adapter->name().characters() << " for " << next_hop_ip.to_string().characters() << " (" << addr.value().to_string().characters() << ")";

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -400,7 +400,7 @@ KResult TCPSocket::protocol_connect(FileDescription& description, ShouldBlock sh
     if (should_block == ShouldBlock::Yes) {
         locker.unlock();
         auto unblock_flags = Thread::FileBlocker::BlockFlags::None;
-        if (Thread::current()->block<Thread::ConnectBlocker>(nullptr, description, unblock_flags).was_interrupted())
+        if (Thread::current()->block<Thread::ConnectBlocker>({}, description, unblock_flags).was_interrupted())
             return KResult(-EINTR);
         locker.lock();
         ASSERT(setup_state() == SetupState::Completed);

--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -89,7 +89,7 @@ OwnPtr<KBuffer> PerformanceEventBuffer::to_json(ProcessID pid, const String& exe
 {
     KBufferBuilder builder;
     if (!to_json(builder, pid, executable_path))
-        return nullptr;
+        return {};
     return builder.build();
 }
 

--- a/Kernel/Random.cpp
+++ b/Kernel/Random.cpp
@@ -69,7 +69,7 @@ KernelRng::KernelRng()
 void KernelRng::wait_for_entropy()
 {
     if (!resource().is_ready()) {
-        m_seed_queue.wait_on(nullptr, "KernelRng");
+        m_seed_queue.wait_on({}, "KernelRng");
     }
 }
 

--- a/Kernel/Storage/Partition/MBRPartitionTable.cpp
+++ b/Kernel/Storage/Partition/MBRPartitionTable.cpp
@@ -54,7 +54,7 @@ OwnPtr<MBRPartitionTable> MBRPartitionTable::try_to_initialize(const StorageDevi
 {
     auto table = make<MBRPartitionTable>(device, start_lba);
     if (!table->is_valid())
-        return nullptr;
+        return {};
     return table;
 }
 

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -90,16 +90,16 @@ OwnPtr<PartitionTable> StorageManagement::try_to_initialize_partition_table(cons
     if (mbr_table_or_result.error() == PartitionTable::Error::MBRProtective) {
         auto gpt_table_or_result = GUIDPartitionTable::try_to_initialize(device);
         if (gpt_table_or_result.is_error())
-            return nullptr;
+            return {};
         return move(gpt_table_or_result.value());
     }
     if (mbr_table_or_result.error() == PartitionTable::Error::ConatinsEBR) {
         auto ebr_table_or_result = EBRPartitionTable::try_to_initialize(device);
         if (ebr_table_or_result.is_error())
-            return nullptr;
+            return {};
         return move(ebr_table_or_result.value());
     }
-    return nullptr;
+    return {};
 }
 
 NonnullRefPtrVector<DiskPartition> StorageManagement::enumerate_disk_partitions() const

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -27,6 +27,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/ScopeGuard.h>
 #include <AK/TemporaryChange.h>
+#include <AK/WeakPtr.h>
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/FileDescription.h>
 #include <Kernel/PerformanceEventBuffer.h>
@@ -269,7 +270,7 @@ KResultOr<Process::LoadResult> Process::load_elf_object(FileDescription& object_
         executable_size,
         VirtualAddress(elf_image.program_header_table_offset()).offset(load_offset).get(),
         elf_image.program_header_count(),
-        master_tls_region ? master_tls_region->make_weak_ptr() : nullptr,
+        AK::try_make_weak_ptr(master_tls_region),
         master_tls_size,
         master_tls_alignment,
         stack_region->make_weak_ptr()

--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -51,7 +51,7 @@ ssize_t Process::sys$read(int fd, Userspace<u8*> buffer, ssize_t size)
     if (description->is_blocking()) {
         if (!description->can_read()) {
             auto unblock_flags = Thread::FileBlocker::BlockFlags::None;
-            if (Thread::current()->block<Thread::ReadBlocker>(nullptr, *description, unblock_flags).was_interrupted())
+            if (Thread::current()->block<Thread::ReadBlocker>({}, *description, unblock_flags).was_interrupted())
                 return -EINTR;
             if (!((u32)unblock_flags & (u32)Thread::FileBlocker::BlockFlags::Read))
                 return -EAGAIN;

--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -115,7 +115,7 @@ int Process::sys$accept(int accepting_socket_fd, Userspace<sockaddr*> user_addre
     if (!socket.can_accept()) {
         if (accepting_socket_description->is_blocking()) {
             auto unblock_flags = Thread::FileBlocker::BlockFlags::None;
-            if (Thread::current()->block<Thread::AcceptBlocker>(nullptr, *accepting_socket_description, unblock_flags).was_interrupted())
+            if (Thread::current()->block<Thread::AcceptBlocker>({}, *accepting_socket_description, unblock_flags).was_interrupted())
                 return -EINTR;
         } else {
             return -EAGAIN;

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -132,7 +132,7 @@ int Process::sys$join_thread(pid_t tid, Userspace<void**> exit_value)
     // NOTE: pthread_join() cannot be interrupted by signals. Only by death.
     for (;;) {
         KResult try_join_result(KSuccess);
-        auto result = current_thread->block<Thread::JoinBlocker>(nullptr, *thread, try_join_result, joinee_exit_value);
+        auto result = current_thread->block<Thread::JoinBlocker>({}, *thread, try_join_result, joinee_exit_value);
         if (result == Thread::BlockResult::NotBlocked) {
             if (try_join_result.is_error())
                 return try_join_result.error();

--- a/Kernel/Syscalls/waitid.cpp
+++ b/Kernel/Syscalls/waitid.cpp
@@ -42,7 +42,7 @@ KResultOr<siginfo_t> Process::do_waitid(idtype_t idtype, int id, int options)
     }
 
     KResultOr<siginfo_t> result = KResult(KSuccess);
-    if (Thread::current()->block<Thread::WaitBlocker>(nullptr, options, idtype, id, result).was_interrupted())
+    if (Thread::current()->block<Thread::WaitBlocker>({}, options, idtype, id, result).was_interrupted())
         return KResult(-EINTR);
     ASSERT(!result.is_error() || (options & WNOHANG) || result.error() != KSuccess);
     return result;

--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -97,7 +97,7 @@ ssize_t Process::do_write(FileDescription& description, const UserOrKernelBuffer
                 return total_nwritten;
             }
             auto unblock_flags = Thread::FileBlocker::BlockFlags::None;
-            if (Thread::current()->block<Thread::WriteBlocker>(nullptr, description, unblock_flags).was_interrupted()) {
+            if (Thread::current()->block<Thread::WriteBlocker>({}, description, unblock_flags).was_interrupted()) {
                 if (total_nwritten == 0)
                     return -EINTR;
             }

--- a/Kernel/Tasks/FinalizerTask.cpp
+++ b/Kernel/Tasks/FinalizerTask.cpp
@@ -36,7 +36,7 @@ void FinalizerTask::spawn()
         finalizer_thread, "FinalizerTask", [](void*) {
             Thread::current()->set_priority(THREAD_PRIORITY_LOW);
             for (;;) {
-                g_finalizer_wait_queue->wait_on(nullptr, "FinalizerTask");
+                g_finalizer_wait_queue->wait_on({}, "FinalizerTask");
 
                 if (g_finalizer_has_work.exchange(false, AK::MemoryOrder::memory_order_acq_rel) == true)
                     Thread::finalize_dying_threads();

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -316,13 +316,13 @@ void Thread::relock_process(LockMode previous_locked, u32 lock_count_to_restore)
 auto Thread::sleep(clockid_t clock_id, const timespec& duration, timespec* remaining_time) -> BlockResult
 {
     ASSERT(state() == Thread::Running);
-    return Thread::current()->block<Thread::SleepBlocker>(nullptr, Thread::BlockTimeout(false, &duration, nullptr, clock_id), remaining_time);
+    return Thread::current()->block<Thread::SleepBlocker>({}, Thread::BlockTimeout(false, &duration, nullptr, clock_id), remaining_time);
 }
 
 auto Thread::sleep_until(clockid_t clock_id, const timespec& deadline) -> BlockResult
 {
     ASSERT(state() == Thread::Running);
-    return Thread::current()->block<Thread::SleepBlocker>(nullptr, Thread::BlockTimeout(true, &deadline, nullptr, clock_id));
+    return Thread::current()->block<Thread::SleepBlocker>({}, Thread::BlockTimeout(true, &deadline, nullptr, clock_id));
 }
 
 const char* Thread::state_string() const

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -207,10 +207,6 @@ public:
             : m_infinite(true)
         {
         }
-        BlockTimeout(std::nullptr_t)
-            : m_infinite(true)
-        {
-        }
         explicit BlockTimeout(bool is_absolute, const timeval* time, const timespec* start_time = nullptr, clockid_t clock_id = CLOCK_MONOTONIC_COARSE)
             : m_clock_id(clock_id)
             , m_infinite(!time)

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -385,7 +385,7 @@ OwnPtr<Region> MemoryManager::allocate_contiguous_kernel_region(size_t size, con
     ScopedSpinLock lock(s_mm_lock);
     auto range = kernel_page_directory().range_allocator().allocate_anywhere(size);
     if (!range.is_valid())
-        return nullptr;
+        return {};
     auto vmobject = ContiguousVMObject::create_with_size(size);
     return allocate_kernel_region_with_vmobject(range, vmobject, name, access, user_accessible, cacheable);
 }
@@ -396,10 +396,10 @@ OwnPtr<Region> MemoryManager::allocate_kernel_region(size_t size, const StringVi
     ScopedSpinLock lock(s_mm_lock);
     auto range = kernel_page_directory().range_allocator().allocate_anywhere(size);
     if (!range.is_valid())
-        return nullptr;
+        return {};
     auto vmobject = AnonymousVMObject::create_with_size(size, strategy);
     if (!vmobject)
-        return nullptr;
+        return {};
     return allocate_kernel_region_with_vmobject(range, vmobject.release_nonnull(), name, access, user_accessible, cacheable);
 }
 
@@ -409,10 +409,10 @@ OwnPtr<Region> MemoryManager::allocate_kernel_region(PhysicalAddress paddr, size
     ScopedSpinLock lock(s_mm_lock);
     auto range = kernel_page_directory().range_allocator().allocate_anywhere(size);
     if (!range.is_valid())
-        return nullptr;
+        return {};
     auto vmobject = AnonymousVMObject::create_for_physical_range(paddr, size);
     if (!vmobject)
-        return nullptr;
+        return {};
     return allocate_kernel_region_with_vmobject(range, *vmobject, name, access, user_accessible, cacheable);
 }
 
@@ -422,10 +422,10 @@ OwnPtr<Region> MemoryManager::allocate_kernel_region_identity(PhysicalAddress pa
     ScopedSpinLock lock(s_mm_lock);
     auto range = kernel_page_directory().identity_range_allocator().allocate_specific(VirtualAddress(paddr.get()), size);
     if (!range.is_valid())
-        return nullptr;
+        return {};
     auto vmobject = AnonymousVMObject::create_for_physical_range(paddr, size);
     if (!vmobject)
-        return nullptr;
+        return {};
     return allocate_kernel_region_with_vmobject(range, *vmobject, name, access, user_accessible, cacheable);
 }
 
@@ -453,7 +453,7 @@ OwnPtr<Region> MemoryManager::allocate_kernel_region_with_vmobject(VMObject& vmo
     ScopedSpinLock lock(s_mm_lock);
     auto range = kernel_page_directory().range_allocator().allocate_anywhere(size);
     if (!range.is_valid())
-        return nullptr;
+        return {};
     return allocate_kernel_region_with_vmobject(range, vmobject, name, access, user_accessible, cacheable);
 }
 

--- a/Libraries/LibCore/Event.cpp
+++ b/Libraries/LibCore/Event.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/WeakPtr.h>
 #include <LibCore/Event.h>
 #include <LibCore/Object.h>
 
@@ -32,7 +33,7 @@ namespace Core {
 ChildEvent::ChildEvent(Type type, Object& child, Object* insertion_before_child)
     : Core::Event(type)
     , m_child(child.make_weak_ptr())
-    , m_insertion_before_child(insertion_before_child ? insertion_before_child->make_weak_ptr() : nullptr)
+    , m_insertion_before_child(AK::try_make_weak_ptr(insertion_before_child))
 {
 }
 

--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -503,7 +503,7 @@ bool SignalHandlers::remove(int handler_id)
         auto it = m_handlers.find(handler_id);
         if (it != m_handlers.end()) {
             // Mark pending remove
-            m_handlers_pending.set(handler_id, nullptr);
+            m_handlers_pending.set(handler_id, {});
             return true;
         }
         it = m_handlers_pending.find(handler_id);

--- a/Libraries/LibCore/Object.h
+++ b/Libraries/LibCore/Object.h
@@ -256,7 +256,7 @@ const LogStream& operator<<(const LogStream&, const Object&);
     register_property(                                           \
         property_name,                                           \
         [this] { return this->getter(); },                       \
-        nullptr);
+        {});
 
 #define REGISTER_RECT_PROPERTY(property_name, getter, setter)          \
     register_property(                                                 \

--- a/Libraries/LibCoreDump/Reader.cpp
+++ b/Libraries/LibCoreDump/Reader.cpp
@@ -37,7 +37,7 @@ OwnPtr<Reader> Reader::create(const String& path)
 {
     auto file_or_error = MappedFile::map(path);
     if (file_or_error.is_error())
-        return nullptr;
+        return {};
     return adopt_own(*new Reader(file_or_error.release_value()));
 }
 

--- a/Libraries/LibDebug/DebugSession.cpp
+++ b/Libraries/LibDebug/DebugSession.cpp
@@ -90,12 +90,12 @@ OwnPtr<DebugSession> DebugSession::exec_and_attach(const String& command, String
 
     if (waitpid(pid, nullptr, WSTOPPED) != pid) {
         perror("waitpid");
-        return nullptr;
+        return {};
     }
 
     if (ptrace(PT_ATTACH, pid, 0, 0) < 0) {
         perror("PT_ATTACH");
-        return nullptr;
+        return {};
     }
 
     // We want to continue until the exit from the 'execve' sycsall.
@@ -105,7 +105,7 @@ OwnPtr<DebugSession> DebugSession::exec_and_attach(const String& command, String
 
     if (waitpid(pid, nullptr, WSTOPPED) != pid) {
         perror("wait_pid");
-        return nullptr;
+        return {};
     }
 
     auto debug_session = adopt_own(*new DebugSession(pid, source_root));
@@ -114,7 +114,7 @@ OwnPtr<DebugSession> DebugSession::exec_and_attach(const String& command, String
     int wstatus = debug_session->continue_debuggee_and_wait();
     if (WSTOPSIG(wstatus) != SIGTRAP) {
         dbgln("expected SIGTRAP");
-        return nullptr;
+        return {};
     }
 
     // At this point, libraries should have been loaded

--- a/Libraries/LibGUI/Action.cpp
+++ b/Libraries/LibGUI/Action.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/WeakPtr.h>
 #include <LibGUI/AboutDialog.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
@@ -39,7 +40,7 @@ namespace CommonActions {
 
 NonnullRefPtr<Action> make_about_action(const String& app_name, const Icon& app_icon, Window* parent)
 {
-    WeakPtr<Window> weak_parent = parent ? parent->make_weak_ptr<Window>() : nullptr;
+    auto weak_parent = AK::try_make_weak_ptr<Window>(parent);
     return Action::create(String::formatted("About {}", app_name), app_icon.bitmap_for_size(16), [=](auto&) {
         AboutDialog::show(app_name, app_icon.bitmap_for_size(32), weak_parent.ptr());
     });
@@ -288,7 +289,7 @@ void Action::set_checked(bool checked)
 
 void Action::set_group(Badge<ActionGroup>, ActionGroup* group)
 {
-    m_action_group = group ? group->make_weak_ptr() : nullptr;
+    m_action_group = AK::try_make_weak_ptr(group);
 }
 
 void Action::set_icon(const Gfx::Bitmap* icon)

--- a/Libraries/LibIPC/Connection.h
+++ b/Libraries/LibIPC/Connection.h
@@ -171,7 +171,7 @@ protected:
             if (!drain_messages_from_peer())
                 break;
         }
-        return nullptr;
+        return {};
     }
 
     bool drain_messages_from_peer()

--- a/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -43,7 +43,7 @@ void ArrayBufferPrototype::initialize(GlobalObject& global_object)
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.slice, slice, 2, attr);
     // FIXME: This should be an accessor property
-    define_native_property(vm.names.byteLength, byte_length_getter, nullptr, Attribute::Configurable);
+    define_native_property(vm.names.byteLength, byte_length_getter, {}, Attribute::Configurable);
 
     define_property(vm.well_known_symbol_to_string_tag(), js_string(vm.heap(), "ArrayBuffer"), Attribute::Configurable);
 }

--- a/Libraries/LibJS/Runtime/ErrorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ErrorPrototype.cpp
@@ -45,7 +45,7 @@ void ErrorPrototype::initialize(GlobalObject& global_object)
     Object::initialize(global_object);
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_property(vm.names.name, name_getter, name_setter, attr);
-    define_native_property(vm.names.message, message_getter, nullptr, attr);
+    define_native_property(vm.names.message, message_getter, {}, attr);
     define_native_function(vm.names.toString, to_string, 0, attr);
 }
 

--- a/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -50,11 +50,11 @@ void RegExpPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.exec, exec, 1, attr);
 
     u8 readable_attr = Attribute::Configurable;
-    define_native_property(vm.names.flags, flags, nullptr, readable_attr);
-    define_native_property(vm.names.source, source, nullptr, readable_attr);
+    define_native_property(vm.names.flags, flags, {}, readable_attr);
+    define_native_property(vm.names.source, source, {}, readable_attr);
 
 #define __JS_ENUMERATE(flagName, flag_name, flag_char, ECMAScriptFlagName) \
-    define_native_property(vm.names.flagName, flag_name, nullptr, readable_attr);
+    define_native_property(vm.names.flagName, flag_name, {}, readable_attr);
     JS_ENUMERATE_REGEXP_FLAGS
 #undef __JS_ENUMERATE
 }

--- a/Libraries/LibJS/Runtime/ScriptFunction.cpp
+++ b/Libraries/LibJS/Runtime/ScriptFunction.cpp
@@ -73,8 +73,8 @@ void ScriptFunction::initialize(GlobalObject& global_object)
         prototype->define_property(vm.names.constructor, this, Attribute::Writable | Attribute::Configurable);
         define_property(vm.names.prototype, prototype, Attribute::Writable);
     }
-    define_native_property(vm.names.length, length_getter, nullptr, Attribute::Configurable);
-    define_native_property(vm.names.name, name_getter, nullptr, Attribute::Configurable);
+    define_native_property(vm.names.length, length_getter, {}, Attribute::Configurable);
+    define_native_property(vm.names.name, name_getter, {}, Attribute::Configurable);
 }
 
 ScriptFunction::~ScriptFunction()

--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -82,7 +82,7 @@ void StringPrototype::initialize(GlobalObject& global_object)
     StringObject::initialize(global_object);
     u8 attr = Attribute::Writable | Attribute::Configurable;
 
-    define_native_property(vm.names.length, length_getter, nullptr, 0);
+    define_native_property(vm.names.length, length_getter, {}, 0);
     define_native_function(vm.names.charAt, char_at, 1, attr);
     define_native_function(vm.names.charCodeAt, char_code_at, 1, attr);
     define_native_function(vm.names.repeat, repeat, 1, attr);

--- a/Libraries/LibJS/Runtime/SymbolPrototype.cpp
+++ b/Libraries/LibJS/Runtime/SymbolPrototype.cpp
@@ -47,7 +47,7 @@ void SymbolPrototype::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
     Object::initialize(global_object);
-    define_native_property(vm.names.description, description_getter, nullptr, Attribute::Configurable);
+    define_native_property(vm.names.description, description_getter, {}, Attribute::Configurable);
     define_native_function(vm.names.toString, to_string, 0, Attribute::Writable | Attribute::Configurable);
     define_native_function(vm.names.valueOf, value_of, 0, Attribute::Writable | Attribute::Configurable);
 

--- a/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -40,7 +40,7 @@ void TypedArrayPrototype::initialize(GlobalObject& object)
     auto& vm = this->vm();
     Object::initialize(object);
     // FIXME: This should be an accessor property
-    define_native_property(vm.names.length, length_getter, nullptr, Attribute::Configurable);
+    define_native_property(vm.names.length, length_getter, {}, Attribute::Configurable);
 }
 
 TypedArrayPrototype::~TypedArrayPrototype()

--- a/Libraries/LibJS/Runtime/Uint8ClampedArray.cpp
+++ b/Libraries/LibJS/Runtime/Uint8ClampedArray.cpp
@@ -42,7 +42,7 @@ Uint8ClampedArray::Uint8ClampedArray(u32 length, Object& prototype)
     , m_length(length)
 {
     auto& vm = this->vm();
-    define_native_property(vm.names.length, length_getter, nullptr);
+    define_native_property(vm.names.length, length_getter, {});
     m_data = (u8*)calloc(m_length, 1);
 }
 

--- a/Libraries/LibLine/InternalFunctions.cpp
+++ b/Libraries/LibLine/InternalFunctions.cpp
@@ -43,7 +43,7 @@ Function<bool(Editor&)> Editor::find_internal_function(const StringView& name)
 
     ENUMERATE_EDITOR_INTERNAL_FUNCTIONS(__ENUMERATE)
 
-    return nullptr;
+    return {};
 }
 
 void Editor::search_forwards()

--- a/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Libraries/LibMarkdown/CodeBlock.cpp
@@ -112,13 +112,13 @@ String CodeBlock::render_for_terminal(size_t) const
 OwnPtr<CodeBlock> CodeBlock::parse(Vector<StringView>::ConstIterator& lines)
 {
     if (lines.is_end())
-        return nullptr;
+        return {};
 
     constexpr auto tick_tick_tick = "```";
 
     StringView line = *lines;
     if (!line.starts_with(tick_tick_tick))
-        return nullptr;
+        return {};
 
     // Our Markdown extension: we allow
     // specifying a style and a language
@@ -134,7 +134,7 @@ OwnPtr<CodeBlock> CodeBlock::parse(Vector<StringView>::ConstIterator& lines)
     StringView style_spec = line.substring_view(3, line.length() - 3);
     auto spec = Text::parse(style_spec);
     if (!spec.has_value())
-        return nullptr;
+        return {};
 
     ++lines;
 

--- a/Libraries/LibMarkdown/Document.cpp
+++ b/Libraries/LibMarkdown/Document.cpp
@@ -119,7 +119,7 @@ OwnPtr<Document> Document::parse(const StringView& str)
 
         auto line = Paragraph::Line::parse(lines);
         if (!line)
-            return nullptr;
+            return {};
 
         paragraph_lines.append(line.release_nonnull());
     }

--- a/Libraries/LibMarkdown/Heading.cpp
+++ b/Libraries/LibMarkdown/Heading.cpp
@@ -62,7 +62,7 @@ String Heading::render_for_terminal(size_t) const
 OwnPtr<Heading> Heading::parse(Vector<StringView>::ConstIterator& lines)
 {
     if (lines.is_end())
-        return nullptr;
+        return {};
 
     const StringView& line = *lines;
     size_t level;
@@ -73,12 +73,12 @@ OwnPtr<Heading> Heading::parse(Vector<StringView>::ConstIterator& lines)
     }
 
     if (!level || level >= line.length() || line[level] != ' ')
-        return nullptr;
+        return {};
 
     StringView title_view = line.substring_view(level + 1, line.length() - level - 1);
     auto text = Text::parse(title_view);
     if (!text.has_value())
-        return nullptr;
+        return {};
 
     auto heading = make<Heading>(move(text.value()), level);
 

--- a/Libraries/LibMarkdown/HorizontalRule.cpp
+++ b/Libraries/LibMarkdown/HorizontalRule.cpp
@@ -47,19 +47,19 @@ String HorizontalRule::render_for_terminal(size_t view_width) const
 OwnPtr<HorizontalRule> HorizontalRule::parse(Vector<StringView>::ConstIterator& lines)
 {
     if (lines.is_end())
-        return nullptr;
+        return {};
 
     const StringView& line = *lines;
 
     if (line.length() < 3)
-        return nullptr;
+        return {};
     if (!line.starts_with('-') && !line.starts_with('_') && !line.starts_with('*'))
-        return nullptr;
+        return {};
 
     auto first_character = line.characters_without_null_termination()[0];
     for (auto ch : line) {
         if (ch != first_character)
-            return nullptr;
+            return {};
     }
 
     ++lines;

--- a/Libraries/LibMarkdown/List.cpp
+++ b/Libraries/LibMarkdown/List.cpp
@@ -122,20 +122,20 @@ OwnPtr<List> List::parse(Vector<StringView>::ConstIterator& lines)
             if (first)
                 is_ordered = appears_ordered;
             else if (is_ordered != appears_ordered)
-                return nullptr;
+                return {};
 
             if (!flush_item_if_needed())
-                return nullptr;
+                return {};
 
             while (offset + 1 < line.length() && line[offset + 1] == ' ')
                 offset++;
 
         } else {
             if (first)
-                return nullptr;
+                return {};
             for (size_t i = 0; i < offset; i++) {
                 if (line[i] != ' ')
-                    return nullptr;
+                    return {};
             }
         }
 
@@ -149,7 +149,7 @@ OwnPtr<List> List::parse(Vector<StringView>::ConstIterator& lines)
     }
 
     if (!flush_item_if_needed() || first)
-        return nullptr;
+        return {};
     return make<List>(move(items), is_ordered);
 }
 

--- a/Libraries/LibMarkdown/Paragraph.cpp
+++ b/Libraries/LibMarkdown/Paragraph.cpp
@@ -61,11 +61,11 @@ String Paragraph::render_for_terminal(size_t) const
 OwnPtr<Paragraph::Line> Paragraph::Line::parse(Vector<StringView>::ConstIterator& lines)
 {
     if (lines.is_end())
-        return nullptr;
+        return {};
 
     auto text = Text::parse(*lines++);
     if (!text.has_value())
-        return nullptr;
+        return {};
 
     return make<Paragraph::Line>(text.release_value());
 }

--- a/Libraries/LibMarkdown/Table.cpp
+++ b/Libraries/LibMarkdown/Table.cpp
@@ -118,12 +118,12 @@ OwnPtr<Table> Table::parse(Vector<StringView>::ConstIterator& lines)
     auto peek_it = lines;
     auto first_line = *peek_it;
     if (!first_line.starts_with('|'))
-        return nullptr;
+        return {};
 
     ++peek_it;
 
     if (peek_it.is_end())
-        return nullptr;
+        return {};
 
     auto header_segments = first_line.split_view('|', true);
     auto header_delimiters = peek_it->split_view('|', true);
@@ -141,10 +141,10 @@ OwnPtr<Table> Table::parse(Vector<StringView>::ConstIterator& lines)
     ++peek_it;
 
     if (header_delimiters.size() != header_segments.size())
-        return nullptr;
+        return {};
 
     if (header_delimiters.is_empty())
-        return nullptr;
+        return {};
 
     size_t total_width = 0;
 
@@ -154,7 +154,7 @@ OwnPtr<Table> Table::parse(Vector<StringView>::ConstIterator& lines)
     for (size_t i = 0; i < header_segments.size(); ++i) {
         auto text_option = Text::parse(header_segments[i]);
         if (!text_option.has_value())
-            return nullptr; // An invalid 'text' in the header should just fail the table parse.
+            return {}; // An invalid 'text' in the header should just fail the table parse.
 
         auto text = text_option.release_value();
         auto& column = table->m_columns[i];

--- a/Libraries/LibPCIDB/Database.cpp
+++ b/Libraries/LibPCIDB/Database.cpp
@@ -138,10 +138,10 @@ int Database::init()
 
     ParseMode mode = ParseMode::UnknownMode;
 
-    OwnPtr<Vendor> current_vendor = nullptr;
-    OwnPtr<Device> current_device = nullptr;
-    OwnPtr<Class> current_class = nullptr;
-    OwnPtr<Subclass> current_subclass = nullptr;
+    OwnPtr<Vendor> current_vendor {};
+    OwnPtr<Device> current_device {};
+    OwnPtr<Class> current_class {};
+    OwnPtr<Subclass> current_subclass {};
 
     auto commit_device = [&]() {
         if (current_device && current_vendor) {

--- a/Libraries/LibRegex/C/Regex.cpp
+++ b/Libraries/LibRegex/C/Regex.cpp
@@ -69,7 +69,7 @@ int regcomp(regex_t* reg, const char* pattern, int cflags)
 
     // Note that subsequent uses of regcomp() without regfree() _will_ leak memory
     // This could've been prevented if libc provided a reginit() or similar, but it does not.
-    reg->__data = new internal_regex_t { 0, 0, nullptr, 0, ReError::REG_NOERR, {}, 0 };
+    reg->__data = new internal_regex_t { 0, 0, {}, 0, ReError::REG_NOERR, {}, 0 };
 
     auto preg = impl_from(reg);
 

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -142,11 +142,11 @@ void CanvasRenderingContext2D::did_draw(const Gfx::FloatRect&)
 OwnPtr<Gfx::Painter> CanvasRenderingContext2D::painter()
 {
     if (!m_element)
-        return nullptr;
+        return {};
 
     if (!m_element->bitmap()) {
         if (!m_element->create_bitmap())
-            return nullptr;
+            return {};
     }
 
     return make<Gfx::Painter>(*m_element->bitmap());
@@ -208,7 +208,7 @@ RefPtr<ImageData> CanvasRenderingContext2D::create_image_data(int width, int hei
 {
     if (!wrapper()) {
         dbgln("Hmm! Attempted to create ImageData for wrapper-less CRC2D.");
-        return nullptr;
+        return {};
     }
     return ImageData::create_with_size(wrapper()->global_object(), width, height);
 }

--- a/Services/Clipboard/ClientConnection.cpp
+++ b/Services/Clipboard/ClientConnection.cpp
@@ -66,7 +66,7 @@ OwnPtr<Messages::ClipboardServer::SetClipboardDataResponse> ClientConnection::ha
     auto shared_buffer = SharedBuffer::create_from_shbuf_id(message.shbuf_id());
     if (!shared_buffer) {
         did_misbehave("SetClipboardData: Bad shared buffer ID");
-        return nullptr;
+        return {};
     }
     Storage::the().set_data(*shared_buffer, message.data_size(), message.mime_type(), message.metadata().entries());
     return make<Messages::ClipboardServer::SetClipboardDataResponse>();

--- a/Services/ImageDecoder/ClientConnection.cpp
+++ b/Services/ImageDecoder/ClientConnection.cpp
@@ -65,14 +65,14 @@ OwnPtr<Messages::ImageDecoderServer::DecodeImageResponse> ClientConnection::hand
 #ifdef IMAGE_DECODER_DEBUG
         dbgln("Could not map encoded data buffer");
 #endif
-        return nullptr;
+        return {};
     }
 
     if (message.encoded_size() > (size_t)encoded_buffer->size()) {
 #ifdef IMAGE_DECODER_DEBUG
         dbgln("Encoded buffer is smaller than encoded size");
 #endif
-        return nullptr;
+        return {};
     }
 
 #ifdef IMAGE_DECODER_DEBUG

--- a/Services/LaunchServer/ClientConnection.cpp
+++ b/Services/LaunchServer/ClientConnection.cpp
@@ -67,7 +67,7 @@ OwnPtr<Messages::LaunchServer::OpenURLResponse> ClientConnection::handle(const M
         if (!allowed) {
             // You are not on the list, go home!
             did_misbehave(String::formatted("Client requested a combination of handler/URL that was not on the list: '{}' with '{}'", request.handler_name(), request.url()).characters());
-            return nullptr;
+            return {};
         }
     }
 
@@ -94,12 +94,12 @@ OwnPtr<Messages::LaunchServer::AddAllowedURLResponse> ClientConnection::handle(c
 {
     if (m_allowlist_is_sealed) {
         did_misbehave("Got request to add more allowed handlers after list was sealed");
-        return nullptr;
+        return {};
     }
 
     if (!request.url().is_valid()) {
         did_misbehave("Got request to allow invalid URL");
-        return nullptr;
+        return {};
     }
 
     m_allowlist.empend(String(), false, Vector<URL> { request.url() });
@@ -111,12 +111,12 @@ OwnPtr<Messages::LaunchServer::AddAllowedHandlerWithAnyURLResponse> ClientConnec
 {
     if (m_allowlist_is_sealed) {
         did_misbehave("Got request to add more allowed handlers after list was sealed");
-        return nullptr;
+        return {};
     }
 
     if (request.handler_name().is_empty()) {
         did_misbehave("Got request to allow empty handler name");
-        return nullptr;
+        return {};
     }
 
     m_allowlist.empend(request.handler_name(), true, Vector<URL>());
@@ -128,17 +128,17 @@ OwnPtr<Messages::LaunchServer::AddAllowedHandlerWithOnlySpecificURLsResponse> Cl
 {
     if (m_allowlist_is_sealed) {
         did_misbehave("Got request to add more allowed handlers after list was sealed");
-        return nullptr;
+        return {};
     }
 
     if (request.handler_name().is_empty()) {
         did_misbehave("Got request to allow empty handler name");
-        return nullptr;
+        return {};
     }
 
     if (request.urls().is_empty()) {
         did_misbehave("Got request to allow empty URL list");
-        return nullptr;
+        return {};
     }
 
     m_allowlist.empend(request.handler_name(), false, request.urls());
@@ -150,7 +150,7 @@ OwnPtr<Messages::LaunchServer::SealAllowlistResponse> ClientConnection::handle(c
 {
     if (m_allowlist_is_sealed) {
         did_misbehave("Got more than one request to seal the allowed handlers list");
-        return nullptr;
+        return {};
     }
 
     return make<Messages::LaunchServer::SealAllowlistResponse>();

--- a/Services/ProtocolServer/GeminiProtocol.cpp
+++ b/Services/ProtocolServer/GeminiProtocol.cpp
@@ -48,7 +48,7 @@ OwnPtr<Download> GeminiProtocol::start_download(ClientConnection& client, const 
 
     auto pipe_result = get_pipe_for_download();
     if (pipe_result.is_error())
-        return nullptr;
+        return {};
 
     auto output_stream = make<OutputFileStream>(pipe_result.value().write_fd);
     output_stream->make_unbuffered();

--- a/Services/ProtocolServer/HttpProtocol.cpp
+++ b/Services/ProtocolServer/HttpProtocol.cpp
@@ -53,7 +53,7 @@ OwnPtr<Download> HttpProtocol::start_download(ClientConnection& client, const St
 
     auto pipe_result = get_pipe_for_download();
     if (pipe_result.is_error())
-        return nullptr;
+        return {};
 
     auto output_stream = make<OutputFileStream>(pipe_result.value().write_fd);
     output_stream->make_unbuffered();

--- a/Services/ProtocolServer/HttpsProtocol.cpp
+++ b/Services/ProtocolServer/HttpsProtocol.cpp
@@ -53,7 +53,7 @@ OwnPtr<Download> HttpsProtocol::start_download(ClientConnection& client, const S
 
     auto pipe_result = get_pipe_for_download();
     if (pipe_result.is_error())
-        return nullptr;
+        return {};
 
     auto output_stream = make<OutputFileStream>(pipe_result.value().write_fd);
     output_stream->make_unbuffered();

--- a/Services/WindowServer/ClientConnection.cpp
+++ b/Services/WindowServer/ClientConnection.cpp
@@ -125,7 +125,7 @@ OwnPtr<Messages::WindowServer::DestroyMenubarResponse> ClientConnection::handle(
     auto it = m_menubars.find(menubar_id);
     if (it == m_menubars.end()) {
         did_misbehave("DestroyMenubar: Bad menubar ID");
-        return nullptr;
+        return {};
     }
     auto& menubar = *(*it).value;
     MenuManager::the().close_menubar(menubar);
@@ -147,7 +147,7 @@ OwnPtr<Messages::WindowServer::DestroyMenuResponse> ClientConnection::handle(con
     auto it = m_menus.find(menu_id);
     if (it == m_menus.end()) {
         did_misbehave("DestroyMenu: Bad menu ID");
-        return nullptr;
+        return {};
     }
     auto& menu = *(*it).value;
     menu.close();
@@ -162,7 +162,7 @@ OwnPtr<Messages::WindowServer::SetApplicationMenubarResponse> ClientConnection::
     auto it = m_menubars.find(menubar_id);
     if (it == m_menubars.end()) {
         did_misbehave("SetApplicationMenubar: Bad menubar ID");
-        return nullptr;
+        return {};
     }
     auto& menubar = *(*it).value;
     m_app_menubar = menubar.make_weak_ptr();
@@ -178,11 +178,11 @@ OwnPtr<Messages::WindowServer::AddMenuToMenubarResponse> ClientConnection::handl
     auto jt = m_menus.find(menu_id);
     if (it == m_menubars.end()) {
         did_misbehave("AddMenuToMenubar: Bad menubar ID");
-        return nullptr;
+        return {};
     }
     if (jt == m_menus.end()) {
         did_misbehave("AddMenuToMenubar: Bad menu ID");
-        return nullptr;
+        return {};
     }
     auto& menubar = *(*it).value;
     auto& menu = *(*jt).value;
@@ -197,7 +197,7 @@ OwnPtr<Messages::WindowServer::AddMenuItemResponse> ClientConnection::handle(con
     auto it = m_menus.find(menu_id);
     if (it == m_menus.end()) {
         dbg() << "AddMenuItem: Bad menu ID: " << menu_id;
-        return nullptr;
+        return {};
     }
     auto& menu = *(*it).value;
     auto menu_item = make<MenuItem>(menu, identifier, message.text(), message.shortcut(), message.enabled(), message.checkable(), message.checked());
@@ -206,7 +206,7 @@ OwnPtr<Messages::WindowServer::AddMenuItemResponse> ClientConnection::handle(con
     if (message.icon_buffer_id() != -1) {
         auto icon_buffer = SharedBuffer::create_from_shbuf_id(message.icon_buffer_id());
         if (!icon_buffer)
-            return nullptr;
+            return {};
         // FIXME: Verify that the icon buffer can accommodate a 16x16 bitmap view.
         auto shared_icon = Gfx::Bitmap::create_with_shared_buffer(Gfx::BitmapFormat::RGBA32, icon_buffer.release_nonnull(), { 16, 16 });
         menu_item->set_icon(shared_icon);
@@ -224,7 +224,7 @@ OwnPtr<Messages::WindowServer::PopupMenuResponse> ClientConnection::handle(const
     auto it = m_menus.find(menu_id);
     if (it == m_menus.end()) {
         did_misbehave("PopupMenu: Bad menu ID");
-        return nullptr;
+        return {};
     }
     auto& menu = *(*it).value;
     menu.popup(position);
@@ -237,7 +237,7 @@ OwnPtr<Messages::WindowServer::DismissMenuResponse> ClientConnection::handle(con
     auto it = m_menus.find(menu_id);
     if (it == m_menus.end()) {
         did_misbehave("DismissMenu: Bad menu ID");
-        return nullptr;
+        return {};
     }
     auto& menu = *(*it).value;
     menu.close();
@@ -250,13 +250,13 @@ OwnPtr<Messages::WindowServer::UpdateMenuItemResponse> ClientConnection::handle(
     auto it = m_menus.find(menu_id);
     if (it == m_menus.end()) {
         did_misbehave("UpdateMenuItem: Bad menu ID");
-        return nullptr;
+        return {};
     }
     auto& menu = *(*it).value;
     auto* menu_item = menu.item_with_identifier(message.identifier());
     if (!menu_item) {
         did_misbehave("UpdateMenuItem: Bad menu item identifier");
-        return nullptr;
+        return {};
     }
     menu_item->set_text(message.text());
     menu_item->set_shortcut_text(message.shortcut());
@@ -274,7 +274,7 @@ OwnPtr<Messages::WindowServer::AddMenuSeparatorResponse> ClientConnection::handl
     auto it = m_menus.find(menu_id);
     if (it == m_menus.end()) {
         did_misbehave("AddMenuSeparator: Bad menu ID");
-        return nullptr;
+        return {};
     }
     auto& menu = *(*it).value;
     menu.add_item(make<MenuItem>(menu, MenuItem::Separator));
@@ -286,7 +286,7 @@ OwnPtr<Messages::WindowServer::MoveWindowToFrontResponse> ClientConnection::hand
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("MoveWindowToFront: Bad window ID");
-        return nullptr;
+        return {};
     }
     WindowManager::the().move_to_front_and_make_active(*(*it).value);
     return make<Messages::WindowServer::MoveWindowToFrontResponse>();
@@ -297,7 +297,7 @@ OwnPtr<Messages::WindowServer::SetFullscreenResponse> ClientConnection::handle(c
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("SetFullscreen: Bad window ID");
-        return nullptr;
+        return {};
     }
     it->value->set_fullscreen(message.fullscreen());
     return make<Messages::WindowServer::SetFullscreenResponse>();
@@ -308,7 +308,7 @@ OwnPtr<Messages::WindowServer::SetWindowOpacityResponse> ClientConnection::handl
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("SetWindowOpacity: Bad window ID");
-        return nullptr;
+        return {};
     }
     it->value->set_opacity(message.opacity());
     return make<Messages::WindowServer::SetWindowOpacityResponse>();
@@ -348,7 +348,7 @@ OwnPtr<Messages::WindowServer::SetWindowTitleResponse> ClientConnection::handle(
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("SetWindowTitle: Bad window ID");
-        return nullptr;
+        return {};
     }
     it->value->set_title(message.title());
     return make<Messages::WindowServer::SetWindowTitleResponse>();
@@ -359,7 +359,7 @@ OwnPtr<Messages::WindowServer::GetWindowTitleResponse> ClientConnection::handle(
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("GetWindowTitle: Bad window ID");
-        return nullptr;
+        return {};
     }
     return make<Messages::WindowServer::GetWindowTitleResponse>(it->value->title());
 }
@@ -369,7 +369,7 @@ OwnPtr<Messages::WindowServer::IsMaximizedResponse> ClientConnection::handle(con
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("IsMaximized: Bad window ID");
-        return nullptr;
+        return {};
     }
     return make<Messages::WindowServer::IsMaximizedResponse>(it->value->is_maximized());
 }
@@ -379,7 +379,7 @@ OwnPtr<Messages::WindowServer::SetWindowIconBitmapResponse> ClientConnection::ha
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("SetWindowIconBitmap: Bad window ID");
-        return nullptr;
+        return {};
     }
     auto& window = *(*it).value;
 
@@ -400,12 +400,12 @@ OwnPtr<Messages::WindowServer::SetWindowRectResponse> ClientConnection::handle(c
     auto it = m_windows.find(window_id);
     if (it == m_windows.end()) {
         did_misbehave("SetWindowRect: Bad window ID");
-        return nullptr;
+        return {};
     }
     auto& window = *(*it).value;
     if (window.is_fullscreen()) {
         dbgln("ClientConnection: Ignoring SetWindowRect request for fullscreen window");
-        return nullptr;
+        return {};
     }
 
     if (message.rect().location() != window.rect().location()) {
@@ -423,7 +423,7 @@ OwnPtr<Messages::WindowServer::GetWindowRectResponse> ClientConnection::handle(c
     auto it = m_windows.find(window_id);
     if (it == m_windows.end()) {
         did_misbehave("GetWindowRect: Bad window ID");
-        return nullptr;
+        return {};
     }
     return make<Messages::WindowServer::GetWindowRectResponse>(it->value->rect());
 }
@@ -434,7 +434,7 @@ OwnPtr<Messages::WindowServer::GetWindowRectInMenubarResponse> ClientConnection:
     auto it = m_windows.find(window_id);
     if (it == m_windows.end()) {
         did_misbehave("GetWindowRectInMenubar: Bad window ID");
-        return nullptr;
+        return {};
     }
     return make<Messages::WindowServer::GetWindowRectInMenubarResponse>(it->value->rect_in_menubar());
 }
@@ -454,7 +454,7 @@ OwnPtr<Messages::WindowServer::CreateWindowResponse> ClientConnection::handle(co
         parent_window = window_from_id(message.parent_window_id());
         if (!parent_window) {
             did_misbehave("CreateWindow with bad parent_window_id");
-            return nullptr;
+            return {};
         }
     }
 
@@ -518,7 +518,7 @@ OwnPtr<Messages::WindowServer::DestroyWindowResponse> ClientConnection::handle(c
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("DestroyWindow: Bad window ID");
-        return nullptr;
+        return {};
     }
     auto& window = *(*it).value;
     Vector<i32> destroyed_window_ids;
@@ -568,7 +568,7 @@ OwnPtr<Messages::WindowServer::SetWindowBackingStoreResponse> ClientConnection::
     auto it = m_windows.find(window_id);
     if (it == m_windows.end()) {
         did_misbehave("SetWindowBackingStore: Bad window ID");
-        return nullptr;
+        return {};
     }
     auto& window = *(*it).value;
     if (window.last_backing_store() && window.last_backing_store()->shbuf_id() == message.shbuf_id()) {
@@ -596,7 +596,7 @@ OwnPtr<Messages::WindowServer::SetGlobalCursorTrackingResponse> ClientConnection
     auto it = m_windows.find(window_id);
     if (it == m_windows.end()) {
         did_misbehave("SetGlobalCursorTracking: Bad window ID");
-        return nullptr;
+        return {};
     }
     it->value->set_global_cursor_tracking_enabled(message.enabled());
     return make<Messages::WindowServer::SetGlobalCursorTrackingResponse>();
@@ -607,12 +607,12 @@ OwnPtr<Messages::WindowServer::SetWindowCursorResponse> ClientConnection::handle
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("SetWindowCursor: Bad window ID");
-        return nullptr;
+        return {};
     }
     auto& window = *(*it).value;
     if (message.cursor_type() < 0 || message.cursor_type() >= (i32)Gfx::StandardCursor::__Count) {
         did_misbehave("SetWindowCursor: Bad cursor type");
-        return nullptr;
+        return {};
     }
     window.set_cursor(Cursor::create((Gfx::StandardCursor)message.cursor_type()));
     Compositor::the().invalidate_cursor();
@@ -624,13 +624,13 @@ OwnPtr<Messages::WindowServer::SetWindowCustomCursorResponse> ClientConnection::
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("SetWindowCustomCursor: Bad window ID");
-        return nullptr;
+        return {};
     }
 
     auto& window = *(*it).value;
     if (!message.cursor().is_valid()) {
         did_misbehave("SetWindowCustomCursor: Bad cursor");
-        return nullptr;
+        return {};
     }
 
     window.set_cursor(Cursor::create(*message.cursor().bitmap()));
@@ -643,7 +643,7 @@ OwnPtr<Messages::WindowServer::SetWindowHasAlphaChannelResponse> ClientConnectio
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("SetWindowHasAlphaChannel: Bad window ID");
-        return nullptr;
+        return {};
     }
     it->value->set_has_alpha_channel(message.has_alpha_channel());
     return make<Messages::WindowServer::SetWindowHasAlphaChannelResponse>();
@@ -755,7 +755,7 @@ OwnPtr<Messages::WindowServer::StartDragResponse> ClientConnection::handle(const
         ssize_t size_in_bytes = message.bitmap_size().area() * sizeof(Gfx::RGBA32);
         if (size_in_bytes > shared_buffer->size()) {
             did_misbehave("SetAppletBackingStore: Shared buffer is too small for applet size");
-            return nullptr;
+            return {};
         }
         bitmap = Gfx::Bitmap::create_with_shared_buffer(Gfx::BitmapFormat::RGBA32, *shared_buffer, message.bitmap_size());
     }
@@ -769,7 +769,7 @@ OwnPtr<Messages::WindowServer::SetSystemMenuResponse> ClientConnection::handle(c
     auto it = m_menus.find(message.menu_id());
     if (it == m_menus.end()) {
         did_misbehave("SetSystemMenu called with invalid menu ID");
-        return nullptr;
+        return {};
     }
 
     auto& menu = it->value;
@@ -813,7 +813,7 @@ OwnPtr<Messages::WindowServer::SetWindowBaseSizeAndSizeIncrementResponse> Client
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("SetWindowBaseSizeAndSizeIncrementResponse: Bad window ID");
-        return nullptr;
+        return {};
     }
 
     auto& window = *it->value;
@@ -828,7 +828,7 @@ OwnPtr<Messages::WindowServer::SetWindowResizeAspectRatioResponse> ClientConnect
     auto it = m_windows.find(message.window_id());
     if (it == m_windows.end()) {
         did_misbehave("SetWindowResizeAspectRatioResponse: Bad window ID");
-        return nullptr;
+        return {};
     }
 
     auto& window = *it->value;
@@ -886,7 +886,7 @@ OwnPtr<Messages::WindowServer::SetMouseAccelerationResponse> ClientConnection::h
 {
     if (message.factor() < mouse_accel_min || message.factor() > mouse_accel_max) {
         did_misbehave("SetMouseAcceleration with bad acceleration factor");
-        return nullptr;
+        return {};
     }
     WindowManager::the().set_acceleration_factor(message.factor());
     return make<Messages::WindowServer::SetMouseAccelerationResponse>();
@@ -901,7 +901,7 @@ OwnPtr<Messages::WindowServer::SetScrollStepSizeResponse> ClientConnection::hand
 {
     if (message.step_size() < scroll_step_size_min) {
         did_misbehave("SetScrollStepSize with bad scroll step size");
-        return nullptr;
+        return {};
     }
     WindowManager::the().set_scroll_step_size(message.step_size());
     return make<Messages::WindowServer::SetScrollStepSizeResponse>();

--- a/Services/WindowServer/WindowManager.h
+++ b/Services/WindowServer/WindowManager.h
@@ -169,8 +169,21 @@ public:
     void start_window_resize(Window&, const Gfx::IntPoint&, MouseButton);
     void start_window_resize(Window&, const MouseEvent&);
 
-    const Window* active_fullscreen_window() const { return (m_active_window && m_active_window->is_fullscreen()) ? m_active_window : nullptr; }
-    Window* active_fullscreen_window() { return (m_active_window && m_active_window->is_fullscreen()) ? m_active_window : nullptr; }
+    const Window* active_fullscreen_window() const
+    {
+        if (m_active_window && m_active_window->is_fullscreen()) {
+            return m_active_window;
+        }
+        return nullptr;
+    };
+
+    Window* active_fullscreen_window()
+    {
+        if (m_active_window && m_active_window->is_fullscreen()) {
+            return m_active_window;
+        }
+        return nullptr;
+    }
 
     bool update_theme(String theme_path, String theme_name);
 

--- a/Userland/expr.cpp
+++ b/Userland/expr.cpp
@@ -370,7 +370,7 @@ public:
         Match,
     };
 
-    StringExpression(StringOperation op, NonnullOwnPtr<Expression> string, OwnPtr<Expression> pos_or_chars = nullptr, OwnPtr<Expression> length = nullptr)
+    StringExpression(StringOperation op, NonnullOwnPtr<Expression> string, OwnPtr<Expression> pos_or_chars = {}, OwnPtr<Expression> length = {})
         : m_op(op)
         , m_str(move(string))
         , m_pos_or_chars(move(pos_or_chars))

--- a/Userland/find.cpp
+++ b/Userland/find.cpp
@@ -338,7 +338,7 @@ static OwnPtr<Command> parse_simple_command(char* argv[])
     StringView arg = argv[optind];
 
     if (arg.is_null()) {
-        return nullptr;
+        return {};
     } else if (arg == "(") {
         optind++;
         auto command = parse_complex_command(argv);

--- a/Userland/test.cpp
+++ b/Userland/test.cpp
@@ -345,7 +345,7 @@ static OwnPtr<Condition> parse_simple_expression(char* argv[])
 {
     StringView arg = argv[optind];
     if (arg.is_null()) {
-        return nullptr;
+        return {};
     }
 
     if (arg == "(") {
@@ -403,7 +403,7 @@ static OwnPtr<Condition> parse_simple_expression(char* argv[])
             // '-a' and '-o' are boolean ops, which are part of a complex expression
             // so we have nothing to parse, simply return to caller.
             --optind;
-            return nullptr;
+            return {};
         case 'n':
             return make<StringCompare>("", value, StringCompare::NotEqual);
         case 'z':


### PR DESCRIPTION
Problem:
- Many constructors are defined as `{}` rather than using the ` =
  default` compiler-provided constructor.
- Some types provide an implicit conversion operator from `nullptr_t`
  instead of requiring the caller to default construct. This violates
  the C++ Core Guidelines suggestion to declare single-argument
  constructors explicit
  (https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c46-by-default-declare-single-argument-constructors-explicit).

Solution:
- Change default constructors to use the compiler-provided default
  constructor.
- Remove implicit conversion operators from `nullptr_t` and change
  usage to enforce type consistency without conversion.