### PR TITLE
Userland: Fix tar/unzip directory traversal vulnerability

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -46,6 +46,7 @@ void LexicalPath::canonicalize()
     }
 
     m_is_absolute = m_string[0] == '/';
+    m_is_dir = m_string.ends_with('/');
     auto parts = m_string.split_view('/');
 
     size_t approximate_canonical_length = 0;
@@ -104,6 +105,10 @@ void LexicalPath::canonicalize()
         if (m_is_absolute || i != 0)
             builder.append('/');
         builder.append(canonical_part);
+    }
+    if (m_is_dir) {
+        builder.append('/');
+        m_dirname = builder.to_string();
     }
     m_parts = move(canonical_parts);
     m_string = builder.to_string();

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -63,6 +63,7 @@ private:
     String m_extension;
     bool m_is_valid { false };
     bool m_is_absolute { false };
+    bool m_is_dir { false };
 };
 
 template<>


### PR DESCRIPTION
This change validates the filenames within a tar/zip archive during
extraction. If the filename within a the archive is outside of the
current working directory the file will be skipped and not extracted
onto the host system.

Closes #3991
Closes #3992