### PR TITLE
LibGfx: Implement bi-directional, floating-point scaling support

### DIFF
--- a/Userland/Applications/Piano/KeysWidget.cpp
+++ b/Userland/Applications/Piano/KeysWidget.cpp
@@ -242,7 +242,7 @@ int KeysWidget::note_for_event_position(const Gfx::IntPoint& a_point) const
         return -1;
 
     auto point = a_point;
-    point.move_by(-frame_thickness(), -frame_thickness());
+    point.translate_by(-frame_thickness(), -frame_thickness());
 
     int white_keys = point.x() / white_key_width;
     int note = note_from_white_keys(white_keys);

--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -112,7 +112,7 @@ void RollWidget::paint_event(GUI::PaintEvent& event)
             const char* note_name = note_names[note % notes_per_octave];
 
             background_painter.draw_text(note_name_rect, note_name, Gfx::TextAlignment::CenterLeft);
-            note_name_rect.move_by(Gfx::FontDatabase::default_font().width(note_name) + 2, 0);
+            note_name_rect.translate_by(Gfx::FontDatabase::default_font().width(note_name) + 2, 0);
             if (note % notes_per_octave == 0)
                 background_painter.draw_text(note_name_rect, String::formatted("{}", note / notes_per_octave + 1), Gfx::TextAlignment::CenterLeft);
         }

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -162,7 +162,7 @@ GUI::MouseEvent ImageEditor::event_with_pan_and_scale_applied(const GUI::MouseEv
 GUI::MouseEvent ImageEditor::event_adjusted_for_layer(const GUI::MouseEvent& event, const Layer& layer) const
 {
     auto image_position = editor_position_to_image_position(event.position());
-    image_position.move_by(-layer.location().x(), -layer.location().y());
+    image_position.translate_by(-layer.location().x(), -layer.location().y());
     return {
         static_cast<GUI::Event::Type>(event.type()),
         Gfx::IntPoint(image_position.x(), image_position.y()),

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -71,7 +71,7 @@ void LayerListWidget::paint_event(GUI::PaintEvent& event)
         auto adjusted_rect = gadget.rect;
 
         if (gadget.is_moving) {
-            adjusted_rect.move_by(0, gadget.movement_delta.y());
+            adjusted_rect.translate_by(0, gadget.movement_delta.y());
         }
 
         if (gadget.is_moving) {

--- a/Userland/Applications/PixelPaint/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/MoveTool.cpp
@@ -66,16 +66,16 @@ void MoveTool::on_keydown(GUI::KeyEvent& event)
 
     switch (event.key()) {
     case Key_Up:
-        new_location.move_by(0, -1);
+        new_location.translate_by(0, -1);
         break;
     case Key_Down:
-        new_location.move_by(0, 1);
+        new_location.translate_by(0, 1);
         break;
     case Key_Left:
-        new_location.move_by(-1, 0);
+        new_location.translate_by(-1, 0);
         break;
     case Key_Right:
-        new_location.move_by(1, 0);
+        new_location.translate_by(1, 0);
         break;
     default:
         return;

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -96,10 +96,10 @@ void TreeMapWidget::paint_cell_frame(GUI::Painter& painter, const TreeMapNode& n
         painter.clear_clip_rect();
         painter.add_clip_rect(cell_rect);
         Gfx::IntRect text_rect = remainder;
-        text_rect.move_by(2, 2);
+        text_rect.translate_by(2, 2);
         painter.draw_text(text_rect, node.name(), font(), Gfx::TextAlignment::TopLeft, Color::Black);
         if (node_is_leaf(node)) {
-            text_rect.move_by(0, font().presentation_size() + 1);
+            text_rect.translate_by(0, font().presentation_size() + 1);
             painter.draw_text(text_rect, human_readable_size(node.area()), font(), Gfx::TextAlignment::TopLeft, Color::Black);
         }
         painter.clear_clip_rect();

--- a/Userland/Games/Solitaire/CardStack.cpp
+++ b/Userland/Games/Solitaire/CardStack.cpp
@@ -164,9 +164,9 @@ void CardStack::push(NonnullRefPtr<Card> card)
 
     if (size && size % m_rules.step == 0) {
         if (peek().is_upside_down())
-            top_most_position.move_by(m_rules.shift_x, m_rules.shift_y_upside_down);
+            top_most_position.translate_by(m_rules.shift_x, m_rules.shift_y_upside_down);
         else
-            top_most_position.move_by(m_rules.shift_x, m_rules.shift_y);
+            top_most_position.translate_by(m_rules.shift_x, m_rules.shift_y);
     }
 
     if (m_type == Stock)

--- a/Userland/Games/Solitaire/SolitaireWidget.cpp
+++ b/Userland/Games/Solitaire/SolitaireWidget.cpp
@@ -256,7 +256,7 @@ void SolitaireWidget::mousemove_event(GUI::MouseEvent& event)
 
     for (auto& to_intersect : m_focused_cards) {
         mark_intersecting_stacks_dirty(to_intersect);
-        to_intersect.rect().move_by(dx, dy);
+        to_intersect.rect().translate_by(dx, dy);
     }
 
     m_mouse_down_location = click_location;

--- a/Userland/Games/Solitaire/SolitaireWidget.h
+++ b/Userland/Games/Solitaire/SolitaireWidget.h
@@ -46,9 +46,9 @@ private:
             if (m_animation_card->position().y() + Card::height + m_y_velocity > SolitaireWidget::height + 1 && m_y_velocity > 0) {
                 m_y_velocity = min((m_y_velocity * -m_bouncyness), -8.f);
                 m_animation_card->rect().set_y(SolitaireWidget::height - Card::height);
-                m_animation_card->rect().move_by(m_x_velocity, 0);
+                m_animation_card->rect().translate_by(m_x_velocity, 0);
             } else {
-                m_animation_card->rect().move_by(m_x_velocity, m_y_velocity);
+                m_animation_card->rect().translate_by(m_x_velocity, m_y_velocity);
             }
         }
 

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -188,7 +188,7 @@ void Application::tooltip_show_timer_did_fire()
     const int margin = 30;
     Gfx::IntPoint adjusted_pos = WindowServerConnection::the().send_sync<Messages::WindowServer::GetGlobalCursorPosition>()->position();
 
-    adjusted_pos.move_by(0, 18);
+    adjusted_pos.translate_by(0, 18);
 
     if (adjusted_pos.x() + m_tooltip_window->width() >= desktop_rect.width() - margin) {
         adjusted_pos = adjusted_pos.translated(-m_tooltip_window->width(), 0);

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -62,7 +62,7 @@ void Button::paint_event(PaintEvent& event)
         painter.blit_filtered(icon_location.translated(1, 1), *m_icon, m_icon->rect(), [&shadow_color](auto) {
             return shadow_color;
         });
-        icon_location.move_by(-1, -1);
+        icon_location.translate_by(-1, -1);
     }
 
     if (m_icon) {
@@ -77,7 +77,7 @@ void Button::paint_event(PaintEvent& event)
     }
     auto& font = is_checked() ? Gfx::FontDatabase::default_bold_font() : this->font();
     if (m_icon && !text().is_empty()) {
-        content_rect.move_by(m_icon->width() + icon_spacing(), 0);
+        content_rect.translate_by(m_icon->width() + icon_spacing(), 0);
         content_rect.set_width(content_rect.width() - m_icon->width() - icon_spacing());
     }
 

--- a/Userland/Libraries/LibGUI/HeaderView.cpp
+++ b/Userland/Libraries/LibGUI/HeaderView.cpp
@@ -246,7 +246,7 @@ void HeaderView::paint_horizontal(Painter& painter)
         }
         auto text_rect = cell_rect.shrunken(m_table_view.horizontal_padding() * 2, 0);
         if (pressed)
-            text_rect.move_by(1, 1);
+            text_rect.translate_by(1, 1);
         painter.draw_text(text_rect, text, font(), section_alignment(section), palette().button_text());
         x_offset += section_width + m_table_view.horizontal_padding() * 2;
     }
@@ -274,7 +274,7 @@ void HeaderView::paint_vertical(Painter& painter)
         String text = String::number(section);
         auto text_rect = cell_rect.shrunken(m_table_view.horizontal_padding() * 2, 0);
         if (pressed)
-            text_rect.move_by(1, 1);
+            text_rect.translate_by(1, 1);
         painter.draw_text(text_rect, text, font(), section_alignment(section), palette().button_text());
         y_offset += section_size;
     }

--- a/Userland/Libraries/LibGUI/IconView.cpp
+++ b/Userland/Libraries/LibGUI/IconView.cpp
@@ -381,7 +381,7 @@ void IconView::update_item_rects(int item_index, ItemData& item_data) const
 {
     auto item_rect = this->item_rect(item_index);
     item_data.icon_rect.center_within(item_rect);
-    item_data.icon_rect.move_by(0, item_data.icon_offset_y);
+    item_data.icon_rect.translate_by(0, item_data.icon_offset_y);
     item_data.text_rect.center_horizontally_within(item_rect);
     item_data.text_rect.set_top(item_rect.y() + item_data.text_offset_y);
 }
@@ -418,7 +418,7 @@ void IconView::get_item_rects(int item_index, ItemData& item_data, const Gfx::Fo
     item_data.icon_rect = { 0, 0, 32, 32 };
     item_data.icon_rect.center_within(item_rect);
     item_data.icon_offset_y = -font.glyph_height() - 6;
-    item_data.icon_rect.move_by(0, item_data.icon_offset_y);
+    item_data.icon_rect.translate_by(0, item_data.icon_offset_y);
 
     int unwrapped_text_width = font.width(item_data.text);
     int available_width = item_rect.width() - 6;

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -79,7 +79,7 @@ Gfx::IntRect Label::text_rect(size_t line) const
     if (frame_thickness() > 0)
         indent = font().glyph_width('x') / 2;
     auto rect = frame_inner_rect();
-    rect.move_by(indent, line * (font().glyph_height() + 1));
+    rect.translate_by(indent, line * (font().glyph_height() + 1));
     rect.set_width(rect.width() - indent * 2);
     return rect;
 }

--- a/Userland/Libraries/LibGUI/ListView.cpp
+++ b/Userland/Libraries/LibGUI/ListView.cpp
@@ -127,7 +127,7 @@ void ListView::paint_list_item(Painter& painter, int row_index, int painted_item
         else
             text_color = index.data(ModelRole::ForegroundColor).to_color(palette().color(foreground_role()));
         auto text_rect = row_rect;
-        text_rect.move_by(horizontal_padding(), 0);
+        text_rect.translate_by(horizontal_padding(), 0);
         text_rect.set_width(text_rect.width() - horizontal_padding() * 2);
         auto text_alignment = index.data(ModelRole::TextAlignment).to_text_alignment(Gfx::TextAlignment::CenterLeft);
         painter.draw_text(text_rect, data.to_string(), font, text_alignment, text_color);

--- a/Userland/Libraries/LibGUI/Painter.cpp
+++ b/Userland/Libraries/LibGUI/Painter.cpp
@@ -20,7 +20,7 @@ Painter::Painter(Widget& widget)
 {
     state().font = &widget.font();
     auto origin_rect = widget.window_relative_rect();
-    state().translation = origin_rect.location();
+    translate(origin_rect.location());
     state().clip_rect = origin_rect.intersected(m_target->rect());
     m_clip_origin = state().clip_rect;
 }

--- a/Userland/Libraries/LibGUI/ScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableWidget.cpp
@@ -225,16 +225,16 @@ Gfx::IntRect ScrollableWidget::widget_inner_rect() const
 Gfx::IntPoint ScrollableWidget::to_content_position(const Gfx::IntPoint& widget_position) const
 {
     auto content_position = widget_position;
-    content_position.move_by(horizontal_scrollbar().value(), vertical_scrollbar().value());
-    content_position.move_by(-frame_thickness(), -frame_thickness());
+    content_position.translate_by(horizontal_scrollbar().value(), vertical_scrollbar().value());
+    content_position.translate_by(-frame_thickness(), -frame_thickness());
     return content_position;
 }
 
 Gfx::IntPoint ScrollableWidget::to_widget_position(const Gfx::IntPoint& content_position) const
 {
     auto widget_position = content_position;
-    widget_position.move_by(-horizontal_scrollbar().value(), -vertical_scrollbar().value());
-    widget_position.move_by(frame_thickness(), frame_thickness());
+    widget_position.translate_by(-horizontal_scrollbar().value(), -vertical_scrollbar().value());
+    widget_position.translate_by(frame_thickness(), frame_thickness());
     return widget_position;
 }
 

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -201,14 +201,14 @@ void Scrollbar::paint_event(PaintEvent& event)
     if (length(orientation()) > default_button_size()) {
         auto decrement_location = decrement_button_rect().location().translated(3, 3);
         if (decrement_pressed)
-            decrement_location.move_by(1, 1);
+            decrement_location.translate_by(1, 1);
         if (!has_scrubber() || !is_enabled())
             painter.draw_bitmap(decrement_location.translated(1, 1), orientation() == Orientation::Vertical ? *s_up_arrow_bitmap : *s_left_arrow_bitmap, palette().threed_highlight());
         painter.draw_bitmap(decrement_location, orientation() == Orientation::Vertical ? *s_up_arrow_bitmap : *s_left_arrow_bitmap, (has_scrubber() && is_enabled()) ? palette().button_text() : palette().threed_shadow1());
 
         auto increment_location = increment_button_rect().location().translated(3, 3);
         if (increment_pressed)
-            increment_location.move_by(1, 1);
+            increment_location.translate_by(1, 1);
         if (!has_scrubber() || !is_enabled())
             painter.draw_bitmap(increment_location.translated(1, 1), orientation() == Orientation::Vertical ? *s_down_arrow_bitmap : *s_right_arrow_bitmap, palette().threed_highlight());
         painter.draw_bitmap(increment_location, orientation() == Orientation::Vertical ? *s_down_arrow_bitmap : *s_right_arrow_bitmap, (has_scrubber() && is_enabled()) ? palette().button_text() : palette().threed_shadow1());

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -197,7 +197,7 @@ void TabWidget::paint_event(PaintEvent& event)
         if (!icon)
             return;
         Gfx::IntRect icon_rect { button_rect.x(), button_rect.y(), 16, 16 };
-        icon_rect.move_by(4, 3);
+        icon_rect.translate_by(4, 3);
         painter.draw_scaled_bitmap(icon_rect, *icon, icon->rect());
         text_rect.set_x(icon_rect.right() + 1 + 4);
         text_rect.intersect(button_rect);
@@ -281,13 +281,13 @@ Gfx::IntRect TabWidget::button_rect(int index) const
     }
     Gfx::IntRect rect { x_offset, 0, m_uniform_tabs ? uniform_tab_width() : m_tabs[index].width(font()), bar_height() };
     if (m_tabs[index].widget != m_active_widget) {
-        rect.move_by(0, m_tab_position == TabPosition::Top ? 2 : 0);
+        rect.translate_by(0, m_tab_position == TabPosition::Top ? 2 : 0);
         rect.set_height(rect.height() - 2);
     } else {
-        rect.move_by(-2, 0);
+        rect.translate_by(-2, 0);
         rect.set_width(rect.width() + 4);
     }
-    rect.move_by(bar_rect().location());
+    rect.translate_by(bar_rect().location());
     return rect;
 }
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -134,7 +134,7 @@ TextPosition TextEditor::text_position_at_content_position(const Gfx::IntPoint& 
 {
     auto position = content_position;
     if (is_single_line() && icon())
-        position.move_by(-(icon_size() + icon_padding()), 0);
+        position.translate_by(-(icon_size() + icon_padding()), 0);
 
     size_t line_index = 0;
 
@@ -194,9 +194,9 @@ TextPosition TextEditor::text_position_at_content_position(const Gfx::IntPoint& 
 TextPosition TextEditor::text_position_at(const Gfx::IntPoint& widget_position) const
 {
     auto content_position = widget_position;
-    content_position.move_by(horizontal_scrollbar().value(), vertical_scrollbar().value());
-    content_position.move_by(-(m_horizontal_content_padding + ruler_width()), 0);
-    content_position.move_by(-frame_thickness(), -frame_thickness());
+    content_position.translate_by(horizontal_scrollbar().value(), vertical_scrollbar().value());
+    content_position.translate_by(-(m_horizontal_content_padding + ruler_width()), 0);
+    content_position.translate_by(-frame_thickness(), -frame_thickness());
     return text_position_at_content_position(content_position);
 }
 
@@ -435,8 +435,8 @@ void TextEditor::paint_event(PaintEvent& event)
         height() - height_occupied_by_horizontal_scrollbar()
     };
     if (m_ruler_visible)
-        text_clip_rect.move_by(-ruler_width(), 0);
-    text_clip_rect.move_by(horizontal_scrollbar().value(), vertical_scrollbar().value());
+        text_clip_rect.translate_by(-ruler_width(), 0);
+    text_clip_rect.translate_by(horizontal_scrollbar().value(), vertical_scrollbar().value());
     painter.add_clip_rect(text_clip_rect);
 
     size_t span_index = 0;
@@ -507,7 +507,7 @@ void TextEditor::paint_event(PaintEvent& event)
                     if (underline) {
                         painter.draw_line(span_rect.bottom_left().translated(0, 1), span_rect.bottom_right().translated(0, 1), color);
                     }
-                    span_rect.move_by(span_rect.width(), 0);
+                    span_rect.translate_by(span_rect.width(), 0);
                 };
                 for (;;) {
                     if (span_index >= document().spans().size()) {
@@ -1015,8 +1015,8 @@ Gfx::IntRect TextEditor::line_widget_rect(size_t line_index) const
     auto rect = line_content_rect(line_index);
     rect.set_x(frame_thickness());
     rect.set_width(frame_inner_rect().width());
-    rect.move_by(0, -(vertical_scrollbar().value()));
-    rect.move_by(0, frame_thickness());
+    rect.translate_by(0, -(vertical_scrollbar().value()));
+    rect.translate_by(0, frame_thickness());
     rect.intersect(frame_inner_rect());
     return rect;
 }
@@ -1567,7 +1567,7 @@ void TextEditor::for_each_visual_line(size_t line_index, Callback callback) cons
         if (is_single_line()) {
             visual_line_rect.center_vertically_within(editor_visible_text_rect);
             if (m_icon)
-                visual_line_rect.move_by(icon_size() + icon_padding(), 0);
+                visual_line_rect.translate_by(icon_size() + icon_padding(), 0);
         }
         if (callback(visual_line_rect, visual_line_view, start_of_line, visual_line_index == visual_data.visual_line_breaks.size() - 1) == IterationDecision::Break)
             break;

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -575,7 +575,7 @@ Gfx::IntRect Widget::window_relative_rect() const
 {
     auto rect = relative_rect();
     for (auto* parent = parent_widget(); parent; parent = parent->parent_widget()) {
-        rect.move_by(parent->relative_position());
+        rect.translate_by(parent->relative_position());
     }
     return rect;
 }
@@ -957,7 +957,7 @@ void Widget::set_content_margins(const Margins& margins)
 Gfx::IntRect Widget::content_rect() const
 {
     auto rect = relative_rect();
-    rect.move_by(m_content_margins.left(), m_content_margins.top());
+    rect.translate_by(m_content_margins.left(), m_content_margins.top());
     rect.set_width(rect.width() - (m_content_margins.left() + m_content_margins.right()));
     rect.set_height(rect.height() - (m_content_margins.top() + m_content_margins.bottom()));
     return rect;

--- a/Userland/Libraries/LibGfx/AffineTransform.cpp
+++ b/Userland/Libraries/LibGfx/AffineTransform.cpp
@@ -31,6 +31,26 @@ float AffineTransform::y_scale() const
     return hypotenuse(m_values[2], m_values[3]);
 }
 
+FloatPoint AffineTransform::scale() const
+{
+    return { x_scale(), y_scale() };
+}
+
+float AffineTransform::x_translation() const
+{
+    return e();
+}
+
+float AffineTransform::y_translation() const
+{
+    return f();
+}
+
+FloatPoint AffineTransform::translation() const
+{
+    return { x_translation(), y_translation() };
+}
+
 AffineTransform& AffineTransform::scale(float sx, float sy)
 {
     m_values[0] *= sx;
@@ -40,11 +60,47 @@ AffineTransform& AffineTransform::scale(float sx, float sy)
     return *this;
 }
 
+AffineTransform& AffineTransform::scale(const FloatPoint& s)
+{
+    return scale(s.x(), s.y());
+}
+
+AffineTransform& AffineTransform::set_scale(float sx, float sy)
+{
+    m_values[0] = sx;
+    m_values[1] = 0;
+    m_values[2] = 0;
+    m_values[3] = sy;
+    return *this;
+}
+
+AffineTransform& AffineTransform::set_scale(const FloatPoint& s)
+{
+    return set_scale(s.x(), s.y());
+}
+
 AffineTransform& AffineTransform::translate(float tx, float ty)
 {
     m_values[4] += tx * m_values[0] + ty * m_values[2];
     m_values[5] += tx * m_values[1] + ty * m_values[3];
     return *this;
+}
+
+AffineTransform& AffineTransform::translate(const FloatPoint& t)
+{
+    return translate(t.x(), t.y());
+}
+
+AffineTransform& AffineTransform::set_translation(float tx, float ty)
+{
+    m_values[4] = tx;
+    m_values[5] = ty;
+    return *this;
+}
+
+AffineTransform& AffineTransform::set_translation(const FloatPoint& t)
+{
+    return set_translation(t.x(), t.y());
 }
 
 AffineTransform& AffineTransform::multiply(const AffineTransform& other)
@@ -71,8 +127,8 @@ AffineTransform& AffineTransform::rotate_radians(float radians)
 
 void AffineTransform::map(float unmapped_x, float unmapped_y, float& mapped_x, float& mapped_y) const
 {
-    mapped_x = (m_values[0] * unmapped_x + m_values[2] * unmapped_y + m_values[4]);
-    mapped_y = (m_values[1] * unmapped_x + m_values[3] * unmapped_y + m_values[5]);
+    mapped_x = a() * unmapped_x + b() * unmapped_y + m_values[4];
+    mapped_y = c() * unmapped_x + d() * unmapped_y + m_values[5];
 }
 
 template<>
@@ -80,7 +136,7 @@ IntPoint AffineTransform::map(const IntPoint& point) const
 {
     float mapped_x;
     float mapped_y;
-    map(point.x(), point.y(), mapped_x, mapped_y);
+    map(static_cast<float>(point.x()), static_cast<float>(point.y()), mapped_x, mapped_y);
     return { roundf(mapped_x), roundf(mapped_y) };
 }
 
@@ -96,7 +152,10 @@ FloatPoint AffineTransform::map(const FloatPoint& point) const
 template<>
 IntSize AffineTransform::map(const IntSize& size) const
 {
-    return { roundf(size.width() * x_scale()), roundf(size.height() * y_scale()) };
+    return {
+        roundf(static_cast<float>(size.width()) * x_scale()),
+        roundf(static_cast<float>(size.height()) * y_scale()),
+    };
 }
 
 template<>

--- a/Userland/Libraries/LibGfx/AffineTransform.h
+++ b/Userland/Libraries/LibGfx/AffineTransform.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Format.h>
 #include <AK/Forward.h>
 #include <LibGfx/Forward.h>
 
@@ -36,18 +37,28 @@ public:
     template<typename T>
     Rect<T> map(const Rect<T>&) const;
 
-    float a() const { return m_values[0]; }
-    float b() const { return m_values[1]; }
-    float c() const { return m_values[2]; }
-    float d() const { return m_values[3]; }
-    float e() const { return m_values[4]; }
-    float f() const { return m_values[5]; }
+    [[nodiscard]] ALWAYS_INLINE float a() const { return m_values[0]; }
+    [[nodiscard]] ALWAYS_INLINE float b() const { return m_values[1]; }
+    [[nodiscard]] ALWAYS_INLINE float c() const { return m_values[2]; }
+    [[nodiscard]] ALWAYS_INLINE float d() const { return m_values[3]; }
+    [[nodiscard]] ALWAYS_INLINE float e() const { return m_values[4]; }
+    [[nodiscard]] ALWAYS_INLINE float f() const { return m_values[5]; }
 
-    float x_scale() const;
-    float y_scale() const;
+    [[nodiscard]] float x_scale() const;
+    [[nodiscard]] float y_scale() const;
+    [[nodiscard]] FloatPoint scale() const;
+    [[nodiscard]] float x_translation() const;
+    [[nodiscard]] float y_translation() const;
+    [[nodiscard]] FloatPoint translation() const;
 
     AffineTransform& scale(float sx, float sy);
+    AffineTransform& scale(const FloatPoint& s);
+    AffineTransform& set_scale(float sx, float sy);
+    AffineTransform& set_scale(const FloatPoint& s);
     AffineTransform& translate(float tx, float ty);
+    AffineTransform& translate(const FloatPoint& t);
+    AffineTransform& set_translation(float tx, float ty);
+    AffineTransform& set_translation(const FloatPoint& t);
     AffineTransform& rotate_radians(float);
     AffineTransform& multiply(const AffineTransform&);
 
@@ -56,3 +67,11 @@ private:
 };
 
 }
+
+template<>
+struct AK::Formatter<Gfx::AffineTransform> : Formatter<FormatString> {
+    void format(FormatBuilder& builder, Gfx::AffineTransform value)
+    {
+        return Formatter<FormatString>::format(builder, "[{} {} {} {} {} {}]", value.a(), value.b(), value.c(), value.d(), value.e(), value.f());
+    }
+};

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -389,6 +389,115 @@ RefPtr<Gfx::Bitmap> Bitmap::flipped(Gfx::Orientation orientation) const
     return new_bitmap;
 }
 
+RefPtr<Gfx::Bitmap> Bitmap::scaled(int sx, int sy) const
+{
+    VERIFY(sx >= 0 && sy >= 0);
+    if (sx == 1 && sy == 1)
+        return this;
+
+    auto new_bitmap = Gfx::Bitmap::create(format(), { width() * sx, height() * sy }, scale());
+    if (!new_bitmap)
+        return nullptr;
+
+    auto old_width = physical_width();
+    auto old_height = physical_height();
+
+    for (int y = 0; y < old_height; y++) {
+        for (int x = 0; x < old_width; x++) {
+            auto color = get_pixel(x, y);
+
+            auto base_x = x * sx;
+            auto base_y = y * sy;
+            for (int new_y = base_y; new_y < base_y + sy; new_y++) {
+                for (int new_x = base_x; new_x < base_x + sx; new_x++) {
+                    new_bitmap->set_pixel(new_x, new_y, color);
+                }
+            }
+        }
+    }
+
+    return new_bitmap;
+}
+
+// http://fourier.eng.hmc.edu/e161/lectures/resize/node3.html
+RefPtr<Gfx::Bitmap> Bitmap::scaled(float sx, float sy) const
+{
+    VERIFY(sx >= 0.0f && sy >= 0.0f);
+    if (floorf(sx) == sx && floorf(sy) == sy)
+        return scaled(static_cast<int>(sx), static_cast<int>(sy));
+
+    auto new_bitmap = Gfx::Bitmap::create(format(), { width() * sx, height() * sy }, scale());
+    if (!new_bitmap)
+        return nullptr;
+
+    auto old_width = physical_width();
+    auto old_height = physical_height();
+    auto new_width = new_bitmap->physical_width();
+    auto new_height = new_bitmap->physical_height();
+
+    // The interpolation goes out of bounds on the bottom- and right-most edges.
+    // We handle those in two specialized loops not only to make them faster, but
+    // also to avoid four branch checks for every pixel.
+
+    for (int y = 0; y < new_height - 1; y++) {
+        for (int x = 0; x < new_width - 1; x++) {
+            auto p = static_cast<float>(x) * static_cast<float>(old_width - 1) / static_cast<float>(new_width - 1);
+            auto q = static_cast<float>(y) * static_cast<float>(old_height - 1) / static_cast<float>(new_height - 1);
+
+            int i = floor(p);
+            int j = floor(q);
+            float u = p - static_cast<float>(i);
+            float v = q - static_cast<float>(j);
+
+            auto a = get_pixel(i, j);
+            auto b = get_pixel(i + 1, j);
+            auto c = get_pixel(i, j + 1);
+            auto d = get_pixel(i + 1, j + 1);
+
+            auto e = a.interpolate(b, u);
+            auto f = c.interpolate(d, u);
+            auto color = e.interpolate(f, v);
+            new_bitmap->set_pixel(x, y, color);
+        }
+    }
+
+    // Bottom strip (excluding last pixel)
+    auto old_bottom_y = old_height - 1;
+    auto new_bottom_y = new_height - 1;
+    for (int x = 0; x < new_width - 1; x++) {
+        auto p = static_cast<float>(x) * static_cast<float>(old_width - 1) / static_cast<float>(new_width - 1);
+
+        int i = floor(p);
+        float u = p - static_cast<float>(i);
+
+        auto a = get_pixel(i, old_bottom_y);
+        auto b = get_pixel(i + 1, old_bottom_y);
+        auto color = a.interpolate(b, u);
+        new_bitmap->set_pixel(x, new_bottom_y, color);
+    }
+
+    // Right strip (excluding last pixel)
+    auto old_right_x = old_width - 1;
+    auto new_right_x = new_width - 1;
+    for (int y = 0; y < new_height - 1; y++) {
+        auto q = static_cast<float>(y) * static_cast<float>(old_height - 1) / static_cast<float>(new_height - 1);
+
+        int j = floor(q);
+        float v = q - static_cast<float>(j);
+
+        auto c = get_pixel(old_right_x, j);
+        auto d = get_pixel(old_right_x, j + 1);
+
+        auto color = c.interpolate(d, v);
+        new_bitmap->set_pixel(new_right_x, y, color);
+    }
+
+    // Bottom-right pixel
+    new_bitmap->set_pixel(new_width - 1, new_height - 1, get_pixel(physical_width() - 1, physical_height() - 1));
+
+    return new_bitmap;
+}
+
 #ifdef __serenity__
 RefPtr<Bitmap> Bitmap::to_bitmap_backed_by_anon_fd() const
 {

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -115,6 +115,8 @@ public:
 
     RefPtr<Gfx::Bitmap> rotated(Gfx::RotationDirection) const;
     RefPtr<Gfx::Bitmap> flipped(Gfx::Orientation) const;
+    RefPtr<Gfx::Bitmap> scaled(int sx, int sy) const;
+    RefPtr<Gfx::Bitmap> scaled(float sx, float sy) const;
     RefPtr<Bitmap> to_bitmap_backed_by_anon_fd() const;
     ByteBuffer serialize_to_byte_buffer() const;
 

--- a/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
+++ b/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
@@ -319,7 +319,7 @@ void ClassicStylePainter::paint_progressbar(Painter& painter, const IntRect& rec
         float progress_height = progress * rect.height();
         hole_rect = { 0, 0, rect.width(), (int)(rect.height() - progress_height) };
     }
-    hole_rect.move_by(rect.location());
+    hole_rect.translate_by(rect.location());
     hole_rect.set_right_without_resize(rect.right());
     PainterStateSaver saver(painter);
     painter.fill_rect(hole_rect, palette.base());

--- a/Userland/Libraries/LibGfx/ClassicWindowTheme.cpp
+++ b/Userland/Libraries/LibGfx/ClassicWindowTheme.cpp
@@ -36,7 +36,7 @@ Gfx::IntRect ClassicWindowTheme::titlebar_icon_rect(WindowType window_type, cons
         16,
     };
     icon_rect.center_vertically_within(titlebar_rect);
-    icon_rect.move_by(0, 1);
+    icon_rect.translate_by(0, 1);
     return icon_rect;
 }
 

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -12,6 +12,7 @@
 #include <AK/SIMD.h>
 #include <AK/StdLibExtras.h>
 #include <LibIPC/Forward.h>
+#include <math.h>
 
 namespace Gfx {
 
@@ -137,6 +138,15 @@ public:
         u8 a = d / 255;
         return Color(r, g, b, a);
 #endif
+    }
+
+    constexpr Color interpolate(const Color& other, float weight) const
+    {
+        u8 r = red() + roundf(static_cast<float>(other.red() - red()) * weight);
+        u8 g = green() + roundf(static_cast<float>(other.green() - green()) * weight);
+        u8 b = blue() + roundf(static_cast<float>(other.blue() - blue()) * weight);
+        u8 a = alpha() + roundf(static_cast<float>(other.alpha() - alpha()) * weight);
+        return Color(r, g, b, a);
     }
 
     constexpr Color multiply(const Color& other) const

--- a/Userland/Libraries/LibGfx/DisjointRectSet.cpp
+++ b/Userland/Libraries/LibGfx/DisjointRectSet.cpp
@@ -56,7 +56,7 @@ void DisjointRectSet::shatter()
 void DisjointRectSet::move_by(int dx, int dy)
 {
     for (auto& r : m_rects)
-        r.move_by(dx, dy);
+        r.translate_by(dx, dy);
 }
 
 bool DisjointRectSet::contains(const IntRect& rect) const

--- a/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
@@ -95,7 +95,7 @@ public:
             // TODO: We probably don't need the entire source_rect, we could inflate
             // the target_rect appropriately
             apply_cache.m_target = Gfx::Bitmap::create(source.format(), source_rect.size());
-            target_rect.move_by(-target_rect.location());
+            target_rect.translate_by(-target_rect.location());
         }
 
         Bitmap* render_target_bitmap = (&target != &source) ? &target : apply_cache.m_target.ptr();

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -61,8 +61,8 @@ Painter::Painter(Gfx::Bitmap& bitmap)
     VERIFY(bitmap.physical_height() % scale == 0);
     m_state_stack.append(State());
     state().font = &FontDatabase::default_font();
-    state().clip_rect = { { 0, 0 }, bitmap.size() };
-    state().scale = scale;
+    state().clip_rect = { { 0, 0 }, bitmap.size() * scale };
+    transform().set_scale(scale, scale);
     m_clip_origin = state().clip_rect;
 }
 
@@ -72,9 +72,7 @@ Painter::~Painter()
 
 void Painter::fill_rect_with_draw_op(const IntRect& a_rect, Color color)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
-    auto rect = a_rect.translated(translation()).intersected(clip_rect());
+    auto rect = to_physical(a_rect);
     if (rect.is_empty())
         return;
 
@@ -90,12 +88,9 @@ void Painter::fill_rect_with_draw_op(const IntRect& a_rect, Color color)
 
 void Painter::clear_rect(const IntRect& a_rect, Color color)
 {
-    auto rect = a_rect.translated(translation()).intersected(clip_rect());
+    auto rect = to_physical(a_rect);
     if (rect.is_empty())
         return;
-
-    VERIFY(m_target->rect().contains(rect));
-    rect *= scale();
 
     RGBA32* dst = m_target->scanline(rect.top()) + rect.left();
     const size_t dst_skip = m_target->pitch() / sizeof(RGBA32);
@@ -109,13 +104,10 @@ void Painter::clear_rect(const IntRect& a_rect, Color color)
 void Painter::fill_physical_rect(const IntRect& physical_rect, Color color)
 {
     // Callers must do clipping.
-    RGBA32* dst = m_target->scanline(physical_rect.top()) + physical_rect.left();
-    const size_t dst_skip = m_target->pitch() / sizeof(RGBA32);
-
-    for (int i = physical_rect.height() - 1; i >= 0; --i) {
-        for (int j = 0; j < physical_rect.width(); ++j)
-            dst[j] = Color::from_rgba(dst[j]).blend(color).value();
-        dst += dst_skip;
+    for (int y = physical_rect.top(); y <= physical_rect.bottom(); ++y) {
+        auto* scanline = m_target->scanline(y);
+        for (int x = physical_rect.left(); x <= physical_rect.right(); ++x)
+            scanline[x] = Color::from_rgba(scanline[x]).blend(color).value();
     }
 }
 
@@ -134,19 +126,16 @@ void Painter::fill_rect(const IntRect& a_rect, Color color)
         return;
     }
 
-    auto rect = a_rect.translated(translation()).intersected(clip_rect());
+    auto rect = to_physical(a_rect);
     if (rect.is_empty())
         return;
-    VERIFY(m_target->rect().contains(rect));
 
-    fill_physical_rect(rect * scale(), color);
+    fill_physical_rect(rect, color);
 }
 
 void Painter::fill_rect_with_dither_pattern(const IntRect& a_rect, Color color_a, Color color_b)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
-    auto rect = a_rect.translated(translation()).intersected(clip_rect());
+    auto rect = to_physical(a_rect);
     if (rect.is_empty())
         return;
 
@@ -168,19 +157,19 @@ void Painter::fill_rect_with_dither_pattern(const IntRect& a_rect, Color color_a
 
 void Painter::fill_rect_with_checkerboard(const IntRect& a_rect, const IntSize& cell_size, Color color_dark, Color color_light)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
-    auto rect = a_rect.translated(translation()).intersected(clip_rect());
+    auto rect = to_physical(a_rect);
     if (rect.is_empty())
         return;
+
+    auto scaled_cell_size = scaled(cell_size);
 
     RGBA32* dst = m_target->scanline(rect.top()) + rect.left();
     const size_t dst_skip = m_target->pitch() / sizeof(RGBA32);
 
     for (int i = 0; i < rect.height(); ++i) {
         for (int j = 0; j < rect.width(); ++j) {
-            int cell_row = i / cell_size.height();
-            int cell_col = j / cell_size.width();
+            int cell_row = i / scaled_cell_size.height();
+            int cell_col = j / scaled_cell_size.width();
             dst[j] = ((cell_row % 2) ^ (cell_col % 2)) ? color_light.value() : color_dark.value();
         }
         dst += dst_skip;
@@ -198,8 +187,8 @@ void Painter::fill_rect_with_gradient(Orientation orientation, const IntRect& a_
     return fill_rect(a_rect, gradient_start);
 #endif
 
-    auto rect = to_physical(a_rect);
-    auto clipped_rect = IntRect::intersection(rect, clip_rect() * scale());
+    auto rect = a_rect.transformed(transform());
+    auto clipped_rect = rect.intersected(clip_rect());
     if (clipped_rect.is_empty())
         return;
 
@@ -208,7 +197,7 @@ void Painter::fill_rect_with_gradient(Orientation orientation, const IntRect& a_
     RGBA32* dst = m_target->scanline(clipped_rect.top()) + clipped_rect.left();
     const size_t dst_skip = m_target->pitch() / sizeof(RGBA32);
 
-    float increment = (1.0 / ((rect.primary_size_for_orientation(orientation))));
+    float increment = (1.0f / rect.primary_size_for_orientation(orientation));
     float alpha_increment = increment * ((float)gradient_end.alpha() - (float)gradient_start.alpha());
 
     if (orientation == Orientation::Horizontal) {
@@ -247,13 +236,9 @@ void Painter::fill_rect_with_gradient(const IntRect& a_rect, Color gradient_star
 
 void Painter::fill_ellipse(const IntRect& a_rect, Color color)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
-    auto rect = a_rect.translated(translation()).intersected(clip_rect());
+    auto rect = to_physical(a_rect);
     if (rect.is_empty())
         return;
-
-    VERIFY(m_target->rect().contains(rect));
 
     RGBA32* dst = m_target->scanline(rect.top()) + rect.left() + rect.width() / 2;
     const size_t dst_skip = m_target->pitch() / sizeof(RGBA32);
@@ -268,17 +253,15 @@ void Painter::fill_ellipse(const IntRect& a_rect, Color color)
 
 void Painter::draw_ellipse_intersecting(const IntRect& rect, Color color, int thickness)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
     constexpr int number_samples = 100; // FIXME: dynamically work out the number of samples based upon the rect size
     double increment = M_PI / number_samples;
 
     auto ellipse_x = [&](double theta) -> int {
-        return (cos(theta) * rect.width() / sqrt(2)) + rect.center().x();
+        return static_cast<int>(cos(theta) * rect.width() / sqrt(2)) + rect.center().x();
     };
 
     auto ellipse_y = [&](double theta) -> int {
-        return (sin(theta) * rect.height() / sqrt(2)) + rect.center().y();
+        return static_cast<int>(sin(theta) * rect.height() / sqrt(2)) + rect.center().y();
     };
 
     for (auto theta = 0.0; theta < 2 * M_PI; theta += increment) {
@@ -286,8 +269,8 @@ void Painter::draw_ellipse_intersecting(const IntRect& rect, Color color, int th
     }
 }
 
-template<typename RectType, typename Callback>
-static void for_each_pixel_around_rect_clockwise(const RectType& rect, Callback callback)
+template<typename Callback>
+static void for_each_pixel_around_rect_clockwise(const IntRect& rect, Callback callback)
 {
     if (rect.is_empty())
         return;
@@ -305,10 +288,9 @@ static void for_each_pixel_around_rect_clockwise(const RectType& rect, Callback 
     }
 }
 
-void Painter::draw_focus_rect(const IntRect& rect, Color color)
+void Painter::draw_focus_rect(const IntRect& a_rect, Color color)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
+    auto rect = to_physical(a_rect);
     if (rect.is_empty())
         return;
     bool state = false;
@@ -319,55 +301,14 @@ void Painter::draw_focus_rect(const IntRect& rect, Color color)
     });
 }
 
-void Painter::draw_rect(const IntRect& a_rect, Color color, bool rough)
+void Painter::draw_rect(const IntRect& rect, Color color, bool without_corners)
 {
-    IntRect rect = a_rect.translated(translation());
-    auto clipped_rect = rect.intersected(clip_rect());
-    if (clipped_rect.is_empty())
-        return;
+    int shift = without_corners ? 1 : 0;
 
-    int min_y = clipped_rect.top();
-    int max_y = clipped_rect.bottom();
-    int scale = this->scale();
-
-    if (rect.top() >= clipped_rect.top() && rect.top() <= clipped_rect.bottom()) {
-        int start_x = rough ? max(rect.x() + 1, clipped_rect.x()) : clipped_rect.x();
-        int width = rough ? min(rect.width() - 2, clipped_rect.width()) : clipped_rect.width();
-        for (int i = 0; i < scale; ++i)
-            fill_physical_scanline_with_draw_op(rect.top() * scale + i, start_x * scale, width * scale, color);
-        ++min_y;
-    }
-    if (rect.bottom() >= clipped_rect.top() && rect.bottom() <= clipped_rect.bottom()) {
-        int start_x = rough ? max(rect.x() + 1, clipped_rect.x()) : clipped_rect.x();
-        int width = rough ? min(rect.width() - 2, clipped_rect.width()) : clipped_rect.width();
-        for (int i = 0; i < scale; ++i)
-            fill_physical_scanline_with_draw_op(max_y * scale + i, start_x * scale, width * scale, color);
-        --max_y;
-    }
-
-    bool draw_left_side = rect.left() >= clipped_rect.left();
-    bool draw_right_side = rect.right() == clipped_rect.right();
-
-    if (draw_left_side && draw_right_side) {
-        // Specialized loop when drawing both sides.
-        for (int y = min_y * scale; y <= max_y * scale; ++y) {
-            auto* bits = m_target->scanline(y);
-            for (int i = 0; i < scale; ++i)
-                set_physical_pixel_with_draw_op(bits[rect.left() * scale + i], color);
-            for (int i = 0; i < scale; ++i)
-                set_physical_pixel_with_draw_op(bits[rect.right() * scale + i], color);
-        }
-    } else {
-        for (int y = min_y * scale; y <= max_y * scale; ++y) {
-            auto* bits = m_target->scanline(y);
-            if (draw_left_side)
-                for (int i = 0; i < scale; ++i)
-                    set_physical_pixel_with_draw_op(bits[rect.left() * scale + i], color);
-            if (draw_right_side)
-                for (int i = 0; i < scale; ++i)
-                    set_physical_pixel_with_draw_op(bits[rect.right() * scale + i], color);
-        }
-    }
+    draw_line(rect.top_left().moved_right(shift), rect.top_right().moved_left(shift), color);
+    draw_line(rect.bottom_left().moved_right(shift), rect.bottom_right().moved_left(shift), color);
+    draw_line(rect.top_left().moved_down(shift), rect.bottom_left().moved_up(shift), color);
+    draw_line(rect.top_right().moved_down(shift), rect.bottom_right().moved_up(shift), color);
 }
 
 void Painter::draw_bitmap(const IntPoint& p, const CharacterBitmap& bitmap, Color color)
@@ -437,11 +378,9 @@ void Painter::draw_bitmap(const IntPoint& p, const GlyphBitmap& bitmap, Color co
 
 void Painter::draw_triangle(const IntPoint& a, const IntPoint& b, const IntPoint& c, Color color)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
-    IntPoint p0(a);
-    IntPoint p1(b);
-    IntPoint p2(c);
+    auto p0 = to_physical(a);
+    auto p1 = to_physical(b);
+    auto p2 = to_physical(c);
 
     // sort points from top to bottom
     if (p0.y() > p1.y())
@@ -1411,10 +1350,7 @@ void Painter::draw_text(Function<void(const IntRect&, u32)> draw_one_glyph, cons
 
 void Painter::set_pixel(const IntPoint& p, Color color)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
-    auto point = p;
-    point.translate_by(state().translation);
+    auto point = to_physical(p);
     if (!clip_rect().contains(point))
         return;
     m_target->scanline(point.y())[point.x()] = color.value();
@@ -1468,33 +1404,36 @@ ALWAYS_INLINE void Painter::fill_physical_scanline_with_draw_op(int y, int x, in
     }
 }
 
-void Painter::draw_physical_pixel(const IntPoint& physical_position, Color color, int thickness)
+void Painter::draw_physical_pixel(const IntPoint& physical_position, Color color, IntSize thickness)
 {
     // This always draws a single physical pixel, independent of scale().
     // This should only be called by routines that already handle scale
     // (including scaling thickness).
     VERIFY(draw_op() == DrawOp::Copy);
 
-    if (thickness == 1) { // Implies scale() == 1.
+    if (thickness.width() == 1 && thickness.height() == 1) { // Implies scale() == 1.
         auto& pixel = m_target->scanline(physical_position.y())[physical_position.x()];
         return set_physical_pixel_with_draw_op(pixel, Color::from_rgba(pixel).blend(color));
     }
 
-    IntRect rect { physical_position, { thickness, thickness } };
-    rect.intersect(clip_rect() * scale());
+    IntRect rect { physical_position, thickness };
+    rect.intersect(clip_rect());
     fill_physical_rect(rect, color);
 }
 
-void Painter::draw_line(const IntPoint& p1, const IntPoint& p2, Color color, int thickness, LineStyle style)
+void Painter::draw_line(const IntPoint& p1, const IntPoint& p2, Color color, int thickness_, LineStyle style)
 {
+    auto horizontal_thickness = static_cast<int>(thickness_ * float_scale().x());
+    auto vertical_thickness = static_cast<int>(thickness_ * float_scale().y());
+    IntSize thickness { horizontal_thickness, vertical_thickness };
+
     if (color.alpha() == 0)
         return;
 
-    auto clip_rect = this->clip_rect() * scale();
+    auto clip_rect = this->clip_rect();
 
     auto point1 = to_physical(p1);
     auto point2 = to_physical(p2);
-    thickness *= scale();
 
     // Special case: vertical line.
     if (point1.x() == point2.x()) {
@@ -1510,16 +1449,16 @@ void Painter::draw_line(const IntPoint& p1, const IntPoint& p2, Color color, int
         int min_y = max(point1.y(), clip_rect.top());
         int max_y = min(point2.y(), clip_rect.bottom());
         if (style == LineStyle::Dotted) {
-            for (int y = min_y; y <= max_y; y += thickness * 2)
+            for (int y = min_y; y <= max_y; y += vertical_thickness * 2)
                 draw_physical_pixel({ x, y }, color, thickness);
         } else if (style == LineStyle::Dashed) {
-            for (int y = min_y; y <= max_y; y += thickness * 6) {
+            for (int y = min_y; y <= max_y; y += vertical_thickness * 6) {
                 draw_physical_pixel({ x, y }, color, thickness);
-                draw_physical_pixel({ x, min(y + thickness, max_y) }, color, thickness);
-                draw_physical_pixel({ x, min(y + thickness * 2, max_y) }, color, thickness);
+                draw_physical_pixel({ x, min(y + vertical_thickness, max_y) }, color, thickness);
+                draw_physical_pixel({ x, min(y + vertical_thickness * 2, max_y) }, color, thickness);
             }
         } else {
-            for (int y = min_y; y <= max_y; y += thickness)
+            for (int y = min_y; y <= max_y; y += vertical_thickness)
                 draw_physical_pixel({ x, y }, color, thickness);
         }
         return;
@@ -1539,16 +1478,16 @@ void Painter::draw_line(const IntPoint& p1, const IntPoint& p2, Color color, int
         int min_x = max(point1.x(), clip_rect.left());
         int max_x = min(point2.x(), clip_rect.right());
         if (style == LineStyle::Dotted) {
-            for (int x = min_x; x <= max_x; x += thickness * 2)
+            for (int x = min_x; x <= max_x; x += horizontal_thickness * 2)
                 draw_physical_pixel({ x, y }, color, thickness);
         } else if (style == LineStyle::Dashed) {
-            for (int x = min_x; x <= max_x; x += thickness * 6) {
+            for (int x = min_x; x <= max_x; x += horizontal_thickness * 6) {
                 draw_physical_pixel({ x, y }, color, thickness);
-                draw_physical_pixel({ min(x + thickness, max_x), y }, color, thickness);
-                draw_physical_pixel({ min(x + thickness * 2, max_x), y }, color, thickness);
+                draw_physical_pixel({ min(x + horizontal_thickness, max_x), y }, color, thickness);
+                draw_physical_pixel({ min(x + horizontal_thickness * 2, max_x), y }, color, thickness);
             }
         } else {
-            for (int x = min_x; x <= max_x; x += thickness)
+            for (int x = min_x; x <= max_x; x += horizontal_thickness)
                 draw_physical_pixel({ x, y }, color, thickness);
         }
         return;
@@ -1682,10 +1621,8 @@ static bool can_approximate_elliptical_arc(const FloatPoint& p1, const FloatPoin
 
 void Painter::draw_quadratic_bezier_curve(const IntPoint& control_point, const IntPoint& p1, const IntPoint& p2, Color color, int thickness, LineStyle style)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
     for_each_line_segment_on_bezier_curve(FloatPoint(control_point), FloatPoint(p1), FloatPoint(p2), [&](const FloatPoint& fp1, const FloatPoint& fp2) {
-        draw_line(IntPoint(fp1.x(), fp1.y()), IntPoint(fp2.x(), fp2.y()), color, thickness, style);
+        draw_line({ fp1.x(), fp1.y() }, { fp2.x(), fp2.y() }, color, thickness, style);
     });
 }
 
@@ -1736,22 +1673,25 @@ void Painter::for_each_line_segment_on_elliptical_arc(const FloatPoint& p1, cons
 
 void Painter::draw_elliptical_arc(const IntPoint& p1, const IntPoint& p2, const IntPoint& center, const FloatPoint& radii, float x_axis_rotation, float theta_1, float theta_delta, Color color, int thickness, LineStyle style)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
     for_each_line_segment_on_elliptical_arc(FloatPoint(p1), FloatPoint(p2), FloatPoint(center), radii, x_axis_rotation, theta_1, theta_delta, [&](const FloatPoint& fp1, const FloatPoint& fp2) {
-        draw_line(IntPoint(fp1.x(), fp1.y()), IntPoint(fp2.x(), fp2.y()), color, thickness, style);
+        draw_line({ fp1.x(), fp1.y() }, { fp2.x(), fp2.y() }, color, thickness, style);
     });
 }
 
 void Painter::add_clip_rect(const IntRect& rect)
 {
-    state().clip_rect.intersect(rect.translated(translation()));
-    state().clip_rect.intersect(m_target->rect()); // FIXME: This shouldn't be necessary?
+    state().clip_rect.intersect(rect.transformed(transform()));
 }
 
 void Painter::clear_clip_rect()
 {
     state().clip_rect = m_clip_origin;
+}
+
+int Painter::scale() const
+{
+    VERIFY(has_integer_scale());
+    return transform().x_scale();
 }
 
 PainterStateSaver::PainterStateSaver(Painter& painter)
@@ -1767,8 +1707,6 @@ PainterStateSaver::~PainterStateSaver()
 
 void Painter::stroke_path(const Path& path, Color color, int thickness)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
     FloatPoint cursor;
 
     for (auto& segment : path.segments()) {
@@ -1822,8 +1760,6 @@ void Painter::stroke_path(const Path& path, Color color, int thickness)
 
 void Painter::fill_path(Path& path, Color color, WindingRule winding_rule)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
     const auto& segments = path.split_lines();
 
     if (segments.size() == 0)

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1070,28 +1070,28 @@ void draw_text_line(const IntRect& a_rect, const TextType& text, const Font& fon
 
     if (is_vertically_centered_text_alignment(alignment)) {
         int distance_from_baseline_to_bottom = (font.glyph_height() - 1) - font.baseline();
-        rect.move_by(0, distance_from_baseline_to_bottom / 2);
+        rect.translate_by(0, distance_from_baseline_to_bottom / 2);
     }
 
     auto point = rect.location();
     int space_width = font.glyph_width(' ') + font.glyph_spacing();
 
     if (direction == TextDirection::RTL) {
-        point.move_by(rect.width(), 0); // Start drawing from the end
-        space_width = -space_width;     // Draw spaces backwards
+        point.translate_by(rect.width(), 0); // Start drawing from the end
+        space_width = -space_width;          // Draw spaces backwards
     }
 
     for (u32 code_point : final_text) {
         if (code_point == ' ') {
-            point.move_by(space_width, 0);
+            point.translate_by(space_width, 0);
             continue;
         }
         IntSize glyph_size(font.glyph_or_emoji_width(code_point) + font.glyph_spacing(), font.glyph_height());
         if (direction == TextDirection::RTL)
-            point.move_by(-glyph_size.width(), 0); // If we are drawing right to left, we have to move backwards before drawing the glyph
+            point.translate_by(-glyph_size.width(), 0); // If we are drawing right to left, we have to move backwards before drawing the glyph
         draw_glyph({ point, glyph_size }, code_point);
         if (direction == TextDirection::LTR)
-            point.move_by(glyph_size.width(), 0);
+            point.translate_by(glyph_size.width(), 0);
     }
 }
 
@@ -1414,7 +1414,7 @@ void Painter::set_pixel(const IntPoint& p, Color color)
     VERIFY(scale() == 1); // FIXME: Add scaling support.
 
     auto point = p;
-    point.move_by(state().translation);
+    point.translate_by(state().translation);
     if (!clip_rect().contains(point))
         return;
     m_target->scanline(point.y())[point.x()] = color.value();

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -100,7 +100,7 @@ public:
     void clear_clip_rect();
 
     void translate(int dx, int dy) { translate({ dx, dy }); }
-    void translate(const IntPoint& delta) { state().translation.move_by(delta); }
+    void translate(const IntPoint& delta) { state().translation.translate_by(delta); }
 
     Gfx::Bitmap* target() { return m_target.ptr(); }
 

--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -50,7 +50,7 @@ void Path::elliptical_arc_to(const FloatPoint& point, const FloatPoint& radii, d
         }
 
         // Move the endpoint by a small amount to avoid division by zero.
-        next_point.move_by(0.01f, 0.01f);
+        next_point.translate_by(0.01f, 0.01f);
     }
 
     // Find (cx, cy), theta_1, theta_delta

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -233,7 +233,7 @@ public:
     }
 
     template<typename U>
-    Point<U> to_type() const
+    [[nodiscard]] ALWAYS_INLINE Point<U> to_type() const
     {
         return Point<U>(*this);
     }

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Format.h>
+#include <LibGfx/AffineTransform.h>
 #include <LibGfx/Orientation.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Size.h>
@@ -24,7 +25,7 @@ T abst(T value)
 template<typename T>
 class Rect {
 public:
-    Rect() { }
+    Rect() = default;
 
     Rect(T x, T y, T width, T height)
         : m_location(x, y)
@@ -59,37 +60,47 @@ public:
     {
     }
 
-    bool is_null() const
-    {
-        return width() == 0 && height() == 0;
-    }
+    [[nodiscard]] ALWAYS_INLINE T x() const { return location().x(); }
+    [[nodiscard]] ALWAYS_INLINE T y() const { return location().y(); }
+    [[nodiscard]] ALWAYS_INLINE T width() const { return m_size.width(); }
+    [[nodiscard]] ALWAYS_INLINE T height() const { return m_size.height(); }
 
-    bool is_empty() const
-    {
-        return width() <= 0 || height() <= 0;
-    }
+    ALWAYS_INLINE void set_x(T x) { m_location.set_x(x); }
+    ALWAYS_INLINE void set_y(T y) { m_location.set_y(y); }
+    ALWAYS_INLINE void set_width(T width) { m_size.set_width(width); }
+    ALWAYS_INLINE void set_height(T height) { m_size.set_height(height); }
 
-    void move_by(T dx, T dy)
-    {
-        m_location.move_by(dx, dy);
-    }
+    [[nodiscard]] ALWAYS_INLINE const Point<T>& location() const { return m_location; }
+    [[nodiscard]] ALWAYS_INLINE const Size<T>& size() const { return m_size; }
 
-    void move_by(const Point<T>& delta)
+    [[nodiscard]] ALWAYS_INLINE bool is_null() const { return width() == 0 && height() == 0; }
+    [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return width() <= 0 || height() <= 0; }
+
+    ALWAYS_INLINE void translate_by(T dx, T dy) { m_location.translate_by(dx, dy); }
+    ALWAYS_INLINE void translate_by(T dboth) { m_location.translate_by(dboth); }
+    ALWAYS_INLINE void translate_by(const Point<T>& delta) { m_location.translate_by(delta); }
+
+    ALWAYS_INLINE void scale_by(T dx, T dy)
     {
-        m_location.move_by(delta);
+        m_location.scale_by(dx, dy);
+        m_size.scale_by(dx, dy);
     }
+    ALWAYS_INLINE void scale_by(T dboth) { scale_by(dboth, dboth); }
+    ALWAYS_INLINE void scale_by(const Point<T>& delta) { scale_by(delta.x(), delta.y()); }
+
+    void transform_by(const AffineTransform& transform) { *this = transform.map(*this); }
 
     Point<T> center() const
     {
         return { x() + width() / 2, y() + height() / 2 };
     }
 
-    void set_location(const Point<T>& location)
+    ALWAYS_INLINE void set_location(const Point<T>& location)
     {
         m_location = location;
     }
 
-    void set_size(const Size<T>& size)
+    ALWAYS_INLINE void set_size(const Size<T>& size)
     {
         m_size = size;
     }
@@ -134,6 +145,41 @@ public:
         set_height(height() - size.height());
     }
 
+    Rect<T> translated(T dx, T dy) const
+    {
+        Rect<T> rect = *this;
+        rect.translate_by(dx, dy);
+        return rect;
+    }
+
+    Rect<T> translated(const Point<T>& delta) const
+    {
+        Rect<T> rect = *this;
+        rect.translate_by(delta);
+        return rect;
+    }
+
+    Rect<T> scaled(T sx, T sy) const
+    {
+        Rect<T> rect = *this;
+        rect.scale_by(sx, sy);
+        return rect;
+    }
+
+    Rect<T> scaled(const Point<T>& s) const
+    {
+        Rect<T> rect = *this;
+        rect.scale_by(s);
+        return rect;
+    }
+
+    Rect<T> transformed(const AffineTransform& transform) const
+    {
+        Rect<T> rect = *this;
+        rect.transform_by(transform);
+        return rect;
+    }
+
     Rect<T> shrunken(T w, T h) const
     {
         Rect<T> rect = *this;
@@ -159,20 +205,6 @@ public:
     {
         Rect<T> rect = *this;
         rect.inflate(size);
-        return rect;
-    }
-
-    Rect<T> translated(T dx, T dy) const
-    {
-        Rect<T> rect = *this;
-        rect.move_by(dx, dy);
-        return rect;
-    }
-
-    Rect<T> translated(const Point<T>& delta) const
-    {
-        Rect<T> rect = *this;
-        rect.move_by(delta);
         return rect;
     }
 
@@ -235,7 +267,7 @@ public:
         return x >= m_location.x() && x <= right() && y >= m_location.y() && y <= bottom();
     }
 
-    bool contains(const Point<T>& point) const
+    ALWAYS_INLINE bool contains(const Point<T>& point) const
     {
         return contains(point.x(), point.y());
     }
@@ -260,15 +292,15 @@ public:
         return have_any;
     }
 
-    int primary_offset_for_orientation(Orientation orientation) const { return m_location.primary_offset_for_orientation(orientation); }
-    void set_primary_offset_for_orientation(Orientation orientation, int value) { m_location.set_primary_offset_for_orientation(orientation, value); }
-    int secondary_offset_for_orientation(Orientation orientation) const { return m_location.secondary_offset_for_orientation(orientation); }
-    void set_secondary_offset_for_orientation(Orientation orientation, int value) { m_location.set_secondary_offset_for_orientation(orientation, value); }
+    ALWAYS_INLINE int primary_offset_for_orientation(Orientation orientation) const { return m_location.primary_offset_for_orientation(orientation); }
+    ALWAYS_INLINE void set_primary_offset_for_orientation(Orientation orientation, int value) { m_location.set_primary_offset_for_orientation(orientation, value); }
+    ALWAYS_INLINE int secondary_offset_for_orientation(Orientation orientation) const { return m_location.secondary_offset_for_orientation(orientation); }
+    ALWAYS_INLINE void set_secondary_offset_for_orientation(Orientation orientation, int value) { m_location.set_secondary_offset_for_orientation(orientation, value); }
 
-    int primary_size_for_orientation(Orientation orientation) const { return m_size.primary_size_for_orientation(orientation); }
-    int secondary_size_for_orientation(Orientation orientation) const { return m_size.secondary_size_for_orientation(orientation); }
-    void set_primary_size_for_orientation(Orientation orientation, int value) { m_size.set_primary_size_for_orientation(orientation, value); }
-    void set_secondary_size_for_orientation(Orientation orientation, int value) { m_size.set_secondary_size_for_orientation(orientation, value); }
+    ALWAYS_INLINE int primary_size_for_orientation(Orientation orientation) const { return m_size.primary_size_for_orientation(orientation); }
+    ALWAYS_INLINE int secondary_size_for_orientation(Orientation orientation) const { return m_size.secondary_size_for_orientation(orientation); }
+    ALWAYS_INLINE void set_primary_size_for_orientation(Orientation orientation, int value) { m_size.set_primary_size_for_orientation(orientation, value); }
+    ALWAYS_INLINE void set_secondary_size_for_orientation(Orientation orientation, int value) { m_size.set_secondary_size_for_orientation(orientation, value); }
 
     T first_edge_for_orientation(Orientation orientation) const
     {
@@ -284,27 +316,27 @@ public:
         return right();
     }
 
-    T left() const { return x(); }
-    T right() const { return x() + width() - 1; }
-    T top() const { return y(); }
-    T bottom() const { return y() + height() - 1; }
+    [[nodiscard]] ALWAYS_INLINE T left() const { return x(); }
+    [[nodiscard]] ALWAYS_INLINE T right() const { return x() + width() - 1; }
+    [[nodiscard]] ALWAYS_INLINE T top() const { return y(); }
+    [[nodiscard]] ALWAYS_INLINE T bottom() const { return y() + height() - 1; }
 
-    void set_left(T left)
+    ALWAYS_INLINE void set_left(T left)
     {
         set_x(left);
     }
 
-    void set_top(T top)
+    ALWAYS_INLINE void set_top(T top)
     {
         set_y(top);
     }
 
-    void set_right(T right)
+    ALWAYS_INLINE void set_right(T right)
     {
         set_width(right - x() + 1);
     }
 
-    void set_bottom(T bottom)
+    ALWAYS_INLINE void set_bottom(T bottom)
     {
         set_height(bottom - y() + 1);
     }
@@ -312,13 +344,13 @@ public:
     void set_right_without_resize(T new_right)
     {
         int delta = new_right - right();
-        move_by(delta, 0);
+        translate_by(delta, 0);
     }
 
     void set_bottom_without_resize(T new_bottom)
     {
         int delta = new_bottom - bottom();
-        move_by(0, delta);
+        translate_by(0, delta);
     }
 
     bool intersects_vertically(const Rect<T>& other) const
@@ -365,19 +397,6 @@ public:
         return IterationDecision::Continue;
     }
 
-    T x() const { return location().x(); }
-    T y() const { return location().y(); }
-    T width() const { return m_size.width(); }
-    T height() const { return m_size.height(); }
-
-    void set_x(T x) { m_location.set_x(x); }
-    void set_y(T y) { m_location.set_y(y); }
-    void set_width(T width) { m_size.set_width(width); }
-    void set_height(T height) { m_size.set_height(height); }
-
-    const Point<T>& location() const { return m_location; }
-    const Size<T>& size() const { return m_size; }
-
     Vector<Rect<T>, 4> shatter(const Rect<T>& hammer) const;
 
     template<class U>
@@ -415,7 +434,7 @@ public:
         return r;
     }
 
-    Rect<T> intersected(const Rect<T>& other) const
+    ALWAYS_INLINE Rect<T> intersected(const Rect<T>& other) const
     {
         return intersection(*this, other);
     }
@@ -446,7 +465,7 @@ public:
     }
 
     template<typename U>
-    Rect<U> to() const
+    ALWAYS_INLINE Rect<U> to_type() const
     {
         return Rect<U>(*this);
     }

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -8,6 +8,7 @@
 
 #include <AK/Format.h>
 #include <LibGfx/Orientation.h>
+#include <LibGfx/Point.h>
 #include <LibIPC/Forward.h>
 
 namespace Gfx {
@@ -15,7 +16,7 @@ namespace Gfx {
 template<typename T>
 class Size {
 public:
-    Size() { }
+    Size() = default;
 
     Size(T w, T h)
         : m_width(w)
@@ -37,16 +38,54 @@ public:
     {
     }
 
-    bool is_null() const { return !m_width && !m_height; }
-    bool is_empty() const { return m_width <= 0 || m_height <= 0; }
+    [[nodiscard]] ALWAYS_INLINE T width() const { return m_width; }
+    [[nodiscard]] ALWAYS_INLINE T height() const { return m_height; }
+    [[nodiscard]] ALWAYS_INLINE T area() const { return width() * height(); }
 
-    T width() const { return m_width; }
-    T height() const { return m_height; }
+    ALWAYS_INLINE void set_width(T w) { m_width = w; }
+    ALWAYS_INLINE void set_height(T h) { m_height = h; }
 
-    T area() const { return width() * height(); }
+    [[nodiscard]] ALWAYS_INLINE bool is_null() const { return !m_width && !m_height; }
+    [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return m_width <= 0 || m_height <= 0; }
 
-    void set_width(T w) { m_width = w; }
-    void set_height(T h) { m_height = h; }
+    void scale_by(T dx, T dy)
+    {
+        m_width *= dx;
+        m_height *= dy;
+    }
+
+    void transform_by(const AffineTransform& transform) { *this = transform.map(*this); }
+
+    ALWAYS_INLINE void scale_by(T dboth) { scale_by(dboth, dboth); }
+    ALWAYS_INLINE void scale_by(const Point<T>& s) { scale_by(s.x(), s.y()); }
+
+    Size scaled_by(T dx, T dy) const
+    {
+        Size<T> size = *this;
+        size.scale_by(dx, dy);
+        return size;
+    }
+
+    Size scaled_by(T dboth) const
+    {
+        Size<T> size = *this;
+        size.scale_by(dboth);
+        return size;
+    }
+
+    Size scaled_by(const Point<T>& s) const
+    {
+        Size<T> size = *this;
+        size.scale_by(s);
+        return size;
+    }
+
+    Size transformed_by(const AffineTransform& transform) const
+    {
+        Size<T> size = *this;
+        size.transform_by(transform);
+        return size;
+    }
 
     template<typename U>
     bool contains(const Size<U>& other) const
@@ -118,7 +157,7 @@ public:
     }
 
     template<typename U>
-    Size<U> to_type() const
+    ALWAYS_INLINE Size<U> to_type() const
     {
         return Size<U>(*this);
     }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -157,7 +157,7 @@ void CanvasRenderingContext2D::fill_text(const String& text, float x, float y, O
     auto text_rect = Gfx::IntRect(x, y, max_width.has_value() ? max_width.value() : painter->font().width(text), painter->font().glyph_height());
     auto transformed_rect = m_transform.map(text_rect);
     painter->draw_text(transformed_rect, text, Gfx::TextAlignment::TopLeft, m_fill_style);
-    did_draw(transformed_rect.to<float>());
+    did_draw(transformed_rect.to_type<float>());
 }
 
 void CanvasRenderingContext2D::begin_path()

--- a/Userland/Libraries/LibWeb/Layout/BlockBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockBox.cpp
@@ -142,7 +142,7 @@ bool BlockBox::handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsi
     if (!is_scrollable())
         return false;
     auto new_offset = m_scroll_offset;
-    new_offset.move_by(0, wheel_delta);
+    new_offset.translate_by(0, wheel_delta);
     set_scroll_offset(new_offset);
 
     return true;

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -550,7 +550,7 @@ static Gfx::FloatRect rect_in_coordinate_space(const Box& box, const Box& contex
     for (auto* ancestor = box.parent(); ancestor; ancestor = ancestor->parent()) {
         if (is<Box>(*ancestor)) {
             auto offset = downcast<Box>(*ancestor).effective_offset();
-            rect.move_by(offset);
+            rect.translate_by(offset);
         }
         if (ancestor == &context_box)
             break;

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -154,7 +154,7 @@ const Gfx::FloatRect Box::absolute_rect() const
 {
     Gfx::FloatRect rect { effective_offset(), size() };
     for (auto* block = containing_block(); block; block = block->containing_block()) {
-        rect.move_by(block->effective_offset());
+        rect.translate_by(block->effective_offset());
     }
     return rect;
 }

--- a/Userland/Libraries/LibWeb/Layout/ButtonBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ButtonBox.cpp
@@ -49,7 +49,7 @@ void ButtonBox::paint(PaintContext& context, PaintPhase phase)
 
         auto text_rect = enclosing_int_rect(absolute_rect());
         if (m_being_pressed)
-            text_rect.move_by(1, 1);
+            text_rect.translate_by(1, 1);
         context.painter().draw_text(text_rect, dom_node().value(), font(), Gfx::TextAlignment::Center, context.palette().button_text());
     }
 }

--- a/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
@@ -60,7 +60,7 @@ void FrameBox::paint(PaintContext& context, PaintPhase phase)
 
         if constexpr (HIGHLIGHT_FOCUSED_FRAME_DEBUG) {
             if (dom_node().content_frame()->is_focused_frame()) {
-                context.painter().draw_rect(absolute_rect().to<int>(), Color::Cyan);
+                context.painter().draw_rect(absolute_rect().to_type<int>(), Color::Cyan);
             }
         }
     }

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -110,7 +110,7 @@ bool ImageBox::renders_as_alt_text() const
 
 void ImageBox::frame_did_set_viewport_rect(const Gfx::IntRect& viewport_rect)
 {
-    m_image_loader.set_visible_in_viewport(viewport_rect.to<float>().intersects(absolute_rect()));
+    m_image_loader.set_visible_in_viewport(viewport_rect.to_type<float>().intersects(absolute_rect()));
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -154,7 +154,7 @@ void InlineFormattingContext::run(Box&, LayoutMode layout_mode)
                 // Shift subsequent sibling fragments to the right to adjust for change in width.
                 for (size_t j = i + 1; j < line_box.fragments().size(); ++j) {
                     auto offset = line_box.fragments()[j].offset();
-                    offset.move_by(diff, 0);
+                    offset.translate_by(diff, 0);
                     line_box.fragments()[j].set_offset(offset);
                 }
             }

--- a/Userland/Libraries/LibWeb/Layout/LineBoxFragment.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBoxFragment.cpp
@@ -48,7 +48,7 @@ const Gfx::FloatRect LineBoxFragment::absolute_rect() const
 {
     Gfx::FloatRect rect { {}, size() };
     rect.set_location(m_layout_node.containing_block()->absolute_position());
-    rect.move_by(offset());
+    rect.translate_by(offset());
     return rect;
 }
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -319,7 +319,7 @@ bool Node::handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsigned
         if (!containing_block->is_scrollable())
             return false;
         auto new_offset = containing_block->scroll_offset();
-        new_offset.move_by(0, wheel_delta);
+        new_offset.translate_by(0, wheel_delta);
         containing_block->set_scroll_offset(new_offset);
         return true;
     }

--- a/Userland/Libraries/LibWeb/Page/Frame.cpp
+++ b/Userland/Libraries/LibWeb/Page/Frame.cpp
@@ -182,7 +182,7 @@ void Frame::scroll_to_anchor(const String& fragment)
     if (is<Layout::Box>(layout_node)) {
         auto& layout_box = downcast<Layout::Box>(layout_node);
         auto padding_box = layout_box.box_model().padding_box();
-        float_rect.move_by(-padding_box.left, -padding_box.top);
+        float_rect.translate_by(-padding_box.left, -padding_box.top);
     }
 
     if (m_page)
@@ -206,7 +206,7 @@ Gfx::IntPoint Frame::to_main_frame_position(const Gfx::IntPoint& a_position)
             return {};
         if (!ancestor->host_element()->layout_node())
             return {};
-        position.move_by(ancestor->host_element()->layout_node()->box_type_agnostic_position().to_type<int>());
+        position.translate_by(ancestor->host_element()->layout_node()->box_type_agnostic_position().to_type<int>());
     }
     return position;
 }

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -72,20 +72,20 @@ void paint_border(PaintContext& context, BorderEdge edge, const Gfx::FloatRect& 
     if (gfx_line_style != Gfx::Painter::LineStyle::Solid) {
         switch (edge) {
         case BorderEdge::Top:
-            p1.move_by(int_width / 2, int_width / 2);
-            p2.move_by(-int_width / 2, int_width / 2);
+            p1.translate_by(int_width / 2, int_width / 2);
+            p2.translate_by(-int_width / 2, int_width / 2);
             break;
         case BorderEdge::Right:
-            p1.move_by(-int_width / 2, int_width / 2);
-            p2.move_by(-int_width / 2, -int_width / 2);
+            p1.translate_by(-int_width / 2, int_width / 2);
+            p2.translate_by(-int_width / 2, -int_width / 2);
             break;
         case BorderEdge::Bottom:
-            p1.move_by(int_width / 2, -int_width / 2);
-            p2.move_by(-int_width / 2, -int_width / 2);
+            p1.translate_by(int_width / 2, -int_width / 2);
+            p2.translate_by(-int_width / 2, -int_width / 2);
             break;
         case BorderEdge::Left:
-            p1.move_by(int_width / 2, int_width / 2);
-            p2.move_by(int_width / 2, -int_width / 2);
+            p1.translate_by(int_width / 2, int_width / 2);
+            p2.translate_by(int_width / 2, -int_width / 2);
             break;
         }
         context.painter().draw_line({ (int)p1.x(), (int)p1.y() }, { (int)p2.x(), (int)p2.y() }, color, int_width, gfx_line_style);
@@ -105,8 +105,8 @@ void paint_border(PaintContext& context, BorderEdge edge, const Gfx::FloatRect& 
         p2_step = style.border_right().width / (float)int_width;
         for (int i = 0; i < int_width; ++i) {
             draw_line(p1, p2);
-            p1.move_by(p1_step, 1);
-            p2.move_by(-p2_step, 1);
+            p1.translate_by(p1_step, 1);
+            p2.translate_by(-p2_step, 1);
         }
         break;
     case BorderEdge::Right:
@@ -114,8 +114,8 @@ void paint_border(PaintContext& context, BorderEdge edge, const Gfx::FloatRect& 
         p2_step = style.border_bottom().width / (float)int_width;
         for (int i = int_width - 1; i >= 0; --i) {
             draw_line(p1, p2);
-            p1.move_by(-1, p1_step);
-            p2.move_by(-1, -p2_step);
+            p1.translate_by(-1, p1_step);
+            p2.translate_by(-1, -p2_step);
         }
         break;
     case BorderEdge::Bottom:
@@ -123,8 +123,8 @@ void paint_border(PaintContext& context, BorderEdge edge, const Gfx::FloatRect& 
         p2_step = style.border_right().width / (float)int_width;
         for (int i = int_width - 1; i >= 0; --i) {
             draw_line(p1, p2);
-            p1.move_by(p1_step, -1);
-            p2.move_by(-p2_step, -1);
+            p1.translate_by(p1_step, -1);
+            p2.translate_by(-p2_step, -1);
         }
         break;
     case BorderEdge::Left:
@@ -132,8 +132,8 @@ void paint_border(PaintContext& context, BorderEdge edge, const Gfx::FloatRect& 
         p2_step = style.border_bottom().width / (float)int_width;
         for (int i = 0; i < int_width; ++i) {
             draw_line(p1, p2);
-            p1.move_by(1, p1_step);
-            p2.move_by(1, -p2_step);
+            p1.translate_by(1, p1_step);
+            p2.translate_by(1, -p2_step);
         }
         break;
     }

--- a/Userland/Services/Taskbar/TaskbarButton.cpp
+++ b/Userland/Services/Taskbar/TaskbarButton.cpp
@@ -80,7 +80,7 @@ static void paint_custom_progressbar(GUI::Painter& painter, const Gfx::IntRect& 
     }
 
     Gfx::IntRect hole_rect { (int)progress_width, 0, (int)(rect.width() - progress_width), rect.height() };
-    hole_rect.move_by(rect.location());
+    hole_rect.translate_by(rect.location());
     hole_rect.set_right_without_resize(rect.right());
     Gfx::PainterStateSaver saver(painter);
     painter.add_clip_rect(hole_rect);
@@ -109,7 +109,7 @@ void TaskbarButton::paint_event(GUI::PaintEvent& event)
         icon_location.set_x(content_rect.x());
 
     if (!text().is_empty()) {
-        content_rect.move_by(icon.width() + 4, 0);
+        content_rect.translate_by(icon.width() + 4, 0);
         content_rect.set_width(content_rect.width() - icon.width() - 4);
     }
 
@@ -119,8 +119,8 @@ void TaskbarButton::paint_event(GUI::PaintEvent& event)
     text_rect.align_within(content_rect, text_alignment());
 
     if (is_being_pressed() || is_checked()) {
-        text_rect.move_by(1, 1);
-        icon_location.move_by(1, 1);
+        text_rect.translate_by(1, 1);
+        icon_location.translate_by(1, 1);
     }
 
     if (window.progress().has_value()) {

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -138,7 +138,7 @@ void Compositor::compose()
             auto invalidate_rect = dirty_rect.intersected(frame_rect);
             if (!invalidate_rect.is_empty()) {
                 auto inner_rect_offset = window.rect().location() - frame_rect.location();
-                invalidate_rect.move_by(-(frame_rect.location() + inner_rect_offset));
+                invalidate_rect.translate_by(-(frame_rect.location() + inner_rect_offset));
                 window.invalidate_no_notify(invalidate_rect);
                 m_invalidated_window = true;
             }
@@ -449,7 +449,7 @@ void Compositor::compose()
             if (!wm.dnd_text().is_empty()) {
                 auto text_rect = dnd_rect;
                 if (wm.dnd_bitmap())
-                    text_rect.move_by(wm.dnd_bitmap()->width() + 8, 0);
+                    text_rect.translate_by(wm.dnd_bitmap()->width() + 8, 0);
                 back_painter.draw_text(text_rect, wm.dnd_text(), Gfx::TextAlignment::CenterLeft, wm.palette().selection_text());
             }
             if (wm.dnd_bitmap()) {

--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -133,7 +133,7 @@ Window& Menu::ensure_menu_window()
         else if (item.type() == MenuItem::Separator)
             height = 8;
         item.set_rect({ next_item_location, { width - frame_thickness() * 2, height } });
-        next_item_location.move_by(0, height);
+        next_item_location.translate_by(0, height);
     }
 
     int window_height_available = Screen::the().height() - frame_thickness() * 2;
@@ -236,7 +236,7 @@ void Menu::draw()
                     painter.blit_filtered(icon_rect.location().translated(1, 1), *item.icon(), item.icon()->rect(), [&shadow_color](auto) {
                         return shadow_color;
                     });
-                    icon_rect.move_by(-1, -1);
+                    icon_rect.translate_by(-1, -1);
                 }
                 if (item.is_enabled())
                     painter.blit(icon_rect.location(), *item.icon(), item.icon()->rect());

--- a/Userland/Services/WindowServer/Screen.cpp
+++ b/Userland/Services/WindowServer/Screen.cpp
@@ -123,7 +123,7 @@ void Screen::on_receive_mouse_data(const MousePacket& packet)
 {
     auto prev_location = m_physical_cursor_location / m_scale_factor;
     if (packet.is_relative) {
-        m_physical_cursor_location.move_by(packet.x * m_acceleration_factor, packet.y * m_acceleration_factor);
+        m_physical_cursor_location.translate_by(packet.x * m_acceleration_factor, packet.y * m_acceleration_factor);
         dbgln_if(WSSCREEN_DEBUG, "Screen: New Relative mouse point @ {}", m_physical_cursor_location);
     } else {
         m_physical_cursor_location = { packet.x * physical_width() / 0xffff, packet.y * physical_height() / 0xffff };

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -541,7 +541,7 @@ bool Window::invalidate_no_notify(const Gfx::IntRect& rect, bool with_frame)
 
     auto outer_rect = frame().render_rect();
     auto inner_rect = rect;
-    inner_rect.move_by(position());
+    inner_rect.translate_by(position());
     // FIXME: This seems slightly wrong; the inner rect shouldn't intersect the border part of the outer rect.
     inner_rect.intersect(outer_rect);
     if (inner_rect.is_empty())
@@ -976,7 +976,7 @@ void Window::set_menubar(Menubar* menubar)
         m_menubar->for_each_menu([&](Menu& menu) {
             int text_width = wm.font().width(Gfx::parse_ampersand_string(menu.name()));
             menu.set_rect_in_window_menubar({ next_menu_location.x(), 0, text_width + menubar_menu_margin, menubar_rect.height() });
-            next_menu_location.move_by(menu.rect_in_window_menubar().width(), 0);
+            next_menu_location.translate_by(menu.rect_in_window_menubar().width(), 0);
             return IterationDecision::Continue;
         });
     }

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -301,7 +301,7 @@ void WindowFrame::paint_menubar(Gfx::Painter& painter)
         auto text_rect = menu.rect_in_window_menubar();
         Color text_color = palette.window_text();
         if (MenuManager::the().is_open(menu))
-            text_rect.move_by(1, 1);
+            text_rect.translate_by(1, 1);
         bool paint_as_pressed = MenuManager::the().is_open(menu);
         bool paint_as_hovered = !paint_as_pressed && &menu == MenuManager::the().hovered_menu();
         if (paint_as_pressed || paint_as_hovered) {
@@ -546,7 +546,7 @@ void WindowFrame::invalidate(Gfx::IntRect relative_rect)
 {
     auto frame_rect = rect();
     auto window_rect = m_window.rect();
-    relative_rect.move_by(frame_rect.x() - window_rect.x(), frame_rect.y() - window_rect.y());
+    relative_rect.translate_by(frame_rect.x() - window_rect.x(), frame_rect.y() - window_rect.y());
     m_dirty = true;
     m_window.invalidate(relative_rect, true);
 }


### PR DESCRIPTION
As part of my ongoing SVG quest, this PR will allow me to implement support for the SVG viewBox, which is an extremely prevalent property on most SVGs. 

This PR makes a bunch of changes in support of the Painter's new `scale(float, float)` method, which allows arbitrary scaling (both up and down) in both directions separately. Unfortunately, I'm not quite sure how to handle Bitmaps. I did add a similar scale method to `Gfx::Bitmap` (which uses bi-linear interpolation), however it is unused at the moment. 

The main issue is that if you pass in a normal bitmap to the painter every frame, and the painter has scaling, the bitmap can't be scaled every frame as it is an expensive operation (especially if the scaling in non-integer). My idea was to have a cache of (bitmap & scale) -> (scaled bitmap), but I'd like to hear some more opinions.

Also, the [HighDPI](https://github.com/mattco98/serenity/blob/painter-scale/Documentation/HighDPI.md) design document mentions possibly introducing a container class for Bitmap which would store multiple lazily-initialized bitmaps at different scales. It is only concerned with integer scaling, but such a container could be used for floating point scaling as well. 

~TODO:~
- [ ] ~Handle scaling everywhere (pretty much just where bitmaps are handled)~
- [ ] ~Remove useless methods (like making `scale()` do what `float_scale()` does, remove `has_integer_scaling()`, etc)~