### PR TITLE
LibWeb: Create a new BFC when the overflow is neither visible nor clip

### DIFF
--- a/Base/res/html/misc/float-3.html
+++ b/Base/res/html/misc/float-3.html
@@ -1,0 +1,27 @@
+<style>
+    body {
+        width: 780px;
+        text-align: center
+    }
+    .box {
+        height: 100px;
+        width: 300px;
+        background: red;
+    }
+    #top {
+        overflow: hidden;
+    }
+    #bottom {
+        border: 1px solid black;
+    }
+</style>
+<body>
+    <div id="top">
+        <div id="top-left" class="box" style="float: left"></div>
+        <div id="top-right" class="box" style="float: right"></div>
+    </div>
+    <div id="bottom">
+        <!-- Due to the overflow property of the top div, this div should be laid beneath the top, rather than inline -->
+        <div id="text">foobar</div>
+    </div>
+</body>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -41,6 +41,7 @@ span#loadtime {
         <li><a href="contenteditable.html">contenteditable</a></li>
         <li><a href="clear-1.html">clearing floats</a></li>
         <li><a href="float-1.html">floating boxes</a></li>
+        <li><a href="float-3.html">floating boxes with overflow=hidden</a></li>
         <li><a href="padding-inline.html">inline elements with padding</a></li>
         <li><a href="event-bubbling-and-multiple-listeners.html">event bubbling and multiple listeners</a></li>
         <li><a href="checkbox.html">checkbox</a></li>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -409,13 +409,13 @@ void BlockFormattingContext::layout_block_level_children(Box& box, LayoutMode la
         layout_inside(child_box, layout_mode);
         compute_height(child_box);
 
+        if (child_box.computed_values().position() == CSS::Position::Relative)
+            compute_position(child_box);
+
         if (is<ReplacedBox>(child_box))
             place_block_level_replaced_element_in_normal_flow(child_box, box);
         else if (is<BlockBox>(child_box))
             place_block_level_non_replaced_element_in_normal_flow(child_box, box);
-
-        if (child_box.computed_values().position() == CSS::Position::Relative)
-            compute_position(child_box); // Note: Shifting position should occur after the above layout.
 
         // FIXME: This should be factored differently. It's uncool that we mutate the tree *during* layout!
         //        Instead, we should generate the marker box during the tree build.

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -60,6 +60,14 @@ bool FormattingContext::creates_block_formatting_context(const Box& box)
     if (is<TableCellBox>(box))
         return true;
 
+    CSS::Overflow overflow_x = box.computed_values().overflow_x();
+    if ((overflow_x != CSS::Overflow::Visible) && (overflow_x != CSS::Overflow::Clip))
+        return true;
+
+    CSS::Overflow overflow_y = box.computed_values().overflow_y();
+    if ((overflow_y != CSS::Overflow::Visible) && (overflow_y != CSS::Overflow::Clip))
+        return true;
+
     // FIXME: inline-flex as well
     if (box.parent() && box.parent()->computed_values().display() == CSS::Display::Flex) {
         // FIXME: Flex items (direct children of the element with display: flex or inline-flex) if they are neither flex nor grid nor table containers themselves.
@@ -69,7 +77,6 @@ bool FormattingContext::creates_block_formatting_context(const Box& box)
 
     // FIXME: table-caption
     // FIXME: anonymous table cells
-    // FIXME: Block elements where overflow has a value other than visible and clip.
     // FIXME: display: flow-root
     // FIXME: Elements with contain: layout, content, or paint.
     // FIXME: grid


### PR DESCRIPTION
This fixes the layout of the middle box containing the comic on xkcd.com.

Before:
![before](https://user-images.githubusercontent.com/5600524/113048762-e3413c00-9170-11eb-930c-b3a1f8a58f8b.png)

After:
![after](https://user-images.githubusercontent.com/5600524/113048771-e63c2c80-9170-11eb-9e99-f70b29fcc140.png)
