### PR TITLE
Kernel: Fix some race conditions with Lock and waiting/waking threads

### DIFF
--- a/Kernel/WaitQueue.h
+++ b/Kernel/WaitQueue.h
@@ -34,9 +34,15 @@ namespace Kernel {
 
 class WaitQueue : public Thread::BlockCondition {
 public:
-    void wake_one();
+    u32 wake_one();
     u32 wake_n(u32 wake_count);
     u32 wake_all();
+
+    void should_block(bool block)
+    {
+        ScopedSpinLock lock(m_lock);
+        m_should_block = block;
+    }
 
     template<class... Args>
     Thread::BlockResult wait_on(const Thread::BlockTimeout& timeout, Args&&... args)
@@ -49,6 +55,7 @@ protected:
 
 private:
     bool m_wake_requested { false };
+    bool m_should_block { true };
 };
 
 }


### PR DESCRIPTION
There is a window between acquiring/releasing the lock with the atomic
variables and subsequently waiting or waking threads. With a single
processor this window was closed by using a critical section, but
this doesn't prevent other processors from running these code paths.
To solve this, set a flag in the WaitQueue while holding m_lock which
determines if threads should be blocked at all.

_These are from #5073, trying to keep my delta smaller because of so many logging changes, which makes rebasing very painful..._