### PR TITLE
Ports: Add GnuCOBOL

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -31,6 +31,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`genemu`](genemu)             | Genesis / MegaDrive Emulator                  |                   | https://github.com/rasky/genemu                       |
 | [`git`](git/)                  | Git                                           | 2.26.0            | https://git-scm.com/                                  |
 | [`gmp`](gmp/)                  | GNU Multiple Precision Arithmetic Library     | 6.2.1             | https://gmplib.org/                                   |
+| [`gnucobol`](gnucobol/)        | GnuCOBOL                                      | 3.1.2             | https://gnucobol.sourceforge.io/                      |
 | [`gnuplot`](gnuplot/)          | Gnuplot                                       | 5.2.8             | http://www.gnuplot.info/                              |
 | [`grep`](grep/)                | GNU Grep                                      | 2.5.4             | https://www.gnu.org/software/grep/                    |
 | [`hatari`](hatari/)            | Atari ST/STE/TT/Falcon emulator               | 2.4.0-devel       | https://hatari.tuxfamily.org/                         |

--- a/Ports/gnucobol/package.sh
+++ b/Ports/gnucobol/package.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=gnucobol
+version=3.1.2
+useconfigure="true"
+depends="gmp gcc bash"
+files="https://ftp.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2 gnucobol-${version}.tar.bz2
+https://ftp.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2.sig gnucobol-${version}.tar.bz2.sig
+https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+auth_type="sig"
+auth_opts="--keyring ./gnu-keyring.gpg gnucobol-${version}.tar.bz2.sig"
+configopts="--prefix=/usr/local --enable-hardening --disable-rpath --with-gnu-ld --with-dl --with-math=gmp --with-db=no --with-json=no --with-curses=curses"

--- a/Ports/gnucobol/patches/cob-config.patch
+++ b/Ports/gnucobol/patches/cob-config.patch
@@ -1,0 +1,8 @@
+--- gnucobol-3.1.2/bin/cob-config.in	2020-12-23 02:51:16.000000000 -0800
++++ gnucobol-3.1.2/bin/cob-config.in	2021-04-08 03:05:22.989720870 -0700
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ #
+ # cob-config
+ #

--- a/Ports/gnucobol/patches/config.sub.patch
+++ b/Ports/gnucobol/patches/config.sub.patch
@@ -1,0 +1,10 @@
+--- gnucobol-3.1.2/build_aux/config.sub	2021-04-08 02:49:20.863867201 -0700
++++ gnucobol-3.1.2/build_aux/config.sub	2021-04-08 02:49:22.715869376 -0700
+@@ -1339,6 +1339,7 @@
+ 	# Each alternative MUST end in a * to match a version number.
+ 	# sysv* is not here because it comes later, after sysvr4.
+ 	gnu* | bsd* | mach* | minix* | genix* | ultrix* | irix* \
++	     | serenity* \
+ 	     | *vms* | esix* | aix* | cnk* | sunos | sunos[34]*\
+ 	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* \
+ 	     | sym* | kopensolaris* | plan9* \


### PR DESCRIPTION
This requires downgrade a `TODO()` in LibC `dlopen()` :

```diff
diff --git a/Userland/Libraries/LibC/dlfcn.cpp b/Userland/Libraries/LibC/dlfcn.cpp
index df6d8680e..9a5a4fbfa 100644
--- a/Userland/Libraries/LibC/dlfcn.cpp
+++ b/Userland/Libraries/LibC/dlfcn.cpp
@@ -62,7 +62,7 @@ void* dlopen(const char* filename, int flags)
         // FIXME: Return the handle for "the main executable"
         //     The Serenity Kernel will keep a mapping of the main elf binary resident in memory,
         //     But a future dynamic loader might have a different idea/way of letting us access this information
-        TODO();
+        return nullptr;
     }
 
     auto basename = LexicalPath(filename).basename();
```

![Hello World!](https://user-images.githubusercontent.com/434827/114014557-16d84080-98ac-11eb-9a43-02299fd42019.png)

Invoking LibC functions from within a GnuCOBOL program:

![call libc](https://user-images.githubusercontent.com/434827/114014588-1dff4e80-98ac-11eb-8194-a3d5a0cb19a2.png)

Converting COBOL to C:

![COBOL to C](https://user-images.githubusercontent.com/434827/114016710-78011380-98ae-11eb-837e-8982b461acd6.png)

