### PR TITLE
WebServer: Serve X-Frame-Options and X-Content-Type-Options HTTP headers

### DIFF
--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -137,6 +137,8 @@ void Client::send_response(InputStream& response, const HTTP::HttpRequest& reque
     StringBuilder builder;
     builder.append("HTTP/1.0 200 OK\r\n");
     builder.append("Server: WebServer (SerenityOS)\r\n");
+    builder.append("X-Frame-Options: SAMEORIGIN\r\n");
+    builder.append("X-Content-Type-Options: nosniff\r\n");
     builder.append("Content-Type: ");
     builder.append(content_type);
     builder.append("\r\n");


### PR DESCRIPTION
* X-Frame-Options: SAMEORIGIN
* X-Content-Type-Options: nosniff

Help prevent client side attacks against clients using the web server. (Also lets us test these features once they're implemented in `Browser`).
