### PR TITLE
Line number integration through URL query

### DIFF
--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -176,7 +176,7 @@ bool Launcher::open_url(const URL& url, const String& handler_name)
     if (url.protocol() == "file")
         return open_file_url(url);
 
-    return open_with_user_preferences(m_protocol_handlers, url.protocol(), url.to_string());
+    return open_with_user_preferences(m_protocol_handlers, url.protocol(), { url.to_string() });
 }
 
 bool Launcher::open_with_handler_name(const URL& url, const String& handler_name)
@@ -225,20 +225,20 @@ Handler Launcher::get_handler_for_executable(Handler::Type handler_type, const S
     return handler;
 }
 
-bool Launcher::open_with_user_preferences(const HashMap<String, String>& user_preferences, const String key, const String argument, const String default_program)
+bool Launcher::open_with_user_preferences(const HashMap<String, String>& user_preferences, const String key, const AK::Vector<String> arguments, const String default_program)
 {
     auto program_path = user_preferences.get(key);
     if (program_path.has_value())
-        return spawn(program_path.value(), { argument });
+        return spawn(program_path.value(), arguments);
 
     // There wasn't a handler for this, so try the fallback instead
     program_path = user_preferences.get("*");
     if (program_path.has_value())
-        return spawn(program_path.value(), { argument });
+        return spawn(program_path.value(), arguments);
 
     // Absolute worst case, try the provided default program, if any
     if (!default_program.is_empty())
-        return spawn(default_program, { argument });
+        return spawn(default_program, arguments);
 
     return false;
 }
@@ -312,6 +312,19 @@ bool Launcher::open_file_url(const URL& url)
     String extension = {};
     if (extension_parts.size() > 1)
         extension = extension_parts.last();
-    return open_with_user_preferences(m_file_handlers, extension, url.path(), "/bin/TextEditor");
+
+    // Additionnal parameters parsing, specific for the file protocol
+    Vector<String> additional_parameters;
+    additional_parameters.append(url.path());
+    auto parameters = url.query().split('&');
+    for (auto parameter = parameters.begin(); parameter != parameters.end(); ++parameter) {
+        auto pair = parameter->split('=');
+        if (pair[0] == "line_number") {
+            auto line = pair[1].to_int();
+            if (line.has_value())
+                additional_parameters.prepend(String::format("-l%i", *line));
+        }
+    }
+    return open_with_user_preferences(m_file_handlers, extension, additional_parameters, "/bin/TextEditor");
 }
 }

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -225,7 +225,7 @@ Handler Launcher::get_handler_for_executable(Handler::Type handler_type, const S
     return handler;
 }
 
-bool Launcher::open_with_user_preferences(const HashMap<String, String>& user_preferences, const String key, const AK::Vector<String> arguments, const String default_program)
+bool Launcher::open_with_user_preferences(const HashMap<String, String>& user_preferences, const String& key, const Vector<String>& arguments, const String& default_program)
 {
     auto program_path = user_preferences.get(key);
     if (program_path.has_value())
@@ -313,16 +313,16 @@ bool Launcher::open_file_url(const URL& url)
     if (extension_parts.size() > 1)
         extension = extension_parts.last();
 
-    // Additionnal parameters parsing, specific for the file protocol
+    // Additional parameters parsing, specific for the file protocol and TextEditor
     Vector<String> additional_parameters;
     additional_parameters.append(url.path());
     auto parameters = url.query().split('&');
     for (auto parameter = parameters.begin(); parameter != parameters.end(); ++parameter) {
         auto pair = parameter->split('=');
-        if (pair[0] == "line_number") {
+        if (pair.size() == 2 && pair[0] == "line_number") {
             auto line = pair[1].to_int();
             if (line.has_value())
-                additional_parameters.prepend(String::format("-l%i", *line));
+                additional_parameters.prepend(String::formatted("-l {}", line.value()));
         }
     }
     return open_with_user_preferences(m_file_handlers, extension, additional_parameters, "/bin/TextEditor");

--- a/Userland/Services/LaunchServer/Launcher.h
+++ b/Userland/Services/LaunchServer/Launcher.h
@@ -72,7 +72,7 @@ private:
     void for_each_handler(const String& key, HashMap<String, String>& user_preferences, Function<bool(const Handler&)> f);
     void for_each_handler_for_path(const String&, Function<bool(const Handler&)> f);
     bool open_file_url(const URL&);
-    bool open_with_user_preferences(const HashMap<String, String>& user_preferences, const String key, const String argument, const String default_program = {});
+    bool open_with_user_preferences(const HashMap<String, String>& user_preferences, const String key, const AK::Vector<String> arguments, const String default_program = {});
     bool open_with_handler_name(const URL&, const String& handler_name);
 };
 }

--- a/Userland/Services/LaunchServer/Launcher.h
+++ b/Userland/Services/LaunchServer/Launcher.h
@@ -72,7 +72,7 @@ private:
     void for_each_handler(const String& key, HashMap<String, String>& user_preferences, Function<bool(const Handler&)> f);
     void for_each_handler_for_path(const String&, Function<bool(const Handler&)> f);
     bool open_file_url(const URL&);
-    bool open_with_user_preferences(const HashMap<String, String>& user_preferences, const String key, const AK::Vector<String> arguments, const String default_program = {});
+    bool open_with_user_preferences(const HashMap<String, String>& user_preferences, const String& key, const Vector<String>& arguments, const String& default_program = {});
     bool open_with_handler_name(const URL&, const String& handler_name);
 };
 }

--- a/Userland/Utilities/bt.cpp
+++ b/Userland/Utilities/bt.cpp
@@ -91,10 +91,10 @@ int main(int argc, char** argv)
             auto full_path = LexicalPath::canonicalized_path(String::formatted("/usr/src/serenity/dummy/{}", symbol.filename));
             if (access(full_path.characters(), F_OK) == 0) {
                 linked = true;
-                out("\033]8;;file://{}{}\033\\", hostname, full_path);
+                out("\033]8;;file://{}{}?line_number={}\033\\", hostname, full_path, symbol.line_number);
             }
 
-            out("\033[34;1m{}\033[0m:{}", LexicalPath(symbol.filename).basename(), symbol.line_number);
+            out("\033[34;1m{}:{}\033[0m", LexicalPath(symbol.filename).basename(), symbol.line_number);
 
             if (linked)
                 out("\033]8;;\033\\");


### PR DESCRIPTION
Hi there ! 
This small PR aims to allow files to be open from the terminal at a specific line number. I tried to do it by making use of the URL query functionnality, since it is not usable in a traditionnal file path anyway. That's probably a bad idea, but I wanted to give it a try. 

I also implemented the integration for the small `bt` utility, since it's what motivated me to do it in the first place. 

(_I'd like to take this opportunity to thank you guys, and @awesomekling for your brillant work on this operating system. I'm a long time follower and enjoyer of the youtube coding sessions, and always wanted to add my little brick of my own, within the boundaries of my capacities...)_ 