### PR TITLE
FileManager+unzip: Unzip from context menu

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -49,6 +49,7 @@
 #include <spawn.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 using namespace FileManager;
@@ -58,6 +59,7 @@ static int run_in_windowed_mode(RefPtr<Core::ConfigFile>, String initial_locatio
 static void do_copy(const Vector<String>& selected_file_paths, FileUtils::FileOperation file_operation);
 static void do_paste(const String& target_directory, GUI::Window* window);
 static void do_create_link(const Vector<String>& selected_file_paths, GUI::Window* window);
+static void do_unzip_archive(const Vector<String>& selected_file_paths, GUI::Window* window);
 static void show_properties(const String& container_dir_path, const String& path, const Vector<String>& selected, GUI::Window* window);
 static bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, const DirectoryView& directory_view, const String& full_path, RefPtr<GUI::Action>& default_action, NonnullRefPtrVector<LauncherHandler>& current_file_launch_handlers);
 
@@ -192,6 +194,32 @@ void do_create_link(const Vector<String>& selected_file_paths, GUI::Window* wind
     }
 }
 
+void do_unzip_archive(const Vector<String>& selected_file_paths, GUI::Window* window)
+{
+    String archive_file_path = selected_file_paths.first();
+    String output_directory_path = archive_file_path.substring(0, archive_file_path.length() - 4);
+
+    pid_t unzip_pid = fork();
+    if (unzip_pid < 0) {
+        perror("fork");
+        VERIFY_NOT_REACHED();
+    }
+
+    if (!unzip_pid) {
+        int rc = execlp("/bin/unzip", "/bin/unzip", "-o", output_directory_path.characters(), archive_file_path.characters(), nullptr);
+        if (rc < 0) {
+            perror("execlp");
+            _exit(1);
+        }
+    } else {
+        // FIXME: this could probably be tied in with the new file operation progress tracking
+        int status;
+        waitpid(unzip_pid, &status, 0);
+        if(status != 0)
+            GUI::MessageBox::show(window, "Could not extract archive", "Extract Archive Error", GUI::MessageBox::Type::Error);
+    }
+}
+
 void show_properties(const String& container_dir_path, const String& path, const Vector<String>& selected, GUI::Window* window)
 {
     RefPtr<PropertiesWindow> properties;
@@ -285,6 +313,18 @@ int run_in_desktop_mode([[maybe_unused]] RefPtr<Core::ConfigFile> config)
         window);
     cut_action->set_enabled(false);
 
+    auto unzip_archive_action
+        = GUI::Action::create(
+            "E&xtract Here",
+            [&](const GUI::Action&) {
+                auto paths = directory_view.selected_file_paths();
+                if (paths.is_empty())
+                    return;
+
+                do_unzip_archive(paths, directory_view.window());
+            },
+            window);
+
     directory_view.on_selection_change = [&](const GUI::AbstractView& view) {
         copy_action->set_enabled(!view.selection().is_empty());
         cut_action->set_enabled(!view.selection().is_empty());
@@ -353,6 +393,11 @@ int run_in_desktop_mode([[maybe_unused]] RefPtr<Core::ConfigFile> config)
                 file_context_menu->add_action(paste_action);
                 file_context_menu->add_action(directory_view.delete_action());
                 file_context_menu->add_separator();
+
+                if (node.full_path().ends_with(".zip")) {
+                    file_context_menu->add_action(unzip_archive_action);
+                    file_context_menu->add_separator();
+                }
 
                 bool added_open_menu_items = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node.full_path(), file_context_menu_action_default_action, current_file_handlers);
                 if (added_open_menu_items)
@@ -645,6 +690,19 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
                     return;
                 }
                 do_create_link(paths, directory_view.window());
+            },
+            window);
+
+    auto unzip_archive_action
+        = GUI::Action::create(
+            "E&xtract Here",
+            [&](const GUI::Action&) {
+                auto paths = directory_view.selected_file_paths();
+                if (paths.is_empty())
+                    return;
+
+                do_unzip_archive(paths, directory_view.window());
+                refresh_tree_view();
             },
             window);
 
@@ -964,6 +1022,11 @@ int run_in_windowed_mode(RefPtr<Core::ConfigFile> config, String initial_locatio
                 file_context_menu->add_action(directory_view.delete_action());
                 file_context_menu->add_action(shortcut_action);
                 file_context_menu->add_separator();
+
+                if (node.full_path().ends_with(".zip")) {
+                    file_context_menu->add_action(unzip_archive_action);
+                    file_context_menu->add_separator();
+                }
 
                 bool added_launch_file_handlers = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node.full_path(), file_context_menu_action_default_action, current_file_handlers);
                 if (added_launch_file_handlers)

--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 static bool unpack_zip_member(Archive::ZipMember zip_member)
 {
@@ -71,9 +72,11 @@ int main(int argc, char** argv)
 {
     const char* path;
     int map_size_limit = 32 * MiB;
+    String output_directory_path;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(map_size_limit, "Maximum chunk size to map", "map-size-limit", 0, "size");
+    args_parser.add_option(output_directory_path, "Directory to receive the archive content", "output-directory", 'o', "path");
     args_parser.add_positional_argument(path, "File to unzip", "path", Core::ArgsParser::Required::Yes);
     args_parser.parse(argc, argv);
 
@@ -109,6 +112,21 @@ int main(int argc, char** argv)
     if (!zip_file.has_value()) {
         warnln("Invalid zip file {}", zip_file_path);
         return 1;
+    }
+
+    if(!output_directory_path.is_empty())
+    {
+        rc = mkdir(output_directory_path.characters(), 0755);
+        if (rc < 0 && errno != EEXIST) {
+            perror("mkdir");
+            return 1;
+        }
+
+        rc = chdir(output_directory_path.characters());
+        if(rc < 0) {
+            perror("chdir");
+            return 1;
+        }
     }
 
     auto success = zip_file->for_each_member([&](auto zip_member) {


### PR DESCRIPTION
My first OSS contribution, here goes nothing :^)

This PR adds a new context menu action to FileManager that allows for extracting zip archives without having to open the terminal. I thought this would make a good first contribution after playing around a bit with SerenityOS and finding this quality of life feature that can be found in other file managers like those of Gnome and Windows to be lacking.

"Extract Here" in Gnome
![Screenshot from 2021-04-24 13-40-33](https://user-images.githubusercontent.com/26672774/115992648-0673d580-a5cf-11eb-84bc-aeda49347e6a.png)

My implementation in SerenityOS
![Screenshot from 2021-04-25 14-30-27](https://user-images.githubusercontent.com/26672774/115992664-17bce200-a5cf-11eb-9f54-456f2fae4d27.png)

Future improvements may include support for more archive formats like .tar and .tar.gz as well as integration with the new file operation progress tracking.

