### PR TITLE
Ports: c-ray: Pin version to latest commit rather than use master branch

### DIFF
--- a/Ports/c-ray/package.sh
+++ b/Ports/c-ray/package.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=c-ray
-version=git
-workdir=c-ray-master
+version=c094d64570c30c70f4003e9428d31a2a0d9d3d41
 useconfigure=true
-files="https://github.com/vkoskiv/c-ray/archive/master.tar.gz c-ray-git.tar.gz 939b40cdb642b78a2b300b5b2981e337"
+files="https://github.com/vkoskiv/c-ray/archive/${version}.tar.gz ${version}.tar.gz b83e3c6a1462486257dfe38d309b47c2"
 auth_type=md5
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt"
 depends="SDL2"
+workdir="${port}-${version}"
 
 configure() {
     run cmake $configopts
@@ -14,5 +14,5 @@ configure() {
 
 install() {
 	mkdir -p "${SERENITY_BUILD_DIR}/Root/home/anon/c-ray"
-	cp -r c-ray-master/* "${SERENITY_BUILD_DIR}/Root/home/anon/c-ray"
+	cp -r "${port}-${version}"/* "${SERENITY_BUILD_DIR}/Root/home/anon/c-ray"
 }

--- a/Ports/c-ray/patches/replace-micro-symbol.patch
+++ b/Ports/c-ray/patches/replace-micro-symbol.patch
@@ -1,9 +1,8 @@
---- c-ray-master/src/renderer/renderer.c	2021-03-13 22:08:24.699323180 +0100
-+++ c-ray-master/src/renderer/renderer.c	2021-03-13 22:08:53.513237904 +0100
-@@ -108,7 +108,7 @@
- 			float sps = (1000000.0f/usPerRay) * r->prefs.threadCount;
++++ c-ray-master/src/renderer/renderer.c	2021-04-16 13:21:09.364524790 -0700
+@@ -138,7 +138,7 @@
+ 			float sps = (1000000.0f / usPerRay) * (r->prefs.threadCount + remoteThreads);
  			char rem[64];
- 			smartTime((msecTillFinished) / r->prefs.threadCount, rem);
+ 			smartTime((msecTillFinished) / (r->prefs.threadCount + remoteThreads), rem);
 -			logr(info, "[%s%.0f%%%s] μs/path: %.02f, etf: %s, %.02lfMs/s %s        \r",
 +			logr(info, "[%s%.0f%%%s] us/path: %.02f, etf: %s, %.02lfMs/s %s        \r",
  				 KBLU,


### PR DESCRIPTION
Prior to this PR, the port is broken due to code rot. The `replace-micro-symbol.patch` patch no longer applies.
