### PR TITLE
SystemServer.ini: Default to not showing network change notifications

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -104,7 +104,7 @@ User=anon
 
 [Network.MenuApplet]
 Executable=/bin/Network.MenuApplet
-Arguments=--name=Network --display-notifications
+Arguments=--name=Network
 Priority=low
 KeepAlive=1
 User=anon


### PR DESCRIPTION
Until someone has time to implement something for not showing the
very first network change at boot, let's turn off notifications for
network changes by default altogether. Having to dismiss this
notification at every boot gets old fast.