### PR TITLE
FontEditor+TextEditor+Playground: Refuse to load device files

### DIFF
--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -80,7 +80,13 @@ int main(int argc, char** argv)
         path = "/tmp/saved.font";
         edited_font = static_ptr_cast<Gfx::BitmapFont>(Gfx::FontDatabase::default_font().clone());
     } else {
-        edited_font = static_ptr_cast<Gfx::BitmapFont>(Gfx::BitmapFont::load_from_file(path)->clone());
+        auto bitmap_font = Gfx::BitmapFont::load_from_file(path);
+        if (!bitmap_font) {
+            String message = String::formatted("Couldn't load font: {}\n", path);
+            GUI::MessageBox::show(nullptr, message, "Font Editor", GUI::MessageBox::Type::Error);
+            return 1;
+        }
+        edited_font = static_ptr_cast<Gfx::BitmapFont>(bitmap_font->clone());
         if (!edited_font) {
             String message = String::formatted("Couldn't load font: {}\n", path);
             GUI::MessageBox::show(nullptr, message, "Font Editor", GUI::MessageBox::Type::Error);
@@ -112,7 +118,13 @@ int main(int argc, char** argv)
         if (!open_path.has_value())
             return;
 
-        RefPtr<Gfx::BitmapFont> new_font = static_ptr_cast<Gfx::BitmapFont>(Gfx::BitmapFont::load_from_file(open_path.value())->clone());
+        auto bitmap_font = Gfx::BitmapFont::load_from_file(open_path.value());
+        if (!bitmap_font) {
+            String message = String::formatted("Couldn't load font: {}\n", open_path.value());
+            GUI::MessageBox::show(window, message, "Font Editor", GUI::MessageBox::Type::Error);
+            return;
+        }
+        RefPtr<Gfx::BitmapFont> new_font = static_ptr_cast<Gfx::BitmapFont>(bitmap_font->clone());
         if (!new_font) {
             String message = String::formatted("Couldn't load font: {}\n", open_path.value());
             GUI::MessageBox::show(window, message, "Font Editor", GUI::MessageBox::Type::Error);

--- a/Userland/Applications/TextEditor/TextEditorWidget.cpp
+++ b/Userland/Applications/TextEditor/TextEditorWidget.cpp
@@ -639,6 +639,11 @@ bool TextEditorWidget::open_file(const String& path)
         return false;
     }
 
+    if (file->is_device()) {
+        GUI::MessageBox::show(window(), String::formatted("Opening \"{}\" failed: Can't open device files", path), "Error", GUI::MessageBox::Type::Error);
+        return false;
+    }
+
     m_editor->set_text(file->read_all());
     m_document_dirty = false;
     m_document_opening = true;

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -139,6 +139,10 @@ int main(int argc, char** argv)
             GUI::MessageBox::show(window, String::formatted("Opening \"{}\" failed: {}", path, strerror(errno)), "Error", GUI::MessageBox::Type::Error);
             return 1;
         }
+        if (file->is_device()) {
+            GUI::MessageBox::show(window, String::formatted("Opening \"{}\" failed: Can't open device files", path), "Error", GUI::MessageBox::Type::Error);
+            return 1;
+        }
         editor.set_text(file->read_all());
     }
 
@@ -161,6 +165,11 @@ int main(int argc, char** argv)
         auto file = Core::File::construct(open_path.value());
         if (!file->open(Core::IODevice::ReadOnly) && file->error() != ENOENT) {
             GUI::MessageBox::show(window, String::formatted("Opening \"{}\" failed: {}", open_path.value(), strerror(errno)), "Error", GUI::MessageBox::Type::Error);
+            return;
+        }
+
+        if (file->is_device()) {
+            GUI::MessageBox::show(window, String::formatted("Opening \"{}\" failed: Can't open device files", open_path.value()), "Error", GUI::MessageBox::Type::Error);
             return;
         }
 

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -110,6 +110,22 @@ bool File::open_impl(IODevice::OpenMode mode, mode_t permissions)
     return true;
 }
 
+bool File::is_device() const
+{
+    struct stat stat;
+    if (fstat(fd(), &stat) < 0)
+        return false;
+    return S_ISBLK(stat.st_mode) || S_ISCHR(stat.st_mode);
+}
+
+bool File::is_device(const String& filename)
+{
+    struct stat st;
+    if (stat(filename.characters(), &st) < 0)
+        return false;
+    return S_ISBLK(st.st_mode) || S_ISCHR(st.st_mode);
+}
+
 bool File::is_directory() const
 {
     struct stat stat;

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -47,6 +47,9 @@ public:
     bool is_directory() const;
     static bool is_directory(const String& filename);
 
+    bool is_device() const;
+    static bool is_device(const String& filename);
+
     static bool exists(const String& filename);
     static bool ensure_parent_directories(const String& path);
 

--- a/Userland/Libraries/LibGfx/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/BitmapFont.cpp
@@ -172,6 +172,9 @@ size_t BitmapFont::glyph_count_by_type(FontTypes type)
 
 RefPtr<BitmapFont> BitmapFont::load_from_file(const StringView& path)
 {
+    if (Core::File::is_device(path))
+        return nullptr;
+
     auto file_or_error = MappedFile::map(path);
     if (file_or_error.is_error())
         return nullptr;


### PR DESCRIPTION
This prevents the undefined behaviour that would come up as a result of doing so.
(For example: opening "infinite" devices like /dev/full will result in an infinite loop until exhaustion of memory)
Fixes #5874.