### PR TITLE
AK+Everywhere: Check dbgln() format at compiletime

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -84,6 +84,22 @@ struct Array {
 template<typename T, typename... Types>
 Array(T, Types...) -> Array<T, sizeof...(Types) + 1>;
 
+namespace Detail {
+template<typename T, unsigned long... Is>
+constexpr auto integer_sequence_generate_array([[maybe_unused]] const T offset, IntegerSequence<T, Is...>) -> Array<T, sizeof...(Is)>
+{
+    return { { (offset + Is)... } };
+}
+}
+
+template<typename T, T N>
+constexpr static auto iota_array(const T offset = {})
+{
+    static_assert(N >= T {}, "Negative sizes not allowed in iota_array()");
+    return Detail::integer_sequence_generate_array<T>(offset, MakeIntegerSequence<T, N>());
+}
+
 }
 
 using AK::Array;
+using AK::iota_array;

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <AK/AllOf.h>
+#include <AK/AnyOf.h>
 #include <AK/Array.h>
 #include <AK/GenericLexer.h>
 #include <AK/Optional.h>
@@ -33,6 +35,160 @@
 
 #ifndef KERNEL
 #    include <stdio.h>
+#endif
+
+#ifndef DBGLN_NO_COMPILETIME_FORMAT_CHECK
+// Note: Clang 12 adds support for CTAD, this would fail with any version prior to that.
+#    if defined(__clang__) && __clang_major__ < 12
+#        define DBGLN_NO_COMPILETIME_FORMAT_CHECK
+#    endif
+#endif
+
+#ifndef DBGLN_NO_COMPILETIME_FORMAT_CHECK
+namespace {
+
+template<size_t N>
+consteval auto extract_used_argument_index(const char (&fmt)[N], size_t specifier_start_index, size_t specifier_end_index, size_t& next_implicit_argument_index)
+{
+    struct {
+        size_t index_value { 0 };
+        bool saw_explicit_index { false };
+    } state;
+    for (size_t i = specifier_start_index; i < specifier_end_index; ++i) {
+        auto c = fmt[i];
+        if (c > '9' || c < '0')
+            break;
+
+        state.index_value *= 10;
+        state.index_value += c - '0';
+        state.saw_explicit_index = true;
+    }
+
+    if (!state.saw_explicit_index)
+        return next_implicit_argument_index++;
+
+    return state.index_value;
+}
+
+// FIXME: We should rather parse these format strings at compile-time if possible.
+template<size_t N>
+consteval auto count_fmt_params(const char (&fmt)[N])
+{
+    struct {
+        // FIXME: Switch to variable-sized storage whenever we can come up with one :)
+        Array<size_t, 128> used_arguments { 0 };
+        size_t total_used_argument_count { 0 };
+        size_t next_implicit_argument_index { 0 };
+        bool has_explicit_argument_references { false };
+
+        size_t unclosed_braces { 0 };
+        size_t extra_closed_braces { 0 };
+
+        Array<size_t, 4> last_format_specifier_start { 0 };
+        size_t total_used_last_format_specifier_start_count { 0 };
+
+        StringLiteral<128> internal_error { { 0 } };
+    } result;
+
+    for (size_t i = 0; i < N; ++i) {
+        auto ch = fmt[i];
+        switch (ch) {
+        case '{':
+            if (i + 1 < N && fmt[i + 1] == '{') {
+                ++i;
+                continue;
+            }
+
+            // Note: There's no compile-time throw, so we have to abuse a compile-time string to store errors.
+            if (result.total_used_last_format_specifier_start_count >= result.last_format_specifier_start.size() - 1)
+                result.internal_error = "Format-String Checker internal error: Format specifier nested too deep";
+
+            result.last_format_specifier_start[result.total_used_last_format_specifier_start_count++] = i + 1;
+
+            ++result.unclosed_braces;
+            break;
+        case '}':
+            if (i + 1 < N && fmt[i + 1] == '}') {
+                ++i;
+                continue;
+            }
+            if (result.unclosed_braces) {
+                --result.unclosed_braces;
+
+                if (result.total_used_last_format_specifier_start_count == 0)
+                    result.internal_error = "Format-String Checker internal error: Expected location information";
+
+                const auto specifier_start_index = result.last_format_specifier_start[--result.total_used_last_format_specifier_start_count];
+
+                if (result.total_used_argument_count >= result.used_arguments.size())
+                    result.internal_error = "Format-String Checker internal error: Too many format arguments in format string";
+
+                auto used_argument_index = extract_used_argument_index<N>(fmt, specifier_start_index, i, result.next_implicit_argument_index);
+                if (used_argument_index + 1 != result.next_implicit_argument_index)
+                    result.has_explicit_argument_references = true;
+                result.used_arguments[result.total_used_argument_count++] = used_argument_index;
+
+            } else {
+                ++result.extra_closed_braces;
+            }
+            break;
+        default:
+            continue;
+        }
+    }
+    return result;
+}
+}
+
+template<size_t N, StringLiteral<N> fmt, size_t param_count, auto check = count_fmt_params<N>(fmt.data)>
+constexpr bool check_format_parameter_consistency()
+{
+    static_assert(check.internal_error.data[0] == 0, "Some internal error occured, try looking at the check function type for the error");
+    static_assert(check.unclosed_braces == 0, "Extra unclosed braces in format string");
+    static_assert(check.extra_closed_braces == 0, "Extra closing braces in format string");
+
+    {
+        constexpr auto begin = check.used_arguments.begin();
+        constexpr auto end = check.used_arguments.begin() + check.total_used_argument_count;
+        constexpr auto has_all_referenced_arguments = !AK::any_of(begin, end, [](auto& entry) { return entry >= param_count; });
+        static_assert(has_all_referenced_arguments, "Format string references nonexistent parameter");
+    }
+
+    if constexpr (!check.has_explicit_argument_references)
+        static_assert(check.total_used_argument_count == param_count, "Format string does not reference all passed parameters");
+
+    // Ensure that no passed parameter is ignored or otherwise not referenced in the format
+    // As this check is generally pretty expensive, try to avoid it where it cannot fail.
+    // We will only do this check if the format string has explicit argument refs
+    // otherwise, the check above covers this check too, as implicit refs
+    // monotonically increase, and cannot have 'gaps'.
+    if constexpr (check.has_explicit_argument_references) {
+        constexpr auto all_parameters = iota_array<size_t, param_count>(0);
+        auto contains = [](auto begin, auto end, auto entry) {
+            for (; begin != end; begin++) {
+                if (*begin == entry)
+                    return true;
+            }
+
+            return false;
+        };
+        constexpr auto references_all_arguments = AK::all_of(
+            all_parameters.begin(),
+            all_parameters.end(),
+            [&](auto& entry) {
+                return contains(
+                    check.used_arguments.begin(),
+                    check.used_arguments.begin() + check.total_used_argument_count,
+                    entry);
+            });
+        static_assert(references_all_arguments, "Format string does not reference all passed parameters");
+    }
+
+    return true;
+}
+
+template<auto fmt, auto param_count>
+concept ConsistentFormatParameters = check_format_parameter_consistency<fmt.size, fmt, param_count>();
 #endif
 
 namespace AK {
@@ -392,6 +548,14 @@ inline void warnln() { outln(stderr); }
 
 void vdbgln(StringView fmtstr, TypeErasedFormatParams);
 
+#ifndef DBGLN_NO_COMPILETIME_FORMAT_CHECK
+template<StringLiteral fmt, bool enabled = true, typename... Parameters>
+void dbgln(const Parameters&... parameters) requires ConsistentFormatParameters<fmt, sizeof...(Parameters)>
+{
+    dbgln<enabled>(StringView { fmt.data }, parameters...);
+}
+#endif
+
 template<bool enabled = true, typename... Parameters>
 void dbgln(StringView fmtstr, const Parameters&... parameters)
 {
@@ -400,6 +564,7 @@ void dbgln(StringView fmtstr, const Parameters&... parameters)
 }
 template<bool enabled = true, typename... Parameters>
 void dbgln(const char* fmtstr, const Parameters&... parameters) { dbgln<enabled>(StringView { fmtstr }, parameters...); }
+
 template<bool enabled = true>
 void dbgln() { dbgln<enabled>(""); }
 
@@ -484,4 +649,10 @@ using AK::dbgln;
 using AK::FormatIfSupported;
 using AK::FormatString;
 
-#define dbgln_if(flag, format, ...) dbgln<flag>(format, ##__VA_ARGS__)
+#ifdef DBGLN_NO_COMPILETIME_FORMAT_CHECK
+#    define dbgln(fmt, ...) dbgln(fmt, ##__VA_ARGS__)
+#    define dbgln_if(flag, fmt, ...) dbgln<flag>(fmt, ##__VA_ARGS__)
+#else
+#    define dbgln(fmt, ...) dbgln<fmt>(__VA_ARGS__)
+#    define dbgln_if(flag, fmt, ...) dbgln<fmt, flag>(__VA_ARGS__)
+#endif

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -483,3 +483,5 @@ using AK::dbgln;
 
 using AK::FormatIfSupported;
 using AK::FormatString;
+
+#define dbgln_if(flag, format, ...) dbgln<flag>(format, ##__VA_ARGS__)

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -565,6 +565,38 @@ using MakeIntegerSequence = decltype(make_integer_sequence_impl<T, N>());
 template<unsigned N>
 using MakeIndexSequence = MakeIntegerSequence<unsigned, N>;
 
+template<unsigned long N>
+struct StringLiteral {
+    constexpr StringLiteral(const char (&in)[N])
+        : data {}
+        , size { N }
+    {
+        for (unsigned long i = 0; i < N; ++i)
+            data[i] = in[i];
+    }
+
+    template<unsigned long Nx>
+    constexpr StringLiteral& operator=(const StringLiteral<Nx>& other)
+    {
+        static_assert(Nx <= N, "Storing a string literal in a smaller one");
+        for (unsigned long i = 0; i < Nx; ++i)
+            data[i] = other[i];
+        return *this;
+    }
+
+    template<unsigned long Nx>
+    constexpr StringLiteral& operator=(const char (&other)[Nx])
+    {
+        static_assert(Nx <= N, "Storing a string literal in a smaller one");
+        for (unsigned long i = 0; i < Nx; ++i)
+            data[i] = other[i];
+        return *this;
+    }
+
+    char data[N];
+    unsigned long size;
+};
+
 }
 
 using AK::AddConst;
@@ -597,5 +629,6 @@ using AK::max;
 using AK::min;
 using AK::move;
 using AK::RemoveConst;
+using AK::StringLiteral;
 using AK::swap;
 using AK::Void;

--- a/AK/String.h
+++ b/AK/String.h
@@ -275,7 +275,10 @@ public:
     }
 
     template<typename T>
-    static String number(T value) requires IsArithmetic<T>::value { return formatted("{}", value); }
+    static String number(T value) requires IsArithmetic<T>::value
+    {
+        return formatted("{}", value);
+    }
 
     StringView view() const;
 

--- a/Kernel/ACPI/MultiProcessorParser.cpp
+++ b/Kernel/ACPI/MultiProcessorParser.cpp
@@ -67,7 +67,7 @@ void MultiProcessorParser::parse_configuration_table()
     size_t entry_count = config_table->entry_count;
     auto* entry = config_table->entries;
     while (entry_count > 0) {
-        dbgln<MULTIPROCESSOR_DEBUG>("MultiProcessor: Entry Type {} detected.", entry->entry_type);
+        dbgln_if(MULTIPROCESSOR_DEBUG, "MultiProcessor: Entry Type {} detected.", entry->entry_type);
         switch (entry->entry_type) {
         case ((u8)MultiProcessor::ConfigurationTableEntryType::Processor):
             entry = (MultiProcessor::EntryHeader*)(FlatPtr)entry + sizeof(MultiProcessor::ProcessorEntry);

--- a/Kernel/ACPI/Parser.cpp
+++ b/Kernel/ACPI/Parser.cpp
@@ -66,12 +66,12 @@ void Parser::locate_static_data()
 
 PhysicalAddress Parser::find_table(const StringView& signature)
 {
-    dbgln<ACPI_DEBUG>("ACPI: Calling Find Table method!");
+    dbgln_if(ACPI_DEBUG, "ACPI: Calling Find Table method!");
     for (auto p_sdt : m_sdt_pointers) {
         auto sdt = map_typed<Structures::SDTHeader>(p_sdt);
-        dbgln<ACPI_DEBUG>("ACPI: Examining Table @ {}", p_sdt);
+        dbgln_if(ACPI_DEBUG, "ACPI: Examining Table @ {}", p_sdt);
         if (!strncmp(sdt->sig, signature.characters_without_null_termination(), 4)) {
-            dbgln<ACPI_DEBUG>("ACPI: Found Table @ {}", p_sdt);
+            dbgln_if(ACPI_DEBUG, "ACPI: Found Table @ {}", p_sdt);
             return p_sdt;
         }
     }
@@ -93,7 +93,7 @@ void Parser::init_fadt()
 
     auto sdt = map_typed<Structures::FADT>(m_fadt);
 
-    dbgln<ACPI_DEBUG>("ACPI: FADT @ V{}, {}", &sdt, m_fadt);
+    dbgln_if(ACPI_DEBUG, "ACPI: FADT @ V{}, {}", &sdt, m_fadt);
 
     klog() << "ACPI: Fixed ACPI data, Revision " << sdt->h.revision << ", Length " << sdt->h.length << " bytes";
     klog() << "ACPI: DSDT " << PhysicalAddress(sdt->dsdt_ptr);
@@ -219,7 +219,7 @@ void Parser::try_acpi_reboot()
         klog() << "ACPI: Reboot, Not supported!";
         return;
     }
-    dbgln<ACPI_DEBUG>("ACPI: Rebooting, Probing FADT ({})", m_fadt);
+    dbgln_if(ACPI_DEBUG, "ACPI: Rebooting, Probing FADT ({})", m_fadt);
 
     auto fadt = map_typed<Structures::FADT>(m_fadt);
     ASSERT(validate_reset_register());
@@ -267,18 +267,18 @@ void Parser::initialize_main_system_description_table()
         auto& xsdt = (const Structures::XSDT&)*sdt;
         klog() << "ACPI: Using XSDT, Enumerating tables @ " << m_main_system_description_table;
         klog() << "ACPI: XSDT Revision " << revision << ", Total length - " << length;
-        dbgln<ACPI_DEBUG>("ACPI: XSDT pointer @ V{}", &xsdt);
+        dbgln_if(ACPI_DEBUG, "ACPI: XSDT pointer @ V{}", &xsdt);
         for (u32 i = 0; i < ((length - sizeof(Structures::SDTHeader)) / sizeof(u64)); i++) {
-            dbgln<ACPI_DEBUG>("ACPI: Found new table [{0}], @ V{1:p} - P{1:p}", i, &xsdt.table_ptrs[i]);
+            dbgln_if(ACPI_DEBUG, "ACPI: Found new table [{0}], @ V{1:p} - P{1:p}", i, &xsdt.table_ptrs[i]);
             m_sdt_pointers.append(PhysicalAddress(xsdt.table_ptrs[i]));
         }
     } else {
         auto& rsdt = (const Structures::RSDT&)*sdt;
         klog() << "ACPI: Using RSDT, Enumerating tables @ " << m_main_system_description_table;
         klog() << "ACPI: RSDT Revision " << revision << ", Total length - " << length;
-        dbgln<ACPI_DEBUG>("ACPI: RSDT pointer @ V{}", &rsdt);
+        dbgln_if(ACPI_DEBUG, "ACPI: RSDT pointer @ V{}", &rsdt);
         for (u32 i = 0; i < ((length - sizeof(Structures::SDTHeader)) / sizeof(u32)); i++) {
-            dbgln<ACPI_DEBUG>("ACPI: Found new table [{0}], @ V{1:p} - P{1:p}", i, &rsdt.table_ptrs[i]);
+            dbgln_if(ACPI_DEBUG, "ACPI: Found new table [{0}], @ V{1:p} - P{1:p}", i, &rsdt.table_ptrs[i]);
             m_sdt_pointers.append(PhysicalAddress(rsdt.table_ptrs[i]));
         }
     }

--- a/Kernel/Devices/BXVGADevice.cpp
+++ b/Kernel/Devices/BXVGADevice.cpp
@@ -106,7 +106,7 @@ void BXVGADevice::revert_resolution()
 
 void BXVGADevice::set_resolution_registers(size_t width, size_t height)
 {
-    dbgln<BXVGA_DEBUG>("BXVGADevice resolution registers set to - {}x{}", width, height);
+    dbgln_if(BXVGA_DEBUG, "BXVGADevice resolution registers set to - {}x{}", width, height);
     set_register(VBE_DISPI_INDEX_ENABLE, VBE_DISPI_DISABLED);
     set_register(VBE_DISPI_INDEX_XRES, (u16)width);
     set_register(VBE_DISPI_INDEX_YRES, (u16)height);
@@ -119,7 +119,7 @@ void BXVGADevice::set_resolution_registers(size_t width, size_t height)
 
 bool BXVGADevice::test_resolution(size_t width, size_t height)
 {
-    dbgln<BXVGA_DEBUG>("BXVGADevice resolution test - {}x{}", width, height);
+    dbgln_if(BXVGA_DEBUG, "BXVGADevice resolution test - {}x{}", width, height);
     set_resolution_registers(width, height);
     bool resolution_changed = validate_setup_resolution(width, height);
     revert_resolution();
@@ -241,7 +241,7 @@ int BXVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
         if (resolution.width > MAX_RESOLUTION_WIDTH || resolution.height > MAX_RESOLUTION_HEIGHT)
             return -EINVAL;
         if (!set_resolution(resolution.width, resolution.height)) {
-            dbgln<BXVGA_DEBUG>("Reverting resolution: [{}x{}]", m_framebuffer_width, m_framebuffer_height);
+            dbgln_if(BXVGA_DEBUG, "Reverting resolution: [{}x{}]", m_framebuffer_width, m_framebuffer_height);
             resolution.pitch = m_framebuffer_pitch;
             resolution.width = m_framebuffer_width;
             resolution.height = m_framebuffer_height;
@@ -249,7 +249,7 @@ int BXVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
                 return -EFAULT;
             return -EINVAL;
         }
-        dbgln<BXVGA_DEBUG>("New resolution: [{}x{}]", m_framebuffer_width, m_framebuffer_height);
+        dbgln_if(BXVGA_DEBUG, "New resolution: [{}x{}]", m_framebuffer_width, m_framebuffer_height);
         resolution.pitch = m_framebuffer_pitch;
         resolution.width = m_framebuffer_width;
         resolution.height = m_framebuffer_height;

--- a/Kernel/Devices/PS2MouseDevice.cpp
+++ b/Kernel/Devices/PS2MouseDevice.cpp
@@ -99,7 +99,7 @@ void PS2MouseDevice::irq_handle_byte_read(u8 byte)
 
     auto commit_packet = [&] {
         m_data_state = 0;
-        dbgln<PS2MOUSE_DEBUG>("PS2Mouse: {}, {} {} {}",
+        dbgln_if(PS2MOUSE_DEBUG, "PS2Mouse: {}, {} {} {}",
             m_data.bytes[1],
             m_data.bytes[2],
             (m_data.bytes[0] & 1) ? "Left" : "",

--- a/Kernel/Devices/VMWareBackdoor.cpp
+++ b/Kernel/Devices/VMWareBackdoor.cpp
@@ -177,7 +177,7 @@ void VMWareBackdoor::send_high_bandwidth(VMWareCommand& command)
 {
     vmware_high_bandwidth_send(command);
 
-    dbgln<VMWARE_BACKDOOR_DEBUG>("VMWareBackdoor Command High bandwidth Send Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
+    dbgln_if(VMWARE_BACKDOOR_DEBUG, "VMWareBackdoor Command High bandwidth Send Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
         command.ax,
         command.bx,
         command.cx,
@@ -188,7 +188,7 @@ void VMWareBackdoor::get_high_bandwidth(VMWareCommand& command)
 {
     vmware_high_bandwidth_get(command);
 
-    dbgln<VMWARE_BACKDOOR_DEBUG>("VMWareBackdoor Command High bandwidth Get Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
+    dbgln_if(VMWARE_BACKDOOR_DEBUG, "VMWareBackdoor Command High bandwidth Get Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
         command.ax,
         command.bx,
         command.cx,
@@ -199,7 +199,7 @@ void VMWareBackdoor::send(VMWareCommand& command)
 {
     vmware_out(command);
 
-    dbgln<VMWARE_BACKDOOR_DEBUG>("VMWareBackdoor Command Send Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
+    dbgln_if(VMWARE_BACKDOOR_DEBUG, "VMWareBackdoor Command Send Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
         command.ax,
         command.bx,
         command.cx,

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -49,7 +49,7 @@ KResultOr<NonnullRefPtr<FileDescription>> FileDescription::create(Custody& custo
     description->m_custody = custody;
     auto result = description->attach();
     if (result.is_error()) {
-        dbgln<FILEDESCRIPTION_DEBUG>("Failed to create file description for custody: {}", result);
+        dbgln_if(FILEDESCRIPTION_DEBUG, "Failed to create file description for custody: {}", result);
         return result;
     }
     return description;
@@ -60,7 +60,7 @@ KResultOr<NonnullRefPtr<FileDescription>> FileDescription::create(File& file)
     auto description = adopt(*new FileDescription(file));
     auto result = description->attach();
     if (result.is_error()) {
-        dbgln<FILEDESCRIPTION_DEBUG>("Failed to create file description for file: {}", result);
+        dbgln_if(FILEDESCRIPTION_DEBUG, "Failed to create file description for file: {}", result);
         return result;
     }
     return description;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -1015,7 +1015,7 @@ NonnullRefPtr<Inode> ProcFS::root_inode() const
 
 RefPtr<Inode> ProcFS::get_inode(InodeIdentifier inode_id) const
 {
-    dbgln<PROCFS_DEBUG>("ProcFS::get_inode({})", inode_id.index());
+    dbgln_if(PROCFS_DEBUG, "ProcFS::get_inode({})", inode_id.index());
     if (inode_id == root_inode()->identifier())
         return m_root_inode;
 
@@ -1128,7 +1128,7 @@ void ProcFSInode::did_seek(FileDescription& description, off_t new_offset)
 
 InodeMetadata ProcFSInode::metadata() const
 {
-    dbgln<PROCFS_DEBUG>("ProcFSInode::metadata({})", index());
+    dbgln_if(PROCFS_DEBUG, "ProcFSInode::metadata({})", index());
     InodeMetadata metadata;
     metadata.inode = identifier();
     metadata.ctime = mepoch;
@@ -1137,7 +1137,7 @@ InodeMetadata ProcFSInode::metadata() const
     auto proc_parent_directory = to_proc_parent_directory(identifier());
     auto proc_file_type = to_proc_file_type(identifier());
 
-    dbgln<PROCFS_DEBUG>("  -> pid={}, fi={}, pdi={}", to_pid(identifier()).value(), (int)proc_file_type, (int)proc_parent_directory);
+    dbgln_if(PROCFS_DEBUG, "  -> pid={}, fi={}, pdi={}", to_pid(identifier()).value(), (int)proc_file_type, (int)proc_parent_directory);
 
     if (is_process_related_file(identifier())) {
         ProcessID pid = to_pid(identifier());
@@ -1210,14 +1210,14 @@ InodeMetadata ProcFSInode::metadata() const
 
 ssize_t ProcFSInode::read_bytes(off_t offset, ssize_t count, UserOrKernelBuffer& buffer, FileDescription* description) const
 {
-    dbgln<PROCFS_DEBUG>("ProcFS: read_bytes offset: {} count: {}", offset, count);
+    dbgln_if(PROCFS_DEBUG, "ProcFS: read_bytes offset: {} count: {}", offset, count);
     ASSERT(offset >= 0);
     ASSERT(buffer.user_or_kernel_ptr());
 
     if (!description)
         return -EIO;
     if (!description->data()) {
-        dbgln<PROCFS_DEBUG>("ProcFS: Do not have cached data!");
+        dbgln_if(PROCFS_DEBUG, "ProcFS: Do not have cached data!");
         return -EIO;
     }
 
@@ -1241,7 +1241,7 @@ InodeIdentifier ProcFS::ProcFSDirectoryEntry::identifier(unsigned fsid) const
 
 KResult ProcFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntryView&)> callback) const
 {
-    dbgln<PROCFS_DEBUG>("ProcFS: traverse_as_directory {}", index());
+    dbgln_if(PROCFS_DEBUG, "ProcFS: traverse_as_directory {}", index());
 
     if (!Kernel::is_directory(identifier()))
         return ENOTDIR;

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -400,7 +400,7 @@ KResultOr<NonnullRefPtr<FileDescription>> VFS::create(StringView path, int optio
     if (parent_custody.is_readonly())
         return EROFS;
 
-    dbgln<VFS_DEBUG>("VFS::create: '{}' in {}", p.basename(), parent_inode.identifier());
+    dbgln_if(VFS_DEBUG, "VFS::create: '{}' in {}", p.basename(), parent_inode.identifier());
     uid_t uid = owner.has_value() ? owner.value().uid : current_process->euid();
     gid_t gid = owner.has_value() ? owner.value().gid : current_process->egid();
     auto inode_or_error = parent_inode.create_child(p.basename(), mode, 0, uid, gid);
@@ -442,7 +442,7 @@ KResult VFS::mkdir(StringView path, mode_t mode, Custody& base)
         return EROFS;
 
     LexicalPath p(path);
-    dbgln<VFS_DEBUG>("VFS::mkdir: '{}' in {}", p.basename(), parent_inode.identifier());
+    dbgln_if(VFS_DEBUG, "VFS::mkdir: '{}' in {}", p.basename(), parent_inode.identifier());
     return parent_inode.create_child(p.basename(), S_IFDIR | mode, 0, current_process->euid(), current_process->egid()).result();
 }
 

--- a/Kernel/FutexQueue.cpp
+++ b/Kernel/FutexQueue.cpp
@@ -133,7 +133,7 @@ u32 FutexQueue::wake_all(bool& is_empty)
         ASSERT(data);
         ASSERT(b.blocker_type() == Thread::Blocker::Type::Futex);
         auto& blocker = static_cast<Thread::FutexBlocker&>(b);
-        dbgln<FUTEXQUEUE_DEBUG>("FutexQueue @ {}: wake_all unblocking", this, *static_cast<Thread*>(data));
+        dbgln<FUTEXQUEUE_DEBUG>("FutexQueue @ {}: wake_all unblocking {}", this, *static_cast<Thread*>(data));
         if (blocker.unblock(true)) {
             did_wake++;
             return true;

--- a/Kernel/FutexQueue.cpp
+++ b/Kernel/FutexQueue.cpp
@@ -36,7 +36,7 @@ bool FutexQueue::should_add_blocker(Thread::Blocker& b, void* data)
     ASSERT(m_lock.is_locked());
     ASSERT(b.blocker_type() == Thread::Blocker::Type::Futex);
 
-    dbgln<FUTEXQUEUE_DEBUG>("FutexQueue @ {}: should block thread {}", this, *static_cast<Thread*>(data));
+    dbgln_if(FUTEXQUEUE_DEBUG, "FutexQueue @ {}: should block thread {}", this, *static_cast<Thread*>(data));
 
     return true;
 }
@@ -46,7 +46,7 @@ u32 FutexQueue::wake_n_requeue(u32 wake_count, const Function<FutexQueue*()>& ge
     is_empty_target = false;
     ScopedSpinLock lock(m_lock);
 
-    dbgln<FUTEXQUEUE_DEBUG>("FutexQueue @ {}: wake_n_requeue({}, {})", this, wake_count, requeue_count);
+    dbgln_if(FUTEXQUEUE_DEBUG, "FutexQueue @ {}: wake_n_requeue({}, {})", this, wake_count, requeue_count);
 
     u32 did_wake = 0, did_requeue = 0;
     do_unblock([&](Thread::Blocker& b, void* data, bool& stop_iterating) {
@@ -54,7 +54,7 @@ u32 FutexQueue::wake_n_requeue(u32 wake_count, const Function<FutexQueue*()>& ge
         ASSERT(b.blocker_type() == Thread::Blocker::Type::Futex);
         auto& blocker = static_cast<Thread::FutexBlocker&>(b);
 
-        dbgln<FUTEXQUEUE_DEBUG>("FutexQueue @ {}: wake_n_requeue unblocking {}", this, *static_cast<Thread*>(data));
+        dbgln_if(FUTEXQUEUE_DEBUG, "FutexQueue @ {}: wake_n_requeue unblocking {}", this, *static_cast<Thread*>(data));
         ASSERT(did_wake < wake_count);
         if (blocker.unblock()) {
             if (++did_wake >= wake_count)
@@ -68,7 +68,7 @@ u32 FutexQueue::wake_n_requeue(u32 wake_count, const Function<FutexQueue*()>& ge
         auto blockers_to_requeue = do_take_blockers(requeue_count);
         if (!blockers_to_requeue.is_empty()) {
             if (auto* target_futex_queue = get_target_queue()) {
-                dbgln<FUTEXQUEUE_DEBUG>("FutexQueue @ {}: wake_n_requeue requeueing {} blockers to {}", this, blockers_to_requeue.size(), target_futex_queue);
+                dbgln_if(FUTEXQUEUE_DEBUG, "FutexQueue @ {}: wake_n_requeue requeueing {} blockers to {}", this, blockers_to_requeue.size(), target_futex_queue);
 
                 // While still holding m_lock, notify each blocker
                 for (auto& info : blockers_to_requeue) {
@@ -91,7 +91,7 @@ u32 FutexQueue::wake_n_requeue(u32 wake_count, const Function<FutexQueue*()>& ge
                 target_futex_queue->do_append_blockers(move(blockers_to_requeue));
                 is_empty_target = target_futex_queue->is_empty_locked();
             } else {
-                dbgln<FUTEXQUEUE_DEBUG>("FutexQueue @ {}: wake_n_requeue could not get target queue to requeue {} blockers", this, blockers_to_requeue.size());
+                dbgln_if(FUTEXQUEUE_DEBUG, "FutexQueue @ {}: wake_n_requeue could not get target queue to requeue {} blockers", this, blockers_to_requeue.size());
                 do_append_blockers(move(blockers_to_requeue));
             }
         }
@@ -104,14 +104,14 @@ u32 FutexQueue::wake_n(u32 wake_count, const Optional<u32>& bitset, bool& is_emp
     if (wake_count == 0)
         return 0; // should we assert instead?
     ScopedSpinLock lock(m_lock);
-    dbgln<FUTEXQUEUE_DEBUG>("FutexQueue @ {}: wake_n({})", this, wake_count);
+    dbgln_if(FUTEXQUEUE_DEBUG, "FutexQueue @ {}: wake_n({})", this, wake_count);
     u32 did_wake = 0;
     do_unblock([&](Thread::Blocker& b, void* data, bool& stop_iterating) {
         ASSERT(data);
         ASSERT(b.blocker_type() == Thread::Blocker::Type::Futex);
         auto& blocker = static_cast<Thread::FutexBlocker&>(b);
 
-        dbgln<FUTEXQUEUE_DEBUG>("FutexQueue @ {}: wake_n unblocking {}", this, *static_cast<Thread*>(data));
+        dbgln_if(FUTEXQUEUE_DEBUG, "FutexQueue @ {}: wake_n unblocking {}", this, *static_cast<Thread*>(data));
         ASSERT(did_wake < wake_count);
         if (bitset.has_value() ? blocker.unblock_bitset(bitset.value()) : blocker.unblock()) {
             if (++did_wake >= wake_count)
@@ -127,13 +127,13 @@ u32 FutexQueue::wake_n(u32 wake_count, const Optional<u32>& bitset, bool& is_emp
 u32 FutexQueue::wake_all(bool& is_empty)
 {
     ScopedSpinLock lock(m_lock);
-    dbgln<FUTEXQUEUE_DEBUG>("FutexQueue @ {}: wake_all", this);
+    dbgln_if(FUTEXQUEUE_DEBUG, "FutexQueue @ {}: wake_all", this);
     u32 did_wake = 0;
     do_unblock([&](Thread::Blocker& b, void* data, bool&) {
         ASSERT(data);
         ASSERT(b.blocker_type() == Thread::Blocker::Type::Futex);
         auto& blocker = static_cast<Thread::FutexBlocker&>(b);
-        dbgln<FUTEXQUEUE_DEBUG>("FutexQueue @ {}: wake_all unblocking {}", this, *static_cast<Thread*>(data));
+        dbgln_if(FUTEXQUEUE_DEBUG, "FutexQueue @ {}: wake_all unblocking {}", this, *static_cast<Thread*>(data));
         if (blocker.unblock(true)) {
             did_wake++;
             return true;

--- a/Kernel/Interrupts/IOAPIC.cpp
+++ b/Kernel/Interrupts/IOAPIC.cpp
@@ -320,13 +320,13 @@ void IOAPIC::write_register(u32 index, u32 value) const
     m_regs->select = index;
     m_regs->window = value;
 
-    dbgln<IOAPIC_DEBUG>("IOAPIC Writing, Value {:#x} @ offset {:#x}", (u32)m_regs->window, (u32)m_regs->select);
+    dbgln_if(IOAPIC_DEBUG, "IOAPIC Writing, Value {:#x} @ offset {:#x}", (u32)m_regs->window, (u32)m_regs->select);
 }
 u32 IOAPIC::read_register(u32 index) const
 {
     InterruptDisabler disabler;
     m_regs->select = index;
-    dbgln<IOAPIC_DEBUG>("IOAPIC Reading, Value {:#x} @ offset {:#x}", (u32)m_regs->window, (u32)m_regs->select);
+    dbgln_if(IOAPIC_DEBUG, "IOAPIC Reading, Value {:#x} @ offset {:#x}", (u32)m_regs->window, (u32)m_regs->select);
     return m_regs->window;
 }
 

--- a/Kernel/Interrupts/IRQHandler.cpp
+++ b/Kernel/Interrupts/IRQHandler.cpp
@@ -44,7 +44,7 @@ IRQHandler::~IRQHandler()
 
 bool IRQHandler::eoi()
 {
-    dbgln<IRQ_DEBUG>("EOI IRQ {}", interrupt_number());
+    dbgln_if(IRQ_DEBUG, "EOI IRQ {}", interrupt_number());
     if (!m_shared_with_others) {
         ASSERT(!m_responsible_irq_controller.is_null());
         m_responsible_irq_controller->eoi(*this);
@@ -55,7 +55,7 @@ bool IRQHandler::eoi()
 
 void IRQHandler::enable_irq()
 {
-    dbgln<IRQ_DEBUG>("Enable IRQ {}", interrupt_number());
+    dbgln_if(IRQ_DEBUG, "Enable IRQ {}", interrupt_number());
     m_enabled = true;
     if (!m_shared_with_others)
         m_responsible_irq_controller->enable(*this);
@@ -63,7 +63,7 @@ void IRQHandler::enable_irq()
 
 void IRQHandler::disable_irq()
 {
-    dbgln<IRQ_DEBUG>("Disable IRQ {}", interrupt_number());
+    dbgln_if(IRQ_DEBUG, "Disable IRQ {}", interrupt_number());
     m_enabled = false;
     if (!m_shared_with_others)
         m_responsible_irq_controller->disable(*this);

--- a/Kernel/Interrupts/SharedIRQHandler.cpp
+++ b/Kernel/Interrupts/SharedIRQHandler.cpp
@@ -59,7 +59,7 @@ void SharedIRQHandler::unregister_handler(GenericInterruptHandler& handler)
 
 bool SharedIRQHandler::eoi()
 {
-    dbgln<INTERRUPT_DEBUG>("EOI IRQ {}", interrupt_number());
+    dbgln_if(INTERRUPT_DEBUG, "EOI IRQ {}", interrupt_number());
     m_responsible_irq_controller->eoi(*this);
     return true;
 }
@@ -93,11 +93,11 @@ void SharedIRQHandler::handle_interrupt(const RegisterState& regs)
 
     int i = 0;
     for (auto* handler : m_handlers) {
-        dbgln<INTERRUPT_DEBUG>("Going for Interrupt Handling @ {}, Shared Interrupt {}", i, interrupt_number());
+        dbgln_if(INTERRUPT_DEBUG, "Going for Interrupt Handling @ {}, Shared Interrupt {}", i, interrupt_number());
         ASSERT(handler != nullptr);
         handler->increment_invoking_counter();
         handler->handle_interrupt(regs);
-        dbgln<INTERRUPT_DEBUG>("Going for Interrupt Handling @ {}, Shared Interrupt {} - End", i, interrupt_number());
+        dbgln_if(INTERRUPT_DEBUG, "Going for Interrupt Handling @ {}, Shared Interrupt {} - End", i, interrupt_number());
         i++;
     }
 }

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -362,7 +362,7 @@ void E1000NetworkAdapter::initialize_tx_descriptors()
 
 void E1000NetworkAdapter::out8(u16 address, u8 data)
 {
-    dbgln<E1000_DEBUG>("E1000: OUT8 {:#02x} @ {:#04x}", data, address);
+    dbgln_if(E1000_DEBUG, "E1000: OUT8 {:#02x} @ {:#04x}", data, address);
     if (m_use_mmio) {
         auto* ptr = (volatile u8*)(m_mmio_base.get() + address);
         *ptr = data;
@@ -373,7 +373,7 @@ void E1000NetworkAdapter::out8(u16 address, u8 data)
 
 void E1000NetworkAdapter::out16(u16 address, u16 data)
 {
-    dbgln<E1000_DEBUG>("E1000: OUT16 {:#04x} @ {:#04x}", data, address);
+    dbgln_if(E1000_DEBUG, "E1000: OUT16 {:#04x} @ {:#04x}", data, address);
     if (m_use_mmio) {
         auto* ptr = (volatile u16*)(m_mmio_base.get() + address);
         *ptr = data;
@@ -384,7 +384,7 @@ void E1000NetworkAdapter::out16(u16 address, u16 data)
 
 void E1000NetworkAdapter::out32(u16 address, u32 data)
 {
-    dbgln<E1000_DEBUG>("E1000: OUT32 {:#08x} @ {:#04x}", data, address);
+    dbgln_if(E1000_DEBUG, "E1000: OUT32 {:#08x} @ {:#04x}", data, address);
     if (m_use_mmio) {
         auto* ptr = (volatile u32*)(m_mmio_base.get() + address);
         *ptr = data;
@@ -395,7 +395,7 @@ void E1000NetworkAdapter::out32(u16 address, u32 data)
 
 u8 E1000NetworkAdapter::in8(u16 address)
 {
-    dbgln<E1000_DEBUG>("E1000: IN8 @ {:#04x}", address);
+    dbgln_if(E1000_DEBUG, "E1000: IN8 @ {:#04x}", address);
     if (m_use_mmio)
         return *(volatile u8*)(m_mmio_base.get() + address);
     return m_io_base.offset(address).in<u8>();
@@ -403,7 +403,7 @@ u8 E1000NetworkAdapter::in8(u16 address)
 
 u16 E1000NetworkAdapter::in16(u16 address)
 {
-    dbgln<E1000_DEBUG>("E1000: IN16 @ {:#04x}", address);
+    dbgln_if(E1000_DEBUG, "E1000: IN16 @ {:#04x}", address);
     if (m_use_mmio)
         return *(volatile u16*)(m_mmio_base.get() + address);
     return m_io_base.offset(address).in<u16>();
@@ -411,7 +411,7 @@ u16 E1000NetworkAdapter::in16(u16 address)
 
 u32 E1000NetworkAdapter::in32(u16 address)
 {
-    dbgln<E1000_DEBUG>("E1000: IN32 @ {:#04x}", address);
+    dbgln_if(E1000_DEBUG, "E1000: IN32 @ {:#04x}", address);
     if (m_use_mmio)
         return *(volatile u32*)(m_mmio_base.get() + address);
     return m_io_base.offset(address).in<u32>();

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -66,7 +66,7 @@ KResultOr<NonnullRefPtr<Socket>> IPv4Socket::create(int type, int protocol)
 IPv4Socket::IPv4Socket(int type, int protocol)
     : Socket(AF_INET, type, protocol)
 {
-    dbgln<IPV4_SOCKET_DEBUG>("IPv4Socket({}) created with type={}, protocol={}", this, type, protocol);
+    dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket({}) created with type={}, protocol={}", this, type, protocol);
     m_buffer_mode = type == SOCK_STREAM ? BufferMode::Bytes : BufferMode::Packets;
     if (m_buffer_mode == BufferMode::Bytes) {
         m_scratch_buffer = KBuffer::create_with_size(65536);
@@ -119,7 +119,7 @@ KResult IPv4Socket::bind(Userspace<const sockaddr*> user_address, socklen_t addr
     m_local_address = IPv4Address((const u8*)&address.sin_addr.s_addr);
     m_local_port = requested_local_port;
 
-    dbgln<IPV4_SOCKET_DEBUG>("IPv4Socket::bind {}({}) to {}:{}", class_name(), this, m_local_address, m_local_port);
+    dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket::bind {}({}) to {}:{}", class_name(), this, m_local_address, m_local_port);
 
     return protocol_bind();
 }
@@ -135,7 +135,7 @@ KResult IPv4Socket::listen(size_t backlog)
     m_role = Role::Listener;
     evaluate_block_conditions();
 
-    dbgln<IPV4_SOCKET_DEBUG>("IPv4Socket({}) listening with backlog={}", this, backlog);
+    dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket({}) listening with backlog={}", this, backlog);
 
     return protocol_listen();
 }
@@ -287,7 +287,7 @@ KResultOr<size_t> IPv4Socket::receive_packet_buffered(FileDescription& descripti
             packet = m_receive_queue.take_first();
             set_can_read(!m_receive_queue.is_empty());
 
-            dbgln<IPV4_SOCKET_DEBUG>("IPv4Socket({}): recvfrom without blocking {} bytes, packets in queue: {}",
+            dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket({}): recvfrom without blocking {} bytes, packets in queue: {}",
                 this,
                 packet.data.value().size(),
                 m_receive_queue.size());
@@ -316,7 +316,7 @@ KResultOr<size_t> IPv4Socket::receive_packet_buffered(FileDescription& descripti
         packet = m_receive_queue.take_first();
         set_can_read(!m_receive_queue.is_empty());
 
-        dbgln<IPV4_SOCKET_DEBUG>("IPv4Socket({}): recvfrom with blocking {} bytes, packets in queue: {}",
+        dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket({}): recvfrom with blocking {} bytes, packets in queue: {}",
             this,
             packet.data.value().size(),
             m_receive_queue.size());
@@ -326,7 +326,7 @@ KResultOr<size_t> IPv4Socket::receive_packet_buffered(FileDescription& descripti
     packet_timestamp = packet.timestamp;
 
     if (addr) {
-        dbgln<IPV4_SOCKET_DEBUG>("Incoming packet is from: {}:{}", packet.peer_address, packet.peer_port);
+        dbgln_if(IPV4_SOCKET_DEBUG, "Incoming packet is from: {}:{}", packet.peer_address, packet.peer_port);
 
         sockaddr_in out_addr {};
         memcpy(&out_addr.sin_addr, &packet.peer_address, sizeof(IPv4Address));

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -74,7 +74,7 @@ LocalSocket::LocalSocket(int type)
         evaluate_block_conditions();
     });
 
-    dbgln<LOCAL_SOCKET_DEBUG>("LocalSocket({}) created with type={}", this, type);
+    dbgln_if(LOCAL_SOCKET_DEBUG, "LocalSocket({}) created with type={}", this, type);
 }
 
 LocalSocket::~LocalSocket()
@@ -110,7 +110,7 @@ KResult LocalSocket::bind(Userspace<const sockaddr*> user_address, socklen_t add
 
     auto path = String(address.sun_path, strnlen(address.sun_path, sizeof(address.sun_path)));
 
-    dbgln<LOCAL_SOCKET_DEBUG>("LocalSocket({}) bind({})", this, path);
+    dbgln_if(LOCAL_SOCKET_DEBUG, "LocalSocket({}) bind({})", this, path);
 
     mode_t mode = S_IFSOCK | (m_prebind_mode & 0777);
     UidAndGid owner { m_prebind_uid, m_prebind_gid };
@@ -154,7 +154,7 @@ KResult LocalSocket::connect(FileDescription& description, Userspace<const socka
         return EFAULT;
     safe_address[sizeof(safe_address) - 1] = '\0';
 
-    dbgln<LOCAL_SOCKET_DEBUG>("LocalSocket({}) connect({})", this, safe_address);
+    dbgln_if(LOCAL_SOCKET_DEBUG, "LocalSocket({}) connect({})", this, safe_address);
 
     auto description_or_error = VFS::the().open(safe_address, O_RDWR, 0, Process::current()->current_directory());
     if (description_or_error.is_error())
@@ -190,7 +190,7 @@ KResult LocalSocket::connect(FileDescription& description, Userspace<const socka
         return EINTR;
     }
 
-    dbgln<LOCAL_SOCKET_DEBUG>("LocalSocket({}) connect({}) status is {}", this, safe_address, to_string(setup_state()));
+    dbgln_if(LOCAL_SOCKET_DEBUG, "LocalSocket({}) connect({}) status is {}", this, safe_address, to_string(setup_state()));
 
     if (!((u32)unblock_flags & (u32)Thread::FileDescriptionBlocker::BlockFlags::Connect)) {
         set_connect_side_role(Role::None);
@@ -210,7 +210,7 @@ KResult LocalSocket::listen(size_t backlog)
     m_role = Role::Listener;
     set_connect_side_role(Role::Listener, previous_role != m_role);
 
-    dbgln<LOCAL_SOCKET_DEBUG>("LocalSocket({}) listening with backlog={}", this, backlog);
+    dbgln_if(LOCAL_SOCKET_DEBUG, "LocalSocket({}) listening with backlog={}", this, backlog);
 
     return KSuccess;
 }

--- a/Kernel/Net/NE2000NetworkAdapter.cpp
+++ b/Kernel/Net/NE2000NetworkAdapter.cpp
@@ -210,13 +210,13 @@ NE2000NetworkAdapter::~NE2000NetworkAdapter()
 void NE2000NetworkAdapter::handle_irq(const RegisterState&)
 {
     u8 status = in8(REG_RW_INTERRUPTSTATUS);
-    dbgln<NE2000_DEBUG>("NE2000NetworkAdapter: Got interrupt, status=0x{}", String::format("%02x", status));
+    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Got interrupt, status=0x{}", String::format("%02x", status));
 
     if (status & BIT_INTERRUPTMASK_PRX) {
-        dbgln<NE2000_DEBUG>("NE2000NetworkAdapter: Interrupt for packet received");
+        dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Interrupt for packet received");
     }
     if (status & BIT_INTERRUPTMASK_PTX) {
-        dbgln<NE2000_DEBUG>("NE2000NetworkAdapter: Interrupt for packet sent");
+        dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Interrupt for packet sent");
     }
     if (status & BIT_INTERRUPTMASK_RXE) {
         u8 fae = in8(REG_RD_FAE_TALLY);
@@ -278,9 +278,9 @@ int NE2000NetworkAdapter::ram_test()
         for (size_t j = 0; j < buffer.size(); ++j) {
             if (buffer[j] != patterns[i]) {
                 if (errors < 16)
-                    dbgln<NE2000_DEBUG>("NE2000NetworkAdapter: Bad adapter RAM @ {} expected={} got={}", PhysicalAddress(NE2K_RAM_BEGIN + j), patterns[i], buffer[j]);
+                    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Bad adapter RAM @ {} expected={} got={}", PhysicalAddress(NE2K_RAM_BEGIN + j), patterns[i], buffer[j]);
                 else if (errors == 16)
-                    dbgln<NE2000_DEBUG>("NE2000NetworkAdapter: Too many RAM errors, silencing further output");
+                    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Too many RAM errors, silencing further output");
                 errors++;
             }
         }
@@ -330,7 +330,7 @@ void NE2000NetworkAdapter::reset()
 
 void NE2000NetworkAdapter::rdma_read(size_t address, Bytes payload)
 {
-    dbgln<NE2000_DEBUG>("NE2000NetworkAdapter: DMA read @ {} length={}", PhysicalAddress(address), payload.size());
+    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: DMA read @ {} length={}", PhysicalAddress(address), payload.size());
 
     u8 command = in8(REG_RW_COMMAND) & ~(BIT_COMMAND_PAGE_FIELD | BIT_COMMAND_DMA_FIELD);
     out8(REG_RW_COMMAND, command | BIT_COMMAND_DMA_ABORT);
@@ -357,7 +357,7 @@ void NE2000NetworkAdapter::rdma_read(size_t address, Bytes payload)
 
 void NE2000NetworkAdapter::rdma_write(size_t address, ReadonlyBytes payload)
 {
-    dbgln<NE2000_DEBUG>("NE2000NetworkAdapter: DMA write @ {} length={}", PhysicalAddress(address), payload.size());
+    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: DMA write @ {} length={}", PhysicalAddress(address), payload.size());
 
     u8 command = in8(REG_RW_COMMAND) & ~(BIT_COMMAND_PAGE_FIELD | BIT_COMMAND_DMA_FIELD);
     out8(REG_RW_COMMAND, command | BIT_COMMAND_DMA_ABORT);
@@ -384,7 +384,7 @@ void NE2000NetworkAdapter::rdma_write(size_t address, ReadonlyBytes payload)
 
 void NE2000NetworkAdapter::send_raw(ReadonlyBytes payload)
 {
-    dbgln<NE2000_DEBUG>("NE2000NetworkAdapter: Sending packet length={}", payload.size());
+    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Sending packet length={}", payload.size());
 
     if (payload.size() > NE2K_RAM_SEND_SIZE) {
         dmesgln("NE2000NetworkAdapter: Packet to send was too big; discarding");
@@ -404,7 +404,7 @@ void NE2000NetworkAdapter::send_raw(ReadonlyBytes payload)
     out8(REG_WR_TRANSMITBYTECOUNT1, packet_size >> 8);
     out8(REG_RW_COMMAND, BIT_COMMAND_DMA_ABORT | BIT_COMMAND_TXP | BIT_COMMAND_START);
 
-    dbgln<NE2000_DEBUG>("NE2000NetworkAdapter: Packet submitted for transmission");
+    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Packet submitted for transmission");
 
     enable_irq();
 }
@@ -423,7 +423,7 @@ void NE2000NetworkAdapter::receive()
         rdma_read(header_address, Bytes(reinterpret_cast<u8*>(&header), sizeof(header)));
 
         bool packet_ok = header.status & BIT_RECEIVESTATUS_PRX;
-        dbgln<NE2000_DEBUG>("NE2000NetworkAdapter: Packet received {} length={}", (packet_ok ? "intact" : "damaged"), header.length);
+        dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Packet received {} length={}", (packet_ok ? "intact" : "damaged"), header.length);
 
         if (packet_ok) {
             auto packet = ByteBuffer::create_uninitialized(sizeof(received_packet_header) + header.length);

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -64,7 +64,7 @@ Socket::~Socket()
 
 void Socket::set_setup_state(SetupState new_setup_state)
 {
-    dbgln<SOCKET_DEBUG>("Socket({}) setup state moving from {} to {}", this, to_string(m_setup_state), to_string(new_setup_state));
+    dbgln_if(SOCKET_DEBUG, "Socket({}) setup state moving from {} to {}", this, to_string(m_setup_state), to_string(new_setup_state));
     m_setup_state = new_setup_state;
     evaluate_block_conditions();
 }
@@ -74,7 +74,7 @@ RefPtr<Socket> Socket::accept()
     LOCKER(m_lock);
     if (m_pending.is_empty())
         return nullptr;
-    dbgln<SOCKET_DEBUG>("Socket({}) de-queueing connection", this);
+    dbgln_if(SOCKET_DEBUG, "Socket({}) de-queueing connection", this);
     auto client = m_pending.take_first();
     ASSERT(!client->is_connected());
     auto& process = *Process::current();
@@ -88,7 +88,7 @@ RefPtr<Socket> Socket::accept()
 
 KResult Socket::queue_connection_from(NonnullRefPtr<Socket> peer)
 {
-    dbgln<SOCKET_DEBUG>("Socket({}) queueing connection", this);
+    dbgln_if(SOCKET_DEBUG, "Socket({}) queueing connection", this);
     LOCKER(m_lock);
     if (m_pending.size() >= m_backlog)
         return ECONNREFUSED;

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -47,7 +47,7 @@ void TCPSocket::for_each(Function<void(const TCPSocket&)> callback)
 
 void TCPSocket::set_state(State new_state)
 {
-    dbgln<TCP_SOCKET_DEBUG>("TCPSocket({}) state moving from {} to {}", this, to_string(m_state), to_string(new_state));
+    dbgln_if(TCP_SOCKET_DEBUG, "TCPSocket({}) state moving from {} to {}", this, to_string(m_state), to_string(new_state));
 
     auto was_disconnected = protocol_is_disconnected();
     auto previous_role = m_role;
@@ -154,7 +154,7 @@ TCPSocket::~TCPSocket()
     LOCKER(sockets_by_tuple().lock());
     sockets_by_tuple().resource().remove(tuple());
 
-    dbgln<TCP_SOCKET_DEBUG>("~TCPSocket in state {}", to_string(state()));
+    dbgln_if(TCP_SOCKET_DEBUG, "~TCPSocket in state {}", to_string(state()));
 }
 
 NonnullRefPtr<TCPSocket> TCPSocket::create(int protocol)
@@ -273,14 +273,14 @@ void TCPSocket::receive_tcp_packet(const TCPPacket& packet, u16 size)
     if (packet.has_ack()) {
         u32 ack_number = packet.ack_number();
 
-        dbgln<TCP_SOCKET_DEBUG>("TCPSocket: receive_tcp_packet: {}", ack_number);
+        dbgln_if(TCP_SOCKET_DEBUG, "TCPSocket: receive_tcp_packet: {}", ack_number);
 
         int removed = 0;
         LOCKER(m_not_acked_lock);
         while (!m_not_acked.is_empty()) {
             auto& packet = m_not_acked.first();
 
-            dbgln<TCP_SOCKET_DEBUG>("TCPSocket: iterate: {}", packet.ack_number);
+            dbgln_if(TCP_SOCKET_DEBUG, "TCPSocket: iterate: {}", packet.ack_number);
 
             if (packet.ack_number <= ack_number) {
                 m_not_acked.take_first();
@@ -290,7 +290,7 @@ void TCPSocket::receive_tcp_packet(const TCPPacket& packet, u16 size)
             }
         }
 
-        dbgln<TCP_SOCKET_DEBUG>("TCPSocket: receive_tcp_packet acknowledged {} packets", removed);
+        dbgln_if(TCP_SOCKET_DEBUG, "TCPSocket: receive_tcp_packet acknowledged {} packets", removed);
     }
 
     m_packets_in++;

--- a/Kernel/PCI/Access.cpp
+++ b/Kernel/PCI/Access.cpp
@@ -74,34 +74,34 @@ PhysicalID Access::get_physical_id(Address address) const
 
 u8 Access::early_read8_field(Address address, u32 field)
 {
-    dbgln<PCI_DEBUG>("PCI: Early reading 8-bit field {:#08x} for {}", field, address);
+    dbgln_if(PCI_DEBUG, "PCI: Early reading 8-bit field {:#08x} for {}", field, address);
     IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
     return IO::in8(PCI_VALUE_PORT + (field & 3));
 }
 
 u16 Access::early_read16_field(Address address, u32 field)
 {
-    dbgln<PCI_DEBUG>("PCI: Early reading 16-bit field {:#08x} for {}", field, address);
+    dbgln_if(PCI_DEBUG, "PCI: Early reading 16-bit field {:#08x} for {}", field, address);
     IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
     return IO::in16(PCI_VALUE_PORT + (field & 2));
 }
 
 u32 Access::early_read32_field(Address address, u32 field)
 {
-    dbgln<PCI_DEBUG>("PCI: Early reading 32-bit field {:#08x} for {}", field, address);
+    dbgln_if(PCI_DEBUG, "PCI: Early reading 32-bit field {:#08x} for {}", field, address);
     IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
     return IO::in32(PCI_VALUE_PORT);
 }
 
 u16 Access::early_read_type(Address address)
 {
-    dbgln<PCI_DEBUG>("PCI: Early reading type for {}", address);
+    dbgln_if(PCI_DEBUG, "PCI: Early reading type for {}", address);
     return (early_read8_field(address, PCI_CLASS) << 8u) | early_read8_field(address, PCI_SUBCLASS);
 }
 
 void Access::enumerate_functions(int type, u8 bus, u8 device, u8 function, Function<void(Address, ID)>& callback, bool recursive)
 {
-    dbgln<PCI_DEBUG>("PCI: Enumerating function type={}, bus={}, device={}, function={}", type, bus, device, function);
+    dbgln_if(PCI_DEBUG, "PCI: Enumerating function type={}, bus={}, device={}, function={}", type, bus, device, function);
     Address address(0, bus, device, function);
     if (type == -1 || type == early_read_type(address))
         callback(address, { early_read16_field(address, PCI_VENDOR_ID), early_read16_field(address, PCI_DEVICE_ID) });
@@ -117,7 +117,7 @@ void Access::enumerate_functions(int type, u8 bus, u8 device, u8 function, Funct
 
 void Access::enumerate_device(int type, u8 bus, u8 device, Function<void(Address, ID)>& callback, bool recursive)
 {
-    dbgln<PCI_DEBUG>("PCI: Enumerating device type={}, bus={}, device={}", type, bus, device);
+    dbgln_if(PCI_DEBUG, "PCI: Enumerating device type={}, bus={}, device={}", type, bus, device);
     Address address(0, bus, device, 0);
     if (early_read16_field(address, PCI_VENDOR_ID) == PCI_NONE)
         return;
@@ -133,7 +133,7 @@ void Access::enumerate_device(int type, u8 bus, u8 device, Function<void(Address
 
 void Access::enumerate_bus(int type, u8 bus, Function<void(Address, ID)>& callback, bool recursive)
 {
-    dbgln<PCI_DEBUG>("PCI: Enumerating bus type={}, bus={}", type, bus);
+    dbgln_if(PCI_DEBUG, "PCI: Enumerating bus type={}, bus={}", type, bus);
     for (u8 device = 0; device < 32; ++device)
         enumerate_device(type, bus, device, callback, recursive);
 }
@@ -152,12 +152,12 @@ void enumerate(Function<void(Address, ID)> callback)
 
 Optional<u8> get_capabilities_pointer(Address address)
 {
-    dbgln<PCI_DEBUG>("PCI: Getting capabilities pointer for {}", address);
+    dbgln_if(PCI_DEBUG, "PCI: Getting capabilities pointer for {}", address);
     if (PCI::read16(address, PCI_STATUS) & (1 << 4)) {
-        dbgln<PCI_DEBUG>("PCI: Found capabilities pointer for {}", address);
+        dbgln_if(PCI_DEBUG, "PCI: Found capabilities pointer for {}", address);
         return PCI::read8(address, PCI_CAPABILITIES_POINTER);
     }
-    dbgln<PCI_DEBUG>("PCI: No capabilities pointer for {}", address);
+    dbgln_if(PCI_DEBUG, "PCI: No capabilities pointer for {}", address);
     return {};
 }
 
@@ -168,16 +168,16 @@ PhysicalID get_physical_id(Address address)
 
 Vector<Capability> get_capabilities(Address address)
 {
-    dbgln<PCI_DEBUG>("PCI: Getting capabilities for {}", address);
+    dbgln_if(PCI_DEBUG, "PCI: Getting capabilities for {}", address);
     auto capabilities_pointer = PCI::get_capabilities_pointer(address);
     if (!capabilities_pointer.has_value()) {
-        dbgln<PCI_DEBUG>("PCI: No capabilities for {}", address);
+        dbgln_if(PCI_DEBUG, "PCI: No capabilities for {}", address);
         return {};
     }
     Vector<Capability> capabilities;
     auto capability_pointer = capabilities_pointer.value();
     while (capability_pointer != 0) {
-        dbgln<PCI_DEBUG>("PCI: Reading in capability at {:#02x} for {}", capability_pointer, address);
+        dbgln_if(PCI_DEBUG, "PCI: Reading in capability at {:#02x} for {}", capability_pointer, address);
         u16 capability_header = PCI::read16(address, capability_pointer);
         u8 capability_id = capability_header & 0xff;
         capability_pointer = capability_header >> 8;

--- a/Kernel/PCI/IOAccess.cpp
+++ b/Kernel/PCI/IOAccess.cpp
@@ -35,7 +35,7 @@ void IOAccess::initialize()
 {
     if (!Access::is_initialized()) {
         new IOAccess();
-        dbgln<PCI_DEBUG>("PCI: IO access initialised.");
+        dbgln_if(PCI_DEBUG, "PCI: IO access initialised.");
     }
 }
 
@@ -49,37 +49,37 @@ IOAccess::IOAccess()
 
 u8 IOAccess::read8_field(Address address, u32 field)
 {
-    dbgln<PCI_DEBUG>("PCI: IO Reading 8-bit field {:#08x} for {}", field, address);
+    dbgln_if(PCI_DEBUG, "PCI: IO Reading 8-bit field {:#08x} for {}", field, address);
     return Access::early_read8_field(address, field);
 }
 
 u16 IOAccess::read16_field(Address address, u32 field)
 {
-    dbgln<PCI_DEBUG>("PCI: IO Reading 16-bit field {:#08x} for {}", field, address);
+    dbgln_if(PCI_DEBUG, "PCI: IO Reading 16-bit field {:#08x} for {}", field, address);
     return Access::early_read16_field(address, field);
 }
 
 u32 IOAccess::read32_field(Address address, u32 field)
 {
-    dbgln<PCI_DEBUG>("PCI: IO Reading 32-bit field {:#08x} for {}", field, address);
+    dbgln_if(PCI_DEBUG, "PCI: IO Reading 32-bit field {:#08x} for {}", field, address);
     return Access::early_read32_field(address, field);
 }
 
 void IOAccess::write8_field(Address address, u32 field, u8 value)
 {
-    dbgln<PCI_DEBUG>("PCI: IO Writing to 8-bit field {:#08x}, value={:#02x} for {}", field, value, address);
+    dbgln_if(PCI_DEBUG, "PCI: IO Writing to 8-bit field {:#08x}, value={:#02x} for {}", field, value, address);
     IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
     IO::out8(PCI_VALUE_PORT + (field & 3), value);
 }
 void IOAccess::write16_field(Address address, u32 field, u16 value)
 {
-    dbgln<PCI_DEBUG>("PCI: IO Writing to 16-bit field {:#08x}, value={:#02x} for {}", field, value, address);
+    dbgln_if(PCI_DEBUG, "PCI: IO Writing to 16-bit field {:#08x}, value={:#02x} for {}", field, value, address);
     IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
     IO::out16(PCI_VALUE_PORT + (field & 2), value);
 }
 void IOAccess::write32_field(Address address, u32 field, u32 value)
 {
-    dbgln<PCI_DEBUG>("PCI: IO Writing to 32-bit field {:#08x}, value={:#02x} for {}", field, value, address);
+    dbgln_if(PCI_DEBUG, "PCI: IO Writing to 32-bit field {:#08x}, value={:#02x} for {}", field, value, address);
     IO::out32(PCI_ADDRESS_PORT, address.io_address_for_field(field));
     IO::out32(PCI_VALUE_PORT, value);
 }

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -337,7 +337,7 @@ Process::Process(RefPtr<Thread>& first_thread, const String& name, uid_t uid, gi
     , m_ppid(ppid)
     , m_wait_block_condition(*this)
 {
-    dbgln<PROCESS_DEBUG>("Created new process {}({})", m_name, m_pid.value());
+    dbgln_if(PROCESS_DEBUG, "Created new process {}({})", m_name, m_pid.value());
 
     m_page_directory = PageDirectory::create_for_userspace(*this, fork_parent ? &fork_parent->page_directory().range_allocator() : nullptr);
 
@@ -602,7 +602,7 @@ void Process::finalize()
 {
     ASSERT(Thread::current() == g_finalizer);
 
-    dbgln<PROCESS_DEBUG>("Finalizing process {}", *this);
+    dbgln_if(PROCESS_DEBUG, "Finalizing process {}", *this);
 
     if (is_dumpable()) {
         if (m_should_dump_core)

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -231,7 +231,7 @@ bool Scheduler::pick_next()
     }
 
     if constexpr (SCHEDULER_RUNNABLE_DEBUG) {
-        dbgln("Scheduler thread list:", Processor::id());
+        dbgln("Scheduler thread list for processor {}:", Processor::id());
         Thread::for_each([&](Thread& thread) -> IterationDecision {
             switch (thread.state()) {
             case Thread::Dying:

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -267,7 +267,7 @@ bool Scheduler::pick_next()
         // but since we're still holding the scheduler lock we're still in a critical section
         critical.leave();
 
-        dbgln<SCHEDULER_DEBUG>("Processing pending donate to {} reason={}", *pending_beneficiary, reason);
+        dbgln_if(SCHEDULER_DEBUG, "Processing pending donate to {} reason={}", *pending_beneficiary, reason);
         return donate_to_and_switch(pending_beneficiary.ptr(), reason);
     }
 
@@ -303,7 +303,7 @@ bool Scheduler::yield()
     scheduler_data.m_pending_donate_reason = nullptr;
 
     auto current_thread = Thread::current();
-    dbgln<SCHEDULER_DEBUG>("Scheduler[{}]: yielding thread {} in_irq={}", proc.get_id(), *current_thread, proc.in_irq());
+    dbgln_if(SCHEDULER_DEBUG, "Scheduler[{}]: yielding thread {} in_irq={}", proc.get_id(), *current_thread, proc.in_irq());
     ASSERT(current_thread != nullptr);
     if (proc.in_irq() || proc.in_critical()) {
         // If we're handling an IRQ we can't switch context, or we're in
@@ -333,7 +333,7 @@ bool Scheduler::donate_to_and_switch(Thread* beneficiary, [[maybe_unused]] const
         return Scheduler::yield();
 
     unsigned ticks_to_donate = min(ticks_left - 1, time_slice_for(*beneficiary));
-    dbgln<SCHEDULER_DEBUG>("Scheduler[{}]: Donating {} ticks to {}, reason={}", proc.get_id(), ticks_to_donate, *beneficiary, reason);
+    dbgln_if(SCHEDULER_DEBUG, "Scheduler[{}]: Donating {} ticks to {}, reason={}", proc.get_id(), ticks_to_donate, *beneficiary, reason);
     beneficiary->set_ticks_left(ticks_to_donate);
 
     return Scheduler::context_switch(beneficiary);

--- a/Kernel/Syscalls/fcntl.cpp
+++ b/Kernel/Syscalls/fcntl.cpp
@@ -33,7 +33,7 @@ namespace Kernel {
 int Process::sys$fcntl(int fd, int cmd, u32 arg)
 {
     REQUIRE_PROMISE(stdio);
-    dbgln<IO_DEBUG>("sys$fcntl: fd={}, cmd={}, arg={}", fd, cmd, arg);
+    dbgln_if(IO_DEBUG, "sys$fcntl: fd={}, cmd={}, arg={}", fd, cmd, arg);
     auto description = file_description(fd);
     if (!description)
         return -EBADF;

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -53,7 +53,7 @@ pid_t Process::sys$fork(RegisterState& regs)
     child->m_pg = m_pg;
     child->m_umask = m_umask;
 
-    dbgln<FORK_DEBUG>("fork: child={}", child);
+    dbgln_if(FORK_DEBUG, "fork: child={}", child);
 
     child->m_extra_gids = m_extra_gids;
 
@@ -82,7 +82,7 @@ pid_t Process::sys$fork(RegisterState& regs)
     {
         ScopedSpinLock lock(m_lock);
         for (auto& region : m_regions) {
-            dbgln<FORK_DEBUG>("fork: cloning Region({}) '{}' @ {}", &region, region.name(), region.vaddr());
+            dbgln_if(FORK_DEBUG, "fork: cloning Region({}) '{}' @ {}", &region, region.name(), region.vaddr());
             auto region_clone = region.clone(*child);
             if (!region_clone) {
                 dbgln("fork: Cannot clone region, insufficient memory");

--- a/Kernel/Syscalls/futex.cpp
+++ b/Kernel/Syscalls/futex.cpp
@@ -39,7 +39,7 @@ FutexQueue::FutexQueue(FlatPtr user_address_or_offset, VMObject* vmobject)
     : m_user_address_or_offset(user_address_or_offset)
     , m_is_global(vmobject != nullptr)
 {
-    dbgln<FUTEX_DEBUG>("Futex @ {}{}",
+    dbgln_if(FUTEX_DEBUG, "Futex @ {}{}",
         this,
         m_is_global ? " (global)" : " (local)");
 
@@ -56,7 +56,7 @@ FutexQueue::~FutexQueue()
         if (auto vmobject = m_vmobject.strong_ref())
             vmobject->unregister_on_deleted_handler(*this);
     }
-    dbgln<FUTEX_DEBUG>("~Futex @ {}{}",
+    dbgln_if(FUTEX_DEBUG, "~Futex @ {}{}",
         this,
         m_is_global ? " (global)" : " (local)");
 }
@@ -68,7 +68,7 @@ void FutexQueue::vmobject_deleted(VMObject& vmobject)
     // to make sure we have at last a reference until we're done
     NonnullRefPtr<FutexQueue> own_ref(*this);
 
-    dbgln<FUTEX_DEBUG>("Futex::vmobject_deleted @ {}{}",
+    dbgln_if(FUTEX_DEBUG, "Futex::vmobject_deleted @ {}{}",
         this,
         m_is_global ? " (global)" : " (local)");
 

--- a/Kernel/Syscalls/open.cpp
+++ b/Kernel/Syscalls/open.cpp
@@ -63,7 +63,7 @@ int Process::sys$open(Userspace<const Syscall::SC_open_params*> user_params)
     if (path.is_error())
         return path.error();
 
-    dbgln<IO_DEBUG>("sys$open(dirfd={}, path='{}', options={}, mode={})", dirfd, path.value(), options, mode);
+    dbgln_if(IO_DEBUG, "sys$open(dirfd={}, path='{}', options={}, mode={})", dirfd, path.value(), options, mode);
     int fd = alloc_fd();
     if (fd < 0)
         return fd;
@@ -99,7 +99,7 @@ int Process::sys$close(int fd)
 {
     REQUIRE_PROMISE(stdio);
     auto description = file_description(fd);
-    dbgln<IO_DEBUG>("sys$close({}) {}", fd, description.ptr());
+    dbgln_if(IO_DEBUG, "sys$close({}) {}", fd, description.ptr());
     if (!description)
         return -EBADF;
     int rc = description->close();

--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -37,7 +37,7 @@ ssize_t Process::sys$read(int fd, Userspace<u8*> buffer, ssize_t size)
         return -EINVAL;
     if (size == 0)
         return 0;
-    dbgln<IO_DEBUG>("sys$read({}, {}, {})", fd, buffer.ptr(), size);
+    dbgln_if(IO_DEBUG, "sys$read({}, {}, {})", fd, buffer.ptr(), size);
     auto description = file_description(fd);
     if (!description)
         return -EBADF;

--- a/Kernel/Syscalls/select.cpp
+++ b/Kernel/Syscalls/select.cpp
@@ -99,7 +99,7 @@ int Process::sys$select(const Syscall::SC_select_params* user_params)
         dbgln("selecting on {} fds, timeout={}", fds_info.size(), params.timeout);
 
     if (current_thread->block<Thread::SelectBlocker>(timeout, fds_info).was_interrupted()) {
-        dbgln<POLL_SELECT_DEBUG>("select was interrupted");
+        dbgln_if(POLL_SELECT_DEBUG, "select was interrupted");
         return -EINTR;
     }
 

--- a/Kernel/Syscalls/waitid.cpp
+++ b/Kernel/Syscalls/waitid.cpp
@@ -55,7 +55,7 @@ pid_t Process::sys$waitid(Userspace<const Syscall::SC_waitid_params*> user_param
     if (!copy_from_user(&params, user_params))
         return -EFAULT;
 
-    dbgln<PROCESS_DEBUG>("sys$waitid({}, {}, {}, {})", params.idtype, params.id, params.infop, params.options);
+    dbgln_if(PROCESS_DEBUG, "sys$waitid({}, {}, {}, {})", params.idtype, params.id, params.infop, params.options);
 
     auto siginfo_or_error = do_waitid(static_cast<idtype_t>(params.idtype), params.id, params.options);
     if (siginfo_or_error.is_error())

--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -125,7 +125,7 @@ ssize_t Process::sys$write(int fd, const u8* data, ssize_t size)
     if (size == 0)
         return 0;
 
-    dbgln<IO_DEBUG>("sys$write({}, {}, {})", fd, data, size);
+    dbgln_if(IO_DEBUG, "sys$write({}, {}, {})", fd, data, size);
     auto description = file_description(fd);
     if (!description)
         return -EBADF;

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -53,7 +53,7 @@ MasterPTY::MasterPTY(unsigned index)
 
 MasterPTY::~MasterPTY()
 {
-    dbgln<MASTERPTY_DEBUG>("~MasterPTY({})", m_index);
+    dbgln_if(MASTERPTY_DEBUG, "~MasterPTY({})", m_index);
     PTYMultiplexer::the().notify_master_destroyed({}, m_index);
 }
 
@@ -91,7 +91,7 @@ bool MasterPTY::can_write(const FileDescription&, size_t) const
 
 void MasterPTY::notify_slave_closed(Badge<SlavePTY>)
 {
-    dbgln<MASTERPTY_DEBUG>("MasterPTY({}): slave closed, my retains: {}, slave retains: {}", m_index, ref_count(), m_slave->ref_count());
+    dbgln_if(MASTERPTY_DEBUG, "MasterPTY({}): slave closed, my retains: {}, slave retains: {}", m_index, ref_count(), m_slave->ref_count());
     // +1 ref for my MasterPTY::m_slave
     // +1 ref for FileDescription::m_device
     if (m_slave->ref_count() == 2)

--- a/Kernel/TTY/PTYMultiplexer.cpp
+++ b/Kernel/TTY/PTYMultiplexer.cpp
@@ -61,7 +61,7 @@ KResultOr<NonnullRefPtr<FileDescription>> PTYMultiplexer::open(int options)
         return EBUSY;
     auto master_index = m_freelist.take_last();
     auto master = adopt(*new MasterPTY(master_index));
-    dbgln<PTMX_DEBUG>("PTYMultiplexer::open: Vending master {}", master->index());
+    dbgln_if(PTMX_DEBUG, "PTYMultiplexer::open: Vending master {}", master->index());
     auto description = FileDescription::create(move(master));
     if (!description.is_error()) {
         description.value()->set_rw_mode(options);
@@ -74,7 +74,7 @@ void PTYMultiplexer::notify_master_destroyed(Badge<MasterPTY>, unsigned index)
 {
     LOCKER(m_lock);
     m_freelist.append(index);
-    dbgln<PTMX_DEBUG>("PTYMultiplexer: {} added to freelist", index);
+    dbgln_if(PTMX_DEBUG, "PTYMultiplexer: {} added to freelist", index);
 }
 
 }

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -47,7 +47,7 @@ SlavePTY::SlavePTY(MasterPTY& master, unsigned index)
 
 SlavePTY::~SlavePTY()
 {
-    dbgln<SLAVEPTY_DEBUG>("~SlavePTY({})", m_index);
+    dbgln_if(SLAVEPTY_DEBUG, "~SlavePTY({})", m_index);
     DevPtsFS::unregister_slave_pty(*this);
 }
 

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -304,7 +304,7 @@ void TTY::set_termios(const termios& t)
 {
     m_termios = t;
 
-    dbgln<TTY_DEBUG>("{} set_termios: ECHO={}, ISIG={}, ICANON={}, ECHOE={}, ECHOK={}, ECHONL={}, ISTRIP={}, ICRNL={}, INLCR={}, IGNCR={}",
+    dbgln_if(TTY_DEBUG, "{} set_termios: ECHO={}, ISIG={}, ICANON={}, ECHOE={}, ECHOK={}, ECHONL={}, ISTRIP={}, ICRNL={}, INLCR={}, IGNCR={}",
         tty_name(),
         should_echo_input(),
         should_generate_signals(),

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -388,7 +388,7 @@ void Thread::finalize()
 
     {
         ScopedSpinLock lock(g_scheduler_lock);
-        dbgln<THREAD_DEBUG>("Finalizing thread {}", *this);
+        dbgln_if(THREAD_DEBUG, "Finalizing thread {}", *this);
         set_state(Thread::State::Dead);
         m_join_condition.thread_finalizing();
     }
@@ -493,7 +493,7 @@ void Thread::send_signal(u8 signal, [[maybe_unused]] Process* sender)
 
     // FIXME: Figure out what to do for masked signals. Should we also ignore them here?
     if (should_ignore_signal(signal)) {
-        dbgln<SIGNAL_DEBUG>("Signal {} was ignored by {}", signal, process());
+        dbgln_if(SIGNAL_DEBUG, "Signal {} was ignored by {}", signal, process());
         return;
     }
 
@@ -510,12 +510,12 @@ void Thread::send_signal(u8 signal, [[maybe_unused]] Process* sender)
     if (m_state == Stopped) {
         ScopedSpinLock lock(m_lock);
         if (pending_signals_for_state()) {
-            dbgln<SIGNAL_DEBUG>("Signal: Resuming stopped {} to deliver signal {}", *this, signal);
+            dbgln_if(SIGNAL_DEBUG, "Signal: Resuming stopped {} to deliver signal {}", *this, signal);
             resume_from_stopped();
         }
     } else {
         ScopedSpinLock block_lock(m_block_lock);
-        dbgln<SIGNAL_DEBUG>("Signal: Unblocking {} to deliver signal {}", *this, signal);
+        dbgln_if(SIGNAL_DEBUG, "Signal: Unblocking {} to deliver signal {}", *this, signal);
         unblock(signal);
     }
 }
@@ -729,7 +729,7 @@ DispatchSignalResult Thread::dispatch_signal(u8 signal)
     auto& process = this->process();
     auto tracer = process.tracer();
     if (signal == SIGSTOP || (tracer && default_signal_action(signal) == DefaultSignalAction::DumpCore)) {
-        dbgln<SIGNAL_DEBUG>("signal: signal {} sopping thread {}", signal, *this);
+        dbgln_if(SIGNAL_DEBUG, "signal: signal {} sopping thread {}", signal, *this);
         set_state(State::Stopped, signal);
         return DispatchSignalResult::Yield;
     }
@@ -907,13 +907,13 @@ void Thread::set_state(State new_state, u8 stop_signal)
         if (previous_state == Invalid) {
             // If we were *just* created, we may have already pending signals
             if (has_unmasked_pending_signals()) {
-                dbgln<THREAD_DEBUG>("Dispatch pending signals to new thread {}", *this);
+                dbgln_if(THREAD_DEBUG, "Dispatch pending signals to new thread {}", *this);
                 dispatch_one_pending_signal();
             }
         }
 
         m_state = new_state;
-        dbgln<THREAD_DEBUG>("Set thread {} state to {}", *this, state_string());
+        dbgln_if(THREAD_DEBUG, "Set thread {} state to {}", *this, state_string());
     }
 
     if (previous_state == Runnable) {
@@ -925,7 +925,7 @@ void Thread::set_state(State new_state, u8 stop_signal)
             process.for_each_thread([&](auto& thread) {
                 if (&thread == this || !thread.is_stopped())
                     return IterationDecision::Continue;
-                dbgln<THREAD_DEBUG>("Resuming peer thread {}", thread);
+                dbgln_if(THREAD_DEBUG, "Resuming peer thread {}", thread);
                 thread.resume_from_stopped();
                 return IterationDecision::Continue;
             });
@@ -944,7 +944,7 @@ void Thread::set_state(State new_state, u8 stop_signal)
             process.for_each_thread([&](auto& thread) {
                 if (&thread == this || thread.is_stopped())
                     return IterationDecision::Continue;
-                dbgln<THREAD_DEBUG>("Stopping peer thread {}", thread);
+                dbgln_if(THREAD_DEBUG, "Stopping peer thread {}", thread);
                 thread.set_state(Stopped, stop_signal);
                 return IterationDecision::Continue;
             });

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -889,7 +889,7 @@ public:
         scheduler_lock.unlock();
         block_lock.unlock();
 
-        dbgln<THREAD_DEBUG>("Thread {} blocking on {} ({}) -->", *this, &t, t.state_string());
+        dbgln_if(THREAD_DEBUG, "Thread {} blocking on {} ({}) -->", *this, &t, t.state_string());
         bool did_timeout = false;
         u32 lock_count_to_restore = 0;
         auto previous_locked = unlock_process_if_locked(lock_count_to_restore);
@@ -920,7 +920,7 @@ public:
                 ASSERT(m_blocker == &t);
                 m_blocker = nullptr;
             }
-            dbgln<THREAD_DEBUG>("<-- Thread {} unblocked from {} ({})", *this, &t, t.state_string());
+            dbgln_if(THREAD_DEBUG, "<-- Thread {} unblocked from {} ({})", *this, &t, t.state_string());
             m_in_block = false;
             break;
         }

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -908,7 +908,7 @@ public:
             }
             if (m_blocker && !m_blocker->can_be_interrupted() && !m_should_die) {
                 block_lock2.unlock();
-                dbgln("Thread should not be unblocking, current state: ", state_string());
+                dbgln("Thread should not be unblocking, current state: {}", state_string());
                 set_state(Thread::Blocked);
                 continue;
             }

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -462,9 +462,9 @@ void Thread::WaitBlockCondition::try_unblock(Thread::WaitBlocker& blocker)
             if (blocker.is_wait()) {
                 if (info.flags == Thread::WaitBlocker::UnblockFlags::Terminated) {
                     m_processes.remove(i);
-                    dbgln<WAITBLOCK_DEBUG>("WaitBlockCondition[{}] terminated, remove {}", m_process, *info.process);
+                    dbgln_if(WAITBLOCK_DEBUG, "WaitBlockCondition[{}] terminated, remove {}", m_process, *info.process);
                 } else {
-                    dbgln<WAITBLOCK_DEBUG>("WaitBlockCondition[{}] terminated, mark as waited {}", m_process, *info.process);
+                    dbgln_if(WAITBLOCK_DEBUG, "WaitBlockCondition[{}] terminated, mark as waited {}", m_process, *info.process);
                     info.was_waited = true;
                 }
             }
@@ -488,7 +488,7 @@ void Thread::WaitBlockCondition::disowned_by_waiter(Process& process)
                 ASSERT(did_unblock); // disowning must unblock everyone
                 return true;
             });
-            dbgln<WAITBLOCK_DEBUG>("WaitBlockCondition[{}] disowned {}", m_process, *info.process);
+            dbgln_if(WAITBLOCK_DEBUG, "WaitBlockCondition[{}] disowned {}", m_process, *info.process);
             m_processes.remove(i);
             continue;
         }
@@ -541,13 +541,13 @@ bool Thread::WaitBlockCondition::unblock(Process& process, WaitBlocker::UnblockF
                 info.flags = flags;
                 info.signal = signal;
                 info.was_waited = did_wait;
-                dbgln<WAITBLOCK_DEBUG>("WaitBlockCondition[{}] update {} flags={}, waited={}", m_process, process, (int)flags, info.was_waited);
+                dbgln_if(WAITBLOCK_DEBUG, "WaitBlockCondition[{}] update {} flags={}, waited={}", m_process, process, (int)flags, info.was_waited);
                 updated_existing = true;
                 break;
             }
         }
         if (!updated_existing) {
-            dbgln<WAITBLOCK_DEBUG>("WaitBlockCondition[{}] add {} flags: {}", m_process, process, (int)flags);
+            dbgln_if(WAITBLOCK_DEBUG, "WaitBlockCondition[{}] add {} flags: {}", m_process, process, (int)flags);
             m_processes.append(ProcessBlockInfo(process, flags, signal));
         }
     }

--- a/Kernel/Time/HPET.cpp
+++ b/Kernel/Time/HPET.cpp
@@ -206,7 +206,7 @@ void HPET::update_periodic_comparator_value()
             // and we can only write the period into the comparator value...
             timer.capabilities = timer.capabilities | (u32)HPETFlags::TimerConfiguration::ValueSet;
             u64 value = frequency() / comparator.ticks_per_second();
-            dbgln<HPET_DEBUG>("HPET: Update periodic comparator {} comparator value to {} main value was: {}",
+            dbgln_if(HPET_DEBUG, "HPET: Update periodic comparator {} comparator value to {} main value was: {}",
                 comparator.comparator_number(),
                 value,
                 previous_main_value);
@@ -217,7 +217,7 @@ void HPET::update_periodic_comparator_value()
             // Set the new target comparator value to the delta to the remaining ticks
             u64 current_value = (u64)timer.comparator_value.low | ((u64)timer.comparator_value.high << 32);
             u64 value = current_value - previous_main_value;
-            dbgln<HPET_DEBUG>("HPET: Update non-periodic comparator {} comparator value from {} to {} main value was: {}",
+            dbgln_if(HPET_DEBUG, "HPET: Update non-periodic comparator {} comparator value from {} to {} main value was: {}",
                 comparator.comparator_number(),
                 current_value,
                 value,

--- a/Kernel/Time/HPETComparator.cpp
+++ b/Kernel/Time/HPETComparator.cpp
@@ -109,7 +109,7 @@ bool HPETComparator::try_to_set_frequency(size_t frequency)
     m_frequency = frequency;
     m_enabled = true;
 
-    dbgln<HPET_COMPARATOR_DEBUG>("HPET Comparator: Max frequency {} Hz, want to set {} Hz, periodic: {}", hpet_frequency, frequency, is_periodic());
+    dbgln_if(HPET_COMPARATOR_DEBUG, "HPET Comparator: Max frequency {} Hz, want to set {} Hz, periodic: {}", hpet_frequency, frequency, is_periodic());
 
     if (is_periodic()) {
         HPET::the().update_periodic_comparator_value();

--- a/Kernel/VM/AnonymousVMObject.cpp
+++ b/Kernel/VM/AnonymousVMObject.cpp
@@ -472,7 +472,7 @@ PageFaultResponse AnonymousVMObject::handle_cow_fault(size_t page_index, Virtual
     }
 
     u8* dest_ptr = MM.quickmap_page(*page);
-    dbgln<PAGE_FAULT_DEBUG>("      >> COW {} <- {}", page->paddr(), page_slot->paddr());
+    dbgln_if(PAGE_FAULT_DEBUG, "      >> COW {} <- {}", page->paddr(), page_slot->paddr());
     {
         SmapDisabler disabler;
         void* fault_at;

--- a/Kernel/VM/ContiguousVMObject.cpp
+++ b/Kernel/VM/ContiguousVMObject.cpp
@@ -42,7 +42,7 @@ ContiguousVMObject::ContiguousVMObject(size_t size, size_t physical_alignment)
     auto contiguous_physical_pages = MM.allocate_contiguous_supervisor_physical_pages(size, physical_alignment);
     for (size_t i = 0; i < page_count(); i++) {
         physical_pages()[i] = contiguous_physical_pages[i];
-        dbgln<CONTIGUOUS_VMOBJECT_DEBUG>("Contiguous page[{}]: {}", i, physical_pages()[i]->paddr());
+        dbgln_if(CONTIGUOUS_VMOBJECT_DEBUG, "Contiguous page[{}]: {}", i, physical_pages()[i]->paddr());
     }
 }
 

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -421,7 +421,7 @@ PageFaultResponse Region::handle_fault(const PageFault& fault, ScopedSpinLock<Re
             return PageFaultResponse::ShouldCrash;
         }
         if (vmobject().is_inode()) {
-            dbgln<PAGE_FAULT_DEBUG>("NP(inode) fault in Region({})[{}]", this, page_index_in_region);
+            dbgln_if(PAGE_FAULT_DEBUG, "NP(inode) fault in Region({})[{}]", this, page_index_in_region);
             return handle_inode_fault(page_index_in_region, mm_lock);
         }
 
@@ -446,10 +446,10 @@ PageFaultResponse Region::handle_fault(const PageFault& fault, ScopedSpinLock<Re
     }
     ASSERT(fault.type() == PageFault::Type::ProtectionViolation);
     if (fault.access() == PageFault::Access::Write && is_writable() && should_cow(page_index_in_region)) {
-        dbgln<PAGE_FAULT_DEBUG>("PV(cow) fault in Region({})[{}] at {}", this, page_index_in_region, fault.vaddr());
+        dbgln_if(PAGE_FAULT_DEBUG, "PV(cow) fault in Region({})[{}] at {}", this, page_index_in_region, fault.vaddr());
         auto* phys_page = physical_page(page_index_in_region);
         if (phys_page->is_shared_zero_page() || phys_page->is_lazy_committed_page()) {
-            dbgln<PAGE_FAULT_DEBUG>("NP(zero) fault in Region({})[{}] at {}", this, page_index_in_region, fault.vaddr());
+            dbgln_if(PAGE_FAULT_DEBUG, "NP(zero) fault in Region({})[{}] at {}", this, page_index_in_region, fault.vaddr());
             return handle_zero_fault(page_index_in_region);
         }
         return handle_cow_fault(page_index_in_region);
@@ -483,14 +483,14 @@ PageFaultResponse Region::handle_zero_fault(size_t page_index_in_region)
 
     if (page_slot->is_lazy_committed_page()) {
         page_slot = static_cast<AnonymousVMObject&>(*m_vmobject).allocate_committed_page(page_index_in_vmobject);
-        dbgln<PAGE_FAULT_DEBUG>("      >> ALLOCATED COMMITTED {}", page_slot->paddr());
+        dbgln_if(PAGE_FAULT_DEBUG, "      >> ALLOCATED COMMITTED {}", page_slot->paddr());
     } else {
         page_slot = MM.allocate_user_physical_page(MemoryManager::ShouldZeroFill::Yes);
         if (page_slot.is_null()) {
             klog() << "MM: handle_zero_fault was unable to allocate a physical page";
             return PageFaultResponse::OutOfMemory;
         }
-        dbgln<PAGE_FAULT_DEBUG>("      >> ALLOCATED {}", page_slot->paddr());
+        dbgln_if(PAGE_FAULT_DEBUG, "      >> ALLOCATED {}", page_slot->paddr());
     }
 
     if (!remap_vmobject_page(page_index_in_vmobject)) {
@@ -535,10 +535,10 @@ PageFaultResponse Region::handle_inode_fault(size_t page_index_in_region, Scoped
     auto page_index_in_vmobject = translate_to_vmobject_page(page_index_in_region);
     auto& vmobject_physical_page_entry = inode_vmobject.physical_pages()[page_index_in_vmobject];
 
-    dbgln<PAGE_FAULT_DEBUG>("Inode fault in {} page index: {}", name(), page_index_in_region);
+    dbgln_if(PAGE_FAULT_DEBUG, "Inode fault in {} page index: {}", name(), page_index_in_region);
 
     if (!vmobject_physical_page_entry.is_null()) {
-        dbgln<PAGE_FAULT_DEBUG>("MM: page_in_from_inode() but page already present. Fine with me!");
+        dbgln_if(PAGE_FAULT_DEBUG, "MM: page_in_from_inode() but page already present. Fine with me!");
         if (!remap_vmobject_page(page_index_in_vmobject))
             return PageFaultResponse::OutOfMemory;
         return PageFaultResponse::Continue;

--- a/Kernel/WaitQueue.cpp
+++ b/Kernel/WaitQueue.cpp
@@ -37,10 +37,10 @@ bool WaitQueue::should_add_blocker(Thread::Blocker& b, void* data)
     ASSERT(b.blocker_type() == Thread::Blocker::Type::Queue);
     if (m_wake_requested || !m_should_block) {
         m_wake_requested = false;
-        dbgln<WAITQUEUE_DEBUG>("WaitQueue @ {}: do not block thread {}, {}", this, data, m_should_block ? "wake was pending" : "not blocking");
+        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: do not block thread {}, {}", this, data, m_should_block ? "wake was pending" : "not blocking");
         return false;
     }
-    dbgln<WAITQUEUE_DEBUG>("WaitQueue @ {}: should block thread {}", this, data);
+    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: should block thread {}", this, data);
     return true;
 }
 
@@ -48,12 +48,12 @@ u32 WaitQueue::wake_one()
 {
     u32 did_wake = 0;
     ScopedSpinLock lock(m_lock);
-    dbgln<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_one", this);
+    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_one", this);
     bool did_unblock_one = do_unblock([&](Thread::Blocker& b, void* data, bool& stop_iterating) {
         ASSERT(data);
         ASSERT(b.blocker_type() == Thread::Blocker::Type::Queue);
         auto& blocker = static_cast<Thread::QueueBlocker&>(b);
-        dbgln<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_one unblocking {}", this, data);
+        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_one unblocking {}", this, data);
         if (blocker.unblock()) {
             stop_iterating = true;
             did_wake = 1;
@@ -62,7 +62,7 @@ u32 WaitQueue::wake_one()
         return false;
     });
     m_wake_requested = !did_unblock_one;
-    dbgln<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_one woke {} threads", this, did_wake);
+    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_one woke {} threads", this, did_wake);
     return did_wake;
 }
 
@@ -71,14 +71,14 @@ u32 WaitQueue::wake_n(u32 wake_count)
     if (wake_count == 0)
         return 0; // should we assert instead?
     ScopedSpinLock lock(m_lock);
-    dbgln<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_n({})", this, wake_count);
+    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_n({})", this, wake_count);
     u32 did_wake = 0;
 
     bool did_unblock_some = do_unblock([&](Thread::Blocker& b, void* data, bool& stop_iterating) {
         ASSERT(data);
         ASSERT(b.blocker_type() == Thread::Blocker::Type::Queue);
         auto& blocker = static_cast<Thread::QueueBlocker&>(b);
-        dbgln<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_n unblocking {}", this, data);
+        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_n unblocking {}", this, data);
         ASSERT(did_wake < wake_count);
         if (blocker.unblock()) {
             if (++did_wake >= wake_count)
@@ -88,7 +88,7 @@ u32 WaitQueue::wake_n(u32 wake_count)
         return false;
     });
     m_wake_requested = !did_unblock_some;
-    dbgln<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_n({}) woke {} threads", this, wake_count, did_wake);
+    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_n({}) woke {} threads", this, wake_count, did_wake);
     return did_wake;
 }
 
@@ -96,7 +96,7 @@ u32 WaitQueue::wake_all()
 {
     ScopedSpinLock lock(m_lock);
 
-    dbgln<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_all", this);
+    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_all", this);
     u32 did_wake = 0;
 
     bool did_unblock_any = do_unblock([&](Thread::Blocker& b, void* data, bool&) {
@@ -104,7 +104,7 @@ u32 WaitQueue::wake_all()
         ASSERT(b.blocker_type() == Thread::Blocker::Type::Queue);
         auto& blocker = static_cast<Thread::QueueBlocker&>(b);
 
-        dbgln<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_all unblocking {}", this, data);
+        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_all unblocking {}", this, data);
 
         if (blocker.unblock()) {
             did_wake++;
@@ -113,7 +113,7 @@ u32 WaitQueue::wake_all()
         return false;
     });
     m_wake_requested = !did_unblock_any;
-    dbgln<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_all woke {} threads", this, did_wake);
+    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_all woke {} threads", this, did_wake);
     return did_wake;
 }
 

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -11,7 +11,6 @@ if [ "$#" -eq "1" ]; then
             '*.cpp' \
             '*.h' \
             ':!:Base' \
-            ':!:Kernel/Arch/i386/CPU.cpp' \
             ':!:Kernel/FileSystem/ext2_fs.h' \
             ':!:Userland/Libraries/LibC/getopt.cpp' \
             ':!:Userland/Libraries/LibC/syslog.h' \

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -353,7 +353,7 @@ void Sheet::copy_cells(Vector<Position> from, Vector<Position> to, Optional<Posi
         auto& target = to.first();
 
         for (auto& position : from) {
-            dbgln<COPY_DEBUG>("Paste from '{}' to '{}'", position.to_url(), target.to_url());
+            dbgln_if(COPY_DEBUG, "Paste from '{}' to '{}'", position.to_url(), target.to_url());
             copy_to(position, resolve_relative_to.has_value() ? offset_relative_to(target, position, resolve_relative_to.value()) : target);
         }
 
@@ -364,7 +364,7 @@ void Sheet::copy_cells(Vector<Position> from, Vector<Position> to, Optional<Posi
         // Fill the target selection with the single cell.
         auto& source = from.first();
         for (auto& position : to) {
-            dbgln<COPY_DEBUG>("Paste from '{}' to '{}'", source.to_url(), position.to_url());
+            dbgln_if(COPY_DEBUG, "Paste from '{}' to '{}'", source.to_url(), position.to_url());
             copy_to(source, resolve_relative_to.has_value() ? offset_relative_to(position, source, resolve_relative_to.value()) : position);
         }
         return;

--- a/Userland/DevTools/HackStudio/CursorTool.cpp
+++ b/Userland/DevTools/HackStudio/CursorTool.cpp
@@ -48,7 +48,7 @@ void CursorTool::on_mousedown(GUI::MouseEvent& event)
                 m_editor.selection().toggle(*result.widget);
             } else if (!event.modifiers()) {
                 if (!m_editor.selection().contains(*result.widget)) {
-                    dbgln<CURSOR_TOOL_DEBUG>("Selection didn't contain {}, making it the only selected one", *result.widget);
+                    dbgln_if(CURSOR_TOOL_DEBUG, "Selection didn't contain {}, making it the only selected one", *result.widget);
                     m_editor.selection().set(*result.widget);
                 }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.cpp
@@ -88,7 +88,7 @@ void ClientConnection::handle(const Messages::LanguageServer::FileOpened& messag
     auto document = GUI::TextDocument::create(&s_default_document_client);
     document->set_text(content_view);
     m_open_files.set(message.file_name(), document);
-    dbgln<FILE_CONTENT_DEBUG>("{}", document->text());
+    dbgln_if(FILE_CONTENT_DEBUG, "{}", document->text());
 }
 
 void ClientConnection::handle(const Messages::LanguageServer::FileEditInsertText& message)

--- a/Userland/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.cpp
@@ -87,7 +87,7 @@ void ClientConnection::handle(const Messages::LanguageServer::FileOpened& messag
     auto document = GUI::TextDocument::create(&s_default_document_client);
     document->set_text(content_view);
     m_open_files.set(message.file_name(), document);
-    dbgln<FILE_CONTENT_DEBUG>("{}", document->text());
+    dbgln_if(FILE_CONTENT_DEBUG, "{}", document->text());
 }
 
 void ClientConnection::handle(const Messages::LanguageServer::FileEditInsertText& message)
@@ -129,7 +129,7 @@ void ClientConnection::handle(const Messages::LanguageServer::FileEditRemoveText
     };
 
     document->remove(range);
-    dbgln<FILE_CONTENT_DEBUG>("{}", document->text());
+    dbgln_if(FILE_CONTENT_DEBUG, "{}", document->text());
 }
 
 void ClientConnection::handle(const Messages::LanguageServer::AutoCompleteSuggestions& message)

--- a/Userland/DevTools/UserspaceEmulator/Report.h
+++ b/Userland/DevTools/UserspaceEmulator/Report.h
@@ -34,7 +34,7 @@ template<typename... Ts>
 void reportln(const StringView& format, Ts... args)
 {
     if (g_report_to_debug)
-        dbgln(format, args...);
+        AK::vdbgln(format, AK::VariadicFormatParams { args... });
     else
         warnln(format, args...);
 }

--- a/Userland/Libraries/LibC/cxxabi.cpp
+++ b/Userland/Libraries/LibC/cxxabi.cpp
@@ -93,13 +93,13 @@ void __cxa_finalize(void* dso_handle)
 
     ssize_t entry_index = atexit_entry_count;
 
-    dbgln<GLOBAL_DTORS_DEBUG>("__cxa_finalize: {} entries in the finalizer list", entry_index);
+    dbgln_if(GLOBAL_DTORS_DEBUG, "__cxa_finalize: {} entries in the finalizer list", entry_index);
 
     while (--entry_index >= 0) {
         auto& exit_entry = atexit_entries[entry_index];
         bool needs_calling = !exit_entry.has_been_called && (!dso_handle || dso_handle == exit_entry.dso_handle);
         if (needs_calling) {
-            dbgln<GLOBAL_DTORS_DEBUG>("__cxa_finalize: calling entry[{}] {:p}({:p}) dso: {:p}", entry_index, exit_entry.method, exit_entry.parameter, exit_entry.dso_handle);
+            dbgln_if(GLOBAL_DTORS_DEBUG, "__cxa_finalize: calling entry[{}] {:p}({:p}) dso: {:p}", entry_index, exit_entry.method, exit_entry.parameter, exit_entry.dso_handle);
             exit_entry.method(exit_entry.parameter);
             unlock_atexit_handlers();
             exit_entry.has_been_called = true;

--- a/Userland/Libraries/LibCore/Gzip.cpp
+++ b/Userland/Libraries/LibCore/Gzip.cpp
@@ -102,7 +102,7 @@ static Optional<ByteBuffer> get_gzip_payload(const ByteBuffer& data)
     }
 
     auto new_size = data.size() - current;
-    dbgln<GZIP_DEBUG>("get_gzip_payload: Returning slice from {} with size {}", current, new_size);
+    dbgln_if(GZIP_DEBUG, "get_gzip_payload: Returning slice from {} with size {}", current, new_size);
     return data.slice(current, new_size);
 }
 
@@ -110,7 +110,7 @@ Optional<ByteBuffer> Gzip::decompress(const ByteBuffer& data)
 {
     ASSERT(is_compressed(data));
 
-    dbgln<GZIP_DEBUG>("Gzip::decompress: Decompressing gzip compressed data. size={}", data.size());
+    dbgln_if(GZIP_DEBUG, "Gzip::decompress: Decompressing gzip compressed data. size={}", data.size());
     auto optional_payload = get_gzip_payload(data);
     if (!optional_payload.has_value()) {
         return Optional<ByteBuffer>();

--- a/Userland/Libraries/LibCore/NetworkJob.cpp
+++ b/Userland/Libraries/LibCore/NetworkJob.cpp
@@ -55,7 +55,7 @@ void NetworkJob::did_finish(NonnullRefPtr<NetworkResponse>&& response)
     NonnullRefPtr<NetworkJob> protector(*this);
 
     m_response = move(response);
-    dbgln<CNETWORKJOB_DEBUG>("{} job did_finish", *this);
+    dbgln_if(CNETWORKJOB_DEBUG, "{} job did_finish", *this);
     ASSERT(on_finish);
     on_finish(true);
     shutdown();

--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -79,7 +79,7 @@ bool Socket::connect(const String& hostname, int port)
     }
 
     IPv4Address host_address((const u8*)hostent->h_addr_list[0]);
-    dbgln<CSOCKET_DEBUG>("Socket::connect: Resolved '{}' to {}", hostname, host_address);
+    dbgln_if(CSOCKET_DEBUG, "Socket::connect: Resolved '{}' to {}", hostname, host_address);
     return connect(host_address, port);
 }
 
@@ -98,7 +98,7 @@ bool Socket::connect(const SocketAddress& address, int port)
 {
     ASSERT(!is_connected());
     ASSERT(address.type() == SocketAddress::Type::IPv4);
-    dbgln<CSOCKET_DEBUG>("{} connecting to {}...", *this, address);
+    dbgln_if(CSOCKET_DEBUG, "{} connecting to {}...", *this, address);
 
     ASSERT(port > 0 && port <= 65535);
 
@@ -119,7 +119,7 @@ bool Socket::connect(const SocketAddress& address)
 {
     ASSERT(!is_connected());
     ASSERT(address.type() == SocketAddress::Type::Local);
-    dbgln<CSOCKET_DEBUG>("{} connecting to {}...", *this, address);
+    dbgln_if(CSOCKET_DEBUG, "{} connecting to {}...", *this, address);
 
     sockaddr_un saddr;
     saddr.sun_family = AF_LOCAL;
@@ -138,7 +138,7 @@ bool Socket::connect(const SocketAddress& address)
 bool Socket::common_connect(const struct sockaddr* addr, socklen_t addrlen)
 {
     auto connected = [this] {
-        dbgln<CSOCKET_DEBUG>("{} connected!", *this);
+        dbgln_if(CSOCKET_DEBUG, "{} connected!", *this);
         if (!m_connected) {
             m_connected = true;
             ensure_read_notifier();
@@ -153,7 +153,7 @@ bool Socket::common_connect(const struct sockaddr* addr, socklen_t addrlen)
     int rc = ::connect(fd(), addr, addrlen);
     if (rc < 0) {
         if (errno == EINPROGRESS) {
-            dbgln<CSOCKET_DEBUG>("{} connection in progress (EINPROGRESS)", *this);
+            dbgln_if(CSOCKET_DEBUG, "{} connection in progress (EINPROGRESS)", *this);
             m_notifier = Notifier::construct(fd(), Notifier::Event::Write, this);
             m_notifier->on_ready_to_write = move(connected);
             return true;
@@ -163,7 +163,7 @@ bool Socket::common_connect(const struct sockaddr* addr, socklen_t addrlen)
         errno = saved_errno;
         return false;
     }
-    dbgln<CSOCKET_DEBUG>("{} connected ok!", *this);
+    dbgln_if(CSOCKET_DEBUG, "{} connected ok!", *this);
     connected();
     return true;
 }

--- a/Userland/Libraries/LibCore/SyscallUtils.h
+++ b/Userland/Libraries/LibCore/SyscallUtils.h
@@ -44,7 +44,7 @@ inline int safe_syscall(Syscall syscall, Args&&... args)
         if (sysret == -1) {
             if constexpr (SAFE_SYSCALL_DEBUG) {
                 int saved_errno = errno;
-                dbgln<SAFE_SYSCALL_DEBUG>("Core::safe_syscall: {} ({}: {})", sysret, saved_errno, strerror(saved_errno));
+                dbgln_if(SAFE_SYSCALL_DEBUG, "Core::safe_syscall: {} ({}: {})", sysret, saved_errno, strerror(saved_errno));
             }
 
             if (errno == EINTR)

--- a/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
@@ -83,7 +83,7 @@ void SyntaxHighlighter::rehighlight(Gfx::Palette palette)
 
     Vector<GUI::TextDocumentSpan> spans;
     for (auto& token : tokens) {
-        dbgln<SYNTAX_HIGHLIGHTING_DEBUG>("{} @ {}:{} - {}:{}", token.to_string(), token.m_start.line, token.m_start.column, token.m_end.line, token.m_end.column);
+        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "{} @ {}:{} - {}:{}", token.to_string(), token.m_start.line, token.m_start.column, token.m_end.line, token.m_end.column);
         GUI::TextDocumentSpan span;
         span.range.set_start({ token.m_start.line, token.m_start.column });
         span.range.set_end({ token.m_end.line, token.m_end.column });

--- a/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
+++ b/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
@@ -100,7 +100,7 @@ GHash::TagType GHash::process(ReadonlyBytes aad, ReadonlyBytes cipher)
     tag[2] ^= high(cipher_bits);
     tag[3] ^= low(cipher_bits);
 
-    dbgln<GHASH_PROCESS_DEBUG>("Tag bits: {} : {} : {} : {}", tag[0], tag[1], tag[2], tag[3]);
+    dbgln_if(GHASH_PROCESS_DEBUG, "Tag bits: {} : {} : {} : {}", tag[0], tag[1], tag[2], tag[3]);
 
     galois_multiply(tag, m_key, tag);
 

--- a/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
+++ b/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
@@ -231,7 +231,7 @@ UnsignedBigInteger LCM(const UnsignedBigInteger& a, const UnsignedBigInteger& b)
     UnsignedBigInteger::divide_without_allocation(a, gcd_output, temp_1, temp_2, temp_3, temp_4, temp_quotient, temp_remainder);
     UnsignedBigInteger::multiply_without_allocation(temp_quotient, b, temp_1, temp_2, temp_3, temp_4, output);
 
-    dbgln<NT_DEBUG>("quot: {} rem: {} out: {}", temp_quotient, temp_remainder, output);
+    dbgln_if(NT_DEBUG, "quot: {} rem: {} out: {}", temp_quotient, temp_remainder, output);
 
     return output;
 }

--- a/Userland/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Userland/Libraries/LibCrypto/PK/RSA.cpp
@@ -116,7 +116,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes in)
 
 void RSA::encrypt(ReadonlyBytes in, Bytes& out)
 {
-    dbgln<CRYPTO_DEBUG>("in size: {}", in.size());
+    dbgln_if(CRYPTO_DEBUG, "in size: {}", in.size());
     auto in_integer = UnsignedBigInteger::import_data(in.data(), in.size());
     if (!(in_integer < m_public_key.modulus())) {
         dbgln("value too large for key");
@@ -230,7 +230,7 @@ VerificationConsistency RSA_EMSA_PSS<HashFunction>::verify(ReadonlyBytes in)
 void RSA_PKCS1_EME::encrypt(ReadonlyBytes in, Bytes& out)
 {
     auto mod_len = (m_public_key.modulus().trimmed_length() * sizeof(u32) * 8 + 7) / 8;
-    dbgln<CRYPTO_DEBUG>("key size: {}", mod_len);
+    dbgln_if(CRYPTO_DEBUG, "key size: {}", mod_len);
     if (in.size() > mod_len - 11) {
         dbgln("message too long :(");
         out = out.trim(0);
@@ -262,7 +262,7 @@ void RSA_PKCS1_EME::encrypt(ReadonlyBytes in, Bytes& out)
     out.overwrite(3 + ps_length, in.data(), in.size());
     out = out.trim(3 + ps_length + in.size()); // should be a single block
 
-    dbgln<CRYPTO_DEBUG>("padded output size: {} buffer size: {}", 3 + ps_length + in.size(), out.size());
+    dbgln_if(CRYPTO_DEBUG, "padded output size: {} buffer size: {}", 3 + ps_length + in.size(), out.size());
 
     RSA::encrypt(out, out);
 }

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -251,7 +251,7 @@ void LineProgram::run_program()
         u8 opcode = 0;
         m_stream >> opcode;
 
-        dbgln<DWARF_DEBUG>("{:p}: opcode: {}", m_stream.offset() - 1, opcode);
+        dbgln_if(DWARF_DEBUG, "{:p}: opcode: {}", m_stream.offset() - 1, opcode);
 
         if (opcode == 0) {
             handle_extended_opcode();

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -433,7 +433,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(size_t total_tls_si
         //     We could explicitly do them first using m_number_of_relocatoins from DT_RELCOUNT
         //     However, our compiler is nice enough to put them at the front of the relocations for us :)
         dbgln<DYNAMIC_LOAD_DEBUG>("Load address relocation at offset {:#08x}", relocation.offset());
-        dbgln<DYNAMIC_LOAD_DEBUG>("    patch ptr == %p, adding load base address ({:p}) to it and storing {:p}", *patch_ptr, m_dynamic_object->base_address().as_ptr(), *patch_ptr + m_dynamic_object->base_address().as_ptr());
+        dbgln<DYNAMIC_LOAD_DEBUG>("    patch ptr == {:p}, adding load base address ({:p}) to it and storing {:p}", *patch_ptr, m_dynamic_object->base_address().as_ptr(), *patch_ptr + m_dynamic_object->base_address().as_ptr());
         *patch_ptr += (FlatPtr)m_dynamic_object->base_address().as_ptr(); // + addend for RelA (addend for Rel is stored at addr)
         break;
     }

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -73,8 +73,8 @@ void DynamicObject::dump() const
     if (m_has_soname)
         builder.appendf("DT_SONAME: %s\n", soname()); // FIXME: Valdidate that this string is null terminated?
 
-    dbgln<DYNAMIC_LOAD_DEBUG>("Dynamic section at address {} contains {} entries:", m_dynamic_address.as_ptr(), num_dynamic_sections);
-    dbgln<DYNAMIC_LOAD_DEBUG>("{}", builder.string_view());
+    dbgln_if(DYNAMIC_LOAD_DEBUG, "Dynamic section at address {} contains {} entries:", m_dynamic_address.as_ptr(), num_dynamic_sections);
+    dbgln_if(DYNAMIC_LOAD_DEBUG, "{}", builder.string_view());
 }
 
 void DynamicObject::parse()
@@ -303,7 +303,7 @@ const DynamicObject::Symbol DynamicObject::HashSection::lookup_elf_symbol(const 
     for (u32 i = buckets[hash_value % num_buckets]; i; i = chains[i]) {
         auto symbol = m_dynamic.symbol(i);
         if (strcmp(name, symbol.name()) == 0) {
-            dbgln<DYNAMIC_LOAD_DEBUG>("Returning SYSV dynamic symbol with index {} for {}: {}", i, symbol.name(), symbol.address().as_ptr());
+            dbgln_if(DYNAMIC_LOAD_DEBUG, "Returning SYSV dynamic symbol with index {} for {}: {}", i, symbol.name(), symbol.address().as_ptr());
             return symbol;
         }
     }
@@ -348,7 +348,7 @@ const DynamicObject::Symbol DynamicObject::HashSection::lookup_gnu_symbol(const 
         hash2 = *(current_chain++);
         const auto symbol = m_dynamic.symbol(current_sym);
         if ((hash1 == (hash2 & ~1)) && strcmp(name, symbol.name()) == 0) {
-            dbgln<DYNAMIC_LOAD_DEBUG>("Returning GNU dynamic symbol with index {} for {}: {}", current_sym, symbol.name(), symbol.address().as_ptr());
+            dbgln_if(DYNAMIC_LOAD_DEBUG, "Returning GNU dynamic symbol with index {} for {}: {}", current_sym, symbol.name(), symbol.address().as_ptr());
             return symbol;
         }
         if (hash2 & 1) {
@@ -494,7 +494,7 @@ Elf32_Addr DynamicObject::patch_plt_entry(u32 relocation_offset)
 
     u32 symbol_location = result.value().address;
 
-    dbgln<DYNAMIC_LOAD_DEBUG>("DynamicLoader: Jump slot relocation: putting {} ({:p}) into PLT at {}", sym.name(), symbol_location, (void*)relocation_address);
+    dbgln_if(DYNAMIC_LOAD_DEBUG, "DynamicLoader: Jump slot relocation: putting {} ({:p}) into PLT at {}", sym.name(), symbol_location, (void*)relocation_address);
 
     *(u32*)relocation_address = symbol_location;
 
@@ -503,12 +503,12 @@ Elf32_Addr DynamicObject::patch_plt_entry(u32 relocation_offset)
 
 Optional<DynamicObject::SymbolLookupResult> DynamicObject::lookup_symbol(const ELF::DynamicObject::Symbol& symbol) const
 {
-    dbgln<DYNAMIC_LOAD_DEBUG>("looking up symbol: {}", symbol.name());
+    dbgln_if(DYNAMIC_LOAD_DEBUG, "looking up symbol: {}", symbol.name());
     if (symbol.is_undefined() || symbol.bind() == STB_WEAK)
         return DynamicLinker::lookup_global_symbol(symbol.name());
 
     if (!symbol.is_undefined()) {
-        dbgln<DYNAMIC_LOAD_DEBUG>("symbol is defined in its object");
+        dbgln_if(DYNAMIC_LOAD_DEBUG, "symbol is defined in its object");
         return SymbolLookupResult { symbol.value(), (FlatPtr)symbol.address().as_ptr(), symbol.bind(), &symbol.object() };
     }
     return DynamicLinker::lookup_global_symbol(symbol.name());

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -140,25 +140,25 @@ void WindowServerConnection::handle(const Messages::WindowClient::KeyDown& messa
     auto key_event = make<KeyEvent>(Event::KeyDown, (KeyCode)message.key(), message.modifiers(), message.code_point(), message.scancode());
     Action* action = nullptr;
 
-    dbgln<KEYBOARD_SHORTCUTS_DEBUG>("Looking up action for {}", key_event->to_string());
+    dbgln_if(KEYBOARD_SHORTCUTS_DEBUG, "Looking up action for {}", key_event->to_string());
 
     if (auto* focused_widget = window->focused_widget()) {
         for (auto* widget = focused_widget; widget && !action; widget = widget->parent_widget()) {
             action = widget->action_for_key_event(*key_event);
 
-            dbgln<KEYBOARD_SHORTCUTS_DEBUG>("  > Focused widget {} gave action: {}", *widget, action);
+            dbgln_if(KEYBOARD_SHORTCUTS_DEBUG, "  > Focused widget {} gave action: {}", *widget, action);
         }
     }
 
     if (!action) {
         action = window->action_for_key_event(*key_event);
-        dbgln<KEYBOARD_SHORTCUTS_DEBUG>("  > Asked window {}, got action: {}", *window, action);
+        dbgln_if(KEYBOARD_SHORTCUTS_DEBUG, "  > Asked window {}, got action: {}", *window, action);
     }
 
     // NOTE: Application-global shortcuts are ignored while a modal window is up.
     if (!action && !window->is_modal()) {
         action = Application::the()->action_for_key_event(*key_event);
-        dbgln<KEYBOARD_SHORTCUTS_DEBUG>("  > Asked application, got action: {}", action);
+        dbgln_if(KEYBOARD_SHORTCUTS_DEBUG, "  > Asked application, got action: {}", action);
     }
 
     if (action) {

--- a/Userland/Libraries/LibGfx/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/BMPLoader.cpp
@@ -317,7 +317,7 @@ static u8 get_scaled_color(u32 data, u8 mask_size, i8 mask_shift)
 //   to scale the values in order to reach the proper value of 255.
 static u32 int_to_scaled_rgb(BMPLoadingContext& context, u32 data)
 {
-    dbgln<BMP_DEBUG>("DIB info sizes before access: #masks={}, #mask_sizes={}, #mask_shifts={}",
+    dbgln_if(BMP_DEBUG, "DIB info sizes before access: #masks={}, #mask_sizes={}, #mask_shifts={}",
         context.dib.info.masks.size(),
         context.dib.info.mask_sizes.size(),
         context.dib.info.mask_shifts.size());
@@ -471,7 +471,7 @@ static bool decode_bmp_header(BMPLoadingContext& context)
         return true;
 
     if (!context.file_bytes || context.file_size < bmp_header_size) {
-        dbgln<BMP_DEBUG>("Missing BMP header");
+        dbgln_if(BMP_DEBUG, "Missing BMP header");
         context.state = BMPLoadingContext::State::Error;
         return false;
     }
@@ -480,7 +480,7 @@ static bool decode_bmp_header(BMPLoadingContext& context)
 
     u16 header = streamer.read_u16();
     if (header != 0x4d42) {
-        dbgln<BMP_DEBUG>("BMP has invalid magic header number: {:#04x}", header);
+        dbgln_if(BMP_DEBUG, "BMP has invalid magic header number: {:#04x}", header);
         context.state = BMPLoadingContext::State::Error;
         return false;
     }
@@ -502,7 +502,7 @@ static bool decode_bmp_header(BMPLoadingContext& context)
     }
 
     if (context.data_offset >= context.file_size) {
-        dbgln<BMP_DEBUG>("BMP data offset is beyond file end?!");
+        dbgln_if(BMP_DEBUG, "BMP data offset is beyond file end?!");
         return false;
     }
 
@@ -725,12 +725,12 @@ static bool decode_bmp_v3_dib(BMPLoadingContext& context, Streamer& streamer)
     // suite results.
     if (context.dib.info.compression == Compression::ALPHABITFIELDS) {
         context.dib.info.masks.append(streamer.read_u32());
-        dbgln<BMP_DEBUG>("BMP alpha mask: {:#08x}", context.dib.info.masks[3]);
+        dbgln_if(BMP_DEBUG, "BMP alpha mask: {:#08x}", context.dib.info.masks[3]);
     } else if (context.dib_size() >= 56 && context.dib.core.bpp >= 16) {
         auto mask = streamer.read_u32();
         if ((context.dib.core.bpp == 32 && mask != 0) || context.dib.core.bpp == 16) {
             context.dib.info.masks.append(mask);
-            dbgln<BMP_DEBUG>("BMP alpha mask: {:#08x}", mask);
+            dbgln_if(BMP_DEBUG, "BMP alpha mask: {:#08x}", mask);
         }
     } else {
         streamer.drop_bytes(4);
@@ -807,7 +807,7 @@ static bool decode_bmp_dib(BMPLoadingContext& context)
 
     streamer = Streamer(context.file_bytes + bmp_header_size + 4, context.data_offset - bmp_header_size - 4);
 
-    dbgln<BMP_DEBUG>("BMP dib size: {}", dib_size);
+    dbgln_if(BMP_DEBUG, "BMP dib size: {}", dib_size);
 
     bool error = false;
 
@@ -937,7 +937,7 @@ static bool uncompress_bmp_rle_data(BMPLoadingContext& context, ByteBuffer& buff
 {
     // RLE-compressed images cannot be stored top-down
     if (context.dib.core.height < 0) {
-        dbgln<BMP_DEBUG>("BMP is top-down and RLE compressed");
+        dbgln_if(BMP_DEBUG, "BMP is top-down and RLE compressed");
         context.state = BMPLoadingContext::State::Error;
         return false;
     }

--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -212,13 +212,13 @@ public:
         }
 
         if (m_current_code > m_code_table.size()) {
-            dbgln<GIF_DEBUG>("Corrupted LZW stream, invalid code: {} at bit index {}, code table size: {}",
+            dbgln_if(GIF_DEBUG, "Corrupted LZW stream, invalid code: {} at bit index {}, code table size: {}",
                 m_current_code,
                 m_current_bit_index,
                 m_code_table.size());
             return {};
         } else if (m_current_code == m_code_table.size() && m_output.is_empty()) {
-            dbgln<GIF_DEBUG>("Corrupted LZW stream, valid new code but output buffer is empty: {} at bit index {}, code table size: {}",
+            dbgln_if(GIF_DEBUG, "Corrupted LZW stream, valid new code but output buffer is empty: {} at bit index {}, code table size: {}",
                 m_current_code,
                 m_current_bit_index,
                 m_code_table.size());
@@ -541,12 +541,12 @@ static bool load_gif_frame_descriptors(GIFLoadingContext& context)
 
             if (extension_type == 0xFF) {
                 if (sub_block.size() != 14) {
-                    dbgln<GIF_DEBUG>("Unexpected application extension size: {}", sub_block.size());
+                    dbgln_if(GIF_DEBUG, "Unexpected application extension size: {}", sub_block.size());
                     continue;
                 }
 
                 if (sub_block[11] != 1) {
-                    dbgln<GIF_DEBUG>("Unexpected application extension format");
+                    dbgln_if(GIF_DEBUG, "Unexpected application extension format");
                     continue;
                 }
 

--- a/Userland/Libraries/LibGfx/JPGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPGLoader.cpp
@@ -230,13 +230,13 @@ static void generate_huffman_codes(HuffmanTableSpec& table)
 static Optional<size_t> read_huffman_bits(HuffmanStreamState& hstream, size_t count = 1)
 {
     if (count > (8 * sizeof(size_t))) {
-        dbgln<JPG_DEBUG>("Can't read {} bits at once!", count);
+        dbgln_if(JPG_DEBUG, "Can't read {} bits at once!", count);
         return {};
     }
     size_t value = 0;
     while (count--) {
         if (hstream.byte_offset >= hstream.stream.size()) {
-            dbgln<JPG_DEBUG>("Huffman stream exhausted. This could be an error!");
+            dbgln_if(JPG_DEBUG, "Huffman stream exhausted. This could be an error!");
             return {};
         }
         u8 current_byte = hstream.stream[hstream.byte_offset];
@@ -313,7 +313,7 @@ static bool build_macroblocks(JPGLoadingContext& context, Vector<Macroblock>& ma
                 // For DC coefficients, symbol encodes the length of the coefficient.
                 auto dc_length = symbol_or_error.release_value();
                 if (dc_length > 11) {
-                    dbgln<JPG_DEBUG>("DC coefficient too long: {}!", dc_length);
+                    dbgln_if(JPG_DEBUG, "DC coefficient too long: {}!", dc_length);
                     return false;
                 }
 
@@ -350,13 +350,13 @@ static bool build_macroblocks(JPGLoadingContext& context, Vector<Macroblock>& ma
                     j += run_length;
 
                     if (j >= 64) {
-                        dbgln<JPG_DEBUG>("Run-length exceeded boundaries. Cursor: {}, Skipping: {}!", j, run_length);
+                        dbgln_if(JPG_DEBUG, "Run-length exceeded boundaries. Cursor: {}, Skipping: {}!", j, run_length);
                         return false;
                     }
 
                     u8 coeff_length = ac_symbol & 0x0F;
                     if (coeff_length > 10) {
-                        dbgln<JPG_DEBUG>("AC coefficient too long: {}!", coeff_length);
+                        dbgln_if(JPG_DEBUG, "AC coefficient too long: {}!", coeff_length);
                         return false;
                     }
 
@@ -445,7 +445,7 @@ static inline bool is_valid_marker(const Marker marker)
     if (marker >= JPG_APPN0 && marker <= JPG_APPNF) {
 
         if (marker != JPG_APPN0)
-            dbgln<JPG_DEBUG>("{:#04x} not supported yet. The decoder may fail!", marker);
+            dbgln_if(JPG_DEBUG, "{:#04x} not supported yet. The decoder may fail!", marker);
         return true;
     }
     if (marker >= JPG_RESERVED1 && marker <= JPG_RESERVEDD)
@@ -467,7 +467,7 @@ static inline bool is_valid_marker(const Marker marker)
 
     if (marker >= 0xFFC0 && marker <= 0xFFCF) {
         if (marker != 0xFFC4 && marker != 0xFFC8 && marker != 0xFFCC) {
-            dbgln<JPG_DEBUG>("Decoding this frame-type (SOF{}) is not currently supported. Decoder will fail!", marker & 0xf);
+            dbgln_if(JPG_DEBUG, "Decoding this frame-type (SOF{}) is not currently supported. Decoder will fail!", marker & 0xf);
             return false;
         }
     }
@@ -504,7 +504,7 @@ static inline Marker read_marker_at_cursor(InputMemoryStream& stream)
 static bool read_start_of_scan(InputMemoryStream& stream, JPGLoadingContext& context)
 {
     if (context.state < JPGLoadingContext::State::FrameDecoded) {
-        dbgln<JPG_DEBUG>("{}: SOS found before reading a SOF!", stream.offset());
+        dbgln_if(JPG_DEBUG, "{}: SOS found before reading a SOF!", stream.offset());
         return false;
     }
 
@@ -519,7 +519,7 @@ static bool read_start_of_scan(InputMemoryStream& stream, JPGLoadingContext& con
     if (stream.handle_any_error())
         return false;
     if (component_count != context.component_count) {
-        dbgln<JPG_DEBUG>("{}: Unsupported number of components: {}!", stream.offset(), component_count);
+        dbgln_if(JPG_DEBUG, "{}: Unsupported number of components: {}!", stream.offset(), component_count);
         return false;
     }
 
@@ -538,7 +538,7 @@ static bool read_start_of_scan(InputMemoryStream& stream, JPGLoadingContext& con
                 return false;
             }
         } else {
-            dbgln<JPG_DEBUG>("{}: Unsupported component id: {}!", stream.offset(), component_id);
+            dbgln_if(JPG_DEBUG, "{}: Unsupported component id: {}!", stream.offset(), component_id);
             return false;
         }
 
@@ -551,17 +551,17 @@ static bool read_start_of_scan(InputMemoryStream& stream, JPGLoadingContext& con
         component->ac_destination_id = table_ids & 0x0F;
 
         if (context.dc_tables.size() != context.ac_tables.size()) {
-            dbgln<JPG_DEBUG>("{}: DC & AC table count mismatch!", stream.offset());
+            dbgln_if(JPG_DEBUG, "{}: DC & AC table count mismatch!", stream.offset());
             return false;
         }
 
         if (!context.dc_tables.contains(component->dc_destination_id)) {
-            dbgln<JPG_DEBUG>("DC table (id: {}) does not exist!", component->dc_destination_id);
+            dbgln_if(JPG_DEBUG, "DC table (id: {}) does not exist!", component->dc_destination_id);
             return false;
         }
 
         if (!context.ac_tables.contains(component->ac_destination_id)) {
-            dbgln<JPG_DEBUG>("AC table (id: {}) does not exist!", component->ac_destination_id);
+            dbgln_if(JPG_DEBUG, "AC table (id: {}) does not exist!", component->ac_destination_id);
             return false;
         }
     }
@@ -580,7 +580,7 @@ static bool read_start_of_scan(InputMemoryStream& stream, JPGLoadingContext& con
         return false;
     // The three values should be fixed for baseline JPEGs utilizing sequential DCT.
     if (spectral_selection_start != 0 || spectral_selection_end != 63 || successive_approximation != 0) {
-        dbgln<JPG_DEBUG>("{}: ERROR! Start of Selection: {}, End of Selection: {}, Successive Approximation: {}!",
+        dbgln_if(JPG_DEBUG, "{}: ERROR! Start of Selection: {}, End of Selection: {}, Successive Approximation: {}!",
             stream.offset(),
             spectral_selection_start,
             spectral_selection_end,
@@ -597,7 +597,7 @@ static bool read_reset_marker(InputMemoryStream& stream, JPGLoadingContext& cont
         return false;
     bytes_to_read -= 2;
     if (bytes_to_read != 2) {
-        dbgln<JPG_DEBUG>("{}: Malformed reset marker found!", stream.offset());
+        dbgln_if(JPG_DEBUG, "{}: Malformed reset marker found!", stream.offset());
         return false;
     }
     context.dc_reset_interval = read_be_word(stream);
@@ -623,11 +623,11 @@ static bool read_huffman_table(InputMemoryStream& stream, JPGLoadingContext& con
         u8 table_type = table_info >> 4;
         u8 table_destination_id = table_info & 0x0F;
         if (table_type > 1) {
-            dbgln<JPG_DEBUG>("{}: Unrecognized huffman table: {}!", stream.offset(), table_type);
+            dbgln_if(JPG_DEBUG, "{}: Unrecognized huffman table: {}!", stream.offset(), table_type);
             return false;
         }
         if (table_destination_id > 1) {
-            dbgln<JPG_DEBUG>("{}: Invalid huffman table destination id: {}!", stream.offset(), table_destination_id);
+            dbgln_if(JPG_DEBUG, "{}: Invalid huffman table destination id: {}!", stream.offset(), table_destination_id);
             return false;
         }
 
@@ -667,7 +667,7 @@ static bool read_huffman_table(InputMemoryStream& stream, JPGLoadingContext& con
     }
 
     if (bytes_to_read != 0) {
-        dbgln<JPG_DEBUG>("{}: Extra bytes detected in huffman header!", stream.offset());
+        dbgln_if(JPG_DEBUG, "{}: Extra bytes detected in huffman header!", stream.offset());
         return false;
     }
     return true;
@@ -705,7 +705,7 @@ static inline void set_macroblock_metadata(JPGLoadingContext& context)
 static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& context)
 {
     if (context.state == JPGLoadingContext::FrameDecoded) {
-        dbgln<JPG_DEBUG>("{}: SOF repeated!", stream.offset());
+        dbgln_if(JPG_DEBUG, "{}: SOF repeated!", stream.offset());
         return false;
     }
 
@@ -721,7 +721,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
     if (stream.handle_any_error())
         return false;
     if (context.frame.precision != 8) {
-        dbgln<JPG_DEBUG>("{}: SOF precision != 8!", stream.offset());
+        dbgln_if(JPG_DEBUG, "{}: SOF precision != 8!", stream.offset());
         return false;
     }
 
@@ -732,7 +732,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
     if (stream.handle_any_error())
         return false;
     if (!context.frame.width || !context.frame.height) {
-        dbgln<JPG_DEBUG>("{}: ERROR! Image height: {}, Image width: {}!", stream.offset(), context.frame.height, context.frame.width);
+        dbgln_if(JPG_DEBUG, "{}: ERROR! Image height: {}, Image width: {}!", stream.offset(), context.frame.height, context.frame.width);
         return false;
     }
 
@@ -747,7 +747,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
     if (stream.handle_any_error())
         return false;
     if (context.component_count != 1 && context.component_count != 3) {
-        dbgln<JPG_DEBUG>("{}: Unsupported number of components in SOF: {}!", stream.offset(), context.component_count);
+        dbgln_if(JPG_DEBUG, "{}: Unsupported number of components in SOF: {}!", stream.offset(), context.component_count);
         return false;
     }
 
@@ -770,7 +770,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
             // By convention, downsampling is applied only on chroma components. So we should
             //  hope to see the maximum sampling factor in the luma component.
             if (!validate_luma_and_modify_context(component, context)) {
-                dbgln<JPG_DEBUG>("{}: Unsupported luma subsampling factors: horizontal: {}, vertical: {}",
+                dbgln_if(JPG_DEBUG, "{}: Unsupported luma subsampling factors: horizontal: {}, vertical: {}",
                     stream.offset(),
                     component.hsample_factor,
                     component.vsample_factor);
@@ -778,7 +778,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
             }
         } else {
             if (component.hsample_factor != 1 || component.vsample_factor != 1) {
-                dbgln<JPG_DEBUG>("{}: Unsupported chroma subsampling factors: horizontal: {}, vertical: {}",
+                dbgln_if(JPG_DEBUG, "{}: Unsupported chroma subsampling factors: horizontal: {}, vertical: {}",
                     stream.offset(),
                     component.hsample_factor,
                     component.vsample_factor);
@@ -790,7 +790,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
         if (stream.handle_any_error())
             return false;
         if (component.qtable_id > 1) {
-            dbgln<JPG_DEBUG>("{}: Unsupported quantization table id: {}!", stream.offset(), component.qtable_id);
+            dbgln_if(JPG_DEBUG, "{}: Unsupported quantization table id: {}!", stream.offset(), component.qtable_id);
             return false;
         }
 
@@ -815,12 +815,12 @@ static bool read_quantization_table(InputMemoryStream& stream, JPGLoadingContext
             return false;
         u8 element_unit_hint = info_byte >> 4;
         if (element_unit_hint > 1) {
-            dbgln<JPG_DEBUG>("{}: Unsupported unit hint in quantization table: {}!", stream.offset(), element_unit_hint);
+            dbgln_if(JPG_DEBUG, "{}: Unsupported unit hint in quantization table: {}!", stream.offset(), element_unit_hint);
             return false;
         }
         u8 table_id = info_byte & 0x0F;
         if (table_id > 1) {
-            dbgln<JPG_DEBUG>("{}: Unsupported quantization table id: {}!", stream.offset(), table_id);
+            dbgln_if(JPG_DEBUG, "{}: Unsupported quantization table id: {}!", stream.offset(), table_id);
             return false;
         }
         u32* table = table_id == 0 ? context.luma_table : context.chroma_table;
@@ -843,7 +843,7 @@ static bool read_quantization_table(InputMemoryStream& stream, JPGLoadingContext
         bytes_to_read -= 1 + (element_unit_hint == 0 ? 64 : 128);
     }
     if (bytes_to_read != 0) {
-        dbgln<JPG_DEBUG>("{}: Invalid length for one or more quantization tables!", stream.offset());
+        dbgln_if(JPG_DEBUG, "{}: Invalid length for one or more quantization tables!", stream.offset());
         return false;
     }
 
@@ -1109,7 +1109,7 @@ static bool parse_header(InputMemoryStream& stream, JPGLoadingContext& context)
     if (stream.handle_any_error())
         return false;
     if (marker != JPG_SOI) {
-        dbgln<JPG_DEBUG>("{}: SOI not found: {:x}!", stream.offset(), marker);
+        dbgln_if(JPG_DEBUG, "{}: SOI not found: {:x}!", stream.offset(), marker);
         return false;
     }
     for (;;) {
@@ -1137,7 +1137,7 @@ static bool parse_header(InputMemoryStream& stream, JPGLoadingContext& context)
         case JPG_RST7:
         case JPG_SOI:
         case JPG_EOI:
-            dbgln<JPG_DEBUG>("{}: Unexpected marker {:x}!", stream.offset(), marker);
+            dbgln_if(JPG_DEBUG, "{}: Unexpected marker {:x}!", stream.offset(), marker);
             return false;
         case JPG_SOF0:
             if (!read_start_of_frame(stream, context))
@@ -1160,7 +1160,7 @@ static bool parse_header(InputMemoryStream& stream, JPGLoadingContext& context)
             return read_start_of_scan(stream, context);
         default:
             if (!skip_marker_with_length(stream)) {
-                dbgln<JPG_DEBUG>("{}: Error skipping marker: {:x}!", stream.offset(), marker);
+                dbgln_if(JPG_DEBUG, "{}: Error skipping marker: {:x}!", stream.offset(), marker);
                 return false;
             }
             break;
@@ -1182,7 +1182,7 @@ static bool scan_huffman_stream(InputMemoryStream& stream, JPGLoadingContext& co
         last_byte = current_byte;
         stream >> current_byte;
         if (stream.handle_any_error()) {
-            dbgln<JPG_DEBUG>("{}: EOI not found!", stream.offset());
+            dbgln_if(JPG_DEBUG, "{}: EOI not found!", stream.offset());
             return false;
         }
 
@@ -1206,7 +1206,7 @@ static bool scan_huffman_stream(InputMemoryStream& stream, JPGLoadingContext& co
                     return false;
                 continue;
             }
-            dbgln<JPG_DEBUG>("{}: Invalid marker: {:x}!", stream.offset(), marker);
+            dbgln_if(JPG_DEBUG, "{}: Invalid marker: {:x}!", stream.offset(), marker);
             return false;
         } else {
             context.huffman_stream.stream.append(last_byte);
@@ -1227,7 +1227,7 @@ static bool decode_jpg(JPGLoadingContext& context)
 
     auto result = decode_huffman_stream(context);
     if (!result.has_value()) {
-        dbgln<JPG_DEBUG>("{}: Failed to decode Macroblocks!", stream.offset());
+        dbgln_if(JPG_DEBUG, "{}: Failed to decode Macroblocks!", stream.offset());
         return false;
     }
 

--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -613,7 +613,7 @@ static bool decode_png_bitmap_simple(PNGLoadingContext& context)
         }
 
         if (filter > 4) {
-            dbgln<PNG_DEBUG>("Invalid PNG filter: {}", filter);
+            dbgln_if(PNG_DEBUG, "Invalid PNG filter: {}", filter);
             context.state = PNGLoadingContext::State::Error;
             return false;
         }
@@ -715,7 +715,7 @@ static bool decode_adam7_pass(PNGLoadingContext& context, Streamer& streamer, in
         }
 
         if (filter > 4) {
-            dbgln<PNG_DEBUG>("Invalid PNG filter: {}", filter);
+            dbgln_if(PNG_DEBUG, "Invalid PNG filter: {}", filter);
             context.state = PNGLoadingContext::State::Error;
             return false;
         }

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -947,7 +947,7 @@ void Painter::draw_glyph_or_emoji(const IntPoint& point, u32 code_point, const F
     // Perhaps it's an emoji?
     auto* emoji = Emoji::emoji_for_code_point(code_point);
     if (emoji == nullptr) {
-        dbgln<EMOJI_DEBUG>("Failed to find an emoji for code_point {}", code_point);
+        dbgln_if(EMOJI_DEBUG, "Failed to find an emoji for code_point {}", code_point);
         draw_glyph(point, '?', font, color);
         return;
     }
@@ -1661,7 +1661,7 @@ void Painter::fill_path(Path& path, Color color, WindingRule winding_rule)
                         // The points between this segment and the previous are
                         // inside the shape
 
-                        dbgln<FILL_PATH_DEBUG>("y={}: {} at {}: {} -- {}", scanline, winding_number, i, from, to);
+                        dbgln_if(FILL_PATH_DEBUG, "y={}: {} at {}: {} -- {}", scanline, winding_number, i, from, to);
                         draw_line(from, to, color, 1);
                     }
 

--- a/Userland/Libraries/LibGfx/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/PortableImageLoaderCommon.h
@@ -104,14 +104,14 @@ static bool read_magic_number(TContext& context, Streamer& streamer)
 
     if (!context.data || context.data_size < 2) {
         context.state = TContext::State::Error;
-        dbgln<PORTABLE_IMAGE_LOADER_DEBUG>("There is no enough data for {}", TContext::image_type);
+        dbgln_if(PORTABLE_IMAGE_LOADER_DEBUG, "There is no enough data for {}", TContext::image_type);
         return false;
     }
 
     u8 magic_number[2] {};
     if (!streamer.read_bytes(magic_number, 2)) {
         context.state = TContext::State::Error;
-        dbgln<PORTABLE_IMAGE_LOADER_DEBUG>("We can't read magic number for {}", TContext::image_type);
+        dbgln_if(PORTABLE_IMAGE_LOADER_DEBUG, "We can't read magic number for {}", TContext::image_type);
         return false;
     }
 
@@ -128,7 +128,7 @@ static bool read_magic_number(TContext& context, Streamer& streamer)
     }
 
     context.state = TContext::State::Error;
-    dbgln<PORTABLE_IMAGE_LOADER_DEBUG>("Magic number is not valid for {}{}{}", magic_number[0], magic_number[1], TContext::image_type);
+    dbgln_if(PORTABLE_IMAGE_LOADER_DEBUG, "Magic number is not valid for {}{}{}", magic_number[0], magic_number[1], TContext::image_type);
     return false;
 }
 
@@ -186,7 +186,7 @@ static bool read_max_val(TContext& context, Streamer& streamer)
     }
 
     if (context.max_val > 255) {
-        dbgln<PORTABLE_IMAGE_LOADER_DEBUG>("We can't parse 2 byte color for {}", TContext::image_type);
+        dbgln_if(PORTABLE_IMAGE_LOADER_DEBUG, "We can't parse 2 byte color for {}", TContext::image_type);
         context.state = TContext::Error;
         return false;
     }

--- a/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
@@ -107,7 +107,7 @@ void SyntaxHighlighter::rehighlight(Gfx::Palette palette)
         spans.append(span);
         advance_position(str[str.length() - 1]);
 
-        dbgln<SYNTAX_HIGHLIGHTING_DEBUG>("{}{} @ '{}' {}:{} - {}:{}",
+        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "{}{} @ '{}' {}:{} - {}:{}",
             token.name(),
             is_trivia ? " (trivia)" : "",
             token.value(),

--- a/Userland/Libraries/LibMarkdown/Table.cpp
+++ b/Userland/Libraries/LibMarkdown/Table.cpp
@@ -182,7 +182,7 @@ OwnPtr<Table> Table::parse(Vector<StringView>::ConstIterator& lines)
         size_t relative_width = delimiter.length();
         for (auto ch : delimiter) {
             if (ch != '-') {
-                dbgln<MARKDOWN_DEBUG>("Invalid character _{}_ in table heading delimiter (ignored)", ch);
+                dbgln_if(MARKDOWN_DEBUG, "Invalid character _{}_ in table heading delimiter (ignored)", ch);
                 --relative_width;
             }
         }

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -148,7 +148,7 @@ RegexResult Matcher<Parser>::match(const Vector<RegexStringView> views, Optional
 
     for (auto& view : views) {
         input.view = view;
-        dbgln<REGEX_DEBUG>("[match] Starting match with view ({}): _{}_", view.length(), view);
+        dbgln_if(REGEX_DEBUG, "[match] Starting match with view ({}): _{}_", view.length(), view);
 
         auto view_length = view.length();
         size_t view_index = m_pattern.start_offset;

--- a/Userland/Libraries/LibTLS/ClientHandshake.cpp
+++ b/Userland/Libraries/LibTLS/ClientHandshake.cpp
@@ -112,7 +112,7 @@ ssize_t TLSv12::handle_hello(ReadonlyBytes buffer, WritePacketStage& write_packe
         return (i8)Error::NoCommonCipher;
     }
     m_context.cipher = cipher;
-    dbgln<TLS_DEBUG>("Cipher: {}", (u16)cipher);
+    dbgln_if(TLS_DEBUG, "Cipher: {}", (u16)cipher);
 
     // The handshake hash function is _always_ SHA256
     m_context.handshake_hash.initialize(Crypto::Hash::HashKind::SHA256);
@@ -146,7 +146,7 @@ ssize_t TLSv12::handle_hello(ReadonlyBytes buffer, WritePacketStage& write_packe
         u16 extension_length = AK::convert_between_host_and_network_endian(*(const u16*)buffer.offset_pointer(res));
         res += 2;
 
-        dbgln<TLS_DEBUG>("extension {} with length {}", (u16)extension_type, extension_length);
+        dbgln_if(TLS_DEBUG, "extension {} with length {}", (u16)extension_type, extension_length);
 
         if (extension_length) {
             if (buffer.size() - res < extension_length) {
@@ -218,12 +218,12 @@ ssize_t TLSv12::handle_finished(ReadonlyBytes buffer, WritePacketStage& write_pa
     u32 size = buffer[0] * 0x10000 + buffer[1] * 0x100 + buffer[2];
 
     if (size < 12) {
-        dbgln<TLS_DEBUG>("finished packet smaller than minimum size: {}", size);
+        dbgln_if(TLS_DEBUG, "finished packet smaller than minimum size: {}", size);
         return (i8)Error::BrokenPacket;
     }
 
     if (size < buffer.size() - index) {
-        dbgln<TLS_DEBUG>("not enough data after length: {} > {}", size, buffer.size() - index);
+        dbgln_if(TLS_DEBUG, "not enough data after length: {} > {}", size, buffer.size() - index);
         return (i8)Error::NeedMoreData;
     }
 
@@ -324,7 +324,7 @@ ssize_t TLSv12::handle_payload(ReadonlyBytes vbuffer)
         auto type = buffer[0];
         auto write_packets { WritePacketStage::Initial };
         size_t payload_size = buffer[1] * 0x10000 + buffer[2] * 0x100 + buffer[3] + 3;
-        dbgln<TLS_DEBUG>("payload size: {} buffer length: {}", payload_size, buffer_length);
+        dbgln_if(TLS_DEBUG, "payload size: {} buffer length: {}", payload_size, buffer_length);
         if (payload_size + 1 > buffer_length)
             return (i8)Error::NeedMoreData;
 

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -174,7 +174,7 @@ void TLSv12::read_from_socket()
 
 void TLSv12::write_into_socket()
 {
-    dbgln<TLS_DEBUG>("Flushing cached records: {} established? {}", m_context.tls_buffer.size(), is_established());
+    dbgln_if(TLS_DEBUG, "Flushing cached records: {} established? {}", m_context.tls_buffer.size(), is_established());
 
     m_has_scheduled_write_flush = false;
     if (!check_connection_state(false))
@@ -199,7 +199,7 @@ bool TLSv12::check_connection_state(bool read)
         m_context.connection_finished = true;
     }
     if (m_context.critical_error) {
-        dbgln<TLS_DEBUG>("CRITICAL ERROR {} :(", m_context.critical_error);
+        dbgln_if(TLS_DEBUG, "CRITICAL ERROR {} :(", m_context.critical_error);
 
         if (on_tls_error)
             on_tls_error((AlertDescription)m_context.critical_error);
@@ -211,7 +211,7 @@ bool TLSv12::check_connection_state(bool read)
                 on_tls_finished();
         }
         if (m_context.tls_buffer.size()) {
-            dbgln<TLS_DEBUG>("connection closed without finishing data transfer, {} bytes still in buffer and {} bytes in application buffer",
+            dbgln_if(TLS_DEBUG, "connection closed without finishing data transfer, {} bytes still in buffer and {} bytes in application buffer",
                 m_context.tls_buffer.size(),
                 m_context.application_buffer.size());
         } else {
@@ -247,7 +247,7 @@ bool TLSv12::flush()
     }
     if (m_context.send_retries++ == 10) {
         // drop the records, we can't send
-        dbgln<TLS_DEBUG>("Dropping {} bytes worth of TLS records as max retries has been reached", write_buffer().size());
+        dbgln_if(TLS_DEBUG, "Dropping {} bytes worth of TLS records as max retries has been reached", write_buffer().size());
         write_buffer().clear();
         m_context.send_retries = 0;
     }

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -406,7 +406,7 @@ static ssize_t _parse_asn1(const Context& context, Certificate& cert, const u8* 
             hash.initialize(Crypto::Hash::HashKind::SHA512);
             break;
         default:
-            dbgln<TLS_DEBUG>("Unsupported hash mode {}", (u32)cert.key_algorithm);
+            dbgln_if(TLS_DEBUG, "Unsupported hash mode {}", (u32)cert.key_algorithm);
             // fallback to md5, it will fail later
             hash.initialize(Crypto::Hash::HashKind::MD5);
             break;
@@ -436,7 +436,7 @@ Optional<Certificate> TLSv12::parse_asn1(ReadonlyBytes buffer, bool) const
 
     _parse_asn1(m_context, cert, buffer.data(), buffer.size(), 1, fields, nullptr, 0, nullptr, nullptr);
 
-    dbgln<TLS_DEBUG>("Certificate issued for {} by {}", cert.subject, cert.issuer_subject);
+    dbgln_if(TLS_DEBUG, "Certificate issued for {} by {}", cert.subject, cert.issuer_subject);
 
     return cert;
 }
@@ -454,7 +454,7 @@ ssize_t TLSv12::handle_certificate(ReadonlyBytes buffer)
 
     u32 certificate_total_length = buffer[0] * 0x10000 + buffer[1] * 0x100 + buffer[2];
 
-    dbgln<TLS_DEBUG>("total length: {}", certificate_total_length);
+    dbgln_if(TLS_DEBUG, "total length: {}", certificate_total_length);
 
     if (certificate_total_length <= 4)
         return 3 * certificate_total_length;
@@ -549,7 +549,7 @@ void TLSv12::consume(ReadonlyBytes record)
         return;
     }
 
-    dbgln<TLS_DEBUG>("Consuming {} bytes", record.size());
+    dbgln_if(TLS_DEBUG, "Consuming {} bytes", record.size());
 
     m_context.message_buffer.append(record.data(), record.size());
 
@@ -559,12 +559,12 @@ void TLSv12::consume(ReadonlyBytes record)
     size_t size_offset { 3 }; // read the common record header
     size_t header_size { 5 };
 
-    dbgln<TLS_DEBUG>("message buffer length {}", buffer_length);
+    dbgln_if(TLS_DEBUG, "message buffer length {}", buffer_length);
 
     while (buffer_length >= 5) {
         auto length = AK::convert_between_host_and_network_endian(*(u16*)m_context.message_buffer.offset_pointer(index + size_offset)) + header_size;
         if (length > buffer_length) {
-            dbgln<TLS_DEBUG>("Need more data: {} > {}", length, buffer_length);
+            dbgln_if(TLS_DEBUG, "Need more data: {} > {}", length, buffer_length);
             break;
         }
         auto consumed = handle_message(m_context.message_buffer.bytes().slice(index, length));

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -85,9 +85,9 @@ void HTMLScriptElement::execute_script()
             document().set_current_script({}, nullptr);
 
         if (m_from_an_external_file)
-            dbgln<HTML_SCRIPT_DEBUG>("HTMLScriptElement: Running script {}", attribute(HTML::AttributeNames::src));
+            dbgln_if(HTML_SCRIPT_DEBUG, "HTMLScriptElement: Running script {}", attribute(HTML::AttributeNames::src));
         else
-            dbgln<HTML_SCRIPT_DEBUG>("HTMLScriptElement: Running inline script");
+            dbgln_if(HTML_SCRIPT_DEBUG, "HTMLScriptElement: Running inline script");
 
         document().run_javascript(m_script_source);
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLDocumentParser.cpp
@@ -141,7 +141,7 @@ void HTMLDocumentParser::run(const URL& url)
             break;
         auto& token = optional_token.value();
 
-        dbgln<PARSER_DEBUG>("[{}] {}", insertion_mode_name(), token.to_string());
+        dbgln_if(PARSER_DEBUG, "[{}] {}", insertion_mode_name(), token.to_string());
 
         // FIXME: If the adjusted current node is a MathML text integration point and the token is a start tag whose tag name is neither "mglyph" nor "malignmark"
         // FIXME: If the adjusted current node is a MathML text integration point and the token is a character token
@@ -157,7 +157,7 @@ void HTMLDocumentParser::run(const URL& url)
         }
 
         if (m_stop_parsing) {
-            dbgln<PARSER_DEBUG>("Stop parsing{}! :^)", m_parsing_fragment ? " fragment" : "");
+            dbgln_if(PARSER_DEBUG, "Stop parsing{}! :^)", m_parsing_fragment ? " fragment" : "");
             break;
         }
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -221,7 +221,7 @@ Optional<u32> HTMLTokenizer::next_code_point()
         return {};
     m_prev_utf8_iterator = m_utf8_iterator;
     ++m_utf8_iterator;
-    dbgln<TOKENIZER_TRACE_DEBUG>("(Tokenizer) Next code_point: {}", (char)*m_prev_utf8_iterator);
+    dbgln_if(TOKENIZER_TRACE_DEBUG, "(Tokenizer) Next code_point: {}", (char)*m_prev_utf8_iterator);
     return *m_prev_utf8_iterator;
 }
 
@@ -2618,17 +2618,17 @@ HTMLTokenizer::HTMLTokenizer(const StringView& input, const String& encoding)
 
 void HTMLTokenizer::will_switch_to([[maybe_unused]] State new_state)
 {
-    dbgln<TOKENIZER_TRACE_DEBUG>("[{}] Switch to {}", state_name(m_state), state_name(new_state));
+    dbgln_if(TOKENIZER_TRACE_DEBUG, "[{}] Switch to {}", state_name(m_state), state_name(new_state));
 }
 
 void HTMLTokenizer::will_reconsume_in([[maybe_unused]] State new_state)
 {
-    dbgln<TOKENIZER_TRACE_DEBUG>("[{}] Reconsume in {}", state_name(m_state), state_name(new_state));
+    dbgln_if(TOKENIZER_TRACE_DEBUG, "[{}] Reconsume in {}", state_name(m_state), state_name(new_state));
 }
 
 void HTMLTokenizer::switch_to(Badge<HTMLDocumentParser>, State new_state)
 {
-    dbgln<TOKENIZER_TRACE_DEBUG>("[{}] Parser switches tokenizer state to {}", state_name(m_state), state_name(new_state));
+    dbgln_if(TOKENIZER_TRACE_DEBUG, "[{}] Parser switches tokenizer state to {}", state_name(m_state), state_name(new_state));
     m_state = new_state;
 }
 

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -100,7 +100,7 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, const HashMap
         m_encoding = encoding_from_content_type(content_type.value());
         m_mime_type = mime_type_from_content_type(content_type.value());
     } else if (url().protocol() == "data" && !url().data_mime_type().is_empty()) {
-        dbgln<RESOURCE_DEBUG>("This is a data URL with mime-type _{}_", url().data_mime_type());
+        dbgln_if(RESOURCE_DEBUG, "This is a data URL with mime-type _{}_", url().data_mime_type());
         m_encoding = "utf-8"; // FIXME: This doesn't seem nice.
         m_mime_type = url().data_mime_type();
     } else {

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -86,7 +86,7 @@ RefPtr<Resource> ResourceLoader::load_resource(Resource::Type type, const LoadRe
             if (it->value->type() != type) {
                 dbgln("FIXME: Not using cached resource for {} since there's a type mismatch.", request.url());
             } else {
-                dbgln<CACHE_DEBUG>("Reusing cached resource for: {}", request.url());
+                dbgln_if(CACHE_DEBUG, "Reusing cached resource for: {}", request.url());
                 return it->value;
             }
         }

--- a/Userland/Libraries/LibWeb/WebContentClient.cpp
+++ b/Userland/Libraries/LibWeb/WebContentClient.cpp
@@ -60,7 +60,7 @@ void WebContentClient::handle([[maybe_unused]] const Messages::WebContentClient:
 
 void WebContentClient::handle(const Messages::WebContentClient::DidInvalidateContentRect& message)
 {
-    dbgln<SPAM_DEBUG>("handle: WebContentClient::DidInvalidateContentRect! content_rect={}", message.content_rect());
+    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidInvalidateContentRect! content_rect={}", message.content_rect());
 
     // FIXME: Figure out a way to coalesce these messages to reduce unnecessary painting
     m_view.notify_server_did_invalidate_content_rect({}, message.content_rect());
@@ -76,25 +76,25 @@ void WebContentClient::handle(const Messages::WebContentClient::DidChangeSelecti
 
 void WebContentClient::handle(const Messages::WebContentClient::DidLayout& message)
 {
-    dbgln<SPAM_DEBUG>("handle: WebContentClient::DidLayout! content_size={}", message.content_size());
+    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidLayout! content_size={}", message.content_size());
     m_view.notify_server_did_layout({}, message.content_size());
 }
 
 void WebContentClient::handle(const Messages::WebContentClient::DidChangeTitle& message)
 {
-    dbgln<SPAM_DEBUG>("handle: WebContentClient::DidChangeTitle! title={}", message.title());
+    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidChangeTitle! title={}", message.title());
     m_view.notify_server_did_change_title({}, message.title());
 }
 
 void WebContentClient::handle(const Messages::WebContentClient::DidRequestScrollIntoView& message)
 {
-    dbgln<SPAM_DEBUG>("handle: WebContentClient::DidRequestScrollIntoView! rect={}", message.rect());
+    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidRequestScrollIntoView! rect={}", message.rect());
     m_view.notify_server_did_request_scroll_into_view({}, message.rect());
 }
 
 void WebContentClient::handle(const Messages::WebContentClient::DidHoverLink& message)
 {
-    dbgln<SPAM_DEBUG>("handle: WebContentClient::DidHoverLink! url={}", message.url());
+    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidHoverLink! url={}", message.url());
     m_view.notify_server_did_hover_link({}, message.url());
 }
 

--- a/Userland/Services/DHCPClient/DHCPv4.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4.cpp
@@ -44,7 +44,7 @@ ParsedDHCPv4Options DHCPv4Packet::parse_options() const
                 dbgln("Bogus option length {} assuming forgotten END", length);
                 break;
             }
-            dbgln<DHCPV4_DEBUG>("DHCP Option {} with length {}", (u8)opt_name, length);
+            dbgln_if(DHCPV4_DEBUG, "DHCP Option {} with length {}", (u8)opt_name, length);
             ++index;
             options.options.set(opt_name, { length, &m_options[index] });
             index += length - 1;

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -207,7 +207,7 @@ void DHCPv4Client::process_incoming(const DHCPv4Packet& packet)
 {
     auto options = packet.parse_options();
 
-    dbgln<DHCPV4CLIENT_DEBUG>("Here are the options: {}", options.to_string());
+    dbgln_if(DHCPV4CLIENT_DEBUG, "Here are the options: {}", options.to_string());
 
     auto value = options.get<DHCPMessageType>(DHCPOption::DHCPMessageType).value();
     switch (value) {

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -115,7 +115,7 @@ void Service::setup_notifier()
 
 void Service::handle_socket_connection()
 {
-    dbgln<SERVICE_DEBUG>("Ready to read on behalf of {}", name());
+    dbgln_if(SERVICE_DEBUG, "Ready to read on behalf of {}", name());
 
     if (m_accept_socket_connections) {
         int accepted_fd = accept(m_socket_fd, nullptr, nullptr);
@@ -144,7 +144,7 @@ void Service::activate()
 
 void Service::spawn(int socket_fd)
 {
-    dbgln<SERVICE_DEBUG>("Spawning {}", name());
+    dbgln_if(SERVICE_DEBUG, "Spawning {}", name());
 
     m_run_timer.start();
     pid_t pid = fork();

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -54,7 +54,7 @@ static void sigchld_handler(int)
         if (pid == 0)
             break;
 
-        dbgln<SYSTEMSERVER_DEBUG>("Reaped child with pid {}, exit status {}", pid, status);
+        dbgln_if(SYSTEMSERVER_DEBUG, "Reaped child with pid {}, exit status {}", pid, status);
 
         Service* service = Service::find_by_pid(pid);
         if (service == nullptr) {

--- a/Userland/Services/WebContent/ClientConnection.cpp
+++ b/Userland/Services/WebContent/ClientConnection.cpp
@@ -87,7 +87,7 @@ void ClientConnection::handle(const Messages::WebContentServer::UpdateSystemThem
 
 void ClientConnection::handle(const Messages::WebContentServer::LoadURL& message)
 {
-    dbgln<SPAM_DEBUG>("handle: WebContentServer::LoadURL: url={}", message.url());
+    dbgln_if(SPAM_DEBUG, "handle: WebContentServer::LoadURL: url={}", message.url());
 
     String process_name;
     if (message.url().host().is_empty())
@@ -102,13 +102,13 @@ void ClientConnection::handle(const Messages::WebContentServer::LoadURL& message
 
 void ClientConnection::handle(const Messages::WebContentServer::LoadHTML& message)
 {
-    dbgln<SPAM_DEBUG>("handle: WebContentServer::LoadHTML: html={}, url={}", message.html(), message.url());
+    dbgln_if(SPAM_DEBUG, "handle: WebContentServer::LoadHTML: html={}, url={}", message.html(), message.url());
     page().load_html(message.html(), message.url());
 }
 
 void ClientConnection::handle(const Messages::WebContentServer::SetViewportRect& message)
 {
-    dbgln<SPAM_DEBUG>("handle: WebContentServer::SetViewportRect: rect={}", message.rect());
+    dbgln_if(SPAM_DEBUG, "handle: WebContentServer::SetViewportRect: rect={}", message.rect());
     m_page_host->set_viewport_rect(message.rect());
 }
 

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -215,7 +215,7 @@ void Compositor::compose()
     };
 
     auto prepare_rect = [&](const Gfx::IntRect& rect) {
-        dbgln<COMPOSE_DEBUG>("    -> flush opaque: {}", rect);
+        dbgln_if(COMPOSE_DEBUG, "    -> flush opaque: {}", rect);
         ASSERT(!flush_rects.intersects(rect));
         ASSERT(!flush_transparent_rects.intersects(rect));
         flush_rects.add(rect);
@@ -223,7 +223,7 @@ void Compositor::compose()
     };
 
     auto prepare_transparency_rect = [&](const Gfx::IntRect& rect) {
-        dbgln<COMPOSE_DEBUG>("   -> flush transparent: {}", rect);
+        dbgln_if(COMPOSE_DEBUG, "   -> flush transparent: {}", rect);
         ASSERT(!flush_rects.intersects(rect));
         bool have_rect = false;
         for (auto& r : flush_transparent_rects.rects()) {
@@ -270,7 +270,7 @@ void Compositor::compose()
     };
 
     m_opaque_wallpaper_rects.for_each_intersected(dirty_screen_rects, [&](const Gfx::IntRect& render_rect) {
-        dbgln<COMPOSE_DEBUG>("  render wallpaper opaque: {}", render_rect);
+        dbgln_if(COMPOSE_DEBUG, "  render wallpaper opaque: {}", render_rect);
         prepare_rect(render_rect);
         paint_wallpaper(back_painter, render_rect);
         return IterationDecision::Continue;
@@ -282,7 +282,7 @@ void Compositor::compose()
             return IterationDecision::Continue;
         auto frame_rects = frame_rect.shatter(window.rect());
 
-        dbgln<COMPOSE_DEBUG>("  window {} frame rect: {}", window.title(), frame_rect);
+        dbgln_if(COMPOSE_DEBUG, "  window {} frame rect: {}", window.title(), frame_rect);
 
         RefPtr<Gfx::Bitmap> backing_store = window.backing_store();
         auto compose_window_rect = [&](Gfx::Painter& painter, const Gfx::IntRect& rect) {
@@ -291,7 +291,7 @@ void Compositor::compose()
                     // TODO: Should optimize this to use a backing buffer
                     Gfx::PainterStateSaver saver(painter);
                     painter.add_clip_rect(intersected_rect);
-                    dbgln<COMPOSE_DEBUG>("    render frame: {}", intersected_rect);
+                    dbgln_if(COMPOSE_DEBUG, "    render frame: {}", intersected_rect);
                     window.frame().paint(painter);
                     return IterationDecision::Continue;
                 });
@@ -373,7 +373,7 @@ void Compositor::compose()
         auto& opaque_rects = window.opaque_rects();
         if (!opaque_rects.is_empty()) {
             opaque_rects.for_each_intersected(dirty_rects, [&](const Gfx::IntRect& render_rect) {
-                dbgln<COMPOSE_DEBUG>("    render opaque: {}", render_rect);
+                dbgln_if(COMPOSE_DEBUG, "    render opaque: {}", render_rect);
 
                 prepare_rect(render_rect);
                 Gfx::PainterStateSaver saver(back_painter);
@@ -388,7 +388,7 @@ void Compositor::compose()
         auto& transparency_wallpaper_rects = window.transparency_wallpaper_rects();
         if (!transparency_wallpaper_rects.is_empty()) {
             transparency_wallpaper_rects.for_each_intersected(dirty_rects, [&](const Gfx::IntRect& render_rect) {
-                dbgln<COMPOSE_DEBUG>("    render wallpaper: {}", render_rect);
+                dbgln_if(COMPOSE_DEBUG, "    render wallpaper: {}", render_rect);
 
                 prepare_transparency_rect(render_rect);
                 paint_wallpaper(temp_painter, render_rect);
@@ -398,7 +398,7 @@ void Compositor::compose()
         auto& transparency_rects = window.transparency_rects();
         if (!transparency_rects.is_empty()) {
             transparency_rects.for_each_intersected(dirty_rects, [&](const Gfx::IntRect& render_rect) {
-                dbgln<COMPOSE_DEBUG>("    render transparent: {}", render_rect);
+                dbgln_if(COMPOSE_DEBUG, "    render transparent: {}", render_rect);
 
                 prepare_transparency_rect(render_rect);
                 Gfx::PainterStateSaver saver(temp_painter);
@@ -671,7 +671,7 @@ void Compositor::run_animations(Gfx::DisjointRectSet& flush_rects)
                 from_rect.height() - (int)(height_delta_per_step * animation_index)
             };
 
-            dbgln<MINIMIZE_ANIMATION_DEBUG>("Minimize animation from {} to {} frame# {} {}", from_rect, to_rect, animation_index, rect);
+            dbgln_if(MINIMIZE_ANIMATION_DEBUG, "Minimize animation from {} to {} frame# {} {}", from_rect, to_rect, animation_index, rect);
 
             painter.draw_rect(rect, Color::Transparent); // Color doesn't matter, we draw inverted
             flush_rects.add(rect);

--- a/Userland/Services/WindowServer/MenuManager.cpp
+++ b/Userland/Services/WindowServer/MenuManager.cpp
@@ -466,7 +466,7 @@ void MenuManager::set_current_menubar(MenuBar* menubar)
     else
         m_current_menubar = nullptr;
 
-    dbgln<MENUS_DEBUG>("[WM] Current menubar is now {}", menubar);
+    dbgln_if(MENUS_DEBUG, "[WM] Current menubar is now {}", menubar);
 
     Gfx::IntPoint next_menu_location { MenuManager::menubar_menu_margin() / 2, 0 };
     for_each_active_menubar_menu([&](Menu& menu) {

--- a/Userland/Services/WindowServer/Screen.cpp
+++ b/Userland/Services/WindowServer/Screen.cpp
@@ -82,7 +82,7 @@ bool Screen::set_resolution(int width, int height, int new_scale_factor)
 
     FBResolution physical_resolution { 0, (unsigned)new_physical_width, (unsigned)new_physical_height };
     int rc = fb_set_resolution(m_framebuffer_fd, &physical_resolution);
-    dbgln<WSSCREEN_DEBUG>("fb_set_resolution() - return code {}", rc);
+    dbgln_if(WSSCREEN_DEBUG, "fb_set_resolution() - return code {}", rc);
 
     if (rc == 0) {
         on_change_resolution(physical_resolution.pitch, physical_resolution.width, physical_resolution.height, new_scale_factor);

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -343,7 +343,7 @@ void WindowManager::notify_title_changed(Window& window)
     if (window.type() != WindowType::Normal)
         return;
 
-    dbgln<WINDOWMANAGER_DEBUG>("[WM] Window({}) title set to '{}'", &window, window.title());
+    dbgln_if(WINDOWMANAGER_DEBUG, "[WM] Window({}) title set to '{}'", &window, window.title());
 
     if (m_switcher.is_visible())
         m_switcher.refresh();
@@ -356,7 +356,7 @@ void WindowManager::notify_modal_unparented(Window& window)
     if (window.type() != WindowType::Normal)
         return;
 
-    dbgln<WINDOWMANAGER_DEBUG>("[WM] Window({}) was unparented", &window);
+    dbgln_if(WINDOWMANAGER_DEBUG, "[WM] Window({}) was unparented", &window);
 
     if (m_switcher.is_visible())
         m_switcher.refresh();
@@ -366,7 +366,7 @@ void WindowManager::notify_modal_unparented(Window& window)
 
 void WindowManager::notify_rect_changed(Window& window, const Gfx::IntRect& old_rect, const Gfx::IntRect& new_rect)
 {
-    dbgln<RESIZE_DEBUG>("[WM] Window({}) rect changed {} -> {}", &window, old_rect, new_rect);
+    dbgln_if(RESIZE_DEBUG, "[WM] Window({}) rect changed {} -> {}", &window, old_rect, new_rect);
 
     if (m_switcher.is_visible() && window.type() != WindowType::WindowSwitcher)
         m_switcher.refresh();
@@ -431,7 +431,7 @@ bool WindowManager::pick_new_active_window(Window* previous_active)
 
 void WindowManager::start_window_move(Window& window, const MouseEvent& event)
 {
-    dbgln<MOVE_DEBUG>("[WM] Begin moving Window({})", &window);
+    dbgln_if(MOVE_DEBUG, "[WM] Begin moving Window({})", &window);
 
     move_to_front_and_make_active(window);
     m_move_window = window;
@@ -464,7 +464,7 @@ void WindowManager::start_window_resize(Window& window, const Gfx::IntPoint& pos
         return;
     }
 
-    dbgln<RESIZE_DEBUG>("[WM] Begin resizing Window({})", &window);
+    dbgln_if(RESIZE_DEBUG, "[WM] Begin resizing Window({})", &window);
 
     m_resizing_mouse_button = button;
     m_resize_window = window;
@@ -491,7 +491,7 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event, Window*& hove
         return false;
     if (event.type() == Event::MouseUp && event.button() == MouseButton::Left) {
 
-        dbgln<MOVE_DEBUG>("[WM] Finish moving Window({})", m_move_window);
+        dbgln_if(MOVE_DEBUG, "[WM] Finish moving Window({})", m_move_window);
 
         m_move_window->invalidate();
         if (m_move_window->rect().contains(event.position()))
@@ -577,7 +577,7 @@ bool WindowManager::process_ongoing_window_resize(const MouseEvent& event, Windo
         return false;
 
     if (event.type() == Event::MouseUp && event.button() == m_resizing_mouse_button) {
-        dbgln<RESIZE_DEBUG>("[WM] Finish resizing Window({})", m_resize_window);
+        dbgln_if(RESIZE_DEBUG, "[WM] Finish resizing Window({})", m_resize_window);
 
         Core::EventLoop::current().post_event(*m_resize_window, make<ResizeEvent>(m_resize_window->rect()));
         m_resize_window->invalidate();
@@ -684,7 +684,7 @@ bool WindowManager::process_ongoing_window_resize(const MouseEvent& event, Windo
     if (m_resize_window->rect() == new_rect)
         return true;
 
-    dbgln<RESIZE_DEBUG>("[WM] Resizing, original: {}, now: {}", m_resize_window_original_rect, new_rect);
+    dbgln_if(RESIZE_DEBUG, "[WM] Resizing, original: {}, now: {}", m_resize_window_original_rect, new_rect);
 
     m_resize_window->set_rect(new_rect);
     Core::EventLoop::current().post_event(*m_resize_window, make<ResizeEvent>(new_rect));
@@ -806,7 +806,7 @@ void WindowManager::start_menu_doubleclick(Window& window, const MouseEvent& eve
         // we either haven't clicked anywhere, or we haven't clicked on this
         // window. set the current click window, and reset the timers.
 
-        dbgln<DOUBLECLICK_DEBUG>("Initial mousedown on Window({}) for menus (previous was {})", &window, m_double_click_info.m_clicked_window);
+        dbgln_if(DOUBLECLICK_DEBUG, "Initial mousedown on Window({}) for menus (previous was {})", &window, m_double_click_info.m_clicked_window);
 
         m_double_click_info.m_clicked_window = window;
         m_double_click_info.reset();
@@ -838,7 +838,7 @@ void WindowManager::process_event_for_doubleclick(Window& window, MouseEvent& ev
     if (&window != m_double_click_info.m_clicked_window) {
         // we either haven't clicked anywhere, or we haven't clicked on this
         // window. set the current click window, and reset the timers.
-        dbgln<DOUBLECLICK_DEBUG>("Initial mouseup on Window({}) for menus (previous was {})", &window, m_double_click_info.m_clicked_window);
+        dbgln_if(DOUBLECLICK_DEBUG, "Initial mouseup on Window({}) for menus (previous was {})", &window, m_double_click_info.m_clicked_window);
 
         m_double_click_info.m_clicked_window = window;
         m_double_click_info.reset();
@@ -853,7 +853,7 @@ void WindowManager::process_event_for_doubleclick(Window& window, MouseEvent& ev
         // clock
         metadata.clock.start();
     } else {
-        dbgln<DOUBLECLICK_DEBUG>("Transforming MouseUp to MouseDoubleClick ({} < {})!", metadata.clock.elapsed(), m_double_click_speed);
+        dbgln_if(DOUBLECLICK_DEBUG, "Transforming MouseUp to MouseDoubleClick ({} < {})!", metadata.clock.elapsed(), m_double_click_speed);
 
         event = MouseEvent(Event::MouseDoubleClick, event.position(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
         // invalidate this now we've delivered a doubleclick, otherwise


### PR DESCRIPTION
This is still _very_ WIP.
it's also fairly invasive, I think a better option would be to provide a macro `dbgln(fmt, ...)` -> `dbgln_helper<fmt>(...)` - but that would interfere with the `enabled` thing we currently have.

This caught two bugs as-is, but it seems to have a pretty big impact on compile time.