### PR TITLE
Kernel: Fix HPET timer structure layout

### DIFF
--- a/Kernel/Time/HPET.h
+++ b/Kernel/Time/HPET.h
@@ -72,7 +72,7 @@ private:
     void global_disable();
     void global_enable();
 
-    bool is_periodic_capable(u8 comparator_number) const;
+    bool is_periodic_capable(u8 comparator_number);
     void set_comparators_to_optimal_interrupt_state(size_t timers_count);
 
     u64 calculate_ticks_in_nanoseconds() const;


### PR DESCRIPTION
_I'm not sure if this is actually correct. The spec seems to be conflicting. Table 2.3.1 says there's 32 timers, yet the range for the timers is only supposed to be `0x160-0x3ff`. But that's only true if there's only 31 timers. If there are 32 timers that range would `0x160-0x417`..._

Only the first 3 timers have a reserved field, the 29 other timers
do not have a reserved field.

Fixes #5530