### PR TITLE
Kernel: Add boot argument to disable the UHCI Controller

### DIFF
--- a/Documentation/NetworkBoot.md
+++ b/Documentation/NetworkBoot.md
@@ -166,8 +166,12 @@ boot
 This file can be called in any name you'd want. For the sake of simplicity in this guide,
 this file is named `script.ipxe` from now on.
 Don't forget to replace `X.Y.Z.W` with your HTTP server IP address.
-For troubleshooting purposes, you could add `disable_physical_storage` and `disable_ps2_controller` 
-if you suspect our implementation fails to work with your hardware. 
+
+For troubleshooting purposes, you can add the following command line arguments if you suspect our implementation fails to work with your hardware:
+- `disable_physical_storage`
+- `disable_ps2_controller`
+- `disable_uhci_controller`
+
 Because iPXE (unlike GRUB) doesn't support VESA VBE modesetting when booting a multiboot kernel,
 you might not see any output, so add the `boot_mode=text` argument as well to boot into VGA text mode.
 

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -165,6 +165,11 @@ UNMAP_AFTER_INIT bool CommandLine::disable_physical_storage() const
     return contains("disable_physical_storage");
 }
 
+UNMAP_AFTER_INIT bool CommandLine::disable_uhci_controller() const
+{
+    return contains("disable_uhci_controller");
+}
+
 UNMAP_AFTER_INIT AHCIResetMode CommandLine::ahci_reset_mode() const
 {
     const auto ahci_reset_mode = lookup("ahci_reset_mode").value_or("controller");

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -86,6 +86,7 @@ public:
     [[nodiscard]] HPETMode hpet_mode() const;
     [[nodiscard]] bool disable_physical_storage() const;
     [[nodiscard]] bool disable_ps2_controller() const;
+    [[nodiscard]] bool disable_uhci_controller() const;
     [[nodiscard]] AHCIResetMode ahci_reset_mode() const;
     [[nodiscard]] String userspace_init() const;
     [[nodiscard]] Vector<String> userspace_init_args() const;

--- a/Kernel/Devices/USB/UHCIController.cpp
+++ b/Kernel/Devices/USB/UHCIController.cpp
@@ -26,7 +26,7 @@
  */
 
 #include <AK/Platform.h>
-
+#include <Kernel/CommandLine.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Devices/USB/UHCIController.h>
 #include <Kernel/Process.h>
@@ -89,6 +89,9 @@ UHCIController& UHCIController::the()
 
 UNMAP_AFTER_INIT void UHCIController::detect()
 {
+    if (kernel_command_line().disable_uhci_controller())
+        return;
+
     PCI::enumerate([&](const PCI::Address& address, PCI::ID id) {
         if (address.is_null())
             return;


### PR DESCRIPTION
Helps with bare metal debugging, as we can't be sure our implementation
will work with a given machine.

As reported by someone on Discord, their machine hangs when we attempt
the dummy transfer.