### PR TITLE
Ports: Allow verbose argument in build_all.sh

### DIFF
--- a/Ports/build_all.sh
+++ b/Ports/build_all.sh
@@ -1,9 +1,25 @@
 #!/usr/bin/env bash
 
 clean=false
+verbose=false
+
 case "$1" in
     clean)
         clean=true
+        ;;
+    verbose)
+        verbose=true
+        ;;
+    *)
+        ;;
+esac
+
+case "$2" in
+    clean)
+        clean=true
+        ;;
+    verbose)
+        verbose=true
         ;;
     *)
         ;;
@@ -16,13 +32,26 @@ for file in *; do
         pushd $file > /dev/null
             dirname=$(basename $file)
             if [ "$clean" == true ]; then
-                ./package.sh clean_all > /dev/null 2>&1
+                if [ "$verbose" == true ]; then
+                    ./package.sh clean_all
+                else
+                    ./package.sh clean_all > /dev/null 2>&1
+                fi
             fi
-            if $(./package.sh > /dev/null 2>&1 ); then
-                echo "Built ${dirname}."
+            if [ "$verbose" == true ]; then
+                if $(./package.sh); then
+                    echo "Built ${dirname}."
+                else
+                    echo "ERROR: Build of ${dirname} was not successful!"
+                    some_failed=true
+                fi
             else
-                echo "ERROR: Build of ${dirname} was not successful!"
-                some_failed=true
+                if $(./package.sh > /dev/null 2>&1); then
+                    echo "Built ${dirname}."
+                else
+                    echo "ERROR: Build of ${dirname} was not successful!"
+                    some_failed=true
+                fi
             fi
         popd > /dev/null
     fi

--- a/Ports/build_all.sh
+++ b/Ports/build_all.sh
@@ -39,14 +39,14 @@ for file in *; do
                 fi
             fi
             if [ "$verbose" == true ]; then
-                if $(./package.sh); then
+                if ./package.sh; then
                     echo "Built ${dirname}."
                 else
                     echo "ERROR: Build of ${dirname} was not successful!"
                     some_failed=true
                 fi
             else
-                if $(./package.sh > /dev/null 2>&1); then
+                if ./package.sh > /dev/null 2>&1; then
                     echo "Built ${dirname}."
                 else
                     echo "ERROR: Build of ${dirname} was not successful!"


### PR DESCRIPTION
This patch allows for a verbose argument to be passed
so that the build output of the individual builds
is printed to stdout instead of /dev/null to help with diagnosing errors

If the verbose argument is not passed the old behaviour is preserved
and the build output is printed to /dev/null

Also fixes #5783 