### PR TITLE
Tidy cmake compile options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,21 +71,6 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-
-if (${CMAKE_HOST_SYSTEM_NAME} MATCHES SerenityOS)
-    # FIXME: Something makes this go crazy and flag unused variables that aren't flagged as such when building with the toolchain.
-    #        Disable -Werror for now.
-    add_compile_options(-Wno-unknown-warning-option -Wall -Wextra -Wmissing-declarations -Wformat=2 -fdiagnostics-color=always)
-else()
-    add_compile_options(-Wno-unknown-warning-option -Wall -Wextra -Werror -Wmissing-declarations -Wformat=2 -fdiagnostics-color=always)
-endif()
-
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    add_compile_options(-fconcepts -Wno-literal-suffix)
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_compile_options(-Wno-overloaded-virtual -Wno-user-defined-literals)
-endif()
-
 if (ENABLE_ALL_THE_DEBUG_MACROS)
     include(${CMAKE_SOURCE_DIR}/Meta/CMake/all_the_debug_macros.cmake)
 endif(ENABLE_ALL_THE_DEBUG_MACROS)
@@ -153,11 +138,22 @@ set(CMAKE_CXX_LINK_FLAGS "-Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecstack")
 # This will need to be revisited when the Loader supports RPATH/RUN_PATH.
 set(CMAKE_SKIP_RPATH TRUE)
 
+if (${CMAKE_HOST_SYSTEM_NAME} MATCHES SerenityOS)
+    # FIXME: Something makes this go crazy and flag unused variables that aren't flagged as such when building with the toolchain.
+    #        Disable -Werror for now.
+    add_compile_options(-Wno-unknown-warning-option -Wall -Wextra -Wmissing-declarations -Wformat=2 -fdiagnostics-color=always)
+else()
+    add_compile_options(-Wno-unknown-warning-option -Wall -Wextra -Werror -Wmissing-declarations -Wformat=2 -fdiagnostics-color=always)
+endif()
+
 add_compile_options(-g1 -fno-exceptions -fstack-protector-strong -Wno-address-of-packed-member -Wundef -Wcast-qual -Wwrite-strings -Wimplicit-fallthrough -Wno-nonnull-compare -Wno-deprecated-copy -Wno-expansion-to-defined)
 add_compile_options(-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    add_compile_options(-fconcepts -Wno-literal-suffix)
     add_compile_options(-fstack-clash-protection)
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    add_compile_options(-Wno-overloaded-virtual -Wno-user-defined-literals)
 endif()
 
 add_compile_definitions(DEBUG SANITIZE_PTRS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,22 +138,42 @@ set(CMAKE_CXX_LINK_FLAGS "-Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecstack")
 # This will need to be revisited when the Loader supports RPATH/RUN_PATH.
 set(CMAKE_SKIP_RPATH TRUE)
 
-if (${CMAKE_HOST_SYSTEM_NAME} MATCHES SerenityOS)
+add_compile_options(-Wformat=2)
+add_compile_options(-fdiagnostics-color=always)
+
+if (NOT ${CMAKE_HOST_SYSTEM_NAME} MATCHES SerenityOS)
     # FIXME: Something makes this go crazy and flag unused variables that aren't flagged as such when building with the toolchain.
     #        Disable -Werror for now.
-    add_compile_options(-Wno-unknown-warning-option -Wall -Wextra -Wmissing-declarations -Wformat=2 -fdiagnostics-color=always)
-else()
-    add_compile_options(-Wno-unknown-warning-option -Wall -Wextra -Werror -Wmissing-declarations -Wformat=2 -fdiagnostics-color=always)
+    add_compile_options(-Werror)
 endif()
 
-add_compile_options(-g1 -fno-exceptions -fstack-protector-strong -Wno-address-of-packed-member -Wundef -Wcast-qual -Wwrite-strings -Wimplicit-fallthrough -Wno-nonnull-compare -Wno-deprecated-copy -Wno-expansion-to-defined)
+add_compile_options(-Wall)
+add_compile_options(-Wextra)
+
+add_compile_options(-Wno-address-of-packed-member)
+add_compile_options(-Wcast-qual)
+add_compile_options(-Wno-deprecated-copy)
+add_compile_options(-Wno-expansion-to-defined)
+add_compile_options(-Wimplicit-fallthrough)
+add_compile_options(-Wmissing-declarations)
+add_compile_options(-Wno-nonnull-compare)
+add_compile_options(-Wno-unknown-warning-option)
+add_compile_options(-Wundef)
+add_compile_options(-Wwrite-strings)
+
 add_compile_options(-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.)
+add_compile_options(-fno-exceptions)
+add_compile_options(-fstack-protector-strong)
+add_compile_options(-g1)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    add_compile_options(-fconcepts -Wno-literal-suffix)
+    add_compile_options(-Wno-literal-suffix)
+
+    add_compile_options(-fconcepts)
     add_compile_options(-fstack-clash-protection)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_compile_options(-Wno-overloaded-virtual -Wno-user-defined-literals)
+    add_compile_options(-Wno-overloaded-virtual)
+    add_compile_options(-Wno-user-defined-literals)
 endif()
 
 add_compile_definitions(DEBUG SANITIZE_PTRS)


### PR DESCRIPTION
Prior to this patch set there are 2 sections of the CMakeLists.txt that configure the compiler options, with hard to read/maintain long  configuration strings.
This patch set regroup them and then order them logically with sections of one command entry per line. Sections are:
- Warning format control
- Warning as error
- Group warning enabling
- Fine grained warning tuning
- Compiler options
Then the same order is *repeated* per compiler.