### PR TITLE
Ports: ffmpeg 4.4 (+ relevant LibC additions)

### DIFF
--- a/Ports/ffmpeg/package.sh
+++ b/Ports/ffmpeg/package.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+port=ffmpeg
+version=4.4
+useconfigure=true
+files="https://ffmpeg.org/releases/ffmpeg-${version}.tar.gz ffmpeg-${version}.tar.gz a4abede145de22eaf233baa1726e38e137f5698d9edd61b5763cd02b883f3c7c"
+auth_type="sha256"
+installopts="INSTALL_TOP=${SERENITY_INSTALL_ROOT}/usr/local"
+configopts="SRC_PATH=."
+
+configure() {
+    run ./configure \
+        --arch="x86_32" \
+        --cc="${CC} -std=gnu99" \
+        --cxx="${CXX} -std=gnu99" \
+        --disable-network \
+        --enable-cross-compile
+}

--- a/Userland/Libraries/LibC/inttypes.h
+++ b/Userland/Libraries/LibC/inttypes.h
@@ -28,7 +28,9 @@ __BEGIN_DECLS
 #define PRIu32 "u"
 #define PRIu64 "llu"
 #define PRIx8 "b"
+#define PRIX8 "hhX"
 #define PRIx16 "w"
+#define PRIX16 "hX"
 #define PRIx32 "x"
 #define PRIX32 "X"
 #define PRIx64 "llx"
@@ -51,6 +53,24 @@ __BEGIN_DECLS
 
 #define SCNu64 __PRI64_PREFIX "u"
 #define SCNd64 __PRI64_PREFIX "d"
+#define SCNi64 __PRI64_PREFIX "i"
+#define SCNx64 __PRI64_PREFIX "x"
+
+#define SCNd8 "hhd"
+#define SCNd16 "hd"
+#define SCNd32 "ld"
+
+#define SCNi8 "hhi"
+#define SCNi16 "hi"
+#define SCNi32 "li"
+
+#define SCNu8 "hhu"
+#define SCNu16 "hu"
+#define SCNu32 "lu"
+
+#define SCNx8 "hhx"
+#define SCNx16 "hx"
+#define SCNx32 "lx"
 
 typedef struct imaxdiv_t {
     intmax_t quot;

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -713,6 +713,11 @@ int abs(int i)
     return i < 0 ? -i : i;
 }
 
+long long int llabs(long long int i)
+{
+    return i < 0 ? -i : i;
+}
+
 long int random()
 {
     return rand();

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -49,6 +49,7 @@ char* ptsname(int fd);
 int ptsname_r(int fd, char* buffer, size_t);
 int abs(int);
 long labs(long);
+long long int llabs(long long int);
 double atof(const char*);
 int system(const char* command);
 char* mktemp(char*);


### PR DESCRIPTION
Hi I've finally got something!

I've got ffmpeg 4.4 to run in SerenityOS.

It is now using a sha256 hash that I derived because I was having issues with gpg.

I have not extensively tested it in serenity yet, but it does seem to be missing media/library codecs that would make it more practically useful.

I'm still able to continue improving this port.