### PR TITLE
Meta: Include queued checks in the discord notification's checks filter

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Wait for tests to finish
-        uses: IdanHo/action-wait-for-check@890bf0671eeeac09faf19f57deb4397eeccc59aa
+        uses: IdanHo/action-wait-for-check@7b2192dd83108237d2f2e6518f6351be333a955c
         id: wait-for-tests
         if: ${{ (github.event['pull_request'] && github.event['action'] == 'opened' && !(github.event['pull_request'] == 'draft')) || github.event['commits'] }}
         with:


### PR DESCRIPTION
The previous filter would filter out queued checks as well, which would result in erroneous build success notifications going out if github started the discord notifications workflow before all other workflows. (Matching commit: https://github.com/IdanHo/action-wait-for-check/commit/7b2192dd83108237d2f2e6518f6351be333a955c)
(An example of that happening is PR #6330)