### PR TITLE
Remove unused private fields.

### DIFF
--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -31,7 +31,6 @@
 namespace Kernel {
 
 File::File()
-    : m_block_condition(*this)
 {
 }
 

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -43,10 +43,7 @@ class File;
 
 class FileBlockCondition : public Thread::BlockCondition {
 public:
-    FileBlockCondition(File& file)
-        : m_file(file)
-    {
-    }
+    FileBlockCondition() { }
 
     virtual bool should_add_blocker(Thread::Blocker& b, void* data) override
     {
@@ -64,9 +61,6 @@ public:
             return blocker.unblock(false, data);
         });
     }
-
-private:
-    File& m_file;
 };
 
 // File is the base class for anything that can be referenced by a FileDescription.

--- a/Kernel/Storage/AHCIPort.cpp
+++ b/Kernel/Storage/AHCIPort.cpp
@@ -43,7 +43,6 @@ NonnullRefPtr<AHCIPort::ScatterList> AHCIPort::ScatterList::create(AsyncBlockDev
 
 AHCIPort::ScatterList::ScatterList(AsyncBlockDeviceRequest& request, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size)
     : m_vm_object(AnonymousVMObject::create_with_physical_pages(allocated_pages))
-    , m_device_block_size(device_block_size)
 {
     m_dma_region = MM.allocate_kernel_region_with_vmobject(m_vm_object, page_round_up((request.block_count() * device_block_size)), "AHCI Scattered DMA", Region::Access::Read | Region::Access::Write, Region::Cacheable::Yes);
 }

--- a/Kernel/Storage/AHCIPort.h
+++ b/Kernel/Storage/AHCIPort.h
@@ -63,7 +63,6 @@ private:
     private:
         ScatterList(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
         NonnullRefPtr<AnonymousVMObject> m_vm_object;
-        size_t m_device_block_size;
         OwnPtr<Region> m_dma_region;
     };
 

--- a/Kernel/Storage/Partition/EBRPartitionTable.h
+++ b/Kernel/Storage/Partition/EBRPartitionTable.h
@@ -49,6 +49,5 @@ private:
     void search_extended_partition(const StorageDevice&, MBRPartitionTable&, u64, size_t limit);
 
     bool m_valid { false };
-    size_t m_partitions_count { 0 };
 };
 }

--- a/Kernel/Storage/Partition/MBRPartitionTable.h
+++ b/Kernel/Storage/Partition/MBRPartitionTable.h
@@ -82,6 +82,5 @@ private:
     bool m_header_valid { false };
     const u32 m_start_lba;
     ByteBuffer m_cached_header;
-    size_t m_partitions_count { 0 };
 };
 }

--- a/Kernel/WorkQueue.cpp
+++ b/Kernel/WorkQueue.cpp
@@ -39,7 +39,6 @@ void WorkQueue::initialize()
 }
 
 WorkQueue::WorkQueue(const char* name)
-    : m_name(name)
 {
     RefPtr<Thread> thread;
     Process::create_kernel_process(thread, name, [this] {

--- a/Kernel/WorkQueue.h
+++ b/Kernel/WorkQueue.h
@@ -84,7 +84,6 @@ private:
 
     void do_queue(WorkItem*);
 
-    const char* const m_name;
     RefPtr<Thread> m_thread;
     WaitQueue m_wait_queue;
     IntrusiveList<WorkItem, &WorkItem::m_node> m_items;


### PR DESCRIPTION
Hi,
Trying to compile Serenity on my system using clang triggered a bunch of warnings promoted to errors because of -Wunused-private-fields. The following change set remove these entries.

Please note that I can only compile test using clang for now since my distro is still stuck on gcc 9.2.1 for now.
Please review.