### PR TITLE
LibIPC: Make Connection::send_sync return a NonnullOwnPtr

### DIFF
--- a/Userland/Libraries/LibDesktop/Launcher.cpp
+++ b/Userland/Libraries/LibDesktop/Launcher.cpp
@@ -79,7 +79,7 @@ static LaunchServerConnection& connection()
 
 bool Launcher::add_allowed_url(const URL& url)
 {
-    auto response = connection().send_sync<Messages::LaunchServer::AddAllowedURL>(url);
+    auto response = connection().send_sync_but_allow_failure<Messages::LaunchServer::AddAllowedURL>(url);
     if (!response) {
         dbgln("Launcher::add_allowed_url: Failed");
         return false;
@@ -89,7 +89,7 @@ bool Launcher::add_allowed_url(const URL& url)
 
 bool Launcher::add_allowed_handler_with_any_url(const String& handler)
 {
-    auto response = connection().send_sync<Messages::LaunchServer::AddAllowedHandlerWithAnyURL>(handler);
+    auto response = connection().send_sync_but_allow_failure<Messages::LaunchServer::AddAllowedHandlerWithAnyURL>(handler);
     if (!response) {
         dbgln("Launcher::add_allowed_handler_with_any_url: Failed");
         return false;
@@ -99,7 +99,7 @@ bool Launcher::add_allowed_handler_with_any_url(const String& handler)
 
 bool Launcher::add_allowed_handler_with_only_specific_urls(const String& handler, const Vector<URL>& urls)
 {
-    auto response = connection().send_sync<Messages::LaunchServer::AddAllowedHandlerWithOnlySpecificURLs>(handler, urls);
+    auto response = connection().send_sync_but_allow_failure<Messages::LaunchServer::AddAllowedHandlerWithOnlySpecificURLs>(handler, urls);
     if (!response) {
         dbgln("Launcher::add_allowed_handler_with_only_specific_urls: Failed");
         return false;
@@ -109,7 +109,7 @@ bool Launcher::add_allowed_handler_with_only_specific_urls(const String& handler
 
 bool Launcher::seal_allowlist()
 {
-    auto response = connection().send_sync<Messages::LaunchServer::SealAllowlist>();
+    auto response = connection().send_sync_but_allow_failure<Messages::LaunchServer::SealAllowlist>();
     if (!response) {
         dbgln("Launcher::seal_allowlist: Failed");
         return false;

--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -118,12 +118,12 @@ public:
     }
 
     template<typename RequestType, typename... Args>
-    OwnPtr<typename RequestType::ResponseType> send_sync(Args&&... args)
+    NonnullOwnPtr<typename RequestType::ResponseType> send_sync(Args&&... args)
     {
         post_message(RequestType(forward<Args>(args)...));
         auto response = wait_for_specific_endpoint_message<typename RequestType::ResponseType, PeerEndpoint>();
         VERIFY(response);
-        return response;
+        return response.release_nonnull();
     }
 
     template<typename RequestType, typename... Args>


### PR DESCRIPTION
Since we VERIFY that we received a response, the response pointer is always non-null. (This PR also replaces an incorrect usage of send_sync with send_sync_but_allow_failure in LibDesktop)