### PR TITLE
Kernel: KResultOr can use the same storage as the object for the error

### DIFF
--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -172,8 +172,10 @@ public:
     }
 
 private:
-    alignas(T) char m_storage[sizeof(T)];
-    KResult m_error;
+    union {
+        alignas(T) char m_storage[sizeof(T)];
+        KResult m_error;
+    };
     bool m_is_error { false };
     bool m_have_storage { false };
 };


### PR DESCRIPTION
Since it can only hold either an object or an error code, we can share
the same storage to hold either.