### PR TITLE
Meta: Allow serenity.sh to be used outside of assumed working directory

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -104,8 +104,11 @@ create_build_dir() {
 
 cmd_with_target() {
     is_valid_target || ( >&2 echo "Unknown target: $TARGET"; usage )
-    SERENITY_ROOT="$(get_top_dir)"
-    export SERENITY_ROOT
+
+    if [ ! -d "$SERENITY_ROOT" ]; then
+        SERENITY_ROOT="$(get_top_dir)"
+        export SERENITY_ROOT
+    fi
     BUILD_DIR="$SERENITY_ROOT/Build/$TARGET"
     if [ "$TARGET" != "lagom" ]; then
         export SERENITY_ARCH="$TARGET"
@@ -136,7 +139,7 @@ delete_target() {
 }
 
 build_toolchain() {
-    ( cd Toolchain && ARCH="$TARGET" ./BuildIt.sh )
+    ( cd "$SERENITY_ROOT/Toolchain" && ARCH="$TARGET" ./BuildIt.sh )
 }
 
 ensure_toolchain() {


### PR DESCRIPTION
This change fixes two bugs:

1) If you run `serenity.sh` outside of your serenity git clone, the
   `get_top_dir()` function won't be able to auto detect the serenity
    root dir and we'll error out. By allowing the script to use an
    existing $SERENITY_ROOT vlaue if it exists, we can solve
    this problem.

2) If tried to run a command which ends up calling `build_toolchain()`
   and you were outside of the root of the project, it should just
   fail. Fix this by utilizing `$SERENITY_ROOT`.