### PR TITLE
HackStudio+LibDebug: Improve the debugger "lifecycle"

### DIFF
--- a/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
@@ -110,6 +110,11 @@ int Debugger::start_static()
     return 0;
 }
 
+void Debugger::stop()
+{
+    set_requested_debugger_action(DebuggerAction::Exit);
+}
+
 void Debugger::start()
 {
     m_debug_session = Debug::DebugSession::exec_and_attach(m_executable_path, m_source_root);
@@ -190,11 +195,9 @@ int Debugger::debugger_loop()
             do_step_over(regs);
             return Debug::DebugSession::DebugDecision::Continue;
         case DebuggerAction::Exit:
-            // NOTE: Is detaching from the debuggee the best thing to do here?
-            // We could display a dialog in the UI, remind the user that there is
-            // a live debugged process, and ask whether they want to terminate/detach.
             dbgln("Debugger exiting");
-            return Debug::DebugSession::DebugDecision::Detach;
+            m_on_exit_callback();
+            return Debug::DebugSession::DebugDecision::Kill;
         }
         VERIFY_NOT_REACHED();
     });

--- a/Userland/DevTools/HackStudio/Debugger/Debugger.h
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.h
@@ -60,6 +60,8 @@ public:
 
     Debug::DebugSession* session() { return m_debug_session.ptr(); }
 
+    void stop();
+
     // Thread entry point
     static int start_static();
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -676,6 +676,7 @@ void HackStudioWidget::initialize_debugger()
                 m_debug_info_widget->program_stopped();
                 m_disassembly_widget->program_stopped();
                 m_stop_action->set_enabled(false);
+                m_debugger_thread.clear();
                 HackStudioWidget::hide_action_tabs();
                 GUI::MessageBox::show(window(), "Program Exited", "Debugger", GUI::MessageBox::Type::Information);
             }));

--- a/Userland/Libraries/LibDebug/DebugSession.h
+++ b/Userland/Libraries/LibDebug/DebugSession.h
@@ -352,7 +352,8 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
             break;
         }
         if (decision == DebugDecision::Kill) {
-            VERIFY_NOT_REACHED(); // TODO: implement
+            kill(m_debuggee_pid, SIGTERM);
+            break;
         }
 
         if (state == State::SingleStep && !did_single_step) {


### PR DESCRIPTION
Adds support for stopping a currently debugged process. Also implements cleaning up the debugger thread when debugging is finished, which fixes #4393.