### PR TITLE
Browser: Parse and store (most) cookie attributes

### DIFF
--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -221,9 +221,9 @@ void CookieJar::process_attribute(Cookie& cookie, StringView attribute_name, Str
     } else if (attribute_name.equals_ignoring_case("Path")) {
         on_path_attribute(cookie, attribute_value);
     } else if (attribute_name.equals_ignoring_case("Secure")) {
-        on_secure_attribute(cookie, attribute_value);
+        on_secure_attribute(cookie);
     } else if (attribute_name.equals_ignoring_case("HttpOnly")) {
-        on_http_only_attribute(cookie, attribute_value);
+        on_http_only_attribute(cookie);
     }
 }
 
@@ -291,14 +291,16 @@ void CookieJar::on_path_attribute(Cookie& cookie, StringView attribute_value)
     cookie.path = attribute_value;
 }
 
-void CookieJar::on_secure_attribute([[maybe_unused]] Cookie& cookie, [[maybe_unused]] StringView attribute_value)
+void CookieJar::on_secure_attribute(Cookie& cookie)
 {
     // https://tools.ietf.org/html/rfc6265#section-5.2.5
+    cookie.secure = true;
 }
 
-void CookieJar::on_http_only_attribute([[maybe_unused]] Cookie& cookie, [[maybe_unused]] StringView attribute_value)
+void CookieJar::on_http_only_attribute(Cookie& cookie)
 {
     // https://tools.ietf.org/html/rfc6265#section-5.2.6
+    cookie.http_only = true;
 }
 
 }

--- a/Userland/Applications/Browser/CookieJar.h
+++ b/Userland/Applications/Browser/CookieJar.h
@@ -46,6 +46,14 @@ public:
 private:
     static Optional<String> canonicalize_domain(const URL& url);
     static Optional<Cookie> parse_cookie(const String& cookie_string);
+    static void parse_attributes(Cookie& cookie, StringView unparsed_attributes);
+    static void process_attribute(Cookie& cookie, StringView attribute_name, StringView attribute_value);
+    static void on_expires_attribute(Cookie& cookie, StringView attribute_value);
+    static void on_max_age_attribute(Cookie& cookie, StringView attribute_value);
+    static void on_domain_attribute(Cookie& cookie, StringView attribute_value);
+    static void on_path_attribute(Cookie& cookie, StringView attribute_value);
+    static void on_secure_attribute(Cookie& cookie, StringView attribute_value);
+    static void on_http_only_attribute(Cookie& cookie, StringView attribute_value);
 
     HashMap<String, Vector<Cookie>> m_cookies;
 };

--- a/Userland/Applications/Browser/CookieJar.h
+++ b/Userland/Applications/Browser/CookieJar.h
@@ -40,6 +40,8 @@ struct Cookie {
     Core::DateTime expiry_time {};
     String domain {};
     String path {};
+    bool secure { false };
+    bool http_only { false };
 };
 
 class CookieJar {
@@ -57,8 +59,8 @@ private:
     static void on_max_age_attribute(Cookie& cookie, StringView attribute_value);
     static void on_domain_attribute(Cookie& cookie, StringView attribute_value);
     static void on_path_attribute(Cookie& cookie, StringView attribute_value);
-    static void on_secure_attribute(Cookie& cookie, StringView attribute_value);
-    static void on_http_only_attribute(Cookie& cookie, StringView attribute_value);
+    static void on_secure_attribute(Cookie& cookie);
+    static void on_http_only_attribute(Cookie& cookie);
 
     HashMap<String, Vector<Cookie>> m_cookies;
 };

--- a/Userland/Applications/Browser/CookieJar.h
+++ b/Userland/Applications/Browser/CookieJar.h
@@ -38,6 +38,7 @@ struct Cookie {
     String name;
     String value;
     Core::DateTime expiry_time {};
+    String domain {};
 };
 
 class CookieJar {
@@ -47,7 +48,7 @@ public:
 
 private:
     static Optional<String> canonicalize_domain(const URL& url);
-    static Optional<Cookie> parse_cookie(const String& cookie_string);
+    static Optional<Cookie> parse_cookie(const String& cookie_string, String default_domain);
     static void parse_attributes(Cookie& cookie, StringView unparsed_attributes);
     static void process_attribute(Cookie& cookie, StringView attribute_name, StringView attribute_value);
     static void on_expires_attribute(Cookie& cookie, StringView attribute_value);

--- a/Userland/Applications/Browser/CookieJar.h
+++ b/Userland/Applications/Browser/CookieJar.h
@@ -30,12 +30,14 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibCore/DateTime.h>
 
 namespace Browser {
 
 struct Cookie {
     String name;
     String value;
+    Core::DateTime expiry_time {};
 };
 
 class CookieJar {

--- a/Userland/Applications/Browser/CookieJar.h
+++ b/Userland/Applications/Browser/CookieJar.h
@@ -39,6 +39,7 @@ struct Cookie {
     String value;
     Core::DateTime expiry_time {};
     String domain {};
+    String path {};
 };
 
 class CookieJar {
@@ -48,7 +49,8 @@ public:
 
 private:
     static Optional<String> canonicalize_domain(const URL& url);
-    static Optional<Cookie> parse_cookie(const String& cookie_string, String default_domain);
+    static String default_path(const URL& url);
+    static Optional<Cookie> parse_cookie(const String& cookie_string, String default_domain, String default_path);
     static void parse_attributes(Cookie& cookie, StringView unparsed_attributes);
     static void process_attribute(Cookie& cookie, StringView attribute_name, StringView attribute_value);
     static void on_expires_attribute(Cookie& cookie, StringView attribute_value);


### PR DESCRIPTION
This excludes just the `Expires` attribute, didn't get a chance to do the cookie date-time parsing today :)