### PR TITLE
Ports: Use new curl domain

### DIFF
--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -3,8 +3,8 @@ port=curl
 version=7.65.3
 useconfigure=true
 configopts="--disable-threaded-resolver"
-files="https://curl.haxx.se/download/curl-${version}.tar.bz2 curl-${version}.tar.bz2
-https://curl.haxx.se/download/curl-${version}.tar.bz2.asc curl-${version}.tar.bz2.asc"
+files="https://curl.se/download/curl-${version}.tar.bz2 curl-${version}.tar.bz2
+https://curl.se/download/curl-${version}.tar.bz2.asc curl-${version}.tar.bz2.asc"
 
 depends=zlib
 auth_type="sig"


### PR DESCRIPTION
curl switched it's domain to curl.se last year:
https://daniel.haxx.se/blog/2020/11/04/the-journey-to-a-curl-domain/

I think we should follow this change and adapt the new domain name.