### PR TITLE
PropertiesWindow: Display the file size in a human readable format

### DIFF
--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -54,6 +54,15 @@ static inline String human_readable_size(u64 size)
     return number_string_with_one_decimal(size, EiB, "EiB");
 }
 
+static inline String human_readable_size_long(u64 size)
+{
+    if (size < 1 * KiB)
+        return String::formatted("{} bytes", size);
+    else
+        return String::formatted("{} ({} bytes)", human_readable_size(size), size);
+}
+
 }
 
 using AK::human_readable_size;
+using AK::human_readable_size_long;

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -26,6 +26,7 @@
 
 #include "PropertiesWindow.h"
 #include <AK/LexicalPath.h>
+#include <AK/NumberFormat.h>
 #include <AK/StringBuilder.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/BoxLayout.h>
@@ -128,7 +129,7 @@ PropertiesWindow::PropertiesWindow(const String& path, bool disable_rename, Wind
         }
     }
 
-    properties.append({ "Size:", String::formatted("{} bytes", st.st_size) });
+    properties.append({ "Size:", human_readable_size_long(st.st_size) });
     properties.append({ "Owner:", String::formatted("{} ({})", owner_name, st.st_uid) });
     properties.append({ "Group:", String::formatted("{} ({})", group_name, st.st_gid) });
     properties.append({ "Created at:", GUI::FileSystemModel::timestamp_string(st.st_ctime) });


### PR DESCRIPTION
Instead of just displaying the file size in plain bytes, display both a more readable format as well as bytes if the size is above 1 KiB.

![image](https://user-images.githubusercontent.com/13297896/112379556-91b82d80-8ce8-11eb-96eb-bc2301ea6e7a.png)
![image](https://user-images.githubusercontent.com/13297896/112379747-d348d880-8ce8-11eb-9b71-b03df8d2cdc7.png)