### PR TITLE
WindowManager: Fix (un-)maximizing and (un-)tiling

### DIFF
--- a/Userland/Libraries/LibGfx/Rect.cpp
+++ b/Userland/Libraries/LibGfx/Rect.cpp
@@ -141,6 +141,16 @@ void Rect<T>::align_within(const Rect<T>& other, TextAlignment alignment)
     }
 }
 
+template<typename T>
+void Rect<T>::set_size_around(const Size<T>& new_size, const Point<T>& fixed_point)
+{
+    const T new_x = fixed_point.x() - (T)(new_size.width() * ((float)(fixed_point.x() - x()) / width()));
+    const T new_y = fixed_point.y() - (T)(new_size.height() * ((float)(fixed_point.y() - y()) / height()));
+
+    set_location({ new_x, new_y });
+    set_size(new_size);
+}
+
 template<>
 String IntRect::to_string() const
 {

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -114,6 +114,8 @@ public:
         m_size = size;
     }
 
+    void set_size_around(const Size<T>&, const Point<T>& fixed_point);
+
     void set_size(T width, T height)
     {
         m_size.set_width(width);

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -688,9 +688,10 @@ void Window::set_tiled(WindowTileType tiled)
     if (resize_aspect_ratio().has_value())
         return;
 
-    m_tiled = tiled;
-    if (tiled != WindowTileType::None)
+    if (m_tiled == WindowTileType::None)
         m_untiled_rect = m_rect;
+    m_tiled = tiled;
+
     set_rect(tiled_rect(tiled));
     Core::EventLoop::current().post_event(*this, make<ResizeEvent>(m_rect));
 }

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -158,6 +158,7 @@ public:
     void set_rect(const Gfx::IntRect&);
     void set_rect(int x, int y, int width, int height) { set_rect({ x, y, width, height }); }
     void set_rect_without_repaint(const Gfx::IntRect&);
+    void normalize_rect();
 
     void set_taskbar_rect(const Gfx::IntRect&);
     const Gfx::IntRect& taskbar_rect() const { return m_taskbar_rect; }

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -103,13 +103,14 @@ public:
     void set_resizable(bool);
 
     bool is_maximized() const { return m_maximized; }
-    void set_maximized(bool);
+    void set_maximized(bool, Optional<Gfx::IntPoint> fixed_point = {});
 
     bool is_fullscreen() const { return m_fullscreen; }
     void set_fullscreen(bool);
 
     WindowTileType tiled() const { return m_tiled; }
     void set_tiled(WindowTileType);
+    bool set_untiled(const Gfx::IntPoint& fixed_point);
 
     bool is_occluded() const { return m_occluded; }
     void set_occluded(bool);
@@ -220,7 +221,16 @@ public:
     void set_size_increment(const Gfx::IntSize& increment) { m_size_increment = increment; }
 
     const Optional<Gfx::IntSize>& resize_aspect_ratio() const { return m_resize_aspect_ratio; }
-    void set_resize_aspect_ratio(const Optional<Gfx::IntSize>& ratio) { m_resize_aspect_ratio = ratio; }
+    void set_resize_aspect_ratio(const Optional<Gfx::IntSize>& ratio)
+    {
+        // "Tiled" means that we take up a chunk of space relative to the screen.
+        // The screen can change, so "tiled" and "fixed aspect ratio" are mutually exclusive.
+        // Similarly for "maximized" and "fixed aspect ratio".
+        // In order to resolve this, undo those properties first:
+        set_untiled(position());
+        set_maximized(false);
+        m_resize_aspect_ratio = ratio;
+    }
 
     Gfx::IntSize base_size() const { return m_base_size; }
     void set_base_size(const Gfx::IntSize& size) { m_base_size = size; }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -530,9 +530,7 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event, Window*& hove
                 m_move_origin = event.position();
                 if (m_move_origin.y() <= secondary_deadzone)
                     return true;
-                auto width_before_resize = m_move_window->width();
-                m_move_window->set_maximized(false);
-                m_move_window->move_to(m_move_origin.x() - (m_move_window->width() * ((float)m_move_origin.x() / width_before_resize)), m_move_origin.y());
+                m_move_window->set_maximized(false, event.position());
                 m_move_window_origin = m_move_window->position();
             }
         } else {
@@ -558,15 +556,18 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event, Window*& hove
                 m_move_window->set_tiled(WindowTileType::Top);
             } else if (is_resizable && event.y() >= desktop.bottom() - secondary_deadzone) {
                 m_move_window->set_tiled(WindowTileType::Bottom);
-            } else if (pixels_moved_from_start > 5 || m_move_window->tiled() == WindowTileType::None) {
-                m_move_window->set_tiled(WindowTileType::None);
+            } else if (m_move_window->tiled() == WindowTileType::None) {
                 Gfx::IntPoint pos = m_move_window_origin.translated(event.position() - m_move_origin);
                 m_move_window->set_position_without_repaint(pos);
-                if (m_move_window->rect().contains(event.position()))
-                    hovered_window = m_move_window;
+            } else if (pixels_moved_from_start > 5) {
+                m_move_window->set_untiled(event.position());
+                m_move_origin = event.position();
+                m_move_window_origin = m_move_window->position();
             }
-            return true;
         }
+        if (m_move_window->rect().contains(event.position()))
+            hovered_window = m_move_window;
+        return true;
     }
     return false;
 }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -522,13 +522,14 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event, Window*& hove
 
         const int tiling_deadzone = 10;
         const int secondary_deadzone = 2;
+        auto desktop = desktop_rect();
 
         if (m_move_window->is_maximized()) {
             auto pixels_moved_from_start = event.position().pixels_moved(m_move_origin);
             if (pixels_moved_from_start > 5) {
                 // dbgln("[WM] de-maximizing window");
                 m_move_origin = event.position();
-                if (m_move_origin.y() <= secondary_deadzone)
+                if (m_move_origin.y() <= secondary_deadzone + desktop.top())
                     return true;
                 m_move_window->set_maximized(false, event.position());
                 m_move_window_origin = m_move_window->position();
@@ -536,7 +537,6 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event, Window*& hove
         } else {
             bool is_resizable = m_move_window->is_resizable();
             auto pixels_moved_from_start = event.position().pixels_moved(m_move_origin);
-            auto desktop = desktop_rect();
 
             if (is_resizable && event.x() <= tiling_deadzone) {
                 if (event.y() <= tiling_deadzone + desktop.top())

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -559,6 +559,8 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event, Window*& hove
             } else if (m_move_window->tiled() == WindowTileType::None) {
                 Gfx::IntPoint pos = m_move_window_origin.translated(event.position() - m_move_origin);
                 m_move_window->set_position_without_repaint(pos);
+                // "Bounce back" the window it it would end up too far outside the screen:
+                m_move_window->normalize_rect();
             } else if (pixels_moved_from_start > 5) {
                 m_move_window->set_untiled(event.position());
                 m_move_origin = event.position();


### PR DESCRIPTION
There were many things that could make a window inaccessible:
- A misbehaving program sending `CreateWindow`
- A perfectly upright program sending `CreateWindow` with `auto_position` set to true whose parent window is close to the border of the screen
- Unmaximizing (nearly always)
- Untiling (often, but not always)
- The user moving the window in an unfortunate way, so that the window is technically still accessible, but extremely hard to grab

Also, there was some funny logic around aspect ratio / tiling / maximization, where setting the aspect ratio did not cause the tiling/maximization to stop. And finally, when dragging a window upright, there was a bit of logic that was probably supposed to make the window stay maximized, but didn't work properly. This is fixed, too.

Closes issues #4135, #4644, #5052.

This also preserves a nice plug-in spot (`Window::normalize_rect`) that @tomuta probably needs for multi-monitor support :D