### PR TITLE
LibC: static_assert that all malloc size classes have an alignment of 8

### DIFF
--- a/Userland/Libraries/LibC/mallocdefs.h
+++ b/Userland/Libraries/LibC/mallocdefs.h
@@ -17,6 +17,16 @@
 static constexpr unsigned short size_classes[] = { 8, 16, 32, 64, 128, 256, 504, 1016, 2032, 4088, 8184, 16376, 32752, 0 };
 static constexpr size_t num_size_classes = (sizeof(size_classes) / sizeof(unsigned short)) - 1;
 
+consteval bool check_size_classes_alignment()
+{
+    for (size_t i = 0; i < num_size_classes; i++) {
+        if ((size_classes[i] % 8) != 0)
+            return false;
+    }
+    return true;
+}
+static_assert(check_size_classes_alignment());
+
 struct CommonHeader {
     size_t m_magic;
     size_t m_size;


### PR DESCRIPTION
This will help prevent issues like the one fixed by #6703 from happening again.
(Saw @awesomekling's comment and decided to add it in :)