### PR TITLE
AK: Simplify code by using forwarding references

### DIFF
--- a/AK/CircularDeque.h
+++ b/AK/CircularDeque.h
@@ -35,7 +35,8 @@ namespace AK {
 template<typename T, size_t Capacity>
 class CircularDeque : public CircularQueue<T, Capacity> {
 public:
-    void enqueue_begin(T&& value)
+    template<typename U = T>
+    void enqueue_begin(U&& value)
     {
         const auto new_head = (this->m_head - 1 + Capacity) % Capacity;
         auto& slot = this->elements()[new_head];
@@ -44,13 +45,8 @@ public:
         else
             ++this->m_size;
 
-        new (&slot) T(move(value));
+        new (&slot) T(forward<U>(value));
         this->m_head = new_head;
-    }
-
-    void enqueue_begin(const T& value)
-    {
-        enqueue_begin(T(value));
     }
 
     T dequeue_end()

--- a/AK/CircularQueue.h
+++ b/AK/CircularQueue.h
@@ -60,22 +60,18 @@ public:
 
     size_t capacity() const { return Capacity; }
 
-    void enqueue(T&& value)
+    template<typename U = T>
+    void enqueue(U&& value)
     {
         auto& slot = elements()[(m_head + m_size) % Capacity];
         if (m_size == Capacity)
             slot.~T();
 
-        new (&slot) T(move(value));
+        new (&slot) T(forward<U>(value));
         if (m_size == Capacity)
             m_head = (m_head + 1) % Capacity;
         else
             ++m_size;
-    }
-
-    void enqueue(const T& value)
-    {
-        enqueue(T(value));
     }
 
     T dequeue()

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -203,15 +203,16 @@ public:
         *this = HashTable();
     }
 
-    HashSetResult set(T&& value)
+    template<typename U = T>
+    HashSetResult set(U&& value)
     {
         auto& bucket = lookup_for_writing(value);
         if (bucket.used) {
-            (*bucket.slot()) = move(value);
+            (*bucket.slot()) = forward<U>(value);
             return HashSetResult::ReplacedExistingEntry;
         }
 
-        new (bucket.slot()) T(move(value));
+        new (bucket.slot()) T(forward<U>(value));
         bucket.used = true;
         if (bucket.deleted) {
             bucket.deleted = false;
@@ -219,11 +220,6 @@ public:
         }
         ++m_size;
         return HashSetResult::InsertedNewEntry;
-    }
-
-    HashSetResult set(const T& value)
-    {
-        return set(T(value));
     }
 
     template<typename Finder>

--- a/AK/Queue.h
+++ b/AK/Queue.h
@@ -41,17 +41,13 @@ public:
     size_t size() const { return m_size; }
     bool is_empty() const { return m_size == 0; }
 
-    void enqueue(T&& value)
+    template<typename U = T>
+    void enqueue(U&& value)
     {
         if (m_segments.is_empty() || m_segments.last()->size() >= segment_size)
             m_segments.append(make<Vector<T, segment_size>>());
-        m_segments.last()->append(move(value));
+        m_segments.last()->append(forward<U>(value));
         ++m_size;
-    }
-
-    void enqueue(const T& value)
-    {
-        enqueue(T(value));
     }
 
     T dequeue()

--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -135,14 +135,10 @@ public:
         return value;
     }
 
-    void append(const T& value)
+    template<typename U = T>
+    void append(U&& value)
     {
-        append(T(value));
-    }
-
-    void append(T&& value)
-    {
-        auto* node = new Node(move(value));
+        auto* node = new Node(forward<U>(value));
         if (!m_head) {
             m_head = node;
             m_tail = node;
@@ -201,14 +197,10 @@ public:
         delete iterator.m_node;
     }
 
-    void insert_before(Iterator iterator, const T& value)
+    template<typename U = T>
+    void insert_before(Iterator iterator, U&& value)
     {
-        insert_before(iterator, T(value));
-    }
-
-    void insert_before(Iterator iterator, T&& value)
-    {
-        auto* node = new Node(move(value));
+        auto* node = new Node(forward<U>(value));
         node->next = iterator.m_node;
         if (m_head == iterator.m_node)
             m_head = node;
@@ -216,19 +208,15 @@ public:
             iterator.m_prev->next = node;
     }
 
-    void insert_after(Iterator iterator, const T& value)
-    {
-        insert_after(iterator, T(value));
-    }
-
-    void insert_after(Iterator iterator, T&& value)
+    template<typename U = T>
+    void insert_after(Iterator iterator, U&& value)
     {
         if (iterator.is_end()) {
             append(value);
             return;
         }
 
-        auto* node = new Node(move(value));
+        auto* node = new Node(forward<U>(value));
         node->next = iterator.m_node->next;
 
         iterator.m_node->next = node;

--- a/AK/SinglyLinkedListWithCount.h
+++ b/AK/SinglyLinkedListWithCount.h
@@ -80,16 +80,11 @@ public:
         return List::take_first();
     }
 
-    void append(const T& value)
+    template<typename U = T>
+    void append(U&& value)
     {
         m_count++;
-        return SinglyLinkedList<T>::append(value);
-    }
-
-    void append(T&& value)
-    {
-        m_count++;
-        return List::append(move(value));
+        return List::append(forward<T>(value));
     }
 
     bool contains_slow(const T& value) const
@@ -135,28 +130,18 @@ public:
         return List::remove(iterator);
     }
 
-    void insert_before(Iterator iterator, const T& value)
+    template<typename U = T>
+    void insert_before(Iterator iterator, U&& value)
     {
         m_count++;
-        List::insert_before(iterator, value);
+        List::insert_before(iterator, forward<T>(value));
     }
 
-    void insert_before(Iterator iterator, T&& value)
+    template<typename U = T>
+    void insert_after(Iterator iterator, U&& value)
     {
         m_count++;
-        List::insert_before(iterator, move(value));
-    }
-
-    void insert_after(Iterator iterator, const T& value)
-    {
-        m_count++;
-        List::insert_after(iterator, value);
-    }
-
-    void insert_after(Iterator iterator, T&& value)
-    {
-        m_count++;
-        List::insert_after(iterator, move(value));
+        List::insert_after(iterator, forward<T>(value));
     }
 
 private:

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -278,11 +278,12 @@ public:
         m_size -= count;
     }
 
-    void insert(size_t index, T&& value)
+    template<typename U = T>
+    void insert(size_t index, U&& value)
     {
         ASSERT(index <= size());
         if (index == size())
-            return append(move(value));
+            return append(forward<U>(value));
         grow_capacity(size() + 1);
         ++m_size;
         if constexpr (Traits<T>::is_trivial()) {
@@ -293,26 +294,21 @@ public:
                 at(i - 1).~T();
             }
         }
-        new (slot(index)) T(move(value));
+        new (slot(index)) T(forward<U>(value));
     }
 
-    void insert(size_t index, const T& value)
-    {
-        insert(index, T(value));
-    }
-
-    template<typename C>
-    void insert_before_matching(T&& value, C callback, size_t first_index = 0, size_t* inserted_index = nullptr)
+    template<typename C, typename U = T>
+    void insert_before_matching(U&& value, C callback, size_t first_index = 0, size_t* inserted_index = nullptr)
     {
         for (size_t i = first_index; i < size(); ++i) {
             if (callback(at(i))) {
-                insert(i, move(value));
+                insert(i, forward<U>(value));
                 if (inserted_index)
                     *inserted_index = i;
                 return;
             }
         }
-        append(move(value));
+        append(forward<U>(value));
         if (inserted_index)
             *inserted_index = size() - 1;
     }
@@ -404,16 +400,12 @@ public:
         }
     }
 
-    ALWAYS_INLINE void unchecked_append(T&& value)
+    template<typename U = T>
+    ALWAYS_INLINE void unchecked_append(U&& value)
     {
         ASSERT((size() + 1) <= capacity());
-        new (slot(m_size)) T(move(value));
+        new (slot(m_size)) T(forward<U>(value));
         ++m_size;
-    }
-
-    ALWAYS_INLINE void unchecked_append(const T& value)
-    {
-        unchecked_append(T(value));
     }
 
     template<class... Args>
@@ -436,14 +428,10 @@ public:
         append(T(value));
     }
 
-    void prepend(T&& value)
+    template<typename U = T>
+    void prepend(U&& value)
     {
-        insert(0, move(value));
-    }
-
-    void prepend(const T& value)
-    {
-        insert(0, value);
+        insert(0, forward<U>(value));
     }
 
     void prepend(Vector&& other)


### PR DESCRIPTION
Problem:                                                              
- Using regular functions rather than function templates results in   
  the arguments not being deduced. This then requires the same        
  function to be written multiple times and for `move` to be used     
  rather than `forward`.                                              
                                                                      
Solution:                                                             
- Collapse multiple function overloads to a single function template  
  with a deduced argument. This allows the argument to be a forwarding
  reference and bind to either an l-value or r-value and forward the  
  value.                         
