### PR TITLE
LibC: Add ctime_r() / asctime_r() / INET6_ADDRSTRLEN implementations + start LibC unit tests.

### DIFF
--- a/Userland/DynamicLoader/CMakeLists.txt
+++ b/Userland/DynamicLoader/CMakeLists.txt
@@ -8,6 +8,8 @@ file(GLOB AK_SOURCES "../../AK/*.cpp")
 file(GLOB ELF_SOURCES "../Libraries/LibELF/*.cpp")
 file(GLOB LIBC_SOURCES1 "../Libraries/LibC/*.cpp")
 file(GLOB LIBC_SOURCES2 "../Libraries/LibC/*/*.cpp")
+file(GLOB LIBC_TEST_SOURCES "../Libraries/LibC/Tests/*.cpp")
+list(REMOVE_ITEM LIBC_SOURCES2 ${LIBC_TEST_SOURCES})
 
 if ("${SERENITY_ARCH}" STREQUAL "i686")
     file(GLOB LIBC_SOURCES3 "../Libraries/LibC/arch/i386/*.S")

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(Tests)
+
 set(LIBC_SOURCES
     arpa/inet.cpp
     assert.cpp

--- a/Userland/Libraries/LibC/Tests/CMakeLists.txt
+++ b/Userland/Libraries/LibC/Tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB TEST_SOURCES CONFIGURE_DEPENDS "*.cpp")
+
+foreach(source ${TEST_SOURCES})
+    get_filename_component(name ${source} NAME_WE)
+    add_executable(${name} ${source})
+    target_link_libraries(${name} LibC LibCore)
+    install(TARGETS ${name} RUNTIME DESTINATION usr/Tests/LibC)
+endforeach()

--- a/Userland/Libraries/LibC/Tests/TestLibCTime.cpp
+++ b/Userland/Libraries/LibC/Tests/TestLibCTime.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, Brian Gianforcaro <b.gianfo@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/StringView.h>
+#include <AK/TestSuite.h>
+#include <time.h>
+
+const auto expected_epoch = "Thu Jan  1 00:00:00 1970\n"sv;
+
+TEST_CASE(asctime)
+{
+    time_t epoch = 0;
+    auto result = asctime(localtime(&epoch));
+    EXPECT_EQ(expected_epoch, StringView(result));
+}
+
+TEST_CASE(asctime_r)
+{
+    char buffer[26] {};
+    time_t epoch = 0;
+    auto result = asctime_r(localtime(&epoch), buffer);
+    EXPECT_EQ(expected_epoch, StringView(result));
+}
+
+TEST_CASE(ctime)
+{
+    time_t epoch = 0;
+    auto result = ctime(&epoch);
+
+    EXPECT_EQ(expected_epoch, StringView(result));
+}
+
+TEST_CASE(ctime_r)
+{
+    char buffer[26] {};
+    time_t epoch = 0;
+    auto result = ctime_r(&epoch, buffer);
+
+    EXPECT_EQ(expected_epoch, StringView(result));
+}
+
+TEST_MAIN(LibCTime)

--- a/Userland/Libraries/LibC/arpa/inet.h
+++ b/Userland/Libraries/LibC/arpa/inet.h
@@ -35,6 +35,7 @@
 __BEGIN_DECLS
 
 #define INET_ADDRSTRLEN 16
+#define INET6_ADDRSTRLEN 46
 
 const char* inet_ntop(int af, const void* src, char* dst, socklen_t);
 int inet_pton(int af, const char* src, void* dst);

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -84,6 +84,12 @@ char* ctime(const time_t* t)
     return asctime(localtime(t));
 }
 
+char* ctime_r(const time_t* t, char* buf)
+{
+    struct tm tm_buf;
+    return asctime_r(localtime_r(t, &tm_buf), buf);
+}
+
 static const int __seconds_per_day = 60 * 60 * 24;
 
 static void time_to_tm(struct tm* tm, time_t t)
@@ -180,7 +186,14 @@ struct tm* gmtime_r(const time_t* t, struct tm* tm)
 char* asctime(const struct tm* tm)
 {
     static char buffer[69];
-    strftime(buffer, sizeof buffer, "%a %b %e %T %Y", tm);
+    return asctime_r(tm, buffer);
+}
+
+char* asctime_r(const struct tm* tm, char* buffer)
+{
+    // Spec states buffer must be at least 26 bytes.
+    constexpr size_t assumed_len = 26;
+    strftime(buffer, assumed_len, "%a %b %e %T %Y", tm);
     return buffer;
 }
 

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -193,7 +193,11 @@ char* asctime_r(const struct tm* tm, char* buffer)
 {
     // Spec states buffer must be at least 26 bytes.
     constexpr size_t assumed_len = 26;
-    strftime(buffer, assumed_len, "%a %b %e %T %Y", tm);
+    size_t filled_size = strftime(buffer, assumed_len, "%a %b %e %T %Y\n", tm);
+
+    // Verify that the buffer was large enough.
+    VERIFY(filled_size != 0);
+
     return buffer;
 }
 

--- a/Userland/Libraries/LibC/time.h
+++ b/Userland/Libraries/LibC/time.h
@@ -57,8 +57,10 @@ time_t mktime(struct tm*);
 time_t timegm(struct tm*);
 time_t time(time_t*);
 char* ctime(const time_t*);
+char* ctime_r(const time_t* tm, char* buf);
 void tzset();
 char* asctime(const struct tm*);
+char* asctime_r(const struct tm*, char* buf);
 
 #define CLOCKS_PER_SEC 1000
 clock_t clock();


### PR DESCRIPTION
These are some of the things I need for porting [fio](https://fio.readthedocs.io)

-   __LibC: Add ctime_r() and asctime_r() implementations__

-   __LibC: Setup a unit test harness for LibC, add tests.__

    LibC is no different than any other code, it should be unit tested where
    appropriate / possible. Add some ctime_r / asctime_r tests. 

-   __LibC: Add a definition for `INET6_ADDRSTRLEN`__

    Although serenity doesn't implement IPv6 yet, applications
    will often declare buffers to be of size `INET6_ADDRSTRLEN`
    so it's guaranteed to work in both IPv4 / IPv6 environments.

    This is standardized here:
    https://pubs.opengroup.org/onlinepubs/009695399/basedefs/netinet/in.h.html
