### PR TITLE
Kernel: Avoid some un-necessary copies coming from range based for loops

### DIFF
--- a/Kernel/Interrupts/InterruptManagement.cpp
+++ b/Kernel/Interrupts/InterruptManagement.cpp
@@ -117,7 +117,7 @@ RefPtr<IRQController> InterruptManagement::get_responsible_irq_controller(u8 int
     if (m_interrupt_controllers.size() == 1 && m_interrupt_controllers[0]->type() == IRQControllerType::i8259) {
         return m_interrupt_controllers[0];
     }
-    for (auto irq_controller : m_interrupt_controllers) {
+    for (auto& irq_controller : m_interrupt_controllers) {
         if (irq_controller->gsi_base() <= interrupt_vector)
             if (!irq_controller->is_hard_disabled())
                 return irq_controller;

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -195,7 +195,7 @@ void MemoryManager::parse_memory_map()
     auto* mmap_begin = reinterpret_cast<multiboot_memory_map_t*>(low_physical_to_virtual(multiboot_info_ptr->mmap_addr));
     auto* mmap_end = reinterpret_cast<multiboot_memory_map_t*>(low_physical_to_virtual(multiboot_info_ptr->mmap_addr) + multiboot_info_ptr->mmap_length);
 
-    for (auto used_range : m_used_memory_ranges) {
+    for (auto& used_range : m_used_memory_ranges) {
         klog() << "MM: " << used_range;
     }
 
@@ -255,7 +255,7 @@ void MemoryManager::parse_memory_map()
 
             // Skip used memory ranges.
             bool should_skip = false;
-            for (auto used_range : m_used_memory_ranges) {
+            for (auto& used_range : m_used_memory_ranges) {
                 if (addr.get() >= used_range.start.get() && addr.get() <= used_range.end.get()) {
                     should_skip = true;
                     break;


### PR DESCRIPTION
- The irq_controller was getting add_ref/released needlessly during enumeration.

- Used ranges were also getting needlessly copied.