### PR TITLE
WindowServer: Recompute occlusions and re-render shadows on theme change

### DIFF
--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -85,6 +85,13 @@ public:
         m_dirty = true;
     }
 
+    void theme_changed()
+    {
+        m_dirty = m_shadow_dirty = true;
+        layout_buttons();
+        set_button_icons();
+    }
+
 private:
     void paint_simple_rect_shadow(Gfx::Painter&, const Gfx::IntRect&, const Gfx::Bitmap&) const;
     void paint_notification_frame(Gfx::Painter&);

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1432,14 +1432,14 @@ bool WindowManager::update_theme(String theme_path, String theme_name)
                 notified_clients.set(window.client());
             }
         }
-        window.frame().layout_buttons();
-        window.frame().set_button_icons();
+        window.frame().theme_changed();
         return IterationDecision::Continue;
     });
     MenuManager::the().did_change_theme();
     auto wm_config = Core::ConfigFile::open("/etc/WindowServer/WindowServer.ini");
     wm_config->write_entry("Theme", "Name", theme_name);
     wm_config->sync();
+    Compositor::the().invalidate_occlusions();
     Compositor::the().invalidate_screen();
     return true;
 }


### PR DESCRIPTION
Since theme changes may change geometrics, which are also affected by
window shadows, we need to recompute occlusions as well as re-render
window frames.