### PR TITLE
LibCompress: Rename libcompression.so to libcompress.so

### DIFF
--- a/Ports/SDL2_ttf/package.sh
+++ b/Ports/SDL2_ttf/package.sh
@@ -10,5 +10,5 @@ configure() {
     run ./configure \
         --host=${SERENITY_ARCH}-pc-serenity \
         --with-sdl-prefix=${SERENITY_ROOT}/Build/Root/usr \
-        LIBS="-lgui -lgfx -lipc -lcore -lcompression"
+        LIBS="-lgui -lgfx -lipc -lcore -lcompress"
 }

--- a/Userland/Libraries/LibCompress/CMakeLists.txt
+++ b/Userland/Libraries/LibCompress/CMakeLists.txt
@@ -4,5 +4,5 @@ set(SOURCES
     Gzip.cpp
 )
 
-serenity_lib(LibCompress compression)
+serenity_lib(LibCompress compress)
 target_link_libraries(LibCompress LibC LibCrypto)


### PR DESCRIPTION
Andreas mentioned this small discrepancy in his Diablo vid, so let's rename the library file.