### PR TITLE
VimEditingEngine: Fix visual selection wrapping

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -151,6 +151,20 @@ bool EditingEngine::on_key(const KeyEvent& event)
     return false;
 }
 
+TextPosition EditingEngine::get_next_valid_position(const TextPosition& position)
+{
+    size_t new_line = position.line();
+    size_t new_column = position.column();
+    if (position.column() < m_editor->line(position.line()).length()) {
+        new_line = position.line();
+        new_column = position.column() + 1;
+    } else if (position.line() != m_editor->line_count() - 1) {
+        new_line = position.line() + 1;
+        new_column = 0;
+    }
+    return { new_line, new_column };
+}
+
 void EditingEngine::move_one_left(const KeyEvent& event)
 {
     if (m_editor->cursor().column() > 0) {
@@ -167,17 +181,9 @@ void EditingEngine::move_one_left(const KeyEvent& event)
 
 void EditingEngine::move_one_right(const KeyEvent& event)
 {
-    int new_line = m_editor->cursor().line();
-    int new_column = m_editor->cursor().column();
-    if (m_editor->cursor().column() < m_editor->current_line().length()) {
-        new_line = m_editor->cursor().line();
-        new_column = m_editor->cursor().column() + 1;
-    } else if (m_editor->cursor().line() != m_editor->line_count() - 1) {
-        new_line = m_editor->cursor().line() + 1;
-        new_column = 0;
-    }
     m_editor->toggle_selection_if_needed_for_event(event.shift());
-    m_editor->set_cursor(new_line, new_column);
+    auto next_position = get_next_valid_position(m_editor->cursor());
+    m_editor->set_cursor(next_position);
 }
 
 void EditingEngine::move_to_previous_span(const KeyEvent& event)

--- a/Userland/Libraries/LibGUI/EditingEngine.h
+++ b/Userland/Libraries/LibGUI/EditingEngine.h
@@ -36,6 +36,7 @@ protected:
 
     WeakPtr<TextEditor> m_editor;
 
+    TextPosition get_next_valid_position(const TextPosition& position);
     void move_one_left(const KeyEvent& event);
     void move_one_right(const KeyEvent& event);
     void move_one_up(const KeyEvent& event);

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -446,7 +446,7 @@ void VimEditingEngine::switch_to_visual_mode()
     m_editor->reset_cursor_blink();
     m_previous_key = {};
     m_selection_start_position = m_editor->cursor();
-    m_editor->selection()->set(m_editor->cursor(), { m_editor->cursor().line(), m_editor->cursor().column() + 1 });
+    m_editor->selection()->set(m_editor->cursor(), get_next_valid_position(m_editor->cursor()));
     m_editor->did_update_selection();
 }
 
@@ -455,7 +455,7 @@ void VimEditingEngine::update_selection_on_cursor_move()
     auto cursor = m_editor->cursor();
     auto start = m_selection_start_position < cursor ? m_selection_start_position : cursor;
     auto end = m_selection_start_position < cursor ? cursor : m_selection_start_position;
-    end.set_column(end.column() + 1);
+    end = get_next_valid_position(end);
     m_editor->selection()->set(start, end);
     m_editor->did_update_selection();
 }


### PR DESCRIPTION
Hello :wave: 

This PR fixes #6014, the issue was that the wrapping was not considered. This created an invalid selection.

PS: I noticed that you can currently only yank a multi-line selection. Deleting/Editing crashes TextEditor, should I fix this in this PR or open an issue and another PR ?