### PR TITLE
Ports: Add emu2 DOS emulator

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -23,6 +23,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`doom`](doom/)                | DOOM                                          |                   | https://github.com/SerenityOS/SerenityDOOM            |
 | [`dropbear`](dropbear/)        | Dropbear SSH                                  | 2019.78           | https://dropbear.nl/mirror/dropbear.html              |
 | [`ed`](ed/)                    | GNU ed                                        | 1.15              | https://www.gnu.org/software/ed/                      |
+| [`emu2`](emu2/)                | emu2 DOS emulator                             |                   | https://github.com/dmsc/emu2                          |
 | [`figlet`](figlet/)            | FIGlet                                        | 2.2.5             | http://www.figlet.org/                                |
 | [`flatbuffers`](flatbuffers/)  | Flatbuffers                                   | 1.12.0            | https://github.com/google/flatbuffers                 |
 | [`flex`](flex/)                | flex                                          | 2.6.4             | https://github.com/westes/flex                        |

--- a/Ports/emu2/package.sh
+++ b/Ports/emu2/package.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=emu2
+version=ff276eb0a755a3e784f73da00b5db6c1b25c1f83
+files="https://github.com/dmsc/emu2/archive/${version}.zip emu2-${version}.zip 2640a713d6c7ed98d020e0b7dccbc404"
+
+build() {
+    export CC="${SERENITY_ROOT}/Toolchain/Local/${SERENITY_ARCH}/bin/${SERENITY_ARCH}-pc-serenity-gcc"
+    run make DESTDIR="${SERENITY_BUILD_DIR}/Root" CC="${CC}" $installopts
+}

--- a/Ports/emu2/patches/codepage.patch
+++ b/Ports/emu2/patches/codepage.patch
@@ -1,0 +1,9 @@
++++ emu2-master/src/codepage.c	2021-04-14 07:13:48.165698165 -0700
+@@ -3,6 +3,7 @@
+ #include "env.h"
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ 
+ /* List of code-pages */
+ struct cp_data

--- a/Ports/emu2/patches/dosnames.patch
+++ b/Ports/emu2/patches/dosnames.patch
@@ -1,0 +1,27 @@
++++ emu2-master/src/dosnames.c	2021-04-14 07:15:44.036839086 -0700
+@@ -9,6 +9,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ #include <sys/stat.h>
+ 
+ // DOS directory entries.
+@@ -179,7 +180,7 @@
+     struct dirent **dir;
+     struct dos_file_list *ret;
+ 
+-    int n = scandir(path, &dir, 0, dos_unix_sort);
++    int n = 0; //scandir(path, &dir, 0, dos_unix_sort);
+     if(n <= 0)
+         return 0;
+ 
+@@ -589,7 +590,7 @@
+ static struct dos_file_list *find_first_file(char *fspec)
+ {
+     // Now, separate the path to the spec
+-    char *glob, *unixpath, *p = rindex(fspec, '/');
++    char *glob, *unixpath, *p = strrchr(fspec, '/');
+     if(!p)
+     {
+         glob = fspec;

--- a/Ports/emu2/patches/keyb.patch
+++ b/Ports/emu2/patches/keyb.patch
@@ -1,0 +1,10 @@
++++ emu2-master/src/keyb.c	2021-04-14 09:28:52.597237515 -0700
+@@ -385,7 +385,7 @@
+ {
+     if(tty_fd < 0)
+     {
+-        tty_fd = open("/dev/tty", O_NOCTTY | O_RDONLY);
++        tty_fd = open(ttyname(0), O_NOCTTY | O_RDONLY);
+         if(tty_fd < 0)
+         {
+             print_error("error at open TTY, %s\n", strerror(errno));

--- a/Ports/emu2/patches/main.patch
+++ b/Ports/emu2/patches/main.patch
@@ -1,0 +1,14 @@
++++ emu2-master/src/main.c	2021-04-14 07:16:54.192314882 -0700
+@@ -304,12 +304,6 @@
+     signal(SIGQUIT, exit_handler);
+     signal(SIGPIPE, exit_handler);
+     signal(SIGTERM, exit_handler);
+-    struct itimerval itv;
+-    itv.it_interval.tv_sec = 0;
+-    itv.it_interval.tv_usec = 54925;
+-    itv.it_value.tv_sec = 0;
+-    itv.it_value.tv_usec = 54925;
+-    setitimer(ITIMER_REAL, &itv, 0);
+     init_bios_mem();
+     while(1)
+     {

--- a/Ports/emu2/patches/video.patch
+++ b/Ports/emu2/patches/video.patch
@@ -1,0 +1,10 @@
++++ emu2-master/src/video.c	2021-04-14 09:29:03.273155128 -0700
+@@ -154,7 +154,7 @@
+ static void init_video(void)
+ {
+     debug(debug_video, "starting video emulation.\n");
+-    int tty_fd = open("/dev/tty", O_NOCTTY | O_WRONLY);
++    int tty_fd = open(ttyname(0), O_NOCTTY | O_WRONLY);
+     if(tty_fd < 0)
+     {
+         print_error("error at open TTY, %s\n", strerror(errno));


### PR DESCRIPTION
Runs DOS programs, so long as they only output text.

It will not work for programs which do anything with video or keyboard due to issues with TTY/PTS. It is probably a simple fix.

Also `scandir()` is commented out as LibC `dirent` does not have this yet.

![DUNE2](https://user-images.githubusercontent.com/434827/114753055-63cf8180-9d9a-11eb-83df-2bb202db2ae8.png)

![EICAR](https://user-images.githubusercontent.com/434827/114753061-65994500-9d9a-11eb-8747-8d0e673cc339.png)
