### PR TITLE
LibWeb: Support ordered lists as well as different list-style-types for unordered lists

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -199,6 +199,14 @@ ol {
     padding-left: 20px;
 }
 
+ul {
+    list-style-type: disc;
+}
+
+ol {
+    list-style-type: decimal;
+}
+
 /* FIXME: This is a temporary hack until we can render a native-looking frame for these. */
 input[type=text] {
     border: 1px solid black;

--- a/Userland/Libraries/LibWeb/Layout/ListItemBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemBox.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Tobias Christiansen <tobi@tobyase.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,7 +50,8 @@ void ListItemBox::layout_marker()
         return;
 
     if (!m_marker) {
-        m_marker = adopt(*new ListItemMarkerBox(document()));
+        int child_index = parent()->index_of_child<ListItemBox>(*this).value();
+        m_marker = adopt(*new ListItemMarkerBox(document(), computed_values().list_style_type(), child_index + 1));
         if (first_child())
             m_marker->set_inline(first_child()->is_inline());
         append_child(*m_marker);

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -45,11 +45,39 @@ void ListItemMarkerBox::paint(PaintContext& context, PaintPhase phase)
 {
     if (phase != PaintPhase::Foreground)
         return;
-    Gfx::IntRect bullet_rect { 0, 0, 4, 4 };
-    bullet_rect.center_within(enclosing_int_rect(absolute_rect()));
+
     // FIXME: It would be nicer to not have to go via the parent here to get our inherited style.
     auto color = parent()->computed_values().color();
-    context.painter().fill_rect(bullet_rect, color);
+
+    auto enclosing = enclosing_int_rect(absolute_rect());
+    int marker_width = (int)enclosing.height() / 2;
+    Gfx::IntRect marker_rect { 0, 0, marker_width, marker_width };
+    marker_rect.center_within(enclosing);
+
+    switch (m_list_style_type) {
+    case CSS::ListStyleType::Square:
+        context.painter().fill_rect(marker_rect, color);
+        break;
+    case CSS::ListStyleType::Circle:
+        // For some reason for draw_ellipse() the ellipse is outside of the rect while for fill_ellipse() the ellipse is inside.
+        // Scale the marker_rect with sqrt(2) to get an ellipse arc (circle) that appears as if it was inside of the marker_rect.
+        marker_rect.set_height(marker_rect.height() / 1.41);
+        marker_rect.set_width(marker_rect.width() / 1.41);
+        marker_rect.center_within(enclosing);
+        context.painter().draw_ellipse_intersecting(marker_rect, color);
+        break;
+    case CSS::ListStyleType::Decimal:
+        context.painter().draw_text(enclosing, String::formatted("{}.", m_index), Gfx::TextAlignment::Center);
+        break;
+    case CSS::ListStyleType::Disc:
+        context.painter().fill_ellipse(marker_rect, color);
+        break;
+    case CSS::ListStyleType::None:
+        return;
+
+    default:
+        VERIFY_NOT_REACHED();
+    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Tobias Christiansen <tobi@tobyase.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,8 +30,10 @@
 
 namespace Web::Layout {
 
-ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document)
+ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document, CSS::ListStyleType style_type, size_t index)
     : Box(document, nullptr, CSS::StyleProperties::create())
+    , m_list_style_type(style_type)
+    , m_index(index)
 {
 }
 

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Tobias Christiansen <tobi@tobyase.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,10 +33,14 @@ namespace Web::Layout {
 
 class ListItemMarkerBox final : public Box {
 public:
-    explicit ListItemMarkerBox(DOM::Document&);
+    explicit ListItemMarkerBox(DOM::Document&, CSS::ListStyleType, size_t index);
     virtual ~ListItemMarkerBox() override;
 
     virtual void paint(PaintContext&, PaintPhase) override;
+
+private:
+    CSS::ListStyleType m_list_style_type { CSS::ListStyleType::None };
+    size_t m_index;
 };
 
 }

--- a/Userland/Libraries/LibWeb/TreeNode.h
+++ b/Userland/Libraries/LibWeb/TreeNode.h
@@ -97,6 +97,39 @@ public:
         return const_cast<TreeNode*>(this)->child_at_index(index);
     }
 
+    Optional<size_t> index_of_child(const T& search_child)
+    {
+        VERIFY(search_child.parent() == this);
+        size_t index = 0;
+        auto* child = first_child();
+        VERIFY(child);
+
+        do {
+            if (child == &search_child)
+                return index;
+            index++;
+        } while (child && (child = child->next_sibling()));
+        return {};
+    }
+
+    template<typename ChildType>
+    Optional<size_t> index_of_child(const T& search_child)
+    {
+        VERIFY(search_child.parent() == this);
+        size_t index = 0;
+        auto* child = first_child();
+        VERIFY(child);
+
+        do {
+            if (!is<ChildType>(child))
+                continue;
+            if (child == &search_child)
+                return index;
+            index++;
+        } while (child && (child = child->next_sibling()));
+        return {};
+    }
+
     bool is_ancestor_of(const TreeNode&) const;
     bool is_inclusive_ancestor_of(const TreeNode&) const;
     bool is_descendant_of(const TreeNode&) const;


### PR DESCRIPTION
This PR implements the display of ordered lists in the web browser (just decimal counting for now).
There is a pretty old issue #2059 discussing the matter but it seems it never got anywhere.

While I was at it, it was easy to also support the different list-style-types for unordered lists:
![image](https://user-images.githubusercontent.com/6002167/115127022-bd6ec080-9fd3-11eb-97c1-efd957862833.png)

There are a lot more list-style-types out there, but they aren't supported by the parser yet.

Fixes #2059