### PR TITLE
Browser+LibWeb: Move cookie structures into LibWeb and support HttpOnly cookies

### DIFF
--- a/Base/res/html/misc/cookie.html
+++ b/Base/res/html/misc/cookie.html
@@ -9,7 +9,7 @@
     <br /><input id=invalid1 type=button onclick="setCookie(this.value)" value="cookie4=value4; domain=serenityos.org" />
     <label for=invalid1>The Domain attribute does not domain-match this page</label>
     <br /><input id=invalid2 type=button onclick="setCookie(this.value)" value="cookie5=value5; httponly" />
-    <label for=invalid2>The cookie is HttpOnly thus cannot be set via JavaScript (*not yet implemented*)</label>
+    <label for=invalid2>The cookie is HttpOnly thus cannot be set via JavaScript</label>
     <br /><input id=invalid3 type=button onclick="setCookie(this.value)" value="cookie6=value6; max-age=-1" />
     <label for=invalid3>The cookie expired in the past</label>
     <br /><input id=invalid4 type=button onclick="setCookie(this.value)" value="cookie7=value7; expires=Mon, 23 Jan 1989 08:10:36 GMT" />

--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -157,7 +157,7 @@ void CookieJar::store_cookie(Web::Cookie::ParsedCookie& parsed_cookie, const URL
     // https://tools.ietf.org/html/rfc6265#section-5.3
 
     // 2. Create a new cookie with name cookie-name, value cookie-value. Set the creation-time and the last-access-time to the current date and time.
-    Cookie cookie { move(parsed_cookie.name), move(parsed_cookie.value) };
+    Web::Cookie::Cookie cookie { move(parsed_cookie.name), move(parsed_cookie.value) };
     cookie.creation_time = Core::DateTime::now();
     cookie.last_access_time = cookie.creation_time;
 

--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -33,7 +33,7 @@
 
 namespace Browser {
 
-String CookieJar::get_cookie(const URL& url)
+String CookieJar::get_cookie(const URL& url, Web::Cookie::Source)
 {
     purge_expired_cookies();
 
@@ -55,7 +55,7 @@ String CookieJar::get_cookie(const URL& url)
     return builder.build();
 }
 
-void CookieJar::set_cookie(const URL& url, const String& cookie_string)
+void CookieJar::set_cookie(const URL& url, const String& cookie_string, Web::Cookie::Source)
 {
     auto domain = canonicalize_domain(url);
     if (!domain.has_value())

--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -25,25 +25,13 @@
  */
 
 #include "CookieJar.h"
-#include <AK/AllOf.h>
 #include <AK/IPv4Address.h>
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
 #include <AK/Vector.h>
-#include <ctype.h>
+#include <LibWeb/Cookie/ParsedCookie.h>
 
 namespace Browser {
-
-struct ParsedCookie {
-    String name;
-    String value;
-    Optional<Core::DateTime> expiry_time_from_expires_attribute {};
-    Optional<Core::DateTime> expiry_time_from_max_age_attribute {};
-    Optional<String> domain {};
-    Optional<String> path {};
-    bool secure_attribute_present { false };
-    bool http_only_attribute_present { false };
-};
 
 String CookieJar::get_cookie(const URL& url)
 {
@@ -73,7 +61,7 @@ void CookieJar::set_cookie(const URL& url, const String& cookie_string)
     if (!domain.has_value())
         return;
 
-    auto parsed_cookie = parse_cookie(cookie_string);
+    auto parsed_cookie = Web::Cookie::parse_cookie(cookie_string);
     if (!parsed_cookie.has_value())
         return;
 
@@ -118,332 +106,6 @@ Optional<String> CookieJar::canonicalize_domain(const URL& url)
     return url.host().to_lowercase();
 }
 
-String CookieJar::default_path(const URL& url)
-{
-    // https://tools.ietf.org/html/rfc6265#section-5.1.4
-
-    // 1. Let uri-path be the path portion of the request-uri if such a portion exists (and empty otherwise).
-    String uri_path = url.path();
-
-    // 2. If the uri-path is empty or if the first character of the uri-path is not a %x2F ("/") character, output %x2F ("/") and skip the remaining steps.
-    if (uri_path.is_empty() || (uri_path[0] != '/'))
-        return "/";
-
-    StringView uri_path_view = uri_path;
-    std::size_t last_separator = uri_path_view.find_last_of('/').value();
-
-    // 3. If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step.
-    if (last_separator == 0)
-        return "/";
-
-    // 4. Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/").
-    return uri_path.substring(0, last_separator);
-}
-
-Optional<ParsedCookie> CookieJar::parse_cookie(const String& cookie_string)
-{
-    // https://tools.ietf.org/html/rfc6265#section-5.2
-    StringView name_value_pair;
-    StringView unparsed_attributes;
-
-    // 1. If the set-cookie-string contains a %x3B (";") character:
-    if (auto position = cookie_string.find(';'); position.has_value()) {
-        // The name-value-pair string consists of the characters up to, but not including, the first %x3B (";"), and the unparsed-
-        // attributes consist of the remainder of the set-cookie-string (including the %x3B (";") in question).
-        name_value_pair = cookie_string.substring_view(0, position.value());
-        unparsed_attributes = cookie_string.substring_view(position.value());
-    } else {
-        // The name-value-pair string consists of all the characters contained in the set-cookie-string, and the unparsed-
-        // attributes is the empty string.
-        name_value_pair = cookie_string;
-    }
-
-    StringView name;
-    StringView value;
-
-    if (auto position = name_value_pair.find('='); position.has_value()) {
-        // 3. The (possibly empty) name string consists of the characters up to, but not including, the first %x3D ("=") character, and the
-        //    (possibly empty) value string consists of the characters after the first %x3D ("=") character.
-        name = name_value_pair.substring_view(0, position.value());
-
-        if (position.value() < name_value_pair.length() - 1)
-            value = name_value_pair.substring_view(position.value() + 1);
-    } else {
-        // 2. If the name-value-pair string lacks a %x3D ("=") character, ignore the set-cookie-string entirely.
-        return {};
-    }
-
-    // 4. Remove any leading or trailing WSP characters from the name string and the value string.
-    name = name.trim_whitespace();
-    value = value.trim_whitespace();
-
-    // 5. If the name string is empty, ignore the set-cookie-string entirely.
-    if (name.is_empty())
-        return {};
-
-    // 6. The cookie-name is the name string, and the cookie-value is the value string.
-    ParsedCookie parsed_cookie { name, value };
-
-    parse_attributes(parsed_cookie, unparsed_attributes);
-    return parsed_cookie;
-}
-
-void CookieJar::parse_attributes(ParsedCookie& parsed_cookie, StringView unparsed_attributes)
-{
-    // 1. If the unparsed-attributes string is empty, skip the rest of these steps.
-    if (unparsed_attributes.is_empty())
-        return;
-
-    // 2. Discard the first character of the unparsed-attributes (which will be a %x3B (";") character).
-    unparsed_attributes = unparsed_attributes.substring_view(1);
-
-    StringView cookie_av;
-
-    // 3. If the remaining unparsed-attributes contains a %x3B (";") character:
-    if (auto position = unparsed_attributes.find(';'); position.has_value()) {
-        // Consume the characters of the unparsed-attributes up to, but not including, the first %x3B (";") character.
-        cookie_av = unparsed_attributes.substring_view(0, position.value());
-        unparsed_attributes = unparsed_attributes.substring_view(position.value());
-    } else {
-        // Consume the remainder of the unparsed-attributes.
-        cookie_av = unparsed_attributes;
-        unparsed_attributes = {};
-    }
-
-    StringView attribute_name;
-    StringView attribute_value;
-
-    // 4. If the cookie-av string contains a %x3D ("=") character:
-    if (auto position = cookie_av.find('='); position.has_value()) {
-        // The (possibly empty) attribute-name string consists of the characters up to, but not including, the first %x3D ("=")
-        // character, and the (possibly empty) attribute-value string consists of the characters after the first %x3D ("=") character.
-        attribute_name = cookie_av.substring_view(0, position.value());
-
-        if (position.value() < cookie_av.length() - 1)
-            attribute_value = cookie_av.substring_view(position.value() + 1);
-    } else {
-        // The attribute-name string consists of the entire cookie-av string, and the attribute-value string is empty.
-        attribute_name = cookie_av;
-    }
-
-    // 5. Remove any leading or trailing WSP characters from the attribute-name string and the attribute-value string.
-    attribute_name = attribute_name.trim_whitespace();
-    attribute_value = attribute_value.trim_whitespace();
-
-    // 6. Process the attribute-name and attribute-value according to the requirements in the following subsections.
-    //    (Notice that attributes with unrecognized attribute-names are ignored.)
-    process_attribute(parsed_cookie, attribute_name, attribute_value);
-
-    // 7. Return to Step 1 of this algorithm.
-    parse_attributes(parsed_cookie, unparsed_attributes);
-}
-
-void CookieJar::process_attribute(ParsedCookie& parsed_cookie, StringView attribute_name, StringView attribute_value)
-{
-    if (attribute_name.equals_ignoring_case("Expires")) {
-        on_expires_attribute(parsed_cookie, attribute_value);
-    } else if (attribute_name.equals_ignoring_case("Max-Age")) {
-        on_max_age_attribute(parsed_cookie, attribute_value);
-    } else if (attribute_name.equals_ignoring_case("Domain")) {
-        on_domain_attribute(parsed_cookie, attribute_value);
-    } else if (attribute_name.equals_ignoring_case("Path")) {
-        on_path_attribute(parsed_cookie, attribute_value);
-    } else if (attribute_name.equals_ignoring_case("Secure")) {
-        on_secure_attribute(parsed_cookie);
-    } else if (attribute_name.equals_ignoring_case("HttpOnly")) {
-        on_http_only_attribute(parsed_cookie);
-    }
-}
-
-void CookieJar::on_expires_attribute(ParsedCookie& parsed_cookie, StringView attribute_value)
-{
-    // https://tools.ietf.org/html/rfc6265#section-5.2.1
-    if (auto expiry_time = parse_date_time(attribute_value); expiry_time.has_value())
-        parsed_cookie.expiry_time_from_expires_attribute = move(*expiry_time);
-}
-
-void CookieJar::on_max_age_attribute(ParsedCookie& parsed_cookie, StringView attribute_value)
-{
-    // https://tools.ietf.org/html/rfc6265#section-5.2.2
-
-    // If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av.
-    if (attribute_value.is_empty() || (!isdigit(attribute_value[0]) && (attribute_value[0] != '-')))
-        return;
-
-    // Let delta-seconds be the attribute-value converted to an integer.
-    if (auto delta_seconds = attribute_value.to_int(); delta_seconds.has_value()) {
-        Core::DateTime expiry_time;
-
-        if (*delta_seconds <= 0) {
-            // If delta-seconds is less than or equal to zero (0), let expiry-time be the earliest representable date and time.
-            parsed_cookie.expiry_time_from_max_age_attribute = Core::DateTime::from_timestamp(0);
-        } else {
-            // Otherwise, let the expiry-time be the current date and time plus delta-seconds seconds.
-            time_t now = Core::DateTime::now().timestamp();
-            parsed_cookie.expiry_time_from_max_age_attribute = Core::DateTime::from_timestamp(now + *delta_seconds);
-        }
-    }
-}
-
-void CookieJar::on_domain_attribute(ParsedCookie& parsed_cookie, StringView attribute_value)
-{
-    // https://tools.ietf.org/html/rfc6265#section-5.2.3
-
-    // If the attribute-value is empty, the behavior is undefined. However, the user agent SHOULD ignore the cookie-av entirely.
-    if (attribute_value.is_empty())
-        return;
-
-    StringView cookie_domain;
-
-    // If the first character of the attribute-value string is %x2E ("."):
-    if (attribute_value[0] == '.') {
-        // Let cookie-domain be the attribute-value without the leading %x2E (".") character.
-        cookie_domain = attribute_value.substring_view(1);
-    } else {
-        // Let cookie-domain be the entire attribute-value.
-        cookie_domain = attribute_value;
-    }
-
-    // Convert the cookie-domain to lower case.
-    parsed_cookie.domain = String(cookie_domain).to_lowercase();
-}
-
-void CookieJar::on_path_attribute(ParsedCookie& parsed_cookie, StringView attribute_value)
-{
-    // https://tools.ietf.org/html/rfc6265#section-5.2.4
-
-    // If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):
-    if (attribute_value.is_empty() || attribute_value[0] != '/')
-        // Let cookie-path be the default-path.
-        return;
-
-    // Let cookie-path be the attribute-value
-    parsed_cookie.path = attribute_value;
-}
-
-void CookieJar::on_secure_attribute(ParsedCookie& parsed_cookie)
-{
-    // https://tools.ietf.org/html/rfc6265#section-5.2.5
-    parsed_cookie.secure_attribute_present = true;
-}
-
-void CookieJar::on_http_only_attribute(ParsedCookie& parsed_cookie)
-{
-    // https://tools.ietf.org/html/rfc6265#section-5.2.6
-    parsed_cookie.http_only_attribute_present = true;
-}
-
-Optional<Core::DateTime> CookieJar::parse_date_time(StringView date_string)
-{
-    // https://tools.ietf.org/html/rfc6265#section-5.1.1
-    unsigned hour = 0;
-    unsigned minute = 0;
-    unsigned second = 0;
-    unsigned day_of_month = 0;
-    unsigned month = 0;
-    unsigned year = 0;
-
-    auto to_uint = [](StringView token, unsigned& result) {
-        if (!all_of(token.begin(), token.end(), isdigit))
-            return false;
-
-        if (auto converted = token.to_uint(); converted.has_value()) {
-            result = *converted;
-            return true;
-        }
-
-        return false;
-    };
-
-    auto parse_time = [&](StringView token) {
-        Vector<StringView> parts = token.split_view(':');
-        if (parts.size() != 3)
-            return false;
-
-        for (const auto& part : parts) {
-            if (part.is_empty() || part.length() > 2)
-                return false;
-        }
-
-        return to_uint(parts[0], hour) && to_uint(parts[1], minute) && to_uint(parts[2], second);
-    };
-
-    auto parse_day_of_month = [&](StringView token) {
-        if (token.is_empty() || token.length() > 2)
-            return false;
-        return to_uint(token, day_of_month);
-    };
-
-    auto parse_month = [&](StringView token) {
-        static const char* months[] { "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec" };
-
-        for (unsigned i = 0; i < 12; ++i) {
-            if (token.equals_ignoring_case(months[i])) {
-                month = i + 1;
-                return true;
-            }
-        }
-
-        return false;
-    };
-
-    auto parse_year = [&](StringView token) {
-        if (token.length() != 2 && token.length() != 4)
-            return false;
-        return to_uint(token, year);
-    };
-
-    auto is_delimeter = [](char ch) {
-        return ch == 0x09 || (ch >= 0x20 && ch <= 0x2f) || (ch >= 0x3b && ch <= 0x40) || (ch >= 0x5b && ch <= 0x60) || (ch >= 0x7b && ch <= 0x7e);
-    };
-
-    // 1. Using the grammar below, divide the cookie-date into date-tokens.
-    Vector<StringView> date_tokens = date_string.split_view_if(is_delimeter);
-
-    // 2. Process each date-token sequentially in the order the date-tokens appear in the cookie-date.
-    bool found_time = false;
-    bool found_day_of_month = false;
-    bool found_month = false;
-    bool found_year = false;
-
-    for (const auto& date_token : date_tokens) {
-        if (!found_time && parse_time(date_token)) {
-            found_time = true;
-        } else if (!found_day_of_month && parse_day_of_month(date_token)) {
-            found_day_of_month = true;
-        } else if (!found_month && parse_month(date_token)) {
-            found_month = true;
-        } else if (!found_year && parse_year(date_token)) {
-            found_year = true;
-        }
-    }
-
-    // 3. If the year-value is greater than or equal to 70 and less than or equal to 99, increment the year-value by 1900.
-    if (year >= 70 && year <= 99)
-        year += 1900;
-
-    // 4. If the year-value is greater than or equal to 0 and less than or equal to 69, increment the year-value by 2000.
-    if (year <= 69)
-        year += 2000;
-
-    // 5. Abort these steps and fail to parse the cookie-date if:
-    if (!found_time || !found_day_of_month || !found_month || !found_year)
-        return {};
-    if (day_of_month < 1 || day_of_month > 31)
-        return {};
-    if (year < 1601)
-        return {};
-    if (hour > 23)
-        return {};
-    if (minute > 59)
-        return {};
-    if (second > 59)
-        return {};
-
-    // FIXME: Fail on dates that do not exist.
-    return Core::DateTime::create(year, month, day_of_month, hour, minute, second);
-}
-
 bool CookieJar::domain_matches(const String& string, const String& domain_string)
 {
     // https://tools.ietf.org/html/rfc6265#section-5.1.3
@@ -468,7 +130,29 @@ bool CookieJar::domain_matches(const String& string, const String& domain_string
     return true;
 }
 
-void CookieJar::store_cookie(ParsedCookie& parsed_cookie, const URL& url, String canonicalized_domain)
+String CookieJar::default_path(const URL& url)
+{
+    // https://tools.ietf.org/html/rfc6265#section-5.1.4
+
+    // 1. Let uri-path be the path portion of the request-uri if such a portion exists (and empty otherwise).
+    String uri_path = url.path();
+
+    // 2. If the uri-path is empty or if the first character of the uri-path is not a %x2F ("/") character, output %x2F ("/") and skip the remaining steps.
+    if (uri_path.is_empty() || (uri_path[0] != '/'))
+        return "/";
+
+    StringView uri_path_view = uri_path;
+    std::size_t last_separator = uri_path_view.find_last_of('/').value();
+
+    // 3. If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step.
+    if (last_separator == 0)
+        return "/";
+
+    // 4. Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/").
+    return uri_path.substring(0, last_separator);
+}
+
+void CookieJar::store_cookie(Web::Cookie::ParsedCookie& parsed_cookie, const URL& url, String canonicalized_domain)
 {
     // https://tools.ietf.org/html/rfc6265#section-5.3
 

--- a/Userland/Applications/Browser/CookieJar.h
+++ b/Userland/Applications/Browser/CookieJar.h
@@ -46,8 +46,8 @@ struct CookieStorageKey {
 
 class CookieJar {
 public:
-    String get_cookie(const URL& url);
-    void set_cookie(const URL& url, const String& cookie);
+    String get_cookie(const URL& url, Web::Cookie::Source source);
+    void set_cookie(const URL& url, const String& cookie, Web::Cookie::Source source);
     void dump_cookies() const;
 
 private:

--- a/Userland/Applications/Browser/CookieJar.h
+++ b/Userland/Applications/Browser/CookieJar.h
@@ -31,6 +31,7 @@
 #include <AK/String.h>
 #include <AK/Traits.h>
 #include <LibCore/DateTime.h>
+#include <LibWeb/Forward.h>
 
 namespace Browser {
 
@@ -48,8 +49,6 @@ struct Cookie {
     bool persistent { false };
 };
 
-struct ParsedCookie;
-
 struct CookieStorageKey {
     bool operator==(const CookieStorageKey&) const = default;
 
@@ -66,20 +65,10 @@ public:
 
 private:
     static Optional<String> canonicalize_domain(const URL& url);
-    static String default_path(const URL& url);
-    static Optional<ParsedCookie> parse_cookie(const String& cookie_string);
-    static void parse_attributes(ParsedCookie& parsed_cookie, StringView unparsed_attributes);
-    static void process_attribute(ParsedCookie& parsed_cookie, StringView attribute_name, StringView attribute_value);
-    static void on_expires_attribute(ParsedCookie& parsed_cookie, StringView attribute_value);
-    static void on_max_age_attribute(ParsedCookie& parsed_cookie, StringView attribute_value);
-    static void on_domain_attribute(ParsedCookie& parsed_cookie, StringView attribute_value);
-    static void on_path_attribute(ParsedCookie& parsed_cookie, StringView attribute_value);
-    static void on_secure_attribute(ParsedCookie& parsed_cookie);
-    static void on_http_only_attribute(ParsedCookie& parsed_cookie);
-    static Optional<Core::DateTime> parse_date_time(StringView date_string);
     static bool domain_matches(const String& string, const String& domain_string);
+    static String default_path(const URL& url);
 
-    void store_cookie(ParsedCookie& parsed_cookie, const URL& url, String canonicalized_domain);
+    void store_cookie(Web::Cookie::ParsedCookie& parsed_cookie, const URL& url, String canonicalized_domain);
     void purge_expired_cookies();
 
     HashMap<CookieStorageKey, Cookie> m_cookies;

--- a/Userland/Applications/Browser/CookieJar.h
+++ b/Userland/Applications/Browser/CookieJar.h
@@ -55,7 +55,7 @@ private:
     static bool domain_matches(const String& string, const String& domain_string);
     static String default_path(const URL& url);
 
-    void store_cookie(Web::Cookie::ParsedCookie& parsed_cookie, const URL& url, String canonicalized_domain);
+    void store_cookie(Web::Cookie::ParsedCookie& parsed_cookie, const URL& url, String canonicalized_domain, Web::Cookie::Source source);
     void purge_expired_cookies();
 
     HashMap<CookieStorageKey, Web::Cookie::Cookie> m_cookies;

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -242,15 +242,15 @@ Tab::Tab(Type type)
             on_favicon_change(icon);
     };
 
-    hooks().on_get_cookie = [this](auto& url) -> String {
+    hooks().on_get_cookie = [this](auto& url, auto source) -> String {
         if (on_get_cookie)
-            return on_get_cookie(url);
+            return on_get_cookie(url, source);
         return {};
     };
 
-    hooks().on_set_cookie = [this](auto& url, auto& cookie) {
+    hooks().on_set_cookie = [this](auto& url, auto& cookie, auto source) {
         if (on_set_cookie)
-            on_set_cookie(url, cookie);
+            on_set_cookie(url, cookie, source);
     };
 
     hooks().on_get_source = [this](auto& url, auto& source) {

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -70,8 +70,8 @@ public:
     Function<void(const URL&)> on_tab_open_request;
     Function<void(Tab&)> on_tab_close_request;
     Function<void(const Gfx::Bitmap&)> on_favicon_change;
-    Function<String(const URL& url)> on_get_cookie;
-    Function<void(const URL& url, const String& cookie)> on_set_cookie;
+    Function<String(const URL& url, Web::Cookie::Source source)> on_get_cookie;
+    Function<void(const URL& url, const String& cookie, Web::Cookie::Source source)> on_set_cookie;
     Function<void()> on_dump_cookies;
 
     const String& title() const { return m_title; }

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -219,12 +219,12 @@ int main(int argc, char** argv)
             });
         };
 
-        new_tab.on_get_cookie = [&](auto& url) -> String {
-            return cookie_jar.get_cookie(url);
+        new_tab.on_get_cookie = [&](auto& url, auto source) -> String {
+            return cookie_jar.get_cookie(url, source);
         };
 
-        new_tab.on_set_cookie = [&](auto& url, auto& cookie) {
-            cookie_jar.set_cookie(url, cookie);
+        new_tab.on_set_cookie = [&](auto& url, auto& cookie, auto source) {
+            cookie_jar.set_cookie(url, cookie, source);
         };
 
         new_tab.on_dump_cookies = [&]() {

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     Bindings/ScriptExecutionContext.cpp
     Bindings/WindowObject.cpp
     Bindings/Wrappable.cpp
+    Cookie/ParsedCookie.cpp
     CSS/CSSImportRule.cpp
     CSS/CSSRule.cpp
     CSS/CSSStyleDeclaration.cpp

--- a/Userland/Libraries/LibWeb/Cookie/Cookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/Cookie.h
@@ -31,6 +31,11 @@
 
 namespace Web::Cookie {
 
+enum class Source {
+    NonHttp,
+    Http,
+};
+
 struct Cookie {
     String name;
     String value;

--- a/Userland/Libraries/LibWeb/Cookie/Cookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/Cookie.h
@@ -26,55 +26,23 @@
 
 #pragma once
 
-#include <AK/HashMap.h>
-#include <AK/Optional.h>
 #include <AK/String.h>
-#include <AK/Traits.h>
 #include <LibCore/DateTime.h>
-#include <LibWeb/Cookie/Cookie.h>
-#include <LibWeb/Forward.h>
 
-namespace Browser {
+namespace Web::Cookie {
 
-struct CookieStorageKey {
-    bool operator==(const CookieStorageKey&) const = default;
-
+struct Cookie {
     String name;
-    String domain;
-    String path;
-};
-
-class CookieJar {
-public:
-    String get_cookie(const URL& url);
-    void set_cookie(const URL& url, const String& cookie);
-    void dump_cookies() const;
-
-private:
-    static Optional<String> canonicalize_domain(const URL& url);
-    static bool domain_matches(const String& string, const String& domain_string);
-    static String default_path(const URL& url);
-
-    void store_cookie(Web::Cookie::ParsedCookie& parsed_cookie, const URL& url, String canonicalized_domain);
-    void purge_expired_cookies();
-
-    HashMap<CookieStorageKey, Web::Cookie::Cookie> m_cookies;
-};
-
-}
-
-namespace AK {
-
-template<>
-struct Traits<Browser::CookieStorageKey> : public GenericTraits<Browser::CookieStorageKey> {
-    static unsigned hash(const Browser::CookieStorageKey& key)
-    {
-        unsigned hash = 0;
-        hash = pair_int_hash(hash, string_hash(key.name.characters(), key.name.length()));
-        hash = pair_int_hash(hash, string_hash(key.domain.characters(), key.domain.length()));
-        hash = pair_int_hash(hash, string_hash(key.path.characters(), key.path.length()));
-        return hash;
-    }
+    String value;
+    Core::DateTime creation_time {};
+    Core::DateTime last_access_time {};
+    Core::DateTime expiry_time {};
+    String domain {};
+    String path {};
+    bool secure { false };
+    bool http_only { false };
+    bool host_only { false };
+    bool persistent { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ParsedCookie.h"
+#include <AK/Vector.h>
+#include <ctype.h>
+
+namespace Web::Cookie {
+
+static void parse_attributes(ParsedCookie& parsed_cookie, StringView unparsed_attributes);
+static void process_attribute(ParsedCookie& parsed_cookie, StringView attribute_name, StringView attribute_value);
+static void on_expires_attribute(ParsedCookie& parsed_cookie, StringView attribute_value);
+static void on_max_age_attribute(ParsedCookie& parsed_cookie, StringView attribute_value);
+static void on_domain_attribute(ParsedCookie& parsed_cookie, StringView attribute_value);
+static void on_path_attribute(ParsedCookie& parsed_cookie, StringView attribute_value);
+static void on_secure_attribute(ParsedCookie& parsed_cookie);
+static void on_http_only_attribute(ParsedCookie& parsed_cookie);
+static Optional<Core::DateTime> parse_date_time(StringView date_string);
+
+Optional<ParsedCookie> parse_cookie(const String& cookie_string)
+{
+    // https://tools.ietf.org/html/rfc6265#section-5.2
+    StringView name_value_pair;
+    StringView unparsed_attributes;
+
+    // 1. If the set-cookie-string contains a %x3B (";") character:
+    if (auto position = cookie_string.find(';'); position.has_value()) {
+        // The name-value-pair string consists of the characters up to, but not including, the first %x3B (";"), and the unparsed-
+        // attributes consist of the remainder of the set-cookie-string (including the %x3B (";") in question).
+        name_value_pair = cookie_string.substring_view(0, position.value());
+        unparsed_attributes = cookie_string.substring_view(position.value());
+    } else {
+        // The name-value-pair string consists of all the characters contained in the set-cookie-string, and the unparsed-
+        // attributes is the empty string.
+        name_value_pair = cookie_string;
+    }
+
+    StringView name;
+    StringView value;
+
+    if (auto position = name_value_pair.find('='); position.has_value()) {
+        // 3. The (possibly empty) name string consists of the characters up to, but not including, the first %x3D ("=") character, and the
+        //    (possibly empty) value string consists of the characters after the first %x3D ("=") character.
+        name = name_value_pair.substring_view(0, position.value());
+
+        if (position.value() < name_value_pair.length() - 1)
+            value = name_value_pair.substring_view(position.value() + 1);
+    } else {
+        // 2. If the name-value-pair string lacks a %x3D ("=") character, ignore the set-cookie-string entirely.
+        return {};
+    }
+
+    // 4. Remove any leading or trailing WSP characters from the name string and the value string.
+    name = name.trim_whitespace();
+    value = value.trim_whitespace();
+
+    // 5. If the name string is empty, ignore the set-cookie-string entirely.
+    if (name.is_empty())
+        return {};
+
+    // 6. The cookie-name is the name string, and the cookie-value is the value string.
+    ParsedCookie parsed_cookie { name, value };
+
+    parse_attributes(parsed_cookie, unparsed_attributes);
+    return parsed_cookie;
+}
+
+void parse_attributes(ParsedCookie& parsed_cookie, StringView unparsed_attributes)
+{
+    // 1. If the unparsed-attributes string is empty, skip the rest of these steps.
+    if (unparsed_attributes.is_empty())
+        return;
+
+    // 2. Discard the first character of the unparsed-attributes (which will be a %x3B (";") character).
+    unparsed_attributes = unparsed_attributes.substring_view(1);
+
+    StringView cookie_av;
+
+    // 3. If the remaining unparsed-attributes contains a %x3B (";") character:
+    if (auto position = unparsed_attributes.find(';'); position.has_value()) {
+        // Consume the characters of the unparsed-attributes up to, but not including, the first %x3B (";") character.
+        cookie_av = unparsed_attributes.substring_view(0, position.value());
+        unparsed_attributes = unparsed_attributes.substring_view(position.value());
+    } else {
+        // Consume the remainder of the unparsed-attributes.
+        cookie_av = unparsed_attributes;
+        unparsed_attributes = {};
+    }
+
+    StringView attribute_name;
+    StringView attribute_value;
+
+    // 4. If the cookie-av string contains a %x3D ("=") character:
+    if (auto position = cookie_av.find('='); position.has_value()) {
+        // The (possibly empty) attribute-name string consists of the characters up to, but not including, the first %x3D ("=")
+        // character, and the (possibly empty) attribute-value string consists of the characters after the first %x3D ("=") character.
+        attribute_name = cookie_av.substring_view(0, position.value());
+
+        if (position.value() < cookie_av.length() - 1)
+            attribute_value = cookie_av.substring_view(position.value() + 1);
+    } else {
+        // The attribute-name string consists of the entire cookie-av string, and the attribute-value string is empty.
+        attribute_name = cookie_av;
+    }
+
+    // 5. Remove any leading or trailing WSP characters from the attribute-name string and the attribute-value string.
+    attribute_name = attribute_name.trim_whitespace();
+    attribute_value = attribute_value.trim_whitespace();
+
+    // 6. Process the attribute-name and attribute-value according to the requirements in the following subsections.
+    //    (Notice that attributes with unrecognized attribute-names are ignored.)
+    process_attribute(parsed_cookie, attribute_name, attribute_value);
+
+    // 7. Return to Step 1 of this algorithm.
+    parse_attributes(parsed_cookie, unparsed_attributes);
+}
+
+void process_attribute(ParsedCookie& parsed_cookie, StringView attribute_name, StringView attribute_value)
+{
+    if (attribute_name.equals_ignoring_case("Expires")) {
+        on_expires_attribute(parsed_cookie, attribute_value);
+    } else if (attribute_name.equals_ignoring_case("Max-Age")) {
+        on_max_age_attribute(parsed_cookie, attribute_value);
+    } else if (attribute_name.equals_ignoring_case("Domain")) {
+        on_domain_attribute(parsed_cookie, attribute_value);
+    } else if (attribute_name.equals_ignoring_case("Path")) {
+        on_path_attribute(parsed_cookie, attribute_value);
+    } else if (attribute_name.equals_ignoring_case("Secure")) {
+        on_secure_attribute(parsed_cookie);
+    } else if (attribute_name.equals_ignoring_case("HttpOnly")) {
+        on_http_only_attribute(parsed_cookie);
+    }
+}
+
+void on_expires_attribute(ParsedCookie& parsed_cookie, StringView attribute_value)
+{
+    // https://tools.ietf.org/html/rfc6265#section-5.2.1
+    if (auto expiry_time = parse_date_time(attribute_value); expiry_time.has_value())
+        parsed_cookie.expiry_time_from_expires_attribute = move(*expiry_time);
+}
+
+void on_max_age_attribute(ParsedCookie& parsed_cookie, StringView attribute_value)
+{
+    // https://tools.ietf.org/html/rfc6265#section-5.2.2
+
+    // If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av.
+    if (attribute_value.is_empty() || (!isdigit(attribute_value[0]) && (attribute_value[0] != '-')))
+        return;
+
+    // Let delta-seconds be the attribute-value converted to an integer.
+    if (auto delta_seconds = attribute_value.to_int(); delta_seconds.has_value()) {
+        Core::DateTime expiry_time;
+
+        if (*delta_seconds <= 0) {
+            // If delta-seconds is less than or equal to zero (0), let expiry-time be the earliest representable date and time.
+            parsed_cookie.expiry_time_from_max_age_attribute = Core::DateTime::from_timestamp(0);
+        } else {
+            // Otherwise, let the expiry-time be the current date and time plus delta-seconds seconds.
+            time_t now = Core::DateTime::now().timestamp();
+            parsed_cookie.expiry_time_from_max_age_attribute = Core::DateTime::from_timestamp(now + *delta_seconds);
+        }
+    }
+}
+
+void on_domain_attribute(ParsedCookie& parsed_cookie, StringView attribute_value)
+{
+    // https://tools.ietf.org/html/rfc6265#section-5.2.3
+
+    // If the attribute-value is empty, the behavior is undefined. However, the user agent SHOULD ignore the cookie-av entirely.
+    if (attribute_value.is_empty())
+        return;
+
+    StringView cookie_domain;
+
+    // If the first character of the attribute-value string is %x2E ("."):
+    if (attribute_value[0] == '.') {
+        // Let cookie-domain be the attribute-value without the leading %x2E (".") character.
+        cookie_domain = attribute_value.substring_view(1);
+    } else {
+        // Let cookie-domain be the entire attribute-value.
+        cookie_domain = attribute_value;
+    }
+
+    // Convert the cookie-domain to lower case.
+    parsed_cookie.domain = String(cookie_domain).to_lowercase();
+}
+
+void on_path_attribute(ParsedCookie& parsed_cookie, StringView attribute_value)
+{
+    // https://tools.ietf.org/html/rfc6265#section-5.2.4
+
+    // If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):
+    if (attribute_value.is_empty() || attribute_value[0] != '/')
+        // Let cookie-path be the default-path.
+        return;
+
+    // Let cookie-path be the attribute-value
+    parsed_cookie.path = attribute_value;
+}
+
+void on_secure_attribute(ParsedCookie& parsed_cookie)
+{
+    // https://tools.ietf.org/html/rfc6265#section-5.2.5
+    parsed_cookie.secure_attribute_present = true;
+}
+
+void on_http_only_attribute(ParsedCookie& parsed_cookie)
+{
+    // https://tools.ietf.org/html/rfc6265#section-5.2.6
+    parsed_cookie.http_only_attribute_present = true;
+}
+
+Optional<Core::DateTime> parse_date_time(StringView date_string)
+{
+    // https://tools.ietf.org/html/rfc6265#section-5.1.1
+    unsigned hour = 0;
+    unsigned minute = 0;
+    unsigned second = 0;
+    unsigned day_of_month = 0;
+    unsigned month = 0;
+    unsigned year = 0;
+
+    auto to_uint = [](StringView token, unsigned& result) {
+        if (!all_of(token.begin(), token.end(), isdigit))
+            return false;
+
+        if (auto converted = token.to_uint(); converted.has_value()) {
+            result = *converted;
+            return true;
+        }
+
+        return false;
+    };
+
+    auto parse_time = [&](StringView token) {
+        Vector<StringView> parts = token.split_view(':');
+        if (parts.size() != 3)
+            return false;
+
+        for (const auto& part : parts) {
+            if (part.is_empty() || part.length() > 2)
+                return false;
+        }
+
+        return to_uint(parts[0], hour) && to_uint(parts[1], minute) && to_uint(parts[2], second);
+    };
+
+    auto parse_day_of_month = [&](StringView token) {
+        if (token.is_empty() || token.length() > 2)
+            return false;
+        return to_uint(token, day_of_month);
+    };
+
+    auto parse_month = [&](StringView token) {
+        static const char* months[] { "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec" };
+
+        for (unsigned i = 0; i < 12; ++i) {
+            if (token.equals_ignoring_case(months[i])) {
+                month = i + 1;
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    auto parse_year = [&](StringView token) {
+        if (token.length() != 2 && token.length() != 4)
+            return false;
+        return to_uint(token, year);
+    };
+
+    auto is_delimeter = [](char ch) {
+        return ch == 0x09 || (ch >= 0x20 && ch <= 0x2f) || (ch >= 0x3b && ch <= 0x40) || (ch >= 0x5b && ch <= 0x60) || (ch >= 0x7b && ch <= 0x7e);
+    };
+
+    // 1. Using the grammar below, divide the cookie-date into date-tokens.
+    Vector<StringView> date_tokens = date_string.split_view_if(is_delimeter);
+
+    // 2. Process each date-token sequentially in the order the date-tokens appear in the cookie-date.
+    bool found_time = false;
+    bool found_day_of_month = false;
+    bool found_month = false;
+    bool found_year = false;
+
+    for (const auto& date_token : date_tokens) {
+        if (!found_time && parse_time(date_token)) {
+            found_time = true;
+        } else if (!found_day_of_month && parse_day_of_month(date_token)) {
+            found_day_of_month = true;
+        } else if (!found_month && parse_month(date_token)) {
+            found_month = true;
+        } else if (!found_year && parse_year(date_token)) {
+            found_year = true;
+        }
+    }
+
+    // 3. If the year-value is greater than or equal to 70 and less than or equal to 99, increment the year-value by 1900.
+    if (year >= 70 && year <= 99)
+        year += 1900;
+
+    // 4. If the year-value is greater than or equal to 0 and less than or equal to 69, increment the year-value by 2000.
+    if (year <= 69)
+        year += 2000;
+
+    // 5. Abort these steps and fail to parse the cookie-date if:
+    if (!found_time || !found_day_of_month || !found_month || !found_year)
+        return {};
+    if (day_of_month < 1 || day_of_month > 31)
+        return {};
+    if (year < 1601)
+        return {};
+    if (hour > 23)
+        return {};
+    if (minute > 59)
+        return {};
+    if (second > 59)
+        return {};
+
+    // FIXME: Fail on dates that do not exist.
+    return Core::DateTime::create(year, month, day_of_month, hour, minute, second);
+}
+
+}

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <LibCore/DateTime.h>
+
+namespace Web::Cookie {
+
+struct ParsedCookie {
+    String name;
+    String value;
+    Optional<Core::DateTime> expiry_time_from_expires_attribute {};
+    Optional<Core::DateTime> expiry_time_from_max_age_attribute {};
+    Optional<String> domain {};
+    Optional<String> path {};
+    bool secure_attribute_present { false };
+    bool http_only_attribute_present { false };
+};
+
+Optional<ParsedCookie> parse_cookie(const String& cookie_string);
+
+}

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -821,17 +821,17 @@ void Document::completely_finish_loading()
     dispatch_event(DOM::Event::create(HTML::EventNames::load));
 }
 
-String Document::cookie()
+String Document::cookie(Cookie::Source source)
 {
     if (auto* page = this->page())
-        return page->client().page_did_request_cookie(m_url);
+        return page->client().page_did_request_cookie(m_url, source);
     return {};
 }
 
-void Document::set_cookie(String cookie)
+void Document::set_cookie(String cookie, Cookie::Source source)
 {
     if (auto* page = this->page())
-        page->client().page_did_set_cookie(m_url, cookie);
+        page->client().page_did_set_cookie(m_url, cookie, source);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -40,6 +40,7 @@
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/StyleResolver.h>
 #include <LibWeb/CSS/StyleSheetList.h>
+#include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/DOM/DOMImplementation.h>
 #include <LibWeb/DOM/ExceptionOr.h>
 #include <LibWeb/DOM/NonElementParentNode.h>
@@ -73,8 +74,8 @@ public:
 
     virtual ~Document() override;
 
-    String cookie();
-    void set_cookie(String);
+    String cookie(Cookie::Source = Cookie::Source::NonHttp);
+    void set_cookie(String, Cookie::Source = Cookie::Source::NonHttp);
 
     bool should_invalidate_styles_on_attribute_changes() const { return m_should_invalidate_styles_on_attribute_changes; }
     void set_should_invalidate_styles_on_attribute_changes(bool b) { m_should_invalidate_styles_on_attribute_changes = b; }

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -27,6 +27,10 @@
 
 #pragma once
 
+namespace Web::Cookie {
+struct ParsedCookie;
+}
+
 namespace Web::CSS {
 class CSSRule;
 class CSSImportRule;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -30,6 +30,7 @@
 namespace Web::Cookie {
 struct Cookie;
 struct ParsedCookie;
+enum class Source;
 }
 
 namespace Web::CSS {

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -28,6 +28,7 @@
 #pragma once
 
 namespace Web::Cookie {
+struct Cookie;
 struct ParsedCookie;
 }
 

--- a/Userland/Libraries/LibWeb/InProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/InProcessWebView.cpp
@@ -433,17 +433,17 @@ String InProcessWebView::page_did_request_prompt(const String& message, const St
     return {};
 }
 
-String InProcessWebView::page_did_request_cookie(const URL& url)
+String InProcessWebView::page_did_request_cookie(const URL& url, Cookie::Source source)
 {
     if (on_get_cookie)
-        return on_get_cookie(url);
+        return on_get_cookie(url, source);
     return {};
 }
 
-void InProcessWebView::page_did_set_cookie(const URL& url, const String& cookie)
+void InProcessWebView::page_did_set_cookie(const URL& url, const String& cookie, Cookie::Source source)
 {
     if (on_set_cookie)
-        on_set_cookie(url, cookie);
+        on_set_cookie(url, cookie, source);
 }
 
 }

--- a/Userland/Libraries/LibWeb/InProcessWebView.h
+++ b/Userland/Libraries/LibWeb/InProcessWebView.h
@@ -111,8 +111,8 @@ private:
     virtual void page_did_request_alert(const String&) override;
     virtual bool page_did_request_confirm(const String&) override;
     virtual String page_did_request_prompt(const String&, const String&) override;
-    virtual String page_did_request_cookie(const URL&) override;
-    virtual void page_did_set_cookie(const URL&, const String&) override;
+    virtual String page_did_request_cookie(const URL&, Cookie::Source) override;
+    virtual void page_did_set_cookie(const URL&, const String&, Cookie::Source) override;
 
     void layout_and_sync_size();
 

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -277,7 +277,7 @@ void FrameLoader::resource_did_load()
     // FIXME: Support multiple instances of the Set-Cookie response header.
     auto set_cookie = resource()->response_headers().get("Set-Cookie");
     if (set_cookie.has_value())
-        document->set_cookie(set_cookie.value());
+        document->set_cookie(set_cookie.value(), Cookie::Source::Http);
 
     if (!url.fragment().is_empty())
         frame().scroll_to_anchor(url.fragment());

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -365,17 +365,17 @@ void OutOfProcessWebView::notify_server_did_change_favicon(const Gfx::Bitmap& fa
         on_favicon_change(favicon);
 }
 
-String OutOfProcessWebView::notify_server_did_request_cookie(Badge<WebContentClient>, const URL& url)
+String OutOfProcessWebView::notify_server_did_request_cookie(Badge<WebContentClient>, const URL& url, Cookie::Source source)
 {
     if (on_get_cookie)
-        return on_get_cookie(url);
+        return on_get_cookie(url, source);
     return {};
 }
 
-void OutOfProcessWebView::notify_server_did_set_cookie(Badge<WebContentClient>, const URL& url, const String& cookie)
+void OutOfProcessWebView::notify_server_did_set_cookie(Badge<WebContentClient>, const URL& url, const String& cookie, Cookie::Source source)
 {
     if (on_set_cookie)
-        on_set_cookie(url, cookie);
+        on_set_cookie(url, cookie, source);
 }
 
 void OutOfProcessWebView::did_scroll()

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.h
@@ -79,8 +79,8 @@ public:
     void notify_server_did_get_source(const URL& url, const String& source);
     void notify_server_did_js_console_output(const String& method, const String& line);
     void notify_server_did_change_favicon(const Gfx::Bitmap& favicon);
-    String notify_server_did_request_cookie(Badge<WebContentClient>, const URL& url);
-    void notify_server_did_set_cookie(Badge<WebContentClient>, const URL& url, const String& cookie);
+    String notify_server_did_request_cookie(Badge<WebContentClient>, const URL& url, Cookie::Source source);
+    void notify_server_did_set_cookie(Badge<WebContentClient>, const URL& url, const String& cookie, Cookie::Source source);
 
 private:
     OutOfProcessWebView();

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -111,8 +111,8 @@ public:
     virtual void page_did_request_alert(const String&) { }
     virtual bool page_did_request_confirm(const String&) { return false; }
     virtual String page_did_request_prompt(const String&, const String&) { return {}; }
-    virtual String page_did_request_cookie(const URL&) { return {}; }
-    virtual void page_did_set_cookie(const URL&, const String&) { }
+    virtual String page_did_request_cookie(const URL&, Cookie::Source) { return {}; }
+    virtual void page_did_set_cookie(const URL&, const String&, Cookie::Source) { }
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebContentClient.cpp
+++ b/Userland/Libraries/LibWeb/WebContentClient.cpp
@@ -199,13 +199,13 @@ void WebContentClient::handle(const Messages::WebContentClient::DidChangeFavicon
 
 OwnPtr<Messages::WebContentClient::DidRequestCookieResponse> WebContentClient::handle(const Messages::WebContentClient::DidRequestCookie& message)
 {
-    auto result = m_view.notify_server_did_request_cookie({}, message.url());
+    auto result = m_view.notify_server_did_request_cookie({}, message.url(), static_cast<Cookie::Source>(message.source()));
     return make<Messages::WebContentClient::DidRequestCookieResponse>(result);
 }
 
 void WebContentClient::handle(const Messages::WebContentClient::DidSetCookie& message)
 {
-    m_view.notify_server_did_set_cookie({}, message.url(), message.cookie());
+    m_view.notify_server_did_set_cookie({}, message.url(), message.cookie(), static_cast<Cookie::Source>(message.source()));
 }
 
 }

--- a/Userland/Libraries/LibWeb/WebViewHooks.h
+++ b/Userland/Libraries/LibWeb/WebViewHooks.h
@@ -48,8 +48,8 @@ public:
     Function<void(DOM::Document*)> on_set_document;
     Function<void(const URL&, const String&)> on_get_source;
     Function<void(const String& method, const String& line)> on_js_console_output;
-    Function<String(const URL& url)> on_get_cookie;
-    Function<void(const URL& url, const String& cookie)> on_set_cookie;
+    Function<String(const URL& url, Cookie::Source source)> on_get_cookie;
+    Function<void(const URL& url, const String& cookie, Cookie::Source source)> on_set_cookie;
 };
 
 }

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -208,14 +208,14 @@ void PageHost::page_did_request_image_context_menu(const Gfx::IntPoint& content_
     m_client.post_message(Messages::WebContentClient::DidRequestImageContextMenu(content_position, url, target, modifiers, bitmap->to_shareable_bitmap()));
 }
 
-String PageHost::page_did_request_cookie(const URL& url)
+String PageHost::page_did_request_cookie(const URL& url, Web::Cookie::Source source)
 {
-    return m_client.send_sync<Messages::WebContentClient::DidRequestCookie>(url)->cookie();
+    return m_client.send_sync<Messages::WebContentClient::DidRequestCookie>(url, static_cast<u8>(source))->cookie();
 }
 
-void PageHost::page_did_set_cookie(const URL& url, const String& cookie)
+void PageHost::page_did_set_cookie(const URL& url, const String& cookie, Web::Cookie::Source source)
 {
-    m_client.post_message(Messages::WebContentClient::DidSetCookie(url, cookie));
+    m_client.post_message(Messages::WebContentClient::DidSetCookie(url, cookie, static_cast<u8>(source)));
 }
 
 }

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -79,8 +79,8 @@ private:
     virtual String page_did_request_prompt(const String&, const String&) override;
     virtual void page_did_change_favicon(const Gfx::Bitmap&) override;
     virtual void page_did_request_image_context_menu(const Gfx::IntPoint&, const URL&, const String& target, unsigned modifiers, const Gfx::Bitmap*) override;
-    virtual String page_did_request_cookie(const URL&) override;
-    virtual void page_did_set_cookie(const URL&, const String&) override;
+    virtual String page_did_request_cookie(const URL&, Web::Cookie::Source) override;
+    virtual void page_did_set_cookie(const URL&, const String&, Web::Cookie::Source) override;
 
     explicit PageHost(ClientConnection&);
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -25,6 +25,6 @@ endpoint WebContentClient = 90
     DidGetSource(URL url, String source) =|
     DidJSConsoleOutput(String method, String line) =|
     DidChangeFavicon(Gfx::ShareableBitmap favicon) =|
-    DidRequestCookie(URL url) => (String cookie)
-    DidSetCookie(URL url, String cookie) =|
+    DidRequestCookie(URL url, u8 source) => (String cookie)
+    DidSetCookie(URL url, String cookie, u8 source) =|
 }


### PR DESCRIPTION
Reasons for moving the cookie structures (except the CookieJar storage itself) into LibWeb are in first commit. But the primary reason is that I'd like to move cookie parsing into the OOP tab to protect the main browser. Cookie parsers should (ours doesn't yet) have protection against e.g. enormous cookie strings, but if something goes wrong, it's better for that problem to be isolated to that web page's tab than to bring down the whole browser.

Having some cookie infra in LibWeb also made it a tiny bit simpler to implement the HttpOnly attribute. So now cookies with HttpOnly cannot be set via JavaScript. Reading cookies from JavaScript aren't protected yet, as the `get_cookie` steps aren't written to the spec yet.