### PR TITLE
Ports: Add launchers for some of the ports

### DIFF
--- a/Ports/SDLPoP/package.sh
+++ b/Ports/SDLPoP/package.sh
@@ -7,6 +7,9 @@ workdir=SDLPoP-86988c668eeaa10f218e1d4938fc5b4e42314d68
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
 files="https://github.com/NagyD/SDLPoP/archive/86988c668eeaa10f218e1d4938fc5b4e42314d68.zip PoP.zip d18cae8541fb8cbcc374fd998316993d561429a83f92061bc0754337ada774c5"
 auth_type=sha256
+launcher_name="Prince of Persia"
+launcher_category=Games
+launcher_command=/opt/PrinceOfPersia/prince
 
 configure() {
     run cmake $configopts ./src
@@ -15,4 +18,5 @@ configure() {
 install() {
     mkdir -p "${SERENITY_INSTALL_ROOT}/opt/PrinceOfPersia"
     run cp -r prince data SDLPoP.ini "${SERENITY_INSTALL_ROOT}/opt/PrinceOfPersia" 
+    install_launcher
 }

--- a/Ports/Super-Mario/package.sh
+++ b/Ports/Super-Mario/package.sh
@@ -7,6 +7,9 @@ workdir=Super-Mario-Clone-Cpp-master
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
 files="https://github.com/Bennyhwanggggg/Super-Mario-Clone-Cpp/archive/refs/heads/master.zip master.zip 11f622721d1ba504acf75c024aa0dbe3"
 auth_type=md5
+launcher_name="Super Mario"
+launcher_category=Games
+launcher_command=/opt/Super_Mario/uMario
 
 configure() {
     run cmake $configopts
@@ -15,4 +18,5 @@ configure() {
 install() {
     run mkdir -p "${SERENITY_INSTALL_ROOT}/opt/Super_Mario"
     run cp -r uMario app.ico icon2.ico files "${SERENITY_INSTALL_ROOT}/opt/Super_Mario" 
+    install_launcher
 }

--- a/Ports/cmatrix/package.sh
+++ b/Ports/cmatrix/package.sh
@@ -7,6 +7,9 @@ workdir=cmatrix-master
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
 files="https://github.com/abishekvashok/cmatrix/archive/refs/heads/master.zip cmatrix.zip 2541321b89149b375d5732402e52d654"
 auth_type=md5
+launcher_name=cmatrix
+launcher_category=Games
+launcher_command="Terminal -e cmatrix"
 
 configure() {
     run cmake $configopts
@@ -14,4 +17,5 @@ configure() {
 
 install() {
     run cp cmatrix "${SERENITY_INSTALL_ROOT}/bin"
+    install_launcher
 }

--- a/Ports/doom/package.sh
+++ b/Ports/doom/package.sh
@@ -6,3 +6,6 @@ files="https://github.com/SerenityOS/SerenityDOOM/archive/master.tar.gz doom-git
 auth_type=md5
 makeopts="-C doomgeneric/"
 installopts="-C doomgeneric/"
+launcher_name=Doom
+launcher_category=Games
+launcher_command=doom

--- a/Ports/hatari/package.sh
+++ b/Ports/hatari/package.sh
@@ -8,11 +8,10 @@ workdir="${port}-${commit}"
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
 files="https://github.com/hatari/hatari/archive/${commit}.tar.gz ${commit}.tar.gz 614d8c20a06deea6df464a5de32cc795"
 auth_type=md5
+launcher_name=Hatari
+launcher_category=Games
+launcher_command=hatari
 
 configure() {
     run cmake $configopts
-}
-
-install() {
-    run make install
 }

--- a/Ports/nyancat/package.sh
+++ b/Ports/nyancat/package.sh
@@ -4,3 +4,6 @@ version=git
 workdir=nyancat-master
 files="https://github.com/klange/nyancat/archive/master.tar.gz nyancat-git.tar.gz dcb9dc135f87a4e5e0e6e72e6c3b2430"
 auth_type=md5
+launcher_name=Nyancat
+launcher_category=Games
+launcher_command="Terminal -e nyancat"

--- a/Ports/quake/package.sh
+++ b/Ports/quake/package.sh
@@ -6,6 +6,9 @@ useconfigure=false
 files="https://github.com/SerenityOS/SerenityQuake/archive/master.tar.gz quake.tar.gz"
 makeopts="V=1 SYMBOLS_ON=Y "
 depends=SDL2
+launcher_name=Quake
+launcher_category=Games
+launcher_command=quake
 
 # FIXME: Uhh, the things in this directory are not supposed to run on the host, why add this to $PATH?!
 export PATH="${SERENITY_INSTALL_ROOT}/usr/bin:${PATH}"

--- a/Ports/vitetris/package.sh
+++ b/Ports/vitetris/package.sh
@@ -5,6 +5,9 @@ version="0.59.1"
 files="https://github.com/vicgeralds/vitetris/archive/refs/tags/v${version}.tar.gz vitetris.tar.gz 699443df03c8d4bf2051838c1015da72039bbbdd0ab0eede891c59c840bdf58d"
 configopts="--without-xlib --without-joystick --without-network"
 auth_type=sha256
+launcher_name=vitetris
+launcher_category=Games
+launcher_command="Terminal -e tetris"
 
 configure() {
     run chmod +x "$configscript"

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -198,14 +198,8 @@ int Shell::builtin_cd(int argc, const char** argv)
             if (oldpwd == nullptr)
                 return 1;
             new_path = oldpwd;
-        } else if (arg_path[0] == '/') {
-            new_path = argv[1];
         } else {
-            StringBuilder builder;
-            builder.append(cwd);
-            builder.append('/');
-            builder.append(arg_path);
-            new_path = builder.to_string();
+            new_path = arg_path;
         }
     }
 


### PR DESCRIPTION
There's still one thing I'm not quite happy yet: The wrapper scripts are kinda ugly.

My other idea was to change the launcher by adding two new attributes for app files: `arguments` (and _maybe_ `workdir` - though that's really a problem that's quite specific to the Super Mario port - it crashes without the right working directory and could probably be patched in the port instead).

Or maybe have the launcher detect whether an app is a GUI application (i.e., whether it links against `LibGUI`) maybe? Windows has this thing where it does an implicit `AllocConsole` for console applications. This could also be useful so you can launch console apps from the file manager. Ideas welcome.

However, that's probably a somewhat larger change for another PR.