### PR TITLE
DHCPClient: Parse MacAddress parts using strtoul

### DIFF
--- a/Userland/Services/DHCPClient/main.cpp
+++ b/Userland/Services/DHCPClient/main.cpp
@@ -29,6 +29,7 @@
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/String.h>
+#include <AK/StringUtils.h>
 #include <AK/Types.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
@@ -39,8 +40,9 @@
 
 static u8 mac_part(const Vector<String>& parts, size_t index)
 {
-    auto chars = parts.at(index).characters();
-    return (chars[0] - '0') * 16 + (chars[1] - '0');
+    auto result = AK::StringUtils::convert_to_uint_from_hex(parts.at(index));
+    VERIFY(result.has_value());
+    return result.value();
 }
 
 static MACAddress mac_from_string(const String& str)


### PR DESCRIPTION
The current parsing code assumed the ascii lowercase letters came after the ascii numbers, which is not the case, and as such corrupted any mac address that included hex letters (a-f). We likely did not notice this as QEMU's emulated MAC is made up of only hex digits.
@Lubrsi and i noticed this while testing #6076 