### PR TITLE
Ports: Add Dialog

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -17,6 +17,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`cmatrix`](cmatrix/)          | cmatrix                                       |                   | https://github.com/abishekvashok/cmatrix              |
 | [`curl`](curl/)                | curl                                          | 7.65.3            | https://curl.se/                                      |
 | [`dash`](dash/)                | DASH                                          | 0.5.10.2          | http://gondor.apana.org.au/~herbert/dash              |
+| [`dialog`](dialog/)            | Dialog                                        | 1.3-20210324      | https://invisible-island.net/dialog/                  |
 | [`diffutils`](diffutils/)      | GNU Diffutils                                 | 3.5               | https://www.gnu.org/software/diffutils/               |
 | [`dmidecode`](dmidecode/)      | dmidecode                                     | 3.3               | https://github.com/mirror/dmidecode                   |
 | [`doom`](doom/)                | DOOM                                          |                   | https://github.com/SerenityOS/SerenityDOOM            |

--- a/Ports/dialog/package.sh
+++ b/Ports/dialog/package.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=dialog
+version=1.3-20210324
+depends="ncurses"
+files="https://invisible-mirror.net/archives/dialog/dialog-${version}.tgz dialog-${version}.tgz
+https://invisible-mirror.net/archives/dialog/dialog-${version}.tgz.asc dialog-${version}.tgz.asc"
+auth_type="sig"
+auth_import_key="C52048C0C0748FEE227D47A2702353E0F7E48EDB"
+auth_opts="dialog-${version}.tgz.asc dialog-${version}.tgz"
+useconfigure=true
+configopts="--prefix=/usr/local --with-ncurses --with-curses-dir=${SERENITY_ROOT}/Build/i686/Root/usr/local/include/ncurses"

--- a/Ports/dialog/patches/config.sub.patch
+++ b/Ports/dialog/patches/config.sub.patch
@@ -1,0 +1,10 @@
+--- dialog-1.3-20210324/config.sub	2020-08-16 20:36:41.000000000 -0700
++++ dialog-1.3-20210324/config.sub	2021-04-11 20:15:18.580516177 -0700
+@@ -1693,6 +1693,7 @@
+ 	# The portable systems comes first.
+ 	# Each alternative MUST end in a * to match a version number.
+ 	gnu* | android* | bsd* | mach* | minix* | genix* | ultrix* | irix* \
++	     | serenity* \
+ 	     | *vms* | esix* | aix* | cnk* | sunos | sunos[34]* \
+ 	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* \
+ 	     | sym* |  plan9* | psp* | sim* | xray* | os68k* | v88r* \


### PR DESCRIPTION
The formatting is a bit funky, likely due to missing VT support.

```
Terminal(18): Set Mode: Unimplemented mode 1049
Terminal(18): FIXME: XTERM_WM: Ps: 22 (param count: 3)
Terminal(18): Unimplemented escape: l, parameters:4
Terminal(18): Set Mode: Unimplemented mode 7
Terminal(18): Set Mode: Unimplemented mode 1049
Terminal(18): FIXME: XTERM_WM: Ps: 23 (param count: 3)
Terminal(18): Set Mode: Unimplemented mode 1
Terminal(18): Unexpected character in GotEscape '='
Terminal(18): Set Mode: Unimplemented mode 1006
Terminal(18): Set Mode: Unimplemented mode 1
Terminal(18): Unexpected character in GotEscape '='
```

The exit status code work correctly.

```
$ dialog --yesno "Well Hello Friends!" 20 20
```

![Dialog](https://user-images.githubusercontent.com/434827/114362644-e7327c80-9bba-11eb-85e6-d26c7912d918.png)
