### PR TITLE
Meta: Reduce cmake warning space coming from icon-size detection + add rebuild-world to serenity.sh

### DIFF
--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -86,7 +86,13 @@ function(serenity_app target_name)
     if (EXISTS "${medium_icon}")
         embed_resource("${target_name}" serenity_icon_m "${medium_icon}")
     else()
-        message(WARNING "Missing medium app icon: ${medium_icon}")
+        # These icons are designed small only for use in applets, and thus are exempt.
+        list(APPEND allowed_missing_medium_icons "audio-volume-high")
+        list(APPEND allowed_missing_medium_icons "edit-copy")
+
+        if (NOT ${SERENITY_APP_ICON} IN_LIST allowed_missing_medium_icons)
+            message(WARNING "Missing medium app icon: ${medium_icon}")
+        endif()
     endif()
 endfunction()
 

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -39,6 +39,7 @@ Usage: $NAME COMMAND [TARGET] [ARGS...]
                     Resolves the ADDRESS in BINARY_FILE to a file:line. It will
                     attempt to find the BINARY_FILE in the appropriate build directory
     rebuild-toolchain: Deletes and re-builds the TARGET's toolchain
+    rebuild-world:     Deletes and re-builds the toolchain and build environment for TARGET.
 
   Examples:
     $NAME run i686 smp=on
@@ -307,6 +308,14 @@ elif [ "$CMD" = "rebuild-toolchain" ]; then
     lagom_unsupported "The lagom target uses the host toolchain"
     delete_toolchain
     ensure_toolchain
+elif [ "$CMD" = "rebuild-world" ]; then
+    cmd_with_target
+    lagom_unsupported "The lagom target uses the host toolchain"
+    delete_toolchain
+    delete_target
+    ensure_toolchain
+    ensure_target
+    build_target
 elif [ "$CMD" = "__tmux_cmd" ]; then
     trap kill_tmux_session EXIT
     cmd_with_target


### PR DESCRIPTION
-  Add a rebuild-world command to serenity.sh

    This was brought up as something that would be useful by
    `RealKC` on the discord, and I happened to agree that it
    would be useful. Especially given the abundance of Toolchain
    changes recently.

-  Add allow-list for icon size detection in CMake

    The only icons we are currently warning about are designed
    and rendered as small icons intentionally, as their only use
    is in desktop applets, and thus are exempt to this rule.

    This reduces build spam back down to a minimum.
    I should have just done this in the first place, back in #4729