### PR TITLE
AK + LibWeb + LibGUI + Base: Grab bag of small improvements 

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -104,7 +104,7 @@ struct TypeBoundsChecker<Destination, Source, true, true, false> {
 };
 
 template<typename Destination, typename Source>
-constexpr bool is_within_range(Source value)
+[[nodiscard]] constexpr bool is_within_range(Source value)
 {
     return TypeBoundsChecker<Destination, Source>::is_within_range(value);
 }
@@ -149,7 +149,7 @@ public:
         return *this;
     }
 
-    constexpr bool has_overflow() const
+    [[nodiscard]] constexpr bool has_overflow() const
     {
         return m_overflow;
     }
@@ -265,7 +265,7 @@ public:
     }
 
     template<typename U, typename V>
-    static constexpr bool addition_would_overflow(U u, V v)
+    [[nodiscard]] static constexpr bool addition_would_overflow(U u, V v)
     {
 #ifdef __clang__
         Checked checked;
@@ -278,7 +278,7 @@ public:
     }
 
     template<typename U, typename V>
-    static constexpr bool multiplication_would_overflow(U u, V v)
+    [[nodiscard]] static constexpr bool multiplication_would_overflow(U u, V v)
     {
 #ifdef __clang__
         Checked checked;
@@ -291,7 +291,7 @@ public:
     }
 
     template<typename U, typename V, typename X>
-    static constexpr bool multiplication_would_overflow(U u, V v, X x)
+    [[nodiscard]] static constexpr bool multiplication_would_overflow(U u, V v, X x)
     {
         Checked checked;
         checked = u;

--- a/AK/DoublyLinkedList.h
+++ b/AK/DoublyLinkedList.h
@@ -44,7 +44,7 @@ public:
     }
     ElementType& operator*() { return m_node->value; }
     ElementType* operator->() { return &m_node->value; }
-    bool is_end() const { return !m_node; }
+    [[nodiscard]] bool is_end() const { return !m_node; }
     static DoublyLinkedListIterator universal_end() { return DoublyLinkedListIterator(nullptr); }
 
 private:
@@ -76,7 +76,7 @@ public:
     DoublyLinkedList() = default;
     ~DoublyLinkedList() { clear(); }
 
-    bool is_empty() const { return !m_head; }
+    [[nodiscard]] bool is_empty() const { return !m_head; }
 
     void clear()
     {
@@ -89,22 +89,22 @@ public:
         m_tail = nullptr;
     }
 
-    T& first()
+    [[nodiscard]] T& first()
     {
         VERIFY(m_head);
         return m_head->value;
     }
-    const T& first() const
+    [[nodiscard]] const T& first() const
     {
         VERIFY(m_head);
         return m_head->value;
     }
-    T& last()
+    [[nodiscard]] T& last()
     {
         VERIFY(m_head);
         return m_tail->value;
     }
-    const T& last() const
+    [[nodiscard]] const T& last() const
     {
         VERIFY(m_head);
         return m_tail->value;
@@ -147,7 +147,7 @@ public:
         m_head = node;
     }
 
-    bool contains_slow(const T& value) const
+    [[nodiscard]] bool contains_slow(const T& value) const
     {
         return find(value) != end();
     }

--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -64,12 +64,12 @@ public:
     }
 #endif
 
-    bool is_empty() const
+    [[nodiscard]] bool is_empty() const
     {
         return m_table.is_empty();
     }
-    size_t size() const { return m_table.size(); }
-    size_t capacity() const { return m_table.capacity(); }
+    [[nodiscard]] size_t size() const { return m_table.size(); }
+    [[nodiscard]] size_t capacity() const { return m_table.capacity(); }
     void clear() { m_table.clear(); }
 
     HashSetResult set(const K& key, const V& value) { return m_table.set({ key, value }); }

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -142,9 +142,9 @@ public:
         swap(a.m_deleted_count, b.m_deleted_count);
     }
 
-    bool is_empty() const { return !m_size; }
-    size_t size() const { return m_size; }
-    size_t capacity() const { return m_capacity; }
+    [[nodiscard]] bool is_empty() const { return !m_size; }
+    [[nodiscard]] size_t size() const { return m_size; }
+    [[nodiscard]] size_t capacity() const { return m_capacity; }
 
     template<typename U, size_t N>
     void set_from(U (&from_array)[N])
@@ -352,8 +352,8 @@ private:
         }
     }
 
-    size_t used_bucket_count() const { return m_size + m_deleted_count; }
-    bool should_grow() const { return ((used_bucket_count() + 1) * 100) >= (m_capacity * load_factor_in_percent); }
+    [[nodiscard]] size_t used_bucket_count() const { return m_size + m_deleted_count; }
+    [[nodiscard]] bool should_grow() const { return ((used_bucket_count() + 1) * 100) >= (m_capacity * load_factor_in_percent); }
 
     Bucket* m_buckets { nullptr };
     size_t m_size { 0 };

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -87,7 +87,7 @@ class HashTable {
 
 public:
     HashTable() = default;
-    HashTable(size_t capacity) { rehash(capacity); }
+    explicit HashTable(size_t capacity) { rehash(capacity); }
 
     ~HashTable()
     {

--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -47,16 +47,16 @@ public:
     ~IntrusiveList();
 
     void clear();
-    bool is_empty() const;
+    [[nodiscard]] bool is_empty() const;
     void append(T& n);
     void prepend(T& n);
     void remove(T& n);
-    bool contains(const T&) const;
-    T* first() const;
-    T* last() const;
+    [[nodiscard]] bool contains(const T&) const;
+    [[nodiscard]] T* first() const;
+    [[nodiscard]] T* last() const;
 
-    T* take_first();
-    T* take_last();
+    [[nodiscard]] T* take_first();
+    [[nodiscard]] T* take_last();
 
     class Iterator {
     public:

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -57,15 +57,15 @@ public:
         vformat(*this, fmtstr.view(), VariadicFormatParams { parameters... });
     }
 
-    String build() const;
-    String to_string() const;
-    ByteBuffer to_byte_buffer() const;
+    [[nodiscard]] String build() const;
+    [[nodiscard]] String to_string() const;
+    [[nodiscard]] ByteBuffer to_byte_buffer() const;
 
-    StringView string_view() const;
+    [[nodiscard]] StringView string_view() const;
     void clear();
 
-    size_t length() const { return m_length; }
-    bool is_empty() const { return m_length == 0; }
+    [[nodiscard]] size_t length() const { return m_length; }
+    [[nodiscard]] bool is_empty() const { return m_length == 0; }
     void trim(size_t count) { m_length -= count; }
 
     template<class SeparatorType, class CollectionType>

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -65,34 +65,34 @@ public:
     StringView(const String&);
     StringView(const FlyString&);
 
-    bool is_null() const { return !m_characters; }
-    bool is_empty() const { return m_length == 0; }
+    [[nodiscard]] bool is_null() const { return !m_characters; }
+    [[nodiscard]] bool is_empty() const { return m_length == 0; }
 
-    const char* characters_without_null_termination() const { return m_characters; }
-    size_t length() const { return m_length; }
+    [[nodiscard]] const char* characters_without_null_termination() const { return m_characters; }
+    [[nodiscard]] size_t length() const { return m_length; }
 
-    ReadonlyBytes bytes() const { return { m_characters, m_length }; }
+    [[nodiscard]] ReadonlyBytes bytes() const { return { m_characters, m_length }; }
 
     const char& operator[](size_t index) const { return m_characters[index]; }
 
     using ConstIterator = SimpleIterator<const StringView, const char>;
 
-    constexpr ConstIterator begin() const { return ConstIterator::begin(*this); }
-    constexpr ConstIterator end() const { return ConstIterator::end(*this); }
+    [[nodiscard]] constexpr ConstIterator begin() const { return ConstIterator::begin(*this); }
+    [[nodiscard]] constexpr ConstIterator end() const { return ConstIterator::end(*this); }
 
-    unsigned hash() const;
+    [[nodiscard]] unsigned hash() const;
 
-    bool starts_with(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
-    bool ends_with(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
-    bool starts_with(char) const;
-    bool ends_with(char) const;
-    bool matches(const StringView& mask, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;
-    bool matches(const StringView& mask, Vector<MaskSpan>&, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;
-    bool contains(char) const;
-    bool contains(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
-    bool equals_ignoring_case(const StringView& other) const;
+    [[nodiscard]] bool starts_with(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
+    [[nodiscard]] bool ends_with(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
+    [[nodiscard]] bool starts_with(char) const;
+    [[nodiscard]] bool ends_with(char) const;
+    [[nodiscard]] bool matches(const StringView& mask, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;
+    [[nodiscard]] bool matches(const StringView& mask, Vector<MaskSpan>&, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;
+    [[nodiscard]] bool contains(char) const;
+    [[nodiscard]] bool contains(const StringView&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
+    [[nodiscard]] bool equals_ignoring_case(const StringView& other) const;
 
-    StringView trim_whitespace(TrimMode mode = TrimMode::Both) const { return StringUtils::trim_whitespace(*this, mode); }
+    [[nodiscard]] StringView trim_whitespace(TrimMode mode = TrimMode::Both) const { return StringUtils::trim_whitespace(*this, mode); }
 
     Optional<size_t> find_first_of(char) const;
     Optional<size_t> find_first_of(const StringView&) const;
@@ -103,16 +103,16 @@ public:
     Optional<size_t> find(const StringView&) const;
     Optional<size_t> find(char c) const;
 
-    StringView substring_view(size_t start, size_t length) const;
-    StringView substring_view(size_t start) const;
-    Vector<StringView> split_view(char, bool keep_empty = false) const;
-    Vector<StringView> split_view(const StringView&, bool keep_empty = false) const;
+    [[nodiscard]] StringView substring_view(size_t start, size_t length) const;
+    [[nodiscard]] StringView substring_view(size_t start) const;
+    [[nodiscard]] Vector<StringView> split_view(char, bool keep_empty = false) const;
+    [[nodiscard]] Vector<StringView> split_view(const StringView&, bool keep_empty = false) const;
 
     // Create a Vector of StringViews split by line endings. As of CommonMark
     // 0.29, the spec defines a line ending as "a newline (U+000A), a carriage
     // return (U+000D) not followed by a newline, or a carriage return and a
     // following newline.".
-    Vector<StringView> lines(bool consider_cr = true) const;
+    [[nodiscard]] Vector<StringView> lines(bool consider_cr = true) const;
 
     template<typename T = int>
     Optional<T> to_int() const;
@@ -135,8 +135,8 @@ public:
     //     StringView substr { "oo" };
     //
     // would not work.
-    StringView substring_view_starting_from_substring(const StringView& substring) const;
-    StringView substring_view_starting_after_substring(const StringView& substring) const;
+    [[nodiscard]] StringView substring_view_starting_from_substring(const StringView& substring) const;
+    [[nodiscard]] StringView substring_view_starting_after_substring(const StringView& substring) const;
 
     bool operator==(const char* cstring) const
     {
@@ -187,12 +187,12 @@ public:
 
     const StringImpl* impl() const { return m_impl; }
 
-    String to_string() const;
+    [[nodiscard]] String to_string() const;
 
-    bool is_whitespace() const { return StringUtils::is_whitespace(*this); }
+    [[nodiscard]] bool is_whitespace() const { return StringUtils::is_whitespace(*this); }
 
     template<typename T, typename... Rest>
-    bool is_one_of(const T& string, Rest... rest) const
+    [[nodiscard]] bool is_one_of(const T& string, Rest... rest) const
     {
         if (*this == string)
             return true;
@@ -200,7 +200,7 @@ public:
     }
 
 private:
-    bool is_one_of() const { return false; }
+    [[nodiscard]] bool is_one_of() const { return false; }
 
     friend class String;
     const StringImpl* m_impl { nullptr };

--- a/AK/Trie.h
+++ b/AK/Trie.h
@@ -201,7 +201,7 @@ public:
     ConstIterator begin() const { return ConstIterator(*this); }
     ConstIterator end() const { return ConstIterator::end(); }
 
-    bool is_empty() const { return m_children.is_empty(); }
+    [[nodiscard]] bool is_empty() const { return m_children.is_empty(); }
     void clear() { m_children.clear(); }
 
     BaseType deep_copy()

--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -143,7 +143,7 @@ public:
         return *this;
     }
 
-    RefPtr<T> strong_ref() const
+    [[nodiscard]] RefPtr<T> strong_ref() const
     {
         // This only works with RefCounted objects, but it is the only
         // safe way to get a strong reference from a WeakPtr. Any code
@@ -169,7 +169,7 @@ public:
     operator T*() { return unsafe_ptr(); }
 #endif
 
-    T* unsafe_ptr() const
+    [[nodiscard]] T* unsafe_ptr() const
     {
         T* ptr = nullptr;
         m_link.do_while_locked([&](WeakLink* link) {
@@ -181,10 +181,10 @@ public:
 
     operator bool() const { return m_link ? !m_link->is_null() : false; }
 
-    bool is_null() const { return !m_link || m_link->is_null(); }
+    [[nodiscard]] bool is_null() const { return !m_link || m_link->is_null(); }
     void clear() { m_link = nullptr; }
 
-    RefPtr<WeakLink> take_link() { return move(m_link); }
+    [[nodiscard]] RefPtr<WeakLink> take_link() { return move(m_link); }
 
 private:
     WeakPtr(const RefPtr<WeakLink>& link)

--- a/Base/home/anon/tests/run-tests-and-shutdown.sh
+++ b/Base/home/anon/tests/run-tests-and-shutdown.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+echo
 echo "==== Running Tests on SerenityOS ===="
 
 run(index) {

--- a/Userland/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.cpp
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <AK/Debug.h>
 #include <AK/JsonObject.h>
 #include <LibCore/File.h>
 #include <LibGUI/JsonArrayModel.h>

--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -606,7 +606,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
         dbgln("Unimplemented JS-to-C++ conversion: {}", parameter.type.name);
         VERIFY_NOT_REACHED();
     }
-};
+}
 
 template<typename FunctionType>
 static void generate_argument_count_check(SourceGenerator& generator, FunctionType& function)
@@ -631,7 +631,7 @@ static void generate_argument_count_check(SourceGenerator& generator, FunctionTy
         return {};
     }
 )~~~");
-};
+}
 
 static void generate_arguments(SourceGenerator& generator, const Vector<IDL::Parameter>& parameters, StringBuilder& arguments_builder, bool return_void = false)
 {
@@ -652,7 +652,7 @@ static void generate_arguments(SourceGenerator& generator, const Vector<IDL::Par
     }
 
     arguments_builder.join(", ", parameter_names);
-};
+}
 
 static void generate_header(const IDL::Interface& interface)
 {


### PR DESCRIPTION
- AK: Mark more things [[nodiscard]], make certain constructors explicit,

- LibWeb: Remove trailing ';' from WrapperGenerator functions.

- LibGUI: Remove an unused `AK/Debug.h` include

- Base: Make CI Test output slightly better with a newline.  