### PR TITLE
AK: Change worst-case dual_pivot_quick_sort behavior on sorted arrays.

### DIFF
--- a/AK/QuickSort.h
+++ b/AK/QuickSort.h
@@ -18,13 +18,24 @@ namespace AK {
 template<typename Collection, typename LessThan>
 void dual_pivot_quick_sort(Collection& col, int start, int end, LessThan less_than)
 {
-    if (start >= end) {
+    int size = end - start + 1;
+    if (size <= 1) {
         return;
     }
 
-    int left_pointer, right_pointer;
-    if (!less_than(col[start], col[end])) {
-        swap(col[start], col[end]);
+    if (size > 3) {
+        int third = size / 3;
+        if (less_than(col[start + third], col[end - third])) {
+            swap(col[start + third], col[start]);
+            swap(col[end - third], col[end]);
+        } else {
+            swap(col[start + third], col[end]);
+            swap(col[end - third], col[start]);
+        }
+    } else {
+        if (!less_than(col[start], col[end])) {
+            swap(col[start], col[end]);
+        }
     }
 
     int j = start + 1;
@@ -57,8 +68,8 @@ void dual_pivot_quick_sort(Collection& col, int start, int end, LessThan less_th
     swap(col[start], col[j]);
     swap(col[end], col[g]);
 
-    left_pointer = j;
-    right_pointer = g;
+    int left_pointer = j;
+    int right_pointer = g;
 
     dual_pivot_quick_sort(col, start, left_pointer - 1, less_than);
     dual_pivot_quick_sort(col, left_pointer + 1, right_pointer - 1, less_than);

--- a/AK/QuickSort.h
+++ b/AK/QuickSort.h
@@ -18,62 +18,75 @@ namespace AK {
 template<typename Collection, typename LessThan>
 void dual_pivot_quick_sort(Collection& col, int start, int end, LessThan less_than)
 {
-    int size = end - start + 1;
-    if (size <= 1) {
-        return;
-    }
-
-    if (size > 3) {
-        int third = size / 3;
-        if (less_than(col[start + third], col[end - third])) {
-            swap(col[start + third], col[start]);
-            swap(col[end - third], col[end]);
-        } else {
-            swap(col[start + third], col[end]);
-            swap(col[end - third], col[start]);
-        }
-    } else {
-        if (!less_than(col[start], col[end])) {
-            swap(col[start], col[end]);
-        }
-    }
-
-    int j = start + 1;
-    int k = start + 1;
-    int g = end - 1;
-
-    auto&& left_pivot = col[start];
-    auto&& right_pivot = col[end];
-
-    while (k <= g) {
-        if (less_than(col[k], left_pivot)) {
-            swap(col[k], col[j]);
-            j++;
-        } else if (!less_than(col[k], right_pivot)) {
-            while (!less_than(col[g], right_pivot) && k < g) {
-                g--;
+    while (start < end) {
+        int size = end - start + 1;
+        if (size > 3) {
+            int third = size / 3;
+            if (less_than(col[start + third], col[end - third])) {
+                swap(col[start + third], col[start]);
+                swap(col[end - third], col[end]);
+            } else {
+                swap(col[start + third], col[end]);
+                swap(col[end - third], col[start]);
             }
-            swap(col[k], col[g]);
-            g--;
+        } else {
+            if (!less_than(col[start], col[end])) {
+                swap(col[start], col[end]);
+            }
+        }
+
+        int j = start + 1;
+        int k = start + 1;
+        int g = end - 1;
+
+        auto&& left_pivot = col[start];
+        auto&& right_pivot = col[end];
+
+        while (k <= g) {
             if (less_than(col[k], left_pivot)) {
                 swap(col[k], col[j]);
                 j++;
+            } else if (!less_than(col[k], right_pivot)) {
+                while (!less_than(col[g], right_pivot) && k < g) {
+                    g--;
+                }
+                swap(col[k], col[g]);
+                g--;
+                if (less_than(col[k], left_pivot)) {
+                    swap(col[k], col[j]);
+                    j++;
+                }
             }
+            k++;
         }
-        k++;
+        j--;
+        g++;
+
+        swap(col[start], col[j]);
+        swap(col[end], col[g]);
+
+        int left_pointer = j;
+        int right_pointer = g;
+
+        int left_size = left_pointer - start;
+        int middle_size = right_pointer - (left_pointer + 1);
+        int right_size = (end + 1) - (right_pointer + 1);
+
+        if (left_size >= middle_size && left_size >= right_size) {
+            dual_pivot_quick_sort(col, left_pointer + 1, right_pointer - 1, less_than);
+            dual_pivot_quick_sort(col, right_pointer + 1, end, less_than);
+            end = left_pointer - 1;
+        } else if (middle_size >= right_size) {
+            dual_pivot_quick_sort(col, start, left_pointer - 1, less_than);
+            dual_pivot_quick_sort(col, right_pointer + 1, end, less_than);
+            start = left_pointer + 1;
+            end = right_pointer - 1;
+        } else {
+            dual_pivot_quick_sort(col, start, left_pointer - 1, less_than);
+            dual_pivot_quick_sort(col, left_pointer + 1, right_pointer - 1, less_than);
+            start = right_pointer + 1;
+        }
     }
-    j--;
-    g++;
-
-    swap(col[start], col[j]);
-    swap(col[end], col[g]);
-
-    int left_pointer = j;
-    int right_pointer = g;
-
-    dual_pivot_quick_sort(col, start, left_pointer - 1, less_than);
-    dual_pivot_quick_sort(col, left_pointer + 1, right_pointer - 1, less_than);
-    dual_pivot_quick_sort(col, right_pointer + 1, end, less_than);
 }
 
 template<typename Iterator, typename LessThan>


### PR DESCRIPTION
Changes dual_pivot_quick_sort pivot selection to avoid worst-case behavior on sorted arrays. If a worst-case input happens somehow anyway, use iteration instead of recursion for the largest of the three partitions to avoid the call stack from blowing up.

Some analysis shows that performance:
- is not negatively impacted by these changes on arrays of random integers,
- and hugely improved on arrays of sorted integers.

Fixes: https://github.com/SerenityOS/serenity/issues/6629

![dual_pivot_quicksort_random_32_bit_integers](https://user-images.githubusercontent.com/330865/116430898-8c01ba80-a847-11eb-9433-bf922406a806.png)
![dual_pivot_quicksort_sorted_32_bit_integers](https://user-images.githubusercontent.com/330865/116430877-87d59d00-a847-11eb-913c-c27cf316f640.png)