### PR TITLE
Toolchain/Dockerfile: Update to Ubuntu 21.04, add git

### DIFF
--- a/Toolchain/Dockerfile
+++ b/Toolchain/Dockerfile
@@ -1,12 +1,24 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y && apt-get install -y tzdata
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get install -y build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs qemu-utils wget genext2fs sudo ninja-build
-
-RUN mkdir /serenity
+RUN apt-get update -y \
+    && apt-get install -y \
+        build-essential \
+        cmake \
+        curl \
+        genext2fs \
+        git \
+        libmpfr-dev \
+        libmpc-dev \
+        libgmp-dev \
+        e2fsprogs \
+        ninja-build \
+        qemu-utils \
+        sudo \
+        tzdata \
+        wget
 
 WORKDIR /serenity
 
 RUN /bin/bash
-


### PR DESCRIPTION
Also made it easier to manage the dependencies to install. Running `Meta/serenity.sh` was impossible with the resulting image since it requires `git`.