### PR TITLE
Browser: Set parent of tab child windows

### DIFF
--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -82,6 +82,8 @@ private:
     Web::WebViewHooks& hooks();
     void update_actions();
     void update_bookmark_button(const String& url);
+    void start_download(const URL& url);
+    void view_source(const URL& url, const String& source);
 
     Type m_type;
 


### PR DESCRIPTION
By setting the parent of the JS console, DOM inspector, view source and download windows, they will be destroyed automatically when the main browser window is closed.

Fixes #2373.