### PR TITLE
LibWeb: Don't hit test a stacked child if it is behind its parent

### DIFF
--- a/Base/res/html/misc/link-over-zindex-block.html
+++ b/Base/res/html/misc/link-over-zindex-block.html
@@ -1,0 +1,47 @@
+<style>
+    ul {
+        margin: 0;
+        padding: 0;
+        text-align: center;
+        list-style-type: none;
+    }
+    a {
+        color: black;
+        text-decoration: none;
+    }
+    a:hover {
+        text-decoration: underline;
+    }
+    #contents {
+        position: relative;
+        overflow: hidden;
+    }
+    #links {
+        width: 110px;
+        float: left;
+        padding: 5px;
+    }
+    #background {
+        width: 120px;
+        position: absolute;
+        float: left;
+        left: 0;
+        bottom: 0;
+        top: 0;
+        background: cyan;
+        border: 1px solid black;
+        z-index: -10000;
+    }
+</style>
+<body>
+    <div id=contents>
+        <div id=links>
+            <ul>
+                <li><a href="welcome.html">Home 1</a></li>
+                <li><a href="welcome.html">Home 2</a></li>
+                <li><a href="welcome.html">Home 3</a></li>
+            </ul>
+        </div>
+        <div id=background></div>
+    </div>
+</body>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -38,6 +38,7 @@ span#loadtime {
     <p>This page loaded in <b><span id="loadtime"></span></b> ms</p>
     <p>Some small test pages:</p>
     <ul>
+        <li><a href="link-over-zindex-block.html">link elements with background box placed with z-index</a></li>
         <li><a href="contenteditable.html">contenteditable</a></li>
         <li><a href="clear-1.html">clearing floats</a></li>
         <li><a href="float-1.html">floating boxes</a></li>

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -73,7 +73,13 @@ HitTestResult StackingContext::hit_test(const Gfx::IntPoint& position, HitTestTy
         result = downcast<InitialContainingBlockBox>(m_box).BlockBox::hit_test(position, type);
     }
 
+    int z_index = m_box.computed_values().z_index().value_or(0);
+
     for (auto* child : m_children) {
+        int child_z_index = child->m_box.computed_values().z_index().value_or(0);
+        if (result.layout_node && (child_z_index < z_index))
+            continue;
+
         auto result_here = child->hit_test(position, type);
         if (result_here.layout_node)
             result = result_here;


### PR DESCRIPTION
Before, if a box was placed behind a set of links with via its z-index, that box was selected as the target of hit testing and the links would be unclickable:
![before](https://user-images.githubusercontent.com/5600524/113162625-75971d80-920d-11eb-95bd-5d756250d569.png)

This changes the stacking context to consider the its own box's z-index when deciding to hit test its children:
![after](https://user-images.githubusercontent.com/5600524/113162931-b131e780-920d-11eb-858f-5ca8f2a39bc6.png)
