### PR TITLE
Small stuff: Outdated copypaste, nullptr deref, typo

### DIFF
--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -36,12 +36,9 @@ ssize_t Process::sys$readv(int fd, Userspace<const struct iovec*> iov, int iov_c
     if (iov_count < 0)
         return -EINVAL;
 
-    {
-        Checked checked_iov_count = sizeof(iovec);
-        checked_iov_count *= iov_count;
-        if (checked_iov_count.has_overflow())
-            return -EFAULT;
-    }
+    // Arbitrary pain threshold.
+    if (iov_count > (int)MiB)
+        return -EFAULT;
 
     u64 total_length = 0;
     Vector<iovec, 32> vecs;

--- a/Userland/Libraries/LibC/netinet/ip_icmp.h
+++ b/Userland/Libraries/LibC/netinet/ip_icmp.h
@@ -50,7 +50,7 @@ struct icmphdr {
 #define ICMP_SOURCE_QUENCH 4   // Source Quench
 #define ICMP_REDIRECT 5        // Redirect
 #define ICMP_ECHO 8            // Echo Request
-#define ICMP_TIME_EXCEEDED 11  // Time Rxceeded
+#define ICMP_TIME_EXCEEDED 11  // Time Exceeded
 #define ICMP_PARAMETERPROB 12  // Parameter Problem
 #define ICMP_TIMESTAMP 13      // Timestamp Request
 #define ICMP_TIMESTAMPREPLY 14 // Timestamp Reply

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -900,9 +900,12 @@ int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int)
 
 int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void))
 {
-    __pthread_fork_atfork_register_prepare(prepare);
-    __pthread_fork_atfork_register_parent(parent);
-    __pthread_fork_atfork_register_child(child);
+    if (prepare)
+        __pthread_fork_atfork_register_prepare(prepare);
+    if (parent)
+        __pthread_fork_atfork_register_parent(parent);
+    if (child)
+        __pthread_fork_atfork_register_child(child);
     return 0;
 }
 


### PR DESCRIPTION
Most significantly: The `readv` bug got introduced by copying code that [already was fixed on master](https://github.com/SerenityOS/serenity/commit/c6027ed7cce901dc0d2b6f68002a911178ae587f) but apparently was copy-pasted before the fix-commit landed on master.

In my eyes, this highlights why "DRY" exists: Define stuff (magic numbers, algorithms, checks) in a single place, so that when you fix it you can make sure to fix *all* instances. Even those that are currently in-flight in a different PR! :)