### PR TITLE
WindowManager: Remove MouseMove workaround for hovered windows

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -335,6 +335,12 @@ void Window::handle_drop_event(DropEvent& event)
 
 void Window::handle_mouse_event(MouseEvent& event)
 {
+    if (event.type() == Event::WindowLeft) {
+        set_hovered_widget(nullptr);
+        Application::the()->set_drag_hovered_widget({}, nullptr);
+        return;
+    }
+
     if (m_global_cursor_tracking_widget) {
         auto window_relative_rect = m_global_cursor_tracking_widget->window_relative_rect();
         Gfx::IntPoint local_point { event.x() - window_relative_rect.x(), event.y() - window_relative_rect.y() };
@@ -529,12 +535,6 @@ void Window::handle_drag_move_event(DragEvent& event)
     }
 }
 
-void Window::handle_left_event()
-{
-    set_hovered_widget(nullptr);
-    Application::the()->set_drag_hovered_widget({}, nullptr);
-}
-
 void Window::event(Core::Event& event)
 {
     ScopeGuard guard([&] {
@@ -544,7 +544,7 @@ void Window::event(Core::Event& event)
     if (event.type() == Event::Drop)
         return handle_drop_event(static_cast<DropEvent&>(event));
 
-    if (event.type() == Event::MouseUp || event.type() == Event::MouseDown || event.type() == Event::MouseDoubleClick || event.type() == Event::MouseMove || event.type() == Event::MouseWheel)
+    if (event.type() == Event::MouseUp || event.type() == Event::MouseDown || event.type() == Event::MouseDoubleClick || event.type() == Event::MouseMove || event.type() == Event::MouseWheel || event.type() == Event::WindowEntered || event.type() == Event::WindowLeft)
         return handle_mouse_event(static_cast<MouseEvent&>(event));
 
     if (event.type() == Event::MultiPaint)
@@ -561,9 +561,6 @@ void Window::event(Core::Event& event)
 
     if (event.type() == Event::WindowCloseRequest)
         return handle_close_request();
-
-    if (event.type() == Event::WindowLeft)
-        return handle_left_event();
 
     if (event.type() == Event::Resize)
         return handle_resize_event(static_cast<ResizeEvent&>(event));

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -215,7 +215,6 @@ private:
     void handle_theme_change_event(ThemeChangeEvent&);
     void handle_screen_rect_change_event(ScreenRectChangeEvent&);
     void handle_drag_move_event(DragEvent&);
-    void handle_left_event();
 
     void server_did_destroy();
 

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -102,13 +102,13 @@ void WindowServerConnection::handle(const Messages::WindowClient::WindowCloseReq
 void WindowServerConnection::handle(const Messages::WindowClient::WindowEntered& message)
 {
     if (auto* window = Window::from_window_id(message.window_id()))
-        Core::EventLoop::current().post_event(*window, make<Event>(Event::WindowEntered));
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::WindowEntered, message.mouse_position(), 0, MouseButton::None, 0, 0));
 }
 
 void WindowServerConnection::handle(const Messages::WindowClient::WindowLeft& message)
 {
     if (auto* window = Window::from_window_id(message.window_id()))
-        Core::EventLoop::current().post_event(*window, make<Event>(Event::WindowLeft));
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::WindowLeft, message.mouse_position(), 0, MouseButton::None, 0, 0));
 }
 
 void WindowServerConnection::handle(const Messages::WindowClient::KeyDown& message)

--- a/Userland/Services/WindowServer/Event.h
+++ b/Userland/Services/WindowServer/Event.h
@@ -44,7 +44,7 @@ public:
     }
     virtual ~Event() { }
 
-    bool is_mouse_event() const { return type() == MouseMove || type() == MouseDown || type() == MouseDoubleClick || type() == MouseUp || type() == MouseWheel; }
+    bool is_mouse_event() const { return type() == MouseMove || type() == MouseDown || type() == MouseDoubleClick || type() == MouseUp || type() == MouseWheel || type() == WindowEntered || type() == WindowLeft; }
     bool is_key_event() const { return type() == KeyUp || type() == KeyDown; }
 };
 

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -240,6 +240,12 @@ void Window::handle_mouse_event(const MouseEvent& event)
     case Event::MouseWheel:
         m_client->post_message(Messages::WindowClient::MouseWheel(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta()));
         break;
+    case Event::WindowEntered:
+        m_client->post_message(Messages::WindowClient::WindowEntered(m_window_id, event.position()));
+        break;
+    case Event::WindowLeft:
+        m_client->post_message(Messages::WindowClient::WindowLeft(m_window_id, event.position()));
+        break;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -413,12 +419,6 @@ void Window::event(Core::Event& event)
         return handle_mouse_event(static_cast<const MouseEvent&>(event));
 
     switch (event.type()) {
-    case Event::WindowEntered:
-        m_client->post_message(Messages::WindowClient::WindowEntered(m_window_id));
-        break;
-    case Event::WindowLeft:
-        m_client->post_message(Messages::WindowClient::WindowLeft(m_window_id));
-        break;
     case Event::KeyDown:
         handle_keydown_event(static_cast<const KeyEvent&>(event));
         break;

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -6,8 +6,8 @@ endpoint WindowClient
     MouseDoubleClick(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta) =|
     MouseUp(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta) =|
     MouseWheel(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta) =|
-    WindowEntered(i32 window_id) =|
-    WindowLeft(i32 window_id) =|
+    WindowEntered(i32 window_id, Gfx::IntPoint mouse_position) =|
+    WindowLeft(i32 window_id, Gfx::IntPoint mouse_position) =|
     WindowInputEntered(i32 window_id) =|
     WindowInputLeft(i32 window_id) =|
     KeyDown(i32 window_id, u32 code_point, u32 key, u32 modifiers, u32 scancode) =|

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1112,25 +1112,9 @@ void WindowManager::reevaluate_hovered_window(Window* updated_window)
         });
     }
 
-    if (set_hovered_window(hovered_window)) {
-        if (currently_hovered && m_resize_candidate == currently_hovered)
-            clear_resize_candidate();
-
-        if (hovered_window) {
-            // Send a fake MouseMove event. This allows the new hovering window
-            // to determine which widget we're hovering, and also update the cursor
-            // accordingly. We do this because this re-evaluation of the currently
-            // hovered window wasn't triggered by a mouse move event, but rather
-            // e.g. a hit-test result change due to a transparent window repaint.
-            if (hovered_window->hit_test(cursor_location, false)) {
-                MouseEvent event(Event::MouseMove, cursor_location.translated(-hovered_window->rect().location()), 0, MouseButton::None, 0);
-                hovered_window->dispatch_event(event);
-            } else if (!hovered_window->is_frameless()) {
-                MouseEvent event(Event::MouseMove, cursor_location.translated(-hovered_window->frame().rect().location()), 0, MouseButton::None, 0);
-                hovered_window->frame().on_mouse_event(event);
-            }
-        }
-    }
+    auto was_set = set_hovered_window(hovered_window);
+    if (was_set && currently_hovered && m_resize_candidate == currently_hovered)
+        clear_resize_candidate();
 }
 
 void WindowManager::clear_resize_candidate()


### PR DESCRIPTION
In `WindowManager::reevaluate_hovered_window()` a workaround existed that triggered the hovered window by sending a fake `MouseMove` event. After 2e1320f264, the Screensaver application stopped working since it received a `MouseMove` immediately.

This commit removes the `MouseMove` workaround (introduced in 2d29bfc89ef):

* The fake `MouseMove` event is removed from `::reevaluate_hovered_window()`;
* The existing `WindowEntered` and `WindowLeft` events are converted to mouse events and made to include the mouse position;
* `GUI::Window::handle_mouse_event()` now handles the `WindowEntered` and `WindowLeft` events, performing a mouse hit test for the former.

Fixes #6692.

Tested as part of this PR: the Breakout game, the Cube demo (frameless), Screensaver.

CC @tomuta 