### PR TITLE
LibWeb: Make ExceptionOr work with non-JS::Value types 

### DIFF
--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -1514,9 +1514,11 @@ JS_DEFINE_NATIVE_FUNCTION(@prototype_class@::@function.name:snakecase@)
         function_generator.set(".arguments", arguments_builder.string_view());
 
         function_generator.append(R"~~~(
-    auto retval = throw_dom_exception_if_needed(vm, global_object, [&] { return impl->@function.cpp_name@(@.arguments@); });
-    if (should_return_empty(retval))
+    auto result = throw_dom_exception_if_needed(vm, global_object, [&] { return impl->@function.cpp_name@(@.arguments@); });
+    if (should_return_empty(result))
         return JS::Value();
+
+    [[maybe_unused]] auto retval = result.release_value();
 )~~~");
 
         generate_return_statement(function.return_type);

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -743,17 +743,13 @@ void Document::adopt_node(Node& node)
 }
 
 // https://dom.spec.whatwg.org/#dom-document-adoptnode
-NonnullRefPtr<Node> Document::adopt_node_binding(NonnullRefPtr<Node> node)
+ExceptionOr<NonnullRefPtr<Node>> Document::adopt_node_binding(NonnullRefPtr<Node> node)
 {
-    if (is<Document>(*node)) {
-        dbgln("Document::adopt_node_binding: Cannot adopt a document into a document (FIXME: throw as NotSupportedError exception, see issue #6075");
-        return node;
-    }
+    if (is<Document>(*node))
+        return DOM ::NotSupportedError::create("Cannot adopt a document into a document");
 
-    if (is<ShadowRoot>(*node)) {
-        dbgln("Document::adopt_node_binding: Cannot adopt a shadow root into a document (FIXME: throw as HierarchyRequestError exception, see issue #6075");
-        return node;
-    }
+    if (is<ShadowRoot>(*node))
+        return DOM::HierarchyRequestError::create("Cannot adopt a shadow root into a document");
 
     if (is<DocumentFragment>(*node) && downcast<DocumentFragment>(*node).host())
         return node;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -189,7 +189,7 @@ public:
     void set_quirks_mode(QuirksMode mode) { m_quirks_mode = mode; }
 
     void adopt_node(Node&);
-    NonnullRefPtr<Node> adopt_node_binding(NonnullRefPtr<Node>);
+    ExceptionOr<NonnullRefPtr<Node>> adopt_node_binding(NonnullRefPtr<Node>);
 
     const DocumentType* doctype() const;
     const String& compat_mode() const;

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -280,13 +280,11 @@ void Node::insert_before(NonnullRefPtr<Node> node, RefPtr<Node> child, bool supp
 }
 
 // https://dom.spec.whatwg.org/#concept-node-pre-insert
-NonnullRefPtr<Node> Node::pre_insert(NonnullRefPtr<Node> node, RefPtr<Node> child)
+ExceptionOr<NonnullRefPtr<Node>> Node::pre_insert(NonnullRefPtr<Node> node, RefPtr<Node> child)
 {
     auto validity_result = ensure_pre_insertion_validity(node, child);
-    if (validity_result.is_exception()) {
-        dbgln("Node::pre_insert: ensure_pre_insertion_validity failed: {}. (FIXME: throw as exception, see issue #6075)", validity_result.exception().message());
-        return node;
-    }
+    if (validity_result.is_exception())
+        return NonnullRefPtr<DOMException>(validity_result.exception());
 
     auto reference_child = child;
     if (reference_child == node)
@@ -297,12 +295,10 @@ NonnullRefPtr<Node> Node::pre_insert(NonnullRefPtr<Node> node, RefPtr<Node> chil
 }
 
 // https://dom.spec.whatwg.org/#concept-node-pre-remove
-NonnullRefPtr<Node> Node::pre_remove(NonnullRefPtr<Node> child)
+ExceptionOr<NonnullRefPtr<Node>> Node::pre_remove(NonnullRefPtr<Node> child)
 {
-    if (child->parent() != this) {
-        dbgln("Node::pre_remove: Child doesn't belong to this node. (FIXME: throw NotFoundError DOMException, see issue #6075)");
-        return child;
-    }
+    if (child->parent() != this)
+        return DOM::NotFoundError::create("Child does not belong to this node");
 
     child->remove();
 
@@ -310,7 +306,7 @@ NonnullRefPtr<Node> Node::pre_remove(NonnullRefPtr<Node> child)
 }
 
 // https://dom.spec.whatwg.org/#concept-node-append
-NonnullRefPtr<Node> Node::append_child(NonnullRefPtr<Node> node)
+ExceptionOr<NonnullRefPtr<Node>> Node::append_child(NonnullRefPtr<Node> node)
 {
     return pre_insert(node, nullptr);
 }

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -93,10 +93,10 @@ public:
 
     virtual bool is_editable() const;
 
-    NonnullRefPtr<Node> pre_insert(NonnullRefPtr<Node>, RefPtr<Node>);
-    NonnullRefPtr<Node> pre_remove(NonnullRefPtr<Node>);
+    ExceptionOr<NonnullRefPtr<Node>> pre_insert(NonnullRefPtr<Node>, RefPtr<Node>);
+    ExceptionOr<NonnullRefPtr<Node>> pre_remove(NonnullRefPtr<Node>);
 
-    NonnullRefPtr<Node> append_child(NonnullRefPtr<Node>);
+    ExceptionOr<NonnullRefPtr<Node>> append_child(NonnullRefPtr<Node>);
     void insert_before(NonnullRefPtr<Node> node, RefPtr<Node> child, bool suppress_observers = false);
     void remove(bool suppress_observers = false);
     void remove_all_children(bool suppress_observers = false);


### PR DESCRIPTION
Fixes #6075.

cc @Lubrsi: Please double-check the exceptions I returned; I used the comments, but one case was just "throw an exception", not sure if I did the right thing.