### PR TITLE
Ports: ProTracker 2 clone

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -151,6 +151,7 @@ func_defined pre_configure || pre_configure() {
     :
 }
 func_defined configure || configure() {
+    chmod +x "${workdir}"/"$configscript"
     run ./"$configscript" --host=i686-pc-serenity $configopts
 }
 func_defined build || build() {
@@ -252,7 +253,6 @@ do_configure() {
     if [ "$useconfigure" = "true" ]; then
         echo "Configuring $port!"
         pre_configure
-        chmod +x "${workdir}"/"$configscript"
         configure
     else
         echo "This port does not use a configure script. Skipping configure step."

--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -54,6 +54,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`pcre2`](pcre2/)              | Perl-compatible Regular Expressions (PCRE2)   | 10.34             | https://www.pcre.org/                                 |
 | [`pkgconf`](pkgconf/)          | pkgconf                                       | 1.7.3             | https://github.com/pkgconf/pkgconf                    |
 | [`printf`](printf/)            | printf (OpenBSD)                              | 6.6               | https://github.com/ibara/libpuffy                     |
+| [`pt2-clone`](pt2-clone/)      | ProTracker 2 clone                            | 1.28              | https://github.com/8bitbubsy/pt2-clone                |
 | [`python3`](python3/)          | Python                                        | 3.9.1             | https://www.python.org/                               |
 | [`quake`](quake/)              | Quake                                         | 0.65              | https://github.com/SerenityOS/SerenityQuake           |
 | [`rsync`](rsync/)              | rsync                                         | 3.1.3             | https://rsync.samba.org/                              |

--- a/Ports/pt2-clone/package.sh
+++ b/Ports/pt2-clone/package.sh
@@ -1,0 +1,16 @@
+#!/bin/bash ../.port_include.sh
+port=pt2-clone
+version=1.28
+workdir=pt2-clone-$version
+useconfigure=true
+files="https://github.com/8bitbubsy/pt2-clone/archive/v${version}.tar.gz v${version}.tar.gz"
+configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMakeToolchain.txt"
+depends="SDL2"
+
+configure() {
+    run cmake $configopts
+}
+
+install() {
+    run make install
+}

--- a/Ports/pt2-clone/patches/CMakeLists_outputpath.patch
+++ b/Ports/pt2-clone/patches/CMakeLists_outputpath.patch
@@ -1,0 +1,10 @@
+--- pt2-clone-1.28/CMakeLists.txt	2021-01-01 20:48:32.000000000 +0100
++++ pt2-clone-1.28D/CMakeLists.txt	2021-01-22 13:59:34.871852522 +0100
+@@ -3,7 +3,6 @@
+ project(pt2-clone)
+ 
+ find_package(SDL2 REQUIRED)
+-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${pt2-clone_SOURCE_DIR}/release/other/")
+ 
+ file(GLOB pt2-clone_SRC
+     "${pt2-clone_SOURCE_DIR}/src/*.c"

--- a/Ports/pt2-clone/patches/PATH_MAX.patch
+++ b/Ports/pt2-clone/patches/PATH_MAX.patch
@@ -1,0 +1,78 @@
+Common subdirectories: pt2-clone-1.28/src/gfx and pt2-clone-1.28d/src/gfx
+diff -u pt2-clone-1.28/src/pt2_config.c pt2-clone-1.28d/src/pt2_config.c
+--- pt2-clone-1.28/src/pt2_config.c	2021-01-01 20:48:32.000000000 +0100
++++ pt2-clone-1.28d/src/pt2_config.c	2021-01-22 13:34:22.058489000 +0100
+@@ -21,6 +21,7 @@
+ #include "pt2_diskop.h"
+ #include "pt2_textout.h"
+ #include "pt2_sampler.h"
++#define PATH_MAX 4096
+ 
+ #ifndef _WIN32
+ static char oldCwd[PATH_MAX];
+diff -u pt2-clone-1.28/src/pt2_diskop.c pt2-clone-1.28d/src/pt2_diskop.c
+--- pt2-clone-1.28/src/pt2_diskop.c	2021-01-01 20:48:32.000000000 +0100
++++ pt2-clone-1.28d/src/pt2_diskop.c	2021-01-22 13:33:49.531212000 +0100
+@@ -36,6 +36,7 @@
+ #include "pt2_visuals.h"
+ #include "pt2_sample_loader.h"
+ #include "pt2_bmp.h"
++#define PATH_MAX 4096
+ 
+ typedef struct fileEntry_t
+ {
+diff -u pt2-clone-1.28/src/pt2_edit.c pt2-clone-1.28d/src/pt2_edit.c
+--- pt2-clone-1.28/src/pt2_edit.c	2021-01-01 20:48:32.000000000 +0100
++++ pt2-clone-1.28d/src/pt2_edit.c	2021-01-22 13:33:14.987979000 +0100
+@@ -29,6 +29,7 @@
+ #include "pt2_audio.h"
+ #include "pt2_sync.h"
+ #include "pt2_chordmaker.h"
++#define PATH_MAX 4096
+ 
+ const int8_t scancode2NoteLo[52] = // "USB usage page standard" order
+ {
+diff -u pt2-clone-1.28/src/pt2_main.c pt2-clone-1.28d/src/pt2_main.c
+--- pt2-clone-1.28/src/pt2_main.c	2021-01-01 20:48:32.000000000 +0100
++++ pt2-clone-1.28d/src/pt2_main.c	2021-01-22 13:33:34.867538000 +0100
+@@ -36,6 +36,7 @@
+ #include "pt2_bmp.h"
+ #include "pt2_sync.h"
+ #include "pt2_sampling.h"
++#define PATH_MAX 4096
+ 
+ #define CRASH_TEXT "Oh no!\nThe ProTracker 2 clone has crashed...\n\nA backup .mod was hopefully " \
+                    "saved to the current module directory.\n\nPlease report this bug if you can.\n" \
+diff -u pt2-clone-1.28/src/pt2_module_loader.c pt2-clone-1.28d/src/pt2_module_loader.c
+--- pt2-clone-1.28/src/pt2_module_loader.c	2021-01-01 20:48:32.000000000 +0100
++++ pt2-clone-1.28d/src/pt2_module_loader.c	2021-01-22 13:34:32.490256000 +0100
+@@ -27,6 +27,7 @@
+ #include "pt2_sample_loader.h"
+ #include "pt2_config.h"
+ #include "pt2_sampling.h"
++#define PATH_MAX 4096
+ 
+ typedef struct mem_t
+ {
+diff -u pt2-clone-1.28/src/pt2_mouse.c pt2-clone-1.28d/src/pt2_mouse.c
+--- pt2-clone-1.28/src/pt2_mouse.c	2021-01-01 20:48:32.000000000 +0100
++++ pt2-clone-1.28d/src/pt2_mouse.c	2021-01-22 13:33:59.278995000 +0100
+@@ -26,6 +26,7 @@
+ #include "pt2_bmp.h"
+ #include "pt2_sampling.h"
+ #include "pt2_chordmaker.h"
++#define PATH_MAX 4096
+ 
+ /* TODO: Move irrelevant routines outta here! Disgusting design!
+ ** Keep in mind that this was programmed in my early programming days...
+diff -u pt2-clone-1.28/src/pt2_sample_loader.c pt2-clone-1.28d/src/pt2_sample_loader.c
+--- pt2-clone-1.28/src/pt2_sample_loader.c	2021-01-01 20:48:32.000000000 +0100
++++ pt2-clone-1.28d/src/pt2_sample_loader.c	2021-01-22 13:34:03.582900000 +0100
+@@ -19,6 +19,7 @@
+ #include "pt2_config.h"
+ #include "pt2_sampling.h"
+ #include "pt2_downsamplers2x.h"
++#define PATH_MAX 4096
+ 
+ enum
+ {

--- a/Ports/pt2-clone/patches/hackyMouse.patch
+++ b/Ports/pt2-clone/patches/hackyMouse.patch
@@ -1,0 +1,11 @@
+--- pt2-clone-1.28/src/pt2_visuals.c	2021-01-22 17:55:51.038785767 +0100
++++ pt2-clone-1.28/src/pt2_visuals.c.og	2021-01-22 17:55:12.287382000 +0100
+@@ -2426,7 +2426,7 @@
+ 		SDL_ShowCursor(SDL_FALSE);
+ 
+ 	// Workaround: SDL_GetGlobalMouseState() doesn't work with KMSDRM
+-	video.useDesktopMouseCoords = true;
++	video.useDesktopMouseCoords = false;
+ 	const char *videoDriver = SDL_GetCurrentVideoDriver();
+ 	if (videoDriver != NULL && strcmp("KMSDRM", videoDriver) == 0)
+ 		video.useDesktopMouseCoords = true;


### PR DESCRIPTION
So after trying to port MilkyTracker and failing miserably, i tried to port something else. It's a port of pt2-clone by 8bitbubsy. I also need to thank @danboid because i was searching through issues here and this clone(or ft2-clone?) was mentioned in one of them.
This one atleast works and plays modules in comparison with the MilkyTracker port but has a small issue with mouse not being captured even after disabling HWCURSOR in protracker.ini

Here's a video if you want to see it in action.
https://www.youtube.com/watch?v=gxZfQc_plwI

(also note: SDL2 or this might not compile due to the recent changes in Gfx::Bitmap https://github.com/SerenityOS/SDL/pull/4)

![Screen Shot 2021-01-22 at 14 43 29](https://user-images.githubusercontent.com/13377926/105498255-39e95000-5cc0-11eb-91b9-c0a58f2f872d.png)
