### PR TITLE
TextEditor: Add vim status indicators to the statusbar

### DIFF
--- a/Userland/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Userland/Applications/TextEditor/TextEditorWidget.cpp
@@ -39,11 +39,13 @@
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/CppSyntaxHighlighter.h>
+#include <LibGUI/EditingEngine.h>
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/FontPicker.h>
 #include <LibGUI/GMLSyntaxHighlighter.h>
 #include <LibGUI/INISyntaxHighlighter.h>
 #include <LibGUI/JSSyntaxHighlighter.h>
+#include <LibGUI/Label.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/MenuBar.h>
 #include <LibGUI/MessageBox.h>
@@ -57,6 +59,7 @@
 #include <LibGUI/ToolBarContainer.h>
 #include <LibGUI/VimEditingEngine.h>
 #include <LibGfx/Font.h>
+#include <LibGfx/FontDatabase.h>
 #include <LibMarkdown/Document.h>
 #include <LibWeb/OutOfProcessWebView.h>
 #include <string.h>
@@ -300,6 +303,21 @@ TextEditorWidget::TextEditorWidget()
     m_editor->add_custom_context_menu_action(*m_find_previous_action);
 
     m_statusbar = *find_descendant_of_type_named<GUI::StatusBar>("statusbar");
+
+    m_statusbar->label(m_vim_mode_statusbar_index)->set_visible(m_editor->editing_engine()->type() == GUI::EditingEngineType::Vim);
+    m_statusbar->label(m_vim_mode_statusbar_index)->set_font(Gfx::FontDatabase::default_bold_font());
+
+    m_statusbar->label(m_vim_previous_keys_statusbar_index)->set_visible(m_editor->editing_engine()->type() == GUI::EditingEngineType::Vim);
+
+    m_editor->on_vim_statusbar_messages_changed = [this] {
+        m_statusbar->set_text(m_vim_mode_statusbar_index, m_editor->vim_mode_statusbar_message());
+        m_statusbar->set_text(m_vim_previous_keys_statusbar_index, m_editor->vim_previous_keys_statusbar_message());
+    };
+
+    m_editor->on_editing_engine_changed = [this]() {
+        m_statusbar->label(m_vim_mode_statusbar_index)->set_visible(m_editor->editing_engine()->type() == GUI::EditingEngineType::Vim);
+        m_statusbar->label(m_vim_previous_keys_statusbar_index)->set_visible(m_editor->editing_engine()->type() == GUI::EditingEngineType::Vim);
+    };
 
     m_editor->on_cursor_change = [this] { update_statusbar_cursor_position(); };
 
@@ -666,5 +684,5 @@ void TextEditorWidget::update_statusbar_cursor_position()
 {
     StringBuilder builder;
     builder.appendff("Line: {}, Column: {}", m_editor->cursor().line() + 1, m_editor->cursor().column());
-    m_statusbar->set_text(builder.to_string());
+    m_statusbar->set_text(m_cursor_position_statusbar_index, builder.to_string());
 }

--- a/Userland/Applications/TextEditor/TextEditorWidget.h
+++ b/Userland/Applications/TextEditor/TextEditorWidget.h
@@ -91,6 +91,9 @@ private:
     RefPtr<GUI::Action> m_html_preview_action;
 
     RefPtr<GUI::StatusBar> m_statusbar;
+    const int m_cursor_position_statusbar_index = 0;
+    const int m_vim_mode_statusbar_index = 1;
+    const int m_vim_previous_keys_statusbar_index = 2;
 
     RefPtr<GUI::TextBox> m_find_textbox;
     RefPtr<GUI::TextBox> m_replace_textbox;

--- a/Userland/Applications/TextEditor/TextEditorWindow.gml
+++ b/Userland/Applications/TextEditor/TextEditorWindow.gml
@@ -84,5 +84,6 @@
 
     @GUI::StatusBar {
         name: "statusbar"
+        label_count: 3
     }
 }

--- a/Userland/Libraries/LibGUI/EditingEngine.h
+++ b/Userland/Libraries/LibGUI/EditingEngine.h
@@ -37,6 +37,11 @@ enum CursorWidth {
     WIDE
 };
 
+enum EditingEngineType {
+    Regular,
+    Vim
+};
+
 class EditingEngine {
     AK_MAKE_NONCOPYABLE(EditingEngine);
     AK_MAKE_NONMOVABLE(EditingEngine);
@@ -51,10 +56,14 @@ public:
 
     virtual bool on_key(const KeyEvent& event);
 
+    EditingEngineType type() const { return m_editing_engine_type; }
+
 protected:
     EditingEngine() { }
 
     WeakPtr<TextEditor> m_editor;
+
+    EditingEngineType m_editing_engine_type;
 
     void move_one_left(const KeyEvent& event);
     void move_one_right(const KeyEvent& event);

--- a/Userland/Libraries/LibGUI/RegularEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/RegularEditingEngine.cpp
@@ -30,6 +30,11 @@
 
 namespace GUI {
 
+RegularEditingEngine::RegularEditingEngine()
+{
+    m_editing_engine_type = EditingEngineType::Regular;
+}
+
 CursorWidth RegularEditingEngine::cursor_width() const
 {
     return CursorWidth::NARROW;

--- a/Userland/Libraries/LibGUI/RegularEditingEngine.h
+++ b/Userland/Libraries/LibGUI/RegularEditingEngine.h
@@ -33,6 +33,8 @@ namespace GUI {
 class RegularEditingEngine final : public EditingEngine {
 
 public:
+    RegularEditingEngine();
+
     virtual CursorWidth cursor_width() const override;
 
     virtual bool on_key(const KeyEvent& event) override;

--- a/Userland/Libraries/LibGUI/StatusBar.cpp
+++ b/Userland/Libraries/LibGUI/StatusBar.cpp
@@ -44,15 +44,15 @@ StatusBar::StatusBar(int label_count)
     layout()->set_margins({ 0, 0, 0, 0 });
     layout()->set_spacing(2);
 
-    if (label_count < 1)
-        label_count = 1;
+    if (label_count > 0) {
+        for (auto i = 0; i < label_count; i++)
+            m_labels.append(create_label());
 
-    for (auto i = 0; i < label_count; i++)
-        m_labels.append(create_label());
-
-    m_corner = add<ResizeCorner>();
+        m_corner = add<ResizeCorner>();
+    }
 
     REGISTER_STRING_PROPERTY("text", text, set_text);
+    REGISTER_INT_PROPERTY("label_count", label_count, set_label_count);
 }
 
 StatusBar::~StatusBar()
@@ -102,6 +102,21 @@ void StatusBar::resize_event(ResizeEvent& event)
         m_corner->set_visible(window()->is_maximized() ? false : true);
 
     Widget::resize_event(event);
+}
+
+void StatusBar::set_label_count(int label_count)
+{
+    ASSERT(m_labels.is_empty());
+    m_label_count = label_count;
+    for (auto i = 0; i < label_count; ++i) {
+        m_labels.append(create_label());
+    }
+    m_corner = add<ResizeCorner>();
+}
+
+NonnullRefPtr<Label> StatusBar::label(int index) const
+{
+    return m_labels.at(index);
 }
 
 }

--- a/Userland/Libraries/LibGUI/StatusBar.h
+++ b/Userland/Libraries/LibGUI/StatusBar.h
@@ -39,9 +39,10 @@ public:
     String text(int index) const;
     void set_text(const StringView&);
     void set_text(int index, const StringView&);
+    NonnullRefPtr<Label> label(int index) const;
 
 protected:
-    explicit StatusBar(int label_count = 1);
+    explicit StatusBar(int label_count = 0);
     virtual void paint_event(PaintEvent&) override;
     virtual void resize_event(ResizeEvent&) override;
 
@@ -49,6 +50,12 @@ private:
     NonnullRefPtr<Label> create_label();
     NonnullRefPtrVector<Label> m_labels;
     RefPtr<ResizeCorner> m_corner;
+
+    // Used to initialize the number of labels that should
+    // be created from a GML file as opposed to the constructor.
+    int label_count() const { return m_label_count; }
+    void set_label_count(int);
+    int m_label_count {};
 };
 
 }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -150,6 +150,8 @@ public:
     Function<void()> on_down_pressed;
     Function<void()> on_pageup_pressed;
     Function<void()> on_pagedown_pressed;
+    Function<void()> on_vim_statusbar_messages_changed;
+    Function<void()> on_editing_engine_changed;
 
     Action& undo_action() { return *m_undo_action; }
     Action& redo_action() { return *m_redo_action; }
@@ -194,6 +196,9 @@ public:
     TextPosition text_position_at_content_position(const Gfx::IntPoint&) const;
 
     void delete_text_range(TextRange);
+
+    String vim_mode_statusbar_message() const { return m_vim_mode_statusbar_message; }
+    String vim_previous_keys_statusbar_message() const { return m_vim_previous_keys_statusbar_message; }
 
 protected:
     explicit TextEditor(Type = Type::MultiLine);
@@ -351,6 +356,9 @@ private:
     Gfx::IntPoint m_last_mousemove_position;
 
     RefPtr<Gfx::Bitmap> m_icon;
+
+    String m_vim_mode_statusbar_message {};
+    String m_vim_previous_keys_statusbar_message {};
 };
 
 }

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -30,6 +30,11 @@
 
 namespace GUI {
 
+VimEditingEngine::VimEditingEngine()
+{
+    m_editing_engine_type = EditingEngineType::Vim;
+}
+
 CursorWidth VimEditingEngine::cursor_width() const
 {
     return m_vim_mode == VimMode::Insert ? CursorWidth::NARROW : CursorWidth::WIDE;
@@ -101,19 +106,19 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
             delete_to.set_column(delete_to.column() + 1);
             m_editor->delete_text_range(TextRange(m_editor->cursor(), delete_to).normalized());
         }
-        m_previous_key = {};
+        clear_previous_key();
     } else if (m_previous_key == KeyCode::Key_G) {
         if (event.key() == KeyCode::Key_G) {
             move_to_first_line();
         } else if (event.key() == KeyCode::Key_E) {
             move_to_end_of_previous_word();
         }
-        m_previous_key = {};
+        clear_previous_key();
     } else if (m_previous_key == KeyCode::Key_Y) {
         if (event.key() == KeyCode::Key_Y) {
             yank(Line);
         }
-        m_previous_key = {};
+        clear_previous_key();
     } else if (m_previous_key == KeyCode::Key_C) {
         if (event.key() == KeyCode::Key_C) {
             // Needed because the code to replace the deleted line is called after delete_line() so
@@ -169,7 +174,7 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
             m_editor->delete_text_range(TextRange(adjusted_cursor, delete_to).normalized());
             switch_to_insert_mode();
         }
-        m_previous_key = {};
+        clear_previous_key();
     } else {
         // Handle first any key codes that are to be applied regardless of modifiers.
         switch (event.key()) {
@@ -240,7 +245,7 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
                 move_to_beginning_of_previous_word();
                 break;
             case (KeyCode::Key_C):
-                m_previous_key = event.key();
+                set_previous_key(event);
                 break;
             case (KeyCode::Key_Backspace):
             case (KeyCode::Key_H):
@@ -248,13 +253,13 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
                 move_one_left(event);
                 break;
             case (KeyCode::Key_D):
-                m_previous_key = event.key();
+                set_previous_key(event);
                 break;
             case (KeyCode::Key_E):
                 move_to_end_of_next_word();
                 break;
             case (KeyCode::Key_G):
-                m_previous_key = event.key();
+                set_previous_key(event);
                 break;
             case (KeyCode::Key_Down):
             case (KeyCode::Key_J):
@@ -293,7 +298,7 @@ bool VimEditingEngine::on_key_in_normal_mode(const KeyEvent& event)
                 switch_to_visual_mode();
                 break;
             case (KeyCode::Key_Y):
-                m_previous_key = event.key();
+                set_previous_key(event);
                 break;
             case (KeyCode::Key_P):
                 put(event);
@@ -316,7 +321,7 @@ bool VimEditingEngine::on_key_in_visual_mode(const KeyEvent& event)
             move_to_end_of_previous_word();
             update_selection_on_cursor_move();
         }
-        m_previous_key = {};
+        clear_previous_key();
     } else {
         // Handle first any key codes that are to be applied regardless of modifiers.
         switch (event.key()) {
@@ -391,7 +396,7 @@ bool VimEditingEngine::on_key_in_visual_mode(const KeyEvent& event)
                 update_selection_on_cursor_move();
                 break;
             case (KeyCode::Key_G):
-                m_previous_key = event.key();
+                set_previous_key(event);
                 break;
             case (KeyCode::Key_Down):
             case (KeyCode::Key_J):
@@ -448,26 +453,32 @@ void VimEditingEngine::switch_to_normal_mode()
 {
     m_vim_mode = VimMode::Normal;
     m_editor->reset_cursor_blink();
-    m_previous_key = {};
+    clear_previous_key();
     clear_visual_mode_data();
+    if (on_mode_change)
+        on_mode_change(m_vim_mode);
 };
 
 void VimEditingEngine::switch_to_insert_mode()
 {
     m_vim_mode = VimMode::Insert;
     m_editor->reset_cursor_blink();
-    m_previous_key = {};
+    clear_previous_key();
     clear_visual_mode_data();
+    if (on_mode_change)
+        on_mode_change(m_vim_mode);
 };
 
 void VimEditingEngine::switch_to_visual_mode()
 {
     m_vim_mode = VimMode::Visual;
     m_editor->reset_cursor_blink();
-    m_previous_key = {};
+    clear_previous_key();
     m_selection_start_position = m_editor->cursor();
     m_editor->selection()->set(m_editor->cursor(), { m_editor->cursor().line(), m_editor->cursor().column() + 1 });
     m_editor->did_update_selection();
+    if (on_mode_change)
+        on_mode_change(m_vim_mode);
 }
 
 void VimEditingEngine::update_selection_on_cursor_move()

--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -30,20 +30,48 @@
 
 namespace GUI {
 
+enum VimMode {
+    Normal,
+    Insert,
+    Visual
+};
+
 class VimEditingEngine final : public EditingEngine {
 
 public:
+    VimEditingEngine();
+
     virtual CursorWidth cursor_width() const override;
 
     virtual bool on_key(const KeyEvent& event) override;
 
-private:
-    enum VimMode {
-        Normal,
-        Insert,
-        Visual
+    class PreviousKey {
+    public:
+        PreviousKey() = default;
+        PreviousKey(const KeyEvent& event)
+            : key(event.key())
+            , code_point(event.code_point())
+        {
+        }
+
+        bool operator==(const KeyCode& key) const
+        {
+            return this->key == key;
+        }
+
+        bool operator==(const u32& code_point) const
+        {
+            return this->code_point == code_point;
+        }
+
+        KeyCode key {};
+        u32 code_point {};
     };
 
+    Function<void(VimMode)> on_mode_change;
+    Function<void(const PreviousKey&, bool has_previous_key)> on_previous_keys_change;
+
+private:
     enum YankType {
         Line,
         Selection
@@ -61,7 +89,26 @@ private:
     void update_selection_on_cursor_move();
     void clear_visual_mode_data();
 
-    KeyCode m_previous_key {};
+    // FIXME Support multiple previous keys, this is a temporary measure.
+    PreviousKey m_previous_key {};
+    bool has_previous_key { false };
+
+    void set_previous_key(PreviousKey event)
+    {
+        m_previous_key = event;
+        has_previous_key = true;
+        if (on_previous_keys_change)
+            on_previous_keys_change(m_previous_key, has_previous_key);
+    }
+
+    void clear_previous_key()
+    {
+        m_previous_key = {};
+        has_previous_key = false;
+        if (on_previous_keys_change)
+            on_previous_keys_change(m_previous_key, has_previous_key);
+    }
+
     void switch_to_normal_mode();
     void switch_to_insert_mode();
     void switch_to_visual_mode();


### PR DESCRIPTION
When using the VimEditingEngine in the TextEditor application, vim's
mode and the previous key are shown in the editor's status bar.

At the moment the UI doesn't look great because in the `GUI::StatusBar`, you can only set the number of labels in the constructor. And as far as I could see, you can't set constructor arguments in GML files. Correct me if I'm wrong there.

To get around this, I added a method to `GUI::StatusBar` that allows me to add labels after the constructor has been called, but then the resize corner wasn't updating with the new labels and I thought I'd better just stop there and ask what you think before changing more stuff.