### PR TITLE
HackStudio+LibDebug: Various debugger fixes

### DIFF
--- a/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
@@ -70,9 +70,9 @@ void Debugger::on_breakpoint_change(const String& file, size_t line, BreakpointC
     auto position = create_source_position(file, line);
 
     if (change_type == BreakpointChange::Added) {
-        Debugger::the().m_breakpoints.append(position);
+        m_breakpoints.append(position);
     } else {
-        Debugger::the().m_breakpoints.remove_all_matching([&](Debug::DebugInfo::SourcePosition val) { return val == position; });
+        m_breakpoints.remove_all_matching([&](const Debug::DebugInfo::SourcePosition& val) { return val == position; });
     }
 
     auto session = Debugger::the().session();
@@ -99,9 +99,9 @@ void Debugger::on_breakpoint_change(const String& file, size_t line, BreakpointC
 
 Debug::DebugInfo::SourcePosition Debugger::create_source_position(const String& file, size_t line)
 {
-    if (!file.starts_with('/') && !file.starts_with("./"))
-        return { String::formatted("./{}", file), line + 1 };
-    return { file, line + 1 };
+    if (file.starts_with("/"))
+        return { file, line + 1 };
+    return { LexicalPath::canonicalized_path(String::formatted("{}/{}", m_source_root, file)), line + 1 };
 }
 
 int Debugger::start_static()

--- a/Userland/DevTools/HackStudio/Debugger/Debugger.h
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.h
@@ -28,6 +28,7 @@
 
 #include "BreakpointCallback.h"
 #include <AK/Function.h>
+#include <AK/LexicalPath.h>
 #include <AK/Vector.h>
 #include <LibDebug/DebugSession.h>
 #include <LibThread/Lock.h>
@@ -52,9 +53,10 @@ public:
 
     static bool is_initialized();
 
-    static void on_breakpoint_change(const String& file, size_t line, BreakpointChange change_type);
+    void on_breakpoint_change(const String& file, size_t line, BreakpointChange change_type);
 
     void set_executable_path(const String& path) { m_executable_path = path; }
+    void set_source_root(const String& source_root) { m_source_root = source_root; }
 
     Debug::DebugSession* session() { return m_debug_session.ptr(); }
 
@@ -108,7 +110,7 @@ private:
         Function<void()> on_continue_callback,
         Function<void()> on_exit_callback);
 
-    static Debug::DebugInfo::SourcePosition create_source_position(const String& file, size_t line);
+    Debug::DebugInfo::SourcePosition create_source_position(const String& file, size_t line);
 
     void start();
     int debugger_loop();

--- a/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
@@ -83,7 +83,8 @@ static String variable_value_as_string(const Debug::DebugInfo::VariableInfo& var
         auto it = variable.type->members.find_if([&enumerator_value = value.value()](const auto& enumerator) {
             return enumerator->constant_data.as_u32 == enumerator_value;
         });
-        VERIFY(!it.is_end());
+        if (it.is_end())
+            return String::formatted("Unknown ({})", value.value());
         return String::formatted("{}::{}", variable.type_name, (*it)->name);
     }
 

--- a/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
@@ -97,7 +97,7 @@ static String variable_value_as_string(const Debug::DebugInfo::VariableInfo& var
     if (variable.type_name == "char") {
         auto value = Debugger::the().session()->peek((u32*)variable_address);
         VERIFY(value.has_value());
-        return String::formatted("'{0:c}' ({0:d})", value.value());
+        return String::formatted("'{0:c}'", (char)value.value());
     }
 
     if (variable.type_name == "bool") {

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -271,10 +271,10 @@ void Editor::mousedown_event(GUI::MouseEvent& event)
     if (event.button() == GUI::MouseButton::Left && event.position().x() < ruler_line_rect.width()) {
         if (!breakpoint_lines().contains_slow(text_position.line())) {
             breakpoint_lines().append(text_position.line());
-            Debugger::on_breakpoint_change(wrapper().filename_label().text(), text_position.line(), BreakpointChange::Added);
+            Debugger::the().on_breakpoint_change(wrapper().filename_label().text(), text_position.line(), BreakpointChange::Added);
         } else {
             breakpoint_lines().remove_first_matching([&](size_t line) { return line == text_position.line(); });
-            Debugger::on_breakpoint_change(wrapper().filename_label().text(), text_position.line(), BreakpointChange::Removed);
+            Debugger::the().on_breakpoint_change(wrapper().filename_label().text(), text_position.line(), BreakpointChange::Removed);
         }
     }
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -198,7 +198,9 @@ void HackStudioWidget::open_project(const String& root_path)
         m_project_tree_view->update();
     }
     if (Debugger::is_initialized()) {
-        Debugger::the().reset_breakpoints();
+        auto& debugger = Debugger::the();
+        debugger.reset_breakpoints();
+        debugger.set_source_root(m_project->root_path());
     }
 }
 

--- a/Userland/Libraries/LibDebug/DebugInfo.h
+++ b/Userland/Libraries/LibDebug/DebugInfo.h
@@ -140,7 +140,7 @@ private:
     void prepare_variable_scopes();
     void prepare_lines();
     void parse_scopes_impl(const Dwarf::DIE& die);
-    OwnPtr<VariableInfo> create_variable_info(const Dwarf::DIE& variable_die, const PtraceRegisters&) const;
+    OwnPtr<VariableInfo> create_variable_info(const Dwarf::DIE& variable_die, const PtraceRegisters&, u32 address_offset = 0) const;
 
     NonnullOwnPtr<const ELF::Image> m_elf;
     String m_source_root;

--- a/Userland/Libraries/LibDebug/DebugInfo.h
+++ b/Userland/Libraries/LibDebug/DebugInfo.h
@@ -141,6 +141,7 @@ private:
     void prepare_lines();
     void parse_scopes_impl(const Dwarf::DIE& die);
     OwnPtr<VariableInfo> create_variable_info(const Dwarf::DIE& variable_die, const PtraceRegisters&, u32 address_offset = 0) const;
+    static bool is_variable_tag_supported(const Dwarf::EntryTag& tag);
 
     NonnullOwnPtr<const ELF::Image> m_elf;
     String m_source_root;


### PR DESCRIPTION
HackStudio's debugger instance has its source root property updated when switching projects, and breakpoints will properly canonicalize their file paths as the Debugger now expects.

This fixes breakpoints not activating in the "little" project (~~although actually trying to debug the program still trips an assertion in LibDebug, probably tackling that issue next~~ fixed!).

cc @itamar8910 