### PR TITLE
Revert "LibCore: Try to fix fuzzer build"

### DIFF
--- a/Userland/Libraries/LibCore/AnonymousBuffer.cpp
+++ b/Userland/Libraries/LibCore/AnonymousBuffer.cpp
@@ -24,10 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if defined(__linux__) && !defined(_GNU_SOURCE)
-#    define _GNU_SOURCE // For memfd_create, MFD_CLOEXEC
-#endif
-
 #include <LibCore/AnonymousBuffer.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>


### PR DESCRIPTION
Reverts SerenityOS/serenity#5020

I now tried running the oss-fuzz fuzzer build locally (cf #5024) and this doesn't help.

My current theory is that oss-fuzz using ubuntu 16.04 means that its glibc is too old to have the memfd stuff, but I'm still reading.