### PR TITLE
Ports: MilkyTracker v1.03 port

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -45,6 +45,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`mandoc`](mandoc/)            | mandoc                                        | 1.14.5            | https://mandoc.bsd.lv/                                |
 | [`mawk`](mawk/)                | mawk                                          | 1.3.4-20200120    | https://invisible-island.net/mawk/                    |
 | [`mbedtls`](mbedtls/)          | Mbed TLS                                      | 2.16.2            | https://tls.mbed.org/                                 |
+| [`milkytracker`](milkytracker/)| MilkyTracker                                  | 1.03              | https://github.com/milkytracker/MilkyTracker          |
 | [`mrsh`](mrsh/)                | mrsh                                          | d9763a3           | https://mrsh.sh/                                      |
 | [`nano`](nano/)                | GNU nano                                      | 4.5               | https://www.nano-editor.org/                          |
 | [`nasm`](nasm/)                | Netwide Assembler (NASM)                      | 2.14.02           | https://www.nasm.us/                                  |

--- a/Ports/milkytracker/package.sh
+++ b/Ports/milkytracker/package.sh
@@ -1,0 +1,12 @@
+#!/bin/bash ../.port_include.sh
+port=milkytracker
+version=1.03.00
+workdir=MilkyTracker-$version
+useconfigure=true
+files="https://github.com/milkytracker/MilkyTracker/archive/v$version.tar.gz MilkyTracker-$version.tar.gz"
+configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMakeToolchain.txt"
+depends="SDL2"
+
+configure() {
+    run cmake $configopts
+}

--- a/Ports/milkytracker/patches/BasicTypes-strings.patch
+++ b/Ports/milkytracker/patches/BasicTypes-strings.patch
@@ -1,0 +1,10 @@
+--- MilkyTracker-1.0.0bk/src/ppui/BasicTypes.h	2021-01-03 16:49:34.708314454 +0100
++++ MilkyTracker-1.0.0/src/ppui/BasicTypes.h	2021-01-03 17:14:26.352641274 +0100
+@@ -30,6 +30,7 @@
+ typedef unsigned int	pp_uint32;
+ typedef signed int		pp_int32;
+ 
++#include <strings.h>
+ #include "ScanCodes.h"
+ 
+ #if defined(WIN32) || defined(_WIN32_WCE) 

--- a/Ports/milkytracker/patches/CMakeLists.patch
+++ b/Ports/milkytracker/patches/CMakeLists.patch
@@ -1,0 +1,11 @@
+--- MilkyTracker-1.03.00/CMakeListsorig.txt	2021-01-04 15:50:36.284423249 +0100
++++ MilkyTracker-1.03.00/CMakeLists.txt	2021-01-04 15:50:25.028625114 +0100
+@@ -220,8 +220,6 @@
+     set(CMAKE_FIND_LIBRARY_SUFFIXES ${SUFFIXES_ORIG})
+ endif()
+ 
+-add_subdirectory(docs)
+-add_subdirectory(resources/music)
+ add_subdirectory(src/compression)
+ add_subdirectory(src/fx)
+ add_subdirectory(src/milkyplay)

--- a/Ports/milkytracker/patches/DisplayDevice_SDL.patch
+++ b/Ports/milkytracker/patches/DisplayDevice_SDL.patch
@@ -1,0 +1,73 @@
+--- MilkyTracker_orig/src/ppui/sdl/DisplayDevice_SDL.cpp	2020-12-09 23:58:14.000000000 +0100
++++ MilkyTracker-1.03.00/src/ppui/sdl/DisplayDevice_SDL.cpp	2021-02-20 10:24:50.816107401 +0100
+@@ -26,30 +26,8 @@
+ SDL_Window* PPDisplayDevice::CreateWindow(pp_int32& w, pp_int32& h, pp_int32& bpp, Uint32 flags)
+ {
+ 	size_t namelen = 0;
+-	char rendername[256] = { 0 };
+-	PFNGLGETSTRINGPROC glGetStringAPI = NULL;
+-
+-	for (int it = 0; it < SDL_GetNumRenderDrivers(); it++)
+-	{
+-		SDL_RendererInfo info;
+-		SDL_GetRenderDriverInfo(it, &info);
+-
+-		namelen += strlen(info.name) + 1;
+-		strncat(rendername, info.name, sizeof(rendername) - namelen);
+-		strncat(rendername, " ", sizeof(rendername) - namelen);
+-
+-		if (strncmp("opengles2", info.name, 9) == 0)
+-		{
+-			drv_index = it;
+-			SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+-			SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+-			SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+-			SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
+-		}
+-	}
+-
+ 	// Create SDL window
+-	SDL_Window* theWindow = SDL_CreateWindow("MilkyTracker", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, SDL_WINDOW_OPENGL | flags);
++	SDL_Window* theWindow = SDL_CreateWindow("MilkyTracker", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, flags);
+ 
+ 	if (theWindow == NULL)
+ 	{
+@@ -59,7 +37,7 @@
+ 		w = getDefaultWidth();
+ 		h = getDefaultHeight();
+ 		
+-		theWindow = SDL_CreateWindow("MilkyTracker", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, SDL_WINDOW_OPENGL | flags);
++		theWindow = SDL_CreateWindow("MilkyTracker", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, flags);
+ 		
+ 		if (theWindow == NULL)
+ 		{
+@@ -69,21 +47,6 @@
+ 		}
+ 	}
+ 
+-	SDL_GLContext ctx = SDL_GL_CreateContext(theWindow);
+-	SDL_GL_MakeCurrent(theWindow, ctx);
+-	
+-	glGetStringAPI = (PFNGLGETSTRINGPROC)SDL_GL_GetProcAddress("glGetString");
+-
+-	fprintf(stdout, "Available Renderers: %s\n", rendername);
+-	if (glGetStringAPI)
+-	{
+-		fprintf(stdout, "Vendor     : %s\n", glGetStringAPI(GL_VENDOR));
+-		fprintf(stdout, "Renderer   : %s\n", glGetStringAPI(GL_RENDERER));
+-		fprintf(stdout, "Version    : %s\n", glGetStringAPI(GL_VERSION));
+-#ifdef DEBUG
+-		fprintf(stdout, "Extensions : %s\n", glGetStringAPI(GL_EXTENSIONS));
+-#endif
+-	}
+ 	// Prevent window from being resized below minimum
+ 	SDL_SetWindowMinimumSize(theWindow, w, h);
+ 	fprintf(stderr, "SDL: Minimum window size set to %dx%d.\n", w, h);
+@@ -105,7 +68,6 @@
+ 
+ 	bFullScreen = fullScreen;
+ 
+-	drv_index = -1;
+ 
+ 	initMousePointers();
+ }

--- a/Ports/milkytracker/patches/ModuleEditor-exception.patch
+++ b/Ports/milkytracker/patches/ModuleEditor-exception.patch
@@ -1,0 +1,24 @@
+--- ModuleEditor.orig	2021-01-03 21:04:15.779375382 +0100
++++ MilkyTracker-1.03.00/src/tracker/ModuleEditor.cpp	2021-01-03 21:06:27.099748162 +0100
+@@ -699,16 +699,16 @@
+ 	
+ 		PPSystemString tempFile(getTempFilename());
+ 	
+-		try
+-		{
++		//try
++		//{
+ 			res = module->saveExtendedModule(tempFile) == MP_OK;
+ 			if(!res)
+ 				return res;
+ 
+ 			res = module->loadModule(tempFile) == MP_OK;
+-		} catch (const std::bad_alloc &) {
+-			return false;
+-		}
++		//} catch (const std::bad_alloc &) {
++		//	return false;
++		//}
+ 	
+ 		// restore one shot looping flag
+ 		if (type == XModule::ModuleType_MOD)

--- a/Ports/milkytracker/patches/PPSystem_POSIX.patch
+++ b/Ports/milkytracker/patches/PPSystem_POSIX.patch
@@ -1,0 +1,20 @@
+--- MilkyTracker_orig/src/ppui/osinterface/posix/PPSystem_POSIX.cpp	2020-12-09 23:58:14.000000000 +0100
++++ MilkyTracker-1.03.00/src/ppui/osinterface/posix/PPSystem_POSIX.cpp	2021-02-20 09:43:52.440927065 +0100
+@@ -53,6 +53,8 @@
+ #include <Path.h>
+ #endif
+ 
++#define PATH_MAX 4096
++
+ SYSCHAR System::buffer[PATH_MAX+1];
+ 
+ const SYSCHAR* System::getTempFileName()
+@@ -67,7 +69,7 @@
+ 	// instead of a file name.
+ #pragma clang diagnostic push
+ #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+-	if ((tmpnam(buffer) == NULL))
++	if ((mkstemp(buffer) == NULL))
+ #pragma clang diagnostic pop
+ 	{
+ 		// should not be the case, if it is the case, create something that

--- a/Ports/milkytracker/patches/SDL_Main-PATH_MAX.patch
+++ b/Ports/milkytracker/patches/SDL_Main-PATH_MAX.patch
@@ -1,0 +1,10 @@
+--- MilkyTracker-1.03.00/src/tracker/sdl/SDL_Main.cpp	2020-12-09 23:58:14.000000000 +0100
++++ MilkyTracker-1.03.00DD/src/tracker/sdl/SDL_Main.cpp	2021-01-04 15:26:23.821172703 +0100
+@@ -51,6 +51,7 @@
+  *    - Fix for french azerty keyboards (their number keys are shifted)
+  *
+  */
++#define PATH_MAX 4096
+ 
+ #ifdef HAVE_CONFIG_H
+ #include "config.h"

--- a/Ports/milkytracker/patches/SampleEditor-fabsf.patch
+++ b/Ports/milkytracker/patches/SampleEditor-fabsf.patch
@@ -1,0 +1,11 @@
+--- MilkyTracker-1.03.00/src/tracker/SampleEditor.cpp	2020-12-09 23:58:14.000000000 +0100
++++ SampleEditor.cpp	2021-01-07 21:31:05.830204543 +0100
+@@ -1620,7 +1620,7 @@
+ 
+ 			f = (1.0f-frac)*f1 + frac*f2;
+ 
+-			step = powf(16.0f,fabsf(fi));
++			step = powf(16.0f,fi);
+ 			// the lower half wave is matched
+ 			// to keep the frequency constant
+ 			if (f*fi<0.0f)

--- a/Ports/milkytracker/patches/tracker-CMakeLists.patch
+++ b/Ports/milkytracker/patches/tracker-CMakeLists.patch
@@ -1,0 +1,10 @@
+--- MilkyTracker-1.03.00d/src/tracker/CMakeLists.txt	2021-01-04 15:49:14.173940007 +0100
++++ MilkyTracker-1.03.00/src/tracker/CMakeLists.txt	2021-01-04 15:48:03.179731481 +0100
+@@ -374,4 +375,7 @@
+     set(INSTALL_DEST ${CMAKE_INSTALL_BINDIR})
+ endif()
+ 
++target_link_libraries(tracker -L../../SDL2/SDL-master-serenity/ -lSDL2 -lgui -lipc -lm)
++set(INSTALL_DEST ../../../../../../usr/bin/)
++
+ install(TARGETS tracker DESTINATION ${INSTALL_DEST})


### PR DESCRIPTION
Before i made my pt2-clone port I had a "dream" to see MilkyTracker working on Serenity. And even if i was able to get MilkyTracker to compile and sorta run, it was just more crashing than working back then. So I just gave up for a while and made the pt2-clone port.
But I came back to it and I think that @danboid will be excited to see this.

The port now works, plays, saves settings all as it should.
It's _nearly_ flawless, doesn't have any weird issues like pthread spam, broken settings, instant continuous backup crashes etc, but the only problem now is that the UI isn't refreshing and stays still, but it atleast plays now.

![Screen Shot 2021-02-20 at 02 34 11](https://user-images.githubusercontent.com/13377926/108578774-1e578080-7324-11eb-97d8-58c95890a329.png)


There are still a few things i want to improve (patches and old mistakes from before) so i'm drafting it for now.

Edit: there's a bit of noticable crackling, but it was also present on the pt2-clone