### PR TITLE
LibGUI: Prevent a Painter's clip_rect from being outside of its target

### DIFF
--- a/Userland/Libraries/LibGUI/Painter.cpp
+++ b/Userland/Libraries/LibGUI/Painter.cpp
@@ -21,9 +21,8 @@ Painter::Painter(Widget& widget)
     state().font = &widget.font();
     auto origin_rect = widget.window_relative_rect();
     state().translation = origin_rect.location();
-    state().clip_rect = origin_rect;
-    m_clip_origin = origin_rect;
-    state().clip_rect.intersect(m_target->rect());
+    state().clip_rect = origin_rect.intersected(m_target->rect());
+    m_clip_origin = state().clip_rect;
 }
 
 }


### PR DESCRIPTION
Previously a Painter's m_clip_origin field was initialized to a widget's window_relative_rect, which is not ensured to be within the target rect.
m_clip_origin is normally not used for clipping, but after calling clear_clip_rect the clip rect that IS used for clipping gets reset to m_clip_origin (so an invalid state is entered).
Now the window_relative_rect will be clipped by the target rect first, and will only then be used to initialize both the active clip_rect and m_clip_origin.