### PR TITLE
LibWeb: Add a line box fragment for <br> nodes

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BreakNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BreakNode.cpp
@@ -42,7 +42,8 @@ BreakNode::~BreakNode()
 
 void BreakNode::split_into_lines(InlineFormattingContext& context, LayoutMode)
 {
-    context.containing_block().add_line_box();
+    auto& line_box = context.containing_block().add_line_box();
+    line_box.add_fragment(*this, 0, 0, 0, context.containing_block().line_height());
 }
 
 }


### PR DESCRIPTION
This fixes (some of) the rendering of http://serenityos.org/dromaeo/ :)

The DOM for this page has some `<li>` nodes with a number of `<br>` nodes as their last element. When `BlockFormattingContext` tried to figure out the height of those `<li>` tags, it decided on 0 because the last `<br>` child didn't have any line box fragments.

Before:
![before](https://user-images.githubusercontent.com/5600524/113439538-c7c87200-93b8-11eb-8fad-975de1d889d8.png)

After:
![after](https://user-images.githubusercontent.com/5600524/113439637-f2b2c600-93b8-11eb-91c7-0d738ec8f4d2.png)
