### PR TITLE
HackStudio: fixed bugs related to file open

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -672,7 +672,7 @@ void HackStudioWidget::create_project_tree_view(GUI::Widget& parent)
     };
 
     m_project_tree_view->on_activation = [this](auto& index) {
-        auto filename = index.data(GUI::ModelRole::Custom).to_string();
+        auto filename = index.data().as_string();
         open_file(filename);
     };
 }

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -209,6 +209,9 @@ Vector<String> HackStudioWidget::selected_file_names() const
 
 void HackStudioWidget::open_file(const String& filename)
 {
+    if (Core::File::is_directory(filename))
+        return;
+
     if (!currently_open_file().is_empty()) {
         // Since the file is previously open, it should always be in m_open_files.
         ASSERT(m_open_files.find(currently_open_file()) != m_open_files.end());


### PR DESCRIPTION
Two bugs related to file opening were solved:
* Opening empty directories as file in the editor;
* Opening a file with _double click_ would open the file with absolute path.

### Opening empty directories as file in the editor
In the tree view, when _double clicking_ or when _right click > Open_ with an empty directory selected, said directory would open in the editor section as if it was a file to edit.

### Opening a file with _double click_ would open the file with absolute path
When _double clicking_ in the tree view, the selected file would open with absolute path, while opening the same file with _right click > Open_ would open the file with relative path. This would cause the `open_file_view` to have the same file twice, but with different path displayed.