### PR TITLE
Run on-target tests in QEMU in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,20 +9,13 @@ env:
   SERENITY_ROOT: ${{ github.workspace }}
 
 jobs:
-  build_and_test:
+  build_and_test_serenity:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-20.04
-            allow-test-failure: false
-            # There sure is a lot of logic here, is there a better way?
-            # TODO: Make IRC notifications its own job/workflow?
-            should-notify-irc: ${{ github.repository == 'SerenityOS/serenity' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')) }}
-          - os: macos-10.15
-            allow-test-failure: true
-            should-notify-irc: false
+        debug-macros: ['ALL_DEBUG', 'NORMAL_DEBUG']
+        os: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2
@@ -37,7 +30,6 @@ jobs:
     - name: Purge interfering packages
       # Remove GCC 9 and clang-format 10 (installed by default)
       run: sudo apt-get purge -y gcc-9 g++-9 libstdc++-9-dev clang-format-10
-      if: ${{ runner.os == 'Linux' }}
     - name: "Install Ubuntu dependencies"
       # These packages are already part of the ubuntu-20.04 image:
       # cmake gcc-10 g++-10 shellcheck libgmp-dev
@@ -46,17 +38,9 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
         sudo apt-get update
-        sudo apt-get install clang-format-11 libstdc++-10-dev libmpfr-dev libmpc-dev ninja-build npm
-      # If we ever do any qemu-emulation on Github Actions, we should re-enable this:
-      # e2fsprogs qemu-system-i386 qemu-utils
-      if: ${{ runner.os == 'Linux' }}
+        sudo apt-get install clang-format-11 libstdc++-10-dev libmpfr-dev libmpc-dev ninja-build npm e2fsprogs qemu-utils qemu-system-i386
     - name: Use GCC 10 instead
       run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
-      if: ${{ runner.os == 'Linux' }}
-
-    - name: Install macOS dependencies
-      run: brew install coreutils ninja
-      if: ${{ runner.os == 'macOS' }}
 
     - name: Install JS dependencies
       run: sudo npm install -g prettier
@@ -72,7 +56,6 @@ jobs:
 
     - name: Lint (Phase 1/2)
       run: ${{ github.workspace }}/Meta/lint-ci.sh
-      if: ${{ runner.os == 'Linux' }}
     - name: Toolchain cache
       uses: actions/cache@v2
       with:
@@ -86,6 +69,15 @@ jobs:
     # TODO: ccache
     # https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
     # https://github.com/cristianadam/HelloWorld/blob/master/.github/workflows/build_cmake.yml
+    - name: Create build environment with debug macros
+      working-directory: ${{ github.workspace }}
+      # Build the entire project with debug macros turned on, to prevent code rot.
+      # However, it is unweildy and slow to run tests with them enabled, so we will build twice.
+      run: |
+        mkdir -p Build
+        cd Build
+        cmake .. -GNinja -DBUILD_LAGOM=ON -DENABLE_ALL_THE_DEBUG_MACROS=ON -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+      if: ${{ matrix.debug-macros == 'ALL_DEBUG' }}
     - name: Create build environment
       working-directory: ${{ github.workspace }}
       # Note that this needs to run *even if* the Toolchain was built,
@@ -93,9 +85,10 @@ jobs:
       run: |
         mkdir -p Build
         cd Build
-        cmake .. -GNinja -DBUILD_LAGOM=ON -DENABLE_ALL_THE_DEBUG_MACROS=ON -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+        cmake .. -GNinja -DBUILD_LAGOM=ON -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+      if: ${{ matrix.debug-macros == 'NORMAL_DEBUG' }}
 
-    # === ACTUALLY BUILD AND TEST ===
+    # === ACTUALLY BUILD ===
 
     - name: Build Serenity and Tests
       working-directory: ${{ github.workspace }}/Build
@@ -103,16 +96,106 @@ jobs:
     - name: Lint (Phase 2/2)
       working-directory: ${{ github.workspace }}/Meta
       run: ./check-symbols.sh
-    - name: Run CMake tests
+
+    - name: Create Serenity Rootfs
+      if: ${{ matrix.debug-macros == 'NORMAL_DEBUG'}}
       working-directory: ${{ github.workspace }}/Build
+      run: ninja install && ninja image
+
+    - name: Run On-Target Tests
+      if: ${{ matrix.debug-macros == 'NORMAL_DEBUG'}}
+      working-directory: ${{ github.workspace }}/Build
+      env:
+        SERENITY_KERNEL_CMDLINE: "boot_mode=self-test"
+        SERENITY_RUN: "ci"
+      run: ninja run
+      timeout-minutes: 10
+    - name: Print target logs
+      if: ${{ !cancelled() && matrix.debug-macros == 'NORMAL_DEBUG'}}
+      working-directory: ${{ github.workspace }}/Build
+      run: cat ./debug.log
+
+  build_and_test_lagom:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - with-fuzzers: FUZZ
+            os: ubuntu-20.04
+            allow-test-failure: false
+          - with-fuzzers: NO_FUZZ
+            os: ubuntu-20.04
+            allow-test-failure: false
+          - with-fuzzers: NO_FUZZ
+            os: macos-10.15
+            allow-test-failure: true
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # === OS SETUP ===
+    #
+    - name: Install Ubuntu dependencies
+      run: sudo apt-get install ninja-build
+      if: ${{ runner.os == 'Linux' }}
+    - name: Install macOS dependencies
+      run: brew install ninja
+      if: ${{ runner.os == 'macOS' }}
+    - name: Check versions
+      run: set +e; clang --version; clang++ --version; ninja --version
+
+    # === PREPARE FOR BUILDING ===
+
+    # TODO: ccache
+    # https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
+    # https://github.com/cristianadam/HelloWorld/blob/master/.github/workflows/build_cmake.yml
+    - name: Create build environment (fuzz)
+      working-directory: ${{ github.workspace }}/Meta/Lagom
+      run: |
+        mkdir -p Build
+        cd Build
+        cmake -GNinja -DBUILD_LAGOM=ON -DENABLE_FUZZER_SANITIZER=ON -DENABLE_ADDRESS_SANITIZER=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ..
+      if: ${{ matrix.with-fuzzers == 'FUZZ' }}
+
+    - name: Create build environment (no fuzz)
+      working-directory: ${{ github.workspace }}/Meta/Lagom
+      run: |
+        mkdir -p Build
+        cd Build
+        cmake -GNinja -DBUILD_LAGOM=ON -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 ..
+      if: ${{ matrix.with-fuzzers == 'NO_FUZZ' }}
+
+    # === ACTUALLY BUILD AND TEST ===
+
+    - name: Build Lagom
+      working-directory: ${{ github.workspace }}/Meta/Lagom/Build
+      run: cmake --build .
+
+    - name: Run CMake tests
+      working-directory: ${{ github.workspace }}/Meta/Lagom/Build
       run: CTEST_OUTPUT_ON_FAILURE=1 ninja test || ${{ matrix.allow-test-failure }}
       timeout-minutes: 2
+      if: ${{ matrix.with-fuzzers == 'NO_FUZZ' }}
     - name: Run JS tests
-      working-directory: ${{ github.workspace }}/Build/Meta/Lagom
+      working-directory: ${{ github.workspace }}/Meta/Lagom/Build
+      if: ${{ matrix.with-fuzzers == 'NO_FUZZ' }}
       run: DISABLE_DBG_OUTPUT=1 ./test-js || ${{ matrix.allow-test-failure }}
     - name: Run LibCompress tests
-      working-directory: ${{ github.workspace }}/Build/Meta/Lagom
+      working-directory: ${{ github.workspace }}/Meta/Lagom/Build
       run: ./test-compress
+      if: ${{ matrix.with-fuzzers == 'NO_FUZZ' }}
+
+  notify_irc:
+    needs: [build_and_test_serenity, build_and_test_lagom]
+    runs-on: ubuntu-20.04
+    if: always() && github.repository == 'SerenityOS/serenity' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master'))
+
+    steps:
+    - uses: actions/checkout@v2
+    # Sets environment variable env.WORKFLOW_CONCLUSION to one of [neutral, success, skipped, cancelled, timed_out, action_required, failure]
+    # depending on result of all needs jobs
+    - uses: technote-space/workflow-conclusion-action@v2
 
     # === NOTIFICATIONS ===
 
@@ -122,43 +205,13 @@ jobs:
       run: |
         cat <<"EOF"
         ${{ toJSON(github.event) }}
+        ${{ toJSON(needs) }}
         EOF
     - name: Generate IRC message
-      if: matrix.should-notify-irc == true && !cancelled()
+      if: always()
       run: |
         ${{ github.workspace }}/Meta/notify_irc.py <<"EOF"
-        ["${{ github.actor }}", ${{ github.run_id }}, "${{ job.status }}",
+        ["${{ github.actor }}", ${{ github.run_id }}, "${{ env.WORKFLOW_CONCLUSION }}",
         ${{ toJSON(github.event) }}
         ]
         EOF
-
-  build_lagom_with_fuzzers:
-    runs-on: ubuntu-20.04
-
-    steps:
-    - uses: actions/checkout@v2
-
-    # === OS SETUP ===
-    #
-    - name: Install dependencies
-      run: sudo apt-get install ninja-build
-    - name: Check versions
-      run: set +e; clang --version; clang++ --version; ninja --version
-
-    # === PREPARE FOR BUILDING ===
-
-    # TODO: ccache
-    # https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
-    # https://github.com/cristianadam/HelloWorld/blob/master/.github/workflows/build_cmake.yml
-    - name: Create build environment
-      working-directory: ${{ github.workspace }}/Meta/Lagom
-      run: |
-        mkdir -p Build
-        cd Build
-        cmake -GNinja -DBUILD_LAGOM=ON -DENABLE_FUZZER_SANITIZER=ON -DENABLE_ADDRESS_SANITIZER=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ..
-
-    # === ACTUALLY BUILD ===
-
-    - name: Build Lagom with Fuzzers
-      working-directory: ${{ github.workspace }}/Meta/Lagom/Build
-      run: cmake --build .

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -110,6 +110,8 @@ jobs:
         SERENITY_RUN: "ci"
       run: ninja run
       timeout-minutes: 10
+      # FIXME: When stable, remove continue on error. (See issue #5541)
+      continue-on-error: true
     - name: Print target logs
       if: ${{ !cancelled() && matrix.debug-macros == 'NORMAL_DEBUG'}}
       working-directory: ${{ github.workspace }}/Build

--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -1,3 +1,5 @@
 include(${CMAKE_SOURCE_DIR}/Meta/CMake/utils.cmake)
 serenity_install_headers(AK)
 serenity_install_sources(AK)
+
+add_subdirectory(Tests)

--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+
+
 set(AK_TEST_SOURCES
     TestAllOf.cpp
     TestAnyOf.cpp
@@ -51,17 +53,6 @@ set(AK_TEST_SOURCES
 foreach(source ${AK_TEST_SOURCES})
     get_filename_component(name ${source} NAME_WE)
     add_executable(${name} ${source})
-    target_link_libraries(${name} LagomCore)
-    add_test(
-        NAME ${name}
-        COMMAND ${name}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-
-    set_tests_properties(
-        ${name}
-        PROPERTIES
-            FAIL_REGULAR_EXPRESSION
-            "FAIL"
-    )
+    target_link_libraries(${name} LibCore)
+    install(TARGETS ${name} RUNTIME DESTINATION usr/Tests/AK)
 endforeach()

--- a/AK/Tests/TestCircularDuplexStream.cpp
+++ b/AK/Tests/TestCircularDuplexStream.cpp
@@ -41,7 +41,7 @@ TEST_CASE(works_like_a_queue)
     }
 
     for (size_t idx = 0; idx < capacity; ++idx) {
-        u8 byte;
+        u8 byte = 0;
         stream >> byte;
 
         EXPECT_EQ(queue.dequeue(), byte);
@@ -70,7 +70,7 @@ TEST_CASE(overwritting_is_well_defined)
         stream << static_cast<u8>(idx % 256);
 
     for (size_t idx = 0; idx < capacity; ++idx) {
-        u8 byte;
+        u8 byte = 0;
         stream >> byte;
 
         if (idx < half_capacity)

--- a/AK/Tests/TestMemoryStream.cpp
+++ b/AK/Tests/TestMemoryStream.cpp
@@ -101,7 +101,7 @@ TEST_CASE(seeking_slicing_offset)
     const Array<u8, 4> expected1 { 4, 5, 6, 7 };
     const Array<u8, 4> expected2 { 1, 2, 3, 4 };
 
-    Array<u8, 4> actual0, actual1, actual2;
+    Array<u8, 4> actual0 {}, actual1 {}, actual2 {};
 
     InputMemoryStream stream { input };
 

--- a/AK/Tests/TestNumberFormat.cpp
+++ b/AK/Tests/TestNumberFormat.cpp
@@ -129,35 +129,22 @@ TEST_CASE(extremes_4byte)
     EXPECT_EQ(human_readable_size(0xffffffff), "3.9 GiB");
 }
 
-template<int>
-void actual_extremes_8byte();
-
-template<>
-void actual_extremes_8byte<4>()
-{
-    warnln("(Skipping 8-byte-size_t test)");
-}
-
-template<>
-void actual_extremes_8byte<8>()
-{
-    warnln("(Running true 8-byte-size_t test)");
-    // Your editor might show "implicit conversion" warnings here.
-    // This is because your editor thinks the world is 32-bit, but it isn't.
-    EXPECT_EQ(human_readable_size(0x100000000ULL), "4.0 GiB");
-    EXPECT_EQ(human_readable_size(0x100000001ULL), "4.0 GiB");
-    EXPECT_EQ(human_readable_size(0x800000000ULL), "32.0 GiB");
-    EXPECT_EQ(human_readable_size(0x10000000000ULL), "1024.0 GiB");
-
-    // Oh yeah! These are *correct*!
-    EXPECT_EQ(human_readable_size(0x7fffffffffffffffULL), "8589934591.9 GiB");
-    EXPECT_EQ(human_readable_size(0x8000000000000000ULL), "8589934592.0 GiB");
-    EXPECT_EQ(human_readable_size(0xffffffffffffffffULL), "17179869183.9 GiB");
-}
-
 TEST_CASE(extremes_8byte)
 {
-    actual_extremes_8byte<sizeof(size_t)>();
+    if constexpr (sizeof(size_t) == 8) {
+        warnln("(Running 8-byte-size_t test)");
+        EXPECT_EQ(human_readable_size(0x100000000ULL), "4.0 GiB");
+        EXPECT_EQ(human_readable_size(0x100000001ULL), "4.0 GiB");
+        EXPECT_EQ(human_readable_size(0x800000000ULL), "32.0 GiB");
+        EXPECT_EQ(human_readable_size(0x10000000000ULL), "1024.0 GiB");
+
+        // Oh yeah! These are *correct*!
+        EXPECT_EQ(human_readable_size(0x7fffffffffffffffULL), "8589934591.9 GiB");
+        EXPECT_EQ(human_readable_size(0x8000000000000000ULL), "8589934592.0 GiB");
+        EXPECT_EQ(human_readable_size(0xffffffffffffffffULL), "17179869183.9 GiB");
+    } else {
+        warnln("(Skipping 8-byte-size_t test on 32-bit platform)");
+    }
 }
 
 TEST_MAIN(NumberFormat)

--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -4,7 +4,7 @@ SocketPermissions=660
 Lazy=1
 Priority=low
 User=protocol
-BootModes=text,graphical
+BootModes=text,graphical,self-test
 MultiInstance=1
 AcceptSocketConnections=1
 
@@ -39,13 +39,13 @@ Lazy=1
 Priority=low
 KeepAlive=1
 User=lookup
-BootModes=text,graphical
+BootModes=text,graphical,self-test
 
 [DHCPClient]
 Priority=low
 KeepAlive=1
 User=root
-BootModes=text,graphical
+BootModes=text,graphical,self-test
 
 [NotificationServer]
 Socket=/tmp/portal/notify
@@ -175,3 +175,11 @@ AcceptSocketConnections=1
 Executable=/bin/CrashDaemon
 KeepAlive=1
 User=anon
+
+[TestRunner@ttyS0]
+Executable=/home/anon/tests/run-tests-and-shutdown.sh
+StdIO=/dev/ttyS0
+Environment=DO_SHUTDOWN_AFTER_TESTS=1 TERM=xterm PATH=/bin:/usr/bin:/usr/local/bin
+User=anon
+WorkingDirectory=/home/anon
+BootModes=self-test

--- a/Base/home/anon/tests/run-tests-and-shutdown.sh
+++ b/Base/home/anon/tests/run-tests-and-shutdown.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+echo "==== Running Tests on SerenityOS ===="
+
+run() {
+    test_cmd=($*)
+    echo "Running test -- $test_cmd"
+    if $test_cmd {
+        echo "::debug file=$test_cmd:: $test_cmd passed!"
+    } else {
+        echo "::error file=$test_cmd:: $test_cmd returned non-zero exit code, check logs!"
+    }
+}
+
+# TODO: It'd be nice to have a list+list op (as opposed to nest-on-in-another)
+# TODO: It'd be nice to have a list.length or enumerate(list) operation to allow terminal progress bar
+# TODO: test-web requires the window server
+system_tests=(test-js test-pthread test-compress (test-crypto bigint -t))
+# FIXME: Running too much at once is likely to run into #5541. Remove commented out find below when stable
+all_tests=($system_tests) #$(find /usr/Tests -type f | grep -v Kernel | grep -v .inc | shuf))
+
+for list in $all_tests {
+    for $list { run $it }
+}
+
+echo "==== Done running tests ===="
+
+if test $DO_SHUTDOWN_AFTER_TESTS {
+    shutdown -n
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,6 @@ include_directories(${CMAKE_BINARY_DIR})
 add_subdirectory(Meta/Lagom)
 add_subdirectory(Userland/DevTools/IPCCompiler)
 add_subdirectory(Userland/Libraries/LibWeb/CodeGenerators)
-add_subdirectory(AK/Tests)
-add_subdirectory(Userland/Libraries/LibRegex/Tests)
 
 set(write_if_different ${CMAKE_SOURCE_DIR}/Meta/write-only-on-difference.sh)
 

--- a/Documentation/RunningTests.md
+++ b/Documentation/RunningTests.md
@@ -1,0 +1,87 @@
+## Running SerenityOS Tests
+
+There are two classes of tests built during a Serenity build: host tests and target tests. Host tests run on the build
+machine, and use [Lagom](../Meta/Lagom/README.md) to build Serenity userspace libraries for the host platform. Target
+tests run on the Serenity machine, either emulated or bare metal.
+
+### Running Host Tests
+
+There are two ways to build host tests: from a full build, or from a Lagom-only build. The only difference is the CMake
+command used to initailize the build directory.
+
+For a full build, pass `-DBUILD_LAGOM=ON` to the CMake command.
+
+```sh
+mkdir Build
+cd Build
+cmake .. -GNinja -DBUILD_LAGOM=ON
+```
+
+For a Lagom-only build, pass the Lagom directory to CMake.
+
+```sh
+mkdir BuildLagom
+cd BuildLagom
+cmake ../Meta/Lagom -GNinja
+```
+
+In both cases, the tests can be run via ninja after doing a build:
+
+```sh
+ninja && ninja test
+```
+
+### Running Target Tests
+
+Tests built for the Serenity target get installed either into `/usr/Tests` or `/bin`. `/usr/Tests` is preferred, but
+some system tests are installed into `/bin` for historical reasons.
+
+The easiest way to run all of the known tests in the system is to use the `run-tests-and-shutdown.sh` script that gets
+installed into `/home/anon/tests`. When running in CI, the environment variable `$DO_SHUTDOWN_AFTER_TESTS` is set, which
+will run `shutdown -n` after running all the tests.
+
+For completeness, a basic on-target test run will need the Serenity image built and run via QEMU.
+
+```sh
+mkdir Build
+cd Build
+cmake .. -GNinja
+ninja && ninja install && ninja image && ninja run
+```
+
+In the initial terminal, one can easily run the test runner script:
+
+```
+courage ~ $ ./tests/run-tests-and-shutdown.sh
+=== Running Tests on SerenityOS ===
+...
+```
+
+CI runs the tests in self-test mode, using the 'ci' run options and the TestRunner entry in /etc/SystemServer.ini to run
+tests automatically on startup.
+
+The system server entry looks as below:
+
+```ini
+[TestRunner@ttyS0]
+Executable=/home/anon/tests/run-tests-and-shutdown.sh
+StdIO=/dev/ttyS0
+Environment=DO_SHUTDOWN_AFTER_TESTS=1 TERM=xterm PATH=/bin:/usr/bin:/usr/local/bin
+User=anon
+WorkingDirectory=/home/anon
+BootModes=self-test
+```
+
+`/dev/ttyS0` is used as stdio because that serial port is connected when qemu is run with `-display none` and
+`-nographic`, and output to it will show up in the stdout of the qemu window. Seperately, the CI run script redirects
+the serial debug output to `./debug.log` so that both stdout of the tests and the dbgln from the kernel/tests can be
+captured.
+
+To run with CI's TestRunner system server entry, Serenity needs booted in self-test mode. Running the following shell
+lines will boot Serenity in self-test mode, run tests, and exit.
+
+```sh
+export SERENITY_RUN=ci
+export SERENITY_KERNEL_CMDLINE="boot_mode=self-test"
+ninja run
+```

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -247,7 +247,9 @@ void init_stage2(void*)
 
     PCI::initialize();
 
-    bool text_mode = kernel_command_line().lookup("boot_mode").value_or("graphical") == "text";
+    auto boot_mode = kernel_command_line().lookup("boot_mode").value_or("graphical");
+    // FIXME: Richer boot mode options would be nice instead of adding more strcmp here
+    bool text_mode = boot_mode == "text" || boot_mode == "self-test";
 
     if (text_mode) {
         dbgln("Text mode enabled");

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.0)
 project (Lagom)
 
 if (NOT ENABLE_OSS_FUZZ)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option -O2 -Wall -Wextra -Werror -std=c++2a -fPIC -g -Wno-deprecated-copy")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option -Wno-literal-suffix -O2 -Wall -Wextra -Werror -std=c++2a -fPIC -g -Wno-deprecated-copy")
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a -fPIC -g -Wno-deprecated-copy")
 endif()
@@ -42,8 +42,10 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 endif()
 
 file(GLOB AK_SOURCES CONFIGURE_DEPENDS "../../AK/*.cpp")
+file(GLOB AK_TEST_SOURCES CONFIGURE_DEPENDS "../../AK/Tests/*.cpp")
 file(GLOB LIBREGEX_LIBC_SOURCES "../../Userland/Libraries/LibRegex/C/Regex.cpp")
 file(GLOB LIBREGEX_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibRegex/*.cpp")
+file(GLOB LIBREGEX_TESTS CONFIGURE_DEPENDS "../../Userland/Libraries/LibRegex/Tests/*.cpp")
 file(GLOB LIBCORE_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibCore/*.cpp")
 file(GLOB LIBELF_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibELF/*.cpp")
 # There's no way we can reliably make this cross platform
@@ -89,6 +91,7 @@ if (BUILD_LAGOM)
     add_library(Lagom $<TARGET_OBJECTS:LagomCore> ${LAGOM_MORE_SOURCES})
 
     if (NOT ENABLE_OSS_FUZZ AND NOT ENABLE_FUZZER_SANITIZER)
+        enable_testing()
         add_executable(TestApp TestApp.cpp)
         target_link_libraries(TestApp Lagom)
         target_link_libraries(TestApp stdc++)
@@ -159,6 +162,43 @@ if (BUILD_LAGOM)
                 TIMEOUT 10
                 FAIL_REGULAR_EXPRESSION "FAIL"
                 PASS_REGULAR_EXPRESSION "PASS"
+            )
+        endforeach()
+
+        foreach(source ${AK_TEST_SOURCES})
+            get_filename_component(name ${source} NAME_WE)
+            add_executable(${name}_lagom ${source})
+            target_link_libraries(${name}_lagom LagomCore)
+            add_test(
+                NAME ${name}_lagom
+                COMMAND ${name}_lagom
+                # FIXME: Only TestJSON needs this property
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../AK/Tests
+            )
+
+            set_tests_properties(
+                ${name}_lagom
+                PROPERTIES
+                    FAIL_REGULAR_EXPRESSION
+                    "FAIL"
+            )
+        endforeach()
+
+        foreach(source ${LIBREGEX_TESTS})
+            get_filename_component(name ${source} NAME_WE)
+            add_executable(${name}_lagom ${source} ${LAGOM_REGEX_SOURCES})
+            target_link_libraries(${name}_lagom LagomCore)
+            add_test(
+                NAME ${name}_lagom
+                COMMAND ${name}_lagom
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            )
+
+            set_tests_properties(
+                ${name}_lagom
+                PROPERTIES
+                    FAIL_REGULAR_EXPRESSION
+                    "FAIL"
             )
         endforeach()
     endif()

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -11,7 +11,8 @@ if [ "$#" -eq "0" ]; then
             '*.sh' \
             ':!:Toolchain' \
             ':!:Ports' \
-            ':!:Userland/Shell/Tests'
+            ':!:Userland/Shell/Tests' \
+            ':!:Base/home/anon/tests'
     )
 else
     files=()

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -138,6 +138,22 @@ elif [ "$SERENITY_RUN" = "qcmd" ]; then
         -device e1000,netdev=breh \
         -kernel Kernel/Kernel \
         -append "${SERENITY_KERNEL_CMDLINE}"
+elif [ "$SERENITY_RUN" = "ci" ]; then
+    # Meta/run.sh ci: qemu in text mode
+    echo "Running QEMU in CI"
+    "$SERENITY_QEMU_BIN" \
+        $SERENITY_EXTRA_QEMU_ARGS \
+        -s -m $SERENITY_RAM_SIZE \
+        -cpu $SERENITY_QEMU_CPU \
+        -d guest_errors \
+        -smp 2 \
+        -drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk \
+        -device ich9-ahci \
+        -nographic \
+        -display none \
+        -debugcon file:debug.log \
+        -kernel Kernel/Kernel \
+        -append "${SERENITY_KERNEL_CMDLINE}"
 else
     # Meta/run.sh: qemu with user networking
     "$SERENITY_QEMU_BIN" \

--- a/Userland/Libraries/LibRegex/CMakeLists.txt
+++ b/Userland/Libraries/LibRegex/CMakeLists.txt
@@ -8,3 +8,5 @@ set(SOURCES
 
 serenity_lib(LibRegex regex)
 target_link_libraries(LibRegex LibC LibCore)
+
+add_subdirectory(Tests)

--- a/Userland/Libraries/LibRegex/RegexDebug.h
+++ b/Userland/Libraries/LibRegex/RegexDebug.h
@@ -129,8 +129,10 @@ public:
         for (size_t i = 0; i < length; ++i) {
             builder.append('=');
         }
+        auto str = builder.to_string();
+        VERIFY(!str.is_empty());
 
-        fprintf(m_file, "%s\n", builder.to_string().characters());
+        fprintf(m_file, "%s\n", str.characters());
         fflush(m_file);
 
         builder.clear();

--- a/Userland/Libraries/LibRegex/Tests/CMakeLists.txt
+++ b/Userland/Libraries/LibRegex/Tests/CMakeLists.txt
@@ -4,17 +4,6 @@ file(GLOB REGEX_SOURCES CONFIGURE_DEPENDS "../*.cpp" "../C/*.cpp")
 foreach(source ${TEST_SOURCES})
     get_filename_component(name ${source} NAME_WE)
     add_executable(${name} ${source} ${REGEX_SOURCES})
-    target_link_libraries(${name} LagomCore)
-    add_test(
-        NAME ${name}
-        COMMAND ${name}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-
-    set_tests_properties(
-        ${name}
-        PROPERTIES
-            FAIL_REGULAR_EXPRESSION
-            "FAIL"
-    )
+    target_link_libraries(${name} LibCore)
+    install(TARGETS ${name} RUNTIME DESTINATION usr/Tests/LibRegex)
 endforeach()

--- a/Userland/Libraries/LibRegex/Tests/RegexLibC.cpp
+++ b/Userland/Libraries/LibRegex/Tests/RegexLibC.cpp
@@ -163,26 +163,26 @@ TEST_CASE(simple_questionmark_matchall)
 
     EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "a", num_matches, matches, REG_GLOBAL), REG_NOMATCH);
-    EXPECT_EQ(matches[0].rm_cnt, 0u);
+    EXPECT_EQ(matches[0].rm_cnt, 0);
     EXPECT_EQ(regexec(&regex, "daa", num_matches, matches, REG_GLOBAL), REG_NOMATCH);
-    EXPECT_EQ(matches[0].rm_cnt, 0u);
+    EXPECT_EQ(matches[0].rm_cnt, 0);
 
     EXPECT_EQ(regexec(&regex, "ddddd", num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 2u);
+    EXPECT_EQ(matches[0].rm_cnt, 2);
 
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 2u);
-    EXPECT_EQ(matches[1].rm_so, 2u);
-    EXPECT_EQ(matches[1].rm_eo, 4u);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 2);
+    EXPECT_EQ(matches[1].rm_so, 2);
+    EXPECT_EQ(matches[1].rm_eo, 4);
 
     EXPECT_EQ(regexec(&regex, "dd", num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
     EXPECT_EQ(regexec(&regex, "dad", num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
     EXPECT_EQ(regexec(&regex, "dada", num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
     EXPECT_EQ(regexec(&regex, "adadaa", num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
 
     regfree(&regex);
 }
@@ -197,9 +197,9 @@ TEST_CASE(character_class)
     String haystack = "[Window]\nOpacity=255\nAudibleBeep=0\n";
     EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), REG_NOERR);
     EXPECT_EQ(regexec(&regex, haystack.characters(), num_matches, matches, 0), REG_NOMATCH);
-    EXPECT_EQ(matches[0].rm_cnt, 0u);
+    EXPECT_EQ(matches[0].rm_cnt, 0);
     EXPECT_EQ(regexec(&regex, haystack.characters(), num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 24u);
+    EXPECT_EQ(matches[0].rm_cnt, 24);
     EXPECT_EQ(haystack.substring_view(matches[0].rm_so, matches[0].rm_eo - matches[0].rm_so), "W");
     EXPECT_EQ(haystack.substring_view(matches[1].rm_so, matches[1].rm_eo - matches[1].rm_so), "i");
 
@@ -217,7 +217,7 @@ TEST_CASE(character_class2)
     EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED | REG_NEWLINE), REG_NOERR);
     EXPECT_EQ(regexec(&regex, haystack.characters(), num_matches, matches, 0), REG_NOERR);
 
-    EXPECT_EQ(matches[0].rm_cnt, 3u);
+    EXPECT_EQ(matches[0].rm_cnt, 3);
 #if 0
     for (int i = 0; i < num_matches; ++i) {
         fprintf(stderr, "Matches[%i].rm_so: %li, .rm_eo: %li .rm_cnt: %li: ", i, matches[i].rm_so, matches[i].rm_eo, matches[i].rm_cnt);
@@ -275,7 +275,7 @@ TEST_CASE(char_qualifier_asterisk)
 
     EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "#include <regex.h>", num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
 
     regfree(&regex);
 }
@@ -289,7 +289,7 @@ TEST_CASE(char_utf8)
 
     EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "Привет, мир! 😀 γειά σου κόσμος 😀 こんにちは世界", num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 2u);
+    EXPECT_EQ(matches[0].rm_cnt, 2);
 
     regfree(&regex);
 }
@@ -304,12 +304,12 @@ TEST_CASE(parens)
     EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), REG_NOERR);
 
     EXPECT_EQ(regexec(&regex, "testhellotest", num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
 
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 13u);
-    EXPECT_EQ(matches[1].rm_so, 4u);
-    EXPECT_EQ(matches[1].rm_eo, 9u);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 13);
+    EXPECT_EQ(matches[1].rm_so, 4);
+    EXPECT_EQ(matches[1].rm_eo, 9);
 
     regfree(&regex);
 }
@@ -427,18 +427,18 @@ TEST_CASE(parens_qualifier_questionmark)
 
     match_str = "testtest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 8u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 8);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testtest");
 
     match_str = "testhellotest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 13u);
-    EXPECT_EQ(matches[1].rm_so, 4u);
-    EXPECT_EQ(matches[1].rm_eo, 9u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 13);
+    EXPECT_EQ(matches[1].rm_so, 4);
+    EXPECT_EQ(matches[1].rm_eo, 9);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testhellotest");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
@@ -457,32 +457,32 @@ TEST_CASE(parens_qualifier_asterisk)
 
     match_str = "testtest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 8u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 8);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testtest");
 
     match_str = "testhellohellotest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 18u);
-    EXPECT_EQ(matches[1].rm_so, 9u);
-    EXPECT_EQ(matches[1].rm_eo, 14u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 18);
+    EXPECT_EQ(matches[1].rm_so, 9);
+    EXPECT_EQ(matches[1].rm_eo, 14);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testhellohellotest");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
     match_str = "testhellohellotest, testhellotest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 2u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 18u);
-    EXPECT_EQ(matches[1].rm_so, 9u);
-    EXPECT_EQ(matches[1].rm_eo, 14u);
-    EXPECT_EQ(matches[2].rm_so, 20u);
-    EXPECT_EQ(matches[2].rm_eo, 33u);
-    EXPECT_EQ(matches[3].rm_so, 24u);
-    EXPECT_EQ(matches[3].rm_eo, 29u);
+    EXPECT_EQ(matches[0].rm_cnt, 2);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 18);
+    EXPECT_EQ(matches[1].rm_so, 9);
+    EXPECT_EQ(matches[1].rm_eo, 14);
+    EXPECT_EQ(matches[2].rm_so, 20);
+    EXPECT_EQ(matches[2].rm_eo, 33);
+    EXPECT_EQ(matches[3].rm_so, 24);
+    EXPECT_EQ(matches[3].rm_eo, 29);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testhellohellotest");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
     EXPECT_EQ(StringView(&match_str[matches[2].rm_so], matches[2].rm_eo - matches[2].rm_so), "testhellotest");
@@ -503,31 +503,31 @@ TEST_CASE(parens_qualifier_asterisk_2)
 
     match_str = "testasdftest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 12u);
-    EXPECT_EQ(matches[1].rm_so, 4u);
-    EXPECT_EQ(matches[1].rm_eo, 8u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 12);
+    EXPECT_EQ(matches[1].rm_so, 4);
+    EXPECT_EQ(matches[1].rm_eo, 8);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testasdftest");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "asdf");
 
     match_str = "testasdfasdftest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 16u);
-    EXPECT_EQ(matches[1].rm_so, 4u);
-    EXPECT_EQ(matches[1].rm_eo, 12u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 16);
+    EXPECT_EQ(matches[1].rm_so, 4);
+    EXPECT_EQ(matches[1].rm_eo, 12);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testasdfasdftest");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "asdfasdf");
 
     match_str = "testaaaatest, testbbbtest, testtest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 35u);
-    EXPECT_EQ(matches[1].rm_so, 4u);
-    EXPECT_EQ(matches[1].rm_eo, 31u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 35);
+    EXPECT_EQ(matches[1].rm_so, 4);
+    EXPECT_EQ(matches[1].rm_eo, 31);
 
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testaaaatest, testbbbtest, testtest");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "aaaatest, testbbbtest, test");
@@ -549,52 +549,52 @@ TEST_CASE(mulit_parens_qualifier_too_less_result_values)
 
     match_str = "testabtest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches - 1, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 10u);
-    EXPECT_EQ(matches[1].rm_so, 4u);
-    EXPECT_EQ(matches[1].rm_eo, 5u);
-    EXPECT_EQ(matches[2].rm_so, 5u);
-    EXPECT_EQ(matches[2].rm_eo, 6u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 10);
+    EXPECT_EQ(matches[1].rm_so, 4);
+    EXPECT_EQ(matches[1].rm_eo, 5);
+    EXPECT_EQ(matches[2].rm_so, 5);
+    EXPECT_EQ(matches[2].rm_eo, 6);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testabtest");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "a");
     EXPECT_EQ(StringView(&match_str[matches[2].rm_so], matches[2].rm_eo - matches[2].rm_so), "b");
     EXPECT_EQ(matches[3].rm_so, -2);
     EXPECT_EQ(matches[3].rm_eo, -2);
-    EXPECT_EQ(matches[3].rm_cnt, 100u);
+    EXPECT_EQ(matches[3].rm_cnt, 100);
 
     match_str = "testabctest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches - 1, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 11u);
-    EXPECT_EQ(matches[1].rm_so, 4u);
-    EXPECT_EQ(matches[1].rm_eo, 5u);
-    EXPECT_EQ(matches[2].rm_so, 5u);
-    EXPECT_EQ(matches[2].rm_eo, 6u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 11);
+    EXPECT_EQ(matches[1].rm_so, 4);
+    EXPECT_EQ(matches[1].rm_eo, 5);
+    EXPECT_EQ(matches[2].rm_so, 5);
+    EXPECT_EQ(matches[2].rm_eo, 6);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testabctest");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "a");
     EXPECT_EQ(StringView(&match_str[matches[2].rm_so], matches[2].rm_eo - matches[2].rm_so), "b");
     EXPECT_EQ(matches[3].rm_so, -2);
     EXPECT_EQ(matches[3].rm_eo, -2);
-    EXPECT_EQ(matches[3].rm_cnt, 100u);
+    EXPECT_EQ(matches[3].rm_cnt, 100);
 
     match_str = "testabctest, testabctest";
 
     EXPECT_EQ(regexec(&regex, match_str, num_matches - 1, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 2u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 11u);
-    EXPECT_EQ(matches[1].rm_so, 4u);
-    EXPECT_EQ(matches[1].rm_eo, 5u);
-    EXPECT_EQ(matches[2].rm_so, 5u);
-    EXPECT_EQ(matches[2].rm_eo, 6u);
+    EXPECT_EQ(matches[0].rm_cnt, 2);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 11);
+    EXPECT_EQ(matches[1].rm_so, 4);
+    EXPECT_EQ(matches[1].rm_eo, 5);
+    EXPECT_EQ(matches[2].rm_so, 5);
+    EXPECT_EQ(matches[2].rm_eo, 6);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testabctest");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "a");
     EXPECT_EQ(StringView(&match_str[matches[2].rm_so], matches[2].rm_eo - matches[2].rm_so), "b");
     EXPECT_EQ(matches[3].rm_so, -2);
     EXPECT_EQ(matches[3].rm_eo, -2);
-    EXPECT_EQ(matches[3].rm_cnt, 100u);
+    EXPECT_EQ(matches[3].rm_cnt, 100);
 
     regfree(&regex);
 }
@@ -611,20 +611,20 @@ TEST_CASE(multi_parens_qualifier_questionmark)
 
     match_str = "testtest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 8u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 8);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testtest");
 
     match_str = "testabctest";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 11u);
-    EXPECT_EQ(matches[1].rm_so, 4u);
-    EXPECT_EQ(matches[1].rm_eo, 5u);
-    EXPECT_EQ(matches[2].rm_so, 5u);
-    EXPECT_EQ(matches[2].rm_eo, 6u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 11);
+    EXPECT_EQ(matches[1].rm_so, 4);
+    EXPECT_EQ(matches[1].rm_eo, 5);
+    EXPECT_EQ(matches[2].rm_so, 5);
+    EXPECT_EQ(matches[2].rm_eo, 6);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testabctest");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "a");
     EXPECT_EQ(StringView(&match_str[matches[2].rm_so], matches[2].rm_eo - matches[2].rm_so), "b");
@@ -632,24 +632,24 @@ TEST_CASE(multi_parens_qualifier_questionmark)
     match_str = "testabctest, testactest";
 
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 2u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 11u);
-    EXPECT_EQ(matches[1].rm_so, 4u);
-    EXPECT_EQ(matches[1].rm_eo, 5u);
-    EXPECT_EQ(matches[2].rm_so, 5u);
-    EXPECT_EQ(matches[2].rm_eo, 6u);
-    EXPECT_EQ(matches[3].rm_so, 6u);
-    EXPECT_EQ(matches[3].rm_eo, 7u);
+    EXPECT_EQ(matches[0].rm_cnt, 2);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 11);
+    EXPECT_EQ(matches[1].rm_so, 4);
+    EXPECT_EQ(matches[1].rm_eo, 5);
+    EXPECT_EQ(matches[2].rm_so, 5);
+    EXPECT_EQ(matches[2].rm_eo, 6);
+    EXPECT_EQ(matches[3].rm_so, 6);
+    EXPECT_EQ(matches[3].rm_eo, 7);
 
-    EXPECT_EQ(matches[4].rm_so, 13u);
-    EXPECT_EQ(matches[4].rm_eo, 23u);
-    EXPECT_EQ(matches[5].rm_so, 17u);
-    EXPECT_EQ(matches[5].rm_eo, 18u);
+    EXPECT_EQ(matches[4].rm_so, 13);
+    EXPECT_EQ(matches[4].rm_eo, 23);
+    EXPECT_EQ(matches[5].rm_so, 17);
+    EXPECT_EQ(matches[5].rm_eo, 18);
     EXPECT_EQ(matches[6].rm_so, -1);
     EXPECT_EQ(matches[6].rm_eo, -1);
-    EXPECT_EQ(matches[7].rm_so, 18u);
-    EXPECT_EQ(matches[7].rm_eo, 19u);
+    EXPECT_EQ(matches[7].rm_so, 18);
+    EXPECT_EQ(matches[7].rm_eo, 19);
 
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testabctest");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "a");
@@ -673,19 +673,19 @@ TEST_CASE(simple_alternative)
     EXPECT_EQ(regcomp(&regex, pattern.characters(), REG_EXTENDED), REG_NOERR);
 
     EXPECT_EQ(regexec(&regex, "test", num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 4u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 4);
 
     EXPECT_EQ(regexec(&regex, "hello", num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 5u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 5);
 
     EXPECT_EQ(regexec(&regex, "friends", num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 7u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 7);
 
     regfree(&regex);
 }
@@ -702,7 +702,7 @@ TEST_CASE(alternative_match_groups)
 
     match_str = "test";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
     EXPECT_EQ(matches[0].rm_so, 0);
     EXPECT_EQ(matches[0].rm_eo, 4);
     EXPECT_EQ(matches[1].rm_so, -1);
@@ -715,11 +715,11 @@ TEST_CASE(alternative_match_groups)
 
     match_str = "testa";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 5u);
-    EXPECT_EQ(matches[1].rm_so, 4u);
-    EXPECT_EQ(matches[1].rm_eo, 5u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 5);
+    EXPECT_EQ(matches[1].rm_so, 4);
+    EXPECT_EQ(matches[1].rm_eo, 5);
     EXPECT_EQ(matches[2].rm_so, -1);
     EXPECT_EQ(matches[2].rm_eo, -1);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testa");
@@ -728,22 +728,22 @@ TEST_CASE(alternative_match_groups)
 
     match_str = "testb";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 5u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 5);
     EXPECT_EQ(matches[1].rm_so, -1);
     EXPECT_EQ(matches[1].rm_eo, -1);
-    EXPECT_EQ(matches[2].rm_so, 4u);
-    EXPECT_EQ(matches[2].rm_eo, 5u);
+    EXPECT_EQ(matches[2].rm_so, 4);
+    EXPECT_EQ(matches[2].rm_eo, 5);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "testb");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "");
     EXPECT_EQ(StringView(&match_str[matches[2].rm_so], matches[2].rm_eo - matches[2].rm_so), "b");
 
     match_str = "hello friends";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 13u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 13);
     EXPECT_EQ(matches[1].rm_so, -1);
     EXPECT_EQ(matches[1].rm_eo, -1);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hello friends");
@@ -751,9 +751,9 @@ TEST_CASE(alternative_match_groups)
 
     match_str = "hello dear friends";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 18u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 18);
     EXPECT_EQ(matches[1].rm_so, -1);
     EXPECT_EQ(matches[1].rm_eo, -1);
     EXPECT_EQ(matches[2].rm_so, -1);
@@ -767,9 +767,9 @@ TEST_CASE(alternative_match_groups)
 
     match_str = "hello my friends";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 16u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 16);
     EXPECT_EQ(matches[1].rm_so, -1);
     EXPECT_EQ(matches[1].rm_eo, -1);
     EXPECT_EQ(matches[2].rm_so, -1);
@@ -783,13 +783,13 @@ TEST_CASE(alternative_match_groups)
 
     match_str = "testabc";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOMATCH);
-    EXPECT_EQ(matches[0].rm_cnt, 0u);
+    EXPECT_EQ(matches[0].rm_cnt, 0);
     EXPECT_EQ(matches[0].rm_so, -1);
     EXPECT_EQ(matches[0].rm_eo, -1);
 
     match_str = "hello test friends";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOMATCH);
-    EXPECT_EQ(matches[0].rm_cnt, 0u);
+    EXPECT_EQ(matches[0].rm_cnt, 0);
     EXPECT_EQ(matches[0].rm_so, -1);
     EXPECT_EQ(matches[0].rm_eo, -1);
 
@@ -808,35 +808,35 @@ TEST_CASE(parens_qualifier_exact)
 
     match_str = "hello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOMATCH);
-    EXPECT_EQ(matches[0].rm_cnt, 0u);
+    EXPECT_EQ(matches[0].rm_cnt, 0);
 
     match_str = "hellohellohello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 15u);
-    EXPECT_EQ(matches[1].rm_so, 10u);
-    EXPECT_EQ(matches[1].rm_eo, 15u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 15);
+    EXPECT_EQ(matches[1].rm_so, 10);
+    EXPECT_EQ(matches[1].rm_eo, 15);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hellohellohello");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
     match_str = "hellohellohellohello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 15u);
-    EXPECT_EQ(matches[1].rm_so, 10u);
-    EXPECT_EQ(matches[1].rm_eo, 15u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 15);
+    EXPECT_EQ(matches[1].rm_so, 10);
+    EXPECT_EQ(matches[1].rm_eo, 15);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hellohellohello");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
     match_str = "test hellohellohello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 5u);
-    EXPECT_EQ(matches[0].rm_eo, 20u);
-    EXPECT_EQ(matches[1].rm_so, 15u);
-    EXPECT_EQ(matches[1].rm_eo, 20u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 5);
+    EXPECT_EQ(matches[0].rm_eo, 20);
+    EXPECT_EQ(matches[1].rm_so, 15);
+    EXPECT_EQ(matches[1].rm_eo, 20);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hellohellohello");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
@@ -855,46 +855,46 @@ TEST_CASE(parens_qualifier_minimum)
 
     match_str = "hello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOMATCH);
-    EXPECT_EQ(matches[0].rm_cnt, 0u);
+    EXPECT_EQ(matches[0].rm_cnt, 0);
 
     match_str = "hellohellohello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 15u);
-    EXPECT_EQ(matches[1].rm_so, 10u);
-    EXPECT_EQ(matches[1].rm_eo, 15u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 15);
+    EXPECT_EQ(matches[1].rm_so, 10);
+    EXPECT_EQ(matches[1].rm_eo, 15);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hellohellohello");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
     match_str = "hellohellohellohello";
 
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, REG_SEARCH), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 20u);
-    EXPECT_EQ(matches[1].rm_so, 15u);
-    EXPECT_EQ(matches[1].rm_eo, 20u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 20);
+    EXPECT_EQ(matches[1].rm_so, 15);
+    EXPECT_EQ(matches[1].rm_eo, 20);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hellohellohellohello");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
     match_str = "test hellohellohello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 5u);
-    EXPECT_EQ(matches[0].rm_eo, 20u);
-    EXPECT_EQ(matches[1].rm_so, 15u);
-    EXPECT_EQ(matches[1].rm_eo, 20u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 5);
+    EXPECT_EQ(matches[0].rm_eo, 20);
+    EXPECT_EQ(matches[1].rm_so, 15);
+    EXPECT_EQ(matches[1].rm_eo, 20);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hellohellohello");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
     match_str = "test hellohellohellohello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 5u);
-    EXPECT_EQ(matches[0].rm_eo, 25u);
-    EXPECT_EQ(matches[1].rm_so, 20u);
-    EXPECT_EQ(matches[1].rm_eo, 25u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 5);
+    EXPECT_EQ(matches[0].rm_eo, 25);
+    EXPECT_EQ(matches[1].rm_so, 20);
+    EXPECT_EQ(matches[1].rm_eo, 25);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hellohellohellohello");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
@@ -913,45 +913,45 @@ TEST_CASE(parens_qualifier_maximum)
 
     match_str = "hello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOMATCH);
-    EXPECT_EQ(matches[0].rm_cnt, 0u);
+    EXPECT_EQ(matches[0].rm_cnt, 0);
 
     match_str = "hellohellohello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 15u);
-    EXPECT_EQ(matches[1].rm_so, 10u);
-    EXPECT_EQ(matches[1].rm_eo, 15u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 15);
+    EXPECT_EQ(matches[1].rm_so, 10);
+    EXPECT_EQ(matches[1].rm_eo, 15);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hellohellohello");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
     match_str = "hellohellohellohello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 0u);
-    EXPECT_EQ(matches[0].rm_eo, 15u);
-    EXPECT_EQ(matches[1].rm_so, 10u);
-    EXPECT_EQ(matches[1].rm_eo, 15u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 0);
+    EXPECT_EQ(matches[0].rm_eo, 15);
+    EXPECT_EQ(matches[1].rm_so, 10);
+    EXPECT_EQ(matches[1].rm_eo, 15);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hellohellohello");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
     match_str = "test hellohellohello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 5u);
-    EXPECT_EQ(matches[0].rm_eo, 20u);
-    EXPECT_EQ(matches[1].rm_so, 15u);
-    EXPECT_EQ(matches[1].rm_eo, 20u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 5);
+    EXPECT_EQ(matches[0].rm_eo, 20);
+    EXPECT_EQ(matches[1].rm_so, 15);
+    EXPECT_EQ(matches[1].rm_eo, 20);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hellohellohello");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
     match_str = "test hellohellohellohello";
     EXPECT_EQ(regexec(&regex, match_str, num_matches, matches, REG_GLOBAL), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
-    EXPECT_EQ(matches[0].rm_so, 5u);
-    EXPECT_EQ(matches[0].rm_eo, 20u);
-    EXPECT_EQ(matches[1].rm_so, 15u);
-    EXPECT_EQ(matches[1].rm_eo, 20u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
+    EXPECT_EQ(matches[0].rm_so, 5);
+    EXPECT_EQ(matches[0].rm_eo, 20);
+    EXPECT_EQ(matches[1].rm_so, 15);
+    EXPECT_EQ(matches[1].rm_eo, 20);
     EXPECT_EQ(StringView(&match_str[matches[0].rm_so], matches[0].rm_eo - matches[0].rm_so), "hellohellohello");
     EXPECT_EQ(StringView(&match_str[matches[1].rm_so], matches[1].rm_eo - matches[1].rm_so), "hello");
 
@@ -970,7 +970,7 @@ TEST_CASE(char_qualifier_min_max)
     EXPECT_EQ(regexec(&regex, "cc", num_matches, matches, 0), REG_NOMATCH);
     EXPECT_EQ(regexec(&regex, "ccc", num_matches, matches, 0), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "cccccccccccccccccccccccccccccc", num_matches, matches, 0), REG_NOERR);
-    EXPECT_EQ(matches[0].rm_cnt, 1u);
+    EXPECT_EQ(matches[0].rm_cnt, 1);
     EXPECT_EQ(regexec(&regex, "ccccccccccccccccccccccccccccccc", num_matches, matches, 0), REG_NOMATCH);
     EXPECT_EQ(regexec(&regex, "ccccccccccccccccccccccccccccccc", num_matches, matches, REG_GLOBAL), REG_NOERR);
     EXPECT_EQ(regexec(&regex, "cccccccccccccccccccccccccccccccc", num_matches, matches, 0), REG_NOMATCH);

--- a/Userland/Shell/CMakeLists.txt
+++ b/Userland/Shell/CMakeLists.txt
@@ -18,3 +18,9 @@ set(SOURCES
 
 serenity_bin(Shell)
 target_link_libraries(Shell LibShell)
+
+install(DIRECTORY Tests/ DESTINATION usr/Tests/Shell
+        PATTERN "Tests/*"
+        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
+                   GROUP_EXECUTE GROUP_READ
+                   WORLD_EXECUTE WORLD_READ)

--- a/Userland/Shell/Tests/backgrounding.sh
+++ b/Userland/Shell/Tests/backgrounding.sh
@@ -4,7 +4,7 @@ echo "Not running Shell-backgrounding as it has a high failure rate"
 echo PASS
 exit 0
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 setopt --verbose
 

--- a/Userland/Shell/Tests/brace-exp.sh
+++ b/Userland/Shell/Tests/brace-exp.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 setopt --verbose
 

--- a/Userland/Shell/Tests/builtin-redir.sh
+++ b/Userland/Shell/Tests/builtin-redir.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 rm -rf shell-test
 mkdir -p shell-test

--- a/Userland/Shell/Tests/control-structure-as-command.sh
+++ b/Userland/Shell/Tests/control-structure-as-command.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 setopt --verbose
 

--- a/Userland/Shell/Tests/function.sh
+++ b/Userland/Shell/Tests/function.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 # Syntax ok?
 fn() { echo $* }

--- a/Userland/Shell/Tests/if.sh
+++ b/Userland/Shell/Tests/if.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 setopt --verbose
 

--- a/Userland/Shell/Tests/loop.sh
+++ b/Userland/Shell/Tests/loop.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 singlecommand_ok=yes
 multicommand_ok=yes

--- a/Userland/Shell/Tests/match.sh
+++ b/Userland/Shell/Tests/match.sh
@@ -1,6 +1,6 @@
 #!/bin/Shell
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 result=no
 match hello {

--- a/Userland/Shell/Tests/sigpipe.sh
+++ b/Userland/Shell/Tests/sigpipe.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 # `head -n 1` should close stdout of the `Shell -c` command, which means the
 # second echo should exit unsuccessfully and sigpipe.sh.out should not be

--- a/Userland/Shell/Tests/special-vars.sh
+++ b/Userland/Shell/Tests/special-vars.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 if not test "$*" = "" { fail "Argv list not empty" }
 if not test "$#" -eq 0 { fail "Argv list empty but count non-zero" }

--- a/Userland/Shell/Tests/subshell.sh
+++ b/Userland/Shell/Tests/subshell.sh
@@ -1,6 +1,6 @@
-#/bin/sh
+#!/bin/sh
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 setopt --verbose
 

--- a/Userland/Shell/Tests/valid.sh
+++ b/Userland/Shell/Tests/valid.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source test-commons.inc
+source $(dirname "$0")/test-commons.inc
 
 # Are comments ignored?
 # Sanity check: can we do && and || ?

--- a/Userland/Utilities/shuf.cpp
+++ b/Userland/Utilities/shuf.cpp
@@ -40,12 +40,11 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     Vector<String> lines;
 
+    char* buffer = nullptr;
     for (;;) {
-        char* buffer = nullptr;
-        ssize_t buflen = 0;
-        size_t n;
+        size_t n = 0;
         errno = 0;
-        buflen = getline(&buffer, &n, stdin);
+        ssize_t buflen = getline(&buffer, &n, stdin);
         if (buflen == -1 && errno != 0) {
             perror("getline");
             exit(1);
@@ -54,6 +53,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
             break;
         lines.append({ buffer, AK::ShouldChomp::Chomp });
     }
+    free(buffer);
 
     // Fisher-Yates shuffle
     String tmp;


### PR DESCRIPTION
This PR  does a few things:

- Reorganize building of AK, Shell, and LibRegex tests.
   - Test/Tests directories are now always included by their parent. Make sure that  we have rules to install tests onto the Serenity rootfs target.
   - Tests that use CTest or `add_test` are moved to the Lagom CMakeLists.txt

- Remove some unnecessary waitid safety checks from Shell
- Fix a memory leak in shuf
- Add a "ci" run target that has minimal hardware such that it can be run in limited docker containers

- Rework CI script into 3 stages: BuildSerenity, BuildLagom, and NotifyIRC
    - BuildSerenity only runs for ubuntu, and has two variants: with and without ALL_DEBUG. Attempting to run on-target tests with ALL_DEBUG on is an exercise in extreme patience.
    - BuildLagom only builds and runs Lagom tests (and the Fuzzer enabled build). This stage runs on ubuntu and Mac.
    - NotifyIRC uses the action https://github.com/marketplace/actions/workflow-conclusion-action from technote-space to aggregate the matrix job results into the same format as before.
    
- Add documentation on how to run tests.