### PR TITLE
SMP: Implement thread priority queues

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -670,9 +670,9 @@ void vdbgln(StringView fmtstr, TypeErasedFormatParams params)
 #    ifdef KERNEL
     if (Kernel::Processor::is_initialized() && Kernel::Thread::current()) {
         auto& thread = *Kernel::Thread::current();
-        builder.appendff("\033[34;1m[{}({}:{})]\033[0m: ", thread.process().name(), thread.pid().value(), thread.tid().value());
+        builder.appendff("\033[34;1m[#{} {}({}:{})]\033[0m: ", Kernel::Processor::id(), thread.process().name(), thread.pid().value(), thread.tid().value());
     } else {
-        builder.appendff("\033[34;1m[Kernel]\033[0m: ");
+        builder.appendff("\033[34;1m[#{} Kernel]\033[0m: ", Kernel::Processor::id());
     }
 #    else
     static TriState got_process_name = TriState::Unknown;

--- a/AK/LogStream.cpp
+++ b/AK/LogStream.cpp
@@ -129,7 +129,7 @@ DebugLogStream dbg()
 #endif
 #if defined(__serenity__) && defined(KERNEL)
     if (Kernel::Processor::is_initialized() && Kernel::Thread::current())
-        stream << "\033[34;1m[" << *Kernel::Thread::current() << "]\033[0m: ";
+        stream << "\033[34;1m[#" << Kernel::Processor::id() << " " << *Kernel::Thread::current() << "]\033[0m: ";
     else
         stream << "\033[36;1m[Kernel]\033[0m: ";
 #endif
@@ -141,7 +141,7 @@ KernelLogStream klog()
 {
     KernelLogStream stream;
     if (Kernel::Processor::is_initialized() && Kernel::Thread::current())
-        stream << "\033[34;1m[" << *Kernel::Thread::current() << "]\033[0m: ";
+        stream << "\033[34;1m[#" << Kernel::Processor::id() << " " << *Kernel::Thread::current() << "]\033[0m: ";
     else
         stream << "\033[36;1m[Kernel]\033[0m: ";
     return stream;

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -709,6 +709,7 @@ class Processor {
     u32 m_cpu;
     u32 m_in_irq;
     Atomic<u32, AK::MemoryOrder::memory_order_relaxed> m_in_critical;
+    static Atomic<u32> s_idle_cpu_mask;
 
     TSS32 m_tss;
     static FPUState s_clean_fpu_state;
@@ -762,6 +763,16 @@ public:
 
     void early_initialize(u32 cpu);
     void initialize(u32 cpu);
+
+    void idle_begin()
+    {
+        s_idle_cpu_mask.fetch_or(1u << m_cpu, AK::MemoryOrder::memory_order_relaxed);
+    }
+
+    void idle_end()
+    {
+        s_idle_cpu_mask.fetch_and(~(1u << m_cpu), AK::MemoryOrder::memory_order_relaxed);
+    }
 
     static u32 count()
     {
@@ -1010,6 +1021,7 @@ public:
     static void smp_unicast(u32 cpu, void (*callback)(), bool async);
     static void smp_unicast(u32 cpu, void (*callback)(void*), void* data, void (*free_data)(void*), bool async);
     static void smp_broadcast_flush_tlb(const PageDirectory*, VirtualAddress, size_t);
+    static u32 smp_wake_n_idle_processors(u32 wake_count);
 
     template<typename Callback>
     static void deferred_call_queue(Callback callback)

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -758,11 +758,6 @@ inline const LogStream& operator<<(const LogStream& stream, const Process& proce
     return stream << process.name() << '(' << process.pid().value() << ')';
 }
 
-inline u32 Thread::effective_priority() const
-{
-    return m_priority + m_extra_priority;
-}
-
 #define REQUIRE_NO_PROMISES                        \
     do {                                           \
         if (Process::current()->has_promises()) {  \

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -544,13 +544,17 @@ void Scheduler::notify_finalizer()
 
 void Scheduler::idle_loop(void*)
 {
-    dbgln("Scheduler[{}]: idle loop running", Processor::id());
+    auto& proc = Processor::current();
+    dbgln("Scheduler[{}]: idle loop running", proc.get_id());
     ASSERT(are_interrupts_enabled());
 
     for (;;) {
+        proc.idle_begin();
         asm("hlt");
 
-        if (Processor::id() == 0)
+        proc.idle_end();
+        ASSERT_INTERRUPTS_ENABLED();
+        if (Processor::current().id() == 0)
             yield();
     }
 }

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -70,6 +70,9 @@ public:
     static void idle_loop(void*);
     static void invoke_async();
     static void notify_finalizer();
+    static Thread& pull_next_runnable_thread();
+    static bool dequeue_runnable_thread(Thread&, bool = false);
+    static void queue_runnable_thread(Thread&);
 
     template<typename Callback>
     static inline IterationDecision for_each_runnable(Callback);

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -305,17 +305,16 @@ void Thread::relock_process(LockMode previous_locked, u32 lock_count_to_restore)
     // flagged by calling Scheduler::donate_to or Scheduler::yield
     // above. We have to do it this way because we intentionally
     // leave the critical section here to be able to switch contexts.
-    u32 prev_flags;
-    u32 prev_crit = Processor::current().clear_critical(prev_flags, true);
+    auto critical_before = Processor::current().in_critical();
+    ASSERT(critical_before);
 
-    // CONTEXT SWITCH HAPPENS HERE!
+    Scheduler::yield_from_critical();
 
-    // NOTE: We may be on a different CPU now!
-    Processor::current().restore_critical(prev_crit, prev_flags);
-
+    ASSERT(Processor::current().in_critical() == critical_before);
     if (previous_locked != LockMode::Unlocked) {
         // We've unblocked, relock the process if needed and carry on.
         RESTORE_LOCK(process().big_lock(), previous_locked, lock_count_to_restore);
+        ASSERT(Processor::current().in_critical() == critical_before);
     }
 }
 

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -919,7 +919,9 @@ void Thread::set_state(State new_state, u8 stop_signal)
         }
     }
 
-    if (m_state == Stopped) {
+    if (m_state == Runnable) {
+        Processor::smp_wake_n_idle_processors(1);
+    } else if (m_state == Stopped) {
         // We don't want to restore to Running state, only Runnable!
         m_stop_state = previous_state != Running ? previous_state : Runnable;
         auto& process = this->process();

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -83,6 +83,7 @@ class Thread
 
     friend class Process;
     friend class Scheduler;
+    friend class ThreadReadyQueue;
 
 public:
     inline static Thread* current()
@@ -102,7 +103,7 @@ public:
     void set_priority(u32 p) { m_priority = p; }
     u32 priority() const { return m_priority; }
 
-    u32 effective_priority() const;
+    u32 effective_priority() const { return m_priority; }
 
     void detach()
     {
@@ -1170,6 +1171,7 @@ public:
 
 private:
     IntrusiveListNode m_runnable_list_node;
+    int m_runnable_priority { -1 };
 
 private:
     friend struct SchedulerData;
@@ -1243,6 +1245,7 @@ private:
     TSS32 m_tss;
     TrapFrame* m_current_trap { nullptr };
     u32 m_saved_critical { 1 };
+    IntrusiveListNode m_ready_queue_node;
     Atomic<u32> m_cpu { 0 };
     u32 m_cpu_affinity { THREAD_AFFINITY_DEFAULT };
     u32 m_ticks_left { 0 };
@@ -1294,7 +1297,6 @@ private:
     State m_state { Invalid };
     String m_name;
     u32 m_priority { THREAD_PRIORITY_NORMAL };
-    u32 m_extra_priority { 0 };
 
     State m_stop_state { Invalid };
 

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -391,7 +391,7 @@ PageFaultResponse MemoryManager::handle_page_fault(const PageFault& fault)
         return PageFaultResponse::ShouldCrash;
     }
 
-    return region->handle_fault(fault);
+    return region->handle_fault(fault, lock);
 }
 
 OwnPtr<Region> MemoryManager::allocate_contiguous_kernel_region(size_t size, const StringView& name, u8 access, bool user_accessible, bool cacheable)

--- a/Kernel/VM/Region.h
+++ b/Kernel/VM/Region.h
@@ -93,7 +93,7 @@ public:
     bool is_kernel() const { return m_kernel || vaddr().get() >= 0xc0000000; }
     void set_kernel(bool kernel) { m_kernel = kernel; }
 
-    PageFaultResponse handle_fault(const PageFault&);
+    PageFaultResponse handle_fault(const PageFault&, ScopedSpinLock<RecursiveSpinLock>&);
 
     OwnPtr<Region> clone(Process&);
 
@@ -254,7 +254,7 @@ private:
     bool remap_vmobject_page(size_t index, bool with_flush = true);
 
     PageFaultResponse handle_cow_fault(size_t page_index);
-    PageFaultResponse handle_inode_fault(size_t page_index);
+    PageFaultResponse handle_inode_fault(size_t page_index, ScopedSpinLock<RecursiveSpinLock>&);
     PageFaultResponse handle_zero_fault(size_t page_index);
 
     bool map_individual_page_impl(size_t page_index);

--- a/Kernel/VM/SharedInodeVMObject.cpp
+++ b/Kernel/VM/SharedInodeVMObject.cpp
@@ -34,8 +34,8 @@ namespace Kernel {
 NonnullRefPtr<SharedInodeVMObject> SharedInodeVMObject::create_with_inode(Inode& inode)
 {
     size_t size = inode.size();
-    if (inode.shared_vmobject())
-        return *inode.shared_vmobject();
+    if (auto shared_vmobject = inode.shared_vmobject())
+        return shared_vmobject.release_nonnull();
     auto vmobject = adopt(*new SharedInodeVMObject(inode, size));
     vmobject->inode().set_shared_vmobject(*vmobject);
     return vmobject;


### PR DESCRIPTION
This is a continuation of #3864 and is based on #5100

For the purposes of implementing thread priority queues, I think this can be merged. I removed the commit to actually enable scheduling on all processors as there are at least two outstanding issues that prevent it from working properly:

- `KernelRng` needs some serious fixing as it almost instantly crashes the system, this is now tracked in #5132
- WindowServer hangs for a few seconds and resumes working normal, I suspect there is a race condition somewhere related to blockers.