### PR TITLE
CPU: Make InstructionFetch PageFault flags match up

### DIFF
--- a/Kernel/Arch/i386/CPU.h
+++ b/Kernel/Arch/i386/CPU.h
@@ -433,7 +433,7 @@ public:
     bool is_write() const { return (m_code & 2) == PageFaultFlags::Write; }
     bool is_user() const { return (m_code & 4) == PageFaultFlags::UserMode; }
     bool is_supervisor() const { return (m_code & 4) == PageFaultFlags::SupervisorMode; }
-    bool is_instruction_fetch() const { return (m_code & 8) == PageFaultFlags::InstructionFetch; }
+    bool is_instruction_fetch() const { return (m_code & 16) == PageFaultFlags::InstructionFetch; }
 
 private:
     u16 m_code;


### PR DESCRIPTION
Previously, the instruction fetch flag of the page fault handler did not have the correct binary representation, and would always return false. This aligns these flags.