### PR TITLE
Kernel: Populate ELF::AuxilaryValue::Platform from Processor object.

### DIFF
--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -1013,6 +1013,11 @@ String Processor::features_string() const
     return builder.build();
 }
 
+String Processor::platform_string() const
+{
+    return "i386";
+}
+
 UNMAP_AFTER_INIT void Processor::early_initialize(u32 cpu)
 {
     m_self = this;

--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -1069,6 +1069,8 @@ public:
     static Vector<FlatPtr> capture_stack_trace(Thread& thread, size_t max_frames = 0);
 
     void set_thread_specific(u8* data, size_t len);
+
+    String platform_string() const;
 };
 
 class ScopedCritical {

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -651,8 +651,7 @@ static Vector<ELF::AuxiliaryValue> generate_auxiliary_vector(FlatPtr load_base, 
     auxv.append({ ELF::AuxiliaryValue::Gid, (long)gid });
     auxv.append({ ELF::AuxiliaryValue::EGid, (long)egid });
 
-    // FIXME: Don't hard code this? We might support other platforms later.. (e.g. x86_64)
-    auxv.append({ ELF::AuxiliaryValue::Platform, "i386" });
+    auxv.append({ ELF::AuxiliaryValue::Platform, Processor::current().platform_string() });
     // FIXME: This is platform specific
     auxv.append({ ELF::AuxiliaryValue::HwCap, (long)CPUID(1).edx() });
 


### PR DESCRIPTION
Move this to the processor object so it can easily be implemented
when Serenity is compiled for a different architecture.