### PR TITLE
LibGfx: Remove unreachable branch in Painter::draw_scaled_bitmap

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -877,9 +877,6 @@ void Painter::draw_scaled_bitmap(const IntRect& a_dst_rect, const Gfx::Bitmap& s
         case BitmapFormat::RGB32:
             do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, get_pixel<BitmapFormat::RGB32>, opacity);
             break;
-        case BitmapFormat::RGBA32:
-            do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, get_pixel<BitmapFormat::RGBA32>, opacity);
-            break;
         case BitmapFormat::Indexed8:
             do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, get_pixel<BitmapFormat::Indexed8>, opacity);
             break;


### PR DESCRIPTION
This is in the else block of a `(source.has_alpha_channel() || opacity != 1.0f)`
conditional, so it's guaranteed that !source.has_alpha_channel() in
here, which means source.format() can't be RGBA32.

No behavior change.