### PR TITLE
Kernel+LibC: Make libc.a self contained and fix TLS allocation for static programs

### DIFF
--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -310,6 +310,7 @@ static KResultOr<LoadResult> load_elf_object(NonnullOwnPtr<Space> new_space, Fil
                 ph_load_result = region_or_error.error();
                 return IterationDecision::Break;
             }
+
             master_tls_region = region_or_error.value();
             master_tls_size = program_header.size_in_memory();
             master_tls_alignment = program_header.alignment();
@@ -444,6 +445,11 @@ KResultOr<LoadResult> Process::load(NonnullRefPtr<FileDescription> main_program_
         auto result = load_elf_object(new_space.release_nonnull(), main_program_description, FlatPtr { 0 }, ShouldAllocateTls::Yes);
         if (result.is_error())
             return result.error();
+
+        m_master_tls_region = result.value().tls_region;
+        m_master_tls_size = result.value().tls_size;
+        m_master_tls_alignment = result.value().tls_alignment;
+
         return result;
     }
 

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -1005,7 +1005,7 @@ size_t Thread::thread_specific_region_size() const
 
 KResult Thread::make_thread_specific_region(Badge<Process>)
 {
-    // The process may not require a TLS region
+    // The process may not require a TLS region, or allocate TLS later with sys$allocate_tls (which is what dynamically loaded programs do)
     if (!process().m_master_tls_region)
         return KSuccess;
 
@@ -1022,8 +1022,10 @@ KResult Thread::make_thread_specific_region(Badge<Process>)
     auto* thread_local_storage = (u8*)((u8*)thread_specific_data) - align_up_to(process().m_master_tls_size, process().m_master_tls_alignment);
     m_thread_specific_data = VirtualAddress(thread_specific_data);
     thread_specific_data->self = thread_specific_data;
+
     if (process().m_master_tls_size)
         memcpy(thread_local_storage, process().m_master_tls_region.unsafe_ptr()->vaddr().as_ptr(), process().m_master_tls_size);
+
     return KSuccess;
 }
 

--- a/Meta/check-symbols.sh
+++ b/Meta/check-symbols.sh
@@ -11,8 +11,12 @@ cd "$script_path/.." || exit 1
 FORBIDDEN_SYMBOLS="__cxa_guard_acquire __cxa_guard_release"
 LIBC_PATH="Build/Userland/Libraries/LibC/libc.a"
 for forbidden_symbol in $FORBIDDEN_SYMBOLS; do
-    # check if symbol is undefined
-    if nm $LIBC_PATH | grep "U $forbidden_symbol" ; then
+    # check if there's an undefined reference to the symbol & it is not defined anywhere else in the library
+    nm $LIBC_PATH | grep "U $forbidden_symbol"
+    APPEARS_AS_UNDEFINED=$?
+    nm $LIBC_PATH | grep "T $forbidden_symbol"
+    APPEARS_AS_DEFINED=$?
+    if [ $APPEARS_AS_UNDEFINED -eq 0 ] && [ ! $APPEARS_AS_DEFINED -eq 0 ]; then
         echo "Forbidden undefined symbol in LibC: $forbidden_symbol"
         echo "See comment in Meta/check-symbols.sh for more info"
         exit 1

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -85,11 +85,31 @@ add_custom_command(
 
 set(SOURCES ${LIBC_SOURCES} ${AK_SOURCES} ${ELF_SOURCES} ${ASM_SOURCES})
 
-serenity_libc_static(LibCStatic c)
-target_link_libraries(LibCStatic crt0 ssp system)
-add_dependencies(LibCStatic LibM LibSystem)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++")
+add_library(LibCStaticWithoutDeps STATIC ${SOURCES})
+target_link_libraries(LibCStaticWithoutDeps crt0 ssp)
+add_dependencies(LibCStaticWithoutDeps LibM LibSystem)
+
+add_custom_target(LibCStatic
+        COMMAND ${CMAKE_AR} -x $<TARGET_FILE:LibCStaticWithoutDeps>
+        COMMAND ${CMAKE_AR} -x $<TARGET_FILE:ssp>
+        COMMAND ${CMAKE_AR} -x $<TARGET_FILE:LibSystemStatic>
+        COMMAND ${CMAKE_AR} -qcs ${CMAKE_CURRENT_BINARY_DIR}/libc.a *.o
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        DEPENDS LibCStaticWithoutDeps ssp LibSystemStatic
+        )
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libc.a DESTINATION ${CMAKE_INSTALL_PREFIX}/usr/lib/)
+file(GLOB TEMP_OBJ_FILES ${CMAKE_CURRENT_BINARY_DIR}/*.o)
+set_property(
+        TARGET LibCStatic
+        APPEND
+        PROPERTY ADDITIONAL_CLEAN_FILES ${TEMP_OBJ_FILES}
+)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++")
 serenity_libc(LibC c)
 target_link_libraries(LibC crt0 ssp system)
-add_dependencies(LibC LibM LibSystem)
+
+# We mark LibCStatic as a dependency of LibC because this triggers the build of the LibCStatic target
+add_dependencies(LibC LibM LibSystem LibCStatic)

--- a/Userland/Libraries/LibSystem/CMakeLists.txt
+++ b/Userland/Libraries/LibSystem/CMakeLists.txt
@@ -5,3 +5,6 @@ set(SOURCES
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdlib")
 serenity_libc(LibSystem system)
 target_include_directories(LibSystem PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(LibSystemStatic STATIC ${SOURCES})
+target_include_directories(LibSystemStatic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Closes #5758.

Apparently simply using `target_link_libraries` with static archives does not actually include the contents of the dependencies in the target archive.
So previously, `libc.a` did not contain symbols from `ssp` and `LibSystem` which caused compilation of statically linked programs to fail.

This PR fixes this by first building `LibCStaticWithoutDeps`, which is an archive that consists of all object files of libc without any other required dependencies. 

We then build `libc.a` with a custom CMake rule that first extracts all object files out of the archives of `LibCStaticWithoutDeps` and the required dependencies, and then combines them all into a single libc.a.

Doing this with a custom CMake target is not the prettiest, but I didn't find any built-in way to do this with CMake. ~~And hardcoding the path to `libstdc++` is meh~~ (We actually don't need to link libcstdc++ here). So suggestions to improve the way it's done here are welcome.

I also fixed some loading code in the kernel to actually setup a TLS region for statically linked programs (I'm pretty sure it used to work right after we switched to dynamic linking and we just didn't notice when it broke).

Compiling & running a test program with `-static` now works. 

cc @BenWiederhake @ADKaster 