### PR TITLE
LibCompress: Allow partial header reads in GzipDecompressor

### DIFF
--- a/Userland/Libraries/LibCompress/Gzip.h
+++ b/Userland/Libraries/LibCompress/Gzip.h
@@ -91,6 +91,8 @@ private:
     Member& current_member() { return m_current_member.value(); }
 
     InputStream& m_input_stream;
+    u8 m_partial_header[sizeof(BlockHeader)];
+    size_t m_partial_header_offset { 0 };
     Optional<Member> m_current_member;
 
     bool m_eof { false };


### PR DESCRIPTION
We now read the header into a temporary header byte array that is used as the header once its filled up by the input stream, instead of just ending the stream if we are out of bytes mid header.

As requested by @alimpfard on IRC