### PR TITLE
PixelPaint: Avoid notifying image when creating a layer's snapshot

### DIFF
--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -55,10 +55,17 @@ RefPtr<Layer> Layer::create_with_bitmap(Image& image, const Gfx::Bitmap& bitmap,
 RefPtr<Layer> Layer::create_snapshot(Image& image, const Layer& layer)
 {
     auto snapshot = create_with_bitmap(image, *layer.bitmap().clone(), layer.name());
-    snapshot->set_opacity_percent(layer.opacity_percent());
-    snapshot->set_visible(layer.is_visible());
+    /*
+        We set these properties directly because calling the setters might 
+        notify the image of an update on the newly created layer, but this 
+        layer has not yet been added to the image.
+    */
+    snapshot->m_opacity_percent = layer.opacity_percent();
+    snapshot->m_visible = layer.is_visible();
+
     snapshot->set_selected(layer.is_selected());
     snapshot->set_location(layer.location());
+
     return snapshot;
 }
 


### PR DESCRIPTION
This fixes a bug where the application would crash if the user changed the default values for opacity or visibility of a layer and then tried to draw on it. 

Calling `set_opacity_percent`/`set_visible` also calls `m_image.layer_did_modify_properties({}, *this)` which tries (and fails) to lookup the newly created layer. It worked for default values because those two methods do nothing if the new value is the same as the current one.