### PR TITLE
UserspaceEmulator: downgrade TODO to dbgln for invalid fcntl cmd arg

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -668,7 +668,7 @@ u32 Emulator::virt$fcntl(int fd, int cmd, u32 arg)
     case F_ISTTY:
         break;
     default:
-        TODO();
+        dbgln("Invalid fcntl cmd: {}", cmd);
     }
 
     return syscall(SC_fcntl, fd, cmd, arg);


### PR DESCRIPTION
Test: `/usr/Tests/Kernel/crash-fcntl-invalid-cmd`
