### PR TITLE
LaunchServer: Fix argument order to FileManager

### DIFF
--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -283,9 +283,9 @@ bool Launcher::open_file_url(const URL& url)
         if (url.fragment().is_empty()) {
             fm_arguments.append(url.path());
         } else {
-            fm_arguments.append(String::formatted("{}/{}", url.path(), url.fragment()));
             fm_arguments.append("-s");
             fm_arguments.append("-r");
+            fm_arguments.append(String::formatted("{}/{}", url.path(), url.fragment()));
         }
         return spawn("/bin/FileManager", fm_arguments);
     }


### PR DESCRIPTION
Correct the order we pass the arguments to the FileManager so opening file:// URLs works.

The path is a positional argument that was passed after the flags.We need to make sure the flags are passed before positional arguments.