### PR TITLE
LibELF: DynamicObject: set for_each_symbol/for_each_dynamic_entry public

### DIFF
--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -251,6 +251,12 @@ public:
     template<typename F>
     void for_each_initialization_array_function(F f) const;
 
+    template<typename F>
+    void for_each_dynamic_entry(F) const;
+
+    template<typename F>
+    void for_each_symbol(F) const;
+
     struct SymbolLookupResult {
         FlatPtr value { 0 };
         VirtualAddress address;
@@ -272,12 +278,6 @@ private:
     StringView symbol_string_table_string(Elf32_Word) const;
     const char* raw_symbol_string_table_string(Elf32_Word) const;
     void parse();
-
-    template<typename F>
-    void for_each_symbol(F) const;
-
-    template<typename F>
-    void for_each_dynamic_entry(F) const;
 
     VirtualAddress m_base_address;
     VirtualAddress m_dynamic_address;


### PR DESCRIPTION
Change `DynamicObject` functions `for_each_symbol` and `for_each_dynamic_entry` from private to public.

I need to access these functions from outside the `DynamicLoader` context for work-in-progress changes to the `readelf` utility when parsing the dynamic section and symbols.

Similar helpers (`for_each_needed_library` and `for_each_initialization_array_function`) are already exposed as `public`.

These functions were private as they're not used anywhere. There's no reason to keep these private and no harm in exposing publicly.

Alternatively, helper functions could be added to `DynamicLoader` to access properties of the mapped `DynamicObject`, but that seems unnecessary.
