### PR TITLE
Profiler: Print addresses as pointers in new Samples view

### DIFF
--- a/Userland/DevTools/Profiler/IndividualSampleModel.cpp
+++ b/Userland/DevTools/Profiler/IndividualSampleModel.cpp
@@ -71,7 +71,7 @@ GUI::Variant IndividualSampleModel::data(const GUI::ModelIndex& index, GUI::Mode
 
     if (role == GUI::ModelRole::Display) {
         if (index.column() == Column::Address)
-            return String::formatted("{:08x}", frame.address);
+            return String::formatted("{:p}", frame.address);
 
         if (index.column() == Column::Symbol) {
             return frame.symbol;


### PR DESCRIPTION
The previous formatting was missing the "0x" prefix.