### PR TITLE
LibWeb+WebContent: Support displaying favicons in OOPWV

### DIFF
--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -335,6 +335,12 @@ void OutOfProcessWebView::notify_server_did_js_console_output(const String& meth
         on_js_console_output(method, line);
 }
 
+void OutOfProcessWebView::notify_server_did_change_favicon(const Gfx::Bitmap& favicon)
+{
+    if (on_favicon_change)
+        on_favicon_change(favicon);
+}
+
 void OutOfProcessWebView::did_scroll()
 {
     client().post_message(Messages::WebContentServer::SetViewportRect(visible_content_rect()));

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.h
@@ -75,6 +75,7 @@ public:
     String notify_server_did_request_prompt(Badge<WebContentClient>, const String& message, const String& default_);
     void notify_server_did_get_source(const URL& url, const String& source);
     void notify_server_did_js_console_output(const String& method, const String& line);
+    void notify_server_did_change_favicon(const Gfx::Bitmap& favicon);
 
 private:
     OutOfProcessWebView();

--- a/Userland/Libraries/LibWeb/WebContentClient.cpp
+++ b/Userland/Libraries/LibWeb/WebContentClient.cpp
@@ -173,4 +173,13 @@ OwnPtr<Messages::WebContentClient::DidRequestPromptResponse> WebContentClient::h
     return make<Messages::WebContentClient::DidRequestPromptResponse>(result);
 }
 
+void WebContentClient::handle(const Messages::WebContentClient::DidChangeFavicon& message)
+{
+    if (!message.favicon().is_valid()) {
+        dbgln("DidChangeFavicon: Received invalid favicon");
+        return;
+    }
+    m_view.notify_server_did_change_favicon(*message.favicon().bitmap());
+}
+
 }

--- a/Userland/Libraries/LibWeb/WebContentClient.h
+++ b/Userland/Libraries/LibWeb/WebContentClient.h
@@ -68,6 +68,7 @@ private:
     virtual void handle(const Messages::WebContentClient::DidRequestLinkContextMenu&) override;
     virtual void handle(const Messages::WebContentClient::DidGetSource&) override;
     virtual void handle(const Messages::WebContentClient::DidJSConsoleOutput&) override;
+    virtual void handle(const Messages::WebContentClient::DidChangeFavicon&) override;
     virtual OwnPtr<Messages::WebContentClient::DidRequestAlertResponse> handle(const Messages::WebContentClient::DidRequestAlert&) override;
     virtual OwnPtr<Messages::WebContentClient::DidRequestConfirmResponse> handle(const Messages::WebContentClient::DidRequestConfirm&) override;
     virtual OwnPtr<Messages::WebContentClient::DidRequestPromptResponse> handle(const Messages::WebContentClient::DidRequestPrompt&) override;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -188,4 +188,9 @@ String PageHost::page_did_request_prompt(const String& message, const String& de
     return m_client.send_sync<Messages::WebContentClient::DidRequestPrompt>(message, default_)->response();
 }
 
+void PageHost::page_did_change_favicon(const Gfx::Bitmap& favicon)
+{
+    m_client.post_message(Messages::WebContentClient::DidChangeFavicon(favicon.to_shareable_bitmap()));
+}
+
 }

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -72,6 +72,7 @@ private:
     virtual void page_did_request_alert(const String&) override;
     virtual bool page_did_request_confirm(const String&) override;
     virtual String page_did_request_prompt(const String&, const String&) override;
+    virtual void page_did_change_favicon(const Gfx::Bitmap&) override;
 
     explicit PageHost(ClientConnection&);
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -21,4 +21,5 @@ endpoint WebContentClient = 90
     DidRequestPrompt(String message, String default_) => (String response)
     DidGetSource(URL url, String source) =|
     DidJSConsoleOutput(String method, String line) =|
+    DidChangeFavicon(Gfx::ShareableBitmap favicon) =|
 }


### PR DESCRIPTION
In single process mode, the browser will display a page's favicon in
both the location bar and tab. This adds the same support for multi-
process mode.