### PR TITLE
DHCPClient: Fix undefined behaviour when calling memcpy()

### DIFF
--- a/Userland/Services/DHCPClient/DHCPv4.h
+++ b/Userland/Services/DHCPClient/DHCPv4.h
@@ -277,7 +277,8 @@ public:
         options[next_option_offset++] = (u8)option;
         memcpy(options + next_option_offset, &length, 1);
         next_option_offset++;
-        memcpy(options + next_option_offset, data, length);
+        if (data && length)
+            memcpy(options + next_option_offset, data, length);
         next_option_offset += length;
     }
 


### PR DESCRIPTION
Hi, I found a suspicious code while reading the sources.

Calling `memcpy` with null pointers results in undefined behaviour, even if count is zero (see: https://en.cppreference.com/w/cpp/string/byte/memcpy). The `data == nullptr` is passed to this method [from here](https://github.com/SerenityOS/serenity/tree/5c1da19eb6dd2a48aea64ade6c31817e97cf8836/Userland/Services/DHCPClient/DHCPv4.h#L290). At the moment, this UB does not affect anything, but I think it is better to fix it to avoid problems in the future.

The problem is this `memcpy` call is exploited by GCC. For example, the following code:
```cpp
    memcpy (dst, src, n);
    if (!src)
      return;
    src[0] = 0xcafe;
```
will be optimized as:
```cpp
    memcpy (dst, src, n);
    src[0] = 0xcafe;
```
IOW the test for null is gone.