### PR TITLE
Shell: Some backgrounding (yes, again) fixes, and some other random fixes

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1358,7 +1358,7 @@ int Emulator::virt$waitid(FlatPtr params_addr)
     mmu().copy_from_vm(&params, params_addr, sizeof(params));
 
     Syscall::SC_waitid_params host_params = params;
-    siginfo info;
+    siginfo info {};
     host_params.infop = &info;
 
     int rc = syscall(SC_waitid, &host_params);
@@ -1366,7 +1366,8 @@ int Emulator::virt$waitid(FlatPtr params_addr)
         return rc;
 
     if (info.si_addr) {
-        // FIXME: Translate this somehow.
+        // FIXME: Translate this somehow once we actually start setting it in the kernel.
+        dbgln("si_addr is set to {:p}, I did not expect this!", info.si_addr);
         TODO();
     }
 

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -111,7 +111,7 @@ int Shell::builtin_bg(int argc, const char** argv)
 
     job->set_running_in_background(true);
     job->set_should_announce_exit(true);
-    job->set_is_suspended(false);
+    job->set_shell_did_continue(true);
 
     dbgln("Resuming {} ({})", job->pid(), job->cmd());
     warnln("Resuming job {} - {}", job->job_id(), job->cmd().characters());
@@ -396,7 +396,7 @@ int Shell::builtin_fg(int argc, const char** argv)
     }
 
     job->set_running_in_background(false);
-    job->set_is_suspended(false);
+    job->set_shell_did_continue(true);
 
     dbgln("Resuming {} ({})", job->pid(), job->cmd());
     warnln("Resuming job {} - {}", job->job_id(), job->cmd().characters());

--- a/Userland/Shell/Job.cpp
+++ b/Userland/Shell/Job.cpp
@@ -48,9 +48,10 @@ bool Job::print_status(PrintStatusMode mode)
 
         if (WIFSIGNALED(wstatus))
             status = "signaled";
-    } else if (rc < 0) {
-        // We couldn't waitpid() it, probably because we're not the parent shell.
-        // just use the old information.
+    } else {
+        // if rc < 0, We couldn't waitpid() it, probably because we're not the parent shell.
+        // Otherwise, the information we have is already correct,
+        // so just use the old information.
         if (exited())
             status = "exited";
         else if (m_is_suspended)

--- a/Userland/Shell/Job.h
+++ b/Userland/Shell/Job.h
@@ -86,6 +86,7 @@ public:
     bool should_announce_exit() const { return m_should_announce_exit; }
     bool should_announce_signal() const { return m_should_announce_signal; }
     bool is_suspended() const { return m_is_suspended; }
+    bool shell_did_continue() const { return m_shell_did_continue; }
     void unblock() const;
 
     Core::ElapsedTimer& timer() { return m_command_timer; }
@@ -94,6 +95,7 @@ public:
     void set_signalled(int sig);
 
     void set_is_suspended(bool value) const { m_is_suspended = value; }
+    void set_shell_did_continue(bool value) const { m_shell_did_continue = value; }
 
     void set_running_in_background(bool running_in_background)
     {
@@ -129,6 +131,7 @@ private:
     Core::ElapsedTimer m_command_timer;
     mutable bool m_active { true };
     mutable bool m_is_suspended { false };
+    mutable bool m_shell_did_continue { false };
     bool m_should_be_disowned { false };
     OwnPtr<AST::Command> m_command;
 };

--- a/Userland/Utilities/sleep.cpp
+++ b/Userland/Utilities/sleep.cpp
@@ -65,6 +65,7 @@ int main(int argc, char** argv)
 
     timespec remaining_sleep {};
 
+sleep_again:
     if (clock_nanosleep(CLOCK_MONOTONIC, 0, &requested_sleep, &remaining_sleep) < 0) {
         if (errno != EINTR) {
             perror("clock_nanosleep");
@@ -73,6 +74,11 @@ int main(int argc, char** argv)
     }
 
     if (remaining_sleep.tv_sec || remaining_sleep.tv_nsec) {
+        if (!g_interrupted) {
+            // If not interrupted with SIGINT, just go back to sleep.
+            requested_sleep = remaining_sleep;
+            goto sleep_again;
+        }
         outln("Sleep interrupted with {}.{} seconds remaining.", remaining_sleep.tv_sec, remaining_sleep.tv_nsec);
     }
 


### PR DESCRIPTION
- Less `#if *_DEBUG`
- SIGCHLD when child "stopped" state changes, + handling that
- ~A "PROMPT" function, to maybe try and move away from cryptic yet-more-escapes approach~

The last one is too slow to be usable, so this PR is gonna remain a draft for now, I'll split the unrelated fixes if it takes too long.

---

Profiling 10 iterations of running `PROMPT` says that about 60% of the runtime is spent in syscalls, with about half of that being just `fork()` and `mmap()`.
For reference, running the same `PROMPT` function in linux (with `Lagom/shell`) takes about 10ms, so there's quite a big room for improvement.

Any clues about why `fork()` is taking so long (and how to fix it) would be much appreciated, since I'm a complete and total n00b at dealing with this sort of thing.

-> #6043 