### PR TITLE
FileManager: Add launch handler actions to desktop context menu

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -444,7 +444,7 @@ void DirectoryView::set_should_show_dotfiles(bool show_dotfiles)
     m_model->set_should_show_dotfiles(show_dotfiles);
 }
 
-void DirectoryView::launch(const URL&, const LauncherHandler& launcher_handler)
+void DirectoryView::launch(const URL&, const LauncherHandler& launcher_handler) const
 {
     pid_t child;
     if (launcher_handler.details().launcher_type == Desktop::Launcher::LauncherType::Application) {

--- a/Userland/Applications/FileManager/DirectoryView.h
+++ b/Userland/Applications/FileManager/DirectoryView.h
@@ -74,12 +74,12 @@ public:
     int path_history_size() const { return m_path_history.size(); }
     int path_history_position() const { return m_path_history_position; }
     static RefPtr<LauncherHandler> get_default_launch_handler(const NonnullRefPtrVector<LauncherHandler>& handlers);
-    NonnullRefPtrVector<LauncherHandler> get_launch_handlers(const URL& url);
-    NonnullRefPtrVector<LauncherHandler> get_launch_handlers(const String& path);
+    static NonnullRefPtrVector<LauncherHandler> get_launch_handlers(const URL& url);
+    static NonnullRefPtrVector<LauncherHandler> get_launch_handlers(const String& path);
 
     void refresh();
 
-    void launch(const URL&, const LauncherHandler&);
+    void launch(const URL&, const LauncherHandler&) const;
 
     Function<void(const StringView& path, bool can_write_in_path)> on_path_change;
     Function<void(GUI::AbstractView&)> on_selection_change;


### PR DESCRIPTION
Extracted a method from the code in the File Manager application which
added actions for activating launch handlers found for the selected
file from the context menu. Applied this method to desktop files
and shortcuts.

Note: made some launch handler related methods in the DirectoryView
static or const which allows passing const DirectoryView& to certain
methods.