### PR TITLE
Ports: Pass along any command arguments in package.sh

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -398,7 +398,9 @@ parse_arguments() {
     else
         case "$1" in
             fetch|patch|configure|build|install|installdepends|clean|clean_dist|clean_all|uninstall|showproperty)
-                do_$1 $2
+                method=$1
+                shift
+                do_${method} "$@"
                 ;;
             --auto)
                 do_all $1


### PR DESCRIPTION
Commit b3db01e20 broke simple commands without arguments like:
```
./package.sh clean
```
Now, all available arguments are passed along, even if there are none.