### PR TITLE
Ports: Set freetype2 include path for SDL2_ttf

### DIFF
--- a/Ports/SDL2_ttf/package.sh
+++ b/Ports/SDL2_ttf/package.sh
@@ -9,5 +9,6 @@ configure() {
     run ./configure \
         --host="${SERENITY_ARCH}-pc-serenity" \
         --with-sdl-prefix="${SERENITY_BUILD_DIR}/Root/usr" \
+        FT2_CFLAGS="-I${SERENITY_BUILD_DIR}/Root/usr/local/include/freetype2" \
         LIBS="-lgui -lgfx -lipc -lcore -lcompress"
 }


### PR DESCRIPTION
It tried to use some headers from my host machine and failed to build.