### PR TITLE
Kernel: Implements fastbins for heap

### DIFF
--- a/Kernel/Heap/SlabAllocator.cpp
+++ b/Kernel/Heap/SlabAllocator.cpp
@@ -36,99 +36,76 @@
 namespace Kernel {
 
 template<size_t templated_slab_size>
-class SlabAllocator {
-public:
-    SlabAllocator() = default;
-
-    void init(size_t size)
-    {
-        m_base = kmalloc_eternal(size);
-        m_end = (u8*)m_base + size;
-        FreeSlab* slabs = (FreeSlab*)m_base;
-        m_slab_count = size / templated_slab_size;
-        for (size_t i = 1; i < m_slab_count; ++i) {
-            slabs[i].next = &slabs[i - 1];
-        }
-        slabs[0].next = nullptr;
-        m_freelist = &slabs[m_slab_count - 1];
-        m_num_allocated = 0;
+void SlabAllocator<templated_slab_size>::init(void* base, size_t size)
+{
+    m_base = base;
+    m_end = (u8*)m_base + size;
+    FreeSlab* slabs = (FreeSlab*)m_base;
+    m_slab_count = size / templated_slab_size;
+    for (size_t i = 1; i < m_slab_count; ++i) {
+        slabs[i].next = &slabs[i - 1];
     }
+    slabs[0].next = nullptr;
+    m_freelist = &slabs[m_slab_count - 1];
+    m_num_allocated = 0;
+}
 
-    constexpr size_t slab_size() const { return templated_slab_size; }
-    size_t slab_count() const { return m_slab_count; }
-
-    void* alloc()
+template<size_t templated_slab_size>
+void* SlabAllocator<templated_slab_size>::alloc()
+{
+    FreeSlab* free_slab;
     {
-        FreeSlab* free_slab;
-        {
-            // We want to avoid being swapped out in the middle of this
-            ScopedCritical critical;
-            FreeSlab* next_free;
-            free_slab = m_freelist.load(AK::memory_order_consume);
-            do {
-                if (!free_slab)
-                    return kmalloc(slab_size());
-                // It's possible another processor is doing the same thing at
-                // the same time, so next_free *can* be a bogus pointer. However,
-                // in that case compare_exchange_strong would fail and we would
-                // try again.
-                next_free = free_slab->next;
-            } while (!m_freelist.compare_exchange_strong(free_slab, next_free, AK::memory_order_acq_rel));
-
-            m_num_allocated++;
-        }
-
-#ifdef SANITIZE_SLABS
-        memset(free_slab, SLAB_ALLOC_SCRUB_BYTE, slab_size());
-#endif
-        return free_slab;
-    }
-
-    void dealloc(void* ptr)
-    {
-        VERIFY(ptr);
-        if (ptr < m_base || ptr >= m_end) {
-            kfree(ptr);
-            return;
-        }
-        FreeSlab* free_slab = (FreeSlab*)ptr;
-#ifdef SANITIZE_SLABS
-        if (slab_size() > sizeof(FreeSlab*))
-            memset(free_slab->padding, SLAB_DEALLOC_SCRUB_BYTE, sizeof(FreeSlab::padding));
-#endif
-
         // We want to avoid being swapped out in the middle of this
         ScopedCritical critical;
-        FreeSlab* next_free = m_freelist.load(AK::memory_order_consume);
+        FreeSlab* next_free;
+        free_slab = m_freelist.load(AK::memory_order_consume);
         do {
-            free_slab->next = next_free;
-        } while (!m_freelist.compare_exchange_strong(next_free, free_slab, AK::memory_order_acq_rel));
+            if (!free_slab)
+                return kmalloc_slowbin(slab_size());
+            // It's possible another processor is doing the same thing at
+            // the same time, so next_free *can* be a bogus pointer. However,
+            // in that case compare_exchange_strong would fail and we would
+            // try again.
+            next_free = free_slab->next;
+        } while (!m_freelist.compare_exchange_strong(free_slab, next_free, AK::memory_order_acq_rel));
 
-        m_num_allocated--;
+        m_num_allocated++;
     }
 
-    size_t num_allocated() const { return m_num_allocated; }
-    size_t num_free() const { return m_slab_count - m_num_allocated; }
+#ifdef SANITIZE_SLABS
+    memset(free_slab, SLAB_ALLOC_SCRUB_BYTE, slab_size());
+#endif
+    return free_slab;
+}
 
-private:
-    struct FreeSlab {
-        FreeSlab* next;
-        char padding[templated_slab_size - sizeof(FreeSlab*)];
-    };
+template<size_t templated_slab_size>
+void SlabAllocator<templated_slab_size>::dealloc(void* ptr)
+{
+    VERIFY(ptr);
+    if (ptr < m_base || ptr >= m_end) {
+        kfree(ptr);
+        return;
+    }
+    FreeSlab* free_slab = (FreeSlab*)ptr;
+#ifdef SANITIZE_SLABS
+    if (slab_size() > sizeof(FreeSlab*))
+        memset(free_slab->padding, SLAB_DEALLOC_SCRUB_BYTE, sizeof(FreeSlab::padding));
+#endif
 
-    Atomic<FreeSlab*> m_freelist { nullptr };
-    Atomic<ssize_t, AK::MemoryOrder::memory_order_relaxed> m_num_allocated;
-    size_t m_slab_count;
-    void* m_base { nullptr };
-    void* m_end { nullptr };
+    // We want to avoid being swapped out in the middle of this
+    ScopedCritical critical;
+    FreeSlab* next_free = m_freelist.load(AK::memory_order_consume);
+    do {
+        free_slab->next = next_free;
+    } while (!m_freelist.compare_exchange_strong(next_free, free_slab, AK::memory_order_acq_rel));
 
-    static_assert(sizeof(FreeSlab) == templated_slab_size);
-};
+    m_num_allocated--;
+}
 
-static SlabAllocator<16> s_slab_allocator_16;
-static SlabAllocator<32> s_slab_allocator_32;
-static SlabAllocator<64> s_slab_allocator_64;
-static SlabAllocator<128> s_slab_allocator_128;
+SlabAllocator<16> s_slab_allocator_16;
+SlabAllocator<32> s_slab_allocator_32;
+SlabAllocator<64> s_slab_allocator_64;
+SlabAllocator<128> s_slab_allocator_128;
 
 #if ARCH(I386)
 static_assert(sizeof(Region) <= s_slab_allocator_128.slab_size());
@@ -145,18 +122,22 @@ void for_each_allocator(Callback callback)
 
 UNMAP_AFTER_INIT void slab_alloc_init()
 {
-    s_slab_allocator_16.init(128 * KiB);
-    s_slab_allocator_32.init(128 * KiB);
-    s_slab_allocator_64.init(512 * KiB);
-    s_slab_allocator_128.init(512 * KiB);
+    // Allocating this way ensure a contiguous memory.
+    s_slab_allocator_16.init(kmalloc_eternal(128 * KiB * 2 + 512 * KiB * 2),
+        128 * KiB);
+    s_slab_allocator_32.init(s_slab_allocator_16.end(), 128 * KiB);
+    s_slab_allocator_64.init(s_slab_allocator_32.end(), 512 * KiB);
+    s_slab_allocator_128.init(s_slab_allocator_64.end(), 512 * KiB);
 }
 
 void* slab_alloc(size_t slab_size)
 {
-    if (slab_size <= 16)
-        return s_slab_allocator_16.alloc();
-    if (slab_size <= 32)
+    if (slab_size <= 32) {
+        if (slab_size <= 16)
+            return s_slab_allocator_16.alloc();
         return s_slab_allocator_32.alloc();
+    }
+    // Can't make it faster here due to the VERIFY_NOT_REACHED branch
     if (slab_size <= 64)
         return s_slab_allocator_64.alloc();
     if (slab_size <= 128)
@@ -166,14 +147,38 @@ void* slab_alloc(size_t slab_size)
 
 void slab_dealloc(void* ptr, size_t slab_size)
 {
-    if (slab_size <= 16)
-        return s_slab_allocator_16.dealloc(ptr);
-    if (slab_size <= 32)
+    if (slab_size <= 32) {
+        if (slab_size <= 16)
+            return s_slab_allocator_16.dealloc(ptr);
         return s_slab_allocator_32.dealloc(ptr);
+    }
+    // Can't make it faster here due to the VERIFY_NOT_REACHED branch
     if (slab_size <= 64)
         return s_slab_allocator_64.dealloc(ptr);
     if (slab_size <= 128)
         return s_slab_allocator_128.dealloc(ptr);
+    VERIFY_NOT_REACHED();
+}
+
+void slab_dealloc(void* ptr)
+{
+    if (ptr < s_slab_allocator_32.end()) {
+        if (ptr >= s_slab_allocator_32.base())
+            return s_slab_allocator_32.dealloc(ptr);
+
+        // In theory not needed, still this checks that we aren't unmapping
+        // something that isn't in any allocator.
+        if (ptr >= s_slab_allocator_16.base())
+            return s_slab_allocator_16.dealloc(ptr);
+    } else {
+        if (ptr < s_slab_allocator_64.end())
+            return s_slab_allocator_64.dealloc(ptr);
+
+        // In theory not needed, still this checks that we aren't unmapping
+        // something that isn't in any allocator.
+        if (ptr < s_slab_allocator_128.end())
+            return s_slab_allocator_128.dealloc(ptr);
+    }
     VERIFY_NOT_REACHED();
 }
 

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -61,6 +61,8 @@ inline void* operator new(size_t, void* p) { return p; }
 inline void* operator new[](size_t, void* p) { return p; }
 
 [[gnu::malloc, gnu::returns_nonnull, gnu::alloc_size(1)]] void* kmalloc(size_t);
+// kmalloc_slowbin is the same as kmalloc but skips the fastbins
+[[gnu::malloc, gnu::returns_nonnull, gnu::alloc_size(1)]] void* kmalloc_slowbin(size_t);
 
 template<size_t ALIGNMENT>
 [[gnu::malloc, gnu::returns_nonnull, gnu::alloc_size(1)]] inline void* kmalloc_aligned(size_t size)


### PR DESCRIPTION
This makes kmalloc and realateds to use a slab allocator instead of the variable heap if praticable.

This is somewhat faster but not by much (`<1%` on overall system I think).

Idealy the compiler would "rewrite" all calls to `kmalloc` where size is known at build time and would be better if used in a slab allocator into a slab allocator call else for when the size is unknown the current implementation is fine. But I really don't know how to do this kind of compiler instrumentation.