### PR TITLE
LibRegex: Implement section B.1.4. of the ECMA262 spec / LibRegex: some tiny fixes

### DIFF
--- a/Userland/Libraries/LibC/regex.h
+++ b/Userland/Libraries/LibC/regex.h
@@ -83,21 +83,22 @@ struct regmatch_t {
 };
 
 enum __RegexAllFlags {
-    __Regex_Global = 1,                                  // All matches (don't return after first match)
-    __Regex_Insensitive = __Regex_Global << 1,           // Case insensitive match (ignores case of [a-zA-Z])
-    __Regex_Ungreedy = __Regex_Global << 2,              // The match becomes lazy by default. Now a ? following a quantifier makes it greedy
-    __Regex_Unicode = __Regex_Global << 3,               // Enable all unicode features and interpret all unicode escape sequences as such
-    __Regex_Extended = __Regex_Global << 4,              // Ignore whitespaces. Spaces and text after a # in the pattern are ignored
-    __Regex_Extra = __Regex_Global << 5,                 // Disallow meaningless escapes. A \ followed by a letter with no special meaning is faulted
-    __Regex_MatchNotBeginOfLine = __Regex_Global << 6,   // Pattern is not forced to ^ -> search in whole string!
-    __Regex_MatchNotEndOfLine = __Regex_Global << 7,     // Don't Force the dollar sign, $, to always match end of the string, instead of end of the line. This option is ignored if the Multiline-flag is set
-    __Regex_SkipSubExprResults = __Regex_Global << 8,    // Do not return sub expressions in the result
-    __Regex_StringCopyMatches = __Regex_Global << 9,     // Do explicitly copy results into new allocated string instead of StringView to original string.
-    __Regex_SingleLine = __Regex_Global << 10,           // Dot matches newline characters
-    __Regex_Sticky = __Regex_Global << 11,               // Force the pattern to only match consecutive matches from where the previous match ended.
-    __Regex_Multiline = __Regex_Global << 12,            // Handle newline characters. Match each line, one by one.
-    __Regex_SkipTrimEmptyMatches = __Regex_Global << 13, // Do not remove empty capture group results.
-    __Regex_Internal_Stateful = __Regex_Global << 14,    // Internal flag; enables stateful matches.
+    __Regex_Global = 1,                                      // All matches (don't return after first match)
+    __Regex_Insensitive = __Regex_Global << 1,               // Case insensitive match (ignores case of [a-zA-Z])
+    __Regex_Ungreedy = __Regex_Global << 2,                  // The match becomes lazy by default. Now a ? following a quantifier makes it greedy
+    __Regex_Unicode = __Regex_Global << 3,                   // Enable all unicode features and interpret all unicode escape sequences as such
+    __Regex_Extended = __Regex_Global << 4,                  // Ignore whitespaces. Spaces and text after a # in the pattern are ignored
+    __Regex_Extra = __Regex_Global << 5,                     // Disallow meaningless escapes. A \ followed by a letter with no special meaning is faulted
+    __Regex_MatchNotBeginOfLine = __Regex_Global << 6,       // Pattern is not forced to ^ -> search in whole string!
+    __Regex_MatchNotEndOfLine = __Regex_Global << 7,         // Don't Force the dollar sign, $, to always match end of the string, instead of end of the line. This option is ignored if the Multiline-flag is set
+    __Regex_SkipSubExprResults = __Regex_Global << 8,        // Do not return sub expressions in the result
+    __Regex_StringCopyMatches = __Regex_Global << 9,         // Do explicitly copy results into new allocated string instead of StringView to original string.
+    __Regex_SingleLine = __Regex_Global << 10,               // Dot matches newline characters
+    __Regex_Sticky = __Regex_Global << 11,                   // Force the pattern to only match consecutive matches from where the previous match ended.
+    __Regex_Multiline = __Regex_Global << 12,                // Handle newline characters. Match each line, one by one.
+    __Regex_SkipTrimEmptyMatches = __Regex_Global << 13,     // Do not remove empty capture group results.
+    __Regex_Internal_Stateful = __Regex_Global << 14,        // Internal flag; enables stateful matches.
+    __Regex_Internal_BrowserExtended = __Regex_Global << 15, // Internal flag; enable browser-specific ECMA262 extensions.
     __Regex_Last = __Regex_SkipTrimEmptyMatches
 };
 

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -37,7 +37,9 @@ static Flags options_from(const String& flags, VM& vm, GlobalObject& global_obje
 {
     bool g = false, i = false, m = false, s = false, u = false, y = false;
     Flags options {
-        { (regex::ECMAScriptFlags)regex::AllFlags::Global }, // JS regexps are all 'global' by default as per our definition, but the "global" flag enables "stateful".
+        // JS regexps are all 'global' by default as per our definition, but the "global" flag enables "stateful".
+        // FIXME: Enable 'BrowserExtended' only if in a browser context.
+        { (regex::ECMAScriptFlags)regex::AllFlags::Global | ECMAScriptFlags::BrowserExtended },
         {},
     };
 

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -136,7 +136,9 @@ public:
     u32 operator[](size_t index) const
     {
         if (is_u8_view()) {
-            return u8view()[index];
+            i8 ch = u8view()[index];
+            u8 value = *reinterpret_cast<u8*>(&ch);
+            return static_cast<u32>(value);
         }
         return u32view().code_points()[index];
     }

--- a/Userland/Libraries/LibRegex/RegexOptions.h
+++ b/Userland/Libraries/LibRegex/RegexOptions.h
@@ -39,22 +39,23 @@ namespace regex {
 using FlagsUnderlyingType = u16;
 
 enum class AllFlags {
-    Global = __Regex_Global,                             // All matches (don't return after first match)
-    Insensitive = __Regex_Insensitive,                   // Case insensitive match (ignores case of [a-zA-Z])
-    Ungreedy = __Regex_Ungreedy,                         // The match becomes lazy by default. Now a ? following a quantifier makes it greedy
-    Unicode = __Regex_Unicode,                           // Enable all unicode features and interpret all unicode escape sequences as such
-    Extended = __Regex_Extended,                         // Ignore whitespaces. Spaces and text after a # in the pattern are ignored
-    Extra = __Regex_Extra,                               // Disallow meaningless escapes. A \ followed by a letter with no special meaning is faulted
-    MatchNotBeginOfLine = __Regex_MatchNotBeginOfLine,   // Pattern is not forced to ^ -> search in whole string!
-    MatchNotEndOfLine = __Regex_MatchNotEndOfLine,       // Don't Force the dollar sign, $, to always match end of the string, instead of end of the line. This option is ignored if the Multiline-flag is set
-    SkipSubExprResults = __Regex_SkipSubExprResults,     // Do not return sub expressions in the result
-    StringCopyMatches = __Regex_StringCopyMatches,       // Do explicitly copy results into new allocated string instead of StringView to original string.
-    SingleLine = __Regex_SingleLine,                     // Dot matches newline characters
-    Sticky = __Regex_Sticky,                             // Force the pattern to only match consecutive matches from where the previous match ended.
-    Multiline = __Regex_Multiline,                       // Handle newline characters. Match each line, one by one.
-    SkipTrimEmptyMatches = __Regex_SkipTrimEmptyMatches, // Do not remove empty capture group results.
-    Internal_Stateful = __Regex_Internal_Stateful,       // Make global matches match one result at a time, and further match() calls on the same instance continue where the previous one left off.
-    Last = Internal_Stateful,
+    Global = __Regex_Global,                                     // All matches (don't return after first match)
+    Insensitive = __Regex_Insensitive,                           // Case insensitive match (ignores case of [a-zA-Z])
+    Ungreedy = __Regex_Ungreedy,                                 // The match becomes lazy by default. Now a ? following a quantifier makes it greedy
+    Unicode = __Regex_Unicode,                                   // Enable all unicode features and interpret all unicode escape sequences as such
+    Extended = __Regex_Extended,                                 // Ignore whitespaces. Spaces and text after a # in the pattern are ignored
+    Extra = __Regex_Extra,                                       // Disallow meaningless escapes. A \ followed by a letter with no special meaning is faulted
+    MatchNotBeginOfLine = __Regex_MatchNotBeginOfLine,           // Pattern is not forced to ^ -> search in whole string!
+    MatchNotEndOfLine = __Regex_MatchNotEndOfLine,               // Don't Force the dollar sign, $, to always match end of the string, instead of end of the line. This option is ignored if the Multiline-flag is set
+    SkipSubExprResults = __Regex_SkipSubExprResults,             // Do not return sub expressions in the result
+    StringCopyMatches = __Regex_StringCopyMatches,               // Do explicitly copy results into new allocated string instead of StringView to original string.
+    SingleLine = __Regex_SingleLine,                             // Dot matches newline characters
+    Sticky = __Regex_Sticky,                                     // Force the pattern to only match consecutive matches from where the previous match ended.
+    Multiline = __Regex_Multiline,                               // Handle newline characters. Match each line, one by one.
+    SkipTrimEmptyMatches = __Regex_SkipTrimEmptyMatches,         // Do not remove empty capture group results.
+    Internal_Stateful = __Regex_Internal_Stateful,               // Make global matches match one result at a time, and further match() calls on the same instance continue where the previous one left off.
+    Internal_BrowserExtended = __Regex_Internal_BrowserExtended, // Only for ECMA262, Enable the behaviours defined in section B.1.4. of the ECMA262 spec.
+    Last = Internal_BrowserExtended,
 };
 
 enum class PosixFlags : FlagsUnderlyingType {
@@ -83,6 +84,7 @@ enum class ECMAScriptFlags : FlagsUnderlyingType {
     Sticky = (FlagsUnderlyingType)AllFlags::Sticky,
     Multiline = (FlagsUnderlyingType)AllFlags::Multiline,
     StringCopyMatches = (FlagsUnderlyingType)AllFlags::StringCopyMatches,
+    BrowserExtended = (FlagsUnderlyingType)AllFlags::Internal_BrowserExtended,
 };
 
 template<class T>

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -954,12 +954,10 @@ bool ECMA262Parser::parse_quantifier(ByteCode& stack, size_t& match_length_minim
         if (match(TokenType::Comma)) {
             consume();
             auto high_bound = read_digits();
-            if (!high_bound.has_value()) {
-                set_error(Error::InvalidBraceContent);
-                return false;
-            }
-
-            repeat_max = high_bound.value();
+            if (high_bound.has_value())
+                repeat_max = high_bound.value();
+        } else {
+            repeat_max = repeat_min;
         }
 
         if (!match(TokenType::RightCurly)) {

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -1015,7 +1015,7 @@ bool ECMA262Parser::parse_atom(ByteCode& stack, size_t& match_length_minimum, bo
         // Also part of AtomEscape.
         auto token = consume();
         match_length_minimum += 1;
-        stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (ByteCodeValueType)token.value()[0] } });
+        stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (ByteCodeValueType)token.value()[1] } });
         return true;
     }
     if (try_skip("\\")) {

--- a/Userland/Libraries/LibRegex/Tests/Regex.cpp
+++ b/Userland/Libraries/LibRegex/Tests/Regex.cpp
@@ -549,6 +549,7 @@ TEST_CASE(ECMA262_match)
         { "bar.*(?<!foo)", "barbar", true },
         { "((...)X)+", "fooXbarXbazX", true },
         { "(?:)", "", true },
+        { "\\^", "^" },
         // ECMA262, B.1.4. Regular Expression Pattern extensions for browsers
         { "{", "{", true, ECMAScriptFlags::BrowserExtended },
         { "\\5", "\5", true, ECMAScriptFlags::BrowserExtended },

--- a/Userland/Libraries/LibRegex/Tests/Regex.cpp
+++ b/Userland/Libraries/LibRegex/Tests/Regex.cpp
@@ -563,6 +563,7 @@ TEST_CASE(ECMA262_match)
         { "^(?:^^\\.?|[!+-]|!=|!==|#|%|%=|&|&&|&&=|&=|\\(|\\*|\\*=|\\+=|,|-=|->|\\/|\\/=|:|::|;|<|<<|<<=|<=|=|==|===|>|>=|>>|>>=|>>>|>>>=|[?@[^]|\\^=|\\^\\^|\\^\\^=|{|\\||\\|=|\\|\\||\\|\\|=|~|break|case|continue|delete|do|else|finally|instanceof|return|throw|try|typeof)\\s*(\\/(?=[^*/])(?:[^/[\\\\]|\\\\[\\S\\s]|\\[(?:[^\\\\\\]]|\\\\[\\S\\s])*(?:]|$))+\\/)",
                  "return /xx/", true, ECMAScriptFlags::BrowserExtended
         }, // #5517, appears to be matching JS expressions that involve regular expressions...
+        { "a{2,}", "aaaa" }, // #5518
     };
     // clang-format on
 


### PR DESCRIPTION
This allows the parser to deal with crazy patterns like the one in #5517.

I decided to _conditionally_ bite the bullet (in the regex library).
As discussed, this enables that flag by default in LibJS (+a FIXME). we can later disable it as needed.

Fixes #5517.
Fixes #5518.