### PR TITLE
Remove all text relocations and remove PaX holes that existed for it.

### DIFF
--- a/Userland/Libraries/LibELF/Arch/i386/plt_trampoline.S
+++ b/Userland/Libraries/LibELF/Arch/i386/plt_trampoline.S
@@ -45,7 +45,7 @@ _plt_trampoline:	# (obj, reloff)
 
 	pushl	20(%esp)		 # Copy of reloff
 	pushl	20(%esp)		 # Copy of obj
-	call	_fixup_plt_entry # Call the binder
+	call	_fixup_plt_entry@PLT # Call the binder
 	addl	$8,%esp			 # pop binder args
 	movl	%eax,20(%esp)	 # Store function to be called in obj
 


### PR DESCRIPTION
Also reduces memory use after boot from 178 MiB to 173 MiB, due to libc having no dirty pages.

The patch is obviously correct.

---

Actually, I have no idea why this works. I thought plt_trampoline.S is what makes @PLT relocations work, so not sure why things don't blow up here.

@ADKaster @itamar8910 