### PR TITLE
LibELF: Fixes for loading libicudata.so

### DIFF
--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -306,8 +306,7 @@ void DynamicLoader::load_program_headers()
         return IterationDecision::Continue;
     });
 
-    VERIFY(!text_regions.is_empty());
-    VERIFY(!data_regions.is_empty());
+    VERIFY(!text_regions.is_empty() || !data_regions.is_empty());
 
     auto compare_load_address = [](ProgramHeaderRegion& a, ProgramHeaderRegion& b) {
         return a.desired_load_address().as_ptr() < b.desired_load_address().as_ptr();

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -183,6 +183,8 @@ void DynamicObject::parse()
         case DT_NEEDED:
             // We handle these in for_each_needed_library
             break;
+        case DT_SYMBOLIC:
+            break;
         default:
             dbgln("DynamicObject: DYNAMIC tag handling not implemented for DT_{}", name_for_dtag(entry.tag()));
             VERIFY_NOT_REACHED(); // FIXME: Maybe just break out here and return false?


### PR DESCRIPTION
This fixes the dynamic loader so that it can successfully load `libicudata.so`:

* It allows loading shared libraries which don't have any text segments.
* It properly ignores `DT_SYMBOLIC` dynamic entries.