### PR TITLE
MouseSettings: add ability to configure double-click speed.

### DIFF
--- a/Userland/Applications/MouseSettings/CMakeLists.txt
+++ b/Userland/Applications/MouseSettings/CMakeLists.txt
@@ -1,5 +1,10 @@
+compile_gml(MouseSettingsWindow.gml MouseSettingsWindowGML.h mouse_settings_window_gml)
+
 set(SOURCES
     main.cpp
+    MouseSettingsWindow.cpp
+    MouseSettingsWindow.h
+    MouseSettingsWindowGML.h
 )
 
 serenity_app(MouseSettings ICON app-mouse)

--- a/Userland/Applications/MouseSettings/MouseSettingsWindow.cpp
+++ b/Userland/Applications/MouseSettings/MouseSettingsWindow.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020, Idan Horowitz <idan.horowitz@gmail.com>
+ * Copyright (c) 2021, the SerenityOS developers
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "MouseSettingsWindow.h"
+#include <Applications/MouseSettings/MouseSettingsWindowGML.h>
+#include <LibGUI/Application.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/Event.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/Widget.h>
+#include <LibGUI/Window.h>
+#include <LibGUI/WindowServerConnection.h>
+#include <WindowServer/Screen.h>
+#include <WindowServer/WindowManager.h>
+
+constexpr double speed_slider_scale = 100.0;
+constexpr int default_scroll_length = 4;
+constexpr int double_click_speed_default = 250;
+
+void MouseSettingsWindow::update_window_server()
+{
+    const float factor = m_speed_slider->value() / speed_slider_scale;
+    GUI::WindowServerConnection::the().send_sync<Messages::WindowServer::SetMouseAcceleration>(factor);
+    GUI::WindowServerConnection::the().send_sync<Messages::WindowServer::SetScrollStepSize>(m_scroll_length_spinbox->value());
+    GUI::WindowServerConnection::the().send_sync<Messages::WindowServer::SetDoubleClickSpeed>(m_double_click_speed_slider->value());
+}
+
+void MouseSettingsWindow::reset_default_values()
+{
+    m_speed_slider->set_value(speed_slider_scale);
+    m_scroll_length_spinbox->set_value(default_scroll_length);
+    m_double_click_speed_slider->set_value(double_click_speed_default);
+    update_window_server();
+}
+
+MouseSettingsWindow::MouseSettingsWindow()
+{
+    auto& main_widget = set_main_widget<GUI::Widget>();
+    main_widget.load_from_gml(mouse_settings_window_gml);
+
+    m_speed_label = *main_widget.find_descendant_of_type_named<GUI::Label>("speed_label");
+    m_speed_slider = *main_widget.find_descendant_of_type_named<GUI::HorizontalSlider>("speed_slider");
+    m_speed_slider->set_range(WindowServer::mouse_accel_min * speed_slider_scale, WindowServer::mouse_accel_max * speed_slider_scale);
+    m_speed_slider->on_change = [&](const int value) {
+        m_speed_label->set_text(String::formatted("{} %", value));
+    };
+    const int slider_value = speed_slider_scale * GUI::WindowServerConnection::the().send_sync<Messages::WindowServer::GetMouseAcceleration>()->factor();
+    m_speed_slider->set_value(slider_value);
+
+    m_scroll_length_spinbox = *main_widget.find_descendant_of_type_named<GUI::SpinBox>("scroll_length_spinbox");
+    m_scroll_length_spinbox->set_min(WindowServer::scroll_step_size_min);
+    m_scroll_length_spinbox->set_value(GUI::WindowServerConnection::the().send_sync<Messages::WindowServer::GetScrollStepSize>()->step_size());
+
+    m_double_click_speed_label = *main_widget.find_descendant_of_type_named<GUI::Label>("double_click_speed_label");
+    m_double_click_speed_slider = *main_widget.find_descendant_of_type_named<GUI::HorizontalSlider>("double_click_speed_slider");
+    m_double_click_speed_slider->set_min(WindowServer::double_click_speed_min);
+    m_double_click_speed_slider->set_max(WindowServer::double_click_speed_max);
+    m_double_click_speed_slider->on_change = [&](const int value) {
+        m_double_click_speed_label->set_text(String::formatted("{} ms", value));
+    };
+    m_double_click_speed_slider->set_value(GUI::WindowServerConnection::the().send_sync<Messages::WindowServer::GetDoubleClickSpeed>()->speed());
+
+    m_ok_button = *main_widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+    m_ok_button->on_click = [this](auto) {
+        update_window_server();
+        GUI::Application::the()->quit();
+    };
+
+    m_apply_button = *main_widget.find_descendant_of_type_named<GUI::Button>("apply_button");
+    m_apply_button->on_click = [this](auto) {
+        update_window_server();
+    };
+
+    m_reset_button = *main_widget.find_descendant_of_type_named<GUI::Button>("reset_button");
+    m_reset_button->on_click = [this](auto) {
+        reset_default_values();
+    };
+}
+
+MouseSettingsWindow::~MouseSettingsWindow()
+{
+}

--- a/Userland/Applications/MouseSettings/MouseSettingsWindow.gml
+++ b/Userland/Applications/MouseSettings/MouseSettingsWindow.gml
@@ -1,0 +1,105 @@
+@GUI::Widget {
+    fill_with_background_color: true
+
+    layout: @GUI::VerticalBoxLayout {
+        margins: [4, 4, 4, 4]
+    }
+
+    @GUI::GroupBox {
+        title: "Mouse speed"
+        fixed_height: 60
+
+        layout: @GUI::HorizontalBoxLayout {
+            margins: [6, 16, 8, 6]
+        }
+
+        @GUI::HorizontalSlider {
+            name: "speed_slider"
+            max: 3500
+            min: 500
+            value: 100
+        }
+
+        @GUI::Label {
+            name: "speed_label"
+            text: "100.0 %"
+            fixed_width: 50
+            text_alignment: "CenterRight"
+        }
+    }
+
+    @GUI::GroupBox {
+        title: "Scroll length"
+        fixed_height: 60
+
+        layout: @GUI::HorizontalBoxLayout {
+            margins: [16, 16, 8, 6]
+        }
+
+        @GUI::Label {
+            text: "Scroll by "
+            autosize: true
+            text_alignment: "CenterLeft"
+        }
+
+        @GUI::SpinBox {
+            name: "scroll_length_spinbox"
+            max: 32
+            min: 1
+            value: 4
+            text_alignment: "CenterRight"
+            fixed_width: 80
+        }
+
+        @GUI::Label {
+            text: " lines at a time"
+            text_alignent: "CenterLeft"
+            autosize: true
+        }
+    }
+
+    @GUI::GroupBox {
+        title: "Double-click speed"
+        fixed_height: 60
+
+        layout: @GUI::HorizontalBoxLayout {
+            margins: [6, 16, 8, 6]
+        }
+
+        @GUI::HorizontalSlider {
+            name: "double_click_speed_slider"
+            max: 900
+            min: 100
+            value: 250
+        }
+
+        @GUI::Label {
+            name: "double_click_speed_label"
+            text: "250 ms"
+            fixed_width: 50
+            text_alignment: "CenterRight"
+        }
+    }
+
+    @GUI::Widget {
+        fixed_height: 22
+
+        layout: @GUI::HorizontalBoxLayout {
+        }
+
+        @GUI::Button {
+            name: "ok_button"
+            text: "OK"
+        }
+
+        @GUI::Button {
+            name: "apply_button"
+            text: "Apply"
+        }
+
+        @GUI::Button {
+            name: "reset_button"
+            text: "Reset"
+        }
+    }
+}

--- a/Userland/Applications/MouseSettings/MouseSettingsWindow.h
+++ b/Userland/Applications/MouseSettings/MouseSettingsWindow.h
@@ -25,47 +25,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "MouseSettingsWindow.h"
-#include <LibGUI/Action.h>
-#include <LibGUI/Application.h>
-#include <LibGUI/Icon.h>
-#include <LibGUI/Menu.h>
-#include <LibGUI/MenuBar.h>
-#include <unistd.h>
+#pragma once
 
-int main(int argc, char** argv)
-{
-    if (pledge("stdio cpath rpath recvfd sendfd unix fattr", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+#include <LibGUI/Button.h>
+#include <LibGUI/Slider.h>
+#include <LibGUI/SpinBox.h>
+#include <LibGUI/Window.h>
 
-    auto app = GUI::Application::construct(argc, argv);
+class MouseSettingsWindow final : public GUI::Window {
+    C_OBJECT(MouseSettingsWindow)
+public:
+    virtual ~MouseSettingsWindow() override;
 
-    if (pledge("stdio cpath rpath recvfd sendfd", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+private:
+    MouseSettingsWindow();
 
-    auto app_icon = GUI::Icon::default_icon("app-mouse");
+    void update_window_server();
+    void reset_default_values();
 
-    auto window = MouseSettingsWindow::construct();
-    window->set_title("Mouse Settings");
-    window->resize(300, 220);
-    window->set_resizable(false);
-    window->set_minimizable(false);
-    window->set_icon(app_icon.bitmap_for_size(16));
-
-    auto menubar = GUI::MenuBar::construct();
-    auto& app_menu = menubar->add_menu("File");
-    app_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) {
-        app->quit();
-    }));
-
-    auto& help_menu = menubar->add_menu("Help");
-    help_menu.add_action(GUI::CommonActions::make_about_action("Mouse Settings", app_icon, window));
-    window->set_menubar(move(menubar));
-
-    window->show();
-    return app->exec();
-}
+    RefPtr<GUI::HorizontalSlider> m_speed_slider;
+    RefPtr<GUI::Label> m_speed_label;
+    RefPtr<GUI::SpinBox> m_scroll_length_spinbox;
+    RefPtr<GUI::HorizontalSlider> m_double_click_speed_slider;
+    RefPtr<GUI::Label> m_double_click_speed_label;
+    RefPtr<GUI::Button> m_ok_button;
+    RefPtr<GUI::Button> m_apply_button;
+    RefPtr<GUI::Button> m_reset_button;
+};

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -955,6 +955,19 @@ OwnPtr<Messages::WindowServer::GetScrollStepSizeResponse> ClientConnection::hand
 {
     return make<Messages::WindowServer::GetScrollStepSizeResponse>(Screen::the().scroll_step_size());
 }
+OwnPtr<Messages::WindowServer::SetDoubleClickSpeedResponse> ClientConnection::handle(const Messages::WindowServer::SetDoubleClickSpeed& message)
+{
+    if (message.speed() < double_click_speed_min || message.speed() > double_click_speed_max) {
+        did_misbehave("SetDoubleClickSpeed with bad speed");
+        return {};
+    }
+    WindowManager::the().set_double_click_speed(message.speed());
+    return make<Messages::WindowServer::SetDoubleClickSpeedResponse>();
+}
+OwnPtr<Messages::WindowServer::GetDoubleClickSpeedResponse> ClientConnection::handle(const Messages::WindowServer::GetDoubleClickSpeed&)
+{
+    return make<Messages::WindowServer::GetDoubleClickSpeedResponse>(WindowManager::the().double_click_speed());
+}
 
 void ClientConnection::set_unresponsive(bool unresponsive)
 {

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -168,6 +168,8 @@ private:
     virtual OwnPtr<Messages::WindowServer::SetScrollStepSizeResponse> handle(const Messages::WindowServer::SetScrollStepSize&) override;
     virtual OwnPtr<Messages::WindowServer::GetScrollStepSizeResponse> handle(const Messages::WindowServer::GetScrollStepSize&) override;
     virtual OwnPtr<Messages::WindowServer::GetScreenBitmapResponse> handle(const Messages::WindowServer::GetScreenBitmap&) override;
+    virtual OwnPtr<Messages::WindowServer::SetDoubleClickSpeedResponse> handle(const Messages::WindowServer::SetDoubleClickSpeed&) override;
+    virtual OwnPtr<Messages::WindowServer::GetDoubleClickSpeedResponse> handle(const Messages::WindowServer::GetDoubleClickSpeed&) override;
 
     Window* window_from_id(i32 window_id);
 

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -172,6 +172,20 @@ void WindowManager::set_scroll_step_size(unsigned step_size)
     m_config->sync();
 }
 
+void WindowManager::set_double_click_speed(int speed)
+{
+    VERIFY(speed >= double_click_speed_min && speed <= double_click_speed_max);
+    m_double_click_speed = speed;
+    dbgln("Saving double-click speed {} to config file at {}", speed, m_config->file_name());
+    m_config->write_entry("Input", "DoubleClickSpeed", String::number(speed));
+    m_config->sync();
+}
+
+int WindowManager::double_click_speed() const
+{
+    return m_double_click_speed;
+}
+
 int WindowManager::scale_factor() const
 {
     return Screen::the().scale_factor();

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -47,6 +47,9 @@
 
 namespace WindowServer {
 
+const int double_click_speed_max = 900;
+const int double_click_speed_min = 100;
+
 class Screen;
 class MouseEvent;
 class Window;
@@ -151,6 +154,8 @@ public:
 
     void set_acceleration_factor(double);
     void set_scroll_step_size(unsigned);
+    void set_double_click_speed(int);
+    int double_click_speed() const;
 
     Window* set_active_input_window(Window*);
     void restore_active_input_window(Window*);

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -126,4 +126,7 @@ endpoint WindowServer = 2
     GetScreenBitmap() => (Gfx::ShareableBitmap bitmap)
 
     Pong() =|
+
+    SetDoubleClickSpeed(int speed) => ()
+    GetDoubleClickSpeed() => (int speed)
 }


### PR DESCRIPTION
Also adds labels to display the values for to each slider.

Before:
![MouseSettings-before](https://user-images.githubusercontent.com/209150/111848684-e878ce00-88c8-11eb-8efe-eb4a1fdcebf2.png)

After:
![MouseSettings-after](https://user-images.githubusercontent.com/209150/111848689-ed3d8200-88c8-11eb-9fe5-25c4c5d6a6c1.png)
