### PR TITLE
Meta: Remove references to Userland/Libraries/LibELF/exec_elf.h

### DIFF
--- a/Meta/check-debug-flags.sh
+++ b/Meta/check-debug-flags.sh
@@ -26,7 +26,6 @@ done < <(
         '*.h' \
         '*.in' \
         ':!:Kernel/FileSystem/ext2_fs.h' \
-        ':!:Userland/Libraries/LibELF/exec_elf.h' \
     | xargs grep -P '(_DEBUG|DEBUG_)' \
     | sed -re 's,^.*[^a-zA-Z0-9_]([a-zA-Z0-9_]*DEBUG[a-zA-Z0-9_]*).*$,\1,' \
     | sort \

--- a/Meta/check-newlines-at-eof.py
+++ b/Meta/check-newlines-at-eof.py
@@ -22,8 +22,7 @@ def run():
             "CMake*.txt",
             "**/CMake*.txt",
             ":!:AK/Tests/*.json",
-            ":!:Kernel/FileSystem/ext2_fs.h",
-            ":!:Userland/Libraries/LibELF/exec_elf.h"
+            ":!:Kernel/FileSystem/ext2_fs.h"
         ],
         check=True,
         capture_output=True

--- a/Meta/check-style.sh
+++ b/Meta/check-style.sh
@@ -41,7 +41,6 @@ done < <(git ls-files -- \
     '*.h' \
     ':!:Base' \
     ':!:Kernel/FileSystem/ext2_fs.h' \
-    ':!:Userland/Libraries/LibELF/exec_elf.h' \
 )
 
 exit_status=0

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -12,8 +12,7 @@ if [ "$#" -eq "1" ]; then
             '*.h' \
             ':!:Base' \
             ':!:Kernel/FileSystem/ext2_fs.h' \
-            ':!:Userland/Libraries/LibC/syslog.h' \
-            ':!:Userland/Libraries/LibELF/exec_elf.h'
+            ':!:Userland/Libraries/LibC/syslog.h'
     )
 else
     files=()


### PR DESCRIPTION
This file no longer exists.
