### PR TITLE
Ports: Add flatbuffers library

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -21,6 +21,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`dropbear`](dropbear/)        | Dropbear SSH                                  | 2019.78           | https://dropbear.nl/mirror/dropbear.html              |
 | [`ed`](ed/)                    | GNU ed                                        | 1.15              | https://www.gnu.org/software/ed/                      |
 | [`figlet`](figlet/)            | FIGlet                                        | 2.2.5             | http://www.figlet.org/                                |
+| [`flatbuffers`](flatbuffers/)  | Flatbuffers                                   | 1.12.0            | https://github.com/google/flatbuffers                 |
 | [`flex`](flex/)                | flex                                          | 2.6.4             | https://github.com/westes/flex                        |
 | [`freetype`](freetype/)        | FreeType                                      | 2.10.4            | https://www.freetype.org/                             |
 | [`frotz`](frotz/)              | Frotz                                         |                   | https://gitlab.com/DavidGriffith/frotz                |

--- a/Ports/flatbuffers/package.sh
+++ b/Ports/flatbuffers/package.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+
+port="flatbuffers"
+version="1.12.0"
+auth_type=sha256
+files="https://github.com/google/flatbuffers/archive/refs/tags/v${version}.tar.gz v${version}.tar.gz 62f2223fb9181d1d6338451375628975775f7522185266cd5296571ac152bc45"
+useconfigure=true
+# Since we are cross-compiling, we cannot build the tests, because we need
+# the flatbuffers compiler to build them
+configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMakeToolchain.txt -DFLATBUFFERS_BUILD_TESTS=off"
+
+configure() {
+    run cmake $configopts
+}
+
+install() {
+    run make install
+}

--- a/Ports/flatbuffers/patches/flatbuffers-1.12.0.patch
+++ b/Ports/flatbuffers/patches/flatbuffers-1.12.0.patch
@@ -1,0 +1,35 @@
+diff -ruN flatbuffers-1.12.0/src/code_generators.cpp flatbuffers-1.12.0-serenity/src/code_generators.cpp
+--- flatbuffers-1.12.0/src/code_generators.cpp	2020-03-12 19:33:39.000000000 -0300
++++ flatbuffers-1.12.0-serenity/src/code_generators.cpp	2021-03-31 20:39:12.000000000 -0300
+@@ -23,6 +23,17 @@
+ #include "flatbuffers/base.h"
+ #include "flatbuffers/util.h"
+ 
++#if defined(__serenity__)
++  // We do not have those functions inside std namespace...
++
++namespace std {
++  auto isnan(double x) { return ::isnan(x); }
++  auto isinf(double x) { return ::isinf(x); }
++}
++
++#endif
++
++
+ #if defined(_MSC_VER)
+ #  pragma warning(push)
+ #  pragma warning(disable : 4127)  // C4127: conditional expression is constant
+diff -ruN flatbuffers-1.12.0/src/util.cpp flatbuffers-1.12.0-serenity/src/util.cpp
+--- flatbuffers-1.12.0/src/util.cpp	2020-03-12 19:33:39.000000000 -0300
++++ flatbuffers-1.12.0-serenity/src/util.cpp	2021-03-31 20:28:59.000000000 -0300
+@@ -189,6 +189,10 @@
+ std::string AbsolutePath(const std::string &filepath) {
+   // clang-format off
+ 
++  #ifdef __serenity__
++  #define PATH_MAX 4096
++  #endif
++
+   #ifdef FLATBUFFERS_NO_ABSOLUTE_PATH_RESOLUTION
+     return filepath;
+   #else

--- a/Ports/flatbuffers/patches/flatbuffers-1.12.0.patch
+++ b/Ports/flatbuffers/patches/flatbuffers-1.12.0.patch
@@ -19,17 +19,3 @@ diff -ruN flatbuffers-1.12.0/src/code_generators.cpp flatbuffers-1.12.0-serenity
  #if defined(_MSC_VER)
  #  pragma warning(push)
  #  pragma warning(disable : 4127)  // C4127: conditional expression is constant
-diff -ruN flatbuffers-1.12.0/src/util.cpp flatbuffers-1.12.0-serenity/src/util.cpp
---- flatbuffers-1.12.0/src/util.cpp	2020-03-12 19:33:39.000000000 -0300
-+++ flatbuffers-1.12.0-serenity/src/util.cpp	2021-03-31 20:28:59.000000000 -0300
-@@ -189,6 +189,10 @@
- std::string AbsolutePath(const std::string &filepath) {
-   // clang-format off
- 
-+  #ifdef __serenity__
-+  #define PATH_MAX 4096
-+  #endif
-+
-   #ifdef FLATBUFFERS_NO_ABSOLUTE_PATH_RESOLUTION
-     return filepath;
-   #else


### PR DESCRIPTION
The flatbuffers library is a serialization library, created by Google for game development and performance-critical applications.
It aims to be fast and efficient.

This commit creates a port of it to SerenityOS. 
Although this library is not much popular among the bigger opensource projects, there are [some uses of it here on Github](https://github.com/search?l=C%2B%2B&q=FlatBufferBuilder&type=Code). If someone happens to port any small game that uses flatbuffers, it would be one less dependency for the person to port

The flatbuffers build process generates three things: some header files, a library (libflatbuffers) and a schema compiler (flatc).

------

A small caveat of this port: the library comes with a test suite, but we cannot run it, because it attempts to run the flatc executable we are compiling to SerenityOS in the host system. The host system does not recognize the file format, so it fails.
Nevertheless, the port compiles and runs: the schema compiler runs and the library links successfully 
