### PR TITLE
TextEditor: Add basic case insensitivity to Find/Replace and reorganize its layout

### DIFF
--- a/Userland/Applications/TextEditor/TextEditorWidget.h
+++ b/Userland/Applications/TextEditor/TextEditorWidget.h
@@ -78,10 +78,8 @@ private:
     RefPtr<GUI::Action> m_vim_emulation_setting_action;
 
     RefPtr<GUI::Action> m_find_next_action;
-    RefPtr<GUI::Action> m_find_regex_action;
     RefPtr<GUI::Action> m_find_previous_action;
-    RefPtr<GUI::Action> m_replace_next_action;
-    RefPtr<GUI::Action> m_replace_previous_action;
+    RefPtr<GUI::Action> m_replace_action;
     RefPtr<GUI::Action> m_replace_all_action;
 
     RefPtr<GUI::Action> m_layout_toolbar_action;
@@ -99,13 +97,14 @@ private:
     RefPtr<GUI::TextBox> m_replace_textbox;
     RefPtr<GUI::Button> m_find_previous_button;
     RefPtr<GUI::Button> m_find_next_button;
-    RefPtr<GUI::Button> m_find_regex_button;
-    RefPtr<GUI::Button> m_replace_previous_button;
-    RefPtr<GUI::Button> m_replace_next_button;
+    RefPtr<GUI::Button> m_replace_button;
     RefPtr<GUI::Button> m_replace_all_button;
     RefPtr<GUI::Widget> m_find_replace_widget;
     RefPtr<GUI::Widget> m_find_widget;
     RefPtr<GUI::Widget> m_replace_widget;
+    RefPtr<GUI::CheckBox> m_regex_checkbox;
+    RefPtr<GUI::CheckBox> m_match_case_checkbox;
+    RefPtr<GUI::CheckBox> m_wrap_around_checkbox;
 
     GUI::ActionGroup m_wrapping_mode_actions;
     RefPtr<GUI::Action> m_no_wrapping_action;
@@ -126,7 +125,9 @@ private:
     bool m_document_dirty { false };
     bool m_document_opening { false };
     bool m_auto_detect_preview_mode { false };
-    bool m_find_use_regex { false };
+    bool m_use_regex { false };
+    bool m_match_case { true };
+    bool m_should_wrap { true };
 
     PreviewMode m_preview_mode { PreviewMode::None };
 };

--- a/Userland/Applications/TextEditor/TextEditorWindow.gml
+++ b/Userland/Applications/TextEditor/TextEditorWindow.gml
@@ -25,14 +25,15 @@
         }
     }
 
-    @GUI::Widget {
+    @GUI::GroupBox {
         name: "find_replace_widget"
         visible: false
         fill_with_background_color: true
-        fixed_height: 48
+        fixed_height: 56
 
         layout: @GUI::VerticalBoxLayout {
-            margins: [2, 2, 2, 4]
+            spacing: 2
+            margins: [5, 5, 5, 5]
         }
 
         @GUI::Widget {
@@ -41,18 +42,33 @@
             fixed_height: 22
 
             layout: @GUI::HorizontalBoxLayout {
+                spacing: 4
             }
 
             @GUI::Button {
                 name: "find_previous_button"
-                text: "Find previous"
-                fixed_width: 150
+                fixed_width: 38
             }
 
             @GUI::Button {
                 name: "find_next_button"
-                text: "Find next"
-                fixed_width: 150
+                fixed_width: 38
+            }
+
+            @GUI::TextBox {
+                name: "find_textbox"
+            }
+
+            @GUI::CheckBox {
+                name: "regex_checkbox"
+                text: "Use RegEx"
+                fixed_width: 80
+            }
+
+            @GUI::CheckBox {
+                name: "match_case_checkbox"
+                text: "Match case"
+                fixed_width: 85
             }
         }
 
@@ -62,24 +78,29 @@
             fixed_height: 22
 
             layout: @GUI::HorizontalBoxLayout {
+                spacing: 4
             }
 
             @GUI::Button {
-                name: "replace_previous_button"
-                text: "Replace previous"
-                fixed_width: 100
+                name: "replace_button"
+                text: "Replace"
+                fixed_width: 80
             }
 
-            @GUI::Button {
-                name: "replace_next_button"
-                text: "Replace next"
-                fixed_width: 100
+            @GUI::TextBox {
+                name: "replace_textbox"
             }
 
             @GUI::Button {
                 name: "replace_all_button"
                 text: "Replace all"
-                fixed_width: 100
+                fixed_width: 80
+            }
+
+            @GUI::CheckBox {
+                name: "wrap_around_checkbox"
+                text: "Wrap around"
+                fixed_width: 85
             }
         }
     }

--- a/Userland/Libraries/LibGUI/GroupBox.cpp
+++ b/Userland/Libraries/LibGUI/GroupBox.cpp
@@ -50,8 +50,8 @@ void GroupBox::paint_event(PaintEvent& event)
     painter.add_clip_rect(event.rect());
 
     Gfx::IntRect frame_rect {
-        0, font().glyph_height() / 2,
-        width(), height() - font().glyph_height() / 2
+        0, (!m_title.is_empty() ? font().glyph_height() / 2 : 0),
+        width(), height() - (!m_title.is_empty() ? font().glyph_height() / 2 : 0)
     };
     Gfx::StylePainter::paint_frame(painter, frame_rect, palette(), Gfx::FrameShape::Box, Gfx::FrameShadow::Sunken, 2);
 

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -387,7 +387,7 @@ void TextDocument::update_regex_matches(const StringView& needle)
     }
 }
 
-TextRange TextDocument::find_next(const StringView& needle, const TextPosition& start, SearchShouldWrap should_wrap, bool regmatch)
+TextRange TextDocument::find_next(const StringView& needle, const TextPosition& start, SearchShouldWrap should_wrap, bool regmatch, bool match_case)
 {
     if (needle.is_empty())
         return {};
@@ -450,7 +450,7 @@ TextRange TextDocument::find_next(const StringView& needle, const TextPosition& 
     do {
         auto ch = code_point_at(position);
         // FIXME: This is not the right way to use a Unicode needle!
-        if (ch == (u32)needle[needle_index]) {
+        if (match_case ? ch == (u32)needle[needle_index] : tolower(ch) == tolower((u32)needle[needle_index])) {
             if (needle_index == 0)
                 start_of_potential_match = position;
             ++needle_index;
@@ -467,7 +467,7 @@ TextRange TextDocument::find_next(const StringView& needle, const TextPosition& 
     return {};
 }
 
-TextRange TextDocument::find_previous(const StringView& needle, const TextPosition& start, SearchShouldWrap should_wrap, bool regmatch)
+TextRange TextDocument::find_previous(const StringView& needle, const TextPosition& start, SearchShouldWrap should_wrap, bool regmatch, bool match_case)
 {
     if (needle.is_empty())
         return {};
@@ -524,6 +524,8 @@ TextRange TextDocument::find_previous(const StringView& needle, const TextPositi
 
     TextPosition position = start.is_valid() ? start : TextPosition(0, 0);
     position = previous_position_before(position, should_wrap);
+    if (position.line() >= line_count())
+        return {};
     TextPosition original_position = position;
 
     TextPosition end_of_potential_match;
@@ -532,7 +534,7 @@ TextRange TextDocument::find_previous(const StringView& needle, const TextPositi
     do {
         auto ch = code_point_at(position);
         // FIXME: This is not the right way to use a Unicode needle!
-        if (ch == (u32)needle[needle_index]) {
+        if (match_case ? ch == (u32)needle[needle_index] : tolower(ch) == tolower((u32)needle[needle_index])) {
             if (needle_index == needle.length() - 1)
                 end_of_potential_match = position;
             if (needle_index == 0)

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -109,8 +109,8 @@ public:
     Vector<TextRange> find_all(const StringView& needle, bool regmatch = false);
 
     void update_regex_matches(const StringView&);
-    TextRange find_next(const StringView&, const TextPosition& start = {}, SearchShouldWrap = SearchShouldWrap::Yes, bool regmatch = false);
-    TextRange find_previous(const StringView&, const TextPosition& start = {}, SearchShouldWrap = SearchShouldWrap::Yes, bool regmatch = false);
+    TextRange find_next(const StringView&, const TextPosition& start = {}, SearchShouldWrap = SearchShouldWrap::Yes, bool regmatch = false, bool match_case = true);
+    TextRange find_previous(const StringView&, const TextPosition& start = {}, SearchShouldWrap = SearchShouldWrap::Yes, bool regmatch = false, bool match_case = true);
 
     TextPosition next_position_after(const TextPosition&, SearchShouldWrap = SearchShouldWrap::Yes) const;
     TextPosition previous_position_before(const TextPosition&, SearchShouldWrap = SearchShouldWrap::Yes) const;


### PR DESCRIPTION
Makes find a bit more useful until it gets proper code point matching
![find-replace](https://user-images.githubusercontent.com/66646555/108643761-f0845000-7479-11eb-8bde-46fff1265391.png)
