### PR TITLE
LibLine: Don't restore() when not initialized / LibLine: Redraw suggestions on resize / Shell: Less whining about tcsetpgrp()

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -576,6 +576,20 @@ void Editor::interrupted()
     });
 }
 
+void Editor::resized()
+{
+    m_was_resized = true;
+    m_previous_num_columns = m_num_columns;
+    get_terminal_size();
+
+    reposition_cursor(true);
+    m_suggestion_display->redisplay(m_suggestion_manager, m_num_lines, m_num_columns);
+    reposition_cursor();
+
+    if (m_is_searching)
+        m_search_editor->resized();
+}
+
 void Editor::really_quit_event_loop()
 {
     m_finish = false;

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -600,7 +600,9 @@ void Editor::really_quit_event_loop()
     m_buffer.clear();
     m_chars_touched_in_the_middle = buffer().size();
     m_is_editing = false;
-    restore();
+
+    if (m_initialized)
+        restore();
 
     m_returned_line = string;
 

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -189,15 +189,7 @@ public:
 #undef __ENUMERATE_EDITOR_INTERNAL_FUNCTION
 
     void interrupted();
-    void resized()
-    {
-        m_was_resized = true;
-        m_previous_num_columns = m_num_columns;
-        get_terminal_size();
-        m_suggestion_display->set_vt_size(m_num_lines, m_num_columns);
-        if (m_is_searching)
-            m_search_editor->resized();
-    }
+    void resized();
 
     size_t cursor() const { return m_cursor; }
     void set_cursor(size_t cursor)

--- a/Userland/Libraries/LibLine/SuggestionDisplay.h
+++ b/Userland/Libraries/LibLine/SuggestionDisplay.h
@@ -44,6 +44,17 @@ public:
     virtual void finish() = 0;
     virtual void set_initial_prompt_lines(size_t) = 0;
 
+    void redisplay(const SuggestionManager& manager, size_t lines, size_t columns)
+    {
+        if (m_is_showing_suggestions) {
+            cleanup();
+            set_vt_size(lines, columns);
+            display(manager);
+        } else {
+            set_vt_size(lines, columns);
+        }
+    }
+
     virtual void set_vt_size(size_t lines, size_t columns) = 0;
 
     size_t origin_row() const { return m_origin_row; }
@@ -56,8 +67,12 @@ public:
     }
 
 protected:
+    void did_display() { m_is_showing_suggestions = true; }
+    void did_cleanup() { m_is_showing_suggestions = false; }
+
     int m_origin_row { 0 };
     int m_origin_column { 0 };
+    bool m_is_showing_suggestions { false };
 };
 
 class XtermSuggestionDisplay : public SuggestionDisplay {

--- a/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -35,6 +35,8 @@ namespace Line {
 
 void XtermSuggestionDisplay::display(const SuggestionManager& manager)
 {
+    did_display();
+
     size_t longest_suggestion_length = 0;
     size_t longest_suggestion_byte_length = 0;
 
@@ -172,6 +174,8 @@ void XtermSuggestionDisplay::display(const SuggestionManager& manager)
 
 bool XtermSuggestionDisplay::cleanup()
 {
+    did_cleanup();
+
     if (m_lines_used_for_last_suggestions) {
         VT::clear_lines(0, m_lines_used_for_last_suggestions);
         m_lines_used_for_last_suggestions = 0;

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -822,10 +822,12 @@ RefPtr<Job> Shell::run_command(const AST::Command& command)
             perror("setpgid");
 
         if (!m_is_subshell) {
-            if (tcsetpgrp(STDOUT_FILENO, pgid) != 0 && m_is_interactive)
-                perror("tcsetpgrp(OUT)");
-            if (tcsetpgrp(STDIN_FILENO, pgid) != 0 && m_is_interactive)
-                perror("tcsetpgrp(IN)");
+            // There's no reason to care about the errors here
+            // either we're in a tty, we're interactive, and this works
+            // or we're not, and it fails - in which case, we don't need
+            // stdin/stdout handoff to child processes anyway.
+            tcsetpgrp(STDOUT_FILENO, pgid);
+            tcsetpgrp(STDIN_FILENO, pgid);
         }
     }
 


### PR DESCRIPTION
(Are these PR names getting too damn long? I should start splitting these into multiple PRs...)

cc @nooga for the suggestions thing.
cc @Lubrsi and whomever was torturing libline yesterday

Fixes #6472.
Closes #6471.