### PR TITLE
Meta: Get building on NixOS

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -57,6 +57,44 @@ sudo apt update
 
 Ensure your CMake version is >= 3.16 with `cmake --version`. If your system doesn't provide a suitable version of CMake, you can download a binary release from the [CMake website](https://cmake.org/download).
 
+**NixOS**
+
+You can use a `nix-shell` script like the following to set up the correct environment:
+
+myshell.nix:
+```
+with import <nixpkgs> {};
+
+stdenv.mkDerivation {
+  name = "cpp-env";
+  nativeBuildInputs = [
+    gcc10
+    curl
+    cmake
+    mpfr
+    ninja
+    gmp
+    libmpc
+    e2fsprogs
+    patch
+
+    # Example Build-time Additional Dependencies
+    pkgconfig
+  ];
+  buildInputs = [
+    # Example Run-time Additional Dependencies
+    openssl
+    x11
+    # glibc
+  ];
+  hardeningDisable = [ "format" "fortify" ];
+}
+```
+
+Then use this script: `nix-shell myshell.nix`.
+
+Once you're in nix-shell, you should be able to follow the build directions.
+
 #### macOS prerequisites
 Make sure you have all the dependencies installed:
 ```bash

--- a/Meta/check-ak-test-files.sh
+++ b/Meta/check-ak-test-files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/Meta/check-debug-flags.sh
+++ b/Meta/check-debug-flags.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/Meta/check-style.sh
+++ b/Meta/check-style.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path/.." || exit 1

--- a/Meta/generate-embedded-resource-assembly.sh
+++ b/Meta/generate-embedded-resource-assembly.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/Meta/lint-executable-resources.sh
+++ b/Meta/lint-executable-resources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/Meta/lint-ipc-ids.sh
+++ b/Meta/lint-ipc-ids.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/Meta/lint-missing-resources.sh
+++ b/Meta/lint-missing-resources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/Meta/lint-prettier.sh
+++ b/Meta/lint-prettier.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/Meta/lint-python.sh
+++ b/Meta/lint-python.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 SCRIPT=`dirname $0`

--- a/Ports/SDL2/package.sh
+++ b/Ports/SDL2/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=SDL2
 version=serenity-git
 workdir=SDL-master-serenity

--- a/Ports/bash/package.sh
+++ b/Ports/bash/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=bash
 version=5.0
 useconfigure=true

--- a/Ports/bc/package.sh
+++ b/Ports/bc/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=bc
 version=2.5.1
 files="https://github.com/gavinhoward/bc/releases/download/${version}/bc-${version}.tar.xz bc-${version}.tar.xz

--- a/Ports/binutils/package.sh
+++ b/Ports/binutils/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=binutils
 version=2.32
 useconfigure=true

--- a/Ports/build_all.sh
+++ b/Ports/build_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 clean=false
 case "$1" in

--- a/Ports/byacc/package.sh
+++ b/Ports/byacc/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=byacc
 version=20191125
 files="https://invisible-mirror.net/archives/byacc/byacc-${version}.tgz byacc-${version}.tgz

--- a/Ports/c-ray/package.sh
+++ b/Ports/c-ray/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=c-ray
 version=git
 workdir=c-ray-master

--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=curl
 version=7.65.3
 useconfigure=true

--- a/Ports/dash/package.sh
+++ b/Ports/dash/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=dash
 version=0.5.10.2
 useconfigure=true

--- a/Ports/diffutils/package.sh
+++ b/Ports/diffutils/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=diffutils
 version=3.5
 files="https://ftp.gnu.org/gnu/diffutils/diffutils-${version}.tar.xz diffutils-${version}.tar.xz

--- a/Ports/doom/package.sh
+++ b/Ports/doom/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=doom
 workdir=SerenityDOOM-master
 version=serenity-git

--- a/Ports/dropbear/package.sh
+++ b/Ports/dropbear/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=dropbear
 version=2019.78
 files="https://mirror.dropbear.nl/mirror/releases/dropbear-${version}.tar.bz2 dropbear-${version}.tar.bz2

--- a/Ports/ed/package.sh
+++ b/Ports/ed/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=ed
 version=1.15
 files="https://ftp.gnu.org/gnu/ed/ed-1.15.tar.lz ed-1.15.tar.lz"

--- a/Ports/editline/package.sh
+++ b/Ports/editline/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=editline
 version=1.17.1
 useconfigure=true

--- a/Ports/figlet/package.sh
+++ b/Ports/figlet/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=figlet
 version=2.2.5
 files="http://ftp.figlet.org/pub/figlet/program/unix/figlet-2.2.5.tar.gz figlet-2.2.5.tar.gz d88cb33a14f1469fff975d021ae2858e"

--- a/Ports/flex/package.sh
+++ b/Ports/flex/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=flex
 version=2.6.4
 files="https://github.com/westes/flex/releases/download/v${version}/flex-${version}.tar.gz flex-${version}.tar.gz

--- a/Ports/frotz/package.sh
+++ b/Ports/frotz/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=frotz
 version=git
 workdir=frotz-master

--- a/Ports/gcc/package.sh
+++ b/Ports/gcc/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=gcc
 version=10.2.0
 useconfigure=true

--- a/Ports/git/package.sh
+++ b/Ports/git/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=git
 version=2.26.0
 useconfigure="true"

--- a/Ports/gnuplot/package.sh
+++ b/Ports/gnuplot/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=gnuplot
 version=5.2.8
 useconfigure=true

--- a/Ports/grep/package.sh
+++ b/Ports/grep/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=grep
 version=2.5.4
 files="https://ftp.gnu.org/gnu/grep/grep-${version}.tar.gz grep-${version}.tar.gz

--- a/Ports/indent/package.sh
+++ b/Ports/indent/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=indent
 version=2.2.11
 files="https://ftp.gnu.org/gnu/indent/indent-${version}.tar.gz indent-${version}.tar.gz

--- a/Ports/jot/package.sh
+++ b/Ports/jot/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=jot
 version=6.6
 files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/jot-${version}.tar.gz jot-${version}.tar.gz"

--- a/Ports/jq/package.sh
+++ b/Ports/jq/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=jq
 version=1.6
 useconfigure=true

--- a/Ports/klong/package.sh
+++ b/Ports/klong/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=klong
 version=20190926
 files="http://t3x.org/klong/klong20190926.tgz klong20190926.tgz"

--- a/Ports/less/package.sh
+++ b/Ports/less/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=less
 version=530
 useconfigure="true"

--- a/Ports/libarchive/package.sh
+++ b/Ports/libarchive/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=libarchive
 version=3.4.0
 useconfigure=true

--- a/Ports/libexpat/package.sh
+++ b/Ports/libexpat/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=libexpat
 version=2.2.9
 useconfigure=true

--- a/Ports/libffi/package.sh
+++ b/Ports/libffi/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=libffi
 version=3.3
 useconfigure=true

--- a/Ports/libiconv/package.sh
+++ b/Ports/libiconv/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=libiconv
 version=1.16
 useconfigure=true

--- a/Ports/libpuffy/package.sh
+++ b/Ports/libpuffy/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=libpuffy
 version=1.0
 files="https://github.com/ibara/libpuffy/releases/download/libpuffy-${version}/libpuffy-${version}.tar.gz libpuffy-${version}.tar.gz"

--- a/Ports/links/package.sh
+++ b/Ports/links/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=links
 version=2.19
 useconfigure=true

--- a/Ports/lua/package.sh
+++ b/Ports/lua/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=lua
 version=5.3.5
 files="http://www.lua.org/ftp/lua-5.3.5.tar.gz lua-5.3.5.tar.gz 4f4b4f323fd3514a68e0ab3da8ce3455"

--- a/Ports/m4/package.sh
+++ b/Ports/m4/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=m4
 version=1.4.9
 useconfigure=true

--- a/Ports/make/package.sh
+++ b/Ports/make/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=make
 version=4.3
 useconfigure=true

--- a/Ports/mandoc/package.sh
+++ b/Ports/mandoc/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=mandoc
 version=1.14.5
 useconfigure=true

--- a/Ports/mawk/package.sh
+++ b/Ports/mawk/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=mawk
 version=1.3.4-20200120
 files="https://invisible-mirror.net/archives/mawk/mawk-${version}.tgz mawk-${version}.tgz

--- a/Ports/mbedtls/package.sh
+++ b/Ports/mbedtls/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=mbedtls
 version=2.16.2
 files="https://tls.mbed.org/download/mbedtls-${version}-apache.tgz mbedtls-${version}-apache.tgz ba809acfd4b41b86895b92e98d936695b5b62b73"

--- a/Ports/mrsh/package.sh
+++ b/Ports/mrsh/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=mrsh
 version=d9763a32e7da572677d1681bb1fc67f117d641f3
 files="https://codeload.github.com/emersion/mrsh/legacy.tar.gz/d9763a32e7da572677d1681bb1fc67f117d641f3 emersion-mrsh-d9763a3.tar.gz"

--- a/Ports/nano/package.sh
+++ b/Ports/nano/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=nano
 version=4.5
 useconfigure="true"

--- a/Ports/nasm/package.sh
+++ b/Ports/nasm/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=nasm
 version=2.14.02
 files="https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.gz nasm-2.14.02.tar.gz"

--- a/Ports/ncurses/package.sh
+++ b/Ports/ncurses/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=ncurses
 version=6.2
 useconfigure=true

--- a/Ports/neofetch/package.sh
+++ b/Ports/neofetch/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=neofetch
 version=7.0.0
 useconfigure=false

--- a/Ports/neofetch/patches/fix-shebang.patch
+++ b/Ports/neofetch/patches/fix-shebang.patch
@@ -2,7 +2,7 @@
 +++ neofetch-7.0.0/neofetch	2020-04-27 18:57:54.263417418 +0100
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env bash
-+#!/bin/bash
++#!/usr/bin/env bash
  # vim: noai:ts=4:sw=4:expandtab
  # shellcheck source=/dev/null
  # shellcheck disable=2009

--- a/Ports/nesalizer/package.sh
+++ b/Ports/nesalizer/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=nesalizer
 version=master
 makeopts="CONF=release"

--- a/Ports/ninja/package.sh
+++ b/Ports/ninja/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=ninja
 version=1.8.2
 workdir=ninja-1.8.2

--- a/Ports/nyancat/package.sh
+++ b/Ports/nyancat/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=nyancat
 version=git
 workdir=nyancat-master

--- a/Ports/openssh/package.sh
+++ b/Ports/openssh/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=openssh
 workdir=openssh-portable-9ca7e9c861775dd6c6312bc8aaab687403d24676
 version=8.3-9ca7e9c

--- a/Ports/openssl/package.sh
+++ b/Ports/openssl/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=openssl
 branch='1.0.2'
 version="${branch}t"

--- a/Ports/patch/package.sh
+++ b/Ports/patch/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=patch
 version=6.6
 files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/patch-${version}.tar.gz patch-${version}.tar.gz"

--- a/Ports/pcre2/package.sh
+++ b/Ports/pcre2/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=pcre2
 version=10.34
 useconfigure=true

--- a/Ports/pkgconf/package.sh
+++ b/Ports/pkgconf/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=pkgconf
 version=1.7.3
 files="https://distfiles.dereferenced.org/pkgconf/pkgconf-1.7.3.tar.xz pkgconf-1.7.3.tar.xz"

--- a/Ports/printf/package.sh
+++ b/Ports/printf/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=printf
 version=6.6
 files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/printf-${version}.tar.gz printf-${version}.tar.gz"

--- a/Ports/quake/package.sh
+++ b/Ports/quake/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=quake
 version=0.65
 workdir=SerenityQuake-master

--- a/Ports/rsync/package.sh
+++ b/Ports/rsync/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=rsync
 version=3.1.3
 useconfigure="true"

--- a/Ports/sed/package.sh
+++ b/Ports/sed/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=sed
 version=4.2.1
 useconfigure="true"

--- a/Ports/sl/package.sh
+++ b/Ports/sl/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=sl
 version=git
 workdir=sl-master

--- a/Ports/stress-ng/package.sh
+++ b/Ports/stress-ng/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=stress-ng
 version=0.11.23
 workdir=stress-ng-${version}

--- a/Ports/termcap/package.sh
+++ b/Ports/termcap/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=termcap
 version=1.3.1
 useconfigure=true

--- a/Ports/tinycc/package.sh
+++ b/Ports/tinycc/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=tinycc
 workdir=tinycc-dev
 version=dev

--- a/Ports/tr/package.sh
+++ b/Ports/tr/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=tr
 version=6.7
 files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/tr-${version}.tar.gz tr-${version}.tar.gz"

--- a/Ports/vim/package.sh
+++ b/Ports/vim/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=vim
 version=git
 workdir=vim-master

--- a/Ports/vttest/package.sh
+++ b/Ports/vttest/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=vttest
 version=20200610
 useconfigure=true

--- a/Ports/zlib/package.sh
+++ b/Ports/zlib/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=zlib
 version=1.2.11
 useconfigure=true

--- a/Ports/zstd/package.sh
+++ b/Ports/zstd/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash ../.port_include.sh
+#!/usr/bin/env -S bash ../.port_include.sh
 port=zstd
 version=1.4.4
 files="https://github.com/facebook/zstd/releases/download/v${version}/zstd-${version}.tar.gz zstd-${version}.tar.gz

--- a/Toolchain/BuildPython.sh
+++ b/Toolchain/BuildPython.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -e
 
 # This file will need to be run in bash, for now.

--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # This file will need to be run in bash, for now.

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -390,7 +390,7 @@ add_custom_target(generate_PropertyID.h DEPENDS CSS/PropertyID.h)
 
 add_custom_command(
     OUTPUT CSS/PropertyID.cpp
-    COMMAND /bin/mkdir -p CSS
+    COMMAND /usr/bin/env -S mkdir -p CSS
     COMMAND ${write_if_different} CSS/PropertyID.cpp CodeGenerators/Generate_CSS_PropertyID_cpp ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Properties.json
     VERBATIM
     DEPENDS Generate_CSS_PropertyID_cpp
@@ -408,7 +408,7 @@ add_custom_target(generate_ValueID.h DEPENDS CSS/ValueID.h)
 
 add_custom_command(
     OUTPUT CSS/ValueID.cpp
-    COMMAND /bin/mkdir -p CSS
+    COMMAND /usr/bin/env -S mkdir -p CSS
     COMMAND ${write_if_different} CSS/ValueID.cpp CodeGenerators/Generate_CSS_ValueID_cpp ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Identifiers.json
     VERBATIM
     DEPENDS Generate_CSS_ValueID_cpp


### PR DESCRIPTION
Managed to get this building on NixOS and figured I'd turn it into a PR so it didn't get lost. The gist is largely to not use `/bin/bash` or `/bin/mkdir`, since those aren't available on NixOS and instead use `env` to find where they are.

The rest of this is setting up the build dependencies so that both the bootstrap and Serenity can build successfully.