### PR TITLE
EditingEngine: Split selection from movement functions

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.h
+++ b/Userland/Libraries/LibGUI/EditingEngine.h
@@ -42,16 +42,16 @@ protected:
 
     WeakPtr<TextEditor> m_editor;
 
-    void move_one_left(const KeyEvent& event);
-    void move_one_right(const KeyEvent& event);
+    void move_one_left();
+    void move_one_right();
     void move_one_up(const KeyEvent& event);
     void move_one_down(const KeyEvent& event);
-    void move_to_previous_span(const KeyEvent& event);
+    void move_to_previous_span();
     void move_to_next_span(const KeyEvent& event);
-    void move_to_line_beginning(const KeyEvent& event);
-    void move_to_line_end(const KeyEvent& event);
-    void move_page_up(const KeyEvent& event);
-    void move_page_down(const KeyEvent& event);
+    void move_to_line_beginning();
+    void move_to_line_end();
+    void move_page_up();
+    void move_page_down();
     void move_to_first_line();
     void move_to_last_line();
     TextPosition find_beginning_of_next_word();
@@ -63,8 +63,8 @@ protected:
     TextPosition find_beginning_of_previous_word();
     void move_to_beginning_of_previous_word();
 
-    void move_up(const KeyEvent& event, double page_height_factor);
-    void move_down(const KeyEvent& event, double page_height_factor);
+    void move_up(double page_height_factor);
+    void move_down(double page_height_factor);
 
     void get_selection_line_boundaries(size_t& first_line, size_t& last_line);
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -920,7 +920,7 @@ void TextEditor::reset_cursor_blink()
     start_timer(500);
 }
 
-void TextEditor::toggle_selection_if_needed_for_event(bool is_selecting)
+void TextEditor::update_selection(bool is_selecting)
 {
     if (is_selecting && !selection()->is_valid()) {
         selection()->set(cursor(), {});

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -178,7 +178,7 @@ public:
 
     void add_code_point(u32 code_point);
     void reset_cursor_blink();
-    void toggle_selection_if_needed_for_event(bool is_selecting);
+    void update_selection(bool is_selecting);
 
     int number_of_visible_lines() const;
     Gfx::IntRect cursor_content_rect() const;

--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -166,7 +166,7 @@ private:
     String m_yank_buffer {};
     void yank(YankType);
     void yank(TextRange);
-    void put(const GUI::KeyEvent&);
+    void put();
 
     void update_selection_on_cursor_move();
     void clear_visual_mode_data();
@@ -175,8 +175,8 @@ private:
     void switch_to_normal_mode();
     void switch_to_insert_mode();
     void switch_to_visual_mode();
-    void move_half_page_up(const KeyEvent& event);
-    void move_half_page_down(const KeyEvent& event);
+    void move_half_page_up();
+    void move_half_page_down();
     void move_to_previous_empty_lines_block();
     void move_to_next_empty_lines_block();
 


### PR DESCRIPTION
This patch moves selection updates outside movement functions in
`EditingEngine`.  Previously, movement functions would automatically
update the selection based on whether the Shift key was pressed down
during movement.  However, not all `EditingEngine` subclasses want that;
`VimEditingEngine` being a good example (because all selection is handled
in visual mode).

Therefore, this patch moves all selection updating to
`EditingEngine::on_key()`.  Subclasses wishing to provide custom movement
and selection semantics should override it (and `VimEditingEngine` already
does).