### PR TITLE
LibDebug: Implement support for AttributeDataForm::Data8

### DIFF
--- a/Userland/Libraries/LibDebug/Dwarf/DIE.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DIE.cpp
@@ -131,6 +131,14 @@ DIE::AttributeValue DIE::get_attribute_value(AttributeDataForm form,
         value.data.as_u32 = data;
         break;
     }
+    case AttributeDataForm::Data8: {
+        u64 data;
+        debug_info_stream >> data;
+        VERIFY(!debug_info_stream.has_any_error());
+        value.type = AttributeValue::Type::LongUnsignedNumber;
+        value.data.as_u64 = data;
+        break;
+    }
     case AttributeDataForm::Ref4: {
         u32 data;
         debug_info_stream >> data;

--- a/Userland/Libraries/LibDebug/Dwarf/DIE.h
+++ b/Userland/Libraries/LibDebug/Dwarf/DIE.h
@@ -46,6 +46,7 @@ public:
         enum class Type : u8 {
             UnsignedNumber,
             SignedNumber,
+            LongUnsignedNumber,
             String,
             DieReference, // Reference to another DIE in the same compilation unit
             Boolean,
@@ -57,6 +58,7 @@ public:
         union {
             u32 as_u32;
             i32 as_i32;
+            u64 as_u64;
             const char* as_string; // points to bytes in the memory mapped elf image
             bool as_bool;
             struct {


### PR DESCRIPTION
I came across this while analyzing a crash dump for openttd.