### PR TITLE
AK + Kernel: Make AsyncDeviceRequest sub-req management alloc free with AK::IntrusiveList

### DIFF
--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -246,7 +246,7 @@ inline Container IntrusiveList<T, Container, member>::first() const
 template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
 inline Container IntrusiveList<T, Container, member>::take_first()
 {
-    if (auto* ptr = first()) {
+    if (Container ptr = first()) {
         remove(*ptr);
         return ptr;
     }
@@ -256,7 +256,7 @@ inline Container IntrusiveList<T, Container, member>::take_first()
 template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
 inline Container IntrusiveList<T, Container, member>::take_last()
 {
-    if (auto* ptr = last()) {
+    if (Container ptr = last()) {
         remove(*ptr);
         return ptr;
     }

--- a/AK/Tests/CMakeLists.txt
+++ b/AK/Tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(AK_TEST_SOURCES
     TestHex.cpp
     TestIPv4Address.cpp
     TestIndexSequence.cpp
+    TestIntrusiveList.cpp
     TestIntrusiveRedBlackTree.cpp
     TestJSON.cpp
     TestLexicalPath.cpp

--- a/AK/Tests/TestIntrusiveList.cpp
+++ b/AK/Tests/TestIntrusiveList.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Brian Gianforcaro <b.gianfo@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <AK/TestSuite.h>
+
+#include <AK/IntrusiveList.h>
+#include <AK/NonnullOwnPtrVector.h>
+#include <AK/Random.h>
+
+class IntrusiveTestItem {
+public:
+    IntrusiveTestItem() = default;
+
+    IntrusiveListNode<IntrusiveTestItem> m_list_node;
+};
+
+using IntrusiveTestList = IntrusiveList<IntrusiveTestItem, RawPtr<IntrusiveTestItem>, &IntrusiveTestItem::m_list_node>;
+
+TEST_CASE(construct)
+{
+    IntrusiveTestList empty;
+    EXPECT(empty.is_empty());
+}
+
+TEST_CASE(insert)
+{
+    IntrusiveTestList list;
+    list.append(*new IntrusiveTestItem());
+
+    EXPECT(!list.is_empty());
+
+    delete list.take_last();
+}
+
+TEST_CASE(enumeration)
+{
+    constexpr size_t expected_size = 10;
+    IntrusiveTestList list;
+    for (size_t i = 0; i < expected_size; i++) {
+        list.append(*new IntrusiveTestItem());
+    }
+
+    size_t actual_size = 0;
+    for (auto& elem : list) {
+        actual_size++;
+    }
+    EXPECT_EQ(expected_size, actual_size);
+    while (auto elem = list.take_first()) {
+        delete elem;
+    }
+}
+
+TEST_MAIN(IntrusiveList)

--- a/Kernel/Devices/AsyncDeviceRequest.h
+++ b/Kernel/Devices/AsyncDeviceRequest.h
@@ -45,7 +45,7 @@ class AsyncDeviceRequest : public RefCounted<AsyncDeviceRequest> {
     AK_MAKE_NONMOVABLE(AsyncDeviceRequest);
 
 public:
-    enum RequestResult {
+    enum [[nodiscard]] RequestResult {
         Pending = 0,
         Started,
         Success,
@@ -145,14 +145,14 @@ private:
     void sub_request_finished(AsyncDeviceRequest&);
     void request_finished();
 
-    bool in_target_context(const UserOrKernelBuffer& buffer) const
+    [[nodiscard]] bool in_target_context(const UserOrKernelBuffer& buffer) const
     {
         if (buffer.is_kernel_buffer())
             return true;
         return m_process == Process::current();
     }
 
-    static bool is_completed_result(RequestResult result)
+    [[nodiscard]] static bool is_completed_result(RequestResult result)
     {
         return result > Started;
     }

--- a/Kernel/Devices/AsyncDeviceRequest.h
+++ b/Kernel/Devices/AsyncDeviceRequest.h
@@ -26,7 +26,8 @@
 
 #pragma once
 
-#include <AK/NonnullRefPtrVector.h>
+#include <AK/IntrusiveList.h>
+#include <AK/NonnullRefPtr.h>
 #include <Kernel/Process.h>
 #include <Kernel/Thread.h>
 #include <Kernel/UserOrKernelBuffer.h>
@@ -160,8 +161,12 @@ private:
 
     AsyncDeviceRequest* m_parent_request { nullptr };
     RequestResult m_result { Pending };
-    NonnullRefPtrVector<AsyncDeviceRequest> m_sub_requests_pending;
-    NonnullRefPtrVector<AsyncDeviceRequest> m_sub_requests_complete;
+    IntrusiveListNode<AsyncDeviceRequest, RefPtr<AsyncDeviceRequest>> m_list_node;
+
+    typedef IntrusiveList<AsyncDeviceRequest, RefPtr<AsyncDeviceRequest>, &AsyncDeviceRequest::m_list_node> AsyncDeviceSubRequestList;
+
+    AsyncDeviceSubRequestList m_sub_requests_pending;
+    AsyncDeviceSubRequestList m_sub_requests_complete;
     WaitQueue m_queue;
     NonnullRefPtr<Process> m_process;
     void* m_private { nullptr };


### PR DESCRIPTION
-  __AK: Add some initial unit tests for AK::IntrusiveList__

-   __AK: Fix IntrusiveList::take_first/last() actually compile with RefPtr<T>__

    PR #6376 made IntrusiveList capable of holding RefPtr<T>, etc. however
    there was a latent bug where take_first() / take_last() would fail to
    compile because they weren't being converted to their container type.

-   __AK: Add unit tests to verify AK::InstrusiveList<T> holding RefPtr<T>__

    Validate that the refcounting works as expected, and continues to work.

-   __Kernel: Make AsyncDeviceRequest sub-req management alloc free__

    The previous implementation could allocate on insertion into the completed / pending
    sub request vectors. There's no reason these can't be intrusive lists instead.

    This is a very minor step towards improving the ability to handle OOM, as tracked by #6369
    It might also help improve performance on the IO path in certain situations.
    I'll benchmark that later.

-   __Kernel: Annotate more AsyncDeviceRequest API's with [[nodiscard]]__


CC: @alimpfard for the AK::IntrusiveList<T> fixes. 

