### PR TITLE
LibX86: sanity check for Instruction read size

### DIFF
--- a/Userland/Libraries/LibX86/Instruction.h
+++ b/Userland/Libraries/LibX86/Instruction.h
@@ -863,6 +863,8 @@ ALWAYS_INLINE Instruction::Instruction(InstructionStreamType& stream, bool o32, 
     case 4:
         m_imm2 = stream.read32();
         break;
+    default:
+        ASSERT_NOT_REACHED();
     }
 
     switch (imm1_bytes) {
@@ -875,6 +877,8 @@ ALWAYS_INLINE Instruction::Instruction(InstructionStreamType& stream, bool o32, 
     case 4:
         m_imm1 = stream.read32();
         break;
+    default:
+        ASSERT_NOT_REACHED();
     }
 
     m_extra_bytes = prefix_bytes + imm1_bytes + imm2_bytes;


### PR DESCRIPTION
During "Emulator hacking: Let's make the userspace emulator go faster!",
the switch implented in read() was inlined (toward the end of the video).

This patch restore the assert check for any read other than 8, 16 or 32
bits which was lost during the code conversion.