### PR TITLE
Website: Bounty: Add rule for user interaction/social engineering

### DIFF
--- a/Meta/Websites/serenityos.org/bounty/index.html
+++ b/Meta/Websites/serenityos.org/bounty/index.html
@@ -21,6 +21,7 @@
         <li>The PoC exploit needs to work against the master branch at the time of claim.</li>
         <li>Max 5 bounties per person.</li>
         <li>No duplicates. If a bug is already reported, only the earliest reporter may claim the reward. This includes bugs found by continuous fuzzing systems.</li>
+        <li>No rewards for bugs that require unlikely user interaction or social engineering.</li>
         <li>Remote bugs must be exploitable with an unmodified "default setup" of SerenityOS. Bugs in programs that are not started by default don't qualify.</li>
         <li>The PoC exploit needs to work on a QEMU-emulated CPU that supports SMAP, SMEP, UMIP, NX, WP, and TSD natively.</li>
         <li>SerenityOS always runs with assertions enabled, so you'll need to find a way around them.</li>


### PR DESCRIPTION
"unlikely" is a bit vague.

The spirit of this rule is to prevent claims such as "here, run this totally legit ~~trojan~~ application!" while still rewarding reports for client-side vulnerabilities, such as exploitation of file-format vulnerabilities in image rendering libraries exploited via loading a page in the web browser.
