### PR TITLE
Kernel: Allow specifying a physical alignment when allocating

### DIFF
--- a/Kernel/VM/ContiguousVMObject.cpp
+++ b/Kernel/VM/ContiguousVMObject.cpp
@@ -31,15 +31,15 @@
 
 namespace Kernel {
 
-NonnullRefPtr<ContiguousVMObject> ContiguousVMObject::create_with_size(size_t size)
+NonnullRefPtr<ContiguousVMObject> ContiguousVMObject::create_with_size(size_t size, size_t physical_alignment)
 {
-    return adopt(*new ContiguousVMObject(size));
+    return adopt(*new ContiguousVMObject(size, physical_alignment));
 }
 
-ContiguousVMObject::ContiguousVMObject(size_t size)
+ContiguousVMObject::ContiguousVMObject(size_t size, size_t physical_alignment)
     : VMObject(size)
 {
-    auto contiguous_physical_pages = MM.allocate_contiguous_supervisor_physical_pages(size);
+    auto contiguous_physical_pages = MM.allocate_contiguous_supervisor_physical_pages(size, physical_alignment);
     for (size_t i = 0; i < page_count(); i++) {
         physical_pages()[i] = contiguous_physical_pages[i];
         dbgln<CONTIGUOUS_VMOBJECT_DEBUG>("Contiguous page[{}]: {}", i, physical_pages()[i]->paddr());

--- a/Kernel/VM/ContiguousVMObject.h
+++ b/Kernel/VM/ContiguousVMObject.h
@@ -35,10 +35,10 @@ class ContiguousVMObject final : public VMObject {
 public:
     virtual ~ContiguousVMObject() override;
 
-    static NonnullRefPtr<ContiguousVMObject> create_with_size(size_t);
+    static NonnullRefPtr<ContiguousVMObject> create_with_size(size_t, size_t physical_alignment = PAGE_SIZE);
 
 private:
-    explicit ContiguousVMObject(size_t);
+    explicit ContiguousVMObject(size_t, size_t physical_alignment);
     explicit ContiguousVMObject(const ContiguousVMObject&);
 
     virtual const char* class_name() const override { return "ContiguousVMObject"; }

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -137,11 +137,11 @@ public:
     NonnullRefPtr<PhysicalPage> allocate_committed_user_physical_page(ShouldZeroFill = ShouldZeroFill::Yes);
     RefPtr<PhysicalPage> allocate_user_physical_page(ShouldZeroFill = ShouldZeroFill::Yes, bool* did_purge = nullptr);
     RefPtr<PhysicalPage> allocate_supervisor_physical_page();
-    NonnullRefPtrVector<PhysicalPage> allocate_contiguous_supervisor_physical_pages(size_t size);
+    NonnullRefPtrVector<PhysicalPage> allocate_contiguous_supervisor_physical_pages(size_t size, size_t physical_alignment = PAGE_SIZE);
     void deallocate_user_physical_page(const PhysicalPage&);
     void deallocate_supervisor_physical_page(const PhysicalPage&);
 
-    OwnPtr<Region> allocate_contiguous_kernel_region(size_t, const StringView& name, u8 access, bool user_accessible = false, bool cacheable = true);
+    OwnPtr<Region> allocate_contiguous_kernel_region(size_t, const StringView& name, u8 access, size_t physical_alignment = PAGE_SIZE, bool user_accessible = false, bool cacheable = true);
     OwnPtr<Region> allocate_kernel_region(size_t, const StringView& name, u8 access, bool user_accessible = false, AllocationStrategy strategy = AllocationStrategy::Reserve, bool cacheable = true);
     OwnPtr<Region> allocate_kernel_region(PhysicalAddress, size_t, const StringView& name, u8 access, bool user_accessible = false, bool cacheable = true);
     OwnPtr<Region> allocate_kernel_region_identity(PhysicalAddress, size_t, const StringView& name, u8 access, bool user_accessible = false, bool cacheable = true);

--- a/Kernel/VM/PhysicalRegion.h
+++ b/Kernel/VM/PhysicalRegion.h
@@ -52,12 +52,12 @@ public:
     bool contains(const PhysicalPage& page) const { return page.paddr() >= m_lower && page.paddr() <= m_upper; }
 
     RefPtr<PhysicalPage> take_free_page(bool supervisor);
-    NonnullRefPtrVector<PhysicalPage> take_contiguous_free_pages(size_t count, bool supervisor);
+    NonnullRefPtrVector<PhysicalPage> take_contiguous_free_pages(size_t count, bool supervisor, size_t physical_alignment = PAGE_SIZE);
     void return_page(const PhysicalPage& page);
 
 private:
-    unsigned find_contiguous_free_pages(size_t count);
-    Optional<unsigned> find_and_allocate_contiguous_range(size_t count);
+    unsigned find_contiguous_free_pages(size_t count, size_t physical_alignment = PAGE_SIZE);
+    Optional<unsigned> find_and_allocate_contiguous_range(size_t count, unsigned alignment = 1);
     Optional<unsigned> find_one_free_page();
     void free_page_at(PhysicalAddress addr);
 


### PR DESCRIPTION
Some drivers may require allocating contiguous physical pages with
a specific alignment for the physical address.

_This is cherry-picked from #4339. Some drivers such as SB16 mandate that DMA transfers don't cross certain boundaries, in that example DMA transfers must not cross a 64k boundary._