### PR TITLE
Ports: Add SQLite

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -73,6 +73,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`SDL2_ttf`](SDL2_ttf/)        | SDL2\_ttf (TrueType Font add-on for SDL2)     | 2.0.15            | https://www.libsdl.org/projects/SDL_ttf/              |
 | [`sed`](sed/)                  | GNU sed                                       | 4.2.1             | https://www.gnu.org/software/sed/                     |
 | [`sl`](sl/)                    | Steam Locomotive (SL)                         |                   | https://github.com/mtoyoda/sl                         |
+| [`sqlite`](sqlite/)            | SQLite                                        | 3350300           | https://www.sqlite.org/                               |
 | [`stress-ng`](stress-ng/)      | stress-ng                                     | 0.11.23           | https://github.com/ColinIanKing/stress-ng             |
 | [`termcap`](termcap/)          | GNU termcap                                   | 1.3.1             | https://www.gnu.org/software/termutils/               |
 | [`tinycc`](tinycc/)            | Tiny C Compiler (TinyCC)                      | dev               | https://github.com/TinyCC/tinycc                      |

--- a/Ports/sqlite/package.sh
+++ b/Ports/sqlite/package.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=sqlite
+useconfigure="true"
+version="3350300"
+files="https://www.sqlite.org/2021/sqlite-autoconf-${version}.tar.gz sqlite-autoconf-${version}.tar.gz"
+workdir="sqlite-autoconf-${version}"
+configopts="CFLAGS=-DHAVE_UTIME"

--- a/Ports/sqlite/patches/config.sub.patch
+++ b/Ports/sqlite/patches/config.sub.patch
@@ -1,0 +1,11 @@
+--- sqlite-autoconf-3350300/config.sub	2021-03-26 15:25:02.000000000 +0100
++++ sqlite-autoconf-port/config.sub	2021-03-26 23:31:42.457629453 +0100
+@@ -1366,7 +1366,7 @@
+ 	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
+ 	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -cnk* | -sunos | -sunos[34]*\
+ 	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -auroraux* | -solaris* \
+-	      | -sym* | -kopensolaris* | -plan9* \
++	      | -sym* | -kopensolaris* | -plan9* | -serenity* \
+ 	      | -amigaos* | -amigados* | -msdos* | -newsos* | -unicos* | -aof* \
+ 	      | -aos* | -aros* | -cloudabi* | -sortix* \
+ 	      | -nindy* | -vxsim* | -vxworks* | -ebmon* | -hms* | -mvs* \

--- a/Ports/sqlite/patches/shell.c.patch
+++ b/Ports/sqlite/patches/shell.c.patch
@@ -1,0 +1,13 @@
+--- sqlite-autoconf-3350300/shell.c	2021-03-26 15:24:58.000000000 +0100
++++ sqlite-autoconf-port/shell.c	2021-03-27 12:05:40.289547647 +0100
+@@ -2554,6 +2554,10 @@
+     if( utimensat(AT_FDCWD, zFile, times, AT_SYMLINK_NOFOLLOW) ){
+       return 1;
+     }
++#elif defined(HAVE_UTIME)
++    int rc = utime(zFile, NULL);
++    if (rc < 0)
++        return 1;
+ #else
+     /* Legacy unix */
+     struct timeval times[2];

--- a/Ports/sqlite/patches/sqlite3.c.patch
+++ b/Ports/sqlite/patches/sqlite3.c.patch
@@ -1,0 +1,18 @@
+--- sqlite-autoconf-3350300/sqlite3.c	2021-03-26 15:24:58.000000000 +0100
++++ sqlite-autoconf-port/sqlite3.c	2021-03-27 12:30:47.197494792 +0100
+@@ -41852,6 +41852,7 @@
+   ** array cannot be const.
+   */
+   static sqlite3_vfs aVfs[] = {
++    UNIXVFS("unix-none",     nolockIoFinder ),
+ #if SQLITE_ENABLE_LOCKING_STYLE && defined(__APPLE__)
+     UNIXVFS("unix",          autolockIoFinder ),
+ #elif OS_VXWORKS
+@@ -41859,7 +41860,6 @@
+ #else
+     UNIXVFS("unix",          posixIoFinder ),
+ #endif
+-    UNIXVFS("unix-none",     nolockIoFinder ),
+     UNIXVFS("unix-dotfile",  dotlockIoFinder ),
+     UNIXVFS("unix-excl",     posixIoFinder ),
+ #if OS_VXWORKS

--- a/Userland/Libraries/LibC/fcntl.h
+++ b/Userland/Libraries/LibC/fcntl.h
@@ -94,6 +94,7 @@ int watch_file(const char* path, size_t path_length);
 #define F_RDLCK 0
 #define F_WRLCK 1
 #define F_UNLCK 2
+#define F_GETLK 5
 #define F_SETLK 6
 #define F_SETLKW 7
 


### PR DESCRIPTION
First port I've done; let's get some SQL action into Serenity! :-)

![image](https://user-images.githubusercontent.com/3210731/112719624-1332da00-8efa-11eb-9be8-b12141ea0597.png)

Notes:
* SQLite seems to choke on locking mechanics, which is why `unix-none` is set as the default VFS
* Trying to `INSERT` on an opened database file will trigger an Ext2FS read error; doing so in an in-memory database or opening existing database files works fine