### PR TITLE
Spreadsheet: Implement the cut operation for cells

### DIFF
--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2020-2021, the SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -325,7 +325,7 @@ Position Sheet::offset_relative_to(const Position& base, const Position& offset,
     return { new_column, new_row };
 }
 
-void Sheet::copy_cells(Vector<Position> from, Vector<Position> to, Optional<Position> resolve_relative_to)
+void Sheet::copy_cells(Vector<Position> from, Vector<Position> to, Optional<Position> resolve_relative_to, CopyOperation copy_operation)
 {
     auto copy_to = [&](auto& source_position, Position target_position) {
         auto& target_cell = ensure(target_position);
@@ -337,6 +337,8 @@ void Sheet::copy_cells(Vector<Position> from, Vector<Position> to, Optional<Posi
         }
 
         target_cell.copy_from(*source_cell);
+        if (copy_operation == CopyOperation::Cut)
+            source_cell->set_data("");
     };
 
     if (from.size() == to.size()) {

--- a/Userland/Applications/Spreadsheet/Spreadsheet.h
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2020-2021, the SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -140,7 +140,12 @@ public:
 
     const Workbook& workbook() const { return m_workbook; }
 
-    void copy_cells(Vector<Position> from, Vector<Position> to, Optional<Position> resolve_relative_to = {});
+    enum class CopyOperation {
+        Copy,
+        Cut
+    };
+
+    void copy_cells(Vector<Position> from, Vector<Position> to, Optional<Position> resolve_relative_to = {}, CopyOperation copy_operation = CopyOperation::Copy);
 
     /// Gives the bottom-right corner of the smallest bounding box containing all the written data.
     Position written_data_bounds() const;


### PR DESCRIPTION
This is done by adding another field to our custom text/x-spreadsheet-data mime-type that specifies the action (just copy/cut for now).

This closes #4275