### PR TITLE
Kernel: Handle overflow in more places

### DIFF
--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -138,6 +138,8 @@ off_t FileDescription::seek(off_t offset, int whence)
         new_offset = offset;
         break;
     case SEEK_CUR:
+        if (Checked<off_t>::addition_would_overflow(m_current_offset, offset))
+            return -EOVERFLOW;
         new_offset = m_current_offset + offset;
         break;
     case SEEK_END:

--- a/Kernel/Syscalls/keymap.cpp
+++ b/Kernel/Syscalls/keymap.cpp
@@ -44,15 +44,15 @@ int Process::sys$setkeymap(Userspace<const Syscall::SC_setkeymap_params*> user_p
 
     Keyboard::CharacterMapData character_map_data;
 
-    if (!copy_from_user(character_map_data.map, params.map, CHAR_MAP_SIZE * sizeof(u32)))
+    if (!copy_n_from_user(character_map_data.map, params.map, CHAR_MAP_SIZE))
         return -EFAULT;
-    if (!copy_from_user(character_map_data.shift_map, params.shift_map, CHAR_MAP_SIZE * sizeof(u32)))
+    if (!copy_n_from_user(character_map_data.shift_map, params.shift_map, CHAR_MAP_SIZE))
         return -EFAULT;
-    if (!copy_from_user(character_map_data.alt_map, params.alt_map, CHAR_MAP_SIZE * sizeof(u32)))
+    if (!copy_n_from_user(character_map_data.alt_map, params.alt_map, CHAR_MAP_SIZE))
         return -EFAULT;
-    if (!copy_from_user(character_map_data.altgr_map, params.altgr_map, CHAR_MAP_SIZE * sizeof(u32)))
+    if (!copy_n_from_user(character_map_data.altgr_map, params.altgr_map, CHAR_MAP_SIZE))
         return -EFAULT;
-    if (!copy_from_user(character_map_data.shift_altgr_map, params.shift_altgr_map, CHAR_MAP_SIZE * sizeof(u32)))
+    if (!copy_n_from_user(character_map_data.shift_altgr_map, params.shift_altgr_map, CHAR_MAP_SIZE))
         return -EFAULT;
 
     auto map_name = get_syscall_path_argument(params.map_name);

--- a/Kernel/Syscalls/select.cpp
+++ b/Kernel/Syscalls/select.cpp
@@ -169,7 +169,7 @@ int Process::sys$poll(Userspace<const Syscall::SC_poll_params*> user_params)
         if (nfds_checked.has_overflow())
             return -EFAULT;
         fds_copy.resize(params.nfds);
-        if (!copy_from_user(&fds_copy[0], &params.fds[0], params.nfds * sizeof(pollfd)))
+        if (!copy_from_user(fds_copy.data(), &params.fds[0], nfds_checked.value()))
             return -EFAULT;
     }
 
@@ -242,7 +242,7 @@ int Process::sys$poll(Userspace<const Syscall::SC_poll_params*> user_params)
             fds_with_revents++;
     }
 
-    if (params.nfds > 0 && !copy_to_user(&params.fds[0], &fds_copy[0], params.nfds * sizeof(pollfd)))
+    if (params.nfds > 0 && !copy_to_user(&params.fds[0], fds_copy.data(), params.nfds * sizeof(pollfd)))
         return -EFAULT;
 
     return fds_with_revents;

--- a/Kernel/Syscalls/setuid.cpp
+++ b/Kernel/Syscalls/setuid.cpp
@@ -150,7 +150,7 @@ int Process::sys$setgroups(ssize_t count, Userspace<const gid_t*> user_gids)
 
     Vector<gid_t> gids;
     gids.resize(count);
-    if (!copy_from_user(gids.data(), user_gids.unsafe_userspace_ptr(), sizeof(gid_t) * count))
+    if (!copy_n_from_user(gids.data(), user_gids, count))
         return -EFAULT;
 
     HashTable<gid_t> unique_extra_gids;


### PR DESCRIPTION
Cleanup some overflow handling I noticed around the kernel:

- Handle overflow in `FileDescription::seek(, SEEK_CUR)`

- Kernel: Use `copy_n_from_user` in sys$setkeymap

- Use already computed `nfds_checked` value when copying from use. 

- Use `copy_n_from_user` in `sys$setgroups` to check for overflow 