### PR TITLE
Kernel+LibC: Update struct stat to use struct timespec instead of time_t

### DIFF
--- a/Kernel/FileSystem/InodeMetadata.h
+++ b/Kernel/FileSystem/InodeMetadata.h
@@ -117,9 +117,12 @@ struct InodeMetadata {
         buffer.st_size = size;
         buffer.st_blksize = block_size;
         buffer.st_blocks = block_count;
-        buffer.st_atime = atime;
-        buffer.st_mtime = mtime;
-        buffer.st_ctime = ctime;
+        buffer.st_atim.tv_sec = atime;
+        buffer.st_atim.tv_nsec = 0;
+        buffer.st_mtim.tv_sec = mtime;
+        buffer.st_mtim.tv_nsec = 0;
+        buffer.st_ctim.tv_sec = ctime;
+        buffer.st_ctim.tv_nsec = 0;
         return KSuccess;
     }
 

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -451,20 +451,25 @@ struct termios {
     speed_t c_ospeed;
 };
 
+struct timespec {
+    time_t tv_sec; /* Seconds */
+    long tv_nsec;  /* Nanoseconds */
+};
+
 struct stat {
-    dev_t st_dev;         /* ID of device containing file */
-    ino_t st_ino;         /* inode number */
-    mode_t st_mode;       /* protection */
-    nlink_t st_nlink;     /* number of hard links */
-    uid_t st_uid;         /* user ID of owner */
-    gid_t st_gid;         /* group ID of owner */
-    dev_t st_rdev;        /* device ID (if special file) */
-    off_t st_size;        /* total size, in bytes */
-    blksize_t st_blksize; /* blocksize for file system I/O */
-    blkcnt_t st_blocks;   /* number of 512B blocks allocated */
-    time_t st_atime;      /* time of last access */
-    time_t st_mtime;      /* time of last modification */
-    time_t st_ctime;      /* time of last status change */
+    dev_t st_dev;            /* ID of device containing file */
+    ino_t st_ino;            /* inode number */
+    mode_t st_mode;          /* protection */
+    nlink_t st_nlink;        /* number of hard links */
+    uid_t st_uid;            /* user ID of owner */
+    gid_t st_gid;            /* group ID of owner */
+    dev_t st_rdev;           /* device ID (if special file) */
+    off_t st_size;           /* total size, in bytes */
+    blksize_t st_blksize;    /* blocksize for file system I/O */
+    blkcnt_t st_blocks;      /* number of 512B blocks allocated */
+    struct timespec st_atim; /* time of last access */
+    struct timespec st_mtim; /* time of last modification */
+    struct timespec st_ctim; /* time of last status change */
 };
 
 #define POLLIN (1u << 0)
@@ -573,11 +578,6 @@ typedef i32 suseconds_t;
 struct timeval {
     time_t tv_sec;
     suseconds_t tv_usec;
-};
-
-struct timespec {
-    time_t tv_sec;
-    long tv_nsec;
 };
 
 typedef enum {

--- a/Userland/Libraries/LibC/sys/stat.h
+++ b/Userland/Libraries/LibC/sys/stat.h
@@ -28,6 +28,7 @@
 
 #include <sys/cdefs.h>
 #include <sys/types.h>
+#include <time.h>
 
 __BEGIN_DECLS
 
@@ -69,20 +70,24 @@ __BEGIN_DECLS
 #define S_ISSOCK(m) (((m)&S_IFMT) == S_IFSOCK)
 
 struct stat {
-    dev_t st_dev;         /* ID of device containing file */
-    ino_t st_ino;         /* inode number */
-    mode_t st_mode;       /* protection */
-    nlink_t st_nlink;     /* number of hard links */
-    uid_t st_uid;         /* user ID of owner */
-    gid_t st_gid;         /* group ID of owner */
-    dev_t st_rdev;        /* device ID (if special file) */
-    off_t st_size;        /* total size, in bytes */
-    blksize_t st_blksize; /* blocksize for file system I/O */
-    blkcnt_t st_blocks;   /* number of 512B blocks allocated */
-    time_t st_atime;      /* time of last access */
-    time_t st_mtime;      /* time of last modification */
-    time_t st_ctime;      /* time of last status change */
+    dev_t st_dev;            /* ID of device containing file */
+    ino_t st_ino;            /* inode number */
+    mode_t st_mode;          /* protection */
+    nlink_t st_nlink;        /* number of hard links */
+    uid_t st_uid;            /* user ID of owner */
+    gid_t st_gid;            /* group ID of owner */
+    dev_t st_rdev;           /* device ID (if special file) */
+    off_t st_size;           /* total size, in bytes */
+    blksize_t st_blksize;    /* blocksize for file system I/O */
+    blkcnt_t st_blocks;      /* number of 512B blocks allocated */
+    struct timespec st_atim; /* time of last access */
+    struct timespec st_mtim; /* time of last modification */
+    struct timespec st_ctim; /* time of last status change */
 };
+
+#define st_atime st_atim.tv_sec
+#define st_mtime st_mtim.tv_sec
+#define st_ctime st_ctim.tv_sec
 
 mode_t umask(mode_t);
 int chmod(const char* pathname, mode_t);


### PR DESCRIPTION
Some programs unconditionally expect `struct stat` to have nanosecond support. This adds support for that.