### PR TITLE
LibTLS: Support empty SNI in ServerHello messages

### DIFF
--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -175,6 +175,10 @@ enum class HandshakeExtension : u16 {
     SignatureAlgorithms = 0x0d,
 };
 
+enum class NameType : u8 {
+    HostName = 0x00,
+};
+
 enum class WritePacketStage {
     Initial = 0,
     ClientHandshake = 1,


### PR DESCRIPTION
According to [RFC6066](https://tools.ietf.org/html/rfc6066), empty extension_data for an SNI extension is absolutely one of the possibilities - so let's support this instead of spamming the debug log.

Fixes #6201.
