### PR TITLE
Kernel: Stop treating port 0 (ephemeral auto bind) as a privileged port

### DIFF
--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -112,7 +112,7 @@ KResult IPv4Socket::bind(Userspace<const sockaddr*> user_address, socklen_t addr
 
     auto requested_local_port = ntohs(address.sin_port);
     if (!Process::current()->is_superuser()) {
-        if (requested_local_port < 1024) {
+        if (requested_local_port > 0 && requested_local_port < 1024) {
             dbgln("UID {} attempted to bind {} to port {}", Process::current()->uid(), class_name(), requested_local_port);
             return EACCES;
         }


### PR DESCRIPTION
Binding to port 0 is used to signal to listen() to bind to any port that is available. (in serenity's case, to the port range of 32768 to 60999, which are not privileged ports)

(This should help with getting networking working in @gunnarbeutner's openttd port)