### PR TITLE
Ports/scummvm: Build with C++11 support

### DIFF
--- a/Ports/scummvm/package.sh
+++ b/Ports/scummvm/package.sh
@@ -5,11 +5,10 @@ version="2.2.0"
 files="https://downloads.scummvm.org/frs/scummvm/${version}/scummvm-${version}.tar.gz scummvm-${version}.tar.gz f48f07347e5ab0b3094a868367c0e1f2"
 auth_type=md5
 depends="SDL2"
-
-configure() {
-    export LIBS="-lgui -lgfx -lcore"
-    run ./configure \
-        --host="${SERENITY_ARCH}-pc-serenity" \
-        --opengl-mode=none                    \
-        --with-sdl-prefix="${SERENITY_BUILD_DIR}/Root/usr/local"
-}
+configopts="
+    --enable-c++11
+    --enable-release-mode
+    --enable-optimizations
+    --opengl-mode=none
+    --with-sdl-prefix=${SERENITY_BUILD_DIR}/Root/usr/local
+"


### PR DESCRIPTION
This unbreaks the ScummVM port build. Some `[[noreturn]]` keywords were added to `<assert.h>` recently and this required an additional flag to the ScummVM configure script to fix.

Also removed the now unnecessary `export LIBS` and enabled release mode.