### PR TITLE
Tests: fixed test-crypto wrong argument order that failed - run-tests-and-shutdown.sh

### DIFF
--- a/Base/home/anon/tests/run-tests-and-shutdown.sh
+++ b/Base/home/anon/tests/run-tests-and-shutdown.sh
@@ -15,7 +15,7 @@ run(index) {
 }
 
 # TODO: test-web requires the window server
-system_tests=((test-js --show-progress=false) test-pthread test-compress /usr/Tests/LibM/test-math (test-crypto bigint -t))
+system_tests=((test-js --show-progress=false) test-pthread test-compress /usr/Tests/LibM/test-math (test-crypto -t bigint))
 # FIXME: Running too much at once is likely to run into #5541. Remove commented out find below when stable
 all_tests=${concat_lists $system_tests} #$(find /usr/Tests -type f | grep -v Kernel | grep -v .inc | shuf))
 count_of_all_tests=${length $all_tests}


### PR DESCRIPTION
run-tests-and-shutdown.sh failed on startup of `test-crypto` because of wrong parameter order
with the new parameter order the test actually runs (and succeeds)
:)
