### PR TITLE
Revert "Ports: Add imgcat port"

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -2,6 +2,7 @@
 
 Please make sure to keep this list up to date when adding and updating ports. :^)
 
+<<<<<<< HEAD
 | Port                                   | Name                                                       | Version                  | Website                                                                        |
 |----------------------------------------|------------------------------------------------------------|--------------------------|--------------------------------------------------------------------------------|
 | [`bash`](bash/)                        | GNU Bash                                                   | 5.0                      | https://www.gnu.org/software/bash/                                             |
@@ -38,7 +39,6 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`gnuplot`](gnuplot/)                  | Gnuplot                                                    | 5.2.8                    | http://www.gnuplot.info/                                                       |
 | [`grep`](grep/)                        | GNU Grep                                                   | 2.5.4                    | https://www.gnu.org/software/grep/                                             |
 | [`hatari`](hatari/)                    | Atari ST/STE/TT/Falcon emulator                            | 2.4.0-devel              | https://hatari.tuxfamily.org/                                                  |
-| [`imgcat`](imgcat/)                    | imgcat                                                     | 2.5.0                    | https://github.com/eddieantonio/imgcat                                         |
 | [`indent`](indent/)                    | GNU indent                                                 | 2.2.11                   | https://www.gnu.org/software/indent/                                           |
 | [`jot`](jot/)                          | jot (OpenBSD)                                              | 6.6                      | https://github.com/ibara/libpuffy                                              |
 | [`jq`](jq/)                            | jq                                                         | 1.6                      | https://stedolan.github.io/jq/                                                 |
@@ -113,3 +113,115 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`yasm`](yasm/)                        | Yasm Modular Assembler                                     | 1.3.0                    | https://yasm.tortall.net/                                                      |
 | [`zlib`](zlib/)                        | zlib                                                       | 1.2.11                   | https://www.zlib.net/                                                          |
 | [`zstd`](zstd/)                        | Zstandard                                                  | 1.4.4                    | https://facebook.github.io/zstd/                                               |
+=======
+| Port                           | Name                                          | Version           | Website                                               |
+|--------------------------------|-----------------------------------------------|-------------------|-------------------------------------------------------|
+| [`bash`](bash/)                | GNU Bash                                      | 5.0               | https://www.gnu.org/software/bash/                    |
+| [`bc`](bc/)                    | bc                                            | 2.5.1             | https://github.com/gavinhoward/bc                     |
+| [`binutils`](binutils/)        | GNU Binutils                                  | 2.32              | https://www.gnu.org/software/binutils/                |
+| [`bison`](bison/)              | GNU Bison                                     | 1.25              | https://www.gnu.org/software/bison/                   |
+| [`byacc`](byacc/)              | Berkeley Yacc                                 | 20191125          | https://invisible-island.net/byacc/byacc.html         |
+| [`bzip2`](bzip2/)              | bzip2                                         | 1.0.8             | https://sourceware.org/bzip2/                         |
+| [`carl`](carl/)                | Crypto Ancienne Resource Loader               | 1.5               | https://github.com/classilla/cryanc                   |
+| [`c-ray`](c-ray/)              | C-Ray                                         |                   | https://github.com/vkoskiv/c-ray                      |
+| [`chester`](chester/)          | Chester Gameboy Emulator                      |                   | https://github.com/veikkos/chester                    |
+| [`cmake`](cmake/)              | CMake                                         | 3.19.4            | https://cmake.org/                                    |
+| [`cmatrix`](cmatrix/)          | cmatrix                                       |                   | https://github.com/abishekvashok/cmatrix              |
+| [`curl`](curl/)                | curl                                          | 7.65.3            | https://curl.se/                                      |
+| [`dash`](dash/)                | DASH                                          | 0.5.10.2          | http://gondor.apana.org.au/~herbert/dash              |
+| [`dialog`](dialog/)            | Dialog                                        | 1.3-20210324      | https://invisible-island.net/dialog/                  |
+| [`diffutils`](diffutils/)      | GNU Diffutils                                 | 3.5               | https://www.gnu.org/software/diffutils/               |
+| [`dmidecode`](dmidecode/)      | dmidecode                                     | 3.3               | https://github.com/mirror/dmidecode                   |
+| [`doom`](doom/)                | DOOM                                          |                   | https://github.com/SerenityOS/SerenityDOOM            |
+| [`dropbear`](dropbear/)        | Dropbear SSH                                  | 2019.78           | https://dropbear.nl/mirror/dropbear.html              |
+| [`ed`](ed/)                    | GNU ed                                        | 1.15              | https://www.gnu.org/software/ed/                      |
+| [`emu2`](emu2/)                | emu2 DOS emulator                             |                   | https://github.com/dmsc/emu2                          |
+| [`figlet`](figlet/)            | FIGlet                                        | 2.2.5             | http://www.figlet.org/                                |
+| [`flatbuffers`](flatbuffers/)  | Flatbuffers                                   | 1.12.0            | https://github.com/google/flatbuffers                 |
+| [`flex`](flex/)                | flex                                          | 2.6.4             | https://github.com/westes/flex                        |
+| [`freetype`](freetype/)        | FreeType                                      | 2.10.4            | https://www.freetype.org/                             |
+| [`frotz`](frotz/)              | Frotz                                         |                   | https://gitlab.com/DavidGriffith/frotz                |
+| [`gcc`](gcc/)                  | GNU Compiler Collection                       | 10.3.0            | https://gcc.gnu.org/                                  |
+| [`genemu`](genemu)             | Genesis / MegaDrive Emulator                  |                   | https://github.com/rasky/genemu                       |
+| [`git`](git/)                  | Git                                           | 2.31.1            | https://git-scm.com/                                  |
+| [`gmp`](gmp/)                  | GNU Multiple Precision Arithmetic Library     | 6.2.1             | https://gmplib.org/                                   |
+| [`gnucobol`](gnucobol/)        | GnuCOBOL                                      | 3.1.2             | https://gnucobol.sourceforge.io/                      |
+| [`gnupg`](gnupg/)              | GnuPG                                         | 2.3.0             | https://gnupg.org/software/index.html                 |
+| [`gnuplot`](gnuplot/)          | Gnuplot                                       | 5.2.8             | http://www.gnuplot.info/                              |
+| [`grep`](grep/)                | GNU Grep                                      | 2.5.4             | https://www.gnu.org/software/grep/                    |
+| [`hatari`](hatari/)            | Atari ST/STE/TT/Falcon emulator               | 2.4.0-devel       | https://hatari.tuxfamily.org/                         |
+| [`indent`](indent/)            | GNU indent                                    | 2.2.11            | https://www.gnu.org/software/indent/                  |
+| [`jot`](jot/)                  | jot (OpenBSD)                                 | 6.6               | https://github.com/ibara/libpuffy                     |
+| [`jq`](jq/)                    | jq                                            | 1.6               | https://stedolan.github.io/jq/                        |
+| [`klong`](klong/)              | Klong                                         | 20190926          | http://t3x.org/klong/                                 |
+| [`less`](less/)                | less                                          | 530               | http://www.greenwoodsoftware.com/less/                |
+| [`libarchive`](libarchive/)    | libarchive                                    | 3.4.0             | https://libarchive.org/                               |
+| [`libassuan`](libassuan/)      | libassuan                                     | 2.5.5             | https://gnupg.org/software/libassuan/index.html       |
+| [`libexpat`](libexpat/)        | Expat                                         | 2.2.9             | https://libexpat.github.io/                           |
+| [`libffi`](libffi/)            | libffi                                        | 3.3               | https://www.sourceware.org/libffi/                    |
+| [`libgcrypt`](libgcrypt/)      | libgcrypt                                     | 1.9.2             | https://gnupg.org/software/libgcrypt/index.html       |
+| [`libgpg-error`](libgpg-error/)| libgpg-error                                  | 1.42              | https://gnupg.org/software/libgpg-error/index.html    |
+| [`libiconv`](libiconv/)        | GNU libiconv                                  | 1.16              | https://www.gnu.org/software/libiconv/                |
+| [`libicu`](libicu/)            | ICU                                           | 69.1              | http://site.icu-project.org/                          |
+| [`libksba`](libksba/)          | libksba                                       | 1.5.1             | https://gnupg.org/software/libksba/index.html         |
+| [`libjpeg`](libjpeg/)          | libjpeg                                       | 9d                | https://ijg.org/                                      |
+| [`libogg`](libogg/)            | libogg                                        | 1.3.4             | https://github.com/xiph/ogg                           |
+| [`libpng`](libpng/)            | libpng                                        | 1.6.37            | https://libpng.org/                                   |
+| [`libpuffy`](libpuffy/)        | libpuffy                                      | 1.0               | https://github.com/ibara/libpuffy                     |
+| [`libtiff`](libtiff/)          | libtiff                                       | 4.2.0             | http://www.libtiff.org/                               |
+| [`libtool`](libtool/)          | libtool                                       | 2.4               | https://www.gnu.org/software/libtool/                 |
+| [`libvorbis`](libvorbis/)      | libvorbis                                     | 1.3.7             | https://github.com/xiph/vorbis                        |
+| [`libzip`](libzip/)            | libzip                                        | 1.7.3             | https://libzip.org/                                   |
+| [`links`](links/)              | Links web browser                             | 2.22              | http://links.twibright.com/                           |
+| [`lua`](lua/)                  | Lua                                           | 5.3.5             | https://www.lua.org/                                  |
+| [`m4`](m4/)                    | GNU M4                                        | 1.4.9             | https://www.gnu.org/software/m4/                      |
+| [`make`](make/)                | GNU make                                      | 4.3               | https://www.gnu.org/software/make/                    |
+| [`mandoc`](mandoc/)            | mandoc                                        | 1.14.5            | https://mandoc.bsd.lv/                                |
+| [`mawk`](mawk/)                | mawk                                          | 1.3.4-20200120    | https://invisible-island.net/mawk/                    |
+| [`mbedtls`](mbedtls/)          | Mbed TLS                                      | 2.16.2            | https://tls.mbed.org/                                 |
+| [`mrsh`](mrsh/)                | mrsh                                          | d9763a3           | https://mrsh.sh/                                      |
+| [`nano`](nano/)                | GNU nano                                      | 4.5               | https://www.nano-editor.org/                          |
+| [`nasm`](nasm/)                | Netwide Assembler (NASM)                      | 2.15.05           | https://www.nasm.us/                                  |
+| [`ncurses`](ncurses/)          | ncurses                                       | 6.2               | https://invisible-island.net/ncurses/announce.html    |
+| [`neofetch`](neofetch/)        | neofetch                                      | 7.1.0             | https://github.com/dylanaraps/neofetch                |
+| [`nesalizer`](nesalizer/)      | Nesalizer                                     |                   | https://github.com/SerenityOS/nesalizer               |
+| [`nethack`](nethack/)          | nethack                                       | 3.6.6             | https://www.nethack.org/                              |
+| [`ninja`](ninja/)              | Ninja                                         | 1.8.2             | https://ninja-build.org/                              |
+| [`npth`](npth/)                | New GNU Portable Threads Library              | 1.6               | https://gnupg.org/software/npth/index.html            |
+| [`ntbtls`](ntbtls/)            | The Not Too Bad TLS Library                   | 0.2.0             | https://gnupg.org/software/ntbtls/index.html          |
+| [`nyancat`](nyancat/)          | Nyancat                                       |                   | https://github.com/klange/nyancat                     |
+| [`openssh`](openssh/)          | OpenSSH                                       | 8.3-9ca7e9c       | https://github.com/openssh/openssh-portable           |
+| [`openssl`](openssl/)          | OpenSSL                                       | 1.0.2             | https://www.openssl.org/                              |
+| [`oksh`](oksh/)                | oksh                                          | 6.8.1             | https://github.com/ibara/oksh                         |
+| [`patch`](patch/)              | patch (OpenBSD)                               | 6.6               | https://github.com/ibara/libpuffy                     |
+| [`pcre`](pcre/)                | Perl-compatible Regular Expressions (PCRE)    | 8.44              | https://www.pcre.org/                                 |
+| [`pcre2`](pcre2/)              | Perl-compatible Regular Expressions (PCRE2)   | 10.34             | https://www.pcre.org/                                 |
+| [`pkgconf`](pkgconf/)          | pkgconf                                       | 1.7.3             | https://github.com/pkgconf/pkgconf                    |
+| [`SDLPoP`](SDLPoP/)            | Prince of Persia game                         |                   | https://github.com/NagyD/SDLPoP                       |
+| [`printf`](printf/)            | printf (OpenBSD)                              | 6.6               | https://github.com/ibara/libpuffy                     |
+| [`pt2-clone`](pt2-clone/)      | ProTracker 2 clone                            | 1.28              | https://github.com/8bitbubsy/pt2-clone                |
+| [`python3`](python3/)          | Python                                        | 3.9.4             | https://www.python.org/                               |
+| [`quake`](quake/)              | Quake                                         | 0.65              | https://github.com/SerenityOS/SerenityQuake           |
+| [`rsync`](rsync/)              | rsync                                         | 3.1.3             | https://rsync.samba.org/                              |
+| [`scummvm`](scummvm/)          | ScummVM                                       | 2.2.0             | https://www.scummvm.org/                              |
+| [`SDL2`](SDL2/)                | Simple DirectMedia Layer (SDL2)               |                   | https://github.com/SerenityOS/SDL                     |
+| [`SDL2_gfx`](SDL2_gfx/)        | SDL2\_gfx (Graphics primitives add-on for SDL2) | 1.0.4           | https://sourceforge.net/projects/sdl2gfx/             |
+| [`SDL2_image`](SDL2_image/)    | SDL2\_image (Image loading add-on for SDL2)   | 2.0.5             | https://www.libsdl.org/projects/SDL_image/            |
+| [`SDL2_mixer`](SDL2_mixer/)    | SDL2\_mixer (audio mixer add-on for SDL2)     | 2.0.4             | https://www.libsdl.org/projects/SDL_mixer/            |
+| [`SDL2_ttf`](SDL2_ttf/)        | SDL2\_ttf (TrueType Font add-on for SDL2)     | 2.0.15            | https://www.libsdl.org/projects/SDL_ttf/              |
+| [`sed`](sed/)                  | GNU sed                                       | 4.2.1             | https://www.gnu.org/software/sed/                     |
+| [`sl`](sl/)                    | Steam Locomotive (SL)                         |                   | https://github.com/mtoyoda/sl                         |
+| [`sqlite`](sqlite/)            | SQLite                                        | 3350300           | https://www.sqlite.org/                               |
+| [`stress-ng`](stress-ng/)      | stress-ng                                     | 0.11.23           | https://github.com/ColinIanKing/stress-ng             |
+| [`Super-Mario`](Super-Mario/)  | Super-Mario Clone                             |                   |https://github.com/Bennyhwanggggg/Super-Mario-Clone-Cpp|
+| [`termcap`](termcap/)          | GNU termcap                                   | 1.3.1             | https://www.gnu.org/software/termutils/               |
+| [`tinycc`](tinycc/)            | Tiny C Compiler (TinyCC)                      | dev               | https://github.com/TinyCC/tinycc                      |
+| [`tinyscheme`](tinyscheme/)    | TinyScheme Interpreter                        | 1.42              | https://sourceforge.net/projects/tinyscheme/          |
+| [`tr`](tr/)                    | tr (OpenBSD)                                  | 6.7               | https://github.com/ibara/libpuffy                     |
+| [`vim`](vim/)                  | Vim                                           |                   | https://www.vim.org/                                  |
+| [`vitetris`](vitetris/)        | vitetris                                      | 0.59.1            | https://github.com/vicgeralds/vitetris                |
+| [`vttest`](vttest/)            | vttest                                        | 20210210          | https://invisible-island.net/vttest/                  |
+| [`yasm`](yasm/)                | Yasm Modular Assembler                        | 1.3.0             | https://yasm.tortall.net/                             |
+| [`zlib`](zlib/)                | zlib                                          | 1.2.11            | https://www.zlib.net/                                 |
+| [`zstd`](zstd/)                | Zstandard                                     | 1.4.4             | https://facebook.github.io/zstd/                      |
+>>>>>>> parent of 40c2c2498 (Ports: Add imgcat port)

--- a/Ports/imgcat/package.sh
+++ b/Ports/imgcat/package.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env -S bash ../.port_include.sh
-port=imgcat
-version=2.5.0
-useconfigure=false
-files="https://github.com/eddieantonio/imgcat/releases/download/v${version}/imgcat-${version}.tar.gz imgcat-v${version}.tar.gz 1b5d45ccafc6fbb7a7ee685d4a5110101418d48b"
-auth_type=md5
-
-depends="ncurses"


### PR DESCRIPTION
There's tons of issues with the `imgcat` port of mine.

From a mismatching md5 checksum, all the way up to source code-related incompatibilities with the system and a custom, forsaken `configure` file. It'd be best to remove it for the time being and work on it again in a pull request with a procedure, rather than sending tons of pull requests meant to patch things up.

- Original PR: #6436