### PR TITLE
CppLanguageServer: Fix crash after typing anything after '#'

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.cpp
@@ -426,6 +426,7 @@ OwnPtr<ParserAutoComplete::DocumentData> ParserAutoComplete::create_document_dat
     document_data->m_filename = move(filename);
     document_data->m_text = move(text);
     document_data->m_preprocessor = make<Preprocessor>(document_data->m_filename, document_data->text());
+    document_data->preprocessor().set_ignore_unsupported_keywords(true);
     document_data->preprocessor().process();
 
     Preprocessor::Definitions all_definitions;

--- a/Userland/Libraries/LibCpp/Preprocessor.cpp
+++ b/Userland/Libraries/LibCpp/Preprocessor.cpp
@@ -184,8 +184,11 @@ void Preprocessor::handle_preprocessor_line(const StringView& line)
         lexer.consume_all();
         return;
     }
-    dbgln("Unsupported preprocessor keyword: {}", keyword);
-    VERIFY_NOT_REACHED();
+
+    if (!m_options.ignore_unsupported_keywords) {
+        dbgln("Unsupported preprocessor keyword: {}", keyword);
+        VERIFY_NOT_REACHED();
+    }
 }
 
 const String& Preprocessor::processed_text()

--- a/Userland/Libraries/LibCpp/Preprocessor.h
+++ b/Userland/Libraries/LibCpp/Preprocessor.h
@@ -52,6 +52,8 @@ public:
 
     const Definitions& definitions() const { return m_definitions; }
 
+    void set_ignore_unsupported_keywords(bool ignore) { m_options.ignore_unsupported_keywords = ignore; }
+
 private:
     void handle_preprocessor_line(const StringView&);
 
@@ -74,5 +76,9 @@ private:
 
     Vector<StringView> m_included_paths;
     String m_processed_text;
+
+    struct Options {
+        bool ignore_unsupported_keywords { false };
+    } m_options;
 };
 }


### PR DESCRIPTION
Under some circumstances we need to ignore unsupported preprocessor keywords instead of crashing the processing, for example during live parsing in HackStudio.

Fixes #5846