### PR TITLE
Spreadsheet: Fix cell identifier label

### DIFF
--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -57,7 +57,7 @@ CellTypeDialog::CellTypeDialog(const Vector<Position>& positions, Sheet& sheet, 
     StringBuilder builder;
 
     if (positions.size() == 1)
-        builder.appendff("Format cell {}{}", positions.first().column, positions.first().row);
+        builder.appendff("Format cell {}", positions.first().to_cell_identifier(sheet));
     else
         builder.appendff("Format {} cells", positions.size());
 

--- a/Userland/Applications/Spreadsheet/Position.h
+++ b/Userland/Applications/Spreadsheet/Position.h
@@ -62,6 +62,7 @@ struct Position {
         return !(other == *this);
     }
 
+    String to_cell_identifier(const Sheet& sheet) const;
     URL to_url(const Sheet& sheet) const;
 
     size_t column { 0 };

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -113,7 +113,7 @@ static String convert_to_string(size_t value, unsigned base = 26, StringView map
         value /= base;
     } while (value > 0);
 
-    // NOTE: Weird as this may seem, the thing that comes after 'A' is 'AA', which as a number would be '00'
+    // NOTE: Weird as this may seem, the thing that comes after 'Z' is 'AA', which as a number would be '00'
     //       to make this work, only the most significant digit has to be in a range of (1..25) as opposed to (0..25),
     //       but only if it's not the only digit in the string.
     if (i > 1)
@@ -726,13 +726,18 @@ String Sheet::generate_inline_documentation_for(StringView function, size_t argu
     return builder.build();
 }
 
+String Position::to_cell_identifier(const Sheet& sheet) const
+{
+    return String::formatted("{}{}", sheet.column(column), row);
+}
+
 URL Position::to_url(const Sheet& sheet) const
 {
     URL url;
     url.set_protocol("spreadsheet");
     url.set_host("cell");
     url.set_path(String::formatted("/{}", getpid()));
-    url.set_fragment(String::formatted("{}{}", sheet.column(column), row));
+    url.set_fragment(to_cell_identifier(sheet));
     return url;
 }
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -155,11 +155,8 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
 
             if (selection.size() == 1) {
                 auto& position = selection.first();
-                StringBuilder builder;
-                builder.append(position.column);
-                builder.appendff("{}", position.row);
                 m_current_cell_label->set_enabled(true);
-                m_current_cell_label->set_text(builder.string_view());
+                m_current_cell_label->set_text(position.to_cell_identifier(m_selected_view->sheet()));
 
                 auto& cell = m_selected_view->sheet().ensure(position);
                 m_cell_value_editor->on_change = nullptr;


### PR DESCRIPTION
Commit 6a6f19a broke the cell position display in the top left of the Spreadsheet window and the title of the cell type dialog, causing the application to crash when interacting with cells beyond column FE.