### PR TITLE
AK: Update LexicalPath::relative_path to work for '/' prefix

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -127,7 +127,9 @@ String LexicalPath::relative_path(const String absolute_path, const String& pref
     if (!absolute_path.starts_with(prefix))
         return absolute_path;
 
-    size_t prefix_length = LexicalPath { prefix }.string().length() + 1;
+    size_t prefix_length = LexicalPath { prefix }.string().length();
+    if (prefix != "/")
+        prefix_length++;
     if (prefix_length >= absolute_path.length())
         return {};
 

--- a/AK/Tests/TestLexicalPath.cpp
+++ b/AK/Tests/TestLexicalPath.cpp
@@ -84,4 +84,15 @@ TEST_CASE(has_extension)
     }
 }
 
+TEST_CASE(relative_path)
+{
+    EXPECT_EQ(LexicalPath::relative_path("/tmp/abc.txt", "/tmp"), "abc.txt");
+    EXPECT_EQ(LexicalPath::relative_path("/tmp/abc.txt", "/tmp/"), "abc.txt");
+    EXPECT_EQ(LexicalPath::relative_path("/tmp/abc.txt", "/"), "tmp/abc.txt");
+    EXPECT_EQ(LexicalPath::relative_path("/tmp/abc.txt", "/usr"), "/tmp/abc.txt");
+
+    EXPECT_EQ(LexicalPath::relative_path("/tmp/foo.txt", "tmp"), String {});
+    EXPECT_EQ(LexicalPath::relative_path("tmp/foo.txt", "/tmp"), String {});
+}
+
 TEST_MAIN(LexicalPath)


### PR DESCRIPTION
If the prefix path ends in a slash the LexicalPath was removing too many characters. Now only remove an extra character if the prefix does not end in a slash.