### PR TITLE
Documentation: Fix typo in CodingStyle.md

### DIFF
--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -401,7 +401,7 @@ public:
 
     void jam();
 
-private;
+private:
     String m_name;
     int m_frob_count { 0 };
 }


### PR DESCRIPTION
I know this is a minor thing, that does not affect the quality of the documentation at all.