### PR TITLE
Run: Fix newline in info label

### DIFF
--- a/Userland/Applications/Run/Run.gml
+++ b/Userland/Applications/Run/Run.gml
@@ -16,7 +16,7 @@
 
         @GUI::Label {
             name: "info"
-            text: "Type the name of a program, folder, document,\\nor website, and SerenityOS will open it for you."
+            text: "Type the name of a program, folder, document,\nor website, and SerenityOS will open it for you."
             text_alignment: "CenterLeft"
         }
     }


### PR DESCRIPTION
This apparently was a workaround for escape sequences in GML at some point (see #4937), but it now literally inserts "\n" and no newline, as the backslash itself is escaped.

Before and after:

![image](https://user-images.githubusercontent.com/19366641/105214989-0340f780-5b51-11eb-94f9-dba265883a0c.png)
![image](https://user-images.githubusercontent.com/19366641/105214995-050abb00-5b51-11eb-9207-ef858707ef1e.png)
