### PR TITLE
crash: Add options for pledge() violation and failing assertion

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -467,7 +467,7 @@ public:
 
     bool has_promises() const
     {
-        return m_promises;
+        return m_has_promises;
     }
     bool has_promised(Pledge pledge) const
     {
@@ -637,6 +637,7 @@ private:
 
     RefPtr<Timer> m_alarm_timer;
 
+    bool m_has_promises { false };
     u32 m_promises { 0 };
     u32 m_execpromises { 0 };
 

--- a/Kernel/Syscalls/pledge.cpp
+++ b/Kernel/Syscalls/pledge.cpp
@@ -67,29 +67,24 @@ int Process::sys$pledge(Userspace<const Syscall::SC_pledge_params*> user_params)
         return true;
     };
 
-    u32 new_promises;
-    u32 new_execpromises;
+    u32 new_promises = 0;
+    u32 new_execpromises = 0;
 
     if (!promises.is_null()) {
-        new_promises = 0;
         if (!parse_pledge(promises, new_promises))
             return -EINVAL;
         if (m_promises && (!new_promises || new_promises & ~m_promises))
             return -EPERM;
-    } else {
-        new_promises = m_promises;
     }
 
     if (!execpromises.is_null()) {
-        new_execpromises = 0;
         if (!parse_pledge(execpromises, new_execpromises))
             return -EINVAL;
         if (m_execpromises && (!new_execpromises || new_execpromises & ~m_execpromises))
             return -EPERM;
-    } else {
-        new_execpromises = m_execpromises;
     }
 
+    m_has_promises = true;
     m_promises = new_promises;
     m_execpromises = new_execpromises;
 

--- a/Userland/Utilities/crash.cpp
+++ b/Userland/Utilities/crash.cpp
@@ -122,6 +122,7 @@ int main(int argc, char** argv)
     bool do_use_io_instruction = false;
     bool do_read_cpu_counter = false;
     bool do_pledge_violation = false;
+    bool do_failing_assertion = false;
 
     auto args_parser = Core::ArgsParser();
     args_parser.set_general_help(
@@ -145,6 +146,7 @@ int main(int argc, char** argv)
     args_parser.add_option(do_use_io_instruction, "Use an x86 I/O instruction in userspace", nullptr, 'I');
     args_parser.add_option(do_read_cpu_counter, "Read the x86 TSC (Time Stamp Counter) directly", nullptr, 'c');
     args_parser.add_option(do_pledge_violation, "Violate pledge()'d promises", nullptr, 'p');
+    args_parser.add_option(do_failing_assertion, "Perform a failing assertion", nullptr, 'n');
 
     if (argc != 2) {
         args_parser.print_usage(stderr, argv[0]);
@@ -334,6 +336,13 @@ int main(int argc, char** argv)
                 return Crash::Failure::DidNotCrash;
             }
             printf("Didn't pledge 'stdio', this should fail!\n");
+            return Crash::Failure::DidNotCrash;
+        }).run(run_type);
+    }
+
+    if (do_failing_assertion || do_all_crash_types) {
+        Crash("Perform a failing assertion", [] {
+            ASSERT(1 == 2);
             return Crash::Failure::DidNotCrash;
         }).run(run_type);
     }


### PR DESCRIPTION
...also, add support for `pledge("", nullptr)`.

![image](https://user-images.githubusercontent.com/19366641/105770149-1a238780-5f5f-11eb-8207-ec6e5d4262d3.png)
