### PR TITLE
Kernel: Prevent mmap-ing as both fixed and randomized

### DIFF
--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -128,6 +128,9 @@ void* Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> user_params)
     if (!map_shared && !map_private)
         return (void*)-EINVAL;
 
+    if (map_fixed && map_randomized)
+        return (void*)-EINVAL;
+
     if (!validate_mmap_prot(prot, map_stack))
         return (void*)-EINVAL;
 


### PR DESCRIPTION
Just a small improvement I thought of while watching the video :^) 