### PR TITLE
SystemMonitor: Tweak default window size

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -174,7 +174,7 @@ int main(int argc, char** argv)
 
     auto window = GUI::Window::construct();
     window->set_title("System Monitor");
-    window->resize(680, 400);
+    window->resize(680, 430);
 
     auto& main_widget = window->set_main_widget<GUI::Widget>();
     main_widget.set_layout<GUI::VerticalBoxLayout>();


### PR DESCRIPTION
This ensures that all information on the 'Graphs' tab is visible by default without having to resize the window.

Fixes #6135.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/19366641/113559310-69420480-9601-11eb-9def-6a798a371030.png) | ![image](https://user-images.githubusercontent.com/19366641/113559091-15cfb680-9601-11eb-9510-51b355b5adab.png) |