### PR TITLE
Ports: Fix building the stress-ng port

### DIFF
--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -566,6 +566,7 @@ KResultOr<FlatPtr> Process::sys$mremap(Userspace<const Syscall::SC_mremap_params
         auto range = old_region->range();
         auto old_name = old_region->name();
         auto old_prot = region_access_flags_to_prot(old_region->access());
+        auto old_offset = old_region->offset_in_vmobject();
         NonnullRefPtr inode = static_cast<SharedInodeVMObject&>(old_region->vmobject()).inode();
 
         // Unmap without deallocating the VM range since we're going to reuse it.
@@ -575,7 +576,7 @@ KResultOr<FlatPtr> Process::sys$mremap(Userspace<const Syscall::SC_mremap_params
 
         auto new_vmobject = PrivateInodeVMObject::create_with_inode(inode);
 
-        auto new_region_or_error = space().allocate_region_with_vmobject(range, new_vmobject, 0, old_name, old_prot, false);
+        auto new_region_or_error = space().allocate_region_with_vmobject(range, new_vmobject, old_offset, old_name, old_prot, false);
         if (new_region_or_error.is_error())
             return new_region_or_error.error().error();
         auto& new_region = *new_region_or_error.value();

--- a/Ports/stress-ng/package.sh
+++ b/Ports/stress-ng/package.sh
@@ -2,4 +2,9 @@
 port=stress-ng
 version=0.11.23
 files="https://github.com/ColinIanKing/stress-ng/archive/V${version}.tar.gz stress-ng-${version}.tar.gz"
-makeopts="STATIC=1 LDFLAGS=-L${SERENITY_BUILD_DIR}/Root/usr/local/lib"
+depends=zlib
+
+pre_configure() {
+    export CFLAGS="-I${SERENITY_BUILD_DIR}/Root/usr/local/include"
+    export LDFLAGS="-L${SERENITY_BUILD_DIR}/Root/usr/local/lib -lzlib"
+}

--- a/Ports/stress-ng/patches/0005-misc-fixups.patch
+++ b/Ports/stress-ng/patches/0005-misc-fixups.patch
@@ -276,21 +276,14 @@ diff -ur a/stress-ng.h b/stress-ng.h
  #include <setjmp.h>
  #include <signal.h>
  #include <stdarg.h>
-@@ -1093,14 +1092,6 @@
+@@ -1092,6 +1092,7 @@
  #define PACKED
  #endif
  
--/* force inlining hint */
--#if defined(__GNUC__) && NEED_GNUC(3,4,0)	/* or possibly earlier */ \
-- && ((!defined(__s390__) && !defined(__s390x__)) || NEED_GNUC(6,0,1))
--#define ALWAYS_INLINE	__attribute__ ((always_inline))
--#else
--#define ALWAYS_INLINE
--#endif
--
- /* force no inlining hint */
- #if defined(__GNUC__) && NEED_GNUC(3,4,0)	/* or possibly earier */
- #define NOINLINE	__attribute__ ((noinline))
++#undef ALWAYS_INLINE
+ /* force inlining hint */
+ #if defined(__GNUC__) && NEED_GNUC(3,4,0)	/* or possibly earlier */ \
+  && ((!defined(__s390__) && !defined(__s390x__)) || NEED_GNUC(6,0,1))
 @@ -2230,7 +2221,6 @@
  		uint64_t timeout[STRESS_PROCS_MAX];	/* Shared futex timeouts */
  	} futex;
@@ -579,3 +572,58 @@ iff -ur a/stress-schedpolicy.c b/stress-schedpolicy.c
  #if defined(SCHED_RR)
  		case SCHED_RR:
 
+diff -Naur stress-ng-0.11.23/core-net.c stress-ng-0.11.23.serenity/core-net.c
+--- stress-ng-0.11.23/core-net.c	2021-04-13 03:20:49.389317525 +0200
++++ stress-ng-0.11.23.serenity/core-net.c	2021-04-13 03:21:42.786948162 +0200
+@@ -114,6 +114,7 @@
+ 		break;
+ 	}
+ #endif
++#ifndef __serenity__
+ #if defined(AF_INET6)
+ 	case AF_INET6: {
+ 		static struct sockaddr_in6 addr;
+@@ -138,6 +139,7 @@
+ 		break;
+ 	}
+ #endif
++#endif
+ #if defined(AF_UNIX)
+ 	case AF_UNIX: {
+ 		static struct sockaddr_un addr;
+@@ -176,6 +178,7 @@
+ 		break;
+ 	}
+ #endif
++#ifndef __serenity__
+ #if defined(AF_INET6)
+ 	case AF_INET6: {
+ 		struct sockaddr_in6 *addr = (struct sockaddr_in6 *)sockaddr;
+@@ -183,6 +186,7 @@
+ 		break;
+ 	}
+ #endif
++#endif
+ #if defined(AF_UNIX)
+ 	case AF_UNIX:
+ 		break;
+diff -Naur stress-ng-0.11.23/stress-zlib.c stress-ng-0.11.23.serenity/stress-zlib.c
+--- stress-ng-0.11.23/stress-zlib.c	2021-04-13 03:29:29.112182330 +0200
++++ stress-ng-0.11.23.serenity/stress-zlib.c	2021-04-13 03:28:52.128162386 +0200
+@@ -698,14 +698,14 @@
+ 	register int i;
+ 
+ 	if (UNLIKELY(!seeded)) {
+-		srand48(stress_mwc32());
++		srand(stress_mwc32());
+ 		seeded = true;
+ 	}
+ 
+ 	(void)args;
+ 
+ 	for (i = 0; i < n; i++, data++)
+-		*data = lrand48();
++		*data = rand();
+ }
+ 
+ /*

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -276,7 +276,7 @@ void ELF::DynamicLinker::linker_main(String&& main_program_name, int main_progra
         auto main_executable_loader = load_main_executable(main_program_name);
         auto entry_point = main_executable_loader->image().entry();
         if (main_executable_loader->is_dynamic())
-            entry_point = entry_point.offset(main_executable_loader->text_segment_load_address().get());
+            entry_point = entry_point.offset(main_executable_loader->base_address().get());
         return (EntryPointFunction)(entry_point.as_ptr());
     }();
 

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -38,6 +38,22 @@
 
 namespace ELF {
 
+class LoadedSegment {
+public:
+    LoadedSegment(VirtualAddress address, size_t size)
+        : m_address(address)
+        , m_size(size)
+    {
+    }
+
+    VirtualAddress address() const { return m_address; }
+    size_t size() const { return m_size; }
+
+private:
+    VirtualAddress m_address;
+    size_t m_size;
+};
+
 class DynamicLoader : public RefCounted<DynamicLoader> {
 public:
     static RefPtr<DynamicLoader> try_create(int fd, String filename);
@@ -74,7 +90,8 @@ public:
     template<typename F>
     void for_each_needed_library(F) const;
 
-    VirtualAddress text_segment_load_address() const { return m_text_segment_load_address; }
+    VirtualAddress base_address() const { return m_base_address; }
+    const Vector<LoadedSegment> text_segments() const { return m_text_segments; }
     bool is_dynamic() const { return m_elf_image.is_dynamic(); }
 
     static Optional<DynamicObject::SymbolLookupResult> lookup_symbol(const ELF::DynamicObject::Symbol&);
@@ -141,8 +158,8 @@ private:
 
     RefPtr<DynamicObject> m_dynamic_object;
 
-    VirtualAddress m_text_segment_load_address;
-    size_t m_text_segment_size { 0 };
+    VirtualAddress m_base_address;
+    Vector<LoadedSegment> m_text_segments;
 
     VirtualAddress m_relro_segment_address;
     size_t m_relro_segment_size { 0 };

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -38,9 +38,9 @@ namespace ELF {
 
 static const char* name_for_dtag(Elf32_Sword d_tag);
 
-DynamicObject::DynamicObject(VirtualAddress base_address, VirtualAddress dynamic_section_addresss)
+DynamicObject::DynamicObject(VirtualAddress base_address, VirtualAddress dynamic_section_address)
     : m_base_address(base_address)
-    , m_dynamic_address(dynamic_section_addresss)
+    , m_dynamic_address(dynamic_section_address)
 {
     auto* header = (Elf32_Ehdr*)base_address.as_ptr();
     auto* pheader = (Elf32_Phdr*)(base_address.as_ptr() + header->e_phoff);


### PR DESCRIPTION
This fixes a number of things:

* `mremap()` incorrectly resets the mapping's offset to zero when a non-zero offset was originally specified in `mmap()`.
* Add support for ELF objects where the text segment doesn't start at offset zero. For this to work `should_make_executable_exception_for_dynamic_loader()` now reads from the inode rather than the mapping.
* Add support for loading ELF objects which have multiple text and data segments.
* Build fixes for the stress-ng port.

![Screenshot from 2021-04-13 19-46-12](https://user-images.githubusercontent.com/388571/114598154-dbfe5000-9c91-11eb-9d8c-a9de842eff7c.png)