### PR TITLE
Kernel: Fix LOCK_DEBUG tracking to work again, move it to use AK::SourceLocation

### DIFF
--- a/AK/SourceLocation.h
+++ b/AK/SourceLocation.h
@@ -23,6 +23,8 @@ public:
         return SourceLocation(file, line, function);
     }
 
+    constexpr SourceLocation() = default;
+
 private:
     constexpr SourceLocation(const char* const file, u32 line, const char* const function)
         : m_function(function)

--- a/Kernel/DoubleBuffer.cpp
+++ b/Kernel/DoubleBuffer.cpp
@@ -45,7 +45,7 @@ ssize_t DoubleBuffer::write(const UserOrKernelBuffer& data, size_t size)
     if (!size || m_storage.is_null())
         return 0;
     VERIFY(size > 0);
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     size_t bytes_to_write = min(size, m_space_for_writing);
     u8* write_ptr = m_write_buffer->data + m_write_buffer->size;
     m_write_buffer->size += bytes_to_write;
@@ -62,7 +62,7 @@ ssize_t DoubleBuffer::read(UserOrKernelBuffer& data, size_t size)
     if (!size || m_storage.is_null())
         return 0;
     VERIFY(size > 0);
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (m_read_buffer_index >= m_read_buffer->size && m_write_buffer->size != 0)
         flip();
     if (m_read_buffer_index >= m_read_buffer->size)

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -116,7 +116,7 @@ BlockBasedFS::~BlockBasedFS()
 
 KResult BlockBasedFS::write_block(BlockIndex index, const UserOrKernelBuffer& data, size_t count, size_t offset, bool allow_cache)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     VERIFY(m_logical_block_size);
     VERIFY(offset + count <= block_size());
     dbgln_if(BBFS_DEBUG, "BlockBasedFileSystem::write_block {}, size={}", index, count);
@@ -151,7 +151,7 @@ KResult BlockBasedFS::write_block(BlockIndex index, const UserOrKernelBuffer& da
 
 bool BlockBasedFS::raw_read(BlockIndex index, UserOrKernelBuffer& buffer)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     u32 base_offset = index.value() * m_logical_block_size;
     auto seek_result = file_description().seek(base_offset, SEEK_SET);
     VERIFY(!seek_result.is_error());
@@ -163,7 +163,7 @@ bool BlockBasedFS::raw_read(BlockIndex index, UserOrKernelBuffer& buffer)
 
 bool BlockBasedFS::raw_write(BlockIndex index, const UserOrKernelBuffer& buffer)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     size_t base_offset = index.value() * m_logical_block_size;
     auto seek_result = file_description().seek(base_offset, SEEK_SET);
     VERIFY(!seek_result.is_error());
@@ -175,7 +175,7 @@ bool BlockBasedFS::raw_write(BlockIndex index, const UserOrKernelBuffer& buffer)
 
 bool BlockBasedFS::raw_read_blocks(BlockIndex index, size_t count, UserOrKernelBuffer& buffer)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     auto current = buffer;
     for (unsigned block = index.value(); block < (index.value() + count); block++) {
         if (!raw_read(BlockIndex { block }, current))
@@ -187,7 +187,7 @@ bool BlockBasedFS::raw_read_blocks(BlockIndex index, size_t count, UserOrKernelB
 
 bool BlockBasedFS::raw_write_blocks(BlockIndex index, size_t count, const UserOrKernelBuffer& buffer)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     auto current = buffer;
     for (unsigned block = index.value(); block < (index.value() + count); block++) {
         if (!raw_write(block, current))
@@ -199,7 +199,7 @@ bool BlockBasedFS::raw_write_blocks(BlockIndex index, size_t count, const UserOr
 
 KResult BlockBasedFS::write_blocks(BlockIndex index, unsigned count, const UserOrKernelBuffer& data, bool allow_cache)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     VERIFY(m_logical_block_size);
     dbgln_if(BBFS_DEBUG, "BlockBasedFileSystem::write_blocks {}, count={}", index, count);
     for (unsigned i = 0; i < count; ++i) {
@@ -212,7 +212,7 @@ KResult BlockBasedFS::write_blocks(BlockIndex index, unsigned count, const UserO
 
 KResult BlockBasedFS::read_block(BlockIndex index, UserOrKernelBuffer* buffer, size_t count, size_t offset, bool allow_cache) const
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     VERIFY(m_logical_block_size);
     VERIFY(offset + count <= block_size());
     dbgln_if(BBFS_DEBUG, "BlockBasedFileSystem::read_block {}", index);
@@ -250,7 +250,7 @@ KResult BlockBasedFS::read_block(BlockIndex index, UserOrKernelBuffer* buffer, s
 
 KResult BlockBasedFS::read_blocks(BlockIndex index, unsigned count, UserOrKernelBuffer& buffer, bool allow_cache) const
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     VERIFY(m_logical_block_size);
     if (!count)
         return EINVAL;
@@ -269,7 +269,7 @@ KResult BlockBasedFS::read_blocks(BlockIndex index, unsigned count, UserOrKernel
 
 void BlockBasedFS::flush_specific_block_if_needed(BlockIndex index)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (!cache().is_dirty())
         return;
     Vector<CacheEntry*, 32> cleaned_entries;
@@ -292,7 +292,7 @@ void BlockBasedFS::flush_specific_block_if_needed(BlockIndex index)
 
 void BlockBasedFS::flush_writes_impl()
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (!cache().is_dirty())
         return;
     u32 count = 0;

--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -74,7 +74,7 @@ KResultOr<NonnullRefPtr<FileDescription>> FIFO::open_direction_blocking(FIFO::Di
 FIFO::FIFO(uid_t uid)
     : m_uid(uid)
 {
-    LOCKER(all_fifos().lock());
+    Locker locker(all_fifos().lock());
     all_fifos().resource().set(this);
     m_fifo_id = ++s_next_fifo_id;
 
@@ -86,7 +86,7 @@ FIFO::FIFO(uid_t uid)
 
 FIFO::~FIFO()
 {
-    LOCKER(all_fifos().lock());
+    Locker locker(all_fifos().lock());
     all_fifos().resource().remove(this);
 }
 

--- a/Kernel/FileSystem/FileDescription.cpp
+++ b/Kernel/FileSystem/FileDescription.cpp
@@ -99,7 +99,7 @@ Thread::FileBlocker::BlockFlags FileDescription::should_unblock(Thread::FileBloc
 
 KResult FileDescription::stat(::stat& buffer)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     // FIXME: This is a little awkward, why can't we always forward to File::stat()?
     if (m_inode)
         return metadata().stat(buffer);
@@ -108,7 +108,7 @@ KResult FileDescription::stat(::stat& buffer)
 
 KResultOr<off_t> FileDescription::seek(off_t offset, int whence)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (!m_file->is_seekable())
         return ESPIPE;
 
@@ -147,7 +147,7 @@ KResultOr<off_t> FileDescription::seek(off_t offset, int whence)
 
 KResultOr<size_t> FileDescription::read(UserOrKernelBuffer& buffer, size_t count)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (Checked<off_t>::addition_would_overflow(m_current_offset, count))
         return EOVERFLOW;
     auto nread_or_error = m_file->read(*this, offset(), buffer, count);
@@ -161,7 +161,7 @@ KResultOr<size_t> FileDescription::read(UserOrKernelBuffer& buffer, size_t count
 
 KResultOr<size_t> FileDescription::write(const UserOrKernelBuffer& data, size_t size)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (Checked<off_t>::addition_would_overflow(m_current_offset, size))
         return EOVERFLOW;
     auto nwritten_or_error = m_file->write(*this, offset(), data, size);
@@ -193,7 +193,7 @@ KResultOr<NonnullOwnPtr<KBuffer>> FileDescription::read_entire_file()
 
 ssize_t FileDescription::get_dir_entries(UserOrKernelBuffer& buffer, ssize_t size)
 {
-    LOCKER(m_lock, Lock::Mode::Shared);
+    Locker locker(m_lock, Lock::Mode::Shared);
     if (!is_directory())
         return -ENOTDIR;
 
@@ -309,13 +309,13 @@ InodeMetadata FileDescription::metadata() const
 
 KResultOr<Region*> FileDescription::mmap(Process& process, const Range& range, u64 offset, int prot, bool shared)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     return m_file->mmap(process, *this, range, offset, prot, shared);
 }
 
 KResult FileDescription::truncate(u64 length)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     return m_file->truncate(length);
 }
 
@@ -352,7 +352,7 @@ const Socket* FileDescription::socket() const
 
 void FileDescription::set_file_flags(u32 flags)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     m_is_blocking = !(flags & O_NONBLOCK);
     m_should_append = flags & O_APPEND;
     m_direct = flags & O_DIRECT;
@@ -361,13 +361,13 @@ void FileDescription::set_file_flags(u32 flags)
 
 KResult FileDescription::chmod(mode_t mode)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     return m_file->chmod(*this, mode);
 }
 
 KResult FileDescription::chown(uid_t uid, gid_t gid)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     return m_file->chown(*this, uid, gid);
 }
 

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -112,7 +112,7 @@ Inode::~Inode()
 
 void Inode::will_be_destroyed()
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (m_metadata_dirty)
         flush_metadata();
 }
@@ -144,13 +144,13 @@ KResult Inode::decrement_link_count()
 
 void Inode::set_shared_vmobject(SharedInodeVMObject& vmobject)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     m_shared_vmobject = vmobject;
 }
 
 bool Inode::bind_socket(LocalSocket& socket)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (m_socket)
         return false;
     m_socket = socket;
@@ -159,7 +159,7 @@ bool Inode::bind_socket(LocalSocket& socket)
 
 bool Inode::unbind_socket()
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (!m_socket)
         return false;
     m_socket = nullptr;
@@ -168,21 +168,21 @@ bool Inode::unbind_socket()
 
 void Inode::register_watcher(Badge<InodeWatcher>, InodeWatcher& watcher)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     VERIFY(!m_watchers.contains(&watcher));
     m_watchers.set(&watcher);
 }
 
 void Inode::unregister_watcher(Badge<InodeWatcher>, InodeWatcher& watcher)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     VERIFY(m_watchers.contains(&watcher));
     m_watchers.remove(&watcher);
 }
 
 NonnullRefPtr<FIFO> Inode::fifo()
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     VERIFY(metadata().is_fifo());
 
     // FIXME: Release m_fifo when it is closed by all readers and writers
@@ -195,7 +195,7 @@ NonnullRefPtr<FIFO> Inode::fifo()
 
 void Inode::set_metadata_dirty(bool metadata_dirty)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
 
     if (metadata_dirty) {
         // Sanity check.
@@ -217,7 +217,7 @@ void Inode::set_metadata_dirty(bool metadata_dirty)
 
 void Inode::did_add_child(const InodeIdentifier& child_id)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     for (auto& watcher : m_watchers) {
         watcher->notify_child_added({}, child_id);
     }
@@ -225,7 +225,7 @@ void Inode::did_add_child(const InodeIdentifier& child_id)
 
 void Inode::did_remove_child(const InodeIdentifier& child_id)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     for (auto& watcher : m_watchers) {
         watcher->notify_child_removed({}, child_id);
     }
@@ -235,7 +235,7 @@ KResult Inode::prepare_to_write_data()
 {
     // FIXME: It's a poor design that filesystems are expected to call this before writing out data.
     //        We should funnel everything through an interface at the VFS layer so this can happen from a single place.
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (fs().is_readonly())
         return EROFS;
     auto metadata = this->metadata();
@@ -248,13 +248,13 @@ KResult Inode::prepare_to_write_data()
 
 RefPtr<SharedInodeVMObject> Inode::shared_vmobject() const
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     return m_shared_vmobject.strong_ref();
 }
 
 bool Inode::is_shared_vmobject(const SharedInodeVMObject& other) const
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     return m_shared_vmobject.unsafe_ptr() == &other;
 }
 

--- a/Kernel/FileSystem/InodeWatcher.cpp
+++ b/Kernel/FileSystem/InodeWatcher.cpp
@@ -39,7 +39,7 @@ bool InodeWatcher::can_write(const FileDescription&, size_t) const
 
 KResultOr<size_t> InodeWatcher::read(FileDescription&, u64, UserOrKernelBuffer& buffer, size_t buffer_size)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     VERIFY(!m_queue.is_empty() || !m_inode);
 
     if (!m_inode)
@@ -76,21 +76,21 @@ String InodeWatcher::absolute_path(const FileDescription&) const
 
 void InodeWatcher::notify_inode_event(Badge<Inode>, InodeWatcherEvent::Type event_type)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     m_queue.enqueue({ event_type });
     evaluate_block_conditions();
 }
 
 void InodeWatcher::notify_child_added(Badge<Inode>, const InodeIdentifier& child_id)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     m_queue.enqueue({ InodeWatcherEvent::Type::ChildAdded, child_id.index().value() });
     evaluate_block_conditions();
 }
 
 void InodeWatcher::notify_child_removed(Badge<Inode>, const InodeIdentifier& child_id)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     m_queue.enqueue({ InodeWatcherEvent::Type::ChildRemoved, child_id.index().value() });
     evaluate_block_conditions();
 }

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -475,7 +475,7 @@ void Plan9FS::Plan9FSBlockCondition::try_unblock(Plan9FS::Blocker& blocker)
 
 bool Plan9FS::is_complete(const ReceiveCompletion& completion)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (m_completions.contains(completion.tag)) {
         // If it's still in the map then it can't be complete
         VERIFY(!completion.completed);
@@ -495,12 +495,12 @@ KResult Plan9FS::post_message(Message& message, RefPtr<ReceiveCompletion> comple
     size_t size = buffer.size();
     auto& description = file_description();
 
-    LOCKER(m_send_lock);
+    Locker locker(m_send_lock);
 
     if (completion) {
         // Save the completion record *before* we send the message. This
         // ensures that it exists when the thread reads the response
-        LOCKER(m_lock);
+        Locker locker(m_lock);
         auto tag = completion->tag;
         m_completions.set(tag, completion.release_nonnull());
         // TODO: What if there is a collision? Do we need to wait until
@@ -569,7 +569,7 @@ KResult Plan9FS::read_and_dispatch_one_message()
     if (result.is_error())
         return result;
 
-    LOCKER(m_lock);
+    Locker locker(m_lock);
 
     auto optional_completion = m_completions.get(header.tag);
     if (optional_completion.has_value()) {
@@ -647,7 +647,7 @@ void Plan9FS::thread_main()
         auto result = read_and_dispatch_one_message();
         if (result.is_error()) {
             // If we fail to read, wake up everyone with an error.
-            LOCKER(m_lock);
+            Locker locker(m_lock);
 
             for (auto& it : m_completions) {
                 it.value->result = result;
@@ -698,7 +698,7 @@ KResult Plan9FSInode::ensure_open_for_mode(int mode)
     u8 p9_mode = 0;
 
     {
-        LOCKER(m_lock);
+        Locker locker(m_lock);
 
         // If it's already open in this mode, we're done.
         if ((m_open_mode & mode) == mode)

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -801,6 +801,9 @@ static bool procfs$all(InodeIdentifier, KBufferBuilder& builder)
         auto thread_array = process_object.add_array("threads");
         process.for_each_thread([&](const Thread& thread) {
             auto thread_object = thread_array.add_object();
+#if LOCK_DEBUG
+            thread_object.add("lock_count", thread.lock_count());
+#endif
             thread_object.add("tid", thread.tid().value());
             thread_object.add("name", thread.name());
             thread_object.add("times_scheduled", thread.times_scheduled());

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -50,7 +50,7 @@ InodeIdentifier VFS::root_inode_id() const
 
 KResult VFS::mount(FS& file_system, Custody& mount_point, int flags)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
 
     auto& inode = mount_point.inode();
     dbgln("VFS: Mounting {} at {} (inode: {}) with flags {}",
@@ -66,7 +66,7 @@ KResult VFS::mount(FS& file_system, Custody& mount_point, int flags)
 
 KResult VFS::bind_mount(Custody& source, Custody& mount_point, int flags)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
 
     dbgln("VFS: Bind-mounting {} at {}", source.absolute_path(), mount_point.absolute_path());
     // FIXME: check that this is not already a mount point
@@ -77,7 +77,7 @@ KResult VFS::bind_mount(Custody& source, Custody& mount_point, int flags)
 
 KResult VFS::remount(Custody& mount_point, int new_flags)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
 
     dbgln("VFS: Remounting {}", mount_point.absolute_path());
 
@@ -91,7 +91,7 @@ KResult VFS::remount(Custody& mount_point, int new_flags)
 
 KResult VFS::unmount(Inode& guest_inode)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     dbgln("VFS: unmount called with inode {}", guest_inode.identifier());
 
     for (size_t i = 0; i < m_mounts.size(); ++i) {

--- a/Kernel/Lock.h
+++ b/Kernel/Lock.h
@@ -128,7 +128,6 @@ private:
 };
 
 #define LOCKER(...) Locker locker(__VA_ARGS__)
-#define RESTORE_LOCK(lock, ...) (lock).restore_lock(__VA_ARGS__)
 
 template<typename T>
 class Lockable {

--- a/Kernel/Lock.h
+++ b/Kernel/Lock.h
@@ -127,8 +127,6 @@ private:
     bool m_locked { true };
 };
 
-#define LOCKER(...) Locker locker(__VA_ARGS__)
-
 template<typename T>
 class Lockable {
 public:
@@ -142,7 +140,7 @@ public:
 
     [[nodiscard]] T lock_and_copy()
     {
-        LOCKER(m_lock);
+        Locker locker(m_lock);
         return m_resource;
     }
 

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -53,13 +53,13 @@ IPv4Socket::IPv4Socket(int type, int protocol)
     if (m_buffer_mode == BufferMode::Bytes) {
         m_scratch_buffer = KBuffer::create_with_size(65536);
     }
-    LOCKER(all_sockets().lock());
+    Locker locker(all_sockets().lock());
     all_sockets().resource().set(this);
 }
 
 IPv4Socket::~IPv4Socket()
 {
-    LOCKER(all_sockets().lock());
+    Locker locker(all_sockets().lock());
     all_sockets().resource().remove(this);
 }
 
@@ -108,7 +108,7 @@ KResult IPv4Socket::bind(Userspace<const sockaddr*> user_address, socklen_t addr
 
 KResult IPv4Socket::listen(size_t backlog)
 {
-    LOCKER(lock());
+    Locker locker(lock());
     int rc = allocate_local_port_if_needed();
     if (rc < 0)
         return EADDRINUSE;
@@ -172,7 +172,7 @@ int IPv4Socket::allocate_local_port_if_needed()
 
 KResultOr<size_t> IPv4Socket::sendto(FileDescription&, const UserOrKernelBuffer& data, size_t data_length, [[maybe_unused]] int flags, Userspace<const sockaddr*> addr, socklen_t addr_length)
 {
-    LOCKER(lock());
+    Locker locker(lock());
 
     if (addr && addr_length != sizeof(sockaddr_in))
         return EINVAL;
@@ -357,7 +357,7 @@ KResultOr<size_t> IPv4Socket::recvfrom(FileDescription& description, UserOrKerne
 
 bool IPv4Socket::did_receive(const IPv4Address& source_address, u16 source_port, KBuffer&& packet, const Time& packet_timestamp)
 {
-    LOCKER(lock());
+    Locker locker(lock());
 
     if (is_shut_down_for_reading())
         return false;

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -28,14 +28,14 @@ static Lockable<HashTable<NetworkAdapter*>>& all_adapters()
 
 void NetworkAdapter::for_each(Function<void(NetworkAdapter&)> callback)
 {
-    LOCKER(all_adapters().lock());
+    Locker locker(all_adapters().lock());
     for (auto& it : all_adapters().resource())
         callback(*it);
 }
 
 RefPtr<NetworkAdapter> NetworkAdapter::from_ipv4_address(const IPv4Address& address)
 {
-    LOCKER(all_adapters().lock());
+    Locker locker(all_adapters().lock());
     for (auto* adapter : all_adapters().resource()) {
         if (adapter->ipv4_address() == address)
             return adapter;

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -196,7 +196,7 @@ void handle_icmp(const EthernetFrameHeader& eth, const IPv4Packet& ipv4_packet, 
     {
         NonnullRefPtrVector<IPv4Socket> icmp_sockets;
         {
-            LOCKER(IPv4Socket::all_sockets().lock(), Lock::Mode::Shared);
+            Locker locker(IPv4Socket::all_sockets().lock(), Lock::Mode::Shared);
             for (auto* socket : IPv4Socket::all_sockets().resource()) {
                 if (socket->protocol() != (unsigned)IPv4Protocol::ICMP)
                     continue;
@@ -330,7 +330,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
         return;
     }
 
-    LOCKER(socket->lock());
+    Locker locker(socket->lock());
 
     VERIFY(socket->type() == SOCK_STREAM);
     VERIFY(socket->local_port() == tcp_packet.destination_port());
@@ -361,7 +361,7 @@ void handle_tcp(const IPv4Packet& ipv4_packet, const Time& packet_timestamp)
                 dmesgln("handle_tcp: couldn't create client socket");
                 return;
             }
-            LOCKER(client->lock());
+            Locker locker(client->lock());
             dbgln_if(TCP_DEBUG, "handle_tcp: created new client socket with tuple {}", client->tuple().to_string());
             client->set_sequence_number(1000);
             client->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -104,7 +104,7 @@ Lockable<HashMap<IPv4Address, MACAddress>>& arp_table()
 
 void update_arp_table(const IPv4Address& ip_addr, const MACAddress& addr)
 {
-    LOCKER(arp_table().lock());
+    Locker locker(arp_table().lock());
     arp_table().resource().set(ip_addr, addr);
     s_arp_table_block_condition->unblock(ip_addr, addr);
 
@@ -196,7 +196,7 @@ RoutingDecision route_to(const IPv4Address& target, const IPv4Address& source, c
         return { adapter, { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } };
 
     {
-        LOCKER(arp_table().lock());
+        Locker locker(arp_table().lock());
         auto addr = arp_table().resource().get(next_hop_ip);
         if (addr.has_value()) {
             dbgln_if(ROUTING_DEBUG, "Routing: Using cached ARP entry for {} ({})", next_hop_ip, addr.value().to_string());

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -51,7 +51,7 @@ void Socket::set_setup_state(SetupState new_setup_state)
 
 RefPtr<Socket> Socket::accept()
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (m_pending.is_empty())
         return nullptr;
     dbgln_if(SOCKET_DEBUG, "Socket({}) de-queueing connection", this);
@@ -69,7 +69,7 @@ RefPtr<Socket> Socket::accept()
 KResult Socket::queue_connection_from(NonnullRefPtr<Socket> peer)
 {
     dbgln_if(SOCKET_DEBUG, "Socket({}) queueing connection", this);
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (m_pending.size() >= m_backlog)
         return ECONNREFUSED;
     m_pending.append(peer);
@@ -240,7 +240,7 @@ KResultOr<size_t> Socket::write(FileDescription& description, u64, const UserOrK
 
 KResult Socket::shutdown(int how)
 {
-    LOCKER(lock());
+    Locker locker(lock());
     if (type() == SOCK_STREAM && !is_connected())
         return ENOTCONN;
     if (m_role == Role::Listener)
@@ -263,7 +263,7 @@ KResult Socket::stat(::stat& st) const
 
 void Socket::set_connected(bool connected)
 {
-    LOCKER(lock());
+    Locker locker(lock());
     if (m_connected == connected)
         return;
     m_connected = connected;

--- a/Kernel/Random.cpp
+++ b/Kernel/Random.cpp
@@ -125,7 +125,7 @@ bool get_good_random_bytes(u8* buffer, size_t buffer_size, bool allow_wait, bool
     if (can_wait && allow_wait) {
         for (;;) {
             {
-                LOCKER(KernelRng::the().lock());
+                Locker locker(KernelRng::the().lock());
                 if (kernel_rng.resource().get_random_bytes(buffer, buffer_size)) {
                     result = true;
                     break;

--- a/Kernel/Storage/AHCIPort.cpp
+++ b/Kernel/Storage/AHCIPort.cpp
@@ -105,7 +105,7 @@ void AHCIPort::handle_interrupt()
         } else {
             g_io_work->queue([this]() {
                 dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request handled", representative_port_index());
-                LOCKER(m_lock);
+                Locker locker(m_lock);
                 VERIFY(m_current_request);
                 VERIFY(m_current_scatter_list);
                 if (m_current_request->request_type() == AsyncBlockDeviceRequest::Read) {
@@ -133,7 +133,7 @@ bool AHCIPort::is_interrupts_enabled() const
 
 void AHCIPort::recover_from_fatal_error()
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     ScopedSpinLock lock(m_hard_lock);
     dmesgln("{}: AHCI Port {} fatal error, shutting down!", m_parent_handler->hba_controller()->pci_address(), representative_port_index());
     dmesgln("{}: AHCI Port {} fatal error, SError {}", m_parent_handler->hba_controller()->pci_address(), representative_port_index(), (u32)m_port_registers.serr);
@@ -217,7 +217,7 @@ void AHCIPort::eject()
 
 bool AHCIPort::reset()
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     ScopedSpinLock lock(m_hard_lock);
 
     dbgln_if(AHCI_DEBUG, "AHCI Port {}: Resetting", representative_port_index());
@@ -242,7 +242,7 @@ bool AHCIPort::reset()
 
 bool AHCIPort::initialize_without_reset()
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     ScopedSpinLock lock(m_hard_lock);
     dmesgln("AHCI Port {}: {}", representative_port_index(), try_disambiguate_sata_status());
     return initialize(lock);
@@ -454,7 +454,7 @@ Optional<AsyncDeviceRequest::RequestResult> AHCIPort::prepare_and_set_scatter_li
 
 void AHCIPort::start_request(AsyncBlockDeviceRequest& request)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request start", representative_port_index());
     VERIFY(!m_current_request);
     VERIFY(!m_current_scatter_list);
@@ -657,7 +657,7 @@ bool AHCIPort::identify_device(ScopedSpinLock<SpinLock<u8>>& main_lock)
 
 bool AHCIPort::shutdown()
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     ScopedSpinLock lock(m_hard_lock);
     rebase();
     set_interface_state(AHCI::DeviceDetectionInitialization::DisableInterface);

--- a/Kernel/Storage/IDEChannel.cpp
+++ b/Kernel/Storage/IDEChannel.cpp
@@ -90,7 +90,7 @@ UNMAP_AFTER_INIT IDEChannel::~IDEChannel()
 
 void IDEChannel::start_request(AsyncBlockDeviceRequest& request, bool is_slave, u16 capabilities)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     VERIFY(m_current_request.is_null());
 
     dbgln_if(PATA_DEBUG, "IDEChannel::start_request");
@@ -117,7 +117,7 @@ void IDEChannel::complete_current_request(AsyncDeviceRequest::RequestResult resu
     // before Processor::deferred_call_queue returns!
     g_io_work->queue([this, result]() {
         dbgln_if(PATA_DEBUG, "IDEChannel::complete_current_request result: {}", (int)result);
-        LOCKER(m_lock);
+        Locker locker(m_lock);
         VERIFY(m_current_request);
         auto current_request = m_current_request;
         m_current_request.clear();
@@ -205,7 +205,7 @@ void IDEChannel::handle_irq(const RegisterState&)
     // This is important so that we can safely access the buffers, which could
     // trigger page faults
     g_io_work->queue([this]() {
-        LOCKER(m_lock);
+        Locker locker(m_lock);
         ScopedSpinLock lock(m_request_lock);
         if (m_current_request->request_type() == AsyncBlockDeviceRequest::Read) {
             dbgln_if(PATA_DEBUG, "IDEChannel: Read block {}/{}", m_current_request_block_index, m_current_request->block_count());

--- a/Kernel/Storage/RamdiskDevice.cpp
+++ b/Kernel/Storage/RamdiskDevice.cpp
@@ -35,7 +35,7 @@ const char* RamdiskDevice::class_name() const
 
 void RamdiskDevice::start_request(AsyncBlockDeviceRequest& request)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
 
     u8* base = m_region->vaddr().as_ptr();
     size_t size = m_region->size();

--- a/Kernel/Syscalls/hostname.cpp
+++ b/Kernel/Syscalls/hostname.cpp
@@ -16,7 +16,7 @@ KResultOr<int> Process::sys$gethostname(Userspace<char*> buffer, ssize_t size)
     REQUIRE_PROMISE(stdio);
     if (size < 0)
         return EINVAL;
-    LOCKER(*g_hostname_lock, Lock::Mode::Shared);
+    Locker locker(*g_hostname_lock, Lock::Mode::Shared);
     if ((size_t)size < (g_hostname->length() + 1))
         return ENAMETOOLONG;
     if (!copy_to_user(buffer, g_hostname->characters(), g_hostname->length() + 1))
@@ -31,7 +31,7 @@ KResultOr<int> Process::sys$sethostname(Userspace<const char*> hostname, ssize_t
         return EPERM;
     if (length < 0)
         return EINVAL;
-    LOCKER(*g_hostname_lock, Lock::Mode::Exclusive);
+    Locker locker(*g_hostname_lock, Lock::Mode::Exclusive);
     if (length > 64)
         return ENAMETOOLONG;
     auto copied_hostname = copy_string_from_user(hostname, length);

--- a/Kernel/Syscalls/uname.cpp
+++ b/Kernel/Syscalls/uname.cpp
@@ -15,7 +15,7 @@ KResultOr<int> Process::sys$uname(Userspace<utsname*> user_buf)
 
     REQUIRE_PROMISE(stdio);
 
-    LOCKER(*g_hostname_lock, Lock::Mode::Shared);
+    Locker locker(*g_hostname_lock, Lock::Mode::Shared);
     if (g_hostname->length() + 1 > sizeof(utsname::nodename))
         return ENAMETOOLONG;
 

--- a/Kernel/TTY/PTYMultiplexer.cpp
+++ b/Kernel/TTY/PTYMultiplexer.cpp
@@ -36,7 +36,7 @@ UNMAP_AFTER_INIT PTYMultiplexer::~PTYMultiplexer()
 
 KResultOr<NonnullRefPtr<FileDescription>> PTYMultiplexer::open(int options)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     if (m_freelist.is_empty())
         return EBUSY;
     auto master_index = m_freelist.take_last();
@@ -52,7 +52,7 @@ KResultOr<NonnullRefPtr<FileDescription>> PTYMultiplexer::open(int options)
 
 void PTYMultiplexer::notify_master_destroyed(Badge<MasterPTY>, unsigned index)
 {
-    LOCKER(m_lock);
+    Locker locker(m_lock);
     m_freelist.append(index);
     dbgln_if(PTMX_DEBUG, "PTYMultiplexer: {} added to freelist", index);
 }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -360,8 +360,10 @@ void Thread::finalize()
     if (lock_count() > 0) {
         dbgln("Thread {} leaking {} Locks!", *this, lock_count());
         ScopedSpinLock list_lock(m_holding_locks_lock);
-        for (auto& info : m_holding_locks_list)
-            dbgln(" - {} @ {} locked at {}:{} count: {}", info.lock->name(), info.lock, info.file, info.line, info.count);
+        for (auto& info : m_holding_locks_list) {
+            const auto& location = info.source_location;
+            dbgln(" - Lock: \"{}\" @ {} locked in function \"{}\" at \"{}:{}\" with a count of: {}", info.lock->name(), info.lock, location.function_name(), location.file_name(), location.line_number(), info.count);
+        }
         VERIFY_NOT_REACHED();
     }
 #endif

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -310,7 +310,7 @@ void Thread::relock_process(LockMode previous_locked, u32 lock_count_to_restore)
 
     if (previous_locked != LockMode::Unlocked) {
         // We've unblocked, relock the process if needed and carry on.
-        RESTORE_LOCK(process().big_lock(), previous_locked, lock_count_to_restore);
+        process().big_lock().restore_lock(previous_locked, lock_count_to_restore);
     }
 }
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -12,6 +12,7 @@
 #include <AK/IntrusiveList.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
+#include <AK/SourceLocation.h>
 #include <AK/String.h>
 #include <AK/Time.h>
 #include <AK/Vector.h>
@@ -1066,7 +1067,7 @@ public:
     RecursiveSpinLock& get_lock() const { return m_lock; }
 
 #if LOCK_DEBUG
-    void holding_lock(Lock& lock, int refs_delta, const char* file = nullptr, int line = 0)
+    void holding_lock(Lock& lock, int refs_delta, const SourceLocation& location)
     {
         VERIFY(refs_delta != 0);
         m_holding_locks.fetch_add(refs_delta, AK::MemoryOrder::memory_order_relaxed);
@@ -1082,7 +1083,7 @@ public:
                 }
             }
             if (!have_existing)
-                m_holding_locks_list.append({ &lock, file ? file : "unknown", line, 1 });
+                m_holding_locks_list.append({ &lock, location, 1 });
         } else {
             VERIFY(refs_delta < 0);
             bool found = false;
@@ -1208,8 +1209,7 @@ private:
 #if LOCK_DEBUG
     struct HoldingLockInfo {
         Lock* lock;
-        const char* file;
-        int line;
+        SourceLocation source_location;
         unsigned count;
     };
     Atomic<u32> m_holding_locks { 0 };

--- a/Kernel/VM/AnonymousVMObject.cpp
+++ b/Kernel/VM/AnonymousVMObject.cpp
@@ -161,7 +161,7 @@ AnonymousVMObject::~AnonymousVMObject()
 
 int AnonymousVMObject::purge()
 {
-    LOCKER(m_paging_lock);
+    Locker locker(m_paging_lock);
     return purge_impl();
 }
 

--- a/Kernel/VM/InodeVMObject.cpp
+++ b/Kernel/VM/InodeVMObject.cpp
@@ -53,7 +53,7 @@ size_t InodeVMObject::amount_dirty() const
 
 int InodeVMObject::release_all_clean_pages()
 {
-    LOCKER(m_paging_lock);
+    Locker locker(m_paging_lock);
     return release_all_clean_pages_impl();
 }
 

--- a/Kernel/VM/Region.cpp
+++ b/Kernel/VM/Region.cpp
@@ -451,7 +451,7 @@ PageFaultResponse Region::handle_zero_fault(size_t page_index_in_region)
     VERIFY_INTERRUPTS_DISABLED();
     VERIFY(vmobject().is_anonymous());
 
-    LOCKER(vmobject().m_paging_lock);
+    Locker locker(vmobject().m_paging_lock);
 
     auto& page_slot = physical_page_slot(page_index_in_region);
     auto page_index_in_vmobject = translate_to_vmobject_page(page_index_in_region);
@@ -514,7 +514,7 @@ PageFaultResponse Region::handle_inode_fault(size_t page_index_in_region, Scoped
     VERIFY(!s_mm_lock.own_lock());
     VERIFY(!g_scheduler_lock.own_lock());
 
-    LOCKER(vmobject().m_paging_lock);
+    Locker locker(vmobject().m_paging_lock);
 
     mm_lock.lock();
 


### PR DESCRIPTION
There are a hand full of changes here,  all around improving the `LOCK_DEBUG` facilities / API.

- __Kernel: Fix LOCK_DEBUG feature to work again__

    - UBSAN detected cases where we were calling current_thread->holding_lock
      but current_thread was nullptr.

    - Fix Lock::force_unlock_if_locked to not pass the correct ref delta to
      holding_lock(..).

-  __Kernel: Add lock_count to procfs$all when LOCK_DEBUG is enabled.__

- __AK: Add default constructor to SourceLocation__

- __Kernel: Utilize AK::SourceLocation for LOCK_DEBUG instrumentation.__

    The previous `LOCKER(..)` instrumentation only covered some of the
    cases where a lock is actually acquired. By utilizing the new
    `AK::SourceLocation` functionality we can now reliably instrument
    all calls to lock automatically.

    Other changes:
    - Tweak the message in `Thread::finalize()` which dumps leaked lock
      so it's more readable and includes the function information that is
      now available.

    - Make the `LOCKER(..)` define a no-op, it will be cleaned up in a
      follow up change.

- __Kernel: Remove the now defunct `RESTORE_LOCK(..)` macro.__

- __Kernel: Remove the now defunct `LOCKER(..)` macro.__