### PR TITLE
VirtualFileSystem: Added checks whether mount points are already in use

### DIFF
--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -117,10 +117,10 @@ private:
     BlockBasedFS& m_fs;
     size_t m_entry_count { 10000 };
     mutable HashMap<BlockBasedFS::BlockIndex, CacheEntry*> m_hash;
-    mutable IntrusiveList<CacheEntry, &CacheEntry::list_node> m_clean_list;
-    mutable IntrusiveList<CacheEntry, &CacheEntry::list_node> m_dirty_list;
     KBuffer m_cached_block_data;
     KBuffer m_entries;
+    mutable IntrusiveList<CacheEntry, &CacheEntry::list_node> m_clean_list;
+    mutable IntrusiveList<CacheEntry, &CacheEntry::list_node> m_dirty_list;
     bool m_dirty { false };
 };
 

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -90,7 +90,8 @@ KResult VFS::mount(FS& file_system, Custody& mount_point, int flags)
         inode.identifier(),
         flags);
 
-    if (mount_point_is_in_use(mount_point)) return EBUSY;
+    if (mount_point_is_in_use(mount_point))
+        return EBUSY;
 
     Mount mount { file_system, &mount_point, flags };
     m_mounts.append(move(mount));
@@ -103,7 +104,8 @@ KResult VFS::bind_mount(Custody& source, Custody& mount_point, int flags)
 
     dbgln("VFS: Bind-mounting {} at {}", source.absolute_path(), mount_point.absolute_path());
 
-    if (mount_point_is_in_use(mount_point)) return EBUSY;
+    if (mount_point_is_in_use(mount_point))
+        return EBUSY;
 
     Mount mount { source.inode(), mount_point, flags };
     m_mounts.append(move(mount));

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -126,6 +126,7 @@ private:
     KResult validate_path_against_process_veil(StringView path, int options);
 
     bool is_vfs_root(InodeIdentifier) const;
+    bool mount_point_is_in_use(Custody&) const;
 
     KResult traverse_directory_inode(Inode&, Function<bool(const FS::DirectoryEntryView&)>);
 

--- a/Kernel/Syscalls/mount.cpp
+++ b/Kernel/Syscalls/mount.cpp
@@ -121,10 +121,12 @@ KResultOr<int> Process::sys$mount(Userspace<const Syscall::SC_mount_params*> use
     }
 
     auto result = VFS::the().mount(fs.release_nonnull(), target_custody, params.flags);
-    if (!description.is_null())
-        dbgln("mount: successfully mounted {} on {}", description->absolute_path(), target);
-    else
-        dbgln("mount: successfully mounted {}", target);
+    if (result == KSuccess) {
+        if (!description.is_null())
+            dbgln("mount: successfully mounted {} on {}", description->absolute_path(), target);
+        else
+            dbgln("mount: successfully mounted {}", target);
+    }
     return result;
 }
 


### PR DESCRIPTION
Hello,

I implemented two "FIXMEs" in VirtualFileSystem.cpp that proposed to check whether a mount point is already in use.
The _mount_ syscall now returns EBUSY if the requested mount point is in use.
This pull request also includes a fix for a segfault in the DiskCache class in BlockedFileSystem.cpp, which was triggered by these checks.
When DiskCache was deconstructed the fields m_cached_block_data and m_entries were deconstructed before m_clean_list and m_dirty_list, which, without this fix, attempt to use the already deallocated buffers m_cached_block_data and m_entries in their deconstructors.
I fixed this by changing the order in which these fields are deconstructed.
This is only a small pull request to familiarise myself with the code.

Paul

PS: This is my first PR. Please let me know if I am doing something wrong.