### PR TITLE
Kernel: allow munmap to unmap multiple pages

### DIFF
--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -493,9 +493,6 @@ KResultOr<int> Process::sys$munmap(void* addr, size_t size)
     // Try again while checkin multiple regions at a time
     // slow: without caching
     const auto& regions = space().find_regions_intersecting(range_to_unmap);
-    // if there still no regions found error out
-    if (!regions.size())
-        return EINVAL;
 
     // check if any of the regions is not mmaped, to not accientally
     // error-out with just half a region map left
@@ -528,6 +525,7 @@ KResultOr<int> Process::sys$munmap(void* addr, size_t size)
     for (auto* new_region : new_regions) {
         new_region->map(space().page_directory());
     }
+
     return 0;
 }
 

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Leon Albrecht <leon2002.la@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -489,9 +490,45 @@ KResultOr<int> Process::sys$munmap(void* addr, size_t size)
         return 0;
     }
 
-    // FIXME: We should also support munmap() across multiple regions. (#175)
+    // Try again while checkin multiple regions at a time
+    // slow: without caching
+    const auto& regions = space().find_regions_intersecting(range_to_unmap);
+    // if there still no regions found error out
+    if (!regions.size())
+        return EINVAL;
 
-    return EINVAL;
+    // check if any of the regions is not mmaped, to not accientally
+    // error-out with just half a region map left
+    for (auto* region : regions) {
+        if (!region->is_mmap())
+            return EPERM;
+    }
+
+    Vector<Region*, 2> new_regions;
+
+    for (auto* old_region : regions) {
+        // if it's a full match we can delete the complete old region
+        if (old_region->range().intersect(range_to_unmap).size() == old_region->size()) {
+            bool res = space().deallocate_region(*old_region);
+            VERIFY(res);
+            continue;
+        }
+
+        // otherwise just split the regions and collect them for future mapping
+        new_regions.append(space().split_region_around_range(*old_region, range_to_unmap));
+
+        // We manually unmap the old region here, specifying that we *don't* want the VM deallocated.
+        old_region->unmap(Region::ShouldDeallocateVirtualMemoryRange::No);
+        bool res = space().deallocate_region(*old_region);
+        VERIFY(res);
+    }
+    // Instead we give back the unwanted VM manually at the end.
+    space().page_directory().range_allocator().deallocate(range_to_unmap);
+    // And finally we map the new region(s) using our page directory (they were just allocated and don't have one).
+    for (auto* new_region : new_regions) {
+        new_region->map(space().page_directory());
+    }
+    return 0;
 }
 
 KResultOr<FlatPtr> Process::sys$mremap(Userspace<const Syscall::SC_mremap_params*> user_params)

--- a/Kernel/VM/Range.cpp
+++ b/Kernel/VM/Range.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Leon Albrecht <leon2002.la@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,6 +43,16 @@ Vector<Range, 2> Range::carve(const Range& taken) const
     if (taken.end() < end())
         parts.append({ taken.end(), end().get() - taken.end().get() });
     return parts;
+}
+Range Range::intersect(const Range& other) const
+{
+    if (*this == other) {
+        return *this;
+    }
+    auto new_base = max(base(), other.base());
+    auto new_end = min(end(), other.end());
+    VERIFY(new_base < new_end);
+    return Range(new_base, (new_end - new_base).get());
 }
 
 }

--- a/Kernel/VM/Range.h
+++ b/Kernel/VM/Range.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Leon Albrecht <leon2002.la@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -67,6 +68,7 @@ public:
     }
 
     Vector<Range, 2> carve(const Range&) const;
+    Range intersect(const Range&) const;
 
 private:
     VirtualAddress m_base;

--- a/Kernel/VM/Space.h
+++ b/Kernel/VM/Space.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Leon Albrecht <leon2002.la@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,6 +28,7 @@
 #pragma once
 
 #include <AK/NonnullOwnPtrVector.h>
+#include <AK/Vector.h>
 #include <AK/WeakPtr.h>
 #include <Kernel/UnixTypes.h>
 #include <Kernel/VM/AllocationStrategy.h>
@@ -62,6 +64,8 @@ public:
 
     Region* find_region_from_range(const Range&);
     Region* find_region_containing(const Range&);
+
+    Vector<Region*> find_regions_intersecting(const Range&);
 
     bool enforces_syscall_regions() const { return m_enforces_syscall_regions; }
     void set_enforces_syscall_regions(bool b) { m_enforces_syscall_regions = b; }

--- a/Userland/Tests/Kernel/munmap-multi-region-unmapping.cpp
+++ b/Userland/Tests/Kernel/munmap-multi-region-unmapping.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Types.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+int main()
+{
+    {
+        printf("Testing full unnmap\n");
+        auto* map1 = mmap(nullptr, 2 * PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, 0, 0);
+        if (map1 == MAP_FAILED) {
+            perror("mmap 1");
+            return 1;
+        }
+        auto* map2 = mmap((void*)((FlatPtr)map1 + 2 * PAGE_SIZE), 2 * PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, 0, 0);
+        if (map2 == MAP_FAILED) {
+            perror("mmap 2");
+            return 1;
+        }
+
+        ((u32*)map1)[0] = 0x41414141;
+        ((u32*)map1)[PAGE_SIZE / sizeof(u32)] = 0x42424242;
+
+        ((u32*)map2)[0] = 0xbeefbeef;
+        ((u32*)map2)[PAGE_SIZE / sizeof(u32)] = 0xc0dec0de;
+
+        if (((u32*)map1)[0] != 0x41414141 || ((u32*)map1)[PAGE_SIZE / sizeof(u32)] != 0x42424242
+            || ((u32*)map2)[0] != 0xbeefbeef || ((u32*)map2)[PAGE_SIZE / sizeof(u32)] != 0xc0dec0de) {
+            perror("write");
+            return 1;
+        }
+
+        int res = munmap(map1, 4 * PAGE_SIZE);
+        if (res < 0) {
+            perror("unmap");
+            return 1;
+        }
+    }
+    {
+        printf("Testing partial unmaping\n");
+        auto* map1 = mmap(nullptr, 2 * PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, 0, 0);
+        if (map1 == MAP_FAILED) {
+            perror("mmap 1");
+            return 1;
+        }
+        auto* map2 = mmap((void*)((FlatPtr)map1 + 2 * PAGE_SIZE), 2 * PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, 0, 0);
+        if (map2 == MAP_FAILED) {
+            perror("mmap 2");
+            return 1;
+        }
+
+        ((u32*)map1)[0] = 0x41414141;
+        ((u32*)map1)[PAGE_SIZE / sizeof(u32)] = 0x42424242;
+
+        ((u32*)map2)[0] = 0xbeefbeef;
+        ((u32*)map2)[PAGE_SIZE / sizeof(u32)] = 0xc0dec0de;
+
+        if (((u32*)map1)[0] != 0x41414141 || ((u32*)map1)[PAGE_SIZE / sizeof(u32)] != 0x42424242
+            || ((u32*)map2)[0] != 0xbeefbeef || ((u32*)map2)[PAGE_SIZE / sizeof(u32)] != 0xc0dec0de) {
+            perror("write");
+            return 1;
+        }
+
+        int res = munmap((void*)((FlatPtr)map1 + PAGE_SIZE), 2 * PAGE_SIZE);
+        if (res < 0) {
+            perror("unmap");
+            return 1;
+        }
+
+        auto* map3 = mmap((void*)((FlatPtr)map1 + PAGE_SIZE), PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, 0, 0);
+        if (map3 == MAP_FAILED) {
+            perror("remap 1");
+            return 1;
+        }
+        auto* map4 = mmap(map2, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, 0, 0);
+        if (map4 == MAP_FAILED) {
+            perror("remap 2");
+            return 1;
+        }
+        ((u32*)map3)[0] = 0x13371337;
+        ((u32*)map4)[0] = 0x1b1b1b1b;
+        if (((u32*)map1)[0] != 0x41414141 || ((u32*)map2)[PAGE_SIZE / sizeof(u32)] != 0xc0dec0de
+            || ((u32*)map3)[0] != 0x13371337 || ((u32*)map4)[0] != 0x1b1b1b1b
+            || ((u32*)map1)[PAGE_SIZE / sizeof(int)] != ((u32*)map3)[0] || ((u32*)map2)[0] != ((u32*)map4)[0]) {
+            perror("read at old map and write at remap");
+            return 1;
+        }
+
+        res = munmap(map1, PAGE_SIZE * 4);
+        if (res < 0) {
+            perror("cleanup");
+            return 1;
+        }
+    }
+
+    printf("PASS\n");
+    return 0;
+}


### PR DESCRIPTION
This should fix #175, wich is lingering in the issue box since mid 2019

The implemetation is probably not efficient, because I dont ~know if the regions are sorted by adress in their list, if yes we could make it O(n) instead of  probably O(n^2)~ use the cache

Please check my logic and standard complience.