### PR TITLE
Meta: Increase discord notification's check interval to 100 seconds

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -11,11 +11,13 @@ jobs:
       - name: Wait for tests to finish
         uses: IdanHo/action-wait-for-check@890bf0671eeeac09faf19f57deb4397eeccc59aa
         id: wait-for-tests
+        if: ${{ (github.event['pull_request'] && github.event['action'] == 'opened' && !(github.event['pull_request'] == 'draft')) || github.event['commits'] }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           excludedCheckName: "notify_discord"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           timeoutSeconds: 3600
+          intervalSeconds: 100
 
       - name: Discord action notification
         env:


### PR DESCRIPTION
Since our tests usually take at least 10 minutes theres no point in checking every 10 seconds, and github was starting to complain about the very high API usage. (I also added a check to only wait for test results if the checks were triggered by a new PR, since if this is a re-check of an existing PR we wouldnt send any discord notifications anyways)