### PR TITLE
AK + LibELF: Add support for AK::StringView literals with operator""sv

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -213,4 +213,9 @@ struct Traits<StringView> : public GenericTraits<String> {
 
 }
 
+[[nodiscard]] ALWAYS_INLINE constexpr AK::StringView operator"" sv(const char* cstring, size_t length)
+{
+    return AK::StringView(cstring, length);
+}
+
 using AK::StringView;

--- a/AK/Tests/TestStringView.cpp
+++ b/AK/Tests/TestStringView.cpp
@@ -59,6 +59,15 @@ TEST_CASE(compare_views)
     EXPECT_EQ(view1, "foo");
 }
 
+TEST_CASE(string_view_literal_operator)
+{
+    StringView literal_view = "foo"sv;
+    String test_string = "foo";
+
+    EXPECT_EQ(literal_view.length(), test_string.length());
+    EXPECT_EQ(literal_view, test_string);
+}
+
 TEST_CASE(starts_with)
 {
     String test_string = "ABCDEF";

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,9 @@ else()
 endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    add_compile_options(-fconcepts)
+    add_compile_options(-fconcepts -Wno-literal-suffix)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_compile_options(-Wno-overloaded-virtual)
+    add_compile_options(-Wno-overloaded-virtual -Wno-user-defined-literals)
 endif()
 
 if (ENABLE_ALL_THE_DEBUG_MACROS)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual -Wno-user-defined-literals")
 
     if (ENABLE_ADDRESS_SANITIZER)
         add_definitions(-fsanitize=address -fno-omit-frame-pointer)

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -219,9 +219,8 @@ public:
 
     HashSection hash_section() const
     {
-        auto section_name = m_hash_type == HashType::SYSV
-            ? StringView { "DT_HASH", 7 }
-            : StringView { "DT_GNU_HASH", 11 };
+        auto section_name = m_hash_type == HashType::SYSV ? "DT_HASH"sv : "DT_GNU_HASH"sv;
+
         return HashSection(Section(*this, m_hash_table_offset, 0, 0, section_name), m_hash_type);
     }
 


### PR DESCRIPTION
 * AK: Add support for AK::StringView literals with operator""sv

    A new operator, operator""sv was added as of C++17 to support
    string_view literals. This allows string_views to be constructed
    from string literals and with no runtime cost to find the string
    length.

    See: https://en.cppreference.com/w/cpp/string/basic_string_view/operator%22%22sv

* LibELF: Use StringView literal syntax to build section names.

    This change implements that functionality in AK::StringView