### PR TITLE
LibDebug: DWARF: Add support for ref8 and data8 DWARF attributes

### DIFF
--- a/Userland/Libraries/LibDebug/Dwarf/DIE.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DIE.cpp
@@ -131,12 +131,28 @@ DIE::AttributeValue DIE::get_attribute_value(AttributeDataForm form,
         value.data.as_u32 = data;
         break;
     }
+    case AttributeDataForm::Data8: {
+        u64 data;
+        debug_info_stream >> data;
+        VERIFY(!debug_info_stream.has_any_error());
+        value.type = AttributeValue::Type::UnsignedNumber;
+        value.data.as_u64 = data;
+        break;
+    }
     case AttributeDataForm::Ref4: {
         u32 data;
         debug_info_stream >> data;
         VERIFY(!debug_info_stream.has_any_error());
         value.type = AttributeValue::Type::DieReference;
         value.data.as_u32 = data + m_compilation_unit.offset();
+        break;
+    }
+    case AttributeDataForm::Ref8: {
+        u64 data;
+        debug_info_stream >> data;
+        VERIFY(!debug_info_stream.has_any_error());
+        value.type = AttributeValue::Type::DieReference;
+        value.data.as_u64 = data + m_compilation_unit.offset();
         break;
     }
     case AttributeDataForm::FlagPresent: {

--- a/Userland/Libraries/LibDebug/Dwarf/DIE.h
+++ b/Userland/Libraries/LibDebug/Dwarf/DIE.h
@@ -57,6 +57,7 @@ public:
         union {
             u32 as_u32;
             i32 as_i32;
+            u64 as_u64;
             const char* as_string; // points to bytes in the memory mapped elf image
             bool as_bool;
             struct {


### PR DESCRIPTION
These attributes were added in #2469, but weren't supported by `get_attribute_value`.

Without these, `CrashDaemon` will crash attempting to parse some core dumps.

Before this PR, to reproduce a `CrashDaemon` crash, install the `links` port, run `links`, and enter `g http://any.domain/`. `links` will crash due to failed DNS lookup. `CrashDaemon` will crash attempting to parse the coredump.

After this PR. `CrashDaemon` won't crash and will print the backtrace successfully. Except the generated coredump file is corrupt ... Good times. Closing this PR.
