### PR TITLE
LanguageServers/Cpp: Fix nullptr dereference in ~LanguageClient

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageClient.h
+++ b/Userland/DevTools/HackStudio/LanguageClient.h
@@ -112,7 +112,10 @@ public:
 
     virtual ~LanguageClient()
     {
-        m_server_connection->detach();
+        // m_server_connection is nullified if the server crashes
+        if (m_server_connection)
+            m_server_connection->detach();
+
         VERIFY(m_previous_client.ptr() != this);
         if (m_previous_client)
             m_server_connection->attach(*m_previous_client);


### PR DESCRIPTION
Closes #5570.

The reason this bug manifested when switching files after the c++ language-server crashed is that we tried to destruct the current `LanguageClient` of the Editor when switching to a new file.