### PR TITLE
Shell/Tests: `type f -f` -> `type -f f` to make it work with ArgsParser / Userland/test: '!' being used as a string

### DIFF
--- a/Userland/Shell/Tests/builtin-test.sh
+++ b/Userland/Shell/Tests/builtin-test.sh
@@ -12,7 +12,7 @@ f() { ls }
 if not [ "$(type f)" = "f is a function f() { ls }" ] { fail "'type' on a function not working" }
 
 
-if not [ "$(type f -f)" = "f is a function" ] { fail "'type' on a function not working with -f" }
+if not [ "$(type -f f)" = "f is a function" ] { fail "'type' on a function not working with -f" }
 
 alias l=ls
 


### PR DESCRIPTION
Fixes #6465 
Fixes #6467 