### PR TITLE
CatDog: Fix wake-sleep "loop" when cursor is over right-top of head

### DIFF
--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -137,6 +137,8 @@ public:
 
     void mousemove_event(GUI::MouseEvent& event) override
     {
+        if (m_temp_pos == event.position())
+            return;
         m_temp_pos = event.position();
         m_timer.start();
         if (m_sleeping) {

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -751,7 +751,7 @@ void Window::flip(const Vector<Gfx::IntRect, 32>& dirty_rects)
     // Copy whatever was painted from the front to the back.
     Painter painter(m_back_store->bitmap());
     for (auto& dirty_rect : dirty_rects)
-        painter.blit(dirty_rect.location(), m_front_store->bitmap(), dirty_rect);
+        painter.blit(dirty_rect.location(), m_front_store->bitmap(), dirty_rect, 1.0f, false);
 
     m_back_store->bitmap().set_volatile();
 }


### PR DESCRIPTION
Because re-evaluation of the hovered window may trigger sending a
MouseMove event to a window we should only wake it if the mouse
position actually has changed.