### PR TITLE
LibJS: Handle overlong encoded utf8 sequences in abstract relations

### DIFF
--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -144,6 +144,24 @@ size_t Utf8View::calculate_length() const
     return length;
 }
 
+bool Utf8View::starts_with(const Utf8View& start) const
+{
+    if (start.is_empty())
+        return true;
+    if (is_empty())
+        return false;
+    if (start.length() > length())
+        return false;
+    if (begin_ptr() == start.begin_ptr())
+        return true;
+
+    for (auto k = begin(), l = start.begin(); l != start.end(); ++k, ++l) {
+        if (*k != *l)
+            return false;
+    }
+    return true;
+}
+
 Utf8CodepointIterator::Utf8CodepointIterator(const unsigned char* ptr, size_t length)
     : m_ptr(ptr)
     , m_length(length)

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -80,6 +80,8 @@ public:
     Utf8View substring_view(int byte_offset, int byte_length) const;
     bool is_empty() const { return m_string.is_empty(); }
 
+    bool starts_with(const Utf8View&) const;
+
     size_t iterator_offset(const Utf8CodepointIterator& it) const
     {
         return byte_offset_of(it);

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -1189,13 +1189,14 @@ TriState abstract_relation(GlobalObject& global_object, bool left_first, Value l
         auto x_string = x_primitive.as_string().string();
         auto y_string = y_primitive.as_string().string();
 
-        if (x_string.starts_with(y_string))
-            return TriState::False;
-        if (y_string.starts_with(x_string))
-            return TriState::True;
-
         Utf8View x_code_points { x_string };
         Utf8View y_code_points { y_string };
+
+        if (x_code_points.starts_with(y_code_points))
+            return TriState::False;
+        if (y_code_points.starts_with(x_code_points))
+            return TriState::True;
+
         for (auto k = x_code_points.begin(), l = y_code_points.begin();
              k != x_code_points.end() && l != y_code_points.end();
              ++k, ++l) {


### PR DESCRIPTION
This adds Utf8View::starts_with and uses it in LibJS's abstract relation, which unlike String/StringView::starts_with this compares utf8 code points instead of "characters" (bytes), which is important when handling aribtary utf-8 input that could include overlong characters. This was found by/fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31134.

NOTE: while this fixes this specific bug i think there is more discussion to be had about the handing of malformed utf8 source code in libjs, as currently we do no validation to the input source code (a lot of invalid utf8 codes like 0xFE can crash libjs). overlong encoded utf8 sequences are a seperate issue as well, since they are technically valid, but usually are a sign of bad data (and as such rejecting them/and or replacing them with valid counterparts at/before the lexer stage might be a good idea). (relevant issue: #3549)