### PR TITLE
Kernel/Storage: Rewrite IDE disk detection and disk access

### DIFF
--- a/Kernel/Storage/IDEChannel.h
+++ b/Kernel/Storage/IDEChannel.h
@@ -117,21 +117,37 @@ private:
     //^ IRQHandler
     virtual void handle_irq(const RegisterState&) override;
 
+    enum class LBAMode : u8 {
+        None, // CHS
+        TwentyEightBit,
+        FortyEightBit,
+    };
+
+    enum class Direction : u8 {
+        Read,
+        Write,
+    };
+
     void initialize(bool force_pio);
     void detect_disks();
+    String channel_type_string() const;
 
-    void start_request(AsyncBlockDeviceRequest&, bool, bool);
+    void try_disambiguate_error();
+    void wait_until_not_busy();
+
+    void start_request(AsyncBlockDeviceRequest&, bool, bool, u16);
     void complete_current_request(AsyncDeviceRequest::RequestResult);
 
-    void ata_read_sectors_with_dma(bool);
-    void ata_read_sectors(bool);
+    void ata_access(Direction, bool, u32, u8, u16, bool);
+    void ata_read_sectors_with_dma(bool, u16);
+    void ata_read_sectors(bool, u16);
     bool ata_do_read_sector();
-    void ata_write_sectors_with_dma(bool);
-    void ata_write_sectors(bool);
+    void ata_write_sectors_with_dma(bool, u16);
+    void ata_write_sectors(bool, u16);
     void ata_do_write_sector();
 
     // Data members
-    u8 m_channel_number { 0 }; // Channel number. 0 = master, 1 = slave
+    ChannelType m_channel_type { ChannelType::Primary };
 
     volatile u8 m_device_error { 0 };
 

--- a/Kernel/Storage/PATADiskDevice.cpp
+++ b/Kernel/Storage/PATADiskDevice.cpp
@@ -33,18 +33,20 @@
 
 namespace Kernel {
 
-NonnullRefPtr<PATADiskDevice> PATADiskDevice::create(const IDEController& controller, IDEChannel& channel, DriveType type, u8 cylinders, u8 heads, u8 spt, int major, int minor)
+NonnullRefPtr<PATADiskDevice> PATADiskDevice::create(const IDEController& controller, IDEChannel& channel, DriveType type, InterfaceType interface_type, u16 cylinders, u16 heads, u16 spt, u16 capabilities, int major, int minor)
 {
-    return adopt(*new PATADiskDevice(controller, channel, type, cylinders, heads, spt, major, minor));
+    return adopt(*new PATADiskDevice(controller, channel, type, interface_type, cylinders, heads, spt, capabilities, major, minor));
 }
 
-PATADiskDevice::PATADiskDevice(const IDEController& controller, IDEChannel& channel, DriveType type, u8 cylinders, u8 heads, u8 spt, int major, int minor)
+PATADiskDevice::PATADiskDevice(const IDEController& controller, IDEChannel& channel, DriveType type, InterfaceType interface_type, u16 cylinders, u16 heads, u16 spt, u16 capabilities, int major, int minor)
     : StorageDevice(controller, major, minor, 512, 0)
     , m_cylinders(cylinders)
     , m_heads(heads)
     , m_sectors_per_track(spt)
+    , m_capabilities(capabilities)
     , m_channel(channel)
     , m_drive_type(type)
+    , m_interface_type(interface_type)
 {
 }
 
@@ -60,7 +62,7 @@ const char* PATADiskDevice::class_name() const
 void PATADiskDevice::start_request(AsyncBlockDeviceRequest& request)
 {
     bool use_dma = !m_channel.m_io_group.bus_master_base().is_null() && m_channel.m_dma_enabled.resource();
-    m_channel.start_request(request, use_dma, is_slave());
+    m_channel.start_request(request, use_dma, is_slave(), m_capabilities);
 }
 
 String PATADiskDevice::device_name() const

--- a/Kernel/Storage/PATADiskDevice.h
+++ b/Kernel/Storage/PATADiskDevice.h
@@ -51,8 +51,13 @@ public:
         Slave
     };
 
+    enum class InterfaceType : u8 {
+        ATA,
+        ATAPI,
+    };
+
 public:
-    static NonnullRefPtr<PATADiskDevice> create(const IDEController&, IDEChannel&, DriveType, u8, u8, u8, int major, int minor);
+    static NonnullRefPtr<PATADiskDevice> create(const IDEController&, IDEChannel&, DriveType, InterfaceType, u16, u16, u16, u16, int major, int minor);
     virtual ~PATADiskDevice() override;
 
     // ^StorageDevice
@@ -64,7 +69,7 @@ public:
     virtual String device_name() const override;
 
 private:
-    PATADiskDevice(const IDEController&, IDEChannel&, DriveType, u8, u8, u8, int major, int minor);
+    PATADiskDevice(const IDEController&, IDEChannel&, DriveType, InterfaceType, u16, u16, u16, u16, int major, int minor);
 
     // ^DiskDevice
     virtual const char* class_name() const override;
@@ -75,8 +80,10 @@ private:
     u16 m_cylinders { 0 };
     u16 m_heads { 0 };
     u16 m_sectors_per_track { 0 };
+    u16 m_capabilities { 0 };
     IDEChannel& m_channel;
     DriveType m_drive_type { DriveType::Master };
+    InterfaceType m_interface_type { InterfaceType::ATA };
 };
 
 }


### PR DESCRIPTION
This replaces the current disk detection and disk access code with
code based on https://wiki.osdev.org/IDE

This allows the system to boot on VirtualBox with serial debugging
enabled and VMWare Player.

I believe there were several issues with the current code:
- It didn't utilise the last 8 bits of the LBA in 24-bit mode.
- {read,write}_sectors_with_dma was not setting the obsolete bits,
  which according to OSdev wiki aren't used but should be set.
- The PIO and DMA methods were using slightly different copy
  and pasted access code, which is now put into a single
  function called "ata_access"
- PIO mode doesn't work. This doesn't fix that and should
  be looked into in the future.
- The detection code was not checking for ATA/ATAPI.
- The detection code accidentally had cyls/heads/spt as 8-bit,
  when they're 16-bit.
- The capabilities of the device were not considered. This is now
  brought in and is currently used to check if the device supports
  LBA. If not, use CHS.