### PR TITLE
LibGfx: Correctly handle source rect offset in draw_scaled_bitmap

### DIFF
--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -100,6 +100,8 @@ void Canvas::draw(Gfx::Painter& painter)
 
     auto buggie = Gfx::Bitmap::load_from_file("/res/graphics/buggie.png");
     painter.blit({ 25, 39 }, *buggie, { 2, 30, 62, 20 });
+    painter.draw_scaled_bitmap({ 88, 39, 62 * 2, 20 * 2 }, *buggie, { 2, 30, 62, 20 });
+    painter.draw_scaled_bitmap({ 202, 39, 80, 40 }, *buggie, { 2, 30, 62, 20 });
 }
 
 int main(int argc, char** argv)

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -841,7 +841,7 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, const IntRe
         for (int x = clipped_rect.left(); x <= clipped_rect.right(); ++x) {
             auto scaled_x = ((x - dst_rect.x()) * hscale) >> 16;
             auto scaled_y = ((y - dst_rect.y()) * vscale) >> 16;
-            auto src_pixel = get_pixel(source, scaled_x, scaled_y);
+            auto src_pixel = get_pixel(source, scaled_x + src_rect.left(), scaled_y + src_rect.top());
             if (has_opacity)
                 src_pixel.set_alpha(src_pixel.alpha() * opacity);
             if constexpr (has_alpha_channel) {


### PR DESCRIPTION
The do_draw_integer_scaled_bitmap() fastpath already handled this
correctly, but the arbitrary scale path did not.

Before:
![before](https://user-images.githubusercontent.com/3487/105509357-68a0ff80-5c9b-11eb-9082-77464d85f8f1.png)

After:
![after](https://user-images.githubusercontent.com/3487/105509393-70f93a80-5c9b-11eb-9cf0-10d74495fb8a.png)
