### PR TITLE
Kernel+LibCore+FileOperation: Copy files without kernel/userland copies

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -192,7 +192,8 @@ namespace Kernel {
     S(anon_create)            \
     S(msyscall)               \
     S(readv)                  \
-    S(emuctl)
+    S(emuctl)                 \
+    S(fdcopy)
 
 namespace Syscall {
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -146,6 +146,7 @@ set(KERNEL_SOURCES
     Syscalls/execve.cpp
     Syscalls/exit.cpp
     Syscalls/fcntl.cpp
+    Syscalls/fdcopy.cpp
     Syscalls/fork.cpp
     Syscalls/ftruncate.cpp
     Syscalls/futex.cpp

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -296,6 +296,7 @@ public:
     KResultOr<ssize_t> sys$readv(int fd, Userspace<const struct iovec*> iov, int iov_count);
     KResultOr<ssize_t> sys$write(int fd, Userspace<const u8*>, ssize_t);
     KResultOr<ssize_t> sys$writev(int fd, Userspace<const struct iovec*> iov, int iov_count);
+    KResultOr<ssize_t> sys$fdcopy(int srcfd, int dstfd, ssize_t count);
     KResultOr<int> sys$fstat(int fd, Userspace<stat*>);
     KResultOr<int> sys$stat(Userspace<const Syscall::SC_stat_params*>);
     KResultOr<int> sys$lseek(int fd, Userspace<off_t*>, int whence);

--- a/Kernel/Syscalls/fdcopy.cpp
+++ b/Kernel/Syscalls/fdcopy.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021, Leandro Pereira <leandro@tia.mat.br>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/StdLibExtras.h>
+#include <Kernel/Debug.h>
+#include <Kernel/FileSystem/FileDescription.h>
+#include <Kernel/Process.h>
+
+namespace Kernel {
+
+using BlockFlags = Thread::FileBlocker::BlockFlags;
+
+KResultOr<ssize_t> Process::sys$fdcopy(int srcfd, int dstfd, ssize_t count)
+{
+    REQUIRE_PROMISE(stdio);
+
+    if (count > (ssize_t)MiB)
+        count = MiB;
+    if (count < 0)
+        return EINVAL;
+
+    auto source_description = file_description(srcfd);
+    if (!source_description)
+        return EBADF;
+    if (!source_description->is_readable())
+        return EBADF;
+    if (source_description->is_directory())
+        return EISDIR;
+
+    auto destination_description = file_description(dstfd);
+    if (!destination_description)
+        return EBADF;
+    if (!destination_description->is_writable())
+        return EBADF;
+    if (destination_description->is_directory())
+        return EISDIR;
+
+    auto backing_buffer = KBuffer::try_create_with_size(AK::min((ssize_t)65536, count));
+    if (!backing_buffer)
+        return ENOMEM;
+
+    auto buffer = UserOrKernelBuffer::for_kernel_buffer(backing_buffer->data());
+
+    ssize_t bytes_copied = 0;
+
+    while (count) {
+        if (source_description->is_blocking() && !source_description->can_read()) {
+            auto unblock_flags = BlockFlags::None;
+            if (Thread::current()->block<Thread::ReadBlocker>({}, *source_description, unblock_flags).was_interrupted())
+                return EINTR;
+            if (!has_flag(unblock_flags, BlockFlags::Read))
+                return EAGAIN;
+        }
+
+        auto bytes_to_read = AK::min(backing_buffer->capacity(), (size_t)count);
+        auto read_result = source_description->read(buffer, bytes_to_read);
+        if (read_result.is_error())
+            return read_result.error();
+        if (!read_result.value())
+            break;
+
+        auto write_result = do_write(*destination_description, buffer, read_result.value());
+        if (write_result.is_error())
+            return write_result.error();
+
+        bytes_copied += (ssize_t)write_result.value();
+        count -= write_result.value();
+    }
+
+    return bytes_copied;
+}
+
+}

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -295,6 +295,12 @@ ssize_t write(int fd, const void* buf, size_t count)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+ssize_t fdcopy(int srcfd, int dstfd, size_t count)
+{
+    int rc = syscall(SC_fdcopy, srcfd, dstfd, count);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
 int ttyname_r(int fd, char* buffer, size_t size)
 {
     int rc = syscall(SC_ttyname, fd, buffer, size);

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -101,6 +101,7 @@ int tcsetpgrp(int fd, pid_t pgid);
 ssize_t read(int fd, void* buf, size_t count);
 ssize_t pread(int fd, void* buf, size_t count, off_t);
 ssize_t write(int fd, const void* buf, size_t count);
+ssize_t fdcopy(int srcfd, int dstfd, size_t count);
 int close(int fd);
 int chdir(const char* path);
 int fchdir(int fd);

--- a/Userland/Libraries/LibCore/IODevice.h
+++ b/Userland/Libraries/LibCore/IODevice.h
@@ -86,6 +86,8 @@ public:
     ByteBuffer read_all();
     String read_line(size_t max_size = 16384);
 
+    size_t copy_from(const IODevice& source, size_t buffer_size = 65536);
+
     bool write(const u8*, int size);
     bool write(const StringView&);
 

--- a/Userland/Libraries/LibCore/IODevice.h
+++ b/Userland/Libraries/LibCore/IODevice.h
@@ -72,6 +72,8 @@ public:
     unsigned mode() const { return m_mode; }
     bool is_open() const { return m_mode != NotOpen; }
     bool eof() const { return m_eof; }
+    bool is_readable() const { return mode() & OpenMode::ReadOnly; }
+    bool is_writable() const { return mode() & OpenMode::WriteOnly; }
 
     int error() const { return m_error; }
     const char* error_string() const;

--- a/Userland/Services/FileOperation/main.cpp
+++ b/Userland/Services/FileOperation/main.cpp
@@ -148,15 +148,17 @@ int perform_copy(const String& source, const String& destination)
 
         while (true) {
             print_progress();
-            auto buffer = source_file.read(65536);
-            if (buffer.is_null())
-                break;
-            if (!destination_file.write(buffer)) {
+
+            size_t copied = destination_file.copy_from(source_file);
+            if (destination_file.has_error()) {
                 warnln("Failed to write to destination file: {}", destination_file.error_string());
                 return 1;
             }
-            item_done += buffer.size();
-            bytes_copied_so_far += buffer.size();
+            if (copied == 0)
+                break;
+
+            item_done += copied;
+            bytes_copied_so_far += copied;
             print_progress();
             // FIXME: Remove this once the kernel is smart enough to schedule other threads
             //        while we're doing heavy I/O. Right now, copying a large file will totally


### PR DESCRIPTION
Introduce a new system call, `fdcopy(int srcfd, int dstfd, ssize_t count)`, to copy between file descriptors without passing through user mode.  With it, implement `IODevice::copy_from()` and use it in FileOperation to copy files.

Creating this as a draft as I'm not sure yet about the details of this interface, but this seems to be working just fine.