### PR TITLE
Meta+Ports: Only allow sha256 and sig for auth_type in ports 

### DIFF
--- a/Meta/lint-ports.py
+++ b/Meta/lint-ports.py
@@ -117,6 +117,11 @@ def check_package_files(ports):
             continue
 
         props = get_port_properties(port)
+
+        if not props['auth_type'] in ('sha256', 'sig', ''):
+            print(f"Ports/{port} uses invalid signature algorithm '{props['auth_type']}' for 'auth_type'")
+            all_good = False
+
         for prop in PORT_PROPERTIES:
             if prop == 'auth_type' and re.match('^https://github.com/SerenityOS/', props["files"]):
                 continue

--- a/Ports/SDL2_gfx/package.sh
+++ b/Ports/SDL2_gfx/package.sh
@@ -2,8 +2,8 @@
 
 port=SDL2_gfx
 version=1.0.4
-files="https://downloads.sourceforge.net/project/sdl2gfx/SDL2_gfx-${version}.tar.gz SDL2_gfx-${version}.tar.gz 15f9866c6464ca298f28f62fe5b36d9f"
-auth_type=md5
+files="https://downloads.sourceforge.net/project/sdl2gfx/SDL2_gfx-${version}.tar.gz SDL2_gfx-${version}.tar.gz 63e0e01addedc9df2f85b93a248f06e8a04affa014a835c2ea34bfe34e576262"
+auth_type=sha256
 depends="SDL2"
 useconfigure=true
 configopts="--with-sdl-prefix=${SERENITY_INSTALL_ROOT}/usr/local"

--- a/Ports/SDL2_image/package.sh
+++ b/Ports/SDL2_image/package.sh
@@ -3,8 +3,8 @@ port=SDL2_image
 useconfigure=true
 version=2.0.5
 depends="SDL2 libpng libjpeg libtiff"
-files="https://www.libsdl.org/projects/SDL_image/release/SDL2_image-${version}.tar.gz SDL_image-${version}.tar.gz f26f3a153360a8f09ed5220ef7b07aea"
-auth_type=md5
+files="https://www.libsdl.org/projects/SDL_image/release/SDL2_image-${version}.tar.gz SDL_image-${version}.tar.gz bdd5f6e026682f7d7e1be0b6051b209da2f402a2dd8bd1c4bd9c25ad263108d0"
+auth_type=sha256
 
 configure() {
     run ./configure \

--- a/Ports/SDL2_mixer/package.sh
+++ b/Ports/SDL2_mixer/package.sh
@@ -2,8 +2,8 @@
 port=SDL2_mixer
 version=2.0.4
 useconfigure=true
-files="https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${version}.tar.gz SDL2_mixer-${version}.tar.gz a36e8410cac46b00a4d01752b32c3eb1"
-auth_type=md5
+files="https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${version}.tar.gz SDL2_mixer-${version}.tar.gz b4cf5a382c061cd75081cf246c2aa2f9df8db04bdda8dcdc6b6cca55bede2419"
+auth_type=sha256
 depends="SDL2 libvorbis"
 
 configure() {

--- a/Ports/SDL2_ttf/package.sh
+++ b/Ports/SDL2_ttf/package.sh
@@ -2,8 +2,8 @@
 port=SDL2_ttf
 version=2.0.15
 useconfigure=true
-files="https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-${version}.tar.gz SDL2_ttf-${version}.tar.gz 04fe06ff7623d7bdcb704e82f5f88391"
-auth_type=md5
+files="https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-${version}.tar.gz SDL2_ttf-${version}.tar.gz a9eceb1ad88c1f1545cd7bd28e7cbc0b2c14191d40238f531a15b01b1b22cd33"
+auth_type=sha256
 depends="SDL2 freetype"
 
 configure() {

--- a/Ports/Super-Mario/package.sh
+++ b/Ports/Super-Mario/package.sh
@@ -5,8 +5,8 @@ version=git
 depends="SDL2 SDL2_mixer SDL2_image"
 workdir=Super-Mario-Clone-Cpp-master
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
-files="https://github.com/Bennyhwanggggg/Super-Mario-Clone-Cpp/archive/refs/heads/master.zip master.zip 11f622721d1ba504acf75c024aa0dbe3"
-auth_type=md5
+files="https://github.com/Bennyhwanggggg/Super-Mario-Clone-Cpp/archive/refs/heads/master.zip master.zip fcacc15d3b5afccb3227f982d3e05f2cfeb198f0fffd008fdcda005cb7f87f91"
+auth_type=sha256
 launcher_name="Super Mario"
 launcher_category=Games
 launcher_command=/opt/Super_Mario/uMario

--- a/Ports/bison/package.sh
+++ b/Ports/bison/package.sh
@@ -3,5 +3,5 @@ port=bison
 version=1.25
 useconfigure=true
 configopts="--prefix=${SERENITY_INSTALL_ROOT}/usr/local"
-files="https://ftpmirror.gnu.org/gnu/bison/bison-${version}.tar.gz bison-${version}.tar.gz 65f577d0f8ffaf61ae21c23c0918d225"
-auth_type="md5"
+files="https://ftpmirror.gnu.org/gnu/bison/bison-${version}.tar.gz bison-${version}.tar.gz 356bff0a058ca3d59528e0c49e68b90cdeb09779e0d626fc78a94270beed93a6"
+auth_type=sha256

--- a/Ports/bzip2/package.sh
+++ b/Ports/bzip2/package.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=bzip2
 version=1.0.8
-files="https://sourceware.org/pub/bzip2/bzip2-${version}.tar.gz bzip2-${version}.tar.gz 67e051268d0c475ea773822f7500d0e5"
-auth_type=md5
+files="https://sourceware.org/pub/bzip2/bzip2-${version}.tar.gz bzip2-${version}.tar.gz ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
+auth_type=sha256
 makeopts=bzip2
 installopts="PREFIX=${SERENITY_INSTALL_ROOT}/usr/local"
 

--- a/Ports/c-ray/package.sh
+++ b/Ports/c-ray/package.sh
@@ -2,8 +2,8 @@
 port=c-ray
 version=c094d64570c30c70f4003e9428d31a2a0d9d3d41
 useconfigure=true
-files="https://github.com/vkoskiv/c-ray/archive/${version}.tar.gz ${version}.tar.gz b83e3c6a1462486257dfe38d309b47c2"
-auth_type=md5
+files="https://github.com/vkoskiv/c-ray/archive/${version}.tar.gz ${version}.tar.gz 1e0663a1d83e8a9984aced33b9307471f3302c8a5ea7ec47954854d60902a747"
+auth_type=sha256
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
 depends="SDL2"
 workdir="${port}-${version}"

--- a/Ports/carl/package.sh
+++ b/Ports/carl/package.sh
@@ -2,8 +2,8 @@
 port=carl
 version=1.5
 workdir=cryanc-"${version}"
-files="https://github.com/classilla/cryanc/archive/refs/tags/${version}.tar.gz cryanc-${version}.tar.gz f2cae13addf4ed7cb7af3d06069cf082"
-auth_type=md4
+files="https://github.com/classilla/cryanc/archive/refs/tags/${version}.tar.gz cryanc-${version}.tar.gz 019c2a4df4ce5a332fc29b7903244d6a76bb0bd8bb3e406326b6239416a5b0f6"
+auth_type=sha256
 
 build() {
     run $CC -O3 carl.c -o carl

--- a/Ports/chester/package.sh
+++ b/Ports/chester/package.sh
@@ -5,8 +5,8 @@ version=git
 depends="SDL2"
 workdir=chester-public
 configopts="-DCMAKE_TOOLCHAIN_FILE=${SERENITY_SOURCE_DIR}/Toolchain/CMake/CMakeToolchain.txt"
-files="https://github.com/veikkos/chester/archive/public.tar.gz chester.tar.gz f09d797209e7bfd9b1460d2540525186"
-auth_type=md5
+files="https://github.com/veikkos/chester/archive/public.tar.gz chester.tar.gz b3ea7ad40608e1050fa434258f5c69b93e7bad10523c4c4a86fe08d1442a907b"
+auth_type=sha256
 
 configure() {
     run cmake $configopts

--- a/Ports/cmake/package.sh
+++ b/Ports/cmake/package.sh
@@ -2,8 +2,8 @@
 port=cmake
 version=3.19.4
 useconfigure=true
-files="https://github.com/Kitware/CMake/releases/download/v$version/cmake-$version.tar.gz cmake-$version.tar.gz 2a71f16c61bac5402004066d193fc14e"
-auth_type=md5
+files="https://github.com/Kitware/CMake/releases/download/v$version/cmake-$version.tar.gz cmake-$version.tar.gz 7d0232b9f1c57e8de81f38071ef8203e6820fe7eec8ae46a1df125d88dbcc2e1"
+auth_type=sha256
 depends="bash gcc make sed ncurses"
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
 

--- a/Ports/cmatrix/package.sh
+++ b/Ports/cmatrix/package.sh
@@ -5,8 +5,8 @@ version=git
 depends="ncurses"
 workdir=cmatrix-master
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
-files="https://github.com/abishekvashok/cmatrix/archive/refs/heads/master.zip cmatrix.zip 2541321b89149b375d5732402e52d654"
-auth_type=md5
+files="https://github.com/abishekvashok/cmatrix/archive/refs/heads/master.zip cmatrix.zip c32ca7562e58fb1fd7a96ebdfbe51c5de060709d39b67fce3c0bc42547e0ccb2"
+auth_type=sha256
 launcher_name=cmatrix
 launcher_category=Games
 launcher_command="Terminal -e cmatrix"

--- a/Ports/doom/package.sh
+++ b/Ports/doom/package.sh
@@ -2,8 +2,8 @@
 port=doom
 workdir=SerenityDOOM-master
 version=git
-files="https://github.com/SerenityOS/SerenityDOOM/archive/master.tar.gz doom-git.tar.gz 481406ef30e04ad55d39aa94baab73bd"
-auth_type=md5
+files="https://github.com/SerenityOS/SerenityDOOM/archive/master.tar.gz doom-git.tar.gz 13aaa5b1655b85190b744905c9a8a69f1a1e26e7331c9363a241e83510f5b26b"
+auth_type=sha256
 makeopts="-C doomgeneric/"
 installopts="-C doomgeneric/"
 launcher_name=Doom

--- a/Ports/figlet/package.sh
+++ b/Ports/figlet/package.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=figlet
 version=2.2.5
-files="http://ftp.figlet.org/pub/figlet/program/unix/figlet-${version}.tar.gz figlet-${version}.tar.gz d88cb33a14f1469fff975d021ae2858e"
-auth_type=md5
+files="http://ftp.figlet.org/pub/figlet/program/unix/figlet-${version}.tar.gz figlet-${version}.tar.gz bf88c40fd0f077dab2712f54f8d39ac952e4e9f2e1882f1195be9e5e4257417d"
+auth_type=sha256
 
 build() {
     run make CC="${CC}" LD="${CC}" $makeopts

--- a/Ports/freetype/package.sh
+++ b/Ports/freetype/package.sh
@@ -2,6 +2,6 @@
 port=freetype
 version=2.10.4
 useconfigure=true
-files="https://download.savannah.gnu.org/releases/freetype/freetype-${version}.tar.gz freetype-${version}.tar.gz 4934a8b61b636920bcce58e7c7f3e1a2"
-auth_type=md5
+files="https://download.savannah.gnu.org/releases/freetype/freetype-${version}.tar.gz freetype-${version}.tar.gz 5eab795ebb23ac77001cfb68b7d4d50b5d6c7469247b0b01b2c953269f658dac"
+auth_type=sha256
 configopts="--with-brotli=no --with-bzip2=no --with-zlib=no --with-harfbuzz=no --with-png=no"

--- a/Ports/genemu/package.sh
+++ b/Ports/genemu/package.sh
@@ -2,8 +2,8 @@
 port="genemu"
 version=3bf6f7cd893db3451019d6e18a2d9ad1de0e7c8c
 useconfigure=true
-files="https://github.com/rasky/genemu/archive/${version}.tar.gz genemu-${version}.tar.gz 5704a21341ea56d026601e48e08f4605"
-auth_type=md5
+files="https://github.com/rasky/genemu/archive/${version}.tar.gz genemu-${version}.tar.gz 07e4f6aba1778143796bc0a571dfc7a693a2cbc5cf303a31df19d74e12f8cf54"
+auth_type=sha256
 configopts="-DCMAKE_TOOLCHAIN_FILE=${SERENITY_SOURCE_DIR}/Toolchain/CMake/CMakeToolchain.txt"
 depends="SDL2"
 

--- a/Ports/git/package.sh
+++ b/Ports/git/package.sh
@@ -2,8 +2,8 @@
 port=git
 version=2.31.1
 useconfigure="true"
-files="https://mirrors.edge.kernel.org/pub/software/scm/git/git-${version}.tar.xz git-${version}.tar.xz 51bd18a1af964dd3b1c7b0220889ebb6"
-auth_type=md5
+files="https://mirrors.edge.kernel.org/pub/software/scm/git/git-${version}.tar.xz git-${version}.tar.xz 9f61417a44d5b954a5012b6f34e526a3336dcf5dd720e2bb7ada92ad8b3d6680"
+auth_type=sha256
 configopts="--target=${SERENITY_ARCH}-pc-serenity CFLAGS=-DNO_IPV6"
 depends="zlib"
 

--- a/Ports/gnuplot/package.sh
+++ b/Ports/gnuplot/package.sh
@@ -3,8 +3,8 @@ port=gnuplot
 version=5.2.8
 useconfigure=true
 # Note: gnuplot's source code is hosted on SourceForge, but using the GitHub mirror makes downloading a versioned .tar.gz easier.
-files="https://github.com/gnuplot/gnuplot/archive/${version}.tar.gz gnuplot-${version}.tar.gz 292f983e273cd50cf02e0737043fae0e"
-auth_type=md5
+files="https://github.com/gnuplot/gnuplot/archive/${version}.tar.gz gnuplot-${version}.tar.gz b55f591e2ad9d01ffca821f2f91ce781b481bb5dd602ce5188bfad3140f44ac0"
+auth_type=sha256
 configopts="--prefix=${SERENITY_INSTALL_ROOT}/usr/local --with-readline=builtin --without-latex"
 
 pre_configure() {

--- a/Ports/hatari/package.sh
+++ b/Ports/hatari/package.sh
@@ -6,8 +6,8 @@ depends="SDL2 zlib"
 commit=353379e1f8a847cc0e284541d2b40fd49d175d22
 workdir="${port}-${commit}"
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
-files="https://github.com/hatari/hatari/archive/${commit}.tar.gz ${commit}.tar.gz 614d8c20a06deea6df464a5de32cc795"
-auth_type=md5
+files="https://github.com/hatari/hatari/archive/${commit}.tar.gz ${commit}.tar.gz 617f95b30c4e590bb61ddcc1dafc22f4bf270377caa7aa5867f3f7413250b538"
+auth_type=sha256
 launcher_name=Hatari
 launcher_category=Games
 launcher_command=hatari

--- a/Ports/imgcat/package.sh
+++ b/Ports/imgcat/package.sh
@@ -2,8 +2,8 @@
 port=imgcat
 version=2.5.0
 depends="ncurses"
-files="https://github.com/eddieantonio/imgcat/releases/download/v${version}/imgcat-${version}.tar.gz imgcat-v${version}.tar.gz 16e5386f5ce2237643785e7c8bb2cfce"
-auth_type=md5
+files="https://github.com/eddieantonio/imgcat/releases/download/v${version}/imgcat-${version}.tar.gz imgcat-v${version}.tar.gz 8f18e10464ed1426b29a5b11aee766a43db92be17ba0a17fd127dd9cf9fb544b"
+auth_type=sha256
 
 build() {
     run make \

--- a/Ports/jot/package.sh
+++ b/Ports/jot/package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=jot
 version=6.6
-files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/jot-${version}.tar.gz jot-${version}.tar.gz 6905e24f8b3c61dad19f1d6608de4ae0"
-auth_type=md5
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/jot-${version}.tar.gz jot-${version}.tar.gz ad7d955e6a22b5c71d32479703cdac6f2c009765e7bf1bb860775f05b1e1d303"
+auth_type=sha256
 depends=libpuffy

--- a/Ports/klong/package.sh
+++ b/Ports/klong/package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=klong
 version=20190926
-files="http://t3x.org/klong/klong20190926.tgz klong20190926.tgz d03ed117cc8b9fadc87c1dd68b7fe7ec"
-auth_type=md5
+files="http://t3x.org/klong/klong20190926.tgz klong20190926.tgz 98009744f2200fc34d94b129590bbe52de1d330acbdb7c28e36d34a5cb30dc48"
+auth_type=sha256
 useconfigure=false
 workdir=klong

--- a/Ports/libassuan/package.sh
+++ b/Ports/libassuan/package.sh
@@ -3,8 +3,8 @@ port=libassuan
 version=2.5.5
 useconfigure=true
 #configopts="--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
-files="https://gnupg.org/ftp/gcrypt/libassuan/libassuan-${version}.tar.bz2 libassuan-${version}.tar.bz2 7194453152bb67e3d45da698762b5d6f"
-auth_type=md5
+files="https://gnupg.org/ftp/gcrypt/libassuan/libassuan-${version}.tar.bz2 libassuan-${version}.tar.bz2 8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4"
+auth_type=sha256
 
 pre_configure() {
     export gcry_cv_gcc_has_f_visibility=no

--- a/Ports/libffi/package.sh
+++ b/Ports/libffi/package.sh
@@ -2,5 +2,5 @@
 port=libffi
 version=3.3
 useconfigure=true
-files="ftp://sourceware.org/pub/libffi/libffi-${version}.tar.gz libffi-${version}.tar.gz 6313289e32f1d38a9df4770b014a2ca7"
-auth_type=md5
+files="ftp://sourceware.org/pub/libffi/libffi-${version}.tar.gz libffi-${version}.tar.gz 72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056"
+auth_type=sha256

--- a/Ports/libgcrypt/package.sh
+++ b/Ports/libgcrypt/package.sh
@@ -4,8 +4,8 @@ version=1.9.2
 useconfigure=true
 configopts="--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
 depends=libgpg-error
-files="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${version}.tar.bz2 libgcrypt-${version}.tar.bz2 00121b05e1ff4cc85a4a6503e0a7d9fb"
-auth_type=md5
+files="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${version}.tar.bz2 libgcrypt-${version}.tar.bz2 b2c10d091513b271e47177274607b1ffba3d95b188bbfa8797f948aec9053c5a"
+auth_type=sha256
 
 pre_configure() {
     export gcry_cv_gcc_has_f_visibility=no

--- a/Ports/libgpg-error/package.sh
+++ b/Ports/libgpg-error/package.sh
@@ -3,8 +3,8 @@ port=libgpg-error
 version=1.42
 useconfigure=true
 configopts="--disable-tests --disable-threads"
-files="https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-${version}.tar.bz2 libgpg-error-${version}.tar.bz2 133fed221ba8f63f5842858a1ff67cb3"
-auth_type=md5
+files="https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-${version}.tar.bz2 libgpg-error-${version}.tar.bz2 fc07e70f6c615f8c4f590a8e37a9b8dd2e2ca1e9408f8e60459c67452b925e23"
+auth_type=sha256
 
 pre_configure() {
     export gcry_cv_gcc_has_f_visibility=no

--- a/Ports/libicu/package.sh
+++ b/Ports/libicu/package.sh
@@ -4,8 +4,8 @@ version=69.1
 useconfigure=true
 workdir=icu/source
 configopts=--with-cross-build=$(pwd)/${workdir}/../host-build
-files="https://github.com/unicode-org/icu/releases/download/release-${version//./-}/icu4c-${version//./_}-src.tgz icu4c-${version//./_}-src.tgz 9403db682507369d0f60a25ea67014c4"
-auth_type=md5
+files="https://github.com/unicode-org/icu/releases/download/release-${version//./-}/icu4c-${version//./_}-src.tgz icu4c-${version//./_}-src.tgz 4cba7b7acd1d3c42c44bb0c14be6637098c7faf2b330ce876bc5f3b915d09745"
+auth_type=sha256
 
 configure() {
     host_env

--- a/Ports/libjpeg/package.sh
+++ b/Ports/libjpeg/package.sh
@@ -2,8 +2,8 @@
 port=libjpeg
 version=9d
 useconfigure=true
-files="https://ijg.org/files/jpegsrc.v${version}.tar.gz jpeg-${version}.tar.gz ad7e40dedc268f97c44e7ee3cd54548a"
-auth_type="md5"
+files="https://ijg.org/files/jpegsrc.v${version}.tar.gz jpeg-${version}.tar.gz 6c434a3be59f8f62425b2e3c077e785c9ce30ee5874ea1c270e843f273ba71ee"
+auth_type=sha256
 workdir="jpeg-$version"
 
 install() {

--- a/Ports/libksba/package.sh
+++ b/Ports/libksba/package.sh
@@ -2,8 +2,8 @@
 port=libksba
 version=1.5.1
 useconfigure=true
-files="https://gnupg.org/ftp/gcrypt/libksba/libksba-${version}.tar.bz2 libksba-${version}.tar.bz2 96e207b7adc637a3dbc29bac90312200"
-auth_type=md5
+files="https://gnupg.org/ftp/gcrypt/libksba/libksba-${version}.tar.bz2 libksba-${version}.tar.bz2 b0f4c65e4e447d9a2349f6b8c0e77a28be9531e4548ba02c545d1f46dc7bf921"
+auth_type=sha256
 
 pre_configure() {
     export ksba_cv_gcc_has_f_visibility=no

--- a/Ports/libogg/package.sh
+++ b/Ports/libogg/package.sh
@@ -2,8 +2,8 @@
 port=libogg
 version=1.3.4
 useconfigure=true
-files="https://github.com/xiph/ogg/releases/download/v${version}/libogg-${version}.tar.gz libogg-${version}.tar.gz b9a66c80bdf45363605e4aa75fa951a8"
-auth_type=md5
+files="https://github.com/xiph/ogg/releases/download/v${version}/libogg-${version}.tar.gz libogg-${version}.tar.gz fe5670640bd49e828d64d2879c31cb4dde9758681bb664f9bdbf159a01b0c76e"
+auth_type=sha256
 
 install() {
     run make DESTDIR=${SERENITY_INSTALL_ROOT} $installopts install

--- a/Ports/libpng/package.sh
+++ b/Ports/libpng/package.sh
@@ -2,8 +2,8 @@
 port=libpng
 version=1.6.37
 useconfigure=true
-files="https://download.sourceforge.net/libpng/libpng-${version}.tar.gz libpng-${version}.tar.gz 6c7519f6c75939efa0ed3053197abd54"
-auth_type=md5
+files="https://download.sourceforge.net/libpng/libpng-${version}.tar.gz libpng-${version}.tar.gz daeb2620d829575513e35fecc83f0d3791a620b9b93d800b763542ece9390fb4"
+auth_type=sha256
 depends="zlib"
 
 install() {

--- a/Ports/libpuffy/package.sh
+++ b/Ports/libpuffy/package.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=libpuffy
 version=1.0
-files="https://github.com/ibara/libpuffy/releases/download/libpuffy-${version}/libpuffy-${version}.tar.gz libpuffy-${version}.tar.gz b22b6f24a3d4f3ac67f43b9efd3a9dc1"
-auth_type=md5
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-${version}/libpuffy-${version}.tar.gz libpuffy-${version}.tar.gz 919bb025fed88227fe464116194c978513a864a223542f50c59a7c17b0dd9caa"
+auth_type=sha256

--- a/Ports/libvorbis/package.sh
+++ b/Ports/libvorbis/package.sh
@@ -2,8 +2,8 @@
 port=libvorbis
 version=1.3.7
 useconfigure=true
-files="https://github.com/xiph/vorbis/releases/download/v${version}/libvorbis-${version}.tar.gz libvorbis-${version}.tar.gz 9b8034da6edc1a17d18b9bc4542015c7"
-auth_type=md5
+files="https://github.com/xiph/vorbis/releases/download/v${version}/libvorbis-${version}.tar.gz libvorbis-${version}.tar.gz 0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab"
+auth_type=sha256
 depends=libogg
 
 install() {

--- a/Ports/libzip/package.sh
+++ b/Ports/libzip/package.sh
@@ -5,8 +5,8 @@ version=1.7.3
 depends="zlib"
 workdir=libzip-${version}
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
-files="https://libzip.org/download/libzip-${version}.tar.gz libzip-${version}.tar.gz 76f8fea9b88f6ead7f15ed7712eb5aef"
-auth_type=md5
+files="https://libzip.org/download/libzip-${version}.tar.gz libzip-${version}.tar.gz 0e2276c550c5a310d4ebf3a2c3dfc43fb3b4602a072ff625842ad4f3238cb9cc"
+auth_type=sha256
 
 configure() {
     run cmake $configopts

--- a/Ports/links/package.sh
+++ b/Ports/links/package.sh
@@ -2,5 +2,5 @@
 port=links
 version=2.22
 useconfigure=true
-files="http://links.twibright.com/download/links-${version}.tar.bz2 links-${version}.tar.bz2 55f745dea500aac52cede98bab8d96e2"
-auth_type=md5
+files="http://links.twibright.com/download/links-${version}.tar.bz2 links-${version}.tar.bz2 0364986b3a7f1e8e3171bea362b53f71e1dd3360a8842d66fdc65580ebc2084d"
+auth_type=sha256

--- a/Ports/lua/package.sh
+++ b/Ports/lua/package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=lua
 version=5.3.5
-files="http://www.lua.org/ftp/lua-${version}.tar.gz lua-${version}.tar.gz 4f4b4f323fd3514a68e0ab3da8ce3455"
-auth_type=md5
+files="http://www.lua.org/ftp/lua-${version}.tar.gz lua-${version}.tar.gz 0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac"
+auth_type=sha256
 makeopts="-j$(nproc) serenity"
 installopts="INSTALL_TOP=${SERENITY_INSTALL_ROOT}/usr/local"

--- a/Ports/mbedtls/package.sh
+++ b/Ports/mbedtls/package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=mbedtls
 version=2.16.2
-files="https://tls.mbed.org/download/mbedtls-${version}-apache.tgz mbedtls-${version}-apache.tgz ba809acfd4b41b86895b92e98d936695b5b62b73"
+files="https://tls.mbed.org/download/mbedtls-${version}-apache.tgz mbedtls-${version}-apache.tgz a6834fcd7b7e64b83dfaaa6ee695198cb5019a929b2806cb0162e049f98206a4"
 makeopts="CFLAGS=-DPLATFORM_UTIL_USE_GMTIME"
-auth_type="sha1"
+auth_type=sha256

--- a/Ports/mrsh/package.sh
+++ b/Ports/mrsh/package.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=mrsh
 version=d9763a32e7da572677d1681bb1fc67f117d641f3
-files="https://codeload.github.com/emersion/mrsh/legacy.tar.gz/${version} emersion-mrsh-d9763a3.tar.gz 80d268ebf0fca32293605b6e91bc64d0"
-auth_type=md5
+files="https://codeload.github.com/emersion/mrsh/legacy.tar.gz/${version} emersion-mrsh-d9763a3.tar.gz 6896493a1020774715ccca28e8d8f4ec722af63a93543fb6dd2762f7b1de9c8a"
+auth_type=sha256
 useconfigure=true
 makeopts=
 workdir=emersion-mrsh-d9763a3

--- a/Ports/neofetch/package.sh
+++ b/Ports/neofetch/package.sh
@@ -4,8 +4,8 @@ port=neofetch
 version=7.1.0
 useconfigure=false
 depends="bash jq"
-files="https://github.com/dylanaraps/neofetch/archive/${version}.tar.gz neofetch-${version}.tar.gz 37ba9026fdd353f66d822fdce16420a8"
-auth_type=md5
+files="https://github.com/dylanaraps/neofetch/archive/${version}.tar.gz neofetch-${version}.tar.gz 58a95e6b714e41efc804eca389a223309169b2def35e57fa934482a6b47c27e7"
+auth_type=sha256
 
 install() {
     run make DESTDIR=${SERENITY_INSTALL_ROOT} PREFIX=/usr/local $installopts install

--- a/Ports/nethack/package.sh
+++ b/Ports/nethack/package.sh
@@ -2,8 +2,8 @@
 port=nethack
 version=3.6.6
 workdir=NetHack-NetHack-${version}_Released
-files="https://www.nethack.org/download/${version}/nethack-${version//.}-src.tgz nethack-${version//.}-src.tgz 6c9a75f556d24c66801d74d8727a602e"
-auth_type=md5
+files="https://www.nethack.org/download/${version}/nethack-${version//.}-src.tgz nethack-${version//.}-src.tgz cfde0c3ab6dd7c22ae82e1e5a59ab80152304eb23fb06e3129439271e5643ed2"
+auth_type=sha256
 depends="ncurses bash"
 
 build() {

--- a/Ports/ninja/package.sh
+++ b/Ports/ninja/package.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=ninja
 version=1.8.2
-files="https://github.com/ninja-build/ninja/archive/v${version}.tar.gz ninja-v${version}.tar.gz 5fdb04461cc7f5d02536b3bfc0300166"
-auth_type=md5
+files="https://github.com/ninja-build/ninja/archive/v${version}.tar.gz ninja-v${version}.tar.gz 86b8700c3d0880c2b44c2ff67ce42774aaf8c28cbf57725cb881569288c1c6f4"
+auth_type=sha256
 
 build() {
     CXXFLAGS="--sysroot=${SERENITY_INSTALL_ROOT}" \

--- a/Ports/npth/package.sh
+++ b/Ports/npth/package.sh
@@ -2,8 +2,8 @@
 port=npth
 version=1.6
 useconfigure=true
-files="https://gnupg.org/ftp/gcrypt/npth/npth-${version}.tar.bz2 npth-${version}.tar.bz2 375d1a15ad969f32d25f1a7630929854"
-auth_type=md5
+files="https://gnupg.org/ftp/gcrypt/npth/npth-${version}.tar.bz2 npth-${version}.tar.bz2 1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1"
+auth_type=sha256
 
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" $configopts

--- a/Ports/ntbtls/package.sh
+++ b/Ports/ntbtls/package.sh
@@ -3,8 +3,8 @@ port=ntbtls
 version=0.2.0
 useconfigure=true
 #configopts="--with-libgpg-error-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
-files="https://gnupg.org/ftp/gcrypt/ntbtls/ntbtls-${version}.tar.bz2 ntbtls-${version}.tar.bz2 efe1b12502df319bf78707a2fa767098"
-auth_type=md5
+files="https://gnupg.org/ftp/gcrypt/ntbtls/ntbtls-${version}.tar.bz2 ntbtls-${version}.tar.bz2 649fe74a311d13e43b16b26ebaa91665ddb632925b73902592eac3ed30519e17"
+auth_type=sha256
 
 pre_configure() {
     export ntbtls_cv_gcc_has_f_visibility=no

--- a/Ports/nyancat/package.sh
+++ b/Ports/nyancat/package.sh
@@ -2,8 +2,8 @@
 port=nyancat
 version=git
 workdir=nyancat-master
-files="https://github.com/klange/nyancat/archive/master.tar.gz nyancat-git.tar.gz dcb9dc135f87a4e5e0e6e72e6c3b2430"
-auth_type=md5
+files="https://github.com/klange/nyancat/archive/master.tar.gz nyancat-git.tar.gz cfd6c817f25adcecc9490321991ecb571bfdfe0d8c249663843d3df4194f935d"
+auth_type=sha256
 launcher_name=Nyancat
 launcher_category=Games
 launcher_command="Terminal -e nyancat"

--- a/Ports/oksh/package.sh
+++ b/Ports/oksh/package.sh
@@ -4,8 +4,8 @@ useconfigure=true
 version=6.8.1
 depends="ncurses"
 workdir=oksh-${version}
-files="https://github.com/ibara/oksh/releases/download/oksh-${version}/oksh-${version}.tar.gz oksh-${version}.tar.gz ce8b7c278e6d36bbbd7b54c218fae7ba"
-auth_type=md5
+files="https://github.com/ibara/oksh/releases/download/oksh-${version}/oksh-${version}.tar.gz oksh-${version}.tar.gz ddd2b27b99009a4ee58ddf58da73edf83962018066ccf33b2fe1f570a00917b0"
+auth_type=sha256
 
 configure() {
     export CC=${SERENITY_SOURCE_DIR}/Toolchain/Local/${SERENITY_ARCH}/bin/${SERENITY_ARCH}-pc-serenity-gcc 

--- a/Ports/openssh/package.sh
+++ b/Ports/openssh/package.sh
@@ -2,8 +2,8 @@
 port=openssh
 workdir=openssh-portable-9ca7e9c861775dd6c6312bc8aaab687403d24676
 version=8.3-9ca7e9c
-files="https://github.com/openssh/openssh-portable/archive/9ca7e9c861775dd6c6312bc8aaab687403d24676.tar.gz openssh-8.3-9ca7e9c.tar.gz 9ddfeabac11b59a1c5670a6905463ce2"
-auth_type=md5
+files="https://github.com/openssh/openssh-portable/archive/9ca7e9c861775dd6c6312bc8aaab687403d24676.tar.gz openssh-8.3-9ca7e9c.tar.gz 78e3051cd76e505b1c9ea4fdcc108f47c64d4db058dad4f776908ed0229f6234"
+auth_type=sha256
 depends="zlib openssl"
 useconfigure=true
 configopts="--prefix=/usr/local --disable-utmp --disable-strip --sysconfdir=/etc/ssh --with-ssl-dir=${SERENITY_INSTALL_ROOT}/usr/local/lib"

--- a/Ports/patch/package.sh
+++ b/Ports/patch/package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=patch
 version=6.6
-files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/patch-${version}.tar.gz patch-${version}.tar.gz 451c14a5ec595465d0dcc05d86eed195"
-auth_type=md5
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/patch-${version}.tar.gz patch-${version}.tar.gz b82ba726d9bdb683534839673f0c845d4f97c8d08490fa53dbef502665fee637"
+auth_type=sha256
 depends=libpuffy

--- a/Ports/pkgconf/package.sh
+++ b/Ports/pkgconf/package.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=pkgconf
 version=1.7.3
-files="https://distfiles.dereferenced.org/pkgconf/pkgconf-${version}.tar.xz pkgconf-${version}.tar.xz 2a19acafd0eccb61d09a5bbf7ce18c9d"
-auth_type=md5
+files="https://distfiles.dereferenced.org/pkgconf/pkgconf-${version}.tar.xz pkgconf-${version}.tar.xz b846aea51cf696c3392a0ae58bef93e2e72f8e7073ca6ad1ed8b01c85871f9c0"
+auth_type=sha256
 useconfigure=true
 # FIXME: This looks suspiciously host-y... 
 configopts="--prefix=/usr/local --with-pkg-config-dir=/usr/local/lib/pkgconfig"

--- a/Ports/printf/package.sh
+++ b/Ports/printf/package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=printf
 version=6.6
-files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/printf-${version}.tar.gz printf-${version}.tar.gz 384e80195cfaf474159efb8631e5271b"
-auth_type=md5
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/printf-${version}.tar.gz printf-${version}.tar.gz 44b68af9795a3cde7dfc73a588fd2b12054dd84d1ab520106713d49935d791a8"
+auth_type=sha256
 depends=libpuffy

--- a/Ports/pt2-clone/package.sh
+++ b/Ports/pt2-clone/package.sh
@@ -2,8 +2,8 @@
 port=pt2-clone
 version=1.28
 useconfigure=true
-files="https://github.com/8bitbubsy/pt2-clone/archive/v${version}.tar.gz v${version}.tar.gz 42df939c03b7e598ed8b17a764150860"
-auth_type=md5
+files="https://github.com/8bitbubsy/pt2-clone/archive/v${version}.tar.gz v${version}.tar.gz a3ce83e326d94f1abf6dd75fb788fe508922818c08e6f988155df9ed288f180e"
+auth_type=sha256
 configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_SOURCE_DIR/Toolchain/CMake/CMakeToolchain.txt"
 depends="SDL2"
 

--- a/Ports/rsync/package.sh
+++ b/Ports/rsync/package.sh
@@ -2,7 +2,7 @@
 port=rsync
 version=3.1.3
 useconfigure="true"
-files="https://download.samba.org/pub/rsync/src/rsync-${version}.tar.gz rsync-${version}.tar.gz 1581a588fde9d89f6bc6201e8129afaf
+files="https://download.samba.org/pub/rsync/src/rsync-${version}.tar.gz rsync-${version}.tar.gz 55cc554efec5fdaad70de921cd5a5eeb6c29a95524c715f3bbf849235b0800c0
 https://download.samba.org/pub/rsync/src/rsync-${version}.tar.gz.asc rsync-${version}.tar.gz.asc 5cde11b63857d647f6cb9850f76c52cb"
-auth_type=md5
+auth_type=sha256
 configopts="--target=${SERENITY_ARCH}-pc-serenity"

--- a/Ports/scummvm/package.sh
+++ b/Ports/scummvm/package.sh
@@ -2,8 +2,8 @@
 port=scummvm
 useconfigure="true"
 version="2.2.0"
-files="https://downloads.scummvm.org/frs/scummvm/${version}/scummvm-${version}.tar.gz scummvm-${version}.tar.gz f48f07347e5ab0b3094a868367c0e1f2"
-auth_type=md5
+files="https://downloads.scummvm.org/frs/scummvm/${version}/scummvm-${version}.tar.gz scummvm-${version}.tar.gz 6ec5bd63b73861c10ca9869f27a74989a9ad6013bad30a1ef70de6ec146c2cb5"
+auth_type=sha256
 depends="SDL2"
 configopts="
     --enable-c++11

--- a/Ports/sl/package.sh
+++ b/Ports/sl/package.sh
@@ -2,8 +2,8 @@
 port=sl
 version=git
 workdir=sl-master
-files="https://github.com/mtoyoda/sl/archive/master.tar.gz sl-git.tar.gz 230347a534644a46e635877a6b0dfb77"
-auth_type=md5
+files="https://github.com/mtoyoda/sl/archive/master.tar.gz sl-git.tar.gz 3270434e28c4f4e15b8e98de60ea98508a7486485f52356a61f36ac5430fbc80"
+auth_type=sha256
 depends="ncurses"
 
 build() {

--- a/Ports/sqlite/package.sh
+++ b/Ports/sqlite/package.sh
@@ -2,6 +2,6 @@
 port=sqlite
 useconfigure="true"
 version="3350300"
-files="https://www.sqlite.org/2021/sqlite-autoconf-${version}.tar.gz sqlite-autoconf-${version}.tar.gz cadd4db9b528dfd0a7efde39f767cd83"
-auth_type=md5
+files="https://www.sqlite.org/2021/sqlite-autoconf-${version}.tar.gz sqlite-autoconf-${version}.tar.gz ecbccdd440bdf32c0e1bb3611d635239e3b5af268248d130d0445a32daf0274b"
+auth_type=sha256
 workdir="sqlite-autoconf-${version}"

--- a/Ports/stress-ng/package.sh
+++ b/Ports/stress-ng/package.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=stress-ng
 version=0.11.23
-files="https://github.com/ColinIanKing/stress-ng/archive/V${version}.tar.gz stress-ng-${version}.tar.gz 49fa5547c8cfd7871b9d6261cce6ace3"
-auth_type=md5
+files="https://github.com/ColinIanKing/stress-ng/archive/V${version}.tar.gz stress-ng-${version}.tar.gz ffa1c516e3098a1d7ae6a4fd48c6fb41b8dfaabda22aaeebb569d24875870216"
+auth_type=sha256
 depends=zlib
 
 pre_configure() {

--- a/Ports/termcap/package.sh
+++ b/Ports/termcap/package.sh
@@ -3,5 +3,5 @@ port=termcap
 version=1.3.1
 useconfigure=true
 configopts="--prefix=${SERENITY_INSTALL_ROOT}/usr/local"
-files="https://ftpmirror.gnu.org/gnu/termcap/termcap-${version}.tar.gz termcap-${version}.tar.gz ffe6f86e63a3a29fa53ac645faaabdfa"
-auth_type=md5
+files="https://ftpmirror.gnu.org/gnu/termcap/termcap-${version}.tar.gz termcap-${version}.tar.gz 91a0e22e5387ca4467b5bcb18edf1c51b930262fd466d5fda396dd9d26719100"
+auth_type=sha256

--- a/Ports/tinycc/package.sh
+++ b/Ports/tinycc/package.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=tinycc
 version=dev
-files="https://github.com/TinyCC/tinycc/archive/dev.tar.gz tinycc-dev.tar.gz 400f909c1dc2d392efff8279fec1cfdb"
-auth_type=md5
+files="https://github.com/TinyCC/tinycc/archive/dev.tar.gz tinycc-dev.tar.gz 1e16fd9926e8e2662a35c790b7c56e8e7e8769c6a8a86a59a534c26046d0d83e"
+auth_type=sha256
 useconfigure=true
 makeopts=tcc
 

--- a/Ports/tinyscheme/package.sh
+++ b/Ports/tinyscheme/package.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=tinyscheme
 version=1.42
-files="https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinyscheme-${version}/tinyscheme-${version}.tar.gz tinyscheme-${version}.tar.gz 273ac5ffe5305986b329e9045f2aea89"
-auth_type=md5
+files="https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinyscheme-${version}/tinyscheme-${version}.tar.gz tinyscheme-${version}.tar.gz 17b0b1bffd22f3d49d5833e22a120b339039d2cfda0b46d6fc51dd2f01b407ad"
+auth_type=sha256
 useconfigure=false
 
 build() {

--- a/Ports/tr/package.sh
+++ b/Ports/tr/package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=tr
 version=6.7
-files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/tr-${version}.tar.gz tr-${version}.tar.gz d54e214d8f2ba615a3175063379d0ce9"
-auth_type=md5
+files="https://github.com/ibara/libpuffy/releases/download/libpuffy-1.0/tr-${version}.tar.gz tr-${version}.tar.gz 6390b9f90baf097c7ee660e3d1f107161dd422e3048ce7b7bea65043b916d416"
+auth_type=sha256
 depends=libpuffy

--- a/Ports/vim/package.sh
+++ b/Ports/vim/package.sh
@@ -3,8 +3,8 @@ port=vim
 version=8.2.2772
 workdir="${port}-${version}"
 useconfigure="true"
-files="https://github.com/vim/vim/archive/refs/tags/v${version}.tar.gz vim-v${version}.tar.gz 0dbd7323008c1d95d0396e119210630f"
-auth_type=md5
+files="https://github.com/vim/vim/archive/refs/tags/v${version}.tar.gz vim-v${version}.tar.gz 47613400943bbf3e110c38e8c4923b9e51c1d63d9774313820e1d9b4c4bb9e11"
+auth_type=sha256
 configopts="--with-tlib=tinfo --with-features=normal"
 depends="ncurses"
 

--- a/Ports/vttest/package.sh
+++ b/Ports/vttest/package.sh
@@ -2,5 +2,5 @@
 port=vttest
 version=20210210
 useconfigure=true
-files="https://invisible-island.net/datafiles/release/vttest.tar.gz vttest.tar.gz 21c7493640a7912ea746b3eb0689f2a7"
-auth_type=md5
+files="https://invisible-island.net/datafiles/release/vttest.tar.gz vttest.tar.gz 0f98a2e305982915f1520984c3e8698e3acd508ee210711528c89f5a7ea7f046"
+auth_type=sha256


### PR DESCRIPTION
This PR changes the port scripts so that:

* Updates the `ports-lint.py` script to only allow SHA256 and GPG.
* Updates all ports which still used other signature algorithms to use SHA256.
* Updates the `.port_include.sh` so that it attempts to download files again one more time when verification fails. This was previously an issue when cancelling `./package.sh fetch` during the download phase. That way you'd end up with partially downloaded files which would then fail verification when the `package.sh` script is run again.
* Makes sure we only extract files after verification has succeeded.