### PR TITLE
Everywhere: Working towards 64 bits storage, step 2

### DIFF
--- a/Kernel/Devices/BXVGADevice.cpp
+++ b/Kernel/Devices/BXVGADevice.cpp
@@ -173,7 +173,7 @@ UNMAP_AFTER_INIT u32 BXVGADevice::find_framebuffer_address()
     return framebuffer_address;
 }
 
-KResultOr<Region*> BXVGADevice::mmap(Process& process, FileDescription&, const Range& range, size_t offset, int prot, bool shared)
+KResultOr<Region*> BXVGADevice::mmap(Process& process, FileDescription&, const Range& range, u64 offset, int prot, bool shared)
 {
     REQUIRE_PROMISE(video);
     if (!shared)

--- a/Kernel/Devices/BXVGADevice.h
+++ b/Kernel/Devices/BXVGADevice.h
@@ -42,7 +42,7 @@ public:
     BXVGADevice();
 
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
-    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, size_t offset, int prot, bool shared) override;
+    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
 
     // ^Device
     virtual mode_t required_mode() const override { return 0660; }

--- a/Kernel/Devices/MBVGADevice.cpp
+++ b/Kernel/Devices/MBVGADevice.cpp
@@ -51,7 +51,7 @@ UNMAP_AFTER_INIT MBVGADevice::MBVGADevice(PhysicalAddress addr, size_t pitch, si
     s_the = this;
 }
 
-KResultOr<Region*> MBVGADevice::mmap(Process& process, FileDescription&, const Range& range, size_t offset, int prot, bool shared)
+KResultOr<Region*> MBVGADevice::mmap(Process& process, FileDescription&, const Range& range, u64 offset, int prot, bool shared)
 {
     REQUIRE_PROMISE(video);
     if (!shared)

--- a/Kernel/Devices/MBVGADevice.h
+++ b/Kernel/Devices/MBVGADevice.h
@@ -41,7 +41,7 @@ public:
     MBVGADevice(PhysicalAddress addr, size_t pitch, size_t width, size_t height);
 
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
-    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, size_t offset, int prot, bool shared) override;
+    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
 
     // ^Device
     virtual mode_t required_mode() const override { return 0660; }

--- a/Kernel/Devices/MemoryDevice.cpp
+++ b/Kernel/Devices/MemoryDevice.cpp
@@ -52,7 +52,7 @@ void MemoryDevice::did_seek(FileDescription&, off_t)
     TODO();
 }
 
-KResultOr<Region*> MemoryDevice::mmap(Process& process, FileDescription&, const Range& range, size_t offset, int prot, bool shared)
+KResultOr<Region*> MemoryDevice::mmap(Process& process, FileDescription&, const Range& range, u64 offset, int prot, bool shared)
 {
     auto viewed_address = PhysicalAddress(offset);
 

--- a/Kernel/Devices/MemoryDevice.h
+++ b/Kernel/Devices/MemoryDevice.h
@@ -39,7 +39,7 @@ public:
     MemoryDevice();
     ~MemoryDevice();
 
-    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, size_t offset, int prot, bool shared) override;
+    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
 
     // ^Device
     virtual mode_t required_mode() const override { return 0660; }

--- a/Kernel/FileSystem/AnonymousFile.cpp
+++ b/Kernel/FileSystem/AnonymousFile.cpp
@@ -39,7 +39,7 @@ AnonymousFile::~AnonymousFile()
 {
 }
 
-KResultOr<Region*> AnonymousFile::mmap(Process& process, FileDescription&, const Range& range, size_t offset, int prot, bool shared)
+KResultOr<Region*> AnonymousFile::mmap(Process& process, FileDescription&, const Range& range, u64 offset, int prot, bool shared)
 {
     if (offset != 0)
         return EINVAL;

--- a/Kernel/FileSystem/AnonymousFile.h
+++ b/Kernel/FileSystem/AnonymousFile.h
@@ -39,7 +39,7 @@ public:
 
     virtual ~AnonymousFile() override;
 
-    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, size_t offset, int prot, bool shared) override;
+    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
 
 private:
     virtual const char* class_name() const override { return "AnonymousFile"; }

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -235,7 +235,7 @@ KResult BlockBasedFS::read_block(BlockIndex index, UserOrKernelBuffer* buffer, s
 
     if (!allow_cache) {
         const_cast<BlockBasedFS*>(this)->flush_specific_block_if_needed(index);
-        size_t base_offset = index.value() * block_size() + offset;
+        auto base_offset = index.value() * block_size() + offset;
         file_description().seek(base_offset, SEEK_SET);
         auto nread = file_description().read(*buffer, count);
         if (nread.is_error())
@@ -246,7 +246,7 @@ KResult BlockBasedFS::read_block(BlockIndex index, UserOrKernelBuffer* buffer, s
 
     auto& entry = cache().get(index);
     if (!entry.has_data) {
-        size_t base_offset = index.value() * block_size();
+        auto base_offset = index.value() * block_size();
         file_description().seek(base_offset, SEEK_SET);
         auto entry_data_buffer = UserOrKernelBuffer::for_kernel_buffer(entry.data);
         auto nread = file_description().read(entry_data_buffer, block_size());

--- a/Kernel/FileSystem/BlockBasedFileSystem.h
+++ b/Kernel/FileSystem/BlockBasedFileSystem.h
@@ -32,7 +32,7 @@ namespace Kernel {
 
 class BlockBasedFS : public FileBackedFS {
 public:
-    TYPEDEF_DISTINCT_ORDERED_ID(unsigned, BlockIndex);
+    TYPEDEF_DISTINCT_ORDERED_ID(u64, BlockIndex);
 
     virtual ~BlockBasedFS() override;
 

--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -59,7 +59,7 @@ int File::ioctl(FileDescription&, unsigned, FlatPtr)
     return -ENOTTY;
 }
 
-KResultOr<Region*> File::mmap(Process&, FileDescription&, const Range&, size_t, int, bool)
+KResultOr<Region*> File::mmap(Process&, FileDescription&, const Range&, u64, int, bool)
 {
     return ENODEV;
 }

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -114,7 +114,7 @@ public:
     virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) = 0;
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) = 0;
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg);
-    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, size_t offset, int prot, bool shared);
+    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared);
     virtual KResult stat(::stat&) const { return EBADF; }
 
     virtual String absolute_path(const FileDescription&) const = 0;

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -327,7 +327,7 @@ InodeMetadata FileDescription::metadata() const
     return {};
 }
 
-KResultOr<Region*> FileDescription::mmap(Process& process, const Range& range, size_t offset, int prot, bool shared)
+KResultOr<Region*> FileDescription::mmap(Process& process, const Range& range, u64 offset, int prot, bool shared)
 {
     LOCKER(m_lock);
     return m_file->mmap(process, *this, range, offset, prot, shared);

--- a/Kernel/FileSystem/FileDescription.h
+++ b/Kernel/FileSystem/FileDescription.h
@@ -108,7 +108,7 @@ public:
     Custody* custody() { return m_custody.ptr(); }
     const Custody* custody() const { return m_custody.ptr(); }
 
-    KResultOr<Region*> mmap(Process&, const Range&, size_t offset, int prot, bool shared);
+    KResultOr<Region*> mmap(Process&, const Range&, u64 offset, int prot, bool shared);
 
     bool is_blocking() const { return m_is_blocking; }
     void set_blocking(bool b) { m_is_blocking = b; }

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -107,7 +107,7 @@ int InodeFile::ioctl(FileDescription& description, unsigned request, FlatPtr arg
     }
 }
 
-KResultOr<Region*> InodeFile::mmap(Process& process, FileDescription& description, const Range& range, size_t offset, int prot, bool shared)
+KResultOr<Region*> InodeFile::mmap(Process& process, FileDescription& description, const Range& range, u64 offset, int prot, bool shared)
 {
     // FIXME: If PROT_EXEC, check that the underlying file system isn't mounted noexec.
     RefPtr<InodeVMObject> vmobject;

--- a/Kernel/FileSystem/InodeFile.h
+++ b/Kernel/FileSystem/InodeFile.h
@@ -50,7 +50,7 @@ public:
     virtual KResultOr<size_t> read(FileDescription&, u64, UserOrKernelBuffer&, size_t) override;
     virtual KResultOr<size_t> write(FileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
     virtual int ioctl(FileDescription&, unsigned request, FlatPtr arg) override;
-    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, size_t offset, int prot, bool shared) override;
+    virtual KResultOr<Region*> mmap(Process&, FileDescription&, const Range&, u64 offset, int prot, bool shared) override;
 
     virtual String absolute_path(const FileDescription&) const override;
 

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -148,12 +148,12 @@ KResultOr<FlatPtr> Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> u
         return EFAULT;
 
     FlatPtr addr = params.addr;
-    size_t size = params.size;
-    size_t alignment = params.alignment;
-    int prot = params.prot;
-    int flags = params.flags;
-    int fd = params.fd;
-    int offset = params.offset;
+    auto size = params.size;
+    auto alignment = params.alignment;
+    auto prot = params.prot;
+    auto flags = params.flags;
+    auto fd = params.fd;
+    auto offset = params.offset;
 
     if (prot & PROT_EXEC) {
         REQUIRE_PROMISE(prot_exec);
@@ -255,7 +255,7 @@ KResultOr<FlatPtr> Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> u
                 return EACCES;
         }
 
-        auto region_or_error = description->mmap(*this, range.value(), static_cast<size_t>(offset), prot, map_shared);
+        auto region_or_error = description->mmap(*this, range.value(), static_cast<u64>(offset), prot, map_shared);
         if (region_or_error.is_error())
             return region_or_error.error().error();
         region = region_or_error.value();

--- a/Userland/Utilities/checksum.cpp
+++ b/Userland/Utilities/checksum.cpp
@@ -85,7 +85,9 @@ int main(int argc, char** argv)
             has_error = true;
             continue;
         }
-        hash.update(file->read_all());
+
+        while (!file->eof() && !file->has_error())
+            hash.update(file->read(PAGE_SIZE));
         auto digest = hash.digest();
         auto digest_data = digest.immutable_data();
         StringBuilder builder;


### PR DESCRIPTION
Follow-up of #5766. With this, SerenityOS seems to handle now ext2 file systems and their files beyond the 2 GiB mark without blowing up immediately. However, due to severe performance issues when manipulating data at this scale, I cannot properly test if this actually works fine in practice.