### PR TITLE
Documentation: Fix missing subdirectory in build path

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -187,7 +187,7 @@ Once the toolchain has been built, go into the `Build/i686/` directory and run t
 
 ```console
 $ cd ../Build/i686
-$ cmake ../.. -G Ninja
+$ cmake ../../.. -G Ninja
 $ ninja install
 ```
 


### PR DESCRIPTION
The build path moved from `Build/` into `Build/i686/`, but the `cmake` command in the documentation currently does not accommodate for that, as the `CMakeLists.txt` is in the root rather than in `Build/`, which causes `cmake` to be unable to find the file.