### PR TITLE
LibWeb: Load resources that have url containing spaces

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -156,7 +156,7 @@ void ResourceLoader::load(const LoadRequest& request, Function<void(ReadonlyByte
             headers.set(it.key, it.value);
         }
 
-        auto download = protocol_client().start_download(request.method(), url.to_string(), headers, request.body());
+        auto download = protocol_client().start_download(request.method(), url.to_string_encoded(), headers, request.body());
         if (!download) {
             if (error_callback)
                 error_callback("Failed to initiate load", {});


### PR DESCRIPTION
Encode urls before requesting them, fixes referencing e.g. images with spaces in their url.