### PR TITLE
Ports: vim: Pin version to latest release rather than use master branch

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -106,7 +106,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`tinycc`](tinycc/)            | Tiny C Compiler (TinyCC)                      | dev               | https://github.com/TinyCC/tinycc                      |
 | [`tinyscheme`](tinyscheme/)    | TinyScheme Interpreter                        | 1.42              | https://sourceforge.net/projects/tinyscheme/          |
 | [`tr`](tr/)                    | tr (OpenBSD)                                  | 6.7               | https://github.com/ibara/libpuffy                     |
-| [`vim`](vim/)                  | Vim                                           |                   | https://www.vim.org/                                  |
+| [`vim`](vim/)                  | Vim                                           | 8.2.2772          | https://www.vim.org/                                  |
 | [`vitetris`](vitetris/)        | vitetris                                      | 0.59.1            | https://github.com/vicgeralds/vitetris                |
 | [`vttest`](vttest/)            | vttest                                        | 20210210          | https://invisible-island.net/vttest/                  |
 | [`yasm`](yasm/)                | Yasm Modular Assembler                        | 1.3.0             | https://yasm.tortall.net/                             |

--- a/Ports/vim/package.sh
+++ b/Ports/vim/package.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=vim
-version=git
-workdir=vim-master
+version=8.2.2772
+workdir="${port}-${version}"
 useconfigure="true"
-files="https://github.com/vim/vim/archive/master.tar.gz vim-git.tar.gz 9f999815c6afc320612d55f93f0db67b"
+files="https://github.com/vim/vim/archive/refs/tags/v${version}.tar.gz vim-v${version}.tar.gz 0dbd7323008c1d95d0396e119210630f"
 auth_type=md5
 configopts="--with-tlib=tinfo --with-features=normal"
 depends="ncurses"


### PR DESCRIPTION
Perhaps controversial. We don't ship any patches for this version of `vim`.

It is nice to know the version we ship is safe and has been tested.
