### PR TITLE
LibC: Add additional data types

### DIFF
--- a/Userland/Libraries/LibC/sys/types.h
+++ b/Userland/Libraries/LibC/sys/types.h
@@ -57,15 +57,19 @@ typedef __WINT_TYPE__ wint_t;
 typedef uint32_t ino_t;
 typedef int64_t off_t;
 
+typedef uint32_t blkcnt_t;
+typedef uint32_t blksize_t;
 typedef uint32_t dev_t;
 typedef uint16_t mode_t;
 typedef uint32_t nlink_t;
-typedef uint32_t blksize_t;
-typedef uint32_t blkcnt_t;
+
 typedef int64_t time_t;
 typedef uint32_t useconds_t;
 typedef int32_t suseconds_t;
 typedef uint32_t clock_t;
+
+typedef uint64_t fsblkcnt_t;
+typedef uint64_t fsfilcnt_t;
 
 #define __socklen_t_defined
 #define __socklen_t uint32_t


### PR DESCRIPTION
- Reorganized some variables (alphabetically and based on their function) so that the new ones don't stick out.
- See: https://github.com/SerenityOS/serenity/issues/6068

Small, hesitant steps!

## Additional notes

- The following variables are important for many programs that calculate the available space on the disk. They still need to be implemented properly.

```cpp
typedef int64_t fsblkcnt_t;
typedef int64_t fsfilcnt_t;
```

- I added `typedef uint16_t u_mode_t;` while I was at it because I was familiar with the variable being used with umasks, not 100% sure if I should keep it or not.