### PR TITLE
LibWeb: Only call page_did_change_title() from main frame

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -287,8 +287,10 @@ void Document::set_title(const String& title)
 
     title_element->append_child(adopt(*new Text(*this, title)));
 
-    if (auto* page = this->page())
-        page->client().page_did_change_title(title);
+    if (auto* page = this->page()) {
+        if (frame() == &page->main_frame())
+            page->client().page_did_change_title(title);
+    }
 }
 
 void Document::attach_to_frame(Badge<Frame>, Frame& frame)

--- a/Userland/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
@@ -42,8 +42,10 @@ HTMLTitleElement::~HTMLTitleElement()
 void HTMLTitleElement::children_changed()
 {
     HTMLElement::children_changed();
-    if (auto* page = document().page())
-        page->client().page_did_change_title(document().title());
+    if (auto* page = document().page()) {
+        if (document().frame() == &page->main_frame())
+            page->client().page_did_change_title(document().title());
+    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/Page/Frame.cpp
+++ b/Userland/Libraries/LibWeb/Page/Frame.cpp
@@ -102,7 +102,7 @@ void Frame::set_document(DOM::Document* document)
 
     if (m_document) {
         m_document->attach_to_frame({}, *this);
-        if (m_page)
+        if (m_page && is_main_frame())
             m_page->client().page_did_change_title(m_document->title());
     }
 


### PR DESCRIPTION
Otherwise an embedded iframe will override the page title in the browser, for example.