### PR TITLE
Shell: Consume the username when parsing '~user'

### DIFF
--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -1686,7 +1686,11 @@ RefPtr<AST::Node> Parser::parse_bareword()
             restore_to(rule_start->offset, rule_start->line);
             auto ch = consume();
             VERIFY(ch == '~');
+            auto username_length = username.length();
             tilde = create<AST::Tilde>(move(username));
+            // Consume the username (if any)
+            for (size_t i = 0; i < username_length; ++i)
+                consume();
         }
 
         if (string.is_empty())


### PR DESCRIPTION
Otherwise it will stay there and be parsed as a juxtaposition.
Fixes #5798.