### PR TITLE
Kernel: Mark BlockResult as [[nodiscard]]

### DIFF
--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -239,7 +239,7 @@ void SB16::handle_irq(const RegisterState&)
 
 void SB16::wait_for_irq()
 {
-    m_irq_queue.wait_on({}, "SB16");
+    m_irq_queue.wait_forever("SB16");
     disable_irq();
 }
 

--- a/Kernel/Devices/USB/UHCIController.cpp
+++ b/Kernel/Devices/USB/UHCIController.cpp
@@ -450,7 +450,7 @@ void UHCIController::spawn_port_proc()
                     }
                 }
             }
-            Thread::current()->sleep(sleep_time);
+            (void)Thread::current()->sleep(sleep_time);
         }
     });
 }

--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -74,7 +74,7 @@ KResultOr<NonnullRefPtr<FileDescription>> FIFO::open_direction_blocking(FIFO::Di
 
         if (m_writers == 0) {
             locker.unlock();
-            m_write_open_queue.wait_on({}, "FIFO");
+            m_write_open_queue.wait_forever("FIFO");
             locker.lock();
         }
     }
@@ -84,7 +84,7 @@ KResultOr<NonnullRefPtr<FileDescription>> FIFO::open_direction_blocking(FIFO::Di
 
         if (m_readers == 0) {
             locker.unlock();
-            m_read_open_queue.wait_on({}, "FIFO");
+            m_read_open_queue.wait_forever("FIFO");
             locker.lock();
         }
     }

--- a/Kernel/Lock.cpp
+++ b/Kernel/Lock.cpp
@@ -127,7 +127,7 @@ void Lock::lock(Mode mode)
         }
         m_lock.store(false, AK::memory_order_release);
         dbgln_if(LOCK_TRACE_DEBUG, "Lock::lock @ {} ({}) waiting...", this, m_name);
-        m_queue.wait_on({}, m_name);
+        m_queue.wait_forever(m_name);
         dbgln_if(LOCK_TRACE_DEBUG, "Lock::lock @ {} ({}) waited", this, m_name);
     }
 }

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -444,7 +444,7 @@ void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
             sti();
             break;
         }
-        m_wait_queue.wait_on({}, "E1000NetworkAdapter");
+        m_wait_queue.wait_forever("E1000NetworkAdapter");
     }
 #if E1000_DEBUG
     dbgln("E1000: Sent packet, status is now {:#02x}!", (u8)descriptor.status);

--- a/Kernel/Net/NE2000NetworkAdapter.cpp
+++ b/Kernel/Net/NE2000NetworkAdapter.cpp
@@ -392,7 +392,7 @@ void NE2000NetworkAdapter::send_raw(ReadonlyBytes payload)
     }
 
     while (in8(REG_RW_COMMAND) & BIT_COMMAND_TXP)
-        m_wait_queue.wait_on({}, "NE2000NetworkAdapter");
+        m_wait_queue.wait_forever("NE2000NetworkAdapter");
 
     disable_irq();
     size_t packet_size = payload.size();

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -106,7 +106,7 @@ void NetworkTask_main(void*)
     for (;;) {
         size_t packet_size = dequeue_packet(buffer, buffer_size, packet_timestamp);
         if (!packet_size) {
-            packet_wait_queue.wait_on({}, "NetworkTask");
+            packet_wait_queue.wait_forever("NetworkTask");
             continue;
         }
         if (packet_size < sizeof(EthernetFrameHeader)) {

--- a/Kernel/Random.cpp
+++ b/Kernel/Random.cpp
@@ -91,7 +91,7 @@ void KernelRng::wait_for_entropy()
     ScopedSpinLock lock(get_lock());
     if (!resource().is_ready()) {
         dbgln("Entropy starvation...");
-        m_seed_queue.wait_on({}, "KernelRng");
+        m_seed_queue.wait_forever("KernelRng");
     }
 }
 

--- a/Kernel/Tasks/FinalizerTask.cpp
+++ b/Kernel/Tasks/FinalizerTask.cpp
@@ -36,7 +36,7 @@ void FinalizerTask::spawn()
         finalizer_thread, "FinalizerTask", [](void*) {
             Thread::current()->set_priority(THREAD_PRIORITY_LOW);
             for (;;) {
-                g_finalizer_wait_queue->wait_on({}, "FinalizerTask");
+                g_finalizer_wait_queue->wait_forever("FinalizerTask");
 
                 if (g_finalizer_has_work.exchange(false, AK::MemoryOrder::memory_order_acq_rel) == true)
                     Thread::finalize_dying_threads();

--- a/Kernel/Tasks/SyncTask.cpp
+++ b/Kernel/Tasks/SyncTask.cpp
@@ -38,7 +38,7 @@ void SyncTask::spawn()
         dbgln("SyncTask is running");
         for (;;) {
             VFS::the().sync();
-            Thread::current()->sleep({ 1, 0 });
+            (void)Thread::current()->sleep({ 1, 0 });
         }
     });
 }

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -155,7 +155,7 @@ public:
         Blocked
     };
 
-    class BlockResult {
+    class [[nodiscard]] BlockResult {
     public:
         enum Type {
             WokeNormally,

--- a/Kernel/WaitQueue.h
+++ b/Kernel/WaitQueue.h
@@ -50,6 +50,12 @@ public:
         return Thread::current()->block<Thread::QueueBlocker>(timeout, *this, forward<Args>(args)...);
     }
 
+    template<class... Args>
+    void wait_forever(Args&&... args)
+    {
+        (void)Thread::current()->block<Thread::QueueBlocker>({}, *this, forward<Args>(args)...);
+    }
+
 protected:
     virtual bool should_add_blocker(Thread::Blocker& b, void* data) override;
 


### PR DESCRIPTION
In the majority of cases we want to force callers to observe the
result of a blocking operation as it's not grantee to succeed as
they expect. Mark BlockResult as [[nodiscard]] to force any callers
to observe the result of the blocking operation.

In preparation for marking BlockingResult [[nodiscard]], there are a few
places that perform infinite waits, which we never observe the result of
the wait. Instead of suppressing them, add an alternate function which
returns void when performing and infinite wait.

Also explicitly ignore unobserved BlockResult from Thread::Sleep in places
which don't seem to care. 