### PR TITLE
LibGUI: Remove premature return in Window::handle_key_event

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -446,7 +446,6 @@ void Window::handle_key_event(KeyEvent& event)
 {
     if (!m_focused_widget && event.type() == Event::KeyDown && event.key() == Key_Tab && !event.ctrl() && !event.alt() && !event.super()) {
         focus_a_widget_if_possible(FocusSource::Keyboard);
-        return;
     }
 
     if (m_focused_widget)


### PR DESCRIPTION
I've removed the return from Window::handle_key_event  and ran some tests - this has fixed the issue with Tab KeyDown events not propagating, and doesn't seem to have affected keyboard navigation in GUI applications.

Fixes #6532.