### PR TITLE
Vim: Add change word and delete word functionality

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.h
+++ b/Userland/Libraries/LibGUI/EditingEngine.h
@@ -68,9 +68,13 @@ protected:
     void move_page_down(const KeyEvent& event);
     void move_to_first_line();
     void move_to_last_line();
+    TextPosition find_beginning_of_next_word();
     void move_to_beginning_of_next_word();
+    TextPosition find_end_of_next_word();
     void move_to_end_of_next_word();
+    TextPosition find_end_of_previous_word();
     void move_to_end_of_previous_word();
+    TextPosition find_beginning_of_previous_word();
     void move_to_beginning_of_previous_word();
 
     void move_up(const KeyEvent& event, double page_height_factor);

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1130,6 +1130,15 @@ void TextEditor::delete_selection()
     update();
 }
 
+void TextEditor::delete_text_range(TextRange range)
+{
+    auto normalized_range = range.normalized();
+    execute<RemoveTextCommand>(document().text_in_range(normalized_range), normalized_range);
+    did_change();
+    set_cursor(normalized_range.start());
+    update();
+}
+
 void TextEditor::insert_at_cursor_or_replace_selection(const StringView& text)
 {
     ReflowDeferrer defer(*this);

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -193,6 +193,8 @@ public:
     Gfx::IntRect cursor_content_rect() const;
     TextPosition text_position_at_content_position(const Gfx::IntPoint&) const;
 
+    void delete_text_range(TextRange);
+
 protected:
     explicit TextEditor(Type = Type::MultiLine);
 


### PR DESCRIPTION
Add the functionality of key sequences 'cw', 'ce', 'cb', 'dw', 'de' and 'db'.