### PR TITLE
Everywhere: Continue replacing dbg() dbgln(). (4)

### DIFF
--- a/AK/Debug.h
+++ b/AK/Debug.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// FIXME: We could generate this file with CMake and configure.
+
+#ifdef PROCESS_DEBUG
+constexpr bool debug_process = true;
+#else
+constexpr bool debug_process = false;
+#endif
+
+#ifdef SCHEDULER_DEBUG
+constexpr bool debug_scheduler = true;
+#else
+constexpr bool debug_scheduler = false;
+#endif
+
+#ifdef SCHEDULER_RUNNABLE_DEBUG
+constexpr bool debug_scheduler_runnable = true;
+#else
+constexpr bool debug_scheduler_runnable = false;
+#endif
+
+#ifdef SHARED_BUFFER_DEBUG
+constexpr bool debug_shared_buffer = true;
+#else
+constexpr bool debug_shared_buffer = false;
+#endif
+
+#ifdef THREAD_DEBUG
+constexpr bool debug_thread = true;
+#else
+constexpr bool debug_thread = false;
+#endif
+
+#ifdef LOCK_DEBUG
+constexpr bool debug_lock = true;
+#else
+constexpr bool debug_lock = false;
+#endif
+
+#ifdef SIGNAL_DEBUG
+constexpr bool debug_signal = true;
+#else
+constexpr bool debug_signal = false;
+#endif

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -392,11 +392,16 @@ inline void warnln() { outln(stderr); }
 
 void vdbgln(StringView fmtstr, TypeErasedFormatParams);
 
-template<typename... Parameters>
-void dbgln(StringView fmtstr, const Parameters&... parameters) { vdbgln(fmtstr, VariadicFormatParams { parameters... }); }
-template<typename... Parameters>
-void dbgln(const char* fmtstr, const Parameters&... parameters) { dbgln(StringView { fmtstr }, parameters...); }
-inline void dbgln() { dbgln(""); }
+template<bool enabled = true, typename... Parameters>
+void dbgln(StringView fmtstr, const Parameters&... parameters)
+{
+    if constexpr (enabled)
+        vdbgln(fmtstr, VariadicFormatParams { parameters... });
+}
+template<bool enabled = true, typename... Parameters>
+void dbgln(const char* fmtstr, const Parameters&... parameters) { dbgln<enabled>(StringView { fmtstr }, parameters...); }
+template<bool enabled = true>
+void dbgln() { dbgln<enabled>(""); }
 
 template<typename T, typename = void>
 struct HasFormatter : TrueType {

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -133,15 +133,6 @@ class WeakPtr;
 template<typename T, size_t inline_capacity = 0>
 class Vector;
 
-template<typename... Parameters>
-void dbgln(const char* fmtstr, const Parameters&...);
-
-template<typename... Parameters>
-void warnln(const char* fmtstr, const Parameters&...);
-
-template<typename... Parameters>
-void outln(const char* fmtstr, const Parameters&...);
-
 }
 
 using AK::Array;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/Debug.h>
 #include <AK/Demangle.h>
 #include <AK/QuickSort.h>
 #include <AK/StdLibExtras.h>
@@ -353,9 +354,7 @@ Process::Process(RefPtr<Thread>& first_thread, const String& name, uid_t uid, gi
     , m_ppid(ppid)
     , m_wait_block_condition(*this)
 {
-#ifdef PROCESS_DEBUG
-    dbg() << "Created new process " << m_name << "(" << m_pid.value() << ")";
-#endif
+    dbgln<debug_process>("Created new process {}({})", m_name, m_pid.value());
 
     m_page_directory = PageDirectory::create_for_userspace(*this, fork_parent ? &fork_parent->page_directory().range_allocator() : nullptr);
 
@@ -618,9 +617,8 @@ bool Process::dump_perfcore()
 void Process::finalize()
 {
     ASSERT(Thread::current() == g_finalizer);
-#ifdef PROCESS_DEBUG
-    dbg() << "Finalizing process " << *this;
-#endif
+
+    dbgln<debug_process>("Finalizing process {}", *this);
 
     if (is_dumpable()) {
         if (m_should_dump_core)

--- a/Kernel/SharedBuffer.h
+++ b/Kernel/SharedBuffer.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Debug.h>
 #include <AK/OwnPtr.h>
 #include <AK/WeakPtr.h>
 #include <Kernel/VM/AnonymousVMObject.h>
@@ -52,16 +53,12 @@ public:
         : m_shbuf_id(id)
         , m_vmobject(move(vmobject))
     {
-#ifdef SHARED_BUFFER_DEBUG
-        dbg() << "Created shared buffer " << m_shbuf_id << " of size " << m_vmobject->size();
-#endif
+        dbgln<debug_shared_buffer>("Created shared buffer {} of size {}", m_shbuf_id, size());
     }
 
     ~SharedBuffer()
     {
-#ifdef SHARED_BUFFER_DEBUG
-        dbg() << "Destroyed shared buffer " << m_shbuf_id << " of size " << size();
-#endif
+        dbgln<debug_shared_buffer>("Destroyed shared buffer {} of size {}", m_shbuf_id, size());
     }
 
     void sanity_check(const char* what);

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -992,7 +992,7 @@ bool Widget::load_from_json(const JsonObject& json, RefPtr<Widget> (*unregistere
         } else if (class_name.to_string() == "GUI::HorizontalBoxLayout") {
             set_layout<GUI::HorizontalBoxLayout>();
         } else {
-            dbg() << "Unknown layout class: '" << class_name.to_string() << "'";
+            dbgln("Unknown layout class: '{}'", class_name.to_string());
             return false;
         }
 

--- a/Userland/Libraries/LibIPC/ClientConnection.h
+++ b/Userland/Libraries/LibIPC/ClientConnection.h
@@ -54,13 +54,13 @@ public:
 
     void did_misbehave()
     {
-        dbg() << *this << " (id=" << m_client_id << ", pid=" << client_pid() << ") misbehaved, disconnecting.";
+        dbgln("{} (id={}, pid={}) misbehaved, disconnecting.", *this, m_client_id, client_pid());
         this->shutdown();
     }
 
     void did_misbehave(const char* message)
     {
-        dbg() << *this << " (id=" << m_client_id << ", pid=" << client_pid() << ") misbehaved (" << message << "), disconnecting.";
+        dbgln("{} (id={}, pid={}) misbehaved ({}), disconnecting.", *this, m_client_id, client_pid(), message);
         this->shutdown();
     }
 
@@ -76,3 +76,8 @@ private:
 };
 
 }
+
+template<>
+template<typename ClientEndpoint, typename ServerEndpoint>
+struct AK::Formatter<IPC::ClientConnection<ClientEndpoint, ServerEndpoint>> : Formatter<Core::Object> {
+};

--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -99,11 +99,11 @@ public:
             if (nwritten < 0) {
                 switch (errno) {
                 case EPIPE:
-                    dbg() << *this << "::post_message: Disconnected from peer";
+                    dbgln("{}::post_message: Disconnected from peer", *this);
                     shutdown();
                     return;
                 case EAGAIN:
-                    dbg() << *this << "::post_message: Peer buffer overflowed";
+                    dbgln("{}::post_message: Peer buffer overflowed", *this);
                     shutdown();
                     return;
                 default:
@@ -231,7 +231,7 @@ protected:
             // in the next run of this function.
             auto remaining_bytes = ByteBuffer::copy(bytes.data() + index, bytes.size() - index);
             if (!m_unprocessed_bytes.is_empty()) {
-                dbg() << *this << "::drain_messages_from_peer: Already have unprocessed bytes";
+                dbgln("{}::drain_messages_from_peer: Already have unprocessed bytes", *this);
                 shutdown();
                 return false;
             }
@@ -279,3 +279,8 @@ protected:
 };
 
 }
+
+template<>
+template<typename LocalEndpoint, typename PeerEndpoint>
+struct AK::Formatter<IPC::Connection<LocalEndpoint, PeerEndpoint>> : Formatter<Core::Object> {
+};

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -78,7 +78,7 @@ RefPtr<Gfx::Bitmap> Client::decode_image(const ByteBuffer& encoded_data)
 
     auto decoded_buffer = SharedBuffer::create_from_shbuf_id(response->decoded_shbuf_id());
     if (!decoded_buffer) {
-        dbg() << "Could not map decoded image shbuf_id=" << response->decoded_shbuf_id();
+        dbgln("Could not map decoded image shbuf_id={}", response->decoded_shbuf_id());
         return nullptr;
     }
 

--- a/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
+++ b/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
@@ -45,7 +45,7 @@ Optional<CharacterMapData> CharacterMapFile::load_from_file(const String& file_n
     auto file = Core::File::construct(path);
     file->open(Core::IODevice::ReadOnly);
     if (!file->is_open()) {
-        dbg() << "Failed to open " << file_name << ":" << file->error_string();
+        dbgln("Failed to open {}: {}", file_name, file->error_string());
         return {};
     }
 

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -367,7 +367,7 @@ void Editor::register_key_input_callback(const KeyBinding& binding)
     if (binding.kind == KeyBinding::Kind::InternalFunction) {
         auto internal_function = find_internal_function(binding.binding);
         if (!internal_function) {
-            dbg() << "LibLine: Unknown internal function '" << binding.binding << "'";
+            dbgln("LibLine: Unknown internal function '{}'", binding.binding);
             return;
         }
         return register_key_input_callback(binding.keys, move(internal_function));
@@ -1644,7 +1644,7 @@ Vector<size_t, 2> Editor::vt_dsr()
                 // ????
                 continue;
             }
-            dbg() << "Error while reading DSR: " << strerror(errno);
+            dbgln("Error while reading DSR: {}", strerror(errno));
             m_input_error = Error::ReadFailure;
             finish();
             return { 1, 1 };

--- a/Userland/Libraries/LibRegex/C/Regex.cpp
+++ b/Userland/Libraries/LibRegex/C/Regex.cpp
@@ -87,7 +87,7 @@ int regcomp(regex_t* reg, const char* pattern, int cflags)
         preg->re_pat_err = (ReError)parser_result.error;
         preg->re_pat = pattern;
 
-        dbg() << "Have Error: " << (ReError)parser_result.error;
+        dbgln("Have Error: {}", (int)parser_result.error);
 
         return (ReError)parser_result.error;
     }

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -62,7 +62,7 @@ ALWAYS_INLINE Token Parser::consume(TokenType type, Error error)
 {
     if (m_parser_state.current_token.type() != type) {
         set_error(error);
-        dbg() << "[PARSER] Error: Unexpected token " << m_parser_state.current_token.name() << ". Expected: " << Token::name(type);
+        dbgln("[PARSER] Error: Unexpected token {}. Expected: {}", m_parser_state.current_token.name(), Token::name(type));
     }
     return consume();
 }

--- a/Userland/Libraries/LibTLS/ClientHandshake.cpp
+++ b/Userland/Libraries/LibTLS/ClientHandshake.cpp
@@ -64,7 +64,7 @@ ssize_t TLSv12::handle_hello(ReadonlyBytes buffer, WritePacketStage& write_packe
     size_t following_bytes = buffer[0] * 0x10000 + buffer[1] * 0x100 + buffer[2];
     res += 3;
     if (buffer.size() - res < following_bytes) {
-        dbg() << "not enough data after header: " << buffer.size() - res << " < " << following_bytes;
+        dbgln("not enough data after header: {} < {}", buffer.size() - res, following_bytes);
         return (i8)Error::NeedMoreData;
     }
 
@@ -160,13 +160,13 @@ ssize_t TLSv12::handle_hello(ReadonlyBytes buffer, WritePacketStage& write_packe
             if (extension_type == HandshakeExtension::ServerName) {
                 u16 sni_host_length = AK::convert_between_host_and_network_endian(*(const u16*)buffer.offset_pointer(res + 3));
                 if (buffer.size() - res - 5 < sni_host_length) {
-                    dbg() << "Not enough data for sni " << (buffer.size() - res - 5) << " < " << sni_host_length;
+                    dbgln("Not enough data for sni {} < {}", (buffer.size() - res - 5), sni_host_length);
                     return (i8)Error::NeedMoreData;
                 }
 
                 if (sni_host_length) {
                     m_context.SNI = String { (const char*)buffer.offset_pointer(res + 5), sni_host_length };
-                    dbg() << "server name indicator: " << m_context.SNI;
+                    dbgln("server name indicator: {}", m_context.SNI);
                 }
             } else if (extension_type == HandshakeExtension::ApplicationLayerProtocolNegotiation && m_context.alpn.size()) {
                 if (buffer.size() - res > 2) {
@@ -181,7 +181,7 @@ ssize_t TLSv12::handle_hello(ReadonlyBytes buffer, WritePacketStage& write_packe
                             String alpn_str { (const char*)alpn + alpn_position, alpn_length };
                             if (alpn_size && m_context.alpn.contains_slow(alpn_str)) {
                                 m_context.negotiated_alpn = alpn_str;
-                                dbg() << "negotiated alpn: " << alpn_str;
+                                dbgln("negotiated alpn: {}", alpn_str);
                                 break;
                             }
                             alpn_position += alpn_length;
@@ -523,7 +523,7 @@ ssize_t TLSv12::handle_payload(ReadonlyBytes vbuffer)
             }
             break;
         default:
-            dbg() << "message type not understood: " << type;
+            dbgln("message type not understood: {}", type);
             return (i8)Error::NotUnderstood;
         }
 
@@ -588,7 +588,7 @@ ssize_t TLSv12::handle_payload(ReadonlyBytes vbuffer)
                 // Ignore this, as it's not an "error"
                 break;
             default:
-                dbg() << "Unknown TLS::Error with value " << payload_res;
+                dbgln("Unknown TLS::Error with value {}", payload_res);
                 ASSERT_NOT_REACHED();
                 break;
             }

--- a/Userland/Libraries/LibTLS/Exchange.cpp
+++ b/Userland/Libraries/LibTLS/Exchange.cpp
@@ -156,7 +156,7 @@ bool TLSv12::compute_master_secret(size_t length)
 {
     if (m_context.premaster_key.size() == 0 || length < 48) {
         dbgln("there's no way I can make a master secret like this");
-        dbg() << "I'd like to talk to your manager about this length of " << length;
+        dbgln("I'd like to talk to your manager about this length of {}", length);
         return false;
     }
 

--- a/Userland/Libraries/LibTLS/Record.cpp
+++ b/Userland/Libraries/LibTLS/Record.cpp
@@ -331,7 +331,7 @@ ssize_t TLSv12::handle_message(ReadonlyBytes buffer)
                 tag);
 
             if (consistency != Crypto::VerificationConsistency::Consistent) {
-                dbg() << "integrity check failed (tag length " << tag.size() << ")";
+                dbgln("integrity check failed (tag length {})", tag.size());
                 auto packet = build_alert(true, (u8)AlertDescription::BadRecordMAC);
                 write_packet(packet);
 
@@ -373,7 +373,7 @@ ssize_t TLSv12::handle_message(ReadonlyBytes buffer)
             auto hmac = hmac_message({ temp_buf, 5 }, decrypted_span.slice(0, length), mac_size);
             auto message_mac = ReadonlyBytes { message_hmac, mac_size };
             if (hmac != message_mac) {
-                dbg() << "integrity check failed (mac length " << mac_size << ")";
+                dbgln("integrity check failed (mac length {})", mac_size);
                 dbgln("mac received:");
                 print_buffer(message_mac);
                 dbgln("mac computed:");
@@ -433,7 +433,7 @@ ssize_t TLSv12::handle_message(ReadonlyBytes buffer)
             auto level = plain[0];
             auto code = plain[1];
             if (level == (u8)AlertLevel::Critical) {
-                dbg() << "We were alerted of a critical error: " << code << " (" << alert_name((AlertDescription)code) << ")";
+                dbgln("We were alerted of a critical error: {} ({})", code, alert_name((AlertDescription)code));
                 m_context.critical_error = code;
                 try_disambiguate_error();
                 res = (i8)Error::UnknownError;

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -102,13 +102,13 @@ static bool _set_algorithm(CertificateKeyAlgorithm& algorithm, const u8* value, 
 
     if (length == 8) {
         // named EC key
-        dbg() << "Cert.algorithm: Named EC (" << *value << "), unsupported";
+        dbgln("Cert.algorithm: Named EC ({}), unsupported", *value);
         return false;
     }
 
     if (length == 5) {
         // named EC SECP key
-        dbg() << "Cert.algorithm: Named EC secp (" << *value << "), unsupported";
+        dbgln("Cert.algorithm: Named EC secp ({}), unsupported", *value);
         return false;
     }
 
@@ -142,7 +142,7 @@ static bool _set_algorithm(CertificateKeyAlgorithm& algorithm, const u8* value, 
         return true;
     }
 
-    dbg() << "Unsupported RSA Signature mode " << value[8];
+    dbgln("Unsupported RSA Signature mode {}", value[8]);
     return false;
 }
 
@@ -385,7 +385,6 @@ static ssize_t _parse_asn1(const Context& context, Certificate& cert, const u8* 
                 }
                 break;
             default:
-                // dbg() << "unused field " << type;
                 break;
             }
         }

--- a/Userland/Libraries/LibTTF/Font.cpp
+++ b/Userland/Libraries/LibTTF/Font.cpp
@@ -199,7 +199,7 @@ RefPtr<Font> Font::load_from_file(const StringView& path, unsigned index)
 {
     auto file_or_error = Core::File::open(String(path), Core::IODevice::ReadOnly);
     if (file_or_error.is_error()) {
-        dbg() << "Could not open file: " << file_or_error.error();
+        dbgln("Could not open file: {}", file_or_error.error());
         return nullptr;
     }
     auto file = file_or_error.value();

--- a/Userland/Libraries/LibTextCodec/Decoder.cpp
+++ b/Userland/Libraries/LibTextCodec/Decoder.cpp
@@ -156,7 +156,7 @@ String get_standardized_encoding(const String& encoding)
     if (trimmed_lowercase_encoding == "x-user-defined")
         return "x-user-defined";
 
-    dbg() << "TextCodec: Unrecognized encoding: " << encoding;
+    dbgln("TextCodec: Unrecognized encoding: {}", encoding);
     return {};
 }
 

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -893,7 +893,7 @@ void Terminal::on_input(u8 ch)
             m_parser_state = Normal;
             return;
         } else {
-            dbg() << "Unexpected character in GotEscape '" << (char)ch << "'";
+            dbgln("Unexpected character in GotEscape '{}'", (char)ch);
             m_parser_state = Normal;
         }
         return;
@@ -919,7 +919,7 @@ void Terminal::on_input(u8 ch)
         if (ch == '\\')
             execute_xterm_command();
         else
-            dbg() << "Unexpected string terminator: " << String::format("%02x", ch);
+            dbgln("Unexpected string terminator: {:#02x}", ch);
         m_parser_state = Normal;
         return;
     case ExpectParameter:
@@ -1216,7 +1216,7 @@ void Terminal::execute_hashtag(u8 hashtag)
         }
         break;
     default:
-        dbg() << "Unknown hashtag: '" << hashtag << "'";
+        dbgln("Unknown hashtag: '{}'", (char)hashtag);
     }
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/CSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/CSSParser.cpp
@@ -34,11 +34,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define PARSE_ASSERT(x)                                                   \
-    if (!(x)) {                                                           \
-        dbg() << "CSS PARSER ASSERTION FAILED: " << #x;                   \
-        dbg() << "At character# " << index << " in CSS: _" << css << "_"; \
-        ASSERT_NOT_REACHED();                                             \
+#define PARSE_ASSERT(x)                                     \
+    if (!(x)) {                                             \
+        dbgln("CSS PARSER ASSERTION FAILED: {}", #x);       \
+        dbgln("At character# {} in CSS: _{}_", index, css); \
+        ASSERT_NOT_REACHED();                               \
     }
 
 #define PARSE_ERROR()             \
@@ -764,7 +764,7 @@ public:
 
         auto property_id = CSS::property_id_from_string(property_name);
         if (property_id == CSS::PropertyID::Invalid) {
-            dbg() << "CSSParser: Unrecognized property '" << property_name << "'";
+            dbgln("CSSParser: Unrecognized property '{}'", property_name);
         }
         auto value = parse_css_value(m_context, property_value, property_id);
         if (!value)

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
@@ -492,7 +492,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
                 }
                 return;
             }
-            dbg() << "Unsure what to do with CSS margin value '" << value.to_string() << "'";
+            dbgln("Unsure what to do with CSS margin value '{}'", value.to_string());
             return;
         }
         return;
@@ -544,7 +544,7 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
                 }
                 return;
             }
-            dbg() << "Unsure what to do with CSS padding value '" << value.to_string() << "'";
+            dbgln("Unsure what to do with CSS padding value '{}'", value.to_string());
             return;
         }
         return;

--- a/Userland/Libraries/LibWeb/DOM/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/DOM/XMLHttpRequest.cpp
@@ -73,13 +73,13 @@ void XMLHttpRequest::open(const String& method, const String& url)
 void XMLHttpRequest::send()
 {
     URL request_url = m_window->document().complete_url(m_url);
-    dbg() << "XHR send from " << m_window->document().url() << " to " << request_url;
+    dbgln("XHR send from {} to {}", m_window->document().url(), request_url);
 
     // TODO: Add support for preflight requests to support CORS requests
     Origin request_url_origin = Origin(request_url.protocol(), request_url.host(), request_url.port());
 
     if (!m_window->document().origin().is_same(request_url_origin)) {
-        dbg() << "XHR failed to load: Same-Origin Policy violation: " << m_window->document().url() << " may not load " << request_url;
+        dbgln("XHR failed to load: Same-Origin Policy violation: {} may not load {}", m_window->document().url(), request_url);
         auto weak_this = make_weak_ptr();
         if (!weak_this)
             return;
@@ -102,7 +102,7 @@ void XMLHttpRequest::send()
         [weak_this = make_weak_ptr()](auto& error) {
             if (!weak_this)
                 return;
-            dbg() << "XHR failed to load: " << error;
+            dbgln("XHR failed to load: {}", error);
             const_cast<XMLHttpRequest&>(*weak_this).set_ready_state(ReadyState::Done);
             const_cast<XMLHttpRequest&>(*weak_this).dispatch_event(DOM::Event::create(HTML::EventNames::error));
         });

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -113,19 +113,19 @@ void CanvasRenderingContext2D::draw_image(const HTMLImageElement& image_element,
 
 void CanvasRenderingContext2D::scale(float sx, float sy)
 {
-    dbg() << "CanvasRenderingContext2D::scale(): " << sx << ", " << sy;
+    dbgln("CanvasRenderingContext2D::scale({}, {})", sx, sy);
     m_transform.scale(sx, sy);
 }
 
 void CanvasRenderingContext2D::translate(float tx, float ty)
 {
-    dbg() << "CanvasRenderingContext2D::translate(): " << tx << ", " << ty;
+    dbgln("CanvasRenderingContext2D::translate({}, {})", tx, ty);
     m_transform.translate(tx, ty);
 }
 
 void CanvasRenderingContext2D::rotate(float radians)
 {
-    dbg() << "CanvasRenderingContext2D::rotate(): " << radians;
+    dbgln("CanvasRenderingContext2D::rotate({})", radians);
     m_transform.rotate_radians(radians);
 }
 


### PR DESCRIPTION
Follow up to #4907.

I've started touching some `dbg()` statements which are in `#ifdef` blocks. (Only in the last commit.)

Before:
~~~none
$ grep -rnI 'dbg()' | wc -l
641
~~~

After:
~~~none
$ grep -rnI 'dbg()' | wc -l
565
~~~
