### PR TITLE
LibWeb: Add optional default values and optional bools in IDL, add Event.initEvent

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/DOMException.idl
+++ b/Userland/Libraries/LibWeb/DOM/DOMException.idl
@@ -1,8 +1,6 @@
 interface DOMException {
 
-    // FIXME: Support parameter default values in WrapperGenerator
-    // constructor(optional DOMString message = "", optional DOMString name = "Error");
-    constructor(optional DOMString message, optional DOMString name);
+    constructor(optional DOMString message = "", optional DOMString name = "Error");
 
     readonly attribute DOMString name;
     readonly attribute DOMString message;

--- a/Userland/Libraries/LibWeb/DOM/Event.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Event.cpp
@@ -56,4 +56,27 @@ void Event::set_cancelled_flag()
         m_cancelled = true;
 }
 
+// https://dom.spec.whatwg.org/#concept-event-initialize
+void Event::initialize(const String& type, bool bubbles, bool cancelable)
+{
+    m_initialized = true;
+    m_stop_propagation = false;
+    m_stop_immediate_propagation = false;
+    m_cancelled = false;
+    m_is_trusted = false;
+    m_target = nullptr;
+    m_type = type;
+    m_bubbles = bubbles;
+    m_cancelable = cancelable;
+}
+
+// https://dom.spec.whatwg.org/#dom-event-initevent
+void Event::init_event(const String& type, bool bubbles, bool cancelable)
+{
+    if (m_dispatch)
+        return;
+
+    initialize(type, bubbles, cancelable);
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Event.h
+++ b/Userland/Libraries/LibWeb/DOM/Event.h
@@ -154,12 +154,16 @@ public:
         m_stop_immediate_propagation = true;
     }
 
+    void init_event(const String&, bool, bool);
+
 protected:
     explicit Event(const FlyString& type)
         : m_type(type)
         , m_initialized(true)
     {
     }
+
+    void initialize(const String&, bool, bool);
 
 private:
     FlyString m_type;

--- a/Userland/Libraries/LibWeb/DOM/Event.idl
+++ b/Userland/Libraries/LibWeb/DOM/Event.idl
@@ -23,4 +23,6 @@ interface Event {
 
     readonly attribute boolean isTrusted;
 
+    undefined initEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false);
+
 };


### PR DESCRIPTION
LibWeb: Add support for optional default values and optional bools in IDL

Fixed the DOMException constructor as it had the default value version
commented out.

-----

LibWeb: Add Event.initEvent

Used by YouTube after creating an event with Document.createEvent