### PR TITLE
UE: More Bits!

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/MmapRegion.cpp
+++ b/Userland/DevTools/UserspaceEmulator/MmapRegion.cpp
@@ -129,6 +129,40 @@ ValueWithShadow<u64> MmapRegion::read64(u32 offset)
     return { *reinterpret_cast<const u64*>(m_data + offset), *reinterpret_cast<const u64*>(m_shadow_data + offset) };
 }
 
+ValueWithShadow<u128> MmapRegion::read128(u32 offset)
+{
+    if (!is_readable()) {
+        reportln("128-bit read from unreadable MmapRegion @ {:p}", base() + offset);
+        emulator().dump_backtrace();
+        TODO();
+    }
+
+    if (is_malloc_block()) {
+        if (auto* tracer = emulator().malloc_tracer())
+            tracer->audit_read(*this, base() + offset, 16);
+    }
+
+    VERIFY(offset + 15 < size());
+    return { *reinterpret_cast<const u128*>(m_data + offset), *reinterpret_cast<const u128*>(m_shadow_data + offset) };
+}
+
+ValueWithShadow<u256> MmapRegion::read256(u32 offset)
+{
+    if (!is_readable()) {
+        reportln("256-bit read from unreadable MmapRegion @ {:p}", base() + offset);
+        emulator().dump_backtrace();
+        TODO();
+    }
+
+    if (is_malloc_block()) {
+        if (auto* tracer = emulator().malloc_tracer())
+            tracer->audit_read(*this, base() + offset, 32);
+    }
+
+    VERIFY(offset + 31 < size());
+    return { *reinterpret_cast<const u256*>(m_data + offset), *reinterpret_cast<const u256*>(m_shadow_data + offset) };
+}
+
 void MmapRegion::write8(u32 offset, ValueWithShadow<u8> value)
 {
     if (!is_writable()) {
@@ -201,6 +235,44 @@ void MmapRegion::write64(u32 offset, ValueWithShadow<u64> value)
     VERIFY(m_data != m_shadow_data);
     *reinterpret_cast<u64*>(m_data + offset) = value.value();
     *reinterpret_cast<u64*>(m_shadow_data + offset) = value.shadow();
+}
+
+void MmapRegion::write128(u32 offset, ValueWithShadow<u128> value)
+{
+    if (!is_writable()) {
+        reportln("128-bit write from unwritable MmapRegion @ {:p}", base() + offset);
+        emulator().dump_backtrace();
+        TODO();
+    }
+
+    if (is_malloc_block()) {
+        if (auto* tracer = emulator().malloc_tracer())
+            tracer->audit_write(*this, base() + offset, 16);
+    }
+
+    VERIFY(offset + 15 < size());
+    VERIFY(m_data != m_shadow_data);
+    *reinterpret_cast<u128*>(m_data + offset) = value.value();
+    *reinterpret_cast<u128*>(m_shadow_data + offset) = value.shadow();
+}
+
+void MmapRegion::write256(u32 offset, ValueWithShadow<u256> value)
+{
+    if (!is_writable()) {
+        reportln("256-bit write from unwritable MmapRegion @ {:p}", base() + offset);
+        emulator().dump_backtrace();
+        TODO();
+    }
+
+    if (is_malloc_block()) {
+        if (auto* tracer = emulator().malloc_tracer())
+            tracer->audit_write(*this, base() + offset, 32);
+    }
+
+    VERIFY(offset + 31 < size());
+    VERIFY(m_data != m_shadow_data);
+    *reinterpret_cast<u256*>(m_data + offset) = value.value();
+    *reinterpret_cast<u256*>(m_shadow_data + offset) = value.shadow();
 }
 
 NonnullOwnPtr<MmapRegion> MmapRegion::split_at(VirtualAddress offset)

--- a/Userland/DevTools/UserspaceEmulator/MmapRegion.h
+++ b/Userland/DevTools/UserspaceEmulator/MmapRegion.h
@@ -24,11 +24,15 @@ public:
     virtual ValueWithShadow<u16> read16(u32 offset) override;
     virtual ValueWithShadow<u32> read32(u32 offset) override;
     virtual ValueWithShadow<u64> read64(u32 offset) override;
+    virtual ValueWithShadow<u128> read128(u32 offset) override;
+    virtual ValueWithShadow<u256> read256(u32 offset) override;
 
     virtual void write8(u32 offset, ValueWithShadow<u8>) override;
     virtual void write16(u32 offset, ValueWithShadow<u16>) override;
     virtual void write32(u32 offset, ValueWithShadow<u32>) override;
     virtual void write64(u32 offset, ValueWithShadow<u64>) override;
+    virtual void write128(u32 offset, ValueWithShadow<u128>) override;
+    virtual void write256(u32 offset, ValueWithShadow<u256>) override;
 
     virtual u8* data() override { return m_data; }
     virtual u8* shadow_data() override { return m_shadow_data; }

--- a/Userland/DevTools/UserspaceEmulator/Region.h
+++ b/Userland/DevTools/UserspaceEmulator/Region.h
@@ -10,6 +10,7 @@
 #include "ValueWithShadow.h"
 #include <AK/TypeCasts.h>
 #include <AK/Types.h>
+#include <LibX86/Types.h>
 
 namespace UserspaceEmulator {
 
@@ -31,11 +32,15 @@ public:
     virtual void write16(u32 offset, ValueWithShadow<u16>) = 0;
     virtual void write32(u32 offset, ValueWithShadow<u32>) = 0;
     virtual void write64(u32 offset, ValueWithShadow<u64>) = 0;
+    virtual void write128(u32 offset, ValueWithShadow<u128>) = 0;
+    virtual void write256(u32 offset, ValueWithShadow<u256>) = 0;
 
     virtual ValueWithShadow<u8> read8(u32 offset) = 0;
     virtual ValueWithShadow<u16> read16(u32 offset) = 0;
     virtual ValueWithShadow<u32> read32(u32 offset) = 0;
     virtual ValueWithShadow<u64> read64(u32 offset) = 0;
+    virtual ValueWithShadow<u128> read128(u32 offset) = 0;
+    virtual ValueWithShadow<u256> read256(u32 offset) = 0;
 
     virtual u8* cacheable_ptr([[maybe_unused]] u32 offset) { return nullptr; }
 

--- a/Userland/DevTools/UserspaceEmulator/SimpleRegion.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SimpleRegion.cpp
@@ -47,6 +47,18 @@ ValueWithShadow<u64> SimpleRegion::read64(u32 offset)
     return { *reinterpret_cast<const u64*>(m_data + offset), *reinterpret_cast<const u64*>(m_shadow_data + offset) };
 }
 
+ValueWithShadow<u128> SimpleRegion::read128(u32 offset)
+{
+    VERIFY(offset + 15 < size());
+    return { *reinterpret_cast<const u128*>(m_data + offset), *reinterpret_cast<const u128*>(m_shadow_data + offset) };
+}
+
+ValueWithShadow<u256> SimpleRegion::read256(u32 offset)
+{
+    VERIFY(offset + 31 < size());
+    return { *reinterpret_cast<const u256*>(m_data + offset), *reinterpret_cast<const u256*>(m_shadow_data + offset) };
+}
+
 void SimpleRegion::write8(u32 offset, ValueWithShadow<u8> value)
 {
     VERIFY(offset < size());
@@ -73,6 +85,18 @@ void SimpleRegion::write64(u32 offset, ValueWithShadow<u64> value)
     VERIFY(offset + 7 < size());
     *reinterpret_cast<u64*>(m_data + offset) = value.value();
     *reinterpret_cast<u64*>(m_shadow_data + offset) = value.shadow();
+}
+void SimpleRegion::write128(u32 offset, ValueWithShadow<u128> value)
+{
+    VERIFY(offset + 15 < size());
+    *reinterpret_cast<u128*>(m_data + offset) = value.value();
+    *reinterpret_cast<u128*>(m_shadow_data + offset) = value.shadow();
+}
+void SimpleRegion::write256(u32 offset, ValueWithShadow<u256> value)
+{
+    VERIFY(offset + 31 < size());
+    *reinterpret_cast<u256*>(m_data + offset) = value.value();
+    *reinterpret_cast<u256*>(m_shadow_data + offset) = value.shadow();
 }
 
 u8* SimpleRegion::cacheable_ptr(u32 offset)

--- a/Userland/DevTools/UserspaceEmulator/SimpleRegion.h
+++ b/Userland/DevTools/UserspaceEmulator/SimpleRegion.h
@@ -19,11 +19,15 @@ public:
     virtual ValueWithShadow<u16> read16(u32 offset) override;
     virtual ValueWithShadow<u32> read32(u32 offset) override;
     virtual ValueWithShadow<u64> read64(u32 offset) override;
+    virtual ValueWithShadow<u128> read128(u32 offset) override;
+    virtual ValueWithShadow<u256> read256(u32 offset) override;
 
     virtual void write8(u32 offset, ValueWithShadow<u8>) override;
     virtual void write16(u32 offset, ValueWithShadow<u16>) override;
     virtual void write32(u32 offset, ValueWithShadow<u32>) override;
     virtual void write64(u32 offset, ValueWithShadow<u64>) override;
+    virtual void write128(u32 offset, ValueWithShadow<u128>) override;
+    virtual void write256(u32 offset, ValueWithShadow<u256>) override;
 
     virtual u8* data() override { return m_data; }
     virtual u8* shadow_data() override { return m_shadow_data; }

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -133,6 +133,25 @@ ValueWithShadow<u64> SoftCPU::read_memory64(X86::LogicalAddress address)
     return value;
 }
 
+ValueWithShadow<u128> SoftCPU::read_memory128(X86::LogicalAddress address)
+{
+    VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
+    auto value = m_emulator.mmu().read128(address);
+#if MEMORY_DEBUG
+    outln("\033[36;1mread_memory128: @{:04x}:{:08x} -> {:032x} ({:032x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+#endif
+    return value;
+}
+ValueWithShadow<u256> SoftCPU::read_memory256(X86::LogicalAddress address)
+{
+    VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
+    auto value = m_emulator.mmu().read256(address);
+#if MEMORY_DEBUG
+    outln("\033[36;1mread_memory256: @{:04x}:{:08x} -> {:064x} ({:064x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+#endif
+    return value;
+}
+
 void SoftCPU::write_memory8(X86::LogicalAddress address, ValueWithShadow<u8> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
@@ -159,6 +178,24 @@ void SoftCPU::write_memory64(X86::LogicalAddress address, ValueWithShadow<u64> v
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
     outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory64: @{:04x}:{:08x} <- {:016x} ({:016x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write64(address, value);
+}
+
+void SoftCPU::write_memory128(X86::LogicalAddress address, ValueWithShadow<u128> value)
+{
+    VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
+#if MEMORY_DEBUG
+    outln("\033[36;1mwrite_memory128: @{:04x}:{:08x} <- {:032x} ({:032x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+#endif
+    m_emulator.mmu().write128(address, value);
+}
+
+void SoftCPU::write_memory256(X86::LogicalAddress address, ValueWithShadow<u256> value)
+{
+    VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
+#if MEMORY_DEBUG
+    outln("\033[36;1mwrite_memory256: @{:04x}:{:08x} <- {:064x} ({:064x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+#endif
+    m_emulator.mmu().write256(address, value);
 }
 
 void SoftCPU::push_string(const StringView& string)

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.h
@@ -39,6 +39,8 @@ public:
     using ValueWithShadowType16 = ValueWithShadow<u16>;
     using ValueWithShadowType32 = ValueWithShadow<u32>;
     using ValueWithShadowType64 = ValueWithShadow<u64>;
+    using ValueWithShadowType128 = ValueWithShadow<u128>;
+    using ValueWithShadowType256 = ValueWithShadow<u256>;
 
     explicit SoftCPU(Emulator&);
     void dump() const;
@@ -347,6 +349,8 @@ public:
     ValueWithShadow<u16> read_memory16(X86::LogicalAddress);
     ValueWithShadow<u32> read_memory32(X86::LogicalAddress);
     ValueWithShadow<u64> read_memory64(X86::LogicalAddress);
+    ValueWithShadow<u128> read_memory128(X86::LogicalAddress);
+    ValueWithShadow<u256> read_memory256(X86::LogicalAddress);
 
     template<typename T>
     ValueWithShadow<T> read_memory(X86::LogicalAddress address)
@@ -357,12 +361,20 @@ public:
             return read_memory16(address);
         if constexpr (sizeof(T) == 4)
             return read_memory32(address);
+        if constexpr (sizeof(T) == 8)
+            return read_memory64(address);
+        if constexpr (sizeof(T) == 16)
+            return read_memory128(address);
+        if constexpr (sizeof(T) == 32)
+            return read_memory256(address);
     }
 
     void write_memory8(X86::LogicalAddress, ValueWithShadow<u8>);
     void write_memory16(X86::LogicalAddress, ValueWithShadow<u16>);
     void write_memory32(X86::LogicalAddress, ValueWithShadow<u32>);
     void write_memory64(X86::LogicalAddress, ValueWithShadow<u64>);
+    void write_memory128(X86::LogicalAddress, ValueWithShadow<u128>);
+    void write_memory256(X86::LogicalAddress, ValueWithShadow<u256>);
 
     template<typename T>
     void write_memory(X86::LogicalAddress address, ValueWithShadow<T> data)
@@ -373,6 +385,12 @@ public:
             return write_memory16(address, data);
         if constexpr (sizeof(T) == 4)
             return write_memory32(address, data);
+        if constexpr (sizeof(T) == 8)
+            return write_memory64(address, data);
+        if constexpr (sizeof(T) == 16)
+            return write_memory128(address, data);
+        if constexpr (sizeof(T) == 32)
+            return write_memory256(address, data);
     }
 
     bool evaluate_condition(u8 condition) const

--- a/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
@@ -163,6 +163,42 @@ ValueWithShadow<u64> SoftMMU::read64(X86::LogicalAddress address)
     return region->read64(address.offset() - region->base());
 }
 
+ValueWithShadow<u128> SoftMMU::read128(X86::LogicalAddress address)
+{
+    auto* region = find_region(address);
+    if (!region) {
+        reportln("SoftMMU::read128: No region for @ {:p}", address.offset());
+        m_emulator.dump_backtrace();
+        TODO();
+    }
+
+    if (!region->is_readable()) {
+        reportln("SoftMMU::read128: Non-readable region @ {:p}", address.offset());
+        m_emulator.dump_backtrace();
+        TODO();
+    }
+
+    return region->read128(address.offset() - region->base());
+}
+
+ValueWithShadow<u256> SoftMMU::read256(X86::LogicalAddress address)
+{
+    auto* region = find_region(address);
+    if (!region) {
+        reportln("SoftMMU::read256: No region for @ {:p}", address.offset());
+        m_emulator.dump_backtrace();
+        TODO();
+    }
+
+    if (!region->is_readable()) {
+        reportln("SoftMMU::read256: Non-readable region @ {:p}", address.offset());
+        m_emulator.dump_backtrace();
+        TODO();
+    }
+
+    return region->read256(address.offset() - region->base());
+}
+
 void SoftMMU::write8(X86::LogicalAddress address, ValueWithShadow<u8> value)
 {
     auto* region = find_region(address);
@@ -232,6 +268,42 @@ void SoftMMU::write64(X86::LogicalAddress address, ValueWithShadow<u64> value)
     }
 
     region->write64(address.offset() - region->base(), value);
+}
+
+void SoftMMU::write128(X86::LogicalAddress address, ValueWithShadow<u128> value)
+{
+    auto* region = find_region(address);
+    if (!region) {
+        reportln("SoftMMU::write128: No region for @ {:p}", address.offset());
+        m_emulator.dump_backtrace();
+        TODO();
+    }
+
+    if (!region->is_writable()) {
+        reportln("SoftMMU::write128: Non-writable region @ {:p}", address.offset());
+        m_emulator.dump_backtrace();
+        TODO();
+    }
+
+    region->write128(address.offset() - region->base(), value);
+}
+
+void SoftMMU::write256(X86::LogicalAddress address, ValueWithShadow<u256> value)
+{
+    auto* region = find_region(address);
+    if (!region) {
+        reportln("SoftMMU::write256: No region for @ {:p}", address.offset());
+        m_emulator.dump_backtrace();
+        TODO();
+    }
+
+    if (!region->is_writable()) {
+        reportln("SoftMMU::write256: Non-writable region @ {:p}", address.offset());
+        m_emulator.dump_backtrace();
+        TODO();
+    }
+
+    region->write256(address.offset() - region->base(), value);
 }
 
 void SoftMMU::copy_to_vm(FlatPtr destination, const void* source, size_t size)

--- a/Userland/DevTools/UserspaceEmulator/SoftMMU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftMMU.h
@@ -26,11 +26,15 @@ public:
     ValueWithShadow<u16> read16(X86::LogicalAddress);
     ValueWithShadow<u32> read32(X86::LogicalAddress);
     ValueWithShadow<u64> read64(X86::LogicalAddress);
+    ValueWithShadow<u128> read128(X86::LogicalAddress);
+    ValueWithShadow<u256> read256(X86::LogicalAddress);
 
     void write8(X86::LogicalAddress, ValueWithShadow<u8>);
     void write16(X86::LogicalAddress, ValueWithShadow<u16>);
     void write32(X86::LogicalAddress, ValueWithShadow<u32>);
     void write64(X86::LogicalAddress, ValueWithShadow<u64>);
+    void write128(X86::LogicalAddress, ValueWithShadow<u128>);
+    void write256(X86::LogicalAddress, ValueWithShadow<u256>);
 
     ALWAYS_INLINE Region* find_region(X86::LogicalAddress address)
     {

--- a/Userland/DevTools/UserspaceEmulator/ValueWithShadow.h
+++ b/Userland/DevTools/UserspaceEmulator/ValueWithShadow.h
@@ -4,12 +4,18 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
-#include <AK/Platform.h>
-
 #pragma once
 
+#include <AK/Format.h>
+#include <AK/Platform.h>
+#include <LibX86/Types.h>
+#include <string.h>
+
 namespace UserspaceEmulator {
+
+constexpr u64 _inititalized_64 = 0x01010101'01010101LLU;
+constexpr u128 _initialized_128 = u128(_inititalized_64, _inititalized_64);
+constexpr u256 _initialized_256 = u256(_initialized_128, _initialized_128);
 
 template<typename T>
 class ValueAndShadowReference;
@@ -32,6 +38,12 @@ public:
 
     bool is_uninitialized() const
     {
+        if constexpr (sizeof(T) == 32)
+            return (m_shadow & _initialized_256) != _initialized_256;
+        if constexpr (sizeof(T) == 16)
+            return (m_shadow & _initialized_128) != _initialized_128;
+        if constexpr (sizeof(T) == 8)
+            return (m_shadow & _inititalized_64) != _inititalized_64;
         if constexpr (sizeof(T) == 4)
             return (m_shadow & 0x01010101) != 0x01010101;
         if constexpr (sizeof(T) == 2)
@@ -42,6 +54,12 @@ public:
 
     void set_initialized()
     {
+        if constexpr (sizeof(T) == 32)
+            m_shadow = _initialized_256;
+        if constexpr (sizeof(T) == 16)
+            m_shadow = _initialized_128;
+        if constexpr (sizeof(T) == 8)
+            m_shadow = _inititalized_64;
         if constexpr (sizeof(T) == 4)
             m_shadow = 0x01010101;
         if constexpr (sizeof(T) == 2)
@@ -68,6 +86,12 @@ public:
 
     bool is_uninitialized() const
     {
+        if constexpr (sizeof(T) == 32)
+            return (m_shadow & _initialized_256) != _initialized_256;
+        if constexpr (sizeof(T) == 16)
+            return (m_shadow & _initialized_128) != _initialized_128;
+        if constexpr (sizeof(T) == 8)
+            return (m_shadow & _inititalized_64) != _inititalized_64;
         if constexpr (sizeof(T) == 4)
             return (m_shadow & 0x01010101) != 0x01010101;
         if constexpr (sizeof(T) == 2)
@@ -92,8 +116,12 @@ private:
 template<typename T>
 ALWAYS_INLINE ValueWithShadow<T> shadow_wrap_as_initialized(T value)
 {
+    if constexpr (sizeof(T) == 32)
+        return { value, _initialized_256 };
+    if constexpr (sizeof(T) == 16)
+        return { value, _initialized_128 };
     if constexpr (sizeof(T) == 8)
-        return { value, 0x01010101'01010101LLU };
+        return { value, _inititalized_64 };
     if constexpr (sizeof(T) == 4)
         return { value, 0x01010101 };
     if constexpr (sizeof(T) == 2)
@@ -149,3 +177,7 @@ struct AK::Formatter<UserspaceEmulator::ValueWithShadow<T>> : AK::Formatter<T> {
         return Formatter<T>::format(builder, value.value());
     }
 };
+
+#undef INITIALIZED_64
+#undef INITIALIZED_128
+#undef INITIALIZED_256

--- a/Userland/Libraries/LibX86/CMakeLists.txt
+++ b/Userland/Libraries/LibX86/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     Instruction.cpp
+    Types/Formatter.cpp   
 )
 
 serenity_lib(LibX86 x86)

--- a/Userland/Libraries/LibX86/Instruction.h
+++ b/Userland/Libraries/LibX86/Instruction.h
@@ -380,6 +380,10 @@ public:
     void write32(CPU&, const Instruction&, T);
     template<typename CPU, typename T>
     void write64(CPU&, const Instruction&, T);
+    template<typename CPU, typename T>
+    void write128(CPU&, const Instruction&, T);
+    template<typename CPU, typename T>
+    void write256(CPU&, const Instruction&, T);
 
     template<typename CPU>
     typename CPU::ValueWithShadowType8 read8(CPU&, const Instruction&);
@@ -389,6 +393,10 @@ public:
     typename CPU::ValueWithShadowType32 read32(CPU&, const Instruction&);
     template<typename CPU>
     typename CPU::ValueWithShadowType64 read64(CPU&, const Instruction&);
+    template<typename CPU>
+    typename CPU::ValueWithShadowType128 read128(CPU&, const Instruction&);
+    template<typename CPU>
+    typename CPU::ValueWithShadowType256 read256(CPU&, const Instruction&);
 
     template<typename CPU>
     LogicalAddress resolve(const CPU&, const Instruction&);
@@ -680,6 +688,22 @@ ALWAYS_INLINE void MemoryOrRegisterReference::write64(CPU& cpu, const Instructio
     cpu.write_memory64(address, value);
 }
 
+template<typename CPU, typename T>
+ALWAYS_INLINE void MemoryOrRegisterReference::write128(CPU& cpu, const Instruction& insn, T value)
+{
+    VERIFY(!is_register());
+    auto address = resolve(cpu, insn);
+    cpu.write_memory128(address, value);
+}
+
+template<typename CPU, typename T>
+ALWAYS_INLINE void MemoryOrRegisterReference::write256(CPU& cpu, const Instruction& insn, T value)
+{
+    VERIFY(!is_register());
+    auto address = resolve(cpu, insn);
+    cpu.write_memory256(address, value);
+}
+
 template<typename CPU>
 ALWAYS_INLINE typename CPU::ValueWithShadowType8 MemoryOrRegisterReference::read8(CPU& cpu, const Instruction& insn)
 {
@@ -716,6 +740,22 @@ ALWAYS_INLINE typename CPU::ValueWithShadowType64 MemoryOrRegisterReference::rea
     VERIFY(!is_register());
     auto address = resolve(cpu, insn);
     return cpu.read_memory64(address);
+}
+
+template<typename CPU>
+ALWAYS_INLINE typename CPU::ValueWithShadowType128 MemoryOrRegisterReference::read128(CPU& cpu, const Instruction& insn)
+{
+    VERIFY(!is_register());
+    auto address = resolve(cpu, insn);
+    return cpu.read_memory128(address);
+}
+
+template<typename CPU>
+ALWAYS_INLINE typename CPU::ValueWithShadowType256 MemoryOrRegisterReference::read256(CPU& cpu, const Instruction& insn)
+{
+    VERIFY(!is_register());
+    auto address = resolve(cpu, insn);
+    return cpu.read_memory256(address);
 }
 
 template<typename InstructionStreamType>

--- a/Userland/Libraries/LibX86/Types.h
+++ b/Userland/Libraries/LibX86/Types.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2021, Leon Albrecht <leon2002.la@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Types/u128.h"
+#include "Types/u256.h"

--- a/Userland/Libraries/LibX86/Types/Formatter.cpp
+++ b/Userland/Libraries/LibX86/Types/Formatter.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021, Leon Albrecht <leon2002.la@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "u128.h"
+#include "u256.h"
+
+#include <AK/Format.h>
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
+#include <serenity.h>
+#include <stdio.h>
+
+void AK::Formatter<u128>::format(AK::FormatBuilder& builder, u128 value)
+{
+    if (value.high() == 0) {
+        AK::Formatter<u64> formatter { *this };
+        return formatter.format(builder, value.low());
+    }
+
+    if (m_precision.has_value())
+        VERIFY_NOT_REACHED();
+
+    if (m_mode == Mode::Pointer) {
+        // this is way to big for a pointer
+        VERIFY_NOT_REACHED();
+    }
+
+    u8 base = 0;
+    bool upper_case = false;
+    if (m_mode == Mode::Binary) {
+        base = 2;
+    } else if (m_mode == Mode::BinaryUppercase) {
+        base = 2;
+        upper_case = true;
+    } else if (m_mode == Mode::Octal) {
+        base = 8;
+    } else if (m_mode == Mode::Decimal || m_mode == Mode::Default) {
+        // FIXME: implement this
+        TODO();
+    } else if (m_mode == Mode::Hexadecimal) {
+        base = 16;
+    } else if (m_mode == Mode::HexadecimalUppercase) {
+        base = 16;
+        upper_case = true;
+    } else {
+        VERIFY_NOT_REACHED();
+    }
+
+    u16 lower_length = sizeof(u64) * 0xFF / base;
+    if (m_width.value() > lower_length) {
+        builder.put_u64(value.high(), base, m_alternative_form, upper_case, m_zero_pad, m_align, m_width.value() - lower_length, m_fill, m_sign_mode);
+        builder.put_u64(value.low(), base, false, upper_case, m_zero_pad, m_align, m_width.value(), m_fill, m_sign_mode);
+    } else {
+        builder.put_u64(value.low(), base, m_alternative_form, upper_case, m_zero_pad, m_align, m_width.value(), m_fill, m_sign_mode);
+    }
+}
+
+void AK::Formatter<u256>::format(AK::FormatBuilder& builder, u256 value)
+{
+    if (value.high() == 0) {
+        AK::Formatter<u128> formatter { *this };
+        return formatter.format(builder, value.low());
+    }
+
+    if (m_precision.has_value())
+        VERIFY_NOT_REACHED();
+
+    if (m_mode == Mode::Pointer) {
+        // this is way to big for a pointer
+        VERIFY_NOT_REACHED();
+    }
+
+    u8 base = 0;
+    bool upper_case = false;
+    if (m_mode == Mode::Binary) {
+        base = 2;
+    } else if (m_mode == Mode::BinaryUppercase) {
+        base = 2;
+        upper_case = true;
+    } else if (m_mode == Mode::Octal) {
+        base = 8;
+    } else if (m_mode == Mode::Decimal || m_mode == Mode::Default) {
+        // FIXME: implement this
+        TODO();
+    } else if (m_mode == Mode::Hexadecimal) {
+        base = 16;
+    } else if (m_mode == Mode::HexadecimalUppercase) {
+        base = 16;
+        upper_case = true;
+    } else {
+        VERIFY_NOT_REACHED();
+    }
+
+    u16 part_length = sizeof(u128) * 0xFF / base;
+    if (m_width.value() > part_length * 3) {
+        builder.put_u64(value.high().high(), base, m_alternative_form, upper_case, m_zero_pad, m_align, m_width.value() - part_length * 3, m_fill, m_sign_mode);
+        builder.put_u64(value.high().low(), base, false, upper_case, m_zero_pad, m_align, part_length, m_fill, m_sign_mode);
+        builder.put_u64(value.low().high(), base, false, upper_case, m_zero_pad, m_align, part_length, m_fill, m_sign_mode);
+        builder.put_u64(value.low().low(), base, false, upper_case, m_zero_pad, m_align, part_length, m_fill, m_sign_mode);
+    } else if (m_width.value() > part_length * 2) {
+        builder.put_u64(value.high().low(), base, m_alternative_form, upper_case, m_zero_pad, m_align, m_width.value() - part_length * 2, m_fill, m_sign_mode);
+        builder.put_u64(value.low().high(), base, false, upper_case, m_zero_pad, m_align, part_length, m_fill, m_sign_mode);
+        builder.put_u64(value.low().low(), base, false, upper_case, m_zero_pad, m_align, part_length, m_fill, m_sign_mode);
+    } else if (m_width.value() > part_length) {
+        builder.put_u64(value.low().high(), base, m_alternative_form, upper_case, m_zero_pad, m_align, m_width.value() - part_length, m_fill, m_sign_mode);
+        builder.put_u64(value.low().low(), base, false, upper_case, m_zero_pad, m_align, part_length, m_fill, m_sign_mode);
+    } else {
+        builder.put_u64(value.low().low(), base, m_alternative_form, upper_case, m_zero_pad, m_align, m_width.value(), m_fill, m_sign_mode);
+    }
+}

--- a/Userland/Libraries/LibX86/Types/u128.h
+++ b/Userland/Libraries/LibX86/Types/u128.h
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2021, Leon Albrecht <leon2002.la@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/Format.h>
+#include <AK/Types.h>
+
+namespace X86 {
+
+class u128 {
+public:
+    constexpr u128() = default;
+    template<Unsigned T>
+    constexpr u128(T val)
+        : m_low(val)
+    {
+    }
+    constexpr u128(u64 val_low, u64 val_high)
+        : m_low(val_low)
+        , m_high(val_high)
+    {
+    }
+
+    ALWAYS_INLINE u8* bytes()
+    {
+        return m_bytes;
+    }
+    ALWAYS_INLINE const u8* bytes() const
+    {
+        return m_bytes;
+    }
+
+    ALWAYS_INLINE u16* words()
+    {
+        return (u16*)m_bytes;
+    }
+    ALWAYS_INLINE const u16* words() const
+    {
+        return (const u16*)m_bytes;
+    }
+
+    ALWAYS_INLINE u32* double_words()
+    {
+        return (u32*)m_bytes;
+    }
+    ALWAYS_INLINE const u32* double_words() const
+    {
+        return (const u32*)m_bytes;
+    }
+
+    ALWAYS_INLINE constexpr u64& low()
+    {
+        return m_low;
+    }
+    ALWAYS_INLINE constexpr const u64& low() const
+    {
+        return m_low;
+    }
+
+    ALWAYS_INLINE constexpr u64& high()
+    {
+        return m_high;
+    }
+    ALWAYS_INLINE constexpr const u64& high() const
+    {
+        return m_high;
+    }
+
+    // conversion
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr operator T() const
+    {
+        return m_low;
+    }
+
+    ALWAYS_INLINE constexpr operator bool() const
+    {
+        return m_low || m_high;
+    }
+
+    // comparisons
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr bool operator==(const T& other) const
+    {
+        return (!m_high) && m_low == other;
+    }
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr bool operator!=(const T& other) const
+    {
+        return m_high || m_low != other;
+    }
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr bool operator>(const T& other) const
+    {
+        return m_high || m_low > other;
+    }
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr bool operator<(const T& other) const
+    {
+        return !m_high && m_low < other;
+    }
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr bool operator>=(const T& other) const
+    {
+        return *this == other || *this > other;
+    }
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr bool operator<=(const T& other) const
+    {
+        return *this == other || *this < other;
+    }
+
+    ALWAYS_INLINE constexpr bool operator==(const u128& other) const
+    {
+        return m_low == other.low() && m_high == other.high();
+    }
+    ALWAYS_INLINE constexpr bool operator!=(const u128& other) const
+    {
+        return m_low != other.low() || m_high != other.high();
+    }
+    ALWAYS_INLINE constexpr bool operator>(const u128& other) const
+    {
+        return m_high > other.high()
+            || (m_high == other.high() && m_low > other.low());
+    }
+    ALWAYS_INLINE constexpr bool operator<(const u128& other) const
+    {
+        return m_high < other.high()
+            || (m_high == other.high() && m_low < other.low());
+    }
+    ALWAYS_INLINE constexpr bool operator>=(const u128& other) const
+    {
+        return *this == other || *this > other;
+    }
+    ALWAYS_INLINE constexpr bool operator<=(const u128& other) const
+    {
+        return *this == other || *this < other;
+    }
+
+    // bitwise
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr T operator&(const T& other) const
+    {
+        return m_low & other;
+    }
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr u128 operator|(const T& other) const
+    {
+        return { m_low | other, m_high };
+    }
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr u128 operator^(const T& other) const
+    {
+        return { m_low ^ other, m_high };
+    }
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr u128 operator<<(const T& other) const
+    {
+        u64 overflow = m_low >> (64 - other);
+        return { m_low << other, (m_high << other) | overflow };
+    }
+    template<Unsigned T>
+    ALWAYS_INLINE constexpr u128 operator>>(const T& other) const
+    {
+        u64 underflow = m_high & other;
+        return { (m_low >> other) | (underflow << (64 - other)), m_high >> other };
+    }
+
+    ALWAYS_INLINE constexpr u128 operator&(const u128& other) const
+    {
+        return { m_low & other.low(), m_high & other.high() };
+    }
+    ALWAYS_INLINE constexpr u128 operator|(const u128& other) const
+    {
+        return { m_low | other.low(), m_high | other.high() };
+    }
+    ALWAYS_INLINE constexpr u128 operator^(const u128& other) const
+    {
+        return { m_low ^ other.low(), m_high ^ other.high() };
+    }
+
+    // bitwise assign
+    template<Unsigned T>
+    constexpr u128& operator&=(const T& other)
+    {
+        m_high = 0;
+        m_low &= other;
+        return *this;
+    }
+    template<Unsigned T>
+    constexpr u128& operator|=(const T& other)
+    {
+        m_low |= other;
+        return *this;
+    }
+    template<Unsigned T>
+    constexpr u128& operator^=(const T& other)
+    {
+        m_low ^= other;
+        return *this;
+    }
+    template<Unsigned T>
+    constexpr u128& operator>>=(const T& other)
+    {
+        *this = *this >> other;
+        return *this;
+    }
+    template<Unsigned T>
+    constexpr u128& operator<<=(const T& other)
+    {
+        *this = *this << other;
+        return *this;
+    }
+
+    constexpr u128& operator&=(const u128& other)
+    {
+        m_high &= other.high();
+        m_low &= other.low();
+        return *this;
+    }
+    constexpr u128& operator|=(const u128& other)
+    {
+        m_high |= other.high();
+        m_low |= other.low();
+        return *this;
+    }
+    constexpr u128& operator^=(const u128& other)
+    {
+        m_high ^= other.high();
+        m_low ^= other.low();
+        return *this;
+    }
+
+private:
+    union {
+        u8 m_bytes[16] = { 0 };
+        struct {
+            u64 m_low;
+            u64 m_high;
+        };
+    };
+};
+
+static_assert(sizeof(u128) == 16);
+
+template<typename T>
+concept Unsigned_128 = IsUnsigned<T> || IsSame<T, u128>;
+
+}
+
+using X86::u128;
+using X86::Unsigned_128;
+
+template<>
+struct AK::Formatter<u128> : StandardFormatter {
+    Formatter() = default;
+    explicit Formatter(StandardFormatter formatter)
+        : StandardFormatter(formatter)
+    {
+    }
+
+    void format(AK::FormatBuilder&, u128);
+};

--- a/Userland/Libraries/LibX86/Types/u256.h
+++ b/Userland/Libraries/LibX86/Types/u256.h
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2021, Leon Albrecht <leon2002.la@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "u128.h"
+
+#include <AK/Concepts.h>
+#include <AK/Format.h>
+#include <AK/Types.h>
+
+namespace X86 {
+
+class u256 {
+public:
+    constexpr u256() = default;
+    constexpr u256(u64 val)
+        : m_low(val)
+    {
+    }
+    constexpr u256(u128 val)
+        : m_low(val)
+    {
+    }
+    constexpr u256(u128 val_low, u128 val_high)
+        : m_low(val_low)
+        , m_high(val_high)
+    {
+    }
+
+    ALWAYS_INLINE u8* bytes()
+    {
+        return (u8*)this;
+    }
+    ALWAYS_INLINE const u8* bytes() const
+    {
+        return (const u8*)this;
+    }
+
+    ALWAYS_INLINE u16* words()
+    {
+        return (u16*)this;
+    }
+    ALWAYS_INLINE const u16* words() const
+    {
+        return (const u16*)this;
+    }
+
+    ALWAYS_INLINE u32* double_words()
+    {
+        return (u32*)this;
+    }
+    ALWAYS_INLINE const u32* double_words() const
+    {
+        return (const u32*)this;
+    }
+
+    ALWAYS_INLINE constexpr u128& low()
+    {
+        return m_low;
+    }
+    ALWAYS_INLINE constexpr const u128& low() const
+    {
+        return m_low;
+    }
+
+    ALWAYS_INLINE constexpr u128& high()
+    {
+        return m_high;
+    }
+    ALWAYS_INLINE constexpr const u128& high() const
+    {
+        return m_high;
+    }
+    // conversion
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr operator T() const
+    {
+        return m_low;
+    }
+
+    ALWAYS_INLINE constexpr operator bool() const
+    {
+        return m_low || m_high;
+    }
+
+    // comparisons
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr bool operator==(const T& other) const
+    {
+        return !m_high && m_low == other;
+    }
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr bool operator!=(const T& other) const
+    {
+        return m_high || m_low != other;
+    }
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr bool operator>(const T& other) const
+    {
+        return m_high || m_low > other;
+    }
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr bool operator<(const T& other) const
+    {
+        return !m_high && m_low < other;
+    }
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr bool operator>=(const T& other) const
+    {
+        return *this == other || *this > other;
+    }
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr bool operator<=(const T& other) const
+    {
+        return *this == other || *this < other;
+    }
+
+    ALWAYS_INLINE constexpr bool operator==(const u256& other) const
+    {
+        return m_low == other.low() && m_high == other.high();
+    }
+    ALWAYS_INLINE constexpr bool operator!=(const u256& other) const
+    {
+        return m_low != other.low() || m_high != other.high();
+    }
+    ALWAYS_INLINE constexpr bool operator>(const u256& other) const
+    {
+        return m_high > other.high()
+            || (m_high == other.high() && m_low > other.low());
+    }
+    ALWAYS_INLINE constexpr bool operator<(const u256& other) const
+    {
+        return m_high < other.high()
+            || (m_high == other.high() && m_low < other.low());
+    }
+    ALWAYS_INLINE constexpr bool operator>=(const u256& other) const
+    {
+        return *this == other || *this > other;
+    }
+    ALWAYS_INLINE constexpr bool operator<=(const u256& other) const
+    {
+        return *this == other || *this < other;
+    }
+
+    // bitwise
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr T operator&(const T& other) const
+    {
+        return m_low & other;
+    }
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr u256 operator|(const T& other) const
+    {
+        return { m_low | other, m_high };
+    }
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr u256 operator^(const T& other) const
+    {
+        return { m_low ^ other, m_high };
+    }
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr u256 operator<<(const T& other) const
+    {
+        u128 overflow = m_low >> (128 - other);
+        return { m_low << other, (m_high << other) | overflow };
+    }
+    template<Unsigned_128 T>
+    ALWAYS_INLINE constexpr u256 operator>>(const T& other) const
+    {
+        u128 underflow = m_high & other;
+        return { (m_low >> other) | (underflow << (128 - other)), m_high >> other };
+    }
+
+    ALWAYS_INLINE constexpr u256 operator&(const u256& other) const
+    {
+        return { m_low & other.low(), m_high & other.high() };
+    }
+    ALWAYS_INLINE constexpr u256 operator|(const u256& other) const
+    {
+        return { m_low | other.low(), m_high | other.high() };
+    }
+    ALWAYS_INLINE constexpr u256 operator^(const u256& other) const
+    {
+        return { m_low ^ other.low(), m_high ^ other.high() };
+    }
+
+    // bitwise assign
+    template<Unsigned_128 T>
+    constexpr u256& operator&=(const T& other)
+    {
+        m_high = 0;
+        m_low &= other;
+        return *this;
+    }
+    template<Unsigned_128 T>
+    constexpr u256& operator|=(const T& other)
+    {
+        m_low |= other;
+        return *this;
+    }
+    template<Unsigned_128 T>
+    constexpr u256& operator^=(const T& other)
+    {
+        m_low ^= other;
+        return *this;
+    }
+    template<Unsigned_128 T>
+    constexpr u256& operator>>=(const T& other)
+    {
+        *this = *this >> other;
+        return *this;
+    }
+    template<Unsigned_128 T>
+    constexpr u256& operator<<=(const T& other)
+    {
+        *this = *this << other;
+        return *this;
+    }
+
+    constexpr u256& operator&=(const u256& other)
+    {
+        m_high &= other.high();
+        m_low &= other.low();
+        return *this;
+    }
+    constexpr u256& operator|=(const u256& other)
+    {
+        m_high |= other.high();
+        m_low |= other.low();
+        return *this;
+    }
+    constexpr u256& operator^=(const u256& other)
+    {
+        m_high ^= other.high();
+        m_low ^= other.low();
+        return *this;
+    }
+
+private:
+    // FIXME: Somehow make this a union to directly expose the bytes (see u128)
+    u128 m_low {};
+    u128 m_high {};
+};
+
+static_assert(sizeof(u256) == 32);
+
+template<typename T>
+concept Unsigned_256 = IsUnsigned<T> || IsSame<T, u128> || IsSame<T, u256>;
+
+}
+
+using X86::u256;
+using X86::Unsigned_256;
+
+template<>
+struct AK::Formatter<u256> : StandardFormatter {
+    Formatter() = default;
+    explicit Formatter(StandardFormatter formatter)
+        : StandardFormatter(formatter)
+    {
+    }
+
+    void format(AK::FormatBuilder&, u256);
+};


### PR DESCRIPTION
* Adds support for 128/256 bit reads and writes
* ~Adds support for Packed Data and operations upon them~
* Adds FLD_RM80 and FSTP_RM80 instruction support

Known Issues:
* ~u256 is not constexpr'nable, at least not in a neat way due to u128 not being "trivially constructible"~ u128 and u256 are not trivially contructable
* narrowing conversions from u128/u256 down are not marked by the compiler
* ~the name of the Packed data containers is not that good (is it even in the right place?)~ deleted for now
* We could do two reads/writes for f80 instead of one too big one

Side Note:
* long double's are weird with their supposed size