### PR TITLE
Browser: Display full UserAgent string in status bar on menu hover

### DIFF
--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -67,6 +67,9 @@ public:
     void did_become_active();
     void context_menu_requested(const Gfx::IntPoint& screen_position);
 
+    void action_entered(GUI::Action&);
+    void action_left(GUI::Action&);
+
     Function<void(String)> on_title_change;
     Function<void(const URL&)> on_tab_open_request;
     Function<void(Tab&)> on_tab_close_request;

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -248,6 +248,20 @@ int main(int argc, char** argv)
         }
     }
 
+    app->on_action_enter = [&](GUI::Action& action) {
+        auto* tab = static_cast<Browser::Tab*>(tab_widget.active_widget());
+        if (!tab)
+            return;
+        tab->action_entered(action);
+    };
+
+    app->on_action_leave = [&](auto& action) {
+        auto* tab = static_cast<Browser::Tab*>(tab_widget.active_widget());
+        if (!tab)
+            return;
+        tab->action_left(action);
+    };
+
     window_actions.on_create_new_tab = [&] {
         create_new_tab(Browser::g_home_url, true);
     };


### PR DESCRIPTION
This uses the new on_action_enter & on_action_leave APIs to display the full useragent string when hovering over one of the useragent spoof menu options.

![image](https://user-images.githubusercontent.com/16208640/115125673-76340000-9fd2-11eb-8b8b-2bfefbe5f004.png)
