### PR TITLE
Browser: Add GitHub and Yandex to search engines

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -433,7 +433,9 @@ Tab::Tab(Type type)
     // FIXME: Support adding custom search engines
     add_search_engine("Bing", "https://www.bing.com/search?q={}");
     add_search_engine("DuckDuckGo", "https://duckduckgo.com/?q={}");
+    add_search_engine("GitHub", "https://github.com/search=?q={}");
     add_search_engine("Google", "https://google.com/search?q={}");
+    add_search_engine("Yandex", "https://yandex.com/search/?text={}");
 
     auto& debug_menu = m_menubar->add_menu("&Debug");
     debug_menu.add_action(GUI::Action::create(


### PR DESCRIPTION
- DuckDuckGo is by far one of the least privacy-invasive options in comparison to Bing and Google.
- Yandex is extremely popular in the Russosphere.
- Wikipedia is, well, in a league of its own.