### PR TITLE
AudioServer: Mixer: limit max volume to 200%

### DIFF
--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -116,10 +116,12 @@ void Mixer::set_main_volume(int volume)
 {
     if (volume < 0)
         m_main_volume = 0;
+    else if (volume > 200)
+        m_main_volume = 200;
     else
         m_main_volume = volume;
-    ClientConnection::for_each([volume](ClientConnection& client) {
-        client.did_change_main_mix_volume({}, volume);
+    ClientConnection::for_each([&](ClientConnection& client) {
+        client.did_change_main_mix_volume({}, m_main_volume);
     });
 }
 


### PR DESCRIPTION
The maximum volume was limited to 100% in #4230; however, this was reverted in df536d4d746a8fdfb37a2c3b8e41975237915d8a (#5878).

https://github.com/SerenityOS/serenity/pull/5878/files#diff-5f36f9886793ec03954a2717b720fd54cb325cb37f9ddc7d8b6e4713dd850ce0R137-R138

Allowing more than 100% is reasonable, but allowing `MAXINT` volume is insane.

This PR sets the maximum volume to 200% and also resolves #6596 by ensuring that the new system volume is returned in the `did_change_main_mix_volume` IPC notification message instead of returning the user-supplied volume (which could be negative or larger than 200).
