### PR TITLE
 Meta: Re-use existing disk image where possible

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -24,38 +24,77 @@ disk_usage() {
 }
 
 DISK_SIZE=$(($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) + 100))
+DISK_SIZE=${DISK_SIZE:-600}
+DISK_SIZE_BYTES=$((DISK_SIZE * 1024 * 1024))
+unset DISK_SIZE
 
-echo "setting up disk image..."
-qemu-img create _disk_image "${DISK_SIZE:-600}"m || die "could not create disk image"
-chown "$SUDO_UID":"$SUDO_GID" _disk_image || die "could not adjust permissions on disk image"
-echo "done"
+USE_EXISTING=0
 
-printf "creating new filesystem... "
-if [ "$(uname -s)" = "OpenBSD" ]; then
-    VND=$(vnconfig _disk_image)
-    (echo "e 0"; echo 83; echo n; echo 0; echo "*"; echo "quit") | fdisk -e "$VND"
-    newfs_ext2fs -D 128 "/dev/r${VND}i" || die "could not create filesystem"
-elif [ "$(uname -s)" = "FreeBSD" ]; then
-    MD=$(mdconfig _disk_image)
-    mke2fs -q -I 128 _disk_image || die "could not create filesystem"
-else
-    if [ -x /sbin/mke2fs ]; then
-        /sbin/mke2fs -q -I 128 _disk_image || die "could not create filesystem"
+if [ -f _disk_image ]; then
+    USE_EXISTING=1
+
+    echo "checking existing image"
+    result=0
+    e2fsck -f -y _disk_image || result=$?
+    if [ $result -ge 4 ]; then
+        rm -f _disk_image
+        USE_EXISTING=0
+        echo "failed, not using existing image"
     else
-        mke2fs -q -I 128 _disk_image || die "could not create filesystem"
+        echo "done"
     fi
 fi
-echo "done"
+
+if [ $USE_EXISTING -eq 1 ];  then
+    OLD_DISK_SIZE_BYTES=$(wc -c < _disk_image)
+    if [ $DISK_SIZE_BYTES -gt "$OLD_DISK_SIZE_BYTES" ]; then
+        echo "resizing disk image..."
+        qemu-img resize -f raw _disk_image $DISK_SIZE_BYTES || die "could not resize disk image"
+        if ! resize2fs _disk_image; then
+            rm -f _disk_image
+            USE_EXISTING=0
+            echo "failed, not using existing image"
+        fi
+        echo "done"
+    fi
+fi
+
+if [ $USE_EXISTING -ne 1 ]; then
+    printf "setting up disk image... "
+    qemu-img create -q -f raw _disk_image $DISK_SIZE_BYTES || die "could not create disk image"
+    chown "$SUDO_UID":"$SUDO_GID" _disk_image || die "could not adjust permissions on disk image"
+    echo "done"
+
+    printf "creating new filesystem... "
+    if [ "$(uname -s)" = "OpenBSD" ]; then
+        VND=$(vnconfig _disk_image)
+        (echo "e 0"; echo 83; echo n; echo 0; echo "*"; echo "quit") | fdisk -e "$VND"
+        newfs_ext2fs -D 128 "/dev/r${VND}i" || die "could not create filesystem"
+    elif [ "$(uname -s)" = "FreeBSD" ]; then
+        MD=$(mdconfig _disk_image)
+        mke2fs -q -I 128 _disk_image || die "could not create filesystem"
+    else
+        if [ -x /sbin/mke2fs ]; then
+            /sbin/mke2fs -q -I 128 _disk_image || die "could not create filesystem"
+        else
+            mke2fs -q -I 128 _disk_image || die "could not create filesystem"
+        fi
+    fi
+    echo "done"
+fi
 
 printf "mounting filesystem... "
 mkdir -p mnt
 use_genext2fs=0
 if [ "$(uname -s)" = "Darwin" ]; then
     fuse-ext2 _disk_image mnt -o rw+,allow_other,uid=501,gid=20 || die "could not mount filesystem"
+    echo "done"
 elif [ "$(uname -s)" = "OpenBSD" ]; then
     mount -t ext2fs "/dev/${VND}i" mnt/ || die "could not mount filesystem"
+    echo "done"
 elif [ "$(uname -s)" = "FreeBSD" ]; then
     fuse-ext2 -o rw+,direct_io "/dev/${MD}" mnt/ || die "could not mount filesystem"
+    echo "done"
 else
     if ! mount _disk_image mnt/ ; then
         if command -v genext2fs 1>/dev/null ; then
@@ -64,9 +103,10 @@ else
         else
             die "could not mount filesystem and genext2fs is missing"
         fi
+    else
+         echo "done"
     fi
 fi
-echo "done"
 
 cleanup() {
     if [ -d mnt ]; then
@@ -96,7 +136,7 @@ if [ $use_genext2fs = 1 ]; then
     # genext2fs is very slow in generating big images, so I use a smaller image here. size can be updated
     # if it's not enough.
     # not using "-i 128" since it hangs. Serenity handles whatever default this uses instead.
-    genext2fs -b 250000 -d mnt _disk_image || die "try increasing image size (genext2fs -b)"
+    genext2fs -B 4096 -b $((DISK_SIZE_BYTES / 4096)) -d mnt _disk_image || die "try increasing image size (genext2fs -b)"
     # if using docker with shared mount, file is created as root, so make it writable for users
     chmod 0666 _disk_image
 fi

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -32,9 +32,15 @@ fi
 umask 0022
 
 printf "installing base system... "
-$CP -PdR "$SERENITY_SOURCE_DIR"/Base/* mnt/
+if command -v rsync >/dev/null; then
+    rsync -aH --inplace "$SERENITY_SOURCE_DIR"/Base/ mnt/
+    rsync -aH --inplace Root/ mnt/
+else
+    echo "Please install rsync to speed up image creation times, falling back to cp for now"
+    $CP -PdR "$SERENITY_SOURCE_DIR"/Base/* mnt/
+    $CP -PdR Root/* mnt/
+fi
 $CP "$SERENITY_SOURCE_DIR"/Toolchain/Local/i686/i686-pc-serenity/lib/libgcc_s.so mnt/usr/lib/
-$CP -PdR Root/* mnt/
 # If umask was 027 or similar when the repo was cloned,
 # file permissions in Base/ are too restrictive. Restore
 # the permissions needed in the image.
@@ -108,22 +114,22 @@ chown -R 200:200 mnt/home/nona
 echo "done"
 
 printf "adding some desktop icons..."
-ln -s /bin/Browser mnt/home/anon/Desktop/
-ln -s /bin/TextEditor mnt/home/anon/Desktop/
-ln -s /bin/Help mnt/home/anon/Desktop/
-ln -s /home/anon mnt/home/anon/Desktop/Home
+ln -sf /bin/Browser mnt/home/anon/Desktop/
+ln -sf /bin/TextEditor mnt/home/anon/Desktop/
+ln -sf /bin/Help mnt/home/anon/Desktop/
+ln -sf /home/anon mnt/home/anon/Desktop/Home
 echo "done"
 
 printf "installing shortcuts... "
-ln -s Shell mnt/bin/sh
-ln -s test mnt/bin/[
+ln -sf Shell mnt/bin/sh
+ln -sf test mnt/bin/[
 echo "done"
 
 printf "installing 'checksum' variants... "
-ln -s checksum mnt/bin/md5sum
-ln -s checksum mnt/bin/sha1sum
-ln -s checksum mnt/bin/sha256sum
-ln -s checksum mnt/bin/sha512sum
+ln -sf checksum mnt/bin/md5sum
+ln -sf checksum mnt/bin/sha1sum
+ln -sf checksum mnt/bin/sha256sum
+ln -sf checksum mnt/bin/sha512sum
 echo "done"
 
 # Run local sync script, if it exists


### PR DESCRIPTION
This adds support for re-using and re-sizing existing disk images. Disk images are checked with `e2fsck` prior to re-use and a new disk image is automatically created when that check fails.

The PR changes the scripts to support using `rsync` to install the root filesystem. If `rsync` isn't available we fall back to using `cp`.

Using `rsync` is significantly faster when we're using an existing image because we only have to copy files which are new or have
been updated. This cuts down the image creation time to about a second or two assuming an old image exists.