### PR TITLE
Vim: Added a Basic Implementation of Visual Mode

### DIFF
--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -32,7 +32,7 @@ namespace GUI {
 
 CursorWidth VimEditingEngine::cursor_width() const
 {
-    return m_vim_mode == VimMode::Normal ? CursorWidth::WIDE : CursorWidth::NARROW;
+    return m_vim_mode == VimMode::Insert ? CursorWidth::NARROW : CursorWidth::WIDE;
 }
 
 bool VimEditingEngine::on_key(const KeyEvent& event)
@@ -43,6 +43,8 @@ bool VimEditingEngine::on_key(const KeyEvent& event)
     switch (m_vim_mode) {
     case (VimMode::Insert):
         return on_key_in_insert_mode(event);
+    case (VimMode::Visual):
+        return on_key_in_visual_mode(event);
     case (VimMode::Normal):
         return on_key_in_normal_mode(event);
     default:
@@ -180,6 +182,138 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
             case (KeyCode::Key_0):
                 move_to_line_beginning(event);
                 break;
+            case (KeyCode::Key_V):
+                switch_to_visual_mode();
+                break;
+            case (KeyCode::Key_C):
+                m_editor->do_delete();
+                switch_to_insert_mode();
+                break;
+            default:
+                break;
+            }
+        }
+    }
+    return true;
+}
+
+bool VimEditingEngine::on_key_in_visual_mode(const KeyEvent& event)
+{
+    if (m_previous_key == KeyCode::Key_G) {
+        if (event.key() == KeyCode::Key_G) {
+            move_to_first_line();
+            update_selection_on_cursor_move();
+        }
+        m_previous_key = {};
+    } else {
+        // Handle first any key codes that are to be applied regardless of modifiers.
+        switch (event.key()) {
+        case (KeyCode::Key_Dollar):
+            move_to_line_end(event);
+            update_selection_on_cursor_move();
+            break;
+        case (KeyCode::Key_Escape):
+            switch_to_normal_mode();
+            if (m_editor->on_escape_pressed)
+                m_editor->on_escape_pressed();
+            break;
+        default:
+            break;
+        }
+
+        // SHIFT is pressed.
+        if (event.shift() && !event.ctrl() && !event.alt()) {
+            switch (event.key()) {
+            case (KeyCode::Key_A):
+                move_to_line_end(event);
+                switch_to_insert_mode();
+                break;
+            case (KeyCode::Key_G):
+                move_to_last_line();
+                break;
+            case (KeyCode::Key_I):
+                move_to_line_beginning(event);
+                switch_to_insert_mode();
+                break;
+            default:
+                break;
+            }
+        }
+
+        // CTRL is pressed.
+        if (event.ctrl() && !event.shift() && !event.alt()) {
+            switch (event.key()) {
+            case (KeyCode::Key_D):
+                move_half_page_down(event);
+                update_selection_on_cursor_move();
+                break;
+            case (KeyCode::Key_U):
+                move_half_page_up(event);
+                update_selection_on_cursor_move();
+                break;
+            default:
+                break;
+            }
+        }
+
+        // No modifier is pressed.
+        if (!event.ctrl() && !event.shift() && !event.alt()) {
+            switch (event.key()) {
+            case (KeyCode::Key_B):
+                move_to_previous_span(event); // FIXME: This probably isn't 100% correct.
+                update_selection_on_cursor_move();
+                break;
+            case (KeyCode::Key_Backspace):
+            case (KeyCode::Key_H):
+            case (KeyCode::Key_Left):
+                move_one_left(event);
+                update_selection_on_cursor_move();
+                break;
+            case (KeyCode::Key_D):
+                // TODO: Yank selected text
+                m_editor->do_delete();
+                break;
+            case (KeyCode::Key_G):
+                m_previous_key = event.key();
+                break;
+            case (KeyCode::Key_Down):
+            case (KeyCode::Key_J):
+                move_one_down(event);
+                update_selection_on_cursor_move();
+                break;
+            case (KeyCode::Key_K):
+            case (KeyCode::Key_Up):
+                move_one_up(event);
+                update_selection_on_cursor_move();
+                break;
+            case (KeyCode::Key_L):
+            case (KeyCode::Key_Right):
+                move_one_right(event);
+                update_selection_on_cursor_move();
+                break;
+            case (KeyCode::Key_U):
+                // FIXME: Set selection to uppercase.
+                break;
+            case (KeyCode::Key_W):
+                move_to_next_span(event); // FIXME: This probably isn't 100% correct.
+                update_selection_on_cursor_move();
+                break;
+            case (KeyCode::Key_X):
+                // TODO: Yank selected text
+                m_editor->do_delete();
+                break;
+            case (KeyCode::Key_0):
+                move_to_line_beginning(event);
+                update_selection_on_cursor_move();
+                break;
+            case (KeyCode::Key_V):
+                switch_to_normal_mode();
+                break;
+            case (KeyCode::Key_C):
+                // TODO: Yank selected text
+                m_editor->do_delete();
+                switch_to_insert_mode();
+                break;
             default:
                 break;
             }
@@ -192,13 +326,46 @@ void VimEditingEngine::switch_to_normal_mode()
 {
     m_vim_mode = VimMode::Normal;
     m_editor->reset_cursor_blink();
+    m_previous_key = {};
+    clear_visual_mode_data();
 };
 
 void VimEditingEngine::switch_to_insert_mode()
 {
     m_vim_mode = VimMode::Insert;
     m_editor->reset_cursor_blink();
+    m_previous_key = {};
+    clear_visual_mode_data();
 };
+
+void VimEditingEngine::switch_to_visual_mode()
+{
+    m_vim_mode = VimMode::Visual;
+    m_editor->reset_cursor_blink();
+    m_previous_key = {};
+    m_selection_start_position = m_editor->cursor();
+    m_editor->selection()->set(m_editor->cursor(), { m_editor->cursor().line(), m_editor->cursor().column() + 1 });
+    m_editor->did_update_selection();
+}
+
+void VimEditingEngine::update_selection_on_cursor_move()
+{
+    auto cursor = m_editor->cursor();
+    auto start = m_selection_start_position < cursor ? m_selection_start_position : cursor;
+    auto end = m_selection_start_position < cursor ? cursor : m_selection_start_position;
+    end.set_column(end.column() + 1);
+    m_editor->selection()->set(start, end);
+    m_editor->did_update_selection();
+}
+
+void VimEditingEngine::clear_visual_mode_data()
+{
+    if (m_editor->has_selection()) {
+        m_editor->selection()->clear();
+        m_editor->did_update_selection();
+    }
+    m_selection_start_position = {};
+}
 
 void VimEditingEngine::move_half_page_up(const KeyEvent& event)
 {

--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -41,18 +41,25 @@ private:
     enum VimMode {
         Normal,
         Insert,
+        Visual
     };
 
     VimMode m_vim_mode { VimMode::Normal };
 
+    TextPosition m_selection_start_position {};
+    void update_selection_on_cursor_move();
+    void clear_visual_mode_data();
+
     KeyCode m_previous_key {};
     void switch_to_normal_mode();
     void switch_to_insert_mode();
+    void switch_to_visual_mode();
     void move_half_page_up(const KeyEvent& event);
     void move_half_page_down(const KeyEvent& event);
 
     bool on_key_in_insert_mode(const KeyEvent& event);
     bool on_key_in_normal_mode(const KeyEvent& event);
+    bool on_key_in_visual_mode(const KeyEvent& event);
 };
 
 }


### PR DESCRIPTION
This PR adds visual mode to the VimEditingEngine. Most of the work is done in the `on_key_in_visual_mode()` method which started as a copy of the `on_key_in_normal_mode()` method as most of the keys share the same function just slightly adjusted to add, edit or remove selected text.