### PR TITLE
Ports: Add dmidecode

### DIFF
--- a/Base/usr/share/man/man4/mem.md
+++ b/Base/usr/share/man/man4/mem.md
@@ -1,0 +1,31 @@
+## Name
+
+mem - physical system memory
+
+## Description
+
+`/dev/mem` is a character device file that is used by other programs to examine
+the physical memory.
+
+Trying to [`mmap`(2)](../mmap.md) a physical range results either with success,
+or with an error. When invoking [`mmap`(2)](../mmap.md) on bad memory range, 
+the kernel will write a message about it to the kernel log.
+
+By default, the kernel limits the areas which can be accessed. The allowed areas
+are the reserved ranges in physical memory, essentially limiting the access to
+ROMs and memory-mapped PCI regions on x86.
+
+To create it manually:
+```sh
+mknod /dev/mem c 1 1
+chmod 660 /dev/mem
+```
+
+## Returned error values after [`mmap`(2)](../mmap.md)
+
+* `EINVAL`: An access violation was detected.
+* `ENOMEM`: The requested range would wrap around, creating an access violation.
+
+## See also
+
+* [`mmap`(2)](../mmap.md)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -18,6 +18,7 @@ set(KERNEL_SOURCES
     CommandLine.cpp
     Console.cpp
     CoreDump.cpp
+    DMI.cpp
     Devices/AsyncDeviceRequest.cpp
     Devices/BXVGADevice.cpp
     Devices/BlockDevice.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -28,6 +28,7 @@ set(KERNEL_SOURCES
     Devices/I8042Controller.cpp
     Devices/KeyboardDevice.cpp
     Devices/MBVGADevice.cpp
+    Devices/MemoryDevice.cpp
     Devices/NullDevice.cpp
     Devices/PCSpeaker.cpp
     Devices/PS2MouseDevice.cpp

--- a/Kernel/DMI.cpp
+++ b/Kernel/DMI.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Singleton.h>
+#include <AK/StringView.h>
+#include <AK/Types.h>
+#include <Kernel/Arch/PC/BIOS.h>
+#include <Kernel/DMI.h>
+#include <Kernel/StdLib.h>
+#include <Kernel/VM/MappedROM.h>
+#include <Kernel/VM/MemoryManager.h>
+#include <Kernel/VM/TypedMapping.h>
+
+namespace Kernel {
+
+#define SMBIOS_BASE_SEARCH_ADDR 0xf0000
+#define SMBIOS_END_SEARCH_ADDR 0xfffff
+#define SMBIOS_SEARCH_AREA_SIZE (SMBIOS_END_SEARCH_ADDR - SMBIOS_BASE_SEARCH_ADDR)
+
+AK::Singleton<DMIExpose> s_the;
+
+void DMIExpose::set_64_bit_entry_initialization_values()
+{
+    klog() << "DMIExpose: SMBIOS 64bit Entry point @ " << m_entry_point;
+    auto smbios_entry = map_typed<SMBIOS::EntryPoint64bit>(PhysicalAddress(m_entry_point), SMBIOS_SEARCH_AREA_SIZE);
+    m_structure_table = PhysicalAddress(smbios_entry.ptr()->table_ptr);
+    m_entry_point_length = smbios_entry.ptr()->length;
+    m_structure_table_length = smbios_entry.ptr()->table_maximum_size;
+}
+
+void DMIExpose::set_32_bit_entry_initialization_values()
+{
+    klog() << "DMIExpose: SMBIOS 32bit Entry point @ " << m_entry_point;
+    auto smbios_entry = map_typed<SMBIOS::EntryPoint32bit>(PhysicalAddress(m_entry_point), SMBIOS_SEARCH_AREA_SIZE);
+    m_structure_table = PhysicalAddress(smbios_entry.ptr()->legacy_structure.smbios_table_ptr);
+    m_entry_point_length = smbios_entry.ptr()->length;
+    m_structure_table_length = smbios_entry.ptr()->legacy_structure.smboios_table_length;
+}
+
+void DMIExpose::initialize()
+{
+    s_the.ensure_instance();
+}
+
+DMIExpose& DMIExpose::the()
+{
+    return *s_the;
+}
+
+void DMIExpose::initialize_exposer()
+{
+    ASSERT(!(m_entry_point.is_null()));
+    if (m_using_64bit_entry_point) {
+        set_64_bit_entry_initialization_values();
+    } else {
+        set_32_bit_entry_initialization_values();
+    }
+    klog() << "DMIExpose: Data table @ " << m_structure_table;
+}
+
+OwnPtr<KBuffer> DMIExpose::entry_point() const
+{
+    auto dmi_blob = map_typed<u8>((m_entry_point), m_entry_point_length);
+    return KBuffer::try_create_with_bytes(Span<u8> { dmi_blob.ptr(), m_entry_point_length });
+}
+OwnPtr<KBuffer> DMIExpose::structure_table() const
+{
+    auto dmi_blob = map_typed<u8>(m_structure_table, m_structure_table_length);
+    return KBuffer::try_create_with_bytes(Span<u8> { dmi_blob.ptr(), m_structure_table_length });
+}
+
+DMIExpose::DMIExpose()
+{
+    auto entry_32bit = find_entry32bit_point();
+    m_entry_point = entry_32bit.value();
+
+    auto entry_64bit = find_entry64bit_point();
+    if (entry_64bit.has_value()) {
+        m_entry_point = entry_64bit.value();
+        m_using_64bit_entry_point = true;
+    }
+    if (m_entry_point.is_null())
+        return;
+    m_available = true;
+    initialize_exposer();
+}
+
+Optional<PhysicalAddress> DMIExpose::find_entry64bit_point()
+{
+    return map_bios().find_chunk_starting_with("_SM3_", 16);
+}
+
+Optional<PhysicalAddress> DMIExpose::find_entry32bit_point()
+{
+    return map_bios().find_chunk_starting_with("_SM_", 16);
+}
+
+}

--- a/Kernel/DMI.cpp
+++ b/Kernel/DMI.cpp
@@ -70,6 +70,15 @@ DMIExpose& DMIExpose::the()
     return *s_the;
 }
 
+size_t DMIExpose::entry_point_length() const
+{
+    return m_entry_point_length;
+}
+size_t DMIExpose::structure_table_length() const
+{
+    return m_structure_table_length;
+}
+
 void DMIExpose::initialize_exposer()
 {
     ASSERT(!(m_entry_point.is_null()));

--- a/Kernel/DMI.h
+++ b/Kernel/DMI.h
@@ -85,6 +85,8 @@ public:
     bool is_available() const { return m_available; }
     OwnPtr<KBuffer> entry_point() const;
     OwnPtr<KBuffer> structure_table() const;
+    size_t entry_point_length() const;
+    size_t structure_table_length() const;
 
 private:
     void set_64_bit_entry_initialization_values();

--- a/Kernel/DMI.h
+++ b/Kernel/DMI.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/SinglyLinkedList.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+#include <Kernel/KBuffer.h>
+#include <Kernel/PhysicalAddress.h>
+#include <Kernel/VM/Region.h>
+#include <Kernel/VirtualAddress.h>
+
+namespace Kernel::SMBIOS {
+
+struct [[gnu::packed]] LegacyEntryPoint32bit {
+    char legacy_sig[5];
+    u8 checksum2;
+    u16 smboios_table_length;
+    u32 smbios_table_ptr;
+    u16 smbios_tables_count;
+    u8 smbios_bcd_revision;
+};
+
+struct [[gnu::packed]] EntryPoint32bit {
+    char sig[4];
+    u8 checksum;
+    u8 length;
+    u8 major_version;
+    u8 minor_version;
+    u16 maximum_structure_size;
+    u8 implementation_revision;
+    char formatted_area[5];
+    LegacyEntryPoint32bit legacy_structure;
+};
+
+struct [[gnu::packed]] EntryPoint64bit {
+    char sig[5];
+    u8 checksum;
+    u8 length;
+    u8 major_version;
+    u8 minor_version;
+    u8 document_revision;
+    u8 revision;
+    u8 reserved;
+    u32 table_maximum_size;
+    u64 table_ptr;
+};
+}
+
+namespace Kernel {
+
+class DMIExpose {
+
+public:
+    static void initialize();
+
+    DMIExpose();
+
+    static DMIExpose& the();
+
+    bool is_available() const { return m_available; }
+    OwnPtr<KBuffer> entry_point() const;
+    OwnPtr<KBuffer> structure_table() const;
+
+private:
+    void set_64_bit_entry_initialization_values();
+    void set_32_bit_entry_initialization_values();
+    void initialize_exposer();
+
+    Optional<PhysicalAddress> find_entry64bit_point();
+    Optional<PhysicalAddress> find_entry32bit_point();
+
+    PhysicalAddress m_entry_point;
+    PhysicalAddress m_structure_table;
+    bool m_using_64bit_entry_point { false };
+    bool m_available { false };
+    size_t m_structure_table_length { 0 };
+    size_t m_entry_point_length { 0 };
+};
+
+}

--- a/Kernel/Devices/MemoryDevice.cpp
+++ b/Kernel/Devices/MemoryDevice.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "MemoryDevice.h"
+#include <AK/Memory.h>
+#include <AK/StdLibExtras.h>
+#include <Kernel/Arch/PC/BIOS.h>
+#include <Kernel/VM/AnonymousVMObject.h>
+#include <Kernel/VM/TypedMapping.h>
+
+namespace Kernel {
+
+MemoryDevice::MemoryDevice()
+    : CharacterDevice(1, 1)
+{
+}
+
+MemoryDevice::~MemoryDevice()
+{
+}
+
+KResultOr<size_t> MemoryDevice::read(FileDescription&, size_t, UserOrKernelBuffer&, size_t)
+{
+    TODO();
+}
+
+void MemoryDevice::did_seek(FileDescription&, off_t)
+{
+    TODO();
+}
+
+KResultOr<Region*> MemoryDevice::mmap(Process& process, FileDescription&, const Range& range, size_t offset, int prot, bool shared)
+{
+    auto viewed_address = PhysicalAddress(offset);
+
+    dbgln("MemoryDevice: Trying to mmap physical memory at {} for range of {} bytes", viewed_address, range.size());
+    if (!MM.is_allowed_to_mmap_to_userspace(viewed_address, range)) {
+        dbgln("MemoryDevice: Trying to mmap physical memory at {} for range of {} bytes failed due to violation of access", viewed_address, range.size());
+        return EINVAL;
+    }
+
+    auto vmobject = AnonymousVMObject::create_for_physical_range(viewed_address, range.size());
+    if (!vmobject)
+        return ENOMEM;
+    dbgln("MemoryDevice: Mapped physical memory at {} for range of {} bytes", viewed_address, range.size());
+    return process.allocate_region_with_vmobject(
+        range,
+        vmobject.release_nonnull(),
+        0,
+        "Mapped Physical Memory",
+        prot,
+        shared);
+}
+
+}

--- a/Kernel/Devices/MemoryDevice.h
+++ b/Kernel/Devices/MemoryDevice.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/Types.h>
+#include <Kernel/Devices/CharacterDevice.h>
+#include <Kernel/PhysicalAddress.h>
+
+namespace Kernel {
+
+class MemoryDevice final : public CharacterDevice {
+    AK_MAKE_ETERNAL
+public:
+    MemoryDevice();
+    ~MemoryDevice();
+
+    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, size_t offset, int prot, bool shared) override;
+
+    // ^Device
+    virtual mode_t required_mode() const override { return 0660; }
+    virtual String device_name() const override { return "mem"; };
+
+private:
+    virtual const char* class_name() const override { return "MemoryDevice"; }
+    virtual bool can_read(const FileDescription&, size_t) const override { return true; }
+    virtual bool can_write(const FileDescription&, size_t) const override { return false; }
+    virtual bool is_seekable() const { return true; }
+    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
+
+    virtual void did_seek(FileDescription&, off_t) override;
+
+    bool is_allowed_range(PhysicalAddress, const Range&) const;
+};
+
+}

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -1176,6 +1176,14 @@ InodeMetadata ProcFSInode::metadata() const
     case FI_PID_stacks:
         metadata.mode = S_IFDIR | S_IRUSR | S_IXUSR;
         break;
+    case FI_Root_smbios_entry_point:
+        metadata.mode = S_IFREG | S_IRUSR | S_IRGRP | S_IROTH;
+        metadata.size = DMIExpose::the().entry_point_length();
+        break;
+    case FI_Root_dmi:
+        metadata.mode = S_IFREG | S_IRUSR | S_IRGRP | S_IROTH;
+        metadata.size = DMIExpose::the().structure_table_length();
+        break;
     default:
         metadata.mode = S_IFREG | S_IRUSR | S_IRGRP | S_IROTH;
         break;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -32,6 +32,7 @@
 #include <Kernel/Arch/i386/ProcessorInfo.h>
 #include <Kernel/CommandLine.h>
 #include <Kernel/Console.h>
+#include <Kernel/DMI.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Devices/BlockDevice.h>
 #include <Kernel/Devices/KeyboardDevice.h>
@@ -86,6 +87,8 @@ enum ProcFileType {
     FI_Root_cpuinfo,
     FI_Root_dmesg,
     FI_Root_interrupts,
+    FI_Root_dmi,
+    FI_Root_smbios_entry_point,
     FI_Root_keymap,
     FI_Root_pci,
     FI_Root_devices,
@@ -374,6 +377,24 @@ static bool procfs$pci(InodeIdentifier, KBufferBuilder& builder)
         obj.add("subsystem_vendor_id", PCI::get_subsystem_vendor_id(address));
     });
     array.finish();
+    return true;
+}
+
+static bool procfs$dmi(InodeIdentifier, KBufferBuilder& builder)
+{
+    if (!DMIExpose::the().is_available())
+        return false;
+    auto structures_ptr = DMIExpose::the().structure_table();
+    builder.append_bytes(ReadonlyBytes { structures_ptr->data(), structures_ptr->size() });
+    return true;
+}
+
+static bool procfs$smbios_entry_point(InodeIdentifier, KBufferBuilder& builder)
+{
+    if (!DMIExpose::the().is_available())
+        return false;
+    auto structures_ptr = DMIExpose::the().entry_point();
+    builder.append_bytes(ReadonlyBytes { structures_ptr->data(), structures_ptr->size() });
     return true;
 }
 
@@ -1624,6 +1645,8 @@ ProcFS::ProcFS()
     m_entries[FI_Root_self] = { "self", FI_Root_self, false, procfs$self };
     m_entries[FI_Root_pci] = { "pci", FI_Root_pci, false, procfs$pci };
     m_entries[FI_Root_interrupts] = { "interrupts", FI_Root_interrupts, false, procfs$interrupts };
+    m_entries[FI_Root_dmi] = { "DMI", FI_Root_dmi, false, procfs$dmi };
+    m_entries[FI_Root_smbios_entry_point] = { "smbios_entry_point", FI_Root_smbios_entry_point, false, procfs$smbios_entry_point };
     m_entries[FI_Root_keymap] = { "keymap", FI_Root_keymap, false, procfs$keymap };
     m_entries[FI_Root_devices] = { "devices", FI_Root_devices, false, procfs$devices };
     m_entries[FI_Root_uptime] = { "uptime", FI_Root_uptime, false, procfs$uptime };

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -60,8 +60,8 @@ enum {
     _SC_NPROCESSORS_CONF,
     _SC_NPROCESSORS_ONLN,
     _SC_OPEN_MAX,
-    _SC_PAGESIZE,
     _SC_TTY_NAME_MAX,
+    _SC_PAGESIZE,
 };
 
 #define PERF_EVENT_SAMPLE 0

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -36,6 +36,7 @@
 #include <Kernel/Devices/FullDevice.h>
 #include <Kernel/Devices/I8042Controller.h>
 #include <Kernel/Devices/MBVGADevice.h>
+#include <Kernel/Devices/MemoryDevice.h>
 #include <Kernel/Devices/NullDevice.h>
 #include <Kernel/Devices/RandomDevice.h>
 #include <Kernel/Devices/SB16.h>
@@ -262,6 +263,7 @@ void init_stage2(void*)
 
     Syscall::initialize();
 
+    new MemoryDevice;
     new ZeroDevice;
     new FullDevice;
     new RandomDevice;

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -31,6 +31,7 @@
 #include <Kernel/Arch/i386/CPU.h>
 #include <Kernel/CMOS.h>
 #include <Kernel/CommandLine.h>
+#include <Kernel/DMI.h>
 #include <Kernel/Devices/BXVGADevice.h>
 #include <Kernel/Devices/FullDevice.h>
 #include <Kernel/Devices/I8042Controller.h>
@@ -252,6 +253,7 @@ void init_stage2(void*)
     }
 
     USB::UHCIController::detect();
+    DMIExpose::initialize();
 
     E1000NetworkAdapter::detect();
     RTL8139NetworkAdapter::detect();

--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -12,6 +12,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`curl`](curl/)                | curl                                          | 7.65.3            | https://curl.se/                                      |
 | [`dash`](dash/)                | DASH                                          | 0.5.10.2          | http://gondor.apana.org.au/~herbert/dash              |
 | [`diffutils`](diffutils/)      | GNU Diffutils                                 | 3.5               | https://www.gnu.org/software/diffutils/               |
+| [`dmidecode`](dmidecode/)      | dmidecode                                     | 3.1               | https://github.com/mirror/dmidecode                   |
 | [`doom`](doom/)                | DOOM                                          |                   | https://github.com/SerenityOS/SerenityDOOM            |
 | [`dropbear`](dropbear/)        | Dropbear SSH                                  | 2019.78           | https://dropbear.nl/mirror/dropbear.html              |
 | [`ed`](ed/)                    | GNU ed                                        | 1.15              | https://www.gnu.org/software/ed/                      |

--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -12,7 +12,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`curl`](curl/)                | curl                                          | 7.65.3            | https://curl.se/                                      |
 | [`dash`](dash/)                | DASH                                          | 0.5.10.2          | http://gondor.apana.org.au/~herbert/dash              |
 | [`diffutils`](diffutils/)      | GNU Diffutils                                 | 3.5               | https://www.gnu.org/software/diffutils/               |
-| [`dmidecode`](dmidecode/)      | dmidecode                                     | 3.1               | https://github.com/mirror/dmidecode                   |
+| [`dmidecode`](dmidecode/)      | dmidecode                                     | 3.3               | https://github.com/mirror/dmidecode                   |
 | [`doom`](doom/)                | DOOM                                          |                   | https://github.com/SerenityOS/SerenityDOOM            |
 | [`dropbear`](dropbear/)        | Dropbear SSH                                  | 2019.78           | https://dropbear.nl/mirror/dropbear.html              |
 | [`ed`](ed/)                    | GNU ed                                        | 1.15              | https://www.gnu.org/software/ed/                      |

--- a/Ports/dmidecode/package.sh
+++ b/Ports/dmidecode/package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=dmidecode
-version=3.1
+version=3.3
 useconfigure=false
 prefix=
 files="https://download.savannah.gnu.org/releases/dmidecode/dmidecode-${version}.tar.xz dmidecode-${version}.tar.xz

--- a/Ports/dmidecode/package.sh
+++ b/Ports/dmidecode/package.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=dmidecode
+version=3.1
+useconfigure=false
+prefix=
+files="https://download.savannah.gnu.org/releases/dmidecode/dmidecode-${version}.tar.xz dmidecode-${version}.tar.xz
+https://download.savannah.gnu.org/releases/dmidecode/dmidecode-${version}.tar.xz.sig dmidecode-${version}.tar.xz.sig
+https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+auth_type="sig"
+auth_import_key="90DFD6523C57373D81F63D19865688D038F02FC8"
+auth_opts="--keyring ./gnu-keyring.gpg dmidecode-${version}.tar.xz.sig"
+
+install() {
+    run make clean
+    run make CC=i686-pc-serenity-gcc
+}
+
+post_install() {
+    mkdir -p $SERENITY_ROOT/Build/Root/bin
+    run make install-bin DESTDIR=$SERENITY_ROOT/Build/Root/
+    ln -s /usr/local/sbin/dmidecode $SERENITY_ROOT/Build/Root/bin/dmidecode
+    ln -s /usr/local/sbin/biosdecode $SERENITY_ROOT/Build/Root/bin/biosdecode
+    ln -s /usr/local/sbin/vpddecode $SERENITY_ROOT/Build/Root/bin/vpddecode
+}

--- a/Ports/dmidecode/patches/dmidecode.patch
+++ b/Ports/dmidecode/patches/dmidecode.patch
@@ -1,8 +1,7 @@
-diff --git a/dmidecode.c b/dmidecode.c
-index 6559567..17573a9 100644
---- a/dmidecode.c
+diff -u b/dmidecode.c b/dmidecode.c
+--- b/dmidecode.c
 +++ b/dmidecode.c
-@@ -80,7 +80,7 @@ static const char *bad_index = "<BAD INDEX>";
+@@ -90,7 +90,7 @@
  #define FLAG_NO_FILE_OFFSET     (1 << 0)
  #define FLAG_STOP_AT_EOT        (1 << 1)
  
@@ -11,21 +10,44 @@ index 6559567..17573a9 100644
  #define SYS_ENTRY_FILE SYS_FIRMWARE_DIR "/smbios_entry_point"
  #define SYS_TABLE_FILE SYS_FIRMWARE_DIR "/DMI"
  
-@@ -5053,7 +5053,7 @@ int main(int argc, char * const argv[])
- 	}
+@@ -3654,8 +3654,6 @@
+ {
+ 	if (addrtype == 0x1) /* IPv4 */
+ 		return inet_ntop(AF_INET, data, storage, 64);
+-	if (addrtype == 0x2) /* IPv6 */
+-		return inet_ntop(AF_INET6, data, storage, 64);
+ 	return out_of_spec;
+ }
  
- 	/*
--	 * First try reading from sysfs tables.  The entry point file could
-+	 * First try reading from procfs tables.  The entry point file could
- 	 * contain one of several types of entry points, so read enough for
+@@ -5278,7 +5276,7 @@
+ 	if ((flags & FLAG_NO_FILE_OFFSET) || (opt.flags & FLAG_FROM_DUMP))
+ 	{
+ 		/*
+-		 * When reading from sysfs or from a dump file, the file may be
++		 * When reading from procfs or from a dump file, the file may be
+ 		 * shorter than announced. For SMBIOS v3 this is expcted, as we
+ 		 * only know the maximum table size, not the actual table size.
+ 		 * For older implementations (and for SMBIOS v3 too), this
+@@ -5647,11 +5645,11 @@
  	 * the largest one, then determine what type it contains.
  	 */
-@@ -5062,7 +5062,7 @@ int main(int argc, char * const argv[])
+ 	size = 0x20;
+-	if (!(opt.flags & FLAG_NO_SYSFS)
++	if (!(opt.flags & FLAG_NO_PROCFS)
  	 && (buf = read_file(0, &size, SYS_ENTRY_FILE)) != NULL)
  	{
  		if (!(opt.flags & FLAG_QUIET))
--			printf("Getting SMBIOS data from sysfs.\n");
-+			printf("Getting SMBIOS data from procfs.\n");
+-			pr_info("Getting SMBIOS data from sysfs.");
++			pr_info("Getting SMBIOS data from procfs.");
  		if (size >= 24 && memcmp(buf, "_SM3_", 5) == 0)
  		{
  			if (smbios3_decode(buf, SYS_TABLE_FILE, FLAG_NO_FILE_OFFSET))
+@@ -5671,7 +5669,7 @@
+ 		if (found)
+ 			goto done;
+ 		if (!(opt.flags & FLAG_QUIET))
+-			pr_info("Failed to get SMBIOS data from sysfs.");
++			pr_info("Failed to get SMBIOS data from procfs.");
+ 	}
+ 
+ 	/* Next try EFI (ia64, Intel-based Mac, arm64) */

--- a/Ports/dmidecode/patches/dmidecode.patch
+++ b/Ports/dmidecode/patches/dmidecode.patch
@@ -1,0 +1,31 @@
+diff --git a/dmidecode.c b/dmidecode.c
+index 6559567..17573a9 100644
+--- a/dmidecode.c
++++ b/dmidecode.c
+@@ -80,7 +80,7 @@ static const char *bad_index = "<BAD INDEX>";
+ #define FLAG_NO_FILE_OFFSET     (1 << 0)
+ #define FLAG_STOP_AT_EOT        (1 << 1)
+ 
+-#define SYS_FIRMWARE_DIR "/sys/firmware/dmi/tables"
++#define SYS_FIRMWARE_DIR "/proc"
+ #define SYS_ENTRY_FILE SYS_FIRMWARE_DIR "/smbios_entry_point"
+ #define SYS_TABLE_FILE SYS_FIRMWARE_DIR "/DMI"
+ 
+@@ -5053,7 +5053,7 @@ int main(int argc, char * const argv[])
+ 	}
+ 
+ 	/*
+-	 * First try reading from sysfs tables.  The entry point file could
++	 * First try reading from procfs tables.  The entry point file could
+ 	 * contain one of several types of entry points, so read enough for
+ 	 * the largest one, then determine what type it contains.
+ 	 */
+@@ -5062,7 +5062,7 @@ int main(int argc, char * const argv[])
+ 	 && (buf = read_file(0, &size, SYS_ENTRY_FILE)) != NULL)
+ 	{
+ 		if (!(opt.flags & FLAG_QUIET))
+-			printf("Getting SMBIOS data from sysfs.\n");
++			printf("Getting SMBIOS data from procfs.\n");
+ 		if (size >= 24 && memcmp(buf, "_SM3_", 5) == 0)
+ 		{
+ 			if (smbios3_decode(buf, SYS_TABLE_FILE, FLAG_NO_FILE_OFFSET))

--- a/Ports/dmidecode/patches/dmiopt.c.patch
+++ b/Ports/dmidecode/patches/dmiopt.c.patch
@@ -1,17 +1,26 @@
 diff --git a/dmiopt.c b/dmiopt.c
-index da42546..8d43119 100644
+index d08288f..42f5458 100644
 --- a/dmiopt.c
 +++ b/dmiopt.c
-@@ -259,7 +259,7 @@ int parse_command_line(int argc, char * const argv[])
- 		{ "dump-bin", required_argument, NULL, 'B' },
+@@ -277,7 +277,7 @@ int parse_command_line(int argc, char * const argv[])
  		{ "from-dump", required_argument, NULL, 'F' },
+ 		{ "handle", required_argument, NULL, 'H' },
  		{ "oem-string", required_argument, NULL, 'O' },
 -		{ "no-sysfs", no_argument, NULL, 'S' },
 +		{ "no-procfs", no_argument, NULL, 'S' },
  		{ "version", no_argument, NULL, 'V' },
  		{ NULL, 0, NULL, 0 }
  	};
-@@ -353,7 +353,7 @@ void print_help(void)
+@@ -326,7 +326,7 @@ int parse_command_line(int argc, char * const argv[])
+ 				opt.flags |= FLAG_DUMP;
+ 				break;
+ 			case 'S':
+-				opt.flags |= FLAG_NO_SYSFS;
++				opt.flags |= FLAG_NO_PROCFS;
+ 				break;
+ 			case 'V':
+ 				opt.flags |= FLAG_VERSION;
+@@ -377,7 +377,7 @@ void print_help(void)
  		" -u, --dump             Do not decode the entries\n"
  		"     --dump-bin FILE    Dump the DMI data to a binary file\n"
  		"     --from-dump FILE   Read the DMI data from a binary file\n"

--- a/Ports/dmidecode/patches/dmiopt.h.patch
+++ b/Ports/dmidecode/patches/dmiopt.h.patch
@@ -1,0 +1,13 @@
+diff --git a/dmiopt.h b/dmiopt.h
+index 2374637..d215aff 100644
+--- a/dmiopt.h
++++ b/dmiopt.h
+@@ -45,7 +45,7 @@ extern struct opt opt;
+ #define FLAG_QUIET              (1 << 3)
+ #define FLAG_DUMP_BIN           (1 << 4)
+ #define FLAG_FROM_DUMP          (1 << 5)
+-#define FLAG_NO_SYSFS           (1 << 6)
++#define FLAG_NO_PROCFS          (1 << 6)
+ 
+ int parse_command_line(int argc, char * const argv[]);
+ void print_help(void);

--- a/Ports/dmidecode/patches/dmiopt.patch
+++ b/Ports/dmidecode/patches/dmiopt.patch
@@ -1,0 +1,22 @@
+diff --git a/dmiopt.c b/dmiopt.c
+index da42546..8d43119 100644
+--- a/dmiopt.c
++++ b/dmiopt.c
+@@ -259,7 +259,7 @@ int parse_command_line(int argc, char * const argv[])
+ 		{ "dump-bin", required_argument, NULL, 'B' },
+ 		{ "from-dump", required_argument, NULL, 'F' },
+ 		{ "oem-string", required_argument, NULL, 'O' },
+-		{ "no-sysfs", no_argument, NULL, 'S' },
++		{ "no-procfs", no_argument, NULL, 'S' },
+ 		{ "version", no_argument, NULL, 'V' },
+ 		{ NULL, 0, NULL, 0 }
+ 	};
+@@ -353,7 +353,7 @@ void print_help(void)
+ 		" -u, --dump             Do not decode the entries\n"
+ 		"     --dump-bin FILE    Dump the DMI data to a binary file\n"
+ 		"     --from-dump FILE   Read the DMI data from a binary file\n"
+-		"     --no-sysfs         Do not attempt to read DMI data from sysfs files\n"
++		"     --no-procfs        Do not attempt to read DMI data from procfs files\n"
+ 		"     --oem-string N     Only display the value of the given OEM string\n"
+ 		" -V, --version          Display the version and exit\n";
+ 

--- a/Userland/Libraries/LibC/getopt.h
+++ b/Userland/Libraries/LibC/getopt.h
@@ -41,6 +41,11 @@ struct option {
     int val;
 };
 
+extern int opterr;
+extern int optopt;
+extern int optind;
+extern int optreset;
+extern char* optarg;
 int getopt_long(int argc, char** argv, const char* short_options, const struct option* long_options, int* out_long_option_index);
 
 __END_DECLS


### PR DESCRIPTION
For this to work, I added two entries in `ProcFS`, and also added a new device called `MemoryDevice` (`/dev/mem`), which only allows currently to map the BIOS ROM between physical address `0xf0000` to `0x100000`.