### PR TITLE
Kernel: Use system time as entropy if CPU doesn't support RDRAND

### DIFF
--- a/Kernel/Time/HPET.cpp
+++ b/Kernel/Time/HPET.cpp
@@ -269,6 +269,12 @@ u64 HPET::update_time(u64& seconds_since_boot, u32& ticks_this_second, bool quer
     return (delta_ticks * 1000000000ull) / ticks_per_second;
 }
 
+u64 HPET::read_main_counter() const
+{
+    auto& main_counter = registers().main_counter_value;
+    return ((u64)main_counter.high << 32) | (u64)main_counter.low;
+}
+
 void HPET::enable_periodic_interrupt(const HPETComparator& comparator)
 {
 #ifdef HPET_DEBUG

--- a/Kernel/Time/HPET.h
+++ b/Kernel/Time/HPET.h
@@ -60,6 +60,7 @@ public:
     void disable_periodic_interrupt(const HPETComparator& comparator);
 
     u64 update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only);
+    u64 read_main_counter() const;
 
     Vector<unsigned> capable_interrupt_numbers(u8 comparator_number);
     Vector<unsigned> capable_interrupt_numbers(const HPETComparator&);

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -80,6 +80,8 @@ public:
     timespec remaining_epoch_time_adjustment() const { return m_remaining_epoch_time_adjustment; }
     void set_remaining_epoch_time_adjustment(const timespec& adjustment) { m_remaining_epoch_time_adjustment = adjustment; }
 
+    bool can_query_precise_time() const { return m_can_query_precise_time; }
+
 private:
     bool probe_and_set_legacy_hardware_timers();
     bool probe_and_set_non_legacy_hardware_timers();

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -140,9 +140,9 @@ extern "C" [[noreturn]] void init()
 
     klog() << "Starting SerenityOS...";
 
-    __stack_chk_guard = get_fast_random<u32>();
-
     TimeManagement::initialize(0);
+
+    __stack_chk_guard = get_fast_random<u32>();
 
     NullDevice::initialize();
     if (!get_serial_debug())


### PR DESCRIPTION
We don't have anything better for these CPUs for now, but should be enough since it's better than hanging on black screen :).

Fixes #4490.