### PR TITLE
LibCrypto: Fail with overflow when bitfield has too many unused bits

### DIFF
--- a/Userland/Libraries/LibCrypto/ASN1/DER.cpp
+++ b/Userland/Libraries/LibCrypto/ASN1/DER.cpp
@@ -196,7 +196,12 @@ Result<const BitmapView, DecodeError> Decoder::decode_bit_string(ReadonlyBytes d
         return DecodeError::InvalidInputFormat;
 
     auto unused_bits = data[0];
-    return BitmapView { const_cast<u8*>(data.offset_pointer(1)), data.size() * 8 - unused_bits };
+    auto total_size_in_bits = data.size() * 8;
+
+    if (unused_bits > total_size_in_bits)
+        return DecodeError::Overflow;
+
+    return BitmapView { const_cast<u8*>(data.offset_pointer(1)), total_size_in_bits - unused_bits };
 }
 
 Result<Tag, DecodeError> Decoder::peek()


### PR DESCRIPTION
There cannot be more unused bits than the entirety of the input.
Found by OSS-Fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31706#c1