### PR TITLE
Meta: Expect sync-local.sh script at repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ compile_commands.json
 Ports/packages.db
 .idea/
 cmake-build-debug/
+sync-local.sh

--- a/Kernel/.gitignore
+++ b/Kernel/.gitignore
@@ -1,4 +1,3 @@
 kernel.map
-sync-local.sh
 *.pcap
 eth_null*

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -125,7 +125,22 @@ ln -s checksum mnt/bin/sha256sum
 ln -s checksum mnt/bin/sha512sum
 echo "done"
 
+if [ -f "${SERENITY_ROOT}/Kernel/sync-local.sh" ] || [ -f "${SERENITY_ROOT}/Build/sync-local.sh" ]; then
+    # TODO: Deprecated on 2021-01-30. In a few months, remove this 'if'.
+    tput setaf 1
+    echo
+    echo "   +-----------------------------------------------------------------------------+"
+    echo "   |                                                                             |"
+    echo "   |  WARNING: sync-local.sh, previously located in Kernel/ and later Build/     |"
+    echo "   |           must be moved to \$SERENITY_ROOT!                                  |"
+    echo "   |           See https://github.com/SerenityOS/serenity/pull/5172 for details. |"
+    echo "   |                                                                             |"
+    echo "   +-----------------------------------------------------------------------------+"
+    echo
+    tput sgr 0
+fi
+
 # Run local sync script, if it exists
-if [ -f sync-local.sh ]; then
-    sh sync-local.sh
+if [ -f "$SERENITY_ROOT}/sync-local.sh" ]; then
+    sh "${SERENITY_ROOT}/sync-local.sh"
 fi


### PR DESCRIPTION
This used to be in `Kernel/`, next to the `build-root-filesystem.sh` script, which was then moved to `Meta/` during the transition to CMake but has the working directory set to `Build/`, effectively expecting it there - which seems silly.

TL;DR: Very confusing. Use an explicit path relative to `SERENITY_ROOT` instead and update the `.gitignore` files.

---

cc @BenWiederhake, you mentioned this on IRC, so you probably use it & have an opinion :)