### PR TITLE
LibWeb: Move element_child_count to ParentNode and add its IDL attribute

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -18,12 +18,6 @@ interface Document : Node {
     ArrayFromVector getElementsByTagName(DOMString tagName);
     ArrayFromVector getElementsByClassName(DOMString className);
 
-    readonly attribute Element? firstElementChild;
-    readonly attribute Element? lastElementChild;
-
-    Element? querySelector(DOMString selectors);
-    ArrayFromVector querySelectorAll(DOMString selectors);
-
     Element createElement(DOMString tagName);
     Element createElementNS(DOMString? namespace, DOMString qualifiedName);
     DocumentFragment createDocumentFragment();
@@ -47,6 +41,14 @@ interface Document : Node {
     readonly attribute DOMString readyState;
 
     attribute DOMString title;
+
+    // FIXME: These should all come from a ParentNode mixin
+    readonly attribute Element? firstElementChild;
+    readonly attribute Element? lastElementChild;
+    readonly attribute unsigned long childElementCount;
+
+    Element? querySelector(DOMString selectors);
+    ArrayFromVector querySelectorAll(DOMString selectors);
 
     // FIXME: These should all come from a GlobalEventHandlers mixin
     attribute EventHandler onabort;

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
@@ -2,8 +2,10 @@ interface DocumentFragment : Node {
 
     Element? getElementById(DOMString id);
 
+    // FIXME: These should all come from a ParentNode mixin
     readonly attribute Element? firstElementChild;
     readonly attribute Element? lastElementChild;
+    readonly attribute unsigned long childElementCount;
 
     Element? querySelector(DOMString selectors);
     ArrayFromVector querySelectorAll(DOMString selectors);

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -11,12 +11,6 @@ interface Element : Node {
     ArrayFromVector getElementsByTagName(DOMString tagName);
     ArrayFromVector getElementsByClassName(DOMString className);
 
-    readonly attribute Element? firstElementChild;
-    readonly attribute Element? lastElementChild;
-
-    Element? querySelector(DOMString selectors);
-    ArrayFromVector querySelectorAll(DOMString selectors);
-
     [LegacyNullToEmptyString] attribute DOMString innerHTML;
     [Reflect] attribute DOMString id;
     [Reflect=class] attribute DOMString className;
@@ -25,4 +19,12 @@ interface Element : Node {
     readonly attribute Element? previousElementSibling;
 
     [ImplementedAs=style_for_bindings] readonly attribute CSSStyleDeclaration style;
+
+    // FIXME: These should all come from a ParentNode mixin
+    readonly attribute Element? firstElementChild;
+    readonly attribute Element? lastElementChild;
+    readonly attribute unsigned long childElementCount;
+
+    Element? querySelector(DOMString selectors);
+    ArrayFromVector querySelectorAll(DOMString selectors);
 };

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -204,7 +204,7 @@ ExceptionOr<void> Node::ensure_pre_insertion_validity(NonnullRefPtr<Node> node, 
 
     if (is<Document>(this)) {
         if (is<DocumentFragment>(*node)) {
-            auto node_element_child_count = node->element_child_count();
+            auto node_element_child_count = downcast<DocumentFragment>(*node).child_element_count();
             if ((node_element_child_count > 1 || node->has_child_of_type<Text>())
                 || (node_element_child_count == 1 && (has_child_of_type<Element>() || is<DocumentType>(child.ptr()) /* FIXME: or child is non-null and a doctype is following child. */))) {
                 return DOM::HierarchyRequestError::create("Invalid node type for insertion");
@@ -495,16 +495,6 @@ u16 Node::compare_document_position(RefPtr<Node> other)
 bool Node::is_host_including_inclusive_ancestor_of(const Node& other) const
 {
     return is_inclusive_ancestor_of(other) || (is<DocumentFragment>(other.root()) && downcast<DocumentFragment>(other.root())->host() && is_inclusive_ancestor_of(*downcast<DocumentFragment>(other.root())->host().ptr()));
-}
-
-size_t Node::element_child_count() const
-{
-    size_t count = 0;
-    for (auto* child = first_child(); child; child = child->next_sibling()) {
-        if (is<Element>(child))
-            ++count;
-    }
-    return count;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -175,8 +175,6 @@ public:
 
     bool is_host_including_inclusive_ancestor_of(const Node&) const;
 
-    size_t element_child_count() const;
-
 protected:
     Node(Document&, NodeType);
 

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -80,4 +80,15 @@ RefPtr<Element> ParentNode::last_element_child()
     return last_child_of_type<Element>();
 }
 
+// https://dom.spec.whatwg.org/#dom-parentnode-childelementcount
+u32 ParentNode::child_element_count() const
+{
+    u32 count = 0;
+    for (auto* child = first_child(); child; child = child->next_sibling()) {
+        if (is<Element>(child))
+            ++count;
+    }
+    return count;
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.h
@@ -40,6 +40,7 @@ public:
 
     RefPtr<Element> first_element_child();
     RefPtr<Element> last_element_child();
+    u32 child_element_count() const;
 
     RefPtr<Element> query_selector(const StringView&);
     NonnullRefPtrVector<Element> query_selector_all(const StringView&);


### PR DESCRIPTION
I initially had it in Node just because, but then saw it was part of
ParentNode in the spec.