### PR TITLE
LibC+LibPthread: Make atexit handlers thread-safe and destroy TLS keys after everything else

### DIFF
--- a/Userland/Libraries/LibC/cxxabi.cpp
+++ b/Userland/Libraries/LibC/cxxabi.cpp
@@ -26,6 +26,7 @@
 
 #include <AK/Debug.h>
 #include <AK/Format.h>
+#include <LibC/bits/pthread_integration.h>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -46,6 +47,7 @@ static constexpr size_t max_atexit_entry_count = PAGE_SIZE / sizeof(AtExitEntry)
 
 static AtExitEntry* atexit_entries;
 static size_t atexit_entry_count = 0;
+static pthread_mutex_t atexit_mutex = __PTHREAD_MUTEX_INITIALIZER;
 
 static void lock_atexit_handlers()
 {
@@ -65,12 +67,17 @@ static void unlock_atexit_handlers()
 
 int __cxa_atexit(AtExitFunction exit_function, void* parameter, void* dso_handle)
 {
-    if (atexit_entry_count >= max_atexit_entry_count)
+    __pthread_mutex_lock(&atexit_mutex);
+
+    if (atexit_entry_count >= max_atexit_entry_count) {
+        __pthread_mutex_unlock(&atexit_mutex);
         return -1;
+    }
 
     if (!atexit_entries) {
         atexit_entries = (AtExitEntry*)mmap(nullptr, PAGE_SIZE, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
         if (atexit_entries == MAP_FAILED) {
+            __pthread_mutex_unlock(&atexit_mutex);
             perror("__cxa_atexit mmap");
             _exit(1);
         }
@@ -79,6 +86,8 @@ int __cxa_atexit(AtExitFunction exit_function, void* parameter, void* dso_handle
     unlock_atexit_handlers();
     atexit_entries[atexit_entry_count++] = { exit_function, parameter, dso_handle, false };
     lock_atexit_handlers();
+
+    __pthread_mutex_unlock(&atexit_mutex);
 
     return 0;
 }
@@ -92,6 +101,8 @@ void __cxa_finalize(void* dso_handle)
     // Multiple calls to __cxa_finalize shall not result in calling termination function entries multiple times;
     // the implementation may either remove entries or mark them finished.
 
+    __pthread_mutex_lock(&atexit_mutex);
+
     ssize_t entry_index = atexit_entry_count;
 
     dbgln_if(GLOBAL_DTORS_DEBUG, "__cxa_finalize: {} entries in the finalizer list", entry_index);
@@ -104,9 +115,13 @@ void __cxa_finalize(void* dso_handle)
             unlock_atexit_handlers();
             exit_entry.has_been_called = true;
             lock_atexit_handlers();
+            __pthread_mutex_unlock(&atexit_mutex);
             exit_entry.method(exit_entry.parameter);
+            __pthread_mutex_lock(&atexit_mutex);
         }
     }
+
+    __pthread_mutex_unlock(&atexit_mutex);
 }
 
 [[noreturn]] void __cxa_pure_virtual()

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -31,6 +31,7 @@
 #include <AK/Types.h>
 #include <AK/Utf8View.h>
 #include <LibELF/AuxiliaryVector.h>
+#include <LibPthread/pthread.h>
 #include <alloca.h>
 #include <assert.h>
 #include <ctype.h>
@@ -47,6 +48,8 @@
 #include <sys/wait.h>
 #include <syscall.h>
 #include <unistd.h>
+
+void (*__libc_pthread_key_destroy_for_current_thread)() = nullptr;
 
 static void strtons(const char* str, char** endptr)
 {
@@ -224,6 +227,10 @@ void exit(int status)
     _fini();
     fflush(stdout);
     fflush(stderr);
+
+    if (__libc_pthread_key_destroy_for_current_thread)
+        __libc_pthread_key_destroy_for_current_thread();
+
     _exit(status);
 }
 

--- a/Userland/Libraries/LibPthread/pthread.h
+++ b/Userland/Libraries/LibPthread/pthread.h
@@ -146,4 +146,6 @@ int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
 
 int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void));
 
+void __pthread_key_destroy_for_current_thread();
+
 __END_DECLS


### PR DESCRIPTION
This PR fixes two things related to thread support in LibC:

* Registration and invocation of atexit handlers is now thread-safe.
* TLS keys are destroyed after everything else. Previously they were an ordinary destructor (in the `[[gnu::destructor]]` sense) and the order those run in is not deterministic, i.e. you could end up with TLS keys getting destroyed before another destructor then did something with TLS variables. Even something as simple as `pthread_mutex_unlock` in a destructor would crash because `pthread_mutex_unlock` calls `pthread_self` which then calls `gettid` and which finally accesses a TLS variable.