### PR TITLE
LibELF+LibTest: Fix serenity_install_sources() paths

### DIFF
--- a/Userland/Libraries/LibELF/CMakeLists.txt
+++ b/Userland/Libraries/LibELF/CMakeLists.txt
@@ -1,1 +1,1 @@
-serenity_install_sources(Libraries/LibELF)
+serenity_install_sources("Userland/Libraries/LibELF")

--- a/Userland/Libraries/LibTest/CMakeLists.txt
+++ b/Userland/Libraries/LibTest/CMakeLists.txt
@@ -1,2 +1,1 @@
-
-serenity_install_sources(Libraries/LibTest)
+serenity_install_sources("Userland/Libraries/LibTest")


### PR DESCRIPTION
Currently we end up with the following:

    serenity/
        AK/
            ...
        Kernel/
            ...
        Libraries/
            LibELF/
            LibTest/
        Userland/
            Libraries/
                <all other libs>
            ...