### PR TITLE
WindowServer: Mark screen dirty when changing highlighted window

### DIFF
--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -576,6 +576,14 @@ void Window::prepare_dirty_rects()
             m_dirty_rects = rect();
     } else {
         m_dirty_rects.move_by(frame().render_rect().location());
+        if (m_invalidated_frame) {
+            if (m_invalidated) {
+                m_dirty_rects.add(frame().render_rect());
+            } else {
+                for (auto& rects : frame().render_rect().shatter(rect()))
+                    m_dirty_rects.add(rects);
+            }
+        }
     }
 }
 

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -217,6 +217,8 @@ Gfx::Bitmap* WindowFrame::window_shadow() const
     case WindowType::Taskbar:
         return s_task_bar_shadow;
     default:
+        if (auto* highlight_window = WindowManager::the().highlight_window())
+            return highlight_window == &m_window ? s_active_window_shadow : s_inactive_window_shadow;
         return m_window.is_active() ? s_active_window_shadow : s_inactive_window_shadow;
     }
 }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1252,10 +1252,16 @@ void WindowManager::set_highlight_window(Window* window)
         return;
     auto* previous_highlight_window = m_highlight_window.ptr();
     m_highlight_window = window;
-    if (previous_highlight_window)
+    if (previous_highlight_window) {
         previous_highlight_window->invalidate(true, true);
-    if (m_highlight_window)
+        Compositor::the().invalidate_screen(previous_highlight_window->frame().render_rect());
+    }
+    if (m_highlight_window) {
         m_highlight_window->invalidate(true, true);
+        Compositor::the().invalidate_screen(m_highlight_window->frame().render_rect());
+    }
+    // Invalidate occlusions in case the state change changes geometry
+    Compositor::the().invalidate_occlusions();
 }
 
 bool WindowManager::is_active_window_or_accessory(Window& window) const


### PR DESCRIPTION
Because the z-order changes we not only need to recompute occlusions
but we also need to mark the screen area of the previous and new
highlighted window as dirty.

Fixes #5599