### PR TITLE
Shell: Don't blindly dereference the result of Parser::parse()

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1582,7 +1582,11 @@ bool Shell::has_history_event(StringView source)
         bool has_history_event { false };
     } visitor;
 
-    Parser { source, true }.parse()->visit(visitor);
+    auto ast = Parser { source, true }.parse();
+    if (!ast)
+        return false;
+
+    ast->visit(visitor);
     return visitor.has_history_event;
 }
 


### PR DESCRIPTION
It _may_ return nullptr if there's nothing to return.
Fixes #5691.