### PR TITLE
LibRegex: Backreference to the future; some other fixes

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.exec.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.exec.js
@@ -66,3 +66,15 @@ test("not matching", () => {
 
     expect(res).toBe(null);
 });
+
+// Backreference to a group not yet parsed: #6039
+test("Future group backreference, #6039", () => {
+    let re = /(\3)(\1)(a)/;
+    let result = re.exec("cat");
+    expect(result.length).toBe(4);
+    expect(result[0]).toBe("a");
+    expect(result[1]).toBe("");
+    expect(result[2]).toBe("");
+    expect(result[3]).toBe("a");
+    expect(result.index).toBe(1);
+});

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -334,26 +334,26 @@ public:
     {
 
         // FORKJUMP _ALT
-        // REGEXP ALT1
+        // REGEXP ALT2
         // JUMP  _END
         // LABEL _ALT
-        // REGEXP ALT2
+        // REGEXP ALT1
         // LABEL _END
 
         ByteCode byte_code;
 
         empend(static_cast<ByteCodeValueType>(OpCodeId::ForkJump));
-        empend(left.size() + 2); // Jump to the _ALT label
+        empend(right.size() + 2); // Jump to the _ALT label
 
-        for (auto& op : left)
+        for (auto& op : right)
             append(move(op));
 
         empend(static_cast<ByteCodeValueType>(OpCodeId::Jump));
-        empend(right.size()); // Jump to the _END label
+        empend(left.size()); // Jump to the _END label
 
         // LABEL _ALT = bytecode.size() + 2
 
-        for (auto& op : right)
+        for (auto& op : left)
             append(move(op));
 
         // LABEL _END = alterantive_bytecode.size

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -768,7 +768,7 @@ public:
 
 private:
     ALWAYS_INLINE static void compare_char(const MatchInput& input, MatchState& state, u32 ch1, bool inverse, bool& inverse_matched);
-    ALWAYS_INLINE static bool compare_string(const MatchInput& input, MatchState& state, const char* str, size_t length);
+    ALWAYS_INLINE static bool compare_string(const MatchInput& input, MatchState& state, const char* str, size_t length, bool& had_zero_length_match);
     ALWAYS_INLINE static void compare_character_class(const MatchInput& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched);
     ALWAYS_INLINE static void compare_character_range(const MatchInput& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched);
 };

--- a/Userland/Libraries/LibRegex/RegexLexer.h
+++ b/Userland/Libraries/LibRegex/RegexLexer.h
@@ -93,6 +93,7 @@ public:
     void set_source(const StringView source) { m_source = source; }
     bool try_skip(char);
     char skip();
+    const auto& source() const { return m_source; }
 
 private:
     ALWAYS_INLINE char peek(size_t offset = 0) const;

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -210,6 +210,14 @@ private:
     bool parse_legacy_octal_escape_sequence(ByteCode& bytecode_stack, size_t& length);
     Optional<u8> parse_legacy_octal_escape();
 
+    size_t ensure_total_number_of_capturing_parenthesis();
+
+    // ECMA-262's flavour of regex is a bit weird in that it allows backrefs to reference "future" captures, and such backrefs
+    // always match the empty string. So we have to know how many capturing parenthesis there are, but we don't want to always
+    // parse it twice, so we'll just do so when it's actually needed.
+    // Most patterns should have no need to ever populate this field.
+    Optional<size_t> m_total_number_of_capturing_parenthesis;
+
     // Keep the Annex B. behaviour behind a flag, the users can enable it by passing the `ECMAScriptFlags::BrowserExtended` flag.
     bool m_should_use_browser_extended_grammar { false };
 };


### PR DESCRIPTION
~Draft until the full scope of what this fixes from #6042 is determined.~

Fixes a few cases from #6042 (see https://github.com/SerenityOS/serenity/pull/6057#issuecomment-811946303)
Fixes #6039.