### PR TITLE
LibLine: ^X^E - edit in external editor

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -62,6 +62,7 @@ Configuration Configuration::from_config(const StringView& libname)
     // Read behaviour options.
     auto refresh = config_file->read_entry("behaviour", "refresh", "lazy");
     auto operation = config_file->read_entry("behaviour", "operation_mode");
+    auto default_text_editor = config_file->read_entry("behaviour", "default_text_editor");
 
     if (refresh.equals_ignoring_case("lazy"))
         configuration.set(Configuration::Lazy);
@@ -76,6 +77,11 @@ Configuration Configuration::from_config(const StringView& libname)
         configuration.set(Configuration::OperationMode::NonInteractive);
     else
         configuration.set(Configuration::OperationMode::Unset);
+
+    if (!default_text_editor.is_empty())
+        configuration.set(DefaultTextEditor { move(default_text_editor) });
+    else
+        configuration.set(DefaultTextEditor { "/bin/TextEditor" });
 
     // Read keybinds.
 
@@ -167,6 +173,9 @@ void Editor::set_default_keybinds()
     register_key_input_callback(ctrl('R'), EDITOR_INTERNAL_FUNCTION(enter_search));
     register_key_input_callback(ctrl('T'), EDITOR_INTERNAL_FUNCTION(transpose_characters));
     register_key_input_callback('\n', EDITOR_INTERNAL_FUNCTION(finish));
+
+    // ^X^E: Edit in external editor
+    register_key_input_callback(Vector<Key> { ctrl('X'), ctrl('E') }, EDITOR_INTERNAL_FUNCTION(edit_in_external_editor));
 
     // ^[.: alt-.: insert last arg of previous command (similar to `!$`)
     register_key_input_callback(Key { '.', Key::Alt }, EDITOR_INTERNAL_FUNCTION(insert_last_words));

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -81,6 +81,10 @@ struct Configuration {
         NoSignalHandlers,
     };
 
+    struct DefaultTextEditor {
+        String command;
+    };
+
     Configuration()
     {
     }
@@ -96,6 +100,7 @@ struct Configuration {
     void set(OperationMode mode) { operation_mode = mode; }
     void set(SignalHandler mode) { m_signal_mode = mode; }
     void set(const KeyBinding& binding) { keybindings.append(binding); }
+    void set(DefaultTextEditor editor) { m_default_text_editor = move(editor.command); }
 
     static Configuration from_config(const StringView& libname = "line");
 
@@ -103,6 +108,7 @@ struct Configuration {
     SignalHandler m_signal_mode { SignalHandler::WithSignalHandlers };
     OperationMode operation_mode { OperationMode::Unset };
     Vector<KeyBinding> keybindings;
+    String m_default_text_editor {};
 };
 
 #define ENUMERATE_EDITOR_INTERNAL_FUNCTIONS(M) \
@@ -130,7 +136,8 @@ struct Configuration {
     M(erase_alnum_word_forwards)               \
     M(capitalize_word)                         \
     M(lowercase_word)                          \
-    M(uppercase_word)
+    M(uppercase_word)                          \
+    M(edit_in_external_editor)
 
 #define EDITOR_INTERNAL_FUNCTION(name) \
     [](auto& editor) { editor.name();  return false; }


### PR DESCRIPTION
Adds support for ^X^E, not sure how we've been living without this so far!

Also fixes a dumb case where LibLine would miss a WINCH signal while another program is in the foreground.
It can be reproduced like so (prior to the changes in this PR)
- `$ te`
- resize the terminal while `te` is running
- close `te`
- now the shell doesn't know that the terminal size has changed