### PR TITLE
TextEditor: Fix multi-line cut and paste in the text editor.

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -329,6 +329,14 @@ void TextDocument::set_all_cursors(const TextPosition& position)
     }
 }
 
+void TextDocument::set_all_cursors_post_update(const TextPosition& position)
+{
+    if (m_client_notifications_enabled) {
+        for (auto* client : m_clients)
+            client->document_did_set_cursor_post_update(position);
+    }
+}
+
 String TextDocument::text() const
 {
     StringBuilder builder;
@@ -343,9 +351,9 @@ String TextDocument::text() const
 
 String TextDocument::text_in_range(const TextRange& a_range) const
 {
-    if (is_empty() || line_count() < a_range.end().line() - a_range.start().line() || line(a_range.start().line()).is_empty())
-        return String("");
     auto range = a_range.normalized();
+    if (is_empty() || line_count() < range.end().line() - range.start().line() || line(range.start().line()).is_empty())
+        return String("");
 
     StringBuilder builder;
     for (size_t i = range.start().line(); i <= range.end().line(); ++i) {
@@ -780,7 +788,7 @@ RemoveTextCommand::RemoveTextCommand(TextDocument& document, const String& text,
 void RemoveTextCommand::redo()
 {
     m_document.remove(m_range);
-    m_document.set_all_cursors(m_range.start());
+    m_document.set_all_cursors_post_update(m_range.start());
 }
 
 void RemoveTextCommand::undo()

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -67,6 +67,7 @@ public:
         virtual void document_did_change() = 0;
         virtual void document_did_set_text() = 0;
         virtual void document_did_set_cursor(const TextPosition&) = 0;
+        virtual void document_did_set_cursor_post_update(const TextPosition&) {}
 
         virtual bool is_automatic_indentation_enabled() const = 0;
         virtual int soft_tab_width() const = 0;
@@ -134,6 +135,7 @@ public:
 
     void notify_did_change();
     void set_all_cursors(const TextPosition&);
+    void set_all_cursors_post_update(const TextPosition&);
 
     TextPosition insert_at(const TextPosition&, u32, const Client* = nullptr);
     TextPosition insert_at(const TextPosition&, const StringView&, const Client* = nullptr);

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -67,7 +67,7 @@ public:
         virtual void document_did_change() = 0;
         virtual void document_did_set_text() = 0;
         virtual void document_did_set_cursor(const TextPosition&) = 0;
-        virtual void document_did_set_cursor_post_update(const TextPosition&) {}
+        virtual void document_did_set_cursor_post_update(const TextPosition&) { }
 
         virtual bool is_automatic_indentation_enabled() const = 0;
         virtual int soft_tab_width() const = 0;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1127,9 +1127,7 @@ void TextEditor::set_cursor_post_update(const TextPosition& a_position)
         m_cursor = position;
         m_cursor_state = true;
     }
-
     cursor_did_change();
-
     if (m_highlighter)
     {
         m_highlighter->cursor_did_change();

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1128,8 +1128,7 @@ void TextEditor::set_cursor_post_update(const TextPosition& a_position)
         m_cursor_state = true;
     }
     cursor_did_change();
-    if (m_highlighter)
-    {
+    if (m_highlighter) {
         m_highlighter->cursor_did_change();
     }
 }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -176,6 +176,7 @@ public:
     void set_cursor_and_focus_line(size_t line, size_t column);
     void set_cursor(size_t line, size_t column);
     virtual void set_cursor(const TextPosition&);
+    virtual void set_cursor_post_update(const TextPosition&);
 
     const Syntax::Highlighter* syntax_highlighter() const;
     void set_syntax_highlighter(OwnPtr<Syntax::Highlighter>);
@@ -243,6 +244,7 @@ private:
     virtual void document_did_change() override;
     virtual void document_did_set_text() override;
     virtual void document_did_set_cursor(const TextPosition&) override;
+    virtual void document_did_set_cursor_post_update(const TextPosition&) override;
 
     // ^Syntax::HighlighterClient
     virtual Vector<TextDocumentSpan>& spans() final { return document().spans(); }


### PR DESCRIPTION
- Make sure we first normalize in TextDocument::text_in_range()
- in RemoveTextCommand::redo() call set_all_cursors_post_update() rather than set_all_cursors() which tries to re-read an already deleted text which causes the crash.