### PR TITLE
UserspaceEmulator: Improve detection of memory leaks

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/MallocTracer.h
+++ b/Userland/DevTools/UserspaceEmulator/MallocTracer.h
@@ -39,6 +39,14 @@ namespace UserspaceEmulator {
 class Emulator;
 class SoftCPU;
 
+struct GraphNode {
+    Vector<FlatPtr> edges_from_node {};
+
+    bool is_reachable { false };
+};
+
+using MemoryGraph = HashMap<FlatPtr, GraphNode>;
+
 struct Mallocation {
     bool contains(FlatPtr a) const
     {
@@ -87,9 +95,13 @@ private:
     Mallocation* find_mallocation(FlatPtr);
     Mallocation* find_mallocation_before(FlatPtr);
     Mallocation* find_mallocation_after(FlatPtr);
-    bool is_reachable(const Mallocation&) const;
+
+    void dump_memory_graph();
+    void populate_memory_graph();
 
     Emulator& m_emulator;
+
+    MemoryGraph m_memory_graph {};
 
     bool m_auditing_enabled { true };
 };
@@ -112,5 +124,4 @@ ALWAYS_INLINE Mallocation* MallocTracer::find_mallocation(const Region& region, 
         return nullptr;
     return mallocation;
 }
-
 }


### PR DESCRIPTION
I was watching one of your older videos about the UserspaceEmulator and thought why not help?

I replaced the logic determining whether a mallocation is reachable with an implementation that puts all of the mallocations into a graph and find out that way. Doing it like this allows us to also catch leaks where two (or more) mallocations point to each other but nothing from outside has any pointer into any of these segments. Previously these mallocations would've been considered reachable.

This is my first contribution to this project and apart from some Hacktoberfest projects also the first contribution to a real open source project :) Also the first time touching C++, so hopefully I didn't make a complete fool out of me.