### PR TITLE
Kernel: Change KResultOr::take_value to use move semantics

### DIFF
--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -163,7 +163,7 @@ public:
     {
         ASSERT(!m_is_error);
         ASSERT(m_have_storage);
-        T released_value = *reinterpret_cast<T*>(&m_storage);
+        T released_value(move(*reinterpret_cast<T*>(&m_storage)));
         value().~T();
         m_have_storage = false;
         return released_value;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -811,7 +811,7 @@ RefPtr<Thread> Process::create_kernel_thread(void (*entry)(void*), void* entry_d
     if (thread_or_error.is_error())
         return {};
 
-    auto& thread = thread_or_error.value();
+    auto thread = thread_or_error.release_value();
     thread->set_name(name);
     thread->set_affinity(affinity);
     thread->set_priority(priority);


### PR DESCRIPTION
This may be more light weight than copying the object.