### PR TITLE
Shell: Add support for indexing into variables

### DIFF
--- a/Base/usr/share/man/man5/Shell.md
+++ b/Base/usr/share/man/man5/Shell.md
@@ -47,6 +47,33 @@ Any sequence of _Double Quoted String Part_ tokens:
 ##### Variable Reference
 Any sequence of _Identifier_ characters, or a _Special Variable_ following a `$`
 
+##### Immediate Expressions
+An expression of the form '${identifier expression...}', such expressions are expanded to other kinds of nodes before resolution, and are internal functions provided by the shell.
+Currently, the following functions are exposed:
+- ${length (string|list)? _expression_}
+Finds the length of the given _expression_. if either `string` or `list` is given, the shell will attempt to treat _expression_ as that type, otherwise the type of _expression_ will be inferred.
+
+- ${length\_across (string|list) _expression_}
+Finds the lengths of the entries in _expression_, this requires _expression_ to be a list.
+If either `string` or `list` is given, the shell attempts to treat the elements of _expression_ as that type, otherwise the types are individually inferred.
+
+- ${split _delimiter_ _string_}
+Splits the _string_ with _delimiter_, and evaluates to a list.
+Both _string_ and _delimiter_ must be strings.
+
+- ${remove\_suffix _suffix_ _string_}
+Removes the suffix _suffix_ (if present) from the given _string_.
+
+- ${remove\_prefix _prefix_ _string_}
+Removes the prefix _prefix_ (if present) from the given _string_.
+
+- ${concat\_lists _list_...}
+Concatenates all the given expressions as lists, and evaluates to a list.
+
+- ${regex\_replace _pattern_ _replacement-template_ _string_}
+Replaces all occurences of the regular expression _pattern_ in the given _string_, using the given _replacement-template_.
+Capture groups in _pattern_ can be referred to as `\<group_number>` in the _replacement template_, for example, to reference capture group 1, use `\1`.
+
 ##### Evaluate expression
 Any expression following a `$` that is not a variable reference:
 * Inline execution: A _syntactic list_ following a `$`:
@@ -403,6 +430,7 @@ list_expression :: ' '* expression (' '+ list_expression)?
 expression :: evaluate expression?
             | string_composite expression?
             | comment expression?
+            | immediate_expression expression?
             | history_designator expression?
             | '(' list_expression ')' expression?
 
@@ -432,6 +460,10 @@ variable :: '$' identifier
           | ...
 
 comment :: '#' [^\n]*
+
+immediate_expression :: '$' '{' immediate_function expression* '}'
+
+immediate_function :: identifier    { predetermined list of names, see Shell.h:ENUMERATE_SHELL_IMMEDIATE_FUNCTIONS }
 
 history_designator :: '!' event_selector (':' word_selector_composite)?
 

--- a/Base/usr/share/man/man5/Shell.md
+++ b/Base/usr/share/man/man5/Shell.md
@@ -45,7 +45,16 @@ Any sequence of _Double Quoted String Part_ tokens:
 * Escaped sequences
 
 ##### Variable Reference
-Any sequence of _Identifier_ characters, or a _Special Variable_ following a `$`
+Any sequence of _Identifier_ characters, or a _Special Variable_ following a `$`.
+Variables may be followed by a _Slice_ (see [Slice](#Slice))
+
+##### Slice
+Variables may be sliced into, which will allow the user to select a subset of entries in the contents of the variable.
+An expression of the form $_identifier_[_slice-contents_] can be used to slice into a variable, where _slice-contents_ has semantics similar to _Brace Expansions_, but it may only evaluate to numeric values, that are used to index into the variable being sliced.
+Negative indices are allowed, and will index the contents from the end. It should be noted that the shell will always perform bounds-checking on the indices, and raise an error on out-of-bound accesses. Slices can slice into both lists and strings.
+
+For example, `$lst[1..-2]` can be used to select a permutation of a 4-element list referred to by the variable `lst`, as the slice will evaluate to the list `(1 0 -1 -2)`, which will select the indices 1, 0, 3, 2 (in that order).
+
 
 ##### Immediate Expressions
 An expression of the form '${identifier expression...}', such expressions are expanded to other kinds of nodes before resolution, and are internal functions provided by the shell.
@@ -452,12 +461,16 @@ dquoted_string_inner :: '\' . dquoted_string_inner?       {concat}
                       | '\' 'x' digit digit dquoted_string_inner?
                       | '\' [abefrn] dquoted_string_inner?
 
-variable :: '$' identifier
+variable :: variable_ref slice?
+
+variable_ref :: '$' identifier
           | '$' '$'
           | '$' '?'
           | '$' '*'
           | '$' '#'
           | ...
+
+slice :: '[' brace_expansion_spec ']'
 
 comment :: '#' [^\n]*
 

--- a/Userland/Shell/Formatter.h
+++ b/Userland/Shell/Formatter.h
@@ -90,6 +90,7 @@ private:
     virtual void visit(const AST::ReadWriteRedirection*) override;
     virtual void visit(const AST::Sequence*) override;
     virtual void visit(const AST::Subshell*) override;
+    virtual void visit(const AST::Slice*) override;
     virtual void visit(const AST::SimpleVariable*) override;
     virtual void visit(const AST::SpecialVariable*) override;
     virtual void visit(const AST::Juxtaposition*) override;

--- a/Userland/Shell/Forward.h
+++ b/Userland/Shell/Forward.h
@@ -67,6 +67,7 @@ class ReadRedirection;
 class ReadWriteRedirection;
 class Sequence;
 class Subshell;
+class Slice;
 class SimpleVariable;
 class SpecialVariable;
 class Juxtaposition;

--- a/Userland/Shell/NodeVisitor.cpp
+++ b/Userland/Shell/NodeVisitor.cpp
@@ -202,12 +202,21 @@ void NodeVisitor::visit(const AST::Subshell* node)
         node->block()->visit(*this);
 }
 
-void NodeVisitor::visit(const AST::SimpleVariable*)
+void NodeVisitor::visit(const AST::Slice* node)
 {
+    node->selector()->visit(*this);
 }
 
-void NodeVisitor::visit(const AST::SpecialVariable*)
+void NodeVisitor::visit(const AST::SimpleVariable* node)
 {
+    if (const AST::Node* slice = node->slice())
+        slice->visit(*this);
+}
+
+void NodeVisitor::visit(const AST::SpecialVariable* node)
+{
+    if (const AST::Node* slice = node->slice())
+        slice->visit(*this);
 }
 
 void NodeVisitor::visit(const AST::Juxtaposition* node)

--- a/Userland/Shell/NodeVisitor.h
+++ b/Userland/Shell/NodeVisitor.h
@@ -63,6 +63,7 @@ public:
     virtual void visit(const AST::ReadWriteRedirection*);
     virtual void visit(const AST::Sequence*);
     virtual void visit(const AST::Subshell*);
+    virtual void visit(const AST::Slice*);
     virtual void visit(const AST::SimpleVariable*);
     virtual void visit(const AST::SpecialVariable*);
     virtual void visit(const AST::Juxtaposition*);

--- a/Userland/Shell/Parser.h
+++ b/Userland/Shell/Parser.h
@@ -91,6 +91,8 @@ private:
     RefPtr<AST::Node> parse_string();
     RefPtr<AST::Node> parse_doublequoted_string_inner();
     RefPtr<AST::Node> parse_variable();
+    RefPtr<AST::Node> parse_variable_ref();
+    RefPtr<AST::Node> parse_slice();
     RefPtr<AST::Node> parse_evaluate();
     RefPtr<AST::Node> parse_history_designator();
     RefPtr<AST::Node> parse_comment();
@@ -261,12 +263,16 @@ dquoted_string_inner :: '\' . dquoted_string_inner?       {concat}
                       | '\' 'x' digit digit dquoted_string_inner?
                       | '\' [abefrn] dquoted_string_inner?
 
-variable :: '$' identifier
+variable :: variable_ref slice?
+
+variable_ref :: '$' identifier
           | '$' '$'
           | '$' '?'
           | '$' '*'
           | '$' '#'
           | ...
+
+slice :: '[' brace_expansion_spec ']'
 
 comment :: '#' [^\n]*
 

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1885,6 +1885,7 @@ void Shell::possibly_print_error() const
     case ShellError::EvaluatedSyntaxError:
         warnln("Shell Syntax Error: {}", m_error_description);
         break;
+    case ShellError::InvalidSliceContentsError:
     case ShellError::InvalidGlobError:
     case ShellError::NonExhaustiveMatchRules:
         warnln("Shell: {}", m_error_description);

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -235,6 +235,7 @@ public:
         EvaluatedSyntaxError,
         NonExhaustiveMatchRules,
         InvalidGlobError,
+        InvalidSliceContentsError,
         OpenFailure,
     };
 

--- a/Userland/Shell/Tests/slice.sh
+++ b/Userland/Shell/Tests/slice.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+source $(dirname "$0")/test-commons.inc
+
+# can we use [0] as a bareword still?
+if not test [0] = "[0]" {
+    fail cannot use '[0]' as a bareword anymore
+}
+
+# can we use [0,2] as a bareword still?
+if not test [0,2] = "[0,2]" {
+    fail cannot use '[0,2]' as a bareword anymore
+}
+
+# can we use [0..2] as a bareword still?
+if not test [0..2] = "[0..2]" {
+    fail cannot use '[0..2]' as a bareword anymore
+}
+
+# Lists
+x=(1 2 3)
+if not test $x[0] -eq 1 {
+    fail invalid first element
+}
+
+if not test $x[1] -eq 2 {
+    fail invalid second element
+}
+
+if not test $x[-1] -eq 3 {
+    fail invalid first-from-end element
+}
+
+if not test $x[-2] -eq 2 {
+    fail invalid second-from-end element
+}
+
+## Multiple indices
+if not test "$x[1,2]" = "2 3" {
+    fail invalid multi-select '(1, 2)'
+}
+
+if not test "$x[0..2]" = "1 2 3" {
+    fail invalid multi-select with range '[0..2]'
+}
+
+# Strings
+x="Well Hello Friends!"
+if not test $x[0] = W {
+    fail invalid string first element
+}
+
+if not test $x[1] = e {
+    fail invalid string second element
+}
+
+if not test $x[-1] = '!' {
+    fail invalid string first-from-end element
+}
+
+if not test $x[-2] = 's' {
+    fail invalid string second-from-end element
+}
+
+if not test $x[0,5,11,-1] = 'WHF!' {
+    fail invalid string multi-select
+}
+
+if not test $x[5..9] = "Hello" {
+    fail invalid string multi-select with range '[5..9]'
+}
+
+pass


### PR DESCRIPTION
Now a variable may have an optional slice (only _one_ slice), which can
also use negative indices to index from the end.
This works on both lists and strings.
The contents of the slice have the same semantics as brace expansions.
For example:
```sh
$ x=(1 2 3 4 5 6)
$ echo $x[1..3] # select indices 1, 2, 3
2 3 4
$ echo $x[3,4,1,0] # select indices 3, 4, 1, 0 (in that order)
4 5 2 1
$ x="Well Hello Friends!"
$ echo $x[5..9]
Hello
```