### PR TITLE
Shell: jobspecs and builtin 'kill'

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1194,6 +1194,27 @@ String Shell::unescape_token(const String& token)
     return builder.build();
 }
 
+String Shell::find_in_path(const StringView& program_name)
+{
+    String path = getenv("PATH");
+    if (!path.is_empty()) {
+        auto directories = path.split(':');
+        for (const auto& directory : directories) {
+            Core::DirIterator programs(directory.characters(), Core::DirIterator::SkipDots);
+            while (programs.has_next()) {
+                auto program = programs.next_path();
+                auto program_path = String::formatted("{}/{}", directory, program);
+                if (access(program_path.characters(), X_OK) != 0)
+                    continue;
+                if (program == program_name)
+                    return program_path;
+            }
+        }
+    }
+
+    return {};
+}
+
 void Shell::cache_path()
 {
     if (!m_is_interactive)

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -175,7 +175,7 @@ public:
     void restore_ios();
 
     u64 find_last_job_id() const;
-    const Job* find_job(u64 id);
+    const Job* find_job(u64 id, bool is_pid = false);
     const Job* current_job() const { return m_current_job; }
     void kill_job(const Job*, int sig);
 
@@ -271,6 +271,7 @@ private:
     void save_to(JsonObject&);
     void bring_cursor_to_beginning_of_a_line() const;
 
+    Optional<int> resolve_job_spec(const String&);
     void cache_path();
     void add_entry_to_cache(const String&);
     void stop_all_jobs();

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -46,7 +46,8 @@
     __ENUMERATE_SHELL_BUILTIN(fg)      \
     __ENUMERATE_SHELL_BUILTIN(bg)      \
     __ENUMERATE_SHELL_BUILTIN(wait)    \
-    __ENUMERATE_SHELL_BUILTIN(dump)
+    __ENUMERATE_SHELL_BUILTIN(dump)    \
+    __ENUMERATE_SHELL_BUILTIN(kill)
 
 #define ENUMERATE_SHELL_OPTIONS()                                                                                    \
     __ENUMERATE_SHELL_OPTION(inline_exec_keep_empty_segments, false, "Keep empty segments in inline execute $(...)") \
@@ -102,6 +103,8 @@ public:
     Vector<AST::Command> expand_aliases(Vector<AST::Command>);
     String resolve_path(String) const;
     String resolve_alias(const String&) const;
+
+    static String find_in_path(const StringView& program_name);
 
     static bool has_history_event(StringView);
 


### PR DESCRIPTION
Switches `fg`, `bg`, `disown`, `wait` and `kill` to use jobspecs.
Fixes #6578.

Note: since `%?foo` is a glob, you have to quote it, so `kill '%?sleep'`. I don't love that, but it's not too bad