### PR TITLE
LibGfx: Make Painter::draw_pixel() with thickness = 1 work with RGBA

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1157,8 +1157,10 @@ ALWAYS_INLINE void Painter::fill_scanline_with_draw_op(int y, int x, int width, 
 
 void Painter::draw_pixel(const IntPoint& position, Color color, int thickness)
 {
-    if (thickness == 1)
-        return set_pixel_with_draw_op(m_target->scanline(position.y())[position.x()], color);
+    if (thickness == 1) {
+        auto& pixel = m_target->scanline(position.y())[position.x()];
+        return set_pixel_with_draw_op(pixel, Color::from_rgba(pixel).blend(color));
+    }
     IntRect rect { position.translated(-(thickness / 2), -(thickness / 2)), { thickness, thickness } };
     fill_rect(rect.translated(-state().translation), color);
 }


### PR DESCRIPTION
cherry-picked(-ish) from #4895.