### PR TITLE
Kernel: Add 'boot_prof' option to enable full system profiling on boot 

### DIFF
--- a/Kernel/ACPI/Initialize.cpp
+++ b/Kernel/ACPI/Initialize.cpp
@@ -31,33 +31,17 @@
 namespace Kernel {
 namespace ACPI {
 
-enum class FeatureLevel {
-    Enabled,
-    Limited,
-    Disabled,
-};
-
-UNMAP_AFTER_INIT static FeatureLevel determine_feature_level()
-{
-    auto value = kernel_command_line().lookup("acpi").value_or("on");
-    if (value == "limited")
-        return FeatureLevel::Limited;
-    if (value == "off")
-        return FeatureLevel::Disabled;
-    return FeatureLevel::Enabled;
-}
-
 UNMAP_AFTER_INIT void initialize()
 {
-    auto feature_level = determine_feature_level();
-    if (feature_level == FeatureLevel::Disabled)
+    auto feature_level = kernel_command_line().acpi_feature_level();
+    if (feature_level == AcpiFeatureLevel::Disabled)
         return;
 
     auto rsdp = StaticParsing::find_rsdp();
     if (!rsdp.has_value())
         return;
 
-    if (feature_level == FeatureLevel::Enabled)
+    if (feature_level == AcpiFeatureLevel::Enabled)
         Parser::initialize<DynamicParser>(rsdp.value());
     else
         Parser::initialize<Parser>(rsdp.value());

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <Kernel/CommandLine.h>
+#include <Kernel/Panic.h>
 #include <Kernel/StdLib.h>
 
 namespace Kernel {
@@ -85,6 +86,94 @@ Optional<String> CommandLine::lookup(const String& key) const
 bool CommandLine::contains(const String& key) const
 {
     return m_params.contains(key);
+}
+
+UNMAP_AFTER_INIT bool CommandLine::is_ide_enabled() const
+{
+    return !contains("disable_ide");
+}
+
+UNMAP_AFTER_INIT bool CommandLine::is_smp_enabled() const
+{
+    return lookup("smp").value_or("off") == "on";
+}
+
+UNMAP_AFTER_INIT bool CommandLine::is_vmmouse_enabled() const
+{
+    return lookup("vmmouse").value_or("on") == "on";
+}
+
+UNMAP_AFTER_INIT bool CommandLine::is_mmio_enabled() const
+{
+    return lookup("pci_mmio").value_or("off") == "on";
+}
+
+UNMAP_AFTER_INIT bool CommandLine::is_legacy_time_enabled() const
+{
+    return lookup("time").value_or("modern") == "legacy";
+}
+
+UNMAP_AFTER_INIT bool CommandLine::is_force_pio() const
+{
+    return contains("force_pio");
+}
+
+UNMAP_AFTER_INIT String CommandLine::root_device() const
+{
+    return lookup("root").value_or("/dev/hda");
+}
+
+UNMAP_AFTER_INIT AcpiFeatureLevel CommandLine::acpi_feature_level() const
+{
+    auto value = kernel_command_line().lookup("acpi").value_or("on");
+    if (value == "limited")
+        return AcpiFeatureLevel::Limited;
+    if (value == "off")
+        return AcpiFeatureLevel::Disabled;
+    return AcpiFeatureLevel::Enabled;
+}
+
+UNMAP_AFTER_INIT HPETMode CommandLine::hpet_mode() const
+{
+    auto hpet_mode = lookup("hpet").value_or("periodic");
+    if (hpet_mode == "periodic")
+        return HPETMode::Periodic;
+    if (hpet_mode == "nonperiodic")
+        return HPETMode::NonPeriodic;
+    PANIC("Unknown HPETMode: {}", hpet_mode);
+}
+
+UNMAP_AFTER_INIT BootMode CommandLine::boot_mode() const
+{
+    const auto boot_mode = lookup("boot_mode").value_or("graphical");
+    if (boot_mode == "text") {
+        return BootMode::Text;
+    } else if (boot_mode == "self-test") {
+        return BootMode::SelfTest;
+    } else if (boot_mode == "graphical") {
+        return BootMode::Graphical;
+    }
+    PANIC("Unknown BootMode: {}", boot_mode);
+}
+
+UNMAP_AFTER_INIT bool CommandLine::is_text_mode() const
+{
+    const auto mode = boot_mode();
+    return mode == BootMode::Text || mode == BootMode::SelfTest;
+}
+
+String CommandLine::userspace_init() const
+{
+    return lookup("init").value_or("/bin/SystemServer");
+}
+
+Vector<String> CommandLine::userspace_init_args() const
+{
+    auto init_args = lookup("init_args").value_or("").split(',');
+    if (!init_args.is_empty())
+        init_args.prepend(userspace_init());
+
+    return init_args;
 }
 
 }

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -88,6 +88,11 @@ bool CommandLine::contains(const String& key) const
     return m_params.contains(key);
 }
 
+UNMAP_AFTER_INIT bool CommandLine::is_boot_profiling_enabled() const
+{
+    return contains("boot_prof");
+}
+
 UNMAP_AFTER_INIT bool CommandLine::is_ide_enabled() const
 {
     return !contains("disable_ide");

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -61,6 +61,7 @@ public:
     Optional<String> lookup(const String& key) const;
     [[nodiscard]] bool contains(const String& key) const;
 
+    [[nodiscard]] bool is_boot_profiling_enabled() const;
     [[nodiscard]] bool is_ide_enabled() const;
     [[nodiscard]] bool is_smp_enabled() const;
     [[nodiscard]] bool is_vmmouse_enabled() const;

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -29,8 +29,26 @@
 #include <AK/HashMap.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
+#include <AK/Vector.h>
 
 namespace Kernel {
+
+enum class BootMode {
+    Text,
+    SelfTest,
+    Graphical
+};
+
+enum class HPETMode {
+    Periodic,
+    NonPeriodic
+};
+
+enum class AcpiFeatureLevel {
+    Enabled,
+    Limited,
+    Disabled,
+};
 
 class CommandLine {
     AK_MAKE_ETERNAL;
@@ -39,9 +57,23 @@ public:
     static void early_initialize(const char* cmd_line);
     static void initialize();
 
-    const String& string() const { return m_string; }
+    [[nodiscard]] const String& string() const { return m_string; }
     Optional<String> lookup(const String& key) const;
-    bool contains(const String& key) const;
+    [[nodiscard]] bool contains(const String& key) const;
+
+    [[nodiscard]] bool is_ide_enabled() const;
+    [[nodiscard]] bool is_smp_enabled() const;
+    [[nodiscard]] bool is_vmmouse_enabled() const;
+    [[nodiscard]] bool is_mmio_enabled() const;
+    [[nodiscard]] bool is_legacy_time_enabled() const;
+    [[nodiscard]] bool is_text_mode() const;
+    [[nodiscard]] bool is_force_pio() const;
+    [[nodiscard]] AcpiFeatureLevel acpi_feature_level() const;
+    [[nodiscard]] BootMode boot_mode() const;
+    [[nodiscard]] HPETMode hpet_mode() const;
+    [[nodiscard]] String userspace_init() const;
+    [[nodiscard]] Vector<String> userspace_init_args() const;
+    [[nodiscard]] String root_device() const;
 
 private:
     CommandLine(const String&);

--- a/Kernel/Devices/VMWareBackdoor.cpp
+++ b/Kernel/Devices/VMWareBackdoor.cpp
@@ -118,7 +118,7 @@ VMWareBackdoor* VMWareBackdoor::the()
 
 UNMAP_AFTER_INIT VMWareBackdoor::VMWareBackdoor()
 {
-    if (kernel_command_line().lookup("vmmouse").value_or("on") == "on")
+    if (kernel_command_line().is_vmmouse_enabled())
         enable_absolute_vmmouse();
 }
 

--- a/Kernel/Interrupts/InterruptManagement.cpp
+++ b/Kernel/Interrupts/InterruptManagement.cpp
@@ -61,7 +61,7 @@ UNMAP_AFTER_INIT void InterruptManagement::initialize()
     VERIFY(!InterruptManagement::initialized());
     s_interrupt_management = new InterruptManagement();
 
-    if (kernel_command_line().lookup("smp").value_or("off") == "on")
+    if (kernel_command_line().is_smp_enabled())
         InterruptManagement::the().switch_to_ioapic_mode();
     else
         InterruptManagement::the().switch_to_pic_mode();

--- a/Kernel/PCI/Initializer.cpp
+++ b/Kernel/PCI/Initializer.cpp
@@ -50,7 +50,7 @@ UNMAP_AFTER_INIT static Access::Type detect_optimal_access_type(bool mmio_allowe
 
 UNMAP_AFTER_INIT void initialize()
 {
-    bool mmio_allowed = kernel_command_line().lookup("pci_mmio").value_or("off") == "on";
+    bool mmio_allowed = kernel_command_line().is_mmio_enabled();
 
     if (detect_optimal_access_type(mmio_allowed) == Access::Type::MMIO)
         MMIOAccess::initialize(ACPI::Parser::the()->find_table("MCFG"));

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -62,7 +62,7 @@ bool StorageManagement::boot_argument_contains_partition_uuid()
 NonnullRefPtrVector<StorageController> StorageManagement::enumerate_controllers(bool force_pio) const
 {
     NonnullRefPtrVector<StorageController> controllers;
-    if (!kernel_command_line().contains("disable_ide")) {
+    if (kernel_command_line().is_ide_enabled()) {
         PCI::enumerate([&](const PCI::Address& address, PCI::ID) {
             if (PCI::get_class(address) == 0x1 && PCI::get_subclass(address) == 0x1) {
                 controllers.append(IDEController::initialize(address, force_pio));

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -59,7 +59,7 @@ bool StorageManagement::boot_argument_contains_partition_uuid()
     return m_boot_argument.starts_with("PARTUUID=");
 }
 
-NonnullRefPtrVector<StorageController> StorageManagement::enumerate_controllers(bool force_pio) const
+UNMAP_AFTER_INIT NonnullRefPtrVector<StorageController> StorageManagement::enumerate_controllers(bool force_pio) const
 {
     NonnullRefPtrVector<StorageController> controllers;
     if (kernel_command_line().is_ide_enabled()) {
@@ -73,7 +73,7 @@ NonnullRefPtrVector<StorageController> StorageManagement::enumerate_controllers(
     return controllers;
 }
 
-NonnullRefPtrVector<StorageDevice> StorageManagement::enumerate_storage_devices() const
+UNMAP_AFTER_INIT NonnullRefPtrVector<StorageDevice> StorageManagement::enumerate_storage_devices() const
 {
     VERIFY(!m_controllers.is_empty());
     NonnullRefPtrVector<StorageDevice> devices;
@@ -88,7 +88,7 @@ NonnullRefPtrVector<StorageDevice> StorageManagement::enumerate_storage_devices(
     return devices;
 }
 
-OwnPtr<PartitionTable> StorageManagement::try_to_initialize_partition_table(const StorageDevice& device) const
+UNMAP_AFTER_INIT OwnPtr<PartitionTable> StorageManagement::try_to_initialize_partition_table(const StorageDevice& device) const
 {
     auto mbr_table_or_result = MBRPartitionTable::try_to_initialize(device);
     if (!mbr_table_or_result.is_error())
@@ -108,7 +108,7 @@ OwnPtr<PartitionTable> StorageManagement::try_to_initialize_partition_table(cons
     return {};
 }
 
-NonnullRefPtrVector<DiskPartition> StorageManagement::enumerate_disk_partitions() const
+UNMAP_AFTER_INIT NonnullRefPtrVector<DiskPartition> StorageManagement::enumerate_disk_partitions() const
 {
     VERIFY(!m_storage_devices.is_empty());
     NonnullRefPtrVector<DiskPartition> partitions;
@@ -131,7 +131,7 @@ NonnullRefPtrVector<DiskPartition> StorageManagement::enumerate_disk_partitions(
     return partitions;
 }
 
-void StorageManagement::determine_boot_device()
+UNMAP_AFTER_INIT void StorageManagement::determine_boot_device()
 {
     VERIFY(!m_controllers.is_empty());
     if (m_boot_argument.starts_with("/dev/")) {
@@ -151,7 +151,7 @@ void StorageManagement::determine_boot_device()
     }
 }
 
-void StorageManagement::determine_boot_device_with_partition_uuid()
+UNMAP_AFTER_INIT void StorageManagement::determine_boot_device_with_partition_uuid()
 {
     VERIFY(!m_disk_partitions.is_empty());
     VERIFY(m_boot_argument.starts_with("PARTUUID="));

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -192,7 +192,7 @@ time_t TimeManagement::boot_time() const
 
 UNMAP_AFTER_INIT TimeManagement::TimeManagement()
 {
-    bool probe_non_legacy_hardware_timers = !(kernel_command_line().lookup("time").value_or("modern") == "legacy");
+    bool probe_non_legacy_hardware_timers = !(kernel_command_line().is_legacy_time_enabled());
     if (ACPI::is_enabled()) {
         if (!ACPI::Parser::the()->x86_specific_flags().cmos_rtc_not_present) {
             RTC::initialize();
@@ -247,12 +247,14 @@ Vector<HardwareTimerBase*> TimeManagement::scan_for_non_periodic_timers()
 
 bool TimeManagement::is_hpet_periodic_mode_allowed()
 {
-    auto hpet_mode = kernel_command_line().lookup("hpet").value_or("periodic");
-    if (hpet_mode == "periodic")
+    switch (kernel_command_line().hpet_mode()) {
+    case HPETMode::Periodic:
         return true;
-    if (hpet_mode == "nonperiodic")
+    case HPETMode::NonPeriodic:
         return false;
-    VERIFY_NOT_REACHED();
+    default:
+        VERIFY_NOT_REACHED();
+    }
 }
 
 UNMAP_AFTER_INIT bool TimeManagement::probe_and_set_non_legacy_hardware_timers()

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -219,7 +219,7 @@ Time TimeManagement::now()
     return s_the.ptr()->epoch_time();
 }
 
-Vector<HardwareTimerBase*> TimeManagement::scan_and_initialize_periodic_timers()
+UNMAP_AFTER_INIT Vector<HardwareTimerBase*> TimeManagement::scan_and_initialize_periodic_timers()
 {
     bool should_enable = is_hpet_periodic_mode_allowed();
     dbgln("Time: Scanning for periodic timers");
@@ -234,7 +234,7 @@ Vector<HardwareTimerBase*> TimeManagement::scan_and_initialize_periodic_timers()
     return timers;
 }
 
-Vector<HardwareTimerBase*> TimeManagement::scan_for_non_periodic_timers()
+UNMAP_AFTER_INIT Vector<HardwareTimerBase*> TimeManagement::scan_for_non_periodic_timers()
 {
     dbgln("Time: Scanning for non-periodic timers");
     Vector<HardwareTimerBase*> timers;

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -246,7 +246,7 @@ void init_stage2(void*)
     FinalizerTask::spawn();
 
     PCI::initialize();
-
+    auto boot_profiling = kernel_command_line().is_boot_profiling_enabled();
     auto is_text_mode = kernel_command_line().is_text_mode();
     if (is_text_mode) {
         dbgln("Text mode enabled");
@@ -318,6 +318,12 @@ void init_stage2(void*)
         PANIC("init_stage2: Error spawning SystemServer: {}", error);
     }
     thread->set_priority(THREAD_PRIORITY_HIGH);
+
+    if (boot_profiling) {
+        dbgln("Starting full system boot profiling");
+        auto result = Process::current()->sys$profiling_enable(-1);
+        VERIFY(!result.is_error());
+    }
 
     NetworkTask::spawn();
 


### PR DESCRIPTION
The full system profiling functionality is useful for profiling the boot performance of the system.
Add a new kernel boot option to start the system with profiling enabled. This lets you disable and
view a profile once the system is booted.

You can use it by running:
```
$ run.sh qcmd boot_prof
```

In addition this PR includes some cleanup:
* I found more of the kernel initialization to mark as UNMAP_AFTER_INIT
* I moved the Kernel CommandLine parsing to strongly typed API.