### PR TITLE
Support more <ol> list styles

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Identifiers.json
+++ b/Userland/Libraries/LibWeb/CSS/Identifiers.json
@@ -160,6 +160,8 @@
   "text",
   "underline",
   "uppercase",
+  "upper-alpha",
+  "upper-latin",
   "visible",
   "vertical-text",
   "wait",

--- a/Userland/Libraries/LibWeb/CSS/Identifiers.json
+++ b/Userland/Libraries/LibWeb/CSS/Identifiers.json
@@ -104,6 +104,8 @@
   "line-through",
   "list-item",
   "lowercase",
+  "lower-alpha",
+  "lower-latin",
   "medium",
   "move",
   "ne-resize",

--- a/Userland/Libraries/LibWeb/CSS/Identifiers.json
+++ b/Userland/Libraries/LibWeb/CSS/Identifiers.json
@@ -77,6 +77,7 @@
   "crosshair",
   "dashed",
   "decimal",
+  "decimal-leading-zero",
   "default",
   "disc",
   "dotted",

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -578,6 +578,10 @@ Optional<CSS::ListStyleType> StyleProperties::list_style_type() const
         return CSS::ListStyleType::Decimal;
     case CSS::ValueID::DecimalLeadingZero:
         return CSS::ListStyleType::DecimalLeadingZero;
+    case CSS::ValueID::LowerAlpha:
+        return CSS::ListStyleType::LowerAlpha;
+    case CSS::ValueID::LowerLatin:
+        return CSS::ListStyleType::LowerLatin;
     default:
         return {};
     }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -576,6 +576,8 @@ Optional<CSS::ListStyleType> StyleProperties::list_style_type() const
         return CSS::ListStyleType::Square;
     case CSS::ValueID::Decimal:
         return CSS::ListStyleType::Decimal;
+    case CSS::ValueID::DecimalLeadingZero:
+        return CSS::ListStyleType::DecimalLeadingZero;
     default:
         return {};
     }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -582,6 +582,10 @@ Optional<CSS::ListStyleType> StyleProperties::list_style_type() const
         return CSS::ListStyleType::LowerAlpha;
     case CSS::ValueID::LowerLatin:
         return CSS::ListStyleType::LowerLatin;
+    case CSS::ValueID::UpperAlpha:
+        return CSS::ListStyleType::UpperAlpha;
+    case CSS::ValueID::UpperLatin:
+        return CSS::ListStyleType::UpperLatin;
     default:
         return {};
     }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -162,6 +162,8 @@ enum class ListStyleType {
     DecimalLeadingZero,
     LowerAlpha,
     LowerLatin,
+    UpperAlpha,
+    UpperLatin,
 };
 
 enum class Overflow : u8 {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -160,6 +160,8 @@ enum class ListStyleType {
     Square,
     Decimal,
     DecimalLeadingZero,
+    LowerAlpha,
+    LowerLatin,
 };
 
 enum class Overflow : u8 {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -159,6 +159,7 @@ enum class ListStyleType {
     Circle,
     Square,
     Decimal,
+    DecimalLeadingZero,
 };
 
 enum class Overflow : u8 {

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -12,6 +12,7 @@
 namespace Web::Layout {
 
 constexpr auto lower_alpha = "abcdefghijklmnopqrstuvwxyz";
+constexpr auto upper_alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document, CSS::ListStyleType style_type, size_t index)
     : Box(document, nullptr, CSS::StyleProperties::create())
@@ -80,6 +81,10 @@ void ListItemMarkerBox::paint(PaintContext& context, PaintPhase phase)
     case CSS::ListStyleType::LowerAlpha:
     case CSS::ListStyleType::LowerLatin:
         context.painter().draw_text(enclosing, number_to_alphabet(m_index, lower_alpha), Gfx::TextAlignment::Center);
+        break;
+    case CSS::ListStyleType::UpperAlpha:
+    case CSS::ListStyleType::UpperLatin:
+        context.painter().draw_text(enclosing, number_to_alphabet(m_index, upper_alpha), Gfx::TextAlignment::Center);
         break;
     case CSS::ListStyleType::None:
         return;

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -52,6 +52,13 @@ void ListItemMarkerBox::paint(PaintContext& context, PaintPhase phase)
     case CSS::ListStyleType::Disc:
         context.painter().fill_ellipse(marker_rect, color);
         break;
+    case CSS::ListStyleType::DecimalLeadingZero:
+        // This is weird, but in accordance to spec.
+        context.painter().draw_text(
+            enclosing,
+            m_index < 10 ? String::formatted("0{}.", m_index) : String::formatted("{}.", m_index),
+            Gfx::TextAlignment::Center);
+        break;
     case CSS::ListStyleType::None:
         return;
 

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -21,6 +21,21 @@ ListItemMarkerBox::~ListItemMarkerBox()
 {
 }
 
+static const String number_to_alphabet(unsigned int number, const String alphabet)
+{
+    auto base = alphabet.length();
+    StringBuilder output_string;
+    while (number > base) {
+        number--;
+        auto remainder = number % base;
+        number -= remainder;
+        output_string.append(alphabet[remainder]);
+        number /= base;
+    };
+    output_string.append(alphabet[number - 1]);
+    return output_string.to_string().reverse();
+}
+
 void ListItemMarkerBox::paint(PaintContext& context, PaintPhase phase)
 {
     if (phase != PaintPhase::Foreground)

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -5,10 +5,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/StringBuilder.h>
 #include <LibGfx/Painter.h>
 #include <LibWeb/Layout/ListItemMarkerBox.h>
 
 namespace Web::Layout {
+
+constexpr auto lower_alpha = "abcdefghijklmnopqrstuvwxyz";
 
 ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document, CSS::ListStyleType style_type, size_t index)
     : Box(document, nullptr, CSS::StyleProperties::create())
@@ -73,6 +76,10 @@ void ListItemMarkerBox::paint(PaintContext& context, PaintPhase phase)
             enclosing,
             m_index < 10 ? String::formatted("0{}.", m_index) : String::formatted("{}.", m_index),
             Gfx::TextAlignment::Center);
+        break;
+    case CSS::ListStyleType::LowerAlpha:
+    case CSS::ListStyleType::LowerLatin:
+        context.painter().draw_text(enclosing, number_to_alphabet(m_index, lower_alpha), Gfx::TextAlignment::Center);
         break;
     case CSS::ListStyleType::None:
         return;


### PR DESCRIPTION
I had already done a few `list-style-type`s so I thought why not add a few more?
This adds support for  `list-style-type:` `upper-latin`, `upper-alpha`, `lower-latin`, `lower-alpha` and `decimal-leading-zero`.

The conversion number->alphabet is a bit tricky since the alphabet doesn't have a zero. In case anybody else finds this, the term you want to search for is "bijective numeration" and "bijective base".
Also I made it very alphabet-agnostic to support other easy counting-methods using different charsets. There are a lot out there.
 
I noticed that the markers can collide with the list item itself when they become wider. This needs to be tackled in another PR (issue: #6567) as it seems to not be that trivial.