### PR TITLE
LibPthread: Use realtime clock in futex_wait()

### DIFF
--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -17,15 +17,15 @@ Thread::BlockTimeout::BlockTimeout(bool is_absolute, const Time* time, const Tim
     : m_clock_id(clock_id)
     , m_infinite(!time)
 {
-    if (!m_infinite) {
-        if (*time > Time::zero()) {
-            m_time = *time;
-            m_should_block = true;
-        }
-        m_start_time = start_time ? *start_time : TimeManagement::the().current_time(clock_id).value();
-        if (!is_absolute)
-            m_time = m_time + m_start_time;
+    if (m_infinite)
+        return;
+    if (*time > Time::zero()) {
+        m_time = *time;
+        m_should_block = true;
     }
+    m_start_time = start_time ? *start_time : TimeManagement::the().current_time(clock_id).value();
+    if (!is_absolute)
+        m_time += m_start_time;
 }
 
 bool Thread::Blocker::set_block_condition(Thread::BlockCondition& block_condition, void* data)

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -442,7 +442,7 @@ static int futex_wait(uint32_t& futex_addr, uint32_t value, const struct timespe
 {
     int saved_errno = errno;
     // NOTE: FUTEX_WAIT takes a relative timeout, so use FUTEX_WAIT_BITSET instead!
-    int rc = futex(&futex_addr, FUTEX_WAIT_BITSET, value, abstime, nullptr, FUTEX_BITSET_MATCH_ANY);
+    int rc = futex(&futex_addr, FUTEX_WAIT_BITSET | FUTEX_CLOCK_REALTIME, value, abstime, nullptr, FUTEX_BITSET_MATCH_ANY);
     if (rc < 0 && errno == EAGAIN) {
         // If we didn't wait, that's not an error
         errno = saved_errno;


### PR DESCRIPTION
Running ScummVM with COMI exposed an issue with LibPthread: ScummVM uses `SDL_AddTimer` to manage a custom timer implementation, but their timer handler was never invoked causing all sorts of issues (but mainly, for music & speech not to load).

As it turns out, LibPthread's `futex_wait()` was calling the `futex` syscall with an absolute timeout value but not passing along `FUTEX_CLOCK_REALTIME`. `sys$futex` then defaults to a monotonic clock and assumes the timeout provided is an absolute monotonic value, which it is not. As a result, it only times out when the monotonic clock reaches the value of the realtime (epoch) timeout, which is basically taking forever.

This PR changes two things:
* `pthread_cond_timedwait` now invokes the `futex` syscall with `FUTEX_CLOCK_REALTIME`
* `sys$futex` now checks the command to see if `FUTEX_CLOCK_REALTIME` is allowed

FYI @tomuta 