### PR TITLE
PixelPaint: Empty Tool menu

### DIFF
--- a/Userland/Applications/PixelPaint/ToolboxWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolboxWidget.cpp
@@ -105,9 +105,7 @@ ToolboxWidget::ToolboxWidget()
     m_action_group.set_exclusive(true);
     m_action_group.set_unchecking_allowed(false);
 
-    deferred_invoke([this](auto&) {
-        setup_tools();
-    });
+    setup_tools();
 }
 
 ToolboxWidget::~ToolboxWidget()


### PR DESCRIPTION
Fix #4038 by not deferring the creation of the tools. The original
change that introduced this, 7973f767905abd64942bf538a53e385ab207bd6e,
mentions this was needed to avoid having the menu work on the wrong
window, but I don't see that issue with this change so that may not be
needed anymore. An alternative fix would be to delay the menu creation as well.