### PR TITLE
HackStudio+TextEditor: Add statusbar with selected text information

### DIFF
--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -52,17 +52,9 @@ EditorWrapper::EditorWrapper()
     m_filename_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
     m_filename_label->set_fixed_height(14);
 
-    m_cursor_label = label_wrapper.add<GUI::Label>("(Cursor)");
-    m_cursor_label->set_text_alignment(Gfx::TextAlignment::CenterRight);
-    m_cursor_label->set_fixed_height(14);
-
     m_editor = add<Editor>();
     m_editor->set_ruler_visible(true);
     m_editor->set_automatic_indentation_enabled(true);
-
-    m_editor->on_cursor_change = [this] {
-        m_cursor_label->set_text(String::formatted("Line: {}, Column: {}", m_editor->cursor().line() + 1, m_editor->cursor().column()));
-    };
 
     m_editor->on_focus = [this] {
         set_current_editor_wrapper(this);

--- a/Userland/DevTools/HackStudio/EditorWrapper.h
+++ b/Userland/DevTools/HackStudio/EditorWrapper.h
@@ -59,7 +59,6 @@ private:
     EditorWrapper();
 
     RefPtr<GUI::Label> m_filename_label;
-    RefPtr<GUI::Label> m_cursor_label;
     RefPtr<Editor> m_editor;
 };
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -125,6 +125,7 @@ private:
     void create_help_menubar(GUI::Menubar&);
     void create_project_tab(GUI::Widget& parent);
     void configure_project_tree_view();
+    void update_statusbar();
 
     void run(TerminalWrapper& wrapper);
     void build(TerminalWrapper& wrapper);
@@ -156,6 +157,7 @@ private:
     RefPtr<GUI::Menu> m_project_tree_view_context_menu;
     RefPtr<GUI::TabWidget> m_action_tab_widget;
     RefPtr<GUI::TabWidget> m_project_tab;
+    RefPtr<GUI::Statusbar> m_statusbar;
     RefPtr<TerminalWrapper> m_terminal_wrapper;
     RefPtr<Locator> m_locator;
     RefPtr<FindInFilesWidget> m_find_in_files_widget;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1235,6 +1235,44 @@ String TextEditor::selected_text() const
     return document().text_in_range(m_selection);
 }
 
+int TextEditor::selected_word_count() const
+{
+    int word_count = 0;
+    bool in_word = false;
+    auto selection = this->selected_text();
+    for (char c : selection) {
+        if (in_word && isspace(c)) {
+            in_word = false;
+            word_count++;
+            continue;
+        }
+        if (!in_word && !isspace(c))
+            in_word = true;
+    }
+    if (in_word)
+        word_count++;
+
+    return word_count;
+}
+
+size_t TextEditor::selected_line_count() const
+{
+    size_t first_line;
+    size_t last_line;
+    auto selection = this->normalized_selection();
+    if (!selection.is_valid()) {
+        first_line = this->cursor().line();
+        last_line = this->cursor().line();
+    } else {
+        first_line = selection.start().line();
+        last_line = selection.end().line();
+    }
+    if (first_line == last_line || selection.start().column() == 0 || selection.start().column() != 0)
+        last_line += 1;
+
+    return last_line - first_line;
+}
+
 void TextEditor::delete_selection()
 {
     auto selection = normalized_selection();

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -135,6 +135,8 @@ public:
     bool write_to_file(const String& path);
     bool has_selection() const { return m_selection.is_valid(); }
     String selected_text() const;
+    int selected_word_count() const;
+    size_t selected_line_count() const;
     void set_selection(const TextRange&);
     void clear_selection();
     bool can_undo() const { return document().can_undo(); }


### PR DESCRIPTION
This removes the cursor label located at the top right of editor
and will implement a statusbar which displays the line
and column position of the cursor. When the user selects (highlights)
text, the statusbar will also show the number of selected lines,
words, and characters.

![2021-04-15_17-49](https://user-images.githubusercontent.com/38510174/114944941-7d161380-9e16-11eb-9299-b3e83a912a05.png)
