### PR TITLE
Kernel: Add kernel command line flag to disable VirtIO support

### DIFF
--- a/Documentation/NotesOnWSL.md
+++ b/Documentation/NotesOnWSL.md
@@ -40,6 +40,9 @@ By default this will be located at `/mnt/c/Program Files/qemu/qemu-system-i386.e
 
 - Locate the _Windows_ path to the SerenityOS disk image, as native QEMU will be accessing it via the Windows filesystem. If your build tree is located in the WSL2 partition, this will be accessible under the `\\wsl$` network file share (see [notes below](#note-on-filesystems)).
 
+- Set the `SERENITY_KERNEL_CMDLINE` environment variable to disable VirtIO support (Because it is currently broken on native windows QEMU):
+`export SERENITY_KERNEL_CMDLINE="disable_virtio"`
+
 - Set the `SERENITY_DISK_IMAGE` environment variable to the full path of the SerenityOS disk image file from above. For example: \
 `export SERENITY_DISK_IMAGE='\\wsl$\Ubuntu-20.04\home\username\serenity\Build\i686\_disk_image'`
 

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -170,6 +170,11 @@ UNMAP_AFTER_INIT bool CommandLine::disable_uhci_controller() const
     return contains("disable_uhci_controller");
 }
 
+UNMAP_AFTER_INIT bool CommandLine::disable_virtio() const
+{
+    return contains("disable_virtio");
+}
+
 UNMAP_AFTER_INIT AHCIResetMode CommandLine::ahci_reset_mode() const
 {
     const auto ahci_reset_mode = lookup("ahci_reset_mode").value_or("controller");

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -87,6 +87,7 @@ public:
     [[nodiscard]] bool disable_physical_storage() const;
     [[nodiscard]] bool disable_ps2_controller() const;
     [[nodiscard]] bool disable_uhci_controller() const;
+    [[nodiscard]] bool disable_virtio() const;
     [[nodiscard]] AHCIResetMode ahci_reset_mode() const;
     [[nodiscard]] String userspace_init() const;
     [[nodiscard]] Vector<String> userspace_init_args() const;

--- a/Kernel/VirtIO/VirtIO.cpp
+++ b/Kernel/VirtIO/VirtIO.cpp
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <Kernel/CommandLine.h>
 #include <Kernel/VirtIO/VirtIO.h>
 #include <Kernel/VirtIO/VirtIOConsole.h>
 #include <Kernel/VirtIO/VirtIORNG.h>
@@ -32,6 +33,8 @@ namespace Kernel {
 
 void VirtIO::detect()
 {
+    if (kernel_command_line().disable_virtio())
+        return;
     PCI::enumerate([&](const PCI::Address& address, PCI::ID id) {
         if (address.is_null() || id.is_null())
             return;


### PR DESCRIPTION
This command line flag can be used to disable VirtIO support on certain configurations (native windows) where interfacing with virtio devices can cause qemu to freeze. (This is a temporary fix for #6422)