### PR TITLE
LibWeb: Stop scrolling above content in BlockBox

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockBox.cpp
@@ -150,7 +150,8 @@ bool BlockBox::is_scrollable() const
 
 void BlockBox::set_scroll_offset(const Gfx::FloatPoint& offset)
 {
-    if (m_scroll_offset == offset)
+    // FIXME: If there is horizontal and vertical scroll ignore only part of the new offset
+    if (offset.y() < 0 || m_scroll_offset == offset)
         return;
     m_scroll_offset = offset;
     set_needs_display();


### PR DESCRIPTION
While trying to implement `overflow-{x, y}` I found out you can just scroll above the content with `overflow: scroll`.
An example:
![serenity_scroll](https://user-images.githubusercontent.com/3750649/109681029-5a3ce200-7b7d-11eb-890b-abcbd16bc3b6.png)
