### PR TITLE
AK+WrapperGenerator: Add and use String::to_snakecase()

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -389,6 +389,11 @@ String String::to_uppercase() const
     return m_impl->to_uppercase();
 }
 
+String String::to_snakecase() const
+{
+    return StringUtils::to_snakecase(*this);
+}
+
 bool operator<(const char* characters, const String& string)
 {
     if (!characters)

--- a/AK/String.h
+++ b/AK/String.h
@@ -131,6 +131,7 @@ public:
 
     String to_lowercase() const;
     String to_uppercase() const;
+    String to_snakecase() const;
 
     bool is_whitespace() const { return StringUtils::is_whitespace(*this); }
 

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -29,6 +29,7 @@
 #include <AK/Memory.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
+#include <AK/StringBuilder.h>
 #include <AK/StringUtils.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
@@ -350,6 +351,33 @@ Optional<size_t> find(const StringView& haystack, const StringView& needle)
         haystack.characters_without_null_termination(), haystack.length(),
         needle.characters_without_null_termination(), needle.length());
 }
+
+String to_snakecase(const StringView& str)
+{
+    auto should_insert_underscore = [&](auto i, auto current_char) {
+        if (i == 0)
+            return false;
+        auto previous_ch = str[i - 1];
+        if (islower(previous_ch) && isupper(current_char))
+            return true;
+        if (i >= str.length() - 1)
+            return false;
+        auto next_ch = str[i + 1];
+        if (isupper(current_char) && islower(next_ch))
+            return true;
+        return false;
+    };
+
+    StringBuilder builder;
+    for (size_t i = 0; i < str.length(); ++i) {
+        auto ch = str[i];
+        if (should_insert_underscore(i, ch))
+            builder.append('_');
+        builder.append(tolower(ch));
+    }
+    return builder.to_string();
+}
+
 }
 
 }

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -72,6 +72,8 @@ bool contains(const StringView&, const StringView&, CaseSensitivity);
 bool is_whitespace(const StringView&);
 StringView trim_whitespace(const StringView&, TrimMode mode);
 Optional<size_t> find(const StringView& haystack, const StringView& needle);
+String to_snakecase(const StringView&);
+
 }
 
 }

--- a/AK/Tests/TestStringUtils.cpp
+++ b/AK/Tests/TestStringUtils.cpp
@@ -310,4 +310,18 @@ TEST_CASE(find)
     EXPECT_EQ(AK::StringUtils::find(test_string, "78").has_value(), false);
 }
 
+TEST_CASE(to_snakecase)
+{
+    EXPECT_EQ(AK::StringUtils::to_snakecase("foobar"), "foobar");
+    EXPECT_EQ(AK::StringUtils::to_snakecase("Foobar"), "foobar");
+    EXPECT_EQ(AK::StringUtils::to_snakecase("FOOBAR"), "foobar");
+    EXPECT_EQ(AK::StringUtils::to_snakecase("fooBar"), "foo_bar");
+    EXPECT_EQ(AK::StringUtils::to_snakecase("FooBar"), "foo_bar");
+    EXPECT_EQ(AK::StringUtils::to_snakecase("fooBAR"), "foo_bar");
+    EXPECT_EQ(AK::StringUtils::to_snakecase("FOOBar"), "foo_bar");
+    EXPECT_EQ(AK::StringUtils::to_snakecase("foo_bar"), "foo_bar");
+    EXPECT_EQ(AK::StringUtils::to_snakecase("FBar"), "f_bar");
+    EXPECT_EQ(AK::StringUtils::to_snakecase("FooB"), "foo_b");
+}
+
 TEST_MAIN(StringUtils)

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -39,7 +39,7 @@ DOMImplementation::DOMImplementation(Document& document)
 {
 }
 
-const NonnullRefPtr<Document> DOMImplementation::create_htmldocument(const String& title) const
+const NonnullRefPtr<Document> DOMImplementation::create_html_document(const String& title) const
 {
     auto html_document = Document::create();
 

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.h
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.h
@@ -45,8 +45,7 @@ public:
         return adopt(*new DOMImplementation(document));
     }
 
-    // FIXME: snake_case in WrapperGenerator turns "createHTMLDocument" into "create_htmldocument"
-    const NonnullRefPtr<Document> create_htmldocument(const String& title) const;
+    const NonnullRefPtr<Document> create_html_document(const String& title) const;
 
     // https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature
     bool has_feature() const { return true; }


### PR DESCRIPTION
This adds `to_snakecase()` to `AK::String{,Utils}` and uses it in WrapperGenerator, replacing the (slightly worse) `snake_name()` function. Also, tests :)