### PR TITLE
Shell: Make history range values larger than u32 a syntax error

### DIFF
--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -1364,6 +1364,10 @@ HistoryEvent::HistoryEvent(Position position, HistorySelector selector)
     : Node(move(position))
     , m_selector(move(selector))
 {
+    if (m_selector.word_selector_range.start.syntax_error_node)
+        set_is_syntax_error(*m_selector.word_selector_range.start.syntax_error_node);
+    else if (m_selector.word_selector_range.end.has_value() && m_selector.word_selector_range.end->syntax_error_node)
+        set_is_syntax_error(*m_selector.word_selector_range.end->syntax_error_node);
 }
 
 HistoryEvent::~HistoryEvent()

--- a/Userland/Shell/AST.h
+++ b/Userland/Shell/AST.h
@@ -908,6 +908,7 @@ struct HistorySelector {
         WordSelectorKind kind { Index };
         size_t selector { 0 };
         Position position;
+        RefPtr<AST::SyntaxError> syntax_error_node;
 
         size_t resolve(size_t size) const
         {


### PR DESCRIPTION
Found by oss-fuzz:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29792&sort=reported&q=serenity