### PR TITLE
Deprecated dbg() and add kerneln().

### DIFF
--- a/AK/Debug.h
+++ b/AK/Debug.h
@@ -573,3 +573,15 @@ constexpr bool debug_lock_restore = true;
 #else
 constexpr bool debug_lock_restore = false;
 #endif
+
+#ifdef FUTEXQUEUE_DEBUG
+constexpr bool debug_futex_queue = true;
+#else
+constexpr bool debug_futex_queue = false;
+#endif
+
+#ifdef FUTEX_DEBUG
+constexpr bool debug_futex = true;
+#else
+constexpr bool debug_futex = false;
+#endif

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -405,6 +405,16 @@ void dbgln() { dbgln<enabled>(""); }
 
 void set_debug_enabled(bool);
 
+#ifdef KERNEL
+void vdmesgln(StringView fmtstr, TypeErasedFormatParams);
+
+template<typename... Parameters>
+void dmesgln(StringView fmtstr, const Parameters&... parameters) { vdmesgln(fmtstr, VariadicFormatParams { parameters... }); }
+template<typename... Parameters>
+void dmesgln(const char* fmtstr, const Parameters&... parameters) { vdmesgln(fmtstr, VariadicFormatParams { parameters... }); }
+inline void dmesgln() { dmesgln(""); }
+#endif
+
 template<typename T, typename = void>
 struct HasFormatter : TrueType {
 };
@@ -459,7 +469,9 @@ struct Formatter<FormatString> : Formatter<String> {
 
 } // namespace AK
 
-#ifndef KERNEL
+#ifdef KERNEL
+using AK::dmesgln;
+#else
 using AK::out;
 using AK::outln;
 

--- a/AK/LogStream.cpp
+++ b/AK/LogStream.cpp
@@ -149,7 +149,10 @@ KernelLogStream klog()
 #else
 DebugLogStream klog()
 {
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     return dbg();
+#    pragma GCC diagnostic pop
 }
 #endif
 

--- a/AK/LogStream.h
+++ b/AK/LogStream.h
@@ -179,7 +179,7 @@ inline const LogStream& operator<<(const LogStream& stream, bool value)
     return stream << (value ? "true" : "false");
 }
 
-DebugLogStream dbg();
+[[deprecated("Plase use dbgln in AK/Format.h instead.")]] DebugLogStream dbg();
 
 #ifdef KERNEL
 KernelLogStream klog();


### PR DESCRIPTION
This should prevent anyone from adding new `dbg()` statements. In the meantime I can work on finishing up the debug macro stuff and removing `klog()` as well.

I've also added `kernelln()` which is the format version of `klog()`. I am open to suggestions if someone has better idea, here are a few names that I came up with:

  - `kernelln`, currently my favorite.
  - `klogln`, feels a bit overloaded to me especially if we look at `vklogln`.
  - `logln`, isn't clear enough.
  - `kernln`, abbreviating doesn't make the name better in my opinion.
  - `syslogln`, doesn't entirely match what it does.
  - `sysln`, abbreviating doesn't make the name better in my opinion.
