### PR TITLE
Meta: Use a bash shebang for text-to-cpp-string.sh

### DIFF
--- a/Meta/text-to-cpp-string.sh
+++ b/Meta/text-to-cpp-string.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # $1 name of the variable
 # $2 input path
 


### PR DESCRIPTION
Previously we had /bin/sh, which might be bash but is run in POSIX mode on some systems, causing read -r to not work correctly and inserting newlines when encountering literal "\n" in the source.

Fixes #5040.