### PR TITLE
Everywhere: Remove unnecessary `clang-format off`s

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -37,18 +37,16 @@ namespace AK {
 
 static constexpr auto make_alphabet()
 {
-    // clang-format off
     Array alphabet = {
-      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
-      'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
-      'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
-      'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
-      'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
-      'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-      'w', 'x', 'y', 'z', '0', '1', '2', '3',
-      '4', '5', '6', '7', '8', '9', '+', '/'
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+        'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+        'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+        'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+        'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+        'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+        'w', 'x', 'y', 'z', '0', '1', '2', '3',
+        '4', '5', '6', '7', '8', '9', '+', '/'
     };
-    // clang-format on
     return alphabet;
 }
 

--- a/Kernel/Interrupts/PIC.cpp
+++ b/Kernel/Interrupts/PIC.cpp
@@ -42,7 +42,6 @@ namespace Kernel {
 #define PIC1_CTL 0xA0
 #define PIC1_CMD 0xA1
 
-// clang-format off
 #define ICW1_ICW4 0x01      /* ICW4 (not) needed */
 #define ICW1_SINGLE 0x02    /* Single (cascade) mode */
 #define ICW1_INTERVAL4 0x04 /* Call address interval 4 (8) */
@@ -54,7 +53,6 @@ namespace Kernel {
 #define ICW4_BUF_SLAVE 0x08  /* Buffered mode/slave */
 #define ICW4_BUF_MASTER 0x0C /* Buffered mode/master */
 #define ICW4_SFNM 0x10       /* Special fully nested (not) */
-// clang-format on
 
 bool inline static is_all_masked(u16 reg)
 {

--- a/Kernel/KResult.h
+++ b/Kernel/KResult.h
@@ -89,10 +89,7 @@ public:
         m_have_storage = true;
     }
 
-    // FIXME: clang-format gets confused about KResultOr. Why?
-    // clang-format off
     KResultOr(KResultOr&& other)
-    // clang-format on
     {
         m_is_error = other.m_is_error;
         if (m_is_error)

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -32,7 +32,6 @@
 
 namespace Kernel {
 
-// clang-format off
 #define REG_CTRL 0x0000
 #define REG_STATUS 0x0008
 #define REG_EEPROM 0x0014
@@ -139,7 +138,6 @@ namespace Kernel {
 #define INTERRUPT_PHYINT (1 << 12)
 #define INTERRUPT_TXD_LOW (1 << 15)
 #define INTERRUPT_SRPD (1 << 16)
-// clang-format on
 
 // https://www.intel.com/content/dam/doc/manual/pci-pci-x-family-gbe-controllers-software-dev-manual.pdf Section 5.2
 static bool is_valid_device_id(u16 device_id)

--- a/Kernel/PCI/Definitions.h
+++ b/Kernel/PCI/Definitions.h
@@ -35,7 +35,6 @@
 
 namespace Kernel {
 
-// clang-format off
 #define PCI_VENDOR_ID 0x00            // word
 #define PCI_DEVICE_ID 0x02            // word
 #define PCI_COMMAND 0x04              // word
@@ -68,7 +67,6 @@ namespace Kernel {
 #define PCI_MAX_DEVICES_PER_BUS 32
 #define PCI_MAX_BUSES 256
 #define PCI_MAX_FUNCTIONS_PER_DEVICE 8
-// clang-format on
 
 namespace PCI {
 struct ID {

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -648,7 +648,6 @@ struct ifreq {
         unsigned int ifru_index;
     } ifr_ifru;
 
-    // clang-format off
 #define ifr_addr ifr_ifru.ifru_addr           // address
 #define ifr_dstaddr ifr_ifru.ifru_dstaddr     // other end of p-to-p link
 #define ifr_broadaddr ifr_ifru.ifru_broadaddr // broadcast address
@@ -665,7 +664,6 @@ struct ifreq {
 #define ifr_index ifr_ifru.ifru_index         // interface index
 #define ifr_llprio ifr_ifru.ifru_metric       // link layer priority
 #define ifr_hwaddr ifr_ifru.ifru_hwaddr       // MAC address
-    // clang-format on
 };
 
 struct rtentry {

--- a/Userland/Libraries/LibC/net/if.h
+++ b/Userland/Libraries/LibC/net/if.h
@@ -48,7 +48,6 @@ struct ifreq {
         unsigned int ifru_index;
     } ifr_ifru;
 
-    // clang-format off
 #define ifr_addr ifr_ifru.ifru_addr           // address
 #define ifr_dstaddr ifr_ifru.ifru_dstaddr     // other end of p-to-p link
 #define ifr_broadaddr ifr_ifru.ifru_broadaddr // broadcast address
@@ -65,7 +64,6 @@ struct ifreq {
 #define ifr_index ifr_ifru.ifru_index         // interface index
 #define ifr_llprio ifr_ifru.ifru_metric       // link layer priority
 #define ifr_hwaddr ifr_ifru.ifru_hwaddr       // MAC address
-    // clang-format on
 };
 
 __END_DECLS

--- a/Userland/Libraries/LibC/netinet/ip_icmp.h
+++ b/Userland/Libraries/LibC/netinet/ip_icmp.h
@@ -44,7 +44,6 @@ struct icmphdr {
     } un;
 };
 
-// clang-format off
 #define ICMP_ECHOREPLY 0       // Echo Reply
 #define ICMP_DEST_UNREACH 3    // Destination Unreachable
 #define ICMP_SOURCE_QUENCH 4   // Source Quench
@@ -59,6 +58,5 @@ struct icmphdr {
 #define ICMP_ADDRESS 17        // Address Mask Request
 #define ICMP_ADDRESSREPLY 18   // Address Mask Reply
 #define NR_ICMP_TYPES 18
-//clang-format on
 
 __END_DECLS

--- a/Userland/Libraries/LibC/regex.h
+++ b/Userland/Libraries/LibC/regex.h
@@ -102,7 +102,6 @@ enum __RegexAllFlags {
     __Regex_Last = __Regex_SkipTrimEmptyMatches
 };
 
-// clang-format off
 // Values for the cflags parameter to the regcomp() function:
 #define REG_EXTENDED __Regex_Extended                // Use Extended Regular Expressions.
 #define REG_ICASE __Regex_Insensitive                // Ignore case in match.
@@ -116,7 +115,6 @@ enum __RegexAllFlags {
 
 //static_assert (sizeof(FlagsUnderlyingType) * 8 >= regex::POSIXFlags::Last << 1), "flags type too small")
 #define REG_SEARCH __Regex_Last << 1
-// clang-format on
 
 int regcomp(regex_t*, const char*, int);
 int regexec(const regex_t*, const char*, size_t, regmatch_t[], int);

--- a/Userland/Libraries/LibELF/AuxiliaryVector.h
+++ b/Userland/Libraries/LibELF/AuxiliaryVector.h
@@ -40,7 +40,6 @@ typedef struct
     } a_un;
 } auxv_t;
 
-// clang-format off
 #define AT_NULL 0           /* No length, last entry's a_type has this value */
 #define AT_IGNORE 1         /* Entry has no meaning, a_un undefined */
 #define AT_EXECFD 2         /* a_val contains a file descriptor of the main program image */
@@ -66,7 +65,6 @@ typedef struct
 #define AT_EXECFN 31        /* a_ptr points to file name of executed program */
 #define AT_EXE_BASE 32      /* a_ptr holds base address where main program was loaded into memory */
 #define AT_EXE_SIZE 33      /* a_val holds the size of the main program in memory */
-// clang-format on
 
 namespace ELF {
 


### PR DESCRIPTION
Mostly due to the fact that clang-format allows aligned comments via
AlignTrailingComments.

We could also use raw string literals in inline asm, which clang-format
deals with properly (and would be nicer in a lot of places).