### PR TITLE
LibCore: Include fcntl before using it for non-linux lagom builds

### DIFF
--- a/Userland/Libraries/LibCore/TCPServer.cpp
+++ b/Userland/Libraries/LibCore/TCPServer.cpp
@@ -33,6 +33,7 @@
 #include <sys/socket.h>
 
 #ifndef SOCK_NONBLOCK
+#    include <fcntl.h>
 #    include <sys/ioctl.h>
 #endif
 namespace Core {


### PR DESCRIPTION
SOCK_NONBLOCK is a linux-ism that serenity and linux support. For lagom
builds, we use ioctl/fcntl to get a non-blocking socket the old
fashioned way. Some file re-org unhid the fcntl.h dependency of TcpServer,
so add the header explicitly.

This should un-break macOS CI. :)