### PR TITLE
Meta: Add .vim directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ compile_commands.json
 .idea/
 cmake-build-debug/
 sync-local.sh
+.vim/


### PR DESCRIPTION
My global gitignore didn't cover for this directory. I'm guessing that it's because of the top rows in this file?