### PR TITLE
CI: Use clang-12 instead of clang-10 when building fuzzers

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -182,7 +182,14 @@ jobs:
     # === OS SETUP ===
     #
     - name: Install Ubuntu dependencies
-      run: sudo apt-get install ninja-build
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main"
+        sudo apt-get purge -y clang-10
+        sudo apt-get update
+        sudo apt-get install clang-12 ninja-build
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 60
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 60
       if: ${{ runner.os == 'Linux' }}
     - name: Install macOS dependencies
       run: brew install ninja


### PR DESCRIPTION
oss-fuzz uses clang-12 anyway, so this patch shouldn't be breaking
anything, just letting us use more modern C++ without the CI being
sad.