### PR TITLE
LibM: optimized (branchless) copysign

### DIFF
--- a/Userland/Libraries/LibM/math.cpp
+++ b/Userland/Libraries/LibM/math.cpp
@@ -745,12 +745,11 @@ long double nexttowardl(long double, long double) NOEXCEPT
 
 double copysign(double x, double y)
 {
-    if (x < 0 && y < 0)
-        return x;
-    if (x >= 0 && y < 0)
-        return -x;
-    if (x < 0 && y >= 0)
-        return -x;
-    return x;
+    using Extractor = FloatExtractor<decltype(x)>;
+    Extractor ex, ey;
+    ex.d = x;
+    ey.d = y;
+    ex.sign = ey.sign;
+    return ex.d;
 }
 }


### PR DESCRIPTION
This version just copies the sign bit from y into x. This is just an optimization after @awesomekling mentioned there is likely a more clever way to do it in his recent video. I think this is the clever way :^)