### PR TITLE
Make UserspaceEmulator emulate again!

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -99,7 +99,7 @@ private:
     u32 virt$mmap(u32);
     FlatPtr virt$mremap(FlatPtr);
     u32 virt$mount(u32);
-    u32 virt$munmap(FlatPtr address, u32 size);
+    u32 virt$munmap(FlatPtr address, size_t size);
     u32 virt$gettid();
     u32 virt$getpid();
     u32 virt$unveil(u32);

--- a/Userland/DevTools/UserspaceEmulator/MmapRegion.cpp
+++ b/Userland/DevTools/UserspaceEmulator/MmapRegion.cpp
@@ -223,6 +223,19 @@ void MmapRegion::write64(u32 offset, ValueWithShadow<u64> value)
     *reinterpret_cast<u64*>(m_shadow_data + offset) = value.shadow();
 }
 
+NonnullOwnPtr<MmapRegion> MmapRegion::split_at(VirtualAddress offset)
+{
+    VERIFY(!m_malloc);
+    VERIFY(!m_malloc_metadata);
+    Range new_range = range();
+    Range other_range = new_range.split_at(offset);
+    auto other_region = adopt_own(*new MmapRegion(other_range.base().get(), other_range.size(), prot(), data() + new_range.size(), shadow_data() + new_range.size()));
+    other_region->m_file_backed = m_file_backed;
+    other_region->m_name = m_name;
+    set_range(new_range);
+    return other_region;
+}
+
 void MmapRegion::set_prot(int prot)
 {
     set_readable(prot & PROT_READ);

--- a/Userland/DevTools/UserspaceEmulator/MmapRegion.h
+++ b/Userland/DevTools/UserspaceEmulator/MmapRegion.h
@@ -64,7 +64,7 @@ public:
     const String& name() const { return m_name; }
 
 private:
-    MmapRegion(u32 base, u32 size, int prot);
+    MmapRegion(u32 base, u32 size, int prot, u8* data, u8* shadow_data);
 
     u8* m_data { nullptr };
     u8* m_shadow_data { nullptr };

--- a/Userland/DevTools/UserspaceEmulator/MmapRegion.h
+++ b/Userland/DevTools/UserspaceEmulator/MmapRegion.h
@@ -56,6 +56,12 @@ public:
     bool is_malloc_block() const { return m_malloc; }
     void set_malloc(bool b) { m_malloc = b; }
 
+    NonnullOwnPtr<MmapRegion> split_at(VirtualAddress);
+
+    int prot() const
+    {
+        return (is_readable() ? PROT_READ : 0) | (is_writable() ? PROT_WRITE : 0) | (is_executable() ? PROT_EXEC : 0);
+    }
     void set_prot(int prot);
 
     MallocRegionMetadata* malloc_metadata() { return m_malloc_metadata; }

--- a/Userland/DevTools/UserspaceEmulator/Range.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Range.cpp
@@ -29,7 +29,7 @@
 
 namespace UserspaceEmulator {
 
-Vector<Range, 2> Range::carve(const Range& taken)
+Vector<Range, 2> Range::carve(const Range& taken) const
 {
     VERIFY((taken.size() % PAGE_SIZE) == 0);
     Vector<Range, 2> parts;

--- a/Userland/DevTools/UserspaceEmulator/Range.h
+++ b/Userland/DevTools/UserspaceEmulator/Range.h
@@ -67,7 +67,18 @@ public:
         return contains(other.base(), other.size());
     }
 
-    Vector<Range, 2> carve(const Range&);
+    Vector<Range, 2> carve(const Range&) const;
+
+    Range split_at(VirtualAddress address)
+    {
+        VERIFY(address.is_page_aligned());
+        VERIFY(m_base < address);
+        size_t new_size = (address - m_base).get();
+        VERIFY(new_size < m_size);
+        size_t other_size = m_size - new_size;
+        m_size = new_size;
+        return { address, other_size };
+    }
 
 private:
     VirtualAddress m_base;

--- a/Userland/DevTools/UserspaceEmulator/Region.h
+++ b/Userland/DevTools/UserspaceEmulator/Region.h
@@ -81,6 +81,7 @@ public:
 
 protected:
     Region(u32 base, u32 size);
+    void set_range(Range r) { m_range = r; };
 
 private:
     Emulator& m_emulator;

--- a/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
@@ -61,6 +61,38 @@ void SoftMMU::remove_region(Region& region)
     m_regions.remove_first_matching([&](auto& entry) { return entry.ptr() == &region; });
 }
 
+void SoftMMU::ensure_split_at(X86::LogicalAddress address)
+{
+    // FIXME: If this fails, call Emulator::dump_backtrace
+    VERIFY(address.selector() != 0x2b);
+
+    u32 offset = address.offset();
+    VERIFY((offset & (PAGE_SIZE - 1)) == 0);
+    size_t page_index = address.offset() / PAGE_SIZE;
+
+    if (!page_index)
+        return;
+    if (m_page_to_region_map[page_index - 1] != m_page_to_region_map[page_index])
+        return;
+    if (!m_page_to_region_map[page_index])
+        return;
+
+    // If we get here, we know that the page exists and belongs to a region, that there is
+    // a previous page, and that it belongs to the same region.
+    VERIFY(is<MmapRegion>(m_page_to_region_map[page_index]));
+    MmapRegion* old_region = static_cast<MmapRegion*>(m_page_to_region_map[page_index]);
+    NonnullOwnPtr<MmapRegion> new_region = old_region->split_at(VirtualAddress(offset));
+
+    size_t first_page_in_region = new_region->base() / PAGE_SIZE;
+    size_t last_page_in_region = (new_region->base() + new_region->size() - 1) / PAGE_SIZE;
+    for (size_t page = first_page_in_region; page <= last_page_in_region; ++page) {
+        VERIFY(m_page_to_region_map[page] == old_region);
+        m_page_to_region_map[page] = new_region.ptr();
+    }
+
+    m_regions.append(move(new_region));
+}
+
 void SoftMMU::set_tls_region(NonnullOwnPtr<Region> region)
 {
     VERIFY(!m_tls_region);

--- a/Userland/DevTools/UserspaceEmulator/SoftMMU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftMMU.h
@@ -63,6 +63,7 @@ public:
 
     void add_region(NonnullOwnPtr<Region>);
     void remove_region(Region&);
+    void ensure_split_at(X86::LogicalAddress);
 
     void set_tls_region(NonnullOwnPtr<Region>);
 

--- a/Userland/DevTools/UserspaceEmulator/SoftMMU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftMMU.h
@@ -57,7 +57,7 @@ public:
         if (address.selector() == 0x2b)
             return m_tls_region.ptr();
 
-        size_t page_index = (address.offset() & ~(PAGE_SIZE - 1)) / PAGE_SIZE;
+        size_t page_index = address.offset() / PAGE_SIZE;
         return m_page_to_region_map[page_index];
     }
 


### PR DESCRIPTION
Welp, noone fixed it so I did.

Note that memory-region-splitting is a bit easier in UE than in the Kernel because UE can afford to keep a 3.1 MB `m_page_to_region_map` around. ( … If someone were to implement some kind of interval-map data-structure, this could be implemented much more efficiently. So efficiently that we could think about making the Kernel use the same one …)

Closes #5663.