### PR TITLE
LibC+Kernel: Fix make port

### DIFF
--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -84,7 +84,7 @@ KResultOr<ssize_t> Process::do_write(FileDescription& description, const UserOrK
             return EAGAIN;
     }
 
-    if (description.should_append()) {
+    if (description.should_append() && description.file().is_seekable()) {
         auto seek_result = description.seek(0, SEEK_END);
         if (seek_result.is_error())
             return seek_result.error();

--- a/Userland/Libraries/LibC/cxxabi.cpp
+++ b/Userland/Libraries/LibC/cxxabi.cpp
@@ -101,10 +101,10 @@ void __cxa_finalize(void* dso_handle)
         bool needs_calling = !exit_entry.has_been_called && (!dso_handle || dso_handle == exit_entry.dso_handle);
         if (needs_calling) {
             dbgln_if(GLOBAL_DTORS_DEBUG, "__cxa_finalize: calling entry[{}] {:p}({:p}) dso: {:p}", entry_index, exit_entry.method, exit_entry.parameter, exit_entry.dso_handle);
-            exit_entry.method(exit_entry.parameter);
             unlock_atexit_handlers();
             exit_entry.has_been_called = true;
             lock_atexit_handlers();
+            exit_entry.method(exit_entry.parameter);
         }
     }
 }


### PR DESCRIPTION
This fixes the `make` port.
The regression in the kernel was probably introduced in d48666489c83b7f0922537ff2f3123644d17201e