### PR TITLE
AK: (Hopefully) Fix build with Clang>=12

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -38,7 +38,7 @@
 #endif
 
 #ifndef DBGLN_NO_COMPILETIME_FORMAT_CHECK
-// Note: Clang 12 adds support for CTAD, this would fail with any version prior to that.
+// Note: Clang 12 adds support for CTAD on NTTPs, this would fail with any version prior to that.
 #    if defined(__clang__) && __clang_major__ < 12
 #        define DBGLN_NO_COMPILETIME_FORMAT_CHECK
 #    endif
@@ -47,15 +47,15 @@
 #ifndef DBGLN_NO_COMPILETIME_FORMAT_CHECK
 namespace {
 
-template<size_t N>
-consteval auto extract_used_argument_index(const char (&fmt)[N], size_t specifier_start_index, size_t specifier_end_index, size_t& next_implicit_argument_index)
+template<size_t N, StringLiteral<N> fmt>
+consteval auto extract_used_argument_index(size_t specifier_start_index, size_t specifier_end_index, size_t& next_implicit_argument_index)
 {
     struct {
         size_t index_value { 0 };
         bool saw_explicit_index { false };
     } state;
     for (size_t i = specifier_start_index; i < specifier_end_index; ++i) {
-        auto c = fmt[i];
+        auto c = fmt.data[i];
         if (c > '9' || c < '0')
             break;
 
@@ -71,8 +71,8 @@ consteval auto extract_used_argument_index(const char (&fmt)[N], size_t specifie
 }
 
 // FIXME: We should rather parse these format strings at compile-time if possible.
-template<size_t N>
-consteval auto count_fmt_params(const char (&fmt)[N])
+template<size_t N, StringLiteral<N> fmt>
+consteval auto count_fmt_params()
 {
     struct {
         // FIXME: Switch to variable-sized storage whenever we can come up with one :)
@@ -91,10 +91,10 @@ consteval auto count_fmt_params(const char (&fmt)[N])
     } result;
 
     for (size_t i = 0; i < N; ++i) {
-        auto ch = fmt[i];
+        auto ch = fmt.data[i];
         switch (ch) {
         case '{':
-            if (i + 1 < N && fmt[i + 1] == '{') {
+            if (i + 1 < N && fmt.data[i + 1] == '{') {
                 ++i;
                 continue;
             }
@@ -108,7 +108,7 @@ consteval auto count_fmt_params(const char (&fmt)[N])
             ++result.unclosed_braces;
             break;
         case '}':
-            if (i + 1 < N && fmt[i + 1] == '}') {
+            if (i + 1 < N && fmt.data[i + 1] == '}') {
                 ++i;
                 continue;
             }
@@ -123,7 +123,7 @@ consteval auto count_fmt_params(const char (&fmt)[N])
                 if (result.total_used_argument_count >= result.used_arguments.size())
                     result.internal_error = "Format-String Checker internal error: Too many format arguments in format string";
 
-                auto used_argument_index = extract_used_argument_index<N>(fmt, specifier_start_index, i, result.next_implicit_argument_index);
+                auto used_argument_index = extract_used_argument_index<N, fmt>(specifier_start_index, i, result.next_implicit_argument_index);
                 if (used_argument_index + 1 != result.next_implicit_argument_index)
                     result.has_explicit_argument_references = true;
                 result.used_arguments[result.total_used_argument_count++] = used_argument_index;
@@ -140,7 +140,7 @@ consteval auto count_fmt_params(const char (&fmt)[N])
 }
 }
 
-template<size_t N, StringLiteral<N> fmt, size_t param_count, auto check = count_fmt_params<N>(fmt.data)>
+template<size_t N, StringLiteral<N> fmt, size_t param_count, auto check = count_fmt_params<N, fmt>()>
 constexpr bool check_format_parameter_consistency()
 {
     static_assert(check.internal_error.data[0] == 0, "Some internal error occured, try looking at the check function type for the error");


### PR DESCRIPTION
Build failure as in https://oss-fuzz-build-logs.storage.googleapis.com/log-79750138-f41e-4f39-8812-7c536f1d2e35.txt
Clang does not appear to like using consteval functions' arguments as
constant expressions, so move all the arguments that need to appear as
constant expressions into the template parameters for now.

This patch should fix the OSS-Fuzz build.

---

cc @nico 

<details>
<summary>Relevant build error</summary>

```
Step #4: In file included from /src/serenity/Userland/Libraries/LibELF/Image.cpp:28:
Step #4: In file included from ../../../AK/Demangle.h:29:
Step #4: In file included from ../../../AK/String.h:29:
Step #4: ../../../AK/Format.h:126:44: error: call to consteval function '(anonymous namespace)::extract_used_argument_index<42>' is not a constant expression
Step #4:                 auto used_argument_index = extract_used_argument_index<N>(fmt, specifier_start_index, i, result.next_implicit_argument_index);
Step #4:                                            ^
Step #4: ../../../AK/Format.h:143:75: note: in instantiation of function template specialization '(anonymous namespace)::count_fmt_params<42>' requested here
Step #4: template<size_t N, StringLiteral<N> fmt, size_t param_count, auto check = count_fmt_params<N>(fmt.data)>
Step #4:                                                                           ^
Step #4: ../../../AK/Format.h:144:16: note: in instantiation of default argument for 'check_format_parameter_consistency<42, {{69, 76, 70, 58, 58, 73, 109, 97, 103, 101, ...}, 42}, 0>' required here
Step #4: constexpr bool check_format_parameter_consistency()
Step #4:                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Step #4: ../../../AK/Format.h:191:38: note: while substituting deduced template arguments into function template 'check_format_parameter_consistency' [with N = 42, fmt = {{69, 76, 70, 58, 58, 73, 109, 97, 103, 101, ...}, 42}, param_count = 0, check = (no value)]
Step #4: concept ConsistentFormatParameters = check_format_parameter_consistency<fmt.size, fmt, param_count>();
Step #4:                                      ^
Step #4: ../../../AK/Format.h:191:38: note: while substituting template arguments into constraint expression here
Step #4: concept ConsistentFormatParameters = check_format_parameter_consistency<fmt.size, fmt, param_count>();
Step #4:                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Step #4: ../../../AK/Format.h:553:54: note: while checking the satisfaction of concept 'ConsistentFormatParameters<{{69, 76, 70, 58, 58, 73, 109, 97, 103, 101, ...}, 42}, 0>' requested here
Step #4: void dbgln(const Parameters&... parameters) requires ConsistentFormatParameters<fmt, sizeof...(Parameters)>
Step #4:                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Step #4: /src/serenity/Userland/Libraries/LibELF/Image.cpp:163:13: note: while substituting deduced template arguments into function template 'dbgln' [with fmt = {{69, 76, 70, 58, 58, 73, 109, 97, 103, 101, ...}, 42}, enabled = (no value), Parameters = <>]
Step #4:             dbgln("ELF::Image::parse(): ELF Header not valid");
Step #4:             ^
Step #4: ../../../AK/Format.h:656:29: note: expanded from macro 'dbgln'
Step #4: #    define dbgln(fmt, ...) dbgln<fmt>(__VA_ARGS__)
Step #4:                             ^
Step #4: ../../../AK/Format.h:126:75: note: function parameter 'fmt' with unknown value cannot be used in a constant expression
Step #4:                 auto used_argument_index = extract_used_argument_index<N>(fmt, specifier_start_index, i, result.next_implicit_argument_index);
Step #4:                                                                           ^
Step #4: ../../../AK/Format.h:75:46: note: declared here
Step #4: consteval auto count_fmt_params(const char (&fmt)[N])
Step #4:                                              ^
Step #4: ../../../AK/Format.h:126:44: error: call to consteval function '(anonymous namespace)::extract_used_argument_index<51>' is not a constant expression
Step #4:                 auto used_argument_index = extract_used_argument_index<N>(fmt, specifier_start_index, i, result.next_implicit_argument_index);
Step #4:                                            ^
Step #4: ../../../AK/Format.h:143:75: note: in instantiation of function template specialization '(anonymous namespace)::count_fmt_params<51>' requested here
Step #4: template<size_t N, StringLiteral<N> fmt, size_t param_count, auto check = count_fmt_params<N>(fmt.data)>
Step #4:                                                                           ^
Step #4: ../../../AK/Format.h:144:16: note: in instantiation of default argument for 'check_format_parameter_consistency<51, {{69, 76, 70, 58, 58, 73, 109, 97, 103, 101, ...}, 51}, 0>' required here
Step #4: constexpr bool check_format_parameter_consistency()
Step #4:                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Step #4: ../../../AK/Format.h:191:38: note: while substituting deduced template arguments into function template 'check_format_parameter_consistency' [with N = 51, fmt = {{69, 76, 70, 58, 58, 73, 109, 97, 103, 101, ...}, 51}, param_count = 0, check = (no value)]
Step #4: concept ConsistentFormatParameters = check_format_parameter_consistency<fmt.size, fmt, param_count>();
Step #4:                                      ^
Step #4: ../../../AK/Format.h:191:38: note: while substituting template arguments into constraint expression here
Step #4: concept ConsistentFormatParameters = check_format_parameter_consistency<fmt.size, fmt, param_count>();
Step #4:                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Step #4: ../../../AK/Format.h:553:54: note: while checking the satisfaction of concept 'ConsistentFormatParameters<{{69, 76, 70, 58, 58, 73, 109, 97, 103, 101, ...}, 51}, 0>' requested here
Step #4: void dbgln(const Parameters&... parameters) requires ConsistentFormatParameters<fmt, sizeof...(Parameters)>
Step #4:                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Step #4: /src/serenity/Userland/Libraries/LibELF/Image.cpp:169:13: note: while substituting deduced template arguments into function template 'dbgln' [with fmt = {{69, 76, 70, 58, 58, 73, 109, 97, 103, 101, ...}, 51}, enabled = (no value), Parameters = <>]
Step #4:             dbgln("ELF::Image::parse(): ELF Program Headers not valid");
Step #4:             ^
Step #4: ../../../AK/Format.h:656:29: note: expanded from macro 'dbgln'
Step #4: #    define dbgln(fmt, ...) dbgln<fmt>(__VA_ARGS__)
Step #4:                             ^
Step #4: ../../../AK/Format.h:126:75: note: function parameter 'fmt' with unknown value cannot be used in a constant expression
Step #4:                 auto used_argument_index = extract_used_argument_index<N>(fmt, specifier_start_index, i, result.next_implicit_argument_index);
Step #4:                                                                           ^
Step #4: ../../../AK/Format.h:75:46: note: declared here
Step #4: consteval auto count_fmt_params(const char (&fmt)[N])
```

</details>