### PR TITLE
Shell: add `type` builtin

### DIFF
--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -1010,6 +1010,8 @@ bool Shell::run_builtin(const AST::Command& command, const NonnullRefPtrVector<A
         retval = builtin_##builtin(argv.size() - 1, argv.data());        \
         if (!has_error(ShellError::None))                                \
             raise_error(m_error, m_error_description, command.position); \
+        fflush(stdout);                                                  \
+        fflush(stderr);                                                  \
         return true;                                                     \
     }
 

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -45,6 +45,7 @@
     __ENUMERATE_SHELL_BUILTIN(cd)      \
     __ENUMERATE_SHELL_BUILTIN(cdh)     \
     __ENUMERATE_SHELL_BUILTIN(pwd)     \
+    __ENUMERATE_SHELL_BUILTIN(type)    \
     __ENUMERATE_SHELL_BUILTIN(exec)    \
     __ENUMERATE_SHELL_BUILTIN(exit)    \
     __ENUMERATE_SHELL_BUILTIN(export)  \

--- a/Userland/Shell/Tests/builtin-test.sh
+++ b/Userland/Shell/Tests/builtin-test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+source $(dirname "$0")/test-commons.inc
+
+
+if not [ "$(type ls)" = "ls is $(which ls)" ] { fail "'type' on a binary not working" }
+
+if not [ "$(type pwd)" = "pwd is a shell builtin" ] { fail "'type' on a builtin not working" }
+
+f() { ls }
+
+if not [ "$(type f)" = "f is a function f() { ls }" ] { fail "'type' on a function not working" }
+
+
+if not [ "$(type f -f)" = "f is a function" ] { fail "'type' on a function not working with -f" }
+
+alias l=ls
+
+if not [ "$(type l)" = "l is aliased to `ls`" ] { fail "'type' on a alias not working" }
+
+
+if not [ "$(type l ls)" = "l is aliased to `ls` ls is $(which ls)" ] { fail "'type' on multiple commands not working" }
+
+echo PASS


### PR DESCRIPTION
This is my first pr, so please tell me if something is non-idomatic or wrong :^).
![image](https://user-images.githubusercontent.com/58830309/114291303-5c377200-9a54-11eb-8b17-6c597e887484.png)
In bash, type on a function shows the source (I quite like this feature), but I couldn't figure out how to get source of a function from a `Node` so I left it as a fixme. If anyone knows, please tell me and I'll add it!