### PR TITLE
LibLine: Cleanup the suggestions before inserting a new code point

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1033,6 +1033,9 @@ void Editor::handle_read_event()
             continue;
         }
 
+        // If we got here, manually cleanup the suggestions and then insert the new code point.
+        suggestion_cleanup.disarm();
+        cleanup_suggestions();
         insert(code_point);
     }
 


### PR DESCRIPTION
Otherwise `reposition_cursor()` will move the cursor one character too
far to the right, and since we don't redraw the entire buffer when
the character is inserted at the end, the mistake won't be immediately
fixed by a complete redraw.
Fixes #5722