### PR TITLE
LibJS: Include <typeinfo> in AST.cpp

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -49,6 +49,7 @@
 #include <LibJS/Runtime/Shape.h>
 #include <LibJS/Runtime/StringObject.h>
 #include <LibJS/Runtime/WithScope.h>
+#include <typeinfo>
 
 namespace JS {
 


### PR DESCRIPTION
Without this, the oss-fuzz build says:

```
../Userland/Libraries/LibJS/AST.cpp:58:34: error: member access into incomplete type 'const std::type_info'
    return demangle(typeid(*this).name()).substring(4);
                                 ^
```