### PR TITLE
Kernel: Enable PCI ECAM method again if available

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -115,8 +115,9 @@ set(KERNEL_SOURCES
     PCI/Device.cpp
     PCI/DeviceController.cpp
     PCI/IOAccess.cpp
-    PCI/Initializer.cpp
     PCI/MMIOAccess.cpp
+    PCI/Initializer.cpp
+    PCI/WindowedMMIOAccess.cpp
     Panic.cpp
     PerformanceEventBuffer.cpp
     Process.cpp

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -108,9 +108,14 @@ UNMAP_AFTER_INIT bool CommandLine::is_vmmouse_enabled() const
     return lookup("vmmouse").value_or("on") == "on";
 }
 
-UNMAP_AFTER_INIT bool CommandLine::is_mmio_enabled() const
+UNMAP_AFTER_INIT bool CommandLine::is_pci_ecam_enabled() const
 {
-    return lookup("pci_mmio").value_or("off") == "on";
+    auto value = lookup("pci_ecam").value_or("on");
+    if (value == "on")
+        return true;
+    if (value == "off")
+        return false;
+    PANIC("Unknown PCI ECAM setting: {}", value);
 }
 
 UNMAP_AFTER_INIT bool CommandLine::is_legacy_time_enabled() const

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -108,13 +108,15 @@ UNMAP_AFTER_INIT bool CommandLine::is_vmmouse_enabled() const
     return lookup("vmmouse").value_or("on") == "on";
 }
 
-UNMAP_AFTER_INIT bool CommandLine::is_pci_ecam_enabled() const
+UNMAP_AFTER_INIT PCIAccessLevel CommandLine::pci_access_level() const
 {
     auto value = lookup("pci_ecam").value_or("on");
     if (value == "on")
-        return true;
+        return PCIAccessLevel::MappingPerBus;
+    if (value == "per-device")
+        return PCIAccessLevel::MappingPerDevice;
     if (value == "off")
-        return false;
+        return PCIAccessLevel::IOAddressing;
     PANIC("Unknown PCI ECAM setting: {}", value);
 }
 

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -50,6 +50,12 @@ enum class AcpiFeatureLevel {
     Disabled,
 };
 
+enum class PCIAccessLevel {
+    IOAddressing,
+    MappingPerBus,
+    MappingPerDevice,
+};
+
 enum class AHCIResetMode {
     ControllerOnly,
     Complete,
@@ -71,7 +77,7 @@ public:
     [[nodiscard]] bool is_ide_enabled() const;
     [[nodiscard]] bool is_smp_enabled() const;
     [[nodiscard]] bool is_vmmouse_enabled() const;
-    [[nodiscard]] bool is_pci_ecam_enabled() const;
+    [[nodiscard]] PCIAccessLevel pci_access_level() const;
     [[nodiscard]] bool is_legacy_time_enabled() const;
     [[nodiscard]] bool is_text_mode() const;
     [[nodiscard]] bool is_force_pio() const;

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -71,7 +71,7 @@ public:
     [[nodiscard]] bool is_ide_enabled() const;
     [[nodiscard]] bool is_smp_enabled() const;
     [[nodiscard]] bool is_vmmouse_enabled() const;
-    [[nodiscard]] bool is_mmio_enabled() const;
+    [[nodiscard]] bool is_pci_ecam_enabled() const;
     [[nodiscard]] bool is_legacy_time_enabled() const;
     [[nodiscard]] bool is_text_mode() const;
     [[nodiscard]] bool is_force_pio() const;

--- a/Kernel/PCI/Access.h
+++ b/Kernel/PCI/Access.h
@@ -34,11 +34,6 @@ namespace Kernel {
 
 class PCI::Access {
 public:
-    enum class Type {
-        IO,
-        MMIO,
-    };
-
     void enumerate(Function<void(Address, ID)>&) const;
 
     void enumerate_bus(int type, u8 bus, Function<void(Address, ID)>&, bool recursive);

--- a/Kernel/PCI/Definitions.h
+++ b/Kernel/PCI/Definitions.h
@@ -226,6 +226,7 @@ PhysicalID get_physical_id(Address address);
 
 class Access;
 class MMIOAccess;
+class WindowedMMIOAccess;
 class IOAccess;
 class MMIOSegment;
 class DeviceController;

--- a/Kernel/PCI/IOAccess.h
+++ b/Kernel/PCI/IOAccess.h
@@ -40,7 +40,7 @@ protected:
 
 private:
     virtual void enumerate_hardware(Function<void(Address, ID)>) override;
-    virtual const char* access_type() const override { return "IO-Access"; };
+    virtual const char* access_type() const override { return "IOAccess"; };
     virtual uint32_t segment_count() const override { return 1; };
     virtual void write8_field(Address address, u32, u8) override final;
     virtual void write16_field(Address address, u32, u16) override final;

--- a/Kernel/PCI/Initializer.cpp
+++ b/Kernel/PCI/Initializer.cpp
@@ -50,7 +50,7 @@ UNMAP_AFTER_INIT static Access::Type detect_optimal_access_type(bool mmio_allowe
 
 UNMAP_AFTER_INIT void initialize()
 {
-    bool mmio_allowed = kernel_command_line().is_mmio_enabled();
+    bool mmio_allowed = kernel_command_line().is_pci_ecam_enabled();
 
     if (detect_optimal_access_type(mmio_allowed) == Access::Type::MMIO)
         MMIOAccess::initialize(ACPI::Parser::the()->find_table("MCFG"));

--- a/Kernel/PCI/MMIOAccess.cpp
+++ b/Kernel/PCI/MMIOAccess.cpp
@@ -126,7 +126,7 @@ UNMAP_AFTER_INIT MMIOAccess::MMIOAccess(PhysicalAddress p_mcfg)
     });
 }
 
-UNMAP_AFTER_INIT Optional<VirtualAddress> MMIOAccess::get_device_configuration_space(Address address)
+Optional<VirtualAddress> MMIOAccess::get_device_configuration_space(Address address)
 {
     dbgln_if(PCI_DEBUG, "PCI: Getting device configuration space for {}", address);
     for (auto& mapping : m_mapped_device_regions) {

--- a/Kernel/PCI/WindowedMMIOAccess.cpp
+++ b/Kernel/PCI/WindowedMMIOAccess.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020-2021, Liav A. <liavalb@hotmail.co.il>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/Optional.h>
+#include <AK/StringView.h>
+#include <Kernel/Debug.h>
+#include <Kernel/PCI/WindowedMMIOAccess.h>
+#include <Kernel/VM/MemoryManager.h>
+
+namespace Kernel {
+namespace PCI {
+
+UNMAP_AFTER_INIT DeviceConfigurationSpaceMapping::DeviceConfigurationSpaceMapping(Address device_address, const MMIOAccess::MMIOSegment& mmio_segment)
+    : m_device_address(device_address)
+    , m_mapped_region(MM.allocate_kernel_region(page_round_up(PCI_MMIO_CONFIG_SPACE_SIZE), "PCI MMIO Device Access", Region::Access::Read | Region::Access::Write).release_nonnull())
+{
+    PhysicalAddress segment_lower_addr = mmio_segment.get_paddr();
+    PhysicalAddress device_physical_mmio_space = segment_lower_addr.offset(
+        PCI_MMIO_CONFIG_SPACE_SIZE * m_device_address.function() + (PCI_MMIO_CONFIG_SPACE_SIZE * PCI_MAX_FUNCTIONS_PER_DEVICE) * m_device_address.device() + (PCI_MMIO_CONFIG_SPACE_SIZE * PCI_MAX_FUNCTIONS_PER_DEVICE * PCI_MAX_DEVICES_PER_BUS) * (m_device_address.bus() - mmio_segment.get_start_bus()));
+    m_mapped_region->physical_page_slot(0) = PhysicalPage::create(device_physical_mmio_space, false, false);
+    m_mapped_region->remap();
+}
+
+UNMAP_AFTER_INIT void WindowedMMIOAccess::initialize(PhysicalAddress mcfg)
+{
+    if (!Access::is_initialized()) {
+        new WindowedMMIOAccess(mcfg);
+        dbgln_if(PCI_DEBUG, "PCI: MMIO access initialised.");
+    }
+}
+
+UNMAP_AFTER_INIT WindowedMMIOAccess::WindowedMMIOAccess(PhysicalAddress p_mcfg)
+    : MMIOAccess(p_mcfg)
+{
+    dmesgln("PCI: Using MMIO (mapping per device) for PCI configuration space access");
+
+    InterruptDisabler disabler;
+
+    enumerate_hardware([&](const Address& address, ID) {
+        m_mapped_device_regions.append(make<DeviceConfigurationSpaceMapping>(address, m_segments.get(address.seg()).value()));
+    });
+}
+
+Optional<VirtualAddress> WindowedMMIOAccess::get_device_configuration_space(Address address)
+{
+    dbgln_if(PCI_DEBUG, "PCI: Getting device configuration space for {}", address);
+    for (auto& mapping : m_mapped_device_regions) {
+        auto checked_address = mapping.address();
+        dbgln_if(PCI_DEBUG, "PCI Device Configuration Space Mapping: Check if {} was requested", checked_address);
+        if (address.seg() == checked_address.seg()
+            && address.bus() == checked_address.bus()
+            && address.device() == checked_address.device()
+            && address.function() == checked_address.function()) {
+            dbgln_if(PCI_DEBUG, "PCI Device Configuration Space Mapping: Found {}", checked_address);
+            return mapping.vaddr();
+        }
+    }
+
+    dbgln_if(PCI_DEBUG, "PCI: No device configuration space found for {}", address);
+    return {};
+}
+
+u8 WindowedMMIOAccess::read8_field(Address address, u32 field)
+{
+    InterruptDisabler disabler;
+    VERIFY(field <= 0xfff);
+    dbgln_if(PCI_DEBUG, "PCI: MMIO Reading 8-bit field {:#08x} for {}", field, address);
+    return *((u8*)(get_device_configuration_space(address).value().get() + (field & 0xfff)));
+}
+
+u16 WindowedMMIOAccess::read16_field(Address address, u32 field)
+{
+    InterruptDisabler disabler;
+    VERIFY(field < 0xfff);
+    dbgln_if(PCI_DEBUG, "PCI: MMIO Reading 16-bit field {:#08x} for {}", field, address);
+    return *((u16*)(get_device_configuration_space(address).value().get() + (field & 0xfff)));
+}
+
+u32 WindowedMMIOAccess::read32_field(Address address, u32 field)
+{
+    InterruptDisabler disabler;
+    VERIFY(field <= 0xffc);
+    dbgln_if(PCI_DEBUG, "PCI: MMIO Reading 32-bit field {:#08x} for {}", field, address);
+    return *((u32*)(get_device_configuration_space(address).value().get() + (field & 0xfff)));
+}
+
+void WindowedMMIOAccess::write8_field(Address address, u32 field, u8 value)
+{
+    InterruptDisabler disabler;
+    VERIFY(field <= 0xfff);
+    dbgln_if(PCI_DEBUG, "PCI: MMIO Writing 8-bit field {:#08x}, value={:#02x} for {}", field, value, address);
+    *((u8*)(get_device_configuration_space(address).value().get() + (field & 0xfff))) = value;
+}
+void WindowedMMIOAccess::write16_field(Address address, u32 field, u16 value)
+{
+    InterruptDisabler disabler;
+    VERIFY(field < 0xfff);
+    dbgln_if(PCI_DEBUG, "PCI: MMIO Writing 16-bit field {:#08x}, value={:#02x} for {}", field, value, address);
+    *((u16*)(get_device_configuration_space(address).value().get() + (field & 0xfff))) = value;
+}
+void WindowedMMIOAccess::write32_field(Address address, u32 field, u32 value)
+{
+    InterruptDisabler disabler;
+    VERIFY(field <= 0xffc);
+    dbgln_if(PCI_DEBUG, "PCI: MMIO Writing 32-bit field {:#08x}, value={:#02x} for {}", field, value, address);
+    *((u32*)(get_device_configuration_space(address).value().get() + (field & 0xfff))) = value;
+}
+
+}
+}

--- a/Kernel/PCI/WindowedMMIOAccess.h
+++ b/Kernel/PCI/WindowedMMIOAccess.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2020-2021, Liav A. <liavalb@hotmail.co.il>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,7 +32,7 @@
 #include <AK/Types.h>
 #include <Kernel/ACPI/Definitions.h>
 #include <Kernel/PCI/Access.h>
-#include <Kernel/SpinLock.h>
+#include <Kernel/PCI/MMIOAccess.h>
 #include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/PhysicalRegion.h>
 #include <Kernel/VM/Region.h>
@@ -41,39 +41,25 @@
 namespace Kernel {
 namespace PCI {
 
-#define PCI_MMIO_CONFIG_SPACE_SIZE 4096
-
-class MMIOAccess : public Access {
+class DeviceConfigurationSpaceMapping {
 public:
-    class MMIOSegment {
-    public:
-        MMIOSegment(PhysicalAddress, u8, u8);
-        u8 get_start_bus() const;
-        u8 get_end_bus() const;
-        size_t get_size() const;
-        PhysicalAddress get_paddr() const;
+    DeviceConfigurationSpaceMapping(Address, const MMIOAccess::MMIOSegment&);
+    VirtualAddress vaddr() const { return m_mapped_region->vaddr(); };
+    PhysicalAddress paddr() const { return m_mapped_region->physical_page(0)->paddr(); }
+    const Address& address() const { return m_device_address; };
 
-    private:
-        PhysicalAddress m_base_addr;
-        u8 m_start_bus;
-        u8 m_end_bus;
-    };
+private:
+    Address m_device_address;
+    NonnullOwnPtr<Region> m_mapped_region;
+};
+
+class WindowedMMIOAccess final : public MMIOAccess {
+public:
     static void initialize(PhysicalAddress mcfg);
 
 private:
-    PhysicalAddress determine_memory_mapped_bus_region(u32 segment, u8 bus) const;
-    void map_bus_region(u32, u8);
-    VirtualAddress get_device_configuration_space(Address address);
-    SpinLock<u8> m_access_lock;
-    u8 m_mapped_bus { 0 };
-    OwnPtr<Region> m_mapped_region;
-
-protected:
-    explicit MMIOAccess(PhysicalAddress mcfg);
-
-    virtual const char* access_type() const override { return "MMIOAccess"; };
-    virtual u32 segment_count() const override;
-    virtual void enumerate_hardware(Function<void(Address, ID)>) override;
+    explicit WindowedMMIOAccess(PhysicalAddress mcfg);
+    virtual const char* access_type() const override { return "WindowedMMIOAccess"; };
     virtual void write8_field(Address address, u32, u8) override;
     virtual void write16_field(Address address, u32, u16) override;
     virtual void write32_field(Address address, u32, u32) override;
@@ -81,11 +67,8 @@ protected:
     virtual u16 read16_field(Address address, u32) override;
     virtual u32 read32_field(Address address, u32) override;
 
-    virtual u8 segment_start_bus(u32) const override;
-    virtual u8 segment_end_bus(u32) const override;
-
-    PhysicalAddress m_mcfg;
-    HashMap<u16, MMIOSegment> m_segments;
+    Optional<VirtualAddress> get_device_configuration_space(Address address);
+    NonnullOwnPtrVector<DeviceConfigurationSpaceMapping> m_mapped_device_regions;
 };
 
 }


### PR DESCRIPTION
Apparently we don't enable PCI ECAM (MMIO access to the PCI
configuration space) even if we can. This is a regression, as it was
enabled in the past and in unknown time it was regressed.

The CommandLine::is_mmio_enabled method was renamed to
CommandLine::is_pci_ecam_enabled to better represent the meaning
of this method and what it determines.

Also, an UNMAP_AFTER_INIT macro was removed from a method
in the MMIOAccess class as it halted the system when the kernel
tried to access devices after the boot process.