### PR TITLE
QuickShow: Replace posix_spawn with LibDesktop::Launcher

### DIFF
--- a/Userland/Applications/QuickShow/CMakeLists.txt
+++ b/Userland/Applications/QuickShow/CMakeLists.txt
@@ -4,4 +4,4 @@ set(SOURCES
 )
 
 serenity_app(QuickShow ICON filetype-image)
-target_link_libraries(QuickShow LibGUI LibGfx)
+target_link_libraries(QuickShow LibDesktop LibGUI LibGfx)


### PR DESCRIPTION
When multiple images are dragged and dropped onto the image widget,
QuickShow will use LibDesktop::Launcher to launch a new instance
of QuickShow for each item, rather than spawn a child QuickShow
process for each item with posix_spawn.

This allows `proc` and `exec` pledges to be removed :^)