### PR TITLE
LibGUI+TextEditor: Fix crash in TextDocument widget and add further info to TextEditor statusbar

### DIFF
--- a/Userland/Applications/TextEditor/TextEditorWidget.h
+++ b/Userland/Applications/TextEditor/TextEditorWidget.h
@@ -63,7 +63,7 @@ private:
     void update_preview();
     void update_markdown_preview();
     void update_html_preview();
-    void update_statusbar_cursor_position();
+    void update_statusbar();
 
     virtual void drop_event(GUI::DropEvent&) override;
 

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -315,6 +315,8 @@ String TextDocument::text() const
 
 String TextDocument::text_in_range(const TextRange& a_range) const
 {
+    if (is_empty())
+        return String("");
     auto range = a_range.normalized();
 
     StringBuilder builder;


### PR DESCRIPTION
This pull request solves issues #5768 and #5760 




Hello, this is my first contribution to this project! As such, I'd appreciate feedback on what to do and what not to do, or if I did anything wrong, as I want to be a valuable contributor.