### PR TITLE
LibGfx: Use integer version of Bresenham's algorithm.

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1387,8 +1387,8 @@ void Painter::draw_line(const IntPoint& p1, const IntPoint& p2, Color color, int
     // FIXME: Implement dotted/dashed diagonal lines.
     VERIFY(style == LineStyle::Solid);
 
-    const double adx = abs(point2.x() - point1.x());
-    const double ady = abs(point2.y() - point1.y());
+    const int adx = abs(point2.x() - point1.x());
+    const int ady = abs(point2.y() - point1.y());
 
     if (adx > ady) {
         if (point1.x() > point2.x())
@@ -1399,34 +1399,34 @@ void Painter::draw_line(const IntPoint& p1, const IntPoint& p2, Color color, int
     }
 
     // FIXME: Implement clipping below.
-    const double dx = point2.x() - point1.x();
-    const double dy = point2.y() - point1.y();
-    double error = 0;
+    const int dx = point2.x() - point1.x();
+    const int dy = point2.y() - point1.y();
+    int error = 0;
 
     if (dx > dy) {
-        const double y_step = dy == 0 ? 0 : (dy > 0 ? 1 : -1);
-        const double delta_error = fabs(dy / dx);
+        const int y_step = dy == 0 ? 0 : (dy > 0 ? 1 : -1);
+        const int delta_error = 2 * abs(dy);
         int y = point1.y();
         for (int x = point1.x(); x <= point2.x(); ++x) {
             if (clip_rect.contains(x, y))
                 draw_physical_pixel({ x, y }, color, thickness);
             error += delta_error;
-            if (error >= 0.5) {
-                y = (double)y + y_step;
-                error -= 1.0;
+            if (error >= dx) {
+                y += y_step;
+                error -= 2 * dx;
             }
         }
     } else {
-        const double x_step = dx == 0 ? 0 : (dx > 0 ? 1 : -1);
-        const double delta_error = fabs(dx / dy);
+        const int x_step = dx == 0 ? 0 : (dx > 0 ? 1 : -1);
+        const int delta_error = 2 * abs(dx);
         int x = point1.x();
         for (int y = point1.y(); y <= point2.y(); ++y) {
             if (clip_rect.contains(x, y))
                 draw_physical_pixel({ x, y }, color, thickness);
             error += delta_error;
-            if (error >= 0.5) {
-                x = (double)x + x_step;
-                error -= 1.0;
+            if (error >= dy) {
+                x += x_step;
+                error -= 2 * dy;
             }
         }
     }


### PR DESCRIPTION
Multiply the original floating-point version by 2dx (or 2dy in another branch) and you get an integer version of the same line-drawing algorithm. My quick benchmark showed that diagonal line drawing is 20% faster with this version. However, it's not exactly equivalent:

<details>
<summary>Floating point version</summary>

![float_version](https://user-images.githubusercontent.com/8525038/113482078-a6917f80-94a5-11eb-96dc-656b32e15e9e.png)
</details>

<details>
<summary>Integer version</summary>

![int_version](https://user-images.githubusercontent.com/8525038/113482101-bb6e1300-94a5-11eb-9089-c2e5e1e92d71.png)
</details>

<details>
<summary>Imagemagick's "compare"</summary>

![diff](https://user-images.githubusercontent.com/8525038/113482110-c2952100-94a5-11eb-83af-e8aa1d876cfa.png)
</details>

Notice few pixels on the the left Bezier curve. Still, because nothing else changed I think it was just floating point weirdness for the short lines the curve was made of, and it's safe to use the new version.