### PR TITLE
IPCCompiler: Remove hardcoded endpoint magic, attempt deux

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageServers/LanguageClient.ipc
+++ b/Userland/DevTools/HackStudio/LanguageServers/LanguageClient.ipc
@@ -1,4 +1,4 @@
-endpoint LanguageClient = 8002
+endpoint LanguageClient
 {
     AutoCompleteSuggestions(Vector<GUI::AutocompleteProvider::Entry> suggestions) =|
     DeclarationLocation(GUI::AutocompleteProvider::ProjectLocation location) =|

--- a/Userland/DevTools/HackStudio/LanguageServers/LanguageServer.ipc
+++ b/Userland/DevTools/HackStudio/LanguageServers/LanguageServer.ipc
@@ -1,4 +1,4 @@
-endpoint LanguageServer = 8001
+endpoint LanguageServer
 {
     Greet(String project_root) => ()
 

--- a/Userland/Libraries/LibC/netdb.cpp
+++ b/Userland/Libraries/LibC/netdb.cpp
@@ -26,6 +26,11 @@ static in_addr_t* __gethostbyname_address_list_buffer[2];
 
 static hostent __gethostbyaddr_buffer;
 static in_addr_t* __gethostbyaddr_address_list_buffer[2];
+// XXX: IPCCompiler depends on LibC. Because of this, it cannot be compiled
+// before LibC is. However, the lookup magic can only be obtained from the
+// endpoint itself if IPCCompiler has compiled the IPC file, so this creates
+// a chicken-and-egg situation. Because of this, the LookupServer endpoint magic
+// is hardcoded here.
 static constexpr i32 lookup_server_endpoint_magic = 9001;
 
 // Get service entry buffers and file information for the getservent() family of functions.

--- a/Userland/Libraries/LibIPC/Endpoint.h
+++ b/Userland/Libraries/LibIPC/Endpoint.h
@@ -21,7 +21,7 @@ class Endpoint {
 public:
     virtual ~Endpoint();
 
-    virtual int magic() const = 0;
+    virtual u32 magic() const = 0;
     virtual String name() const = 0;
     virtual OwnPtr<Message> handle(const Message&) = 0;
 

--- a/Userland/Libraries/LibIPC/Message.h
+++ b/Userland/Libraries/LibIPC/Message.h
@@ -20,7 +20,7 @@ class Message {
 public:
     virtual ~Message();
 
-    virtual int endpoint_magic() const = 0;
+    virtual u32 endpoint_magic() const = 0;
     virtual int message_id() const = 0;
     virtual const char* message_name() const = 0;
     virtual MessageBuffer encode() const = 0;

--- a/Userland/Services/AudioServer/AudioClient.ipc
+++ b/Userland/Services/AudioServer/AudioClient.ipc
@@ -1,4 +1,4 @@
-endpoint AudioClient = 82
+endpoint AudioClient
 {
     FinishedPlayingBuffer(i32 buffer_id) =|
     MutedStateChanged(bool muted) =|

--- a/Userland/Services/AudioServer/AudioServer.ipc
+++ b/Userland/Services/AudioServer/AudioServer.ipc
@@ -1,4 +1,4 @@
-endpoint AudioServer = 85
+endpoint AudioServer
 {
     // Basic protocol
     Greet() => ()

--- a/Userland/Services/Clipboard/ClipboardClient.ipc
+++ b/Userland/Services/Clipboard/ClipboardClient.ipc
@@ -1,4 +1,4 @@
-endpoint ClipboardClient = 804
+endpoint ClipboardClient
 {
     ClipboardDataChanged([UTF8] String mime_type) =|
 }

--- a/Userland/Services/Clipboard/ClipboardServer.ipc
+++ b/Userland/Services/Clipboard/ClipboardServer.ipc
@@ -1,4 +1,4 @@
-endpoint ClipboardServer = 802
+endpoint ClipboardServer
 {
     Greet() => ()
 

--- a/Userland/Services/ImageDecoder/ImageDecoderClient.ipc
+++ b/Userland/Services/ImageDecoder/ImageDecoderClient.ipc
@@ -1,4 +1,4 @@
-endpoint ImageDecoderClient = 7002
+endpoint ImageDecoderClient
 {
     Dummy() =|
 }

--- a/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
+++ b/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
@@ -1,4 +1,4 @@
-endpoint ImageDecoderServer = 7001
+endpoint ImageDecoderServer
 {
     Greet() => ()
 

--- a/Userland/Services/LaunchServer/LaunchClient.ipc
+++ b/Userland/Services/LaunchServer/LaunchClient.ipc
@@ -1,4 +1,4 @@
-endpoint LaunchClient = 102
+endpoint LaunchClient
 {
     Dummy() =|
 }

--- a/Userland/Services/LaunchServer/LaunchServer.ipc
+++ b/Userland/Services/LaunchServer/LaunchServer.ipc
@@ -1,4 +1,4 @@
-endpoint LaunchServer = 101
+endpoint LaunchServer
 {
     Greet() => ()
     OpenURL(URL url, String handler_name) => (bool response)

--- a/Userland/Services/LookupServer/LookupClient.ipc
+++ b/Userland/Services/LookupServer/LookupClient.ipc
@@ -1,4 +1,4 @@
-endpoint LookupClient = 9002
+endpoint LookupClient
 {
     Dummy() =|
 }

--- a/Userland/Services/LookupServer/LookupServer.ipc
+++ b/Userland/Services/LookupServer/LookupServer.ipc
@@ -1,4 +1,4 @@
-endpoint LookupServer = 9001
+endpoint LookupServer [magic=9001]
 {
     LookupName(String name) => (int code, Vector<String> addresses)
     LookupAddress(String address) => (int code, String name)

--- a/Userland/Services/NotificationServer/NotificationClient.ipc
+++ b/Userland/Services/NotificationServer/NotificationClient.ipc
@@ -1,4 +1,4 @@
-endpoint NotificationClient = 92
+endpoint NotificationClient
 {
     Dummy() =|
 }

--- a/Userland/Services/NotificationServer/NotificationServer.ipc
+++ b/Userland/Services/NotificationServer/NotificationServer.ipc
@@ -1,4 +1,4 @@
-endpoint NotificationServer = 95
+endpoint NotificationServer
 {
     // Basic protocol
     Greet() => ()

--- a/Userland/Services/ProtocolServer/ProtocolClient.ipc
+++ b/Userland/Services/ProtocolServer/ProtocolClient.ipc
@@ -1,4 +1,4 @@
-endpoint ProtocolClient = 13
+endpoint ProtocolClient
 {
     // Download notifications
     DownloadProgress(i32 download_id, Optional<u32> total_size, u32 downloaded_size) =|

--- a/Userland/Services/ProtocolServer/ProtocolServer.ipc
+++ b/Userland/Services/ProtocolServer/ProtocolServer.ipc
@@ -1,4 +1,4 @@
-endpoint ProtocolServer = 9
+endpoint ProtocolServer
 {
     // Basic protocol
     Greet() => ()

--- a/Userland/Services/SymbolServer/SymbolClient.ipc
+++ b/Userland/Services/SymbolServer/SymbolClient.ipc
@@ -1,4 +1,4 @@
-endpoint SymbolClient = 4541511
+endpoint SymbolClient
 {
     Dummy() =|
 }

--- a/Userland/Services/SymbolServer/SymbolServer.ipc
+++ b/Userland/Services/SymbolServer/SymbolServer.ipc
@@ -1,4 +1,4 @@
-endpoint SymbolServer = 4541510
+endpoint SymbolServer
 {
     Greet() => ()
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -1,4 +1,4 @@
-endpoint WebContentClient = 90
+endpoint WebContentClient
 {
     DidStartLoading(URL url) =|
     DidFinishLoading(URL url) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -1,4 +1,4 @@
-endpoint WebContentServer = 89
+endpoint WebContentServer
 {
     Greet() => ()
 

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -1,4 +1,4 @@
-endpoint WindowClient = 4
+endpoint WindowClient
 {
     Paint(i32 window_id, Gfx::IntSize window_size, Vector<Gfx::IntRect> rects) =|
     MouseMove(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta, bool is_drag, Vector<String> mime_types) =|

--- a/Userland/Services/WindowServer/WindowManagerClient.ipc
+++ b/Userland/Services/WindowServer/WindowManagerClient.ipc
@@ -1,4 +1,4 @@
-endpoint WindowManagerClient = 1872
+endpoint WindowManagerClient
 {
     WindowRemoved(i32 wm_id, i32 client_id, i32 window_id) =|
     WindowStateChanged(i32 wm_id, i32 client_id, i32 window_id, i32 parent_client_id, i32 parent_window_id, bool is_active, bool is_minimized, bool is_modal, bool is_frameless, i32 window_type, [UTF8] String title, Gfx::IntRect rect, i32 progress) =|

--- a/Userland/Services/WindowServer/WindowManagerServer.ipc
+++ b/Userland/Services/WindowServer/WindowManagerServer.ipc
@@ -1,4 +1,4 @@
-endpoint WindowManagerServer = 1871
+endpoint WindowManagerServer
 {
     SetEventMask(u32 event_mask) => ()
     SetManagerWindow(i32 window_id) => ()

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -1,4 +1,4 @@
-endpoint WindowServer = 2
+endpoint WindowServer
 {
     Greet() => (Gfx::IntRect screen_rect, Core::AnonymousBuffer theme_buffer)
 


### PR DESCRIPTION
This patch removes the IPC endpoint numbers that needed to be specified
in the IPC files.  Since the string hash is a (hopefully) collision free
number that depends on the name of the endpoint, we now use that
instead. :^)

Additionally, endpoint magic is now treated as a u32, because endpoint
numbers were never negative anyway.

For cases where the endpoint number does have to be hardcoded (a current
case is `LookupServer` because the endpoint number must be known in `LibC`),
the syntax has been made more explicit to avoid confusing those
unfamiliar.  To hardcode the endpoint magic, the following syntax is now
used:
```
endpoint EndpointName [magic=1234]
```