### PR TITLE
Libc: implement missing swab — swap adjacent bytes

### DIFF
--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -790,4 +790,20 @@ int getpagesize()
 {
     return PAGE_SIZE;
 }
+
+void swab(const void* from, void* to, ssize_t n)
+{
+    if (n <= 0) {
+        return;
+    }
+    ASSERT(from != NULL);
+    ASSERT(to != NULL);
+    u8* dest = (u8*)to;
+    for (size_t ix = 0; ix < (size_t)(n - (n % 2)); ix += 2) {
+        *dest = *((const u8*)from + ix + 1);
+        dest++;
+        *dest = *((const u8*)from + ix);
+        dest++;
+    }
+}
 }

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -139,6 +139,7 @@ int umount(const char* mountpoint);
 int pledge(const char* promises, const char* execpromises);
 int unveil(const char* path, const char* permissions);
 char* getpass(const char* prompt);
+void swab(const void* from, void* to, ssize_t n);
 
 enum {
     _PC_NAME_MAX,


### PR DESCRIPTION

Whilst trying to compile dcraw within Serenity I noticed [swab()](https://pubs.opengroup.org/onlinepubs/007904875/functions/swab.html) was not implemented.

![Screenshot_20210218_220746](https://user-images.githubusercontent.com/14606456/108428063-ee31b400-7235-11eb-98f4-3c22c2c3384d.png)