### PR TITLE
WindowServer: Don't restore active window if it is minimized

### DIFF
--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -41,15 +41,32 @@ public:
     const MenuItem& item(int index) const { return m_items.at(index); }
     MenuItem& item(int index) { return m_items.at(index); }
 
+    MenuItem* item_by_identifier(unsigned identifier)
+    {
+        MenuItem* found_item = nullptr;
+        for_each_item([&](auto& item) {
+            if (item.identifier() == identifier) {
+                found_item = &item;
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+        return found_item;
+    }
+
     void add_item(NonnullOwnPtr<MenuItem>);
 
     String name() const { return m_name; }
 
     template<typename Callback>
-    void for_each_item(Callback callback) const
+    IterationDecision for_each_item(Callback callback)
     {
-        for (auto& item : m_items)
-            callback(item);
+        for (auto& item : m_items) {
+            IterationDecision decision = callback(item);
+            if (decision != IterationDecision::Continue)
+                return decision;
+        }
+        return IterationDecision::Continue;
     }
 
     Gfx::IntRect rect_in_window_menubar() const { return m_rect_in_window_menubar; }

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -656,30 +656,37 @@ void Window::ensure_window_menu()
         m_window_menu->item((int)PopupMenuItem::Maximize).set_enabled(m_resizable);
 
         m_window_menu->on_item_activation = [&](auto& item) {
-            switch (static_cast<WindowMenuAction>(item.identifier())) {
-            case WindowMenuAction::MinimizeOrUnminimize:
-                WindowManager::the().minimize_windows(*this, !m_minimized);
-                if (!m_minimized)
-                    WindowManager::the().move_to_front_and_make_active(*this);
-                break;
-            case WindowMenuAction::MaximizeOrRestore:
-                WindowManager::the().maximize_windows(*this, !m_maximized);
-                WindowManager::the().move_to_front_and_make_active(*this);
-                break;
-            case WindowMenuAction::Close:
-                request_close();
-                break;
-            case WindowMenuAction::ToggleMenubarVisibility:
-                frame().invalidate();
-                item.set_checked(!item.is_checked());
-                m_should_show_menubar = item.is_checked();
-                frame().invalidate();
-                recalculate_rect();
-                Compositor::the().invalidate_occlusions();
-                Compositor::the().invalidate_screen();
-                break;
-            }
+            handle_window_menu_action(static_cast<WindowMenuAction>(item.identifier()));
         };
+    }
+}
+
+void Window::handle_window_menu_action(WindowMenuAction action)
+{
+    switch (action) {
+    case WindowMenuAction::MinimizeOrUnminimize:
+        WindowManager::the().minimize_windows(*this, !m_minimized);
+        if (!m_minimized)
+            WindowManager::the().move_to_front_and_make_active(*this);
+        break;
+    case WindowMenuAction::MaximizeOrRestore:
+        WindowManager::the().maximize_windows(*this, !m_maximized);
+        WindowManager::the().move_to_front_and_make_active(*this);
+        break;
+    case WindowMenuAction::Close:
+        request_close();
+        break;
+    case WindowMenuAction::ToggleMenubarVisibility: {
+        auto& item = *m_window_menu->item_by_identifier((unsigned)action);
+        frame().invalidate();
+        item.set_checked(!item.is_checked());
+        m_should_show_menubar = item.is_checked();
+        frame().invalidate();
+        recalculate_rect();
+        Compositor::the().invalidate_occlusions();
+        Compositor::the().invalidate_screen();
+        break;
+    }
     }
 }
 

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -77,6 +77,7 @@ public:
     virtual ~Window() override;
 
     void popup_window_menu(const Gfx::IntPoint&, WindowMenuDefaultAction);
+    void handle_window_menu_action(WindowMenuAction);
     void window_menu_activate_default();
     void request_close();
 

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -65,14 +65,14 @@ WindowFrame::WindowFrame(Window& window)
     : m_window(window)
 {
     auto button = make<Button>(*this, [this](auto&) {
-        m_window.request_close();
+        m_window.handle_window_menu_action(WindowMenuAction::Close);
     });
     m_close_button = button.ptr();
     m_buttons.append(move(button));
 
     if (window.is_resizable()) {
         auto button = make<Button>(*this, [this](auto&) {
-            WindowManager::the().maximize_windows(m_window, !m_window.is_maximized());
+            m_window.handle_window_menu_action(WindowMenuAction::MaximizeOrRestore);
         });
         button->on_middle_click = [&](auto&) {
             m_window.set_vertically_maximized();
@@ -83,7 +83,7 @@ WindowFrame::WindowFrame(Window& window)
 
     if (window.is_minimizable()) {
         auto button = make<Button>(*this, [this](auto&) {
-            WindowManager::the().minimize_windows(m_window, true);
+            m_window.handle_window_menu_action(WindowMenuAction::MinimizeOrUnminimize);
         });
         m_minimize_button = button.ptr();
         m_buttons.append(move(button));

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1322,7 +1322,10 @@ void WindowManager::restore_active_input_window(Window* window)
     if (!window && pick_new_active_window(nullptr))
         return;
 
-    set_active_input_window(window);
+    if (window && !window->is_minimized() && window->is_visible())
+        set_active_input_window(window);
+    else
+        set_active_input_window(nullptr);
 }
 
 Window* WindowManager::set_active_input_window(Window* window)


### PR DESCRIPTION
When closing a menu, don't restore the active input to a window that
is now minimized or invisible.

Fixes #6690