### PR TITLE
FileManager+Everywhere: Improvements for starting FileManager with pre-selected files

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -444,11 +444,12 @@ u16 URL::default_port_for_protocol(const String& protocol)
     return 0;
 }
 
-URL URL::create_with_file_protocol(const String& path)
+URL URL::create_with_file_protocol(const String& path, const String& fragment)
 {
     URL url;
     url.set_protocol("file");
     url.set_path(path);
+    url.set_fragment(fragment);
     return url;
 }
 

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -77,7 +77,7 @@ public:
     const String& data_payload() const { return m_data_payload; }
 
     static URL create_with_url_or_path(const String& url_or_path);
-    static URL create_with_file_protocol(const String& path);
+    static URL create_with_file_protocol(const String& path, const String& fragment = {});
     static URL create_with_data(const StringView& mime_type, const StringView& payload, bool is_base64 = false);
     static bool protocol_requires_port(const String& protocol);
     static u16 default_port_for_protocol(const String& protocol);

--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -166,7 +166,7 @@ void DownloadWidget::did_finish(bool success)
     m_close_button->set_enabled(true);
     m_cancel_button->set_text("Open in Folder");
     m_cancel_button->on_click = [this](auto) {
-        Desktop::Launcher::open(URL::create_with_file_protocol(Core::StandardPaths::downloads_directory()));
+        Desktop::Launcher::open(URL::create_with_file_protocol(Core::StandardPaths::downloads_directory(), m_url.basename()));
         window()->close();
     };
     m_cancel_button->update();

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -206,13 +206,15 @@ int main(int argc, char** argv)
     auto& executable_link_label = *widget.find_descendant_of_type_named<GUI::LinkLabel>("executable_link");
     executable_link_label.set_text(LexicalPath::canonicalized_path(executable_path));
     executable_link_label.on_click = [&] {
-        Desktop::Launcher::open(URL::create_with_file_protocol(LexicalPath(executable_path).dirname()));
+        LexicalPath path { executable_path };
+        Desktop::Launcher::open(URL::create_with_file_protocol(path.dirname(), path.basename()));
     };
 
     auto& coredump_link_label = *widget.find_descendant_of_type_named<GUI::LinkLabel>("coredump_link");
     coredump_link_label.set_text(LexicalPath::canonicalized_path(coredump_path));
     coredump_link_label.on_click = [&] {
-        Desktop::Launcher::open(URL::create_with_file_protocol(LexicalPath(coredump_path).dirname()));
+        LexicalPath path { coredump_path };
+        Desktop::Launcher::open(URL::create_with_file_protocol(path.dirname(), path.basename()));
     };
 
     auto& arguments_label = *widget.find_descendant_of_type_named<GUI::Label>("arguments_label");

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -113,8 +113,7 @@ PropertiesWindow::PropertiesWindow(const String& path, bool disable_rename, Wind
 
     auto properties = Vector<PropertyValuePair>();
     properties.append({ "Type:", get_description(m_mode) });
-    auto parent_link = URL::create_with_file_protocol(m_parent_path);
-    parent_link.set_fragment(m_name);
+    auto parent_link = URL::create_with_file_protocol(m_parent_path, m_name);
     properties.append(PropertyValuePair { "Location:", path, Optional(parent_link) });
 
     if (S_ISLNK(m_mode)) {
@@ -124,7 +123,7 @@ PropertiesWindow::PropertiesWindow(const String& path, bool disable_rename, Wind
         } else {
             auto link_directory = LexicalPath(link_destination);
             VERIFY(link_directory.is_valid());
-            auto link_parent = URL::create_with_file_protocol(link_directory.dirname());
+            auto link_parent = URL::create_with_file_protocol(link_directory.dirname(), link_directory.basename());
             properties.append({ "Link target:", link_destination, Optional(link_parent) });
         }
     }

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -32,6 +32,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
 #include <Applications/FileManager/FileManagerWindowGML.h>
+#include <LibCore/ArgsParser.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
 #include <LibCore/MimeData.h>
@@ -98,6 +99,15 @@ int main(int argc, char** argv)
 
     RefPtr<Core::ConfigFile> config = Core::ConfigFile::get_for_app("FileManager");
 
+    Core::ArgsParser args_parser;
+    bool is_desktop_mode { false }, is_selection_mode { false }, ignore_path_resolution { false };
+    String initial_location;
+    args_parser.add_option(is_desktop_mode, "Run in desktop mode", "desktop", 'd');
+    args_parser.add_option(is_selection_mode, "Show entry in parent folder", "select", 's');
+    args_parser.add_option(ignore_path_resolution, "Use raw path, do not resolve real path", "raw", 'r');
+    args_parser.add_positional_argument(initial_location, "Path to open", "path", Core::ArgsParser::Required::No);
+    args_parser.parse(argc, argv);
+
     auto app = GUI::Application::construct(argc, argv);
 
     if (pledge("stdio thread recvfd sendfd accept cpath rpath wpath fattr proc exec unix", nullptr) < 0) {
@@ -105,17 +115,20 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (app->args().contains_slow("--desktop") || app->args().contains_slow("-d"))
+    if (is_desktop_mode)
         return run_in_desktop_mode(move(config));
 
     // our initial location is defined as, in order of precedence:
-    // 1. the first command-line argument (e.g. FileManager /bin)
+    // 1. the command-line path argument (e.g. FileManager /bin)
     // 2. the user's home directory
     // 3. the root directory
-    String initial_location;
 
-    if (argc >= 2) {
-        initial_location = Core::File::real_path_for(argv[1]);
+    if (!initial_location.is_empty()) {
+        if (!ignore_path_resolution)
+            initial_location = Core::File::real_path_for(initial_location);
+
+        if (!Core::File::is_directory(initial_location))
+            is_selection_mode = true;
     }
 
     if (initial_location.is_empty())
@@ -124,10 +137,12 @@ int main(int argc, char** argv)
     if (initial_location.is_empty())
         initial_location = "/";
 
-    // the second command-line argument is the name of the entry we wan't the focus to be on
     String focused_entry;
-    if (argc >= 3)
-        focused_entry = argv[2];
+    if (is_selection_mode) {
+        LexicalPath path(initial_location);
+        initial_location = path.dirname();
+        focused_entry = path.basename();
+    }
 
     return run_in_windowed_mode(move(config), initial_location, focused_entry);
 }

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "TreeMapWidget.h"
+#include <AK/LexicalPath.h>
 #include <AK/Queue.h>
 #include <AK/QuickSort.h>
 #include <AK/RefCounted.h>
@@ -305,7 +306,8 @@ int main(int argc, char* argv[])
         Desktop::Launcher::open(URL::create_with_file_protocol(get_absolute_path_to_selected_node(treemapwidget)));
     });
     auto open_containing_folder_action = GUI::Action::create("Open Containing Folder", { Mod_Ctrl, Key_O }, Gfx::Bitmap::load_from_file("/res/icons/16x16/open.png"), [&](auto&) {
-        Desktop::Launcher::open(URL::create_with_file_protocol(get_absolute_path_to_selected_node(treemapwidget, false)));
+        LexicalPath path { get_absolute_path_to_selected_node(treemapwidget) };
+        Desktop::Launcher::open(URL::create_with_file_protocol(path.dirname(), path.basename()));
     });
     auto copy_path_action = GUI::Action::create("Copy Path to Clipboard", { Mod_Ctrl, Key_C }, Gfx::Bitmap::load_from_file("/res/icons/16x16/edit-copy.png"), [&](auto&) {
         GUI::Clipboard::the().set_plain_text(get_absolute_path_to_selected_node(treemapwidget));

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -342,6 +342,21 @@ void ArgsParser::add_positional_argument(const char*& value, const char* help_st
     add_positional_argument(move(arg));
 }
 
+void ArgsParser::add_positional_argument(String& value, const char* help_string, const char* name, Required required)
+{
+    Arg arg {
+        help_string,
+        name,
+        required == Required::Yes ? 1 : 0,
+        1,
+        [&value](const char* s) {
+            value = s;
+            return true;
+        }
+    };
+    add_positional_argument(move(arg));
+}
+
 void ArgsParser::add_positional_argument(int& value, const char* help_string, const char* name, Required required)
 {
     Arg arg {

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -79,6 +79,7 @@ public:
 
     void add_positional_argument(Arg&&);
     void add_positional_argument(const char*& value, const char* help_string, const char* name, Required required = Required::Yes);
+    void add_positional_argument(String& value, const char* help_string, const char* name, Required required = Required::Yes);
     void add_positional_argument(int& value, const char* help_string, const char* name, Required required = Required::Yes);
     void add_positional_argument(double& value, const char* help_string, const char* name, Required required = Required::Yes);
     void add_positional_argument(Vector<const char*>& value, const char* help_string, const char* name, Required required = Required::Yes);

--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -72,6 +72,12 @@ void IconView::resize_event(ResizeEvent& event)
 {
     AbstractView::resize_event(event);
     update_content_size();
+
+    if (!m_had_valid_size) {
+        m_had_valid_size = true;
+        if (!selection().is_empty())
+            scroll_into_view(selection().first());
+    }
 }
 
 void IconView::reinit_item_cache() const

--- a/Userland/Libraries/LibGUI/IconView.h
+++ b/Userland/Libraries/LibGUI/IconView.h
@@ -182,6 +182,8 @@ private:
     mutable bool m_item_data_cache_valid { false };
 
     bool m_changing_selection { false };
+
+    bool m_had_valid_size { false };
 };
 
 }

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -299,9 +299,14 @@ bool Launcher::open_file_url(const URL& url)
 
     // TODO: Make directory opening configurable
     if (S_ISDIR(st.st_mode)) {
-        Vector<String> fm_arguments { url.path() };
-        if (!url.fragment().is_empty())
-            fm_arguments.append(url.fragment());
+        Vector<String> fm_arguments;
+        if (url.fragment().is_empty()) {
+            fm_arguments.append(url.path());
+        } else {
+            fm_arguments.append(String::formatted("{}/{}", url.path(), url.fragment()));
+            fm_arguments.append("-s");
+            fm_arguments.append("-r");
+        }
         return spawn("/bin/FileManager", fm_arguments);
     }
 


### PR DESCRIPTION
This PR adds opening the folder in FileManager with a pre-selected file into more places (closes #5586), and a bit of related refactoring and fixing.

I've added that to all the places that I could've to think of, but the list probably is still incomplete.
So if you know more places where it makes sense, feel free to mention them :^)

Also, the LibGUI commit feels very hackish to me, but I'm struggling to come up with a better solution.
Maybe anyone has some ideas of a better fix?