### PR TITLE
CrashReporter: Fix showing assertion info in backtrace

### DIFF
--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -69,17 +69,19 @@ static TitleAndText build_backtrace(const CoreDump::Reader& coredump, const ELF:
         builder.append('\n');
     };
 
+    auto& backtrace_entries = backtrace.entries();
+
+    if (coredump.metadata().contains("assertion"))
+        prepend_metadata("assertion", "ASSERTION FAILED: {}");
+    else if (coredump.metadata().contains("pledge_violation"))
+        prepend_metadata("pledge_violation", "Has not pledged {}");
+
     auto first_entry = true;
     for (auto& entry : backtrace.entries()) {
-        if (first_entry) {
-            if (entry.function_name.starts_with("__assertion_failed"))
-                prepend_metadata("assertion", "ASSERTION FAILED: {}");
-            else if (coredump.metadata().contains("pledge_violation"))
-                prepend_metadata("pledge_violation", "Has not pledged {}");
+        if (first_entry)
             first_entry = false;
-        } else {
+        else
             builder.append('\n');
-        }
         builder.append(entry.to_string());
     }
 


### PR DESCRIPTION
This was needlessly expecting the first backtrace entry function name to start with '__assertion_failed', which is no longer the case - it's now something from libsystem.so. Let's just check whether we have an 'assertion' key in the coredump's metadata, just like we do for pledge violations.