### PR TITLE
LanguageServers/Cpp: Add 'FindDeclaration' capability

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -119,4 +119,19 @@ String LexicalPath::canonicalized_path(const StringView& path)
     return LexicalPath(path).string();
 }
 
+String LexicalPath::relative_path(const String absolute_path, const String& prefix)
+{
+    if (!LexicalPath { absolute_path }.is_absolute() || !LexicalPath { prefix }.is_absolute())
+        return {};
+
+    if (!absolute_path.starts_with(prefix))
+        return absolute_path;
+
+    size_t prefix_length = LexicalPath { prefix }.string().length() + 1;
+    if (prefix_length >= absolute_path.length())
+        return {};
+
+    return absolute_path.substring(prefix_length);
+}
+
 }

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -50,6 +50,7 @@ public:
     bool has_extension(const StringView&) const;
 
     static String canonicalized_path(const StringView&);
+    static String relative_path(const String absolute_path, const String& prefix);
 
 private:
     void canonicalize();

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -431,7 +431,6 @@ void Editor::set_document(GUI::TextDocument& doc)
 
     if (m_language_client) {
         set_autocomplete_provider(make<LanguageServerAidedAutocompleteProvider>(*m_language_client));
-        dbgln("Opening {}", code_document.file_path());
         int fd = open(code_document.file_path().characters(), O_RDONLY | O_NOCTTY);
         if (fd < 0) {
             perror("open");

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -76,6 +76,7 @@ private:
 
     void show_documentation_tooltip_if_available(const String&, const Gfx::IntPoint& screen_location);
     void navigate_to_include_if_available(String);
+    void on_navigatable_link_click(const GUI::TextDocumentSpan&);
 
     Gfx::IntRect breakpoint_icon_rect(size_t line_number) const;
     static const Gfx::Bitmap& breakpoint_icon_bitmap();
@@ -109,7 +110,7 @@ private:
     String m_last_parsed_token;
     GUI::TextPosition m_previous_text_position { 0, 0 };
     bool m_hovering_editor { false };
-    bool m_hovering_link { false };
+    bool m_hovering_clickable { false };
     bool m_autocomplete_in_focus { false };
 
     OwnPtr<LanguageClient> m_language_client;

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * 2018-2021, the SerenityOS developers
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -77,6 +78,8 @@ private:
     void show_documentation_tooltip_if_available(const String&, const Gfx::IntPoint& screen_location);
     void navigate_to_include_if_available(String);
     void on_navigatable_link_click(const GUI::TextDocumentSpan&);
+    void on_identifier_click(const GUI::TextDocumentSpan&);
+    void open_and_set_cursor(const String& file, size_t line, size_t column);
 
     Gfx::IntRect breakpoint_icon_rect(size_t line_number) const;
     static const Gfx::Bitmap& breakpoint_icon_bitmap();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -210,8 +210,13 @@ Vector<String> HackStudioWidget::selected_file_names() const
     return files;
 }
 
-void HackStudioWidget::open_file(const String& filename)
+void HackStudioWidget::open_file(const String& full_filename)
 {
+    String filename = full_filename;
+    if (full_filename.starts_with(project().root_path())) {
+        filename = LexicalPath::relative_path(full_filename, project().root_path());
+    }
+    dbgln("HackStudio is opening {}", filename);
     if (Core::File::is_directory(filename))
         return;
 

--- a/Userland/DevTools/HackStudio/LanguageClient.h
+++ b/Userland/DevTools/HackStudio/LanguageClient.h
@@ -90,6 +90,7 @@ public:
 
 protected:
     virtual void handle(const Messages::LanguageClient::AutoCompleteSuggestions&) override;
+    virtual void handle(const Messages::LanguageClient::DeclarationLocation&) override;
 
     String m_project_path;
     WeakPtr<LanguageClient> m_language_client;
@@ -123,11 +124,14 @@ public:
     virtual void remove_text(const String& path, size_t from_line, size_t from_column, size_t to_line, size_t to_column);
     virtual void request_autocomplete(const String& path, size_t cursor_line, size_t cursor_column);
     virtual void set_autocomplete_mode(const String& mode);
+    virtual void search_declaration(const String& path, size_t line, size_t column);
 
     void provide_autocomplete_suggestions(const Vector<GUI::AutocompleteProvider::Entry>&);
+    void declaration_found(const String& file, size_t line, size_t column);
     void on_server_crash();
 
     Function<void(Vector<GUI::AutocompleteProvider::Entry>)> on_autocomplete_suggestions;
+    Function<void(const String&, size_t, size_t)> on_declaration_found;
 
 private:
     WeakPtr<ServerConnection> m_server_connection;

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/AutoCompleteEngine.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/AutoCompleteEngine.h
@@ -41,6 +41,13 @@ public:
     virtual void on_edit([[maybe_unused]] const String& file) {};
     virtual void file_opened([[maybe_unused]] const String& file) {};
 
+    struct ProjectPosition {
+        String file;
+        size_t line;
+        size_t column;
+    };
+    virtual Optional<ProjectPosition> find_declaration_of(const String&, const GUI::TextPosition&) { return {}; };
+
 protected:
     const FileDB& filedb() const { return m_filedb; }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
@@ -57,6 +57,7 @@ private:
     virtual void handle(const Messages::LanguageServer::SetFileContent&) override;
     virtual void handle(const Messages::LanguageServer::AutoCompleteSuggestions&) override;
     virtual void handle(const Messages::LanguageServer::SetAutoCompleteMode&) override;
+    virtual void handle(const Messages::LanguageServer::FindDeclaration&) override;
 
     FileDB m_filedb;
     OwnPtr<AutoCompleteEngine> m_autocomplete_engine;

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
@@ -72,7 +72,7 @@ OwnPtr<ParserAutoComplete::DocumentData> ParserAutoComplete::create_document_dat
     auto document = filedb().get(file);
     ASSERT(document);
     auto content = document->text();
-    auto document_data = make<DocumentData>(document->text());
+    auto document_data = make<DocumentData>(document->text(), file);
     auto root = document_data->parser.parse();
     for (auto& path : document_data->preprocessor.included_paths()) {
         get_or_create_document_data(document_path_from_include_path(path));
@@ -88,10 +88,10 @@ void ParserAutoComplete::set_document_data(const String& file, OwnPtr<DocumentDa
     m_documents.set(filedb().to_absolute_path(file), move(data));
 }
 
-ParserAutoComplete::DocumentData::DocumentData(String&& _text)
+ParserAutoComplete::DocumentData::DocumentData(String&& _text, const String& filename)
     : text(move(_text))
     , preprocessor(text.view())
-    , parser(preprocessor.process().view())
+    , parser(preprocessor.process().view(), filename)
 {
 }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
@@ -47,10 +47,11 @@ public:
     virtual Vector<GUI::AutocompleteProvider::Entry> get_suggestions(const String& file, const GUI::TextPosition& autocomplete_position) override;
     virtual void on_edit(const String& file) override;
     virtual void file_opened([[maybe_unused]] const String& file) override;
+    virtual Optional<ProjectPosition> find_declaration_of(const String& file_name, const GUI::TextPosition& identifier_position) override;
 
 private:
     struct DocumentData {
-        DocumentData(String&& text);
+        DocumentData(String&& text, const String& filename);
         String text;
         Preprocessor preprocessor;
         Parser parser;
@@ -63,6 +64,8 @@ private:
     String type_of_variable(const Identifier&) const;
     bool is_property(const ASTNode&) const;
     bool is_empty_property(const DocumentData&, const ASTNode&, const Position& autocomplete_position) const;
+    RefPtr<Declaration> find_declaration_of(const DocumentData&, const ASTNode&) const;
+    NonnullRefPtrVector<Declaration> get_available_declarations(const DocumentData&, const ASTNode&) const;
 
     struct PropertyInfo {
         StringView name;

--- a/Userland/DevTools/HackStudio/LanguageServers/LanguageClient.ipc
+++ b/Userland/DevTools/HackStudio/LanguageServers/LanguageClient.ipc
@@ -1,4 +1,5 @@
 endpoint LanguageClient = 8002
 {
     AutoCompleteSuggestions(Vector<GUI::AutocompleteProvider::Entry> suggestions) =|
+    DeclarationLocation(String file_name, i32 line, i32 column) =|
 }

--- a/Userland/DevTools/HackStudio/LanguageServers/LanguageServer.ipc
+++ b/Userland/DevTools/HackStudio/LanguageServers/LanguageServer.ipc
@@ -9,4 +9,6 @@ endpoint LanguageServer = 8001
 
     AutoCompleteSuggestions(String file_name, i32 cursor_line, i32 cursor_column) =|
     SetAutoCompleteMode(String mode) =|
+    FindDeclaration(String file_name, i32 line, i32 column) =|
+
 }

--- a/Userland/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.h
@@ -57,6 +57,7 @@ private:
     virtual void handle(const Messages::LanguageServer::SetFileContent&) override;
     virtual void handle(const Messages::LanguageServer::AutoCompleteSuggestions&) override;
     virtual void handle(const Messages::LanguageServer::SetAutoCompleteMode&) override { }
+    virtual void handle(const Messages::LanguageServer::FindDeclaration&) override {};
 
     RefPtr<GUI::TextDocument> document_for(const String& file_name);
 

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -38,9 +38,10 @@
 
 namespace Cpp {
 
-Parser::Parser(const StringView& program)
+Parser::Parser(const StringView& program, const String& filename)
     : m_program(program)
     , m_lines(m_program.split_view("\n", true))
+    , m_filename(filename)
 {
     Lexer lexer(m_program);
     for (auto& token : lexer.lex()) {

--- a/Userland/Libraries/LibCpp/Parser.h
+++ b/Userland/Libraries/LibCpp/Parser.h
@@ -34,7 +34,7 @@ namespace Cpp {
 
 class Parser final {
 public:
-    explicit Parser(const StringView&);
+    explicit Parser(const StringView& program, const String& filename);
     ~Parser() = default;
 
     NonnullRefPtr<TranslationUnit> parse();
@@ -137,7 +137,7 @@ private:
     NonnullRefPtr<T>
     create_ast_node(ASTNode& parent, const Position& start, Optional<Position> end, Args&&... args)
     {
-        auto node = adopt(*new T(&parent, start, end, forward<Args>(args)...));
+        auto node = adopt(*new T(&parent, start, end, m_filename, forward<Args>(args)...));
         m_nodes.append(node);
         return node;
     }
@@ -145,7 +145,7 @@ private:
     NonnullRefPtr<TranslationUnit>
     create_root_ast_node(const Position& start, Position end)
     {
-        auto node = adopt(*new TranslationUnit(nullptr, start, end));
+        auto node = adopt(*new TranslationUnit(nullptr, start, end, m_filename));
         m_nodes.append(node);
         m_root_node = node;
         return node;
@@ -153,6 +153,7 @@ private:
 
     StringView m_program;
     Vector<StringView> m_lines;
+    String m_filename;
     Vector<Token> m_tokens;
     State m_state;
     Vector<State> m_saved_states;

--- a/Userland/Utilities/CppParserTest.cpp
+++ b/Userland/Utilities/CppParserTest.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
     }
     auto content = file->read_all();
     StringView content_view(content);
-    ::Cpp::Parser parser(content_view);
+    ::Cpp::Parser parser(content_view, path);
     if (tokens_mode) {
         parser.print_tokens();
         return 0;


### PR DESCRIPTION
The C++ LanguageServer can now find the matching declaration for variable names, function calls, struct/class types and properties.

When clicking on one of the above with Ctrl pressed, HackStudio will ask the language server to find a matching declaration, and navigate to the result in the Editor

Example usage:

![goto_declaration](https://user-images.githubusercontent.com/9247514/108593453-6a361400-737c-11eb-9a5c-a0efac28cc25.gif)
