### PR TITLE
Kernel: Fix "serial_debug" and text mode TTY

### DIFF
--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -335,7 +335,7 @@ void VirtualConsole::terminal_history_changed()
 void VirtualConsole::emit(const u8* data, size_t size)
 {
     for (size_t i = 0; i < size; i++)
-        TTY::emit(data[i]);
+        TTY::emit(data[i], true);
 }
 
 String VirtualConsole::device_name() const

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -307,10 +307,8 @@ void setup_serial_debug()
     // serial_debug will output all the klog() and dbgln() data to COM1 at
     // 8-N-1 57600 baud. this is particularly useful for debugging the boot
     // process on live hardware.
-    //
-    // note: it must be the first option in the boot cmdline.
     u32 cmdline = low_physical_to_virtual(multiboot_info_ptr->cmdline);
-    if (cmdline && StringView(reinterpret_cast<const char*>(cmdline)).starts_with("serial_debug"))
+    if (cmdline && StringView(reinterpret_cast<const char*>(cmdline)).contains("serial_debug"))
         set_serial_debug(true);
 }
 


### PR DESCRIPTION
Text mode TTY clients (i.e. the shell) receives input now, fixing `boot_mode=text` on QEMU.