### PR TITLE
LibC: Turn CRASH() into a function and add noreturn attribute

### DIFF
--- a/Userland/Libraries/LibC/assert.cpp
+++ b/Userland/Libraries/LibC/assert.cpp
@@ -53,3 +53,9 @@ void __assertion_failed(const char* msg)
 }
 #endif
 }
+
+void __crash()
+{
+    asm volatile("ud2");
+    __builtin_unreachable();
+}

--- a/Userland/Libraries/LibC/assert.h
+++ b/Userland/Libraries/LibC/assert.h
@@ -45,10 +45,9 @@ __attribute__((noreturn)) void __assertion_failed(const char* msg);
 #    define VERIFY_NOT_REACHED() CRASH()
 #endif
 
-#define CRASH()              \
-    do {                     \
-        asm volatile("ud2"); \
-    } while (0)
+__attribute__((noreturn)) void __crash();
+
+#define CRASH() __crash()
 #define VERIFY assert
 #define TODO VERIFY_NOT_REACHED
 


### PR DESCRIPTION
This way CRASH() can be used in functions that are themselves marked as noreturn.