### PR TITLE
Vim: Add a simple yank and put implementation

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -771,7 +771,7 @@ void TextEditor::delete_current_line()
         start = { 0, 0 };
         end = { 0, line(0).length() };
     } else if (m_cursor.line() == line_count() - 1) {
-        start = { m_cursor.line() - 1, line(m_cursor.line()).length() };
+        start = { m_cursor.line() - 1, line(m_cursor.line() - 1).length() };
         end = { m_cursor.line(), line(m_cursor.line()).length() };
     } else {
         start = { m_cursor.line(), 0 };

--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -44,7 +44,18 @@ private:
         Visual
     };
 
+    enum YankType {
+        Line,
+        Selection
+    };
+
     VimMode m_vim_mode { VimMode::Normal };
+
+    YankType m_yank_type {};
+    String m_yank_buffer {};
+    void yank(YankType);
+    void yank(TextRange);
+    void put(const GUI::KeyEvent&);
 
     TextPosition m_selection_start_position {};
     void update_selection_on_cursor_move();


### PR DESCRIPTION
Add a simple yank and put implementation. 

Add some key bindings that couldn't be used without yank and put such as 'y', 'yy', 'p', etc.

The FIXMEs added will be handled in the next commit or so.