### PR TITLE
AK+Kernel: Remove NO_DISCARD macro hack

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -60,11 +60,6 @@
 #endif
 #define FLATTEN [[gnu::flatten]]
 
-#ifdef NO_DISCARD
-#    undef NO_DISCARD
-#endif
-#define NO_DISCARD [[nodiscard]]
-
 #ifndef __serenity__
 #    define PAGE_SIZE sysconf(_SC_PAGESIZE)
 #endif

--- a/Kernel/SpinLock.h
+++ b/Kernel/SpinLock.h
@@ -126,7 +126,7 @@ private:
 };
 
 template<typename LockType>
-class NO_DISCARD ScopedSpinLock {
+class [[nodiscard]] ScopedSpinLock {
 
     AK_MAKE_NONCOPYABLE(ScopedSpinLock);
 


### PR DESCRIPTION
This was added as clang-format would mess up the formatting when using `[[nodiscard]]` on a class, which is no longer the case.