### PR TITLE
Terminal: Add support for fullscreen view

### DIFF
--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -457,6 +457,9 @@ int main(int argc, char** argv)
         }));
 
     auto& view_menu = menubar->add_menu("View");
+    view_menu.add_action(GUI::CommonActions::make_fullscreen_action([&](auto&) {
+        window->set_fullscreen(!window->is_fullscreen());
+    }));
     view_menu.add_action(terminal.clear_including_history_action());
     view_menu.add_separator();
     view_menu.add_action(pick_font_action);


### PR DESCRIPTION
I use full screen often.

Terminal fullscreen (foreground):

![Terminal fullscreen (foreground)](https://user-images.githubusercontent.com/434827/111018150-65a8cc80-840b-11eb-9a0f-5d16805b9e0f.png)

Terminal fullscreen (background):

![Terminal fullscreen (background)](https://user-images.githubusercontent.com/434827/111018155-693c5380-840b-11eb-9fef-fd94b9aac0bb.png)

Commands and associated output in windowed mode will survive in the terminal buffer during transitioning to full screen and back. However, commands and associated output in fullscreen mode will be corrupted when switching back to windowed mode.

Return to windowed mode:

![Return to windowed mode](https://user-images.githubusercontent.com/434827/111018553-938f1080-840d-11eb-9fa7-36c3c6a5a1c7.png)

Return to windowed mode then pressing enter:

![Return to windowed mode then pressing enter](https://user-images.githubusercontent.com/434827/111018554-968a0100-840d-11eb-8e02-db39e9c054e3.png)
