### PR TITLE
CMake: Add 'setup-and-run' target to perform all prereqs and run the image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,18 @@ add_custom_target(run
     USES_TERMINAL
 )
 
+# This can currently only be implemented by ordered commands
+# as cmake doesn't support inter dependency ordering, and we
+# would like to avoid inject dependencies on the existing
+# custom commands to allow people to run commands adhoc with
+# out forcing re-builds when they might not want them.
+add_custom_target(setup-and-run
+    COMMAND ${CMAKE_MAKE_PROGRAM} install
+    COMMAND ${CMAKE_MAKE_PROGRAM} image
+    COMMAND ${CMAKE_MAKE_PROGRAM} run
+    USES_TERMINAL
+)
+
 add_custom_target(image
     DEPENDS qemu-image
 )


### PR DESCRIPTION
Running 'ninja && ninja install && ninja image && ninja run` is mildly annoying.
I got tired, and came up with this instead, which does the right thing
and I don't have to type out the incantation every time.

I'm not in love with the name, any suggestions would be welcome.