### PR TITLE
LibJS: Use VM::names for Object::invoke() function names

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -309,7 +309,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::to_locale_string)
         auto* value_object = value.to_object(global_object);
         if (!value_object)
             return {};
-        auto locale_string_result = value_object->invoke("toLocaleString");
+        auto locale_string_result = value_object->invoke(vm.names.toLocaleString);
         if (vm.exception())
             return {};
         auto string = locale_string_result.to_string(global_object);

--- a/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -119,7 +119,7 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::to_locale_string)
     auto* this_object = vm.this_value(global_object).to_object(global_object);
     if (!this_object)
         return {};
-    return this_object->invoke("toString");
+    return this_object->invoke(vm.names.toString);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::value_of)


### PR DESCRIPTION
Just something I noticed, seems kinda out of place since we have & use `VM::names`.