### PR TITLE
EditingEngine: Don't jump to the beginning or end of a non-existant word

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -477,6 +477,10 @@ TextPosition EditingEngine::find_end_of_next_word()
     bool is_first_iteration = true;
     auto& lines = m_editor->lines();
     auto cursor = m_editor->cursor();
+
+    if ((lines.at(cursor.line()).length() - cursor.column()) <= 1)
+        return { cursor.line(), cursor.column() };
+
     for (size_t line_index = cursor.line(); line_index < lines.size(); line_index++) {
         auto& line = lines.at(line_index);
 
@@ -605,6 +609,10 @@ TextPosition EditingEngine::find_beginning_of_previous_word()
     bool is_first_iteration = true;
     auto& lines = m_editor->lines();
     auto cursor = m_editor->cursor();
+
+    if ((lines.at(cursor.line()).length() - cursor.column()) <= 1)
+        return { cursor.line(), cursor.column() };
+
     for (size_t line_index = cursor.line(); (int)line_index >= 0; line_index--) {
         auto& line = lines.at(line_index);
 


### PR DESCRIPTION
Previously, when jumping to the next word on the last column of a line, or when jumping to the previous word on the first column, it would crash. This checks if that is the case, and if so, will do nothing. Fixes #5953