### PR TITLE
LibCpp + Language Server: Support Namespaces

### DIFF
--- a/Base/home/anon/Source/little/other.cpp
+++ b/Base/home/anon/Source/little/other.cpp
@@ -1,6 +1,8 @@
 #include "other.h"
 #include <stdio.h>
 
+namespace MyNamespace {
+
 int func()
 {
     int x = 1;
@@ -11,4 +13,6 @@ int func()
     printf("y: %d\n", y);
     printf("x+y: %d\n", x + y);
     return x + y;
+}
+
 }

--- a/Base/home/anon/Source/little/other.h
+++ b/Base/home/anon/Source/little/other.h
@@ -1,3 +1,6 @@
+
+namespace MyNamespace {
+
 int func();
 
 #define USE_VAR2
@@ -12,3 +15,5 @@ struct StructInHeader {
     int var3;
 #endif
 };
+
+}

--- a/Userland/DevTools/HackStudio/AutoCompleteResponse.h
+++ b/Userland/DevTools/HackStudio/AutoCompleteResponse.h
@@ -98,6 +98,7 @@ inline bool encode(Encoder& encoder, const GUI::AutocompleteProvider::Declaratio
     if (!encode(encoder, declaration.position))
         return false;
     encoder << (u32)declaration.type;
+    encoder << declaration.scope;
     return true;
 }
 
@@ -109,8 +110,12 @@ inline bool decode(Decoder& decoder, GUI::AutocompleteProvider::Declaration& dec
 
     if (!decode(decoder, declaration.position))
         return false;
+
     u32 type;
     if (!decoder.decode(type))
+        return false;
+
+    if (!decoder.decode(declaration.scope))
         return false;
 
     declaration.type = static_cast<GUI::AutocompleteProvider::DeclarationType>(type);

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
@@ -96,7 +96,8 @@ private:
         RefPtr<Type> type;
     };
     Vector<PropertyInfo> properties_of_type(const DocumentData& document, const String& type) const;
-    NonnullRefPtrVector<Declaration> get_declarations_in_outer_scope_including_headers(const DocumentData& document) const;
+    NonnullRefPtrVector<Declaration> get_global_declarations_including_headers(const DocumentData& document) const;
+    NonnullRefPtrVector<Declaration> get_global_declarations(const ASTNode& node) const;
 
     const DocumentData* get_document_data(const String& file) const;
     const DocumentData* get_or_create_document_data(const String& file);

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ParserAutoComplete.h
@@ -107,6 +107,7 @@ private:
     String document_path_from_include_path(const StringView& include_path) const;
     void update_declared_symbols(const DocumentData&);
     GUI::AutocompleteProvider::DeclarationType type_of_declaration(const Declaration&);
+    String scope_of_declaration(const Declaration&);
     Optional<GUI::AutocompleteProvider::ProjectLocation> find_preprocessor_definition(const DocumentData&, const GUI::TextPosition&);
 
     OwnPtr<DocumentData> create_document_data(String&& text, const String& filename);

--- a/Userland/DevTools/HackStudio/LanguageServers/Shell/AutoComplete.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Shell/AutoComplete.cpp
@@ -233,7 +233,7 @@ void AutoComplete::update_declared_symbols(const DocumentData& document)
 
                 if (!name.is_empty()) {
                     dbgln("Found variable {}", name);
-                    declarations.append({ move(name), { filename, entry.name->position().start_line.line_number, entry.name->position().start_line.line_column }, GUI::AutocompleteProvider::DeclarationType::Variable });
+                    declarations.append({ move(name), { filename, entry.name->position().start_line.line_number, entry.name->position().start_line.line_column }, GUI::AutocompleteProvider::DeclarationType::Variable, {} });
                 }
             }
             ::Shell::AST::NodeVisitor::visit(node);
@@ -242,7 +242,7 @@ void AutoComplete::update_declared_symbols(const DocumentData& document)
         void visit(const ::Shell::AST::FunctionDeclaration* node) override
         {
             dbgln("Found function {}", node->name().name);
-            declarations.append({ node->name().name, { filename, node->position().start_line.line_number, node->position().start_line.line_column }, GUI::AutocompleteProvider::DeclarationType::Function });
+            declarations.append({ node->name().name, { filename, node->position().start_line.line_number, node->position().start_line.line_column }, GUI::AutocompleteProvider::DeclarationType::Function, {} });
         }
 
         const String& filename;

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -77,8 +77,11 @@ public:
                 return GUI::FileIconProvider::icon_for_path(suggestion.as_filename.value());
         }
         if (suggestion.is_symbol_declaration()) {
-            if (index.column() == Column::Name)
-                return suggestion.as_symbol_declaration.value().name;
+            if (index.column() == Column::Name) {
+                if (suggestion.as_symbol_declaration.value().scope.is_null())
+                    return suggestion.as_symbol_declaration.value().name;
+                return String::formatted("{}::{}", suggestion.as_symbol_declaration.value().scope, suggestion.as_symbol_declaration.value().name);
+            }
             if (index.column() == Column::Filename)
                 return suggestion.as_symbol_declaration.value().position.file;
             if (index.column() == Column::Icon) {
@@ -225,7 +228,7 @@ void Locator::update_suggestions()
 
     for (auto& item : m_document_to_declarations) {
         for (auto& decl : item.value) {
-            if (decl.name.contains(typed_text, CaseSensitivity::CaseInsensitive))
+            if (decl.name.contains(typed_text, CaseSensitivity::CaseInsensitive) || decl.scope.contains(typed_text, CaseSensitivity::CaseInsensitive))
                 suggestions.append((LocatorSuggestionModel::Suggestion::create_symbol_declaration(decl)));
         }
     }

--- a/Userland/Libraries/LibCpp/AST.cpp
+++ b/Userland/Libraries/LibCpp/AST.cpp
@@ -43,7 +43,7 @@ void ASTNode::dump(size_t indent) const
 void TranslationUnit::dump(size_t indent) const
 {
     ASTNode::dump(indent);
-    for (const auto& child : m_children) {
+    for (const auto& child : m_declarations) {
         child.dump(indent + 1);
     }
 }
@@ -413,4 +413,14 @@ NonnullRefPtrVector<Declaration> IfStatement::declarations() const
     declarations.append(m_else->declarations());
     return declarations;
 }
+
+void NamespaceDeclaration::dump(size_t indent) const
+{
+    ASTNode::dump(indent);
+    print_indent(indent + 1);
+    outln("{}", m_name);
+    for (auto& decl : m_declarations)
+        decl.dump(indent + 1);
+}
+
 }

--- a/Userland/Libraries/LibCpp/AST.h
+++ b/Userland/Libraries/LibCpp/AST.h
@@ -96,23 +96,16 @@ class TranslationUnit : public ASTNode {
 
 public:
     virtual ~TranslationUnit() override = default;
-    const NonnullRefPtrVector<Declaration>& children() const { return m_children; }
     virtual const char* class_name() const override { return "TranslationUnit"; }
     virtual void dump(size_t indent) const override;
-    void append(NonnullRefPtr<Declaration> child)
-    {
-        m_children.append(move(child));
-    }
-    virtual NonnullRefPtrVector<Declaration> declarations() const override { return m_children; }
+    virtual NonnullRefPtrVector<Declaration> declarations() const override { return m_declarations; }
 
-public:
     TranslationUnit(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
         : ASTNode(parent, start, end, filename)
     {
     }
 
-private:
-    NonnullRefPtrVector<Declaration> m_children;
+    NonnullRefPtrVector<Declaration> m_declarations;
 };
 
 class Statement : public ASTNode {
@@ -140,6 +133,7 @@ public:
     virtual bool is_struct() const { return false; }
     virtual bool is_class() const { return false; }
     virtual bool is_function() const { return false; }
+    virtual bool is_namespace() const { return false; }
     const StringView& name() const { return m_name; }
 
     StringView m_name;
@@ -616,6 +610,24 @@ public:
     RefPtr<Expression> m_predicate;
     RefPtr<Statement> m_then;
     RefPtr<Statement> m_else;
+};
+
+class NamespaceDeclaration : public Declaration {
+public:
+    virtual ~NamespaceDeclaration() override = default;
+    virtual const char* class_name() const override { return "NamespaceDeclaration"; }
+    virtual void dump(size_t indent) const override;
+    virtual bool is_namespace() const override { return true; }
+
+    NamespaceDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
+        : Declaration(parent, start, end, filename)
+    {
+    }
+
+    virtual NonnullRefPtrVector<Declaration> declarations() const override { return m_declarations; }
+
+    StringView m_name;
+    NonnullRefPtrVector<Declaration> m_declarations;
 };
 
 }

--- a/Userland/Libraries/LibCpp/AST.h
+++ b/Userland/Libraries/LibCpp/AST.h
@@ -75,6 +75,7 @@ public:
     virtual bool is_variable_or_parameter_declaration() const { return false; }
     virtual bool is_function_call() const { return false; }
     virtual bool is_type() const { return false; }
+    virtual bool is_declaration() const { return false; }
 
 protected:
     ASTNode(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
@@ -113,7 +114,6 @@ public:
     virtual ~Statement() override = default;
     virtual const char* class_name() const override { return "Statement"; }
 
-    virtual bool is_declaration() const { return false; }
     virtual NonnullRefPtrVector<Declaration> declarations() const override;
 
 protected:

--- a/Userland/Libraries/LibCpp/Parser.h
+++ b/Userland/Libraries/LibCpp/Parser.h
@@ -68,13 +68,10 @@ private:
         Variable,
         Enum,
         Struct,
+        Namespace,
     };
 
-    bool done();
-
-    Optional<DeclarationType> match_declaration();
     Optional<DeclarationType> match_declaration_in_translation_unit();
-    Optional<DeclarationType> match_declaration_in_function_definition();
     bool match_function_declaration();
     bool match_comment();
     bool match_preprocessor();
@@ -90,6 +87,7 @@ private:
     bool match_boolean_literal();
     bool match_keyword(const String&);
     bool match_block_statement();
+    bool match_namespace_declaration();
 
     Optional<NonnullRefPtrVector<Parameter>> parse_parameter_list(ASTNode& parent);
     Optional<Token> consume_whitespace();
@@ -119,6 +117,10 @@ private:
     NonnullRefPtr<BlockStatement> parse_block_statement(ASTNode& parent);
     NonnullRefPtr<Comment> parse_comment(ASTNode& parent);
     NonnullRefPtr<IfStatement> parse_if_statement(ASTNode& parent);
+    NonnullRefPtr<NamespaceDeclaration> parse_namespace_declaration(ASTNode& parent, bool is_nested_namespace = false);
+    NonnullRefPtrVector<Declaration> parse_declarations_in_translation_unit(ASTNode& parent);
+    RefPtr<Declaration> parse_single_declaration_in_translation_unit(ASTNode& parent);
+
 
     bool match(Token::Type);
     Token consume(Token::Type);
@@ -132,13 +134,7 @@ private:
     void save_state();
     void load_state();
 
-    enum class Context {
-        InTranslationUnit,
-        InFunctionDefinition,
-    };
-
     struct State {
-        Context context { Context::InTranslationUnit };
         size_t token_index { 0 };
     };
 

--- a/Userland/Libraries/LibCpp/Parser.h
+++ b/Userland/Libraries/LibCpp/Parser.h
@@ -121,7 +121,6 @@ private:
     NonnullRefPtrVector<Declaration> parse_declarations_in_translation_unit(ASTNode& parent);
     RefPtr<Declaration> parse_single_declaration_in_translation_unit(ASTNode& parent);
 
-
     bool match(Token::Type);
     Token consume(Token::Type);
     Token consume();

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.h
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.h
@@ -75,6 +75,7 @@ public:
         String name;
         ProjectLocation position;
         DeclarationType type;
+        String scope;
     };
 
     virtual void provide_completions(Function<void(Vector<Entry>)>) = 0;


### PR DESCRIPTION
We can now parse c++ namespaces, and include the scope of symbols in the Locator.

Example:
![hs-namespace](https://user-images.githubusercontent.com/9247514/112156655-1de62a00-8bef-11eb-898d-5996a0d5e64a.png)
