### PR TITLE
oss-fuzz: Try harder to fix build

### DIFF
--- a/Userland/Libraries/LibCore/AnonymousBuffer.cpp
+++ b/Userland/Libraries/LibCore/AnonymousBuffer.cpp
@@ -37,6 +37,16 @@
 #    include <serenity.h>
 #endif
 
+#if defined(__linux__) && !defined(MFD_CLOEXEC)
+#    include <linux/memfd.h>
+#    include <sys/syscall.h>
+
+static int memfd_create(const char* name, unsigned int flags)
+{
+    return syscall(SYS_memfd_create, name, flags);
+}
+#endif
+
 namespace Core {
 
 AnonymousBuffer AnonymousBuffer::create_with_size(size_t size)


### PR DESCRIPTION
Apparently memfd_create() is newish in glibc, and oss-fuzz
uses Ubuntu 16.04 as base for its docker images, which doens't
yet have memfd_create(). But, not to worry, it does have the syscall
define and that's all we really need :/

---

With this, my local oss-fuzz-like build gets farther, but then complains about libmprf.so later on. Not sure if this is due to me holding things wrong or if that's genuinely newly broken in some way.