### PR TITLE
LibPthread: Improvements for semaphores

### DIFF
--- a/Userland/Libraries/LibPthread/semaphore.cpp
+++ b/Userland/Libraries/LibPthread/semaphore.cpp
@@ -51,9 +51,25 @@ int sem_destroy(sem_t* sem)
     return 0;
 }
 
-int sem_getvalue(sem_t*, int*)
+int sem_getvalue(sem_t* sem, int* sval)
 {
-    VERIFY_NOT_REACHED();
+    auto rc = pthread_mutex_trylock(&sem->mtx);
+
+    if (rc == EBUSY) {
+        *sval = 0;
+        return 0;
+    }
+
+    if (rc != 0) {
+        errno = rc;
+        return -1;
+    }
+
+    *sval = sem->value;
+
+    pthread_mutex_unlock(&sem->mtx);
+
+    return 0;
 }
 
 int sem_init(sem_t* sem, int shared, unsigned int value)

--- a/Userland/Libraries/LibPthread/semaphore.h
+++ b/Userland/Libraries/LibPthread/semaphore.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <limits.h>
 #include <pthread.h>
 #include <sys/cdefs.h>
 #include <sys/types.h>
@@ -47,5 +48,7 @@ int sem_post(sem_t*);
 int sem_trywait(sem_t*);
 int sem_unlink(const char*);
 int sem_wait(sem_t*);
+
+#define SEM_VALUE_MAX INT_MAX
 
 __END_DECLS


### PR DESCRIPTION
This PR improves the `sem_*()` functions:

* Ensures we're not overflowing the semaphore's value.
* Improves error handling for the semaphore functions by returning the error codes from `pthread_*()` in errno.
* Makes sure we're not holding sem->mtx after sem_wait()/sem_trywait().
* Implements sem_getvalue().