### PR TITLE
Piano: Reset position in piano roll when exporting

### DIFF
--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -134,6 +134,9 @@ void Track::reset()
     memset(m_note_on, 0, sizeof(m_note_on));
     memset(m_power, 0, sizeof(m_power));
     memset(m_envelope, 0, sizeof(m_envelope));
+
+    for (size_t note = 0; note < note_count; ++note)
+        m_roll_iters[note] = m_roll_notes[note].begin();
 }
 
 String Track::set_recorded_sample(const StringView& path)


### PR DESCRIPTION
When you reset() a Track, you need to set the piano roll iterators back
to the first notes.

Fixes #2578. The bug was due to pressing export between 2 notes - the
tracks were never told to go back to the first note.