### PR TITLE
Ports: Add build_installed.sh script to rebuild installed ports

### DIFF
--- a/Ports/build_all.sh
+++ b/Ports/build_all.sh
@@ -21,7 +21,7 @@ for file in *; do
             if $(./package.sh > /dev/null 2>&1 ); then
                 echo "Built ${dirname}."
             else
-                echo "ERROR: Built ${dirname} not succesful!"
+                echo "ERROR: Build of ${dirname} was not successful!"
                 some_failed=true
             fi
         popd > /dev/null

--- a/Ports/build_installed.sh
+++ b/Ports/build_installed.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+packagesdb="$SERENITY_ROOT/Build/packages.db"
+
+clean=false
+case "$1" in
+    clean)
+        clean=true
+        ;;
+    *)
+        ;;
+esac
+
+some_failed=false
+
+while IFS= read -r line; do
+    port="$(echo "$line" | cut -d' ' -f2)"
+    if [ -d "$port" ]; then
+        pushd $port > /dev/null
+            dirname=$(basename $port)
+            if [ "$clean" == true ]; then
+                ./package.sh clean_all
+            fi
+            if ./package.sh; then
+                echo "Built ${dirname}."
+            else
+                echo "ERROR: Build of ${dirname} was not successful!"
+                some_failed=true
+            fi
+        popd > /dev/null
+    else
+        echo "ERROR: Previously installed port $port doesn't exist!"
+        some_failed=true
+    fi
+done < <(grep -E "^(auto|manual)" "$packagesdb")
+
+if [ "$some_failed" == false ]; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
Based on `build_all.sh`, but reading from `packages.db` and not hiding build output.

cc @alimpfard 