### PR TITLE
HackStudio: Actions on project tree selections improved

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -54,8 +54,6 @@ public:
     virtual ~HackStudioWidget() override;
     void open_file(const String& filename);
 
-    Vector<String> selected_file_names() const;
-
     void update_actions();
     Project& project();
     GUI::TextEditor& current_editor();
@@ -73,6 +71,7 @@ public:
 
 private:
     static String get_full_path_of_serenity_source(const String& file);
+    Vector<String> selected_file_paths() const;
 
     HackStudioWidget(const String& path_to_project);
     void open_project(const String& root_path);


### PR DESCRIPTION
Creating a file while having a file or directory selected will now
create the file in the selected directory, or in same directory as
a selected file.
Creating directories works the same way.

Right click -> Open on selected files will now open the selected files.

Deleting selected files will now delete the selected files.

As suggested by sagefarrenholz this was accomplished by adding a private
function HackStudioWidget::selected_file_paths() that returns a
Vector<LexicalPath> of the current project tree selection.

(Fixes #5935)

This is my first contribution so there is probably something that is in need
of change!