### PR TITLE
Browser: Add bookmark cap and entry for it in config file

### DIFF
--- a/Base/home/anon/.config/Browser.ini
+++ b/Base/home/anon/.config/Browser.ini
@@ -1,2 +1,3 @@
 [Preferences]
 Home=file:///res/html/misc/welcome.html
+MaxBookmarks=300

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -33,6 +33,7 @@
 #include <LibGUI/Event.h>
 #include <LibGUI/JsonArrayModel.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/Model.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Widget.h>
@@ -185,6 +186,13 @@ void BookmarksBarWidget::set_model(RefPtr<GUI::Model> model)
     m_model->register_client(*this);
 }
 
+void BookmarksBarWidget::set_max_bookmarks(int max_bookmarks)
+{
+    if (max_bookmarks == m_max_bookmarks)
+        return;
+    m_max_bookmarks = max_bookmarks;
+}
+
 void BookmarksBarWidget::resize_event(GUI::ResizeEvent& event)
 {
     Widget::resize_event(event);
@@ -310,6 +318,10 @@ bool BookmarksBarWidget::add_bookmark(const String& url, const String& title)
     values.append(url);
 
     auto& json_model = *static_cast<GUI::JsonArrayModel*>(model());
+    if (json_model.row_count() == m_max_bookmarks) {
+        GUI::MessageBox::show(window(), String::format("Sorry, you have too many bookmarks. The maximum amount is %d.", m_max_bookmarks), "Too many bookmarks!", GUI::MessageBox::Type::Error);
+        return false;
+    }
     if (json_model.add(move(values))) {
         json_model.store();
         return true;

--- a/Userland/Applications/Browser/BookmarksBarWidget.h
+++ b/Userland/Applications/Browser/BookmarksBarWidget.h
@@ -43,6 +43,7 @@ public:
     virtual ~BookmarksBarWidget() override;
 
     void set_model(RefPtr<GUI::Model>);
+    void set_max_bookmarks(int);
     GUI::Model* model() { return m_model.ptr(); }
     const GUI::Model* model() const { return m_model.ptr(); }
 
@@ -76,6 +77,7 @@ private:
 
     NonnullRefPtrVector<GUI::Button> m_bookmarks;
 
+    int m_max_bookmarks { 300 };
     int m_last_visible_index { -1 };
 };
 

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -149,6 +149,8 @@ int main(int argc, char** argv)
     bool bookmarksbar_enabled = true;
     auto bookmarks_bar = Browser::BookmarksBarWidget::construct(Browser::bookmarks_file_path(), bookmarksbar_enabled);
 
+    bookmarks_bar->set_max_bookmarks(m_config->read_num_entry("Preferences", "MaxBookmarks"));
+
     Browser::CookieJar cookie_jar;
 
     auto window = GUI::Window::construct();


### PR DESCRIPTION
I thought this might be important as we currently load all bookmarks into memory.
The limit of 300 is rather arbitrary, so other numbers are welcome.

This is my first (relatively) "big" pr, so please excuse any obvious mistakes I may make. :)