### PR TITLE
WIP: UserspaceEmulator: Add a callgrind-like CallTracer

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/CMakeLists.txt
+++ b/Userland/DevTools/UserspaceEmulator/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    CallTracer.cpp
     Emulator.cpp
     Emulator_syscalls.cpp
     MallocTracer.cpp

--- a/Userland/DevTools/UserspaceEmulator/CallTracer.cpp
+++ b/Userland/DevTools/UserspaceEmulator/CallTracer.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, Tobias Christiansen <tobi@tobyase.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CallTracer.h"
+#include "Emulator.h"
+#include "Report.h"
+#include <AK/QuickSort.h>
+#include <LibDebug/DebugInfo.h>
+#include <unistd.h>
+
+namespace UserspaceEmulator {
+
+CallTracer::CallTracer(Emulator& emulator)
+    : m_emulator(emulator)
+{
+}
+
+void CallTracer::prepare_call_data()
+{
+    if (m_has_been_sorted)
+        warn("The call data should only be prepared once!");
+
+    m_has_been_sorted = true;
+
+    for (auto& address : m_calls.keys()) {
+        auto& call = m_calls.find(address)->value;
+        m_sorted_calls.append(call);
+    }
+
+    quick_sort(m_sorted_calls, [](auto& a, auto& b) {
+        return a.total_count > b.total_count;
+    });
+}
+
+void CallTracer::dump_calls()
+{
+    if (!m_has_been_sorted)
+        prepare_call_data();
+
+    reportln("\n=={}==  \033[33;1mCalls\033[0m", getpid());
+
+    for (auto& entry : m_sorted_calls) {
+        // TODO: Symbolicate
+        reportln("=={}==  {:5} {:p}", getpid(), entry.total_count, entry.called_address);
+    }
+}
+
+void CallTracer::register_call(FlatPtr callee, FlatPtr caller)
+{
+    if (!m_calls.contains(callee))
+        m_calls.set(callee, { callee, 0, {} });
+
+    auto& call = m_calls.find(callee)->value;
+    call.total_count++;
+
+    if (!call.calls_from.contains(caller))
+        call.calls_from.set(caller, 0);
+
+    (call.calls_from.find(caller)->value)++;
+}
+
+void CallTracer::to_json(JsonObjectSerializer<StringBuilder>& serializer)
+{
+    if (!m_has_been_sorted)
+        prepare_call_data();
+
+    auto array = serializer.add_array("calls");
+    for (auto& call : m_sorted_calls) {
+        auto call_object = array.add_object();
+        call_object.add("address", call.called_address);
+        call_object.add("total_count", call.total_count);
+        auto call_from_array = call_object.add_array("calls_to");
+        for (auto& entry : call.calls_from.keys()) {
+            auto& value = call.calls_from.find(entry)->value;
+            auto call_entry_object = call_from_array.add_object();
+            call_entry_object.add("address", entry);
+            call_entry_object.add("count", value);
+            call_entry_object.finish();
+        }
+        call_from_array.finish();
+        call_object.finish();
+    }
+    array.finish();
+}
+
+}

--- a/Userland/DevTools/UserspaceEmulator/CallTracer.h
+++ b/Userland/DevTools/UserspaceEmulator/CallTracer.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, Tobias Christiansen <tobi@tobyase.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/JsonObjectSerializer.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+
+namespace UserspaceEmulator {
+
+class Emulator;
+
+class CallTracer {
+public:
+    explicit CallTracer(Emulator&);
+
+    void register_call(FlatPtr callee, FlatPtr caller);
+
+    void dump_calls();
+
+    void to_json(JsonObjectSerializer<StringBuilder>& serializer);
+
+private:
+    Emulator& m_emulator;
+
+    struct Call {
+        FlatPtr called_address;
+        size_t total_count;
+        HashMap<FlatPtr, size_t> calls_from;
+    };
+
+    HashMap<FlatPtr, Call> m_calls {};
+
+    bool m_has_been_sorted { false };
+
+    void prepare_call_data();
+
+    Vector<Call> m_sorted_calls {};
+};
+}

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -1180,6 +1180,7 @@ void SoftCPU::CALL_RM32(const X86::Instruction& insn)
     push32(shadow_wrap_as_initialized(eip()));
     auto address = insn.modrm().read32(*this, insn);
     warn_if_uninitialized(address, "call rm32");
+    m_emulator.trace_call_if_needed(address.value());
     set_eip(address.value());
 }
 
@@ -1190,7 +1191,9 @@ void SoftCPU::CALL_imm16_imm32(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::CALL_imm32(const X86::Instruction& insn)
 {
     push32(shadow_wrap_as_initialized(eip()));
-    set_eip(eip() + (i32)insn.imm32());
+    auto address = eip() + (i32)insn.imm32();
+    m_emulator.trace_call_if_needed(address);
+    set_eip(address);
 }
 
 void SoftCPU::CBW(const X86::Instruction&)

--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -35,6 +35,7 @@
 #include <string.h>
 
 bool g_report_to_debug = false;
+bool g_call_tracing = false;
 
 int main(int argc, char** argv, char** env)
 {
@@ -42,6 +43,7 @@ int main(int argc, char** argv, char** env)
 
     Core::ArgsParser parser;
     parser.add_option(g_report_to_debug, "Write reports to the debug log", "report-to-debug", 0);
+    parser.add_option(g_call_tracing, "Trace all call-instructions", "trace-calls", 'c');
     parser.add_positional_argument(command, "Command to emulate", "command");
     parser.parse(argc, argv);
 


### PR DESCRIPTION
I wanted to add a utility to the UserspaceEmulator that somehow mimics what callgrind does.
What I think it should do:
- Show you the hottest/coldest functions in the program
- Show how many calls to these functions there were
- Show who called who and how often

It would be cool to have a tool like KCacheGrind in the future but let's start slow ;)

You enable the call-tracer by passing `-c` to the UserspaceEmulator.
I hooked into the call instructions and kept track who called who. There for sure are a lot of optimizations/edge cases but for now this approach works somewhat.