### PR TITLE
LibC: Use "static inline" for inline functions in arpa/inet.h

### DIFF
--- a/Userland/Libraries/LibC/arpa/inet.h
+++ b/Userland/Libraries/LibC/arpa/inet.h
@@ -44,7 +44,7 @@ static inline int inet_aton(const char* cp, struct in_addr* inp)
 
 char* inet_ntoa(struct in_addr);
 
-inline uint16_t htons(uint16_t value)
+static inline uint16_t htons(uint16_t value)
 {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return __builtin_bswap16(value);
@@ -53,12 +53,12 @@ inline uint16_t htons(uint16_t value)
 #endif
 }
 
-inline uint16_t ntohs(uint16_t value)
+static inline uint16_t ntohs(uint16_t value)
 {
     return htons(value);
 }
 
-inline uint32_t htonl(uint32_t value)
+static inline uint32_t htonl(uint32_t value)
 {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return __builtin_bswap32(value);
@@ -67,7 +67,7 @@ inline uint32_t htonl(uint32_t value)
 #endif
 }
 
-inline uint32_t ntohl(uint32_t value)
+static inline uint32_t ntohl(uint32_t value)
 {
     return htonl(value);
 }


### PR DESCRIPTION
Whilst trying to build [dcraw](https://www.dechifro.org/dcraw/) natively I experienced unresolved symbols when using the inlined functions in arpa/inet.h

![Screenshot_20210217_224702](https://user-images.githubusercontent.com/14606456/108278563-21f7d580-7173-11eb-920f-8f9ccfb04d55.png)

declaring the functions static inline (or extern inline) fixed the issue.