### PR TITLE
Shell: Some (script) usability improvements and a few random bugfixes

### DIFF
--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -892,10 +892,15 @@ int Shell::builtin_not(int argc, const char** argv)
 
     auto commands = expand_aliases({ move(command) });
     int exit_code = 1;
+    auto found_a_job = false;
     for (auto& job : run_commands(commands)) {
+        found_a_job = true;
         block_on_job(job);
         exit_code = job.exit_code();
     }
+    // In case it was a function.
+    if (!found_a_job)
+        exit_code = last_return_code;
     return exit_code == 0 ? 1 : 0;
 }
 

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -299,9 +299,10 @@ int Shell::builtin_exit(int argc, const char** argv)
         }
     }
     stop_all_jobs();
-    m_editor->save_history(get_history_path());
-    if (m_is_interactive)
+    if (m_is_interactive) {
+        m_editor->save_history(get_history_path());
         printf("Good-bye!\n");
+    }
     exit(exit_code);
     return 0;
 }

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1232,6 +1232,14 @@ void Shell::cache_path()
     for (const auto& builtin_name : builtin_names)
         cached_path.append(escape_token(builtin_name));
 
+    // Add functions to the cache.
+    for (auto& function : m_functions) {
+        auto name = escape_token(function.key);
+        if (cached_path.contains_slow(name))
+            continue;
+        cached_path.append(name);
+    }
+
     // Add aliases to the cache.
     for (const auto& alias : m_aliases) {
         auto name = escape_token(alias.key);

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -264,7 +264,7 @@ public:
 #undef __ENUMERATE_SHELL_OPTION
 
 private:
-    Shell(Line::Editor&);
+    Shell(Line::Editor&, bool attempt_interactive);
     Shell();
     virtual ~Shell() override;
 


### PR DESCRIPTION
TL;DR I tried turning @tomuta's `serenity.sh` into a Serenity shell script (because that's my shell :P) and found a bunch of bugs to fix.

Reminder to check the size of your `~/.history`, because I had 6 million entries in it.

<details>
<summary>The aforementioned "port" of serenity.sh</summary>

```sh
#!/bin/env serenity-shell

ARG0="$0"

print_help() {
  echo "Usage: $ARG0 COMMAND [TARGET] [ARGS...]
  Supported COMMANDs:
    build:    Compiles the target binaries, [ARGS...] are passed through to ninja
    install:  Installs the target binary
    image:    Creates a disk image with the installed binaries
    run:      TARGET lagom:      Runs the unit tests on the build host
              All other TARGETs: Runs the built image in QEMU
    delete:   Removes the build environment for the TARGET
    recreate: Deletes and re-creates the build environment for TARGET
    rebuild:  Deletes and re-creates the build environment, and compiles for TARGET

    rebuild-toolchain: Deletes and re-builds the TARGET's toolchain
  Supported TARGETs: i686 (default), x86_64, lagom"
}

usage() {
  1>&2 print_help
  exit 1
}

CMD="$1"
BUILD_DIR=''
TOOLCHAIN=''
TOOLCHAIN_DIR=''

[ '!' -z "$CMD" ] \
  || usage
shift

if [ $CMD = "help" ] {
  print_help
  exit 0
}

if [ '!' -z "$1" ] {
  TARGET="$1"
  shift
} else {
  TARGET="i686"
}

CMAKE_ARGS=()

get_top_dir() {
  git rev-parse --show-toplevel
}

is_valid_target() {
  if [ $TARGET = "lagom" ] {
    echo 'target is lagom'
    CMAKE_ARGS=($CMAKE_ARGS "-DBUILD_LAGOM=ON")
    true
  } else {
      match $TARGET {
          i686|x86_64|lagom {
              true
          }
          * {
              false
          }
      }
  }
}

create_build_dir() {
  mkdir -p "$BUILD_DIR"
  {
    cd "$BUILD_DIR" \
      && cmake -GNinja $CMAKE_ARGS ../..
  }
}

cmd_with_target() {
  if not is_valid_target {
    1>&2 echo "Unknown target: $TARGET"
    usage
  }
  export SERENITY_ARCH="$TARGET"
  SERENITY_ROOT=$(get_top_dir)
  export SERENITY_ROOT
  BUILD_DIR="$SERENITY_ROOT/Build/$TARGET"
  if [ $TARGET = "lagom" ] {
    TOOLCHAIN=i686
  } else {
    TOOLCHAIN="$TARGET"
  }
  TOOLCHAIN_DIR="$SERENITY_ROOT/Toolchain/Build/$TARGET"
}

ensure_target() {
  [ -d "$BUILD_DIR" ] \
    || create_build_dir
}

build_target() {
  {
    
    cd "$BUILD_DIR" \
      && ninja $*
  }
}

delete_target() {
  [ '!' -d "$BUILD_DIR" ] \
    || rm -rf "$BUILD_DIR"
}

build_toolchain() {
  {
    cd Toolchain \
      && ARCH="$TOOLCHAIN" ./BuildIt.sh
  }
}

ensure_toolchain() {
  [ -d "$TOOLCHAIN_DIR" ] \
    || build_toolchain
}

delete_toolchain() {
  [ '!' -d "$TOOLCHAIN_DIR" ] \
    || rm -rf "$TOOLCHAIN_DIR"
}

not_supported_lagom() {
  1>&2 echo "Command '$CMD' not supported for the lagom target"
  exit 1
}

match $CMD {
  delete {
    cmd_with_target
    delete_target
  }
  rebuild-toolchain {
    cmd_with_target
    if [ "$TARGET" '!'= "lagom" ] {
      1>&2 echo "The lagom target uses the host toolchain"
      exit 1
    }
    delete_toolchain
    ensure_toolchain
  }
  build | install | image | run | rebuild | recreate | setup-and-run {
    
  }
  * {
    1>&2 echo "Unknown command: $CMD"
    usage
  }
}

cmd_with_target
[ $CMD '!'= "recreate" -a $cmd '!'= "rebuild" ] \
  || delete_target

ensure_target
ensure_toolchain
match "$CMD" {
  build {
    build_target $*
  }
  install {
    [ $TARGET '!'= "lagom" ] \
      || not_supported_lagom
    build_target
    build_target install
  }
  image {
    [ $TARGET '!'= "lagom" ] \
      || not_supported_lagom
    build_target
    build_target install
    build_target image
  }
  run {
    build_target
    if [ $TARGET = "lagom" ] {
      build_target test
    } else {
      build_target install
      build_target image
      build_target run
    }
  }
  rebuild {
    build_target $*
  }
  recreate {
    
  }
  * {
    build_target "$CMD" $*
  }
}

```

</details>