### PR TITLE
Kernel: DevFS + Block Device IO fixes

### DIFF
--- a/Kernel/Devices/AsyncDeviceRequest.cpp
+++ b/Kernel/Devices/AsyncDeviceRequest.cpp
@@ -91,15 +91,11 @@ void AsyncDeviceRequest::add_sub_request(NonnullRefPtr<AsyncDeviceRequest> sub_r
     VERIFY(sub_request->m_parent_request == nullptr);
     sub_request->m_parent_request = this;
 
-    bool should_start;
-    {
-        ScopedSpinLock lock(m_lock);
-        VERIFY(!is_completed_result(m_result));
-        m_sub_requests_pending.append(sub_request);
-        should_start = (m_result == Started);
-    }
-    if (should_start)
-        sub_request->do_start();
+    ScopedSpinLock lock(m_lock);
+    VERIFY(!is_completed_result(m_result));
+    m_sub_requests_pending.append(sub_request);
+    if (m_result == Started)
+        sub_request->do_start(move(lock));
 }
 
 void AsyncDeviceRequest::sub_request_finished(AsyncDeviceRequest& sub_request)

--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -82,19 +82,14 @@ String Device::absolute_path(const FileDescription&) const
 
 void Device::process_next_queued_request(Badge<AsyncDeviceRequest>, const AsyncDeviceRequest& completed_request)
 {
-    AsyncDeviceRequest* next_request = nullptr;
-
-    {
-        ScopedSpinLock lock(m_requests_lock);
-        VERIFY(!m_requests.is_empty());
-        VERIFY(m_requests.first().ptr() == &completed_request);
-        m_requests.remove(m_requests.begin());
-        if (!m_requests.is_empty())
-            next_request = m_requests.first().ptr();
+    ScopedSpinLock lock(m_requests_lock);
+    VERIFY(!m_requests.is_empty());
+    VERIFY(m_requests.first().ptr() == &completed_request);
+    m_requests.remove(m_requests.begin());
+    if (!m_requests.is_empty()) {
+        auto* next_request = m_requests.first().ptr();
+        next_request->do_start(move(lock));
     }
-
-    if (next_request)
-        next_request->start();
 
     evaluate_block_conditions();
 }

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -72,14 +72,11 @@ public:
     NonnullRefPtr<AsyncRequestType> make_request(Args&&... args)
     {
         auto request = adopt(*new AsyncRequestType(*this, forward<Args>(args)...));
-        bool was_empty;
-        {
-            ScopedSpinLock lock(m_requests_lock);
-            was_empty = m_requests.is_empty();
-            m_requests.append(request);
-        }
+        ScopedSpinLock lock(m_requests_lock);
+        bool was_empty = m_requests.is_empty();
+        m_requests.append(request);
         if (was_empty)
-            request->do_start({});
+            request->do_start(move(lock));
         return request;
     }
 

--- a/Kernel/FileSystem/DevFS.cpp
+++ b/Kernel/FileSystem/DevFS.cpp
@@ -387,7 +387,7 @@ ssize_t DevFSDeviceInode::write_bytes(off_t offset, ssize_t count, const UserOrK
 {
     LOCKER(m_lock);
     VERIFY(!!description);
-    if (!m_attached_device->can_read(*description, offset))
+    if (!m_attached_device->can_write(*description, offset))
         return -EIO;
     auto nread = const_cast<Device&>(*m_attached_device).write(*description, offset, buffer, count);
     if (nread.is_error())

--- a/Kernel/FileSystem/DevFS.cpp
+++ b/Kernel/FileSystem/DevFS.cpp
@@ -362,7 +362,7 @@ ssize_t DevFSDeviceInode::read_bytes(off_t offset, ssize_t count, UserOrKernelBu
     LOCKER(m_lock);
     VERIFY(!!description);
     if (!m_attached_device->can_read(*description, offset))
-        return -EIO;
+        return 0;
     auto nread = const_cast<Device&>(*m_attached_device).read(*description, offset, buffer, count);
     if (nread.is_error())
         return -EIO;
@@ -388,7 +388,7 @@ ssize_t DevFSDeviceInode::write_bytes(off_t offset, ssize_t count, const UserOrK
     LOCKER(m_lock);
     VERIFY(!!description);
     if (!m_attached_device->can_write(*description, offset))
-        return -EIO;
+        return 0;
     auto nread = const_cast<Device&>(*m_attached_device).write(*description, offset, buffer, count);
     if (nread.is_error())
         return -EIO;


### PR DESCRIPTION
Thanks to @tomuta, we are able to read from harddrives when booting with IDE drives.

Related to #5793.