### PR TITLE
Meta: Fix path to kernel binary in debug-kernel.sh

### DIFF
--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -9,6 +9,6 @@
 # the debugger which binary to load symbols, etc from.
 #
 $SERENITY_KERNEL_DEBUGGER \
-    -ex "file $(pwd)/kernel" \
+    -ex "file $(dirname "$0")/../Build/Kernel/Kernel" \
     -ex 'set arch i386:intel' \
     -ex 'target remote localhost:1234'


### PR DESCRIPTION
This appears to have been broken since the migration to cmake.