### PR TITLE
Ports: Add carl

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -10,6 +10,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`bison`](bison/)              | GNU Bison                                     | 1.25              | https://www.gnu.org/software/bison/                   |
 | [`byacc`](byacc/)              | Berkeley Yacc                                 | 20191125          | https://invisible-island.net/byacc/byacc.html         |
 | [`bzip2`](bzip2/)              | bzip2                                         | 1.0.8             | https://sourceware.org/bzip2/                         |
+| [`carl`](carl/)                | Crypto Ancienne Resource Loader               | 1.5               | https://github.com/classilla/cryanc                   |
 | [`c-ray`](c-ray/)              | C-Ray                                         |                   | https://github.com/vkoskiv/c-ray                      |
 | [`chester`](chester/)          | Chester Gameboy Emulator                      |                   | https://github.com/veikkos/chester                    |
 | [`cmake`](cmake/)              | CMake                                         | 3.19.4            | https://cmake.org/                                    |

--- a/Ports/carl/package.sh
+++ b/Ports/carl/package.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=carl
+version=1.5
+workdir=cryanc-"${version}"
+files="https://github.com/classilla/cryanc/archive/refs/tags/${version}.tar.gz cryanc-${version}.tar.gz f2cae13addf4ed7cb7af3d06069cf082"
+
+build() {
+    run $CC -O3 carl.c -o carl
+}
+
+install() {
+    run mkdir -p "${SERENITY_BUILD_DIR}/Root/usr/local"
+    run cp carl "${SERENITY_BUILD_DIR}/Root/usr/local/bin"
+}


### PR DESCRIPTION
We could theoretically use this combined with something like `micro_inetd` to provide TLS for links/lynx or other projects without having support compiled in. 

For more info on this:

https://github.com/classilla/cryanc
https://oldvcr.blogspot.com/2020/11/fun-with-crypto-ancienne-tls-for.html