### PR TITLE
Ports: Beef up the python3 port

### DIFF
--- a/Ports/.gitignore
+++ b/Ports/.gitignore
@@ -4,4 +4,3 @@
 !*/patches/*
 !*/.gitignore
 !*/README.md
-!python3/version.sh

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -154,6 +154,9 @@ func_defined configure || configure() {
     chmod +x "${workdir}"/"$configscript"
     run ./"$configscript" --host=i686-pc-serenity $configopts
 }
+func_defined post_configure || post_configure() {
+    :
+}
 func_defined build || build() {
     run make $makeopts
 }
@@ -254,6 +257,7 @@ do_configure() {
         echo "Configuring $port!"
         pre_configure
         configure
+        post_configure
     else
         echo "This port does not use a configure script. Skipping configure step."
     fi

--- a/Ports/python3/.gitignore
+++ b/Ports/python3/.gitignore
@@ -1,0 +1,2 @@
+!version.sh
+!Setup.local

--- a/Ports/python3/Setup.local
+++ b/Ports/python3/Setup.local
@@ -64,6 +64,7 @@ syslog syslogmodule.c
 unicodedata unicodedata.c
 xxlimited xxlimited.c
 xxsubtype xxsubtype.c
+zlib zlibmodule.c -I$(SERENITY_ROOT)/Build/Root/usr/local/include -L$(SERENITY_ROOT)/Build/Root/usr/local/lib -lz
 
 *disabled*
 # Not building, patch Python some more or fix LibC...

--- a/Ports/python3/Setup.local
+++ b/Ports/python3/Setup.local
@@ -1,0 +1,76 @@
+# Build most modules that are usually built as shared objects statically as importing such modules
+# currently asserts in the dynamic loader (may or may not be related to https://github.com/SerenityOS/serenity/issues/4642):
+#
+#     ASSERTION FAILED: flags & RTLD_GLOBAL
+#     ../Userland/Libraries/LibELF/DynamicLoader.cpp:171 (as of 2020-02-01 at least)
+#
+# This means we otherwise couldn't import any of these nor anything that imports them, which is quite limiting.
+#
+# The list is mostly copied from Modules/Setup, with some minor tweaks (include paths, added a bunch of other modules).
+# As a result of static linking, a build failure in any of these modules will fail the build of Python itself,
+# instead of just not building that specific .so - obviously. If this stops working, tweak the list accordingly.
+#
+# Some stuff is neither under *static* nor *disabled*, so lib-dynload isn't entirely empty - mostly _test* modules though.
+#
+# Python itself is still linked dynamically, which works fine - it's just module imports that blow up.
+# This file can simply be removed, along with post_configure() in package.sh, once the issue mentioned above is resolved.
+
+*static*
+
+_asyncio _asynciomodule.c
+_bisect _bisectmodule.c
+_blake2 _blake2/blake2module.c _blake2/blake2b_impl.c _blake2/blake2s_impl.c
+_codecs_cn cjkcodecs/_codecs_cn.c
+_codecs_hk cjkcodecs/_codecs_hk.c
+_codecs_iso2022 cjkcodecs/_codecs_iso2022.c
+_codecs_jp cjkcodecs/_codecs_jp.c
+_codecs_kr cjkcodecs/_codecs_kr.c
+_codecs_tw cjkcodecs/_codecs_tw.c
+_contextvars _contextvarsmodule.c
+_crypt _cryptmodule.c
+_csv _csv.c
+_ctypes _ctypes/_ctypes.c _ctypes/callbacks.c _ctypes/callproc.c _ctypes/cfield.c _ctypes/malloc_closure.c _ctypes/stgdict.c -I$(SERENITY_ROOT)/Build/Root/usr/local/include $(SERENITY_ROOT)/Build/Root/usr/local/lib/libffi.a
+_datetime _datetimemodule.c
+_elementtree -I$(srcdir)/Modules/expat -DHAVE_EXPAT_CONFIG_H -DUSE_PYEXPAT_CAPI _elementtree.c
+_heapq _heapqmodule.c
+_json -I$(srcdir)/Include/internal -DPy_BUILD_CORE_BUILTIN _json.c
+_md5 md5module.c
+_multibytecodec cjkcodecs/multibytecodec.c
+_opcode _opcode.c
+_pickle _pickle.c
+_posixsubprocess _posixsubprocess.c
+_queue _queuemodule.c
+_random _randommodule.c -DPy_BUILD_CORE_MODULE
+_sha1 sha1module.c
+_sha256 sha256module.c -DPy_BUILD_CORE_BUILTIN
+_sha3 _sha3/sha3module.c
+_sha512 sha512module.c -DPy_BUILD_CORE_BUILTIN
+_statistics _statisticsmodule.c
+_struct _struct.c
+_weakref _weakref.c
+_xxsubinterpreters _xxsubinterpretersmodule.c
+_zoneinfo _zoneinfo.c
+array arraymodule.c
+audioop audioop.c
+binascii binascii.c
+cmath cmathmodule.c _math.c -DPy_BUILD_CORE_MODULE
+fcntl fcntlmodule.c
+grp grpmodule.c
+math mathmodule.c _math.c -DPy_BUILD_CORE_MODULE
+parser parsermodule.c
+pyexpat expat/xmlparse.c expat/xmlrole.c expat/xmltok.c pyexpat.c -I$(srcdir)/Modules/expat -DHAVE_EXPAT_CONFIG_H -DXML_POOR_ENTROPY -DUSE_PYEXPAT_CAPI
+select selectmodule.c
+syslog syslogmodule.c
+unicodedata unicodedata.c
+xxlimited xxlimited.c
+xxsubtype xxsubtype.c
+
+*disabled*
+# Not building, patch Python some more or fix LibC...
+_decimal _socket mmap resource spwd termios
+
+# Linker errors
+_lsprof _multiprocessing
+
+# Lots and lots of linker errors, although these flags should be correct:
+_curses _cursesmodule.c -I$(SERENITY_ROOT)/Build/Root/usr/local/include/ncurses -L$(SERENITY_ROOT)/Build/Root/usr/local/lib -lncurses -ltermcap

--- a/Ports/python3/package.sh
+++ b/Ports/python3/package.sh
@@ -12,9 +12,9 @@ auth_type="sig"
 auth_import_key="E3FF2839C048B25C084DEBE9B26995E310250568"
 auth_opts="Python-${version}.tar.xz.asc Python-${version}.tar.xz"
 
-# We could also add `ncurses`, `openssl`, and `zlib` here, but neither of the _curses, _ssl, and zlib
+# We could also add `ncurses`/`termcap` and `openssl` here, but neither of the _curses nor _ssl
 # modules build at the moment even with those available, so it's pointless.
-depends="libffi"
+depends="libffi zlib"
 
 # FIXME: the --build value is detected correctly by the configure script (via config.guess in the Python source root),
 # but still needs to be set explicitly when cross compiling. Figure out how to not hardcode this.

--- a/Ports/python3/package.sh
+++ b/Ports/python3/package.sh
@@ -25,6 +25,10 @@ configopts="--build=${BUILD} --without-ensurepip ac_cv_file__dev_ptmx=no ac_cv_f
 
 export BLDSHARED="${CC} -shared"
 
+post_configure() {
+    run cp "${SERENITY_ROOT}/Ports/${port}/Setup.local" "Modules/Setup.local"
+}
+
 if [ -x "$(command -v python3)" ]; then
     # Check if major and minor version of python3 are matching
     if ! python3 -c "import sys; major, minor, _ = map(int, '${PYTHON_VERSION}'.split('.')); sys.exit(not (sys.version_info.major == major and sys.version_info.minor == minor))"; then


### PR DESCRIPTION
Many more extension modules are usable now. Current build summary:

```
Python build finished successfully!
The necessary bits to build these optional modules were not found:
_bz2                  _curses               _curses_panel      
_dbm                  _gdbm                 _hashlib           
_lzma                 _sqlite3              _ssl               
_tkinter              _uuid                 nis                
ossaudiodev           readline              spwd               
zlib                                                           
To find the necessary bits, look in setup.py in detect_modules() for the module's name.


The following modules found by detect_modules() in setup.py, have been
built by the Makefile instead, as configured by the Setup files:
_abc                  _asyncio              _bisect            
_blake2               _codecs_cn            _codecs_hk         
_codecs_iso2022       _codecs_jp            _codecs_kr         
_codecs_tw            _contextvars          _crypt             
_csv                  _ctypes               _datetime          
_elementtree          _heapq                _json              
_md5                  _multibytecodec       _opcode            
_pickle               _posixsubprocess      _queue             
_random               _sha1                 _sha256            
_sha3                 _sha512               _statistics        
_struct               _xxsubinterpreters    _zoneinfo          
array                 atexit                audioop            
binascii              cmath                 fcntl              
grp                   math                  parser             
pwd                   pyexpat               select             
syslog                time                  unicodedata        
xxlimited                                                      


The following modules found by detect_modules() in setup.py have not
been built, they are *disabled* in the Setup files:
_decimal              _lsprof               _multiprocessing   
_socket               mmap                  resource           
termios
```

---

(`zlib` in the first section is a lie...)

![image](https://user-images.githubusercontent.com/19366641/106505593-d4b80a80-64c8-11eb-8e02-02e88cacb5cd.png)
