### PR TITLE
Shot + LibGfx: Added the ability for shot to take partial screenshots

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -409,6 +409,27 @@ RefPtr<Gfx::Bitmap> Bitmap::flipped(Gfx::Orientation orientation) const
     return new_bitmap;
 }
 
+RefPtr<Gfx::Bitmap> Bitmap::cropped(const Gfx::IntRect& rect) const
+{
+    auto crop_width = rect.width();
+    auto crop_height = rect.height();
+    auto start_x = rect.top_left().x();
+    auto start_y = rect.top_left().y();
+
+    auto new_bitmap = Gfx::Bitmap::create(this->format(), { crop_width, crop_height }, scale());
+    if (!new_bitmap)
+        return nullptr;
+
+    for (int i = 0; i < crop_width; i++) {
+        for (int j = 0; j < crop_height; j++) {
+            auto original_pixel = get_pixel(i + start_x, j + start_y);
+            new_bitmap->set_pixel(i, j, original_pixel);
+        }
+    }
+
+    return new_bitmap;
+}
+
 #ifdef __serenity__
 RefPtr<Bitmap> Bitmap::to_bitmap_backed_by_anon_fd() const
 {

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -135,6 +135,7 @@ public:
 
     RefPtr<Gfx::Bitmap> rotated(Gfx::RotationDirection) const;
     RefPtr<Gfx::Bitmap> flipped(Gfx::Orientation) const;
+    RefPtr<Gfx::Bitmap> cropped(const Gfx::IntRect&) const;
     RefPtr<Bitmap> to_bitmap_backed_by_anon_fd() const;
     ByteBuffer serialize_to_byte_buffer() const;
 

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -39,10 +39,18 @@ int main(int argc, char** argv)
     Core::ArgsParser args_parser;
 
     String output_path;
+    const char* start_x = nullptr;
+    const char* start_y = nullptr;
+    const char* width = nullptr;
+    const char* height = nullptr;
     bool output_to_clipboard = false;
     int delay = 0;
 
     args_parser.add_positional_argument(output_path, "Output filename", "output", Core::ArgsParser::Required::No);
+    args_parser.add_option(start_x, "Pixels from where the screenshot gets taken (x)", "starting-x", 'x', "pixels");
+    args_parser.add_option(start_y, "Pixels from where the screenshot gets taken (y)", "starting-y", 'y', "pixels");
+    args_parser.add_option(height, "Screenshot height in pixels", "height", 'h', "pixels");
+    args_parser.add_option(width, "Screenshot width in pixels", "width", 'w', "pixels");
     args_parser.add_option(output_to_clipboard, "Output to clipboard", "clipboard", 'c');
     args_parser.add_option(delay, "Seconds to wait before taking a screenshot", "delay", 'd', "seconds");
 
@@ -60,6 +68,15 @@ int main(int argc, char** argv)
     if (!bitmap) {
         warnln("Failed to grab screenshot");
         return 1;
+    }
+
+    //FIXME: There must be a cleaner way to do this. Maybe have initials value set? Like width being the screen width.
+    if (start_x != nullptr && start_y != nullptr && width != nullptr && height != nullptr) {
+        int x = atoi(start_x);
+        int y = atoi(start_y);
+        int w = atoi(width);
+        int h = atoi(height);
+        bitmap = bitmap->cropped({ x, y, w, h }).leak_ref();
     }
 
     if (output_to_clipboard) {


### PR DESCRIPTION
cropped(Gfx::Point top_left, Gfx::Point bottom_right) is a function that can be used on a bitmap to return a crop from another bitmap (aka another bitmap). It requires two points as arguments (the top-left and bottom-right parts of the crop). This could be used to implement a screenshot section-feature for shot :)