### PR TITLE
AK+Format: Don't cast to size_t when you want u64.

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -368,7 +368,7 @@ void FormatBuilder::put_i64(
     const auto is_negative = value < 0;
     value = is_negative ? -value : value;
 
-    put_u64(static_cast<size_t>(value), base, prefix, upper_case, zero_pad, align, min_width, fill, sign_mode, is_negative);
+    put_u64(static_cast<u64>(value), base, prefix, upper_case, zero_pad, align, min_width, fill, sign_mode, is_negative);
 }
 
 #ifndef KERNEL

--- a/Userland/Tests/AK/CMakeLists.txt
+++ b/Userland/Tests/AK/CMakeLists.txt
@@ -1,0 +1,9 @@
+file(GLOB CMD_SOURCES CONFIGURE_DEPENDS "*.cpp")
+
+foreach(CMD_SRC ${CMD_SOURCES})
+    get_filename_component(CMD_NAME ${CMD_SRC} NAME_WE)
+    add_executable(${CMD_NAME}_Userland ${CMD_SRC})
+    set_target_properties(${CMD_NAME}_Userland PROPERTIES OUTPUT_NAME ${CMD_NAME})
+    target_link_libraries(${CMD_NAME}_Userland LibCore)
+    install(TARGETS ${CMD_NAME}_Userland RUNTIME DESTINATION usr/Tests/AK)
+endforeach()

--- a/Userland/Tests/AK/TestFormat.cpp
+++ b/Userland/Tests/AK/TestFormat.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+TEST_CASE(long_long_regression)
+{
+    EXPECT_EQ(String::formatted("{}", 0x0123456789abcdefLL), "81985529216486895");
+
+    StringBuilder builder;
+    AK::FormatBuilder fmtbuilder { builder };
+    fmtbuilder.put_i64(0x0123456789abcdefLL);
+
+    EXPECT_EQ(builder.string_view(), "81985529216486895");
+}
+
+TEST_MAIN(Format)

--- a/Userland/Tests/CMakeLists.txt
+++ b/Userland/Tests/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(AK)
 add_subdirectory(Kernel)
 add_subdirectory(LibC)
 add_subdirectory(LibGfx)


### PR DESCRIPTION
In Serenity, `size_t` is defined as `u32`, thus `static_cast<size_t>(value)` truncates the value.

Since the unit test only ever failed inside of Serenity, I quickly added another `TestFormat.cpp` file. When we finally run tests in Serenity, we'd have to merge these files.

Fixes #5308
