### PR TITLE
Base: Add egrep and rgrep aliases to /etc/shellrc

### DIFF
--- a/Base/etc/shellrc
+++ b/Base/etc/shellrc
@@ -27,6 +27,8 @@ alias sl=Solitaire
 alias ue=UserspaceEmulator
 alias welcome=Serendipity
 
+alias rgrep="grep -r"
+alias egrep="grep -E"
 alias ll='ls -l'
 
 export PROMPT="\\X\\u@\\h:\\w\\a\\e[32;1m@\\h\\e[0m:\\e[34;1m\\w\\e[0m \\p "


### PR DESCRIPTION
Common aliases. Available by default on Debian systems (and derivatives such as Ubuntu) as simple shell wrapper scripts.
