### PR TITLE
LibGUI: Fix issue where buttons with a menu sometimes stayed depressed

### DIFF
--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -174,4 +174,12 @@ void Button::mousedown_event(MouseEvent& event)
     AbstractButton::mousedown_event(event);
 }
 
+void Button::mousemove_event(MouseEvent& event)
+{
+    if (m_menu) {
+        return;
+    }
+    AbstractButton::mousemove_event(event);
+}
+
 }

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -50,6 +50,7 @@ public:
 protected:
     explicit Button(String text = {});
     virtual void mousedown_event(MouseEvent&) override;
+    virtual void mousemove_event(MouseEvent&) override;
     virtual void paint_event(PaintEvent&) override;
 
 private:


### PR DESCRIPTION
When a Button has a menu, the AbstractButton behavior will now not
be used in the mousemove_event. This was already the case for
mousedown_event.

Why only sometimes?
Normally the presence of the menu prevents mousemove_events from being
delivered to the button. But the menu doesn't spawn immediately. So
sometimes mousemove events got through to the AbstractButton after the
menu was told to spawn but before it appeared. This caused the
m_being_pressed field of AbstractButton to be set to true. But there
was never a mouseup_event because the menu got those instead.

Fixes: https://github.com/SerenityOS/serenity/issues/6555