### PR TITLE
LibWeb: Implement fieldset rendering

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -164,6 +164,7 @@ set(SOURCES
     Layout/ButtonBox.cpp
     Layout/CanvasBox.cpp
     Layout/CheckBox.cpp
+    Layout/FieldSet.cpp
     Layout/FlexFormattingContext.cpp
     Layout/FormattingContext.cpp
     Layout/FrameBox.cpp
@@ -173,6 +174,7 @@ set(SOURCES
     Layout/InlineNode.cpp
     Layout/Label.cpp
     Layout/LayoutPosition.cpp
+    Layout/Legend.cpp
     Layout/LineBox.cpp
     Layout/LineBoxFragment.cpp
     Layout/ListItemBox.cpp

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -236,3 +236,8 @@ option {
 fieldset {
     border: 1px solid #888888;
 }
+
+legend {
+    position: absolute;
+    z-index: -1;
+}

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -232,3 +232,7 @@ input[type=text] {
 option {
     display: none;
 }
+
+fieldset {
+    border: 1px solid #888888;
+}

--- a/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLFieldSetElement.h>
+#include <LibWeb/Layout/FieldSet.h>
 
 namespace Web::HTML {
 
@@ -15,6 +17,16 @@ HTMLFieldSetElement::HTMLFieldSetElement(DOM::Document& document, QualifiedName 
 
 HTMLFieldSetElement::~HTMLFieldSetElement()
 {
+}
+
+RefPtr<Layout::Node> HTMLFieldSetElement::create_layout_node()
+{
+    auto style = document().style_resolver().resolve_style(*this);
+    if (style->display() == CSS::Display::None)
+        return nullptr;
+
+    auto layout_node = adopt_ref(*new Layout::FieldSet(document(), this, move(style)));
+    return layout_node;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
@@ -17,6 +17,8 @@ public:
     HTMLFieldSetElement(DOM::Document&, QualifiedName);
     virtual ~HTMLFieldSetElement() override;
 
+    virtual RefPtr<Layout::Node> create_layout_node() override;
+
     const String& type() const
     {
         static String fieldset = "fieldset";

--- a/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/HTML/HTMLLegendElement.h>
+#include <LibWeb/Layout/Legend.h>
 
 namespace Web::HTML {
 
@@ -15,6 +16,17 @@ HTMLLegendElement::HTMLLegendElement(DOM::Document& document, QualifiedName qual
 
 HTMLLegendElement::~HTMLLegendElement()
 {
+}
+
+RefPtr<Layout::Node> HTMLLegendElement::create_layout_node()
+{
+    auto style = document().style_resolver().resolve_style(*this);
+    if (style->display() == CSS::Display::None)
+        return nullptr;
+
+    auto layout_node = adopt_ref(*new Layout::Legend(document(), this, move(style)));
+    layout_node->set_inline(true);
+    return layout_node;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
@@ -16,6 +17,8 @@ public:
 
     HTMLLegendElement(DOM::Document&, QualifiedName);
     virtual ~HTMLLegendElement() override;
+
+    virtual RefPtr<Layout::Node> create_layout_node() override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Layout/BlockBox.h>
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/FieldSet.h>
 #include <LibWeb/Layout/InitialContainingBlockBox.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
 #include <LibWeb/Layout/ListItemBox.h>
@@ -404,6 +405,9 @@ void BlockFormattingContext::layout_block_level_children(Box& box, LayoutMode la
         //        Instead, we should generate the marker box during the tree build.
         if (is<ListItemBox>(child_box))
             downcast<ListItemBox>(child_box).layout_marker();
+
+        if (is<FieldSet>(child_box))
+            downcast<FieldSet>(child_box).layout_legend();
 
         content_height = max(content_height, child_box.effective_offset().y() + child_box.height() + child_box.box_model().margin_box().bottom);
         content_width = max(content_width, downcast<Box>(child_box).width());

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -35,11 +35,7 @@ void Box::paint(PaintContext& context, PaintPhase phase)
     }
 
     if (phase == PaintPhase::Border) {
-        auto bordered_rect = this->bordered_rect();
-        Painting::paint_border(context, Painting::BorderEdge::Left, bordered_rect, computed_values());
-        Painting::paint_border(context, Painting::BorderEdge::Right, bordered_rect, computed_values());
-        Painting::paint_border(context, Painting::BorderEdge::Top, bordered_rect, computed_values());
-        Painting::paint_border(context, Painting::BorderEdge::Bottom, bordered_rect, computed_values());
+        paint_border(context);
     }
 
     if (phase == PaintPhase::Overlay && dom_node() && document().inspected_node() == dom_node()) {
@@ -60,6 +56,15 @@ void Box::paint(PaintContext& context, PaintPhase phase)
     if (phase == PaintPhase::FocusOutline && dom_node() && dom_node()->is_element() && downcast<DOM::Element>(*dom_node()).is_focused()) {
         context.painter().draw_rect(enclosing_int_rect(absolute_rect()), context.palette().focus_outline());
     }
+}
+
+void Box::paint_border(PaintContext& context)
+{
+    auto bordered_rect = this->bordered_rect();
+    Painting::paint_border(context, Painting::BorderEdge::Left, bordered_rect, computed_values());
+    Painting::paint_border(context, Painting::BorderEdge::Right, bordered_rect, computed_values());
+    Painting::paint_border(context, Painting::BorderEdge::Top, bordered_rect, computed_values());
+    Painting::paint_border(context, Painting::BorderEdge::Bottom, bordered_rect, computed_values());
 }
 
 void Box::paint_background_image(

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -110,6 +110,7 @@ public:
     StackingContext* enclosing_stacking_context();
 
     virtual void paint(PaintContext&, PaintPhase) override;
+    virtual void paint_border(PaintContext& context);
 
     Vector<LineBox>& line_boxes() { return m_line_boxes; }
     const Vector<LineBox>& line_boxes() const { return m_line_boxes; }

--- a/Userland/Libraries/LibWeb/Layout/FieldSet.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FieldSet.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Tobias Christiansen <tobi@tobyase.de>
+ * 
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/HTML/HTMLLegendElement.h>
+#include <LibWeb/Layout/FieldSet.h>
+#include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BorderPainting.h>
+
+namespace Web::Layout {
+
+FieldSet::FieldSet(DOM::Document& document, HTML::HTMLFieldSetElement* element, NonnullRefPtr<CSS::StyleProperties> style)
+    : BlockBox(document, element, move(style))
+{
+}
+
+FieldSet::~FieldSet()
+{
+}
+
+void FieldSet::layout_legend()
+{
+    auto legend = first_child_of_type_including_subtree<Legend>();
+
+    if (!legend)
+        return;
+
+    Gfx::FloatPoint fieldset_position = { bordered_rect().x(), bordered_rect().y() };
+
+    Gfx::FloatPoint legend_offset_from_fieldset = { border_length_left_of_legend(), -(line_height() / 2) };
+    legend->set_offset(fieldset_position + legend_offset_from_fieldset);
+
+    m_legend = legend;
+}
+
+void FieldSet::paint_border(PaintContext& context)
+{
+    auto bordered_rect = this->bordered_rect();
+    Painting::paint_border(context, Painting::BorderEdge::Left, bordered_rect, computed_values());
+    Painting::paint_border(context, Painting::BorderEdge::Right, bordered_rect, computed_values());
+    Painting::paint_border(context, Painting::BorderEdge::Bottom, bordered_rect, computed_values());
+
+    if (!m_legend) {
+        Painting::paint_border(context, Painting::BorderEdge::Top, bordered_rect, computed_values());
+        return;
+    }
+
+    auto legend_width = m_legend->width();
+    auto padding_and_border_width_overhead_left = box_model().border.left + box_model().padding.left;
+    auto padding_and_border_width_overhead_right = box_model().border.right + box_model().padding.right;
+
+    // Painting the top border:
+    // ---------------- Legend            ---------------
+    //  segment_before  space for legend   segment_after
+
+    auto segment_before_rect = bordered_rect;
+    segment_before_rect.set_width(max(border_length_left_of_legend() - padding_and_border_width_overhead_left - padding_and_border_width_overhead_right, 0.0f));
+
+    auto segment_after_rect = bordered_rect;
+    segment_after_rect.set_width(width() - legend_width - border_length_left_of_legend() - padding_and_border_width_overhead_left - padding_and_border_width_overhead_right);
+    segment_after_rect.set_x(absolute_rect().x() + border_length_left_of_legend() + padding_and_border_width_overhead_right + 2 * padding_and_border_width_overhead_left + legend_width);
+
+    Painting::paint_border(context, Painting::BorderEdge::Top, segment_before_rect, computed_values());
+    Painting::paint_border(context, Painting::BorderEdge::Top, segment_after_rect, computed_values());
+}
+
+}

--- a/Userland/Libraries/LibWeb/Layout/FieldSet.h
+++ b/Userland/Libraries/LibWeb/Layout/FieldSet.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Tobias Christiansen <tobi@tobyase.de>
+ * 
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/HTML/HTMLFieldSetElement.h>
+#include <LibWeb/Layout/BlockBox.h>
+#include <LibWeb/Layout/Legend.h>
+
+namespace Web::Layout {
+
+class FieldSet : public BlockBox {
+public:
+    FieldSet(DOM::Document&, HTML::HTMLFieldSetElement*, NonnullRefPtr<CSS::StyleProperties>);
+    virtual ~FieldSet() override;
+
+    virtual void paint_border(PaintContext& context) override;
+
+    void layout_legend();
+
+private:
+    Legend* m_legend { nullptr };
+
+    float border_length_left_of_legend() { return max(10.0f, box_model().border.left * 5); }
+};
+
+}

--- a/Userland/Libraries/LibWeb/Layout/Legend.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Legend.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 Tobias Christiansen <tobi@tobyase.de>
+ * 
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Layout/Legend.h>
+
+namespace Web::Layout {
+
+Legend::Legend(DOM::Document& document, HTML::HTMLLegendElement* element, NonnullRefPtr<CSS::StyleProperties> style)
+    : BlockBox(document, element, move(style))
+{
+}
+
+Legend::~Legend()
+{
+}
+
+}

--- a/Userland/Libraries/LibWeb/Layout/Legend.h
+++ b/Userland/Libraries/LibWeb/Layout/Legend.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 Tobias Christiansen <tobi@tobyase.de>
+ * 
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/HTML/HTMLLegendElement.h>
+#include <LibWeb/Layout/BlockBox.h>
+
+namespace Web::Layout {
+
+class Legend : public BlockBox {
+public:
+    Legend(DOM::Document&, HTML::HTMLLegendElement*, NonnullRefPtr<CSS::StyleProperties>);
+    virtual ~Legend() override;
+};
+
+}

--- a/Userland/Libraries/LibWeb/TreeNode.h
+++ b/Userland/Libraries/LibWeb/TreeNode.h
@@ -328,6 +328,18 @@ public:
     }
 
     template<typename U>
+    U* first_child_of_type_including_subtree()
+    {
+        for (auto* child = first_child(); child; child = child->next_sibling()) {
+            if (is<U>(*child))
+                return &downcast<U>(*child);
+            if (auto child_result = child->template first_child_of_type_including_subtree<U>())
+                return child_result;
+        }
+        return nullptr;
+    }
+
+    template<typename U>
     U* last_child_of_type()
     {
         for (auto* child = last_child(); child; child = child->previous_sibling()) {


### PR DESCRIPTION
This PR creates the ability to render `<fieldset>`s correctly.
A fieldset has to know about its legend to set the top-border correctly, thats a bit finicky.