### PR TITLE
WindowServer: Recalculate window rect when toggling menubar

### DIFF
--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -700,6 +700,7 @@ void Window::ensure_window_menu()
                 item.set_checked(!item.is_checked());
                 m_should_show_menubar = item.is_checked();
                 frame().invalidate();
+                recalculate_rect();
                 Compositor::the().invalidate_occlusions();
                 Compositor::the().invalidate_screen();
                 break;


### PR DESCRIPTION
As [reported](https://discord.com/channels/830522505605283862/830529037251641374/831217260655017997) by @Lubrsi on Discord.