### PR TITLE
LibWeb: Actually return an empty value when an exception is thrown via throw_dom_exception_if_needed()

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
+++ b/Userland/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
@@ -104,8 +104,8 @@ template<typename T>
 bool should_return_empty(const Optional<T>& value)
 {
     if constexpr (IsSame<JS::Value, T>)
-        return value.has_value() && value.value().is_empty();
-    return false;
+        return !value.has_value() || value.value().is_empty();
+    return !value.has_value();
 }
 
 }


### PR DESCRIPTION
(yes, actually) Fixes #6298.

__burning_ hotfix to bring the issue count back under 400 :P
