### PR TITLE
LibWeb: CSS auto-height property computation fixes

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -290,7 +290,9 @@ float BlockFormattingContext::compute_auto_height_for_block_level_element(const 
         // the top margin-edge of the topmost block-level child box
         // and the bottom margin-edge of the bottommost block-level child box.
         box.for_each_child_of_type<Box>([&](Layout::Box& child_box) {
-            if (box.is_absolutely_positioned() || box.is_floating())
+            if (child_box.is_absolutely_positioned())
+                return IterationDecision::Continue;
+            if ((box.computed_values().overflow_y() == CSS::Overflow::Visible) && child_box.is_floating())
                 return IterationDecision::Continue;
 
             float child_box_top = child_box.effective_offset().y() - child_box.box_model().margin_box().top;


### PR DESCRIPTION
This PR contains a couple fixes for computing the height of block elements when it isn't specified in the CSS. In particular, on xkcd.com, the two boxes behind the navigation links and logo previously had a computed height of 0.

I think `FormattingContext::compute_height_for_absolutely_positioned_non_replaced_element` needs some more work to be compliant with section 10.6.4 of the [height property spec](https://www.w3.org/TR/CSS2/visudet.html#the-height-property), but now it at least handles rule 5 of that section.

Before:
![before](https://user-images.githubusercontent.com/5600524/112692485-6737b300-8e55-11eb-94db-2ab633dcc54f.png)

After:
![after](https://user-images.githubusercontent.com/5600524/112692490-6a32a380-8e55-11eb-8243-89aabd9c7ca8.png)
