### PR TITLE
Meta: Removed commas from command in macOS prereqs

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -115,7 +115,7 @@ Make sure you have all the dependencies installed:
 brew install coreutils qemu bash gcc@10 ninja cmake
 
 # Fuse + ex2
-brew install osxfuse, e2fsprogs, m4, autoconf, automake, libtool
+brew install osxfuse e2fsprogs m4 autoconf automake libtool
 brew install --cask osxfuse
 Toolchain/BuildFuseExt2.sh
 ```


### PR DESCRIPTION
The commas cause Homebrew to attempt to install "osxfuse," instead of osxfuse. "osxfuse," doesn't exist.