### PR TITLE
Fix HackStudio/LibCpp crash

### DIFF
--- a/Userland/Libraries/LibCpp/CMakeLists.txt
+++ b/Userland/Libraries/LibCpp/CMakeLists.txt
@@ -6,4 +6,4 @@ set(SOURCES
 )
 
 serenity_lib(LibCpp cpp)
-target_link_libraries(LibCpp LibC)
+target_link_libraries(LibCpp LibC LibSyntax)


### PR DESCRIPTION
The C++ language server was crashing at load time because of an unresolved symbol that belonged to LibSyntax (Which also made hackstudio crash when a .cpp file is opened).

Also, I noticed that (for some reason) using dbgln() in the dynamic loader crashes it now. This needs to be investigated,
but for now I moved the dbgln() error reporting that's enabled by default to use dbgprintf().