### PR TITLE
Kernel: Use default con/de-structors

### DIFF
--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -62,10 +62,6 @@ CoreDump::CoreDump(NonnullRefPtr<Process> process, NonnullRefPtr<FileDescription
 {
 }
 
-CoreDump::~CoreDump()
-{
-}
-
 RefPtr<FileDescription> CoreDump::create_target_file(const Process& process, const String& output_path)
 {
     LexicalPath lexical_path(output_path);

--- a/Kernel/CoreDump.h
+++ b/Kernel/CoreDump.h
@@ -41,7 +41,7 @@ class CoreDump {
 public:
     static OwnPtr<CoreDump> create(NonnullRefPtr<Process>, const String& output_path);
 
-    ~CoreDump();
+    ~CoreDump() = default;
     [[nodiscard]] KResult write();
 
 private:

--- a/Kernel/Devices/I8042Controller.h
+++ b/Kernel/Devices/I8042Controller.h
@@ -43,7 +43,7 @@ namespace Kernel {
 
 class I8042Device {
 public:
-    virtual ~I8042Device() { }
+    virtual ~I8042Device() = default;
 
     virtual void irq_handle_byte_read(u8 byte) = 0;
     virtual void enable_interrupts() = 0;

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -51,7 +51,7 @@ public:
         }
     }
 
-    ~DiskCache() { }
+    ~DiskCache() = default;
 
     bool is_dirty() const { return m_dirty; }
     void set_dirty(bool b) { m_dirty = b; }

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -40,7 +40,7 @@ namespace Kernel {
 
 class FileDescriptionData {
 public:
-    virtual ~FileDescriptionData() { }
+    virtual ~FileDescriptionData() = default;
 };
 
 class FileDescription : public RefCounted<FileDescription> {

--- a/Kernel/FileSystem/InodeIdentifier.h
+++ b/Kernel/FileSystem/InodeIdentifier.h
@@ -40,7 +40,7 @@ TYPEDEF_DISTINCT_ORDERED_ID(unsigned, InodeIndex);
 
 class InodeIdentifier {
 public:
-    InodeIdentifier() { }
+    InodeIdentifier() = default;
     InodeIdentifier(u32 fsid, InodeIndex inode)
         : m_fsid(fsid)
         , m_index(inode)

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -58,7 +58,7 @@ private:
     ProcFS();
 
     struct ProcFSDirectoryEntry {
-        ProcFSDirectoryEntry() { }
+        ProcFSDirectoryEntry() = default;
         ProcFSDirectoryEntry(const char* a_name, unsigned a_proc_file_type, bool a_supervisor_only, bool (*read_callback)(InodeIdentifier, KBufferBuilder&) = nullptr, ssize_t (*write_callback)(InodeIdentifier, const UserOrKernelBuffer&, size_t) = nullptr, RefPtr<ProcFSInode>&& a_inode = nullptr)
             : name(a_name)
             , proc_file_type(a_proc_file_type)

--- a/Kernel/Heap/Heap.h
+++ b/Kernel/Heap/Heap.h
@@ -58,9 +58,7 @@ public:
         // at the end of the memory block.
         VERIFY(m_total_chunks * CHUNK_SIZE + (m_total_chunks + 7) / 8 <= memory_size);
     }
-    ~Heap()
-    {
-    }
+    ~Heap() = default;
 
     static size_t calculate_memory_for_bytes(size_t bytes)
     {

--- a/Kernel/Heap/SlabAllocator.cpp
+++ b/Kernel/Heap/SlabAllocator.cpp
@@ -38,7 +38,7 @@ namespace Kernel {
 template<size_t templated_slab_size>
 class SlabAllocator {
 public:
-    SlabAllocator() { }
+    SlabAllocator() = default;
 
     void init(size_t size)
     {

--- a/Kernel/IO.h
+++ b/Kernel/IO.h
@@ -101,7 +101,7 @@ inline void delay(size_t microseconds)
 
 class IOAddress {
 public:
-    IOAddress() { }
+    IOAddress() = default;
     explicit IOAddress(u16 address)
         : m_address(address)
     {

--- a/Kernel/Interrupts/IRQController.h
+++ b/Kernel/Interrupts/IRQController.h
@@ -39,7 +39,7 @@ enum class IRQControllerType {
 
 class IRQController : public RefCounted<IRQController> {
 public:
-    virtual ~IRQController() { }
+    virtual ~IRQController() = default;
 
     virtual void enable(const GenericInterruptHandler&) = 0;
     virtual void disable(const GenericInterruptHandler&) = 0;
@@ -57,7 +57,7 @@ public:
     virtual IRQControllerType type() const = 0;
 
 protected:
-    IRQController() { }
+    IRQController() = default;
     virtual void initialize() = 0;
     bool m_hard_disabled { false };
 };

--- a/Kernel/KBufferBuilder.h
+++ b/Kernel/KBufferBuilder.h
@@ -39,7 +39,7 @@ public:
     explicit KBufferBuilder(bool can_expand = false);
     explicit KBufferBuilder(RefPtr<KBufferImpl>&, bool can_expand = false);
     KBufferBuilder(KBufferBuilder&&) = default;
-    ~KBufferBuilder() { }
+    ~KBufferBuilder() = default;
 
     void append(const StringView&);
     void append(char);

--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -56,7 +56,7 @@ public:
 private:
     template<typename T>
     friend class KResultOr;
-    KResult() { }
+    KResult() = default;
 
     int m_error { 0 };
 };

--- a/Kernel/Lock.h
+++ b/Kernel/Lock.h
@@ -48,7 +48,7 @@ public:
         : m_name(name)
     {
     }
-    ~Lock() { }
+    ~Lock() = default;
 
     void lock(Mode = Mode::Exclusive);
 #if LOCK_DEBUG
@@ -144,7 +144,7 @@ private:
 template<typename T>
 class Lockable {
 public:
-    Lockable() { }
+    Lockable() = default;
     Lockable(T&& resource)
         : m_resource(move(resource))
     {

--- a/Kernel/Net/EthernetFrameHeader.h
+++ b/Kernel/Net/EthernetFrameHeader.h
@@ -33,8 +33,8 @@
 
 class [[gnu::packed]] EthernetFrameHeader {
 public:
-    EthernetFrameHeader() { }
-    ~EthernetFrameHeader() { }
+    EthernetFrameHeader() = default;
+    ~EthernetFrameHeader() = default;
 
     MACAddress destination() const { return m_destination; }
     void set_destination(const MACAddress& address) { m_destination = address; }

--- a/Kernel/Net/ICMP.h
+++ b/Kernel/Net/ICMP.h
@@ -38,8 +38,8 @@ struct ICMPType {
 
 class [[gnu::packed]] ICMPHeader {
 public:
-    ICMPHeader() { }
-    ~ICMPHeader() { }
+    ICMPHeader() = default;
+    ~ICMPHeader() = default;
 
     u8 type() const { return m_type; }
     void set_type(u8 b) { m_type = b; }

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -180,7 +180,7 @@ private:
 template<typename SocketType>
 class SocketHandle {
 public:
-    SocketHandle() { }
+    SocketHandle() = default;
 
     SocketHandle(NonnullRefPtr<SocketType>&& socket)
         : m_socket(move(socket))

--- a/Kernel/Net/UDP.h
+++ b/Kernel/Net/UDP.h
@@ -32,8 +32,8 @@ namespace Kernel {
 
 class [[gnu::packed]] UDPPacket {
 public:
-    UDPPacket() { }
-    ~UDPPacket() { }
+    UDPPacket() = default;
+    ~UDPPacket() = default;
 
     u16 source_port() const { return m_source_port; }
     void set_source_port(u16 port) { m_source_port = port; }

--- a/Kernel/PCI/Definitions.h
+++ b/Kernel/PCI/Definitions.h
@@ -92,7 +92,7 @@ inline const LogStream& operator<<(const LogStream& stream, const ID value)
 }
 struct Address {
 public:
-    Address() { }
+    Address() = default;
     Address(u16 seg)
         : m_seg(seg)
         , m_bus(0)

--- a/Kernel/PCI/DeviceController.h
+++ b/Kernel/PCI/DeviceController.h
@@ -34,7 +34,7 @@ class PCI::DeviceController {
 public:
     Address pci_address() const { return m_pci_address; };
 
-    virtual ~DeviceController() { }
+    virtual ~DeviceController() = default;
     void enable_pin_based_interrupts() const;
     void disable_pin_based_interrupts() const;
 

--- a/Kernel/PhysicalAddress.h
+++ b/Kernel/PhysicalAddress.h
@@ -31,7 +31,7 @@
 
 class PhysicalAddress {
 public:
-    PhysicalAddress() { }
+    PhysicalAddress() = default;
     explicit PhysicalAddress(FlatPtr address)
         : m_address(address)
     {

--- a/Kernel/Storage/Partition/GUIDPartitionTable.h
+++ b/Kernel/Storage/Partition/GUIDPartitionTable.h
@@ -37,7 +37,8 @@ namespace Kernel {
 struct GUIDPartitionHeader;
 class GUIDPartitionTable final : public MBRPartitionTable {
 public:
-    virtual ~GUIDPartitionTable() {};
+    virtual ~GUIDPartitionTable() = default;
+    ;
 
     static Result<NonnullOwnPtr<GUIDPartitionTable>, PartitionTable::Error> try_to_initialize(const StorageDevice&);
     explicit GUIDPartitionTable(const StorageDevice&);

--- a/Kernel/Storage/Partition/PartitionTable.h
+++ b/Kernel/Storage/Partition/PartitionTable.h
@@ -52,7 +52,7 @@ public:
     Optional<DiskPartitionMetadata> partition(unsigned index);
     size_t partitions_count() const { return m_partitions.size(); }
     virtual Type type() const = 0;
-    virtual ~PartitionTable() { }
+    virtual ~PartitionTable() = default;
     virtual bool is_valid() const = 0;
 
     Vector<DiskPartitionMetadata> partitions() const { return m_partitions; }

--- a/Kernel/Time/HardwareTimer.h
+++ b/Kernel/Time/HardwareTimer.h
@@ -47,7 +47,7 @@ class HardwareTimer;
 class HardwareTimerBase
     : public RefCounted<HardwareTimerBase> {
 public:
-    virtual ~HardwareTimerBase() { }
+    virtual ~HardwareTimerBase() = default;
 
     // We need to create a virtual will_be_destroyed here because we derive
     // from RefCounted<HardwareTimerBase> here, which means that RefCounted<>

--- a/Kernel/VM/PhysicalPage.h
+++ b/Kernel/VM/PhysicalPage.h
@@ -68,7 +68,7 @@ public:
 
 private:
     PhysicalPage(PhysicalAddress paddr, bool supervisor, bool may_return_to_freelist = true);
-    ~PhysicalPage() { }
+    ~PhysicalPage() = default;
 
     void return_to_freelist() const;
 

--- a/Kernel/VM/PhysicalRegion.h
+++ b/Kernel/VM/PhysicalRegion.h
@@ -39,7 +39,7 @@ class PhysicalRegion : public RefCounted<PhysicalRegion> {
 
 public:
     static NonnullRefPtr<PhysicalRegion> create(PhysicalAddress lower, PhysicalAddress upper);
-    ~PhysicalRegion() { }
+    ~PhysicalRegion() = default;
 
     void expand(PhysicalAddress lower, PhysicalAddress upper);
     unsigned finalize_capacity();

--- a/Kernel/VM/VMObject.h
+++ b/Kernel/VM/VMObject.h
@@ -41,7 +41,7 @@ class PhysicalPage;
 
 class VMObjectDeletedHandler {
 public:
-    virtual ~VMObjectDeletedHandler() { }
+    virtual ~VMObjectDeletedHandler() = default;
     virtual void vmobject_deleted(VMObject&) = 0;
 };
 

--- a/Kernel/VirtualAddress.h
+++ b/Kernel/VirtualAddress.h
@@ -31,7 +31,7 @@
 
 class VirtualAddress {
 public:
-    VirtualAddress() { }
+    VirtualAddress() = default;
     explicit VirtualAddress(FlatPtr address)
         : m_address(address)
     {


### PR DESCRIPTION
This may seem like a no-op change, however it shrinks down the Kernel by a bit:

.text -432
.unmap_after_init -60
.data -480
.debug_info -673
.debug_aranges +8
.debug_ranges -232
.debug_line -558
.debug_str -308
.debug_frame -40

… so overall it shrinks down stuff, and makes the code a bit nicer to read. Yay!

With '= default', the compiler can do more inlining, hence the savings.
I intentionally omitted some opportunities for '= default', because they
would increase the Kernel size.