### PR TITLE
Tests: Test set uid/gid not dropped upon file rename

### DIFF
--- a/Userland/Tests/Kernel/filesystem-strips-file-suid-sgid-bits-when-modified.cpp
+++ b/Userland/Tests/Kernel/filesystem-strips-file-suid-sgid-bits-when-modified.cpp
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/String.h>
+#include <LibCore/File.h>
 #include <assert.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -48,11 +50,10 @@ static void test_change_file_contents()
     struct stat s;
     assert(fstat(fd, &s) != -1);
     close(fd);
-
-    assert(s.st_mode & ~S_ISUID);
-    assert(s.st_mode & ~S_ISGID);
-
     unlink(path);
+
+    assert(!(s.st_mode & S_ISUID));
+    assert(!(s.st_mode & S_ISGID));
 }
 
 static void test_change_file_ownership()
@@ -68,11 +69,10 @@ static void test_change_file_ownership()
     struct stat s;
     assert(fstat(fd, &s) != -1);
     close(fd);
-
-    assert(s.st_mode & ~S_ISUID);
-    assert(s.st_mode & ~S_ISGID);
-
     unlink(path);
+
+    assert(!(s.st_mode & S_ISUID));
+    assert(!(s.st_mode & S_ISGID));
 }
 
 static void test_change_file_permissions()
@@ -88,11 +88,36 @@ static void test_change_file_permissions()
     struct stat s;
     assert(fstat(fd, &s) != -1);
     close(fd);
-
-    assert(s.st_mode & ~S_ISUID);
-    assert(s.st_mode & ~S_ISGID);
-
     unlink(path);
+
+    assert(!(s.st_mode & S_ISUID));
+    assert(!(s.st_mode & S_ISGID));
+}
+
+static void test_change_file_location()
+{
+    char path[] = "/tmp/suid.XXXXXX";
+    auto fd = mkstemp(path);
+    assert(fd != -1);
+    ftruncate(fd, 0);
+    assert(fchmod(fd, 06755) != -1);
+
+    auto suid_path = Core::File::read_link(String::formatted("/proc/{}/fd/{}", getpid(), fd));
+    assert(suid_path.characters());
+    auto new_path = String::formatted("{}.renamed", suid_path);
+
+    rename(suid_path.characters(), new_path.characters());
+
+    struct stat s;
+    assert(lstat(new_path.characters(), &s) != -1);
+    close(fd);
+    unlink(path);
+
+    // renamed file should retain set-uid/set-gid permissions
+    assert(s.st_mode & S_ISUID);
+    assert(s.st_mode & S_ISGID);
+
+    unlink(new_path.characters());
 }
 
 int main()
@@ -106,6 +131,7 @@ int main()
     RUNTEST(test_change_file_contents);
     RUNTEST(test_change_file_ownership);
     RUNTEST(test_change_file_permissions);
+    RUNTEST(test_change_file_location);
     printf("PASS\n");
 
     return 0;


### PR DESCRIPTION
Also fixes the other set-uid/set-gid tests which only worked because of a bug in setting and unsetting the set-gid bit (#4060).
