### PR TITLE
CrashDaemon: Replace usleep() for 10ms with sleep() for 1s

### DIFF
--- a/Userland/Services/CrashDaemon/main.cpp
+++ b/Userland/Services/CrashDaemon/main.cpp
@@ -45,7 +45,7 @@ static void wait_until_coredump_is_ready(const String& coredump_path)
         if (statbuf.st_mode & 0400) // Check if readable
             break;
 
-        usleep(10000); // sleep for 10ms
+        sleep(1);
     }
 }
 


### PR DESCRIPTION
The "Conforming To" section of the [usleep man page for Linux](https://www.man7.org/linux/man-pages/man3/usleep.3.html) suggests `usleep()` was removed from the 2008 POSIX standard and recommends using `nanosleep()` instead:

       4.3BSD, POSIX.1-2001.  POSIX.1-2001 declares this function
       obsolete; use nanosleep(2) instead.  POSIX.1-2008 removes the
       specification of usleep().

Compliance with POSIX in Serenity is generally desired, but not required, and it looks like the sleep funtcions all wrap the `sys$clock_nanosleep` syscall anyway:

* https://github.com/SerenityOS/serenity/pull/3337#discussion_r479940749
* fd29bed656ffdad79edd8d8a614195d4ae53ae58

However, this begs the question: does `CrashDaemon` really need to hammer the filesystem with `stat()` 100 times per second (every 10 milliseconds) in `wait_until_coredump_is_ready()` ?

Simply waiting for one full second seems reasonable.
