### PR TITLE
WindowServer, LibGUI, SystemMenu: Fix ShutdownDialog theming

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -845,6 +845,11 @@ void Window::schedule_relayout()
     });
 }
 
+void Window::refresh_system_theme()
+{
+    WindowServerConnection::the().post_message(Messages::WindowServer::RefreshSystemTheme());
+}
+
 void Window::for_each_window(Badge<WindowServerConnection>, Function<void(Window&)> callback)
 {
     for (auto& e : *reified_windows) {

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -181,6 +181,8 @@ public:
 
     void schedule_relayout();
 
+    void refresh_system_theme();
+
     static void for_each_window(Badge<WindowServerConnection>, Function<void(Window&)>);
     static void update_all_windows(Badge<WindowServerConnection>);
     void notify_state_changed(Badge<WindowServerConnection>, bool minimized, bool occluded);

--- a/Userland/Services/SystemMenu/ShutdownDialog.cpp
+++ b/Userland/Services/SystemMenu/ShutdownDialog.cpp
@@ -68,6 +68,9 @@ ShutdownDialog::ShutdownDialog()
     set_title("SerenityOS");
     set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/power.png"));
 
+    // Request WindowServer to re-update us on the current theme as we might've not been alive for the last notification.
+    refresh_system_theme();
+
     auto& main = set_main_widget<GUI::Widget>();
     main.set_layout<GUI::VerticalBoxLayout>();
     main.layout()->set_margins({ 8, 8, 8, 8 });

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -869,6 +869,12 @@ void ClientConnection::handle(const Messages::WindowServer::SetWindowProgress& m
     it->value->set_progress(message.progress());
 }
 
+void ClientConnection::handle(const Messages::WindowServer::RefreshSystemTheme&)
+{
+    // Post the client an UpdateSystemTheme message to refresh its theme.
+    post_message(Messages::WindowClient::UpdateSystemTheme(Gfx::current_system_theme_buffer_id()));
+}
+
 void ClientConnection::handle(const Messages::WindowServer::Pong&)
 {
     m_ping_timer = nullptr;

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -143,6 +143,7 @@ private:
     virtual void handle(const Messages::WindowServer::EnableDisplayLink&) override;
     virtual void handle(const Messages::WindowServer::DisableDisplayLink&) override;
     virtual void handle(const Messages::WindowServer::SetWindowProgress&) override;
+    virtual void handle(const Messages::WindowServer::RefreshSystemTheme&) override;
     virtual void handle(const Messages::WindowServer::Pong&) override;
     virtual OwnPtr<Messages::WindowServer::GetGlobalCursorPositionResponse> handle(const Messages::WindowServer::GetGlobalCursorPosition&) override;
     virtual OwnPtr<Messages::WindowServer::SetMouseAccelerationResponse> handle(const Messages::WindowServer::SetMouseAcceleration&) override;

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -98,6 +98,7 @@ endpoint WindowServer = 2
 
     SetSystemTheme(String theme_path, [UTF8] String theme_name) => (bool success)
     GetSystemTheme() => ([UTF8] String theme_name)
+    RefreshSystemTheme() =|
 
     SetWindowBaseSizeAndSizeIncrement(i32 window_id, Gfx::IntSize base_size, Gfx::IntSize size_increment) => ()
     SetWindowResizeAspectRatio(i32 window_id, Optional<Gfx::IntSize> resize_aspect_ratio) => ()


### PR DESCRIPTION
WindowServer seems to only notify clients of theme changes when they have a Window. As SystemMenu spends most of its time connected to WindowServer without displaying a window, it appears to miss most theme changes. This PR adds a new asynchronous IPC call to WindowServer (`RefreshSystemTheme`,) which causes WindowServer to immediately respond with an `UpdateSystemTheme` message. A relevant helper method is added to LibGUI::Window, and called in SystemMenu::ShutdownDialog's constructor so that it immediately receives and processes an `UpdateSystemTheme` message containing the current system theme shbuf ID.