### PR TITLE
LibLine: Update the lazy refresh data and flags in some more places

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1531,12 +1531,16 @@ void VT::apply_style(const Style& style, bool is_starting)
 
 void VT::clear_lines(size_t count_above, size_t count_below)
 {
-    // Go down count_below lines.
-    if (count_below > 0)
-        fprintf(stderr, "\033[%dB", (int)count_below);
-    // Then clear lines going upwards.
-    for (size_t i = count_below + count_above; i > 0; --i)
-        fputs(i == 1 ? "\033[2K" : "\033[2K\033[A", stderr);
+    if (count_below + count_above == 0) {
+        fputs("\033[2K", stderr);
+    } else {
+        // Go down count_below lines.
+        if (count_below > 0)
+            fprintf(stderr, "\033[%dB", (int)count_below);
+        // Then clear lines going upwards.
+        for (size_t i = count_below + count_above; i > 0; --i)
+            fputs(i == 1 ? "\033[2K" : "\033[2K\033[A", stderr);
+    }
 }
 
 void VT::save_cursor()

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -319,6 +319,9 @@ private:
         m_refresh_needed = true;
         m_input_error.clear();
         m_returned_line = String::empty();
+        m_chars_touched_in_the_middle = 0;
+        m_drawn_end_of_line_offset = 0;
+        m_drawn_spans = {};
     }
 
     void refresh_display();

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -65,6 +65,7 @@ void Editor::search_forwards()
         }
     } else {
         m_search_offset_state = SearchOffsetState::Unbiased;
+        m_chars_touched_in_the_middle = buffer().size();
         m_cursor = 0;
         m_buffer.clear();
         insert(search_phrase);
@@ -218,6 +219,7 @@ void Editor::transpose_characters()
         swap(m_buffer[m_cursor - 1], m_buffer[m_cursor - 2]);
         // FIXME: Update anchored styles too.
         m_refresh_needed = true;
+        m_chars_touched_in_the_middle += 2;
     }
 }
 
@@ -245,6 +247,8 @@ void Editor::enter_search()
             StringBuilder builder;
             builder.append(Utf32View { search_editor.buffer().data(), search_editor.buffer().size() });
             if (!search(builder.build(), false, false)) {
+                m_chars_touched_in_the_middle = m_buffer.size();
+                m_refresh_needed = true;
                 m_buffer.clear();
                 m_cursor = 0;
             }
@@ -405,6 +409,7 @@ void Editor::transpose_words()
         m_cursor = cursor;
         // FIXME: Update anchored styles too.
         m_refresh_needed = true;
+        m_chars_touched_in_the_middle += end - start;
     }
 }
 
@@ -428,6 +433,7 @@ void Editor::clear_screen()
     VT::move_absolute(1, 1);
     set_origin(1, 1);
     m_refresh_needed = true;
+    m_cached_prompt_valid = false;
 }
 
 void Editor::insert_last_words()


### PR DESCRIPTION
These were forgotten in the last LibLine commit, any changes to m_buffer
not going through insert() and remove_at_index() should also be updating
these.

Fixes #5440.

LibLine: That one library in dire need of tests...a VT test thing would be nice...