### PR TITLE
LibJS: Actually use eval() in non-string arg eval test

### DIFF
--- a/Userland/Libraries/LibJS/Tests/eval-basic.js
+++ b/Userland/Libraries/LibJS/Tests/eval-basic.js
@@ -26,6 +26,6 @@ test("syntax error", () => {
 });
 
 test("returns 1st argument unless 1st argument is a string", () => {
-    var string_object = new String("1 + 2");
-    expect(string_object).toBe(string_object);
+    var stringObject = new String("1 + 2");
+    expect(eval(stringObject)).toBe(stringObject);
 });


### PR DESCRIPTION
:^)