### PR TITLE
WindowServer: Window frame transparency and render caching

### DIFF
--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -288,11 +288,10 @@ void Compositor::compose()
         auto compose_window_rect = [&](Gfx::Painter& painter, const Gfx::IntRect& rect) {
             if (!window.is_fullscreen()) {
                 rect.for_each_intersected(frame_rects, [&](const Gfx::IntRect& intersected_rect) {
-                    // TODO: Should optimize this to use a backing buffer
                     Gfx::PainterStateSaver saver(painter);
                     painter.add_clip_rect(intersected_rect);
                     dbgln_if(COMPOSE_DEBUG, "    render frame: {}", intersected_rect);
-                    window.frame().paint(painter);
+                    window.frame().paint(painter, intersected_rect);
                     return IterationDecision::Continue;
                 });
             }

--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -45,7 +45,9 @@ public:
     ~WindowFrame();
 
     Gfx::IntRect rect() const;
-    void paint(Gfx::Painter&);
+    void paint(Gfx::Painter&, const Gfx::IntRect&);
+    void render(Gfx::Painter&);
+    void render_to_cache();
     void on_mouse_event(const MouseEvent&);
     void notify_window_rect_changed(const Gfx::IntRect& old_rect, const Gfx::IntRect& new_rect);
     void invalidate_title_bar();
@@ -62,15 +64,24 @@ public:
 
     void start_flash_animation();
 
+    bool has_alpha_channel() const { return m_has_alpha_channel; }
+    void set_has_alpha_channel(bool value) { m_has_alpha_channel = value; }
+
+    void set_opacity(float);
     float opacity() const { return m_opacity; }
 
     bool is_opaque() const
     {
         if (opacity() < 1.0f)
             return false;
-        //if (has_alpha_channel())
-        //    return false;
+        if (has_alpha_channel())
+            return false;
         return true;
+    }
+
+    void scale_changed()
+    {
+        m_dirty = true;
     }
 
 private:
@@ -85,9 +96,16 @@ private:
     Button* m_maximize_button { nullptr };
     Button* m_minimize_button { nullptr };
 
+    RefPtr<Gfx::Bitmap> m_top_bottom;
+    RefPtr<Gfx::Bitmap> m_left_right;
+    int m_bottom_y { 0 }; // y-offset in m_top_bottom for the bottom half
+    int m_right_x { 0 };  // x-offset in m_left_right for the right half
+
     RefPtr<Core::Timer> m_flash_timer;
     size_t m_flash_counter { 0 };
     float m_opacity { 1 };
+    bool m_has_alpha_channel { false };
+    bool m_dirty { false };
 };
 
 }

--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -62,6 +62,17 @@ public:
 
     void start_flash_animation();
 
+    float opacity() const { return m_opacity; }
+
+    bool is_opaque() const
+    {
+        if (opacity() < 1.0f)
+            return false;
+        //if (has_alpha_channel())
+        //    return false;
+        return true;
+    }
+
 private:
     void paint_notification_frame(Gfx::Painter&);
     void paint_normal_frame(Gfx::Painter&);
@@ -76,6 +87,7 @@ private:
 
     RefPtr<Core::Timer> m_flash_timer;
     size_t m_flash_counter { 0 };
+    float m_opacity { 1 };
 };
 
 }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1515,7 +1515,9 @@ void WindowManager::reload_icon_bitmaps_after_scale_change(bool allow_hidpi_icon
     m_allow_hidpi_icons = allow_hidpi_icons;
     reload_config();
     for_each_window([&](Window& window) {
-        window.frame().set_button_icons();
+        auto& window_frame = window.frame();
+        window_frame.set_button_icons();
+        window_frame.scale_changed();
         return IterationDecision::Continue;
     });
 }


### PR DESCRIPTION
This only renders the window frame once until the size of the window
changes, or some other event requires re-rendering. It is rendered
to a temporary bitmap, and then the top and bottom part is stored
in one bitmap as well as the left and right part. This also adds
an opacity setting, allowing it to be rendered with a different
opacity.

This makes it easier to enhance window themes and allows using
arbitrary bitmaps with e.g. alpha channels for e.g. shadows.

_This should make implementing a shadow effect as attempted in #5107 a lot easier. It does not address hit-testing based on the alpha channel in the rendered window frame._

This is an example of 0.75 opacity for window frames:
![Screenshot from 2021-02-07 22-25-34](https://user-images.githubusercontent.com/10320822/107180426-ea7c7280-6995-11eb-9442-f9b4f649d399.png)
