### PR TITLE
LibGfx: Let PNGLoader handle failed chunk decoding gracefully

### DIFF
--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -592,8 +592,9 @@ static bool decode_png_chunks(PNGLoadingContext& context)
     Streamer streamer(data_ptr, data_remaining);
     while (!streamer.at_end()) {
         if (!process_chunk(streamer, context)) {
-            context.state = PNGLoadingContext::State::Error;
-            return false;
+            // Ignore failed chunk and just consider chunk decoding being done.
+            // decode_png_bitmap() will check whether we got all required ones anyway.
+            break;
         }
     }
 


### PR DESCRIPTION
`decode_png_chunks()` is not handling "critical" chunks, unlike `decode_png_size()` for example. When we encounter a chunk decoding failure, e.g. because not enough bytes were left to read, just continue with decoding the bitmap - which will fail on its own, if we're missing some required chunk(s).

Fixes #4984.