### PR TITLE
WindowServer: Fix clearing area not covered by backing bitmap

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -590,9 +590,13 @@ void Painter::blit_filtered(const IntPoint& position, const Gfx::Bitmap& source,
         for (int row = first_row; row <= last_row; ++row) {
             for (int x = 0; x <= (last_column - first_column); ++x) {
                 u8 alpha = Color::from_rgba(src[x]).alpha();
-                if (alpha == 0xff)
-                    dst[x] = filter(Color::from_rgba(src[x])).value();
-                else if (!alpha)
+                if (alpha == 0xff) {
+                    auto color = filter(Color::from_rgba(src[x]));
+                    if (color.alpha() == 0xff)
+                        dst[x] = color.value();
+                    else
+                        dst[x] = Color::from_rgba(dst[x]).blend(color).value();
+                } else if (!alpha)
                     continue;
                 else
                     dst[x] = Color::from_rgba(dst[x]).blend(filter(Color::from_rgba(src[x]))).value();
@@ -605,9 +609,13 @@ void Painter::blit_filtered(const IntPoint& position, const Gfx::Bitmap& source,
             const RGBA32* src = source.scanline(safe_src_rect.top() + row / s) + safe_src_rect.left() + first_column / s;
             for (int x = 0; x <= (last_column - first_column); ++x) {
                 u8 alpha = Color::from_rgba(src[x / s]).alpha();
-                if (alpha == 0xff)
-                    dst[x] = filter(Color::from_rgba(src[x / s])).value();
-                else if (!alpha)
+                if (alpha == 0xff) {
+                    auto color = filter(Color::from_rgba(src[x / s]));
+                    if (color.alpha() == 0xff)
+                        dst[x] = color.value();
+                    else
+                        dst[x] = Color::from_rgba(dst[x]).blend(color).value();
+                } else if (!alpha)
                     continue;
                 else
                     dst[x] = Color::from_rgba(dst[x]).blend(filter(Color::from_rgba(src[x / s]))).value();

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -345,9 +345,18 @@ void Compositor::compose()
                 auto dst = backing_rect.location().translated(dirty_rect_in_backing_coordinates.location());
 
                 if (window.client() && window.client()->is_unresponsive()) {
-                    painter.blit_filtered(dst, *backing_store, dirty_rect_in_backing_coordinates, [](Color src) {
-                        return src.to_grayscale().darkened(0.75f);
-                    });
+                    if (window.is_opaque()) {
+                        painter.blit_filtered(dst, *backing_store, dirty_rect_in_backing_coordinates, [](Color src) {
+                            return src.to_grayscale().darkened(0.75f);
+                        });
+                    } else {
+                        u8 alpha = 255 * window.opacity();
+                        painter.blit_filtered(dst, *backing_store, dirty_rect_in_backing_coordinates, [&](Color src) {
+                            auto color = src.to_grayscale().darkened(0.75f);
+                            color.set_alpha(alpha);
+                            return color;
+                        });
+                    }
                 } else {
                     painter.blit(dst, *backing_store, dirty_rect_in_backing_coordinates, window.opacity());
                 }


### PR DESCRIPTION
We only cleared the area not covered by the backing bitmap if a
rendering rectangle intersected with the backing bitmap. But because
we are potentially calling the render function many times we need
to always clear the area not covered by the backing bitmap, whether
it intersects or not.

Fixes #5291