### PR TITLE
LibGUI: Return symlink fallback icon if target icon cannot be determined

### DIFF
--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -235,6 +235,8 @@ Icon FileIconProvider::icon_for_path(const String& path, mode_t mode)
             target_path = Core::File::real_path_for(String::formatted("{}/{}", LexicalPath(path).dirname(), raw_symlink_target));
         }
         auto target_icon = icon_for_path(target_path);
+        if (target_icon.sizes().is_empty())
+            return s_symlink_icon;
 
         Icon generated_icon;
         for (auto size : target_icon.sizes()) {


### PR DESCRIPTION
This is the case for symlinks that point to themselves, for example - previously the returned icon would be empty.

Fixes #5978.
Fixes #5979.