### PR TITLE
Everywhere: working towards 64 bits storage

### DIFF
--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -114,9 +114,11 @@ public:
 
     int to_int(int default_value = 0) const { return to_i32(default_value); }
     i32 to_i32(i32 default_value = 0) const { return to_number<i32>(default_value); }
+    i64 to_i64(i64 default_value = 0) const { return to_number<i64>(default_value); }
 
     unsigned to_uint(unsigned default_value = 0) const { return to_u32(default_value); }
     u32 to_u32(u32 default_value = 0) const { return to_number<u32>(default_value); }
+    u64 to_u64(u64 default_value = 0) const { return to_number<u64>(default_value); }
 
     bool to_bool(bool default_value = false) const
     {

--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -31,13 +31,13 @@
 namespace AK {
 
 // FIXME: Remove this hackery once printf() supports floats.
-static String number_string_with_one_decimal(u64 number, u32 unit, const char* suffix)
+static String number_string_with_one_decimal(u64 number, u64 unit, const char* suffix)
 {
     int decimal = (number % unit) * 10 / unit;
     return String::formatted("{}.{} {}", number / unit, decimal, suffix);
 }
 
-static inline String human_readable_size(size_t size)
+static inline String human_readable_size(u64 size)
 {
     if (size < 1 * KiB)
         return String::formatted("{} B", size);
@@ -45,7 +45,13 @@ static inline String human_readable_size(size_t size)
         return number_string_with_one_decimal(size, KiB, "KiB");
     if (size < 1 * GiB)
         return number_string_with_one_decimal(size, MiB, "MiB");
-    return number_string_with_one_decimal(size, GiB, "GiB");
+    if (size < 1 * TiB)
+        return number_string_with_one_decimal(size, GiB, "GiB");
+    if (size < 1 * PiB)
+        return number_string_with_one_decimal(size, TiB, "TiB");
+    if (size < 1 * EiB)
+        return number_string_with_one_decimal(size, PiB, "PiB");
+    return number_string_with_one_decimal(size, EiB, "EiB");
 }
 
 }

--- a/AK/Tests/TestNumberFormat.cpp
+++ b/AK/Tests/TestNumberFormat.cpp
@@ -136,12 +136,11 @@ TEST_CASE(extremes_8byte)
         EXPECT_EQ(human_readable_size(0x100000000ULL), "4.0 GiB");
         EXPECT_EQ(human_readable_size(0x100000001ULL), "4.0 GiB");
         EXPECT_EQ(human_readable_size(0x800000000ULL), "32.0 GiB");
-        EXPECT_EQ(human_readable_size(0x10000000000ULL), "1024.0 GiB");
-
-        // Oh yeah! These are *correct*!
-        EXPECT_EQ(human_readable_size(0x7fffffffffffffffULL), "8589934591.9 GiB");
-        EXPECT_EQ(human_readable_size(0x8000000000000000ULL), "8589934592.0 GiB");
-        EXPECT_EQ(human_readable_size(0xffffffffffffffffULL), "17179869183.9 GiB");
+        EXPECT_EQ(human_readable_size(0x10000000000ULL), "1.0 TiB");
+        EXPECT_EQ(human_readable_size(0x4000000000000ULL), "1.0 PiB");
+        EXPECT_EQ(human_readable_size(0x7fffffffffffffffULL), "7.9 EiB");
+        EXPECT_EQ(human_readable_size(0x8000000000000000ULL), "8.0 EiB");
+        EXPECT_EQ(human_readable_size(0xffffffffffffffffULL), "15.9 EiB");
     } else {
         warnln("(Skipping 8-byte-size_t test on 32-bit platform)");
     }

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -74,9 +74,12 @@ using __ptrdiff_t = __PTRDIFF_TYPE__;
 
 using FlatPtr = Conditional<sizeof(void*) == 8, u64, u32>::Type;
 
-constexpr unsigned KiB = 1024;
-constexpr unsigned MiB = KiB * KiB;
-constexpr unsigned GiB = KiB * KiB * KiB;
+constexpr u64 KiB = 1024;
+constexpr u64 MiB = KiB * KiB;
+constexpr u64 GiB = KiB * KiB * KiB;
+constexpr u64 TiB = KiB * KiB * KiB * KiB;
+constexpr u64 PiB = KiB * KiB * KiB * KiB * KiB;
+constexpr u64 EiB = KiB * KiB * KiB * KiB * KiB * KiB;
 
 namespace std {
 using nullptr_t = decltype(nullptr);

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -244,7 +244,7 @@ struct SC_mmap_params {
     int32_t prot;
     int32_t flags;
     int32_t fd;
-    ssize_t offset;
+    int64_t offset;
     StringArgument name;
 };
 

--- a/Kernel/Console.cpp
+++ b/Kernel/Console.cpp
@@ -65,14 +65,14 @@ bool Console::can_read(const Kernel::FileDescription&, size_t) const
     return false;
 }
 
-Kernel::KResultOr<size_t> Console::read(Kernel::FileDescription&, size_t, Kernel::UserOrKernelBuffer&, size_t)
+Kernel::KResultOr<size_t> Console::read(FileDescription&, u64, Kernel::UserOrKernelBuffer&, size_t)
 {
     // FIXME: Implement reading from the console.
     //        Maybe we could use a ring buffer for this device?
     return 0;
 }
 
-Kernel::KResultOr<size_t> Console::write(Kernel::FileDescription&, size_t, const Kernel::UserOrKernelBuffer& data, size_t size)
+Kernel::KResultOr<size_t> Console::write(FileDescription&, u64, const Kernel::UserOrKernelBuffer& data, size_t size)
 {
     if (!size)
         return 0;

--- a/Kernel/Console.h
+++ b/Kernel/Console.h
@@ -43,8 +43,8 @@ public:
     // ^CharacterDevice
     virtual bool can_read(const Kernel::FileDescription&, size_t) const override;
     virtual bool can_write(const Kernel::FileDescription&, size_t) const override { return true; }
-    virtual Kernel::KResultOr<size_t> read(Kernel::FileDescription&, size_t, Kernel::UserOrKernelBuffer&, size_t) override;
-    virtual Kernel::KResultOr<size_t> write(Kernel::FileDescription&, size_t, const Kernel::UserOrKernelBuffer&, size_t) override;
+    virtual Kernel::KResultOr<size_t> read(FileDescription&, u64, Kernel::UserOrKernelBuffer&, size_t) override;
+    virtual Kernel::KResultOr<size_t> write(FileDescription&, u64, const Kernel::UserOrKernelBuffer&, size_t) override;
     virtual const char* class_name() const override { return "Console"; }
 
     void put_char(char);

--- a/Kernel/Devices/BXVGADevice.h
+++ b/Kernel/Devices/BXVGADevice.h
@@ -53,8 +53,8 @@ private:
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
     virtual void start_request(AsyncBlockDeviceRequest& request) override { request.complete(AsyncDeviceRequest::Failure); }
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override { return -EINVAL; }
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override { return -EINVAL; }
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
 
     void set_safe_resolution();
 

--- a/Kernel/Devices/BlockDevice.cpp
+++ b/Kernel/Devices/BlockDevice.cpp
@@ -28,7 +28,7 @@
 
 namespace Kernel {
 
-AsyncBlockDeviceRequest::AsyncBlockDeviceRequest(Device& block_device, RequestType request_type, u32 block_index, u32 block_count, const UserOrKernelBuffer& buffer, size_t buffer_size)
+AsyncBlockDeviceRequest::AsyncBlockDeviceRequest(Device& block_device, RequestType request_type, u64 block_index, u32 block_count, const UserOrKernelBuffer& buffer, size_t buffer_size)
     : AsyncDeviceRequest(block_device)
     , m_block_device(static_cast<BlockDevice&>(block_device))
     , m_request_type(request_type)
@@ -48,7 +48,7 @@ BlockDevice::~BlockDevice()
 {
 }
 
-bool BlockDevice::read_block(unsigned index, UserOrKernelBuffer& buffer)
+bool BlockDevice::read_block(u64 index, UserOrKernelBuffer& buffer)
 {
     auto read_request = make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Read, index, 1, buffer, 512);
     switch (read_request->wait().request_result()) {
@@ -69,7 +69,7 @@ bool BlockDevice::read_block(unsigned index, UserOrKernelBuffer& buffer)
     return false;
 }
 
-bool BlockDevice::write_block(unsigned index, const UserOrKernelBuffer& buffer)
+bool BlockDevice::write_block(u64 index, const UserOrKernelBuffer& buffer)
 {
     auto write_request = make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Write, index, 1, buffer, 512);
     switch (write_request->wait().request_result()) {

--- a/Kernel/Devices/BlockDevice.h
+++ b/Kernel/Devices/BlockDevice.h
@@ -39,10 +39,10 @@ public:
         Write
     };
     AsyncBlockDeviceRequest(Device& block_device, RequestType request_type,
-        u32 block_index, u32 block_count, const UserOrKernelBuffer& buffer, size_t buffer_size);
+        u64 block_index, u32 block_count, const UserOrKernelBuffer& buffer, size_t buffer_size);
 
     RequestType request_type() const { return m_request_type; }
-    u32 block_index() const { return m_block_index; }
+    u64 block_index() const { return m_block_index; }
     u32 block_count() const { return m_block_count; }
     UserOrKernelBuffer& buffer() { return m_buffer; }
     const UserOrKernelBuffer& buffer() const { return m_buffer; }
@@ -64,7 +64,7 @@ public:
 private:
     BlockDevice& m_block_device;
     const RequestType m_request_type;
-    const u32 m_block_index;
+    const u64 m_block_index;
     const u32 m_block_count;
     UserOrKernelBuffer m_buffer;
     const size_t m_buffer_size;
@@ -77,8 +77,8 @@ public:
     size_t block_size() const { return m_block_size; }
     virtual bool is_seekable() const override { return true; }
 
-    bool read_block(unsigned index, UserOrKernelBuffer&);
-    bool write_block(unsigned index, const UserOrKernelBuffer&);
+    bool read_block(u64 index, UserOrKernelBuffer&);
+    bool write_block(u64 index, const UserOrKernelBuffer&);
 
     virtual void start_request(AsyncBlockDeviceRequest&) = 0;
 

--- a/Kernel/Devices/FullDevice.cpp
+++ b/Kernel/Devices/FullDevice.cpp
@@ -46,7 +46,7 @@ bool FullDevice::can_read(const FileDescription&, size_t) const
     return true;
 }
 
-KResultOr<size_t> FullDevice::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> FullDevice::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
     ssize_t count = min(static_cast<size_t>(PAGE_SIZE), size);
     if (!buffer.memset(0, count))
@@ -54,7 +54,7 @@ KResultOr<size_t> FullDevice::read(FileDescription&, size_t, UserOrKernelBuffer&
     return count;
 }
 
-KResultOr<size_t> FullDevice::write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t size)
+KResultOr<size_t> FullDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t size)
 {
     if (size == 0)
         return 0;

--- a/Kernel/Devices/FullDevice.h
+++ b/Kernel/Devices/FullDevice.h
@@ -42,8 +42,8 @@ public:
 
 private:
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
     virtual const char* class_name() const override { return "FullDevice"; }

--- a/Kernel/Devices/KeyboardDevice.cpp
+++ b/Kernel/Devices/KeyboardDevice.cpp
@@ -430,7 +430,7 @@ bool KeyboardDevice::can_read(const FileDescription&, size_t) const
     return !m_queue.is_empty();
 }
 
-KResultOr<size_t> KeyboardDevice::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> KeyboardDevice::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
     size_t nread = 0;
     ScopedSpinLock lock(m_queue_lock);
@@ -458,7 +458,7 @@ KResultOr<size_t> KeyboardDevice::read(FileDescription&, size_t, UserOrKernelBuf
     return nread;
 }
 
-KResultOr<size_t> KeyboardDevice::write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t)
+KResultOr<size_t> KeyboardDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t)
 {
     return 0;
 }

--- a/Kernel/Devices/KeyboardDevice.h
+++ b/Kernel/Devices/KeyboardDevice.h
@@ -61,9 +61,9 @@ public:
     const String keymap_name() { return m_character_map.character_map_name(); }
 
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 
     virtual const char* purpose() const override { return class_name(); }

--- a/Kernel/Devices/MBVGADevice.h
+++ b/Kernel/Devices/MBVGADevice.h
@@ -51,8 +51,8 @@ private:
     virtual const char* class_name() const override { return "MBVGA"; }
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override { return -EINVAL; }
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override { return -EINVAL; }
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
     virtual void start_request(AsyncBlockDeviceRequest& request) override { request.complete(AsyncDeviceRequest::Failure); }
 
     size_t framebuffer_size_in_bytes() const { return m_framebuffer_pitch * m_framebuffer_height; }

--- a/Kernel/Devices/MemoryDevice.cpp
+++ b/Kernel/Devices/MemoryDevice.cpp
@@ -42,7 +42,7 @@ UNMAP_AFTER_INIT MemoryDevice::~MemoryDevice()
 {
 }
 
-KResultOr<size_t> MemoryDevice::read(FileDescription&, size_t, UserOrKernelBuffer&, size_t)
+KResultOr<size_t> MemoryDevice::read(FileDescription&, u64, UserOrKernelBuffer&, size_t)
 {
     TODO();
 }

--- a/Kernel/Devices/MemoryDevice.h
+++ b/Kernel/Devices/MemoryDevice.h
@@ -50,8 +50,8 @@ private:
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual bool can_write(const FileDescription&, size_t) const override { return false; }
     virtual bool is_seekable() const { return true; }
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return -EINVAL; }
 
     virtual void did_seek(FileDescription&, off_t) override;
 

--- a/Kernel/Devices/NullDevice.cpp
+++ b/Kernel/Devices/NullDevice.cpp
@@ -56,12 +56,12 @@ bool NullDevice::can_read(const FileDescription&, size_t) const
     return true;
 }
 
-KResultOr<size_t> NullDevice::read(FileDescription&, size_t, UserOrKernelBuffer&, size_t)
+KResultOr<size_t> NullDevice::read(FileDescription&, u64, UserOrKernelBuffer&, size_t)
 {
     return 0;
 }
 
-KResultOr<size_t> NullDevice::write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t buffer_size)
+KResultOr<size_t> NullDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t buffer_size)
 {
     return min(static_cast<size_t>(PAGE_SIZE), buffer_size);
 }

--- a/Kernel/Devices/NullDevice.h
+++ b/Kernel/Devices/NullDevice.h
@@ -45,8 +45,8 @@ public:
 
 private:
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual const char* class_name() const override { return "NullDevice"; }

--- a/Kernel/Devices/PS2MouseDevice.cpp
+++ b/Kernel/Devices/PS2MouseDevice.cpp
@@ -273,7 +273,7 @@ bool PS2MouseDevice::can_read(const FileDescription&, size_t) const
     return !m_queue.is_empty();
 }
 
-KResultOr<size_t> PS2MouseDevice::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> PS2MouseDevice::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
     VERIFY(size > 0);
     size_t nread = 0;
@@ -300,7 +300,7 @@ KResultOr<size_t> PS2MouseDevice::read(FileDescription&, size_t, UserOrKernelBuf
     return nread;
 }
 
-KResultOr<size_t> PS2MouseDevice::write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t)
+KResultOr<size_t> PS2MouseDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t)
 {
     return 0;
 }

--- a/Kernel/Devices/PS2MouseDevice.h
+++ b/Kernel/Devices/PS2MouseDevice.h
@@ -48,8 +48,8 @@ public:
 
     // ^CharacterDevice
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 
     virtual const char* purpose() const override { return class_name(); }

--- a/Kernel/Devices/RandomDevice.cpp
+++ b/Kernel/Devices/RandomDevice.cpp
@@ -43,7 +43,7 @@ bool RandomDevice::can_read(const FileDescription&, size_t) const
     return true;
 }
 
-KResultOr<size_t> RandomDevice::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> RandomDevice::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
     bool success = buffer.write_buffered<256>(size, [&](u8* data, size_t data_size) {
         get_good_random_bytes(data, data_size);
@@ -54,7 +54,7 @@ KResultOr<size_t> RandomDevice::read(FileDescription&, size_t, UserOrKernelBuffe
     return size;
 }
 
-KResultOr<size_t> RandomDevice::write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t size)
+KResultOr<size_t> RandomDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t size)
 {
     // FIXME: Use input for entropy? I guess that could be a neat feature?
     return min(static_cast<size_t>(PAGE_SIZE), size);

--- a/Kernel/Devices/RandomDevice.h
+++ b/Kernel/Devices/RandomDevice.h
@@ -42,8 +42,8 @@ public:
 
 private:
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
     virtual const char* class_name() const override { return "RandomDevice"; }

--- a/Kernel/Devices/SB16.cpp
+++ b/Kernel/Devices/SB16.cpp
@@ -189,7 +189,7 @@ bool SB16::can_read(const FileDescription&, size_t) const
     return false;
 }
 
-KResultOr<size_t> SB16::read(FileDescription&, size_t, UserOrKernelBuffer&, size_t)
+KResultOr<size_t> SB16::read(FileDescription&, u64, UserOrKernelBuffer&, size_t)
 {
     return 0;
 }
@@ -243,7 +243,7 @@ void SB16::wait_for_irq()
     disable_irq();
 }
 
-KResultOr<size_t> SB16::write(FileDescription&, size_t, const UserOrKernelBuffer& data, size_t length)
+KResultOr<size_t> SB16::write(FileDescription&, u64, const UserOrKernelBuffer& data, size_t length)
 {
     if (!m_dma_region) {
         auto page = MM.allocate_supervisor_physical_page();

--- a/Kernel/Devices/SB16.h
+++ b/Kernel/Devices/SB16.h
@@ -48,8 +48,8 @@ public:
 
     // ^CharacterDevice
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 
     virtual const char* purpose() const override { return class_name(); }

--- a/Kernel/Devices/SerialDevice.cpp
+++ b/Kernel/Devices/SerialDevice.cpp
@@ -45,7 +45,7 @@ bool SerialDevice::can_read(const FileDescription&, size_t) const
     return (get_line_status() & DataReady) != 0;
 }
 
-KResultOr<size_t> SerialDevice::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> SerialDevice::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
     if (!size)
         return 0;
@@ -69,7 +69,7 @@ bool SerialDevice::can_write(const FileDescription&, size_t) const
     return (get_line_status() & EmptyTransmitterHoldingRegister) != 0;
 }
 
-KResultOr<size_t> SerialDevice::write(FileDescription&, size_t, const UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> SerialDevice::write(FileDescription&, u64, const UserOrKernelBuffer& buffer, size_t size)
 {
     if (!size)
         return 0;

--- a/Kernel/Devices/SerialDevice.h
+++ b/Kernel/Devices/SerialDevice.h
@@ -43,9 +43,9 @@ public:
 
     // ^CharacterDevice
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
 
     enum InterruptEnable {
         LowPowerMode = 0x01 << 5,

--- a/Kernel/Devices/ZeroDevice.cpp
+++ b/Kernel/Devices/ZeroDevice.cpp
@@ -44,7 +44,7 @@ bool ZeroDevice::can_read(const FileDescription&, size_t) const
     return true;
 }
 
-KResultOr<size_t> ZeroDevice::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> ZeroDevice::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
     ssize_t count = min(static_cast<size_t>(PAGE_SIZE), size);
     if (!buffer.memset(0, count))
@@ -52,7 +52,7 @@ KResultOr<size_t> ZeroDevice::read(FileDescription&, size_t, UserOrKernelBuffer&
     return count;
 }
 
-KResultOr<size_t> ZeroDevice::write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t size)
+KResultOr<size_t> ZeroDevice::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t size)
 {
     return min(static_cast<size_t>(PAGE_SIZE), size);
 }

--- a/Kernel/Devices/ZeroDevice.h
+++ b/Kernel/Devices/ZeroDevice.h
@@ -42,8 +42,8 @@ public:
 
 private:
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
     virtual const char* class_name() const override { return "ZeroDevice"; }

--- a/Kernel/FileSystem/AnonymousFile.h
+++ b/Kernel/FileSystem/AnonymousFile.h
@@ -46,8 +46,8 @@ private:
     virtual String absolute_path(const FileDescription&) const override { return ":anonymous-file:"; }
     virtual bool can_read(const FileDescription&, size_t) const override { return false; }
     virtual bool can_write(const FileDescription&, size_t) const override { return false; }
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override { return ENOTSUP; }
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override { return ENOTSUP; }
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override { return ENOTSUP; }
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return ENOTSUP; }
 
     explicit AnonymousFile(NonnullRefPtr<AnonymousVMObject>);
 

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -49,7 +49,7 @@ class Ext2FSInode final : public Inode {
 public:
     virtual ~Ext2FSInode() override;
 
-    size_t size() const { return m_raw_inode.i_size; }
+    u64 size() const;
     bool is_symlink() const { return Kernel::is_symlink(m_raw_inode.i_mode); }
     bool is_directory() const { return Kernel::is_directory(m_raw_inode.i_mode); }
 
@@ -105,6 +105,11 @@ class Ext2FS final : public BlockBasedFS {
     friend class Ext2FSInode;
 
 public:
+    enum class FeaturesReadOnly : u32 {
+        None = 0,
+        FileSize64bits = 1 << 1,
+    };
+
     static NonnullRefPtr<Ext2FS> create(FileDescription&);
 
     virtual ~Ext2FS() override;
@@ -120,6 +125,8 @@ public:
     virtual bool supports_watchers() const override { return true; }
 
     virtual u8 internal_file_type_to_directory_entry_type(const DirectoryEntryView& entry) const override;
+
+    FeaturesReadOnly get_features_readonly() const;
 
 private:
     TYPEDEF_DISTINCT_ORDERED_ID(unsigned, GroupIndex);

--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -144,14 +144,14 @@ bool FIFO::can_write(const FileDescription&, size_t) const
     return m_buffer.space_for_writing() || !m_readers;
 }
 
-KResultOr<size_t> FIFO::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> FIFO::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
     if (!m_writers && m_buffer.is_empty())
         return 0;
     return m_buffer.read(buffer, size);
 }
 
-KResultOr<size_t> FIFO::write(FileDescription&, size_t, const UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> FIFO::write(FileDescription&, u64, const UserOrKernelBuffer& buffer, size_t size)
 {
     if (!m_readers) {
         Thread::current()->send_signal(SIGPIPE, Process::current());

--- a/Kernel/FileSystem/FIFO.h
+++ b/Kernel/FileSystem/FIFO.h
@@ -57,8 +57,8 @@ public:
 
 private:
     // ^File
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual KResult stat(::stat&) const override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -111,8 +111,8 @@ public:
     virtual KResult attach(FileDescription&) { return KSuccess; }
     virtual void detach(FileDescription&) { }
     virtual void did_seek(FileDescription&, off_t) { }
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) = 0;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) = 0;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) = 0;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) = 0;
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg);
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, size_t offset, int prot, bool shared);
     virtual KResult stat(::stat&) const { return EBADF; }

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -46,7 +46,7 @@ InodeFile::~InodeFile()
 {
 }
 
-KResultOr<size_t> InodeFile::read(FileDescription& description, size_t offset, UserOrKernelBuffer& buffer, size_t count)
+KResultOr<size_t> InodeFile::read(FileDescription& description, u64 offset, UserOrKernelBuffer& buffer, size_t count)
 {
     if (Checked<off_t>::addition_would_overflow(offset, count))
         return EOVERFLOW;
@@ -61,7 +61,7 @@ KResultOr<size_t> InodeFile::read(FileDescription& description, size_t offset, U
     return nread;
 }
 
-KResultOr<size_t> InodeFile::write(FileDescription& description, size_t offset, const UserOrKernelBuffer& data, size_t count)
+KResultOr<size_t> InodeFile::write(FileDescription& description, u64 offset, const UserOrKernelBuffer& data, size_t count)
 {
     if (Checked<off_t>::addition_would_overflow(offset, count))
         return EOVERFLOW;

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -47,8 +47,8 @@ public:
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
     virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, size_t offset, int prot, bool shared) override;
 

--- a/Kernel/FileSystem/InodeWatcher.cpp
+++ b/Kernel/FileSystem/InodeWatcher.cpp
@@ -57,7 +57,7 @@ bool InodeWatcher::can_write(const FileDescription&, size_t) const
     return true;
 }
 
-KResultOr<size_t> InodeWatcher::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t buffer_size)
+KResultOr<size_t> InodeWatcher::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t buffer_size)
 {
     LOCKER(m_lock);
     VERIFY(!m_queue.is_empty() || !m_inode);
@@ -82,7 +82,7 @@ KResultOr<size_t> InodeWatcher::read(FileDescription&, size_t, UserOrKernelBuffe
     return bytes_to_write;
 }
 
-KResultOr<size_t> InodeWatcher::write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t)
+KResultOr<size_t> InodeWatcher::write(FileDescription&, u64, const UserOrKernelBuffer&, size_t)
 {
     return EIO;
 }

--- a/Kernel/FileSystem/InodeWatcher.h
+++ b/Kernel/FileSystem/InodeWatcher.h
@@ -44,8 +44,8 @@ public:
 
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual String absolute_path(const FileDescription&) const override;
     virtual const char* class_name() const override { return "InodeWatcher"; };
 

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -243,7 +243,7 @@ KResult Socket::getsockopt(FileDescription&, int level, int option, Userspace<vo
     }
 }
 
-KResultOr<size_t> Socket::read(FileDescription& description, size_t, UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> Socket::read(FileDescription& description, u64, UserOrKernelBuffer& buffer, size_t size)
 {
     if (is_shut_down_for_reading())
         return 0;
@@ -251,7 +251,7 @@ KResultOr<size_t> Socket::read(FileDescription& description, size_t, UserOrKerne
     return recvfrom(description, buffer, size, 0, {}, 0, t);
 }
 
-KResultOr<size_t> Socket::write(FileDescription& description, size_t, const UserOrKernelBuffer& data, size_t size)
+KResultOr<size_t> Socket::write(FileDescription& description, u64, const UserOrKernelBuffer& data, size_t size)
 {
     if (is_shut_down_for_writing())
         return EPIPE;

--- a/Kernel/Net/Socket.h
+++ b/Kernel/Net/Socket.h
@@ -123,8 +123,8 @@ public:
     Lock& lock() { return m_lock; }
 
     // ^File
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override final;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override final;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override final;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override final;
     virtual KResult stat(::stat&) const override;
     virtual String absolute_path(const FileDescription&) const override = 0;
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -276,7 +276,6 @@ public:
     KResultOr<int> sys$dump_backtrace();
     KResultOr<pid_t> sys$gettid();
     KResultOr<int> sys$donate(pid_t tid);
-    KResultOr<int> sys$ftruncate(int fd, off_t);
     KResultOr<pid_t> sys$setsid();
     KResultOr<pid_t> sys$getsid(pid_t);
     KResultOr<int> sys$setpgid(pid_t pid, pid_t pgid);
@@ -299,7 +298,8 @@ public:
     KResultOr<ssize_t> sys$writev(int fd, Userspace<const struct iovec*> iov, int iov_count);
     KResultOr<int> sys$fstat(int fd, Userspace<stat*>);
     KResultOr<int> sys$stat(Userspace<const Syscall::SC_stat_params*>);
-    KResultOr<int> sys$lseek(int fd, off_t, int whence);
+    KResultOr<int> sys$lseek(int fd, Userspace<off_t*>, int whence);
+    KResultOr<int> sys$ftruncate(int fd, Userspace<off_t*>);
     KResultOr<int> sys$kill(pid_t pid_or_pgid, int sig);
     [[noreturn]] void sys$exit(int status);
     KResultOr<int> sys$sigreturn(RegisterState& registers);

--- a/Kernel/Storage/AHCIPort.cpp
+++ b/Kernel/Storage/AHCIPort.cpp
@@ -243,7 +243,7 @@ bool AHCIPort::initialize()
 
     size_t logical_sector_size = 512;
     size_t physical_sector_size = 512;
-    size_t max_addressable_sector = 0;
+    u64 max_addressable_sector = 0;
     if (identify_device()) {
         auto identify_block = map_typed<ATAIdentifyBlock>(m_parent_handler->get_identify_metadata_physical_region(m_port_index));
         // Check if word 106 is valid before using it!
@@ -266,7 +266,7 @@ bool AHCIPort::initialize()
             m_port_registers.cmd = m_port_registers.cmd | (1 << 24);
         }
 
-        dmesgln("AHCI Port {}: max lba {:x}, L/P sector size - {}/{} ", representative_port_index(), max_addressable_sector, logical_sector_size, physical_sector_size);
+        dmesgln("AHCI Port {}: Device found, Capacity={}, Bytes per logical sector={}, Bytes per physical sector={}", representative_port_index(), max_addressable_sector * logical_sector_size, logical_sector_size, physical_sector_size);
 
         // FIXME: We don't support ATAPI devices yet, so for now we don't "create" them
         if (!is_atapi_attached()) {

--- a/Kernel/Storage/IDEChannel.h
+++ b/Kernel/Storage/IDEChannel.h
@@ -140,7 +140,7 @@ private:
 
     void clear_pending_interrupts() const;
 
-    void ata_access(Direction, bool, u32, u8, u16, bool);
+    void ata_access(Direction, bool, u64, u8, u16, bool);
     void ata_read_sectors_with_dma(bool, u16);
     void ata_read_sectors(bool, u16);
     bool ata_do_read_sector();

--- a/Kernel/Storage/PATADiskDevice.cpp
+++ b/Kernel/Storage/PATADiskDevice.cpp
@@ -33,16 +33,13 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullRefPtr<PATADiskDevice> PATADiskDevice::create(const IDEController& controller, IDEChannel& channel, DriveType type, InterfaceType interface_type, u16 cylinders, u16 heads, u16 spt, u16 capabilities)
+UNMAP_AFTER_INIT NonnullRefPtr<PATADiskDevice> PATADiskDevice::create(const IDEController& controller, IDEChannel& channel, DriveType type, InterfaceType interface_type, u16 capabilities, u64 max_addressable_block)
 {
-    return adopt(*new PATADiskDevice(controller, channel, type, interface_type, cylinders, heads, spt, capabilities));
+    return adopt(*new PATADiskDevice(controller, channel, type, interface_type, capabilities, max_addressable_block));
 }
 
-UNMAP_AFTER_INIT PATADiskDevice::PATADiskDevice(const IDEController& controller, IDEChannel& channel, DriveType type, InterfaceType interface_type, u16 cylinders, u16 heads, u16 spt, u16 capabilities)
-    : StorageDevice(controller, 512, 0)
-    , m_cylinders(cylinders)
-    , m_heads(heads)
-    , m_sectors_per_track(spt)
+UNMAP_AFTER_INIT PATADiskDevice::PATADiskDevice(const IDEController& controller, IDEChannel& channel, DriveType type, InterfaceType interface_type, u16 capabilities, u64 max_addressable_block)
+    : StorageDevice(controller, 512, max_addressable_block)
     , m_capabilities(capabilities)
     , m_channel(channel)
     , m_drive_type(type)
@@ -68,11 +65,6 @@ void PATADiskDevice::start_request(AsyncBlockDeviceRequest& request)
 String PATADiskDevice::device_name() const
 {
     return String::formatted("hd{:c}", 'a' + minor());
-}
-
-size_t PATADiskDevice::max_addressable_block() const
-{
-    return m_cylinders * m_heads * m_sectors_per_track;
 }
 
 bool PATADiskDevice::is_slave() const

--- a/Kernel/Storage/PATADiskDevice.h
+++ b/Kernel/Storage/PATADiskDevice.h
@@ -57,19 +57,18 @@ public:
     };
 
 public:
-    static NonnullRefPtr<PATADiskDevice> create(const IDEController&, IDEChannel&, DriveType, InterfaceType, u16, u16, u16, u16);
+    static NonnullRefPtr<PATADiskDevice> create(const IDEController&, IDEChannel&, DriveType, InterfaceType, u16, u64);
     virtual ~PATADiskDevice() override;
 
     // ^StorageDevice
     virtual Type type() const override { return StorageDevice::Type::IDE; }
-    virtual size_t max_addressable_block() const override;
 
     // ^BlockDevice
     virtual void start_request(AsyncBlockDeviceRequest&) override;
     virtual String device_name() const override;
 
 private:
-    PATADiskDevice(const IDEController&, IDEChannel&, DriveType, InterfaceType, u16, u16, u16, u16);
+    PATADiskDevice(const IDEController&, IDEChannel&, DriveType, InterfaceType, u16, u64);
 
     // ^DiskDevice
     virtual const char* class_name() const override;

--- a/Kernel/Storage/Partition/DiskPartition.cpp
+++ b/Kernel/Storage/Partition/DiskPartition.cpp
@@ -57,7 +57,7 @@ void DiskPartition::start_request(AsyncBlockDeviceRequest& request)
         request.block_index() + m_metadata.start_block(), request.block_count(), request.buffer(), request.buffer_size()));
 }
 
-KResultOr<size_t> DiskPartition::read(FileDescription& fd, size_t offset, UserOrKernelBuffer& outbuf, size_t len)
+KResultOr<size_t> DiskPartition::read(FileDescription& fd, u64 offset, UserOrKernelBuffer& outbuf, size_t len)
 {
     unsigned adjust = m_metadata.start_block() * block_size();
     dbgln_if(OFFD_DEBUG, "DiskPartition::read offset={}, adjust={}, len={}", fd.offset(), adjust, len);
@@ -71,7 +71,7 @@ bool DiskPartition::can_read(const FileDescription& fd, size_t offset) const
     return m_device->can_read(fd, offset + adjust);
 }
 
-KResultOr<size_t> DiskPartition::write(FileDescription& fd, size_t offset, const UserOrKernelBuffer& inbuf, size_t len)
+KResultOr<size_t> DiskPartition::write(FileDescription& fd, u64 offset, const UserOrKernelBuffer& inbuf, size_t len)
 {
     unsigned adjust = m_metadata.start_block() * block_size();
     dbgln_if(OFFD_DEBUG, "DiskPartition::write offset={}, adjust={}, len={}", offset, adjust, len);

--- a/Kernel/Storage/Partition/DiskPartition.h
+++ b/Kernel/Storage/Partition/DiskPartition.h
@@ -40,9 +40,9 @@ public:
     virtual void start_request(AsyncBlockDeviceRequest&) override;
 
     // ^BlockDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override;
 
     // ^Device

--- a/Kernel/Storage/RamdiskDevice.cpp
+++ b/Kernel/Storage/RamdiskDevice.cpp
@@ -38,10 +38,10 @@ NonnullRefPtr<RamdiskDevice> RamdiskDevice::create(const RamdiskController& cont
 }
 
 RamdiskDevice::RamdiskDevice(const RamdiskController& controller, OwnPtr<Region>&& region, int major, int minor)
-    : StorageDevice(controller, major, minor, 512, 0)
+    : StorageDevice(controller, major, minor, 512, m_region->size() / 512)
     , m_region(move(region))
 {
-    dmesgln("Ramdisk: Device #{} @ {}, length {}", minor, m_region->vaddr(), m_region->size());
+    dmesgln("Ramdisk: Device #{} @ {}, Capacity={}", minor, m_region->vaddr(), max_addressable_block() * 512);
 }
 
 RamdiskDevice::~RamdiskDevice()
@@ -51,11 +51,6 @@ RamdiskDevice::~RamdiskDevice()
 const char* RamdiskDevice::class_name() const
 {
     return "RamdiskDevice";
-}
-
-size_t RamdiskDevice::max_addressable_block() const
-{
-    return m_region->size() / 512;
 }
 
 void RamdiskDevice::start_request(AsyncBlockDeviceRequest& request)

--- a/Kernel/Storage/RamdiskDevice.h
+++ b/Kernel/Storage/RamdiskDevice.h
@@ -43,7 +43,6 @@ public:
 
     // ^StorageDevice
     virtual Type type() const override { return StorageDevice::Type::Ramdisk; }
-    virtual size_t max_addressable_block() const override;
 
     // ^BlockDevice
     virtual void start_request(AsyncBlockDeviceRequest&) override;

--- a/Kernel/Storage/SATADiskDevice.cpp
+++ b/Kernel/Storage/SATADiskDevice.cpp
@@ -33,12 +33,12 @@
 
 namespace Kernel {
 
-NonnullRefPtr<SATADiskDevice> SATADiskDevice::create(const AHCIController& controller, const AHCIPort& port, size_t sector_size, size_t max_addressable_block)
+NonnullRefPtr<SATADiskDevice> SATADiskDevice::create(const AHCIController& controller, const AHCIPort& port, size_t sector_size, u64 max_addressable_block)
 {
     return adopt(*new SATADiskDevice(controller, port, sector_size, max_addressable_block));
 }
 
-SATADiskDevice::SATADiskDevice(const AHCIController& controller, const AHCIPort& port, size_t sector_size, size_t max_addressable_block)
+SATADiskDevice::SATADiskDevice(const AHCIController& controller, const AHCIPort& port, size_t sector_size, u64 max_addressable_block)
     : StorageDevice(controller, sector_size, max_addressable_block)
     , m_port(port)
 {

--- a/Kernel/Storage/SATADiskDevice.h
+++ b/Kernel/Storage/SATADiskDevice.h
@@ -44,7 +44,7 @@ public:
     };
 
 public:
-    static NonnullRefPtr<SATADiskDevice> create(const AHCIController&, const AHCIPort&, size_t sector_size, size_t max_addressable_block);
+    static NonnullRefPtr<SATADiskDevice> create(const AHCIController&, const AHCIPort&, size_t sector_size, u64 max_addressable_block);
     virtual ~SATADiskDevice() override;
 
     // ^StorageDevice
@@ -54,7 +54,7 @@ public:
     virtual String device_name() const override;
 
 private:
-    SATADiskDevice(const AHCIController&, const AHCIPort&, size_t sector_size, size_t max_addressable_block);
+    SATADiskDevice(const AHCIController&, const AHCIPort&, size_t sector_size, u64 max_addressable_block);
 
     // ^DiskDevice
     virtual const char* class_name() const override;

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -57,7 +57,7 @@ NonnullRefPtr<StorageController> StorageDevice::controller() const
     return m_storage_controller;
 }
 
-KResultOr<size_t> StorageDevice::read(FileDescription&, size_t offset, UserOrKernelBuffer& outbuf, size_t len)
+KResultOr<size_t> StorageDevice::read(FileDescription&, u64 offset, UserOrKernelBuffer& outbuf, size_t len)
 {
     unsigned index = offset / block_size();
     u16 whole_blocks = len / block_size();
@@ -122,7 +122,7 @@ bool StorageDevice::can_read(const FileDescription&, size_t offset) const
     return offset < (max_addressable_block() * block_size());
 }
 
-KResultOr<size_t> StorageDevice::write(FileDescription&, size_t offset, const UserOrKernelBuffer& inbuf, size_t len)
+KResultOr<size_t> StorageDevice::write(FileDescription&, u64 offset, const UserOrKernelBuffer& inbuf, size_t len)
 {
     unsigned index = offset / block_size();
     u16 whole_blocks = len / block_size();

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -33,14 +33,14 @@
 
 namespace Kernel {
 
-StorageDevice::StorageDevice(const StorageController& controller, size_t sector_size, size_t max_addressable_block)
+StorageDevice::StorageDevice(const StorageController& controller, size_t sector_size, u64 max_addressable_block)
     : BlockDevice(StorageManagement::major_number(), StorageManagement::minor_number(), sector_size)
     , m_storage_controller(controller)
     , m_max_addressable_block(max_addressable_block)
 {
 }
 
-StorageDevice::StorageDevice(const StorageController& controller, int major, int minor, size_t sector_size, size_t max_addressable_block)
+StorageDevice::StorageDevice(const StorageController& controller, int major, int minor, size_t sector_size, u64 max_addressable_block)
     : BlockDevice(major, minor, sector_size)
     , m_storage_controller(controller)
     , m_max_addressable_block(max_addressable_block)

--- a/Kernel/Storage/StorageDevice.h
+++ b/Kernel/Storage/StorageDevice.h
@@ -52,9 +52,9 @@ public:
     NonnullRefPtr<StorageController> controller() const;
 
     // ^BlockDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override;
 
     // ^Device

--- a/Kernel/Storage/StorageDevice.h
+++ b/Kernel/Storage/StorageDevice.h
@@ -47,7 +47,7 @@ public:
 
 public:
     virtual Type type() const = 0;
-    virtual size_t max_addressable_block() const { return m_max_addressable_block; }
+    virtual u64 max_addressable_block() const { return m_max_addressable_block; }
 
     NonnullRefPtr<StorageController> controller() const;
 
@@ -61,15 +61,15 @@ public:
     virtual mode_t required_mode() const override { return 0600; }
 
 protected:
-    StorageDevice(const StorageController&, size_t, size_t);
-    StorageDevice(const StorageController&, int, int, size_t, size_t);
+    StorageDevice(const StorageController&, size_t, u64);
+    StorageDevice(const StorageController&, int, int, size_t, u64);
     // ^DiskDevice
     virtual const char* class_name() const override;
 
 private:
     NonnullRefPtr<StorageController> m_storage_controller;
     NonnullRefPtrVector<DiskPartition> m_partitions;
-    size_t m_max_addressable_block;
+    u64 m_max_addressable_block;
 };
 
 }

--- a/Kernel/Syscalls/ftruncate.cpp
+++ b/Kernel/Syscalls/ftruncate.cpp
@@ -29,9 +29,12 @@
 
 namespace Kernel {
 
-KResultOr<int> Process::sys$ftruncate(int fd, off_t length)
+KResultOr<int> Process::sys$ftruncate(int fd, Userspace<off_t*> userspace_length)
 {
     REQUIRE_PROMISE(stdio);
+    off_t length;
+    if (!copy_from_user(&length, userspace_length))
+        return EFAULT;
     if (length < 0)
         return EINVAL;
     auto description = file_description(fd);

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -62,14 +62,14 @@ String MasterPTY::pts_name() const
     return m_pts_name;
 }
 
-KResultOr<size_t> MasterPTY::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> MasterPTY::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
     if (!m_slave && m_buffer.is_empty())
         return 0;
     return m_buffer.read(buffer, size);
 }
 
-KResultOr<size_t> MasterPTY::write(FileDescription&, size_t, const UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> MasterPTY::write(FileDescription&, u64, const UserOrKernelBuffer& buffer, size_t size)
 {
     if (!m_slave)
         return EIO;

--- a/Kernel/TTY/MasterPTY.h
+++ b/Kernel/TTY/MasterPTY.h
@@ -54,8 +54,8 @@ public:
 
 private:
     // ^CharacterDevice
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual KResult close() override;

--- a/Kernel/TTY/PTYMultiplexer.h
+++ b/Kernel/TTY/PTYMultiplexer.h
@@ -48,8 +48,8 @@ public:
 
     // ^CharacterDevice
     virtual KResultOr<NonnullRefPtr<FileDescription>> open(int options) override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override { return 0; }
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override { return 0; }
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override { return 0; }
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return 0; }
     virtual bool can_read(const FileDescription&, size_t) const override { return true; }
     virtual bool can_write(const FileDescription&, size_t) const override { return true; }
 

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -93,7 +93,7 @@ bool SlavePTY::can_read(const FileDescription& description, size_t offset) const
     return TTY::can_read(description, offset);
 }
 
-KResultOr<size_t> SlavePTY::read(FileDescription& description, size_t offset, UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> SlavePTY::read(FileDescription& description, u64 offset, UserOrKernelBuffer& buffer, size_t size)
 {
     if (m_master->is_closed())
         return 0;

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -52,7 +52,7 @@ private:
 
     // ^CharacterDevice
     virtual bool can_read(const FileDescription&, size_t) const override;
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual const char* class_name() const override { return "SlavePTY"; }
     virtual KResult close() override;

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -52,7 +52,7 @@ void TTY::set_default_termios()
     memcpy(m_termios.c_cc, default_cc, sizeof(default_cc));
 }
 
-KResultOr<size_t> TTY::read(FileDescription&, size_t, UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> TTY::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {
     if (Process::current()->pgid() != pgid()) {
         // FIXME: Should we propagate this error path somehow?
@@ -100,7 +100,7 @@ KResultOr<size_t> TTY::read(FileDescription&, size_t, UserOrKernelBuffer& buffer
     return (size_t)nwritten;
 }
 
-KResultOr<size_t> TTY::write(FileDescription&, size_t, const UserOrKernelBuffer& buffer, size_t size)
+KResultOr<size_t> TTY::write(FileDescription&, u64, const UserOrKernelBuffer& buffer, size_t size)
 {
     if (m_termios.c_lflag & TOSTOP && Process::current()->pgid() != pgid()) {
         [[maybe_unused]] auto rc = Process::current()->send_signal(SIGTTOU, nullptr);

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -39,8 +39,8 @@ class TTY : public CharacterDevice {
 public:
     virtual ~TTY() override;
 
-    virtual KResultOr<size_t> read(FileDescription&, size_t, UserOrKernelBuffer&, size_t) override;
-    virtual KResultOr<size_t> write(FileDescription&, size_t, const UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual bool can_read(const FileDescription&, size_t) const override;
     virtual bool can_write(const FileDescription&, size_t) const override;
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override final;

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -424,9 +424,7 @@ struct sigaction {
 #define CLD_STOPPED 4
 #define CLD_CONTINUED 5
 
-#define OFF_T_MAX 2147483647
-
-typedef ssize_t off_t;
+typedef i64 off_t;
 typedef i64 time_t;
 
 struct utimbuf {

--- a/Userland/Libraries/LibC/sys/types.h
+++ b/Userland/Libraries/LibC/sys/types.h
@@ -55,7 +55,7 @@ typedef int id_t;
 typedef __WINT_TYPE__ wint_t;
 
 typedef uint32_t ino_t;
-typedef ssize_t off_t;
+typedef int64_t off_t;
 
 typedef uint32_t dev_t;
 typedef uint16_t mode_t;

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -440,8 +440,8 @@ ssize_t readlink(const char* path, char* buffer, size_t size)
 
 off_t lseek(int fd, off_t offset, int whence)
 {
-    int rc = syscall(SC_lseek, fd, offset, whence);
-    __RETURN_WITH_ERRNO(rc, rc, -1);
+    int rc = syscall(SC_lseek, fd, &offset, whence);
+    __RETURN_WITH_ERRNO(rc, offset, -1);
 }
 
 int link(const char* old_path, const char* new_path)
@@ -633,7 +633,7 @@ char* getlogin()
 
 int ftruncate(int fd, off_t length)
 {
-    int rc = syscall(SC_ftruncate, fd, length);
+    int rc = syscall(SC_ftruncate, fd, &length);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -240,7 +240,7 @@ void Client::handle_directory_listing(const String& requested_path, const String
         builder.append(escape_html_entities(name));
         builder.append("</a></td><td>&nbsp;</td>");
 
-        builder.appendf("<td>%10zd</td><td>&nbsp;</td>", st.st_size);
+        builder.appendf("<td>%10lld</td><td>&nbsp;</td>", st.st_size);
         builder.append("<td>");
         builder.append(Core::DateTime::from_timestamp(st.st_mtime).to_string());
         builder.append("</td>");

--- a/Userland/Tests/Kernel/stress-writeread.cpp
+++ b/Userland/Tests/Kernel/stress-writeread.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Random.h>
+#include <LibCore/ArgsParser.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+bool verify_block(int fd, int seed, off_t block, AK::ByteBuffer& buffer);
+bool write_block(int fd, int seed, off_t block, AK::ByteBuffer& buffer);
+
+bool verify_block(int fd, int seed, off_t block, AK::ByteBuffer& buffer)
+{
+    auto offset = block * buffer.size();
+    auto rs = lseek(fd, offset, SEEK_SET);
+    if (rs < 0) {
+        fprintf(stderr, "Couldn't seek to block %lld (offset %lld) while verifying: %s\n", block, offset, strerror(errno));
+        return false;
+    }
+    auto rw = read(fd, buffer.data(), buffer.size());
+    if (rw != static_cast<int>(buffer.size())) {
+        fprintf(stderr, "Failure to read block %lld: %s\n", block, strerror(errno));
+        return false;
+    }
+    srand((seed + 1) * (block + 1));
+    for (size_t i = 0; i < buffer.size(); i++) {
+        if (buffer[i] != rand() % 256) {
+            fprintf(stderr, "Discrepancy detected at block %lld offset %zd\n", block, i);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool write_block(int fd, int seed, off_t block, AK::ByteBuffer& buffer)
+{
+    auto offset = block * buffer.size();
+    auto rs = lseek(fd, offset, SEEK_SET);
+    if (rs < 0) {
+        fprintf(stderr, "Couldn't seek to block %lld (offset %lld) while verifying: %s\n", block, offset, strerror(errno));
+        return false;
+    }
+    srand((seed + 1) * (block + 1));
+    for (size_t i = 0; i < buffer.size(); i++)
+        buffer[i] = rand();
+    auto rw = write(fd, buffer.data(), buffer.size());
+    if (rw != static_cast<int>(buffer.size())) {
+        fprintf(stderr, "Failure to write block %lld: %s\n", block, strerror(errno));
+        return false;
+    }
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    const char* target = nullptr;
+    int min_block_offset = 0;
+    int block_length = 2048;
+    int block_size = 512;
+    int count = 1024;
+    int rng_seed = 0;
+    bool paranoid_mode = false;
+    bool random_mode = false;
+    bool stop_mode = false;
+    bool uninitialized_mode = false;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(min_block_offset, "Minimum block offset to consider", "min-offset", 'o', "size");
+    args_parser.add_option(block_length, "Number of blocks to consider", "length", 's', "size");
+    args_parser.add_option(block_size, "Block size", "block-size", 'b', "size");
+    args_parser.add_option(count, "Number of write/read cycles to run", "number", 'n', "number");
+    args_parser.add_option(rng_seed, "Random number generator seed", "seed", 'S', "number");
+    args_parser.add_option(paranoid_mode, "Check entire range for consistency after each write", "paranoid", 'p');
+    args_parser.add_option(random_mode, "Write one block inside range at random", "random", 'r');
+    args_parser.add_option(stop_mode, "Stop after first error", "abort-on-error", 'a');
+    args_parser.add_option(uninitialized_mode, "Don't pre-initialize block range", "uninitialized", 'u');
+    args_parser.add_positional_argument(target, "Target device/file path", "target");
+    args_parser.parse(argc, argv);
+
+    auto buffer = AK::ByteBuffer::create_zeroed(block_size);
+
+    int fd = open(target, O_CREAT | O_RDWR, 0666);
+    if (fd < 0) {
+        perror("Couldn't create target file");
+        return EXIT_FAILURE;
+    }
+
+    if (!uninitialized_mode) {
+        int old_percent = -100;
+        for (int i = min_block_offset; i < min_block_offset + block_length; i++) {
+            int percent;
+            if (block_length <= 1)
+                percent = 100;
+            else
+                percent = 100 * (i - min_block_offset) / (block_length - 1);
+            if (old_percent != percent) {
+                printf("Pre-initializing entire block range (%3d%%)...\n", percent);
+                old_percent = percent;
+            }
+
+            if (!write_block(fd, rng_seed, i, buffer))
+                return EXIT_FAILURE;
+        }
+    }
+
+    int r = EXIT_SUCCESS;
+    for (int i = 0; i < count; i++) {
+        printf("(%d/%d)\tPass %d...\n", i + 1, count, i + 1);
+
+        for (int j = min_block_offset; j < min_block_offset + block_length; j++) {
+            off_t block;
+            if (random_mode)
+                while ((block = AK::get_random<off_t>()) < 0)
+                    ;
+            else
+                block = j;
+            block = min_block_offset + block % block_length;
+
+            if (paranoid_mode) {
+                for (int k = min_block_offset; j < min_block_offset + block_length; j++) {
+                    if (!verify_block(fd, rng_seed, k, buffer)) {
+                        if (stop_mode)
+                            return EXIT_FAILURE;
+                        else
+                            r = EXIT_FAILURE;
+                    }
+                }
+            } else {
+                if (!verify_block(fd, rng_seed, block, buffer)) {
+                    if (stop_mode)
+                        return EXIT_FAILURE;
+                    else
+                        r = EXIT_FAILURE;
+                }
+            }
+
+            if (!write_block(fd, rng_seed, block, buffer)) {
+                if (stop_mode)
+                    return EXIT_FAILURE;
+                else
+                    r = EXIT_FAILURE;
+            }
+        }
+    }
+
+    close(fd);
+    return r;
+}

--- a/Userland/Utilities/df.cpp
+++ b/Userland/Utilities/df.cpp
@@ -33,6 +33,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -76,11 +77,11 @@ int main(int argc, char** argv)
     json.for_each([](auto& value) {
         auto fs_object = value.as_object();
         auto fs = fs_object.get("class_name").to_string();
-        auto total_block_count = fs_object.get("total_block_count").to_u32();
-        auto free_block_count = fs_object.get("free_block_count").to_u32();
-        [[maybe_unused]] auto total_inode_count = fs_object.get("total_inode_count").to_u32();
-        [[maybe_unused]] auto free_inode_count = fs_object.get("free_inode_count").to_u32();
-        auto block_size = fs_object.get("block_size").to_u32();
+        auto total_block_count = fs_object.get("total_block_count").to_u64();
+        auto free_block_count = fs_object.get("free_block_count").to_u64();
+        [[maybe_unused]] auto total_inode_count = fs_object.get("total_inode_count").to_u64();
+        [[maybe_unused]] auto free_inode_count = fs_object.get("free_inode_count").to_u64();
+        auto block_size = fs_object.get("block_size").to_u64();
         auto mount_point = fs_object.get("mount_point").to_string();
 
         printf("%-10s", fs.characters());
@@ -90,9 +91,9 @@ int main(int argc, char** argv)
             printf("%10s   ", human_readable_size((total_block_count - free_block_count) * block_size).characters());
             printf("%10s   ", human_readable_size(free_block_count * block_size).characters());
         } else {
-            printf("%10u  ", total_block_count);
-            printf("%10u   ", total_block_count - free_block_count);
-            printf("%10u   ", free_block_count);
+            printf("%10" PRIu64 "  ", total_block_count);
+            printf("%10" PRIu64 "   ", total_block_count - free_block_count);
+            printf("%10" PRIu64 "   ", free_block_count);
         }
 
         printf("%s", mount_point.characters());

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -310,7 +310,7 @@ static bool print_filesystem_object(const String& path, const String& name, cons
         printf("  %4u,%4u ", major(st.st_rdev), minor(st.st_rdev));
     } else {
         if (flag_human_readable) {
-            printf(" %10s ", human_readable_size((size_t)st.st_size).characters());
+            printf(" %10s ", human_readable_size(st.st_size).characters());
         } else {
             printf(" %10lld ", st.st_size);
         }

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -312,7 +312,7 @@ static bool print_filesystem_object(const String& path, const String& name, cons
         if (flag_human_readable) {
             printf(" %10s ", human_readable_size((size_t)st.st_size).characters());
         } else {
-            printf(" %10zd ", st.st_size);
+            printf(" %10lld ", st.st_size);
         }
     }
 

--- a/Userland/Utilities/stat.cpp
+++ b/Userland/Utilities/stat.cpp
@@ -48,7 +48,7 @@ static int stat(const char* file, bool should_follow_links)
     if (S_ISCHR(st.st_mode) || S_ISBLK(st.st_mode))
         printf("  Device: %u,%u\n", major(st.st_rdev), minor(st.st_rdev));
     else
-        printf("    Size: %zd\n", st.st_size);
+        printf("    Size: %lld\n", st.st_size);
     printf("   Links: %u\n", st.st_nlink);
     printf("  Blocks: %u\n", st.st_blocks);
     printf("     UID: %u", st.st_uid);

--- a/Userland/Utilities/truncate.cpp
+++ b/Userland/Utilities/truncate.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
     }
 
     auto op = OP_Set;
-    int size = 0;
+    off_t size = 0;
 
     if (resize) {
         String str = resize;
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
             break;
         }
 
-        auto size_opt = str.to_int();
+        auto size_opt = str.to_int<off_t>();
         if (!size_opt.has_value()) {
             args_parser.print_usage(stderr, argv[0]);
             return 1;


### PR DESCRIPTION
I wanted to properly test out my triply indirect block support for Ext2FS, but it turns out the storage stack of SerenityOS has trouble dealing with disks, files and file systems bigger than 2 GiB... Since this is not the 1990s anymore, bring out the storage stack into the 2000s, kicking and screaming.

Suffice to say, this is snowballing out of control pretty badly since this requires changes to syscalls, system types, device drivers and probably other things I've yet to discover... Note that while this branch appears to work, Ext2FS so far has yet to survive an encounter with a 8 GiB root filesystem and live to tell the tale.