### PR TITLE
Kernel: Change AHCI port reset policy

### DIFF
--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -148,6 +148,19 @@ UNMAP_AFTER_INIT HPETMode CommandLine::hpet_mode() const
     PANIC("Unknown HPETMode: {}", hpet_mode);
 }
 
+UNMAP_AFTER_INIT AHCIResetMode CommandLine::ahci_reset_mode() const
+{
+    const auto ahci_reset_mode = lookup("ahci_reset_mode").value_or("controller");
+    if (ahci_reset_mode == "controller") {
+        return AHCIResetMode::ControllerOnly;
+    } else if (ahci_reset_mode == "none") {
+        return AHCIResetMode::None;
+    } else if (ahci_reset_mode == "complete") {
+        return AHCIResetMode::Complete;
+    }
+    PANIC("Unknown AHCIResetMode: {}", ahci_reset_mode);
+}
+
 UNMAP_AFTER_INIT BootMode CommandLine::boot_mode() const
 {
     const auto boot_mode = lookup("boot_mode").value_or("graphical");

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -50,6 +50,12 @@ enum class AcpiFeatureLevel {
     Disabled,
 };
 
+enum class AHCIResetMode {
+    ControllerOnly,
+    Complete,
+    None
+};
+
 class CommandLine {
     AK_MAKE_ETERNAL;
 
@@ -72,6 +78,7 @@ public:
     [[nodiscard]] AcpiFeatureLevel acpi_feature_level() const;
     [[nodiscard]] BootMode boot_mode() const;
     [[nodiscard]] HPETMode hpet_mode() const;
+    [[nodiscard]] AHCIResetMode ahci_reset_mode() const;
     [[nodiscard]] String userspace_init() const;
     [[nodiscard]] Vector<String> userspace_init_args() const;
     [[nodiscard]] String root_device() const;

--- a/Kernel/Storage/AHCIController.cpp
+++ b/Kernel/Storage/AHCIController.cpp
@@ -28,6 +28,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
 #include <AK/Types.h>
+#include <Kernel/CommandLine.h>
 #include <Kernel/Storage/AHCIController.h>
 #include <Kernel/Storage/SATADiskDevice.h>
 #include <Kernel/VM/MemoryManager.h>
@@ -144,11 +145,13 @@ AHCIController::~AHCIController()
 
 void AHCIController::initialize()
 {
-    if (!reset()) {
-        dmesgln("{}: AHCI controller reset failed", pci_address());
-        return;
+    if (kernel_command_line().ahci_reset_mode() != AHCIResetMode::None) {
+        if (!reset()) {
+            dmesgln("{}: AHCI controller reset failed", pci_address());
+            return;
+        }
+        dmesgln("{}: AHCI controller reset", pci_address());
     }
-    dmesgln("{}: AHCI controller reset", pci_address());
     dbgln("{}: AHCI command list entries count - {}", pci_address(), hba_capabilities().max_command_list_entries_count);
     hba().control_regs.ghc = 0x80000000; // Ensure that HBA knows we are AHCI aware.
     PCI::enable_interrupt_line(pci_address());

--- a/Kernel/Storage/AHCIPort.cpp
+++ b/Kernel/Storage/AHCIPort.cpp
@@ -210,6 +210,22 @@ bool AHCIPort::reset()
     if (!initiate_sata_reset()) {
         return false;
     }
+    return initialize();
+}
+
+bool AHCIPort::initialize_without_reset()
+{
+    ScopedSpinLock lock(m_lock);
+    dmesgln("AHCI Port {}: {}", representative_port_index(), try_disambiguate_sata_status());
+    return initialize();
+}
+
+bool AHCIPort::initialize()
+{
+    VERIFY(m_lock.is_locked());
+    dbgln_if(AHCI_DEBUG, "AHCI Port {}: SIG {:x}", representative_port_index(), static_cast<u32>(m_port_registers.sig));
+    if (!is_phy_enabled())
+        return false;
     rebase();
     power_on();
     spin_up();

--- a/Kernel/Storage/AHCIPort.cpp
+++ b/Kernel/Storage/AHCIPort.cpp
@@ -606,39 +606,39 @@ bool AHCIPort::initiate_sata_reset()
     full_memory_barrier();
     size_t retry = 0;
     // Try to wait 1 second for HBA to clear Command List Running
-    while (retry < 500) {
+    while (retry < 5000) {
         if (!(m_port_registers.cmd & (1 << 15)))
             break;
         // The AHCI specification says to wait now a 500 milliseconds
-        IO::delay(1000);
+        IO::delay(100);
         retry++;
     }
     full_memory_barrier();
     spin_up();
     full_memory_barrier();
     set_interface_state(AHCI::DeviceDetectionInitialization::PerformInterfaceInitializationSequence);
-    // The AHCI specification says to wait now a 1 millisecond, we wait 2 ms
-    IO::delay(10000);
+    // The AHCI specification says to wait now a 1 millisecond
+    IO::delay(1000);
     full_memory_barrier();
     set_interface_state(AHCI::DeviceDetectionInitialization::NoActionRequested);
     full_memory_barrier();
 
     retry = 0;
-    while (retry < 5) {
+    while (retry < 5000) {
         if (!((m_port_registers.ssts & 0xf) == 0))
             break;
 
-        IO::delay(10000);
+        IO::delay(10);
         retry++;
     }
 
     // If device presence detected and Phy communication established, wait for signature to update
     if ((m_port_registers.ssts & 0xf) == 3) {
         retry = 0;
-        while (retry < 30) {
+        while (retry < 30000) {
             if (!(m_port_registers.tfd & (ATA_SR_BSY | ATA_SR_DRQ)) && m_port_registers.sig != 0xffffffff)
                 break;
-            IO::delay(10000);
+            IO::delay(10);
             retry++;
         }
     }

--- a/Kernel/Storage/AHCIPort.cpp
+++ b/Kernel/Storage/AHCIPort.cpp
@@ -632,22 +632,11 @@ bool AHCIPort::initiate_sata_reset()
         retry++;
     }
 
-    // If device presence detected and Phy communication established, wait for signature to update
-    if ((m_port_registers.ssts & 0xf) == 3) {
-        retry = 0;
-        while (retry < 30000) {
-            if (!(m_port_registers.tfd & (ATA_SR_BSY | ATA_SR_DRQ)) && m_port_registers.sig != 0xffffffff)
-                break;
-            IO::delay(10);
-            retry++;
-        }
-    }
-
     dmesgln("AHCI Port {}: {}", representative_port_index(), try_disambiguate_sata_status());
 
     full_memory_barrier();
     clear_sata_error_register();
-    return m_port_registers.sig != AHCI::DeviceSignature::Unconnected;
+    return (m_port_registers.ssts & 0xf) == 3;
 }
 
 void AHCIPort::set_interface_state(AHCI::DeviceDetectionInitialization requested_action)

--- a/Kernel/Storage/AHCIPort.h
+++ b/Kernel/Storage/AHCIPort.h
@@ -78,9 +78,13 @@ public:
     RefPtr<StorageDevice> connected_device() const { return m_connected_device; }
 
     bool reset();
+    UNMAP_AFTER_INIT bool initialize_without_reset();
     void handle_interrupt();
 
 private:
+    bool is_phy_enabled() const { return (m_port_registers.ssts & 0xf) == 3; }
+    bool initialize();
+
     UNMAP_AFTER_INIT AHCIPort(const AHCIPortHandler&, volatile AHCI::PortRegisters&, u32 port_index);
 
     ALWAYS_INLINE void clear_sata_error_register() const;

--- a/Kernel/Storage/AHCIPortHandler.cpp
+++ b/Kernel/Storage/AHCIPortHandler.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <Kernel/CommandLine.h>
 #include <Kernel/Storage/AHCIPortHandler.h>
 
 namespace Kernel {
@@ -46,10 +47,19 @@ AHCIPortHandler::AHCIPortHandler(AHCIController& controller, u8 irq, AHCI::Maske
     // Clear pending interrupts, if there are any!
     m_pending_ports_interrupts.set_all();
     enable_irq();
+
+    if (kernel_command_line().ahci_reset_mode() == AHCIResetMode::Complete) {
+        for (auto index : taken_ports.to_vector()) {
+            auto port = AHCIPort::create(*this, static_cast<volatile AHCI::PortRegisters&>(controller.hba().port_regs[index]), index);
+            m_handled_ports.set(index, port);
+            port->reset();
+        }
+        return;
+    }
     for (auto index : taken_ports.to_vector()) {
         auto port = AHCIPort::create(*this, static_cast<volatile AHCI::PortRegisters&>(controller.hba().port_regs[index]), index);
         m_handled_ports.set(index, port);
-        port->reset();
+        port->initialize_without_reset();
     }
 }
 


### PR DESCRIPTION
The intention is to make the boot to be faster, therefore we should
decrease the time deltas in timeout loops to allow earlier break
from these.