### PR TITLE
LibGfx: Make top highlight of classic buttons fit to the top left corner

### DIFF
--- a/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
+++ b/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
@@ -147,8 +147,8 @@ static void paint_button_new(Painter& painter, const IntRect& a_rect, const Pale
         painter.fill_rect({ 0, 0, rect.width(), rect.height() }, button_color);
 
         // Top highlight
-        painter.draw_line({ 1, 1 }, { rect.width() - 3, 1 }, highlight_color);
-        painter.draw_line({ 1, 1 }, { 1, rect.height() - 3 }, highlight_color);
+        painter.draw_line({ 0, 0 }, { rect.width() - 2, 0 }, highlight_color);
+        painter.draw_line({ 0, 0 }, { 0, rect.height() - 2 }, highlight_color);
 
         // Outer shadow
         painter.draw_line({ 0, rect.height() - 1 }, { rect.width() - 1, rect.height() - 1 }, shadow_color2);


### PR DESCRIPTION
It didn't quite fit before:
![Screenshot from 2021-04-17 02-25-55](https://user-images.githubusercontent.com/25595356/115097840-6bbb2d00-9f24-11eb-9d9b-fc08f0627f76.png)

After:
![Screenshot from 2021-04-17 02-26-20](https://user-images.githubusercontent.com/25595356/115097843-6f4eb400-9f24-11eb-91bb-1419770b0a10.png)

