### PR TITLE
LibWeb: Implement Node.isConnected and Node.compareDocumentPosition

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -100,6 +100,7 @@ public:
     void insert_before(NonnullRefPtr<Node> node, RefPtr<Node> child, bool suppress_observers = false);
     void remove(bool suppress_observers = false);
     void remove_all_children(bool suppress_observers = false);
+    u16 compare_document_position(RefPtr<Node> other);
 
     // NOTE: This is intended for the JS bindings.
     bool has_child_nodes() const { return has_children(); }

--- a/Userland/Libraries/LibWeb/DOM/Node.idl
+++ b/Userland/Libraries/LibWeb/DOM/Node.idl
@@ -32,4 +32,12 @@ interface Node : EventTarget {
     const unsigned short DOCUMENT_FRAGMENT_NODE = 11;
     const unsigned short NOTATION_NODE = 12;
 
+    unsigned short compareDocumentPosition(Node? otherNode);
+    // Node.compareDocumentPosition() constants
+    const unsigned short DOCUMENT_POSITION_DISCONNECTED = 1;
+    const unsigned short DOCUMENT_POSITION_PRECEDING = 2;
+    const unsigned short DOCUMENT_POSITION_FOLLOWING = 4;
+    const unsigned short DOCUMENT_POSITION_CONTAINS = 8;
+    const unsigned short DOCUMENT_POSITION_CONTAINED_BY = 16;
+    const unsigned short DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32;
 };

--- a/Userland/Libraries/LibWeb/DOM/Node.idl
+++ b/Userland/Libraries/LibWeb/DOM/Node.idl
@@ -12,6 +12,7 @@ interface Node : EventTarget {
     readonly attribute Node? nextSibling;
     readonly attribute Node? parentNode;
     readonly attribute Element? parentElement;
+    readonly attribute boolean isConnected;
     attribute DOMString textContent;
 
     Node appendChild(Node node);

--- a/Userland/Libraries/LibWeb/Tests/DOM/Node.js
+++ b/Userland/Libraries/LibWeb/Tests/DOM/Node.js
@@ -25,4 +25,15 @@ afterInitialPageLoad(() => {
             HIDDEN TEXT
         `);
     });
+
+    test("Node.isConnected", () => {
+        var element = document.createElement("p");
+        expect(element.isConnected).toBeFalse();
+
+        document.body.appendChild(element);
+        expect(element.isConnected).toBeTrue();
+
+        document.body.removeChild(element);
+        expect(element.isConnected).toBeFalse();
+    });
 });

--- a/Userland/Libraries/LibWeb/Tests/DOM/Node.js
+++ b/Userland/Libraries/LibWeb/Tests/DOM/Node.js
@@ -36,4 +36,27 @@ afterInitialPageLoad(() => {
         document.body.removeChild(element);
         expect(element.isConnected).toBeFalse();
     });
+
+    test("Node.compareDocumentPosition()", () => {
+        const head = document.head;
+        const body = document.body;
+
+        expect(head.compareDocumentPosition(head)).toBe(0);
+
+        // FIXME: Can be uncommented once the IDL parser correctly implements nullable paramaters.
+        // expect(head.compareDocumentPosition(null) & Node.DOCUMENT_POSITION_DISCONNECTED | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC).
+        //    toBe(Node.DOCUMENT_POSITION_DISCONNECTED | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC);
+
+        expect(head.compareDocumentPosition(body)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+        expect(body.compareDocumentPosition(head)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
+
+        const source = document.getElementById("source");
+        expect(source.compareDocumentPosition(body)).toBe(
+            Node.DOCUMENT_POSITION_CONTAINS | Node.DOCUMENT_POSITION_PRECEDING
+        );
+        expect(body.compareDocumentPosition(source)).toBe(
+            Node.DOCUMENT_POSITION_CONTAINED_BY | Node.DOCUMENT_POSITION_FOLLOWING
+        );
+        expect(source.compareDocumentPosition(head)).toBe(Node.DOCUMENT_POSITION_PRECEDING);
+    });
 });


### PR DESCRIPTION
While looking into getting Duck Duck Go loading further in the
Browser, I noticed that it was complaining about the missing
method `Node.compareDocumentPosition()`.

This change implements as much of the DOM spec as possible
with the current implementation of the DOM to date. The
implementation is validated by new tests in the Node.js.

I also saw the `Node.isConnected` property and implemented it, as it was
already implemented in the C++ object model. That brings the
browser closer to standards conformance.