### PR TITLE
DHCPClient: Retry DISCOVER for interfaces that fail

### DIFF
--- a/Userland/Services/DHCPClient/DHCPv4Client.h
+++ b/Userland/Services/DHCPClient/DHCPv4Client.h
@@ -29,6 +29,7 @@
 #include "DHCPv4.h"
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
+#include <AK/Result.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibCore/UDPServer.h>
@@ -59,7 +60,7 @@ class DHCPv4Client final : public Core::Object {
     C_OBJECT(DHCPv4Client)
 
 public:
-    explicit DHCPv4Client(Vector<InterfaceDescriptor> ifnames);
+    explicit DHCPv4Client(Vector<InterfaceDescriptor> ifnames_for_immediate_discover, Vector<InterfaceDescriptor> ifnames_for_later);
     virtual ~DHCPv4Client() override;
 
     void dhcp_discover(const InterfaceDescriptor& ifname);
@@ -69,10 +70,21 @@ public:
 
     bool id_is_registered(u32 id) { return m_ongoing_transactions.contains(id); }
 
+    struct Interfaces {
+        Vector<InterfaceDescriptor> ready;
+        Vector<InterfaceDescriptor> not_ready;
+    };
+    static Result<Interfaces, String> get_discoverable_interfaces();
+
 private:
+    void try_discover_deferred_ifs();
+
     HashMap<u32, OwnPtr<DHCPv4Transaction>> m_ongoing_transactions;
-    Vector<InterfaceDescriptor> m_ifnames;
+    Vector<InterfaceDescriptor> m_ifnames_for_immediate_discover;
+    Vector<InterfaceDescriptor> m_ifnames_for_later;
     RefPtr<Core::UDPServer> m_server;
+    RefPtr<Core::Timer> m_fail_check_timer;
+    int m_max_timer_backoff_interval { 600000 }; // 10 minutes
 
     void handle_offer(const DHCPv4Packet&, const ParsedDHCPv4Options&);
     void handle_ack(const DHCPv4Packet&, const ParsedDHCPv4Options&);

--- a/Userland/Services/DHCPClient/main.cpp
+++ b/Userland/Services/DHCPClient/main.cpp
@@ -38,23 +38,6 @@
 #include <string.h>
 #include <unistd.h>
 
-static u8 mac_part(const Vector<String>& parts, size_t index)
-{
-    auto result = AK::StringUtils::convert_to_uint_from_hex(parts.at(index));
-    VERIFY(result.has_value());
-    return result.value();
-}
-
-static MACAddress mac_from_string(const String& str)
-{
-    auto chunks = str.split(':');
-    VERIFY(chunks.size() == 6); // should we...worry about this?
-    return {
-        mac_part(chunks, 0), mac_part(chunks, 1), mac_part(chunks, 2),
-        mac_part(chunks, 3), mac_part(chunks, 4), mac_part(chunks, 5)
-    };
-}
-
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
     if (pledge("stdio unix inet cpath rpath fattr", nullptr) < 0) {
@@ -71,36 +54,16 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 
     unveil(nullptr, nullptr);
 
-    auto file = Core::File::construct("/proc/net/adapters");
-    if (!file->open(Core::IODevice::ReadOnly)) {
-        dbgln("Error: {}", file->error_string());
+    auto ifs_result = DHCPv4Client::get_discoverable_interfaces();
+    if (ifs_result.is_error()) {
+        warnln("Error: {}", ifs_result.error());
         return 1;
     }
 
-    auto file_contents = file->read_all();
-    auto json = JsonValue::from_string(file_contents);
+    auto ifs = ifs_result.release_value();
+    auto client = DHCPv4Client::construct(move(ifs.ready), move(ifs.not_ready));
 
-    if (!json.has_value() || !json.value().is_array()) {
-        dbgln("Error: No network adapters available");
-        return 1;
-    }
-
-    Vector<InterfaceDescriptor> ifnames;
-    json.value().as_array().for_each([&ifnames](auto& value) {
-        auto if_object = value.as_object();
-
-        if (if_object.get("class_name").to_string() == "LoopbackAdapter")
-            return;
-
-        auto name = if_object.get("name").to_string();
-        auto mac = if_object.get("mac_address").to_string();
-        dbgln_if(DHCPV4_DEBUG, "Found adapter '{}' with mac {}", name, mac);
-        ifnames.append({ name, mac_from_string(mac) });
-    });
-
-    auto client = DHCPv4Client::construct(move(ifnames));
-
-    if (pledge("stdio inet", nullptr) < 0) {
+    if (pledge("stdio inet cpath rpath fattr", nullptr) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
Also avoid trying to acquire an IP on interfaces that aren't up.
Fixes #6126.
Fixes #6125.

I'm not too happy about the polling style, but it's not frequent enough to be an issue...probably.
cc @Lubrsi 