### PR TITLE
LibJS: Fix crash when printing error for missing class extends value prototype

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -818,7 +818,7 @@ Value ClassExpression::execute(Interpreter& interpreter, GlobalObject& global_ob
 
         Object* super_constructor_prototype = nullptr;
         if (!super_constructor.is_null()) {
-            auto super_constructor_prototype_value = super_constructor.as_object().get(vm.names.prototype);
+            auto super_constructor_prototype_value = super_constructor.as_object().get(vm.names.prototype).value_or(js_undefined());
             if (interpreter.exception())
                 return {};
             if (!super_constructor_prototype_value.is_object() && !super_constructor_prototype_value.is_null()) {


### PR DESCRIPTION
If it's missing we get an empty value, but we can't use that with `to_string_without_side_effects()` so we have to use undefined as the default.

Fixes #5142.