### PR TITLE
 LibELF: Fix support for relocating weak symbols

### DIFF
--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -444,7 +444,7 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(size_t total_tls_si
             if (symbol.bind() == STB_WEAK)
                 return RelocationResult::ResolveLater;
             dbgln("ERROR: symbol not found: {}.", symbol.name());
-            VERIFY_NOT_REACHED();
+            return RelocationResult::Failed;
         }
         auto symbol_address = res.value().address;
         *patch_ptr += symbol_address.get();
@@ -453,7 +453,8 @@ DynamicLoader::RelocationResult DynamicLoader::do_relocation(size_t total_tls_si
     case R_386_PC32: {
         auto symbol = relocation.symbol();
         auto result = lookup_symbol(symbol);
-        VERIFY(result.has_value());
+        if (!result.has_value())
+            return RelocationResult::Failed;
         auto relative_offset = result.value().address - m_dynamic_object->base_address().offset(relocation.offset());
         *patch_ptr += relative_offset.get();
         break;

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -54,6 +54,11 @@ private:
     size_t m_size;
 };
 
+enum class ShouldInitializeWeak {
+    Yes,
+    No
+};
+
 class DynamicLoader : public RefCounted<DynamicLoader> {
 public:
     static RefPtr<DynamicLoader> try_create(int fd, String filename);
@@ -145,7 +150,7 @@ private:
         Success = 1,
         ResolveLater = 2,
     };
-    RelocationResult do_relocation(size_t total_tls_size, const DynamicObject::Relocation&);
+    RelocationResult do_relocation(size_t total_tls_size, const DynamicObject::Relocation&, ShouldInitializeWeak should_initialize_weak);
     size_t calculate_tls_size() const;
 
     String m_filename;

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -475,7 +475,7 @@ VirtualAddress DynamicObject::patch_plt_entry(u32 relocation_offset)
 
     auto result = DynamicLoader::lookup_symbol(symbol);
     if (!result.has_value()) {
-        dbgln("did not find symbol: {}", symbol.name());
+        dbgln("did not find symbol while doing relocations for library {}: {}", m_filename, symbol.name());
         VERIFY_NOT_REACHED();
     }
 


### PR DESCRIPTION
Having unresolved weak symbols is allowed and we should initialize them to zero. This allows users to check whether a symbol is available at runtime:

```
__attribute__((weak)) void weak_func();

int main() {
    if (weak_func)
        weak_func();
}
```