### PR TITLE
LibGfx: Implement scaling support for Painter::blit_filtered()

### DIFF
--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -113,6 +113,10 @@ void Canvas::draw(Gfx::Painter& painter)
     ASSERT(!grid->has_alpha_channel());
     painter.fill_rect({ 25, 122, 62, 20 }, Color::Green);
     painter.blit({ 25, 122 }, *grid, { (grid->width() - 62) / 2, (grid->height() - 20) / 2 + 40, 62, 20 }, 0.9);
+
+    painter.blit_brightened({ 88, 122 }, *buggie, { 2, 30, 62, 20 });
+    painter.blit_dimmed({ 140, 122 }, *buggie, { 2, 30, 62, 20 });
+    painter.blit_disabled({ 192, 122 }, *buggie, { 2, 30, 62, 20 }, palette());
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
...and functions implemented in terms of it: blit_brightened(),
blit_dimmed(), blit_disabled().

In theory, this should stop the window server from asserting when
an application becomes unresponsive, but that feature seems to be
broken for unrelated reasons atm (#5111).