### PR TITLE
Utilities: Fix division by zero

### DIFF
--- a/Userland/Utilities/top.cpp
+++ b/Userland/Utilities/top.cpp
@@ -201,8 +201,8 @@ int main(int, char**)
             u32 times_scheduled_before = (*jt).value.times_scheduled;
             u32 times_scheduled_diff = times_scheduled_now - times_scheduled_before;
             it.value.times_scheduled_since_prev = times_scheduled_diff;
-            it.value.cpu_percent = ((times_scheduled_diff * 100) / sum_diff);
-            it.value.cpu_percent_decimal = (((times_scheduled_diff * 1000) / sum_diff) % 10);
+            it.value.cpu_percent = sum_diff > 0 ? ((times_scheduled_diff * 100) / sum_diff) : 0;
+            it.value.cpu_percent_decimal = sum_diff > 0 ? (((times_scheduled_diff * 1000) / sum_diff) % 10) : 0;
             threads.append(&it.value);
         }
 


### PR DESCRIPTION
top crashes when sum_diff is zero.

```
CrashDaemon(15): --- Backtrace for thread #0 (TID 3052) ---
CrashDaemon(15): 0x96537f56: [/bin/top] main +0x4f6 (top.cpp:204)
CrashDaemon(15): 0x96538138: [/bin/top] _start +0x58 (crt0.cpp:58)
```