### PR TITLE
AK + Kernel + LibGUI:  Add AK_ENUM_BITWISE_OPERATORS(..) to enable type-safe, enum bitwise operations and start using it

### DIFF
--- a/AK/EnumBits.h
+++ b/AK/EnumBits.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021, Brian Gianforcaro <b.gianfo@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AK/StdLibExtras.h"
+
+// Enables bitwise operators for the specified Enum type.
+//
+#define AK_ENUM_BITWISE_OPERATORS(Enum) \
+    _AK_ENUM_BITWISE_OPERATORS_INTERNAL(Enum, )
+
+// Enables bitwise operators for the specified Enum type, this
+// version is meant for use on enums which are private to the
+// containing type.
+//
+#define AK_ENUM_BITWISE_FRIEND_OPERATORS(Enum) \
+    _AK_ENUM_BITWISE_OPERATORS_INTERNAL(Enum, friend)
+
+#define _AK_ENUM_BITWISE_OPERATORS_INTERNAL(Enum, Prefix)                    \
+                                                                             \
+    [[nodiscard]] Prefix constexpr inline Enum operator|(Enum lhs, Enum rhs) \
+    {                                                                        \
+        using Type = UnderlyingType<Enum>::Type;                             \
+        return static_cast<Enum>(                                            \
+            static_cast<Type>(lhs) | static_cast<Type>(rhs));                \
+    }                                                                        \
+                                                                             \
+    [[nodiscard]] Prefix constexpr inline Enum operator&(Enum lhs, Enum rhs) \
+    {                                                                        \
+        using Type = UnderlyingType<Enum>::Type;                             \
+        return static_cast<Enum>(                                            \
+            static_cast<Type>(lhs) & static_cast<Type>(rhs));                \
+    }                                                                        \
+                                                                             \
+    [[nodiscard]] Prefix constexpr inline Enum operator^(Enum lhs, Enum rhs) \
+    {                                                                        \
+        using Type = UnderlyingType<Enum>::Type;                             \
+        return static_cast<Enum>(                                            \
+            static_cast<Type>(lhs) ^ static_cast<Type>(rhs));                \
+    }                                                                        \
+                                                                             \
+    [[nodiscard]] Prefix constexpr inline Enum operator~(Enum rhs)           \
+    {                                                                        \
+        using Type = UnderlyingType<Enum>::Type;                             \
+        return static_cast<Enum>(                                            \
+            ~static_cast<Type>(rhs));                                        \
+    }                                                                        \
+                                                                             \
+    Prefix constexpr inline Enum& operator|=(Enum& lhs, Enum rhs)            \
+    {                                                                        \
+        using Type = UnderlyingType<Enum>::Type;                             \
+        lhs = static_cast<Enum>(                                             \
+            static_cast<Type>(lhs) | static_cast<Type>(rhs));                \
+        return lhs;                                                          \
+    }                                                                        \
+                                                                             \
+    Prefix constexpr inline Enum& operator&=(Enum& lhs, Enum rhs)            \
+    {                                                                        \
+        using Type = UnderlyingType<Enum>::Type;                             \
+        lhs = static_cast<Enum>(                                             \
+            static_cast<Type>(lhs) & static_cast<Type>(rhs));                \
+        return lhs;                                                          \
+    }                                                                        \
+                                                                             \
+    Prefix constexpr inline Enum& operator^=(Enum& lhs, Enum rhs)            \
+    {                                                                        \
+        using Type = UnderlyingType<Enum>::Type;                             \
+        lhs = static_cast<Enum>(                                             \
+            static_cast<Type>(lhs) ^ static_cast<Type>(rhs));                \
+        return lhs;                                                          \
+    }                                                                        \
+                                                                             \
+    Prefix constexpr inline bool has_flag(Enum value, Enum mask)             \
+    {                                                                        \
+        using Type = UnderlyingType<Enum>::Type;                             \
+        return static_cast<Type>(value & mask) != 0;                         \
+    }

--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(AK_TEST_SOURCES
     TestDistinctNumeric.cpp
     TestDoublyLinkedList.cpp
     TestEndian.cpp
+    TestEnumBits.cpp
     TestFind.cpp
     TestFormat.cpp
     TestHashFunctions.cpp

--- a/AK/Tests/TestEnumBits.cpp
+++ b/AK/Tests/TestEnumBits.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, Brian Gianforcaro <b.gianfo@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/EnumBits.h>
+#include <AK/TestSuite.h>
+
+enum class VideoIntro : u8 {
+    None = 0x0,
+    Well = 0x1,
+    Hello = 0x2,
+    Friends = 0x4,
+    ExclimationMark = 0x8,
+    CompleteIntro = Well | Hello | Friends | ExclimationMark,
+};
+
+AK_ENUM_BITWISE_OPERATORS(VideoIntro);
+
+TEST_CASE(bitwise_or)
+{
+    auto intro = VideoIntro::Well | VideoIntro::Hello | VideoIntro::Friends | VideoIntro::ExclimationMark;
+    EXPECT_EQ(intro, VideoIntro::CompleteIntro);
+}
+
+TEST_CASE(bitwise_and)
+{
+    auto intro = VideoIntro::CompleteIntro;
+    EXPECT_EQ(intro & VideoIntro::Hello, VideoIntro::Hello);
+}
+
+TEST_CASE(bitwise_xor)
+{
+    auto intro = VideoIntro::Well | VideoIntro::Hello | VideoIntro::Friends;
+    EXPECT_EQ(intro ^ VideoIntro::CompleteIntro, VideoIntro::ExclimationMark);
+}
+
+TEST_CASE(bitwise_not)
+{
+    auto intro = ~VideoIntro::CompleteIntro;
+    EXPECT_EQ(intro & VideoIntro::CompleteIntro, VideoIntro::None);
+}
+
+TEST_CASE(bitwise_or_equal)
+{
+    auto intro = VideoIntro::Well | VideoIntro::Hello | VideoIntro::Friends;
+    EXPECT_EQ(intro |= VideoIntro::ExclimationMark, VideoIntro::CompleteIntro);
+}
+
+TEST_CASE(bitwise_and_equal)
+{
+    auto intro = VideoIntro::CompleteIntro;
+    EXPECT_EQ(intro &= VideoIntro::Hello, VideoIntro::Hello);
+}
+
+TEST_CASE(bitwise_xor_equal)
+{
+    auto intro = VideoIntro::Well | VideoIntro::Hello | VideoIntro::Friends;
+    EXPECT_EQ(intro ^= VideoIntro::CompleteIntro, VideoIntro::ExclimationMark);
+}
+
+TEST_CASE(has_flag)
+{
+    auto intro = VideoIntro::Hello | VideoIntro::Friends;
+    EXPECT(has_flag(intro, VideoIntro::Friends));
+    EXPECT(!has_flag(intro, VideoIntro::Well));
+}
+
+TEST_MAIN(EnumBits)

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -98,22 +98,23 @@ KResult FileDescription::attach()
 
 Thread::FileBlocker::BlockFlags FileDescription::should_unblock(Thread::FileBlocker::BlockFlags block_flags) const
 {
-    u32 unblock_flags = (u32)Thread::FileBlocker::BlockFlags::None;
-    if (((u32)block_flags & (u32)Thread::FileBlocker::BlockFlags::Read) && can_read())
-        unblock_flags |= (u32)Thread::FileBlocker::BlockFlags::Read;
-    if (((u32)block_flags & (u32)Thread::FileBlocker::BlockFlags::Write) && can_write())
-        unblock_flags |= (u32)Thread::FileBlocker::BlockFlags::Write;
+    using BlockFlags = Thread::FileBlocker::BlockFlags;
+    BlockFlags unblock_flags = BlockFlags::None;
+    if (has_flag(block_flags, BlockFlags::Read) && can_read())
+        unblock_flags |= BlockFlags::Read;
+    if (has_flag(block_flags, BlockFlags::Write) && can_write())
+        unblock_flags |= BlockFlags::Write;
     // TODO: Implement Thread::FileBlocker::BlockFlags::Exception
 
-    if ((u32)block_flags & (u32)Thread::FileBlocker::BlockFlags::SocketFlags) {
+    if (has_flag(block_flags, BlockFlags::SocketFlags)) {
         auto* sock = socket();
         VERIFY(sock);
-        if (((u32)block_flags & (u32)Thread::FileBlocker::BlockFlags::Accept) && sock->can_accept())
-            unblock_flags |= (u32)Thread::FileBlocker::BlockFlags::Accept;
-        if (((u32)block_flags & (u32)Thread::FileBlocker::BlockFlags::Connect) && sock->setup_state() == Socket::SetupState::Completed)
-            unblock_flags |= (u32)Thread::FileBlocker::BlockFlags::Connect;
+        if (has_flag(block_flags, BlockFlags::Accept) && sock->can_accept())
+            unblock_flags |= BlockFlags::Accept;
+        if (has_flag(block_flags, BlockFlags::Connect) && sock->setup_state() == Socket::SetupState::Completed)
+            unblock_flags |= BlockFlags::Connect;
     }
-    return (Thread::FileBlocker::BlockFlags)unblock_flags;
+    return unblock_flags;
 }
 
 KResult FileDescription::stat(::stat& buffer)

--- a/Kernel/KBuffer.h
+++ b/Kernel/KBuffer.h
@@ -48,7 +48,7 @@ namespace Kernel {
 
 class KBufferImpl : public RefCounted<KBufferImpl> {
 public:
-    static RefPtr<KBufferImpl> try_create_with_size(size_t size, u8 access, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
+    static RefPtr<KBufferImpl> try_create_with_size(size_t size, Region::Access access, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
     {
         auto region = MM.allocate_kernel_region(page_round_up(size), name, access, strategy);
         if (!region)
@@ -56,7 +56,7 @@ public:
         return adopt(*new KBufferImpl(region.release_nonnull(), size, strategy));
     }
 
-    static RefPtr<KBufferImpl> try_create_with_bytes(ReadonlyBytes bytes, u8 access, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
+    static RefPtr<KBufferImpl> try_create_with_bytes(ReadonlyBytes bytes, Region::Access access, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
     {
         auto region = MM.allocate_kernel_region(page_round_up(bytes.size()), name, access, strategy);
         if (!region)
@@ -65,12 +65,12 @@ public:
         return adopt(*new KBufferImpl(region.release_nonnull(), bytes.size(), strategy));
     }
 
-    static RefPtr<KBufferImpl> create_with_size(size_t size, u8 access, const char* name, AllocationStrategy strategy = AllocationStrategy::Reserve)
+    static RefPtr<KBufferImpl> create_with_size(size_t size, Region::Access access, const char* name, AllocationStrategy strategy = AllocationStrategy::Reserve)
     {
         return try_create_with_size(size, access, name, strategy);
     }
 
-    static RefPtr<KBufferImpl> copy(const void* data, size_t size, u8 access, const char* name)
+    static RefPtr<KBufferImpl> copy(const void* data, size_t size, Region::Access access, const char* name)
     {
         auto buffer = create_with_size(size, access, name, AllocationStrategy::AllocateNow);
         if (!buffer)
@@ -124,7 +124,7 @@ public:
     {
     }
 
-    [[nodiscard]] static OwnPtr<KBuffer> try_create_with_size(size_t size, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
+    [[nodiscard]] static OwnPtr<KBuffer> try_create_with_size(size_t size, Region::Access access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
     {
         auto impl = KBufferImpl::try_create_with_size(size, access, name, strategy);
         if (!impl)
@@ -132,7 +132,7 @@ public:
         return adopt_own(*new KBuffer(impl.release_nonnull()));
     }
 
-    [[nodiscard]] static OwnPtr<KBuffer> try_create_with_bytes(ReadonlyBytes bytes, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
+    [[nodiscard]] static OwnPtr<KBuffer> try_create_with_bytes(ReadonlyBytes bytes, Region::Access access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
     {
         auto impl = KBufferImpl::try_create_with_bytes(bytes, access, name, strategy);
         if (!impl)
@@ -140,12 +140,12 @@ public:
         return adopt_own(*new KBuffer(impl.release_nonnull()));
     }
 
-    [[nodiscard]] static KBuffer create_with_size(size_t size, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
+    [[nodiscard]] static KBuffer create_with_size(size_t size, Region::Access access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer", AllocationStrategy strategy = AllocationStrategy::Reserve)
     {
         return KBuffer(KBufferImpl::create_with_size(size, access, name, strategy));
     }
 
-    [[nodiscard]] static KBuffer copy(const void* data, size_t size, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer")
+    [[nodiscard]] static KBuffer copy(const void* data, size_t size, Region::Access access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer")
     {
         return KBuffer(KBufferImpl::copy(data, size, access, name));
     }
@@ -165,7 +165,7 @@ public:
     [[nodiscard]] const KBufferImpl& impl() const { return *m_impl; }
     [[nodiscard]] RefPtr<KBufferImpl> take_impl() { return move(m_impl); }
 
-    KBuffer(const ByteBuffer& buffer, u8 access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer")
+    KBuffer(const ByteBuffer& buffer, Region::Access access = Region::Access::Read | Region::Access::Write, const char* name = "KBuffer")
         : m_impl(KBufferImpl::copy(buffer.data(), buffer.size(), access, name))
     {
     }

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -192,7 +192,7 @@ KResult LocalSocket::connect(FileDescription& description, Userspace<const socka
 
     dbgln_if(LOCAL_SOCKET_DEBUG, "LocalSocket({}) connect({}) status is {}", this, safe_address, to_string(setup_state()));
 
-    if (!((u32)unblock_flags & (u32)Thread::FileDescriptionBlocker::BlockFlags::Connect)) {
+    if (!has_flag(unblock_flags, Thread::FileDescriptionBlocker::BlockFlags::Connect)) {
         set_connect_side_role(Role::None);
         return ECONNREFUSED;
     }

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/EnumBits.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/IntrusiveList.h>
@@ -1266,6 +1267,8 @@ private:
     void yield_while_not_holding_big_lock();
     void drop_thread_count(bool);
 };
+
+AK_ENUM_BITWISE_OPERATORS(Thread::FileBlocker::BlockFlags);
 
 template<typename Callback>
 inline IterationDecision Thread::for_each(Callback callback)

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -265,17 +265,17 @@ const FileDescription& Thread::FileDescriptionBlocker::blocked_description() con
 }
 
 Thread::AcceptBlocker::AcceptBlocker(FileDescription& description, BlockFlags& unblocked_flags)
-    : FileDescriptionBlocker(description, (BlockFlags)((u32)BlockFlags::Accept | (u32)BlockFlags::Exception), unblocked_flags)
+    : FileDescriptionBlocker(description, BlockFlags::Accept | BlockFlags::Exception, unblocked_flags)
 {
 }
 
 Thread::ConnectBlocker::ConnectBlocker(FileDescription& description, BlockFlags& unblocked_flags)
-    : FileDescriptionBlocker(description, (BlockFlags)((u32)BlockFlags::Connect | (u32)BlockFlags::Exception), unblocked_flags)
+    : FileDescriptionBlocker(description, BlockFlags::Connect | BlockFlags::Exception, unblocked_flags)
 {
 }
 
 Thread::WriteBlocker::WriteBlocker(FileDescription& description, BlockFlags& unblocked_flags)
-    : FileDescriptionBlocker(description, (BlockFlags)((u32)BlockFlags::Write | (u32)BlockFlags::Exception), unblocked_flags)
+    : FileDescriptionBlocker(description, BlockFlags::Write | BlockFlags::Exception, unblocked_flags)
 {
 }
 
@@ -295,7 +295,7 @@ auto Thread::WriteBlocker::override_timeout(const BlockTimeout& timeout) -> cons
 }
 
 Thread::ReadBlocker::ReadBlocker(FileDescription& description, BlockFlags& unblocked_flags)
-    : FileDescriptionBlocker(description, (BlockFlags)((u32)BlockFlags::Read | (u32)BlockFlags::Exception), unblocked_flags)
+    : FileDescriptionBlocker(description, BlockFlags::Read | BlockFlags::Exception, unblocked_flags)
 {
 }
 

--- a/Kernel/VM/MemoryManager.cpp
+++ b/Kernel/VM/MemoryManager.cpp
@@ -489,7 +489,7 @@ PageFaultResponse MemoryManager::handle_page_fault(const PageFault& fault)
     return region->handle_fault(fault, lock);
 }
 
-OwnPtr<Region> MemoryManager::allocate_contiguous_kernel_region(size_t size, String name, u8 access, size_t physical_alignment, Region::Cacheable cacheable)
+OwnPtr<Region> MemoryManager::allocate_contiguous_kernel_region(size_t size, String name, Region::Access access, size_t physical_alignment, Region::Cacheable cacheable)
 {
     VERIFY(!(size % PAGE_SIZE));
     ScopedSpinLock lock(s_mm_lock);
@@ -500,7 +500,7 @@ OwnPtr<Region> MemoryManager::allocate_contiguous_kernel_region(size_t size, Str
     return allocate_kernel_region_with_vmobject(range.value(), vmobject, move(name), access, cacheable);
 }
 
-OwnPtr<Region> MemoryManager::allocate_kernel_region(size_t size, String name, u8 access, AllocationStrategy strategy, Region::Cacheable cacheable)
+OwnPtr<Region> MemoryManager::allocate_kernel_region(size_t size, String name, Region::Access access, AllocationStrategy strategy, Region::Cacheable cacheable)
 {
     VERIFY(!(size % PAGE_SIZE));
     ScopedSpinLock lock(s_mm_lock);
@@ -513,7 +513,7 @@ OwnPtr<Region> MemoryManager::allocate_kernel_region(size_t size, String name, u
     return allocate_kernel_region_with_vmobject(range.value(), vmobject.release_nonnull(), move(name), access, cacheable);
 }
 
-OwnPtr<Region> MemoryManager::allocate_kernel_region(PhysicalAddress paddr, size_t size, String name, u8 access, Region::Cacheable cacheable)
+OwnPtr<Region> MemoryManager::allocate_kernel_region(PhysicalAddress paddr, size_t size, String name, Region::Access access, Region::Cacheable cacheable)
 {
     VERIFY(!(size % PAGE_SIZE));
     ScopedSpinLock lock(s_mm_lock);
@@ -526,7 +526,7 @@ OwnPtr<Region> MemoryManager::allocate_kernel_region(PhysicalAddress paddr, size
     return allocate_kernel_region_with_vmobject(range.value(), *vmobject, move(name), access, cacheable);
 }
 
-OwnPtr<Region> MemoryManager::allocate_kernel_region_identity(PhysicalAddress paddr, size_t size, String name, u8 access, Region::Cacheable cacheable)
+OwnPtr<Region> MemoryManager::allocate_kernel_region_identity(PhysicalAddress paddr, size_t size, String name, Region::Access access, Region::Cacheable cacheable)
 {
     VERIFY(!(size % PAGE_SIZE));
     ScopedSpinLock lock(s_mm_lock);
@@ -539,7 +539,7 @@ OwnPtr<Region> MemoryManager::allocate_kernel_region_identity(PhysicalAddress pa
     return allocate_kernel_region_with_vmobject(range.value(), *vmobject, move(name), access, cacheable);
 }
 
-OwnPtr<Region> MemoryManager::allocate_kernel_region_with_vmobject(const Range& range, VMObject& vmobject, String name, u8 access, Region::Cacheable cacheable)
+OwnPtr<Region> MemoryManager::allocate_kernel_region_with_vmobject(const Range& range, VMObject& vmobject, String name, Region::Access access, Region::Cacheable cacheable)
 {
     ScopedSpinLock lock(s_mm_lock);
     auto region = Region::create_kernel_only(range, vmobject, 0, move(name), access, cacheable);
@@ -548,7 +548,7 @@ OwnPtr<Region> MemoryManager::allocate_kernel_region_with_vmobject(const Range& 
     return region;
 }
 
-OwnPtr<Region> MemoryManager::allocate_kernel_region_with_vmobject(VMObject& vmobject, size_t size, String name, u8 access, Region::Cacheable cacheable)
+OwnPtr<Region> MemoryManager::allocate_kernel_region_with_vmobject(VMObject& vmobject, size_t size, String name, Region::Access access, Region::Cacheable cacheable)
 {
     VERIFY(!(size % PAGE_SIZE));
     ScopedSpinLock lock(s_mm_lock);

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -163,12 +163,12 @@ public:
     void deallocate_user_physical_page(const PhysicalPage&);
     void deallocate_supervisor_physical_page(const PhysicalPage&);
 
-    OwnPtr<Region> allocate_contiguous_kernel_region(size_t, String name, u8 access, size_t physical_alignment = PAGE_SIZE, Region::Cacheable = Region::Cacheable::Yes);
-    OwnPtr<Region> allocate_kernel_region(size_t, String name, u8 access, AllocationStrategy strategy = AllocationStrategy::Reserve, Region::Cacheable = Region::Cacheable::Yes);
-    OwnPtr<Region> allocate_kernel_region(PhysicalAddress, size_t, String name, u8 access, Region::Cacheable = Region::Cacheable::Yes);
-    OwnPtr<Region> allocate_kernel_region_identity(PhysicalAddress, size_t, String name, u8 access, Region::Cacheable = Region::Cacheable::Yes);
-    OwnPtr<Region> allocate_kernel_region_with_vmobject(VMObject&, size_t, String name, u8 access, Region::Cacheable = Region::Cacheable::Yes);
-    OwnPtr<Region> allocate_kernel_region_with_vmobject(const Range&, VMObject&, String name, u8 access, Region::Cacheable = Region::Cacheable::Yes);
+    OwnPtr<Region> allocate_contiguous_kernel_region(size_t, String name, Region::Access access, size_t physical_alignment = PAGE_SIZE, Region::Cacheable = Region::Cacheable::Yes);
+    OwnPtr<Region> allocate_kernel_region(size_t, String name, Region::Access access, AllocationStrategy strategy = AllocationStrategy::Reserve, Region::Cacheable = Region::Cacheable::Yes);
+    OwnPtr<Region> allocate_kernel_region(PhysicalAddress, size_t, String name, Region::Access access, Region::Cacheable = Region::Cacheable::Yes);
+    OwnPtr<Region> allocate_kernel_region_identity(PhysicalAddress, size_t, String name, Region::Access access, Region::Cacheable = Region::Cacheable::Yes);
+    OwnPtr<Region> allocate_kernel_region_with_vmobject(VMObject&, size_t, String name, Region::Access access, Region::Cacheable = Region::Cacheable::Yes);
+    OwnPtr<Region> allocate_kernel_region_with_vmobject(const Range&, VMObject&, String name, Region::Access access, Region::Cacheable = Region::Cacheable::Yes);
 
     unsigned user_physical_pages() const { return m_user_physical_pages; }
     unsigned user_physical_pages_used() const { return m_user_physical_pages_used; }

--- a/Kernel/VM/TypedMapping.h
+++ b/Kernel/VM/TypedMapping.h
@@ -44,7 +44,7 @@ struct TypedMapping {
 };
 
 template<typename T>
-static TypedMapping<T> map_typed(PhysicalAddress paddr, size_t length, u8 access = Region::Access::Read)
+static TypedMapping<T> map_typed(PhysicalAddress paddr, size_t length, Region::Access access = Region::Access::Read)
 {
     TypedMapping<T> table;
     table.region = MM.allocate_kernel_region(paddr.page_base(), page_round_up(length), {}, access);

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -389,7 +389,7 @@ void Widget::handle_mouseup_event(MouseEvent& event)
 
 void Widget::handle_mousedown_event(MouseEvent& event)
 {
-    if (((unsigned)focus_policy() & (unsigned)FocusPolicy::ClickFocus))
+    if (has_flag(focus_policy(), FocusPolicy::ClickFocus))
         set_focus(true, FocusSource::Mouse);
     mousedown_event(event);
     if (event.button() == MouseButton::Right) {

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/EnumBits.h>
 #include <AK/JsonObject.h>
 #include <AK/String.h>
 #include <LibCore/Object.h>
@@ -79,6 +80,8 @@ enum class FocusPolicy {
     ClickFocus = 0x2,
     StrongFocus = TabFocus | ClickFocus,
 };
+
+AK_ENUM_BITWISE_OPERATORS(FocusPolicy)
 
 class Widget : public Core::Object {
     C_OBJECT(Widget)

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -831,10 +831,10 @@ Vector<Widget*> Window::focusable_widgets(FocusSource source) const
         bool widget_accepts_focus = false;
         switch (source) {
         case FocusSource::Keyboard:
-            widget_accepts_focus = ((unsigned)widget.focus_policy() & (unsigned)FocusPolicy::TabFocus);
+            widget_accepts_focus = has_flag(widget.focus_policy(), FocusPolicy::TabFocus);
             break;
         case FocusSource::Mouse:
-            widget_accepts_focus = ((unsigned)widget.focus_policy() & (unsigned)FocusPolicy::ClickFocus);
+            widget_accepts_focus = has_flag(widget.focus_policy(), FocusPolicy::ClickFocus);
             break;
         case FocusSource::Programmatic:
             widget_accepts_focus = widget.focus_policy() != FocusPolicy::NoFocus;


### PR DESCRIPTION
This change introduces `AK_ENUM_BITWISE_OPERATORS(..)` which when
enabled for an enum, will automatically declare all the necessary
bitwise operators for that enum.
    
This allows bit masks enums to be used as first class, type safe, citizens and
starts switching some Kernel and LibGUI code to start using it. 
