### PR TITLE
DHCPClient: DHCPRequest bug fixes found on real hardware

### DIFF
--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -287,7 +287,6 @@ void DHCPv4Client::dhcp_request(DHCPv4Transaction& transaction, const DHCPv4Pack
 
     // set packet options
     builder.set_message_type(DHCPMessageType::DHCPRequest);
-    builder.add_option(DHCPOption::ServerIdentifier, sizeof(IPv4Address), &offer.siaddr());
     builder.add_option(DHCPOption::RequestedIPAddress, sizeof(IPv4Address), &offer.yiaddr());
     auto& dhcp_packet = builder.build();
 

--- a/Userland/Services/DHCPClient/DHCPv4Client.h
+++ b/Userland/Services/DHCPClient/DHCPv4Client.h
@@ -40,6 +40,7 @@
 struct InterfaceDescriptor {
     String m_ifname;
     MACAddress m_mac_address;
+    IPv4Address m_current_ip_address { 0, 0, 0, 0 };
 };
 
 struct DHCPv4Transaction {
@@ -61,7 +62,7 @@ public:
     explicit DHCPv4Client(Vector<InterfaceDescriptor> ifnames);
     virtual ~DHCPv4Client() override;
 
-    void dhcp_discover(const InterfaceDescriptor& ifname, IPv4Address previous = IPv4Address { 0, 0, 0, 0 });
+    void dhcp_discover(const InterfaceDescriptor& ifname);
     void dhcp_request(DHCPv4Transaction& transaction, const DHCPv4Packet& packet);
 
     void process_incoming(const DHCPv4Packet& packet);


### PR DESCRIPTION
2 small bugs in the DHCPRequest implementation that @Lubrsi found on real hardware while testing #6076. (these dont affect QEMU's emulated DHCP server, as it just ServerIdentifier option and uses multicast for the ack)