### PR TITLE
Everywhere: Remove a bunch of redundant 'AK::' namespace prefixes

### DIFF
--- a/AK/DistinctNumeric.h
+++ b/AK/DistinctNumeric.h
@@ -311,9 +311,9 @@ struct Formatter<DistinctNumeric<T, X, Incr, Cmp, Bool, Flags, Shift, Arith>> : 
 // TODO: Further type aliases?
 
 template<typename T, typename X, auto... Args>
-struct AK::Traits<AK::DistinctNumeric<T, X, Args...>> : public AK::GenericTraits<AK::DistinctNumeric<T, X, Args...>> {
+struct Traits<AK::DistinctNumeric<T, X, Args...>> : public GenericTraits<AK::DistinctNumeric<T, X, Args...>> {
     static constexpr bool is_trivial() { return true; }
-    static constexpr auto hash(const AK::DistinctNumeric<T, X, Args...>& d) { return AK::Traits<T>::hash(d.value()); }
+    static constexpr auto hash(const DistinctNumeric<T, X, Args...>& d) { return Traits<T>::hash(d.value()); }
 };
 
 using AK::DistinctNumeric;

--- a/AK/FlyString.cpp
+++ b/AK/FlyString.cpp
@@ -34,7 +34,7 @@
 
 namespace AK {
 
-struct FlyStringImplTraits : public AK::Traits<StringImpl*> {
+struct FlyStringImplTraits : public Traits<StringImpl*> {
     static unsigned hash(const StringImpl* s) { return s ? s->hash() : 0; }
     static bool equals(const StringImpl* a, const StringImpl* b)
     {

--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -231,7 +231,7 @@ Optional<JsonValue> JsonParser::parse_number()
             auto number = number_string.to_int<i64>();
             if (!number.has_value())
                 return {};
-            if (number.value() <= AK::NumericLimits<i32>::max()) {
+            if (number.value() <= NumericLimits<i32>::max()) {
                 value = JsonValue((i32)number.value());
             } else {
                 value = JsonValue(number.value());

--- a/AK/MACAddress.h
+++ b/AK/MACAddress.h
@@ -79,11 +79,11 @@ public:
 
     constexpr bool is_zero() const
     {
-        return AK::all_of(m_data.begin(), m_data.end(), [](const auto octet) { return octet == 0; });
+        return all_of(m_data.begin(), m_data.end(), [](const auto octet) { return octet == 0; });
     }
 
 private:
-    AK::Array<u8, s_mac_address_length> m_data {};
+    Array<u8, s_mac_address_length> m_data {};
 };
 
 static_assert(sizeof(MACAddress) == 6u);

--- a/AK/String.h
+++ b/AK/String.h
@@ -305,7 +305,7 @@ struct Traits<String> : public GenericTraits<String> {
     static unsigned hash(const String& s) { return s.impl() ? s.impl()->hash() : 0; }
 };
 
-struct CaseInsensitiveStringTraits : public AK::Traits<String> {
+struct CaseInsensitiveStringTraits : public Traits<String> {
     static unsigned hash(const String& s) { return s.impl() ? s.to_lowercase().impl()->hash() : 0; }
     static bool equals(const String& a, const String& b) { return a.to_lowercase() == b.to_lowercase(); }
 };

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -184,7 +184,7 @@ Optional<T> convert_to_uint_from_hex(const StringView& str)
 
     T value = 0;
     const auto count = str_trimmed.length();
-    const T upper_bound = AK::NumericLimits<T>::max();
+    const T upper_bound = NumericLimits<T>::max();
 
     for (size_t i = 0; i < count; i++) {
         char digit = str_trimmed[i];

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -282,7 +282,7 @@ Optional<size_t> StringView::find_first_of(const StringView& view) const
 {
     if (const auto location = AK::find_if(begin(), end(),
             [&](const auto c) {
-                return AK::any_of(view.begin(), view.end(),
+                return any_of(view.begin(), view.end(),
                     [&](const auto view_char) {
                         return c == view_char;
                     });

--- a/AK/TestSuite.h
+++ b/AK/TestSuite.h
@@ -90,7 +90,7 @@ private:
     struct timeval m_started;
 };
 
-using TestFunction = AK::Function<void()>;
+using TestFunction = Function<void()>;
 
 class TestCase : public RefCounted<TestCase> {
 public:

--- a/AK/Tests/TestAllOf.cpp
+++ b/AK/Tests/TestAllOf.cpp
@@ -31,13 +31,13 @@
 
 TEST_CASE(should_determine_if_predicate_applies_to_all_elements_in_container)
 {
-    constexpr AK::Array<int, 10> a {};
+    constexpr Array<int, 10> a {};
 
-    static_assert(AK::all_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
-    static_assert(!AK::all_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
+    static_assert(all_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
+    static_assert(!all_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
 
-    EXPECT(AK::all_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
-    EXPECT(!AK::all_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
+    EXPECT(all_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
+    EXPECT(!all_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
 }
 
 TEST_MAIN(AllOf)

--- a/AK/Tests/TestAnyOf.cpp
+++ b/AK/Tests/TestAnyOf.cpp
@@ -31,15 +31,15 @@
 
 TEST_CASE(should_determine_if_predicate_applies_to_any_element_in_container)
 {
-    constexpr AK::Array<int, 10> a { 1 };
+    constexpr Array<int, 10> a { 1 };
 
-    static_assert(AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
-    static_assert(AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
-    static_assert(!AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 2; }));
+    static_assert(any_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
+    static_assert(any_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
+    static_assert(!any_of(a.begin(), a.end(), [](auto elem) { return elem == 2; }));
 
-    EXPECT(AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
-    EXPECT(AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
-    EXPECT(!AK::any_of(a.begin(), a.end(), [](auto elem) { return elem == 2; }));
+    EXPECT(any_of(a.begin(), a.end(), [](auto elem) { return elem == 0; }));
+    EXPECT(any_of(a.begin(), a.end(), [](auto elem) { return elem == 1; }));
+    EXPECT(!any_of(a.begin(), a.end(), [](auto elem) { return elem == 2; }));
 }
 
 TEST_MAIN(AllOf)

--- a/AK/Tests/TestBadge.cpp
+++ b/AK/Tests/TestBadge.cpp
@@ -30,7 +30,7 @@
 
 TEST_CASE(should_provide_underlying_type)
 {
-    static_assert(AK::IsSame<int, Badge<int>::Type>::value);
+    static_assert(IsSame<int, Badge<int>::Type>::value);
 }
 
 TEST_MAIN(Badge)

--- a/AK/Tests/TestFind.cpp
+++ b/AK/Tests/TestFind.cpp
@@ -32,7 +32,7 @@
 
 TEST_CASE(should_return_end_if_not_in_container)
 {
-    constexpr AK::Array<int, 10> a {};
+    constexpr Array<int, 10> a {};
 
     static_assert(a.end() == AK::find(a.begin(), a.end(), 1));
 
@@ -41,7 +41,7 @@ TEST_CASE(should_return_end_if_not_in_container)
 
 TEST_CASE(should_return_iterator_to_first_matching_value_in_container)
 {
-    static constexpr AK::Array<int, 10> a { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+    static constexpr Array<int, 10> a { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
 
     constexpr auto expected = a.begin() + 4;
 
@@ -52,7 +52,7 @@ TEST_CASE(should_return_iterator_to_first_matching_value_in_container)
 
 TEST_CASE(should_return_iterator_to_first_predicate_matching_value_in_container)
 {
-    static constexpr AK::Array<int, 10> a { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+    static constexpr Array<int, 10> a { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
 
     constexpr auto expected = a.begin() + 4;
 
@@ -66,7 +66,7 @@ TEST_CASE(should_return_iterator_to_first_predicate_matching_value_in_container)
 
 TEST_CASE(should_return_index_to_first_predicate_matching_value_in_container)
 {
-    static constexpr AK::Array<int, 10> a { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+    static constexpr Array<int, 10> a { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
 
     static_assert(4 == AK::find_index(a.begin(), a.end(), 0));
 

--- a/AK/Tests/TestSpan.cpp
+++ b/AK/Tests/TestSpan.cpp
@@ -49,7 +49,7 @@ TEST_CASE(span_works_with_constant_types)
     static constexpr u8 buffer[4] { 1, 2, 3, 4 };
     constexpr ReadonlyBytes bytes { buffer, 4 };
 
-    static_assert(AK::IsConst<AK::RemoveReference<decltype(bytes[1])>::Type>::value);
+    static_assert(IsConst<AK::RemoveReference<decltype(bytes[1])>::Type>::value);
     static_assert(bytes[2] == 3);
 }
 

--- a/AK/Tests/TestVector.cpp
+++ b/AK/Tests/TestVector.cpp
@@ -396,7 +396,7 @@ TEST_CASE(should_compare_vectors_of_different_sizes)
 
 TEST_CASE(should_find_value)
 {
-    AK::Vector<int> v { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+    Vector<int> v { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
 
     const auto expected = v.begin() + 4;
 
@@ -405,7 +405,7 @@ TEST_CASE(should_find_value)
 
 TEST_CASE(should_find_predicate)
 {
-    AK::Vector<int> v { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+    Vector<int> v { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
 
     const auto expected = v.begin() + 4;
 
@@ -414,7 +414,7 @@ TEST_CASE(should_find_predicate)
 
 TEST_CASE(should_find_index)
 {
-    AK::Vector<int> v { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
+    Vector<int> v { 1, 2, 3, 4, 0, 6, 7, 8, 0, 0 };
 
     EXPECT_EQ(4u, v.find_first_index(0).value());
     EXPECT(!v.find_first_index(42).has_value());

--- a/Kernel/Interrupts/APIC.h
+++ b/Kernel/Interrupts/APIC.h
@@ -112,8 +112,8 @@ private:
     OwnPtr<Region> m_apic_base;
     Vector<OwnPtr<Processor>> m_ap_processor_info;
     Vector<Thread*> m_ap_idle_threads;
-    AK::Atomic<u8> m_apic_ap_count { 0 };
-    AK::Atomic<u8> m_apic_ap_continue { 0 };
+    Atomic<u8> m_apic_ap_count { 0 };
+    Atomic<u8> m_apic_ap_continue { 0 };
     u32 m_processor_cnt { 0 };
     u32 m_processor_enabled_cnt { 0 };
     APICTimer* m_apic_timer { nullptr };

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -138,7 +138,7 @@ public:
     ~Process();
 
     static Vector<ProcessID> all_pids();
-    static AK::NonnullRefPtrVector<Process> all_processes();
+    static NonnullRefPtrVector<Process> all_processes();
 
     template<typename EntryFunction>
     RefPtr<Thread> create_kernel_thread(EntryFunction entry, u32 priority, const String& name, u32 affinity = THREAD_AFFINITY_DEFAULT, bool joinable = true)

--- a/Kernel/SpinLock.h
+++ b/Kernel/SpinLock.h
@@ -69,7 +69,7 @@ public:
     }
 
 private:
-    AK::Atomic<BaseType> m_lock { 0 };
+    Atomic<BaseType> m_lock { 0 };
 };
 
 class RecursiveSpinLock {
@@ -121,7 +121,7 @@ public:
     }
 
 private:
-    AK::Atomic<FlatPtr> m_lock { 0 };
+    Atomic<FlatPtr> m_lock { 0 };
     u32 m_recursions { 0 };
 };
 

--- a/Kernel/UnveilNode.h
+++ b/Kernel/UnveilNode.h
@@ -50,8 +50,8 @@ struct UnveilMetadata {
     bool unveil_inherited_from_root { false }; // true if permissions are inherited from the tree root (/).
 };
 
-struct UnveilNode final : public AK::Trie<String, UnveilMetadata, Traits<String>, UnveilNode> {
-    using AK::Trie<String, UnveilMetadata, Traits<String>, UnveilNode>::Trie;
+struct UnveilNode final : public Trie<String, UnveilMetadata, Traits<String>, UnveilNode> {
+    using Trie<String, UnveilMetadata, Traits<String>, UnveilNode>::Trie;
 
     bool permissions_inherited_from_root() const { return this->metadata_value().unveil_inherited_from_root; }
     bool was_explicitly_unveiled() const { return this->metadata_value().explicitly_unveiled; }

--- a/Meta/Lagom/Fuzzers/FuzzGemini.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGemini.cpp
@@ -32,7 +32,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto gemini = AK::StringView(static_cast<const unsigned char*>(data), size);
+    auto gemini = StringView(static_cast<const unsigned char*>(data), size);
     Gemini::Document::parse(gemini, {});
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzJs.cpp
@@ -34,7 +34,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto js = AK::StringView(static_cast<const unsigned char*>(data), size);
+    auto js = StringView(static_cast<const unsigned char*>(data), size);
     auto lexer = JS::Lexer(js);
     auto parser = JS::Parser(lexer);
     auto program = parser.parse_program();

--- a/Meta/Lagom/Fuzzers/FuzzMarkdown.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMarkdown.cpp
@@ -32,7 +32,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto markdown = AK::StringView(static_cast<const unsigned char*>(data), size);
+    auto markdown = StringView(static_cast<const unsigned char*>(data), size);
     Markdown::Document::parse(markdown);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzRegexECMA262.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRegexECMA262.cpp
@@ -31,7 +31,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto pattern = AK::StringView(static_cast<const unsigned char*>(data), size);
+    auto pattern = StringView(static_cast<const unsigned char*>(data), size);
     [[maybe_unused]] auto re = Regex<ECMA262>(pattern);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzRegexPosixExtended.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRegexPosixExtended.cpp
@@ -31,7 +31,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto pattern = AK::StringView(static_cast<const unsigned char*>(data), size);
+    auto pattern = StringView(static_cast<const unsigned char*>(data), size);
     [[maybe_unused]] auto re = Regex<PosixExtended>(pattern);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzShell.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzShell.cpp
@@ -31,7 +31,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    auto source = AK::StringView(static_cast<const unsigned char*>(data), size);
+    auto source = StringView(static_cast<const unsigned char*>(data), size);
     Shell::Parser parser(source);
     parser.parse();
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -232,7 +232,7 @@ int main(int, char**)
 
         int result = 0;
 
-        auto js = AK::StringView(static_cast<const unsigned char*>(data_buffer.data()), script_size);
+        auto js = StringView(static_cast<const unsigned char*>(data_buffer.data()), script_size);
 
         auto lexer = JS::Lexer(js);
         auto parser = JS::Parser(lexer);

--- a/Userland/Applications/DisplaySettings/DisplaySettings.cpp
+++ b/Userland/Applications/DisplaySettings/DisplaySettings.cpp
@@ -101,7 +101,7 @@ void DisplaySettingsWidget::create_frame()
 
     m_wallpaper_combo = *find_descendant_of_type_named<GUI::ComboBox>("wallpaper_combo");
     m_wallpaper_combo->set_only_allow_values_from_model(true);
-    m_wallpaper_combo->set_model(*GUI::ItemListModel<AK::String>::create(m_wallpapers));
+    m_wallpaper_combo->set_model(*GUI::ItemListModel<String>::create(m_wallpapers));
     m_wallpaper_combo->on_change = [this](auto& text, const GUI::ModelIndex& index) {
         String path = text;
         if (path.starts_with("/") && m_monitor_widget->set_wallpaper(path)) {
@@ -139,7 +139,7 @@ void DisplaySettingsWidget::create_frame()
 
     m_mode_combo = *find_descendant_of_type_named<GUI::ComboBox>("mode_combo");
     m_mode_combo->set_only_allow_values_from_model(true);
-    m_mode_combo->set_model(*GUI::ItemListModel<AK::String>::create(m_modes));
+    m_mode_combo->set_model(*GUI::ItemListModel<String>::create(m_modes));
     m_mode_combo->on_change = [this](auto&, const GUI::ModelIndex& index) {
         m_monitor_widget->set_wallpaper_mode(m_modes.at(index.row()));
         m_monitor_widget->update();

--- a/Userland/Applications/FileManager/DirectoryView.h
+++ b/Userland/Applications/FileManager/DirectoryView.h
@@ -79,7 +79,7 @@ public:
 
     void refresh();
 
-    void launch(const AK::URL&, const LauncherHandler&);
+    void launch(const URL&, const LauncherHandler&);
 
     Function<void(const StringView& path, bool can_write_in_path)> on_path_change;
     Function<void(GUI::AbstractView&)> on_selection_change;

--- a/Userland/Applications/KeyboardMapper/KeyPositions.h
+++ b/Userland/Applications/KeyboardMapper/KeyPositions.h
@@ -36,7 +36,7 @@ struct KeyPosition {
     int height;
     bool enabled;
     int map_index;
-    AK::String name;
+    String name;
 };
 
 #define KEY_COUNT 63

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -189,7 +189,7 @@ void KeyboardMapperWidget::save_to_file(const StringView& file_name)
     auto add_array = [&](String name, u32* values) {
         JsonArray items;
         for (int i = 0; i < 90; i++) {
-            AK::StringBuilder sb;
+            StringBuilder sb;
             if (values[i])
                 sb.append_code_point(values[i]);
 
@@ -282,7 +282,7 @@ void KeyboardMapperWidget::set_current_map(const String current_map)
         if (index == 0)
             continue;
 
-        AK::StringBuilder sb;
+        StringBuilder sb;
         sb.append_code_point(map[index]);
 
         m_keys.at(k)->set_text(sb.to_string());

--- a/Userland/Applications/QuickShow/QSWidget.cpp
+++ b/Userland/Applications/QuickShow/QSWidget.cpp
@@ -78,7 +78,7 @@ void QSWidget::navigate(Directions direction)
     StringBuilder sb;
     sb.append("/");
     sb.join("/", parts);
-    AK::String current_dir = sb.to_string();
+    auto current_dir = sb.to_string();
 
     if (m_files_in_same_dir.is_empty()) {
         Core::DirIterator iterator(current_dir, Core::DirIterator::Flags::SkipDots);

--- a/Userland/Demos/WidgetGallery/main.cpp
+++ b/Userland/Demos/WidgetGallery/main.cpp
@@ -257,7 +257,7 @@ int main(int argc, char** argv)
 
     auto& combobox1 = combo_container.add<GUI::ComboBox>();
     combobox1.set_only_allow_values_from_model(true);
-    combobox1.set_model(*ListViewModel<AK::String>::create(model_items));
+    combobox1.set_model(*ListViewModel<String>::create(model_items));
 
     auto& combobox2 = combo_container.add<GUI::ComboBox>();
     combobox2.set_enabled(false);

--- a/Userland/DevTools/Inspector/RemoteProcess.h
+++ b/Userland/DevTools/Inspector/RemoteProcess.h
@@ -54,10 +54,10 @@ public:
     Function<void()> on_update;
 
 private:
-    void handle_get_all_objects_response(const AK::JsonObject&);
-    void handle_identify_response(const AK::JsonObject&);
+    void handle_get_all_objects_response(const JsonObject&);
+    void handle_identify_response(const JsonObject&);
 
-    void send_request(const AK::JsonObject&);
+    void send_request(const JsonObject&);
 
     pid_t m_pid { -1 };
     String m_process_name;

--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -87,7 +87,7 @@ Emulator::Emulator(const String& executable_path, const Vector<String>& argument
     static constexpr FlatPtr userspace_range_ceiling = 0xbe000000;
 #ifdef UE_ASLR
     static constexpr FlatPtr page_mask = 0xfffff000u;
-    size_t random_offset = (AK::get_random<u8>() % 32 * MiB) & page_mask;
+    size_t random_offset = (get_random<u8>() % 32 * MiB) & page_mask;
     FlatPtr base = userspace_range_base + random_offset;
 #else
     FlatPtr base = userspace_range_base;

--- a/Userland/DevTools/UserspaceEmulator/RangeAllocator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/RangeAllocator.cpp
@@ -81,7 +81,7 @@ Optional<Range> RangeAllocator::allocate_randomized(size_t size, size_t alignmen
     // FIXME: I'm sure there's a smarter way to do this.
     static constexpr size_t maximum_randomization_attempts = 1000;
     for (size_t i = 0; i < maximum_randomization_attempts; ++i) {
-        VirtualAddress random_address { AK::get_random<FlatPtr>() };
+        VirtualAddress random_address { get_random<FlatPtr>() };
         random_address.mask(PAGE_MASK);
 
         if (!m_total_range.contains(random_address, size))

--- a/Userland/Libraries/LibChess/Chess.h
+++ b/Userland/Libraries/LibChess/Chess.h
@@ -194,7 +194,7 @@ private:
 
     HashMap<Board, int> m_previous_states;
     Vector<Move> m_moves;
-    friend struct AK::Traits<Board>;
+    friend struct Traits<Board>;
 };
 
 template<typename Callback>

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -114,7 +114,7 @@ u32 CanonicalCode::read_symbol(InputBitStream& stream) const
         // FIXME: This is very inefficient and could greatly be improved by implementing this
         //        algorithm: https://www.hanshq.net/zip.html#huffdec
         size_t index;
-        if (AK::binary_search(m_symbol_codes.span(), code_bits, &index))
+        if (binary_search(m_symbol_codes.span(), code_bits, &index))
             return m_symbol_values[index];
     }
 }

--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -41,7 +41,7 @@ namespace Core {
 static String get_salt()
 {
     char random_data[12];
-    AK::fill_with_random(random_data, sizeof(random_data));
+    fill_with_random(random_data, sizeof(random_data));
 
     StringBuilder builder;
     builder.append("$5$");

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -117,7 +117,7 @@ public:
 
     void deferred_invoke(Function<void(Object&)>);
 
-    void save_to(AK::JsonObject&);
+    void save_to(JsonObject&);
 
     bool set_property(const StringView& name, const JsonValue& value);
     JsonValue property(const StringView& name) const;

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -64,7 +64,7 @@ public:
         return { UnsignedBigInteger::create_invalid(), false };
     }
 
-    static SignedBigInteger import_data(const AK::StringView& data) { return import_data((const u8*)data.characters_without_null_termination(), data.length()); }
+    static SignedBigInteger import_data(const StringView& data) { return import_data((const u8*)data.characters_without_null_termination(), data.length()); }
     static SignedBigInteger import_data(const u8* ptr, size_t length);
 
     size_t export_data(Bytes, bool remove_leading_zeros = false) const;

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -42,7 +42,7 @@ class UnsignedBigInteger {
 public:
     UnsignedBigInteger(u32 x) { m_words.append(x); }
 
-    explicit UnsignedBigInteger(AK::Vector<u32, STARTING_WORD_SIZE>&& words)
+    explicit UnsignedBigInteger(Vector<u32, STARTING_WORD_SIZE>&& words)
         : m_words(move(words))
     {
     }
@@ -53,7 +53,7 @@ public:
 
     static UnsignedBigInteger create_invalid();
 
-    static UnsignedBigInteger import_data(const AK::StringView& data) { return import_data((const u8*)data.characters_without_null_termination(), data.length()); }
+    static UnsignedBigInteger import_data(const StringView& data) { return import_data((const u8*)data.characters_without_null_termination(), data.length()); }
     static UnsignedBigInteger import_data(const u8* ptr, size_t length)
     {
         return UnsignedBigInteger(ptr, length);
@@ -64,7 +64,7 @@ public:
     static UnsignedBigInteger from_base10(const String& str);
     String to_base10() const;
 
-    const AK::Vector<u32, STARTING_WORD_SIZE>& words() const { return m_words; }
+    const Vector<u32, STARTING_WORD_SIZE>& words() const { return m_words; }
 
     void set_to_0();
     void set_to(u32 other);
@@ -116,7 +116,7 @@ private:
     static constexpr size_t BITS_IN_WORD = 32;
     // Little endian
     // m_word[0] + m_word[1] * 256 + m_word[2] * 65536 + ...
-    AK::Vector<u32, STARTING_WORD_SIZE> m_words;
+    Vector<u32, STARTING_WORD_SIZE> m_words;
 
     // Used to indicate a negative result, or a result of an invalid operation
     bool m_is_invalid { false };

--- a/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
+++ b/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
@@ -291,7 +291,7 @@ UnsignedBigInteger random_number(const UnsignedBigInteger& min, const UnsignedBi
     // Also, if we're about to crash anyway, at least produce a nice error:
     VERIFY(size < 8 * MiB);
     u8 buf[size];
-    AK::fill_with_random(buf, size);
+    fill_with_random(buf, size);
     UnsignedBigInteger random { buf, size };
     // At this point, `random` is a large number, in the range [0, 256^size).
     // To get down to the actual range, we could just compute random % range.

--- a/Userland/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
+++ b/Userland/Libraries/LibCrypto/PK/Code/EMSA_PSS.h
@@ -57,7 +57,7 @@ public:
         auto em_length = (em_bits + 7) / 8;
         u8 salt[SaltLength];
 
-        AK::fill_with_random(salt, SaltLength);
+        fill_with_random(salt, SaltLength);
 
         if (em_length < hash_length + SaltLength + 2) {
             dbgln("Ooops...encoding error");

--- a/Userland/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Userland/Libraries/LibCrypto/PK/RSA.cpp
@@ -358,12 +358,12 @@ void RSA_PKCS1_EME::encrypt(ReadonlyBytes in, Bytes& out)
     // FIXME: Without this assertion, GCC refuses to compile due to a memcpy overflow(!?)
     VERIFY(ps_length < 16384);
 
-    AK::fill_with_random(ps, ps_length);
+    fill_with_random(ps, ps_length);
     // since arc4random can create zeros (shocking!)
     // we have to go through and un-zero the zeros
     for (size_t i = 0; i < ps_length; ++i)
         while (!ps[i])
-            AK::fill_with_random(ps + i, 1);
+            fill_with_random(ps + i, 1);
 
     u8 paddings[] { 0x00, 0x02 };
 

--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -350,7 +350,7 @@ void AbstractTableView::layout_headers()
 
         int x = frame_thickness() + row_header_width - horizontal_scrollbar().value();
         int y = frame_thickness();
-        int width = AK::max(content_width(), rect().width() - frame_thickness() * 2 - row_header_width - vertical_scrollbar_width);
+        int width = max(content_width(), rect().width() - frame_thickness() * 2 - row_header_width - vertical_scrollbar_width);
 
         column_header().set_relative_rect(x, y, width, column_header().min_size().height());
     }
@@ -361,7 +361,7 @@ void AbstractTableView::layout_headers()
 
         int x = frame_thickness();
         int y = frame_thickness() + column_header_height - vertical_scrollbar().value();
-        int height = AK::max(content_height(), rect().height() - frame_thickness() * 2 - column_header_height - horizontal_scrollbar_height);
+        int height = max(content_height(), rect().height() - frame_thickness() * 2 - column_header_height - horizontal_scrollbar_height);
 
         row_header().set_relative_rect(x, y, row_header().min_size().width(), height);
     }

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -64,7 +64,7 @@ void InputBox::build()
 
     int text_width = widget.font().width(m_prompt);
     int title_width = widget.font().width(title()) + 24 /* icon, plus a little padding -- not perfect */;
-    int max_width = AK::max(text_width, title_width);
+    int max_width = max(text_width, title_width);
 
     set_rect(x(), y(), max_width + 140, 62);
 

--- a/Userland/Libraries/LibGUI/Variant.cpp
+++ b/Userland/Libraries/LibGUI/Variant.cpp
@@ -257,7 +257,7 @@ Variant& Variant::operator=(Variant&& other)
     if (&other == this)
         return *this;
     clear();
-    move_from(AK::move(other));
+    move_from(move(other));
     return *this;
 }
 

--- a/Userland/Libraries/LibGUI/Variant.h
+++ b/Userland/Libraries/LibGUI/Variant.h
@@ -51,7 +51,7 @@ public:
     Variant(const Gfx::IntRect&);
     Variant(const Gfx::Font&);
     Variant(const Gfx::TextAlignment);
-    Variant(const AK::JsonValue&);
+    Variant(const JsonValue&);
     Variant(Color);
 
     Variant(const Variant&);

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -178,7 +178,7 @@ void WindowServerConnection::handle(const Messages::WindowClient::KeyDown& messa
         key_event->m_key = Key_Invalid;
         key_event->m_modifiers = 0;
 
-        AK::Utf8View m_utf8_view(emoji_input_dialog->selected_emoji_text().characters());
+        Utf8View m_utf8_view(emoji_input_dialog->selected_emoji_text().characters());
         u32 code_point = *m_utf8_view.begin();
 
         key_event->m_code_point = code_point;

--- a/Userland/Libraries/LibGfx/PGMLoader.cpp
+++ b/Userland/Libraries/LibGfx/PGMLoader.cpp
@@ -67,7 +67,7 @@ struct PGMLoadingContext {
     RefPtr<Gfx::Bitmap> bitmap;
 };
 
-static void set_adjusted_pixels(PGMLoadingContext& context, const AK::Vector<Gfx::Color>& color_data)
+static void set_adjusted_pixels(PGMLoadingContext& context, const Vector<Gfx::Color>& color_data)
 {
     size_t index = 0;
     for (size_t y = 0; y < context.height; ++y) {

--- a/Userland/Libraries/LibGfx/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/PortableImageLoaderCommon.h
@@ -207,7 +207,7 @@ static bool create_bitmap(TContext& context)
 }
 
 template<typename TContext>
-static void set_pixels(TContext& context, const AK::Vector<Gfx::Color>& color_data)
+static void set_pixels(TContext& context, const Vector<Gfx::Color>& color_data)
 {
     size_t index = 0;
     for (size_t y = 0; y < context.height; ++y) {

--- a/Userland/Libraries/LibGfx/Streamer.h
+++ b/Userland/Libraries/LibGfx/Streamer.h
@@ -44,7 +44,7 @@ public:
     template<typename T>
     constexpr bool read(T& value)
     {
-        AK::Array<u8, sizeof(T)> network_buffer {};
+        Array<u8, sizeof(T)> network_buffer {};
         auto network_value = new (network_buffer.data()) AK::NetworkOrdered<T> {};
         auto res = read_bytes(network_buffer.data(), sizeof(T));
         value = T(*network_value);

--- a/Userland/Libraries/LibJS/Runtime/MarkedValueList.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MarkedValueList.cpp
@@ -36,7 +36,7 @@ MarkedValueList::MarkedValueList(Heap& heap)
 }
 
 MarkedValueList::MarkedValueList(MarkedValueList&& other)
-    : AK::Vector<Value, 32>(move(static_cast<Vector<Value, 32>&>(other)))
+    : Vector<Value, 32>(move(static_cast<Vector<Value, 32>&>(other)))
     , m_heap(other.m_heap)
 {
     m_heap.did_create_marked_value_list({}, *this);

--- a/Userland/Libraries/LibJS/Runtime/MarkedValueList.h
+++ b/Userland/Libraries/LibJS/Runtime/MarkedValueList.h
@@ -33,7 +33,7 @@
 
 namespace JS {
 
-class MarkedValueList : public AK::Vector<Value, 32> {
+class MarkedValueList : public Vector<Value, 32> {
     AK_MAKE_NONCOPYABLE(MarkedValueList);
 
 public:
@@ -55,4 +55,5 @@ public:
 private:
     Heap& m_heap;
 };
+
 }

--- a/Userland/Libraries/LibTLS/ClientHandshake.cpp
+++ b/Userland/Libraries/LibTLS/ClientHandshake.cpp
@@ -251,12 +251,12 @@ void TLSv12::build_random(PacketBuilder& builder)
     u8 random_bytes[48];
     size_t bytes = 48;
 
-    AK::fill_with_random(random_bytes, bytes);
+    fill_with_random(random_bytes, bytes);
 
     // remove zeros from the random bytes
     for (size_t i = 0; i < bytes; ++i) {
         if (!random_bytes[i])
-            random_bytes[i--] = AK::get_random<u8>();
+            random_bytes[i--] = get_random<u8>();
     }
 
     if (m_context.is_server) {

--- a/Userland/Libraries/LibTLS/Handshake.cpp
+++ b/Userland/Libraries/LibTLS/Handshake.cpp
@@ -33,7 +33,7 @@ namespace TLS {
 
 ByteBuffer TLSv12::build_hello()
 {
-    AK::fill_with_random(&m_context.local_random, 32);
+    fill_with_random(&m_context.local_random, 32);
 
     auto packet_version = (u16)m_context.version;
     auto version = (u16)m_context.version;

--- a/Userland/Libraries/LibTLS/Record.cpp
+++ b/Userland/Libraries/LibTLS/Record.cpp
@@ -127,7 +127,7 @@ void TLSv12::update_packet(ByteBuffer& packet)
                     u8 iv[16];
                     Bytes iv_bytes { iv, 16 };
                     Bytes { m_context.crypto.local_aead_iv, 4 }.copy_to(iv_bytes);
-                    AK::fill_with_random(iv_bytes.offset(4), 8);
+                    fill_with_random(iv_bytes.offset(4), 8);
                     memset(iv_bytes.offset(12), 0, 4);
 
                     // write the random part of the iv out
@@ -164,7 +164,7 @@ void TLSv12::update_packet(ByteBuffer& packet)
                     VERIFY(buffer_position == buffer.size());
 
                     auto iv = ByteBuffer::create_uninitialized(iv_size);
-                    AK::fill_with_random(iv.data(), iv.size());
+                    fill_with_random(iv.data(), iv.size());
 
                     // write it into the ciphertext portion of the message
                     ct.overwrite(header_size, iv.data(), iv.size());

--- a/Userland/Libraries/LibTTF/Font.h
+++ b/Userland/Libraries/LibTTF/Font.h
@@ -168,7 +168,7 @@ private:
     float m_y_scale { 0.0f };
     float m_point_width { 0.0f };
     float m_point_height { 0.0f };
-    mutable AK::HashMap<u32, RefPtr<Gfx::Bitmap>> m_cached_glyph_bitmaps;
+    mutable HashMap<u32, RefPtr<Gfx::Bitmap>> m_cached_glyph_bitmaps;
 };
 
 }

--- a/Userland/Libraries/LibTTF/Glyf.h
+++ b/Userland/Libraries/LibTTF/Glyf.h
@@ -45,7 +45,7 @@ private:
     void draw_line(Gfx::FloatPoint, Gfx::FloatPoint);
 
     Gfx::IntSize m_size;
-    AK::Vector<float> m_data;
+    Vector<float> m_data;
 };
 
 class Loca {

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -171,8 +171,8 @@ private:
     StringView m_input;
 
     Utf8View m_utf8_view;
-    AK::Utf8CodepointIterator m_utf8_iterator;
-    AK::Utf8CodepointIterator m_prev_utf8_iterator;
+    Utf8CodepointIterator m_utf8_iterator;
+    Utf8CodepointIterator m_prev_utf8_iterator;
 
     HTMLToken m_current_token;
 

--- a/Userland/Services/DHCPClient/DHCPv4.h
+++ b/Userland/Services/DHCPClient/DHCPv4.h
@@ -127,7 +127,7 @@ enum class DHCPMessageType : u8 {
 };
 
 template<>
-struct AK::Traits<DHCPOption> : public AK::GenericTraits<DHCPOption> {
+struct AK::Traits<DHCPOption> : public GenericTraits<DHCPOption> {
     static constexpr bool is_trivial() { return true; }
     static unsigned hash(DHCPOption u) { return int_hash((u8)u); }
 };

--- a/Userland/Services/ProtocolServer/HttpProtocol.cpp
+++ b/Userland/Services/ProtocolServer/HttpProtocol.cpp
@@ -46,7 +46,7 @@ HttpProtocol::HttpProtocol()
 
 OwnPtr<Download> HttpProtocol::start_download(ClientConnection& client, const String& method, const URL& url, const HashMap<String, String>& headers, ReadonlyBytes body)
 {
-    return Detail::start_download(AK::Badge<HttpProtocol> {}, client, method, url, headers, body, get_pipe_for_download());
+    return Detail::start_download(Badge<HttpProtocol> {}, client, method, url, headers, body, get_pipe_for_download());
 }
 
 }

--- a/Userland/Services/ProtocolServer/HttpsProtocol.cpp
+++ b/Userland/Services/ProtocolServer/HttpsProtocol.cpp
@@ -46,7 +46,7 @@ HttpsProtocol::HttpsProtocol()
 
 OwnPtr<Download> HttpsProtocol::start_download(ClientConnection& client, const String& method, const URL& url, const HashMap<String, String>& headers, ReadonlyBytes body)
 {
-    return Detail::start_download(AK::Badge<HttpsProtocol> {}, client, method, url, headers, body, get_pipe_for_download());
+    return Detail::start_download(Badge<HttpsProtocol> {}, client, method, url, headers, body, get_pipe_for_download());
 }
 
 }

--- a/Userland/Services/SystemServer/Service.h
+++ b/Userland/Services/SystemServer/Service.h
@@ -44,7 +44,7 @@ public:
     static Service* find_by_pid(pid_t);
 
     // FIXME: Port to Core::Property
-    void save_to(AK::JsonObject&);
+    void save_to(JsonObject&);
 
 private:
     Service(const Core::ConfigFile&, const StringView& name);

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -1417,7 +1417,7 @@ RefPtr<AST::Node> Parser::parse_history_designator()
             ++it;
             is_negative = true;
         }
-        if (it != selector.event.text.end() && AK::all_of(it, selector.event.text.end(), is_digit)) {
+        if (it != selector.event.text.end() && all_of(it, selector.event.text.end(), is_digit)) {
             if (is_negative)
                 selector.event.kind = AST::HistorySelector::EventKind::IndexFromEnd;
             else

--- a/Userland/Tests/LibC/snprintf-correctness.cpp
+++ b/Userland/Tests/LibC/snprintf-correctness.cpp
@@ -74,7 +74,7 @@ static bool test_single(const Testcase& testcase)
 
     // Setup
     ByteBuffer actual = ByteBuffer::create_uninitialized(SANDBOX_CANARY_SIZE + testcase.dest_n + SANDBOX_CANARY_SIZE);
-    AK::fill_with_random(actual.data(), actual.size());
+    fill_with_random(actual.data(), actual.size());
     ByteBuffer expected = actual.isolated_copy();
     VERIFY(actual.offset_pointer(0) != expected.offset_pointer(0));
     actual.overwrite(SANDBOX_CANARY_SIZE, testcase.dest, testcase.dest_n);

--- a/Userland/Tests/LibC/strlcpy-correctness.cpp
+++ b/Userland/Tests/LibC/strlcpy-correctness.cpp
@@ -76,7 +76,7 @@ static bool test_single(const Testcase& testcase)
 
     // Setup
     ByteBuffer actual = ByteBuffer::create_uninitialized(SANDBOX_CANARY_SIZE + testcase.dest_n + SANDBOX_CANARY_SIZE);
-    AK::fill_with_random(actual.data(), actual.size());
+    fill_with_random(actual.data(), actual.size());
     ByteBuffer expected = actual.isolated_copy();
     VERIFY(actual.offset_pointer(0) != expected.offset_pointer(0));
     actual.overwrite(SANDBOX_CANARY_SIZE, testcase.dest, testcase.dest_n);

--- a/Userland/Utilities/cut.cpp
+++ b/Userland/Utilities/cut.cpp
@@ -63,8 +63,8 @@ static void add_if_not_exists(Vector<Index>& indexes, Index data)
     for (auto& index : indexes) {
         if (index.intersects(data)) {
             if (index.m_type == Index::Type::RangedIndex) {
-                index.m_from = AK::min(index.m_from, data.m_from);
-                index.m_to = AK::max(index.m_to, data.m_to);
+                index.m_from = min(index.m_from, data.m_from);
+                index.m_to = max(index.m_to, data.m_to);
             }
             append_to_vector = false;
         }

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -406,14 +406,14 @@ static void print(JS::Value value)
     outln();
 }
 
-static bool file_has_shebang(AK::ByteBuffer file_contents)
+static bool file_has_shebang(ByteBuffer file_contents)
 {
     if (file_contents.size() >= 2 && file_contents[0] == '#' && file_contents[1] == '!')
         return true;
     return false;
 }
 
-static StringView strip_shebang(AK::ByteBuffer file_contents)
+static StringView strip_shebang(ByteBuffer file_contents)
 {
     size_t i = 0;
     for (i = 2; i < file_contents.size(); ++i) {

--- a/Userland/Utilities/lspci.cpp
+++ b/Userland/Utilities/lspci.cpp
@@ -64,7 +64,7 @@ int main(int argc, char** argv)
 
     const char* format = flag_show_numerical ? format_numerical : format_textual;
 
-    AK::RefPtr<PCIDB::Database> db;
+    RefPtr<PCIDB::Database> db;
     if (!flag_show_numerical) {
         db = PCIDB::Database::open();
         if (!db) {

--- a/Userland/Utilities/test-bindtodevice.cpp
+++ b/Userland/Utilities/test-bindtodevice.cpp
@@ -38,7 +38,7 @@ static void test_no_route(int);
 static void test_valid(int);
 static void test_send(int);
 
-static void test(AK::Function<void(int)> test_fn)
+static void test(Function<void(int)> test_fn)
 {
 
     int fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);

--- a/Userland/Utilities/test-crypto.cpp
+++ b/Userland/Utilities/test-crypto.cpp
@@ -2217,7 +2217,7 @@ static void bigint_test_fibo500()
 {
     {
         I_TEST((BigInteger | Fibonacci500));
-        bool pass = (bigint_fibonacci(500).words() == AK::Vector<u32> { 315178285, 505575602, 1883328078, 125027121, 3649625763, 347570207, 74535262, 3832543808, 2472133297, 1600064941, 65273441 });
+        bool pass = (bigint_fibonacci(500).words() == Vector<u32> { 315178285, 505575602, 1883328078, 125027121, 3649625763, 347570207, 74535262, 3832543808, 2472133297, 1600064941, 65273441 });
 
         if (pass) {
             PASS;
@@ -2428,7 +2428,7 @@ static void bigint_import_export()
         I_TEST((BigInteger | BigEndian Decode / Encode roundtrip));
         u8 random_bytes[128];
         u8 target_buffer[128];
-        AK::fill_with_random(random_bytes, 128);
+        fill_with_random(random_bytes, 128);
         auto encoded = Crypto::UnsignedBigInteger::import_data(random_bytes, 128);
         encoded.export_data({ target_buffer, 128 });
         if (memcmp(target_buffer, random_bytes, 128) != 0)
@@ -2540,7 +2540,7 @@ static void bigint_test_signed_fibo500()
 {
     {
         I_TEST((Signed BigInteger | Fibonacci500));
-        bool pass = (bigint_signed_fibonacci(500).unsigned_value().words() == AK::Vector<u32> { 315178285, 505575602, 1883328078, 125027121, 3649625763, 347570207, 74535262, 3832543808, 2472133297, 1600064941, 65273441 });
+        bool pass = (bigint_signed_fibonacci(500).unsigned_value().words() == Vector<u32> { 315178285, 505575602, 1883328078, 125027121, 3649625763, 347570207, 74535262, 3832543808, 2472133297, 1600064941, 65273441 });
 
         if (pass) {
             PASS;
@@ -2745,7 +2745,7 @@ static void bigint_signed_import_export()
         u8 random_bytes[129];
         u8 target_buffer[129];
         random_bytes[0] = 1;
-        AK::fill_with_random(random_bytes + 1, 128);
+        fill_with_random(random_bytes + 1, 128);
         auto encoded = Crypto::SignedBigInteger::import_data(random_bytes, 129);
         encoded.export_data({ target_buffer, 129 });
         if (memcmp(target_buffer, random_bytes, 129) != 0)

--- a/Userland/Utilities/tree.cpp
+++ b/Userland/Utilities/tree.cpp
@@ -54,7 +54,7 @@ static void print_directory_tree(const String& root_path, int depth, const Strin
         out("{}|-- ", root_indent_string);
     }
 
-    String root_dir_name = AK::LexicalPath(root_path).basename();
+    String root_dir_name = LexicalPath(root_path).basename();
     out("\033[34;1m{}\033[0m\n", root_dir_name);
 
     if (depth >= max_depth) {

--- a/Userland/Utilities/uniq.cpp
+++ b/Userland/Utilities/uniq.cpp
@@ -89,7 +89,7 @@ int main(int argc, char** argv)
             continue;
 
         fputs(current->buf, outfile);
-        AK::swap(current, previous);
+        swap(current, previous);
         first_run = false;
     }
 


### PR DESCRIPTION
This is basically just for consistency, it's quite strange to see multiple AK container types next to each other, some with and some without the namespace prefix - we're `using AK::Foo;` a lot and should leverage that. :^)