### PR TITLE
Kernel: Create /dev/full with mode 0666

### DIFF
--- a/Kernel/Devices/FullDevice.h
+++ b/Kernel/Devices/FullDevice.h
@@ -37,7 +37,7 @@ public:
     virtual ~FullDevice() override;
 
     // ^Device
-    virtual mode_t required_mode() const override { return 0600; }
+    virtual mode_t required_mode() const override { return 0666; }
     virtual String device_name() const override { return "full"; }
 
 private:


### PR DESCRIPTION
Currently `/dev/full` is created with `600` permissions by default (not `666`).

The intention of this device is to allow programs (including userland programs) to test error handling when writing to devices which are full. Limiting this to root only by default seems like an oversight.
