### PR TITLE
"Random" stuff

### DIFF
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -39,7 +39,6 @@ $CP -PdR Root/* mnt/
 # file permissions in Base/ are too restrictive. Restore
 # the permissions needed in the image.
 chmod -R g+rX,o+rX "$SERENITY_ROOT"/Base/* mnt/
-chmod 400 mnt/res/kernel.map
 
 chmod 660 mnt/etc/WindowServer/WindowServer.ini
 chown $window_uid:$window_gid mnt/etc/WindowServer/WindowServer.ini
@@ -63,7 +62,6 @@ chmod 4750 mnt/bin/keymap
 chown 0:$utmp_gid mnt/bin/utmpupdate
 chmod 2755 mnt/bin/utmpupdate
 chmod 600 mnt/etc/shadow
-
 echo "done"
 
 printf "creating initial filesystem structure... "
@@ -83,6 +81,7 @@ echo "done"
 
 printf "setting up device nodes folder... "
 mkdir -p mnt/dev
+echo "done"
 
 printf "writing version file... "
 GIT_HASH=$( (git log --pretty=format:'%h' -n 1 | head -c 7) || true )

--- a/Userland/Games/Conway/Game.cpp
+++ b/Userland/Games/Conway/Game.cpp
@@ -31,7 +31,6 @@
 
 Game::Game()
 {
-    srand(time(nullptr));
     reset();
 }
 

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -1039,9 +1039,22 @@ void arc4random_buf(void* buffer, size_t buffer_size)
 
 uint32_t arc4random_uniform(uint32_t max_bounds)
 {
-    // XXX: Should actually apply special rules for uniformity; avoid what is
-    // called "modulo bias".
-    return arc4random() % max_bounds;
+    // If we try to divide all 2**32 numbers into groups of "max_bounds" numbers, we may end up
+    // with a group around 2**32-1 that is a bit too small. For this reason, the implementation
+    // `arc4random() % max_bounds` would be insufficient. Here we compute the last number of the
+    // last "full group". Note that if max_bounds is a divisor of UINT32_MAX,
+    // then we end up with UINT32_MAX:
+    const uint32_t max_usable = UINT32_MAX - (static_cast<uint64_t>(UINT32_MAX) + 1) % max_bounds;
+    uint32_t random_value = arc4random();
+    for (int i = 0; i < 20 && random_value > max_usable; ++i) {
+        // By chance we picked a value from the incomplete group. Note that this group has size at
+        // most 2**31-1, so picking this group has a chance of less than 50%.
+        // In practice, this means that for the worst possible input, there is still only a
+        // once-in-a-million chance to get to iteration 20. In theory we should be able to loop
+        // forever. Here we prefer marginally imperfect random numbers over weird runtime behavior.
+        random_value = arc4random();
+    }
+    return random_value % max_bounds;
 }
 
 char* realpath(const char* pathname, char* buffer)

--- a/Userland/Utilities/shuf.cpp
+++ b/Userland/Utilities/shuf.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    if (pledge("stdio", nullptr) > 0) {
+        perror("pledge");
+        return 1;
+    }
+
+    Vector<String> lines;
+
+    for (;;) {
+        char* buffer = nullptr;
+        ssize_t buflen = 0;
+        size_t n;
+        errno = 0;
+        buflen = getline(&buffer, &n, stdin);
+        if (buflen == -1 && errno != 0) {
+            perror("getline");
+            exit(1);
+        }
+        if (buflen == -1)
+            break;
+        lines.append({ buffer, AK::ShouldChomp::Chomp });
+    }
+
+    // Fisher-Yates shuffle
+    String tmp;
+    for (size_t i = lines.size() - 1; i >= 1; --i) {
+        size_t j = arc4random_uniform(i + 1);
+        // Swap i and j
+        if (i == j)
+            continue;
+        tmp = move(lines[j]);
+        lines[j] = move(lines[i]);
+        lines[i] = move(tmp);
+    }
+
+    for (auto& line : lines) {
+        fputs(line.characters(), stdout);
+        fputc('\n', stdout);
+    }
+
+    return 0;
+}

--- a/Userland/Utilities/sort.cpp
+++ b/Userland/Utilities/sort.cpp
@@ -53,7 +53,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
         }
         if (buflen == -1)
             break;
-        lines.append(buffer);
+        lines.append({ buffer, AK::ShouldChomp::Chomp });
     }
 
     quick_sort(lines, [](auto& a, auto& b) {
@@ -62,6 +62,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     for (auto& line : lines) {
         fputs(line.characters(), stdout);
+        fputc('\n', stdout);
     }
 
     return 0;


### PR DESCRIPTION
In this PR:
- Fix sliiightly weird output (missing newline) of the `build-root-filesystem.sh` script, as well as a duplicated `chmod` call. This should make building the image *several* nanoseconds faster! ;)
- Don't mislead the readers of `Conway` by using `srand` when never calling `rand`
- Fix the modulo bias in `arc4random_uniform`. This should be the only controversial commit, if any: This implementation actually chooses performance over speed! In theory any implementation must be able to be "kept in suspense" indefinitely, if the Kernel always returns just the wrong randomness. In practice, if this happens too many times in a row, it's probably better to give up. I chose 20 iterations, because that guarantees that this will happen at most once-in-a-million for the worst-case input, and for normal inputs this chance is much lower. (For example, it is exactly 0 for all powers of two.)
- Fix a weird newlines-bug in `sort` (see screenshots below)
- Write the most basic implementation possible of `shuf` (guess where I copied it from ;) )

Before the `sort` fix:

![Bildschirmfoto_2021-01-19_22-51-57](https://user-images.githubusercontent.com/2690845/105098832-f8338c00-5aaa-11eb-8900-734611efb5ba.png)

After:

![Bildschirmfoto_2021-01-19_22-53-11](https://user-images.githubusercontent.com/2690845/105098848-fe296d00-5aaa-11eb-93b4-90cc56789a93.png)