### PR TITLE
Kernel: Make VirtIOConsole block when VirtIOQueue is full

### DIFF
--- a/Kernel/VirtIO/VirtIO.h
+++ b/Kernel/VirtIO/VirtIO.h
@@ -192,6 +192,12 @@ protected:
         return m_queues[queue_index];
     }
 
+    const VirtIOQueue& get_queue(u16 queue_index) const
+    {
+        VERIFY(queue_index < m_queue_count);
+        return m_queues[queue_index];
+    }
+
     template<typename F>
     bool negotiate_features(F f)
     {

--- a/Kernel/VirtIO/VirtIOConsole.cpp
+++ b/Kernel/VirtIO/VirtIOConsole.cpp
@@ -110,7 +110,7 @@ KResultOr<size_t> VirtIOConsole::read(FileDescription&, u64, [[maybe_unused]] Us
 
 bool VirtIOConsole::can_write(const FileDescription&, size_t) const
 {
-    return true;
+    return get_queue(TRANSMITQ).can_write();
 }
 
 KResultOr<size_t> VirtIOConsole::write(FileDescription&, u64, const UserOrKernelBuffer& data, size_t size)

--- a/Kernel/VirtIO/VirtIOQueue.cpp
+++ b/Kernel/VirtIO/VirtIOQueue.cpp
@@ -145,4 +145,9 @@ void VirtIOQueue::pop_buffer(u16 descriptor_index)
     m_free_head = descriptor_index;
 }
 
+bool VirtIOQueue::can_write() const
+{
+    return m_free_buffers > 0;
+}
+
 }

--- a/Kernel/VirtIO/VirtIOQueue.h
+++ b/Kernel/VirtIO/VirtIOQueue.h
@@ -60,6 +60,7 @@ public:
 
     bool supply_buffer(Badge<VirtIODevice>, const ScatterGatherList&, BufferType, void* token);
     bool new_data_available() const;
+    bool can_write() const;
     void* get_buffer(size_t*);
     void discard_used_buffers();
 


### PR DESCRIPTION
Currently, filling the backing VirtIOQueue will cause an assertion failure. This makes it block instead.