### PR TITLE
LibGfx: Remove Painter::blit_scaled() in favor of Painter::draw_scale…

### DIFF
--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -147,7 +147,7 @@ void Canvas::draw()
 
     auto buggie = Gfx::Bitmap::load_from_file("/res/graphics/buggie.png");
     painter.blit({ 280, 280 }, *buggie, buggie->rect(), 0.5);
-    painter.blit_scaled({ 360, 280, buggie->rect().width() * 2, buggie->rect().height() * 2 }, *buggie, buggie->rect(), 0.5, 0.5);
+    painter.draw_scaled_bitmap({ 360, 280, buggie->rect().width() * 2, buggie->rect().height() * 2 }, *buggie, buggie->rect());
 
     painter.draw_rect({ 20, 260, 480, 320 }, Color::DarkGray);
 

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -509,38 +509,6 @@ void Painter::draw_triangle(const IntPoint& a, const IntPoint& b, const IntPoint
     }
 }
 
-void Painter::blit_scaled(const IntRect& dst_rect_raw, const Gfx::Bitmap& source, const IntRect& src_rect, float hscale, float vscale)
-{
-    ASSERT(scale() == 1); // FIXME: Add scaling support.
-
-    auto dst_rect = IntRect(dst_rect_raw.location(), dst_rect_raw.size()).translated(translation());
-    auto clipped_rect = dst_rect.intersected(clip_rect());
-    if (clipped_rect.is_empty())
-        return;
-    const int first_row = (clipped_rect.top() - dst_rect.top());
-    const int last_row = (clipped_rect.bottom() - dst_rect.top());
-    const int first_column = (clipped_rect.left() - dst_rect.left());
-    RGBA32* dst = m_target->scanline(clipped_rect.y()) + clipped_rect.x();
-    const size_t dst_skip = m_target->pitch() / sizeof(RGBA32);
-
-    int x_start = first_column + src_rect.left();
-    for (int row = first_row; row <= last_row; ++row) {
-        int sr = (row + src_rect.top()) * vscale;
-        if (sr >= source.size().height() || sr < 0) {
-            dst += dst_skip;
-            continue;
-        }
-        const RGBA32* sl = source.scanline(sr);
-        for (int x = x_start; x < clipped_rect.width() + x_start; ++x) {
-            int sx = x * hscale;
-            if (sx < source.size().width() && sx >= 0)
-                dst[x - x_start] = sl[sx];
-        }
-        dst += dst_skip;
-    }
-    return;
-}
-
 void Painter::blit_with_opacity(const IntPoint& position, const Gfx::Bitmap& source, const IntRect& src_rect, float opacity)
 {
     ASSERT(scale() == 1); // FIXME: Add scaling support.

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -75,7 +75,6 @@ public:
     void blit_filtered(const IntPoint&, const Gfx::Bitmap&, const IntRect& src_rect, Function<Color(Color)>);
     void draw_tiled_bitmap(const IntRect& dst_rect, const Gfx::Bitmap&);
     void blit_offset(const IntPoint&, const Gfx::Bitmap&, const IntRect& src_rect, const IntPoint&);
-    void blit_scaled(const IntRect&, const Gfx::Bitmap&, const IntRect&, float, float);
     void blit_disabled(const IntPoint&, const Gfx::Bitmap&, const IntRect&, const Palette&);
     void draw_text(const IntRect&, const StringView&, const Font&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None);
     void draw_text(const IntRect&, const StringView&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None);

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -268,7 +268,7 @@ void Compositor::compose()
                 float vscale = (float)m_wallpaper->size().height() / (float)ws.size().height();
 
                 // TODO: this may look ugly, we should scale to a backing bitmap and then blit
-                painter.blit_scaled(rect, *m_wallpaper, rect, hscale, vscale);
+                painter.draw_scaled_bitmap(rect, *m_wallpaper, { rect.x() * hscale, rect.y() * vscale, rect.width() * hscale, rect.height() * vscale });
             } else {
                 ASSERT_NOT_REACHED();
             }


### PR DESCRIPTION
…d_bitmap()

draw_scaled_bitmap() has a clearer API (just source and dest rects --
blit_scaled() took those and scale factors and then ignored width and
height on the source rect and it was less clear what it was supposed to
do), and they do mostly the same thing.

The draw_scaled_bitmap() API takes an IntRect as source rect, so it's
currently not always possible to split a big draw_scaled_bitmap() into
two (or more) smaller draw_scaled_bitmap() calls that do the same thing
-- that'd require FloatRects. The compositor kind of wants this to be
possible, but there's already a FIXME about this not looking quite right
with the previous approach either.

draw_scaled_bitmap() handles transparent sources, so after this change
wallpapers with transparency will be blended instead of copied. But that
seems fine, and if not, the Right Fix for that is to remove the alpha
channel from wallpapers after loading them anyways.

As an added bonus, draw_scaled_bitmap() already handles display scale,
so this fixes window server asserts for background images that are shown
as "stretch" (#5017). The window server still asserts for "tile" and
"offset" for now though.

Calling draw_scaled_bitmap() here exposed a bug in it fixed by #5041.
Before that is merged, this change here will cause smearing on the
background image when moving windows around.