### PR TITLE
Kernel: Track previous mode when entering/exiting traps

### DIFF
--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -1078,6 +1078,7 @@ private:
 
 struct TrapFrame {
     u32 prev_irq_level;
+    TrapFrame* next_trap;
     RegisterState* regs; // must be last
 
     TrapFrame() = delete;
@@ -1087,7 +1088,7 @@ struct TrapFrame {
     TrapFrame& operator=(TrapFrame&&) = delete;
 };
 
-#define TRAP_FRAME_SIZE (2 * 4)
+#define TRAP_FRAME_SIZE (3 * 4)
 static_assert(TRAP_FRAME_SIZE == sizeof(TrapFrame));
 
 extern "C" void enter_trap_no_irq(TrapFrame*);

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -867,9 +867,20 @@ public:
         write_fs_u32(__builtin_offsetof(Processor, m_current_thread), FlatPtr(&current_thread));
     }
 
-    ALWAYS_INLINE u32 id()
+    ALWAYS_INLINE u32 get_id() const
     {
+        // NOTE: This variant should only be used when iterating over all
+        // Processor instances, or when it's guaranteed that the thread
+        // cannot move to another processor in between calling Processor::current
+        // and Processor::get_id, or if this fact is not important.
+        // All other cases should use Processor::id instead!
         return m_cpu;
+    }
+
+    ALWAYS_INLINE static u32 id()
+    {
+        // See comment in Processor::current_thread
+        return read_fs_u32(__builtin_offsetof(Processor, m_cpu));
     }
 
     ALWAYS_INLINE u32 raise_irq()

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -677,7 +677,7 @@ static bool procfs$cpuinfo(InodeIdentifier, KBufferBuilder& builder)
             JsonArray features;
             for (auto& feature : info.features().split(' '))
                 features.append(feature);
-            obj.add("processor", proc.id());
+            obj.add("processor", proc.get_id());
             obj.add("cpuid", info.cpuid());
             obj.add("family", info.display_family());
             obj.add("features", features);

--- a/Kernel/Interrupts/APIC.cpp
+++ b/Kernel/Interrupts/APIC.cpp
@@ -508,7 +508,7 @@ void APIC::init_finished(u32 cpu)
 void APIC::broadcast_ipi()
 {
 #if APIC_SMP_DEBUG
-    klog() << "SMP: Broadcast IPI from cpu #" << Processor::current().id();
+    klog() << "SMP: Broadcast IPI from cpu #" << Processor::id();
 #endif
     wait_for_pending_icr();
     write_icr(ICRReg(IRQ_APIC_IPI + IRQ_VECTOR_BASE, ICRReg::Fixed, ICRReg::Logical, ICRReg::Assert, ICRReg::TriggerMode::Edge, ICRReg::AllExcludingSelf));
@@ -516,11 +516,10 @@ void APIC::broadcast_ipi()
 
 void APIC::send_ipi(u32 cpu)
 {
-    auto& proc = Processor::current();
 #if APIC_SMP_DEBUG
-    klog() << "SMP: Send IPI from cpu #" << proc.id() << " to cpu #" << cpu;
+    klog() << "SMP: Send IPI from cpu #" << Processor::id() << " to cpu #" << cpu;
 #endif
-    ASSERT(cpu != proc.id());
+    ASSERT(cpu != Processor::id());
     ASSERT(cpu < 8);
     wait_for_pending_icr();
     write_icr(ICRReg(IRQ_APIC_IPI + IRQ_VECTOR_BASE, ICRReg::Fixed, ICRReg::Logical, ICRReg::Assert, ICRReg::TriggerMode::Edge, ICRReg::NoShorthand, 1u << cpu));
@@ -532,7 +531,7 @@ APICTimer* APIC::initialize_timers(HardwareTimerBase& calibration_timer)
         return nullptr;
 
     // We should only initialize and calibrate the APIC timer once on the BSP!
-    ASSERT(Processor::current().id() == 0);
+    ASSERT(Processor::id() == 0);
     ASSERT(!m_apic_timer);
 
     m_apic_timer = APICTimer::initialize(IRQ_APIC_TIMER, calibration_timer);
@@ -605,7 +604,7 @@ u32 APIC::get_timer_divisor()
 void APICIPIInterruptHandler::handle_interrupt(const RegisterState&)
 {
 #if APIC_SMP_DEBUG
-    klog() << "APIC IPI on cpu #" << Processor::current().id();
+    klog() << "APIC IPI on cpu #" << Processor::id();
 #endif
 }
 
@@ -620,7 +619,7 @@ bool APICIPIInterruptHandler::eoi()
 
 void APICErrInterruptHandler::handle_interrupt(const RegisterState&)
 {
-    klog() << "APIC: SMP error on cpu #" << Processor::current().id();
+    klog() << "APIC: SMP error on cpu #" << Processor::id();
 }
 
 bool APICErrInterruptHandler::eoi()

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -112,7 +112,7 @@ class Process
 public:
     inline static Process* current()
     {
-        auto current_thread = Processor::current().current_thread();
+        auto current_thread = Processor::current_thread();
         return current_thread ? &current_thread->process() : nullptr;
     }
 

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -500,7 +500,7 @@ void Scheduler::timer_tick(const RegisterState& regs)
         [[maybe_unused]] auto rc = perf_events.append_with_eip_and_ebp(regs.eip, regs.ebp, PERF_EVENT_SAMPLE, 0, 0);
     }
 
-    if (current_thread->tick((regs.cs & 3) == 0))
+    if (current_thread->tick())
         return;
 
     ASSERT_INTERRUPTS_DISABLED();

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -483,7 +483,7 @@ void Scheduler::timer_tick(const RegisterState& regs)
     ASSERT_INTERRUPTS_DISABLED();
     ASSERT(Processor::current().in_irq());
 
-    auto current_thread = Processor::current().current_thread();
+    auto current_thread = Processor::current_thread();
     if (!current_thread)
         return;
 

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -137,6 +137,7 @@ void syscall_handler(TrapFrame* trap)
 {
     auto& regs = *trap->regs;
     auto current_thread = Thread::current();
+    ASSERT(current_thread->previous_mode() == Thread::PreviousMode::UserMode);
     auto& process = current_thread->process();
 
     if (auto tracer = process.tracer(); tracer && tracer->is_tracing_syscalls()) {
@@ -205,6 +206,9 @@ void syscall_handler(TrapFrame* trap)
     current_thread->yield_if_stopped();
 
     current_thread->check_dispatch_pending_signal();
+
+    // If the previous mode somehow changed something is seriously messed up...
+    ASSERT(current_thread->previous_mode() == Thread::PreviousMode::UserMode);
 
     // Check if we're supposed to return to userspace or just die.
     current_thread->die_if_needed();

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -413,9 +413,9 @@ void Thread::finalize_dying_threads()
     }
 }
 
-bool Thread::tick(bool in_kernel)
+bool Thread::tick()
 {
-    if (in_kernel) {
+    if (previous_mode() == PreviousMode::KernelMode) {
         ++m_process->m_ticks_in_kernel;
         ++m_ticks_in_kernel;
     } else {

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -87,7 +87,7 @@ class Thread
 public:
     inline static Thread* current()
     {
-        return Processor::current().current_thread();
+        return Processor::current_thread();
     }
 
     explicit Thread(NonnullRefPtr<Process>);

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -971,7 +971,7 @@ public:
 
     void exit(void* = nullptr);
 
-    bool tick(bool in_kernel);
+    bool tick();
     void set_ticks_left(u32 t) { m_ticks_left = t; }
     u32 ticks_left() const { return m_ticks_left; }
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1106,6 +1106,14 @@ public:
     u32 ticks_in_user() const { return m_ticks_in_user; }
     u32 ticks_in_kernel() const { return m_ticks_in_kernel; }
 
+    enum class PreviousMode : u8 {
+        KernelMode = 0,
+        UserMode
+    };
+    PreviousMode previous_mode() const { return m_previous_mode; }
+    void set_previous_mode(PreviousMode mode) { m_previous_mode = mode; }
+    TrapFrame*& current_trap() { return m_current_trap; }
+
     RecursiveSpinLock& get_lock() const { return m_lock; }
 
 #if LOCK_DEBUG
@@ -1230,6 +1238,7 @@ private:
     NonnullRefPtr<Process> m_process;
     ThreadID m_tid { -1 };
     TSS32 m_tss;
+    TrapFrame* m_current_trap { nullptr };
     Atomic<u32> m_cpu { 0 };
     u32 m_cpu_affinity { THREAD_AFFINITY_DEFAULT };
     u32 m_ticks_left { 0 };
@@ -1261,6 +1270,7 @@ private:
     Atomic<bool> m_is_active { false };
     bool m_is_joinable { true };
     bool m_handling_page_fault { false };
+    PreviousMode m_previous_mode { PreviousMode::UserMode };
 
     unsigned m_syscall_count { 0 };
     unsigned m_inode_faults { 0 };

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1065,6 +1065,9 @@ public:
         m_is_active.store(active, AK::memory_order_release);
     }
 
+    u32 saved_critical() const { return m_saved_critical; }
+    void save_critical(u32 critical) { m_saved_critical = critical; }
+
     [[nodiscard]] bool is_active() const
     {
         return m_is_active.load(AK::MemoryOrder::memory_order_acquire);
@@ -1239,6 +1242,7 @@ private:
     ThreadID m_tid { -1 };
     TSS32 m_tss;
     TrapFrame* m_current_trap { nullptr };
+    u32 m_saved_critical { 1 };
     Atomic<u32> m_cpu { 0 };
     u32 m_cpu_affinity { THREAD_AFFINITY_DEFAULT };
     u32 m_ticks_left { 0 };

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -170,7 +170,7 @@ void TimeManagement::initialize(u32 cpu)
 
 void TimeManagement::set_system_timer(HardwareTimerBase& timer)
 {
-    ASSERT(Processor::current().id() == 0); // This should only be called on the BSP!
+    ASSERT(Processor::id() == 0); // This should only be called on the BSP!
     auto original_callback = m_system_timer->set_callback(nullptr);
     m_system_timer->disable();
     timer.set_callback(move(original_callback));
@@ -287,7 +287,7 @@ bool TimeManagement::probe_and_set_non_legacy_hardware_timers()
         // Update the time. We don't really care too much about the
         // frequency of the interrupt because we'll query the main
         // counter to get an accurate time.
-        if (Processor::current().id() == 0) {
+        if (Processor::id() == 0) {
             // TODO: Have the other CPUs call system_timer_tick directly
             increment_time_since_boot_hpet();
         }

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -378,16 +378,16 @@ PageFaultResponse MemoryManager::handle_page_fault(const PageFault& fault)
     ScopedSpinLock lock(s_mm_lock);
     if (Processor::current().in_irq()) {
         dbgln("CPU[{}] BUG! Page fault while handling IRQ! code={}, vaddr={}, irq level: {}",
-            Processor::current().id(), fault.code(), fault.vaddr(), Processor::current().in_irq());
+            Processor::id(), fault.code(), fault.vaddr(), Processor::current().in_irq());
         dump_kernel_regions();
         return PageFaultResponse::ShouldCrash;
     }
 #if PAGE_FAULT_DEBUG
-    dbgln("MM: CPU[{}] handle_page_fault({:#04x}) at {}", Processor::current().id(), fault.code(), fault.vaddr());
+    dbgln("MM: CPU[{}] handle_page_fault({:#04x}) at {}", Processor::id(), fault.code(), fault.vaddr());
 #endif
     auto* region = find_region_from_vaddr(fault.vaddr());
     if (!region) {
-        klog() << "CPU[" << Processor::current().id() << "] NP(error) fault at invalid address " << fault.vaddr();
+        klog() << "CPU[" << Processor::id() << "] NP(error) fault at invalid address " << fault.vaddr();
         return PageFaultResponse::ShouldCrash;
     }
 
@@ -745,7 +745,7 @@ u8* MemoryManager::quickmap_page(PhysicalPage& physical_page)
     mm_data.m_quickmap_prev_flags = mm_data.m_quickmap_in_use.lock();
     ScopedSpinLock lock(s_mm_lock);
 
-    u32 pte_idx = 8 + Processor::current().id();
+    u32 pte_idx = 8 + Processor::id();
     VirtualAddress vaddr(0xffe00000 + pte_idx * PAGE_SIZE);
 
     auto& pte = boot_pd3_pt1023[pte_idx];
@@ -765,7 +765,7 @@ void MemoryManager::unquickmap_page()
     ScopedSpinLock lock(s_mm_lock);
     auto& mm_data = get_data();
     ASSERT(mm_data.m_quickmap_in_use.is_locked());
-    u32 pte_idx = 8 + Processor::current().id();
+    u32 pte_idx = 8 + Processor::id();
     VirtualAddress vaddr(0xffe00000 + pte_idx * PAGE_SIZE);
     auto& pte = boot_pd3_pt1023[pte_idx];
     pte.clear();


### PR DESCRIPTION
This allows us to determine what the previous mode (user or kernel)
was, e.g. in the timer interrupt. This is used e.g. to determine
whether a signal handler should be set up.

Fixes #5096