### PR TITLE
Kernel + LibC: + profile: Expose ability to free kernel profiling buffer, and the ability to disable profiling on user input

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -171,6 +171,7 @@ namespace Kernel {
     S(purge)                  \
     S(profiling_enable)       \
     S(profiling_disable)      \
+    S(profiling_free_buffer)  \
     S(futex)                  \
     S(chroot)                 \
     S(pledge)                 \

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -700,6 +700,12 @@ bool Process::create_perf_events_buffer_if_needed()
     return !!m_perf_event_buffer;
 }
 
+void Process::delete_perf_events_buffer()
+{
+    if (m_perf_event_buffer)
+        m_perf_event_buffer = nullptr;
+}
+
 bool Process::remove_thread(Thread& thread)
 {
     ProtectedDataMutationScope scope { *this };

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -394,6 +394,7 @@ public:
     KResultOr<int> sys$module_unload(Userspace<const char*> name, size_t name_length);
     KResultOr<int> sys$profiling_enable(pid_t);
     KResultOr<int> sys$profiling_disable(pid_t);
+    KResultOr<int> sys$profiling_free_buffer(pid_t);
     KResultOr<int> sys$futex(Userspace<const Syscall::SC_futex_params*>);
     KResultOr<int> sys$chroot(Userspace<const char*> path, size_t path_length, int mount_flags);
     KResultOr<int> sys$pledge(Userspace<const Syscall::SC_pledge_params*>);
@@ -520,6 +521,7 @@ private:
     bool dump_core();
     bool dump_perfcore();
     bool create_perf_events_buffer_if_needed();
+    void delete_perf_events_buffer();
 
     KResult do_exec(NonnullRefPtr<FileDescription> main_program_description, Vector<String> arguments, Vector<String> environment, RefPtr<FileDescription> interpreter_description, Thread*& new_main_thread, u32& prev_flags, const Elf32_Ehdr& main_program_header);
     KResultOr<ssize_t> do_write(FileDescription&, const UserOrKernelBuffer&, size_t);

--- a/Userland/Libraries/LibC/serenity.cpp
+++ b/Userland/Libraries/LibC/serenity.cpp
@@ -62,6 +62,12 @@ int profiling_disable(pid_t pid)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+int profiling_free_buffer(pid_t pid)
+{
+    int rc = syscall(SC_profiling_free_buffer, pid);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
 int futex(uint32_t* userspace_address, int futex_op, uint32_t value, const struct timespec* timeout, uint32_t* userspace_address2, uint32_t value3)
 {
     int rc;

--- a/Userland/Libraries/LibC/serenity.h
+++ b/Userland/Libraries/LibC/serenity.h
@@ -39,6 +39,7 @@ int module_unload(const char* name, size_t name_length);
 
 int profiling_enable(pid_t);
 int profiling_disable(pid_t);
+int profiling_free_buffer(pid_t);
 
 #define THREAD_PRIORITY_MIN 1
 #define THREAD_PRIORITY_LOW 10


### PR DESCRIPTION
A few changes here:

-  Add a syscall to clear the profiling buffer, expose it via LibC/profile frontend.

    While profiling all processes the profile buffer lives forever.
    Once you have copied the profile to disk, there's no need to keep it
    in memory. This syscall surfaces the ability to clear that buffer.

-  Add an option to wait for user input to disable profiling.

    Often you want to enable and then disable profiling after a period of time.
    To make this slightly more ergonomic, add an option to wait for user
    input after enabling profiling, this will disable profiling on exit
    after the key press.