### PR TITLE
LibGUI: Fix TextEditor crash when double clicking an empty line.

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -62,14 +62,12 @@ bool EditingEngine::on_key(const KeyEvent& event)
             move_to_previous_span(event);
             if (event.shift() && m_editor->selection()->start().is_valid()) {
                 m_editor->selection()->set_end(m_editor->cursor());
-                m_editor->did_update_selection();
             }
             return true;
         }
         move_one_left(event);
         if (event.shift() && m_editor->selection()->start().is_valid()) {
             m_editor->selection()->set_end(m_editor->cursor());
-            m_editor->did_update_selection();
         }
         return true;
     }
@@ -91,7 +89,6 @@ bool EditingEngine::on_key(const KeyEvent& event)
         move_one_right(event);
         if (event.shift() && m_editor->selection()->start().is_valid()) {
             m_editor->selection()->set_end(m_editor->cursor());
-            m_editor->did_update_selection();
         }
         return true;
     }
@@ -100,7 +97,6 @@ bool EditingEngine::on_key(const KeyEvent& event)
         move_one_up(event);
         if (event.shift() && m_editor->selection()->start().is_valid()) {
             m_editor->selection()->set_end(m_editor->cursor());
-            m_editor->did_update_selection();
         }
         return true;
     }
@@ -109,7 +105,6 @@ bool EditingEngine::on_key(const KeyEvent& event)
         move_one_down(event);
         if (event.shift() && m_editor->selection()->start().is_valid()) {
             m_editor->selection()->set_end(m_editor->cursor());
-            m_editor->did_update_selection();
         }
         return true;
     }
@@ -120,13 +115,11 @@ bool EditingEngine::on_key(const KeyEvent& event)
             move_to_first_line();
             if (event.shift() && m_editor->selection()->start().is_valid()) {
                 m_editor->selection()->set_end(m_editor->cursor());
-                m_editor->did_update_selection();
             }
         } else {
             move_to_line_beginning(event);
             if (event.shift() && m_editor->selection()->start().is_valid()) {
                 m_editor->selection()->set_end(m_editor->cursor());
-                m_editor->did_update_selection();
             }
         }
         return true;
@@ -138,13 +131,11 @@ bool EditingEngine::on_key(const KeyEvent& event)
             move_to_last_line();
             if (event.shift() && m_editor->selection()->start().is_valid()) {
                 m_editor->selection()->set_end(m_editor->cursor());
-                m_editor->did_update_selection();
             }
         } else {
             move_to_line_end(event);
             if (event.shift() && m_editor->selection()->start().is_valid()) {
                 m_editor->selection()->set_end(m_editor->cursor());
-                m_editor->did_update_selection();
             }
         }
         return true;
@@ -154,7 +145,6 @@ bool EditingEngine::on_key(const KeyEvent& event)
         move_page_up(event);
         if (event.shift() && m_editor->selection()->start().is_valid()) {
             m_editor->selection()->set_end(m_editor->cursor());
-            m_editor->did_update_selection();
         }
         return true;
     }
@@ -163,7 +153,6 @@ bool EditingEngine::on_key(const KeyEvent& event)
         move_page_down(event);
         if (event.shift() && m_editor->selection()->start().is_valid()) {
             m_editor->selection()->set_end(m_editor->cursor());
-            m_editor->did_update_selection();
         }
         return true;
     }

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -344,7 +344,7 @@ String TextDocument::text() const
 String TextDocument::text_in_range(const TextRange& a_range) const
 {
     if (is_empty() || line_count() < a_range.end().line() - a_range.start().line() || line(a_range.start().line()).is_empty())
-        return String("");
+        return String::empty();
     auto range = a_range.normalized();
 
     StringBuilder builder;
@@ -352,6 +352,8 @@ String TextDocument::text_in_range(const TextRange& a_range) const
         auto& line = this->line(i);
         size_t selection_start_column_on_line = range.start().line() == i ? range.start().column() : 0;
         size_t selection_end_column_on_line = range.end().line() == i ? range.end().column() : line.length();
+        if (selection_start_column_on_line == selection_end_column_on_line)
+            return String::empty();
         builder.append(Utf32View(line.code_points() + selection_start_column_on_line, selection_end_column_on_line - selection_start_column_on_line));
         if (i != range.end().line())
             builder.append('\n');

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, the SerenityOS developers
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1392,6 +1393,11 @@ void TextEditor::set_mode(const Mode mode)
 
 void TextEditor::did_update_selection()
 {
+    if (m_selection == m_previous_selection) {
+        return;
+    }
+    m_previous_selection = m_selection;
+
     m_cut_action->set_enabled(is_editable() && has_selection());
     m_copy_action->set_enabled(has_selection());
     if (on_selection_change)

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -327,6 +327,7 @@ private:
     size_t m_soft_tab_width { 4 };
     int m_horizontal_content_padding { 3 };
     TextRange m_selection;
+    TextRange m_previous_selection;
     RefPtr<Menu> m_context_menu;
     RefPtr<Action> m_undo_action;
     RefPtr<Action> m_redo_action;


### PR DESCRIPTION
I also reduced the number of calls to `TextEditor::did_update_selection` - not sure if I should make a second PR. Fixes #5995 