### PR TITLE
LibChess: SetOptionCommand: Set provided option name and value

### DIFF
--- a/Userland/Libraries/LibChess/UCICommand.cpp
+++ b/Userland/Libraries/LibChess/UCICommand.cpp
@@ -82,13 +82,37 @@ SetOptionCommand SetOptionCommand::from_string(const StringView& command)
     auto tokens = command.split_view(' ');
     ASSERT(tokens[0] == "setoption");
     ASSERT(tokens[1] == "name");
-    if (tokens.size() == 3) {
-        return SetOptionCommand(tokens[1]);
-    } else if (tokens.size() == 4) {
-        ASSERT(tokens[2] == "value");
-        return SetOptionCommand(tokens[1], tokens[3]);
+    ASSERT(tokens.size() > 2);
+
+    StringBuilder name;
+    StringBuilder value;
+    bool in_name = false;
+    bool in_value = false;
+    for (auto& part : tokens) {
+        if (in_name) {
+            if (part == "value") {
+                in_name = false;
+                in_value = true;
+                continue;
+            }
+            name.append(part);
+            name.append(' ');
+            continue;
+        }
+        if (in_value) {
+            value.append(part);
+            value.append(' ');
+            continue;
+        }
+        if (part == "name") {
+            in_name = true;
+            continue;
+        }
     }
-    ASSERT_NOT_REACHED();
+
+    ASSERT(!name.is_empty());
+
+    return SetOptionCommand(name.to_string().trim_whitespace(), value.to_string().trim_whitespace());
 }
 
 String SetOptionCommand::to_string() const


### PR DESCRIPTION
This PR addresses multiple bugs within the `setoption` verb and associated `SetOptionCommand` function in the `LibChess` UCI implementation. This verb and function are not yet used anywhere within `LibChess` or the `Chess` application.

The [UCI specification](https://www.shredderchess.com/download/div/uci.zip) for `setoption` states as follows:

```
* setoption name <id> [value <x>]
	this is sent to the engine when the user wants to change the internal parameters
	of the engine. For the "button" type no value is needed.
	One string will be sent for each parameter and this will only be sent when the engine is waiting.
	The name and value of the option in <id> should not be case sensitive and can inlude spaces.
	The substrings "value" and "name" should be avoided in <id> and <x> to allow unambiguous parsing,
	for example do not use <name> = "draw value".
	Here are some strings for the example below:
	   "setoption name Nullmove value true\n"
      "setoption name Selectivity value 3\n"
	   "setoption name Style value Risky\n"
	   "setoption name Clear Hash\n"
	   "setoption name NalimovPath value c:\chess\tb\4;c:\chess\tb\5\n"
```

The existing `LibChess` implementation is as follows:

https://github.com/SerenityOS/serenity/blob/cfb0f3309d86d01bd4aa4cd026cf5f4f21db495a/Userland/Libraries/LibChess/UCICommand.cpp#L80-L92

This function fails to account for instances where the option name or value contain spaces. As the command parsing is based on splitting by spaces, this is doomed to failure for a number of reasons, not helped by several token array index off-by-one bugs in the existing implementation:

* Firstly, `SetOptionCommand(tokens[1])` is used to set the option name to `tokens[1]` - which is literally `"name"` (as per the assertion a few lines earlier). This is incorrect - the name is stored in `tokens[2]` (or from `2` to `?` if the `name` contains spaces).
* A similar bug exists a few lines later, where `ASSERT(tokens[2] == "value")` is incorrectly checking if the option name is `"value"`. This is incorrect - the expected location for the `"value"` string is `tokens[3]` (or more than `3` if the preceding `name` contains spaces).
* Finally, if an optional value is set, `return SetOptionCommand(tokens[1], tokens[3])` attempts to set the option name to `tokens[1]` - which is literally `"name"`, and set the option value to `tokens[3]` which is literally `"value"` (or part of the `name` if the `name` contains spaces).

Note that the specification states that `name` and `value` *should* be avoided (not *must*) in option names and values to prevent ambiguous parsing.
