### PR TITLE
LibAudio: decrease WavLoader's size limit to a more reasonable size

### DIFF
--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -34,6 +34,8 @@
 
 namespace Audio {
 
+static constexpr size_t maximum_wav_size = 1 * GiB; // FIXME: is there a more appropriate size limit?
+
 WavLoaderPlugin::WavLoaderPlugin(const StringView& path)
     : m_file(Core::File::construct(path))
 {
@@ -243,7 +245,7 @@ bool WavLoaderPlugin::parse_header()
     CHECK_OK("Found no data chunk");
     VERIFY(found_data);
 
-    ok = ok && data_sz < INT32_MAX;
+    ok = ok && data_sz < maximum_wav_size;
     CHECK_OK("Data was too large");
 
     int bytes_per_sample = (m_bits_per_sample / 8) * m_num_channels;


### PR DESCRIPTION
A 4 GiB wav (current size limit) is very unreasonable, and larger than oss-fuzz's 2.5 GiB per-process memory limit.
Found as a result of investigating https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31658 and should fix it.