### PR TITLE
 LibC: Implement getaddrinfo(), freeaddrinfo(), gai_strerror() and getnameinfo()

### DIFF
--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -2,11 +2,11 @@
 port=curl
 version=7.65.3
 useconfigure=true
-configopts="--disable-threaded-resolver --disable-ipv6"
+configopts="--disable-threaded-resolver --disable-ipv6 --disable-ntlm-wb"
 files="https://curl.se/download/curl-${version}.tar.bz2 curl-${version}.tar.bz2
 https://curl.se/download/curl-${version}.tar.bz2.asc curl-${version}.tar.bz2.asc"
 
-depends=zlib
+depends="zlib openssl"
 auth_type="sig"
 auth_import_key="27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2"
 auth_opts="curl-${version}.tar.bz2.asc curl-${version}.tar.bz2"

--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -10,8 +10,3 @@ depends=zlib
 auth_type="sig"
 auth_import_key="27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2"
 auth_opts="curl-${version}.tar.bz2.asc curl-${version}.tar.bz2"
-
-pre_configure() {
-    # serenity's getaddrinfo exists but is a stub
-    export curl_disallow_getaddrinfo=yes
-}

--- a/Ports/curl/patches/disable-nbio.patch
+++ b/Ports/curl/patches/disable-nbio.patch
@@ -1,0 +1,14 @@
+diff -Naur curl-7.65.3/lib/nonblock.c curl-7.65.3.serenity/lib/nonblock.c
+--- curl-7.65.3/lib/nonblock.c	2021-04-12 18:25:48.687757722 +0200
++++ curl-7.65.3.serenity/lib/nonblock.c	2021-04-12 18:22:32.390375039 +0200
+@@ -39,6 +39,10 @@
+ 
+ #include "nonblock.h"
+ 
++#ifdef __serenity__
++#define USE_BLOCKING_SOCKETS
++#endif
++
+ /*
+  * curlx_nonblock() set the given socket to either blocking or non-blocking
+  * mode based on the 'nonblock' boolean argument. This function is highly

--- a/Ports/openssh/patches/fnmatch.patch
+++ b/Ports/openssh/patches/fnmatch.patch
@@ -1,0 +1,20 @@
+diff -Naur openssh-portable-9ca7e9c861775dd6c6312bc8aaab687403d24676/openbsd-compat/fnmatch.h openssh-portable-9ca7e9c861775dd6c6312bc8aaab687403d24676.serenity/openbsd-compat/fnmatch.h
+--- openssh-portable-9ca7e9c861775dd6c6312bc8aaab687403d24676/openbsd-compat/fnmatch.h	2021-04-12 13:48:40.263056972 +0200
++++ openssh-portable-9ca7e9c861775dd6c6312bc8aaab687403d24676.serenity/openbsd-compat/fnmatch.h	2021-04-12 13:48:03.432331975 +0200
+@@ -34,6 +34,16 @@
+ 
+ /* OPENBSD ORIGINAL: include/fnmatch.h */
+ 
++#ifdef __serenity__
++#define	FNM_NOMATCH	1	/* Match failed. */
++
++#define	FNM_NOESCAPE	0x01	/* Disable backslash escaping. */
++#define	FNM_PATHNAME	0x02	/* Slash must be matched by slash. */
++#define	FNM_PERIOD	0x04	/* Period must be matched by period. */
++#define	FNM_CASEFOLD	0x10	/* Case insensitive search. */
++#define	FNM_LEADING_DIR	0x08	/* Ignore /<tail> after Imatch. */
++#endif
++
+ #ifndef HAVE_FNMATCH_H
+ /* Ensure we define FNM_CASEFOLD */
+ #define __BSD_VISIBLE 1

--- a/Ports/openssh/patches/prctl-hack.patch
+++ b/Ports/openssh/patches/prctl-hack.patch
@@ -1,0 +1,12 @@
+diff -Naur openssh-portable-9ca7e9c861775dd6c6312bc8aaab687403d24676/platform-tracing.c openssh-portable-9ca7e9c861775dd6c6312bc8aaab687403d24676.serenity/platform-tracing.c
+--- openssh-portable-9ca7e9c861775dd6c6312bc8aaab687403d24676/platform-tracing.c	2020-05-27 02:38:00.000000000 +0200
++++ openssh-portable-9ca7e9c861775dd6c6312bc8aaab687403d24676.serenity/platform-tracing.c	2021-04-12 13:45:38.662816561 +0200
+@@ -35,7 +35,7 @@
+ {
+ #if defined(HAVE_PRCTL) && defined(PR_SET_DUMPABLE)
+ 	/* Disable ptrace on Linux without sgid bit */
+-	if (prctl(PR_SET_DUMPABLE, 0) != 0 && strict)
++	if (prctl(PR_SET_DUMPABLE, 0, 0) != 0 && strict)
+ 		fatal("unable to make the process undumpable");
+ #endif
+ #if defined(HAVE_SETPFLAGS) && defined(__PROC_PROTECT)

--- a/Userland/Libraries/LibC/arpa/inet.cpp
+++ b/Userland/Libraries/LibC/arpa/inet.cpp
@@ -37,6 +37,10 @@ const char* inet_ntop(int af, const void* src, char* dst, socklen_t len)
         errno = EAFNOSUPPORT;
         return nullptr;
     }
+    if (len < 4) {
+        errno = ENOSPC;
+        return nullptr;
+    }
     auto* bytes = (const unsigned char*)src;
     snprintf(dst, len, "%u.%u.%u.%u", bytes[0], bytes[1], bytes[2], bytes[3]);
     return (const char*)dst;

--- a/Userland/Libraries/LibC/netdb.cpp
+++ b/Userland/Libraries/LibC/netdb.cpp
@@ -342,7 +342,7 @@ struct servent* getservent()
         return nullptr;
 
     __getserv_buffer.s_name = const_cast<char*>(__getserv_name_buffer.characters());
-    __getserv_buffer.s_port = __getserv_port_buffer;
+    __getserv_buffer.s_port = htons(__getserv_port_buffer);
     __getserv_buffer.s_proto = const_cast<char*>(__getserv_protocol_buffer.characters());
 
     __getserv_alias_list.clear_with_capacity();

--- a/Userland/Libraries/LibC/netdb.h
+++ b/Userland/Libraries/LibC/netdb.h
@@ -97,6 +97,7 @@ struct addrinfo {
 #define EAI_SERVICE 9
 #define EAI_SOCKTYPE 10
 #define EAI_SYSTEM 11
+#define EAI_OVERFLOW 12
 
 #define AI_PASSIVE 0x0001
 #define AI_CANONNAME 0x0002
@@ -109,8 +110,12 @@ struct addrinfo {
 #define NI_MAXHOST 1025
 #define NI_MAXSERV 32
 
+#define NI_NUMERICHOST 1
+#define NI_NUMERICSERV 2
+
 int getaddrinfo(const char* __restrict node, const char* __restrict service, const struct addrinfo* __restrict hints, struct addrinfo** __restrict res);
 void freeaddrinfo(struct addrinfo* res);
 const char* gai_strerror(int errcode);
+int getnameinfo(const struct sockaddr* __restrict addr, socklen_t addrlen, char* __restrict host, socklen_t hostlen, char* __restrict serv, socklen_t servlen, int flags);
 
 __END_DECLS


### PR DESCRIPTION
This enables building OpenSSL and OpenSSH. Also, curl can be built with SSL support (depends on the pkg-config changes from #6253 to successfully find the OpenSSL library):

![Screenshot from 2021-04-12 21-43-21](https://user-images.githubusercontent.com/388571/114452305-9893db00-9bd8-11eb-95bb-f4530d874705.png)

Unfortunately OpenSSH crashes after connecting to remove hosts and I haven't quite figured out why. But it's a step in the right direction.

Also, non-blocking I/O in curl didn't work with OpenSSL so I disabled that for now.