### PR TITLE
LibAudio: Support 32 and 64-bit float WAV files

### DIFF
--- a/Userland/Libraries/LibAudio/Buffer.cpp
+++ b/Userland/Libraries/LibAudio/Buffer.cpp
@@ -1,13 +1,40 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/Atomic.h>
+#include <AK/Debug.h>
+#include <AK/String.h>
 #include <LibAudio/Buffer.h>
 
 namespace Audio {
+
+u16 pcm_bits_per_sample(PcmSampleFormat format)
+{
+    switch (format) {
+    case Uint8:
+        return 8;
+    case Int16:
+        return 16;
+    case Int24:
+        return 24;
+    case Float32:
+        return 32;
+    case Float64:
+        return 64;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+String sample_format_name(PcmSampleFormat format)
+{
+    bool is_float = format == Float32 || format == Float64;
+    return String::formatted("PCM {}bit {}", pcm_bits_per_sample(format), is_float ? "Float" : "LE");
+}
 
 i32 Buffer::allocate_id()
 {
@@ -54,6 +81,20 @@ static void read_samples_from_stream(InputMemoryStream& stream, SampleReader rea
     }
 }
 
+static double read_float_sample_64(InputMemoryStream& stream)
+{
+    LittleEndian<double> sample;
+    stream >> sample;
+    return double(sample);
+}
+
+static double read_float_sample_32(InputMemoryStream& stream)
+{
+    LittleEndian<float> sample;
+    stream >> sample;
+    return double(sample);
+}
+
 static double read_norm_sample_24(InputMemoryStream& stream)
 {
     u8 byte = 0;
@@ -85,26 +126,32 @@ static double read_norm_sample_8(InputMemoryStream& stream)
     return double(sample) / NumericLimits<u8>::max();
 }
 
-RefPtr<Buffer> Buffer::from_pcm_data(ReadonlyBytes data, ResampleHelper& resampler, int num_channels, int bits_per_sample)
+RefPtr<Buffer> Buffer::from_pcm_data(ReadonlyBytes data, ResampleHelper& resampler, int num_channels, PcmSampleFormat sample_format)
 {
     InputMemoryStream stream { data };
-    return from_pcm_stream(stream, resampler, num_channels, bits_per_sample, data.size() / (bits_per_sample / 8));
+    return from_pcm_stream(stream, resampler, num_channels, sample_format, data.size() / (pcm_bits_per_sample(sample_format) / 8));
 }
 
-RefPtr<Buffer> Buffer::from_pcm_stream(InputMemoryStream& stream, ResampleHelper& resampler, int num_channels, int bits_per_sample, int num_samples)
+RefPtr<Buffer> Buffer::from_pcm_stream(InputMemoryStream& stream, ResampleHelper& resampler, int num_channels, PcmSampleFormat sample_format, int num_samples)
 {
     Vector<Frame> fdata;
     fdata.ensure_capacity(num_samples);
 
-    switch (bits_per_sample) {
-    case 8:
+    switch (sample_format) {
+    case PcmSampleFormat::Uint8:
         read_samples_from_stream(stream, read_norm_sample_8, fdata, resampler, num_channels);
         break;
-    case 16:
+    case PcmSampleFormat::Int16:
         read_samples_from_stream(stream, read_norm_sample_16, fdata, resampler, num_channels);
         break;
-    case 24:
+    case PcmSampleFormat::Int24:
         read_samples_from_stream(stream, read_norm_sample_24, fdata, resampler, num_channels);
+        break;
+    case PcmSampleFormat::Float32:
+        read_samples_from_stream(stream, read_float_sample_32, fdata, resampler, num_channels);
+        break;
+    case PcmSampleFormat::Float64:
+        read_samples_from_stream(stream, read_float_sample_64, fdata, resampler, num_channels);
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibAudio/Buffer.h
+++ b/Userland/Libraries/LibAudio/Buffer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +9,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/MemoryStream.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <LibCore/AnonymousBuffer.h>
@@ -69,6 +71,19 @@ struct Frame {
     double right;
 };
 
+// Supported PCM sample formats.
+enum PcmSampleFormat : u8 {
+    Uint8,
+    Int16,
+    Int24,
+    Float32,
+    Float64,
+};
+
+// Most of the read code only cares about how many bits to read or write
+u16 pcm_bits_per_sample(PcmSampleFormat format);
+String sample_format_name(PcmSampleFormat format);
+
 // Small helper to resample from one playback rate to another
 // This isn't really "smart", in that we just insert (or drop) samples.
 // Should do better...
@@ -89,8 +104,8 @@ private:
 // A buffer of audio samples, normalized to 44100hz.
 class Buffer : public RefCounted<Buffer> {
 public:
-    static RefPtr<Buffer> from_pcm_data(ReadonlyBytes data, ResampleHelper& resampler, int num_channels, int bits_per_sample);
-    static RefPtr<Buffer> from_pcm_stream(InputMemoryStream& stream, ResampleHelper& resampler, int num_channels, int bits_per_sample, int num_samples);
+    static RefPtr<Buffer> from_pcm_data(ReadonlyBytes data, ResampleHelper& resampler, int num_channels, PcmSampleFormat sample_format);
+    static RefPtr<Buffer> from_pcm_stream(InputMemoryStream& stream, ResampleHelper& resampler, int num_channels, PcmSampleFormat sample_format, int num_samples);
     static NonnullRefPtr<Buffer> create_with_samples(Vector<Frame>&& samples)
     {
         return adopt_ref(*new Buffer(move(samples)));

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, the SerenityOS developers.
+ * Copyright (c) 2018-2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -33,7 +33,7 @@ public:
     virtual int total_samples() = 0;
     virtual u32 sample_rate() = 0;
     virtual u16 num_channels() = 0;
-    virtual u16 bits_per_sample() = 0;
+    virtual PcmSampleFormat pcm_format() = 0;
     virtual RefPtr<Core::File> file() = 0;
 };
 
@@ -62,7 +62,7 @@ public:
     int total_samples() const { return m_plugin ? m_plugin->total_samples() : 0; }
     u32 sample_rate() const { return m_plugin ? m_plugin->sample_rate() : 0; }
     u16 num_channels() const { return m_plugin ? m_plugin->num_channels() : 0; }
-    u16 bits_per_sample() const { return m_plugin ? m_plugin->bits_per_sample() : 0; }
+    u16 bits_per_sample() const { return m_plugin ? pcm_bits_per_sample(m_plugin->pcm_format()) : 0; }
     RefPtr<Core::File> file() const { return m_plugin ? m_plugin->file() : nullptr; }
 
 private:

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, kleines Filmröllchen <malu.bertsch@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,6 +19,13 @@
 
 namespace Audio {
 class Buffer;
+
+// defines for handling the WAV header data
+#define WAVE_FORMAT_PCM 0x0001        // PCM
+#define WAVE_FORMAT_IEEE_FLOAT 0x0003 // IEEE float
+#define WAVE_FORMAT_ALAW 0x0006       // 8-bit ITU-T G.711 A-law
+#define WAVE_FORMAT_MULAW 0x0007      // 8-bit ITU-T G.711 µ-law
+#define WAVE_FORMAT_EXTENSIBLE 0xFFFE // Determined by SubFormat
 
 // Parses a WAV file and produces an Audio::Buffer.
 class WavLoaderPlugin : public LoaderPlugin {
@@ -39,7 +47,7 @@ public:
     virtual int total_samples() override { return m_total_samples; }
     virtual u32 sample_rate() override { return m_sample_rate; }
     virtual u16 num_channels() override { return m_num_channels; }
-    virtual u16 bits_per_sample() override { return m_bits_per_sample; }
+    virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
     virtual RefPtr<Core::File> file() override { return m_file; }
 
 private:
@@ -53,7 +61,7 @@ private:
 
     u32 m_sample_rate { 0 };
     u16 m_num_channels { 0 };
-    u16 m_bits_per_sample { 0 };
+    PcmSampleFormat m_sample_format;
 
     int m_loaded_samples { 0 };
     int m_total_samples { 0 };


### PR DESCRIPTION
LibAudio's WavLoader plugin for loading WAV files now supports loading audio files with 32-bit float or 64-bit float samples.

By supporting these new non-int sample formats, Audio::Buffer now stores the sample format (out of a list of supported formats) instead of the raw bit depth. (The bit depth is easily calculated with pcm_bits_per_sample)