### PR TITLE
UserspaceEmulator: Add symlink, rename, set_coredump_metadata syscalls

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -125,6 +125,9 @@ private:
     int virt$mkdir(FlatPtr path, size_t path_length, mode_t mode);
     int virt$rmdir(FlatPtr path, size_t path_length);
     int virt$unlink(FlatPtr path, size_t path_length);
+    int virt$symlink(FlatPtr address);
+    int virt$rename(FlatPtr address);
+    int virt$set_coredump_metadata(FlatPtr address);
     int virt$get_process_name(FlatPtr buffer, int size);
     int virt$set_process_name(FlatPtr buffer, int size);
     int virt$set_mmap_name(FlatPtr);


### PR DESCRIPTION
Test `rename`:

```
ue /usr/Tests/Kernel/filesystem-strips-file-suid-sgid-bits-when-modified
```

Test `symlink`:

```
ue /usr/Tests/Kernel/bind-local-socket-to-symlink
```
