### PR TITLE
AK+LibCompress: More stream error handling

### DIFF
--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -118,7 +118,8 @@ public:
 
     bool handle_any_error() override
     {
-        return m_stream.handle_any_error() || Stream::handle_any_error();
+        bool handled_errors = m_stream.handle_any_error();
+        return Stream::handle_any_error() || handled_errors;
     }
 
 private:

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -323,7 +323,8 @@ bool DeflateDecompressor::unreliable_eof() const { return m_state == State::Idle
 
 bool DeflateDecompressor::handle_any_error()
 {
-    return m_input_stream.handle_any_error() || Stream::handle_any_error();
+    bool handled_errors = m_input_stream.handle_any_error();
+    return Stream::handle_any_error() || handled_errors;
 }
 
 Optional<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)

--- a/Userland/Libraries/LibCompress/Gzip.h
+++ b/Userland/Libraries/LibCompress/Gzip.h
@@ -67,6 +67,7 @@ public:
     bool discard_or_error(size_t) override;
 
     bool unreliable_eof() const override;
+    bool handle_any_error() override;
 
     static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
     static bool is_likely_compressed(ReadonlyBytes bytes);


### PR DESCRIPTION
This PR fixes a small mistake in #5803 related to boolean short-circuiting (which should help FuzzDeflateDecompression pass the oss-fuzz build checks), as well as improves stream error handling in GzipDecompressor, which should help improve fuzzing coverage in the FuzzGzipDecompression fuzzer.