### PR TITLE
Ports: SDL2: Use correct CMAKE_TOOLCHAIN_FILE in configopts

### DIFF
--- a/Ports/SDL2/package.sh
+++ b/Ports/SDL2/package.sh
@@ -5,7 +5,7 @@ workdir=SDL-main-serenity
 useconfigure=true
 files="https://github.com/SerenityOS/SDL/archive/main-serenity.tar.gz SDL2-git.tar.gz 18ce496be8644b0eb7fc4cad0d8dd5ff"
 auth_type=md5
-configopts="DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt -DPULSEAUDIO=OFF -DJACK=OFF"
+configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt -DPULSEAUDIO=OFF -DJACK=OFF"
 
 configure() {
     run cmake $configopts


### PR DESCRIPTION
My bad. I accidentally removed a `-` when resolving merge conflicts in a206ab2211d15cfdd27287b2e237e02eecee55a2.
