### PR TITLE
Base: Make /www read-write by default

### DIFF
--- a/Base/etc/fstab
+++ b/Base/etc/fstab
@@ -7,6 +7,7 @@
 /home	/home	bind	bind,nodev,nosuid
 /root	/root	bind	bind,nodev,nosuid
 /var	/var	bind	bind,nodev,nosuid
+/www	/www	bind	bind,nodev,nosuid
 
 none	/proc	proc	nosuid
 none	/tmp	tmp	nodev,nosuid


### PR DESCRIPTION
Since it is owned by root anyway, there is no need for 'additional security' to prevent
modification of that directory. This makes it easier to quickly export files from Serenity.

Fixes #5152.