### PR TITLE
LibCompress+AK: Fail gracefuly in Zlib and Deflate decompression

### DIFF
--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -116,6 +116,11 @@ public:
             m_next_byte.clear();
     }
 
+    bool handle_any_error() override
+    {
+        return m_stream.handle_any_error() || Stream::handle_any_error();
+    }
+
 private:
     Optional<u8> m_next_byte;
     size_t m_bit_offset { 0 };

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -321,6 +321,11 @@ bool DeflateDecompressor::discard_or_error(size_t count)
 
 bool DeflateDecompressor::unreliable_eof() const { return m_state == State::Idle && m_read_final_bock; }
 
+bool DeflateDecompressor::handle_any_error()
+{
+    return m_input_stream.handle_any_error() || Stream::handle_any_error();
+}
+
 Optional<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
 {
     InputMemoryStream memory_stream { bytes };

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -102,6 +102,7 @@ public:
     bool discard_or_error(size_t) override;
 
     bool unreliable_eof() const override;
+    bool handle_any_error() override;
 
     static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
 

--- a/Userland/Libraries/LibCompress/Zlib.h
+++ b/Userland/Libraries/LibCompress/Zlib.h
@@ -34,21 +34,22 @@ namespace Compress {
 
 class Zlib {
 public:
-    Zlib(ReadonlyBytes data);
-
     Optional<ByteBuffer> decompress();
     u32 checksum();
 
+    static Optional<Zlib> try_create(ReadonlyBytes data);
     static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
 
 private:
+    Zlib(const ReadonlyBytes& data);
+
     u8 m_compression_method;
     u8 m_compression_info;
     u8 m_check_bits;
     u8 m_has_dictionary;
     u8 m_compression_level;
 
-    u32 m_checksum;
+    u32 m_checksum { 0 };
     ReadonlyBytes m_input_data;
     ReadonlyBytes m_data_bytes;
 };


### PR DESCRIPTION
This PR adds a verify-less try_create method to the Zlib decompressor to allow for graceful failures of parsing the Zlib headers, as well as ensures that error handling is propagated to the underlying wrapped streams in DeflateDecompressor so they dont fail a VERIFY on destruction.

FuzzZlibDecompression & FuzzDeflateDecompression are 2 of 3 fuzzers that are crashing on the majority of cases fed to them by oss-fuzz, causing oss-fuzz to assume a failing build, merging this should hopefully fix #5682.