### PR TITLE
LibC: getaddrinfo: Set addrinfo sin_port to 0 if service arg is NULL

### DIFF
--- a/Userland/Libraries/LibC/netdb.cpp
+++ b/Userland/Libraries/LibC/netdb.cpp
@@ -362,6 +362,9 @@ struct servent* getservent()
 
 struct servent* getservbyname(const char* name, const char* protocol)
 {
+    if (name == nullptr)
+        return nullptr;
+
     bool previous_file_open_setting = keep_service_file_open;
     setservent(1);
     struct servent* current_service = nullptr;
@@ -689,10 +692,14 @@ int getaddrinfo(const char* __restrict node, const char* __restrict service, con
         svc_ent = getservbyname(service, proto);
     }
     if (!svc_ent) {
-        char* end;
-        port = htons(strtol(service, &end, 10));
-        if (*end)
-            return EAI_FAIL;
+        if (service) {
+            char* end;
+            port = htons(strtol(service, &end, 10));
+            if (*end)
+                return EAI_FAIL;
+        } else {
+            port = htons(0);
+        }
 
         if (hints && hints->ai_socktype != 0)
             socktype = hints->ai_socktype;


### PR DESCRIPTION
This can be tested with the `links` port with `g http://example.com/` (or any host which requires lookup - ie, a domain not an IP address).

Prior to this PR, hostname resolution would crash in `getservbyname()` due to a null pointer. This PR adds a guard clause for null `service` argument to `getservbyname()`, and ensures `getaddrinfo()` sets the port to zero in each returned `addrinfo` struct if `service` is null.

```
CrashDaemon(15): New coredump file: /tmp/coredump/links_27_1618287824
CrashDaemon(15): --- Backtrace for thread #0 (TID 27) ---
CrashDaemon(15): 0x32229b30: [libc.so] strtoll +0x20 (stdlib.cpp:55)
CrashDaemon(15): 0x32229fd0: [libc.so] strtol +0x20 (stdlib.cpp:905)
CrashDaemon(15): 0x3220feec: [libc.so] getaddrinfo +0x39c (netdb.cpp:706)
CrashDaemon(15): 0x0188b2fb: [/usr/local/bin/links] do_real_lookup +0xdb (dns.c:306)
CrashDaemon(15): 0x0188b4fc: [/usr/local/bin/links] lookup_fn +0x2c (dns.c:460)
CrashDaemon(15): 0x018b9e11: [/usr/local/bin/links] start_thread +0x91 (os_dep.c:2658)
CrashDaemon(15): 0x0188b5d4: [/usr/local/bin/links] find_host_no_cache +0xb4 (dns.c:492)
CrashDaemon(15): 0x0188b714: [/usr/local/bin/links] find_host +0x64 (dns.c:624)
CrashDaemon(15): 0x01885d17: [/usr/local/bin/links] make_connection +0x1f7 (connect.c:246)
CrashDaemon(15): 0x018a8dca: [/usr/local/bin/links] http_func +0x4a (http.c:181)
CrashDaemon(15): 0x018bb86b: [/usr/local/bin/links] run_connection +0xfb (sched.c:538)
CrashDaemon(15): 0x018bbb87: [/usr/local/bin/links] try_connection +0x67 (sched.c:616)
CrashDaemon(15): 0x018bbd87: [/usr/local/bin/links] check_queue +0x1e7 (sched.c:677)
CrashDaemon(15): 0x018be1c5: [/usr/local/bin/links] check_bottom_halves +0x65 (select.c:227)
CrashDaemon(15): 0x018bf107: [/usr/local/bin/links] select_loop +0x307 (select.c:1082)
CrashDaemon(15): 0x01874d4e: [/usr/local/bin/links] main +0x4e (main.c:774)
CrashDaemon(15): 0x01874e75: [/usr/local/bin/links] _start +0x45 (crt0_shared.cpp:60)
```

`man getaddrinfo` states as follows:

       service  sets the port in each returned address structure.  If this argument is a service name (see services(5)), it is translated to the corresponding port number.  This argument can also be speci‐
       fied as a decimal number, which is simply converted to binary.  If service is NULL, then the port number of the returned socket addresses will be left uninitialized.  If AI_NUMERICSERV is  specified
       in  hints.ai_flags  and  service is not NULL, then service must point to a string containing a numeric port number.  This flag is used to inhibit the invocation of a name resolution service in cases
       where it is known not to be required.
