### PR TITLE
Kernel: Don't trust user-supplied bool in sys$stat

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -432,7 +432,7 @@ struct SC_waitid_params {
 struct SC_stat_params {
     StringArgument path;
     struct stat* statbuf;
-    bool follow_symlinks;
+    int follow_symlinks;
 };
 
 struct SC_ptrace_params {


### PR DESCRIPTION
Found by fuzz-syscalls. Can be reproduced by running this in the Shell:

    $ syscall stat [ Desktop 7 buf 2 ]

Fixes #5316.

Since we don't have any other syscalls that take `bool`s anywhere, no other changes are needed. Also, introducing a new syscall with a `bool` is unlikely, so I'm not gonna write a linter just yet.