### PR TITLE
LibWeb: Compute space for inline blocks with absolute positions

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -406,16 +406,17 @@ void BlockFormattingContext::layout_block_level_children(Box& box, LayoutMode la
         }
 
         compute_width(child_box);
-        layout_inside(child_box, layout_mode);
         compute_height(child_box);
+
+        if (child_box.computed_values().position() == CSS::Position::Relative)
+            compute_position(child_box);
 
         if (is<ReplacedBox>(child_box))
             place_block_level_replaced_element_in_normal_flow(child_box, box);
         else if (is<BlockBox>(child_box))
             place_block_level_non_replaced_element_in_normal_flow(child_box, box);
 
-        if (child_box.computed_values().position() == CSS::Position::Relative)
-            compute_position(child_box); // Note: Shifting position should occur after the above layout.
+        layout_inside(child_box, layout_mode);
 
         // FIXME: This should be factored differently. It's uncool that we mutate the tree *during* layout!
         //        Instead, we should generate the marker box during the tree build.

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -113,6 +113,17 @@ public:
         return rect;
     }
 
+    Gfx::FloatRect margin_box_as_absolute_rect() const
+    {
+        auto rect = absolute_rect();
+        auto margin_box = box_model().margin_box();
+        rect.set_x(rect.x() - margin_box.left);
+        rect.set_width(rect.width() + margin_box.left + margin_box.right);
+        rect.set_y(rect.y() - margin_box.top);
+        rect.set_height(rect.height() + margin_box.top + margin_box.bottom);
+        return rect;
+    }
+
     float absolute_x() const { return absolute_rect().x(); }
     float absolute_y() const { return absolute_rect().y(); }
     Gfx::FloatPoint absolute_position() const { return absolute_rect().location(); }

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -55,13 +55,13 @@ static AvailableSpaceForLineInfo available_space_for_line(const InlineFormatting
 
     // FIXME: This is a total hack guess since we don't actually know the final y position of lines here!
     float line_height = context.containing_block().line_height();
-    float y = (line_index * line_height);
+    float y = (line_index * line_height) + context.containing_block().margin_box_as_absolute_rect().top();
 
     auto& bfc = static_cast<const BlockFormattingContext&>(*context.parent());
 
     for (ssize_t i = bfc.left_floating_boxes().size() - 1; i >= 0; --i) {
         auto& floating_box = *bfc.left_floating_boxes().at(i);
-        auto rect = floating_box.margin_box_as_relative_rect();
+        auto rect = floating_box.margin_box_as_absolute_rect();
         if (rect.contains_vertically(y)) {
             info.left = rect.right() + 1;
             break;
@@ -72,7 +72,7 @@ static AvailableSpaceForLineInfo available_space_for_line(const InlineFormatting
 
     for (ssize_t i = bfc.right_floating_boxes().size() - 1; i >= 0; --i) {
         auto& floating_box = *bfc.right_floating_boxes().at(i);
-        auto rect = floating_box.margin_box_as_relative_rect();
+        auto rect = floating_box.margin_box_as_absolute_rect();
         if (rect.contains_vertically(y)) {
             info.right = rect.left() - 1;
             break;


### PR DESCRIPTION
Totally up for discussion on whether this is the right approach. Details on this change are in the commit message. This change didn't seem to hurt the existing floating and inline box tests linked on welcome.html, and it quite nicely improves xkcd.com, but of course there may be something I missed :)

Before:
![before](https://user-images.githubusercontent.com/5600524/113012069-6e5a0c00-9148-11eb-9906-641992783a3f.png)

After:
![after](https://user-images.githubusercontent.com/5600524/113012087-71ed9300-9148-11eb-83f4-1cbda181a48b.png)
