### PR TITLE
Ports: Use ftpmirror.gnu.org mirror server for GNU ports

### DIFF
--- a/Ports/bash/package.sh
+++ b/Ports/bash/package.sh
@@ -3,9 +3,9 @@ port=bash
 version=5.0
 useconfigure=true
 configopts="--disable-nls --without-bash-malloc"
-files="https://ftp.gnu.org/gnu/bash/bash-${version}.tar.gz bash-${version}.tar.gz
-https://ftp.gnu.org/gnu/bash/bash-${version}.tar.gz.sig bash-${version}.tar.gz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/bash/bash-${version}.tar.gz bash-${version}.tar.gz
+https://ftpmirror.gnu.org/gnu/bash/bash-${version}.tar.gz.sig bash-${version}.tar.gz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg bash-${version}.tar.gz.sig"
 

--- a/Ports/binutils/package.sh
+++ b/Ports/binutils/package.sh
@@ -3,9 +3,9 @@ port=binutils
 version=2.32
 useconfigure=true
 configopts="--target=${SERENITY_ARCH}-pc-serenity --with-sysroot=/ --with-build-sysroot=${SERENITY_BUILD_DIR}/Root --disable-werror --disable-gdb --disable-nls"
-files="https://ftp.gnu.org/gnu/binutils/binutils-${version}.tar.xz binutils-${version}.tar.xz
-https://ftp.gnu.org/gnu/binutils/binutils-${version}.tar.xz.sig binutils-${version}.tar.xz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/binutils/binutils-${version}.tar.xz binutils-${version}.tar.xz
+https://ftpmirror.gnu.org/gnu/binutils/binutils-${version}.tar.xz.sig binutils-${version}.tar.xz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg binutils-${version}.tar.xz.sig"
 export ac_cv_func_getrusage=no

--- a/Ports/bison/package.sh
+++ b/Ports/bison/package.sh
@@ -3,5 +3,5 @@ port=bison
 version=1.25
 useconfigure=true
 configopts="--prefix=${SERENITY_BUILD_DIR}/Root/usr/local"
-files="https://ftp.gnu.org/gnu/bison/bison-${version}.tar.gz bison-${version}.tar.gz 65f577d0f8ffaf61ae21c23c0918d225"
+files="https://ftpmirror.gnu.org/gnu/bison/bison-${version}.tar.gz bison-${version}.tar.gz 65f577d0f8ffaf61ae21c23c0918d225"
 auth_type="md5"

--- a/Ports/diffutils/package.sh
+++ b/Ports/diffutils/package.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=diffutils
 version=3.5
-files="https://ftp.gnu.org/gnu/diffutils/diffutils-${version}.tar.xz diffutils-${version}.tar.xz
-https://ftp.gnu.org/gnu/diffutils/diffutils-${version}.tar.xz.sig diffutils-${version}.tar.xz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/diffutils/diffutils-${version}.tar.xz diffutils-${version}.tar.xz
+https://ftpmirror.gnu.org/gnu/diffutils/diffutils-${version}.tar.xz.sig diffutils-${version}.tar.xz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 useconfigure=true
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg diffutils-${version}.tar.xz.sig"

--- a/Ports/dmidecode/package.sh
+++ b/Ports/dmidecode/package.sh
@@ -4,7 +4,7 @@ version=3.3
 useconfigure=false
 files="https://download.savannah.gnu.org/releases/dmidecode/dmidecode-${version}.tar.xz dmidecode-${version}.tar.xz
 https://download.savannah.gnu.org/releases/dmidecode/dmidecode-${version}.tar.xz.sig dmidecode-${version}.tar.xz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_import_key="90DFD6523C57373D81F63D19865688D038F02FC8"
 auth_opts="--keyring ./gnu-keyring.gpg dmidecode-${version}.tar.xz.sig"

--- a/Ports/ed/package.sh
+++ b/Ports/ed/package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=ed
 version=1.15
-files="https://ftp.gnu.org/gnu/ed/ed-${version}.tar.lz ed-${version}.tar.lz"
+files="https://ftpmirror.gnu.org/gnu/ed/ed-${version}.tar.lz ed-${version}.tar.lz"
 useconfigure=true
 depends=pcre2
 

--- a/Ports/gcc/package.sh
+++ b/Ports/gcc/package.sh
@@ -3,9 +3,9 @@ port=gcc
 version=10.2.0
 useconfigure=true
 configopts="--target=${SERENITY_ARCH}-pc-serenity --with-sysroot=/ --with-build-sysroot=${SERENITY_BUILD_DIR}/Root --with-newlib --enable-languages=c,c++ --disable-lto --disable-nls --enable-shared --enable-default-pie --enable-host-shared"
-files="https://ftp.gnu.org/gnu/gcc/gcc-${version}/gcc-${version}.tar.xz gcc-${version}.tar.xz
-https://ftp.gnu.org/gnu/gcc/gcc-${version}/gcc-${version}.tar.xz.sig gcc-${version}.tar.xz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/gcc/gcc-${version}/gcc-${version}.tar.xz gcc-${version}.tar.xz
+https://ftpmirror.gnu.org/gnu/gcc/gcc-${version}/gcc-${version}.tar.xz.sig gcc-${version}.tar.xz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 makeopts="all-gcc all-target-libgcc all-target-libstdc++-v3 -j $(nproc)"
 installopts="DESTDIR=${SERENITY_BUILD_DIR}/Root install-gcc install-target-libgcc install-target-libstdc++-v3"
 depends="binutils"

--- a/Ports/gmp/package.sh
+++ b/Ports/gmp/package.sh
@@ -2,8 +2,8 @@
 port=gmp
 version=6.2.1
 useconfigure="true"
-files="https://ftp.gnu.org/gnu/gmp/gmp-${version}.tar.bz2 gmp-${version}.tar.bz2
-https://ftp.gnu.org/gnu/gmp/gmp-${version}.tar.bz2.sig gmp-${version}.tar.bz2.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/gmp/gmp-${version}.tar.bz2 gmp-${version}.tar.bz2
+https://ftpmirror.gnu.org/gnu/gmp/gmp-${version}.tar.bz2.sig gmp-${version}.tar.bz2.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg gmp-${version}.tar.bz2.sig"

--- a/Ports/gnucobol/package.sh
+++ b/Ports/gnucobol/package.sh
@@ -3,9 +3,9 @@ port=gnucobol
 version=3.1.2
 useconfigure="true"
 depends="gmp gcc bash"
-files="https://ftp.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2 gnucobol-${version}.tar.bz2
-https://ftp.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2.sig gnucobol-${version}.tar.bz2.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2 gnucobol-${version}.tar.bz2
+https://ftpmirror.gnu.org/gnu/gnucobol/gnucobol-${version}.tar.bz2.sig gnucobol-${version}.tar.bz2.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg gnucobol-${version}.tar.bz2.sig"
 configopts="--prefix=/usr/local --enable-hardening --disable-rpath --with-gnu-ld --with-dl --with-math=gmp --with-db=no --with-json=no --with-curses=curses"

--- a/Ports/grep/package.sh
+++ b/Ports/grep/package.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=grep
 version=2.5.4
-files="https://ftp.gnu.org/gnu/grep/grep-${version}.tar.gz grep-${version}.tar.gz
-https://ftp.gnu.org/gnu/grep/grep-${version}.tar.gz.sig grep-${version}.tar.gz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/grep/grep-${version}.tar.gz grep-${version}.tar.gz
+https://ftpmirror.gnu.org/gnu/grep/grep-${version}.tar.gz.sig grep-${version}.tar.gz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 
 useconfigure=true
 configopts=--disable-perl-regexp

--- a/Ports/indent/package.sh
+++ b/Ports/indent/package.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=indent
 version=2.2.11
-files="https://ftp.gnu.org/gnu/indent/indent-${version}.tar.gz indent-${version}.tar.gz
-https://ftp.gnu.org/gnu/indent/indent-${version}.tar.gz.sig indent-${version}.tar.gz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/indent/indent-${version}.tar.gz indent-${version}.tar.gz
+https://ftpmirror.gnu.org/gnu/indent/indent-${version}.tar.gz.sig indent-${version}.tar.gz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 useconfigure=true
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg indent-${version}.tar.gz.sig"

--- a/Ports/less/package.sh
+++ b/Ports/less/package.sh
@@ -2,9 +2,9 @@
 port=less
 version=530
 useconfigure="true"
-files="https://ftp.gnu.org/gnu/less/less-${version}.tar.gz less-${version}.tar.gz
-https://ftp.gnu.org/gnu/less/less-${version}.tar.gz.sig less-${version}.tar.gz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/less/less-${version}.tar.gz less-${version}.tar.gz
+https://ftpmirror.gnu.org/gnu/less/less-${version}.tar.gz.sig less-${version}.tar.gz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 
 depends="ncurses"
 auth_type="sig"

--- a/Ports/libiconv/package.sh
+++ b/Ports/libiconv/package.sh
@@ -3,9 +3,9 @@ port=libiconv
 version=1.16
 useconfigure=true
 configopts=--enable-shared
-files="https://ftp.gnu.org/pub/gnu/libiconv/libiconv-${version}.tar.gz libiconv-${version}.tar.gz
-https://ftp.gnu.org/gnu/libiconv/libiconv-${version}.tar.gz.sig libiconv-${version}.tar.gz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/pub/gnu/libiconv/libiconv-${version}.tar.gz libiconv-${version}.tar.gz
+https://ftpmirror.gnu.org/gnu/libiconv/libiconv-${version}.tar.gz.sig libiconv-${version}.tar.gz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg libiconv-${version}.tar.gz.sig"

--- a/Ports/libtool/package.sh
+++ b/Ports/libtool/package.sh
@@ -3,9 +3,9 @@ port=libtool
 version=2.4
 useconfigure="true"
 depends="bash sed"
-files="https://ftp.gnu.org/gnu/libtool/libtool-${version}.tar.xz libtool-${version}.tar.xz
-https://ftp.gnu.org/gnu/libtool/libtool-${version}.tar.xz.sig libtool-${version}.tar.xz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/libtool/libtool-${version}.tar.xz libtool-${version}.tar.xz
+https://ftpmirror.gnu.org/gnu/libtool/libtool-${version}.tar.xz.sig libtool-${version}.tar.xz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg libtool-${version}.tar.xz.sig"
 configopts="--prefix=/usr/local"

--- a/Ports/m4/package.sh
+++ b/Ports/m4/package.sh
@@ -2,8 +2,8 @@
 port=m4
 version=1.4.9
 useconfigure=true
-files="https://ftp.gnu.org/gnu/m4/m4-${version}.tar.gz m4-${version}.tar.gz
-https://ftp.gnu.org/gnu/m4/m4-${version}.tar.gz.sig m4-${version}.tar.gz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/m4/m4-${version}.tar.gz m4-${version}.tar.gz
+https://ftpmirror.gnu.org/gnu/m4/m4-${version}.tar.gz.sig m4-${version}.tar.gz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg m4-${version}.tar.gz.sig"

--- a/Ports/make/package.sh
+++ b/Ports/make/package.sh
@@ -2,9 +2,9 @@
 port=make
 version=4.3
 useconfigure=true
-files="https://ftp.gnu.org/gnu/make/make-${version}.tar.gz make-${version}.tar.gz
-https://ftp.gnu.org/gnu/make/make-${version}.tar.gz.sig make-${version}.tar.gz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/make/make-${version}.tar.gz make-${version}.tar.gz
+https://ftpmirror.gnu.org/gnu/make/make-${version}.tar.gz.sig make-${version}.tar.gz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg make-${version}.tar.gz.sig"
 configopts="--target=${SERENITY_ARCH}-pc-serenity --with-sysroot=/ --without-guile"

--- a/Ports/ncurses/package.sh
+++ b/Ports/ncurses/package.sh
@@ -3,8 +3,8 @@ port=ncurses
 version=6.2
 useconfigure=true
 configopts="--with-termlib --enable-pc-files --with-pkg-config=/usr/local/lib/pkgconfig --with-pkg-config-libdir=/usr/local/lib/pkgconfig --without-ada --enable-sigwinch"
-files="ftp://ftp.gnu.org/gnu/ncurses/ncurses-${version}.tar.gz ncurses-${version}.tar.gz
-https://ftp.gnu.org/gnu/ncurses/ncurses-${version}.tar.gz.sig ncurses-${version}.tar.gz.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="ftp://ftpmirror.gnu.org/gnu/ncurses/ncurses-${version}.tar.gz ncurses-${version}.tar.gz
+https://ftpmirror.gnu.org/gnu/ncurses/ncurses-${version}.tar.gz.sig ncurses-${version}.tar.gz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg ncurses-${version}.tar.gz.sig"

--- a/Ports/sed/package.sh
+++ b/Ports/sed/package.sh
@@ -2,8 +2,8 @@
 port=sed
 version=4.2.1
 useconfigure="true"
-files="https://ftp.gnu.org/gnu/sed/sed-${version}.tar.bz2 sed-${version}.tar.bz2
-https://ftp.gnu.org/gnu/sed/sed-${version}.tar.bz2.sig sed-${version}.tar.bz2.sig
-https://ftp.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+files="https://ftpmirror.gnu.org/gnu/sed/sed-${version}.tar.bz2 sed-${version}.tar.bz2
+https://ftpmirror.gnu.org/gnu/sed/sed-${version}.tar.bz2.sig sed-${version}.tar.bz2.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts="--keyring ./gnu-keyring.gpg sed-${version}.tar.bz2.sig"

--- a/Ports/termcap/package.sh
+++ b/Ports/termcap/package.sh
@@ -3,4 +3,4 @@ port=termcap
 version=1.3.1
 useconfigure=true
 configopts="--prefix=${SERENITY_BUILD_DIR}/Root/usr"
-files="https://ftp.gnu.org/gnu/termcap/termcap-${version}.tar.gz termcap-${version}.tar.gz"
+files="https://ftpmirror.gnu.org/gnu/termcap/termcap-${version}.tar.gz termcap-${version}.tar.gz"


### PR DESCRIPTION
As per http://www.gnu.org/server/mirror.html :

```
First, for users/downloaders: the address http://ftpmirror.gnu.org/ multiplexes between the mirrors,
trying to choose one that is nearby and up to date.
E.g., http://ftpmirror.gnu.org/emacs/ goes to a mirror's directory of GNU Emacs.
We recommend using this generic ftpmirror.gnu.org address wherever possible in links,
documentation, etc., to reduce load on the main GNU server.

[...]

However, please consider mirroring from another site, again to reduce load on the GNU server.
These sites provide access to all the material on ftp.gnu.org. They update from us nightly (at least),
and you may access them via rsync with the same options as above.
```
