### PR TITLE
PixelPaint: Add keyboard zoom shortcuts

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -392,6 +392,15 @@ void ImageEditor::scale_centered_on_position(const Gfx::IntPoint& position, floa
         relayout();
 }
 
+void ImageEditor::reset_scale_and_position()
+{
+    if (m_scale != 1.0f)
+        m_scale = 1.0f;
+    
+    m_pan_origin = Gfx::FloatPoint(0, 0);
+    relayout();
+}
+
 void ImageEditor::relayout()
 {
     if (!image())

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -370,15 +370,19 @@ Layer* ImageEditor::layer_at_editor_position(const Gfx::IntPoint& editor_positio
     return nullptr;
 }
 
-void ImageEditor::scale_centered_on_position(const Gfx::IntPoint& position, float scale_delta)
+void ImageEditor::clamped_scale(float scale_delta)
 {
-    auto old_scale = m_scale;
-
     m_scale += scale_delta;
     if (m_scale < 0.1f)
         m_scale = 0.1f;
     if (m_scale > 100.0f)
         m_scale = 100.0f;
+}
+
+void ImageEditor::scale_centered_on_position(const Gfx::IntPoint& position, float scale_delta)
+{
+    auto old_scale = m_scale;
+    clamped_scale(scale_delta);
 
     auto focus_point = Gfx::FloatPoint(
         m_pan_origin.x() - ((float)position.x() - (float)width() / 2.0) / old_scale,
@@ -392,11 +396,19 @@ void ImageEditor::scale_centered_on_position(const Gfx::IntPoint& position, floa
         relayout();
 }
 
+void ImageEditor::scale_by(float scale_delta)
+{
+    if (scale_delta != 0) {
+        clamped_scale(scale_delta);
+        relayout();
+    }
+}
+
 void ImageEditor::reset_scale_and_position()
 {
     if (m_scale != 1.0f)
         m_scale = 1.0f;
-    
+
     m_pan_origin = Gfx::FloatPoint(0, 0);
     relayout();
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -64,6 +64,7 @@ public:
     Layer* layer_at_editor_position(const Gfx::IntPoint&);
 
     void scale_centered_on_position(const Gfx::IntPoint&, float);
+    void reset_scale_and_position();
 
     Color primary_color() const { return m_primary_color; }
     void set_primary_color(Color);

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -65,6 +65,7 @@ public:
 
     void scale_centered_on_position(const Gfx::IntPoint&, float);
     void reset_scale_and_position();
+    void scale_by(float);
 
     Color primary_color() const { return m_primary_color; }
     void set_primary_color(Color);
@@ -107,6 +108,7 @@ private:
     GUI::MouseEvent event_adjusted_for_layer(const GUI::MouseEvent&, const Layer&) const;
     GUI::MouseEvent event_with_pan_and_scale_applied(const GUI::MouseEvent&) const;
 
+    void clamped_scale(float);
     void relayout();
 
     RefPtr<Image> m_image;

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -217,6 +217,14 @@ int main(int argc, char** argv)
         image_editor.redo();
     });
     edit_menu.add_action(redo_action);
+    
+    auto& view_menu = menubar->add_menu("&View");
+    view_menu.add_action(GUI::Action::create(
+        "&Reset Zoom", { Mod_Ctrl, Key_0 }, [&](auto&) {
+            image_editor.reset_scale_and_position();
+            return;
+        },
+        window));
 
     auto& tool_menu = menubar->add_menu("&Tool");
     toolbox.for_each_tool([&](auto& tool) {

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -217,12 +217,23 @@ int main(int argc, char** argv)
         image_editor.redo();
     });
     edit_menu.add_action(redo_action);
-    
+
     auto& view_menu = menubar->add_menu("&View");
+    view_menu.add_action(GUI::Action::create(
+        "Zoom &In", { Mod_Ctrl, Key_Equal }, [&](auto&) {
+            image_editor.scale_by(0.1f);
+        },
+        window));
+
+    view_menu.add_action(GUI::Action::create(
+        "Zoom &Out", { Mod_Ctrl, Key_Minus }, [&](auto&) {
+            image_editor.scale_by(-0.1f);
+        },
+        window));
+
     view_menu.add_action(GUI::Action::create(
         "&Reset Zoom", { Mod_Ctrl, Key_0 }, [&](auto&) {
             image_editor.reset_scale_and_position();
-            return;
         },
         window));
 


### PR DESCRIPTION
Adds the conventional `0`, `-`, `=` keyboard zoom shortcuts and their respective menubar items. 

Fixes #4138