### PR TITLE
LibGfx: Make Painter take the scale factor as constructor argument

### DIFF
--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -60,11 +60,10 @@ Canvas::Canvas()
     m_bitmap_1x = Gfx::Bitmap::create(Gfx::BitmapFormat::RGB32, { WIDTH, HEIGHT });
     m_bitmap_2x = Gfx::Bitmap::create(Gfx::BitmapFormat::RGB32, { WIDTH * 2, HEIGHT * 2 });
 
-    Gfx::Painter painter_1x(*m_bitmap_1x);
+    Gfx::Painter painter_1x(*m_bitmap_1x, 1);
     draw(painter_1x);
 
-    Gfx::Painter painter_2x(*m_bitmap_2x);
-    painter_2x.scale(2);
+    Gfx::Painter painter_2x(*m_bitmap_2x, 2);
     draw(painter_2x);
 
     update();

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -68,13 +68,16 @@ ALWAYS_INLINE Color get_pixel(const Gfx::Bitmap& bitmap, int x, int y)
     return bitmap.get_pixel(x, y);
 }
 
-Painter::Painter(Gfx::Bitmap& bitmap)
+Painter::Painter(Gfx::Bitmap& bitmap, int scale)
     : m_target(bitmap)
 {
     ASSERT(bitmap.format() == Gfx::BitmapFormat::RGB32 || bitmap.format() == Gfx::BitmapFormat::RGBA32);
+    ASSERT(bitmap.width() % scale == 0);
+    ASSERT(bitmap.height() % scale == 0);
     m_state_stack.append(State());
     state().font = &FontDatabase::default_font();
     state().clip_rect = { { 0, 0 }, bitmap.size() };
+    state().scale = scale;
     m_clip_origin = state().clip_rect;
 }
 

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -41,7 +41,7 @@ namespace Gfx {
 
 class Painter {
 public:
-    explicit Painter(Gfx::Bitmap&);
+    explicit Painter(Gfx::Bitmap&, int scale = 1);
     ~Painter();
 
     enum class LineStyle {
@@ -119,7 +119,6 @@ public:
 
     void translate(int dx, int dy) { translate({ dx, dy }); }
     void translate(const IntPoint& delta) { state().translation.move_by(delta * state().scale); }
-    void scale(int s) { state().scale *= s; }
 
     Gfx::Bitmap* target() { return m_target.ptr(); }
 

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -95,19 +95,16 @@ void Compositor::init_bitmaps()
     auto physical_size = screen.physical_size();
 
     m_front_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::RGB32, physical_size, screen.pitch(), screen.scanline(0));
-    m_front_painter = make<Gfx::Painter>(*m_front_bitmap);
-    m_front_painter->scale(screen.scale_factor());
+    m_front_painter = make<Gfx::Painter>(*m_front_bitmap, screen.scale_factor());
 
     if (m_screen_can_set_buffer)
         m_back_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::RGB32, physical_size, screen.pitch(), screen.scanline(physical_size.height()));
     else
         m_back_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::RGB32, physical_size);
-    m_back_painter = make<Gfx::Painter>(*m_back_bitmap);
-    m_back_painter->scale(screen.scale_factor());
+    m_back_painter = make<Gfx::Painter>(*m_back_bitmap, screen.scale_factor());
 
     m_temp_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::RGB32, physical_size);
-    m_temp_painter = make<Gfx::Painter>(*m_temp_bitmap);
-    m_temp_painter->scale(screen.scale_factor());
+    m_temp_painter = make<Gfx::Painter>(*m_temp_bitmap, screen.scale_factor());
 
     m_buffers_are_flipped = false;
 
@@ -456,7 +453,7 @@ void Compositor::compose()
         {
             // FIXME: Give Bitmap an intrinsic scale factor and make Painter::blit() do the right thing if both it and the passed bitmap have scale factors:
             // If a 2x scaled bitmap is blitted on a 2x scaled painter, it should be blitted without scale.
-            Gfx::Painter unscaled_back_painter(*m_back_bitmap);
+            Gfx::Painter unscaled_back_painter(*m_back_bitmap, 1);
             auto scale = Screen::the().scale_factor();
             for (auto& rect : flush_transparent_rects.rects())
                 unscaled_back_painter.blit(rect.location() * scale, *m_temp_bitmap, rect * scale);
@@ -825,7 +822,7 @@ void Compositor::restore_cursor_back()
 
     // FIXME: Give Bitmap an intrinsic scale factor and make Painter::blit() do the right thing if both it and the passed bitmap have scale factors:
     // If a 2x scaled bitmap is blitted on a 2x scaled painter, it should be blitted without scale.
-    Gfx::Painter unscaled_back_painter(*m_back_bitmap);
+    Gfx::Painter unscaled_back_painter(*m_back_bitmap, 1);
     auto last_physical_cursor_rect = (m_last_cursor_rect * Screen::the().scale_factor()).intersected(Screen::the().physical_rect());
     unscaled_back_painter.blit(last_physical_cursor_rect.location(), *m_cursor_back_bitmap, { { 0, 0 }, last_physical_cursor_rect.size() });
 }


### PR DESCRIPTION
I want to give Bitmap an intrinsic scale factor and this is a step
in that direction.

No behavior change.