### PR TITLE
TextEditor: Allow Binary files to be opened

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -190,7 +190,11 @@ bool TextDocumentLine::set_text(TextDocument& document, const StringView& text)
     m_text.clear();
     Utf8View utf8_view(text);
     if (!utf8_view.validate()) {
-        return false;
+        for (const auto& c : text) {
+            m_text.append(c);
+        }
+
+        return true;
     }
     for (auto code_point : utf8_view)
         m_text.append(code_point);


### PR DESCRIPTION
When the Utf8 validation fails we are just showing what we get, we can add more encodings here in the future instead. 