### PR TITLE
Ports: Add libjpeg 9d

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -34,6 +34,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`libexpat`](libexpat/)        | Expat                                         | 2.2.9             | https://libexpat.github.io/                           |
 | [`libffi`](libffi/)            | libffi                                        | 3.3               | https://www.sourceware.org/libffi/                    |
 | [`libiconv`](libiconv/)        | GNU libiconv                                  | 1.16              | https://www.gnu.org/software/libiconv/                |
+| [`libjpeg`](libjpeg/)          | libjpeg                                       | 9d                | https://ijg.org/                                      |
 | [`libpuffy`](libpuffy/)        | libpuffy                                      | 1.0               | https://github.com/ibara/libpuffy                     |
 | [`links`](links/)              | Links web browser                             | 2.19              | http://links.twibright.com/                           |
 | [`lua`](lua/)                  | Lua                                           | 5.3.5             | https://www.lua.org/                                  |

--- a/Ports/libjpeg/package.sh
+++ b/Ports/libjpeg/package.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=libjpeg
+version=9d
+useconfigure=true
+files="https://ijg.org/files/jpegsrc.v${version}.tar.gz jpeg-${version}.tar.gz ad7e40dedc268f97c44e7ee3cd54548a"
+auth_type="md5"
+workdir="jpeg-$version"

--- a/Ports/libjpeg/patches/system-detect.patch
+++ b/Ports/libjpeg/patches/system-detect.patch
@@ -1,0 +1,11 @@
+--- jpeg-9d/config.sub.orig	2021-02-17 23:18:21.463855433 +0000
++++ jpeg-9d/config.sub	2021-02-17 23:18:42.043804955 +0000
+@@ -1390,7 +1390,7 @@
+ 	      | -powermax* | -dnix* | -nx6 | -nx7 | -sei* | -dragonfly* \
+ 	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es* \
+ 	      | -onefs* | -tirtos* | -phoenix* | -fuchsia* | -redox* | -bme* \
+-	      | -midnightbsd*)
++	      | -midnightbsd* | -serenity* )
+ 	# Remember, each alternative MUST END IN *, to match a version number.
+ 		;;
+ 	-qnx*)


### PR DESCRIPTION
All command-line utils run successfully (with just -h argument) and was able to build a native program with the library