### PR TITLE
AK + Kernel + Userland: Avoid raw memset where possible, as it's easy to introduce bugs. 

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -89,6 +89,8 @@ public:
 
     void grow(size_t size);
 
+    void zero_fill();
+
 private:
     explicit ByteBufferImpl(size_t);
     ByteBufferImpl(const void*, size_t);
@@ -248,6 +250,11 @@ public:
         __builtin_memcpy(this->data() + offset, data, data_size);
     }
 
+    void zero_fill()
+    {
+        m_impl->zero_fill();
+    }
+
     operator Bytes() { return bytes(); }
     operator ReadonlyBytes() const { return bytes(); }
 
@@ -293,6 +300,11 @@ inline void ByteBufferImpl::grow(size_t size)
     m_size = size;
     if (old_data)
         kfree(old_data);
+}
+
+inline void ByteBufferImpl::zero_fill()
+{
+    __builtin_memset(m_data, 0, m_size);
 }
 
 inline NonnullRefPtr<ByteBufferImpl> ByteBufferImpl::create_uninitialized(size_t size)

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -822,8 +822,7 @@ KResult Ext2FSInode::resize(u64 new_size)
         // FIXME: There are definitely more efficient ways to achieve this.
         size_t bytes_to_clear = new_size - old_size;
         size_t clear_from = old_size;
-        u8 zero_buffer[PAGE_SIZE];
-        memset(zero_buffer, 0, sizeof(zero_buffer));
+        u8 zero_buffer[PAGE_SIZE] {};
         while (bytes_to_clear) {
             auto nwritten = write_bytes(clear_from, min(sizeof(zero_buffer), bytes_to_clear), UserOrKernelBuffer::for_kernel_buffer(zero_buffer), nullptr);
             if (nwritten < 0)
@@ -1429,8 +1428,7 @@ KResultOr<NonnullRefPtr<Inode>> Ext2FS::create_inode(Ext2FSInode& parent_inode, 
 
     struct timeval now;
     kgettimeofday(now);
-    ext2_inode e2inode;
-    memset(&e2inode, 0, sizeof(ext2_inode));
+    ext2_inode e2inode {};
     e2inode.i_mode = mode;
     e2inode.i_uid = uid;
     e2inode.i_gid = gid;

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -343,7 +343,7 @@ KResult Ext2FS::write_block_list_for_inode(InodeIndex inode_index, ext2_inode& e
 
         auto dind_block_contents = ByteBuffer::create_uninitialized(block_size());
         if (dind_block_new) {
-            memset(dind_block_contents.data(), 0, dind_block_contents.size());
+            dind_block_contents.zero_fill();
             dind_block_dirty = true;
         } else {
             auto buffer = UserOrKernelBuffer::for_kernel_buffer(dind_block_contents.data());
@@ -370,7 +370,7 @@ KResult Ext2FS::write_block_list_for_inode(InodeIndex inode_index, ext2_inode& e
 
             auto ind_block_contents = ByteBuffer::create_uninitialized(block_size());
             if (ind_block_new) {
-                memset(ind_block_contents.data(), 0, dind_block_contents.size());
+                ind_block_contents.zero_fill();
                 ind_block_dirty = true;
             } else {
                 auto buffer = UserOrKernelBuffer::for_kernel_buffer(ind_block_contents.data());

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -390,8 +390,7 @@ void kgettimeofday(timeval& tv)
 
 siginfo_t Process::wait_info()
 {
-    siginfo_t siginfo;
-    memset(&siginfo, 0, sizeof(siginfo));
+    siginfo_t siginfo {};
     siginfo.si_signo = SIGCHLD;
     siginfo.si_pid = pid().value();
     siginfo.si_uid = uid();

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -739,11 +739,10 @@ bool Thread::WaitBlocker::unblock(Process& process, UnblockFlags flags, u8 signa
         // more than once!
         do_set_result(process.wait_info());
     } else {
-        siginfo_t siginfo;
-        memset(&siginfo, 0, sizeof(siginfo));
+        siginfo_t siginfo {};
         {
             ScopedSpinLock lock(g_scheduler_lock);
-            // We need to gather the information before we release the sheduler lock!
+            // We need to gather the information before we release the scheduler lock!
             siginfo.si_signo = SIGCHLD;
             siginfo.si_pid = process.pid().value();
             siginfo.si_uid = process.uid();

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -213,8 +213,8 @@ int main(int argc, char** argv)
     }
     g_debug_session = result.release_nonnull();
 
-    struct sigaction sa;
-    memset(&sa, 0, sizeof(struct sigaction));
+    struct sigaction sa {
+    };
     sa.sa_handler = handle_sigint;
     sigaction(SIGINT, &sa, nullptr);
 

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -63,8 +63,8 @@ int main(int argc, char** argv)
             return 1;
         }
 
-        struct sockaddr_in sa;
-        memset(&sa, 0, sizeof sa);
+        struct sockaddr_in sa {
+        };
         sa.sin_family = AF_INET;
         sa.sin_port = htons(port);
         sa.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -133,9 +133,8 @@ int main(int argc, char** argv)
 
         char addr_str[INET_ADDRSTRLEN];
 
-        struct sockaddr_in dst_addr;
-        memset(&dst_addr, 0, sizeof(dst_addr));
-
+        struct sockaddr_in dst_addr {
+        };
         dst_addr.sin_family = AF_INET;
         dst_addr.sin_port = htons(port);
         if (inet_pton(AF_INET, addr, &dst_addr.sin_addr) < 0) {


### PR DESCRIPTION
Raw `memset` is relatively easy to mess up, avoid it when there are
better alternatives provided by the compiler in modern C++.

This change addresses this by using uniform initialization instead of `memset` for stack variables

The other change is to enlighten `ByteBuffer` with a new `zero_buffer` function which performs the
`memset` internally with the known pointer / data size. 
