### PR TITLE
Shell: Disable ENSURE_WAITID_ONCE

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -60,9 +60,11 @@ extern char** environ;
 
 namespace Shell {
 
+// Note: Conditionally enabling this with `ifdef __serenity__` produces some odd behaviour
+// https://github.com/SerenityOS/serenity/pull/4921#discussion_r563338358
+#if 0
 // FIXME: This should eventually be removed once we've established that
 //        waitpid() is not passed the same job twice.
-#ifdef __serenity__
 #    define ENSURE_WAITID_ONCE
 #endif
 


### PR DESCRIPTION
Keeping it conditionally enabled seems to cause waitid to segfault for
unknown reasons.
```
 < CxByte> honestly...let's just remove ENSURE_WAITID_ONCE and pretend this weirdo behaviour never happened
 < andrewkaster> Problem for a few months from now, I like the way you think
 < CxByte> running just the preprocessor with the condition there, and the condition not there produces the exact same file
 < CxByte> so I declare spooky-action and will just remove that define.
```

If someone knows _why_ this is happening, please do tell!