### PR TITLE
Base: Change path to both `modload` and `modunload`

### DIFF
--- a/Base/usr/share/man/man7/kernel_modules.md
+++ b/Base/usr/share/man/man7/kernel_modules.md
@@ -59,7 +59,7 @@ extern "C" void module_fini()
 
 ## See also
 
-* [`modload`(1)](../man1/modload.md)
-* [`modunload`(1)](../man1/modunload.md)
+* [`modload`(1)](../man8/modload.md)
+* [`modunload`(1)](../man8/modunload.md)
 * [`module_load`(2)](../man2/module_load.md)
 * [`module_unload`(2)](../man2/module_unload.md)

--- a/Base/usr/share/man/man7/kernel_modules.md
+++ b/Base/usr/share/man/man7/kernel_modules.md
@@ -59,7 +59,7 @@ extern "C" void module_fini()
 
 ## See also
 
-* [`modload`(1)](../man8/modload.md)
-* [`modunload`(1)](../man8/modunload.md)
+* [`modload`(8)](../man8/modload.md)
+* [`modunload`(8)](../man8/modunload.md)
 * [`module_load`(2)](../man2/module_load.md)
 * [`module_unload`(2)](../man2/module_unload.md)


### PR DESCRIPTION
Seems like the `MD` file of `modload` and `modunload` has moved to `man8` instead of `man1`.