### PR TITLE
Ports: Build Python with --disable-ipv6

### DIFF
--- a/Ports/python3/package.sh
+++ b/Ports/python3/package.sh
@@ -17,7 +17,7 @@ auth_opts="Python-${version}.tar.xz.asc Python-${version}.tar.xz"
 depends="libffi zlib"
 
 # FIXME: --enable-optimizations results in lots of __gcov_* linker errors
-configopts="--without-ensurepip ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no"
+configopts="--disable-ipv6 --without-ensurepip ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no"
 
 export BLDSHARED="${CC} -shared"
 


### PR DESCRIPTION
The addition of some IPv6 related things makes the configure script think we support it now. We don't.