### PR TITLE
LibGfx: Fix read buffer overflow in interlaced GIF decode

### DIFF
--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -399,13 +399,14 @@ static bool decode_frame(GIFLoadingContext& context, size_t frame_index)
                 ++pixel_index;
                 if (pixel_index % image.width == 0) {
                     if (image.interlaced) {
-                        if (row + INTERLACE_ROW_STRIDES[interlace_pass] >= image.height) {
-                            ++interlace_pass;
-                            if (interlace_pass < 4)
-                                row = INTERLACE_ROW_OFFSETS[interlace_pass];
-                        } else {
-                            if (interlace_pass < 4)
+                        if (interlace_pass < 4) {
+                            if (row + INTERLACE_ROW_STRIDES[interlace_pass] >= image.height) {
+                                ++interlace_pass;
+                                if (interlace_pass < 4)
+                                    row = INTERLACE_ROW_OFFSETS[interlace_pass];
+                            } else {
                                 row += INTERLACE_ROW_STRIDES[interlace_pass];
+                            }
                         }
                     } else {
                         ++row;


### PR DESCRIPTION
Unfortunately 10420dee7e48c818a7b1c5386b8fcebc587825f0 didn't quite fix it,
as the buffer overflow was actually happening here:
https://github.com/SerenityOS/serenity/blob/af2220448834fb0bff5132bf68104719819862ce/Userland/Libraries/LibGfx/GIFLoader.cpp#L402

Found by oss-fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30507