### PR TITLE
Profiler: Display timing information in ProfileTimelineWidget

### DIFF
--- a/Userland/DevTools/Profiler/ProfileTimelineWidget.h
+++ b/Userland/DevTools/Profiler/ProfileTimelineWidget.h
@@ -50,4 +50,5 @@ private:
     bool m_selecting { false };
     u64 m_select_start_time { 0 };
     u64 m_select_end_time { 0 };
+    u64 m_hover_time { 0 };
 };


### PR DESCRIPTION
Currently, there is no way to know when in a profile's duration a
sample was taken. This commit adds a basic timestamp to the timeline
widget, and a black bar to show where the cursor is hovering over.

Example:
![2021-02-06-143308_2048x1590_scrot](https://user-images.githubusercontent.com/12678164/107108876-77f38180-6833-11eb-9283-5022e05dccd7.png)
