### PR TITLE
Kernel: Try to detect Sound Blaster 16

### DIFF
--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -89,6 +89,19 @@ SB16::~SB16()
 {
 }
 
+void SB16::detect()
+{
+    IO::out8(0x226, 1);
+    IO::delay(32);
+    IO::out8(0x226, 0);
+
+    auto data = dsp_read();
+    if (data != 0xaa) {
+        return;
+    }
+    SB16::create();
+}
+
 void SB16::create()
 {
     s_the.ensure_instance();

--- a/Kernel/Devices/SB16.h
+++ b/Kernel/Devices/SB16.h
@@ -42,6 +42,7 @@ public:
     SB16();
     virtual ~SB16() override;
 
+    static void detect();
     static void create();
     static SB16& the();
 
@@ -69,7 +70,7 @@ private:
     void dma_start(uint32_t length);
     void set_sample_rate(uint16_t hz);
     void dsp_write(u8 value);
-    u8 dsp_read();
+    static u8 dsp_read();
     u8 get_irq_line();
     void set_irq_register(u8 irq_number);
     void set_irq_line(u8 irq_number);

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -268,7 +268,7 @@ void init_stage2(void*)
     new FullDevice;
     new RandomDevice;
     PTYMultiplexer::initialize();
-    new SB16;
+    SB16::detect();
     VMWareBackdoor::the(); // don't wait until first mouse packet
 
     bool force_pio = kernel_command_line().contains("force_pio");


### PR DESCRIPTION
We shouldn't create a SB16 instance without checking if the Sound
Blaster 16 card is not installed in the system.

Partially fixes #5234.