### PR TITLE
LibDebug: Support for parsing arrays

### DIFF
--- a/Base/home/anon/Source/little/main.cpp
+++ b/Base/home/anon/Source/little/main.cpp
@@ -23,6 +23,8 @@ int main(int, char**)
     MyStruct my_struct;
     my_struct.status = !my_struct.status;
     printf("my_struct.x is %d\n", my_struct.x);
+    int arr[6] = { -1, 2, 20, 5, 5 };
+    int other_arr[1][2] = { { 0, 2 } };
     Container container;
     for (int i = 0; i < 3; ++i) {
         // This is a comment :^)

--- a/Userland/Libraries/LibDebug/DebugInfo.cpp
+++ b/Userland/Libraries/LibDebug/DebugInfo.cpp
@@ -215,7 +215,7 @@ static Optional<Dwarf::DIE> parse_variable_type_die(const Dwarf::DIE& variable_d
         variable_info.type_name = type_name.value().data.as_string;
     } else {
         dbgln("Unnamed DWARF type at offset: {}", type_die.offset());
-        variable_info.name = "[Unnamed Type]";
+        variable_info.type_name = "[Unnamed Type]";
     }
 
     return type_die;
@@ -263,7 +263,9 @@ OwnPtr<DebugInfo::VariableInfo> DebugInfo::create_variable_info(const Dwarf::DIE
     }
 
     NonnullOwnPtr<VariableInfo> variable_info = make<VariableInfo>();
-    variable_info->name = variable_die.get_attribute(Dwarf::Attribute::Name).value().data.as_string;
+    auto name_attribute = variable_die.get_attribute(Dwarf::Attribute::Name);
+    if (name_attribute.has_value())
+        variable_info->name = name_attribute.value().data.as_string;
 
     auto type_die = parse_variable_type_die(variable_die, *variable_info);
 

--- a/Userland/Libraries/LibDebug/DebugInfo.h
+++ b/Userland/Libraries/LibDebug/DebugInfo.h
@@ -94,6 +94,7 @@ public:
         OwnPtr<VariableInfo> type;
         NonnullOwnPtrVector<VariableInfo> members;
         VariableInfo* parent { nullptr };
+        Vector<u32> dimension_sizes;
 
         bool is_enum_type() const { return type && type->type_tag == Dwarf::EntryTag::EnumerationType; }
     };
@@ -142,6 +143,7 @@ private:
     void parse_scopes_impl(const Dwarf::DIE& die);
     OwnPtr<VariableInfo> create_variable_info(const Dwarf::DIE& variable_die, const PtraceRegisters&, u32 address_offset = 0) const;
     static bool is_variable_tag_supported(const Dwarf::EntryTag& tag);
+    void add_type_info_to_variable(const Dwarf::DIE& type_die, const PtraceRegisters& regs, DebugInfo::VariableInfo* parent_variable) const;
 
     NonnullOwnPtr<const ELF::Image> m_elf;
     String m_source_root;


### PR DESCRIPTION
When debugging variables with array types they will now display actual data instead of crashing.

![preview](https://i.imgur.com/zzkDxeM.png)

cc @itamar8910 