### PR TITLE
AK: Tests: TestURL: Add port_int_overflow_wrap test

### DIFF
--- a/AK/Tests/TestURL.cpp
+++ b/AK/Tests/TestURL.cpp
@@ -213,4 +213,12 @@ TEST_CASE(trailing_port)
     EXPECT_EQ(url.port(), 8086);
 }
 
+TEST_CASE(port_int_overflow_wrap)
+{
+    auto expected_port = 80;
+    URL url(String::formatted("http://example.com:{}/", (u32)((65536 * 1000) + expected_port)));
+    EXPECT_EQ(url.port(), expected_port);
+    EXPECT_EQ(url.is_valid(), true);
+}
+
 TEST_MAIN(URL)


### PR DESCRIPTION
`AK::URL` casts the port portion of the URL string to `u16`. The current intended and expected behavior is for values larger than `u16` max integer size (`65,536`) to wrap. This is fine, so long as all users of `AK::URL` rely on the `port` property instead of trying to implement their own parsing outside of `AK::URL`.

This PR adds a test to ensure this behavior doesn't change as this may affect instances where port wrapping is relied upon.
