### PR TITLE
Kernel: Add `-Wnull-dereference` flag

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -298,7 +298,7 @@ set(SOURCES
     ${C_SOURCES}
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option -Wvla")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option -Wvla -Wnull-dereference")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pie -fPIE -fno-rtti -ffreestanding -fbuiltin")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-80387 -mno-mmx -mno-sse -mno-sse2")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-asynchronous-unwind-tables")


### PR DESCRIPTION
`-Wnull-dereference` has found a lot of "possible null dereferences" in userland.
However, in the kernel, no warnings occurred. To keep it that way,
preemptivly add the flag here and remove it once it is enabled system
wide.

This flag makes the compiler check statically for a null deref. It does
not take into account any human-imposed invariants and as such, may need a
`VERIFY(ptr);`, `if(ptr)`, or `if(!ptr)` before using a pointer.
However, as long as a pointer is not reassigned,
the verify will be valid, meaning that adding `VERIFY` can be done sparingly.

Work towards #5487 