### PR TITLE
LibGUI: Add transient option to show dotfiles in FilePicker

### DIFF
--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -36,6 +36,7 @@
 #include <LibGUI/FilePickerDialogGML.h>
 #include <LibGUI/FileSystemModel.h>
 #include <LibGUI/InputBox.h>
+#include <LibGUI/Menu.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/MultiView.h>
 #include <LibGUI/SortingProxyModel.h>
@@ -182,6 +183,18 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& file_
 
         if (!node.is_directory())
             m_filename_textbox->set_text(node.name);
+    };
+
+    m_context_menu = GUI::Menu::construct();
+    m_context_menu->add_action(GUI::Action::create_checkable("Show dotfiles", [&](auto& action) {
+        m_model->set_should_show_dotfiles(action.is_checked());
+        m_model->update();
+    }));
+
+    m_view->on_context_menu_request = [&](const GUI::ModelIndex& index, const GUI::ContextMenuEvent& event) {
+        if (!index.is_valid()) {
+            m_context_menu->popup(event.screen_position());
+        }
     };
 
     auto& ok_button = *widget.find_descendant_of_type_named<GUI::Button>("ok_button");

--- a/Userland/Libraries/LibGUI/FilePicker.h
+++ b/Userland/Libraries/LibGUI/FilePicker.h
@@ -83,6 +83,7 @@ private:
 
     RefPtr<TextBox> m_filename_textbox;
     RefPtr<TextBox> m_location_textbox;
+    RefPtr<Menu> m_context_menu;
     Mode m_mode { Mode::Open };
 };
 


### PR DESCRIPTION
This is particularly useful when wanting to open files in ~/.config
from the Text Editor. The option is currently not persistent, but could
be hooked into File Manager's configuration.