### PR TITLE
Hardware: Fixes for booting on Asus A7N8X-E Deluxe motherboard

### DIFF
--- a/Kernel/Random.cpp
+++ b/Kernel/Random.cpp
@@ -69,6 +69,7 @@ KernelRng::KernelRng()
 void KernelRng::wait_for_entropy()
 {
     if (!resource().is_ready()) {
+        dbgln("Entropy starvation...");
         m_seed_queue.wait_on({}, "KernelRng");
     }
 }
@@ -80,7 +81,7 @@ void KernelRng::wake_if_ready()
     }
 }
 
-size_t EntropySource::next_source { 0 };
+size_t EntropySource::next_source { static_cast<size_t>(EntropySource::Static::MaxHardcodedSourceIndex) };
 
 void get_good_random_bytes(u8* buffer, size_t buffer_size)
 {

--- a/Kernel/Random.h
+++ b/Kernel/Random.h
@@ -147,8 +147,18 @@ class EntropySource {
     };
 
 public:
+    enum class Static : size_t {
+        Interrupts,
+        MaxHardcodedSourceIndex,
+    };
+
     EntropySource()
         : m_source(next_source++)
+    {
+    }
+
+    EntropySource(Static hardcoded_source)
+        : m_source(static_cast<size_t>(hardcoded_source))
     {
     }
 
@@ -166,7 +176,6 @@ private:
     static size_t next_source;
     size_t m_pool { 0 };
     size_t m_source;
-    Lock m_lock;
 };
 
 // NOTE: These API's are primarily about expressing intent/needs in the calling code.

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/UUID.h>
+#include <Kernel/CommandLine.h>
 #include <Kernel/Devices/BlockDevice.h>
 #include <Kernel/FileSystem/Ext2FileSystem.h>
 #include <Kernel/PCI/Access.h>
@@ -60,11 +61,13 @@ bool StorageManagement::boot_argument_contains_partition_uuid()
 NonnullRefPtrVector<StorageController> StorageManagement::enumerate_controllers(bool force_pio) const
 {
     NonnullRefPtrVector<StorageController> controllers;
-    PCI::enumerate([&](const PCI::Address& address, PCI::ID) {
-        if (PCI::get_class(address) == 0x1 && PCI::get_subclass(address) == 0x1) {
-            controllers.append(IDEController::initialize(address, force_pio));
-        }
-    });
+    if (!kernel_command_line().contains("disable_ide")) {
+        PCI::enumerate([&](const PCI::Address& address, PCI::ID) {
+            if (PCI::get_class(address) == 0x1 && PCI::get_subclass(address) == 0x1) {
+                controllers.append(IDEController::initialize(address, force_pio));
+            }
+        });
+    }
     controllers.append(RamdiskController::initialize());
     return controllers;
 }


### PR DESCRIPTION
This is what it takes to boot SerenityOS in graphical mode on that particular motherboard.

Of note :
- `/dev/mouse` is missing. Worked around by making SystemServer ignore missing peripherals and by not making WindowServer require peripherals to work.
- The kernel doesn't like the IDE controllers on that motherboard. Worked around with `disable_ide` for now.
- An AMD K7-class CPU doesn't have RDRAND/RDSEED, making the system severely starved of entropy and essentially stuck. Worked around by adding interrupts as an entropy source.
- The system has been booted with a ramdisk over PXE. Local boot has not been attempted.