### PR TITLE
LibGfx: Don't truncate macroblock indices in JPG decoder.

### DIFF
--- a/Userland/Libraries/LibGfx/JPGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPGLoader.cpp
@@ -288,7 +288,7 @@ static Optional<u8> get_next_symbol(HuffmanStreamState& hstream, const HuffmanTa
  * macroblocks that share the chrominance data. Next two iterations (assuming that
  * we are dealing with three components) will fill up the blocks with chroma data.
  */
-static bool build_macroblocks(JPGLoadingContext& context, Vector<Macroblock>& macroblocks, u8 hcursor, u8 vcursor)
+static bool build_macroblocks(JPGLoadingContext& context, Vector<Macroblock>& macroblocks, u32 hcursor, u32 vcursor)
 {
     for (auto it = context.components.begin(); it != context.components.end(); ++it) {
         ComponentSpec& component = it->value;


### PR DESCRIPTION
Fixes the rendering of large (>256 MCUs in one dimension) jpeg files. Before the fix the rendered upper left corner was full of image chunks and the rest of the image was just gray.