### PR TITLE
Profiler: remove unimplemented Profile::LibraryMetadata::symbolicate() definition

### DIFF
--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -184,8 +184,6 @@ public:
     public:
         LibraryMetadata(JsonArray regions);
 
-        String symbolicate(FlatPtr ptr, u32& offset) const;
-
         struct Library {
             FlatPtr base;
             size_t size;


### PR DESCRIPTION
The implementation of Profile::LibraryMetadata::symbolicate() was removed in 340180ba057096d8cca917d2774c5a75c4b15975, but the corresponding public declaration was not.