### PR TITLE
Browser+LibWeb+WebContent: Intial support for cookies

### DIFF
--- a/Base/res/html/misc/cookie.html
+++ b/Base/res/html/misc/cookie.html
@@ -1,0 +1,15 @@
+<body>
+    <input type=button onclick="setCookie('cookie1=value1')" value="Set Cookie 1" />
+    <input type=button onclick="setCookie('cookie2=value2')" value="Set Cookie 2" />
+    <input type=button onclick="setCookie('cookie3=value3')" value="Set Cookie 3" />
+    <br /><pre id=cookies></pre>
+
+    <script>
+        function setCookie(cookie) {
+            document.cookie = cookie;
+            document.getElementById('cookies').innerHTML = document.cookie;
+        }
+
+        document.getElementById('cookies').innerHTML = document.cookie;
+    </script>
+</body>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -38,6 +38,7 @@ span#loadtime {
     <p>This page loaded in <b><span id="loadtime"></span></b> ms</p>
     <p>Some small test pages:</p>
     <ul>
+        <li><a href="cookie.html">document.cookie</a></li>
         <li><a href="last-of-type.html">CSS :last-of-type selector</a></li>
         <li><a href="first-of-type.html">CSS :first-of-type selector</a></li>
         <li><a href="background-repeat-test.html">background image with repetition rules</a></li>

--- a/Userland/Applications/Browser/CMakeLists.txt
+++ b/Userland/Applications/Browser/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     BookmarksBarWidget.cpp
     BrowserConsoleClient.cpp
     ConsoleWidget.cpp
+    CookieJar.cpp
     DownloadWidget.cpp
     History.cpp
     InspectorWidget.cpp

--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CookieJar.h"
+#include <AK/URL.h>
+
+namespace Browser {
+
+String CookieJar::get_cookie(const URL& url) const
+{
+    auto domain = canonicalize_domain(url);
+    if (!domain.has_value())
+        return {};
+
+    StringBuilder builder;
+
+    if (auto it = m_cookies.find(*domain); it != m_cookies.end()) {
+        for (const auto& cookie : it->value) {
+            if (!builder.is_empty())
+                builder.append("; ");
+            builder.appendff("{}={}", cookie.name, cookie.value);
+        }
+    }
+
+    return builder.build();
+}
+
+void CookieJar::set_cookie(const URL& url, const String& cookie_string)
+{
+    auto domain = canonicalize_domain(url);
+    if (!domain.has_value())
+        return;
+
+    auto new_cookie = parse_cookie(cookie_string);
+    if (!new_cookie.has_value())
+        return;
+
+    auto it = m_cookies.find(*domain);
+    if (it == m_cookies.end()) {
+        m_cookies.set(*domain, { move(*new_cookie) });
+        return;
+    }
+
+    for (auto& cookie : it->value) {
+        if (cookie.name == new_cookie->name) {
+            cookie = move(*new_cookie);
+            return;
+        }
+    }
+
+    it->value.append(move(*new_cookie));
+}
+
+Optional<String> CookieJar::canonicalize_domain(const URL& url)
+{
+    // https://tools.ietf.org/html/rfc6265#section-5.1.2
+    if (!url.is_valid())
+        return {};
+
+    // FIXME: Implement RFC 5890 to "Convert each label that is not a Non-Reserved LDH (NR-LDH) label to an A-label".
+    return url.host().to_lowercase();
+}
+
+Optional<Cookie> CookieJar::parse_cookie(const String& cookie_string)
+{
+    // https://tools.ietf.org/html/rfc6265#section-5.2
+    StringView name_value_pair;
+
+    // 1. If the set-cookie-string contains a %x3B (";") character:
+    if (auto position = cookie_string.find(';'); position.has_value()) {
+        // The name-value-pair string consists of the characters up to, but not including, the first %x3B (";"), and the unparsed-
+        // attributes consist of the remainder of the set-cookie-string (including the %x3B (";") in question).
+
+        // FIXME: Support optional cookie attributes. For now, ignore those attributes.
+        name_value_pair = cookie_string.substring_view(0, position.value());
+    } else {
+        // The name-value-pair string consists of all the characters contained in the set-cookie-string, and the unparsed-
+        // attributes is the empty string.
+        name_value_pair = cookie_string;
+    }
+
+    StringView name;
+    StringView value;
+
+    if (auto position = name_value_pair.find('='); position.has_value()) {
+        // 3. The (possibly empty) name string consists of the characters up to, but not including, the first %x3D ("=") character, and the
+        //    (possibly empty) value string consists of the characters after the first %x3D ("=") character.
+        name = name_value_pair.substring_view(0, position.value());
+
+        if (position.value() < name_value_pair.length() - 1)
+            value = name_value_pair.substring_view(position.value() + 1);
+    } else {
+        // 2. If the name-value-pair string lacks a %x3D ("=") character, ignore the set-cookie-string entirely.
+        return {};
+    }
+
+    // 4. Remove any leading or trailing WSP characters from the name string and the value string.
+    name = name.trim_whitespace();
+    value = value.trim_whitespace();
+
+    // 5. If the name string is empty, ignore the set-cookie-string entirely.
+    if (name.is_empty())
+        return {};
+
+    // 6. The cookie-name is the name string, and the cookie-value is the value string.
+    return Cookie { name, value };
+}
+
+}

--- a/Userland/Applications/Browser/CookieJar.h
+++ b/Userland/Applications/Browser/CookieJar.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+
+namespace Browser {
+
+struct Cookie {
+    String name;
+    String value;
+};
+
+class CookieJar {
+public:
+    String get_cookie(const URL& url) const;
+    void set_cookie(const URL& url, const String& cookie);
+
+private:
+    static Optional<String> canonicalize_domain(const URL& url);
+    static Optional<Cookie> parse_cookie(const String& cookie_string);
+
+    HashMap<String, Vector<Cookie>> m_cookies;
+};
+
+}

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -242,6 +242,17 @@ Tab::Tab(Type type)
             on_favicon_change(icon);
     };
 
+    hooks().on_get_cookie = [this](auto& url) -> String {
+        if (on_get_cookie)
+            return on_get_cookie(url);
+        return {};
+    };
+
+    hooks().on_set_cookie = [this](auto& url, auto& cookie) {
+        if (on_set_cookie)
+            on_set_cookie(url, cookie);
+    };
+
     hooks().on_get_source = [this](auto& url, auto& source) {
         view_source(url, source);
     };

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -70,6 +70,8 @@ public:
     Function<void(const URL&)> on_tab_open_request;
     Function<void(Tab&)> on_tab_close_request;
     Function<void(const Gfx::Bitmap&)> on_favicon_change;
+    Function<String(const URL& url)> on_get_cookie;
+    Function<void(const URL& url, const String& cookie)> on_set_cookie;
 
     const String& title() const { return m_title; }
     const Gfx::Bitmap* icon() const { return m_icon; }

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -26,6 +26,7 @@
 
 #include "BookmarksBarWidget.h"
 #include "Browser.h"
+#include "CookieJar.h"
 #include "Tab.h"
 #include "WindowActions.h"
 #include <AK/StringBuilder.h>
@@ -148,6 +149,8 @@ int main(int argc, char** argv)
     bool bookmarksbar_enabled = true;
     auto bookmarks_bar = Browser::BookmarksBarWidget::construct(Browser::bookmarks_file_path(), bookmarksbar_enabled);
 
+    Browser::CookieJar cookie_jar;
+
     auto window = GUI::Window::construct();
     window->resize(640, 480);
     window->set_icon(app_icon.bitmap_for_size(16));
@@ -214,6 +217,14 @@ int main(int argc, char** argv)
                 if (tab_widget.children().is_empty())
                     app->quit();
             });
+        };
+
+        new_tab.on_get_cookie = [&](auto& url) -> String {
+            return cookie_jar.get_cookie(url);
+        };
+
+        new_tab.on_set_cookie = [&](auto& url, auto& cookie) {
+            cookie_jar.set_cookie(url, cookie);
         };
 
         new_tab.load(url);

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -825,15 +825,17 @@ void Document::completely_finish_loading()
     dispatch_event(DOM::Event::create(HTML::EventNames::load));
 }
 
-String Document::cookie() const
+String Document::cookie()
 {
-    // FIXME: Support cookies!
+    if (auto* page = this->page())
+        return page->client().page_did_request_cookie(m_url);
     return {};
 }
 
-void Document::set_cookie(String)
+void Document::set_cookie(String cookie)
 {
-    // FIXME: Support cookies!
+    if (auto* page = this->page())
+        page->client().page_did_set_cookie(m_url, cookie);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -73,7 +73,7 @@ public:
 
     virtual ~Document() override;
 
-    String cookie() const;
+    String cookie();
     void set_cookie(String);
 
     bool should_invalidate_styles_on_attribute_changes() const { return m_should_invalidate_styles_on_attribute_changes; }

--- a/Userland/Libraries/LibWeb/InProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/InProcessWebView.cpp
@@ -433,4 +433,17 @@ String InProcessWebView::page_did_request_prompt(const String& message, const St
     return {};
 }
 
+String InProcessWebView::page_did_request_cookie(const URL& url)
+{
+    if (on_get_cookie)
+        return on_get_cookie(url);
+    return {};
+}
+
+void InProcessWebView::page_did_set_cookie(const URL& url, const String& cookie)
+{
+    if (on_set_cookie)
+        on_set_cookie(url, cookie);
+}
+
 }

--- a/Userland/Libraries/LibWeb/InProcessWebView.h
+++ b/Userland/Libraries/LibWeb/InProcessWebView.h
@@ -111,6 +111,8 @@ private:
     virtual void page_did_request_alert(const String&) override;
     virtual bool page_did_request_confirm(const String&) override;
     virtual String page_did_request_prompt(const String&, const String&) override;
+    virtual String page_did_request_cookie(const URL&) override;
+    virtual void page_did_set_cookie(const URL&, const String&) override;
 
     void layout_and_sync_size();
 

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -274,6 +274,11 @@ void FrameLoader::resource_did_load()
         return;
     }
 
+    // FIXME: Support multiple instances of the Set-Cookie response header.
+    auto set_cookie = resource()->response_headers().get("Set-Cookie");
+    if (set_cookie.has_value())
+        document->set_cookie(set_cookie.value());
+
     if (!url.fragment().is_empty())
         frame().scroll_to_anchor(url.fragment());
 

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -365,6 +365,19 @@ void OutOfProcessWebView::notify_server_did_change_favicon(const Gfx::Bitmap& fa
         on_favicon_change(favicon);
 }
 
+String OutOfProcessWebView::notify_server_did_request_cookie(Badge<WebContentClient>, const URL& url)
+{
+    if (on_get_cookie)
+        return on_get_cookie(url);
+    return {};
+}
+
+void OutOfProcessWebView::notify_server_did_set_cookie(Badge<WebContentClient>, const URL& url, const String& cookie)
+{
+    if (on_set_cookie)
+        on_set_cookie(url, cookie);
+}
+
 void OutOfProcessWebView::did_scroll()
 {
     client().post_message(Messages::WebContentServer::SetViewportRect(visible_content_rect()));

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.h
@@ -79,6 +79,8 @@ public:
     void notify_server_did_get_source(const URL& url, const String& source);
     void notify_server_did_js_console_output(const String& method, const String& line);
     void notify_server_did_change_favicon(const Gfx::Bitmap& favicon);
+    String notify_server_did_request_cookie(Badge<WebContentClient>, const URL& url);
+    void notify_server_did_set_cookie(Badge<WebContentClient>, const URL& url, const String& cookie);
 
 private:
     OutOfProcessWebView();

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -111,6 +111,8 @@ public:
     virtual void page_did_request_alert(const String&) { }
     virtual bool page_did_request_confirm(const String&) { return false; }
     virtual String page_did_request_prompt(const String&, const String&) { return {}; }
+    virtual String page_did_request_cookie(const URL&) { return {}; }
+    virtual void page_did_set_cookie(const URL&, const String&) { }
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebContentClient.cpp
+++ b/Userland/Libraries/LibWeb/WebContentClient.cpp
@@ -197,4 +197,15 @@ void WebContentClient::handle(const Messages::WebContentClient::DidChangeFavicon
     m_view.notify_server_did_change_favicon(*message.favicon().bitmap());
 }
 
+OwnPtr<Messages::WebContentClient::DidRequestCookieResponse> WebContentClient::handle(const Messages::WebContentClient::DidRequestCookie& message)
+{
+    auto result = m_view.notify_server_did_request_cookie({}, message.url());
+    return make<Messages::WebContentClient::DidRequestCookieResponse>(result);
+}
+
+void WebContentClient::handle(const Messages::WebContentClient::DidSetCookie& message)
+{
+    m_view.notify_server_did_set_cookie({}, message.url(), message.cookie());
+}
+
 }

--- a/Userland/Libraries/LibWeb/WebContentClient.h
+++ b/Userland/Libraries/LibWeb/WebContentClient.h
@@ -75,6 +75,8 @@ private:
     virtual OwnPtr<Messages::WebContentClient::DidRequestAlertResponse> handle(const Messages::WebContentClient::DidRequestAlert&) override;
     virtual OwnPtr<Messages::WebContentClient::DidRequestConfirmResponse> handle(const Messages::WebContentClient::DidRequestConfirm&) override;
     virtual OwnPtr<Messages::WebContentClient::DidRequestPromptResponse> handle(const Messages::WebContentClient::DidRequestPrompt&) override;
+    virtual OwnPtr<Messages::WebContentClient::DidRequestCookieResponse> handle(const Messages::WebContentClient::DidRequestCookie&) override;
+    virtual void handle(const Messages::WebContentClient::DidSetCookie&) override;
 
     OutOfProcessWebView& m_view;
 };

--- a/Userland/Libraries/LibWeb/WebViewHooks.h
+++ b/Userland/Libraries/LibWeb/WebViewHooks.h
@@ -48,6 +48,8 @@ public:
     Function<void(DOM::Document*)> on_set_document;
     Function<void(const URL&, const String&)> on_get_source;
     Function<void(const String& method, const String& line)> on_js_console_output;
+    Function<String(const URL& url)> on_get_cookie;
+    Function<void(const URL& url, const String& cookie)> on_set_cookie;
 };
 
 }

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -208,4 +208,14 @@ void PageHost::page_did_request_image_context_menu(const Gfx::IntPoint& content_
     m_client.post_message(Messages::WebContentClient::DidRequestImageContextMenu(content_position, url, target, modifiers, bitmap->to_shareable_bitmap()));
 }
 
+String PageHost::page_did_request_cookie(const URL& url)
+{
+    return m_client.send_sync<Messages::WebContentClient::DidRequestCookie>(url)->cookie();
+}
+
+void PageHost::page_did_set_cookie(const URL& url, const String& cookie)
+{
+    m_client.post_message(Messages::WebContentClient::DidSetCookie(url, cookie));
+}
+
 }

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -79,6 +79,8 @@ private:
     virtual String page_did_request_prompt(const String&, const String&) override;
     virtual void page_did_change_favicon(const Gfx::Bitmap&) override;
     virtual void page_did_request_image_context_menu(const Gfx::IntPoint&, const URL&, const String& target, unsigned modifiers, const Gfx::Bitmap*) override;
+    virtual String page_did_request_cookie(const URL&) override;
+    virtual void page_did_set_cookie(const URL&, const String&) override;
 
     explicit PageHost(ClientConnection&);
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -25,4 +25,6 @@ endpoint WebContentClient = 90
     DidGetSource(URL url, String source) =|
     DidJSConsoleOutput(String method, String line) =|
     DidChangeFavicon(Gfx::ShareableBitmap favicon) =|
+    DidRequestCookie(URL url) => (String cookie)
+    DidSetCookie(URL url, String cookie) =|
 }


### PR DESCRIPTION
This adds a (currently ephemeral) backend storage for cookies set via `document.cookie` or the `Set-Cookie` HTTP response header. We can parse the name-value pair from cookies, but are currently ignoring attributes.