### PR TITLE
Ports: Make sure we're building libvorbis before SDL2_mixer

### DIFF
--- a/Ports/SDL2_mixer/package.sh
+++ b/Ports/SDL2_mixer/package.sh
@@ -3,7 +3,7 @@ port=SDL2_mixer
 version=2.0.4
 useconfigure=true
 files="https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${version}.tar.gz SDL2_mixer-${version}.tar.gz"
-depends="SDL2"
+depends="SDL2 libvorbis"
 
 configure() {
     run ./configure \


### PR DESCRIPTION
This hasn't been an issue for me so far because I was using `./build_all.sh` which builds the ports in alphabetical order (so `libvorbis` comes before `SDL2_mixer`).