### PR TITLE
Kernel: Make sure the E1000 network adapter keeps receiving packets

### DIFF
--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -425,10 +425,8 @@ void E1000NetworkAdapter::receive()
 {
     auto* rx_descriptors = (e1000_tx_desc*)m_rx_descriptors_region->vaddr().as_ptr();
     u32 rx_current;
-    for (;;) {
+    for (u32 i = 0; i < number_of_rx_descriptors; i++) {
         rx_current = in32(REG_RXDESCTAIL) % number_of_rx_descriptors;
-        if (rx_current == (in32(REG_RXDESCHEAD) % number_of_rx_descriptors))
-            return;
         rx_current = (rx_current + 1) % number_of_rx_descriptors;
         if (!(rx_descriptors[rx_current].status & 1))
             break;

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -7,6 +7,7 @@
 #include <AK/MACAddress.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Net/E1000NetworkAdapter.h>
+#include <Kernel/PCI/IDs.h>
 
 namespace Kernel {
 
@@ -117,8 +118,6 @@ namespace Kernel {
 #define INTERRUPT_TXD_LOW (1 << 15)
 #define INTERRUPT_SRPD (1 << 16)
 
-#define PCI_VENDOR_INTEL 0x8086
-
 // https://www.intel.com/content/dam/doc/manual/pci-pci-x-family-gbe-controllers-software-dev-manual.pdf Section 5.2
 static bool is_valid_device_id(u16 device_id)
 {
@@ -162,7 +161,7 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::detect()
     PCI::enumerate([&](const PCI::Address& address, PCI::ID id) {
         if (address.is_null())
             return;
-        if (id.vendor_id != PCI_VENDOR_INTEL)
+        if (id.vendor_id != (u16)PCIVendorID::Intel)
             return;
         if (!is_valid_device_id(id.device_id))
             return;

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -206,7 +206,6 @@ UNMAP_AFTER_INIT E1000NetworkAdapter::E1000NetworkAdapter(PCI::Address address, 
     initialize_rx_descriptors();
     initialize_tx_descriptors();
 
-    out32(REG_INTERRUPT_MASK_SET, 0x1f6dc);
     out32(REG_INTERRUPT_MASK_SET, INTERRUPT_LSC | INTERRUPT_RXT0 | INTERRUPT_RXO);
     in32(REG_INTERRUPT_CAUSE_READ);
 
@@ -219,8 +218,6 @@ UNMAP_AFTER_INIT E1000NetworkAdapter::~E1000NetworkAdapter()
 
 void E1000NetworkAdapter::handle_irq(const RegisterState&)
 {
-    out32(REG_INTERRUPT_MASK_CLEAR, 0xffffffff);
-
     u32 status = in32(REG_INTERRUPT_CAUSE_READ);
 
     m_entropy_source.add_random_event(status);
@@ -241,7 +238,7 @@ void E1000NetworkAdapter::handle_irq(const RegisterState&)
 
     m_wait_queue.wake_all();
 
-    out32(REG_INTERRUPT_MASK_SET, INTERRUPT_LSC | INTERRUPT_RXT0 | INTERRUPT_RXO);
+    out32(REG_INTERRUPT_CAUSE_READ, 0xffffffff);
 }
 
 UNMAP_AFTER_INIT void E1000NetworkAdapter::detect_eeprom()

--- a/Kernel/Net/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/E1000NetworkAdapter.cpp
@@ -207,7 +207,7 @@ UNMAP_AFTER_INIT E1000NetworkAdapter::E1000NetworkAdapter(PCI::Address address, 
     initialize_tx_descriptors();
 
     out32(REG_INTERRUPT_MASK_SET, 0x1f6dc);
-    out32(REG_INTERRUPT_MASK_SET, INTERRUPT_LSC | INTERRUPT_RXT0);
+    out32(REG_INTERRUPT_MASK_SET, INTERRUPT_LSC | INTERRUPT_RXT0 | INTERRUPT_RXO);
     in32(REG_INTERRUPT_CAUSE_READ);
 
     enable_irq();
@@ -231,6 +231,9 @@ void E1000NetworkAdapter::handle_irq(const RegisterState&)
     }
     if (status & INTERRUPT_RXDMT0) {
         // Threshold OK?
+    }
+    if (status & INTERRUPT_RXO) {
+        dbgln_if(E1000_DEBUG, "E1000: RX buffer overrun");
     }
     if (status & INTERRUPT_RXT0) {
         receive();

--- a/Kernel/PCI/IDs.h
+++ b/Kernel/PCI/IDs.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Kernel {
+
+enum class PCIVendorID {
+    VirtIO = 0x1af4,
+    Intel = 0x8086,
+};
+
+enum class PCIDeviceID {
+    VirtIOConsole = 0x1003,
+    VirtIOEntropy = 0x1005,
+};
+
+}

--- a/Kernel/VirtIO/VirtIO.cpp
+++ b/Kernel/VirtIO/VirtIO.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <Kernel/CommandLine.h>
+#include <Kernel/PCI/IDs.h>
 #include <Kernel/VirtIO/VirtIO.h>
 #include <Kernel/VirtIO/VirtIOConsole.h>
 #include <Kernel/VirtIO/VirtIORNG.h>
@@ -18,14 +19,14 @@ void VirtIO::detect()
     PCI::enumerate([&](const PCI::Address& address, PCI::ID id) {
         if (address.is_null() || id.is_null())
             return;
-        if (id.vendor_id != VIRTIO_PCI_VENDOR_ID)
+        if (id.vendor_id != (u16)PCIVendorID::VirtIO)
             return;
         switch (id.device_id) {
-        case VIRTIO_CONSOLE_PCI_DEVICE_ID: {
+        case (u16)PCIDeviceID::VirtIOConsole: {
             [[maybe_unused]] auto& unused = adopt_ref(*new VirtIOConsole(address)).leak_ref();
             break;
         }
-        case VIRTIO_ENTROPY_PCI_DEVICE_ID: {
+        case (u16)PCIDeviceID::VirtIOEntropy: {
             [[maybe_unused]] auto& unused = adopt_ref(*new VirtIORNG(address)).leak_ref();
             break;
         }

--- a/Kernel/VirtIO/VirtIO.h
+++ b/Kernel/VirtIO/VirtIO.h
@@ -17,8 +17,6 @@
 
 namespace Kernel {
 
-#define VIRTIO_PCI_VENDOR_ID 0x1AF4
-
 #define REG_DEVICE_FEATURES 0x0
 #define REG_GUEST_FEATURES 0x4
 #define REG_QUEUE_ADDRESS 0x8

--- a/Kernel/VirtIO/VirtIOConsole.h
+++ b/Kernel/VirtIO/VirtIOConsole.h
@@ -11,8 +11,6 @@
 
 namespace Kernel {
 
-#define VIRTIO_CONSOLE_PCI_DEVICE_ID 0x1003
-
 #define VIRTIO_CONSOLE_F_SIZE (1 << 0)
 #define VIRTIO_CONSOLE_F_MULTIPORT (1 << 1)
 #define VIRTIO_CONSOLE_F_EMERG_WRITE (1 << 2)

--- a/Kernel/VirtIO/VirtIORNG.h
+++ b/Kernel/VirtIO/VirtIORNG.h
@@ -12,8 +12,6 @@
 
 namespace Kernel {
 
-#define VIRTIO_ENTROPY_PCI_DEVICE_ID 0x1005
-
 #define REQUESTQ 0
 
 class VirtIORNG final : public CharacterDevice


### PR DESCRIPTION
Previously the E1000 network adapter would stop receiving further packets when an RX buffer overrun occurred. This was the case when connecting the adapter to a real network where enough broadcast traffic caused the buffer to be full before the kernel had a chance to clear the RX buffer.

This also updates the E1000 module to use macros instead of hard-coded magic values.

Further it adds logging for E1000 RX buffer overruns and avoids resetting the IRQ mask on each interrupt.