### PR TITLE
LibGfx: Implement blit_offset() in terms of blit()

### DIFF
--- a/Userland/Applications/DisplaySettings/MonitorWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.cpp
@@ -84,7 +84,7 @@ Gfx::Color MonitorWidget::background_color()
 
 void MonitorWidget::paint_event(GUI::PaintEvent& event)
 {
-    Gfx::IntRect screen_rect = { 0, 0, m_desktop_resolution.width(), m_desktop_resolution.height() };
+    Gfx::IntRect screen_rect = { { 0, 0 }, m_desktop_resolution };
     auto screen_bitmap = Gfx::Bitmap::create(m_monitor_bitmap->format(), m_desktop_resolution);
     GUI::Painter screen_painter(*screen_bitmap);
     screen_painter.fill_rect(screen_rect, m_desktop_color);
@@ -93,7 +93,7 @@ void MonitorWidget::paint_event(GUI::PaintEvent& event)
         if (m_desktop_wallpaper_mode == "simple") {
             screen_painter.blit({ 0, 0 }, *m_desktop_wallpaper_bitmap, m_desktop_wallpaper_bitmap->rect());
         } else if (m_desktop_wallpaper_mode == "center") {
-            Gfx::IntPoint offset { screen_rect.width() / 2 - m_desktop_wallpaper_bitmap->size().width() / 2, screen_rect.height() / 2 - m_desktop_wallpaper_bitmap->size().height() / 2 };
+            Gfx::IntPoint offset { (screen_rect.width() - m_desktop_wallpaper_bitmap->width()) / 2, (screen_rect.height() - m_desktop_wallpaper_bitmap->height()) / 2 };
             screen_painter.blit_offset(screen_rect.location(), *m_desktop_wallpaper_bitmap, screen_rect, offset);
         } else if (m_desktop_wallpaper_mode == "tile") {
             screen_painter.draw_tiled_bitmap(screen_bitmap->rect(), *m_desktop_wallpaper_bitmap);

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -626,40 +626,19 @@ void Painter::draw_tiled_bitmap(const IntRect& a_dst_rect, const Gfx::Bitmap& so
     ASSERT_NOT_REACHED();
 }
 
-void Painter::blit_offset(const IntPoint& position, const Gfx::Bitmap& source, const IntRect& src_rect, const IntPoint& offset)
+void Painter::blit_offset(const IntPoint& a_position, const Gfx::Bitmap& source, const IntRect& a_src_rect, const IntPoint& offset)
 {
-    ASSERT(scale() == 1); // FIXME: Add scaling support.
-
-    auto dst_rect = IntRect(position, src_rect.size()).translated(translation());
-    auto clipped_rect = dst_rect.intersected(clip_rect());
-    if (clipped_rect.is_empty())
-        return;
-    const int first_row = (clipped_rect.top() - dst_rect.top());
-    const int last_row = (clipped_rect.bottom() - dst_rect.top());
-    const int first_column = (clipped_rect.left() - dst_rect.left());
-    RGBA32* dst = m_target->scanline(clipped_rect.y()) + clipped_rect.x();
-    const size_t dst_skip = m_target->pitch() / sizeof(RGBA32);
-
-    if (source.format() == BitmapFormat::RGB32 || source.format() == BitmapFormat::RGBA32) {
-        int x_start = first_column + src_rect.left();
-        for (int row = first_row; row <= last_row; ++row) {
-            int sr = row - offset.y() + src_rect.top();
-            if (sr >= source.size().height() || sr < 0) {
-                dst += dst_skip;
-                continue;
-            }
-            const RGBA32* sl = source.scanline(sr);
-            for (int x = x_start; x < clipped_rect.width() + x_start; ++x) {
-                int sx = x - offset.x();
-                if (sx < source.size().width() && sx >= 0)
-                    dst[x - x_start] = sl[sx];
-            }
-            dst += dst_skip;
-        }
-        return;
+    auto src_rect = IntRect { a_src_rect.location() - offset, a_src_rect.size() };
+    auto position = a_position;
+    if (src_rect.x() < 0) {
+        position.set_x(position.x() - src_rect.x());
+        src_rect.set_x(0);
     }
-
-    ASSERT_NOT_REACHED();
+    if (src_rect.y() < 0) {
+        position.set_y(position.y() - src_rect.y());
+        src_rect.set_y(0);
+    }
+    blit(position, source, src_rect);
 }
 
 void Painter::blit_with_alpha(const IntPoint& position, const Gfx::Bitmap& source, const IntRect& a_src_rect)

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -257,10 +257,8 @@ void Compositor::compose()
             if (m_wallpaper_mode == WallpaperMode::Simple) {
                 painter.blit(rect.location(), *m_wallpaper, rect);
             } else if (m_wallpaper_mode == WallpaperMode::Center) {
-                Gfx::IntPoint offset { ws.size().width() / 2 - m_wallpaper->size().width() / 2,
-                    ws.size().height() / 2 - m_wallpaper->size().height() / 2 };
-                painter.blit_offset(rect.location(), *m_wallpaper,
-                    rect, offset);
+                Gfx::IntPoint offset { (ws.width() - m_wallpaper->width()) / 2, (ws.height() - m_wallpaper->height()) / 2 };
+                painter.blit_offset(rect.location(), *m_wallpaper, rect, offset);
             } else if (m_wallpaper_mode == WallpaperMode::Tile) {
                 painter.draw_tiled_bitmap(rect, *m_wallpaper);
             } else if (m_wallpaper_mode == WallpaperMode::Stretch) {


### PR DESCRIPTION
It's less code, and blit() already handles scaled painters.

Fixes the window server asserting in highdpi mode with a centered
background image. Part of #5017.