### PR TITLE
Kernel: Introduce two new boot arguments to assist with bare metal debug

### DIFF
--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -155,6 +155,16 @@ UNMAP_AFTER_INIT HPETMode CommandLine::hpet_mode() const
     PANIC("Unknown HPETMode: {}", hpet_mode);
 }
 
+UNMAP_AFTER_INIT bool CommandLine::disable_ps2_controller() const
+{
+    return contains("disable_ps2_controller");
+}
+
+UNMAP_AFTER_INIT bool CommandLine::disable_physical_storage() const
+{
+    return contains("disable_physical_storage");
+}
+
 UNMAP_AFTER_INIT AHCIResetMode CommandLine::ahci_reset_mode() const
 {
     const auto ahci_reset_mode = lookup("ahci_reset_mode").value_or("controller");

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -84,6 +84,8 @@ public:
     [[nodiscard]] AcpiFeatureLevel acpi_feature_level() const;
     [[nodiscard]] BootMode boot_mode() const;
     [[nodiscard]] HPETMode hpet_mode() const;
+    [[nodiscard]] bool disable_physical_storage() const;
+    [[nodiscard]] bool disable_ps2_controller() const;
     [[nodiscard]] AHCIResetMode ahci_reset_mode() const;
     [[nodiscard]] String userspace_init() const;
     [[nodiscard]] Vector<String> userspace_init_args() const;

--- a/Kernel/Devices/HID/HIDManagement.cpp
+++ b/Kernel/Devices/HID/HIDManagement.cpp
@@ -26,6 +26,7 @@
 
 #include <AK/Singleton.h>
 #include <Kernel/ACPI/Parser.h>
+#include <Kernel/CommandLine.h>
 #include <Kernel/Devices/HID/HIDManagement.h>
 #include <Kernel/Devices/HID/I8042Controller.h>
 
@@ -125,7 +126,7 @@ UNMAP_AFTER_INIT void HIDManagement::enumerate()
     // emulation of the PS/2 controller if it was set by the BIOS.
     // If ACPI indicates we have an i8042 controller and the USB controller was
     // set to emulate PS/2, we should not initialize the PS/2 controller.
-    if (!ACPI::Parser::the()->have_8042())
+    if (!ACPI::Parser::the()->have_8042() || kernel_command_line().disable_ps2_controller())
         return;
     m_i8042_controller = I8042Controller::initialize();
     m_i8042_controller->detect_devices();


### PR DESCRIPTION
The first one is for disabling the PS2 controller, the other one is for
disabling physical storage enumeration.
We can't be sure any machine will work with our implementation,
therefore this will help us to test more machines.