### PR TITLE
SpaceAnalyzer: Fix TreeMapWidget layout issue for small rects.

### DIFF
--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -84,7 +84,7 @@ Gfx::IntRect TreeMapWidget::inner_rect_for_frame(const Gfx::IntRect& rect) const
     Gfx::IntRect tmp_rect = rect;
     tmp_rect.shrink(2, 2); // border
     tmp_rect.shrink(2, 2); // shading
-    if (rect_can_contain_label(rect)) {
+    if (rect_can_contain_label(tmp_rect)) {
         tmp_rect.set_y(tmp_rect.y() + font().presentation_size() + margin);
         tmp_rect.set_height(tmp_rect.height() - (font().presentation_size() + margin * 2));
         tmp_rect.set_x(tmp_rect.x() + margin);


### PR DESCRIPTION
For small rects there was a disagreement between two parts of the
layout algorithm. There is a function that decides if there is
enough space in a rectangle for a label. But this function was
called on two slightly different rectangles.

![spaceanalyzer-before](https://user-images.githubusercontent.com/330865/104587253-f90d8d80-5666-11eb-892b-5658ce8656ed.png) ![spaceanalyzer-after](https://user-images.githubusercontent.com/330865/104587265-fca11480-5666-11eb-8387-4439a9c975f0.png)