### PR TITLE
LibJS: Implement String.prototype.substr according to the spec

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.substr.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.substr.js
@@ -1,6 +1,9 @@
 test("basic functionality", () => {
     expect(String.prototype.substr).toHaveLength(2);
 
+    expect("".substr(1)).toBe("");
+    expect("".substr()).toBe("");
+    expect("".substr(-1)).toBe("");
     expect("hello friends".substr()).toBe("hello friends");
     expect("hello friends".substr(1)).toBe("ello friends");
     expect("hello friends".substr(0, 5)).toBe("hello");


### PR DESCRIPTION
Fixes #6325

The JavaScript on the HTML Spec site that caused the crash is:
    window.location.hash.substr(1)

Of course, window.location.hash can be the empty string. The spec allows
for calling substr(1) on an empty string, but our partial implementation
wasn't handling it properly.