### PR TITLE
WindowServer: Fix compositing of fullscreen window

### DIFF
--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -408,6 +408,7 @@ void Compositor::compose()
     if (m_invalidated_window) {
         if (auto* fullscreen_window = wm.active_fullscreen_window()) {
             compose_window(*fullscreen_window);
+            fullscreen_window->clear_dirty_rects();
         } else {
             wm.for_each_visible_window_from_back_to_front([&](Window& window) {
                 compose_window(window);


### PR DESCRIPTION
I honestly don't know the internals of all this and what exactly is going on, but this fixes compositing of the fullscreen window. By trial and error I found that specifically `m_invalidated_all` needs to be set to `false`, so it's probably different behaviour in `prepare_dirty_rects()`, which depends on that...
Either way, the code composing all windows in non-fullscreen mode calls `Window::clear_dirty_rects()` for each, so not doing that for the fullscreen window as well seems like an oversight.

Fixes #4810.