### PR TITLE
Meta: Add basic Zsh completions for serenity.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !Makefile
 !LICENSE
 !Base/**
+!Meta/ShellCompletions/**
 
 *.o
 *.ao

--- a/Meta/ShellCompletions/zsh/_serenity
+++ b/Meta/ShellCompletions/zsh/_serenity
@@ -1,0 +1,63 @@
+#compdef serenity serenity.sh
+
+_serenity() {
+    local args
+    args=(
+        '1:command:->commands'
+        '2:target:->targets'
+        '*:: :->args'
+    )
+
+    local commands
+    commands=(
+        'build'
+        'install'
+        'image'
+        'run'
+        'gdb'
+        'test'
+        'delete'
+        'recreate'
+        'rebuild'
+        'kaddr2line'
+        'addr2line'
+        'rebuild-toolchain'
+        'rebuild-world'
+    )
+
+    local targets
+    targets=(
+        'i686:Target i686 (default)'
+        'x86_64:Target x86_64'
+        'lagom:Target host machine'
+    )
+
+    _arguments -C -S "$args[@]"
+
+    local command
+    command="$line[1]"
+
+    local target
+    target="$line[2]"
+
+    case "$state" in
+        commands)
+            _describe 'command' commands
+            ;;
+        targets)
+            case "$command" in
+                install|image|kaddr2line|rebuild-toolchain|rebuild-world)
+                    # lagom target is not supported for these, remove from targets
+                    targets[$targets[(i)lagom]]=()
+                    ;;
+            esac
+            _describe 'target' targets
+            ;;
+        args)
+            ;;
+    esac
+
+    return 0
+}
+
+_serenity


### PR DESCRIPTION
This patch adds a basic Zsh completion script for the commands and targets provided by `Meta/serenity.sh`. There's some room for improvement here, e.g. we could provide completion for available CMake targets - currently completion stops after `serenity.sh <command> <target>`.

You can enable it by adding this to your `.zshrc` before completions are loaded:

```sh
fpath=($SERENITY_SOURCE_DIR/Meta/ShellCompletions/zsh $fpath)
```