### PR TITLE
LibWeb: Implement Element.getElementsBy{Tag,Class}Name()

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -505,7 +505,7 @@ NonnullRefPtrVector<Element> Document::get_elements_by_class_name(const FlyStrin
 {
     NonnullRefPtrVector<Element> elements;
     for_each_in_subtree_of_type<Element>([&](auto& element) {
-        if (element.has_class(class_name))
+        if (element.has_class(class_name, in_quirks_mode() ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive))
             elements.append(element);
         return IterationDecision::Continue;
     });

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -487,10 +487,15 @@ NonnullRefPtrVector<Element> Document::get_elements_by_name(const String& name) 
 
 NonnullRefPtrVector<Element> Document::get_elements_by_tag_name(const FlyString& tag_name) const
 {
+    // FIXME: Support "*" for tag_name
+    // https://dom.spec.whatwg.org/#concept-getelementsbytagname
     NonnullRefPtrVector<Element> elements;
     for_each_in_subtree_of_type<Element>([&](auto& element) {
-        if (element.local_name() == tag_name)
+        if (element.namespace_() == Namespace::HTML
+                ? element.local_name().to_lowercase() == tag_name.to_lowercase()
+                : element.local_name() == tag_name) {
             elements.append(element);
+        }
         return IterationDecision::Continue;
     });
     return elements;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -46,6 +46,7 @@
 #include <LibWeb/Layout/TableRowGroupBox.h>
 #include <LibWeb/Layout/TreeBuilder.h>
 #include <LibWeb/Layout/WidgetBox.h>
+#include <LibWeb/Namespace.h>
 
 namespace Web::DOM {
 
@@ -342,6 +343,33 @@ String Element::inner_html() const
 bool Element::is_focused() const
 {
     return document().focused_element() == this;
+}
+
+NonnullRefPtrVector<Element> Element::get_elements_by_tag_name(const FlyString& tag_name) const
+{
+    // FIXME: Support "*" for tag_name
+    // https://dom.spec.whatwg.org/#concept-getelementsbytagname
+    NonnullRefPtrVector<Element> elements;
+    for_each_in_subtree_of_type<Element>([&](auto& element) {
+        if (element.namespace_() == Namespace::HTML
+                ? element.local_name().to_lowercase() == tag_name.to_lowercase()
+                : element.local_name() == tag_name) {
+            elements.append(element);
+        }
+        return IterationDecision::Continue;
+    });
+    return elements;
+}
+
+NonnullRefPtrVector<Element> Element::get_elements_by_class_name(const FlyString& class_name) const
+{
+    NonnullRefPtrVector<Element> elements;
+    for_each_in_subtree_of_type<Element>([&](auto& element) {
+        if (element.has_class(class_name, m_document->in_quirks_mode() ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive))
+            elements.append(element);
+        return IterationDecision::Continue;
+    });
+    return elements;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -103,9 +103,13 @@ void Element::remove_attribute(const FlyString& name)
     m_attributes.remove_first_matching([&](auto& attribute) { return attribute.name() == name; });
 }
 
-bool Element::has_class(const FlyString& class_name) const
+bool Element::has_class(const FlyString& class_name, CaseSensitivity case_sensitivity) const
 {
-    return any_of(m_classes.begin(), m_classes.end(), [&](auto& it) { return it == class_name; });
+    return any_of(m_classes.begin(), m_classes.end(), [&](auto& it) {
+        return case_sensitivity == CaseSensitivity::CaseSensitive
+            ? it == class_name
+            : it.to_lowercase() == class_name.to_lowercase();
+    });
 }
 
 RefPtr<Layout::Node> Element::create_layout_node()

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -73,7 +73,7 @@ public:
             callback(attribute.name(), attribute.value());
     }
 
-    bool has_class(const FlyString&) const;
+    bool has_class(const FlyString&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
     const Vector<FlyString>& class_names() const { return m_classes; }
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const { }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -98,6 +98,9 @@ public:
     bool is_focused() const;
     virtual bool is_focusable() const { return false; }
 
+    NonnullRefPtrVector<Element> get_elements_by_tag_name(const FlyString&) const;
+    NonnullRefPtrVector<Element> get_elements_by_class_name(const FlyString&) const;
+
 protected:
     RefPtr<Layout::Node> create_layout_node() override;
 

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -8,6 +8,9 @@ interface Element : Node {
     boolean hasAttribute(DOMString qualifiedName);
     boolean hasAttributes();
 
+    ArrayFromVector getElementsByTagName(DOMString tagName);
+    ArrayFromVector getElementsByClassName(DOMString className);
+
     readonly attribute Element? firstElementChild;
     readonly attribute Element? lastElementChild;
 


### PR DESCRIPTION
Just like the `Document` variants, but using the given `Element` as `for_each_in_subtree_of_type()` root.