### PR TITLE
Build: Enable --noexecstack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,8 +146,8 @@ endforeach()
 
 set(CMAKE_INSTALL_NAME_TOOL "")
 set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
-set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-shared -Wl,--hash-style=gnu,-z,relro,-z,now")
-set(CMAKE_CXX_LINK_FLAGS "-Wl,--hash-style=gnu,-z,relro,-z,now")
+set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-shared -Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecstack")
+set(CMAKE_CXX_LINK_FLAGS "-Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecstack")
 
 # We disable it completely because it makes cmake very spammy.
 # This will need to be revisited when the Loader supports RPATH/RUN_PATH.


### PR DESCRIPTION
Build ELF executables with a zero length `GNU_STACK`
program header flagged non-executable.

The stack is never executable on SerenityOS regardless
of whether the `GNU_STACK` header is specified.

Specifically defining this header is more explicit,
as absence of this header implies an executable stack
on other systems (Linux).

---

This might also be beneficial when executing ELF
executables outside of SerenityOS (Lagom).

Also, checking for a non-executable stack by checking for
a `GNU_STACK` header is common practice. Using this header
lets us show off how securely built our executables are.
