### PR TITLE
Ports: Add port for xz

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -110,6 +110,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`vim`](vim/)                          | Vim                                                        | 8.2.2772                 | https://www.vim.org/                                                           |
 | [`vitetris`](vitetris/)                | vitetris                                                   | 0.59.1                   | https://github.com/vicgeralds/vitetris                                         |
 | [`vttest`](vttest/)                    | vttest                                                     | 20210210                 | https://invisible-island.net/vttest/                                           |
+| [`xz`](xz/)                            | xz                                                         | 5.2.5                    | https://tukaani.org/xz/                                                        |
 | [`yasm`](yasm/)                        | Yasm Modular Assembler                                     | 1.3.0                    | https://yasm.tortall.net/                                                      |
 | [`zlib`](zlib/)                        | zlib                                                       | 1.2.11                   | https://www.zlib.net/                                                          |
 | [`zstd`](zstd/)                        | Zstandard                                                  | 1.4.4                    | https://facebook.github.io/zstd/                                               |

--- a/Ports/xz/package.sh
+++ b/Ports/xz/package.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=xz
+version=5.2.5
+useconfigure=true
+files="https://tukaani.org/xz/xz-${version}.tar.gz xz-${version}.tar.gz f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"
+auth_type=sha256
+depends="zlib libiconv"
+
+install() {
+    run make DESTDIR=$DESTDIR $installopts install
+    ${CC} -shared -o $DESTDIR/usr/local/lib/liblzma.so -Wl,--whole-archive $DESTDIR/usr/local/lib/liblzma.a -Wl,--no-whole-archive -lz -liconv
+    rm -f $DESTDIR/usr/local/lib/liblzma.la
+}

--- a/Ports/xz/patches/configure.patch
+++ b/Ports/xz/patches/configure.patch
@@ -1,0 +1,12 @@
+diff -Naur xz-5.2.5/build-aux/config.sub xz-5.2.5.serenity/build-aux/config.sub
+--- xz-5.2.5/build-aux/config.sub	2020-03-17 15:29:35.000000000 +0100
++++ xz-5.2.5.serenity/build-aux/config.sub	2021-04-18 21:28:26.405741777 +0200
+@@ -1363,7 +1363,7 @@
+ 	# The portable systems comes first.
+ 	# Each alternative MUST end in a * to match a version number.
+ 	# -sysv* is not here because it comes later, after sysvr4.
+-	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
++	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* | -serenity* \
+ 	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -cnk* | -sunos | -sunos[34]*\
+ 	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -auroraux* | -solaris* \
+ 	      | -sym* | -kopensolaris* | -plan9* \

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -143,6 +143,16 @@ void pthread_exit(void* value_ptr)
     exit_thread(value_ptr);
 }
 
+void pthread_cleanup_push([[maybe_unused]] void (*routine)(void*), [[maybe_unused]] void* arg)
+{
+    TODO();
+}
+
+void pthread_cleanup_pop([[maybe_unused]] int execute)
+{
+    TODO();
+}
+
 int pthread_join(pthread_t thread, void** exit_value_ptr)
 {
     int rc = syscall(SC_join_thread, thread, exit_value_ptr);


### PR DESCRIPTION
The `libpthread` changes are necessary to make the `xz` port properly detect `pthread` support. The two functions are only used in the configure script and nowhere else.

This port depends on #6343, i.e. won't build properly without it because `-pthread` isn't supported.