### PR TITLE
Browser+LibWeb+WebContent: Add action to clear resource cache

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -453,6 +453,13 @@ Tab::Tab(Type type)
             m_web_content_view->debug_request("collect-garbage");
         }
     }));
+    debug_menu.add_action(GUI::Action::create("Clear cache", { Mod_Ctrl | Mod_Shift, Key_C }, [this](auto&) {
+        if (m_type == Type::InProcessWebView) {
+            Web::ResourceLoader::the().clear_cache();
+        } else {
+            m_web_content_view->debug_request("clear-cache");
+        }
+    }));
 
     auto& help_menu = m_menubar->add_menu("Help");
     help_menu.add_action(WindowActions::the().about_action());

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -236,4 +236,10 @@ bool ResourceLoader::is_port_blocked(int port)
     return false;
 }
 
+void ResourceLoader::clear_cache()
+{
+    dbgln("Clearing {} items from ResourceLoader cache", s_resource_cache.size());
+    s_resource_cache.clear();
+}
+
 }

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -56,6 +56,8 @@ public:
 
     const String& user_agent() const { return m_user_agent; }
 
+    void clear_cache();
+
 private:
     ResourceLoader();
     static bool is_port_blocked(int port);

--- a/Userland/Services/WebContent/ClientConnection.cpp
+++ b/Userland/Services/WebContent/ClientConnection.cpp
@@ -37,6 +37,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/Layout/InitialContainingBlockBox.h>
+#include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Page/Frame.h>
 #include <WebContent/ClientConnection.h>
 #include <WebContent/PageHost.h>
@@ -209,6 +210,10 @@ void ClientConnection::handle(const Messages::WebContentServer::DebugRequest& me
         bool state = message.argument() == "on";
         m_page_host->set_should_show_line_box_borders(state);
         page().main_frame().set_needs_display(page().main_frame().viewport_rect());
+    }
+
+    if (message.request() == "clear-cache") {
+        Web::ResourceLoader::the().clear_cache();
     }
 }
 


### PR DESCRIPTION
Useful for debugging changing pages without having to restart the browser. It would be nice to also have a cache-skipping reload action (i.e. `ctrl+shift+r`), but seems a bit trickier to get that to stick across multiple resource requests.