### PR TITLE
Ports: Updated the SDL2_mixer port to make it compile without the opus and modplug music libraries.

### DIFF
--- a/Ports/SDL2_mixer/package.sh
+++ b/Ports/SDL2_mixer/package.sh
@@ -9,6 +9,9 @@ configure() {
     run ./configure \
         --host="${SERENITY_ARCH}-pc-serenity" \
         --with-sdl-prefix="${SERENITY_BUILD_DIR}/Root/usr" \
+        --prefix="/usr"                                    \
+        --enable-music-opus=false --enable-music-opus-shared=false \
+        --enable-music-mod-modplug=false --enable-music-mod-modplug-shared=false \
         EXTRA_LDFLAGS="-lgui -lgfx -lipc -lcore -lcompression"
 }
 


### PR DESCRIPTION
Previously the library wasnt compiling as we do not have ports of the modplug and opus libraries. I have also changed the install location of the SDL2_mixer so it installs under /usr/include/SDL2 instead of /usr/local/include/SDL2.