### PR TITLE
Kernel: Check kernel symbol's name length matches searched name

### DIFF
--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -32,8 +32,9 @@ static u8 parse_hex_digit(char nibble)
 FlatPtr address_for_kernel_symbol(const StringView& name)
 {
     for (size_t i = 0; i < s_symbol_count; ++i) {
-        if (!strncmp(name.characters_without_null_termination(), s_symbols[i].name, name.length()))
-            return s_symbols[i].address;
+        const auto& symbol = s_symbols[i];
+        if (name == symbol.name)
+            return symbol.address;
     }
     return 0;
 }


### PR DESCRIPTION
The current implementation would only check the first name.length() characters match, which means any kernel symbol that the provided name is a prefix of would match, instead of the actual matching symbol.

This commit fixes that by storing the kernel symbol's name's length and comparing it to the provided searched name's length before its chars are compared. This also results in a small performance bump due to not having to compare so many characters on each call, but at the expense of higher memory usage.

(Found this while looking into fixing #4392)