### PR TITLE
Run, LibGUI: Run command history + ComboBox list window size fixes

### DIFF
--- a/Userland/Applications/Run/Run.gml
+++ b/Userland/Applications/Run/Run.gml
@@ -31,7 +31,7 @@
             text_alignment: "CenterLeft"
         }
 
-        @GUI::TextBox {
+        @GUI::ComboBox {
             name: "path"
         }
     }

--- a/Userland/Applications/Run/RunWindow.h
+++ b/Userland/Applications/Run/RunWindow.h
@@ -27,8 +27,9 @@
 #pragma once
 
 #include <LibGUI/Button.h>
+#include <LibGUI/ComboBox.h>
 #include <LibGUI/ImageWidget.h>
-#include <LibGUI/TextBox.h>
+#include <LibGUI/ItemListModel.h>
 #include <LibGUI/Window.h>
 
 class RunWindow final : public GUI::Window {
@@ -45,9 +46,16 @@ private:
     bool run_as_command(const String& run_input);
     bool run_via_launch(const String& run_input);
 
+    String history_file_path();
+    void load_history();
+    void save_history();
+
+    Vector<String> m_path_history;
+    NonnullRefPtr<GUI::ItemListModel<String>> m_path_history_model;
+
     RefPtr<GUI::ImageWidget> m_icon_image_widget;
     RefPtr<GUI::Button> m_ok_button;
     RefPtr<GUI::Button> m_cancel_button;
     RefPtr<GUI::Button> m_browse_button;
-    RefPtr<GUI::TextBox> m_path_text_box;
+    RefPtr<GUI::ComboBox> m_path_combo_box;
 };

--- a/Userland/Applications/Run/main.cpp
+++ b/Userland/Applications/Run/main.cpp
@@ -35,14 +35,14 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio recvfd sendfd thread accept cpath rpath unix fattr proc exec", nullptr) < 0) {
+    if (pledge("stdio recvfd sendfd thread accept cpath rpath wpath unix fattr proc exec", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
 
     auto app = GUI::Application::construct(argc, argv);
 
-    if (pledge("stdio recvfd sendfd thread accept rpath unix proc exec", nullptr) < 0) {
+    if (pledge("stdio recvfd sendfd thread accept cpath rpath wpath unix proc exec", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -244,6 +244,13 @@ void ComboBox::open()
         // change the list view's selected item without triggering a change to it.
         m_list_view->set_cursor(m_selected_index.value(), AbstractView::SelectionUpdate::Set);
     }
+
+    // Set the minimum minimum height of the list window to the height of three
+    // items or the row count, whichever is smaller, plus the frame thickness.
+    // This prevents the list from becoming infinitesimally small when pushed
+    // up against the screen edge.
+    m_list_window->set_minimum_size(1, min(3, model()->row_count()) * m_list_view->item_height() + m_list_view->frame_thickness() * 2);
+
     m_list_window->set_rect(list_window_rect);
     m_list_window->show();
 }


### PR DESCRIPTION
Rolling these two commits into one PR as I came across the interesting `ComboBox` behaviour whilst implementing the Run history, and more or less worked on the two simultaneously. Can split into separate PRs if desired :)

- Run now stores successfully ran command history in a simple text file under `.config/RunHistory.txt` and presents it as a `ComboBox`. The last 25 successfully ran inputs are stored, with the newest entries being inserted at the top. If the command ran is already in the history, it is moved to the top.
- `LibGUI::ComboBox` now explicitly sets a minimum list window size using the new mechanism established in #5360. The previous behaviour was a minimum list window size of 50px, even though the inner list widget may've not been that tall - this resulted in unpainted area in the list window. The minimum height is now set to the total height of all the items in the list, or the height of three items, whichever is smaller. This calculation for minimum size, rather than just setting to `{1, 1}`, is needed to prevent the list window from becoming infinitesimally small when opened near the screen edge. 😁