### PR TITLE
LibTTF: Check if the given offset plus offset table size would overflow

### DIFF
--- a/Userland/Libraries/LibTTF/Font.cpp
+++ b/Userland/Libraries/LibTTF/Font.cpp
@@ -241,6 +241,11 @@ RefPtr<Font> Font::load_from_memory(ByteBuffer& buffer, unsigned index)
 // FIXME: "loca" and "glyf" are not available for CFF fonts.
 RefPtr<Font> Font::load_from_offset(ByteBuffer&& buffer, u32 offset)
 {
+    if (Checked<u32>::addition_would_overflow(offset, (u32)Sizes::OffsetTable)) {
+        dbgln("Invalid offset in font header");
+        return nullptr;
+    }
+
     if (buffer.size() < offset + (u32)Sizes::OffsetTable) {
         dbgln("Font file too small");
         return nullptr;


### PR DESCRIPTION
If it does overflow, it would think there was enough data to read in
table information, when there isn't. This would cause read buffer
overflows when reading in the table information.

Found by: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29338&sort=-opened&can=1&q=proj%3Aserenity
