### PR TITLE
Ports: Add bison 1.25

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -7,6 +7,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`bash`](bash/)                | GNU Bash                                      | 5.0               | https://www.gnu.org/software/bash/                    |
 | [`bc`](bc/)                    | bc                                            | 2.5.1             | https://github.com/gavinhoward/bc                     |
 | [`binutils`](binutils/)        | GNU Binutils                                  | 2.32              | https://www.gnu.org/software/binutils/                |
+| [`bison`](bison/)              | GNU Bison                                     | 1.25              | https://www.gnu.org/software/bison/                   |
 | [`byacc`](byacc/)              | Berkeley Yacc                                 | 20191125          | https://invisible-island.net/byacc/byacc.html         |
 | [`c-ray`](c-ray/)              | C-Ray                                         |                   | https://github.com/vkoskiv/c-ray                      |
 | [`cmake`](cmake/)              | CMake                                         | 3.19.4            | https://cmake.org/                                    |

--- a/Ports/bison/package.sh
+++ b/Ports/bison/package.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=bison
+version=1.25
+useconfigure=true
+configopts="--prefix=$SERENITY_ROOT/Build/Root/usr/local"
+files="https://ftp.gnu.org/gnu/bison/bison-${version}.tar.gz bison-${version}.tar.gz 65f577d0f8ffaf61ae21c23c0918d225"
+auth_type="md5"


### PR DESCRIPTION
Hi. I wanted to see how ports work so whilst in the rabbit hole of trying to port ImageMagick i found something that worked with little effort. Admittedly, the release is very old (1996-05-11).

bison -h works. Not tried with any grammar files