### PR TITLE
LibGUI: AbstractTableView: prevent setting an invalid index

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -235,7 +235,9 @@ void AbstractTableView::move_cursor_relative(int vertical_steps, int horizontal_
     } else {
         new_index = model.index(0, 0);
     }
-    set_cursor(new_index, selection_update);
+    if (new_index.is_valid()) {
+        set_cursor(new_index, selection_update);
+    }
 }
 
 void AbstractTableView::scroll_into_view(const ModelIndex& index, bool scroll_horizontally, bool scroll_vertically)


### PR DESCRIPTION
If you tried to move a cursor down when the last row is selected, the index becomes invalid without updating the selection. On the next cursor movement the invalid index is then reset to {0, 0}, selecting the first row instead.