### PR TITLE
HackStudio+LanguageServer+LibCpp: Various fixes and improvements

### DIFF
--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOURCES
     Git/GitRepo.cpp
     Git/GitWidget.cpp
     HackStudioWidget.cpp
+    Language.cpp
     LanguageClient.cpp
     Locator.cpp
     Project.cpp

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -426,6 +426,11 @@ void Editor::set_document(GUI::TextDocument& doc)
 
     if (m_language_client) {
         set_autocomplete_provider(make<LanguageServerAidedAutocompleteProvider>(*m_language_client));
+        // NOTE:
+        // When a file is opened for the first time in HackStudio, its content is already synced with the filesystem.
+        // Otherwise, if the file has already been opened before in some Editor instance, it should exist in the LanguageServer's
+        // FileDB, and the LanguageServer should already have its up-to-date content.
+        // So it's OK to just pass an fd here (rather than the TextDocument's content).
         int fd = open(code_document.file_path().characters(), O_RDONLY | O_NOCTTY);
         if (fd < 0) {
             perror("open");

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -236,9 +236,6 @@ void HackStudioWidget::open_file(const String& full_filename)
         new_project_file = it->value;
     } else {
         new_project_file = m_project->get_file(filename);
-        if (!new_project_file) {
-            new_project_file = ProjectFile::construct_with_name(filename);
-        }
         m_open_files.set(filename, *new_project_file);
         m_open_files_vector.append(filename);
         m_open_files_view->model()->update();

--- a/Userland/DevTools/HackStudio/Language.cpp
+++ b/Userland/DevTools/HackStudio/Language.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * Copyright (c) 2020, the SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,34 +24,37 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "CodeDocument.h"
+#include "Language.h"
 
 namespace HackStudio {
 
-NonnullRefPtr<CodeDocument> CodeDocument::create(const String& file_path, Client* client)
+Language language_from_file_extension(const String& extension)
 {
-    return adopt(*new CodeDocument(file_path, client));
+    VERIFY(!extension.starts_with("."));
+    if (extension == "cpp" || extension == "h")
+        return Language::Cpp;
+    else if (extension == "js")
+        return Language::JavaScript;
+    else if (extension == "gml")
+        return Language::GML;
+    else if (extension == "ini")
+        return Language::Ini;
+    else if (extension == "sh")
+        return Language::Shell;
+
+    return Language::Unknown;
 }
 
-NonnullRefPtr<CodeDocument> CodeDocument::create(Client* client)
+Language language_from_name(const String& name)
 {
-    return adopt(*new CodeDocument(client));
-}
+    if (name == "Cpp")
+        return Language::Cpp;
+    if (name == "Javascript")
+        return Language::JavaScript;
+    if (name == "Shell")
+        return Language::Shell;
 
-CodeDocument::CodeDocument(const String& file_path, Client* client)
-    : TextDocument(client)
-    , m_file_path(file_path)
-{
-    m_language = language_from_file_extension(LexicalPath { file_path }.extension());
-}
-
-CodeDocument::CodeDocument(Client* client)
-    : TextDocument(client)
-{
-}
-
-CodeDocument::~CodeDocument()
-{
+    return Language::Unknown;
 }
 
 }

--- a/Userland/DevTools/HackStudio/Language.h
+++ b/Userland/DevTools/HackStudio/Language.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <AK/String.h>
+
 namespace HackStudio {
 enum class Language {
     Unknown,
@@ -35,4 +37,8 @@ enum class Language {
     Ini,
     Shell,
 };
+
+Language language_from_file_extension(const String&);
+Language language_from_name(const String&);
+
 }

--- a/Userland/DevTools/HackStudio/LanguageClient.cpp
+++ b/Userland/DevTools/HackStudio/LanguageClient.cpp
@@ -36,67 +36,67 @@ namespace HackStudio {
 
 void ServerConnection::handle(const Messages::LanguageClient::AutoCompleteSuggestions& message)
 {
-    if (!m_language_client) {
+    if (!m_current_language_client) {
         dbgln("Language Server connection has no attached language client");
         return;
     }
-    m_language_client->provide_autocomplete_suggestions(message.suggestions());
+    m_current_language_client->provide_autocomplete_suggestions(message.suggestions());
 }
 
 void ServerConnection::handle(const Messages::LanguageClient::DeclarationLocation& message)
 {
-    if (!m_language_client) {
+    if (!m_current_language_client) {
         dbgln("Language Server connection has no attached language client");
         return;
     }
-    m_language_client->declaration_found(message.location().file, message.location().line, message.location().column);
+    m_current_language_client->declaration_found(message.location().file, message.location().line, message.location().column);
 }
 
 void ServerConnection::die()
 {
-    dbgln("ServerConnection::die()");
-    if (!m_language_client)
-        return;
-    m_language_client->on_server_crash();
+    VERIFY(m_wrapper);
+    // Wrapper destructs us here
+    m_wrapper->on_crash();
 }
 
 void LanguageClient::open_file(const String& path, int fd)
 {
-    if (!m_server_connection)
+    if (!m_connection_wrapper.connection())
         return;
-    m_server_connection->post_message(Messages::LanguageServer::FileOpened(path, fd));
+    m_connection_wrapper.connection()->post_message(Messages::LanguageServer::FileOpened(path, fd));
 }
 
 void LanguageClient::set_file_content(const String& path, const String& content)
 {
-    if (!m_server_connection)
+    if (!m_connection_wrapper.connection())
         return;
-    m_server_connection->post_message(Messages::LanguageServer::SetFileContent(path, content));
+    m_connection_wrapper.connection()->post_message(Messages::LanguageServer::SetFileContent(path, content));
 }
 
 void LanguageClient::insert_text(const String& path, const String& text, size_t line, size_t column)
 {
-    if (!m_server_connection)
+    if (!m_connection_wrapper.connection())
         return;
-    m_server_connection->post_message(Messages::LanguageServer::FileEditInsertText(path, text, line, column));
+    //    set_active_client();
+    m_connection_wrapper.connection()->post_message(Messages::LanguageServer::FileEditInsertText(path, text, line, column));
 }
 
 void LanguageClient::remove_text(const String& path, size_t from_line, size_t from_column, size_t to_line, size_t to_column)
 {
-    if (!m_server_connection)
+    if (!m_connection_wrapper.connection())
         return;
-    m_server_connection->post_message(Messages::LanguageServer::FileEditRemoveText(path, from_line, from_column, to_line, to_column));
+    m_connection_wrapper.connection()->post_message(Messages::LanguageServer::FileEditRemoveText(path, from_line, from_column, to_line, to_column));
 }
 
 void LanguageClient::request_autocomplete(const String& path, size_t cursor_line, size_t cursor_column)
 {
-    if (!m_server_connection)
+    if (!m_connection_wrapper.connection())
         return;
     set_active_client();
-    m_server_connection->post_message(Messages::LanguageServer::AutoCompleteSuggestions(GUI::AutocompleteProvider::ProjectLocation { path, cursor_line, cursor_column }));
+    m_connection_wrapper.connection()->post_message(Messages::LanguageServer::AutoCompleteSuggestions(GUI::AutocompleteProvider::ProjectLocation { path, cursor_line, cursor_column }));
 }
 
-void LanguageClient::provide_autocomplete_suggestions(const Vector<GUI::AutocompleteProvider::Entry>& suggestions)
+void LanguageClient::provide_autocomplete_suggestions(const Vector<GUI::AutocompleteProvider::Entry>& suggestions) const
 {
     if (on_autocomplete_suggestions)
         on_autocomplete_suggestions(suggestions);
@@ -106,44 +106,20 @@ void LanguageClient::provide_autocomplete_suggestions(const Vector<GUI::Autocomp
 
 void LanguageClient::set_autocomplete_mode(const String& mode)
 {
-    if (!m_server_connection)
+    if (!m_connection_wrapper.connection())
         return;
-    m_server_connection->post_message(Messages::LanguageServer::SetAutoCompleteMode(mode));
+    m_connection_wrapper.connection()->post_message(Messages::LanguageServer::SetAutoCompleteMode(mode));
 }
 
 void LanguageClient::set_active_client()
 {
-    if (!m_server_connection)
+    if (!m_connection_wrapper.connection())
         return;
-    m_server_connection->attach(*this);
+    m_connection_wrapper.set_active_client(*this);
 }
 
-void LanguageClient::on_server_crash()
-{
-    VERIFY(m_server_connection);
-    auto project_path = m_server_connection->project_path();
-    ServerConnection::remove_instance_for_language(project_path);
-    m_server_connection = nullptr;
+HashMap<String, NonnullOwnPtr<ServerConnectionWrapper>> ServerConnectionInstances::s_instance_for_language;
 
-    auto notification = GUI::Notification::construct();
-
-    notification->set_icon(Gfx::Bitmap::load_from_file("/res/icons/32x32/app-hack-studio.png"));
-    notification->set_title("Oops!");
-    notification->set_text(String::formatted("LanguageServer for {} crashed", project_path));
-    notification->show();
-}
-
-HashMap<String, NonnullRefPtr<ServerConnection>> ServerConnection::s_instance_for_language;
-
-void ServerConnection::set_instance_for_project(const String& language_name, NonnullRefPtr<ServerConnection>&& instance)
-{
-    s_instance_for_language.set(language_name, move(instance));
-}
-
-void ServerConnection::remove_instance_for_language(const String& language_name)
-{
-    s_instance_for_language.remove(language_name);
-}
 void ServerConnection::handle(const Messages::LanguageClient::DeclarationsInDocument& message)
 {
     locator().set_declared_symbols(message.filename(), message.declarations());
@@ -151,19 +127,122 @@ void ServerConnection::handle(const Messages::LanguageClient::DeclarationsInDocu
 
 void LanguageClient::search_declaration(const String& path, size_t line, size_t column)
 {
-    if (!m_server_connection)
+    if (!m_connection_wrapper.connection())
         return;
     set_active_client();
-    m_server_connection->post_message(Messages::LanguageServer::FindDeclaration(GUI::AutocompleteProvider::ProjectLocation { path, line, column }));
+    m_connection_wrapper.connection()->post_message(Messages::LanguageServer::FindDeclaration(GUI::AutocompleteProvider::ProjectLocation { path, line, column }));
 }
 
-void LanguageClient::declaration_found(const String& file, size_t line, size_t column)
+void LanguageClient::declaration_found(const String& file, size_t line, size_t column) const
 {
     if (!on_declaration_found) {
         dbgln("on_declaration_found callback is not set");
         return;
     }
     on_declaration_found(file, line, column);
+}
+
+void ServerConnectionInstances::set_instance_for_language(const String& language_name, NonnullOwnPtr<ServerConnectionWrapper>&& connection_wrapper)
+{
+    s_instance_for_language.set(language_name, move(connection_wrapper));
+}
+
+void ServerConnectionInstances::remove_instance_for_language(const String& language_name)
+{
+    s_instance_for_language.remove(language_name);
+}
+
+ServerConnectionWrapper* ServerConnectionInstances::get_instance_wrapper(const String& language_name)
+{
+    if (auto instance = s_instance_for_language.get(language_name); instance.has_value()) {
+        return const_cast<ServerConnectionWrapper*>(instance.value());
+    }
+    return nullptr;
+}
+
+void ServerConnectionWrapper::on_crash()
+{
+    show_crash_notification();
+    m_connection.clear();
+
+    static constexpr int max_crash_frequency_seconds = 3;
+    if (m_last_crash_timer.is_valid() && m_last_crash_timer.elapsed() / 1000 < max_crash_frequency_seconds) {
+        dbgln("LanguageServer crash frequency is too high");
+        m_respawn_allowed = false;
+
+        show_frequenct_crashes_notification();
+    } else {
+        m_last_crash_timer.start();
+        try_respawn_connection();
+    }
+}
+void ServerConnectionWrapper::show_frequenct_crashes_notification() const
+{
+    auto notification = GUI::Notification::construct();
+    notification->set_icon(Gfx::Bitmap::load_from_file("/res/icons/32x32/app-hack-studio.png"));
+    notification->set_title("LanguageServer Crashes too much!");
+    notification->set_text("LanguageServer aided features will not be available in this session");
+    notification->show();
+}
+void ServerConnectionWrapper::show_crash_notification() const
+{
+    auto notification = GUI::Notification::construct();
+    notification->set_icon(Gfx::Bitmap::load_from_file("/res/icons/32x32/app-hack-studio.png"));
+    notification->set_title("Oops!");
+    notification->set_text(String::formatted("LanguageServer has crashed"));
+    notification->show();
+}
+
+ServerConnectionWrapper::ServerConnectionWrapper(const String& language_name, Function<NonnullRefPtr<ServerConnection>()> connection_creator)
+    : m_language(language_from_name(language_name))
+    , m_connection_creator(move(connection_creator))
+{
+    create_connection();
+}
+
+void ServerConnectionWrapper::create_connection()
+{
+    VERIFY(m_connection.is_null());
+    m_connection = m_connection_creator();
+    m_connection->set_wrapper(*this);
+    m_connection->handshake();
+}
+
+ServerConnection* ServerConnectionWrapper::connection()
+{
+    return m_connection.ptr();
+}
+
+void ServerConnectionWrapper::attach(LanguageClient& client)
+{
+    m_connection->m_current_language_client = &client;
+}
+
+void ServerConnectionWrapper::detach()
+{
+    m_connection->m_current_language_client.clear();
+}
+
+void ServerConnectionWrapper::set_active_client(LanguageClient& client)
+{
+    m_connection->m_current_language_client = &client;
+}
+
+void ServerConnectionWrapper::try_respawn_connection()
+{
+    if (!m_respawn_allowed)
+        return;
+
+    dbgln("Respawning ServerConnection");
+    create_connection();
+
+    // After respawning the language-server, we have to flush the content of the project files
+    // so the server's FileDB will be up-to-date.
+    project().for_each_text_file([this](const ProjectFile& file) {
+        if (file.code_document().language() != m_language)
+            return;
+        m_connection->post_message(Messages::LanguageServer::SetFileContent(file.code_document().file_path(), file.document().text()));
+    });
 }
 
 }

--- a/Userland/DevTools/HackStudio/LanguageClient.cpp
+++ b/Userland/DevTools/HackStudio/LanguageClient.cpp
@@ -122,7 +122,7 @@ void LanguageClient::on_server_crash()
 {
     VERIFY(m_server_connection);
     auto project_path = m_server_connection->project_path();
-    ServerConnection::remove_instance_for_project(project_path);
+    ServerConnection::remove_instance_for_language(project_path);
     m_server_connection = nullptr;
 
     auto notification = GUI::Notification::construct();
@@ -133,27 +133,16 @@ void LanguageClient::on_server_crash()
     notification->show();
 }
 
-HashMap<String, NonnullRefPtr<ServerConnection>> ServerConnection::s_instances_for_projects;
+HashMap<String, NonnullRefPtr<ServerConnection>> ServerConnection::s_instance_for_language;
 
-RefPtr<ServerConnection> ServerConnection::instance_for_project(const String& project_path)
+void ServerConnection::set_instance_for_project(const String& language_name, NonnullRefPtr<ServerConnection>&& instance)
 {
-    auto key = LexicalPath { project_path }.string();
-    auto value = s_instances_for_projects.get(key);
-    if (!value.has_value())
-        return nullptr;
-    return *value.value();
+    s_instance_for_language.set(language_name, move(instance));
 }
 
-void ServerConnection::set_instance_for_project(const String& project_path, NonnullRefPtr<ServerConnection>&& instance)
+void ServerConnection::remove_instance_for_language(const String& language_name)
 {
-    auto key = LexicalPath { project_path }.string();
-    s_instances_for_projects.set(key, move(instance));
-}
-
-void ServerConnection::remove_instance_for_project(const String& project_path)
-{
-    auto key = LexicalPath { project_path }.string();
-    s_instances_for_projects.remove(key);
+    s_instance_for_language.remove(language_name);
 }
 void ServerConnection::handle(const Messages::LanguageClient::DeclarationsInDocument& message)
 {

--- a/Userland/DevTools/HackStudio/LanguageClients/ServerConnections.h
+++ b/Userland/DevTools/HackStudio/LanguageClients/ServerConnections.h
@@ -32,10 +32,13 @@
 #include <DevTools/HackStudio/LanguageServers/LanguageServerEndpoint.h>
 #include <LibIPC/ServerConnection.h>
 
-#define LANGUAGE_CLIENT(namespace_, socket_name)                                               \
-    namespace namespace_ {                                                                     \
+#define LANGUAGE_CLIENT(language_name_, socket_name)                                           \
+    namespace language_name_ {                                                                 \
     class ServerConnection : public HackStudio::ServerConnection {                             \
         C_OBJECT(ServerConnection)                                                             \
+    public:                                                                                    \
+        static const char* language_name() { return #language_name_; }                         \
+                                                                                               \
     private:                                                                                   \
         ServerConnection(const String& project_path)                                           \
             : HackStudio::ServerConnection("/tmp/portal/language/" #socket_name, project_path) \

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
@@ -60,7 +60,7 @@ const ParserAutoComplete::DocumentData* ParserAutoComplete::get_document_data(co
 
 OwnPtr<ParserAutoComplete::DocumentData> ParserAutoComplete::create_document_data_for(const String& file)
 {
-    auto document = filedb().get(file);
+    auto document = filedb().get_or_create_from_filesystem(file);
     if (!document)
         return {};
     auto content = document->text();

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
@@ -76,8 +76,8 @@ private:
     Vector<PropertyInfo> properties_of_type(const DocumentData& document, const String& type) const;
     NonnullRefPtrVector<Declaration> get_declarations_in_outer_scope_including_headers(const DocumentData& document) const;
 
-    const DocumentData& get_document_data(const String& file) const;
-    const DocumentData& get_or_create_document_data(const String& file);
+    const DocumentData* get_document_data(const String& file) const;
+    const DocumentData* get_or_create_document_data(const String& file);
     void set_document_data(const String& file, OwnPtr<DocumentData>&& data);
 
     OwnPtr<DocumentData> create_document_data_for(const String& file);

--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.h
@@ -37,19 +37,23 @@ class FileDB final {
 public:
     RefPtr<const GUI::TextDocument> get(const String& file_name) const;
     RefPtr<GUI::TextDocument> get(const String& file_name);
+    RefPtr<const GUI::TextDocument> get_or_create_from_filesystem(const String& file_name) const;
+    RefPtr<GUI::TextDocument> get_or_create_from_filesystem(const String& file_name);
     bool add(const String& file_name, int fd);
+    bool add(const String& file_name, const String& content);
 
     void set_project_root(const String& root_path) { m_project_root = root_path; }
 
     void on_file_edit_insert_text(const String& file_name, const String& inserted_text, size_t start_line, size_t start_column);
     void on_file_edit_remove_text(const String& file_name, size_t start_line, size_t start_column, size_t end_line, size_t end_column);
     String to_absolute_path(const String& file_name) const;
-    bool is_open(String file_name) const;
+    bool is_open(const String& file_name) const;
 
 private:
     RefPtr<GUI::TextDocument> create_from_filesystem(const String& file_name) const;
     RefPtr<GUI::TextDocument> create_from_fd(int fd) const;
     RefPtr<GUI::TextDocument> create_from_file(Core::File&) const;
+    static RefPtr<GUI::TextDocument> create_with_content(const String&);
 
 private:
     HashMap<String, NonnullRefPtr<GUI::TextDocument>> m_open_files;

--- a/Userland/DevTools/HackStudio/Project.cpp
+++ b/Userland/DevTools/HackStudio/Project.cpp
@@ -70,15 +70,24 @@ void Project::for_each_text_file(Function<void(const ProjectFile&)> callback) co
     });
 }
 
-RefPtr<ProjectFile> Project::get_file(const String& path) const
+NonnullRefPtr<ProjectFile> Project::get_file(const String& path) const
 {
+    auto full_path = to_absolute_path(path);
     for (auto& file : m_files) {
-        if (file.name() == path)
+        if (file.name() == full_path)
             return file;
     }
-    auto file = ProjectFile::construct_with_name(path);
+    auto file = ProjectFile::construct_with_name(full_path);
     m_files.append(file);
     return file;
+}
+
+String Project::to_absolute_path(const String& path) const
+{
+    if (LexicalPath { path }.is_absolute()) {
+        return path;
+    }
+    return LexicalPath { String::formatted("{}/{}", m_root_path, path) }.string();
 }
 
 }

--- a/Userland/DevTools/HackStudio/Project.h
+++ b/Userland/DevTools/HackStudio/Project.h
@@ -48,12 +48,14 @@ public:
     String name() const { return LexicalPath(m_root_path).basename(); }
     String root_path() const { return m_root_path; }
 
-    RefPtr<ProjectFile> get_file(const String& path) const;
+    NonnullRefPtr<ProjectFile> get_file(const String& path) const;
 
     void for_each_text_file(Function<void(const ProjectFile&)>) const;
 
 private:
     explicit Project(const String& root_path);
+
+    String to_absolute_path(const String&) const;
 
     RefPtr<GUI::FileSystemModel> m_model;
     mutable NonnullRefPtrVector<ProjectFile> m_files;

--- a/Userland/DevTools/HackStudio/ProjectFile.cpp
+++ b/Userland/DevTools/HackStudio/ProjectFile.cpp
@@ -37,17 +37,8 @@ ProjectFile::ProjectFile(const String& name)
 
 GUI::TextDocument& ProjectFile::document() const
 {
-    if (!m_document) {
-        m_document = CodeDocument::create(m_name);
-        auto file_or_error = Core::File::open(m_name, Core::File::ReadOnly);
-        if (file_or_error.is_error()) {
-            warnln("Couldn't open '{}': {}", m_name, file_or_error.error());
-            // This is okay though, we'll just go with an empty document and create the file when saving.
-        } else {
-            auto& file = *file_or_error.value();
-            m_document->set_text(file.read_all());
-        }
-    }
+    create_document_if_needed();
+    VERIFY(m_document);
     return *m_document;
 }
 
@@ -69,6 +60,29 @@ int ProjectFile::horizontal_scroll_value() const
 void ProjectFile::horizontal_scroll_value(int horizontal_scroll_value)
 {
     m_horizontal_scroll_value = horizontal_scroll_value;
+}
+
+CodeDocument& ProjectFile::code_document() const
+{
+    create_document_if_needed();
+    VERIFY(m_document);
+    return *m_document;
+}
+
+void ProjectFile::create_document_if_needed() const
+{
+    if (m_document)
+        return;
+
+    m_document = CodeDocument::create(m_name);
+    auto file_or_error = Core::File::open(m_name, Core::File::ReadOnly);
+    if (file_or_error.is_error()) {
+        warnln("Couldn't open '{}': {}", m_name, file_or_error.error());
+        // This is okay though, we'll just go with an empty document and create the file when saving.
+    } else {
+        auto& file = *file_or_error.value();
+        m_document->set_text(file.read_all());
+    }
 }
 
 }

--- a/Userland/DevTools/HackStudio/ProjectFile.h
+++ b/Userland/DevTools/HackStudio/ProjectFile.h
@@ -44,6 +44,7 @@ public:
     const String& name() const { return m_name; }
 
     GUI::TextDocument& document() const;
+    CodeDocument& code_document() const;
 
     int vertical_scroll_value() const;
     void vertical_scroll_value(int);
@@ -52,6 +53,7 @@ public:
 
 private:
     explicit ProjectFile(const String& name);
+    void create_document_if_needed() const;
 
     String m_name;
     mutable RefPtr<CodeDocument> m_document;

--- a/Userland/Libraries/LibCpp/AST.cpp
+++ b/Userland/Libraries/LibCpp/AST.cpp
@@ -127,7 +127,8 @@ NonnullRefPtrVector<Declaration> FunctionDefinition::declarations() const
 void VariableDeclaration::dump(size_t indent) const
 {
     ASTNode::dump(indent);
-    m_type->dump(indent + 1);
+    if (m_type)
+        m_type->dump(indent + 1);
     print_indent(indent + 1);
     outln("{}", m_name);
     if (m_initial_value)

--- a/Userland/Libraries/LibCpp/Preprocessor.cpp
+++ b/Userland/Libraries/LibCpp/Preprocessor.cpp
@@ -67,6 +67,8 @@ void Preprocessor::handle_preprocessor_line(const StringView& line)
     lexer.consume_specific('#');
     consume_whitespace();
     auto keyword = lexer.consume_until(' ');
+    if (keyword.is_empty() || keyword.is_null() || keyword.is_whitespace())
+        return;
 
     if (keyword == "include") {
         consume_whitespace();


### PR DESCRIPTION
Main things:

- Store connections to different LanguageServers by the language name. This allows us to use multiple language servers in the same HackStudio instance (e.g a project that contains both C++ and Shell).
- Fix an issue were "Find In Files" would not search in the up-to-date content of a file that was edited but not yet saved to the filesystem.
- We now restart the LanguageServer if it crashes. If it crashes twice within 3 seconds, we give up and won't restart it again.
  HackStudio can still be used normally, but features that use the language server won't work.
  For this we use a new class that wraps the connection to the language-server and restarts it if needed, `ServerConnectionWrapper`.
- Some LibCpp fixes.

Closes #5569
Closes #5634 
Closes #5574