### PR TITLE
LibGUI: Make empty TextRange invalid

### DIFF
--- a/Userland/Libraries/LibGUI/TextRange.h
+++ b/Userland/Libraries/LibGUI/TextRange.h
@@ -40,7 +40,7 @@ public:
     {
     }
 
-    bool is_valid() const { return m_start.is_valid() && m_end.is_valid(); }
+    bool is_valid() const { return m_start.is_valid() && m_end.is_valid() && m_start != m_end; }
     void clear()
     {
         m_start = {};


### PR DESCRIPTION
Having TextRange which is empty doesn't make any sense.
So it confuses the functions that rely on having a valid range (selection range in case of #5341), and causes them to do no action.
Closes #5341