### PR TITLE
Kernel+LibDebug+HackStudio: Implement variable watchpoints

### DIFF
--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -362,14 +362,15 @@ void debug_handler(TrapFrame* trap)
         PANIC("Debug exception in ring 0");
     }
     constexpr u8 REASON_SINGLESTEP = 14;
-    bool is_reason_singlestep = (read_dr6() & (1 << REASON_SINGLESTEP));
-    if (!is_reason_singlestep)
+    auto debug_status = read_dr6();
+    auto should_trap_mask = (1 << REASON_SINGLESTEP) | 0b1111;
+    if ((debug_status & should_trap_mask) == 0)
         return;
-
     if (auto tracer = process.tracer()) {
         tracer->set_regs(regs);
     }
     current_thread->send_urgent_signal_to_self(SIGTRAP);
+    write_dr6(debug_status & ~(should_trap_mask));
 }
 
 EH_ENTRY_NO_CODE(3, breakpoint);

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -854,18 +854,69 @@ FlatPtr read_cr4()
     return cr4;
 }
 
-FlatPtr read_dr6()
+void read_debug_registers_into(DebugRegisterState& state)
 {
-    FlatPtr dr6;
-#if ARCH(I386)
-    asm("mov %%dr6, %%eax"
-        : "=a"(dr6));
-#else
-    asm("mov %%dr6, %%rax"
-        : "=a"(dr6));
-#endif
-    return dr6;
+    state.dr0 = read_dr0();
+    state.dr1 = read_dr1();
+    state.dr2 = read_dr2();
+    state.dr3 = read_dr3();
+    state.dr6 = read_dr6();
+    state.dr7 = read_dr7();
 }
+
+void write_debug_registers_from(const DebugRegisterState& state)
+{
+    write_dr0(state.dr0);
+    write_dr1(state.dr1);
+    write_dr2(state.dr2);
+    write_dr3(state.dr3);
+    write_dr6(state.dr6);
+    write_dr7(state.dr7);
+}
+
+void clear_debug_registers()
+{
+    write_dr0(0);
+    write_dr1(0);
+    write_dr2(0);
+    write_dr3(0);
+    write_dr7(1 << 10); // Bit 10 is reserved and must be set to 1.
+}
+
+#if ARCH(I386)
+#    define DEFINE_DEBUG_REGISTER(index)                         \
+        FlatPtr read_dr##index()                                 \
+        {                                                        \
+            FlatPtr value;                                       \
+            asm("mov %%dr" #index ", %%eax"                      \
+                : "=a"(value));                                  \
+            return value;                                        \
+        }                                                        \
+        void write_dr##index(FlatPtr value)                      \
+        {                                                        \
+            asm volatile("mov %%eax, %%dr" #index ::"a"(value)); \
+        }
+#else
+#    define DEFINE_DEBUG_REGISTER(index)                         \
+        FlatPtr read_dr##index()                                 \
+        {                                                        \
+            FlatPtr value;                                       \
+            asm("mov %%dr" #index ", %%rax"                      \
+                : "=a"(value));                                  \
+            return value;                                        \
+        }                                                        \
+        void write_dr##index(FlatPtr value)                      \
+        {                                                        \
+            asm volatile("mov %%rax, %%dr" #index ::"a"(value)); \
+        }
+#endif
+
+DEFINE_DEBUG_REGISTER(0);
+DEFINE_DEBUG_REGISTER(1);
+DEFINE_DEBUG_REGISTER(2);
+DEFINE_DEBUG_REGISTER(3);
+DEFINE_DEBUG_REGISTER(6);
+DEFINE_DEBUG_REGISTER(7);
 
 #define XCR_XFEATURE_ENABLED_MASK 0
 
@@ -1390,6 +1441,15 @@ extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
     set_fs(to_tss.fs);
     set_gs(to_tss.gs);
 
+    if (from_thread->process().is_traced())
+        read_debug_registers_into(from_thread->debug_register_state());
+
+    if (to_thread->process().is_traced()) {
+        write_debug_registers_from(to_thread->debug_register_state());
+    } else {
+        clear_debug_registers();
+    }
+
     auto& processor = Processor::current();
     auto& tls_descriptor = processor.get_gdt_entry(GDT_SELECTOR_TLS);
     tls_descriptor.set_base(to_thread->thread_specific_data());
@@ -1403,7 +1463,6 @@ extern "C" void enter_thread_context(Thread* from_thread, Thread* to_thread)
 
     asm volatile("fxrstor %0" ::"m"(to_thread->fpu_state()));
 
-    // TODO: debug registers
     // TODO: ioperm?
 }
 

--- a/Kernel/Arch/x86/CPU.h
+++ b/Kernel/Arch/x86/CPU.h
@@ -430,6 +430,15 @@ struct [[gnu::packed]] RegisterState {
     FlatPtr userspace_ss;
 };
 
+struct [[gnu::packed]] DebugRegisterState {
+    FlatPtr dr0;
+    FlatPtr dr1;
+    FlatPtr dr2;
+    FlatPtr dr3;
+    FlatPtr dr6;
+    FlatPtr dr7;
+};
+
 #if ARCH(I386)
 #    define REGISTER_STATE_SIZE (19 * 4)
 #else
@@ -476,7 +485,21 @@ void write_cr3(FlatPtr);
 void write_cr4(FlatPtr);
 void write_xcr0(u64);
 
+void read_debug_registers_into(DebugRegisterState&);
+void write_debug_registers_from(const DebugRegisterState&);
+void clear_debug_registers();
+FlatPtr read_dr0();
+void write_dr0(FlatPtr);
+FlatPtr read_dr1();
+void write_dr1(FlatPtr);
+FlatPtr read_dr2();
+void write_dr2(FlatPtr);
+FlatPtr read_dr3();
+void write_dr3(FlatPtr);
 FlatPtr read_dr6();
+void write_dr6(FlatPtr);
+FlatPtr read_dr7();
+void write_dr7(FlatPtr);
 
 static inline bool is_kernel_mode()
 {

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -972,6 +972,9 @@ public:
     u32 signal_mask() const;
     void clear_signals();
 
+    KResultOr<u32> peek_debug_register(u32 register_index);
+    KResult poke_debug_register(u32 register_index, u32 data);
+
     void set_dump_backtrace_on_finalization() { m_dump_backtrace_on_finalization = true; }
 
     DispatchSignalResult dispatch_one_pending_signal();

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -763,6 +763,9 @@ public:
     RegisterState& get_register_dump_from_stack();
     const RegisterState& get_register_dump_from_stack() const { return const_cast<Thread*>(this)->get_register_dump_from_stack(); }
 
+    DebugRegisterState& debug_register_state() { return m_debug_register_state; }
+    const DebugRegisterState& debug_register_state() const { return m_debug_register_state; }
+
     TSS& tss() { return m_tss; }
     const TSS& tss() const { return m_tss; }
     State state() const { return m_state; }
@@ -1200,6 +1203,7 @@ private:
     NonnullRefPtr<Process> m_process;
     ThreadID m_tid { -1 };
     TSS m_tss {};
+    DebugRegisterState m_debug_register_state {};
     TrapFrame* m_current_trap { nullptr };
     u32 m_saved_critical { 1 };
     IntrusiveListNode m_ready_queue_node;

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -690,6 +690,8 @@ struct rtentry {
 #define PT_PEEK 7
 #define PT_POKE 8
 #define PT_SETREGS 9
+#define PT_POKEDEBUG 10
+#define PT_PEEKDEBUG 11
 
 // Used in struct dirent
 enum {

--- a/Meta/CMake/all_the_debug_macros.cmake
+++ b/Meta/CMake/all_the_debug_macros.cmake
@@ -186,5 +186,11 @@ set(LANGUAGE_SERVER_DEBUG ON)
 # set(LOG_DEBUG ON)
 # False positive: UHCI_USBCMD_SOFTWARE_DEBUG is a flag, but for a bitset, not a feature.
 # set(UHCI_USBCMD_SOFTWARE_DEBUG ON)
+# False positive: DEBUG_CONTROL_REGISTER represents a specification constant.
+# set(DEBUG_CONTROL_REGISTER ON)
+# False positive: DEBUG_STATUS_REGISTER represents a specification constant.
+# set(DEBUG_STATUS_REGISTER ON)
+# False positive: DEFINE_DEBUG_REGISTER is used to define read/write methods for debug registers.
+# set(DEFINE_DEBUG_REGISTER ON)
 # Clogs up build: The WrapperGenerator stuff is run at compile time.
 # set(WRAPPER_GENERATOR_DEBUG ON)

--- a/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.h
+++ b/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.h
@@ -56,6 +56,8 @@ private:
 
     NonnullRefPtr<GUI::Widget> build_variables_tab();
     NonnullRefPtr<GUI::Widget> build_registers_tab();
+    bool does_variable_support_writing(const Debug::DebugInfo::VariableInfo*);
+    RefPtr<GUI::Menu> get_context_menu_for_variable(const GUI::ModelIndex&);
 
     RefPtr<GUI::TreeView> m_variables_view;
     RefPtr<GUI::TableView> m_registers_view;

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -53,7 +53,7 @@ class HackStudioWidget : public GUI::Widget {
 
 public:
     virtual ~HackStudioWidget() override;
-    void open_file(const String& filename);
+    bool open_file(const String& filename);
 
     void update_actions();
     Project& project();
@@ -106,7 +106,7 @@ private:
     NonnullRefPtr<GUI::Action> create_set_autocomplete_mode_action();
 
     void add_new_editor(GUI::Widget& parent);
-    NonnullRefPtr<EditorWrapper> get_editor_of_file(const String& file_name);
+    RefPtr<EditorWrapper> get_editor_of_file(const String& file_name);
     String get_project_executable_path() const;
 
     void on_action_tab_change();

--- a/Userland/Libraries/LibC/sys/ptrace.cpp
+++ b/Userland/Libraries/LibC/sys/ptrace.cpp
@@ -40,7 +40,8 @@ int ptrace(int request, pid_t tid, void* addr, int data)
 
     u32 out_data;
     Syscall::SC_ptrace_peek_params peek_params;
-    if (request == PT_PEEK) {
+    auto is_peek_type = request == PT_PEEK || request == PT_PEEKDEBUG;
+    if (is_peek_type) {
         peek_params.address = reinterpret_cast<u32*>(addr);
         peek_params.out_data = &out_data;
         addr = &peek_params;
@@ -54,7 +55,7 @@ int ptrace(int request, pid_t tid, void* addr, int data)
     };
     int rc = syscall(SC_ptrace, &params);
 
-    if (request == PT_PEEK) {
+    if (is_peek_type) {
         if (rc < 0) {
             errno = -rc;
             return -1;

--- a/Userland/Libraries/LibC/sys/ptrace.h
+++ b/Userland/Libraries/LibC/sys/ptrace.h
@@ -42,6 +42,9 @@ __BEGIN_DECLS
 #define PT_POKEDEBUG 10
 #define PT_PEEKDEBUG 11
 
+#define DEBUG_STATUS_REGISTER 6
+#define DEBUG_CONTROL_REGISTER 7
+
 // FIXME: PID/TID ISSUE
 // Affects the entirety of LibDebug and Userland/strace.cpp.
 // See also Kernel/Ptrace.cpp

--- a/Userland/Libraries/LibC/sys/ptrace.h
+++ b/Userland/Libraries/LibC/sys/ptrace.h
@@ -39,6 +39,8 @@ __BEGIN_DECLS
 #define PT_PEEK 7
 #define PT_POKE 8
 #define PT_SETREGS 9
+#define PT_POKEDEBUG 10
+#define PT_PEEKDEBUG 11
 
 // FIXME: PID/TID ISSUE
 // Affects the entirety of LibDebug and Userland/strace.cpp.


### PR DESCRIPTION
This PR adds the ability to place a hardware watchpoint on a debugged variable. To do this from HackStudio, just right click on a variable in the variables view and select add watchpoint. Under the hood this will use ptrace to communicate with the kernel to modify the proper x86 debug registers.

This is my first time ever looking at the Kernel in depth, much less modifying it, so I'm definitely open to suggestions there.

![](https://i.imgur.com/FRYVwKn.png)