### PR TITLE
Toolchain: Always strip, make code less confusing

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -143,14 +143,22 @@ jobs:
       env:
         SERENITY_KERNEL_CMDLINE: "boot_mode=self-test"
         SERENITY_RUN: "ci"
-      run: ninja run
+      run: |
+        echo "::group::ninja run # Qemu output"
+        run_worked=y
+        ninja run || run_worked=n
+        echo "::endgroup::"
+        echo "::group::cat debug.log # Serenity output"
+        if [ "y" = "${run_worked}" ] ; then
+          cat debug.log
+        else
+          echo "skipped (qemu had non-zero exit-code)"
+        fi
+        echo "::endgroup::"
+        [ "y" = ${run_worked} ]
       timeout-minutes: 10
       # FIXME: When stable, remove continue on error. (See issue #5541)
       continue-on-error: true
-    - name: Print target logs
-      if: ${{ !cancelled() && matrix.debug-macros == 'NORMAL_DEBUG'}}
-      working-directory: ${{ github.workspace }}/Build
-      run: cat ./debug.log
 
   build_and_test_lagom:
     runs-on: ${{ matrix.os }}

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -274,6 +274,22 @@ pushd "$DIR/Build/$ARCH"
 popd
 
 
+# == STRIP BINARIES TO SAVE SPACE ==
+
+pushd "$DIR"
+    # Stripping doesn't seem to work on macOS.
+    if [ "$(uname)" != "Darwin" ]; then
+        # We *most definitely* don't need debug symbols in the linker/compiler.
+        # This cuts the uncompressed size from 1.2 GiB per Toolchain down to about 120 MiB.
+        # Hence, this might actually cause marginal speedups, although the point is to not waste space as blatantly.
+        echo "Stripping executables ..."
+        echo "Before: $(du -sh Local)"
+        find Local/ -type f -executable ! -name '*.la' ! -name '*.sh' ! -name 'mk*' -exec strip {} +
+        echo "After: $(du -sh Local)"
+    fi
+popd
+
+
 # == SAVE TO CACHE ==
 
 pushd "$DIR"
@@ -283,16 +299,6 @@ pushd "$DIR"
 
         rm -f "${CACHED_TOOLCHAIN_ARCHIVE}"  # Just in case
 
-        # Stripping doesn't seem to work on macOS.
-        # However, this doesn't seem to be necessary on macOS, the uncompressed size is already about 210 MiB.
-        if [ "$(uname)" != "Darwin" ]; then
-            # We *most definitely* don't need debug symbols in the linker/compiler.
-            # This cuts the uncompressed size from 1.2 GiB per Toolchain down to about 190 MiB.
-            echo "Stripping executables ..."
-            echo "Before: $(du -sh Local)"
-            find Local/ -type f -executable ! -name '*.la' ! -name '*.sh' ! -name 'mk*' -exec strip {} +
-            echo "After: $(du -sh Local)"
-        fi
         tar czf "${CACHED_TOOLCHAIN_ARCHIVE}" Local/
 
         echo "Cache (after):"


### PR DESCRIPTION
I always manually strip the executables, simply because a 1.2 GB toolchain is ridiculous and might cause some slowdowns during build.

So I thought: Hey, we have the code here anyway, why not enable it for everyone(*)? So that's what I did.

(*): Except MacOS users. Apparently there's something wonky, but I can't test it.