### PR TITLE
Everywhere: Remove redundant inline keyword with constexpr

### DIFF
--- a/AK/EnumBits.h
+++ b/AK/EnumBits.h
@@ -40,62 +40,62 @@
 #define AK_ENUM_BITWISE_FRIEND_OPERATORS(Enum) \
     _AK_ENUM_BITWISE_OPERATORS_INTERNAL(Enum, friend)
 
-#define _AK_ENUM_BITWISE_OPERATORS_INTERNAL(Enum, Prefix)                    \
-                                                                             \
-    [[nodiscard]] Prefix constexpr inline Enum operator|(Enum lhs, Enum rhs) \
-    {                                                                        \
-        using Type = UnderlyingType<Enum>;                                   \
-        return static_cast<Enum>(                                            \
-            static_cast<Type>(lhs) | static_cast<Type>(rhs));                \
-    }                                                                        \
-                                                                             \
-    [[nodiscard]] Prefix constexpr inline Enum operator&(Enum lhs, Enum rhs) \
-    {                                                                        \
-        using Type = UnderlyingType<Enum>;                                   \
-        return static_cast<Enum>(                                            \
-            static_cast<Type>(lhs) & static_cast<Type>(rhs));                \
-    }                                                                        \
-                                                                             \
-    [[nodiscard]] Prefix constexpr inline Enum operator^(Enum lhs, Enum rhs) \
-    {                                                                        \
-        using Type = UnderlyingType<Enum>;                                   \
-        return static_cast<Enum>(                                            \
-            static_cast<Type>(lhs) ^ static_cast<Type>(rhs));                \
-    }                                                                        \
-                                                                             \
-    [[nodiscard]] Prefix constexpr inline Enum operator~(Enum rhs)           \
-    {                                                                        \
-        using Type = UnderlyingType<Enum>;                                   \
-        return static_cast<Enum>(                                            \
-            ~static_cast<Type>(rhs));                                        \
-    }                                                                        \
-                                                                             \
-    Prefix constexpr inline Enum& operator|=(Enum& lhs, Enum rhs)            \
-    {                                                                        \
-        using Type = UnderlyingType<Enum>;                                   \
-        lhs = static_cast<Enum>(                                             \
-            static_cast<Type>(lhs) | static_cast<Type>(rhs));                \
-        return lhs;                                                          \
-    }                                                                        \
-                                                                             \
-    Prefix constexpr inline Enum& operator&=(Enum& lhs, Enum rhs)            \
-    {                                                                        \
-        using Type = UnderlyingType<Enum>;                                   \
-        lhs = static_cast<Enum>(                                             \
-            static_cast<Type>(lhs) & static_cast<Type>(rhs));                \
-        return lhs;                                                          \
-    }                                                                        \
-                                                                             \
-    Prefix constexpr inline Enum& operator^=(Enum& lhs, Enum rhs)            \
-    {                                                                        \
-        using Type = UnderlyingType<Enum>;                                   \
-        lhs = static_cast<Enum>(                                             \
-            static_cast<Type>(lhs) ^ static_cast<Type>(rhs));                \
-        return lhs;                                                          \
-    }                                                                        \
-                                                                             \
-    Prefix constexpr inline bool has_flag(Enum value, Enum mask)             \
-    {                                                                        \
-        using Type = UnderlyingType<Enum>;                                   \
-        return static_cast<Type>(value & mask) != 0;                         \
+#define _AK_ENUM_BITWISE_OPERATORS_INTERNAL(Enum, Prefix)             \
+                                                                      \
+    [[nodiscard]] Prefix constexpr Enum operator|(Enum lhs, Enum rhs) \
+    {                                                                 \
+        using Type = UnderlyingType<Enum>;                            \
+        return static_cast<Enum>(                                     \
+            static_cast<Type>(lhs) | static_cast<Type>(rhs));         \
+    }                                                                 \
+                                                                      \
+    [[nodiscard]] Prefix constexpr Enum operator&(Enum lhs, Enum rhs) \
+    {                                                                 \
+        using Type = UnderlyingType<Enum>;                            \
+        return static_cast<Enum>(                                     \
+            static_cast<Type>(lhs) & static_cast<Type>(rhs));         \
+    }                                                                 \
+                                                                      \
+    [[nodiscard]] Prefix constexpr Enum operator^(Enum lhs, Enum rhs) \
+    {                                                                 \
+        using Type = UnderlyingType<Enum>;                            \
+        return static_cast<Enum>(                                     \
+            static_cast<Type>(lhs) ^ static_cast<Type>(rhs));         \
+    }                                                                 \
+                                                                      \
+    [[nodiscard]] Prefix constexpr Enum operator~(Enum rhs)           \
+    {                                                                 \
+        using Type = UnderlyingType<Enum>;                            \
+        return static_cast<Enum>(                                     \
+            ~static_cast<Type>(rhs));                                 \
+    }                                                                 \
+                                                                      \
+    Prefix constexpr Enum& operator|=(Enum& lhs, Enum rhs)            \
+    {                                                                 \
+        using Type = UnderlyingType<Enum>;                            \
+        lhs = static_cast<Enum>(                                      \
+            static_cast<Type>(lhs) | static_cast<Type>(rhs));         \
+        return lhs;                                                   \
+    }                                                                 \
+                                                                      \
+    Prefix constexpr Enum& operator&=(Enum& lhs, Enum rhs)            \
+    {                                                                 \
+        using Type = UnderlyingType<Enum>;                            \
+        lhs = static_cast<Enum>(                                      \
+            static_cast<Type>(lhs) & static_cast<Type>(rhs));         \
+        return lhs;                                                   \
+    }                                                                 \
+                                                                      \
+    Prefix constexpr Enum& operator^=(Enum& lhs, Enum rhs)            \
+    {                                                                 \
+        using Type = UnderlyingType<Enum>;                            \
+        lhs = static_cast<Enum>(                                      \
+            static_cast<Type>(lhs) ^ static_cast<Type>(rhs));         \
+        return lhs;                                                   \
+    }                                                                 \
+                                                                      \
+    Prefix constexpr bool has_flag(Enum value, Enum mask)             \
+    {                                                                 \
+        using Type = UnderlyingType<Enum>;                            \
+        return static_cast<Type>(value & mask) != 0;                  \
     }

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -432,10 +432,10 @@ void dmesgln(CheckedFormatString<Parameters...>&& fmt, const Parameters&... para
 #endif
 
 template<typename T, typename = void>
-inline constexpr bool HasFormatter = true;
+constexpr bool HasFormatter = true;
 
 template<typename T>
-inline constexpr bool HasFormatter<T, typename Formatter<T>::__no_formatter_defined> = false;
+constexpr bool HasFormatter<T, typename Formatter<T>::__no_formatter_defined> = false;
 
 template<typename T>
 class FormatIfSupported {

--- a/Userland/Applications/Spreadsheet/Readers/XSV.h
+++ b/Userland/Applications/Spreadsheet/Readers/XSV.h
@@ -72,7 +72,7 @@ enum class ReadError {
 #undef E
 };
 
-inline constexpr ParserBehaviour default_behaviours()
+constexpr ParserBehaviour default_behaviours()
 {
     return ParserBehaviour::QuoteOnlyInFieldStart;
 }

--- a/Userland/Applications/Spreadsheet/Writers/XSV.h
+++ b/Userland/Applications/Spreadsheet/Writers/XSV.h
@@ -74,7 +74,7 @@ enum class WriteError {
 #undef E
 };
 
-inline constexpr WriterBehaviour default_behaviours()
+constexpr WriterBehaviour default_behaviours()
 {
     return WriterBehaviour::None;
 }

--- a/Userland/Libraries/LibCrypto/Hash/SHA1.cpp
+++ b/Userland/Libraries/LibCrypto/Hash/SHA1.cpp
@@ -31,7 +31,7 @@
 namespace Crypto {
 namespace Hash {
 
-inline static constexpr auto ROTATE_LEFT(u32 value, size_t bits)
+static constexpr auto ROTATE_LEFT(u32 value, size_t bits)
 {
     return (value << bits) | (value >> (32 - bits));
 }

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -319,7 +319,7 @@ private:
     RGBA32 m_value { 0 };
 };
 
-inline constexpr Color::Color(NamedColor named)
+constexpr Color::Color(NamedColor named)
 {
     if (named == Transparent) {
         m_value = 0;

--- a/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
@@ -33,7 +33,7 @@
 namespace Gfx {
 
 template<size_t N, typename T>
-inline static constexpr void normalize(Matrix<N, T>& matrix)
+static constexpr void normalize(Matrix<N, T>& matrix)
 {
     auto sum = 0.0f;
     for (size_t i = 0; i < matrix.Size; ++i) {


### PR DESCRIPTION
Problem:
- `constexpr` functions are additionally decorated with `inline`
  keyword. This is redundant since `constexpr` implies `inline`.

Solution:
- Remove redundancies.