### PR TITLE
LibGfx+LibWeb: CanvasRenderingContext2D Path fixes and tweaks

### DIFF
--- a/Base/res/html/misc/canvas-path-rect.html
+++ b/Base/res/html/misc/canvas-path-rect.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>canvas path - rect example</title>
+</head>
+<body>
+<canvas width=500 height=500></canvas>
+<script>
+
+    function drawRect() {
+        var canvas = document.querySelector("canvas");
+        var ctx = canvas.getContext("2d");
+        ctx.fillStyle = 'black';
+        ctx.fillRect(0, 0, 500, 500);
+
+        ctx.fillStyle = 'red';
+        ctx.beginPath();
+        ctx.rect(10, 20, 150, 100);
+        ctx.fill();
+
+        ctx.fillStyle = 'green';
+        ctx.beginPath();
+        ctx.rect(200, 210, 100, 100);
+        ctx.fill('evenodd');
+    }
+
+    drawRect();
+
+</script>
+</body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -70,6 +70,7 @@ span#loadtime {
         <li><a href="percent-css.html">CSS percentage values</a></li>
         <li><a href="inline-block.html">display: inline-block; test</a></li>
         <li><a href="canvas-path-quadratic-curve.html">canvas path quadratic curve test</a></li>
+        <li><a href="canvas-path-rect.html">canvas path rect test</a></li>
         <li><a href="pngsuite_siz_png.html">pngsuite odd sizes test</a></li>
         <li><a href="pngsuite_bas_png.html">pngsuite basic formats test</a></li>
         <li><a href="pngsuite_int_png.html">pngsuite interlacing test</a></li>

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1696,7 +1696,7 @@ void Painter::fill_path(Path& path, Color color, WindingRule winding_rule)
 #endif
 
             if (active_list.size() > 1) {
-                auto winding_number { 0 };
+                auto winding_number { winding_rule == WindingRule::Nonzero ? 1 : 0 };
                 for (size_t i = 1; i < active_list.size(); ++i) {
                     auto& previous = active_list[i - 1];
                     auto& current = active_list[i];

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -195,6 +195,7 @@ void CanvasRenderingContext2D::stroke()
         return;
 
     painter->stroke_path(m_path, m_stroke_style, m_line_width);
+    did_draw(m_path.bounding_box());
 }
 
 void CanvasRenderingContext2D::fill(Gfx::Painter::WindingRule winding)
@@ -206,6 +207,7 @@ void CanvasRenderingContext2D::fill(Gfx::Painter::WindingRule winding)
     auto path = m_path;
     path.close_all_subpaths();
     painter->fill_path(path, m_fill_style, winding);
+    did_draw(m_path.bounding_box());
 }
 
 void CanvasRenderingContext2D::fill(const String& fill_rule)

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -188,6 +188,17 @@ void CanvasRenderingContext2D::quadratic_curve_to(float cx, float cy, float x, f
     m_path.quadratic_bezier_curve_to({ cx, cy }, { x, y });
 }
 
+void CanvasRenderingContext2D::rect(float x, float y, float width, float height)
+{
+    m_path.move_to({ x, y });
+    if (width == 0 || height == 0)
+        return;
+    m_path.line_to({ x + width, y });
+    m_path.line_to({ x + width, y + height });
+    m_path.line_to({ x, y + height });
+    m_path.close();
+}
+
 void CanvasRenderingContext2D::stroke()
 {
     auto painter = this->painter();

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -33,6 +33,7 @@
 #include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
 #include <LibWeb/Bindings/Wrappable.h>
+#include <LibWeb/DOM/ExceptionOr.h>
 
 namespace Web::HTML {
 
@@ -73,6 +74,7 @@ public:
     void move_to(float x, float y);
     void line_to(float x, float y);
     void quadratic_curve_to(float cx, float cy, float x, float y);
+    void rect(float x, float y, float width, float height);
     void stroke();
 
     // FIXME: We should only have one fill(), really. Fix the wrapper generator!

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -10,7 +10,7 @@ interface CanvasRenderingContext2D {
 
     undefined beginPath();
     undefined closePath();
-    undefined fill(DOMString fillRule);
+    undefined fill(optional DOMString fillRule = "nonzero");
     undefined stroke();
     undefined moveTo(double x, double y);
     undefined lineTo(double x, double y);

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -15,6 +15,7 @@ interface CanvasRenderingContext2D {
     undefined moveTo(double x, double y);
     undefined lineTo(double x, double y);
     undefined quadraticCurveTo(double cpx, double cpy, double x, double y);
+    undefined rect(double x, double y, double width, double height);
 
     undefined drawImage(HTMLImageElement image, double dx, double dy);
 


### PR DESCRIPTION
Several fixes to CanvasRenderingContext2D i found while trying to get MDN's simple breakout tutorial game to run in Serenity's Browser (http://breakout.enclavegames.com/lesson10.html) as well as a missing path method it needed.
Unfortunately i was not able to get it fully working, as it also requires the arc path method, of which i do not have the needed mathematical understanding to implement.