### PR TITLE
WindowServer+LibGUI: Variable minimum window sizes

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -149,6 +149,7 @@ void Window::show()
         m_opacity_when_windowless,
         m_base_size,
         m_size_increment,
+        m_minimum_size_when_windowless,
         m_resize_aspect_ratio,
         (i32)m_window_type,
         m_title_when_windowless,
@@ -258,6 +259,23 @@ void Window::set_rect(const Gfx::IntRect& a_rect)
         m_main_widget->resize(window_rect.size());
 }
 
+Gfx::IntSize Window::minimum_size() const
+{
+    if (!is_visible())
+        return m_minimum_size_when_windowless;
+
+    return WindowServerConnection::the().send_sync<Messages::WindowServer::GetWindowMinimumSize>(m_window_id)->size();
+}
+
+void Window::set_minimum_size(const Gfx::IntSize& size)
+{
+    m_minimum_size_modified = true;
+    m_minimum_size_when_windowless = size;
+
+    if (is_visible())
+        WindowServerConnection::the().send_sync<Messages::WindowServer::SetWindowMinimumSize>(m_window_id, size);
+}
+
 void Window::center_on_screen()
 {
     auto window_rect = rect();
@@ -277,6 +295,14 @@ void Window::center_within(const Window& other)
 void Window::set_window_type(WindowType window_type)
 {
     m_window_type = window_type;
+
+    if (!m_minimum_size_modified) {
+        // Apply minimum size defaults.
+        if (m_window_type == WindowType::Normal)
+            m_minimum_size_when_windowless = { 50, 50 };
+        else
+            m_minimum_size_when_windowless = { 1, 1 };
+    }
 }
 
 void Window::set_cursor(Gfx::StandardCursor cursor)

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -105,6 +105,10 @@ public:
 
     Gfx::IntPoint position() const { return rect().location(); }
 
+    Gfx::IntSize minimum_size() const;
+    void set_minimum_size(const Gfx::IntSize&);
+    void set_minimum_size(int width, int height) { set_minimum_size({ width, height }); }
+
     void move_to(int x, int y) { move_to({ x, y }); }
     void move_to(const Gfx::IntPoint& point) { set_rect({ point, size() }); }
 
@@ -244,6 +248,8 @@ private:
     WeakPtr<Widget> m_automatic_cursor_tracking_widget;
     WeakPtr<Widget> m_hovered_widget;
     Gfx::IntRect m_rect_when_windowless;
+    Gfx::IntSize m_minimum_size_when_windowless { 50, 50 };
+    bool m_minimum_size_modified { false };
     String m_title_when_windowless;
     Vector<Gfx::IntRect, 32> m_pending_paint_event_rects;
     Gfx::IntSize m_size_increment;

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -109,6 +109,8 @@ private:
     virtual void handle(const Messages::WindowServer::StartWindowResize&) override;
     virtual OwnPtr<Messages::WindowServer::SetWindowRectResponse> handle(const Messages::WindowServer::SetWindowRect&) override;
     virtual OwnPtr<Messages::WindowServer::GetWindowRectResponse> handle(const Messages::WindowServer::GetWindowRect&) override;
+    virtual OwnPtr<Messages::WindowServer::SetWindowMinimumSizeResponse> handle(const Messages::WindowServer::SetWindowMinimumSize&) override;
+    virtual OwnPtr<Messages::WindowServer::GetWindowMinimumSizeResponse> handle(const Messages::WindowServer::GetWindowMinimumSize&) override;
     virtual OwnPtr<Messages::WindowServer::GetWindowRectInMenubarResponse> handle(const Messages::WindowServer::GetWindowRectInMenubar&) override;
     virtual void handle(const Messages::WindowServer::InvalidateRect&) override;
     virtual void handle(const Messages::WindowServer::DidFinishPainting&) override;

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -162,8 +162,12 @@ public:
     void set_rect(const Gfx::IntRect&);
     void set_rect(int x, int y, int width, int height) { set_rect({ x, y, width, height }); }
     void set_rect_without_repaint(const Gfx::IntRect&);
-    void apply_minimum_size(Gfx::IntRect&);
+    bool apply_minimum_size(Gfx::IntRect&);
     void nudge_into_desktop(bool force_titlebar_visible = true);
+
+    Gfx::IntSize minimum_size() const { return m_minimum_size; }
+    void set_minimum_size(const Gfx::IntSize&);
+    void set_minimum_size(int width, int height) { set_minimum_size({ width, height }); }
 
     void set_taskbar_rect(const Gfx::IntRect&);
     const Gfx::IntRect& taskbar_rect() const { return m_taskbar_rect; }
@@ -182,6 +186,8 @@ public:
     void invalidate(bool with_frame = true, bool re_render_frame = false);
     void invalidate(const Gfx::IntRect&, bool with_frame = false);
     bool invalidate_no_notify(const Gfx::IntRect& rect, bool with_frame = false);
+
+    void refresh_client_size();
 
     void prepare_dirty_rects();
     void clear_dirty_rects();
@@ -367,6 +373,7 @@ private:
     float m_opacity { 1 };
     Gfx::IntSize m_size_increment;
     Gfx::IntSize m_base_size;
+    Gfx::IntSize m_minimum_size { 1, 1 };
     NonnullRefPtr<Gfx::Bitmap> m_icon;
     RefPtr<Cursor> m_cursor;
     WindowFrame m_frame;

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -43,6 +43,7 @@ endpoint WindowServer = 2
         float opacity,
         Gfx::IntSize base_size,
         Gfx::IntSize size_increment,
+        Gfx::IntSize minimum_size,
         Optional<Gfx::IntSize> resize_aspect_ratio,
         i32 type,
         [UTF8] String title,
@@ -57,6 +58,9 @@ endpoint WindowServer = 2
 
     SetWindowRect(i32 window_id, Gfx::IntRect rect) => (Gfx::IntRect rect)
     GetWindowRect(i32 window_id) => (Gfx::IntRect rect)
+
+    SetWindowMinimumSize(i32 window_id, Gfx::IntSize size) => ()
+    GetWindowMinimumSize(i32 window_id) => (Gfx::IntSize size)
 
     GetWindowRectInMenubar(i32 window_id) => (Gfx::IntRect rect)
 


### PR DESCRIPTION
Minimum window size can now be customised and set at runtime  via the `SetWindowMinimumSize` `WindowServer` message and the `set_minimum_size` `LibGUI::Window` method. Windows are automatically resized if their minimum size is set larger than the current window size. The default minimum size remains at 50x50. Addresses #5357.