### PR TITLE
Meta/Userland: More test cleanup

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -177,15 +177,7 @@ jobs:
     - name: Run CMake tests
       working-directory: ${{ github.workspace }}/Meta/Lagom/Build
       run: CTEST_OUTPUT_ON_FAILURE=1 ninja test || ${{ matrix.allow-test-failure }}
-      timeout-minutes: 2
-      if: ${{ matrix.with-fuzzers == 'NO_FUZZ' }}
-    - name: Run JS tests
-      working-directory: ${{ github.workspace }}/Meta/Lagom/Build
-      if: ${{ matrix.with-fuzzers == 'NO_FUZZ' }}
-      run: DISABLE_DBG_OUTPUT=1 ./test-js || ${{ matrix.allow-test-failure }}
-    - name: Run LibCompress tests
-      working-directory: ${{ github.workspace }}/Meta/Lagom/Build
-      run: ./test-compress
+      timeout-minutes: 4
       if: ${{ matrix.with-fuzzers == 'NO_FUZZ' }}
 
   notify_irc:

--- a/Base/home/anon/tests/run-tests-and-shutdown.sh
+++ b/Base/home/anon/tests/run-tests-and-shutdown.sh
@@ -15,7 +15,7 @@ run() {
 # TODO: It'd be nice to have a list+list op (as opposed to nest-on-in-another)
 # TODO: It'd be nice to have a list.length or enumerate(list) operation to allow terminal progress bar
 # TODO: test-web requires the window server
-system_tests=(test-js test-pthread test-compress /usr/Tests/LibM/test-math (test-crypto bigint -t))
+system_tests=((test-js --show-progress=false) test-pthread test-compress /usr/Tests/LibM/test-math (test-crypto bigint -t))
 # FIXME: Running too much at once is likely to run into #5541. Remove commented out find below when stable
 all_tests=($system_tests) #$(find /usr/Tests -type f | grep -v Kernel | grep -v .inc | shuf))
 

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -121,6 +121,11 @@ if (BUILD_LAGOM)
         target_link_libraries(test-js_lagom Lagom)
         target_link_libraries(test-js_lagom stdc++)
         target_link_libraries(test-js_lagom pthread)
+        add_test(
+            NAME JS
+            COMMAND test-js_lagom --show-progress=false
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
 
         add_executable(test-crypto_lagom ../../Userland/Utilities/test-crypto.cpp)
         set_target_properties(test-crypto_lagom PROPERTIES OUTPUT_NAME test-crypto)
@@ -136,6 +141,11 @@ if (BUILD_LAGOM)
         set_target_properties(test-compress_lagom PROPERTIES OUTPUT_NAME test-compress)
         target_link_libraries(test-compress_lagom Lagom)
         target_link_libraries(test-compress_lagom stdc++)
+        add_test(
+            NAME Compress
+            COMMAND test-compress_lagom
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
 
         add_executable(disasm_lagom ../../Userland/Utilities/disasm.cpp)
         set_target_properties(disasm_lagom PROPERTIES OUTPUT_NAME disasm)


### PR DESCRIPTION
In test-js, gate the OSC-9 progress messages behind an argument instead of always printing them in serenity. This avoids some weird character spam in the github action logs.

Make sure that executables named test-foo in Meta/Lagom/CMakeLists.txt are added as ctests. This lets us remove the special cases for test-js and test-compress in the actions workflow.

cc @bgianfo  : This might conflict with WIP work you have, feel free to incorporate :)
cc @linusg  and @BenWiederhake 

Also conflicts with #5205 by @marcobiscaro2112 but I think that PR needs some build-script rebase/rework already :/