### PR TITLE
SystemMonitor: Use system color themes for graph widgets

### DIFF
--- a/Userland/Applications/SystemMonitor/GraphWidget.cpp
+++ b/Userland/Applications/SystemMonitor/GraphWidget.cpp
@@ -27,7 +27,9 @@
 #include "GraphWidget.h"
 #include <LibGUI/Painter.h>
 #include <LibGfx/Font.h>
+#include <LibGfx/Palette.h>
 #include <LibGfx/Path.h>
+#include <LibGfx/SystemTheme.h>
 
 GraphWidget::GraphWidget()
 {
@@ -49,7 +51,7 @@ void GraphWidget::paint_event(GUI::PaintEvent& event)
     GUI::Painter painter(*this);
     painter.add_clip_rect(event.rect());
     painter.add_clip_rect(frame_inner_rect());
-    painter.fill_rect(event.rect(), m_background_color);
+    painter.fill_rect(event.rect(), palette().base());
 
     auto inner_rect = frame_inner_rect();
     float scale = (float)inner_rect.height() / (float)m_max;

--- a/Userland/Applications/SystemMonitor/GraphWidget.h
+++ b/Userland/Applications/SystemMonitor/GraphWidget.h
@@ -39,8 +39,6 @@ public:
 
     void add_value(Vector<int, 1>&&);
 
-    void set_background_color(Color color) { m_background_color = color; }
-
     struct ValueFormat {
         Color line_color { Color::Transparent };
         Color background_color { Color::Transparent };
@@ -63,7 +61,6 @@ private:
     int m_max { 100 };
     Vector<ValueFormat, 1> m_value_format;
     CircularQueue<Vector<int, 1>, 4000> m_values;
-    Color m_background_color { Color::Black };
     bool m_stack_values { false };
 
     Vector<Gfx::IntPoint, 1> m_calculated_points;

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -568,6 +568,8 @@ NonnullRefPtr<GUI::Widget> build_graphs_tab()
     auto graphs_container = GUI::LazyWidget::construct();
 
     graphs_container->on_first_show = [](GUI::LazyWidget& self) {
+        const auto system_palette = GUI::Application::the()->palette();
+
         self.set_fill_with_background_color(true);
         self.set_background_role(ColorRole::Button);
         self.set_layout<GUI::VerticalBoxLayout>();
@@ -581,17 +583,14 @@ NonnullRefPtr<GUI::Widget> build_graphs_tab()
         for (size_t i = 0; i < ProcessModel::the().cpus().size(); i++) {
             auto& cpu_graph = cpu_graph_group_box.add<GraphWidget>();
             cpu_graph.set_max(100);
-            cpu_graph.set_background_color(Color::White);
             cpu_graph.set_value_format(0, {
-                                              .line_color = Color::Blue,
-                                              .background_color = Color::from_rgb(0xaaaaff),
+                                              .line_color = system_palette.syntax_preprocessor_statement(),
                                               .text_formatter = [](int value) {
                                                   return String::formatted("Total: {}%", value);
                                               },
                                           });
             cpu_graph.set_value_format(1, {
-                                              .line_color = Color::Red,
-                                              .background_color = Color::from_rgb(0xffaaaa),
+                                              .line_color = system_palette.syntax_preprocessor_value(),
                                               .text_formatter = [](int value) {
                                                   return String::formatted("Kernel: {}%", value);
                                               },
@@ -608,25 +607,21 @@ NonnullRefPtr<GUI::Widget> build_graphs_tab()
         memory_graph_group_box.layout()->set_margins({ 6, 16, 6, 6 });
         memory_graph_group_box.set_fixed_height(120);
         auto& memory_graph = memory_graph_group_box.add<GraphWidget>();
-        memory_graph.set_background_color(Color::White);
         memory_graph.set_stack_values(true);
         memory_graph.set_value_format(0, {
-                                             .line_color = Color::from_rgb(0x619910),
-                                             .background_color = Color::from_rgb(0xbbffbb),
+                                             .line_color = system_palette.syntax_comment(),
                                              .text_formatter = [&memory_graph](int value) {
                                                  return String::formatted("Committed: {} KiB", value);
                                              },
                                          });
         memory_graph.set_value_format(1, {
-                                             .line_color = Color::Blue,
-                                             .background_color = Color::from_rgb(0xaaaaff),
+                                             .line_color = system_palette.syntax_preprocessor_statement(),
                                              .text_formatter = [&memory_graph](int value) {
                                                  return String::formatted("Allocated: {} KiB", value);
                                              },
                                          });
         memory_graph.set_value_format(2, {
-                                             .line_color = Color::Red,
-                                             .background_color = Color::from_rgb(0xffaaaa),
+                                             .line_color = system_palette.syntax_preprocessor_value(),
                                              .text_formatter = [&memory_graph](int value) {
                                                  return String::formatted("Kernel heap: {} KiB", value);
                                              },


### PR DESCRIPTION
#4895 pointed out that the graphs in SystemMonitor look kind of bad with dark themes. This PR changes the graphs to use system theme colors, using the text widget background color and syntax highlighting colors to ensure that the graph is both readable and thematically appropriate.

Screenshots:
![](https://user-images.githubusercontent.com/12678164/104255317-b71af680-5470-11eb-8366-d5013088d90e.png)
![](https://user-images.githubusercontent.com/12678164/104255327-bc784100-5470-11eb-9fd5-2a96ddcbe160.png)
![](https://user-images.githubusercontent.com/12678164/104255333-beda9b00-5470-11eb-9507-1a83de74039b.png)
![](https://user-images.githubusercontent.com/12678164/104255337-c0a45e80-5470-11eb-9667-27e4061f5533.png)