### PR TITLE
Improve AK/HashTable

### DIFF
--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -308,9 +308,9 @@ private:
     {
         if (is_empty())
             return nullptr;
-        size_t bucket_index = hash % m_capacity;
+
         for (;;) {
-            auto& bucket = m_buckets[bucket_index];
+            auto& bucket = m_buckets[hash % m_capacity];
 
             if (usable_bucket_for_writing && !*usable_bucket_for_writing && !bucket.used) {
                 *usable_bucket_for_writing = &bucket;
@@ -323,7 +323,6 @@ private:
                 return nullptr;
 
             hash = double_hash(hash);
-            bucket_index = hash % m_capacity;
         }
     }
 
@@ -348,14 +347,12 @@ private:
         else if (usable_bucket_for_writing)
             return *usable_bucket_for_writing;
 
-        size_t bucket_index = hash % m_capacity;
 
         for (;;) {
-            auto& bucket = m_buckets[bucket_index];
+            auto& bucket = m_buckets[hash % m_capacity];
             if (!bucket.used)
                 return bucket;
             hash = double_hash(hash);
-            bucket_index = hash % m_capacity;
         }
     }
 

--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(AK_TEST_SOURCES
     TestFormat.cpp
     TestHashFunctions.cpp
     TestHashMap.cpp
+    TestHashTable.cpp
     TestIPv4Address.cpp
     TestIndexSequence.cpp
     TestJSON.cpp

--- a/AK/Tests/TestHashTable.cpp
+++ b/AK/Tests/TestHashTable.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2021, thislooksfun <tlf@thislooks.fun>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/HashTable.h>
+#include <AK/String.h>
+
+TEST_CASE(construct)
+{
+    using IntTable = HashTable<int>;
+    EXPECT(IntTable().is_empty());
+    EXPECT_EQ(IntTable().size(), 0u);
+}
+
+TEST_CASE(populate)
+{
+    HashTable<String> strings;
+    strings.set("One");
+    strings.set("Two");
+    strings.set("Three");
+
+    EXPECT_EQ(strings.is_empty(), false);
+    EXPECT_EQ(strings.size(), 3u);
+}
+
+TEST_CASE(range_loop)
+{
+    HashTable<String> strings;
+    EXPECT_EQ(strings.set("One"), AK::HashSetResult::InsertedNewEntry);
+    EXPECT_EQ(strings.set("Two"), AK::HashSetResult::InsertedNewEntry);
+    EXPECT_EQ(strings.set("Three"), AK::HashSetResult::InsertedNewEntry);
+
+    int loop_counter = 0;
+    for (auto& it : strings) {
+        EXPECT_EQ(it.is_null(), false);
+        ++loop_counter;
+    }
+    EXPECT_EQ(loop_counter, 3);
+}
+
+TEST_CASE(table_remove)
+{
+    HashTable<String> strings;
+    EXPECT_EQ(strings.set("One"), AK::HashSetResult::InsertedNewEntry);
+    EXPECT_EQ(strings.set("Two"), AK::HashSetResult::InsertedNewEntry);
+    EXPECT_EQ(strings.set("Three"), AK::HashSetResult::InsertedNewEntry);
+
+    EXPECT_EQ(strings.remove("One"), true);
+    EXPECT_EQ(strings.size(), 2u);
+    EXPECT(strings.find("One") == strings.end());
+
+    EXPECT_EQ(strings.remove("Three"), true);
+    EXPECT_EQ(strings.size(), 1u);
+    EXPECT(strings.find("Three") == strings.end());
+    EXPECT(strings.find("Two") != strings.end());
+}
+
+TEST_CASE(case_insensitive)
+{
+    HashTable<String, CaseInsensitiveStringTraits> casetable;
+    EXPECT_EQ(String("nickserv").to_lowercase(), String("NickServ").to_lowercase());
+    EXPECT_EQ(casetable.set("nickserv"), AK::HashSetResult::InsertedNewEntry);
+    EXPECT_EQ(casetable.set("NickServ"), AK::HashSetResult::ReplacedExistingEntry);
+    EXPECT_EQ(casetable.size(), 1u);
+}
+
+TEST_CASE(many_strings)
+{
+    HashTable<String> strings;
+    for (int i = 0; i < 999; ++i) {
+        EXPECT_EQ(strings.set(String::number(i)), AK::HashSetResult::InsertedNewEntry);
+    }
+    EXPECT_EQ(strings.size(), 999u);
+    for (int i = 0; i < 999; ++i) {
+        EXPECT_EQ(strings.remove(String::number(i)), true);
+    }
+    EXPECT_EQ(strings.is_empty(), true);
+}
+
+TEST_CASE(many_collisions)
+{
+    struct StringCollisionTraits : public GenericTraits<String> {
+        static unsigned hash(const String&) { return 0; }
+    };
+
+    HashTable<String, StringCollisionTraits> strings;
+    for (int i = 0; i < 999; ++i) {
+        EXPECT_EQ(strings.set(String::number(i)), AK::HashSetResult::InsertedNewEntry);
+    }
+
+    EXPECT_EQ(strings.set("foo"), AK::HashSetResult::InsertedNewEntry);
+    EXPECT_EQ(strings.size(), 1000u);
+
+    for (int i = 0; i < 999; ++i) {
+        EXPECT_EQ(strings.remove(String::number(i)), true);
+    }
+
+    // FIXME: Doing this with an "EXPECT_NOT_EQ" would be cleaner.
+    EXPECT_EQ(strings.find("foo") == strings.end(), false);
+}
+
+TEST_CASE(space_reuse)
+{
+    struct StringCollisionTraits : public GenericTraits<String> {
+        static unsigned hash(const String&) { return 0; }
+    };
+
+    HashTable<String, StringCollisionTraits> strings;
+
+    // Add a few items to allow it to do initial resizing.
+    EXPECT_EQ(strings.set("0"), AK::HashSetResult::InsertedNewEntry);
+    for (int i = 1; i < 5; ++i) {
+        EXPECT_EQ(strings.set(String::number(i)), AK::HashSetResult::InsertedNewEntry);
+        EXPECT_EQ(strings.remove(String::number(i - 1)), true);
+    }
+
+    auto capacity = strings.capacity();
+
+    for (int i = 5; i < 999; ++i) {
+        EXPECT_EQ(strings.set(String::number(i)), AK::HashSetResult::InsertedNewEntry);
+        EXPECT_EQ(strings.remove(String::number(i - 1)), true);
+    }
+
+    EXPECT_EQ(strings.capacity(), capacity);
+}
+
+TEST_CASE(basic_remove)
+{
+    HashTable<int> table;
+    table.set(1);
+    table.set(2);
+    table.set(3);
+
+    EXPECT_EQ(table.remove(3), true);
+    EXPECT_EQ(table.remove(3), false);
+    EXPECT_EQ(table.size(), 2u);
+
+    EXPECT_EQ(table.remove(1), true);
+    EXPECT_EQ(table.remove(1), false);
+    EXPECT_EQ(table.size(), 1u);
+
+    EXPECT_EQ(table.remove(2), true);
+    EXPECT_EQ(table.remove(2), false);
+    EXPECT_EQ(table.size(), 0u);
+}
+
+TEST_CASE(basic_contains)
+{
+    HashTable<int> table;
+    table.set(1);
+    table.set(2);
+    table.set(3);
+
+    EXPECT_EQ(table.contains(1), true);
+    EXPECT_EQ(table.contains(2), true);
+    EXPECT_EQ(table.contains(3), true);
+    EXPECT_EQ(table.contains(4), false);
+
+    EXPECT_EQ(table.remove(3), true);
+    EXPECT_EQ(table.contains(3), false);
+    EXPECT_EQ(table.contains(1), true);
+    EXPECT_EQ(table.contains(2), true);
+
+    EXPECT_EQ(table.remove(2), true);
+    EXPECT_EQ(table.contains(2), false);
+    EXPECT_EQ(table.contains(3), false);
+    EXPECT_EQ(table.contains(1), true);
+
+    EXPECT_EQ(table.remove(1), true);
+    EXPECT_EQ(table.contains(1), false);
+}
+
+TEST_MAIN(HashTable)


### PR DESCRIPTION
While watching [this video](https://www.youtube.com/watch?v=p2j5eWSa7zA) I noticed a few areas for improvement and decided to implement them!

The main change is removing the double lookup in `lookup_for_writing`. Previously there was potential for a nasty edge case. Imagine the following:
1. You insert a lot of elements that result in hash collisions.
2. The table is at its limit (`should_grow()` is `true`).
3. You go to insert a *new* item into the table.

Previously this would result in one pass through the array which would find a place for writing, then a rehash, then a *second* pass to find an open bucket. The new system will only ever do one pass, which ranges from the same to measurably faster, depending on how common resizes are. Additionally `lookup_with_hash` should also be slightly faster since it has fewer checks to perform each loop.

---

On a meta note, I'm not 100% sure what I did with the copyright header in `TestHashTable.cpp` is correct, if it needs to be changed just let me know!