### PR TITLE
AK/Format: Fix incorrectly non-inlined variable templates

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -432,10 +432,10 @@ void dmesgln(CheckedFormatString<Parameters...>&& fmt, const Parameters&... para
 #endif
 
 template<typename T, typename = void>
-constexpr bool HasFormatter = true;
+inline constexpr bool HasFormatter = true;
 
 template<typename T>
-constexpr bool HasFormatter<T, typename Formatter<T>::__no_formatter_defined> = false;
+inline constexpr bool HasFormatter<T, typename Formatter<T>::__no_formatter_defined> = false;
 
 template<typename T>
 class FormatIfSupported {


### PR DESCRIPTION
Problem:
- Global variables (and variable templates) defined in header files
  need to be decorated `inline` to avoid multiple definition issues.

Solution:
- Put back the `inline` keyword which was erroneously removed.