### PR TITLE
LibGUI+WindowServer: Separate window manager IPC from regular IPC

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -63,7 +63,7 @@ User=anon
 BootModes=text,graphical
 
 [WindowServer]
-Socket=/tmp/portal/window
+Socket=/tmp/portal/window,/tmp/portal/wm
 SocketPermissions=660
 Priority=high
 KeepAlive=1

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SOURCES
     Widget.cpp
     Window.cpp
     WindowServerConnection.cpp
+    WindowManagerServerConnection.cpp
     Wizards/WizardDialog.cpp
     Wizards/AbstractWizardPage.cpp
     Wizards/CoverWizardPage.cpp

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -39,6 +39,7 @@
 #include <LibGUI/Painter.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
+#include <LibGUI/WindowManagerServerConnection.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/Bitmap.h>
 #include <fcntl.h>
@@ -313,6 +314,14 @@ void Window::set_window_type(WindowType window_type)
         else
             m_minimum_size_when_windowless = { 1, 1 };
     }
+}
+
+void Window::make_window_manager(unsigned event_mask)
+{
+    GUI::WindowManagerServerConnection::the()
+        .post_message(Messages::WindowManagerServer::SetEventMask(event_mask));
+    GUI::WindowManagerServerConnection::the()
+        .post_message(Messages::WindowManagerServer::SetManagerWindow(m_window_id));
 }
 
 void Window::set_cursor(Gfx::StandardCursor cursor)

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -80,6 +80,8 @@ public:
 
     int window_id() const { return m_window_id; }
 
+    void make_window_manager(unsigned event_mask);
+
     String title() const;
     void set_title(String);
 

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <LibGUI/Event.h>
+#include <LibGUI/Window.h>
+#include <LibGUI/WindowManagerServerConnection.h>
+#include <WindowServer/Window.h>
+
+namespace GUI {
+
+WindowManagerServerConnection& WindowManagerServerConnection::the()
+{
+    static WindowManagerServerConnection* s_connection = nullptr;
+    if (!s_connection)
+        s_connection = new WindowManagerServerConnection;
+    return *s_connection;
+}
+
+void WindowManagerServerConnection::handshake()
+{
+    // :^)
+}
+
+void WindowManagerServerConnection::handle(const Messages::WindowManagerClient::WindowStateChanged& message)
+{
+    if (auto* window = Window::from_window_id(message.wm_id()))
+        Core::EventLoop::current().post_event(*window, make<WMWindowStateChangedEvent>(message.client_id(), message.window_id(), message.parent_client_id(), message.parent_window_id(), message.title(), message.rect(), message.is_active(), message.is_modal(), static_cast<WindowType>(message.window_type()), message.is_minimized(), message.is_frameless(), message.progress()));
+}
+
+void WindowManagerServerConnection::handle(const Messages::WindowManagerClient::AppletAreaSizeChanged& message)
+{
+    if (auto* window = Window::from_window_id(message.wm_id()))
+        Core::EventLoop::current().post_event(*window, make<WMAppletAreaSizeChangedEvent>(message.size()));
+}
+
+void WindowManagerServerConnection::handle(const Messages::WindowManagerClient::WindowRectChanged& message)
+{
+    if (auto* window = Window::from_window_id(message.wm_id()))
+        Core::EventLoop::current().post_event(*window, make<WMWindowRectChangedEvent>(message.client_id(), message.window_id(), message.rect()));
+}
+
+void WindowManagerServerConnection::handle(const Messages::WindowManagerClient::WindowIconBitmapChanged& message)
+{
+    if (auto* window = Window::from_window_id(message.wm_id())) {
+        Core::EventLoop::current().post_event(*window, make<WMWindowIconBitmapChangedEvent>(message.client_id(), message.window_id(), message.bitmap().bitmap()));
+    }
+}
+
+void WindowManagerServerConnection::handle(const Messages::WindowManagerClient::WindowRemoved& message)
+{
+    if (auto* window = Window::from_window_id(message.wm_id()))
+        Core::EventLoop::current().post_event(*window, make<WMWindowRemovedEvent>(message.client_id(), message.window_id()));
+}
+}

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -273,37 +273,6 @@ void WindowServerConnection::handle(const Messages::WindowClient::MenuItemActiva
         action->activate(menu);
 }
 
-void WindowServerConnection::handle(const Messages::WindowClient::WM_WindowStateChanged& message)
-{
-    if (auto* window = Window::from_window_id(message.wm_id()))
-        Core::EventLoop::current().post_event(*window, make<WMWindowStateChangedEvent>(message.client_id(), message.window_id(), message.parent_client_id(), message.parent_window_id(), message.title(), message.rect(), message.is_active(), message.is_modal(), static_cast<WindowType>(message.window_type()), message.is_minimized(), message.is_frameless(), message.progress()));
-}
-
-void WindowServerConnection::handle(const Messages::WindowClient::WM_AppletAreaSizeChanged& message)
-{
-    if (auto* window = Window::from_window_id(message.wm_id()))
-        Core::EventLoop::current().post_event(*window, make<WMAppletAreaSizeChangedEvent>(message.size()));
-}
-
-void WindowServerConnection::handle(const Messages::WindowClient::WM_WindowRectChanged& message)
-{
-    if (auto* window = Window::from_window_id(message.wm_id()))
-        Core::EventLoop::current().post_event(*window, make<WMWindowRectChangedEvent>(message.client_id(), message.window_id(), message.rect()));
-}
-
-void WindowServerConnection::handle(const Messages::WindowClient::WM_WindowIconBitmapChanged& message)
-{
-    if (auto* window = Window::from_window_id(message.wm_id())) {
-        Core::EventLoop::current().post_event(*window, make<WMWindowIconBitmapChangedEvent>(message.client_id(), message.window_id(), message.bitmap().bitmap()));
-    }
-}
-
-void WindowServerConnection::handle(const Messages::WindowClient::WM_WindowRemoved& message)
-{
-    if (auto* window = Window::from_window_id(message.wm_id()))
-        Core::EventLoop::current().post_event(*window, make<WMWindowRemovedEvent>(message.client_id(), message.window_id()));
-}
-
 void WindowServerConnection::handle(const Messages::WindowClient::ScreenRectChanged& message)
 {
     Desktop::the().did_receive_screen_rect({}, message.rect());

--- a/Userland/Libraries/LibGUI/WindowServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.h
@@ -66,11 +66,6 @@ private:
     virtual void handle(const Messages::WindowClient::MenuItemActivated&) override;
     virtual void handle(const Messages::WindowClient::MenuVisibilityDidChange&) override;
     virtual void handle(const Messages::WindowClient::ScreenRectChanged&) override;
-    virtual void handle(const Messages::WindowClient::WM_WindowRemoved&) override;
-    virtual void handle(const Messages::WindowClient::WM_WindowStateChanged&) override;
-    virtual void handle(const Messages::WindowClient::WM_WindowIconBitmapChanged&) override;
-    virtual void handle(const Messages::WindowClient::WM_WindowRectChanged&) override;
-    virtual void handle(const Messages::WindowClient::WM_AppletAreaSizeChanged&) override;
     virtual void handle(const Messages::WindowClient::AsyncSetWallpaperFinished&) override;
     virtual void handle(const Messages::WindowClient::DragDropped&) override;
     virtual void handle(const Messages::WindowClient::DragAccepted&) override;

--- a/Userland/Services/Taskbar/TaskbarButton.cpp
+++ b/Userland/Services/Taskbar/TaskbarButton.cpp
@@ -28,6 +28,7 @@
 #include "WindowList.h"
 #include <LibGUI/Action.h>
 #include <LibGUI/Painter.h>
+#include <LibGUI/WindowManagerServerConnection.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/Font.h>
 #include <LibGfx/FontDatabase.h>
@@ -45,13 +46,17 @@ TaskbarButton::~TaskbarButton()
 
 void TaskbarButton::context_menu_event(GUI::ContextMenuEvent&)
 {
-    GUI::WindowServerConnection::the().post_message(Messages::WindowServer::WM_PopupWindowMenu(m_identifier.client_id(), m_identifier.window_id(), screen_relative_rect().location()));
+    GUI::WindowManagerServerConnection::the().post_message(
+        Messages::WindowManagerServer::PopupWindowMenu(
+            m_identifier.client_id(),
+            m_identifier.window_id(),
+            screen_relative_rect().location()));
 }
 
 void TaskbarButton::update_taskbar_rect()
 {
-    GUI::WindowServerConnection::the().post_message(
-        Messages::WindowServer::WM_SetWindowTaskbarRect(
+    GUI::WindowManagerServerConnection::the().post_message(
+        Messages::WindowManagerServer::SetWindowTaskbarRect(
             m_identifier.client_id(),
             m_identifier.window_id(),
             screen_relative_rect()));
@@ -59,8 +64,8 @@ void TaskbarButton::update_taskbar_rect()
 
 void TaskbarButton::clear_taskbar_rect()
 {
-    GUI::WindowServerConnection::the().post_message(
-        Messages::WindowServer::WM_SetWindowTaskbarRect(
+    GUI::WindowManagerServerConnection::the().post_message(
+        Messages::WindowManagerServer::SetWindowTaskbarRect(
             m_identifier.client_id(),
             m_identifier.window_id(),
             {}));

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -39,6 +39,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
+#include <LibGUI/WindowManagerServerConnection.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
@@ -182,7 +183,7 @@ void TaskbarWindow::update_applet_area()
     main_widget()->do_layout();
     Gfx::IntRect new_rect { {}, m_applet_area_size };
     new_rect.center_within(m_applet_area_container->screen_relative_rect());
-    GUI::WindowServerConnection::the().send_sync<Messages::WindowServer::WM_SetAppletAreaPosition>(new_rect.location());
+    GUI::WindowManagerServerConnection::the().send_sync<Messages::WindowManagerServer::SetAppletAreaPosition>(new_rect.location());
 }
 
 NonnullRefPtr<GUI::Button> TaskbarWindow::create_button(const WindowIdentifier& identifier)
@@ -209,9 +210,9 @@ void TaskbarWindow::add_window_button(::Window& window, const WindowIdentifier& 
         // false because window is the modal window's owner (which is not
         // active)
         if (window->is_minimized() || !button->is_checked()) {
-            GUI::WindowServerConnection::the().post_message(Messages::WindowServer::WM_SetActiveWindow(identifier.client_id(), identifier.window_id()));
+            GUI::WindowManagerServerConnection::the().post_message(Messages::WindowManagerServer::SetActiveWindow(identifier.client_id(), identifier.window_id()));
         } else {
-            GUI::WindowServerConnection::the().post_message(Messages::WindowServer::WM_SetWindowMinimized(identifier.client_id(), identifier.window_id(), true));
+            GUI::WindowManagerServerConnection::the().post_message(Messages::WindowManagerServer::SetWindowMinimized(identifier.client_id(), identifier.window_id(), true));
         }
     };
 }

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -36,7 +36,9 @@
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/WindowManagerServerConnection.h>
 #include <LibGUI/WindowServerConnection.h>
+#include <WindowServer/Window.h>
 #include <serenity.h>
 #include <signal.h>
 #include <spawn.h>
@@ -61,6 +63,9 @@ int main(int argc, char** argv)
             ;
     });
 
+    // We need to obtain the WM connection here as well before the pledge shortening.
+    GUI::WindowManagerServerConnection::the();
+
     if (pledge("stdio recvfd sendfd accept proc exec rpath", nullptr) < 0) {
         perror("pledge");
         return 1;
@@ -71,6 +76,11 @@ int main(int argc, char** argv)
 
     auto window = TaskbarWindow::construct(move(menu));
     window->show();
+
+    window->make_window_manager(
+        WindowServer::WMEventMask::WindowStateChanges
+        | WindowServer::WMEventMask::WindowRemovals
+        | WindowServer::WMEventMask::WindowIconChanges);
 
     return app->exec();
 }

--- a/Userland/Services/WindowServer/AppletManager.cpp
+++ b/Userland/Services/WindowServer/AppletManager.cpp
@@ -155,7 +155,7 @@ void AppletManager::relayout()
 
     repaint();
 
-    WindowManager::the().tell_wm_listeners_applet_area_size_changed(rect.size());
+    WindowManager::the().tell_wms_applet_area_size_changed(rect.size());
 }
 
 void AppletManager::repaint()

--- a/Userland/Services/WindowServer/CMakeLists.txt
+++ b/Userland/Services/WindowServer/CMakeLists.txt
@@ -1,5 +1,7 @@
 compile_ipc(WindowServer.ipc WindowServerEndpoint.h)
 compile_ipc(WindowClient.ipc WindowClientEndpoint.h)
+compile_ipc(WindowManagerServer.ipc WindowManagerServerEndpoint.h)
+compile_ipc(WindowManagerClient.ipc WindowManagerClientEndpoint.h)
 
 set(SOURCES
     AppletManager.cpp
@@ -20,6 +22,9 @@ set(SOURCES
     WindowSwitcher.cpp
     WindowServerEndpoint.h
     WindowClientEndpoint.h
+    WindowManagerServerEndpoint.h
+    WindowManagerClientEndpoint.h
+    WMClientConnection.cpp
 )
 
 serenity_bin(WindowServer)

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -45,6 +45,7 @@ class Compositor;
 class Window;
 class Menu;
 class Menubar;
+class WMClientConnection;
 
 class ClientConnection final
     : public IPC::ClientConnection<WindowClientEndpoint, WindowServerEndpoint>
@@ -132,11 +133,6 @@ private:
     virtual OwnPtr<Messages::WindowServer::SetGlobalCursorTrackingResponse> handle(const Messages::WindowServer::SetGlobalCursorTracking&) override;
     virtual OwnPtr<Messages::WindowServer::SetWindowOpacityResponse> handle(const Messages::WindowServer::SetWindowOpacity&) override;
     virtual OwnPtr<Messages::WindowServer::SetWindowBackingStoreResponse> handle(const Messages::WindowServer::SetWindowBackingStore&) override;
-    virtual void handle(const Messages::WindowServer::WM_SetActiveWindow&) override;
-    virtual void handle(const Messages::WindowServer::WM_SetWindowMinimized&) override;
-    virtual void handle(const Messages::WindowServer::WM_StartWindowResize&) override;
-    virtual void handle(const Messages::WindowServer::WM_PopupWindowMenu&) override;
-    virtual OwnPtr<Messages::WindowServer::WM_SetAppletAreaPositionResponse> handle(const Messages::WindowServer::WM_SetAppletAreaPosition&) override;
     virtual OwnPtr<Messages::WindowServer::SetWindowHasAlphaChannelResponse> handle(const Messages::WindowServer::SetWindowHasAlphaChannel&) override;
     virtual OwnPtr<Messages::WindowServer::SetWindowAlphaHitThresholdResponse> handle(const Messages::WindowServer::SetWindowAlphaHitThreshold&) override;
     virtual OwnPtr<Messages::WindowServer::MoveWindowToFrontResponse> handle(const Messages::WindowServer::MoveWindowToFront&) override;
@@ -152,7 +148,6 @@ private:
     virtual OwnPtr<Messages::WindowServer::PopupMenuResponse> handle(const Messages::WindowServer::PopupMenu&) override;
     virtual OwnPtr<Messages::WindowServer::DismissMenuResponse> handle(const Messages::WindowServer::DismissMenu&) override;
     virtual OwnPtr<Messages::WindowServer::SetWindowIconBitmapResponse> handle(const Messages::WindowServer::SetWindowIconBitmap&) override;
-    virtual void handle(const Messages::WindowServer::WM_SetWindowTaskbarRect&) override;
     virtual OwnPtr<Messages::WindowServer::StartDragResponse> handle(const Messages::WindowServer::StartDrag&) override;
     virtual OwnPtr<Messages::WindowServer::SetSystemThemeResponse> handle(const Messages::WindowServer::SetSystemTheme&) override;
     virtual OwnPtr<Messages::WindowServer::GetSystemThemeResponse> handle(const Messages::WindowServer::GetSystemTheme&) override;
@@ -186,6 +181,9 @@ private:
 
     bool m_has_display_link { false };
     bool m_unresponsive { false };
+
+    // Need this to get private client connection stuff
+    friend WMClientConnection;
 };
 
 }

--- a/Userland/Services/WindowServer/WMClientConnection.cpp
+++ b/Userland/Services/WindowServer/WMClientConnection.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <WindowServer/AppletManager.h>
+#include <WindowServer/ClientConnection.h>
+#include <WindowServer/Screen.h>
+#include <WindowServer/WMClientConnection.h>
+
+namespace WindowServer {
+
+HashMap<int, NonnullRefPtr<WMClientConnection>> WMClientConnection::s_connections {};
+
+WMClientConnection::WMClientConnection(NonnullRefPtr<Core::LocalSocket> client_socket, int client_id)
+    : IPC::ClientConnection<WindowManagerClientEndpoint, WindowManagerServerEndpoint>(*this, move(client_socket), client_id)
+{
+    s_connections.set(client_id, *this);
+}
+
+WMClientConnection::~WMClientConnection()
+{
+    // The WM has gone away, so take away the applet manager (cause there's nowhere
+    // to draw it in).
+    AppletManager::the().set_position({});
+}
+
+void WMClientConnection::die()
+{
+    deferred_invoke([this](auto&) {
+        s_connections.remove(client_id());
+    });
+}
+
+OwnPtr<Messages::WindowManagerServer::SetAppletAreaPositionResponse> WMClientConnection::handle(const Messages::WindowManagerServer::SetAppletAreaPosition& message)
+{
+    if (m_window_id < 0) {
+        did_misbehave("SetAppletAreaPosition: WM didn't assign window as manager yet");
+        // FIXME: return ok boolean?
+        return make<Messages::WindowManagerServer::SetAppletAreaPositionResponse>();
+    }
+
+    AppletManager::the().set_position(message.position());
+    return make<Messages::WindowManagerServer::SetAppletAreaPositionResponse>();
+}
+
+void WMClientConnection::handle(const Messages::WindowManagerServer::SetActiveWindow& message)
+{
+    auto* client = WindowServer::ClientConnection::from_client_id(message.client_id());
+    if (!client) {
+        did_misbehave("SetActiveWindow: Bad client ID");
+        return;
+    }
+    auto it = client->m_windows.find(message.window_id());
+    if (it == client->m_windows.end()) {
+        did_misbehave("SetActiveWindow: Bad window ID");
+        return;
+    }
+    auto& window = *(*it).value;
+    WindowManager::the().minimize_windows(window, false);
+    WindowManager::the().move_to_front_and_make_active(window);
+}
+
+void WMClientConnection::handle(const Messages::WindowManagerServer::PopupWindowMenu& message)
+{
+    auto* client = WindowServer::ClientConnection::from_client_id(message.client_id());
+    if (!client) {
+        did_misbehave("PopupWindowMenu: Bad client ID");
+        return;
+    }
+    auto it = client->m_windows.find(message.window_id());
+    if (it == client->m_windows.end()) {
+        did_misbehave("PopupWindowMenu: Bad window ID");
+        return;
+    }
+    auto& window = *(*it).value;
+    if (auto* modal_window = window.blocking_modal_window()) {
+        modal_window->popup_window_menu(message.screen_position(), WindowMenuDefaultAction::BasedOnWindowState);
+    } else {
+        window.popup_window_menu(message.screen_position(), WindowMenuDefaultAction::BasedOnWindowState);
+    }
+}
+
+void WMClientConnection::handle(const Messages::WindowManagerServer::StartWindowResize& request)
+{
+    auto* client = WindowServer::ClientConnection::from_client_id(request.client_id());
+    if (!client) {
+        did_misbehave("WM_StartWindowResize: Bad client ID");
+        return;
+    }
+    auto it = client->m_windows.find(request.window_id());
+    if (it == client->m_windows.end()) {
+        did_misbehave("WM_StartWindowResize: Bad window ID");
+        return;
+    }
+    auto& window = *(*it).value;
+    // FIXME: We are cheating a bit here by using the current cursor location and hard-coding the left button.
+    //        Maybe the client should be allowed to specify what initiated this request?
+    WindowManager::the().start_window_resize(window, Screen::the().cursor_location(), MouseButton::Left);
+}
+
+void WMClientConnection::handle(const Messages::WindowManagerServer::SetWindowMinimized& message)
+{
+    auto* client = WindowServer::ClientConnection::from_client_id(message.client_id());
+    if (!client) {
+        did_misbehave("WM_SetWindowMinimized: Bad client ID");
+        return;
+    }
+    auto it = client->m_windows.find(message.window_id());
+    if (it == client->m_windows.end()) {
+        did_misbehave("WM_SetWindowMinimized: Bad window ID");
+        return;
+    }
+    auto& window = *(*it).value;
+    WindowManager::the().minimize_windows(window, message.minimized());
+}
+
+OwnPtr<Messages::WindowManagerServer::SetEventMaskResponse> WMClientConnection::handle(const Messages::WindowManagerServer::SetEventMask& message)
+{
+    m_event_mask = message.event_mask();
+    return make<Messages::WindowManagerServer::SetEventMaskResponse>();
+}
+
+OwnPtr<Messages::WindowManagerServer::SetManagerWindowResponse> WMClientConnection::handle(const Messages::WindowManagerServer::SetManagerWindow& message)
+{
+    m_window_id = message.window_id();
+
+    // Let the window manager know that we obtained a manager window, and should
+    // receive information about other windows.
+    WindowManager::the().greet_window_manager(*this);
+
+    return make<Messages::WindowManagerServer::SetManagerWindowResponse>();
+}
+
+void WMClientConnection::handle(const Messages::WindowManagerServer::SetWindowTaskbarRect& message)
+{
+    // Because the Taskbar (which should be the only user of this API) does not own the
+    // window or the client id, there is a possibility that it may send this message for
+    // a window or client that may have been destroyed already. This is not an error,
+    // and we should not call did_misbehave() for either.
+    auto* client = WindowServer::ClientConnection::from_client_id(message.client_id());
+    if (!client)
+        return;
+
+    auto it = client->m_windows.find(message.window_id());
+    if (it == client->m_windows.end())
+        return;
+
+    auto& window = *(*it).value;
+    window.set_taskbar_rect(message.rect());
+}
+
+}

--- a/Userland/Services/WindowServer/WMClientConnection.h
+++ b/Userland/Services/WindowServer/WMClientConnection.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AK/NonnullRefPtr.h"
+#include <AK/HashMap.h>
+#include <LibIPC/ClientConnection.h>
+#include <WindowServer/WindowManagerClientEndpoint.h>
+#include <WindowServer/WindowManagerServerEndpoint.h>
+
+namespace WindowServer {
+
+class WMClientConnection final
+    : public IPC::ClientConnection<WindowManagerClientEndpoint, WindowManagerServerEndpoint>
+    , public WindowManagerServerEndpoint {
+    C_OBJECT(WMClientConnection)
+
+public:
+    ~WMClientConnection() override;
+
+    virtual void handle(const Messages::WindowManagerServer::SetActiveWindow&) override;
+    virtual void handle(const Messages::WindowManagerServer::SetWindowMinimized&) override;
+    virtual void handle(const Messages::WindowManagerServer::StartWindowResize&) override;
+    virtual void handle(const Messages::WindowManagerServer::PopupWindowMenu&) override;
+    virtual void handle(const Messages::WindowManagerServer::SetWindowTaskbarRect&) override;
+    virtual OwnPtr<Messages::WindowManagerServer::SetAppletAreaPositionResponse> handle(const Messages::WindowManagerServer::SetAppletAreaPosition&) override;
+    virtual OwnPtr<Messages::WindowManagerServer::SetEventMaskResponse> handle(const Messages::WindowManagerServer::SetEventMask&) override;
+    virtual OwnPtr<Messages::WindowManagerServer::SetManagerWindowResponse> handle(const Messages::WindowManagerServer::SetManagerWindow&) override;
+
+    unsigned event_mask() const { return m_event_mask; }
+    int window_id() const { return m_window_id; }
+
+private:
+    explicit WMClientConnection(NonnullRefPtr<Core::LocalSocket> client_socket, int client_id);
+
+    // ^ClientConnection
+    virtual void die() override;
+
+    // RefPtr<Core::Timer> m_ping_timer;
+    static HashMap<int, NonnullRefPtr<WMClientConnection>> s_connections;
+    unsigned m_event_mask { 0 };
+    int m_window_id { -1 };
+
+    // WindowManager needs to access the window manager clients to notify
+    // about events.
+    friend class WindowManager;
+};
+
+};

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -113,12 +113,6 @@ Window::Window(ClientConnection& client, WindowType window_type, int window_id, 
     , m_icon(default_window_icon())
     , m_frame(*this)
 {
-    // FIXME: This should not be hard-coded here.
-    if (m_type == WindowType::Taskbar) {
-        m_wm_event_mask = WMEventMask::WindowStateChanges | WMEventMask::WindowRemovals | WMEventMask::WindowIconChanges;
-        m_listens_to_wm_events = true;
-    }
-
     // Set default minimum size for Normal windows
     if (m_type == WindowType::Normal)
         m_minimum_size = s_default_normal_minimum_size;

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -100,9 +100,6 @@ public:
     void window_menu_activate_default();
     void request_close();
 
-    unsigned wm_event_mask() const { return m_wm_event_mask; }
-    void set_wm_event_mask(unsigned mask) { m_wm_event_mask = mask; }
-
     bool is_minimized() const { return m_minimized; }
     void set_minimized(bool);
 
@@ -136,8 +133,6 @@ public:
     const WindowFrame& frame() const { return m_frame; }
 
     Window* blocking_modal_window();
-
-    bool listens_to_wm_events() const { return m_listens_to_wm_events; }
 
     ClientConnection* client() { return m_client; }
     const ClientConnection* client() const { return m_client; }
@@ -381,7 +376,6 @@ private:
     bool m_frameless { false };
     bool m_resizable { false };
     Optional<Gfx::IntSize> m_resize_aspect_ratio {};
-    bool m_listens_to_wm_events { false };
     bool m_minimized { false };
     bool m_maximized { false };
     bool m_fullscreen { false };
@@ -411,7 +405,6 @@ private:
     RefPtr<Cursor> m_cursor;
     RefPtr<Cursor> m_cursor_override;
     WindowFrame m_frame;
-    unsigned m_wm_event_mask { 0 };
     Gfx::DisjointRectSet m_pending_paint_rects;
     Gfx::IntRect m_unmaximized_rect;
     Gfx::IntRect m_rect_in_applet_area;

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -23,12 +23,6 @@ endpoint WindowClient = 4
 
     ScreenRectChanged(Gfx::IntRect rect) =|
 
-    WM_WindowRemoved(i32 wm_id, i32 client_id, i32 window_id) =|
-    WM_WindowStateChanged(i32 wm_id, i32 client_id, i32 window_id, i32 parent_client_id, i32 parent_window_id, bool is_active, bool is_minimized, bool is_modal, bool is_frameless, i32 window_type, [UTF8] String title, Gfx::IntRect rect, i32 progress) =|
-    WM_WindowIconBitmapChanged(i32 wm_id, i32 client_id, i32 window_id, Gfx::ShareableBitmap bitmap) =|
-    WM_WindowRectChanged(i32 wm_id, i32 client_id, i32 window_id, Gfx::IntRect rect) =|
-    WM_AppletAreaSizeChanged(i32 wm_id, Gfx::IntSize size) =|
-
     AsyncSetWallpaperFinished(bool success) =|
 
     DragAccepted() =|

--- a/Userland/Services/WindowServer/WindowManagerClient.ipc
+++ b/Userland/Services/WindowServer/WindowManagerClient.ipc
@@ -1,0 +1,8 @@
+endpoint WindowManagerClient = 1872
+{
+    WindowRemoved(i32 wm_id, i32 client_id, i32 window_id) =|
+    WindowStateChanged(i32 wm_id, i32 client_id, i32 window_id, i32 parent_client_id, i32 parent_window_id, bool is_active, bool is_minimized, bool is_modal, bool is_frameless, i32 window_type, [UTF8] String title, Gfx::IntRect rect, i32 progress) =|
+    WindowIconBitmapChanged(i32 wm_id, i32 client_id, i32 window_id, Gfx::ShareableBitmap bitmap) =|
+    WindowRectChanged(i32 wm_id, i32 client_id, i32 window_id, Gfx::IntRect rect) =|
+    AppletAreaSizeChanged(i32 wm_id, Gfx::IntSize size) =|
+}

--- a/Userland/Services/WindowServer/WindowManagerServer.ipc
+++ b/Userland/Services/WindowServer/WindowManagerServer.ipc
@@ -1,0 +1,12 @@
+endpoint WindowManagerServer = 1871
+{
+    SetEventMask(u32 event_mask) => ()
+    SetManagerWindow(i32 window_id) => ()
+
+    SetActiveWindow(i32 client_id, i32 window_id) =|
+    SetWindowMinimized(i32 client_id, i32 window_id, bool minimized) =|
+    StartWindowResize(i32 client_id, i32 window_id) =|
+    PopupWindowMenu(i32 client_id, i32 window_id, Gfx::IntPoint screen_position) =|
+    SetWindowTaskbarRect(i32 client_id, i32 window_id, Gfx::IntRect rect) =|
+    SetAppletAreaPosition(Gfx::IntPoint position) => ()
+}

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -78,13 +78,6 @@ endpoint WindowServer = 2
 
     SetWindowBackingStore(i32 window_id, i32 bpp, i32 pitch, IPC::File anon_file, i32 serial, bool has_alpha_channel, Gfx::IntSize size, bool flush_immediately) => ()
 
-    WM_SetActiveWindow(i32 client_id, i32 window_id) =|
-    WM_SetWindowMinimized(i32 client_id, i32 window_id, bool minimized) =|
-    WM_StartWindowResize(i32 client_id, i32 window_id) =|
-    WM_PopupWindowMenu(i32 client_id, i32 window_id, Gfx::IntPoint screen_position) =|
-    WM_SetWindowTaskbarRect(i32 client_id, i32 window_id, Gfx::IntRect rect) =|
-    WM_SetAppletAreaPosition(Gfx::IntPoint position) => ()
-
     SetWindowHasAlphaChannel(i32 window_id, bool has_alpha_channel) => ()
     MoveWindowToFront(i32 window_id) => ()
     SetFullscreen(i32 window_id, bool fullscreen) => ()


### PR DESCRIPTION
With this patch the window manager related functionality is split out
onto a new endpoint pair named WindowManagerServer/Client.  This allows
window manager functionality to be potentially privilege separated in
the future.  To this end, a new client named WMConnectionClient
is used to maintain a window manager connection.  When a process
connects to the endpoint and greets the WindowServer as a window manager
(via Window::make_window_manager(int)), they're subscribed to the events
they requested via the WM event mask.

This patch also removes the hardcoding of the Taskbar WindowType to
receive WM events automatically.  However, being a window manager still
requires having an active window, at the moment.

~~This patch currently depends on #6334, and will be a draft until that is merged.~~
Since #6334 is merged I've un-drafted it.