### PR TITLE
LibCore+TextEditor: Introduce LibCore::MimeType, and use it to check when opening files in TextEditor

### DIFF
--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -84,7 +84,7 @@ Result<bool, String> Workbook::load(const StringView& filename)
 
     auto mime = Core::guess_mime_type_based_on_filename(filename);
 
-    if (mime == "text/csv") {
+    if (mime.has_value() && mime->as_string() == "text/csv") {
         // FIXME: Prompt the user for settings.
         NonnullRefPtrVector<Sheet> sheets;
 
@@ -154,7 +154,7 @@ Result<bool, String> Workbook::save(const StringView& filename)
         return sb.to_string();
     }
 
-    if (mime == "text/csv") {
+    if (mime.has_value() && mime->as_string() == "text/csv") {
         // FIXME: Prompt the user for settings and which sheet to export.
         Core::OutputFileStream stream { file };
         auto data = m_sheets[0].to_xsv();

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -90,8 +90,8 @@ int main(int argc, char** argv)
 
     if (file_to_edit)
         text_widget.open_file(file_to_edit);
-    else
-        text_widget.update_title();
+
+    text_widget.update_title();
 
     if (initial_line_number != 0)
         text_widget.editor().set_cursor_and_focus_line(initial_line_number - 1, 0);

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
     LocalServer.cpp
     LocalSocket.cpp
     MimeData.cpp
+    MimeType.cpp
     NetworkJob.cpp
     NetworkResponse.cpp
     Notifier.cpp

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, James Puleo <james@jame.xyz>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -70,33 +71,45 @@ void MimeData::set_text(const String& text)
     set_data("text/plain", text.to_byte_buffer());
 }
 
-String guess_mime_type_based_on_filename(const StringView& path)
+Optional<Core::MimeType> guess_mime_type_based_on_filename(const StringView& path)
 {
+    // TODO: This probably should be a JSON file soon...
     if (path.ends_with(".pbm", CaseSensitivity::CaseInsensitive))
-        return "image/x‑portable‑bitmap";
+        return Core::MimeType(Core::MimeType::Type::image, "x‑portable‑bitmap");
     if (path.ends_with(".pgm", CaseSensitivity::CaseInsensitive))
-        return "image/x‑portable‑graymap";
+        return Core::MimeType(Core::MimeType::Type::image, "x‑portable‑graymap");
     if (path.ends_with(".png", CaseSensitivity::CaseInsensitive))
-        return "image/png";
+        return Core::MimeType(Core::MimeType::Type::image, "png");
     if (path.ends_with(".ppm", CaseSensitivity::CaseInsensitive))
-        return "image/x‑portable‑pixmap";
+        return Core::MimeType(Core::MimeType::Type::image, "x‑portable‑pixmap");
     if (path.ends_with(".gif", CaseSensitivity::CaseInsensitive))
-        return "image/gif";
+        return Core::MimeType(Core::MimeType::Type::image, "gif");
     if (path.ends_with(".bmp", CaseSensitivity::CaseInsensitive))
-        return "image/bmp";
+        return Core::MimeType(Core::MimeType::Type::image, "bmp");
     if (path.ends_with(".jpg", CaseSensitivity::CaseInsensitive) || path.ends_with(".jpeg", CaseSensitivity::CaseInsensitive))
-        return "image/jpeg";
+        return Core::MimeType(Core::MimeType::Type::image, "jpeg");
     if (path.ends_with(".svg", CaseSensitivity::CaseInsensitive))
-        return "image/svg+xml";
+        return Core::MimeType(Core::MimeType::Type::image, "svg+xml");
     if (path.ends_with(".md", CaseSensitivity::CaseInsensitive))
-        return "text/markdown";
+        return Core::MimeType(Core::MimeType::Type::text, "markdown");
     if (path.ends_with(".html", CaseSensitivity::CaseInsensitive) || path.ends_with(".htm", CaseSensitivity::CaseInsensitive))
-        return "text/html";
+        return Core::MimeType(Core::MimeType::Type::text, "html");
     if (path.ends_with("/", CaseSensitivity::CaseInsensitive))
-        return "text/html";
+        return Core::MimeType(Core::MimeType::Type::text, "html");
     if (path.ends_with(".csv", CaseSensitivity::CaseInsensitive))
-        return "text/csv";
-    return "text/plain";
+        return Core::MimeType(Core::MimeType::Type::text, "csv");
+    if (path.ends_with(".css", CaseSensitivity::CaseInsensitive))
+        return Core::MimeType(Core::MimeType::Type::text, "css");
+    if (path.ends_with(".js", CaseSensitivity::CaseInsensitive))
+        return Core::MimeType(Core::MimeType::Type::text, "javascript");
+    if (path.ends_with(".json", CaseSensitivity::CaseInsensitive))
+        return Core::MimeType(Core::MimeType::Type::application, "json");
+    if (path.ends_with(".txt", CaseSensitivity::CaseInsensitive))
+        return Core::MimeType(Core::MimeType::Type::text, "plain");
+    if (path.ends_with(".xml", CaseSensitivity::CaseInsensitive))
+        return Core::MimeType(Core::MimeType::Type::text, "xml");
+
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibCore/MimeData.h
+++ b/Userland/Libraries/LibCore/MimeData.h
@@ -29,6 +29,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/HashMap.h>
 #include <AK/URL.h>
+#include <LibCore/MimeType.h>
 #include <LibCore/Object.h>
 
 namespace Core {
@@ -67,6 +68,6 @@ private:
     HashMap<String, ByteBuffer> m_data;
 };
 
-String guess_mime_type_based_on_filename(const StringView&);
+Optional<Core::MimeType> guess_mime_type_based_on_filename(const StringView&);
 
 }

--- a/Userland/Libraries/LibCore/MimeType.cpp
+++ b/Userland/Libraries/LibCore/MimeType.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, James Puleo <james@jame.xyz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Vector.h>
+#include <LibCore/MimeType.h>
+
+namespace Core {
+MimeType::MimeType(const String& type, const String& subtype)
+{
+    m_mime = String::formatted("{}/{}", type, subtype);
+    m_type = m_mime.substring_view(0, type.length());
+    m_subtype = m_mime.substring_view(type.length() + 1, m_mime.length() - type.length() - 1);
+}
+
+Optional<MimeType> MimeType::parse(const String& mime)
+{
+    auto parts = mime.split_view('/');
+    if (parts.size() != 2)
+        return {};
+
+    return MimeType(mime, parts[0], parts[1]);
+}
+}

--- a/Userland/Libraries/LibCore/MimeType.h
+++ b/Userland/Libraries/LibCore/MimeType.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, James Puleo <james@jame.xyz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <AK/Traits.h>
+
+namespace Core {
+class MimeType {
+public:
+    MimeType(const String& type, const String& subtype);
+
+    const StringView& type() const { return m_type; }
+    const StringView& subtype() const { return m_subtype; }
+    const String& as_string() const { return m_mime; }
+
+    static Optional<MimeType> parse(const String&);
+
+    bool operator==(const MimeType& other) const
+    {
+        return as_string() == other.as_string();
+    }
+    bool operator!=(const MimeType& other) const { return !(*this == other); }
+
+    struct Type {
+        static constexpr const char* text = "text";
+        static constexpr const char* image = "image";
+        static constexpr const char* audio = "audio";
+        static constexpr const char* video = "video";
+        static constexpr const char* application = "application";
+    };
+
+private:
+    MimeType(String mime, const StringView& type, const StringView& subtype)
+        : m_mime(move(mime))
+        , m_type(type)
+        , m_subtype(subtype)
+    {
+    }
+
+    String m_mime;
+    StringView m_type;
+    StringView m_subtype;
+};
+
+}
+
+namespace AK {
+template<>
+struct Traits<Core::MimeType> : public AK::GenericTraits<Core::MimeType> {
+    static unsigned hash(const Core::MimeType& mime) { return mime.as_string().hash(); }
+};
+}

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -108,7 +108,9 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, const HashMap
         dbgln("No Content-Type header to go on! Guessing based on filename...");
 #endif
         m_encoding = "utf-8"; // FIXME: This doesn't seem nice.
-        m_mime_type = Core::guess_mime_type_based_on_filename(url().path());
+
+        auto mime_type = Core::guess_mime_type_based_on_filename(url().path());
+        m_mime_type = mime_type.has_value() ? mime_type->as_string() : "text/plain";
     }
 
     for_each_client([](auto& client) {

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -129,7 +129,8 @@ void Client::handle_request(ReadonlyBytes raw_request)
 
     Core::InputFileStream stream { file };
 
-    send_response(stream, request, Core::guess_mime_type_based_on_filename(real_path));
+    auto mime_type = Core::guess_mime_type_based_on_filename(real_path);
+    send_response(stream, request, mime_type.has_value() ? mime_type->as_string() : "text/plain");
 }
 
 void Client::send_response(InputStream& response, const HTTP::HttpRequest& request, const String& content_type)


### PR DESCRIPTION
This will prompt the user when opening a file in TextEditor that doesn't have a MIME type of `text`.

Currently, opening binary files in text editor will crash simply because the UTF8 parser doesn't fail gracefully. So at least the user will now know there's a good chance something will go wrong.

Some file types have very bad MIME types assigned to them (_cough_ `application/json` _cough_), and files without any MIME type assigned to them will also ask the user. If _may_ be too annoying, so we might want to only ask for files we know for certain aren't text .