### PR TITLE
HackStudio: Fix issue #5471 (files appearing empty)

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -695,8 +695,8 @@ void HackStudioWidget::create_project_tree_view(GUI::Widget& parent)
     };
 
     m_project_tree_view->on_activation = [this](auto& index) {
-        auto filename = index.data().as_string();
-        open_file(filename);
+        auto full_path_to_file = m_project->model().full_path(index);
+        open_file(full_path_to_file);
     };
 }
 


### PR DESCRIPTION
When files were placed outside of the project root, they would appear empty because the label in the tree would differ from the actual file path relative to the root.

I am uncertain how this regression was introduced, as this bug is not present in Andreas' earlier videos – nevermind, as it works now (again).

Fixes #5471.