### PR TITLE
Ports/git: Forcing NO_IPV6 option.

### DIFF
--- a/Ports/git/package.sh
+++ b/Ports/git/package.sh
@@ -3,7 +3,7 @@ port=git
 version=2.26.0
 useconfigure="true"
 files="https://mirrors.edge.kernel.org/pub/software/scm/git/git-${version}.tar.xz git-${version}.tar.xz"
-configopts="--target=i686-pc-serenity"
+configopts="--target=i686-pc-serenity CFLAGS=-DNO_IPV6"
 depends="zlib"
 
 build() {


### PR DESCRIPTION
This fixes the build, how ever I don't know why the auto detection broke in the first place.