### PR TITLE
Meta: Enable pull_request_target context for the notify_discord action

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -253,31 +253,3 @@ jobs:
         ${{ toJSON(github.event) }}
         ]
         EOF
-
-  notify_discord:
-    needs: [build_and_test_serenity, build_and_test_lagom]
-    runs-on: ubuntu-20.04
-    if: always() && github.repository == 'SerenityOS/serenity' && (github.event_name == 'pull_request_target' || (github.event_name == 'push' && github.ref == 'refs/heads/master'))
-
-    steps:
-    # Sets environment variable env.WORKFLOW_CONCLUSION to one of [neutral, success, skipped, cancelled, timed_out, action_required, failure]
-    # depending on result of all needs jobs
-    - uses: technote-space/workflow-conclusion-action@v2
-
-    # === NOTIFICATIONS ===
-
-    - name: Discord action notification
-      env:
-        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-      uses: Ilshidur/action-discord@0.3.0
-      if: ${{ (github.event['pull_request'] && github.event['action'] == 'opened' && !(github.event['pull_request'] == 'draft')) || github.event['commits'] }}
-
-    - name: Discord build result
-      env:
-        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        DISCORD_USERNAME: GitHub # we have to set these manually for non-default messages
-        DISCORD_AVATAR: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
-      uses: Ilshidur/action-discord@0.3.0
-      if: ${{ (github.event['pull_request'] && github.event['action'] == 'opened' && !(github.event['pull_request'] == 'draft')) || github.event['commits'] }}
-      with:
-        args: "The build ${{ env.WORKFLOW_CONCLUSION == 'success' && 'passed :white_check_mark:' || 'failed :x:' }}"

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,35 @@
+name: Discord notifications
+
+on: [push, pull_request_target]
+
+jobs:
+  notify_discord:
+    runs-on: ubuntu-20.04
+    if: always() && github.repository == 'SerenityOS/serenity' && (github.event_name == 'pull_request_target' || (github.event_name == 'push' && github.ref == 'refs/heads/master'))
+
+    steps:
+      - name: Wait for tests to finish
+        uses: IdanHo/action-wait-for-check@890bf0671eeeac09faf19f57deb4397eeccc59aa
+        id: wait-for-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          excludedCheckName: "notify_discord"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          timeoutSeconds: 1200
+
+      - name: Discord action notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          CUSTOM_GITHUB_EVENT_NAME: ${{ github.event_name == 'pull_request_target' && 'pull_request' || github.event_name }} # fake the event type as discord doesnt know how to parse the special pull_request_target context
+        uses: IdanHo/action-discord@754598254f288e6d8e9fca637832e3c163515ba8
+        if: ${{ (github.event['pull_request'] && github.event['action'] == 'opened' && !(github.event['pull_request'] == 'draft')) || github.event['commits'] }}
+
+      - name: Discord build status
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_USERNAME: GitHub # we have to set these manually for non-default messages
+          DISCORD_AVATAR: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+        uses: IdanHo/action-discord@754598254f288e6d8e9fca637832e3c163515ba8
+        if: ${{ (github.event['pull_request'] && github.event['action'] == 'opened' && !(github.event['pull_request'] == 'draft')) || github.event['commits'] }}
+        with:
+          args: "The build ${{ steps.wait-for-tests.outputs.conclusion == 'success' && 'passed :white_check_mark:' || 'failed :x:' }}"


### PR DESCRIPTION
While we did allow the notify_discord job to run inside the context, we didnt ask github to run in that context (resulting in no notifications about PRs being posted), so this commit enables that. While i was there i also noticed a flaw in the implementation of the build status posts for PRs: since we run the discord posts in a seperate context for PRs their build status would always be success (as the reported build status is only for the jobs in the current context), so this commit uses the "action-wait-for-check" sub-action (which i forked from the original to add missing functionality https://github.com/IdanHo/action-wait-for-check) to ensure the posted build results are accurate for pull requests (since the build workflow is done in a separate context for PRs).
The logic turned out quite complex, if someone has any good ideas on how to simplify it i would be glad to hear about it :)