### PR TITLE
LibC + LibPthread: Add pthread_attr_[set|get]scope, pwrite(..) and LOG_NOWAIT implementations. 

### DIFF
--- a/Userland/Libraries/LibC/syslog.h
+++ b/Userland/Libraries/LibC/syslog.h
@@ -101,6 +101,8 @@ struct syslog_data {
 #define LOG_NDELAY (1 << 3)
 /* Log to stderr as well. */
 #define LOG_PERROR (1 << 4)
+/* Don't wait for child processes created while logging the message. */
+#define LOG_NOWAIT (1 << 5)
 
 /* This is useful to have, but has to be stored weirdly for compatibility. */
 #ifdef SYSLOG_NAMES

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -289,10 +289,30 @@ ssize_t read(int fd, void* buf, size_t count)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+ssize_t pread(int fd, void* buf, size_t count, off_t offset)
+{
+    // FIXME: This is not thread safe and should be implemented in the kernel instead.
+    off_t old_offset = lseek(fd, 0, SEEK_CUR);
+    lseek(fd, offset, SEEK_SET);
+    ssize_t nread = read(fd, buf, count);
+    lseek(fd, old_offset, SEEK_SET);
+    return nread;
+}
+
 ssize_t write(int fd, const void* buf, size_t count)
 {
     int rc = syscall(SC_write, fd, buf, count);
     __RETURN_WITH_ERRNO(rc, rc, -1);
+}
+
+ssize_t pwrite(int fd, const void* buf, size_t count, off_t offset)
+{
+    // FIXME: This is not thread safe and should be implemented in the kernel instead.
+    off_t old_offset = lseek(fd, 0, SEEK_CUR);
+    lseek(fd, offset, SEEK_SET);
+    ssize_t nwritten = write(fd, buf, count);
+    lseek(fd, old_offset, SEEK_SET);
+    return nwritten;
 }
 
 int ttyname_r(int fd, char* buffer, size_t size)
@@ -767,16 +787,6 @@ int unveil(const char* path, const char* permissions)
     };
     int rc = syscall(SC_unveil, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);
-}
-
-ssize_t pread(int fd, void* buf, size_t count, off_t offset)
-{
-    // FIXME: This is not thread safe and should be implemented in the kernel instead.
-    off_t old_offset = lseek(fd, 0, SEEK_CUR);
-    lseek(fd, offset, SEEK_SET);
-    ssize_t nread = read(fd, buf, count);
-    lseek(fd, old_offset, SEEK_SET);
-    return nread;
 }
 
 char* getpass(const char* prompt)

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -101,6 +101,7 @@ int tcsetpgrp(int fd, pid_t pgid);
 ssize_t read(int fd, void* buf, size_t count);
 ssize_t pread(int fd, void* buf, size_t count, off_t);
 ssize_t write(int fd, const void* buf, size_t count);
+ssize_t pwrite(int fd, const void* buf, size_t count, off_t);
 int close(int fd);
 int chdir(const char* path);
 int fchdir(int fd);

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -436,6 +436,16 @@ int pthread_attr_setstacksize(pthread_attr_t* attributes, size_t stack_size)
     return 0;
 }
 
+int pthread_attr_getscope([[maybe_unused]] const pthread_attr_t* attributes, [[maybe_unused]] int* contention_scope)
+{
+    return 0;
+}
+
+int pthread_attr_setscope([[maybe_unused]] pthread_attr_t* attributes, [[maybe_unused]] int contention_scope)
+{
+    return 0;
+}
+
 int pthread_getschedparam([[maybe_unused]] pthread_t thread, [[maybe_unused]] int* policy, [[maybe_unused]] struct sched_param* param)
 {
     return 0;

--- a/Userland/Libraries/LibPthread/pthread.h
+++ b/Userland/Libraries/LibPthread/pthread.h
@@ -68,6 +68,12 @@ int pthread_attr_setstack(pthread_attr_t* attr, void*, size_t);
 int pthread_attr_getstacksize(const pthread_attr_t*, size_t*);
 int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 
+#define PTHREAD_SCOPE_SYSTEM 0
+#define PTHREAD_SCOPE_PROCESS 1
+
+int pthread_attr_getscope(const pthread_attr_t*, int*);
+int pthread_attr_setscope(pthread_attr_t*, int);
+
 int pthread_once(pthread_once_t*, void (*)(void));
 #define PTHREAD_ONCE_INIT 0
 void* pthread_getspecific(pthread_key_t key);


### PR DESCRIPTION
More changes needed for porting: https://fio.readthedocs.io

-  LibPthread: Add non functional pthread_attr_[set|get]scope stubs

    Standard: https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_getscope.html

-  LibC: Add pwrite(..) implementation to match the existing pread(..)

    Add a basic non-thread safe implementation of pwrite, following the
    existing pread(..) design.

-  LibC: Add LOG_NOWAIT stub to syslog.h