### PR TITLE
CMake: Fix build incrementality for boot.S

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -326,7 +326,14 @@ add_compile_definitions(__serenity__)
 
 add_link_options(LINKER:-T ${CMAKE_CURRENT_BINARY_DIR}/linker.ld -nostdlib)
 
+# HACK: This is to work around a bug in CMake dependency resolution, the
+#       kernel won't re-link when boot.S changes without this.
+set_source_files_properties(init.cpp
+    PROPERTIES
+    OBJECT_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Arch/i386/Boot/boot.S
+)
 add_library(boot OBJECT Arch/i386/Boot/boot.S)
+
 add_library(kernel_heap STATIC ${KERNEL_HEAP_SOURCES})
 file(GENERATE OUTPUT linker.ld INPUT linker.ld)
 


### PR DESCRIPTION
Due to the non-standard way the boot assembler code is linked into
the kernel (not an actual dependency, but linked via linker.ld script)
both make and ninja weren't re-linking the kernel when boot.S was
changed. This should theoretically work since we use the cmake
`add_dependencies(..)` directive to express a manual dependency
on boot from Kernel, but something is obviously broken in cmake.

We can work around that with a hack, which forces a dependency on
a file we know will always exist in the kernel (init.cpp). So if
boot.S is rebuilt, then init.cpp is forced to be rebuilt, and then
we re-link the kernel. init.cpp is also relatively small, so it
compiles fast.