### PR TITLE
Ports: Add libtiff

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -35,6 +35,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`libffi`](libffi/)            | libffi                                        | 3.3               | https://www.sourceware.org/libffi/                    |
 | [`libiconv`](libiconv/)        | GNU libiconv                                  | 1.16              | https://www.gnu.org/software/libiconv/                |
 | [`libpuffy`](libpuffy/)        | libpuffy                                      | 1.0               | https://github.com/ibara/libpuffy                     |
+| [`libtiff`](libtiff/)          | libtiff                                       | 4.2.0             | http://www.libtiff.org/                               |
 | [`links`](links/)              | Links web browser                             | 2.19              | http://links.twibright.com/                           |
 | [`lua`](lua/)                  | Lua                                           | 5.3.5             | https://www.lua.org/                                  |
 | [`m4`](m4/)                    | GNU M4                                        | 1.4.9             | https://www.gnu.org/software/m4/                      |

--- a/Ports/libtiff/package.sh
+++ b/Ports/libtiff/package.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=tiff
+version=4.2.0
+useconfigure=true
+files="http://download.osgeo.org/libtiff/tiff-${version}.tar.gz tiff-${version}.tar.gz
+http://download.osgeo.org/libtiff/tiff-${version}.tar.gz.sig tiff-${version}.tar.gz.sig"
+auth_type="sig"
+auth_import_key="EBDFDB21B020EE8FD151A88DE301047DE1198975"
+auth_opts="tiff-${version}.tar.gz.sig tiff-${version}.tar.gz"

--- a/Ports/libtiff/patches/system-detect.patch
+++ b/Ports/libtiff/patches/system-detect.patch
@@ -1,0 +1,11 @@
+--- tiff-4.2.0/config/config.sub.orig	2021-02-16 23:55:55.240259207 +0000
++++ tiff-4.2.0/config/config.sub	2021-02-16 23:55:59.792227377 +0000
+@@ -1393,7 +1393,7 @@
+ 	      | -os2* | -vos* | -palmos* | -uclinux* | -nucleus* \
+ 	      | -morphos* | -superux* | -rtmk* | -rtmk-nova* | -windiss* \
+ 	      | -powermax* | -dnix* | -nx6 | -nx7 | -sei* | -dragonfly* \
+-	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es* | -tirtos*)
++	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es* | -tirtos* | -serenity* )
+ 	# Remember, each alternative MUST END IN *, to match a version number.
+ 		;;
+ 	-qnx*)


### PR DESCRIPTION
programs build and run to the extent that they show the --help. Didn't test if they work with actual tiffs as unable to build curl to get sample tiffs.