### PR TITLE
Shell: Add a posix sh compatablilty mode.

### DIFF
--- a/Base/etc/passwd
+++ b/Base/etc/passwd
@@ -1,4 +1,4 @@
-root::0:0:root:/root:/bin/sh
+root::0:0:root:/root:/bin/Shell
 lookup:!:10:10:LookupServer,,,:/:/bin/false
 protocol:!:11:11:ProtocolServer,,,:/:/bin/false
 notify:!:12:12:NotificationServer,,,:/:/bin/false
@@ -7,5 +7,5 @@ clipboard:!:14:14:Clipboard,,,:/:/bin/false
 webcontent:!:15:15:WebContent,,,:/:/bin/false
 image:!:16:16:ImageDecoder,,,:/:/bin/false
 symbol:!:17:17:SymbolServer,,,:/:/bin/false
-anon:!:100:100:Anonymous,,,:/home/anon:/bin/sh
-nona:!:200:200:Nona,,,:/home/nona:/bin/sh
+anon:!:100:100:Anonymous,,,:/home/anon:/bin/Shell
+nona:!:200:200:Nona,,,:/home/nona:/bin/Shell

--- a/Base/home/anon/.shellrc
+++ b/Base/home/anon/.shellrc
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 # IFS controls what $(...) (inline evaluate) would split its captured
 # string with. the default is \x0a (i.e. newline).

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -166,9 +166,14 @@ if (BUILD_LAGOM)
 
         foreach(TEST_PATH ${SHELL_TESTS})
             get_filename_component(TEST_NAME ${TEST_PATH} NAME_WE)
+            if(${TEST_NAME} MATCHES "posix")
+                set(SHELL_ARGS "--posix-mode")
+            else()
+                set(SHELL_ARGS "")
+            endif()
             add_test(
                 NAME "Shell-${TEST_NAME}"
-                COMMAND shell_lagom --skip-shellrc "${TEST_PATH}"
+                COMMAND shell_lagom --skip-shellrc ${SHELL_ARGS} "${TEST_PATH}"
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../Userland/Shell/Tests
             )
             set_tests_properties("Shell-${TEST_NAME}" PROPERTIES

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -23,7 +23,7 @@ disk_usage() {
     expr "$(du -sk "$1" | cut -f1)" / 1024
 }
 
-DISK_SIZE=$(($(disk_usage "$SERENITY_ROOT/Base") + $(disk_usage Root) + 100))
+DISK_SIZE=$(($(disk_usage "$SERENITY_ROOT/Base") + $(disk_usage Root) + 1000))
 
 echo "setting up disk image..."
 qemu-img create _disk_image "${DISK_SIZE:-600}"m || die "could not create disk image"
@@ -96,7 +96,7 @@ if [ $use_genext2fs = 1 ]; then
     # genext2fs is very slow in generating big images, so I use a smaller image here. size can be updated
     # if it's not enough.
     # not using "-i 128" since it hangs. Serenity handles whatever default this uses instead.
-    genext2fs -b 250000 -d mnt _disk_image || die "try increasing image size (genext2fs -b)"
+    genext2fs -b 1500000 -d mnt _disk_image || die "try increasing image size (genext2fs -b)"
     # if using docker with shared mount, file is created as root, so make it writable for users
     chmod 0666 _disk_image
 fi

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -1441,7 +1441,7 @@ RefPtr<Value> HistoryEvent::run(RefPtr<Shell> shell)
     }
 
     // Then, split it up to "words".
-    auto nodes = Parser { resolved_history }.parse_as_multiple_expressions();
+    auto nodes = Parser { resolved_history, shell->options }.parse_as_multiple_expressions();
 
     // Now take the "words" as described by the word selectors.
     bool is_range = m_selector.word_selector_range.end.has_value();

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -47,7 +47,7 @@ int Shell::builtin_dump(int argc, const char** argv)
     if (argc != 2)
         return 1;
 
-    Parser { argv[1] }.parse()->dump(0);
+    Parser { argv[1], options }.parse()->dump(0);
     return 0;
 }
 

--- a/Userland/Shell/Formatter.cpp
+++ b/Userland/Shell/Formatter.cpp
@@ -34,7 +34,7 @@ namespace Shell {
 
 String Formatter::format()
 {
-    auto node = m_root_node ? m_root_node : Parser(m_source).parse();
+    auto node = m_root_node ? m_root_node : Parser(m_source, m_shell_options).parse();
     if (m_cursor >= 0)
         m_output_cursor = m_cursor;
 

--- a/Userland/Shell/Formatter.h
+++ b/Userland/Shell/Formatter.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "NodeVisitor.h"
+#include "Options.h"
 #include <AK/Forward.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
@@ -37,10 +38,11 @@ namespace Shell {
 
 class Formatter final : public AST::NodeVisitor {
 public:
-    Formatter(const StringView& source, ssize_t cursor = -1)
+    Formatter(const StringView& source, Options shell_options, ssize_t cursor = -1)
         : m_builder(round_up_to_power_of_two(source.length(), 16))
         , m_source(source)
         , m_cursor(cursor)
+        , m_shell_options(shell_options)
     {
         size_t offset = 0;
         for (auto ptr = m_source.end() - 1; ptr >= m_source.begin() && isspace(*ptr); --ptr)
@@ -113,7 +115,7 @@ private:
 
     StringBuilder& current_builder() { return m_builder; }
 
-    struct Options {
+    struct {
         size_t max_line_length_hint { 80 };
         bool explicit_parentheses { false };
         bool explicit_braces { false };
@@ -134,6 +136,8 @@ private:
     const AST::Node* m_last_visited_node { nullptr };
 
     StringView m_trivia;
+
+    Options m_shell_options;
 };
 
 }

--- a/Userland/Shell/Options.h
+++ b/Userland/Shell/Options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2021, The SerenityOS developers.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,31 +26,20 @@
 
 #pragma once
 
-#include "Options.h"
-#include <LibSyntax/Highlighter.h>
+#define ENUMERATE_SHELL_OPTIONS()                                                                                    \
+    __ENUMERATE_SHELL_OPTION(inline_exec_keep_empty_segments, false, "Keep empty segments in inline execute $(...)") \
+    __ENUMERATE_SHELL_OPTION(verbose, false, "Announce every command that is about to be executed")                  \
+    __ENUMERATE_SHELL_OPTION(posix_mode, false, "Enable POSIX Bourne shell compatibility mode")
 
 namespace Shell {
 
-class SyntaxHighlighter : public Syntax::Highlighter {
-public:
-    SyntaxHighlighter(Options shell_options)
-        : m_shell_options(shell_options)
-    {
-    }
-    virtual ~SyntaxHighlighter() override;
+#define __ENUMERATE_SHELL_OPTION(name, default_, description) \
+    bool name { default_ };
 
-    virtual bool is_identifier(void*) const override;
-    virtual bool is_navigatable(void*) const override;
-
-    virtual Syntax::Language language() const override { return Syntax::Language::Shell; }
-    virtual void rehighlight(const Palette&) override;
-
-protected:
-    virtual Vector<MatchingTokenPair> matching_token_pairs() const override;
-    virtual bool token_types_equal(void*, void*) const override;
-
-private:
-    Options m_shell_options;
+struct Options {
+    ENUMERATE_SHELL_OPTIONS();
 };
+
+#undef __ENUMERATE_SHELL_OPTION
 
 }

--- a/Userland/Shell/Parser.h
+++ b/Userland/Shell/Parser.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "AST.h"
+#include "Options.h"
 #include <AK/Function.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
@@ -37,9 +38,10 @@ namespace Shell {
 
 class Parser {
 public:
-    Parser(StringView input, bool interactive = false)
+    Parser(StringView input, Options options, bool interactive = false)
         : m_input(move(input))
         , m_in_interactive_mode(interactive)
+        , m_options(options)
     {
     }
 
@@ -168,6 +170,7 @@ private:
     bool m_is_in_brace_expansion_spec { false };
     bool m_continuation_controls_allowed { false };
     bool m_in_interactive_mode { false };
+    Options m_options;
 };
 
 #if 0

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -70,7 +70,8 @@
 
 #define ENUMERATE_SHELL_OPTIONS()                                                                                    \
     __ENUMERATE_SHELL_OPTION(inline_exec_keep_empty_segments, false, "Keep empty segments in inline execute $(...)") \
-    __ENUMERATE_SHELL_OPTION(verbose, false, "Announce every command that is about to be executed")
+    __ENUMERATE_SHELL_OPTION(verbose, false, "Announce every command that is about to be executed")                  \
+    __ENUMERATE_SHELL_OPTION(posix_mode, false, "Enable POSIX Bourne shell compatibility mode")
 
 #define ENUMERATE_SHELL_IMMEDIATE_FUNCTIONS()           \
     __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(concat_lists)  \

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "Job.h"
+#include "Options.h"
 #include "Parser.h"
 #include <AK/CircularQueue.h>
 #include <AK/HashMap.h>
@@ -67,11 +68,6 @@
     __ENUMERATE_SHELL_BUILTIN(bg)      \
     __ENUMERATE_SHELL_BUILTIN(wait)    \
     __ENUMERATE_SHELL_BUILTIN(dump)
-
-#define ENUMERATE_SHELL_OPTIONS()                                                                                    \
-    __ENUMERATE_SHELL_OPTION(inline_exec_keep_empty_segments, false, "Keep empty segments in inline execute $(...)") \
-    __ENUMERATE_SHELL_OPTION(verbose, false, "Announce every command that is about to be executed")                  \
-    __ENUMERATE_SHELL_OPTION(posix_mode, false, "Enable POSIX Bourne shell compatibility mode")
 
 #define ENUMERATE_SHELL_IMMEDIATE_FUNCTIONS()           \
     __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(concat_lists)  \
@@ -269,14 +265,7 @@ public:
         }
     }
 
-#define __ENUMERATE_SHELL_OPTION(name, default_, description) \
-    bool name { default_ };
-
-    struct Options {
-        ENUMERATE_SHELL_OPTIONS();
-    } options;
-
-#undef __ENUMERATE_SHELL_OPTION
+    struct Options options;
 
 private:
     Shell(Line::Editor&, bool attempt_interactive);

--- a/Userland/Shell/SyntaxHighlighter.cpp
+++ b/Userland/Shell/SyntaxHighlighter.cpp
@@ -554,7 +554,7 @@ void SyntaxHighlighter::rehighlight(const Palette& palette)
 {
     auto text = m_client->get_text();
 
-    Parser parser(text);
+    Parser parser(text, m_shell_options);
     auto ast = parser.parse();
 
     Vector<GUI::TextDocumentSpan> spans;

--- a/Userland/Shell/Tests/brace-exp.sh
+++ b/Userland/Shell/Tests/brace-exp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/builtin-redir.sh
+++ b/Userland/Shell/Tests/builtin-redir.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/builtin-test.sh
+++ b/Userland/Shell/Tests/builtin-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/control-structure-as-command.sh
+++ b/Userland/Shell/Tests/control-structure-as-command.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/function.sh
+++ b/Userland/Shell/Tests/function.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/if.sh
+++ b/Userland/Shell/Tests/if.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/immediate.sh
+++ b/Userland/Shell/Tests/immediate.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/loop.sh
+++ b/Userland/Shell/Tests/loop.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/posix.sh
+++ b/Userland/Shell/Tests/posix.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+### IF STATEMENT
+
+if false
+then
+    fail "if false runs false branch"
+fi
+
+# then on other line
+if true
+then
+else
+    fail "if true runs false branch"
+fi
+
+
+if false
+
+then
+    fail "if false runs true branch"
+else
+fi
+
+# stuff on the same line
+if true; then
+else fail "if true runs false branch"; fi
+
+if false; then fail "if false runs true branch";
+else
+fi
+
+# elif
+
+if false; then
+    fail "if false runs true branch"
+elif true
+then
+else
+    fail "elif true runs false branch"
+fi
+
+if false; then
+    fail "if false runs true branch"
+elif false
+then
+    fail "elif true runs false branch"
+else
+fi
+
+echo PASS

--- a/Userland/Shell/Tests/sigpipe.sh
+++ b/Userland/Shell/Tests/sigpipe.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/slice.sh
+++ b/Userland/Shell/Tests/slice.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/special-vars.sh
+++ b/Userland/Shell/Tests/special-vars.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/subshell.sh
+++ b/Userland/Shell/Tests/subshell.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/Tests/valid.sh
+++ b/Userland/Shell/Tests/valid.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/Shell
 
 source $(dirname "$0")/test-commons.inc
 

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -71,6 +71,11 @@ int main(int argc, char** argv)
     RefPtr<::Shell::Shell> shell;
     bool attempt_interactive = false;
 
+    bool posix_mode = false;
+
+    if (StringView("/bin/sh") == argv[0] || StringView("sh") == argv[0])
+        posix_mode = true;
+
     auto initialize = [&] {
         editor = Line::Editor::construct();
         editor->initialize();
@@ -79,6 +84,7 @@ int main(int argc, char** argv)
         s_shell = shell.ptr();
 
         s_shell->setup_signals();
+        s_shell->options.posix_mode = posix_mode;
 
 #ifndef __serenity__
         sigset_t blocked;
@@ -119,6 +125,7 @@ int main(int argc, char** argv)
     parser.add_option(skip_rc_files, "Skip running shellrc files", "skip-shellrc", 0);
     parser.add_option(format, "Format the given file into stdout and exit", "format", 0, "file");
     parser.add_option(should_format_live, "Enable live formatting", "live-formatting", 'f');
+    parser.add_option(posix_mode, "Enable POSIX Bourne shell compatibility mode", "posix-mode", 0);
     parser.add_positional_argument(file_to_read_from, "File to read commands from", "file", Core::ArgsParser::Required::No);
     parser.add_positional_argument(script_args, "Extra arguments to pass to the script (via $* and co)", "argument", Core::ArgsParser::Required::No);
 


### PR DESCRIPTION
Shell will run in `--posix-mode` by default when invoked as `sh` or `/bin/sh`

features added in this PR:
- [x] if
- [ ] case
- [ ] for