### PR TITLE
Ports: Fix m4

### DIFF
--- a/Ports/m4/patches/Makefile.am.patch
+++ b/Ports/m4/patches/Makefile.am.patch
@@ -1,0 +1,11 @@
+--- m4-1.4.9/Makefile.am	2021-03-22 06:08:56.323301400 +0100
++++ m4-1.4.9-patched/Makefile.am	2021-03-22 06:10:35.508791200 +0100
+@@ -20,7 +20,7 @@
+ ##
+ ## Written by Gary V. Vaughan <gary@gnu.org>
+ 
+-SUBDIRS = . examples lib src doc checks
++SUBDIRS = . lib src 
+ EXTRA_DIST = bootstrap c-boxes.el gendocs.sh GNUmakefile Makefile.maint \
+ 	m4/gnulib-cache.m4
+ DISTCLEANFILES = stamp-h

--- a/Ports/m4/patches/Makefile.in.patch
+++ b/Ports/m4/patches/Makefile.in.patch
@@ -1,0 +1,11 @@
+--- m4-1.4.9/Makefile.in	2021-03-22 06:13:45.959823300 +0100
++++ m4-1.4.9-patched/Makefile.in	2021-03-22 06:18:06.420963000 +0100
+@@ -267,7 +267,7 @@
+ target_alias = @target_alias@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+-SUBDIRS = . examples lib src doc checks
++SUBDIRS = . lib src
+ EXTRA_DIST = bootstrap c-boxes.el gendocs.sh GNUmakefile Makefile.maint \
+ 	m4/gnulib-cache.m4
+ 


### PR DESCRIPTION
This patch fixes the m4 port by removing unneeded make subdirs that
would cause the build to fail on some systems. We now only care about
`lib` and `src`, since we don't want `make` attempting to run the Serenity
binary on Linux, for example, and failing the build because of it.