### PR TITLE
Browser+LibWeb: Add support for spoofing the browser user agent

### DIFF
--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -28,6 +28,7 @@
 
 #include "History.h"
 #include <AK/URL.h>
+#include <LibGUI/ActionGroup.h>
 #include <LibGUI/Widget.h>
 #include <LibGfx/ShareableBitmap.h>
 #include <LibHTTP/HttpJob.h>
@@ -114,6 +115,9 @@ private:
     RefPtr<GUI::Menu> m_image_context_menu;
     Gfx::ShareableBitmap m_image_context_menu_bitmap;
     URL m_image_context_menu_url;
+
+    GUI::ActionGroup m_user_agent_spoof_actions;
+    RefPtr<GUI::Action> m_disable_user_agent_spoofing;
 
     RefPtr<GUI::Menu> m_tab_context_menu;
     RefPtr<GUI::Menu> m_page_context_menu;

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -48,7 +48,7 @@ ResourceLoader& ResourceLoader::the()
 
 ResourceLoader::ResourceLoader()
     : m_protocol_client(Protocol::Client::construct())
-    , m_user_agent("Mozilla/4.0 (SerenityOS; x86) LibWeb+LibJS (Not KHTML, nor Gecko) LibWeb")
+    , m_user_agent(default_user_agent)
 {
 }
 

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -37,6 +37,8 @@ class Client;
 
 namespace Web {
 
+constexpr auto default_user_agent = "Mozilla/4.0 (SerenityOS; x86) LibWeb+LibJS (Not KHTML, nor Gecko) LibWeb";
+
 class ResourceLoader : public Core::Object {
     C_OBJECT(ResourceLoader)
 public:
@@ -55,6 +57,7 @@ public:
     Protocol::Client& protocol_client() { return *m_protocol_client; }
 
     const String& user_agent() const { return m_user_agent; }
+    void set_user_agent(const String& user_agent) { m_user_agent = user_agent; }
 
     void clear_cache();
 

--- a/Userland/Services/WebContent/ClientConnection.cpp
+++ b/Userland/Services/WebContent/ClientConnection.cpp
@@ -220,6 +220,10 @@ void ClientConnection::handle(const Messages::WebContentServer::DebugRequest& me
     if (message.request() == "clear-cache") {
         Web::ResourceLoader::the().clear_cache();
     }
+
+    if (message.request() == "spoof-user-agent") {
+        Web::ResourceLoader::the().set_user_agent(message.argument());
+    }
 }
 
 void ClientConnection::handle(const Messages::WebContentServer::GetSource&)


### PR DESCRIPTION
This is helpful when testing certain sites like twitter.com which display differently based on the user agent.