### PR TITLE
WindowServer: Add support for alpha channel based hit testing

### DIFF
--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -224,6 +224,7 @@ int main(int argc, char** argv)
     window->set_frameless(true);
     window->set_resizable(false);
     window->set_has_alpha_channel(true);
+    window->set_alpha_hit_threshold(1.0f);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto& root_widget = window->set_main_widget<MainFrame>();

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -147,6 +147,7 @@ void Window::show()
         m_frameless,
         m_accessory,
         m_opacity_when_windowless,
+        m_alpha_hit_threshold,
         m_base_size,
         m_size_increment,
         m_resize_aspect_ratio,
@@ -671,6 +672,20 @@ void Window::set_opacity(float opacity)
     if (!is_visible())
         return;
     WindowServerConnection::the().send_sync<Messages::WindowServer::SetWindowOpacity>(m_window_id, opacity);
+}
+
+void Window::set_alpha_hit_threshold(float threshold)
+{
+    if (threshold < 0.0f)
+        threshold = 0.0f;
+    else if (threshold > 1.0f)
+        threshold = 1.0f;
+    if (m_alpha_hit_threshold == threshold)
+        return;
+    m_alpha_hit_threshold = threshold;
+    if (!is_visible())
+        return;
+    WindowServerConnection::the().send_sync<Messages::WindowServer::SetWindowAlphaHitThreshold>(m_window_id, threshold);
 }
 
 void Window::set_hovered_widget(Widget* widget)

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -72,6 +72,9 @@ public:
     void set_opacity(float);
     float opacity() const { return m_opacity_when_windowless; }
 
+    void set_alpha_hit_threshold(float);
+    float alpha_hit_threshold() const { return m_alpha_hit_threshold; }
+
     WindowType window_type() const { return m_window_type; }
     void set_window_type(WindowType);
 
@@ -238,6 +241,7 @@ private:
     RefPtr<Gfx::Bitmap> m_custom_cursor;
     int m_window_id { 0 };
     float m_opacity_when_windowless { 1.0f };
+    float m_alpha_hit_threshold { 0.0f };
     RefPtr<Widget> m_main_widget;
     WeakPtr<Widget> m_focused_widget;
     WeakPtr<Widget> m_global_cursor_tracking_widget;

--- a/Userland/Libraries/LibGfx/ClassicWindowTheme.h
+++ b/Userland/Libraries/LibGfx/ClassicWindowTheme.h
@@ -52,6 +52,7 @@ public:
     {
         return compute_frame_colors(state, palette).uses_alpha();
     }
+    virtual float frame_alpha_hit_threshold(WindowState) const override { return 1.0f; }
 
 private:
     struct FrameColors {

--- a/Userland/Libraries/LibGfx/WindowTheme.h
+++ b/Userland/Libraries/LibGfx/WindowTheme.h
@@ -63,6 +63,7 @@ public:
     virtual Vector<IntRect> layout_buttons(WindowType, const IntRect& window_rect, const Palette&, size_t buttons) const = 0;
     virtual bool is_simple_rect_frame() const = 0;
     virtual bool frame_uses_alpha(WindowState, const Palette&) const = 0;
+    virtual float frame_alpha_hit_threshold(WindowState) const = 0;
 
 protected:
     WindowTheme() { }

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -463,6 +463,7 @@ OwnPtr<Messages::WindowServer::CreateWindowResponse> ClientConnection::handle(co
         window->recalculate_rect();
     }
     window->set_opacity(message.opacity());
+    window->set_alpha_hit_threshold(message.alpha_hit_threshold());
     window->set_size_increment(message.size_increment());
     window->set_base_size(message.base_size());
     window->set_resize_aspect_ratio(message.resize_aspect_ratio());
@@ -634,6 +635,17 @@ OwnPtr<Messages::WindowServer::SetWindowHasAlphaChannelResponse> ClientConnectio
     }
     it->value->set_has_alpha_channel(message.has_alpha_channel());
     return make<Messages::WindowServer::SetWindowHasAlphaChannelResponse>();
+}
+
+OwnPtr<Messages::WindowServer::SetWindowAlphaHitThresholdResponse> ClientConnection::handle(const Messages::WindowServer::SetWindowAlphaHitThreshold& message)
+{
+    auto it = m_windows.find(message.window_id());
+    if (it == m_windows.end()) {
+        did_misbehave("SetWindowAlphaHitThreshold: Bad window ID");
+        return {};
+    }
+    it->value->set_alpha_hit_threshold(message.threshold());
+    return make<Messages::WindowServer::SetWindowAlphaHitThresholdResponse>();
 }
 
 void ClientConnection::handle(const Messages::WindowServer::WM_SetActiveWindow& message)

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -120,6 +120,7 @@ private:
     virtual void handle(const Messages::WindowServer::WM_StartWindowResize&) override;
     virtual void handle(const Messages::WindowServer::WM_PopupWindowMenu&) override;
     virtual OwnPtr<Messages::WindowServer::SetWindowHasAlphaChannelResponse> handle(const Messages::WindowServer::SetWindowHasAlphaChannel&) override;
+    virtual OwnPtr<Messages::WindowServer::SetWindowAlphaHitThresholdResponse> handle(const Messages::WindowServer::SetWindowAlphaHitThreshold&) override;
     virtual OwnPtr<Messages::WindowServer::MoveWindowToFrontResponse> handle(const Messages::WindowServer::MoveWindowToFront&) override;
     virtual OwnPtr<Messages::WindowServer::SetFullscreenResponse> handle(const Messages::WindowServer::SetFullscreen&) override;
     virtual void handle(const Messages::WindowServer::AsyncSetWallpaper&) override;

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -873,4 +873,20 @@ bool Window::is_descendant_of(Window& window) const
     return false;
 }
 
+bool Window::hit_test(const Gfx::IntPoint& point, bool include_frame) const
+{
+    if (!frame().rect().contains(point))
+        return false;
+    if (!rect().contains(point)) {
+        if (include_frame)
+            return frame().hit_test(point);
+        return false;
+    }
+    u8 threshold = alpha_hit_threshold() * 255;
+    if (threshold == 0 || !m_backing_store || !m_backing_store->has_alpha_channel())
+        return true;
+    auto color = m_backing_store->get_pixel(point.translated(-rect().location()));
+    return color.alpha() >= threshold;
+}
+
 }

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -145,6 +145,13 @@ public:
     float opacity() const { return m_opacity; }
     void set_opacity(float);
 
+    float alpha_hit_threshold() const { return m_alpha_hit_threshold; }
+    void set_alpha_hit_threshold(float threshold)
+    {
+        m_alpha_hit_threshold = threshold;
+    }
+    bool hit_test(const Gfx::IntPoint&, bool include_frame = true) const;
+
     int x() const { return m_rect.x(); }
     int y() const { return m_rect.y(); }
     int width() const { return m_rect.width(); }
@@ -365,6 +372,7 @@ private:
     int m_window_id { -1 };
     i32 m_client_id { -1 };
     float m_opacity { 1 };
+    float m_alpha_hit_threshold { 0.0f };
     Gfx::IntSize m_size_increment;
     Gfx::IntSize m_base_size;
     NonnullRefPtr<Gfx::Bitmap> m_icon;

--- a/Userland/Services/WindowServer/WindowFrame.h
+++ b/Userland/Services/WindowServer/WindowFrame.h
@@ -90,6 +90,8 @@ public:
 
     void theme_changed();
 
+    bool hit_test(const Gfx::IntPoint&) const;
+
 private:
     void paint_simple_rect_shadow(Gfx::Painter&, const Gfx::IntRect&, const Gfx::Bitmap&) const;
     void paint_notification_frame(Gfx::Painter&);

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -41,6 +41,7 @@ endpoint WindowServer = 2
         bool frameless,
         bool accessory,
         float opacity,
+        float alpha_hit_threshold,
         Gfx::IntSize base_size,
         Gfx::IntSize size_increment,
         Optional<Gfx::IntSize> resize_aspect_ratio,
@@ -69,6 +70,8 @@ endpoint WindowServer = 2
 
     SetGlobalCursorTracking(i32 window_id, bool enabled) => ()
     SetWindowOpacity(i32 window_id, float opacity) => ()
+
+    SetWindowAlphaHitThreshold(i32 window_id, float threshold) => ()
 
     SetWindowBackingStore(i32 window_id, i32 bpp, i32 pitch, IPC::File anon_file, i32 serial, bool has_alpha_channel, Gfx::IntSize size, bool flush_immediately) => ()
 


### PR DESCRIPTION
This enables implementing non-rectangular window shapes, including
non-rectangular window frames.