### PR TITLE
Ports: Use HTTPS when accessing ftpmirror.gnu.org

### DIFF
--- a/Ports/ncurses/package.sh
+++ b/Ports/ncurses/package.sh
@@ -3,7 +3,7 @@ port=ncurses
 version=6.2
 useconfigure=true
 configopts="--with-termlib --enable-pc-files --with-pkg-config=/usr/local/lib/pkgconfig --with-pkg-config-libdir=/usr/local/lib/pkgconfig --without-ada --enable-sigwinch"
-files="ftp://ftpmirror.gnu.org/gnu/ncurses/ncurses-${version}.tar.gz ncurses-${version}.tar.gz
+files="https://ftpmirror.gnu.org/gnu/ncurses/ncurses-${version}.tar.gz ncurses-${version}.tar.gz
 https://ftpmirror.gnu.org/gnu/ncurses/ncurses-${version}.tar.gz.sig ncurses-${version}.tar.gz.sig
 https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"


### PR DESCRIPTION
Unlike what the name might suggest `ftpmirror.gnu.org` isn't accessible via FTP.