### PR TITLE
LibJS: Accept symbol property in ObjectPrototype::hasOwnProperty

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -215,6 +215,8 @@ String JSONObject::serialize_json_object(GlobalObject& global_object, StringifyS
     Vector<String> property_strings;
 
     auto process_property = [&](const PropertyName& key) {
+        if (key.is_symbol())
+            return;
         auto serialized_property_string = serialize_json_property(global_object, state, key, &object);
         if (vm.exception())
             return;

--- a/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -66,10 +66,10 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::has_own_property)
     auto* this_object = vm.this_value(global_object).to_object(global_object);
     if (!this_object)
         return {};
-    auto name = vm.argument(0).to_string(global_object);
+    auto string_or_symbol = StringOrSymbol::from_value(global_object, vm.argument(0));
     if (vm.exception())
         return {};
-    return Value(this_object->has_own_property(name));
+    return Value(this_object->has_own_property(string_or_symbol));
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::to_string)

--- a/Userland/Libraries/LibJS/Tests/builtins/JSON/JSON.stringify.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/JSON/JSON.stringify.js
@@ -43,6 +43,13 @@ describe("correct behavior", () => {
         Object.defineProperty(o, "baz", { value: "qux", enumerable: false });
         expect(JSON.stringify(o)).toBe('{"foo":"bar"}');
     });
+
+    test("ignores symbol properties", () => {
+        let o = { foo: "bar" };
+        let sym = Symbol("baz");
+        o[sym] = "qux";
+        expect(JSON.stringify(o)).toBe('{"foo":"bar"}');
+    });
 });
 
 describe("errors", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Object/Object.prototype.hasOwnProperty.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Object/Object.prototype.hasOwnProperty.js
@@ -10,4 +10,9 @@ test("basic functionality", () => {
     o.undefined = 2;
     expect(o.hasOwnProperty()).toBeTrue();
     expect(o.hasOwnProperty(undefined)).toBeTrue();
+
+    var testSymbol = Symbol("real");
+    o[testSymbol] = 3;
+    expect(o.hasOwnProperty(testSymbol)).toBeTrue();
+    expect(o.hasOwnProperty(Symbol("fake"))).toBeFalse();
 });


### PR DESCRIPTION
This is used by discord.com and allowed by the specification (https://tc39.es/ecma262/#sec-topropertykey)