### PR TITLE
LibJS: Check if class extends value has a valid prototype

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -36,8 +36,9 @@
     M(BigIntIntArgument, "BigInt argument must be an integer")                                                                          \
     M(BigIntInvalidValue, "Invalid value for BigInt: {}")                                                                               \
     M(ClassConstructorWithoutNew, "Class constructor {} must be called with 'new'")                                                     \
+    M(ClassExtendsValueNotAConstructorOrNull, "Class extends value {} is not a constructor or null")                                    \
+    M(ClassExtendsValueInvalidPrototype, "Class extends value has an invalid prototype {}")                                             \
     M(ClassIsAbstract, "Abstract class {} cannot be constructed directly")                                                              \
-    M(ClassDoesNotExtendAConstructorOrNull, "Class extends value {} is not a constructor or null")                                      \
     M(ConstructorWithoutNew, "{} constructor must be called with 'new'")                                                                \
     M(Convert, "Cannot convert {} to {}")                                                                                               \
     M(ConvertUndefinedToObject, "Cannot convert undefined to object")                                                                   \

--- a/Userland/Libraries/LibJS/Tests/classes/class-advanced-extends.js
+++ b/Userland/Libraries/LibJS/Tests/classes/class-advanced-extends.js
@@ -33,3 +33,17 @@ test("extending String", () => {
     const ms2 = new MyString2("abc");
     expect(ms2.charAt(1)).toBe("#b");
 });
+
+test("class extends value is invalid", () => {
+    expect(() => {
+        class A extends 123 {}
+    }).toThrowWithMessage(TypeError, "Class extends value 123 is not a constructor or null");
+});
+
+test("class extends value has invalid prototype", () => {
+    function f() {}
+    f.prototype = 123;
+    expect(() => {
+        class A extends f {}
+    }).toThrowWithMessage(TypeError, "Class extends value has an invalid prototype 123");
+});


### PR DESCRIPTION
If we have a function as class extends value, we still cannot assume that it has a prototype property and that property has a function or null as its value - blindly `calling to_object()` on it may fail.

Fixes #5075.