### PR TITLE
Run: Prevent printing [null] in case of empty history

### DIFF
--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -101,6 +101,8 @@ void RunWindow::event(Core::Event& event)
             // Escape key pressed, close dialog
             close();
             return;
+        } else if ((key_event.key() == Key_Up || key_event.key() == Key_Down) && m_path_history.is_empty()) {
+            return;
         }
     }
 


### PR DESCRIPTION
Pressing up-arrow or down-arrow with empty command history printed
[null] in the text area.

Fixes #5426