### PR TITLE
HackStudio: Add context option to set execution point while debugging

### DIFF
--- a/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
@@ -77,6 +77,21 @@ void Debugger::on_breakpoint_change(const String& file, size_t line, BreakpointC
     }
 }
 
+bool Debugger::set_execution_position(const String& file, size_t line)
+{
+    auto position = create_source_position(file, line);
+    auto session = Debugger::the().session();
+    if (!session)
+        return false;
+    auto address = session->get_address_from_source_position(position.file_path, position.line_number);
+    if (!address.has_value())
+        return false;
+    auto registers = session->get_registers();
+    registers.eip = address.value().address;
+    session->set_registers(registers);
+    return true;
+}
+
 Debug::DebugInfo::SourcePosition Debugger::create_source_position(const String& file, size_t line)
 {
     if (file.starts_with("/"))

--- a/Userland/DevTools/HackStudio/Debugger/Debugger.h
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.h
@@ -34,6 +34,7 @@ public:
     static bool is_initialized();
 
     void on_breakpoint_change(const String& file, size_t line, BreakpointChange change_type);
+    bool set_execution_position(const String& file, size_t line);
 
     void set_executable_path(const String& path) { m_executable_path = path; }
     void set_source_root(const String& source_root) { m_source_root = source_root; }

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -52,7 +52,20 @@ Editor::Editor()
         auto dialog = EvaluateExpressionDialog::construct(window());
         dialog->exec();
     });
+    m_move_execution_to_line_action = GUI::Action::create("Set execution point to line", [this](auto&) {
+        if (!execution_position().has_value()) {
+            GUI::MessageBox::show(window(), "Program must be paused", "Error", GUI::MessageBox::Type::Error);
+            return;
+        }
+        auto success = Debugger::the().set_execution_position(currently_open_file(), cursor().line());
+        if (success) {
+            set_execution_position(cursor().line());
+        } else {
+            GUI::MessageBox::show(window(), "Failed to set execution position", "Error", GUI::MessageBox::Type::Error);
+        }
+    });
     add_custom_context_menu_action(*m_evaluate_expression_action);
+    add_custom_context_menu_action(*m_move_execution_to_line_action);
 }
 
 Editor::~Editor()

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -104,6 +104,7 @@ private:
     bool m_hovering_clickable { false };
     bool m_autocomplete_in_focus { false };
     RefPtr<GUI::Action> m_evaluate_expression_action;
+    RefPtr<GUI::Action> m_move_execution_to_line_action;
 
     OwnPtr<LanguageClient> m_language_client;
 };


### PR DESCRIPTION
You can now right click in HackStudio's editor while debugging and have the option to instantly move the current execution position to the current line.

This PR wraps up all of the debugger features I was looking forward to adding, so if anyone has more ideas, please let me know :)