### PR TITLE
Chess: Added option to show available moves

### DIFF
--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -142,6 +142,8 @@ private:
     Gfx::IntPoint m_drag_point;
     bool m_dragging_piece { false };
     bool m_drag_enabled { true };
+    bool m_show_available_moves { true };
+    Vector<Chess::Square> m_available_moves;
     RefPtr<Engine> m_engine;
     bool m_coordinates { true };
 };

--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -66,6 +66,9 @@ public:
     void set_drag_enabled(bool e) { m_drag_enabled = e; }
     RefPtr<Gfx::Bitmap> get_piece_graphic(const Chess::Piece& piece) const;
 
+    bool show_available_moves() const { return m_show_available_moves; }
+    void set_show_available_moves(bool e) { m_show_available_moves = e; }
+
     String get_fen() const;
     bool import_pgn(const StringView& import_path);
     bool export_pgn(const StringView& export_path) const;

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -94,6 +94,7 @@ int main(int argc, char** argv)
     widget.set_piece_set(config->read_entry("Style", "PieceSet", "stelar7"));
     widget.set_board_theme(config->read_entry("Style", "BoardTheme", "Beige"));
     widget.set_coordinates(config->read_bool_entry("Style", "Coordinates", true));
+    widget.set_show_available_moves(config->read_bool_entry("Style", "ShowAvailableMoves", true));
 
     auto menubar = GUI::MenuBar::construct();
     auto& app_menu = menubar->add_menu("Game");
@@ -198,6 +199,15 @@ int main(int argc, char** argv)
     });
     coordinates_action->set_checked(widget.coordinates());
     style_menu.add_action(coordinates_action);
+
+    auto show_available_moves_action = GUI::Action::create_checkable("Show Available Moves", [&](auto& action) {
+        widget.set_show_available_moves(action.is_checked());
+        widget.update();
+        config->write_bool_entry("Style", "ShowAvailableMoves", action.is_checked());
+        config->sync();
+    });
+    show_available_moves_action->set_checked(widget.show_available_moves());
+    style_menu.add_action(show_available_moves_action);
 
     auto& engine_menu = menubar->add_menu("Engine");
 


### PR DESCRIPTION
A small change, but I think it goes a long way when playing the game.
Shows a little light gray dot on the squares where the currently dragged piece can move to.

Screenshot: 
![Screenshot_20210327_181830](https://user-images.githubusercontent.com/43870496/112735122-f5c93480-8f28-11eb-9391-863bf0b044bf.png)

