### PR TITLE
LibDebug: Add support for StandardOpcodes::FixAdvancePc

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -424,6 +424,7 @@ void Emulator::dispatch_one_pending_signal()
         if (action == DefaultSignalAction::Ignore)
             return;
         reportln("\n=={}== Got signal {} ({}), no handler registered", getpid(), signum, strsignal(signum));
+        dump_backtrace();
         m_shutdown = true;
         return;
     }

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -48,9 +48,7 @@ void LineProgram::parse_unit_header()
     VERIFY(m_unit_header.version == DWARF_VERSION);
     VERIFY(m_unit_header.opcode_base == SPECIAL_OPCODES_BASE);
 
-#if DWARF_DEBUG
-    dbgln("unit length: {}", m_unit_header.length);
-#endif
+    dbgln_if(DWARF_DEBUG, "unit length: {}", m_unit_header.length);
 }
 
 void LineProgram::parse_source_directories()
@@ -60,9 +58,7 @@ void LineProgram::parse_source_directories()
     while (m_stream.peek_or_error()) {
         String directory;
         m_stream >> directory;
-#if DWARF_DEBUG
-        dbgln("directory: {}", directory);
-#endif
+        dbgln_if(DWARF_DEBUG, "directory: {}", directory);
         m_source_directories.append(move(directory));
     }
     m_stream.handle_recoverable_error();
@@ -81,9 +77,7 @@ void LineProgram::parse_source_files()
         size_t _unused = 0;
         m_stream.read_LEB128_unsigned(_unused); // skip modification time
         m_stream.read_LEB128_unsigned(_unused); // skip file size
-#if DWARF_DEBUG
-        dbgln("file: {}, directory index: {}", file_name, directory_index);
-#endif
+        dbgln_if(DWARF_DEBUG, "file: {}, directory index: {}", file_name, directory_index);
         m_source_files.append({ file_name, directory_index });
     }
     m_stream.discard_or_error(1);
@@ -92,9 +86,7 @@ void LineProgram::parse_source_files()
 
 void LineProgram::append_to_line_info()
 {
-#if DWARF_DEBUG
-    dbgln("appending line info: {:p}, {}:{}", m_address, m_source_files[m_file_index].name, m_line);
-#endif
+    dbgln_if(DWARF_DEBUG, "appending line info: {:p}, {}:{}", m_address, m_source_files[m_file_index].name, m_line);
     if (!m_is_statement)
         return;
 
@@ -136,22 +128,16 @@ void LineProgram::handle_extended_opcode()
     case ExtendedOpcodes::SetAddress: {
         VERIFY(length == sizeof(size_t) + 1);
         m_stream >> m_address;
-#if DWARF_DEBUG
-        dbgln("SetAddress: {:p}", m_address);
-#endif
+        dbgln_if(DWARF_DEBUG, "SetAddress: {:p}", m_address);
         break;
     }
     case ExtendedOpcodes::SetDiscriminator: {
-#if DWARF_DEBUG
-        dbgln("SetDiscriminator");
-#endif
+        dbgln_if(DWARF_DEBUG, "SetDiscriminator");
         m_stream.discard_or_error(1);
         break;
     }
     default:
-#if DWARF_DEBUG
-        dbgln("offset: {:p}", m_stream.offset());
-#endif
+        dbgln_if(DWARF_DEBUG, "offset: {:p}", m_stream.offset());
         VERIFY_NOT_REACHED();
     }
 }
@@ -166,26 +152,20 @@ void LineProgram::handle_standard_opcode(u8 opcode)
         size_t operand = 0;
         m_stream.read_LEB128_unsigned(operand);
         size_t delta = operand * m_unit_header.min_instruction_length;
-#if DWARF_DEBUG
-        dbgln("AdvancePC by: {} to: {:p}", delta, m_address + delta);
-#endif
+        dbgln_if(DWARF_DEBUG, "AdvancePC by: {} to: {:p}", delta, m_address + delta);
         m_address += delta;
         break;
     }
     case StandardOpcodes::SetFile: {
         size_t new_file_index = 0;
         m_stream.read_LEB128_unsigned(new_file_index);
-#if DWARF_DEBUG
-        dbgln("SetFile: new file index: {}", new_file_index);
-#endif
+        dbgln_if(DWARF_DEBUG, "SetFile: new file index: {}", new_file_index);
         m_file_index = new_file_index;
         break;
     }
     case StandardOpcodes::SetColumn: {
         // not implemented
-#if DWARF_DEBUG
-        dbgln("SetColumn");
-#endif
+        dbgln_if(DWARF_DEBUG, "SetColumn");
         size_t new_column;
         m_stream.read_LEB128_unsigned(new_column);
 
@@ -196,15 +176,11 @@ void LineProgram::handle_standard_opcode(u8 opcode)
         m_stream.read_LEB128_signed(line_delta);
         VERIFY(line_delta >= 0 || m_line >= (size_t)(-line_delta));
         m_line += line_delta;
-#if DWARF_DEBUG
-        dbgln("AdvanceLine: {}", m_line);
-#endif
+        dbgln_if(DWARF_DEBUG, "AdvanceLine: {}", m_line);
         break;
     }
     case StandardOpcodes::NegateStatement: {
-#if DWARF_DEBUG
-        dbgln("NegateStatement");
-#endif
+        dbgln_if(DWARF_DEBUG, "NegateStatement");
         m_is_statement = !m_is_statement;
         break;
     }
@@ -212,24 +188,20 @@ void LineProgram::handle_standard_opcode(u8 opcode)
         u8 adjusted_opcode = 255 - SPECIAL_OPCODES_BASE;
         ssize_t address_increment = (adjusted_opcode / m_unit_header.line_range) * m_unit_header.min_instruction_length;
         address_increment *= m_unit_header.min_instruction_length;
-#if DWARF_DEBUG
-        dbgln("ConstAddPc: advance pc by: {} to: {}", address_increment, (m_address + address_increment));
-#endif
+        dbgln_if(DWARF_DEBUG, "ConstAddPc: advance pc by: {} to: {}", address_increment, (m_address + address_increment));
         m_address += address_increment;
         break;
     }
     case StandardOpcodes::SetIsa: {
         size_t isa;
         m_stream.read_LEB128_unsigned(isa);
-        dbgln("SetIsa: {}", isa);
+        dbgln_if(DWARF_DEBUG, "SetIsa: {}", isa);
         break;
     }
     case StandardOpcodes::FixAdvancePc: {
         u16 delta = 0;
         m_stream >> delta;
-#if DWARF_DEBUG
-        dbgln("FixAdvancePC by: {} to: {:p}", delta, m_address + delta);
-#endif
+        dbgln_if(DWARF_DEBUG, "FixAdvancePC by: {} to: {:p}", delta, m_address + delta);
         m_address += delta;
         break;
     }

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -224,6 +224,15 @@ void LineProgram::handle_standard_opcode(u8 opcode)
         dbgln("SetIsa: {}", isa);
         break;
     }
+    case StandardOpcodes::FixAdvancePc: {
+        u16 delta = 0;
+        m_stream >> delta;
+#if DWARF_DEBUG
+        dbgln("FixAdvancePC by: {} to: {:p}", delta, m_address + delta);
+#endif
+        m_address += delta;
+        break;
+    }
     default:
         dbgln("Unhandled LineProgram opcode {}", opcode);
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -98,6 +98,9 @@ void LineProgram::append_to_line_info()
     if (!m_is_statement)
         return;
 
+    if (m_file_index >= m_source_files.size())
+        return;
+
     String directory = m_source_directories[m_source_files[m_file_index].directory_index];
 
     StringBuilder full_path(directory.length() + m_source_files[m_file_index].name.length() + 1);


### PR DESCRIPTION
This implements support for the `DW_LNS_fixed_advance_pc` opcode. Also, it adds a missing bounds check I ran across while debugging some other problem related to `__cxa_throw`:

```
CrashDaemon(28): --- Backtrace for thread #0 (TID 29) ---
CrashDaemon(28): 0xbc8a31a8: [libsystem.so] syscall0 +0x8 (syscall.cpp:35)
CrashDaemon(28): 0x8946d806: [libc.so] __assertion_failed +0x106 (syscall.h:44)
CrashDaemon(28): 0x19de45f5: [libdebug.so] Debug::Dwarf::LineProgram::append_to_line_info() +0x315 (Vector.h:199)
CrashDaemon(28): 0x19de5052: [libdebug.so] Debug::Dwarf::LineProgram::handle_sepcial_opcode(unsigned char) +0x42 (LineProgram.cpp:254)
CrashDaemon(28): 0x19de513a: [libdebug.so] Debug::Dwarf::LineProgram::run_program() +0xda (LineProgram.cpp:271)
CrashDaemon(28): 0x19de5239: [libdebug.so] Debug::Dwarf::LineProgram::LineProgram(AK::InputMemoryStream&) +0xb9 (LineProgram.cpp:42)
CrashDaemon(28): 0x19dd7d6b: [libdebug.so] Debug::DebugInfo::prepare_lines() +0x17b (Vector.h:176)
CrashDaemon(28): 0x19dd8d5b: [libdebug.so] Debug::DebugInfo::DebugInfo(AK::NonnullOwnPtr<ELF::Image const>, AK::String, unsigned int) +0xcb (DebugInfo.cpp:46)
CrashDaemon(28): 0x6f216bcb: [/bin/UserspaceEmulator] UserspaceEmulator::Emulator::create_backtrace_line(unsigned int) +0x39b (Atomic.h:266)
CrashDaemon(28): 0x6f217cce: [/bin/UserspaceEmulator] UserspaceEmulator::Emulator::dump_backtrace(AK::Vector<unsigned int, 0ul> const&) +0x9e (Format.h:229)
CrashDaemon(28): 0x6f217e5e: [/bin/UserspaceEmulator] UserspaceEmulator::Emulator::dump_backtrace() +0x3e (Vector.h:139)
CrashDaemon(28): 0x6f21812c: [/bin/UserspaceEmulator] UserspaceEmulator::Emulator::dispatch_one_pending_signal() +0x29c (Emulator.cpp:428)
CrashDaemon(28): 0x6f218cec: [/bin/UserspaceEmulator] UserspaceEmulator::Emulator::exec() +0xb6c (Emulator.cpp:236)
CrashDaemon(28): 0x6f214293: [/bin/UserspaceEmulator] main +0x723 (main.cpp:81)
CrashDaemon(28): 0x6f214498: [/bin/UserspaceEmulator] _start +0x58 (crt0.cpp:58)
```

And finally I've added a backtrace for unhandled signals:

```
==30== Got signal 6 (Aborted), no handler registered
=={30}==    0x31d6c1cc  [libsystem.so]: syscall2 +0xc (Syscall.h:484)
=={30}==    0x7c4a8de0  [libc.so]: kill +0x20 (signal.cpp:41)
=={30}==    0x7c4a8e83  [libc.so]: raise +0x23 (signal.cpp:54)
=={30}==    0x7c495cbc  [libc.so]: abort +0x19 (stdlib.cpp:245)
=={30}==    0x108b9997  [libgcc_s.so]: _Unwind_RaiseException_Phase2.cold +0x0
=={30}==    0x108cc0f8  [libgcc_s.so]: _Unwind_RaiseException +0x38 (enable-execute-stack.c:10)
=={30}==    0x9ffbbb5b  [/throw]: __cxa_throw +0x3b (throw.cpp:15)
=={30}==    0x9ffba88c  [/throw]: main +0x0 (throw.cpp:9)
=={30}==    0x9ffba8b0  [/throw]: main +0x24 (throw.cpp:15)
=={30}==    0x9ffba6f8  [/throw]: _start +0x58 (crt0.cpp:58)
=={30}==    0x08029c6e
=={30}==    0x0800157b

==30==  Leak, 100-byte allocation at address 0x00850018
=={30}==    0x31d6c1e0  [libsystem.so]: syscall3 +0x10 (Syscall.h:495)
=={30}==    0x7c49b34e  [libc.so]: malloc +0x21e (syscall.h:59)
=={30}==    0x9ffbab0f  [/throw]: __cxa_allocate_exception +0x1f (throw.cpp:15)
=={30}==    0x9ffba871  [/throw]: foo() +0x1c (throw.cpp:5)
=={30}==    0x9ffba8b0  [/throw]: main +0x24 (throw.cpp:15)
=={30}==    0x9ffba6f8  [/throw]: _start +0x58 (crt0.cpp:58)
=={30}==    0x08029c6e
=={30}==    0x0800157b
```