### PR TITLE
Piano: Avoid selecting out of range notes.

### DIFF
--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -191,7 +191,7 @@ void RollWidget::mousemove_event(GUI::MouseEvent& event)
         if (note_width_is_fractional && x_is_not_last)
             ++x;
         x /= m_note_width;
-        return x;
+        return clamp(x, 0, m_num_notes - 1);
     };
 
     int x0 = get_note_x(m_note_drag_start.value().x());


### PR DESCRIPTION
Fixes #5736. I guess the note selection was done so that, when zoomed in, you could drag past the end of the window and still continue selecting the notes. This commit preserves this behavior, but now it won't let you choose invalid notes. 