### PR TITLE
 Ports: Build ports only once when running build_all.sh

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -346,6 +346,9 @@ do_uninstall() {
     echo "Uninstalling $port!"
     uninstall
 }
+do_showdepends() {
+    echo -n $depends
+}
 do_all() {
     do_installdepends
     do_fetch
@@ -361,7 +364,7 @@ parse_arguments() {
         do_all
     else
         case "$1" in
-            fetch|patch|configure|build|install|installdepends|clean|clean_dist|clean_all|uninstall)
+            fetch|patch|configure|build|install|installdepends|clean|clean_dist|clean_all|uninstall|showdepends)
                 do_$1
                 ;;
             --auto)
@@ -373,7 +376,7 @@ parse_arguments() {
                 parse_arguments $@
                 ;;
             *)
-                >&2 echo "I don't understand $1! Supported arguments: fetch, patch, configure, build, install, installdepends, clean, clean_dist, clean_all, uninstall."
+                >&2 echo "I don't understand $1! Supported arguments: fetch, patch, configure, build, install, installdepends, clean, clean_dist, clean_all, uninstall, showdepends."
                 exit 1
                 ;;
         esac

--- a/Ports/build_all.sh
+++ b/Ports/build_all.sh
@@ -30,7 +30,7 @@ some_failed=false
 for file in *; do
     if [ -d $file ]; then
         pushd $file > /dev/null
-            dirname=$(basename $file)
+            port=$(basename $file)
             if [ "$clean" == true ]; then
                 if [ "$verbose" == true ]; then
                     ./package.sh clean_all
@@ -40,16 +40,16 @@ for file in *; do
             fi
             if [ "$verbose" == true ]; then
                 if ./package.sh; then
-                    echo "Built ${dirname}."
+                    echo "Built ${port}."
                 else
-                    echo "ERROR: Build of ${dirname} was not successful!"
+                    echo "ERROR: Build of ${port} was not successful!"
                     some_failed=true
                 fi
             else
                 if ./package.sh > /dev/null 2>&1; then
-                    echo "Built ${dirname}."
+                    echo "Built ${port}."
                 else
-                    echo "ERROR: Build of ${dirname} was not successful!"
+                    echo "ERROR: Build of ${port} was not successful!"
                     some_failed=true
                 fi
             fi

--- a/Ports/build_all.sh
+++ b/Ports/build_all.sh
@@ -26,11 +26,31 @@ case "$2" in
 esac
 
 some_failed=false
+built_ports=""
 
 for file in *; do
     if [ -d $file ]; then
         pushd $file > /dev/null
             port=$(basename $file)
+            port_built=0
+            for built_port in $built_ports; do
+                if [ "$built_port" = "$port" ]; then
+                    port_built=1
+                    break
+                fi
+            done
+            if [ $port_built -eq 1 ]; then
+                echo "Already built $port as a dependency."
+                popd > /dev/null
+                continue
+            fi
+            if ! [ -f package.sh ]; then
+                echo "ERROR: Skipping $port because its package.sh script is missing."
+                popd > /dev/null
+                continue
+            fi
+            built_ports="$built_ports $port $(./package.sh showdepends) "
+
             if [ "$clean" == true ]; then
                 if [ "$verbose" == true ]; then
                     ./package.sh clean_all

--- a/Ports/libgcrypt/package.sh
+++ b/Ports/libgcrypt/package.sh
@@ -3,6 +3,7 @@ port=libgcrypt
 version=1.9.2
 useconfigure=true
 configopts="--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
+depends=libgpg-error
 files="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${version}.tar.bz2 libgcrypt-${version}.tar.bz2 00121b05e1ff4cc85a4a6503e0a7d9fb"
 auth_type=md5
 


### PR DESCRIPTION
Previously we'd end up building some ports (e.g. `gcc`) multiple times, e.g. as a dependency for another port. This changes the `build_all.sh` script so that it builds ports only once.