### PR TITLE
MenuApplets: Remove unused .gitignore files

### DIFF
--- a/Userland/MenuApplets/Audio/.gitignore
+++ b/Userland/MenuApplets/Audio/.gitignore
@@ -1,1 +1,0 @@
-Audio.MenuApplet

--- a/Userland/MenuApplets/Clock/.gitignore
+++ b/Userland/MenuApplets/Clock/.gitignore
@@ -1,1 +1,0 @@
-Clock.MenuApplet

--- a/Userland/MenuApplets/ResourceGraph/.gitignore
+++ b/Userland/MenuApplets/ResourceGraph/.gitignore
@@ -1,1 +1,0 @@
-ResourceGraph.MenuApplet

--- a/Userland/MenuApplets/UserName/.gitignore
+++ b/Userland/MenuApplets/UserName/.gitignore
@@ -1,1 +1,0 @@
-UserName.MenuApplet


### PR DESCRIPTION
These are not needed since the switch to CMake and out-of-tree builds.