### PR TITLE
LibLine: Avoid refreshing the entire line when inserting at the end

### DIFF
--- a/AK/Debug.h.in
+++ b/AK/Debug.h.in
@@ -238,6 +238,10 @@
 #cmakedefine01 LEXER_DEBUG
 #endif
 
+#ifndef LINE_EDITOR_DEBUG
+#cmakedefine01 LINE_EDITOR_DEBUG
+#endif
+
 #ifndef LOG_DEBUG
 #cmakedefine01 LOG_DEBUG
 #endif

--- a/Meta/CMake/all_the_debug_macros.cmake
+++ b/Meta/CMake/all_the_debug_macros.cmake
@@ -168,6 +168,7 @@ set(DEBUG_AUTOCOMPLETE ON)
 set(FILE_WATCHER_DEBUG ON)
 set(SYSCALL_1_DEBUG ON)
 set(RSA_PARSE_DEBUG ON)
+set(LINE_EDITOR_DEBUG ON)
 
 # False positive: DEBUG is a flag but it works differently.
 # set(DEBUG ON)

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -410,8 +410,9 @@ private:
 
     size_t m_cursor { 0 };
     size_t m_drawn_cursor { 0 };
+    size_t m_drawn_end_of_line_offset { 0 };
     size_t m_inline_search_cursor { 0 };
-    size_t m_chars_inserted_in_the_middle { 0 };
+    size_t m_chars_touched_in_the_middle { 0 };
     size_t m_times_tab_pressed { 0 };
     size_t m_num_columns { 0 };
     size_t m_num_lines { 1 };
@@ -470,11 +471,14 @@ private:
     };
     InputState m_state { InputState::Free };
 
-    HashMap<u32, HashMap<u32, Style>> m_spans_starting;
-    HashMap<u32, HashMap<u32, Style>> m_spans_ending;
+    struct Spans {
+        HashMap<u32, HashMap<u32, Style>> m_spans_starting;
+        HashMap<u32, HashMap<u32, Style>> m_spans_ending;
+        HashMap<u32, HashMap<u32, Style>> m_anchored_spans_starting;
+        HashMap<u32, HashMap<u32, Style>> m_anchored_spans_ending;
 
-    HashMap<u32, HashMap<u32, Style>> m_anchored_spans_starting;
-    HashMap<u32, HashMap<u32, Style>> m_anchored_spans_ending;
+        bool contains_up_to_offset(const Spans& other, size_t offset) const;
+    } m_drawn_spans, m_current_spans;
 
     RefPtr<Core::Notifier> m_notifier;
 

--- a/Userland/Libraries/LibLine/Style.h
+++ b/Userland/Libraries/LibLine/Style.h
@@ -35,6 +35,8 @@ namespace Line {
 
 class Style {
 public:
+    bool operator==(const Style&) const = default;
+
     enum class XtermColor : int {
         Default = 9,
         Black = 0,
@@ -57,6 +59,8 @@ public:
     struct ItalicTag {
     };
     struct Color {
+        bool operator==(const Color&) const = default;
+
         explicit Color(XtermColor color)
             : m_xterm_color(color)
             , m_is_rgb(false)
@@ -104,6 +108,8 @@ public:
     };
 
     struct Hyperlink {
+        bool operator==(const Hyperlink&) const = default;
+
         explicit Hyperlink(const StringView& link)
             : m_link(link)
         {


### PR DESCRIPTION
This patchset allows the editor to avoid redrawing the entire line when
the changes cause no unrecoverable style updates, and are at the end of
the line (this applies to most normal typing situations).
Cases that this does not resolve:
- When the cursor is not at the end of the buffer
- When a display refresh changes the styles on the already-drawn parts
  of the line
- When the prompt has not yet been drawn, or has somehow changed

Fixes #5296.

cc @awesomekling, you ask for faster libline redraws, you get more convoluted redraw logic