### PR TITLE
LibJS: Stop rolling back parser state that is immediately replaced

### DIFF
--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -346,7 +346,6 @@ RefPtr<FunctionExpression> Parser::try_parse_arrow_function_expression(bool expe
     auto rule_start = push_start();
 
     ArmedScopeGuard state_rollback_guard = [&] {
-        m_parser_state.m_var_scopes.take_last();
         load_state();
     };
 


### PR DESCRIPTION
This showed up on a profile (barely), so should help a tiny bit with perf in parsing arrow functions.