### PR TITLE
readelf: Tweak section headers output column padding

### DIFF
--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -397,10 +397,10 @@ int main(int argc, char** argv)
             printf("There are no sections in this file.\n");
         } else {
             printf("Section Headers:\n");
-            printf("  Name            Type            Address  Offset   Size     Flags\n");
+            printf("  Name                Type            Address  Offset   Size     Flags\n");
 
             interpreter_image.for_each_section([](const ELF::Image::Section& section) {
-                printf("  %-15s ", StringView(section.name()).to_string().characters());
+                printf("  %-19s ", StringView(section.name()).to_string().characters());
                 printf("%-15s ", object_section_header_type_to_string(section.type()));
                 printf("%08x ", section.address());
                 printf("%08x ", section.offset());


### PR DESCRIPTION
Since `unmap_after_init` was added it is now the longest section name and was messing up `readelf` output columns.

# Before
![image](https://user-images.githubusercontent.com/434827/111073812-4eb1c980-8534-11eb-810e-64df6ec243fb.png)

# After
![image](https://user-images.githubusercontent.com/434827/111073809-4b1e4280-8534-11eb-9346-842b7bdbeb44.png)
