### PR TITLE
Kernel: Remove double fetch pattern in syscall_handler

### DIFF
--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -154,11 +154,13 @@ void syscall_handler(TrapFrame* trap)
     // to make kernel stacks a bit less deterministic.
     // Since this is very hot code, request random data in chunks instead of
     // one byte at a time. This is a noticeable speedup.
-    if (g_random_byte_buffer_offset == RandomByteBufferSize) {
+    int offset = g_random_byte_buffer_offset;
+    if (offset == RandomByteBufferSize) {
         get_fast_random_bytes(g_random_byte_buffer, RandomByteBufferSize);
-        g_random_byte_buffer_offset = 0;
+        offset = 0;
     }
-    auto* ptr = (char*)__builtin_alloca(g_random_byte_buffer[g_random_byte_buffer_offset++]);
+    auto* ptr = (char*)__builtin_alloca(g_random_byte_buffer[offset++]);
+    g_random_byte_buffer_offset = offset;
     asm volatile(""
                  : "=m"(*ptr));
 

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -131,7 +131,7 @@ int handle(RegisterState& regs, u32 function, u32 arg1, u32 arg2, u32 arg3)
 
 constexpr int RandomByteBufferSize = 256;
 u8 g_random_byte_buffer[RandomByteBufferSize];
-int g_random_byte_buffer_offset = RandomByteBufferSize;
+volatile int g_random_byte_buffer_offset = RandomByteBufferSize;
 
 void syscall_handler(TrapFrame* trap)
 {


### PR DESCRIPTION
This patch removes racy double fetch pattern with g_random_byte_buffer_offset
which can potentially lead to out-of-bound access to g_random_byte_buffer.
Instead, I fetch g_random_byte_buffer_offset to a temporary variable then
perform check, use it and store it back later.

The strictly correct way is using some locking mechanisms but it adds overheads
to this hot code.

Fixes #5257