### PR TITLE
Browser: Add basic support for search engines

### DIFF
--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -100,6 +100,7 @@ private:
     URL m_image_context_menu_url;
 
     GUI::ActionGroup m_user_agent_spoof_actions;
+    GUI::ActionGroup m_search_engine_actions;
     RefPtr<GUI::Action> m_disable_user_agent_spoofing;
 
     RefPtr<GUI::Menu> m_tab_context_menu;


### PR DESCRIPTION
If you enter a likely invalid URL (URL with no dots or with spaces),
the browser will use user-selected search engine (none as default).
    
For now, there are several engines hardcoded and there is no support
for custom search engines.