### PR TITLE
WindowManager: Make menus usable without a mouse

### DIFF
--- a/Kernel/API/KeyCode.h
+++ b/Kernel/API/KeyCode.h
@@ -134,7 +134,8 @@
     __ENUMERATE_KEY_CODE(Pipe, "|")                  \
     __ENUMERATE_KEY_CODE(Tilde, "~")                 \
     __ENUMERATE_KEY_CODE(Backtick, "`")              \
-    __ENUMERATE_KEY_CODE(Logo, "Logo")
+    __ENUMERATE_KEY_CODE(Logo, "Logo")               \
+    __ENUMERATE_KEY_CODE(Menu, "Menu")
 
 enum KeyCode : u8 {
 #define __ENUMERATE_KEY_CODE(name, ui_name) Key_##name,

--- a/Kernel/Devices/KeyboardDevice.cpp
+++ b/Kernel/Devices/KeyboardDevice.cpp
@@ -132,6 +132,8 @@ static const KeyCode unshifted_key_map[0x80] = {
     Key_Invalid,
     Key_Invalid,
     Key_Logo,
+    Key_Invalid,
+    Key_Menu,
 };
 
 static const KeyCode shifted_key_map[0x100] = {
@@ -227,6 +229,8 @@ static const KeyCode shifted_key_map[0x100] = {
     Key_Invalid,
     Key_Invalid,
     Key_Logo,
+    Key_Invalid,
+    Key_Menu,
 };
 
 static const KeyCode numpad_key_map[13] = { Key_7, Key_8, Key_9, Key_Invalid, Key_4, Key_5, Key_6, Key_Invalid, Key_1, Key_2, Key_3, Key_0, Key_Comma };

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -260,7 +260,7 @@ void Widget::event(Core::Event& event)
     case Event::Hide:
         return hide_event(static_cast<HideEvent&>(event));
     case Event::KeyDown:
-        return keydown_event(static_cast<KeyEvent&>(event));
+        return handle_keydown_event(static_cast<KeyEvent&>(event));
     case Event::KeyUp:
         return keyup_event(static_cast<KeyEvent&>(event));
     case Event::MouseMove:
@@ -291,6 +291,15 @@ void Widget::event(Core::Event& event)
         return change_event(static_cast<Event&>(event));
     default:
         return Core::Object::event(event);
+    }
+}
+
+void Widget::handle_keydown_event(KeyEvent& event)
+{
+    keydown_event(event);
+    if (event.key() == KeyCode::Key_Menu) {
+        ContextMenuEvent c_event(window_relative_rect().bottom_right(), screen_relative_rect().bottom_right());
+        context_menu_event(c_event);
     }
 }
 

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -345,6 +345,7 @@ private:
     void handle_mousedown_event(MouseEvent&);
     void handle_mousedoubleclick_event(MouseEvent&);
     void handle_mouseup_event(MouseEvent&);
+    void handle_keydown_event(KeyEvent&);
     void handle_enter_event(Core::Event&);
     void handle_leave_event(Core::Event&);
     void focus_previous_widget(FocusSource, bool siblings_only);

--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -391,9 +391,16 @@ void Menu::event(Core::Event& event)
         ASSERT(menu_window());
         ASSERT(menu_window()->is_visible());
 
-        // Default to the first item on key press if one has not been selected yet
+        // Default to the first enabled, non-separator item on key press if one has not been selected yet
         if (!hovered_item()) {
-            m_hovered_item_index = 0;
+            int counter = 0;
+            for (const auto& item : m_items) {
+                if (item.type() != MenuItem::Separator && item.is_enabled()) {
+                    m_hovered_item_index = counter;
+                    break;
+                }
+                counter++;
+            }
             update_for_new_hovered_item(key == Key_Right);
             return;
         }

--- a/Userland/Services/WindowServer/MenuManager.h
+++ b/Userland/Services/WindowServer/MenuManager.h
@@ -89,6 +89,9 @@ public:
             m_current_menubar->for_each_menu(callback);
     }
 
+    Menu* previous_menu(Menu* current);
+    Menu* next_menu(Menu* current);
+
     void did_change_theme();
 
 private:

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1087,6 +1087,9 @@ Gfx::IntRect WindowManager::arena_rect_for_type(WindowType type) const
 void WindowManager::event(Core::Event& event)
 {
     if (static_cast<Event&>(event).is_mouse_event()) {
+        if (event.type() != Event::MouseMove)
+            m_previous_event_is_key_down_logo = false;
+
         Window* hovered_window = nullptr;
         process_mouse_event(static_cast<MouseEvent&>(event), hovered_window);
         set_hovered_window(hovered_window);
@@ -1114,6 +1117,20 @@ void WindowManager::event(Core::Event& event)
             reload_icon_bitmaps_after_scale_change(!m_allow_hidpi_icons);
             Compositor::the().invalidate_screen();
             return;
+        }
+
+        if (key_event.type() == Event::KeyDown && key_event.key() == Key_Logo) {
+            m_previous_event_is_key_down_logo = true;
+        } else if (m_previous_event_is_key_down_logo) {
+            m_previous_event_is_key_down_logo = false;
+            if (key_event.type() == Event::KeyUp && key_event.key() == Key_Logo) {
+                if (MenuManager::the().has_open_menu()) {
+                    MenuManager::the().close_everyone();
+                } else {
+                    MenuManager::the().open_menu(*MenuManager::the().system_menu());
+                }
+                return;
+            }
         }
 
         if (MenuManager::the().current_menu()) {

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -353,6 +353,8 @@ private:
     String m_dnd_text;
     RefPtr<Core::MimeData> m_dnd_mime_data;
     RefPtr<Gfx::Bitmap> m_dnd_bitmap;
+
+    bool m_previous_event_is_key_down_logo { false };
 };
 
 template<typename Callback>


### PR DESCRIPTION
I'm working on bare-metal without a mouse and SerenityOS is missing lots of keyboard shortcuts for essential features... Let's start with the most critical one.