### PR TITLE
Shell: Auto-completion shouldn't suggest non-executable files for the program name

### DIFF
--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -336,7 +336,7 @@ Vector<Line::CompletionSuggestion> Node::complete_for_editor(Shell& shell, size_
 
             // If the literal isn't an option, treat it as a path.
             if (!(text.starts_with("-") || text == "--" || text == "-"))
-                return shell.complete_path("", text, corrected_offset);
+                return shell.complete_path("", text, corrected_offset, Shell::ExecutableOnly::No);
 
             // If the literal is an option, we have to know the program name
             // should we have no way to get that, bail early.
@@ -2349,7 +2349,7 @@ Vector<Line::CompletionSuggestion> PathRedirectionNode::complete_for_editor(Shel
     if (corrected_offset > node->text().length())
         return {};
 
-    return shell.complete_path("", node->text(), corrected_offset);
+    return shell.complete_path("", node->text(), corrected_offset, Shell::ExecutableOnly::No);
 }
 
 PathRedirectionNode::~PathRedirectionNode()
@@ -2895,7 +2895,7 @@ Vector<Line::CompletionSuggestion> Juxtaposition::complete_for_editor(Shell& she
 
         auto text = node->text().substring(1, node->text().length() - 1);
 
-        return shell.complete_path(tilde_value, text, corrected_offset - 1);
+        return shell.complete_path(tilde_value, text, corrected_offset - 1, Shell::ExecutableOnly::No);
     }
 
     return Node::complete_for_editor(shell, offset, hit_test_result);

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -178,9 +178,14 @@ public:
     static bool is_glob(const StringView&);
     static Vector<StringView> split_path(const StringView&);
 
+    enum class ExecutableOnly {
+        Yes,
+        No
+    };
+
     void highlight(Line::Editor&) const;
     Vector<Line::CompletionSuggestion> complete();
-    Vector<Line::CompletionSuggestion> complete_path(const String& base, const String&, size_t offset);
+    Vector<Line::CompletionSuggestion> complete_path(const String& base, const String&, size_t offset, ExecutableOnly executable_only);
     Vector<Line::CompletionSuggestion> complete_program_name(const String&, size_t offset);
     Vector<Line::CompletionSuggestion> complete_variable(const String&, size_t offset);
     Vector<Line::CompletionSuggestion> complete_user(const String&, size_t offset);


### PR DESCRIPTION
Right now the `Shell` suggests `README.md` when trying to auto-complete `./` in the home directory. This file isn't executable though.