### PR TITLE
BXVGADevice+MBVGADevice: Correctly check page-aligned mmaps

### DIFF
--- a/Kernel/Devices/BXVGADevice.cpp
+++ b/Kernel/Devices/BXVGADevice.cpp
@@ -177,8 +177,11 @@ KResultOr<Region*> BXVGADevice::mmap(Process& process, FileDescription&, const R
     REQUIRE_PROMISE(video);
     if (!shared)
         return ENODEV;
-    ASSERT(offset == 0);
-    ASSERT(range.size() == framebuffer_size_in_bytes());
+    if (offset != 0)
+        return ENXIO;
+    if (range.size() != PAGE_ROUND_UP(framebuffer_size_in_bytes()))
+        return EOVERFLOW;
+
     auto vmobject = AnonymousVMObject::create_for_physical_range(m_framebuffer_address, framebuffer_size_in_bytes());
     if (!vmobject)
         return ENOMEM;

--- a/Kernel/Devices/MBVGADevice.cpp
+++ b/Kernel/Devices/MBVGADevice.cpp
@@ -56,8 +56,11 @@ KResultOr<Region*> MBVGADevice::mmap(Process& process, FileDescription&, const R
     REQUIRE_PROMISE(video);
     if (!shared)
         return ENODEV;
-    ASSERT(offset == 0);
-    ASSERT(range.size() == framebuffer_size_in_bytes());
+    if (offset != 0)
+        return ENXIO;
+    if (range.size() != PAGE_ROUND_UP(framebuffer_size_in_bytes()))
+        return EOVERFLOW;
+
     auto vmobject = AnonymousVMObject::create_for_physical_range(m_framebuffer_address, framebuffer_size_in_bytes());
     if (!vmobject)
         return ENOMEM;


### PR DESCRIPTION
In ab14b0ac64cd8bcaf7060050a7ec5a99cf7bd121, `mmap` was changed so that the size of the region is aligned before it was passed to the device driver. The previous logic would assert when the framebuffer size was not a multiple of the page size. I've also taken the liberty of returning an error on `mmap` failure rather than asserting.