### PR TITLE
Ports: Add auth_type verification to all package.sh files

### DIFF
--- a/Ports/SDL2/package.sh
+++ b/Ports/SDL2/package.sh
@@ -3,8 +3,9 @@ port=SDL2
 version=serenity-git
 workdir=SDL-main-serenity
 useconfigure=true
-files="https://github.com/SerenityOS/SDL/archive/main-serenity.tar.gz SDL2-git.tar.gz"
-configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt -DPULSEAUDIO=OFF -DJACK=OFF"
+files="https://github.com/SerenityOS/SDL/archive/main-serenity.tar.gz SDL2-git.tar.gz 18ce496be8644b0eb7fc4cad0d8dd5ff"
+auth_type=md5
+configopts="DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt -DPULSEAUDIO=OFF -DJACK=OFF"
 
 configure() {
     run cmake $configopts

--- a/Ports/SDL2_gfx/package.sh
+++ b/Ports/SDL2_gfx/package.sh
@@ -2,7 +2,8 @@
 
 port=SDL2_gfx
 version=1.0.4
-files="https://downloads.sourceforge.net/project/sdl2gfx/SDL2_gfx-${version}.tar.gz SDL2_gfx-${version}.tar.gz"
+files="https://downloads.sourceforge.net/project/sdl2gfx/SDL2_gfx-${version}.tar.gz SDL2_gfx-${version}.tar.gz 15f9866c6464ca298f28f62fe5b36d9f"
+auth_type=md5
 depends="SDL2"
 useconfigure=true
 configopts="--with-sdl-prefix=${SERENITY_BUILD_DIR}/Root/usr/local"

--- a/Ports/SDL2_image/package.sh
+++ b/Ports/SDL2_image/package.sh
@@ -3,7 +3,8 @@ port=SDL2_image
 useconfigure=true
 version=2.0.5
 depends="SDL2 libpng libjpeg"
-files="https://www.libsdl.org/projects/SDL_image/release/SDL2_image-${version}.tar.gz SDL_image-${version}.tar.gz"
+files="https://www.libsdl.org/projects/SDL_image/release/SDL2_image-${version}.tar.gz SDL_image-${version}.tar.gz f26f3a153360a8f09ed5220ef7b07aea"
+auth_type=md5
 
 configure() {
     run ./configure \

--- a/Ports/SDL2_mixer/package.sh
+++ b/Ports/SDL2_mixer/package.sh
@@ -2,7 +2,8 @@
 port=SDL2_mixer
 version=2.0.4
 useconfigure=true
-files="https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${version}.tar.gz SDL2_mixer-${version}.tar.gz"
+files="https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${version}.tar.gz SDL2_mixer-${version}.tar.gz a36e8410cac46b00a4d01752b32c3eb1"
+auth_type=md5
 depends="SDL2 libvorbis"
 
 configure() {

--- a/Ports/SDL2_ttf/package.sh
+++ b/Ports/SDL2_ttf/package.sh
@@ -2,7 +2,8 @@
 port=SDL2_ttf
 version=2.0.15
 useconfigure=true
-files="https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-${version}.tar.gz SDL2_ttf-${version}.tar.gz"
+files="https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-${version}.tar.gz SDL2_ttf-${version}.tar.gz 04fe06ff7623d7bdcb704e82f5f88391"
+auth_type=md5
 depends="SDL2 freetype"
 
 configure() {

--- a/Ports/SDLPoP/package.sh
+++ b/Ports/SDLPoP/package.sh
@@ -5,7 +5,8 @@ version=git
 depends="SDL2 SDL2_image"
 workdir=SDLPoP-master
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt"
-files="https://github.com/NagyD/SDLPoP/archive/refs/heads/master.zip PoP.zip"
+files="https://github.com/NagyD/SDLPoP/archive/refs/heads/master.zip PoP.zip c75184eb2a7e8c9ed008ffae371ec178"
+auth_type=md5
 install_location="Root/opt/PrinceOfPersia"
 
 configure() {

--- a/Ports/Super-Mario/package.sh
+++ b/Ports/Super-Mario/package.sh
@@ -5,7 +5,8 @@ version=git
 depends="SDL2 SDL2_mixer SDL2_image"
 workdir=Super-Mario-Clone-Cpp-master
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt"
-files="https://github.com/Bennyhwanggggg/Super-Mario-Clone-Cpp/archive/refs/heads/master.zip master.zip"
+files="https://github.com/Bennyhwanggggg/Super-Mario-Clone-Cpp/archive/refs/heads/master.zip master.zip 11f622721d1ba504acf75c024aa0dbe3"
+auth_type=md5
 install_location="Root/opt/Super_Mario"
 
 configure() {

--- a/Ports/bzip2/package.sh
+++ b/Ports/bzip2/package.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=bzip2
 version=1.0.8
-files="https://sourceware.org/pub/bzip2/bzip2-${version}.tar.gz bzip2-${version}.tar.gz"
+files="https://sourceware.org/pub/bzip2/bzip2-${version}.tar.gz bzip2-${version}.tar.gz 67e051268d0c475ea773822f7500d0e5"
+auth_type=md5
 makeopts="bzip2 CC=${CC}"
 installopts="PREFIX=${SERENITY_BUILD_DIR}/Root/usr/local"

--- a/Ports/c-ray/package.sh
+++ b/Ports/c-ray/package.sh
@@ -3,7 +3,8 @@ port=c-ray
 version=git
 workdir=c-ray-master
 useconfigure=true
-files="https://github.com/vkoskiv/c-ray/archive/master.tar.gz c-ray-git.tar.gz"
+files="https://github.com/vkoskiv/c-ray/archive/master.tar.gz c-ray-git.tar.gz 939b40cdb642b78a2b300b5b2981e337"
+auth_type=md5
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt"
 depends="SDL2"
 

--- a/Ports/carl/package.sh
+++ b/Ports/carl/package.sh
@@ -3,6 +3,7 @@ port=carl
 version=1.5
 workdir=cryanc-"${version}"
 files="https://github.com/classilla/cryanc/archive/refs/tags/${version}.tar.gz cryanc-${version}.tar.gz f2cae13addf4ed7cb7af3d06069cf082"
+auth_type=md4
 
 build() {
     run $CC -O3 carl.c -o carl

--- a/Ports/chester/package.sh
+++ b/Ports/chester/package.sh
@@ -5,7 +5,8 @@ version=git
 depends="SDL2"
 workdir=chester-public
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt"
-files="https://github.com/veikkos/chester/archive/public.tar.gz chester.tar.gz"
+files="https://github.com/veikkos/chester/archive/public.tar.gz chester.tar.gz f09d797209e7bfd9b1460d2540525186"
+auth_type=md5
 
 configure() {
     run cmake $configopts

--- a/Ports/cmake/package.sh
+++ b/Ports/cmake/package.sh
@@ -2,7 +2,8 @@
 port=cmake
 version=3.19.4
 useconfigure=false
-files="https://github.com/Kitware/CMake/releases/download/v$version/cmake-$version.tar.gz cmake-$version.tar.gz"
+files="https://github.com/Kitware/CMake/releases/download/v$version/cmake-$version.tar.gz cmake-$version.tar.gz 2a71f16c61bac5402004066d193fc14e"
+auth_type=md5
 depends="bash gcc make sed"
 
 port_path=$(realpath $(dirname ${BASH_SOURCE[0]}))

--- a/Ports/cmatrix/package.sh
+++ b/Ports/cmatrix/package.sh
@@ -5,7 +5,8 @@ version=git
 depends="ncurses"
 workdir=cmatrix-master
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt"
-files="https://github.com/abishekvashok/cmatrix/archive/refs/heads/master.zip cmatrix.zip"
+files="https://github.com/abishekvashok/cmatrix/archive/refs/heads/master.zip cmatrix.zip 2541321b89149b375d5732402e52d654"
+auth_type=md5
 
 configure() {
     run cmake $configopts

--- a/Ports/doom/package.sh
+++ b/Ports/doom/package.sh
@@ -2,6 +2,7 @@
 port=doom
 workdir=SerenityDOOM-master
 version=serenity-git
-files="https://github.com/SerenityOS/SerenityDOOM/archive/master.tar.gz doom-git.tar.gz"
+files="https://github.com/SerenityOS/SerenityDOOM/archive/master.tar.gz doom-git.tar.gz 481406ef30e04ad55d39aa94baab73bd"
+auth_type=md5
 makeopts="-C doomgeneric/"
 installopts="-C doomgeneric/"

--- a/Ports/ed/package.sh
+++ b/Ports/ed/package.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=ed
 version=1.15
-files="https://ftpmirror.gnu.org/gnu/ed/ed-${version}.tar.lz ed-${version}.tar.lz"
+files="https://ftpmirror.gnu.org/gnu/ed/ed-${version}.tar.lz ed-${version}.tar.lz
+https://ftpmirror.gnu.org/gnu/ed/ed-${version}.tar.lz.sig ed-${version}.tar.lz.sig
+https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
+auth_type="sig"
+auth_opts="--keyring ./gnu-keyring.gpg cflow-${version}.tar.bz2.sig"
 useconfigure=true
 depends=pcre2
 

--- a/Ports/emu2/package.sh
+++ b/Ports/emu2/package.sh
@@ -2,6 +2,7 @@
 port=emu2
 version=ff276eb0a755a3e784f73da00b5db6c1b25c1f83
 files="https://github.com/dmsc/emu2/archive/${version}.zip emu2-${version}.zip 2640a713d6c7ed98d020e0b7dccbc404"
+auth_type=md5
 
 build() {
     export CC="${SERENITY_ROOT}/Toolchain/Local/${SERENITY_ARCH}/bin/${SERENITY_ARCH}-pc-serenity-gcc"

--- a/Ports/figlet/package.sh
+++ b/Ports/figlet/package.sh
@@ -2,4 +2,5 @@
 port=figlet
 version=2.2.5
 files="http://ftp.figlet.org/pub/figlet/program/unix/figlet-${version}.tar.gz figlet-${version}.tar.gz d88cb33a14f1469fff975d021ae2858e"
+auth_type=md5
 makeopts="CC=${CC} LD=${CC}"

--- a/Ports/freetype/package.sh
+++ b/Ports/freetype/package.sh
@@ -2,5 +2,6 @@
 port=freetype
 version=2.10.4
 useconfigure=true
-files="https://download.savannah.gnu.org/releases/freetype/freetype-${version}.tar.gz freetype-${version}.tar.gz"
+files="https://download.savannah.gnu.org/releases/freetype/freetype-${version}.tar.gz freetype-${version}.tar.gz 4934a8b61b636920bcce58e7c7f3e1a2"
+auth_type=md5
 configopts="--with-brotli=no --with-bzip2=no --with-zlib=no --with-harfbuzz=no --with-png=no"

--- a/Ports/frotz/package.sh
+++ b/Ports/frotz/package.sh
@@ -2,7 +2,8 @@
 port=frotz
 version=git
 workdir=frotz-master
-files="https://gitlab.com/DavidGriffith/frotz/-/archive/master/frotz-master.zip frotz-master.zip"
+files="https://gitlab.com/DavidGriffith/frotz/-/archive/master/frotz-master.zip frotz-master.zip eeaad3d51354491b07c7f30384c0cede"
+auth_type=md5
 depends="ncurses"
 
 build() {

--- a/Ports/genemu/package.sh
+++ b/Ports/genemu/package.sh
@@ -4,7 +4,8 @@ port="genemu"
 version=git
 workdir="${port}-master"
 useconfigure=true
-files="https://github.com/rasky/genemu/archive/master.tar.gz ${version}.tar.gz"
+files="https://github.com/rasky/genemu/archive/master.tar.gz ${version}.tar.gz a7b9f896c1fd99da03767068493ec89f"
+auth_type=md5
 configopts="-DCMAKE_TOOLCHAIN_FILE=${SERENITY_ROOT}/Toolchain/CMake/CMakeToolchain.txt"
 depends="SDL2"
 

--- a/Ports/git/package.sh
+++ b/Ports/git/package.sh
@@ -2,7 +2,8 @@
 port=git
 version=2.31.1
 useconfigure="true"
-files="https://mirrors.edge.kernel.org/pub/software/scm/git/git-${version}.tar.xz git-${version}.tar.xz"
+files="https://mirrors.edge.kernel.org/pub/software/scm/git/git-${version}.tar.xz git-${version}.tar.xz 51bd18a1af964dd3b1c7b0220889ebb6"
+auth_type=md5
 configopts="--target=${SERENITY_ARCH}-pc-serenity CFLAGS=-DNO_IPV6"
 depends="zlib"
 

--- a/Ports/gnupg/package.sh
+++ b/Ports/gnupg/package.sh
@@ -8,7 +8,8 @@ configopts="--with-libgpg-error-prefix=${SERENITY_BUILD_DIR}/Root/usr/local \
   --with-ntbtls-prefix=${SERENITY_BUILD_DIR}/Root/usr/local \
   --with-npth-prefix=${SERENITY_BUILD_DIR}/Root/usr/local \
   --disable-dirmngr"
-files="https://gnupg.org/ftp/gcrypt/gnupg/gnupg-${version}.tar.bz2 gnupg-${version}.tar.bz2"
+files="https://gnupg.org/ftp/gcrypt/gnupg/gnupg-${version}.tar.bz2 gnupg-${version}.tar.bz2 84c1ef39e8621cfb70f31463a5d1d8edeab44332bc1e0e1af9b78b6f9ed05bb4"
+auth_type=sha256
 depends="libiconv libgpg-error libgcrypt libksba libassuan npth ntbtls"
 
 pre_configure() {

--- a/Ports/gnuplot/package.sh
+++ b/Ports/gnuplot/package.sh
@@ -3,7 +3,8 @@ port=gnuplot
 version=5.2.8
 useconfigure=true
 # Note: gnuplot's source code is hosted on SourceForge, but using the GitHub mirror makes downloading a versioned .tar.gz easier.
-files="https://github.com/gnuplot/gnuplot/archive/${version}.tar.gz gnuplot-${version}.tar.gz"
+files="https://github.com/gnuplot/gnuplot/archive/${version}.tar.gz gnuplot-${version}.tar.gz 292f983e273cd50cf02e0737043fae0e"
+auth_type=md5
 configopts="--prefix=${SERENITY_BUILD_DIR}/Root/usr/local --with-readline=builtin --without-latex"
 
 pre_configure() {

--- a/Ports/hatari/package.sh
+++ b/Ports/hatari/package.sh
@@ -6,7 +6,8 @@ depends="SDL2 zlib"
 commit=353379e1f8a847cc0e284541d2b40fd49d175d22
 workdir="${port}-${commit}"
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt"
-files="https://github.com/hatari/hatari/archive/${commit}.tar.gz ${commit}.tar.gz"
+files="https://github.com/hatari/hatari/archive/${commit}.tar.gz ${commit}.tar.gz 614d8c20a06deea6df464a5de32cc795"
+auth_type=md5
 
 configure() {
 	run cmake $configopts

--- a/Ports/jot/package.sh
+++ b/Ports/jot/package.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=jot
 version=6.6
-files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/jot-${version}.tar.gz jot-${version}.tar.gz"
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/jot-${version}.tar.gz jot-${version}.tar.gz 6905e24f8b3c61dad19f1d6608de4ae0"
+auth_type=md5
 depends=libpuffy

--- a/Ports/jq/package.sh
+++ b/Ports/jq/package.sh
@@ -3,7 +3,8 @@ port=jq
 version=1.6
 useconfigure=true
 configopts="--with-oniguruma=builtin --disable-maintainer-mode"
-files="https://github.com/stedolan/jq/releases/download/jq-${version}/jq-${version}.tar.gz jq-${version}.tar.gz"
+files="https://github.com/stedolan/jq/releases/download/jq-${version}/jq-${version}.tar.gz jq-${version}.tar.gz 5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72"
+auth_type=sha256
 makeopts="LDFLAGS=-all-static"
 
 pre_configure() {

--- a/Ports/klong/package.sh
+++ b/Ports/klong/package.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=klong
 version=20190926
-files="http://t3x.org/klong/klong20190926.tgz klong20190926.tgz"
+files="http://t3x.org/klong/klong20190926.tgz klong20190926.tgz d03ed117cc8b9fadc87c1dd68b7fe7ec"
+auth_type=md5
 useconfigure=false
 workdir=klong

--- a/Ports/libassuan/package.sh
+++ b/Ports/libassuan/package.sh
@@ -3,7 +3,8 @@ port=libassuan
 version=2.5.5
 useconfigure=true
 #configopts="--with-libgpg-error-prefix=${SERENITY_BUILD_DIR}/Root/usr/local"
-files="https://gnupg.org/ftp/gcrypt/libassuan/libassuan-${version}.tar.bz2 libassuan-${version}.tar.bz2"
+files="https://gnupg.org/ftp/gcrypt/libassuan/libassuan-${version}.tar.bz2 libassuan-${version}.tar.bz2 7194453152bb67e3d45da698762b5d6f"
+auth_type=md5
 
 pre_configure() {
     export gcry_cv_gcc_has_f_visibility=no

--- a/Ports/libffi/package.sh
+++ b/Ports/libffi/package.sh
@@ -2,4 +2,5 @@
 port=libffi
 version=3.3
 useconfigure=true
-files="ftp://sourceware.org/pub/libffi/libffi-${version}.tar.gz libffi-${version}.tar.gz"
+files="ftp://sourceware.org/pub/libffi/libffi-${version}.tar.gz libffi-${version}.tar.gz 6313289e32f1d38a9df4770b014a2ca7"
+auth_type=md5

--- a/Ports/libgcrypt/package.sh
+++ b/Ports/libgcrypt/package.sh
@@ -3,7 +3,8 @@ port=libgcrypt
 version=1.9.2
 useconfigure=true
 configopts="--with-libgpg-error-prefix=${SERENITY_BUILD_DIR}/Root/usr/local"
-files="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${version}.tar.bz2 libgcrypt-${version}.tar.bz2"
+files="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${version}.tar.bz2 libgcrypt-${version}.tar.bz2 00121b05e1ff4cc85a4a6503e0a7d9fb"
+auth_type=md5
 
 pre_configure() {
     export gcry_cv_gcc_has_f_visibility=no

--- a/Ports/libgpg-error/package.sh
+++ b/Ports/libgpg-error/package.sh
@@ -3,7 +3,8 @@ port=libgpg-error
 version=1.42
 useconfigure=true
 configopts="--disable-tests --disable-threads"
-files="https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-${version}.tar.bz2 libgpg-error-${version}.tar.bz2"
+files="https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-${version}.tar.bz2 libgpg-error-${version}.tar.bz2 133fed221ba8f63f5842858a1ff67cb3"
+auth_type=md5
 
 pre_configure() {
     export gcry_cv_gcc_has_f_visibility=no

--- a/Ports/libicu/package.sh
+++ b/Ports/libicu/package.sh
@@ -4,7 +4,8 @@ version=69_1
 useconfigure=true
 workdir=icu/source
 configopts=--with-cross-build=$(pwd)/${workdir}/../host-build
-files="https://github.com/unicode-org/icu/releases/download/release-${version//_/-}/icu4c-${version}-src.tgz icu4c-${version}-src.tgz"
+files="https://github.com/unicode-org/icu/releases/download/release-${version//_/-}/icu4c-${version}-src.tgz icu4c-${version}-src.tgz 9403db682507369d0f60a25ea67014c4"
+auth_type=md5
 
 configure() {
     host_env

--- a/Ports/libksba/package.sh
+++ b/Ports/libksba/package.sh
@@ -2,7 +2,8 @@
 port=libksba
 version=1.5.1
 useconfigure=true
-files="https://gnupg.org/ftp/gcrypt/libksba/libksba-${version}.tar.bz2 libksba-${version}.tar.bz2"
+files="https://gnupg.org/ftp/gcrypt/libksba/libksba-${version}.tar.bz2 libksba-${version}.tar.bz2 96e207b7adc637a3dbc29bac90312200"
+auth_type=md5
 
 pre_configure() {
     export ksba_cv_gcc_has_f_visibility=no

--- a/Ports/libogg/package.sh
+++ b/Ports/libogg/package.sh
@@ -2,7 +2,8 @@
 port=libogg
 version=1.3.4
 useconfigure=true
-files="https://github.com/xiph/ogg/releases/download/v${version}/libogg-${version}.tar.gz libogg-${version}.tar.gz"
+files="https://github.com/xiph/ogg/releases/download/v${version}/libogg-${version}.tar.gz libogg-${version}.tar.gz b9a66c80bdf45363605e4aa75fa951a8"
+auth_type=md5
 
 install() {
     run make DESTDIR=$DESTDIR $installopts install

--- a/Ports/libpng/package.sh
+++ b/Ports/libpng/package.sh
@@ -2,7 +2,8 @@
 port=libpng
 version=1.6.37
 useconfigure=true
-files="https://download.sourceforge.net/libpng/libpng-${version}.tar.gz libpng-${version}.tar.gz"
+files="https://download.sourceforge.net/libpng/libpng-${version}.tar.gz libpng-${version}.tar.gz 6c7519f6c75939efa0ed3053197abd54"
+auth_type=md5
 depends="zlib"
 
 install() {

--- a/Ports/libpuffy/package.sh
+++ b/Ports/libpuffy/package.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=libpuffy
 version=1.0
-files="https://github.com/ibara/libpuffy/releases/download/libpuffy-${version}/libpuffy-${version}.tar.gz libpuffy-${version}.tar.gz"
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-${version}/libpuffy-${version}.tar.gz libpuffy-${version}.tar.gz b22b6f24a3d4f3ac67f43b9efd3a9dc1"
+auth_type=md5

--- a/Ports/libvorbis/package.sh
+++ b/Ports/libvorbis/package.sh
@@ -2,7 +2,8 @@
 port=libvorbis
 version=1.3.7
 useconfigure=true
-files="https://github.com/xiph/vorbis/releases/download/v${version}/libvorbis-${version}.tar.gz libvorbis-${version}.tar.gz"
+files="https://github.com/xiph/vorbis/releases/download/v${version}/libvorbis-${version}.tar.gz libvorbis-${version}.tar.gz 9b8034da6edc1a17d18b9bc4542015c7"
+auth_type=md5
 depends=libogg
 
 install() {

--- a/Ports/libzip/package.sh
+++ b/Ports/libzip/package.sh
@@ -5,7 +5,8 @@ version=1.7.3
 depends="zlib"
 workdir=libzip-${version}
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt"
-files="https://libzip.org/download/libzip-${version}.tar.gz libzip-${version}.tar.gz"
+files="https://libzip.org/download/libzip-${version}.tar.gz libzip-${version}.tar.gz 76f8fea9b88f6ead7f15ed7712eb5aef"
+auth_type=md5
 
 configure() {
     run cmake $configopts

--- a/Ports/links/package.sh
+++ b/Ports/links/package.sh
@@ -3,3 +3,4 @@ port=links
 version=2.22
 useconfigure=true
 files="http://links.twibright.com/download/links-${version}.tar.bz2 links-${version}.tar.bz2 55f745dea500aac52cede98bab8d96e2"
+auth_type=md5

--- a/Ports/lua/package.sh
+++ b/Ports/lua/package.sh
@@ -2,5 +2,6 @@
 port=lua
 version=5.3.5
 files="http://www.lua.org/ftp/lua-${version}.tar.gz lua-${version}.tar.gz 4f4b4f323fd3514a68e0ab3da8ce3455"
+auth_type=md5
 makeopts="-j$(nproc) serenity"
 installopts="INSTALL_TOP=${SERENITY_BUILD_DIR}/Root/usr/local"

--- a/Ports/mrsh/package.sh
+++ b/Ports/mrsh/package.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=mrsh
 version=d9763a32e7da572677d1681bb1fc67f117d641f3
-files="https://codeload.github.com/emersion/mrsh/legacy.tar.gz/${version} emersion-mrsh-d9763a3.tar.gz"
+files="https://codeload.github.com/emersion/mrsh/legacy.tar.gz/${version} emersion-mrsh-d9763a3.tar.gz 80d268ebf0fca32293605b6e91bc64d0"
+auth_type=md5
 useconfigure=true
 makeopts=
 workdir=emersion-mrsh-d9763a3

--- a/Ports/nasm/package.sh
+++ b/Ports/nasm/package.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=nasm
 version=2.15.05
-files="https://www.nasm.us/pub/nasm/releasebuilds/${version}/nasm-${version}.tar.gz nasm-${version}.tar.gz"
+files="https://www.nasm.us/pub/nasm/releasebuilds/${version}/nasm-${version}.tar.gz nasm-${version}.tar.gz 58886d8a4084d7c09adb0f425266051b"
+auth_type=md5
 useconfigure=true
 makeopts=

--- a/Ports/neofetch/package.sh
+++ b/Ports/neofetch/package.sh
@@ -4,7 +4,8 @@ port=neofetch
 version=7.1.0
 useconfigure=false
 depends="bash jq"
-files="https://github.com/dylanaraps/neofetch/archive/${version}.tar.gz neofetch-${version}.tar.gz"
+files="https://github.com/dylanaraps/neofetch/archive/${version}.tar.gz neofetch-${version}.tar.gz 37ba9026fdd353f66d822fdce16420a8"
+auth_type=md5
 
 install() {
     run make DESTDIR=$DESTDIR PREFIX=/usr/local $installopts install

--- a/Ports/nesalizer/package.sh
+++ b/Ports/nesalizer/package.sh
@@ -2,5 +2,6 @@
 port=nesalizer
 version=master
 makeopts="CONF=release EXTRA=-I${SERENITY_ROOT}/Build/i686/Root/usr/local/include/SDL2"
-files="https://github.com/SerenityOS/nesalizer/archive/master.zip nesalizer-master.zip"
+files="https://github.com/SerenityOS/nesalizer/archive/master.zip nesalizer-master.zip 0bbcde24c2366ced827ad63935f557cf"
+auth_type=md5
 depends=SDL2

--- a/Ports/nethack/package.sh
+++ b/Ports/nethack/package.sh
@@ -2,7 +2,8 @@
 port=nethack
 version=3.6.6
 workdir=NetHack-NetHack-${version}_Released
-files="https://www.nethack.org/download/${version}/nethack-${version//.}-src.tgz nethack-${version//.}-src.tgz"
+files="https://www.nethack.org/download/${version}/nethack-${version//.}-src.tgz nethack-${version//.}-src.tgz 6c9a75f556d24c66801d74d8727a602e"
+auth_type=md5
 depends="ncurses bash"
 
 build() {

--- a/Ports/ninja/package.sh
+++ b/Ports/ninja/package.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=ninja
 version=1.8.2
-files="https://github.com/ninja-build/ninja/archive/v${version}.tar.gz ninja-v${version}.tar.gz"
+files="https://github.com/ninja-build/ninja/archive/v${version}.tar.gz ninja-v${version}.tar.gz 5fdb04461cc7f5d02536b3bfc0300166"
+auth_type=md5
 
 build() {
     CXXFLAGS="--sysroot=${SERENITY_BUILD_DIR}/Root" \

--- a/Ports/npth/package.sh
+++ b/Ports/npth/package.sh
@@ -2,7 +2,8 @@
 port=npth
 version=1.6
 useconfigure=true
-files="https://gnupg.org/ftp/gcrypt/npth/npth-${version}.tar.bz2 npth-${version}.tar.bz2"
+files="https://gnupg.org/ftp/gcrypt/npth/npth-${version}.tar.bz2 npth-${version}.tar.bz2 375d1a15ad969f32d25f1a7630929854"
+auth_type=md5
 
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" $configopts

--- a/Ports/ntbtls/package.sh
+++ b/Ports/ntbtls/package.sh
@@ -3,7 +3,8 @@ port=ntbtls
 version=0.2.0
 useconfigure=true
 #configopts="--with-libgpg-error-prefix=${SERENITY_BUILD_DIR}/Root/usr/local"
-files="https://gnupg.org/ftp/gcrypt/ntbtls/ntbtls-${version}.tar.bz2 ntbtls-${version}.tar.bz2"
+files="https://gnupg.org/ftp/gcrypt/ntbtls/ntbtls-${version}.tar.bz2 ntbtls-${version}.tar.bz2 efe1b12502df319bf78707a2fa767098"
+auth_type=md5
 
 pre_configure() {
     export ntbtls_cv_gcc_has_f_visibility=no

--- a/Ports/nyancat/package.sh
+++ b/Ports/nyancat/package.sh
@@ -2,4 +2,5 @@
 port=nyancat
 version=git
 workdir=nyancat-master
-files="https://github.com/klange/nyancat/archive/master.tar.gz nyancat-git.tar.gz"
+files="https://github.com/klange/nyancat/archive/master.tar.gz nyancat-git.tar.gz dcb9dc135f87a4e5e0e6e72e6c3b2430"
+auth_type=md5

--- a/Ports/oksh/package.sh
+++ b/Ports/oksh/package.sh
@@ -4,7 +4,8 @@ useconfigure=true
 version=6.8.1
 depends="ncurses"
 workdir=oksh-${version}
-files="https://github.com/ibara/oksh/releases/download/oksh-${version}/oksh-${version}.tar.gz oksh-${version}.tar.gz"
+files="https://github.com/ibara/oksh/releases/download/oksh-${version}/oksh-${version}.tar.gz oksh-${version}.tar.gz ce8b7c278e6d36bbbd7b54c218fae7ba"
+auth_type=md5
 
 configure() {
     export CC=${SERENITY_ROOT}/Toolchain/Local/${SERENITY_ARCH}/bin/${SERENITY_ARCH}-pc-serenity-gcc 

--- a/Ports/openssh/package.sh
+++ b/Ports/openssh/package.sh
@@ -2,7 +2,8 @@
 port=openssh
 workdir=openssh-portable-9ca7e9c861775dd6c6312bc8aaab687403d24676
 version=8.3-9ca7e9c
-files="https://github.com/openssh/openssh-portable/archive/9ca7e9c861775dd6c6312bc8aaab687403d24676.tar.gz openssh-8.3-9ca7e9c.tar.gz"
+files="https://github.com/openssh/openssh-portable/archive/9ca7e9c861775dd6c6312bc8aaab687403d24676.tar.gz openssh-8.3-9ca7e9c.tar.gz 9ddfeabac11b59a1c5670a6905463ce2"
+auth_type=md5
 depends="zlib openssl"
 useconfigure=true
 configopts="--prefix=/usr/local --disable-utmp --sysconfdir=/etc/ssh --with-ssl-dir=${SERENITY_BUILD_DIR}/Root/usr/local/lib"

--- a/Ports/patch/package.sh
+++ b/Ports/patch/package.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=patch
 version=6.6
-files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/patch-${version}.tar.gz patch-${version}.tar.gz"
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/patch-${version}.tar.gz patch-${version}.tar.gz 451c14a5ec595465d0dcc05d86eed195"
+auth_type=md5
 depends=libpuffy

--- a/Ports/pkgconf/package.sh
+++ b/Ports/pkgconf/package.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=pkgconf
 version=1.7.3
-files="https://distfiles.dereferenced.org/pkgconf/pkgconf-${version}.tar.xz pkgconf-${version}.tar.xz"
+files="https://distfiles.dereferenced.org/pkgconf/pkgconf-${version}.tar.xz pkgconf-${version}.tar.xz 2a19acafd0eccb61d09a5bbf7ce18c9d"
+auth_type=md5
 useconfigure=true
 # FIXME: This looks suspiciously host-y... 
 configopts="--prefix=/usr/local --with-pkg-config-dir=/usr/local/lib/pkgconfig"

--- a/Ports/printf/package.sh
+++ b/Ports/printf/package.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=printf
 version=6.6
-files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/printf-${version}.tar.gz printf-${version}.tar.gz"
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/printf-${version}.tar.gz printf-${version}.tar.gz 384e80195cfaf474159efb8631e5271b"
+auth_type=md5
 depends=libpuffy

--- a/Ports/pt2-clone/package.sh
+++ b/Ports/pt2-clone/package.sh
@@ -2,7 +2,8 @@
 port=pt2-clone
 version=1.28
 useconfigure=true
-files="https://github.com/8bitbubsy/pt2-clone/archive/v${version}.tar.gz v${version}.tar.gz"
+files="https://github.com/8bitbubsy/pt2-clone/archive/v${version}.tar.gz v${version}.tar.gz 42df939c03b7e598ed8b17a764150860"
+auth_type=md5
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt"
 depends="SDL2"
 

--- a/Ports/quake/package.sh
+++ b/Ports/quake/package.sh
@@ -3,7 +3,8 @@ port=quake
 version=0.65
 workdir=SerenityQuake-master
 useconfigure=false
-files="https://github.com/SerenityOS/SerenityQuake/archive/master.tar.gz quake.tar.gz"
+files="https://github.com/SerenityOS/SerenityQuake/archive/master.tar.gz quake.tar.gz 09400bae2dc667964ba6ce815962cb59"
+auth_type=md5
 makeopts="V=1 SYMBOLS_ON=Y "
 depends=SDL2
 

--- a/Ports/rsync/package.sh
+++ b/Ports/rsync/package.sh
@@ -2,6 +2,7 @@
 port=rsync
 version=3.1.3
 useconfigure="true"
-files="https://download.samba.org/pub/rsync/src/rsync-${version}.tar.gz rsync-${version}.tar.gz
-https://download.samba.org/pub/rsync/src/rsync-${version}.tar.gz.asc rsync-${version}.tar.gz.asc"
+files="https://download.samba.org/pub/rsync/src/rsync-${version}.tar.gz rsync-${version}.tar.gz 1581a588fde9d89f6bc6201e8129afaf
+https://download.samba.org/pub/rsync/src/rsync-${version}.tar.gz.asc rsync-${version}.tar.gz.asc 5cde11b63857d647f6cb9850f76c52cb"
+auth_type=md5
 configopts="--target=${SERENITY_ARCH}-pc-serenity"

--- a/Ports/scummvm/package.sh
+++ b/Ports/scummvm/package.sh
@@ -2,7 +2,8 @@
 port=scummvm
 useconfigure="true"
 version="2.2.0"
-files="https://downloads.scummvm.org/frs/scummvm/${version}/scummvm-${version}.tar.gz scummvm-${version}.tar.gz"
+files="https://downloads.scummvm.org/frs/scummvm/${version}/scummvm-${version}.tar.gz scummvm-${version}.tar.gz f48f07347e5ab0b3094a868367c0e1f2"
+auth_type=md5
 depends="SDL2"
 
 configure() {

--- a/Ports/sl/package.sh
+++ b/Ports/sl/package.sh
@@ -2,7 +2,8 @@
 port=sl
 version=git
 workdir=sl-master
-files="https://github.com/mtoyoda/sl/archive/master.tar.gz sl-git.tar.gz"
+files="https://github.com/mtoyoda/sl/archive/master.tar.gz sl-git.tar.gz 230347a534644a46e635877a6b0dfb77"
+auth_type=md5
 depends="ncurses"
 
 build() {

--- a/Ports/sqlite/package.sh
+++ b/Ports/sqlite/package.sh
@@ -2,5 +2,6 @@
 port=sqlite
 useconfigure="true"
 version="3350300"
-files="https://www.sqlite.org/2021/sqlite-autoconf-${version}.tar.gz sqlite-autoconf-${version}.tar.gz"
+files="https://www.sqlite.org/2021/sqlite-autoconf-${version}.tar.gz sqlite-autoconf-${version}.tar.gz cadd4db9b528dfd0a7efde39f767cd83"
+auth_type=md5
 workdir="sqlite-autoconf-${version}"

--- a/Ports/stress-ng/package.sh
+++ b/Ports/stress-ng/package.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=stress-ng
 version=0.11.23
-files="https://github.com/ColinIanKing/stress-ng/archive/V${version}.tar.gz stress-ng-${version}.tar.gz"
+files="https://github.com/ColinIanKing/stress-ng/archive/V${version}.tar.gz stress-ng-${version}.tar.gz 49fa5547c8cfd7871b9d6261cce6ace3"
+auth_type=md5
 depends=zlib
 
 pre_configure() {

--- a/Ports/termcap/package.sh
+++ b/Ports/termcap/package.sh
@@ -3,4 +3,5 @@ port=termcap
 version=1.3.1
 useconfigure=true
 configopts="--prefix=${SERENITY_BUILD_DIR}/Root/usr/local"
-files="https://ftpmirror.gnu.org/gnu/termcap/termcap-${version}.tar.gz termcap-${version}.tar.gz"
+files="https://ftpmirror.gnu.org/gnu/termcap/termcap-${version}.tar.gz termcap-${version}.tar.gz ffe6f86e63a3a29fa53ac645faaabdfa"
+auth_type=md5

--- a/Ports/tinycc/package.sh
+++ b/Ports/tinycc/package.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=tinycc
 version=dev
-files="https://github.com/TinyCC/tinycc/archive/dev.tar.gz tinycc-dev.tar.gz"
+files="https://github.com/TinyCC/tinycc/archive/dev.tar.gz tinycc-dev.tar.gz 400f909c1dc2d392efff8279fec1cfdb"
+auth_type=md5
 useconfigure=true
 makeopts=tcc
 

--- a/Ports/tinyscheme/package.sh
+++ b/Ports/tinyscheme/package.sh
@@ -2,7 +2,7 @@
 port=tinyscheme
 version=1.42
 files="https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinyscheme-${version}/tinyscheme-${version}.tar.gz tinyscheme-${version}.tar.gz 273ac5ffe5305986b329e9045f2aea89"
-
+auth_type=md5
 useconfigure=false
 
 build() {

--- a/Ports/tr/package.sh
+++ b/Ports/tr/package.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=tr
 version=6.7
-files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/tr-${version}.tar.gz tr-${version}.tar.gz"
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/tr-${version}.tar.gz tr-${version}.tar.gz d54e214d8f2ba615a3175063379d0ce9"
+auth_type=md5
 depends=libpuffy

--- a/Ports/vim/package.sh
+++ b/Ports/vim/package.sh
@@ -3,7 +3,8 @@ port=vim
 version=git
 workdir=vim-master
 useconfigure="true"
-files="https://github.com/vim/vim/archive/master.tar.gz vim-git.tar.gz"
+files="https://github.com/vim/vim/archive/master.tar.gz vim-git.tar.gz 9f999815c6afc320612d55f93f0db67b"
+auth_type=md5
 configopts="--with-tlib=tinfo --with-features=normal"
 depends="ncurses"
 

--- a/Ports/vitetris/package.sh
+++ b/Ports/vitetris/package.sh
@@ -2,8 +2,9 @@
 port=vitetris
 useconfigure="true"
 version="0.59.1"
-files="https://github.com/vicgeralds/vitetris/archive/refs/tags/v${version}.tar.gz vitetris.tar.gz"
+files="https://github.com/vicgeralds/vitetris/archive/refs/tags/v${version}.tar.gz vitetris.tar.gz 699443df03c8d4bf2051838c1015da72039bbbdd0ab0eede891c59c840bdf58d"
 configopts="--without-xlib --without-joystick --without-network"
+auth_type=sha256
 
 configure() {
     run chmod +x "$configscript"

--- a/Ports/vttest/package.sh
+++ b/Ports/vttest/package.sh
@@ -2,4 +2,5 @@
 port=vttest
 version=20210210
 useconfigure=true
-files="https://invisible-island.net/datafiles/release/vttest.tar.gz vttest.tar.gz"
+files="https://invisible-island.net/datafiles/release/vttest.tar.gz vttest.tar.gz 21c7493640a7912ea746b3eb0689f2a7"
+auth_type=md5


### PR DESCRIPTION
Also adds a lint script to ensure all ports have `'port', 'version', 'files', 'auth_type'` properties.

This will eventually break any ports which use `master` branch from a git repository. Fortunately there's only a few of these. Also, these packages would have broken eventually anyway as the patches drift out of sync. They shouldn't have been using master in the first place, and instead used a known good and known safe version.
