### PR TITLE
Everywhere: Add unused and old-style-cast warnings to AK, Kernel, and Libraries

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -327,7 +327,7 @@ inline NonnullRefPtr<ByteBufferImpl> ByteBufferImpl::copy(const void* data, size
 
 inline const LogStream& operator<<(const LogStream& stream, const ByteBuffer& value)
 {
-    stream.write((const char*)value.data(), value.size());
+    stream.write(reinterpret_cast<const char*>(value.data()), value.size());
     return stream;
 }
 

--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -1,3 +1,4 @@
 include(${CMAKE_SOURCE_DIR}/Meta/CMake/utils.cmake)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunused -Wold-style-cast")
 serenity_install_headers(AK)
 serenity_install_sources(AK)

--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -260,7 +260,7 @@ public:
         checked += v;
         return checked.has_overflow();
 #else
-        return __builtin_add_overflow_p(u, v, (T)0);
+        return __builtin_add_overflow_p(u, v, static_cast<T>(0));
 #endif
     }
 
@@ -273,7 +273,7 @@ public:
         checked *= v;
         return checked.has_overflow();
 #else
-        return __builtin_mul_overflow_p(u, v, (T)0);
+        return __builtin_mul_overflow_p(u, v, static_cast<T>(0));
 #endif
     }
 

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -283,7 +283,7 @@ private:
         auto* old_buckets = m_buckets;
         auto old_capacity = m_capacity;
 
-        m_buckets = (Bucket*)kmalloc(sizeof(Bucket) * (new_capacity + 1));
+        m_buckets = reinterpret_cast<Bucket*>(kmalloc(sizeof(Bucket) * (new_capacity + 1)));
         __builtin_memset(m_buckets, 0, sizeof(Bucket) * (new_capacity + 1));
         m_capacity = new_capacity;
         m_deleted_count = 0;

--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -273,7 +273,11 @@ inline typename IntrusiveList<T, member>::Iterator IntrusiveList<T, member>::end
 template<class T, IntrusiveListNode T::*member>
 inline T* IntrusiveList<T, member>::node_to_value(IntrusiveListNode& node)
 {
-    return (T*)((char*)&node - ((char*)&(((T*)nullptr)->*member) - (char*)nullptr));
+// FIXME: WTF is even going on here, why are we casting nullptrs?
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+    return reinterpret_cast<T*>((char*)&node - ((char*)&(((T*)nullptr)->*member) - (char*)nullptr));
+#pragma GCC diagnostic pop
 }
 
 inline IntrusiveListNode::~IntrusiveListNode()

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -225,16 +225,16 @@ public:
     {
 #if !defined(KERNEL)
         if (is_double())
-            return (T)as_double();
+            return static_cast<T>(as_double());
 #endif
         if (type() == Type::Int32)
-            return (T)as_i32();
+            return static_cast<T>(as_i32());
         if (type() == Type::UnsignedInt32)
-            return (T)as_u32();
+            return static_cast<T>(as_u32());
         if (type() == Type::Int64)
-            return (T)as_i64();
+            return static_cast<T>(as_i64());
         if (type() == Type::UnsignedInt64)
-            return (T)as_u64();
+            return static_cast<T>(as_u64());
         return default_value;
     }
 

--- a/AK/MACAddress.h
+++ b/AK/MACAddress.h
@@ -32,7 +32,8 @@
 #include <AK/String.h>
 #include <AK/Types.h>
 
-class [[gnu::packed]] MACAddress {
+class [[gnu::packed]] MACAddress
+{
     static constexpr size_t s_mac_address_length = 6u;
 
 public:
@@ -92,7 +93,7 @@ namespace AK {
 
 template<>
 struct Traits<MACAddress> : public GenericTraits<MACAddress> {
-    static unsigned hash(const MACAddress& address) { return string_hash((const char*)&address, sizeof(address)); }
+    static unsigned hash(const MACAddress& address) { return string_hash(reinterpret_cast<const char*>(&address), sizeof(address)); }
 };
 
 }

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -29,7 +29,8 @@
 #include <AK/ByteBuffer.h>
 #include <AK/MemMem.h>
 #include <AK/Stream.h>
-#include <AK/Vector.h>
+#include <AK/Types.h>
+#include <stdint.h>
 
 namespace AK {
 
@@ -140,7 +141,7 @@ public:
 
         if (num_bytes * 7 < sizeof(size_t) * 4 && (byte & 0x40)) {
             // sign extend
-            result |= ((size_t)(-1) << (num_bytes * 7));
+            result |= (SIZE_MAX << (num_bytes * 7));
         }
 
         return true;

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -72,9 +72,9 @@ public:
         clear();
 #ifdef SANITIZE_PTRS
         if constexpr (sizeof(T*) == 8)
-            m_ptr = (T*)(0xe3e3e3e3e3e3e3e3);
+            m_ptr = reinterpret_cast<T*>(0xe3e3e3e3e3e3e3e3);
         else
-            m_ptr = (T*)(0xe3e3e3e3);
+            m_ptr = reinterpret_cast<T*>(0xe3e3e3e3);
 #endif
     }
 
@@ -179,7 +179,7 @@ make(Args&&... args)
 template<typename T>
 struct Traits<NonnullOwnPtr<T>> : public GenericTraits<NonnullOwnPtr<T>> {
     using PeekType = const T*;
-    static unsigned hash(const NonnullOwnPtr<T>& p) { return int_hash((u32)p.ptr()); }
+    static unsigned hash(const NonnullOwnPtr<T>& p) { return int_hash(ptr_to_type<u32>(p.ptr())); }
     static bool equals(const NonnullOwnPtr<T>& a, const NonnullOwnPtr<T>& b) { return a.ptr() == b.ptr(); }
 };
 

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -62,9 +62,9 @@ public:
         clear();
 #ifdef SANITIZE_PTRS
         if constexpr (sizeof(T*) == 8)
-            m_ptr = (T*)(0xe1e1e1e1e1e1e1e1);
+            m_ptr = reinterpret_cast<T*>(0xe1e1e1e1e1e1e1e1);
         else
-            m_ptr = (T*)(0xe1e1e1e1);
+            m_ptr = reinterpret_cast<T*>(0xe1e1e1e1);
 #endif
     }
 

--- a/AK/Singleton.h
+++ b/AK/Singleton.h
@@ -65,7 +65,7 @@ public:
             Kernel::ScopedCritical critical;
 #endif
             if constexpr (allow_create) {
-                if (obj == nullptr && AK::atomic_compare_exchange_strong(&obj_var, obj, (T*)0x1, AK::memory_order_acq_rel)) {
+                if (obj == nullptr && AK::atomic_compare_exchange_strong(&obj_var, obj, reinterpret_cast<T*>(0x1), AK::memory_order_acq_rel)) {
                     // We're the first one
                     obj = InitFunction();
                     AK::atomic_store(&obj_var, obj, AK::memory_order_release);
@@ -73,7 +73,7 @@ public:
                 }
             }
             // Someone else was faster, wait until they're done
-            while (obj == (T*)0x1) {
+            while (obj == reinterpret_cast<T*>(0x1)) {
 #ifdef KERNEL
                 Kernel::Processor::wait_check();
 #else
@@ -85,7 +85,7 @@ public:
                 // We should always return an instance if we allow creating one
                 VERIFY(obj != nullptr);
             }
-            VERIFY(obj != (T*)0x1);
+            VERIFY(obj != reinterpret_cast<T*>(0x1));
         }
         return obj;
     }

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -84,8 +84,8 @@ constexpr T&& move(T& arg)
 template<typename T, typename U>
 inline void swap(T& a, U& b)
 {
-    U tmp = move((U&)a);
-    a = (T &&) move(b);
+    U tmp = move(reinterpret_cast<U&>(a));
+    a = reinterpret_cast<T&&>(move(b));
     b = move(tmp);
 }
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -262,7 +262,7 @@ public:
             return {};
         if (buffer.is_empty())
             return empty();
-        return String((const char*)buffer.data(), buffer.size(), should_chomp);
+        return String(reinterpret_cast<const char*>(buffer.data()), buffer.size(), should_chomp);
     }
 
     static String format(const char*, ...) __attribute__((format(printf, 1, 2)));

--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -120,7 +120,7 @@ constexpr u32 string_hash(const char* characters, size_t length)
 {
     u32 hash = 0;
     for (size_t i = 0; i < length; ++i) {
-        hash += (u32)characters[i];
+        hash += static_cast<u32>(characters[i]);
         hash += (hash << 10);
         hash ^= (hash >> 6);
     }

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -42,13 +42,13 @@ public:
         : m_characters(characters)
         , m_length(length)
     {
-        VERIFY(!Checked<uintptr_t>::addition_would_overflow((uintptr_t)characters, length));
+        VERIFY(!Checked<uintptr_t>::addition_would_overflow(reinterpret_cast<uintptr_t>(characters), length));
     }
     ALWAYS_INLINE StringView(const unsigned char* characters, size_t length)
-        : m_characters((const char*)characters)
+        : m_characters(reinterpret_cast<const char*>(characters))
         , m_length(length)
     {
-        VERIFY(!Checked<uintptr_t>::addition_would_overflow((uintptr_t)characters, length));
+        VERIFY(!Checked<uintptr_t>::addition_would_overflow(reinterpret_cast<uintptr_t>(characters), length));
     }
     ALWAYS_INLINE constexpr StringView(const char* cstring)
         : m_characters(cstring)

--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -94,7 +94,7 @@ template<typename T>
 struct Traits<T*> : public GenericTraits<T*> {
     static unsigned hash(const T* p)
     {
-        return int_hash((unsigned)(__PTRDIFF_TYPE__)p);
+        return int_hash(ptr_to_type<u32>(p));
     }
     static constexpr bool is_trivial() { return true; }
     static bool equals(const T* a, const T* b) { return a == b; }

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -73,6 +73,8 @@ using __ptrdiff_t = __PTRDIFF_TYPE__;
 #endif
 
 using FlatPtr = Conditional<sizeof(void*) == 8, u64, u32>::Type;
+constexpr FlatPtr FlatPtrMax = ~0;
+constexpr FlatPtr _RefPtrMask = ~1;
 
 constexpr unsigned KiB = 1024;
 constexpr unsigned MiB = KiB * KiB;
@@ -102,6 +104,12 @@ enum class [[nodiscard]] TriState : u8 {
     True,
     Unknown
 };
+
+template<typename T, typename U>
+constexpr T ptr_to_type(U* ptr)
+{
+    return static_cast<T>(reinterpret_cast<FlatPtr>(ptr));
+}
 
 namespace AK {
 

--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -47,7 +47,7 @@ public:
     Userspace() = default;
 
     operator bool() const { return m_ptr; }
-    operator FlatPtr() const { return (FlatPtr)m_ptr; }
+    operator FlatPtr() const { return reinterpret_cast<FlatPtr>(m_ptr); }
 
     // Disable default implementations that would use surprising integer promotion.
     bool operator==(const Userspace&) const = delete;
@@ -63,7 +63,7 @@ public:
     }
 
     FlatPtr ptr() const { return m_ptr; }
-    T unsafe_userspace_ptr() const { return (T)m_ptr; }
+    T unsafe_userspace_ptr() const { return reinterpret_cast<T>(m_ptr); }
 #else
     Userspace(T ptr)
         : m_ptr(ptr)
@@ -89,7 +89,7 @@ inline Userspace<T> static_ptr_cast(const Userspace<U>& ptr)
 #else
     auto casted_ptr = static_cast<T>(ptr.ptr());
 #endif
-    return Userspace<T>((FlatPtr)casted_ptr);
+    return Userspace<T>(reinterpret_cast<FlatPtr>(casted_ptr));
 }
 
 }

--- a/AK/Utf32View.h
+++ b/AK/Utf32View.h
@@ -72,7 +72,7 @@ public:
 private:
     Utf32CodepointIterator(const u32* ptr, size_t length)
         : m_ptr(ptr)
-        , m_length((ssize_t)length)
+        , m_length(static_cast<ssize_t>(length))
     {
     }
     const u32* m_ptr { nullptr };
@@ -109,7 +109,7 @@ public:
     {
         VERIFY(it.m_ptr >= m_code_points);
         VERIFY(it.m_ptr < m_code_points + m_length);
-        return ((ptrdiff_t)it.m_ptr - (ptrdiff_t)m_code_points) / sizeof(u32);
+        return (reinterpret_cast<ptrdiff_t>(it.m_ptr) - reinterpret_cast<ptrdiff_t>(m_code_points)) / sizeof(u32);
     }
 
     Utf32View substring_view(size_t offset, size_t length) const

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -488,7 +488,7 @@ public:
         if (m_capacity >= needed_capacity)
             return;
         size_t new_capacity = needed_capacity;
-        auto* new_buffer = (T*)kmalloc(new_capacity * sizeof(T));
+        auto* new_buffer = reinterpret_cast<T*>(kmalloc(new_capacity * sizeof(T)));
 
         if constexpr (Traits<T>::is_trivial()) {
             TypedTransfer<T>::copy(new_buffer, data(), m_size);

--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -61,7 +61,7 @@ public:
     template<typename U, typename EnableIf<IsBaseOf<T, U>::value>::Type* = nullptr>
     WeakPtr& operator=(const WeakPtr<U>& other)
     {
-        if ((const void*)this != (const void*)&other)
+        if (reinterpret_cast<const void*>(this) != reinterpret_cast<const void*>(&other))
             m_link = other.m_link;
         return *this;
     }

--- a/AK/Weakable.h
+++ b/AK/Weakable.h
@@ -61,7 +61,7 @@ public:
             Kernel::ScopedCritical critical;
 #endif
             if (!(m_consumers.fetch_add(1u << 1, AK::MemoryOrder::memory_order_acquire) & 1u)) {
-                T* ptr = (T*)m_ptr.load(AK::MemoryOrder::memory_order_acquire);
+                T* ptr = reinterpret_cast<T*>(m_ptr.load(AK::MemoryOrder::memory_order_acquire));
                 if (ptr && ptr->try_ref())
                     ref = adopt(*ptr);
             }
@@ -80,7 +80,7 @@ public:
         // has been triggered as there is a possible race! But it's "unsafe"
         // anyway because we return a raw pointer without ensuring a
         // reference...
-        return (T*)m_ptr.load(AK::MemoryOrder::memory_order_acquire);
+        return reinterpret_cast<T*>(m_ptr.load(AK::MemoryOrder::memory_order_acquire));
     }
 
     bool is_null() const

--- a/Kernel/ACPI/MultiProcessorParser.cpp
+++ b/Kernel/ACPI/MultiProcessorParser.cpp
@@ -69,31 +69,31 @@ UNMAP_AFTER_INIT void MultiProcessorParser::parse_configuration_table()
     while (entry_count > 0) {
         dbgln_if(MULTIPROCESSOR_DEBUG, "MultiProcessor: Entry Type {} detected.", entry->entry_type);
         switch (entry->entry_type) {
-        case ((u8)MultiProcessor::ConfigurationTableEntryType::Processor):
-            entry = (MultiProcessor::EntryHeader*)(FlatPtr)entry + sizeof(MultiProcessor::ProcessorEntry);
+        case (static_cast<u8>(MultiProcessor::ConfigurationTableEntryType::Processor)):
+            entry = reinterpret_cast<MultiProcessor::EntryHeader*>(reinterpret_cast<FlatPtr>(entry) + sizeof(MultiProcessor::ProcessorEntry));
             break;
-        case ((u8)MultiProcessor::ConfigurationTableEntryType::Bus):
-            m_bus_entries.append(*(const MultiProcessor::BusEntry*)entry);
-            entry = (MultiProcessor::EntryHeader*)(FlatPtr)entry + sizeof(MultiProcessor::BusEntry);
+        case (static_cast<u8>(MultiProcessor::ConfigurationTableEntryType::Bus)):
+            m_bus_entries.append(*reinterpret_cast<const MultiProcessor::BusEntry*>(entry));
+            entry = reinterpret_cast<MultiProcessor::EntryHeader*>(reinterpret_cast<FlatPtr>(entry) + sizeof(MultiProcessor::BusEntry));
             break;
-        case ((u8)MultiProcessor::ConfigurationTableEntryType::IOAPIC):
-            entry = (MultiProcessor::EntryHeader*)(FlatPtr)entry + sizeof(MultiProcessor::IOAPICEntry);
+        case (static_cast<u8>(MultiProcessor::ConfigurationTableEntryType::IOAPIC)):
+            entry = reinterpret_cast<MultiProcessor::EntryHeader*>(reinterpret_cast<FlatPtr>(entry) + sizeof(MultiProcessor::IOAPICEntry));
             break;
-        case ((u8)MultiProcessor::ConfigurationTableEntryType::IO_Interrupt_Assignment):
-            m_io_interrupt_assignment_entries.append(*(const MultiProcessor::IOInterruptAssignmentEntry*)entry);
-            entry = (MultiProcessor::EntryHeader*)(FlatPtr)entry + sizeof(MultiProcessor::IOInterruptAssignmentEntry);
+        case (static_cast<u8>(MultiProcessor::ConfigurationTableEntryType::IO_Interrupt_Assignment)):
+            m_io_interrupt_assignment_entries.append(*reinterpret_cast<const MultiProcessor::IOInterruptAssignmentEntry*>(entry));
+            entry = reinterpret_cast<MultiProcessor::EntryHeader*>(reinterpret_cast<FlatPtr>(entry) + sizeof(MultiProcessor::IOInterruptAssignmentEntry));
             break;
-        case ((u8)MultiProcessor::ConfigurationTableEntryType::Local_Interrupt_Assignment):
-            entry = (MultiProcessor::EntryHeader*)(FlatPtr)entry + sizeof(MultiProcessor::LocalInterruptAssignmentEntry);
+        case (static_cast<u8>(MultiProcessor::ConfigurationTableEntryType::Local_Interrupt_Assignment)):
+            entry = reinterpret_cast<MultiProcessor::EntryHeader*>(reinterpret_cast<FlatPtr>(entry) + sizeof(MultiProcessor::LocalInterruptAssignmentEntry));
             break;
-        case ((u8)MultiProcessor::ConfigurationTableEntryType::SystemAddressSpaceMapping):
-            entry = (MultiProcessor::EntryHeader*)(FlatPtr)entry + sizeof(MultiProcessor::SystemAddressSpaceMappingEntry);
+        case (static_cast<u8>(MultiProcessor::ConfigurationTableEntryType::SystemAddressSpaceMapping)):
+            entry = reinterpret_cast<MultiProcessor::EntryHeader*>(reinterpret_cast<FlatPtr>(entry) + sizeof(MultiProcessor::SystemAddressSpaceMappingEntry));
             break;
-        case ((u8)MultiProcessor::ConfigurationTableEntryType::BusHierarchyDescriptor):
-            entry = (MultiProcessor::EntryHeader*)(FlatPtr)entry + sizeof(MultiProcessor::BusHierarchyDescriptorEntry);
+        case (static_cast<u8>(MultiProcessor::ConfigurationTableEntryType::BusHierarchyDescriptor)):
+            entry = reinterpret_cast<MultiProcessor::EntryHeader*>(reinterpret_cast<FlatPtr>(entry) + sizeof(MultiProcessor::BusHierarchyDescriptorEntry));
             break;
-        case ((u8)MultiProcessor::ConfigurationTableEntryType::CompatibilityBusAddressSpaceModifier):
-            entry = (MultiProcessor::EntryHeader*)(FlatPtr)entry + sizeof(MultiProcessor::CompatibilityBusAddressSpaceModifierEntry);
+        case (static_cast<u8>(MultiProcessor::ConfigurationTableEntryType::CompatibilityBusAddressSpaceModifier)):
+            entry = reinterpret_cast<MultiProcessor::EntryHeader*>(reinterpret_cast<FlatPtr>(entry) + sizeof(MultiProcessor::CompatibilityBusAddressSpaceModifierEntry));
             break;
         default:
             VERIFY_NOT_REACHED();

--- a/Kernel/ACPI/Parser.cpp
+++ b/Kernel/ACPI/Parser.cpp
@@ -97,38 +97,38 @@ UNMAP_AFTER_INIT void Parser::init_fadt()
 
     klog() << "ACPI: Fixed ACPI data, Revision " << sdt->h.revision << ", Length " << sdt->h.length << " bytes";
     klog() << "ACPI: DSDT " << PhysicalAddress(sdt->dsdt_ptr);
-    m_x86_specific_flags.cmos_rtc_not_present = (sdt->ia_pc_boot_arch_flags & (u8)FADTFlags::IA_PC_Flags::CMOS_RTC_Not_Present);
+    m_x86_specific_flags.cmos_rtc_not_present = (sdt->ia_pc_boot_arch_flags & static_cast<u8>(FADTFlags::IA_PC_Flags::CMOS_RTC_Not_Present));
 
     // FIXME: QEMU doesn't report that we have an i8042 controller in these flags, even if it should (when FADT revision is 3),
     // Later on, we need to make sure that we enumerate the ACPI namespace (AML encoded), instead of just using this value.
-    m_x86_specific_flags.keyboard_8042 = (sdt->h.revision <= 3) || (sdt->ia_pc_boot_arch_flags & (u8)FADTFlags::IA_PC_Flags::PS2_8042);
+    m_x86_specific_flags.keyboard_8042 = (sdt->h.revision <= 3) || (sdt->ia_pc_boot_arch_flags & static_cast<u8>(FADTFlags::IA_PC_Flags::PS2_8042));
 
-    m_x86_specific_flags.legacy_devices = (sdt->ia_pc_boot_arch_flags & (u8)FADTFlags::IA_PC_Flags::Legacy_Devices);
-    m_x86_specific_flags.msi_not_supported = (sdt->ia_pc_boot_arch_flags & (u8)FADTFlags::IA_PC_Flags::MSI_Not_Supported);
-    m_x86_specific_flags.vga_not_present = (sdt->ia_pc_boot_arch_flags & (u8)FADTFlags::IA_PC_Flags::VGA_Not_Present);
+    m_x86_specific_flags.legacy_devices = (sdt->ia_pc_boot_arch_flags & static_cast<u8>(FADTFlags::IA_PC_Flags::Legacy_Devices));
+    m_x86_specific_flags.msi_not_supported = (sdt->ia_pc_boot_arch_flags & static_cast<u8>(FADTFlags::IA_PC_Flags::MSI_Not_Supported));
+    m_x86_specific_flags.vga_not_present = (sdt->ia_pc_boot_arch_flags & static_cast<u8>(FADTFlags::IA_PC_Flags::VGA_Not_Present));
 
-    m_hardware_flags.cpu_software_sleep = (sdt->flags & (u32)FADTFlags::FeatureFlags::CPU_SW_SLP);
-    m_hardware_flags.docking_capability = (sdt->flags & (u32)FADTFlags::FeatureFlags::DCK_CAP);
-    m_hardware_flags.fix_rtc = (sdt->flags & (u32)FADTFlags::FeatureFlags::FIX_RTC);
-    m_hardware_flags.force_apic_cluster_model = (sdt->flags & (u32)FADTFlags::FeatureFlags::FORCE_APIC_CLUSTER_MODEL);
-    m_hardware_flags.force_apic_physical_destination_mode = (sdt->flags & (u32)FADTFlags::FeatureFlags::FORCE_APIC_PHYSICAL_DESTINATION_MODE);
-    m_hardware_flags.hardware_reduced_acpi = (sdt->flags & (u32)FADTFlags::FeatureFlags::HW_REDUCED_ACPI);
-    m_hardware_flags.headless = (sdt->flags & (u32)FADTFlags::FeatureFlags::HEADLESS);
-    m_hardware_flags.low_power_s0_idle_capable = (sdt->flags & (u32)FADTFlags::FeatureFlags::LOW_POWER_S0_IDLE_CAPABLE);
-    m_hardware_flags.multiprocessor_c2 = (sdt->flags & (u32)FADTFlags::FeatureFlags::P_LVL2_UP);
-    m_hardware_flags.pci_express_wake = (sdt->flags & (u32)FADTFlags::FeatureFlags::PCI_EXP_WAK);
-    m_hardware_flags.power_button = (sdt->flags & (u32)FADTFlags::FeatureFlags::PWR_BUTTON);
-    m_hardware_flags.processor_c1 = (sdt->flags & (u32)FADTFlags::FeatureFlags::PROC_C1);
-    m_hardware_flags.remote_power_on_capable = (sdt->flags & (u32)FADTFlags::FeatureFlags::REMOTE_POWER_ON_CAPABLE);
-    m_hardware_flags.reset_register_supported = (sdt->flags & (u32)FADTFlags::FeatureFlags::RESET_REG_SUPPORTED);
-    m_hardware_flags.rtc_s4 = (sdt->flags & (u32)FADTFlags::FeatureFlags::RTC_s4);
-    m_hardware_flags.s4_rtc_status_valid = (sdt->flags & (u32)FADTFlags::FeatureFlags::S4_RTC_STS_VALID);
-    m_hardware_flags.sealed_case = (sdt->flags & (u32)FADTFlags::FeatureFlags::SEALED_CASE);
-    m_hardware_flags.sleep_button = (sdt->flags & (u32)FADTFlags::FeatureFlags::SLP_BUTTON);
-    m_hardware_flags.timer_value_extension = (sdt->flags & (u32)FADTFlags::FeatureFlags::TMR_VAL_EXT);
-    m_hardware_flags.use_platform_clock = (sdt->flags & (u32)FADTFlags::FeatureFlags::USE_PLATFORM_CLOCK);
-    m_hardware_flags.wbinvd = (sdt->flags & (u32)FADTFlags::FeatureFlags::WBINVD);
-    m_hardware_flags.wbinvd_flush = (sdt->flags & (u32)FADTFlags::FeatureFlags::WBINVD_FLUSH);
+    m_hardware_flags.cpu_software_sleep = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::CPU_SW_SLP));
+    m_hardware_flags.docking_capability = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::DCK_CAP));
+    m_hardware_flags.fix_rtc = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::FIX_RTC));
+    m_hardware_flags.force_apic_cluster_model = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::FORCE_APIC_CLUSTER_MODEL));
+    m_hardware_flags.force_apic_physical_destination_mode = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::FORCE_APIC_PHYSICAL_DESTINATION_MODE));
+    m_hardware_flags.hardware_reduced_acpi = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::HW_REDUCED_ACPI));
+    m_hardware_flags.headless = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::HEADLESS));
+    m_hardware_flags.low_power_s0_idle_capable = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::LOW_POWER_S0_IDLE_CAPABLE));
+    m_hardware_flags.multiprocessor_c2 = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::P_LVL2_UP));
+    m_hardware_flags.pci_express_wake = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::PCI_EXP_WAK));
+    m_hardware_flags.power_button = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::PWR_BUTTON));
+    m_hardware_flags.processor_c1 = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::PROC_C1));
+    m_hardware_flags.remote_power_on_capable = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::REMOTE_POWER_ON_CAPABLE));
+    m_hardware_flags.reset_register_supported = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::RESET_REG_SUPPORTED));
+    m_hardware_flags.rtc_s4 = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::RTC_s4));
+    m_hardware_flags.s4_rtc_status_valid = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::S4_RTC_STS_VALID));
+    m_hardware_flags.sealed_case = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::SEALED_CASE));
+    m_hardware_flags.sleep_button = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::SLP_BUTTON));
+    m_hardware_flags.timer_value_extension = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::TMR_VAL_EXT));
+    m_hardware_flags.use_platform_clock = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::USE_PLATFORM_CLOCK));
+    m_hardware_flags.wbinvd = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::WBINVD));
+    m_hardware_flags.wbinvd_flush = (sdt->flags & static_cast<u32>(FADTFlags::FeatureFlags::WBINVD_FLUSH));
 }
 
 bool Parser::can_reboot()
@@ -141,20 +141,20 @@ bool Parser::can_reboot()
 
 void Parser::access_generic_address(const Structures::GenericAddressStructure& structure, u32 value)
 {
-    switch ((GenericAddressStructure::AddressSpace)structure.address_space) {
+    switch (static_cast<GenericAddressStructure::AddressSpace>(structure.address_space)) {
     case GenericAddressStructure::AddressSpace::SystemIO: {
         IOAddress address(structure.address);
         dbgln("ACPI: Sending value {:x} to {}", value, address);
         switch (structure.access_size) {
-        case (u8)GenericAddressStructure::AccessSize::QWord: {
+        case static_cast<u8>(GenericAddressStructure::AccessSize::QWord): {
             dbgln("Trying to send QWord to IO port");
             VERIFY_NOT_REACHED();
             break;
         }
-        case (u8)GenericAddressStructure::AccessSize::Undefined: {
+        case static_cast<u8>(GenericAddressStructure::AccessSize::Undefined): {
             dbgln("ACPI Warning: Unknown access size {}", structure.access_size);
-            VERIFY(structure.bit_width != (u8)GenericAddressStructure::BitWidth::QWord);
-            VERIFY(structure.bit_width != (u8)GenericAddressStructure::BitWidth::Undefined);
+            VERIFY(structure.bit_width != static_cast<u8>(GenericAddressStructure::BitWidth::QWord));
+            VERIFY(structure.bit_width != static_cast<u8>(GenericAddressStructure::BitWidth::Undefined));
             dbgln("ACPI: Bit Width - {} bits", structure.bit_width);
             address.out(value, structure.bit_width);
             break;
@@ -167,7 +167,7 @@ void Parser::access_generic_address(const Structures::GenericAddressStructure& s
     }
     case GenericAddressStructure::AddressSpace::SystemMemory: {
         dbgln("ACPI: Sending value {:x} to {}", value, PhysicalAddress(structure.address));
-        switch ((GenericAddressStructure::AccessSize)structure.access_size) {
+        switch (static_cast<GenericAddressStructure::AccessSize>(structure.access_size)) {
         case GenericAddressStructure::AccessSize::Byte:
             *map_typed<u8>(PhysicalAddress(structure.address)) = value;
             break;
@@ -191,11 +191,11 @@ void Parser::access_generic_address(const Structures::GenericAddressStructure& s
         auto pci_address = PCI::Address(0, 0, ((structure.address >> 24) & 0xFF), ((structure.address >> 16) & 0xFF));
         dbgln("ACPI: Sending value {:x} to {}", value, pci_address);
         u32 offset_in_pci_address = structure.address & 0xFFFF;
-        if (structure.access_size == (u8)GenericAddressStructure::AccessSize::QWord) {
+        if (structure.access_size == static_cast<u8>(GenericAddressStructure::AccessSize::QWord)) {
             dbgln("Trying to send QWord to PCI configuration space");
             VERIFY_NOT_REACHED();
         }
-        VERIFY(structure.access_size != (u8)GenericAddressStructure::AccessSize::Undefined);
+        VERIFY(structure.access_size != static_cast<u8>(GenericAddressStructure::AccessSize::Undefined));
         PCI::raw_access(pci_address, offset_in_pci_address, (1 << (structure.access_size - 1)), value);
         return;
     }
@@ -209,7 +209,7 @@ bool Parser::validate_reset_register()
 {
     // According to the ACPI spec 6.2, page 152, The reset register can only be located in I/O bus, PCI bus or memory-mapped.
     auto fadt = map_typed<Structures::FADT>(m_fadt);
-    return (fadt->reset_reg.address_space == (u8)GenericAddressStructure::AddressSpace::PCIConfigurationSpace || fadt->reset_reg.address_space == (u8)GenericAddressStructure::AddressSpace::SystemMemory || fadt->reset_reg.address_space == (u8)GenericAddressStructure::AddressSpace::SystemIO);
+    return (fadt->reset_reg.address_space == static_cast<u8>(GenericAddressStructure::AddressSpace::PCIConfigurationSpace) || fadt->reset_reg.address_space == static_cast<u8>(GenericAddressStructure::AddressSpace::SystemMemory) || fadt->reset_reg.address_space == static_cast<u8>(GenericAddressStructure::AddressSpace::SystemIO));
 }
 
 void Parser::try_acpi_reboot()
@@ -264,7 +264,7 @@ UNMAP_AFTER_INIT void Parser::initialize_main_system_description_table()
     klog() << "ACPI: Main Description Table valid? " << validate_table(*sdt, length);
 
     if (m_xsdt_supported) {
-        auto& xsdt = (const Structures::XSDT&)*sdt;
+        const auto& xsdt = reinterpret_cast<Structures::XSDT&>(*sdt);
         klog() << "ACPI: Using XSDT, Enumerating tables @ " << m_main_system_description_table;
         klog() << "ACPI: XSDT Revision " << revision << ", Total length - " << length;
         dbgln_if(ACPI_DEBUG, "ACPI: XSDT pointer @ V{}", &xsdt);
@@ -273,7 +273,7 @@ UNMAP_AFTER_INIT void Parser::initialize_main_system_description_table()
             m_sdt_pointers.append(PhysicalAddress(xsdt.table_ptrs[i]));
         }
     } else {
-        auto& rsdt = (const Structures::RSDT&)*sdt;
+        const auto& rsdt = reinterpret_cast<Structures::RSDT&>(*sdt);
         klog() << "ACPI: Using RSDT, Enumerating tables @ " << m_main_system_description_table;
         klog() << "ACPI: RSDT Revision " << revision << ", Total length - " << length;
         dbgln_if(ACPI_DEBUG, "ACPI: RSDT pointer @ V{}", &rsdt);
@@ -290,7 +290,7 @@ UNMAP_AFTER_INIT void Parser::locate_main_system_description_table()
     if (rsdp->base.revision == 0) {
         m_xsdt_supported = false;
     } else if (rsdp->base.revision >= 2) {
-        if (rsdp->xsdt_ptr != (u64) nullptr) {
+        if (rsdp->xsdt_ptr != reinterpret_cast<u64>(nullptr)) {
             m_xsdt_supported = true;
         } else {
             m_xsdt_supported = false;
@@ -313,7 +313,7 @@ UNMAP_AFTER_INIT Parser::Parser(PhysicalAddress rsdp)
 static bool validate_table(const Structures::SDTHeader& v_header, size_t length)
 {
     u8 checksum = 0;
-    auto* sdt = (const u8*)&v_header;
+    auto* sdt = reinterpret_cast<const u8*>(&v_header);
     for (size_t i = 0; i < length; i++)
         checksum += sdt[i];
     if (checksum == 0)
@@ -356,8 +356,8 @@ UNMAP_AFTER_INIT static PhysicalAddress search_table_in_xsdt(PhysicalAddress xsd
     auto xsdt = map_typed<Structures::XSDT>(xsdt_address);
 
     for (size_t i = 0; i < ((xsdt->h.length - sizeof(Structures::SDTHeader)) / sizeof(u64)); ++i) {
-        if (match_table_signature(PhysicalAddress((FlatPtr)xsdt->table_ptrs[i]), signature))
-            return PhysicalAddress((FlatPtr)xsdt->table_ptrs[i]);
+        if (match_table_signature(PhysicalAddress(static_cast<FlatPtr>(xsdt->table_ptrs[i])), signature))
+            return PhysicalAddress(static_cast<FlatPtr>(xsdt->table_ptrs[i]));
     }
     return {};
 }
@@ -379,8 +379,8 @@ UNMAP_AFTER_INIT static PhysicalAddress search_table_in_rsdt(PhysicalAddress rsd
     auto rsdt = map_typed<Structures::RSDT>(rsdt_address);
 
     for (u32 i = 0; i < ((rsdt->h.length - sizeof(Structures::SDTHeader)) / sizeof(u32)); i++) {
-        if (match_table_signature(PhysicalAddress((FlatPtr)rsdt->table_ptrs[i]), signature))
-            return PhysicalAddress((FlatPtr)rsdt->table_ptrs[i]);
+        if (match_table_signature(PhysicalAddress(static_cast<FlatPtr>(rsdt->table_ptrs[i])), signature))
+            return PhysicalAddress(static_cast<FlatPtr>(rsdt->table_ptrs[i]));
     }
     return {};
 }

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -471,7 +471,7 @@ inline uintptr_t invoke(Function function, T1 arg1)
     uintptr_t result;
     asm volatile("int $0x82"
                  : "=a"(result)
-                 : "a"(function), "d"((uintptr_t)arg1)
+                 : "a"(function), "d"(reinterpret_cast<uintptr_t>(arg1))
                  : "memory");
     return result;
 }
@@ -482,7 +482,7 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2)
     uintptr_t result;
     asm volatile("int $0x82"
                  : "=a"(result)
-                 : "a"(function), "d"((uintptr_t)arg1), "c"((uintptr_t)arg2)
+                 : "a"(function), "d"(reinterpret_cast<uintptr_t>(arg1)), "c"(reinterpret_cast<uintptr_t>(arg2))
                  : "memory");
     return result;
 }
@@ -493,7 +493,7 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3)
     uintptr_t result;
     asm volatile("int $0x82"
                  : "=a"(result)
-                 : "a"(function), "d"((uintptr_t)arg1), "c"((uintptr_t)arg2), "b"((uintptr_t)arg3)
+                 : "a"(function), "d"(reinterpret_cast<uintptr_t>(arg1)), "c"(reinterpret_cast<uintptr_t>(arg2)), "b"(reinterpret_cast<uintptr_t>(arg3))
                  : "memory");
     return result;
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -277,6 +277,7 @@ set(SOURCES
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunused -Wold-style-cast")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pie -fPIE -fno-rtti -ffreestanding -fbuiltin")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-80387 -mno-mmx -mno-sse -mno-sse2")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-asynchronous-unwind-tables")

--- a/Kernel/Console.cpp
+++ b/Kernel/Console.cpp
@@ -79,12 +79,12 @@ Kernel::KResultOr<size_t> Console::write(Kernel::FileDescription&, size_t, const
 
     ssize_t nread = data.read_buffered<256>(size, [&](const u8* bytes, size_t bytes_count) {
         for (size_t i = 0; i < bytes_count; i++)
-            put_char((char)bytes[i]);
-        return (ssize_t)bytes_count;
+            put_char(static_cast<char>(bytes[i]));
+        return static_cast<ssize_t>(bytes_count);
     });
     if (nread < 0)
-        return Kernel::KResult((ErrnoCode)-nread);
-    return (size_t)nread;
+        return Kernel::KResult(static_cast<ErrnoCode>(-nread));
+    return static_cast<size_t>(nread);
 }
 
 void Console::put_char(char ch)

--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -220,7 +220,7 @@ ByteBuffer CoreDump::create_notes_process_data() const
 
     ELF::Core::ProcessInfo info {};
     info.header.type = ELF::Core::NotesEntryHeader::Type::ProcessInfo;
-    process_data.append((void*)&info, sizeof(info));
+    process_data.append(reinterpret_cast<void*>(&info), sizeof(info));
 
     JsonObject process_obj;
     process_obj.set("pid", m_process->pid().value());
@@ -247,7 +247,7 @@ ByteBuffer CoreDump::create_notes_threads_data() const
         info.tid = thread.tid().value();
         copy_kernel_registers_into_ptrace_registers(info.regs, thread.get_register_dump_from_stack());
 
-        entry_buff.append((void*)&info, sizeof(info));
+        entry_buff.append(reinterpret_cast<void*>(&info), sizeof(info));
 
         threads_data += entry_buff;
     }
@@ -268,7 +268,7 @@ ByteBuffer CoreDump::create_notes_regions_data() const
         info.region_end = region.vaddr().offset(region.size()).get();
         info.program_header_index = region_index;
 
-        memory_region_info_buffer.append((void*)&info, sizeof(info));
+        memory_region_info_buffer.append(reinterpret_cast<void*>(&info), sizeof(info));
 
         auto name = region.name();
         if (name.is_null())
@@ -286,7 +286,7 @@ ByteBuffer CoreDump::create_notes_metadata_data() const
 
     ELF::Core::Metadata metadata {};
     metadata.header.type = ELF::Core::NotesEntryHeader::Type::Metadata;
-    metadata_data.append((void*)&metadata, sizeof(metadata));
+    metadata_data.append(reinterpret_cast<void*>(&metadata), sizeof(metadata));
 
     JsonObject metadata_obj;
     for (auto& it : m_process->coredump_metadata())

--- a/Kernel/Devices/KeyboardDevice.cpp
+++ b/Kernel/Devices/KeyboardDevice.cpp
@@ -438,7 +438,7 @@ KResultOr<size_t> KeyboardDevice::read(FileDescription&, size_t, UserOrKernelBuf
         if (m_queue.is_empty())
             break;
         // Don't return partial data frames.
-        if ((size - nread) < (ssize_t)sizeof(Event))
+        if ((size - nread) < static_cast<ssize_t>(sizeof(Event)))
             break;
         auto event = m_queue.dequeue();
 
@@ -446,11 +446,11 @@ KResultOr<size_t> KeyboardDevice::read(FileDescription&, size_t, UserOrKernelBuf
 
         ssize_t n = buffer.write_buffered<sizeof(Event)>(sizeof(Event), [&](u8* data, size_t data_bytes) {
             memcpy(data, &event, sizeof(Event));
-            return (ssize_t)data_bytes;
+            return static_cast<ssize_t>(data_bytes);
         });
         if (n < 0)
-            return KResult((ErrnoCode)-n);
-        VERIFY((size_t)n == sizeof(Event));
+            return KResult(static_cast<ErrnoCode>(-n));
+        VERIFY(static_cast<size_t>(n) == sizeof(Event));
         nread += sizeof(Event);
 
         lock.lock();

--- a/Kernel/Devices/MBVGADevice.cpp
+++ b/Kernel/Devices/MBVGADevice.cpp
@@ -78,21 +78,21 @@ int MBVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
     REQUIRE_PROMISE(video);
     switch (request) {
     case FB_IOCTL_GET_SIZE_IN_BYTES: {
-        auto* out = (size_t*)arg;
+        auto* out = reinterpret_cast<size_t*>(arg);
         size_t value = framebuffer_size_in_bytes();
         if (!copy_to_user(out, &value))
             return -EFAULT;
         return 0;
     }
     case FB_IOCTL_GET_BUFFER: {
-        auto* index = (int*)arg;
+        auto* index = reinterpret_cast<int*>(arg);
         int value = 0;
         if (!copy_to_user(index, &value))
             return -EFAULT;
         return 0;
     }
     case FB_IOCTL_GET_RESOLUTION: {
-        auto* user_resolution = (FBResolution*)arg;
+        auto* user_resolution = reinterpret_cast<FBResolution*>(arg);
         FBResolution resolution;
         resolution.pitch = m_framebuffer_pitch;
         resolution.width = m_framebuffer_width;
@@ -102,7 +102,7 @@ int MBVGADevice::ioctl(FileDescription&, unsigned request, FlatPtr arg)
         return 0;
     }
     case FB_IOCTL_SET_RESOLUTION: {
-        auto* user_resolution = (FBResolution*)arg;
+        auto* user_resolution = reinterpret_cast<FBResolution*>(arg);
         FBResolution resolution;
         resolution.pitch = m_framebuffer_pitch;
         resolution.width = m_framebuffer_width;

--- a/Kernel/Devices/PS2MouseDevice.cpp
+++ b/Kernel/Devices/PS2MouseDevice.cpp
@@ -150,7 +150,7 @@ MousePacket PS2MouseDevice::parse_data_packet(const RawPacket& raw_packet)
     if (m_has_wheel) {
         // FIXME: For non-Intellimouse, this is a full byte.
         //        However, for now, m_has_wheel is only set for Intellimouse.
-        z = (char)(raw_packet.bytes[3] & 0x0f);
+        z = static_cast<char>(raw_packet.bytes[3] & 0x0f);
 
         // -1 in 4 bits
         if (z == 15)

--- a/Kernel/Devices/RandomDevice.cpp
+++ b/Kernel/Devices/RandomDevice.cpp
@@ -47,7 +47,7 @@ KResultOr<size_t> RandomDevice::read(FileDescription&, size_t, UserOrKernelBuffe
 {
     bool success = buffer.write_buffered<256>(size, [&](u8* data, size_t data_size) {
         get_good_random_bytes(data, data_size);
-        return (ssize_t)data_size;
+        return static_cast<ssize_t>(data_size);
     });
     if (!success)
         return EFAULT;

--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -69,11 +69,11 @@ u8 SB16::dsp_read()
 void SB16::set_sample_rate(uint16_t hz)
 {
     dsp_write(0x41); // output
-    dsp_write((u8)(hz >> 8));
-    dsp_write((u8)hz);
+    dsp_write(static_cast<u8>(hz >> 8));
+    dsp_write(static_cast<u8>(hz));
     dsp_write(0x42); // input
-    dsp_write((u8)(hz >> 8));
-    dsp_write((u8)hz);
+    dsp_write(static_cast<u8>(hz >> 8));
+    dsp_write(static_cast<u8>(hz));
 }
 
 static AK::Singleton<SB16> s_the;
@@ -211,12 +211,12 @@ void SB16::dma_start(uint32_t length)
 
     // Write the offset of the buffer
     u16 offset = (addr / 2) % 65536;
-    IO::out8(0xc4, (u8)offset);
-    IO::out8(0xc4, (u8)(offset >> 8));
+    IO::out8(0xc4, static_cast<u8>(offset));
+    IO::out8(0xc4, static_cast<u8>(offset >> 8));
 
     // Write the transfer length
-    IO::out8(0xc6, (u8)(length - 1));
-    IO::out8(0xc6, (u8)((length - 1) >> 8));
+    IO::out8(0xc6, static_cast<u8>(length - 1));
+    IO::out8(0xc6, static_cast<u8>((length - 1) >> 8));
 
     // Write the buffer
     IO::out8(0x8b, addr >> 16);
@@ -264,7 +264,7 @@ KResultOr<size_t> SB16::write(FileDescription&, size_t, const UserOrKernelBuffer
         return ENOSPC;
     }
 
-    u8 mode = (u8)SampleFormat::Signed | (u8)SampleFormat::Stereo;
+    u8 mode = static_cast<u8>(SampleFormat::Signed) | static_cast<u8>(SampleFormat::Stereo);
 
     const int sample_rate = 44100;
     set_sample_rate(sample_rate);
@@ -277,7 +277,7 @@ KResultOr<size_t> SB16::write(FileDescription&, size_t, const UserOrKernelBuffer
     u8 command = 0xb0;
 
     u16 sample_count = length / sizeof(i16);
-    if (mode & (u8)SampleFormat::Stereo)
+    if (mode & static_cast<u8>(SampleFormat::Stereo))
         sample_count /= 2;
 
     sample_count -= 1;
@@ -287,8 +287,8 @@ KResultOr<size_t> SB16::write(FileDescription&, size_t, const UserOrKernelBuffer
 
     dsp_write(command);
     dsp_write(mode);
-    dsp_write((u8)sample_count);
-    dsp_write((u8)(sample_count >> 8));
+    dsp_write(static_cast<u8>(sample_count));
+    dsp_write(static_cast<u8>(sample_count >> 8));
 
     wait_for_irq();
     return length;

--- a/Kernel/Devices/SerialDevice.cpp
+++ b/Kernel/Devices/SerialDevice.cpp
@@ -56,10 +56,10 @@ KResultOr<size_t> SerialDevice::read(FileDescription&, size_t, UserOrKernelBuffe
     ssize_t nwritten = buffer.write_buffered<128>(size, [&](u8* data, size_t data_size) {
         for (size_t i = 0; i < data_size; i++)
             data[i] = IO::in8(m_base_addr);
-        return (ssize_t)data_size;
+        return static_cast<ssize_t>(data_size);
     });
     if (nwritten < 0)
-        return KResult((ErrnoCode)-nwritten);
+        return KResult(static_cast<ErrnoCode>(-nwritten));
 
     return size;
 }
@@ -80,11 +80,11 @@ KResultOr<size_t> SerialDevice::write(FileDescription&, size_t, const UserOrKern
     ssize_t nread = buffer.read_buffered<128>(size, [&](const u8* data, size_t data_size) {
         for (size_t i = 0; i < data_size; i++)
             IO::out8(m_base_addr, data[i]);
-        return (ssize_t)data_size;
+        return static_cast<ssize_t>(data_size);
     });
     if (nread < 0)
-        return KResult((ErrnoCode)-nread);
-    return (size_t)nread;
+        return KResult(static_cast<ErrnoCode>(-nread));
+    return static_cast<size_t>(nread);
 }
 
 String SerialDevice::device_name() const
@@ -112,10 +112,10 @@ void SerialDevice::set_baud(Baud baud)
 {
     m_baud = baud;
 
-    IO::out8(m_base_addr + 3, IO::in8(m_base_addr + 3) | 0x80); // turn on DLAB
-    IO::out8(m_base_addr + 0, ((char)(baud)) >> 2);             // lower half of divisor
-    IO::out8(m_base_addr + 1, ((char)(baud)) & 0xff);           // upper half of divisor
-    IO::out8(m_base_addr + 3, IO::in8(m_base_addr + 3) & 0x7f); // turn off DLAB
+    IO::out8(m_base_addr + 3, IO::in8(m_base_addr + 3) | 0x80);  // turn on DLAB
+    IO::out8(m_base_addr + 0, (static_cast<char>(baud)) >> 2);   // lower half of divisor
+    IO::out8(m_base_addr + 1, (static_cast<char>(baud)) & 0xff); // upper half of divisor
+    IO::out8(m_base_addr + 3, IO::in8(m_base_addr + 3) & 0x7f);  // turn off DLAB
 }
 
 void SerialDevice::set_fifo_control(char fifo_control)

--- a/Kernel/Devices/USB/UHCIDescriptorTypes.h
+++ b/Kernel/Devices/USB/UHCIDescriptorTypes.h
@@ -124,7 +124,7 @@ struct alignas(16) TransferDescriptor final {
 
     void print()
     {
-        dbgln("UHCI: TD({}) @ {}: link_ptr={}, status={}, token={}, buffer_ptr={}", this, m_paddr, m_link_ptr, (u32)m_control_status, m_token, m_buffer_ptr);
+        dbgln("UHCI: TD({}) @ {}: link_ptr={}, status={}, token={}, buffer_ptr={}", this, m_paddr, m_link_ptr, static_cast<u32>(m_control_status), m_token, m_buffer_ptr);
 
         // Now let's print the flags!
         dbgln("UHCI: TD({}) @ {}: link_ptr={}{}{}, status={}{}{}{}{}{}{}",
@@ -264,7 +264,7 @@ struct alignas(16) QueueHead {
 
     void print()
     {
-        dbgln("UHCI: QH({}) @ {}: link_ptr={}, element_link_ptr={}", this, m_paddr, m_link_ptr, (FlatPtr)m_element_link_ptr);
+        dbgln("UHCI: QH({}) @ {}: link_ptr={}, element_link_ptr={}", this, m_paddr, m_link_ptr, reinterpret_cast<FlatPtr>(m_element_link_ptr));
     }
 
 private:

--- a/Kernel/DoubleBuffer.cpp
+++ b/Kernel/DoubleBuffer.cpp
@@ -74,7 +74,7 @@ ssize_t DoubleBuffer::write(const UserOrKernelBuffer& data, size_t size)
         return -EFAULT;
     if (m_unblock_callback && !m_empty)
         m_unblock_callback();
-    return (ssize_t)bytes_to_write;
+    return static_cast<ssize_t>(bytes_to_write);
 }
 
 ssize_t DoubleBuffer::read(UserOrKernelBuffer& data, size_t size)
@@ -94,7 +94,7 @@ ssize_t DoubleBuffer::read(UserOrKernelBuffer& data, size_t size)
     compute_lockfree_metadata();
     if (m_unblock_callback && m_space_for_writing > 0)
         m_unblock_callback();
-    return (ssize_t)nread;
+    return static_cast<ssize_t>(nread);
 }
 
 }

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -103,8 +103,8 @@ public:
         return new_entry;
     }
 
-    const CacheEntry* entries() const { return (const CacheEntry*)m_entries.data(); }
-    CacheEntry* entries() { return (CacheEntry*)m_entries.data(); }
+    const CacheEntry* entries() const { return reinterpret_cast<const CacheEntry*>(m_entries.data()); }
+    CacheEntry* entries() { return reinterpret_cast<CacheEntry*>(m_entries.data()); }
 
     template<typename Callback>
     void for_each_dirty_entry(Callback callback)

--- a/Kernel/FileSystem/DevFS.cpp
+++ b/Kernel/FileSystem/DevFS.cpp
@@ -176,7 +176,7 @@ ssize_t DevFSLinkInode::read_bytes(off_t offset, ssize_t, UserOrKernelBuffer& bu
     LOCKER(m_lock);
     VERIFY(offset == 0);
     VERIFY(!m_link.is_null());
-    if (!buffer.write(((const u8*)m_link.substring_view(0).characters_without_null_termination()) + offset, m_link.length()))
+    if (!buffer.write((reinterpret_cast<const u8*>(m_link.substring_view(0).characters_without_null_termination())) + offset, m_link.length()))
         return -EFAULT;
     return m_link.length();
 }

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -119,8 +119,8 @@ private:
 
     const ext2_super_block& super_block() const { return m_super_block; }
     const ext2_group_desc& group_descriptor(GroupIndex) const;
-    ext2_group_desc* block_group_descriptors() { return (ext2_group_desc*)m_cached_group_descriptor_table->data(); }
-    const ext2_group_desc* block_group_descriptors() const { return (const ext2_group_desc*)m_cached_group_descriptor_table->data(); }
+    ext2_group_desc* block_group_descriptors() { return reinterpret_cast<ext2_group_desc*>(m_cached_group_descriptor_table->data()); }
+    const ext2_group_desc* block_group_descriptors() const { return reinterpret_cast<const ext2_group_desc*>(m_cached_group_descriptor_table->data()); }
     void flush_block_group_descriptor_table();
     unsigned inodes_per_block() const;
     unsigned inodes_per_group() const;

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -98,22 +98,22 @@ KResult FileDescription::attach()
 
 Thread::FileBlocker::BlockFlags FileDescription::should_unblock(Thread::FileBlocker::BlockFlags block_flags) const
 {
-    u32 unblock_flags = (u32)Thread::FileBlocker::BlockFlags::None;
-    if (((u32)block_flags & (u32)Thread::FileBlocker::BlockFlags::Read) && can_read())
-        unblock_flags |= (u32)Thread::FileBlocker::BlockFlags::Read;
-    if (((u32)block_flags & (u32)Thread::FileBlocker::BlockFlags::Write) && can_write())
-        unblock_flags |= (u32)Thread::FileBlocker::BlockFlags::Write;
+    u32 unblock_flags = static_cast<u32>(Thread::FileBlocker::BlockFlags::None);
+    if ((static_cast<u32>(block_flags) & static_cast<u32>(Thread::FileBlocker::BlockFlags::Read)) && can_read())
+        unblock_flags |= static_cast<u32>(Thread::FileBlocker::BlockFlags::Read);
+    if ((static_cast<u32>(block_flags) & static_cast<u32>(Thread::FileBlocker::BlockFlags::Write)) && can_write())
+        unblock_flags |= static_cast<u32>(Thread::FileBlocker::BlockFlags::Write);
     // TODO: Implement Thread::FileBlocker::BlockFlags::Exception
 
-    if ((u32)block_flags & (u32)Thread::FileBlocker::BlockFlags::SocketFlags) {
+    if (static_cast<u32>(block_flags) & static_cast<u32>(Thread::FileBlocker::BlockFlags::SocketFlags)) {
         auto* sock = socket();
         VERIFY(sock);
-        if (((u32)block_flags & (u32)Thread::FileBlocker::BlockFlags::Accept) && sock->can_accept())
-            unblock_flags |= (u32)Thread::FileBlocker::BlockFlags::Accept;
-        if (((u32)block_flags & (u32)Thread::FileBlocker::BlockFlags::Connect) && sock->setup_state() == Socket::SetupState::Completed)
-            unblock_flags |= (u32)Thread::FileBlocker::BlockFlags::Connect;
+        if ((static_cast<u32>(block_flags) & static_cast<u32>(Thread::FileBlocker::BlockFlags::Accept)) && sock->can_accept())
+            unblock_flags |= static_cast<u32>(Thread::FileBlocker::BlockFlags::Accept);
+        if ((static_cast<u32>(block_flags) & static_cast<u32>(Thread::FileBlocker::BlockFlags::Connect)) && sock->setup_state() == Socket::SetupState::Completed)
+            unblock_flags |= static_cast<u32>(Thread::FileBlocker::BlockFlags::Connect);
     }
-    return (Thread::FileBlocker::BlockFlags)unblock_flags;
+    return static_cast<Thread::FileBlocker::BlockFlags>(unblock_flags);
 }
 
 KResult FileDescription::stat(::stat& buffer)
@@ -229,9 +229,9 @@ ssize_t FileDescription::get_dir_entries(UserOrKernelBuffer& buffer, ssize_t siz
     OutputMemoryStream stream { temp_buffer };
 
     KResult result = VFS::the().traverse_directory_inode(*m_inode, [&stream, this](auto& entry) {
-        stream << (u32)entry.inode.index().value();
+        stream << static_cast<u32>(entry.inode.index().value());
         stream << m_inode->fs().internal_file_type_to_directory_entry_type(entry);
-        stream << (u32)entry.name.length();
+        stream << static_cast<u32>(entry.name.length());
         stream << entry.name.bytes();
         return true;
     });

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -69,15 +69,15 @@ template<size_t ALIGNMENT>
     static_assert(ALIGNMENT > 1);
     static_assert(ALIGNMENT < 255);
     void* ptr = kmalloc(size + ALIGNMENT + sizeof(u8));
-    size_t max_addr = (size_t)ptr + ALIGNMENT;
-    void* aligned_ptr = (void*)(max_addr - (max_addr % ALIGNMENT));
-    ((u8*)aligned_ptr)[-1] = (u8)((u8*)aligned_ptr - (u8*)ptr);
+    FlatPtr max_addr = reinterpret_cast<FlatPtr>(ptr) + ALIGNMENT;
+    void* aligned_ptr = reinterpret_cast<void*>(max_addr - (max_addr % ALIGNMENT));
+    (reinterpret_cast<u8*>(aligned_ptr))[-1] = reinterpret_cast<u8>(reinterpret_cast<u8*>(aligned_ptr) - reinterpret_cast<u8*>(ptr));
     return aligned_ptr;
 }
 
 inline void kfree_aligned(void* ptr)
 {
-    kfree((u8*)ptr - ((u8*)ptr)[-1]);
+    kfree(reinterpret_cast<u8*>(ptr) - (reinterpret_cast<u8*>(ptr))[-1]);
 }
 
 void kmalloc_enable_expand();

--- a/Kernel/Interrupts/APIC.h
+++ b/Kernel/Interrupts/APIC.h
@@ -101,7 +101,7 @@ private:
 
         ICRReg(u8 vector, DeliveryMode delivery_mode, DestinationMode destination_mode, Level level, TriggerMode trigger_mode, DestinationShorthand destinationShort, u8 destination = 0)
             : m_low(vector | (delivery_mode << 8) | (destination_mode << 11) | (level << 14) | (static_cast<u32>(trigger_mode) << 15) | (destinationShort << 18))
-            , m_high((u32)destination << 24)
+            , m_high(static_cast<u32>(destination) << 24)
         {
         }
 

--- a/Kernel/Net/IPv4.h
+++ b/Kernel/Net/IPv4.h
@@ -47,7 +47,8 @@ enum class IPv4PacketFlags : u16 {
 
 NetworkOrdered<u16> internet_checksum(const void*, size_t);
 
-class [[gnu::packed]] IPv4Packet {
+class [[gnu::packed]] IPv4Packet
+{
 public:
     u8 version() const { return (m_version_and_ihl >> 4) & 0xf; }
     void set_version(u8 version) { m_version_and_ihl = (m_version_and_ihl & 0x0f) | (version << 4); }
@@ -80,15 +81,15 @@ public:
     const void* payload() const { return this + 1; }
 
     u16 flags_and_fragment() const { return m_flags_and_fragment; }
-    u16 fragment_offset() const { return ((u16)m_flags_and_fragment & 0x1fff); }
-    u16 flags() const { return (((u16)m_flags_and_fragment) & (((u16)IPv4PacketFlags::MoreFragments) | ((u16)IPv4PacketFlags::DontFragment))); }
+    u16 fragment_offset() const { return (static_cast<u16>(m_flags_and_fragment) & 0x1fff); }
+    u16 flags() const { return ((static_cast<u16>(m_flags_and_fragment)) & ((static_cast<u16>(IPv4PacketFlags::MoreFragments)) | (static_cast<u16>(IPv4PacketFlags::DontFragment)))); }
 
     void set_has_more_fragments(bool more_fragments)
     {
         if (more_fragments)
-            m_flags_and_fragment = (u16)m_flags_and_fragment | ((u16)IPv4PacketFlags::MoreFragments);
+            m_flags_and_fragment = static_cast<u16>(m_flags_and_fragment) | (static_cast<u16>(IPv4PacketFlags::MoreFragments));
         else
-            m_flags_and_fragment = (u16)m_flags_and_fragment & ((u16)IPv4PacketFlags::MoreFragments);
+            m_flags_and_fragment = static_cast<u16>(m_flags_and_fragment) & (static_cast<u16>(IPv4PacketFlags::MoreFragments));
     }
     void set_fragment_offset(u16 offset)
     {
@@ -98,7 +99,7 @@ public:
     bool is_a_fragment() const
     {
         // either has More-Fragments set, or has a fragment offset
-        return (((u16)m_flags_and_fragment) & ((u16)IPv4PacketFlags::MoreFragments)) || ((u16)m_flags_and_fragment & 0x1fff);
+        return (static_cast<u16>(m_flags_and_fragment) & static_cast<u16>(IPv4PacketFlags::MoreFragments)) || (static_cast<u16>(m_flags_and_fragment) & 0x1fff);
     }
 
     u16 payload_size() const { return m_length - sizeof(IPv4Packet); }
@@ -128,7 +129,7 @@ const LogStream& operator<<(const LogStream& stream, const IPv4Packet& packet);
 inline NetworkOrdered<u16> internet_checksum(const void* ptr, size_t count)
 {
     u32 checksum = 0;
-    auto* w = (const u16*)ptr;
+    auto* w = reinterpret_cast<const u16*>(ptr);
     while (count > 1) {
         checksum += AK::convert_between_host_and_network_endian(*w++);
         if (checksum & 0x80000000)

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -420,7 +420,7 @@ public:
     }
     bool has_promised(Pledge pledge) const
     {
-        return m_promises & (1u << (u32)pledge);
+        return m_promises & (1u << static_cast<u32>(pledge));
     }
 
     VeilState veil_state() const

--- a/Kernel/Time/HardwareTimer.h
+++ b/Kernel/Time/HardwareTimer.h
@@ -89,7 +89,7 @@ public:
         return previous_callback;
     }
 
-    virtual u32 frequency() const override { return (u32)m_frequency; }
+    virtual u32 frequency() const override { return static_cast<u32>(m_frequency); }
 
 protected:
     HardwareTimer(u8 irq_number, Function<void(const RegisterState&)> callback = nullptr)
@@ -134,7 +134,7 @@ public:
     virtual const char* controller() const override { return nullptr; }
     virtual bool eoi() override;
 
-    virtual u32 frequency() const override { return (u32)m_frequency; }
+    virtual u32 frequency() const override { return static_cast<u32>(m_frequency); }
 
 protected:
     HardwareTimer(u8 irq_number, Function<void(const RegisterState&)> callback = nullptr)

--- a/Kernel/UserOrKernelBuffer.h
+++ b/Kernel/UserOrKernelBuffer.h
@@ -36,17 +36,18 @@
 
 namespace Kernel {
 
-class [[nodiscard]] UserOrKernelBuffer {
+class [[nodiscard]] UserOrKernelBuffer
+{
 public:
     UserOrKernelBuffer() = delete;
 
-    static UserOrKernelBuffer for_kernel_buffer(u8* kernel_buffer)
+    static UserOrKernelBuffer for_kernel_buffer(u8 * kernel_buffer)
     {
         VERIFY(!kernel_buffer || !is_user_address(VirtualAddress(kernel_buffer)));
         return UserOrKernelBuffer(kernel_buffer);
     }
 
-    static Optional<UserOrKernelBuffer> for_user_buffer(u8* user_buffer, size_t size)
+    static Optional<UserOrKernelBuffer> for_user_buffer(u8 * user_buffer, size_t size)
     {
         if (user_buffer && !is_user_range(VirtualAddress(user_buffer), size))
             return {};
@@ -58,7 +59,7 @@ public:
     {
         if (!is_user_range(VirtualAddress(userspace.unsafe_userspace_ptr()), size))
             return {};
-        return UserOrKernelBuffer(const_cast<u8*>((const u8*)userspace.unsafe_userspace_ptr()));
+        return UserOrKernelBuffer(const_cast<u8*>(reinterpret_cast<const u8*>(userspace.unsafe_userspace_ptr())));
     }
 
     [[nodiscard]] bool is_kernel_buffer() const;
@@ -120,14 +121,14 @@ public:
             ssize_t copied = f(buffer, to_copy);
             if (copied < 0)
                 return copied;
-            VERIFY((size_t)copied <= to_copy);
-            if (!write(buffer, nwritten, (size_t)copied))
+            VERIFY(static_cast<size_t>(copied) <= to_copy);
+            if (!write(buffer, nwritten, static_cast<size_t>(copied)))
                 return -EFAULT;
-            nwritten += (size_t)copied;
-            if ((size_t)copied < to_copy)
+            nwritten += static_cast<size_t>(copied);
+            if (static_cast<size_t>(copied) < to_copy)
                 break;
         }
-        return (ssize_t)nwritten;
+        return static_cast<ssize_t>(nwritten);
     }
     template<size_t BUFFER_BYTES, typename F>
     [[nodiscard]] ssize_t write_buffered(size_t len, F f)
@@ -156,9 +157,9 @@ public:
             ssize_t copied = f(buffer, to_copy);
             if (copied < 0)
                 return copied;
-            VERIFY((size_t)copied <= to_copy);
-            nread += (size_t)copied;
-            if ((size_t)copied < to_copy)
+            VERIFY(static_cast<size_t>(copied) <= to_copy);
+            nread += static_cast<size_t>(copied);
+            if (static_cast<size_t>(copied) < to_copy)
                 break;
         }
         return nread;
@@ -170,7 +171,7 @@ public:
     }
 
 private:
-    explicit UserOrKernelBuffer(u8* buffer)
+    explicit UserOrKernelBuffer(u8 * buffer)
         : m_buffer(buffer)
     {
     }

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -46,7 +46,7 @@ constexpr bool page_round_up_would_wrap(FlatPtr x)
 
 constexpr FlatPtr page_round_up(FlatPtr x)
 {
-    FlatPtr rounded = (((FlatPtr)(x)) + PAGE_SIZE - 1) & (~(PAGE_SIZE - 1));
+    FlatPtr rounded = (x + PAGE_SIZE - 1) & (~(PAGE_SIZE - 1));
     // Rounding up >0xffff0000 wraps back to 0. That's never what we want.
     VERIFY(x == 0 || rounded != 0);
     return rounded;
@@ -54,7 +54,7 @@ constexpr FlatPtr page_round_up(FlatPtr x)
 
 constexpr FlatPtr page_round_down(FlatPtr x)
 {
-    return ((FlatPtr)(x)) & ~(PAGE_SIZE - 1);
+    return x & ~(PAGE_SIZE - 1);
 }
 
 inline u32 low_physical_to_virtual(u32 physical)

--- a/Kernel/VM/PurgeablePageRanges.h
+++ b/Kernel/VM/PurgeablePageRanges.h
@@ -158,7 +158,7 @@ public:
             m_ranges.span(), r, &nearby_index, [](auto& a, auto& b) {
                 if (a.intersects(b))
                     return 0;
-                return (signed)(a.base - (b.base + b.count - 1));
+                return static_cast<signed>(a.base - (b.base + b.count - 1));
             });
         if (!existing_range)
             return IterationDecision::Continue;

--- a/Kernel/VirtualAddress.h
+++ b/Kernel/VirtualAddress.h
@@ -38,7 +38,7 @@ public:
     }
 
     explicit VirtualAddress(const void* address)
-        : m_address((FlatPtr)address)
+        : m_address(reinterpret_cast<FlatPtr>(address))
     {
     }
 

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -102,7 +102,7 @@ static bool handle_disassemble_command(const String& command, void* first_instru
 
 static bool insert_breakpoint_at_address(FlatPtr address)
 {
-    return g_debug_session->insert_breakpoint((void*)address);
+    return g_debug_session->insert_breakpoint(reinterpret_cast<void*>(address));
 }
 
 static bool insert_breakpoint_at_source_position(const String& file, size_t line)
@@ -168,7 +168,7 @@ static bool handle_examine_command(const String& command)
         return false;
     }
     u32 address = strtoul(argument.characters() + 2, nullptr, 16);
-    auto res = g_debug_session->peek((u32*)address);
+    auto res = g_debug_session->peek(reinterpret_cast<u32*>(address));
     if (!res.has_value()) {
         printf("could not examine memory at address 0x%x\n", address);
         return true;

--- a/Userland/Libraries/CMakeLists.txt
+++ b/Userland/Libraries/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunused -Wold-style-cast")
+
 add_subdirectory(LibAudio)
 add_subdirectory(LibC)
 add_subdirectory(LibChess)

--- a/Userland/Libraries/LibC/bits/stdint.h
+++ b/Userland/Libraries/LibC/bits/stdint.h
@@ -139,6 +139,6 @@ typedef __INTMAX_TYPE__ intmax_t;
 #define INT64_C(x) x##LL
 #define UINT64_C(x) x##ULL
 
-#define SIZE_MAX ((size_t)-1)
+#define SIZE_MAX (static_cast<size_t>(-1))
 
 __END_DECLS

--- a/Userland/Libraries/LibC/mallocdefs.h
+++ b/Userland/Libraries/LibC/mallocdefs.h
@@ -67,11 +67,11 @@ struct ChunkedBlock
         m_magic = MAGIC_PAGE_HEADER;
         m_size = bytes_per_chunk;
         m_free_chunks = chunk_capacity();
-        m_freelist = (FreelistEntry*)chunk(0);
+        m_freelist = reinterpret_cast<FreelistEntry*>(chunk(0));
         for (size_t i = 0; i < chunk_capacity(); ++i) {
-            auto* entry = (FreelistEntry*)chunk(i);
+            auto* entry = reinterpret_cast<FreelistEntry*>(chunk(i));
             if (i != chunk_capacity() - 1)
-                entry->next = (FreelistEntry*)chunk(i + 1);
+                entry->next = reinterpret_cast<FreelistEntry*>(chunk(i + 1));
             else
                 entry->next = nullptr;
         }

--- a/Userland/Libraries/LibC/mman.h
+++ b/Userland/Libraries/LibC/mman.h
@@ -44,7 +44,7 @@
 #define PROT_EXEC 0x4
 #define PROT_NONE 0x0
 
-#define MAP_FAILED ((void*)-1)
+#define MAP_FAILED (reinterpret_cast<void*>(-1))
 
 #define MADV_SET_VOLATILE 0x100
 #define MADV_SET_NONVOLATILE 0x200

--- a/Userland/Libraries/LibCore/AnonymousBuffer.h
+++ b/Userland/Libraries/LibCore/AnonymousBuffer.h
@@ -71,7 +71,7 @@ public:
         static_assert(IsVoid<T>::value || is_trivial<T>());
         if (!m_impl)
             return nullptr;
-        return (T*)m_impl->data();
+        return reinterpret_cast<T*>(m_impl->data());
     }
 
     template<typename T>
@@ -80,7 +80,7 @@ public:
         static_assert(IsVoid<T>::value || is_trivial<T>());
         if (!m_impl)
             return nullptr;
-        return (const T*)m_impl->data();
+        return reinterpret_cast<const T*>(m_impl->data());
     }
 
 private:

--- a/Userland/Libraries/LibCrypto/Authentication/GHash.h
+++ b/Userland/Libraries/LibCrypto/Authentication/GHash.h
@@ -56,7 +56,7 @@ public:
     explicit GHash(const ReadonlyBytes& key)
     {
         for (size_t i = 0; i < 16; i += 4)
-            m_key[i / 4] = AK::convert_between_host_and_big_endian(*(const u32*)(key.offset(i)));
+            m_key[i / 4] = AK::convert_between_host_and_big_endian(*reinterpret_cast<const u32*>(key.offset(i)));
     }
 
     constexpr static size_t digest_size() { return TagType::Size; }

--- a/Userland/Libraries/LibCrypto/Cipher/AES.h
+++ b/Userland/Libraries/LibCrypto/Cipher/AES.h
@@ -79,7 +79,7 @@ struct AESCipherKey : public CipherKey {
     String to_string() const;
     const u32* round_keys() const
     {
-        return (const u32*)m_rd_keys;
+        return m_rd_keys;
     }
 
     AESCipherKey(ReadonlyBytes user_key, size_t key_bits, Intent intent)
@@ -99,7 +99,7 @@ struct AESCipherKey : public CipherKey {
 protected:
     u32* round_keys()
     {
-        return (u32*)m_rd_keys;
+        return m_rd_keys;
     }
 
 private:

--- a/Userland/Libraries/LibCrypto/Cipher/Cipher.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Cipher.h
@@ -81,15 +81,15 @@ public:
         VERIFY(sizeof(T) <= 4);
 
         if constexpr (sizeof(T) > 3)
-            ptr[index++] = (u8)(value >> 24);
+            ptr[index++] = static_cast<u8>(value >> 24);
 
         if constexpr (sizeof(T) > 2)
-            ptr[index++] = (u8)(value >> 16);
+            ptr[index++] = static_cast<u8>(value >> 16);
 
         if constexpr (sizeof(T) > 1)
-            ptr[index++] = (u8)(value >> 8);
+            ptr[index++] = static_cast<u8>(value >> 8);
 
-        ptr[index] = (u8)value;
+        ptr[index] = static_cast<u8>(value);
     }
 
 private:

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/CTR.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/CTR.h
@@ -93,7 +93,7 @@ struct IncrementInplace {
     {
         for (size_t i = in.size(); i > 0;) {
             --i;
-            if (in[i] == (u8)-1) {
+            if (in[i] == 0xFF) {
                 in[i] = 0;
             } else {
                 in[i]++;

--- a/Userland/Libraries/LibCrypto/Hash/HashFunction.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashFunction.h
@@ -49,7 +49,7 @@ public:
     void update(const Bytes& buffer) { update(buffer.data(), buffer.size()); };
     void update(const ReadonlyBytes& buffer) { update(buffer.data(), buffer.size()); };
     void update(const ByteBuffer& buffer) { update(buffer.data(), buffer.size()); };
-    void update(const StringView& string) { update((const u8*)string.characters_without_null_termination(), string.length()); };
+    void update(const StringView& string) { update(reinterpret_cast<const u8*>(string.characters_without_null_termination()), string.length()); };
 
     virtual DigestType peek() = 0;
     virtual DigestType digest() = 0;

--- a/Userland/Libraries/LibCrypto/Hash/SHA2.h
+++ b/Userland/Libraries/LibCrypto/Hash/SHA2.h
@@ -116,7 +116,7 @@ public:
     }
 
     inline static DigestType hash(const ByteBuffer& buffer) { return hash(buffer.data(), buffer.size()); }
-    inline static DigestType hash(const StringView& buffer) { return hash((const u8*)buffer.characters_without_null_termination(), buffer.length()); }
+    inline static DigestType hash(const StringView& buffer) { return hash(reinterpret_cast<const u8*>(buffer.characters_without_null_termination()), buffer.length()); }
 
     virtual String class_name() const override
     {
@@ -168,7 +168,7 @@ public:
     }
 
     inline static DigestType hash(const ByteBuffer& buffer) { return hash(buffer.data(), buffer.size()); }
-    inline static DigestType hash(const StringView& buffer) { return hash((const u8*)buffer.characters_without_null_termination(), buffer.length()); }
+    inline static DigestType hash(const StringView& buffer) { return hash(reinterpret_cast<const u8*>(buffer.characters_without_null_termination()), buffer.length()); }
 
     virtual String class_name() const override
     {

--- a/Userland/Libraries/LibDebug/DebugSession.h
+++ b/Userland/Libraries/LibDebug/DebugSession.h
@@ -226,11 +226,11 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
         Optional<BreakPoint> current_breakpoint;
 
         if (state == State::FreeRun || state == State::Syscall) {
-            current_breakpoint = m_breakpoints.get((void*)((u32)regs.eip - 1));
+            current_breakpoint = m_breakpoints.get(reinterpret_cast<void*>(static_cast<u32>(regs.eip) - 1));
             if (current_breakpoint.has_value())
                 state = State::FreeRun;
         } else {
-            current_breakpoint = m_breakpoints.get((void*)regs.eip);
+            current_breakpoint = m_breakpoints.get(reinterpret_cast<void*>(regs.eip));
         }
 
         if (current_breakpoint.has_value()) {

--- a/Userland/Libraries/LibELF/AuxiliaryVector.h
+++ b/Userland/Libraries/LibELF/AuxiliaryVector.h
@@ -107,7 +107,7 @@ struct AuxiliaryValue {
     AuxiliaryValue(Type type, void* ptr)
     {
         auxv.a_type = type;
-        auxv.a_un.a_ptr = (void*)ptr;
+        auxv.a_un.a_ptr = reinterpret_cast<void*>(ptr);
     }
     AuxiliaryValue(Type type, String string)
     {

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -366,7 +366,7 @@ inline void DynamicObject::for_each_needed_library(F func) const
         if (entry.tag() != DT_NEEDED)
             return IterationDecision::Continue;
         Elf32_Word offset = entry.val();
-        StringView name { (const char*)(m_base_address.offset(m_string_table_offset).offset(offset)).as_ptr() };
+        StringView name { reinterpret_cast<const char*>((m_base_address.offset(m_string_table_offset).offset(offset)).as_ptr()) };
         if (func(StringView(name)) == IterationDecision::Break)
             return IterationDecision::Break;
         return IterationDecision::Continue;
@@ -378,9 +378,9 @@ void DynamicObject::for_each_initialization_array_function(F f) const
 {
     if (!has_init_array_section())
         return;
-    FlatPtr init_array = (FlatPtr)init_array_section().address().as_ptr();
+    FlatPtr init_array = reinterpret_cast<FlatPtr>(init_array_section().address().as_ptr());
     for (size_t i = 0; i < (m_init_array_size / sizeof(void*)); ++i) {
-        InitializationFunction current = ((InitializationFunction*)(init_array))[i];
+        InitializationFunction current = reinterpret_cast<InitializationFunction*>(init_array)[i];
         f(current);
     }
 }

--- a/Userland/Libraries/LibELF/Image.h
+++ b/Userland/Libraries/LibELF/Image.h
@@ -47,7 +47,7 @@ public:
     {
         if (address < m_buffer)
             return false;
-        if (((const u8*)address + size) > m_buffer + m_size)
+        if ((reinterpret_cast<const u8*>(address) + size) > m_buffer + m_size)
             return false;
         return true;
     }
@@ -206,7 +206,7 @@ public:
     bool is_dynamic() const { return header().e_type == ET_DYN; }
 
     VirtualAddress entry() const { return VirtualAddress(header().e_entry); }
-    FlatPtr base_address() const { return (FlatPtr)m_buffer; }
+    FlatPtr base_address() const { return reinterpret_cast<FlatPtr>(m_buffer); }
     size_t size() const { return m_size; }
 
     Optional<Symbol> find_demangled_function(const String& name) const;

--- a/Userland/Libraries/LibELF/exec_elf.h
+++ b/Userland/Libraries/LibELF/exec_elf.h
@@ -348,11 +348,11 @@ typedef struct {
 
 /* Extract symbol info - st_info */
 #define ELF32_ST_BIND(x) ((x) >> 4)
-#define ELF32_ST_TYPE(x) (((unsigned int)x) & 0xf)
+#define ELF32_ST_TYPE(x) ((static_cast<unsigned int>(x)) & 0xf)
 #define ELF32_ST_INFO(b, t) (((b) << 4) + ((t)&0xf))
 
 #define ELF64_ST_BIND(x) ((x) >> 4)
-#define ELF64_ST_TYPE(x) (((unsigned int)x) & 0xf)
+#define ELF64_ST_TYPE(x) ((static_cast<unsigned int>(x)) & 0xf)
 #define ELF64_ST_INFO(b, t) (((b) << 4) + ((t)&0xf))
 
 /* Symbol Binding - ELF32_ST_BIND - st_info */
@@ -398,8 +398,8 @@ typedef struct {
 
 /* Extract relocation info - r_info */
 #define ELF32_R_SYM(i) ((i) >> 8)
-#define ELF32_R_TYPE(i) ((unsigned char)(i))
-#define ELF32_R_INFO(s, t) (((s) << 8) + (unsigned char)(t))
+#define ELF32_R_TYPE(i) (static_cast<unsigned char>(i))
+#define ELF32_R_INFO(s, t) (((s) << 8) + static_cast<unsigned char>(t))
 
 typedef struct {
     Elf64_Xword r_offset; /* where to do it */

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -59,13 +59,13 @@ enum class BitmapFormat {
 inline bool is_valid_bitmap_format(unsigned format)
 {
     switch (format) {
-    case (unsigned)BitmapFormat::Invalid:
-    case (unsigned)BitmapFormat::Indexed1:
-    case (unsigned)BitmapFormat::Indexed2:
-    case (unsigned)BitmapFormat::Indexed4:
-    case (unsigned)BitmapFormat::Indexed8:
-    case (unsigned)BitmapFormat::RGB32:
-    case (unsigned)BitmapFormat::RGBA32:
+    case static_cast<unsigned>(BitmapFormat::Invalid):
+    case static_cast<unsigned>(BitmapFormat::Indexed1):
+    case static_cast<unsigned>(BitmapFormat::Indexed2):
+    case static_cast<unsigned>(BitmapFormat::Indexed4):
+    case static_cast<unsigned>(BitmapFormat::Indexed8):
+    case static_cast<unsigned>(BitmapFormat::RGB32):
+    case static_cast<unsigned>(BitmapFormat::RGBA32):
         return true;
     }
     return false;

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -181,7 +181,11 @@ public:
 
     Color lightened(float amount = 1.2f) const
     {
-        return Color(min(255, (int)((float)red() * amount)), min(255, (int)((float)green() * amount)), min(255, (int)((float)blue() * amount)), alpha());
+        return Color(
+            min(255, static_cast<int>(static_cast<float>(red()) * amount)),
+            min(255, static_cast<int>(static_cast<float>(green()) * amount)),
+            min(255, static_cast<int>(static_cast<float>(blue()) * amount)),
+            alpha());
     }
 
     Color inverted() const
@@ -304,9 +308,9 @@ public:
             break;
         }
 
-        u8 out_r = (u8)(r * 255);
-        u8 out_g = (u8)(g * 255);
-        u8 out_b = (u8)(b * 255);
+        u8 out_r = static_cast<u8>(r * 255);
+        u8 out_g = static_cast<u8>(g * 255);
+        u8 out_b = static_cast<u8>(b * 255);
         return Color(out_r, out_g, out_b);
     }
 

--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -63,7 +63,8 @@ struct Scanline {
     ReadonlyBytes data {};
 };
 
-struct [[gnu::packed]] PaletteEntry {
+struct [[gnu::packed]] PaletteEntry
+{
     u8 r;
     u8 g;
     u8 b;
@@ -71,20 +72,23 @@ struct [[gnu::packed]] PaletteEntry {
 };
 
 template<typename T>
-struct [[gnu::packed]] Tuple {
+struct [[gnu::packed]] Tuple
+{
     T gray;
     T a;
 };
 
 template<typename T>
-struct [[gnu::packed]] Triplet {
+struct [[gnu::packed]] Triplet
+{
     T r;
     T g;
     T b;
 };
 
 template<typename T>
-struct [[gnu::packed]] Quad {
+struct [[gnu::packed]] Quad
+{
     T r;
     T g;
     T b;
@@ -222,7 +226,8 @@ ALWAYS_INLINE static u8 paeth_predictor(int a, int b, int c)
     return c;
 }
 
-union [[gnu::packed]] Pixel {
+union [[gnu::packed]] Pixel
+{
     RGBA32 rgba { 0 };
     u8 v[4];
     struct {

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -236,7 +236,7 @@ public:
     const struct termios& default_termios() const { return m_default_termios; }
     struct winsize terminal_size() const
     {
-        winsize ws { (u16)m_num_lines, (u16)m_num_columns, 0, 0 };
+        winsize ws { static_cast<u16>(m_num_lines), static_cast<u16>(m_num_columns), 0, 0 };
         return ws;
     }
 

--- a/Userland/Libraries/LibLine/StringMetrics.h
+++ b/Userland/Libraries/LibLine/StringMetrics.h
@@ -45,7 +45,7 @@ struct StringMetrics {
         {
             size_t length = this->length;
             for (auto& mask : masked_chars) {
-                if (offset < 0 || mask.position <= (size_t)offset) {
+                if (offset < 0 || mask.position <= static_cast<size_t>(offset)) {
                     length -= mask.original_length;
                     length += mask.masked_length;
                 }

--- a/Userland/Libraries/LibSystem/syscall.h
+++ b/Userland/Libraries/LibSystem/syscall.h
@@ -46,17 +46,17 @@ inline uintptr_t syscall(auto function)
 
 inline uintptr_t syscall(auto function, auto arg0)
 {
-    return syscall1((uintptr_t)function, (uintptr_t)arg0);
+    return syscall1(static_cast<uintptr_t>(function), reinterpret_cast<uintptr_t>(arg0));
 }
 
 inline uintptr_t syscall(auto function, auto arg0, auto arg1)
 {
-    return syscall2((uintptr_t)function, (uintptr_t)arg0, (uintptr_t)arg1);
+    return syscall2(static_cast<uintptr_t>(function), reinterpret_cast<uintptr_t>(arg0), reinterpret_cast<uintptr_t>(arg1));
 }
 
 inline uintptr_t syscall(auto function, auto arg0, auto arg1, auto arg2)
 {
-    return syscall3((uintptr_t)function, (uintptr_t)arg0, (uintptr_t)arg1, (uintptr_t)arg2);
+    return syscall3(static_cast<uintptr_t>(function), static_cast<uintptr_t>(arg0), static_cast<uintptr_t>(arg1), static_cast<uintptr_t>(arg2));
 }
 
 #endif

--- a/Userland/Libraries/LibX86/Instruction.h
+++ b/Userland/Libraries/LibX86/Instruction.h
@@ -338,21 +338,21 @@ public:
     {
         u8 lsb = read8();
         u8 msb = read8();
-        return ((u16)msb << 8) | (u16)lsb;
+        return (static_cast<u16>(msb) << 8) | static_cast<u16>(lsb);
     }
 
     virtual u32 read32() override
     {
         u16 lsw = read16();
         u16 msw = read16();
-        return ((u32)msw << 16) | (u32)lsw;
+        return (static_cast<u32>(msw) << 16) | static_cast<u32>(lsw);
     }
 
     virtual u64 read64() override
     {
         u32 lsw = read32();
         u32 msw = read32();
-        return ((u64)msw << 32) | (u64)lsw;
+        return (static_cast<u64>(msw) << 32) | static_cast<u64>(lsw);
     }
     size_t offset() const { return m_offset; }
 
@@ -586,7 +586,7 @@ ALWAYS_INLINE LogicalAddress MemoryOrRegisterReference::resolve32(const CPU& cpu
     switch (m_rm & 0x07) {
     case 0 ... 3:
     case 6 ... 7:
-        offset = cpu.const_gpr32((RegisterIndex32)(m_rm & 0x07)).value() + m_displacement32;
+        offset = cpu.const_gpr32(static_cast<RegisterIndex32>(m_rm & 0x07)).value() + m_displacement32;
         break;
     case 4:
         offset = evaluate_sib(cpu, default_segment);
@@ -614,7 +614,7 @@ ALWAYS_INLINE u32 MemoryOrRegisterReference::evaluate_sib(const CPU& cpu, Segmen
     switch ((m_sib >> 3) & 0x07) {
     case 0 ... 3:
     case 5 ... 7:
-        index = cpu.const_gpr32((RegisterIndex32)((m_sib >> 3) & 0x07)).value();
+        index = cpu.const_gpr32(static_cast<RegisterIndex32>((m_sib >> 3) & 0x07)).value();
         break;
     case 4:
         index = 0;
@@ -625,7 +625,7 @@ ALWAYS_INLINE u32 MemoryOrRegisterReference::evaluate_sib(const CPU& cpu, Segmen
     switch (m_sib & 0x07) {
     case 0 ... 3:
     case 6 ... 7:
-        base += cpu.const_gpr32((RegisterIndex32)(m_sib & 0x07)).value();
+        base += cpu.const_gpr32(static_cast<RegisterIndex32>(m_sib & 0x07)).value();
         break;
     case 4:
         default_segment = SegmentRegister::SS;
@@ -801,7 +801,7 @@ ALWAYS_INLINE Instruction::Instruction(InstructionStreamType& stream, bool o32, 
         }
         auto segment_prefix = to_segment_prefix(opbyte);
         if (segment_prefix.has_value()) {
-            m_segment_prefix = (u8)segment_prefix.value();
+            m_segment_prefix = static_cast<u8>(segment_prefix.value());
             continue;
         }
         m_op = opbyte;


### PR DESCRIPTION
this is work towards #5487

During whis I've found some other (related things) things:
* we were casting m_raw to u32 to just cast it back to u64
* somewhere we were using size_t as a ptr_t instead of FlatPtr
* why are we casting nulltptrs?
* why are we casting constants over two corners and not just saying the constant directly?
* someone else should take a look at IntrusiveList<T, member>::node_to_value its horrifying
* God help me are these a lot of casts