### PR TITLE
WindowServer: Reevaluate hovered window on window rect change

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -119,7 +119,6 @@ void Window::show()
 
     auto* parent_window = find_parent_window();
 
-    m_cursor = Gfx::StandardCursor::None;
     auto response = WindowServerConnection::the().send_sync<Messages::WindowServer::CreateWindow>(
         m_rect_when_windowless,
         !m_moved_by_client,

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -414,6 +414,7 @@ void WindowManager::notify_rect_changed(Window& window, const Gfx::IntRect& old_
         AppletManager::the().relayout();
 
     MenuManager::the().refresh();
+    reevaluate_hovered_window(&window);
 }
 
 void WindowManager::notify_opacity_changed(Window&)


### PR DESCRIPTION
See commit messages for more details.

Fixes #4809