### PR TITLE
ls: ls will print directory name when listing multiple directories

### DIFF
--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -145,8 +145,22 @@ int main(int argc, char** argv)
     } else if (paths.size() == 1) {
         status = do_file_system_object(paths[0]);
     } else {
+        Vector<const char*> exists;
         for (auto& path : paths) {
+            if (Core::File::exists(path)) {
+                exists.append(path);
+            } else {
+                status = do_file_system_object(path);
+            }
+        }
+        for (size_t i = 0; i < exists.size(); ++i) {
+            auto path = exists.at(i);
+            printf("%s:\n", path);
             status = do_file_system_object(path);
+
+            if (i + 1 == exists.size() - 1) {
+                printf("\n");
+            }
         }
     }
     return status;


### PR DESCRIPTION
Makes serenity ls behave like other unix ls when listing multiple directories by printing the path before listing its content.
GNU ls:
![ls_debian](https://user-images.githubusercontent.com/61476054/114309167-96515400-9ae6-11eb-8534-8a375537a583.png)

openbsd ls:
![ls_openbsd](https://user-images.githubusercontent.com/61476054/114309481-7f5f3180-9ae7-11eb-8ed4-57fa1d00b396.png)

serenity ls before:
![ls_serenity_before](https://user-images.githubusercontent.com/61476054/114309305-052ead00-9ae7-11eb-8d12-f372713f6a37.png)

serenity ls after:
![ls_serenity_final](https://user-images.githubusercontent.com/61476054/114309005-04494b80-9ae6-11eb-9e92-048f4db66b37.png)

