### PR TITLE
Base: clang-format the cpp-gui template project.

### DIFF
--- a/Base/res/devel/templates/cpp-gui/main.cpp
+++ b/Base/res/devel/templates/cpp-gui/main.cpp
@@ -1,8 +1,8 @@
-#include <stdio.h>
 #include <LibGUI/Application.h>
-#include <LibGUI/Window.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/MessageBox.h>
+#include <LibGUI/Window.h>
+#include <stdio.h>
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
I noticed this was miss-formated when fixing up the clang-format
error in a different PR. I just ran `pre-commit run --all-files`