### PR TITLE
AK: Simplify RefPtr again

### DIFF
--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -118,9 +118,6 @@ template<typename T>
 class Optional;
 
 template<typename T>
-struct RefPtrTraits;
-
-template<typename T, typename PtrTraits = RefPtrTraits<T>>
 class RefPtr;
 
 template<typename T>

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -35,7 +35,7 @@
 
 namespace AK {
 
-template<typename T, typename PtrTraits>
+template<typename T>
 class RefPtr;
 template<typename T>
 class NonnullRefPtr;
@@ -85,14 +85,14 @@ public:
     template<typename U>
     NonnullOwnPtr& operator=(const NonnullOwnPtr<U>&) = delete;
 
-    template<typename U, typename PtrTraits = RefPtrTraits<U>>
-    NonnullOwnPtr(const RefPtr<U, PtrTraits>&) = delete;
+    template<typename U>
+    NonnullOwnPtr(const RefPtr<U>&) = delete;
     template<typename U>
     NonnullOwnPtr(const NonnullRefPtr<U>&) = delete;
     template<typename U>
     NonnullOwnPtr(const WeakPtr<U>&) = delete;
-    template<typename U, typename PtrTraits = RefPtrTraits<U>>
-    NonnullOwnPtr& operator=(const RefPtr<U, PtrTraits>&) = delete;
+    template<typename U>
+    NonnullOwnPtr& operator=(const RefPtr<U>&) = delete;
     template<typename U>
     NonnullOwnPtr& operator=(const NonnullRefPtr<U>&) = delete;
     template<typename U>

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -42,98 +42,8 @@ template<typename T>
 class OwnPtr;
 
 template<typename T>
-struct RefPtrTraits {
-    ALWAYS_INLINE static T* as_ptr(FlatPtr bits)
-    {
-        return (T*)(bits & ~(FlatPtr)1);
-    }
-
-    ALWAYS_INLINE static FlatPtr as_bits(T* ptr)
-    {
-        VERIFY(!((FlatPtr)ptr & 1));
-        return (FlatPtr)ptr;
-    }
-
-    template<typename U, typename PtrTraits>
-    ALWAYS_INLINE static FlatPtr convert_from(FlatPtr bits)
-    {
-        if (PtrTraits::is_null(bits))
-            return default_null_value;
-        return as_bits(PtrTraits::as_ptr(bits));
-    }
-
-    ALWAYS_INLINE static bool is_null(FlatPtr bits)
-    {
-        return !(bits & ~(FlatPtr)1);
-    }
-
-    ALWAYS_INLINE static FlatPtr exchange(Atomic<FlatPtr>& atomic_var, FlatPtr new_value)
-    {
-        // Only exchange when lock is not held
-        VERIFY(!(new_value & 1));
-        FlatPtr expected = atomic_var.load(AK::MemoryOrder::memory_order_relaxed);
-        for (;;) {
-            expected &= ~(FlatPtr)1; // only if lock bit is not set
-            if (atomic_var.compare_exchange_strong(expected, new_value, AK::MemoryOrder::memory_order_acq_rel))
-                break;
-#ifdef KERNEL
-            Kernel::Processor::wait_check();
-#endif
-        }
-        return expected;
-    }
-
-    ALWAYS_INLINE static bool exchange_if_null(Atomic<FlatPtr>& atomic_var, FlatPtr new_value)
-    {
-        // Only exchange when lock is not held
-        VERIFY(!(new_value & 1));
-        for (;;) {
-            FlatPtr expected = default_null_value; // only if lock bit is not set
-            if (atomic_var.compare_exchange_strong(expected, new_value, AK::MemoryOrder::memory_order_acq_rel))
-                break;
-            if (!is_null(expected))
-                return false;
-#ifdef KERNEL
-            Kernel::Processor::wait_check();
-#endif
-        }
-        return true;
-    }
-
-    ALWAYS_INLINE static FlatPtr lock(Atomic<FlatPtr>& atomic_var)
-    {
-        // This sets the lock bit atomically, preventing further modifications.
-        // This is important when e.g. copying a RefPtr where the source
-        // might be released and freed too quickly. This allows us
-        // to temporarily lock the pointer so we can add a reference, then
-        // unlock it
-        FlatPtr bits;
-        for (;;) {
-            bits = atomic_var.fetch_or(1, AK::MemoryOrder::memory_order_acq_rel);
-            if (!(bits & 1))
-                break;
-#ifdef KERNEL
-            Kernel::Processor::wait_check();
-#endif
-        }
-        VERIFY(!(bits & 1));
-        return bits;
-    }
-
-    ALWAYS_INLINE static void unlock(Atomic<FlatPtr>& atomic_var, FlatPtr new_value)
-    {
-        VERIFY(!(new_value & 1));
-        atomic_var.store(new_value, AK::MemoryOrder::memory_order_release);
-    }
-
-    static constexpr FlatPtr default_null_value = 0;
-
-    using NullType = std::nullptr_t;
-};
-
-template<typename T, typename PtrTraits>
 class RefPtr {
-    template<typename U, typename P>
+    template<typename U>
     friend class RefPtr;
     template<typename U>
     friend class WeakPtr;
@@ -145,54 +55,54 @@ public:
 
     RefPtr() = default;
     RefPtr(const T* ptr)
-        : m_bits(PtrTraits::as_bits(const_cast<T*>(ptr)))
+        : m_ptr(const_cast<T*>(ptr))
     {
         ref_if_not_null(const_cast<T*>(ptr));
     }
     RefPtr(const T& object)
-        : m_bits(PtrTraits::as_bits(const_cast<T*>(&object)))
+        : m_ptr(const_cast<T*>(&object))
     {
-        T* ptr = const_cast<T*>(&object);
+        T* ptr = m_ptr;
         VERIFY(ptr);
         VERIFY(!is_null());
         ptr->ref();
     }
     RefPtr(AdoptTag, T& object)
-        : m_bits(PtrTraits::as_bits(&object))
+        : m_ptr(&object)
     {
         VERIFY(!is_null());
     }
     RefPtr(RefPtr&& other)
-        : m_bits(other.leak_ref_raw())
+        : m_ptr(other.leak_ref())
     {
     }
     ALWAYS_INLINE RefPtr(const NonnullRefPtr<T>& other)
-        : m_bits(PtrTraits::as_bits(const_cast<T*>(other.add_ref())))
+        : m_ptr(const_cast<T*>(other.add_ref()))
     {
     }
     template<typename U>
     ALWAYS_INLINE RefPtr(const NonnullRefPtr<U>& other)
-        : m_bits(PtrTraits::as_bits(const_cast<U*>(other.add_ref())))
+        : m_ptr(const_cast<U*>(other.add_ref()))
     {
     }
     template<typename U>
     ALWAYS_INLINE RefPtr(NonnullRefPtr<U>&& other)
-        : m_bits(PtrTraits::as_bits(&other.leak_ref()))
+        : m_ptr(&other.leak_ref())
     {
         VERIFY(!is_null());
     }
-    template<typename U, typename P = RefPtrTraits<U>>
-    RefPtr(RefPtr<U, P>&& other)
-        : m_bits(PtrTraits::template convert_from<U, P>(other.leak_ref_raw()))
+    template<typename U>
+    RefPtr(RefPtr<U>&& other)
+        : m_ptr(other.leak_ref())
     {
     }
     RefPtr(const RefPtr& other)
-        : m_bits(other.add_ref_raw())
+        : m_ptr(other.do_add_ref())
     {
     }
-    template<typename U, typename P = RefPtrTraits<U>>
-    RefPtr(const RefPtr<U, P>& other)
-        : m_bits(other.add_ref_raw())
+    template<typename U>
+    RefPtr(const RefPtr<U>& other)
+        : m_ptr(other.do_add_ref())
     {
     }
     ALWAYS_INLINE ~RefPtr()
@@ -200,9 +110,9 @@ public:
         clear();
 #ifdef SANITIZE_PTRS
         if constexpr (sizeof(T*) == 8)
-            m_bits.store(0xe0e0e0e0e0e0e0e0, AK::MemoryOrder::memory_order_relaxed);
+            m_ptr = (T*)0xe0e0e0e0e0e0e0e0;
         else
-            m_bits.store(0xe0e0e0e0, AK::MemoryOrder::memory_order_relaxed);
+            m_ptr = (T*)0xe0e0e0e0;
 #endif
     }
 
@@ -216,80 +126,78 @@ public:
         if (this == &other)
             return;
 
-        // NOTE: swap is not atomic!
-        FlatPtr other_bits = PtrTraits::exchange(other.m_bits, PtrTraits::default_null_value);
-        FlatPtr bits = PtrTraits::exchange(m_bits, other_bits);
-        PtrTraits::exchange(other.m_bits, bits);
+        T* other_ptr = other.m_ptr.exchange(nullptr);
+        T* ptr = m_ptr.exchange(other_ptr);
+        other.m_ptr.exchange(ptr);
     }
 
-    template<typename U, typename P = RefPtrTraits<U>>
-    void swap(RefPtr<U, P>& other)
+    template<typename U>
+    void swap(RefPtr<U>& other)
     {
-        // NOTE: swap is not atomic!
-        FlatPtr other_bits = P::exchange(other.m_bits, P::default_null_value);
-        FlatPtr bits = PtrTraits::exchange(m_bits, PtrTraits::template convert_from<U, P>(other_bits));
-        P::exchange(other.m_bits, P::template convert_from<U, P>(bits));
+        U* other_ptr = other.m_ptr.exchange(nullptr);
+        T* ptr = m_ptr.exchange(static_cast<T*>(other_ptr));
+        other.m_ptr.exchange(static_cast<T*>(other_ptr));
     }
 
     ALWAYS_INLINE RefPtr& operator=(RefPtr&& other)
     {
         if (this != &other)
-            assign_raw(other.leak_ref_raw());
+            assign(other.leak_ref());
         return *this;
     }
 
-    template<typename U, typename P = RefPtrTraits<U>>
-    ALWAYS_INLINE RefPtr& operator=(RefPtr<U, P>&& other)
+    template<typename U>
+    ALWAYS_INLINE RefPtr& operator=(RefPtr<U>&& other)
     {
-        assign_raw(PtrTraits::template convert_from<U, P>(other.leak_ref_raw()));
+        assign(other.leak_ref());
         return *this;
     }
 
     template<typename U>
     ALWAYS_INLINE RefPtr& operator=(NonnullRefPtr<U>&& other)
     {
-        assign_raw(PtrTraits::as_bits(&other.leak_ref()));
+        assign(&other.leak_ref());
         return *this;
     }
 
     ALWAYS_INLINE RefPtr& operator=(const NonnullRefPtr<T>& other)
     {
-        assign_raw(PtrTraits::as_bits(other.add_ref()));
+        assign(other.add_ref());
         return *this;
     }
 
     template<typename U>
     ALWAYS_INLINE RefPtr& operator=(const NonnullRefPtr<U>& other)
     {
-        assign_raw(PtrTraits::as_bits(other.add_ref()));
+        assign(other.add_ref());
         return *this;
     }
 
     ALWAYS_INLINE RefPtr& operator=(const RefPtr& other)
     {
         if (this != &other)
-            assign_raw(other.add_ref_raw());
+            assign(other.do_add_ref());
         return *this;
     }
 
     template<typename U>
     ALWAYS_INLINE RefPtr& operator=(const RefPtr<U>& other)
     {
-        assign_raw(other.add_ref_raw());
+        assign(other.do_add_ref());
         return *this;
     }
 
     ALWAYS_INLINE RefPtr& operator=(const T* ptr)
     {
         ref_if_not_null(const_cast<T*>(ptr));
-        assign_raw(PtrTraits::as_bits(const_cast<T*>(ptr)));
+        assign(const_cast<T*>(ptr));
         return *this;
     }
 
     ALWAYS_INLINE RefPtr& operator=(const T& object)
     {
         const_cast<T&>(object).ref();
-        assign_raw(PtrTraits::as_bits(const_cast<T*>(&object)));
+        assign(const_cast<T*>(&object));
         return *this;
     }
 
@@ -303,162 +211,117 @@ public:
     {
         if (this == &other)
             return is_null();
-        return PtrTraits::exchange_if_null(m_bits, other.leak_ref_raw());
+        T* other_ptr = other.leak_ref();
+        T* expected = nullptr;
+        if (m_ptr.compare_exchange_strong(expected, other_ptr))
+            return true;
+        unref_if_not_null(other_ptr);
+        return false;
     }
 
-    template<typename U, typename P = RefPtrTraits<U>>
-    ALWAYS_INLINE bool assign_if_null(RefPtr<U, P>&& other)
+    template<typename U>
+    ALWAYS_INLINE bool assign_if_null(RefPtr<U>&& other)
     {
         if (this == &other)
             return is_null();
-        return PtrTraits::exchange_if_null(m_bits, PtrTraits::template convert_from<U, P>(other.leak_ref_raw()));
+        T* other_ptr = static_cast<T*>(other.leak_ref());
+        T* expected = nullptr;
+        if (m_ptr.compare_exchange_strong(expected, other_ptr))
+            return true;
+        unref_if_not_null(other_ptr);
+        return false;
     }
 
     ALWAYS_INLINE void clear()
     {
-        assign_raw(PtrTraits::default_null_value);
+        assign(nullptr);
     }
 
-    bool operator!() const { return PtrTraits::is_null(m_bits.load(AK::MemoryOrder::memory_order_relaxed)); }
+    bool operator!() const { return !m_ptr; }
 
     [[nodiscard]] T* leak_ref()
     {
-        FlatPtr bits = PtrTraits::exchange(m_bits, PtrTraits::default_null_value);
-        return PtrTraits::as_ptr(bits);
+        return m_ptr.exchange(nullptr);
     }
 
     NonnullRefPtr<T> release_nonnull()
     {
-        FlatPtr bits = PtrTraits::exchange(m_bits, PtrTraits::default_null_value);
-        VERIFY(!PtrTraits::is_null(bits));
-        return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *PtrTraits::as_ptr(bits));
+        T* ptr = leak_ref();
+        VERIFY(ptr);
+        return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *ptr);
     }
 
-    ALWAYS_INLINE T* ptr() { return as_ptr(); }
-    ALWAYS_INLINE const T* ptr() const { return as_ptr(); }
+    ALWAYS_INLINE T* ptr() { return m_ptr; }
+    ALWAYS_INLINE const T* ptr() const { return m_ptr; }
 
     ALWAYS_INLINE T* operator->()
     {
-        return as_nonnull_ptr();
+        return nonnull_ptr();
     }
 
     ALWAYS_INLINE const T* operator->() const
     {
-        return as_nonnull_ptr();
+        return nonnull_ptr();
     }
 
     ALWAYS_INLINE T& operator*()
     {
-        return *as_nonnull_ptr();
+        return *nonnull_ptr();
     }
 
     ALWAYS_INLINE const T& operator*() const
     {
-        return *as_nonnull_ptr();
+        return *nonnull_ptr();
     }
 
-    ALWAYS_INLINE operator const T*() const { return as_ptr(); }
-    ALWAYS_INLINE operator T*() { return as_ptr(); }
+    ALWAYS_INLINE operator const T*() const { return ptr(); }
+    ALWAYS_INLINE operator T*() { return ptr(); }
 
     ALWAYS_INLINE operator bool() { return !is_null(); }
 
     bool operator==(std::nullptr_t) const { return is_null(); }
     bool operator!=(std::nullptr_t) const { return !is_null(); }
 
-    bool operator==(const RefPtr& other) const { return as_ptr() == other.as_ptr(); }
-    bool operator!=(const RefPtr& other) const { return as_ptr() != other.as_ptr(); }
+    bool operator==(const RefPtr& other) const { return ptr() == other.ptr(); }
+    bool operator!=(const RefPtr& other) const { return ptr() != other.ptr(); }
 
-    bool operator==(RefPtr& other) { return as_ptr() == other.as_ptr(); }
-    bool operator!=(RefPtr& other) { return as_ptr() != other.as_ptr(); }
+    bool operator==(RefPtr& other) { return ptr() == other.ptr(); }
+    bool operator!=(RefPtr& other) { return ptr() != other.ptr(); }
 
-    bool operator==(const T* other) const { return as_ptr() == other; }
-    bool operator!=(const T* other) const { return as_ptr() != other; }
+    bool operator==(const T* other) const { return ptr() == other; }
+    bool operator!=(const T* other) const { return ptr() != other; }
 
-    bool operator==(T* other) { return as_ptr() == other; }
-    bool operator!=(T* other) { return as_ptr() != other; }
+    bool operator==(T* other) { return ptr() == other; }
+    bool operator!=(T* other) { return ptr() != other; }
 
-    ALWAYS_INLINE bool is_null() const { return PtrTraits::is_null(m_bits.load(AK::MemoryOrder::memory_order_relaxed)); }
-
-    template<typename U = T, typename EnableIf<IsSame<U, T> && !IsNullPointer<typename PtrTraits::NullType>>::Type* = nullptr>
-    typename PtrTraits::NullType null_value() const
-    {
-        // make sure we are holding a null value
-        FlatPtr bits = m_bits.load(AK::MemoryOrder::memory_order_relaxed);
-        VERIFY(PtrTraits::is_null(bits));
-        return PtrTraits::to_null_value(bits);
-    }
-    template<typename U = T, typename EnableIf<IsSame<U, T> && !IsNullPointer<typename PtrTraits::NullType>>::Type* = nullptr>
-    void set_null_value(typename PtrTraits::NullType value)
-    {
-        // make sure that new null value would be interpreted as a null value
-        FlatPtr bits = PtrTraits::from_null_value(value);
-        VERIFY(PtrTraits::is_null(bits));
-        assign_raw(bits);
-    }
+    ALWAYS_INLINE bool is_null() const { return !m_ptr; }
 
 private:
-    template<typename F>
-    void do_while_locked(F f) const
+    [[nodiscard]] ALWAYS_INLINE T* do_add_ref() const
     {
-#ifdef KERNEL
-        // We don't want to be pre-empted while we have the lock bit set
-        Kernel::ScopedCritical critical;
-#endif
-        FlatPtr bits = PtrTraits::lock(m_bits);
-        T* ptr = PtrTraits::as_ptr(bits);
-        f(ptr);
-        PtrTraits::unlock(m_bits, bits);
-    }
-
-    [[nodiscard]] ALWAYS_INLINE FlatPtr leak_ref_raw()
-    {
-        return PtrTraits::exchange(m_bits, PtrTraits::default_null_value);
-    }
-
-    [[nodiscard]] ALWAYS_INLINE FlatPtr add_ref_raw() const
-    {
-#ifdef KERNEL
-        // We don't want to be pre-empted while we have the lock bit set
-        Kernel::ScopedCritical critical;
-#endif
-        // This prevents a race condition between thread A and B:
-        // 1. Thread A copies RefPtr, e.g. through assignment or copy constructor,
-        //    gets the pointer from source, but is pre-empted before adding
-        //    another reference
-        // 2. Thread B calls clear, leak_ref, or release_nonnull on source, and
-        //    then drops the last reference, causing the object to be deleted
-        // 3. Thread A finishes step #1 by attempting to add a reference to
-        //    the object that was already deleted in step #2
-        FlatPtr bits = PtrTraits::lock(m_bits);
-        if (T* ptr = PtrTraits::as_ptr(bits))
+        T* ptr = m_ptr;
+        if (ptr)
             ptr->ref();
-        PtrTraits::unlock(m_bits, bits);
-        return bits;
+        return ptr;
     }
 
-    ALWAYS_INLINE void assign_raw(FlatPtr bits)
+    ALWAYS_INLINE void assign(T* ptr)
     {
-        FlatPtr prev_bits = PtrTraits::exchange(m_bits, bits);
-        unref_if_not_null(PtrTraits::as_ptr(prev_bits));
+        T* prev_ptr = m_ptr.exchange(ptr);
+        if (prev_ptr != ptr)
+            unref_if_not_null(prev_ptr);
     }
 
-    ALWAYS_INLINE T* as_ptr() const
+    ALWAYS_INLINE T* nonnull_ptr() const
     {
-        return PtrTraits::as_ptr(m_bits.load(AK::MemoryOrder::memory_order_relaxed));
+        VERIFY(m_ptr);
+        return m_ptr;
     }
 
-    ALWAYS_INLINE T* as_nonnull_ptr() const
-    {
-        return as_nonnull_ptr(m_bits.load(AK::MemoryOrder::memory_order_relaxed));
-    }
-
-    ALWAYS_INLINE T* as_nonnull_ptr(FlatPtr bits) const
-    {
-        VERIFY(!PtrTraits::is_null(bits));
-        return PtrTraits::as_ptr(bits);
-    }
-
-    mutable Atomic<FlatPtr> m_bits { PtrTraits::default_null_value };
+    // We use relaxed because we don't need to synchronize on the
+    // object unless the last reference is dropped (which is done
+    // in RefCounted)
+    Atomic<T*, MemoryOrder::memory_order_relaxed> m_ptr { nullptr };
 };
 
 template<typename T>
@@ -482,14 +345,14 @@ inline NonnullRefPtr<T> static_ptr_cast(const NonnullRefPtr<U>& ptr)
     return NonnullRefPtr<T>(static_cast<const T&>(*ptr));
 }
 
-template<typename T, typename U, typename PtrTraits = RefPtrTraits<T>>
+template<typename T, typename U>
 inline RefPtr<T> static_ptr_cast(const RefPtr<U>& ptr)
 {
-    return RefPtr<T, PtrTraits>(static_cast<const T*>(ptr.ptr()));
+    return RefPtr<T>(static_cast<const T*>(ptr.ptr()));
 }
 
-template<typename T, typename PtrTraitsT, typename U, typename PtrTraitsU>
-inline void swap(RefPtr<T, PtrTraitsT>& a, RefPtr<U, PtrTraitsU>& b)
+template<typename T, typename U>
+inline void swap(RefPtr<T>& a, RefPtr<U>& b)
 {
     a.swap(b);
 }

--- a/AK/Weakable.h
+++ b/AK/Weakable.h
@@ -49,10 +49,10 @@ class WeakLink : public RefCounted<WeakLink> {
     friend class WeakPtr;
 
 public:
-    template<typename T, typename PtrTraits = RefPtrTraits<T>, typename EnableIf<IsBaseOf<RefCountedBase, T>>::Type* = nullptr>
-    RefPtr<T, PtrTraits> strong_ref() const
+    template<typename T, typename EnableIf<IsBaseOf<RefCountedBase, T>>::Type* = nullptr>
+    RefPtr<T> strong_ref() const
     {
-        RefPtr<T, PtrTraits> ref;
+        RefPtr<T> ref;
 
         {
 #ifdef KERNEL

--- a/Userland/Demos/WidgetGallery/GalleryModels.h
+++ b/Userland/Demos/WidgetGallery/GalleryModels.h
@@ -109,7 +109,7 @@ private:
 
 class FileIconsModel final : public GUI::Model {
 public:
-    static NonnullRefPtr<MouseCursorModel> create() { return adopt(*new FileIconsModel); }
+    static NonnullRefPtr<FileIconsModel> create() { return adopt(*new FileIconsModel); }
     virtual ~FileIconsModel() override { }
 
     enum Column {

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -148,7 +148,7 @@ int main(int argc, char** argv)
 
     editor.on_change = [&] {
         preview.remove_all_children();
-        preview.load_from_gml(editor.text(), [](const String& class_name) -> RefPtr<GUI::Widget> {
+        preview.load_from_gml(editor.text(), [](const String& class_name) -> RefPtr<Core::Object> {
             return UnregisteredWidget::construct(class_name);
         });
     };

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -39,6 +39,34 @@
 
 namespace Core {
 
+#define REGISTER_CORE_OBJECT(namespace_, class_name)                                                                                                 \
+    namespace {                                                                                                                                 \
+    Core::ObjectClassRegistration registration_##class_name(#namespace_ "::" #class_name, []() { return namespace_::class_name::construct(); }); \
+    }
+
+
+class ObjectClassRegistration {
+AK_MAKE_NONCOPYABLE(ObjectClassRegistration);
+AK_MAKE_NONMOVABLE(ObjectClassRegistration);
+
+public:
+    ObjectClassRegistration(const String& class_name, Function<NonnullRefPtr<Object>()> factory, ObjectClassRegistration* parent_class = nullptr);
+    ~ObjectClassRegistration();
+
+    String class_name() const { return m_class_name; }
+    const ObjectClassRegistration* parent_class() const { return m_parent_class; }
+    NonnullRefPtr<Object> construct() const { return m_factory(); }
+    bool is_derived_from(const ObjectClassRegistration& base_class) const;
+
+    static void for_each(Function<void(const ObjectClassRegistration&)>);
+    static const ObjectClassRegistration* find(const String& class_name);
+
+private:
+    String m_class_name;
+    Function<NonnullRefPtr<Object>()> m_factory;
+    ObjectClassRegistration* m_parent_class { nullptr };
+};
+
 class RPCClient;
 
 enum class TimerShouldFireWhenNotVisible {
@@ -149,6 +177,7 @@ public:
     void increment_inspector_count(Badge<RPCClient>);
     void decrement_inspector_count(Badge<RPCClient>);
 
+    virtual bool load_from_json(const JsonObject&, RefPtr<Core::Object> (*)(const String&)) { return false; }
 protected:
     explicit Object(Object* parent = nullptr);
 

--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -30,8 +30,8 @@
 #include <LibGfx/Orientation.h>
 #include <stdio.h>
 
-REGISTER_WIDGET(GUI, HorizontalBoxLayout)
-REGISTER_WIDGET(GUI, VerticalBoxLayout)
+REGISTER_CORE_OBJECT(GUI, HorizontalBoxLayout)
+REGISTER_CORE_OBJECT(GUI, VerticalBoxLayout)
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -43,40 +43,9 @@
 #include <LibGfx/Palette.h>
 #include <unistd.h>
 
-REGISTER_WIDGET(GUI, Widget)
+REGISTER_CORE_OBJECT(GUI, Widget)
 
 namespace GUI {
-
-static HashMap<String, WidgetClassRegistration*>& widget_classes()
-{
-    static HashMap<String, WidgetClassRegistration*>* map;
-    if (!map)
-        map = new HashMap<String, WidgetClassRegistration*>;
-    return *map;
-}
-
-WidgetClassRegistration::WidgetClassRegistration(const String& class_name, Function<NonnullRefPtr<Widget>()> factory)
-    : m_class_name(class_name)
-    , m_factory(move(factory))
-{
-    widget_classes().set(class_name, this);
-}
-
-WidgetClassRegistration::~WidgetClassRegistration()
-{
-}
-
-void WidgetClassRegistration::for_each(Function<void(const WidgetClassRegistration&)> callback)
-{
-    for (auto& it : widget_classes()) {
-        callback(*it.value);
-    }
-}
-
-const WidgetClassRegistration* WidgetClassRegistration::find(const String& class_name)
-{
-    return widget_classes().get(class_name).value_or(nullptr);
-}
 
 Widget::Widget()
     : Core::Object(nullptr)
@@ -1015,13 +984,13 @@ void Widget::set_override_cursor(Gfx::StandardCursor cursor)
 
 bool Widget::load_from_gml(const StringView& gml_string)
 {
-    return load_from_gml(gml_string, [](const String& class_name) -> RefPtr<Widget> {
+    return load_from_gml(gml_string, [](const String& class_name) -> RefPtr<Core::Object> {
         dbgln("Class '{}' not registered", class_name);
         return nullptr;
     });
 }
 
-bool Widget::load_from_gml(const StringView& gml_string, RefPtr<Widget> (*unregistered_child_handler)(const String&))
+bool Widget::load_from_gml(const StringView& gml_string, RefPtr<Core::Object> (*unregistered_child_handler)(const String&))
 {
     auto value = parse_gml(gml_string);
     if (!value.is_object())
@@ -1029,7 +998,7 @@ bool Widget::load_from_gml(const StringView& gml_string, RefPtr<Widget> (*unregi
     return load_from_json(value.as_object(), unregistered_child_handler);
 }
 
-bool Widget::load_from_json(const JsonObject& json, RefPtr<Widget> (*unregistered_child_handler)(const String&))
+bool Widget::load_from_json(const JsonObject& json, RefPtr<Core::Object> (*unregistered_child_handler)(const String&))
 {
     json.for_each_member([&](auto& key, auto& value) {
         set_property(key, value);
@@ -1074,16 +1043,16 @@ bool Widget::load_from_json(const JsonObject& json, RefPtr<Widget> (*unregistere
                 return false;
             }
 
-            RefPtr<Widget> child_widget;
-            if (auto* registration = WidgetClassRegistration::find(class_name.as_string())) {
-                child_widget = registration->construct();
+            RefPtr<Core::Object> child;
+            if (auto* registration = Core::ObjectClassRegistration::find(class_name.as_string())) {
+                child = registration->construct();
             } else {
-                child_widget = unregistered_child_handler(class_name.as_string());
-                if (!child_widget)
-                    return false;
+                child = unregistered_child_handler(class_name.as_string());
             }
-            add_child(*child_widget);
-            child_widget->load_from_json(child_json, unregistered_child_handler);
+            if (!child)
+                return false;
+            add_child(*child);
+            child->load_from_json(child_json, unregistered_child_handler);
         }
     }
 


### PR DESCRIPTION
Let's make `RefPtr` not thread-safe itself again (similar to the std library) as the overhead is just too much, considering most of our code is single-threaded and doesn't need these features.

- [ ] Fix weird linker error:
```
i686-pc-serenity/bin/ld: Userland/Libraries/LibGUI/CMakeFiles/LibGUI.dir/Button.cpp.o: relocation R_386_GOTOFF against undefined symbol `_ZN12_GLOBAL__N_119registration_WidgetE' can not be used when making a shared object
i686-pc-serenity/bin/ld: final link failed: bad value
```
- [ ] Figure out a solution for #6086