### PR TITLE
Everywhere, mostly AK: Fix some includes

### DIFF
--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
-#include <AK/Span.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 

--- a/AK/BinarySearch.h
+++ b/AK/BinarySearch.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 

--- a/AK/Bitmap.h
+++ b/AK/Bitmap.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <AK/Assertions.h>
 #include <AK/Noncopyable.h>
 #include <AK/Optional.h>
 #include <AK/Platform.h>

--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -27,11 +27,9 @@
 #pragma once
 
 #include <AK/NonnullRefPtr.h>
-#include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Span.h>
-#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <AK/kmalloc.h>
 

--- a/AK/CircularDeque.h
+++ b/AK/CircularDeque.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <AK/Assertions.h>
 #include <AK/CircularQueue.h>
 #include <AK/Types.h>
 

--- a/AK/DoublyLinkedList.h
+++ b/AK/DoublyLinkedList.h
@@ -29,7 +29,6 @@
 #include <AK/Assertions.h>
 #include <AK/Find.h>
 #include <AK/StdLibExtras.h>
-#include <AK/Traits.h>
 
 namespace AK {
 

--- a/AK/FileStream.h
+++ b/AK/FileStream.h
@@ -28,7 +28,6 @@
 
 #include <AK/Stream.h>
 #ifndef KERNEL
-#    include <AK/LogStream.h>
 #    include <errno.h>
 #    include <stdio.h>
 

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -35,7 +35,6 @@
 #    include <Kernel/Thread.h>
 #else
 #    include <stdio.h>
-#    include <unistd.h>
 #endif
 
 namespace AK {

--- a/AK/Function.h
+++ b/AK/Function.h
@@ -28,7 +28,6 @@
 #include <AK/Assertions.h>
 #include <AK/OwnPtr.h>
 #include <AK/StdLibExtras.h>
-#include <AK/Traits.h>
 
 namespace AK {
 

--- a/AK/HashFunctions.h
+++ b/AK/HashFunctions.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "Types.h"
+#include <AK/Types.h>
 
 constexpr unsigned int_hash(u32 key)
 {

--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -28,7 +28,6 @@
 
 #include <AK/HashTable.h>
 #include <AK/Optional.h>
-#include <AK/StdLibExtras.h>
 #include <AK/Vector.h>
 
 // NOTE: We can't include <initializer_list> during the toolchain bootstrap,

--- a/AK/Hex.h
+++ b/AK/Hex.h
@@ -28,7 +28,6 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/Optional.h>
-#include <AK/Span.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 

--- a/AK/IDAllocator.h
+++ b/AK/IDAllocator.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <AK/HashTable.h>
-#include <stdlib.h>
 
 namespace AK {
 

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -31,7 +31,6 @@
 #include <AK/JsonObjectSerializer.h>
 #include <AK/JsonValue.h>
 #include <AK/String.h>
-#include <AK/StringImpl.h>
 
 namespace AK {
 

--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -27,7 +27,6 @@
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonParser.h>
-#include <AK/Memory.h>
 #include <ctype.h>
 
 namespace AK {

--- a/AK/JsonPath.cpp
+++ b/AK/JsonPath.cpp
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonPath.h>
 #include <AK/JsonValue.h>

--- a/AK/JsonPath.h
+++ b/AK/JsonPath.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -29,7 +29,6 @@
 #include <AK/JsonObject.h>
 #include <AK/JsonParser.h>
 #include <AK/JsonValue.h>
-#include <AK/StringBuilder.h>
 
 namespace AK {
 

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/Function.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonParser.h>

--- a/AK/LogStream.cpp
+++ b/AK/LogStream.cpp
@@ -35,10 +35,6 @@
 #    include <Kernel/Thread.h>
 #endif
 
-#if !defined(KERNEL)
-#    include <stdio.h>
-#endif
-
 namespace AK {
 
 const LogStream& operator<<(const LogStream& stream, const String& value)

--- a/AK/MappedFile.cpp
+++ b/AK/MappedFile.cpp
@@ -28,7 +28,6 @@
 #include <AK/ScopeGuard.h>
 #include <AK/String.h>
 #include <fcntl.h>
-#include <stdio.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -29,7 +29,6 @@
 #include <AK/Assertions.h>
 #include <AK/Atomic.h>
 #include <AK/LogStream.h>
-#include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #ifdef KERNEL
 #    include <Kernel/Arch/i386/CPU.h>

--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <AK/Forward.h>
 #include <AK/String.h>
 
 namespace AK {

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <AK/Assertions.h>
-#include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <AK/kmalloc.h>

--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -26,10 +26,8 @@
 
 #pragma once
 
-#include <AK/Assertions.h>
-#include <AK/LogStream.h>
+#include <AK/Format.h>
 #include <AK/StdLibExtras.h>
-#include <AK/StringBuilder.h>
 #include <AK/Types.h>
 #include <stdarg.h>
 

--- a/AK/Singleton.h
+++ b/AK/Singleton.h
@@ -29,7 +29,6 @@
 #include <AK/Assertions.h>
 #include <AK/Atomic.h>
 #include <AK/Noncopyable.h>
-#include <AK/kmalloc.h>
 #ifdef KERNEL
 #    include <Kernel/Arch/i386/CPU.h>
 #endif

--- a/AK/SinglyLinkedListWithCount.h
+++ b/AK/SinglyLinkedListWithCount.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <AK/SinglyLinkedList.h>
-#include <AK/StdLibExtras.h>
 
 namespace AK {
 

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -34,10 +34,6 @@
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 
-#ifndef KERNEL
-#    include <inttypes.h>
-#endif
-
 namespace AK {
 
 String::String(const StringView& view)

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -33,14 +33,14 @@ namespace AK {
 template<typename T>
 class TypedTransfer {
 public:
-    static size_t move(T* destination, T* source, size_t count)
+    static void move(T* destination, T* source, size_t count)
     {
         if (!count)
-            return 0;
+            return;
 
         if constexpr (Traits<T>::is_trivial()) {
             __builtin_memmove(destination, source, count * sizeof(T));
-            return count;
+            return;
         }
 
         for (size_t i = 0; i < count; ++i) {
@@ -50,7 +50,7 @@ public:
                 new (&destination[count - i - 1]) T(AK::move(source[count - i - 1]));
         }
 
-        return count;
+        return;
     }
 
     static size_t copy(T* destination, const T* source, size_t count)

--- a/Documentation/UsingQtCreator.md
+++ b/Documentation/UsingQtCreator.md
@@ -24,9 +24,11 @@ First, make sure you have a working toolchain and can build and run SerenityOS. 
 Userland/Services/
 Userland/Libraries/
 Userland/Libraries/LibC/
-Userland/Libraries/LibPthread/
 Userland/Libraries/LibM/
+Userland/Libraries/LibPthread/
 Toolchain/Local/i686/i686-pc-serenity/include/c++/10.2.0
+Build/
+Build/Userland/
 Build/Userland/Services/
 Build/Userland/Libraries/
 AK/

--- a/Documentation/UsingQtCreator.md
+++ b/Documentation/UsingQtCreator.md
@@ -26,6 +26,7 @@ Userland/Libraries/
 Userland/Libraries/LibC/
 Userland/Libraries/LibM/
 Userland/Libraries/LibPthread/
+Userland/Libraries/LibSystem/
 Toolchain/Local/i686/i686-pc-serenity/include/c++/10.2.0
 Build/
 Build/Userland/

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -49,7 +49,7 @@
 #include <Kernel/VM/AllocationStrategy.h>
 #include <Kernel/VM/RangeAllocator.h>
 #include <LibC/signal_numbers.h>
-#include <Libraries/LibELF/exec_elf.h>
+#include <LibELF/exec_elf.h>
 
 namespace Kernel {
 

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -37,7 +37,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <string>
 #include <sys/mman.h>
 
 #include <fcntl.h>

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -32,7 +32,6 @@
 #include <LibJS/Lexer.h>
 #include <LibJS/Parser.h>
 #include <LibJS/Runtime/GlobalObject.h>
-#include <signal.h>
 
 #include <stddef.h>
 #include <stdint.h>

--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -26,8 +26,8 @@
  */
 
 #include "CalculatorWidget.h"
-#include "Applications/Calculator/CalculatorGML.h"
 #include <AK/Assertions.h>
+#include <Applications/Calculator/CalculatorGML.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/TextBox.h>

--- a/Userland/Applications/PixelPaint/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/BrushTool.cpp
@@ -34,7 +34,6 @@
 #include <LibGUI/Slider.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Rect.h>
-#include <utility>
 
 namespace PixelPaint {
 

--- a/Userland/DevTools/HackStudio/FindInFilesWidget.h
+++ b/Userland/DevTools/HackStudio/FindInFilesWidget.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <LibGUI/Button.h>
+#include <LibGUI/TableView.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Widget.h>
 

--- a/Userland/DevTools/HackStudio/LanguageClient.cpp
+++ b/Userland/DevTools/HackStudio/LanguageClient.cpp
@@ -25,9 +25,9 @@
  */
 
 #include "LanguageClient.h"
-#include "DevTools/HackStudio/LanguageServers/LanguageServerEndpoint.h"
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <DevTools/HackStudio/LanguageServers/LanguageServerEndpoint.h>
 
 namespace HackStudio {
 

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/main.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/main.cpp
@@ -24,8 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "ClientConnection.h"
 #include <AK/LexicalPath.h>
-#include <DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibCore/LocalServer.h>

--- a/Userland/DevTools/HackStudio/LanguageServers/Shell/main.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Shell/main.cpp
@@ -24,8 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "ClientConnection.h"
 #include <AK/LexicalPath.h>
-#include <DevTools/HackStudio/LanguageServers/Shell/ClientConnection.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibCore/LocalServer.h>

--- a/Userland/Libraries/LibC/stdio.h
+++ b/Userland/Libraries/LibC/stdio.h
@@ -94,6 +94,7 @@ int vsnprintf(char* buffer, size_t, const char* fmt, va_list) __attribute__((for
 int fprintf(FILE*, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 int printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 int dbgprintf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+int vdbgprintf(const char* fmt, va_list ap);
 void dbgputch(char);
 int dbgputstr(const char*, ssize_t);
 int sprintf(char* buffer, const char* fmt, ...) __attribute__((format(printf, 2, 3)));

--- a/Userland/Libraries/LibCpp/AST.h
+++ b/Userland/Libraries/LibCpp/AST.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include "Applications/Piano/Music.h"
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/Optional.h>
 #include <AK/RefCounted.h>

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -27,7 +27,6 @@
 #include <AK/Vector.h>
 #include <LibGfx/BMPWriter.h>
 #include <LibGfx/Bitmap.h>
-#include <cstring>
 
 namespace Gfx {
 

--- a/Userland/Services/WindowServer/Button.h
+++ b/Userland/Services/WindowServer/Button.h
@@ -28,6 +28,7 @@
 
 #include <AK/Function.h>
 #include <AK/Weakable.h>
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
 

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -35,6 +35,7 @@
 #include <LibGfx/Bitmap.h>
 #include <LibIPC/ClientConnection.h>
 #include <WindowServer/Event.h>
+#include <WindowServer/Menu.h>
 #include <WindowServer/WindowClientEndpoint.h>
 #include <WindowServer/WindowServerEndpoint.h>
 

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -33,6 +33,7 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/DisjointRectSet.h>
 #include <LibGfx/Rect.h>
+#include <WindowServer/Cursor.h>
 #include <WindowServer/WindowFrame.h>
 #include <WindowServer/WindowType.h>
 

--- a/Userland/Utilities/tree.cpp
+++ b/Userland/Utilities/tree.cpp
@@ -32,7 +32,7 @@
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DirIterator.h>
-#include <cstdio>
+#include <stdio.h>
 #include <sys/stat.h>
 
 static bool flag_show_hidden_files = false;


### PR DESCRIPTION
This fixes some "weird" includes, and removes some unnecessary ones.

[You asked!](https://github.com/SerenityOS/serenity/pull/5034#issuecomment-765308894) :^)

I ran out of motivation to push this particular feature any further, which is also the reason why most the edits happen in the alphabetically-first directory. This tool needs excessive amounts of computational power, and double-checking the results makes my brain mushy. If anyone wants to pick this up and find a few more, be my guest. More information on how to continue below the fold.

I split the header removal up to be more easily auditable. In particular I'd like to highlight `#include <string>`, which provides the class `std::string` from the C++ standard library, which is not used in FuzziliJS, so I'm rather confident that this should be fine.

<details>

You're crazy. Welcome!

[Here is the very-WIP tool. Thar be dragons, boy! Currently points to 53b7c0e67887be67cf4c2503b5f301422045d71f, but might update at any time. Or never.](https://github.com/BenWiederhake/serenity/tree/historic/brute-force-includes)

- Make sure to run `Userland/HeaderCheck/generate_all.py` to significantly reduce the amount of false-positives.
- You can write a `Build/whitelist.json` to tell the tool which includes to ignore. You can start from scratch (duplicating some of my work), or use the one below.
- You also probably want to extend the map `ASSOCIATED_CLASSES_REGEXES` so that the LibC headers have fewer false-positives.
- Run `../Meta/try-remove-headers.py --modify-files-and-run-ninja` in `Build/`, and look at the output. It tells you what to fix or how to add it to the whitelist.

My own `Build/whitelist.json`, you must change the paths to be absolute, some items may be superfluous by now:

```
[
    ["PATH_TO_YOUR/serenity/AK/Atomic.h", "#include <AK/Platform.h>"],
    ["PATH_TO_YOUR/serenity/AK/ByteBuffer.h", "#include <AK/kmalloc.h>"],
    ["PATH_TO_YOUR/serenity/AK/ByteBuffer.h", "#include <AK/NonnullRefPtr.h>"],
    ["PATH_TO_YOUR/serenity/AK/ByteBuffer.h", "#include <AK/RefCounted.h>"],
    ["PATH_TO_YOUR/serenity/AK/ByteBuffer.h", "#include <AK/Span.h>"],
    ["PATH_TO_YOUR/serenity/AK/ByteBuffer.h", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/AK/CircularQueue.h", "#include <AK/StdLibExtras.h>"],
    ["PATH_TO_YOUR/serenity/AK/Demangle.h", "#include <AK/StringView.h>"],
    ["PATH_TO_YOUR/serenity/AK/DoublyLinkedList.h", "#include <AK/StdLibExtras.h>"],
    ["PATH_TO_YOUR/serenity/AK/Endian.h", "#include <AK/Platform.h>"],
    ["PATH_TO_YOUR/serenity/AK/Endian.h", "#    include <libkern/OSByteOrder.h>"],
    ["PATH_TO_YOUR/serenity/AK/Endian.h", "#    include <machine/endian.h>"],
    ["PATH_TO_YOUR/serenity/AK/FileStream.h", "#    include <errno.h>"],
    ["PATH_TO_YOUR/serenity/AK/FileStream.h", "#    include <stdio.h>"],
    ["PATH_TO_YOUR/serenity/AK/Format.cpp", "#include <AK/GenericLexer.h>"],
    ["PATH_TO_YOUR/serenity/AK/Format.cpp", "#include <AK/StringBuilder.h>"],
    ["PATH_TO_YOUR/serenity/AK/Format.cpp", "#    include <Kernel/Thread.h>"],
    ["PATH_TO_YOUR/serenity/AK/Format.cpp", "#    include <stdio.h>"],
    ["PATH_TO_YOUR/serenity/AK/HashMap.h", "#    include <initializer_list>"],
    ["PATH_TO_YOUR/serenity/AK/HashMap.h//", "ist wahrscheinlich ein false-positive"],
    ["PATH_TO_YOUR/serenity/AK/Hex.h", "#include <AK/ByteBuffer.h>"],
    ["PATH_TO_YOUR/serenity/AK/Hex.h", "#include <AK/Optional.h>"],
    ["PATH_TO_YOUR/serenity/AK/Hex.h", "#include <AK/StringView.h>"],
    ["PATH_TO_YOUR/serenity/AK/JsonObject.h", "#include <AK/JsonValue.h>"],
    ["PATH_TO_YOUR/serenity/AK/JsonPath.h", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/AK/LexicalPath.cpp", "#include <AK/StringBuilder.h>"],
    ["PATH_TO_YOUR/serenity/AK/LexicalPath.cpp", "#include <AK/StringView.h>"],
    ["PATH_TO_YOUR/serenity/AK/LexicalPath.cpp", "#include <AK/Vector.h>"],
    ["PATH_TO_YOUR/serenity/AK/MappedFile.cpp", "#include <unistd.h>"],
    ["PATH_TO_YOUR/serenity/AK/Memory.h", "#    include <stdlib.h>"],
    ["PATH_TO_YOUR/serenity/AK/NonnullRefPtrVector.h", "#include <AK/NonnullRefPtr.h>"],
    ["PATH_TO_YOUR/serenity/AK/PrintfImplementation.h", "#include <AK/StdLibExtras.h>"],
    ["PATH_TO_YOUR/serenity/AK/PrintfImplementation.h", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/AK/PrintfImplementation.h", "#include <stdarg.h>"],
    ["PATH_TO_YOUR/serenity/AK/Random.h", "#include <AK/Platform.h>"],
    ["PATH_TO_YOUR/serenity/AK/Random.h", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/AK/Singleton.h", "#    include <new>"],
    ["PATH_TO_YOUR/serenity/AK/Stream.h", "#include <AK/Forward.h>"],
    ["PATH_TO_YOUR/serenity/AK/Stream.h", "#include <AK/Optional.h>"],
    ["PATH_TO_YOUR/serenity/AK/Span.h", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/AK/Function.h", "#include <AK/Assertions.h>"],
    ["PATH_TO_YOUR/serenity/AK/Function.h", "#include <AK/StdLibExtras.h>"],
    ["PATH_TO_YOUR/serenity/AK/LogStream.h", "#include <AK/Forward.h>"],
    ["PATH_TO_YOUR/serenity/Kernel/Arch/i386/CPU.cpp", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/Kernel/Arch/i386/ProcessorInfo.cpp", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/Kernel/Devices/KeyboardDevice.cpp", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/Kernel/Heap/kmalloc.cpp", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/Kernel/Interrupts/APIC.cpp", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/Kernel/Interrupts/PIC.cpp", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/Kernel/init.cpp", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/Kernel/kprintf.cpp", "#include <AK/Types.h>"],
    ["PATH_TO_YOUR/serenity/AK/HashTable.h", "#include <AK/HashFunctions.h>"],
    ["PATH_TO_YOUR/serenity/AK/HashTable.h", "#include <AK/StdLibExtras.h>"],
    ["PATH_TO_YOUR/serenity/AK/MappedFile.h", "#include <AK/Noncopyable.h>"],
    ["PATH_TO_YOUR/serenity/AK/MemMem.h", "#include <AK/Assertions.h>"],
    ["PATH_TO_YOUR/serenity/AK/String.h", "#include <AK/Forward.h>"],
    ["PATH_TO_YOUR/serenity/Userland/Libraries/LibC/serenity.cpp", "#include <errno.h>"],
    ["PATH_TO_YOUR/serenity/Meta/Lagom/Fuzzers/FuzzilliJs.cpp", "#include <stddef.h>"],
    ["PATH_TO_YOUR/serenity/AK/Stream.h", "#include <AK/StdLibExtras.h>"]
]
```

Example output:

```
Building without /home/user/workspace/serenity/Userland/Tests/LibC/stack-smash.cpp:27: /* #include <cstdio> // weird */ ... failed
Building without /home/user/workspace/serenity/AK/Tests/TestString.cpp:32: /* #include <cstring> // weird */ ... failed
Building without /home/user/workspace/serenity/AK/Vector.h:44: /* #    include <initializer_list> // weird */ ... failed
Building without /home/user/workspace/serenity/AK/Vector.h:48: /* #    include <new> // weird */ ... succeeded
AK/Vector.h:48: #    include <new> ****** Unnecessary include found! ****** // weird ["/home/user/workspace/serenity/AK/Vector.h", "#    include <new>"],
```

</details>