### PR TITLE
WindowServer: Fix ScreenSaver not showing

### DIFF
--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1116,7 +1116,7 @@ void WindowManager::reevaluate_hovered_window(Window* updated_window)
         if (currently_hovered && m_resize_candidate == currently_hovered)
             clear_resize_candidate();
 
-        if (hovered_window) {
+        if (hovered_window && !hovered_window->is_fullscreen()) {
             // Send a fake MouseMove event. This allows the new hovering window
             // to determine which widget we're hovering, and also update the cursor
             // accordingly. We do this because this re-evaluation of the currently


### PR DESCRIPTION
We shouldn't send fake MouseMove events to fullscreen windows. There 
is no way another window could trigger moving into a fullscreen window,
so when re-evaluating hit testing, which is now also done when changing
a window's geometry, we only send a WindowEntered event, and then only
MouseMove events if the mouse was actually moved.

Fixes #6692

Successor of #6695 by @GMTA 