### PR TITLE
LibJS: Accept symbol property in the `in` operator

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -1020,10 +1020,10 @@ Value in(GlobalObject& global_object, Value lhs, Value rhs)
         global_object.vm().throw_exception<TypeError>(global_object, ErrorType::InOperatorWithObject);
         return {};
     }
-    auto lhs_string = lhs.to_string(global_object);
+    auto lhs_string_or_symbol = StringOrSymbol::from_value(global_object, lhs);
     if (global_object.vm().exception())
         return {};
-    return Value(rhs.as_object().has_property(lhs_string));
+    return Value(rhs.as_object().has_property(lhs_string_or_symbol));
 }
 
 Value instance_of(GlobalObject& global_object, Value lhs, Value rhs)

--- a/Userland/Libraries/LibJS/Tests/operators/in-operator-basic.js
+++ b/Userland/Libraries/LibJS/Tests/operators/in-operator-basic.js
@@ -1,10 +1,12 @@
 test("in operator with objects", () => {
-    const o = { foo: "bar", bar: undefined };
+    const sym = Symbol();
+    const o = { foo: "bar", bar: undefined, [sym]: "qux" };
     expect("" in o).toBeFalse();
     expect("foo" in o).toBeTrue();
     expect("bar" in o).toBeTrue();
     expect("baz" in o).toBeFalse();
     expect("toString" in o).toBeTrue();
+    expect(sym in o).toBeTrue();
 });
 
 test("in operator with arrays", () => {


### PR DESCRIPTION
This is used by discord.com (Similar to #6364) and allowed by the specification: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
discord.com now progresses enough to crash the browser on a different bug instead of just rendering a mostly white page :^)