### PR TITLE
Ports: Add tinyscheme 1.42

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -66,6 +66,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`stress-ng`](stress-ng/)      | stress-ng                                     | 0.11.23           | https://github.com/ColinIanKing/stress-ng             |
 | [`termcap`](termcap/)          | GNU termcap                                   | 1.3.1             | https://www.gnu.org/software/termutils/               |
 | [`tinycc`](tinycc/)            | Tiny C Compiler (TinyCC)                      | dev               | https://github.com/TinyCC/tinycc                      |
+| [`tinyscheme`](tinyscheme/)    | TinyScheme Interpreter                        | 1.42              | https://sourceforge.net/projects/tinyscheme/          |
 | [`tr`](tr/)                    | tr (OpenBSD)                                  | 6.7               | https://github.com/ibara/libpuffy                     |
 | [`vim`](vim/)                  | Vim                                           |                   | https://www.vim.org/                                  |
 | [`vttest`](vttest/)            | vttest                                        | 20200610          | https://invisible-island.net/vttest/                  |

--- a/Ports/tinyscheme/package.sh
+++ b/Ports/tinyscheme/package.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=tinyscheme
+version=1.42
+files="https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinyscheme-${version}/tinyscheme-${version}.tar.gz tinyscheme-${version}.tar.gz 273ac5ffe5305986b329e9045f2aea89"
+
+useconfigure=false
+
+build() {
+    run make scheme CC="i686-pc-serenity-gcc -fpic -pedantic" SYS_LIBS= FEATURES='-DUSE_NO_FEATURES=1 -DInitFile=\"/usr/local/include/tinyscheme/init.scm\"'
+}
+
+install() {
+    run mkdir -p "${SERENITY_ROOT}/Build/Root/usr/local/bin"
+    run cp scheme "${SERENITY_ROOT}/Build/Root/usr/local/bin/tinyscheme"
+    run mkdir -p "${SERENITY_ROOT}/Build/Root/usr/local/include/tinyscheme"
+    run cp init.scm "${SERENITY_ROOT}/Build/Root/usr/local/include/tinyscheme/init.scm"
+}


### PR DESCRIPTION
Thought it would be nifty to be able to work through the examples and exercises of [Structure and Interpretation of Computer Programs](https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/book.html) from Serenity :)

![tinyscheme repl](https://i.imgur.com/bVMQolm.png)


Let me know if the port can be improved in any way, this is my first contribution.