### PR TITLE
AK + LibCPP + LibWeb: Utilize AK::SourceLocation instead of macros.

### DIFF
--- a/AK/ScopeLogger.h
+++ b/AK/ScopeLogger.h
@@ -6,21 +6,21 @@
 
 #pragma once
 
+#include <AK/SourceLocation.h>
 #include <AK/StringBuilder.h>
-
-#ifdef DEBUG_SPAM
 
 namespace AK {
 class ScopeLogger {
 public:
-    ScopeLogger(StringView&& fun)
-        : m_fun(fun)
+#ifdef DEBUG_SPAM
+    ScopeLogger(const SourceLocation& location = SourceLocation::current())
+        : m_location(location)
     {
         StringBuilder sb;
 
         for (auto indent = m_depth++; indent > 0; indent--)
             sb.append(' ');
-        dbgln("\033[1;{}m{}entering {}\033[0m", m_depth % 8 + 30, sb.to_string(), m_fun);
+        dbgln("\033[1;{}m{}entering {}\033[0m", m_depth % 8 + 30, sb.to_string(), m_location);
     }
     ~ScopeLogger()
     {
@@ -28,18 +28,16 @@ public:
 
         for (auto indent = --m_depth; indent > 0; indent--)
             sb.append(' ');
-        dbgln("\033[1;{}m{}leaving {}\033[0m", (m_depth + 1) % 8 + 30, sb.to_string(), m_fun);
+        dbgln("\033[1;{}m{}leaving {}\033[0m", (m_depth + 1) % 8 + 30, sb.to_string(), m_location);
     }
 
 private:
     static inline size_t m_depth = 0;
-    StringView m_fun;
+    SourceLocation m_location;
+#else
+    ScopeLogger() = default;
+#endif
 };
 }
 
 using AK::ScopeLogger;
-#    define SCOPE_LOGGER() auto tmp##__COUNTER__ = ScopeLogger(__PRETTY_FUNCTION__);
-
-#else
-#    define SCOPE_LOGGER()
-#endif

--- a/AK/SourceLocation.h
+++ b/AK/SourceLocation.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Format.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 
@@ -37,5 +38,13 @@ private:
 };
 
 }
+
+template<>
+struct AK::Formatter<AK::SourceLocation> : AK::Formatter<FormatString> {
+    void format(FormatBuilder& builder, AK::SourceLocation location)
+    {
+        return AK::Formatter<FormatString>::format(builder, "[{} @ {}:{}]", location.function_name(), location.file_name(), location.line_number());
+    }
+};
 
 using AK::SourceLocation;

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -54,7 +54,7 @@ void Parser::initialize_program_tokens(const StringView& program)
 
 NonnullRefPtr<TranslationUnit> Parser::parse()
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     if (m_tokens.is_empty())
         return create_root_ast_node({}, {});
     auto unit = create_root_ast_node(m_tokens.first().start(), m_tokens.last().end());
@@ -156,7 +156,7 @@ NonnullRefPtr<FunctionDeclaration> Parser::parse_function_declaration(ASTNode& p
 
 NonnullRefPtr<FunctionDefinition> Parser::parse_function_definition(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     auto func = create_ast_node<FunctionDefinition>(parent, position(), {});
     consume(Token::Type::LeftCurly);
     while (!eof() && peek().type() != Token::Type::RightCurly) {
@@ -170,7 +170,7 @@ NonnullRefPtr<FunctionDefinition> Parser::parse_function_definition(ASTNode& par
 
 NonnullRefPtr<Statement> Parser::parse_statement(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     ArmedScopeGuard consume_semicolon([this]() {
         consume(Token::Type::Semicolon);
     });
@@ -222,7 +222,7 @@ bool Parser::match_block_statement()
 
 NonnullRefPtr<BlockStatement> Parser::parse_block_statement(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     auto block_statement = create_ast_node<BlockStatement>(parent, position(), {});
     consume(Token::Type::LeftCurly);
     while (!eof() && peek().type() != Token::Type::RightCurly) {
@@ -269,7 +269,7 @@ bool Parser::match_template_arguments()
 
 NonnullRefPtrVector<Type> Parser::parse_template_arguments(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
 
     consume(Token::Type::Less);
 
@@ -285,7 +285,7 @@ NonnullRefPtrVector<Type> Parser::parse_template_arguments(ASTNode& parent)
 
 bool Parser::match_variable_declaration()
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     save_state();
     ScopeGuard state_guard = [this] { load_state(); };
 
@@ -316,7 +316,7 @@ bool Parser::match_variable_declaration()
 
 NonnullRefPtr<VariableDeclaration> Parser::parse_variable_declaration(ASTNode& parent, bool expect_semicolon)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     auto var = create_ast_node<VariableDeclaration>(parent, position(), {});
     if (!match_variable_declaration()) {
         error("unexpected token for variable type");
@@ -344,7 +344,7 @@ NonnullRefPtr<VariableDeclaration> Parser::parse_variable_declaration(ASTNode& p
 
 NonnullRefPtr<Expression> Parser::parse_expression(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     auto expression = parse_primary_expression(parent);
     // TODO: remove eof() logic, should still work without it
     if (eof() || match(Token::Type::Semicolon)) {
@@ -406,7 +406,7 @@ bool Parser::match_secondary_expression()
 
 NonnullRefPtr<Expression> Parser::parse_primary_expression(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     // TODO: remove eof() logic, should still work without it
     if (eof()) {
         auto node = create_ast_node<Identifier>(parent, position(), position());
@@ -536,7 +536,7 @@ NonnullRefPtr<Expression> Parser::parse_literal(ASTNode& parent)
 
 NonnullRefPtr<Expression> Parser::parse_secondary_expression(ASTNode& parent, NonnullRefPtr<Expression> lhs)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     switch (peek().type()) {
     case Token::Type::Plus:
         return parse_binary_expression(parent, lhs, BinaryOp::Addition);
@@ -689,7 +689,7 @@ bool Parser::match_function_declaration()
 
 Optional<NonnullRefPtrVector<Parameter>> Parser::parse_parameter_list(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     NonnullRefPtrVector<Parameter> parameters;
     while (peek().type() != Token::Type::RightParen && !eof()) {
         if (match_ellipsis()) {
@@ -739,7 +739,7 @@ bool Parser::match_preprocessor()
 
 void Parser::consume_preprocessor()
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     switch (peek().type()) {
     case Token::Type::PreprocessorStatement:
         consume();
@@ -756,7 +756,7 @@ void Parser::consume_preprocessor()
 
 Optional<Token> Parser::consume_whitespace()
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     return consume(Token::Type::Whitespace);
 }
 
@@ -832,7 +832,7 @@ String Parser::text_in_range(Position start, Position end) const
 
 void Parser::error(StringView message)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     if (message.is_null() || message.is_empty())
         message = "<empty>";
     String formatted_message;
@@ -937,7 +937,7 @@ void Parser::print_tokens() const
 
 NonnullRefPtr<StringLiteral> Parser::parse_string_literal(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     Optional<size_t> start_token_index;
     Optional<size_t> end_token_index;
     while (!eof()) {
@@ -971,7 +971,7 @@ NonnullRefPtr<StringLiteral> Parser::parse_string_literal(ASTNode& parent)
 
 NonnullRefPtr<ReturnStatement> Parser::parse_return_statement(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     auto return_statement = create_ast_node<ReturnStatement>(parent, position(), {});
     consume(Token::Type::Keyword);
     if (!peek(Token::Type::Semicolon).has_value()) {
@@ -984,7 +984,7 @@ NonnullRefPtr<ReturnStatement> Parser::parse_return_statement(ASTNode& parent)
 
 NonnullRefPtr<EnumDeclaration> Parser::parse_enum_declaration(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     auto enum_decl = create_ast_node<EnumDeclaration>(parent, position(), {});
     consume_keyword("enum");
     auto name_token = consume(Token::Type::Identifier);
@@ -1031,7 +1031,7 @@ bool Parser::match_keyword(const String& keyword)
 
 NonnullRefPtr<StructOrClassDeclaration> Parser::parse_struct_or_class_declaration(ASTNode& parent, StructOrClassDeclaration::Type type)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     auto decl = create_ast_node<StructOrClassDeclaration>(parent, position(), {}, type);
     switch (type) {
     case StructOrClassDeclaration::Type::Struct:
@@ -1058,7 +1058,7 @@ NonnullRefPtr<StructOrClassDeclaration> Parser::parse_struct_or_class_declaratio
 
 NonnullRefPtr<MemberDeclaration> Parser::parse_member_declaration(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     auto member_decl = create_ast_node<MemberDeclaration>(parent, position(), {});
     member_decl->m_type = parse_type(*member_decl);
 
@@ -1077,7 +1077,7 @@ NonnullRefPtr<MemberDeclaration> Parser::parse_member_declaration(ASTNode& paren
 
 NonnullRefPtr<BooleanLiteral> Parser::parse_boolean_literal(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     auto token = consume(Token::Type::Keyword);
     auto text = text_of_token(token);
     // text == "true" || text == "false";
@@ -1096,7 +1096,7 @@ bool Parser::match_boolean_literal()
 
 NonnullRefPtr<Type> Parser::parse_type(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
 
     if (!match_type()) {
         auto token = consume();
@@ -1134,7 +1134,7 @@ NonnullRefPtr<Type> Parser::parse_type(ASTNode& parent)
 
 NonnullRefPtr<ForStatement> Parser::parse_for_statement(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     auto for_statement = create_ast_node<ForStatement>(parent, position(), {});
     consume(Token::Type::Keyword);
     consume(Token::Type::LeftParen);
@@ -1158,7 +1158,7 @@ NonnullRefPtr<ForStatement> Parser::parse_for_statement(ASTNode& parent)
 
 NonnullRefPtr<IfStatement> Parser::parse_if_statement(ASTNode& parent)
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     auto if_statement = create_ast_node<IfStatement>(parent, position(), {});
     consume(Token::Type::Keyword);
     consume(Token::Type::LeftParen);
@@ -1176,7 +1176,7 @@ NonnullRefPtr<IfStatement> Parser::parse_if_statement(ASTNode& parent)
 }
 Vector<StringView> Parser::parse_type_qualifiers()
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     Vector<StringView> qualifiers;
     while (!eof()) {
         auto token = peek();
@@ -1195,7 +1195,7 @@ Vector<StringView> Parser::parse_type_qualifiers()
 
 Vector<StringView> Parser::parse_function_qualifiers()
 {
-    SCOPE_LOGGER();
+    ScopeLogger logger {};
     Vector<StringView> qualifiers;
     while (!eof()) {
         auto token = peek();

--- a/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeprecatedCSSParser.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/HashMap.h>
+#include <AK/SourceLocation.h>
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
@@ -22,10 +23,10 @@
         VERIFY_NOT_REACHED();                               \
     }
 
-#define PARSE_ERROR()             \
-    do {                          \
-        dbgln("CSS parse error"); \
-    } while (0)
+static inline void log_parse_error(const SourceLocation& location = SourceLocation::current())
+{
+    dbgln("CSS Parse error! {}", location);
+}
 
 namespace Web {
 
@@ -325,11 +326,11 @@ public:
             dbgln("CSSParser: Peeked '{:c}' wanted specific '{:c}'", peek(), ch);
         }
         if (!peek()) {
-            PARSE_ERROR();
+            log_parse_error();
             return false;
         }
         if (peek() != ch) {
-            PARSE_ERROR();
+            log_parse_error();
             ++index;
             return false;
         }
@@ -795,12 +796,12 @@ public:
     {
         parse_selector_list();
         if (!consume_specific('{')) {
-            PARSE_ERROR();
+            log_parse_error();
             return;
         }
         parse_declaration();
         if (!consume_specific('}')) {
-            PARSE_ERROR();
+            log_parse_error();
             return;
         }
 
@@ -810,7 +811,7 @@ public:
     Optional<String> parse_string()
     {
         if (!is_valid_string_quotes_char(peek())) {
-            PARSE_ERROR();
+            log_parse_error();
             return {};
         }
 
@@ -870,7 +871,7 @@ public:
             if (!consume_specific(')'))
                 return;
         } else {
-            PARSE_ERROR();
+            log_parse_error();
             return;
         }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/NonnullOwnPtrVector.h>
-#include <AK/Vector.h>
-#include <LibWeb/CSS/CSSStyleRule.h>
+#include <AK/SourceLocation.h>
 #include <LibWeb/CSS/Parser/AtStyleRule.h>
 #include <LibWeb/CSS/Parser/DeclarationOrAtRule.h>
 #include <LibWeb/CSS/Parser/Parser.h>
@@ -18,10 +16,10 @@
 
 #define CSS_PARSER_TRACE 1
 
-#define PARSE_ERROR()                                                                           \
-    do {                                                                                        \
-        dbgln_if(CSS_PARSER_TRACE, "Parse error (CSS) {} @ {}", __PRETTY_FUNCTION__, __LINE__); \
-    } while (0)
+static void log_parse_error(const SourceLocation& location = SourceLocation::current())
+{
+    dbgln_if(CSS_PARSER_TRACE, "Parse error (CSS) {}", location);
+}
 
 namespace Web::CSS {
 
@@ -161,7 +159,7 @@ AtStyleRule Parser::consume_an_at_rule()
         }
 
         if (token.is_eof()) {
-            PARSE_ERROR();
+            log_parse_error();
             return rule;
         }
 
@@ -191,7 +189,7 @@ Optional<QualifiedStyleRule> Parser::consume_a_qualified_rule()
         auto token = next_token();
 
         if (token.is_eof()) {
-            PARSE_ERROR();
+            log_parse_error();
             return {};
         }
 
@@ -251,7 +249,7 @@ StyleBlockRule Parser::consume_a_simple_block()
         }
 
         if (token.is_eof()) {
-            PARSE_ERROR();
+            log_parse_error();
             return block;
         }
 
@@ -278,7 +276,7 @@ StyleFunctionRule Parser::consume_a_function()
         }
 
         if (token.is_eof()) {
-            PARSE_ERROR();
+            log_parse_error();
             return function;
         }
 
@@ -316,7 +314,7 @@ Optional<StyleDeclarationRule> Parser::consume_a_declaration()
     auto colon = next_token();
 
     if (!colon.is_colon()) {
-        PARSE_ERROR();
+        log_parse_error();
         return {};
     }
 
@@ -402,7 +400,7 @@ Vector<DeclarationOrAtRule> Parser::consume_a_list_of_declarations()
             }
         }
 
-        PARSE_ERROR();
+        log_parse_error();
         reconsume_current_input_token();
         auto peek = peek_token();
         if (!(peek.is_semicolon() || peek.is_eof())) {

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/SourceLocation.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/HTML/Parser/Entities.h>
 #include <LibWeb/HTML/Parser/HTMLToken.h>
@@ -15,15 +16,6 @@
 namespace Web::HTML {
 
 #pragma GCC diagnostic ignored "-Wunused-label"
-
-#if TOKENIZER_TRACE_DEBUG
-#    define PARSE_ERROR()                                                               \
-        do {                                                                            \
-            dbgln("Parse error (tokenization) {} @ {}", __PRETTY_FUNCTION__, __LINE__); \
-        } while (0)
-#else
-#    define PARSE_ERROR()
-#endif
 
 #define CONSUME_NEXT_INPUT_CHARACTER \
     current_input_character = next_code_point();
@@ -175,6 +167,11 @@ namespace Web::HTML {
     }                     \
     }
 
+static inline void log_parse_error(const SourceLocation& location = SourceLocation::current())
+{
+    dbgln_if(TOKENIZER_TRACE_DEBUG, "Parse error (tokenization) {}", location);
+}
+
 static inline bool is_surrogate(u32 code_point)
 {
     return (code_point & 0xfffff800) == 0xd800;
@@ -237,7 +234,7 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_CURRENT_CHARACTER;
                 }
                 ON_EOF
@@ -268,19 +265,19 @@ _StartOfFunction:
                 }
                 ON('?')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     create_new_token(HTMLToken::Type::Comment);
                     RECONSUME_IN(BogusComment);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_CHARACTER_AND_RECONSUME_IN('<', Data);
                 }
             }
@@ -307,13 +304,13 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_tag.tag_name.append_code_point(0xFFFD);
                     continue;
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -333,19 +330,19 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     SWITCH_TO(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_queued_tokens.enqueue(HTMLToken::make_character('<'));
                     m_queued_tokens.enqueue(HTMLToken::make_character('/'));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     create_new_token(HTMLToken::Type::Comment);
                     RECONSUME_IN(BogusComment);
                 }
@@ -367,7 +364,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     create_new_token(HTMLToken::Type::Comment);
                     SWITCH_TO(BogusComment);
                 }
@@ -387,7 +384,7 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_comment_or_character.data.append_code_point(0xFFFD);
                     continue;
                 }
@@ -411,7 +408,7 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
@@ -419,7 +416,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     RECONSUME_IN(BeforeDOCTYPEName);
                 }
             }
@@ -440,7 +437,7 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_token.m_doctype.name.append_code_point(0xFFFD);
                     m_current_token.m_doctype.missing_name = false;
@@ -448,14 +445,14 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_token.m_doctype.force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     create_new_token(HTMLToken::Type::DOCTYPE);
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
@@ -488,13 +485,13 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.name.append_code_point(0xFFFD);
                     continue;
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
@@ -519,7 +516,7 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
@@ -532,7 +529,7 @@ _StartOfFunction:
                     if (toupper(current_input_character.value()) == 'S' && consume_next_if_match("YSTEM", CaseSensitivity::CaseInsensitive)) {
                         SWITCH_TO(AfterDOCTYPESystemKeyword);
                     }
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
@@ -547,34 +544,34 @@ _StartOfFunction:
                 }
                 ON('"')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.public_identifier.clear();
                     m_current_token.m_doctype.missing_public_identifier = false;
                     SWITCH_TO(DOCTYPEPublicIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.public_identifier.clear();
                     m_current_token.m_doctype.missing_public_identifier = false;
                     SWITCH_TO(DOCTYPEPublicIdentifierSingleQuoted);
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
@@ -589,34 +586,34 @@ _StartOfFunction:
                 }
                 ON('"')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.system_identifier.clear();
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.system_identifier.clear();
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
@@ -643,20 +640,20 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
@@ -683,20 +680,20 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
@@ -711,19 +708,19 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.public_identifier.append_code_point(0xFFFD);
                     continue;
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
@@ -744,19 +741,19 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.public_identifier.append_code_point(0xFFFD);
                     continue;
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
@@ -777,19 +774,19 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.system_identifier.append_code_point(0xFFFD);
                     continue;
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
@@ -810,19 +807,19 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.system_identifier.append_code_point(0xFFFD);
                     continue;
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
@@ -847,28 +844,28 @@ _StartOfFunction:
                 }
                 ON('"')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.system_identifier.clear();
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierDoubleQuoted);
                 }
                 ON('\'')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.system_identifier.clear();
                     m_current_token.m_doctype.missing_system_identifier = false;
                     SWITCH_TO(DOCTYPESystemIdentifierSingleQuoted);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
@@ -899,14 +896,14 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     RECONSUME_IN(BogusDOCTYPE);
                 }
@@ -925,14 +922,14 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_doctype.force_quirks = true;
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     RECONSUME_IN(BogusDOCTYPE);
                 }
             }
@@ -946,7 +943,7 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     continue;
                 }
                 ON_EOF
@@ -981,7 +978,7 @@ _StartOfFunction:
                 }
                 ON('=')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     auto new_attribute = HTMLToken::AttributeBuilder();
                     new_attribute.local_name_builder.append_code_point(current_input_character.value());
                     m_current_token.m_tag.attributes.append(new_attribute);
@@ -1004,12 +1001,12 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     RECONSUME_IN(BeforeAttributeName);
                 }
             }
@@ -1044,23 +1041,23 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_tag.attributes.last().local_name_builder.append_code_point(0xFFFD);
                     continue;
                 }
                 ON('"')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     goto AnythingElseAttributeName;
                 }
                 ON('\'')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     goto AnythingElseAttributeName;
                 }
                 ON('<')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     goto AnythingElseAttributeName;
                 }
                 ANYTHING_ELSE
@@ -1092,7 +1089,7 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1119,7 +1116,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ANYTHING_ELSE
@@ -1142,13 +1139,13 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_tag.attributes.last().value_builder.append_code_point(0xFFFD);
                     continue;
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1172,13 +1169,13 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_tag.attributes.last().value_builder.append_code_point(0xFFFD);
                     continue;
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1206,38 +1203,38 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_tag.attributes.last().value_builder.append_code_point(0xFFFD);
                     continue;
                 }
                 ON('"')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     goto AnythingElseAttributeValueUnquoted;
                 }
                 ON('\'')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     goto AnythingElseAttributeValueUnquoted;
                 }
                 ON('<')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     goto AnythingElseAttributeValueUnquoted;
                 }
                 ON('=')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     goto AnythingElseAttributeValueUnquoted;
                 }
                 ON('`')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     goto AnythingElseAttributeValueUnquoted;
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -1265,12 +1262,12 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     RECONSUME_IN(BeforeAttributeName);
                 }
             }
@@ -1284,7 +1281,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ANYTHING_ELSE
@@ -1302,12 +1299,12 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
@@ -1332,13 +1329,13 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_current_token.m_comment_or_character.data.append_code_point(0xFFFD);
                     continue;
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
@@ -1367,7 +1364,7 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
@@ -1388,12 +1385,12 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
@@ -1413,7 +1410,7 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_queued_tokens.enqueue(m_current_token);
                     EMIT_EOF;
                 }
@@ -1482,7 +1479,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     RECONSUME_IN(CommentEnd);
                 }
             }
@@ -1533,7 +1530,7 @@ _StartOfFunction:
                     }
 
                     if (!match.value().entity.ends_with(';')) {
-                        PARSE_ERROR();
+                        log_parse_error();
                     }
 
                     m_temporary_buffer.clear();
@@ -1563,7 +1560,7 @@ _StartOfFunction:
                 }
                 ON(';')
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     RECONSUME_IN_RETURN_STATE;
                 }
                 ANYTHING_ELSE
@@ -1602,7 +1599,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     FLUSH_CODEPOINTS_CONSUMED_AS_A_CHARACTER_REFERENCE;
                     RECONSUME_IN_RETURN_STATE;
                 }
@@ -1617,7 +1614,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     FLUSH_CODEPOINTS_CONSUMED_AS_A_CHARACTER_REFERENCE;
                     RECONSUME_IN_RETURN_STATE;
                 }
@@ -1650,7 +1647,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     RECONSUME_IN(NumericCharacterReferenceEnd);
                 }
             }
@@ -1670,7 +1667,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     RECONSUME_IN(NumericCharacterReferenceEnd);
                 }
             }
@@ -1681,22 +1678,22 @@ _StartOfFunction:
                 DONT_CONSUME_NEXT_INPUT_CHARACTER;
 
                 if (m_character_reference_code == 0) {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_character_reference_code = 0xFFFD;
                 }
                 if (m_character_reference_code > 0x10ffff) {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_character_reference_code = 0xFFFD;
                 }
                 if (is_surrogate(m_character_reference_code)) {
-                    PARSE_ERROR();
+                    log_parse_error();
                     m_character_reference_code = 0xFFFD;
                 }
                 if (is_noncharacter(m_character_reference_code)) {
-                    PARSE_ERROR();
+                    log_parse_error();
                 }
                 if (m_character_reference_code == 0xd || (is_control(m_character_reference_code) && !isspace(m_character_reference_code))) {
-                    PARSE_ERROR();
+                    log_parse_error();
                     constexpr struct {
                         u32 number;
                         u32 code_point;
@@ -1757,7 +1754,7 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_CHARACTER(0xFFFD);
                 }
                 ON_EOF
@@ -1867,7 +1864,7 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_CHARACTER(0xFFFD);
                 }
                 ON_EOF
@@ -1977,7 +1974,7 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_CHARACTER(0xFFFD);
                 }
                 ON_EOF
@@ -1995,7 +1992,7 @@ _StartOfFunction:
             {
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_CHARACTER(0xFFFD);
                 }
                 ON_EOF
@@ -2071,12 +2068,12 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     SWITCH_TO_AND_EMIT_CHARACTER(0xFFFD, ScriptDataEscaped);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -2242,12 +2239,12 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_CHARACTER(0xFFFD);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -2269,12 +2266,12 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     SWITCH_TO_AND_EMIT_CHARACTER(0xFFFD, ScriptDataDoubleEscaped);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -2300,12 +2297,12 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     SWITCH_TO_AND_EMIT_CHARACTER(0xFFFD, ScriptDataDoubleEscaped);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -2388,12 +2385,12 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     SWITCH_TO_AND_EMIT_CHARACTER(0xFFFD, ScriptDataEscaped);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -2415,12 +2412,12 @@ _StartOfFunction:
                 }
                 ON(0)
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_CHARACTER(0xFFFD);
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -2509,7 +2506,7 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    PARSE_ERROR();
+                    log_parse_error();
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE


### PR DESCRIPTION
Small collection of minor cleanups in the life long quest to kill macro's:

-   AK: Add a AK::Formatter implementation for AK::SourceLocation

-   AK + LibCpp: Convert ScopeLogger to use AK:SourceLocation

    Utilize AK::SourceLocation to get function information into
    the scope logger, instead of relying on pre-processor macros.

-   LibWeb: Use SourceLocation for DeprecatedCSSParser logging.

-   LibWeb: Utilize SourceLocation for CSS/Parser logging

-   LibWeb: Utilize SourceLocation for CSS/Tokenizer logging

-   LibWeb: Utilize SourceLocation for HTMLTokenizer logging

-   LibWeb: Utilize SourceLocation for HTMLDocumentParser logging
