### PR TITLE
HackStudio: Fixed a bug related to action tab widget

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -908,7 +908,7 @@ void HackStudioWidget::create_action_tab(GUI::Widget& parent)
         on_action_tab_change();
 
         static bool first_time = true;
-        if (!first_time)
+        if (first_time)
             m_action_tab_widget->set_fixed_height(200);
         first_time = false;
     };


### PR DESCRIPTION
When launching HackStudio, the action tab widget used to have a height
of 0. Also, when you change the height of a certain tab and change to 
another tab, the tab you changed to used to keep its previous scale.

Both of these issues got fixed.