### PR TITLE
Browser+LibWeb+WebContent: Changes for cookie safety

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -36,6 +36,8 @@ namespace AK {
 template<typename T>
 class alignas(T) [[nodiscard]] Optional {
 public:
+    using ValueType = T;
+
     ALWAYS_INLINE Optional() = default;
 
     ALWAYS_INLINE Optional(const T& value)

--- a/Base/res/html/misc/cookie.html
+++ b/Base/res/html/misc/cookie.html
@@ -14,6 +14,8 @@
     <label for=invalid3>The cookie expired in the past</label>
     <br /><input id=invalid4 type=button onclick="setCookie(this.value)" value="cookie7=value7; expires=Mon, 23 Jan 1989 08:10:36 GMT" />
     <label for=invalid4>The cookie expired in the past</label>
+    <br /><input id=invalid5 type=button onclick="setTooLargeCookie()" value="cookie10=[more than 4096 chars]" />
+    <label for=invalid5>The cookie is too large</label>
     <br />
 
     <h3>Unretrievable cookies (the browser should accept these but not display them):</h3>
@@ -29,6 +31,11 @@
         function setCookie(cookie) {
             document.cookie = cookie;
             document.getElementById('cookies').innerHTML = document.cookie;
+        }
+
+        function setTooLargeCookie() {
+            const cookie = 'name=' + 'x'.repeat(4 << 10);
+            setCookie(cookie);
         }
 
         document.getElementById('cookies').innerHTML = document.cookie;

--- a/Userland/Applications/Browser/CookieJar.h
+++ b/Userland/Applications/Browser/CookieJar.h
@@ -47,7 +47,7 @@ struct CookieStorageKey {
 class CookieJar {
 public:
     String get_cookie(const URL& url, Web::Cookie::Source source);
-    void set_cookie(const URL& url, const String& cookie, Web::Cookie::Source source);
+    void set_cookie(const URL& url, const Web::Cookie::ParsedCookie& parsed_cookie, Web::Cookie::Source source);
     void dump_cookies() const;
 
 private:
@@ -56,7 +56,7 @@ private:
     static bool path_matches(const String& request_path, const String& cookie_path);
     static String default_path(const URL& url);
 
-    void store_cookie(Web::Cookie::ParsedCookie& parsed_cookie, const URL& url, String canonicalized_domain, Web::Cookie::Source source);
+    void store_cookie(const Web::Cookie::ParsedCookie& parsed_cookie, const URL& url, String canonicalized_domain, Web::Cookie::Source source);
     Vector<Web::Cookie::Cookie*> get_matching_cookies(const URL& url, const String& canonicalized_domain, Web::Cookie::Source source);
     void purge_expired_cookies();
 

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -72,7 +72,7 @@ public:
     Function<void(Tab&)> on_tab_close_request;
     Function<void(const Gfx::Bitmap&)> on_favicon_change;
     Function<String(const URL& url, Web::Cookie::Source source)> on_get_cookie;
-    Function<void(const URL& url, const String& cookie, Web::Cookie::Source source)> on_set_cookie;
+    Function<void(const URL& url, const Web::Cookie::ParsedCookie& cookie, Web::Cookie::Source source)> on_set_cookie;
     Function<void()> on_dump_cookies;
 
     const String& title() const { return m_title; }

--- a/Userland/Libraries/LibCore/DateTime.h
+++ b/Userland/Libraries/LibCore/DateTime.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <LibIPC/Forward.h>
 #include <time.h>
 
 namespace Core {
@@ -68,5 +69,12 @@ private:
     unsigned m_minute { 0 };
     unsigned m_second { 0 };
 };
+
+}
+
+namespace IPC {
+
+bool encode(IPC::Encoder&, const Core::DateTime&);
+bool decode(IPC::Decoder&, Core::DateTime&);
 
 }

--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -27,6 +27,7 @@
 #include <AK/MemoryStream.h>
 #include <AK/URL.h>
 #include <LibCore/AnonymousBuffer.h>
+#include <LibCore/DateTime.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Dictionary.h>
 #include <LibIPC/File.h>
@@ -203,6 +204,16 @@ bool decode(Decoder& decoder, Core::AnonymousBuffer& buffer)
 
     buffer = Core::AnonymousBuffer::create_from_anon_fd(anon_file.take_fd(), size);
     return buffer.is_valid();
+}
+
+bool decode(Decoder& decoder, Core::DateTime& datetime)
+{
+    i64 timestamp = -1;
+    if (!decoder.decode(timestamp))
+        return false;
+
+    datetime = Core::DateTime::from_timestamp(static_cast<time_t>(timestamp));
+    return true;
 }
 
 }

--- a/Userland/Libraries/LibIPC/Encoder.cpp
+++ b/Userland/Libraries/LibIPC/Encoder.cpp
@@ -28,6 +28,7 @@
 #include <AK/String.h>
 #include <AK/URL.h>
 #include <LibCore/AnonymousBuffer.h>
+#include <LibCore/DateTime.h>
 #include <LibIPC/Dictionary.h>
 #include <LibIPC/Encoder.h>
 #include <LibIPC/File.h>
@@ -180,4 +181,11 @@ bool encode(Encoder& encoder, const Core::AnonymousBuffer& buffer)
     }
     return true;
 }
+
+bool encode(Encoder& encoder, const Core::DateTime& datetime)
+{
+    encoder << static_cast<i64>(datetime.timestamp());
+    return true;
+}
+
 }

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -30,6 +30,8 @@
 
 namespace Web::Cookie {
 
+static constexpr size_t s_max_cookie_size = 4096;
+
 static void parse_attributes(ParsedCookie& parsed_cookie, StringView unparsed_attributes);
 static void process_attribute(ParsedCookie& parsed_cookie, StringView attribute_name, StringView attribute_value);
 static void on_expires_attribute(ParsedCookie& parsed_cookie, StringView attribute_value);
@@ -43,6 +45,10 @@ static Optional<Core::DateTime> parse_date_time(StringView date_string);
 Optional<ParsedCookie> parse_cookie(const String& cookie_string)
 {
     // https://tools.ietf.org/html/rfc6265#section-5.2
+
+    if (cookie_string.length() > s_max_cookie_size)
+        return {};
+
     StringView name_value_pair;
     StringView unparsed_attributes;
 

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -25,7 +25,10 @@
  */
 
 #include "ParsedCookie.h"
+#include <AK/StdLibExtras.h>
 #include <AK/Vector.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 #include <ctype.h>
 
 namespace Web::Cookie {
@@ -350,4 +353,40 @@ Optional<Core::DateTime> parse_date_time(StringView date_string)
     return Core::DateTime::create(year, month, day_of_month, hour, minute, second);
 }
 
+}
+
+bool IPC::encode(IPC::Encoder& encoder, const Web::Cookie::ParsedCookie& cookie)
+{
+    encoder << cookie.name;
+    encoder << cookie.value;
+    encoder << cookie.expiry_time_from_expires_attribute;
+    encoder << cookie.expiry_time_from_max_age_attribute;
+    encoder << cookie.domain;
+    encoder << cookie.path;
+    encoder << cookie.secure_attribute_present;
+    encoder << cookie.http_only_attribute_present;
+
+    return true;
+}
+
+bool IPC::decode(IPC::Decoder& decoder, Web::Cookie::ParsedCookie& cookie)
+{
+    if (!decoder.decode(cookie.name))
+        return false;
+    if (!decoder.decode(cookie.value))
+        return false;
+    if (!decoder.decode(cookie.expiry_time_from_expires_attribute))
+        return false;
+    if (!decoder.decode(cookie.expiry_time_from_max_age_attribute))
+        return false;
+    if (!decoder.decode(cookie.domain))
+        return false;
+    if (!decoder.decode(cookie.path))
+        return false;
+    if (!decoder.decode(cookie.secure_attribute_present))
+        return false;
+    if (!decoder.decode(cookie.http_only_attribute_present))
+        return false;
+
+    return true;
 }

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
@@ -29,6 +29,7 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <LibCore/DateTime.h>
+#include <LibIPC/Forward.h>
 
 namespace Web::Cookie {
 
@@ -44,5 +45,12 @@ struct ParsedCookie {
 };
 
 Optional<ParsedCookie> parse_cookie(const String& cookie_string);
+
+}
+
+namespace IPC {
+
+bool encode(IPC::Encoder&, const Web::Cookie::ParsedCookie&);
+bool decode(IPC::Decoder&, Web::Cookie::ParsedCookie&);
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -34,6 +34,7 @@
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/CSS/StyleResolver.h>
+#include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/DOM/Comment.h>
 #include <LibWeb/DOM/DOMException.h>
 #include <LibWeb/DOM/Document.h>
@@ -828,10 +829,14 @@ String Document::cookie(Cookie::Source source)
     return {};
 }
 
-void Document::set_cookie(String cookie, Cookie::Source source)
+void Document::set_cookie(String cookie_string, Cookie::Source source)
 {
+    auto cookie = Cookie::parse_cookie(cookie_string);
+    if (!cookie.has_value())
+        return;
+
     if (auto* page = this->page())
-        page->client().page_did_set_cookie(m_url, cookie, source);
+        page->client().page_did_set_cookie(m_url, cookie.value(), source);
 }
 
 }

--- a/Userland/Libraries/LibWeb/InProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/InProcessWebView.cpp
@@ -440,7 +440,7 @@ String InProcessWebView::page_did_request_cookie(const URL& url, Cookie::Source 
     return {};
 }
 
-void InProcessWebView::page_did_set_cookie(const URL& url, const String& cookie, Cookie::Source source)
+void InProcessWebView::page_did_set_cookie(const URL& url, const Cookie::ParsedCookie& cookie, Cookie::Source source)
 {
     if (on_set_cookie)
         on_set_cookie(url, cookie, source);

--- a/Userland/Libraries/LibWeb/InProcessWebView.h
+++ b/Userland/Libraries/LibWeb/InProcessWebView.h
@@ -112,7 +112,7 @@ private:
     virtual bool page_did_request_confirm(const String&) override;
     virtual String page_did_request_prompt(const String&, const String&) override;
     virtual String page_did_request_cookie(const URL&, Cookie::Source) override;
-    virtual void page_did_set_cookie(const URL&, const String&, Cookie::Source) override;
+    virtual void page_did_set_cookie(const URL&, const Cookie::ParsedCookie&, Cookie::Source) override;
 
     void layout_and_sync_size();
 

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -372,7 +372,7 @@ String OutOfProcessWebView::notify_server_did_request_cookie(Badge<WebContentCli
     return {};
 }
 
-void OutOfProcessWebView::notify_server_did_set_cookie(Badge<WebContentClient>, const URL& url, const String& cookie, Cookie::Source source)
+void OutOfProcessWebView::notify_server_did_set_cookie(Badge<WebContentClient>, const URL& url, const Cookie::ParsedCookie& cookie, Cookie::Source source)
 {
     if (on_set_cookie)
         on_set_cookie(url, cookie, source);

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.h
@@ -80,7 +80,7 @@ public:
     void notify_server_did_js_console_output(const String& method, const String& line);
     void notify_server_did_change_favicon(const Gfx::Bitmap& favicon);
     String notify_server_did_request_cookie(Badge<WebContentClient>, const URL& url, Cookie::Source source);
-    void notify_server_did_set_cookie(Badge<WebContentClient>, const URL& url, const String& cookie, Cookie::Source source);
+    void notify_server_did_set_cookie(Badge<WebContentClient>, const URL& url, const Cookie::ParsedCookie& cookie, Cookie::Source source);
 
 private:
     OutOfProcessWebView();

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -112,7 +112,7 @@ public:
     virtual bool page_did_request_confirm(const String&) { return false; }
     virtual String page_did_request_prompt(const String&, const String&) { return {}; }
     virtual String page_did_request_cookie(const URL&, Cookie::Source) { return {}; }
-    virtual void page_did_set_cookie(const URL&, const String&, Cookie::Source) { }
+    virtual void page_did_set_cookie(const URL&, const Cookie::ParsedCookie&, Cookie::Source) { }
 
 protected:
     virtual ~PageClient() = default;

--- a/Userland/Libraries/LibWeb/WebContentClient.cpp
+++ b/Userland/Libraries/LibWeb/WebContentClient.cpp
@@ -27,6 +27,7 @@
 #include "WebContentClient.h"
 #include "OutOfProcessWebView.h"
 #include <AK/Debug.h>
+#include <LibWeb/Cookie/ParsedCookie.h>
 
 namespace Web {
 

--- a/Userland/Libraries/LibWeb/WebContentClient.h
+++ b/Userland/Libraries/LibWeb/WebContentClient.h
@@ -28,6 +28,7 @@
 
 #include <AK/HashMap.h>
 #include <LibIPC/ServerConnection.h>
+#include <LibWeb/Cookie/ParsedCookie.h>
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebContentServerEndpoint.h>
 

--- a/Userland/Libraries/LibWeb/WebViewHooks.h
+++ b/Userland/Libraries/LibWeb/WebViewHooks.h
@@ -49,7 +49,7 @@ public:
     Function<void(const URL&, const String&)> on_get_source;
     Function<void(const String& method, const String& line)> on_js_console_output;
     Function<String(const URL& url, Cookie::Source source)> on_get_cookie;
-    Function<void(const URL& url, const String& cookie, Cookie::Source source)> on_set_cookie;
+    Function<void(const URL& url, const Cookie::ParsedCookie& cookie, Cookie::Source source)> on_set_cookie;
 };
 
 }

--- a/Userland/Services/WebContent/ClientConnection.cpp
+++ b/Userland/Services/WebContent/ClientConnection.cpp
@@ -34,6 +34,7 @@
 #include <LibJS/Parser.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/Layout/InitialContainingBlockBox.h>

--- a/Userland/Services/WebContent/ClientConnection.h
+++ b/Userland/Services/WebContent/ClientConnection.h
@@ -29,6 +29,7 @@
 #include <AK/HashMap.h>
 #include <LibIPC/ClientConnection.h>
 #include <LibJS/Forward.h>
+#include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/Forward.h>
 #include <WebContent/Forward.h>
 #include <WebContent/WebContentClientEndpoint.h>

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -28,6 +28,7 @@
 #include "ClientConnection.h"
 #include <LibGfx/Painter.h>
 #include <LibGfx/SystemTheme.h>
+#include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/Layout/InitialContainingBlockBox.h>
 #include <LibWeb/Page/Frame.h>
 #include <WebContent/WebContentClientEndpoint.h>
@@ -213,7 +214,7 @@ String PageHost::page_did_request_cookie(const URL& url, Web::Cookie::Source sou
     return m_client.send_sync<Messages::WebContentClient::DidRequestCookie>(url, static_cast<u8>(source))->cookie();
 }
 
-void PageHost::page_did_set_cookie(const URL& url, const String& cookie, Web::Cookie::Source source)
+void PageHost::page_did_set_cookie(const URL& url, const Web::Cookie::ParsedCookie& cookie, Web::Cookie::Source source)
 {
     m_client.post_message(Messages::WebContentClient::DidSetCookie(url, cookie, static_cast<u8>(source)));
 }

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -80,7 +80,7 @@ private:
     virtual void page_did_change_favicon(const Gfx::Bitmap&) override;
     virtual void page_did_request_image_context_menu(const Gfx::IntPoint&, const URL&, const String& target, unsigned modifiers, const Gfx::Bitmap*) override;
     virtual String page_did_request_cookie(const URL&, Web::Cookie::Source) override;
-    virtual void page_did_set_cookie(const URL&, const String&, Web::Cookie::Source) override;
+    virtual void page_did_set_cookie(const URL&, const Web::Cookie::ParsedCookie&, Web::Cookie::Source) override;
 
     explicit PageHost(ClientConnection&);
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -26,5 +26,5 @@ endpoint WebContentClient = 90
     DidJSConsoleOutput(String method, String line) =|
     DidChangeFavicon(Gfx::ShareableBitmap favicon) =|
     DidRequestCookie(URL url, u8 source) => (String cookie)
-    DidSetCookie(URL url, String cookie, u8 source) =|
+    DidSetCookie(URL url, Web::Cookie::ParsedCookie cookie, u8 source) =|
 }


### PR DESCRIPTION
Two changes here to protect the browser from bad cookies:
1. Limit the max size of cookies to 4KiB (a recommendation from the spec).
2. Parse cookies in the OOP tab, and send the parsed result over IPC to the main process for storage.