### PR TITLE
Meta+Docs+CI: Require clang-format >= 12

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,9 +38,9 @@ jobs:
       # These aren't:
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
+        sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main"
         sudo apt-get update
-        sudo apt-get install clang-format-11 libstdc++-10-dev libmpfr-dev libmpc-dev ninja-build npm e2fsprogs qemu-utils qemu-system-i386 ccache
+        sudo apt-get install clang-format-12 libstdc++-10-dev libmpfr-dev libmpc-dev ninja-build npm e2fsprogs qemu-utils qemu-system-i386 ccache
     - name: Use GCC 10 instead
       run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
@@ -52,7 +52,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 requests
     - name: Check versions
-      run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-11 --version; prettier --version; python --version; python3 --version; ninja --version; flake8 --version; ccache --version
+      run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-12 --version; prettier --version; python --version; python3 --version; ninja --version; flake8 --version; ccache --version
 
     # === PREPARE FOR BUILDING ===
 
@@ -228,7 +228,6 @@ jobs:
     needs: [build_and_test_serenity, build_and_test_lagom]
     runs-on: ubuntu-20.04
     if: always() && github.repository == 'SerenityOS/serenity' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master'))
-
     steps:
     - uses: actions/checkout@v2
     # Sets environment variable env.WORKFLOW_CONCLUSION to one of [neutral, success, skipped, cancelled, timed_out, action_required, failure]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Nobody is perfect, and sometimes we mess things up. That said, here are some goo
 **Do:**
 
 * Write in idiomatic Serenity C++20, using the `AK` containers in all code.
-* Conform to the project coding style found in [CodingStyle.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Please use `clang-format` (version 11 or later) to automatically format C++ files.
+* Conform to the project coding style found in [CodingStyle.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Please use `clang-format` (version 12 or later) to automatically format C++ files.
 * Choose expressive variable, function and class names. Make it as obvious as possible what the code is doing.
 * Split your changes into separate, atomic commits.
 * Make sure your commits are rebased on the master branch.

--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -2,7 +2,7 @@
 
 For low-level styling (spaces, parentheses, brace placement, etc), all code should follow the format specified in `.clang-format` in the project root.
 
-**Important: Make sure you use `clang-format` version 11 or later!**
+**Important: Make sure you use `clang-format` version 12 or later!**
 
 This document describes the coding style used for C++ code in the Serenity Operating System project. All new code should conform to this style.
 

--- a/Documentation/UsingQtCreator.md
+++ b/Documentation/UsingQtCreator.md
@@ -41,7 +41,7 @@ Qt Creator should be set up correctly now, go ahead and explore the project and 
 
 ## Auto-Formatting
 
-You can use `clang-format` to help you with the [style guide](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Before you proceed, check that you're actually using clang-format version 11, as some OSes still ship clang-format version 9 or 10 by default.
+You can use `clang-format` to help you with the [style guide](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Before you proceed, check that you're actually using clang-format version 12, as some OSes still ship clang-format version 9, 10 or 11 by default.
 
 - In QtCreator, go to "Help > About Plugins…"
 - Find the `Beautifier (experimental)` row (for example, by typing `beau` into the search)

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -26,17 +26,17 @@ fi
 
 if (( ${#files[@]} )); then
     CLANG_FORMAT=false
-    if command -v clang-format-11 >/dev/null 2>&1 ; then
-        CLANG_FORMAT=clang-format-11
+    if command -v clang-format-12 >/dev/null 2>&1 ; then
+        CLANG_FORMAT=clang-format-12
     elif command -v clang-format >/dev/null 2>&1 ; then
         CLANG_FORMAT=clang-format
-        if ! "${CLANG_FORMAT}" --version | grep -qF ' 11.' ; then
-            echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 11."
+        if ! "${CLANG_FORMAT}" --version | grep -qF ' 12.' ; then
+            echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 12."
             echo "It is very likely that the resulting changes are not what you wanted."
         fi
     else
-        echo "clang-format-11 is not available, but C or C++ files need linting! Either skip this script, or install clang-format-11."
-        echo "(If you install a package 'clang-format', please make sure it's version 11.)"
+        echo "clang-format-12 is not available, but C or C++ files need linting! Either skip this script, or install clang-format-12."
+        echo "(If you install a package 'clang-format', please make sure it's version 12.)"
         exit 1
     fi
 


### PR DESCRIPTION
llvm 12 was released within the last 24 hours, so that must mean it's good to use right away, right? :^)

I ran clang-format-12 over all the .h and .cpp in AK, Kernel and Userland, and it didn't come up with any differences, suprisingly.

Scanning through the closed PRs, it seems the only things that are likely to be more of an option now are Concepts? Assuming CLion and QTCreator parse them properly that is. Didn't find any obvious clang-format off comments that should be addressed either.

cc @alimpfard @linusg 