### PR TITLE
Shell: Avoid unnecessarily taking control of the standard streams

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -862,7 +862,6 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
         if (!job->exited())
             return;
 
-        restore_ios();
         if (job->is_running_in_background() && job->should_announce_exit())
             warnln("Shell: Job {} ({}) exited\n", job->job_id(), job->cmd().characters());
         else if (job->signaled() && job->should_announce_signal())


### PR DESCRIPTION
As of a0506cb, this is no longer needed to write to stdout.
Fixes #5776.

Let's hope this doesn't break anything else >_<