### PR TITLE
Shell: Make the parser read consecutive sequences without recursing / Don't keep pushing EventLoops when blocking on jobs (#4976)

### DIFF
--- a/Userland/Libraries/LibGUI/ShellSyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibGUI/ShellSyntaxHighlighter.cpp
@@ -380,21 +380,19 @@ private:
     }
     virtual void visit(const AST::Sequence* node) override
     {
-        {
+        for (auto& entry : node->entries()) {
             ScopedValueRollback first_in_command { m_is_first_in_command };
-            node->left()->visit(*this);
-        }
-        {
-            ScopedValueRollback first_in_command { m_is_first_in_command };
-            node->right()->visit(*this);
+            entry.visit(*this);
         }
 
-        auto& span = span_for_node(node);
-        span.range.set_start({ node->separator_position().start_line.line_number, node->separator_position().start_line.line_column });
-        set_offset_range_end(span.range, node->separator_position().end_line);
-        span.attributes.color = m_palette.syntax_punctuation();
-        span.attributes.bold = true;
-        span.is_skippable = true;
+        for (auto& position : node->separator_positions()) {
+            auto& span = span_for_node(node);
+            span.range.set_start({ position.start_line.line_number, position.start_line.line_column });
+            set_offset_range_end(span.range, position.end_line);
+            span.attributes.color = m_palette.syntax_punctuation();
+            span.attributes.bold = true;
+            span.is_skippable = true;
+        }
     }
     virtual void visit(const AST::Subshell* node) override
     {

--- a/Userland/Shell/AST.h
+++ b/Userland/Shell/AST.h
@@ -1139,14 +1139,13 @@ private:
 
 class Sequence final : public Node {
 public:
-    Sequence(Position, NonnullRefPtr<Node>, NonnullRefPtr<Node>, Position separator_position);
+    Sequence(Position, NonnullRefPtrVector<Node>, Vector<Position> separator_positions);
     virtual ~Sequence();
     virtual void visit(NodeVisitor& visitor) override { visitor.visit(this); }
 
-    const NonnullRefPtr<Node>& left() const { return m_left; }
-    const NonnullRefPtr<Node>& right() const { return m_right; }
+    const NonnullRefPtrVector<Node>& entries() const { return m_entries; }
 
-    const Position& separator_position() const { return m_separator_position; }
+    const Vector<Position>& separator_positions() const { return m_separator_positions; }
 
 private:
     NODE(Sequence);
@@ -1157,9 +1156,8 @@ private:
     virtual bool is_list() const override { return true; }
     virtual bool should_override_execution_in_current_process() const override { return true; }
 
-    NonnullRefPtr<Node> m_left;
-    NonnullRefPtr<Node> m_right;
-    Position m_separator_position;
+    NonnullRefPtrVector<Node> m_entries;
+    Vector<Position> m_separator_positions;
 };
 
 class Subshell final : public Node {

--- a/Userland/Shell/Formatter.cpp
+++ b/Userland/Shell/Formatter.cpp
@@ -631,10 +631,17 @@ void Formatter::visit(const AST::Sequence* node)
     test_and_update_output_cursor(node);
 
     TemporaryChange<const AST::Node*> parent { m_parent_node, node };
-    node->left()->visit(*this);
-    insert_separator();
 
-    node->right()->visit(*this);
+    bool first = true;
+    for (auto& entry : node->entries()) {
+        if (first)
+            first = false;
+        else
+            insert_separator();
+
+        entry.visit(*this);
+    }
+
     visited(node);
 }
 

--- a/Userland/Shell/NodeVisitor.cpp
+++ b/Userland/Shell/NodeVisitor.cpp
@@ -186,8 +186,8 @@ void NodeVisitor::visit(const AST::ReadWriteRedirection* node)
 
 void NodeVisitor::visit(const AST::Sequence* node)
 {
-    node->left()->visit(*this);
-    node->right()->visit(*this);
+    for (auto& entry : node->entries())
+        entry.visit(*this);
 }
 
 void NodeVisitor::visit(const AST::Subshell* node)

--- a/Userland/Shell/Parser.h
+++ b/Userland/Shell/Parser.h
@@ -55,9 +55,19 @@ public:
     SavedOffset save_offset() const;
 
 private:
+    enum class ShouldReadMoreSequences {
+        Yes,
+        No,
+    };
+    struct SequenceParseResult {
+        NonnullRefPtrVector<AST::Node> entries;
+        Vector<AST::Position, 1> separator_positions;
+        ShouldReadMoreSequences decision;
+    };
+
     constexpr static size_t max_allowed_nested_rule_depth = 2048;
     RefPtr<AST::Node> parse_toplevel();
-    RefPtr<AST::Node> parse_sequence();
+    SequenceParseResult parse_sequence();
     RefPtr<AST::Node> parse_function_decl();
     RefPtr<AST::Node> parse_and_logical_sequence();
     RefPtr<AST::Node> parse_or_logical_sequence();
@@ -108,6 +118,10 @@ private:
 
     StringView consume_while(Function<bool(char)>);
 
+    struct Offset {
+        size_t offset;
+        AST::Position::Line line;
+    };
     struct ScopedOffset {
         ScopedOffset(Vector<size_t>& offsets, Vector<AST::Position::Line>& lines, size_t offset, size_t lineno, size_t linecol)
             : offsets(offsets)
@@ -136,6 +150,7 @@ private:
     void restore_to(const ScopedOffset& offset) { restore_to(offset.offset, offset.line); }
 
     OwnPtr<ScopedOffset> push_start();
+    Offset current_position();
 
     StringView m_input;
     size_t m_offset { 0 };

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -614,6 +614,8 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
     // If the command is empty, store the redirections and apply them to all later commands.
     if (command.argv.is_empty() && !command.should_immediately_execute_next) {
         m_global_redirections.append(command.redirections);
+        for (auto& next_in_chain : command.next_chain)
+            run_tail(command, next_in_chain, last_return_code);
         return nullptr;
     }
 


### PR DESCRIPTION
This fixes #4976.

Task lists? never heard of 'em.