### PR TITLE
Ports: Fix building the nasm port

### DIFF
--- a/Ports/nasm/package.sh
+++ b/Ports/nasm/package.sh
@@ -4,7 +4,3 @@ version=2.15.05
 files="https://www.nasm.us/pub/nasm/releasebuilds/${version}/nasm-${version}.tar.gz nasm-${version}.tar.gz"
 useconfigure=true
 makeopts=
-
-pre_configure() {
-	run ./autogen.sh
-}

--- a/Ports/nasm/patches/config.sub.patch
+++ b/Ports/nasm/patches/config.sub.patch
@@ -1,20 +1,12 @@
---- nasm-2.15.05/autoconf/helpers/original-config.sub	2021-04-13 19:00:40.329393345 +0100
-+++ nasm-2.15.05/autoconf/helpers/config.sub	2021-04-13 19:02:01.489645184 +0100
-@@ -134,7 +134,7 @@
- 			nto-qnx* | linux-* | uclinux-uclibc* \
- 			| uclinux-gnu* | kfreebsd*-gnu* | knetbsd*-gnu* | netbsd*-gnu* \
- 			| netbsd*-eabi* | kopensolaris*-gnu* | cloudabi*-eabi* \
--			| storm-chaos* | os2-emx* | rtmk-nova*)
-+			| storm-chaos* | os2-emx* | rtmk-nova* | serenity)
- 				basic_machine=$field1
- 				basic_os=$maybe_os
- 				;;
-@@ -1720,7 +1720,7 @@
- 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
- 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
- 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
--	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx*)
-+	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | serenity*)
- 		;;
- 	# This one is extra strict with allowed versions
- 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
+diff -Naur nasm-2.15.05/autoconf/helpers/config.sub nasm-2.15.05.serenity/autoconf/helpers/config.sub
+--- nasm-2.15.05/autoconf/helpers/config.sub	2020-08-28 18:04:07.000000000 +0200
++++ nasm-2.15.05.serenity/autoconf/helpers/config.sub	2021-04-14 11:44:38.324488456 +0200
+@@ -1333,7 +1333,7 @@
+ 	# The portable systems comes first.
+ 	# Each alternative MUST end in a * to match a version number.
+ 	# sysv* is not here because it comes later, after sysvr4.
+-	gnu* | bsd* | mach* | minix* | genix* | ultrix* | irix* \
++	gnu* | bsd* | mach* | minix* | genix* | ultrix* | irix* | serenity* \
+ 	     | *vms* | esix* | aix* | cnk* | sunos | sunos[34]*\
+ 	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* \
+ 	     | sym* | kopensolaris* | plan9* \


### PR DESCRIPTION
I can't get the nasm port to build with the changes from #6292:

```
[gunnar@nyx nasm]$ ./package.sh
Installing dependencies of nasm!
Fetching nasm!
URL: https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.gz
/usr/bin/curl
nasm-2.15.05.tar.gz already exists
+ tar -xzf nasm-2.15.05.tar.gz (nocd)
+ touch .nasm-2.15.05.tar.gz_extracted
Patching nasm!
+ patch -p1
patching file autoconf/helpers/config.sub
Hunk #1 succeeded at 134 with fuzz 2.
Hunk #2 FAILED at 1720.
1 out of 2 hunks FAILED -- saving rejects to file autoconf/helpers/config.sub.rej
```

This PR removes the `autogen.sh` build step because it's no longer necessary with nasm 2.15.05 and updates the `config.sub` patch to apply cleanly.