### PR TITLE
LibJS: Fix crash due to AST node tracking inside call stack

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -225,7 +225,7 @@ Value CallExpression::execute(Interpreter& interpreter, GlobalObject& global_obj
         }
     }
 
-    vm.call_frame().current_node = vm.node_stack().last();
+    vm.call_frame().current_node = vm.current_node();
     Object* new_object = nullptr;
     Value result;
     if (is<NewExpression>(*this)) {

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -900,7 +900,7 @@ Value Object::call_native_property_getter(NativeProperty& property, Value this_v
 {
     auto& vm = this->vm();
     CallFrame call_frame;
-    call_frame.current_node = property.vm().node_stack().last();
+    call_frame.current_node = property.vm().current_node();
     call_frame.is_strict_mode = vm.in_strict_mode();
     call_frame.this_value = this_value;
     vm.push_call_frame(call_frame, global_object());
@@ -915,7 +915,7 @@ void Object::call_native_property_setter(NativeProperty& property, Value this_va
 {
     auto& vm = this->vm();
     CallFrame call_frame;
-    call_frame.current_node = property.vm().node_stack().last();
+    call_frame.current_node = property.vm().current_node();
     call_frame.is_strict_mode = vm.in_strict_mode();
     call_frame.this_value = this_value;
     vm.push_call_frame(call_frame, global_object());

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -211,7 +211,7 @@ Reference VM::get_reference(const FlyString& name)
 Value VM::construct(Function& function, Function& new_target, Optional<MarkedValueList> arguments, GlobalObject& global_object)
 {
     CallFrame call_frame;
-    call_frame.current_node = function.vm().node_stack().last();
+    call_frame.current_node = current_node();
     call_frame.is_strict_mode = function.is_strict_mode();
 
     push_call_frame(call_frame, function.global_object());
@@ -335,7 +335,7 @@ Value VM::call_internal(Function& function, Value this_value, Optional<MarkedVal
     VERIFY(!exception());
 
     CallFrame call_frame;
-    call_frame.current_node = function.vm().node_stack().last();
+    call_frame.current_node = current_node();
     call_frame.is_strict_mode = function.is_strict_mode();
     call_frame.function_name = function.name();
     call_frame.this_value = function.bound_this().value_or(this_value);

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -134,6 +134,7 @@ public:
     const CallFrame& call_frame() const { return *m_call_stack.last(); }
     const Vector<CallFrame*>& call_stack() const { return m_call_stack; }
     Vector<CallFrame*>& call_stack() { return m_call_stack; }
+    const ASTNode* current_node() const { return !m_ast_nodes.is_empty() ? m_ast_nodes.last() : nullptr; }
     const Vector<const ASTNode*>& node_stack() const { return m_ast_nodes; }
 
     const ScopeObject* current_scope() const { return call_frame().scope; }


### PR DESCRIPTION
I am not sure what's going on, but it seems #5547 made the WebContent processes crash-prone because the AST node stack might be empty when we try to access it while tracking execution progress in the call stack. This prevents the assert from triggering, but I am not confident that this is the correct fix...