### PR TITLE
StringView: Implement `find_first_of` in terms of `AK::find`

### DIFF
--- a/AK/AnyOf.h
+++ b/AK/AnyOf.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Iterator.h>
+
+namespace AK {
+
+template<typename Container, typename ValueType>
+constexpr bool any_of(
+    const SimpleIterator<Container, ValueType>& begin,
+    const SimpleIterator<Container, ValueType>& end,
+    const auto& predicate)
+{
+    for (auto iter = begin; iter != end; ++iter) {
+        if (predicate(*iter)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -24,7 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <AK/AnyOf.h>
 #include <AK/ByteBuffer.h>
+#include <AK/Find.h>
 #include <AK/FlyString.h>
 #include <AK/Memory.h>
 #include <AK/String.h>
@@ -270,21 +272,23 @@ bool StringView::operator==(const String& string) const
 
 Optional<size_t> StringView::find_first_of(char c) const
 {
-    for (size_t pos = 0; pos < m_length; ++pos) {
-        if (m_characters[pos] == c)
-            return pos;
+    if (const auto location = AK::find(begin(), end(), c); location != end()) {
+        return location.index();
     }
     return {};
 }
 
 Optional<size_t> StringView::find_first_of(const StringView& view) const
 {
-    for (size_t pos = 0; pos < m_length; ++pos) {
-        char c = m_characters[pos];
-        for (char view_char : view) {
-            if (c == view_char)
-                return pos;
-        }
+    if (const auto location = AK::find_if(begin(), end(),
+            [&](const auto c) {
+                return AK::any_of(view.begin(), view.end(),
+                    [&](const auto view_char) {
+                        return c == view_char;
+                    });
+            });
+        location != end()) {
+        return location.index();
     }
     return {};
 }

--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(AK_TEST_SOURCES
     TestAllOf.cpp
+    TestAnyOf.cpp
     TestArray.cpp
     TestAtomic.cpp
     TestBase64.cpp

--- a/AK/Tests/TestAnyOf.cpp
+++ b/AK/Tests/TestAnyOf.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/AnyOf.h>
+#include <AK/Array.h>
+
+TEST_CASE(should_determine_if_predicate_applies_to_any_element_in_container)
+{
+    constexpr AK::Array<int, 10> a { 1 };
+
+    static_assert(AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
+    static_assert(AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
+    static_assert(!AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 2; }));
+
+    EXPECT(AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
+    EXPECT(AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
+    EXPECT(!AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 2; }));
+}
+
+TEST_MAIN(AllOf)


### PR DESCRIPTION
Problem:
- The implementation of `find_first_of` is coupled to the
  implementation of `StringView`.

Solution:
- Decouple the implementation of `find_first_of` from the class by
  using a generic `find` algorithm.