### PR TITLE
LibGfx: Draw window frame icon scaled to title_bar_icon_rect()

### DIFF
--- a/Userland/Libraries/LibGfx/ClassicWindowTheme.cpp
+++ b/Userland/Libraries/LibGfx/ClassicWindowTheme.cpp
@@ -109,7 +109,7 @@ void ClassicWindowTheme::paint_normal_frame(Painter& painter, WindowState window
         painter.draw_text(clipped_title_rect.translated(0, 1), title_text, title_font, Gfx::TextAlignment::CenterLeft, title_color, Gfx::TextElision::Right);
     }
 
-    painter.blit(titlebar_icon_rect.location(), icon, icon.rect());
+    painter.draw_scaled_bitmap(titlebar_icon_rect, icon, icon.rect());
 }
 
 void ClassicWindowTheme::paint_tool_window_frame(Painter& painter, WindowState window_state, const IntRect& window_rect, const StringView& title_text, const Palette& palette, const IntRect& leftmost_button_rect) const


### PR DESCRIPTION
Partially fixes #5806.

---

Current state (using unaltered `/res/graphics/buggie.png` as window icon):

![image](https://user-images.githubusercontent.com/19366641/111218496-17482900-85d7-11eb-9b93-50716be7e749.png)


The `TaskbarButton` icon needs some more thought as it involves `blit_disabled()` and `blit_brightened()` which cannot easily be replaced with `draw_scaled_bitmap()` like this.