### PR TITLE
Chess: pledge thread

### DIFF
--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv)
 
     RefPtr<Core::ConfigFile> config = Core::ConfigFile::get_for_app("Chess");
 
-    if (pledge("stdio rpath accept wpath cpath recvfd sendfd proc exec", nullptr) < 0) {
+    if (pledge("stdio rpath accept wpath cpath recvfd sendfd thread proc exec", nullptr) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
`thread` is required by the file browse dialog
when importing or exporting PGN files.

<details>
<p>

```
[#0 Chess(27:27)]: Has not pledged thread
[#0 Chess(27:27)]: 0x00000000  (?)

[#0 Chess(27:27)]: 0xc01c2350  Kernel::Process::crash(int, unsigned int, bool) +0x2e6
[#0 Chess(27:27)]: 0xc02025d6  Kernel::Process::sys$create_thread(void* (*)(void*), AK::Userspace<Kernel::Syscall::SC_create_thread_params const*>) +0xda
[#0 Chess(27:27)]: 0xc01cc781  syscall_handler +0xa18
[#0 Chess(27:27)]: 0xc01cbd31  syscall_asm_entry +0x31
[#0 Chess(27:27)]: Process regions:
[#0 Chess(27:27)]: BEGIN       END         SIZE        ACCESS  NAME
[#0 Chess(27:27)]: 02101000 -- 02200fff 00100000 RW  T  Stack (Main thread)
[#0 Chess(27:27)]: 02202000 -- 02202fff 00001000 R XS C Signal trampoline
[#0 Chess(27:27)]: 02204000 -- 02204fff 00001000 RW S   
[#0 Chess(27:27)]: 02206000 -- 02209fff 00004000 R  S   /res/fonts/CsillaBold10.font
[#0 Chess(27:27)]: 0220d000 -- 0220dfff 00001000 RW     
[#0 Chess(27:27)]: 02210000 -- 0221ffff 00010000        malloc: ChunkedBlock(256)
[#0 Chess(27:27)]: 02221000 -- 02221fff 00001000 R      mmap
[#0 Chess(27:27)]: 02223000 -- 02223fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/app-chess.png
[#0 Chess(27:27)]: 02227000 -- 02228fff 00002000 RW     Thread-specific
[#0 Chess(27:27)]: 0222a000 -- 0222afff 00001000 RW     Gfx::Bitmap [[32x32]] - Decoded PNG: /res/icons/32x32/app-chess.png
[#0 Chess(27:27)]: 0222c000 -- 0222cfff 00001000 RW     GraphicsBitmap [16x16]
[#0 Chess(27:27)]: 02230000 -- 0223ffff 00010000 RW     malloc: ChunkedBlock(32)
[#0 Chess(27:27)]: 02241000 -- 02245fff 00005000 R  S   /res/fonts/CsillaBold12.font
[#0 Chess(27:27)]: 02247000 -- 0224afff 00004000 R  S   /res/fonts/CsillaRegular10.font
[#0 Chess(27:27)]: 0224c000 -- 0224cfff 00001000 RW     GraphicsBitmap [16x16]
[#0 Chess(27:27)]: 02250000 -- 0225ffff 00010000        malloc: ChunkedBlock(64)
[#0 Chess(27:27)]: 02261000 -- 02265fff 00005000 R  S   /res/fonts/CsillaRegular12.font
[#0 Chess(27:27)]: 02267000 -- 0226afff 00004000 R  S   /res/fonts/KaticaBold10.font
[#0 Chess(27:27)]: 02270000 -- 0227ffff 00010000 RW     malloc: ChunkedBlock(8184)
[#0 Chess(27:27)]: 02281000 -- 02285fff 00005000 R  S   /res/fonts/KaticaBold12.font
[#0 Chess(27:27)]: 02287000 -- 0228afff 00004000 R  S   /res/fonts/KaticaRegular10.font
[#0 Chess(27:27)]: 0228c000 -- 02290fff 00005000 R  S   /res/fonts/KaticaRegular12.font
[#0 Chess(27:27)]: 02292000 -- 02295fff 00004000 R  S   /res/fonts/LizaBlack10.font
[#0 Chess(27:27)]: 02297000 -- 022a0fff 0000a000 R  S   /res/fonts/LizaBlack24.font
[#0 Chess(27:27)]: 022a2000 -- 022affff 0000e000 R  S   /res/fonts/LizaBlack36.font
[#0 Chess(27:27)]: 022b1000 -- 022b4fff 00004000 R  S   /res/fonts/LizaBold10.font
[#0 Chess(27:27)]: 022b6000 -- 022b9fff 00004000 R  S   /res/fonts/LizaRegular10.font
[#0 Chess(27:27)]: 022bb000 -- 022bbfff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/chess/mini-board.png
[#0 Chess(27:27)]: 022bd000 -- 022bdfff 00001000 RW     Gfx::Bitmap [[32x32]] - Decoded PNG: /res/icons/32x32/hard-disk.png
[#0 Chess(27:27)]: 022c0000 -- 022cffff 00010000 RW     malloc: ChunkedBlock(128)
[#0 Chess(27:27)]: 022d1000 -- 022dafff 0000a000 R  S   /res/fonts/LizaBold24.font
[#0 Chess(27:27)]: 022dc000 -- 022dcfff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/undo.png
[#0 Chess(27:27)]: 022e0000 -- 022effff 00010000 RW     malloc: ChunkedBlock(256)
[#0 Chess(27:27)]: 022f1000 -- 022fafff 0000a000 R  S   /res/fonts/LizaRegular24.font
[#0 Chess(27:27)]: 022fc000 -- 022fcfff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/redo.png
[#0 Chess(27:27)]: 02300000 -- 0230ffff 00010000 RW     malloc: ChunkedBlock(500)
[#0 Chess(27:27)]: 02311000 -- 02316fff 00006000 R  S   /res/fonts/PebbletonBold14.font
[#0 Chess(27:27)]: 02318000 -- 0231dfff 00006000 R  S   /res/fonts/PebbletonRegular14.font
[#0 Chess(27:27)]: 02320000 -- 0232ffff 00010000        malloc: ChunkedBlock(1016)
[#0 Chess(27:27)]: 02331000 -- 02331fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/edit-cut.png
[#0 Chess(27:27)]: 02333000 -- 02333fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/edit-copy.png
[#0 Chess(27:27)]: 02335000 -- 02335fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/paste.png
[#0 Chess(27:27)]: 02337000 -- 02337fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/delete.png
[#0 Chess(27:27)]: 02339000 -- 02339fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/select-all.png
[#0 Chess(27:27)]: 0233b000 -- 0233bfff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/table-view.png
[#0 Chess(27:27)]: 0233d000 -- 0233dfff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/icon-view.png
[#0 Chess(27:27)]: 02340000 -- 0234ffff 00010000 RW     malloc: ChunkedBlock(8)
[#0 Chess(27:27)]: 02351000 -- 02354fff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/black-pawn.png
[#0 Chess(27:27)]: 02357000 -- 0235afff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/white-pawn.png
[#0 Chess(27:27)]: 0235c000 -- 0235cfff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/columns-view.png
[#0 Chess(27:27)]: 02360000 -- 0236ffff 00010000 RW     malloc: ChunkedBlock(64)
[#0 Chess(27:27)]: 02371000 -- 02374fff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/black-bishop.png
[#0 Chess(27:27)]: 02377000 -- 0237afff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/white-bishop.png
[#0 Chess(27:27)]: 0237c000 -- 0237cfff 00001000 RW     Gfx::Bitmap [[7x10]] - Decoded PNG: /res/emoji/U+2B06.png
[#0 Chess(27:27)]: 02380000 -- 0238ffff 00010000 RW     malloc: ChunkedBlock(16)
[#0 Chess(27:27)]: 02391000 -- 02391fff 00001000 RW     Gfx::Bitmap [[10x10]] - Decoded PNG: /res/icons/symlink-emblem.png
[#0 Chess(27:27)]: 02393000 -- 02393fff 00001000 RW     Gfx::Bitmap [[8x8]] - Decoded PNG: /res/icons/symlink-emblem-small.png
[#0 Chess(27:27)]: 02396000 -- 02399fff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/black-knight.png
[#0 Chess(27:27)]: 0239b000 -- 0239bfff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/hard-disk.png
[#0 Chess(27:27)]: 0239d000 -- 0239dfff 00001000 RW     Gfx::Bitmap [[32x32]] - Decoded PNG: /res/icons/32x32/filetype-folder.png
[#0 Chess(27:27)]: 023a0000 -- 023affff 00010000 RW     malloc: ChunkedBlock(128)
[#0 Chess(27:27)]: 023b1000 -- 023b4fff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/black-rook.png
[#0 Chess(27:27)]: 023b7000 -- 023bafff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/white-rook.png
[#0 Chess(27:27)]: 023bc000 -- 023bcfff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/filetype-folder.png
[#0 Chess(27:27)]: 023c0000 -- 023cffff 00010000 RW     malloc: ChunkedBlock(32)
[#0 Chess(27:27)]: 023d1000 -- 023d4fff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/black-queen.png
[#0 Chess(27:27)]: 023d7000 -- 023dafff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/white-queen.png
[#0 Chess(27:27)]: 023e0000 -- 023effff 00010000 RW     malloc: ChunkedBlock(256)
[#0 Chess(27:27)]: 023f1000 -- 023f4fff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/black-king.png
[#0 Chess(27:27)]: 023f7000 -- 023fafff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/white-king.png
[#0 Chess(27:27)]: 023fc000 -- 023fcfff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/filetype-folder-open.png
[#0 Chess(27:27)]: 02400000 -- 0240ffff 00010000 RW     malloc: ChunkedBlock(500)
[#0 Chess(27:27)]: 02411000 -- 02414fff 00004000 RW     Gfx::Bitmap [[64x64]] - Decoded PNG: /res/icons/chess/sets/stelar7/white-knight.png
[#0 Chess(27:27)]: 02416000 -- 02416fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/filetype-folder-inaccessible.png
[#0 Chess(27:27)]: 02418000 -- 02418fff 00001000 RW     Gfx::Bitmap [[32x32]] - Decoded PNG: /res/icons/32x32/filetype-folder-inaccessible.png
[#0 Chess(27:27)]: 0241a000 -- 0241afff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/home-directory.png
[#0 Chess(27:27)]: 0241c000 -- 0241cfff 00001000 RW     Gfx::Bitmap [[32x32]] - Decoded PNG: /res/icons/32x32/home-directory.png
[#0 Chess(27:27)]: 02420000 -- 0242ffff 00010000 RW     malloc: ChunkedBlock(1016)
[#0 Chess(27:27)]: 02431000 -- 0243efff 0000e000 R  S   /res/fonts/LizaBold36.font
[#0 Chess(27:27)]: 02440000 -- 0244dfff 0000e000 R  S   /res/fonts/LizaRegular36.font
[#0 Chess(27:27)]: 02450000 -- 0245ffff 00010000 RW     malloc: ChunkedBlock(16376)
[#0 Chess(27:27)]: 02461000 -- 02461fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/home-directory-open.png
[#0 Chess(27:27)]: 02463000 -- 02463fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/filetype-unknown.png
[#0 Chess(27:27)]: 02465000 -- 02465fff 00001000 RW     Gfx::Bitmap [[32x32]] - Decoded PNG: /res/icons/32x32/filetype-unknown.png
[#0 Chess(27:27)]: 02467000 -- 02467fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/filetype-symlink.png
[#0 Chess(27:27)]: 02469000 -- 02469fff 00001000 RW     Gfx::Bitmap [[32x32]] - Decoded PNG: /res/icons/32x32/filetype-symlink.png
[#0 Chess(27:27)]: 0246b000 -- 0246bfff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/filetype-socket.png
[#0 Chess(27:27)]: 0246d000 -- 0246dfff 00001000 RW     Gfx::Bitmap [[32x32]] - Decoded PNG: /res/icons/32x32/filetype-socket.png
[#0 Chess(27:27)]: 02470000 -- 0247ffff 00010000 RW     malloc: ChunkedBlock(2032)
[#0 Chess(27:27)]: 02481000 -- 02481fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/filetype-image.png
[#0 Chess(27:27)]: 02483000 -- 02483fff 00001000 RW     Gfx::Bitmap [[32x32]] - Decoded PNG: /res/icons/32x32/filetype-image.png
[#0 Chess(27:27)]: 02485000 -- 02485fff 00001000 RW     Gfx::Bitmap [[16x16]] - Decoded PNG: /res/icons/16x16/filetype-executable.png
[#0 Chess(27:27)]: 02487000 -- 02487fff 00001000 RW     Gfx::Bitmap [[32x32]] - Decoded PNG: /res/icons/32x32/filetype-executable.png
[#0 Chess(27:27)]: 02490000 -- 0249ffff 00010000        malloc: ChunkedBlock(4088)
[#0 Chess(27:27)]: 024a1000 -- 025a0fff 00100000 RW S   
[#0 Chess(27:27)]: 025a2000 -- 026a1fff 00100000 RW S   
[#0 Chess(27:27)]: 026b0000 -- 026bffff 00010000        malloc: BigAllocationBlock
[#0 Chess(27:27)]: 026d0000 -- 026dffff 00010000        malloc: ChunkedBlock(32752)
[#0 Chess(27:27)]: 026e1000 -- 02ae0fff 00400000 RW  T  Thread stack
[#0 Chess(27:27)]: 030c0000 -- 030cffff 00010000        malloc: ChunkedBlock(2032)
[#0 Chess(27:27)]: 030e0000 -- 030effff 00010000        malloc: ChunkedBlock(4088)
[#0 Chess(27:27)]: 03100000 -- 0310ffff 00010000        malloc: ChunkedBlock(8184)
[#0 Chess(27:27)]: 03120000 -- 0312ffff 00010000        malloc: ChunkedBlock(16376)
[#0 Chess(27:27)]: 03140000 -- 0314ffff 00010000        malloc: ChunkedBlock(32752)
[#0 Chess(27:27)]: 03160000 -- 0316ffff 00010000        malloc: BigAllocationBlock
[#0 Chess(27:27)]: 0eba9000 -- 0ebf0fff 00048000 R XS   /usr/lib/Loader.so
[#0 Chess(27:27)]: 0ebf1000 -- 0ebf2fff 00002000 RW     /usr/lib/Loader.so (data-rw)
[#0 Chess(27:27)]: 12c7c000 -- 12c88fff 0000d000 R XS   libttf.so: .text
[#0 Chess(27:27)]: 12c89000 -- 12c89fff 00001000 RW     libttf.so: .data
[#0 Chess(27:27)]: 1d6d8000 -- 1d6d8fff 00001000 R XS C libsystem.so: .text
[#0 Chess(27:27)]: 1d6d9000 -- 1d6d9fff 00001000 RW     libsystem.so: .data
[#0 Chess(27:27)]: 30c03000 -- 30c07fff 00005000 R XS   libipc.so: .text
[#0 Chess(27:27)]: 30c08000 -- 30c08fff 00001000 RW     libipc.so: .data
[#0 Chess(27:27)]: 31f02000 -- 31f03fff 00002000 R XS   libsyntax.so: .text
[#0 Chess(27:27)]: 31f04000 -- 31f04fff 00001000 RW     libsyntax.so: .data
[#0 Chess(27:27)]: 34c56000 -- 34cc7fff 00072000 R X    libc.so: .text
[#0 Chess(27:27)]: 34cc8000 -- 34ccafff 00003000 RW     libc.so: .data
[#0 Chess(27:27)]: 3b7cc000 -- 3b90dfff 00142000 R XS   libgui.so: .text
[#0 Chess(27:27)]: 3b90e000 -- 3b919fff 0000c000 RW     libgui.so: .data
[#0 Chess(27:27)]: 58b19000 -- 58b1dfff 00005000 R XS   libtextcodec.so: .text
[#0 Chess(27:27)]: 58b1e000 -- 58b1efff 00001000 RW     libtextcodec.so: .data
[#0 Chess(27:27)]: 69097000 -- 690f9fff 00063000 R XS   libgfx.so: .text
[#0 Chess(27:27)]: 690fa000 -- 690fcfff 00003000 RW     libgfx.so: .data
[#0 Chess(27:27)]: 706bb000 -- 706bcfff 00002000 R XS   libm.so: .text
[#0 Chess(27:27)]: 706bd000 -- 706bdfff 00001000 RW     libm.so: .data
[#0 Chess(27:27)]: 71184000 -- 711bbfff 00038000 R XS   libcore.so: .text
[#0 Chess(27:27)]: 711bc000 -- 711bdfff 00002000 RW     libcore.so: .data
[#0 Chess(27:27)]: 7afcf000 -- 7afebfff 0001d000 R XS   libcrypto.so: .text
[#0 Chess(27:27)]: 7afec000 -- 7afecfff 00001000 RW     libcrypto.so: .data
[#0 Chess(27:27)]: 85926000 -- 85928fff 00003000 R XS   libpthread.so: .text
[#0 Chess(27:27)]: 85929000 -- 85929fff 00001000 RW     libpthread.so: .data
[#0 Chess(27:27)]: 910e6000 -- 910f8fff 00013000 R XS   libchess.so: .text
[#0 Chess(27:27)]: 910f9000 -- 910f9fff 00001000 RW     libchess.so: .data
[#0 Chess(27:27)]: 9c071000 -- 9c088fff 00018000 R XS   libgcc_s.so: .text
[#0 Chess(27:27)]: 9c089000 -- 9c089fff 00001000 RW     libgcc_s.so: .data
[#0 Chess(27:27)]: a2c7b000 -- a2c7efff 00004000 R XS   libthread.so: .text
[#0 Chess(27:27)]: a2c7f000 -- a2c7ffff 00001000 RW     libthread.so: .data
[#0 Chess(27:27)]: a655f000 -- a6574fff 00016000 R XS   /bin/Chess: .text
[#0 Chess(27:27)]: a6575000 -- a6575fff 00001000 RW     /bin/Chess: .data
[#0 Chess(27:27)]: a6902000 -- a6903fff 00002000 R XS   libcrypt.so: .text
[#0 Chess(27:27)]: a6904000 -- a6904fff 00001000 RW     libcrypt.so: .data
[#0 Chess(27:27)]: a8d45000 -- a8d69fff 00025000 R XS   libregex.so: .text
[#0 Chess(27:27)]: a8d6a000 -- a8d6afff 00001000 RW     libregex.so: .data
[#0 Chess(27:27)]: Kernel regions:
[#0 Chess(27:27)]: BEGIN       END         SIZE        ACCESS  NAME
[#0 Chess(27:27)]: c0801000 -- c0900fff 00100000 RW     kmalloc subheap
[#0 Chess(27:27)]: c0904000 -- c0904fff 00001000 RW     HPET MMIO
[#0 Chess(27:27)]: c0906000 -- c0906fff 00001000 R    C Signal trampolines
[#0 Chess(27:27)]: c0908000 -- c0917fff 00010000 RW  T  Kernel stack (thread 0)
[#0 Chess(27:27)]: c092a000 -- c0939fff 00010000 RW  T  Kernel stack (thread 2)
[#0 Chess(27:27)]: c093b000 -- c094afff 00010000 RW  T  Kernel stack (thread 3)
[#0 Chess(27:27)]: c094c000 -- c094cfff 00001000  W     UHCI Framelist
[#0 Chess(27:27)]: c094e000 -- c094ffff 00002000  W     UHCI Queue Head Pool
[#0 Chess(27:27)]: c0951000 -- c0952fff 00002000  W     UHCI Transfer Descriptor Pool
[#0 Chess(27:27)]: c0954000 -- c0963fff 00010000 RW  T  Kernel stack (thread 4)
[#0 Chess(27:27)]: c0965000 -- c0965fff 00001000 RW     E1000 RX
[#0 Chess(27:27)]: c0967000 -- c0967fff 00001000 RW     E1000 TX
[#0 Chess(27:27)]: c0969000 -- c0988fff 00020000 RW     E1000 MMIO
[#0 Chess(27:27)]: c098a000 -- c098bfff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c098d000 -- c098efff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c0990000 -- c0991fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c0993000 -- c0994fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c0996000 -- c0997fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c0999000 -- c099afff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c099c000 -- c099dfff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c099f000 -- c09a0fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09a2000 -- c09a3fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09a5000 -- c09a6fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09a8000 -- c09a9fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09ab000 -- c09acfff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09ae000 -- c09affff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09b1000 -- c09b2fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09b4000 -- c09b5fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09b7000 -- c09b8fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09ba000 -- c09bbfff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09bd000 -- c09befff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09c0000 -- c09c1fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09c3000 -- c09c4fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09c6000 -- c09c7fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09c9000 -- c09cafff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09cc000 -- c09cdfff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09cf000 -- c09d0fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09d2000 -- c09d3fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09d5000 -- c09d6fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09d8000 -- c09d9fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09db000 -- c09dcfff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09de000 -- c09dffff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09e1000 -- c09e2fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09e4000 -- c09e5fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09e7000 -- c09e8fff 00002000 RW     E1000 RX buffer
[#0 Chess(27:27)]: c09ea000 -- c09ebfff 00002000 RW     E1000 TX buffer
[#0 Chess(27:27)]: c09ed000 -- c09eefff 00002000 RW     E1000 TX buffer
[#0 Chess(27:27)]: c09f0000 -- c09f1fff 00002000 RW     E1000 TX buffer
[#0 Chess(27:27)]: c09f3000 -- c09f4fff 00002000 RW     E1000 TX buffer
[#0 Chess(27:27)]: c09f6000 -- c09f7fff 00002000 RW     E1000 TX buffer
[#0 Chess(27:27)]: c09f9000 -- c09fafff 00002000 RW     E1000 TX buffer
[#0 Chess(27:27)]: c09fc000 -- c09fdfff 00002000 RW     E1000 TX buffer
[#0 Chess(27:27)]: c09ff000 -- c0a00fff 00002000 RW     E1000 TX buffer
[#0 Chess(27:27)]: c0a02000 -- c0a02fff 00001000 RW     Ext2FS: Block group descriptors
[#0 Chess(27:27)]: c0a04000 -- c3113fff 02710000 RW     KBuffer
[#0 Chess(27:27)]: c3115000 -- c314ffff 0003b000 RW     KBuffer
[#0 Chess(27:27)]: c3151000 -- c3151fff 00001000 RW     Ext2FS: Cached bitmap block
[#0 Chess(27:27)]: c3153000 -- c3153fff 00001000 RW     Ext2FS: Cached bitmap block
[#0 Chess(27:27)]: c3155000 -- c3164fff 00010000 RW  T  Kernel stack (thread 5)
[#0 Chess(27:27)]: c3166000 -- c3175fff 00010000 RW  T  Kernel stack (thread 6)
[#0 Chess(27:27)]: c3177000 -- c3186fff 00010000 RW     Kernel Packet Buffer
[#0 Chess(27:27)]: c3188000 -- c31a7fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c31a9000 -- c31c8fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c31ca000 -- c31e9fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c31eb000 -- c320afff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c320c000 -- c322bfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c322d000 -- c324cfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c324e000 -- c326dfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c326f000 -- c328efff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3290000 -- c32affff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c32b1000 -- c32d0fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c32d2000 -- c32f1fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c32f3000 -- c3312fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3314000 -- c3333fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3335000 -- c3354fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3356000 -- c3375fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3377000 -- c3396fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3398000 -- c33b7fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c33b9000 -- c33d8fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c33da000 -- c33f9fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c33fb000 -- c341afff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c341c000 -- c343bfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c343d000 -- c345cfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c345e000 -- c347dfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c347f000 -- c349efff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c34a0000 -- c34bffff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c34c1000 -- c34e0fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c34e2000 -- c3501fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3503000 -- c3512fff 00010000 RW  T  Kernel stack (thread 8)
[#0 Chess(27:27)]: c3514000 -- c3523fff 00010000 RW  T  Kernel stack (thread 9)
[#0 Chess(27:27)]: c3525000 -- c3534fff 00010000 RW  T  Kernel stack (thread 10)
[#0 Chess(27:27)]: c3536000 -- c3545fff 00010000 RW  T  Kernel stack (thread 11)
[#0 Chess(27:27)]: c3547000 -- c3556fff 00010000 RW  T  Kernel stack (thread 12)
[#0 Chess(27:27)]: c3558000 -- c3567fff 00010000 RW  T  Kernel stack (thread 13)
[#0 Chess(27:27)]: c3569000 -- c3578fff 00010000 RW  T  Kernel stack (thread 14)
[#0 Chess(27:27)]: c357a000 -- c3589fff 00010000 RW  T  Kernel stack (thread 15)
[#0 Chess(27:27)]: c358b000 -- c359afff 00010000 RW  T  Kernel stack (thread 16)
[#0 Chess(27:27)]: c359c000 -- c35abfff 00010000 RW  T  Kernel stack (thread 17)
[#0 Chess(27:27)]: c35ad000 -- c35bcfff 00010000 RW  T  Kernel stack (thread 18)
[#0 Chess(27:27)]: c35be000 -- c35cdfff 00010000 RW  T  Kernel stack (thread 19)
[#0 Chess(27:27)]: c35cf000 -- c35defff 00010000 RW  T  Kernel stack (thread 20)
[#0 Chess(27:27)]: c35e0000 -- c35effff 00010000 RW  T  Kernel stack (thread 21)
[#0 Chess(27:27)]: c35f1000 -- c3600fff 00010000 RW  T  Kernel stack (thread 22)
[#0 Chess(27:27)]: c3602000 -- c3611fff 00010000 RW  T  Kernel stack (thread 23)
[#0 Chess(27:27)]: c3613000 -- c3632fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3634000 -- c3653fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3655000 -- c3674fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3676000 -- c3695fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3697000 -- c36b6fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c36b8000 -- c36d7fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c36d9000 -- c36f8fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c36fa000 -- c3719fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c371b000 -- c373afff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c373c000 -- c375bfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c375d000 -- c377cfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c377e000 -- c379dfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c379f000 -- c37befff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c37c0000 -- c37dffff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c37e1000 -- c3800fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3802000 -- c3821fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3823000 -- c3842fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3844000 -- c3863fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3865000 -- c3884fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3886000 -- c38a5fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c38a7000 -- c38c6fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c38c8000 -- c38e7fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c38e9000 -- c3908fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c390a000 -- c3929fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c392b000 -- c394afff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c394c000 -- c396bfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c396d000 -- c398cfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c398e000 -- c39adfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c39af000 -- c39cefff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c39d0000 -- c39effff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c39f1000 -- c3a10fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3a12000 -- c3a31fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3a33000 -- c3a52fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3a54000 -- c3a73fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3a75000 -- c3a94fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3a96000 -- c3ab5fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3ab7000 -- c3ad6fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3ad8000 -- c3af7fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3af9000 -- c3b18fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3b1a000 -- c3b39fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3b3b000 -- c3b5afff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3b5c000 -- c3b7bfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3b7d000 -- c3b9cfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3b9e000 -- c3bbdfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3bbf000 -- c3bdefff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3be0000 -- c3bfffff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3c01000 -- c3c20fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3c22000 -- c3c41fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3c43000 -- c3c62fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3c64000 -- c3c83fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3c85000 -- c3ca4fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3ca6000 -- c3cb5fff 00010000 RW  T  Kernel stack (thread 24)
[#0 Chess(27:27)]: c3cb7000 -- c3cd6fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3cd8000 -- c3cf7fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3cf9000 -- c3d18fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c3d1a000 -- c4119fff 00400000 RW     KBuffer
[#0 Chess(27:27)]: c411b000 -- c413afff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c413c000 -- c415bfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c415d000 -- c417cfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c417e000 -- c419dfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c419f000 -- c41befff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c41c0000 -- c41dffff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c41e1000 -- c4200fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c0919000 -- c0919fff 00001000 RW     KBuffer
[#0 Chess(27:27)]: c4202000 -- c4221fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4223000 -- c4242fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4244000 -- c4263fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4265000 -- c4284fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4286000 -- c42a5fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c42a7000 -- c42c6fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c42c8000 -- c42e7fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c42e9000 -- c4308fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c430a000 -- c4329fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c432b000 -- c434afff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c434c000 -- c436bfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c436d000 -- c438cfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c438e000 -- c43adfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c43af000 -- c43cefff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c43d0000 -- c43effff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c43f1000 -- c4410fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4412000 -- c4431fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4433000 -- c4452fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4454000 -- c4473fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4475000 -- c4494fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4496000 -- c44b5fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c44b7000 -- c44d6fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c44d8000 -- c44f7fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c44f9000 -- c4518fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c451a000 -- c4539fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c453b000 -- c455afff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c455c000 -- c457bfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c457d000 -- c459cfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c459e000 -- c45bdfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c45bf000 -- c45defff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c45e0000 -- c45fffff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4601000 -- c4620fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4622000 -- c4641fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4643000 -- c4662fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4664000 -- c4683fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4685000 -- c4694fff 00010000 RW  T  Kernel stack (thread 25)
[#0 Chess(27:27)]: c091b000 -- c091bfff 00001000 RW     Ext2FS: Cached bitmap block
[#0 Chess(27:27)]: c4696000 -- c46b5fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c46b7000 -- c46d6fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c46d8000 -- c46f7fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c46f9000 -- c4af8fff 00400000 RW     KBuffer
[#0 Chess(27:27)]: c4afa000 -- c4ef9fff 00400000 RW     KBuffer
[#0 Chess(27:27)]: c4f1c000 -- c4f2bfff 00010000 RW  T  Kernel stack (thread 27)
[#0 Chess(27:27)]: c4f2d000 -- c4f4cfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4f4e000 -- c4f6dfff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4f6f000 -- c4f8efff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4f90000 -- c4faffff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4fb1000 -- c4fd0fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4fd2000 -- c4ff1fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c4ff3000 -- c5012fff 00020000 RW     DoubleBuffer
[#0 Chess(27:27)]: c5415000 -- c5514fff 00100000 RW     kmalloc subheap
[#0 FinalizerTask(3:3)]: Generating coredump for pid: 27
[#0 FinalizerTask(3:3)]: RTC: Year: 2021, month: 2, day: 18, hour: 9, minute: 0, second: 38
CrashDaemon(20): New coredump file: /tmp/coredump/Chess_27_1613638838
Shell(25): Job entry 'Chess' deleted in 32379 ms
CrashDaemon(20): --- Backtrace for thread #0 (TID 27) ---
CrashDaemon(20): 0x1d6d8177: [libsystem.so] syscall2 +0xe (syscall.cpp:45)
CrashDaemon(20): 0x85927cac: [libpthread.so] pthread_create +0x11e (pthread.cpp:101)
CrashDaemon(20): 0xa2c7dc20: [libthread.so] LibThread::Thread::start() +0x2a (Thread.cpp:62)
CrashDaemon(20): 0xa2c7d425: [libthread.so] init() +0x1ad (BackgroundAction.cpp:60)
CrashDaemon(20): 0xa2c7d486: [libthread.so] LibThread::BackgroundActionBase::background_thread() +0x1e (BackgroundAction.cpp:73)
CrashDaemon(20): 0x3b89815f: [libgui.so] LibThread::BackgroundAction<AK::RefPtr<Gfx::Bitmap, AK::RefPtrTraits<Gfx::Bitmap> > >::BackgroundAction(AK::Function<AK::RefPtr<Gfx::Bitmap, AK::RefPtrTraits<Gfx::Bitmap> > ()>, AK::Function<void (AK::RefPtr<Gfx::Bitmap, AK::RefPtrTraits<Gfx::Bitmap> >)>) +0x35 (BackgroundAction.h:74)
CrashDaemon(20): 0x3b896aff: [libgui.so] GUI::FileSystemModel::fetch_thumbnail_for(GUI::FileSystemModel::Node const&) +0x1e5 (Atomic.h:156)
CrashDaemon(20): 0x3b896d71: [libgui.so] GUI::FileSystemModel::icon_for(GUI::FileSystemModel::Node const&) const +0xbb (FileSystemModel.cpp:471)
CrashDaemon(20): 0x3b8972c9: [libgui.so] .L1313 +0xf (FileSystemModel.cpp:459)
CrashDaemon(20): 0x3b8c3644: [libgui.so] GUI::SortingProxyModel::data(GUI::ModelIndex const&, GUI::ModelRole) const +0x6c (SortingProxyModel.cpp:131)
CrashDaemon(20): 0x3b8b4c4c: [libgui.so] GUI::ModelIndex::data(GUI::ModelRole) const +0x52 (ModelIndex.cpp:39)
CrashDaemon(20): 0x3b8522eb: [libgui.so] GUI::AbstractTableView::update_column_sizes() +0x1fd (Variant.h:93)
CrashDaemon(20): 0x3b853248: [libgui.so] GUI::AbstractTableView::model_did_update(unsigned int) +0x34 (AbstractTableView.cpp:307)
CrashDaemon(20): 0x3b8b3e3f: [libgui.so] GUI::Model::did_update(unsigned int) +0x35 (Model.cpp:61)
CrashDaemon(20): 0x3b8c3ef1: [libgui.so] GUI::SortingProxyModel::invalidate(unsigned int) +0xaf (SortingProxyModel.cpp:59)
CrashDaemon(20): 0x3b8c4009: [libgui.so] GUI::SortingProxyModel::model_did_update(unsigned int) +0x1d (SortingProxyModel.cpp:64)
CrashDaemon(20): 0x3b8b3e3f: [libgui.so] GUI::Model::did_update(unsigned int) +0x35 (Model.cpp:61)
CrashDaemon(20): 0x3b8960eb: [libgui.so] GUI::FileSystemModel::update() +0xb3 (FileSystemModel.cpp:328)
CrashDaemon(20): 0x3b894f40: [libgui.so] GUI::FileSystemModel::set_root_path(AK::StringView const&) +0x90 (FileSystemModel.cpp:310)
CrashDaemon(20): 0x3b8914f7: [libgui.so] GUI::FilePicker::set_path(AK::String const&) +0xdf (FilePicker.cpp:329)
CrashDaemon(20): 0x3b892945: [libgui.so] GUI::FilePicker::FilePicker(GUI::Window*, GUI::FilePicker::Mode, GUI::FilePicker::Options, AK::StringView const&, AK::StringView const&) +0x6fb (FilePicker.cpp:130)
CrashDaemon(20): 0x3b893534: [libgui.so] GUI::FilePicker::get_save_filepath(GUI::Window*, AK::String const&, AK::String const&, GUI::FilePicker::Options) +0xce (FilePicker.h:41)
CrashDaemon(20): 0xa656849e: [/bin/Chess] AK::Function<void (GUI::Action&)>::CallableWrapper<main::{lambda(auto:1&)#4}>::call(GUI::Action&) const +0x82 (main.cpp:122)
CrashDaemon(20): 0x3b857cb5: [libgui.so] GUI::Action::activate(Core::Object*) +0x143 (Atomic.h:255)
CrashDaemon(20): 0x3b8f533b: [libgui.so] GUI::WindowServerConnection::handle(Messages::WindowClient::MenuItemActivated const&) +0xbf (WindowServerConnection.cpp:263)
CrashDaemon(20): 0x3b8f71e9: [libgui.so] .L134 +0x7 (WindowClientEndpoint.h:2211)
CrashDaemon(20): 0x3b86fa3d: [libgui.so] IPC::Connection<WindowClientEndpoint, WindowServerEndpoint>::handle_messages() +0x7b (OwnPtr.h:191)
CrashDaemon(20): 0x3b8f8453: [libgui.so] AK::Function<void ()>::CallableWrapper<IPC::Connection<WindowClientEndpoint, WindowServerEndpoint>::Connection(WindowClientEndpoint&, AK::NonnullRefPtr<Core::LocalSocket>)::{lambda()#2}>::call() const +0x27 (Function.h:103)
CrashDaemon(20): 0x711afe10: [libcore.so] Core::Notifier::event(Core::Event&) +0x4e (Notifier.cpp:74)
CrashDaemon(20): 0x711b06d5: [libcore.so] Core::Object::dispatch_event(Core::Event&, Core::Object*) +0x59 (Object.h:104)
CrashDaemon(20): 0x711a2d9b: [libcore.so] Core::EventLoop::pump(Core::EventLoop::WaitMode) +0x1dd (Atomic.h:255)
CrashDaemon(20): 0x711a3091: [libcore.so] Core::EventLoop::exec() +0x6b (EventLoop.cpp:392)
CrashDaemon(20): 0x3b85b090: [libgui.so] GUI::Application::exec() +0x32 (Application.cpp:121)
CrashDaemon(20): 0xa656744a: [/bin/Chess] main +0x194a (main.cpp:230)
CrashDaemon(20): 0xa65676d3: [/bin/Chess] _start +0x42 (crt0_shared.cpp:60)
```
</p>
</details>
