### PR TITLE
Kernel: Consolidate Scatter gather list implementations

### DIFF
--- a/Kernel/Storage/AHCIPort.h
+++ b/Kernel/Storage/AHCIPort.h
@@ -20,6 +20,7 @@
 #include <Kernel/Storage/StorageDevice.h>
 #include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/PhysicalPage.h>
+#include <Kernel/VM/ScatterGatherList.h>
 #include <Kernel/WaitQueue.h>
 
 namespace Kernel {
@@ -31,20 +32,6 @@ class SATADiskDevice;
 class AHCIPort : public RefCounted<AHCIPort> {
     friend class AHCIPortHandler;
     friend class SATADiskDevice;
-
-private:
-    class ScatterList : public RefCounted<ScatterList> {
-    public:
-        static NonnullRefPtr<ScatterList> create(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
-        const VMObject& vmobject() const { return m_vm_object; }
-        VirtualAddress dma_region() const { return m_dma_region->vaddr(); }
-        size_t scatters_count() const { return m_vm_object->physical_pages().size(); }
-
-    private:
-        ScatterList(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
-        NonnullRefPtr<AnonymousVMObject> m_vm_object;
-        OwnPtr<Region> m_dma_region;
-    };
 
 public:
     UNMAP_AFTER_INIT static NonnullRefPtr<AHCIPort> create(const AHCIPortHandler&, volatile AHCI::PortRegisters&, u32 port_index);
@@ -132,7 +119,7 @@ private:
     AHCI::PortInterruptStatusBitField m_interrupt_status;
     AHCI::PortInterruptEnableBitField m_interrupt_enable;
 
-    RefPtr<AHCIPort::ScatterList> m_current_scatter_list;
+    RefPtr<ScatterGatherList> m_current_scatter_list;
     bool m_disabled_by_firmware { false };
 };
 }

--- a/Kernel/VM/MemoryManager.h
+++ b/Kernel/VM/MemoryManager.h
@@ -104,7 +104,7 @@ class MemoryManager {
     friend class PhysicalRegion;
     friend class AnonymousVMObject;
     friend class Region;
-    friend class ScatterGatherList;
+    friend class ScatterGatherRefList;
     friend class VMObject;
 
 public:

--- a/Kernel/VM/ScatterGatherList.cpp
+++ b/Kernel/VM/ScatterGatherList.cpp
@@ -8,10 +8,21 @@
 
 namespace Kernel {
 
-ScatterGatherList ScatterGatherList::create_from_buffer(const u8* buffer, size_t size)
+NonnullRefPtr<ScatterGatherList> ScatterGatherList::create(AsyncBlockDeviceRequest& request, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size)
+{
+    return adopt_ref(*new ScatterGatherList(request, allocated_pages, device_block_size));
+}
+
+ScatterGatherList::ScatterGatherList(AsyncBlockDeviceRequest& request, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size)
+    : m_vm_object(AnonymousVMObject::create_with_physical_pages(allocated_pages))
+{
+    m_dma_region = MM.allocate_kernel_region_with_vmobject(m_vm_object, page_round_up((request.block_count() * device_block_size)), "AHCI Scattered DMA", Region::Access::Read | Region::Access::Write, Region::Cacheable::Yes);
+}
+
+ScatterGatherRefList ScatterGatherRefList::create_from_buffer(const u8* buffer, size_t size)
 {
     VERIFY(buffer && size);
-    ScatterGatherList new_list;
+    ScatterGatherRefList new_list;
     auto* region = MM.find_region_from_vaddr(VirtualAddress(buffer));
     VERIFY(region);
     while (size > 0) {
@@ -25,20 +36,20 @@ ScatterGatherList ScatterGatherList::create_from_buffer(const u8* buffer, size_t
     return new_list;
 }
 
-ScatterGatherList ScatterGatherList::create_from_physical(PhysicalAddress paddr, size_t size)
+ScatterGatherRefList ScatterGatherRefList::create_from_physical(PhysicalAddress paddr, size_t size)
 {
     VERIFY(!paddr.is_null() && size);
-    ScatterGatherList new_list;
+    ScatterGatherRefList new_list;
     new_list.add_entry(paddr.page_base().get(), paddr.offset_in_page(), size);
     return new_list;
 }
 
-void ScatterGatherList::add_entry(FlatPtr addr, size_t offset, size_t size)
+void ScatterGatherRefList::add_entry(FlatPtr addr, size_t offset, size_t size)
 {
     m_entries.append({ addr, offset, size });
 }
 
-void ScatterGatherList::for_each_entry(Function<void(const FlatPtr, const size_t)> callback) const
+void ScatterGatherRefList::for_each_entry(Function<void(const FlatPtr, const size_t)> callback) const
 {
     for (auto& entry : m_entries)
         callback(entry.page_base + entry.offset, entry.length);

--- a/Kernel/VM/ScatterGatherList.cpp
+++ b/Kernel/VM/ScatterGatherList.cpp
@@ -46,13 +46,13 @@ ScatterGatherRefList ScatterGatherRefList::create_from_physical(PhysicalAddress 
 
 void ScatterGatherRefList::add_entry(FlatPtr addr, size_t offset, size_t size)
 {
-    m_entries.append({ addr, offset, size });
+    m_entries.append({ addr + offset, size });
 }
 
 void ScatterGatherRefList::for_each_entry(Function<void(const FlatPtr, const size_t)> callback) const
 {
     for (auto& entry : m_entries)
-        callback(entry.page_base + entry.offset, entry.length);
+        callback(entry.position, entry.length);
 }
 
 }

--- a/Kernel/VM/ScatterGatherList.cpp
+++ b/Kernel/VM/ScatterGatherList.cpp
@@ -44,15 +44,24 @@ ScatterGatherRefList ScatterGatherRefList::create_from_physical(PhysicalAddress 
     return new_list;
 }
 
-void ScatterGatherRefList::add_entry(FlatPtr addr, size_t offset, size_t size)
+bool ScatterGatherRefList::add_entry(FlatPtr addr, size_t offset, size_t size)
 {
+    // TODO: make this use Vector::try_append() when that is implemented
     m_entries.append({ addr + offset, size });
+    return true;
 }
 
 void ScatterGatherRefList::for_each_entry(Function<void(const FlatPtr, const size_t)> callback) const
 {
     for (auto& entry : m_entries)
         callback(entry.position, entry.length);
+}
+
+bool ScatterGatherRefList::try_reserve(size_t expected_size)
+{
+    // TODO: make this use Vector::try_grow_capacity() when that is implemented
+    m_entries.grow_capacity(expected_size);
+    return true;
 }
 
 }

--- a/Kernel/VM/ScatterGatherList.h
+++ b/Kernel/VM/ScatterGatherList.h
@@ -7,21 +7,40 @@
 #pragma once
 
 #include <AK/Vector.h>
+#include <Kernel/Devices/BlockDevice.h>
 #include <Kernel/PhysicalAddress.h>
+#include <Kernel/VM/AnonymousVMObject.h>
 #include <Kernel/VM/MemoryManager.h>
 
 namespace Kernel {
 
-class ScatterGatherList {
-    struct ScatterGatherEntry {
+/// A Scatter-Gather List type that owns its buffers
+
+class ScatterGatherList : public RefCounted<ScatterGatherList> {
+public:
+    static NonnullRefPtr<ScatterGatherList> create(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
+    const VMObject& vmobject() const { return m_vm_object; }
+    VirtualAddress dma_region() const { return m_dma_region->vaddr(); }
+    size_t scatters_count() const { return m_vm_object->physical_pages().size(); }
+
+private:
+    ScatterGatherList(AsyncBlockDeviceRequest&, NonnullRefPtrVector<PhysicalPage> allocated_pages, size_t device_block_size);
+    NonnullRefPtr<AnonymousVMObject> m_vm_object;
+    OwnPtr<Region> m_dma_region;
+};
+
+/// A Scatter-Gather List type that doesn't own its buffers
+
+class ScatterGatherRefList {
+    struct ScatterGatherRef {
         FlatPtr page_base;
         size_t offset;
         size_t length;
     };
 
 public:
-    static ScatterGatherList create_from_buffer(const u8* buffer, size_t);
-    static ScatterGatherList create_from_physical(PhysicalAddress, size_t);
+    static ScatterGatherRefList create_from_buffer(const u8* buffer, size_t);
+    static ScatterGatherRefList create_from_physical(PhysicalAddress, size_t);
 
     void add_entry(FlatPtr, size_t offset, size_t size);
     [[nodiscard]] size_t length() const { return m_entries.size(); }
@@ -29,7 +48,7 @@ public:
     void for_each_entry(Function<void(const FlatPtr, const size_t)> callback) const;
 
 private:
-    Vector<ScatterGatherEntry> m_entries;
+    Vector<ScatterGatherRef> m_entries;
 };
 
 }

--- a/Kernel/VM/ScatterGatherList.h
+++ b/Kernel/VM/ScatterGatherList.h
@@ -41,7 +41,8 @@ public:
     static ScatterGatherRefList create_from_buffer(const u8* buffer, size_t);
     static ScatterGatherRefList create_from_physical(PhysicalAddress, size_t);
 
-    void add_entry(FlatPtr, size_t offset, size_t size);
+    bool add_entry(FlatPtr, size_t offset, size_t size);
+    bool try_reserve(size_t expected_size);
     [[nodiscard]] size_t length() const { return m_entries.size(); }
 
     void for_each_entry(Function<void(const FlatPtr, const size_t)> callback) const;

--- a/Kernel/VM/ScatterGatherList.h
+++ b/Kernel/VM/ScatterGatherList.h
@@ -33,8 +33,7 @@ private:
 
 class ScatterGatherRefList {
     struct ScatterGatherRef {
-        FlatPtr page_base;
-        size_t offset;
+        FlatPtr position;
         size_t length;
     };
 

--- a/Kernel/VirtIO/VirtIO.cpp
+++ b/Kernel/VirtIO/VirtIO.cpp
@@ -334,7 +334,7 @@ void VirtIODevice::finish_init()
     dbgln_if(VIRTIO_DEBUG, "{}: Finished initialization", m_class_name);
 }
 
-void VirtIODevice::supply_buffer_and_notify(u16 queue_index, const ScatterGatherList& scatter_list, BufferType buffer_type, void* token)
+void VirtIODevice::supply_buffer_and_notify(u16 queue_index, const ScatterGatherRefList& scatter_list, BufferType buffer_type, void* token)
 {
     VERIFY(queue_index < m_queue_count);
     if (get_queue(queue_index).supply_buffer({}, scatter_list, buffer_type, token))

--- a/Kernel/VirtIO/VirtIO.h
+++ b/Kernel/VirtIO/VirtIO.h
@@ -198,7 +198,7 @@ protected:
         return is_feature_set(m_accepted_features, feature);
     }
 
-    void supply_buffer_and_notify(u16 queue_index, const ScatterGatherList&, BufferType, void* token);
+    void supply_buffer_and_notify(u16 queue_index, const ScatterGatherRefList&, BufferType, void* token);
 
     virtual bool handle_device_config_change() = 0;
     virtual void handle_queue_update(u16 queue_index) = 0;

--- a/Kernel/VirtIO/VirtIOConsole.cpp
+++ b/Kernel/VirtIO/VirtIOConsole.cpp
@@ -43,7 +43,7 @@ VirtIOConsole::VirtIOConsole(PCI::Address address)
             finish_init();
             m_receive_region = MM.allocate_contiguous_kernel_region(PAGE_SIZE, "VirtIOConsole Receive", Region::Access::Read | Region::Access::Write);
             if (m_receive_region) {
-                supply_buffer_and_notify(RECEIVEQ, ScatterGatherList::create_from_physical(m_receive_region->physical_page(0)->paddr(), m_receive_region->size()), BufferType::DeviceWritable, m_receive_region->vaddr().as_ptr());
+                supply_buffer_and_notify(RECEIVEQ, ScatterGatherRefList::create_from_physical(m_receive_region->physical_page(0)->paddr(), m_receive_region->size()), BufferType::DeviceWritable, m_receive_region->vaddr().as_ptr());
             }
             m_transmit_region = MM.allocate_contiguous_kernel_region(PAGE_SIZE, "VirtIOConsole Transmit", Region::Access::Read | Region::Access::Write);
         }
@@ -98,7 +98,7 @@ KResultOr<size_t> VirtIOConsole::write(FileDescription&, u64, const UserOrKernel
     if (!size)
         return 0;
 
-    auto scatter_list = ScatterGatherList::create_from_buffer(static_cast<const u8*>(data.user_or_kernel_ptr()), size);
+    auto scatter_list = ScatterGatherRefList::create_from_buffer(static_cast<const u8*>(data.user_or_kernel_ptr()), size);
     supply_buffer_and_notify(TRANSMITQ, scatter_list, BufferType::DeviceReadable, const_cast<void*>(data.user_or_kernel_ptr()));
 
     return size;

--- a/Kernel/VirtIO/VirtIOQueue.cpp
+++ b/Kernel/VirtIO/VirtIOQueue.cpp
@@ -48,7 +48,7 @@ void VirtIOQueue::disable_interrupts()
     m_driver->flags = 1;
 }
 
-bool VirtIOQueue::supply_buffer(Badge<VirtIODevice>, const ScatterGatherList& scatter_list, BufferType buffer_type, void* token)
+bool VirtIOQueue::supply_buffer(Badge<VirtIODevice>, const ScatterGatherRefList& scatter_list, BufferType buffer_type, void* token)
 {
     VERIFY(scatter_list.length() && scatter_list.length() <= m_free_buffers);
     m_free_buffers -= scatter_list.length();

--- a/Kernel/VirtIO/VirtIOQueue.h
+++ b/Kernel/VirtIO/VirtIOQueue.h
@@ -38,7 +38,7 @@ public:
     PhysicalAddress driver_area() const { return to_physical(m_driver.ptr()); }
     PhysicalAddress device_area() const { return to_physical(m_device.ptr()); }
 
-    bool supply_buffer(Badge<VirtIODevice>, const ScatterGatherList&, BufferType, void* token);
+    bool supply_buffer(Badge<VirtIODevice>, const ScatterGatherRefList&, BufferType, void* token);
     bool new_data_available() const;
     bool can_write() const;
     void* get_buffer(size_t*);

--- a/Kernel/VirtIO/VirtIORNG.cpp
+++ b/Kernel/VirtIO/VirtIORNG.cpp
@@ -23,7 +23,7 @@ VirtIORNG::VirtIORNG(PCI::Address address)
         m_entropy_buffer = MM.allocate_contiguous_kernel_region(PAGE_SIZE, "VirtIORNG", Region::Access::Read | Region::Access::Write);
         if (m_entropy_buffer) {
             memset(m_entropy_buffer->vaddr().as_ptr(), 0, m_entropy_buffer->size());
-            supply_buffer_and_notify(REQUESTQ, ScatterGatherList::create_from_physical(m_entropy_buffer->physical_page(0)->paddr(), m_entropy_buffer->size()), BufferType::DeviceWritable, m_entropy_buffer->vaddr().as_ptr());
+            supply_buffer_and_notify(REQUESTQ, ScatterGatherRefList::create_from_physical(m_entropy_buffer->physical_page(0)->paddr(), m_entropy_buffer->size()), BufferType::DeviceWritable, m_entropy_buffer->vaddr().as_ptr());
         }
     }
 }


### PR DESCRIPTION
Currently, we have two scatter gather lists in the kernel, one in the AHCI subsystem and one in the VirtIO subsystem. This commit consolidates them into `VM/ScatterGatherList.h`.