### PR TITLE
AK: StringView::find() / AK: Fix StringView::split_view()

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -469,4 +469,14 @@ String String::vformatted(StringView fmtstr, TypeErasedFormatParams params)
     return builder.to_string();
 }
 
+Optional<size_t> String::find(char c) const
+{
+    return find(StringView { &c, 1 });
+}
+
+Optional<size_t> String::find(const StringView& view) const
+{
+    return StringUtils::find(*this, view);
+}
+
 }

--- a/AK/String.h
+++ b/AK/String.h
@@ -138,6 +138,10 @@ public:
 
     Vector<String> split_limit(char separator, size_t limit, bool keep_empty = false) const;
     Vector<String> split(char separator, bool keep_empty = false) const;
+
+    Optional<size_t> find(char) const;
+    Optional<size_t> find(const StringView&) const;
+
     String substring(size_t start) const;
     String substring(size_t start, size_t length) const;
 

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -25,6 +25,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/MemMem.h>
 #include <AK/Memory.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
@@ -341,6 +342,13 @@ StringView trim_whitespace(const StringView& str, TrimMode mode)
     }
 
     return str.substring_view(substring_start, substring_length);
+}
+
+Optional<size_t> find(const StringView& haystack, const StringView& needle)
+{
+    return AK::memmem_optional(
+        haystack.characters_without_null_termination(), haystack.length(),
+        needle.characters_without_null_termination(), needle.length());
 }
 }
 

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -71,6 +71,7 @@ bool starts_with(const StringView&, const StringView&, CaseSensitivity);
 bool contains(const StringView&, const StringView&, CaseSensitivity);
 bool is_whitespace(const StringView&);
 StringView trim_whitespace(const StringView&, TrimMode mode);
+Optional<size_t> find(const StringView& haystack, const StringView& needle);
 }
 
 }

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -86,14 +86,14 @@ Vector<StringView> StringView::split_view(const StringView& separator, bool keep
 
     Vector<StringView> parts;
 
-    auto maybe_separator_index = find_first_of(separator);
+    auto maybe_separator_index = find(separator);
     while (maybe_separator_index.has_value()) {
         auto separator_index = maybe_separator_index.value();
         auto part_with_separator = view.substring_view(0, separator_index + separator.length());
         if (keep_empty || separator_index > 0)
             parts.append(part_with_separator.substring_view(0, separator_index));
         view = view.substring_view_starting_after_substring(part_with_separator);
-        maybe_separator_index = view.find_first_of(separator);
+        maybe_separator_index = view.find(separator);
     }
     if (keep_empty || !view.is_empty())
         parts.append(view);

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -310,6 +310,16 @@ Optional<size_t> StringView::find_last_of(const StringView& view) const
     return {};
 }
 
+Optional<size_t> StringView::find(char c) const
+{
+    return find(StringView { &c, 1 });
+}
+
+Optional<size_t> StringView::find(const StringView& view) const
+{
+    return StringUtils::find(*this, view);
+}
+
 String StringView::to_string() const { return String { *this }; }
 
 }

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -100,6 +100,9 @@ public:
     Optional<size_t> find_last_of(char) const;
     Optional<size_t> find_last_of(const StringView&) const;
 
+    Optional<size_t> find(const StringView&) const;
+    Optional<size_t> find(char c) const;
+
     StringView substring_view(size_t start, size_t length) const;
     StringView substring_view(size_t start) const;
     Vector<StringView> split_view(char, bool keep_empty = false) const;

--- a/AK/Tests/TestStringUtils.cpp
+++ b/AK/Tests/TestStringUtils.cpp
@@ -298,4 +298,16 @@ TEST_CASE(is_whitespace)
     EXPECT(!AK::StringUtils::is_whitespace("a\t"));
 }
 
+TEST_CASE(find)
+{
+    String test_string = "1234567";
+    EXPECT_EQ(AK::StringUtils::find(test_string, "1").value_or(1), 0u);
+    EXPECT_EQ(AK::StringUtils::find(test_string, "2").value_or(2), 1u);
+    EXPECT_EQ(AK::StringUtils::find(test_string, "3").value_or(3), 2u);
+    EXPECT_EQ(AK::StringUtils::find(test_string, "4").value_or(4), 3u);
+    EXPECT_EQ(AK::StringUtils::find(test_string, "5").value_or(5), 4u);
+    EXPECT_EQ(AK::StringUtils::find(test_string, "34").value_or(3), 2u);
+    EXPECT_EQ(AK::StringUtils::find(test_string, "78").has_value(), false);
+}
+
 TEST_MAIN(StringUtils)

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -292,7 +292,7 @@ bool Editor::save_history(const String& path)
         merge(
             file->line_begin(), file->line_end(), m_history.begin(), m_history.end(), final_history,
             [](StringView str) {
-                auto it = str.find_first_of("::").value_or(0);
+                auto it = str.find("::").value_or(0);
                 auto time = str.substring_view(0, it).to_uint<time_t>().value_or(0);
                 auto string = str.substring_view(it == 0 ? it : it + 2);
                 return HistoryEntry { string, time };


### PR DESCRIPTION
I opted to keep `find_first_of()` under its (very misleading) current name since it mirrors an `std::string` API, and _you better know all the caveats of std::string APIs_.

Also moves the logic in `AK::memmem` to a `AK::memmem_optional` to make it nicer to use.
+ Some tests.

Fixes #4926.