### PR TITLE
LibGfx+LibWeb: CRC2D.ellipse() and .arc(), plus less recursion in drawing algorithms

### DIFF
--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -141,7 +141,7 @@ void Canvas::draw()
     path.quadratic_bezier_curve_to({ 320, 500 }, { 220, 400 });
     path.line_to({ 300, 440 });
     path.line_to({ 90, 460 });
-    path.quadratic_bezier_curve_to({ 260, 500 }, { 200, 540 });
+    path.elliptical_arc_to({ 260, 540 }, { 40, 30 }, 0, true, false);
     path.close();
     painter.fill_path(path, Color::Yellow, Gfx::Painter::WindingRule::EvenOdd);
 

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1492,7 +1492,7 @@ void Painter::for_each_line_segment_on_bezier_curve(const FloatPoint& control_po
 
 static bool can_approximate_elliptical_arc(const FloatPoint& p1, const FloatPoint& p2, const FloatPoint& center, const FloatPoint radii, float x_axis_rotation, float theta_1, float theta_delta)
 {
-    constexpr static float tolerance = 0.5f;
+    constexpr static float tolerance = 0.3f;
 
     auto half_theta_delta = theta_delta / 2.0f;
 

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1492,7 +1492,7 @@ void Painter::for_each_line_segment_on_bezier_curve(const FloatPoint& control_po
 
 static bool can_approximate_elliptical_arc(const FloatPoint& p1, const FloatPoint& p2, const FloatPoint& center, const FloatPoint radii, float x_axis_rotation, float theta_1, float theta_delta)
 {
-    constexpr static float tolerance = 1;
+    constexpr static float tolerance = 0.5f;
 
     auto half_theta_delta = theta_delta / 2.0f;
 

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -155,6 +155,10 @@ public:
     }
 
     void elliptical_arc_to(const FloatPoint& point, const FloatPoint& radii, double x_axis_rotation, bool large_arc, bool sweep);
+    void arc_to(const FloatPoint& point, float radius, bool large_arc, bool sweep)
+    {
+        elliptical_arc_to(point, { radius, radius }, 0, large_arc, sweep);
+    }
 
     void close();
     void close_all_subpaths();

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -154,11 +154,7 @@ public:
         invalidate_split_lines();
     }
 
-    void elliptical_arc_to(const FloatPoint& point, const FloatPoint& center, const FloatPoint& radii, float x_axis_rotation, float theta_1, float theta_delta)
-    {
-        append_segment<EllipticalArcSegment>(point, center, radii, x_axis_rotation, theta_1, theta_delta);
-        invalidate_split_lines();
-    }
+    void elliptical_arc_to(const FloatPoint& point, const FloatPoint& radii, double x_axis_rotation, bool large_arc, bool sweep);
 
     void close();
     void close_all_subpaths();

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -160,6 +160,20 @@ public:
         elliptical_arc_to(point, { radius, radius }, 0, large_arc, sweep);
     }
 
+    // Note: This does not do any sanity checks!
+    void elliptical_arc_to(const FloatPoint& endpoint, const FloatPoint& center, const FloatPoint& radii, double x_axis_rotation, double theta, double theta_delta)
+    {
+        append_segment<EllipticalArcSegment>(
+            endpoint,
+            center,
+            radii,
+            x_axis_rotation,
+            theta,
+            theta_delta);
+
+        invalidate_split_lines();
+    }
+
     void close();
     void close_all_subpaths();
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -74,6 +74,9 @@ public:
     void move_to(float x, float y);
     void line_to(float x, float y);
     void quadratic_curve_to(float cx, float cy, float x, float y);
+
+    void arc(float x, float y, float radius, float start_angle, float end_angle, bool counter_clockwise);
+    void ellipse(float x, float y, float radius_x, float radius_y, float rotation, float start_angle, float end_angle, bool counter_clockwise);
     void rect(float x, float y, float width, float height);
     void stroke();
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -15,6 +15,9 @@ interface CanvasRenderingContext2D {
     undefined moveTo(double x, double y);
     undefined lineTo(double x, double y);
     undefined quadraticCurveTo(double cpx, double cpy, double x, double y);
+
+    undefined arc(double x, double y, double radius, double startAngle, double endAngle, optional boolean counterclockwise = false);
+    undefined ellipse(double x, double y, double radiusX, double radiusY, double rotation, double startAngle, double endAngle, optional boolean counterclockwise = false);
     undefined rect(double x, double y, double width, double height);
 
     undefined drawImage(HTMLImageElement image, double dx, double dy);

--- a/Userland/Tests/LibM/test-math.cpp
+++ b/Userland/Tests/LibM/test-math.cpp
@@ -29,6 +29,15 @@
 #include <float.h>
 #include <math.h>
 
+TEST_CASE(atan2)
+{
+    EXPECT_APPROXIMATE(atan2(-1, -0.0e0), -M_PI_2);
+    EXPECT_APPROXIMATE(atan2(-0.0e0, -1), -M_PI);
+    EXPECT_APPROXIMATE(atan2(0.0e0, -1), M_PI);
+    EXPECT_APPROXIMATE(atan2(-0.0e0, 1), -0.0e0);
+    EXPECT_APPROXIMATE(atan2(0.0e0, 1), 0.0e0);
+}
+
 TEST_CASE(trig)
 {
     EXPECT_APPROXIMATE(sin(1234), 0.601927);


### PR DESCRIPTION
Here's how MDN's example is supposed to look:
![shot-2021-04-15_18-50-21](https://user-images.githubusercontent.com/14001776/114885066-8bb2f980-9e1b-11eb-9bcc-c3f5206fd0b0.jpg)

and how it looks:
![shot-2021-04-15_18-50-38](https://user-images.githubusercontent.com/14001776/114885082-8f468080-9e1b-11eb-9c17-0b3fbe876ebf.jpg)

As is obvious, I failed to make it work to-spec, but hey, it's a start.

Continuing #6330: 
![shot-2021-04-15_18-54-34](https://user-images.githubusercontent.com/14001776/114885577-0714ab00-9e1c-11eb-8ead-fbe9aef41467.jpg)
(it's far more jittery than it looks)


cc @IdanHo, @mattco98.
