### PR TITLE
Revert "AK: Remove virtual destructors from non-virtual classes"

### DIFF
--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -17,7 +17,7 @@ template<Integral K, typename V, IntrusiveRedBlackTreeNode<K> V::*member>
 class IntrusiveRedBlackTree : public BaseRedBlackTree<K> {
 public:
     IntrusiveRedBlackTree() = default;
-    ~IntrusiveRedBlackTree()
+    virtual ~IntrusiveRedBlackTree() override
     {
         clear();
     }

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -33,10 +33,12 @@ public:
             : key(key)
         {
         }
+        virtual ~Node() {};
     };
 
 protected:
     BaseRedBlackTree() = default; // These are protected to ensure no one instantiates the leaky base red black tree directly
+    virtual ~BaseRedBlackTree() {};
 
     void rotate_left(Node* subtree_root)
     {
@@ -416,7 +418,7 @@ template<Integral K, typename V>
 class RedBlackTree : public BaseRedBlackTree<K> {
 public:
     RedBlackTree() = default;
-    ~RedBlackTree()
+    virtual ~RedBlackTree() override
     {
         clear();
     }


### PR DESCRIPTION
Reverts SerenityOS/serenity#6573, as it causes page faults in userland. (BaseRedBlackTree::Node is a virtual class, and as such its destructor should be virtual as well)