### PR TITLE
WindowServer: Rename WallpaperMode::{Scaled => Stretch}

### DIFF
--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -58,8 +58,8 @@ static WallpaperMode mode_to_enum(const String& name)
         return WallpaperMode::Tile;
     if (name == "center")
         return WallpaperMode::Center;
-    if (name == "scaled")
-        return WallpaperMode::Scaled;
+    if (name == "stretch")
+        return WallpaperMode::Stretch;
     return WallpaperMode::Simple;
 }
 
@@ -263,7 +263,7 @@ void Compositor::compose()
                     rect, offset);
             } else if (m_wallpaper_mode == WallpaperMode::Tile) {
                 painter.draw_tiled_bitmap(rect, *m_wallpaper);
-            } else if (m_wallpaper_mode == WallpaperMode::Scaled) {
+            } else if (m_wallpaper_mode == WallpaperMode::Stretch) {
                 float hscale = (float)m_wallpaper->size().width() / (float)ws.size().width();
                 float vscale = (float)m_wallpaper->size().height() / (float)ws.size().height();
 

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -43,7 +43,7 @@ enum class WallpaperMode {
     Simple,
     Tile,
     Center,
-    Scaled,
+    Stretch,
     Unchecked
 };
 


### PR DESCRIPTION
This option was renamed from scaled to stretch in DisplaySettings in 699ba84, but since WindowServer receives a plain string and was not updated, it wouldn't recognize the new renamed value as a valid option.
Turns out sending plain strings via IPC and only mapping them to enum values on the receiving end is brittle, we should probably update `Desktop::set_wallpaper_mode()` to use an enum as well at some point.

Fixes #5006.