### PR TITLE
LibJS: Set length of TypedArray constructors to 3

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -112,7 +112,7 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
         auto& vm = this->vm();                                                                                                         \
         NativeFunction::initialize(global_object);                                                                                     \
         define_property(vm.names.prototype, global_object.snake_name##_prototype(), 0);                                                \
-        define_property(vm.names.length, Value(1), Attribute::Configurable);                                                           \
+        define_property(vm.names.length, Value(3), Attribute::Configurable);                                                           \
         define_property(vm.names.BYTES_PER_ELEMENT, Value((i32)sizeof(Type)), 0);                                                      \
     }                                                                                                                                  \
     Value ConstructorName::call()                                                                                                      \


### PR DESCRIPTION
https://tc39.es/ecma262/#sec-typedarray-constructors

> Each TypedArray constructor [...] has a "length" property whose value is 3.