### PR TITLE
LibGUI: Process pending window updates after handling input events

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -363,8 +363,12 @@ void Window::handle_mouse_event(MouseEvent& event)
     if (event.buttons() != 0 && !m_automatic_cursor_tracking_widget)
         m_automatic_cursor_tracking_widget = *result.widget;
     if (result.widget != m_global_cursor_tracking_widget.ptr())
-        return result.widget->dispatch_event(*local_event, this);
-    return;
+        result.widget->dispatch_event(*local_event, this);
+
+    if (!m_pending_paint_event_rects.is_empty()) {
+        MultiPaintEvent paint_event(move(m_pending_paint_event_rects), size());
+        handle_multi_paint_event(paint_event);
+    }
 }
 
 void Window::handle_multi_paint_event(MultiPaintEvent& event)


### PR DESCRIPTION
Since input events may trigger window portions to be invalidated,
rather than making a round trip to WindowServer to get paint events
we can simply fake an immediate paint event and update the window
contents more quickly.

Improves #5881

_Not sure I like this solution, but it makes sense to more rapidly trigger paint events after processing input events if they may require the screen to be updated. It's not perfect, though._