### PR TITLE
LibJS: Make ArrayPrototype an Array object

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Array.cpp
@@ -39,7 +39,12 @@ Array* Array::create(GlobalObject& global_object)
 Array::Array(Object& prototype)
     : Object(prototype)
 {
+}
+
+void Array::initialize(GlobalObject& global_object)
+{
     auto& vm = this->vm();
+    Object::initialize(global_object);
     define_native_property(vm.names.length, length_getter, length_setter, Attribute::Writable);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Array.h
@@ -30,13 +30,14 @@
 
 namespace JS {
 
-class Array final : public Object {
+class Array : public Object {
     JS_OBJECT(Array, Object);
 
 public:
     static Array* create(GlobalObject&);
 
     explicit Array(Object& prototype);
+    virtual void initialize(GlobalObject&) override;
     virtual ~Array() override;
 
     static Array* typed_this(VM&, GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -44,14 +44,14 @@ namespace JS {
 static HashTable<Object*> s_array_join_seen_objects;
 
 ArrayPrototype::ArrayPrototype(GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : Array(*global_object.object_prototype())
 {
 }
 
 void ArrayPrototype::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();
-    Object::initialize(global_object);
+    Array::initialize(global_object);
     u8 attr = Attribute::Writable | Attribute::Configurable;
 
     define_native_function(vm.names.filter, filter, 1, attr);
@@ -81,7 +81,6 @@ void ArrayPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.fill, fill, 1, attr);
     define_native_function(vm.names.values, values, 0, attr);
     define_native_function(vm.names.flat, flat, 0, attr);
-    define_property(vm.names.length, Value(0), Attribute::Configurable);
 
     // Use define_property here instead of define_native_function so that
     // Object.is(Array.prototype[Symbol.iterator], Array.prototype.values)

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.h
@@ -27,12 +27,12 @@
 
 #pragma once
 
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Array.h>
 
 namespace JS {
 
-class ArrayPrototype final : public Object {
-    JS_OBJECT(ArrayPrototype, Object);
+class ArrayPrototype final : public Array {
+    JS_OBJECT(ArrayPrototype, Array);
 
 public:
     ArrayPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -36,7 +36,7 @@
 namespace JS {
 
 RegExpPrototype::RegExpPrototype(GlobalObject& global_object)
-    : RegExpObject({}, {}, *global_object.object_prototype())
+    : Object(*global_object.object_prototype())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -30,8 +30,8 @@
 
 namespace JS {
 
-class RegExpPrototype final : public RegExpObject {
-    JS_OBJECT(RegExpPrototype, RegExpObject);
+class RegExpPrototype final : public Object {
+    JS_OBJECT(RegExpPrototype, Object);
 
 public:
     explicit RegExpPrototype(GlobalObject&);

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.isArray.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.isArray.js
@@ -21,6 +21,5 @@ test("arguments that evaluate to true", () => {
     expect(Array.isArray(new Array())).toBeTrue();
     expect(Array.isArray(new Array(10))).toBeTrue();
     expect(Array.isArray(new Array("a", "b", "c"))).toBeTrue();
-    // FIXME: Array.prototype is supposed to be an array!
-    // expect(Array.isArray(Array.prototype)).toBeTrue();
+    expect(Array.isArray(Array.prototype)).toBeTrue();
 });


### PR DESCRIPTION
That's how it's supposed to be, and it's not even complicated - no idea why that FIXME was around for so long. :^)