### PR TITLE
jp: add variable indentation level and use stdin input by default

### DIFF
--- a/Base/usr/share/man/man1/jp.md
+++ b/Base/usr/share/man/man1/jp.md
@@ -1,0 +1,35 @@
+## Name
+
+jp - pretty-print a JSON file with syntax-coloring and indentation
+
+## Synopsis
+
+```**sh
+$ jp [options...] [path...]
+```
+
+## Description
+
+`jp` pretty-prints a JSON file with syntax-coloring and indentation.
+
+If no *path* argument is provided stdin is used.
+
+## Options
+
+* `--help`: Display this message
+* `-i`, `--indent-size`: Size of indentations in spaces
+
+## Arguments
+
+* path: file to pretty-print
+
+## Examples
+
+```sh
+# Pretty-print stdin
+$ cat /proc/all | jp
+# Pretty-print a file
+$ jp json-data.json
+# Pretty-print a file with two spaces per indent
+$ jp -i 2 json-data.json
+```

--- a/Userland/Utilities/jp.cpp
+++ b/Userland/Utilities/jp.cpp
@@ -34,11 +34,11 @@
 #include <stdio.h>
 #include <unistd.h>
 
-static void print(const JsonValue& value, int indent = 0, bool use_color = true);
-static void print_indent(int indent)
+static void print(const JsonValue& value, int spaces_per_indent, int indent = 0, bool use_color = true);
+static void print_indent(int indent, int spaces_per_indent)
 {
-    for (int i = 0; i < indent; ++i)
-        out("  ");
+    for (int i = 0; i < indent * spaces_per_indent; ++i)
+        out(" ");
 }
 
 int main(int argc, char** argv)
@@ -49,12 +49,16 @@ int main(int argc, char** argv)
     }
 
     const char* path = nullptr;
+    int spaces_in_indent = 4;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Pretty-print a JSON file with syntax-coloring and indentation.");
-    args_parser.add_positional_argument(path, "Path to JSON file", "path");
+    args_parser.add_option(spaces_in_indent, "Indent size", "indent-size", 'i', "spaces_in_indent");
+    args_parser.add_positional_argument(path, "Path to JSON file", "path", Core::ArgsParser::Required::No);
+    VERIFY(spaces_in_indent >= 0);
     args_parser.parse(argc, argv);
-
+    if (path == nullptr)
+        path = "/dev/stdin";
     auto file = Core::File::construct(path);
     if (!file->open(Core::IODevice::ReadOnly)) {
         warnln("Couldn't open {} for reading: {}", path, file->error_string());
@@ -73,13 +77,13 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    print(json.value(), 0, isatty(STDOUT_FILENO));
+    print(json.value(), spaces_in_indent, 0, isatty(STDOUT_FILENO));
     outln();
 
     return 0;
 }
 
-void print(const JsonValue& value, int indent, bool use_color)
+void print(const JsonValue& value, int spaces_per_indent, int indent, bool use_color)
 {
     if (value.is_object()) {
         size_t printed_members = 0;
@@ -87,17 +91,17 @@ void print(const JsonValue& value, int indent, bool use_color)
         outln("{{");
         object.for_each_member([&](auto& member_name, auto& member_value) {
             ++printed_members;
-            print_indent(indent + 1);
+            print_indent(indent + 1, spaces_per_indent);
             if (use_color)
                 out("\"\033[33;1m{}\033[0m\": ", member_name);
             else
                 out("\"{}\": ", member_name);
-            print(member_value, indent + 1, use_color);
+            print(member_value, spaces_per_indent, indent + 1, use_color);
             if (printed_members < static_cast<size_t>(object.size()))
                 out(",");
             outln();
         });
-        print_indent(indent);
+        print_indent(indent, spaces_per_indent);
         out("}}");
         return;
     }
@@ -107,13 +111,13 @@ void print(const JsonValue& value, int indent, bool use_color)
         outln("[");
         array.for_each([&](auto& entry_value) {
             ++printed_entries;
-            print_indent(indent + 1);
-            print(entry_value, indent + 1, use_color);
+            print_indent(indent + 1, spaces_per_indent);
+            print(entry_value, spaces_per_indent, indent + 1, use_color);
             if (printed_entries < static_cast<size_t>(array.size()))
                 out(",");
             outln();
         });
-        print_indent(indent);
+        print_indent(indent, spaces_per_indent);
         out("]");
         return;
     }


### PR DESCRIPTION
This PR was originally for a new utility, but upon realizing it was sort of duplicated, turned into extending an existing one.

Pass -i N where N is an integer to change the indentation to N spaces.