### PR TITLE
Kernel: Fix scrolling up in VMware

### DIFF
--- a/Kernel/Devices/VMWareBackdoor.cpp
+++ b/Kernel/Devices/VMWareBackdoor.cpp
@@ -231,7 +231,7 @@ Optional<MousePacket> VMWareBackdoor::receive_mouse_packet()
     int buttons = (command.ax & 0xFFFF);
     int x = (command.bx);
     int y = (command.cx);
-    int z = (command.dx);
+    int z = (i8)(command.dx); // signed 8 bit value only!
 
     if constexpr (PS2MOUSE_DEBUG) {
         dbgln("Absolute Mouse: Buttons {:x}", buttons);


### PR DESCRIPTION
The mouse wheel delta is provided as a signed 8 bit value.

_This was reported in #2927, and apparently fixed in #3289 but it somehow regressed (I'm guessing the I8042 changes)...
 **EDIT**: never mind, that was about VBox_