### PR TITLE
TextEditor: display message if binary file is detected and stop editing

### DIFF
--- a/Userland/Applications/TextEditor/TextEditorWidget.h
+++ b/Userland/Applications/TextEditor/TextEditorWidget.h
@@ -65,6 +65,9 @@ private:
     void update_html_preview();
     void update_statusbar();
 
+    void set_mode_displayable();
+    void set_mode_non_displayable();
+
     virtual void drop_event(GUI::DropEvent&) override;
 
     RefPtr<GUI::TextEditor> m_editor;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -118,11 +118,12 @@ void TextEditor::create_actions()
     m_select_all_action = CommonActions::make_select_all_action([this](auto&) { select_all(); }, this);
 }
 
-void TextEditor::set_text(const StringView& text)
+bool TextEditor::set_text(const StringView& text)
 {
     m_selection.clear();
 
-    document().set_text(text);
+    if (!document().set_text(text))
+        return false;
 
     update_content_size();
     recompute_all_visual_lines();
@@ -132,6 +133,7 @@ void TextEditor::set_text(const StringView& text)
         set_cursor(0, 0);
     did_update_selection();
     update();
+    return true;
 }
 
 void TextEditor::update_content_size()

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -118,7 +118,7 @@ public:
     Function<void()> on_focusin;
     Function<void()> on_focusout;
 
-    void set_text(const StringView&);
+    bool set_text(const StringView&);
     void scroll_cursor_into_view();
     void scroll_position_into_view(const TextPosition&);
     size_t line_count() const { return document().line_count(); }


### PR DESCRIPTION
To know if the file is displayable or not we used `TextDocument::set_text`'s return value, because we don't have access to it directly, we changed `TextEditor::set_text` to get the result of  `TextDocument::set_text`.

If the file is not displayable, we disable editing and display a message to show that a binary file was detected.

Before this, `TextEditor` will only show a white empty editor when opening a binary editor and not report any errors.
This behavior was taken from `HackStudio`.

