### PR TITLE
LibGUI: Show human readable size in filemanager

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -413,10 +413,8 @@ void DirectoryView::update_statusbar()
     size_t selected_byte_count = 0;
 
     current_view().selection().for_each_index([&](auto& index) {
-        auto& model = *current_view().model();
-        auto size_index = model.index(index.row(), GUI::FileSystemModel::Column::Size, model.parent_index(index));
-        auto file_size = size_index.data().to_i32();
-        selected_byte_count += file_size;
+        const auto& node = this->node(index);
+        selected_byte_count += node.size;
     });
 
     StringBuilder builder;

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <AK/LexicalPath.h>
+#include <AK/NumberFormat.h>
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/DirIterator.h>
@@ -439,7 +440,7 @@ Variant FileSystemModel::data(const ModelIndex& index, ModelRole role) const
         case Column::Name:
             return node.name;
         case Column::Size:
-            return (int)node.size;
+            return human_readable_size(node.size);
         case Column::Owner:
             return name_for_uid(node.uid);
         case Column::Group:


### PR DESCRIPTION
Th size is visible only in TableView mode.
This fixes #5938.