### PR TITLE
SpaceAnalyzer: Added context menu for nodes

### DIFF
--- a/Userland/Applications/SpaceAnalyzer/CMakeLists.txt
+++ b/Userland/Applications/SpaceAnalyzer/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SOURCES
 )
 
 serenity_app(SpaceAnalyzer ICON app-space-analyzer)
-target_link_libraries(SpaceAnalyzer LibGfx LibGUI)
+target_link_libraries(SpaceAnalyzer LibDesktop LibGfx LibGUI)

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -312,6 +312,8 @@ void TreeMapWidget::mousedown_event(GUI::MouseEvent& event)
 
 void TreeMapWidget::doubleclick_event(GUI::MouseEvent& event)
 {
+    if (event.button() != GUI::MouseButton::Left)
+        return;
     const TreeMapNode* node = path_node(m_viewpoint);
     if (node && !node_is_leaf(*node)) {
         Vector<int> path = path_to_position(event.position());
@@ -339,6 +341,12 @@ void TreeMapWidget::mousewheel_event(GUI::MouseEvent& event)
         size_t step_up = (-delta) / step_size;
         set_viewpoint(m_viewpoint + step_up);
     }
+}
+
+void TreeMapWidget::context_menu_event(GUI::ContextMenuEvent& context_menu_event)
+{
+    if (on_context_menu_request)
+        on_context_menu_request(context_menu_event);
 }
 
 void TreeMapWidget::set_tree(RefPtr<TreeMap> tree)

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.h
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.h
@@ -50,6 +50,7 @@ class TreeMapWidget final : public GUI::Frame {
 public:
     virtual ~TreeMapWidget() override;
     Function<void()> on_path_change;
+    Function<void(GUI::ContextMenuEvent&)> on_context_menu_request;
     size_t path_size() const;
     const TreeMapNode* path_node(size_t n) const;
     size_t viewpoint() const;
@@ -62,6 +63,7 @@ private:
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void doubleclick_event(GUI::MouseEvent&) override;
     virtual void mousewheel_event(GUI::MouseEvent&) override;
+    virtual void context_menu_event(GUI::ContextMenuEvent&) override;
 
     bool rect_can_contain_children(const Gfx::IntRect& rect) const;
     bool rect_can_contain_label(const Gfx::IntRect& rect) const;


### PR DESCRIPTION
Currently supports 3 actions: Open, Copy Path, and Delete (as described in  #4979).
![Screenshot_20210220_175347](https://user-images.githubusercontent.com/1040972/108601334-c0b74880-73a4-11eb-8965-35eaa6cb4a3a.png)
