### PR TITLE
LibWeb: IDL constructors :^)

### DIFF
--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -125,8 +125,6 @@ struct Function {
 
     size_t length() const
     {
-        // FIXME: This seems to produce a length that is way over what it's supposed to be.
-        //        For example, getElementsByTagName has its length set to 20 when it should be 1.
         size_t length = 0;
         for (auto& parameter : parameters) {
             if (!parameter.optional)
@@ -990,10 +988,10 @@ void @prototype_class@::initialize(JS::GlobalObject& global_object)
         auto function_generator = generator.fork();
         function_generator.set("function.name", function.name);
         function_generator.set("function.name:snakecase", snake_name(function.name));
-        function_generator.set("function.name:length", String::number(function.name.length()));
+        function_generator.set("function.length", String::number(function.length()));
 
         function_generator.append(R"~~~(
-    define_native_function("@function.name@", @function.name:snakecase@, @function.name:length@, default_attributes);
+    define_native_function("@function.name@", @function.name:snakecase@, @function.length@, default_attributes);
 )~~~");
     }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -36,6 +36,7 @@
 #include <LibCore/Forward.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/Bindings/ScriptExecutionContext.h>
+#include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/CSS/StyleResolver.h>
 #include <LibWeb/CSS/StyleSheet.h>
 #include <LibWeb/CSS/StyleSheetList.h>
@@ -60,7 +61,15 @@ class Document
 public:
     using WrapperType = Bindings::DocumentWrapper;
 
-    static NonnullRefPtr<Document> create(const URL& url = "about:blank") { return adopt(*new Document(url)); }
+    static NonnullRefPtr<Document> create(const URL& url = "about:blank")
+    {
+        return adopt(*new Document(url));
+    }
+    static NonnullRefPtr<Document> create_with_global_object(Bindings::WindowObject&)
+    {
+        return Document::create();
+    }
+
     virtual ~Document() override;
 
     bool should_invalidate_styles_on_attribute_changes() const { return m_should_invalidate_styles_on_attribute_changes; }

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -1,5 +1,7 @@
 interface Document : Node {
 
+    constructor();
+
     readonly attribute DOMImplementation implementation;
 
     readonly attribute DOMString characterSet;

--- a/Userland/Libraries/LibWeb/DOM/Event.h
+++ b/Userland/Libraries/LibWeb/DOM/Event.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/DOM/EventTarget.h>
 
@@ -63,6 +64,10 @@ public:
     static NonnullRefPtr<Event> create(const FlyString& event_name)
     {
         return adopt(*new Event(event_name));
+    }
+    static NonnullRefPtr<Event> create_with_global_object(Bindings::WindowObject&, const FlyString& event_name)
+    {
+        return Event::create(event_name);
     }
 
     virtual ~Event() { }

--- a/Userland/Libraries/LibWeb/DOM/Event.idl
+++ b/Userland/Libraries/LibWeb/DOM/Event.idl
@@ -1,5 +1,8 @@
 interface Event {
 
+    // FIXME: second parameter: 'optional EventInit eventInitDict = {}'
+    constructor(DOMString type);
+
     readonly attribute DOMString type;
     readonly attribute EventTarget? target;
     readonly attribute EventTarget? srcTarget;

--- a/Userland/Libraries/LibWeb/DOM/Range.h
+++ b/Userland/Libraries/LibWeb/DOM/Range.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/RefCounted.h>
+#include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/DOM/Node.h>
 
@@ -45,6 +46,10 @@ public:
     static NonnullRefPtr<Range> create(Node& start_container, size_t start_offset, Node& end_container, size_t end_offset)
     {
         return adopt(*new Range(start_container, start_offset, end_container, end_offset));
+    }
+    static NonnullRefPtr<Range> create_with_global_object(Bindings::WindowObject& window)
+    {
+        return Range::create(window.impl());
     }
 
     // FIXME: There are a ton of methods missing here.

--- a/Userland/Libraries/LibWeb/DOM/Range.idl
+++ b/Userland/Libraries/LibWeb/DOM/Range.idl
@@ -1,5 +1,7 @@
 interface Range {
 
+    constructor();
+
     readonly attribute Node startContainer;
     readonly attribute unsigned long startOffset;
     readonly attribute Node endContainer;

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -30,6 +30,7 @@
 #include <AK/RefCounted.h>
 #include <AK/URL.h>
 #include <AK/Weakable.h>
+#include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/XHR/XMLHttpRequestEventTarget.h>
@@ -51,7 +52,14 @@ public:
 
     using WrapperType = Bindings::XMLHttpRequestWrapper;
 
-    static NonnullRefPtr<XMLHttpRequest> create(DOM::Window& window) { return adopt(*new XMLHttpRequest(window)); }
+    static NonnullRefPtr<XMLHttpRequest> create(DOM::Window& window)
+    {
+        return adopt(*new XMLHttpRequest(window));
+    }
+    static NonnullRefPtr<XMLHttpRequest> create_with_global_object(Bindings::WindowObject& window)
+    {
+        return XMLHttpRequest::create(window.impl());
+    }
 
     virtual ~XMLHttpRequest() override;
 

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
@@ -1,5 +1,7 @@
 interface XMLHttpRequest : XMLHttpRequestEventTarget {
 
+    constructor();
+
     const unsigned short UNSENT = 0;
     const unsigned short OPENED = 1;
     const unsigned short HEADERS_RECEIVED = 2;


### PR DESCRIPTION
See commit messages for details.

Examples of generated constructors:

```cpp
JS::Value EventConstructor::construct(Function&)
{

    [[maybe_unused]] auto& vm = this->vm();
    auto& global_object = this->global_object();

    auto& window = static_cast<WindowObject&>(global_object);

    if (vm.argument_count() < 1) {
        vm.throw_exception<JS::TypeError>(global_object, JS::ErrorType::BadArgCountOne, "Event");
        return {};
    }

    auto arg0 = vm.argument(0);

    auto type = arg0.to_string(global_object, false);
    if (vm.exception())
        return {};

    auto impl = DOM::Event::create_with_global_object(window, type);

    return EventWrapper::create(global_object, impl);

}
```

```cpp
JS::Value XMLHttpRequestConstructor::construct(Function&)
{

    [[maybe_unused]] auto& vm = this->vm();
    auto& global_object = this->global_object();

    auto& window = static_cast<WindowObject&>(global_object);

    auto impl = XHR::XMLHttpRequest::create_with_global_object(window);

    return XMLHttpRequestWrapper::create(global_object, impl);

}
```