### PR TITLE
LibJS: Don't apply arguments object hack to global execution context

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -163,8 +163,8 @@ void VM::set_variable(const FlyString& name, Value value, GlobalObject& global_o
 
 Value VM::get_variable(const FlyString& name, GlobalObject& global_object)
 {
-    if (m_call_stack.size()) {
-        if (name == names.arguments) {
+    if (!m_call_stack.is_empty()) {
+        if (name == names.arguments && m_call_stack.size() > 1) {
             // HACK: Special handling for the name "arguments":
             //       If the name "arguments" is defined in the current scope, for example via
             //       a function parameter, or by a local var declaration, we use that.


### PR DESCRIPTION
Checking for the existence of a call frame is not enough to check if we're in a function call, as the global execution context is a regular call frame as well.

Found by OSS-Fuzz, where simply accessing "arguments" in the global scope would crash due to `call_frame().callee` being an empty value (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=32115).