### PR TITLE
TextEditor: Add a command line option to jump to a specific line number

### DIFF
--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -45,9 +45,11 @@ int main(int argc, char** argv)
     }
 
     const char* preview_mode = "auto";
+    int initial_line_number = 0;
     const char* file_to_edit = nullptr;
     Core::ArgsParser parser;
     parser.add_option(preview_mode, "Preview mode, one of 'none', 'html', 'markdown', 'auto'", "preview-mode", '\0', "mode");
+    parser.add_option(initial_line_number, "Start at line number", "line-number", 'l', "line");
     parser.add_positional_argument(file_to_edit, "File to edit", "file", Core::ArgsParser::Required::No);
 
     parser.parse(argc, argv);
@@ -90,6 +92,9 @@ int main(int argc, char** argv)
         text_widget.open_file(file_to_edit);
     else
         text_widget.update_title();
+
+    if (initial_line_number != 0)
+        text_widget.editor().set_cursor_and_focus_line(initial_line_number - 1, 0);
 
     window->show();
     window->set_icon(app_icon.bitmap_for_size(16));


### PR DESCRIPTION
This adds a command line option (-l or --line-number) to specify a line number to start at when opening a file in TextEditor.