### PR TITLE
Kernel: Retire SchedulerData and add Thread lookup table

### DIFF
--- a/AK/DistinctNumeric.h
+++ b/AK/DistinctNumeric.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Traits.h>
 #include <AK/Types.h>
 
 namespace AK {
@@ -64,9 +65,9 @@ namespace AK {
  * There are many more operators that do not make sense for numerical types,
  * or cannot be overloaded in the first place. Naturally, they are not implemented.
  */
-template<typename T, bool Incr, bool Cmp, bool Bool, bool Flags, bool Shift, bool Arith, typename X>
+template<typename T, typename X, bool Incr, bool Cmp, bool Bool, bool Flags, bool Shift, bool Arith>
 class DistinctNumeric {
-    using Self = DistinctNumeric<T, Incr, Cmp, Bool, Flags, Shift, Arith, X>;
+    using Self = DistinctNumeric<T, X, Incr, Cmp, Bool, Flags, Shift, Arith>;
 
 public:
     DistinctNumeric(T value)
@@ -301,8 +302,14 @@ private:
 }
 
 #define TYPEDEF_DISTINCT_NUMERIC_GENERAL(T, Incr, Cmp, Bool, Flags, Shift, Arith, NAME) \
-    using NAME = DistinctNumeric<T, Incr, Cmp, Bool, Flags, Shift, Arith, struct __##NAME##_tag>;
+    using NAME = DistinctNumeric<T, struct __##NAME##_tag, Incr, Cmp, Bool, Flags, Shift, Arith>;
 #define TYPEDEF_DISTINCT_ORDERED_ID(T, NAME) TYPEDEF_DISTINCT_NUMERIC_GENERAL(T, false, true, true, false, false, false, NAME)
 // TODO: Further type aliases?
+
+template<typename T, typename X, auto... Args>
+struct AK::Traits<AK::DistinctNumeric<T, X, Args...>> : public AK::GenericTraits<AK::DistinctNumeric<T, X, Args...>> {
+    static constexpr bool is_trivial() { return true; }
+    static constexpr auto hash(const AK::DistinctNumeric<T, X, Args...>& d) { return AK::Traits<T>::hash(d.value()); }
+};
 
 using AK::DistinctNumeric;

--- a/Kernel/Scheduler.h
+++ b/Kernel/Scheduler.h
@@ -40,12 +40,10 @@ class Process;
 class Thread;
 class WaitQueue;
 struct RegisterState;
-struct SchedulerData;
 
 extern Thread* g_finalizer;
 extern WaitQueue* g_finalizer_wait_queue;
 extern Atomic<bool> g_finalizer_has_work;
-extern SchedulerData* g_scheduler_data;
 extern RecursiveSpinLock g_scheduler_lock;
 
 class Scheduler {
@@ -73,14 +71,6 @@ public:
     static Thread& pull_next_runnable_thread();
     static bool dequeue_runnable_thread(Thread&, bool = false);
     static void queue_runnable_thread(Thread&);
-
-    template<typename Callback>
-    static inline IterationDecision for_each_runnable(Callback);
-
-    template<typename Callback>
-    static inline IterationDecision for_each_nonrunnable(Callback);
-
-    static void init_thread(Thread& thread);
 };
 
 }

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -162,6 +162,7 @@ extern "C" [[noreturn]] void init()
     }
     VirtualConsole::switch_to(0);
 
+    Thread::initialize();
     Process::initialize();
     Scheduler::initialize();
 


### PR DESCRIPTION
This allows us to get rid of the thread lists in SchedulerData.
Also, instead of iterating over all threads to find a thread by id,
just use a lookup table. In the rare case of having to iterate over
all threads, just iterate the lookup table.

_This does change the output of `SCHEDULER_RUNNABLE_DEBUG` a bit for the worse, but I feel like it's still worth getting rid of this baggage._