### PR TITLE
Documentation: Change make to ninja in the installation guide

### DIFF
--- a/Documentation/INSTALL.md
+++ b/Documentation/INSTALL.md
@@ -20,7 +20,7 @@ For more details on known working hardware see the [SerenityOS Hardware Compatib
 
 ## Creating a Serenity GRUB disk image
 
-Before creating a Serenity disk image, you need to build the OS as described in the [SerenityOS build instructions](https://github.com/SerenityOS/serenity/blob/master/Documentation/BuildInstructions.md). Follow those instructions up to and including running **make install**. After the OS has built, run **make grub-image** to create a new file called **grub_disk_image** with GRUB2 installed that can be booted on a real PC.
+Before creating a Serenity disk image, you need to build the OS as described in the [SerenityOS build instructions](https://github.com/SerenityOS/serenity/blob/master/Documentation/BuildInstructions.md). Follow those instructions up to and including running **ninja install**. After the OS has built, run **ninja grub-image** to create a new file called **grub_disk_image** with GRUB2 installed that can be booted on a real PC.
 
 The final step is copying **grub_disk_image** onto the disk you wish to use to boot Serenity using a command such as:
 


### PR DESCRIPTION
Even though ninja is now the default compiler in the build guide, the installation guide still references make which could make it a little confusing for people installing the OS for the first time.