### PR TITLE
Meta: Fix debug-flag detection

### DIFF
--- a/Meta/CMake/all_the_debug_macros.cmake
+++ b/Meta/CMake/all_the_debug_macros.cmake
@@ -170,7 +170,15 @@ set(SYSCALL_1_DEBUG ON)
 
 # False positive: DEBUG is a flag but it works differently.
 # set(DEBUG ON)
+# False positive: DT_DEBUG is a flag, but for a bitset, not a feature.
+# set(DT_DEBUG ON)
+# False positive: GUI_DND_DEBUG is a flag, but passed as an envvar.
+# set(GUI_DND_DEBUG ON)
+# False positive: GUI_FOCUS_DEBUG is a flag, but passed as an envvar.
+# set(GUI_FOCUS_DEBUG ON)
 # False positive: LOG_DEBUG is a flag, but for a bitset, not a feature.
 # set(LOG_DEBUG ON)
+# False positive: UHCI_USBCMD_SOFTWARE_DEBUG is a flag, but for a bitset, not a feature.
+# set(UHCI_USBCMD_SOFTWARE_DEBUG ON)
 # Clogs up build: The WrapperGenerator stuff is run at compile time.
 # set(WRAPPER_GENERATOR_DEBUG ON)

--- a/Meta/check-debug-flags.sh
+++ b/Meta/check-debug-flags.sh
@@ -12,7 +12,7 @@ while IFS= read -r FLAG; do
     # There are (basically) no false positives, but there might be false negatives,
     # for example we intentionally don't check for commented-out lines here.
     if ! grep -qP "set\(${FLAG}" Meta/CMake/all_the_debug_macros.cmake ; then
-        echo "ALL_THE_DEBUG_MACROS probably doesn't include ${FLAG}"
+        echo "'all_the_debug_macros.cmake' is missing ${FLAG}"
         MISSING_FLAGS=y
     fi
 done < <(
@@ -22,16 +22,16 @@ done < <(
         '*.in' \
         ':!:Kernel/FileSystem/ext2_fs.h' \
         ':!:Userland/Libraries/LibELF/exec_elf.h' \
-    | xargs grep -P '^ *#.*DEBUG' \
+    | xargs grep -P '(_DEBUG|DEBUG_)' \
     | sed -re 's,^.*[^a-zA-Z0-9_]([a-zA-Z0-9_]*DEBUG[a-zA-Z0-9_]*).*$,\1,' \
     | sort \
     | uniq
 )
 
 if [ "n" != "${MISSING_FLAGS}" ] ; then
-    echo "Some flags are missing for the ALL_THE_DEBUG_MACROS feature in CMakeLists.txt."
+    echo "Some flags are missing for the ALL_THE_DEBUG_MACROS feature."
     echo "If you just added a new SOMETHING_DEBUG flag, that's great!"
     echo "We want to enable all of these in automated builds, so that the code doesn't rot."
-    echo "Please add it to the ALL_THE_DEBUG_MACROS section."
+    echo "Please add it to Meta/CMake/all_the_debug_macros.cmake"
     exit 1
 fi


### PR DESCRIPTION
Detection broke when we moved from '#ifdef DEBUG_FOO dbgln()' to 'dbgln<DEBUG_FOO>()'.
This patch makes detection more general, which sadly runs into more false-positives.

No rotten code was found, hooray! :^)