### PR TITLE
VimEditingEngine: Add handling { and } to move between empty lines

### DIFF
--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -204,6 +204,12 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
                 move_one_up(event);
                 switch_to_insert_mode();
                 break;
+            case (KeyCode::Key_LeftBrace):
+                move_to_previous_empty_lines_block();
+                break;
+            case (KeyCode::Key_RightBrace):
+                move_to_next_empty_lines_block();
+                break;
             default:
                 break;
             }
@@ -538,5 +544,45 @@ void VimEditingEngine::put(const GUI::KeyEvent& event)
         move_one_left(event);
     }
 }
+
+void VimEditingEngine::move_to_previous_empty_lines_block()
+{
+    VERIFY(!m_editor.is_null());
+    size_t line_idx = m_editor->cursor().line();
+    bool skipping_initial_empty_lines = true;
+    while (line_idx > 0) {
+        if (m_editor->document().line(line_idx).is_empty()) {
+            if (!skipping_initial_empty_lines)
+                break;
+        } else {
+            skipping_initial_empty_lines = false;
+        }
+        line_idx--;
+    }
+
+    TextPosition new_cursor = { line_idx, 0 };
+
+    m_editor->set_cursor(new_cursor);
+};
+
+void VimEditingEngine::move_to_next_empty_lines_block()
+{
+    VERIFY(!m_editor.is_null());
+    size_t line_idx = m_editor->cursor().line();
+    bool skipping_initial_empty_lines = true;
+    while (line_idx < m_editor->line_count() - 1) {
+        if (m_editor->document().line(line_idx).is_empty()) {
+            if (!skipping_initial_empty_lines)
+                break;
+        } else {
+            skipping_initial_empty_lines = false;
+        }
+        line_idx++;
+    }
+
+    TextPosition new_cursor = { line_idx, 0 };
+
+    m_editor->set_cursor(new_cursor);
+};
 
 }

--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -67,6 +67,8 @@ private:
     void switch_to_visual_mode();
     void move_half_page_up(const KeyEvent& event);
     void move_half_page_down(const KeyEvent& event);
+    void move_to_previous_empty_lines_block();
+    void move_to_next_empty_lines_block();
 
     bool on_key_in_insert_mode(const KeyEvent& event);
     bool on_key_in_normal_mode(const KeyEvent& event);


### PR DESCRIPTION
This makes the Vim emulator handle SHIFT+LeftBrace  and SHIFT+RightBrace to jump to the previous / next empty lines block.