### PR TITLE
LibJS: Rename some error types

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -155,7 +155,7 @@
     M(StringRepeatCountMustBe, "repeat count must be a {} number")                                                                      \
     M(ThisHasNotBeenInitialized, "|this| has not been initialized")                                                                     \
     M(ThisIsAlreadyInitialized, "|this| is already initialized")                                                                        \
-    M(ToObjectNullOrUndef, "ToObject on null or undefined")                                                                             \
+    M(ToObjectNullOrUndefined, "ToObject on null or undefined")                                                                         \
     M(TypedArrayInvalidBufferLength, "Invalid buffer length for {}: must be a multiple of {}, got {}")                                  \
     M(TypedArrayInvalidByteOffset, "Invalid byte offset for {}: must be a multiple of {}, got {}")                                      \
     M(TypedArrayOutOfRangeByteOffset, "Typed array byte offset {} is out of range for buffer with length {}")                           \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -111,9 +111,9 @@
                                             "a non-configurable property")                                                              \
     M(ProxyGetOwnDescriptorReturn, "Proxy handler's getOwnPropertyDescriptor trap violates "                                            \
                                    "invariant: must return an object or undefined")                                                     \
-    M(ProxyGetOwnDescriptorUndefReturn, "Proxy handler's getOwnPropertyDescriptor trap "                                                \
-                                        "violates invariant: cannot report a property as being undefined if it exists as an "           \
-                                        "own property of the target and the target is non-extensible")                                  \
+    M(ProxyGetOwnDescriptorUndefinedReturn, "Proxy handler's getOwnPropertyDescriptor trap "                                            \
+                                            "violates invariant: cannot report a property as being undefined if it exists as an "       \
+                                            "own property of the target and the target is non-extensible")                              \
     M(ProxyGetPrototypeOfNonExtensible, "Proxy handler's getPrototypeOf trap violates "                                                 \
                                         "invariant: cannot return a different prototype object for a non-extensible target")            \
     M(ProxyGetPrototypeOfReturn, "Proxy handler's getPrototypeOf trap violates invariant: "                                             \

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -248,7 +248,7 @@ Optional<PropertyDescriptor> ProxyObject::get_own_property_descriptor(const Prop
         }
         if (!m_target.is_extensible()) {
             if (!vm.exception())
-                vm.throw_exception<TypeError>(global_object(), ErrorType::ProxyGetOwnDescriptorUndefReturn);
+                vm.throw_exception<TypeError>(global_object(), ErrorType::ProxyGetOwnDescriptorUndefinedReturn);
             return {};
         }
         return {};

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -616,7 +616,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::symbol_iterator)
 {
     auto this_object = vm.this_value(global_object);
     if (this_object.is_nullish()) {
-        vm.throw_exception<TypeError>(global_object, ErrorType::ToObjectNullOrUndef);
+        vm.throw_exception<TypeError>(global_object, ErrorType::ToObjectNullOrUndefined);
         return {};
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -355,7 +355,7 @@ Object* Value::to_object(GlobalObject& global_object) const
     switch (m_type) {
     case Type::Undefined:
     case Type::Null:
-        global_object.vm().throw_exception<TypeError>(global_object, ErrorType::ToObjectNullOrUndef);
+        global_object.vm().throw_exception<TypeError>(global_object, ErrorType::ToObjectNullOrUndefined);
         return nullptr;
     case Type::Boolean:
         return BooleanObject::create(global_object, m_value.as_bool);


### PR DESCRIPTION
This seems like an unnecessary and uncommon abbreviation.