### PR TITLE
LibGUI: Don't inflate icon text rects beyond available width

### DIFF
--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -480,6 +480,8 @@ void IconView::get_item_rects(int item_index, ItemData& item_data, const Gfx::Fo
     } else {
         item_data.text_rect.set_width(unwrapped_text_width);
         item_data.text_rect.inflate(6, 4);
+        if (item_data.text_rect.width() > available_width)
+            item_data.text_rect.set_width(available_width);
         item_data.text_rect.center_horizontally_within(item_rect);
     }
     item_data.text_rect.intersect(item_rect);


### PR DESCRIPTION
![textwrapping](https://user-images.githubusercontent.com/66646555/112925003-1f2bc100-90df-11eb-9469-61e3a4da18a8.gif)
