### PR TITLE
LibELF: Avoid quadratic memory usage weakness

### DIFF
--- a/Userland/Libraries/LibELF/Image.cpp
+++ b/Userland/Libraries/LibELF/Image.cpp
@@ -207,7 +207,7 @@ StringView Image::table_string(unsigned table_index, unsigned offset) const
             dbgln("SHENANIGANS! Image::table_string() computed offset outside image.");
         return {};
     }
-    size_t max_length = m_size - computed_offset;
+    size_t max_length = min(m_size - computed_offset, (size_t)PAGE_SIZE);
     size_t length = strnlen(raw_data(sh.sh_offset + offset), max_length);
     return { raw_data(sh.sh_offset + offset), length };
 }


### PR DESCRIPTION
Section names are referred to by offset and length. We do not check
(and probably should not check) whether these names overlap in any way.
This opened the door to many sections (in this example: about 2700)
forcing ELF::Image::m_sections to contain endless copies of the same
huge string (in this case: 882K).

Fix this by loading only the first PAGE_SIZE bytes of each name.
Since section names are only relevant for relocations and debug
information and most section names are hard-coded (and far below 4096
bytes) anyway, this should be no restriction at all for 'normal'
executables.

Found by OSS-Fuzz:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29187