### PR TITLE
Documentation: Improve wording around build directory location

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -185,13 +185,13 @@ $ cd Toolchain
 $ ./BuildIt.sh
 ```
 
-Building the toolchain will also automatically create a `Build/i686/` directory for the build to live in. Specifically, change the current directory to the `Build/` parent directory. To go there from `Toolchain/`, use this command:
+Building the toolchain will also automatically create a `Build/i686/` directory for the build to live in. Once the toolchain has been built, go into the `Build/i686/` directory. Specifically, change the current directory to the `Build/` parent directory. To go there from `Toolchain/`, use this command:
 
 ```console
 $ cd ../Build/i686
 ```
 
-Once the toolchain has been built, go into the `Build/i686/` directory and run the commands. Note that while `ninja` seems to be faster, you can also just use GNU make, by omitting `-G Ninja` and calling `make` instead of `ninja`:
+Run the following commands from within the `Build/i686/` directory. Note that while `ninja` seems to be faster, you can also just use GNU make, by omitting `-G Ninja` and calling `make` instead of `ninja`:
 
 ```console
 $ cmake ../.. -G Ninja

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -185,12 +185,15 @@ $ cd Toolchain
 $ ./BuildIt.sh
 ```
 
-Building the toolchain will also automatically create a `Build/i686/` directory for the build to live in.
+Building the toolchain will also automatically create a `Build/i686/` directory for the build to live in. Specifically, change the current directory to the `Build/` parent directory. To go there from `Toolchain/`, use this command:
+
+```console
+$ cd ../Build/i686
+```
 
 Once the toolchain has been built, go into the `Build/i686/` directory and run the commands. Note that while `ninja` seems to be faster, you can also just use GNU make, by omitting `-G Ninja` and calling `make` instead of `ninja`:
 
 ```console
-$ cd ../Build/i686
 $ cmake ../.. -G Ninja
 $ ninja install
 ```


### PR DESCRIPTION
Instead of including the `cd` command in the build instruction block, I separated the commands to clarify where the build directory should be located. Though the previous instructions were correct, this revision points that it should be the parent `Build/` instead of the directory inside of `Toolchain/Build/`. These instructions have historically confused users. See #5903 and #6165 for an example.

Example of the current `Toolchain/Build/` folder.

```
sklei4@computer:~/serenityos/serenity/Toolchain$ ls
Build             BuildPython.sh      Dockerfile  README.md
BuildFuseExt2.sh  BuildQemu.sh        Local       Tarballs
BuildIt.sh        CMakeToolchain.txt  Patches
```