### PR TITLE
Ports: Add MilkyTracker port

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -68,6 +68,7 @@ Please make sure to keep this list up to date when adding and updating ports. :^
 | [`mandoc`](mandoc/)                    | mandoc                                                     | 1.14.5                   | https://mandoc.bsd.lv/                                                         |
 | [`mawk`](mawk/)                        | mawk                                                       | 1.3.4-20200120           | https://invisible-island.net/mawk/                                             |
 | [`mbedtls`](mbedtls/)                  | Mbed TLS                                                   | 2.16.2                   | https://tls.mbed.org/                                                          |
+| [`milkytracker`](milkytracker/)        | milkytracker                                               | 1.03.00                  | https://github.com/milkytracker/MilkyTracker                                   |
 | [`mrsh`](mrsh/)                        | mrsh                                                       | d9763a3                  | https://mrsh.sh/                                                               |
 | [`nano`](nano/)                        | GNU nano                                                   | 4.5                      | https://www.nano-editor.org/                                                   |
 | [`nasm`](nasm/)                        | Netwide Assembler (NASM)                                   | 2.15.05                  | https://www.nasm.us/                                                           |

--- a/Ports/milkytracker/package.sh
+++ b/Ports/milkytracker/package.sh
@@ -1,0 +1,16 @@
+#!/bin/bash ../.port_include.sh
+port=milkytracker
+version=1.03.00
+workdir=MilkyTracker-$version
+useconfigure=true
+files="https://github.com/milkytracker/MilkyTracker/archive/v$version.tar.gz MilkyTracker-$version.tar.gz 72d5357e303380b52383b66b51f944a77cd77e2b3bfeb227d87cc0e72ab292f7"
+auth_type=sha256
+configopts="-DCMAKE_TOOLCHAIN_FILE=$SERENITY_ROOT/Toolchain/CMake/CMakeToolchain.txt"
+depends="SDL2 zlib"
+launcher_name="MilkyTracker"
+launcher_category=Sound
+launcher_command=/usr/local/bin/milkytracker
+
+configure() {
+    run cmake $configopts
+}

--- a/Ports/milkytracker/patches/IncludeStringsInBasicTypes.patch
+++ b/Ports/milkytracker/patches/IncludeStringsInBasicTypes.patch
@@ -1,0 +1,10 @@
+--- MilkyTracker-1.03.00/src/ppui/BasicTypes.h	2021-04-27 15:17:42.529000000 +1000
++++ MilkyTracker-1.03.00/src/ppui/BasicTypes.h	2021-04-27 15:17:42.529000000 +1000
+@@ -30,6 +30,7 @@
+ typedef unsigned int	pp_uint32;
+ typedef signed int		pp_int32;
+
++#include <strings.h>
+ #include "ScanCodes.h"
+
+ #if defined(WIN32) || defined(_WIN32_WCE) 

--- a/Ports/milkytracker/patches/RemoveOpenGL.patch
+++ b/Ports/milkytracker/patches/RemoveOpenGL.patch
@@ -1,0 +1,73 @@
+--- MilkyTracker-1.03.00/src/ppui/sdl/DisplayDevice_SDL.cpp	2021-04-27 15:17:42.529000000 +1000
++++ MilkyTracker-1.03.00/src/ppui/sdl/DisplayDevice_SDL.cpp	2021-04-27 15:17:42.529000000 +1000
+@@ -26,30 +26,8 @@
+ SDL_Window* PPDisplayDevice::CreateWindow(pp_int32& w, pp_int32& h, pp_int32& bpp, Uint32 flags)
+ {
+ 	size_t namelen = 0;
+-	char rendername[256] = { 0 };
+-	PFNGLGETSTRINGPROC glGetStringAPI = NULL;
+-
+-	for (int it = 0; it < SDL_GetNumRenderDrivers(); it++)
+-	{
+-		SDL_RendererInfo info;
+-		SDL_GetRenderDriverInfo(it, &info);
+-
+-		namelen += strlen(info.name) + 1;
+-		strncat(rendername, info.name, sizeof(rendername) - namelen);
+-		strncat(rendername, " ", sizeof(rendername) - namelen);
+-
+-		if (strncmp("opengles2", info.name, 9) == 0)
+-		{
+-			drv_index = it;
+-			SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+-			SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+-			SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+-			SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
+-		}
+-	}
+-
+ 	// Create SDL window
+-	SDL_Window* theWindow = SDL_CreateWindow("MilkyTracker", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, SDL_WINDOW_OPENGL | flags);
++	SDL_Window* theWindow = SDL_CreateWindow("MilkyTracker", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, flags);
+ 
+ 	if (theWindow == NULL)
+ 	{
+@@ -59,7 +37,7 @@
+ 		w = getDefaultWidth();
+ 		h = getDefaultHeight();
+ 		
+-		theWindow = SDL_CreateWindow("MilkyTracker", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, SDL_WINDOW_OPENGL | flags);
++		theWindow = SDL_CreateWindow("MilkyTracker", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w, h, flags);
+ 		
+ 		if (theWindow == NULL)
+ 		{
+@@ -69,21 +47,6 @@
+ 		}
+ 	}
+ 
+-	SDL_GLContext ctx = SDL_GL_CreateContext(theWindow);
+-	SDL_GL_MakeCurrent(theWindow, ctx);
+-	
+-	glGetStringAPI = (PFNGLGETSTRINGPROC)SDL_GL_GetProcAddress("glGetString");
+-
+-	fprintf(stdout, "Available Renderers: %s\n", rendername);
+-	if (glGetStringAPI)
+-	{
+-		fprintf(stdout, "Vendor     : %s\n", glGetStringAPI(GL_VENDOR));
+-		fprintf(stdout, "Renderer   : %s\n", glGetStringAPI(GL_RENDERER));
+-		fprintf(stdout, "Version    : %s\n", glGetStringAPI(GL_VERSION));
+-#ifdef DEBUG
+-		fprintf(stdout, "Extensions : %s\n", glGetStringAPI(GL_EXTENSIONS));
+-#endif
+-	}
+ 	// Prevent window from being resized below minimum
+ 	SDL_SetWindowMinimumSize(theWindow, w, h);
+ 	fprintf(stderr, "SDL: Minimum window size set to %dx%d.\n", w, h);
+@@ -105,7 +68,6 @@
+ 
+ 	bFullScreen = fullScreen;
+ 
+-	drv_index = -1;
+ 
+ 	initMousePointers();
+ }

--- a/Ports/milkytracker/patches/SDLTimerToLibCoreTimer.patch
+++ b/Ports/milkytracker/patches/SDLTimerToLibCoreTimer.patch
@@ -1,0 +1,65 @@
+--- MilkyTracker-1.03.00/src/tracker/sdl/SDL_Main.cpp	2021-04-27 15:17:42.529000000 +1000
++++ MilkyTracker-1.03.00/src/tracker/sdl/SDL_Main.cpp	2021-04-27 15:17:42.529000000 +1000
+@@ -68,6 +68,8 @@
+ 
+ #include <SDL.h>
+ #include "SDL_KeyTranslation.h"
++
++#include <LibCore/Timer.h>
+ // ---------------------------- Tracker includes ----------------------------
+ #include "PPUI.h"
+ #include "DisplayDevice_SDL.h"
+@@ -83,7 +85,7 @@
+ #endif
+ // --------------------------------------------------------------------------
+ 
+-static SDL_TimerID			timer;
++RefPtr<Core::Timer> m_timer;
+ 
+ // Tracker globals
+ static PPScreen*			myTrackerScreen		= NULL;
+@@ -163,11 +165,11 @@
+ 	SDLUserEventMidiKeyUp,
+ };
+ 
+-static Uint32 SDLCALL timerCallback(Uint32 interval, void* param)
++static void timerCallback()
+ {
+ 	if (!myTrackerScreen || !myTracker || !ticking)
+ 	{
+-		return interval;
++		return;
+ 	}
+ 
+ 	SDL_UserEvent ev;
+@@ -219,8 +221,6 @@
+ 		//PPEvent myEvent(eRMouseRepeat, &p, sizeof(PPPoint));
+ 		//RaiseEventSerialized(&myEvent);
+ 	}
+-
+-	return interval;
+ }
+ 
+ #ifdef HAVE_LIBRTMIDI
+@@ -834,7 +834,12 @@
+ #endif
+ 
+ 	// Try to create timer
+-	timer = SDL_AddTimer(20, timerCallback, NULL);
++	m_timer = Core::Timer::construct();
++   m_timer->on_timeout = [&]() {
++   	timerCallback();
++   };
++   m_timer->set_interval(20);
++	m_timer->start();
+ 
+ 	// Start capturing text input events
+ 	SDL_StartTextInput();
+@@ -1033,7 +1038,6 @@
+ 	}
+ 
+ 	ticking = false;
+-	SDL_RemoveTimer(timer);
+ 
+ 	globalMutex->lock();
+ #ifdef HAVE_LIBRTMIDI

--- a/Ports/milkytracker/patches/SetCXXStandardAndExcludeSubdirs.patch
+++ b/Ports/milkytracker/patches/SetCXXStandardAndExcludeSubdirs.patch
@@ -1,0 +1,22 @@
+--- MilkyTracker-1.03.00/CMakeLists.txt	2021-04-27 15:17:42.529000000 +1000
++++ MilkyTracker-1.03.00/CMakeLists.txt	2021-04-27 15:17:50.388987606 +1000
+@@ -22,8 +22,8 @@
+ cmake_minimum_required(VERSION 3.10)
+ project(MilkyTracker)
+ 
+-# Set C++ standard to C++98
+-set(CMAKE_CXX_STANDARD 98)
++# Set C++ standard to C++20
++set(CMAKE_CXX_STANDARD 20)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+ 
+ # Enable IDE solution folders
+@@ -220,8 +220,6 @@
+     set(CMAKE_FIND_LIBRARY_SUFFIXES ${SUFFIXES_ORIG})
+ endif()
+ 
+-add_subdirectory(docs)
+-add_subdirectory(resources/music)
+ add_subdirectory(src/compression)
+ add_subdirectory(src/fx)
+ add_subdirectory(src/milkyplay)

--- a/Ports/milkytracker/patches/SetTrackerLinks.patch
+++ b/Ports/milkytracker/patches/SetTrackerLinks.patch
@@ -1,0 +1,11 @@
+--- MilkyTracker-1.03.00/src/tracker/CMakeLists.txt	2021-04-27 15:17:42.529000000 +1000
++++ MilkyTracker-1.03.00/src/tracker/CMakeLists.txt	2021-04-27 15:17:42.529000000 +1000
+@@ -374,4 +375,7 @@
+     set(INSTALL_DEST ${CMAKE_INSTALL_BINDIR})
+ endif()
+ 
++target_link_libraries(tracker -lSDL2 -lgui -lipc -lm -lcore)
++set(INSTALL_DEST bin)
++
+ install(TARGETS tracker DESTINATION ${INSTALL_DEST})
+ 

--- a/Ports/milkytracker/patches/TmpnamToMkstemp.patch
+++ b/Ports/milkytracker/patches/TmpnamToMkstemp.patch
@@ -1,0 +1,11 @@
+--- MilkyTracker-1.03.00/src/ppui/osinterface/posix/PPSystem_POSIX.cpp	2021-04-27 15:17:42.529000000 +1000
++++ MilkyTracker-1.03.00/src/ppui/osinterface/posix/PPSystem_POSIX.cpp	2021-04-27 15:17:42.529000000 +1000
+@@ -67,7 +69,7 @@
+ 	// instead of a file name.
+ #pragma clang diagnostic push
+ #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+-	if ((tmpnam(buffer) == NULL))
++	if ((mkstemp(buffer) == NULL))
+ #pragma clang diagnostic pop
+ 	{
+ 		// should not be the case, if it is the case, create something that


### PR DESCRIPTION
Ported MilkyTracker 1.03, a music tracker which attempts to recreate FastTracker II, to SerenityOS.

The interface update issues encountered during previous port attempts were solved by replacing SDL Timer with LibCore::Timer.