### PR TITLE
Meta: Fix error building filesystem on macOS

### DIFF
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -34,7 +34,7 @@ umask 0022
 printf "installing base system... "
 $CP -PdR "$SERENITY_ROOT"/Base/* mnt/
 $CP "$SERENITY_ROOT"/Toolchain/Local/i686/i686-pc-serenity/lib/libgcc_s.so mnt/usr/lib/
-$CP -PdR Root/* mnt/
+$CP -PdR Root/* mnt/ || $CP -PdR Root/* mnt/
 # If umask was 027 or similar when the repo was cloned,
 # file permissions in Base/ are too restrictive. Restore
 # the permissions needed in the image.


### PR DESCRIPTION
This is an ugly hack and I'm not proud of it.

But without it, I get the following error:

```
→ ninja image
[0/2] Re-checking globbed directories...
[0/1] cd /Users/tim/pp/serenity/Build && /usr/local/Cellar/cmake/3.19.1/bin/cmake -E env SERENITY_ROOT=/Users/tim/pp/serenity SERENITY_ARCH=i686 /Users/tim/pp/serenity/Meta/build-image-qemu.sh
Password:
setting up disk image...
Formatting '_disk_image', fmt=raw size=231735296
done
creating new filesystem... done
mounting filesystem... done
installing base system... gcp: cannot create hard link 'mnt/usr/local/share/terminfo/76/vt320-w-nam' to 'mnt/usr/local/share/terminfo/76/vt300-w-nam': No such file or directory
gcp: cannot create hard link 'mnt/usr/local/share/terminfo/76/vt330' to 'mnt/usr/local/share/terminfo/64/dec-vt340': No such file or directory
gcp: cannot create hard link 'mnt/usr/local/share/terminfo/76/vt340' to 'mnt/usr/local/share/terminfo/64/dec-vt340': No such file or directory
gcp: cannot create hard link 'mnt/usr/local/share/terminfo/78/xnuppc-200x64' to 'mnt/usr/local/share/terminfo/64/darwin-200x64': No such file or directory
gcp: cannot create hard link 'mnt/usr/local/share/terminfo/78/xnuppc-200x75-m' to 'mnt/usr/local/share/terminfo/64/darwin-200x75-m': No such file or directory
gcp: cannot create hard link 'mnt/usr/local/share/terminfo/78/xnuppc-200x75' to 'mnt/usr/local/share/terminfo/64/darwin-200x75': No such file or directory
gcp: cannot create hard link 'mnt/usr/local/share/terminfo/78/xnuppc-256x96-m' to 'mnt/usr/local/share/terminfo/64/darwin-256x96-m': No such file or directory
gcp: cannot create hard link 'mnt/usr/local/share/terminfo/78/xnuppc-256x96' to 'mnt/usr/local/share/terminfo/64/darwin-256x96': No such file or directory
gcp: cannot create hard link 'mnt/usr/local/share/terminfo/78/xterm.js' to 'mnt/usr/local/share/terminfo/76/vscode': No such file or directory
gcp: cannot create hard link 'mnt/usr/local/share/terminfo/78/x10term' to 'mnt/usr/local/share/terminfo/76/vs100-x10': No such file or directory
unmounting filesystem... done
FAILED: CMakeFiles/qemu-image _disk_image
cd /Users/tim/pp/serenity/Build && /usr/local/Cellar/cmake/3.19.1/bin/cmake -E env SERENITY_ROOT=/Users/tim/pp/serenity SERENITY_ARCH=i686 /Users/tim/pp/serenity/Meta/build-image-qemu.sh
ninja: build stopped: subcommand failed.
```

It appears that the copy of gcp on my system (macOS), when preserving hard links, attempts to do things out of order. It is trying to hardlink a file to an inode that has not yet been copied (or something like that).

Running the same copy command twice seems to be a workaround for such silliness.

I'm hoping someone knows more about what's happening and comes up with a far better solution.

My OS: macOS Big Sur (11.2)
gcp version: cp (GNU coreutils) 8.32