### PR TITLE
LibGUI: Paint all widgets as toolbars in ToolBarContainer

### DIFF
--- a/Userland/Libraries/LibGUI/ToolBarContainer.cpp
+++ b/Userland/Libraries/LibGUI/ToolBarContainer.cpp
@@ -55,9 +55,9 @@ void ToolBarContainer::paint_event(GUI::PaintEvent& event)
     Painter painter(*this);
     painter.add_clip_rect(event.rect());
 
-    for_each_child_of_type<ToolBar>([&](auto& toolbar) {
-        if (toolbar.is_visible()) {
-            auto rect = toolbar.relative_rect();
+    for_each_child_widget([&](auto& widget) {
+        if (widget.is_visible()) {
+            auto rect = widget.relative_rect();
             painter.draw_line(rect.top_left().translated(0, -1), rect.top_right().translated(0, -1), palette().threed_highlight());
             painter.draw_line(rect.bottom_left().translated(0, 1), rect.bottom_right().translated(0, 1), palette().threed_shadow1());
         }


### PR DESCRIPTION
A while ago ToolBarContainer started checking for child widget type and stopped drawing the bookmark bar with proper threading. At first I thought it looked janky but then I went dark-theme-sicko-mode and realized it might look kinda nice recessed below the main toolbar. This makes that depth explicit in all themes. Up to you!
![toolbarcontainer](https://user-images.githubusercontent.com/66646555/109090284-bd8fc580-76e0-11eb-8fcb-a63caa7c4ecb.png)
