### PR TITLE
LibCore: Include fcntl.h in more places that we use fcntl for Lagom

### DIFF
--- a/Userland/Libraries/LibCore/UDPServer.cpp
+++ b/Userland/Libraries/LibCore/UDPServer.cpp
@@ -33,6 +33,7 @@
 #include <unistd.h>
 
 #ifndef SOCK_NONBLOCK
+#    include <fcntl.h>
 #    include <sys/ioctl.h>
 #endif
 


### PR DESCRIPTION
Looks like it's more than just TcpServer where we do this :)

This will *actually* fix the Lagom build for macOS. Whoops!.