### PR TITLE
Ports: Add zlib dependency to libpng

### DIFF
--- a/Ports/libpng/package.sh
+++ b/Ports/libpng/package.sh
@@ -4,3 +4,4 @@ version=1.6.37
 useconfigure=true
 files="https://download.sourceforge.net/libpng/libpng-${version}.tar.gz libpng-${version}.tar.gz"
 workdir="libpng-$version"
+depends="zlib"


### PR DESCRIPTION
I didn't have zlib installed when I was trying to compile libpng.
It said it was missing, so add a dependency to zlib.