### PR TITLE
WindowServer: Reset menu position when opened by the menu bar

### DIFF
--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -323,7 +323,7 @@ void Menu::descend_into_submenu_at_hovered_item()
     ASSERT(hovered_item());
     auto submenu = hovered_item()->submenu();
     ASSERT(submenu);
-    MenuManager::the().open_menu(*submenu, false);
+    MenuManager::the().open_menu(*submenu, false, false);
     submenu->set_hovered_item(0);
     ASSERT(submenu->hovered_item()->type() != MenuItem::Separator);
 }
@@ -554,7 +554,7 @@ void Menu::do_popup(const Gfx::IntPoint& position, bool make_input)
 
     window.move_to(adjusted_pos);
     window.set_visible(true);
-    MenuManager::the().open_menu(*this, make_input);
+    MenuManager::the().open_menu(*this, false, make_input);
     WindowManager::the().did_popup_a_menu({});
 }
 

--- a/Userland/Services/WindowServer/MenuManager.cpp
+++ b/Userland/Services/WindowServer/MenuManager.cpp
@@ -291,7 +291,7 @@ void MenuManager::handle_mouse_event(MouseEvent& mouse_event)
 void MenuManager::handle_menu_mouse_event(Menu& menu, const MouseEvent& event)
 {
     bool is_hover_with_any_menu_open = event.type() == MouseEvent::MouseMove
-        && has_open_menu()
+        && has_open_menu() && m_current_menu_bar_menu
         && (m_open_menu_stack.first()->menubar() || m_open_menu_stack.first() == m_system_menu.ptr());
     bool is_mousedown_with_left_button = event.type() == MouseEvent::MouseDown && event.button() == MouseButton::Left;
     bool should_open_menu = (&menu != m_current_menu || !m_current_menu_bar_menu) && (is_hover_with_any_menu_open || is_mousedown_with_left_button);
@@ -305,7 +305,7 @@ void MenuManager::handle_menu_mouse_event(Menu& menu, const MouseEvent& event)
         return;
     }
 
-    if (!m_bar_open)
+    if (!m_bar_open && m_current_menu_bar_menu)
         close_everyone();
 }
 

--- a/Userland/Services/WindowServer/MenuManager.h
+++ b/Userland/Services/WindowServer/MenuManager.h
@@ -57,8 +57,7 @@ public:
     Menu* current_menu() { return m_current_menu.ptr(); }
     void set_current_menu(Menu*);
     void clear_current_menu();
-    void open_menu(Menu&, bool as_current_menu = true);
-    void toggle_menu(Menu&);
+    void open_menu(Menu&, bool from_menu_bar, bool as_current_menu = true);
 
     MenuBar* current_menubar() { return m_current_menubar.ptr(); }
     void set_current_menubar(MenuBar*);
@@ -108,6 +107,7 @@ private:
     RefPtr<Window> m_window;
 
     WeakPtr<Menu> m_current_menu;
+    WeakPtr<Menu> m_current_menu_bar_menu;
     WeakPtr<Window> m_previous_input_window;
     Vector<WeakPtr<Menu>> m_open_menu_stack;
 

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1178,7 +1178,7 @@ void WindowManager::event(Core::Event& event)
                 if (MenuManager::the().has_open_menu()) {
                     MenuManager::the().close_everyone();
                 } else {
-                    MenuManager::the().open_menu(*MenuManager::the().system_menu());
+                    MenuManager::the().open_menu(*MenuManager::the().system_menu(), true);
                 }
                 return;
             }


### PR DESCRIPTION
Also, only mark the menu bar item as opened if a menu was actually
opened through the menu bar.

These changes allow a menu to be used both in the menu bar as well
as a context menu.

Fixes #5469