### PR TITLE
Kernel+LibC+UserspaceEmulator: Handle PATH_MAX more gracefully

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -234,12 +234,6 @@ struct MutableBufferArgument {
     SizeType size { 0 };
 };
 
-template<typename DataType, typename SizeType>
-struct ImmutableBufferArgument {
-    const DataType* data { nullptr };
-    SizeType size { 0 };
-};
-
 struct StringListArgument {
     StringArgument* strings {};
     size_t length { 0 };

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -263,7 +263,7 @@ public:
     int sys$select(const Syscall::SC_select_params*);
     int sys$poll(Userspace<const Syscall::SC_poll_params*>);
     ssize_t sys$get_dir_entries(int fd, void*, ssize_t);
-    int sys$getcwd(Userspace<char*>, ssize_t);
+    int sys$getcwd(Userspace<char*>, size_t);
     int sys$chdir(Userspace<const char*>, size_t);
     int sys$fchdir(int fd);
     int sys$sleep(unsigned seconds);

--- a/Kernel/Syscalls/chdir.cpp
+++ b/Kernel/Syscalls/chdir.cpp
@@ -61,17 +61,18 @@ int Process::sys$fchdir(int fd)
     return 0;
 }
 
-int Process::sys$getcwd(Userspace<char*> buffer, ssize_t size)
+int Process::sys$getcwd(Userspace<char*> buffer, size_t size)
 {
     REQUIRE_PROMISE(rpath);
-    if (size < 0)
-        return -EINVAL;
+
     auto path = current_directory().absolute_path();
-    if ((size_t)size < path.length() + 1)
-        return -ERANGE;
-    if (!copy_to_user(buffer, path.characters(), path.length() + 1))
+
+    size_t ideal_size = path.length() + 1;
+    auto size_to_copy = min(ideal_size, size);
+    if (!copy_to_user(buffer, path.characters(), size_to_copy))
         return -EFAULT;
-    return 0;
+    // Note: we return the whole size here, not the copied size.
+    return ideal_size;
 }
 
 }

--- a/Kernel/Syscalls/realpath.cpp
+++ b/Kernel/Syscalls/realpath.cpp
@@ -49,12 +49,12 @@ int Process::sys$realpath(Userspace<const Syscall::SC_realpath_params*> user_par
     auto& custody = custody_or_error.value();
     auto absolute_path = custody->absolute_path();
 
-    if (absolute_path.length() + 1 > params.buffer.size)
-        return -ENAMETOOLONG;
-
-    if (!copy_to_user(params.buffer.data, absolute_path.characters(), absolute_path.length() + 1))
+    size_t ideal_size = absolute_path.length() + 1;
+    auto size_to_copy = min(ideal_size, params.buffer.size);
+    if (!copy_to_user(params.buffer.data, absolute_path.characters(), size_to_copy))
         return -EFAULT;
-    return 0;
+    // Note: we return the whole size here, not the copied size.
+    return ideal_size;
 };
 
 }

--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -1364,20 +1364,16 @@ int Emulator::virt$realpath(FlatPtr params_addr)
     Syscall::SC_realpath_params params;
     mmu().copy_from_vm(&params, params_addr, sizeof(params));
 
-    if (params.path.length > PATH_MAX) {
-        return -ENAMETOOLONG;
-    }
     auto path = mmu().copy_buffer_from_vm((FlatPtr)params.path.characters, params.path.length);
-    char host_buffer[PATH_MAX] = {};
-    size_t host_buffer_size = min(sizeof(host_buffer), params.buffer.size);
+    auto host_buffer = ByteBuffer::create_zeroed(params.buffer.size);
 
     Syscall::SC_realpath_params host_params;
     host_params.path = { (const char*)path.data(), path.size() };
-    host_params.buffer = { host_buffer, host_buffer_size };
+    host_params.buffer = { (char*)host_buffer.data(), host_buffer.size() };
     int rc = syscall(SC_realpath, &host_params);
     if (rc < 0)
         return rc;
-    mmu().copy_to_vm((FlatPtr)params.buffer.data, host_buffer, host_buffer_size);
+    mmu().copy_to_vm((FlatPtr)params.buffer.data, host_buffer.data(), host_buffer.size());
     return rc;
 }
 
@@ -1759,20 +1755,16 @@ int Emulator::virt$readlink(FlatPtr params_addr)
     Syscall::SC_readlink_params params;
     mmu().copy_from_vm(&params, params_addr, sizeof(params));
 
-    if (params.path.length > PATH_MAX) {
-        return -ENAMETOOLONG;
-    }
     auto path = mmu().copy_buffer_from_vm((FlatPtr)params.path.characters, params.path.length);
-    char host_buffer[PATH_MAX] = {};
-    size_t host_buffer_size = min(sizeof(host_buffer), params.buffer.size);
+    auto host_buffer = ByteBuffer::create_zeroed(params.buffer.size);
 
     Syscall::SC_readlink_params host_params;
     host_params.path = { (const char*)path.data(), path.size() };
-    host_params.buffer = { host_buffer, host_buffer_size };
+    host_params.buffer = { (char*)host_buffer.data(), host_buffer.size() };
     int rc = syscall(SC_readlink, &host_params);
     if (rc < 0)
         return rc;
-    mmu().copy_to_vm((FlatPtr)params.buffer.data, host_buffer, host_buffer_size);
+    mmu().copy_to_vm((FlatPtr)params.buffer.data, host_buffer.data(), host_buffer.size());
     return rc;
 }
 

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -1049,11 +1049,16 @@ char* realpath(const char* pathname, char* buffer)
         return nullptr;
     }
     size_t size = PATH_MAX;
-    if (buffer == nullptr)
+    bool self_allocated = false;
+    if (buffer == nullptr) {
         buffer = (char*)malloc(size);
+        self_allocated = true;
+    }
     Syscall::SC_realpath_params params { { pathname, strlen(pathname) }, { buffer, size } };
     int rc = syscall(SC_realpath, &params);
     if (rc < 0) {
+        if (self_allocated)
+            free(buffer);
         errno = -rc;
         return nullptr;
     }

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -322,11 +322,16 @@ int fchdir(int fd)
 
 char* getcwd(char* buffer, size_t size)
 {
+    bool self_allocated = false;
     if (!buffer) {
         size = size ? size : PATH_MAX;
         buffer = (char*)malloc(size);
+        self_allocated = true;
     }
     int rc = syscall(SC_getcwd, buffer, size);
+    if (rc < 0 && self_allocated) {
+        free(buffer);
+    }
     __RETURN_WITH_ERRNO(rc, buffer, nullptr);
 }
 

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -209,7 +209,7 @@ String File::read_link(const StringView& link_path)
         return { large_buffer_ptr, new_size };
     // Otherwise, here's not much we can do, unless we want to loop endlessly
     // in this case. Let's leave it up to the caller whether to loop.
-    errno = -EAGAIN;
+    errno = EAGAIN;
     return {};
 }
 

--- a/Userland/Tests/LibC/overlong_realpath.cpp
+++ b/Userland/Tests/LibC/overlong_realpath.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+// FIXME
+static const char* TEXT_FAIL = "\x1b[01;31m";
+static const char* TEXT_PASS = "\x1b[01;32m";
+static const char* TEXT_RESET = "\x1b[0m";
+
+static const char* TMPDIR_PATTERN = "/tmp/overlong_realpath_XXXXXX";
+static const char* PATH_LOREM_250 = "This-is-an-annoyingly-long-name-that-should-take-up-exactly-two-hundred-and-fifty-characters-and-is-surprisingly-difficult-to-fill-with-reasonably-meaningful-text-which-is-necessary-because-that-makes-it-easier-for-my-eyes-to-spot-any-corruption-fast";
+
+static const size_t ITERATION_DEPTH = 17;
+
+static bool check_result(const char* what, const String& expected, const char* actual)
+{
+    bool good = expected == actual;
+    printf("%s%s%s: %s = \"%s\" (%zu characters)\n", good ? TEXT_PASS : TEXT_FAIL, good ? "GOOD" : "FAIL", TEXT_RESET, what, actual, actual ? strlen(actual) : 0);
+    return good;
+}
+
+int main()
+{
+    // We want to construct a path that is over PATH_MAX characters long.
+    // This cannot be done in a single step.
+
+    // First, switch to a known environment:
+    char* tmp_dir = strdup("/tmp/overlong_realpath_XXXXXX");
+    if (!mkdtemp(tmp_dir)) {
+        perror("mkdtmp");
+        return 1;
+    }
+    if (chdir(tmp_dir) < 0) {
+        perror("chdir tmpdir");
+        return 1;
+    }
+
+    // Then, create a long path.
+    StringBuilder expected;
+    expected.append(tmp_dir);
+
+    // But first, demonstrate the functionality at a reasonable depth:
+    bool all_good = true;
+    auto expected_str = expected.build();
+    all_good &= check_result("getwd", expected_str, getwd(static_cast<char*>(calloc(1, PATH_MAX))));
+    all_good &= check_result("getcwd", expected_str, getcwd(nullptr, 0));
+    all_good &= check_result("realpath", expected_str, realpath(".", nullptr));
+
+    for (size_t i = 0; i < ITERATION_DEPTH; ++i) {
+        if (mkdir(PATH_LOREM_250, 0700) < 0) {
+            perror("mkdir iter");
+            printf("%sFAILED%s in iteration %zu.\n", TEXT_FAIL, TEXT_RESET, i);
+            return 1;
+        }
+        expected.append('/');
+        expected.append(PATH_LOREM_250);
+        if (chdir(PATH_LOREM_250) < 0) {
+            perror("chdir iter");
+            printf("%sFAILED%s in iteration %zu.\n", TEXT_FAIL, TEXT_RESET, i);
+            return 1;
+        }
+    }
+    printf("cwd should now be ridiculously large.\n");
+
+    // Evaluate
+    expected_str = expected.build();
+
+    all_good &= check_result("getwd", {}, getwd(static_cast<char*>(calloc(1, PATH_MAX))));
+    all_good &= check_result("getcwd", expected_str, getcwd(nullptr, 0));
+    all_good &= check_result("realpath", expected_str, realpath(".", nullptr));
+
+    ASSERT(strlen(PATH_LOREM_250) == 250);
+    ASSERT(strlen(TMPDIR_PATTERN) + ITERATION_DEPTH * (1 + strlen(PATH_LOREM_250)) == expected_str.length());
+    ASSERT(expected_str.length() > PATH_MAX);
+
+    if (all_good) {
+        printf("Overall: %sPASS%s\n", TEXT_PASS, TEXT_RESET);
+        return 0;
+    } else {
+        printf("Overall: %sFAIL%s\n", TEXT_FAIL, TEXT_RESET);
+        return 2;
+    }
+}


### PR DESCRIPTION
This is the surprisingly short result of a surprisingly long discussion about [long paths](https://github.com/SerenityOS/serenity/discussions/4357). Now 

This covers all cases of that use `MutableBufferArgument` (`readlink` and `realpath`). If this gets general approval, we should implement a similar "retry dance" for other syscalls that can return arbitrarily long paths, at least `getcwd`.

CC @bugaevc, what do you think? :)