### PR TITLE
LibJS: Remove as_size_t()

### DIFF
--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -449,7 +449,9 @@ JS_DEFINE_NATIVE_FUNCTION(WorkbookObject::sheet)
                 return JS::Value(&sheet.global_object());
         }
     } else {
-        auto index = name_value.as_size_t();
+        auto index = name_value.to_length(global_object);
+        if (vm.exception())
+            return {};
         if (index < workbook.sheets().size())
             return JS::Value(&workbook.sheets()[index].global_object());
     }

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -517,12 +517,6 @@ u32 Value::as_u32() const
     return min((double)as_i32(), MAX_U32);
 }
 
-size_t Value::as_size_t() const
-{
-    VERIFY(as_double() >= 0);
-    return min((double)as_i32(), MAX_ARRAY_LIKE_INDEX);
-}
-
 double Value::to_double(GlobalObject& global_object) const
 {
     auto number = to_number(global_object);

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -258,7 +258,6 @@ public:
 
     i32 as_i32() const;
     u32 as_u32() const;
-    size_t as_size_t() const;
 
     String to_string(GlobalObject&, bool legacy_null_to_empty_string = false) const;
     PrimitiveString* to_primitive_string(GlobalObject&);


### PR DESCRIPTION
Just like `to_size_t()` - which was already removed in f369229 - this is non-standard, use `to_length()` instead. One remaining use was removed, and I'm glad it's gone. :^)