### PR TITLE
LibGUI+NotificationServer: Support mutable notifications

### DIFF
--- a/Userland/Libraries/LibGUI/Notification.cpp
+++ b/Userland/Libraries/LibGUI/Notification.cpp
@@ -49,6 +49,7 @@ private:
 };
 
 Notification::Notification()
+    : m_connection(NotificationServerConnection::construct())
 {
 }
 
@@ -58,9 +59,8 @@ Notification::~Notification()
 
 void Notification::show()
 {
-    auto connection = NotificationServerConnection::construct();
     auto icon = m_icon ? m_icon->to_shareable_bitmap() : Gfx::ShareableBitmap();
-    connection->send_sync<Messages::NotificationServer::ShowNotification>(m_text, m_title, icon);
+    m_connection->send_sync<Messages::NotificationServer::ShowNotification>(m_text, m_title, icon);
 }
 
 }

--- a/Userland/Libraries/LibGUI/Notification.cpp
+++ b/Userland/Libraries/LibGUI/Notification.cpp
@@ -59,8 +59,16 @@ Notification::~Notification()
 
 void Notification::show()
 {
+    VERIFY(!m_showing);
     auto icon = m_icon ? m_icon->to_shareable_bitmap() : Gfx::ShareableBitmap();
     m_connection->send_sync<Messages::NotificationServer::ShowNotification>(m_text, m_title, icon);
+    m_showing = true;
+}
+void Notification::close()
+{
+    VERIFY(m_showing);
+    m_connection->send_sync<Messages::NotificationServer::CloseNotification>();
+    m_showing = false;
 }
 
 }

--- a/Userland/Libraries/LibGUI/Notification.cpp
+++ b/Userland/Libraries/LibGUI/Notification.cpp
@@ -85,6 +85,52 @@ void Notification::close()
     m_showing = false;
     m_disposed = true;
 }
+
+bool Notification::update()
+{
+    VERIFY(m_showing);
+    VERIFY(!m_disposed);
+    if (!m_connection->is_connected()) {
+        m_showing = false;
+        m_disposed = true;
+        return false;
+    }
+
+    bool is_checked = false;
+
+    if (m_text_dirty || m_title_dirty) {
+        auto response = m_connection->send_sync<Messages::NotificationServer::UpdateNotificationText>(m_text, m_title);
+        m_text_dirty = false;
+        m_title_dirty = false;
+
+        is_checked = true;
+        if (!response->still_showing()) {
+            m_showing = false;
+            m_disposed = true;
+            return false;
+        }
+    }
+
+    if (m_icon_dirty) {
+        auto response = m_connection->send_sync<Messages::NotificationServer::UpdateNotificationIcon>(m_icon ? m_icon->to_shareable_bitmap() : Gfx::ShareableBitmap());
+        m_icon_dirty = false;
+
+        is_checked = true;
+        if (!response->still_showing()) {
+            m_showing = false;
+            m_disposed = true;
+            return false;
+        }
+    }
+
+    if (!is_checked) {
+        auto response = m_connection->send_sync<Messages::NotificationServer::IsShowing>();
+        m_showing = response->still_showing();
+        if (!m_showing) {
+            m_disposed = true;
+        }
+    }
+    return m_showing;
 }
 
 }

--- a/Userland/Libraries/LibGUI/Notification.h
+++ b/Userland/Libraries/LibGUI/Notification.h
@@ -30,6 +30,7 @@
 #include <LibGfx/Bitmap.h>
 
 namespace GUI {
+    class NotificationServerConnection;
 
 class Notification : public Core::Object {
     C_OBJECT(Notification);
@@ -54,6 +55,8 @@ private:
     String m_title;
     String m_text;
     RefPtr<Gfx::Bitmap> m_icon;
+
+    NonnullRefPtr<NotificationServerConnection> m_connection;
 };
 
 }

--- a/Userland/Libraries/LibGUI/Notification.h
+++ b/Userland/Libraries/LibGUI/Notification.h
@@ -60,6 +60,7 @@ private:
 
     NonnullRefPtr<NotificationServerConnection> m_connection;
     bool m_showing { false };
+    bool m_disposed { false };
 };
 
 }

--- a/Userland/Libraries/LibGUI/Notification.h
+++ b/Userland/Libraries/LibGUI/Notification.h
@@ -36,6 +36,8 @@ class NotificationServerConnection;
 class Notification : public Core::Object {
     C_OBJECT(Notification);
 
+    friend class NotificationServerConnection;
+
 public:
     virtual ~Notification() override;
 
@@ -64,8 +66,12 @@ public:
     bool update();
     void close();
 
+    bool is_showing() const { return m_shown && !m_destroyed; }
+
 private:
     Notification();
+
+    void connection_closed();
 
     String m_title;
     bool m_title_dirty;
@@ -74,6 +80,8 @@ private:
     RefPtr<Gfx::Bitmap> m_icon;
     bool m_icon_dirty;
 
+    bool m_destroyed { false };
+    bool m_shown { false };
     RefPtr<NotificationServerConnection> m_connection;
 };
 

--- a/Userland/Libraries/LibGUI/Notification.h
+++ b/Userland/Libraries/LibGUI/Notification.h
@@ -30,7 +30,8 @@
 #include <LibGfx/Bitmap.h>
 
 namespace GUI {
-    class NotificationServerConnection;
+
+class NotificationServerConnection;
 
 class Notification : public Core::Object {
     C_OBJECT(Notification);
@@ -48,6 +49,7 @@ public:
     void set_icon(const Gfx::Bitmap* icon) { m_icon = icon; }
 
     void show();
+    void close();
 
 private:
     Notification();
@@ -57,6 +59,7 @@ private:
     RefPtr<Gfx::Bitmap> m_icon;
 
     NonnullRefPtr<NotificationServerConnection> m_connection;
+    bool m_showing { false };
 };
 
 }

--- a/Userland/Libraries/LibGUI/Notification.h
+++ b/Userland/Libraries/LibGUI/Notification.h
@@ -74,9 +74,7 @@ private:
     RefPtr<Gfx::Bitmap> m_icon;
     bool m_icon_dirty;
 
-    NonnullRefPtr<NotificationServerConnection> m_connection;
-    bool m_showing { false };
-    bool m_disposed { false };
+    RefPtr<NotificationServerConnection> m_connection;
 };
 
 }

--- a/Userland/Libraries/LibGUI/Notification.h
+++ b/Userland/Libraries/LibGUI/Notification.h
@@ -40,23 +40,39 @@ public:
     virtual ~Notification() override;
 
     const String& text() const { return m_text; }
-    void set_text(const String& text) { m_text = text; }
+    void set_text(const String& text)
+    {
+        m_text_dirty = true;
+        m_text = text;
+    }
 
     const String& title() const { return m_title; }
-    void set_title(const String& title) { m_title = title; }
+    void set_title(const String& title)
+    {
+        m_title_dirty = true;
+        m_title = title;
+    }
 
     const Gfx::Bitmap* icon() const { return m_icon; }
-    void set_icon(const Gfx::Bitmap* icon) { m_icon = icon; }
+    void set_icon(const Gfx::Bitmap* icon)
+    {
+        m_icon_dirty = true;
+        m_icon = icon;
+    }
 
     void show();
+    bool update();
     void close();
 
 private:
     Notification();
 
     String m_title;
+    bool m_title_dirty;
     String m_text;
+    bool m_text_dirty;
     RefPtr<Gfx::Bitmap> m_icon;
+    bool m_icon_dirty;
 
     NonnullRefPtr<NotificationServerConnection> m_connection;
     bool m_showing { false };

--- a/Userland/Services/NotificationServer/ClientConnection.cpp
+++ b/Userland/Services/NotificationServer/ClientConnection.cpp
@@ -60,4 +60,13 @@ OwnPtr<Messages::NotificationServer::ShowNotificationResponse> ClientConnection:
     return make<Messages::NotificationServer::ShowNotificationResponse>();
 }
 
+OwnPtr<Messages::NotificationServer::CloseNotificationResponse> ClientConnection::handle([[maybe_unused]] const Messages::NotificationServer::CloseNotification& message)
+{
+    auto window = NotificationWindow::get_window_by_id(client_id());
+    if (window) {
+        window->close();
+    }
+    return make<Messages::NotificationServer::CloseNotificationResponse>();
+}
+
 }

--- a/Userland/Services/NotificationServer/ClientConnection.cpp
+++ b/Userland/Services/NotificationServer/ClientConnection.cpp
@@ -55,7 +55,7 @@ OwnPtr<Messages::NotificationServer::GreetResponse> ClientConnection::handle(con
 
 OwnPtr<Messages::NotificationServer::ShowNotificationResponse> ClientConnection::handle(const Messages::NotificationServer::ShowNotification& message)
 {
-    auto window = NotificationWindow::construct(message.text(), message.title(), message.icon());
+    auto window = NotificationWindow::construct(client_id(), message.text(), message.title(), message.icon());
     window->show();
     return make<Messages::NotificationServer::ShowNotificationResponse>();
 }

--- a/Userland/Services/NotificationServer/ClientConnection.cpp
+++ b/Userland/Services/NotificationServer/ClientConnection.cpp
@@ -69,4 +69,29 @@ OwnPtr<Messages::NotificationServer::CloseNotificationResponse> ClientConnection
     return make<Messages::NotificationServer::CloseNotificationResponse>();
 }
 
+OwnPtr<Messages::NotificationServer::UpdateNotificationIconResponse> ClientConnection::handle(const Messages::NotificationServer::UpdateNotificationIcon& message)
+{
+    auto window = NotificationWindow::get_window_by_id(client_id());
+    if (window) {
+        window->set_image(message.icon());
+    }
+    return make<Messages::NotificationServer::UpdateNotificationIconResponse>(window);
+}
+
+OwnPtr<Messages::NotificationServer::UpdateNotificationTextResponse> ClientConnection::handle(const Messages::NotificationServer::UpdateNotificationText& message)
+{
+    auto window = NotificationWindow::get_window_by_id(client_id());
+    if (window) {
+        window->set_text(message.text());
+        window->set_title(message.title());
+    }
+    return make<Messages::NotificationServer::UpdateNotificationTextResponse>(window);
+}
+
+OwnPtr<Messages::NotificationServer::IsShowingResponse> ClientConnection::handle(const Messages::NotificationServer::IsShowing&)
+{
+    auto window = NotificationWindow::get_window_by_id(client_id());
+    return make<Messages::NotificationServer::IsShowingResponse>(window);
+}
+
 }

--- a/Userland/Services/NotificationServer/ClientConnection.h
+++ b/Userland/Services/NotificationServer/ClientConnection.h
@@ -45,6 +45,7 @@ private:
 
     virtual OwnPtr<Messages::NotificationServer::GreetResponse> handle(const Messages::NotificationServer::Greet&) override;
     virtual OwnPtr<Messages::NotificationServer::ShowNotificationResponse> handle(const Messages::NotificationServer::ShowNotification&) override;
+    virtual OwnPtr<Messages::NotificationServer::CloseNotificationResponse> handle(const Messages::NotificationServer::CloseNotification& message) override;
 };
 
 }

--- a/Userland/Services/NotificationServer/ClientConnection.h
+++ b/Userland/Services/NotificationServer/ClientConnection.h
@@ -46,6 +46,9 @@ private:
     virtual OwnPtr<Messages::NotificationServer::GreetResponse> handle(const Messages::NotificationServer::Greet&) override;
     virtual OwnPtr<Messages::NotificationServer::ShowNotificationResponse> handle(const Messages::NotificationServer::ShowNotification&) override;
     virtual OwnPtr<Messages::NotificationServer::CloseNotificationResponse> handle(const Messages::NotificationServer::CloseNotification& message) override;
+    virtual OwnPtr<Messages::NotificationServer::UpdateNotificationIconResponse> handle(const Messages::NotificationServer::UpdateNotificationIcon& message) override;
+    virtual OwnPtr<Messages::NotificationServer::UpdateNotificationTextResponse> handle(const Messages::NotificationServer::UpdateNotificationText& message) override;
+    virtual OwnPtr<Messages::NotificationServer::IsShowingResponse> handle(const Messages::NotificationServer::IsShowing& message) override;
 };
 
 }

--- a/Userland/Services/NotificationServer/NotificationServer.ipc
+++ b/Userland/Services/NotificationServer/NotificationServer.ipc
@@ -4,4 +4,6 @@ endpoint NotificationServer = 95
     Greet() => ()
 
     ShowNotification([UTF8] String text, [UTF8] String title, Gfx::ShareableBitmap icon) => ()
+
+    CloseNotification() => ()
 }

--- a/Userland/Services/NotificationServer/NotificationServer.ipc
+++ b/Userland/Services/NotificationServer/NotificationServer.ipc
@@ -5,5 +5,11 @@ endpoint NotificationServer = 95
 
     ShowNotification([UTF8] String text, [UTF8] String title, Gfx::ShareableBitmap icon) => ()
 
+    UpdateNotificationText([UTF8] String text, [UTF8] String title) => (bool still_showing)
+
+    UpdateNotificationIcon(Gfx::ShareableBitmap icon) => (bool still_showing)
+
+    IsShowing() => (bool still_showing)
+
     CloseNotification() => ()
 }

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -113,10 +113,9 @@ NotificationWindow::NotificationWindow(i32 client_id, const String& text, const 
     right_container.set_fixed_width(36);
     right_container.set_layout<GUI::HorizontalBoxLayout>();
 
-    on_close_request = [this] {
+    on_close = [this] {
         s_windows.remove(m_id);
         update_notification_window_locations();
-        return CloseRequestDecision::Close;
     };
 }
 

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -30,7 +30,7 @@
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Desktop.h>
-#include <LibGUI/ImageWidget.h>
+#include <LibGUI/Icon.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Widget.h>
 #include <LibGfx/Bitmap.h>
@@ -41,6 +41,7 @@
 namespace NotificationServer {
 
 static HashMap<u32, RefPtr<NotificationWindow>> s_windows;
+static const Gfx::Bitmap* default_image = GUI::Icon::default_icon("ladybug").bitmap_for_size(16);
 
 void update_notification_window_locations()
 {
@@ -95,23 +96,21 @@ NotificationWindow::NotificationWindow(i32 client_id, const String& text, const 
     widget.layout()->set_margins({ 8, 8, 8, 8 });
     widget.layout()->set_spacing(6);
 
-    if (icon.is_valid()) {
-        auto& image = widget.add<GUI::ImageWidget>();
-        image.set_bitmap(icon.bitmap());
-    }
+    m_image = &widget.add<GUI::ImageWidget>();
+    m_image->set_bitmap(icon.is_valid() ? icon.bitmap() : default_image);
 
     auto& left_container = widget.add<GUI::Widget>();
     left_container.set_layout<GUI::VerticalBoxLayout>();
 
-    auto& title_label = left_container.add<GUI::Label>(title);
-    title_label.set_font(Gfx::FontDatabase::default_bold_font());
-    title_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
-    auto& text_label = left_container.add<GUI::Label>(text);
-    text_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    m_title_label = &left_container.add<GUI::Label>(title);
+    m_title_label->set_font(Gfx::FontDatabase::default_bold_font());
+    m_title_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    m_text_label = &left_container.add<GUI::Label>(text);
+    m_text_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
     widget.set_tooltip(text);
-    title_label.set_tooltip(text);
-    text_label.set_tooltip(text);
+    m_title_label->set_tooltip(text);
+    m_text_label->set_tooltip(text);
 
     auto& right_container = widget.add<GUI::Widget>();
     right_container.set_fixed_width(36);

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -38,7 +38,6 @@
 namespace NotificationServer {
 
 static HashMap<u32, RefPtr<NotificationWindow>> s_windows;
-static const Gfx::Bitmap* default_image = Gfx::Bitmap::load_from_file("/res/icons/32x32/ladybug.png");
 
 void update_notification_window_locations()
 {
@@ -94,7 +93,10 @@ NotificationWindow::NotificationWindow(i32 client_id, const String& text, const 
     widget.layout()->set_spacing(6);
 
     m_image = &widget.add<GUI::ImageWidget>();
-    m_image->set_bitmap(icon.is_valid() ? icon.bitmap() : default_image);
+    m_image->set_visible(icon.is_valid());
+    if (icon.is_valid()) {
+        m_image->set_bitmap(icon.bitmap());
+    }
 
     auto& left_container = widget.add<GUI::Widget>();
     left_container.set_layout<GUI::VerticalBoxLayout>();
@@ -141,7 +143,10 @@ void NotificationWindow::set_title(const String& value)
 
 void NotificationWindow::set_image(const Gfx::ShareableBitmap& image)
 {
-    m_image->set_bitmap(image.is_valid() ? image.bitmap() : default_image);
+    m_image->set_visible(image.is_valid());
+    if (image.is_valid()) {
+        m_image->set_bitmap(image.bitmap());
+    }
 }
 
 }

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -28,20 +28,17 @@
 #include <AK/HashMap.h>
 #include <AK/Vector.h>
 #include <LibGUI/BoxLayout.h>
-#include <LibGUI/Button.h>
 #include <LibGUI/Desktop.h>
-#include <LibGUI/Icon.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Widget.h>
 #include <LibGfx/Bitmap.h>
-#include <LibGfx/Font.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/ShareableBitmap.h>
 
 namespace NotificationServer {
 
 static HashMap<u32, RefPtr<NotificationWindow>> s_windows;
-static const Gfx::Bitmap* default_image = GUI::Icon::default_icon("ladybug").bitmap_for_size(16);
+static const Gfx::Bitmap* default_image = Gfx::Bitmap::load_from_file("/res/icons/32x32/ladybug.png");
 
 void update_notification_window_locations()
 {
@@ -131,6 +128,21 @@ RefPtr<NotificationWindow> NotificationWindow::get_window_by_id(i32 id)
 {
     auto window = s_windows.get(id);
     return window.value_or(nullptr);
+}
+
+void NotificationWindow::set_text(const String& value)
+{
+    m_text_label->set_text(value);
+}
+
+void NotificationWindow::set_title(const String& value)
+{
+    m_title_label->set_text(value);
+}
+
+void NotificationWindow::set_image(const Gfx::ShareableBitmap& image)
+{
+    m_image->set_bitmap(image.is_valid() ? image.bitmap() : default_image);
 }
 
 }

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -128,4 +128,10 @@ NotificationWindow::~NotificationWindow()
 {
 }
 
+RefPtr<NotificationWindow> NotificationWindow::get_window_by_id(i32 id)
+{
+    auto window = s_windows.get(id);
+    return window.value_or(nullptr);
+}
+
 }

--- a/Userland/Services/NotificationServer/NotificationWindow.h
+++ b/Userland/Services/NotificationServer/NotificationWindow.h
@@ -39,6 +39,8 @@ public:
     virtual ~NotificationWindow() override;
     void set_original_rect(Gfx::IntRect original_rect) { m_original_rect = original_rect; };
 
+    static RefPtr<NotificationWindow> get_window_by_id(i32 id);
+
 private:
     NotificationWindow(i32 client_id, const String& text, const String& title, const Gfx::ShareableBitmap&);
 

--- a/Userland/Services/NotificationServer/NotificationWindow.h
+++ b/Userland/Services/NotificationServer/NotificationWindow.h
@@ -40,6 +40,10 @@ public:
     virtual ~NotificationWindow() override;
     void set_original_rect(Gfx::IntRect original_rect) { m_original_rect = original_rect; };
 
+    void set_text(const String&);
+    void set_title(const String&);
+    void set_image(const Gfx::ShareableBitmap&);
+
     static RefPtr<NotificationWindow> get_window_by_id(i32 id);
 
 private:

--- a/Userland/Services/NotificationServer/NotificationWindow.h
+++ b/Userland/Services/NotificationServer/NotificationWindow.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <LibGUI/ImageWidget.h>
 #include <LibGUI/Window.h>
 
 namespace NotificationServer {
@@ -46,6 +47,10 @@ private:
 
     Gfx::IntRect m_original_rect;
     i32 m_id;
+
+    GUI::Label* m_text_label;
+    GUI::Label* m_title_label;
+    GUI::ImageWidget* m_image;
 };
 
 }

--- a/Userland/Services/NotificationServer/NotificationWindow.h
+++ b/Userland/Services/NotificationServer/NotificationWindow.h
@@ -40,9 +40,10 @@ public:
     void set_original_rect(Gfx::IntRect original_rect) { m_original_rect = original_rect; };
 
 private:
-    NotificationWindow(const String& text, const String& title, const Gfx::ShareableBitmap&);
+    NotificationWindow(i32 client_id, const String& text, const String& title, const Gfx::ShareableBitmap&);
 
     Gfx::IntRect m_original_rect;
+    i32 m_id;
 };
 
 }


### PR DESCRIPTION
This commit aims to add a way to interact with notifications once they have been published. This switches notifications to use a lifetime connection that handles a single notification.

The new API returns a boolean as to if the notification window is still open.

This is meant for applications like chat clients or email clients that could send a notification about a message, but may wish to update the text, title, or image if a second message is received. I'd like to eventually add the option to focus an application and send some data upon a click, but figured I'd get the hang of Serenity by starting here.