### PR TITLE
DHCPClient: handle /proc/net/adapters invalid JSON gracefully

### DIFF
--- a/Userland/Services/DHCPClient/main.cpp
+++ b/Userland/Services/DHCPClient/main.cpp
@@ -69,13 +69,18 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     auto file = Core::File::construct("/proc/net/adapters");
     if (!file->open(Core::IODevice::ReadOnly)) {
-        fprintf(stderr, "Error: %s\n", file->error_string());
+        warnln("Error: {}", file->error_string());
         return 1;
     }
 
     auto file_contents = file->read_all();
     auto json = JsonValue::from_string(file_contents);
-    ASSERT(json.has_value());
+
+    if (!json.has_value() || !json.value().is_array()) {
+        warnln("Error: No network adapters available");
+        return 1;
+    }
+
     Vector<InterfaceDescriptor> ifnames;
     json.value().as_array().for_each([&ifnames](auto& value) {
         auto if_object = value.as_object();


### PR DESCRIPTION
`DHCPClient` exits gracefully if `/proc/net/adapters` is unreadable. We don't need to `assert` a few lines later if `/proc/net/adapters` is empty or malformed. We can easily validate the JSON and return an error message instead.

Given that coredumps are expensive it makes sense to handle errors gracefully rather than delaying system boot by crashing (three times).