### PR TITLE
Inspector: Select entire property row and add Copy Property Name/Value

### DIFF
--- a/Userland/DevTools/Inspector/main.cpp
+++ b/Userland/DevTools/Inspector/main.cpp
@@ -33,6 +33,7 @@
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
+#include <LibGUI/Clipboard.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
@@ -172,6 +173,25 @@ int main(int argc, char** argv)
         auto* remote_object = static_cast<RemoteObject*>(index.internal_data());
         properties_tree_view.set_model(remote_object->property_model());
         remote_process.set_inspected_object(remote_object->address);
+    };
+
+    auto properties_tree_view_context_menu = GUI::Menu::construct("Properties Tree View");
+
+    auto copy_bitmap = Gfx::Bitmap::load_from_file("/res/icons/16x16/edit-copy.png");
+    auto copy_property_name_action = GUI::Action::create("Copy Property Name", copy_bitmap, [&](auto&) {
+        GUI::Clipboard::the().set_plain_text(properties_tree_view.selection().first().data().to_string());
+    });
+    auto copy_property_value_action = GUI::Action::create("Copy Property Value", copy_bitmap, [&](auto&) {
+        GUI::Clipboard::the().set_plain_text(properties_tree_view.selection().first().sibling_at_column(1).data().to_string());
+    });
+
+    properties_tree_view_context_menu->add_action(copy_property_name_action);
+    properties_tree_view_context_menu->add_action(copy_property_value_action);
+
+    properties_tree_view.on_context_menu_request = [&](const GUI::ModelIndex& index, const GUI::ContextMenuEvent& event) {
+        if (index.is_valid()) {
+            properties_tree_view_context_menu->popup(event.screen_position());
+        }
     };
 
     window->set_menubar(move(menubar));

--- a/Userland/DevTools/Inspector/main.cpp
+++ b/Userland/DevTools/Inspector/main.cpp
@@ -162,6 +162,7 @@ int main(int argc, char** argv)
     tree_view.set_fixed_width(286);
 
     auto& properties_tree_view = splitter.add<GUI::TreeView>();
+    properties_tree_view.set_should_fill_selected_rows(true);
     properties_tree_view.set_editable(true);
     properties_tree_view.aid_create_editing_delegate = [](auto&) {
         return make<GUI::StringModelEditingDelegate>();


### PR DESCRIPTION
With some themes (like the default one), it was possible to select a
property, making the text of its value not visible. I solved this by
setting set_should_fill_selected_rows to true.

I also added a context menu for the property tree view to copy the
name/value of a property.

Before
![before](https://user-images.githubusercontent.com/37349526/115455358-26e40e80-a222-11eb-8ed8-5dc99cf89965.gif)

After
![after](https://user-images.githubusercontent.com/37349526/115455367-2ba8c280-a222-11eb-9551-87050dfa154b.gif)