### PR TITLE
Ports: Changed variable names in .hosted_defs.sh

### DIFF
--- a/Ports/.hosted_defs.sh
+++ b/Ports/.hosted_defs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export SERENITY_ROOT="$(realpath "${SCRIPT}/../")"
+export SERENITY_SOURCE_DIR="$(realpath "${SCRIPT}/../")"
 export SERENITY_BUILD_DIR="${SERENITY_ROOT}/Build/${SERENITY_ARCH}"
 export CC="${SERENITY_ARCH}-pc-serenity-gcc"
 export CXX="${SERENITY_ARCH}-pc-serenity-g++"
@@ -9,6 +9,11 @@ export PATH="${SERENITY_ROOT}/Toolchain/Local/${SERENITY_ARCH}/bin:${PATH}"
 export PKG_CONFIG_DIR=""
 export PKG_CONFIG_SYSROOT_DIR="${SERENITY_BUILD_DIR}/Root"
 export PKG_CONFIG_LIBDIR="${PKG_CONFIG_SYSROOT_DIR}/usr/lib/pkgconfig/:${PKG_CONFIG_SYSROOT_DIR}/usr/local/lib/pkgconfig"
+
+# To be removed.
+export SERENITY_ROOT="$(realpath "${SCRIPT}/../")"
+
 enable_ccache
 
 DESTDIR="${SERENITY_BUILD_DIR}/Root"
+export SERENITY_INSTALL_ROOT="$DESTDIR"

--- a/Ports/.hosted_defs.sh
+++ b/Ports/.hosted_defs.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 export SERENITY_SOURCE_DIR="$(realpath "${SCRIPT}/../")"
-export SERENITY_BUILD_DIR="${SERENITY_ROOT}/Build/${SERENITY_ARCH}"
+export SERENITY_BUILD_DIR="${SERENITY_SOURCE_DIR}/Build/${SERENITY_ARCH}"
 export CC="${SERENITY_ARCH}-pc-serenity-gcc"
 export CXX="${SERENITY_ARCH}-pc-serenity-g++"
 export AR="${SERENITY_ARCH}-pc-serenity-ar"
 export RANLIB="${SERENITY_ARCH}-pc-serenity-ranlib"
-export PATH="${SERENITY_ROOT}/Toolchain/Local/${SERENITY_ARCH}/bin:${PATH}"
+export PATH="${SERENITY_SOURCE_DIR}/Toolchain/Local/${SERENITY_ARCH}/bin:${PATH}"
 export PKG_CONFIG_DIR=""
 export PKG_CONFIG_SYSROOT_DIR="${SERENITY_BUILD_DIR}/Root"
 export PKG_CONFIG_LIBDIR="${PKG_CONFIG_SYSROOT_DIR}/usr/lib/pkgconfig/:${PKG_CONFIG_SYSROOT_DIR}/usr/local/lib/pkgconfig"


### PR DESCRIPTION
- DESTDIR and SERENITY_ROOT have not been removed for the time being, in order to ensure a steady transition and to not break all the ports at once.

... Lots of stuff being unpacked here. This was implemented based on this suggestion: https://github.com/SerenityOS/serenity/pull/6482#issuecomment-822356488

In other news, I figured out where the variables are located and what each variable does, so that's good.