### PR TITLE
LibGUI+HackStudio: Add way to tell FilePicker to open a folder

### DIFF
--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -118,7 +118,7 @@ NewProjectDialog::NewProjectDialog(GUI::Window* parent)
 
     m_browse_button = *find_descendant_of_type_named<GUI::Button>("browse_button");
     m_browse_button->on_click = [this](auto) {
-        Optional<String> path = GUI::FilePicker::get_open_filepath(this);
+        Optional<String> path = GUI::FilePicker::get_open_filepath(this, {}, Core::StandardPaths::home_directory(), true);
         if (path.has_value())
             m_create_in_input->set_text(path.value().view());
     };

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -542,7 +542,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_remove_current_editor_action
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_open_action()
 {
     return GUI::Action::create("&Open Project...", { Mod_Ctrl | Mod_Shift, Key_O }, Gfx::Bitmap::load_from_file("/res/icons/16x16/open.png"), [this](auto&) {
-        auto open_path = GUI::FilePicker::get_open_filepath(window(), "Open project");
+        auto open_path = GUI::FilePicker::get_open_filepath(window(), "Open project", Core::StandardPaths::home_directory(), true);
         if (!open_path.has_value())
             return;
         open_project(open_path.value());

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -48,9 +48,9 @@
 
 namespace GUI {
 
-Optional<String> FilePicker::get_open_filepath(Window* parent_window, const String& window_title, const StringView& path)
+Optional<String> FilePicker::get_open_filepath(Window* parent_window, const String& window_title, const StringView& path, bool folder)
 {
-    auto picker = FilePicker::construct(parent_window, Mode::Open, "", path);
+    auto picker = FilePicker::construct(parent_window, folder ? Mode::OpenFolder : Mode::Open, "", path);
 
     if (!window_title.is_null())
         picker->set_title(window_title);
@@ -89,6 +89,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& file_
     switch (m_mode) {
     case Mode::Open:
     case Mode::OpenMultiple:
+    case Mode::OpenFolder:
         set_title("Open");
         set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/open.png"));
         break;
@@ -180,8 +181,12 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, const StringView& file_
         const FileSystemModel::Node& node = m_model->node(local_index);
         LexicalPath path { node.full_path() };
 
-        if (!node.is_directory())
+        auto should_open_folder = m_mode == Mode::OpenFolder;
+        if (should_open_folder == node.is_directory()) {
             m_filename_textbox->set_text(node.name);
+        } else {
+            m_filename_textbox->clear();
+        }
     };
 
     m_context_menu = GUI::Menu::construct();

--- a/Userland/Libraries/LibGUI/FilePicker.h
+++ b/Userland/Libraries/LibGUI/FilePicker.h
@@ -44,10 +44,11 @@ public:
     enum class Mode {
         Open,
         OpenMultiple,
+        OpenFolder,
         Save
     };
 
-    static Optional<String> get_open_filepath(Window* parent_window, const String& window_title = {}, const StringView& path = Core::StandardPaths::home_directory());
+    static Optional<String> get_open_filepath(Window* parent_window, const String& window_title = {}, const StringView& path = Core::StandardPaths::home_directory(), bool folder = false);
     static Optional<String> get_save_filepath(Window* parent_window, const String& title, const String& extension, const StringView& path = Core::StandardPaths::home_directory());
 
     virtual ~FilePicker() override;
@@ -69,6 +70,7 @@ private:
         switch (mode) {
         case Mode::Open:
         case Mode::OpenMultiple:
+        case Mode::OpenFolder:
             return "Open";
         case Mode::Save:
             return "Save";


### PR DESCRIPTION
This now means that when trying to open a folder, one can click on the folder and press open instead of having to actually step into the desired folder. Of course, it also means it won't let you open non-directories anymore.

I encountered this when trying to open the "little" project folder in HackStudio and was confused when it opened the parent dir even though I had the little folder selected. This behavior seems to match both what I expected and what I see in other systems.