### PR TITLE
Spreadsheet: Ensure that cell exists on drop event for text data

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -297,10 +297,8 @@ SpreadsheetView::SpreadsheetView(Sheet& sheet)
         }
 
         if (event.mime_data().has_text()) {
-            auto* target_cell = m_sheet->at({ (size_t)index.column(), (size_t)index.row() });
-            VERIFY(target_cell);
-
-            target_cell->set_data(event.text());
+            auto& target_cell = m_sheet->ensure({ (size_t)index.column(), (size_t)index.row() });
+            target_cell.set_data(event.text());
             return;
         }
     };


### PR DESCRIPTION
Fixes crash where we tried to get a cell to set text from the drop
event. We now create the cell if it does not already exists.

Fixes #5923