### PR TITLE
Meta: Search for the correct ccache cache key

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -90,8 +90,9 @@ jobs:
         # and permitting the restore-key "prefix-" without specifying a timestamp.
         # For this trick to work, the timestamp *must* come last, and it *must* be missing in 'restore-keys'.
         key: ${{ runner.os }}-ccache-i686-v${{ matrix.ccache-mark }}-D${{ matrix.debug-macros }}-toolchain_${{steps.stamps.outputs.libc_headers}}-time${{ steps.stamps.outputs.time }}
+        # IMPORTANT: Keep these two in sync!
         restore-keys: |
-          ${{ runner.os }}-ccache-i686-v${{ matrix.ccache-mark }}-D${{ matrix.debug-macros }}-libc_${{steps.stamps.outputs.libc_headers}}-
+          ${{ runner.os }}-ccache-i686-v${{ matrix.ccache-mark }}-D${{ matrix.debug-macros }}-toolchain_${{steps.stamps.outputs.libc_headers}}-
     - name: Show ccache stats before build and configure
       run: |
         # We only have 5 GiB of cache available *in total*. Beyond that, GitHub deletes caches.


### PR DESCRIPTION
"Hmm, 'toolchain' is a better name here!" I said, and changed the key name.
And then I promptly forgot to update the restore-key value. D'oh!

@bgianfo noticed this in #5614.

(To prove my point that scrapping the ccache cache so often is wasteful: #5639 will cause an unnecessary rebuild of toolchain *and* the ccache, for example.)