### PR TITLE
Toolchain/Dockerfile: Add rsync and unzip

### DIFF
--- a/Toolchain/Dockerfile
+++ b/Toolchain/Dockerfile
@@ -15,8 +15,10 @@ RUN apt-get update -y \
         e2fsprogs \
         ninja-build \
         qemu-utils \
+        rsync \
         sudo \
         tzdata \
+        unzip \
         wget
 
 WORKDIR /serenity


### PR DESCRIPTION
Both utilies are used in the `.port_include.sh` file.