### PR TITLE
Libraries: Add missing headers

### DIFF
--- a/Userland/Applications/Run/main.cpp
+++ b/Userland/Applications/Run/main.cpp
@@ -28,6 +28,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>
 #include <AK/URL.h>
+#include <LibGUI/Application.h>
 #include <string.h>
 
 #include "RunWindow.h"

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -26,6 +26,7 @@
  */
 
 #include <LibCore/ElapsedTimer.h>
+#include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -30,6 +30,7 @@
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/StringView.h>
+#include <LibAudio/Buffer.h>
 #include <LibCore/File.h>
 
 namespace Audio {

--- a/Userland/Libraries/LibC/sys/un.h
+++ b/Userland/Libraries/LibC/sys/un.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <bits/stdint.h>
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS

--- a/Userland/Libraries/LibCrypto/ASN1/PEM.h
+++ b/Userland/Libraries/LibCrypto/ASN1/PEM.h
@@ -32,7 +32,7 @@
 
 namespace Crypto {
 
-static ByteBuffer decode_pem(ReadonlyBytes data_in, size_t cert_index = 0)
+static inline ByteBuffer decode_pem(ReadonlyBytes data_in, size_t cert_index = 0)
 {
     size_t i { 0 };
     size_t start_at { 0 };

--- a/Userland/Libraries/LibELF/Validation.h
+++ b/Userland/Libraries/LibELF/Validation.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibELF/exec_elf.h>
 
 namespace ELF {

--- a/Userland/Libraries/LibGUI/DragOperation.h
+++ b/Userland/Libraries/LibGUI/DragOperation.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/OwnPtr.h>
+#include <LibCore/MimeData.h>
 #include <LibCore/Object.h>
 #include <LibGUI/Forward.h>
 #include <LibGfx/Forward.h>

--- a/Userland/Libraries/LibGUI/FontPicker.h
+++ b/Userland/Libraries/LibGUI/FontPicker.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <LibGUI/Dialog.h>
+#include <LibGfx/Font.h>
 #include <LibGfx/Forward.h>
 
 namespace GUI {

--- a/Userland/Libraries/LibGUI/ModelIndex.h
+++ b/Userland/Libraries/LibGUI/ModelIndex.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Format.h>
 #include <AK/Traits.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/ModelRole.h>

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -29,7 +29,6 @@
 #include <AK/JsonObject.h>
 #include <AK/String.h>
 #include <LibCore/Object.h>
-#include <LibGUI/Application.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Margins.h>

--- a/Userland/Libraries/LibGfx/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageDecoder.h
@@ -30,6 +30,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/Size.h>
 
 namespace Gfx {

--- a/Userland/Libraries/LibLine/Span.h
+++ b/Userland/Libraries/LibLine/Span.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 namespace Line {
 
 class Span {

--- a/Userland/Libraries/LibTTF/Cmap.h
+++ b/Userland/Libraries/LibTTF/Cmap.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/Span.h>
+#include <stdint.h>
 
 namespace TTF {
 

--- a/Userland/Libraries/LibWeb/DOM/EventDispatcher.h
+++ b/Userland/Libraries/LibWeb/DOM/EventDispatcher.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <LibWeb/DOM/Event.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::DOM {

--- a/Userland/Libraries/LibWeb/DOM/Timer.h
+++ b/Userland/Libraries/LibWeb/DOM/Timer.h
@@ -29,6 +29,7 @@
 #include <AK/Forward.h>
 #include <LibCore/Forward.h>
 #include <LibJS/Heap/Handle.h>
+#include <LibJS/Runtime/Function.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::DOM {

--- a/Userland/Libraries/LibWeb/FontCache.h
+++ b/Userland/Libraries/LibWeb/FontCache.h
@@ -29,6 +29,7 @@
 #include <AK/FlyString.h>
 #include <AK/HashMap.h>
 #include <AK/String.h>
+#include <LibGfx/Font.h>
 #include <LibGfx/Forward.h>
 
 struct FontSelector {

--- a/Userland/Libraries/LibWeb/Layout/SVGPathBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGPathBox.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <LibWeb/Layout/SVGGraphicsBox.h>
+#include <LibWeb/SVG/SVGPathElement.h>
 
 namespace Web::Layout {
 

--- a/Userland/Libraries/LibWeb/Page/EditEventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EditEventHandler.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Types.h>
 #include <LibWeb/Forward.h>
 
 namespace Web {

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/WeakPtr.h>
 #include <Kernel/API/KeyCode.h>
 #include <LibGUI/Forward.h>

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Vector.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/Rect.h>

--- a/Userland/Libraries/LibWeb/SVG/SVGContext.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGContext.h
@@ -26,6 +26,9 @@
 
 #pragma once
 
+#include <AK/Vector.h>
+#include <LibGfx/Color.h>
+
 namespace Web {
 
 class SVGContext {

--- a/Userland/Libraries/LibWeb/StylePropertiesModel.h
+++ b/Userland/Libraries/LibWeb/StylePropertiesModel.h
@@ -28,6 +28,7 @@
 
 #include <AK/NonnullRefPtrVector.h>
 #include <LibGUI/Model.h>
+#include <LibWeb/CSS/StyleProperties.h>
 
 namespace Web {
 

--- a/Userland/Libraries/LibX86/ELFSymbolProvider.h
+++ b/Userland/Libraries/LibX86/ELFSymbolProvider.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <LibELF/Image.h>
+#include <LibX86/Instruction.h>
 
 namespace X86 {
 


### PR DESCRIPTION
A C++ source file containing just
```
#include <LibFoo/Bar.h>
```
should always compile cleanly.
    
This patch adds missing header inclusions that could have caused weird error messages like this one if they were used without the expected context:

```
[5/821] Building CXX object Userland/HeaderCheck/CMakeFiles/H...land__Libraries__LibWeb__Painting__PaintContext.h__test.cpp.o
FAILED: Userland/HeaderCheck/CMakeFiles/HeaderCheck.dir/Userland__Libraries__LibWeb__Painting__PaintContext.h__test.cpp.o 
/usr/bin/ccache /home/eispin/workspace/serenity/Toolchain/Local/i686/bin/i686-pc-serenity-g++ -DDEBUG -DSANITIZE_PTRS -I../Userland/Libraries -I../. -I../Userland/Libraries/LibC -I../Userland/Libraries/LibM -I../Userland/Services -I../Userland -I. -IUserland/Services -IUserland/Libraries -IUserland -pie -fpic -Wno-unknown-warning-option -Wall -Wextra -Werror -Wmissing-declarations -Wformat=2 -fdiagnostics-color=always -ftls-model=initial-exec -fconcepts -Os -g1 -fno-exceptions -fstack-protector-strong -Wno-address-of-packed-member -Wundef -Wcast-qual -Wwrite-strings -Wimplicit-fallthrough -Wno-nonnull-compare -Wno-deprecated-copy -Wno-expansion-to-defined -ffile-prefix-map=/home/eispin/workspace/serenity=. -std=c++2a -MD -MT Userland/HeaderCheck/CMakeFiles/HeaderCheck.dir/Userland__Libraries__LibWeb__Painting__PaintContext.h__test.cpp.o -MF Userland/HeaderCheck/CMakeFiles/HeaderCheck.dir/Userland__Libraries__LibWeb__Painting__PaintContext.h__test.cpp.o.d -o Userland/HeaderCheck/CMakeFiles/HeaderCheck.dir/Userland__Libraries__LibWeb__Painting__PaintContext.h__test.cpp.o -c Userland/HeaderCheck/Userland__Libraries__LibWeb__Painting__PaintContext.h__test.cpp
In file included from .././Userland/Libraries/LibWeb/Painting/PaintContext.h:32,
                 from Userland/HeaderCheck/Userland__Libraries__LibWeb__Painting__PaintContext.h__test.cpp:1:
../Userland/Libraries/LibWeb/SVG/SVGContext.h:59:19: error: field 'm_states' has incomplete type 'AK::Vector<Web::SVGContext::State>'
   59 |     Vector<State> m_states;
      |                   ^~~~~~~~
In file included from ../Userland/Libraries/LibGfx/Palette.h:29,
                 from .././Userland/Libraries/LibWeb/Painting/PaintContext.h:30,
                 from Userland/HeaderCheck/Userland__Libraries__LibWeb__Painting__PaintContext.h__test.cpp:1:
.././AK/Forward.h:133:7: note: declaration of 'class AK::Vector<Web::SVGContext::State>'
  133 | class Vector;
      |       ^~~~~~
ninja: build stopped: subcommands failed.
```

Also, this used to confuse QtCreator; now it is no longer getting confused! :)

- Here's the tool that will compile many of Serenity's headers: https://github.com/BenWiederhake/serenity/tree/dev-header-check
  (I didn't include it in this PR because it's kinda ugly, slows down the build immensely, and is likely to generate false-positives. Feel free to use it if you're masochistic.)
- I excluded some tools (UserspaceEmulator, Shell), because they don't work with the tool cleanly.
- I dropped the diffs for HackStudio and WindowServer, because there the argument "Well, someone might want to use the header stand-alone!" doesn't make much sense. See 25dbfeb9818d7c320feae86fffb152993f0d64f3 if you're interested.
- I excluded the entire Kernel, because it *really* doesn't like being compiled in Userland context.