### PR TITLE
Kernel: Fix KResultOr copy-move from itself case

### DIFF
--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -111,6 +111,8 @@ public:
 
     KResultOr& operator=(KResultOr&& other)
     {
+        if (&other == this)
+            return *this;
         if (!m_is_error && m_have_storage) {
             value().~T();
             m_have_storage = false;


### PR DESCRIPTION
If move-assigning from itself we shouldn't do anything.