### PR TITLE
Kernel: Ramdisk support

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -46,6 +46,8 @@ set(KERNEL_SOURCES
     Storage/IDEController.cpp
     Storage/IDEChannel.cpp
     Storage/PATADiskDevice.cpp
+    Storage/RamdiskController.cpp
+    Storage/RamdiskDevice.cpp
     Storage/StorageManagement.cpp
     DoubleBuffer.cpp
     FileSystem/AnonymousFile.cpp

--- a/Kernel/Console.h
+++ b/Kernel/Console.h
@@ -53,6 +53,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0666; }
+    virtual String device_name() const override { return "console"; }
 
 private:
     CircularQueue<char, 16384> m_logbuffer;

--- a/Kernel/Devices/BXVGADevice.cpp
+++ b/Kernel/Devices/BXVGADevice.cpp
@@ -195,6 +195,11 @@ KResultOr<Region*> BXVGADevice::mmap(Process& process, FileDescription&, Virtual
         shared);
 }
 
+String BXVGADevice::device_name() const
+{
+    return String::formatted("fb{}", minor());
+}
+
 int BXVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
 {
     REQUIRE_PROMISE(video);

--- a/Kernel/Devices/BXVGADevice.h
+++ b/Kernel/Devices/BXVGADevice.h
@@ -46,6 +46,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0660; }
+    virtual String device_name() const override;
 
 private:
     virtual const char* class_name() const override { return "BXVGA"; }

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -58,6 +58,7 @@ public:
     uid_t gid() const { return m_gid; }
 
     virtual mode_t required_mode() const = 0;
+    virtual String device_name() const = 0;
 
     virtual bool is_device() const override { return true; }
     virtual bool is_disk_device() const { return false; }

--- a/Kernel/Devices/FullDevice.h
+++ b/Kernel/Devices/FullDevice.h
@@ -38,6 +38,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0600; }
+    virtual String device_name() const override { return "full"; }
 
 private:
     // ^CharacterDevice

--- a/Kernel/Devices/KeyboardDevice.h
+++ b/Kernel/Devices/KeyboardDevice.h
@@ -76,6 +76,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0440; }
+    virtual String device_name() const override { return "keyboard"; }
 
 private:
     // ^IRQHandler

--- a/Kernel/Devices/MBVGADevice.cpp
+++ b/Kernel/Devices/MBVGADevice.cpp
@@ -114,4 +114,9 @@ int MBVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
     };
 }
 
+String MBVGADevice::device_name() const
+{
+    return String::formatted("fb{}", minor());
+}
+
 }

--- a/Kernel/Devices/MBVGADevice.h
+++ b/Kernel/Devices/MBVGADevice.h
@@ -45,6 +45,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0660; }
+    virtual String device_name() const override;
 
 private:
     virtual const char* class_name() const override { return "MBVGA"; }

--- a/Kernel/Devices/NullDevice.h
+++ b/Kernel/Devices/NullDevice.h
@@ -41,6 +41,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0666; }
+    virtual String device_name() const override { return "null"; }
 
 private:
     // ^CharacterDevice

--- a/Kernel/Devices/PS2MouseDevice.h
+++ b/Kernel/Devices/PS2MouseDevice.h
@@ -63,6 +63,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0440; }
+    virtual String device_name() const override { return "mouse"; }
 
 private:
     // ^IRQHandler

--- a/Kernel/Devices/RandomDevice.h
+++ b/Kernel/Devices/RandomDevice.h
@@ -38,6 +38,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0666; }
+    virtual String device_name() const override { return "random"; }
 
 private:
     // ^CharacterDevice

--- a/Kernel/Devices/SB16.h
+++ b/Kernel/Devices/SB16.h
@@ -55,6 +55,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0220; }
+    virtual String device_name() const override { return "audio"; }
 
 private:
     // ^IRQHandler

--- a/Kernel/Devices/SerialDevice.cpp
+++ b/Kernel/Devices/SerialDevice.cpp
@@ -87,6 +87,11 @@ KResultOr<size_t> SerialDevice::write(FileDescription&, size_t, const UserOrKern
     return (size_t)nread;
 }
 
+String SerialDevice::device_name() const
+{
+    return String::formatted("ttyS{}", minor() - 64);
+}
+
 void SerialDevice::initialize()
 {
     set_interrupts(0);

--- a/Kernel/Devices/SerialDevice.h
+++ b/Kernel/Devices/SerialDevice.h
@@ -125,6 +125,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0620; }
+    virtual String device_name() const override;
 
 private:
     // ^CharacterDevice

--- a/Kernel/Devices/ZeroDevice.h
+++ b/Kernel/Devices/ZeroDevice.h
@@ -38,6 +38,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0666; }
+    virtual String device_name() const override { return "zero"; }
 
 private:
     // ^CharacterDevice

--- a/Kernel/FileSystem/DevFS.cpp
+++ b/Kernel/FileSystem/DevFS.cpp
@@ -409,6 +409,9 @@ String DevFSDeviceInode::determine_name() const
             char drive_letter = (u8)drive_index;
             return String::format("hd%c", drive_letter);
         }
+        case 6: {
+            return String::formatted("ramdisk{}", m_attached_device->minor());
+        }
 
         case 100:
             // FIXME: Try to not hardcode a maximum of 16 partitions per drive!

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -82,6 +82,3 @@ inline void kfree_aligned(void* ptr)
 }
 
 void kmalloc_enable_expand();
-
-extern u8* const kmalloc_start;
-extern u8* const kmalloc_end;

--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -191,11 +191,12 @@ void dump_backtrace()
 void load_kernel_symbol_table()
 {
     auto result = VFS::the().open("/res/kernel.map", O_RDONLY, 0, VFS::the().root_custody());
-    ASSERT(!result.is_error());
-    auto description = result.value();
-    auto buffer = description->read_entire_file();
-    ASSERT(!buffer.is_error());
-    load_kernel_sybols_from_data(*buffer.value());
+    if (!result.is_error()) {
+        auto description = result.value();
+        auto buffer = description->read_entire_file();
+        if (!buffer.is_error())
+            load_kernel_sybols_from_data(*buffer.value());
+    }
 }
 
 }

--- a/Kernel/Multiboot.h
+++ b/Kernel/Multiboot.h
@@ -28,6 +28,14 @@
 
 #include <AK/Types.h>
 
+struct multiboot_module_entry {
+    u32 start;
+    u32 end;
+    u32 string_addr;
+    u32 reserved;
+};
+typedef struct multiboot_module_entry multiboot_module_entry_t;
+
 struct multiboot_aout_symbol_table {
     u32 tabsize;
     u32 strsize;

--- a/Kernel/Storage/IDEController.cpp
+++ b/Kernel/Storage/IDEController.cpp
@@ -68,7 +68,8 @@ void IDEController::complete_current_request(AsyncDeviceRequest::RequestResult)
 }
 
 IDEController::IDEController(PCI::Address address, bool force_pio)
-    : StorageController(address)
+    : StorageController()
+    , PCI::DeviceController(address)
 {
     initialize(force_pio);
 }

--- a/Kernel/Storage/IDEController.h
+++ b/Kernel/Storage/IDEController.h
@@ -37,7 +37,8 @@ namespace Kernel {
 
 class AsyncBlockDeviceRequest;
 
-class IDEController final : public StorageController {
+class IDEController final : public StorageController
+    , public PCI::DeviceController {
     AK_MAKE_ETERNAL
 public:
 public:

--- a/Kernel/Storage/PATADiskDevice.cpp
+++ b/Kernel/Storage/PATADiskDevice.cpp
@@ -65,6 +65,13 @@ void PATADiskDevice::start_request(AsyncBlockDeviceRequest& request)
     m_channel.start_request(request, use_dma, is_slave());
 }
 
+String PATADiskDevice::device_name() const
+{
+    // FIXME: Try to not hardcode a maximum of 16 partitions per drive!
+    size_t drive_index = minor() / 16;
+    return String::formatted("hd{:c}{}", 'a' + drive_index, minor() + 1);
+}
+
 size_t PATADiskDevice::max_addressable_block() const
 {
     return m_cylinders * m_heads * m_sectors_per_track;

--- a/Kernel/Storage/PATADiskDevice.h
+++ b/Kernel/Storage/PATADiskDevice.h
@@ -61,6 +61,7 @@ public:
 
     // ^BlockDevice
     virtual void start_request(AsyncBlockDeviceRequest&) override;
+    virtual String device_name() const override;
 
 private:
     PATADiskDevice(const IDEController&, IDEChannel&, DriveType, u8, u8, u8, int major, int minor);

--- a/Kernel/Storage/Partition/DiskPartition.cpp
+++ b/Kernel/Storage/Partition/DiskPartition.cpp
@@ -102,6 +102,13 @@ bool DiskPartition::can_write(const FileDescription& fd, size_t offset) const
     return m_device->can_write(fd, offset + adjust);
 }
 
+String DiskPartition::device_name() const
+{
+    // FIXME: Try to not hardcode a maximum of 16 partitions per drive!
+    size_t partition_index = minor() % 16;
+    return String::formatted("{}{}", m_device->device_name(), partition_index + 1);
+}
+
 const char* DiskPartition::class_name() const
 {
     return "DiskPartition";

--- a/Kernel/Storage/Partition/DiskPartition.h
+++ b/Kernel/Storage/Partition/DiskPartition.h
@@ -47,6 +47,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0600; }
+    virtual String device_name() const override;
 
     const DiskPartitionMetadata& metadata() const;
 

--- a/Kernel/Storage/RamdiskController.cpp
+++ b/Kernel/Storage/RamdiskController.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <AK/Types.h>
+#include <Kernel/Storage/RamdiskController.h>
+
+namespace Kernel {
+
+NonnullRefPtr<RamdiskController> RamdiskController::initialize()
+{
+    return adopt(*new RamdiskController());
+}
+
+bool RamdiskController::reset()
+{
+    TODO();
+}
+
+bool RamdiskController::shutdown()
+{
+    TODO();
+}
+
+size_t RamdiskController::devices_count() const
+{
+    return m_devices.size();
+}
+
+void RamdiskController::start_request(const StorageDevice&, AsyncBlockDeviceRequest&)
+{
+    ASSERT_NOT_REACHED();
+}
+
+void RamdiskController::complete_current_request(AsyncDeviceRequest::RequestResult)
+{
+    ASSERT_NOT_REACHED();
+}
+
+RamdiskController::RamdiskController()
+    : StorageController()
+{
+    // Populate ramdisk controllers from Multiboot boot modules, if any.
+    size_t count = 0;
+    for (auto used_memory_range : MemoryManager::the().used_memory_ranges()) {
+        if (used_memory_range.type == UsedMemoryRangeType::BootModule) {
+            size_t length = PAGE_ROUND_UP(used_memory_range.end.get()) - used_memory_range.start.get();
+            auto region = MemoryManager::the().allocate_kernel_region(used_memory_range.start, length, "Ramdisk", Region::Access::Read | Region::Access::Write);
+            m_devices.append(RamdiskDevice::create(*this, move(region), 6, count));
+            count++;
+        }
+    }
+}
+
+RamdiskController::~RamdiskController()
+{
+}
+
+RefPtr<StorageDevice> RamdiskController::device(u32 index) const
+{
+    if (index >= m_devices.size())
+        return nullptr;
+    return m_devices[index];
+}
+
+}

--- a/Kernel/Storage/RamdiskDevice.cpp
+++ b/Kernel/Storage/RamdiskDevice.cpp
@@ -82,4 +82,11 @@ void RamdiskDevice::start_request(AsyncBlockDeviceRequest& request)
     }
 }
 
+String RamdiskDevice::device_name() const
+{
+    // FIXME: Try to not hardcode a maximum of 16 partitions per drive!
+    size_t drive_index = minor() / 16;
+    return String::formatted("ramdisk{}", drive_index);
+}
+
 }

--- a/Kernel/Storage/RamdiskDevice.cpp
+++ b/Kernel/Storage/RamdiskDevice.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Memory.h>
+#include <AK/StringView.h>
+#include <Kernel/FileSystem/FileDescription.h>
+#include <Kernel/Storage/RamdiskController.h>
+#include <Kernel/Storage/RamdiskDevice.h>
+
+namespace Kernel {
+
+NonnullRefPtr<RamdiskDevice> RamdiskDevice::create(const RamdiskController& controller, OwnPtr<Region>&& region, int major, int minor)
+{
+    return adopt(*new RamdiskDevice(controller, move(region), major, minor));
+}
+
+RamdiskDevice::RamdiskDevice(const RamdiskController& controller, OwnPtr<Region>&& region, int major, int minor)
+    : StorageDevice(controller, major, minor, 512, 0)
+    , m_region(move(region))
+{
+    klog() << "Ramdisk: Device #" << minor << " @ " << m_region->vaddr() << " length " << m_region->size();
+}
+
+RamdiskDevice::~RamdiskDevice()
+{
+}
+
+const char* RamdiskDevice::class_name() const
+{
+    return "RamdiskDevice";
+}
+
+size_t RamdiskDevice::max_addressable_block() const
+{
+    return m_region->size() / 512;
+}
+
+void RamdiskDevice::start_request(AsyncBlockDeviceRequest& request)
+{
+    LOCKER(m_lock);
+
+    u8* base = m_region->vaddr().as_ptr();
+    size_t size = m_region->size();
+    u8* offset = base + request.block_index() * 512;
+    size_t length = request.block_count() * 512;
+
+    if ((offset + length > base + size) || (offset + length < base)) {
+        request.complete(AsyncDeviceRequest::Failure);
+    } else {
+        bool success;
+
+        if (request.request_type() == AsyncBlockDeviceRequest::Read) {
+            success = request.buffer().write(offset, length);
+        } else {
+            success = request.buffer().read(offset, length);
+        }
+
+        request.complete(success ? AsyncDeviceRequest::Success : AsyncDeviceRequest::MemoryFault);
+    }
+}
+
+}

--- a/Kernel/Storage/RamdiskDevice.h
+++ b/Kernel/Storage/RamdiskDevice.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2021, the SerenityOS developers
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,48 +26,36 @@
 
 #pragma once
 
-#include <Kernel/Devices/BlockDevice.h>
-#include <Kernel/Interrupts/IRQHandler.h>
 #include <Kernel/Lock.h>
-#include <Kernel/Storage/Partition/DiskPartition.h>
-#include <Kernel/Storage/StorageController.h>
+#include <Kernel/Storage/StorageDevice.h>
 
 namespace Kernel {
 
-class StorageDevice : public BlockDevice {
-    friend class StorageManagement;
+class RamdiskController;
+
+class RamdiskDevice final : public StorageDevice {
+    friend class RamdiskController;
     AK_MAKE_ETERNAL
 public:
-    enum class Type : u8 {
-        Ramdisk,
-        IDE,
-        NVMe,
-    };
+    static NonnullRefPtr<RamdiskDevice> create(const RamdiskController&, OwnPtr<Region>&& region, int major, int minor);
+    RamdiskDevice(const RamdiskController&, OwnPtr<Region>&&, int major, int minor);
+    virtual ~RamdiskDevice() override;
 
-public:
-    virtual Type type() const = 0;
-    virtual size_t max_addressable_block() const { return m_max_addressable_block; }
-
-    NonnullRefPtr<StorageController> controller() const;
+    // ^StorageDevice
+    virtual Type type() const override { return StorageDevice::Type::Ramdisk; }
+    virtual size_t max_addressable_block() const override;
 
     // ^BlockDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
-    virtual bool can_write(const FileDescription&, size_t) const override;
+    virtual void start_request(AsyncBlockDeviceRequest&) override;
 
-    // ^Device
-    virtual mode_t required_mode() const override { return 0600; }
-
-protected:
-    StorageDevice(const StorageController&, int, int, size_t, size_t);
     // ^DiskDevice
     virtual const char* class_name() const override;
 
-private:
-    NonnullRefPtr<StorageController> m_storage_controller;
-    NonnullRefPtrVector<DiskPartition> m_partitions;
-    size_t m_max_addressable_block;
+    bool is_slave() const;
+
+    Lock m_lock { "RamdiskDevice" };
+
+    OwnPtr<Region> m_region;
 };
 
 }

--- a/Kernel/Storage/RamdiskDevice.h
+++ b/Kernel/Storage/RamdiskDevice.h
@@ -50,6 +50,7 @@ public:
 
     // ^DiskDevice
     virtual const char* class_name() const override;
+    virtual String device_name() const override;
 
     bool is_slave() const;
 

--- a/Kernel/Storage/StorageController.h
+++ b/Kernel/Storage/StorageController.h
@@ -42,24 +42,21 @@ namespace Kernel {
 
 class AsyncBlockDeviceRequest;
 class StorageDevice;
-class StorageController : public RefCounted<StorageController>
-    , public PCI::DeviceController {
+class StorageController : public RefCounted<StorageController> {
     AK_MAKE_ETERNAL
 public:
     enum class Type : u8 {
         IDE,
         NVMe
     };
+
+    virtual ~StorageController() = default;
+
     virtual Type type() const = 0;
     virtual RefPtr<StorageDevice> device(u32 index) const = 0;
     virtual size_t devices_count() const = 0;
 
 protected:
-    explicit StorageController(PCI::Address address)
-        : PCI::DeviceController(address)
-    {
-    }
-
     virtual void start_request(const StorageDevice&, AsyncBlockDeviceRequest&) = 0;
 
 protected:

--- a/Kernel/Storage/StorageController.h
+++ b/Kernel/Storage/StorageController.h
@@ -46,6 +46,7 @@ class StorageController : public RefCounted<StorageController> {
     AK_MAKE_ETERNAL
 public:
     enum class Type : u8 {
+        Ramdisk,
         IDE,
         NVMe
     };

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -32,6 +32,7 @@
 #include <Kernel/Storage/Partition/EBRPartitionTable.h>
 #include <Kernel/Storage/Partition/GUIDPartitionTable.h>
 #include <Kernel/Storage/Partition/MBRPartitionTable.h>
+#include <Kernel/Storage/RamdiskController.h>
 #include <Kernel/Storage/StorageManagement.h>
 
 namespace Kernel {
@@ -64,6 +65,7 @@ NonnullRefPtrVector<StorageController> StorageManagement::enumerate_controllers(
             controllers.append(IDEController::initialize(address, force_pio));
         }
     });
+    controllers.append(RamdiskController::initialize());
     return controllers;
 }
 

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -146,4 +146,9 @@ String MasterPTY::absolute_path(const FileDescription&) const
     return String::formatted("ptm:{}", m_pts_name);
 }
 
+String MasterPTY::device_name() const
+{
+    return String::formatted("{}", minor());
+}
+
 }

--- a/Kernel/TTY/MasterPTY.h
+++ b/Kernel/TTY/MasterPTY.h
@@ -50,6 +50,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0640; }
+    virtual String device_name() const override;
 
 private:
     // ^CharacterDevice

--- a/Kernel/TTY/PTYMultiplexer.h
+++ b/Kernel/TTY/PTYMultiplexer.h
@@ -57,6 +57,7 @@ public:
 
     // ^Device
     virtual mode_t required_mode() const override { return 0666; }
+    virtual String device_name() const override { return "ptmx"; }
 
 private:
     // ^CharacterDevice

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -109,6 +109,11 @@ KResult SlavePTY::close()
     return KSuccess;
 }
 
+String SlavePTY::device_name() const
+{
+    return String::formatted("{}", minor());
+}
+
 FileBlockCondition& SlavePTY::block_condition()
 {
     return m_master->block_condition();

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -57,6 +57,9 @@ private:
     virtual const char* class_name() const override { return "SlavePTY"; }
     virtual KResult close() override;
 
+    // ^Device
+    virtual String device_name() const override;
+
     friend class MasterPTY;
     SlavePTY(MasterPTY&, unsigned index);
 

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -338,6 +338,11 @@ void VirtualConsole::emit(const u8* data, size_t size)
         TTY::emit(data[i]);
 }
 
+String VirtualConsole::device_name() const
+{
+    return String::formatted("tty{}", minor());
+}
+
 void VirtualConsole::echo(u8 ch)
 {
     if (should_echo_input()) {

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -69,6 +69,9 @@ private:
     // ^CharacterDevice
     virtual const char* class_name() const override { return "VirtualConsole"; }
 
+    // ^Device
+    virtual String device_name() const override;
+
     void set_active(bool);
 
     void flush_vga_cursor();

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -483,10 +483,8 @@ void MemoryManager::deallocate_user_physical_page(const PhysicalPage& page)
 {
     ScopedSpinLock lock(s_mm_lock);
     for (auto& region : m_user_physical_regions) {
-        if (!region.contains(page)) {
-            klog() << "MM: deallocate_user_physical_page: " << page.paddr() << " not in " << region.lower() << " -> " << region.upper();
+        if (!region.contains(page))
             continue;
-        }
 
         region.return_page(page);
         --m_user_physical_pages_used;

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -67,6 +67,26 @@ inline u32 virtual_to_low_physical(u32 physical)
 class KBuffer;
 class SynthFSInode;
 
+enum class UsedMemoryRangeType {
+    LowMemory = 0,
+    Kernel,
+    BootModule,
+};
+
+constexpr static const char* UserMemoryRangeTypeNames[] {
+    "Low memory",
+    "Kernel",
+    "Boot module",
+};
+
+struct UsedMemoryRange {
+    UsedMemoryRangeType type;
+    PhysicalAddress start;
+    PhysicalAddress end;
+};
+
+const LogStream& operator<<(const LogStream& stream, const UsedMemoryRange& value);
+
 #define MM Kernel::MemoryManager::the()
 
 struct MemoryManagerData {
@@ -93,6 +113,7 @@ public:
     static MemoryManager& the();
     static bool is_initialized();
 
+    static void early_initialize();
     static void initialize(u32 cpu);
 
     static inline MemoryManagerData& get_data()
@@ -165,6 +186,8 @@ public:
 
     PageDirectory& kernel_page_directory() { return *m_kernel_page_directory; }
 
+    const Vector<UsedMemoryRange>& used_memory_ranges() { return m_used_memory_ranges; }
+
 private:
     MemoryManager();
     ~MemoryManager();
@@ -221,6 +244,7 @@ private:
 
     InlineLinkedList<Region> m_user_regions;
     InlineLinkedList<Region> m_kernel_regions;
+    Vector<UsedMemoryRange> m_used_memory_ranges;
 
     InlineLinkedList<VMObject> m_vmobjects;
 

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -79,6 +79,9 @@ extern ctor_func_t end_ctors;
 extern u32 __stack_chk_guard;
 u32 __stack_chk_guard;
 
+multiboot_module_entry_t multiboot_copy_boot_modules_array[16];
+size_t multiboot_copy_boot_modules_count;
+
 namespace Kernel {
 
 [[noreturn]] static void init_stage2(void*);
@@ -111,7 +114,8 @@ extern "C" [[noreturn]] void init()
     // We need to copy the command line before kmalloc is initialized,
     // as it may overwrite parts of multiboot!
     CommandLine::early_initialize(reinterpret_cast<const char*>(low_physical_to_virtual(multiboot_info_ptr->cmdline)));
-
+    memcpy(multiboot_copy_boot_modules_array, (u8*)low_physical_to_virtual(multiboot_info_ptr->mods_addr), multiboot_info_ptr->mods_count * sizeof(multiboot_module_entry_t));
+    multiboot_copy_boot_modules_count = multiboot_info_ptr->mods_count;
     s_bsp_processor.early_initialize(0);
 
     // Invoke the constructors needed for the kernel heap

--- a/Kernel/linker.ld
+++ b/Kernel/linker.ld
@@ -44,13 +44,18 @@ SECTIONS
         end_of_kernel_data = .;
     }
 
-    .bss ALIGN(4K) : AT (ADDR(.bss) - 0xc0000000)
+    .bss ALIGN(4K) (NOLOAD) : AT (ADDR(.bss) - 0xc0000000)
     {
         start_of_kernel_bss = .;
         *(page_tables)
         *(COMMON)
         *(.bss)
         end_of_kernel_bss = .;
+
+        . = ALIGN(4K);
+        *(.heap)
+        . = ALIGN(4K);
+        *(.super_pages)
     }
 
     end_of_kernel_image = .;


### PR DESCRIPTION
This is part of #5013 for adding diskless booting to SerenityOS. The ramdisk device is a statically-sized block of contiguous physical memory that is used to expose boot modules loaded by a Multiboot bootloader as block devices. This required a fair amount of cleanup in the memory map since SerenityOS made assumptions that break down when a 32 MiB ramdisk is loaded next to the kernel in memory.

I've also made the kernel not assert if it can't load kernel symbols. This is not required for ramdisk support, but it should be harmless to include at this moment and will be useful for space-constrained root file systems later.

~~Note: this is missing support for booting from a ramdisk, as the code for determining the root device and file system needs to be substantially modified in order to cope with this and the IDE controllers at the same time.~~ It boots from a ramdisk now.