### PR TITLE
Boot: Fix undefined Multiboot behaviors

### DIFF
--- a/Kernel/Arch/i386/Boot/boot.S
+++ b/Kernel/Arch/i386/Boot/boot.S
@@ -194,10 +194,13 @@ start:
     orl $0x80000000, %eax
     movl %eax, %cr0
 
+    /* set up stack */
+    mov $stack_top, %esp
+    and $-16, %esp
+
     /* jmp to an address above the 3GB mark */
-    push %cs
-    push $1f 
-    retf
+    movl $1f,%eax
+    jmp *%eax
 1:
     movl %cr3, %eax
     movl %eax, %cr3
@@ -212,10 +215,7 @@ start:
     addl $8, %edi
     loop 1b
 
-    /* set up initial stack and jump into C++ land */
-    mov $stack_top, %esp
-    and $-16, %esp
-
+    /* jump into C++ land */
     addl $0xc0000000, %ebx
     movl %ebx, multiboot_info_ptr
 


### PR DESCRIPTION
Both ESP and GDTR are left undefined by the Multiboot specification and OS images must not rely on these values to be valid. Fix the undefined behaviors so that booting with PXELINUX does not triple-fault the CPU.

Specifically:
* The stack is used at https://github.com/SerenityOS/serenity/blob/master/Kernel/Arch/i386/Boot/boot.S#L197-L199, before the stack pointer is initialized at https://github.com/SerenityOS/serenity/blob/master/Kernel/Arch/i386/Boot/boot.S#L215-L217. Multiboot specification says ESP is undefined and the OS image must create its own stack.
* A far return is done at https://github.com/SerenityOS/serenity/blob/master/Kernel/Arch/i386/Boot/boot.S#L197-L200, which reloads CS. Multiboot specification says GDTR is undefined and the OS image must set up its own GDT.

By the way, modifying `Arch/i386/Boot/boot.S` does not seem to trigger a relink of the kernel with ninja. This PR does not fix that particular problem.