### PR TITLE
test-compress: Initialize byte buffer with random data

### DIFF
--- a/Userland/Utilities/test-compress.cpp
+++ b/Userland/Utilities/test-compress.cpp
@@ -159,7 +159,9 @@ TEST_CASE(deflate_round_trip_compress)
 
 TEST_CASE(deflate_round_trip_compress_large)
 {
-    auto original = ByteBuffer::create_uninitialized(Compress::DeflateCompressor::block_size * 2); // Compress a buffer larger than the maximum block size to test the sliding window mechanism
+    auto size = Compress::DeflateCompressor::block_size * 2;
+    auto original = ByteBuffer::create_uninitialized(size); // Compress a buffer larger than the maximum block size to test the sliding window mechanism
+    fill_with_random(original.data(), size);
     // Since the different levels just change how much time is spent looking for better matches, just use fast here to reduce test time
     auto compressed = Compress::DeflateCompressor::compress_all(original, Compress::DeflateCompressor::CompressionLevel::FAST);
     EXPECT(compressed.has_value());


### PR DESCRIPTION
Whether the buffer is uninitialized or initialized with random junk data should make no difference to the test (unless it's NUL terminated during string compare?).

`UserspaceEmulator` complains about using uninitialized data when running `test-compress`, spitting out the following error hundreds of times, which causes the tests to takes ~80 seconds to complete.

```
==35==  Conditional depends on uninitialized data (jcc imm8)

=={35}==    0x24a48153  [libcompress.so]: Compress::DeflateCompressor::compare_match_candidate(unsigned long, unsigned long, unsigned long, un
signed long) +0x53 (Deflate.cpp:520)
=={35}==    0x24a482a4  [libcompress.so]: Compress::DeflateCompressor::find_back_match(unsigned long, unsigned short, unsigned long, unsigned 
long, unsigned long&) +0xc4 (Deflate.cpp:559)
=={35}==    0x24a4845b  [libcompress.so]: Compress::DeflateCompressor::lz77_compress_block() +0x13b (Deflate.cpp:659)
=={35}==    0x24a4936c  [libcompress.so]: Compress::DeflateCompressor::flush() +0x15c (Deflate.cpp:951)
=={35}==    0x24a49b9c  [libcompress.so]: Compress::DeflateCompressor::write(AK::Span<unsigned char const>) [clone .localalias] +0x11c (Deflat
e.cpp:492)
=={35}==    0x24a49c0d  [libcompress.so]: Compress::DeflateCompressor::write_or_error(AK::Span<unsigned char const>) +0x3d (Deflate.cpp:499)
=={35}==    0x24a49d79  [libcompress.so]: Compress::DeflateCompressor::compress_all(AK::Span<unsigned char const> const&, Compress::DeflateCom
pressor::CompressionLevel) +0xf9 (Deflate.cpp:1023)
=={35}==    0x2e4f8a47  [/bin/test-compress]: __test_deflate_round_trip_compress_large() +0x67 (test-compress.cpp:165)
=={35}==    0x2e4e90a6  [/bin/test-compress]: AK::TestSuite::run(AK::NonnullRefPtrVector<AK::TestCase, 0ul> const&) +0x316 (TestSuite.h:87)
=={35}==    0x2e4e82fe  [/bin/test-compress]: AK::TestSuite::main(AK::String const&, int, char**) +0x29e (TestSuite.h:186)
=={35}==    0x2e4e8766  [/bin/test-compress]: main +0x66 (test-compress.cpp:280)
=={35}==    0x2e4e8bd5  [/bin/test-compress]: _start +0x45 (crt0_shared.cpp:60)
=={35}==    0x08028aa2
=={35}==    0x0800155b
Shell(25): Job entry 'cat asdf' deleted in 132 ms
```

This patch allows `test-compress` to be run in `UserspaceEmulator` in a mere 2.6 seconds.
