### PR TITLE
PixelPaint: Bug fixes

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -60,8 +60,15 @@ void ImageEditor::set_image(RefPtr<Image> image)
     update();
     relayout();
 
-    if (m_image)
+    if (m_image) {
+        for (size_t index = 0; index < m_image->layer_count(); ++index) {
+            const auto layer = &m_image->layer(index);
+            if (layer->is_selected())
+                set_active_layer(layer);
+        }
+
         m_image->add_client(*this);
+    }
 }
 
 void ImageEditor::did_complete_action()

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -52,9 +52,10 @@ RefPtr<Layer> Layer::create_with_bitmap(Image& image, const Gfx::Bitmap& bitmap,
     return adopt(*new Layer(image, bitmap, name));
 }
 
-RefPtr<Layer> Layer::create_snapshot(Image& image, const Layer& layer)
+RefPtr<Layer> Layer::create_snapshot_onto_image(Image& image, const Layer& layer)
 {
     auto snapshot = create_with_bitmap(image, *layer.bitmap().clone(), layer.name());
+    image.add_layer(*snapshot);
     snapshot->set_opacity_percent(layer.opacity_percent());
     snapshot->set_visible(layer.is_visible());
     snapshot->set_selected(layer.is_selected());

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -46,7 +46,7 @@ class Layer
 public:
     static RefPtr<Layer> create_with_size(Image&, const Gfx::IntSize&, const String& name);
     static RefPtr<Layer> create_with_bitmap(Image&, const Gfx::Bitmap&, const String& name);
-    static RefPtr<Layer> create_snapshot(Image&, const Layer&);
+    static RefPtr<Layer> create_snapshot_onto_image(Image&, const Layer&);
 
     ~Layer() { }
 


### PR DESCRIPTION
This PR fixes #5475 and another bug, where opened .pp projects would be uninteractable before a layer was actively (re)selected, even though the last used layer (from when the .pp project was saved) was highlighted in the list on the right.