### PR TITLE
LibWeb: Fix link on crashed browser page

### DIFF
--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -69,7 +69,7 @@ void OutOfProcessWebView::create_client()
             builder.appendff(" on {}", escape_html_entities(m_url.host()));
         }
         builder.append("</h1>");
-        builder.appendff("The web page <a href='{}'>{}</a> has crashed.<br><br>You can reload the page to try again.", AK::urlencode(m_url.to_string()), escape_html_entities(m_url.to_string()));
+        builder.appendff("The web page <a href='{}'>{}</a> has crashed.<br><br>You can reload the page to try again.", m_url.to_string(), escape_html_entities(m_url.to_string()));
         builder.append("</body></html>");
         load_html(builder.to_string(), m_url);
     };


### PR DESCRIPTION
When browser tab crashes, the link on the crash page is weird.

For example, if you load https://fast.com it crashes and on the crash page it shows the link http://fast.com/http%3A%2F%2Ffast.com%2F

Remove the encoding fixes this issue, although I don't know why.