### PR TITLE
Text Editor: Variable soft tab length and whitespace options

### DIFF
--- a/Userland/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Userland/Applications/TextEditor/TextEditorWidget.cpp
@@ -481,6 +481,34 @@ void TextEditorWidget::initialize_menubar(GUI::MenuBar& menubar)
     m_no_wrapping_action->set_checked(true);
 
     view_menu.add_separator();
+
+    m_soft_tab_width_actions.set_exclusive(true);
+    auto& soft_tab_width_menu = view_menu.add_submenu("Tab width");
+    m_soft_tab_1_width_action = GUI::Action::create_checkable("1", [&](auto&) {
+        m_editor->set_soft_tab_width(1);
+    });
+    m_soft_tab_2_width_action = GUI::Action::create_checkable("2", [&](auto&) {
+        m_editor->set_soft_tab_width(2);
+    });
+    m_soft_tab_4_width_action = GUI::Action::create_checkable("4", [&](auto&) {
+        m_editor->set_soft_tab_width(4);
+    });
+    m_soft_tab_8_width_action = GUI::Action::create_checkable("8", [&](auto&) {
+        m_editor->set_soft_tab_width(8);
+    });
+    m_soft_tab_16_width_action = GUI::Action::create_checkable("16", [&](auto&) {
+        m_editor->set_soft_tab_width(16);
+    });
+
+    soft_tab_width_menu.add_action(*m_soft_tab_1_width_action);
+    soft_tab_width_menu.add_action(*m_soft_tab_2_width_action);
+    soft_tab_width_menu.add_action(*m_soft_tab_4_width_action);
+    soft_tab_width_menu.add_action(*m_soft_tab_8_width_action);
+    soft_tab_width_menu.add_action(*m_soft_tab_16_width_action);
+
+    m_soft_tab_4_width_action->set_checked(true);
+
+    view_menu.add_separator();
     view_menu.add_action(*m_no_preview_action);
     view_menu.add_action(*m_markdown_preview_action);
     view_menu.add_action(*m_html_preview_action);

--- a/Userland/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Userland/Applications/TextEditor/TextEditorWidget.cpp
@@ -500,6 +500,12 @@ void TextEditorWidget::initialize_menubar(GUI::MenuBar& menubar)
         m_editor->set_soft_tab_width(16);
     });
 
+    m_soft_tab_width_actions.add_action(*m_soft_tab_1_width_action);
+    m_soft_tab_width_actions.add_action(*m_soft_tab_2_width_action);
+    m_soft_tab_width_actions.add_action(*m_soft_tab_4_width_action);
+    m_soft_tab_width_actions.add_action(*m_soft_tab_8_width_action);
+    m_soft_tab_width_actions.add_action(*m_soft_tab_16_width_action);
+
     soft_tab_width_menu.add_action(*m_soft_tab_1_width_action);
     soft_tab_width_menu.add_action(*m_soft_tab_2_width_action);
     soft_tab_width_menu.add_action(*m_soft_tab_4_width_action);
@@ -507,6 +513,20 @@ void TextEditorWidget::initialize_menubar(GUI::MenuBar& menubar)
     soft_tab_width_menu.add_action(*m_soft_tab_16_width_action);
 
     m_soft_tab_4_width_action->set_checked(true);
+
+    view_menu.add_separator();
+
+    m_visualize_trailing_whitespace_action = GUI::Action::create_checkable("Visualize trailing whitespace", [&](auto&) {
+        m_editor->set_visualize_trailing_whitespace(m_visualize_trailing_whitespace_action->is_checked());
+    });
+    m_visualize_leading_whitespace_action = GUI::Action::create_checkable("Visualize leading whitespace", [&](auto&) {
+        m_editor->set_visualize_leading_whitespace(m_visualize_leading_whitespace_action->is_checked());
+    });
+
+    m_visualize_trailing_whitespace_action->set_checked(true);
+
+    view_menu.add_action(*m_visualize_trailing_whitespace_action);
+    view_menu.add_action(*m_visualize_leading_whitespace_action);
 
     view_menu.add_separator();
     view_menu.add_action(*m_no_preview_action);

--- a/Userland/Applications/TextEditor/TextEditorWidget.h
+++ b/Userland/Applications/TextEditor/TextEditorWidget.h
@@ -114,6 +114,13 @@ private:
     RefPtr<GUI::Action> m_wrap_anywhere_action;
     RefPtr<GUI::Action> m_wrap_at_words_action;
 
+    GUI::ActionGroup m_soft_tab_width_actions;
+    RefPtr<GUI::Action> m_soft_tab_1_width_action;
+    RefPtr<GUI::Action> m_soft_tab_2_width_action;
+    RefPtr<GUI::Action> m_soft_tab_4_width_action;
+    RefPtr<GUI::Action> m_soft_tab_8_width_action;
+    RefPtr<GUI::Action> m_soft_tab_16_width_action;
+
     GUI::ActionGroup syntax_actions;
     RefPtr<GUI::Action> m_plain_text_highlight;
     RefPtr<GUI::Action> m_cpp_highlight;

--- a/Userland/Applications/TextEditor/TextEditorWidget.h
+++ b/Userland/Applications/TextEditor/TextEditorWidget.h
@@ -114,6 +114,9 @@ private:
     RefPtr<GUI::Action> m_wrap_anywhere_action;
     RefPtr<GUI::Action> m_wrap_at_words_action;
 
+    RefPtr<GUI::Action> m_visualize_trailing_whitespace_action;
+    RefPtr<GUI::Action> m_visualize_leading_whitespace_action;
+
     GUI::ActionGroup m_soft_tab_width_actions;
     RefPtr<GUI::Action> m_soft_tab_1_width_action;
     RefPtr<GUI::Action> m_soft_tab_2_width_action;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -640,6 +640,21 @@ void TextEditor::paint_event(PaintEvent& event)
                 }
             }
 
+            if (m_visualize_leading_whitespace && line.leading_spaces() > 0) {
+                size_t physical_column = line.leading_spaces();
+                size_t end_of_leading_whitespace = (start_of_visual_line + physical_column);
+                size_t end_of_visual_line = (start_of_visual_line + visual_line_text.length());
+                if (end_of_leading_whitespace < end_of_visual_line) {
+                    Gfx::IntRect whitespace_rect {
+                        content_x_for_position({ line_index, start_of_visual_line }),
+                        visual_line_rect.y(),
+                        font().width(visual_line_text.substring_view(0, end_of_leading_whitespace)),
+                        visual_line_rect.height()
+                    };
+                    painter.fill_rect_with_dither_pattern(whitespace_rect, Color(), Color(192, 255, 192));
+                }
+            }
+
             if (physical_line_has_selection) {
                 size_t start_of_selection_within_visual_line = (size_t)max(0, (int)selection_start_column_within_line - (int)start_of_visual_line);
                 size_t end_of_selection_within_visual_line = selection_end_column_within_line - start_of_visual_line;
@@ -1761,6 +1776,14 @@ void TextEditor::set_visualize_trailing_whitespace(bool enabled)
     if (m_visualize_trailing_whitespace == enabled)
         return;
     m_visualize_trailing_whitespace = enabled;
+    update();
+}
+
+void TextEditor::set_visualize_leading_whitespace(bool enabled)
+{
+    if (m_visualize_leading_whitespace == enabled)
+        return;
+    m_visualize_leading_whitespace = enabled;
     update();
 }
 

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -81,6 +81,9 @@ public:
     void set_visualize_trailing_whitespace(bool);
     bool visualize_trailing_whitespace() const { return m_visualize_trailing_whitespace; }
 
+    void set_visualize_leading_whitespace(bool);
+    bool visualize_leading_whitespace() const { return m_visualize_leading_whitespace; }
+
     virtual bool is_automatic_indentation_enabled() const final { return m_automatic_indentation_enabled; }
     void set_automatic_indentation_enabled(bool enabled) { m_automatic_indentation_enabled = enabled; }
 
@@ -319,6 +322,7 @@ private:
     bool m_automatic_indentation_enabled { false };
     WrappingMode m_wrapping_mode { WrappingMode::NoWrap };
     bool m_visualize_trailing_whitespace { true };
+    bool m_visualize_leading_whitespace { false };
     int m_line_spacing { 4 };
     size_t m_soft_tab_width { 4 };
     int m_horizontal_content_padding { 3 };

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -85,6 +85,7 @@ public:
     void set_automatic_indentation_enabled(bool enabled) { m_automatic_indentation_enabled = enabled; }
 
     virtual int soft_tab_width() const final { return m_soft_tab_width; }
+    void set_soft_tab_width(int width) { m_soft_tab_width = width; };
 
     WrappingMode wrapping_mode() const { return m_wrapping_mode; }
     bool is_wrapping_enabled() const { return m_wrapping_mode != WrappingMode::NoWrap; }


### PR DESCRIPTION
This pull request partially solves issue #4803, but there are still no ways to input hard tabs in TextEditor. 
Adds three options to TextEditorWidget under View, which are:
- Toggling the visualization of leading whitespace
- Toggling the visualization of trailing whitespace
- Changing the number of spaces inserted on tab