### PR TITLE
LibWeb: Fix misplaced bullet points on list items

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/ListItemBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemBox.cpp
@@ -56,7 +56,7 @@ void ListItemBox::layout_marker()
     }
 
     m_marker->set_offset(-8, 0);
-    m_marker->set_size(4, height());
+    m_marker->set_size(4, line_height());
 }
 
 }


### PR DESCRIPTION
The bullet point should not be centered in the height of the full list item, but rather stay in front of the first line.

This closes #6384