### PR TITLE
WindowServer: Re-evaluate the mouse cursor when alpha hit-testing

### DIFF
--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -603,6 +603,8 @@ void ClientConnection::handle(const Messages::WindowServer::DidFinishPainting& m
     auto& window = *(*it).value;
     for (auto& rect : message.rects())
         window.invalidate(rect);
+    if (window.has_alpha_channel() && window.alpha_hit_threshold() > 0.0)
+        WindowManager::the().reevaluate_hovered_window(&window);
 
     WindowSwitcher::the().refresh_if_needed();
 }
@@ -661,7 +663,8 @@ OwnPtr<Messages::WindowServer::SetWindowCursorResponse> ClientConnection::handle
         return {};
     }
     window.set_cursor(Cursor::create((Gfx::StandardCursor)message.cursor_type()));
-    Compositor::the().invalidate_cursor();
+    if (&window == WindowManager::the().hovered_window())
+        Compositor::the().invalidate_cursor();
     return make<Messages::WindowServer::SetWindowCursorResponse>();
 }
 

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -127,8 +127,10 @@ void Compositor::compose()
 
     {
         auto& current_cursor = wm.active_cursor();
-        if (m_current_cursor != &current_cursor)
+        if (m_current_cursor != &current_cursor) {
             change_cursor(&current_cursor);
+            m_invalidated_cursor = m_invalidated_any = true;
+        }
     }
 
     if (!m_invalidated_any) {

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -189,7 +189,7 @@ public:
 
     bool update_theme(String theme_path, String theme_name);
 
-    void set_hovered_window(Window*);
+    bool set_hovered_window(Window*);
     void deliver_mouse_event(Window& window, MouseEvent& event, bool process_double_click);
 
     void did_popup_a_menu(Badge<Menu>);
@@ -233,6 +233,9 @@ public:
 
     int compositor_icon_scale() const;
     void reload_icon_bitmaps_after_scale_change(bool allow_hidpi_icons = true);
+
+    void reevaluate_hovered_window(Window* = nullptr);
+    Window* hovered_window() const { return m_hovered_window.ptr(); }
 
 private:
     NonnullRefPtr<Cursor> get_cursor(const String& name);


### PR DESCRIPTION
A window repaint may change the alpha value, resulting in a different
hit test outcome. In those cases, re-evaluate the cursor hit testing
after a window was painted, and update the cursor if needed.

_Notice how this properly updates the cursor even though the mouse is not being moved:_
![hittest_cursor](https://user-images.githubusercontent.com/10320822/108635342-3cb09f80-743c-11eb-81ca-f66d442e704d.gif)
