### PR TITLE
LibGUI+WindowServer+Taskbar: Add super key event & show start menu when it is pressed

### DIFF
--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -82,6 +82,7 @@ public:
         WM_WindowRectChanged,
         WM_WindowIconBitmapChanged,
         WM_AppletAreaSizeChanged,
+        WM_SuperKeyPressed,
         __End_WM_Events,
     };
 
@@ -111,6 +112,14 @@ public:
 private:
     int m_client_id { -1 };
     int m_window_id { -1 };
+};
+
+class WMSuperKeyPressedEvent : public WMEvent {
+public:
+    explicit WMSuperKeyPressedEvent(int client_id)
+        : WMEvent(Event::Type::WM_SuperKeyPressed, client_id, 0)
+    {
+    }
 };
 
 class WMAppletAreaSizeChangedEvent : public WMEvent {

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
@@ -74,4 +74,10 @@ void WindowManagerServerConnection::handle(const Messages::WindowManagerClient::
     if (auto* window = Window::from_window_id(message.wm_id()))
         Core::EventLoop::current().post_event(*window, make<WMWindowRemovedEvent>(message.client_id(), message.window_id()));
 }
+
+void WindowManagerServerConnection::handle(const Messages::WindowManagerClient::SuperKeyPressed& message)
+{
+    if (auto* window = Window::from_window_id(message.wm_id()))
+        Core::EventLoop::current().post_event(*window, make<WMSuperKeyPressedEvent>(message.wm_id()));
+}
 }

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
@@ -52,6 +52,7 @@ private:
     virtual void handle(const Messages::WindowManagerClient::WindowIconBitmapChanged&) override;
     virtual void handle(const Messages::WindowManagerClient::WindowRectChanged&) override;
     virtual void handle(const Messages::WindowManagerClient::AppletAreaSizeChanged&) override;
+    virtual void handle(const Messages::WindowManagerClient::SuperKeyPressed&) override;
 };
 
 }

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -84,14 +84,15 @@ TaskbarWindow::TaskbarWindow(NonnullRefPtr<GUI::Menu> start_menu)
     main_widget.set_layout<GUI::HorizontalBoxLayout>();
     main_widget.layout()->set_margins({ 3, 3, 3, 1 });
 
-    auto& start_button = main_widget.add<GUI::Button>("Serenity");
-    start_button.set_font(Gfx::FontDatabase::default_bold_font());
-    start_button.set_icon_spacing(0);
-    start_button.set_fixed_size(80, 22);
+    m_start_button = GUI::Button::construct("Serenity");
+    m_start_button->set_font(Gfx::FontDatabase::default_bold_font());
+    m_start_button->set_icon_spacing(0);
+    m_start_button->set_fixed_size(80, 22);
     auto app_icon = GUI::Icon::default_icon("ladybug");
-    start_button.set_icon(app_icon.bitmap_for_size(16));
-    start_button.set_menu(m_start_menu);
+    m_start_button->set_icon(app_icon.bitmap_for_size(16));
+    m_start_button->set_menu(m_start_menu);
 
+    main_widget.add_child(*m_start_button);
     create_quick_launch_bar();
 
     m_task_button_container = main_widget.add<GUI::Widget>();
@@ -336,6 +337,14 @@ void TaskbarWindow::wm_event(GUI::WMEvent& event)
         m_applet_area_size = changed_event.size();
         m_applet_area_container->set_fixed_size(changed_event.size().width() + 8, 22);
         update_applet_area();
+        break;
+    }
+    case GUI::Event::WM_SuperKeyPressed: {
+        if (m_start_menu->is_visible()) {
+            m_start_menu->dismiss();
+        } else {
+            m_start_menu->popup(m_start_button->screen_relative_rect().top_left());
+        }
         break;
     }
     default:

--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -59,4 +59,5 @@ private:
 
     Gfx::IntSize m_applet_area_size;
     RefPtr<GUI::Frame> m_applet_area_container;
+    RefPtr<GUI::Button> m_start_button;
 };

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -175,6 +175,7 @@ public:
     void tell_wms_window_icon_changed(Window&);
     void tell_wms_window_rect_changed(Window&);
     void tell_wms_applet_area_size_changed(const Gfx::IntSize&);
+    void tell_wms_super_key_pressed();
 
     bool is_active_window_or_accessory(Window&) const;
 
@@ -334,6 +335,7 @@ private:
     DoubleClickInfo m_double_click_info;
     int m_double_click_speed { 0 };
     int m_max_distance_for_double_click { 4 };
+    bool m_previous_event_was_super_keydown { false };
 
     WeakPtr<Window> m_active_window;
     WeakPtr<Window> m_hovered_window;

--- a/Userland/Services/WindowServer/WindowManagerClient.ipc
+++ b/Userland/Services/WindowServer/WindowManagerClient.ipc
@@ -5,4 +5,5 @@ endpoint WindowManagerClient = 1872
     WindowIconBitmapChanged(i32 wm_id, i32 client_id, i32 window_id, Gfx::ShareableBitmap bitmap) =|
     WindowRectChanged(i32 wm_id, i32 client_id, i32 window_id, Gfx::IntRect rect) =|
     AppletAreaSizeChanged(i32 wm_id, Gfx::IntSize size) =|
+    SuperKeyPressed(i32 wm_id) =|
 }


### PR DESCRIPTION
This PR re-implements the start menu being shown when the super key is pressed via the new ``WM_SuperKeyPressed`` event.
The existing functionality powered by the super key (app switching, tiling, etc.) is still fully functional!

Fixes #6153