### PR TITLE
Conway: Set minumum window size to game columns x rows

### DIFF
--- a/Userland/Games/Conway/Game.h
+++ b/Userland/Games/Conway/Game.h
@@ -34,6 +34,9 @@ public:
     virtual ~Game() override;
     void reset();
 
+    int rows() const { return m_rows; };
+    int columns() const { return m_columns; };
+
 private:
     Game();
     virtual void paint_event(GUI::PaintEvent&) override;

--- a/Userland/Games/Conway/main.cpp
+++ b/Userland/Games/Conway/main.cpp
@@ -66,6 +66,7 @@ int main(int argc, char** argv)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto& game = window->set_main_widget<Game>();
+    window->set_minimum_size(game.columns(), game.rows());
 
     auto menubar = GUI::MenuBar::construct();
 


### PR DESCRIPTION
The game renders no cells when the game widget height is < rows or width is < columns, so let's set a minimum window size here.