### PR TITLE
Meta: Stop limiting stale-bot actions per hour.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -45,7 +45,7 @@ closeComment: >
   Thank you for your contributions!
 
 # Limit the number of actions per hour, from 1-30. Default is 30
-limitPerRun: 2
+limitPerRun: 30
 
 # Limit to only `issues` or `pulls`
 only: pulls


### PR DESCRIPTION
Initially this was configured to 2 an hour so that we could easily
disable stale-bot if something went haywire. Now that it's successfully
proved it's doing what it's supposed to, let it run the default number
of actions per hour.