### PR TITLE
SystemServer+LibCore: Allow service to request multiple sockets

### DIFF
--- a/Userland/Libraries/LibCore/LocalServer.h
+++ b/Userland/Libraries/LibCore/LocalServer.h
@@ -36,7 +36,7 @@ class LocalServer : public Object {
 public:
     virtual ~LocalServer() override;
 
-    bool take_over_from_system_server();
+    bool take_over_from_system_server(String const& path = String());
     bool is_listening() const { return m_listening; }
     bool listen(const String& address);
 

--- a/Userland/Libraries/LibCore/LocalSocket.cpp
+++ b/Userland/Libraries/LibCore/LocalSocket.cpp
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 
@@ -73,15 +74,49 @@ LocalSocket::~LocalSocket()
 {
 }
 
-RefPtr<LocalSocket> LocalSocket::take_over_accepted_socket_from_system_server()
-{
-    constexpr auto socket_takeover = "SOCKET_TAKEOVER";
-    if (!getenv(socket_takeover))
-        return nullptr;
+HashMap<String, int> LocalSocket::s_overtaken_sockets {};
+bool LocalSocket::s_overtaken_sockets_parsed { false };
 
-    // The SystemServer has passed us the socket as fd 3,
-    // so use that instead of creating our own.
-    constexpr int fd = 3;
+void LocalSocket::parse_sockets_from_system_server()
+{
+    VERIFY(!s_overtaken_sockets_parsed);
+
+    constexpr auto socket_takeover = "SOCKET_TAKEOVER";
+    const char* sockets = getenv(socket_takeover);
+    if (!sockets) {
+        s_overtaken_sockets_parsed = true;
+        return;
+    }
+
+    for (auto& socket : StringView(sockets).split_view(' ')) {
+        auto params = socket.split_view(':');
+        s_overtaken_sockets.set(params[0].to_string(), strtol(params[1].to_string().characters(), nullptr, 10));
+    }
+
+    s_overtaken_sockets_parsed = true;
+    // We wouldn't want our children to think we're passing
+    // them a socket either, so unset the env variable.
+    unsetenv(socket_takeover);
+}
+
+RefPtr<LocalSocket> LocalSocket::take_over_accepted_socket_from_system_server(String const& socket_path)
+{
+    if (!s_overtaken_sockets_parsed)
+        parse_sockets_from_system_server();
+
+    int fd;
+    if (socket_path.is_null()) {
+        // We want the first (and only) socket.
+        VERIFY(s_overtaken_sockets.size() == 1);
+        fd = s_overtaken_sockets.begin()->value;
+    } else {
+        auto it = s_overtaken_sockets.find(socket_path);
+        if (it == s_overtaken_sockets.end()) {
+            dbgln("Non-existent socket requested");
+            return nullptr;
+        }
+        fd = it->value;
+    }
 
     // Sanity check: it has to be a socket.
     struct stat stat;
@@ -99,9 +134,6 @@ RefPtr<LocalSocket> LocalSocket::take_over_accepted_socket_from_system_server()
     // don't need it to be !CLOEXEC anymore, so set the
     // CLOEXEC flag now.
     fcntl(fd, F_SETFD, FD_CLOEXEC);
-    // We wouldn't want our children to think we're passing
-    // them a socket either, so unset the env variable.
-    unsetenv(socket_takeover);
     return socket;
 }
 

--- a/Userland/Libraries/LibCore/LocalSocket.h
+++ b/Userland/Libraries/LibCore/LocalSocket.h
@@ -35,11 +35,20 @@ class LocalSocket final : public Socket {
 public:
     virtual ~LocalSocket() override;
 
-    static RefPtr<LocalSocket> take_over_accepted_socket_from_system_server();
+    static RefPtr<LocalSocket> take_over_accepted_socket_from_system_server(String const& socket_path = String());
 
 private:
     explicit LocalSocket(Object* parent = nullptr);
     LocalSocket(int fd, Object* parent = nullptr);
+
+    // FIXME: better place to put this so both LocalSocket and LocalServer can
+    // enjoy it?
+    friend class LocalServer;
+
+    static void parse_sockets_from_system_server();
+
+    static HashMap<String, int> s_overtaken_sockets;
+    static bool s_overtaken_sockets_parsed;
 };
 
 }

--- a/Userland/Services/SystemServer/Service.h
+++ b/Userland/Services/SystemServer/Service.h
@@ -51,6 +51,17 @@ private:
 
     void spawn(int socket_fd = -1);
 
+    /// SocketDescriptor describes the details of a single socket that was
+    /// requested by a service.
+    struct SocketDescriptor {
+        /// The path of the socket.
+        String path;
+        /// File descriptor of the socket. -1 if the socket hasn't been opened.
+        int fd { -1 };
+        /// File permissions of the socket.
+        mode_t permissions;
+    };
+
     // Path to the executable. By default this is /bin/{m_name}.
     String m_executable_path;
     // Extra arguments, starting from argv[1], to pass when exec'ing.
@@ -60,10 +71,6 @@ private:
     int m_priority { 1 };
     // Whether we should re-launch it if it exits.
     bool m_keep_alive { false };
-    // Path to the socket to create and listen on on behalf of this service.
-    String m_socket_path;
-    // File system permissions for the socket.
-    mode_t m_socket_permissions { 0 };
     // Whether we should accept connections on the socket and pass the accepted
     // (and not listening) socket to the service. This requires a multi-instance
     // service.
@@ -80,14 +87,14 @@ private:
     bool m_multi_instance { false };
     // Environment variables to pass to the service.
     Vector<String> m_environment;
+    // Socket descriptors for this service.
+    Vector<SocketDescriptor> m_sockets;
 
     // The resolved user account to run this service as.
     Optional<Core::Account> m_account;
 
     // For single-instance services, PID of the running instance of this service.
     pid_t m_pid { -1 };
-    // An open fd to the socket.
-    int m_socket_fd { -1 };
     RefPtr<Core::Notifier> m_socket_notifier;
 
     // Timer since we last spawned the service.
@@ -96,7 +103,8 @@ private:
     // times where it has exited unsuccessfully and too quickly.
     int m_restart_attempts { 0 };
 
-    void setup_socket();
+    void setup_socket(SocketDescriptor&);
+    void setup_sockets();
     void setup_notifier();
     void handle_socket_connection();
 };


### PR DESCRIPTION
SystemServer only allowed a single socket to be created for a service
before this.  Now, SystemServer will allow any amount of sockets.  The
sockets can be defined like so:

```ini
[SomeService]
Socket=/tmp/portal/socket1,/tmp/portal/socket2,/tmp/portal/socket3
SocketPermissions=660,600
```

The last item in SocketPermissions is applied to the remainder of the
sockets in the Socket= line, so multiple sockets can have the same
permissions without having to repeat them.

Defining multiple sockets is not allowed for socket-activated services
at the moment, and wouldn't make much sense anyway.

This patch also makes socket takeovers more robust by removing the
assumption that the socket will always be passed in fd 3.  Now, the
SOCKET_TAKEOVER environment variable carries information about which
endpoint corresponds to which socket, like so:

```console
SOCKET_TAKEOVER=/tmp/portal/socket1:3 /tmp/portal/socket2:4
```
and LocalServer/LocalService will parse this automatically and select
the correct one.  The old behavior of getting the default socket is
preserved so long as the service only requests a single socket in
SystemServer.ini.