### PR TITLE
LibSQL: Parse expressions and statements that require SELECT statements

### DIFF
--- a/Userland/Libraries/LibSQL/AST.h
+++ b/Userland/Libraries/LibSQL/AST.h
@@ -537,6 +537,22 @@ private:
     RefPtr<Expression> m_else_expression;
 };
 
+class ExistsExpression : public Expression {
+public:
+    ExistsExpression(NonnullRefPtr<Select> select_statement, bool invert_expression)
+        : m_select_statement(move(select_statement))
+        , m_invert_expression(invert_expression)
+    {
+    }
+
+    const NonnullRefPtr<Select>& select_statement() const { return m_select_statement; }
+    bool invert_expression() const { return m_invert_expression; }
+
+private:
+    NonnullRefPtr<Select> m_select_statement;
+    bool m_invert_expression;
+};
+
 class CollateExpression : public NestedExpression {
 public:
     CollateExpression(NonnullRefPtr<Expression> expression, String collation_name)

--- a/Userland/Libraries/LibSQL/AST.h
+++ b/Userland/Libraries/LibSQL/AST.h
@@ -83,18 +83,21 @@ private:
 
 class CommonTableExpression : public ASTNode {
 public:
-    CommonTableExpression(String table_name, Vector<String> column_names)
+    CommonTableExpression(String table_name, Vector<String> column_names, NonnullRefPtr<Select> select_statement)
         : m_table_name(move(table_name))
         , m_column_names(move(column_names))
+        , m_select_statement(move(select_statement))
     {
     }
 
     const String& table_name() const { return m_table_name; }
     const Vector<String>& column_names() const { return m_column_names; }
+    const NonnullRefPtr<Select>& select_statement() const { return m_select_statement; }
 
 private:
     String m_table_name;
     Vector<String> m_column_names;
+    NonnullRefPtr<Select> m_select_statement;
 };
 
 class CommonTableExpressionList : public ASTNode {

--- a/Userland/Libraries/LibSQL/AST.h
+++ b/Userland/Libraries/LibSQL/AST.h
@@ -624,6 +624,20 @@ private:
     NonnullRefPtr<Expression> m_expression;
 };
 
+class InSelectionExpression : public InvertibleNestedExpression {
+public:
+    InSelectionExpression(NonnullRefPtr<Expression> expression, NonnullRefPtr<Select> select_statement, bool invert_expression)
+        : InvertibleNestedExpression(move(expression), invert_expression)
+        , m_select_statement(move(select_statement))
+    {
+    }
+
+    const NonnullRefPtr<Select>& select_statement() const { return m_select_statement; }
+
+private:
+    NonnullRefPtr<Select> m_select_statement;
+};
+
 class InChainedExpression : public InvertibleNestedExpression {
 public:
     InChainedExpression(NonnullRefPtr<Expression> expression, NonnullRefPtr<ChainedExpression> expression_chain, bool invert_expression)

--- a/Userland/Libraries/LibSQL/AST.h
+++ b/Userland/Libraries/LibSQL/AST.h
@@ -664,6 +664,15 @@ class ErrorStatement final : public Statement {
 
 class CreateTable : public Statement {
 public:
+    CreateTable(String schema_name, String table_name, RefPtr<Select> select_statement, bool is_temporary, bool is_error_if_table_exists)
+        : m_schema_name(move(schema_name))
+        , m_table_name(move(table_name))
+        , m_select_statement(move(select_statement))
+        , m_is_temporary(is_temporary)
+        , m_is_error_if_table_exists(is_error_if_table_exists)
+    {
+    }
+
     CreateTable(String schema_name, String table_name, NonnullRefPtrVector<ColumnDefinition> columns, bool is_temporary, bool is_error_if_table_exists)
         : m_schema_name(move(schema_name))
         , m_table_name(move(table_name))
@@ -675,13 +684,20 @@ public:
 
     const String& schema_name() const { return m_schema_name; }
     const String& table_name() const { return m_table_name; }
+
+    bool has_selection() const { return !m_select_statement.is_null(); }
+    const RefPtr<Select>& select_statement() const { return m_select_statement; }
+
+    bool has_columns() const { return !m_columns.is_empty(); }
     const NonnullRefPtrVector<ColumnDefinition> columns() const { return m_columns; }
+
     bool is_temporary() const { return m_is_temporary; }
     bool is_error_if_table_exists() const { return m_is_error_if_table_exists; }
 
 private:
     String m_schema_name;
     String m_table_name;
+    RefPtr<Select> m_select_statement;
     NonnullRefPtrVector<ColumnDefinition> m_columns;
     bool m_is_temporary;
     bool m_is_error_if_table_exists;

--- a/Userland/Libraries/LibSQL/Parser.cpp
+++ b/Userland/Libraries/LibSQL/Parser.cpp
@@ -81,7 +81,10 @@ NonnullRefPtr<CreateTable> Parser::parse_create_table_statement()
     String table_name;
     parse_schema_and_table_name(schema_name, table_name);
 
-    // FIXME: Parse "AS select-stmt".
+    if (consume_if(TokenType::As)) {
+        auto select_statement = parse_select_statement({});
+        return create_ast_node<CreateTable>(move(schema_name), move(table_name), move(select_statement), is_temporary, is_error_if_table_exists);
+    }
 
     NonnullRefPtrVector<ColumnDefinition> column_definitions;
     parse_comma_separated_list(true, [&]() { column_definitions.append(parse_column_definition()); });

--- a/Userland/Libraries/LibSQL/Parser.cpp
+++ b/Userland/Libraries/LibSQL/Parser.cpp
@@ -822,11 +822,9 @@ NonnullRefPtr<ReturningClause> Parser::parse_returning_clause()
     do {
         auto expression = parse_expression();
 
-        consume_if(TokenType::As); // 'AS' is optional.
-
         String column_alias;
-        if (match(TokenType::Identifier))
-            column_alias = consume().value();
+        if (consume_if(TokenType::As) || match(TokenType::Identifier))
+            column_alias = consume(TokenType::Identifier).value();
 
         columns.append({ move(expression), move(column_alias) });
         if (!match(TokenType::Comma))
@@ -860,11 +858,10 @@ NonnullRefPtr<ResultColumn> Parser::parse_result_column()
     auto expression = table_name.is_null()
         ? parse_expression()
         : static_cast<NonnullRefPtr<Expression>>(*parse_column_name_expression(move(table_name), parsed_period));
-    consume_if(TokenType::As); // 'AS' is optional.
 
     String column_alias;
-    if (match(TokenType::Identifier))
-        column_alias = consume().value();
+    if (consume_if(TokenType::As) || match(TokenType::Identifier))
+        column_alias = consume(TokenType::Identifier).value();
 
     return create_ast_node<ResultColumn>(move(expression), move(column_alias));
 }
@@ -884,11 +881,9 @@ NonnullRefPtr<TableOrSubquery> Parser::parse_table_or_subquery()
             table_name = move(schema_or_table_name);
         }
 
-        consume_if(TokenType::As); // 'AS' is optional.
-
         String table_alias;
-        if (match(TokenType::Identifier))
-            table_alias = consume().value();
+        if (consume_if(TokenType::As) || match(TokenType::Identifier))
+            table_alias = consume(TokenType::Identifier).value();
 
         return create_ast_node<TableOrSubquery>(move(schema_name), move(table_name), move(table_alias));
     }

--- a/Userland/Libraries/LibSQL/Parser.cpp
+++ b/Userland/Libraries/LibSQL/Parser.cpp
@@ -719,10 +719,10 @@ NonnullRefPtr<CommonTableExpression> Parser::parse_common_table_expression()
 
     consume(TokenType::As);
     consume(TokenType::ParenOpen);
-    // FIXME: Parse "select-stmt".
+    auto select_statement = parse_select_statement({});
     consume(TokenType::ParenClose);
 
-    return create_ast_node<CommonTableExpression>(move(table_name), move(column_names));
+    return create_ast_node<CommonTableExpression>(move(table_name), move(column_names), move(select_statement));
 }
 
 NonnullRefPtr<QualifiedTableName> Parser::parse_qualified_table_name()

--- a/Userland/Libraries/LibSQL/Parser.cpp
+++ b/Userland/Libraries/LibSQL/Parser.cpp
@@ -628,8 +628,8 @@ Optional<NonnullRefPtr<Expression>> Parser::parse_in_expression(NonnullRefPtr<Ex
 
     if (consume_if(TokenType::ParenOpen)) {
         if (match(TokenType::Select)) {
-            // FIXME: Parse "select-stmt".
-            return {};
+            auto select_statement = parse_select_statement({});
+            return create_ast_node<InSelectionExpression>(move(expression), move(select_statement), invert_expression);
         }
 
         // FIXME: Consolidate this with parse_chained_expression(). That method consumes the opening paren as

--- a/Userland/Libraries/LibSQL/Parser.h
+++ b/Userland/Libraries/LibSQL/Parser.h
@@ -68,6 +68,7 @@ private:
     Optional<NonnullRefPtr<Expression>> parse_chained_expression();
     Optional<NonnullRefPtr<Expression>> parse_cast_expression();
     Optional<NonnullRefPtr<Expression>> parse_case_expression();
+    Optional<NonnullRefPtr<Expression>> parse_exists_expression(bool invert_expression, TokenType opening_token = TokenType::Exists);
     Optional<NonnullRefPtr<Expression>> parse_collate_expression(NonnullRefPtr<Expression> expression);
     Optional<NonnullRefPtr<Expression>> parse_is_expression(NonnullRefPtr<Expression> expression);
     Optional<NonnullRefPtr<Expression>> parse_match_expression(NonnullRefPtr<Expression> lhs, bool invert_expression);

--- a/Userland/Libraries/LibSQL/Parser.h
+++ b/Userland/Libraries/LibSQL/Parser.h
@@ -84,6 +84,7 @@ private:
     NonnullRefPtr<ResultColumn> parse_result_column();
     NonnullRefPtr<TableOrSubquery> parse_table_or_subquery();
     NonnullRefPtr<OrderingTerm> parse_ordering_term();
+    void parse_schema_and_table_name(String& schema_name, String& table_name);
 
     template<typename ParseCallback>
     void parse_comma_separated_list(bool surrounded_by_parentheses, ParseCallback&& parse_callback)

--- a/Userland/Libraries/LibSQL/Parser.h
+++ b/Userland/Libraries/LibSQL/Parser.h
@@ -85,6 +85,25 @@ private:
     NonnullRefPtr<TableOrSubquery> parse_table_or_subquery();
     NonnullRefPtr<OrderingTerm> parse_ordering_term();
 
+    template<typename ParseCallback>
+    void parse_comma_separated_list(bool surrounded_by_parentheses, ParseCallback&& parse_callback)
+    {
+        if (surrounded_by_parentheses)
+            consume(TokenType::ParenOpen);
+
+        while (!has_errors() && !match(TokenType::Eof)) {
+            parse_callback();
+
+            if (!match(TokenType::Comma))
+                break;
+
+            consume(TokenType::Comma);
+        };
+
+        if (surrounded_by_parentheses)
+            consume(TokenType::ParenClose);
+    }
+
     Token consume();
     Token consume(TokenType type);
     bool consume_if(TokenType type);

--- a/Userland/Libraries/LibSQL/Tests/TestSqlExpressionParser.cpp
+++ b/Userland/Libraries/LibSQL/Tests/TestSqlExpressionParser.cpp
@@ -338,6 +338,39 @@ TEST_CASE(case_expression)
     validate("CASE 15 WHEN 16 THEN 17 WHEN 18 THEN 19 ELSE 20 END", true, 2, true);
 }
 
+TEST_CASE(exists_expression)
+{
+    EXPECT(parse("EXISTS").is_error());
+    EXPECT(parse("EXISTS (").is_error());
+    EXPECT(parse("EXISTS (SELECT").is_error());
+    EXPECT(parse("EXISTS (SELECT)").is_error());
+    EXPECT(parse("EXISTS (SELECT * FROM table").is_error());
+    EXPECT(parse("NOT EXISTS").is_error());
+    EXPECT(parse("NOT EXISTS (").is_error());
+    EXPECT(parse("NOT EXISTS (SELECT").is_error());
+    EXPECT(parse("NOT EXISTS (SELECT)").is_error());
+    EXPECT(parse("NOT EXISTS (SELECT * FROM table").is_error());
+    EXPECT(parse("(").is_error());
+    EXPECT(parse("(SELECT").is_error());
+    EXPECT(parse("(SELECT)").is_error());
+    EXPECT(parse("(SELECT * FROM table").is_error());
+
+    auto validate = [](StringView sql, bool expected_invert_expression) {
+        auto result = parse(sql);
+        EXPECT(!result.is_error());
+
+        auto expression = result.release_value();
+        EXPECT(is<SQL::ExistsExpression>(*expression));
+
+        const auto& exists = static_cast<const SQL::ExistsExpression&>(*expression);
+        EXPECT_EQ(exists.invert_expression(), expected_invert_expression);
+    };
+
+    validate("EXISTS (SELECT * FROM table)", false);
+    validate("NOT EXISTS (SELECT * FROM table)", true);
+    validate("(SELECT * FROM table)", false);
+}
+
 TEST_CASE(collate_expression)
 {
     EXPECT(parse("COLLATE").is_error());

--- a/Userland/Libraries/LibSQL/Tests/TestSqlStatementParser.cpp
+++ b/Userland/Libraries/LibSQL/Tests/TestSqlStatementParser.cpp
@@ -148,6 +148,8 @@ TEST_CASE(delete_)
     EXPECT(parse("DELETE FROM table WHERE 15").is_error());
     EXPECT(parse("DELETE FROM table WHERE 15 RETURNING").is_error());
     EXPECT(parse("DELETE FROM table WHERE 15 RETURNING *").is_error());
+    EXPECT(parse("DELETE FROM table WHERE 15 RETURNING column").is_error());
+    EXPECT(parse("DELETE FROM table WHERE 15 RETURNING column AS;").is_error());
     EXPECT(parse("DELETE FROM table WHERE (');").is_error());
     EXPECT(parse("WITH DELETE FROM table;").is_error());
     EXPECT(parse("WITH table DELETE FROM table;").is_error());
@@ -243,6 +245,7 @@ TEST_CASE(select)
     EXPECT(parse("SELECT *").is_error());
     EXPECT(parse("SELECT * FROM;").is_error());
     EXPECT(parse("SELECT table. FROM table;").is_error());
+    EXPECT(parse("SELECT column AS FROM table;").is_error());
     EXPECT(parse("SELECT * FROM (").is_error());
     EXPECT(parse("SELECT * FROM ()").is_error());
     EXPECT(parse("SELECT * FROM ();").is_error());
@@ -250,6 +253,7 @@ TEST_CASE(select)
     EXPECT(parse("SELECT * FROM (table1, )").is_error());
     EXPECT(parse("SELECT * FROM (table1, table2)").is_error());
     EXPECT(parse("SELECT * FROM table").is_error());
+    EXPECT(parse("SELECT * FROM table AS;").is_error());
     EXPECT(parse("SELECT * FROM table WHERE;").is_error());
     EXPECT(parse("SELECT * FROM table WHERE 1 ==1").is_error());
     EXPECT(parse("SELECT * FROM table GROUP;").is_error());


### PR DESCRIPTION
This addresses FIXMEs regarding parsing of expressions and statements that depended on SELECT statements being parseable.