### PR TITLE
FileManager+FileOperation: Pass errors from FileOperation and dont crash when displaying them

### DIFF
--- a/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
@@ -117,8 +117,10 @@ void FileOperationProgressWidget::close_pipe()
     if (!m_helper_pipe)
         return;
     m_helper_pipe = nullptr;
-    if (m_notifier)
+    if (m_notifier) {
+        m_notifier->set_enabled(false);
         m_notifier->on_ready_to_read = nullptr;
+    }
     m_notifier = nullptr;
 }
 

--- a/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
@@ -52,11 +52,22 @@ FileOperationProgressWidget::FileOperationProgressWidget(NonnullRefPtr<Core::Fil
     m_notifier->on_ready_to_read = [this] {
         auto line = m_helper_pipe->read_line();
         if (line.is_null()) {
-            did_error();
+            did_error("Read from pipe returned null.");
             return;
         }
+
         auto parts = line.split_view(' ');
         VERIFY(!parts.is_empty());
+
+        if (parts[0] == "ERROR"sv) {
+            did_error(line.substring(6));
+            return;
+        }
+
+        if (parts[0] == "WARN"sv) {
+            did_error(line.substring(5));
+            return;
+        }
 
         if (parts[0] == "FINISH"sv) {
             did_finish();
@@ -88,11 +99,11 @@ void FileOperationProgressWidget::did_finish()
     window()->close();
 }
 
-void FileOperationProgressWidget::did_error()
+void FileOperationProgressWidget::did_error(const String message)
 {
     // FIXME: Communicate more with the user about errors.
     close_pipe();
-    GUI::MessageBox::show(window(), "An error occurred", "Error", GUI::MessageBox::Type::Error, GUI::MessageBox::InputType::OK);
+    GUI::MessageBox::show(window(), String::formatted("An error occurred: {}", message), "Error", GUI::MessageBox::Type::Error, GUI::MessageBox::InputType::OK);
     window()->close();
 }
 

--- a/Userland/Applications/FileManager/FileOperationProgressWidget.h
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.h
@@ -40,7 +40,7 @@ private:
     explicit FileOperationProgressWidget(NonnullRefPtr<Core::File> helper_pipe);
 
     void did_finish();
-    void did_error();
+    void did_error(String message);
     void did_progress(off_t bytes_done, off_t total_byte_count, size_t files_done, size_t total_file_count, off_t current_file_done, off_t current_file_size, const StringView& current_file_name);
 
     void close_pipe();


### PR DESCRIPTION
The FileManager crashed when it tried to display the MessageBox that an error occured. This PR fixed that by additionally disabling the Notifier in the close_pipe() function.
Also the generated Errors and Warnings are passed to the FileManager from the FileOperation. Here both cause the Error-Window to open.
In the future we should collect the non-fatal errors and warnings and display them to the user.

This closes #6310 .