### PR TITLE
LibGfx: Correct the allocated buffer size in serialize_to_byte_buffer()

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -301,7 +301,7 @@ RefPtr<Bitmap> Bitmap::create_from_serialized_byte_buffer(ByteBuffer&& buffer)
 
 ByteBuffer Bitmap::serialize_to_byte_buffer() const
 {
-    auto buffer = ByteBuffer::create_uninitialized(4 * sizeof(unsigned) + sizeof(BitmapFormat) + sizeof(RGBA32) * palette_size(m_format) + size_in_bytes());
+    auto buffer = ByteBuffer::create_uninitialized(5 * sizeof(unsigned) + sizeof(BitmapFormat) + sizeof(RGBA32) * palette_size(m_format) + size_in_bytes());
     OutputMemoryStream stream { buffer };
 
     auto write = [&]<typename T>(T value) {


### PR DESCRIPTION
Fixes #5131.