### PR TITLE
Kernel: Fix inverted logic in KResultOr

### DIFF
--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -138,7 +138,7 @@ public:
         return m_error;
     }
 
-    KResult result() const { return m_is_error ? KSuccess : m_error; }
+    KResult result() const { return m_is_error ? m_error : KSuccess; }
 
     ALWAYS_INLINE T& value()
     {


### PR DESCRIPTION
This silly inversion has survived so long (for about 9000 commits! 2f82d4fb31af551deeb7955073d0f6bf69b33d2a) because we don't exercise the 'unhappy paths' enough. :^)