### PR TITLE
Ports: fix libvorbis installtion prefix

### DIFF
--- a/Ports/libvorbis/package.sh
+++ b/Ports/libvorbis/package.sh
@@ -2,6 +2,5 @@
 port=libvorbis
 version=1.3.7
 useconfigure=true
-configopts="--prefix=${SERENITY_BUILD_DIR}/Root/usr/local"
 files="https://github.com/xiph/vorbis/releases/download/v${version}/libvorbis-${version}.tar.gz libvorbis-${version}.tar.gz"
 depends=libogg


### PR DESCRIPTION
Accidentally left in a --prefix command, causing the port to install to the wrong location.
Sorry!