### PR TITLE
AK: Remove virtual destructors from non-virtual classes

### DIFF
--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -17,7 +17,7 @@ template<Integral K, typename V, IntrusiveRedBlackTreeNode<K> V::*member>
 class IntrusiveRedBlackTree : public BaseRedBlackTree<K> {
 public:
     IntrusiveRedBlackTree() = default;
-    virtual ~IntrusiveRedBlackTree() override
+    ~IntrusiveRedBlackTree()
     {
         clear();
     }

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -33,12 +33,10 @@ public:
             : key(key)
         {
         }
-        virtual ~Node() {};
     };
 
 protected:
     BaseRedBlackTree() = default; // These are protected to ensure no one instantiates the leaky base red black tree directly
-    virtual ~BaseRedBlackTree() {};
 
     void rotate_left(Node* subtree_root)
     {
@@ -418,7 +416,7 @@ template<Integral K, typename V>
 class RedBlackTree : public BaseRedBlackTree<K> {
 public:
     RedBlackTree() = default;
-    virtual ~RedBlackTree() override
+    ~RedBlackTree()
     {
         clear();
     }


### PR DESCRIPTION
Problem:
- Some classes have `virtual` destructors despite not having any
  virtual functions. This causes the classes to have a v-table and
  perform extra jumps at destruction time when there is no need.

Solution:
- Remove `virtual` keyword from destructors where there are no other
  virtual functions.
- Remove the destructor completely when the default destructor can be
  used.