### PR TITLE
HackStudio: File search box stays opened after closing

### DIFF
--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -128,7 +128,7 @@ LocatorSuggestionModel::Suggestion LocatorSuggestionModel::Suggestion::create_sy
     return s;
 }
 
-Locator::Locator()
+Locator::Locator(Core::Object* parent)
 {
     set_layout<GUI::VerticalBoxLayout>();
     set_fixed_height(20);
@@ -171,7 +171,7 @@ Locator::Locator()
         open_suggestion(selected_index);
     };
 
-    m_popup_window = GUI::Window::construct();
+    m_popup_window = GUI::Window::construct(parent);
     // FIXME: This is obviously not a tooltip window, but it's the closest thing to what we want atm.
     m_popup_window->set_window_type(GUI::WindowType::Tooltip);
     m_popup_window->set_rect(0, 0, 500, 200);
@@ -234,11 +234,14 @@ void Locator::update_suggestions()
     }
 
     dbgln("I have {} suggestion(s):", suggestions.size());
-    for (auto& s : suggestions) {
-        if (s.is_filename())
-            dbgln("    {}", s.as_filename.value());
-        if (s.is_symbol_declaration())
-            dbgln("    {} ({})", s.as_symbol_declaration.value().name, s.as_symbol_declaration.value().position.file);
+    // Limit the debug logging otherwise this can be very slow for large projects
+    if (suggestions.size() < 100) {
+        for (auto& s : suggestions) {
+            if (s.is_filename())
+                dbgln("    {}", s.as_filename.value());
+            if (s.is_symbol_declaration())
+                dbgln("    {} ({})", s.as_symbol_declaration.value().name, s.as_symbol_declaration.value().position.file);
+        }
     }
 
     bool has_suggestions = !suggestions.is_empty();

--- a/Userland/DevTools/HackStudio/Locator.h
+++ b/Userland/DevTools/HackStudio/Locator.h
@@ -45,7 +45,7 @@ private:
     void update_suggestions();
     void open_suggestion(const GUI::ModelIndex&);
 
-    Locator();
+    Locator(Core::Object* parent = nullptr);
 
     RefPtr<GUI::TextBox> m_textbox;
     RefPtr<GUI::Window> m_popup_window;


### PR DESCRIPTION
Fix #5061 by passing the parent widget down to the locator object and having the locator object parent it's window to it.

Also removed some debug logging in the case of large projects as it can be extremely slow and made searching without a project just hang the process.