### PR TITLE
LibGfx: Add basic support for bidirectional text rendering

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -8,7 +8,8 @@ else()
 endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual -Wno-user-defined-literals")
+    # Clang's default constexpr-steps limit is 1048576(2^20), GCC doesn't have one
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual -Wno-user-defined-literals -fconstexpr-steps=16777216")
 
     if (ENABLE_ADDRESS_SANITIZER)
         add_definitions(-fsanitize=address -fno-omit-frame-pointer)

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SOURCES
     Size.cpp
     StylePainter.cpp
     SystemTheme.cpp
+    TextDirection.cpp
     Triangle.cpp
     Typeface.cpp
     WindowTheme.cpp

--- a/Userland/Libraries/LibGfx/TextDirection.cpp
+++ b/Userland/Libraries/LibGfx/TextDirection.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Array.h>
+#include <LibGfx/TextDirection.h>
+
+namespace Gfx {
+
+// FIXME: These should be parsed from the official UnicodeData.txt that specifies the class for each character (this function doesnt take into account a large amount of characters)
+static consteval Array<BidirectionalClass, 0x1F000> generate_char_bidi_class_lookup_table()
+{
+    Array<BidirectionalClass, 0x1F000> lookup_table {};
+    for (u32 ch = 0; ch < 0x1F000; ch++) {
+        auto char_class = BidirectionalClass::STRONG_LTR;
+        if ((ch >= 0x600 && ch <= 0x7BF) || (ch >= 0x8A0 && ch <= 0x8FF) || (ch >= 0xFB50 && ch <= 0xFDCF) || (ch >= 0xFDF0 && ch <= 0xFDFF) || (ch >= 0xFE70 && ch <= 0xFEFF) || (ch >= 0x1EE00 && ch <= 0x1EEFF))
+            char_class = BidirectionalClass::STRONG_RTL; // Arabic RTL
+        if ((ch >= 0x590 && ch <= 0x5FF) || (ch >= 0x7C0 && ch <= 0x89F) || (ch == 0x200F) || (ch >= 0xFB1D && ch <= 0xFB4F) || (ch >= 0x10800 && ch <= 0x10FFF) || (ch >= 0x1E800 && ch <= 0x1EDFF) || (ch >= 0x1EF00 && ch <= 0x1EFFF))
+            char_class = BidirectionalClass::STRONG_RTL; // Hebrew RTL
+        if ((ch >= 0x30 && ch <= 0x39) || (ch >= 0x660 && ch <= 0x669) || (ch >= 0x10D30 && ch <= 0x10E7E))
+            char_class = BidirectionalClass::WEAK_NUMBERS; // Numerals
+        if ((ch >= 0x23 && ch <= 0x25) || (ch >= 0x2B && ch <= 0x2F) || (ch == 0x3A))
+            char_class = BidirectionalClass::WEAK_SEPARATORS; // Seperators
+        if ((ch >= 0x9 && ch <= 0xD) || (ch >= 0x1C && ch <= 0x22) || (ch >= 0x26 && ch <= 0x2A) || (ch >= 0x3B && ch <= 0x40) || (ch >= 0x5B && ch <= 0x60) || (ch >= 0x7B && ch <= 0x7E))
+            char_class = BidirectionalClass::NEUTRAL;
+        lookup_table[ch] = char_class;
+    }
+    return lookup_table;
+}
+constexpr Array<BidirectionalClass, 0x1F000> char_bidi_class_lookup_table = generate_char_bidi_class_lookup_table();
+
+}

--- a/Userland/Libraries/LibGfx/TextDirection.h
+++ b/Userland/Libraries/LibGfx/TextDirection.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Utf32View.h>
+#include <AK/Vector.h>
+
+namespace Gfx {
+
+enum class BidirectionalClass {
+    STRONG_LTR,
+    STRONG_RTL,
+    WEAK_NUMBERS,
+    WEAK_SEPARATORS,
+    NEUTRAL,
+};
+
+extern const Array<BidirectionalClass, 0x1F000> char_bidi_class_lookup_table;
+
+constexpr BidirectionalClass get_char_bidi_class(u32 ch)
+{
+    if (ch >= char_bidi_class_lookup_table.size())
+        return BidirectionalClass::STRONG_LTR;
+    return char_bidi_class_lookup_table[ch];
+}
+
+// FIXME: These should be parsed from the official BidiMirroring.txt that specifies the mirroring character for each character (this function doesnt take into account a large amount of characters)
+constexpr u32 get_mirror_char(u32 ch)
+{
+    if (ch == 0x28)
+        return 0x29;
+    if (ch == 0x29)
+        return 0x28;
+    if (ch == 0x3C)
+        return 0x3E;
+    if (ch == 0x3E)
+        return 0x3C;
+    if (ch == 0x5B)
+        return 0x5D;
+    if (ch == 0x7B)
+        return 0x7D;
+    if (ch == 0x7D)
+        return 0x7B;
+    if (ch == 0xAB)
+        return 0xBB;
+    if (ch == 0xBB)
+        return 0xAB;
+    if (ch == 0x2039)
+        return 0x203A;
+    if (ch == 0x203A)
+        return 0x2039;
+    return ch;
+}
+
+enum class TextDirection {
+    LTR,
+    RTL,
+};
+
+constexpr TextDirection bidi_class_to_direction(BidirectionalClass class_)
+{
+    VERIFY(class_ != BidirectionalClass::NEUTRAL);
+    if (class_ == BidirectionalClass::STRONG_LTR || class_ == BidirectionalClass::WEAK_NUMBERS || class_ == BidirectionalClass::WEAK_SEPARATORS)
+        return TextDirection::LTR;
+    return TextDirection::RTL;
+}
+
+// Assumes the text has a homogeneous direction
+template<typename TextType>
+constexpr TextDirection get_text_direction(TextType text)
+{
+    for (u32 code_point : text) {
+        auto char_direction = get_char_bidi_class(code_point);
+        if (char_direction != BidirectionalClass::NEUTRAL)
+            return bidi_class_to_direction(char_direction);
+    }
+    return TextDirection::LTR;
+}
+
+class DirectionalRun {
+public:
+    DirectionalRun(Vector<u32> code_points, u8 embedding_level)
+        : m_code_points(move(code_points))
+        , m_embedding_level(embedding_level)
+    {
+    }
+
+    [[nodiscard]] Utf32View text() const { return { m_code_points.data(), m_code_points.size() }; }
+    [[nodiscard]] u8 embedding_level() const { return m_embedding_level; }
+    [[nodiscard]] TextDirection direction() const { return (m_embedding_level % 2) == 0 ? TextDirection::LTR : TextDirection::RTL; }
+
+    Vector<u32>& code_points() { return m_code_points; }
+
+private:
+    Vector<u32> m_code_points;
+    u8 m_embedding_level;
+};
+
+}


### PR DESCRIPTION
This adds a *very* simplified version of the UNICODE BIDIRECTIONAL ALGORITHM (https://www.unicode.org/reports/tr9/), that can render most bidirectional text but also produces awkward results in a large amount of edge cases, and as such, this should probably be replaced with a fully spec compliant implementation at some point. (but since it at least renders simple bidirectional text like google.co.il just fine, i think its good enough to be merged and iterated upon.)

note for reviewers: Due to having to deal with the generic text type only supporting iteration (since we support both Utf32View which supports random access, and Utf8View which does not), i feel like this came out very allocy, so suggestions about that would be appreciated :)