### PR TITLE
AK/GenericLexer: Add a Position struct and keep track of the line&column numbers

### DIFF
--- a/AK/GenericLexer.cpp
+++ b/AK/GenericLexer.cpp
@@ -10,6 +10,7 @@
 #include <AK/StringBuilder.h>
 
 namespace AK {
+
 // Consume a number of characters
 StringView GenericLexer::consume(size_t count)
 {

--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -22,18 +22,22 @@ public:
 
     StringView remaining() const { return m_input.substring_view(m_index); }
 
+    // Tells whether the parser's index has reached input's end
     constexpr bool is_eof() const { return m_index >= m_input.length(); }
 
+    // Returns the current character at the parser index, plus `offset` if specified
     constexpr char peek(size_t offset = 0) const
     {
         return (m_index + offset < m_input.length()) ? m_input[m_index + offset] : '\0';
     }
 
+    // Tests the next character in the input
     constexpr bool next_is(char expected) const
     {
         return peek() == expected;
     }
 
+    // Tests if the `expected` StringView comes next in the input
     constexpr bool next_is(StringView expected) const
     {
         for (size_t i = 0; i < expected.length(); ++i)
@@ -42,6 +46,7 @@ public:
         return true;
     }
 
+    // Tests if the `expected` c-string comes next in the input
     constexpr bool next_is(const char* expected) const
     {
         for (size_t i = 0; expected[i] != '\0'; ++i)
@@ -50,18 +55,21 @@ public:
         return true;
     }
 
+    // Go back to the previous character
     constexpr void retreat()
     {
         VERIFY(m_index > 0);
         --m_index;
     }
 
+    // Consume a character and advance the parser index
     constexpr char consume()
     {
         VERIFY(!is_eof());
         return m_input[m_index++];
     }
 
+    // Consume the given character if it is next in the input
     template<typename T>
     constexpr bool consume_specific(const T& next)
     {
@@ -76,11 +84,13 @@ public:
         return true;
     }
 
+    // Consume the given String if it is next in the input
     bool consume_specific(const String& next)
     {
         return consume_specific(StringView { next });
     }
 
+    // Consume the given c-string if it is next in the input
     constexpr bool consume_specific(const char* next)
     {
         return consume_specific(StringView { next });
@@ -109,12 +119,15 @@ public:
     StringView consume_quoted_string(char escape_char = 0);
     String consume_and_unescape_string(char escape_char = '\\');
 
+    // Ignore a number of characters (1 by default)
     constexpr void ignore(size_t count = 1)
     {
         count = min(count, m_input.length() - m_index);
         m_index += count;
     }
 
+    // Ignore characters until `stop` is peek'd
+    // The `stop` character is ignored as it is user-defined
     constexpr void ignore_until(char stop)
     {
         while (!is_eof() && peek() != stop) {
@@ -123,6 +136,8 @@ public:
         ignore();
     }
 
+    // Ignore characters until the string `stop` is found
+    // The `stop` string is ignored, as it is user-defined
     constexpr void ignore_until(const char* stop)
     {
         while (!is_eof() && !next_is(stop)) {
@@ -132,7 +147,7 @@ public:
     }
 
     /*
-     * Conditions are used to match arbitrary characters. You can use lambdas,
+     * Predicates are used to match arbitrary characters. You can use lambdas,
      * ctype functions, or is_any_of() and its derivatives (see below).
      * A few examples:
      *   - `if (lexer.next_is(isdigit))`

--- a/AK/Tests/TestGenericLexer.cpp
+++ b/AK/Tests/TestGenericLexer.cpp
@@ -33,6 +33,21 @@ TEST_CASE(should_constexpr_tell_remaining)
     static_assert(sut.tell_remaining() == 6);
 }
 
+TEST_CASE(should_tell_position)
+{
+    GenericLexer sut(StringView { "abc\ndef" });
+    EXPECT_EQ(sut.position().line, 1u);
+    EXPECT_EQ(sut.position().column, 1u);
+
+    EXPECT_EQ(sut.consume(3), "abc");
+    EXPECT_EQ(sut.position().line, 1u);
+    EXPECT_EQ(sut.position().column, 4u);
+
+    EXPECT_EQ(sut.consume(2), "\nd");
+    EXPECT_EQ(sut.position().line, 2u);
+    EXPECT_EQ(sut.position().column, 2u);
+}
+
 TEST_CASE(should_constexpr_peek)
 {
     constexpr GenericLexer sut(StringView { "abcdef" });
@@ -155,4 +170,14 @@ TEST_CASE(should_constexpr_ignore_until_pred)
         return sut;
     }();
     static_assert(sut.peek() == 'c');
+}
+
+TEST_CASE(should_constexpr_ignore_line)
+{
+    constexpr auto sut = [] {
+        GenericLexer sut(StringView { "abc\ndef" });
+        sut.ignore_line();
+        return sut;
+    }();
+    static_assert(sut.next_is('d'));
 }

--- a/Userland/Libraries/LibC/scanf.cpp
+++ b/Userland/Libraries/LibC/scanf.cpp
@@ -413,7 +413,7 @@ extern "C" int vsscanf(const char* input, const char* format, va_list ap)
         // Parse width specification
         [[maybe_unused]] int width_specifier = 0;
         if (format_lexer.next_is(isdigit)) {
-            auto width_digits = format_lexer.consume_while([](char c) { return isdigit(c); });
+            auto width_digits = format_lexer.consume_while(isdigit);
             width_specifier = width_digits.to_int().value();
             // FIXME: Actually use width specifier
         }

--- a/Userland/Libraries/LibCrypto/ASN1/PEM.cpp
+++ b/Userland/Libraries/LibCrypto/ASN1/PEM.cpp
@@ -26,12 +26,12 @@ ByteBuffer decode_pem(ReadonlyBytes data)
         case PreStartData:
             if (lexer.consume_specific("-----BEGIN"))
                 state = Started;
-            lexer.consume_line();
+            lexer.ignore_line();
             break;
         case Started: {
             if (lexer.consume_specific("-----END")) {
                 state = Ended;
-                lexer.consume_line();
+                lexer.ignore_line();
                 break;
             }
             auto b64decoded = decode_base64(lexer.consume_line().trim_whitespace(TrimMode::Right));
@@ -39,7 +39,7 @@ ByteBuffer decode_pem(ReadonlyBytes data)
             break;
         }
         case Ended:
-            lexer.consume_all();
+            lexer.ignore(lexer.tell_remaining());
             break;
         default:
             VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -78,20 +78,20 @@ Configuration Configuration::from_config(const StringView& libname)
                 key = key_lexer.consume_escaped_character();
                 escape = false;
             } else {
-                if (key_lexer.next_is("alt+")) {
-                    alt = key_lexer.consume_specific("alt+");
+                if (key_lexer.consume_specific("alt+")) {
+                    alt = true;
                     continue;
                 }
-                if (key_lexer.next_is("^[")) {
-                    alt = key_lexer.consume_specific("^[");
+                if (key_lexer.consume_specific("^[")) {
+                    alt = true;
                     continue;
                 }
-                if (key_lexer.next_is("^")) {
-                    has_ctrl = key_lexer.consume_specific("^");
+                if (key_lexer.consume_specific("^")) {
+                    has_ctrl = true;
                     continue;
                 }
-                if (key_lexer.next_is("ctrl+")) {
-                    has_ctrl = key_lexer.consume_specific("ctrl+");
+                if (key_lexer.consume_specific("ctrl+")) {
+                    has_ctrl = true;
                     continue;
                 }
                 if (key_lexer.next_is("\\")) {

--- a/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
+++ b/Userland/Libraries/LibWeb/CodeGenerators/WrapperGenerator.cpp
@@ -159,10 +159,10 @@ static OwnPtr<Interface> parse_interface(StringView filename, const StringView& 
     auto consume_whitespace = [&] {
         bool consumed = true;
         while (consumed) {
-            consumed = lexer.consume_while([](char ch) { return isspace(ch); }).length() > 0;
+            consumed = lexer.consume_while(isspace).length() > 0;
 
             if (lexer.consume_specific("//")) {
-                lexer.consume_until('\n');
+                lexer.ignore_line();
                 consumed = true;
             }
         }
@@ -179,9 +179,9 @@ static OwnPtr<Interface> parse_interface(StringView filename, const StringView& 
             consume_whitespace();
             if (lexer.consume_specific(']'))
                 break;
-            auto name = lexer.consume_until([](auto ch) { return ch == ']' || ch == '=' || ch == ','; });
+            auto name = lexer.consume_until(is_any_of("]=,"));
             if (lexer.consume_specific('=')) {
-                auto value = lexer.consume_until([](auto ch) { return ch == ']' || ch == ','; });
+                auto value = lexer.consume_until(is_any_of("],"));
                 extended_attributes.set(name, value);
             } else {
                 extended_attributes.set(name, {});
@@ -197,11 +197,11 @@ static OwnPtr<Interface> parse_interface(StringView filename, const StringView& 
 
     assert_string("interface");
     consume_whitespace();
-    interface->name = lexer.consume_until([](auto ch) { return isspace(ch); });
+    interface->name = lexer.consume_until(isspace);
     consume_whitespace();
     if (lexer.consume_specific(':')) {
         consume_whitespace();
-        interface->parent_name = lexer.consume_until([](auto ch) { return isspace(ch); });
+        interface->parent_name = lexer.consume_until(isspace);
         consume_whitespace();
     }
     assert_specific('{');
@@ -254,7 +254,7 @@ static OwnPtr<Interface> parse_interface(StringView filename, const StringView& 
         consume_whitespace();
         lexer.consume_specific('=');
         consume_whitespace();
-        constant.value = lexer.consume_while([](auto ch) { return !isspace(ch) && ch != ';'; });
+        constant.value = lexer.consume_until([](auto ch) { return isspace(ch) || ch == ';'; });
         consume_whitespace();
         assert_specific(';');
 


### PR DESCRIPTION
Hi all,

I was recently reading the [first PR for the new LibSQL](https://github.com/SerenityOS/serenity/pull/6463) and @trflynn89 mentioned how the `GenericLexer` does not keep track of the line&column numbers of the string it _lexes_, so I thought I would implement it.

All reference to the member `m_index` have been replaced with calls to `tell()` and the new private method `advance()`. It manages how the `GenericLexer` keeps track of the line&column numbers, thus the `m_index` should only be increased/decreased from there.

I am a bit unsure about how to compute the column number when retreating characters though. For now I reverse-iterate until the previous `\n`, but I wonder if it would be ok on very large strings.


Finally, I am thinking of adding something like a `GenericLexer::Token`, which would look something like this:
```c++
struct Token {
    StringView trivia;
    Position start, end;
};
```
With the same goal in mind as its parent (to bootstrap lexers' tokens), and then adapt the `GenericLexer`'s method to return these tokens. But maybe this is too bloat for what the `GenericLexer` is for, please let me know what you think about it :slightly_smiling_face: