### PR TITLE
LibWeb: Add Window.parent and fix Window.top attributes

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -67,7 +67,8 @@ void WindowObject::initialize_global_object()
     define_property("window", this, JS::Attribute::Enumerable);
     define_property("frames", this, JS::Attribute::Enumerable);
     define_property("self", this, JS::Attribute::Enumerable);
-    define_native_property("top", top_getter, JS::Attribute::Enumerable);
+    define_native_property("top", top_getter, nullptr, JS::Attribute::Enumerable);
+    define_native_property("parent", parent_getter, nullptr, JS::Attribute::Enumerable);
     define_native_property("document", document_getter, nullptr, JS::Attribute::Enumerable);
     define_native_property("performance", performance_getter, nullptr, JS::Attribute::Enumerable);
     define_native_property("screen", screen_getter, nullptr, JS::Attribute::Enumerable);
@@ -364,6 +365,22 @@ JS_DEFINE_NATIVE_GETTER(WindowObject::top_getter)
     VERIFY(this_frame->main_frame().document());
     auto& top_window = this_frame->main_frame().document()->window();
     return top_window.wrapper();
+}
+
+JS_DEFINE_NATIVE_GETTER(WindowObject::parent_getter)
+{
+    auto* impl = impl_from(vm, global_object);
+    if (!impl)
+        return {};
+    auto* this_frame = impl->document().frame();
+    VERIFY(this_frame);
+    if (this_frame->parent()) {
+        VERIFY(this_frame->parent()->document());
+        auto& parent_window = this_frame->parent()->document()->window();
+        return parent_window.wrapper();
+    }
+    VERIFY(this_frame == &this_frame->main_frame());
+    return impl->wrapper();
 }
 
 JS_DEFINE_NATIVE_GETTER(WindowObject::document_getter)

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.h
@@ -90,6 +90,8 @@ private:
     JS_DECLARE_NATIVE_GETTER(inner_width_getter);
     JS_DECLARE_NATIVE_GETTER(inner_height_getter);
 
+    JS_DECLARE_NATIVE_GETTER(parent_getter);
+
     JS_DECLARE_NATIVE_FUNCTION(alert);
     JS_DECLARE_NATIVE_FUNCTION(confirm);
     JS_DECLARE_NATIVE_FUNCTION(prompt);


### PR DESCRIPTION
This returns the parent frame of the current frame. If it's the
main frame, it returns itself.

Also fixes the attributes of Window.top, as they were accidentally
being passed in as the setter.

Required by Web Platform Tests.