### PR TITLE
WindowServer: Fix various annoying things

### DIFF
--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -394,8 +394,10 @@ OwnPtr<Messages::WindowServer::SetWindowRectResponse> ClientConnection::handle(c
     if (message.rect().location() != window.rect().location()) {
         window.set_default_positioned(false);
     }
-    window.set_rect(message.rect());
-    window.normalize_rect();
+    auto rect = message.rect();
+    window.apply_minimum_size(rect);
+    window.set_rect(rect);
+    window.nudge_into_desktop();
     window.request_update(window.rect());
     return make<Messages::WindowServer::SetWindowRectResponse>(window.rect());
 }
@@ -452,8 +454,9 @@ OwnPtr<Messages::WindowServer::CreateWindowResponse> ClientConnection::handle(co
             rect = { WindowManager::the().get_recommended_window_position({ 100, 100 }), message.rect().size() };
             window->set_default_positioned(true);
         }
+        window->apply_minimum_size(rect);
         window->set_rect(rect);
-        window->normalize_rect();
+        window->nudge_into_desktop();
     }
     if (window->type() == WindowType::Desktop) {
         window->set_rect(WindowManager::the().desktop_rect());

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -741,8 +741,19 @@ bool Compositor::draw_geometry_label(Gfx::IntRect& geometry_label_damage_rect)
         int height_steps = (window_being_moved_or_resized->height() - window_being_moved_or_resized->base_size().height()) / window_being_moved_or_resized->size_increment().height();
         geometry_string = String::formatted("{} ({}x{})", geometry_string, width_steps, height_steps);
     }
+
     auto geometry_label_rect = Gfx::IntRect { 0, 0, wm.font().width(geometry_string) + 16, wm.font().glyph_height() + 10 };
     geometry_label_rect.center_within(window_being_moved_or_resized->rect());
+    auto desktop_rect = wm.desktop_rect();
+    if (geometry_label_rect.left() < desktop_rect.left())
+        geometry_label_rect.set_left(desktop_rect.left());
+    if (geometry_label_rect.top() < desktop_rect.top())
+        geometry_label_rect.set_top(desktop_rect.top());
+    if (geometry_label_rect.right() > desktop_rect.right())
+        geometry_label_rect.set_right_without_resize(desktop_rect.right());
+    if (geometry_label_rect.bottom() > desktop_rect.bottom())
+        geometry_label_rect.set_bottom_without_resize(desktop_rect.bottom());
+
     auto& back_painter = *m_back_painter;
     back_painter.fill_rect(geometry_label_rect.translated(1, 1), Color(Color::Black).with_alpha(80));
     Gfx::StylePainter::paint_button(back_painter, geometry_label_rect.translated(-1, -1), wm.palette(), Gfx::ButtonStyle::Normal, false);

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -183,7 +183,7 @@ void Window::normalize_rect()
     // For example, the windows that make the desktop rect smaller
     // than the display resolution (e.g. the TaskBar).
     auto min_visible = -1;
-    auto desktop = WindowManager::the().desktop_rect();
+    auto desktop = WindowManager::the().arena_rect_for_type(type())
     auto min_y = 0;
     if (type() == WindowType::Normal) {
         min_size = 50;

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -176,7 +176,7 @@ void Window::set_rect_without_repaint(const Gfx::IntRect& rect)
     m_frame.notify_window_rect_changed(old_rect, rect); // recomputes occlusions
 }
 
-void Window::normalize_rect()
+void Window::normalize_rect(bool force_titlebar_visible)
 {
     Gfx::IntRect arena = WindowManager::the().arena_rect_for_type(type());
     auto min_size = 1;
@@ -201,7 +201,7 @@ void Window::normalize_rect()
 
     // Make sure that at least half of the titlebar is visible.
     auto min_frame_y = arena.top() - (y() - old_frame_rect.y()) / 2;
-    if (new_frame_rect.y() < min_frame_y) {
+    if (force_titlebar_visible && new_frame_rect.y() < min_frame_y) {
         new_frame_rect.set_y(min_frame_y);
     }
 

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -159,7 +159,7 @@ public:
     void set_rect(const Gfx::IntRect&);
     void set_rect(int x, int y, int width, int height) { set_rect({ x, y, width, height }); }
     void set_rect_without_repaint(const Gfx::IntRect&);
-    void normalize_rect();
+    void normalize_rect(bool force_titlebar_visible = true);
 
     void set_taskbar_rect(const Gfx::IntRect&);
     const Gfx::IntRect& taskbar_rect() const { return m_taskbar_rect; }

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -159,7 +159,8 @@ public:
     void set_rect(const Gfx::IntRect&);
     void set_rect(int x, int y, int width, int height) { set_rect({ x, y, width, height }); }
     void set_rect_without_repaint(const Gfx::IntRect&);
-    void normalize_rect(bool force_titlebar_visible = true);
+    void apply_minimum_size(Gfx::IntRect&);
+    void nudge_into_desktop(bool force_titlebar_visible = true);
 
     void set_taskbar_rect(const Gfx::IntRect&);
     const Gfx::IntRect& taskbar_rect() const { return m_taskbar_rect; }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -554,8 +554,10 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event, Window*& hove
             } else if (m_move_window->tiled() == WindowTileType::None) {
                 Gfx::IntPoint pos = m_move_window_origin.translated(event.position() - m_move_origin);
                 m_move_window->set_position_without_repaint(pos);
-                // "Bounce back" the window it it would end up too far outside the screen:
-                m_move_window->normalize_rect();
+                // "Bounce back" the window if it would end up too far outside the screen.
+                // If the user has let go of Mod_Logo, maybe they didn't intentionally press it to begin with. Therefore, refuse to go into a state where knowledge about super-drags is necessary.
+                bool force_titlebar_visible = !(m_keyboard_modifiers & Mod_Logo);
+                m_move_window->normalize_rect(force_titlebar_visible);
             } else if (pixels_moved_from_start > 5) {
                 m_move_window->set_untiled(event.position());
                 m_move_origin = event.position();

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1043,13 +1043,32 @@ Gfx::IntRect WindowManager::menubar_rect() const
 Gfx::IntRect WindowManager::desktop_rect() const
 {
     if (active_fullscreen_window())
-        return {};
+        return Screen::the().rect();
     return {
         0,
         menubar_rect().bottom() + 1,
         Screen::the().width(),
         Screen::the().height() - menubar_rect().height() - 28
     };
+}
+
+Gfx::IntRect WindowManager::arena_rect_for_type(WindowType type) const
+{
+    switch (type) {
+    case WindowType::Desktop:
+    case WindowType::Normal:
+        return desktop_rect();
+    case WindowType::Menu:
+    case WindowType::WindowSwitcher:
+    case WindowType::Taskbar:
+    case WindowType::Tooltip:
+    case WindowType::Menubar:
+    case WindowType::MenuApplet:
+    case WindowType::Notification:
+        return Screen::the().rect();
+    default:
+        ASSERT_NOT_REACHED();
+    }
 }
 
 void WindowManager::event(Core::Event& event)

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -557,7 +557,7 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event, Window*& hove
                 // "Bounce back" the window if it would end up too far outside the screen.
                 // If the user has let go of Mod_Logo, maybe they didn't intentionally press it to begin with. Therefore, refuse to go into a state where knowledge about super-drags is necessary.
                 bool force_titlebar_visible = !(m_keyboard_modifiers & Mod_Logo);
-                m_move_window->normalize_rect(force_titlebar_visible);
+                m_move_window->nudge_into_desktop(force_titlebar_visible);
             } else if (pixels_moved_from_start > 5) {
                 m_move_window->set_untiled(event.position());
                 m_move_origin = event.position();
@@ -633,10 +633,9 @@ bool WindowManager::process_ongoing_window_resize(const MouseEvent& event, Windo
     auto new_rect = m_resize_window_original_rect;
 
     // First, size the new rect.
-    Gfx::IntSize minimum_size { 50, 50 };
-
-    new_rect.set_width(max(minimum_size.width(), new_rect.width() + change_w));
-    new_rect.set_height(max(minimum_size.height(), new_rect.height() + change_h));
+    new_rect.set_width(new_rect.width() + change_w);
+    new_rect.set_height(new_rect.height() + change_h);
+    m_resize_window->apply_minimum_size(new_rect);
 
     if (!m_resize_window->size_increment().is_null()) {
         int horizontal_incs = (new_rect.width() - m_resize_window->base_size().width()) / m_resize_window->size_increment().width();

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -120,6 +120,7 @@ public:
 
     Gfx::IntRect menubar_rect() const;
     Gfx::IntRect desktop_rect() const;
+    Gfx::IntRect arena_rect_for_type(WindowType) const;
 
     const Cursor& active_cursor() const;
     const Cursor& hidden_cursor() const { return *m_hidden_cursor; }


### PR DESCRIPTION
In particular:
- Callers of `WindowManager::desktop_rect()` might have misbehaved during fullscreen (undocumented issue)
- Fix required visible region at the bottom (undocumented issue)
- Allow superdrags to hide the titlebar. #5105
- Fixes WindowServer crashing when a malicious program creates a window of size (0, 0) (undocumented issue)
- Constrain geometry label on move/resize to desktop #5063

I didn't know that other people were working on this, too D:

- Might conflict with PR #5130, if it fixes the issues around setting/reading `m_unmaximized_rect`
- Does *not* conflict with PR #5138
- Does *not* conflict with PR #5129