### PR TITLE
Meta: Increase discord notification's build timeout to 1 hour

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -15,7 +15,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           excludedCheckName: "notify_discord"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          timeoutSeconds: 1200
+          timeoutSeconds: 3600
 
       - name: Discord action notification
         env:


### PR DESCRIPTION
It looks like some particularly long builds (After a toolchain cache reset and on a slow worker) can take much longer than the current set timeout of 20 minutes, causing erroneous build failed notifications. (I got too used to ccache speeds :P)