### PR TITLE
git: Tweak .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
+# Ignore all files without extension
 *
 !*.*
 !*/
-!Makefile
 !LICENSE
 !Base/**
 
@@ -22,13 +22,9 @@
 *.cflags
 *.cxxflags
 *.autosave
-Meta/Lagom/build
 Build
 build
 CMakeFiles
-Toolchain/Tarballs
-Toolchain/Build
-Toolchain/Local
 .vscode
 .ccls-cache
 .DS_Store

--- a/Meta/Lagom/.gitignore
+++ b/Meta/Lagom/.gitignore
@@ -1,5 +1,5 @@
-liblagom.a
 CMakeCache.txt
 CMakeFiles
-Makefile
+build
 cmake_install.cmake
+liblagom.a

--- a/Toolchain/.gitignore
+++ b/Toolchain/.gitignore
@@ -1,3 +1,7 @@
+Build
+Local
+Tarballs
+
 # Created by QEMU build
 config-temp
 config.log


### PR DESCRIPTION
- Push dirs to subdirectories. This is the main motivation -- to
  look at how ot fully rebuild the toolchain I always look in
  Toolchain/.gitignore first, and now that's enough
- Remove "Makefile" in a few places, no longer used
- Restore a comment that was lost in a commit that moved all
  gitignore content to the root gitignore file for some reason
- Push Meta/Lagom/build ignore to the local .gitignore file too

There's a few more things that look like they're unused
(eg all the CMakeCache.txt / CMakeFiles -- they should only be in the
Build dir), but let's leave that there so I have something to do for
next hacktoberfest.