### PR TITLE
LibWeb: Associate <label> and <input> elements for mouse events

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -165,6 +165,7 @@ set(SOURCES
     Layout/InitialContainingBlockBox.cpp
     Layout/InlineFormattingContext.cpp
     Layout/InlineNode.cpp
+    Layout/Label.cpp
     Layout/LayoutPosition.cpp
     Layout/LineBox.cpp
     Layout/LineBoxFragment.cpp

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -174,6 +174,8 @@ class CheckBox;
 class FormattingContext;
 class InitialContainingBlockBox;
 class InlineFormattingContext;
+class Label;
+class LabelableNode;
 class LineBox;
 class LineBoxFragment;
 class Node;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -182,6 +182,7 @@ class Node;
 class NodeWithStyle;
 class RadioButton;
 class ReplacedBox;
+class TextNode;
 }
 
 namespace Web {

--- a/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -24,7 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLLabelElement.h>
+#include <LibWeb/Layout/Label.h>
 
 namespace Web::HTML {
 
@@ -35,6 +37,17 @@ HTMLLabelElement::HTMLLabelElement(DOM::Document& document, QualifiedName qualif
 
 HTMLLabelElement::~HTMLLabelElement()
 {
+}
+
+RefPtr<Layout::Node> HTMLLabelElement::create_layout_node()
+{
+    auto style = document().style_resolver().resolve_style(*this);
+    if (style->display() == CSS::Display::None)
+        return nullptr;
+
+    auto layout_node = adopt(*new Layout::Label(document(), this, move(style)));
+    layout_node->set_inline(true);
+    return layout_node;
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/Label.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Label.cpp
@@ -45,7 +45,7 @@ Label::~Label()
 {
 }
 
-void Label::handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned)
+void Label::handle_mousedown_on_label(Badge<TextNode>, const Gfx::IntPoint&, unsigned button)
 {
     if (button != GUI::MouseButton::Left)
         return;
@@ -56,7 +56,7 @@ void Label::handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned
     m_tracking_mouse = true;
 }
 
-void Label::handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint& position, unsigned button, unsigned)
+void Label::handle_mouseup_on_label(Badge<TextNode>, const Gfx::IntPoint& position, unsigned button)
 {
     if (!m_tracking_mouse || button != GUI::MouseButton::Left)
         return;
@@ -75,7 +75,7 @@ void Label::handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint& position, u
     m_tracking_mouse = false;
 }
 
-void Label::handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint& position, unsigned, unsigned)
+void Label::handle_mousemove_on_label(Badge<TextNode>, const Gfx::IntPoint& position, unsigned)
 {
     if (!m_tracking_mouse)
         return;

--- a/Userland/Libraries/LibWeb/Layout/Label.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Label.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibGUI/Event.h>
+#include <LibGfx/Painter.h>
+#include <LibGfx/StylePainter.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/Layout/InitialContainingBlockBox.h>
+#include <LibWeb/Layout/Label.h>
+#include <LibWeb/Layout/LabelableNode.h>
+#include <LibWeb/Page/Frame.h>
+
+namespace Web::Layout {
+
+Label::Label(DOM::Document& document, HTML::HTMLLabelElement* element, NonnullRefPtr<CSS::StyleProperties> style)
+    : BlockBox(document, element, move(style))
+{
+}
+
+Label::~Label()
+{
+}
+
+void Label::handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned)
+{
+    if (button != GUI::MouseButton::Left)
+        return;
+
+    if (auto* control = control_node(); control)
+        control->handle_associated_label_mousedown({});
+
+    m_tracking_mouse = true;
+}
+
+void Label::handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint& position, unsigned button, unsigned)
+{
+    if (!m_tracking_mouse || button != GUI::MouseButton::Left)
+        return;
+
+    // NOTE: Changing the checked state of the DOM node may run arbitrary JS, which could disappear this node.
+    NonnullRefPtr protect = *this;
+
+    if (auto* control = control_node(); control) {
+        bool is_inside_control = enclosing_int_rect(control->absolute_rect()).contains(position);
+        bool is_inside_label = enclosing_int_rect(absolute_rect()).contains(position);
+
+        if (is_inside_control || is_inside_label)
+            control->handle_associated_label_mouseup({});
+    }
+
+    m_tracking_mouse = false;
+}
+
+void Label::handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint& position, unsigned, unsigned)
+{
+    if (!m_tracking_mouse)
+        return;
+
+    if (auto* control = control_node(); control) {
+        bool is_inside_control = enclosing_int_rect(control->absolute_rect()).contains(position);
+        bool is_inside_label = enclosing_int_rect(absolute_rect()).contains(position);
+
+        control->handle_associated_label_mousemove({}, is_inside_control || is_inside_label);
+    }
+}
+
+bool Label::is_inside_associated_label(LabelableNode& control, const Gfx::IntPoint& position)
+{
+    if (auto* label = label_for_control_node(control); label)
+        return enclosing_int_rect(label->absolute_rect()).contains(position);
+    return false;
+}
+
+Label* Label::label_for_control_node(LabelableNode& control)
+{
+    Label* label = nullptr;
+
+    if (!control.document().layout_node())
+        return label;
+
+    String id = control.dom_node().attribute(HTML::AttributeNames::id);
+    if (id.is_empty())
+        return label;
+
+    control.document().layout_node()->for_each_in_subtree_of_type<Label>([&](auto& node) {
+        if (node.dom_node().for_() == id) {
+            label = &node;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+
+    // FIXME: The spec also allows for associating a label with a labelable node by putting the
+    //        labelable node inside the label.
+    return label;
+}
+
+LabelableNode* Label::control_node()
+{
+    LabelableNode* control = nullptr;
+
+    if (!document().layout_node())
+        return control;
+
+    String for_ = dom_node().for_();
+    if (for_.is_empty())
+        return control;
+
+    document().layout_node()->for_each_in_subtree_of_type<LabelableNode>([&](auto& node) {
+        if (node.dom_node().attribute(HTML::AttributeNames::id) == for_) {
+            control = &node;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+
+    // FIXME: The spec also allows for associating a label with a labelable node by putting the
+    //        labelable node inside the label.
+    return control;
+}
+
+}

--- a/Userland/Libraries/LibWeb/Layout/Label.h
+++ b/Userland/Libraries/LibWeb/Layout/Label.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, The SerenityOS developers.
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,20 +26,31 @@
 
 #pragma once
 
-#include <LibWeb/HTML/HTMLElement.h>
+#include <LibWeb/HTML/HTMLLabelElement.h>
+#include <LibWeb/Layout/BlockBox.h>
 
-namespace Web::HTML {
+namespace Web::Layout {
 
-class HTMLLabelElement final : public HTMLElement {
+class Label : public BlockBox {
 public:
-    using WrapperType = Bindings::HTMLLabelElementWrapper;
+    Label(DOM::Document&, HTML::HTMLLabelElement*, NonnullRefPtr<CSS::StyleProperties>);
+    virtual ~Label() override;
 
-    HTMLLabelElement(DOM::Document&, QualifiedName);
-    virtual ~HTMLLabelElement() override;
+    static bool is_inside_associated_label(LabelableNode&, const Gfx::IntPoint&);
 
-    virtual RefPtr<Layout::Node> create_layout_node() override;
+    const HTML::HTMLLabelElement& dom_node() const { return static_cast<const HTML::HTMLLabelElement&>(*BlockBox::dom_node()); }
+    HTML::HTMLLabelElement& dom_node() { return static_cast<HTML::HTMLLabelElement&>(*BlockBox::dom_node()); }
 
-    String for_() const { return attribute(HTML::AttributeNames::for_); }
+private:
+    virtual bool wants_mouse_events() const override { return true; }
+    virtual void handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
+    virtual void handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
+    virtual void handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
+
+    static Label* label_for_control_node(LabelableNode&);
+    LabelableNode* control_node();
+
+    bool m_tracking_mouse { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/Label.h
+++ b/Userland/Libraries/LibWeb/Layout/Label.h
@@ -41,12 +41,11 @@ public:
     const HTML::HTMLLabelElement& dom_node() const { return static_cast<const HTML::HTMLLabelElement&>(*BlockBox::dom_node()); }
     HTML::HTMLLabelElement& dom_node() { return static_cast<HTML::HTMLLabelElement&>(*BlockBox::dom_node()); }
 
-private:
-    virtual bool wants_mouse_events() const override { return true; }
-    virtual void handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
-    virtual void handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
-    virtual void handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
+    void handle_mousedown_on_label(Badge<TextNode>, const Gfx::IntPoint&, unsigned button);
+    void handle_mouseup_on_label(Badge<TextNode>, const Gfx::IntPoint&, unsigned button);
+    void handle_mousemove_on_label(Badge<TextNode>, const Gfx::IntPoint&, unsigned button);
 
+private:
     static Label* label_for_control_node(LabelableNode&);
     LabelableNode* control_node();
 

--- a/Userland/Libraries/LibWeb/Layout/LabelableNode.h
+++ b/Userland/Libraries/LibWeb/Layout/LabelableNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, The SerenityOS developers.
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,20 +26,24 @@
 
 #pragma once
 
-#include <LibWeb/HTML/HTMLElement.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/Layout/ReplacedBox.h>
 
-namespace Web::HTML {
+namespace Web::Layout {
 
-class HTMLLabelElement final : public HTMLElement {
+class LabelableNode : public ReplacedBox {
 public:
-    using WrapperType = Bindings::HTMLLabelElementWrapper;
+    virtual void handle_associated_label_mousedown(Badge<Label>) { }
+    virtual void handle_associated_label_mouseup(Badge<Label>) { }
+    virtual void handle_associated_label_mousemove(Badge<Label>, [[maybe_unused]] bool is_inside_node_or_label) { }
 
-    HTMLLabelElement(DOM::Document&, QualifiedName);
-    virtual ~HTMLLabelElement() override;
+protected:
+    LabelableNode(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
+        : ReplacedBox(document, element, move(style))
+    {
+    }
 
-    virtual RefPtr<Layout::Node> create_layout_node() override;
-
-    String for_() const { return attribute(HTML::AttributeNames::for_); }
+    virtual ~LabelableNode() = default;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
+++ b/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
@@ -27,6 +27,7 @@
 #include <LibGUI/Event.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/StylePainter.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/RadioButton.h>
 #include <LibWeb/Page/Frame.h>
 
@@ -105,20 +106,12 @@ void RadioButton::set_checked_within_group()
         return;
 
     dom_node().set_checked(true);
-
-    if (!parent())
-        return;
-
     String name = dom_node().name();
 
-    parent()->for_each_child_of_type<RadioButton>([&](auto& child) {
-        if (&child == this)
-            return;
-        if (!child.dom_node().checked())
-            return;
-
-        if (child.dom_node().name() == name)
-            child.dom_node().set_checked(false);
+    document().for_each_in_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
+        if (element.checked() && (element.layout_node() != this) && (element.name() == name))
+            element.set_checked(false);
+        return IterationDecision::Continue;
     });
 }
 

--- a/Userland/Libraries/LibWeb/Layout/RadioButton.h
+++ b/Userland/Libraries/LibWeb/Layout/RadioButton.h
@@ -27,25 +27,29 @@
 #pragma once
 
 #include <LibWeb/HTML/HTMLInputElement.h>
-#include <LibWeb/Layout/ReplacedBox.h>
+#include <LibWeb/Layout/LabelableNode.h>
 
 namespace Web::Layout {
 
-class RadioButton : public ReplacedBox {
+class RadioButton : public LabelableNode {
 public:
     RadioButton(DOM::Document&, HTML::HTMLInputElement&, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~RadioButton() override;
 
     virtual void paint(PaintContext&, PaintPhase) override;
 
-    const HTML::HTMLInputElement& dom_node() const { return static_cast<const HTML::HTMLInputElement&>(ReplacedBox::dom_node()); }
-    HTML::HTMLInputElement& dom_node() { return static_cast<HTML::HTMLInputElement&>(ReplacedBox::dom_node()); }
+    const HTML::HTMLInputElement& dom_node() const { return static_cast<const HTML::HTMLInputElement&>(LabelableNode::dom_node()); }
+    HTML::HTMLInputElement& dom_node() { return static_cast<HTML::HTMLInputElement&>(LabelableNode::dom_node()); }
 
 private:
     virtual bool wants_mouse_events() const override { return true; }
     virtual void handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
     virtual void handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
     virtual void handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint&, unsigned buttons, unsigned modifiers) override;
+
+    virtual void handle_associated_label_mousedown(Badge<Label>) override;
+    virtual void handle_associated_label_mouseup(Badge<Label>) override;
+    virtual void handle_associated_label_mousemove(Badge<Label>, bool is_inside_node_or_label) override;
 
     void set_checked_within_group();
 

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -30,6 +30,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/BlockBox.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
+#include <LibWeb/Layout/Label.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Page/Frame.h>
 #include <ctype.h>
@@ -304,6 +305,34 @@ void TextNode::split_into_lines(InlineFormattingContext& context, LayoutMode lay
     }
 
     split_into_lines_by_rules(context, layout_mode, do_collapse, do_wrap_lines, do_wrap_breaks);
+}
+
+bool TextNode::wants_mouse_events() const
+{
+    return parent() && is<Label>(parent());
+}
+
+void TextNode::handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint& position, unsigned button, unsigned)
+{
+    if (!parent() || !is<Label>(*parent()))
+        return;
+    downcast<Label>(*parent()).handle_mousedown_on_label({}, position, button);
+    frame().event_handler().set_mouse_event_tracking_layout_node(this);
+}
+
+void TextNode::handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint& position, unsigned button, unsigned)
+{
+    if (!parent() || !is<Label>(*parent()))
+        return;
+    downcast<Label>(*parent()).handle_mouseup_on_label({}, position, button);
+    frame().event_handler().set_mouse_event_tracking_layout_node(nullptr);
+}
+
+void TextNode::handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint& position, unsigned button, unsigned)
+{
+    if (!parent() || !is<Label>(*parent()))
+        return;
+    downcast<Label>(*parent()).handle_mousemove_on_label({}, position, button);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/TextNode.h
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.h
@@ -48,6 +48,10 @@ public:
 
 private:
     virtual bool is_text_node() const final { return true; }
+    virtual bool wants_mouse_events() const override;
+    virtual void handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
+    virtual void handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
+    virtual void handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
     void split_into_lines_by_rules(InlineFormattingContext&, LayoutMode, bool do_collapse, bool do_wrap_lines, bool do_wrap_breaks);
     void paint_cursor_if_needed(PaintContext&, const LineBoxFragment&) const;
 


### PR DESCRIPTION
This allows for clicking a `<label>` to activate an `<input>` element such as a radio button:

![Screencast-2021-04-03-221205](https://user-images.githubusercontent.com/5600524/113496667-f71ad400-94c9-11eb-8529-532d89d6dfea.gif)
(The 2 mouse swoops at the end are showing pressing the mouse down on a label, dragging the mouse away and back over the associated input, then releasing the mouse on the input (and vice-versa)).

One thing I'm not sure I've done right is passing mouse events from the `TextNode` to its parent `Label`. What we need is for the `Label` to receive mouse events, but because it has a child text node, that child is what gets the events. So before going too far down the rabbit hole with this solution, I've only hooked up `RadioButton` to labels.