### PR TITLE
Meta: Allow specifying custom grub config file for build-image-grub.sh

### DIFF
--- a/Meta/build-image-grub.sh
+++ b/Meta/build-image-grub.sh
@@ -97,12 +97,18 @@ echo "done"
 script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 "$script_path/build-root-filesystem.sh"
 
-echo "installing grub using $grub..."
+if [ -z "$2" ]; then
+    grub_cfg="$SERENITY_ROOT"/Meta/grub-"${partition_scheme}".cfg
+else
+    grub_cfg=$2
+fi
+
+echo "installing grub using $grub with $grub_cfg..."
 $grub --boot-directory=mnt/boot --target=i386-pc --modules="ext2 part_msdos" "${dev}"
 
 if [ -d mnt/boot/grub2 ]; then
-    cp "$SERENITY_ROOT"/Meta/grub-"${partition_scheme}".cfg mnt/boot/grub2/grub.cfg
+    cp "$grub_cfg" mnt/boot/grub2/grub.cfg
 else
-    cp "$SERENITY_ROOT"/Meta/grub-"${partition_scheme}".cfg mnt/boot/grub/grub.cfg
+    cp "$grub_cfg" mnt/boot/grub/grub.cfg
 fi
 echo "done"


### PR DESCRIPTION
This allows passing a custom grub config file as second argument to
build-image-grub.sh.

_Since grub is only displayed for 1 second I find myself missing that time frame often, and booting without serial debug. This way I can simply specify my own custom grub config._