### PR TITLE
LibELF+Kernel: Support initializing values of TLS data

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -388,7 +388,7 @@ public:
     KResultOr<int> sys$recvfd(int sockfd, int options);
     KResultOr<long> sys$sysconf(int name);
     KResultOr<int> sys$disown(ProcessID);
-    KResultOr<FlatPtr> sys$allocate_tls(size_t);
+    KResultOr<FlatPtr> sys$allocate_tls(Userspace<const char*> initial_data, size_t);
     KResultOr<int> sys$prctl(int option, FlatPtr arg1, FlatPtr arg2);
     KResultOr<int> sys$set_coredump_metadata(Userspace<const Syscall::SC_set_coredump_metadata_params*>);
     KResultOr<int> sys$anon_create(size_t, int options);

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -619,7 +619,7 @@ KResultOr<FlatPtr> Process::sys$allocate_tls(size_t size)
     if (!range.has_value())
         return ENOMEM;
 
-    auto region_or_error = space().allocate_region(range.value(), String(), PROT_READ | PROT_WRITE);
+    auto region_or_error = space().allocate_region(range.value(), String("Master TLS"), PROT_READ | PROT_WRITE);
     if (region_or_error.is_error())
         return region_or_error.error().error();
 

--- a/Userland/Libraries/LibC/mman.cpp
+++ b/Userland/Libraries/LibC/mman.cpp
@@ -73,9 +73,9 @@ int madvise(void* address, size_t size, int advice)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-void* allocate_tls(size_t size)
+void* allocate_tls(const char* initial_data, size_t size)
 {
-    ptrdiff_t rc = syscall(SC_allocate_tls, size);
+    ptrdiff_t rc = syscall(SC_allocate_tls, initial_data, size);
     if (rc < 0 && -rc < EMAXERRNO) {
         errno = -rc;
         return MAP_FAILED;

--- a/Userland/Libraries/LibC/mman.h
+++ b/Userland/Libraries/LibC/mman.h
@@ -40,6 +40,6 @@ int munmap(void*, size_t);
 int mprotect(void*, size_t, int prot);
 int set_mmap_name(void*, size_t, const char*);
 int madvise(void*, size_t, int advice);
-void* allocate_tls(size_t);
+void* allocate_tls(const char* initial_data, size_t);
 
 __END_DECLS

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -170,7 +170,7 @@ static void allocate_tls()
 
     // Initialize TLS data
     for (const auto& entry : s_loaders) {
-        entry.value->copy_initial_tls_data_into(initial_tls_data, s_total_tls_size);
+        entry.value->copy_initial_tls_data_into(initial_tls_data);
     }
 
     void* master_tls = ::allocate_tls((char*)initial_tls_data.data(), initial_tls_data.size());
@@ -282,14 +282,14 @@ static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> load_main_library(co
     }
 
     for (auto& loader : loaders) {
-        bool success = loader.link(flags, s_total_tls_size);
+        bool success = loader.link(flags);
         if (!success) {
             return DlErrorMessage { String::formatted("Failed to link library {}", loader.filename()) };
         }
     }
 
     for (auto& loader : loaders) {
-        auto result = loader.load_stage_3(flags, s_total_tls_size);
+        auto result = loader.load_stage_3(flags);
         VERIFY(!result.is_error());
         auto& object = result.value();
 

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -88,7 +88,7 @@ static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> map_library(const St
     s_loaders.set(get_library_name(filename), *loader);
 
     loader->set_tls_offset(s_current_tls_offset);
-    s_current_tls_offset += loader->tls_size();
+    s_current_tls_offset += loader->tls_size_of_current_object();
 
     return loader;
 }
@@ -156,8 +156,8 @@ static void allocate_tls()
 {
     size_t total_tls_size = 0;
     for (const auto& data : s_loaders) {
-        dbgln_if(DYNAMIC_LOAD_DEBUG, "{}: TLS Size: {}", data.key, data.value->tls_size());
-        total_tls_size += data.value->tls_size();
+        dbgln_if(DYNAMIC_LOAD_DEBUG, "{}: TLS Size: {}", data.key, data.value->tls_size_of_current_object());
+        total_tls_size += data.value->tls_size_of_current_object();
     }
     if (total_tls_size) {
         [[maybe_unused]] void* tls_address = ::allocate_tls(total_tls_size);
@@ -420,7 +420,7 @@ void ELF::DynamicLinker::linker_main(String&& main_program_name, int main_progra
 
     dbgln_if(DYNAMIC_LOAD_DEBUG, "loaded all dependencies");
     for ([[maybe_unused]] auto& lib : s_loaders) {
-        dbgln_if(DYNAMIC_LOAD_DEBUG, "{} - tls size: {}, tls offset: {}", lib.key, lib.value->tls_size(), lib.value->tls_offset());
+        dbgln_if(DYNAMIC_LOAD_DEBUG, "{} - tls size: {}, tls offset: {}", lib.key, lib.value->tls_size_of_current_object(), lib.value->tls_offset());
     }
 
     allocate_tls();

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -64,7 +64,7 @@ DynamicLoader::DynamicLoader(int fd, String filename, void* data, size_t size)
     , m_file_data(data)
     , m_elf_image((u8*)m_file_data, m_file_size)
 {
-    m_tls_size = calculate_tls_size();
+    m_tls_size_of_current_object = calculate_tls_size();
     m_valid = validate();
 }
 
@@ -141,7 +141,7 @@ RefPtr<DynamicObject> DynamicLoader::map()
 
     m_dynamic_object = DynamicObject::create(m_filename, m_base_address, m_dynamic_section_address);
     m_dynamic_object->set_tls_offset(m_tls_offset);
-    m_dynamic_object->set_tls_size(m_tls_size);
+    m_dynamic_object->set_tls_size(m_tls_size_of_current_object);
 
     return m_dynamic_object;
 }

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -78,6 +78,7 @@ public:
     bool is_dynamic() const { return m_elf_image.is_dynamic(); }
 
     static Optional<DynamicObject::SymbolLookupResult> lookup_symbol(const ELF::DynamicObject::Symbol&);
+    void copy_initial_tls_data_into(ByteBuffer& buffer, size_t total_tls_size) const;
 
 private:
     DynamicLoader(int fd, String filename, void* file_data, size_t file_size);

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -130,6 +130,7 @@ private:
     };
     RelocationResult do_relocation(size_t total_tls_size, const DynamicObject::Relocation&, ShouldInitializeWeak should_initialize_weak);
     size_t calculate_tls_size() const;
+    ssize_t negative_offset_from_tls_block_end(size_t value_of_symbol, size_t tls_offset, size_t total_tls_size) const;
 
     String m_filename;
     String m_program_interpreter;
@@ -150,7 +151,7 @@ private:
     VirtualAddress m_dynamic_section_address;
 
     size_t m_tls_offset { 0 };
-    size_t m_tls_size { 0 };
+    size_t m_tls_size { 0 }; // TLS size of the current object
 
     Vector<DynamicObject::Relocation> m_unresolved_relocations;
 

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -54,13 +54,13 @@ public:
     // Note that the DynamicObject will not be linked yet. Callers are responsible for calling link() to finish it.
     RefPtr<DynamicObject> map();
 
-    bool link(unsigned flags, size_t total_tls_size);
+    bool link(unsigned flags);
 
     // Stage 2 of loading: dynamic object loading and primary relocations
-    bool load_stage_2(unsigned flags, size_t total_tls_size);
+    bool load_stage_2(unsigned flags);
 
     // Stage 3 of loading: lazy relocations
-    Result<NonnullRefPtr<DynamicObject>, DlErrorMessage> load_stage_3(unsigned flags, size_t total_tls_size);
+    Result<NonnullRefPtr<DynamicObject>, DlErrorMessage> load_stage_3(unsigned flags);
 
     // Stage 4 of loading: initializers
     void load_stage_4();
@@ -78,7 +78,7 @@ public:
     bool is_dynamic() const { return m_elf_image.is_dynamic(); }
 
     static Optional<DynamicObject::SymbolLookupResult> lookup_symbol(const ELF::DynamicObject::Symbol&);
-    void copy_initial_tls_data_into(ByteBuffer& buffer, size_t total_tls_size) const;
+    void copy_initial_tls_data_into(ByteBuffer& buffer) const;
 
 private:
     DynamicLoader(int fd, String filename, void* file_data, size_t file_size);
@@ -113,10 +113,10 @@ private:
     void load_program_headers();
 
     // Stage 2
-    void do_main_relocations(size_t total_tls_size);
+    void do_main_relocations();
 
     // Stage 3
-    void do_lazy_relocations(size_t total_tls_size);
+    void do_lazy_relocations();
     void setup_plt_trampoline();
 
     // Stage 4
@@ -129,9 +129,9 @@ private:
         Success = 1,
         ResolveLater = 2,
     };
-    RelocationResult do_relocation(size_t total_tls_size, const DynamicObject::Relocation&, ShouldInitializeWeak should_initialize_weak);
+    RelocationResult do_relocation(const DynamicObject::Relocation&, ShouldInitializeWeak should_initialize_weak);
     size_t calculate_tls_size() const;
-    ssize_t negative_offset_from_tls_block_end(size_t value_of_symbol, size_t tls_offset, size_t total_tls_size) const;
+    ssize_t negative_offset_from_tls_block_end(size_t value_of_symbol, size_t tls_offset, size_t symbol_size) const;
 
     String m_filename;
     String m_program_interpreter;

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -66,7 +66,7 @@ public:
     void load_stage_4();
 
     void set_tls_offset(size_t offset) { m_tls_offset = offset; };
-    size_t tls_size() const { return m_tls_size; }
+    size_t tls_size_of_current_object() const { return m_tls_size_of_current_object; }
     size_t tls_offset() const { return m_tls_offset; }
     const ELF::Image& image() const { return m_elf_image; }
 
@@ -151,7 +151,7 @@ private:
     VirtualAddress m_dynamic_section_address;
 
     size_t m_tls_offset { 0 };
-    size_t m_tls_size { 0 }; // TLS size of the current object
+    size_t m_tls_size_of_current_object { 0 };
 
     Vector<DynamicObject::Relocation> m_unresolved_relocations;
 

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -440,7 +440,7 @@ auto DynamicObject::lookup_symbol(const HashSymbol& symbol) const -> Optional<Sy
     auto symbol_result = result.value();
     if (symbol_result.is_undefined())
         return {};
-    return SymbolLookupResult { symbol_result.value(), symbol_result.address(), symbol_result.bind(), this };
+    return SymbolLookupResult { symbol_result.value(), symbol_result.size(), symbol_result.address(), symbol_result.bind(), this };
 }
 
 NonnullRefPtr<DynamicObject> DynamicObject::create(const String& filename, VirtualAddress base_address, VirtualAddress dynamic_section_address)

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -264,6 +264,7 @@ public:
 
     struct SymbolLookupResult {
         FlatPtr value { 0 };
+        size_t size { 0 };
         VirtualAddress address;
         unsigned bind { STB_LOCAL };
         const ELF::DynamicObject* dynamic_object { nullptr }; // The object in which the symbol is defined


### PR DESCRIPTION
We now support initializing TLS data with the values that exist in `PT_TLS` segments, i.e doing `__thread int myvar = 0xdeadbeef`.
Previously, TLS data was always zero-initialized.

Test program:
```
// tls-test.cpp:
#include <AK/Format.h>
#include <LibThread/Thread.h>
#include <MyLib/lib.h>

static int foo()
{
    outln("3: {:08x}", tls_var);
    return 0;
}

int main()
{
    outln("1: {:08x}", tls_var);
    tls_var = 0xbaddcafe;
    outln("2: {:08x}", tls_var);
    auto thread = LibThread::Thread::construct(foo);
    thread->start();
    return 0;
}

// lib.h:
#include <stdint.h>
extern __thread uint32_t tls_var;

// lib.cpp:
#include "lib.h"
__thread uint32_t tls_var = 0xdeadbeef;
```
// result:
```
1: deadbeef
2: baddcafe
3: deadbeef
```

cc @gunnarbeutner @ADKaster 