### PR TITLE
LibGUI: Fix IconView selection with FlowDirection::TopToBottom

### DIFF
--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -820,7 +820,7 @@ inline IterationDecision IconView::for_each_item_intersecting_rect(const Gfx::In
                     return decision;
             }
         }
-        item_index += m_visual_column_count;
+        item_index += (m_flow_direction == FlowDirection::LeftToRight) ? m_visual_column_count : m_visual_row_count;
     };
 
     return IterationDecision::Continue;


### PR DESCRIPTION
While iterating the items contained by the rubberband we need to skip
the correct number of items either vertically or horizontally, depending
on which direction the items flow.

Fixes #5993