### PR TITLE
Change Toolchain/BuildIt.sh BUILD dir

### DIFF
--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -12,7 +12,7 @@ echo "$DIR"
 ARCH=${ARCH:-"i686"}
 TARGET="$ARCH-pc-serenity"
 PREFIX="$DIR/Local/$ARCH"
-BUILD="$DIR/../Build/$ARCH"
+BUILD="$DIR/../Build"
 SYSROOT="$BUILD/Root"
 
 MAKE="make"


### PR DESCRIPTION
The ports seem to rely on this location for the toolchain's `BUILD`.

More specifically the `zlib` port wouldn't compile with the other location for `BUILD`. `ld` was complaining that it couldn't find `crt0_shared.o`.

I git bisected the issue back to 389dddd4b372b3d29e1629a97315e7432e3f04f1, and this is my attempt at fixing it. @tomuta Was changing `BUILD` necessary for something else? I don't want to break the new `Meta/serenity.sh`.
