### PR TITLE
AK: Take advantage of constexpr in Time and add time conversion methods

### DIFF
--- a/AK/Time.h
+++ b/AK/Time.h
@@ -117,8 +117,8 @@ private:
 
     static Time from_half_sanitized(i64 seconds, i32 extra_seconds, u32 nanoseconds);
 
-    i64 m_seconds;
-    u32 m_nanoseconds; // Always less than 1'000'000'000
+    i64 m_seconds { 0 };
+    u32 m_nanoseconds { 0 }; // Always less than 1'000'000'000
 };
 
 template<typename TimevalType>


### PR DESCRIPTION
By making the Time constructor constexpr we can optimize creating a
Time instance from hardcoded values.

Also add more functions to convert between Time and various time units.

Since we tell the compiler to provide a default constructor we
need to initialize the member variables.

_I found myself missing these functions for some Time calculations_