### PR TITLE
LibCoreDump+CrashDaemon: Compress coredumps

### DIFF
--- a/Kernel/CoreDump.cpp
+++ b/Kernel/CoreDump.cpp
@@ -72,7 +72,7 @@ RefPtr<FileDescription> CoreDump::create_target_file(const Process& process, con
         return nullptr;
     }
     auto dump_directory_metadata = dump_directory.value()->inode().metadata();
-    if (dump_directory_metadata.uid != 0 || dump_directory_metadata.gid != 0 || dump_directory_metadata.mode != 040755) {
+    if (dump_directory_metadata.uid != 0 || dump_directory_metadata.gid != 0 || dump_directory_metadata.mode != 040777) {
         dbgln("Refusing to put core dump in sketchy directory '{}'", output_directory);
         return nullptr;
     }
@@ -329,7 +329,7 @@ KResult CoreDump::write()
     if (result.is_error())
         return result;
 
-    return m_fd->chmod(0400); // Make coredump file readable
+    return m_fd->chmod(0600); // Make coredump file read/writable
 }
 
 }

--- a/Userland/Libraries/LibCoreDump/CMakeLists.txt
+++ b/Userland/Libraries/LibCoreDump/CMakeLists.txt
@@ -4,4 +4,4 @@ set(SOURCES
 )
 
 serenity_lib(LibCoreDump coredump)
-target_link_libraries(LibCoreDump LibC LibCore LibDebug)
+target_link_libraries(LibCoreDump LibC LibCompress LibCore LibDebug)

--- a/Userland/Libraries/LibCoreDump/Reader.h
+++ b/Userland/Libraries/LibCoreDump/Reader.h
@@ -70,7 +70,9 @@ public:
     HashMap<String, String> metadata() const;
 
 private:
-    Reader(NonnullRefPtr<MappedFile>);
+    Reader(ReadonlyBytes);
+
+    static ByteBuffer decompress_coredump(const ReadonlyBytes&);
 
     class NotesEntryIterator {
     public:
@@ -92,7 +94,7 @@ private:
     // as getters with the appropriate (non-JsonValue) types.
     const JsonObject process_info() const;
 
-    NonnullRefPtr<MappedFile> m_coredump_file;
+    ByteBuffer m_coredump_buffer;
     ELF::Image m_coredump_image;
     ssize_t m_notes_segment_index { -1 };
 };

--- a/Userland/Services/CrashDaemon/CMakeLists.txt
+++ b/Userland/Services/CrashDaemon/CMakeLists.txt
@@ -3,4 +3,4 @@ set(SOURCES
 )
 
 serenity_bin(CrashDaemon)
-target_link_libraries(CrashDaemon LibC LibCore LibCoreDump)
+target_link_libraries(CrashDaemon LibC LibCompress LibCore LibCoreDump)

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -185,7 +185,8 @@ static void create_tmp_coredump_directory()
 {
     dbgln("Creating /tmp/coredump directory");
     auto old_umask = umask(0);
-    auto rc = mkdir("/tmp/coredump", 0755);
+    // FIXME: the coredump directory should be made read-only once CrashDaemon is no longer responsible for compressing coredumps
+    auto rc = mkdir("/tmp/coredump", 0777);
     if (rc < 0) {
         perror("mkdir(/tmp/coredump)");
         VERIFY_NOT_REACHED();


### PR DESCRIPTION
Most coredumps contain large amounts of consecutive null bytes and as such are a prime candidate for compression.
This commit makes CrashDaemon compress files once the kernel finishes emitting them, as well as adds the functionality needed in LibCoreDump to then parse them. (this fixes #4601)

I'm not entirely sure if this is the right place to compress the core dumps (aka, if it should be done in the kernel, or someplace else), but it works for now. Also, another thing to consider is the (small) increase in startup time for CrashReporter due to the decompression that is now done. (especially the initial launch right after the crash, as that now includes the time needed to compress as well)