### PR TITLE
WindowServer: Add menu item fade-out animation upon activation

### DIFF
--- a/Userland/Libraries/LibCore/Timer.h
+++ b/Userland/Libraries/LibCore/Timer.h
@@ -35,6 +35,12 @@ class Timer final : public Object {
     C_OBJECT(Timer);
 
 public:
+    static NonnullRefPtr<Timer> create_repeating(int interval, Function<void()>&& timeout_handler, Object* parent = nullptr)
+    {
+        auto timer = adopt(*new Timer(interval, move(timeout_handler), parent));
+        timer->stop();
+        return timer;
+    }
     static NonnullRefPtr<Timer> create_single_shot(int interval, Function<void()>&& timeout_handler, Object* parent = nullptr)
     {
         auto timer = adopt(*new Timer(interval, move(timeout_handler), parent));

--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -135,6 +135,8 @@ private:
     void did_activate(MenuItem&, bool leave_menu_open);
     void update_for_new_hovered_item(bool make_input = false);
 
+    void start_activation_animation(MenuItem&);
+
     ClientConnection* m_client { nullptr };
     int m_menu_id { 0 };
     String m_name;

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -949,6 +949,8 @@ bool Window::hit_test(const Gfx::IntPoint& point, bool include_frame) const
             return frame().hit_test(point);
         return false;
     }
+    if (!m_hit_testing_enabled)
+        return false;
     u8 threshold = alpha_hit_threshold() * 255;
     if (threshold == 0 || !m_backing_store || !m_backing_store->has_alpha_channel())
         return true;

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -146,6 +146,10 @@ public:
     float opacity() const { return m_opacity; }
     void set_opacity(float);
 
+    void set_hit_testing_enabled(bool value)
+    {
+        m_hit_testing_enabled = value;
+    }
     float alpha_hit_threshold() const { return m_alpha_hit_threshold; }
     void set_alpha_hit_threshold(float threshold)
     {
@@ -379,6 +383,7 @@ private:
     bool m_invalidated { true };
     bool m_invalidated_all { true };
     bool m_invalidated_frame { true };
+    bool m_hit_testing_enabled { true };
     WindowTileType m_tiled { WindowTileType::None };
     Gfx::IntRect m_untiled_rect;
     bool m_occluded { false };


### PR DESCRIPTION
_Always felt we were missing this..._

![menu_animation](https://user-images.githubusercontent.com/10320822/112734227-07e7aa80-8f0a-11eb-9308-ec8c9187ad0d.gif)