### PR TITLE
LibWeb: Improve fallback font selection

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -76,6 +76,7 @@ private:
     Optional<CSS::Overflow> overflow(CSS::PropertyID) const;
 
     void load_font() const;
+    RefPtr<Gfx::Font> font_fallback(bool monospace, bool bold) const;
 
     mutable RefPtr<Gfx::Font> m_font;
 };


### PR DESCRIPTION
Try to find a font that has at least some of the requested properties.
This makes e.g. rfcs on tools.ietf.org easier to read since their
headers are now bold.