### PR TITLE
Ports: Links: Bump version from 2.19 to 2.22

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -44,7 +44,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`libpng`](libpng/)            | libpng                                        | 1.6.37            | https://libpng.org/                                   |
 | [`libpuffy`](libpuffy/)        | libpuffy                                      | 1.0               | https://github.com/ibara/libpuffy                     |
 | [`libtiff`](libtiff/)          | libtiff                                       | 4.2.0             | http://www.libtiff.org/                               |
-| [`links`](links/)              | Links web browser                             | 2.19              | http://links.twibright.com/                           |
+| [`links`](links/)              | Links web browser                             | 2.22              | http://links.twibright.com/                           |
 | [`lua`](lua/)                  | Lua                                           | 5.3.5             | https://www.lua.org/                                  |
 | [`m4`](m4/)                    | GNU M4                                        | 1.4.9             | https://www.gnu.org/software/m4/                      |
 | [`make`](make/)                | GNU make                                      | 4.3               | https://www.gnu.org/software/make/                    |

--- a/Ports/links/package.sh
+++ b/Ports/links/package.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=links
-version=2.19
+version=2.22
 useconfigure=true
-files="http://links.twibright.com/download/links-2.19.tar.bz2 links-2.19.tar.bz2 fa6df86919640e490187ee9d85a4f598"
+files="http://links.twibright.com/download/links-${version}.tar.bz2 links-${version}.tar.bz2 55f745dea500aac52cede98bab8d96e2"


### PR DESCRIPTION
[Changelog](http://links.twibright.com/download/ChangeLog). Apparently fixes a few crashes, a `<textarea>` HTML parsing bug, some SSL bugs which don't affect us (we compile without SSL), a TOR DNS leak which doesn't affect us (pretty sure we don't support proxying), among other things.

![links](https://user-images.githubusercontent.com/434827/113110925-5d49f180-9253-11eb-808b-1937a90f9337.png)
