### PR TITLE
Kernel: Gently torture the memory verification code

### DIFF
--- a/Userland/Tests/Kernel/invalid-any-pointer-assert.cpp
+++ b/Userland/Tests/Kernel/invalid-any-pointer-assert.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Format.h>
+#include <Kernel/API/Syscall.h>
+#include <errno.h>
+#include <stdio.h>
+
+int main()
+{
+    for (int i = 0; i < Syscall::Function::__Count; ++i) {
+        dbgln("Testing syscall #{}", i);
+        // This is pure torture
+        syscall(Syscall::Function(i), 0xc0000001, 0xc0000002, 0xc0000003);
+    }
+
+    // Finally, test invalid syscalls:
+    dbgln("Testing syscall #{} (n+1)", (int)Syscall::Function::__Count);
+    syscall(Syscall::Function::__Count, 0xc0000001, 0xc0000002, 0xc0000003);
+    dbgln("Testing syscall #-1");
+    syscall(Syscall::Function(-1), 0xc0000001, 0xc0000002, 0xc0000003);
+
+    // If the Kernel survived, pass.
+    printf("PASS\n");
+    return 0;
+}

--- a/Userland/Tests/Kernel/invalid-path-pointer-assert.cpp
+++ b/Userland/Tests/Kernel/invalid-path-pointer-assert.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, Ben Wiederhake <BenWiederhake.GitHub@gmx.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <Kernel/API/Syscall.h>
+#include <errno.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+int main()
+{
+    struct stat statbuf;
+    // stat(3) would call strlen, and we can't have that.
+    Syscall::SC_stat_params params {
+        // Hey Kernel, please try to read the path from this totally valid location!
+        { (const char*)0xc000dead, 50 },
+        &statbuf, false
+    };
+    int rc = syscall(SC_stat, &params);
+
+    if (rc == 0) {
+        printf("stat passed?!\n");
+        printf("FAIL\n");
+        return 1;
+    }
+    if (rc != EFAULT) {
+        printf("error other than EFAULT?! rc = %d\n", rc);
+        printf("FAIL\n");
+        return 1;
+    }
+
+    printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
This is a proof of concept (and can possibly evolve to become our own SerenitySyzkaller) for missing memory validation in the kernel. See #5198 for details.