### PR TITLE
AK + Kernel: Remove unneeded Thread::set_default_signal_dispositions

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -78,6 +78,14 @@ struct Array {
     constexpr operator Span<const T>() const { return span(); }
     constexpr operator Span<T>() { return span(); }
 
+    constexpr size_t fill(const T& value)
+    {
+        for (size_t idx = 0; idx < Size; ++idx)
+            __data[idx] = value;
+
+        return Size;
+    }
+
     T __data[Size];
 };
 

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -46,6 +46,13 @@ public:
     {
     }
 
+    template<size_t size>
+    ALWAYS_INLINE constexpr Span(T (&values)[size])
+        : m_values(values)
+        , m_size(size)
+    {
+    }
+
 protected:
     T* m_values { nullptr };
     size_t m_size { 0 };

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -544,7 +544,6 @@ KResult Process::do_exec(NonnullRefPtr<FileDescription> main_program_description
     m_coredump_metadata.clear();
 
     auto current_thread = Thread::current();
-    current_thread->set_default_signal_dispositions();
     current_thread->clear_signals();
 
     clear_futex_queues_on_exec();

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -547,9 +547,7 @@ void Thread::clear_signals()
     m_signal_mask = 0;
     m_pending_signals = 0;
     m_have_any_unmasked_pending_signals.store(false, AK::memory_order_release);
-
-    Span<SignalActionData> action_data(m_signal_action_data);
-    action_data.fill({});
+    m_signal_action_data.fill({});
 }
 
 // Certain exceptions, such as SIGSEGV and SIGILL, put a
@@ -868,7 +866,8 @@ RefPtr<Thread> Thread::clone(Process& process)
     if (thread_or_error.is_error())
         return {};
     auto& clone = thread_or_error.value();
-    memcpy(clone->m_signal_action_data, m_signal_action_data, sizeof(m_signal_action_data));
+    auto signal_action_data_span = m_signal_action_data.span();
+    signal_action_data_span.copy_to(clone->m_signal_action_data.span());
     clone->m_signal_mask = m_signal_mask;
     memcpy(clone->m_fpu_state, m_fpu_state, sizeof(FPUState));
     clone->m_thread_specific_data = m_thread_specific_data;

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -47,6 +47,7 @@
 #include <Kernel/TimerQueue.h>
 #include <Kernel/UnixTypes.h>
 #include <LibC/fd_set.h>
+#include <LibC/signal_numbers.h>
 
 namespace Kernel {
 
@@ -1239,7 +1240,7 @@ private:
     u32 m_kernel_stack_top { 0 };
     OwnPtr<Region> m_kernel_stack_region;
     VirtualAddress m_thread_specific_data;
-    SignalActionData m_signal_action_data[32] { };
+    Array<SignalActionData, NSIG> m_signal_action_data;
     Blocker* m_blocker { nullptr };
 
 #if LOCK_DEBUG

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1007,8 +1007,6 @@ public:
 
     FPUState& fpu_state() { return *m_fpu_state; }
 
-    void set_default_signal_dispositions();
-
     KResult make_thread_specific_region(Badge<Process>);
 
     unsigned syscall_count() const { return m_syscall_count; }
@@ -1241,7 +1239,7 @@ private:
     u32 m_kernel_stack_top { 0 };
     OwnPtr<Region> m_kernel_stack_region;
     VirtualAddress m_thread_specific_data;
-    SignalActionData m_signal_action_data[32];
+    SignalActionData m_signal_action_data[32] { };
     Blocker* m_blocker { nullptr };
 
 #if LOCK_DEBUG


### PR DESCRIPTION
* Add `Span<T>` constructor for arrays. 

* Add `Array<T, Size>::fill(...)` 

* The `default_signal_action(u8 signal)` function already has the
  full mapping. The only caveat being that now we need to make
  sure the thread constructor and `clear_signals()` method do the work
  of resetting the `m_signal_action_data` array, instead or relying on
  the previous logic in `Thread::set_default_signal_dispositions`.

* Switch `Thread::m_signal_action_data` to use `Array<T, Size>`