### PR TITLE
LibGfx: Make Painter::draw_rect() scale-aware

### DIFF
--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -35,6 +35,7 @@
 #include <LibGfx/Painter.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/Path.h>
+#include <LibGfx/SystemTheme.h>
 #include <LibGfx/WindowTheme.h>
 
 const int WIDTH = 300;
@@ -86,6 +87,9 @@ void Canvas::draw(Gfx::Painter& painter)
 {
     auto active_window_icon = Gfx::Bitmap::load_from_file("/res/icons/16x16/window.png");
     Gfx::WindowTheme::current().paint_normal_frame(painter, Gfx::WindowTheme::WindowState::Active, { 4, 18, WIDTH - 8, HEIGHT - 29 }, "Well hello friends", *active_window_icon, palette(), { WIDTH - 20, 6, 16, 16 });
+
+    painter.draw_rect({ 20, 34, WIDTH - 40, HEIGHT - 45 }, palette().color(Gfx::ColorRole::Selection), true);
+    painter.draw_rect({ 24, 38, WIDTH - 48, HEIGHT - 53 }, palette().color(Gfx::ColorRole::Selection));
 }
 
 int main(int argc, char** argv)

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -135,8 +135,8 @@ protected:
     IntRect to_physical(const IntRect& r) const { return (r * scale()).translated(translation()); }
     IntPoint to_physical(const IntPoint& p) const { return (p * scale()).translated(translation()); }
     int scale() const { return state().scale; }
-    void set_pixel_with_draw_op(u32& pixel, const Color&);
-    void fill_scanline_with_draw_op(int y, int x, int width, const Color& color);
+    void set_physical_pixel_with_draw_op(u32& pixel, const Color&);
+    void fill_physical_scanline_with_draw_op(int y, int x, int width, const Color& color);
     void fill_rect_with_draw_op(const IntRect&, Color);
     void blit_with_alpha(const IntPoint&, const Gfx::Bitmap&, const IntRect& src_rect);
     void blit_with_opacity(const IntPoint&, const Gfx::Bitmap&, const IntRect& src_rect, float opacity);


### PR DESCRIPTION
Needed for the window server minimize animation.

draw_rect() can't just call draw_line() because that isn't
draw_op()-aware. The draw_op()-awareness in Painter looks a bit ad-hoc,
but that's for another day.