### PR TITLE
Kernel: Clear pending interrupts before enabling IRQs of IDE Channel

### DIFF
--- a/Kernel/Storage/IDEChannel.cpp
+++ b/Kernel/Storage/IDEChannel.cpp
@@ -142,7 +142,15 @@ IDEChannel::IDEChannel(const IDEController& controller, IOAddressGroup io_group,
 
     initialize(force_pio);
     detect_disks();
+
+    // Note: calling to detect_disks could generate an interrupt, clear it if that's the case
+    clear_pending_interrupts();
     enable_irq();
+}
+
+void IDEChannel::clear_pending_interrupts() const
+{
+    m_io_group.io_base().offset(ATA_REG_STATUS).in<u8>();
 }
 
 IDEChannel::~IDEChannel()

--- a/Kernel/Storage/IDEChannel.h
+++ b/Kernel/Storage/IDEChannel.h
@@ -138,6 +138,8 @@ private:
     void start_request(AsyncBlockDeviceRequest&, bool, bool, u16);
     void complete_current_request(AsyncDeviceRequest::RequestResult);
 
+    void clear_pending_interrupts() const;
+
     void ata_access(Direction, bool, u32, u8, u16, bool);
     void ata_read_sectors_with_dma(bool, u16);
     void ata_read_sectors(bool, u16);


### PR DESCRIPTION
Calling detect_disks() can generate interrupts, so we must clear it to
allow proper function when booting with kernel argument smp=on.

Fixes #5229.