### PR TITLE
WindowServer: Fix client unresponsiveness detection

### DIFF
--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -892,6 +892,7 @@ void ClientConnection::may_have_become_unresponsive()
     m_ping_timer = Core::Timer::create_single_shot(1000, [this] {
         set_unresponsive(true);
     });
+    m_ping_timer->start();
 }
 
 void ClientConnection::did_become_responsive()


### PR DESCRIPTION
This broke in add01b3, where `Core::Timer::create_single_shot()` was changed to create a stopped timer. Fix it by actually starting the timer right away ourselves.

Fixes #5111.