### PR TITLE
LibTextCodec: Make UTF16BEDecoder read only up to an even offset

### DIFF
--- a/Userland/Libraries/LibTextCodec/Decoder.cpp
+++ b/Userland/Libraries/LibTextCodec/Decoder.cpp
@@ -183,7 +183,8 @@ String UTF8Decoder::to_utf8(const StringView& input)
 String UTF16BEDecoder::to_utf8(const StringView& input)
 {
     StringBuilder builder(input.length() / 2);
-    for (size_t i = 0; i < input.length(); i += 2) {
+    size_t utf16_length = input.length() - (input.length() % 2);
+    for (size_t i = 0; i < utf16_length; i += 2) {
         u16 code_point = (input[i] << 8) | input[i + 1];
         builder.append_code_point(code_point);
     }


### PR DESCRIPTION
Reading up to the end of the input string of odd length results in an out-of-bounds read. (this fixes #5769)

FuzzUTF16BEDecoder is one of the 3 fuzzers that are crashing on the majority of cases fed to them by oss-fuzz (50% in this case assuming even distribution of input lengths :p), causing oss-fuzz to assume a failing build, so this is the first part of 3 to eventually making #5682 build again.