### PR TITLE
WebServer: Stream the downloaded files / some other random tidbits

### DIFF
--- a/Userland/Libraries/LibProtocol/Download.cpp
+++ b/Userland/Libraries/LibProtocol/Download.cpp
@@ -57,7 +57,7 @@ void Download::stream_into(OutputStream& stream)
     };
 
     notifier->on_ready_to_read = [this, &stream, user_on_finish = move(user_on_finish)] {
-        constexpr size_t buffer_size = 1 * KiB;
+        constexpr size_t buffer_size = PAGE_SIZE;
         static char buf[buffer_size];
         auto nread = m_internal_stream_data->read_stream.read({ buf, buffer_size });
         if (!stream.write_or_error({ buf, nread })) {

--- a/Userland/Services/WebServer/Client.h
+++ b/Userland/Services/WebServer/Client.h
@@ -42,7 +42,7 @@ private:
     Client(NonnullRefPtr<Core::TCPSocket>, const String&, Core::Object* parent);
 
     void handle_request(ReadonlyBytes);
-    void send_response(StringView, const HTTP::HttpRequest&, const String& content_type);
+    void send_response(InputStream&, const HTTP::HttpRequest&, const String& content_type);
     void send_redirect(StringView redirect, const HTTP::HttpRequest& request);
     void send_error_response(unsigned code, const StringView& message, const HTTP::HttpRequest&);
     void die();


### PR DESCRIPTION
Addresses my own comment at https://github.com/SerenityOS/serenity/pull/5166#issuecomment-769990034.

Some possibly dumb (but nice-sounding) ideas about streaming stuff
(cc @awesomekling and maybe @bugaevc?)

- Most of the time, the streaming is done from one fd to another
- Why can't the kernel handle this? instead of proxying down to userland and back to the kernel, just directly wire the write call of the source fd to the write handler of the target handler?
- For when it's not, we still have memfd (or rather, anon fds) - but this might be weird to do in the kernel, not all fds can be randomly accessed...