### PR TITLE
Kernel: Merge split function and data sections into one during linking

### DIFF
--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -82,6 +82,11 @@ extern ctor_func_t end_ctors;
 extern u32 __stack_chk_guard;
 u32 __stack_chk_guard;
 
+extern "C" u8* start_of_safemem_text;
+extern "C" u8* end_of_safemem_text;
+extern "C" u8* start_of_safemem_atomic_text;
+extern "C" u8* end_of_safemem_atomic_text;
+
 multiboot_module_entry_t multiboot_copy_boot_modules_array[16];
 size_t multiboot_copy_boot_modules_count;
 
@@ -131,6 +136,10 @@ extern "C" [[noreturn]] void init()
 
     CommandLine::initialize();
     MemoryManager::initialize(0);
+
+    // Ensure that the safemem sections are not empty. This could happen if the linker accidentally discards the sections.
+    ASSERT(&start_of_safemem_text != &end_of_safemem_text);
+    ASSERT(&start_of_safemem_atomic_text != &end_of_safemem_atomic_text);
 
     // Invoke all static global constructors in the kernel.
     // Note that we want to do this as early as possible.

--- a/Kernel/linker.ld
+++ b/Kernel/linker.ld
@@ -11,16 +11,15 @@ SECTIONS
         $<TARGET_OBJECTS:boot>
         *(.multiboot)
         start_of_kernel_text = .;
-        *(.text)
-        *(.text.startup)
 
         start_of_safemem_text = .;
-        *(.text.safemem)
+        KEEP(*(.text.safemem))
         end_of_safemem_text = .;
         start_of_safemem_atomic_text = .;
-        *(.text.safemem.atomic)
+        KEEP(*(.text.safemem.atomic))
         end_of_safemem_atomic_text = .;
 
+        *(.text*)
         end_of_kernel_text = .;
     }
 
@@ -34,13 +33,13 @@ SECTIONS
         *(.ctors)
         end_ctors = .;
 
-        *(.rodata)
+        *(.rodata*)
     }
 
     .data ALIGN(4K) : AT (ADDR(.data) - 0xc0000000)
     {
         start_of_kernel_data = .;
-        *(.data)
+        *(.data*)
         end_of_kernel_data = .;
     }
 


### PR DESCRIPTION
This makes the linker merge all `.text.*`, `.rodata.*` and `.data.*` sections into single `.text`, `.rodata` and `.data` sections to reduce the number of sections in the final binary. This reduces kernel binary size by ~0.5MiB, which is about a 20% reduction in a stripped build.