### PR TITLE
LibGUI: Select last word when double clicking at the end of a line

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -628,7 +628,11 @@ TextPosition TextDocument::first_word_break_before(const TextPosition& position,
 
     auto target = position;
     auto line = this->line(target.line());
-    auto is_start_alphanumeric = isalnum(line.code_points()[target.column() - (start_at_column_before ? 1 : 0)]);
+    auto modifier = start_at_column_before ? 1 : 0;
+    if (target.column() == line.length())
+        modifier = 1;
+
+    auto is_start_alphanumeric = isalnum(line.code_points()[target.column() - modifier]);
 
     while (target.column() > 0) {
         auto prev_code_point = line.code_points()[target.column() - 1];


### PR DESCRIPTION
`first_word_break_before` method was accessing values outside of `code_points` array bounds when user double-clicked at end of the line.

Also fixes: https://github.com/SerenityOS/serenity/issues/6565