### PR TITLE
WindowServer: Don't close menu when clicking on item with submenu

### DIFF
--- a/Userland/Services/WindowServer/MenuManager.cpp
+++ b/Userland/Services/WindowServer/MenuManager.cpp
@@ -242,6 +242,13 @@ void MenuManager::handle_mouse_event(MouseEvent& mouse_event)
             }
 
             if (mouse_event.type() == Event::MouseDown) {
+                for (auto& menu : m_open_menu_stack) {
+                    if (!menu)
+                        continue;
+                    if (!menu->menu_window()->rect().contains(mouse_event.position()))
+                        continue;
+                    return;
+                }
                 close_bar();
                 topmost_menu->set_window_menu_open(false);
             }


### PR DESCRIPTION
When clicking on a menu that has items in it, it should remain open