### PR TITLE
Meta: Allow for spaces in commit title category linter

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -254,7 +254,7 @@ jobs:
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '^\S+?: .+'
+        pattern: '^\S.*?: .+'
         error: 'Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)'
 
   notify_irc:


### PR DESCRIPTION
Fixes #6624 