### PR TITLE
TextEditor: Exit program when file is not opened

### DIFF
--- a/Userland/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Userland/Applications/TextEditor/TextEditorWidget.cpp
@@ -583,12 +583,12 @@ void TextEditorWidget::update_title()
     window()->set_title(builder.to_string());
 }
 
-void TextEditorWidget::open_file(const String& path)
+bool TextEditorWidget::open_file(const String& path)
 {
     auto file = Core::File::construct(path);
     if (!file->open(Core::IODevice::ReadOnly) && file->error() != ENOENT) {
         GUI::MessageBox::show(window(), String::formatted("Opening \"{}\" failed: {}", path, strerror(errno)), "Error", GUI::MessageBox::Type::Error);
-        return;
+        return false;
     }
 
     m_editor->set_text(file->read_all());
@@ -598,6 +598,8 @@ void TextEditorWidget::open_file(const String& path)
     set_path(LexicalPath(path));
 
     m_editor->set_focus(true);
+
+    return true;
 }
 
 bool TextEditorWidget::request_close()

--- a/Userland/Applications/TextEditor/TextEditorWidget.h
+++ b/Userland/Applications/TextEditor/TextEditorWidget.h
@@ -40,7 +40,7 @@ class TextEditorWidget final : public GUI::Widget {
     C_OBJECT(TextEditorWidget)
 public:
     virtual ~TextEditorWidget() override;
-    void open_file(const String& path);
+    bool open_file(const String& path);
     bool request_close();
 
     GUI::TextEditor& editor() { return *m_editor; }

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -90,9 +90,10 @@ int main(int argc, char** argv)
     app->set_menubar(menubar);
 
     if (file_to_edit)
-        text_widget.open_file(file_to_edit);
-    else
-        text_widget.update_title();
+        if (!text_widget.open_file(file_to_edit))
+            return 1;
+
+    text_widget.update_title();
 
     if (initial_line_number != 0)
         text_widget.editor().set_cursor_and_focus_line(initial_line_number - 1, 0);


### PR DESCRIPTION
When trying to open files not permitted by the user, display the error
message and exit.