### PR TITLE
LibGUI: Allow arbitrary font size for TTF fonts in FontPicker

### DIFF
--- a/Userland/Libraries/LibGUI/FontPicker.h
+++ b/Userland/Libraries/LibGUI/FontPicker.h
@@ -53,6 +53,7 @@ private:
     RefPtr<ListView> m_family_list_view;
     RefPtr<ListView> m_weight_list_view;
     RefPtr<ListView> m_size_list_view;
+    RefPtr<SpinBox> m_size_spin_box;
     RefPtr<Label> m_sample_text_label;
 
     Vector<String> m_families;

--- a/Userland/Libraries/LibGUI/FontPickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FontPickerDialog.gml
@@ -53,6 +53,10 @@
                 fixed_height: 16
             }
 
+            @GUI::SpinBox {
+                name: "size_spin_box"
+            }
+
             @GUI::ListView {
                 name: "size_list_view"
             }


### PR DESCRIPTION
This commit adds a SpinBox to the FontPicker size selection portion to allow users to set arbitrary font sizes (1 to 36 inclusive currently) for TTF fonts.

This enhancement was suggested in #5380.

When a font size is set in the SpinBox and that font size exists in the size list, the size will be selected in the list:

![FontPicker_size_SpinBox](https://user-images.githubusercontent.com/6550710/114725379-713d2b00-9d0a-11eb-976b-4385189848bf.png)

Otherwise, if the font size set in the SpinBox does not exist in the size list, selection will be disabled for the list:

![FontPicker_size_SpinBox2](https://user-images.githubusercontent.com/6550710/114725396-74d0b200-9d0a-11eb-8ef2-a6ad9bd369a2.png)

The SpinBox is also hidden when a fixed size font is selected:

![FontPicker_size_SpinBox3](https://user-images.githubusercontent.com/6550710/114725455-81eda100-9d0a-11eb-99ab-249e82cd8d63.png)

Note: This is my first commit to any open source project so any feedback is greatly appreciated.