### PR TITLE
LibRegex: Generate a 'Compare' op for empty character classes

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.exec.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.exec.js
@@ -136,3 +136,15 @@ test("brace quantifier with invalid contents", () => {
     expect(res.length).toBe(1);
     expect(res[0]).toBe("{{lit-746579221856449}}");
 });
+
+// #6256
+test("empty character class semantics", () => {
+    // Should not match zero-length strings.
+    let res = /[]/.exec("");
+    expect(res).toBe(null);
+
+    // Inverse form, should match anything.
+    res = /[^]/.exec("x");
+    expect(res.length).toBe(1);
+    expect(res[0]).toBe("x");
+});

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -1418,6 +1418,9 @@ bool ECMA262Parser::parse_character_class(ByteCode& stack, size_t& match_length_
 
     if (match(TokenType::RightBracket)) {
         consume();
+        // Should only have at most an 'Inverse'
+        VERIFY(compares.size() <= 1);
+        stack.insert_bytecode_compare_values(move(compares));
         return true;
     }
 


### PR DESCRIPTION
Otherwise it would match zero-length strings.
Fixes #6256.