### PR TITLE
Kernel+Fuzzing: Harden Kernel just a tad more, add sysctl for deadliness of UBSan

### DIFF
--- a/AK/Tests/TestChecked.cpp
+++ b/AK/Tests/TestChecked.cpp
@@ -118,6 +118,27 @@ TEST_CASE(detects_signed_overflow)
     EXPECT((Checked<i64>(-0x4000000000000000) - Checked<i64>(0x4000000000000001)).has_overflow());
 }
 
+TEST_CASE(detects_unsigned_overflow)
+{
+    EXPECT(!(Checked<u32>(0x40000000) + Checked<u32>(0x3fffffff)).has_overflow());
+    EXPECT(!(Checked<u32>(0x40000000) + Checked<u32>(0x40000000)).has_overflow());
+    EXPECT(!(Checked<u32>(0xf0000000) + Checked<u32>(0x0fffffff)).has_overflow());
+    EXPECT((Checked<u32>(0xf0000000) + Checked<u32>(0x10000000)).has_overflow());
+
+    EXPECT(!(Checked<u32>(0x40000000) - Checked<u32>(0x3fffffff)).has_overflow());
+    EXPECT(!(Checked<u32>(0x40000000) - Checked<u32>(0x40000000)).has_overflow());
+    EXPECT((Checked<u32>(0x40000000) - Checked<u32>(0x40000001)).has_overflow());
+
+    EXPECT(!(Checked<u64>(0x4000000000000000) + Checked<u64>(0x3fffffffffffffff)).has_overflow());
+    EXPECT(!(Checked<u64>(0x4000000000000000) + Checked<u64>(0x4000000000000000)).has_overflow());
+    EXPECT(!(Checked<u64>(0xf000000000000000) + Checked<u64>(0x0fffffffffffffff)).has_overflow());
+    EXPECT((Checked<u64>(0xf000000000000000) + Checked<u64>(0x1000000000000000)).has_overflow());
+
+    EXPECT(!(Checked<u64>(0x4000000000000000) - Checked<u64>(0x3fffffffffffffff)).has_overflow());
+    EXPECT(!(Checked<u64>(0x4000000000000000) - Checked<u64>(0x4000000000000000)).has_overflow());
+    EXPECT((Checked<u64>(0x4000000000000000) - Checked<u64>(0x4000000000000001)).has_overflow());
+}
+
 TEST_CASE(should_constexpr_default_construct)
 {
     constexpr Checked<int> checked_value {};

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -59,6 +59,7 @@
 #include <Kernel/Scheduler.h>
 #include <Kernel/StdLib.h>
 #include <Kernel/TTY/TTY.h>
+#include <Kernel/UBSanitizer.h>
 #include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/MemoryManager.h>
 #include <LibC/errno_numbers.h>
@@ -994,12 +995,18 @@ void ProcFS::add_sys_string(String&& name, Lockable<String>& var, Function<void(
 bool ProcFS::initialize()
 {
     static Lockable<bool>* kmalloc_stack_helper;
+    static Lockable<bool>* ubsan_deadly_helper;
 
     if (kmalloc_stack_helper == nullptr) {
         kmalloc_stack_helper = new Lockable<bool>();
         kmalloc_stack_helper->resource() = g_dump_kmalloc_stacks;
         ProcFS::add_sys_bool("kmalloc_stacks", *kmalloc_stack_helper, [] {
             g_dump_kmalloc_stacks = kmalloc_stack_helper->resource();
+        });
+        ubsan_deadly_helper = new Lockable<bool>();
+        ubsan_deadly_helper->resource() = UBSanitizer::g_ubsan_is_deadly;
+        ProcFS::add_sys_bool("ubsan_is_deadly", *ubsan_deadly_helper, [] {
+            UBSanitizer::g_ubsan_is_deadly = ubsan_deadly_helper->resource();
         });
     }
     return true;

--- a/Kernel/UBSanitizer.cpp
+++ b/Kernel/UBSanitizer.cpp
@@ -26,10 +26,13 @@
 
 #include <AK/Format.h>
 #include <Kernel/KSyms.h>
+#include <Kernel/Panic.h>
 #include <Kernel/UBSanitizer.h>
 
 using namespace Kernel;
 using namespace Kernel::UBSanitizer;
+
+bool Kernel::UBSanitizer::g_ubsan_is_deadly { true };
 
 extern "C" {
 
@@ -37,11 +40,12 @@ static void print_location(const SourceLocation& location)
 {
     if (!location.filename()) {
         dbgln("KUBSAN: in unknown file");
-
     } else {
         dbgln("KUBSAN: at {}, line {}, column: {}", location.filename(), location.line(), location.column());
     }
     dump_backtrace();
+    if (g_ubsan_is_deadly)
+        PANIC("UB is configured to be deadly.");
 }
 
 void __ubsan_handle_load_invalid_value(const InvalidValueData&, ValueHandle);

--- a/Kernel/UBSanitizer.h
+++ b/Kernel/UBSanitizer.h
@@ -30,6 +30,8 @@
 
 namespace Kernel::UBSanitizer {
 
+extern bool g_ubsan_is_deadly;
+
 typedef void* ValueHandle;
 
 class SourceLocation {

--- a/Userland/Tests/Kernel/fuzz-syscalls.cpp
+++ b/Userland/Tests/Kernel/fuzz-syscalls.cpp
@@ -51,6 +51,28 @@ static bool is_nosys_syscall(int fn)
     return fn == SC_futex;
 }
 
+static bool is_bad_idea(int fn, const size_t* direct_sc_args, const size_t* fake_sc_params, const char* some_string)
+{
+    switch (fn) {
+    case SC_mprotect:
+        // This would mess with future tests or crash the fuzzer.
+        return direct_sc_args[0] == (size_t)fake_sc_params || direct_sc_args[0] == (size_t)some_string;
+    case SC_read:
+    case SC_readv:
+        // FIXME: Known bug: https://github.com/SerenityOS/serenity/issues/5328
+        return direct_sc_args[0] == 1;
+    case SC_write:
+    case SC_writev:
+        // FIXME: Known bug: https://github.com/SerenityOS/serenity/issues/5328
+        return direct_sc_args[0] == 0;
+    case SC_pledge:
+        // Equivalent to pledge(nullptr, _), which would kill the fuzzer.
+        return direct_sc_args[0] == (size_t)fake_sc_params && fake_sc_params[1] == 0;
+    default:
+        return false;
+    }
+}
+
 static void do_systematic_tests()
 {
     int rc;
@@ -119,7 +141,7 @@ static void do_random_tests()
 
     size_t direct_sc_args[3] = { 0 };
     // Isolate to a separate region to make corruption less likely, because we will write to it:
-    size_t* fake_sc_params = reinterpret_cast<size_t*>(mmap(nullptr, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_RANDOMIZED, 0, 0));
+    auto* fake_sc_params = reinterpret_cast<size_t*>(mmap(nullptr, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_RANDOMIZED, 0, 0));
     const char* some_string = "Hello, world!";
     Vector<size_t> interesting_values = {
         0,
@@ -132,23 +154,20 @@ static void do_random_tests()
         0xffffffff,
     };
     dbgln("Doing a few random syscalls with:");
-    for (size_t i = 0; i < interesting_values.size(); ++i) {
-        dbgln("  {0} ({0:p})", interesting_values[i]);
+    for (unsigned long& interesting_value : interesting_values) {
+        dbgln("  {0} ({0:p})", interesting_value);
     }
     for (size_t i = 0; i < fuzz_syscall_count; ++i) {
         // Construct a nice syscall:
         int syscall_fn = arc4random_uniform(Syscall::Function::__Count);
-        if (is_deadly_syscall(syscall_fn) || is_unfuzzable_syscall(syscall_fn)) {
-            // Retry, and don't count towards syscall limit.
-            --i;
-            continue;
-        }
         randomize_from(direct_sc_args, array_size(direct_sc_args), interesting_values);
         randomize_from(fake_sc_params, fake_params_count, interesting_values);
 
-        if (syscall_fn == SC_mprotect && direct_sc_args[0] == (size_t)fake_sc_params) {
-            // Actually, that's a terrible idea.
-            // Pretend we don't want to try that.
+        if (is_deadly_syscall(syscall_fn)
+            || is_unfuzzable_syscall(syscall_fn)
+            || is_bad_idea(syscall_fn, direct_sc_args, fake_sc_params, some_string)) {
+            // Retry, and don't count towards syscall limit.
+            --i;
             continue;
         }
 


### PR DESCRIPTION
This PR:
- Makes `fuzz-syscalls` less brittle, and fixes what may be the last bug findable by such a simple program (`sys$create_thread`, a silly technicality)
- Adds an "obviously missing" Test for `AK::Checked<unsigned>`
- Adds a sysctl (`/proc/sys/ubsan_is_deadly`) to immediately panic the Kernel on UB.
- Perhaps most controversially: This PR makes `ubsan_is_deadly` enabled by default. This is possible since @boricj [fixed](https://github.com/SerenityOS/serenity/pull/5674) what seems to be the last UB during boot. Hooray! :partying_face: 

I'm really not sure whether `ubsan_is_deadly` should be enabled by default, but this flag helped me during fuzzing and will probably be interesting during future testing/fuzzing, too.