### PR TITLE
CrashReporter: Implement kling's feature requests

### DIFF
--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -47,6 +47,13 @@ public:
     {
     }
 
+    template<typename T>
+    JsonArray(const Vector<T>& vector)
+    {
+        for (auto& value : vector)
+            m_values.append(move(value));
+    }
+
     JsonArray& operator=(const JsonArray& other)
     {
         if (this != &other)

--- a/AK/String.h
+++ b/AK/String.h
@@ -30,6 +30,7 @@
 #include <AK/Forward.h>
 #include <AK/RefPtr.h>
 #include <AK/Stream.h>
+#include <AK/StringBuilder.h>
 #include <AK/StringImpl.h>
 #include <AK/StringUtils.h>
 #include <AK/Traits.h>
@@ -111,6 +112,15 @@ public:
     String(const FlyString&);
 
     static String repeated(char, size_t count);
+
+    template<class SeparatorType, class CollectionType>
+    static String join(const SeparatorType& separator, const CollectionType& collection)
+    {
+        StringBuilder builder;
+        builder.join(separator, collection);
+        return builder.build();
+    }
+
     bool matches(const StringView& mask, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;
     bool matches(const StringView& mask, Vector<MaskSpan>&, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;
 

--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -219,15 +219,15 @@ ByteBuffer CoreDump::create_notes_process_data() const
 
     ELF::Core::ProcessInfo info {};
     info.header.type = ELF::Core::NotesEntryHeader::Type::ProcessInfo;
-    info.pid = m_process->pid().value();
-    info.termination_signal = m_process->termination_signal();
-
     process_data.append((void*)&info, sizeof(info));
 
-    auto executable_path = String::empty();
-    if (auto executable = m_process->executable())
-        executable_path = executable->absolute_path();
-    process_data.append(executable_path.characters(), executable_path.length() + 1);
+    JsonObject process_obj;
+    process_obj.set("pid", m_process->pid().value());
+    process_obj.set("termination_signal", m_process->termination_signal());
+    process_obj.set("executable_path", m_process->executable() ? m_process->executable()->absolute_path() : String::empty());
+
+    auto json_data = process_obj.to_string();
+    process_data.append(json_data.characters(), json_data.length() + 1);
 
     return process_data;
 }

--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019-2020, Jesse Buhagiar <jooster669@gmail.com>
  * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * Copyright (c) 2020-2021, Linus Groh <mail@linusgroh.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +27,7 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <Kernel/CoreDump.h>
 #include <Kernel/FileSystem/Custody.h>
@@ -225,6 +227,8 @@ ByteBuffer CoreDump::create_notes_process_data() const
     process_obj.set("pid", m_process->pid().value());
     process_obj.set("termination_signal", m_process->termination_signal());
     process_obj.set("executable_path", m_process->executable() ? m_process->executable()->absolute_path() : String::empty());
+    process_obj.set("arguments", JsonArray(m_process->arguments()));
+    process_obj.set("environment", JsonArray(m_process->environment()));
 
     auto json_data = process_obj.to_string();
     process_data.append(json_data.characters(), json_data.length() + 1);

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -641,6 +641,8 @@ void Process::finalize()
     m_cwd = nullptr;
     m_root_directory = nullptr;
     m_root_directory_relative_to_global_root = nullptr;
+    m_arguments.clear();
+    m_environment.clear();
 
     m_dead = true;
 

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -631,6 +631,8 @@ void Process::finalize()
             dump_perfcore();
     }
 
+    m_threads_for_coredump.clear();
+
     if (m_alarm_timer)
         TimerQueue::the().cancel_timer(m_alarm_timer.release_nonnull());
     m_fds.clear();
@@ -694,6 +696,11 @@ void Process::die()
     // If the master PTY owner relies on an EOF to know when to wait() on a
     // slave owner, we have to allow the PTY pair to be torn down.
     m_tty = nullptr;
+
+    for_each_thread([&](auto& thread) {
+        m_threads_for_coredump.append(&thread);
+        return IterationDecision::Continue;
+    });
 
     kill_all_threads();
 }

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -400,6 +400,9 @@ public:
     Custody* executable() { return m_executable.ptr(); }
     const Custody* executable() const { return m_executable.ptr(); }
 
+    const Vector<String>& arguments() const { return m_arguments; };
+    const Vector<String>& environment() const { return m_environment; };
+
     int number_of_open_file_descriptors() const;
     int max_open_file_descriptors() const
     {
@@ -613,6 +616,9 @@ private:
     RefPtr<Custody> m_cwd;
     RefPtr<Custody> m_root_directory;
     RefPtr<Custody> m_root_directory_relative_to_global_root;
+
+    Vector<String> m_arguments;
+    Vector<String> m_environment;
 
     RefPtr<TTY> m_tty;
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -663,6 +663,8 @@ private:
     Thread::WaitBlockCondition m_wait_block_condition;
 
     HashMap<String, String> m_coredump_metadata;
+
+    Vector<RefPtr<Thread>> m_threads_for_coredump;
 };
 
 extern InlineLinkedList<Process>* g_processes;

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -507,6 +507,8 @@ int Process::do_exec(NonnullRefPtr<FileDescription> main_program_description, Ve
 #endif
 
     m_executable = main_program_description->custody();
+    m_arguments = arguments;
+    m_environment = environment;
 
     m_promises = m_execpromises;
 

--- a/Userland/Applications/CrashReporter/CrashReporterWindow.gml
+++ b/Userland/Applications/CrashReporter/CrashReporterWindow.gml
@@ -58,6 +58,24 @@
         }
     }
 
+    @GUI::Widget {
+        fixed_height: 18
+
+        layout: @GUI::HorizontalBoxLayout {
+        }
+
+        @GUI::Label {
+            text: "Arguments:"
+            text_alignment: "CenterLeft"
+            fixed_width: 90
+        }
+
+        @GUI::Label {
+            name: "arguments_label"
+            text_alignment: "CenterLeft"
+        }
+    }
+
     @GUI::TabWidget {
         name: "tab_widget"
     }

--- a/Userland/Applications/CrashReporter/CrashReporterWindow.gml
+++ b/Userland/Applications/CrashReporter/CrashReporterWindow.gml
@@ -58,21 +58,8 @@
         }
     }
 
-    @GUI::Widget {
-        fixed_height: 18
-
-        layout: @GUI::HorizontalBoxLayout {
-        }
-
-        @GUI::Label {
-            text: "Backtrace:"
-            text_alignment: "CenterLeft"
-        }
-    }
-
-    @GUI::TextEditor {
-        name: "backtrace_text_editor"
-        mode: "ReadOnly"
+    @GUI::TabWidget {
+        name: "tab_widget"
     }
 
     @GUI::Widget {

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Linus Groh <mail@linusgroh.de>
+ * Copyright (c) 2020-2021, Linus Groh <mail@linusgroh.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -96,11 +96,10 @@ int main(int argc, char** argv)
             warnln("Could not open coredump '{}'", coredump_path);
             return 1;
         }
-        auto& process_info = coredump->process_info();
         backtrace = build_backtrace(*coredump);
-        executable_path = String(process_info.executable_path);
-        pid = process_info.pid;
-        termination_signal = process_info.termination_signal;
+        executable_path = coredump->process_executable_path();
+        pid = coredump->process_pid();
+        termination_signal = coredump->process_termination_signal();
     }
 
     auto app = GUI::Application::construct(argc, argv);

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -105,6 +105,8 @@ int main(int argc, char** argv)
     Vector<TitleAndText> thread_backtraces;
 
     String executable_path;
+    Vector<String> arguments;
+    Vector<String> environment;
     int pid { 0 };
     u8 termination_signal { 0 };
 
@@ -123,6 +125,8 @@ int main(int argc, char** argv)
         });
 
         executable_path = coredump->process_executable_path();
+        arguments = coredump->process_arguments();
+        environment = coredump->process_environment();
         pid = coredump->process_pid();
         termination_signal = coredump->process_termination_signal();
     }
@@ -188,6 +192,9 @@ int main(int argc, char** argv)
         Desktop::Launcher::open(URL::create_with_file_protocol(LexicalPath(coredump_path).dirname()));
     };
 
+    auto& arguments_label = *widget.find_descendant_of_type_named<GUI::Label>("arguments_label");
+    arguments_label.set_text(String::join(" ", arguments));
+
     auto& tab_widget = *widget.find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
 
     auto& backtrace_tab = tab_widget.add_tab<GUI::Widget>("Backtrace");
@@ -208,6 +215,15 @@ int main(int argc, char** argv)
         backtrace_text_editor.set_mode(GUI::TextEditor::Mode::ReadOnly);
         backtrace_text_editor.set_should_hide_unnecessary_scrollbars(true);
     }
+
+    auto& environment_tab = tab_widget.add_tab<GUI::Widget>("Environment");
+    environment_tab.set_layout<GUI::VerticalBoxLayout>();
+    environment_tab.layout()->set_margins({ 4, 4, 4, 4 });
+
+    auto& environment_text_editor = environment_tab.add<GUI::TextEditor>();
+    environment_text_editor.set_text(String::join("\n", environment));
+    environment_text_editor.set_mode(GUI::TextEditor::Mode::ReadOnly);
+    environment_text_editor.set_should_hide_unnecessary_scrollbars(true);
 
     auto& close_button = *widget.find_descendant_of_type_named<GUI::Button>("close_button");
     close_button.on_click = [&](auto) {

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -43,6 +43,7 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/Layout.h>
 #include <LibGUI/LinkLabel.h>
+#include <LibGUI/TabWidget.h>
 #include <LibGUI/TextEditor.h>
 #include <LibGUI/Window.h>
 #include <string.h>
@@ -163,7 +164,10 @@ int main(int argc, char** argv)
         Desktop::Launcher::open(URL::create_with_file_protocol(LexicalPath(coredump_path).dirname()));
     };
 
-    auto& backtrace_text_editor = *widget.find_descendant_of_type_named<GUI::TextEditor>("backtrace_text_editor");
+    auto& tab_widget = *widget.find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
+
+    auto& backtrace_text_editor = tab_widget.add_tab<GUI::TextEditor>("Backtrace");
+    backtrace_text_editor.set_mode(GUI::TextEditor::Mode::ReadOnly);
     backtrace_text_editor.set_text(backtrace);
     backtrace_text_editor.set_should_hide_unnecessary_scrollbars(true);
 

--- a/Userland/Libraries/LibCoreDump/Backtrace.h
+++ b/Userland/Libraries/LibCoreDump/Backtrace.h
@@ -29,6 +29,7 @@
 #include <AK/Types.h>
 #include <LibCoreDump/Reader.h>
 #include <LibDebug/DebugInfo.h>
+#include <LibELF/CoreDump.h>
 
 namespace CoreDump {
 
@@ -54,14 +55,16 @@ public:
         String to_string(bool color = false) const;
     };
 
-    Backtrace(const Reader&);
+    Backtrace(const Reader&, const ELF::Core::ThreadInfo&);
     ~Backtrace();
 
+    const ELF::Core::ThreadInfo thread_info() const { return m_thread_info; }
     const Vector<Entry> entries() const { return m_entries; }
 
 private:
-    void add_backtrace_entry(const Reader&, FlatPtr eip);
+    void add_entry(const Reader&, FlatPtr eip);
 
+    ELF::Core::ThreadInfo m_thread_info;
     Vector<Entry> m_entries;
 };
 

--- a/Userland/Libraries/LibCoreDump/Reader.cpp
+++ b/Userland/Libraries/LibCoreDump/Reader.cpp
@@ -184,7 +184,35 @@ String Reader::process_executable_path() const
     return executable_path.as_string_or({});
 }
 
-const HashMap<String, String> Reader::metadata() const
+Vector<String> Reader::process_arguments() const
+{
+    auto process_info = this->process_info();
+    auto arguments = process_info.get("arguments");
+    if (!arguments.is_array())
+        return {};
+    Vector<String> vector;
+    arguments.as_array().for_each([&](auto& value) {
+        if (value.is_string())
+            vector.append(value.as_string());
+    });
+    return vector;
+}
+
+Vector<String> Reader::process_environment() const
+{
+    auto process_info = this->process_info();
+    auto environment = process_info.get("environment");
+    if (!environment.is_array())
+        return {};
+    Vector<String> vector;
+    environment.as_array().for_each([&](auto& value) {
+        if (value.is_string())
+            vector.append(value.as_string());
+    });
+    return vector;
+}
+
+HashMap<String, String> Reader::metadata() const
 {
     const ELF::Core::Metadata* metadata_notes_entry = nullptr;
     for (NotesEntryIterator it((const u8*)m_coredump_image.program_header(m_notes_segment_index).raw_data()); !it.at_end(); it.next()) {

--- a/Userland/Libraries/LibCoreDump/Reader.cpp
+++ b/Userland/Libraries/LibCoreDump/Reader.cpp
@@ -26,7 +26,6 @@
 
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
-#include <LibCoreDump/Backtrace.h>
 #include <LibCoreDump/Reader.h>
 #include <signal_numbers.h>
 #include <string.h>
@@ -159,11 +158,6 @@ const ELF::Core::MemoryRegionInfo* Reader::region_containing(FlatPtr address) co
         return IterationDecision::Continue;
     });
     return ret;
-}
-
-const Backtrace Reader::backtrace() const
-{
-    return Backtrace(*this);
 }
 
 int Reader::process_pid() const

--- a/Userland/Libraries/LibCoreDump/Reader.h
+++ b/Userland/Libraries/LibCoreDump/Reader.h
@@ -65,7 +65,9 @@ public:
     int process_pid() const;
     u8 process_termination_signal() const;
     String process_executable_path() const;
-    const HashMap<String, String> metadata() const;
+    Vector<String> process_arguments() const;
+    Vector<String> process_environment() const;
+    HashMap<String, String> metadata() const;
 
 private:
     Reader(NonnullRefPtr<MappedFile>);

--- a/Userland/Libraries/LibCoreDump/Reader.h
+++ b/Userland/Libraries/LibCoreDump/Reader.h
@@ -44,8 +44,6 @@ public:
     static OwnPtr<Reader> create(const String&);
     ~Reader();
 
-    const ELF::Core::ProcessInfo& process_info() const;
-
     template<typename Func>
     void for_each_memory_region_info(Func func) const;
 
@@ -66,6 +64,10 @@ public:
     const LibraryData* library_containing(FlatPtr address) const;
 
     const Backtrace backtrace() const;
+
+    int process_pid() const;
+    u8 process_termination_signal() const;
+    String process_executable_path() const;
     const HashMap<String, String> metadata() const;
 
 private:
@@ -85,6 +87,11 @@ private:
         const ELF::Core::NotesEntry* m_current { nullptr };
         const u8* start { nullptr };
     };
+
+    // Private as we don't need anyone poking around in this JsonObject
+    // manually - we know very well what should be included and expose that
+    // as getters with the appropriate (non-JsonValue) types.
+    const JsonObject process_info() const;
 
     NonnullRefPtr<MappedFile> m_coredump_file;
     ELF::Image m_coredump_image;

--- a/Userland/Libraries/LibCoreDump/Reader.h
+++ b/Userland/Libraries/LibCoreDump/Reader.h
@@ -30,7 +30,6 @@
 #include <AK/MappedFile.h>
 #include <AK/Noncopyable.h>
 #include <AK/OwnPtr.h>
-#include <LibCoreDump/Forward.h>
 #include <LibELF/CoreDump.h>
 #include <LibELF/Image.h>
 
@@ -62,8 +61,6 @@ public:
         ELF::Image lib_elf;
     };
     const LibraryData* library_containing(FlatPtr address) const;
-
-    const Backtrace backtrace() const;
 
     int process_pid() const;
     u8 process_termination_signal() const;

--- a/Userland/Libraries/LibELF/CoreDump.h
+++ b/Userland/Libraries/LibELF/CoreDump.h
@@ -50,9 +50,14 @@ struct [[gnu::packed]] NotesEntry {
 
 struct [[gnu::packed]] ProcessInfo {
     NotesEntryHeader header;
-    int pid;
-    u8 termination_signal;
-    char executable_path[]; // Null terminated
+    // Information is stored as JSON blob to allow arbitrary
+    // number and length of strings/objects/arrays.
+    //
+    // Keys:
+    // - "pid" (int)
+    // - "termination_signal" (u8)
+    // - "executable_path" (String)
+    char json_data[]; // Null terminated
 };
 
 struct [[gnu::packed]] ThreadInfo {
@@ -81,6 +86,11 @@ struct [[gnu::packed]] MemoryRegionInfo {
 
 struct [[gnu::packed]] Metadata {
     NotesEntryHeader header;
+    // Arbitrary metadata, set via SC_set_coredump_metadata.
+    // Limited to 16 entries and 16 KiB keys/values by the kernel.
+    //
+    // Well-known keys:
+    // - "assertion": Used by LibC's __assertion_failed() to store assertion info
     char json_data[]; // Null terminated
 };
 

--- a/Userland/Services/CrashDaemon/main.cpp
+++ b/Userland/Services/CrashDaemon/main.cpp
@@ -56,8 +56,18 @@ static void print_backtrace(const String& coredump_path)
         dbgln("Could not open coredump '{}'", coredump_path);
         return;
     }
-    for (auto& entry : coredump->backtrace().entries())
-        dbgln("{}", entry.to_string(true));
+
+    size_t thread_index = 0;
+    coredump->for_each_thread_info([&](auto& thread_info) {
+        CoreDump::Backtrace backtrace(*coredump, thread_info);
+        if (thread_index > 0)
+            dbgln();
+        dbgln("--- Backtrace for thread #{} (TID {}) ---", thread_index, thread_info.tid);
+        for (auto& entry : backtrace.entries())
+            dbgln("{}", entry.to_string(true));
+        ++thread_index;
+        return IterationDecision::Continue;
+    });
 }
 
 static void launch_crash_reporter(const String& coredump_path)


### PR DESCRIPTION
As promised. Crashing programs just got even more exciting!

---

Featuring:

- Tabs, because there's no way all of this will fit into the UI otherwise.
- Per-thread backtraces
  ![image](https://user-images.githubusercontent.com/19366641/104781497-d8d2f100-5782-11eb-9f4d-a0a133ada2e3.png)
- CPU register states (also per-thread)
  ![image](https://user-images.githubusercontent.com/19366641/104781549-f4d69280-5782-11eb-97bd-1a299dab4aa2.png)
- Process arguments and environment
  ![image](https://user-images.githubusercontent.com/19366641/104781611-13d52480-5783-11eb-9c8c-5258a5e4b4a3.png)
