### PR TITLE
LibGUI: Make statusbar label flat when displaying override_text

### DIFF
--- a/Userland/Libraries/LibGUI/Statusbar.cpp
+++ b/Userland/Libraries/LibGUI/Statusbar.cpp
@@ -93,7 +93,16 @@ void Statusbar::set_text(size_t index, String text)
 void Statusbar::update_label(size_t index)
 {
     auto& segment = m_segments.at(index);
-    segment.label->set_text(segment.override_text.is_null() ? segment.text : segment.override_text);
+
+    if (segment.override_text.is_null()) {
+        segment.label->set_frame_shadow(Gfx::FrameShadow::Sunken);
+        segment.label->set_frame_shape(Gfx::FrameShape::Panel);
+        segment.label->set_text(segment.text);
+    } else {
+        segment.label->set_frame_shadow(Gfx::FrameShadow::Plain);
+        segment.label->set_frame_shape(Gfx::FrameShape::NoFrame);
+        segment.label->set_text(segment.override_text);
+    }
 }
 
 String Statusbar::text(size_t index) const


### PR DESCRIPTION
Changing the statusbar appearance when overriding text makes it less
confusing as it's supposed to be something temporary, e.g.  only when
hovering over a toolbar or menu item.

This behavior is present on old Windows systems, although things work
slightly differently there (where only the overridden text is displayed
rather than all the segments).

How it looks when a toolbar button is being hovered:
![Screenshot from 2021-04-19 23-57-15](https://user-images.githubusercontent.com/15001/115351338-ac75a900-a1a5-11eb-89bc-3c5ab745c571.png)
