### PR TITLE
Kernel: Some fixes for the profiler

### DIFF
--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -82,8 +82,8 @@ KResult PerformanceEventBuffer::append_with_eip_and_ebp(ProcessID pid, ThreadID 
             memcpy(event.data.mmap.name, arg3.characters_without_null_termination(), min(arg3.length(), sizeof(event.data.mmap.name) - 1));
         break;
     case PERF_EVENT_MUNMAP:
-        event.data.mmap.ptr = arg1;
-        event.data.mmap.size = arg2;
+        event.data.munmap.ptr = arg1;
+        event.data.munmap.size = arg2;
         break;
     case PERF_EVENT_PROCESS_CREATE:
         event.data.process_create.parent_pid = arg1;

--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -221,7 +221,7 @@ void PerformanceEventBuffer::add_process(const Process& process, ProcessEventTyp
 
     [[maybe_unused]] auto rc = append_with_eip_and_ebp(process.pid(), 0, 0, 0,
         event_type == ProcessEventType::Create ? PERF_EVENT_PROCESS_CREATE : PERF_EVENT_PROCESS_EXEC,
-        process.pid().value(), 0, executable.characters());
+        process.pid().value(), 0, executable);
 
     process.for_each_thread([&](auto& thread) {
         [[maybe_unused]] auto rc = append_with_eip_and_ebp(process.pid(), thread.tid().value(),
@@ -231,7 +231,7 @@ void PerformanceEventBuffer::add_process(const Process& process, ProcessEventTyp
 
     for (auto& region : process.space().regions()) {
         [[maybe_unused]] auto rc = append_with_eip_and_ebp(process.pid(), 0,
-            0, 0, PERF_EVENT_MMAP, region->range().base().get(), region->range().size(), region->name().characters());
+            0, 0, PERF_EVENT_MMAP, region->range().base().get(), region->range().size(), region->name());
     }
 }
 

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -249,7 +249,7 @@ KResultOr<FlatPtr> Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> u
 
     if (auto* event_buffer = current_perf_events_buffer()) {
         [[maybe_unused]] auto res = event_buffer->append(PERF_EVENT_MMAP, region->vaddr().get(),
-            region->size(), name.is_null() ? region->name().characters() : name.characters());
+            region->size(), name.is_null() ? region->name() : name);
     }
 
     region->set_mmap(true);

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -89,8 +89,8 @@ void Process::sys$exit_thread(Userspace<void*> exit_value)
         this->sys$exit(0);
     }
 
-    if (m_perf_event_buffer) {
-        [[maybe_unused]] auto rc = m_perf_event_buffer->append(PERF_EVENT_THREAD_EXIT, Thread::current()->tid().value(), 0, nullptr);
+    if (auto* event_buffer = current_perf_events_buffer()) {
+        [[maybe_unused]] auto rc = event_buffer->append(PERF_EVENT_THREAD_EXIT, Thread::current()->tid().value(), 0, nullptr);
     }
 
     Thread::current()->exit(reinterpret_cast<void*>(exit_value.ptr()));

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -90,7 +90,7 @@ void Process::sys$exit_thread(Userspace<void*> exit_value)
     }
 
     if (auto* event_buffer = current_perf_events_buffer()) {
-        [[maybe_unused]] auto rc = event_buffer->append(PERF_EVENT_THREAD_EXIT, Thread::current()->tid().value(), 0, nullptr);
+        [[maybe_unused]] auto rc = event_buffer->append(PERF_EVENT_THREAD_EXIT, 0, 0, nullptr);
     }
 
     Thread::current()->exit(reinterpret_cast<void*>(exit_value.ptr()));


### PR DESCRIPTION
* `PERF_EVENT_MUNMAP` was accessing the wrong union member.
* I changed the `char*` to `StringView` but didn't remove the `.characters()` calls in the other patch.
* We weren't logging `thread_exit` events for global profiles.
* `arg1` for `thread_exit` events should be 0 because we're already logging the TID elsewhere.