### PR TITLE
LibWeb: Convert CheckBox and ButtonBox to be LabelableNode

### DIFF
--- a/Base/res/html/misc/button.html
+++ b/Base/res/html/misc/button.html
@@ -1,0 +1,21 @@
+<body>
+    <br />
+    <input type=button id=button1 name=hp value="Option 1">
+    <label for=button1>Press Me!</label>
+    <br />
+    <input type=button id=button2 name=hp value="Option 2">
+    <label for=button2>No, Press Me!</label>
+    <br />
+    <div style="display: inline-block;">
+        <pre>Last pressed: <span id=last></span></pre>
+    </div>
+
+    <script>
+        document.getElementById('button1').addEventListener('click', function() {
+            document.getElementById('last').innerHTML = this.value;
+        });
+        document.getElementById('button2').addEventListener('click', function() {
+            document.getElementById('last').innerHTML = this.value;
+        });
+    </script>
+</body>

--- a/Base/res/html/misc/checkbox.html
+++ b/Base/res/html/misc/checkbox.html
@@ -1,5 +1,6 @@
 <html>
-    <input id=foo type=checkbox> This is a checkbox
+    <input id=foo type=checkbox>
+    <label for=foo>This is a checkbox</label>
     <pre id=bar></pre>
     <script>
         var foo = document.getElementById("foo");

--- a/Base/res/html/misc/radio.html
+++ b/Base/res/html/misc/radio.html
@@ -30,12 +30,22 @@
     <input type=radio id=targaryen name=got value=Targaryen>
     <label for=targaryen>Targaryen</label>
 
+    <br />
+    <br />
+
+    <b>Selected</b>
+    <br />
+    <div style="display: inline-block;">
+        <pre>HP house: <span id=hp></span></pre>
+        <pre>GoT house: <span id=got></span></pre>
+    </div>
+
     <script>
         const hp = document.getElementsByName('hp');
         for (let i = 0; i < hp.length; ++i) {
             hp[i].addEventListener('change', function() {
                 if (this.checked) {
-                    console.log('HP house:', this.value);
+                    document.getElementById('hp').innerHTML = this.value;
                 }
             });
         }
@@ -44,7 +54,7 @@
         for (let i = 0; i < got.length; ++i) {
             got[i].addEventListener('change', function() {
                 if (this.checked) {
-                    console.log('GoT house:', this.value);
+                    document.getElementById('got').innerHTML = this.value;
                 }
             });
         }

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -46,6 +46,7 @@ span#loadtime {
         <li><a href="float-3.html">floating boxes with overflow=hidden</a></li>
         <li><a href="padding-inline.html">inline elements with padding</a></li>
         <li><a href="event-bubbling-and-multiple-listeners.html">event bubbling and multiple listeners</a></li>
+        <li><a href="button.html">button</a></li>
         <li><a href="radio.html">radio button</a></li>
         <li><a href="checkbox.html">checkbox</a></li>
         <li><a href="canvas-rotate.html">canvas rotate()</a></li>

--- a/Userland/Libraries/LibWeb/Layout/ButtonBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ButtonBox.h
@@ -27,11 +27,11 @@
 #pragma once
 
 #include <LibWeb/HTML/HTMLInputElement.h>
-#include <LibWeb/Layout/ReplacedBox.h>
+#include <LibWeb/Layout/LabelableNode.h>
 
 namespace Web::Layout {
 
-class ButtonBox : public ReplacedBox {
+class ButtonBox : public LabelableNode {
 public:
     ButtonBox(DOM::Document&, HTML::HTMLInputElement&, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~ButtonBox() override;
@@ -39,14 +39,18 @@ public:
     virtual void prepare_for_replaced_layout() override;
     virtual void paint(PaintContext&, PaintPhase) override;
 
-    const HTML::HTMLInputElement& dom_node() const { return static_cast<const HTML::HTMLInputElement&>(ReplacedBox::dom_node()); }
-    HTML::HTMLInputElement& dom_node() { return static_cast<HTML::HTMLInputElement&>(ReplacedBox::dom_node()); }
+    const HTML::HTMLInputElement& dom_node() const { return static_cast<const HTML::HTMLInputElement&>(LabelableNode::dom_node()); }
+    HTML::HTMLInputElement& dom_node() { return static_cast<HTML::HTMLInputElement&>(LabelableNode::dom_node()); }
 
 private:
     virtual bool wants_mouse_events() const override { return true; }
     virtual void handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
     virtual void handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
     virtual void handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint&, unsigned buttons, unsigned modifiers) override;
+
+    virtual void handle_associated_label_mousedown(Badge<Label>) override;
+    virtual void handle_associated_label_mouseup(Badge<Label>) override;
+    virtual void handle_associated_label_mousemove(Badge<Label>, bool is_inside_node_or_label) override;
 
     bool m_being_pressed { false };
     bool m_tracking_mouse { false };

--- a/Userland/Libraries/LibWeb/Layout/CheckBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/CheckBox.cpp
@@ -29,12 +29,13 @@
 #include <LibGfx/Painter.h>
 #include <LibGfx/StylePainter.h>
 #include <LibWeb/Layout/CheckBox.h>
+#include <LibWeb/Layout/Label.h>
 #include <LibWeb/Page/Frame.h>
 
 namespace Web::Layout {
 
 CheckBox::CheckBox(DOM::Document& document, HTML::HTMLInputElement& element, NonnullRefPtr<CSS::StyleProperties> style)
-    : ReplacedBox(document, element, move(style))
+    : LabelableNode(document, element, move(style))
 {
     set_has_intrinsic_width(true);
     set_has_intrinsic_height(true);
@@ -51,7 +52,7 @@ void CheckBox::paint(PaintContext& context, PaintPhase phase)
     if (!is_visible())
         return;
 
-    ReplacedBox::paint(context, phase);
+    LabelableNode::paint(context, phase);
 
     if (phase == PaintPhase::Foreground) {
         Gfx::StylePainter::paint_check_box(context.painter(), enclosing_int_rect(absolute_rect()), context.palette(), dom_node().enabled(), dom_node().checked(), m_being_pressed);
@@ -78,8 +79,11 @@ void CheckBox::handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint& position
     // NOTE: Changing the checked state of the DOM node may run arbitrary JS, which could disappear this node.
     NonnullRefPtr protect = *this;
 
-    bool is_inside = enclosing_int_rect(absolute_rect()).contains(position);
-    if (is_inside)
+    bool is_inside_node_or_label = enclosing_int_rect(absolute_rect()).contains(position);
+    if (!is_inside_node_or_label)
+        is_inside_node_or_label = Label::is_inside_associated_label(*this, position);
+
+    if (is_inside_node_or_label)
         dom_node().set_checked(!dom_node().checked());
 
     m_being_pressed = false;
@@ -92,11 +96,38 @@ void CheckBox::handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint& positi
     if (!m_tracking_mouse || !dom_node().enabled())
         return;
 
-    bool is_inside = enclosing_int_rect(absolute_rect()).contains(position);
-    if (m_being_pressed == is_inside)
+    bool is_inside_node_or_label = enclosing_int_rect(absolute_rect()).contains(position);
+    if (!is_inside_node_or_label)
+        is_inside_node_or_label = Label::is_inside_associated_label(*this, position);
+
+    if (m_being_pressed == is_inside_node_or_label)
         return;
 
-    m_being_pressed = is_inside;
+    m_being_pressed = is_inside_node_or_label;
+    set_needs_display();
+}
+
+void CheckBox::handle_associated_label_mousedown(Badge<Label>)
+{
+    m_being_pressed = true;
+    set_needs_display();
+}
+
+void CheckBox::handle_associated_label_mouseup(Badge<Label>)
+{
+    // NOTE: Changing the checked state of the DOM node may run arbitrary JS, which could disappear this node.
+    NonnullRefPtr protect = *this;
+
+    dom_node().set_checked(!dom_node().checked());
+    m_being_pressed = false;
+}
+
+void CheckBox::handle_associated_label_mousemove(Badge<Label>, bool is_inside_node_or_label)
+{
+    if (m_being_pressed == is_inside_node_or_label)
+        return;
+
+    m_being_pressed = is_inside_node_or_label;
     set_needs_display();
 }
 

--- a/Userland/Libraries/LibWeb/Layout/CheckBox.h
+++ b/Userland/Libraries/LibWeb/Layout/CheckBox.h
@@ -27,25 +27,29 @@
 #pragma once
 
 #include <LibWeb/HTML/HTMLInputElement.h>
-#include <LibWeb/Layout/ReplacedBox.h>
+#include <LibWeb/Layout/LabelableNode.h>
 
 namespace Web::Layout {
 
-class CheckBox : public ReplacedBox {
+class CheckBox : public LabelableNode {
 public:
     CheckBox(DOM::Document&, HTML::HTMLInputElement&, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~CheckBox() override;
 
     virtual void paint(PaintContext&, PaintPhase) override;
 
-    const HTML::HTMLInputElement& dom_node() const { return static_cast<const HTML::HTMLInputElement&>(ReplacedBox::dom_node()); }
-    HTML::HTMLInputElement& dom_node() { return static_cast<HTML::HTMLInputElement&>(ReplacedBox::dom_node()); }
+    const HTML::HTMLInputElement& dom_node() const { return static_cast<const HTML::HTMLInputElement&>(LabelableNode::dom_node()); }
+    HTML::HTMLInputElement& dom_node() { return static_cast<HTML::HTMLInputElement&>(LabelableNode::dom_node()); }
 
 private:
     virtual bool wants_mouse_events() const override { return true; }
     virtual void handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
     virtual void handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers) override;
     virtual void handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint&, unsigned buttons, unsigned modifiers) override;
+
+    virtual void handle_associated_label_mousedown(Badge<Label>) override;
+    virtual void handle_associated_label_mouseup(Badge<Label>) override;
+    virtual void handle_associated_label_mousemove(Badge<Label>, bool is_inside_node_or_label) override;
 
     bool m_being_pressed { false };
     bool m_tracking_mouse { false };

--- a/Userland/Libraries/LibWeb/Layout/Label.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Label.cpp
@@ -32,6 +32,7 @@
 #include <LibWeb/Layout/InitialContainingBlockBox.h>
 #include <LibWeb/Layout/Label.h>
 #include <LibWeb/Layout/LabelableNode.h>
+#include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Page/Frame.h>
 
 namespace Web::Layout {
@@ -92,6 +93,19 @@ bool Label::is_inside_associated_label(LabelableNode& control, const Gfx::IntPoi
 {
     if (auto* label = label_for_control_node(control); label)
         return enclosing_int_rect(label->absolute_rect()).contains(position);
+    return false;
+}
+
+bool Label::is_associated_label_hovered(LabelableNode& control)
+{
+    if (auto* label = label_for_control_node(control); label) {
+        if (label->document().hovered_node() == &label->dom_node())
+            return true;
+
+        if (auto* child = label->first_child_of_type<TextNode>(); child)
+            return label->document().hovered_node() == &child->dom_node();
+    }
+
     return false;
 }
 

--- a/Userland/Libraries/LibWeb/Layout/Label.h
+++ b/Userland/Libraries/LibWeb/Layout/Label.h
@@ -37,6 +37,7 @@ public:
     virtual ~Label() override;
 
     static bool is_inside_associated_label(LabelableNode&, const Gfx::IntPoint&);
+    static bool is_associated_label_hovered(LabelableNode&);
 
     const HTML::HTMLLabelElement& dom_node() const { return static_cast<const HTML::HTMLLabelElement&>(*BlockBox::dom_node()); }
     HTML::HTMLLabelElement& dom_node() { return static_cast<HTML::HTMLLabelElement&>(*BlockBox::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
+++ b/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
@@ -115,6 +115,9 @@ void RadioButton::handle_associated_label_mousedown(Badge<Label>)
 
 void RadioButton::handle_associated_label_mouseup(Badge<Label>)
 {
+    // NOTE: Changing the checked state of the DOM node may run arbitrary JS, which could disappear this node.
+    NonnullRefPtr protect = *this;
+
     set_checked_within_group();
     m_being_pressed = false;
 }

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -324,6 +324,10 @@ void TextNode::handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint& position
 {
     if (!parent() || !is<Label>(*parent()))
         return;
+
+    // NOTE: Changing the state of the DOM node may run arbitrary JS, which could disappear this node.
+    NonnullRefPtr protect = *this;
+
     downcast<Label>(*parent()).handle_mouseup_on_label({}, position, button);
     frame().event_handler().set_mouse_event_tracking_layout_node(nullptr);
 }


### PR DESCRIPTION
This also fixes RadioButton and TextNode to be more protected against a mutating DOM.