### PR TITLE
AK+Kernel+LibELF: Remove the need for `IteratorDecision::Continue`

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/IterationDecision.h>
 #include <AK/StdLibExtras.h>
 
 namespace AK::Concepts {
@@ -27,6 +28,27 @@ concept Signed = IsSigned<T>;
 template<typename T>
 concept Unsigned = IsUnsigned<T>;
 
+template<typename T, typename U>
+concept SameAs = IsSame<T, U>;
+
+template<typename Func, typename... Args>
+concept VoidFunction = requires(Func func, Args... args)
+{
+    {
+        func(args...)
+    }
+    ->SameAs<void>;
+};
+
+template<typename Func, typename... Args>
+concept IteratorFunction = requires(Func func, Args... args)
+{
+    {
+        func(args...)
+    }
+    ->SameAs<IterationDecision>;
+};
+
 #endif
 
 }
@@ -36,7 +58,9 @@ concept Unsigned = IsUnsigned<T>;
 using AK::Concepts::Arithmetic;
 using AK::Concepts::FloatingPoint;
 using AK::Concepts::Integral;
+using AK::Concepts::IteratorFunction;
 using AK::Concepts::Signed;
 using AK::Concepts::Unsigned;
+using AK::Concepts::VoidFunction;
 
 #endif

--- a/AK/InlineLinkedList.h
+++ b/AK/InlineLinkedList.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Concepts.h>
 #include <AK/Types.h>
 
 namespace AK {
@@ -112,7 +113,7 @@ public:
         return false;
     }
 
-    template<typename F>
+    template<IteratorFunction<T&> F>
     IterationDecision for_each(F func) const
     {
         for (T* node = m_head; node; node = node->next()) {
@@ -121,6 +122,13 @@ public:
                 return decision;
         }
         return IterationDecision::Continue;
+    }
+
+    template<VoidFunction<T&> F>
+    void for_each(F func) const
+    {
+        for (T* node = m_head; node; node = node->next())
+            func(*node);
     }
 
     using Iterator = InlineLinkedListIterator<T>;

--- a/Kernel/Arch/i386/CPU.cpp
+++ b/Kernel/Arch/i386/CPU.cpp
@@ -2090,12 +2090,11 @@ void Processor::smp_broadcast_message(ProcessorMessage& msg)
     VERIFY(msg.refs > 0);
     bool need_broadcast = false;
     for_each(
-        [&](Processor& proc) -> IterationDecision {
+        [&](Processor& proc) {
             if (&proc != &cur_proc) {
                 if (proc.smp_queue_message(msg))
                     need_broadcast = true;
             }
-            return IterationDecision::Continue;
         });
 
     // Now trigger an IPI on all other APs (unless all targets already had messages queued)
@@ -2215,9 +2214,8 @@ void Processor::smp_broadcast_halt()
     // We don't want to use a message, because this could have been triggered
     // by being out of memory and we might not be able to get a message
     for_each(
-        [&](Processor& proc) -> IterationDecision {
+        [&](Processor& proc) {
             proc.m_halt_requested.store(true, AK::MemoryOrder::memory_order_release);
-            return IterationDecision::Continue;
         });
 
     // Now trigger an IPI on all other APs

--- a/Kernel/Arch/x86/CPU.h
+++ b/Kernel/Arch/x86/CPU.h
@@ -8,6 +8,7 @@
 
 #include <AK/Atomic.h>
 #include <AK/Badge.h>
+#include <AK/Concepts.h>
 #include <AK/Noncopyable.h>
 #include <AK/Vector.h>
 
@@ -733,7 +734,7 @@ public:
 
     static size_t processor_count() { return processors().size(); }
 
-    template<typename Callback>
+    template<IteratorFunction<Processor&> Callback>
     static inline IterationDecision for_each(Callback callback)
     {
         auto& procs = processors();
@@ -742,6 +743,16 @@ public:
             if (callback(*procs[i]) == IterationDecision::Break)
                 return IterationDecision::Break;
         }
+        return IterationDecision::Continue;
+    }
+
+    template<VoidFunction<Processor&> Callback>
+    static inline IterationDecision for_each(Callback callback)
+    {
+        auto& procs = processors();
+        size_t count = procs.size();
+        for (size_t i = 0; i < count; i++)
+            callback(*procs[i]);
         return IterationDecision::Continue;
     }
 

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -688,7 +688,7 @@ static bool procfs$cpuinfo(InodeIdentifier, KBufferBuilder& builder)
 {
     JsonArraySerializer array { builder };
     Processor::for_each(
-        [&](Processor& proc) -> IterationDecision {
+        [&](Processor& proc) {
             auto& info = proc.info();
             auto obj = array.add_object();
             JsonArray features;
@@ -702,7 +702,6 @@ static bool procfs$cpuinfo(InodeIdentifier, KBufferBuilder& builder)
             obj.add("stepping", info.stepping());
             obj.add("type", info.type());
             obj.add("brandstr", info.brandstr());
-            return IterationDecision::Continue;
         });
     array.finish();
     return true;
@@ -826,7 +825,6 @@ static bool procfs$all(InodeIdentifier, KBufferBuilder& builder)
             thread_object.add("unix_socket_write_bytes", thread.unix_socket_write_bytes());
             thread_object.add("ipv4_socket_read_bytes", thread.ipv4_socket_read_bytes());
             thread_object.add("ipv4_socket_write_bytes", thread.ipv4_socket_write_bytes());
-            return IterationDecision::Continue;
         });
     };
 
@@ -1328,10 +1326,9 @@ KResult ProcFSInode::traverse_as_directory(Function<bool(const FS::DirectoryEntr
         auto process = Process::from_pid(pid);
         if (!process)
             return ENOENT;
-        process->for_each_thread([&](const Thread& thread) -> IterationDecision {
+        process->for_each_thread([&](const Thread& thread) {
             int tid = thread.tid().value();
             callback({ String::number(tid), to_identifier_with_stack(fsid(), tid), 0 });
-            return IterationDecision::Continue;
         });
     } break;
 

--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -230,7 +230,6 @@ void PerformanceEventBuffer::add_process(const Process& process, ProcessEventTyp
     process.for_each_thread([&](auto& thread) {
         [[maybe_unused]] auto rc = append_with_eip_and_ebp(process.pid(), thread.tid().value(),
             0, 0, PERF_EVENT_THREAD_CREATE, 0, 0, 0, nullptr);
-        return IterationDecision::Continue;
     });
 
     for (auto& region : process.space().regions()) {

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -584,7 +584,7 @@ void dump_thread_list()
         return thread.get_register_dump_from_stack().eip;
     };
 
-    Thread::for_each([&](Thread& thread) -> IterationDecision {
+    Thread::for_each([&](Thread& thread) {
         switch (thread.state()) {
         case Thread::Dying:
             dbgln("  {:14} {:30} @ {:04x}:{:08x} Finalizable: {}, (nsched: {})",
@@ -605,8 +605,6 @@ void dump_thread_list()
                 thread.times_scheduled());
             break;
         }
-
-        return IterationDecision::Continue;
     });
 }
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -172,7 +172,7 @@ static KResultOr<RequiredLoadRange> get_required_load_range(FileDescription& pro
     RequiredLoadRange range {};
     elf_image.for_each_program_header([&range](const auto& pheader) {
         if (pheader.type() != PT_LOAD)
-            return IterationDecision::Continue;
+            return;
 
         auto region_start = (FlatPtr)pheader.vaddr().as_ptr();
         auto region_end = region_start + pheader.size_in_memory();
@@ -180,7 +180,6 @@ static KResultOr<RequiredLoadRange> get_required_load_range(FileDescription& pro
             range.start = region_start;
         if (range.end == 0 || region_end > range.end)
             range.end = region_end;
-        return IterationDecision::Continue;
     });
 
     VERIFY(range.end > range.start);

--- a/Kernel/Syscalls/kill.cpp
+++ b/Kernel/Syscalls/kill.cpp
@@ -47,8 +47,6 @@ KResult Process::do_killpg(ProcessGroupID pgrp, int signal)
             any_succeeded = true;
         else
             error = res;
-
-        return IterationDecision::Continue;
     });
 
     if (group_was_empty)

--- a/Kernel/Syscalls/module.cpp
+++ b/Kernel/Syscalls/module.cpp
@@ -51,18 +51,18 @@ KResultOr<int> Process::sys$module_load(Userspace<const char*> user_path, size_t
 
     elf_image->for_each_section_of_type(SHT_PROGBITS, [&](const ELF::Image::Section& section) {
         if (!section.size())
-            return IterationDecision::Continue;
+            return;
         auto section_storage = KBuffer::copy(section.raw_data(), section.size(), Region::Access::Read | Region::Access::Write | Region::Access::Execute);
         section_storage_by_name.set(section.name(), section_storage.data());
         module->sections.append(move(section_storage));
-        return IterationDecision::Continue;
     });
 
     bool missing_symbols = false;
 
     elf_image->for_each_section_of_type(SHT_PROGBITS, [&](const ELF::Image::Section& section) {
         if (!section.size())
-            return IterationDecision::Continue;
+            return;
+
         auto* section_storage = section_storage_by_name.get(section.name()).value_or(nullptr);
         VERIFY(section_storage);
         auto relocations = section.relocations();
@@ -103,10 +103,7 @@ KResultOr<int> Process::sys$module_load(Userspace<const char*> user_path, size_t
                 }
                 break;
             }
-            return IterationDecision::Continue;
         });
-
-        return IterationDecision::Continue;
     });
 
     if (missing_symbols)
@@ -129,7 +126,6 @@ KResultOr<int> Process::sys$module_load(Userspace<const char*> user_path, size_t
             if (storage)
                 module->name = String((const char*)(storage + symbol.value()));
         }
-        return IterationDecision::Continue;
     });
 
     if (!module->module_init)

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -286,7 +286,6 @@ void TTY::generate_signal(int signal)
         dbgln_if(TTY_DEBUG, "{}: Send signal {} to {}", tty_name(), signal, process);
         // FIXME: Should this error be propagated somehow?
         [[maybe_unused]] auto rc = process.send_signal(signal, nullptr);
-        return IterationDecision::Continue;
     });
 }
 

--- a/Kernel/VM/AnonymousVMObject.cpp
+++ b/Kernel/VM/AnonymousVMObject.cpp
@@ -23,13 +23,11 @@ RefPtr<VMObject> AnonymousVMObject::clone()
     // so that the parent is still guaranteed to be able to have all
     // non-volatile memory available.
     size_t need_cow_pages = 0;
-    {
-        // We definitely need to commit non-volatile areas
-        for_each_nonvolatile_range([&](const VolatilePageRange& nonvolatile_range) {
-            need_cow_pages += nonvolatile_range.count;
-            return IterationDecision::Continue;
-        });
-    }
+
+    // We definitely need to commit non-volatile areas
+    for_each_nonvolatile_range([&](const VolatilePageRange& nonvolatile_range) {
+        need_cow_pages += nonvolatile_range.count;
+    });
 
     dbgln_if(COMMIT_DEBUG, "Cloning {:p}, need {} committed cow pages", this, need_cow_pages);
 
@@ -220,7 +218,6 @@ int AnonymousVMObject::purge_impl()
                 }
             });
         }
-        return IterationDecision::Continue;
     });
     return purged_page_count;
 }
@@ -284,7 +281,6 @@ void AnonymousVMObject::update_volatile_cache()
     m_volatile_ranges_cache.clear();
     for_each_nonvolatile_range([&](const VolatilePageRange& range) {
         m_volatile_ranges_cache.add_unchecked(range);
-        return IterationDecision::Continue;
     });
 
     m_volatile_ranges_cache_dirty = false;

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/HashTable.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/String.h>
@@ -157,13 +158,20 @@ public:
     unsigned super_physical_pages() const { return m_super_physical_pages; }
     unsigned super_physical_pages_used() const { return m_super_physical_pages_used; }
 
-    template<typename Callback>
+    template<IteratorFunction<VMObject&> Callback>
     static void for_each_vmobject(Callback callback)
     {
         for (auto& vmobject : MM.m_vmobjects) {
             if (callback(vmobject) == IterationDecision::Break)
                 break;
         }
+    }
+
+    template<VoidFunction<VMObject&> Callback>
+    static void for_each_vmobject(Callback callback)
+    {
+        for (auto& vmobject : MM.m_vmobjects)
+            callback(vmobject);
     }
 
     static Region* find_region_from_vaddr(Space&, VirtualAddress);

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -125,9 +125,8 @@ static Vector<String> get_dependencies(const String& name)
 
     lib->for_each_needed_library([&dependencies, &name](auto needed_name) {
         if (name == needed_name)
-            return IterationDecision::Continue;
+            return;
         dependencies.append(needed_name);
-        return IterationDecision::Continue;
     });
     return dependencies;
 }

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -93,7 +93,6 @@ const DynamicObject& DynamicLoader::dynamic_object() const
             if (program_header.type() == PT_DYNAMIC) {
                 dynamic_section_address = VirtualAddress(program_header.raw_data());
             }
-            return IterationDecision::Continue;
         });
         VERIFY(!dynamic_section_address.is_null());
 
@@ -109,7 +108,6 @@ size_t DynamicLoader::calculate_tls_size() const
         if (program_header.type() == PT_TLS) {
             tls_size = program_header.size_in_memory();
         }
-        return IterationDecision::Continue;
     });
     return tls_size;
 }
@@ -194,7 +192,6 @@ void DynamicLoader::do_main_relocations()
         case RelocationResult::Success:
             break;
         }
-        return IterationDecision::Continue;
     };
     m_dynamic_object->relocation_section().for_each_relocation(do_single_relocation);
     m_dynamic_object->plt_relocation_section().for_each_relocation(do_single_relocation);
@@ -273,7 +270,6 @@ void DynamicLoader::load_program_headers()
             VERIFY(!relro_region.has_value());
             relro_region = region;
         }
-        return IterationDecision::Continue;
     });
 
     VERIFY(!text_regions.is_empty() || !data_regions.is_empty());

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -49,7 +49,6 @@ void DynamicObject::dump() const
         String name_field = String::formatted("({})", name_for_dtag(entry.tag()));
         builder.appendff("{:#08x} {:17} {:#08x}\n", entry.tag(), name_field, entry.val());
         num_dynamic_sections++;
-        return IterationDecision::Continue;
     });
 
     if (m_has_soname)
@@ -171,7 +170,6 @@ void DynamicObject::parse()
             VERIFY_NOT_REACHED(); // FIXME: Maybe just break out here and return false?
             break;
         }
-        return IterationDecision::Continue;
     });
 
     if (!m_size_of_relocation_entry) {

--- a/Userland/Libraries/LibELF/Image.cpp
+++ b/Userland/Libraries/LibELF/Image.cpp
@@ -97,7 +97,6 @@ void Image::dump() const
         dbgln("      offset: {:x}", program_header.offset());
         dbgln("       flags: {:x}", program_header.flags());
         dbgln("    }}");
-        return IterationDecision::Continue;
     });
 
     for (unsigned i = 0; i < header().e_shnum; ++i) {
@@ -344,7 +343,6 @@ NEVER_INLINE void Image::sort_symbols() const
     m_sorted_symbols.ensure_capacity(symbol_count());
     for_each_symbol([this](const auto& symbol) {
         m_sorted_symbols.append({ symbol.value(), symbol.name(), {}, symbol });
-        return IterationDecision::Continue;
     });
     quick_sort(m_sorted_symbols, [](auto& a, auto& b) {
         return a.address < b.address;

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -523,7 +523,6 @@ int main(int argc, char** argv)
                 printf("%08x ", section.size());
                 printf("%u", section.flags());
                 printf("\n");
-                return IterationDecision::Continue;
             });
         }
         printf("\n");
@@ -556,8 +555,6 @@ int main(int argc, char** argv)
 
                 if (program_header.type() == PT_INTERP)
                     printf("      [Interpreter: %s]\n", program_header.raw_data());
-
-                return IterationDecision::Continue;
             });
         }
 
@@ -586,7 +583,6 @@ int main(int argc, char** argv)
             Vector<String> libraries;
             object->for_each_needed_library([&libraries](StringView entry) {
                 libraries.append(String::formatted("{}", entry).characters());
-                return IterationDecision::Continue;
             });
 
             auto library_index = 0;
@@ -607,7 +603,6 @@ int main(int argc, char** argv)
                 } else {
                     printf("0x%08x\n", entry.val());
                 }
-                return IterationDecision::Continue;
             });
         }
 
@@ -630,7 +625,6 @@ int main(int argc, char** argv)
                     printf(" 0x%08x ", reloc.symbol().value());
                     printf(" %s", reloc.symbol().name().to_string().characters());
                     printf("\n");
-                    return IterationDecision::Continue;
                 });
             }
             printf("\n");
@@ -646,7 +640,6 @@ int main(int argc, char** argv)
                     printf(" 0x%08x ", reloc.symbol().value());
                     printf(" %s", reloc.symbol().name().to_string().characters());
                     printf("\n");
-                    return IterationDecision::Continue;
                 });
             }
         } else {
@@ -666,7 +659,7 @@ int main(int argc, char** argv)
         auto found_notes = false;
         elf_image.for_each_program_header([&found_notes](const ELF::Image::ProgramHeader& program_header) {
             if (program_header.type() != PT_NOTE)
-                return IterationDecision::Continue;
+                return;
 
             found_notes = true;
 
@@ -674,8 +667,6 @@ int main(int argc, char** argv)
 
             // FIXME: Parse CORE notes. Notes are in JSON format on SerenityOS, but vary between systems.
             printf("%s\n", program_header.raw_data());
-
-            return IterationDecision::Continue;
         });
 
         if (!found_notes)
@@ -714,7 +705,6 @@ int main(int argc, char** argv)
                     printf("%-8s ", object_symbol_binding_to_string(sym.bind()));
                     printf("%s", StringView(sym.name()).to_string().characters());
                     printf("\n");
-                    return IterationDecision::Continue;
                 });
             }
         }
@@ -738,7 +728,6 @@ int main(int argc, char** argv)
                 printf("%-8s ", object_symbol_binding_to_string(sym.bind()));
                 printf("%s", StringView(sym.name()).to_string().characters());
                 printf("\n");
-                return IterationDecision::Continue;
             });
         } else {
             printf("Symbol table '%s' contains zero entries.\n", ELF_SYMTAB);


### PR DESCRIPTION
Work towards #6188 

The discussion has produced a compiling and running solution.
The only remaining issue is to generalize it for the whole codebase.

Following in the footsteps of `AK_MAKE_NON{COPY,MOVE}ABLE`, the
`DO_CALLBACK` macro will generalize the `void`/`IterationDecision`
compile-time switch.

I am still not certain about the following:
1. Where should this macro be defined?
2. Is there the possibility or use case for a callback with 2 or more arguments? (There is at least one)
3. What about if the `for_each` function needs to return its own `IterationDecision`?
4. Could this somehow be a template, instead of a macro?

What is shown is a small sample of changing one function and one call site. 
The final commit will `hopefully` catch most of the use cases for this PR.