### PR TITLE
FileManager: Make DirectoryView open links in their real directory

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -29,6 +29,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/NumberFormat.h>
 #include <AK/StringBuilder.h>
+#include <LibCore/File.h>
 #include <LibCore/MimeData.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/FileIconProvider.h>
@@ -349,13 +350,15 @@ void DirectoryView::add_path_to_history(const StringView& path)
 
 void DirectoryView::open(const StringView& path)
 {
-    if (model().root_path() == path) {
+    auto real_path = Core::File::real_path_for(path);
+
+    if (model().root_path() == real_path) {
         model().update();
         return;
     }
 
     set_active_widget(&current_view());
-    model().set_root_path(path);
+    model().set_root_path(real_path);
 }
 
 void DirectoryView::set_status_message(const StringView& message)

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -114,9 +114,7 @@ int main(int argc, char** argv)
     String initial_location;
 
     if (argc >= 2) {
-        char* buffer = realpath(argv[1], nullptr);
-        initial_location = buffer;
-        free(buffer);
+        initial_location = Core::File::real_path_for(argv[1]);
     }
 
     if (initial_location.is_empty())


### PR DESCRIPTION
Previously it was possible to open a link like /home/anon/Desktop/Home,
leading to a folder with the same name. Now it correctly opens its real
path, which is /home/anon

This is my first time writing something in C++ and my first time contributing
to an open source project, I hope everything is fine with the pull request!