### PR TITLE
LibGfx: Fix opacity handling in Painter::draw_scaled_bitmap

### DIFF
--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -108,10 +108,11 @@ void Canvas::draw(Gfx::Painter& painter)
 
     painter.blit({ 25, 101 }, *buggie, { 2, 30, 3 * buggie->width(), 20 });
 
-    // banner does not have an alpha channel.
-    auto banner = Gfx::Bitmap::load_from_file("/res/graphics/brand-banner.png");
-    painter.fill_rect({ 25, 122, 28, 20 }, Color::Green);
-    painter.blit({ 25, 122 }, *banner, { 314, 12, 28, 20 }, 0.8);
+    // grid does not have an alpha channel.
+    auto grid = Gfx::Bitmap::load_from_file("/res/wallpapers/grid.png");
+    ASSERT(!grid->has_alpha_channel());
+    painter.fill_rect({ 25, 122, 62, 20 }, Color::Green);
+    painter.blit({ 25, 122 }, *grid, { (grid->width() - 62) / 2, (grid->height() - 20) / 2 + 40, 62, 20 }, 0.9);
 }
 
 int main(int argc, char** argv)

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -527,7 +527,7 @@ void Painter::blit_with_opacity(const IntPoint& position, const Gfx::Bitmap& sou
         return draw_scaled_bitmap({ position, safe_src_rect.size() }, source, safe_src_rect, opacity);
 
     auto dst_rect = IntRect(position, safe_src_rect.size()).translated(translation());
-    auto clipped_rect = IntRect::intersection(dst_rect, clip_rect());
+    auto clipped_rect = dst_rect.intersected(clip_rect());
     if (clipped_rect.is_empty())
         return;
 
@@ -541,8 +541,9 @@ void Painter::blit_with_opacity(const IntPoint& position, const Gfx::Bitmap& sou
     const int first_column = clipped_rect.left() - dst_rect.left();
     const int last_column = clipped_rect.right() - dst_rect.left();
     RGBA32* dst = m_target->scanline(clipped_rect.y()) + clipped_rect.x();
-    const RGBA32* src = source.scanline(src_rect.top() + first_row) + src_rect.left() + first_column;
     const size_t dst_skip = m_target->pitch() / sizeof(RGBA32);
+
+    const RGBA32* src = source.scanline(src_rect.top() + first_row) + src_rect.left() + first_column;
     const unsigned src_skip = source.pitch() / sizeof(RGBA32);
 
     // FIXME: This does the wrong thing if source has an alpha channel: It ignores it and pretends that every pixel in source is fully opaque.

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -848,7 +848,7 @@ void Painter::draw_scaled_bitmap(const IntRect& a_dst_rect, const Gfx::Bitmap& s
     if (clipped_rect.is_empty())
         return;
 
-    if (source.has_alpha_channel()) {
+    if (source.has_alpha_channel() || opacity != 1.0f) {
         switch (source.format()) {
         case BitmapFormat::RGB32:
             do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, get_pixel<BitmapFormat::RGB32>, opacity);


### PR DESCRIPTION
Makes translucent windows work in hidpi mode.