### PR TITLE
TextEditor: Specify the starting line and column number using colons

### DIFF
--- a/Userland/Applications/TextEditor/CMakeLists.txt
+++ b/Userland/Applications/TextEditor/CMakeLists.txt
@@ -2,6 +2,7 @@ compile_gml(TextEditorWindow.gml TextEditorWindowGML.h text_editor_window_gml)
 
 set(SOURCES
     main.cpp
+    FileArgument.cpp
     MainWidget.cpp
     TextEditorWindowGML.h
 )

--- a/Userland/Applications/TextEditor/FileArgument.cpp
+++ b/Userland/Applications/TextEditor/FileArgument.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, ry755 <ryanst755@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "FileArgument.h"
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <LibCore/File.h>
+#include <LibRegex/Regex.h>
+
+FileArgument::FileArgument(String file_argument)
+{
+    m_line = {};
+    m_column = {};
+
+    if (Core::File::exists(file_argument)) {
+        // A file exists with the full specified name, don't attempt to parse it.
+        m_file_name = file_argument;
+        return;
+    }
+
+    // A file doesn't exist with the full specified name, maybe the user entered line/column coordinates?
+    Regex<PosixExtended> re("^(.+?)(:([0-9]+):?([0-9]+)?)?$");
+    RegexResult result = match(file_argument, re, PosixFlags::Global | PosixFlags::Multiline | PosixFlags::Ungreedy);
+    auto& groups = result.capture_group_matches.at(0);
+
+    // Match 0 group 0: file name
+    // Match 0 group 1: line number
+    // Match 0 group 2: column number
+
+    if (groups.size() > 3) {
+        // Both a line and column number were specified.
+        auto file_name = groups.at(0).view.to_string();
+        auto initial_line_number = groups.at(1).view.to_string().to_int();
+        auto initial_column_number = groups.at(2).view.to_string().to_int();
+
+        m_file_name = file_name;
+        if (initial_line_number.has_value() && initial_line_number.value() > 0)
+            m_line = initial_line_number.value();
+        if (initial_column_number.has_value())
+            m_column = initial_column_number.value();
+    } else if (groups.size() == 3) {
+        // Only a line number was specified.
+        auto file_name = groups.at(0).view.to_string();
+        auto initial_line_number = groups.at(1).view.to_string().to_int();
+
+        m_file_name = file_name;
+        if (initial_line_number.has_value() && initial_line_number.value() > 0)
+            m_line = initial_line_number.value();
+    } else {
+        // A colon was found at the end of the file name but no values were found after it.
+        auto file_name = groups.at(0).view.to_string();
+
+        m_file_name = file_name;
+    }
+}
+
+FileArgument::~FileArgument()
+{
+}

--- a/Userland/Applications/TextEditor/FileArgument.h
+++ b/Userland/Applications/TextEditor/FileArgument.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021, ry755 <ryanst755@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+
+class FileArgument final {
+public:
+    FileArgument(String);
+    ~FileArgument();
+
+    String file_name() { return m_file_name; }
+    Optional<size_t> line() { return m_line; }
+    Optional<size_t> column() { return m_column; }
+
+private:
+    String m_file_name;
+    Optional<size_t> m_line;
+    Optional<size_t> m_column;
+};


### PR DESCRIPTION
This allows the user to specify a specific line and column number to start at when opening a file in TextEditor through the terminal, by adding colon(s) after the file name.

For example, `TextEditor ReadMe.md:10:5` will open ReadMe.md and put the cursor on line 10 at column 5.

To ensure that the user isn't trying to open a file that actually has colons in its name, it checks if the file exists before parsing it.

This replaces the -l/--line-number command line option added in b474f4916479fbf64e6fb5a66cb25b8496e153b3 and closes issue #5589

I'm still very new to SerenityOS development (and C++ in general) so any tips would be appreciated!