### PR TITLE
Kernel: Fix APIC timer calibration to be more accurate

### DIFF
--- a/Kernel/Random.cpp
+++ b/Kernel/Random.cpp
@@ -71,7 +71,7 @@ UNMAP_AFTER_INIT KernelRng::KernelRng()
         klog() << "KernelRng: Using HPET as entropy source";
 
         for (size_t i = 0; i < resource().pool_count * resource().reseed_threshold; ++i) {
-            u64 hpet_time = HPET::the().read_main_counter();
+            u64 hpet_time = HPET::the().read_main_counter_unsafe();
             this->resource().add_random_event(hpet_time, i % 32);
         }
     } else {

--- a/Kernel/Time/HPET.h
+++ b/Kernel/Time/HPET.h
@@ -46,6 +46,8 @@ public:
     static HPET& the();
 
     u64 frequency() const { return m_frequency; }
+    u64 raw_counter_ticks_to_ns(u64) const;
+    u64 ns_to_raw_counter_ticks(u64) const;
 
     const NonnullRefPtrVector<HPETComparator>& comparators() const { return m_comparators; }
     void disable(const HPETComparator&);
@@ -60,6 +62,7 @@ public:
     void disable_periodic_interrupt(const HPETComparator& comparator);
 
     u64 update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only);
+    u64 read_main_counter_unsafe() const;
     u64 read_main_counter() const;
 
     Vector<unsigned> capable_interrupt_numbers(u8 comparator_number);
@@ -75,7 +78,7 @@ private:
     bool is_periodic_capable(u8 comparator_number);
     void set_comparators_to_optimal_interrupt_state(size_t timers_count);
 
-    u64 calculate_ticks_in_nanoseconds() const;
+    u64 nanoseconds_to_raw_ticks() const;
 
     PhysicalAddress find_acpi_hpet_registers_block();
     explicit HPET(PhysicalAddress acpi_hpet);

--- a/Kernel/Time/HPETComparator.cpp
+++ b/Kernel/Time/HPETComparator.cpp
@@ -138,4 +138,14 @@ size_t HPETComparator::calculate_nearest_possible_frequency(size_t frequency) co
     return frequency;
 }
 
+u64 HPETComparator::current_raw() const
+{
+    return HPET::the().read_main_counter();
+}
+
+u64 HPETComparator::raw_to_ns(u64 raw_delta) const
+{
+    return HPET::the().raw_counter_ticks_to_ns(raw_delta);
+}
+
 }

--- a/Kernel/Time/HPETComparator.h
+++ b/Kernel/Time/HPETComparator.h
@@ -51,6 +51,9 @@ public:
     virtual void set_periodic() override;
     virtual void set_non_periodic() override;
     virtual void disable() override;
+    virtual bool can_query_raw() const override { return true; }
+    virtual u64 current_raw() const override;
+    virtual u64 raw_to_ns(u64) const override;
 
     virtual void reset_to_default_ticks_per_second() override;
     virtual bool try_to_set_frequency(size_t frequency) override;

--- a/Kernel/Time/HardwareTimer.h
+++ b/Kernel/Time/HardwareTimer.h
@@ -65,6 +65,9 @@ public:
     virtual void set_non_periodic() = 0;
     virtual void disable() = 0;
     virtual u32 frequency() const = 0;
+    virtual bool can_query_raw() const { return false; }
+    virtual u64 current_raw() const { return 0; }
+    virtual u64 raw_to_ns(u64) const { return 0; }
 
     virtual size_t ticks_per_second() const = 0;
 


### PR DESCRIPTION
We were calibrating it to 260 instead of 250 ticks per second (being
off by one for the 1/10th second calibration time), resulting in
ticks of only ~3.6 ms instead of ~4ms. This gets us closer to ~4ms,
but because the APIC isn't nearly as precise as e.g. HPET, it will
only be a best effort. Then, use the higher precision reference
timer to more accurately calculate how many ticks we actually get
each second.

Also the frequency calculation was off, causing a "Frequency too slow"
error with VMware.

Fixes some problems observed in #5539

_@Lubrsi Looks like this also fixes the "Frequency too slow" problem on VMware_