### PR TITLE
LibJS: Provide 'details' key in results object for duplicate test

### DIFF
--- a/Userland/Libraries/LibJS/Tests/test-common.js
+++ b/Userland/Libraries/LibJS/Tests/test-common.js
@@ -429,6 +429,7 @@ class ExpectationError extends Error {
         if (suite[message]) {
             suite[message] = {
                 result: "fail",
+                details: "Another test with the same message did already run",
             };
             return;
         }


### PR DESCRIPTION
The test-js program expects this to exist for `result: "fail"` results and would crash if any duplicated test(message) occurs, as we didn't provide `details` in that case.