### PR TITLE
Meta: Disable discord notifications timeout

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           excludedCheckName: "notify_discord"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          timeoutSeconds: 3600
+          timeoutSeconds: 21600
           intervalSeconds: 100
 
       - name: Discord action notification


### PR DESCRIPTION
Since some builds can take even longer than 1 hour (for example: f033416893b097e9f148711c161537db328d02cd) this commit just increases the timeout to be github's own workflow timeout (effectively disabling it) and just lets github handle it instead.