### PR TITLE
LibRegex: Parse `\0` as a zero-byte instead of 0x30 ("0")

### DIFF
--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -178,11 +178,9 @@ private:
     enum class ReadDigitsInitialZeroState {
         Allow,
         Disallow,
-        Require,
     };
     enum class ReadDigitFollowPolicy {
         Any,
-        DisallowDigit,
         DisallowNonDigit,
     };
     StringView read_digits_as_string(ReadDigitsInitialZeroState initial_zero = ReadDigitsInitialZeroState::Allow, ReadDigitFollowPolicy follow_policy = ReadDigitFollowPolicy::Any, bool hex = false, int max_count = -1);

--- a/Userland/Libraries/LibRegex/Tests/Regex.cpp
+++ b/Userland/Libraries/LibRegex/Tests/Regex.cpp
@@ -538,6 +538,7 @@ TEST_CASE(ECMA262_match)
         { "^hel(?<LO>l.)1$", "hello1" },
         { "^hel(?<LO>l.)1*\\k<LO>.$", "hello1lo1" },
         { "^[-a-z1-3\\s]+$", "hell2 o1" },
+        { "^[\\0-\\x1f]$", "\n" },
         { .pattern = "\\bhello\\B", .subject = "hello1", .options = ECMAScriptFlags::Global },
         { "\\b.*\\b", "hello1" },
         { "[^\\D\\S]{2}", "1 " },


### PR DESCRIPTION
This was causing some regexes like `/[\0-\x1f]/` to trip up. Fixes #6202.