### PR TITLE
LibGfx: Fail gracefuly on invalid interlace method in PNGLoader

### DIFF
--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -796,7 +796,8 @@ static bool decode_png_bitmap(PNGLoadingContext& context)
             return false;
         break;
     default:
-        VERIFY_NOT_REACHED();
+        context.state = PNGLoadingContext::State::Error;
+        return false;
     }
 
     context.decompression_buffer.clear();


### PR DESCRIPTION
This fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29791