### PR TITLE
Adventures in LookupServer, pt. 3

### DIFF
--- a/Base/etc/LookupServer.ini
+++ b/Base/etc/LookupServer.ini
@@ -1,2 +1,3 @@
 [DNS]
 Nameservers=1.1.1.1,1.0.0.1
+EnableServer=0

--- a/Userland/Libraries/LibCore/UDPServer.h
+++ b/Userland/Libraries/LibCore/UDPServer.h
@@ -53,11 +53,14 @@ public:
     Optional<IPv4Address> local_address() const;
     Optional<u16> local_port() const;
 
+    int fd() const { return m_fd; }
+
     Function<void()> on_ready_to_receive;
 
-private:
+protected:
     explicit UDPServer(Object* parent = nullptr);
 
+private:
     int m_fd { -1 };
     bool m_bound { false };
     RefPtr<Notifier> m_notifier;

--- a/Userland/Services/LookupServer/CMakeLists.txt
+++ b/Userland/Services/LookupServer/CMakeLists.txt
@@ -3,6 +3,7 @@ compile_ipc(LookupClient.ipc LookupClientEndpoint.h)
 
 set(SOURCES
     DNSAnswer.cpp
+    DNSName.cpp
     DNSPacket.cpp
     LookupServer.cpp
     LookupServerEndpoint.h

--- a/Userland/Services/LookupServer/CMakeLists.txt
+++ b/Userland/Services/LookupServer/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     DNSAnswer.cpp
     DNSName.cpp
     DNSPacket.cpp
+    DNSServer.cpp
     LookupServer.cpp
     LookupServerEndpoint.h
     LookupClientEndpoint.h

--- a/Userland/Services/LookupServer/ClientConnection.cpp
+++ b/Userland/Services/LookupServer/ClientConnection.cpp
@@ -50,9 +50,13 @@ void ClientConnection::die()
 
 OwnPtr<Messages::LookupServer::LookupNameResponse> ClientConnection::handle(const Messages::LookupServer::LookupName& message)
 {
-    auto addresses = LookupServer::the().lookup(message.name(), T_A);
-    if (addresses.is_empty())
+    auto answers = LookupServer::the().lookup(message.name(), T_A);
+    if (answers.is_empty())
         return make<Messages::LookupServer::LookupNameResponse>(1, Vector<String>());
+    Vector<String> addresses;
+    for (auto& answer : answers) {
+        addresses.append(answer.record_data());
+    }
     return make<Messages::LookupServer::LookupNameResponse>(0, move(addresses));
 }
 
@@ -66,9 +70,9 @@ OwnPtr<Messages::LookupServer::LookupAddressResponse> ClientConnection::handle(c
         address[2],
         address[1],
         address[0]);
-    auto hosts = LookupServer::the().lookup(name, T_PTR);
-    if (hosts.is_empty())
+    auto answers = LookupServer::the().lookup(name, T_PTR);
+    if (answers.is_empty())
         return make<Messages::LookupServer::LookupAddressResponse>(1, String());
-    return make<Messages::LookupServer::LookupAddressResponse>(0, hosts[0]);
+    return make<Messages::LookupServer::LookupAddressResponse>(0, answers[0].record_data());
 }
 }

--- a/Userland/Services/LookupServer/DNSAnswer.cpp
+++ b/Userland/Services/LookupServer/DNSAnswer.cpp
@@ -29,7 +29,7 @@
 
 namespace LookupServer {
 
-DNSAnswer::DNSAnswer(const String& name, u16 type, u16 class_code, u32 ttl, const String& record_data)
+DNSAnswer::DNSAnswer(const DNSName& name, u16 type, u16 class_code, u32 ttl, const String& record_data)
     : m_name(name)
     , m_type(type)
     , m_class_code(class_code)

--- a/Userland/Services/LookupServer/DNSName.cpp
+++ b/Userland/Services/LookupServer/DNSName.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Sergey Bugaev <bugaevc@serenityos.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,33 +24,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #include "DNSName.h"
-#include <AK/String.h>
-#include <AK/Types.h>
 
 namespace LookupServer {
 
-class DNSAnswer {
-public:
-    DNSAnswer(const DNSName& name, u16 type, u16 class_code, u32 ttl, const String& record_data);
-
-    const DNSName& name() const { return m_name; }
-    u16 type() const { return m_type; }
-    u16 class_code() const { return m_class_code; }
-    u32 ttl() const { return m_ttl; }
-    const String& record_data() const { return m_record_data; }
-
-    bool has_expired() const;
-
-private:
-    DNSName m_name;
-    u16 m_type { 0 };
-    u16 m_class_code { 0 };
-    u32 m_ttl { 0 };
-    time_t m_expiration_time { 0 };
-    String m_record_data;
-};
+DNSName::DNSName(const String& name)
+{
+    if (name.ends_with('.'))
+        m_name = name.substring(0, name.length() - 1);
+    else
+        m_name = name;
+}
 
 }

--- a/Userland/Services/LookupServer/DNSName.cpp
+++ b/Userland/Services/LookupServer/DNSName.cpp
@@ -105,4 +105,14 @@ OutputStream& operator<<(OutputStream& stream, const DNSName& name)
     return stream;
 }
 
+unsigned DNSName::Traits::hash(const DNSName& name)
+{
+    return CaseInsensitiveStringTraits::hash(name.as_string());
+}
+
+bool DNSName::Traits::equals(const DNSName& a, const DNSName& b)
+{
+    return CaseInsensitiveStringTraits::equals(a.as_string(), b.as_string());
+}
+
 }

--- a/Userland/Services/LookupServer/DNSName.cpp
+++ b/Userland/Services/LookupServer/DNSName.cpp
@@ -70,6 +70,13 @@ DNSName DNSName::parse(const u8* data, size_t& offset, size_t max_offset, size_t
     }
 }
 
+size_t DNSName::serialized_size() const
+{
+    if (m_name.is_empty())
+        return 1;
+    return m_name.length() + 2;
+}
+
 OutputStream& operator<<(OutputStream& stream, const DNSName& name)
 {
     auto parts = name.as_string().split_view('.');

--- a/Userland/Services/LookupServer/DNSName.cpp
+++ b/Userland/Services/LookupServer/DNSName.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "DNSName.h"
+#include <AK/Vector.h>
 
 namespace LookupServer {
 
@@ -67,6 +68,17 @@ DNSName DNSName::parse(const u8* data, size_t& offset, size_t max_offset, size_t
             offset += b;
         }
     }
+}
+
+OutputStream& operator<<(OutputStream& stream, const DNSName& name)
+{
+    auto parts = name.as_string().split_view('.');
+    for (auto& part : parts) {
+        stream << (u8)part.length();
+        stream << part.bytes();
+    }
+    stream << '\0';
+    return stream;
 }
 
 }

--- a/Userland/Services/LookupServer/DNSName.cpp
+++ b/Userland/Services/LookupServer/DNSName.cpp
@@ -27,6 +27,7 @@
 
 #include "DNSName.h"
 #include <AK/Vector.h>
+#include <ctype.h>
 
 namespace LookupServer {
 
@@ -75,6 +76,22 @@ size_t DNSName::serialized_size() const
     if (m_name.is_empty())
         return 1;
     return m_name.length() + 2;
+}
+
+void DNSName::randomize_case()
+{
+    StringBuilder builder;
+    for (char c : m_name) {
+        // Randomize the 0x20 bit in every ASCII character.
+        if (isalpha(c)) {
+            if (arc4random_uniform(2))
+                c |= 0x20;
+            else
+                c &= ~0x20;
+        }
+        builder.append(c);
+    }
+    m_name = builder.to_string();
 }
 
 OutputStream& operator<<(OutputStream& stream, const DNSName& name)

--- a/Userland/Services/LookupServer/DNSName.h
+++ b/Userland/Services/LookupServer/DNSName.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Sergey Bugaev <bugaevc@serenityos.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,31 +26,17 @@
 
 #pragma once
 
-#include "DNSName.h"
 #include <AK/String.h>
-#include <AK/Types.h>
 
 namespace LookupServer {
 
-class DNSAnswer {
+class DNSName {
 public:
-    DNSAnswer(const DNSName& name, u16 type, u16 class_code, u32 ttl, const String& record_data);
-
-    const DNSName& name() const { return m_name; }
-    u16 type() const { return m_type; }
-    u16 class_code() const { return m_class_code; }
-    u32 ttl() const { return m_ttl; }
-    const String& record_data() const { return m_record_data; }
-
-    bool has_expired() const;
+    DNSName(const String&);
+    const String& as_string() const { return m_name; }
 
 private:
-    DNSName m_name;
-    u16 m_type { 0 };
-    u16 m_class_code { 0 };
-    u32 m_ttl { 0 };
-    time_t m_expiration_time { 0 };
-    String m_record_data;
+    String m_name;
 };
 
 }

--- a/Userland/Services/LookupServer/DNSName.h
+++ b/Userland/Services/LookupServer/DNSName.h
@@ -38,6 +38,7 @@ public:
 
     static DNSName parse(const u8* data, size_t& offset, size_t max_offset, size_t recursion_level = 0);
 
+    size_t serialized_size() const;
     const String& as_string() const { return m_name; }
 
 private:

--- a/Userland/Services/LookupServer/DNSName.h
+++ b/Userland/Services/LookupServer/DNSName.h
@@ -43,6 +43,12 @@ public:
 
     void randomize_case();
 
+    class Traits : public AK::Traits<DNSName> {
+    public:
+        static unsigned hash(const DNSName& name);
+        static bool equals(const DNSName&, const DNSName&);
+    };
+
 private:
     String m_name;
 };

--- a/Userland/Services/LookupServer/DNSName.h
+++ b/Userland/Services/LookupServer/DNSName.h
@@ -41,6 +41,8 @@ public:
     size_t serialized_size() const;
     const String& as_string() const { return m_name; }
 
+    void randomize_case();
+
 private:
     String m_name;
 };

--- a/Userland/Services/LookupServer/DNSName.h
+++ b/Userland/Services/LookupServer/DNSName.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <AK/Forward.h>
 #include <AK/String.h>
 
 namespace LookupServer {
@@ -42,5 +43,7 @@ public:
 private:
     String m_name;
 };
+
+OutputStream& operator<<(OutputStream& stream, const DNSName&);
 
 }

--- a/Userland/Services/LookupServer/DNSName.h
+++ b/Userland/Services/LookupServer/DNSName.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sergey Bugaev <bugaevc@serenityos.org>
  * All rights reserved.
  *
@@ -33,6 +34,9 @@ namespace LookupServer {
 class DNSName {
 public:
     DNSName(const String&);
+
+    static DNSName parse(const u8* data, size_t& offset, size_t max_offset, size_t recursion_level = 0);
+
     const String& as_string() const { return m_name; }
 
 private:

--- a/Userland/Services/LookupServer/DNSPacket.cpp
+++ b/Userland/Services/LookupServer/DNSPacket.cpp
@@ -92,8 +92,14 @@ ByteBuffer DNSPacket::to_byte_buffer() const
         stream << htons(answer.type());
         stream << htons(answer.class_code());
         stream << htonl(answer.ttl());
-        stream << htons(answer.record_data().length());
-        stream << answer.record_data().bytes();
+        if (answer.type() == T_PTR) {
+            DNSName name { answer.record_data() };
+            stream << htons(name.serialized_size());
+            stream << name;
+        } else {
+            stream << htons(answer.record_data().length());
+            stream << answer.record_data().bytes();
+        }
     }
 
     return stream.copy_into_contiguous_buffer();

--- a/Userland/Services/LookupServer/DNSPacket.cpp
+++ b/Userland/Services/LookupServer/DNSPacket.cpp
@@ -58,9 +58,6 @@ void DNSPacket::add_question(const String& name, u16 record_type, ShouldRandomiz
         builder.append(ch);
     }
 
-    if (name[name.length() - 1] != '.')
-        builder.append('.');
-
     m_questions.empend(builder.to_string(), record_type, (u16)C_IN);
 }
 
@@ -85,7 +82,7 @@ ByteBuffer DNSPacket::to_byte_buffer() const
 
     stream << ReadonlyBytes { &header, sizeof(header) };
     for (auto& question : m_questions) {
-        auto parts = question.name().split('.');
+        auto parts = question.name().as_string().split('.');
         for (auto& part : parts) {
             stream << (u8)part.length();
             stream << part.bytes();
@@ -95,7 +92,7 @@ ByteBuffer DNSPacket::to_byte_buffer() const
         stream << htons(question.class_code());
     }
     for (auto& answer : m_answers) {
-        auto parts = answer.name().split('.');
+        auto parts = answer.name().as_string().split('.');
         for (auto& part : parts) {
             stream << (u8)part.length();
             stream << part.bytes();

--- a/Userland/Services/LookupServer/DNSPacket.cpp
+++ b/Userland/Services/LookupServer/DNSPacket.cpp
@@ -83,22 +83,12 @@ ByteBuffer DNSPacket::to_byte_buffer() const
 
     stream << ReadonlyBytes { &header, sizeof(header) };
     for (auto& question : m_questions) {
-        auto parts = question.name().as_string().split('.');
-        for (auto& part : parts) {
-            stream << (u8)part.length();
-            stream << part.bytes();
-        }
-        stream << '\0';
+        stream << question.name();
         stream << htons(question.record_type());
         stream << htons(question.class_code());
     }
     for (auto& answer : m_answers) {
-        auto parts = answer.name().as_string().split('.');
-        for (auto& part : parts) {
-            stream << (u8)part.length();
-            stream << part.bytes();
-        }
-        stream << '\0';
+        stream << answer.name();
         stream << htons(answer.type());
         stream << htons(answer.class_code());
         stream << htonl(answer.ttl());

--- a/Userland/Services/LookupServer/DNSPacket.cpp
+++ b/Userland/Services/LookupServer/DNSPacket.cpp
@@ -37,29 +37,11 @@
 
 namespace LookupServer {
 
-void DNSPacket::add_question(const String& name, u16 record_type, ShouldRandomizeCase should_randomize_case)
+void DNSPacket::add_question(const DNSQuestion& question)
 {
+    m_questions.empend(question);
+
     ASSERT(m_questions.size() <= UINT16_MAX);
-
-    if (name.is_empty())
-        return;
-
-    StringBuilder builder;
-    for (size_t i = 0; i < name.length(); ++i) {
-        u8 ch = name[i];
-        if (should_randomize_case == ShouldRandomizeCase::Yes) {
-            // Randomize the 0x20 bit in every ASCII character.
-            if (isalpha(ch)) {
-                if (arc4random_uniform(2))
-                    ch |= 0x20;
-                else
-                    ch &= ~0x20;
-            }
-        }
-        builder.append(ch);
-    }
-
-    m_questions.empend(builder.to_string(), record_type, (u16)C_IN);
 }
 
 ByteBuffer DNSPacket::to_byte_buffer() const

--- a/Userland/Services/LookupServer/DNSPacket.cpp
+++ b/Userland/Services/LookupServer/DNSPacket.cpp
@@ -44,6 +44,13 @@ void DNSPacket::add_question(const DNSQuestion& question)
     ASSERT(m_questions.size() <= UINT16_MAX);
 }
 
+void DNSPacket::add_answer(const DNSAnswer& answer)
+{
+    m_answers.empend(answer);
+
+    ASSERT(m_answers.size() <= UINT16_MAX);
+}
+
 ByteBuffer DNSPacket::to_byte_buffer() const
 {
     DNSPacketHeader header;
@@ -54,6 +61,7 @@ ByteBuffer DNSPacket::to_byte_buffer() const
         header.set_is_response();
     // FIXME: What should this be?
     header.set_opcode(0);
+    header.set_response_code(m_code);
     header.set_truncated(false); // hopefully...
     header.set_recursion_desired(true);
     // FIXME: what should the be for requests?

--- a/Userland/Services/LookupServer/DNSPacket.h
+++ b/Userland/Services/LookupServer/DNSPacket.h
@@ -80,6 +80,7 @@ public:
     }
 
     void add_question(const DNSQuestion&);
+    void add_answer(const DNSAnswer&);
 
     enum class Code : u8 {
         NOERROR = 0,

--- a/Userland/Services/LookupServer/DNSPacket.h
+++ b/Userland/Services/LookupServer/DNSPacket.h
@@ -79,7 +79,7 @@ public:
         return m_answers.size();
     }
 
-    void add_question(const String& name, u16 record_type, ShouldRandomizeCase);
+    void add_question(const DNSQuestion&);
 
     enum class Code : u8 {
         NOERROR = 0,

--- a/Userland/Services/LookupServer/DNSQuestion.h
+++ b/Userland/Services/LookupServer/DNSQuestion.h
@@ -26,12 +26,14 @@
 
 #pragma once
 
-#include <AK/String.h>
+#include "DNSName.h"
 #include <AK/Types.h>
+
+namespace LookupServer {
 
 class DNSQuestion {
 public:
-    DNSQuestion(const String& name, u16 record_type, u16 class_code)
+    DNSQuestion(const DNSName& name, u16 record_type, u16 class_code)
         : m_name(name)
         , m_record_type(record_type)
         , m_class_code(class_code)
@@ -40,20 +42,12 @@ public:
 
     u16 record_type() const { return m_record_type; }
     u16 class_code() const { return m_class_code; }
-    const String& name() const { return m_name; }
-
-    bool operator==(const DNSQuestion& other) const
-    {
-        return m_name == other.m_name && m_record_type == other.m_record_type && m_class_code == other.m_class_code;
-    }
-
-    bool operator!=(const DNSQuestion& other) const
-    {
-        return !(*this == other);
-    }
+    const DNSName& name() const { return m_name; }
 
 private:
-    String m_name;
+    DNSName m_name;
     u16 m_record_type { 0 };
     u16 m_class_code { 0 };
 };
+
+}

--- a/Userland/Services/LookupServer/DNSServer.cpp
+++ b/Userland/Services/LookupServer/DNSServer.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, Sergey Bugaev <bugaevc@serenityos.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "DNSServer.h"
+#include "DNSPacket.h"
+#include "LookupServer.h"
+#include <AK/IPv4Address.h>
+
+namespace LookupServer {
+
+DNSServer::DNSServer(Object* parent)
+    : Core::UDPServer(parent)
+{
+    bind(IPv4Address(), 53);
+    on_ready_to_receive = [this]() {
+        handle_client();
+    };
+}
+
+void DNSServer::handle_client()
+{
+    sockaddr_in client_address;
+    auto buffer = receive(1024, client_address);
+    auto optional_request = DNSPacket::from_raw_packet(buffer.data(), buffer.size());
+    if (!optional_request.has_value()) {
+        dbgln("Got an invalid DNS packet");
+        return;
+    }
+    auto& request = optional_request.value();
+
+    if (!request.is_query()) {
+        dbgln("It's not a request");
+        return;
+    }
+
+    LookupServer& lookup_server = LookupServer::the();
+
+    DNSPacket response;
+    response.set_is_response();
+    response.set_id(request.id());
+
+    for (auto& question : request.questions()) {
+        if (question.class_code() != C_IN)
+            continue;
+        response.add_question(question);
+        auto answers = lookup_server.lookup(question.name(), question.record_type());
+        for (auto& answer : answers) {
+            response.add_answer(answer);
+        }
+    }
+
+    if (response.answer_count() == 0)
+        response.set_code(DNSPacket::Code::NXDOMAIN);
+    else
+        response.set_code(DNSPacket::Code::NOERROR);
+
+    buffer = response.to_byte_buffer();
+    sendto(fd(), buffer.data(), buffer.size(), 0, (const sockaddr*)&client_address, sizeof(client_address));
+}
+
+}

--- a/Userland/Services/LookupServer/DNSServer.h
+++ b/Userland/Services/LookupServer/DNSServer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Sergey Bugaev <bugaevc@serenityos.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,35 +26,17 @@
 
 #pragma once
 
-#include "DNSName.h"
-#include "DNSPacket.h"
-#include "DNSServer.h"
-#include <LibCore/Object.h>
+#include <LibCore/UDPServer.h>
 
 namespace LookupServer {
 
-class DNSAnswer;
-
-class LookupServer final : public Core::Object {
-    C_OBJECT(LookupServer);
-
-public:
-    static LookupServer& the();
-    Vector<DNSAnswer> lookup(const DNSName& name, unsigned short record_type);
+class DNSServer : public Core::UDPServer {
+    C_OBJECT(DNSServer)
 
 private:
-    LookupServer();
+    explicit DNSServer(Object* parent = nullptr);
 
-    void load_etc_hosts();
-    void put_in_cache(const DNSAnswer&);
-
-    Vector<DNSAnswer> lookup(const DNSName& hostname, const String& nameserver, bool& did_get_response, unsigned short record_type, ShouldRandomizeCase = ShouldRandomizeCase::Yes);
-
-    RefPtr<Core::LocalServer> m_local_server;
-    RefPtr<DNSServer> m_dns_server;
-    Vector<String> m_nameservers;
-    HashMap<DNSName, Vector<DNSAnswer>, DNSName::Traits> m_etc_hosts;
-    HashMap<DNSName, Vector<DNSAnswer>, DNSName::Traits> m_lookup_cache;
+    void handle_client();
 };
 
 }

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -172,7 +172,10 @@ Vector<String> LookupServer::lookup(const DNSName& name, const String& nameserve
     DNSPacket request;
     request.set_is_query();
     request.set_id(arc4random_uniform(UINT16_MAX));
-    request.add_question(name.as_string(), record_type, should_randomize_case);
+    DNSName name_in_question = name;
+    if (should_randomize_case == ShouldRandomizeCase::Yes)
+        name_in_question.randomize_case();
+    request.add_question({ name_in_question, record_type, C_IN });
 
     auto buffer = request.to_byte_buffer();
 

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -194,7 +194,7 @@ Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, unsigned short recor
         }
     }
     if (answers.is_empty()) {
-        fprintf(stderr, "LookupServer: Tried all nameservers but never got a response :(\n");
+        dbgln("Tried all nameservers but never got a response :(");
         return {};
     }
 
@@ -279,7 +279,7 @@ Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, const String& namese
     }
 
     if (response.answer_count() < 1) {
-        dbgln("LookupServer: Not enough answers ({}) :(", response.answer_count());
+        dbgln("LookupServer: No answers :(");
         return {};
     }
 

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -62,6 +62,11 @@ LookupServer::LookupServer()
 
     load_etc_hosts();
 
+    if (config->read_bool_entry("DNS", "EnableServer")) {
+        m_dns_server = DNSServer::construct(this);
+        // TODO: drop root privileges here.
+    }
+
     m_local_server = Core::LocalServer::construct(this);
     m_local_server->on_ready_to_accept = [this]() {
         auto socket = m_local_server->accept();

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -97,7 +97,7 @@ void LookupServer::load_etc_hosts()
         };
         auto raw_addr = addr.to_in_addr_t();
 
-        auto name = fields[1];
+        DNSName name = fields[1];
         m_etc_hosts.set(name, String { (const char*)&raw_addr, sizeof(raw_addr) });
 
         IPv4Address reverse_addr {
@@ -121,7 +121,7 @@ Vector<String> LookupServer::lookup(const DNSName& name, unsigned short record_t
 
     Vector<String> responses;
 
-    if (auto known_host = m_etc_hosts.get(name.as_string()); known_host.has_value()) {
+    if (auto known_host = m_etc_hosts.get(name); known_host.has_value()) {
         responses.append(known_host.value());
     } else if (!name.as_string().is_empty()) {
         for (auto& nameserver : m_nameservers) {
@@ -155,7 +155,7 @@ Vector<String> LookupServer::lookup(const DNSName& name, unsigned short record_t
 
 Vector<String> LookupServer::lookup(const DNSName& name, const String& nameserver, bool& did_get_response, unsigned short record_type, ShouldRandomizeCase should_randomize_case)
 {
-    if (auto cached_answers = m_lookup_cache.get(name.as_string()); cached_answers.has_value()) {
+    if (auto cached_answers = m_lookup_cache.get(name); cached_answers.has_value()) {
         Vector<String> responses;
         for (auto& answer : cached_answers.value()) {
             if (answer.type() == record_type && !answer.has_expired()) {
@@ -270,9 +270,9 @@ void LookupServer::put_in_cache(const DNSAnswer& answer)
     if (m_lookup_cache.size() >= 256)
         m_lookup_cache.remove(m_lookup_cache.begin());
 
-    auto it = m_lookup_cache.find(answer.name().as_string());
+    auto it = m_lookup_cache.find(answer.name());
     if (it == m_lookup_cache.end())
-        m_lookup_cache.set(answer.name().as_string(), { answer });
+        m_lookup_cache.set(answer.name(), { answer });
     else
         it->value.append(answer);
 }

--- a/Userland/Services/LookupServer/LookupServer.h
+++ b/Userland/Services/LookupServer/LookupServer.h
@@ -39,7 +39,7 @@ class LookupServer final : public Core::Object {
 
 public:
     static LookupServer& the();
-    Vector<String> lookup(const DNSName& name, unsigned short record_type);
+    Vector<DNSAnswer> lookup(const DNSName& name, unsigned short record_type);
 
 private:
     LookupServer();
@@ -47,7 +47,7 @@ private:
     void load_etc_hosts();
     void put_in_cache(const DNSAnswer&);
 
-    Vector<String> lookup(const DNSName& hostname, const String& nameserver, bool& did_get_response, unsigned short record_type, ShouldRandomizeCase = ShouldRandomizeCase::Yes);
+    Vector<DNSAnswer> lookup(const DNSName& hostname, const String& nameserver, bool& did_get_response, unsigned short record_type, ShouldRandomizeCase = ShouldRandomizeCase::Yes);
 
 
     RefPtr<Core::LocalServer> m_local_server;

--- a/Userland/Services/LookupServer/LookupServer.h
+++ b/Userland/Services/LookupServer/LookupServer.h
@@ -52,8 +52,8 @@ private:
 
     RefPtr<Core::LocalServer> m_local_server;
     Vector<String> m_nameservers;
-    HashMap<String, String> m_etc_hosts;
-    HashMap<String, Vector<DNSAnswer>> m_lookup_cache;
+    HashMap<DNSName, String, DNSName::Traits> m_etc_hosts;
+    HashMap<DNSName, Vector<DNSAnswer>, DNSName::Traits> m_lookup_cache;
 };
 
 }

--- a/Userland/Services/LookupServer/LookupServer.h
+++ b/Userland/Services/LookupServer/LookupServer.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "DNSPacket.h"
+#include "DNSName.h"
 #include <LibCore/Object.h>
 
 namespace LookupServer {
@@ -38,13 +39,13 @@ class LookupServer final : public Core::Object {
 
 public:
     static LookupServer& the();
-    Vector<String> lookup(const String& name, unsigned short record_type);
+    Vector<String> lookup(const DNSName& name, unsigned short record_type);
 
 private:
     LookupServer();
 
     void load_etc_hosts();
-    Vector<String> lookup(const String& hostname, const String& nameserver, bool& did_get_response, unsigned short record_type, ShouldRandomizeCase = ShouldRandomizeCase::Yes);
+    Vector<String> lookup(const DNSName& hostname, const String& nameserver, bool& did_get_response, unsigned short record_type, ShouldRandomizeCase = ShouldRandomizeCase::Yes);
 
     struct CachedLookup {
         DNSQuestion question;

--- a/Userland/Services/LookupServer/LookupServer.h
+++ b/Userland/Services/LookupServer/LookupServer.h
@@ -45,17 +45,15 @@ private:
     LookupServer();
 
     void load_etc_hosts();
+    void put_in_cache(const DNSAnswer&);
+
     Vector<String> lookup(const DNSName& hostname, const String& nameserver, bool& did_get_response, unsigned short record_type, ShouldRandomizeCase = ShouldRandomizeCase::Yes);
 
-    struct CachedLookup {
-        DNSQuestion question;
-        Vector<DNSAnswer> answers;
-    };
 
     RefPtr<Core::LocalServer> m_local_server;
     Vector<String> m_nameservers;
     HashMap<String, String> m_etc_hosts;
-    HashMap<String, CachedLookup> m_lookup_cache;
+    HashMap<String, Vector<DNSAnswer>> m_lookup_cache;
 };
 
 }

--- a/Userland/Services/LookupServer/LookupServer.h
+++ b/Userland/Services/LookupServer/LookupServer.h
@@ -52,7 +52,7 @@ private:
 
     RefPtr<Core::LocalServer> m_local_server;
     Vector<String> m_nameservers;
-    HashMap<DNSName, String, DNSName::Traits> m_etc_hosts;
+    HashMap<DNSName, Vector<DNSAnswer>, DNSName::Traits> m_etc_hosts;
     HashMap<DNSName, Vector<DNSAnswer>, DNSName::Traits> m_lookup_cache;
 };
 


### PR DESCRIPTION
Lots of stuff here, culminating with our own DNS server!

A picture is worth a thousand words (aka 2KB):

![image](https://user-images.githubusercontent.com/10091584/107880099-bc46e780-6eed-11eb-8fc5-0f84b7627a72.png)

Here, 192.168.122.1 is my host, 192.168.122.42 is SerenityOS VM. The .1 asks the .42, where's SerenityOS.org? LookupServer does not find it in the cache, randomizes the case and sends the question upstream. Upon receiving and validating and caching the answer, it replies back to .1 (notice that it replies back with the case used in the .1-to-.42 query!)

Then .1 asks .42 again, this time for serenityOS.ORG, LookupServer finds it in its cache, and replies back immediately, again using the case from the query. Finally, .1 asks .42 for serenityOS.ORGH, which is (was) not an existing domain. LookupServer asks its upstream servers, and finally returns a NXDOMAIN to .1.

Inverse lookups (get host by addr) are not demonstrated, but should also work.

cc @alimpfard @linusg @itamar8910