### PR TITLE
LibTLS+LibCrypto: Some user configurability and "performance improvements"

### DIFF
--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -156,6 +156,13 @@ size_t UnsignedBigInteger::trimmed_length() const
     return m_cached_trimmed_length.value();
 }
 
+void UnsignedBigInteger::clamp_to_trimmed_length()
+{
+    auto length = trimmed_length();
+    if (m_words.size() > length)
+        m_words.resize(length);
+}
+
 FLATTEN UnsignedBigInteger UnsignedBigInteger::plus(const UnsignedBigInteger& other) const
 {
     UnsignedBigInteger result;
@@ -578,7 +585,7 @@ FLATTEN void UnsignedBigInteger::shift_left_without_allocation(
 
         // output += (carry_word << temp_result.length())
         // FIXME : Using temp_plus this way to transform carry_word into a bigint is not
-        // efficient nor pretty. Maybe we should have an "add_with_shift" method ?
+        //         efficient nor pretty. Maybe we should have an "add_with_shift" method ?
         temp_plus.set_to_0();
         temp_plus.m_words.append(carry_word);
         shift_left_by_n_words(temp_plus, temp_result.length(), temp_result);

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -81,6 +81,8 @@ public:
     // The "trimmed length" is the number of words after trimming leading zeroed words
     size_t trimmed_length() const;
 
+    void clamp_to_trimmed_length();
+
     UnsignedBigInteger plus(const UnsignedBigInteger& other) const;
     UnsignedBigInteger minus(const UnsignedBigInteger& other) const;
     UnsignedBigInteger bitwise_or(const UnsignedBigInteger& other) const;

--- a/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
+++ b/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
@@ -150,6 +150,13 @@ UnsignedBigInteger ModularPower(const UnsignedBigInteger& b, const UnsignedBigIn
         UnsignedBigInteger::multiply_without_allocation(base, base, temp_1, temp_2, temp_3, temp_4, temp_multiply);
         UnsignedBigInteger::divide_without_allocation(temp_multiply, m, temp_1, temp_2, temp_3, temp_4, temp_quotient, temp_remainder);
         base.set_to(temp_remainder);
+
+        // Note that not clamping here would cause future calculations (multiply, specifically) to allocate even more unused space
+        // which would then persist through the temp bigints, and significantly slow down later loops.
+        // To avoid that, we can clamp to a specific max size, or just clamp to the min needed amount of space.
+        ep.clamp_to_trimmed_length();
+        exp.clamp_to_trimmed_length();
+        base.clamp_to_trimmed_length();
     }
     return exp;
 }

--- a/Userland/Libraries/LibTLS/ClientHandshake.cpp
+++ b/Userland/Libraries/LibTLS/ClientHandshake.cpp
@@ -163,8 +163,8 @@ ssize_t TLSv12::handle_hello(ReadonlyBytes buffer, WritePacketStage& write_packe
                 }
 
                 if (sni_host_length) {
-                    m_context.SNI = String { (const char*)buffer.offset_pointer(res + 5), sni_host_length };
-                    dbgln("server name indicator: {}", m_context.SNI);
+                    m_context.extensions.SNI = String { (const char*)buffer.offset_pointer(res + 5), sni_host_length };
+                    dbgln("server name indicator: {}", m_context.extensions.SNI);
                 }
             } else if (extension_type == HandshakeExtension::ApplicationLayerProtocolNegotiation && m_context.alpn.size()) {
                 if (buffer.size() - res > 2) {

--- a/Userland/Libraries/LibTLS/Exchange.cpp
+++ b/Userland/Libraries/LibTLS/Exchange.cpp
@@ -128,7 +128,8 @@ void TLSv12::pseudorandom_function(Bytes output, ReadonlyBytes secret, const u8*
     auto label_seed_buffer = Bytes { l_seed, l_seed_size };
     label_seed_buffer.overwrite(0, label, label_length);
     label_seed_buffer.overwrite(label_length, seed.data(), seed.size());
-    label_seed_buffer.overwrite(label_length + seed.size(), seed_b.data(), seed_b.size());
+    if (seed_b.size() > 0)
+        label_seed_buffer.overwrite(label_length + seed.size(), seed_b.data(), seed_b.size());
 
     auto digest_size = hmac.digest_size();
 
@@ -182,7 +183,7 @@ bool TLSv12::compute_master_secret(size_t length)
 
 ByteBuffer TLSv12::build_certificate()
 {
-    PacketBuilder builder { MessageType::Handshake, m_context.version };
+    PacketBuilder builder { MessageType::Handshake, m_context.options.version };
 
     Vector<const Certificate*> certificates;
     Vector<Certificate>* local_certificates = nullptr;
@@ -237,7 +238,7 @@ ByteBuffer TLSv12::build_certificate()
 
 ByteBuffer TLSv12::build_change_cipher_spec()
 {
-    PacketBuilder builder { MessageType::ChangeCipher, m_context.version, 64 };
+    PacketBuilder builder { MessageType::ChangeCipher, m_context.options.version, 64 };
     builder.append((u8)1);
     auto packet = builder.build();
     update_packet(packet);
@@ -253,7 +254,7 @@ ByteBuffer TLSv12::build_server_key_exchange()
 
 ByteBuffer TLSv12::build_client_key_exchange()
 {
-    PacketBuilder builder { MessageType::Handshake, m_context.version };
+    PacketBuilder builder { MessageType::Handshake, m_context.options.version };
     builder.append((u8)HandshakeType::ClientKeyExchange);
     build_random(builder);
 

--- a/Userland/Libraries/LibTLS/Handshake.cpp
+++ b/Userland/Libraries/LibTLS/Handshake.cpp
@@ -86,8 +86,8 @@ ByteBuffer TLSv12::build_hello()
 
     // set SNI if we have one
     auto sni_length = 0;
-    if (!m_context.SNI.is_null())
-        sni_length = m_context.SNI.length();
+    if (!m_context.extensions.SNI.is_null())
+        sni_length = m_context.extensions.SNI.length();
 
     if (sni_length)
         extension_length += sni_length + 9;
@@ -105,7 +105,7 @@ ByteBuffer TLSv12::build_hello()
         builder.append((u8)0);
         // SNI host length + value
         builder.append((u16)sni_length);
-        builder.append((const u8*)m_context.SNI.characters(), sni_length);
+        builder.append((const u8*)m_context.extensions.SNI.characters(), sni_length);
     }
 
     if (alpn_length) {

--- a/Userland/Libraries/LibTLS/Handshake.cpp
+++ b/Userland/Libraries/LibTLS/Handshake.cpp
@@ -35,8 +35,8 @@ ByteBuffer TLSv12::build_hello()
 {
     fill_with_random(&m_context.local_random, 32);
 
-    auto packet_version = (u16)m_context.version;
-    auto version = (u16)m_context.version;
+    auto packet_version = (u16)m_context.options.version;
+    auto version = (u16)m_context.options.version;
     PacketBuilder builder { MessageType::Handshake, packet_version };
 
     builder.append((u8)ClientHello);
@@ -73,20 +73,18 @@ ByteBuffer TLSv12::build_hello()
     }
 
     // Ciphers
-    builder.append((u16)(5 * sizeof(u16)));
-    builder.append((u16)CipherSuite::RSA_WITH_AES_128_CBC_SHA256);
-    builder.append((u16)CipherSuite::RSA_WITH_AES_256_CBC_SHA256);
-    builder.append((u16)CipherSuite::RSA_WITH_AES_128_CBC_SHA);
-    builder.append((u16)CipherSuite::RSA_WITH_AES_256_CBC_SHA);
-    builder.append((u16)CipherSuite::RSA_WITH_AES_128_GCM_SHA256);
+    builder.append((u16)(m_context.options.usable_cipher_suites.size() * sizeof(u16)));
+    for (auto suite : m_context.options.usable_cipher_suites)
+        builder.append((u16)suite);
 
     // we don't like compression
+    VERIFY(!m_context.options.use_compression);
     builder.append((u8)1);
-    builder.append((u8)0);
+    builder.append((u8)m_context.options.use_compression);
 
-    // set SNI if we have one
+    // set SNI if we have one, and the user hasn't explicitly asked us to omit it.
     auto sni_length = 0;
-    if (!m_context.extensions.SNI.is_null())
+    if (!m_context.extensions.SNI.is_null() && m_context.options.use_sni)
         sni_length = m_context.extensions.SNI.length();
 
     if (sni_length)
@@ -130,7 +128,7 @@ ByteBuffer TLSv12::build_hello()
 
 ByteBuffer TLSv12::build_alert(bool critical, u8 code)
 {
-    PacketBuilder builder(MessageType::Alert, (u16)m_context.version);
+    PacketBuilder builder(MessageType::Alert, (u16)m_context.options.version);
     builder.append((u8)(critical ? AlertLevel::Critical : AlertLevel::Warning));
     builder.append(code);
 
@@ -145,7 +143,7 @@ ByteBuffer TLSv12::build_alert(bool critical, u8 code)
 
 ByteBuffer TLSv12::build_finished()
 {
-    PacketBuilder builder { MessageType::Handshake, m_context.version, 12 + 64 };
+    PacketBuilder builder { MessageType::Handshake, m_context.options.version, 12 + 64 };
     builder.append((u8)HandshakeType::Finished);
 
     u32 out_size = 12;

--- a/Userland/Libraries/LibTLS/Record.cpp
+++ b/Userland/Libraries/LibTLS/Record.cpp
@@ -61,7 +61,7 @@ void TLSv12::update_packet(ByteBuffer& packet)
         if (packet[0] == (u8)MessageType::Handshake && packet.size() > header_size) {
             u8 handshake_type = packet[header_size];
             if (handshake_type != HandshakeType::HelloRequest && handshake_type != HandshakeType::HelloVerifyRequest) {
-                update_hash(packet.bytes().slice(header_size, packet.size() - header_size));
+                update_hash(packet.bytes(), header_size);
             }
         }
         if (m_context.cipher_spec_set && m_context.crypto.created) {
@@ -190,9 +190,10 @@ void TLSv12::update_packet(ByteBuffer& packet)
     ++m_context.local_sequence_number;
 }
 
-void TLSv12::update_hash(ReadonlyBytes message)
+void TLSv12::update_hash(ReadonlyBytes message, size_t header_size)
 {
-    m_context.handshake_hash.update(message);
+    dbgln("Update hash with message of size {}", message.size());
+    m_context.handshake_hash.update(message.slice(header_size));
 }
 
 ByteBuffer TLSv12::hmac_message(const ReadonlyBytes& buf, const Optional<ReadonlyBytes> buf2, size_t mac_length, bool local)

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -83,7 +83,7 @@ bool TLSv12::write(ReadonlyBytes buffer)
         return false;
     }
 
-    PacketBuilder builder { MessageType::ApplicationData, m_context.version, buffer.size() };
+    PacketBuilder builder { MessageType::ApplicationData, m_context.options.version, buffer.size() };
     builder.append(buffer);
     auto packet = builder.build();
 

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -737,6 +737,9 @@ void TLSv12::set_root_certificates(Vector<Certificate> certificates)
 
 bool Context::verify_chain() const
 {
+    if (!options.validate_certificates)
+        return true;
+
     const Vector<Certificate>* local_chain = nullptr;
     if (is_server) {
         dbgln("Unsupported: Server mode");
@@ -813,10 +816,10 @@ Optional<size_t> TLSv12::verify_chain_and_get_matching_certificate(const StringV
     return {};
 }
 
-TLSv12::TLSv12(Core::Object* parent, Version version)
+TLSv12::TLSv12(Core::Object* parent, Options options)
     : Core::Socket(Core::Socket::Type::TCP, parent)
 {
-    m_context.version = version;
+    m_context.options = move(options);
     m_context.is_server = false;
     m_context.tls_buffer = ByteBuffer::create_uninitialized(0);
 #ifdef SOCK_NONBLOCK

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -667,13 +667,13 @@ void TLSv12::try_disambiguate_error() const
     switch ((AlertDescription)m_context.critical_error) {
     case AlertDescription::HandshakeFailure:
         if (!m_context.cipher_spec_set) {
-            dbgln("- No cipher suite in common with {}", m_context.SNI);
+            dbgln("- No cipher suite in common with {}", m_context.extensions.SNI);
         } else {
             dbgln("- Unknown internal issue");
         }
         break;
     case AlertDescription::InsufficientSecurity:
-        dbgln("- No cipher suite in common with {} (the server is oh so secure)", m_context.SNI);
+        dbgln("- No cipher suite in common with {} (the server is oh so secure)", m_context.extensions.SNI);
         break;
     case AlertDescription::ProtocolVersion:
         dbgln("- The server refused to negotiate with TLS 1.2 :(");

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -203,7 +203,6 @@ struct Context {
     static void print_file(const StringView& fname);
 
     u8 remote_random[32];
-    // To be predictable
     u8 local_random[32];
     u8 session_id[32];
     u8 session_id_size { 0 };

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -242,7 +242,10 @@ struct Context {
 
     bool is_child { false };
 
-    String SNI; // I hate your existence
+    struct {
+        // Server Name Indicator
+        String SNI; // I hate your existence
+    } extensions;
 
     u8 request_client_certificate { 0 };
 
@@ -278,7 +281,7 @@ public:
             dbgln("invalid state for set_sni");
             return;
         }
-        m_context.SNI = sni;
+        m_context.extensions.SNI = sni;
     }
 
     Optional<Certificate> parse_asn1(ReadonlyBytes, bool client_cert = false) const;


### PR DESCRIPTION
Some fixes and improvements made while trying to implement DHE (which I ended up deciding to not implement due to how unnecessarily slow and clunky it is, and the fact that it's entirely superseded by ECDHE anyway) - nothing too interesting.

Probably the most interesting part of this is the LibCrypto change, which prevents growing the temporary bigints while calculating the modexp, this is especially noticeable with a large exponent value (e.g. 64 words).