### PR TITLE
Kernel: Add MSG_PEEK support for the IPv4Socket

### DIFF
--- a/Kernel/DoubleBuffer.cpp
+++ b/Kernel/DoubleBuffer.cpp
@@ -44,7 +44,6 @@ ssize_t DoubleBuffer::write(const UserOrKernelBuffer& data, size_t size)
 {
     if (!size || m_storage.is_null())
         return 0;
-    VERIFY(size > 0);
     Locker locker(m_lock);
     size_t bytes_to_write = min(size, m_space_for_writing);
     u8* write_ptr = m_write_buffer->data + m_write_buffer->size;
@@ -61,7 +60,6 @@ ssize_t DoubleBuffer::read(UserOrKernelBuffer& data, size_t size)
 {
     if (!size || m_storage.is_null())
         return 0;
-    VERIFY(size > 0);
     Locker locker(m_lock);
     if (m_read_buffer_index >= m_read_buffer->size && m_write_buffer->size != 0)
         flip();
@@ -71,6 +69,25 @@ ssize_t DoubleBuffer::read(UserOrKernelBuffer& data, size_t size)
     if (!data.write(m_read_buffer->data + m_read_buffer_index, nread))
         return -EFAULT;
     m_read_buffer_index += nread;
+    compute_lockfree_metadata();
+    if (m_unblock_callback && m_space_for_writing > 0)
+        m_unblock_callback();
+    return (ssize_t)nread;
+}
+
+ssize_t DoubleBuffer::peek(UserOrKernelBuffer& data, size_t size)
+{
+    if (!size || m_storage.is_null())
+        return 0;
+    Locker locker(m_lock);
+    if (m_read_buffer_index >= m_read_buffer->size && m_write_buffer->size != 0) {
+        flip();
+    }
+    if (m_read_buffer_index >= m_read_buffer->size)
+        return 0;
+    size_t nread = min(m_read_buffer->size - m_read_buffer_index, size);
+    if (!data.write(m_read_buffer->data + m_read_buffer_index, nread))
+        return -EFAULT;
     compute_lockfree_metadata();
     if (m_unblock_callback && m_space_for_writing > 0)
         m_unblock_callback();

--- a/Kernel/DoubleBuffer.h
+++ b/Kernel/DoubleBuffer.h
@@ -29,6 +29,12 @@ public:
         auto buffer = UserOrKernelBuffer::for_kernel_buffer(data);
         return read(buffer, size);
     }
+    [[nodiscard]] ssize_t peek(UserOrKernelBuffer&, size_t);
+    [[nodiscard]] ssize_t peek(u8* data, size_t size)
+    {
+        auto buffer = UserOrKernelBuffer::for_kernel_buffer(data);
+        return peek(buffer, size);
+    }
 
     bool is_empty() const { return m_empty; }
 

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -496,6 +496,7 @@ struct pollfd {
 
 #define MSG_TRUNC 0x1
 #define MSG_CTRUNC 0x2
+#define MSG_PEEK 0x4
 #define MSG_DONTWAIT 0x40
 
 #define SOL_SOCKET 1

--- a/Userland/Libraries/LibC/sys/socket.h
+++ b/Userland/Libraries/LibC/sys/socket.h
@@ -46,6 +46,7 @@ __BEGIN_DECLS
 
 #define MSG_TRUNC 0x1
 #define MSG_CTRUNC 0x2
+#define MSG_PEEK 0x4
 #define MSG_DONTWAIT 0x40
 
 typedef uint16_t sa_family_t;


### PR DESCRIPTION
MSG_PEEK allows a packet to be read from the kernel's buffer without removing it from said buffer.

This PR will add 2 things:
- A `peek()` function for the `DoubleBuffer`, to let `DoubleBuffer` data be seen without incrementing the read-index, and
- The actual MSG_PEEK, which needs the `peek()` Function mentioned beforehand.