### PR TITLE
Inspector: Allow browsing inspection data in UI after process exits

### DIFF
--- a/Userland/DevTools/Inspector/RemoteProcess.cpp
+++ b/Userland/DevTools/Inspector/RemoteProcess.cpp
@@ -152,7 +152,11 @@ void RemoteProcess::update()
 
         u32 length;
         int nread = m_socket->read((u8*)&length, sizeof(length));
-        ASSERT(nread == sizeof(length));
+        if (nread != sizeof(length)) {
+            dbgln("Disconnected from PID {}", m_pid);
+            m_socket->close();
+            return;
+        }
 
         ByteBuffer data;
         size_t remaining_bytes = length;


### PR DESCRIPTION
Allowing the data to be viewed after the process has terminated is in line with the existing behavior used a few lines earlier when the socket receives EOF.

https://github.com/SerenityOS/serenity/blob/6b7c96589b26b1cd6885d09555dc56e5b85e4412/Userland/DevTools/Inspector/RemoteProcess.cpp#L146-L151

Closes #4938
