### PR TITLE
LibWeb: Support two-value background-repeat

### DIFF
--- a/Base/res/html/misc/background-repeat-test.html
+++ b/Base/res/html/misc/background-repeat-test.html
@@ -34,7 +34,7 @@
         </div>
     </div>
 
-    <h1>Element Background</h1>
+    <h1>One-Value Element Background</h1>
     <div style="overflow: hidden">
         <div class=float>
             <h2>repeat</h2>
@@ -49,6 +49,24 @@
 
             <h2>repeat-y</h2>
             <div class=background style="background-repeat: repeat-y"></div>
+        </div>
+    </div>
+
+    <h1>Two-Value Element Background</h1>
+    <div style="overflow: hidden">
+        <div class=float>
+            <h2>repeat repeat</h2>
+            <div class=background style="background-repeat: repeat repeat"></div>
+
+            <h2>repeat no-repeat</h2>
+            <div class=background style="background-repeat: repeat no-repeat"></div>
+        </div>
+        <div class=float>
+            <h2>no-repeat no-repeat</h2>
+            <div class=background style="background-repeat: no-repeat no-repeat"></div>
+
+            <h2>no-repeat repeat</h2>
+            <div class=background style="background-repeat: no-repeat repeat"></div>
         </div>
     </div>
 </body>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -92,7 +92,8 @@ public:
 
     Color color() const { return m_inherited.color; }
     Color background_color() const { return m_noninherited.background_color; }
-    CSS::Repeat background_repeat() const { return m_noninherited.background_repeat; }
+    CSS::Repeat background_repeat_x() const { return m_noninherited.background_repeat_x; }
+    CSS::Repeat background_repeat_y() const { return m_noninherited.background_repeat_y; }
 
     CSS::ListStyleType list_style_type() const { return m_inherited.list_style_type; }
 
@@ -134,7 +135,8 @@ protected:
         BorderData border_right;
         BorderData border_bottom;
         Color background_color { InitialValues::background_color() };
-        CSS::Repeat background_repeat { InitialValues::background_repeat() };
+        CSS::Repeat background_repeat_x { InitialValues::background_repeat() };
+        CSS::Repeat background_repeat_y { InitialValues::background_repeat() };
         CSS::FlexDirection flex_direction { InitialValues::flex_direction() };
         CSS::Overflow overflow_x { InitialValues::overflow() };
         CSS::Overflow overflow_y { InitialValues::overflow() };
@@ -149,7 +151,8 @@ public:
     void set_color(const Color& color) { m_inherited.color = color; }
     void set_cursor(CSS::Cursor cursor) { m_inherited.cursor = cursor; }
     void set_background_color(const Color& color) { m_noninherited.background_color = color; }
-    void set_background_repeat(CSS::Repeat repeat) { m_noninherited.background_repeat = repeat; }
+    void set_background_repeat_x(CSS::Repeat repeat) { m_noninherited.background_repeat_x = repeat; }
+    void set_background_repeat_y(CSS::Repeat repeat) { m_noninherited.background_repeat_y = repeat; }
     void set_float(CSS::Float value) { m_noninherited.float_ = value; }
     void set_clear(CSS::Clear value) { m_noninherited.clear = value; }
     void set_z_index(Optional<int> value) { m_noninherited.z_index = value; }

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -18,8 +18,20 @@
     "initial": "0% 0%"
   },
   "background-repeat": {
+    "longhands": [
+      "background-repeat-x",
+      "background-repeat-y"
+    ]
+  },
+  "background-repeat-x": {
     "inherited": false,
-    "initial": "repeat"
+    "initial": "repeat",
+    "pseudo": true
+  },
+  "background-repeat-y": {
+    "inherited": false,
+    "initial": "repeat",
+    "pseudo": true
   },
   "border": {
     "longhands": [

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -612,9 +612,9 @@ Optional<CSS::Overflow> StyleProperties::overflow(CSS::PropertyID property_id) c
     }
 }
 
-Optional<CSS::Repeat> StyleProperties::background_repeat() const
+Optional<CSS::Repeat> StyleProperties::background_repeat_x() const
 {
-    auto value = property(CSS::PropertyID::BackgroundRepeat);
+    auto value = property(CSS::PropertyID::BackgroundRepeatX);
     if (!value.has_value())
         return {};
 
@@ -623,10 +623,26 @@ Optional<CSS::Repeat> StyleProperties::background_repeat() const
         return CSS::Repeat::NoRepeat;
     case CSS::ValueID::Repeat:
         return CSS::Repeat::Repeat;
-    case CSS::ValueID::RepeatX:
-        return CSS::Repeat::RepeatX;
-    case CSS::ValueID::RepeatY:
-        return CSS::Repeat::RepeatY;
+    case CSS::ValueID::Round:
+        return CSS::Repeat::Round;
+    case CSS::ValueID::Space:
+        return CSS::Repeat::Space;
+    default:
+        return {};
+    }
+}
+
+Optional<CSS::Repeat> StyleProperties::background_repeat_y() const
+{
+    auto value = property(CSS::PropertyID::BackgroundRepeatY);
+    if (!value.has_value())
+        return {};
+
+    switch (value.value()->to_identifier()) {
+    case CSS::ValueID::NoRepeat:
+        return CSS::Repeat::NoRepeat;
+    case CSS::ValueID::Repeat:
+        return CSS::Repeat::Repeat;
     case CSS::ValueID::Round:
         return CSS::Repeat::Round;
     case CSS::ValueID::Space:

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -73,7 +73,8 @@ public:
     Optional<CSS::FlexDirection> flex_direction() const;
     Optional<CSS::Overflow> overflow_x() const;
     Optional<CSS::Overflow> overflow_y() const;
-    Optional<CSS::Repeat> background_repeat() const;
+    Optional<CSS::Repeat> background_repeat_x() const;
+    Optional<CSS::Repeat> background_repeat_y() const;
 
     const Gfx::Font& font() const
     {

--- a/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleResolver.cpp
@@ -229,9 +229,14 @@ static inline void set_property_border_style(StyleProperties& style, const Style
         style.set_property(CSS::PropertyID::BorderLeftStyle, value);
 }
 
-static void set_property_expanding_shorthands(StyleProperties& style, CSS::PropertyID property_id, const StyleValue& value, DOM::Document& document)
+static void set_property_expanding_shorthands(StyleProperties& style, CSS::PropertyID property_id, const StyleValue& value, DOM::Document& document, bool is_internally_generated_pseudo_property = false)
 {
     CSS::ParsingContext context(document);
+
+    if (is_pseudo_property(property_id) && !is_internally_generated_pseudo_property) {
+        dbgln("Ignoring non-internally-generated pseudo property: {}", string_from_property_id(property_id));
+        return;
+    }
 
     if (property_id == CSS::PropertyID::TextDecoration) {
         switch (value.to_identifier()) {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -192,8 +192,6 @@ enum class Overflow : u8 {
 enum class Repeat : u8 {
     NoRepeat,
     Repeat,
-    RepeatX,
-    RepeatY,
     Round,
     Space,
 };

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_cpp.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_cpp.cpp
@@ -112,7 +112,35 @@ const char* string_from_property_id(PropertyID property_id) {
     }
 }
 
+bool is_pseudo_property(PropertyID property_id)
+{
+    switch (property_id) {
+)~~~");
+
+    json.value().as_object().for_each_member([&](auto& name, auto& value) {
+        VERIFY(value.is_object());
+
+        auto pseudo = value.as_object().get_or("pseudo", false);
+        VERIFY(pseudo.is_bool());
+
+        if (pseudo.as_bool()) {
+            auto member_generator = generator.fork();
+            member_generator.set("name:titlecase", title_casify(name));
+            member_generator.append(R"~~~(
+    case PropertyID::@name:titlecase@:
+        return true;
+)~~~");
+        }
+    });
+
+    generator.append(R"~~~(
+    default:
+        return false;
+    }
+}
+
 } // namespace Web::CSS
+
 )~~~");
 
     outln("{}", generator.as_string_view());

--- a/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/Generate_CSS_PropertyID_h.cpp
@@ -91,6 +91,7 @@ enum class PropertyID {
 
 PropertyID property_id_from_string(const StringView&);
 const char* string_from_property_id(PropertyID);
+bool is_pseudo_property(PropertyID);
 
 } // namespace Web::CSS
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -362,7 +362,7 @@ RefPtr<Gfx::Bitmap> Document::background_image() const
     return background_image->bitmap();
 }
 
-CSS::Repeat Document::background_repeat() const
+CSS::Repeat Document::background_repeat_x() const
 {
     auto* body_element = body();
     if (!body_element)
@@ -372,7 +372,20 @@ CSS::Repeat Document::background_repeat() const
     if (!body_layout_node)
         return CSS::Repeat::Repeat;
 
-    return body_layout_node->computed_values().background_repeat();
+    return body_layout_node->computed_values().background_repeat_x();
+}
+
+CSS::Repeat Document::background_repeat_y() const
+{
+    auto* body_element = body();
+    if (!body_element)
+        return CSS::Repeat::Repeat;
+
+    auto* body_layout_node = body_element->layout_node();
+    if (!body_layout_node)
+        return CSS::Repeat::Repeat;
+
+    return body_layout_node->computed_values().background_repeat_y();
 }
 
 URL Document::complete_url(const String& string) const

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -129,7 +129,8 @@ public:
 
     Color background_color(const Gfx::Palette&) const;
     RefPtr<Gfx::Bitmap> background_image() const;
-    CSS::Repeat background_repeat() const;
+    CSS::Repeat background_repeat_x() const;
+    CSS::Repeat background_repeat_y() const;
 
     Color link_color() const;
     void set_link_color(Color);

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -50,7 +50,7 @@ void Box::paint(PaintContext& context, PaintPhase phase)
         context.painter().fill_rect(background_rect, computed_values().background_color());
 
         if (background_image() && background_image()->bitmap()) {
-            paint_background_image(context, *background_image()->bitmap(), computed_values().background_repeat(), move(background_rect));
+            paint_background_image(context, *background_image()->bitmap(), computed_values().background_repeat_x(), computed_values().background_repeat_y(), move(background_rect));
         }
     }
 
@@ -87,22 +87,30 @@ void Box::paint(PaintContext& context, PaintPhase phase)
 void Box::paint_background_image(
     PaintContext& context,
     const Gfx::Bitmap& background_image,
-    CSS::Repeat background_repeat,
+    CSS::Repeat background_repeat_x,
+    CSS::Repeat background_repeat_y,
     Gfx::IntRect background_rect)
 {
-    switch (background_repeat) {
+    switch (background_repeat_x) {
+    case CSS::Repeat::Round:
+    case CSS::Repeat::Space:
+        // FIXME: Support 'round' and 'space'. Fall through to 'repeat' since that most closely resembles these.
     case CSS::Repeat::Repeat:
         // The background rect is already sized to align with 'repeat'.
         break;
-    case CSS::Repeat::RepeatX:
-        background_rect.set_height(background_image.height());
-        break;
-    case CSS::Repeat::RepeatY:
+    case CSS::Repeat::NoRepeat:
         background_rect.set_width(background_image.width());
+        break;
+    }
+
+    switch (background_repeat_y) {
+    case CSS::Repeat::Round:
+    case CSS::Repeat::Space:
+        // FIXME: Support 'round' and 'space'. Fall through to 'repeat' since that most closely resembles these.
+    case CSS::Repeat::Repeat:
+        // The background rect is already sized to align with 'repeat'.
         break;
     case CSS::Repeat::NoRepeat:
-    default: // FIXME: Support 'round' and 'square'
-        background_rect.set_width(background_image.width());
         background_rect.set_height(background_image.height());
         break;
     }

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -153,7 +153,7 @@ protected:
 
     virtual void did_set_rect() { }
 
-    void paint_background_image(PaintContext&, const Gfx::Bitmap&, CSS::Repeat, Gfx::IntRect);
+    void paint_background_image(PaintContext&, const Gfx::Bitmap&, CSS::Repeat, CSS::Repeat, Gfx::IntRect);
 
     Vector<LineBox> m_line_boxes;
 

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -153,6 +153,8 @@ protected:
 
     virtual void did_set_rect() { }
 
+    void paint_background_image(PaintContext&, const Gfx::Bitmap&, CSS::Repeat, Gfx::IntRect);
+
     Vector<LineBox> m_line_boxes;
 
 private:

--- a/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.cpp
@@ -68,31 +68,8 @@ void InitialContainingBlockBox::paint_document_background(PaintContext& context)
     context.painter().translate(-context.viewport_rect().location());
 
     if (auto background_bitmap = document().background_image()) {
-        int painted_image_width = 0;
-        int painted_image_height = 0;
-
-        switch (document().background_repeat()) {
-        case CSS::Repeat::Repeat:
-            painted_image_width = context.viewport_rect().x() + context.viewport_rect().width();
-            painted_image_height = context.viewport_rect().y() + context.viewport_rect().height();
-            break;
-        case CSS::Repeat::RepeatX:
-            painted_image_width = context.viewport_rect().x() + context.viewport_rect().width();
-            painted_image_height = background_bitmap->rect().height();
-            break;
-        case CSS::Repeat::RepeatY:
-            painted_image_width = background_bitmap->rect().width();
-            painted_image_height = context.viewport_rect().y() + context.viewport_rect().height();
-            break;
-        case CSS::Repeat::NoRepeat:
-        default: // FIXME: Support 'round' and 'square'
-            painted_image_width = background_bitmap->rect().width();
-            painted_image_height = background_bitmap->rect().height();
-            break;
-        }
-
-        Gfx::IntRect background_rect { 0, 0, painted_image_width, painted_image_height };
-        context.painter().blit_tiled(background_rect, *background_bitmap, background_bitmap->rect());
+        Gfx::IntRect background_rect = { 0, 0, context.viewport_rect().x() + context.viewport_rect().width(), context.viewport_rect().y() + context.viewport_rect().height() };
+        paint_background_image(context, *background_bitmap, document().background_repeat(), move(background_rect));
     }
 }
 

--- a/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InitialContainingBlockBox.cpp
@@ -69,7 +69,7 @@ void InitialContainingBlockBox::paint_document_background(PaintContext& context)
 
     if (auto background_bitmap = document().background_image()) {
         Gfx::IntRect background_rect = { 0, 0, context.viewport_rect().x() + context.viewport_rect().width(), context.viewport_rect().y() + context.viewport_rect().height() };
-        paint_background_image(context, *background_bitmap, document().background_repeat(), move(background_rect));
+        paint_background_image(context, *background_bitmap, document().background_repeat_x(), document().background_repeat_y(), move(background_rect));
     }
 }
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -234,9 +234,13 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
         m_background_image = static_ptr_cast<CSS::ImageStyleValue>(bgimage.value());
     }
 
-    auto background_repeat = specified_style.background_repeat();
-    if (background_repeat.has_value())
-        computed_values.set_background_repeat(background_repeat.value());
+    auto background_repeat_x = specified_style.background_repeat_x();
+    if (background_repeat_x.has_value())
+        computed_values.set_background_repeat_x(background_repeat_x.value());
+
+    auto background_repeat_y = specified_style.background_repeat_y();
+    if (background_repeat_y.has_value())
+        computed_values.set_background_repeat_y(background_repeat_y.value());
 
     computed_values.set_display(specified_style.display());
 


### PR DESCRIPTION
This adds support for "pseudo" CSS properties, which are properties that may be used by LibWeb but not by CSS stylesheets. Then to support two-value `background-repeat` identifiers, this adds `background-repeat-x` and `background-repeat-y` pseudo properties.