### PR TITLE
Meta: Precompile some very common headers 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(ENABLE_ALL_THE_DEBUG_MACROS "Enable all debug macros to validate they sti
 option(ENABLE_COMPILETIME_FORMAT_CHECK "Enable compiletime format string checks" ON)
 option(ENABLE_PCI_IDS_DOWNLOAD "Enable download of the pci.ids database at build time" ON)
 option(BUILD_LAGOM "Build parts of the system targeting the host OS for fuzzing/testing" OFF)
+option(PRECOMPILE_COMMON_HEADERS "Precompile some common headers to speedup compilation" ON)
 
 add_custom_target(run
     COMMAND ${CMAKE_SOURCE_DIR}/Meta/run.sh

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -361,6 +361,7 @@ add_executable(Kernel ${SOURCES})
 target_link_libraries(Kernel kernel_heap gcc stdc++)
 add_dependencies(Kernel boot kernel_heap)
 install(TARGETS Kernel RUNTIME DESTINATION boot)
+serenity_add_ak_precompiled_headers_to_target(Kernel)
 
 add_custom_command(
     TARGET Kernel

--- a/Meta/CMake/precompile-headers.cmake
+++ b/Meta/CMake/precompile-headers.cmake
@@ -1,0 +1,9 @@
+function(serenity_add_precompiled_header_to_target target header)
+    if (PRECOMPILE_COMMON_HEADERS AND COMMAND target_precompile_headers)
+        target_precompile_headers(${target} PRIVATE ${header})
+    endif ()
+endfunction()
+
+function(serenity_add_ak_precompiled_headers_to_target target)
+    serenity_add_precompiled_header_to_target(${target} ${CMAKE_SOURCE_DIR}/Meta/Precompile/AK.h)
+endfunction()

--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -1,3 +1,5 @@
+include(${CMAKE_SOURCE_DIR}/Meta/CMake/precompile-headers.cmake)
+
 function(serenity_install_headers target_name)
     file(GLOB_RECURSE headers RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h")
     foreach(header ${headers})
@@ -31,6 +33,7 @@ function(serenity_lib target_name fs_name)
     add_library(${target_name} SHARED ${SOURCES} ${GENERATED_SOURCES})
     install(TARGETS ${target_name} DESTINATION usr/lib)
     set_target_properties(${target_name} PROPERTIES OUTPUT_NAME ${fs_name})
+    serenity_add_ak_precompiled_headers_to_target(${target_name})
     serenity_generated_sources(${target_name})
 endfunction()
 
@@ -67,6 +70,7 @@ endfunction()
 function(serenity_bin target_name)
     add_executable(${target_name} ${SOURCES})
     install(TARGETS ${target_name} RUNTIME DESTINATION bin)
+    serenity_add_ak_precompiled_headers_to_target(${target_name})
     serenity_generated_sources(${target_name})
 endfunction()
 

--- a/Meta/Precompile/AK.h
+++ b/Meta/Precompile/AK.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <ali.mpfard@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/Badge.h>
+#include <AK/ByteBuffer.h>
+#include <AK/Format.h>
+#include <AK/Forward.h>
+#include <AK/Function.h>
+#include <AK/HashMap.h>
+#include <AK/JsonObject.h>
+#include <AK/LexicalPath.h>
+#include <AK/Optional.h>
+#include <AK/OwnPtr.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <AK/StdLibExtras.h>
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
+#include <AK/StringView.h>
+#include <AK/Types.h>
+#include <AK/URL.h>
+#include <AK/Vector.h>

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -93,3 +93,6 @@ set(SOURCES
 
 serenity_lib(LibJS js)
 target_link_libraries(LibJS LibM LibCore LibCrypto LibRegex LibSyntax)
+
+serenity_add_precompiled_header_to_target(LibJS ${CMAKE_CURRENT_SOURCE_DIR}/Heap/Heap.h)
+serenity_add_precompiled_header_to_target(LibJS ${CMAKE_CURRENT_SOURCE_DIR}/Runtime/GlobalObject.h)

--- a/Userland/Services/LookupServer/DNSName.h
+++ b/Userland/Services/LookupServer/DNSName.h
@@ -56,3 +56,11 @@ private:
 OutputStream& operator<<(OutputStream& stream, const DNSName&);
 
 }
+
+template<>
+struct AK::Formatter<LookupServer::DNSName> : Formatter<StringView> {
+    void format(FormatBuilder& builder, const LookupServer::DNSName& value)
+    {
+        return Formatter<StringView>::format(builder, value.as_string());
+    }
+};


### PR DESCRIPTION
You guys just had to go and make the build times slower (it has regressed by about 30 seconds since I last measured it in the compiletime format string check PR).

Times measured from cold ccache, fresh rebuild from idle (same as last time)
|                                           | Time | Difference from baseline |
| :---                                     | :---:   | :---: |
| Baseline (https://github.com/SerenityOS/serenity/pull/5468#issuecomment-783982451) | 452s | 0s |
| Current master (2ebb3f3) | 483s | +31s |
| This PR                            | 441s | -11s |

Is this a substantial amount? Not really.
Downsides:
- if the guess as to what header is "common" enough is wrong, a change in said header will force (basically) the entire codebase to be rebuilt.
    To avoid this, really be careful with including things in `Precompile/AK.h`!
- Nothing else, it's basically free time savings

---

Note that the "common" headers are just found through a simple `for file in $(find Kernel/ AK/ Userland/ -name '*.h' -o -name '*.cpp') { grep '^#include <AK' $file >> all-includes }`.
I picked the most common files that made sense to precompile (e.g. no TestSuite.h and no Debug.h)

---

Until we get the goodness that C++ modules are supposed to be, let's try to shave off some parse time using precompiled headers.
This commit only adds some very common AK headers, only to binaries, libraries and the kernel (tests are not covered due to incompatibility with AK/TestSuite.h).
This option is on by default, but can be disabled by passing `-DPRECOMPILE_COMMON_HEADERS=OFF` to cmake, which will disable all header precompilations.
This makes the build about 40 seconds faster on my machine (about 9%)