### PR TITLE
Swap confirm and cancel buttons on the file picker

### DIFF
--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -210,18 +210,18 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, Options options, const 
     button_container.layout()->set_spacing(4);
     button_container.layout()->add_spacer();
 
-    auto& cancel_button = button_container.add<Button>();
-    cancel_button.set_fixed_width(80);
-    cancel_button.set_text("Cancel");
-    cancel_button.on_click = [this](auto) {
-        done(ExecCancel);
-    };
-
     auto& ok_button = button_container.add<Button>();
     ok_button.set_fixed_width(80);
     ok_button.set_text(ok_button_name(m_mode));
     ok_button.on_click = [this](auto) {
         on_file_return();
+    };
+
+    auto& cancel_button = button_container.add<Button>();
+    cancel_button.set_fixed_width(80);
+    cancel_button.set_text("Cancel");
+    cancel_button.on_click = [this](auto) {
+        done(ExecCancel);
     };
 
     m_view->on_activation = [this](auto& index) {

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -301,7 +301,7 @@ void FilePicker::on_file_return()
     LexicalPath path(String::formatted("{}/{}", m_model->root_path(), m_filename_textbox->text()));
 
     if (FilePicker::file_exists(path.string()) && m_mode == Mode::Save) {
-        auto result = MessageBox::show(this, "File already exists, overwrite?", "Existing File", MessageBox::Type::Warning, MessageBox::InputType::OKCancel);
+        auto result = MessageBox::show(this, "File already exists. Overwrite?", "Existing File", MessageBox::Type::Warning, MessageBox::InputType::OKCancel);
         if (result == MessageBox::ExecCancel)
             return;
     }


### PR DESCRIPTION
And tweak a confirm dialog text.

Not sure if the button order is intentional, but it's inconsistent with the rest of the system as far as I can tell.