### PR TITLE
LibGUI: Fix crash when trying to get selected text after full line and multiline deletes

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -315,7 +315,7 @@ String TextDocument::text() const
 
 String TextDocument::text_in_range(const TextRange& a_range) const
 {
-    if (is_empty())
+    if (is_empty() || line_count() < a_range.end().line() - a_range.start().line() || line(a_range.start().line()).is_empty())
         return String("");
     auto range = a_range.normalized();
 


### PR DESCRIPTION
Fixes #5875 