### PR TITLE
Base: Add documentation for `get_process_name`

### DIFF
--- a/Base/usr/share/man/man2/get_process_name.md
+++ b/Base/usr/share/man/man2/get_process_name.md
@@ -1,0 +1,28 @@
+## Name
+
+get\_process\_name - get the process name
+
+## Synopsis
+
+```**c++
+#include <unistd.h>
+
+int get_process_name(char* buffer, int buffer_length);
+```
+
+## Description
+
+`get_process_name()` places the current process name into the provided `buffer`.
+
+## Pledge
+
+In pledged programs, the `stdio` promise is required for this system call.
+
+## Errors
+
+* `EFAULT`: the process name could not be copied into the buffer.
+* `ENAMETOOLONG`: `buffer_length` is too short.
+
+## See also
+
+* [`set_process_name`(2)](../man2/set_process_name.md)


### PR DESCRIPTION
`set_process_name` has a getter pair (which it links to); lets document it.

Solves #6007.