### PR TITLE
Kernel: Fix unaligned read inside map_ebda()

### DIFF
--- a/Kernel/Arch/PC/BIOS.cpp
+++ b/Kernel/Arch/PC/BIOS.cpp
@@ -43,10 +43,11 @@ MappedROM map_bios()
 MappedROM map_ebda()
 {
     auto ebda_segment_ptr = map_typed<u16>(PhysicalAddress(0x40e));
-    auto ebda_length_ptr = map_typed<u16>(PhysicalAddress(0x413));
+    auto ebda_length_ptr_b0 = map_typed<u8>(PhysicalAddress(0x413));
+    auto ebda_length_ptr_b1 = map_typed<u8>(PhysicalAddress(0x414));
 
     PhysicalAddress ebda_paddr(*ebda_segment_ptr << 4);
-    size_t ebda_size = *ebda_length_ptr;
+    size_t ebda_size = (*ebda_length_ptr_b1 << 8) | *ebda_length_ptr_b0;
 
     MappedROM mapping;
     mapping.region = MM.allocate_kernel_region(ebda_paddr.page_base(), page_round_up(ebda_size), {}, Region::Access::Read);


### PR DESCRIPTION
Fixes this KUBSAN warning:
```
[#0 Kernel]: Early access to ACPI tables for interrupt setup
[#0 Kernel]: KUBSAN: reference binding to misaligned address 0xc1104413 of type 'short unsigned int'
[#0 Kernel]: KUBSAN: at .././Kernel/VM/TypedMapping.h, line 41, column: 33
[#0 Kernel]: 0xc04bb7c7 (next: 0xc0107f38)
[#0 Kernel]: 0xc04bd866 (next: 0xc0107fd8)
[#0 Kernel]: 0xc0120d54 (next: 0xc0108058)
[#0 Kernel]: 0xc05c31fe (next: 0xc01080c8)
[#0 Kernel]: 0xc05e8314 (next: 0xc0108128)
[#0 Kernel]: 0xc05e86ef (next: 0xc0108178)
[#0 Kernel]: 0xc05e87a1 (next: 0xc01081b8)
[#0 Kernel]: 0xc060ea46 (next: 0xc0108298)
[#0 Kernel]: 0xc0100145 (next: 0x00000000)
[#0 Kernel]: KUBSAN: load of misaligned address 0xc1104413 of type 'short unsigned int'
[#0 Kernel]: KUBSAN: at ../Kernel/Arch/PC/BIOS.cpp, line 49, column: 24
[#0 Kernel]: 0xc04bb7c7 (next: 0xc0107f38)
[#0 Kernel]: 0xc04bd866 (next: 0xc0107fd8)
[#0 Kernel]: 0xc0120d72 (next: 0xc0108058)
[#0 Kernel]: 0xc05c31fe (next: 0xc01080c8)
[#0 Kernel]: 0xc05e8314 (next: 0xc0108128)
[#0 Kernel]: 0xc05e86ef (next: 0xc0108178)
[#0 Kernel]: 0xc05e87a1 (next: 0xc01081b8)
[#0 Kernel]: 0xc060ea46 (next: 0xc0108298)
[#0 Kernel]: 0xc0100145 (next: 0x00000000)
[Kernel]: Interrupts: Switch to Legacy PIC mode
[Kernel]: PIC(i8259): cascading mode, vectors 0x50-0x5f
[#0 Kernel]: Trying to unregister unused handler (?)
[#0 Kernel]: Trying to unregister unused handler (?)
[#0 Kernel]: Interrupts: Detected Dual i8259
[#0 Kernel]: KUBSAN: reference binding to misaligned address 0xc1104413 of type 'short unsigned int'
[#0 Kernel]: KUBSAN: at .././Kernel/VM/TypedMapping.h, line 41, column: 33
[#0 Kernel]: 0xc04bb7c7 (next: 0xc0107fd8)
[#0 Kernel]: 0xc04bd866 (next: 0xc0108078)
[#0 Kernel]: 0xc0120d54 (next: 0xc01080f8)
[#0 Kernel]: 0xc05c31fe (next: 0xc0108168)
[#0 Kernel]: 0xc05bf441 (next: 0xc01081b8)
[#0 Kernel]: 0xc060ea4b (next: 0xc0108298)
[#0 Kernel]: 0xc0100145 (next: 0x00000000)
[#0 Kernel]: KUBSAN: load of misaligned address 0xc1104413 of type 'short unsigned int'
[#0 Kernel]: KUBSAN: at ../Kernel/Arch/PC/BIOS.cpp, line 49, column: 24
[#0 Kernel]: 0xc04bb7c7 (next: 0xc0107fd8)
[#0 Kernel]: 0xc04bd866 (next: 0xc0108078)
[#0 Kernel]: 0xc0120d72 (next: 0xc01080f8)
[#0 Kernel]: 0xc05c31fe (next: 0xc0108168)
[#0 Kernel]: 0xc05bf441 (next: 0xc01081b8)
[#0 Kernel]: 0xc060ea4b (next: 0xc0108298)
[#0 Kernel]: 0xc0100145 (next: 0x00000000)
[Kernel]: ACPI: Using RSDP @ P0x000f5ab0
``` 