### PR TITLE
Build: Use cmake's make_directory utility instead of env(1) and mkdir(1) in CMake files.

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -390,7 +390,7 @@ add_custom_target(generate_PropertyID.h DEPENDS CSS/PropertyID.h)
 
 add_custom_command(
     OUTPUT CSS/PropertyID.cpp
-    COMMAND /usr/bin/env -S mkdir -p CSS
+    COMMAND ${CMAKE_COMMAND} -E make_directory CSS
     COMMAND ${write_if_different} CSS/PropertyID.cpp CodeGenerators/Generate_CSS_PropertyID_cpp ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Properties.json
     VERBATIM
     DEPENDS Generate_CSS_PropertyID_cpp
@@ -408,7 +408,7 @@ add_custom_target(generate_ValueID.h DEPENDS CSS/ValueID.h)
 
 add_custom_command(
     OUTPUT CSS/ValueID.cpp
-    COMMAND /usr/bin/env -S mkdir -p CSS
+    COMMAND ${CMAKE_COMMAND} -E make_directory CSS
     COMMAND ${write_if_different} CSS/ValueID.cpp CodeGenerators/Generate_CSS_ValueID_cpp ${CMAKE_CURRENT_SOURCE_DIR}/CSS/Identifiers.json
     VERBATIM
     DEPENDS Generate_CSS_ValueID_cpp


### PR DESCRIPTION
The `-S`s were also unnecessary here since "mkdir" doesn't have any spaces and these are not shebangs.