### PR TITLE
AK/RedBlackTree: Refactor redundant code

### DIFF
--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -37,7 +37,7 @@ template<Integral K, typename V, IntrusiveRedBlackTreeNode<K> V::*member>
 class IntrusiveRedBlackTree : public BaseRedBlackTree<K> {
 public:
     IntrusiveRedBlackTree() = default;
-    virtual ~IntrusiveRedBlackTree() override
+    ~IntrusiveRedBlackTree()
     {
         clear();
     }
@@ -132,8 +132,8 @@ public:
 
         BaseTree::remove(node);
 
-        node->right_child = nullptr;
-        node->left_child = nullptr;
+        node->right_child() = nullptr;
+        node->left_child() = nullptr;
         node->m_in_tree = false;
 
         return true;
@@ -152,10 +152,10 @@ private:
     {
         if (!node)
             return;
-        clear_nodes(static_cast<TreeNode*>(node->right_child));
-        node->right_child = nullptr;
-        clear_nodes(static_cast<TreeNode*>(node->left_child));
-        node->left_child = nullptr;
+        clear_nodes(static_cast<TreeNode*>(node->right_child()));
+        node->right_child() = nullptr;
+        clear_nodes(static_cast<TreeNode*>(node->left_child()));
+        node->left_child() = nullptr;
         node->m_in_tree = false;
     }
 

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/Concepts.h>
 
 namespace AK {
@@ -38,89 +39,57 @@ public:
 
     enum class Color : bool {
         Red,
-        Black
+        Black,
     };
+
+    enum class NodeIndex : int {
+        Left = 0,
+        Right = 1,
+        Parent = 2,
+    };
+
     struct Node {
-        Node* left_child { nullptr };
-        Node* right_child { nullptr };
-        Node* parent { nullptr };
+        Array<Node*, 3> nodes {};
 
         Color color { Color::Red };
 
         K key;
 
-        Node(K key)
+        explicit Node(K key)
             : key(key)
         {
         }
-        virtual ~Node() {};
+
+        auto& left_child() { return nodes[int(NodeIndex::Left)]; }
+        auto& right_child() { return nodes[int(NodeIndex::Right)]; }
+        auto& parent() { return nodes[int(NodeIndex::Parent)]; }
     };
 
 protected:
     BaseRedBlackTree() = default; // These are protected to ensure no one instantiates the leaky base red black tree directly
-    virtual ~BaseRedBlackTree() {};
 
-    void rotate_left(Node* subtree_root)
+    template<auto TSide>
+    constexpr void rotate(Node* subtree_root)
     {
+        constexpr auto side = int(TSide);
+        constexpr auto other_side = TSide == NodeIndex::Left ? int(NodeIndex::Right) : int(NodeIndex::Left);
         VERIFY(subtree_root);
-        auto* pivot = subtree_root->right_child;
+        auto* pivot = subtree_root->nodes[other_side];
         VERIFY(pivot);
-        auto* parent = subtree_root->parent;
+        auto* parent = subtree_root->parent();
 
-        // stage 1 - subtree_root's right child is now pivot's left child
-        subtree_root->right_child = pivot->left_child;
-        if (subtree_root->right_child)
-            subtree_root->right_child->parent = subtree_root;
-
-        // stage 2 - pivot's left child is now subtree_root
-        pivot->left_child = subtree_root;
-        subtree_root->parent = pivot;
-
-        // stage 3 - update pivot's parent
-        pivot->parent = parent;
-        if (!parent) { // new root
-            m_root = pivot;
-        } else if (parent->left_child == subtree_root) { // we are the left child
-            parent->left_child = pivot;
-        } else { // we are the right child
-            parent->right_child = pivot;
-        }
-    }
-
-    void rotate_right(Node* subtree_root)
-    {
-        VERIFY(subtree_root);
-        auto* pivot = subtree_root->left_child;
-        VERIFY(pivot);
-        auto* parent = subtree_root->parent;
-
-        // stage 1 - subtree_root's left child is now pivot's right child
-        subtree_root->left_child = pivot->right_child;
-        if (subtree_root->left_child)
-            subtree_root->left_child->parent = subtree_root;
-
-        // stage 2 - pivot's right child is now subtree_root
-        pivot->right_child = subtree_root;
-        subtree_root->parent = pivot;
-
-        // stage 3 - update pivot's parent
-        pivot->parent = parent;
-        if (!parent) { // new root
-            m_root = pivot;
-        } else if (parent->left_child == subtree_root) { // we are the left child
-            parent->left_child = pivot;
-        } else { // we are the right child
-            parent->right_child = pivot;
-        }
+        update_child<NodeIndex(other_side)>(subtree_root, pivot->nodes[side]);
+        update_pivot_child<TSide>(pivot, subtree_root);
+        update_pivot_parent(pivot, parent, subtree_root);
     }
 
     static Node* find(Node* node, K key)
     {
         while (node && node->key != key) {
             if (key < node->key) {
-                node = node->left_child;
+                node = node->left_child();
             } else {
-                node = node->right_child;
+                node = node->right_child();
             }
         }
         return node;
@@ -133,10 +102,10 @@ protected:
             if (key == node->key) {
                 return node;
             } else if (key < node->key) {
-                node = node->left_child;
+                node = node->left_child();
             } else {
                 candidate = node;
-                node = node->right_child;
+                node = node->right_child();
             }
         }
         return candidate;
@@ -150,9 +119,9 @@ protected:
         while (temp) {
             parent = temp;
             if (node->key < temp->key) {
-                temp = temp->left_child;
+                temp = temp->left_child();
             } else {
-                temp = temp->right_child;
+                temp = temp->right_child();
             }
         }
         if (!parent) { // new root
@@ -162,57 +131,29 @@ protected:
             m_minimum = node;
             return;
         } else if (node->key < parent->key) { // we are the left child
-            parent->left_child = node;
+            parent->left_child() = node;
         } else { // we are the right child
-            parent->right_child = node;
+            parent->right_child() = node;
         }
-        node->parent = parent;
+        node->parent() = parent;
 
-        if (node->parent->parent) // no fixups to be done for a height <= 2 tree
+        if (node->parent()->parent()) // no fixups to be done for a height <= 2 tree
             insert_fixups(node);
 
         m_size++;
-        if (m_minimum->left_child == node)
+        if (m_minimum->left_child() == node)
             m_minimum = node;
     }
 
     void insert_fixups(Node* node)
     {
         VERIFY(node && node->color == Color::Red);
-        while (node->parent && node->parent->color == Color::Red) {
-            auto* grand_parent = node->parent->parent;
-            if (grand_parent->right_child == node->parent) {
-                auto* uncle = grand_parent->left_child;
-                if (uncle && uncle->color == Color::Red) {
-                    node->parent->color = Color::Black;
-                    uncle->color = Color::Black;
-                    grand_parent->color = Color::Red;
-                    node = grand_parent;
-                } else {
-                    if (node->parent->left_child == node) {
-                        node = node->parent;
-                        rotate_right(node);
-                    }
-                    node->parent->color = Color::Black;
-                    grand_parent->color = Color::Red;
-                    rotate_left(grand_parent);
-                }
+        while (node->parent() && node->parent()->color == Color::Red) {
+            auto* grand_parent = node->parent()->parent();
+            if (grand_parent->right_child() == node->parent()) {
+                color_fixup<NodeIndex::Left>(node, grand_parent);
             } else {
-                auto* uncle = grand_parent->right_child;
-                if (uncle && uncle->color == Color::Red) {
-                    node->parent->color = Color::Black;
-                    uncle->color = Color::Black;
-                    grand_parent->color = Color::Red;
-                    node = grand_parent;
-                } else {
-                    if (node->parent->right_child == node) {
-                        node = node->parent;
-                        rotate_left(node);
-                    }
-                    node->parent->color = Color::Black;
-                    grand_parent->color = Color::Red;
-                    rotate_right(grand_parent);
-                }
+                color_fixup<NodeIndex::Right>(node, grand_parent);
             }
         }
         m_root->color = Color::Black; // the root should always be black
@@ -235,64 +176,64 @@ protected:
         // removal assumes the node has 0 or 1 child, so if we have 2, relink with the successor first (by definition the successor has no left child)
         // FIXME: since we dont know how a value is represented in the node, we can't simply swap the values and keys, and instead we relink the nodes
         //  in place, this is quite a bit more expensive, as well as much less readable, is there a better way?
-        if (node->left_child && node->right_child) {
+        if (node->left_child() && node->right_child()) {
             auto* successor_node = successor(node); // this is always non-null as all nodes besides the maximum node have a successor, and the maximum node has no right child
-            auto neighbour_swap = successor_node->parent == node;
-            node->left_child->parent = successor_node;
+            auto neighbour_swap = successor_node->parent() == node;
+            node->left_child()->parent() = successor_node;
             if (!neighbour_swap)
-                node->right_child->parent = successor_node;
-            if (node->parent) {
-                if (node->parent->left_child == node) {
-                    node->parent->left_child = successor_node;
+                node->right_child()->parent() = successor_node;
+            if (node->parent()) {
+                if (node->parent()->left_child() == node) {
+                    node->parent()->left_child() = successor_node;
                 } else {
-                    node->parent->right_child = successor_node;
+                    node->parent()->right_child() = successor_node;
                 }
             } else {
                 m_root = successor_node;
             }
-            if (successor_node->right_child)
-                successor_node->right_child->parent = node;
+            if (successor_node->right_child())
+                successor_node->right_child()->parent() = node;
             if (neighbour_swap) {
-                successor_node->parent = node->parent;
-                node->parent = successor_node;
+                successor_node->parent() = node->parent();
+                node->parent() = successor_node;
             } else {
-                if (successor_node->parent) {
-                    if (successor_node->parent->left_child == successor_node) {
-                        successor_node->parent->left_child = node;
+                if (successor_node->parent()) {
+                    if (successor_node->parent()->left_child() == successor_node) {
+                        successor_node->parent()->left_child() = node;
                     } else {
-                        successor_node->parent->right_child = node;
+                        successor_node->parent()->right_child() = node;
                     }
                 } else {
                     m_root = node;
                 }
-                swap(node->parent, successor_node->parent);
+                swap(node->parent(), successor_node->parent());
             }
-            swap(node->left_child, successor_node->left_child);
+            swap(node->left_child(), successor_node->left_child());
             if (neighbour_swap) {
-                node->right_child = successor_node->right_child;
-                successor_node->right_child = node;
+                node->right_child() = successor_node->right_child();
+                successor_node->right_child() = node;
             } else {
-                swap(node->right_child, successor_node->right_child);
+                swap(node->right_child(), successor_node->right_child());
             }
             swap(node->color, successor_node->color);
         }
 
-        auto* child = node->left_child ?: node->right_child;
+        auto* child = node->left_child() ?: node->right_child();
 
         if (child)
-            child->parent = node->parent;
-        if (node->parent) {
-            if (node->parent->left_child == node)
-                node->parent->left_child = child;
+            child->parent() = node->parent();
+        if (node->parent()) {
+            if (node->parent()->left_child() == node)
+                node->parent()->left_child() = child;
             else
-                node->parent->right_child = child;
+                node->parent()->right_child() = child;
         } else {
             m_root = child;
         }
 
         // if the node is red then child must be black, and just replacing the node with its child should result in a valid tree (no change to black height)
         if (node->color != Color::Red)
-            remove_fixups(child, node->parent);
+            remove_fixups(child, node->parent());
 
         m_size--;
     }
@@ -301,91 +242,86 @@ protected:
     void remove_fixups(Node* node, Node* parent)
     {
         while (node != m_root && (!node || node->color == Color::Black)) {
-            if (parent->left_child == node) {
-                auto* sibling = parent->right_child;
+            if (parent->left_child() == node) {
+                auto* sibling = parent->right_child();
                 if (sibling->color == Color::Red) {
                     sibling->color = Color::Black;
                     parent->color = Color::Red;
-                    rotate_left(parent);
-                    sibling = parent->right_child;
+                    rotate<NodeIndex::Left>(parent);
+                    sibling = parent->right_child();
                 }
-                if ((!sibling->left_child || sibling->left_child->color == Color::Black) && (!sibling->right_child || sibling->right_child->color == Color::Black)) {
+                if ((!sibling->left_child() || sibling->left_child()->color == Color::Black) && (!sibling->right_child() || sibling->right_child()->color == Color::Black)) {
                     sibling->color = Color::Red;
                     node = parent;
                 } else {
-                    if (!sibling->right_child || sibling->right_child->color == Color::Black) {
-                        sibling->left_child->color = Color::Black; // null check?
+                    if (!sibling->right_child() || sibling->right_child()->color == Color::Black) {
+                        sibling->left_child()->color = Color::Black; // null check?
                         sibling->color = Color::Red;
-                        rotate_right(sibling);
-                        sibling = parent->right_child;
+                        rotate<NodeIndex::Right>(sibling);
+                        sibling = parent->right_child();
                     }
                     sibling->color = parent->color;
                     parent->color = Color::Black;
-                    sibling->right_child->color = Color::Black; // null check?
-                    rotate_left(parent);
+                    sibling->right_child()->color = Color::Black; // null check?
+                    rotate<NodeIndex::Left>(parent);
                     node = m_root; // fixed
                 }
             } else {
-                auto* sibling = parent->left_child;
+                auto* sibling = parent->left_child();
                 if (sibling->color == Color::Red) {
                     sibling->color = Color::Black;
                     parent->color = Color::Red;
-                    rotate_right(parent);
-                    sibling = parent->left_child;
+                    rotate<NodeIndex::Right>(parent);
+                    sibling = parent->left_child();
                 }
-                if ((!sibling->left_child || sibling->left_child->color == Color::Black) && (!sibling->right_child || sibling->right_child->color == Color::Black)) {
+                if ((!sibling->left_child() || sibling->left_child()->color == Color::Black) && (!sibling->right_child() || sibling->right_child()->color == Color::Black)) {
                     sibling->color = Color::Red;
                     node = parent;
                 } else {
-                    if (!sibling->left_child || sibling->left_child->color == Color::Black) {
-                        sibling->right_child->color = Color::Black; // null check?
+                    if (!sibling->left_child() || sibling->left_child()->color == Color::Black) {
+                        sibling->right_child()->color = Color::Black; // null check?
                         sibling->color = Color::Red;
-                        rotate_left(sibling);
-                        sibling = parent->left_child;
+                        rotate<NodeIndex::Left>(sibling);
+                        sibling = parent->left_child();
                     }
                     sibling->color = parent->color;
                     parent->color = Color::Black;
-                    sibling->left_child->color = Color::Black; // null check?
-                    rotate_right(parent);
+                    sibling->left_child()->color = Color::Black; // null check?
+                    rotate<NodeIndex::Right>(parent);
                     node = m_root; // fixed
                 }
             }
-            parent = node->parent;
+            parent = node->parent();
         }
         node->color = Color::Black; // by this point node can't be null
     }
 
     static Node* successor(Node* node)
     {
-        VERIFY(node);
-        if (node->right_child) {
-            node = node->right_child;
-            while (node->left_child)
-                node = node->left_child;
-            return node;
-        } else {
-            auto temp = node->parent;
-            while (temp && node == temp->right_child) {
-                node = temp;
-                temp = temp->parent;
-            }
-            return temp;
-        }
+        return next<NodeIndex::Right, NodeIndex::Left>(node);
     }
 
     static Node* predecessor(Node* node)
     {
+        return next<NodeIndex::Left, NodeIndex::Right>(node);
+    }
+
+    template<auto TDirection, auto TOtherDirection>
+    static Node* next(Node* node)
+    {
+        constexpr auto direction = int(TDirection);
+        constexpr auto other_direction = int(TOtherDirection);
         VERIFY(node);
-        if (node->left_child) {
-            node = node->left_child;
-            while (node->right_child)
-                node = node->right_child;
+        if (node->nodes[direction]) {
+            node = node->nodes[direction];
+            while (node->nodes[other_direction])
+                node = node->nodes[other_direction];
             return node;
         } else {
-            auto temp = node->parent;
-            while (temp && node == temp->left_child) {
+            auto temp = node->parent();
+            while (temp && node == temp->nodes[direction]) {
                 node = temp;
-                temp = temp->parent;
+                temp = temp->parent();
             }
             return temp;
         }
@@ -394,6 +330,65 @@ protected:
     Node* m_root { nullptr };
     size_t m_size { 0 };
     Node* m_minimum { nullptr }; // maintained for O(1) begin()
+
+private:
+    template<auto TSide>
+    constexpr void update_child(auto* subtree_root, const auto& pivot_other_child)
+    {
+        constexpr auto side = int(TSide);
+        subtree_root->nodes[side] = pivot_other_child;
+        if (subtree_root->nodes[side])
+            subtree_root->nodes[side]->parent() = subtree_root;
+    }
+
+    template<auto TSide>
+    constexpr void update_pivot_child(auto* pivot, auto* subtree_root)
+    {
+        constexpr auto side = int(TSide);
+        pivot->nodes[side] = subtree_root;
+        subtree_root->parent() = pivot;
+    }
+
+    void update_pivot_parent(auto* pivot, auto* parent, const auto* subtree_root)
+    {
+        pivot->parent() = parent;
+        if (!parent) { // new root
+            m_root = pivot;
+        } else if (parent->left_child() == subtree_root) { // we are the left child
+            parent->left_child() = pivot;
+        } else { // we are the right child
+            parent->right_child() = pivot;
+        }
+    }
+
+    template<auto TSide>
+    constexpr void color_fixup(auto& node, auto* grand_parent)
+    {
+        constexpr auto side = int(TSide);
+        auto* uncle = grand_parent->nodes[side];
+        if (uncle && uncle->color == Color::Red) {
+            node->parent()->color = Color::Black;
+            uncle->color = Color::Black;
+            grand_parent->color = Color::Red;
+            node = grand_parent;
+        } else {
+            if (node->parent()->nodes[side] == node) {
+                node = node->parent();
+                if constexpr (TSide == NodeIndex::Left) {
+                    rotate<NodeIndex::Right>(node);
+                } else {
+                    rotate<NodeIndex::Left>(node);
+                }
+            }
+            node->parent()->color = Color::Black;
+            grand_parent->color = Color::Red;
+            if constexpr (TSide == NodeIndex::Right) {
+                rotate<NodeIndex::Right>(grand_parent);
+            } else {
+                rotate<NodeIndex::Left>(grand_parent);
+            }
+        }
+    }
 };
 
 template<typename TreeType, typename ElementType>
@@ -438,7 +433,7 @@ template<Integral K, typename V>
 class RedBlackTree : public BaseRedBlackTree<K> {
 public:
     RedBlackTree() = default;
-    virtual ~RedBlackTree() override
+    ~RedBlackTree()
     {
         clear();
     }
@@ -493,8 +488,8 @@ public:
 
         V temp = move(static_cast<Node*>(node)->value);
 
-        node->right_child = nullptr;
-        node->left_child = nullptr;
+        node->right_child() = nullptr;
+        node->left_child() = nullptr;
         delete node;
 
         return temp;
@@ -508,8 +503,8 @@ public:
 
         BaseTree::remove(node);
 
-        node->right_child = nullptr;
-        node->left_child = nullptr;
+        node->right_child() = nullptr;
+        node->left_child() = nullptr;
         delete node;
 
         return true;
@@ -538,10 +533,10 @@ private:
 
         ~Node()
         {
-            if (this->left_child)
-                delete this->left_child;
-            if (this->right_child)
-                delete this->right_child;
+            if (this->left_child())
+                delete this->left_child();
+            if (this->right_child())
+                delete this->right_child();
         }
     };
 };


### PR DESCRIPTION
Problem:
- `virtual` destructors in otherwise non-`virtual` classes.
- Non-explicit single argument constructor to `AK::RedBlackTree::Node`
- Redundant code with just side of tree differences.

Solution:
- Remove virtual destructors.
- Make `AK::RedBlackTree::Node` constructor explicit because it only has a single argument.
- Commonize code using template arguments to determine the side.