### PR TITLE
UserspaceEmulator: Print PID in mmap nullptr with MAP_FIXED reportln()

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -750,7 +750,7 @@ u32 Emulator::virt$mmap(u32 params_addr)
         else {
             // mmap(nullptr, …, MAP_FIXED) is technically okay, but tends to be a bug.
             // Therefore, refuse to be helpful.
-            reportln("\n=={}==  \033[31;1mTried to mmap at nullptr with MAP_FIXED.\033[0m, 0x{:x} bytes.", params.size);
+            reportln("\n=={}==  \033[31;1mTried to mmap at nullptr with MAP_FIXED.\033[0m, 0x{:x} bytes.", getpid(), params.size);
             dump_backtrace();
         }
     } else {


### PR DESCRIPTION
Unbalanced `{}` were causing an unrelated crash in `AK/Span.h`.

Test: `ue /usr/Tests/Kernel/munmap-multi-region-unmapping`
