### PR TITLE
HackStudio: Handle LanguageServer crashing & use parser-based c++ autocomplete by default

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -963,6 +963,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_set_autocomplete_mode_action
     auto action = GUI::Action::create_checkable("AutoComplete C++ with Parser", [this](auto& action) {
         get_language_client<LanguageClients::Cpp::ServerConnection>(project().root_path())->set_autocomplete_mode(action.is_checked() ? "Parser" : "Lexer");
     });
+    action->set_checked(true);
     return action;
 }
 

--- a/Userland/DevTools/HackStudio/LanguageClient.cpp
+++ b/Userland/DevTools/HackStudio/LanguageClient.cpp
@@ -28,6 +28,7 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <DevTools/HackStudio/LanguageServers/LanguageServerEndpoint.h>
+#include <LibGUI/Notification.h>
 
 namespace HackStudio {
 
@@ -40,34 +41,54 @@ void ServerConnection::handle(const Messages::LanguageClient::AutoCompleteSugges
     m_language_client->provide_autocomplete_suggestions(message.suggestions());
 }
 
+void ServerConnection::die()
+{
+    dbgln("ServerConnection::die()");
+    if (!m_language_client)
+        return;
+    m_language_client->on_server_crash();
+}
+
 void LanguageClient::open_file(const String& path, int fd)
 {
-    m_connection.post_message(Messages::LanguageServer::FileOpened(path, fd));
+    if (!m_server_connection)
+        return;
+    m_server_connection->post_message(Messages::LanguageServer::FileOpened(path, fd));
 }
 
 void LanguageClient::set_file_content(const String& path, const String& content)
 {
-    m_connection.post_message(Messages::LanguageServer::SetFileContent(path, content));
+    if (!m_server_connection)
+        return;
+    m_server_connection->post_message(Messages::LanguageServer::SetFileContent(path, content));
 }
 
 void LanguageClient::insert_text(const String& path, const String& text, size_t line, size_t column)
 {
-    m_connection.post_message(Messages::LanguageServer::FileEditInsertText(path, text, line, column));
+    if (!m_server_connection)
+        return;
+    m_server_connection->post_message(Messages::LanguageServer::FileEditInsertText(path, text, line, column));
 }
 
 void LanguageClient::remove_text(const String& path, size_t from_line, size_t from_column, size_t to_line, size_t to_column)
 {
-    m_connection.post_message(Messages::LanguageServer::FileEditRemoveText(path, from_line, from_column, to_line, to_column));
+    if (!m_server_connection)
+        return;
+    m_server_connection->post_message(Messages::LanguageServer::FileEditRemoveText(path, from_line, from_column, to_line, to_column));
 }
 
 void LanguageClient::request_autocomplete(const String& path, size_t cursor_line, size_t cursor_column)
 {
+    if (!m_server_connection)
+        return;
     set_active_client();
-    m_connection.post_message(Messages::LanguageServer::AutoCompleteSuggestions(path, cursor_line, cursor_column));
+    m_server_connection->post_message(Messages::LanguageServer::AutoCompleteSuggestions(path, cursor_line, cursor_column));
 }
 
 void LanguageClient::provide_autocomplete_suggestions(const Vector<GUI::AutocompleteProvider::Entry>& suggestions)
 {
+    if (!m_server_connection)
+        return;
     if (on_autocomplete_suggestions)
         on_autocomplete_suggestions(suggestions);
 
@@ -76,12 +97,54 @@ void LanguageClient::provide_autocomplete_suggestions(const Vector<GUI::Autocomp
 
 void LanguageClient::set_autocomplete_mode(const String& mode)
 {
-    m_connection.post_message(Messages::LanguageServer::SetAutoCompleteMode(mode));
+    if (!m_server_connection)
+        return;
+    m_server_connection->post_message(Messages::LanguageServer::SetAutoCompleteMode(mode));
 }
 
 void LanguageClient::set_active_client()
 {
-    m_connection.attach(*this);
+    if (!m_server_connection)
+        return;
+    m_server_connection->attach(*this);
+}
+
+void LanguageClient::on_server_crash()
+{
+    ASSERT(m_server_connection);
+    auto project_path = m_server_connection->projcet_path();
+    ServerConnection::remove_instance_for_project(project_path);
+    m_server_connection = nullptr;
+
+    auto notification = GUI::Notification::construct();
+
+    notification->set_icon(Gfx::Bitmap::load_from_file("/res/icons/32x32/app-hack-studio.png"));
+    notification->set_title("Oops!");
+    notification->set_text(String::formatted("LanguageServer for {} crashed", project_path));
+    notification->show();
+}
+
+HashMap<String, NonnullRefPtr<ServerConnection>> ServerConnection::s_instances_for_projects;
+
+RefPtr<ServerConnection> ServerConnection::instance_for_project(const String& project_path)
+{
+    auto key = LexicalPath { project_path }.string();
+    auto value = s_instances_for_projects.get(key);
+    if (!value.has_value())
+        return nullptr;
+    return *value.value();
+}
+
+void ServerConnection::set_instance_for_project(const String& project_path, NonnullRefPtr<ServerConnection>&& instance)
+{
+    auto key = LexicalPath { project_path }.string();
+    s_instances_for_projects.set(key, move(instance));
+}
+
+void ServerConnection::remove_instance_for_project(const String& project_path)
+{
+    auto key = LexicalPath { project_path }.string();
+    s_instances_for_projects.remove(key);
 }
 
 }

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.cpp
@@ -40,7 +40,7 @@ ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> socket, int 
     : IPC::ClientConnection<LanguageClientEndpoint, LanguageServerEndpoint>(*this, move(socket), client_id)
 {
     s_connections.set(client_id, *this);
-    m_autocomplete_engine = make<LexerAutoComplete>(m_filedb);
+    m_autocomplete_engine = make<ParserAutoComplete>(m_filedb);
 }
 
 ClientConnection::~ClientConnection()

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
@@ -97,8 +97,7 @@ ParserAutoComplete::DocumentData::DocumentData(String&& _text)
 
 Vector<GUI::AutocompleteProvider::Entry> ParserAutoComplete::get_suggestions(const String& file, const GUI::TextPosition& autocomplete_position)
 {
-    ASSERT(autocomplete_position.column() > 0);
-    Cpp::Position position { autocomplete_position.line(), autocomplete_position.column() - 1 };
+    Cpp::Position position { autocomplete_position.line(), autocomplete_position.column() > 0 ? autocomplete_position.column() - 1 : 0 };
 
     VERBOSE("ParserAutoComplete position {}:{}", position.line, position.column);
 

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -128,6 +128,7 @@ static bool make_is_available()
 static void notify_make_not_available()
 {
     auto notification = GUI::Notification::construct();
+    notification->set_icon(Gfx::Bitmap::load_from_file("/res/icons/32x32/app-hack-studio.png"));
     notification->set_title("'make' Not Available");
     notification->set_text("You probably want to install the binutils, gcc, and make ports from the root of the Serenity repository");
     notification->show();

--- a/Userland/Libraries/LibCpp/Lexer.cpp
+++ b/Userland/Libraries/LibCpp/Lexer.cpp
@@ -640,6 +640,10 @@ Vector<Token> Lexer::lex()
                     }
                 }
 
+                // If string is not terminated - stop before EOF
+                if (!peek(1))
+                    break;
+
                 if (consume() == '"')
                     break;
             }

--- a/Userland/Libraries/LibCpp/Parser.h
+++ b/Userland/Libraries/LibCpp/Parser.h
@@ -114,6 +114,7 @@ private:
     Token peek() const;
     Optional<Token> peek(Token::Type) const;
     Position position() const;
+    StringView text_of_range(Position start, Position end) const;
 
     void save_state();
     void load_state();


### PR DESCRIPTION
also some bug fixes in the c++ autocomplete engine.

Screenshot of a LanguageServer crashing:
![hs-langserver-crash](https://user-images.githubusercontent.com/9247514/107848953-78c27f80-6e00-11eb-9172-3835a4b19de8.png)
