### PR TITLE
Kernel: Use the resolved parent path when testing create veil

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -1031,6 +1031,10 @@ KResultOr<NonnullRefPtr<Custody>> VFS::resolve_path_without_veil(StringView path
             if (!safe_to_follow_symlink(*child_inode, parent_metadata))
                 return EACCES;
 
+            auto result = validate_path_against_process_veil(custody->absolute_path(), options);
+            if (result.is_error())
+                return result;
+
             auto symlink_target = child_inode->resolve_as_link(parent, out_parent, options, symlink_recursion_level + 1);
             if (symlink_target.is_error() || !have_more_parts)
                 return symlink_target;

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -383,7 +383,8 @@ KResult VFS::mknod(StringView path, mode_t mode, dev_t dev, Custody& base)
 
 KResultOr<NonnullRefPtr<FileDescription>> VFS::create(StringView path, int options, mode_t mode, Custody& parent_custody, Optional<UidAndGid> owner)
 {
-    auto result = validate_path_against_process_veil(path, options);
+    LexicalPath p(path);
+    auto result = validate_path_against_process_veil(String::formatted("{}/{}", parent_custody.absolute_path(), p.basename()), options);
     if (result.is_error())
         return result;
 
@@ -399,7 +400,6 @@ KResultOr<NonnullRefPtr<FileDescription>> VFS::create(StringView path, int optio
     if (parent_custody.is_readonly())
         return EROFS;
 
-    LexicalPath p(path);
     dbgln<VFS_DEBUG>("VFS::create: '{}' in {}", p.basename(), parent_inode.identifier());
     uid_t uid = owner.has_value() ? owner.value().uid : current_process->euid();
     gid_t gid = owner.has_value() ? owner.value().gid : current_process->egid();

--- a/Userland/Tests/Kernel/unveil-symlinks.cpp
+++ b/Userland/Tests/Kernel/unveil-symlinks.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main()
+{
+    rmdir("/tmp/foo/1");
+    rmdir("/tmp/foo");
+    unlink("/tmp/bar");
+
+    if (mkdir("/tmp/foo", 0755) < 0) {
+        perror("mkdir");
+        return 1;
+    }
+
+    if (mkdir("/tmp/foo/1", 0755) < 0) {
+        perror("mkdir");
+        return 1;
+    }
+
+    if (symlink("/tmp/foo", "/tmp/bar")) {
+        perror("symlink");
+        return 1;
+    }
+
+    if (unveil("/tmp/foo", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil(nullptr, nullptr) < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    int fd = open("/tmp/foo/1", O_RDONLY);
+    if (fd < 0) {
+        perror("open");
+        return 1;
+    }
+    close(fd);
+
+    fd = open("/tmp/bar/1", O_RDONLY);
+    if (fd >= 0) {
+        fprintf(stderr, "FAIL, symlink was not unveiled\n");
+        return 1;
+    }
+
+    if (chdir("/tmp")) {
+        perror("chdir");
+        return 1;
+    }
+
+    fd = open("./foo/1", O_RDONLY);
+    if (fd < 0) {
+        perror("open");
+        return 1;
+    }
+    close(fd);
+
+    fd = open("./bar/1", O_RDONLY);
+    if (fd >= 0) {
+        fprintf(stderr, "FAIL, symlink was not unveiled\n");
+        return 1;
+    }
+
+    printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
When opening a file with O_CREAT, if the [parent exists but the file does](https://github.com/SerenityOS/serenity/blob/91db36064f5da1d5d9f8e010271d7951937a9de5/Kernel/FileSystem/VirtualFileSystem.cpp#L266) not then `validate_path_against_process_veil` is called with the [unresolved path](https://github.com/SerenityOS/serenity/blob/91db36064f5da1d5d9f8e010271d7951937a9de5/Kernel/FileSystem/VirtualFileSystem.cpp#L386) which could allow symlinks to be used to bypass the veil.

Instead of using the original path, we can use the resolved path of the parent custody with the basename of the path.

Example hax.cpp to write a file to the home directory:
```cpp
#include <LibCore/File.h>
#include <serenity.h>

int main()
{
    if (pledge("stdio rpath wpath cpath", nullptr) < 0) {
        perror("pledge");
        return 1;
    }

    if (unveil("/tmp", "rwc")) {
        perror("unveil");
        return 1;
    }

    unveil(nullptr, nullptr);

    if (symlink("/home/anon/missing", "/tmp/missing") < 0) {
        perror("symlink");
    }

    auto file = Core::File::open("/tmp/missing/hax", Core::IODevice::OpenMode::ReadWrite);
    if (file.is_error()) {
        fprintf(stderr, "Error: %s", file.error().characters());
        return 1;
    }
    if (!file.value()->write("haxed")) {
        perror("write");
    }

    return 0;
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/serenityos/serenity/5231)
<!-- Reviewable:end -->
