### PR TITLE
WindowServer: Fix double click handling while using cursor tracking

### DIFF
--- a/Userland/Services/WindowServer/MenuManager.cpp
+++ b/Userland/Services/WindowServer/MenuManager.cpp
@@ -225,7 +225,7 @@ void MenuManager::handle_mouse_event(MouseEvent& mouse_event)
         if (event_is_inside_current_menu) {
             WindowManager::the().set_hovered_window(window);
             auto translated_event = mouse_event.translated(-window->position());
-            WindowManager::the().deliver_mouse_event(*window, translated_event);
+            WindowManager::the().deliver_mouse_event(*window, translated_event, true);
             return;
         }
 
@@ -262,7 +262,7 @@ void MenuManager::handle_mouse_event(MouseEvent& mouse_event)
                     continue;
                 WindowManager::the().set_hovered_window(menu->menu_window());
                 auto translated_event = mouse_event.translated(-menu->menu_window()->position());
-                WindowManager::the().deliver_mouse_event(*menu->menu_window(), translated_event);
+                WindowManager::the().deliver_mouse_event(*menu->menu_window(), translated_event, true);
                 break;
             }
         }

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -190,7 +190,7 @@ public:
     bool update_theme(String theme_path, String theme_name);
 
     void set_hovered_window(Window*);
-    void deliver_mouse_event(Window& window, MouseEvent& event);
+    void deliver_mouse_event(Window& window, MouseEvent& event, bool process_double_click);
 
     void did_popup_a_menu(Badge<Menu>);
 


### PR DESCRIPTION
We need to first deliver the mouse event and possibly the double click
event and record these facts. Then, we need to iterate all global
tracking listeners and deliver the mouse event (but not the double
click event) to any such listener, unless they already had these
events delivered.

Fixes #4703