### PR TITLE
LibCore: Verify type of value in enum property setter

### DIFF
--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -321,6 +321,8 @@ T* Object::find_descendant_of_type_named(const String& name) requires IsBaseOf<O
                 EnumType enum_value;                                         \
                 String string_value;                                         \
             } options[] = { __VA_ARGS__ };                                   \
+            if (!value.is_string())                                          \
+                return false;                                                \
             auto string_value = value.as_string();                           \
             for (size_t i = 0; i < array_size(options); ++i) {               \
                 auto& option = options[i];                                   \


### PR DESCRIPTION
Similar checks are already implemented in `REGISTER_RECT_PROPERTY` and `REGISTER_SIZE_PROPERTY`.

Fixes #5813