### PR TITLE
LibELF: Remove unused m_global_symbol_lookup_func from DynamicObject

### DIFF
--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -288,8 +288,6 @@ public:
     Elf32_Addr patch_plt_entry(u32 relocation_offset);
 
     SymbolLookupResult lookup_symbol(const ELF::DynamicObject::Symbol& symbol) const;
-    using SymbolLookupFunction = DynamicObject::SymbolLookupResult (*)(const char*);
-    SymbolLookupFunction m_global_symbol_lookup_func { nullptr };
 
     bool elf_is_dynamic() const { return m_is_elf_dynamic; }
 


### PR DESCRIPTION
This was refactored in 3e815ad, leaving this unused member behind.