### PR TITLE
LibCompress: Decrease CanonicalCode's size on stack

### DIFF
--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -49,12 +49,12 @@ public:
 
 private:
     // Decompression - indexed by code
-    Vector<u32> m_symbol_codes;
-    Vector<u32> m_symbol_values;
+    Vector<u16> m_symbol_codes;
+    Vector<u16> m_symbol_values;
 
     // Compression - indexed by symbol
-    Array<u32, 288> m_bit_codes {}; // deflate uses a maximum of 288 symbols (maximum of 32 for distances)
-    Array<u32, 288> m_bit_code_lengths {};
+    Array<u16, 288> m_bit_codes {}; // deflate uses a maximum of 288 symbols (maximum of 32 for distances)
+    Array<u16, 288> m_bit_code_lengths {};
 };
 
 class DeflateDecompressor final : public InputStream {


### PR DESCRIPTION
This commit ~~replaces the on stack arrays in CanonicalCode with heap allocated vectors~~, and stores the bit codes as u16s instead of u32s as the maximum code bit length in DEFLATE is 15 (thereby ~~effectively eliminating the stack usage, and~~ halving its total memory usage).

This fixes #5778 (which was UE running out of program stack space), but perhaps the stack space in UE should be increased anyways, as its currently 64KiB, compared to serenity's user stack of 1024KiB.