### PR TITLE
LibC: Don't #define away __{BEGIN,END}_DECLS in stdarg.h

### DIFF
--- a/Userland/Libraries/LibC/stdarg.h
+++ b/Userland/Libraries/LibC/stdarg.h
@@ -26,19 +26,8 @@
 
 #pragma once
 
-#if defined(KERNEL)
-#    define __BEGIN_DECLS
-#    define __END_DECLS
-#else
-#    include <sys/cdefs.h>
-#endif
-
-__BEGIN_DECLS
-
 typedef __builtin_va_list va_list;
 
 #define va_start(v, l) __builtin_va_start(v, l)
 #define va_end(v) __builtin_va_end(v)
 #define va_arg(v, l) __builtin_va_arg(v, l)
-
-__END_DECLS


### PR DESCRIPTION
That would force anything that includes this to have language-specific
linkage, and absolutely break `sys/cdefs.h`.

Fixes #5452.

---

I had to bust out `g++ -E -dD` for this, very nasty to debug...