### PR TITLE
LibC: Additional functionality for getaddrinfo()

### DIFF
--- a/Userland/Libraries/LibC/netdb.cpp
+++ b/Userland/Libraries/LibC/netdb.cpp
@@ -667,6 +667,13 @@ int getaddrinfo(const char* __restrict node, const char* __restrict service, con
     if (hints && hints->ai_family != AF_INET && hints->ai_family != AF_UNSPEC)
         return EAI_FAMILY;
 
+    if (!node) {
+        if (hints && hints->ai_flags & AI_PASSIVE)
+            node = "0.0.0.0";
+        else
+            node = "127.0.0.1";
+    }
+
     auto host_ent = gethostbyname(node);
     if (!host_ent)
         return EAI_FAIL;


### PR DESCRIPTION
When node is `NULL` and `AI_PASSIVE` is specified we are supposed to use the "any" address, otherwise we should use the loopback address.