### PR TITLE
Build fixes for a couple of ports

### DIFF
--- a/Ports/bash/package.sh
+++ b/Ports/bash/package.sh
@@ -17,5 +17,5 @@ build() {
 
 post_install() {
     mkdir -p "${SERENITY_BUILD_DIR}/Root/bin"
-    ln -s /usr/local/bin/bash "${SERENITY_BUILD_DIR}/Root/bin/bash"
+    ln -sf /usr/local/bin/bash "${SERENITY_BUILD_DIR}/Root/bin/bash"
 }

--- a/Ports/dash/package.sh
+++ b/Ports/dash/package.sh
@@ -2,7 +2,6 @@
 port=dash
 version=0.5.10.2
 useconfigure=true
-configopts="--enable-static"
 files="http://gondor.apana.org.au/~herbert/dash/files/dash-${version}.tar.gz dash-${version}.tar.gz
 http://gondor.apana.org.au/~herbert/dash/files/dash-${version}.tar.gz.sha256sum dash-${version}.tar.gz.sha256sum"
 auth_type="sha256"

--- a/Userland/Libraries/LibC/arpa/inet.h
+++ b/Userland/Libraries/LibC/arpa/inet.h
@@ -27,6 +27,8 @@
 #pragma once
 
 #include <endian.h>
+#include <inttypes.h>
+#include <netinet/in.h>
 #include <sys/cdefs.h>
 #include <sys/socket.h>
 

--- a/Userland/Libraries/LibC/ctype.cpp
+++ b/Userland/Libraries/LibC/ctype.cpp
@@ -47,17 +47,93 @@ const char _ctype_[256] = {
     _L, _L, _L, _P, _P, _P, _P, _C
 };
 
-int tolower(int c)
+#undef isalnum
+int isalnum(int c)
 {
-    if (c >= 'A' && c <= 'Z')
-        return c | 0x20;
-    return c;
+    return __inline_isalnum(c);
 }
 
+#undef isalpha
+int isalpha(int c)
+{
+    return __inline_isalpha(c);
+}
+
+#undef iscntrl
+int iscntrl(int c)
+{
+    return __inline_iscntrl(c);
+}
+
+#undef isdigit
+int isdigit(int c)
+{
+    return __inline_isdigit(c);
+}
+
+#undef isxdigit
+int isxdigit(int c)
+{
+    return __inline_isxdigit(c);
+}
+
+#undef isspace
+int isspace(int c)
+{
+    return __inline_isspace(c);
+}
+
+#undef ispunct
+int ispunct(int c)
+{
+    return __inline_ispunct(c);
+}
+
+#undef isprint
+int isprint(int c)
+{
+    return __inline_isprint(c);
+}
+
+#undef isgraph
+int isgraph(int c)
+{
+    return __inline_isgraph(c);
+}
+
+#undef isupper
+int isupper(int c)
+{
+    return __inline_isupper(c);
+}
+
+#undef islower
+int islower(int c)
+{
+    return __inline_islower(c);
+}
+
+#undef isascii
+int isascii(int c)
+{
+    return ((unsigned)c <= 127);
+}
+
+#undef toascii
+int toascii(int c)
+{
+    return __inline_toascii(c);
+}
+
+#undef tolower
+int tolower(int c)
+{
+    return __inline_tolower(c);
+}
+
+#undef toupper
 int toupper(int c)
 {
-    if (c >= 'a' && c <= 'z')
-        return c & ~0x20;
-    return c;
+    return __inline_toupper(c);
 }
 }

--- a/Userland/Libraries/LibC/ctype.h
+++ b/Userland/Libraries/LibC/ctype.h
@@ -42,65 +42,122 @@ __BEGIN_DECLS
 
 extern const char _ctype_[256];
 
-int tolower(int);
-int toupper(int);
-
-static inline int isalnum(int c)
+static inline int __inline_isalnum(int c)
 {
-    return (_ctype_[(unsigned char)(c)] & (_U | _L | _N));
+    return _ctype_[(unsigned char)(c)] & (_U | _L | _N);
 }
 
-static inline int isalpha(int c)
+static inline int __inline_isalpha(int c)
 {
-    return (_ctype_[(unsigned char)(c)] & (_U | _L));
+    return _ctype_[(unsigned char)(c)] & (_U | _L);
 }
 
-static inline int iscntrl(int c)
+static inline int __inline_isascii(int c)
 {
-    return (_ctype_[(unsigned char)(c)] & (_C));
+    return (unsigned)c <= 127;
 }
 
-static inline int isdigit(int c)
+static inline int __inline_iscntrl(int c)
 {
-    return (_ctype_[(unsigned char)(c)] & (_N));
+    return _ctype_[(unsigned char)(c)] & (_C);
 }
 
-static inline int isxdigit(int c)
+static inline int __inline_isdigit(int c)
 {
-    return (_ctype_[(unsigned char)(c)] & (_N | _X));
+    return _ctype_[(unsigned char)(c)] & (_N);
 }
 
-static inline int isspace(int c)
+static inline int __inline_isxdigit(int c)
 {
-    return (_ctype_[(unsigned char)(c)] & (_S));
+    return _ctype_[(unsigned char)(c)] & (_N | _X);
 }
 
-static inline int ispunct(int c)
+static inline int __inline_isspace(int c)
 {
-    return (_ctype_[(unsigned char)(c)] & (_P));
+    return _ctype_[(unsigned char)(c)] & (_S);
 }
 
-static inline int isprint(int c)
+static inline int __inline_ispunct(int c)
 {
-    return (_ctype_[(unsigned char)(c)] & (_P | _U | _L | _N | _B));
+    return _ctype_[(unsigned char)(c)] & (_P);
 }
 
-static inline int isgraph(int c)
+static inline int __inline_isprint(int c)
 {
-    return (_ctype_[(unsigned char)(c)] & (_P | _U | _L | _N));
+    return _ctype_[(unsigned char)(c)] & (_P | _U | _L | _N | _B);
 }
 
-static inline int islower(int c)
+static inline int __inline_isgraph(int c)
 {
-    return ((_ctype_[(unsigned char)(c)] & (_U | _L)) == _L);
+    return _ctype_[(unsigned char)(c)] & (_P | _U | _L | _N);
 }
 
-static inline int isupper(int c)
+static inline int __inline_islower(int c)
 {
-    return ((_ctype_[(unsigned char)(c)] & (_U | _L)) == _U);
+    return _ctype_[(unsigned char)(c)] & (_L);
 }
 
-#define isascii(c) ((unsigned)c <= 127)
-#define toascii(c) ((c)&127)
+static inline int __inline_isupper(int c)
+{
+    return _ctype_[(unsigned char)(c)] & (_U);
+}
+
+static inline int __inline_toascii(int c)
+{
+    return c & 127;
+}
+
+static inline int __inline_tolower(int c)
+{
+    if (c >= 'A' && c <= 'Z')
+        return c | 0x20;
+    return c;
+}
+
+static inline int __inline_toupper(int c)
+{
+    if (c >= 'a' && c <= 'z')
+        return c & ~0x20;
+    return c;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int isalnum(int c);
+int isalpha(int c);
+int isascii(int c);
+int iscntrl(int c);
+int isdigit(int c);
+int isxdigit(int c);
+int isspace(int c);
+int ispunct(int c);
+int isprint(int c);
+int isgraph(int c);
+int islower(int c);
+int isupper(int c);
+int toascii(int c);
+int tolower(int c);
+int toupper(int c);
+
+#ifdef __cplusplus
+}
+#endif
+#define isalnum __inline_isalnum
+#define isalpha __inline_isalpha
+#define isascii __inline_isascii
+#define iscntrl __inline_iscntrl
+#define isdigit __inline_isdigit
+#define isxdigit __inline_isxdigit
+#define isspace __inline_isspace
+#define ispunct __inline_ispunct
+#define isprint __inline_isprint
+#define isgraph __inline_isgraph
+#define islower __inline_islower
+#define isupper __inline_isupper
+#define toascii __inline_toascii
+#define tolower __inline_tolower
+#define toupper __inline_toupper
 
 __END_DECLS


### PR DESCRIPTION
This fixes building the following ports:

* tr: This port expects the `<ctype.h>` functions to also be available as macros (as per https://pubs.opengroup.org/onlinepubs/7908799/xsh/ctype.h.html).
* c-ray: Expects `sockaddr_in` to be defined after including `<arpa/inet.h>`. Ideally c-ray should include `<netinet/in.h>` on its own but https://pubs.opengroup.org/onlinepubs/7908799/xns/arpainet.h.html says that <arpa/inet.h> may optionally include `<netinet/in.h>` and `<inttypes.h>` so I added those there.
* dash: Partially fixed: Building statically linked executables is broken at the moment (because `libc.a` doesn't provide some `cxxabiv1::*` symbols while `libc.so` has those) so I removed the configure option `--enable-static`
* bash: Re-installing the port failed because the symlink already exists, so I used `ln -sf` instead to overwrite it.

Building dash still fails because the `config.h` file is used to build executables for both the cross-compilation target as well as the host system (see `HELPERS` in the Makefile). This is a problem if the host system has `stat64` (which Linux does) while the target doesn't (SerenityOS doesn't). I don't have a fix for that yet.