### PR TITLE
Chess: Allow right click to cancel drag move while dragging a piece

### DIFF
--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -168,7 +168,11 @@ void ChessWidget::mousedown_event(GUI::MouseEvent& event)
     GUI::Widget::mousedown_event(event);
 
     if (event.button() == GUI::MouseButton::Right) {
-        m_current_marking.from = mouse_to_square(event);
+        if (m_dragging_piece) {
+            m_dragging_piece = false;
+        } else {
+            m_current_marking.from = mouse_to_square(event);
+        }
         return;
     }
     m_board_markings.clear();


### PR DESCRIPTION
This feature is supported by many Chess clients and is particularly important during a time scramble.

Without this functionality, a player may attempt to cancel a move by attempting to drop the piece on a square which would constitute an illegal move; however, choosing an illegal move during a time scramble is time consuming and can potentially result in accidentally playing a legal move. Another alternative is to attempt to drop the piece off the board; however, the Chess board takes up the entirety of the Chess application window, and thus this would require dropping the piece outside of the application. This runs the risk of accidentally misclicking on another window, causing the Chess window to lose focus, and thus result in additional wasted time.

Additionally, although Chess does not yet feature timekeeping, and thus a time scramble is impossible, players may instinctively right click to cancel a move, then let go of left click due to muscle memory, causing the move to be played. This would be particularly frustrating as Chess does not yet feature "takeback" functionality to request taking back a move.
