### PR TITLE
Userland: Use INET_ADDRSTRLEN for inet_ntop() buffers

### DIFF
--- a/Userland/Utilities/host.cpp
+++ b/Userland/Utilities/host.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    char buffer[32];
+    char buffer[INET_ADDRSTRLEN];
     const char* ip_str = inet_ntop(AF_INET, hostent->h_addr_list[0], buffer, sizeof(buffer));
 
     printf("%s is %s\n", name_or_ip, ip_str);

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
             return 1;
         }
 
-        char addr_str[100];
+        char addr_str[INET_ADDRSTRLEN];
 
         struct sockaddr_in sin;
         socklen_t len;
@@ -131,7 +131,7 @@ int main(int argc, char** argv)
             return 1;
         }
 
-        char addr_str[100];
+        char addr_str[INET_ADDRSTRLEN];
 
         struct sockaddr_in dst_addr;
         memset(&dst_addr, 0, sizeof(dst_addr));

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -221,7 +221,7 @@ int main(int argc, char** argv)
             else if (ms > max_ms)
                 max_ms = ms;
 
-            char addr_buf[64];
+            char addr_buf[INET_ADDRSTRLEN];
             printf("Pong from %s: id=%u, seq=%u%s, time=%dms\n",
                 inet_ntop(AF_INET, &peer_address.sin_addr, addr_buf, sizeof(addr_buf)),
                 ntohs(pong_packet.header.un.echo.id),


### PR DESCRIPTION
There's no point in using different, seemingly randomly sized buffers as the required size for storing an IPv4 address representation is well known (16 bytes).