### PR TITLE
Ports: Fix building openssh

### DIFF
--- a/Ports/openssh/package.sh
+++ b/Ports/openssh/package.sh
@@ -6,7 +6,7 @@ files="https://github.com/openssh/openssh-portable/archive/9ca7e9c861775dd6c6312
 auth_type=md5
 depends="zlib openssl"
 useconfigure=true
-configopts="--prefix=/usr/local --disable-utmp --sysconfdir=/etc/ssh --with-ssl-dir=${SERENITY_INSTALL_ROOT}/usr/local/lib"
+configopts="--prefix=/usr/local --disable-utmp --disable-strip --sysconfdir=/etc/ssh --with-ssl-dir=${SERENITY_INSTALL_ROOT}/usr/local/lib"
 
 pre_configure() {
     run autoreconf

--- a/Userland/Libraries/LibC/sys/time.h
+++ b/Userland/Libraries/LibC/sys/time.h
@@ -111,6 +111,6 @@ static inline void TIMESPEC_TO_TIMEVAL(struct timeval* tv, const struct timespec
 #define timespecclear timespecclear
 #define timespecisset timespecisset
 #define timespeccmp(ts, us, cmp) \
-    (((ts)->tv_sec == (us)->tv_sec) ? ((ts)->vf_nsec cmp(us)->tv_nsec) : ((ts)->tv_sec cmp(us)->tv_sec))
+    (((ts)->tv_sec == (us)->tv_sec) ? ((ts)->tv_nsec cmp(us)->tv_nsec) : ((ts)->tv_sec cmp(us)->tv_sec))
 
 __END_DECLS


### PR DESCRIPTION
This fixes a spelling mistake in the `timespeccmp()` macro and enables debug symbols for OpenSSH to make diagnosing problems
easier.