### PR TITLE
LibELF: validate_program_headers: Validate PT_INTERP header p_filesz > 1

### DIFF
--- a/Userland/Libraries/LibELF/Validation.cpp
+++ b/Userland/Libraries/LibELF/Validation.cpp
@@ -222,6 +222,11 @@ bool validate_program_headers(const Elf32_Ehdr& elf_header, size_t file_size, co
                     dbgln("Found PT_INTERP header ({}), but the .interp section was not within the buffer :(", header_index);
                 return false;
             }
+            if (program_header.p_filesz <= 1) {
+                if (verbose)
+                    dbgln("Found PT_INTERP header ({}), but p_filesz is invalid ({})", header_index, program_header.p_filesz);
+                return false;
+            }
             if (interpreter_path)
                 *interpreter_path = String((const char*)&buffer[program_header.p_offset], program_header.p_filesz - 1);
             break;


### PR DESCRIPTION
The `Program header (Phdr)` section of the [Linux man page for elf](https://man7.org/linux/man-pages/man5/elf.5.html) states:

        p_filesz
              This member holds the number of bytes in the file image of
              the segment.  It may be zero.

However, an ELF with a `PT_INTERP` header with a `p_filesz` of zero (or one including the null terminator) is doomed to failure, as a null-terminated path name of length < 1 is doomed to failure.

See also: https://blog.quarkslab.com/cve-2018-6924-freebsd-elf-header-parsing-kernel-memory-disclosure.html

> An unprivileged user can trigger an out-of-bounds memory access in the kernel by executing an ELF file of size < 0x1000 bytes containing an specially crafted PT_INTERP program header, with fields p_offset == 0x1000 and p_filesz == 0

Although did not result in leaking kernel memory in SerenityOS. Also, Serenity does not print the invalid interpreter path in userland which would have prevented the leak.

Part of #4563

```cpp
static void test_interp_tiny_p_filesz()
{
    char buffer[0x2000];

    auto& header = *(Elf32_Ehdr*)buffer;
    header.e_ident[EI_MAG0] = ELFMAG0;
    header.e_ident[EI_MAG1] = ELFMAG1;
    header.e_ident[EI_MAG2] = ELFMAG2;
    header.e_ident[EI_MAG3] = ELFMAG3;
    header.e_ident[EI_CLASS] = ELFCLASS32;
    header.e_ident[EI_DATA] = ELFDATA2LSB;
    header.e_ident[EI_VERSION] = EV_CURRENT;
    header.e_ident[EI_OSABI] = ELFOSABI_SYSV;
    header.e_ident[EI_ABIVERSION] = 0;
    header.e_type = ET_REL;
    header.e_version = EV_CURRENT;
    header.e_ehsize = sizeof(Elf32_Ehdr);
    header.e_machine = EM_386;
    header.e_shentsize = sizeof(Elf32_Shdr);

    /* inaccurate */
    header.e_phnum = 1;
    header.e_phoff = 52;
    header.e_phentsize = sizeof(Elf32_Phdr);

    auto* ph = (Elf32_Phdr*)(&buffer[header.e_phoff]);
    ph[0].p_flags = PF_R | PF_X;
    ph[0].p_vaddr = 0x00d4;
    ph[0].p_align = PAGE_SIZE;
    ph[0].p_type = PT_INTERP;
    ph[0].p_memsz = 0xffff0000;
    ph[0].p_offset = 0x100;
    ph[0].p_filesz = 1; // 1 or less

    /* inaccurate and unrelated */
    header.e_shnum = 3;
    header.e_shoff = 1024;
    header.e_shstrndx = 2;
    header.e_entry = 0xc018faa4;

    auto path = "/home/anon/x";
    int fd = open(path, O_RDWR | O_CREAT, 0755);
    if (fd < 0) {
        perror("open");
        return;
    }

    int nwritten = write(fd, buffer, sizeof(buffer));
    if (nwritten < 0) {
        perror("write");
        unlink(path);
        return;
    }

    if (execl(path, "x", nullptr) < 0) {
        perror("execl");
        unlink(path);
        return;
    }

    unlink(path);
}
```