### PR TITLE
WindowServer+ClipboardHistory+Network: Improve the background color consistency of the applets area

### DIFF
--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -93,9 +93,9 @@ int main(int argc, char* argv[])
     auto applet_window = GUI::Window::construct();
     applet_window->set_title("ClipboardHistory");
     applet_window->set_window_type(GUI::WindowType::Applet);
+    applet_window->set_has_alpha_channel(true);
     auto& icon = applet_window->set_main_widget<GUI::ImageWidget>();
     icon.load_from_file("/res/icons/16x16/edit-copy.png");
-    icon.set_fill_with_background_color(true);
     icon.on_click = [&main_window = *main_window] {
         main_window.show();
         main_window.move_to_front();

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -219,9 +219,9 @@ int main(int argc, char* argv[])
     auto window = GUI::Window::construct();
     window->set_title(name);
     window->set_window_type(GUI::WindowType::Applet);
+    window->set_has_alpha_channel(true);
     window->resize(16, 16);
     auto& icon = window->set_main_widget<NetworkWidget>(display_notifications);
-    icon.set_fill_with_background_color(true);
     icon.load_from_file("/res/icons/16x16/network.png");
     window->resize(16, 16);
     window->show();

--- a/Userland/Services/WindowServer/AppletManager.cpp
+++ b/Userland/Services/WindowServer/AppletManager.cpp
@@ -168,7 +168,7 @@ void AppletManager::repaint()
 
     if (!rect.is_empty()) {
         Gfx::Painter painter(*m_window->backing_store());
-        painter.fill_rect(rect, WindowManager::the().palette().window());
+        painter.fill_rect(rect, WindowManager::the().palette().button());
     }
 }
 
@@ -203,7 +203,7 @@ void AppletManager::draw_applet(const Window& applet)
     Gfx::Painter painter(*m_window->backing_store());
     Gfx::PainterStateSaver saver(painter);
     painter.add_clip_rect(applet.rect_in_applet_area());
-    painter.fill_rect(applet.rect_in_applet_area(), WindowManager::the().palette().window());
+    painter.fill_rect(applet.rect_in_applet_area(), WindowManager::the().palette().button());
     painter.blit(applet.rect_in_applet_area().location(), *applet.backing_store(), applet.backing_store()->rect());
 }
 


### PR DESCRIPTION
![Before/After](https://user-images.githubusercontent.com/1713491/113572258-2c353c80-9618-11eb-9008-9b0da3d000a3.png)

This issue wasn't apparent while using the default system theme, but it was while using Nord. These changes make the applet manager use the same color role as the one used by taskbar. I also made the ClipboardHistory and Network applets use the alpha channel as the icons were being filled with an incorrect background color as well.