### PR TITLE
Utilities: Make sure not to overwrite existing file (shot)

### DIFF
--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -49,6 +49,9 @@ int main(int argc, char** argv)
     if (output_path.is_empty())
         output_path = Core::DateTime::now().to_string("screenshot-%Y-%m-%d-%H-%M-%S.png");
     
+    if (!output_path.ends_with(".png"))
+        output_path = String::formatted("{}.png", output_path);
+    
     while (Core::File::exists(output_path)) {
         file_append += 1;
         if (!Core::File::exists(String::formatted("{}({}).png", output_path.split('.')[0], file_append)))

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -38,6 +38,7 @@ int main(int argc, char** argv)
     Core::ArgsParser args_parser;
 
     String output_path;
+    int file_append = 0;
     bool output_to_clipboard = false;
 
     args_parser.add_positional_argument(output_path, "Output filename", "output", Core::ArgsParser::Required::No);
@@ -45,9 +46,17 @@ int main(int argc, char** argv)
 
     args_parser.parse(argc, argv);
 
-    if (output_path.is_empty()) {
+    if (output_path.is_empty())
         output_path = Core::DateTime::now().to_string("screenshot-%Y-%m-%d-%H-%M-%S.png");
+    
+    while (Core::File::exists(output_path)) {
+        file_append += 1;
+        if (!Core::File::exists(String::formatted("{}({}).png", output_path.split('.')[0], file_append)))
+            break;
     }
+
+    if (!file_append == 0)
+        output_path = String::formatted("{}({}).png", output_path.split('.')[0], file_append);
 
     auto app = GUI::Application::construct(argc, argv);
     auto response = GUI::WindowServerConnection::the().send_sync<Messages::WindowServer::GetScreenBitmap>();


### PR DESCRIPTION
A file might get overwritten if you make another screenshot and provide a name of a file that already exists. If a file already exists the patch will just add a number after the name, for example, `file(1).png`, `file(2).png` and so on. I am also checking if `output_path` contains `.png` at the end, and if not I automatically add it.