### PR TITLE
Kernel: Detach the traced process on process exit

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -540,6 +540,22 @@ void Process::die()
         return IterationDecision::Continue;
     });
 
+    {
+        ScopedSpinLock lock(g_processes_lock);
+        for (auto* process = g_processes->head(); process;) {
+            auto* next_process = process->next();
+            if (process->has_tracee_thread(m_pid)) {
+                dbgln_if(PROCESS_DEBUG, "Process {} ({}) is attached by {} ({}) which will exit", process->name(), process->pid(), name(), pid());
+                process->stop_tracing();
+                auto err = process->send_signal(SIGSTOP, this);
+                if (err.is_error())
+                    dbgln("Failed to send the SIGSTOP signal to {} ({})", process->name(), process->pid());
+            }
+
+            process = next_process;
+        }
+    }
+
     kill_all_threads();
 }
 


### PR DESCRIPTION
Currently, when a process which has a tracee exits, nothing will happen,
leaving the tracee unable to be attached again. This will call the
stop_tracing function on any process which is traced by the exiting
process and sending the SIGSTOP signal making the traced process wait
for a SIGCONT (just as Linux does)

(Not part of the commit message):
This was actually somewhat exploitable, since PID overflow is somewhat 
possible by forking until you get a PID which is the same as old tracer 
PID - not actually doable since it will 1. take a long time; 2. the system has 
to be completely idle since negative values will be returned as an error by libc 
and other programs may assert on that; 3. (?) Kernel UBSAN should kick in 
on the overflow. Anyway, if you could get a PID which was the same as the
exited tracer, that process had full ptrace rights (without doing a new 
PT_ATTACH).

