### PR TITLE
LibC: Fix typo in fenv.h

### DIFF
--- a/Userland/Libraries/LibC/fenv.cpp
+++ b/Userland/Libraries/LibC/fenv.cpp
@@ -157,7 +157,7 @@ int fegetround()
 
 int fesetround(int rounding_mode)
 {
-    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOWARDSZERO)
+    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOWARDZERO)
         return 1;
 
     auto control_word = read_control_word();

--- a/Userland/Libraries/LibC/fenv.h
+++ b/Userland/Libraries/LibC/fenv.h
@@ -77,7 +77,7 @@ int feraiseexcept(int exceptions);
 #define FE_TONEAREST 0
 #define FE_DOWNWARD 1
 #define FE_UPWARD 2
-#define FE_TOWARDSZERO 3
+#define FE_TOWARDZERO 3
 
 int fesetround(int round);
 int fegetround(void);


### PR DESCRIPTION
cc @danboid

Don't think this is enough for hatari though, tried building it and it complained about _SC_CLK_TCK not being defined. 