### PR TITLE
Meta: Remove 'keymap exploration' in favor of precommit hook

### DIFF
--- a/Meta/lint-keymaps.py
+++ b/Meta/lint-keymaps.py
@@ -102,27 +102,7 @@ def run_here():
     return run_with(list_files_here())
 
 
-def display_for(filename, index):
-    with open(filename, 'r') as fp:
-        fullmap = json.load(fp)
-    for name in PERMITTED_MAPS:
-        c = None
-        if name in fullmap:
-            m = fullmap[name]
-            if len(m) > index and m[index]:
-                c = m[index]
-        if c is None:
-            print('{}: None'.format(name))
-        else:
-            print('{}: "{}"'.format(name, c))
-
-
 if __name__ == '__main__':
     os.chdir(os.path.dirname(__file__) + "/../Base/res/keymaps/")
-    if len(sys.argv) == 1:
-        exit(0 if run_here() else 1)
-    elif len(sys.argv) == 3:
-        display_for('{}.json'.format(sys.argv[1]), int(sys.argv[2], 0))
-    else:
-        print('USAGE: {} [mapcode index]'.format(sys.argv[0]), file=sys.stderr)
+    if not run_here():
         exit(1)


### PR DESCRIPTION
    <kling> hmmm, Meta/lint-keymaps.py is failing the precommit hook while editing random cpp files :(

That's because the precommit hook passes some data (absolute paths? relative paths? relative to what exactly? What's the working dir?) to `lint-ci.sh`, which passes it along to `lint-keymap.py`, which tried to interpret the filenames as a keycode, which is not an int.

I removed that feature; it can be emulated by `gron | grep` anyway. Now `lint-keymaps.py` accepts any arguments, including garbage :)

```
$ ./Meta/lint-keymaps.py asdkfj o98wezgoaiwu4jh saef
18 out of 18 keymaps passed.
```