### PR TITLE
AK + Kernel: Mark more APIs as [[nodiscard]]

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -124,20 +124,20 @@ public:
         new (&m_storage) T(forward<Parameters>(parameters)...);
     }
 
-    ALWAYS_INLINE bool has_value() const { return m_has_value; }
+    [[nodiscard]] ALWAYS_INLINE bool has_value() const { return m_has_value; }
 
-    ALWAYS_INLINE T& value()
+    [[nodiscard]] ALWAYS_INLINE T& value()
     {
         ASSERT(m_has_value);
         return *reinterpret_cast<T*>(&m_storage);
     }
 
-    ALWAYS_INLINE const T& value() const
+    [[nodiscard]] ALWAYS_INLINE const T& value() const
     {
         return value_without_consume_state();
     }
 
-    T release_value()
+    [[nodiscard]] T release_value()
     {
         ASSERT(m_has_value);
         T released_value = move(value());
@@ -146,7 +146,7 @@ public:
         return released_value;
     }
 
-    ALWAYS_INLINE T value_or(const T& fallback) const
+    [[nodiscard]] ALWAYS_INLINE T value_or(const T& fallback) const
     {
         if (m_has_value)
             return value();

--- a/Kernel/KBuffer.h
+++ b/Kernel/KBuffer.h
@@ -79,7 +79,7 @@ public:
         return buffer;
     }
 
-    bool expand(size_t new_capacity)
+    [[nodiscard]] bool expand(size_t new_capacity)
     {
         auto new_region = MM.allocate_kernel_region(page_round_up(new_capacity), m_region->name(), m_region->access(), m_allocation_strategy);
         if (!new_region)
@@ -90,10 +90,10 @@ public:
         return true;
     }
 
-    u8* data() { return m_region->vaddr().as_ptr(); }
-    const u8* data() const { return m_region->vaddr().as_ptr(); }
-    size_t size() const { return m_size; }
-    size_t capacity() const { return m_region->size(); }
+    [[nodiscard]] u8* data() { return m_region->vaddr().as_ptr(); }
+    [[nodiscard]] const u8* data() const { return m_region->vaddr().as_ptr(); }
+    [[nodiscard]] size_t size() const { return m_size; }
+    [[nodiscard]] size_t capacity() const { return m_region->size(); }
 
     void set_size(size_t size)
     {
@@ -101,8 +101,8 @@ public:
         m_size = size;
     }
 
-    const Region& region() const { return *m_region; }
-    Region& region() { return *m_region; }
+    [[nodiscard]] const Region& region() const { return *m_region; }
+    [[nodiscard]] Region& region() { return *m_region; }
 
 private:
     explicit KBufferImpl(NonnullOwnPtr<Region>&& region, size_t size, AllocationStrategy strategy)
@@ -117,14 +117,14 @@ private:
     NonnullOwnPtr<Region> m_region;
 };
 
-class KBuffer {
+class [[nodiscard]] KBuffer {
 public:
     explicit KBuffer(RefPtr<KBufferImpl>&& impl)
         : m_impl(move(impl))
     {
     }
 
-    static OwnPtr<KBuffer> try_create_with_size(size_t size, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
+    [[nodiscard]] static OwnPtr<KBuffer> try_create_with_size(size_t size, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
     {
         auto impl = KBufferImpl::try_create_with_size(size, access, name, strategy);
         if (!impl)
@@ -132,7 +132,7 @@ public:
         return adopt_own(*new KBuffer(impl.release_nonnull()));
     }
 
-    static OwnPtr<KBuffer> try_create_with_bytes(ReadonlyBytes bytes, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
+    [[nodiscard]] static OwnPtr<KBuffer> try_create_with_bytes(ReadonlyBytes bytes, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
     {
         auto impl = KBufferImpl::try_create_with_bytes(bytes, access, name, strategy);
         if (!impl)
@@ -140,30 +140,30 @@ public:
         return adopt_own(*new KBuffer(impl.release_nonnull()));
     }
 
-    static KBuffer create_with_size(size_t size, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
+    [[nodiscard]] static KBuffer create_with_size(size_t size, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
     {
         return KBuffer(KBufferImpl::create_with_size(size, access, name, strategy));
     }
 
-    static KBuffer copy(const void* data, size_t size, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer")
+    [[nodiscard]] static KBuffer copy(const void* data, size_t size, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer")
     {
         return KBuffer(KBufferImpl::copy(data, size, access, name));
     }
 
-    bool is_null() const { return !m_impl; }
+    [[nodiscard]] bool is_null() const { return !m_impl; }
 
-    u8* data() { return m_impl ? m_impl->data() : nullptr; }
-    const u8* data() const { return m_impl ? m_impl->data() : nullptr; }
-    size_t size() const { return m_impl ? m_impl->size() : 0; }
-    size_t capacity() const { return m_impl ? m_impl->capacity() : 0; }
+    [[nodiscard]] u8* data() { return m_impl ? m_impl->data() : nullptr; }
+    [[nodiscard]] const u8* data() const { return m_impl ? m_impl->data() : nullptr; }
+    [[nodiscard]] size_t size() const { return m_impl ? m_impl->size() : 0; }
+    [[nodiscard]] size_t capacity() const { return m_impl ? m_impl->capacity() : 0; }
 
-    void* end_pointer() { return data() + size(); }
-    const void* end_pointer() const { return data() + size(); }
+    [[nodiscard]] void* end_pointer() { return data() + size(); }
+    [[nodiscard]] const void* end_pointer() const { return data() + size(); }
 
     void set_size(size_t size) { m_impl->set_size(size); }
 
-    const KBufferImpl& impl() const { return *m_impl; }
-    RefPtr<KBufferImpl> take_impl() { return move(m_impl); }
+    [[nodiscard]] const KBufferImpl& impl() const { return *m_impl; }
+    [[nodiscard]] RefPtr<KBufferImpl> take_impl() { return move(m_impl); }
 
     KBuffer(const ByteBuffer& buffer, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer")
         : m_impl(KBufferImpl::copy(buffer.data(), buffer.size(), access, name))

--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -141,27 +141,27 @@ public:
 
     [[nodiscard]] bool is_error() const { return m_is_error; }
 
-    ALWAYS_INLINE KResult error() const
+    [[nodiscard]] ALWAYS_INLINE KResult error() const
     {
         ASSERT(m_is_error);
         return m_error;
     }
 
-    KResult result() const { return m_is_error ? m_error : KSuccess; }
+    [[nodiscard]] KResult result() const { return m_is_error ? m_error : KSuccess; }
 
-    ALWAYS_INLINE T& value()
+    [[nodiscard]] ALWAYS_INLINE T& value()
     {
         ASSERT(!m_is_error);
         return *reinterpret_cast<T*>(&m_storage);
     }
 
-    ALWAYS_INLINE const T& value() const
+    [[nodiscard]] ALWAYS_INLINE const T& value() const
     {
         ASSERT(!m_is_error);
         return *reinterpret_cast<T*>(&m_storage);
     }
 
-    ALWAYS_INLINE T release_value()
+    [[nodiscard]] ALWAYS_INLINE T release_value()
     {
         ASSERT(!m_is_error);
         ASSERT(m_have_storage);

--- a/Kernel/Lock.h
+++ b/Kernel/Lock.h
@@ -58,10 +58,10 @@ public:
     void unlock();
     [[nodiscard]] Mode force_unlock_if_locked(u32&);
     void restore_lock(Mode, u32);
-    bool is_locked() const { return m_mode != Mode::Unlocked; }
+    [[nodiscard]] bool is_locked() const { return m_mode != Mode::Unlocked; }
     void clear_waiters();
 
-    const char* name() const { return m_name; }
+    [[nodiscard]] const char* name() const { return m_name; }
 
     static const char* mode_to_string(Mode mode)
     {
@@ -149,10 +149,10 @@ public:
         : m_resource(move(resource))
     {
     }
-    Lock& lock() { return m_lock; }
-    T& resource() { return m_resource; }
+    [[nodiscard]] Lock& lock() { return m_lock; }
+    [[nodiscard]] T& resource() { return m_resource; }
 
-    T lock_and_copy()
+    [[nodiscard]] T lock_and_copy()
     {
         LOCKER(m_lock);
         return m_resource;

--- a/Kernel/PhysicalAddress.h
+++ b/Kernel/PhysicalAddress.h
@@ -37,18 +37,18 @@ public:
     {
     }
 
-    PhysicalAddress offset(FlatPtr o) const { return PhysicalAddress(m_address + o); }
-    FlatPtr get() const { return m_address; }
+    [[nodiscard]] PhysicalAddress offset(FlatPtr o) const { return PhysicalAddress(m_address + o); }
+    [[nodiscard]] FlatPtr get() const { return m_address; }
     void set(FlatPtr address) { m_address = address; }
     void mask(FlatPtr m) { m_address &= m; }
 
-    bool is_null() const { return m_address == 0; }
+    [[nodiscard]] bool is_null() const { return m_address == 0; }
 
-    u8* as_ptr() { return reinterpret_cast<u8*>(m_address); }
-    const u8* as_ptr() const { return reinterpret_cast<const u8*>(m_address); }
+    [[nodiscard]] u8* as_ptr() { return reinterpret_cast<u8*>(m_address); }
+    [[nodiscard]] const u8* as_ptr() const { return reinterpret_cast<const u8*>(m_address); }
 
-    PhysicalAddress page_base() const { return PhysicalAddress(m_address & 0xfffff000); }
-    FlatPtr offset_in_page() const { return PhysicalAddress(m_address & 0xfff).get(); }
+    [[nodiscard]] PhysicalAddress page_base() const { return PhysicalAddress(m_address & 0xfffff000); }
+    [[nodiscard]] FlatPtr offset_in_page() const { return PhysicalAddress(m_address & 0xfff).get(); }
 
     bool operator==(const PhysicalAddress& other) const { return m_address == other.m_address; }
     bool operator!=(const PhysicalAddress& other) const { return m_address != other.m_address; }

--- a/Kernel/StdLib.h
+++ b/Kernel/StdLib.h
@@ -34,8 +34,8 @@ namespace Syscall {
 struct StringArgument;
 }
 
-String copy_string_from_user(const char*, size_t);
-String copy_string_from_user(Userspace<const char*>, size_t);
+[[nodiscard]] String copy_string_from_user(const char*, size_t);
+[[nodiscard]] String copy_string_from_user(Userspace<const char*>, size_t);
 
 [[nodiscard]] Optional<u32> user_atomic_fetch_add_relaxed(volatile u32* var, u32 val);
 [[nodiscard]] Optional<u32> user_atomic_exchange_relaxed(volatile u32* var, u32 val);
@@ -54,18 +54,18 @@ extern "C" {
 [[nodiscard]] bool memset_user(void*, int, size_t);
 
 void* memcpy(void*, const void*, size_t);
-int strncmp(const char* s1, const char* s2, size_t n);
-char* strstr(const char* haystack, const char* needle);
-int strcmp(char const*, const char*);
-size_t strlen(const char*);
-size_t strnlen(const char*, size_t);
+[[nodiscard]] int strncmp(const char* s1, const char* s2, size_t n);
+[[nodiscard]] char* strstr(const char* haystack, const char* needle);
+[[nodiscard]] int strcmp(char const*, const char*);
+[[nodiscard]] size_t strlen(const char*);
+[[nodiscard]] size_t strnlen(const char*, size_t);
 void* memset(void*, int, size_t);
-int memcmp(const void*, const void*, size_t);
+[[nodiscard]] int memcmp(const void*, const void*, size_t);
 void* memmove(void* dest, const void* src, size_t n);
 const void* memmem(const void* haystack, size_t, const void* needle, size_t);
 
-inline u16 ntohs(u16 w) { return (w & 0xff) << 8 | ((w >> 8) & 0xff); }
-inline u16 htons(u16 w) { return (w & 0xff) << 8 | ((w >> 8) & 0xff); }
+[[nodiscard]] inline u16 ntohs(u16 w) { return (w & 0xff) << 8 | ((w >> 8) & 0xff); }
+[[nodiscard]] inline u16 htons(u16 w) { return (w & 0xff) << 8 | ((w >> 8) & 0xff); }
 }
 
 template<typename T>

--- a/Kernel/UserOrKernelBuffer.h
+++ b/Kernel/UserOrKernelBuffer.h
@@ -36,7 +36,7 @@
 
 namespace Kernel {
 
-class UserOrKernelBuffer {
+class [[nodiscard]] UserOrKernelBuffer {
 public:
     UserOrKernelBuffer() = delete;
 
@@ -61,10 +61,10 @@ public:
         return UserOrKernelBuffer(const_cast<u8*>((const u8*)userspace.unsafe_userspace_ptr()));
     }
 
-    bool is_kernel_buffer() const;
-    const void* user_or_kernel_ptr() const { return m_buffer; }
+    [[nodiscard]] bool is_kernel_buffer() const;
+    [[nodiscard]] const void* user_or_kernel_ptr() const { return m_buffer; }
 
-    UserOrKernelBuffer offset(ssize_t offset) const
+    [[nodiscard]] UserOrKernelBuffer offset(ssize_t offset) const
     {
         if (!m_buffer)
             return *this;
@@ -74,7 +74,7 @@ public:
         return offset_buffer;
     }
 
-    String copy_into_string(size_t size) const;
+    [[nodiscard]] String copy_into_string(size_t size) const;
     [[nodiscard]] bool write(const void* src, size_t offset, size_t len);
     [[nodiscard]] bool write(const void* src, size_t len)
     {

--- a/Kernel/VirtualAddress.h
+++ b/Kernel/VirtualAddress.h
@@ -42,11 +42,11 @@ public:
     {
     }
 
-    bool is_null() const { return m_address == 0; }
-    bool is_page_aligned() const { return (m_address & 0xfff) == 0; }
+    [[nodiscard]] bool is_null() const { return m_address == 0; }
+    [[nodiscard]] bool is_page_aligned() const { return (m_address & 0xfff) == 0; }
 
-    VirtualAddress offset(FlatPtr o) const { return VirtualAddress(m_address + o); }
-    FlatPtr get() const { return m_address; }
+    [[nodiscard]] VirtualAddress offset(FlatPtr o) const { return VirtualAddress(m_address + o); }
+    [[nodiscard]] FlatPtr get() const { return m_address; }
     void set(FlatPtr address) { m_address = address; }
     void mask(FlatPtr m) { m_address &= m; }
 
@@ -57,10 +57,10 @@ public:
     bool operator==(const VirtualAddress& other) const { return m_address == other.m_address; }
     bool operator!=(const VirtualAddress& other) const { return m_address != other.m_address; }
 
-    u8* as_ptr() { return reinterpret_cast<u8*>(m_address); }
-    const u8* as_ptr() const { return reinterpret_cast<const u8*>(m_address); }
+    [[nodiscard]] u8* as_ptr() { return reinterpret_cast<u8*>(m_address); }
+    [[nodiscard]] const u8* as_ptr() const { return reinterpret_cast<const u8*>(m_address); }
 
-    VirtualAddress page_base() const { return VirtualAddress(m_address & 0xfffff000); }
+    [[nodiscard]] VirtualAddress page_base() const { return VirtualAddress(m_address & 0xfffff000); }
 
 private:
     FlatPtr m_address { 0 };


### PR DESCRIPTION
Collection of commits to instrument more Kernel API's with [[nodiscard]].

- AK/Optional getters
- Kernel/StdLib.h C API functions.
- Kernel/Lock getters
- Kernel/KBuffer getters
- Kernel/UserOrKernelBuffer getters
- Kernel/KResult getters
- Kernel/PhysicalAddress getters
- Kernel/VirtualAddress getters