### PR TITLE
Taskbar: Set window title as taskbar button tooltip

### DIFF
--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -220,6 +220,7 @@ void TaskbarWindow::update_window_button(::Window& window, bool show_as_active)
     if (!button)
         return;
     button->set_text(window.title());
+    button->set_tooltip(window.title());
     button->set_checked(show_as_active);
 }
 


### PR DESCRIPTION
This way it's easier to find the right window when many are open at the same time, as all buttons share a limited amount of horizontal space and titles get truncated quickly.