### PR TITLE
DisplaySettings: Add UI for switching the scale factor

### DIFF
--- a/Base/etc/WindowServer/WindowServer.ini
+++ b/Base/etc/WindowServer/WindowServer.ini
@@ -1,6 +1,7 @@
 [Screen]
 Width=1024
 Height=768
+ScaleFactor=1
 
 [Theme]
 Name=Default

--- a/Documentation/HighDPI.md
+++ b/Documentation/HighDPI.md
@@ -31,8 +31,8 @@ The plan is to have all applications use highdpi backbuffers eventually. It'll t
 0. Add some scaling support to Painter. Make it do 2x nearest neighbor scaling of everything at paint time for now.
 1. Add scale factor concept to WindowServer. WindowServer has a scaled framebuffer/backbuffer. All other bitmaps (both other bitmaps in WindowServer, as well as everything WindowServer-client-side) are always stored at 1x and scaled up when they're painted to the framebuffer. Things will look fine at 2x, but pixely (but window gradients will be smooth already).
 2. Let DisplaySettings toggle it WindowServer scale. Now it's possible to switch to and from HighDPI dynamically, using UI.
-2. Come up with a system to have scale-dependent bitmap and font resources. Use that to use a high-res cursor bitmaps and high-res menu bar text painting in window server. Menu text and cursor will look less pixely. (And window frames too, I suppose.)
-3. Let apps opt in to high-res window framebuffers, and convert all apps one-by-one
-4. Remove high-res window framebuffer opt-in since all apps have it now.
+3. Come up with a system to have scale-dependent bitmap and font resources. Use that to use a high-res cursor bitmaps and high-res menu bar text painting in window server. Menu text and cursor will look less pixely. (And window frames too, I suppose.)
+4. Let apps opt in to high-res window framebuffers, and convert all apps one-by-one
+5. Remove high-res window framebuffer opt-in since all apps have it now.
 
-We're currently before point 2.
+We're currently before point 3.

--- a/Userland/Applications/DisplaySettings/DisplaySettings.cpp
+++ b/Userland/Applications/DisplaySettings/DisplaySettings.cpp
@@ -64,13 +64,17 @@ void DisplaySettingsWidget::create_resolution_list()
     m_resolutions.append({ 1024, 768 });
     m_resolutions.append({ 1280, 720 });
     m_resolutions.append({ 1280, 768 });
+    m_resolutions.append({ 1280, 960 });
     m_resolutions.append({ 1280, 1024 });
     m_resolutions.append({ 1360, 768 });
     m_resolutions.append({ 1368, 768 });
     m_resolutions.append({ 1440, 900 });
     m_resolutions.append({ 1600, 900 });
+    m_resolutions.append({ 1600, 1200 });
     m_resolutions.append({ 1920, 1080 });
+    m_resolutions.append({ 2048, 1152 });
     m_resolutions.append({ 2560, 1080 });
+    m_resolutions.append({ 2560, 1440 });
 }
 
 void DisplaySettingsWidget::create_wallpaper_list()

--- a/Userland/Applications/DisplaySettings/DisplaySettings.h
+++ b/Userland/Applications/DisplaySettings/DisplaySettings.h
@@ -29,6 +29,7 @@
 #include "MonitorWidget.h"
 #include <LibGUI/ColorInput.h>
 #include <LibGUI/ComboBox.h>
+#include <LibGUI/RadioButton.h>
 
 class DisplaySettingsWidget : public GUI::Widget {
     C_OBJECT(DisplaySettingsWidget);
@@ -51,5 +52,7 @@ private:
     RefPtr<GUI::ComboBox> m_wallpaper_combo;
     RefPtr<GUI::ComboBox> m_mode_combo;
     RefPtr<GUI::ComboBox> m_resolution_combo;
+    RefPtr<GUI::RadioButton> m_display_scale_radio_1x;
+    RefPtr<GUI::RadioButton> m_display_scale_radio_2x;
     RefPtr<GUI::ColorInput> m_color_input;
 };

--- a/Userland/Applications/DisplaySettings/DisplaySettingsWindow.gml
+++ b/Userland/Applications/DisplaySettings/DisplaySettingsWindow.gml
@@ -64,6 +64,26 @@
 
         @GUI::ComboBox {
             name: "resolution_combo"
+            fixed_width: 90
+        }
+
+        @GUI::Widget {
+        }
+
+        @GUI::Label {
+            text: "Display scale:"
+            text_alignment: "CenterLeft"
+            fixed_width: 75
+        }
+
+        @GUI::RadioButton {
+            name: "scale_1x"
+            text: "100%"
+        }
+
+        @GUI::RadioButton {
+            name: "scale_2x"
+            text: "200%"
         }
     }
 

--- a/Userland/Applications/DisplaySettings/MonitorWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.h
@@ -43,6 +43,9 @@ public:
     void set_desktop_resolution(Gfx::IntSize resolution);
     Gfx::IntSize desktop_resolution();
 
+    void set_desktop_scale_factor(int scale_factor) { m_desktop_scale_factor = scale_factor; }
+    int desktop_scale_factor() const { return m_desktop_scale_factor; }
+
     void set_background_color(Gfx::Color background_color);
     Gfx::Color background_color();
 
@@ -58,6 +61,7 @@ private:
     RefPtr<Gfx::Bitmap> m_desktop_wallpaper_bitmap;
     String m_desktop_wallpaper_mode;
     Gfx::IntSize m_desktop_resolution;
+    int m_desktop_scale_factor { 1 };
     Gfx::Color m_desktop_color;
 };
 


### PR DESCRIPTION
For now, only support 1x and 2x scale.

I tried doing something "smarter" first where the UI would try
to keep the physical resolution constant when toggling between
1x and 2x, but many of the smaller 1x resolutions map to 2x
logical resolutions that Compositor rejects (e.g. 1024x768 becomes
512x384, which is less than the minimum 640x480 that Compositor
wants) and it felt complicated and overly magical.

So this instead just gives you a 1x/2x toggle and a dropdown
with logical (!) resolutions. That is, 800x600 @ 2x gives you
a physical resolution of 1600x1200.

If we don't like this after trying it for a while, we can change
the UI then.