### PR TITLE
Utilities: Add a delay option to the "shot" utility

### DIFF
--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -32,6 +32,7 @@
 #include <LibGUI/Clipboard.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/PNGWriter.h>
+#include <unistd.h>
 
 int main(int argc, char** argv)
 {
@@ -39,9 +40,11 @@ int main(int argc, char** argv)
 
     String output_path;
     bool output_to_clipboard = false;
+    int delay = 0;
 
     args_parser.add_positional_argument(output_path, "Output filename", "output", Core::ArgsParser::Required::No);
     args_parser.add_option(output_to_clipboard, "Output to clipboard", "clipboard", 'c');
+    args_parser.add_option(delay, "Seconds to wait before taking a screenshot", "delay", 'd', "seconds");
 
     args_parser.parse(argc, argv);
 
@@ -50,6 +53,7 @@ int main(int argc, char** argv)
     }
 
     auto app = GUI::Application::construct(argc, argv);
+    sleep(delay);
     auto response = GUI::WindowServerConnection::the().send_sync<Messages::WindowServer::GetScreenBitmap>();
 
     auto* bitmap = response->bitmap().bitmap();


### PR DESCRIPTION
This option allows for the user to set a delay before a screenshot taken.
The user could minimize the window, for example.